### PR TITLE
Return RESULT_SUCCESS for unimplemented functions

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -116,6 +116,10 @@ void ServiceFrameworkBase::ReportUnimplementedFunction(Kernel::HLERequestContext
     w << '}';
 
     LOG_ERROR(Service, "unknown / unimplemented %s", w.c_str());
+
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(RESULT_SUCCESS);
+
     UNIMPLEMENTED();
 }
 


### PR DESCRIPTION
... Like Citra does.
this PR lets yuzu not to crash on unimplemented functions