### PR TITLE
core: Replace remaining old non-generic logger usages with fmt-capable equivalents

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -55,8 +55,8 @@ public:
     }
 
     void InterpreterFallback(u64 pc, size_t num_instructions) override {
-        LOG_INFO(Core_ARM, "Unicorn fallback @ 0x%" PRIx64 " for %zu instructions (instr = %08x)",
-                 pc, num_instructions, MemoryReadCode(pc));
+        NGLOG_INFO(Core_ARM, "Unicorn fallback @ {:#X} for {} instructions (instr = {:08X})", pc,
+                   num_instructions, MemoryReadCode(pc));
 
         ARM_Interface::ThreadContext ctx;
         parent.SaveContext(ctx);

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -55,7 +55,7 @@ System::ResultStatus System::RunLoop(bool tight_loop) {
     // If we don't have a currently active thread then don't execute instructions,
     // instead advance to the next event and try to yield to the next thread
     if (Kernel::GetCurrentThread() == nullptr) {
-        LOG_TRACE(Core_ARM, "Idling");
+        NGLOG_TRACE(Core_ARM, "Idling");
         CoreTiming::Idle();
         CoreTiming::Advance();
         PrepareReschedule();
@@ -82,15 +82,15 @@ System::ResultStatus System::Load(EmuWindow* emu_window, const std::string& file
     app_loader = Loader::GetLoader(filepath);
 
     if (!app_loader) {
-        LOG_CRITICAL(Core, "Failed to obtain loader for %s!", filepath.c_str());
+        NGLOG_CRITICAL(Core, "Failed to obtain loader for {}!", filepath);
         return ResultStatus::ErrorGetLoader;
     }
     std::pair<boost::optional<u32>, Loader::ResultStatus> system_mode =
         app_loader->LoadKernelSystemMode();
 
     if (system_mode.second != Loader::ResultStatus::Success) {
-        LOG_CRITICAL(Core, "Failed to determine system mode (Error %i)!",
-                     static_cast<int>(system_mode.second));
+        NGLOG_CRITICAL(Core, "Failed to determine system mode (Error {})!",
+                       static_cast<int>(system_mode.second));
 
         switch (system_mode.second) {
         case Loader::ResultStatus::ErrorEncrypted:
@@ -106,15 +106,15 @@ System::ResultStatus System::Load(EmuWindow* emu_window, const std::string& file
 
     ResultStatus init_result{Init(emu_window, system_mode.first.get())};
     if (init_result != ResultStatus::Success) {
-        LOG_CRITICAL(Core, "Failed to initialize system (Error %i)!",
-                     static_cast<int>(init_result));
+        NGLOG_CRITICAL(Core, "Failed to initialize system (Error {})!",
+                       static_cast<int>(init_result));
         System::Shutdown();
         return init_result;
     }
 
     const Loader::ResultStatus load_result{app_loader->Load(current_process)};
     if (Loader::ResultStatus::Success != load_result) {
-        LOG_CRITICAL(Core, "Failed to load ROM (Error %i)!", static_cast<int>(load_result));
+        NGLOG_CRITICAL(Core, "Failed to load ROM (Error {})!", static_cast<int>(load_result));
         System::Shutdown();
 
         switch (load_result) {
@@ -151,7 +151,7 @@ void System::Reschedule() {
 }
 
 System::ResultStatus System::Init(EmuWindow* emu_window, u32 system_mode) {
-    LOG_DEBUG(HW_Memory, "initialized OK");
+    NGLOG_DEBUG(HW_Memory, "initialized OK");
 
     CoreTiming::Init();
 
@@ -162,7 +162,7 @@ System::ResultStatus System::Init(EmuWindow* emu_window, u32 system_mode) {
         cpu_core = std::make_shared<ARM_Dynarmic>();
 #else
         cpu_core = std::make_shared<ARM_Unicorn>();
-        LOG_WARNING(Core, "CPU JIT requested, but Dynarmic not available");
+        NGLOG_WARNING(Core, "CPU JIT requested, but Dynarmic not available");
 #endif
     } else {
         cpu_core = std::make_shared<ARM_Unicorn>();
@@ -184,7 +184,7 @@ System::ResultStatus System::Init(EmuWindow* emu_window, u32 system_mode) {
         return ResultStatus::ErrorVideoCore;
     }
 
-    LOG_DEBUG(Core, "Initialized OK");
+    NGLOG_DEBUG(Core, "Initialized OK");
 
     // Reset counters and set time origin to current frame
     GetAndResetPerfStats();
@@ -218,7 +218,7 @@ void System::Shutdown() {
 
     app_loader.reset();
 
-    LOG_DEBUG(Core, "Shutdown OK");
+    NGLOG_DEBUG(Core, "Shutdown OK");
 }
 
 Service::SM::ServiceManager& System::ServiceManager() {

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -51,11 +51,11 @@ inline s64 usToCycles(int us) {
 
 inline s64 usToCycles(s64 us) {
     if (us / 1000000 > MAX_VALUE_TO_MULTIPLY) {
-        LOG_ERROR(Core_Timing, "Integer overflow, use max value");
+        NGLOG_ERROR(Core_Timing, "Integer overflow, use max value");
         return std::numeric_limits<s64>::max();
     }
     if (us > MAX_VALUE_TO_MULTIPLY) {
-        LOG_DEBUG(Core_Timing, "Time very big, do rounding");
+        NGLOG_DEBUG(Core_Timing, "Time very big, do rounding");
         return BASE_CLOCK_RATE * (us / 1000000);
     }
     return (BASE_CLOCK_RATE * us) / 1000000;
@@ -63,11 +63,11 @@ inline s64 usToCycles(s64 us) {
 
 inline s64 usToCycles(u64 us) {
     if (us / 1000000 > MAX_VALUE_TO_MULTIPLY) {
-        LOG_ERROR(Core_Timing, "Integer overflow, use max value");
+        NGLOG_ERROR(Core_Timing, "Integer overflow, use max value");
         return std::numeric_limits<s64>::max();
     }
     if (us > MAX_VALUE_TO_MULTIPLY) {
-        LOG_DEBUG(Core_Timing, "Time very big, do rounding");
+        NGLOG_DEBUG(Core_Timing, "Time very big, do rounding");
         return BASE_CLOCK_RATE * static_cast<s64>(us / 1000000);
     }
     return (BASE_CLOCK_RATE * static_cast<s64>(us)) / 1000000;
@@ -83,11 +83,11 @@ inline s64 nsToCycles(int ns) {
 
 inline s64 nsToCycles(s64 ns) {
     if (ns / 1000000000 > MAX_VALUE_TO_MULTIPLY) {
-        LOG_ERROR(Core_Timing, "Integer overflow, use max value");
+        NGLOG_ERROR(Core_Timing, "Integer overflow, use max value");
         return std::numeric_limits<s64>::max();
     }
     if (ns > MAX_VALUE_TO_MULTIPLY) {
-        LOG_DEBUG(Core_Timing, "Time very big, do rounding");
+        NGLOG_DEBUG(Core_Timing, "Time very big, do rounding");
         return BASE_CLOCK_RATE * (ns / 1000000000);
     }
     return (BASE_CLOCK_RATE * ns) / 1000000000;
@@ -95,11 +95,11 @@ inline s64 nsToCycles(s64 ns) {
 
 inline s64 nsToCycles(u64 ns) {
     if (ns / 1000000000 > MAX_VALUE_TO_MULTIPLY) {
-        LOG_ERROR(Core_Timing, "Integer overflow, use max value");
+        NGLOG_ERROR(Core_Timing, "Integer overflow, use max value");
         return std::numeric_limits<s64>::max();
     }
     if (ns > MAX_VALUE_TO_MULTIPLY) {
-        LOG_DEBUG(Core_Timing, "Time very big, do rounding");
+        NGLOG_DEBUG(Core_Timing, "Time very big, do rounding");
         return BASE_CLOCK_RATE * (static_cast<s64>(ns) / 1000000000);
     }
     return (BASE_CLOCK_RATE * static_cast<s64>(ns)) / 1000000000;

--- a/src/core/frontend/input.h
+++ b/src/core/frontend/input.h
@@ -59,7 +59,7 @@ template <typename InputDeviceType>
 void RegisterFactory(const std::string& name, std::shared_ptr<Factory<InputDeviceType>> factory) {
     auto pair = std::make_pair(name, std::move(factory));
     if (!Impl::FactoryList<InputDeviceType>::list.insert(std::move(pair)).second) {
-        LOG_ERROR(Input, "Factory %s already registered", name.c_str());
+        NGLOG_ERROR(Input, "Factory '{}' already registered", name);
     }
 }
 
@@ -71,7 +71,7 @@ void RegisterFactory(const std::string& name, std::shared_ptr<Factory<InputDevic
 template <typename InputDeviceType>
 void UnregisterFactory(const std::string& name) {
     if (Impl::FactoryList<InputDeviceType>::list.erase(name) == 0) {
-        LOG_ERROR(Input, "Factory %s not registered", name.c_str());
+        NGLOG_ERROR(Input, "Factory '{}' not registered", name);
     }
 }
 
@@ -88,7 +88,7 @@ std::unique_ptr<InputDeviceType> CreateDevice(const std::string& params) {
     const auto pair = factory_list.find(engine);
     if (pair == factory_list.end()) {
         if (engine != "null") {
-            LOG_ERROR(Input, "Unknown engine name: %s", engine.c_str());
+            NGLOG_ERROR(Input, "Unknown engine name: {}", engine);
         }
         return std::make_unique<InputDeviceType>();
     }

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -42,14 +42,14 @@ u64 GetTelemetryId() {
     if (FileUtil::Exists(filename)) {
         FileUtil::IOFile file(filename, "rb");
         if (!file.IsOpen()) {
-            LOG_ERROR(Core, "failed to open telemetry_id: %s", filename.c_str());
+            NGLOG_ERROR(Core, "failed to open telemetry_id: {}", filename);
             return {};
         }
         file.ReadBytes(&telemetry_id, sizeof(u64));
     } else {
         FileUtil::IOFile file(filename, "wb");
         if (!file.IsOpen()) {
-            LOG_ERROR(Core, "failed to open telemetry_id: %s", filename.c_str());
+            NGLOG_ERROR(Core, "failed to open telemetry_id: {}", filename);
             return {};
         }
         telemetry_id = GenerateTelemetryId();
@@ -65,7 +65,7 @@ u64 RegenerateTelemetryId() {
 
     FileUtil::IOFile file(filename, "wb");
     if (!file.IsOpen()) {
-        LOG_ERROR(Core, "failed to open telemetry_id: %s", filename.c_str());
+        NGLOG_ERROR(Core, "failed to open telemetry_id: {}", filename);
         return {};
     }
     file.WriteBytes(&new_telemetry_id, sizeof(u64));

--- a/src/core/tracer/recorder.cpp
+++ b/src/core/tracer/recorder.cpp
@@ -159,7 +159,7 @@ void Recorder::Finish(const std::string& filename) {
                 throw "Failed to write stream element";
         }
     } catch (const char* str) {
-        LOG_ERROR(HW_GPU, "Writing CiTrace file failed: %s", str);
+        NGLOG_ERROR(HW_GPU, "Writing CiTrace file failed: {}", str);
     }
 }
 


### PR DESCRIPTION
LOG_GENERIC usages will be amended in a follow-up to keep API changes separate from interface changes, as it will require removing a parameter from the relevant function in the VMManager class.