### PR TITLE
travis: Use Xcode 9.3 instead of 9.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ matrix:
     - os: osx
       env: NAME="macos build"
       sudo: false
-      osx_image: xcode9.2
+      osx_image: xcode9.3
       install: "./.travis/macos/deps.sh"
       script: "./.travis/macos/build.sh"
       after_success: "./.travis/macos/upload.sh"


### PR DESCRIPTION
Keeps the toolchains up to date.