### PR TITLE
Add config for "Docked" mode and various settings cleanup

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -148,19 +148,15 @@ System::ResultStatus System::Init(EmuWindow* emu_window, u32 system_mode) {
 
     current_process = Kernel::Process::Create("main");
 
-    switch (Settings::values.cpu_core) {
-    case Settings::CpuCore::Unicorn:
-        cpu_core = std::make_shared<ARM_Unicorn>();
-        break;
-    case Settings::CpuCore::Dynarmic:
-    default:
+    if (Settings::values.use_cpu_jit) {
 #ifdef ARCHITECTURE_x86_64
         cpu_core = std::make_shared<ARM_Dynarmic>();
 #else
         cpu_core = std::make_shared<ARM_Unicorn>();
         LOG_WARNING(Core, "CPU JIT requested, but Dynarmic not available");
 #endif
-        break;
+    } else {
+        cpu_core = std::make_shared<ARM_Unicorn>();
     }
 
     gpu_core = std::make_unique<Tegra::GPU>();

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -242,20 +242,20 @@ void ICommonStateGetter::GetCurrentFocusState(Kernel::HLERequestContext& ctx) {
 }
 
 void ICommonStateGetter::GetOperationMode(Kernel::HLERequestContext& ctx) {
-    const bool is_docked{Settings::values.is_docked};
+    const bool use_docked_mode{Settings::values.use_docked_mode};
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
-    rb.Push(static_cast<u8>(is_docked ? OperationMode::Docked : OperationMode::Handheld));
+    rb.Push(static_cast<u8>(use_docked_mode ? OperationMode::Docked : OperationMode::Handheld));
 
     LOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void ICommonStateGetter::GetPerformanceMode(Kernel::HLERequestContext& ctx) {
-    const bool is_docked{Settings::values.is_docked};
+    const bool use_docked_mode{Settings::values.use_docked_mode};
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
-    rb.Push(static_cast<u32>(is_docked ? APM::PerformanceMode::Docked
-                                       : APM::PerformanceMode::Handheld));
+    rb.Push(static_cast<u32>(use_docked_mode ? APM::PerformanceMode::Docked
+                                             : APM::PerformanceMode::Handheld));
 
     LOG_WARNING(Service_AM, "(STUBBED) called");
 }

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -12,6 +12,7 @@
 #include "core/hle/service/apm/apm.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/hle/service/nvflinger/nvflinger.h"
+#include "core/settings.h"
 
 namespace Service {
 namespace AM {
@@ -241,17 +242,20 @@ void ICommonStateGetter::GetCurrentFocusState(Kernel::HLERequestContext& ctx) {
 }
 
 void ICommonStateGetter::GetOperationMode(Kernel::HLERequestContext& ctx) {
+    const bool is_docked{Settings::values.is_docked};
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
-    rb.Push(static_cast<u8>(OperationMode::Handheld));
+    rb.Push(static_cast<u8>(is_docked ? OperationMode::Docked : OperationMode::Handheld));
 
     LOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void ICommonStateGetter::GetPerformanceMode(Kernel::HLERequestContext& ctx) {
+    const bool is_docked{Settings::values.is_docked};
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
-    rb.Push(static_cast<u32>(APM::PerformanceMode::Handheld));
+    rb.Push(static_cast<u32>(is_docked ? APM::PerformanceMode::Docked
+                                       : APM::PerformanceMode::Handheld));
 
     LOG_WARNING(Service_AM, "(STUBBED) called");
 }

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -111,6 +111,9 @@ enum class CpuCore {
 };
 
 struct Values {
+    // System
+    bool is_docked;
+
     // Controls
     std::array<std::string, NativeButton::NumButtons> buttons;
     std::array<std::string, NativeAnalog::NumAnalogs> analogs;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -105,11 +105,6 @@ static const std::array<const char*, NumAnalogs> mapping = {{
 }};
 } // namespace NativeAnalog
 
-enum class CpuCore {
-    Unicorn,
-    Dynarmic,
-};
-
 struct Values {
     // System
     bool use_docked_mode;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -121,7 +121,7 @@ struct Values {
     std::string touch_device;
 
     // Core
-    CpuCore cpu_core;
+    bool use_cpu_jit;
 
     // Data Storage
     bool use_virtual_sd;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -112,7 +112,7 @@ enum class CpuCore {
 
 struct Values {
     // System
-    bool is_docked;
+    bool use_docked_mode;
 
     // Controls
     std::array<std::string, NativeButton::NumButtons> buttons;

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -154,12 +154,13 @@ TelemetrySession::TelemetrySession() {
 #endif
 
     // Log user configuration information
-    AddField(Telemetry::FieldType::UserConfig, "Core_CpuCore",
-             static_cast<int>(Settings::values.cpu_core));
+    AddField(Telemetry::FieldType::UserConfig, "Core_UseCpuJit", Settings::values.use_cpu_jit);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_ResolutionFactor",
              Settings::values.resolution_factor);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_ToggleFramelimit",
              Settings::values.toggle_framelimit);
+    AddField(Telemetry::FieldType::UserConfig, "System_UseDockedMode",
+             Settings::values.use_docked_mode);
 }
 
 TelemetrySession::~TelemetrySession() {

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -77,8 +77,7 @@ void Config::ReadValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("Core");
-    Settings::values.cpu_core =
-        static_cast<Settings::CpuCore>(qt_config->value("cpu_core", 1).toInt());
+    Settings::values.use_cpu_jit = qt_config->value("use_cpu_jit", true).toBool();
     qt_config->endGroup();
 
     qt_config->beginGroup("Renderer");
@@ -175,7 +174,7 @@ void Config::SaveValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("Core");
-    qt_config->setValue("cpu_core", static_cast<int>(Settings::values.cpu_core));
+    qt_config->setValue("use_cpu_jit", Settings::values.use_cpu_jit);
     qt_config->endGroup();
 
     qt_config->beginGroup("Renderer");

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -94,6 +94,10 @@ void Config::ReadValues() {
     Settings::values.use_virtual_sd = qt_config->value("use_virtual_sd", true).toBool();
     qt_config->endGroup();
 
+    qt_config->beginGroup("System");
+    Settings::values.is_docked = qt_config->value("is_docked", true).toBool();
+    qt_config->endGroup();
+
     qt_config->beginGroup("Miscellaneous");
     Settings::values.log_filter = qt_config->value("log_filter", "*:Info").toString().toStdString();
     qt_config->endGroup();
@@ -186,6 +190,10 @@ void Config::SaveValues() {
 
     qt_config->beginGroup("Data Storage");
     qt_config->setValue("use_virtual_sd", Settings::values.use_virtual_sd);
+    qt_config->endGroup();
+
+    qt_config->beginGroup("System");
+    qt_config->setValue("is_docked", Settings::values.is_docked);
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -95,7 +95,7 @@ void Config::ReadValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("System");
-    Settings::values.is_docked = qt_config->value("is_docked", true).toBool();
+    Settings::values.use_docked_mode = qt_config->value("use_docked_mode", true).toBool();
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");
@@ -193,7 +193,7 @@ void Config::SaveValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("System");
-    qt_config->setValue("is_docked", Settings::values.is_docked);
+    qt_config->setValue("use_docked_mode", Settings::values.use_docked_mode);
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -16,7 +16,7 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
     this->setConfiguration();
 
     ui->cpu_core_combobox->setEnabled(!Core::System::GetInstance().IsPoweredOn());
-    ui->is_docked->setEnabled(!Core::System::GetInstance().IsPoweredOn());
+    ui->use_docked_mode->setEnabled(!Core::System::GetInstance().IsPoweredOn());
 }
 
 ConfigureGeneral::~ConfigureGeneral() {}
@@ -25,7 +25,7 @@ void ConfigureGeneral::setConfiguration() {
     ui->toggle_deepscan->setChecked(UISettings::values.gamedir_deepscan);
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing);
     ui->cpu_core_combobox->setCurrentIndex(static_cast<int>(Settings::values.cpu_core));
-    ui->is_docked->setChecked(Settings::values.is_docked);
+    ui->use_docked_mode->setChecked(Settings::values.use_docked_mode);
 }
 
 void ConfigureGeneral::applyConfiguration() {
@@ -33,6 +33,6 @@ void ConfigureGeneral::applyConfiguration() {
     UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
     Settings::values.cpu_core =
         static_cast<Settings::CpuCore>(ui->cpu_core_combobox->currentIndex());
-    Settings::values.is_docked = ui->is_docked->isChecked();
+    Settings::values.use_docked_mode = ui->use_docked_mode->isChecked();
     Settings::Apply();
 }

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -16,6 +16,7 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
     this->setConfiguration();
 
     ui->cpu_core_combobox->setEnabled(!Core::System::GetInstance().IsPoweredOn());
+    ui->is_docked->setEnabled(!Core::System::GetInstance().IsPoweredOn());
 }
 
 ConfigureGeneral::~ConfigureGeneral() {}
@@ -24,6 +25,7 @@ void ConfigureGeneral::setConfiguration() {
     ui->toggle_deepscan->setChecked(UISettings::values.gamedir_deepscan);
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing);
     ui->cpu_core_combobox->setCurrentIndex(static_cast<int>(Settings::values.cpu_core));
+    ui->is_docked->setChecked(Settings::values.is_docked);
 }
 
 void ConfigureGeneral::applyConfiguration() {
@@ -31,5 +33,6 @@ void ConfigureGeneral::applyConfiguration() {
     UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
     Settings::values.cpu_core =
         static_cast<Settings::CpuCore>(ui->cpu_core_combobox->currentIndex());
+    Settings::values.is_docked = ui->is_docked->isChecked();
     Settings::Apply();
 }

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -15,7 +15,7 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
 
     this->setConfiguration();
 
-    ui->cpu_core_combobox->setEnabled(!Core::System::GetInstance().IsPoweredOn());
+    ui->use_cpu_jit->setEnabled(!Core::System::GetInstance().IsPoweredOn());
     ui->use_docked_mode->setEnabled(!Core::System::GetInstance().IsPoweredOn());
 }
 
@@ -24,15 +24,14 @@ ConfigureGeneral::~ConfigureGeneral() {}
 void ConfigureGeneral::setConfiguration() {
     ui->toggle_deepscan->setChecked(UISettings::values.gamedir_deepscan);
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing);
-    ui->cpu_core_combobox->setCurrentIndex(static_cast<int>(Settings::values.cpu_core));
+    ui->use_cpu_jit->setChecked(Settings::values.use_cpu_jit);
     ui->use_docked_mode->setChecked(Settings::values.use_docked_mode);
 }
 
 void ConfigureGeneral::applyConfiguration() {
     UISettings::values.gamedir_deepscan = ui->toggle_deepscan->isChecked();
     UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
-    Settings::values.cpu_core =
-        static_cast<Settings::CpuCore>(ui->cpu_core_combobox->currentIndex());
+    Settings::values.use_cpu_jit = ui->use_cpu_jit->isChecked();
     Settings::values.use_docked_mode = ui->use_docked_mode->isChecked();
     Settings::Apply();
 }

--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -44,31 +44,24 @@
       </widget>
      </item>
      <item>
-       <widget class="QGroupBox" name="CpuCoreGroupBox">
-         <property name="title">
-           <string>CPU Core</string>
-         </property>
-         <layout class="QHBoxLayout" name="CpuCoreHorizontalLayout">
-           <item>
-             <layout class="QVBoxLayout" name="CpuCoreVerticalLayout">
-               <item>
-                 <widget class="QComboBox" name="cpu_core_combobox">
-                  <item>
-                   <property name="text">
-                    <string>Unicorn</string>
-                   </property>
-                  </item>
-                  <item>
-                   <property name="text">
-                    <string>Dynarmic</string>
-                   </property>
-                  </item>
-                 </widget>
-               </item>
-             </layout>
-           </item>
+      <widget class="QGroupBox" name="PerformanceGroupBox">
+       <property name="title">
+        <string>Performance</string>
+       </property>
+       <layout class="QHBoxLayout" name="PerformanceHorizontalLayout">
+        <item>
+         <layout class="QVBoxLayout" name="PerformanceVerticalLayout">
+          <item>
+           <widget class="QCheckBox" name="use_cpu_jit">
+            <property name="text">
+             <string>Enable CPU JIT</string>
+            </property>
+           </widget>
+          </item>
          </layout>
-       </widget>
+        </item>
+       </layout>
+      </widget>
      </item>
      <item>
       <widget class="QGroupBox" name="EmulationGroupBox">

--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -13,17 +13,17 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
+  <layout class="QHBoxLayout" name="HorizontalLayout">
    <item>
-    <layout class="QVBoxLayout" name="verticalLayout">
+    <layout class="QVBoxLayout" name="VerticalLayout">
      <item>
-      <widget class="QGroupBox" name="groupBox">
+      <widget class="QGroupBox" name="GeneralGroupBox">
        <property name="title">
         <string>General</string>
        </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <layout class="QHBoxLayout" name="GeneralHorizontalLayout">
         <item>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
+         <layout class="QVBoxLayout" name="GeneralVerticalLayout">
           <item>
            <widget class="QCheckBox" name="toggle_deepscan">
             <property name="text">
@@ -44,13 +44,13 @@
       </widget>
      </item>
      <item>
-       <widget class="QGroupBox" name="groupBox_2">
+       <widget class="QGroupBox" name="CpuCoreGroupBox">
          <property name="title">
            <string>CPU Core</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_7">
+         <layout class="QHBoxLayout" name="CpuCoreHorizontalLayout">
            <item>
-             <layout class="QVBoxLayout" name="verticalLayout_5">
+             <layout class="QVBoxLayout" name="CpuCoreVerticalLayout">
                <item>
                  <widget class="QComboBox" name="cpu_core_combobox">
                   <item>
@@ -71,13 +71,13 @@
        </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox_4">
+      <widget class="QGroupBox" name="EmulationGroupBox">
        <property name="title">
         <string>Emulation</string>
        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_8">
+        <layout class="QHBoxLayout" name="EmulationHorizontalLayout">
           <item>
-            <layout class="QVBoxLayout" name="verticalLayout_6">
+            <layout class="QVBoxLayout" name="EmulationVerticalLayout">
               <item>
                 <widget class="QCheckBox" name="is_docked">
                   <property name="text">
@@ -91,13 +91,13 @@
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="groupBox_3">
+      <widget class="QGroupBox" name="HotKeysGroupBox">
        <property name="title">
         <string>Hotkeys</string>
        </property>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <layout class="QHBoxLayout" name="HotKeysHorizontalLayout">
         <item>
-         <layout class="QVBoxLayout" name="verticalLayout_4">
+         <layout class="QVBoxLayout" name="HotKeysVerticalLayout">
           <item>
            <widget class="GHotkeysDialog" name="widget" native="true"/>
           </item>

--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -71,6 +71,26 @@
        </widget>
      </item>
      <item>
+      <widget class="QGroupBox" name="groupBox_4">
+       <property name="title">
+        <string>Emulation</string>
+       </property>
+        <layout class="QHBoxLayout" name="horizontalLayout_8">
+          <item>
+            <layout class="QVBoxLayout" name="verticalLayout_6">
+              <item>
+                <widget class="QCheckBox" name="is_docked">
+                  <property name="text">
+                    <string>Enable docked mode</string>
+                  </property>
+                </widget>
+              </item>
+            </layout>
+          </item>
+        </layout>
+      </widget>
+     </item>
+     <item>
       <widget class="QGroupBox" name="groupBox_3">
        <property name="title">
         <string>Hotkeys</string>

--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -79,7 +79,7 @@
           <item>
             <layout class="QVBoxLayout" name="EmulationVerticalLayout">
               <item>
-                <widget class="QCheckBox" name="is_docked">
+                <widget class="QCheckBox" name="use_docked_mode">
                   <property name="text">
                     <string>Enable docked mode</string>
                   </property>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -108,7 +108,7 @@ void Config::ReadValues() {
         sdl2_config->GetBoolean("Data Storage", "use_virtual_sd", true);
 
     // System
-    Settings::values.is_docked = sdl2_config->GetBoolean("System", "is_docked", true);
+    Settings::values.use_docked_mode = sdl2_config->GetBoolean("System", "use_docked_mode", true);
 
     // Miscellaneous
     Settings::values.log_filter = sdl2_config->Get("Miscellaneous", "log_filter", "*:Trace");

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -107,6 +107,9 @@ void Config::ReadValues() {
     Settings::values.use_virtual_sd =
         sdl2_config->GetBoolean("Data Storage", "use_virtual_sd", true);
 
+    // System
+    Settings::values.is_docked = sdl2_config->GetBoolean("System", "is_docked", true);
+
     // Miscellaneous
     Settings::values.log_filter = sdl2_config->Get("Miscellaneous", "log_filter", "*:Trace");
 

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -90,8 +90,7 @@ void Config::ReadValues() {
         sdl2_config->Get("Controls", "touch_device", "engine:emu_window");
 
     // Core
-    Settings::values.cpu_core =
-        static_cast<Settings::CpuCore>(sdl2_config->GetInteger("Core", "cpu_core", 1));
+    Settings::values.use_cpu_jit = sdl2_config->GetBoolean("Core", "use_cpu_jit", true);
 
     // Renderer
     Settings::values.resolution_factor =

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -154,6 +154,10 @@ output_device =
 use_virtual_sd =
 
 [System]
+# Whether the system is docked
+# 1 (default): Yes, 0: No
+is_docked =
+
 # The system region that Citra will use during emulation
 # -1: Auto-select (default), 0: Japan, 1: USA, 2: Europe, 3: Australia, 4: China, 5: Korea, 6: Taiwan
 region_value =

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -156,7 +156,7 @@ use_virtual_sd =
 [System]
 # Whether the system is docked
 # 1 (default): Yes, 0: No
-is_docked =
+use_docked_mode =
 
 # The system region that Citra will use during emulation
 # -1: Auto-select (default), 0: Japan, 1: USA, 2: Europe, 3: Australia, 4: China, 5: Korea, 6: Taiwan

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -76,9 +76,9 @@ motion_device=
 touch_device=
 
 [Core]
-# Which CPU core to use for CPU emulation
-# 0: Unicorn (slow), 1 (default): Dynarmic (faster)
-cpu_core =
+# Whether to use the Just-In-Time (JIT) compiler for CPU emulation
+# 0: Interpreter (slow), 1 (default): JIT (fast)
+use_cpu_jit =
 
 [Renderer]
 # Whether to use software or hardware rendering.


### PR DESCRIPTION
* Adds a config setting for "Docked" mode (versus Handheld).
* Defaults to Docked mode (Note: This indicates higher performance mode, which may make games render at 1080p as opposed to 720p).
* Leaves 1280 x 720 default window size as-is. In my opinion, until we actually have games rendering, the bigger window size is just inconvenient for those of us with lower resolution displays.
* Changes CPU setting dropdown to just "Enable CPU JIT" checkbox, which is what Citra does. This is simpler for users, and we'll never support 3 CPU backends. This will also move everyone to Dynarmic (who previously manually set Unicorn), which is desirable since Unicorn is somewhat busted now due to not properly supporting the `svcSetHeapSize` and `svcMapMemory` stuff.

Obligatory UI change screenshot:
![image](https://user-images.githubusercontent.com/6956688/37944762-ea1725c8-314a-11e8-9c6a-7ea0b9ad09e0.png)
