### PR TITLE
GPU: Implement some wrap modes

### DIFF
--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -74,6 +74,11 @@ inline GLenum WrapMode(Tegra::Texture::WrapMode wrap_mode) {
     switch (wrap_mode) {
     case Tegra::Texture::WrapMode::ClampToEdge:
         return GL_CLAMP_TO_EDGE;
+    case Tegra::Texture::WrapMode::ClampOGL:
+        // TODO(Subv): GL_CLAMP was removed as of OpenGL 3.1, to implement GL_CLAMP, we can use
+        // GL_CLAMP_TO_BORDER to get the border color of the texture, and then sample the edge to
+        // manually mix them. However the shader part of this is not yet implemented.
+        return GL_CLAMP_TO_BORDER;
     }
     LOG_CRITICAL(Render_OpenGL, "Unimplemented texture wrap mode=%u", static_cast<u32>(wrap_mode));
     UNREACHABLE();

--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -72,6 +72,8 @@ inline GLenum TextureFilterMode(Tegra::Texture::TextureFilter filter_mode) {
 
 inline GLenum WrapMode(Tegra::Texture::WrapMode wrap_mode) {
     switch (wrap_mode) {
+    case Tegra::Texture::WrapMode::Wrap:
+        return GL_REPEAT;
     case Tegra::Texture::WrapMode::ClampToEdge:
         return GL_CLAMP_TO_EDGE;
     case Tegra::Texture::WrapMode::ClampOGL:


### PR DESCRIPTION
This PR implements wrap mode 1 (GL_REPEAT) and half-implements wrap mode 4 (GL_CLAMP).

GL_CLAMP was removed from OpenGL starting from version 3.1, so we will have to emulate it some other way. I went with the easiest way i could think of: use GL_CLAMP_TO_BORDER and manually sample the edge in the shader to combine it with the sampled texture border value if the texcoords are out of bounds.
This requires modifications to the shader generator and will require us to pass the texture wrap mode as an uniform to the shaders.

The implementation of mode 1 can be dropped from #339 after this is merged