### PR TITLE
 AppletOE: Stubbed CreateManagedDisplayLayer to create a new layer in the default display.

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -8,8 +8,9 @@
 namespace Service {
 namespace AM {
 
-void InstallInterfaces(SM::ServiceManager& service_manager) {
-    std::make_shared<AppletOE>()->InstallAsService(service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager,
+                       std::shared_ptr<NVFlinger::NVFlinger> nvflinger) {
+    std::make_shared<AppletOE>(nvflinger)->InstallAsService(service_manager);
 }
 
 } // namespace AM

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -4,13 +4,19 @@
 
 #pragma once
 
+#include <memory>
 #include "core/hle/service/service.h"
 
 namespace Service {
+namespace NVFlinger {
+class NVFlinger;
+}
+
 namespace AM {
 
 /// Registers all AM services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager,
+                       std::shared_ptr<NVFlinger::NVFlinger> nvflinger);
 
 } // namespace AM
 } // namespace Service

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -67,6 +67,7 @@ public:
             {14, &ISelfController::SetRestartMessageEnabled, "SetRestartMessageEnabled"},
             {16, &ISelfController::SetOutOfFocusSuspendingEnabled,
              "SetOutOfFocusSuspendingEnabled"},
+            {40, &ISelfController::CreateManagedDisplayLayer, "CreateManagedDisplayLayer"},
         };
         RegisterHandlers(functions);
     }
@@ -143,6 +144,19 @@ private:
     void UnlockExit(Kernel::HLERequestContext& ctx) {
         IPC::RequestBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
+
+        LOG_WARNING(Service, "(STUBBED) called");
+    }
+
+    void CreateManagedDisplayLayer(Kernel::HLERequestContext& ctx) {
+        // TODO(Subv): Find out how AM determines the display to use, for now just create the layer
+        // in the Default display.
+        u64 display_id = nvflinger->OpenDisplay("Default");
+        u64 layer_id = nvflinger->CreateLayer(display_id);
+
+        IPC::RequestBuilder rb{ctx, 4};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push(layer_id);
 
         LOG_WARNING(Service, "(STUBBED) called");
     }

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -7,6 +7,7 @@
 #include "core/hle/kernel/event.h"
 #include "core/hle/service/am/applet_oe.h"
 #include "core/hle/service/apm/apm.h"
+#include "core/hle/service/nvflinger/nvflinger.h"
 
 namespace Service {
 namespace AM {
@@ -53,7 +54,8 @@ public:
 
 class ISelfController final : public ServiceFramework<ISelfController> {
 public:
-    ISelfController() : ServiceFramework("ISelfController") {
+    ISelfController(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
+        : ServiceFramework("ISelfController"), nvflinger(std::move(nvflinger)) {
         static const FunctionInfo functions[] = {
             {1, &ISelfController::LockExit, "LockExit"},
             {2, &ISelfController::UnlockExit, "UnlockExit"},
@@ -144,6 +146,8 @@ private:
 
         LOG_WARNING(Service, "(STUBBED) called");
     }
+
+    std::shared_ptr<NVFlinger::NVFlinger> nvflinger;
 };
 
 class ICommonStateGetter final : public ServiceFramework<ICommonStateGetter> {
@@ -367,7 +371,8 @@ public:
 
 class IApplicationProxy final : public ServiceFramework<IApplicationProxy> {
 public:
-    IApplicationProxy() : ServiceFramework("IApplicationProxy") {
+    IApplicationProxy(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
+        : ServiceFramework("IApplicationProxy"), nvflinger(std::move(nvflinger)) {
         static const FunctionInfo functions[] = {
             {0, &IApplicationProxy::GetCommonStateGetter, "GetCommonStateGetter"},
             {1, &IApplicationProxy::GetSelfController, "GetSelfController"},
@@ -413,7 +418,7 @@ private:
     void GetSelfController(Kernel::HLERequestContext& ctx) {
         IPC::RequestBuilder rb{ctx, 2, 0, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<ISelfController>();
+        rb.PushIpcInterface<ISelfController>(nvflinger);
         LOG_DEBUG(Service, "called");
     }
 
@@ -437,16 +442,19 @@ private:
         rb.PushIpcInterface<IApplicationFunctions>();
         LOG_DEBUG(Service, "called");
     }
+
+    std::shared_ptr<NVFlinger::NVFlinger> nvflinger;
 };
 
 void AppletOE::OpenApplicationProxy(Kernel::HLERequestContext& ctx) {
     IPC::RequestBuilder rb{ctx, 2, 0, 0, 1};
     rb.Push(RESULT_SUCCESS);
-    rb.PushIpcInterface<IApplicationProxy>();
+    rb.PushIpcInterface<IApplicationProxy>(nvflinger);
     LOG_DEBUG(Service, "called");
 }
 
-AppletOE::AppletOE() : ServiceFramework("appletOE") {
+AppletOE::AppletOE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
+    : ServiceFramework("appletOE"), nvflinger(std::move(nvflinger)) {
     static const FunctionInfo functions[] = {
         {0x00000000, &AppletOE::OpenApplicationProxy, "OpenApplicationProxy"},
     };

--- a/src/core/hle/service/am/applet_oe.h
+++ b/src/core/hle/service/am/applet_oe.h
@@ -4,10 +4,15 @@
 
 #pragma once
 
+#include <memory>
 #include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/service/service.h"
 
 namespace Service {
+namespace NVFlinger {
+class NVFlinger;
+}
+
 namespace AM {
 
 // TODO: Add more languages
@@ -18,11 +23,13 @@ enum SystemLanguage {
 
 class AppletOE final : public ServiceFramework<AppletOE> {
 public:
-    AppletOE();
+    AppletOE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger);
     ~AppletOE() = default;
 
 private:
     void OpenApplicationProxy(Kernel::HLERequestContext& ctx);
+
+    std::shared_ptr<NVFlinger::NVFlinger> nvflinger;
 };
 
 } // namespace AM

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -165,6 +165,10 @@ void AddNamedPort(std::string name, SharedPtr<ClientPort> port) {
 
 /// Initialize ServiceManager
 void Init() {
+    // NVFlinger needs to be accessed by several services like Vi and AppletOE so we instantiate it
+    // here and pass it into the respective InstallInterfaces functions.
+    auto nv_flinger = std::make_shared<NVFlinger::NVFlinger>();
+
     SM::g_service_manager = std::make_shared<SM::ServiceManager>();
     SM::ServiceManager::InstallInterfaces(SM::g_service_manager);
 
@@ -180,7 +184,7 @@ void Init() {
     PCTL::InstallInterfaces(*SM::g_service_manager);
     Sockets::InstallInterfaces(*SM::g_service_manager);
     Time::InstallInterfaces(*SM::g_service_manager);
-    VI::InstallInterfaces(*SM::g_service_manager);
+    VI::InstallInterfaces(*SM::g_service_manager, nv_flinger);
     Set::InstallInterfaces(*SM::g_service_manager);
 
     LOG_DEBUG(Service, "initialized OK");

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -173,7 +173,7 @@ void Init() {
     SM::ServiceManager::InstallInterfaces(SM::g_service_manager);
 
     Account::InstallInterfaces(*SM::g_service_manager);
-    AM::InstallInterfaces(*SM::g_service_manager);
+    AM::InstallInterfaces(*SM::g_service_manager, nv_flinger);
     AOC::InstallInterfaces(*SM::g_service_manager);
     APM::InstallInterfaces(*SM::g_service_manager);
     Audio::InstallInterfaces(*SM::g_service_manager);

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -753,8 +753,9 @@ IApplicationDisplayService::IApplicationDisplayService(
     RegisterHandlers(functions);
 }
 
-void InstallInterfaces(SM::ServiceManager& service_manager) {
-    std::make_shared<VI_M>()->InstallAsService(service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager,
+                       std::shared_ptr<NVFlinger::NVFlinger> nv_flinger) {
+    std::make_shared<VI_M>(nv_flinger)->InstallAsService(service_manager);
 }
 
 } // namespace VI

--- a/src/core/hle/service/vi/vi.h
+++ b/src/core/hle/service/vi/vi.h
@@ -39,7 +39,8 @@ private:
 };
 
 /// Registers all VI services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager,
+                       std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
 
 } // namespace VI
 } // namespace Service

--- a/src/core/hle/service/vi/vi_m.cpp
+++ b/src/core/hle/service/vi/vi_m.cpp
@@ -17,13 +17,13 @@ void VI_M::GetDisplayService(Kernel::HLERequestContext& ctx) {
     rb.PushIpcInterface<IApplicationDisplayService>(nv_flinger);
 }
 
-VI_M::VI_M() : ServiceFramework("vi:m") {
+VI_M::VI_M(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
+    : ServiceFramework("vi:m"), nv_flinger(std::move(nv_flinger)) {
     static const FunctionInfo functions[] = {
         {2, &VI_M::GetDisplayService, "GetDisplayService"},
         {3, nullptr, "GetDisplayServiceWithProxyNameExchange"},
     };
     RegisterHandlers(functions);
-    nv_flinger = std::make_shared<NVFlinger::NVFlinger>();
 }
 
 } // namespace VI

--- a/src/core/hle/service/vi/vi_m.h
+++ b/src/core/hle/service/vi/vi_m.h
@@ -16,7 +16,7 @@ namespace VI {
 
 class VI_M final : public ServiceFramework<VI_M> {
 public:
-    VI_M();
+    VI_M(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
     ~VI_M() = default;
 
 private:


### PR DESCRIPTION
This function is used by libnx during initialization.

The NVFlinger instance is now more similar to a singleton, it's created during Service initialization and dependency-injected into the services that need it.