### PR TITLE
travis: Use Xcode 9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - os: osx
       env: NAME="macos build"
       sudo: false
-      osx_image: xcode7.3
+      osx_image: xcode9.2
       install: "./.travis/macos/deps.sh"
       script: "./.travis/macos/build.sh"
       after_success: "./.travis/macos/upload.sh"


### PR DESCRIPTION
Uses the latest available Xcode version. This allows the use of more C++17 facilities without the CI failing. 7.3 is also quite out of date, considering 8.3 is the default Xcode version used by travis.