### PR TITLE
GPU: Process command mode 5 (IncreaseOnce) differently from other commands

### DIFF
--- a/src/video_core/command_processor.h
+++ b/src/video_core/command_processor.h
@@ -34,6 +34,4 @@ static_assert(std::is_standard_layout<CommandHeader>::value == true,
               "CommandHeader does not use standard layout");
 static_assert(sizeof(CommandHeader) == sizeof(u32), "CommandHeader has incorrect size!");
 
-void ProcessCommandList(VAddr address, u32 size);
-
 } // namespace Tegra

--- a/src/video_core/engines/fermi_2d.cpp
+++ b/src/video_core/engines/fermi_2d.cpp
@@ -8,6 +8,7 @@ namespace Tegra {
 namespace Engines {
 
 void Fermi2D::WriteReg(u32 method, u32 value) {}
+void Fermi2D::CallMethod(u32 method, const std::vector<u32>& parameters) {}
 
 } // namespace Engines
 } // namespace Tegra

--- a/src/video_core/engines/fermi_2d.h
+++ b/src/video_core/engines/fermi_2d.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <vector>
 #include "common/common_types.h"
 
 namespace Tegra {
@@ -16,6 +17,13 @@ public:
 
     /// Write the value to the register identified by method.
     void WriteReg(u32 method, u32 value);
+
+    /**
+     * Handles a method call to this engine.
+     * @param method Method to call
+     * @param parameters Arguments to the method call
+     */
+    void CallMethod(u32 method, const std::vector<u32>& parameters);
 };
 
 } // namespace Engines

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -8,7 +8,22 @@
 namespace Tegra {
 namespace Engines {
 
+const std::unordered_map<u32, Maxwell3D::MethodInfo> Maxwell3D::method_handlers = {
+    {0xE24, {"PrepareShader", 5, &Maxwell3D::PrepareShader}},
+};
+
 Maxwell3D::Maxwell3D(MemoryManager& memory_manager) : memory_manager(memory_manager) {}
+
+void Maxwell3D::CallMethod(u32 method, const std::vector<u32>& parameters) {
+    auto itr = method_handlers.find(method);
+    if (itr == method_handlers.end()) {
+        LOG_ERROR(HW_GPU, "Unhandled method call %08X", method);
+        return;
+    }
+
+    ASSERT(itr->second.arguments == parameters.size());
+    (this->*itr->second.handler)(parameters);
+}
 
 void Maxwell3D::WriteReg(u32 method, u32 value) {
     ASSERT_MSG(method < Regs::NUM_REGS,
@@ -55,6 +70,8 @@ void Maxwell3D::ProcessQueryGet() {
 void Maxwell3D::DrawArrays() {
     LOG_WARNING(HW_GPU, "Game requested a DrawArrays, ignoring");
 }
+
+void Maxwell3D::PrepareShader(const std::vector<u32>& parameters) {}
 
 } // namespace Engines
 } // namespace Tegra

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <unordered_map>
+#include <vector>
 #include "common/bit_field.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
@@ -19,6 +21,13 @@ public:
 
     /// Write the value to the register identified by method.
     void WriteReg(u32 method, u32 value);
+
+    /**
+     * Handles a method call to this engine.
+     * @param method Method to call
+     * @param parameters Arguments to the method call
+     */
+    void CallMethod(u32 method, const std::vector<u32>& parameters);
 
     /// Register structure of the Maxwell3D engine.
     /// TODO(Subv): This structure will need to be made bigger as more registers are discovered.
@@ -63,13 +72,24 @@ public:
     static_assert(sizeof(Regs) == Regs::NUM_REGS * sizeof(u32), "Maxwell3D Regs has wrong size");
 
 private:
+    MemoryManager& memory_manager;
+
     /// Handles a write to the QUERY_GET register.
     void ProcessQueryGet();
 
     /// Handles a write to the VERTEX_END_GL register, triggering a draw.
     void DrawArrays();
 
-    MemoryManager& memory_manager;
+    /// Method call handlers
+    void PrepareShader(const std::vector<u32>& parameters);
+
+    struct MethodInfo {
+        const char* name;
+        u32 arguments;
+        void (Maxwell3D::*handler)(const std::vector<u32>& parameters);
+    };
+
+    static const std::unordered_map<u32, MethodInfo> method_handlers;
 };
 
 #define ASSERT_REG_POSITION(field_name, position)                                                  \

--- a/src/video_core/engines/maxwell_compute.cpp
+++ b/src/video_core/engines/maxwell_compute.cpp
@@ -8,6 +8,7 @@ namespace Tegra {
 namespace Engines {
 
 void MaxwellCompute::WriteReg(u32 method, u32 value) {}
+void MaxwellCompute::CallMethod(u32 method, const std::vector<u32>& parameters) {}
 
 } // namespace Engines
 } // namespace Tegra

--- a/src/video_core/engines/maxwell_compute.h
+++ b/src/video_core/engines/maxwell_compute.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <vector>
 #include "common/common_types.h"
 
 namespace Tegra {
@@ -16,6 +17,13 @@ public:
 
     /// Write the value to the register identified by method.
     void WriteReg(u32 method, u32 value);
+
+    /**
+     * Handles a method call to this engine.
+     * @param method Method to call
+     * @param parameters Arguments to the method call
+     */
+    void CallMethod(u32 method, const std::vector<u32>& parameters);
 };
 
 } // namespace Engines

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -41,6 +41,9 @@ private:
     /// Writes a single register in the engine bound to the specified subchannel
     void WriteReg(u32 method, u32 subchannel, u32 value);
 
+    /// Calls a method in the engine bound to the specified subchannel with the input parameters.
+    void CallMethod(u32 method, u32 subchannel, const std::vector<u32>& parameters);
+
     /// Mapping of command subchannels to their bound engine ids.
     std::unordered_map<u32, EngineID> bound_engines;
 


### PR DESCRIPTION
Accumulate all arguments before calling the desired method.

This will make it easier to implement the _other_ DrawArrays[Indirect/Instanced] methods, plus a few currently undocumented shader-related commands.

Note: Maybe we should do the same for the NonIncreasing mode?