### PR TITLE
log: Remove old logging macros and functions

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -2,11 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <algorithm>
-#include <array>
-#include <cstdio>
+#include <utility>
 #include "common/assert.h"
-#include "common/common_funcs.h" // snprintf compatibility define
 #include "common/logging/backend.h"
 #include "common/logging/filter.h"
 #include "common/logging/log.h"
@@ -130,21 +127,6 @@ static Filter* filter = nullptr;
 
 void SetFilter(Filter* new_filter) {
     filter = new_filter;
-}
-
-void LogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
-                const char* function, const char* format, ...) {
-    if (filter && !filter->CheckMessage(log_class, log_level))
-        return;
-    std::array<char, 4 * 1024> formatting_buffer;
-    va_list args;
-    va_start(args, format);
-    vsnprintf(formatting_buffer.data(), formatting_buffer.size(), format, args);
-    va_end(args);
-    Entry entry = CreateEntry(log_class, log_level, filename, line_num, function,
-                              std::string(formatting_buffer.data()));
-
-    PrintColoredMessage(entry);
 }
 
 void FmtLogMessageImpl(Class log_class, Level log_level, const char* filename,

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -92,19 +92,6 @@ enum class Class : ClassType {
     Count              ///< Total number of logging classes
 };
 
-/// Logs a message to the global logger.
-void LogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
-                const char* function,
-#ifdef _MSC_VER
-                _Printf_format_string_
-#endif
-                const char* format,
-                ...)
-#ifdef __GNUC__
-    __attribute__((format(printf, 6, 7)))
-#endif
-    ;
-
 /// Logs a message to the global logger, using fmt
 void FmtLogMessageImpl(Class log_class, Level log_level, const char* filename,
                        unsigned int line_num, const char* function, const char* format,
@@ -119,28 +106,6 @@ void FmtLogMessage(Class log_class, Level log_level, const char* filename, unsig
 
 } // namespace Log
 
-#define LOG_GENERIC(log_class, log_level, ...)                                                     \
-    ::Log::LogMessage(log_class, log_level, __FILE__, __LINE__, __func__, __VA_ARGS__)
-
-#ifdef _DEBUG
-#define LOG_TRACE(log_class, ...)                                                                  \
-    LOG_GENERIC(::Log::Class::log_class, ::Log::Level::Trace, __VA_ARGS__)
-#else
-#define LOG_TRACE(log_class, ...) (void(0))
-#endif
-
-#define LOG_DEBUG(log_class, ...)                                                                  \
-    LOG_GENERIC(::Log::Class::log_class, ::Log::Level::Debug, __VA_ARGS__)
-#define LOG_INFO(log_class, ...)                                                                   \
-    LOG_GENERIC(::Log::Class::log_class, ::Log::Level::Info, __VA_ARGS__)
-#define LOG_WARNING(log_class, ...)                                                                \
-    LOG_GENERIC(::Log::Class::log_class, ::Log::Level::Warning, __VA_ARGS__)
-#define LOG_ERROR(log_class, ...)                                                                  \
-    LOG_GENERIC(::Log::Class::log_class, ::Log::Level::Error, __VA_ARGS__)
-#define LOG_CRITICAL(log_class, ...)                                                               \
-    LOG_GENERIC(::Log::Class::log_class, ::Log::Level::Critical, __VA_ARGS__)
-
-// Define the fmt lib macros
 #ifdef _DEBUG
 #define NGLOG_TRACE(log_class, ...)                                                                \
     ::Log::FmtLogMessage(::Log::Class::log_class, ::Log::Level::Trace, __FILE__, __LINE__,         \


### PR DESCRIPTION
Now that the old macros are no longer used, we can remove all functionality related to them.