### PR TITLE
GPU: Bind uploaded textures when drawing (Rebased)

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -231,6 +231,8 @@ Texture::TICEntry Maxwell3D::GetTICEntry(u32 tic_index) const {
 
     // TODO(Subv): Different data types for separate components are not supported
     ASSERT(r_type == g_type && r_type == b_type && r_type == a_type);
+    // TODO(Subv): Only UNORM formats are supported for now.
+    ASSERT(r_type == Texture::ComponentType::UNORM);
 
     return tic_entry;
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -524,10 +524,10 @@ void main() {
 in vec2 frag_tex_coord;
 out vec4 color;
 
-uniform sampler2D color_texture;
+uniform sampler2D tex[32];
 
 void main() {
-    color = vec4(1.0, 0.0, 1.0, 0.0);
+    color = texture(tex[0], frag_tex_coord);
 }
 )";
 
@@ -547,6 +547,15 @@ void main() {
 
     state.draw.shader_program = test_shader.shader.handle;
     state.Apply();
+
+    for (u32 texture = 0; texture < texture_samplers.size(); ++texture) {
+        // Set the texture samplers to correspond to different texture units
+        std::string uniform_name = "tex[" + std::to_string(texture) + "]";
+        GLint uniform_tex = glGetUniformLocation(test_shader.shader.handle, uniform_name.c_str());
+        if (uniform_tex != -1) {
+            glUniform1i(uniform_tex, TextureUnits::MaxwellTexture(texture).id);
+        }
+    }
 
     if (has_ARB_separate_shader_objects) {
         state.draw.shader_program = 0;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -66,6 +66,12 @@ RasterizerOpenGL::RasterizerOpenGL() {
     has_ARB_separate_shader_objects = false;
     has_ARB_vertex_attrib_binding = false;
 
+    // Create sampler objects
+    for (size_t i = 0; i < texture_samplers.size(); ++i) {
+        texture_samplers[i].Create();
+        state.texture_units[i].sampler = texture_samplers[i].sampler.handle;
+    }
+
     GLint ext_num;
     glGetIntegerv(GL_NUM_EXTENSIONS, &ext_num);
     for (GLint i = 0; i < ext_num; i++) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -85,7 +85,26 @@ public:
                   "FSUniformData structure must be less than 16kb as per the OpenGL spec");
 
 private:
-    struct SamplerInfo {};
+    class SamplerInfo {
+    public:
+        OGLSampler sampler;
+
+        /// Creates the sampler object, initializing its state so that it's in sync with the
+        /// SamplerInfo struct.
+        void Create();
+        /// Syncs the sampler object with the config, updating any necessary state.
+        void SyncWithConfig(const Tegra::Texture::TSCEntry& config);
+
+    private:
+        Tegra::Texture::TextureFilter mag_filter;
+        Tegra::Texture::TextureFilter min_filter;
+        Tegra::Texture::WrapMode wrap_u;
+        Tegra::Texture::WrapMode wrap_v;
+        u32 border_color_r;
+        u32 border_color_g;
+        u32 border_color_b;
+        u32 border_color_a;
+    };
 
     /// Binds the framebuffer color and depth surface
     void BindFramebufferSurfaces(const Surface& color_surface, const Surface& depth_surface,

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -110,6 +110,9 @@ private:
     void BindFramebufferSurfaces(const Surface& color_surface, const Surface& depth_surface,
                                  bool has_stencil);
 
+    /// Binds the required textures to OpenGL before drawing a batch.
+    void BindTextures();
+
     /// Syncs the viewport to match the guest state
     void SyncViewport(const MathUtil::Rectangle<u32>& surfaces_rect, u16 res_scale);
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -92,19 +92,9 @@ static void MortonCopyTile(u32 stride, u8* tile_buffer, u8* gl_buffer) {
             u8* tile_ptr = tile_buffer + VideoCore::MortonInterleave(x, y) * bytes_per_pixel;
             u8* gl_ptr = gl_buffer + ((7 - y) * stride + x) * gl_bytes_per_pixel;
             if (morton_to_gl) {
-                if (format == PixelFormat::D24S8) {
-                    gl_ptr[0] = tile_ptr[3];
-                    std::memcpy(gl_ptr + 1, tile_ptr, 3);
-                } else {
-                    std::memcpy(gl_ptr, tile_ptr, bytes_per_pixel);
-                }
+                std::memcpy(gl_ptr, tile_ptr, bytes_per_pixel);
             } else {
-                if (format == PixelFormat::D24S8) {
-                    std::memcpy(tile_ptr, gl_ptr + 1, 3);
-                    tile_ptr[3] = gl_ptr[0];
-                } else {
-                    std::memcpy(tile_ptr, gl_ptr, bytes_per_pixel);
-                }
+                std::memcpy(tile_ptr, gl_ptr, bytes_per_pixel);
             }
         }
     }

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -115,7 +115,7 @@ void MortonCopy(u32 stride, u32 height, u8* gl_buffer, VAddr base, VAddr start, 
 
 template <>
 void MortonCopy<true, PixelFormat::DXT1>(u32 stride, u32 height, u8* gl_buffer, VAddr base,
-                                                VAddr start, VAddr end) {
+                                         VAddr start, VAddr end) {
     constexpr u32 bytes_per_pixel = SurfaceParams::GetFormatBpp(PixelFormat::DXT1) / 8;
     constexpr u32 gl_bytes_per_pixel = CachedSurface::GetGLBytesPerPixel(PixelFormat::DXT1);
 

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -194,7 +194,7 @@ void OpenGLState::Apply() const {
     // Textures
     for (unsigned i = 0; i < ARRAY_SIZE(texture_units); ++i) {
         if (texture_units[i].texture_2d != cur_state.texture_units[i].texture_2d) {
-            glActiveTexture(TextureUnits::PicaTexture(i).Enum());
+            glActiveTexture(TextureUnits::MaxwellTexture(i).Enum());
             glBindTexture(GL_TEXTURE_2D, texture_units[i].texture_2d);
         }
         if (texture_units[i].sampler != cur_state.texture_units[i].sampler) {

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -16,7 +16,7 @@ struct TextureUnit {
     }
 };
 
-constexpr TextureUnit PicaTexture(int unit) {
+constexpr TextureUnit MaxwellTexture(int unit) {
     return TextureUnit{unit};
 }
 

--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -47,4 +47,27 @@ inline GLenum PrimitiveTopology(Maxwell::PrimitiveTopology topology) {
     return {};
 }
 
+inline GLenum TextureFilterMode(Tegra::Texture::TextureFilter filter_mode) {
+    switch (filter_mode) {
+    case Tegra::Texture::TextureFilter::Linear:
+        return GL_LINEAR;
+    case Tegra::Texture::TextureFilter::Nearest:
+        return GL_NEAREST;
+    }
+    LOG_CRITICAL(Render_OpenGL, "Unimplemented texture filter mode=%u",
+                 static_cast<u32>(filter_mode));
+    UNREACHABLE();
+    return {};
+}
+
+inline GLenum WrapMode(Tegra::Texture::WrapMode wrap_mode) {
+    switch (wrap_mode) {
+    case Tegra::Texture::WrapMode::ClampToEdge:
+        return GL_CLAMP_TO_EDGE;
+    }
+    LOG_CRITICAL(Render_OpenGL, "Unimplemented texture wrap mode=%u", static_cast<u32>(wrap_mode));
+    UNREACHABLE();
+    return {};
+}
+
 } // namespace MaxwellToGL

--- a/src/video_core/textures/texture.h
+++ b/src/video_core/textures/texture.h
@@ -37,6 +37,16 @@ enum class TICHeaderVersion : u32 {
     BlockLinearColorKey = 4,
 };
 
+enum class ComponentType : u32 {
+    SNORM = 1,
+    UNORM = 2,
+    SINT = 3,
+    UINT = 4,
+    SNORM_FORCE_FP16 = 5,
+    UNORM_FORCE_FP16 = 6,
+    FLOAT = 7
+};
+
 union TextureHandle {
     u32 raw;
     BitField<0, 20, u32> tic_id;
@@ -48,10 +58,10 @@ struct TICEntry {
     union {
         u32 raw;
         BitField<0, 7, TextureFormat> format;
-        BitField<7, 3, u32> r_type;
-        BitField<10, 3, u32> g_type;
-        BitField<13, 3, u32> b_type;
-        BitField<16, 3, u32> a_type;
+        BitField<7, 3, ComponentType> r_type;
+        BitField<10, 3, ComponentType> g_type;
+        BitField<13, 3, ComponentType> b_type;
+        BitField<16, 3, ComponentType> a_type;
     };
     u32 address_low;
     union {

--- a/src/video_core/textures/texture.h
+++ b/src/video_core/textures/texture.h
@@ -77,6 +77,11 @@ struct TICEntry {
     u32 Height() const {
         return height_minus_1 + 1;
     }
+
+    bool IsTiled() const {
+        return header_version == TICHeaderVersion::BlockLinear ||
+               header_version == TICHeaderVersion::BlockLinearColorKey;
+    }
 };
 static_assert(sizeof(TICEntry) == 0x20, "TICEntry has wrong size");
 


### PR DESCRIPTION
This PR uploads all non-zero texture handles from the TIC buffer to OpenGL.
In the future we should only upload those that are actually used by the active shader.

This is just a rebase + clang format fix for Subv since he's busy right now. #294 