### PR TITLE
common_funcs: Remove check for VS versions that we don't even support

### DIFF
--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -74,11 +74,6 @@ inline u64 _rotr64(u64 x, unsigned int shift) {
 
 #else // _MSC_VER
 
-#if (_MSC_VER < 1900)
-// Function Cross-Compatibility
-#define snprintf _snprintf
-#endif
-
 // Locale Cross-Compatibility
 #define locale_t _locale_t
 


### PR DESCRIPTION
We don't support any VS versions that don't already have snprintf in the standard library implementation.