### PR TITLE
 GPU: Store shader constbuffer bindings in the GPU state. 

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -15,6 +15,7 @@ const std::unordered_map<u32, Maxwell3D::MethodInfo> Maxwell3D::method_handlers 
 Maxwell3D::Maxwell3D(MemoryManager& memory_manager) : memory_manager(memory_manager) {}
 
 void Maxwell3D::CallMethod(u32 method, const std::vector<u32>& parameters) {
+    // TODO(Subv): Write an interpreter for the macros uploaded via registers 0x45 and 0x47
     auto itr = method_handlers.find(method);
     if (itr == method_handlers.end()) {
         LOG_ERROR(HW_GPU, "Unhandled method call %08X", method);
@@ -86,19 +87,19 @@ void Maxwell3D::SetShader(const std::vector<u32>& parameters) {
      * [1] = Unknown.
      * [2] = Offset to the start of the shader, after the 0x30 bytes header.
      * [3] = Shader Type.
-     * [4] = Shader End Address >> 8.
+     * [4] = Const Buffer Address >> 8.
      */
     auto shader_program = static_cast<Regs::ShaderProgram>(parameters[0]);
     // TODO(Subv): This address is probably an offset from the CODE_ADDRESS register.
-    GPUVAddr begin_address = parameters[2];
+    GPUVAddr address = parameters[2];
     auto shader_type = static_cast<Regs::ShaderType>(parameters[3]);
-    GPUVAddr end_address = parameters[4] << 8;
+    GPUVAddr cb_address = parameters[4] << 8;
 
     auto& shader = state.shaders[static_cast<size_t>(shader_program)];
     shader.program = shader_program;
     shader.type = shader_type;
-    shader.begin_address = begin_address;
-    shader.end_address = end_address;
+    shader.address = address;
+    shader.cb_address = cb_address;
 }
 
 } // namespace Engines

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -38,7 +38,7 @@ public:
         static constexpr size_t NumCBData = 16;
         static constexpr size_t NumVertexArrays = 32;
         static constexpr size_t MaxShaderProgram = 6;
-        static constexpr size_t MaxShaderType = 5;
+        static constexpr size_t MaxShaderStage = 5;
         // Maximum number of const buffers per shader stage.
         static constexpr size_t MaxConstBuffers = 16;
 
@@ -56,7 +56,7 @@ public:
             Fragment = 5,
         };
 
-        enum class ShaderType : u32 {
+        enum class ShaderStage : u32 {
             Vertex = 0,
             TesselationControl = 1,
             TesselationEval = 2,
@@ -136,7 +136,7 @@ public:
                     u32 start_id;
                     INSERT_PADDING_WORDS(1);
                     u32 gpr_alloc;
-                    ShaderType type;
+                    ShaderStage type;
                     INSERT_PADDING_WORDS(9);
                 } shader_config[MaxShaderProgram];
 
@@ -164,7 +164,7 @@ public:
                         BitField<4, 5, u32> index;
                     };
                     INSERT_PADDING_WORDS(7);
-                } cb_bind[MaxShaderType];
+                } cb_bind[MaxShaderStage];
 
                 INSERT_PADDING_WORDS(0x50A);
             };
@@ -183,7 +183,7 @@ public:
         };
 
         struct ShaderProgramInfo {
-            Regs::ShaderType type;
+            Regs::ShaderStage stage;
             Regs::ShaderProgram program;
             GPUVAddr address;
         };
@@ -192,7 +192,7 @@ public:
             std::array<ConstBufferInfo, Regs::MaxConstBuffers> const_buffers;
         };
 
-        std::array<ShaderStageInfo, Regs::MaxShaderType> shader_stages;
+        std::array<ShaderStageInfo, Regs::MaxShaderStage> shader_stages;
         std::array<ShaderProgramInfo, Regs::MaxShaderProgram> shader_programs;
     };
 
@@ -205,7 +205,7 @@ private:
     void ProcessQueryGet();
 
     /// Handles a write to the CB_BIND register.
-    void ProcessCBBind(Regs::ShaderType stage);
+    void ProcessCBBind(Regs::ShaderStage stage);
 
     /// Handles a write to the VERTEX_END_GL register, triggering a draw.
     void DrawArrays();

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -139,9 +139,9 @@ public:
                 INSERT_PADDING_WORDS(0x5D0);
 
                 struct {
-                    u32 shader_code_call;
-                    u32 shader_code_args;
-                } shader_code;
+                    u32 set_shader_call;
+                    u32 set_shader_args;
+                } set_shader;
                 INSERT_PADDING_WORDS(0x10);
             };
             std::array<u32, NUM_REGS> reg_array;
@@ -154,8 +154,8 @@ public:
         struct ShaderInfo {
             Regs::ShaderType type;
             Regs::ShaderProgram program;
-            GPUVAddr begin_address;
-            GPUVAddr end_address;
+            GPUVAddr address;
+            GPUVAddr cb_address;
         };
 
         std::array<ShaderInfo, Regs::MaxShaderProgram> shaders;
@@ -194,7 +194,7 @@ ASSERT_REG_POSITION(query, 0x6C0);
 ASSERT_REG_POSITION(vertex_array[0], 0x700);
 ASSERT_REG_POSITION(vertex_array_limit[0], 0x7C0);
 ASSERT_REG_POSITION(shader_config[0], 0x800);
-ASSERT_REG_POSITION(shader_code, 0xE24);
+ASSERT_REG_POSITION(set_shader, 0xE24);
 
 #undef ASSERT_REG_POSITION
 

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -148,7 +148,7 @@ public:
                     u32 cb_data[NumCBData];
                 } const_buffer;
 
-                INSERT_PADDING_WORDS(0x74);
+                INSERT_PADDING_WORDS(0x10);
 
                 struct {
                     union {
@@ -158,13 +158,7 @@ public:
                     INSERT_PADDING_WORDS(7);
                 } cb_bind[MaxShaderType];
 
-                INSERT_PADDING_WORDS(0x494);
-
-                struct {
-                    u32 set_shader_call;
-                    u32 set_shader_args;
-                } set_shader;
-                INSERT_PADDING_WORDS(0x10);
+                INSERT_PADDING_WORDS(0x50A);
             };
             std::array<u32, NUM_REGS> reg_array;
         };
@@ -217,7 +211,7 @@ ASSERT_REG_POSITION(vertex_array[0], 0x700);
 ASSERT_REG_POSITION(vertex_array_limit[0], 0x7C0);
 ASSERT_REG_POSITION(shader_config[0], 0x800);
 ASSERT_REG_POSITION(const_buffer, 0x8E0);
-ASSERT_REG_POSITION(set_shader, 0xE24);
+ASSERT_REG_POSITION(cb_bind[0], 0x904);
 
 #undef ASSERT_REG_POSITION
 

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -35,8 +35,10 @@ public:
     struct Regs {
         static constexpr size_t NUM_REGS = 0xE36;
 
+        static constexpr size_t NumCBData = 16;
         static constexpr size_t NumVertexArrays = 32;
         static constexpr size_t MaxShaderProgram = 6;
+        static constexpr size_t MaxShaderType = 5;
 
         enum class QueryMode : u32 {
             Write = 0,
@@ -136,7 +138,27 @@ public:
                     INSERT_PADDING_WORDS(9);
                 } shader_config[MaxShaderProgram];
 
-                INSERT_PADDING_WORDS(0x5D0);
+                INSERT_PADDING_WORDS(0x8C);
+
+                struct {
+                    u32 cb_size;
+                    u32 cb_address_high;
+                    u32 cb_address_low;
+                    u32 cb_pos;
+                    u32 cb_data[NumCBData];
+                } const_buffer;
+
+                INSERT_PADDING_WORDS(0x74);
+
+                struct {
+                    union {
+                        BitField<0, 1, u32> valid;
+                        BitField<4, 5, u32> index;
+                    };
+                    INSERT_PADDING_WORDS(7);
+                } cb_bind[MaxShaderType];
+
+                INSERT_PADDING_WORDS(0x494);
 
                 struct {
                     u32 set_shader_call;
@@ -161,7 +183,7 @@ public:
         std::array<ShaderInfo, Regs::MaxShaderProgram> shaders;
     };
 
-    State state;
+    State state{};
 
 private:
     MemoryManager& memory_manager;
@@ -194,6 +216,7 @@ ASSERT_REG_POSITION(query, 0x6C0);
 ASSERT_REG_POSITION(vertex_array[0], 0x700);
 ASSERT_REG_POSITION(vertex_array_limit[0], 0x7C0);
 ASSERT_REG_POSITION(shader_config[0], 0x800);
+ASSERT_REG_POSITION(const_buffer, 0x8E0);
 ASSERT_REG_POSITION(set_shader, 0xE24);
 
 #undef ASSERT_REG_POSITION


### PR DESCRIPTION
These bindings are how the shaders know where to fetch data from. The buffers are accessed via "cX[]" operands in the shaders.