### PR TITLE
Changed ICommonStateGetter::ReceiveMessage to allow further execution in games

### DIFF
--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -81,7 +81,7 @@ private:
     void ReceiveMessage(Kernel::HLERequestContext& ctx) {
         IPC::RequestBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u32>(1);
+        rb.Push<u32>(15);
 
         LOG_WARNING(Service, "(STUBBED) called");
     }


### PR DESCRIPTION
Games/applications usually expect 15 from ICommonStateGetter::ReceiveMessage otherwise they'll freeze execution.