### PR TITLE
core/renderer_opengl: Replace usages of LOG_GENERIC with fmt-capable equivalents

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -134,7 +134,7 @@ void Process::Run(VAddr entry_point, s32 main_thread_priority, u32 stack_size) {
         HandleSpecialMapping(vm_manager, mapping);
     }
 
-    vm_manager.LogLayout(Log::Level::Debug);
+    vm_manager.LogLayout();
     status = ProcessStatus::Running;
 
     Kernel::SetupMainThread(entry_point, main_thread_priority, this);

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <cinttypes>
 #include <iterator>
 #include "common/assert.h"
 #include "common/logging/log.h"
@@ -225,11 +224,10 @@ void VMManager::RefreshMemoryBlockMappings(const std::vector<u8>* block) {
     }
 }
 
-void VMManager::LogLayout(Log::Level log_level) const {
+void VMManager::LogLayout() const {
     for (const auto& p : vma_map) {
         const VirtualMemoryArea& vma = p.second;
-        LOG_GENERIC(Log::Class::Kernel, log_level,
-                    "%016" PRIx64 " - %016" PRIx64 "  size: %16" PRIx64 " %c%c%c %s", vma.base,
+        NGLOG_DEBUG(Kernel, "{:016X} - {:016X} size: {:016X} {}{}{} {}", vma.base,
                     vma.base + vma.size, vma.size,
                     (u8)vma.permissions & (u8)VMAPermission::Read ? 'R' : '-',
                     (u8)vma.permissions & (u8)VMAPermission::Write ? 'W' : '-',

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -187,7 +187,7 @@ public:
     void RefreshMemoryBlockMappings(const std::vector<u8>* block);
 
     /// Dumps the address space layout to the log, for debugging
-    void LogLayout(Log::Level log_level) const;
+    void LogLayout() const;
 
     /// Gets the total memory usage, used by svcGetInfo
     u64 GetTotalMemoryUsage();

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -398,21 +398,22 @@ static const char* GetType(GLenum type) {
 
 static void APIENTRY DebugHandler(GLenum source, GLenum type, GLuint id, GLenum severity,
                                   GLsizei length, const GLchar* message, const void* user_param) {
-    Log::Level level;
+    const char format[] = "{} {} {}: {}";
+    const char* const str_source = GetSource(source);
+    const char* const str_type = GetType(type);
+
     switch (severity) {
     case GL_DEBUG_SEVERITY_HIGH:
-        level = Log::Level::Error;
+        NGLOG_ERROR(Render_OpenGL, format, str_source, str_type, id, message);
         break;
     case GL_DEBUG_SEVERITY_MEDIUM:
-        level = Log::Level::Warning;
+        NGLOG_WARNING(Render_OpenGL, format, str_source, str_type, id, message);
         break;
     case GL_DEBUG_SEVERITY_NOTIFICATION:
     case GL_DEBUG_SEVERITY_LOW:
-        level = Log::Level::Debug;
+        NGLOG_DEBUG(Render_OpenGL, format, str_source, str_type, id, message);
         break;
     }
-    LOG_GENERIC(Log::Class::Render_OpenGL, level, "%s %s %d: %s", GetSource(source), GetType(type),
-                id, message);
 }
 
 /// Initialize the renderer


### PR DESCRIPTION
After this, a follow-up PR will remove the old printf-based logging system.