### PR TITLE
pl_u: Stub out interface for accessing shared font.

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -124,6 +124,8 @@ add_library(core STATIC
     hle/service/nifm/nifm_s.h
     hle/service/nifm/nifm_u.cpp
     hle/service/nifm/nifm_u.h
+    hle/service/ns/pl_u.cpp
+    hle/service/ns/pl_u.h
     hle/service/nvdrv/devices/nvdevice.h
     hle/service/nvdrv/devices/nvdisp_disp0.cpp
     hle/service/nvdrv/devices/nvdisp_disp0.h

--- a/src/core/hle/service/ns/pl_u.cpp
+++ b/src/core/hle/service/ns/pl_u.cpp
@@ -1,0 +1,59 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/ipc_helpers.h"
+#include "core/hle/service/ns/pl_u.h"
+
+namespace Service {
+namespace NS {
+
+static constexpr u64 SHARED_FONT_SIZE{0x2000}; // TODO(bunnei): Find the correct value for this
+
+void InstallInterfaces(SM::ServiceManager& service_manager) {
+    std::make_shared<PL_U>()->InstallAsService(service_manager);
+}
+
+PL_U::PL_U() : ServiceFramework("pl:u") {
+    static const FunctionInfo functions[] = {
+        {1, &PL_U::GetLoadState, "GetLoadState"},
+        {2, &PL_U::GetSize, "GetSize"},
+        {3, &PL_U::GetSharedMemoryAddressOffset, "GetSharedMemoryAddressOffset"},
+        {4, &PL_U::GetSharedMemoryNativeHandle, "GetSharedMemoryNativeHandle"}};
+    RegisterHandlers(functions);
+
+    shared_mem = Kernel::SharedMemory::Create(
+        Kernel::g_current_process, SHARED_FONT_SIZE, Kernel::MemoryPermission::ReadWrite,
+        Kernel::MemoryPermission::Read, 0, Kernel::MemoryRegion::BASE, "PL_U:SharedMemory");
+}
+
+void PL_U::GetLoadState(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service, "(STUBBED) called");
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(RESULT_SUCCESS);
+    rb.Push<u32>(1); // 0 = Loading, 1 = Loaded
+}
+
+void PL_U::GetSize(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service, "(STUBBED) called");
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(RESULT_SUCCESS);
+    rb.Push<u32>(SHARED_FONT_SIZE);
+}
+
+void PL_U::GetSharedMemoryAddressOffset(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service, "(STUBBED) called");
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(RESULT_SUCCESS);
+    rb.Push<u32>(0x1000);
+}
+
+void PL_U::GetSharedMemoryNativeHandle(Kernel::HLERequestContext& ctx) {
+    LOG_DEBUG(Service, "called");
+    IPC::ResponseBuilder rb{ctx, 2, 1};
+    rb.Push(RESULT_SUCCESS);
+    rb.PushCopyObjects(shared_mem);
+}
+
+} // namespace NS
+} // namespace Service

--- a/src/core/hle/service/ns/pl_u.h
+++ b/src/core/hle/service/ns/pl_u.h
@@ -1,0 +1,32 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/kernel/shared_memory.h"
+#include "core/hle/service/service.h"
+
+namespace Service {
+namespace NS {
+
+class PL_U final : public ServiceFramework<PL_U> {
+public:
+    PL_U();
+    ~PL_U() = default;
+
+private:
+    void GetLoadState(Kernel::HLERequestContext& ctx);
+    void GetSize(Kernel::HLERequestContext& ctx);
+    void GetSharedMemoryAddressOffset(Kernel::HLERequestContext& ctx);
+    void GetSharedMemoryNativeHandle(Kernel::HLERequestContext& ctx);
+
+    // Handle to shared memory region designated for a shared font
+    Kernel::SharedPtr<Kernel::SharedMemory> shared_mem;
+};
+
+/// Registers all AOC services with the specified service manager.
+void InstallInterfaces(SM::ServiceManager& service_manager);
+
+} // namespace NS
+} // namespace Service

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -23,6 +23,7 @@
 #include "core/hle/service/hid/hid.h"
 #include "core/hle/service/lm/lm.h"
 #include "core/hle/service/nifm/nifm.h"
+#include "core/hle/service/ns/pl_u.h"
 #include "core/hle/service/nvdrv/nvdrv.h"
 #include "core/hle/service/pctl/pctl.h"
 #include "core/hle/service/service.h"
@@ -182,6 +183,7 @@ void Init() {
     HID::InstallInterfaces(*SM::g_service_manager);
     LM::InstallInterfaces(*SM::g_service_manager);
     NIFM::InstallInterfaces(*SM::g_service_manager);
+    NS::InstallInterfaces(*SM::g_service_manager);
     Nvidia::InstallInterfaces(*SM::g_service_manager);
     PCTL::InstallInterfaces(*SM::g_service_manager);
     Sockets::InstallInterfaces(*SM::g_service_manager);


### PR DESCRIPTION
Stubs out the interface for pl:u (shared font access). Used by Puyo Puyo Tetris. We'll likely need to put a real font here.