### PR TITLE
remove_old_new_3DSmode

### DIFF
--- a/src/core/hle/kernel/memory.cpp
+++ b/src/core/hle/kernel/memory.cpp
@@ -27,23 +27,14 @@ MemoryRegionInfo memory_regions[3];
 
 /// Size of the APPLICATION, SYSTEM and BASE memory regions (respectively) for each system
 /// memory configuration type.
-static const u32 memory_region_sizes[8][3] = {
-    // Old 3DS layouts
-    {0x04000000, 0x02C00000, 0x01400000}, // 0
+static const u32 memory_region_sizes[3][3] = {
     {/* This appears to be unused. */},   // 1
-    {0x06000000, 0x00C00000, 0x01400000}, // 2
-    {0x05000000, 0x01C00000, 0x01400000}, // 3
-    {0x04800000, 0x02400000, 0x01400000}, // 4
-    {0x02000000, 0x04C00000, 0x01400000}, // 5
-
-    // New 3DS layouts
-    {0x07C00000, 0x06400000, 0x02000000}, // 6
-    {0x0B200000, 0x02E00000, 0x02000000}, // 7
+    {0x04800000, 0x02400000, 0x01400000}, // 3
+    {0x02000000, 0x04C00000, 0x01400000}, // 4
 };
 
 void MemoryInit(u32 mem_type) {
-    // TODO(yuriks): On the n3DS, all o3DS configurations (<=5) are forced to 6 instead.
-    ASSERT_MSG(mem_type <= 5, "New 3DS memory configuration aren't supported yet!");
+    ASSERT_MSG(mem_type <= 5, "New memory configuration aren't supported yet!");
     ASSERT(mem_type != 1);
 
     // The kernel allocation regions (APPLICATION, SYSTEM and BASE) are laid out in sequence, with
@@ -67,7 +58,6 @@ void MemoryInit(u32 mem_type) {
     using ConfigMem::config_mem;
     config_mem.app_mem_type = mem_type;
     // app_mem_malloc does not always match the configured size for memory_region[0]: in case the
-    // n3DS type override is in effect it reports the size the game expects, not the real one.
     config_mem.app_mem_alloc = memory_region_sizes[mem_type][0];
     config_mem.sys_mem_alloc = static_cast<u32_le>(memory_regions[1].size);
     config_mem.base_mem_alloc = static_cast<u32_le>(memory_regions[2].size);

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -162,7 +162,6 @@ void Process::LoadModule(SharedPtr<CodeSet> module_, VAddr base_addr) {
 
 VAddr Process::GetLinearHeapAreaAddress() const {
     // Starting from system version 8.0.0 a new linear heap layout is supported to allow usage of
-    // the extra RAM in the n3DS.
     return kernel_version < 0x22C ? Memory::LINEAR_HEAP_VADDR : Memory::NEW_LINEAR_HEAP_VADDR;
 }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -21,7 +21,6 @@
 namespace Memory {
 
 static std::array<u8, Memory::VRAM_SIZE> vram;
-static std::array<u8, Memory::N3DS_EXTRA_RAM_SIZE> n3ds_extra_ram;
 
 static PageTable* current_page_table = nullptr;
 
@@ -283,8 +282,7 @@ u8* GetPhysicalPointer(PAddr address) {
         {VRAM_PADDR, VRAM_SIZE},
         {IO_AREA_PADDR, IO_AREA_SIZE},
         {DSP_RAM_PADDR, DSP_RAM_SIZE},
-        {FCRAM_PADDR, FCRAM_N3DS_SIZE},
-        {N3DS_EXTRA_RAM_PADDR, N3DS_EXTRA_RAM_SIZE},
+        {FCRAM_PADDR, FCRAM_SIZE},
     };
 
     const auto area =
@@ -321,9 +319,6 @@ u8* GetPhysicalPointer(PAddr address) {
             }
         }
         ASSERT_MSG(target_pointer != nullptr, "Invalid FCRAM address");
-        break;
-    case N3DS_EXTRA_RAM_PADDR:
-        target_pointer = n3ds_extra_ram.data() + offset_into_region;
         break;
     default:
         UNREACHABLE();
@@ -740,8 +735,6 @@ boost::optional<PAddr> TryVirtualToPhysicalAddress(const VAddr addr) {
         return addr - DSP_RAM_VADDR + DSP_RAM_PADDR;
     } else if (addr >= IO_AREA_VADDR && addr < IO_AREA_VADDR_END) {
         return addr - IO_AREA_VADDR + IO_AREA_PADDR;
-    } else if (addr >= N3DS_EXTRA_RAM_VADDR && addr < N3DS_EXTRA_RAM_VADDR_END) {
-        return addr - N3DS_EXTRA_RAM_VADDR + N3DS_EXTRA_RAM_PADDR;
     }
 
     return boost::none;
@@ -768,8 +761,6 @@ boost::optional<VAddr> PhysicalToVirtualAddress(const PAddr addr) {
         return addr - DSP_RAM_PADDR + DSP_RAM_VADDR;
     } else if (addr >= IO_AREA_PADDR && addr < IO_AREA_PADDR_END) {
         return addr - IO_AREA_PADDR + IO_AREA_VADDR;
-    } else if (addr >= N3DS_EXTRA_RAM_PADDR && addr < N3DS_EXTRA_RAM_PADDR_END) {
-        return addr - N3DS_EXTRA_RAM_PADDR + N3DS_EXTRA_RAM_VADDR;
     }
 
     return boost::none;

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -98,12 +98,6 @@ enum : PAddr {
     VRAM_SIZE = 0x00600000, ///< VRAM size (6MB)
     VRAM_PADDR_END = VRAM_PADDR + VRAM_SIZE,
 
-    /// New 3DS additional memory. Supposedly faster than regular FCRAM. Part of it can be used by
-    /// applications and system modules if mapped via the ExHeader.
-    N3DS_EXTRA_RAM_PADDR = 0x1F000000,
-    N3DS_EXTRA_RAM_SIZE = 0x00400000, ///< New 3DS additional memory size (4MB)
-    N3DS_EXTRA_RAM_PADDR_END = N3DS_EXTRA_RAM_PADDR + N3DS_EXTRA_RAM_SIZE,
-
     /// DSP memory
     DSP_RAM_PADDR = 0x1FF00000,
     DSP_RAM_SIZE = 0x00080000, ///< DSP memory size (512KB)
@@ -116,10 +110,8 @@ enum : PAddr {
 
     /// Main FCRAM
     FCRAM_PADDR = 0x20000000,
-    FCRAM_SIZE = 0x08000000,      ///< FCRAM size on the Old 3DS (128MB)
-    FCRAM_N3DS_SIZE = 0x10000000, ///< FCRAM size on the New 3DS (256MB)
+    FCRAM_SIZE = 0x08000000, ///< FCRAM size on the (128MB)
     FCRAM_PADDR_END = FCRAM_PADDR + FCRAM_SIZE,
-    FCRAM_N3DS_PADDR_END = FCRAM_PADDR + FCRAM_N3DS_SIZE,
 };
 
 /// Virtual user-space memory regions
@@ -149,10 +141,6 @@ enum : VAddr {
     LINEAR_HEAP_VADDR = 0x14000000,
     LINEAR_HEAP_SIZE = 0x08000000,
     LINEAR_HEAP_VADDR_END = LINEAR_HEAP_VADDR + LINEAR_HEAP_SIZE,
-
-    /// Maps 1:1 to New 3DS additional memory
-    N3DS_EXTRA_RAM_VADDR = 0x1E800000,
-    N3DS_EXTRA_RAM_VADDR_END = N3DS_EXTRA_RAM_VADDR + N3DS_EXTRA_RAM_SIZE,
 
     /// Maps 1:1 to the IO register area.
     IO_AREA_VADDR = 0x1EC00000,


### PR DESCRIPTION
Hi all.

First off all no idea what the hell i'm doing xd, not a coder, I just thought to do some clean ups and remove some necessarily n3ds mode in code for switch..

Any think else to remove let us know ?..
Are close the post, my first try so go easy xd.

1. Is this code still needed for switch ?
2. Dose switch uses a new 3ds mode, like the real 3ds dose..

I did a local compile after this remove, seems to have no impact on the yuzu emulator while running homebrew spacenx.nso