### PR TITLE
AM: Corrected the response in EnsureSaveData.

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -378,8 +378,9 @@ void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
 
 void IApplicationFunctions::EnsureSaveData(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service, "(STUBBED) called");
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
+    rb.Push<u64>(0);
 }
 
 void IApplicationFunctions::SetTerminateResult(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
The values are still unknown and the function is still considered a stub.
Puyo Puyo Tetris now tries to call fsp-srv:MountSaveData.