### PR TITLE
general: Convert assertion macros over to be fmt-compatible

### DIFF
--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -30,14 +30,15 @@ __declspec(noinline, noreturn)
 #define ASSERT(_a_)                                                                                \
     do                                                                                             \
         if (!(_a_)) {                                                                              \
-            assert_noinline_call([] { LOG_CRITICAL(Debug, "Assertion Failed!"); });                \
+            assert_noinline_call([] { NGLOG_CRITICAL(Debug, "Assertion Failed!"); });              \
         }                                                                                          \
     while (0)
 
 #define ASSERT_MSG(_a_, ...)                                                                       \
     do                                                                                             \
         if (!(_a_)) {                                                                              \
-            assert_noinline_call([&] { LOG_CRITICAL(Debug, "Assertion Failed!\n" __VA_ARGS__); }); \
+            assert_noinline_call(                                                                  \
+                [&] { NGLOG_CRITICAL(Debug, "Assertion Failed!\n" __VA_ARGS__); });                \
         }                                                                                          \
     while (0)
 

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -653,12 +653,12 @@ static const std::string GetUserDirectory(const std::string& envvar) {
         else if (envvar == "XDG_CACHE_HOME")
             subdirectory = DIR_SEP ".cache";
         else
-            ASSERT_MSG(false, "Unknown XDG variable %s.", envvar.c_str());
+            ASSERT_MSG(false, "Unknown XDG variable {}.", envvar);
         user_dir = GetHomeDirectory() + subdirectory;
     }
 
-    ASSERT_MSG(!user_dir.empty(), "User directory %s musn’t be empty.", envvar.c_str());
-    ASSERT_MSG(user_dir[0] == '/', "User directory %s must be absolute.", envvar.c_str());
+    ASSERT_MSG(!user_dir.empty(), "User directory {} mustn’t be empty.", envvar);
+    ASSERT_MSG(user_dir[0] == '/', "User directory {} must be absolute.", envvar);
 
     return user_dir;
 }

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -76,7 +76,7 @@ public:
         case Dynarmic::A64::Exception::Yield:
             return;
         default:
-            ASSERT_MSG(false, "ExceptionRaised(exception = %zu, pc = %" PRIx64 ")",
+            ASSERT_MSG(false, "ExceptionRaised(exception = {}, pc = {:X})",
                        static_cast<size_t>(exception), pc);
         }
     }

--- a/src/core/arm/unicorn/arm_unicorn.cpp
+++ b/src/core/arm/unicorn/arm_unicorn.cpp
@@ -30,7 +30,7 @@ LoadDll LoadDll::g_load_dll;
 #define CHECKED(expr)                                                                              \
     do {                                                                                           \
         if (auto _cerr = (expr)) {                                                                 \
-            ASSERT_MSG(false, "Call " #expr " failed with error: %u (%s)\n", _cerr,                \
+            ASSERT_MSG(false, "Call " #expr " failed with error: {} ({})\n", _cerr,                \
                        uc_strerror(_cerr));                                                        \
         }                                                                                          \
     } while (0)
@@ -53,7 +53,7 @@ static bool UnmappedMemoryHook(uc_engine* uc, uc_mem_type type, u64 addr, int si
                                void* user_data) {
     ARM_Interface::ThreadContext ctx{};
     Core::CPU().SaveContext(ctx);
-    ASSERT_MSG(false, "Attempted to read from unmapped memory: 0x%lx, pc=0x%lx, lr=0x%lx", addr,
+    ASSERT_MSG(false, "Attempted to read from unmapped memory: {:#X}, pc={:#X}, lr={:#X}", addr,
                ctx.pc, ctx.cpu_registers[30]);
     return {};
 }

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -74,7 +74,7 @@ EventType* RegisterEvent(const std::string& name, TimedCallback callback) {
     // check for existing type with same name.
     // we want event type names to remain unique so that we can use them for serialization.
     ASSERT_MSG(event_types.find(name) == event_types.end(),
-               "CoreTiming Event \"%s\" is already registered. Events should only be registered "
+               "CoreTiming Event \"{}\" is already registered. Events should only be registered "
                "during Init to avoid breaking save states.",
                name.c_str());
 

--- a/src/core/hle/kernel/object_address_table.cpp
+++ b/src/core/hle/kernel/object_address_table.cpp
@@ -10,12 +10,12 @@ namespace Kernel {
 ObjectAddressTable g_object_address_table;
 
 void ObjectAddressTable::Insert(VAddr addr, SharedPtr<Object> obj) {
-    ASSERT_MSG(objects.find(addr) == objects.end(), "Object already exists with addr=0x%lx", addr);
+    ASSERT_MSG(objects.find(addr) == objects.end(), "Object already exists with addr={:#X}", addr);
     objects[addr] = obj;
 }
 
 void ObjectAddressTable::Close(VAddr addr) {
-    ASSERT_MSG(objects.find(addr) != objects.end(), "Object does not exist with addr=0x%lx", addr);
+    ASSERT_MSG(objects.find(addr) != objects.end(), "Object does not exist with addr={:#X}", addr);
     objects.erase(addr);
 }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -539,7 +539,7 @@ static ResultCode CreateThread(Handle* out_handle, VAddr entry_point, u64 arg, V
                     processor_id);
         break;
     default:
-        ASSERT_MSG(false, "Unsupported thread processor ID: %d", processor_id);
+        ASSERT_MSG(false, "Unsupported thread processor ID: {}", processor_id);
         break;
     }
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -175,11 +175,11 @@ void Thread::ResumeFromWait() {
         return;
 
     case THREADSTATUS_RUNNING:
-        DEBUG_ASSERT_MSG(false, "Thread with object id %u has already resumed.", GetObjectId());
+        DEBUG_ASSERT_MSG(false, "Thread with object id {} has already resumed.", GetObjectId());
         return;
     case THREADSTATUS_DEAD:
         // This should never happen, as threads must complete before being stopped.
-        DEBUG_ASSERT_MSG(false, "Thread with object id %u cannot be resumed because it's DEAD.",
+        DEBUG_ASSERT_MSG(false, "Thread with object id {} cannot be resumed because it's DEAD.",
                          GetObjectId());
         return;
     }

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -245,8 +245,8 @@ VMManager::VMAIter VMManager::StripIterConstness(const VMAHandle& iter) {
 }
 
 ResultVal<VMManager::VMAIter> VMManager::CarveVMA(VAddr base, u64 size) {
-    ASSERT_MSG((size & Memory::PAGE_MASK) == 0, "non-page aligned size: 0x%16" PRIx64, size);
-    ASSERT_MSG((base & Memory::PAGE_MASK) == 0, "non-page aligned base: 0x%016" PRIx64, base);
+    ASSERT_MSG((size & Memory::PAGE_MASK) == 0, "non-page aligned size: {:#018X}", size);
+    ASSERT_MSG((base & Memory::PAGE_MASK) == 0, "non-page aligned base: {:#018X}", base);
 
     VMAIter vma_handle = StripIterConstness(FindVMA(base));
     if (vma_handle == vma_map.end()) {
@@ -281,8 +281,8 @@ ResultVal<VMManager::VMAIter> VMManager::CarveVMA(VAddr base, u64 size) {
 }
 
 ResultVal<VMManager::VMAIter> VMManager::CarveVMARange(VAddr target, u64 size) {
-    ASSERT_MSG((size & Memory::PAGE_MASK) == 0, "non-page aligned size: 0x%16" PRIx64, size);
-    ASSERT_MSG((target & Memory::PAGE_MASK) == 0, "non-page aligned base: 0x%016" PRIx64, target);
+    ASSERT_MSG((size & Memory::PAGE_MASK) == 0, "non-page aligned size: {:#018X}", size);
+    ASSERT_MSG((target & Memory::PAGE_MASK) == 0, "non-page aligned base: {:#018X}", target);
 
     VAddr target_end = target + size;
     ASSERT(target_end >= target);

--- a/src/core/hle/service/nvdrv/nvdrv.cpp
+++ b/src/core/hle/service/nvdrv/nvdrv.cpp
@@ -39,8 +39,8 @@ Module::Module() {
 }
 
 u32 Module::Open(std::string device_name) {
-    ASSERT_MSG(devices.find(device_name) != devices.end(), "Trying to open unknown device %s",
-               device_name.c_str());
+    ASSERT_MSG(devices.find(device_name) != devices.end(), "Trying to open unknown device {}",
+               device_name);
 
     auto device = devices[device_name];
     u32 fd = next_fd++;

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -154,7 +154,7 @@ ResultCode ServiceFrameworkBase::HandleSyncRequest(Kernel::HLERequestContext& co
         break;
     }
     default:
-        UNIMPLEMENTED_MSG("command_type=%d", static_cast<int>(context.GetCommandType()));
+        UNIMPLEMENTED_MSG("command_type={}", static_cast<int>(context.GetCommandType()));
     }
 
     context.WriteToOutgoingCommandBuffer(*Kernel::GetCurrentThread());

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -84,7 +84,7 @@ static std::vector<u8> ReadSegment(FileUtil::IOFile& file, const NsoSegmentHeade
         reinterpret_cast<char*>(uncompressed_data.data()), compressed_size, header.size);
 
     ASSERT_MSG(bytes_uncompressed == header.size && bytes_uncompressed == uncompressed_data.size(),
-               "%d != %u != %zu", bytes_uncompressed, header.size, uncompressed_data.size());
+               "{} != {} != {}", bytes_uncompressed, header.size, uncompressed_data.size());
 
     return uncompressed_data;
 }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cinttypes>
 #include <cstring>
 #include <boost/optional.hpp>
 #include "common/assert.h"
@@ -47,7 +46,7 @@ static void MapPages(PageTable& page_table, VAddr base, u64 size, u8* memory, Pa
 
     VAddr end = base + size;
     while (base != end) {
-        ASSERT_MSG(base < PAGE_TABLE_NUM_ENTRIES, "out of range mapping at %016" PRIX64, base);
+        ASSERT_MSG(base < PAGE_TABLE_NUM_ENTRIES, "out of range mapping at {:016X}", base);
 
         page_table.attributes[base] = type;
         page_table.pointers[base] = memory;
@@ -59,14 +58,14 @@ static void MapPages(PageTable& page_table, VAddr base, u64 size, u8* memory, Pa
 }
 
 void MapMemoryRegion(PageTable& page_table, VAddr base, u64 size, u8* target) {
-    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: %016" PRIX64, size);
-    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: %016" PRIX64, base);
+    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: {:016X}", size);
+    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: {:016X}", base);
     MapPages(page_table, base / PAGE_SIZE, size / PAGE_SIZE, target, PageType::Memory);
 }
 
 void MapIoRegion(PageTable& page_table, VAddr base, u64 size, MemoryHookPointer mmio_handler) {
-    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: %016" PRIX64, size);
-    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: %016" PRIX64, base);
+    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: {:016X}", size);
+    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: {:016X}", base);
     MapPages(page_table, base / PAGE_SIZE, size / PAGE_SIZE, nullptr, PageType::Special);
 
     auto interval = boost::icl::discrete_interval<VAddr>::closed(base, base + size - 1);
@@ -75,8 +74,8 @@ void MapIoRegion(PageTable& page_table, VAddr base, u64 size, MemoryHookPointer 
 }
 
 void UnmapRegion(PageTable& page_table, VAddr base, u64 size) {
-    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: %016" PRIX64, size);
-    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: %016" PRIX64, base);
+    ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: {:016X}", size);
+    ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: {:016X}", base);
     MapPages(page_table, base / PAGE_SIZE, size / PAGE_SIZE, nullptr, PageType::Unmapped);
 
     auto interval = boost::icl::discrete_interval<VAddr>::closed(base, base + size - 1);
@@ -172,7 +171,7 @@ T Read(const VAddr vaddr) {
         NGLOG_ERROR(HW_Memory, "Unmapped Read{} @ {:#010X}", sizeof(T) * 8, vaddr);
         return 0;
     case PageType::Memory:
-        ASSERT_MSG(false, "Mapped memory page without a pointer @ %016" PRIX64, vaddr);
+        ASSERT_MSG(false, "Mapped memory page without a pointer @ {:016X}", vaddr);
         break;
     case PageType::RasterizerCachedMemory: {
         RasterizerFlushVirtualRegion(vaddr, sizeof(T), FlushMode::Flush);
@@ -205,7 +204,7 @@ void Write(const VAddr vaddr, const T data) {
                     vaddr);
         return;
     case PageType::Memory:
-        ASSERT_MSG(false, "Mapped memory page without a pointer @ %016" PRIX64, vaddr);
+        ASSERT_MSG(false, "Mapped memory page without a pointer @ {:016X}", vaddr);
         break;
     case PageType::RasterizerCachedMemory: {
         RasterizerFlushVirtualRegion(vaddr, sizeof(T), FlushMode::Invalidate);

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -168,7 +168,7 @@ void Maxwell3D::ProcessQueryGet() {
         result = 0;
         break;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented query select type %u",
+        UNIMPLEMENTED_MSG("Unimplemented query select type {}",
                           static_cast<u32>(regs.query.query_get.select.Value()));
     }
 
@@ -186,7 +186,7 @@ void Maxwell3D::ProcessQueryGet() {
         break;
     }
     default:
-        UNIMPLEMENTED_MSG("Query mode %u not implemented",
+        UNIMPLEMENTED_MSG("Query mode {} not implemented",
                           static_cast<u32>(regs.query.query_get.mode.Value()));
     }
 }

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -30,7 +30,7 @@ u32 RenderTargetBytesPerPixel(RenderTargetFormat format) {
     case RenderTargetFormat::RGB10_A2_UNORM:
         return 4;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented render target format %u", static_cast<u32>(format));
+        UNIMPLEMENTED_MSG("Unimplemented render target format {}", static_cast<u32>(format));
     }
 }
 

--- a/src/video_core/macro_interpreter.cpp
+++ b/src/video_core/macro_interpreter.cpp
@@ -113,7 +113,7 @@ bool MacroInterpreter::Step(const std::vector<u32>& code, bool is_delay_slot) {
         break;
     }
     default:
-        UNIMPLEMENTED_MSG("Unimplemented macro operation %u",
+        UNIMPLEMENTED_MSG("Unimplemented macro operation {}",
                           static_cast<u32>(opcode.operation.Value()));
     }
 
@@ -154,7 +154,7 @@ u32 MacroInterpreter::GetALUResult(ALUOperation operation, u32 src_a, u32 src_b)
         return ~(src_a & src_b);
 
     default:
-        UNIMPLEMENTED_MSG("Unimplemented ALU operation %u", static_cast<u32>(operation));
+        UNIMPLEMENTED_MSG("Unimplemented ALU operation {}", static_cast<u32>(operation));
     }
 }
 
@@ -201,7 +201,7 @@ void MacroInterpreter::ProcessResult(ResultOperation operation, u32 reg, u32 res
         Send((result >> 12) & 0b111111);
         break;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented result operation %u", static_cast<u32>(operation));
+        UNIMPLEMENTED_MSG("Unimplemented result operation {}", static_cast<u32>(operation));
     }
 }
 

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -17,7 +17,7 @@ void SetShaderUniformBlockBinding(GLuint shader, const char* name,
         GLint ub_size = 0;
         glGetActiveUniformBlockiv(shader, ub_index, GL_UNIFORM_BLOCK_DATA_SIZE, &ub_size);
         ASSERT_MSG(ub_size == expected_size,
-                   "Uniform block size did not match! Got %d, expected %zu",
+                   "Uniform block size did not match! Got {}, expected {}",
                    static_cast<int>(ub_size), expected_size);
         glUniformBlockBinding(shader, ub_index, static_cast<GLuint>(binding));
     }


### PR DESCRIPTION
After this, only LOG_GENERIC calls need to be addressed, then we can kick out the old logging system entirely