### PR TITLE
Fix non translated string (same as Citra PR 2949)

### DIFF
--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -73,5 +73,5 @@ void ConfigureSystem::refreshConsoleID() {
     if (reply == QMessageBox::No)
         return;
     u64 console_id{};
-    ui->label_console_id->setText("Console ID: 0x" + QString::number(console_id, 16).toUpper());
+    ui->label_console_id->setText(tr("Console ID: 0x%1").arg(QString::number(console_id, 16).toUpper()));
 }


### PR DESCRIPTION
Citra's PR #2949 had a few changes, but only a single line was actually relevant so I just made that single line change myself. The other changes were for files that do not exist in Yuzu or for UI elements that are already fixed.