### PR TITLE
IPC: add domain header to response if only it exists in request

### DIFF
--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -118,7 +118,8 @@ public:
 
         AlignWithPadding();
 
-        if (context.Session()->IsDomain() && context.GetDomainMessageHeader()) {
+        const bool request_has_domain_header{context.GetDomainMessageHeader() != nullptr};
+        if (context.Session()->IsDomain() && request_has_domain_header) {
             IPC::DomainMessageHeader domain_header{};
             domain_header.num_objects = num_domain_objects;
             PushRaw(domain_header);

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -118,7 +118,7 @@ public:
 
         AlignWithPadding();
 
-        if (context.Session()->IsDomain()) {
+        if (context.Session()->IsDomain() && context.GetDomainMessageHeader()) {
             IPC::DomainMessageHeader domain_header{};
             domain_header.num_objects = num_domain_objects;
             PushRaw(domain_header);

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -89,6 +89,9 @@ void HLERequestContext::ParseCommandBuffer(u32_le* src_cmdbuf, bool incoming) {
         if (incoming || domain_message_header) {
             domain_message_header =
                 std::make_unique<IPC::DomainMessageHeader>(rp.PopRaw<IPC::DomainMessageHeader>());
+        } else {
+            if (Session()->IsDomain())
+                LOG_WARNING(IPC, "Domain request has no DomainMessageHeader!");
         }
     }
 

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -198,7 +198,7 @@ ResultCode HLERequestContext::WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf, P
 
     // TODO(Subv): Translate the X/A/B/W buffers.
 
-    if (domain_message_header && Session()->IsDomain()) {
+    if (Session()->IsDomain() && domain_message_header) {
         ASSERT(domain_message_header->num_objects == domain_objects.size());
         // Write the domain objects to the command buffer, these go after the raw untranslated data.
         // TODO(Subv): This completely ignores C buffers.

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -85,9 +85,11 @@ void HLERequestContext::ParseCommandBuffer(u32_le* src_cmdbuf, bool incoming) {
 
     if (Session()->IsDomain() && (command_header->type == IPC::CommandType::Request || !incoming)) {
         // If this is an incoming message, only CommandType "Request" has a domain header
-        // All outgoing domain messages have the domain header
-        domain_message_header =
-            std::make_unique<IPC::DomainMessageHeader>(rp.PopRaw<IPC::DomainMessageHeader>());
+        // All outgoing domain messages have the domain header, if only incoming has it
+        if (incoming || domain_message_header) {
+            domain_message_header =
+                std::make_unique<IPC::DomainMessageHeader>(rp.PopRaw<IPC::DomainMessageHeader>());
+        }
     }
 
     data_payload_header =
@@ -196,7 +198,7 @@ ResultCode HLERequestContext::WriteToOutgoingCommandBuffer(u32_le* dst_cmdbuf, P
 
     // TODO(Subv): Translate the X/A/B/W buffers.
 
-    if (Session()->IsDomain()) {
+    if (domain_message_header && Session()->IsDomain()) {
         ASSERT(domain_message_header->num_objects == domain_objects.size());
         // Write the domain objects to the command buffer, these go after the raw untranslated data.
         // TODO(Subv): This completely ignores C buffers.

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -96,7 +96,7 @@ ResultCode ServerSession::HandleSyncRequest(SharedPtr<Thread> thread) {
 
     ResultCode result = RESULT_SUCCESS;
     // If the session has been converted to a domain, handle the domain request
-    if (IsDomain()) {
+    if (context.GetDomainMessageHeader() && IsDomain()) {
         result = HandleDomainSyncRequest(context);
         // If there is no domain header, the regular session handler is used
     } else if (hle_handler != nullptr) {

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -96,7 +96,7 @@ ResultCode ServerSession::HandleSyncRequest(SharedPtr<Thread> thread) {
 
     ResultCode result = RESULT_SUCCESS;
     // If the session has been converted to a domain, handle the domain request
-    if (context.GetDomainMessageHeader() && IsDomain()) {
+    if (IsDomain() && context.GetDomainMessageHeader()) {
         result = HandleDomainSyncRequest(context);
         // If there is no domain header, the regular session handler is used
     } else if (hle_handler != nullptr) {


### PR DESCRIPTION
This PR lets about 10 games pass through `sm::DuplicateSession` crash, which function has no domain header in request, even if service is domain. (and don't want domain header in response).

Looks little hacky, but work