### PR TITLE
travis: Remove CMAKE_OSX_ARCHITECTURES argument

### DIFF
--- a/.travis/macos/build.sh
+++ b/.travis/macos/build.sh
@@ -8,7 +8,7 @@ export UNICORNDIR=$(pwd)/externals/unicorn
 
 mkdir build && cd build
 cmake --version
-cmake .. -DYUZU_BUILD_UNICORN=ON -DCMAKE_OSX_ARCHITECTURES="x86_64;x86_64h" -DCMAKE_BUILD_TYPE=Release
+cmake .. -DYUZU_BUILD_UNICORN=ON -DCMAKE_BUILD_TYPE=Release
 make -j4
 
 ctest -VV -C Release


### PR DESCRIPTION
Unicorn only builds a x86_64 library, without a x86_64h slice.

While you're able to link against x86_64-only dynamic libraries when building for x86_64h, the same isn't true for static libraries.