### PR TITLE
Unicorn build fixups

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ CMAKE_DEPENDENT_OPTION(YUZU_USE_BUNDLED_SDL2 "Download bundled SDL2 binaries" ON
 option(ENABLE_QT "Enable the Qt frontend" ON)
 CMAKE_DEPENDENT_OPTION(YUZU_USE_BUNDLED_QT "Download bundled Qt binaries" ON "ENABLE_SDL2;MSVC" OFF)
 
+option(YUZU_USE_BUNDLED_UNICORN "Build/Download bundled Unicorn" ON)
+
 if(NOT EXISTS ${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit)
     message(STATUS "Copying pre-commit hook")
     file(COPY hooks/pre-commit
@@ -209,8 +211,7 @@ else()
 endif()
 
 # If unicorn isn't found, msvc -> download bundled unicorn; everyone else -> build external
-find_package(Unicorn QUIET)
-if (NOT UNICORN_FOUND)
+if (YUZU_USE_BUNDLED_UNICORN)
     if (MSVC)
         message(STATUS "unicorn not found, falling back to bundled")
         # Detect toolchain and platform
@@ -259,6 +260,8 @@ if (NOT UNICORN_FOUND)
         )
         unset(UNICORN_LIB_NAME)
     endif()
+else()
+    find_package(Unicorn REQUIRED)
 endif()
 
 if (UNICORN_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ if (YUZU_USE_BUNDLED_UNICORN)
         find_package(PythonInterp 2.7 REQUIRED)
 
         add_custom_command(OUTPUT ${LIBUNICORN_LIBRARY}
-            COMMAND ${CMAKE_COMMAND} -E env UNICORN_ARCHS="aarch64" PYTHON="${PYTHON_EXECUTABLE}" /bin/sh make.sh
+            COMMAND ${CMAKE_COMMAND} -E env UNICORN_ARCHS="aarch64" PYTHON="${PYTHON_EXECUTABLE}" /bin/sh make.sh macos-universal-no
             WORKING_DIRECTORY ${UNICORN_PREFIX}
         )
         # ALL makes this custom target build every time


### PR DESCRIPTION
1. It doesn't make much sense for us to look for the system's version of unicorn by default, since our version has features not present upstream. The user can override this, of course.

2. Don't build a universal library for bundled unicorn. We only support x64 anyway.