### PR TITLE
logging: Use variadic template instead of FMT_VARIADIC

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -146,12 +146,12 @@ void LogMessage(Class log_class, Level log_level, const char* filename, unsigned
     PrintColoredMessage(entry);
 }
 
-void FmtLogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
-                   const char* function, const char* format, const fmt::ArgList& args) {
+void LogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
+                const char* function, const char* format, const fmt::format_args& args) {
     if (filter && !filter->CheckMessage(log_class, log_level))
         return;
     Entry entry =
-        CreateEntry(log_class, log_level, filename, line_num, function, fmt::format(format, args));
+        CreateEntry(log_class, log_level, filename, line_num, function, fmt::vformat(format, args));
 
     PrintColoredMessage(entry);
 }

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -104,9 +104,15 @@ void LogMessage(Class log_class, Level log_level, const char* filename, unsigned
 #endif
     ;
 
+/// Logs a message to the global logger, using fmt
+void LogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
+                const char* function, const char* format, const fmt::format_args& args);
+
+template <typename... Args>
 void FmtLogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
-                   const char* function, const char* format, const fmt::ArgList& args);
-FMT_VARIADIC(void, FmtLogMessage, Class, Level, const char*, unsigned int, const char*, const char*)
+                   const char* function, const char* format, const Args&... args) {
+    LogMessage(log_class, log_level, filename, line_num, function, format, fmt::make_args(args...));
+}
 
 } // namespace Log
 


### PR DESCRIPTION
Due to premature merging of #262 I think the build may be failing right now. Should merge this ASAP to fix it.