### PR TITLE
Added CreateSharedMemory & UNIMPLEMENTED() for non existent services.

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -737,12 +737,13 @@ static ResultCode SetThreadCoreMask(u64, u64, u64) {
     return RESULT_SUCCESS;
 }
 
-static ResultCode CreateSharedMemory(Handle* handle, u64 sz, u32 localPerm, u32 remotePerm) {
-    LOG_TRACE(Kernel_SVC, "called, sz=0x%llx, localPerms=0x%08x, remotePerms=0x%08x", sz, localPerm,
-              remotePerm);
+static ResultCode CreateSharedMemory(Handle* handle, u64 sz, u32 local_permissions,
+                                     u32 remote_permissions) {
+    LOG_TRACE(Kernel_SVC, "called, sz=0x%llx, localPerms=0x%08x, remotePerms=0x%08x", sz,
+              local_permissions, remote_permissions);
     auto sharedMemHandle = SharedMemory::Create(
         g_handle_table.Get<Process>(KernelHandle::CurrentProcess), sz,
-        (Kernel::MemoryPermission)localPerm, (Kernel::MemoryPermission)remotePerm);
+        (Kernel::MemoryPermission)local_permissions, (Kernel::MemoryPermission)remote_permissions);
 
     CASCADE_RESULT(*handle, g_handle_table.Create(sharedMemHandle));
     return RESULT_SUCCESS;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -255,9 +255,8 @@ static ResultCode CancelSynchronization(Handle thread_handle) {
 /// Attempts to locks a mutex, creating it if it does not already exist
 static ResultCode ArbitrateLock(Handle holding_thread_handle, VAddr mutex_addr,
                                 Handle requesting_thread_handle) {
-    LOG_TRACE(Kernel_SVC,
-              "called holding_thread_handle=0x%08X, mutex_addr=0x%llx, "
-              "requesting_current_thread_handle=0x%08X",
+    LOG_TRACE(Kernel_SVC, "called holding_thread_handle=0x%08X, mutex_addr=0x%llx, "
+                          "requesting_current_thread_handle=0x%08X",
               holding_thread_handle, mutex_addr, requesting_thread_handle);
 
     SharedPtr<Thread> holding_thread = g_handle_table.Get<Thread>(holding_thread_handle);
@@ -547,9 +546,8 @@ static ResultCode CreateThread(Handle* out_handle, VAddr entry_point, u64 arg, V
 
     Core::System::GetInstance().PrepareReschedule();
 
-    LOG_TRACE(Kernel_SVC,
-              "called entrypoint=0x%08X (%s), arg=0x%08X, stacktop=0x%08X, "
-              "threadpriority=0x%08X, processorid=0x%08X : created handle=0x%08X",
+    LOG_TRACE(Kernel_SVC, "called entrypoint=0x%08X (%s), arg=0x%08X, stacktop=0x%08X, "
+                          "threadpriority=0x%08X, processorid=0x%08X : created handle=0x%08X",
               entry_point, name.c_str(), arg, stack_top, priority, processor_id, *out_handle);
 
     return RESULT_SUCCESS;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -737,7 +737,7 @@ static ResultCode SetThreadCoreMask(u64, u64, u64) {
     return RESULT_SUCCESS;
 }
 
-static ResultCode CreateSharedMemory(Handle* handle, u64 sz, u64 localPerm, u64 remotePerm) {
+static ResultCode CreateSharedMemory(Handle* handle, u64 sz, u32 localPerm, u32 remotePerm) {
     LOG_TRACE(Kernel_SVC, "called, sz=0x%llx, localPerms=0x%08x, remotePerms=0x%08x", sz, localPerm,
               remotePerm);
     auto sharedMemHandle = SharedMemory::Create(

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -255,8 +255,9 @@ static ResultCode CancelSynchronization(Handle thread_handle) {
 /// Attempts to locks a mutex, creating it if it does not already exist
 static ResultCode ArbitrateLock(Handle holding_thread_handle, VAddr mutex_addr,
                                 Handle requesting_thread_handle) {
-    LOG_TRACE(Kernel_SVC, "called holding_thread_handle=0x%08X, mutex_addr=0x%llx, "
-                          "requesting_current_thread_handle=0x%08X",
+    LOG_TRACE(Kernel_SVC,
+              "called holding_thread_handle=0x%08X, mutex_addr=0x%llx, "
+              "requesting_current_thread_handle=0x%08X",
               holding_thread_handle, mutex_addr, requesting_thread_handle);
 
     SharedPtr<Thread> holding_thread = g_handle_table.Get<Thread>(holding_thread_handle);
@@ -546,8 +547,9 @@ static ResultCode CreateThread(Handle* out_handle, VAddr entry_point, u64 arg, V
 
     Core::System::GetInstance().PrepareReschedule();
 
-    LOG_TRACE(Kernel_SVC, "called entrypoint=0x%08X (%s), arg=0x%08X, stacktop=0x%08X, "
-                          "threadpriority=0x%08X, processorid=0x%08X : created handle=0x%08X",
+    LOG_TRACE(Kernel_SVC,
+              "called entrypoint=0x%08X (%s), arg=0x%08X, stacktop=0x%08X, "
+              "threadpriority=0x%08X, processorid=0x%08X : created handle=0x%08X",
               entry_point, name.c_str(), arg, stack_top, priority, processor_id, *out_handle);
 
     return RESULT_SUCCESS;
@@ -737,6 +739,17 @@ static ResultCode SetThreadCoreMask(u64, u64, u64) {
     return RESULT_SUCCESS;
 }
 
+static ResultCode CreateSharedMemory(Handle* handle, u64 sz, u64 localPerm, u64 remotePerm) {
+    LOG_TRACE(Kernel_SVC, "called, sz=0x%llx, localPerms=0x%08x, remotePerms=0x%08x", sz, localPerm,
+              remotePerm);
+    auto sharedMemHandle = SharedMemory::Create(
+        g_handle_table.Get<Process>(KernelHandle::CurrentProcess), sz,
+        (Kernel::MemoryPermission)localPerm, (Kernel::MemoryPermission)remotePerm);
+
+    CASCADE_RESULT(*handle, g_handle_table.Create(sharedMemHandle));
+    return RESULT_SUCCESS;
+}
+
 namespace {
 struct FunctionDef {
     using Func = void();
@@ -828,7 +841,7 @@ static const FunctionDef SVC_Table[] = {
     {0x4D, nullptr, "SleepSystem"},
     {0x4E, nullptr, "ReadWriteRegister"},
     {0x4F, nullptr, "SetProcessActivity"},
-    {0x50, nullptr, "CreateSharedMemory"},
+    {0x50, SvcWrap<CreateSharedMemory>, "CreateSharedMemory"},
     {0x51, nullptr, "MapTransferMemory"},
     {0x52, nullptr, "UnmapTransferMemory"},
     {0x53, nullptr, "CreateInterruptEvent"},

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -145,6 +145,14 @@ void SvcWrap() {
     FuncReturn(retval);
 }
 
+template <ResultCode func(Handle*, u64, u64, u64)>
+void SvcWrap() {
+	u32 param_1 = 0;
+	u32 retval = func(&param_1, PARAM(1), PARAM(2), PARAM(3)).raw;
+	Core::CPU().SetReg(1, param_1);
+	FuncReturn(retval);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Function wrappers that return type u32
 

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -145,12 +145,13 @@ void SvcWrap() {
     FuncReturn(retval);
 }
 
-template <ResultCode func(Handle*, u64, u64, u64)>
+template <ResultCode func(Handle*, u64, u32, u32)>
 void SvcWrap() {
-	u32 param_1 = 0;
-	u32 retval = func(&param_1, PARAM(1), PARAM(2), PARAM(3)).raw;
-	Core::CPU().SetReg(1, param_1);
-	FuncReturn(retval);
+    u32 param_1 = 0;
+    u32 retval =
+        func(&param_1, PARAM(1), (u32)(PARAM(2) & 0xFFFFFFFF), (u32)(PARAM(3) & 0xFFFFFFFF)).raw;
+    Core::CPU().SetReg(1, param_1);
+    FuncReturn(retval);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -103,6 +103,7 @@ void SM::GetService(Kernel::HLERequestContext& ctx) {
         rb.Push(client_port.Code());
         LOG_ERROR(Service_SM, "called service=%s -> error 0x%08X", name.c_str(),
                   client_port.Code().raw);
+        UNIMPLEMENTED();
         return;
     }
 


### PR DESCRIPTION
CreateSharedMemory is needed mainly for nvmemp which is the nv memory profiler. Reason for UNIMPLEMENTED() added for services which don't exist is because binaries don't always fail if it tries to get a service and can cause problems down the line when trying to trace why something is preventing the binary from working.