### PR TITLE
Remove Surface Viewer stub

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -143,9 +143,6 @@ void GMainWindow::InitializeWidgets() {
 }
 
 void GMainWindow::InitializeDebugWidgets() {
-    connect(ui.action_Create_Pica_Surface_Viewer, &QAction::triggered, this,
-            &GMainWindow::OnCreateGraphicsSurfaceViewer);
-
     QMenu* debug_menu = ui.menu_View_Debugging;
 
 #if MICROPROFILE_ENABLED
@@ -598,8 +595,6 @@ void GMainWindow::OnToggleFilterBar() {
         game_list->clearFilter();
     }
 }
-
-void GMainWindow::OnCreateGraphicsSurfaceViewer() {}
 
 void GMainWindow::UpdateStatusBar() {
     if (emu_thread == nullptr) {

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -128,7 +128,6 @@ private slots:
     void OnToggleFilterBar();
     void OnDisplayTitleBars(bool);
     void ToggleWindowMode();
-    void OnCreateGraphicsSurfaceViewer();
     void OnCoreError(Core::System::ResultStatus, std::string);
 
 private:

--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -82,8 +82,6 @@
      <property name="title">
       <string>Debugging</string>
      </property>
-     <addaction name="action_Create_Pica_Surface_Viewer"/>
-     <addaction name="separator"/>
     </widget>
     <addaction name="action_Single_Window_Mode"/>
     <addaction name="action_Display_Dock_Widget_Headers"/>
@@ -189,11 +187,6 @@
    </property>
    <property name="toolTip">
     <string>Selects a folder to display in the game list</string>
-   </property>
-  </action>
-  <action name="action_Create_Pica_Surface_Viewer">
-   <property name="text">
-    <string>Create Pica Surface Viewer</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
There is a leftover  Pica Surface Viewer from Citra.

This removes it because the architecture for the Switch GPU implementation is not yet decided (which may dictate the debugger features). There might also be better alternatives such as using existing debug interface, similar to OpenGL debug names for objects.

If need-be it's also easy enough to reintroduce the stub / menu entry later. It's certainly better than confusing users with non-functional buttons.