### PR TITLE
Port citra #3336

### DIFF
--- a/src/yuzu/configuration/configure.ui
+++ b/src/yuzu/configuration/configure.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>740</width>
+    <width>461</width>
     <height>500</height>
    </rect>
   </property>


### PR DESCRIPTION
- Resizes the configuration window to not be so stretched out

This was referenced in Issue: https://github.com/yuzu-emu/yuzu/issues/40