### PR TITLE
vi::CreateStrayLayer : add padding to request

### DIFF
--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -681,6 +681,7 @@ void IApplicationDisplayService::CreateStrayLayer(Kernel::HLERequestContext& ctx
 
     IPC::RequestParser rp{ctx};
     u32 flags = rp.Pop<u32>();
+    rp.Pop<u32>(); // padding
     u64 display_id = rp.Pop<u64>();
 
     auto& buffer = ctx.BufferDescriptorB()[0];


### PR DESCRIPTION
According to https://github.com/reswitched/libtransistor/blob/development/lib/ipc/vi.c#L240 request contains padding.
This PR lets "test_vi" pass