### PR TITLE
Added webhook notifications to TravisCI build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,3 +42,8 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
+
+notifications:
+  webhooks:
+    urls:
+      - https://api.yuzu-emu.org/code/travis/notify


### PR DESCRIPTION
This will add a new API endpoint for TravisCI builds.
https://docs.travis-ci.com/user/notifications/#Configuring-webhook-notifications

This will be used in the future for notification of build status.