### PR TITLE
service: Move logging macros over to the new fmt-compatible ones

### DIFF
--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -47,7 +47,7 @@ public:
 
 private:
     void GetBase(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
+        NGLOG_WARNING(Service_ACC, "(STUBBED) called");
         ProfileBase profile_base{};
         IPC::ResponseBuilder rb{ctx, 16};
         rb.Push(RESULT_SUCCESS);
@@ -72,14 +72,14 @@ public:
 
 private:
     void CheckAvailability(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
+        NGLOG_WARNING(Service_ACC, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
         rb.Push(true); // TODO: Check when this is supposed to return true and when not
     }
 
     void GetAccountId(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
+        NGLOG_WARNING(Service_ACC, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u64>(0x12345678ABCDEF);
@@ -87,14 +87,14 @@ private:
 };
 
 void Module::Interface::GetUserExistence(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_ACC, "(STUBBED) called");
+    NGLOG_WARNING(Service_ACC, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.Push(true); // TODO: Check when this is supposed to return true and when not
 }
 
 void Module::Interface::ListAllUsers(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_ACC, "(STUBBED) called");
+    NGLOG_WARNING(Service_ACC, "(STUBBED) called");
     constexpr std::array<u128, 10> user_ids{DEFAULT_USER_ID};
     ctx.WriteBuffer(user_ids.data(), user_ids.size());
     IPC::ResponseBuilder rb{ctx, 2};
@@ -102,7 +102,7 @@ void Module::Interface::ListAllUsers(Kernel::HLERequestContext& ctx) {
 }
 
 void Module::Interface::ListOpenUsers(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_ACC, "(STUBBED) called");
+    NGLOG_WARNING(Service_ACC, "(STUBBED) called");
     constexpr std::array<u128, 10> user_ids{DEFAULT_USER_ID};
     ctx.WriteBuffer(user_ids.data(), user_ids.size());
     IPC::ResponseBuilder rb{ctx, 2};
@@ -113,11 +113,11 @@ void Module::Interface::GetProfile(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<IProfile>();
-    LOG_DEBUG(Service_ACC, "called");
+    NGLOG_DEBUG(Service_ACC, "called");
 }
 
 void Module::Interface::InitializeApplicationInfo(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_ACC, "(STUBBED) called");
+    NGLOG_WARNING(Service_ACC, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
@@ -126,11 +126,11 @@ void Module::Interface::GetBaasAccountManagerForApplication(Kernel::HLERequestCo
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<IManagerForApplication>();
-    LOG_DEBUG(Service_ACC, "called");
+    NGLOG_DEBUG(Service_ACC, "called");
 }
 
 void Module::Interface::GetLastOpenedUser(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_ACC, "(STUBBED) called");
+    NGLOG_WARNING(Service_ACC, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 6};
     rb.Push(RESULT_SUCCESS);
     rb.PushRaw(DEFAULT_USER_ID);

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -28,14 +28,14 @@ IWindowController::IWindowController() : ServiceFramework("IWindowController") {
 }
 
 void IWindowController::GetAppletResourceUserId(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
     rb.Push<u64>(0);
 }
 
 void IWindowController::AcquireForegroundRights(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
@@ -54,20 +54,20 @@ IAudioController::IAudioController() : ServiceFramework("IAudioController") {
 }
 
 void IAudioController::SetExpectedMasterVolume(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IAudioController::GetMainAppletExpectedMasterVolume(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.Push(volume);
 }
 
 void IAudioController::GetLibraryAppletExpectedMasterVolume(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.Push(volume);
@@ -139,14 +139,14 @@ void ISelfController::SetFocusHandlingMode(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void ISelfController::SetRestartMessageEnabled(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void ISelfController::SetPerformanceModeChangedNotification(Kernel::HLERequestContext& ctx) {
@@ -157,14 +157,14 @@ void ISelfController::SetPerformanceModeChangedNotification(Kernel::HLERequestCo
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 
-    LOG_WARNING(Service_AM, "(STUBBED) called flag=%u", static_cast<u32>(flag));
+    NGLOG_WARNING(Service_AM, "(STUBBED) called flag={}", flag);
 }
 
 void ISelfController::SetScreenShotPermission(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void ISelfController::SetOperationModeChangedNotification(Kernel::HLERequestContext& ctx) {
@@ -175,7 +175,7 @@ void ISelfController::SetOperationModeChangedNotification(Kernel::HLERequestCont
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 
-    LOG_WARNING(Service_AM, "(STUBBED) called flag=%u", static_cast<u32>(flag));
+    NGLOG_WARNING(Service_AM, "(STUBBED) called flag={}", flag);
 }
 
 void ISelfController::SetOutOfFocusSuspendingEnabled(Kernel::HLERequestContext& ctx) {
@@ -188,21 +188,21 @@ void ISelfController::SetOutOfFocusSuspendingEnabled(Kernel::HLERequestContext& 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 
-    LOG_WARNING(Service_AM, "(STUBBED) called enabled=%u", static_cast<u32>(enabled));
+    NGLOG_WARNING(Service_AM, "(STUBBED) called enabled={}", enabled);
 }
 
 void ISelfController::LockExit(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void ISelfController::UnlockExit(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void ISelfController::GetLibraryAppletLaunchableEvent(Kernel::HLERequestContext& ctx) {
@@ -212,7 +212,7 @@ void ISelfController::GetLibraryAppletLaunchableEvent(Kernel::HLERequestContext&
     rb.Push(RESULT_SUCCESS);
     rb.PushCopyObjects(launchable_event);
 
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void ISelfController::CreateManagedDisplayLayer(Kernel::HLERequestContext& ctx) {
@@ -225,7 +225,7 @@ void ISelfController::CreateManagedDisplayLayer(Kernel::HLERequestContext& ctx) 
     rb.Push(RESULT_SUCCESS);
     rb.Push(layer_id);
 
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 ICommonStateGetter::ICommonStateGetter() : ServiceFramework("ICommonStateGetter") {
@@ -269,7 +269,7 @@ void ICommonStateGetter::GetEventHandle(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.PushCopyObjects(event);
 
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void ICommonStateGetter::ReceiveMessage(Kernel::HLERequestContext& ctx) {
@@ -277,7 +277,7 @@ void ICommonStateGetter::ReceiveMessage(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.Push<u32>(15);
 
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void ICommonStateGetter::GetCurrentFocusState(Kernel::HLERequestContext& ctx) {
@@ -285,7 +285,7 @@ void ICommonStateGetter::GetCurrentFocusState(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.Push(static_cast<u8>(FocusState::InFocus));
 
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void ICommonStateGetter::GetOperationMode(Kernel::HLERequestContext& ctx) {
@@ -294,7 +294,7 @@ void ICommonStateGetter::GetOperationMode(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.Push(static_cast<u8>(use_docked_mode ? OperationMode::Docked : OperationMode::Handheld));
 
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void ICommonStateGetter::GetPerformanceMode(Kernel::HLERequestContext& ctx) {
@@ -304,7 +304,7 @@ void ICommonStateGetter::GetPerformanceMode(Kernel::HLERequestContext& ctx) {
     rb.Push(static_cast<u32>(use_docked_mode ? APM::PerformanceMode::Docked
                                              : APM::PerformanceMode::Handheld));
 
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 class ILibraryAppletAccessor final : public ServiceFramework<ILibraryAppletAccessor> {
@@ -344,7 +344,7 @@ private:
         rb.Push(RESULT_SUCCESS);
         rb.PushCopyObjects(state_changed_event);
 
-        LOG_WARNING(Service_AM, "(STUBBED) called");
+        NGLOG_WARNING(Service_AM, "(STUBBED) called");
     }
 
     Kernel::SharedPtr<Kernel::Event> state_changed_event;
@@ -368,7 +368,7 @@ void ILibraryAppletCreator::CreateLibraryApplet(Kernel::HLERequestContext& ctx) 
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<AM::ILibraryAppletAccessor>();
 
-    LOG_DEBUG(Service_AM, "called");
+    NGLOG_DEBUG(Service_AM, "called");
 }
 
 class IStorageAccessor final : public ServiceFramework<IStorageAccessor> {
@@ -392,7 +392,7 @@ private:
         rb.Push(RESULT_SUCCESS);
         rb.Push(static_cast<u64>(buffer.size()));
 
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     void Read(Kernel::HLERequestContext& ctx) {
@@ -410,7 +410,7 @@ private:
 
         rb.Push(RESULT_SUCCESS);
 
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 };
 
@@ -434,7 +434,7 @@ private:
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<AM::IStorageAccessor>(buffer);
 
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 };
 
@@ -498,14 +498,14 @@ void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<AM::IStorage>(buffer);
 
-    LOG_DEBUG(Service_AM, "called");
+    NGLOG_DEBUG(Service_AM, "called");
 }
 
 void IApplicationFunctions::EnsureSaveData(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     u128 uid = rp.PopRaw<u128>();
 
-    LOG_WARNING(Service, "(STUBBED) called uid = %016" PRIX64 "%016" PRIX64, uid[1], uid[0]);
+    NGLOG_WARNING(Service, "(STUBBED) called uid = {:016X}{:016X}", uid[1], uid[0]);
 
     IPC::ResponseBuilder rb{ctx, 4};
 
@@ -533,27 +533,27 @@ void IApplicationFunctions::SetTerminateResult(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 
-    LOG_WARNING(Service_AM, "(STUBBED) called, result=0x%08X", result);
+    NGLOG_WARNING(Service_AM, "(STUBBED) called, result={:#010}", result);
 }
 
 void IApplicationFunctions::GetDesiredLanguage(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
     rb.Push<u64>(SystemLanguage::English);
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void IApplicationFunctions::InitializeGamePlayRecording(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void IApplicationFunctions::SetGamePlayRecordingState(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void IApplicationFunctions::NotifyRunning(Kernel::HLERequestContext& ctx) {
@@ -561,7 +561,7 @@ void IApplicationFunctions::NotifyRunning(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.Push<u8>(0); // Unknown, seems to be ignored by official processes
 
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    NGLOG_WARNING(Service_AM, "(STUBBED) called");
 }
 
 void InstallInterfaces(SM::ServiceManager& service_manager,

--- a/src/core/hle/service/am/applet_ae.cpp
+++ b/src/core/hle/service/am/applet_ae.cpp
@@ -33,56 +33,56 @@ private:
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<ICommonStateGetter>();
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     void GetSelfController(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<ISelfController>(nvflinger);
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     void GetWindowController(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IWindowController>();
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     void GetAudioController(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IAudioController>();
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     void GetDisplayController(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IDisplayController>();
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     void GetDebugFunctions(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IDebugFunctions>();
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     void GetLibraryAppletCreator(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<ILibraryAppletCreator>();
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     void GetApplicationFunctions(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IApplicationFunctions>();
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     std::shared_ptr<NVFlinger::NVFlinger> nvflinger;
@@ -92,7 +92,7 @@ void AppletAE::OpenLibraryAppletProxyOld(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<ILibraryAppletProxy>(nvflinger);
-    LOG_DEBUG(Service_AM, "called");
+    NGLOG_DEBUG(Service_AM, "called");
 }
 
 AppletAE::AppletAE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -33,56 +33,56 @@ private:
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IAudioController>();
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     void GetDisplayController(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IDisplayController>();
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     void GetDebugFunctions(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IDebugFunctions>();
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     void GetWindowController(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IWindowController>();
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     void GetSelfController(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<ISelfController>(nvflinger);
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     void GetCommonStateGetter(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<ICommonStateGetter>();
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     void GetLibraryAppletCreator(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<ILibraryAppletCreator>();
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     void GetApplicationFunctions(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IApplicationFunctions>();
-        LOG_DEBUG(Service_AM, "called");
+        NGLOG_DEBUG(Service_AM, "called");
     }
 
     std::shared_ptr<NVFlinger::NVFlinger> nvflinger;
@@ -92,7 +92,7 @@ void AppletOE::OpenApplicationProxy(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<IApplicationProxy>(nvflinger);
-    LOG_DEBUG(Service_AM, "called");
+    NGLOG_DEBUG(Service_AM, "called");
 }
 
 AppletOE::AppletOE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -27,14 +27,14 @@ void AOC_U::CountAddOnContent(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
     rb.Push<u64>(0);
-    LOG_WARNING(Service_AOC, "(STUBBED) called");
+    NGLOG_WARNING(Service_AOC, "(STUBBED) called");
 }
 
 void AOC_U::ListAddOnContent(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
     rb.Push<u64>(0);
-    LOG_WARNING(Service_AOC, "(STUBBED) called");
+    NGLOG_WARNING(Service_AOC, "(STUBBED) called");
 }
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {

--- a/src/core/hle/service/apm/interface.cpp
+++ b/src/core/hle/service/apm/interface.cpp
@@ -29,8 +29,8 @@ private:
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
 
-        LOG_WARNING(Service_APM, "(STUBBED) called mode=%u config=%u", static_cast<u32>(mode),
-                    config);
+        NGLOG_WARNING(Service_APM, "(STUBBED) called mode={} config={}", static_cast<u32>(mode),
+                      config);
     }
 
     void GetPerformanceConfiguration(Kernel::HLERequestContext& ctx) {
@@ -42,7 +42,7 @@ private:
         rb.Push(RESULT_SUCCESS);
         rb.Push<u32>(0); // Performance configuration
 
-        LOG_WARNING(Service_APM, "(STUBBED) called mode=%u", static_cast<u32>(mode));
+        NGLOG_WARNING(Service_APM, "(STUBBED) called mode={}", static_cast<u32>(mode));
     }
 };
 

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -60,14 +60,14 @@ public:
 
 private:
     void GetAudioOutState(Kernel::HLERequestContext& ctx) {
-        LOG_DEBUG(Service_Audio, "called");
+        NGLOG_DEBUG(Service_Audio, "called");
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
         rb.Push(static_cast<u32>(audio_out_state));
     }
 
     void StartAudioOut(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        NGLOG_WARNING(Service_Audio, "(STUBBED) called");
 
         // Start audio
         audio_out_state = AudioState::Started;
@@ -77,7 +77,7 @@ private:
     }
 
     void StopAudioOut(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        NGLOG_WARNING(Service_Audio, "(STUBBED) called");
 
         // Stop audio
         audio_out_state = AudioState::Stopped;
@@ -89,7 +89,7 @@ private:
     }
 
     void RegisterBufferEvent(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        NGLOG_WARNING(Service_Audio, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 1};
         rb.Push(RESULT_SUCCESS);
@@ -97,7 +97,7 @@ private:
     }
 
     void AppendAudioOutBuffer(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        NGLOG_WARNING(Service_Audio, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
 
         const u64 key{rp.Pop<u64>()};
@@ -108,7 +108,7 @@ private:
     }
 
     void GetReleasedAudioOutBuffer(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        NGLOG_WARNING(Service_Audio, "(STUBBED) called");
 
         // TODO(st4rk): This is how libtransistor currently implements the
         // GetReleasedAudioOutBuffer, it should return the key (a VAddr) to the app and this address
@@ -164,7 +164,7 @@ private:
 };
 
 void AudOutU::ListAudioOuts(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_Audio, "(STUBBED) called");
+    NGLOG_WARNING(Service_Audio, "(STUBBED) called");
     IPC::RequestParser rp{ctx};
 
     const std::string audio_interface = "AudioInterface";
@@ -180,7 +180,7 @@ void AudOutU::ListAudioOuts(Kernel::HLERequestContext& ctx) {
 }
 
 void AudOutU::OpenAudioOut(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_Audio, "(STUBBED) called");
+    NGLOG_WARNING(Service_Audio, "(STUBBED) called");
 
     if (!audio_out_interface) {
         audio_out_interface = std::make_shared<IAudioOut>();

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -56,7 +56,7 @@ private:
     }
 
     void RequestUpdateAudioRenderer(Kernel::HLERequestContext& ctx) {
-        LOG_DEBUG(Service_Audio, "%s", ctx.Description().c_str());
+        NGLOG_DEBUG(Service_Audio, "{}", ctx.Description());
         AudioRendererResponseData response_data{};
 
         response_data.section_0_size =
@@ -79,7 +79,7 @@ private:
 
         rb.Push(RESULT_SUCCESS);
 
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        NGLOG_WARNING(Service_Audio, "(STUBBED) called");
     }
 
     void StartAudioRenderer(Kernel::HLERequestContext& ctx) {
@@ -87,7 +87,7 @@ private:
 
         rb.Push(RESULT_SUCCESS);
 
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        NGLOG_WARNING(Service_Audio, "(STUBBED) called");
     }
 
     void StopAudioRenderer(Kernel::HLERequestContext& ctx) {
@@ -95,7 +95,7 @@ private:
 
         rb.Push(RESULT_SUCCESS);
 
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        NGLOG_WARNING(Service_Audio, "(STUBBED) called");
     }
 
     void QuerySystemEvent(Kernel::HLERequestContext& ctx) {
@@ -105,7 +105,7 @@ private:
         rb.Push(RESULT_SUCCESS);
         rb.PushCopyObjects(system_event);
 
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        NGLOG_WARNING(Service_Audio, "(STUBBED) called");
     }
 
     struct AudioRendererStateEntry {
@@ -176,7 +176,7 @@ public:
 
 private:
     void ListAudioDeviceName(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        NGLOG_WARNING(Service_Audio, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
 
         const std::string audio_interface = "AudioInterface";
@@ -188,7 +188,7 @@ private:
     }
 
     void SetAudioDeviceOutputVolume(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        NGLOG_WARNING(Service_Audio, "(STUBBED) called");
 
         IPC::RequestParser rp{ctx};
         f32 volume = static_cast<f32>(rp.Pop<u32>());
@@ -201,7 +201,7 @@ private:
     }
 
     void GetActiveAudioDeviceName(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        NGLOG_WARNING(Service_Audio, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
 
         const std::string audio_interface = "AudioDevice";
@@ -213,7 +213,7 @@ private:
     }
 
     void QueryAudioDeviceSystemEvent(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        NGLOG_WARNING(Service_Audio, "(STUBBED) called");
 
         buffer_event->Signal();
 
@@ -223,7 +223,7 @@ private:
     }
 
     void GetActiveChannelCount(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        NGLOG_WARNING(Service_Audio, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u32>(1);
@@ -250,7 +250,7 @@ void AudRenU::OpenAudioRenderer(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<Audio::IAudioRenderer>();
 
-    LOG_DEBUG(Service_Audio, "called");
+    NGLOG_DEBUG(Service_Audio, "called");
 }
 
 void AudRenU::GetAudioRendererWorkBufferSize(Kernel::HLERequestContext& ctx) {
@@ -259,7 +259,7 @@ void AudRenU::GetAudioRendererWorkBufferSize(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.Push<u64>(0x400);
 
-    LOG_WARNING(Service_Audio, "(STUBBED) called");
+    NGLOG_WARNING(Service_Audio, "(STUBBED) called");
 }
 
 void AudRenU::GetAudioDevice(Kernel::HLERequestContext& ctx) {
@@ -268,7 +268,7 @@ void AudRenU::GetAudioDevice(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<Audio::IAudioDevice>();
 
-    LOG_DEBUG(Service_Audio, "called");
+    NGLOG_DEBUG(Service_Audio, "called");
 }
 
 } // namespace Service::Audio

--- a/src/core/hle/service/fatal/fatal.cpp
+++ b/src/core/hle/service/fatal/fatal.cpp
@@ -16,13 +16,13 @@ Module::Interface::Interface(std::shared_ptr<Module> module, const char* name)
 void Module::Interface::FatalSimple(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     u32 error_code = rp.Pop<u32>();
-    LOG_WARNING(Service_Fatal, "(STUBBED) called, error_code=0x%X", error_code);
+    NGLOG_WARNING(Service_Fatal, "(STUBBED) called, error_code={:#X}", error_code);
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void Module::Interface::TransitionToFatalError(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_Fatal, "(STUBBED) called");
+    NGLOG_WARNING(Service_Fatal, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -25,14 +25,14 @@ ResultCode RegisterFileSystem(std::unique_ptr<FileSys::FileSystemFactory>&& fact
     ASSERT_MSG(inserted, "Tried to register more than one system with same id code");
 
     auto& filesystem = result.first->second;
-    LOG_DEBUG(Service_FS, "Registered file system %s with id code 0x%08X",
-              filesystem->GetName().c_str(), static_cast<u32>(type));
+    NGLOG_DEBUG(Service_FS, "Registered file system {} with id code {:#010X}",
+                filesystem->GetName(), static_cast<u32>(type));
     return RESULT_SUCCESS;
 }
 
 ResultVal<std::unique_ptr<FileSys::FileSystemBackend>> OpenFileSystem(Type type,
                                                                       FileSys::Path& path) {
-    LOG_TRACE(Service_FS, "Opening FileSystem with type=%d", type);
+    NGLOG_TRACE(Service_FS, "Opening FileSystem with type={}", static_cast<u32>(type));
 
     auto itr = filesystem_map.find(type);
     if (itr == filesystem_map.end()) {
@@ -44,7 +44,7 @@ ResultVal<std::unique_ptr<FileSys::FileSystemBackend>> OpenFileSystem(Type type,
 }
 
 ResultCode FormatFileSystem(Type type) {
-    LOG_TRACE(Service_FS, "Formatting FileSystem with type=%d", type);
+    NGLOG_TRACE(Service_FS, "Formatting FileSystem with type={}", static_cast<u32>(type));
 
     auto itr = filesystem_map.find(type);
     if (itr == filesystem_map.end()) {

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -35,7 +35,7 @@ private:
         const s64 offset = rp.Pop<s64>();
         const s64 length = rp.Pop<s64>();
 
-        LOG_DEBUG(Service_FS, "called, offset=0x%ld, length=0x%ld", offset, length);
+        NGLOG_DEBUG(Service_FS, "called, offset={:#X}, length={}", offset, length);
 
         // Error checking
         if (length < 0) {
@@ -87,7 +87,7 @@ private:
         const s64 offset = rp.Pop<s64>();
         const s64 length = rp.Pop<s64>();
 
-        LOG_DEBUG(Service_FS, "called, offset=0x%ld, length=0x%ld", offset, length);
+        NGLOG_DEBUG(Service_FS, "called, offset={:#X}, length={}", offset, length);
 
         // Error checking
         if (length < 0) {
@@ -124,7 +124,7 @@ private:
         const s64 offset = rp.Pop<s64>();
         const s64 length = rp.Pop<s64>();
 
-        LOG_DEBUG(Service_FS, "called, offset=0x%ld, length=0x%ld", offset, length);
+        NGLOG_DEBUG(Service_FS, "called, offset={:#X}, length={}", offset, length);
 
         // Error checking
         if (length < 0) {
@@ -152,7 +152,7 @@ private:
     }
 
     void Flush(Kernel::HLERequestContext& ctx) {
-        LOG_DEBUG(Service_FS, "called");
+        NGLOG_DEBUG(Service_FS, "called");
         backend->Flush();
 
         IPC::ResponseBuilder rb{ctx, 2};
@@ -163,7 +163,7 @@ private:
         IPC::RequestParser rp{ctx};
         const u64 size = rp.Pop<u64>();
         backend->SetSize(size);
-        LOG_DEBUG(Service_FS, "called, size=%" PRIu64, size);
+        NGLOG_DEBUG(Service_FS, "called, size={}", size);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -171,7 +171,7 @@ private:
 
     void GetSize(Kernel::HLERequestContext& ctx) {
         const u64 size = backend->GetSize();
-        LOG_DEBUG(Service_FS, "called, size=%" PRIu64, size);
+        NGLOG_DEBUG(Service_FS, "called, size={}", size);
 
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
@@ -197,7 +197,7 @@ private:
         IPC::RequestParser rp{ctx};
         const u64 unk = rp.Pop<u64>();
 
-        LOG_DEBUG(Service_FS, "called, unk=0x%llx", unk);
+        NGLOG_DEBUG(Service_FS, "called, unk={:#X}", unk);
 
         // Calculate how many entries we can fit in the output buffer
         u64 count_entries = ctx.GetWriteBufferSize() / sizeof(FileSys::Entry);
@@ -219,7 +219,7 @@ private:
     }
 
     void GetEntryCount(Kernel::HLERequestContext& ctx) {
-        LOG_DEBUG(Service_FS, "called");
+        NGLOG_DEBUG(Service_FS, "called");
 
         u64 count = backend->GetEntryCount();
 
@@ -265,8 +265,7 @@ public:
         u64 mode = rp.Pop<u64>();
         u32 size = rp.Pop<u32>();
 
-        LOG_DEBUG(Service_FS, "called file %s mode 0x%" PRIX64 " size 0x%08X", name.c_str(), mode,
-                  size);
+        NGLOG_DEBUG(Service_FS, "called file {} mode {:#X} size {:#010X}", name, mode, size);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(backend->CreateFile(name, size));
@@ -280,7 +279,7 @@ public:
 
         std::string name(file_buffer.begin(), end);
 
-        LOG_DEBUG(Service_FS, "called file %s", name.c_str());
+        NGLOG_DEBUG(Service_FS, "called file {}", name);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(backend->DeleteFile(name));
@@ -294,7 +293,7 @@ public:
 
         std::string name(file_buffer.begin(), end);
 
-        LOG_DEBUG(Service_FS, "called directory %s", name.c_str());
+        NGLOG_DEBUG(Service_FS, "called directory {}", name);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(backend->CreateDirectory(name));
@@ -314,7 +313,7 @@ public:
         end = std::find(buffer.begin(), buffer.end(), '\0');
         std::string dst_name(buffer.begin(), end);
 
-        LOG_DEBUG(Service_FS, "called file '%s' to file '%s'", src_name.c_str(), dst_name.c_str());
+        NGLOG_DEBUG(Service_FS, "called file '{}' to file '{}'", src_name, dst_name);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(backend->RenameFile(src_name, dst_name));
@@ -330,7 +329,7 @@ public:
 
         auto mode = static_cast<FileSys::Mode>(rp.Pop<u32>());
 
-        LOG_DEBUG(Service_FS, "called file %s mode %u", name.c_str(), static_cast<u32>(mode));
+        NGLOG_DEBUG(Service_FS, "called file {} mode {}", name, static_cast<u32>(mode));
 
         auto result = backend->OpenFile(name, mode);
         if (result.Failed()) {
@@ -357,7 +356,7 @@ public:
         // TODO(Subv): Implement this filter.
         u32 filter_flags = rp.Pop<u32>();
 
-        LOG_DEBUG(Service_FS, "called directory %s filter %u", name.c_str(), filter_flags);
+        NGLOG_DEBUG(Service_FS, "called directory {} filter {}", name, filter_flags);
 
         auto result = backend->OpenDirectory(name);
         if (result.Failed()) {
@@ -381,7 +380,7 @@ public:
 
         std::string name(file_buffer.begin(), end);
 
-        LOG_DEBUG(Service_FS, "called file %s", name.c_str());
+        NGLOG_DEBUG(Service_FS, "called file {}", name);
 
         auto result = backend->GetEntryType(name);
         if (result.Failed()) {
@@ -396,7 +395,7 @@ public:
     }
 
     void Commit(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_FS, "(STUBBED) called");
+        NGLOG_WARNING(Service_FS, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -512,14 +511,14 @@ void FSP_SRV::TryLoadRomFS() {
 }
 
 void FSP_SRV::Initialize(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_FS, "(STUBBED) called");
+    NGLOG_WARNING(Service_FS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void FSP_SRV::MountSdCard(Kernel::HLERequestContext& ctx) {
-    LOG_DEBUG(Service_FS, "called");
+    NGLOG_DEBUG(Service_FS, "called");
 
     FileSys::Path unused;
     auto filesystem = OpenFileSystem(Type::SDMC, unused).Unwrap();
@@ -536,14 +535,14 @@ void FSP_SRV::CreateSaveData(Kernel::HLERequestContext& ctx) {
     auto save_create_struct = rp.PopRaw<std::array<u8, 0x40>>();
     u128 uid = rp.PopRaw<u128>();
 
-    LOG_WARNING(Service_FS, "(STUBBED) called uid = %016" PRIX64 "%016" PRIX64, uid[1], uid[0]);
+    NGLOG_WARNING(Service_FS, "(STUBBED) called uid = {:016X}{:016X}", uid[1], uid[0]);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void FSP_SRV::MountSaveData(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_FS, "(STUBBED) called");
+    NGLOG_WARNING(Service_FS, "(STUBBED) called");
 
     FileSys::Path unused;
     auto filesystem = OpenFileSystem(Type::SaveData, unused).Unwrap();
@@ -554,7 +553,7 @@ void FSP_SRV::MountSaveData(Kernel::HLERequestContext& ctx) {
 }
 
 void FSP_SRV::GetGlobalAccessLogMode(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_FS, "(STUBBED) called");
+    NGLOG_WARNING(Service_FS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
@@ -562,12 +561,12 @@ void FSP_SRV::GetGlobalAccessLogMode(Kernel::HLERequestContext& ctx) {
 }
 
 void FSP_SRV::OpenDataStorageByCurrentProcess(Kernel::HLERequestContext& ctx) {
-    LOG_DEBUG(Service_FS, "called");
+    NGLOG_DEBUG(Service_FS, "called");
 
     TryLoadRomFS();
     if (!romfs) {
         // TODO (bunnei): Find the right error code to use here
-        LOG_CRITICAL(Service_FS, "no file system interface available!");
+        NGLOG_CRITICAL(Service_FS, "no file system interface available!");
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(ResultCode(-1));
         return;
@@ -576,7 +575,7 @@ void FSP_SRV::OpenDataStorageByCurrentProcess(Kernel::HLERequestContext& ctx) {
     // Attempt to open a StorageBackend interface to the RomFS
     auto storage = romfs->OpenFile({}, {});
     if (storage.Failed()) {
-        LOG_CRITICAL(Service_FS, "no storage interface available!");
+        NGLOG_CRITICAL(Service_FS, "no storage interface available!");
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(storage.Code());
         return;
@@ -588,7 +587,7 @@ void FSP_SRV::OpenDataStorageByCurrentProcess(Kernel::HLERequestContext& ctx) {
 }
 
 void FSP_SRV::OpenRomStorage(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_FS, "(STUBBED) called, using OpenDataStorageByCurrentProcess");
+    NGLOG_WARNING(Service_FS, "(STUBBED) called, using OpenDataStorageByCurrentProcess");
     OpenDataStorageByCurrentProcess(ctx);
 }
 

--- a/src/core/hle/service/friend/friend.cpp
+++ b/src/core/hle/service/friend/friend.cpp
@@ -13,7 +13,7 @@ namespace Service::Friend {
 void Module::Interface::CreateFriendService(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
-    LOG_WARNING(Service_Friend, "(STUBBED) called");
+    NGLOG_WARNING(Service_Friend, "(STUBBED) called");
 }
 
 Module::Interface::Interface(std::shared_ptr<Module> module, const char* name)

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -53,7 +53,7 @@ private:
         IPC::ResponseBuilder rb{ctx, 2, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushCopyObjects(shared_mem);
-        LOG_DEBUG(Service_HID, "called");
+        NGLOG_DEBUG(Service_HID, "called");
     }
 
     void LoadInputDevices() {
@@ -184,7 +184,7 @@ private:
     void ActivateVibrationDevice(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 };
 
@@ -286,144 +286,144 @@ private:
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IAppletResource>(applet_resource);
-        LOG_DEBUG(Service_HID, "called");
+        NGLOG_DEBUG(Service_HID, "called");
     }
 
     void ActivateDebugPad(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void ActivateTouchScreen(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void ActivateMouse(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void ActivateKeyboard(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void StartSixAxisSensor(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void SetGyroscopeZeroDriftMode(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void SetSupportedNpadStyleSet(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void GetSupportedNpadStyleSet(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u32>(0);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void SetSupportedNpadIdType(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void ActivateNpad(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void AcquireNpadStyleSetUpdateEventHandle(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushCopyObjects(event);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void GetPlayerLedPattern(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void SetNpadJoyHoldType(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void GetNpadJoyHoldType(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
         rb.Push(joy_hold_type);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void SetNpadJoyAssignmentModeSingleByDefault(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void SendVibrationValue(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void GetActualVibrationValue(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void SetNpadJoyAssignmentModeDual(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void SetNpadHandheldActivationMode(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void GetVibrationDeviceInfo(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u64>(0);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 
     void CreateActiveVibrationDeviceList(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IActiveVibrationDeviceList>();
-        LOG_DEBUG(Service_HID, "called");
+        NGLOG_DEBUG(Service_HID, "called");
     }
 
     void SendVibrationValues(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        NGLOG_WARNING(Service_HID, "(STUBBED) called");
     }
 };
 

--- a/src/core/hle/service/lm/lm.cpp
+++ b/src/core/hle/service/lm/lm.cpp
@@ -141,19 +141,19 @@ private:
         if (header.IsTailLog()) {
             switch (header.severity) {
             case MessageHeader::Severity::Trace:
-                LOG_TRACE(Debug_Emulated, "%s", log_stream.str().c_str());
+                NGLOG_TRACE(Debug_Emulated, "{}", log_stream.str());
                 break;
             case MessageHeader::Severity::Info:
-                LOG_INFO(Debug_Emulated, "%s", log_stream.str().c_str());
+                NGLOG_INFO(Debug_Emulated, "{}", log_stream.str());
                 break;
             case MessageHeader::Severity::Warning:
-                LOG_WARNING(Debug_Emulated, "%s", log_stream.str().c_str());
+                NGLOG_WARNING(Debug_Emulated, "{}", log_stream.str());
                 break;
             case MessageHeader::Severity::Error:
-                LOG_ERROR(Debug_Emulated, "%s", log_stream.str().c_str());
+                NGLOG_ERROR(Debug_Emulated, "{}", log_stream.str());
                 break;
             case MessageHeader::Severity::Critical:
-                LOG_CRITICAL(Debug_Emulated, "%s", log_stream.str().c_str());
+                NGLOG_CRITICAL(Debug_Emulated, "{}", log_stream.str());
                 break;
             }
         }
@@ -178,7 +178,7 @@ void LM::Initialize(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<Logger>();
 
-    LOG_DEBUG(Service_LM, "called");
+    NGLOG_DEBUG(Service_LM, "called");
 }
 
 LM::LM() : ServiceFramework("lm") {

--- a/src/core/hle/service/nfp/nfp.cpp
+++ b/src/core/hle/service/nfp/nfp.cpp
@@ -13,7 +13,7 @@ Module::Interface::Interface(std::shared_ptr<Module> module, const char* name)
     : ServiceFramework(name), module(std::move(module)) {}
 
 void Module::Interface::Unknown(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_NFP, "(STUBBED) called");
+    NGLOG_WARNING(Service_NFP, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }

--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -62,24 +62,24 @@ public:
 
 private:
     void GetRequestState(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        NGLOG_WARNING(Service_NIFM, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u32>(0);
     }
     void GetResult(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        NGLOG_WARNING(Service_NIFM, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
     void GetSystemEventReadableHandles(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        NGLOG_WARNING(Service_NIFM, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 2, 2};
         rb.Push(RESULT_SUCCESS);
         rb.PushCopyObjects(event1, event2);
     }
     void Cancel(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        NGLOG_WARNING(Service_NIFM, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
@@ -105,7 +105,7 @@ public:
 
 private:
     void GetClientId(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        NGLOG_WARNING(Service_NIFM, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u64>(0);
@@ -116,7 +116,7 @@ private:
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IScanRequest>();
 
-        LOG_DEBUG(Service_NIFM, "called");
+        NGLOG_DEBUG(Service_NIFM, "called");
     }
     void CreateRequest(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
@@ -124,10 +124,10 @@ private:
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IRequest>();
 
-        LOG_DEBUG(Service_NIFM, "called");
+        NGLOG_DEBUG(Service_NIFM, "called");
     }
     void RemoveNetworkProfile(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        NGLOG_WARNING(Service_NIFM, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
@@ -137,7 +137,7 @@ private:
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<INetworkProfile>();
 
-        LOG_DEBUG(Service_NIFM, "called");
+        NGLOG_DEBUG(Service_NIFM, "called");
     }
 };
 
@@ -187,14 +187,14 @@ void Module::Interface::CreateGeneralServiceOld(Kernel::HLERequestContext& ctx) 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<IGeneralService>();
-    LOG_DEBUG(Service_NIFM, "called");
+    NGLOG_DEBUG(Service_NIFM, "called");
 }
 
 void Module::Interface::CreateGeneralService(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<IGeneralService>();
-    LOG_DEBUG(Service_NIFM, "called");
+    NGLOG_DEBUG(Service_NIFM, "called");
 }
 
 Module::Interface::Interface(std::shared_ptr<Module> module, const char* name)

--- a/src/core/hle/service/ns/pl_u.cpp
+++ b/src/core/hle/service/ns/pl_u.cpp
@@ -52,7 +52,7 @@ PL_U::PL_U() : ServiceFramework("pl:u") {
         ASSERT(file.GetSize() == SHARED_FONT_MEM_SIZE);
         file.ReadBytes(shared_font->data(), shared_font->size());
     } else {
-        LOG_WARNING(Service_NS, "Unable to load shared font: %s", filepath.c_str());
+        NGLOG_WARNING(Service_NS, "Unable to load shared font: {}", filepath);
     }
 }
 
@@ -60,7 +60,7 @@ void PL_U::RequestLoad(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const u32 shared_font_type{rp.Pop<u32>()};
 
-    LOG_DEBUG(Service_NS, "called, shared_font_type=%d", shared_font_type);
+    NGLOG_DEBUG(Service_NS, "called, shared_font_type={}", shared_font_type);
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
@@ -69,7 +69,7 @@ void PL_U::GetLoadState(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const u32 font_id{rp.Pop<u32>()};
 
-    LOG_DEBUG(Service_NS, "called, font_id=%d", font_id);
+    NGLOG_DEBUG(Service_NS, "called, font_id={}", font_id);
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.Push<u32>(static_cast<u32>(LoadState::Done));
@@ -79,7 +79,7 @@ void PL_U::GetSize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const u32 font_id{rp.Pop<u32>()};
 
-    LOG_DEBUG(Service_NS, "called, font_id=%d", font_id);
+    NGLOG_DEBUG(Service_NS, "called, font_id={}", font_id);
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.Push<u32>(SHARED_FONT_REGIONS[font_id].size);
@@ -89,7 +89,7 @@ void PL_U::GetSharedMemoryAddressOffset(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const u32 font_id{rp.Pop<u32>()};
 
-    LOG_DEBUG(Service_NS, "called, font_id=%d", font_id);
+    NGLOG_DEBUG(Service_NS, "called, font_id={}", font_id);
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.Push<u32>(SHARED_FONT_REGIONS[font_id].offset);
@@ -110,7 +110,7 @@ void PL_U::GetSharedMemoryNativeHandle(Kernel::HLERequestContext& ctx) {
         Kernel::MemoryPermission::Read, SHARED_FONT_MEM_VADDR, Kernel::MemoryRegion::BASE,
         "PL_U:shared_font_mem");
 
-    LOG_DEBUG(Service_NS, "called");
+    NGLOG_DEBUG(Service_NS, "called");
     IPC::ResponseBuilder rb{ctx, 2, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushCopyObjects(shared_font_mem);

--- a/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
@@ -20,9 +20,9 @@ u32 nvdisp_disp0::ioctl(Ioctl command, const std::vector<u8>& input, std::vector
 void nvdisp_disp0::flip(u32 buffer_handle, u32 offset, u32 format, u32 width, u32 height,
                         u32 stride, NVFlinger::BufferQueue::BufferTransformFlags transform) {
     VAddr addr = nvmap_dev->GetObjectAddress(buffer_handle);
-    LOG_WARNING(Service,
-                "Drawing from address %lx offset %08X Width %u Height %u Stride %u Format %u", addr,
-                offset, width, height, stride, format);
+    NGLOG_WARNING(Service,
+                  "Drawing from address {:X} offset {:08X} Width {} Height {} Stride {} Format {}",
+                  addr, offset, width, height, stride, format);
 
     using PixelFormat = Tegra::FramebufferConfig::PixelFormat;
     const Tegra::FramebufferConfig framebuffer{

--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
@@ -12,8 +12,8 @@
 namespace Service::Nvidia::Devices {
 
 u32 nvhost_as_gpu::ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) {
-    LOG_DEBUG(Service_NVDRV, "called, command=0x%08x, input_size=0x%zx, output_size=0x%zx",
-              command.raw, input.size(), output.size());
+    NGLOG_DEBUG(Service_NVDRV, "called, command={:#010X}, input_size={:#X}, output_size={:#X}",
+                command.raw, input.size(), output.size());
 
     switch (static_cast<IoctlCommand>(command.raw)) {
     case IoctlCommand::IocInitalizeExCommand:
@@ -38,7 +38,7 @@ u32 nvhost_as_gpu::ioctl(Ioctl command, const std::vector<u8>& input, std::vecto
 u32 nvhost_as_gpu::InitalizeEx(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlInitalizeEx params{};
     std::memcpy(&params, input.data(), input.size());
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, big_page_size=0x%x", params.big_page_size);
+    NGLOG_WARNING(Service_NVDRV, "(STUBBED) called, big_page_size={:#X}", params.big_page_size);
     std::memcpy(output.data(), &params, output.size());
     return 0;
 }
@@ -46,8 +46,8 @@ u32 nvhost_as_gpu::InitalizeEx(const std::vector<u8>& input, std::vector<u8>& ou
 u32 nvhost_as_gpu::AllocateSpace(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlAllocSpace params{};
     std::memcpy(&params, input.data(), input.size());
-    LOG_DEBUG(Service_NVDRV, "called, pages=%x, page_size=%x, flags=%x", params.pages,
-              params.page_size, params.flags);
+    NGLOG_DEBUG(Service_NVDRV, "called, pages={:X}, page_size={:X}, flags={:X}", params.pages,
+                params.page_size, params.flags);
 
     auto& gpu = Core::System::GetInstance().GPU();
     const u64 size{static_cast<u64>(params.pages) * static_cast<u64>(params.page_size)};
@@ -95,11 +95,11 @@ u32 nvhost_as_gpu::MapBufferEx(const std::vector<u8>& input, std::vector<u8>& ou
     IoctlMapBufferEx params{};
     std::memcpy(&params, input.data(), input.size());
 
-    LOG_DEBUG(Service_NVDRV,
-              "called, flags=%x, nvmap_handle=%x, buffer_offset=%" PRIu64 ", mapping_size=%" PRIu64
-              ", offset=%" PRIu64,
-              params.flags, params.nvmap_handle, params.buffer_offset, params.mapping_size,
-              params.offset);
+    NGLOG_DEBUG(Service_NVDRV,
+                "called, flags={:X}, nvmap_handle={:X}, buffer_offset={}, mapping_size={}"
+                ", offset={}",
+                params.flags, params.nvmap_handle, params.buffer_offset, params.mapping_size,
+                params.offset);
 
     if (!params.nvmap_handle) {
         return 0;
@@ -133,7 +133,7 @@ u32 nvhost_as_gpu::MapBufferEx(const std::vector<u8>& input, std::vector<u8>& ou
 u32 nvhost_as_gpu::BindChannel(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlBindChannel params{};
     std::memcpy(&params, input.data(), input.size());
-    LOG_DEBUG(Service_NVDRV, "called, fd=%x", params.fd);
+    NGLOG_DEBUG(Service_NVDRV, "called, fd={:X}", params.fd);
     channel = params.fd;
     std::memcpy(output.data(), &params, output.size());
     return 0;
@@ -142,8 +142,8 @@ u32 nvhost_as_gpu::BindChannel(const std::vector<u8>& input, std::vector<u8>& ou
 u32 nvhost_as_gpu::GetVARegions(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlGetVaRegions params{};
     std::memcpy(&params, input.data(), input.size());
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, buf_addr=%" PRIu64 ", buf_size=%x",
-                params.buf_addr, params.buf_size);
+    NGLOG_WARNING(Service_NVDRV, "(STUBBED) called, buf_addr={:X}, buf_size={:X}", params.buf_addr,
+                  params.buf_size);
 
     params.buf_size = 0x30;
     params.regions[0].offset = 0x04000000;

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -9,8 +9,8 @@
 namespace Service::Nvidia::Devices {
 
 u32 nvhost_ctrl::ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) {
-    LOG_DEBUG(Service_NVDRV, "called, command=0x%08x, input_size=0x%zx, output_size=0x%zx",
-              command.raw, input.size(), output.size());
+    NGLOG_DEBUG(Service_NVDRV, "called, command={:#010X}, input_size={:#X}, output_size={:#X}",
+                command.raw, input.size(), output.size());
 
     switch (static_cast<IoctlCommand>(command.raw)) {
     case IoctlCommand::IocGetConfigCommand:
@@ -25,8 +25,8 @@ u32 nvhost_ctrl::ioctl(Ioctl command, const std::vector<u8>& input, std::vector<
 u32 nvhost_ctrl::NvOsGetConfigU32(const std::vector<u8>& input, std::vector<u8>& output) {
     IocGetConfigParams params{};
     std::memcpy(&params, input.data(), sizeof(params));
-    LOG_DEBUG(Service_NVDRV, "called, setting=%s!%s", params.domain_str.data(),
-              params.param_str.data());
+    NGLOG_DEBUG(Service_NVDRV, "called, setting={}!{}", params.domain_str.data(),
+                params.param_str.data());
 
     if (!strcmp(params.domain_str.data(), "nv")) {
         if (!strcmp(params.param_str.data(), "NV_MEMORY_PROFILER")) {
@@ -48,8 +48,8 @@ u32 nvhost_ctrl::NvOsGetConfigU32(const std::vector<u8>& input, std::vector<u8>&
 u32 nvhost_ctrl::IocCtrlEventWait(const std::vector<u8>& input, std::vector<u8>& output) {
     IocCtrlEventWaitParams params{};
     std::memcpy(&params, input.data(), sizeof(params));
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, syncpt_id=%u threshold=%u timeout=%d",
-                params.syncpt_id, params.threshold, params.timeout);
+    NGLOG_WARNING(Service_NVDRV, "(STUBBED) called, syncpt_id={} threshold={} timeout={}",
+                  params.syncpt_id, params.threshold, params.timeout);
 
     // TODO(Subv): Implement actual syncpt waiting.
     params.value = 0;

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
@@ -10,8 +10,8 @@
 namespace Service::Nvidia::Devices {
 
 u32 nvhost_ctrl_gpu::ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) {
-    LOG_DEBUG(Service_NVDRV, "called, command=0x%08x, input_size=0x%zx, output_size=0x%zx",
-              command.raw, input.size(), output.size());
+    NGLOG_DEBUG(Service_NVDRV, "called, command={:#010X}, input_size={:#X}, output_size={:#X}",
+                command.raw, input.size(), output.size());
 
     switch (static_cast<IoctlCommand>(command.raw)) {
     case IoctlCommand::IocGetCharacteristicsCommand:
@@ -30,7 +30,7 @@ u32 nvhost_ctrl_gpu::ioctl(Ioctl command, const std::vector<u8>& input, std::vec
 }
 
 u32 nvhost_ctrl_gpu::GetCharacteristics(const std::vector<u8>& input, std::vector<u8>& output) {
-    LOG_DEBUG(Service_NVDRV, "called");
+    NGLOG_DEBUG(Service_NVDRV, "called");
     IoctlCharacteristics params{};
     std::memcpy(&params, input.data(), input.size());
     params.gc.arch = 0x120;
@@ -77,14 +77,14 @@ u32 nvhost_ctrl_gpu::GetCharacteristics(const std::vector<u8>& input, std::vecto
 u32 nvhost_ctrl_gpu::GetTPCMasks(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlGpuGetTpcMasksArgs params{};
     std::memcpy(&params, input.data(), input.size());
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, mask=0x%x, mask_buf_addr=0x%" PRIx64,
-                params.mask_buf_size, params.mask_buf_addr);
+    NGLOG_WARNING(Service_NVDRV, "(STUBBED) called, mask={:#X}, mask_buf_addr={:#X}",
+                  params.mask_buf_size, params.mask_buf_addr);
     std::memcpy(output.data(), &params, sizeof(params));
     return 0;
 }
 
 u32 nvhost_ctrl_gpu::GetActiveSlotMask(const std::vector<u8>& input, std::vector<u8>& output) {
-    LOG_DEBUG(Service_NVDRV, "called");
+    NGLOG_DEBUG(Service_NVDRV, "called");
     IoctlActiveSlotMask params{};
     std::memcpy(&params, input.data(), input.size());
     params.slot = 0x07;
@@ -94,7 +94,7 @@ u32 nvhost_ctrl_gpu::GetActiveSlotMask(const std::vector<u8>& input, std::vector
 }
 
 u32 nvhost_ctrl_gpu::ZCullGetCtxSize(const std::vector<u8>& input, std::vector<u8>& output) {
-    LOG_DEBUG(Service_NVDRV, "called");
+    NGLOG_DEBUG(Service_NVDRV, "called");
     IoctlZcullGetCtxSize params{};
     std::memcpy(&params, input.data(), input.size());
     params.size = 0x1;
@@ -103,7 +103,7 @@ u32 nvhost_ctrl_gpu::ZCullGetCtxSize(const std::vector<u8>& input, std::vector<u
 }
 
 u32 nvhost_ctrl_gpu::ZCullGetInfo(const std::vector<u8>& input, std::vector<u8>& output) {
-    LOG_DEBUG(Service_NVDRV, "called");
+    NGLOG_DEBUG(Service_NVDRV, "called");
     IoctlNvgpuGpuZcullGetInfoArgs params{};
     std::memcpy(&params, input.data(), input.size());
     params.width_align_pixels = 0x20;

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
@@ -12,8 +12,8 @@
 namespace Service::Nvidia::Devices {
 
 u32 nvhost_gpu::ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) {
-    LOG_DEBUG(Service_NVDRV, "called, command=0x%08x, input_size=0x%zx, output_size=0x%zx",
-              command.raw, input.size(), output.size());
+    NGLOG_DEBUG(Service_NVDRV, "called, command={:#010X}, input_size={:#X}, output_size={:#X}",
+                command.raw, input.size(), output.size());
 
     switch (static_cast<IoctlCommand>(command.raw)) {
     case IoctlCommand::IocSetNVMAPfdCommand:
@@ -47,14 +47,14 @@ u32 nvhost_gpu::ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u
 u32 nvhost_gpu::SetNVMAPfd(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlSetNvmapFD params{};
     std::memcpy(&params, input.data(), input.size());
-    LOG_DEBUG(Service_NVDRV, "called, fd=%x", params.nvmap_fd);
+    NGLOG_DEBUG(Service_NVDRV, "called, fd={}", params.nvmap_fd);
     nvmap_fd = params.nvmap_fd;
     std::memcpy(output.data(), &params, output.size());
     return 0;
 }
 
 u32 nvhost_gpu::SetClientData(const std::vector<u8>& input, std::vector<u8>& output) {
-    LOG_DEBUG(Service_NVDRV, "called");
+    NGLOG_DEBUG(Service_NVDRV, "called");
     IoctlClientData params{};
     std::memcpy(&params, input.data(), input.size());
     user_data = params.data;
@@ -63,7 +63,7 @@ u32 nvhost_gpu::SetClientData(const std::vector<u8>& input, std::vector<u8>& out
 }
 
 u32 nvhost_gpu::GetClientData(const std::vector<u8>& input, std::vector<u8>& output) {
-    LOG_DEBUG(Service_NVDRV, "called");
+    NGLOG_DEBUG(Service_NVDRV, "called");
     IoctlClientData params{};
     std::memcpy(&params, input.data(), input.size());
     params.data = user_data;
@@ -73,8 +73,8 @@ u32 nvhost_gpu::GetClientData(const std::vector<u8>& input, std::vector<u8>& out
 
 u32 nvhost_gpu::ZCullBind(const std::vector<u8>& input, std::vector<u8>& output) {
     std::memcpy(&zcull_params, input.data(), input.size());
-    LOG_DEBUG(Service_NVDRV, "called, gpu_va=%" PRIx64 ", mode=%x", zcull_params.gpu_va,
-              zcull_params.mode);
+    NGLOG_DEBUG(Service_NVDRV, "called, gpu_va={:X}, mode={:X}", zcull_params.gpu_va,
+                zcull_params.mode);
     std::memcpy(output.data(), &zcull_params, output.size());
     return 0;
 }
@@ -82,15 +82,15 @@ u32 nvhost_gpu::ZCullBind(const std::vector<u8>& input, std::vector<u8>& output)
 u32 nvhost_gpu::SetErrorNotifier(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlSetErrorNotifier params{};
     std::memcpy(&params, input.data(), input.size());
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, offset=%" PRIx64 ", size=%" PRIx64 ", mem=%x",
-                params.offset, params.size, params.mem);
+    NGLOG_WARNING(Service_NVDRV, "(STUBBED) called, offset={:X}, size={:X}, mem={:X}",
+                  params.offset, params.size, params.mem);
     std::memcpy(output.data(), &params, output.size());
     return 0;
 }
 
 u32 nvhost_gpu::SetChannelPriority(const std::vector<u8>& input, std::vector<u8>& output) {
     std::memcpy(&channel_priority, input.data(), input.size());
-    LOG_DEBUG(Service_NVDRV, "(STUBBED) called, priority=%x", channel_priority);
+    NGLOG_DEBUG(Service_NVDRV, "(STUBBED) called, priority={:X}", channel_priority);
     std::memcpy(output.data(), &channel_priority, output.size());
     return 0;
 }
@@ -98,10 +98,11 @@ u32 nvhost_gpu::SetChannelPriority(const std::vector<u8>& input, std::vector<u8>
 u32 nvhost_gpu::AllocGPFIFOEx2(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlAllocGpfifoEx2 params{};
     std::memcpy(&params, input.data(), input.size());
-    LOG_WARNING(Service_NVDRV,
-                "(STUBBED) called, num_entries=%x, flags=%x, unk0=%x, unk1=%x, unk2=%x, unk3=%x",
-                params.num_entries, params.flags, params.unk0, params.unk1, params.unk2,
-                params.unk3);
+    NGLOG_WARNING(Service_NVDRV,
+                  "(STUBBED) called, num_entries={:X}, flags={:X}, unk0={:X}, "
+                  "unk1={:X}, unk2={:X}, unk3={:X}",
+                  params.num_entries, params.flags, params.unk0, params.unk1, params.unk2,
+                  params.unk3);
     params.fence_out.id = 0;
     params.fence_out.value = 0;
     std::memcpy(output.data(), &params, output.size());
@@ -111,8 +112,8 @@ u32 nvhost_gpu::AllocGPFIFOEx2(const std::vector<u8>& input, std::vector<u8>& ou
 u32 nvhost_gpu::AllocateObjectContext(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlAllocObjCtx params{};
     std::memcpy(&params, input.data(), input.size());
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, class_num=%x, flags=%x", params.class_num,
-                params.flags);
+    NGLOG_WARNING(Service_NVDRV, "(STUBBED) called, class_num={:X}, flags={:X}", params.class_num,
+                  params.flags);
     params.obj_id = 0x0;
     std::memcpy(output.data(), &params, output.size());
     return 0;
@@ -123,8 +124,8 @@ u32 nvhost_gpu::SubmitGPFIFO(const std::vector<u8>& input, std::vector<u8>& outp
         UNIMPLEMENTED();
     IoctlSubmitGpfifo params{};
     std::memcpy(&params, input.data(), sizeof(IoctlSubmitGpfifo));
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, gpfifo=%" PRIx64 ", num_entries=%x, flags=%x",
-                params.gpfifo, params.num_entries, params.flags);
+    NGLOG_WARNING(Service_NVDRV, "(STUBBED) called, gpfifo={:X}, num_entries={:X}, flags={:X}",
+                  params.gpfifo, params.num_entries, params.flags);
 
     auto entries = std::vector<IoctlGpfifoEntry>();
     entries.resize(params.num_entries);

--- a/src/core/hle/service/nvdrv/devices/nvmap.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvmap.cpp
@@ -49,7 +49,7 @@ u32 nvmap::IocCreate(const std::vector<u8>& input, std::vector<u8>& output) {
     u32 handle = next_handle++;
     handles[handle] = std::move(object);
 
-    LOG_DEBUG(Service_NVDRV, "size=0x%08X", params.size);
+    NGLOG_DEBUG(Service_NVDRV, "size={:#010X}", params.size);
 
     params.handle = handle;
 
@@ -70,7 +70,7 @@ u32 nvmap::IocAlloc(const std::vector<u8>& input, std::vector<u8>& output) {
     object->addr = params.addr;
     object->status = Object::Status::Allocated;
 
-    LOG_DEBUG(Service_NVDRV, "called, addr=0x%" PRIx64, params.addr);
+    NGLOG_DEBUG(Service_NVDRV, "called, addr={:X}", params.addr);
 
     std::memcpy(output.data(), &params, sizeof(params));
     return 0;
@@ -80,7 +80,7 @@ u32 nvmap::IocGetId(const std::vector<u8>& input, std::vector<u8>& output) {
     IocGetIdParams params;
     std::memcpy(&params, input.data(), sizeof(params));
 
-    LOG_WARNING(Service_NVDRV, "called");
+    NGLOG_WARNING(Service_NVDRV, "called");
 
     auto object = GetObject(params.handle);
     ASSERT(object);
@@ -95,7 +95,7 @@ u32 nvmap::IocFromId(const std::vector<u8>& input, std::vector<u8>& output) {
     IocFromIdParams params;
     std::memcpy(&params, input.data(), sizeof(params));
 
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called");
+    NGLOG_WARNING(Service_NVDRV, "(STUBBED) called");
 
     auto itr = std::find_if(handles.begin(), handles.end(),
                             [&](const auto& entry) { return entry.second->id == params.id; });
@@ -114,7 +114,7 @@ u32 nvmap::IocParam(const std::vector<u8>& input, std::vector<u8>& output) {
     IocParamParams params;
     std::memcpy(&params, input.data(), sizeof(params));
 
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called type=%u", params.type);
+    NGLOG_WARNING(Service_NVDRV, "(STUBBED) called type={}", params.type);
 
     auto object = GetObject(params.handle);
     ASSERT(object);

--- a/src/core/hle/service/nvdrv/interface.cpp
+++ b/src/core/hle/service/nvdrv/interface.cpp
@@ -12,7 +12,7 @@
 namespace Service::Nvidia {
 
 void NVDRV::Open(Kernel::HLERequestContext& ctx) {
-    LOG_DEBUG(Service_NVDRV, "called");
+    NGLOG_DEBUG(Service_NVDRV, "called");
 
     const auto& buffer = ctx.ReadBuffer();
     std::string device_name(buffer.begin(), buffer.end());
@@ -25,7 +25,7 @@ void NVDRV::Open(Kernel::HLERequestContext& ctx) {
 }
 
 void NVDRV::Ioctl(Kernel::HLERequestContext& ctx) {
-    LOG_DEBUG(Service_NVDRV, "called");
+    NGLOG_DEBUG(Service_NVDRV, "called");
 
     IPC::RequestParser rp{ctx};
     u32 fd = rp.Pop<u32>();
@@ -41,7 +41,7 @@ void NVDRV::Ioctl(Kernel::HLERequestContext& ctx) {
 }
 
 void NVDRV::Close(Kernel::HLERequestContext& ctx) {
-    LOG_DEBUG(Service_NVDRV, "called");
+    NGLOG_DEBUG(Service_NVDRV, "called");
 
     IPC::RequestParser rp{ctx};
     u32 fd = rp.Pop<u32>();
@@ -53,7 +53,7 @@ void NVDRV::Close(Kernel::HLERequestContext& ctx) {
 }
 
 void NVDRV::Initialize(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called");
+    NGLOG_WARNING(Service_NVDRV, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.Push<u32>(0);
@@ -63,7 +63,7 @@ void NVDRV::QueryEvent(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     u32 fd = rp.Pop<u32>();
     u32 event_id = rp.Pop<u32>();
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, fd=%x, event_id=%x", fd, event_id);
+    NGLOG_WARNING(Service_NVDRV, "(STUBBED) called, fd={:X}, event_id={:X}", fd, event_id);
 
     IPC::ResponseBuilder rb{ctx, 3, 1};
     rb.Push(RESULT_SUCCESS);
@@ -75,14 +75,14 @@ void NVDRV::SetClientPID(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     pid = rp.Pop<u64>();
 
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, pid=0x%" PRIx64, pid);
+    NGLOG_WARNING(Service_NVDRV, "(STUBBED) called, pid={:#X}", pid);
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.Push<u32>(0);
 }
 
 void NVDRV::FinishInitialize(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called");
+    NGLOG_WARNING(Service_NVDRV, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }

--- a/src/core/hle/service/nvflinger/buffer_queue.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue.cpp
@@ -23,7 +23,7 @@ void BufferQueue::SetPreallocatedBuffer(u32 slot, IGBPBuffer& igbp_buffer) {
     buffer.igbp_buffer = igbp_buffer;
     buffer.status = Buffer::Status::Free;
 
-    LOG_WARNING(Service, "Adding graphics buffer %u", slot);
+    NGLOG_WARNING(Service, "Adding graphics buffer {}", slot);
 
     queue.emplace_back(buffer);
 
@@ -94,7 +94,7 @@ void BufferQueue::ReleaseBuffer(u32 slot) {
 }
 
 u32 BufferQueue::Query(QueryType type) {
-    LOG_WARNING(Service, "(STUBBED) called type=%u", static_cast<u32>(type));
+    NGLOG_WARNING(Service, "(STUBBED) called type={}", static_cast<u32>(type));
     switch (type) {
     case QueryType::NativeWindowFormat:
         // TODO(Subv): Use an enum for this

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -48,7 +48,7 @@ NVFlinger::~NVFlinger() {
 }
 
 u64 NVFlinger::OpenDisplay(const std::string& name) {
-    LOG_WARNING(Service, "Opening display %s", name.c_str());
+    NGLOG_WARNING(Service, "Opening display {}", name);
 
     // TODO(Subv): Currently we only support the Default display.
     ASSERT(name == "Default");

--- a/src/core/hle/service/pctl/pctl_a.cpp
+++ b/src/core/hle/service/pctl/pctl_a.cpp
@@ -113,7 +113,7 @@ void PCTL_A::CreateService(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<IParentalControlService>();
-    LOG_DEBUG(Service_PCTL, "called");
+    NGLOG_DEBUG(Service_PCTL, "called");
 }
 
 PCTL_A::PCTL_A() : ServiceFramework("pctl:a") {

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -120,7 +120,7 @@ void ServiceFrameworkBase::ReportUnimplementedFunction(Kernel::HLERequestContext
     }
     buf.push_back('}');
 
-    LOG_ERROR(Service, "unknown / unimplemented %s", fmt::to_string(buf).c_str());
+    NGLOG_ERROR(Service, "unknown / unimplemented {}", fmt::to_string(buf));
     UNIMPLEMENTED();
 }
 
@@ -131,8 +131,8 @@ void ServiceFrameworkBase::InvokeRequest(Kernel::HLERequestContext& ctx) {
         return ReportUnimplementedFunction(ctx, info);
     }
 
-    LOG_TRACE(
-        Service, "%s",
+    NGLOG_TRACE(
+        Service, "{}",
         MakeFunctionString(info->name, GetServiceName().c_str(), ctx.CommandBuffer()).c_str());
     handler_invoker(this, info->handler_callback, ctx);
 }
@@ -199,12 +199,12 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm) {
     VI::InstallInterfaces(*sm, nv_flinger);
     Set::InstallInterfaces(*sm);
 
-    LOG_DEBUG(Service, "initialized OK");
+    NGLOG_DEBUG(Service, "initialized OK");
 }
 
 /// Shutdown ServiceManager
 void Shutdown() {
     g_kernel_named_ports.clear();
-    LOG_DEBUG(Service, "shutdown OK");
+    NGLOG_DEBUG(Service, "shutdown OK");
 }
 } // namespace Service

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -22,7 +22,7 @@ void SET::GetAvailableLanguageCodes(Kernel::HLERequestContext& ctx) {
 
     rb.Push(RESULT_SUCCESS);
 
-    LOG_WARNING(Service_SET, "(STUBBED) called");
+    NGLOG_WARNING(Service_SET, "(STUBBED) called");
 }
 
 SET::SET() : ServiceFramework("set") {

--- a/src/core/hle/service/set/set_sys.cpp
+++ b/src/core/hle/service/set/set_sys.cpp
@@ -16,7 +16,7 @@ void SET_SYS::GetColorSetId(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.Push<u32>(0);
 
-    LOG_WARNING(Service_SET, "(STUBBED) called");
+    NGLOG_WARNING(Service_SET, "(STUBBED) called");
 }
 
 SET_SYS::SET_SYS() : ServiceFramework("set:sys") {

--- a/src/core/hle/service/sm/controller.cpp
+++ b/src/core/hle/service/sm/controller.cpp
@@ -17,7 +17,7 @@ void Controller::ConvertSessionToDomain(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.Push<u32>(1); // Converted sessions start with 1 request handler
 
-    LOG_DEBUG(Service, "called, server_session=%d", ctx.Session()->GetObjectId());
+    NGLOG_DEBUG(Service, "called, server_session={}", ctx.Session()->GetObjectId());
 }
 
 void Controller::DuplicateSession(Kernel::HLERequestContext& ctx) {
@@ -29,11 +29,11 @@ void Controller::DuplicateSession(Kernel::HLERequestContext& ctx) {
     Kernel::SharedPtr<Kernel::ClientSession> session{ctx.Session()->parent->client};
     rb.PushMoveObjects(session);
 
-    LOG_DEBUG(Service, "called, session=%u", session->GetObjectId());
+    NGLOG_DEBUG(Service, "called, session={}", session->GetObjectId());
 }
 
 void Controller::DuplicateSessionEx(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service, "(STUBBED) called, using DuplicateSession");
+    NGLOG_WARNING(Service, "(STUBBED) called, using DuplicateSession");
 
     DuplicateSession(ctx);
 }
@@ -43,7 +43,7 @@ void Controller::QueryPointerBufferSize(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.Push<u32>(0x500);
 
-    LOG_WARNING(Service, "(STUBBED) called");
+    NGLOG_WARNING(Service, "(STUBBED) called");
 }
 
 Controller::Controller() : ServiceFramework("IpcController") {

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -86,7 +86,7 @@ SM::~SM() = default;
 void SM::Initialize(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
-    LOG_DEBUG(Service_SM, "called");
+    NGLOG_DEBUG(Service_SM, "called");
 }
 
 void SM::GetService(Kernel::HLERequestContext& ctx) {
@@ -102,8 +102,8 @@ void SM::GetService(Kernel::HLERequestContext& ctx) {
     if (client_port.Failed()) {
         IPC::ResponseBuilder rb = rp.MakeBuilder(2, 0, 0);
         rb.Push(client_port.Code());
-        LOG_ERROR(Service_SM, "called service=%s -> error 0x%08X", name.c_str(),
-                  client_port.Code().raw);
+        NGLOG_ERROR(Service_SM, "called service={} -> error {:#010X}", name,
+                    client_port.Code().raw);
         if (name.length() == 0)
             return; // LibNX Fix
         UNIMPLEMENTED();
@@ -113,8 +113,7 @@ void SM::GetService(Kernel::HLERequestContext& ctx) {
     auto session = client_port.Unwrap()->Connect();
     ASSERT(session.Succeeded());
     if (session.Succeeded()) {
-        LOG_DEBUG(Service_SM, "called service=%s -> session=%u", name.c_str(),
-                  (*session)->GetObjectId());
+        NGLOG_DEBUG(Service_SM, "called service={} -> session={}", name, (*session)->GetObjectId());
         IPC::ResponseBuilder rb =
             rp.MakeBuilder(2, 0, 1, IPC::ResponseBuilder::Flags::AlwaysMoveHandles);
         rb.Push(session.Code());

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -8,7 +8,7 @@
 namespace Service::Sockets {
 
 void BSD::RegisterClient(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service, "(STUBBED) called");
+    NGLOG_WARNING(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
 
@@ -17,7 +17,7 @@ void BSD::RegisterClient(Kernel::HLERequestContext& ctx) {
 }
 
 void BSD::StartMonitoring(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service, "(STUBBED) called");
+    NGLOG_WARNING(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
 
@@ -32,7 +32,8 @@ void BSD::Socket(Kernel::HLERequestContext& ctx) {
     u32 type = rp.Pop<u32>();
     u32 protocol = rp.Pop<u32>();
 
-    LOG_WARNING(Service, "(STUBBED) called domain=%u type=%u protocol=%u", domain, type, protocol);
+    NGLOG_WARNING(Service, "(STUBBED) called domain={} type={} protocol={}", domain, type,
+                  protocol);
 
     u32 fd = next_fd++;
 
@@ -44,7 +45,7 @@ void BSD::Socket(Kernel::HLERequestContext& ctx) {
 }
 
 void BSD::Connect(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service, "(STUBBED) called");
+    NGLOG_WARNING(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 4};
 
@@ -54,7 +55,7 @@ void BSD::Connect(Kernel::HLERequestContext& ctx) {
 }
 
 void BSD::SendTo(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service, "(STUBBED) called");
+    NGLOG_WARNING(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 4};
 
@@ -64,7 +65,7 @@ void BSD::SendTo(Kernel::HLERequestContext& ctx) {
 }
 
 void BSD::Close(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service, "(STUBBED) called");
+    NGLOG_WARNING(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 4};
 

--- a/src/core/hle/service/sockets/sfdnsres.cpp
+++ b/src/core/hle/service/sockets/sfdnsres.cpp
@@ -10,7 +10,7 @@ namespace Service::Sockets {
 void SFDNSRES::GetAddrInfo(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
 
-    LOG_WARNING(Service, "(STUBBED) called");
+    NGLOG_WARNING(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
 

--- a/src/core/hle/service/spl/module.cpp
+++ b/src/core/hle/service/spl/module.cpp
@@ -28,7 +28,7 @@ void Module::Interface::GetRandomBytes(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
-    LOG_DEBUG(Service_SPL, "called");
+    NGLOG_DEBUG(Service_SPL, "called");
 }
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {

--- a/src/core/hle/service/ssl/ssl.cpp
+++ b/src/core/hle/service/ssl/ssl.cpp
@@ -65,7 +65,7 @@ public:
 
 private:
     void SetOption(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_SSL, "(STUBBED) called");
+        NGLOG_WARNING(Service_SSL, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
 
         IPC::ResponseBuilder rb = rp.MakeBuilder(2, 0, 0);
@@ -73,7 +73,7 @@ private:
     }
 
     void CreateConnection(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_SSL, "(STUBBED) called");
+        NGLOG_WARNING(Service_SSL, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
@@ -82,7 +82,7 @@ private:
 };
 
 void SSL::CreateContext(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_SSL, "(STUBBED) called");
+    NGLOG_WARNING(Service_SSL, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -32,14 +32,14 @@ private:
         const s64 time_since_epoch{std::chrono::duration_cast<std::chrono::seconds>(
                                        std::chrono::system_clock::now().time_since_epoch())
                                        .count()};
-        LOG_DEBUG(Service_Time, "called");
+        NGLOG_DEBUG(Service_Time, "called");
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u64>(time_since_epoch);
     }
 
     void GetSystemClockContext(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Time, "(STUBBED) called");
+        NGLOG_WARNING(Service_Time, "(STUBBED) called");
         SystemClockContext system_clock_ontext{};
         IPC::ResponseBuilder rb{ctx, (sizeof(SystemClockContext) / 4) + 2};
         rb.Push(RESULT_SUCCESS);
@@ -58,7 +58,7 @@ public:
 
 private:
     void GetCurrentTimePoint(Kernel::HLERequestContext& ctx) {
-        LOG_DEBUG(Service_Time, "called");
+        NGLOG_DEBUG(Service_Time, "called");
         SteadyClockTimePoint steady_clock_time_point{cyclesToMs(CoreTiming::GetTicks()) / 1000};
         IPC::ResponseBuilder rb{ctx, (sizeof(SteadyClockTimePoint) / 4) + 2};
         rb.Push(RESULT_SUCCESS);
@@ -86,7 +86,7 @@ public:
 
 private:
     void GetDeviceLocationName(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Time, "(STUBBED) called");
+        NGLOG_WARNING(Service_Time, "(STUBBED) called");
         LocationName location_name{};
         IPC::ResponseBuilder rb{ctx, (sizeof(LocationName) / 4) + 2};
         rb.Push(RESULT_SUCCESS);
@@ -94,14 +94,14 @@ private:
     }
 
     void GetTotalLocationNameCount(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Time, "(STUBBED) called");
+        NGLOG_WARNING(Service_Time, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u32>(0);
     }
 
     void LoadTimeZoneRule(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Time, "(STUBBED) called");
+        NGLOG_WARNING(Service_Time, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
@@ -110,7 +110,7 @@ private:
         IPC::RequestParser rp{ctx};
         u64 posix_time = rp.Pop<u64>();
 
-        LOG_WARNING(Service_Time, "(STUBBED) called, posix_time=0x%016lX", posix_time);
+        NGLOG_WARNING(Service_Time, "(STUBBED) called, posix_time={:#018X}", posix_time);
 
         CalendarTime calendar_time{2018, 1, 1, 0, 0, 0};
         CalendarAdditionalInfo additional_info{};
@@ -125,35 +125,35 @@ void Module::Interface::GetStandardUserSystemClock(Kernel::HLERequestContext& ct
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<ISystemClock>();
-    LOG_DEBUG(Service_Time, "called");
+    NGLOG_DEBUG(Service_Time, "called");
 }
 
 void Module::Interface::GetStandardNetworkSystemClock(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<ISystemClock>();
-    LOG_DEBUG(Service_Time, "called");
+    NGLOG_DEBUG(Service_Time, "called");
 }
 
 void Module::Interface::GetStandardSteadyClock(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<ISteadyClock>();
-    LOG_DEBUG(Service_Time, "called");
+    NGLOG_DEBUG(Service_Time, "called");
 }
 
 void Module::Interface::GetTimeZoneService(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<ITimeZoneService>();
-    LOG_DEBUG(Service_Time, "called");
+    NGLOG_DEBUG(Service_Time, "called");
 }
 
 void Module::Interface::GetStandardLocalSystemClock(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<ISystemClock>();
-    LOG_DEBUG(Service_Time, "called");
+    NGLOG_DEBUG(Service_Time, "called");
 }
 
 Module::Interface::Interface(std::shared_ptr<Module> time, const char* name)

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -470,7 +470,7 @@ private:
         u32 flags = rp.Pop<u32>();
         auto buffer_queue = nv_flinger->GetBufferQueue(id);
 
-        LOG_DEBUG(Service_VI, "called, transaction=%x", static_cast<u32>(transaction));
+        NGLOG_DEBUG(Service_VI, "called, transaction={:X}", static_cast<u32>(transaction));
 
         if (transaction == TransactionId::Connect) {
             IGBPConnectRequestParcel request{ctx.ReadBuffer()};
@@ -532,7 +532,7 @@ private:
             IGBPQueryResponseParcel response{value};
             ctx.WriteBuffer(response.Serialize());
         } else if (transaction == TransactionId::CancelBuffer) {
-            LOG_WARNING(Service_VI, "(STUBBED) called, transaction=CancelBuffer");
+            NGLOG_WARNING(Service_VI, "(STUBBED) called, transaction=CancelBuffer");
         } else {
             ASSERT_MSG(false, "Unimplemented");
         }
@@ -547,7 +547,8 @@ private:
         s32 addval = rp.PopRaw<s32>();
         u32 type = rp.Pop<u32>();
 
-        LOG_WARNING(Service_VI, "(STUBBED) called id=%u, addval=%08X, type=%08X", id, addval, type);
+        NGLOG_WARNING(Service_VI, "(STUBBED) called id={}, addval={:08X}, type={:08X}", id, addval,
+                      type);
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
@@ -561,7 +562,7 @@ private:
 
         // TODO(Subv): Find out what this actually is.
 
-        LOG_WARNING(Service_VI, "(STUBBED) called id=%u, unknown=%08X", id, unknown);
+        NGLOG_WARNING(Service_VI, "(STUBBED) called id={}, unknown={:08X}", id, unknown);
         IPC::ResponseBuilder rb{ctx, 2, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushCopyObjects(buffer_queue->GetNativeHandle());
@@ -624,7 +625,7 @@ public:
 
 private:
     void SetLayerZ(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        NGLOG_WARNING(Service_VI, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
         u64 layer_id = rp.Pop<u64>();
         u64 z_value = rp.Pop<u64>();
@@ -639,8 +640,8 @@ private:
         bool visibility = rp.Pop<bool>();
         IPC::ResponseBuilder rb = rp.MakeBuilder(2, 0, 0);
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_VI, "(STUBBED) called, layer_id=0x%x, visibility=%u", layer_id,
-                    visibility);
+        NGLOG_WARNING(Service_VI, "(STUBBED) called, layer_id={:#010X}, visibility={}", layer_id,
+                      visibility);
     }
 };
 
@@ -722,7 +723,7 @@ public:
 
 private:
     void CloseDisplay(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        NGLOG_WARNING(Service_VI, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
         u64 display = rp.Pop<u64>();
 
@@ -731,7 +732,7 @@ private:
     }
 
     void CreateManagedLayer(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        NGLOG_WARNING(Service_VI, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
         u32 unknown = rp.Pop<u32>();
         rp.Skip(1, false);
@@ -746,7 +747,7 @@ private:
     }
 
     void AddToLayerStack(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        NGLOG_WARNING(Service_VI, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
         u32 stack = rp.Pop<u32>();
         u64 layer_id = rp.Pop<u64>();
@@ -761,8 +762,8 @@ private:
         bool visibility = rp.Pop<bool>();
         IPC::ResponseBuilder rb = rp.MakeBuilder(2, 0, 0);
         rb.Push(RESULT_SUCCESS);
-        LOG_WARNING(Service_VI, "(STUBBED) called, layer_id=0x%x, visibility=%u", layer_id,
-                    visibility);
+        NGLOG_WARNING(Service_VI, "(STUBBED) called, layer_id={:#X}, visibility={}", layer_id,
+                      visibility);
     }
 
     std::shared_ptr<NVFlinger::NVFlinger> nv_flinger;
@@ -775,7 +776,7 @@ public:
 
 private:
     void GetRelayService(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        NGLOG_WARNING(Service_VI, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
@@ -783,7 +784,7 @@ private:
     }
 
     void GetSystemDisplayService(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        NGLOG_WARNING(Service_VI, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
@@ -791,7 +792,7 @@ private:
     }
 
     void GetManagerDisplayService(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        NGLOG_WARNING(Service_VI, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
@@ -799,7 +800,7 @@ private:
     }
 
     void GetIndirectDisplayTransactionService(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        NGLOG_WARNING(Service_VI, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
@@ -807,7 +808,7 @@ private:
     }
 
     void OpenDisplay(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        NGLOG_WARNING(Service_VI, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
         auto name_buf = rp.PopRaw<std::array<u8, 0x40>>();
         auto end = std::find(name_buf.begin(), name_buf.end(), '\0');
@@ -822,7 +823,7 @@ private:
     }
 
     void CloseDisplay(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        NGLOG_WARNING(Service_VI, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
         u64 display_id = rp.Pop<u64>();
 
@@ -831,7 +832,7 @@ private:
     }
 
     void GetDisplayResolution(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        NGLOG_WARNING(Service_VI, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
         u64 display_id = rp.Pop<u64>();
 
@@ -848,7 +849,7 @@ private:
     }
 
     void SetLayerScalingMode(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        NGLOG_WARNING(Service_VI, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
         u32 scaling_mode = rp.Pop<u32>();
         u64 unknown = rp.Pop<u64>();
@@ -864,11 +865,11 @@ private:
         IPC::ResponseBuilder rb = rp.MakeBuilder(4, 0, 0);
         rb.Push(RESULT_SUCCESS);
         rb.Push<u64>(1);
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        NGLOG_WARNING(Service_VI, "(STUBBED) called");
     }
 
     void OpenLayer(Kernel::HLERequestContext& ctx) {
-        LOG_DEBUG(Service_VI, "called");
+        NGLOG_DEBUG(Service_VI, "called");
         IPC::RequestParser rp{ctx};
         auto name_buf = rp.PopRaw<std::array<u8, 0x40>>();
         auto end = std::find(name_buf.begin(), name_buf.end(), '\0');
@@ -888,7 +889,7 @@ private:
     }
 
     void CreateStrayLayer(Kernel::HLERequestContext& ctx) {
-        LOG_DEBUG(Service_VI, "called");
+        NGLOG_DEBUG(Service_VI, "called");
 
         IPC::RequestParser rp{ctx};
         u32 flags = rp.Pop<u32>();
@@ -908,7 +909,7 @@ private:
     }
 
     void DestroyStrayLayer(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        NGLOG_WARNING(Service_VI, "(STUBBED) called");
 
         IPC::RequestParser rp{ctx};
         u64 layer_id = rp.Pop<u64>();
@@ -918,7 +919,7 @@ private:
     }
 
     void GetDisplayVsyncEvent(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        NGLOG_WARNING(Service_VI, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
         u64 display_id = rp.Pop<u64>();
 
@@ -967,7 +968,7 @@ Module::Interface::Interface(std::shared_ptr<Module> module, const char* name,
     : ServiceFramework(name), module(std::move(module)), nv_flinger(std::move(nv_flinger)) {}
 
 void Module::Interface::GetDisplayService(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_VI, "(STUBBED) called");
+    NGLOG_WARNING(Service_VI, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);


### PR DESCRIPTION
Fairly self-explanatory, moves the macros over to the new fmt-compatible ones.