### PR TITLE
Install Linux icon in hicolor instead of pixmaps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,7 +423,7 @@ if(ENABLE_QT AND UNIX AND NOT APPLE)
     install(FILES "${CMAKE_SOURCE_DIR}/dist/yuzu.desktop"
             DESTINATION "${CMAKE_INSTALL_PREFIX}/share/applications")
     install(FILES "${CMAKE_SOURCE_DIR}/dist/yuzu.svg"
-            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/pixmaps")
+            DESTINATION "${CMAKE_INSTALL_PREFIX}/share/icons/hicolor/scalable/apps")
     install(FILES "${CMAKE_SOURCE_DIR}/dist/yuzu.xml"
             DESTINATION "${CMAKE_INSTALL_PREFIX}/share/mime/packages")
 endif()


### PR DESCRIPTION
hicolor is the preferred location for applications. See https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html#directory_layout

Same as https://github.com/citra-emu/citra/pull/3007