### PR TITLE
travis: Update to clang-format 6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
       addons:
         apt:
           packages:
-            - clang-format-3.9
+            - clang-format-6.0
       script: "./.travis/clang-format/script.sh"
     - os: linux
       env: NAME="linux build"


### PR DESCRIPTION
Clang format has been causing lots of annoyance lately, as newer versions format things slightly differently than 3.9. This is the latest version that ships with Visual Studio extensions installer. If it works fine, I'll push an update auto-formatting everything.