### PR TITLE
Vi: Signal the BufferQueue's Native Handle right after ReleaseBuffer is called

### DIFF
--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -150,6 +150,9 @@ void NVFlinger::Compose() {
                      igbp_buffer.width, igbp_buffer.height, igbp_buffer.stride, buffer->transform);
 
         buffer_queue->ReleaseBuffer(buffer->slot);
+
+        // TODO(Subv): Figure out when we should actually signal this event.
+        buffer_queue->GetNativeHandle()->Signal();
     }
 }
 


### PR DESCRIPTION
This prevents a thread starvation issue in Puyo Puyo Tetris.
We should hwtest this behavior and figure out where exactly this event is signaled.