### PR TITLE
Use Docker for Build Target clang-format for travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,11 @@ matrix:
   include:
     - os: linux
       env: NAME="clang-format"
+      sudo: required
       dist: trusty
-      addons:
-        apt:
-          sources:
-            - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main'
-              key_url: 'https://apt.llvm.org/llvm-snapshot.gpg.key'
-            - sourceline: 'deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu trusty main'
-          packages:
-            - clang-format-6.0
-      script: "./.travis/clang-format/script.sh"
+      services: docker
+      install: "./.travis/clang-format/deps.sh"
+      script: "./.travis/clang-format/build.sh"
     - os: linux
       env: NAME="linux build"
       sudo: required

--- a/.travis/clang-format/build.sh
+++ b/.travis/clang-format/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-docker run -v $(pwd):/yuzu ubuntu:18.04 /bin/bash /yuzu/.travis/clang-format/docker.sh
+docker run -v $(pwd):/yuzu ubuntu:18.04 /bin/bash -ex /yuzu/.travis/clang-format/docker.sh

--- a/.travis/clang-format/build.sh
+++ b/.travis/clang-format/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+
+docker run -v $(pwd):/yuzu ubuntu:18.04 /bin/bash /yuzu/.travis/clang-format/docker.sh

--- a/.travis/clang-format/deps.sh
+++ b/.travis/clang-format/deps.sh
@@ -1,0 +1,3 @@
+#!/bin/sh -ex
+
+docker pull ubuntu:18.04

--- a/.travis/clang-format/docker.sh
+++ b/.travis/clang-format/docker.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -ex
+
+apt-get update
+apt-get install -y clang-format-6.0
+
+# Run clang-format
+cd /yuzu
+./.travis/clang-format/script.sh


### PR DESCRIPTION
This uses the (apparently) more stable Ubuntu Repo instead of the LLVM one.