### PR TITLE
Stubs for HID, AM, and a mutex fix

### DIFF
--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -70,6 +70,7 @@ ResultCode Mutex::Release(Thread* thread) {
     holding_thread->held_mutexes.erase(this);
     holding_thread->UpdatePriority();
     SetHoldingThread(nullptr);
+    SetHasWaiters(!GetWaitingThreads().empty());
     WakeupAllWaitingThreads();
     Core::System::GetInstance().PrepareReschedule();
 

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -270,6 +270,7 @@ private:
 IApplicationFunctions::IApplicationFunctions() : ServiceFramework("IApplicationFunctions") {
     static const FunctionInfo functions[] = {
         {1, &IApplicationFunctions::PopLaunchParameter, "PopLaunchParameter"},
+        {20, &IApplicationFunctions::EnsureSaveData, "EnsureSaveData"},
         {21, &IApplicationFunctions::GetDesiredLanguage, "GetDesiredLanguage"},
         {22, &IApplicationFunctions::SetTerminateResult, "SetTerminateResult"},
         {66, &IApplicationFunctions::InitializeGamePlayRecording, "InitializeGamePlayRecording"},
@@ -297,6 +298,12 @@ void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
     rb.PushIpcInterface<AM::IStorage>(buffer);
 
     LOG_DEBUG(Service_AM, "called");
+}
+
+void IApplicationFunctions::EnsureSaveData(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service, "(STUBBED) called");
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(RESULT_SUCCESS);
 }
 
 void IApplicationFunctions::SetTerminateResult(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -100,6 +100,7 @@ public:
 
 private:
     void PopLaunchParameter(Kernel::HLERequestContext& ctx);
+    void EnsureSaveData(Kernel::HLERequestContext& ctx);
     void SetTerminateResult(Kernel::HLERequestContext& ctx);
     void GetDesiredLanguage(Kernel::HLERequestContext& ctx);
     void InitializeGamePlayRecording(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -174,12 +174,12 @@ public:
         static const FunctionInfo functions[] = {
             {0, &Hid::CreateAppletResource, "CreateAppletResource"},
             {1, &Hid::ActivateDebugPad, "ActivateDebugPad"},
-            {11, nullptr, "ActivateTouchScreen"},
+            {11, &Hid::ActivateTouchScreen, "ActivateTouchScreen"},
             {66, &Hid::StartSixAxisSensor, "StartSixAxisSensor"},
             {100, &Hid::SetSupportedNpadStyleSet, "SetSupportedNpadStyleSet"},
             {102, &Hid::SetSupportedNpadIdType, "SetSupportedNpadIdType"},
             {103, &Hid::ActivateNpad, "ActivateNpad"},
-            {120, nullptr, "SetNpadJoyHoldType"},
+            {120, &Hid::SetNpadJoyHoldType, "SetNpadJoyHoldType"},
             {124, nullptr, "SetNpadJoyAssignmentModeDual"},
             {203, &Hid::CreateActiveVibrationDeviceList, "CreateActiveVibrationDeviceList"},
         };
@@ -207,6 +207,12 @@ private:
         LOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
+    void ActivateTouchScreen(Kernel::HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+        LOG_WARNING(Service_HID, "(STUBBED) called");
+    }
+
     void StartSixAxisSensor(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -226,6 +232,12 @@ private:
     }
 
     void ActivateNpad(Kernel::HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+        LOG_WARNING(Service_HID, "(STUBBED) called");
+    }
+
+    void SetNpadJoyHoldType(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
         LOG_WARNING(Service_HID, "(STUBBED) called");


### PR DESCRIPTION
Various fixes to get Puyo Puyo Tetris booting. These include:
* Stubbing some HID functions
* Stubbing an AM function
* Updating mutex `hasWaiters` state on release