### PR TITLE
Fix time returning epoch time in milliseconds rather than in seconds

### DIFF
--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -25,7 +25,7 @@ public:
 
 private:
     void GetCurrentTime(Kernel::HLERequestContext& ctx) {
-        const s64 time_since_epoch{std::chrono::duration_cast<std::chrono::milliseconds>(
+        const s64 time_since_epoch{std::chrono::duration_cast<std::chrono::seconds>(
                                        std::chrono::system_clock::now().time_since_epoch())
                                        .count()};
         IPC::RequestBuilder rb{ctx, 4};


### PR DESCRIPTION
The epoch time is the total of seconds since January 1 of 1970, not milliseconds. This fixes the clock on RetroArch, however the time zone is still wrong. I don't know whenever GetCurrentTime is supposed to return the UTC+0 time zone and the app is supposed to convert it to the correct time zone (what it does now, and I believe that is the correct behaviour), or if GetCurrentTime returns the epoch value relative to the system time zone.