### PR TITLE
VI cleanup and add a hack for booting games

### DIFF
--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -262,6 +262,11 @@ public:
     Data data;
 };
 
+// TODO(bunnei): Remove this. When set to 1, games will think a fence is valid and boot further.
+// This will break libnx and potentially other apps that more stringently check this. This is here
+// purely as a convenience, and should go away once we implement fences.
+static constexpr u32 FENCE_HACK = 0;
+
 class IGBPDequeueBufferResponseParcel : public Parcel {
 public:
     explicit IGBPDequeueBufferResponseParcel(u32 slot) : Parcel(), slot(slot) {}
@@ -269,11 +274,20 @@ public:
 
 protected:
     void SerializeData() override {
-        Write(slot);
-        // TODO(Subv): Find out how this Fence is used.
-        std::array<u32_le, 11> fence = {};
-        Write(fence);
-        Write<u32_le>(0);
+        // TODO(bunnei): Find out what this all means. Writing anything non-zero here breaks libnx.
+        Write<u32>(0);
+        Write<u32>(FENCE_HACK);
+        Write<u32>(0);
+        Write<u32>(0);
+        Write<u32>(0);
+        Write<u32>(0);
+        Write<u32>(0);
+        Write<u32>(0);
+        Write<u32>(0);
+        Write<u32>(0);
+        Write<u32>(0);
+        Write<u32>(0);
+        Write<u32>(0);
     }
 
     u32_le slot;
@@ -304,7 +318,7 @@ protected:
     void SerializeData() override {
         // TODO(bunnei): Find out what this all means. Writing anything non-zero here breaks libnx.
         Write<u32_le>(0);
-        Write<u32_le>(0);
+        Write<u32_le>(FENCE_HACK);
         Write<u32_le>(0);
         Write(buffer);
         Write<u32_le>(0);
@@ -560,7 +574,7 @@ private:
     }
 
     std::shared_ptr<NVFlinger::NVFlinger> nv_flinger;
-};
+}; // namespace VI
 
 class ISystemDisplayService final : public ServiceFramework<ISystemDisplayService> {
 public:

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -442,18 +442,20 @@ private:
     void TransactParcel(u32 id, TransactionId transaction, const std::vector<u8>& input_data,
                         VAddr output_addr, u64 output_size) {
         auto buffer_queue = nv_flinger->GetBufferQueue(id);
-        std::vector<u8> response_buffer;
+
         if (transaction == TransactionId::Connect) {
             IGBPConnectRequestParcel request{input_data};
             IGBPConnectResponseParcel response{1280, 720};
-            response_buffer = response.Serialize();
+            std::vector<u8> response_buffer = response.Serialize();
+            Memory::WriteBlock(output_addr, response_buffer.data(), response_buffer.size());
         } else if (transaction == TransactionId::SetPreallocatedBuffer) {
             IGBPSetPreallocatedBufferRequestParcel request{input_data};
 
             buffer_queue->SetPreallocatedBuffer(request.data.slot, request.buffer);
 
             IGBPSetPreallocatedBufferResponseParcel response{};
-            response_buffer = response.Serialize();
+            std::vector<u8> response_buffer = response.Serialize();
+            Memory::WriteBlock(output_addr, response_buffer.data(), response_buffer.size());
         } else if (transaction == TransactionId::DequeueBuffer) {
             IGBPDequeueBufferRequestParcel request{input_data};
 
@@ -461,21 +463,24 @@ private:
                                                    request.data.height);
 
             IGBPDequeueBufferResponseParcel response{slot};
-            response_buffer = response.Serialize();
+            std::vector<u8> response_buffer = response.Serialize();
+            Memory::WriteBlock(output_addr, response_buffer.data(), response_buffer.size());
         } else if (transaction == TransactionId::RequestBuffer) {
             IGBPRequestBufferRequestParcel request{input_data};
 
             auto& buffer = buffer_queue->RequestBuffer(request.slot);
 
             IGBPRequestBufferResponseParcel response{buffer};
-            response_buffer = response.Serialize();
+            std::vector<u8> response_buffer = response.Serialize();
+            Memory::WriteBlock(output_addr, response_buffer.data(), response_buffer.size());
         } else if (transaction == TransactionId::QueueBuffer) {
             IGBPQueueBufferRequestParcel request{input_data};
 
             buffer_queue->QueueBuffer(request.data.slot, request.data.transform);
 
             IGBPQueueBufferResponseParcel response{1280, 720};
-            response_buffer = response.Serialize();
+            std::vector<u8> response_buffer = response.Serialize();
+            Memory::WriteBlock(output_addr, response_buffer.data(), response_buffer.size());
         } else if (transaction == TransactionId::Query) {
             IGBPQueryRequestParcel request{input_data};
 
@@ -483,13 +488,11 @@ private:
                 buffer_queue->Query(static_cast<NVFlinger::BufferQueue::QueryType>(request.type));
 
             IGBPQueryResponseParcel response{value};
-            response_buffer = response.Serialize();
-
+            std::vector<u8> response_buffer = response.Serialize();
+            Memory::WriteBlock(output_addr, response_buffer.data(), response_buffer.size());
         } else {
             ASSERT_MSG(false, "Unimplemented");
         }
-
-        Memory::WriteBlock(output_addr, response_buffer.data(), output_size);
     }
 
     void TransactParcel(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -490,6 +490,8 @@ private:
             IGBPQueryResponseParcel response{value};
             std::vector<u8> response_buffer = response.Serialize();
             Memory::WriteBlock(output_addr, response_buffer.data(), response_buffer.size());
+        } else if (transaction == TransactionId::CancelBuffer) {
+            LOG_WARNING(Service_VI, "(STUBBED) called, transaction=CancelBuffer");
         } else {
             ASSERT_MSG(false, "Unimplemented");
         }


### PR DESCRIPTION
This PR has a little bit more VI cleanup, and more notably a small hack for booting commercial games. I added a const for `FENCE_HACK`, which, when set to non-zero, will stub several Parcel responses such that games think their is a valid fence. This will get them running much further. This also breaks libnx, which more stringently checks the responses.
When zero, things will remain as-is in the world.

Why introduce this?
1. By default, the hack is off - so hopefully there is no pollution
2. Several devs internally are using the same hack (but it's much broader scoped and they don't know what is actually happening, just that it helps games boot) - So this puts us all on the same page
3. This scopes the root issue much more narrowly, so it's a step forward in a proper fix/implementation
