### PR TITLE
GPU: Support multiple enabled vertex arrays.

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -500,6 +500,11 @@ public:
                         return static_cast<GPUVAddr>((static_cast<GPUVAddr>(start_high) << 32) |
                                                      start_low);
                     }
+
+                    bool IsEnabled() const {
+                        return enable != 0 && StartAddress() != 0;
+                    }
+
                 } vertex_array[NumVertexArrays];
 
                 Blend blend;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -148,13 +148,13 @@ private:
     static constexpr size_t STREAM_BUFFER_SIZE = 4 * 1024 * 1024;
     std::unique_ptr<OGLStreamBuffer> stream_buffer;
 
-    GLsizeiptr vs_input_size;
+    size_t CalculateVertexArraysSize() const;
 
-    void SetupVertexArray(u8* array_ptr, GLintptr buffer_offset);
+    std::pair<u8*, GLintptr> SetupVertexArrays(u8* array_ptr, GLintptr buffer_offset);
 
     std::array<OGLBuffer, Tegra::Engines::Maxwell3D::Regs::MaxShaderStage> uniform_buffers;
 
-    void SetupShaders(u8* buffer_ptr, GLintptr buffer_offset, size_t ptr_pos);
+    void SetupShaders(u8* buffer_ptr, GLintptr buffer_offset);
 
     enum class AccelDraw { Disabled, Arrays, Indexed };
     AccelDraw accelerate_draw;


### PR DESCRIPTION
The vertex arrays will be copied to the stream buffer one after the other, and the attributes will be set using the ARB_vertex_attrib_binding extension.

yuzu now thus requires OpenGL 4.3 or the ARB_vertex_attrib_binding extension.