### PR TITLE
shaders: Expose hints about used const buffers.

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.h
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.h
@@ -17,8 +17,8 @@ using Tegra::Engines::Maxwell3D;
 
 std::string GetCommonDeclarations();
 
-boost::optional<std::string> DecompileProgram(const ProgramCode& program_code, u32 main_offset,
-                                              Maxwell3D::Regs::ShaderStage stage);
+boost::optional<ProgramResult> DecompileProgram(const ProgramCode& program_code, u32 main_offset,
+                                                Maxwell3D::Regs::ShaderStage stage);
 
 } // namespace Decompiler
 } // namespace GLShader

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -3,18 +3,60 @@
 // Refer to the license.txt file included.
 
 #include "common/assert.h"
+#include "video_core/engines/maxwell_3d.h"
+#include "video_core/renderer_opengl/gl_shader_decompiler.h"
 #include "video_core/renderer_opengl/gl_shader_gen.h"
 
 namespace GLShader {
 
-std::string GenerateVertexShader(const ShaderSetup& setup, const MaxwellVSConfig& config) {
-    UNREACHABLE();
-    return {};
+using Tegra::Engines::Maxwell3D;
+
+static constexpr u32 PROGRAM_OFFSET{10};
+
+ProgramResult GenerateVertexShader(const ShaderSetup& setup, const MaxwellVSConfig& config) {
+    std::string out = "#version 430 core\n";
+    out += "#extension GL_ARB_separate_shader_objects : enable\n\n";
+    out += Decompiler::GetCommonDeclarations();
+
+    ProgramResult program = Decompiler::DecompileProgram(setup.program_code, PROGRAM_OFFSET,
+                                                         Maxwell3D::Regs::ShaderStage::Vertex)
+                                .get_value_or({});
+    out += R"(
+
+out gl_PerVertex {
+    vec4 gl_Position;
+};
+
+void main() {
+    exec_shader();
 }
 
-std::string GenerateFragmentShader(const ShaderSetup& setup, const MaxwellFSConfig& config) {
-    UNREACHABLE();
-    return {};
+)";
+    out += program.first;
+    return {out, program.second};
+}
+
+ProgramResult GenerateFragmentShader(const ShaderSetup& setup, const MaxwellFSConfig& config) {
+    std::string out = "#version 430 core\n";
+    out += "#extension GL_ARB_separate_shader_objects : enable\n\n";
+    out += Decompiler::GetCommonDeclarations();
+
+    ProgramResult program = Decompiler::DecompileProgram(setup.program_code, PROGRAM_OFFSET,
+                                                         Maxwell3D::Regs::ShaderStage::Fragment)
+                                .get_value_or({});
+    out += R"(
+
+out vec4 color;
+
+uniform sampler2D tex[32];
+
+void main() {
+    exec_shader();
+}
+
+)";
+    out += program.first;
+    return {out, program.second};
 }
 
 } // namespace GLShader

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -7,6 +7,8 @@
 #include <array>
 #include <string>
 #include <type_traits>
+#include <utility>
+#include <vector>
 #include "common/common_types.h"
 #include "common/hash.h"
 
@@ -15,6 +17,38 @@ namespace GLShader {
 constexpr size_t MAX_PROGRAM_CODE_LENGTH{0x1000};
 
 using ProgramCode = std::array<u64, MAX_PROGRAM_CODE_LENGTH>;
+
+class ConstBufferEntry {
+public:
+    void MarkAsUsed(unsigned index, unsigned offset) {
+        is_used = true;
+        this->index = index;
+        max_offset = std::max(max_offset, offset);
+    }
+
+    bool IsUsed() const {
+        return is_used;
+    }
+
+    unsigned GetIndex() const {
+        return index;
+    }
+
+    unsigned GetSize() const {
+        return max_offset + 1;
+    }
+
+private:
+    bool is_used{};
+    unsigned index{};
+    unsigned max_offset{};
+};
+
+struct ShaderEntries {
+    std::vector<ConstBufferEntry> const_buffer_entries;
+};
+
+using ProgramResult = std::pair<std::string, ShaderEntries>;
 
 struct ShaderSetup {
     ShaderSetup(ProgramCode&& program_code) : program_code(std::move(program_code)) {}
@@ -58,13 +92,13 @@ struct MaxwellFSConfig : Common::HashableStruct<MaxwellShaderConfigCommon> {
  * Generates the GLSL vertex shader program source code for the given VS program
  * @returns String of the shader source code
  */
-std::string GenerateVertexShader(const ShaderSetup& setup, const MaxwellVSConfig& config);
+ProgramResult GenerateVertexShader(const ShaderSetup& setup, const MaxwellVSConfig& config);
 
 /**
  * Generates the GLSL fragment shader program source code for the given FS program
  * @returns String of the shader source code
  */
-std::string GenerateFragmentShader(const ShaderSetup& setup, const MaxwellFSConfig& config);
+ProgramResult GenerateFragmentShader(const ShaderSetup& setup, const MaxwellFSConfig& config);
 
 } // namespace GLShader
 


### PR DESCRIPTION
Updates shader generation to keep track of uniforms, and declares the used const buffers. Does the necessary plumbing to return these buffers back to GL land. Blah blah blah

**NOTE: NO GAMES WILL RENDER WITH THIS CHANGE**