### PR TITLE
GPU: Don't write to invalid memory locations when handling ioctls that don't have an output.

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
@@ -39,7 +39,6 @@ u32 nvhost_as_gpu::InitalizeEx(const std::vector<u8>& input, std::vector<u8>& ou
     IoctlInitalizeEx params{};
     std::memcpy(&params, input.data(), input.size());
     NGLOG_WARNING(Service_NVDRV, "(STUBBED) called, big_page_size={:#X}", params.big_page_size);
-    std::memcpy(output.data(), &params, output.size());
     return 0;
 }
 
@@ -135,7 +134,6 @@ u32 nvhost_as_gpu::BindChannel(const std::vector<u8>& input, std::vector<u8>& ou
     std::memcpy(&params, input.data(), input.size());
     NGLOG_DEBUG(Service_NVDRV, "called, fd={:X}", params.fd);
     channel = params.fd;
-    std::memcpy(output.data(), &params, output.size());
     return 0;
 }
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
@@ -49,7 +49,6 @@ u32 nvhost_gpu::SetNVMAPfd(const std::vector<u8>& input, std::vector<u8>& output
     std::memcpy(&params, input.data(), input.size());
     NGLOG_DEBUG(Service_NVDRV, "called, fd={}", params.nvmap_fd);
     nvmap_fd = params.nvmap_fd;
-    std::memcpy(output.data(), &params, output.size());
     return 0;
 }
 
@@ -58,7 +57,6 @@ u32 nvhost_gpu::SetClientData(const std::vector<u8>& input, std::vector<u8>& out
     IoctlClientData params{};
     std::memcpy(&params, input.data(), input.size());
     user_data = params.data;
-    std::memcpy(output.data(), &params, output.size());
     return 0;
 }
 
@@ -91,7 +89,6 @@ u32 nvhost_gpu::SetErrorNotifier(const std::vector<u8>& input, std::vector<u8>& 
 u32 nvhost_gpu::SetChannelPriority(const std::vector<u8>& input, std::vector<u8>& output) {
     std::memcpy(&channel_priority, input.data(), input.size());
     NGLOG_DEBUG(Service_NVDRV, "(STUBBED) called, priority={:X}", channel_priority);
-    std::memcpy(output.data(), &channel_priority, output.size());
     return 0;
 }
 


### PR DESCRIPTION
We probably still have some memory corruption scenarios somewhere else, but it's a start.