### PR TITLE
service/time: remove accidental #pragmas

### DIFF
--- a/src/core/hle/service/time/time_s.cpp
+++ b/src/core/hle/service/time/time_s.cpp
@@ -2,8 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#pragma once
-
 #include "core/hle/service/time/time_s.h"
 
 namespace Service {

--- a/src/core/hle/service/time/time_u.cpp
+++ b/src/core/hle/service/time/time_u.cpp
@@ -2,8 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#pragma once
-
 #include "core/hle/service/time/time_u.h"
 
 namespace Service {


### PR DESCRIPTION
fixes these warnings:
```
[ 86%] Building CXX object src/core/CMakeFiles/core.dir/hle/service/time/time_s.cpp.o
/home/thomas/dev/switch/yuzu-fork/src/core/hle/service/time/time_s.cpp:5:9: warning: #pragma once in main file
 #pragma once
         ^~~~
[ 87%] Building CXX object src/core/CMakeFiles/core.dir/hle/service/time/time_u.cpp.o
/home/thomas/dev/switch/yuzu-fork/src/core/hle/service/time/time_u.cpp:5:9: warning: #pragma once in main file
 #pragma once
         ^~~~
```