### PR TITLE
GPU: Intercept writes to the VERTEX_END_GL register.

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -19,6 +19,10 @@ void Maxwell3D::WriteReg(u32 method, u32 value) {
 #define MAXWELL3D_REG_INDEX(field_name) (offsetof(Regs, field_name) / sizeof(u32))
 
     switch (method) {
+    case MAXWELL3D_REG_INDEX(draw.vertex_end_gl): {
+        DrawArrays();
+        break;
+    }
     case MAXWELL3D_REG_INDEX(query.query_get): {
         ProcessQueryGet();
         break;
@@ -47,5 +51,10 @@ void Maxwell3D::ProcessQueryGet() {
         UNIMPLEMENTED_MSG("Query mode %u not implemented", regs.query.query_get.mode.Value());
     }
 }
+
+void Maxwell3D::DrawArrays() {
+    LOG_WARNING(HW_GPU, "Game requested a DrawArrays, ignoring");
+}
+
 } // namespace Engines
 } // namespace Tegra

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -32,7 +32,12 @@ public:
 
         union {
             struct {
-                INSERT_PADDING_WORDS(0x6C0);
+                INSERT_PADDING_WORDS(0x585);
+                struct {
+                    u32 vertex_end_gl;
+                    u32 vertex_begin_gl;
+                } draw;
+                INSERT_PADDING_WORDS(0x139);
                 struct {
                     u32 query_address_high;
                     u32 query_address_low;
@@ -60,6 +65,9 @@ public:
 private:
     /// Handles a write to the QUERY_GET register.
     void ProcessQueryGet();
+
+    /// Handles a write to the VERTEX_END_GL register, triggering a draw.
+    void DrawArrays();
 
     MemoryManager& memory_manager;
 };


### PR DESCRIPTION
This is the register that gets written after a game calls DrawArrays().

We should collect all GPU state and draw using our graphics API here.