### PR TITLE
UI: Fix frame rate perf stats

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
@@ -4,6 +4,7 @@
 
 #include "common/assert.h"
 #include "common/logging/log.h"
+#include "core/core.h"
 #include "core/hle/service/nvdrv/devices/nvdisp_disp0.h"
 #include "core/hle/service/nvdrv/devices/nvmap.h"
 #include "video_core/renderer_base.h"
@@ -28,6 +29,8 @@ void nvdisp_disp0::flip(u32 buffer_handle, u32 offset, u32 format, u32 width, u3
     using PixelFormat = RendererBase::FramebufferInfo::PixelFormat;
     const RendererBase::FramebufferInfo framebuffer_info{
         addr, offset, width, height, stride, static_cast<PixelFormat>(format)};
+
+    Core::System::GetInstance().perf_stats.EndGameFrame();
     VideoCore::g_renderer->SwapBuffers(framebuffer_info);
 }
 

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -69,7 +69,7 @@ PerfStats::Results PerfStats::GetAndResetStats(u64 current_system_time_us) {
 double PerfStats::GetLastFrameTimeScale() {
     std::lock_guard<std::mutex> lock(object_mutex);
 
-    constexpr double FRAME_LENGTH = 1.0 / 60; // GPU::SCREEN_REFRESH_RATE;
+    constexpr double FRAME_LENGTH = 1.0 / 60;
     return duration_cast<DoubleSecs>(previous_frame_length).count() / FRAME_LENGTH;
 }
 


### PR DESCRIPTION
Adds in a missing EndGameFrame when nvdrv swaps buffers. Fixes FPS always showing as 0FPS in the QT frontend. Doesn't fix microprofile