### PR TITLE
Remove more N3DS References

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -23,7 +23,6 @@
 namespace Memory {
 
 static std::array<u8, Memory::VRAM_SIZE> vram;
-static std::array<u8, Memory::N3DS_EXTRA_RAM_SIZE> n3ds_extra_ram;
 
 static PageTable* current_page_table = nullptr;
 
@@ -244,7 +243,6 @@ u8* GetPhysicalPointer(PAddr address) {
         {IO_AREA_PADDR, IO_AREA_SIZE},
         {DSP_RAM_PADDR, DSP_RAM_SIZE},
         {FCRAM_PADDR, FCRAM_N3DS_SIZE},
-        {N3DS_EXTRA_RAM_PADDR, N3DS_EXTRA_RAM_SIZE},
     };
 
     const auto area =
@@ -282,9 +280,6 @@ u8* GetPhysicalPointer(PAddr address) {
             }
         }
         ASSERT_MSG(target_pointer != nullptr, "Invalid FCRAM address");
-        break;
-    case N3DS_EXTRA_RAM_PADDR:
-        target_pointer = n3ds_extra_ram.data() + offset_into_region;
         break;
     default:
         UNREACHABLE();
@@ -609,8 +604,6 @@ boost::optional<PAddr> TryVirtualToPhysicalAddress(const VAddr addr) {
         return addr - DSP_RAM_VADDR + DSP_RAM_PADDR;
     } else if (addr >= IO_AREA_VADDR && addr < IO_AREA_VADDR_END) {
         return addr - IO_AREA_VADDR + IO_AREA_PADDR;
-    } else if (addr >= N3DS_EXTRA_RAM_VADDR && addr < N3DS_EXTRA_RAM_VADDR_END) {
-        return addr - N3DS_EXTRA_RAM_VADDR + N3DS_EXTRA_RAM_PADDR;
     }
 
     return boost::none;
@@ -637,8 +630,6 @@ boost::optional<VAddr> PhysicalToVirtualAddress(const PAddr addr) {
         return addr - DSP_RAM_PADDR + DSP_RAM_VADDR;
     } else if (addr >= IO_AREA_PADDR && addr < IO_AREA_PADDR_END) {
         return addr - IO_AREA_PADDR + IO_AREA_VADDR;
-    } else if (addr >= N3DS_EXTRA_RAM_PADDR && addr < N3DS_EXTRA_RAM_PADDR_END) {
-        return addr - N3DS_EXTRA_RAM_PADDR + N3DS_EXTRA_RAM_VADDR;
     }
 
     return boost::none;

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -98,12 +98,6 @@ enum : PAddr {
     VRAM_SIZE = 0x00600000, ///< VRAM size (6MB)
     VRAM_PADDR_END = VRAM_PADDR + VRAM_SIZE,
 
-    /// New 3DS additional memory. Supposedly faster than regular FCRAM. Part of it can be used by
-    /// applications and system modules if mapped via the ExHeader.
-    N3DS_EXTRA_RAM_PADDR = 0x1F000000,
-    N3DS_EXTRA_RAM_SIZE = 0x00400000, ///< New 3DS additional memory size (4MB)
-    N3DS_EXTRA_RAM_PADDR_END = N3DS_EXTRA_RAM_PADDR + N3DS_EXTRA_RAM_SIZE,
-
     /// DSP memory
     DSP_RAM_PADDR = 0x1FF00000,
     DSP_RAM_SIZE = 0x00080000, ///< DSP memory size (512KB)
@@ -119,7 +113,6 @@ enum : PAddr {
     FCRAM_SIZE = 0x08000000,      ///< FCRAM size on the Old 3DS (128MB)
     FCRAM_N3DS_SIZE = 0x10000000, ///< FCRAM size on the New 3DS (256MB)
     FCRAM_PADDR_END = FCRAM_PADDR + FCRAM_SIZE,
-    FCRAM_N3DS_PADDR_END = FCRAM_PADDR + FCRAM_N3DS_SIZE,
 };
 
 /// Virtual user-space memory regions
@@ -134,10 +127,6 @@ enum : VAddr {
     LINEAR_HEAP_VADDR = 0x14000000,
     LINEAR_HEAP_SIZE = 0x08000000,
     LINEAR_HEAP_VADDR_END = LINEAR_HEAP_VADDR + LINEAR_HEAP_SIZE,
-
-    /// Maps 1:1 to New 3DS additional memory
-    N3DS_EXTRA_RAM_VADDR = 0x1E800000,
-    N3DS_EXTRA_RAM_VADDR_END = N3DS_EXTRA_RAM_VADDR + N3DS_EXTRA_RAM_SIZE,
 
     /// Maps 1:1 to the IO register area.
     IO_AREA_VADDR = 0x1EC00000,


### PR DESCRIPTION
Let me start this off by saying: **PLEASE, BE CAREFUL**.

This is probably very dirty, but because I have updated my Switch to 4.1.0 already (I love Odyssey sue me) I am unable to do extensive tests on it. I used SpaceNX and that one Tic-Tac-Toe Game as tests, which behave the same way after this commit.

Now, what this PR does is just remove some Citra-Specific stuff, nothing fancy, however I don't know whether or not they are still _used_ (hence the carefulness). I couldn't find any references in the code, but hey. I suck. So who knows? I guess you do so have fun out there