### PR TITLE
Tegra progress 3

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -439,7 +439,8 @@ void ReadBlock(const Kernel::Process& process, const VAddr src_addr, void* dest_
     size_t page_offset = src_addr & PAGE_MASK;
 
     while (remaining_size > 0) {
-        const size_t copy_amount = std::min(PAGE_SIZE - page_offset, remaining_size);
+        const size_t copy_amount =
+            std::min(static_cast<size_t>(PAGE_SIZE) - page_offset, remaining_size);
         const VAddr current_vaddr = static_cast<VAddr>((page_index << PAGE_BITS) + page_offset);
 
         switch (page_table.attributes[page_index]) {
@@ -501,7 +502,8 @@ void WriteBlock(const Kernel::Process& process, const VAddr dest_addr, const voi
     size_t page_offset = dest_addr & PAGE_MASK;
 
     while (remaining_size > 0) {
-        const size_t copy_amount = std::min(PAGE_SIZE - page_offset, remaining_size);
+        const size_t copy_amount =
+            std::min(static_cast<size_t>(PAGE_SIZE) - page_offset, remaining_size);
         const VAddr current_vaddr = static_cast<VAddr>((page_index << PAGE_BITS) + page_offset);
 
         switch (page_table.attributes[page_index]) {
@@ -548,7 +550,8 @@ void ZeroBlock(const Kernel::Process& process, const VAddr dest_addr, const size
     static const std::array<u8, PAGE_SIZE> zeros = {};
 
     while (remaining_size > 0) {
-        const size_t copy_amount = std::min(PAGE_SIZE - page_offset, remaining_size);
+        const size_t copy_amount =
+            std::min(static_cast<size_t>(PAGE_SIZE) - page_offset, remaining_size);
         const VAddr current_vaddr = static_cast<VAddr>((page_index << PAGE_BITS) + page_offset);
 
         switch (page_table.attributes[page_index]) {
@@ -587,7 +590,8 @@ void CopyBlock(const Kernel::Process& process, VAddr dest_addr, VAddr src_addr, 
     size_t page_offset = src_addr & PAGE_MASK;
 
     while (remaining_size > 0) {
-        const size_t copy_amount = std::min(PAGE_SIZE - page_offset, remaining_size);
+        const size_t copy_amount =
+            std::min(static_cast<size_t>(PAGE_SIZE) - page_offset, remaining_size);
         const VAddr current_vaddr = static_cast<VAddr>((page_index << PAGE_BITS) + page_offset);
 
         switch (page_table.attributes[page_index]) {

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -255,6 +255,11 @@ enum class FlushMode {
 };
 
 /**
+ * Mark each page touching the region as cached.
+ */
+void RasterizerMarkRegionCached(VAddr start, u64 size, bool cached);
+
+/**
  * Flushes and invalidates any externally cached rasterizer resources touching the given virtual
  * address region.
  */

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -31,6 +31,7 @@ add_library(video_core STATIC
     renderer_opengl/gl_state.h
     renderer_opengl/gl_stream_buffer.cpp
     renderer_opengl/gl_stream_buffer.h
+    renderer_opengl/maxwell_to_gl.h
     renderer_opengl/renderer_opengl.cpp
     renderer_opengl/renderer_opengl.h
     textures/decoders.cpp

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -7,8 +7,11 @@
 #include "core/core.h"
 #include "video_core/debug_utils/debug_utils.h"
 #include "video_core/engines/maxwell_3d.h"
+#include "video_core/rasterizer_interface.h"
+#include "video_core/renderer_base.h"
 #include "video_core/textures/decoders.h"
 #include "video_core/textures/texture.h"
+#include "video_core/video_core.h"
 
 namespace Tegra {
 namespace Engines {
@@ -174,7 +177,9 @@ void Maxwell3D::ProcessQueryGet() {
 }
 
 void Maxwell3D::DrawArrays() {
-    LOG_WARNING(HW_GPU, "Game requested a DrawArrays, ignoring");
+    LOG_DEBUG(HW_GPU, "called, topology=%d, count=%d", regs.draw.topology.Value(),
+              regs.vertex_buffer.count);
+
     auto debug_context = Core::System::GetInstance().GetGPUDebugContext();
 
     if (debug_context) {
@@ -184,6 +189,8 @@ void Maxwell3D::DrawArrays() {
     if (debug_context) {
         debug_context->OnEvent(Tegra::DebugContext::Event::FinishedPrimitiveBatch, nullptr);
     }
+
+    VideoCore::g_renderer->Rasterizer()->AccelerateDrawBatch(false /*is_indexed*/);
 }
 
 void Maxwell3D::BindTextureInfoBuffer(const std::vector<u32>& parameters) {

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -11,6 +11,7 @@
 #include "common/bit_field.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
+#include "common/math_util.h"
 #include "video_core/gpu.h"
 #include "video_core/memory_manager.h"
 #include "video_core/textures/texture.h"
@@ -281,6 +282,15 @@ public:
                     };
                     float depth_range_near;
                     float depth_range_far;
+
+                    MathUtil::Rectangle<s32> GetRect() const {
+                        return {
+                            static_cast<s32>(x),          // left
+                            static_cast<s32>(y + height), // top
+                            static_cast<s32>(x + width),  // right
+                            static_cast<s32>(y)           // bottom
+                        };
+                    };
                 } viewport[NumViewports];
 
                 INSERT_PADDING_WORDS(0x1D);

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -222,6 +222,10 @@ public:
                 UNREACHABLE();
                 return {};
             }
+
+            bool IsNormalized() const {
+                return (type == Type::SignedNorm) || (type == Type::UnsignedNorm);
+            }
         };
 
         enum class PrimitiveTopology : u32 {

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -229,6 +229,41 @@ public:
                     BitField<21, 6, VertexSize> size;
                     BitField<27, 3, VertexType> type;
                     BitField<31, 1, u32> bgra;
+
+                    u32 SizeInBytes() const {
+                        switch (size) {
+                        case VertexSize::Size_32_32_32_32:
+                            return 16;
+                        case VertexSize::Size_32_32_32:
+                            return 12;
+                        case VertexSize::Size_16_16_16_16:
+                            return 8;
+                        case VertexSize::Size_32_32:
+                            return 8;
+                        case VertexSize::Size_16_16_16:
+                            return 6;
+                        case VertexSize::Size_8_8_8_8:
+                            return 4;
+                        case VertexSize::Size_16_16:
+                            return 4;
+                        case VertexSize::Size_32:
+                            return 4;
+                        case VertexSize::Size_8_8_8:
+                            return 3;
+                        case VertexSize::Size_8_8:
+                            return 2;
+                        case VertexSize::Size_16:
+                            return 2;
+                        case VertexSize::Size_8:
+                            return 1;
+                        case VertexSize::Size_10_10_10_2:
+                            return 4;
+                        case VertexSize::Size_11_11_10:
+                            return 4;
+                        default:
+                            UNREACHABLE();
+                        }
+                    }
                 } vertex_attrib_format[NumVertexAttributes];
 
                 INSERT_PADDING_WORDS(0xF);

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -202,22 +202,22 @@ public:
                 return {};
             }
 
-            std::string TypeToString() const {
+            std::string TypeString() const {
                 switch (type) {
                 case Type::SignedNorm:
-                    return "SignedNorm";
+                    return "SNORM";
                 case Type::UnsignedNorm:
-                    return "UnsignedNorm";
+                    return "UNORM";
                 case Type::SignedInt:
-                    return "SignedInt";
+                    return "SINT";
                 case Type::UnsignedInt:
-                    return "UnsignedInt";
+                    return "UINT";
                 case Type::UnsignedScaled:
-                    return "UnsignedScaled";
+                    return "USCALED";
                 case Type::SignedScaled:
-                    return "SignedScaled";
+                    return "SSCALED";
                 case Type::Float:
-                    return "Float";
+                    return "FLOAT";
                 }
                 UNREACHABLE();
                 return {};

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -60,88 +60,169 @@ public:
             Fragment = 4,
         };
 
-        enum class VertexSize : u32 {
-            Size_32_32_32_32 = 0x01,
-            Size_32_32_32 = 0x02,
-            Size_16_16_16_16 = 0x03,
-            Size_32_32 = 0x04,
-            Size_16_16_16 = 0x05,
-            Size_8_8_8_8 = 0x0a,
-            Size_16_16 = 0x0f,
-            Size_32 = 0x12,
-            Size_8_8_8 = 0x13,
-            Size_8_8 = 0x18,
-            Size_16 = 0x1b,
-            Size_8 = 0x1d,
-            Size_10_10_10_2 = 0x30,
-            Size_11_11_10 = 0x31,
-        };
+        struct VertexAttribute {
+            enum class Size : u32 {
+                Size_32_32_32_32 = 0x01,
+                Size_32_32_32 = 0x02,
+                Size_16_16_16_16 = 0x03,
+                Size_32_32 = 0x04,
+                Size_16_16_16 = 0x05,
+                Size_8_8_8_8 = 0x0a,
+                Size_16_16 = 0x0f,
+                Size_32 = 0x12,
+                Size_8_8_8 = 0x13,
+                Size_8_8 = 0x18,
+                Size_16 = 0x1b,
+                Size_8 = 0x1d,
+                Size_10_10_10_2 = 0x30,
+                Size_11_11_10 = 0x31,
+            };
 
-        static std::string VertexSizeToString(VertexSize vertex_size) {
-            switch (vertex_size) {
-            case VertexSize::Size_32_32_32_32:
-                return "32_32_32_32";
-            case VertexSize::Size_32_32_32:
-                return "32_32_32";
-            case VertexSize::Size_16_16_16_16:
-                return "16_16_16_16";
-            case VertexSize::Size_32_32:
-                return "32_32";
-            case VertexSize::Size_16_16_16:
-                return "16_16_16";
-            case VertexSize::Size_8_8_8_8:
-                return "8_8_8_8";
-            case VertexSize::Size_16_16:
-                return "16_16";
-            case VertexSize::Size_32:
-                return "32";
-            case VertexSize::Size_8_8_8:
-                return "8_8_8";
-            case VertexSize::Size_8_8:
-                return "8_8";
-            case VertexSize::Size_16:
-                return "16";
-            case VertexSize::Size_8:
-                return "8";
-            case VertexSize::Size_10_10_10_2:
-                return "10_10_10_2";
-            case VertexSize::Size_11_11_10:
-                return "11_11_10";
+            enum class Type : u32 {
+                SignedNorm = 1,
+                UnsignedNorm = 2,
+                SignedInt = 3,
+                UnsignedInt = 4,
+                UnsignedScaled = 5,
+                SignedScaled = 6,
+                Float = 7,
+            };
+
+            union {
+                BitField<0, 5, u32> buffer;
+                BitField<6, 1, u32> constant;
+                BitField<7, 14, u32> offset;
+                BitField<21, 6, Size> size;
+                BitField<27, 3, Type> type;
+                BitField<31, 1, u32> bgra;
+            };
+
+            u32 ComponentCount() const {
+                switch (size) {
+                case Size::Size_32_32_32_32:
+                    return 4;
+                case Size::Size_32_32_32:
+                    return 3;
+                case Size::Size_16_16_16_16:
+                    return 4;
+                case Size::Size_32_32:
+                    return 2;
+                case Size::Size_16_16_16:
+                    return 3;
+                case Size::Size_8_8_8_8:
+                    return 4;
+                case Size::Size_16_16:
+                    return 2;
+                case Size::Size_32:
+                    return 1;
+                case Size::Size_8_8_8:
+                    return 3;
+                case Size::Size_8_8:
+                    return 2;
+                case Size::Size_16:
+                    return 1;
+                case Size::Size_8:
+                    return 1;
+                case Size::Size_10_10_10_2:
+                    return 4;
+                case Size::Size_11_11_10:
+                    return 3;
+                default:
+                    UNREACHABLE();
+                }
             }
-            UNIMPLEMENTED();
-            return {};
-        }
 
-        enum class VertexType : u32 {
-            SignedNorm = 1,
-            UnsignedNorm = 2,
-            SignedInt = 3,
-            UnsignedInt = 4,
-            UnsignedScaled = 5,
-            SignedScaled = 6,
-            Float = 7,
-        };
-
-        static std::string VertexTypeToString(VertexType vertex_type) {
-            switch (vertex_type) {
-            case VertexType::SignedNorm:
-                return "SignedNorm";
-            case VertexType::UnsignedNorm:
-                return "UnsignedNorm";
-            case VertexType::SignedInt:
-                return "SignedInt";
-            case VertexType::UnsignedInt:
-                return "UnsignedInt";
-            case VertexType::UnsignedScaled:
-                return "UnsignedScaled";
-            case VertexType::SignedScaled:
-                return "SignedScaled";
-            case VertexType::Float:
-                return "Float";
+            u32 SizeInBytes() const {
+                switch (size) {
+                case Size::Size_32_32_32_32:
+                    return 16;
+                case Size::Size_32_32_32:
+                    return 12;
+                case Size::Size_16_16_16_16:
+                    return 8;
+                case Size::Size_32_32:
+                    return 8;
+                case Size::Size_16_16_16:
+                    return 6;
+                case Size::Size_8_8_8_8:
+                    return 4;
+                case Size::Size_16_16:
+                    return 4;
+                case Size::Size_32:
+                    return 4;
+                case Size::Size_8_8_8:
+                    return 3;
+                case Size::Size_8_8:
+                    return 2;
+                case Size::Size_16:
+                    return 2;
+                case Size::Size_8:
+                    return 1;
+                case Size::Size_10_10_10_2:
+                    return 4;
+                case Size::Size_11_11_10:
+                    return 4;
+                default:
+                    UNREACHABLE();
+                }
             }
-            UNIMPLEMENTED();
-            return {};
-        }
+
+            std::string SizeString() const {
+                switch (size) {
+                case Size::Size_32_32_32_32:
+                    return "32_32_32_32";
+                case Size::Size_32_32_32:
+                    return "32_32_32";
+                case Size::Size_16_16_16_16:
+                    return "16_16_16_16";
+                case Size::Size_32_32:
+                    return "32_32";
+                case Size::Size_16_16_16:
+                    return "16_16_16";
+                case Size::Size_8_8_8_8:
+                    return "8_8_8_8";
+                case Size::Size_16_16:
+                    return "16_16";
+                case Size::Size_32:
+                    return "32";
+                case Size::Size_8_8_8:
+                    return "8_8_8";
+                case Size::Size_8_8:
+                    return "8_8";
+                case Size::Size_16:
+                    return "16";
+                case Size::Size_8:
+                    return "8";
+                case Size::Size_10_10_10_2:
+                    return "10_10_10_2";
+                case Size::Size_11_11_10:
+                    return "11_11_10";
+                }
+                UNREACHABLE();
+                return {};
+            }
+
+            std::string TypeToString() const {
+                switch (type) {
+                case Type::SignedNorm:
+                    return "SignedNorm";
+                case Type::UnsignedNorm:
+                    return "UnsignedNorm";
+                case Type::SignedInt:
+                    return "SignedInt";
+                case Type::UnsignedInt:
+                    return "UnsignedInt";
+                case Type::UnsignedScaled:
+                    return "UnsignedScaled";
+                case Type::SignedScaled:
+                    return "SignedScaled";
+                case Type::Float:
+                    return "Float";
+                }
+                UNREACHABLE();
+                return {};
+            }
+        };
 
         enum class PrimitiveTopology : u32 {
             Points = 0x0,
@@ -222,49 +303,7 @@ public:
 
                 INSERT_PADDING_WORDS(0x5B);
 
-                union {
-                    BitField<0, 5, u32> buffer;
-                    BitField<6, 1, u32> constant;
-                    BitField<7, 14, u32> offset;
-                    BitField<21, 6, VertexSize> size;
-                    BitField<27, 3, VertexType> type;
-                    BitField<31, 1, u32> bgra;
-
-                    u32 SizeInBytes() const {
-                        switch (size) {
-                        case VertexSize::Size_32_32_32_32:
-                            return 16;
-                        case VertexSize::Size_32_32_32:
-                            return 12;
-                        case VertexSize::Size_16_16_16_16:
-                            return 8;
-                        case VertexSize::Size_32_32:
-                            return 8;
-                        case VertexSize::Size_16_16_16:
-                            return 6;
-                        case VertexSize::Size_8_8_8_8:
-                            return 4;
-                        case VertexSize::Size_16_16:
-                            return 4;
-                        case VertexSize::Size_32:
-                            return 4;
-                        case VertexSize::Size_8_8_8:
-                            return 3;
-                        case VertexSize::Size_8_8:
-                            return 2;
-                        case VertexSize::Size_16:
-                            return 2;
-                        case VertexSize::Size_8:
-                            return 1;
-                        case VertexSize::Size_10_10_10_2:
-                            return 4;
-                        case VertexSize::Size_11_11_10:
-                            return 4;
-                        default:
-                            UNREACHABLE();
-                        }
-                    }
-                } vertex_attrib_format[NumVertexAttributes];
+                VertexAttribute vertex_attrib_format[NumVertexAttributes];
 
                 INSERT_PADDING_WORDS(0xF);
 

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -11,6 +11,7 @@
 #include "common/bit_field.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
+#include "video_core/gpu.h"
 #include "video_core/memory_manager.h"
 #include "video_core/textures/texture.h"
 
@@ -167,9 +168,9 @@ public:
                 struct {
                     u32 address_high;
                     u32 address_low;
-                    u32 horiz;
-                    u32 vert;
-                    u32 format;
+                    u32 width;
+                    u32 height;
+                    Tegra::RenderTargetFormat format;
                     u32 block_dimensions;
                     u32 array_mode;
                     u32 layer_stride;

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -13,7 +13,7 @@
 
 namespace Tegra {
 
-enum class RenderTargetFormat {
+enum class RenderTargetFormat : u32 {
     RGBA8_UNORM = 0xD5,
 };
 

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -14,6 +14,7 @@
 namespace Tegra {
 
 enum class RenderTargetFormat : u32 {
+    NONE = 0x0,
     RGBA8_UNORM = 0xD5,
 };
 

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -15,8 +15,8 @@ class RasterizerInterface {
 public:
     virtual ~RasterizerInterface() {}
 
-    /// Draw the current batch of triangles
-    virtual void DrawTriangles() = 0;
+    /// Draw the current batch of vertex arrays
+    virtual void DrawArrays() = 0;
 
     /// Notify rasterizer that the specified Maxwell register has been changed
     virtual void NotifyMaxwellRegisterChanged(u32 id) = 0;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -22,6 +22,7 @@
 #include "video_core/renderer_opengl/gl_shader_gen.h"
 #include "video_core/renderer_opengl/renderer_opengl.h"
 
+using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 using PixelFormat = SurfaceParams::PixelFormat;
 using SurfaceType = SurfaceParams::SurfaceType;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -263,28 +263,7 @@ void RasterizerOpenGL::DrawArrays() {
                                               surfaces_rect.bottom, surfaces_rect.top))}; // Bottom
 
     // Bind the framebuffer surfaces
-    state.draw.draw_framebuffer = framebuffer.handle;
-    state.Apply();
-
-    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
-                           color_surface != nullptr ? color_surface->texture.handle : 0, 0);
-    if (depth_surface != nullptr) {
-        if (has_stencil) {
-            // attach both depth and stencil
-            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
-                                   depth_surface->texture.handle, 0);
-        } else {
-            // attach depth
-            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D,
-                                   depth_surface->texture.handle, 0);
-            // clear stencil attachment
-            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
-        }
-    } else {
-        // clear both depth and stencil attachment
-        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0,
-                               0);
-    }
+    BindFramebufferSurfaces(color_surface, depth_surface, has_stencil);
 
     // Sync the viewport
     SyncViewport(surfaces_rect, res_scale);
@@ -527,6 +506,32 @@ void main() {
     if (has_ARB_separate_shader_objects) {
         state.draw.shader_program = 0;
         state.Apply();
+    }
+}
+
+void RasterizerOpenGL::BindFramebufferSurfaces(const Surface& color_surface,
+                                               const Surface& depth_surface, bool has_stencil) {
+    state.draw.draw_framebuffer = framebuffer.handle;
+    state.Apply();
+
+    glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D,
+                           color_surface != nullptr ? color_surface->texture.handle : 0, 0);
+    if (depth_surface != nullptr) {
+        if (has_stencil) {
+            // attach both depth and stencil
+            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
+                                   depth_surface->texture.handle, 0);
+        } else {
+            // attach depth
+            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D,
+                                   depth_surface->texture.handle, 0);
+            // clear stencil attachment
+            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
+        }
+    } else {
+        // clear both depth and stencil attachment
+        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0,
+                               0);
     }
 }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -196,7 +196,8 @@ void RasterizerOpenGL::SetupVertexArray(u8* array_ptr, GLintptr buffer_offset) {
 
 void RasterizerOpenGL::SetupVertexShader(VSUniformData* ub_ptr, GLintptr buffer_offset) {
     MICROPROFILE_SCOPE(OpenGL_VS);
-    UNIMPLEMENTED();
+    LOG_CRITICAL(Render_OpenGL, "Emulated shaders are not supported! Using a passthrough shader.");
+    glUseProgramStages(pipeline.handle, GL_VERTEX_SHADER_BIT, current_shader->shader.handle);
 }
 
 void RasterizerOpenGL::SetupFragmentShader(FSUniformData* ub_ptr, GLintptr buffer_offset) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -188,7 +188,7 @@ void RasterizerOpenGL::SetupVertexArray(u8* array_ptr, GLintptr buffer_offset) {
     const u32 data_size{vertex_array.stride * regs.vertex_buffer.count};
     const VAddr data_addr{memory_manager->PhysicalToVirtualAddress(vertex_array.StartAddress())};
     res_cache.FlushRegion(data_addr, data_size, nullptr);
-    std::memcpy(array_ptr, Memory::GetPointer(data_addr), data_size);
+    Memory::ReadBlock(data_addr, array_ptr, data_size);
 
     array_ptr += data_size;
     buffer_offset += data_size;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -20,6 +20,7 @@
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/renderer_opengl/gl_rasterizer.h"
 #include "video_core/renderer_opengl/gl_shader_gen.h"
+#include "video_core/renderer_opengl/maxwell_to_gl.h"
 #include "video_core/renderer_opengl/renderer_opengl.h"
 
 using Maxwell = Tegra::Engines::Maxwell3D::Regs;
@@ -124,14 +125,14 @@ RasterizerOpenGL::RasterizerOpenGL() {
         glBufferData(GL_UNIFORM_BUFFER, sizeof(VSUniformData), nullptr, GL_STREAM_COPY);
         glBindBufferBase(GL_UNIFORM_BUFFER, 1, vs_uniform_buffer.handle);
     } else {
-        ASSERT_MSG(false, "Unimplemented");
+        UNREACHABLE();
     }
 
     accelerate_draw = AccelDraw::Disabled;
 
     glEnable(GL_BLEND);
 
-    LOG_WARNING(HW_GPU, "Sync fixed function OpenGL state here when ready");
+    LOG_CRITICAL(Render_OpenGL, "Sync fixed function OpenGL state here!");
 }
 
 RasterizerOpenGL::~RasterizerOpenGL() {
@@ -200,12 +201,12 @@ void RasterizerOpenGL::SetupVertexShader(VSUniformData* ub_ptr, GLintptr buffer_
 
 void RasterizerOpenGL::SetupFragmentShader(FSUniformData* ub_ptr, GLintptr buffer_offset) {
     MICROPROFILE_SCOPE(OpenGL_FS);
-    ASSERT_MSG(false, "Unimplemented");
+    UNREACHABLE();
 }
 
 bool RasterizerOpenGL::AccelerateDrawBatch(bool is_indexed) {
     if (!has_ARB_separate_shader_objects) {
-        ASSERT_MSG(false, "Unimplemented");
+        UNREACHABLE();
         return false;
     }
 
@@ -438,17 +439,17 @@ void RasterizerOpenGL::FlushAndInvalidateRegion(VAddr addr, u64 size) {
 
 bool RasterizerOpenGL::AccelerateDisplayTransfer(const void* config) {
     MICROPROFILE_SCOPE(OpenGL_Blits);
-    ASSERT_MSG(false, "Unimplemented");
+    UNREACHABLE();
     return true;
 }
 
 bool RasterizerOpenGL::AccelerateTextureCopy(const void* config) {
-    ASSERT_MSG(false, "Unimplemented");
+    UNREACHABLE();
     return true;
 }
 
 bool RasterizerOpenGL::AccelerateFill(const void* config) {
-    ASSERT_MSG(false, "Unimplemented");
+    UNREACHABLE();
     return true;
 }
 
@@ -529,14 +530,14 @@ void main() {
         return;
     }
 
-    LOG_ERROR(HW_GPU, "Emulated shaders are not supported! Using a passthrough shader.");
+    LOG_CRITICAL(Render_OpenGL, "Emulated shaders are not supported! Using a passthrough shader.");
 
     current_shader = &test_shader;
     if (has_ARB_separate_shader_objects) {
         test_shader.shader.Create(vertex_shader, nullptr, fragment_shader, {}, true);
         glActiveShaderProgram(pipeline.handle, test_shader.shader.handle);
     } else {
-        ASSERT_MSG(false, "Unimplemented");
+        UNREACHABLE();
     }
 
     state.draw.shader_program = test_shader.shader.handle;
@@ -549,33 +550,33 @@ void main() {
 }
 
 void RasterizerOpenGL::SyncClipEnabled() {
-    ASSERT_MSG(false, "Unimplemented");
+    UNREACHABLE();
 }
 
 void RasterizerOpenGL::SyncClipCoef() {
-    ASSERT_MSG(false, "Unimplemented");
+    UNREACHABLE();
 }
 
 void RasterizerOpenGL::SyncCullMode() {
-    ASSERT_MSG(false, "Unimplemented");
+    UNREACHABLE();
 }
 
 void RasterizerOpenGL::SyncDepthScale() {
-    ASSERT_MSG(false, "Unimplemented");
+    UNREACHABLE();
 }
 
 void RasterizerOpenGL::SyncDepthOffset() {
-    ASSERT_MSG(false, "Unimplemented");
+    UNREACHABLE();
 }
 
 void RasterizerOpenGL::SyncBlendEnabled() {
-    ASSERT_MSG(false, "Unimplemented");
+    UNREACHABLE();
 }
 
 void RasterizerOpenGL::SyncBlendFuncs() {
-    ASSERT_MSG(false, "Unimplemented");
+    UNREACHABLE();
 }
 
 void RasterizerOpenGL::SyncBlendColor() {
-    ASSERT_MSG(false, "Unimplemented");
+    UNREACHABLE();
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -326,17 +326,7 @@ void RasterizerOpenGL::DrawArrays() {
     state.Apply();
 
     // Draw the vertex batch
-    GLenum primitive_mode;
-    switch (regs.draw.topology) {
-    case Maxwell::PrimitiveTopology::TriangleStrip:
-        primitive_mode = GL_TRIANGLE_STRIP;
-        break;
-    default:
-        UNREACHABLE();
-    }
-
     const bool is_indexed = accelerate_draw == AccelDraw::Indexed;
-
     AnalyzeVertexArray(is_indexed);
     state.draw.vertex_buffer = stream_buffer->GetHandle();
     state.Apply();
@@ -384,7 +374,8 @@ void RasterizerOpenGL::DrawArrays() {
     if (is_indexed) {
         UNREACHABLE();
     } else {
-        glDrawArrays(primitive_mode, 0, regs.vertex_buffer.count);
+        glDrawArrays(MaxwellToGL::PrimitiveTopology(regs.draw.topology), 0,
+                     regs.vertex_buffer.count);
     }
 
     // Disable scissor test

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -178,7 +178,7 @@ void RasterizerOpenGL::SetupVertexArray(u8* array_ptr, GLintptr buffer_offset) {
     for (unsigned index = 0; index < 16; ++index) {
         auto& attrib = regs.vertex_attrib_format[index];
         glVertexAttribPointer(index, attrib.ComponentCount(), MaxwellToGL::VertexType(attrib),
-                              GL_FALSE, vertex_array.stride,
+                              attrib.IsNormalized() ? GL_TRUE : GL_FALSE, vertex_array.stride,
                               reinterpret_cast<GLvoid*>(buffer_offset + attrib.offset));
         glEnableVertexAttribArray(index);
         hw_vao_enabled_attributes[index] = true;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -212,12 +212,12 @@ bool RasterizerOpenGL::AccelerateDrawBatch(bool is_indexed) {
     }
 
     accelerate_draw = is_indexed ? AccelDraw::Indexed : AccelDraw::Arrays;
-    DrawTriangles();
+    DrawArrays();
 
     return true;
 }
 
-void RasterizerOpenGL::DrawTriangles() {
+void RasterizerOpenGL::DrawArrays() {
     if (accelerate_draw == AccelDraw::Disabled)
         return;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -87,6 +87,9 @@ public:
 private:
     struct SamplerInfo {};
 
+    /// Syncs the viewport to match the guest state
+    void SyncViewport(const MathUtil::Rectangle<u32>& surfaces_rect, u16 res_scale);
+
     /// Syncs the clip enabled status to match the guest state
     void SyncClipEnabled();
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -29,7 +29,7 @@ public:
     RasterizerOpenGL();
     ~RasterizerOpenGL() override;
 
-    void DrawTriangles() override;
+    void DrawArrays() override;
     void NotifyMaxwellRegisterChanged(u32 id) override;
     void FlushAll() override;
     void FlushRegion(VAddr addr, u64 size) override;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -87,6 +87,10 @@ public:
 private:
     struct SamplerInfo {};
 
+    /// Binds the framebuffer color and depth surface
+    void BindFramebufferSurfaces(const Surface& color_surface, const Surface& depth_surface,
+                                 bool has_stencil);
+
     /// Syncs the viewport to match the guest state
     void SyncViewport(const MathUtil::Rectangle<u32>& surfaces_rect, u16 res_scale);
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -139,7 +139,7 @@ private:
     OGLVertexArray hw_vao;
     std::array<bool, 16> hw_vao_enabled_attributes;
 
-    std::array<SamplerInfo, 3> texture_samplers;
+    std::array<SamplerInfo, 32> texture_samplers;
     static constexpr size_t VERTEX_BUFFER_SIZE = 128 * 1024 * 1024;
     std::unique_ptr<OGLStreamBuffer> vertex_buffer;
     OGLBuffer uniform_buffer;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1098,7 +1098,7 @@ SurfaceSurfaceRect_Tuple RasterizerCacheOpenGL::GetFramebufferSurfaces(
     color_params.pixel_format = SurfaceParams::PixelFormatFromRenderTargetFormat(config.format);
     color_params.UpdateParams();
 
-    ASSERT(!using_depth_fb, "depth buffer is unimplemented");
+    ASSERT_MSG(!using_depth_fb, "depth buffer is unimplemented");
     // depth_params.addr = config.GetDepthBufferPhysicalAddress();
     // depth_params.pixel_format = SurfaceParams::PixelFormatFromDepthFormat(config.depth_format);
     // depth_params.UpdateParams();

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -116,6 +116,15 @@ struct SurfaceParams {
         return GetFormatBpp(pixel_format);
     }
 
+    static PixelFormat PixelFormatFromRenderTargetFormat(Tegra::RenderTargetFormat format) {
+        switch (format) {
+        case Tegra::RenderTargetFormat::RGBA8_UNORM:
+            return PixelFormat::RGBA8;
+        default:
+            UNREACHABLE();
+        }
+    }
+
     static PixelFormat PixelFormatFromGPUPixelFormat(Tegra::FramebufferConfig::PixelFormat format) {
         switch (format) {
         case Tegra::FramebufferConfig::PixelFormat::ABGR8:
@@ -308,7 +317,7 @@ public:
 
     /// Get the color and depth surfaces based on the framebuffer configuration
     SurfaceSurfaceRect_Tuple GetFramebufferSurfaces(bool using_color_fb, bool using_depth_fb,
-                                                    const MathUtil::Rectangle<s32>& viewport_rect);
+                                                    const MathUtil::Rectangle<s32>& viewport);
 
     /// Get a surface that matches the fill config
     Surface GetFillSurface(const void* config);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -41,7 +41,7 @@ static_assert(std::is_same<SurfaceRegions::interval_type, SurfaceCache::interval
 using SurfaceRect_Tuple = std::tuple<Surface, MathUtil::Rectangle<u32>>;
 using SurfaceSurfaceRect_Tuple = std::tuple<Surface, Surface, MathUtil::Rectangle<u32>>;
 
-using PageMap = boost::icl::interval_map<u32, int>;
+using PageMap = boost::icl::interval_map<u64, int>;
 
 enum class ScaleMatch {
     Exact,   // only accept same res scale

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -26,7 +26,7 @@ public:
           sanitize_mul(sanitize_mul), emit_cb(emit_cb), setemit_cb(setemit_cb) {}
 
     std::string Decompile() {
-        UNIMPLEMENTED();
+        UNREACHABLE();
         return {};
     }
 

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -8,12 +8,12 @@
 namespace GLShader {
 
 std::string GenerateVertexShader(const MaxwellVSConfig& config) {
-    UNIMPLEMENTED();
+    UNREACHABLE();
     return {};
 }
 
 std::string GenerateFragmentShader(const MaxwellFSConfig& config) {
-    UNIMPLEMENTED();
+    UNREACHABLE();
     return {};
 }
 

--- a/src/video_core/renderer_opengl/gl_shader_util.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_util.cpp
@@ -38,8 +38,8 @@ GLuint LoadProgram(const char* vertex_shader, const char* geometry_shader,
             if (result == GL_TRUE) {
                 LOG_DEBUG(Render_OpenGL, "%s", &vertex_shader_error[0]);
             } else {
-                LOG_ERROR(Render_OpenGL, "Error compiling vertex shader:\n%s",
-                          &vertex_shader_error[0]);
+                LOG_CRITICAL(Render_OpenGL, "Error compiling vertex shader:\n%s",
+                             &vertex_shader_error[0]);
             }
         }
     }
@@ -62,8 +62,8 @@ GLuint LoadProgram(const char* vertex_shader, const char* geometry_shader,
             if (result == GL_TRUE) {
                 LOG_DEBUG(Render_OpenGL, "%s", &geometry_shader_error[0]);
             } else {
-                LOG_ERROR(Render_OpenGL, "Error compiling geometry shader:\n%s",
-                          &geometry_shader_error[0]);
+                LOG_CRITICAL(Render_OpenGL, "Error compiling geometry shader:\n%s",
+                             &geometry_shader_error[0]);
             }
         }
     }
@@ -86,8 +86,8 @@ GLuint LoadProgram(const char* vertex_shader, const char* geometry_shader,
             if (result == GL_TRUE) {
                 LOG_DEBUG(Render_OpenGL, "%s", &fragment_shader_error[0]);
             } else {
-                LOG_ERROR(Render_OpenGL, "Error compiling fragment shader:\n%s",
-                          &fragment_shader_error[0]);
+                LOG_CRITICAL(Render_OpenGL, "Error compiling fragment shader:\n%s",
+                             &fragment_shader_error[0]);
             }
         }
     }
@@ -128,20 +128,20 @@ GLuint LoadProgram(const char* vertex_shader, const char* geometry_shader,
         if (result == GL_TRUE) {
             LOG_DEBUG(Render_OpenGL, "%s", &program_error[0]);
         } else {
-            LOG_ERROR(Render_OpenGL, "Error linking shader:\n%s", &program_error[0]);
+            LOG_CRITICAL(Render_OpenGL, "Error linking shader:\n%s", &program_error[0]);
         }
     }
 
     // If the program linking failed at least one of the shaders was probably bad
     if (result == GL_FALSE) {
         if (vertex_shader) {
-            LOG_ERROR(Render_OpenGL, "Vertex shader:\n%s", vertex_shader);
+            LOG_CRITICAL(Render_OpenGL, "Vertex shader:\n%s", vertex_shader);
         }
         if (geometry_shader) {
-            LOG_ERROR(Render_OpenGL, "Geometry shader:\n%s", geometry_shader);
+            LOG_CRITICAL(Render_OpenGL, "Geometry shader:\n%s", geometry_shader);
         }
         if (fragment_shader) {
-            LOG_ERROR(Render_OpenGL, "Fragment shader:\n%s", fragment_shader);
+            LOG_CRITICAL(Render_OpenGL, "Fragment shader:\n%s", fragment_shader);
         }
     }
     ASSERT_MSG(result == GL_TRUE, "Shader not linked");

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -85,7 +85,7 @@ public:
     struct {
         GLuint texture_2d; // GL_TEXTURE_BINDING_2D
         GLuint sampler;    // GL_SAMPLER_BINDING
-    } texture_units[3];
+    } texture_units[32];
 
     struct {
         GLuint texture_buffer; // GL_TEXTURE_BINDING_BUFFER

--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -37,4 +37,14 @@ inline GLenum VertexType(Maxwell::VertexAttribute attrib) {
     return {};
 }
 
+inline GLenum PrimitiveTopology(Maxwell::PrimitiveTopology topology) {
+    switch (topology) {
+    case Maxwell::PrimitiveTopology::TriangleStrip:
+        return GL_TRIANGLE_STRIP;
+    }
+    LOG_CRITICAL(Render_OpenGL, "Unimplemented primitive topology=%d", topology);
+    UNREACHABLE();
+    return {};
+}
+
 } // namespace MaxwellToGL

--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -23,7 +23,7 @@ inline GLenum VertexType(Maxwell::VertexAttribute attrib) {
             return GL_UNSIGNED_BYTE;
         }
 
-        LOG_CRITICAL(Render_OpenGL, "Unimplemented vertex size=%s", attrib.SizeString());
+        LOG_CRITICAL(Render_OpenGL, "Unimplemented vertex size=%s", attrib.SizeString().c_str());
         UNREACHABLE();
         return {};
     }
@@ -32,7 +32,7 @@ inline GLenum VertexType(Maxwell::VertexAttribute attrib) {
         return GL_FLOAT;
     }
 
-    LOG_CRITICAL(Render_OpenGL, "Unimplemented vertex type=%s", attrib.TypeString());
+    LOG_CRITICAL(Render_OpenGL, "Unimplemented vertex type=%s", attrib.TypeString().c_str());
     UNREACHABLE();
     return {};
 }

--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -1,0 +1,40 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+#include <glad/glad.h>
+#include "common/common_types.h"
+#include "common/logging/log.h"
+#include "video_core/engines/maxwell_3d.h"
+
+namespace MaxwellToGL {
+
+using Maxwell = Tegra::Engines::Maxwell3D::Regs;
+
+inline GLenum VertexType(Maxwell::VertexAttribute attrib) {
+    switch (attrib.type) {
+    case Maxwell::VertexAttribute::Type::UnsignedNorm: {
+
+        switch (attrib.size) {
+        case Maxwell::VertexAttribute::Size::Size_8_8_8_8:
+            return GL_UNSIGNED_BYTE;
+        }
+
+        LOG_CRITICAL(Render_OpenGL, "Unimplemented vertex size=%s", attrib.SizeString());
+        UNREACHABLE();
+        return {};
+    }
+
+    case Maxwell::VertexAttribute::Type::Float:
+        return GL_FLOAT;
+    }
+
+    LOG_CRITICAL(Render_OpenGL, "Unimplemented vertex type=%s", attrib.TypeString());
+    UNREACHABLE();
+    return {};
+}
+
+} // namespace MaxwellToGL

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -279,7 +279,7 @@ void RendererOpenGL::ConfigureFramebufferTexture(TextureInfo& texture,
         gl_framebuffer_data.resize(texture.width * texture.height * 4);
         break;
     default:
-        UNIMPLEMENTED();
+        UNREACHABLE();
     }
 
     state.texture_units[0].texture_2d = texture.resource.handle;
@@ -305,7 +305,7 @@ void RendererOpenGL::DrawSingleScreen(const ScreenInfo& screen_info, float x, fl
             right = texcoords.left;
         } else {
             // Other transformations are unsupported
-            LOG_CRITICAL(HW_GPU, "unsupported framebuffer_transform_flags=%d",
+            LOG_CRITICAL(Render_OpenGL, "Unsupported framebuffer_transform_flags=%d",
                          framebuffer_transform_flags);
             UNIMPLEMENTED();
         }

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -119,7 +119,7 @@ void RendererOpenGL::SwapBuffers(boost::optional<const Tegra::FramebufferConfig&
 
         // Load the framebuffer from memory, draw it to the screen, and swap buffers
         LoadFBToScreenInfo(*framebuffer, screen_info);
-        DrawScreens();
+        DrawScreen();
         render_window->SwapBuffers();
     }
 
@@ -293,8 +293,8 @@ void RendererOpenGL::ConfigureFramebufferTexture(TextureInfo& texture,
     state.Apply();
 }
 
-void RendererOpenGL::DrawSingleScreen(const ScreenInfo& screen_info, float x, float y, float w,
-                                      float h) {
+void RendererOpenGL::DrawScreenTriangles(const ScreenInfo& screen_info, float x, float y, float w,
+                                         float h) {
     const auto& texcoords = screen_info.display_texcoords;
     auto left = texcoords.left;
     auto right = texcoords.right;
@@ -330,7 +330,7 @@ void RendererOpenGL::DrawSingleScreen(const ScreenInfo& screen_info, float x, fl
 /**
  * Draws the emulated screens to the emulator window.
  */
-void RendererOpenGL::DrawScreens() {
+void RendererOpenGL::DrawScreen() {
     const auto& layout = render_window->GetFramebufferLayout();
     const auto& screen = layout.screen;
 
@@ -346,8 +346,8 @@ void RendererOpenGL::DrawScreens() {
     glActiveTexture(GL_TEXTURE0);
     glUniform1i(uniform_color_texture, 0);
 
-    DrawSingleScreen(screen_info, (float)screen.left, (float)screen.top, (float)screen.GetWidth(),
-                     (float)screen.GetHeight());
+    DrawScreenTriangles(screen_info, (float)screen.left, (float)screen.top,
+                        (float)screen.GetWidth(), (float)screen.GetHeight());
 
     m_current_frame++;
 }

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -142,11 +142,6 @@ void RendererOpenGL::LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuf
     const u64 size_in_bytes{framebuffer.stride * framebuffer.height * bytes_per_pixel};
     const VAddr framebuffer_addr{framebuffer.address + framebuffer.offset};
 
-    // TODO(bunnei): The framebuffer region should only be invalidated if it is written to, not
-    // every frame. When we find the right place for this, the below line can be removed.
-    Memory::RasterizerFlushVirtualRegion(framebuffer_addr, size_in_bytes,
-                                         Memory::FlushMode::Invalidate);
-
     // Framebuffer orientation handling
     framebuffer_transform_flags = framebuffer.transform_flags;
 

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -55,8 +55,8 @@ private:
     void InitOpenGLObjects();
     void ConfigureFramebufferTexture(TextureInfo& texture,
                                      const Tegra::FramebufferConfig& framebuffer);
-    void DrawScreens();
-    void DrawSingleScreen(const ScreenInfo& screen_info, float x, float y, float w, float h);
+    void DrawScreen();
+    void DrawScreenTriangles(const ScreenInfo& screen_info, float x, float y, float w, float h);
     void UpdateFramerate();
 
     // Loads framebuffer from emulated memory into the display information structure

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -26,7 +26,7 @@ bool Init(EmuWindow* emu_window) {
     if (g_renderer->Init()) {
         LOG_DEBUG(Render, "initialized OK");
     } else {
-        LOG_ERROR(Render, "initialization failed !");
+        LOG_CRITICAL(Render, "initialization failed !");
         return false;
     }
     return true;

--- a/src/yuzu/debugger/graphics/graphics_surface.cpp
+++ b/src/yuzu/debugger/graphics/graphics_surface.cpp
@@ -339,9 +339,9 @@ void GraphicsSurfaceWidget::OnUpdate() {
                                 static_cast<size_t>(Source::RenderTarget0)];
 
         surface_address = rt.Address();
-        surface_width = rt.horiz;
-        surface_height = rt.vert;
-        if (rt.format != 0) {
+        surface_width = rt.width;
+        surface_height = rt.height;
+        if (rt.format != Tegra::RenderTargetFormat::NONE) {
             surface_format =
                 ConvertToTextureFormat(static_cast<Tegra::RenderTargetFormat>(rt.format));
         }

--- a/src/yuzu/debugger/graphics/graphics_surface.cpp
+++ b/src/yuzu/debugger/graphics/graphics_surface.cpp
@@ -342,8 +342,7 @@ void GraphicsSurfaceWidget::OnUpdate() {
         surface_width = rt.width;
         surface_height = rt.height;
         if (rt.format != Tegra::RenderTargetFormat::NONE) {
-            surface_format =
-                ConvertToTextureFormat(static_cast<Tegra::RenderTargetFormat>(rt.format));
+            surface_format = ConvertToTextureFormat(rt.format);
         }
 
         break;


### PR DESCRIPTION
Part three of my work to retrofit Citra's OpenGL renderer for use with Switch rendering (previous parts were #265 and #254). Now we're starting to make progress 👍 
This change gets the bits in place for very early triangle drawing (NOTE: No games will render yet by design, so it's not worth trying them with this!). As mentioned in prior changes, there is a lot going on in this space and it's tough to review - But this change starts adding real Switch-specific rendering code (as opposed to a lot of boilerplate, as the prior two changes were), so I'd appreciate more thorough reviews with this one. General summary of changes:
* Hookup passthrough vertex/fragment shaders (these will be replaced by shader decompiler soon)
* Decode game-provided vertex attributes into arrays and hook up to the above shaders
* Add support for copying (and swizzling) hardware rendered framebuffers back to guest RAM
* Add support for proper framebuffer caching and texture forwarding, thereby removing the hack to always flush/invalidate this region in memory
* Lots of refactoring and cleanup