### PR TITLE
input_common/sdl: Silence a -Wpessimizing-move warning

### DIFF
--- a/src/input_common/sdl/sdl.cpp
+++ b/src/input_common/sdl/sdl.cpp
@@ -425,7 +425,7 @@ std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> GetPollers(
         pollers.push_back(std::make_unique<SDLButtonPoller>());
         break;
     }
-    return std::move(pollers);
+    return pollers;
 }
 } // namespace Polling
 } // namespace SDL


### PR DESCRIPTION
Also addresses the #3263 checkbox in #40