### PR TITLE
memory_hook: Default virtual destructor in the cpp file

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -253,6 +253,7 @@ add_library(core STATIC
     loader/nso.h
     memory.cpp
     memory.h
+    memory_hook.cpp
     memory_hook.h
     memory_setup.h
     perf_stats.cpp

--- a/src/core/memory_hook.cpp
+++ b/src/core/memory_hook.cpp
@@ -1,0 +1,11 @@
+// Copyright 2018 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/memory_hook.h"
+
+namespace Memory {
+
+MemoryHook::~MemoryHook() = default;
+
+} // namespace Memory

--- a/src/core/memory_hook.h
+++ b/src/core/memory_hook.h
@@ -23,7 +23,7 @@ namespace Memory {
  */
 class MemoryHook {
 public:
-    virtual ~MemoryHook() = default;
+    virtual ~MemoryHook();
 
     virtual boost::optional<bool> IsValidAddress(VAddr addr) = 0;
 


### PR DESCRIPTION
Prevents creating multiple copies of the vtable in every translation unit that uses the class. Also silences a -Wweak-vtables warning