### PR TITLE
resource_limit: Make ResourceTypes an enum class

### DIFF
--- a/src/core/hle/kernel/resource_limit.cpp
+++ b/src/core/hle/kernel/resource_limit.cpp
@@ -34,57 +34,57 @@ SharedPtr<ResourceLimit> ResourceLimit::GetForCategory(ResourceLimitCategory cat
     }
 }
 
-s32 ResourceLimit::GetCurrentResourceValue(u32 resource) const {
+s32 ResourceLimit::GetCurrentResourceValue(ResourceType resource) const {
     switch (resource) {
-    case COMMIT:
+    case ResourceType::Commit:
         return current_commit;
-    case THREAD:
+    case ResourceType::Thread:
         return current_threads;
-    case EVENT:
+    case ResourceType::Event:
         return current_events;
-    case MUTEX:
+    case ResourceType::Mutex:
         return current_mutexes;
-    case SEMAPHORE:
+    case ResourceType::Semaphore:
         return current_semaphores;
-    case TIMER:
+    case ResourceType::Timer:
         return current_timers;
-    case SHARED_MEMORY:
+    case ResourceType::SharedMemory:
         return current_shared_mems;
-    case ADDRESS_ARBITER:
+    case ResourceType::AddressArbiter:
         return current_address_arbiters;
-    case CPU_TIME:
+    case ResourceType::CPUTime:
         return current_cpu_time;
     default:
-        LOG_ERROR(Kernel, "Unknown resource type=%08X", resource);
+        LOG_ERROR(Kernel, "Unknown resource type=%08X", static_cast<u32>(resource));
         UNIMPLEMENTED();
         return 0;
     }
 }
 
-u32 ResourceLimit::GetMaxResourceValue(u32 resource) const {
+u32 ResourceLimit::GetMaxResourceValue(ResourceType resource) const {
     switch (resource) {
-    case PRIORITY:
+    case ResourceType::Priority:
         return max_priority;
-    case COMMIT:
+    case ResourceType::Commit:
         return max_commit;
-    case THREAD:
+    case ResourceType::Thread:
         return max_threads;
-    case EVENT:
+    case ResourceType::Event:
         return max_events;
-    case MUTEX:
+    case ResourceType::Mutex:
         return max_mutexes;
-    case SEMAPHORE:
+    case ResourceType::Semaphore:
         return max_semaphores;
-    case TIMER:
+    case ResourceType::Timer:
         return max_timers;
-    case SHARED_MEMORY:
+    case ResourceType::SharedMemory:
         return max_shared_mems;
-    case ADDRESS_ARBITER:
+    case ResourceType::AddressArbiter:
         return max_address_arbiters;
-    case CPU_TIME:
+    case ResourceType::CPUTime:
         return max_cpu_time;
     default:
-        LOG_ERROR(Kernel, "Unknown resource type=%08X", resource);
+        LOG_ERROR(Kernel, "Unknown resource type=%08X", static_cast<u32>(resource));
         UNIMPLEMENTED();
         return 0;
     }

--- a/src/core/hle/kernel/resource_limit.h
+++ b/src/core/hle/kernel/resource_limit.h
@@ -16,17 +16,17 @@ enum class ResourceLimitCategory : u8 {
     OTHER = 3
 };
 
-enum ResourceTypes {
-    PRIORITY = 0,
-    COMMIT = 1,
-    THREAD = 2,
-    EVENT = 3,
-    MUTEX = 4,
-    SEMAPHORE = 5,
-    TIMER = 6,
-    SHARED_MEMORY = 7,
-    ADDRESS_ARBITER = 8,
-    CPU_TIME = 9,
+enum class ResourceType {
+    Priority = 0,
+    Commit = 1,
+    Thread = 2,
+    Event = 3,
+    Mutex = 4,
+    Semaphore = 5,
+    Timer = 6,
+    SharedMemory = 7,
+    AddressArbiter = 8,
+    CPUTime = 9,
 };
 
 class ResourceLimit final : public Object {
@@ -60,14 +60,14 @@ public:
      * @param resource Requested resource type
      * @returns The current value of the resource type
      */
-    s32 GetCurrentResourceValue(u32 resource) const;
+    s32 GetCurrentResourceValue(ResourceType resource) const;
 
     /**
      * Gets the max value for the specified resource.
      * @param resource Requested resource type
      * @returns The max value of the resource type
      */
-    u32 GetMaxResourceValue(u32 resource) const;
+    u32 GetMaxResourceValue(ResourceType resource) const;
 
     /// Name of resource limit object.
     std::string name;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -407,7 +407,7 @@ static ResultCode SetThreadPriority(Handle handle, u32 priority) {
     // Note: The kernel uses the current process's resource limit instead of
     // the one from the thread owner's resource limit.
     SharedPtr<ResourceLimit>& resource_limit = Core::CurrentProcess()->resource_limit;
-    if (resource_limit->GetMaxResourceValue(ResourceTypes::PRIORITY) > priority) {
+    if (resource_limit->GetMaxResourceValue(ResourceType::Priority) > priority) {
         return ERR_NOT_AUTHORIZED;
     }
 
@@ -541,7 +541,7 @@ static ResultCode CreateThread(Handle* out_handle, VAddr entry_point, u64 arg, V
     }
 
     SharedPtr<ResourceLimit>& resource_limit = Core::CurrentProcess()->resource_limit;
-    if (resource_limit->GetMaxResourceValue(ResourceTypes::PRIORITY) > priority) {
+    if (resource_limit->GetMaxResourceValue(ResourceType::Priority) > priority) {
         return ERR_NOT_AUTHORIZED;
     }
 


### PR DESCRIPTION
Prevents enum identifiers from leaking into the surrounding scope.