### PR TITLE
GPU: Handle writes to the CB_DATA method.

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(video_core STATIC
     engines/maxwell_3d.h
     engines/maxwell_compute.cpp
     engines/maxwell_compute.h
+    gpu.cpp
     gpu.h
     memory_manager.cpp
     memory_manager.h

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -83,6 +83,25 @@ void Maxwell3D::WriteReg(u32 method, u32 value, u32 remaining_params) {
         ASSERT_MSG(regs.code_address.CodeAddress() == 0, "Unexpected CODE_ADDRESS register value.");
         break;
     }
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[0]):
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[1]):
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[2]):
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[3]):
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[4]):
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[5]):
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[6]):
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[7]):
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[8]):
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[9]):
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[10]):
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[11]):
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[12]):
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[13]):
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[14]):
+    case MAXWELL3D_REG_INDEX(const_buffer.cb_data[15]): {
+        ProcessCBData(value);
+        break;
+    }
     case MAXWELL3D_REG_INDEX(cb_bind[0].raw_config): {
         ProcessCBBind(Regs::ShaderStage::Vertex);
         break;
@@ -192,6 +211,23 @@ void Maxwell3D::ProcessCBBind(Regs::ShaderStage stage) {
     buffer.index = bind_data.index;
     buffer.address = regs.const_buffer.BufferAddress();
     buffer.size = regs.const_buffer.cb_size;
+}
+
+void Maxwell3D::ProcessCBData(u32 value) {
+    // Write the input value to the current const buffer at the current position.
+    GPUVAddr buffer_address = regs.const_buffer.BufferAddress();
+    ASSERT(buffer_address != 0);
+
+    // Don't allow writing past the end of the buffer.
+    ASSERT(regs.const_buffer.cb_pos + sizeof(u32) <= regs.const_buffer.cb_size);
+
+    VAddr address =
+        memory_manager.PhysicalToVirtualAddress(buffer_address + regs.const_buffer.cb_pos);
+
+    Memory::Write32(address, value);
+
+    // Increment the current buffer position.
+    regs.const_buffer.cb_pos = regs.const_buffer.cb_pos + 4;
 }
 
 } // namespace Engines

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -166,7 +166,19 @@ public:
 
                 u32 tex_cb_index;
 
-                INSERT_PADDING_WORDS(0x4B3);
+                INSERT_PADDING_WORDS(0x395);
+
+                struct {
+                    /// Compressed address of a buffer that holds information about bound SSBOs.
+                    /// This address is usually bound to c0 in the shaders.
+                    u32 buffer_address;
+
+                    GPUVAddr BufferAddress() const {
+                        return static_cast<GPUVAddr>(buffer_address) << 8;
+                    }
+                } ssbo_info;
+
+                INSERT_PADDING_WORDS(0x11D);
             };
             std::array<u32, NUM_REGS> reg_array;
         };
@@ -229,6 +241,7 @@ private:
 
     /// Method call handlers
     void SetShader(const std::vector<u32>& parameters);
+    void BindStorageBuffer(const std::vector<u32>& parameters);
 
     struct MethodInfo {
         const char* name;
@@ -252,6 +265,7 @@ ASSERT_REG_POSITION(shader_config[0], 0x800);
 ASSERT_REG_POSITION(const_buffer, 0x8E0);
 ASSERT_REG_POSITION(cb_bind[0], 0x904);
 ASSERT_REG_POSITION(tex_cb_index, 0x982);
+ASSERT_REG_POSITION(ssbo_info, 0xD18);
 
 #undef ASSERT_REG_POSITION
 

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -218,6 +218,9 @@ private:
     /// Handles a write to the QUERY_GET register.
     void ProcessQueryGet();
 
+    /// Handles a write to the CB_DATA[i] register.
+    void ProcessCBData(u32 value);
+
     /// Handles a write to the CB_BIND register.
     void ProcessCBBind(Regs::ShaderStage stage);
 

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -1,0 +1,21 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "video_core/engines/fermi_2d.h"
+#include "video_core/engines/maxwell_3d.h"
+#include "video_core/engines/maxwell_compute.h"
+#include "video_core/gpu.h"
+
+namespace Tegra {
+
+GPU::GPU() {
+    memory_manager = std::make_unique<MemoryManager>();
+    maxwell_3d = std::make_unique<Engines::Maxwell3D>(*memory_manager);
+    fermi_2d = std::make_unique<Engines::Fermi2D>();
+    maxwell_compute = std::make_unique<Engines::MaxwellCompute>();
+}
+
+GPU::~GPU() = default;
+
+} // namespace Tegra

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -8,12 +8,15 @@
 #include <unordered_map>
 #include <vector>
 #include "common/common_types.h"
-#include "video_core/engines/fermi_2d.h"
-#include "video_core/engines/maxwell_3d.h"
-#include "video_core/engines/maxwell_compute.h"
 #include "video_core/memory_manager.h"
 
 namespace Tegra {
+
+namespace Engines {
+class Fermi2D;
+class Maxwell3D;
+class MaxwellCompute;
+} // namespace Engines
 
 enum class EngineID {
     FERMI_TWOD_A = 0x902D, // 2D Engine
@@ -25,13 +28,8 @@ enum class EngineID {
 
 class GPU final {
 public:
-    GPU() {
-        memory_manager = std::make_unique<MemoryManager>();
-        maxwell_3d = std::make_unique<Engines::Maxwell3D>(*memory_manager);
-        fermi_2d = std::make_unique<Engines::Fermi2D>();
-        maxwell_compute = std::make_unique<Engines::MaxwellCompute>();
-    }
-    ~GPU() = default;
+    GPU();
+    ~GPU();
 
     /// Processes a command list stored at the specified address in GPU memory.
     void ProcessCommandList(GPUVAddr address, u32 size);


### PR DESCRIPTION
Also implement macro method 0xE2A BindBufferStorage in HLE.

ConstBuffers can be written via the CB_DATA method after setting the CB_ADDRESS and CB_POS registers.