### PR TITLE
GPU: Add support for the DXT23 and DXT45 compressed texture formats.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -55,6 +55,8 @@ struct SurfaceParams {
         ABGR8 = 0,
         B5G6R5 = 1,
         DXT1 = 2,
+        DXT23 = 3,
+        DXT45 = 4,
 
         Max,
         Invalid = 255,
@@ -84,9 +86,11 @@ struct SurfaceParams {
             return 0;
 
         constexpr std::array<unsigned int, MaxPixelFormat> bpp_table = {
-            32, // ABGR8
-            16, // B5G6R5
-            64, // DXT1
+            32,  // ABGR8
+            16,  // B5G6R5
+            64,  // DXT1
+            128, // DXT23
+            128, // DXT45
         };
 
         ASSERT(static_cast<size_t>(format) < bpp_table.size());
@@ -125,6 +129,10 @@ struct SurfaceParams {
             return PixelFormat::B5G6R5;
         case Tegra::Texture::TextureFormat::DXT1:
             return PixelFormat::DXT1;
+        case Tegra::Texture::TextureFormat::DXT23:
+            return PixelFormat::DXT23;
+        case Tegra::Texture::TextureFormat::DXT45:
+            return PixelFormat::DXT45;
         default:
             NGLOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
             UNREACHABLE();
@@ -140,6 +148,10 @@ struct SurfaceParams {
             return Tegra::Texture::TextureFormat::B5G6R5;
         case PixelFormat::DXT1:
             return Tegra::Texture::TextureFormat::DXT1;
+        case PixelFormat::DXT23:
+            return Tegra::Texture::TextureFormat::DXT23;
+        case PixelFormat::DXT45:
+            return Tegra::Texture::TextureFormat::DXT45;
         default:
             UNREACHABLE();
         }

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -48,6 +48,10 @@ u32 BytesPerPixel(TextureFormat format) {
     case TextureFormat::DXT1:
         // In this case a 'pixel' actually refers to a 4x4 tile.
         return 8;
+    case TextureFormat::DXT23:
+    case TextureFormat::DXT45:
+        // In this case a 'pixel' actually refers to a 4x4 tile.
+        return 16;
     case TextureFormat::A8R8G8B8:
         return 4;
     case TextureFormat::B5G6R5:
@@ -67,7 +71,9 @@ std::vector<u8> UnswizzleTexture(VAddr address, TextureFormat format, u32 width,
 
     switch (format) {
     case TextureFormat::DXT1:
-        // In the DXT1 format, each 4x4 tile is swizzled instead of just individual pixel values.
+    case TextureFormat::DXT23:
+    case TextureFormat::DXT45:
+        // In the DXT formats, each 4x4 tile is swizzled instead of just individual pixel values.
         CopySwizzledData(width / 4, height / 4, bytes_per_pixel, bytes_per_pixel, data,
                          unswizzled_data.data(), true, block_height);
         break;
@@ -91,6 +97,8 @@ std::vector<u8> DecodeTexture(const std::vector<u8>& texture_data, TextureFormat
     // TODO(Subv): Implement.
     switch (format) {
     case TextureFormat::DXT1:
+    case TextureFormat::DXT23:
+    case TextureFormat::DXT45:
     case TextureFormat::A8R8G8B8:
     case TextureFormat::B5G6R5:
         // TODO(Subv): For the time being just forward the same data without any decoding.


### PR DESCRIPTION
The respective commit in #339 can be dropped.

Original work by @jroweboy 