### PR TITLE
Stub PopLaunchParameter and implement Buffer C Descriptors reading on hle_ipc

### DIFF
--- a/src/core/hle/ipc.h
+++ b/src/core/hle/ipc.h
@@ -133,6 +133,10 @@ struct BufferDescriptorC {
         address |= static_cast<VAddr>(address_bits_32_47) << 32;
         return address;
     }
+
+    u64 Size() const {
+        return static_cast<u64>(size);
+    }
 };
 static_assert(sizeof(BufferDescriptorC) == 8, "BufferDescriptorC size is incorrect");
 

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -54,6 +54,10 @@ public:
     unsigned GetCurrentOffset() const {
         return static_cast<unsigned>(index);
     }
+
+    void SetCurrentOffset(unsigned offset) {
+        index = static_cast<ptrdiff_t>(offset);
+    }
 };
 
 class RequestBuilder : public RequestHelperBase {

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -143,6 +143,10 @@ public:
         return buffer_b_desciptors;
     }
 
+    const std::vector<IPC::BufferDescriptorC>& BufferDescriptorC() const {
+        return buffer_c_desciptors;
+    }
+
     const std::unique_ptr<IPC::DomainMessageHeader>& GetDomainMessageHeader() const {
         return domain_message_header;
     }
@@ -200,8 +204,10 @@ private:
     std::vector<IPC::BufferDescriptorABW> buffer_a_desciptors;
     std::vector<IPC::BufferDescriptorABW> buffer_b_desciptors;
     std::vector<IPC::BufferDescriptorABW> buffer_w_desciptors;
+    std::vector<IPC::BufferDescriptorC> buffer_c_desciptors;
 
     unsigned data_payload_offset{};
+    unsigned buffer_c_offset{};
     u32_le command{};
 };
 

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -219,7 +219,7 @@ private:
         IPC::RequestBuilder rb{ctx, 4};
 
         rb.Push(RESULT_SUCCESS);
-        rb.Push(buffer.size());
+        rb.Push(static_cast<u64>(buffer.size()));
 
         LOG_DEBUG(Service, "called");
     }

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -292,9 +292,7 @@ private:
             0, 0, 0, 0  // User Id (word 3)
         };
 
-        std::vector<u8> buffer;
-
-        buffer.assign(data, data + sizeof(data));
+        std::vector<u8> buffer(data, data + sizeof(data));
 
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<AM::IStorage>(buffer);

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -201,10 +201,75 @@ private:
     Kernel::SharedPtr<Kernel::Event> event;
 };
 
+class IStorageAccessor final : public ServiceFramework<IStorageAccessor> {
+public:
+    explicit IStorageAccessor(std::vector<u8> buffer) : ServiceFramework("IStorageAccessor"),
+    buffer(std::move(buffer)) {
+        static const FunctionInfo functions[] = {
+            {0, &IStorageAccessor::GetSize, "GetSize"},
+            {11, &IStorageAccessor::Read, "Read"},
+        };
+        RegisterHandlers(functions);
+    }
+
+private:
+    std::vector<u8> buffer;
+
+    void GetSize(Kernel::HLERequestContext& ctx) {
+        IPC::RequestBuilder rb{ctx, 4};
+
+        rb.Push(RESULT_SUCCESS);
+        rb.Push(buffer.size());
+
+        LOG_DEBUG(Service, "called");
+    }
+
+    void Read(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+
+        u64 offset = rp.Pop<u64>();
+
+        const auto& output_buffer = ctx.BufferDescriptorC()[0];
+
+        ASSERT(offset + output_buffer.Size() <= buffer.size());
+
+        Memory::WriteBlock(output_buffer.Address(), buffer.data() + offset, output_buffer.Size());
+
+        IPC::RequestBuilder rb{ctx, 2};
+
+        rb.Push(RESULT_SUCCESS);
+
+        LOG_DEBUG(Service, "called");
+    }
+};
+
+class IStorage final : public ServiceFramework<IStorage> {
+public:
+    explicit IStorage(std::vector<u8> buffer) : ServiceFramework("IStorage"), buffer(std::move(buffer)) {
+        static const FunctionInfo functions[] = {
+            {0, &IStorage::Open, "Open"},
+        };
+        RegisterHandlers(functions);
+    }
+
+private:
+    std::vector<u8> buffer;
+
+    void Open(Kernel::HLERequestContext& ctx) {
+        IPC::RequestBuilder rb{ctx, 2, 0, 0, 1};
+
+        rb.Push(RESULT_SUCCESS);
+        rb.PushIpcInterface<AM::IStorageAccessor>(buffer);
+
+        LOG_DEBUG(Service, "called");
+    }
+};
+
 class IApplicationFunctions final : public ServiceFramework<IApplicationFunctions> {
 public:
     IApplicationFunctions() : ServiceFramework("IApplicationFunctions") {
         static const FunctionInfo functions[] = {
+            {1, &IApplicationFunctions::PopLaunchParameter, "PopLaunchParameter"},
             {22, &IApplicationFunctions::SetTerminateResult, "SetTerminateResult"},
             {66, &IApplicationFunctions::InitializeGamePlayRecording,
              "InitializeGamePlayRecording"},
@@ -215,6 +280,28 @@ public:
     }
 
 private:
+    void PopLaunchParameter(Kernel::HLERequestContext& ctx) {
+        IPC::RequestBuilder rb{ctx, 2, 0, 0, 1};
+
+        constexpr u8 data[0x88] = {
+            0xca, 0x97, 0x94, 0xc7, // Magic
+            1, 0, 0, 0, // IsAccountSelected (bool)
+            1, 0, 0, 0, // User Id (word 0)
+            0, 0, 0, 0, // User Id (word 1)
+            0, 0, 0, 0, // User Id (word 2)
+            0, 0, 0, 0  // User Id (word 3)
+        };
+
+        std::vector<u8> buffer;
+
+        buffer.assign(data, data + sizeof(data));
+
+        rb.Push(RESULT_SUCCESS);
+        rb.PushIpcInterface<AM::IStorage>(buffer);
+
+        LOG_DEBUG(Service, "called");
+    }
+
     void SetTerminateResult(Kernel::HLERequestContext& ctx) {
         // Takes an input u32 Result, no output.
         // For example, in some cases official apps use this with error 0x2A2 then uses svcBreak.

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -203,8 +203,8 @@ private:
 
 class IStorageAccessor final : public ServiceFramework<IStorageAccessor> {
 public:
-    explicit IStorageAccessor(std::vector<u8> buffer) : ServiceFramework("IStorageAccessor"),
-    buffer(std::move(buffer)) {
+    explicit IStorageAccessor(std::vector<u8> buffer)
+        : ServiceFramework("IStorageAccessor"), buffer(std::move(buffer)) {
         static const FunctionInfo functions[] = {
             {0, &IStorageAccessor::GetSize, "GetSize"},
             {11, &IStorageAccessor::Read, "Read"},
@@ -245,7 +245,8 @@ private:
 
 class IStorage final : public ServiceFramework<IStorage> {
 public:
-    explicit IStorage(std::vector<u8> buffer) : ServiceFramework("IStorage"), buffer(std::move(buffer)) {
+    explicit IStorage(std::vector<u8> buffer)
+        : ServiceFramework("IStorage"), buffer(std::move(buffer)) {
         static const FunctionInfo functions[] = {
             {0, &IStorage::Open, "Open"},
         };
@@ -281,18 +282,18 @@ public:
 
 private:
     void PopLaunchParameter(Kernel::HLERequestContext& ctx) {
-        IPC::RequestBuilder rb{ctx, 2, 0, 0, 1};
-
         constexpr u8 data[0x88] = {
             0xca, 0x97, 0x94, 0xc7, // Magic
-            1, 0, 0, 0, // IsAccountSelected (bool)
-            1, 0, 0, 0, // User Id (word 0)
-            0, 0, 0, 0, // User Id (word 1)
-            0, 0, 0, 0, // User Id (word 2)
-            0, 0, 0, 0  // User Id (word 3)
+            1,    0,    0,    0,    // IsAccountSelected (bool)
+            1,    0,    0,    0,    // User Id (word 0)
+            0,    0,    0,    0,    // User Id (word 1)
+            0,    0,    0,    0,    // User Id (word 2)
+            0,    0,    0,    0     // User Id (word 3)
         };
 
         std::vector<u8> buffer(data, data + sizeof(data));
+
+        IPC::RequestBuilder rb{ctx, 2, 0, 0, 1};
 
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<AM::IStorage>(buffer);


### PR DESCRIPTION
This stubs AM::PopLaunchParameter, needed by Tetris.
This includes the changes in PR #74, since IStorageAccessor::Read needs Buffer C Descriptors. If this gets merged, #74 can be closed, and issue #32 can be marked as resolved aswell.

@bunnei PTAL