### PR TITLE
core: Relocate g_service_manager to the System class

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -19,10 +19,16 @@
 class EmuWindow;
 class ARM_Interface;
 
+namespace Service::SM {
+class ServiceManager;
+}
+
 namespace Core {
 
 class System {
 public:
+    ~System();
+
     /**
      * Gets the instance of the System singleton class.
      * @returns Reference to the instance of the System singleton class.
@@ -137,6 +143,9 @@ public:
         return *app_loader;
     }
 
+    Service::SM::ServiceManager& ServiceManager();
+    const Service::SM::ServiceManager& ServiceManager() const;
+
     void SetGPUDebugContext(std::shared_ptr<Tegra::DebugContext> context) {
         debug_context = std::move(context);
     }
@@ -170,6 +179,9 @@ private:
 
     /// When true, signals that a reschedule should happen
     bool reschedule_pending{};
+
+    /// Service manager
+    std::shared_ptr<Service::SM::ServiceManager> service_manager;
 
     /// Telemetry session for this emulation session
     std::unique_ptr<Core::TelemetrySession> telemetry_session;

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -145,7 +145,7 @@ ResultCode ServiceFrameworkBase::HandleSyncRequest(Kernel::HLERequestContext& co
         return ResultCode(ErrorModule::HIPC, ErrorDescription::RemoteProcessDead);
     }
     case IPC::CommandType::Control: {
-        SM::g_service_manager->InvokeControlRequest(context);
+        Core::System::GetInstance().ServiceManager().InvokeControlRequest(context);
         break;
     }
     case IPC::CommandType::Request: {
@@ -170,42 +170,40 @@ void AddNamedPort(std::string name, SharedPtr<ClientPort> port) {
 }
 
 /// Initialize ServiceManager
-void Init() {
+void Init(std::shared_ptr<SM::ServiceManager>& sm) {
     // NVFlinger needs to be accessed by several services like Vi and AppletOE so we instantiate it
     // here and pass it into the respective InstallInterfaces functions.
     auto nv_flinger = std::make_shared<NVFlinger::NVFlinger>();
 
-    SM::g_service_manager = std::make_shared<SM::ServiceManager>();
-    SM::ServiceManager::InstallInterfaces(SM::g_service_manager);
+    SM::ServiceManager::InstallInterfaces(sm);
 
-    Account::InstallInterfaces(*SM::g_service_manager);
-    AM::InstallInterfaces(*SM::g_service_manager, nv_flinger);
-    AOC::InstallInterfaces(*SM::g_service_manager);
-    APM::InstallInterfaces(*SM::g_service_manager);
-    Audio::InstallInterfaces(*SM::g_service_manager);
-    Fatal::InstallInterfaces(*SM::g_service_manager);
-    FileSystem::InstallInterfaces(*SM::g_service_manager);
-    Friend::InstallInterfaces(*SM::g_service_manager);
-    HID::InstallInterfaces(*SM::g_service_manager);
-    LM::InstallInterfaces(*SM::g_service_manager);
-    NFP::InstallInterfaces(*SM::g_service_manager);
-    NIFM::InstallInterfaces(*SM::g_service_manager);
-    NS::InstallInterfaces(*SM::g_service_manager);
-    Nvidia::InstallInterfaces(*SM::g_service_manager);
-    PCTL::InstallInterfaces(*SM::g_service_manager);
-    Sockets::InstallInterfaces(*SM::g_service_manager);
-    SPL::InstallInterfaces(*SM::g_service_manager);
-    SSL::InstallInterfaces(*SM::g_service_manager);
-    Time::InstallInterfaces(*SM::g_service_manager);
-    VI::InstallInterfaces(*SM::g_service_manager, nv_flinger);
-    Set::InstallInterfaces(*SM::g_service_manager);
+    Account::InstallInterfaces(*sm);
+    AM::InstallInterfaces(*sm, nv_flinger);
+    AOC::InstallInterfaces(*sm);
+    APM::InstallInterfaces(*sm);
+    Audio::InstallInterfaces(*sm);
+    Fatal::InstallInterfaces(*sm);
+    FileSystem::InstallInterfaces(*sm);
+    Friend::InstallInterfaces(*sm);
+    HID::InstallInterfaces(*sm);
+    LM::InstallInterfaces(*sm);
+    NFP::InstallInterfaces(*sm);
+    NIFM::InstallInterfaces(*sm);
+    NS::InstallInterfaces(*sm);
+    Nvidia::InstallInterfaces(*sm);
+    PCTL::InstallInterfaces(*sm);
+    Sockets::InstallInterfaces(*sm);
+    SPL::InstallInterfaces(*sm);
+    SSL::InstallInterfaces(*sm);
+    Time::InstallInterfaces(*sm);
+    VI::InstallInterfaces(*sm, nv_flinger);
+    Set::InstallInterfaces(*sm);
 
     LOG_DEBUG(Service, "initialized OK");
 }
 
 /// Shutdown ServiceManager
 void Shutdown() {
-    SM::g_service_manager = nullptr;
     g_kernel_named_ports.clear();
     LOG_DEBUG(Service, "shutdown OK");
 }

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -178,7 +178,7 @@ private:
 };
 
 /// Initialize ServiceManager
-void Init();
+void Init(std::shared_ptr<SM::ServiceManager>& sm);
 
 /// Shutdown ServiceManager
 void Shutdown();

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -14,6 +14,8 @@
 
 namespace Service::SM {
 
+ServiceManager::~ServiceManager() = default;
+
 void ServiceManager::InvokeControlRequest(Kernel::HLERequestContext& context) {
     controller_interface->InvokeRequest(context);
 }
@@ -72,7 +74,7 @@ ResultVal<Kernel::SharedPtr<Kernel::ClientSession>> ServiceManager::ConnectToSer
     return client_port->Connect();
 }
 
-std::shared_ptr<ServiceManager> g_service_manager;
+SM::~SM() = default;
 
 /**
  * SM::Initialize service function

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -23,7 +23,7 @@ namespace Service::SM {
 class SM final : public ServiceFramework<SM> {
 public:
     SM(std::shared_ptr<ServiceManager> service_manager);
-    ~SM() = default;
+    ~SM() override;
 
 private:
     void Initialize(Kernel::HLERequestContext& ctx);
@@ -44,6 +44,8 @@ class ServiceManager {
 public:
     static void InstallInterfaces(std::shared_ptr<ServiceManager> self);
 
+    ~ServiceManager();
+
     ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> RegisterService(std::string name,
                                                                      unsigned int max_sessions);
     ResultVal<Kernel::SharedPtr<Kernel::ClientPort>> GetServicePort(const std::string& name);
@@ -58,7 +60,5 @@ private:
     /// Map of registered services, retrieved using GetServicePort or ConnectToService.
     std::unordered_map<std::string, Kernel::SharedPtr<Kernel::ClientPort>> registered_services;
 };
-
-extern std::shared_ptr<ServiceManager> g_service_manager;
 
 } // namespace Service::SM


### PR DESCRIPTION
Converts the service manager from a global into an instance-based variable.