### PR TITLE
added more svcGetInfo pairs for 3.0.0+ support, Changed HEAP_SIZE and TLS_AREA_VADDR. changed mem usage & heap usage stub added, ISelfController, IApplication function stubs. Added SetThreadCoreMask

### DIFF
--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -131,6 +131,8 @@ public:
     /// Bitmask of allowed CPUs that this process' threads can run on. TODO(Subv): Actually parse
     /// this value from the process header.
     u32 allowed_processor_mask = THREADPROCESSORID_DEFAULT_MASK;
+    u32 allowed_thread_priority_mask = 0xFFFFFFFF;
+    u32 is_virtual_address_memory_enabled = 0;
     /// Current status of the process
     ProcessStatus status;
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -313,6 +313,15 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
     case GetInfoType::AllowedCpuIdBitmask:
         *result = g_current_process->allowed_processor_mask;
         break;
+    case GetInfoType::AllowedThreadPrioBitmask:
+        *result = g_current_process->allowed_thread_priority_mask;
+        break;
+    case GetInfoType::MapRegionBaseAddr:
+        *result = vm_manager.GetAddressSpaceBaseAddr();
+        break;
+    case GetInfoType::MapRegionSize:
+        *result = vm_manager.GetAddressSpaceSize();
+        break;
     case GetInfoType::TotalMemoryUsage:
         *result = vm_manager.GetTotalMemoryUsage();
         break;
@@ -333,6 +342,9 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
         break;
     case GetInfoType::NewMapRegionSize:
         *result = vm_manager.GetNewMapRegionSize();
+        break;
+    case GetInfoType::IsVirtualAddressMemoryEnabled:
+        *result = g_current_process->is_virtual_address_memory_enabled;
         break;
     default:
         UNIMPLEMENTED();

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -721,6 +721,11 @@ static ResultCode CreateTransferMemory(Handle* handle, VAddr addr, u64 size, u32
     return RESULT_SUCCESS;
 }
 
+static ResultCode SetThreadCoreMask(u64, u64, u64) {
+    LOG_WARNING(Kernel_SVC, "(STUBBED) called");
+    return RESULT_SUCCESS;
+}
+
 namespace {
 struct FunctionDef {
     using Func = void();
@@ -747,7 +752,7 @@ static const FunctionDef SVC_Table[] = {
     {0x0C, SvcWrap<GetThreadPriority>, "GetThreadPriority"},
     {0x0D, SvcWrap<SetThreadPriority>, "SetThreadPriority"},
     {0x0E, nullptr, "GetThreadCoreMask"},
-    {0x0F, nullptr, "SetThreadCoreMask"},
+    {0x0F, SvcWrap<SetThreadCoreMask>, "SetThreadCoreMask"},
     {0x10, SvcWrap<GetCurrentProcessorNumber>, "GetCurrentProcessorNumber"},
     {0x11, nullptr, "SignalEvent"},
     {0x12, nullptr, "ClearEvent"},

--- a/src/core/hle/kernel/svc.h
+++ b/src/core/hle/kernel/svc.h
@@ -24,14 +24,27 @@ struct PageInfo {
 enum class GetInfoType : u64 {
     // 1.0.0+
     AllowedCpuIdBitmask = 0,
+    AllowedThreadPrioBitmask = 1,
+    MapRegionBaseAddr = 2,
+    MapRegionSize = 3,
+    HeapRegionBaseAddr = 4,
+    HeapRegionSize = 5,
     TotalMemoryUsage = 6,
     TotalHeapUsage = 7,
+    IsCurrentProcessBeingDebugged = 8,
+    ResourceHandleLimit = 9,
+    IdleTickCount = 10,
     RandomEntropy = 11,
+    PerformanceCounter = 0xF0000002,
     // 2.0.0+
     AddressSpaceBaseAddr = 12,
     AddressSpaceSize = 13,
     NewMapRegionBaseAddr = 14,
     NewMapRegionSize = 15,
+    // 3.0.0+
+    IsVirtualAddressMemoryEnabled = 16,
+    TitleId = 18,
+    PrivilegedProcessId = 19,
 };
 
 void CallSVC(u32 immediate);

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -356,12 +356,12 @@ void VMManager::UpdatePageTableForVMA(const VirtualMemoryArea& vma) {
 
 u64 VMManager::GetTotalMemoryUsage() {
     LOG_WARNING(Kernel, "(STUBBED) called");
-    return 0x400000;
+    return 0xBE000000;
 }
 
 u64 VMManager::GetTotalHeapUsage() {
     LOG_WARNING(Kernel, "(STUBBED) called");
-    return 0x10000;
+    return 0x0;
 }
 
 VAddr VMManager::GetAddressSpaceBaseAddr() {

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -54,13 +54,51 @@ class ISelfController final : public ServiceFramework<ISelfController> {
 public:
     ISelfController() : ServiceFramework("ISelfController") {
         static const FunctionInfo functions[] = {
+            {11, &ISelfController::SetOperationModeChangedNotification,
+             "SetOperationModeChangedNotification"},
+            {12, &ISelfController::SetPerformanceModeChangedNotification,
+             "SetPerformanceModeChangedNotification"},
             {13, &ISelfController::SetFocusHandlingMode, "SetFocusHandlingMode"},
+            {14, &ISelfController::SetRestartMessageEnabled, "SetRestartMessageEnabled"},
+            {16, &ISelfController::SetOutOfFocusSuspendingEnabled,
+             "SetOutOfFocusSuspendingEnabled"},
         };
         RegisterHandlers(functions);
     }
 
 private:
     void SetFocusHandlingMode(Kernel::HLERequestContext& ctx) {
+        // Takes 3 input u8s with each field located immediately after the previous u8, these are
+        // bool flags. No output.
+
+        IPC::RequestBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+
+        LOG_WARNING(Service, "(STUBBED) called");
+    }
+
+    void SetRestartMessageEnabled(Kernel::HLERequestContext& ctx) {
+        IPC::RequestBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+
+        LOG_WARNING(Service, "(STUBBED) called");
+    }
+
+    void SetPerformanceModeChangedNotification(Kernel::HLERequestContext& ctx) {
+        IPC::RequestBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+
+        LOG_WARNING(Service, "(STUBBED) called");
+    }
+
+    void SetOperationModeChangedNotification(Kernel::HLERequestContext& ctx) {
+        IPC::RequestBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+
+        LOG_WARNING(Service, "(STUBBED) called");
+    }
+
+    void SetOutOfFocusSuspendingEnabled(Kernel::HLERequestContext& ctx) {
         // Takes 3 input u8s with each field located immediately after the previous u8, these are
         // bool flags. No output.
 
@@ -119,6 +157,9 @@ public:
     IApplicationFunctions() : ServiceFramework("IApplicationFunctions") {
         static const FunctionInfo functions[] = {
             {22, &IApplicationFunctions::SetTerminateResult, "SetTerminateResult"},
+            {66, &IApplicationFunctions::InitializeGamePlayRecording,
+             "InitializeGamePlayRecording"},
+            {67, &IApplicationFunctions::SetGamePlayRecordingState, "SetGamePlayRecordingState"},
         };
         RegisterHandlers(functions);
     }
@@ -135,6 +176,18 @@ private:
         rb.Push(RESULT_SUCCESS);
 
         LOG_WARNING(Service, "(STUBBED) called, result=0x%08X", result);
+    }
+
+    void InitializeGamePlayRecording(Kernel::HLERequestContext& ctx) {
+        IPC::RequestBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+        LOG_WARNING(Service, "(STUBBED) called");
+    }
+
+    void SetGamePlayRecordingState(Kernel::HLERequestContext& ctx) {
+        IPC::RequestBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+        LOG_WARNING(Service, "(STUBBED) called");
     }
 };
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -136,7 +136,7 @@ enum : VAddr {
 
     /// Application heap (includes stack).
     HEAP_VADDR = 0x108000000,
-    HEAP_SIZE = 0xF0000000, // 0x18000000,
+    HEAP_SIZE = 0xF0000000,
     HEAP_VADDR_END = HEAP_VADDR + HEAP_SIZE,
 
     /// Area where shared memory buffers are mapped onto.
@@ -177,7 +177,7 @@ enum : VAddr {
     SHARED_PAGE_VADDR_END = SHARED_PAGE_VADDR + SHARED_PAGE_SIZE,
 
     /// Area where TLS (Thread-Local Storage) buffers are allocated.
-    TLS_AREA_VADDR = 0x228000000, // 0x1FF82000,
+    TLS_AREA_VADDR = 0x228000000,
     TLS_ENTRY_SIZE = 0x200,
 
     /// Equivalent to LINEAR_HEAP_VADDR, but expanded to cover the extra memory in the New 3DS.

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -136,7 +136,7 @@ enum : VAddr {
 
     /// Application heap (includes stack).
     HEAP_VADDR = 0x108000000,
-    HEAP_SIZE = 0x18000000,
+    HEAP_SIZE = 0xF0000000, // 0x18000000,
     HEAP_VADDR_END = HEAP_VADDR + HEAP_SIZE,
 
     /// Area where shared memory buffers are mapped onto.
@@ -177,7 +177,7 @@ enum : VAddr {
     SHARED_PAGE_VADDR_END = SHARED_PAGE_VADDR + SHARED_PAGE_SIZE,
 
     /// Area where TLS (Thread-Local Storage) buffers are allocated.
-    TLS_AREA_VADDR = 0x1FF82000,
+    TLS_AREA_VADDR = 0x228000000, // 0x1FF82000,
     TLS_ENTRY_SIZE = 0x200,
 
     /// Equivalent to LINEAR_HEAP_VADDR, but expanded to cover the extra memory in the New 3DS.


### PR DESCRIPTION
More support for 3.0.0+ games. is_virtual_address_memory_enabled is set to default 0 to prevent svcMapPhysicalMemory being called as of right now and allow commercial games to run further.