### PR TITLE
gl_shader_gen: Support vertical/horizontal viewport flipping.

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -319,7 +319,14 @@ public:
                     }
                 } rt[NumRenderTargets];
 
-                INSERT_PADDING_WORDS(0x80);
+                f32 viewport_scale_x;
+                f32 viewport_scale_y;
+                f32 viewport_scale_z;
+                u32 viewport_translate_x;
+                u32 viewport_translate_y;
+                u32 viewport_translate_z;
+
+                INSERT_PADDING_WORDS(0x7A);
 
                 struct {
                     union {
@@ -649,6 +656,12 @@ private:
                   "Field " #field_name " has invalid position")
 
 ASSERT_REG_POSITION(rt, 0x200);
+ASSERT_REG_POSITION(viewport_scale_x, 0x280);
+ASSERT_REG_POSITION(viewport_scale_y, 0x281);
+ASSERT_REG_POSITION(viewport_scale_z, 0x282);
+ASSERT_REG_POSITION(viewport_translate_x, 0x283);
+ASSERT_REG_POSITION(viewport_translate_y, 0x284);
+ASSERT_REG_POSITION(viewport_translate_z, 0x285);
 ASSERT_REG_POSITION(viewport, 0x300);
 ASSERT_REG_POSITION(vertex_buffer, 0x35D);
 ASSERT_REG_POSITION(zeta, 0x3F8);

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -319,14 +319,15 @@ public:
                     }
                 } rt[NumRenderTargets];
 
-                f32 viewport_scale_x;
-                f32 viewport_scale_y;
-                f32 viewport_scale_z;
-                u32 viewport_translate_x;
-                u32 viewport_translate_y;
-                u32 viewport_translate_z;
-
-                INSERT_PADDING_WORDS(0x7A);
+                struct {
+                    f32 scale_x;
+                    f32 scale_y;
+                    f32 scale_z;
+                    u32 translate_x;
+                    u32 translate_y;
+                    u32 translate_z;
+                    INSERT_PADDING_WORDS(2);
+                } viewport_transform[NumViewports];
 
                 struct {
                     union {
@@ -656,12 +657,7 @@ private:
                   "Field " #field_name " has invalid position")
 
 ASSERT_REG_POSITION(rt, 0x200);
-ASSERT_REG_POSITION(viewport_scale_x, 0x280);
-ASSERT_REG_POSITION(viewport_scale_y, 0x281);
-ASSERT_REG_POSITION(viewport_scale_z, 0x282);
-ASSERT_REG_POSITION(viewport_translate_x, 0x283);
-ASSERT_REG_POSITION(viewport_translate_y, 0x284);
-ASSERT_REG_POSITION(viewport_translate_z, 0x285);
+ASSERT_REG_POSITION(viewport_transform[0], 0x280);
 ASSERT_REG_POSITION(viewport, 0x300);
 ASSERT_REG_POSITION(vertex_buffer, 0x35D);
 ASSERT_REG_POSITION(zeta, 0x3F8);

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -29,9 +29,15 @@ out gl_PerVertex {
 
 out vec4 position;
 
+layout (std140) uniform vs_config {
+    vec4 viewport_flip;
+};
+
 void main() {
     exec_shader();
 
+    // Viewport can be flipped, which is unsupported by glViewport
+    position.xy *= viewport_flip.xy;
     gl_Position = position;
 }
 )";
@@ -51,6 +57,10 @@ ProgramResult GenerateFragmentShader(const ShaderSetup& setup, const MaxwellFSCo
 
 in vec4 position;
 out vec4 color;
+
+layout (std140) uniform fs_config {
+    vec4 viewport_flip;
+};
 
 uniform sampler2D tex[32];
 

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -53,6 +53,10 @@ void SetShaderSamplerBindings(GLuint shader) {
 
 } // namespace Impl
 
-void MaxwellUniformData::SetFromRegs(const Maxwell3D::State::ShaderStageInfo& shader_stage) {}
+void MaxwellUniformData::SetFromRegs(const Maxwell3D::State::ShaderStageInfo& shader_stage) {
+    const auto& regs = Core::System().GetInstance().GPU().Maxwell3D().regs;
+    viewport_flip[0] = regs.viewport_scale_x < 0.0 ? -1.0 : 1.0;
+    viewport_flip[1] = regs.viewport_scale_y < 0.0 ? -1.0 : 1.0;
+}
 
 } // namespace GLShader

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -55,8 +55,10 @@ void SetShaderSamplerBindings(GLuint shader) {
 
 void MaxwellUniformData::SetFromRegs(const Maxwell3D::State::ShaderStageInfo& shader_stage) {
     const auto& regs = Core::System().GetInstance().GPU().Maxwell3D().regs;
-    viewport_flip[0] = regs.viewport_scale_x < 0.0 ? -1.0 : 1.0;
-    viewport_flip[1] = regs.viewport_scale_y < 0.0 ? -1.0 : 1.0;
+
+    // TODO(bunnei): Support more than one viewport
+    viewport_flip[0] = regs.viewport_transform[0].scale_x < 0.0 ? -1.0 : 1.0;
+    viewport_flip[1] = regs.viewport_transform[0].scale_y < 0.0 ? -1.0 : 1.0;
 }
 
 } // namespace GLShader

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -30,10 +30,9 @@ void SetShaderSamplerBindings(GLuint shader);
 //       Not following that rule will cause problems on some AMD drivers.
 struct MaxwellUniformData {
     void SetFromRegs(const Maxwell3D::State::ShaderStageInfo& shader_stage);
-    // TODO(Subv): Use this for something.
+    alignas(16) GLvec4 viewport_flip;
 };
-// static_assert(sizeof(MaxwellUniformData) == 1024, "MaxwellUniformData structure size is
-// incorrect");
+static_assert(sizeof(MaxwellUniformData) == 16, "MaxwellUniformData structure size is incorrect");
 static_assert(sizeof(MaxwellUniformData) < 16384,
               "MaxwellUniformData structure must be less than 16kb as per the OpenGL spec");
 


### PR DESCRIPTION
This is a continuation of getting the various changes in #339 merged into mainline yuzu. In this PR, we bring over the change to support flipping the viewport vertically (or horizontally) using negative viewport scales. This is not possible with just `glViewPort`, so we flip the final output in the vertex shader. This was tested with Cave Story+. I've also addressed any related comments on #339.

**As was mentioned in other PRs, if you are already using changes to run games, I do not recommend trying to merge this branch. This does not add anything functionally new that isn't in #339.**