### PR TITLE
time: Add GetStandardLocalSystemClock, used by libnx

### DIFF
--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -146,6 +146,13 @@ void Module::Interface::GetTimeZoneService(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_Time, "called");
 }
 
+void Module::Interface::GetStandardLocalSystemClock(Kernel::HLERequestContext& ctx) {
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    rb.Push(RESULT_SUCCESS);
+    rb.PushIpcInterface<ISystemClock>();
+    LOG_DEBUG(Service_Time, "called");
+}
+
 Module::Interface::Interface(std::shared_ptr<Module> time, const char* name)
     : ServiceFramework(name), time(std::move(time)) {}
 

--- a/src/core/hle/service/time/time.h
+++ b/src/core/hle/service/time/time.h
@@ -56,6 +56,7 @@ public:
         void GetStandardNetworkSystemClock(Kernel::HLERequestContext& ctx);
         void GetStandardSteadyClock(Kernel::HLERequestContext& ctx);
         void GetTimeZoneService(Kernel::HLERequestContext& ctx);
+        void GetStandardLocalSystemClock(Kernel::HLERequestContext& ctx);
 
     protected:
         std::shared_ptr<Module> time;

--- a/src/core/hle/service/time/time_u.cpp
+++ b/src/core/hle/service/time/time_u.cpp
@@ -13,6 +13,7 @@ TIME_U::TIME_U(std::shared_ptr<Module> time) : Module::Interface(std::move(time)
         {1, &TIME_U::GetStandardNetworkSystemClock, "GetStandardNetworkSystemClock"},
         {2, &TIME_U::GetStandardSteadyClock, "GetStandardSteadyClock"},
         {3, &TIME_U::GetTimeZoneService, "GetTimeZoneService"},
+        {4, &TIME_U::GetStandardLocalSystemClock, "GetStandardLocalSystemClock"},
     };
     RegisterHandlers(functions);
 }


### PR DESCRIPTION
Fairly recent addition, probably not accurate but it prevents crashes for now. I think most of `time` needs work though.