### PR TITLE
Fix svcGetInfo for libnx

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -314,7 +314,7 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
         *result = g_current_process->allowed_thread_priority_mask;
         break;
     case GetInfoType::MapRegionBaseAddr:
-        *result = vm_manager.GetAddressSpaceBaseAddr();
+        *result = vm_manager.GetMapRegionBaseAddr();
         break;
     case GetInfoType::MapRegionSize:
         *result = vm_manager.GetAddressSpaceSize();

--- a/src/core/hle/kernel/svc.h
+++ b/src/core/hle/kernel/svc.h
@@ -14,7 +14,11 @@ struct MemoryInfo {
     u32 type;
     u32 attributes;
     u32 permission;
+    u32 device_refcount;
+    u32 ipc_refcount;
+    INSERT_PADDING_WORDS(1);
 };
+static_assert(sizeof(MemoryInfo) == 0x28, "MemoryInfo has incorrect size.");
 
 struct PageInfo {
     u64 flags;

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -375,6 +375,11 @@ u64 VMManager::GetAddressSpaceSize() {
     return MAX_ADDRESS;
 }
 
+VAddr VMManager::GetMapRegionBaseAddr() {
+    LOG_WARNING(Kernel, "(STUBBED) called");
+    return Memory::HEAP_VADDR;
+}
+
 VAddr VMManager::GetNewMapRegionBaseAddr() {
     LOG_WARNING(Kernel, "(STUBBED) called");
     return 0x8000000;

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -192,6 +192,9 @@ public:
     /// Gets the total address space address size, used by svcGetInfo
     u64 GetAddressSpaceSize();
 
+    /// Gets the map region base address, used by svcGetInfo
+    VAddr GetMapRegionBaseAddr();
+
     /// Gets the base address for a new memory region, used by svcGetInfo
     VAddr GetNewMapRegionBaseAddr();
 

--- a/src/core/hle/service/nvdrv/interface.cpp
+++ b/src/core/hle/service/nvdrv/interface.cpp
@@ -67,6 +67,17 @@ void NVDRV::Initialize(Kernel::HLERequestContext& ctx) {
     rb.Push<u32>(0);
 }
 
+void NVDRV::SetClientPID(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    u64 pid = rp.Pop<u64>();
+    u64 unk = rp.Pop<u64>();
+
+    LOG_WARNING(Service, "(STUBBED) called, pid=0x%llx, unk=0x%llx", pid, unk);
+
+    IPC::RequestBuilder rb{ctx, 2};
+    rb.Push(RESULT_SUCCESS);
+}
+
 NVDRV::NVDRV(std::shared_ptr<Module> nvdrv, const char* name)
     : ServiceFramework(name), nvdrv(std::move(nvdrv)) {
     static const FunctionInfo functions[] = {
@@ -74,6 +85,7 @@ NVDRV::NVDRV(std::shared_ptr<Module> nvdrv, const char* name)
         {1, &NVDRV::Ioctl, "Ioctl"},
         {2, &NVDRV::Close, "Close"},
         {3, &NVDRV::Initialize, "Initialize"},
+        {8, &NVDRV::SetClientPID, "SetClientPID"},
     };
     RegisterHandlers(functions);
 }

--- a/src/core/hle/service/nvdrv/interface.h
+++ b/src/core/hle/service/nvdrv/interface.h
@@ -22,6 +22,7 @@ private:
     void Ioctl(Kernel::HLERequestContext& ctx);
     void Close(Kernel::HLERequestContext& ctx);
     void Initialize(Kernel::HLERequestContext& ctx);
+    void SetClientPID(Kernel::HLERequestContext& ctx);
 
     std::shared_ptr<Module> nvdrv;
 };


### PR DESCRIPTION
Fixes svcGetInfo and some other minor changes to unblock libnx homebrew. With this change, libnx apps still do not run, but they get to nvdrv code (IHOSBinderDriver::TransactParcelAuto for f/w 3.0.0, /dev/nvhost-ctrl-gpu stuff if we guise as a lower f/w).