### PR TITLE
Remove relocation on NSO/NRO

### DIFF
--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -118,13 +118,6 @@ bool AppLoader_NRO::LoadNro(const std::string& path, VAddr load_base) {
     }
     program_image.resize(PageAlignSize(static_cast<u32>(program_image.size()) + bss_size));
 
-    // Relocate symbols if there was a proper MOD header - This must happen after the image has been
-    // loaded into memory
-    if (has_mod_header) {
-        Relocate(program_image, nro_header.module_header_offset + mod_header.dynamic_offset,
-                 load_base);
-    }
-
     // Load codeset for current process
     codeset->name = path;
     codeset->memory = std::make_shared<std::vector<u8>>(std::move(program_image));
@@ -153,8 +146,6 @@ ResultStatus AppLoader_NRO::Load(Kernel::SharedPtr<Kernel::Process>& process) {
     process->resource_limit =
         Kernel::ResourceLimit::GetForCategory(Kernel::ResourceLimitCategory::APPLICATION);
     process->Run(base_addr, 48, Kernel::DEFAULT_STACK_SIZE);
-
-    ResolveImports();
 
     is_loaded = true;
     return ResultStatus::Success;

--- a/src/core/loader/nso.h
+++ b/src/core/loader/nso.h
@@ -34,7 +34,7 @@ public:
     ResultStatus Load(Kernel::SharedPtr<Kernel::Process>& process) override;
 
 private:
-    VAddr LoadNso(const std::string& path, VAddr load_base, bool relocate = false);
+    VAddr LoadNso(const std::string& path, VAddr load_base);
 
     std::string filepath;
 };


### PR DESCRIPTION
rtld already takes care of relocating and linking on official games, we don't need to do it (twice) on the loader. Both libnx and libtransistor also already has code to do those relocations, see:

https://github.com/switchbrew/libnx/blob/master/nx/source/runtime/dynamic.c#L4
https://github.com/reswitched/libtransistor/blob/master/lib/crt0_common.c#L54