### PR TITLE
Fix fps counter to correctly measure frame end when there was no frame to draw

### DIFF
--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -6,6 +6,7 @@
 
 #include "common/alignment.h"
 #include "common/scope_exit.h"
+#include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/service/nvdrv/devices/nvdisp_disp0.h"
 #include "core/hle/service/nvdrv/nvdrv.h"
@@ -129,6 +130,7 @@ void NVFlinger::Compose() {
 
         if (buffer == boost::none) {
             // There was no queued buffer to draw, render previous frame
+            Core::System::GetInstance().perf_stats.EndGameFrame();
             VideoCore::g_renderer->SwapBuffers({});
             continue;
         }


### PR DESCRIPTION
same thing as what i asked them to do in #174 but this time with clang format fixed