### PR TITLE
Several SVC fixes and improvements

### DIFF
--- a/src/core/hle/kernel/condition_variable.cpp
+++ b/src/core/hle/kernel/condition_variable.cpp
@@ -15,13 +15,12 @@ ConditionVariable::ConditionVariable() {}
 ConditionVariable::~ConditionVariable() {}
 
 ResultVal<SharedPtr<ConditionVariable>> ConditionVariable::Create(VAddr guest_addr,
-                                                                  VAddr mutex_addr,
                                                                   std::string name) {
     SharedPtr<ConditionVariable> condition_variable(new ConditionVariable);
 
     condition_variable->name = std::move(name);
     condition_variable->guest_addr = guest_addr;
-    condition_variable->mutex_addr = mutex_addr;
+    condition_variable->mutex_addr = 0;
 
     // Condition variables are referenced by guest address, so track this in the kernel
     g_object_address_table.Insert(guest_addr, condition_variable);

--- a/src/core/hle/kernel/condition_variable.h
+++ b/src/core/hle/kernel/condition_variable.h
@@ -19,12 +19,10 @@ public:
      * Creates a condition variable.
      * @param guest_addr Address of the object tracking the condition variable in guest memory. If
      * specified, this condition variable will update the guest object when its state changes.
-     * @param mutex_addr Optional address of a guest mutex associated with this condition variable,
-     * used by the OS for implementing events.
      * @param name Optional name of condition variable.
      * @return The created condition variable.
      */
-    static ResultVal<SharedPtr<ConditionVariable>> Create(VAddr guest_addr, VAddr mutex_addr = 0,
+    static ResultVal<SharedPtr<ConditionVariable>> Create(VAddr guest_addr,
                                                           std::string name = "Unknown");
 
     std::string GetTypeName() const override {

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -14,7 +14,7 @@ namespace Kernel {
 SharedMemory::SharedMemory() {}
 SharedMemory::~SharedMemory() {}
 
-SharedPtr<SharedMemory> SharedMemory::Create(SharedPtr<Process> owner_process, u32 size,
+SharedPtr<SharedMemory> SharedMemory::Create(SharedPtr<Process> owner_process, u64 size,
                                              MemoryPermission permissions,
                                              MemoryPermission other_permissions, VAddr address,
                                              MemoryRegion region, std::string name) {

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -39,7 +39,7 @@ public:
      * linear heap.
      * @param name Optional object name, used for debugging purposes.
      */
-    static SharedPtr<SharedMemory> Create(SharedPtr<Process> owner_process, u32 size,
+    static SharedPtr<SharedMemory> Create(SharedPtr<Process> owner_process, u64 size,
                                           MemoryPermission permissions,
                                           MemoryPermission other_permissions, VAddr address = 0,
                                           MemoryRegion region = MemoryRegion::BASE,
@@ -116,7 +116,7 @@ public:
     /// Offset into the backing block for this shared memory.
     size_t backing_block_offset;
     /// Size of the memory block. Page-aligned.
-    u32 size;
+    u64 size;
     /// Permission restrictions applied to the process which created the block.
     MemoryPermission permissions;
     /// Permission restrictions applied to other processes mapping the block.

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -263,6 +263,7 @@ static ResultCode ArbitrateLock(Handle holding_thread_handle, VAddr mutex_addr,
     SharedPtr<Thread> requesting_thread = g_handle_table.Get<Thread>(requesting_thread_handle);
 
     ASSERT(requesting_thread);
+    ASSERT(requesting_thread == GetCurrentThread());
 
     SharedPtr<Mutex> mutex = g_object_address_table.Get<Mutex>(mutex_addr);
     if (!mutex) {

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -332,6 +332,9 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
     case GetInfoType::TotalHeapUsage:
         *result = vm_manager.GetTotalHeapUsage();
         break;
+    case GetInfoType::IsCurrentProcessBeingDebugged:
+        *result = 0;
+        break;
     case GetInfoType::RandomEntropy:
         *result = 0;
         break;


### PR DESCRIPTION
* svcGetInfo: Implement IsCurrentProcessBeingDebugged.
* svcWaitProcessWideKeyAtomic: Handle scenario where condition variable was already created by svcSignalProcessWideKey and doesn't have a mutex set, and furthermore cleanup some asserts.
* SharedMemory: Fix some warnings with u64 -> u32.
* svcArbitrateLock: Assert that requesting_thread is current_thread, as any other usage of this does not really make sense.


