### PR TITLE
arm_dynarmic: Implement system registers and provide more hooks

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <dynarmic/A64/a64.h>
 #include <dynarmic/A64/config.h>
+#include "common/logging/log.h"
 #include "core/arm/dynarmic/arm_dynarmic.h"
 #include "core/core_timing.h"
 #include "core/hle/kernel/memory.h"
@@ -53,6 +54,9 @@ public:
     }
 
     void InterpreterFallback(u64 pc, size_t num_instructions) override {
+        LOG_INFO(Core_ARM, "Unicorn fallback @ 0x%" PRIx64 " for %zu instructions (instr = %08x)",
+                 pc, num_instructions, MemoryReadCode(pc));
+
         ARM_Interface::ThreadContext ctx;
         parent.SaveContext(ctx);
         parent.inner_unicorn.LoadContext(ctx);

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -67,8 +67,17 @@ public:
     }
 
     void ExceptionRaised(u64 pc, Dynarmic::A64::Exception exception) override {
-        ASSERT_MSG(false, "ExceptionRaised(exception = %zu, pc = %" PRIx64 ")",
-                   static_cast<size_t>(exception), pc);
+        switch (exception) {
+        case Dynarmic::A64::Exception::WaitForInterrupt:
+        case Dynarmic::A64::Exception::WaitForEvent:
+        case Dynarmic::A64::Exception::SendEvent:
+        case Dynarmic::A64::Exception::SendEventLocal:
+        case Dynarmic::A64::Exception::Yield:
+            return;
+        default:
+            ASSERT_MSG(false, "ExceptionRaised(exception = %zu, pc = %" PRIx64 ")",
+                       static_cast<size_t>(exception), pc);
+        }
     }
 
     void CallSVC(u32 swi) override {
@@ -85,11 +94,15 @@ public:
     u64 GetTicksRemaining() override {
         return ticks_remaining;
     }
+    u64 GetCNTPCT() override {
+        return CoreTiming::GetTicks();
+    }
 
     ARM_Dynarmic& parent;
     size_t ticks_remaining = 0;
     size_t num_interpreted_instructions = 0;
     u64 tpidrro_el0 = 0;
+    u64 tpidr_el0 = 0;
 };
 
 std::unique_ptr<Dynarmic::A64::Jit> MakeJit(const std::unique_ptr<ARM_Dynarmic_Callbacks>& cb) {
@@ -98,10 +111,13 @@ std::unique_ptr<Dynarmic::A64::Jit> MakeJit(const std::unique_ptr<ARM_Dynarmic_C
     Dynarmic::A64::UserConfig config;
     config.callbacks = cb.get();
     config.tpidrro_el0 = &cb->tpidrro_el0;
+    config.tpidr_el0 = &cb->tpidr_el0;
     config.dczid_el0 = 4;
+    config.ctr_el0 = 0x8444c004;
     config.page_table = reinterpret_cast<void**>(page_table);
     config.page_table_address_space_bits = Memory::ADDRESS_SPACE_BITS;
     config.silently_mirror_page_table = false;
+
     return std::make_unique<Dynarmic::A64::Jit>(config);
 }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -118,6 +118,11 @@ boost::optional<T> ReadSpecial(VAddr addr);
 
 template <typename T>
 T Read(const VAddr vaddr) {
+    if ((vaddr >> PAGE_BITS) >= PAGE_TABLE_NUM_ENTRIES) {
+        LOG_ERROR(HW_Memory, "Read%lu after page table @ 0x%016" PRIX64, sizeof(T) * 8, vaddr);
+        return 0;
+    }
+
     const PageType type = current_page_table->attributes[vaddr >> PAGE_BITS];
     switch (type) {
     case PageType::Unmapped:
@@ -146,6 +151,12 @@ bool WriteSpecial(VAddr addr, const T data);
 
 template <typename T>
 void Write(const VAddr vaddr, const T data) {
+    if ((vaddr >> PAGE_BITS) >= PAGE_TABLE_NUM_ENTRIES) {
+        LOG_ERROR(HW_Memory, "Write%lu after page table 0x%08X @ 0x%016" PRIX64, sizeof(data) * 8,
+                  (u32)data, vaddr);
+        return;
+    }
+
     const PageType type = current_page_table->attributes[vaddr >> PAGE_BITS];
     switch (type) {
     case PageType::Unmapped:


### PR DESCRIPTION
tl;dr: Please verify implementation of `GetCNTPCT`. Also note `ExceptionRaised` is avaliable if hooking any of YIELD, WFE, WFI, SEV, SEVL turns out to be necessary. Hooking [data cache operations](https://github.com/MerryMage/dynarmic/blob/master/include/dynarmic/A64/config.h#L43) is also possible if you needed fine-grained data cache control for whatever reason.

Also feel free to make dynarmic the default cpu emulator at this point. I've completed hardware verification.

**memory: LOG_ERROR when falling off end of page table**

Prevents stray guest pointer from segfaulting host.

**arm_dynarmic: LOG_INFO on unicorn fallback**

To help diagnose slow-downs in the future.

**More accurate NaN handling in FP instructions**

Should now match hardware behaviour. Note: We still do not have accurate FPSR handling, but that is rarely necessary.

**Fixed a bug in MemoryRead128 which would result in crashes**

Oops.

**More instructions implemented**

Further improvements to overall system stability and other minor adjustments have been made to enhance the user experience.