### PR TITLE
[RFC] Add support for reading Buffer C Descriptors on hle_ipc

### DIFF
--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -54,6 +54,10 @@ public:
     unsigned GetCurrentOffset() const {
         return static_cast<unsigned>(index);
     }
+
+    void SetCurrentOffset(unsigned offset) {
+        index = static_cast<ptrdiff_t>(offset);
+    }
 };
 
 class RequestBuilder : public RequestHelperBase {

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -200,8 +200,10 @@ private:
     std::vector<IPC::BufferDescriptorABW> buffer_a_desciptors;
     std::vector<IPC::BufferDescriptorABW> buffer_b_desciptors;
     std::vector<IPC::BufferDescriptorABW> buffer_w_desciptors;
+    std::vector<IPC::BufferDescriptorC> buffer_c_desciptors;
 
     unsigned data_payload_offset{};
+    unsigned buffer_c_offset{};
     u32_le command{};
 };
 

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -143,6 +143,10 @@ public:
         return buffer_b_desciptors;
     }
 
+    const std::vector<IPC::BufferDescriptorC>& BufferDescriptorC() const {
+        return buffer_c_desciptors;
+    }
+
     const std::unique_ptr<IPC::DomainMessageHeader>& GetDomainMessageHeader() const {
         return domain_message_header;
     }


### PR DESCRIPTION
This adds support for reading Buffer C Descriptors (a.k.a. Receive Lists) on hle_ipc. Those are needed by nvdrv for example (altrough nvdrv will pass the same pointers/sizes into both the X and C descriptors).

**Note:** Currently untested as I don't have any game that goes as far as requesting nvdrv commands.

FYI @ogniK5377 
PTAL @bunnei 