### PR TITLE
Clang format as a build target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ matrix:
       dist: trusty
       addons:
         apt:
+          sources:
+            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main'
+              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
           packages:
-            - clang-format-3.9
+            - clang-format-6.0
       script: "./.travis/clang-format/script.sh"
     - os: linux
       env: NAME="linux build"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ matrix:
           sources:
             - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main'
               key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
+            - sourceline: 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main'
           packages:
             - clang-format-6.0
       script: "./.travis/clang-format/script.sh"

--- a/.travis/clang-format/script.sh
+++ b/.travis/clang-format/script.sh
@@ -7,7 +7,7 @@ if grep -nr '\s$' src *.yml *.txt *.md Doxyfile .gitignore .gitmodules .travis* 
 fi
 
 # Default clang-format points to default 3.5 version one
-CLANG_FORMAT=clang-format-3.9
+CLANG_FORMAT=clang-format-6.0
 $CLANG_FORMAT --version
 
 if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,53 @@ if (UNIX OR MINGW)
     endif()
 endif()
 
+# Setup a custom clang-format target (if clang-format can be found) that will run
+# against all the src files. This should be used before making a pull request.
+# =======================================================================
+
+set(CLANG_FORMAT_POSTFIX "-6.0")
+find_program(CLANG_FORMAT
+    NAMES clang-format${CLANG_FORMAT_POSTFIX}
+          clang-format
+    PATHS ${CMAKE_BINARY_DIR}/externals)
+# if find_program doesn't find it, try to download from externals
+if (NOT CLANG_FORMAT)
+    if (WIN32)
+        message(STATUS "Clang format not found! Downloading...")
+        set(CLANG_FORMAT "${CMAKE_BINARY_DIR}/externals/clang-format${CLANG_FORMAT_POSTFIX}.exe")
+        file(DOWNLOAD
+            https://github.com/yuzu-emu/ext-windows-bin/raw/master/clang-format${CLANG_FORMAT_POSTFIX}.exe
+            "${CLANG_FORMAT}" SHOW_PROGRESS
+            STATUS DOWNLOAD_SUCCESS)
+        if (NOT DOWNLOAD_SUCCESS EQUAL 0)
+            message(WARNING "Could not download clang format! Disabling the clang format target")
+            file(REMOVE ${CLANG_FORMAT})
+            unset(CLANG_FORMAT)
+        endif()
+    else()
+        message(WARNING "Clang format not found! Disabling the clang format target")
+    endif()
+endif()
+
+if (CLANG_FORMAT)
+    set(SRCS ${CMAKE_SOURCE_DIR}/src)
+    set(CCOMMENT "Running clang format against all the .h and .cpp files in src/")
+    if (WIN32)
+        add_custom_target(clang-format
+            COMMAND powershell.exe -Command "${CLANG_FORMAT} -i @(Get-ChildItem -Recurse ${SRCS}/* -Include \'*.h\', \'*.cpp\')"
+            COMMENT ${CCOMMENT})
+    elseif(MINGW)
+        add_custom_target(clang-format
+            COMMAND find `cygpath -u ${SRCS}` -iname *.h -o -iname *.cpp | xargs `cygpath -u ${CLANG_FORMAT}` -i
+            COMMENT ${CCOMMENT})
+    else()
+        add_custom_target(clang-format
+            COMMAND find ${SRCS} -iname *.h -o -iname *.cpp | xargs ${CLANG_FORMAT} -i
+            COMMENT ${CCOMMENT})
+    endif()
+    unset(SRCS)
+    unset(CCOMMENT)
+endif()
 
 # Include source code
 # ===================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,14 +3,17 @@ cmake_minimum_required(VERSION 3.6)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/externals/cmake-modules")
 include(DownloadExternals)
+include(CMakeDependentOption)
 
 project(yuzu)
 
+# Set bundled sdl2/qt as dependent options.
+# OFF by default, but if ENABLE_SDL2 and MSVC are true then ON
 option(ENABLE_SDL2 "Enable the SDL2 frontend" ON)
-option(YUZU_USE_BUNDLED_SDL2 "Download bundled SDL2 binaries" OFF)
+CMAKE_DEPENDENT_OPTION(YUZU_USE_BUNDLED_SDL2 "Download bundled SDL2 binaries" ON "ENABLE_SDL2;MSVC" OFF)
 
 option(ENABLE_QT "Enable the Qt frontend" ON)
-option(YUZU_USE_BUNDLED_QT "Download bundled Qt binaries" OFF)
+CMAKE_DEPENDENT_OPTION(YUZU_USE_BUNDLED_QT "Download bundled Qt binaries" ON "ENABLE_SDL2;MSVC" OFF)
 
 if(NOT EXISTS ${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit)
     message(STATUS "Copying pre-commit hook")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,16 @@
 If you believe you have a valid issue report, please post text or a screenshot from the log (the console window that opens alongside yuzu) and build version (hex string visible in the titlebar and zip filename), as well as your hardware and software information if applicable.
 
 # Contributing
-yuzu is a brand new project, so we have a great opportunity to keep things clean and well organized early on. As such, coding style is very important when making commits. We run clang-format on our CI to check the code. Please use it to format your code when contributing. However, it doesn't cover all the rules below. Some of them aren't very strict rules since we want to be flexible and we understand that under certain circumstances some of them can be counterproductive. Just try to follow as many of them as possible:
+yuzu is a brand new project, so we have a great opportunity to keep things clean and well organized early on. As such, coding style is very important when making commits. We run clang-format on our CI to check the code. Please use it to format your code when contributing. However, it doesn't cover all the rules below. Some of them aren't very strict rules since we want to be flexible and we understand that under certain circumstances some of them can be counterproductive. Just try to follow as many of them as possible.
+
+# Using clang format (version 6.0)
+When generating the native build script for your toolset, cmake will try to find the correct version of clang format (or will download it on windows). Before running cmake, please install clang format version 6.0 for your platform as follows:
+
+* Windows: do nothing; cmake will download a pre built binary for MSVC and MINGW. MSVC users can additionally install a clang format Visual Studio extension to add features like format on save.
+* OSX: run `brew install clang-format`.
+* Linux: use your package manager to get an appropriate binary.
+
+If clang format is found, then cmake will add a custom build target that can be run at any time to run clang format against *all* source files and update the formatting in them. This should be used before making a pull request so that the reviewers can spend more time reviewing the code instead of having to worry about minor style violations. On MSVC, you can run clang format by building the clang-format project in the solution. On OSX, you can either use the Makefile target `make clang-format` or by building the clang-format target in XCode. For Makefile builds, you can use the clang-format target with `make clang-format`
 
 ### General Rules
 * A lot of code was taken from other projects (e.g. Citra, Dolphin, PPSSPP, Gekko). In general, when editing other people's code, follow the style of the module you're in (or better yet, fix the style if it drastically differs from our guide).

--- a/src/common/bit_set.h
+++ b/src/common/bit_set.h
@@ -236,7 +236,7 @@ public:
     IntTy m_val;
 };
 
-} // Common
+} // namespace Common
 
 typedef Common::BitSet<u8> BitSet8;
 typedef Common::BitSet<u16> BitSet16;

--- a/src/common/chunk_file.h
+++ b/src/common/chunk_file.h
@@ -607,8 +607,9 @@ public:
         u32 cookie = arbitraryNumber;
         Do(cookie);
         if (mode == PointerWrap::MODE_READ && cookie != arbitraryNumber) {
-            LOG_ERROR(Common, "After \"%s\", found %d (0x%X) instead of save marker %d (0x%X). "
-                              "Aborting savestate load...",
+            LOG_ERROR(Common,
+                      "After \"%s\", found %d (0x%X) instead of save marker %d (0x%X). "
+                      "Aborting savestate load...",
                       prevName, cookie, cookie, arbitraryNumber, arbitraryNumber);
             SetError(ERROR_FAILURE);
         }

--- a/src/common/color.h
+++ b/src/common/color.h
@@ -256,4 +256,4 @@ inline void EncodeX24S8(u8 stencil, u8* bytes) {
     bytes[3] = stencil;
 }
 
-} // namespace
+} // namespace Color

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -873,20 +873,19 @@ bool IOFile::Flush() {
 }
 
 bool IOFile::Resize(u64 size) {
-    if (!IsOpen() ||
-        0 !=
+    if (!IsOpen() || 0 !=
 #ifdef _WIN32
-            // ector: _chsize sucks, not 64-bit safe
-            // F|RES: changed to _chsize_s. i think it is 64-bit safe
-            _chsize_s(_fileno(m_file), size)
+                         // ector: _chsize sucks, not 64-bit safe
+                         // F|RES: changed to _chsize_s. i think it is 64-bit safe
+                         _chsize_s(_fileno(m_file), size)
 #else
-            // TODO: handle 64bit and growing
-            ftruncate(fileno(m_file), size)
+                         // TODO: handle 64bit and growing
+                         ftruncate(fileno(m_file), size)
 #endif
-            )
+    )
         m_good = false;
 
     return m_good;
 }
 
-} // namespace
+} // namespace FileUtil

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -253,7 +253,7 @@ private:
     bool m_good = true;
 };
 
-} // namespace
+} // namespace FileUtil
 
 // To deal with Windows being dumb at unicode:
 template <typename T>

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -132,4 +132,4 @@ void LogMessage(Class log_class, Level log_level, const char* filename, unsigned
 
     PrintColoredMessage(entry);
 }
-}
+} // namespace Log

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -47,4 +47,4 @@ Entry CreateEntry(Class log_class, Level log_level, const char* filename, unsign
                   const char* function, const char* format, va_list args);
 
 void SetFilter(Filter* filter);
-}
+} // namespace Log

--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -94,4 +94,4 @@ bool Filter::ParseFilterRule(const std::string::const_iterator begin,
 bool Filter::CheckMessage(Class log_class, Level level) const {
     return static_cast<u8>(level) >= static_cast<u8>(class_levels[static_cast<size_t>(log_class)]);
 }
-}
+} // namespace Log

--- a/src/common/logging/filter.h
+++ b/src/common/logging/filter.h
@@ -50,4 +50,4 @@ public:
 private:
     std::array<Level, (size_t)Class::Count> class_levels;
 };
-}
+} // namespace Log

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -129,4 +129,4 @@ void PrintColoredMessage(const Entry& entry) {
 #undef ESC
 #endif
 }
-}
+} // namespace Log

--- a/src/common/logging/text_formatter.h
+++ b/src/common/logging/text_formatter.h
@@ -28,4 +28,4 @@ void FormatLogMessage(const Entry& entry, char* out_text, size_t text_len);
 void PrintMessage(const Entry& entry);
 /// Prints the same message as `PrintMessage`, but colored acoording to the severity level.
 void PrintColoredMessage(const Entry& entry);
-}
+} // namespace Log

--- a/src/common/memory_util.cpp
+++ b/src/common/memory_util.cpp
@@ -40,11 +40,12 @@ void* AllocateExecutableMemory(size_t size, bool low) {
     if (low && (!map_hint))
         map_hint = (char*)round_page(512 * 1024 * 1024); /* 0.5 GB rounded up to the next page */
 #endif
-    void* ptr = mmap(map_hint, size, PROT_READ | PROT_WRITE | PROT_EXEC, MAP_ANON | MAP_PRIVATE
+    void* ptr = mmap(map_hint, size, PROT_READ | PROT_WRITE | PROT_EXEC,
+                     MAP_ANON | MAP_PRIVATE
 #if defined(ARCHITECTURE_X64) && defined(MAP_32BIT)
-                                                                             | (low ? MAP_32BIT : 0)
+                         | (low ? MAP_32BIT : 0)
 #endif
-                                                                             ,
+                         ,
                      -1, 0);
 #endif /* defined(_WIN32) */
 

--- a/src/common/quaternion.h
+++ b/src/common/quaternion.h
@@ -46,4 +46,4 @@ inline Quaternion<float> MakeQuaternion(const Math::Vec3<float>& axis, float ang
     return {axis * std::sin(angle / 2), std::cos(angle / 2)};
 }
 
-} // namspace Math
+} // namespace Math

--- a/src/common/scm_rev.h
+++ b/src/common/scm_rev.h
@@ -12,4 +12,4 @@ extern const char g_scm_desc[];
 extern const char g_build_name[];
 extern const char g_build_date[];
 
-} // namespace
+} // namespace Common

--- a/src/common/scope_exit.h
+++ b/src/common/scope_exit.h
@@ -22,7 +22,7 @@ template <typename Func>
 ScopeExitHelper<Func> ScopeExit(Func&& func) {
     return ScopeExitHelper<Func>(std::move(func));
 }
-}
+} // namespace detail
 
 /**
  * This macro allows you to conveniently specify a block of code that will run on scope exit. Handy

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -202,7 +202,7 @@ bool SplitPath(const std::string& full_path, std::string* _pPath, std::string* _
 #ifdef _WIN32
                                             ":"
 #endif
-                                            );
+    );
     if (std::string::npos == dir_end)
         dir_end = 0;
     else
@@ -462,4 +462,4 @@ std::string StringFromFixedZeroTerminatedBuffer(const char* buffer, size_t max_l
 
     return std::string(buffer, len);
 }
-}
+} // namespace Common

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -134,4 +134,4 @@ bool ComparePartialString(InIt begin, InIt end, const char* other) {
  * NUL-terminated then the string ends at max_len characters.
  */
 std::string StringFromFixedZeroTerminatedBuffer(const char* buffer, size_t max_len);
-}
+} // namespace Common

--- a/src/common/thread_queue_list.h
+++ b/src/common/thread_queue_list.h
@@ -158,4 +158,4 @@ private:
     std::array<Queue, NUM_QUEUES> queues;
 };
 
-} // namespace
+} // namespace Common

--- a/src/common/x64/xbyak_abi.h
+++ b/src/common/x64/xbyak_abi.h
@@ -60,20 +60,41 @@ const Xbyak::Reg ABI_PARAM4 = Xbyak::util::r9;
 
 const BitSet32 ABI_ALL_CALLER_SAVED = BuildRegSet({
     // GPRs
-    Xbyak::util::rcx, Xbyak::util::rdx, Xbyak::util::r8, Xbyak::util::r9, Xbyak::util::r10,
+    Xbyak::util::rcx,
+    Xbyak::util::rdx,
+    Xbyak::util::r8,
+    Xbyak::util::r9,
+    Xbyak::util::r10,
     Xbyak::util::r11,
     // XMMs
-    Xbyak::util::xmm0, Xbyak::util::xmm1, Xbyak::util::xmm2, Xbyak::util::xmm3, Xbyak::util::xmm4,
+    Xbyak::util::xmm0,
+    Xbyak::util::xmm1,
+    Xbyak::util::xmm2,
+    Xbyak::util::xmm3,
+    Xbyak::util::xmm4,
     Xbyak::util::xmm5,
 });
 
 const BitSet32 ABI_ALL_CALLEE_SAVED = BuildRegSet({
     // GPRs
-    Xbyak::util::rbx, Xbyak::util::rsi, Xbyak::util::rdi, Xbyak::util::rbp, Xbyak::util::r12,
-    Xbyak::util::r13, Xbyak::util::r14, Xbyak::util::r15,
+    Xbyak::util::rbx,
+    Xbyak::util::rsi,
+    Xbyak::util::rdi,
+    Xbyak::util::rbp,
+    Xbyak::util::r12,
+    Xbyak::util::r13,
+    Xbyak::util::r14,
+    Xbyak::util::r15,
     // XMMs
-    Xbyak::util::xmm6, Xbyak::util::xmm7, Xbyak::util::xmm8, Xbyak::util::xmm9, Xbyak::util::xmm10,
-    Xbyak::util::xmm11, Xbyak::util::xmm12, Xbyak::util::xmm13, Xbyak::util::xmm14,
+    Xbyak::util::xmm6,
+    Xbyak::util::xmm7,
+    Xbyak::util::xmm8,
+    Xbyak::util::xmm9,
+    Xbyak::util::xmm10,
+    Xbyak::util::xmm11,
+    Xbyak::util::xmm12,
+    Xbyak::util::xmm13,
+    Xbyak::util::xmm14,
     Xbyak::util::xmm15,
 });
 
@@ -90,18 +111,40 @@ const Xbyak::Reg ABI_PARAM4 = Xbyak::util::rcx;
 
 const BitSet32 ABI_ALL_CALLER_SAVED = BuildRegSet({
     // GPRs
-    Xbyak::util::rcx, Xbyak::util::rdx, Xbyak::util::rdi, Xbyak::util::rsi, Xbyak::util::r8,
-    Xbyak::util::r9, Xbyak::util::r10, Xbyak::util::r11,
+    Xbyak::util::rcx,
+    Xbyak::util::rdx,
+    Xbyak::util::rdi,
+    Xbyak::util::rsi,
+    Xbyak::util::r8,
+    Xbyak::util::r9,
+    Xbyak::util::r10,
+    Xbyak::util::r11,
     // XMMs
-    Xbyak::util::xmm0, Xbyak::util::xmm1, Xbyak::util::xmm2, Xbyak::util::xmm3, Xbyak::util::xmm4,
-    Xbyak::util::xmm5, Xbyak::util::xmm6, Xbyak::util::xmm7, Xbyak::util::xmm8, Xbyak::util::xmm9,
-    Xbyak::util::xmm10, Xbyak::util::xmm11, Xbyak::util::xmm12, Xbyak::util::xmm13,
-    Xbyak::util::xmm14, Xbyak::util::xmm15,
+    Xbyak::util::xmm0,
+    Xbyak::util::xmm1,
+    Xbyak::util::xmm2,
+    Xbyak::util::xmm3,
+    Xbyak::util::xmm4,
+    Xbyak::util::xmm5,
+    Xbyak::util::xmm6,
+    Xbyak::util::xmm7,
+    Xbyak::util::xmm8,
+    Xbyak::util::xmm9,
+    Xbyak::util::xmm10,
+    Xbyak::util::xmm11,
+    Xbyak::util::xmm12,
+    Xbyak::util::xmm13,
+    Xbyak::util::xmm14,
+    Xbyak::util::xmm15,
 });
 
 const BitSet32 ABI_ALL_CALLEE_SAVED = BuildRegSet({
     // GPRs
-    Xbyak::util::rbx, Xbyak::util::rbp, Xbyak::util::r12, Xbyak::util::r13, Xbyak::util::r14,
+    Xbyak::util::rbx,
+    Xbyak::util::rbp,
+    Xbyak::util::r12,
+    Xbyak::util::r13,
+    Xbyak::util::r14,
     Xbyak::util::r15,
 });
 

--- a/src/core/file_sys/archive_backend.cpp
+++ b/src/core/file_sys/archive_backend.cpp
@@ -119,4 +119,4 @@ std::vector<u8> Path::AsBinary() const {
         return {};
     }
 }
-}
+} // namespace FileSys

--- a/src/core/gdbstub/gdbstub.h
+++ b/src/core/gdbstub/gdbstub.h
@@ -91,4 +91,4 @@ bool GetCpuStepFlag();
  * @param is_step
  */
 void SetCpuStepFlag(bool is_step);
-}
+} // namespace GDBStub

--- a/src/core/hle/config_mem.cpp
+++ b/src/core/hle/config_mem.cpp
@@ -28,4 +28,4 @@ void Init() {
     config_mem.firm_ctr_sdk_ver = 0x0000F297;
 }
 
-} // namespace
+} // namespace ConfigMem

--- a/src/core/hle/config_mem.h
+++ b/src/core/hle/config_mem.h
@@ -53,4 +53,4 @@ extern ConfigMemDef config_mem;
 
 void Init();
 
-} // namespace
+} // namespace ConfigMem

--- a/src/core/hle/kernel/address_arbiter.h
+++ b/src/core/hle/kernel/address_arbiter.h
@@ -57,4 +57,4 @@ private:
     ~AddressArbiter() override;
 };
 
-} // namespace FileSys
+} // namespace Kernel

--- a/src/core/hle/kernel/client_port.cpp
+++ b/src/core/hle/kernel/client_port.cpp
@@ -39,4 +39,4 @@ ResultVal<SharedPtr<ClientSession>> ClientPort::Connect() {
     return MakeResult(std::get<SharedPtr<ClientSession>>(sessions));
 }
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/kernel/client_port.h
+++ b/src/core/hle/kernel/client_port.h
@@ -47,4 +47,4 @@ private:
     ~ClientPort() override;
 };
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/kernel/client_session.cpp
+++ b/src/core/hle/kernel/client_session.cpp
@@ -48,4 +48,4 @@ ResultCode ClientSession::SendSyncRequest(SharedPtr<Thread> thread) {
     return server->HandleSyncRequest(std::move(thread));
 }
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/kernel/client_session.h
+++ b/src/core/hle/kernel/client_session.h
@@ -45,4 +45,4 @@ private:
     ~ClientSession() override;
 };
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/kernel/condition_variable.h
+++ b/src/core/hle/kernel/condition_variable.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include <queue>
 #include <string>
+#include <queue>
 #include "common/common_types.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/wait_object.h"

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -52,4 +52,4 @@ void Event::WakeupAllWaitingThreads() {
         signaled = false;
 }
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/kernel/event.h
+++ b/src/core/hle/kernel/event.h
@@ -49,4 +49,4 @@ private:
     ~Event() override;
 };
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -104,4 +104,4 @@ void HandleTable::Clear() {
     next_free_slot = 0;
 }
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/kernel/handle_table.h
+++ b/src/core/hle/kernel/handle_table.h
@@ -130,4 +130,4 @@ private:
 
 extern HandleTable g_handle_table;
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -99,9 +99,8 @@ void HLERequestContext::ParseCommandBuffer(u32_le* src_cmdbuf, bool incoming) {
 
     data_payload_offset = rp.GetCurrentOffset();
 
-    if (domain_message_header &&
-        domain_message_header->command ==
-            IPC::DomainMessageHeader::CommandType::CloseVirtualHandle) {
+    if (domain_message_header && domain_message_header->command ==
+                                     IPC::DomainMessageHeader::CommandType::CloseVirtualHandle) {
         // CloseVirtualHandle command does not have SFC* or any data
         return;
     }

--- a/src/core/hle/kernel/resource_limit.cpp
+++ b/src/core/hle/kernel/resource_limit.cpp
@@ -151,4 +151,4 @@ void ResourceLimitsInit() {
 
 void ResourceLimitsShutdown() {}
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/kernel/resource_limit.h
+++ b/src/core/hle/kernel/resource_limit.h
@@ -123,4 +123,4 @@ void ResourceLimitsInit();
 // Destroys the resource limits
 void ResourceLimitsShutdown();
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/kernel/server_port.cpp
+++ b/src/core/hle/kernel/server_port.cpp
@@ -50,4 +50,4 @@ std::tuple<SharedPtr<ServerPort>, SharedPtr<ClientPort>> ServerPort::CreatePortP
     return std::make_tuple(std::move(server_port), std::move(client_port));
 }
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/kernel/server_port.h
+++ b/src/core/hle/kernel/server_port.h
@@ -72,4 +72,4 @@ private:
     ~ServerPort() override;
 };
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/kernel/server_session.h
+++ b/src/core/hle/kernel/server_session.h
@@ -113,4 +113,4 @@ private:
  * in the command buffer.
  */
 ResultCode TranslateHLERequest(ServerSession* server_session);
-}
+} // namespace Kernel

--- a/src/core/hle/kernel/session.cpp
+++ b/src/core/hle/kernel/session.cpp
@@ -9,4 +9,4 @@ namespace Kernel {
 
 Session::Session() {}
 Session::~Session() {}
-}
+} // namespace Kernel

--- a/src/core/hle/kernel/session.h
+++ b/src/core/hle/kernel/session.h
@@ -24,4 +24,4 @@ public:
     ServerSession* server = nullptr; ///< The server endpoint of the session.
     SharedPtr<ClientPort> port;      ///< The port that this session is associated with (optional).
 };
-}
+} // namespace Kernel

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -98,10 +98,10 @@ public:
     ResultCode Unmap(Process* target_process, VAddr address);
 
     /**
-    * Gets a pointer to the shared memory block
-    * @param offset Offset from the start of the shared memory block to get pointer
-    * @return Pointer to the shared memory block from the specified offset
-    */
+     * Gets a pointer to the shared memory block
+     * @param offset Offset from the start of the shared memory block to get pointer
+     * @return Pointer to the shared memory block from the specified offset
+     */
     u8* GetPointer(u32 offset = 0);
 
     /// Process that created this shared memory block.
@@ -129,4 +129,4 @@ private:
     ~SharedMemory() override;
 };
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -255,8 +255,9 @@ static ResultCode CancelSynchronization(Handle thread_handle) {
 /// Attempts to locks a mutex, creating it if it does not already exist
 static ResultCode ArbitrateLock(Handle holding_thread_handle, VAddr mutex_addr,
                                 Handle requesting_thread_handle) {
-    LOG_TRACE(Kernel_SVC, "called holding_thread_handle=0x%08X, mutex_addr=0x%llx, "
-                          "requesting_current_thread_handle=0x%08X",
+    LOG_TRACE(Kernel_SVC,
+              "called holding_thread_handle=0x%08X, mutex_addr=0x%llx, "
+              "requesting_current_thread_handle=0x%08X",
               holding_thread_handle, mutex_addr, requesting_thread_handle);
 
     SharedPtr<Thread> holding_thread = g_handle_table.Get<Thread>(holding_thread_handle);
@@ -546,8 +547,9 @@ static ResultCode CreateThread(Handle* out_handle, VAddr entry_point, u64 arg, V
 
     Core::System::GetInstance().PrepareReschedule();
 
-    LOG_TRACE(Kernel_SVC, "called entrypoint=0x%08X (%s), arg=0x%08X, stacktop=0x%08X, "
-                          "threadpriority=0x%08X, processorid=0x%08X : created handle=0x%08X",
+    LOG_TRACE(Kernel_SVC,
+              "called entrypoint=0x%08X (%s), arg=0x%08X, stacktop=0x%08X, "
+              "threadpriority=0x%08X, processorid=0x%08X : created handle=0x%08X",
               entry_point, name.c_str(), arg, stack_top, priority, processor_id, *out_handle);
 
     return RESULT_SUCCESS;

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -111,4 +111,4 @@ void TimersInit() {
 
 void TimersShutdown() {}
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/kernel/timer.h
+++ b/src/core/hle/kernel/timer.h
@@ -76,4 +76,4 @@ void TimersInit();
 /// Tears down the timer variables
 void TimersShutdown();
 
-} // namespace
+} // namespace Kernel

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -222,7 +222,8 @@ public:
     explicit IStorageAccessor(std::vector<u8> buffer)
         : ServiceFramework("IStorageAccessor"), buffer(std::move(buffer)) {
         static const FunctionInfo functions[] = {
-            {0, &IStorageAccessor::GetSize, "GetSize"}, {11, &IStorageAccessor::Read, "Read"},
+            {0, &IStorageAccessor::GetSize, "GetSize"},
+            {11, &IStorageAccessor::Read, "Read"},
         };
         RegisterHandlers(functions);
     }

--- a/src/core/hle/service/apm/apm.cpp
+++ b/src/core/hle/service/apm/apm.cpp
@@ -51,7 +51,8 @@ private:
 
 APM::APM() : ServiceFramework("apm") {
     static const FunctionInfo functions[] = {
-        {0x00000000, &APM::OpenSession, "OpenSession"}, {0x00000001, nullptr, "GetPerformanceMode"},
+        {0x00000000, &APM::OpenSession, "OpenSession"},
+        {0x00000001, nullptr, "GetPerformanceMode"},
     };
     RegisterHandlers(functions);
 }

--- a/src/core/hle/service/nvdrv/nvdrv.cpp
+++ b/src/core/hle/service/nvdrv/nvdrv.cpp
@@ -7,8 +7,8 @@
 #include "core/hle/service/nvdrv/devices/nvdisp_disp0.h"
 #include "core/hle/service/nvdrv/devices/nvhost_as_gpu.h"
 #include "core/hle/service/nvdrv/devices/nvmap.h"
-#include "core/hle/service/nvdrv/nvdrv.h"
 #include "core/hle/service/nvdrv/interface.h"
+#include "core/hle/service/nvdrv/nvdrv.h"
 
 namespace Service {
 namespace Nvidia {

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -21,7 +21,7 @@ class ClientPort;
 class ServerPort;
 class ServerSession;
 class HLERequestContext;
-}
+} // namespace Kernel
 
 namespace Service {
 
@@ -189,4 +189,4 @@ extern std::unordered_map<std::string, Kernel::SharedPtr<Kernel::ClientPort>> g_
 /// Adds a port to the named port table
 void AddNamedPort(std::string name, Kernel::SharedPtr<Kernel::ClientPort> port);
 
-} // namespace
+} // namespace Service

--- a/src/core/hle/shared_page.cpp
+++ b/src/core/hle/shared_page.cpp
@@ -82,4 +82,4 @@ void Init() {
     CoreTiming::ScheduleEvent(0, update_time_event);
 }
 
-} // namespace
+} // namespace SharedPage

--- a/src/core/hle/shared_page.h
+++ b/src/core/hle/shared_page.h
@@ -66,4 +66,4 @@ extern SharedPageDef shared_page;
 
 void Init();
 
-} // namespace
+} // namespace SharedPage

--- a/src/core/hw/hw.cpp
+++ b/src/core/hw/hw.cpp
@@ -91,4 +91,4 @@ void Shutdown() {
     LCD::Shutdown();
     LOG_DEBUG(HW, "shutdown OK");
 }
-}
+} // namespace HW

--- a/src/core/hw/hw.h
+++ b/src/core/hw/hw.h
@@ -47,4 +47,4 @@ void Init();
 /// Shutdown hardware
 void Shutdown();
 
-} // namespace
+} // namespace HW

--- a/src/core/hw/lcd.cpp
+++ b/src/core/hw/lcd.cpp
@@ -64,4 +64,4 @@ void Shutdown() {
     LOG_DEBUG(HW_LCD, "shutdown OK");
 }
 
-} // namespace
+} // namespace LCD

--- a/src/core/hw/lcd.h
+++ b/src/core/hw/lcd.h
@@ -83,4 +83,4 @@ void Init();
 /// Shutdown hardware
 void Shutdown();
 
-} // namespace
+} // namespace LCD

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -323,8 +323,9 @@ SharedPtr<CodeSet> ElfReader::LoadInto(u32 vaddr) {
             }
 
             if (codeset_segment->size != 0) {
-                LOG_ERROR(Loader, "ELF has more than one segment of the same type. Skipping extra "
-                                  "segment (id %i)",
+                LOG_ERROR(Loader,
+                          "ELF has more than one segment of the same type. Skipping extra "
+                          "segment (id %i)",
                           i);
                 continue;
             }

--- a/src/core/memory_setup.h
+++ b/src/core/memory_setup.h
@@ -29,4 +29,4 @@ void MapMemoryRegion(PageTable& page_table, VAddr base, u64 size, u8* target);
 void MapIoRegion(PageTable& page_table, VAddr base, u64 size, MMIORegionPointer mmio_handler);
 
 void UnmapRegion(PageTable& page_table, VAddr base, u64 size);
-}
+} // namespace Memory

--- a/src/core/mmio.h
+++ b/src/core/mmio.h
@@ -35,4 +35,4 @@ public:
 };
 
 using MMIORegionPointer = std::shared_ptr<MMIORegion>;
-};
+}; // namespace Memory

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -100,7 +100,8 @@ enum Values {
 };
 
 static const std::array<const char*, NumAnalogs> mapping = {{
-    "lstick", "rstick",
+    "lstick",
+    "rstick",
 }};
 } // namespace NativeAnalog
 

--- a/src/core/tracer/citrace.h
+++ b/src/core/tracer/citrace.h
@@ -97,4 +97,4 @@ struct CTStreamElement {
 };
 
 #pragma pack()
-}
+} // namespace CiTrace

--- a/src/core/tracer/recorder.cpp
+++ b/src/core/tracer/recorder.cpp
@@ -205,4 +205,4 @@ template void Recorder::RegisterWritten(u32, u8);
 template void Recorder::RegisterWritten(u32, u16);
 template void Recorder::RegisterWritten(u32, u32);
 template void Recorder::RegisterWritten(u32, u64);
-}
+} // namespace CiTrace

--- a/src/core/tracer/recorder.h
+++ b/src/core/tracer/recorder.h
@@ -63,9 +63,9 @@ private:
         CTStreamElement data;
 
         /**
-          * Extra data to store along "core" data.
-          * This is e.g. used for data used in MemoryUpdates.
-          */
+         * Extra data to store along "core" data.
+         * This is e.g. used for data used in MemoryUpdates.
+         */
         std::vector<u8> extra_data;
 
         /// Optional CRC hash (e.g. for hashing memory regions)
@@ -84,4 +84,4 @@ private:
     std::unordered_map<boost::crc_32_type::value_type /*hash*/, u32 /*file_offset*/> memory_regions;
 };
 
-} // namespace
+} // namespace CiTrace

--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -52,7 +52,8 @@ MotionEmu* GetMotionEmu() {
 
 std::string GenerateKeyboardParam(int key_code) {
     Common::ParamPackage param{
-        {"engine", "keyboard"}, {"code", std::to_string(key_code)},
+        {"engine", "keyboard"},
+        {"code", std::to_string(key_code)},
     };
     return param.Serialize();
 }

--- a/src/tests/common/param_package.cpp
+++ b/src/tests/common/param_package.cpp
@@ -10,7 +10,9 @@ namespace Common {
 
 TEST_CASE("ParamPackage", "[common]") {
     ParamPackage original{
-        {"abc", "xyz"}, {"def", "42"}, {"jkl", "$$:1:$2$,3"},
+        {"abc", "xyz"},
+        {"def", "42"},
+        {"jkl", "$$:1:$2$,3"},
     };
     original.Set("ghi", 3.14f);
     ParamPackage copy(original.Serialize());

--- a/src/video_core/renderer_opengl/gl_shader_util.h
+++ b/src/video_core/renderer_opengl/gl_shader_util.h
@@ -16,4 +16,4 @@ namespace GLShader {
  */
 GLuint LoadProgram(const char* vertex_shader, const char* fragment_shader);
 
-} // namespace
+} // namespace GLShader

--- a/src/video_core/utils.h
+++ b/src/video_core/utils.h
@@ -49,4 +49,4 @@ static inline u32 GetMortonOffset(u32 x, u32 y, u32 bytes_per_pixel) {
     return (i + offset) * bytes_per_pixel;
 }
 
-} // namespace
+} // namespace VideoCore

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -39,4 +39,4 @@ void Shutdown() {
     LOG_DEBUG(Render, "shutdown OK");
 }
 
-} // namespace
+} // namespace VideoCore

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -31,4 +31,4 @@ bool Init(EmuWindow* emu_window);
 /// Shutdown the video core
 void Shutdown();
 
-} // namespace
+} // namespace VideoCore

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -26,10 +26,18 @@ const std::array<int, Settings::NativeButton::NumButtons> Config::default_button
 
 const std::array<std::array<int, 5>, Settings::NativeAnalog::NumAnalogs> Config::default_analogs{{
     {
-        Qt::Key_Up, Qt::Key_Down, Qt::Key_Left, Qt::Key_Right, Qt::Key_E,
+        Qt::Key_Up,
+        Qt::Key_Down,
+        Qt::Key_Left,
+        Qt::Key_Right,
+        Qt::Key_E,
     },
     {
-        Qt::Key_I, Qt::Key_K, Qt::Key_J, Qt::Key_L, Qt::Key_R,
+        Qt::Key_I,
+        Qt::Key_K,
+        Qt::Key_J,
+        Qt::Key_L,
+        Qt::Key_R,
     },
 }};
 

--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -14,7 +14,11 @@
 
 const std::array<std::string, ConfigureInput::ANALOG_SUB_BUTTONS_NUM>
     ConfigureInput::analog_sub_buttons{{
-        "up", "down", "left", "right", "modifier",
+        "up",
+        "down",
+        "left",
+        "right",
+        "modifier",
     }};
 
 static QString getKeyName(int key_code) {
@@ -36,7 +40,8 @@ static void SetAnalogButton(const Common::ParamPackage& input_param,
                             Common::ParamPackage& analog_param, const std::string& button_name) {
     if (analog_param.Get("engine", "") != "analog_from_button") {
         analog_param = {
-            {"engine", "analog_from_button"}, {"modifier_scale", "0.5"},
+            {"engine", "analog_from_button"},
+            {"modifier_scale", "0.5"},
         };
     }
     analog_param.Set(button_name, input_param.Serialize());
@@ -107,11 +112,17 @@ ConfigureInput::ConfigureInput(QWidget* parent)
 
     analog_map_buttons = {{
         {
-            ui->buttonLStickUp, ui->buttonLStickDown, ui->buttonLStickLeft, ui->buttonLStickRight,
+            ui->buttonLStickUp,
+            ui->buttonLStickDown,
+            ui->buttonLStickLeft,
+            ui->buttonLStickRight,
             ui->buttonLStickMod,
         },
         {
-            ui->buttonRStickUp, ui->buttonRStickDown, ui->buttonRStickLeft, ui->buttonRStickRight,
+            ui->buttonRStickUp,
+            ui->buttonRStickDown,
+            ui->buttonRStickLeft,
+            ui->buttonRStickRight,
             ui->buttonRStickMod,
         },
     }};

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -9,7 +9,18 @@
 #include "yuzu/ui_settings.h"
 
 static const std::array<int, 12> days_in_month = {{
-    31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
+    31,
+    29,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
 }};
 
 ConfigureSystem::ConfigureSystem(QWidget* parent) : QWidget(parent), ui(new Ui::ConfigureSystem) {

--- a/src/yuzu/debugger/wait_tree.h
+++ b/src/yuzu/debugger/wait_tree.h
@@ -20,7 +20,7 @@ class Mutex;
 class ConditionVariable;
 class Thread;
 class Timer;
-}
+} // namespace Kernel
 
 class WaitTreeThread;
 

--- a/src/yuzu/ui_settings.h
+++ b/src/yuzu/ui_settings.h
@@ -50,4 +50,4 @@ struct Values {
 };
 
 extern Values values;
-}
+} // namespace UISettings

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -49,10 +49,18 @@ static const std::array<int, Settings::NativeButton::NumButtons> default_buttons
 
 static const std::array<std::array<int, 5>, Settings::NativeAnalog::NumAnalogs> default_analogs{{
     {
-        SDL_SCANCODE_UP, SDL_SCANCODE_DOWN, SDL_SCANCODE_LEFT, SDL_SCANCODE_RIGHT, SDL_SCANCODE_D,
+        SDL_SCANCODE_UP,
+        SDL_SCANCODE_DOWN,
+        SDL_SCANCODE_LEFT,
+        SDL_SCANCODE_RIGHT,
+        SDL_SCANCODE_D,
     },
     {
-        SDL_SCANCODE_I, SDL_SCANCODE_K, SDL_SCANCODE_J, SDL_SCANCODE_L, SDL_SCANCODE_D,
+        SDL_SCANCODE_I,
+        SDL_SCANCODE_K,
+        SDL_SCANCODE_J,
+        SDL_SCANCODE_L,
+        SDL_SCANCODE_D,
     },
 }};
 


### PR DESCRIPTION
Please review it commit by commit. This also depends on https://github.com/yuzu-emu/ext-windows-bin/pull/7 for letting windows download a clang-format binary that they can use directly.

## What is all here

* Generates an optional build target when cmake can find the right version of clang-format. For MSVC, you can right click the clang-format project and have it format all source files. For Makefiles, you can run `make clang-format`. I don't know what XCode does as I don't ever use it.

* Each platform has a custom command that is run to gather all the files when the clang-format is run and not when the project is generated. ~~Its *probably* fine to gather a list of all source files using `file(GLOB)` at configuration time, but I was worried that I might miss a case where someone adds a file without regenerating the build scripts. I won't fight it if someone thinks this should be simplified.~~ Eh, I was working on this, but I am running into command line length limits and I don't care to fix that.

* Bumps up the version to clang-format 6.0 which is the version installed when installing the MSVC plugin.

* For a bonus change, I added conditional options to automatically turn on `USE_BUNDLED_*` when MSVC is the toolset and the `ENABLE_*` option is ON. It always seemed silly to me that we make you click those check boxes ... After this is merged, I'll remove those steps from the wiki.

## If you would like to test this:

I've updated the instructions on the contributing guide with how to run clang format. Please try it out and let me know if anything is unclear.