### PR TITLE
Logging: Add fmtlib-based macros

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -90,7 +90,7 @@ endif()
 
 create_target_directory_groups(common)
 
-target_link_libraries(common PUBLIC Boost::boost microprofile)
+target_link_libraries(common PUBLIC Boost::boost fmt microprofile)
 if (ARCHITECTURE_x86_64)
     target_link_libraries(common PRIVATE xbyak)
 endif()

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -11,6 +11,7 @@
 #include "common/logging/filter.h"
 #include "common/logging/log.h"
 #include "common/logging/text_formatter.h"
+#include "common/string_util.h"
 
 namespace Log {
 
@@ -102,25 +103,20 @@ const char* GetLevelName(Level log_level) {
 }
 
 Entry CreateEntry(Class log_class, Level log_level, const char* filename, unsigned int line_nr,
-                  const char* function, const char* format, va_list args) {
+                  const char* function, std::string message) {
     using std::chrono::duration_cast;
     using std::chrono::steady_clock;
 
     static steady_clock::time_point time_origin = steady_clock::now();
 
-    std::array<char, 4 * 1024> formatting_buffer;
-
     Entry entry;
     entry.timestamp = duration_cast<std::chrono::microseconds>(steady_clock::now() - time_origin);
     entry.log_class = log_class;
     entry.log_level = log_level;
-
-    snprintf(formatting_buffer.data(), formatting_buffer.size(), "%s:%s:%u", filename, function,
-             line_nr);
-    entry.location = std::string(formatting_buffer.data());
-
-    vsnprintf(formatting_buffer.data(), formatting_buffer.size(), format, args);
-    entry.message = std::string(formatting_buffer.data());
+    entry.filename = Common::TrimSourcePath(filename);
+    entry.line_num = line_nr;
+    entry.function = function;
+    entry.message = std::move(message);
 
     return entry;
 }
@@ -131,15 +127,27 @@ void SetFilter(Filter* new_filter) {
     filter = new_filter;
 }
 
-void LogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_nr,
+void LogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
                 const char* function, const char* format, ...) {
-    if (filter != nullptr && !filter->CheckMessage(log_class, log_level))
+    if (filter && !filter->CheckMessage(log_class, log_level))
         return;
-
+    std::array<char, 4 * 1024> formatting_buffer;
     va_list args;
     va_start(args, format);
-    Entry entry = CreateEntry(log_class, log_level, filename, line_nr, function, format, args);
+    vsnprintf(formatting_buffer.data(), formatting_buffer.size(), format, args);
     va_end(args);
+    Entry entry = CreateEntry(log_class, log_level, filename, line_num, function,
+                              std::string(formatting_buffer.data()));
+
+    PrintColoredMessage(entry);
+}
+
+void FmtLogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
+                   const char* function, const char* format, const fmt::ArgList& args) {
+    if (filter && !filter->CheckMessage(log_class, log_level))
+        return;
+    Entry entry =
+        CreateEntry(log_class, log_level, filename, line_num, function, fmt::format(format, args));
 
     PrintColoredMessage(entry);
 }

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -22,13 +22,16 @@ struct Entry {
     std::chrono::microseconds timestamp;
     Class log_class;
     Level log_level;
-    std::string location;
+    std::string filename;
+    unsigned int line_num;
+    std::string function;
     std::string message;
 
     Entry() = default;
     Entry(Entry&& o) = default;
 
     Entry& operator=(Entry&& o) = default;
+    Entry& operator=(const Entry& o) = default;
 };
 
 /**
@@ -44,7 +47,7 @@ const char* GetLevelName(Level log_level);
 
 /// Creates a log entry by formatting the given source location, and message.
 Entry CreateEntry(Class log_class, Level log_level, const char* filename, unsigned int line_nr,
-                  const char* function, const char* format, va_list args);
+                  const char* function, std::string message);
 
 void SetFilter(Filter* filter);
 } // namespace Log

--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -65,14 +65,14 @@ bool Filter::ParseFilterRule(const std::string::const_iterator begin,
                              const std::string::const_iterator end) {
     auto level_separator = std::find(begin, end, ':');
     if (level_separator == end) {
-        LOG_ERROR(Log, "Invalid log filter. Must specify a log level after `:`: %s",
-                  std::string(begin, end).c_str());
+        NGLOG_ERROR(Log, "Invalid log filter. Must specify a log level after `:`: %s",
+                    std::string(begin, end).c_str());
         return false;
     }
 
     const Level level = GetLevelByName(level_separator + 1, end);
     if (level == Level::Count) {
-        LOG_ERROR(Log, "Unknown log level in filter: %s", std::string(begin, end).c_str());
+        NGLOG_ERROR(Log, "Unknown log level in filter: %s", std::string(begin, end).c_str());
         return false;
     }
 
@@ -83,7 +83,7 @@ bool Filter::ParseFilterRule(const std::string::const_iterator begin,
 
     const Class log_class = GetClassByName(begin, level_separator);
     if (log_class == Class::Count) {
-        LOG_ERROR(Log, "Unknown log class in filter: %s", std::string(begin, end).c_str());
+        NGLOG_ERROR(Log, "Unknown log class in filter: %s", std::string(begin, end).c_str());
         return false;
     }
 

--- a/src/common/logging/filter.h
+++ b/src/common/logging/filter.h
@@ -19,7 +19,7 @@ namespace Log {
 class Filter {
 public:
     /// Initializes the filter with all classes having `default_level` as the minimum level.
-    Filter(Level default_level);
+    Filter(Level default_level = Level::Info);
 
     /// Resets the filter so that all classes have `level` as the minimum displayed level.
     void ResetAll(Level level);

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <chrono>
+#include <fmt/format.h>
 #include "common/common_types.h"
 
 namespace Log {
@@ -87,7 +89,7 @@ enum class Class : ClassType {
 };
 
 /// Logs a message to the global logger.
-void LogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_nr,
+void LogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
                 const char* function,
 #ifdef _MSC_VER
                 _Printf_format_string_
@@ -98,6 +100,10 @@ void LogMessage(Class log_class, Level log_level, const char* filename, unsigned
     __attribute__((format(printf, 6, 7)))
 #endif
     ;
+
+void FmtLogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
+                   const char* function, const char* format, const fmt::ArgList& args);
+FMT_VARIADIC(void, FmtLogMessage, Class, Level, const char*, unsigned int, const char*, const char*)
 
 } // namespace Log
 
@@ -121,3 +127,28 @@ void LogMessage(Class log_class, Level log_level, const char* filename, unsigned
     LOG_GENERIC(::Log::Class::log_class, ::Log::Level::Error, __VA_ARGS__)
 #define LOG_CRITICAL(log_class, ...)                                                               \
     LOG_GENERIC(::Log::Class::log_class, ::Log::Level::Critical, __VA_ARGS__)
+
+// Define the fmt lib macros
+#ifdef _DEBUG
+#define NGLOG_TRACE(log_class, ...)                                                                \
+    ::Log::FmtLogMessage(::Log::Class::log_class, ::Log::Level::Trace, __FILE__, __LINE__,         \
+                         __func__, __VA_ARGS__)
+#else
+#define NGLOG_TRACE(log_class, fmt, ...) (void(0))
+#endif
+
+#define NGLOG_DEBUG(log_class, ...)                                                                \
+    ::Log::FmtLogMessage(::Log::Class::log_class, ::Log::Level::Debug, __FILE__, __LINE__,         \
+                         __func__, __VA_ARGS__)
+#define NGLOG_INFO(log_class, ...)                                                                 \
+    ::Log::FmtLogMessage(::Log::Class::log_class, ::Log::Level::Info, __FILE__, __LINE__,          \
+                         __func__, __VA_ARGS__)
+#define NGLOG_WARNING(log_class, ...)                                                              \
+    ::Log::FmtLogMessage(::Log::Class::log_class, ::Log::Level::Warning, __FILE__, __LINE__,       \
+                         __func__, __VA_ARGS__)
+#define NGLOG_ERROR(log_class, ...)                                                                \
+    ::Log::FmtLogMessage(::Log::Class::log_class, ::Log::Level::Error, __FILE__, __LINE__,         \
+                         __func__, __VA_ARGS__)
+#define NGLOG_CRITICAL(log_class, ...)                                                             \
+    ::Log::FmtLogMessage(::Log::Class::log_class, ::Log::Level::Critical, __FILE__, __LINE__,      \
+                         __func__, __VA_ARGS__)

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <chrono>
 #include <fmt/format.h>
 #include "common/common_types.h"
 

--- a/src/common/logging/text_formatter.h
+++ b/src/common/logging/text_formatter.h
@@ -10,20 +10,8 @@ namespace Log {
 
 struct Entry;
 
-/**
- * Attempts to trim an arbitrary prefix from `path`, leaving only the part starting at `root`. It's
- * intended to be used to strip a system-specific build directory from the `__FILE__` macro,
- * leaving only the path relative to the sources root.
- *
- * @param path The input file path as a null-terminated string
- * @param root The name of the root source directory as a null-terminated string. Path up to and
- *             including the last occurrence of this name will be stripped
- * @return A pointer to the same string passed as `path`, but starting at the trimmed portion
- */
-const char* TrimSourcePath(const char* path, const char* root = "src");
-
 /// Formats a log entry into the provided text buffer.
-void FormatLogMessage(const Entry& entry, char* out_text, size_t text_len);
+std::string FormatLogMessage(const Entry& entry);
 /// Formats and prints a log entry to stderr.
 void PrintMessage(const Entry& entry);
 /// Prints the same message as `PrintMessage`, but colored acoording to the severity level.

--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -462,4 +462,27 @@ std::string StringFromFixedZeroTerminatedBuffer(const char* buffer, size_t max_l
 
     return std::string(buffer, len);
 }
+
+const char* TrimSourcePath(const char* path, const char* root) {
+    const char* p = path;
+
+    while (*p != '\0') {
+        const char* next_slash = p;
+        while (*next_slash != '\0' && *next_slash != '/' && *next_slash != '\\') {
+            ++next_slash;
+        }
+
+        bool is_src = Common::ComparePartialString(p, next_slash, root);
+        p = next_slash;
+
+        if (*p != '\0') {
+            ++p;
+        }
+        if (is_src) {
+            path = p;
+        }
+    }
+    return path;
+}
+
 } // namespace Common

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -134,4 +134,17 @@ bool ComparePartialString(InIt begin, InIt end, const char* other) {
  * NUL-terminated then the string ends at max_len characters.
  */
 std::string StringFromFixedZeroTerminatedBuffer(const char* buffer, size_t max_len);
+
+/**
+ * Attempts to trim an arbitrary prefix from `path`, leaving only the part starting at `root`. It's
+ * intended to be used to strip a system-specific build directory from the `__FILE__` macro,
+ * leaving only the path relative to the sources root.
+ *
+ * @param path The input file path as a null-terminated string
+ * @param root The name of the root source directory as a null-terminated string. Path up to and
+ *             including the last occurrence of this name will be stripped
+ * @return A pointer to the same string passed as `path`, but starting at the trimmed portion
+ */
+const char* TrimSourcePath(const char* path, const char* root = "src");
+
 } // namespace Common

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -387,7 +387,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
 }
 
 void GMainWindow::BootGame(const QString& filename) {
-    LOG_INFO(Frontend, "yuzu starting...");
+    NGLOG_INFO(Frontend, "yuzu starting...");
     StoreRecentFile(filename); // Put the filename on top of the list
 
     if (!LoadROM(filename))


### PR DESCRIPTION
Add a new set of logging macros based on fmtlib
Similar but not exactly the same as citra-emu/citra#3533, with the main difference being:
* Citra currently uses a different version of fmt, which does not support `FMT_VARIADIC` anymore so
`make_args` is used instead. On the other hand, yuzu uses fmt 4.1.0 which doesn't have `make_args` yet, so `FMT_VARIADIC` is used.

Also, to prove that this works, "yuzu starting..." is changed to be logged with the new macro in yuzu/main.cpp

As discussed in Discord, do we want to do the migration all at once in this PR? Or, make it a two-step process, have this merged then work on the migration.

The main reason that in citra the process is split is due to the number of PRs in the queue, but there seems to be significantly less over here, so it is possible to do all at once.