### PR TITLE
Update Dialog from citra to yuzu

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -350,9 +350,9 @@ bool GMainWindow::LoadROM(const QString& filename) {
                    "yuzu. A real Switch is required.<br/><br/>"
                    "For more information on dumping and decrypting games, please see the following "
                    "wiki pages: <ul>"
-                   "<li><a href='https://citra-emu.org/wiki/dumping-game-cartridges/'>Dumping Game "
+                   "<li><a href='https://yuzu-emu.org/wiki/dumping-game-cartridges/'>Dumping Game "
                    "Cartridges</a></li>"
-                   "<li><a href='https://citra-emu.org/wiki/dumping-installed-titles/'>Dumping "
+                   "<li><a href='https://yuzu-emu.org/wiki/dumping-installed-titles/'>Dumping "
                    "Installed Titles</a></li>"
                    "</ul>"));
             break;
@@ -677,8 +677,8 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
         "The game you are trying to load requires additional files from your Switch to be dumped "
         "before playing.<br/><br/>For more information on dumping these files, please see the "
         "following wiki page: <a "
-        "href='https://citra-emu.org/wiki/"
-        "dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/'>Dumping System "
+        "href='https://yuzu-emu.org/wiki/"
+        "dumping-system-archives-and-the-shared-fonts-from-a-switch-console/'>Dumping System "
         "Archives and the Shared Fonts from a Switch Console</a>.<br/><br/>Would you like to quit "
         "back to the game list? Continuing emulation may result in crashes, corrupted save "
         "data, or other bugs.");

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -673,18 +673,18 @@ void GMainWindow::UpdateStatusBar() {
 void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string details) {
     QMessageBox::StandardButton answer;
     QString status_message;
-    const QString common_message =
-        tr("The game you are trying to load requires additional files from your 3DS to be dumped "
-           "before playing.<br/><br/>For more information on dumping these files, please see the "
-           "following wiki page: <a "
-           "href='https://citra-emu.org/wiki/"
-           "dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/'>Dumping System "
-           "Archives and the Shared Fonts from a 3DS Console</a>.<br/><br/>Would you like to quit "
-           "back to the game list? Continuing emulation may result in crashes, corrupted save "
-           "data, or other bugs.");
+    const QString common_message = tr(
+        "The game you are trying to load requires additional files from your Switch to be dumped "
+        "before playing.<br/><br/>For more information on dumping these files, please see the "
+        "following wiki page: <a "
+        "href='https://citra-emu.org/wiki/"
+        "dumping-system-archives-and-the-shared-fonts-from-a-3ds-console/'>Dumping System "
+        "Archives and the Shared Fonts from a Switch Console</a>.<br/><br/>Would you like to quit "
+        "back to the game list? Continuing emulation may result in crashes, corrupted save "
+        "data, or other bugs.");
     switch (result) {
     case Core::System::ResultStatus::ErrorSystemFiles: {
-        QString message = "Citra was unable to locate a 3DS system archive";
+        QString message = "yuzu was unable to locate a Switch system archive";
         if (!details.empty()) {
             message.append(tr(": %1. ").arg(details.c_str()));
         } else {
@@ -699,7 +699,7 @@ void GMainWindow::OnCoreError(Core::System::ResultStatus result, std::string det
     }
 
     case Core::System::ResultStatus::ErrorSharedFont: {
-        QString message = tr("Citra was unable to locate the 3DS shared fonts. ");
+        QString message = tr("yuzu was unable to locate the Switch shared fonts. ");
         message.append(common_message);
         answer = QMessageBox::question(this, tr("Shared Fonts Not Found"), message,
                                        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -147,7 +147,7 @@ int main(int argc, char** argv) {
         LOG_CRITICAL(Frontend, "The game that you are trying to load must be decrypted before "
                                "being used with yuzu. \n\n For more information on dumping and "
                                "decrypting games, please refer to: "
-                               "https://citra-emu.org/wiki/dumping-game-cartridges/");
+                               "https://yuzu-emu.org/wiki/dumping-game-cartridges/");
         return -1;
     case Core::System::ResultStatus::ErrorLoader_ErrorInvalidFormat:
         LOG_CRITICAL(Frontend, "Error while loading ROM: The ROM format is not supported.");


### PR DESCRIPTION
Just updates the Messages to say to reference Yuzu and the Switch instead of Citra and the 3DS