### PR TITLE
result: Check against self-assignment in ResultVal's copy assignment operator

### DIFF
--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -200,6 +200,9 @@ public:
     }
 
     ResultVal& operator=(const ResultVal& o) {
+        if (this == &o) {
+            return *this;
+        }
         if (!empty()) {
             if (!o.empty()) {
                 object = o.object;


### PR DESCRIPTION
Avoids doing work that doesn't need to be done.