### PR TITLE
CMake: Output binaries to bin/

### DIFF
--- a/.travis/linux/upload.sh
+++ b/.travis/linux/upload.sh
@@ -8,7 +8,7 @@ COMPRESSION_FLAGS="-cJvf"
 
 mkdir "$REV_NAME"
 
-cp build/src/yuzu_cmd/yuzu-cmd "$REV_NAME"
-cp build/src/yuzu/yuzu "$REV_NAME"
+cp build/bin/yuzu-cmd "$REV_NAME"
+cp build/bin/yuzu "$REV_NAME"
 
 . .travis/common/post-upload.sh

--- a/.travis/macos/upload.sh
+++ b/.travis/macos/upload.sh
@@ -8,8 +8,8 @@ COMPRESSION_FLAGS="-czvf"
 
 mkdir "$REV_NAME"
 
-cp build/src/yuzu_cmd/yuzu-cmd "$REV_NAME"
-cp -r build/src/yuzu/yuzu.app "$REV_NAME"
+cp build/bin/yuzu-cmd "$REV_NAME"
+cp -r build/bin/yuzu.app "$REV_NAME"
 
 # move qt libs into app bundle for deployment
 $(brew --prefix)/opt/qt5/bin/macdeployqt "${REV_NAME}/yuzu.app"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,9 @@ if (NOT Boost_FOUND)
     find_package(Boost QUIET REQUIRED)
 endif()
 
+# Output binaries to bin/
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
 # Prefer the -pthread flag on Linux.
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)


### PR DESCRIPTION
Instead of outputting binaries to ``${CMAKE_BINARY_DIR}/src/$DIR`` output them to ``${CMAKE_BINARY_DIR}/bin``.

Much less cumbersome IMO.