### PR TITLE
math_util: Remove the Clamp() function

### DIFF
--- a/src/common/math_util.h
+++ b/src/common/math_util.h
@@ -17,11 +17,6 @@ inline bool IntervalsIntersect(unsigned start0, unsigned length0, unsigned start
     return (std::max(start0, start1) < std::min(start0 + length0, start1 + length1));
 }
 
-template <typename T>
-inline T Clamp(const T val, const T& min, const T& max) {
-    return std::max(min, std::min(max, val));
-}
-
 template <class T>
 struct Rectangle {
     T left;

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <chrono>
 #include <mutex>
 #include <thread>
@@ -87,7 +88,7 @@ void FrameLimiter::DoFrameLimiting(u64 current_system_time_us) {
     frame_limiting_delta_err += microseconds(current_system_time_us - previous_system_time_us);
     frame_limiting_delta_err -= duration_cast<microseconds>(now - previous_walltime);
     frame_limiting_delta_err =
-        MathUtil::Clamp(frame_limiting_delta_err, -MAX_LAG_TIME_US, MAX_LAG_TIME_US);
+        std::clamp(frame_limiting_delta_err, -MAX_LAG_TIME_US, MAX_LAG_TIME_US);
 
     if (frame_limiting_delta_err > microseconds::zero()) {
         std::this_thread::sleep_for(frame_limiting_delta_err);

--- a/src/input_common/motion_emu.cpp
+++ b/src/input_common/motion_emu.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <chrono>
 #include <mutex>
 #include <thread>
@@ -43,8 +44,8 @@ public:
                 tilt_angle = 0;
             } else {
                 tilt_direction = mouse_move.Cast<float>();
-                tilt_angle = MathUtil::Clamp(tilt_direction.Normalize() * sensitivity, 0.0f,
-                                             MathUtil::PI * 0.5f);
+                tilt_angle =
+                    std::clamp(tilt_direction.Normalize() * sensitivity, 0.0f, MathUtil::PI * 0.5f);
             }
         }
     }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <tuple>
@@ -290,18 +291,18 @@ void RasterizerOpenGL::DrawArrays() {
                               : (depth_surface == nullptr ? 1u : depth_surface->res_scale);
 
     MathUtil::Rectangle<u32> draw_rect{
-        static_cast<u32>(MathUtil::Clamp<s32>(static_cast<s32>(surfaces_rect.left) +
-                                                  viewport_rect.left * res_scale,
-                                              surfaces_rect.left, surfaces_rect.right)), // Left
-        static_cast<u32>(MathUtil::Clamp<s32>(static_cast<s32>(surfaces_rect.bottom) +
-                                                  viewport_rect.top * res_scale,
-                                              surfaces_rect.bottom, surfaces_rect.top)), // Top
-        static_cast<u32>(MathUtil::Clamp<s32>(static_cast<s32>(surfaces_rect.left) +
-                                                  viewport_rect.right * res_scale,
-                                              surfaces_rect.left, surfaces_rect.right)), // Right
-        static_cast<u32>(MathUtil::Clamp<s32>(static_cast<s32>(surfaces_rect.bottom) +
-                                                  viewport_rect.bottom * res_scale,
-                                              surfaces_rect.bottom, surfaces_rect.top))}; // Bottom
+        static_cast<u32>(
+            std::clamp<s32>(static_cast<s32>(surfaces_rect.left) + viewport_rect.left * res_scale,
+                            surfaces_rect.left, surfaces_rect.right)), // Left
+        static_cast<u32>(
+            std::clamp<s32>(static_cast<s32>(surfaces_rect.bottom) + viewport_rect.top * res_scale,
+                            surfaces_rect.bottom, surfaces_rect.top)), // Top
+        static_cast<u32>(
+            std::clamp<s32>(static_cast<s32>(surfaces_rect.left) + viewport_rect.right * res_scale,
+                            surfaces_rect.left, surfaces_rect.right)), // Right
+        static_cast<u32>(std::clamp<s32>(static_cast<s32>(surfaces_rect.bottom) +
+                                             viewport_rect.bottom * res_scale,
+                                         surfaces_rect.bottom, surfaces_rect.top))}; // Bottom
 
     // Bind the framebuffer surfaces
     BindFramebufferSurfaces(color_surface, depth_surface, has_stencil);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1086,10 +1086,10 @@ SurfaceSurfaceRect_Tuple RasterizerCacheOpenGL::GetFramebufferSurfaces(
     }
 
     MathUtil::Rectangle<u32> viewport_clamped{
-        static_cast<u32>(MathUtil::Clamp(viewport.left, 0, static_cast<s32>(config.width))),
-        static_cast<u32>(MathUtil::Clamp(viewport.top, 0, static_cast<s32>(config.height))),
-        static_cast<u32>(MathUtil::Clamp(viewport.right, 0, static_cast<s32>(config.width))),
-        static_cast<u32>(MathUtil::Clamp(viewport.bottom, 0, static_cast<s32>(config.height)))};
+        static_cast<u32>(std::clamp(viewport.left, 0, static_cast<s32>(config.width))),
+        static_cast<u32>(std::clamp(viewport.top, 0, static_cast<s32>(config.height))),
+        static_cast<u32>(std::clamp(viewport.right, 0, static_cast<s32>(config.width))),
+        static_cast<u32>(std::clamp(viewport.bottom, 0, static_cast<s32>(config.height)))};
 
     // get color and depth surfaces
     SurfaceParams color_params;


### PR DESCRIPTION
C++17 adds clamp() to the standard library, so we can remove ours in favor of it.