### PR TITLE
Don't call UNIMPLEMENTED for 'empty services', just return error code

### DIFF
--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -103,6 +103,8 @@ void SM::GetService(Kernel::HLERequestContext& ctx) {
         rb.Push(client_port.Code());
         LOG_ERROR(Service_SM, "called service=%s -> error 0x%08X", name.c_str(),
                   client_port.Code().raw);
+        if (name.length() == 0)
+            return; // LibNX Fix
         UNIMPLEMENTED();
         return;
     }


### PR DESCRIPTION
LibNX sends an empty service name just to check if sm: is initialized. If we return any error code(returning 0x415 will just call sm:initialize), libnx continues to work as intended.

See https://github.com/switchbrew/libnx/blob/master/nx/source/services/sm.c#L57