### PR TITLE
 time: Refactor time:* to use a single shared module 

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -130,6 +130,10 @@ add_library(core STATIC
     hle/service/sm/sm.h
     hle/service/time/time.cpp
     hle/service/time/time.h
+    hle/service/time/time_s.cpp
+    hle/service/time/time_s.h
+    hle/service/time/time_u.cpp
+    hle/service/time/time_u.h
     hle/service/vi/vi.cpp
     hle/service/vi/vi.h
     hle/service/vi/vi_m.cpp

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -8,6 +8,8 @@
 #include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/client_session.h"
 #include "core/hle/service/time/time.h"
+#include "core/hle/service/time/time_s.h"
+#include "core/hle/service/time/time_u.h"
 
 namespace Service {
 namespace Time {
@@ -72,7 +74,7 @@ private:
     }
 };
 
-void TIME::GetStandardUserSystemClock(Kernel::HLERequestContext& ctx) {
+void Module::Interface::GetStandardUserSystemClock(Kernel::HLERequestContext& ctx) {
     auto client_port = std::make_shared<ISystemClock>()->CreatePort();
     auto session = client_port->Connect();
     if (session.Succeeded()) {
@@ -86,7 +88,7 @@ void TIME::GetStandardUserSystemClock(Kernel::HLERequestContext& ctx) {
     }
 }
 
-void TIME::GetStandardNetworkSystemClock(Kernel::HLERequestContext& ctx) {
+void Module::Interface::GetStandardNetworkSystemClock(Kernel::HLERequestContext& ctx) {
     auto client_port = std::make_shared<ISystemClock>()->CreatePort();
     auto session = client_port->Connect();
     if (session.Succeeded()) {
@@ -100,7 +102,7 @@ void TIME::GetStandardNetworkSystemClock(Kernel::HLERequestContext& ctx) {
     }
 }
 
-void TIME::GetStandardSteadyClock(Kernel::HLERequestContext& ctx) {
+void Module::Interface::GetStandardSteadyClock(Kernel::HLERequestContext& ctx) {
     auto client_port = std::make_shared<ISteadyClock>()->CreatePort();
     auto session = client_port->Connect();
     if (session.Succeeded()) {
@@ -114,28 +116,20 @@ void TIME::GetStandardSteadyClock(Kernel::HLERequestContext& ctx) {
     }
 }
 
-void TIME::GetTimeZoneService(Kernel::HLERequestContext& ctx) {
+void Module::Interface::GetTimeZoneService(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb{ctx, 2, 0, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<ITimeZoneService>();
     LOG_DEBUG(Service, "called");
 }
 
-TIME::TIME(const char* name) : ServiceFramework(name) {
-    static const FunctionInfo functions[] = {
-        {0x00000000, &TIME::GetStandardUserSystemClock, "GetStandardUserSystemClock"},
-        {0x00000001, &TIME::GetStandardNetworkSystemClock, "GetStandardNetworkSystemClock"},
-        {0x00000002, &TIME::GetStandardSteadyClock, "GetStandardSteadyClock"},
-        {0x00000003, &TIME::GetTimeZoneService, "GetTimeZoneService"},
-    };
-    RegisterHandlers(functions);
-}
+Module::Interface::Interface(std::shared_ptr<Module> time, const char* name)
+    : ServiceFramework(name), time(std::move(time)) {}
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {
-    std::make_shared<TIME>("time:a")->InstallAsService(service_manager);
-    std::make_shared<TIME>("time:r")->InstallAsService(service_manager);
-    std::make_shared<TIME>("time:s")->InstallAsService(service_manager);
-    std::make_shared<TIME>("time:u")->InstallAsService(service_manager);
+    auto time = std::make_shared<Module>();
+    std::make_shared<TIME_S>(time)->InstallAsService(service_manager);
+    std::make_shared<TIME_U>(time)->InstallAsService(service_manager);
 }
 
 } // namespace Time

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -61,16 +61,16 @@ private:
 
     void ToCalendarTimeWithMyRule(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
-        u64 posixTime = rp.Pop<u64>();
+        u64 posix_time = rp.Pop<u64>();
 
-        LOG_WARNING(Service, "(STUBBED) called, posixTime=0x%016llX", posixTime);
+        LOG_WARNING(Service, "(STUBBED) called, posix_time=0x%016llX", posix_time);
 
-        CalendarTime calendarTime{2018, 1, 1, 0, 0, 0};
-        CalendarAdditionalInfo additionalInfo{};
+        CalendarTime calendar_time{2018, 1, 1, 0, 0, 0};
+        CalendarAdditionalInfo additional_info{};
         IPC::RequestBuilder rb{ctx, 10};
         rb.Push(RESULT_SUCCESS);
-        rb.PushRaw(calendarTime);
-        rb.PushRaw(additionalInfo);
+        rb.PushRaw(calendar_time);
+        rb.PushRaw(additional_info);
     }
 };
 

--- a/src/core/hle/service/time/time.h
+++ b/src/core/hle/service/time/time.h
@@ -33,16 +33,20 @@ struct CalendarAdditionalInfo {
 static_assert(sizeof(CalendarAdditionalInfo) == 0x18,
               "CalendarAdditionalInfo structure has incorrect size");
 
-class TIME final : public ServiceFramework<TIME> {
+class Module final {
 public:
-    explicit TIME(const char* name);
-    ~TIME() = default;
+    class Interface : public ServiceFramework<Interface> {
+    public:
+        Interface(std::shared_ptr<Module> time, const char* name);
 
-private:
-    void GetStandardUserSystemClock(Kernel::HLERequestContext& ctx);
-    void GetStandardNetworkSystemClock(Kernel::HLERequestContext& ctx);
-    void GetStandardSteadyClock(Kernel::HLERequestContext& ctx);
-    void GetTimeZoneService(Kernel::HLERequestContext& ctx);
+        void GetStandardUserSystemClock(Kernel::HLERequestContext& ctx);
+        void GetStandardNetworkSystemClock(Kernel::HLERequestContext& ctx);
+        void GetStandardSteadyClock(Kernel::HLERequestContext& ctx);
+        void GetTimeZoneService(Kernel::HLERequestContext& ctx);
+
+    protected:
+        std::shared_ptr<Module> time;
+    };
 };
 
 /// Registers all Time services with the specified service manager.

--- a/src/core/hle/service/time/time_s.cpp
+++ b/src/core/hle/service/time/time_s.cpp
@@ -1,0 +1,20 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/time/time_s.h"
+
+namespace Service {
+namespace Time {
+
+TIME_S::TIME_S(std::shared_ptr<Module> time) : Module::Interface(std::move(time), "time:s") {
+    static const FunctionInfo functions[] = {
+        {0, &TIME_S::GetStandardUserSystemClock, "GetStandardUserSystemClock"},
+    };
+    RegisterHandlers(functions);
+}
+
+} // namespace Time
+} // namespace Service

--- a/src/core/hle/service/time/time_s.h
+++ b/src/core/hle/service/time/time_s.h
@@ -1,0 +1,18 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/time/time.h"
+
+namespace Service {
+namespace Time {
+
+class TIME_S final : public Module::Interface {
+public:
+    explicit TIME_S(std::shared_ptr<Module> time);
+};
+
+} // namespace Time
+} // namespace Service

--- a/src/core/hle/service/time/time_u.cpp
+++ b/src/core/hle/service/time/time_u.cpp
@@ -1,0 +1,23 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/time/time_u.h"
+
+namespace Service {
+namespace Time {
+
+TIME_U::TIME_U(std::shared_ptr<Module> time) : Module::Interface(std::move(time), "time:u") {
+    static const FunctionInfo functions[] = {
+        {0, &TIME_U::GetStandardUserSystemClock, "GetStandardUserSystemClock"},
+        {1, &TIME_U::GetStandardNetworkSystemClock, "GetStandardNetworkSystemClock"},
+        {2, &TIME_U::GetStandardSteadyClock, "GetStandardSteadyClock"},
+        {3, &TIME_U::GetTimeZoneService, "GetTimeZoneService"},
+    };
+    RegisterHandlers(functions);
+}
+
+} // namespace Time
+} // namespace Service

--- a/src/core/hle/service/time/time_u.h
+++ b/src/core/hle/service/time/time_u.h
@@ -1,0 +1,18 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/time/time.h"
+
+namespace Service {
+namespace Time {
+
+class TIME_U final : public Module::Interface {
+public:
+    explicit TIME_U(std::shared_ptr<Module> time);
+};
+
+} // namespace Time
+} // namespace Service


### PR DESCRIPTION
This changes each time:* port to use a common module, with an interface exposing only the commands the port allows. I based it off of how I saw the AC service implemented in Citra.

Also, I included a minor fix for a use of CamelCase in my previous PR.