### PR TITLE
Changed .istorage to .romfs

### DIFF
--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -29,7 +29,7 @@ static std::string FindRomFS(const std::string& directory) {
 
         // Verify extension
         const std::string extension = physical_name.substr(physical_name.find_last_of(".") + 1);
-        if (Common::ToLower(extension) != "istorage") {
+        if (Common::ToLower(extension) != "romfs") {
             return true;
         }
 
@@ -38,7 +38,7 @@ static std::string FindRomFS(const std::string& directory) {
         return false;
     };
 
-    // Search the specified directory recursively, looking for the first .istorage file, which will
+    // Search the specified directory recursively, looking for the first .romfs file, which will
     // be used for the RomFS
     FileUtil::ForeachDirectoryEntry(nullptr, directory, callback);
 
@@ -128,10 +128,10 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(
         Kernel::ResourceLimit::GetForCategory(Kernel::ResourceLimitCategory::APPLICATION);
     process->Run(Memory::PROCESS_IMAGE_VADDR, 48, Kernel::DEFAULT_STACK_SIZE);
 
-    // Find the RomFS by searching for a ".istorage" file in this directory
+    // Find the RomFS by searching for a ".romfs" file in this directory
     filepath_romfs = FindRomFS(directory);
 
-    // Register the RomFS if a ".istorage" file was found
+    // Register the RomFS if a ".romfs" file was found
     if (!filepath_romfs.empty()) {
         Service::FileSystem::RegisterFileSystem(std::make_unique<FileSys::RomFS_Factory>(*this),
                                                 Service::FileSystem::Type::RomFS);

--- a/src/core/loader/deconstructed_rom_directory.h
+++ b/src/core/loader/deconstructed_rom_directory.h
@@ -15,7 +15,7 @@ namespace Loader {
  * This class loads a "deconstructed ROM directory", which are the typical format we see for Switch
  * game dumps. The path should be a "main" NSO, which must be in a directory that contains the other
  * standard ExeFS NSOs (e.g. rtld, sdk, etc.). It will automatically find and load these.
- * Furthermore, it will look for the first .istorage file (optionally) and use this for the RomFS.
+ * Furthermore, it will look for the first .romfs file (optionally) and use this for the RomFS.
  */
 class AppLoader_DeconstructedRomDirectory final : public AppLoader {
 public:


### PR DESCRIPTION
IStorage is a completely incorrect term for RomFS and should be changed early on to get out of this horrible naming habbit. IStorage is the api/interface used to read RomFS and this can create confusion. As we're loading the "RomFS" of files, we really should name them so. IStorage as a whole can be referred to different parts of the system which use the same interface. Example of such things from the FileSystem which use the IStorage interface can include, OpenBisPartition and OpenDataStorage which are clearly not "RomFS".