### PR TITLE
Stub some functions

### DIFF
--- a/src/core/arm/unicorn/arm_unicorn.cpp
+++ b/src/core/arm/unicorn/arm_unicorn.cpp
@@ -52,7 +52,8 @@ static bool UnmappedMemoryHook(uc_engine* uc, uc_mem_type type, u64 addr, int si
                                void* user_data) {
     ARM_Interface::ThreadContext ctx{};
     Core::CPU().SaveContext(ctx);
-    ASSERT_MSG(false, "Attempted to read from unmapped memory: 0x%llx", addr);
+    ASSERT_MSG(false, "Attempted to read from unmapped memory: 0x%llx, pc=0x%llx, lr=0x%llx", addr,
+               ctx.pc, ctx.cpu_registers[30]);
     return {};
 }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -761,6 +761,16 @@ static ResultCode CreateSharedMemory(Handle* handle, u64 size, u32 local_permiss
     return RESULT_SUCCESS;
 }
 
+static ResultCode ClearEvent(Handle handle) {
+    LOG_TRACE(Kernel_SVC, "called, event=0xX", handle);
+
+    SharedPtr<Event> evt = g_handle_table.Get<Event>(handle);
+    if (evt == nullptr)
+        return ERR_INVALID_HANDLE;
+    evt->Clear();
+    return RESULT_SUCCESS;
+}
+
 namespace {
 struct FunctionDef {
     using Func = void();
@@ -790,7 +800,7 @@ static const FunctionDef SVC_Table[] = {
     {0x0F, SvcWrap<SetThreadCoreMask>, "SetThreadCoreMask"},
     {0x10, SvcWrap<GetCurrentProcessorNumber>, "GetCurrentProcessorNumber"},
     {0x11, nullptr, "SignalEvent"},
-    {0x12, nullptr, "ClearEvent"},
+    {0x12, SvcWrap<ClearEvent>, "ClearEvent"},
     {0x13, SvcWrap<MapSharedMemory>, "MapSharedMemory"},
     {0x14, nullptr, "UnmapSharedMemory"},
     {0x15, SvcWrap<CreateTransferMemory>, "CreateTransferMemory"},

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -34,7 +34,38 @@ void IWindowController::AcquireForegroundRights(Kernel::HLERequestContext& ctx) 
     rb.Push(RESULT_SUCCESS);
 }
 
-IAudioController::IAudioController() : ServiceFramework("IAudioController") {}
+IAudioController::IAudioController() : ServiceFramework("IAudioController") {
+    static const FunctionInfo functions[] = {
+        {0, &IAudioController::SetExpectedMasterVolume, "SetExpectedMasterVolume"},
+        {1, &IAudioController::GetMainAppletExpectedMasterVolume,
+         "GetMainAppletExpectedMasterVolume"},
+        {2, &IAudioController::GetLibraryAppletExpectedMasterVolume,
+         "GetLibraryAppletExpectedMasterVolume"},
+        {3, nullptr, "ChangeMainAppletMasterVolume"},
+        {4, nullptr, "SetTransparentVolumeRate"},
+    };
+    RegisterHandlers(functions);
+}
+
+void IAudioController::SetExpectedMasterVolume(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service_AM, "(STUBBED) called");
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(RESULT_SUCCESS);
+}
+
+void IAudioController::GetMainAppletExpectedMasterVolume(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service_AM, "(STUBBED) called");
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(RESULT_SUCCESS);
+    rb.Push(volume);
+}
+
+void IAudioController::GetLibraryAppletExpectedMasterVolume(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service_AM, "(STUBBED) called");
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(RESULT_SUCCESS);
+    rb.Push(volume);
+}
 
 IDisplayController::IDisplayController() : ServiceFramework("IDisplayController") {}
 

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -46,6 +46,7 @@ ISelfController::ISelfController(std::shared_ptr<NVFlinger::NVFlinger> nvflinger
         {1, &ISelfController::LockExit, "LockExit"},
         {2, &ISelfController::UnlockExit, "UnlockExit"},
         {9, &ISelfController::GetLibraryAppletLaunchableEvent, "GetLibraryAppletLaunchableEvent"},
+        {10, &ISelfController::SetScreenShotPermission, "SetScreenShotPermission"},
         {11, &ISelfController::SetOperationModeChangedNotification,
          "SetOperationModeChangedNotification"},
         {12, &ISelfController::SetPerformanceModeChangedNotification,
@@ -96,6 +97,13 @@ void ISelfController::SetPerformanceModeChangedNotification(Kernel::HLERequestCo
     rb.Push(RESULT_SUCCESS);
 
     LOG_WARNING(Service_AM, "(STUBBED) called flag=%u", static_cast<u32>(flag));
+}
+
+void ISelfController::SetScreenShotPermission(Kernel::HLERequestContext& ctx) {
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(RESULT_SUCCESS);
+
+    LOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void ISelfController::SetOperationModeChangedNotification(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -62,6 +62,7 @@ private:
     void UnlockExit(Kernel::HLERequestContext& ctx);
     void GetLibraryAppletLaunchableEvent(Kernel::HLERequestContext& ctx);
     void CreateManagedDisplayLayer(Kernel::HLERequestContext& ctx);
+    void SetScreenShotPermission(Kernel::HLERequestContext& ctx);
 
     std::shared_ptr<NVFlinger::NVFlinger> nvflinger;
     Kernel::SharedPtr<Kernel::Event> launchable_event;

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -36,6 +36,13 @@ private:
 class IAudioController final : public ServiceFramework<IAudioController> {
 public:
     IAudioController();
+
+private:
+    void SetExpectedMasterVolume(Kernel::HLERequestContext& ctx);
+    void GetMainAppletExpectedMasterVolume(Kernel::HLERequestContext& ctx);
+    void GetLibraryAppletExpectedMasterVolume(Kernel::HLERequestContext& ctx);
+
+    u32 volume{100};
 };
 
 class IDisplayController final : public ServiceFramework<IDisplayController> {

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -13,7 +13,7 @@ AOC_U::AOC_U() : ServiceFramework("aoc:u") {
     static const FunctionInfo functions[] = {
         {0, nullptr, "CountAddOnContentByApplicationId"},
         {1, nullptr, "ListAddOnContentByApplicationId"},
-        {2, nullptr, "CountAddOnContent"},
+        {2, &AOC_U::CountAddOnContent, "CountAddOnContent"},
         {3, &AOC_U::ListAddOnContent, "ListAddOnContent"},
         {4, nullptr, "GetAddOnContentBaseIdByApplicationId"},
         {5, nullptr, "GetAddOnContentBaseId"},
@@ -21,6 +21,13 @@ AOC_U::AOC_U() : ServiceFramework("aoc:u") {
         {7, nullptr, "PrepareAddOnContent"},
     };
     RegisterHandlers(functions);
+}
+
+void AOC_U::CountAddOnContent(Kernel::HLERequestContext& ctx) {
+    IPC::ResponseBuilder rb{ctx, 4};
+    rb.Push(RESULT_SUCCESS);
+    rb.Push<u64>(0);
+    LOG_WARNING(Service_AOC, "(STUBBED) called");
 }
 
 void AOC_U::ListAddOnContent(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/aoc/aoc_u.h
+++ b/src/core/hle/service/aoc/aoc_u.h
@@ -15,6 +15,7 @@ public:
     ~AOC_U() = default;
 
 private:
+    void CountAddOnContent(Kernel::HLERequestContext& ctx);
     void ListAddOnContent(Kernel::HLERequestContext& ctx);
 };
 

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -178,10 +178,10 @@ void AudRenU::GetAudioRendererWorkBufferSize(Kernel::HLERequestContext& ctx) {
 }
 
 void AudRenU::GetAudioRenderersProcessMasterVolume(Kernel::HLERequestContext& ctx) {
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx, 3};
 
     rb.Push(RESULT_SUCCESS);
-
+    rb.Push<u32>(100);
     LOG_WARNING(Service_Audio, "(STUBBED) called");
 }
 

--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "core/hle/ipc_helpers.h"
+#include "core/hle/kernel/event.h"
 #include "core/hle/service/nifm/nifm.h"
 #include "core/hle/service/nifm/nifm_a.h"
 #include "core/hle/service/nifm/nifm_s.h"
@@ -28,9 +29,9 @@ class IRequest final : public ServiceFramework<IRequest> {
 public:
     explicit IRequest() : ServiceFramework("IRequest") {
         static const FunctionInfo functions[] = {
-            {0, nullptr, "GetRequestState"},
-            {1, nullptr, "GetResult"},
-            {2, nullptr, "GetSystemEventReadableHandles"},
+            {0, &IRequest::GetRequestState, "GetRequestState"},
+            {1, &IRequest::GetResult, "GetResult"},
+            {2, &IRequest::GetSystemEventReadableHandles, "GetSystemEventReadableHandles"},
             {3, nullptr, "Cancel"},
             {4, nullptr, "Submit"},
             {5, nullptr, "SetRequirement"},
@@ -55,7 +56,32 @@ public:
             {25, nullptr, "UnregisterSocketDescriptor"},
         };
         RegisterHandlers(functions);
+
+        event1 = Kernel::Event::Create(Kernel::ResetType::OneShot, "IRequest:Event1");
+        event2 = Kernel::Event::Create(Kernel::ResetType::OneShot, "IRequest:Event2");
     }
+
+private:
+    void GetRequestState(Kernel::HLERequestContext& ctx) {
+        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push<u32>(0);
+    }
+    void GetResult(Kernel::HLERequestContext& ctx) {
+        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push<u32>(0);
+    }
+    void GetSystemEventReadableHandles(Kernel::HLERequestContext& ctx) {
+        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        IPC::ResponseBuilder rb{ctx, 2, 2};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushCopyObjects(event1, event2);
+    }
+
+    Kernel::SharedPtr<Kernel::Event> event1, event2;
 };
 
 class INetworkProfile final : public ServiceFramework<INetworkProfile> {

--- a/src/core/hle/service/sockets/bsd_u.cpp
+++ b/src/core/hle/service/sockets/bsd_u.cpp
@@ -17,6 +17,15 @@ void BSD_U::RegisterClient(Kernel::HLERequestContext& ctx) {
     rb.Push<u32>(0); // bsd errno
 }
 
+void BSD_U::StartMonitoring(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service, "(STUBBED) called");
+
+    IPC::ResponseBuilder rb{ctx, 3};
+
+    rb.Push(RESULT_SUCCESS);
+    rb.Push<u32>(0); // bsd errno
+}
+
 void BSD_U::Socket(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
 
@@ -67,6 +76,7 @@ void BSD_U::Close(Kernel::HLERequestContext& ctx) {
 
 BSD_U::BSD_U() : ServiceFramework("bsd:u") {
     static const FunctionInfo functions[] = {{0, &BSD_U::RegisterClient, "RegisterClient"},
+                                             {1, &BSD_U::StartMonitoring, "StartMonitoring"},
                                              {2, &BSD_U::Socket, "Socket"},
                                              {11, &BSD_U::SendTo, "SendTo"},
                                              {14, &BSD_U::Connect, "Connect"},

--- a/src/core/hle/service/sockets/bsd_u.h
+++ b/src/core/hle/service/sockets/bsd_u.h
@@ -17,6 +17,7 @@ public:
 
 private:
     void RegisterClient(Kernel::HLERequestContext& ctx);
+    void StartMonitoring(Kernel::HLERequestContext& ctx);
     void Socket(Kernel::HLERequestContext& ctx);
     void Connect(Kernel::HLERequestContext& ctx);
     void SendTo(Kernel::HLERequestContext& ctx);


### PR DESCRIPTION
Stub functions, used in games.
Additionally, add current PC and LR to info about unmapped memory access
Implement svc::ClearEvent