### PR TITLE
Make the fence handling in Vi a little less of a hack.

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -17,6 +17,8 @@ u32 nvhost_ctrl::ioctl(Ioctl command, const std::vector<u8>& input, std::vector<
     switch (static_cast<IoctlCommand>(command.raw)) {
     case IoctlCommand::IocGetConfigCommand:
         return NvOsGetConfigU32(input, output);
+    case IoctlCommand::IocCtrlEventWaitCommand:
+        return IocCtrlEventWait(input, output);
     }
     UNIMPLEMENTED();
     return 0;
@@ -41,6 +43,18 @@ u32 nvhost_ctrl::NvOsGetConfigU32(const std::vector<u8>& input, std::vector<u8>&
     } else {
         UNIMPLEMENTED(); // unknown domain? Only nv has been seen so far on hardware
     }
+    std::memcpy(output.data(), &params, sizeof(params));
+    return 0;
+}
+
+u32 nvhost_ctrl::IocCtrlEventWait(const std::vector<u8>& input, std::vector<u8>& output) {
+    IocCtrlEventWaitParams params{};
+    std::memcpy(&params, input.data(), sizeof(params));
+    LOG_WARNING(Service_NVDRV, "(STUBBED) called, syncpt_id=%u threshold=%u timeout=%d",
+                params.syncpt_id, params.threshold, params.timeout);
+
+    // TODO(Subv): Implement actual syncpt waiting.
+    params.value = 0;
     std::memcpy(output.data(), &params, sizeof(params));
     return 0;
 }

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
@@ -31,6 +31,7 @@ private:
         IocModuleRegRDWRCommand = 0xC008010E,
         IocSyncptWaitexCommand = 0xC0100019,
         IocSyncptReadMaxCommand = 0xC008001A,
+        IocCtrlEventWaitCommand = 0xC010001D,
         IocGetConfigCommand = 0xC183001B,
     };
 
@@ -41,7 +42,17 @@ private:
     };
     static_assert(sizeof(IocGetConfigParams) == 387, "IocGetConfigParams is incorrect size");
 
+    struct IocCtrlEventWaitParams {
+        u32_le syncpt_id;
+        u32_le threshold;
+        s32_le timeout;
+        u32_le value;
+    };
+    static_assert(sizeof(IocCtrlEventWaitParams) == 16, "IocCtrlEventWaitParams is incorrect size");
+
     u32 NvOsGetConfigU32(const std::vector<u8>& input, std::vector<u8>& output);
+
+    u32 IocCtrlEventWait(const std::vector<u8>& input, std::vector<u8>& output);
 };
 
 } // namespace Devices

--- a/src/core/hle/service/nvdrv/devices/nvmap.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvmap.cpp
@@ -103,11 +103,8 @@ u32 nvmap::IocFromId(const std::vector<u8>& input, std::vector<u8>& output) {
                             [&](const auto& entry) { return entry.second->id == params.id; });
     ASSERT(itr != handles.end());
 
-    // Make a new handle for the object
-    u32 handle = next_handle++;
-    handles[handle] = itr->second;
-
-    params.handle = handle;
+    // Return the existing handle instead of creating a new one.
+    params.handle = itr->first;
 
     std::memcpy(output.data(), &params, sizeof(params));
     return 0;

--- a/src/core/hle/service/nvdrv/nvdrv.h
+++ b/src/core/hle/service/nvdrv/nvdrv.h
@@ -17,6 +17,13 @@ namespace Devices {
 class nvdevice;
 }
 
+struct IoctlFence {
+    u32 id;
+    u32 value;
+};
+
+static_assert(sizeof(IoctlFence) == 8, "IoctlFence has wrong size");
+
 class Module final {
 public:
     Module();

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -325,7 +325,8 @@ protected:
     void SerializeData() override {
         // TODO(Subv): Figure out what this value means, writing non-zero here will make libnx try
         // to read an IGBPBuffer object from the parcel.
-        Write<u32_le>(0);
+        Write<u32_le>(1);
+        WriteObject(buffer);
         Write<u32_le>(0);
     }
 

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -289,6 +289,7 @@ protected:
         BufferProducerFence fence = {};
 
         Write(slot);
+        Write<u32_le>(1);
         WriteObject(fence);
         Write<u32_le>(0);
     }

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -319,11 +319,9 @@ public:
 
 protected:
     void SerializeData() override {
-        // TODO(bunnei): Find out what this all means. Writing anything non-zero here breaks libnx.
+        // TODO(Subv): Figure out what this value means, writing non-zero here will make libnx try
+        // to read an IGBPBuffer object from the parcel.
         Write<u32_le>(0);
-        Write<u32_le>(FENCE_HACK);
-        Write<u32_le>(0);
-        Write(buffer);
         Write<u32_le>(0);
     }
 

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -288,8 +288,8 @@ protected:
         // TODO(Subv): Find out how this Fence is used.
         BufferProducerFence fence = {};
         fence.is_valid = 1;
-        fence.fences[0].id = 0;
-        fence.fences[0].value = 0;
+        for (auto& fence_ : fence.fences)
+            fence_.id = -1;
 
         Write(slot);
         Write<u32_le>(1);

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -287,6 +287,9 @@ protected:
     void SerializeData() override {
         // TODO(Subv): Find out how this Fence is used.
         BufferProducerFence fence = {};
+        fence.is_valid = 1;
+        fence.fences[0].id = 0;
+        fence.fences[0].value = 0;
 
         Write(slot);
         Write<u32_le>(1);

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -39,6 +39,7 @@ public:
 
     template <typename T>
     T Read() {
+        ASSERT(read_index + sizeof(T) <= buffer.size());
         T val;
         std::memcpy(&val, buffer.data() + read_index, sizeof(T));
         read_index += sizeof(T);
@@ -48,6 +49,7 @@ public:
 
     template <typename T>
     T ReadUnaligned() {
+        ASSERT(read_index + sizeof(T) <= buffer.size());
         T val;
         std::memcpy(&val, buffer.data() + read_index, sizeof(T));
         read_index += sizeof(T);
@@ -55,6 +57,7 @@ public:
     }
 
     std::vector<u8> ReadBlock(size_t length) {
+        ASSERT(read_index + length <= buffer.size());
         const u8* const begin = buffer.data() + read_index;
         const u8* const end = begin + length;
         std::vector<u8> data(begin, end);
@@ -97,6 +100,8 @@ public:
     }
 
     void Deserialize() {
+        ASSERT(buffer.size() > sizeof(Header));
+
         Header header{};
         std::memcpy(&header, buffer.data(), sizeof(Header));
 


### PR DESCRIPTION
This PR fixes the unmapped read crash in Puyo Puyo Tetris and Breath Of The Wild (and maybe others).

There is a change here that may break libnx homebrew (sending the IGBPBuffer in the RequestBuffer response parcel) due to a padding bug in libnx, but it is required for official games to continue forward.

As of this PR, Puyo Puyo Tetris submits a second set of GPU command lists and then loops on the SendVibrationValues function, starving the main thread. Presumably we'll have to implement multiple concurrent threads to go past this.