### PR TITLE
Fix build for gcc c++17 / boost.icl incompatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,12 @@ else()
     set(CMAKE_EXE_LINKER_FLAGS_RELEASE "/DEBUG /MANIFEST:NO /INCREMENTAL:NO /OPT:REF,ICF" CACHE STRING "" FORCE)
 endif()
 
+# Fix GCC C++17 and Boost.ICL incompatibility (needed to build dynarmic)
+# See https://bugzilla.redhat.com/show_bug.cgi?id=1485641#c1
+if (CMAKE_COMPILER_IS_GNUCC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-new-ttp-matching")
+endif()
+
 # Set file offset size to 64 bits.
 #
 # On modern Unixes, this is typically already the case. The lone exception is


### PR DESCRIPTION
There are problems with using GCC's c++17 support with boost ICL mode, in externals/dynarmic/src/backend_x64/a32_emit_x64.cpp: 

```
[  2%] Built target fmt
[  2%] Building CXX object externals/dynarmic/src/CMakeFiles/dynarmic.dir/backend_x64/a32_emit_x64.cpp.o
In file included from /usr/include/boost/icl/type_traits/identity_element.hpp:11:0,
                 from /usr/include/boost/icl/type_traits/unit_element.hpp:12,
                 from /usr/include/boost/icl/concept/interval.hpp:17,
                 from /usr/include/boost/icl/concept/joinable.hpp:12,
                 from /usr/include/boost/icl/associative_interval_container.hpp:13,
                 from /usr/include/boost/icl/interval_base_set.hpp:24,
                 from /usr/include/boost/icl/interval_set.hpp:14,
                 from /usr/include/boost/icl/interval_map.hpp:13,
                 from /home/habs/Emulation/yuzu/externals/dynarmic/src/./backend_x64/a32_emit_x64.h:12,
                 from /home/habs/Emulation/yuzu/externals/dynarmic/src/backend_x64/a32_emit_x64.cpp:12:
/usr/include/boost/icl/type_traits/type_to_string.hpp:56:12: error: partial specialization of 'struct boost::icl::type_to_string<Unary<Type> >' after instantiation of 'struct boost::icl::type_to_string<std::__cxx11::basic_string<char> >' [-fpermissive]
     struct type_to_string<Unary<Type> >
            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
make[2]: *** [externals/dynarmic/src/CMakeFiles/dynarmic.dir/build.make:1239: externals/dynarmic/src/CMakeFiles/dynarmic.dir/backend_x64/a32_emit_x64.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:155: externals/dynarmic/src/CMakeFiles/dynarmic.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```

Based on [this comment](https://bugzilla.redhat.com/show_bug.cgi?id=1485641#c1), at least as of four months ago "The Boost.ICL library is not compatible with GCC's C++17 mode". Adding '-fno-new-ttp-matching' to CXXFLAGS fixes this incompatibility and allows the project to build when using GCC.