### PR TITLE
logging: Fix new fmtlib-based definitions.

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -146,13 +146,14 @@ void LogMessage(Class log_class, Level log_level, const char* filename, unsigned
     PrintColoredMessage(entry);
 }
 
-void FmtLogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
-                   const char* function, const char* format, const fmt::ArgList& args) {
+void LogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
+                const char* function, const char* format, const fmt::format_args& args) {
     if (filter && !filter->CheckMessage(log_class, log_level))
         return;
     Entry entry =
-        CreateEntry(log_class, log_level, filename, line_num, function, fmt::format(format, args));
+        CreateEntry(log_class, log_level, filename, line_num, function, fmt::vformat(format, args));
 
     PrintColoredMessage(entry);
 }
+
 } // namespace Log

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -104,9 +104,11 @@ void LogMessage(Class log_class, Level log_level, const char* filename, unsigned
 #endif
     ;
 
+template <typename... Args>
 void FmtLogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
-                   const char* function, const char* format, const fmt::ArgList& args);
-FMT_VARIADIC(void, FmtLogMessage, Class, Level, const char*, unsigned int, const char*, const char*)
+                   const char* function, const char* format, const Args&... args) {
+    LogMessage(log_class, log_level, filename, line_num, function, format, fmt::make_args(args...));
+}
 
 } // namespace Log
 

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -104,6 +104,10 @@ void LogMessage(Class log_class, Level log_level, const char* filename, unsigned
 #endif
     ;
 
+/// Logs a message to the global logger, using fmt
+void LogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
+                const char* function, const char* format, const fmt::format_args& args);
+
 template <typename... Args>
 void FmtLogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
                    const char* function, const char* format, const Args&... args) {


### PR DESCRIPTION
Should fix the current build breaks that were accidentally introduced with #262. 