### PR TITLE
core/memory: Move logging macros over to the new fmt-capable ones

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -39,8 +39,8 @@ PageTable* GetCurrentPageTable() {
 }
 
 static void MapPages(PageTable& page_table, VAddr base, u64 size, u8* memory, PageType type) {
-    LOG_DEBUG(HW_Memory, "Mapping %p onto %016" PRIX64 "-%016" PRIX64, memory, base * PAGE_SIZE,
-              (base + size) * PAGE_SIZE);
+    NGLOG_DEBUG(HW_Memory, "Mapping {} onto {:016X}-{:016X}", fmt::ptr(memory), base * PAGE_SIZE,
+                (base + size) * PAGE_SIZE);
 
     RasterizerFlushVirtualRegion(base << PAGE_BITS, size * PAGE_SIZE,
                                  FlushMode::FlushAndInvalidate);
@@ -169,7 +169,7 @@ T Read(const VAddr vaddr) {
     PageType type = current_page_table->attributes[vaddr >> PAGE_BITS];
     switch (type) {
     case PageType::Unmapped:
-        LOG_ERROR(HW_Memory, "unmapped Read%lu @ 0x%08X", sizeof(T) * 8, vaddr);
+        NGLOG_ERROR(HW_Memory, "Unmapped Read{} @ {:#010X}", sizeof(T) * 8, vaddr);
         return 0;
     case PageType::Memory:
         ASSERT_MSG(false, "Mapped memory page without a pointer @ %08X", vaddr);
@@ -201,8 +201,8 @@ void Write(const VAddr vaddr, const T data) {
     PageType type = current_page_table->attributes[vaddr >> PAGE_BITS];
     switch (type) {
     case PageType::Unmapped:
-        LOG_ERROR(HW_Memory, "unmapped Write%lu 0x%08X @ 0x%08X", sizeof(data) * 8, (u32)data,
-                  vaddr);
+        NGLOG_ERROR(HW_Memory, "Unmapped Write{} {:#010X} @ {:#018X}", sizeof(data) * 8, (u32)data,
+                    vaddr);
         return;
     case PageType::Memory:
         ASSERT_MSG(false, "Mapped memory page without a pointer @ %08X", vaddr);
@@ -251,7 +251,7 @@ u8* GetPointer(const VAddr vaddr) {
         return GetPointerFromVMA(vaddr);
     }
 
-    LOG_ERROR(HW_Memory, "unknown GetPointer @ 0x%08x", vaddr);
+    NGLOG_ERROR(HW_Memory, "Unknown GetPointer @ {:#018X}", vaddr);
     return nullptr;
 }
 
@@ -288,13 +288,12 @@ u8* GetPhysicalPointer(PAddr address) {
         });
 
     if (area == std::end(memory_areas)) {
-        LOG_ERROR(HW_Memory, "unknown GetPhysicalPointer @ 0x%016" PRIX64, address);
+        NGLOG_ERROR(HW_Memory, "Unknown GetPhysicalPointer @ {:#018X}", address);
         return nullptr;
     }
 
     if (area->paddr_base == IO_AREA_PADDR) {
-        LOG_ERROR(HW_Memory, "MMIO mappings are not supported yet. phys_addr=0x%016" PRIX64,
-                  address);
+        NGLOG_ERROR(HW_Memory, "MMIO mappings are not supported yet. phys_addr={:018X}", address);
         return nullptr;
     }
 
@@ -341,9 +340,9 @@ void RasterizerMarkRegionCached(Tegra::GPUVAddr gpu_addr, u64 size, bool cached)
             Core::System::GetInstance().GPU().memory_manager->GpuToCpuAddress(gpu_addr);
         // The GPU <-> CPU virtual memory mapping is not 1:1
         if (!maybe_vaddr) {
-            LOG_ERROR(HW_Memory,
-                      "Trying to flush a cached region to an invalid physical address %08X",
-                      gpu_addr);
+            NGLOG_ERROR(HW_Memory,
+                        "Trying to flush a cached region to an invalid physical address {:016X}",
+                        gpu_addr);
             continue;
         }
         VAddr vaddr = *maybe_vaddr;
@@ -477,8 +476,9 @@ void ReadBlock(const Kernel::Process& process, const VAddr src_addr, void* dest_
 
         switch (page_table.attributes[page_index]) {
         case PageType::Unmapped: {
-            LOG_ERROR(HW_Memory, "unmapped ReadBlock @ 0x%08X (start address = 0x%08X, size = %zu)",
-                      current_vaddr, src_addr, size);
+            NGLOG_ERROR(HW_Memory,
+                        "Unmapped ReadBlock @ {:#018X} (start address = {:#018X}, size = {})",
+                        current_vaddr, src_addr, size);
             std::memset(dest_buffer, 0, copy_amount);
             break;
         }
@@ -540,9 +540,9 @@ void WriteBlock(const Kernel::Process& process, const VAddr dest_addr, const voi
 
         switch (page_table.attributes[page_index]) {
         case PageType::Unmapped: {
-            LOG_ERROR(HW_Memory,
-                      "unmapped WriteBlock @ 0x%08X (start address = 0x%08X, size = %zu)",
-                      current_vaddr, dest_addr, size);
+            NGLOG_ERROR(HW_Memory,
+                        "Unmapped WriteBlock @ {:#018X} (start address = {:#018X}, size = {})",
+                        current_vaddr, dest_addr, size);
             break;
         }
         case PageType::Memory: {
@@ -588,8 +588,9 @@ void ZeroBlock(const Kernel::Process& process, const VAddr dest_addr, const size
 
         switch (page_table.attributes[page_index]) {
         case PageType::Unmapped: {
-            LOG_ERROR(HW_Memory, "unmapped ZeroBlock @ 0x%08X (start address = 0x%08X, size = %zu)",
-                      current_vaddr, dest_addr, size);
+            NGLOG_ERROR(HW_Memory,
+                        "Unmapped ZeroBlock @ {:#018X} (start address = {#:018X}, size = {})",
+                        current_vaddr, dest_addr, size);
             break;
         }
         case PageType::Memory: {
@@ -628,8 +629,9 @@ void CopyBlock(const Kernel::Process& process, VAddr dest_addr, VAddr src_addr, 
 
         switch (page_table.attributes[page_index]) {
         case PageType::Unmapped: {
-            LOG_ERROR(HW_Memory, "unmapped CopyBlock @ 0x%08X (start address = 0x%08X, size = %zu)",
-                      current_vaddr, src_addr, size);
+            NGLOG_ERROR(HW_Memory,
+                        "Unmapped CopyBlock @ {:#018X} (start address = {:#018X}, size = {})",
+                        current_vaddr, src_addr, size);
             ZeroBlock(process, dest_addr, copy_amount);
             break;
         }
@@ -678,7 +680,7 @@ boost::optional<PAddr> TryVirtualToPhysicalAddress(const VAddr addr) {
 PAddr VirtualToPhysicalAddress(const VAddr addr) {
     auto paddr = TryVirtualToPhysicalAddress(addr);
     if (!paddr) {
-        LOG_ERROR(HW_Memory, "Unknown virtual address @ 0x%016" PRIX64, addr);
+        NGLOG_ERROR(HW_Memory, "Unknown virtual address @ {:#018X}", addr);
         // To help with debugging, set bit on address so that it's obviously invalid.
         return addr | 0x80000000;
     }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -172,7 +172,7 @@ T Read(const VAddr vaddr) {
         NGLOG_ERROR(HW_Memory, "Unmapped Read{} @ {:#010X}", sizeof(T) * 8, vaddr);
         return 0;
     case PageType::Memory:
-        ASSERT_MSG(false, "Mapped memory page without a pointer @ %08X", vaddr);
+        ASSERT_MSG(false, "Mapped memory page without a pointer @ %016" PRIX64, vaddr);
         break;
     case PageType::RasterizerCachedMemory: {
         RasterizerFlushVirtualRegion(vaddr, sizeof(T), FlushMode::Flush);
@@ -205,7 +205,7 @@ void Write(const VAddr vaddr, const T data) {
                     vaddr);
         return;
     case PageType::Memory:
-        ASSERT_MSG(false, "Mapped memory page without a pointer @ %08X", vaddr);
+        ASSERT_MSG(false, "Mapped memory page without a pointer @ %016" PRIX64, vaddr);
         break;
     case PageType::RasterizerCachedMemory: {
         RasterizerFlushVirtualRegion(vaddr, sizeof(T), FlushMode::Invalidate);


### PR DESCRIPTION
This also amends the address width specifiers to fit the u64 type, which I imagine were just leftovers from citra that weren't converted yet.