### PR TITLE
Stub OpenAudioOut and fix a issue with HID IAppletResource

### DIFF
--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -49,9 +49,22 @@ void AudOutU::ListAudioOuts(Kernel::HLERequestContext& ctx) {
     rb.Push<u32>(1);
 }
 
+void AudOutU::OpenAudioOut(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service, "(STUBBED) called");
+
+    IPC::RequestBuilder rb{ctx, 6};
+
+    rb.Push(RESULT_SUCCESS);
+    rb.Push<u32>(48000); // Sample Rate
+    rb.Push<u32>(2);     // Channels
+    rb.Push<u32>(2);     // PCM Format (INT16)
+    rb.Push<u32>(0);     // Unknown
+    rb.PushIpcInterface<Audio::IAudioOut>();
+}
+
 AudOutU::AudOutU() : ServiceFramework("audout:u") {
     static const FunctionInfo functions[] = {{0x00000000, &AudOutU::ListAudioOuts, "ListAudioOuts"},
-                                             {0x00000001, nullptr, "OpenAudioOut"},
+                                             {0x00000001, &AudOutU::OpenAudioOut, "OpenAudioOut"},
                                              {0x00000002, nullptr, "Unknown2"},
                                              {0x00000003, nullptr, "Unknown3"}};
     RegisterHandlers(functions);

--- a/src/core/hle/service/audio/audout_u.h
+++ b/src/core/hle/service/audio/audout_u.h
@@ -20,6 +20,7 @@ public:
 
 private:
     void ListAudioOuts(Kernel::HLERequestContext& ctx);
+    void OpenAudioOut(Kernel::HLERequestContext& ctx);
 };
 
 } // namespace Audio

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -162,8 +162,13 @@ public:
     ~Hid() = default;
 
 private:
+    Kernel::SharedPtr<Kernel::ClientPort> client_port;
+
     void CreateAppletResource(Kernel::HLERequestContext& ctx) {
-        auto client_port = std::make_shared<IAppletResource>()->CreatePort();
+        if (client_port == nullptr) {
+            client_port = std::make_shared<IAppletResource>()->CreatePort();
+        }
+
         auto session = client_port->Connect();
         if (session.Succeeded()) {
             LOG_DEBUG(Service, "called, initialized IAppletResource -> session=%u",


### PR DESCRIPTION
This stubs OpenAudioOut needed by RetroArch. Also, prevent IAppletResource from being created more than once, this was triggering an assert on core_timing.cpp.