### PR TITLE
Fix NRO entry point

### DIFF
--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -103,7 +103,7 @@ bool AppLoader_NRO::LoadNro(const std::string& path, VAddr load_base) {
         bss_size = PageAlignSize(mod_header.bss_end_offset - mod_header.bss_start_offset);
     }
     codeset->data.size += bss_size;
-    program_image.resize(PageAlignSize(static_cast<u32>(program_image.size()) + bss_size));
+    program_image.resize(static_cast<u32>(program_image.size()) + bss_size);
 
     // Load codeset for current process
     codeset->name = path;
@@ -134,7 +134,7 @@ ResultStatus AppLoader_NRO::Load(Kernel::SharedPtr<Kernel::Process>& process) {
     process->address_mappings = default_address_mappings;
     process->resource_limit =
         Kernel::ResourceLimit::GetForCategory(Kernel::ResourceLimitCategory::APPLICATION);
-    process->Run(base_addr + sizeof(NroHeader), 48, Kernel::DEFAULT_STACK_SIZE);
+    process->Run(base_addr, 48, Kernel::DEFAULT_STACK_SIZE);
 
     is_loaded = true;
     return ResultStatus::Success;


### PR DESCRIPTION
So it seems that libtransistor is wrong, NROs are supposed to have a branch that jumps to 0x80 at 0x0, but current NROs generated by libtransistor tools doesn't seem to have such branch, this previously caused the games to not work on Yuzu beucase the CPU was executing garbage. This PRs restores the old (correct) behaviour, but unfortunately the NROs will need to be recompiled to fix that. So its better to merge after the issue is fixed on libtransistor.