### PR TITLE
GPU: Implement the RGB10_A2 RenderTarget format

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -106,6 +106,8 @@ struct SurfaceParams {
         switch (format) {
         case Tegra::RenderTargetFormat::RGBA8_UNORM:
             return PixelFormat::ABGR8;
+        case Tegra::RenderTargetFormat::RGB10_A2_UNORM:
+            return PixelFormat::A2B10G10R10;
         default:
             NGLOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
             UNREACHABLE();

--- a/src/yuzu/debugger/graphics/graphics_surface.cpp
+++ b/src/yuzu/debugger/graphics/graphics_surface.cpp
@@ -25,6 +25,8 @@ static Tegra::Texture::TextureFormat ConvertToTextureFormat(
     switch (render_target_format) {
     case Tegra::RenderTargetFormat::RGBA8_UNORM:
         return Tegra::Texture::TextureFormat::A8R8G8B8;
+    case Tegra::RenderTargetFormat::RGB10_A2_UNORM:
+        return Tegra::Texture::TextureFormat::A2B10G10R10;
     default:
         UNIMPLEMENTED_MSG("Unimplemented RT format");
     }


### PR DESCRIPTION
It will use the same format as the A2BGR10 texture format.