### PR TITLE
hid: Adjust timing based on actual hardware

### DIFF
--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -18,9 +18,9 @@ namespace HID {
 
 // Updating period for each HID device.
 // TODO(shinyquagsire23): These need better values.
-constexpr u64 pad_update_ticks = BASE_CLOCK_RATE / 234;
-constexpr u64 accelerometer_update_ticks = BASE_CLOCK_RATE / 104;
-constexpr u64 gyroscope_update_ticks = BASE_CLOCK_RATE / 101;
+constexpr u64 pad_update_ticks = BASE_CLOCK_RATE / 10000;
+constexpr u64 accelerometer_update_ticks = BASE_CLOCK_RATE / 10000;
+constexpr u64 gyroscope_update_ticks = BASE_CLOCK_RATE / 10000;
 
 class IAppletResource final : public ServiceFramework<IAppletResource> {
 public:


### PR DESCRIPTION
When observing the difference in tick count between new samples, the number of ticks between samples ranged from 0x68f2 ticks to 0x28761 ticks. From observation, the values mostly fluctuated between 0x10000 and 0x0x20000.

Dividing the clock rate by the average between the min and max values yields ~10000. In reality, I'd imagine the update rate actually depends a lot on factors such as Bluetooth vs UART (rails) connection, bandwidth (Amiibo scanning can increase bytes sent, the IR cam likely does as well). So in any case there isn't really a hard value for this, but this is a pretty safe rate.