### PR TITLE
Service/sockets: add bsd:s, nsd:a, nsd:u services

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -189,8 +189,10 @@ add_library(core STATIC
     hle/service/sm/controller.h
     hle/service/sm/sm.cpp
     hle/service/sm/sm.h
-    hle/service/sockets/bsd_u.cpp
-    hle/service/sockets/bsd_u.h
+    hle/service/sockets/bsd.cpp
+    hle/service/sockets/bsd.h
+    hle/service/sockets/nsd.cpp
+    hle/service/sockets/nsd.h
     hle/service/sockets/sfdnsres.cpp
     hle/service/sockets/sfdnsres.h
     hle/service/sockets/sockets.cpp

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -3,12 +3,12 @@
 // Refer to the license.txt file included.
 
 #include "core/hle/ipc_helpers.h"
-#include "core/hle/service/sockets/bsd_u.h"
+#include "core/hle/service/sockets/bsd.h"
 
 namespace Service {
 namespace Sockets {
 
-void BSD_U::RegisterClient(Kernel::HLERequestContext& ctx) {
+void BSD::RegisterClient(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
@@ -17,7 +17,7 @@ void BSD_U::RegisterClient(Kernel::HLERequestContext& ctx) {
     rb.Push<u32>(0); // bsd errno
 }
 
-void BSD_U::StartMonitoring(Kernel::HLERequestContext& ctx) {
+void BSD::StartMonitoring(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
@@ -26,7 +26,7 @@ void BSD_U::StartMonitoring(Kernel::HLERequestContext& ctx) {
     rb.Push<u32>(0); // bsd errno
 }
 
-void BSD_U::Socket(Kernel::HLERequestContext& ctx) {
+void BSD::Socket(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
 
     u32 domain = rp.Pop<u32>();
@@ -44,7 +44,7 @@ void BSD_U::Socket(Kernel::HLERequestContext& ctx) {
     rb.Push<u32>(0); // bsd errno
 }
 
-void BSD_U::Connect(Kernel::HLERequestContext& ctx) {
+void BSD::Connect(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 4};
@@ -54,7 +54,7 @@ void BSD_U::Connect(Kernel::HLERequestContext& ctx) {
     rb.Push<u32>(0); // bsd errno
 }
 
-void BSD_U::SendTo(Kernel::HLERequestContext& ctx) {
+void BSD::SendTo(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 4};
@@ -64,7 +64,7 @@ void BSD_U::SendTo(Kernel::HLERequestContext& ctx) {
     rb.Push<u32>(0); // bsd errno
 }
 
-void BSD_U::Close(Kernel::HLERequestContext& ctx) {
+void BSD::Close(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 4};
@@ -74,13 +74,15 @@ void BSD_U::Close(Kernel::HLERequestContext& ctx) {
     rb.Push<u32>(0); // bsd errno
 }
 
-BSD_U::BSD_U() : ServiceFramework("bsd:u") {
-    static const FunctionInfo functions[] = {{0, &BSD_U::RegisterClient, "RegisterClient"},
-                                             {1, &BSD_U::StartMonitoring, "StartMonitoring"},
-                                             {2, &BSD_U::Socket, "Socket"},
-                                             {11, &BSD_U::SendTo, "SendTo"},
-                                             {14, &BSD_U::Connect, "Connect"},
-                                             {26, &BSD_U::Close, "Close"}};
+BSD::BSD(const char* name) : ServiceFramework(name) {
+    static const FunctionInfo functions[] = {
+        {0, &BSD::RegisterClient, "RegisterClient"},
+        {1, &BSD::StartMonitoring, "StartMonitoring"},
+        {2, &BSD::Socket, "Socket"},
+        {11, &BSD::SendTo, "SendTo"},
+        {14, &BSD::Connect, "Connect"},
+        {26, &BSD::Close, "Close"},
+    };
     RegisterHandlers(functions);
 }
 

--- a/src/core/hle/service/sockets/bsd.h
+++ b/src/core/hle/service/sockets/bsd.h
@@ -10,10 +10,10 @@
 namespace Service {
 namespace Sockets {
 
-class BSD_U final : public ServiceFramework<BSD_U> {
+class BSD final : public ServiceFramework<BSD> {
 public:
-    BSD_U();
-    ~BSD_U() = default;
+    explicit BSD(const char* name);
+    ~BSD() = default;
 
 private:
     void RegisterClient(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/sockets/nsd.cpp
+++ b/src/core/hle/service/sockets/nsd.cpp
@@ -1,0 +1,34 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/sockets/nsd.h"
+
+namespace Service {
+namespace Sockets {
+
+NSD::NSD(const char* name) : ServiceFramework(name) {
+    static const FunctionInfo functions[] = {
+        {10, nullptr, "GetSettingName"},
+        {11, nullptr, "GetEnvironmentIdentifier"},
+        {12, nullptr, "GetDeviceId"},
+        {13, nullptr, "DeleteSettings"},
+        {14, nullptr, "ImportSettings"},
+        {20, nullptr, "Resolve"},
+        {21, nullptr, "ResolveEx"},
+        {30, nullptr, "GetNasServiceSetting"},
+        {31, nullptr, "GetNasServiceSettingEx"},
+        {40, nullptr, "GetNasRequestFqdn"},
+        {41, nullptr, "GetNasRequestFqdnEx"},
+        {42, nullptr, "GetNasApiFqdn"},
+        {43, nullptr, "GetNasApiFqdnEx"},
+        {50, nullptr, "GetCurrentSetting"},
+        {60, nullptr, "ReadSaveDataFromFsForTest"},
+        {61, nullptr, "WriteSaveDataToFsForTest"},
+        {62, nullptr, "DeleteSaveDataOfFsForTest"},
+    };
+    RegisterHandlers(functions);
+}
+
+} // namespace Sockets
+} // namespace Service

--- a/src/core/hle/service/sockets/nsd.h
+++ b/src/core/hle/service/sockets/nsd.h
@@ -10,13 +10,10 @@
 namespace Service {
 namespace Sockets {
 
-class SFDNSRES final : public ServiceFramework<SFDNSRES> {
+class NSD final : public ServiceFramework<NSD> {
 public:
-    explicit SFDNSRES();
-    ~SFDNSRES() = default;
-
-private:
-    void GetAddrInfo(Kernel::HLERequestContext& ctx);
+    explicit NSD(const char* name);
+    ~NSD() = default;
 };
 
 } // namespace Sockets

--- a/src/core/hle/service/sockets/sfdnsres.cpp
+++ b/src/core/hle/service/sockets/sfdnsres.cpp
@@ -19,16 +19,18 @@ void SFDNSRES::GetAddrInfo(Kernel::HLERequestContext& ctx) {
 }
 
 SFDNSRES::SFDNSRES() : ServiceFramework("sfdnsres") {
-    static const FunctionInfo functions[] = {{0, nullptr, "SetDnsAddressesPrivate"},
-                                             {1, nullptr, "GetDnsAddressPrivate"},
-                                             {2, nullptr, "GetHostByName"},
-                                             {3, nullptr, "GetHostByAddr"},
-                                             {4, nullptr, "GetHostStringError"},
-                                             {5, nullptr, "GetGaiStringError"},
-                                             {6, &SFDNSRES::GetAddrInfo, "GetAddrInfo"},
-                                             {7, nullptr, "GetNameInfo"},
-                                             {8, nullptr, "RequestCancelHandle"},
-                                             {9, nullptr, "CancelSocketCall"}};
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "SetDnsAddressesPrivate"},
+        {1, nullptr, "GetDnsAddressPrivate"},
+        {2, nullptr, "GetHostByName"},
+        {3, nullptr, "GetHostByAddr"},
+        {4, nullptr, "GetHostStringError"},
+        {5, nullptr, "GetGaiStringError"},
+        {6, &SFDNSRES::GetAddrInfo, "GetAddrInfo"},
+        {7, nullptr, "GetNameInfo"},
+        {8, nullptr, "RequestCancelHandle"},
+        {9, nullptr, "CancelSocketCall"},
+    };
     RegisterHandlers(functions);
 }
 

--- a/src/core/hle/service/sockets/sockets.cpp
+++ b/src/core/hle/service/sockets/sockets.cpp
@@ -2,7 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "core/hle/service/sockets/bsd_u.h"
+#include "core/hle/service/sockets/bsd.h"
+#include "core/hle/service/sockets/nsd.h"
 #include "core/hle/service/sockets/sfdnsres.h"
 #include "core/hle/service/sockets/sockets.h"
 
@@ -10,7 +11,10 @@ namespace Service {
 namespace Sockets {
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {
-    std::make_shared<BSD_U>()->InstallAsService(service_manager);
+    std::make_shared<BSD>("bsd:s")->InstallAsService(service_manager);
+    std::make_shared<BSD>("bsd:u")->InstallAsService(service_manager);
+    std::make_shared<NSD>("nsd:a")->InstallAsService(service_manager);
+    std::make_shared<NSD>("nsd:u")->InstallAsService(service_manager);
     std::make_shared<SFDNSRES>()->InstallAsService(service_manager);
 }
 


### PR DESCRIPTION
Skip `bsdcfg`, `ethc:c`, `ethc:i`, as not yet described on switchbrew and not seen in games