### PR TITLE
Make Dynarmic the default CPU core

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -78,7 +78,7 @@ void Config::ReadValues() {
 
     qt_config->beginGroup("Core");
     Settings::values.cpu_core =
-        static_cast<Settings::CpuCore>(qt_config->value("cpu_core", 0).toInt());
+        static_cast<Settings::CpuCore>(qt_config->value("cpu_core", 1).toInt());
     qt_config->endGroup();
 
     qt_config->beginGroup("Renderer");


### PR DESCRIPTION
Locked by #210 . **Please do not merge this without the other PR!**

Makes the default CPU core be Dynarmic. 
Expect some huge speed boosts if you haven't tried Dynarmic before.
If you've launched Yuzu before, you can turn on Dynarmic manually by going into Emulation -> Configure -> CPU Core.