### PR TITLE
Update fmtlib to fix msvc warnings

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -146,8 +146,9 @@ void LogMessage(Class log_class, Level log_level, const char* filename, unsigned
     PrintColoredMessage(entry);
 }
 
-void LogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
-                const char* function, const char* format, const fmt::format_args& args) {
+void FmtLogMessageImpl(Class log_class, Level log_level, const char* filename,
+                       unsigned int line_num, const char* function, const char* format,
+                       const fmt::format_args& args) {
     if (filter && !filter->CheckMessage(log_class, log_level))
         return;
     Entry entry =

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -105,13 +105,15 @@ void LogMessage(Class log_class, Level log_level, const char* filename, unsigned
     ;
 
 /// Logs a message to the global logger, using fmt
-void LogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
-                const char* function, const char* format, const fmt::format_args& args);
+void FmtLogMessageImpl(Class log_class, Level log_level, const char* filename,
+                       unsigned int line_num, const char* function, const char* format,
+                       const fmt::format_args& args);
 
 template <typename... Args>
 void FmtLogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
                    const char* function, const char* format, const Args&... args) {
-    LogMessage(log_class, log_level, filename, line_num, function, format, fmt::make_args(args...));
+    FmtLogMessageImpl(log_class, log_level, filename, line_num, function, format,
+                      fmt::make_args(args...));
 }
 
 } // namespace Log


### PR DESCRIPTION
Additionally, when updating fmtlib, there was a change in fmtlib broke
how the old logging macro was overloaded, so this works around that by
just naming the fmtlib macro impl something different