### PR TITLE
hotkeys: Add missing <QTreeWidgetItem> include

### DIFF
--- a/src/yuzu/hotkeys.cpp
+++ b/src/yuzu/hotkeys.cpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <QKeySequence>
 #include <QShortcut>
+#include <QTreeWidgetItem>
 #include <QtGlobal>
 #include "yuzu/hotkeys.h"
 #include "yuzu/ui_settings.h"


### PR DESCRIPTION
Gets rid of reliance on an indirect inclusion