### PR TITLE
thread: Clear the process list on shutdown.

### DIFF
--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -406,6 +406,8 @@ void ThreadingInit() {
     next_thread_id = 1;
 }
 
-void ThreadingShutdown() {}
+void ThreadingShutdown() {
+    Kernel::ClearProcessList();
+}
 
 } // namespace Kernel


### PR DESCRIPTION
This fixes yuzu not releasing memory when emulation is stopped.