### PR TITLE
set/am: Fix code for getting language codes

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -12,6 +12,7 @@
 #include "core/hle/service/apm/apm.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/hle/service/nvflinger/nvflinger.h"
+#include "core/hle/service/set/set.h"
 #include "core/settings.h"
 
 namespace Service::AM {
@@ -537,10 +538,11 @@ void IApplicationFunctions::SetTerminateResult(Kernel::HLERequestContext& ctx) {
 }
 
 void IApplicationFunctions::GetDesiredLanguage(Kernel::HLERequestContext& ctx) {
+    // TODO(bunnei): This should be configurable
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u64>(SystemLanguage::English);
-    NGLOG_WARNING(Service_AM, "(STUBBED) called");
+    rb.Push(static_cast<u64>(Service::Set::LanguageCode::EN_US));
+    NGLOG_DEBUG(Service_AM, "called");
 }
 
 void IApplicationFunctions::InitializeGamePlayRecording(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -14,15 +14,33 @@ namespace Service::Set {
 void SET::GetAvailableLanguageCodes(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     u32 id = rp.Pop<u32>();
-    constexpr std::array<u8, 13> lang_codes{};
 
-    ctx.WriteBuffer(lang_codes.data(), lang_codes.size());
+    static constexpr std::array<LanguageCode, 17> available_language_codes = {{
+        LanguageCode::JA,
+        LanguageCode::EN_US,
+        LanguageCode::FR,
+        LanguageCode::DE,
+        LanguageCode::IT,
+        LanguageCode::ES,
+        LanguageCode::ZH_CN,
+        LanguageCode::KO,
+        LanguageCode::NL,
+        LanguageCode::PT,
+        LanguageCode::RU,
+        LanguageCode::ZH_TW,
+        LanguageCode::EN_GB,
+        LanguageCode::FR_CA,
+        LanguageCode::ES_419,
+        LanguageCode::ZH_HANS,
+        LanguageCode::ZH_HANT,
+    }};
+    ctx.WriteBuffer(available_language_codes.data(), available_language_codes.size());
 
-    IPC::ResponseBuilder rb{ctx, 2};
-
+    IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
+    rb.Push(static_cast<u64>(available_language_codes.size()));
 
-    NGLOG_WARNING(Service_SET, "(STUBBED) called");
+    NGLOG_DEBUG(Service_SET, "called");
 }
 
 SET::SET() : ServiceFramework("set") {

--- a/src/core/hle/service/set/set.h
+++ b/src/core/hle/service/set/set.h
@@ -8,6 +8,27 @@
 
 namespace Service::Set {
 
+/// This is "nn::settings::LanguageCode", which is a NUL-terminated string stored in a u64.
+enum class LanguageCode : u64 {
+    JA = 0x000000000000616A,
+    EN_US = 0x00000053552D6E65,
+    FR = 0x0000000000007266,
+    DE = 0x0000000000006564,
+    IT = 0x0000000000007469,
+    ES = 0x0000000000007365,
+    ZH_CN = 0x0000004E432D687A,
+    KO = 0x0000000000006F6B,
+    NL = 0x0000000000006C6E,
+    PT = 0x0000000000007470,
+    RU = 0x0000000000007572,
+    ZH_TW = 0x00000057542D687A,
+    EN_GB = 0x00000042472D6E65,
+    FR_CA = 0x00000041432D7266,
+    ES_419 = 0x00003931342D7365,
+    ZH_HANS = 0x00736E61482D687A,
+    ZH_HANT = 0x00746E61482D687A,
+};
+
 class SET final : public ServiceFramework<SET> {
 public:
     explicit SET();


### PR DESCRIPTION
This fixes the text in 1-2-Switch to be the returned language (as opposed to always Japanese).