### PR TITLE
file_util: Remove compiler version checks around is_trivially_copyable

### DIFF
--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -170,12 +170,8 @@ public:
 
     template <typename T>
     size_t ReadArray(T* data, size_t length) {
-        static_assert(std::is_standard_layout<T>(),
-                      "Given array does not consist of standard layout objects");
-#if (__GNUC__ >= 5) || defined(__clang__) || defined(_MSC_VER)
         static_assert(std::is_trivially_copyable<T>(),
                       "Given array does not consist of trivially copyable objects");
-#endif
 
         if (!IsOpen()) {
             m_good = false;
@@ -191,12 +187,8 @@ public:
 
     template <typename T>
     size_t WriteArray(const T* data, size_t length) {
-        static_assert(std::is_standard_layout<T>(),
-                      "Given array does not consist of standard layout objects");
-#if (__GNUC__ >= 5) || defined(__clang__) || defined(_MSC_VER)
         static_assert(std::is_trivially_copyable<T>(),
                       "Given array does not consist of trivially copyable objects");
-#endif
 
         if (!IsOpen()) {
             m_good = false;


### PR DESCRIPTION
The minimum clang/GCC versions we support already support this. MSVC's STL has supported this for quite a while as well.

We can also remove the`is_standard_layout()` check, as `fread` and `fwrite` only require the type to be trivially copyable.