### PR TITLE
Services/vi: add vi:s and vi:u services

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -159,6 +159,10 @@ add_library(core STATIC
     hle/service/vi/vi.h
     hle/service/vi/vi_m.cpp
     hle/service/vi/vi_m.h
+    hle/service/vi/vi_s.cpp
+    hle/service/vi/vi_s.h
+    hle/service/vi/vi_u.cpp
+    hle/service/vi/vi_u.h
     hle/shared_page.cpp
     hle/shared_page.h
     hw/hw.cpp

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -11,6 +11,8 @@
 #include "core/hle/service/nvflinger/buffer_queue.h"
 #include "core/hle/service/vi/vi.h"
 #include "core/hle/service/vi/vi_m.h"
+#include "core/hle/service/vi/vi_s.h"
+#include "core/hle/service/vi/vi_u.h"
 #include "video_core/renderer_base.h"
 #include "video_core/video_core.h"
 
@@ -756,6 +758,8 @@ IApplicationDisplayService::IApplicationDisplayService(
 void InstallInterfaces(SM::ServiceManager& service_manager,
                        std::shared_ptr<NVFlinger::NVFlinger> nv_flinger) {
     std::make_shared<VI_M>(nv_flinger)->InstallAsService(service_manager);
+    std::make_shared<VI_S>(nv_flinger)->InstallAsService(service_manager);
+    std::make_shared<VI_U>(nv_flinger)->InstallAsService(service_manager);
 }
 
 } // namespace VI

--- a/src/core/hle/service/vi/vi_s.cpp
+++ b/src/core/hle/service/vi/vi_s.cpp
@@ -1,0 +1,31 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/logging/log.h"
+#include "core/hle/ipc_helpers.h"
+#include "core/hle/service/vi/vi.h"
+#include "core/hle/service/vi/vi_s.h"
+
+namespace Service {
+namespace VI {
+
+void VI_S::GetDisplayService(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service, "(STUBBED) called");
+
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    rb.Push(RESULT_SUCCESS);
+    rb.PushIpcInterface<IApplicationDisplayService>(nv_flinger);
+}
+
+VI_S::VI_S(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
+    : ServiceFramework("vi:s"), nv_flinger(std::move(nv_flinger)) {
+    static const FunctionInfo functions[] = {
+        {1, &VI_S::GetDisplayService, "GetDisplayService"},
+        {3, nullptr, "GetDisplayServiceWithProxyNameExchange"},
+    };
+    RegisterHandlers(functions);
+}
+
+} // namespace VI
+} // namespace Service

--- a/src/core/hle/service/vi/vi_s.h
+++ b/src/core/hle/service/vi/vi_s.h
@@ -1,0 +1,29 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace NVFlinger {
+class NVFlinger;
+}
+
+namespace VI {
+
+class VI_S final : public ServiceFramework<VI_S> {
+public:
+    VI_S(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+    ~VI_S() = default;
+
+private:
+    void GetDisplayService(Kernel::HLERequestContext& ctx);
+
+    std::shared_ptr<NVFlinger::NVFlinger> nv_flinger;
+};
+
+} // namespace VI
+} // namespace Service

--- a/src/core/hle/service/vi/vi_u.cpp
+++ b/src/core/hle/service/vi/vi_u.cpp
@@ -1,0 +1,31 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/logging/log.h"
+#include "core/hle/ipc_helpers.h"
+#include "core/hle/service/vi/vi.h"
+#include "core/hle/service/vi/vi_u.h"
+
+namespace Service {
+namespace VI {
+
+void VI_U::GetDisplayService(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service, "(STUBBED) called");
+
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    rb.Push(RESULT_SUCCESS);
+    rb.PushIpcInterface<IApplicationDisplayService>(nv_flinger);
+}
+
+VI_U::VI_U(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
+    : ServiceFramework("vi:u"), nv_flinger(std::move(nv_flinger)) {
+    static const FunctionInfo functions[] = {
+        {0, &VI_U::GetDisplayService, "GetDisplayService"},
+        {3, nullptr, "GetDisplayServiceWithProxyNameExchange"},
+    };
+    RegisterHandlers(functions);
+}
+
+} // namespace VI
+} // namespace Service

--- a/src/core/hle/service/vi/vi_u.h
+++ b/src/core/hle/service/vi/vi_u.h
@@ -1,0 +1,29 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace NVFlinger {
+class NVFlinger;
+}
+
+namespace VI {
+
+class VI_U final : public ServiceFramework<VI_U> {
+public:
+    VI_U(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+    ~VI_U() = default;
+
+private:
+    void GetDisplayService(Kernel::HLERequestContext& ctx);
+
+    std::shared_ptr<NVFlinger::NVFlinger> nv_flinger;
+};
+
+} // namespace VI
+} // namespace Service


### PR DESCRIPTION
This PR lets the game "Soldam: Drop, Connect, Erase" pass through next unimplemented service: nifm:u