### PR TITLE
GPU: Handle the SetShader method call (0xE24) and store the shader config.

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -9,7 +9,7 @@ namespace Tegra {
 namespace Engines {
 
 const std::unordered_map<u32, Maxwell3D::MethodInfo> Maxwell3D::method_handlers = {
-    {0xE24, {"PrepareShader", 5, &Maxwell3D::PrepareShader}},
+    {0xE24, {"SetShader", 5, &Maxwell3D::SetShader}},
 };
 
 Maxwell3D::Maxwell3D(MemoryManager& memory_manager) : memory_manager(memory_manager) {}
@@ -79,7 +79,27 @@ void Maxwell3D::DrawArrays() {
     LOG_WARNING(HW_GPU, "Game requested a DrawArrays, ignoring");
 }
 
-void Maxwell3D::PrepareShader(const std::vector<u32>& parameters) {}
+void Maxwell3D::SetShader(const std::vector<u32>& parameters) {
+    /**
+     * Parameters description:
+     * [0] = Shader Program.
+     * [1] = Unknown.
+     * [2] = Offset to the start of the shader, after the 0x30 bytes header.
+     * [3] = Shader Type.
+     * [4] = Shader End Address >> 8.
+     */
+    auto shader_program = static_cast<Regs::ShaderProgram>(parameters[0]);
+    // TODO(Subv): This address is probably an offset from the CODE_ADDRESS register.
+    GPUVAddr begin_address = parameters[2];
+    auto shader_type = static_cast<Regs::ShaderType>(parameters[3]);
+    GPUVAddr end_address = parameters[4] << 8;
+
+    auto& shader = state.shaders[static_cast<size_t>(shader_program)];
+    shader.program = shader_program;
+    shader.type = shader_type;
+    shader.begin_address = begin_address;
+    shader.end_address = end_address;
+}
 
 } // namespace Engines
 } // namespace Tegra

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <unordered_map>
 #include <vector>
 #include "common/bit_field.h"
@@ -104,7 +105,7 @@ public:
                     u32 gpr_alloc;
                     ShaderType type;
                     INSERT_PADDING_WORDS(9);
-                } shader_config[6];
+                } shader_config[MaxShaderProgram];
 
                 INSERT_PADDING_WORDS(0x5D0);
 
@@ -120,6 +121,19 @@ public:
 
     static_assert(sizeof(Regs) == Regs::NUM_REGS * sizeof(u32), "Maxwell3D Regs has wrong size");
 
+    struct State {
+        struct ShaderInfo {
+            Regs::ShaderType type;
+            Regs::ShaderProgram program;
+            GPUVAddr begin_address;
+            GPUVAddr end_address;
+        };
+
+        std::array<ShaderInfo, Regs::MaxShaderProgram> shaders;
+    };
+
+    State state;
+
 private:
     MemoryManager& memory_manager;
 
@@ -130,7 +144,7 @@ private:
     void DrawArrays();
 
     /// Method call handlers
-    void PrepareShader(const std::vector<u32>& parameters);
+    void SetShader(const std::vector<u32>& parameters);
 
     struct MethodInfo {
         const char* name;


### PR DESCRIPTION
This PR introduces a state variable to hold state that can't be maintained in the Regs structure (like method calls).

Perhaps in the future we can implement a shader dump feature.