### PR TITLE
Removes the use of QKeySequence::Cancel

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -187,7 +187,7 @@ void GMainWindow::InitializeHotkeys() {
     RegisterHotkey("Main Window", "Load File", QKeySequence::Open);
     RegisterHotkey("Main Window", "Start Emulation");
     RegisterHotkey("Main Window", "Fullscreen", QKeySequence::FullScreen);
-    RegisterHotkey("Main Window", "Exit Fullscreen", QKeySequence::Cancel, Qt::ApplicationShortcut);
+    RegisterHotkey("Main Window", "Exit Fullscreen", QKeySequence(Qt::Key_Escape), Qt::ApplicationShortcut);
     LoadHotkeys();
 
     connect(GetHotkey("Main Window", "Load File", this), &QShortcut::activated, this,

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -187,7 +187,8 @@ void GMainWindow::InitializeHotkeys() {
     RegisterHotkey("Main Window", "Load File", QKeySequence::Open);
     RegisterHotkey("Main Window", "Start Emulation");
     RegisterHotkey("Main Window", "Fullscreen", QKeySequence::FullScreen);
-    RegisterHotkey("Main Window", "Exit Fullscreen", QKeySequence(Qt::Key_Escape), Qt::ApplicationShortcut);
+    RegisterHotkey("Main Window", "Exit Fullscreen", QKeySequence(Qt::Key_Escape),
+                    Qt::ApplicationShortcut);
     LoadHotkeys();
 
     connect(GetHotkey("Main Window", "Load File", this), &QShortcut::activated, this,

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -188,7 +188,7 @@ void GMainWindow::InitializeHotkeys() {
     RegisterHotkey("Main Window", "Start Emulation");
     RegisterHotkey("Main Window", "Fullscreen", QKeySequence::FullScreen);
     RegisterHotkey("Main Window", "Exit Fullscreen", QKeySequence(Qt::Key_Escape),
-                    Qt::ApplicationShortcut);
+                   Qt::ApplicationShortcut);
     LoadHotkeys();
 
     connect(GetHotkey("Main Window", "Load File", this), &QShortcut::activated, this,


### PR DESCRIPTION
This pull request is for removal of usage of QKeySequence::Cancel and thus eliminate the issues which can potentially be faced while running make. (I faced it in initial cloning and installation)