### PR TITLE
Revert "core_timing: Namespace all functions and constants in core_timing's header"

### DIFF
--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -23,8 +23,6 @@
 #include "common/common_types.h"
 #include "common/logging/log.h"
 
-namespace CoreTiming {
-
 // The below clock rate is based on Switch's clockspeed being widely known as 1.020GHz
 // The exact value used is of course unverified.
 constexpr u64 BASE_CLOCK_RATE = 1019215872; // Switch clock speed is 1020MHz un/docked
@@ -118,6 +116,8 @@ inline s64 cyclesToUs(s64 cycles) {
 inline u64 cyclesToMs(s64 cycles) {
     return cycles * 1000 / BASE_CLOCK_RATE;
 }
+
+namespace CoreTiming {
 
 /**
  * CoreTiming begins at the boundary of timing slice -1. An initial call to Advance() is

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -146,8 +146,7 @@ void Thread::WakeAfterDelay(s64 nanoseconds) {
     if (nanoseconds == -1)
         return;
 
-    CoreTiming::ScheduleEvent(CoreTiming::nsToCycles(nanoseconds), ThreadWakeupEventType,
-                              callback_handle);
+    CoreTiming::ScheduleEvent(nsToCycles(nanoseconds), ThreadWakeupEventType, callback_handle);
 }
 
 void Thread::CancelWakeupTimer() {

--- a/src/core/hle/kernel/timer.cpp
+++ b/src/core/hle/kernel/timer.cpp
@@ -57,8 +57,7 @@ void Timer::Set(s64 initial, s64 interval) {
         // Immediately invoke the callback
         Signal(0);
     } else {
-        CoreTiming::ScheduleEvent(CoreTiming::nsToCycles(initial), timer_callback_event_type,
-                                  callback_handle);
+        CoreTiming::ScheduleEvent(nsToCycles(initial), timer_callback_event_type, callback_handle);
     }
 }
 
@@ -87,7 +86,7 @@ void Timer::Signal(int cycles_late) {
 
     if (interval_delay != 0) {
         // Reschedule the timer with the interval delay
-        CoreTiming::ScheduleEvent(CoreTiming::nsToCycles(interval_delay) - cycles_late,
+        CoreTiming::ScheduleEvent(nsToCycles(interval_delay) - cycles_late,
                                   timer_callback_event_type, callback_handle);
     }
 }

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -18,7 +18,7 @@ constexpr u32 sample_rate{48000};
 /// to more audio channels (probably when Docked I guess)
 constexpr u32 audio_channels{2};
 /// TODO(st4rk): find a proper value for the audio_ticks
-constexpr u64 audio_ticks{static_cast<u64>(CoreTiming::BASE_CLOCK_RATE / 500)};
+constexpr u64 audio_ticks{static_cast<u64>(BASE_CLOCK_RATE / 500)};
 
 class IAudioOut final : public ServiceFramework<IAudioOut> {
 public:

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -12,7 +12,7 @@
 namespace Service::Audio {
 
 /// TODO(bunnei): Find a proper value for the audio_ticks
-constexpr u64 audio_ticks{static_cast<u64>(CoreTiming::BASE_CLOCK_RATE / 200)};
+constexpr u64 audio_ticks{static_cast<u64>(BASE_CLOCK_RATE / 200)};
 
 class IAudioRenderer final : public ServiceFramework<IAudioRenderer> {
 public:

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -18,9 +18,9 @@ namespace Service::HID {
 
 // Updating period for each HID device.
 // TODO(shinyquagsire23): These need better values.
-constexpr u64 pad_update_ticks = CoreTiming::BASE_CLOCK_RATE / 10000;
-constexpr u64 accelerometer_update_ticks = CoreTiming::BASE_CLOCK_RATE / 10000;
-constexpr u64 gyroscope_update_ticks = CoreTiming::BASE_CLOCK_RATE / 10000;
+constexpr u64 pad_update_ticks = BASE_CLOCK_RATE / 10000;
+constexpr u64 accelerometer_update_ticks = BASE_CLOCK_RATE / 10000;
+constexpr u64 gyroscope_update_ticks = BASE_CLOCK_RATE / 10000;
 
 class IAppletResource final : public ServiceFramework<IAppletResource> {
 public:

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -19,7 +19,7 @@
 namespace Service::NVFlinger {
 
 constexpr size_t SCREEN_REFRESH_RATE = 60;
-constexpr u64 frame_ticks = static_cast<u64>(CoreTiming::BASE_CLOCK_RATE / SCREEN_REFRESH_RATE);
+constexpr u64 frame_ticks = static_cast<u64>(BASE_CLOCK_RATE / SCREEN_REFRESH_RATE);
 
 NVFlinger::NVFlinger() {
     // Add the different displays to the list of displays.

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -59,8 +59,7 @@ public:
 private:
     void GetCurrentTimePoint(Kernel::HLERequestContext& ctx) {
         NGLOG_DEBUG(Service_Time, "called");
-        SteadyClockTimePoint steady_clock_time_point{
-            CoreTiming::cyclesToMs(CoreTiming::GetTicks()) / 1000};
+        SteadyClockTimePoint steady_clock_time_point{cyclesToMs(CoreTiming::GetTicks()) / 1000};
         IPC::ResponseBuilder rb{ctx, (sizeof(SteadyClockTimePoint) / 4) + 2};
         rb.Push(RESULT_SUCCESS);
         rb.PushRaw(steady_clock_time_point);

--- a/src/core/hle/shared_page.cpp
+++ b/src/core/hle/shared_page.cpp
@@ -56,14 +56,13 @@ static void UpdateTimeCallback(u64 userdata, int cycles_late) {
 
     date_time.date_time = GetSystemTime();
     date_time.update_tick = CoreTiming::GetTicks();
-    date_time.tick_to_second_coefficient = CoreTiming::BASE_CLOCK_RATE;
+    date_time.tick_to_second_coefficient = BASE_CLOCK_RATE;
     date_time.tick_offset = 0;
 
     ++shared_page.date_time_counter;
 
     // system time is updated hourly
-    CoreTiming::ScheduleEvent(CoreTiming::msToCycles(60 * 60 * 1000) - cycles_late,
-                              update_time_event);
+    CoreTiming::ScheduleEvent(msToCycles(60 * 60 * 1000) - cycles_late, update_time_event);
 }
 
 void Init() {


### PR DESCRIPTION
Reverts yuzu-emu/yuzu#425