### PR TITLE
Added nvmemp, Added /dev/nvhost-ctrl, SetClientPID now stores pid

### DIFF
--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -55,6 +55,7 @@ enum class Class : ClassType {
     Service_CFG,       ///< The CFG (Configuration) service
     Service_DSP,       ///< The DSP (DSP control) service
     Service_HID,       ///< The HID (Human interface device) service
+    Service_NVDRV,     ///< The NVDRV (Nvidia driver) service
     HW,                ///< Low-level hardware emulation
     HW_Memory,         ///< Memory-map and address translation
     HW_LCD,            ///< LCD register emulation

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -112,12 +112,16 @@ add_library(core STATIC
     hle/service/nvdrv/devices/nvdisp_disp0.h
     hle/service/nvdrv/devices/nvhost_as_gpu.cpp
     hle/service/nvdrv/devices/nvhost_as_gpu.h
+    hle/service/nvdrv/devices/nvhost_ctrl.cpp
+    hle/service/nvdrv/devices/nvhost_ctrl.h
     hle/service/nvdrv/devices/nvmap.cpp
     hle/service/nvdrv/devices/nvmap.h
     hle/service/nvdrv/interface.cpp
     hle/service/nvdrv/interface.h
     hle/service/nvdrv/nvdrv.cpp
     hle/service/nvdrv/nvdrv.h
+    hle/service/nvdrv/nvmemp.cpp
+    hle/service/nvdrv/nvmemp.h
     hle/service/pctl/pctl.cpp
     hle/service/pctl/pctl.h
     hle/service/pctl/pctl_a.cpp

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -1,0 +1,44 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/assert.h"
+#include "common/logging/log.h"
+#include "core/hle/service/nvdrv/devices/nvhost_ctrl.h"
+
+namespace Service {
+namespace Nvidia {
+namespace Devices {
+
+u32 nvhost_ctrl::ioctl(u32 command, const std::vector<u8>& input, std::vector<u8>& output) {
+    LOG_WARNING(Debug_GPU, "Got Ioctl 0x%x, inputsz: 0x%x, outputsz: 0x%x", command, input.size(),
+                output.size());
+
+    switch (command) {
+    case IocGetConfigCommand:
+        return NvOsGetConfigU32(input, output);
+    }
+    UNIMPLEMENTED();
+    return 0;
+}
+
+u32 nvhost_ctrl::NvOsGetConfigU32(const std::vector<u8>& input, std::vector<u8>& output) {
+    LOG_WARNING(Service, "(STUBBED) lets do it");
+    IocGetConfigParams params;
+    std::memcpy(&params, input.data(), sizeof(params));
+    LOG_WARNING(Service, "(STUBBED) param_str %s", params.param_str);
+    LOG_WARNING(Service, "(STUBBED) domain_str %s", params.domain_str);
+
+    if (!strcmp(params.param_str, "NV_MEMORY_PROFILER")) {
+        std::memcpy(&params.config_str, "1\x00", 2);
+    } else {
+        UNIMPLEMENTED();
+    }
+    std::memcpy(output.data(), &params, sizeof(params));
+    LOG_WARNING(Service, "(STUBBED) memcpy");
+    return 0;
+}
+
+} // namespace Devices
+} // namespace Nvidia
+} // namespace Service

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -30,7 +30,7 @@ u32 nvhost_ctrl::NvOsGetConfigU32(const std::vector<u8>& input, std::vector<u8>&
 
     if (!strcmp(params.domain_str.data(), "nv")) {
         if (!strcmp(params.param_str.data(), "NV_MEMORY_PROFILER")) {
-            std::memcpy(params.config_str.data(), "1", 1);
+            params.config_str[0] = '1';
         } else {
             UNIMPLEMENTED();
         }

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -25,11 +25,12 @@ u32 nvhost_ctrl::ioctl(u32 command, const std::vector<u8>& input, std::vector<u8
 u32 nvhost_ctrl::NvOsGetConfigU32(const std::vector<u8>& input, std::vector<u8>& output) {
     IocGetConfigParams params;
     std::memcpy(&params, input.data(), sizeof(params));
-    LOG_DEBUG(Service_NVDRV, "called, setting=%s!%s", params.domain_str, params.param_str);
+    LOG_DEBUG(Service_NVDRV, "called, setting=%s!%s", params.domain_str.data(),
+              params.param_str.data());
 
-    if (!strcmp(params.domain_str, "nv")) {
-        if (!strcmp(params.param_str, "NV_MEMORY_PROFILER")) {
-            std::memcpy(&params.config_str, "1\x00", 2);
+    if (!strcmp(params.domain_str.data(), "nv")) {
+        if (!strcmp(params.param_str.data(), "NV_MEMORY_PROFILER")) {
+            std::memcpy(params.config_str.data(), "1", 1);
         } else {
             UNIMPLEMENTED();
         }

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -11,8 +11,8 @@ namespace Nvidia {
 namespace Devices {
 
 u32 nvhost_ctrl::ioctl(u32 command, const std::vector<u8>& input, std::vector<u8>& output) {
-    LOG_WARNING(Debug_GPU, "Got Ioctl 0x%x, inputsz: 0x%x, outputsz: 0x%x", command, input.size(),
-                output.size());
+    LOG_DEBUG(Service_NVDRV, "called, command=0x%08x, input_size=0x%lx, output_size=0x%lx", command,
+              input.size(), output.size());
 
     switch (command) {
     case IocGetConfigCommand:
@@ -23,19 +23,20 @@ u32 nvhost_ctrl::ioctl(u32 command, const std::vector<u8>& input, std::vector<u8
 }
 
 u32 nvhost_ctrl::NvOsGetConfigU32(const std::vector<u8>& input, std::vector<u8>& output) {
-    LOG_WARNING(Service, "(STUBBED) lets do it");
     IocGetConfigParams params;
     std::memcpy(&params, input.data(), sizeof(params));
-    LOG_WARNING(Service, "(STUBBED) param_str %s", params.param_str);
-    LOG_WARNING(Service, "(STUBBED) domain_str %s", params.domain_str);
+    LOG_DEBUG(Service_NVDRV, "called, setting=%s!%s", params.domain_str, params.param_str);
 
-    if (!strcmp(params.param_str, "NV_MEMORY_PROFILER")) {
-        std::memcpy(&params.config_str, "1\x00", 2);
+    if (!strcmp(params.domain_str, "nv")) {
+        if (!strcmp(params.param_str, "NV_MEMORY_PROFILER")) {
+            std::memcpy(&params.config_str, "1\x00", 2);
+        } else {
+            UNIMPLEMENTED();
+        }
     } else {
         UNIMPLEMENTED();
     }
     std::memcpy(output.data(), &params, sizeof(params));
-    LOG_WARNING(Service, "(STUBBED) memcpy");
     return 0;
 }
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
@@ -4,11 +4,12 @@
 
 #pragma once
 
+#include <array>
+#include <cstdlib>
+#include <cstring>
 #include <vector>
 #include "common/common_types.h"
 #include "core/hle/service/nvdrv/devices/nvdevice.h"
-#include <cstring>
-#include <cstdlib>
 
 namespace Service {
 namespace Nvidia {
@@ -33,7 +34,6 @@ private:
         IocGetConfigCommand = 0xC183001B,
     };
 
-private:
     struct IocGetConfigParams {
         std::array<char, 0x41> domain_str;
         std::array<char, 0x41> param_str;

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
@@ -33,9 +33,9 @@ private:
 
 private:
     struct IocGetConfigParams {
-        std::array<u8, 0x41> domain_str;
-        std::array<u8, 0x41> param_str;
-        std::array<u8, 0x101> config_str;
+        std::array<char, 0x41> domain_str;
+        std::array<char, 0x41> param_str;
+        std::array<char, 0x101> config_str;
     };
 
     u32 NvOsGetConfigU32(const std::vector<u8>& input, std::vector<u8>& output);

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
@@ -7,6 +7,8 @@
 #include <vector>
 #include "common/common_types.h"
 #include "core/hle/service/nvdrv/devices/nvdevice.h"
+#include <cstring>
+#include <cstdlib>
 
 namespace Service {
 namespace Nvidia {

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
@@ -33,9 +33,9 @@ private:
 
 private:
     struct IocGetConfigParams {
-        char domain_str[0x41];
-        char param_str[0x41];
-        char config_str[0x101];
+        std::array<u8, 0x41> domain_str;
+        std::array<u8, 0x41> param_str;
+        std::array<u8, 0x101> config_str;
     };
 
     u32 NvOsGetConfigU32(const std::vector<u8>& input, std::vector<u8>& output);

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
@@ -1,0 +1,46 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <vector>
+#include "common/common_types.h"
+#include "core/hle/service/nvdrv/devices/nvdevice.h"
+
+namespace Service {
+namespace Nvidia {
+namespace Devices {
+
+class nvhost_ctrl final : public nvdevice {
+public:
+    nvhost_ctrl() = default;
+    ~nvhost_ctrl() override = default;
+
+    u32 ioctl(u32 command, const std::vector<u8>& input, std::vector<u8>& output) override;
+
+private:
+    enum IoctlCommands {
+        IocSyncptReadCommand = 0xC0080014,
+        IocSyncptIncrCommand = 0x40040015,
+        IocSyncptWaitCommand = 0xC00C0016,
+        IocModuleMutexCommand = 0x40080017,
+        IocModuleRegRDWRCommand = 0xC008010E,
+        IocSyncptWaitexCommand = 0xC0100019,
+        IocSyncptReadMaxCommand = 0xC008001A,
+        IocGetConfigCommand = 0xC183001B,
+    };
+
+private:
+    struct IocGetConfigParams {
+        char domain_str[0x41];
+        char param_str[0x41];
+        char config_str[0x101];
+    };
+
+    u32 NvOsGetConfigU32(const std::vector<u8>& input, std::vector<u8>& output);
+};
+
+} // namespace Devices
+} // namespace Nvidia
+} // namespace Service

--- a/src/core/hle/service/nvdrv/interface.cpp
+++ b/src/core/hle/service/nvdrv/interface.cpp
@@ -69,7 +69,7 @@ void NVDRV::Initialize(Kernel::HLERequestContext& ctx) {
 
 void NVDRV::SetClientPID(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
-    PID = rp.Pop<u64>();
+    pid = rp.Pop<u64>();
 
     LOG_WARNING(Service, "(STUBBED) called");
     IPC::RequestBuilder rb{ctx, 3};

--- a/src/core/hle/service/nvdrv/interface.cpp
+++ b/src/core/hle/service/nvdrv/interface.cpp
@@ -69,13 +69,12 @@ void NVDRV::Initialize(Kernel::HLERequestContext& ctx) {
 
 void NVDRV::SetClientPID(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
-    u64 pid = rp.Pop<u64>();
-    u64 unk = rp.Pop<u64>();
+    PID = rp.Pop<u64>();
 
-    LOG_WARNING(Service, "(STUBBED) called, pid=0x%llx, unk=0x%llx", pid, unk);
-
-    IPC::RequestBuilder rb{ctx, 2};
+    LOG_WARNING(Service, "(STUBBED) called");
+    IPC::RequestBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
+    rb.Push<u32>(0);
 }
 
 NVDRV::NVDRV(std::shared_ptr<Module> nvdrv, const char* name)

--- a/src/core/hle/service/nvdrv/interface.cpp
+++ b/src/core/hle/service/nvdrv/interface.cpp
@@ -71,7 +71,7 @@ void NVDRV::SetClientPID(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     pid = rp.Pop<u64>();
 
-    LOG_WARNING(Service, "(STUBBED) called");
+    LOG_INFO(Service, "called, pid=0x%lx", pid);
     IPC::RequestBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.Push<u32>(0);

--- a/src/core/hle/service/nvdrv/interface.h
+++ b/src/core/hle/service/nvdrv/interface.h
@@ -25,6 +25,8 @@ private:
     void SetClientPID(Kernel::HLERequestContext& ctx);
 
     std::shared_ptr<Module> nvdrv;
+
+    u64 PID;
 };
 
 } // namespace Nvidia

--- a/src/core/hle/service/nvdrv/interface.h
+++ b/src/core/hle/service/nvdrv/interface.h
@@ -26,7 +26,7 @@ private:
 
     std::shared_ptr<Module> nvdrv;
 
-    u64 PID;
+    u64 pid{};
 };
 
 } // namespace Nvidia

--- a/src/core/hle/service/nvdrv/nvdrv.cpp
+++ b/src/core/hle/service/nvdrv/nvdrv.cpp
@@ -6,9 +6,11 @@
 #include "core/hle/service/nvdrv/devices/nvdevice.h"
 #include "core/hle/service/nvdrv/devices/nvdisp_disp0.h"
 #include "core/hle/service/nvdrv/devices/nvhost_as_gpu.h"
+#include "core/hle/service/nvdrv/devices/nvhost_ctrl.h"
 #include "core/hle/service/nvdrv/devices/nvmap.h"
-#include "core/hle/service/nvdrv/nvdrv.h"
 #include "core/hle/service/nvdrv/interface.h"
+#include "core/hle/service/nvdrv/nvdrv.h"
+#include "core/hle/service/nvdrv/nvmemp.h"
 
 namespace Service {
 namespace Nvidia {
@@ -19,6 +21,7 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     auto module_ = std::make_shared<Module>();
     std::make_shared<NVDRV>(module_, "nvdrv")->InstallAsService(service_manager);
     std::make_shared<NVDRV>(module_, "nvdrv:a")->InstallAsService(service_manager);
+    std::make_shared<NVMEMP>()->InstallAsService(service_manager);
     nvdrv = module_;
 }
 
@@ -27,6 +30,7 @@ Module::Module() {
     devices["/dev/nvhost-as-gpu"] = std::make_shared<Devices::nvhost_as_gpu>();
     devices["/dev/nvmap"] = nvmap_dev;
     devices["/dev/nvdisp_disp0"] = std::make_shared<Devices::nvdisp_disp0>(nvmap_dev);
+    devices["/dev/nvhost-ctrl"] = std::make_shared<Devices::nvhost_ctrl>();
 }
 
 u32 Module::Open(std::string device_name) {

--- a/src/core/hle/service/nvdrv/nvmemp.cpp
+++ b/src/core/hle/service/nvdrv/nvmemp.cpp
@@ -1,0 +1,22 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/logging/log.h"
+#include "core/hle/ipc_helpers.h"
+#include "core/hle/service/nvdrv/nvdrv.h"
+#include "core/hle/service/nvdrv/nvmemp.h"
+
+namespace Service {
+namespace Nvidia {
+
+NVMEMP::NVMEMP() : ServiceFramework("nvmemp") {
+    static const FunctionInfo functions[] = {
+        {0, &NVMEMP::Unknown0, "Unknown0"},
+        {1, &NVMEMP::Unknown1, "Unknown1"},
+    };
+    RegisterHandlers(functions);
+}
+
+} // namespace Nvidia
+} // namespace Service

--- a/src/core/hle/service/nvdrv/nvmemp.cpp
+++ b/src/core/hle/service/nvdrv/nvmemp.cpp
@@ -13,7 +13,8 @@ namespace Nvidia {
 
 NVMEMP::NVMEMP() : ServiceFramework("nvmemp") {
     static const FunctionInfo functions[] = {
-        {0, &NVMEMP::Unknown0, "Unknown0"}, {1, &NVMEMP::Unknown1, "Unknown1"},
+        {0, &NVMEMP::Unknown0, "Unknown0"},
+        {1, &NVMEMP::Unknown1, "Unknown1"},
     };
     RegisterHandlers(functions);
 }

--- a/src/core/hle/service/nvdrv/nvmemp.cpp
+++ b/src/core/hle/service/nvdrv/nvmemp.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/assert.h"
 #include "common/logging/log.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/nvdrv/nvdrv.h"
@@ -15,6 +16,14 @@ NVMEMP::NVMEMP() : ServiceFramework("nvmemp") {
         {0, &NVMEMP::Unknown0, "Unknown0"}, {1, &NVMEMP::Unknown1, "Unknown1"},
     };
     RegisterHandlers(functions);
+}
+
+void NVMEMP::Unknown0(Kernel::HLERequestContext& ctx) {
+    UNIMPLEMENTED();
+}
+
+void NVMEMP::Unknown1(Kernel::HLERequestContext& ctx) {
+    UNIMPLEMENTED();
 }
 
 } // namespace Nvidia

--- a/src/core/hle/service/nvdrv/nvmemp.cpp
+++ b/src/core/hle/service/nvdrv/nvmemp.cpp
@@ -12,8 +12,7 @@ namespace Nvidia {
 
 NVMEMP::NVMEMP() : ServiceFramework("nvmemp") {
     static const FunctionInfo functions[] = {
-        {0, &NVMEMP::Unknown0, "Unknown0"},
-        {1, &NVMEMP::Unknown1, "Unknown1"},
+        {0, &NVMEMP::Unknown0, "Unknown0"}, {1, &NVMEMP::Unknown1, "Unknown1"},
     };
     RegisterHandlers(functions);
 }

--- a/src/core/hle/service/nvdrv/nvmemp.h
+++ b/src/core/hle/service/nvdrv/nvmemp.h
@@ -15,13 +15,8 @@ public:
     ~NVMEMP() = default;
 
 private:
-    void Unknown0(Kernel::HLERequestContext& ctx) {
-        UNIMPLEMENTED();
-    }
-
-    void Unknown1(Kernel::HLERequestContext& ctx) {
-        UNIMPLEMENTED();
-    }
+    void Unknown0(Kernel::HLERequestContext& ctx);
+    void Unknown1(Kernel::HLERequestContext& ctx);
 };
 
 } // namespace Nvidia

--- a/src/core/hle/service/nvdrv/nvmemp.h
+++ b/src/core/hle/service/nvdrv/nvmemp.h
@@ -1,0 +1,28 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace Nvidia {
+
+class NVMEMP final : public ServiceFramework<NVMEMP> {
+public:
+    NVMEMP();
+    ~NVMEMP() = default;
+
+private:
+    void Unknown0(Kernel::HLERequestContext& ctx) {
+        UNIMPLEMENTED();
+    }
+
+    void Unknown1(Kernel::HLERequestContext& ctx) {
+        UNIMPLEMENTED();
+    }
+};
+
+} // namespace Nvidia
+} // namespace Service


### PR DESCRIPTION
nvmemp is the memory profilers, could provide some insight into the binaries we're running. Currently, there's no known information on them as they don't exist on retail console however it looks like data and a copy handle are sent. There's two ipc cmds which are Cmd#0, Cmd#1. Will do more research on them. Currently they just throw UNIMPLEMENTED(). The profiler can be disabled by setting nv!NV_MEMORY_PROFILER to 0 in NvOsGetConfigU32.

Added /dev/nvhost-ctrl new device. Currently, it only has the "NVHOST_IOCTL_CTRL_GET_CONFIG" ioctl implemented(NvOsGetConfigU32 as refered to in various games symbols). Currently only nv!NV_MEMORY_PROFILER is implemented. Any unknown settings will throw UNIMPLEMENTED(). 

SetClientPID now stores the PID it's given just in case if it's needed later on.