### PR TITLE
Refactor IPC buffer descriptor interface

### DIFF
--- a/src/core/hle/ipc.h
+++ b/src/core/hle/ipc.h
@@ -91,6 +91,10 @@ struct BufferDescriptorX {
         address |= static_cast<VAddr>(address_bits_36_38) << 36;
         return address;
     }
+
+    u64 Size() const {
+        return static_cast<u64>(size);
+    }
 };
 static_assert(sizeof(BufferDescriptorX) == 8, "BufferDescriptorX size is incorrect");
 

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -229,6 +229,8 @@ std::vector<u8> HLERequestContext::ReadBuffer() const {
 size_t HLERequestContext::WriteBuffer(const void* buffer, const size_t size) const {
     const bool is_buffer_b{BufferDescriptorB().size() && BufferDescriptorB()[0].Size()};
 
+    ASSERT_MSG(size <= GetWriteBufferSize(), "Size %d is too big", size);
+
     if (is_buffer_b) {
         Memory::WriteBlock(BufferDescriptorB()[0].Address(), buffer, size);
     } else {
@@ -240,6 +242,11 @@ size_t HLERequestContext::WriteBuffer(const void* buffer, const size_t size) con
 
 size_t HLERequestContext::WriteBuffer(const std::vector<u8>& buffer) const {
     return WriteBuffer(buffer.data(), buffer.size());
+}
+
+size_t HLERequestContext::GetReadBufferSize() const {
+    const bool is_buffer_a{BufferDescriptorA().size() && BufferDescriptorA()[0].Size()};
+    return is_buffer_a ? BufferDescriptorA()[0].Size() : BufferDescriptorX()[0].Size();
 }
 
 size_t HLERequestContext::GetWriteBufferSize() const {

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -226,7 +226,7 @@ std::vector<u8> HLERequestContext::ReadBuffer() const {
     return buffer;
 }
 
-size_t HLERequestContext::WriteBuffer(const void* buffer, const size_t size) const {
+size_t HLERequestContext::WriteBuffer(const void* buffer, size_t size) const {
     const bool is_buffer_b{BufferDescriptorB().size() && BufferDescriptorB()[0].Size()};
 
     ASSERT_MSG(size <= GetWriteBufferSize(), "Size %d is too big", size);

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -12,6 +12,7 @@
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/server_session.h"
+#include "core/memory.h"
 
 namespace Kernel {
 
@@ -208,6 +209,44 @@ ResultCode HLERequestContext::WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf, P
         }
     }
     return RESULT_SUCCESS;
+}
+
+std::vector<u8> HLERequestContext::ReadBuffer() const {
+    std::vector<u8> buffer;
+    const bool is_buffer_a{BufferDescriptorA().size() && BufferDescriptorA()[0].Size()};
+
+    if (is_buffer_a) {
+        buffer.resize(BufferDescriptorA()[0].Size());
+        Memory::ReadBlock(BufferDescriptorA()[0].Address(), buffer.data(), buffer.size());
+    } else {
+        buffer.resize(BufferDescriptorX()[0].Size());
+        Memory::ReadBlock(BufferDescriptorX()[0].Address(), buffer.data(), buffer.size());
+    }
+
+    return buffer;
+}
+
+size_t HLERequestContext::WriteBuffer(const void* buffer, const size_t size) const {
+    const bool is_buffer_b{BufferDescriptorB().size() && BufferDescriptorB()[0].Size()};
+
+    if (is_buffer_b) {
+        const size_t size{std::min(BufferDescriptorB()[0].Size(), size)};
+        Memory::WriteBlock(BufferDescriptorB()[0].Address(), buffer, size);
+        return size;
+    } else {
+        const size_t size{std::min(BufferDescriptorC()[0].Size(), size)};
+        Memory::WriteBlock(BufferDescriptorC()[0].Address(), buffer, size);
+        return size;
+    }
+}
+
+size_t HLERequestContext::WriteBuffer(const std::vector<u8>& buffer) const {
+    return WriteBuffer(buffer.data(), buffer.size());
+}
+
+size_t HLERequestContext::GetWriteBufferSize() const {
+    const bool is_buffer_b{BufferDescriptorB().size() && BufferDescriptorB()[0].Size()};
+    return is_buffer_b ? BufferDescriptorB()[0].Size() : BufferDescriptorC()[0].Size();
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -230,14 +230,12 @@ size_t HLERequestContext::WriteBuffer(const void* buffer, const size_t size) con
     const bool is_buffer_b{BufferDescriptorB().size() && BufferDescriptorB()[0].Size()};
 
     if (is_buffer_b) {
-        const size_t size{std::min(BufferDescriptorB()[0].Size(), size)};
         Memory::WriteBlock(BufferDescriptorB()[0].Address(), buffer, size);
-        return size;
     } else {
-        const size_t size{std::min(BufferDescriptorC()[0].Size(), size)};
         Memory::WriteBlock(BufferDescriptorC()[0].Address(), buffer, size);
-        return size;
     }
+
+    return size;
 }
 
 size_t HLERequestContext::WriteBuffer(const std::vector<u8>& buffer) const {

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -152,6 +152,9 @@ public:
     /// Helper function to write a buffer using the appropriate buffer descriptor
     size_t WriteBuffer(const std::vector<u8>& buffer) const;
 
+    /// Helper function to get the size of the input buffer
+    size_t GetReadBufferSize() const;
+
     /// Helper function to get the size of the output buffer
     size_t GetWriteBufferSize() const;
 

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -147,7 +147,7 @@ public:
     std::vector<u8> ReadBuffer() const;
 
     /// Helper function to write a buffer using the appropriate buffer descriptor
-    size_t WriteBuffer(const void* buffer, const size_t size) const;
+    size_t WriteBuffer(const void* buffer, size_t size) const;
 
     /// Helper function to write a buffer using the appropriate buffer descriptor
     size_t WriteBuffer(const std::vector<u8>& buffer) const;

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -143,6 +143,18 @@ public:
         return domain_message_header;
     }
 
+    /// Helper function to read a buffer using the appropriate buffer descriptor
+    std::vector<u8> ReadBuffer() const;
+
+    /// Helper function to write a buffer using the appropriate buffer descriptor
+    size_t WriteBuffer(const void* buffer, const size_t size) const;
+
+    /// Helper function to write a buffer using the appropriate buffer descriptor
+    size_t WriteBuffer(const std::vector<u8>& buffer) const;
+
+    /// Helper function to get the size of the output buffer
+    size_t GetWriteBufferSize() const;
+
     template <typename T>
     SharedPtr<T> GetCopyObject(size_t index) {
         ASSERT(index < copy_objects.size());

--- a/src/core/hle/service/acc/acc_u0.cpp
+++ b/src/core/hle/service/acc/acc_u0.cpp
@@ -66,8 +66,7 @@ void ACC_U0::GetUserExistence(Kernel::HLERequestContext& ctx) {
 
 void ACC_U0::ListAllUsers(Kernel::HLERequestContext& ctx) {
     constexpr std::array<u128, 10> user_ids{DEFAULT_USER_ID};
-    const auto& output_buffer = ctx.BufferDescriptorC()[0];
-    Memory::WriteBlock(output_buffer.Address(), user_ids.data(), user_ids.size());
+    ctx.WriteBuffer(user_ids.data(), user_ids.size());
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
     LOG_DEBUG(Service_ACC, "called");

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -306,11 +306,11 @@ private:
 
         u64 offset = rp.Pop<u64>();
 
-        const auto& output_buffer = ctx.BufferDescriptorC()[0];
+        const size_t size{ctx.GetWriteBufferSize()};
 
-        ASSERT(offset + output_buffer.Size() <= buffer.size());
+        ASSERT(offset + size <= buffer.size());
 
-        Memory::WriteBlock(output_buffer.Address(), buffer.data() + offset, output_buffer.Size());
+        ctx.WriteBuffer(buffer.data() + offset, size);
 
         IPC::ResponseBuilder rb{ctx, 2};
 

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -99,8 +99,6 @@ private:
     void GetReleasedAudioOutBuffer_1(Kernel::HLERequestContext& ctx) {
         LOG_WARNING(Service_Audio, "(STUBBED) called");
 
-        const auto& buffer = ctx.BufferDescriptorB()[0];
-
         // TODO(st4rk): This is how libtransistor currently implements the
         // GetReleasedAudioOutBuffer, it should return the key (a VAddr) to the app and this address
         // is used to know which buffer should be filled with data and send again to the service
@@ -112,7 +110,7 @@ private:
             queue_keys.pop_back();
         }
 
-        Memory::WriteBlock(buffer.Address(), &key, sizeof(u64));
+        ctx.WriteBuffer(&key, sizeof(u64));
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
@@ -158,10 +156,8 @@ void AudOutU::ListAudioOuts(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_Audio, "(STUBBED) called");
     IPC::RequestParser rp{ctx};
 
-    auto& buffer = ctx.BufferDescriptorB()[0];
     const std::string audio_interface = "AudioInterface";
-
-    Memory::WriteBlock(buffer.Address(), &audio_interface[0], audio_interface.size());
+    ctx.WriteBuffer(audio_interface.c_str(), audio_interface.size());
 
     IPC::ResponseBuilder rb = rp.MakeBuilder(3, 0, 0);
 

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -69,9 +69,7 @@ private:
             response_data.state_entries[i].state = 5;
         }
 
-        auto& buffer = ctx.BufferDescriptorB()[0];
-
-        Memory::WriteBlock(buffer.Address(), &response_data, response_data.total_size);
+        ctx.WriteBuffer(&response_data, response_data.total_size);
 
         IPC::ResponseBuilder rb{ctx, 2};
 

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -33,12 +33,10 @@ private:
         IPC::RequestParser rp{ctx};
         const s64 offset = rp.Pop<s64>();
         const s64 length = rp.Pop<s64>();
-        const auto& descriptor = ctx.BufferDescriptorB()[0];
 
         LOG_DEBUG(Service_FS, "called, offset=0x%llx, length=0x%llx", offset, length);
 
         // Error checking
-        ASSERT_MSG(length == descriptor.Size(), "unexpected size difference");
         if (length < 0) {
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ResultCode(ErrorModule::FS, ErrorDescription::InvalidLength));
@@ -60,7 +58,7 @@ private:
         }
 
         // Write the data to memory
-        Memory::WriteBlock(descriptor.Address(), output.data(), descriptor.Size());
+        ctx.WriteBuffer(output);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/nvdrv/interface.cpp
+++ b/src/core/hle/service/nvdrv/interface.cpp
@@ -14,9 +14,8 @@ namespace Nvidia {
 void NVDRV::Open(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_NVDRV, "called");
 
-    auto buffer = ctx.BufferDescriptorA()[0];
-
-    std::string device_name = Memory::ReadCString(buffer.Address(), buffer.Size());
+    const auto& buffer = ctx.ReadBuffer();
+    std::string device_name(buffer.begin(), buffer.end());
 
     u32 fd = nvdrv->Open(device_name);
     IPC::ResponseBuilder rb{ctx, 4};

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -17,9 +17,7 @@ void SET::GetAvailableLanguageCodes(Kernel::HLERequestContext& ctx) {
     u32 id = rp.Pop<u32>();
     constexpr std::array<u8, 13> lang_codes{};
 
-    const auto& output_buffer = ctx.BufferDescriptorC()[0];
-
-    Memory::WriteBlock(output_buffer.Address(), lang_codes.data(), lang_codes.size());
+    ctx.WriteBuffer(lang_codes.data(), lang_codes.size());
 
     IPC::ResponseBuilder rb{ctx, 2};
 


### PR DESCRIPTION
Adds some helper functions for `ReadBuffer(..)` and `WriteBuffer(..)`, and replaces uses of `BufferDescriptor*` with these. This is supposed to do the right thing based on the IPC request. Simplifies some code, and furthermore fixes some service functions that can use multiple buffer types (i.e. `TransactParcel`, which fixes a bug with SMO).