### PR TITLE
GPU: Fixed the incorrect component order in ABGR8 textures.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -527,6 +527,8 @@ bool RasterizerOpenGL::AccelerateDisplay(const Tegra::FramebufferConfig& framebu
     src_params.block_height = Tegra::Texture::TICEntry::DefaultBlockHeight;
     src_params.pixel_format =
         SurfaceParams::PixelFormatFromGPUPixelFormat(framebuffer.pixel_format);
+    src_params.component_type =
+        SurfaceParams::ComponentTypeFromGPUPixelFormat(framebuffer.pixel_format);
     src_params.UpdateParams();
 
     MathUtil::Rectangle<u32> src_rect;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -52,7 +52,7 @@ static constexpr std::array<FormatTuple, 1> fb_format_tuples = {{
 }};
 
 static constexpr std::array<FormatTuple, 2> tex_format_tuples = {{
-    {GL_RGBA8, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8, false, 1},                       // RGBA8
+    {GL_RGBA8, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, false, 1},                   // ABGR8
     {GL_COMPRESSED_RGB_S3TC_DXT1_EXT, GL_RGB, GL_UNSIGNED_INT_8_8_8_8, true, 16}, // DXT1
 }};
 
@@ -123,13 +123,13 @@ void MortonCopy(u32 stride, u32 block_height, u32 height, u8* gl_buffer, VAddr b
 
 static constexpr std::array<void (*)(u32, u32, u32, u8*, VAddr, VAddr, VAddr), 2> morton_to_gl_fns =
     {
-        MortonCopy<true, PixelFormat::RGBA8>,
+        MortonCopy<true, PixelFormat::ABGR8>,
         MortonCopy<true, PixelFormat::DXT1>,
 };
 
 static constexpr std::array<void (*)(u32, u32, u32, u8*, VAddr, VAddr, VAddr), 2> gl_to_morton_fns =
     {
-        MortonCopy<false, PixelFormat::RGBA8>,
+        MortonCopy<false, PixelFormat::ABGR8>,
         // TODO(Subv): Swizzling the DXT1 format is not yet supported
         nullptr,
 };

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -57,6 +57,15 @@ struct SurfaceParams {
         Invalid = 255,
     };
 
+    enum class ComponentType {
+        Invalid = 0,
+        SNorm = 1,
+        UNorm = 2,
+        SInt = 3,
+        UInt = 4,
+        Float = 5,
+    };
+
     enum class SurfaceType {
         ColorTexture = 0,
         Depth = 1,
@@ -122,6 +131,40 @@ struct SurfaceParams {
         case PixelFormat::DXT1:
             return Tegra::Texture::TextureFormat::DXT1;
         default:
+            UNREACHABLE();
+        }
+    }
+
+    static ComponentType ComponentTypeFromTexture(Tegra::Texture::ComponentType type) {
+        // TODO(Subv): Implement more component types
+        switch (type) {
+        case Tegra::Texture::ComponentType::UNORM:
+            return ComponentType::UNorm;
+        default:
+            NGLOG_CRITICAL(HW_GPU, "Unimplemented component type={}", static_cast<u32>(type));
+            UNREACHABLE();
+        }
+    }
+
+    static ComponentType ComponentTypeFromRenderTarget(Tegra::RenderTargetFormat format) {
+        // TODO(Subv): Implement more render targets
+        switch (format) {
+        case Tegra::RenderTargetFormat::RGBA8_UNORM:
+        case Tegra::RenderTargetFormat::RGB10_A2_UNORM:
+            return ComponentType::UNorm;
+        default:
+            NGLOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
+            UNREACHABLE();
+        }
+    }
+
+    static ComponentType ComponentTypeFromGPUPixelFormat(
+        Tegra::FramebufferConfig::PixelFormat format) {
+        switch (format) {
+        case Tegra::FramebufferConfig::PixelFormat::ABGR8:
+            return ComponentType::UNorm;
+        default:
+            NGLOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
             UNREACHABLE();
         }
     }
@@ -225,6 +268,7 @@ struct SurfaceParams {
     bool is_tiled = false;
     PixelFormat pixel_format = PixelFormat::Invalid;
     SurfaceType type = SurfaceType::Invalid;
+    ComponentType component_type = ComponentType::Invalid;
 };
 
 struct CachedSurface : SurfaceParams {

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -58,12 +58,11 @@ struct SurfaceParams {
     };
 
     enum class SurfaceType {
-        Color = 0,
-        Texture = 1,
-        Depth = 2,
-        DepthStencil = 3,
-        Fill = 4,
-        Invalid = 5
+        ColorTexture = 0,
+        Depth = 1,
+        DepthStencil = 2,
+        Fill = 3,
+        Invalid = 4,
     };
 
     static constexpr unsigned int GetFormatBpp(PixelFormat format) {
@@ -131,8 +130,7 @@ struct SurfaceParams {
         SurfaceType a_type = GetFormatType(pixel_format_a);
         SurfaceType b_type = GetFormatType(pixel_format_b);
 
-        if ((a_type == SurfaceType::Color || a_type == SurfaceType::Texture) &&
-            (b_type == SurfaceType::Color || b_type == SurfaceType::Texture)) {
+        if (a_type == SurfaceType::ColorTexture && b_type == SurfaceType::ColorTexture) {
             return true;
         }
 
@@ -148,12 +146,8 @@ struct SurfaceParams {
     }
 
     static SurfaceType GetFormatType(PixelFormat pixel_format) {
-        if ((unsigned int)pixel_format <= static_cast<unsigned int>(PixelFormat::ABGR8)) {
-            return SurfaceType::Color;
-        }
-
         if ((unsigned int)pixel_format <= static_cast<unsigned int>(PixelFormat::DXT1)) {
-            return SurfaceType::Texture;
+            return SurfaceType::ColorTexture;
         }
 
         // TODO(Subv): Implement the other formats

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -52,7 +52,7 @@ enum class ScaleMatch {
 
 struct SurfaceParams {
     enum class PixelFormat {
-        RGBA8 = 0,
+        ABGR8 = 0,
         DXT1 = 1,
         Invalid = 255,
     };
@@ -71,7 +71,7 @@ struct SurfaceParams {
             return 0;
 
         constexpr std::array<unsigned int, 2> bpp_table = {
-            32, // RGBA8
+            32, // ABGR8
             64, // DXT1
         };
 
@@ -85,7 +85,7 @@ struct SurfaceParams {
     static PixelFormat PixelFormatFromRenderTargetFormat(Tegra::RenderTargetFormat format) {
         switch (format) {
         case Tegra::RenderTargetFormat::RGBA8_UNORM:
-            return PixelFormat::RGBA8;
+            return PixelFormat::ABGR8;
         default:
             NGLOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
             UNREACHABLE();
@@ -95,7 +95,7 @@ struct SurfaceParams {
     static PixelFormat PixelFormatFromGPUPixelFormat(Tegra::FramebufferConfig::PixelFormat format) {
         switch (format) {
         case Tegra::FramebufferConfig::PixelFormat::ABGR8:
-            return PixelFormat::RGBA8;
+            return PixelFormat::ABGR8;
         default:
             NGLOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
             UNREACHABLE();
@@ -106,7 +106,7 @@ struct SurfaceParams {
         // TODO(Subv): Properly implement this
         switch (format) {
         case Tegra::Texture::TextureFormat::A8R8G8B8:
-            return PixelFormat::RGBA8;
+            return PixelFormat::ABGR8;
         case Tegra::Texture::TextureFormat::DXT1:
             return PixelFormat::DXT1;
         default:
@@ -118,7 +118,7 @@ struct SurfaceParams {
     static Tegra::Texture::TextureFormat TextureFormatFromPixelFormat(PixelFormat format) {
         // TODO(Subv): Properly implement this
         switch (format) {
-        case PixelFormat::RGBA8:
+        case PixelFormat::ABGR8:
             return Tegra::Texture::TextureFormat::A8R8G8B8;
         case PixelFormat::DXT1:
             return Tegra::Texture::TextureFormat::DXT1;
@@ -148,7 +148,7 @@ struct SurfaceParams {
     }
 
     static SurfaceType GetFormatType(PixelFormat pixel_format) {
-        if ((unsigned int)pixel_format <= static_cast<unsigned int>(PixelFormat::RGBA8)) {
+        if ((unsigned int)pixel_format <= static_cast<unsigned int>(PixelFormat::ABGR8)) {
             return SurfaceType::Color;
         }
 


### PR DESCRIPTION
Also added the necessary boilerplate for supporting SNORM, UINT, SINT and FLOAT texture components, this is not yet completely implemented as I haven't seen any game use them yet.