### PR TITLE
nvdrv: stubbed Close(cmd 2)

### DIFF
--- a/src/core/hle/service/nvdrv/interface.cpp
+++ b/src/core/hle/service/nvdrv/interface.cpp
@@ -48,6 +48,18 @@ void NVDRV::Ioctl(Kernel::HLERequestContext& ctx) {
     rb.Push(nv_result);
 }
 
+void NVDRV::Close(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service, "(STUBBED) called");
+
+    IPC::RequestParser rp{ctx};
+    u32 fd = rp.Pop<u32>();
+
+    auto result = nvdrv->Close(fd);
+
+    IPC::RequestBuilder rb{ctx, 2};
+    rb.Push(result);
+}
+
 void NVDRV::Initialize(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service, "(STUBBED) called");
     IPC::RequestBuilder rb{ctx, 3};
@@ -60,6 +72,7 @@ NVDRV::NVDRV(std::shared_ptr<Module> nvdrv, const char* name)
     static const FunctionInfo functions[] = {
         {0, &NVDRV::Open, "Open"},
         {1, &NVDRV::Ioctl, "Ioctl"},
+        {2, &NVDRV::Close, "Close"},
         {3, &NVDRV::Initialize, "Initialize"},
     };
     RegisterHandlers(functions);

--- a/src/core/hle/service/nvdrv/interface.h
+++ b/src/core/hle/service/nvdrv/interface.h
@@ -20,6 +20,7 @@ public:
 private:
     void Open(Kernel::HLERequestContext& ctx);
     void Ioctl(Kernel::HLERequestContext& ctx);
+    void Close(Kernel::HLERequestContext& ctx);
     void Initialize(Kernel::HLERequestContext& ctx);
 
     std::shared_ptr<Module> nvdrv;

--- a/src/core/hle/service/nvdrv/nvdrv.cpp
+++ b/src/core/hle/service/nvdrv/nvdrv.cpp
@@ -49,5 +49,15 @@ u32 Module::Ioctl(u32 fd, u32 command, const std::vector<u8>& input, std::vector
     return device->ioctl(command, input, output);
 }
 
+ResultCode Module::Close(u32 fd) {
+    auto itr = open_files.find(fd);
+    ASSERT_MSG(itr != open_files.end(), "Tried to talk to an invalid device");
+
+    open_files.erase(itr);
+
+    // TODO(flerovium): return correct result code if operation failed.
+    return RESULT_SUCCESS;
+}
+
 } // namespace Nvidia
 } // namespace Service

--- a/src/core/hle/service/nvdrv/nvdrv.h
+++ b/src/core/hle/service/nvdrv/nvdrv.h
@@ -35,6 +35,8 @@ public:
     u32 Open(std::string device_name);
     /// Sends an ioctl command to the specified file descriptor.
     u32 Ioctl(u32 fd, u32 command, const std::vector<u8>& input, std::vector<u8>& output);
+    /// Closes a device file descriptor and returns operation success.
+    ResultCode Close(u32 fd);
 
 private:
     /// Id to use for the next open file descriptor.


### PR DESCRIPTION
Well, apologies for the inconvenience of creating an entirely new PR, my previous repo/branch wasn't really setup with upstream properly and I created a clean fork to fix that.

Added a simple stub for Close in the ```nvdrv``` service. Simply checks if the file descriptor is known and removes the corresponding entry from the ```open_files``` list in that case.
Returns ```RESULT_SUCCESS``` in case of success.