### PR TITLE
CoreTiming: Unschedule the pending events when an Interface is destroyed

### DIFF
--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -52,7 +52,9 @@ public:
         CoreTiming::ScheduleEvent(audio_ticks, audio_event);
     }
 
-    ~IAudioOut() = default;
+    ~IAudioOut() {
+        CoreTiming::UnscheduleEvent(audio_event, 0);
+    }
 
 private:
     void StartAudioOut(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -45,7 +45,9 @@ public:
         // Start the audio event
         CoreTiming::ScheduleEvent(audio_ticks, audio_event);
     }
-    ~IAudioRenderer() = default;
+    ~IAudioRenderer() {
+        CoreTiming::UnscheduleEvent(audio_event, 0);
+    }
 
 private:
     void UpdateAudioCallback() {

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -45,6 +45,10 @@ public:
         CoreTiming::ScheduleEvent(pad_update_ticks, pad_update_event);
     }
 
+    ~IAppletResource() {
+        CoreTiming::UnscheduleEvent(pad_update_event, 0);
+    }
+
 private:
     void GetSharedMemoryHandle(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 1};


### PR DESCRIPTION
Avoid leaving zombie events in CoreTiming's queue.