### PR TITLE
Prevent crash from uninitialized telemetry

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -347,8 +347,6 @@ bool GMainWindow::LoadROM(const QString& filename) {
 
     const Core::System::ResultStatus result{system.Load(render_window, filename.toStdString())};
 
-    Core::Telemetry().AddField(Telemetry::FieldType::App, "Frontend", "Qt");
-
     if (result != Core::System::ResultStatus::Success) {
         switch (result) {
         case Core::System::ResultStatus::ErrorGetLoader:
@@ -409,6 +407,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
         }
         return false;
     }
+    Core::Telemetry().AddField(Telemetry::FieldType::App, "Frontend", "Qt");
     return true;
 }
 


### PR DESCRIPTION
If the core was not initialized, then the telemetry isn't either, so we can't add it before checking for core init success.