### PR TITLE
time: Implement ISteadyClock::GetCurrentTimePoint

### DIFF
--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include "common/logging/log.h"
+#include "core/core_timing.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/client_session.h"
@@ -45,7 +46,21 @@ private:
 
 class ISteadyClock final : public ServiceFramework<ISteadyClock> {
 public:
-    ISteadyClock() : ServiceFramework("ISteadyClock") {}
+    ISteadyClock() : ServiceFramework("ISteadyClock") {
+        static const FunctionInfo functions[] = {
+            {0, &ISteadyClock::GetCurrentTimePoint, "GetCurrentTimePoint"},
+        };
+        RegisterHandlers(functions);
+    }
+
+private:
+    void GetCurrentTimePoint(Kernel::HLERequestContext& ctx) {
+        LOG_DEBUG(Service, "called");
+        SteadyClockTimePoint steady_clock_time_point{cyclesToMs(CoreTiming::GetTicks()) / 1000};
+        IPC::ResponseBuilder rb{ctx, (sizeof(SteadyClockTimePoint) / 4) + 2};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushRaw(steady_clock_time_point);
+    }
 };
 
 class ITimeZoneService final : public ServiceFramework<ITimeZoneService> {

--- a/src/core/hle/service/time/time.h
+++ b/src/core/hle/service/time/time.h
@@ -40,6 +40,12 @@ struct SystemClockContext {
 static_assert(sizeof(SystemClockContext) == 0x20,
               "SystemClockContext structure has incorrect size");
 
+struct SteadyClockTimePoint {
+    u64 value;
+    INSERT_PADDING_WORDS(4);
+};
+static_assert(sizeof(SteadyClockTimePoint) == 0x18, "SteadyClockTimePoint is incorrect size");
+
 class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {


### PR DESCRIPTION
This is used to get a consistent time, regardless of user time settings, time zone, etc.