### PR TITLE
gl_resource_manager: Add missing noexcept specifiers to move constructors and assignment operators

### DIFF
--- a/src/video_core/renderer_opengl/gl_resource_manager.h
+++ b/src/video_core/renderer_opengl/gl_resource_manager.h
@@ -14,13 +14,13 @@ class OGLTexture : private NonCopyable {
 public:
     OGLTexture() = default;
 
-    OGLTexture(OGLTexture&& o) : handle(std::exchange(o.handle, 0)) {}
+    OGLTexture(OGLTexture&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
 
     ~OGLTexture() {
         Release();
     }
 
-    OGLTexture& operator=(OGLTexture&& o) {
+    OGLTexture& operator=(OGLTexture&& o) noexcept {
         Release();
         handle = std::exchange(o.handle, 0);
         return *this;
@@ -49,13 +49,13 @@ class OGLSampler : private NonCopyable {
 public:
     OGLSampler() = default;
 
-    OGLSampler(OGLSampler&& o) : handle(std::exchange(o.handle, 0)) {}
+    OGLSampler(OGLSampler&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
 
     ~OGLSampler() {
         Release();
     }
 
-    OGLSampler& operator=(OGLSampler&& o) {
+    OGLSampler& operator=(OGLSampler&& o) noexcept {
         Release();
         handle = std::exchange(o.handle, 0);
         return *this;
@@ -84,13 +84,13 @@ class OGLShader : private NonCopyable {
 public:
     OGLShader() = default;
 
-    OGLShader(OGLShader&& o) : handle(std::exchange(o.handle, 0)) {}
+    OGLShader(OGLShader&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
 
     ~OGLShader() {
         Release();
     }
 
-    OGLShader& operator=(OGLShader&& o) {
+    OGLShader& operator=(OGLShader&& o) noexcept {
         Release();
         handle = std::exchange(o.handle, 0);
         return *this;
@@ -118,13 +118,13 @@ class OGLProgram : private NonCopyable {
 public:
     OGLProgram() = default;
 
-    OGLProgram(OGLProgram&& o) : handle(std::exchange(o.handle, 0)) {}
+    OGLProgram(OGLProgram&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
 
     ~OGLProgram() {
         Release();
     }
 
-    OGLProgram& operator=(OGLProgram&& o) {
+    OGLProgram& operator=(OGLProgram&& o) noexcept {
         Release();
         handle = std::exchange(o.handle, 0);
         return *this;
@@ -165,13 +165,12 @@ public:
 class OGLPipeline : private NonCopyable {
 public:
     OGLPipeline() = default;
-    OGLPipeline(OGLPipeline&& o) {
-        handle = std::exchange<GLuint>(o.handle, 0);
-    }
+    OGLPipeline(OGLPipeline&& o) noexcept : handle{std::exchange<GLuint>(o.handle, 0)} {}
+
     ~OGLPipeline() {
         Release();
     }
-    OGLPipeline& operator=(OGLPipeline&& o) {
+    OGLPipeline& operator=(OGLPipeline&& o) noexcept {
         handle = std::exchange<GLuint>(o.handle, 0);
         return *this;
     }
@@ -199,13 +198,13 @@ class OGLBuffer : private NonCopyable {
 public:
     OGLBuffer() = default;
 
-    OGLBuffer(OGLBuffer&& o) : handle(std::exchange(o.handle, 0)) {}
+    OGLBuffer(OGLBuffer&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
 
     ~OGLBuffer() {
         Release();
     }
 
-    OGLBuffer& operator=(OGLBuffer&& o) {
+    OGLBuffer& operator=(OGLBuffer&& o) noexcept {
         Release();
         handle = std::exchange(o.handle, 0);
         return *this;
@@ -234,12 +233,12 @@ class OGLSync : private NonCopyable {
 public:
     OGLSync() = default;
 
-    OGLSync(OGLSync&& o) : handle(std::exchange(o.handle, nullptr)) {}
+    OGLSync(OGLSync&& o) noexcept : handle(std::exchange(o.handle, nullptr)) {}
 
     ~OGLSync() {
         Release();
     }
-    OGLSync& operator=(OGLSync&& o) {
+    OGLSync& operator=(OGLSync&& o) noexcept {
         Release();
         handle = std::exchange(o.handle, nullptr);
         return *this;
@@ -267,13 +266,13 @@ class OGLVertexArray : private NonCopyable {
 public:
     OGLVertexArray() = default;
 
-    OGLVertexArray(OGLVertexArray&& o) : handle(std::exchange(o.handle, 0)) {}
+    OGLVertexArray(OGLVertexArray&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
 
     ~OGLVertexArray() {
         Release();
     }
 
-    OGLVertexArray& operator=(OGLVertexArray&& o) {
+    OGLVertexArray& operator=(OGLVertexArray&& o) noexcept {
         Release();
         handle = std::exchange(o.handle, 0);
         return *this;
@@ -302,13 +301,13 @@ class OGLFramebuffer : private NonCopyable {
 public:
     OGLFramebuffer() = default;
 
-    OGLFramebuffer(OGLFramebuffer&& o) : handle(std::exchange(o.handle, 0)) {}
+    OGLFramebuffer(OGLFramebuffer&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
 
     ~OGLFramebuffer() {
         Release();
     }
 
-    OGLFramebuffer& operator=(OGLFramebuffer&& o) {
+    OGLFramebuffer& operator=(OGLFramebuffer&& o) noexcept {
         Release();
         handle = std::exchange(o.handle, 0);
         return *this;


### PR DESCRIPTION
Standard library containers may use std::move_if_noexcept to perform move operations. If a move cannot be performed under these circumstances, then a copy is attempted. Given we only intend for these types to be move-only this can be somewhat problematic. By defining these to be noexcept we prevent cases where copies may be attempted.