### PR TITLE
Shader opcode decoding

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -234,10 +234,12 @@ public:
         KIL,
         LD_A,
         ST_A,
-        TEXS,
+        TEXQ, // Texture Query
+        TEXS, // Texture Fetch with scalar/non-vec4 source/destinations
+        TLDS, // Texture Load with scalar/non-vec4 source/destinations
         EXIT,
         IPA,
-        FFMA_IMM,
+        FFMA_IMM, // Fused Multiply and Add
         FFMA_CR,
         FFMA_RC,
         FFMA_RR,
@@ -248,10 +250,31 @@ public:
         FMUL_R,
         FMUL_IMM,
         FMUL32_IMM,
-        MUFU,
+        MUFU, // Multi-Function Operator
+        RRO,  // Range Reduction Operator
+        F2F_C,
+        F2F_R,
+        F2F_IMM,
+        F2I_C,
+        F2I_R,
+        F2I_IMM,
+        I2F_C,
+        I2F_R,
+        I2F_IMM,
+        LOP32I,
+        MOV_C,
+        MOV_R,
+        MOV_IMM,
+        MOV32I,
+        SHR_C,
+        SHR_R,
+        SHR_IMM,
+        FSETP_C, // Set Predicate
         FSETP_R,
-        FSETP_C,
         FSETP_IMM,
+        ISETP_C,
+        ISETP_IMM,
+        ISETP_R,
     };
 
     enum class Type {
@@ -261,6 +284,7 @@ public:
         Flow,
         Memory,
         FloatPredicate,
+        IntegerPredicate,
         Unknown,
     };
 
@@ -358,7 +382,9 @@ private:
             INST("111000110011----", Id::KIL, Type::Flow, "KIL"),
             INST("1110111111011---", Id::LD_A, Type::Memory, "LD_A"),
             INST("1110111111110---", Id::ST_A, Type::Memory, "ST_A"),
+            INST("1101111101001---", Id::TEXQ, Type::Memory, "TEXQ"),
             INST("1101100---------", Id::TEXS, Type::Memory, "TEXS"),
+            INST("1101101---------", Id::TLDS, Type::Memory, "TLDS"),
             INST("111000110000----", Id::EXIT, Type::Trivial, "EXIT"),
             INST("11100000--------", Id::IPA, Type::Trivial, "IPA"),
             INST("001100101-------", Id::FFMA_IMM, Type::Ffma, "FFMA_IMM"),
@@ -373,9 +399,30 @@ private:
             INST("0011100-01101---", Id::FMUL_IMM, Type::Arithmetic, "FMUL_IMM"),
             INST("00011110--------", Id::FMUL32_IMM, Type::Arithmetic, "FMUL32_IMM"),
             INST("0101000010000---", Id::MUFU, Type::Arithmetic, "MUFU"),
-            INST("010110111011----", Id::FSETP_R, Type::FloatPredicate, "FSETP_R"),
+            INST("0101110010010---", Id::RRO, Type::Arithmetic, "RRO"),
+            INST("0100110010101---", Id::F2F_C, Type::Arithmetic, "F2F_C"),
+            INST("0101110010101---", Id::F2F_R, Type::Arithmetic, "F2F_R"),
+            INST("0011100-10101---", Id::F2F_IMM, Type::Arithmetic, "F2F_IMM"),
+            INST("0100110010110---", Id::F2I_C, Type::Arithmetic, "F2I_C"),
+            INST("0101110010110---", Id::F2I_R, Type::Arithmetic, "F2I_R"),
+            INST("0011100-10110---", Id::F2I_IMM, Type::Arithmetic, "F2I_IMM"),
+            INST("0100110010111---", Id::I2F_C, Type::Arithmetic, "I2F_C"),
+            INST("0101110010111---", Id::I2F_R, Type::Arithmetic, "I2F_R"),
+            INST("0011100-10111---", Id::I2F_IMM, Type::Arithmetic, "I2F_IMM"),
+            INST("000001----------", Id::LOP32I, Type::Arithmetic, "LOP32I"),
+            INST("0100110010011---", Id::MOV_C, Type::Arithmetic, "MOV_C"),
+            INST("0101110010011---", Id::MOV_R, Type::Arithmetic, "MOV_R"),
+            INST("0011100-10011---", Id::MOV_IMM, Type::Arithmetic, "MOV_IMM"),
+            INST("000000010000----", Id::MOV32I, Type::Arithmetic, "MOV32I"),
+            INST("0100110000101---", Id::SHR_C, Type::Arithmetic, "SHR_C"),
+            INST("0101110000101---", Id::SHR_R, Type::Arithmetic, "SHR_R"),
+            INST("0011100-00101---", Id::SHR_IMM, Type::Arithmetic, "SHR_IMM"),
             INST("010010111011----", Id::FSETP_C, Type::FloatPredicate, "FSETP_C"),
+            INST("010110111011----", Id::FSETP_R, Type::FloatPredicate, "FSETP_R"),
             INST("0011011-1011----", Id::FSETP_IMM, Type::FloatPredicate, "FSETP_IMM"),
+            INST("010010110110----", Id::ISETP_C, Type::IntegerPredicate, "ISETP_C"),
+            INST("010110110110----", Id::ISETP_R, Type::IntegerPredicate, "ISETP_R"),
+            INST("0011011-0110----", Id::ISETP_IMM, Type::IntegerPredicate, "ISETP_IMM"),
         };
 #undef INST
         std::stable_sort(table.begin(), table.end(), [](const auto& a, const auto& b) {

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -431,6 +431,10 @@ private:
                 }
                 break;
             }
+            case OpCode::Id::RRO: {
+                NGLOG_DEBUG(HW_GPU, "Skipping RRO instruction");
+                break;
+            }
             default: {
                 NGLOG_CRITICAL(HW_GPU, "Unhandled arithmetic instruction: {}", opcode->GetName());
                 UNREACHABLE();

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -97,11 +97,12 @@ private:
             return exit_method;
 
         for (u32 offset = begin; offset != end && offset != PROGRAM_END; ++offset) {
-            const Instruction instr = {program_code[offset]};
-            switch (instr.opcode.EffectiveOpCode()) {
-            case OpCode::Id::EXIT: {
-                return exit_method = ExitMethod::AlwaysEnd;
-            }
+            if (const auto opcode = OpCode::Decode({program_code[offset]})) {
+                switch (opcode->GetId()) {
+                case OpCode::Id::EXIT: {
+                    return exit_method = ExitMethod::AlwaysEnd;
+                }
+                }
             }
         }
         return exit_method = ExitMethod::AlwaysReturn;
@@ -332,12 +333,20 @@ private:
      */
     u32 CompileInstr(u32 offset) {
         // Ignore sched instructions when generating code.
-        if (IsSchedInstruction(offset))
+        if (IsSchedInstruction(offset)) {
             return offset + 1;
+        }
 
         const Instruction instr = {program_code[offset]};
+        const auto opcode = OpCode::Decode(instr);
 
-        shader.AddLine("// " + std::to_string(offset) + ": " + OpCode::GetInfo(instr.opcode).name);
+        // Decoding failure
+        if (!opcode) {
+            NGLOG_CRITICAL(HW_GPU, "Unhandled instruction: {}", instr.value);
+            UNREACHABLE();
+        }
+
+        shader.AddLine("// " + std::to_string(offset) + ": " + opcode->GetName());
 
         using Tegra::Shader::Pred;
         ASSERT_MSG(instr.pred.full_pred != Pred::NeverExecute,
@@ -349,7 +358,7 @@ private:
             ++shader.scope;
         }
 
-        switch (OpCode::GetInfo(instr.opcode).type) {
+        switch (opcode->GetType()) {
         case OpCode::Type::Arithmetic: {
             std::string dest = GetRegister(instr.gpr0);
             std::string op_a = instr.alu.negate_a ? "-" : "";
@@ -374,7 +383,7 @@ private:
                 op_b = "abs(" + op_b + ")";
             }
 
-            switch (instr.opcode.EffectiveOpCode()) {
+            switch (opcode->GetId()) {
             case OpCode::Id::FMUL_C:
             case OpCode::Id::FMUL_R:
             case OpCode::Id::FMUL_IMM: {
@@ -424,8 +433,8 @@ private:
             }
             default: {
                 NGLOG_CRITICAL(HW_GPU, "Unhandled arithmetic instruction: {} ({}): {}",
-                               static_cast<unsigned>(instr.opcode.EffectiveOpCode()),
-                               OpCode::GetInfo(instr.opcode).name, instr.hex);
+                               static_cast<unsigned>(opcode->GetId()), opcode->GetName(),
+                               instr.value);
                 UNREACHABLE();
             }
             }
@@ -437,7 +446,7 @@ private:
             std::string op_b = instr.ffma.negate_b ? "-" : "";
             std::string op_c = instr.ffma.negate_c ? "-" : "";
 
-            switch (instr.opcode.EffectiveOpCode()) {
+            switch (opcode->GetId()) {
             case OpCode::Id::FFMA_CR: {
                 op_b += GetUniform(instr.uniform);
                 op_c += GetRegister(instr.gpr39);
@@ -460,8 +469,8 @@ private:
             }
             default: {
                 NGLOG_CRITICAL(HW_GPU, "Unhandled FFMA instruction: {} ({}): {}",
-                               static_cast<unsigned>(instr.opcode.EffectiveOpCode()),
-                               OpCode::GetInfo(instr.opcode).name, instr.hex);
+                               static_cast<unsigned>(opcode->GetId()), opcode->GetName(),
+                               instr.value);
                 UNREACHABLE();
             }
             }
@@ -473,7 +482,7 @@ private:
             std::string gpr0 = GetRegister(instr.gpr0);
             const Attribute::Index attribute = instr.attribute.fmt20.index;
 
-            switch (instr.opcode.EffectiveOpCode()) {
+            switch (opcode->GetId()) {
             case OpCode::Id::LD_A: {
                 ASSERT_MSG(instr.attribute.fmt20.size == 0, "untested");
                 SetDest(instr.attribute.fmt20.element, gpr0, GetInputAttribute(attribute), 1, 4);
@@ -505,8 +514,8 @@ private:
             }
             default: {
                 NGLOG_CRITICAL(HW_GPU, "Unhandled memory instruction: {} ({}): {}",
-                               static_cast<unsigned>(instr.opcode.EffectiveOpCode()),
-                               OpCode::GetInfo(instr.opcode).name, instr.hex);
+                               static_cast<unsigned>(opcode->GetId()), opcode->GetName(),
+                               instr.value);
                 UNREACHABLE();
             }
             }
@@ -564,7 +573,7 @@ private:
             break;
         }
         default: {
-            switch (instr.opcode.EffectiveOpCode()) {
+            switch (opcode->GetId()) {
             case OpCode::Id::EXIT: {
                 ASSERT_MSG(instr.pred.pred_index == static_cast<u64>(Pred::UnusedIndex),
                            "Predicated exits not implemented");
@@ -584,8 +593,8 @@ private:
             }
             default: {
                 NGLOG_CRITICAL(HW_GPU, "Unhandled instruction: {} ({}): {}",
-                               static_cast<unsigned>(instr.opcode.EffectiveOpCode()),
-                               OpCode::GetInfo(instr.opcode).name, instr.hex);
+                               static_cast<unsigned>(opcode->GetId()), opcode->GetName(),
+                               instr.value);
                 UNREACHABLE();
             }
             }

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -342,7 +342,7 @@ private:
 
         // Decoding failure
         if (!opcode) {
-            NGLOG_CRITICAL(HW_GPU, "Unhandled instruction: {}", instr.value);
+            NGLOG_CRITICAL(HW_GPU, "Unhandled instruction: {0:x}", instr.value);
             UNREACHABLE();
         }
 
@@ -425,16 +425,14 @@ private:
                     SetDest(0, dest, "min(" + op_a + "," + op_b + ")", 1, 1, instr.alu.abs_d);
                     break;
                 default:
-                    NGLOG_CRITICAL(HW_GPU, "Unhandled MUFU sub op: {}",
+                    NGLOG_CRITICAL(HW_GPU, "Unhandled MUFU sub op: {0:x}",
                                    static_cast<unsigned>(instr.sub_op.Value()));
                     UNREACHABLE();
                 }
                 break;
             }
             default: {
-                NGLOG_CRITICAL(HW_GPU, "Unhandled arithmetic instruction: {} ({}): {}",
-                               static_cast<unsigned>(opcode->GetId()), opcode->GetName(),
-                               instr.value);
+                NGLOG_CRITICAL(HW_GPU, "Unhandled arithmetic instruction: {}", opcode->GetName());
                 UNREACHABLE();
             }
             }
@@ -468,9 +466,7 @@ private:
                 break;
             }
             default: {
-                NGLOG_CRITICAL(HW_GPU, "Unhandled FFMA instruction: {} ({}): {}",
-                               static_cast<unsigned>(opcode->GetId()), opcode->GetName(),
-                               instr.value);
+                NGLOG_CRITICAL(HW_GPU, "Unhandled FFMA instruction: {}", opcode->GetName());
                 UNREACHABLE();
             }
             }
@@ -513,9 +509,7 @@ private:
                 break;
             }
             default: {
-                NGLOG_CRITICAL(HW_GPU, "Unhandled memory instruction: {} ({}): {}",
-                               static_cast<unsigned>(opcode->GetId()), opcode->GetName(),
-                               instr.value);
+                NGLOG_CRITICAL(HW_GPU, "Unhandled memory instruction: {}", opcode->GetName());
                 UNREACHABLE();
             }
             }
@@ -592,9 +586,7 @@ private:
                 break;
             }
             default: {
-                NGLOG_CRITICAL(HW_GPU, "Unhandled instruction: {} ({}): {}",
-                               static_cast<unsigned>(opcode->GetId()), opcode->GetName(),
-                               instr.value);
+                NGLOG_CRITICAL(HW_GPU, "Unhandled instruction: {}", opcode->GetName());
                 UNREACHABLE();
             }
             }


### PR DESCRIPTION
Rewrites shader opcode decoding to use bit strings, similar to how dynarmic works (although much simpler for our use case). This is much more extensible and maintainable than prior approach. Adds decodings for several more unimplemented instructions.