### PR TITLE
Fix gdbstub typo

### DIFF
--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -905,7 +905,7 @@ void ToggleServer(bool status) {
         server_enabled = status;
 
         // Start server
-        if (!IsConnected() && Core::System().GetInstance().IsPoweredOn()) {
+        if (!IsConnected() && Core::System::GetInstance().IsPoweredOn()) {
             Init();
         }
     } else {


### PR DESCRIPTION
This fixes a typo in gdbstub.cpp by porting the citra pr https://github.com/citra-emu/citra/pull/3318 which was listed in the yuzu issue https://github.com/yuzu-emu/yuzu/issues/40




