### PR TITLE
audout:u OpenAudioOut and IAudioOut

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -39,6 +39,7 @@ namespace Log {
     SUB(Service, DSP)                                                                              \
     SUB(Service, HID)                                                                              \
     SUB(Service, NVDRV)                                                                            \
+    SUB(Service, Audio)                                                                            \
     CLS(HW)                                                                                        \
     SUB(HW, Memory)                                                                                \
     SUB(HW, LCD)                                                                                   \

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -40,7 +40,6 @@ namespace Log {
     SUB(Service, HID)                                                                              \
     SUB(Service, NVDRV)                                                                            \
     SUB(Service, Audio)                                                                            \
-    SUB(Service, NVDRV)                                                                            \
     CLS(HW)                                                                                        \
     SUB(HW, Memory)                                                                                \
     SUB(HW, LCD)                                                                                   \

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -40,6 +40,7 @@ namespace Log {
     SUB(Service, HID)                                                                              \
     SUB(Service, NVDRV)                                                                            \
     SUB(Service, Audio)                                                                            \
+    SUB(Service, NVDRV)                                                                            \
     CLS(HW)                                                                                        \
     SUB(HW, Memory)                                                                                \
     SUB(HW, LCD)                                                                                   \

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -56,6 +56,7 @@ enum class Class : ClassType {
     Service_DSP,       ///< The DSP (DSP control) service
     Service_HID,       ///< The HID (Human interface device) service
     Service_NVDRV,     ///< The NVDRV (Nvidia driver) service
+    Service_Audio,     ///< The Audio (Audio control) service
     HW,                ///< Low-level hardware emulation
     HW_Memory,         ///< Memory-map and address translation
     HW_LCD,            ///< LCD register emulation

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -3,30 +3,140 @@
 // Refer to the license.txt file included.
 
 #include "common/logging/log.h"
+#include "core/core_timing.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/hle_ipc.h"
+#include "core/hle/kernel/event.h"
 #include "core/hle/service/audio/audout_u.h"
 
 namespace Service {
 namespace Audio {
+
+// switch sample rate frequency
+constexpr u32 sample_rate = 48000;
+// TODO(st4rk): dynamic number of channels, as I think Switch has support
+// to more audio channels (probably when Docked I guess)
+constexpr u32 audio_channels = 2;
+// TODO(st4rk): find a proper value for the audio_ticks
+constexpr u64 audio_ticks = static_cast<u64>(BASE_CLOCK_RATE / 1000);
 
 class IAudioOut final : public ServiceFramework<IAudioOut> {
 public:
     IAudioOut() : ServiceFramework("IAudioOut") {
         static const FunctionInfo functions[] = {
             {0x0, nullptr, "GetAudioOutState"},
-            {0x1, nullptr, "StartAudioOut"},
-            {0x2, nullptr, "StopAudioOut"},
-            {0x3, nullptr, "AppendAudioOutBuffer_1"},
-            {0x4, nullptr, "RegisterBufferEvent"},
-            {0x5, nullptr, "GetReleasedAudioOutBuffer_1"},
+            {0x1, &IAudioOut::StartAudioOut, "StartAudioOut"},
+            {0x2, &IAudioOut::StopAudioOut, "StopAudioOut"},
+            {0x3, &IAudioOut::AppendAudioOutBuffer_1, "AppendAudioOutBuffer_1"},
+            {0x4, &IAudioOut::RegisterBufferEvent, "RegisterBufferEvent"},
+            {0x5, &IAudioOut::GetReleasedAudioOutBuffer_1, "GetReleasedAudioOutBuffer_1"},
             {0x6, nullptr, "ContainsAudioOutBuffer"},
             {0x7, nullptr, "AppendAudioOutBuffer_2"},
             {0x8, nullptr, "GetReleasedAudioOutBuffer_2"},
         };
         RegisterHandlers(functions);
+
+        // This is the event handle used to check if the audio buffer was released
+        buffer_event = Kernel::Event::Create(Kernel::ResetType::OneShot, "IAudioOut buffer released event handle");
+
+        // Register event callback to update the Audio Buffer
+        audio_event = CoreTiming::RegisterEvent(
+            "IAudioOut::UpdateAudioBuffersCallback",
+            [this](u64 userdata, int cycles_late) {
+                UpdateAudioBuffersCallback();
+                CoreTiming::ScheduleEvent(audio_ticks - cycles_late, audio_event);
+            });
+
+        // Start the audio event
+        CoreTiming::ScheduleEvent(audio_ticks, audio_event);
+
+        // start with the audio stopped
+        audio_out_state = 1;
     }
+
     ~IAudioOut() = default;
+private:
+
+    void StartAudioOut(Kernel::HLERequestContext& ctx) {
+        LOG_WARNING(Service, "(STUBBED) called");
+
+        // start audio
+        audio_out_state = 0x0;
+
+        IPC::RequestBuilder rb{ctx, 2, 0, 0, 0};
+        rb.Push(RESULT_SUCCESS);
+    }
+
+    void StopAudioOut(Kernel::HLERequestContext& ctx) {
+        LOG_WARNING(Service, "(STUBBED) called");
+
+        // stop audio
+        audio_out_state = 0x1;
+
+        IPC::RequestBuilder rb{ctx, 2, 0, 0, 0};
+        rb.Push(RESULT_SUCCESS);
+    }
+
+    void RegisterBufferEvent(Kernel::HLERequestContext& ctx) {
+        LOG_WARNING(Service, "(STUBBED) called");
+
+        IPC::RequestBuilder rb{ctx, 2, 1};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushCopyObjects(buffer_event);
+    }
+
+    void AppendAudioOutBuffer_1(Kernel::HLERequestContext& ctx) {
+        LOG_WARNING(Service, "(STUBBED) called");
+        IPC::RequestParser rp{ctx};
+
+        released_buffer = rp.Pop<u64>();
+
+        IPC::RequestBuilder rb{ctx, 2, 0, 0, 0};
+        rb.Push(RESULT_SUCCESS);
+    }
+
+    void GetReleasedAudioOutBuffer_1(Kernel::HLERequestContext& ctx) {
+        LOG_WARNING(Service, "(STUBBED) called");
+
+        const auto& buffer = ctx.BufferDescriptorB()[0];
+
+        // TODO(st4rk): this is how libtransistor currently implements the
+        // GetReleasedAudioOutBuffer, it should return the key (a VA) to
+        // the APP and this address is used to know which buffer should
+        // be filled with data and send again to the service through
+        // AppendAudioOutBuffer. Check if this is the proper way to
+        // do it.
+
+        Memory::WriteBlock(buffer.Address(), &released_buffer, sizeof(u64));
+
+        IPC::RequestBuilder rb{ctx, 3, 0, 0, 0};
+        rb.Push(RESULT_SUCCESS);
+        // This might be the total of released buffers
+        rb.Push<u32>(0);
+    }
+
+    void UpdateAudioBuffersCallback() {
+        if (!audio_out_state) {
+            buffer_event->Signal();
+        }
+    }
+
+    // This is used to trigger the audio event callback that is going
+    // to read the samples from the audio_buffer list and enqueue the samples
+    // using the sink (audio_core).
+    CoreTiming::EventType* audio_event;
+
+    // This is the evend handle used to check if the audio buffer was released
+    Kernel::SharedPtr<Kernel::Event> buffer_event;
+
+    // (st4rk): this is just a temporary workaround for the future implementation.
+    // Libtransistor uses the key as an address in the App, so we need to return
+    // when the GetReleasedAudioOutBuffer_1 is called, otherwise we'll run in
+    // problems, because libtransistor uses the key returned as an pointer;
+    u64 released_buffer;
+
+    // current audio state: 0 is started and 1 is stopped
+    u32 audio_out_state;
 };
 
 void AudOutU::ListAudioOuts(Kernel::HLERequestContext& ctx) {
@@ -52,14 +162,25 @@ void AudOutU::ListAudioOuts(Kernel::HLERequestContext& ctx) {
 void AudOutU::OpenAudioOut(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service, "(STUBBED) called");
 
-    IPC::RequestBuilder rb{ctx, 6};
+    if (audio_out_interface == nullptr) {
+        audio_out_interface = std::make_shared<IAudioOut>();
+    }
+
+    auto sessions = Kernel::ServerSession::CreateSessionPair(audio_out_interface->GetServiceName());
+    auto server = std::get<Kernel::SharedPtr<Kernel::ServerSession>>(sessions);
+    auto client = std::get<Kernel::SharedPtr<Kernel::ClientSession>>(sessions);
+    audio_out_interface->ClientConnected(server);
+    LOG_DEBUG(Service, "called, initialized IAudioOut -> session=%u",
+              client->GetObjectId());
+    IPC::RequestBuilder rb{ctx, 6,0,1};
 
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u32>(48000); // Sample Rate
-    rb.Push<u32>(2);     // Channels
-    rb.Push<u32>(2);     // PCM Format (INT16)
-    rb.Push<u32>(0);     // Unknown
-    rb.PushIpcInterface<Audio::IAudioOut>();
+    rb.Push<u32>(sample_rate);
+    rb.Push<u32>(audio_channels);
+    rb.Push<u32>(PCM_FORMAT::INT16);
+    // this field is unknown
+    rb.Push<u32>(0);
+    rb.PushMoveObjects(std::move(client));
 }
 
 AudOutU::AudOutU() : ServiceFramework("audout:u") {

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -13,7 +13,7 @@
 namespace Service {
 namespace Audio {
 
-/// switch sample rate frequency
+/// Switch sample rate frequency
 constexpr u32 sample_rate{48000};
 /// TODO(st4rk): dynamic number of channels, as I think Switch has support
 /// to more audio channels (probably when Docked I guess)

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -61,7 +61,7 @@ private:
         // start audio
         audio_out_state = STARTED;
 
-        IPC::RequestBuilder rb{ctx, 2, 0, 0, 0};
+        IPC::RequestBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
 

--- a/src/core/hle/service/audio/audout_u.h
+++ b/src/core/hle/service/audio/audout_u.h
@@ -26,15 +26,7 @@ private:
     void ListAudioOuts(Kernel::HLERequestContext& ctx);
     void OpenAudioOut(Kernel::HLERequestContext& ctx);
 
-    enum PCM_FORMAT {
-        INVALID,
-        INT8,
-        INT16,
-        INT24,
-        INT32,
-        PCM_FLOAT,
-        ADPCM
-    };
+    enum PCM_FORMAT { INVALID, INT8, INT16, INT24, INT32, PCM_FLOAT, ADPCM };
 };
 
 } // namespace Audio

--- a/src/core/hle/service/audio/audout_u.h
+++ b/src/core/hle/service/audio/audout_u.h
@@ -26,7 +26,15 @@ private:
     void ListAudioOuts(Kernel::HLERequestContext& ctx);
     void OpenAudioOut(Kernel::HLERequestContext& ctx);
 
-    enum PCM_FORMAT { INVALID, INT8, INT16, INT24, INT32, PCM_FLOAT, ADPCM };
+    enum class PcmFormat : u32 {
+        Invalid = 0,
+        Int8 = 1,
+        Int16 = 2,
+        Int24 = 3,
+        Int32 = 4,
+        PcmFloat = 5,
+        Adpcm = 6,
+    };
 };
 
 } // namespace Audio

--- a/src/core/hle/service/audio/audout_u.h
+++ b/src/core/hle/service/audio/audout_u.h
@@ -13,14 +13,28 @@ class HLERequestContext;
 namespace Service {
 namespace Audio {
 
+class IAudioOut;
+
 class AudOutU final : public ServiceFramework<AudOutU> {
 public:
     AudOutU();
     ~AudOutU() = default;
 
 private:
+    std::shared_ptr<IAudioOut> audio_out_interface;
+
     void ListAudioOuts(Kernel::HLERequestContext& ctx);
     void OpenAudioOut(Kernel::HLERequestContext& ctx);
+
+    enum PCM_FORMAT {
+        INVALID,
+        INT8,
+        INT16,
+        INT24,
+        INT32,
+        PCM_FLOAT,
+        ADPCM
+    };
 };
 
 } // namespace Audio


### PR DESCRIPTION
Hi!

I've written a proper implementation for the OpenAudioOut stub where we should return the an IAudioOut interface (in the previous implementation we forgot to say that we're sending an interface in the IPC RequestBuilder, thus it wasn't crash as the IAudioOut wasn't being used). However I've a few things that are necessary to be discussed about this stubs implementation and about the current SDK(to be specific libtransistor).

1. RetroArch requesting the audout:u interface two times:
We had the same problem with HID, one of the possible solutions for this problem was implemented by Subv in the following commit: https://github.com/yuzu-emu/yuzu/commit/1003996e80791baf1187b8a122f521d3cf02cc96
I've done the same as this commit, as my previous implementation (that was only being tested in the libtransistor audio output example) was just returning a new IAudioOut interface, this turned out to be a problem because we'll schedule the same event two times (triggering an assert), this happened because RetroArch request the audout:u interface two times (first in the menu and the second time in game). Using the Subv solution seems to solve this problem, however, if one APP can indeed request the audout:u interface N times as well as work with them at the same time (i.e: Append samples buffers to be played) the current solution isn't the ideal and would have many issues. A possible solution for the previous problem would be keep the things as were before (creating a new interface every time) and create another class (like Mixer) that would handle and deal with all samples update to the sink and trigger the signal for the event handles when the buffer is Released.

2. Current implementation of the Append/Released Buffers:
Here is something that is really is bothering me about the libtransistor implementation of Append/Released AudioOut. It currently uses something called "key" to identify which buffer was released. Turns out the key is actually an address in the App VA, this address is send through IPC in the AppendAudioOutBuffer_1 together with the structure that hold information about the samples to be played, later, when the samples is played and the event handle is signaled, this address is returned through the GetReleasedAudioOutBuffer_1 and is used by a pointer in the libtransistor that will be feed with samples information and send again through the AppendAudioOutBuffer_1. Honestly I don't think that this is a normal behavior (to leak an address to another process) and would be glad to know if you guys think the same or no ?

Anyway there are a lot of stuff to be changed, I've left few TODO that I'll eventually work on it (i.e: number of channels, as we're using always 2 because this is what libtransistor example enforces us to do and I believe Switch when docked has more than only two channels).

Oh! if you guys can test this commit as well (I've tried only with RetroArch + Sonic and libtransistor example) I'd be glad :) 

