### PR TITLE
Added IPC RequestWithContext & ControlWithContext

### DIFF
--- a/src/core/hle/ipc.h
+++ b/src/core/hle/ipc.h
@@ -32,6 +32,8 @@ enum class CommandType : u32 {
     Close = 2,
     Request = 4,
     Control = 5,
+    RequestWithContext = 6,
+    ControlWithContext = 7,
     Unspecified,
 };
 

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -110,7 +110,9 @@ void HLERequestContext::ParseCommandBuffer(u32_le* src_cmdbuf, bool incoming) {
     // Padding to align to 16 bytes
     rp.AlignWithPadding();
 
-    if (Session()->IsDomain() && (command_header->type == IPC::CommandType::Request || !incoming)) {
+    if (Session()->IsDomain() && ((command_header->type == IPC::CommandType::Request ||
+                                   command_header->type == IPC::CommandType::RequestWithContext) ||
+                                  !incoming)) {
         // If this is an incoming message, only CommandType "Request" has a domain header
         // All outgoing domain messages have the domain header, if only incoming has it
         if (incoming || domain_message_header) {

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -144,10 +144,12 @@ ResultCode ServiceFrameworkBase::HandleSyncRequest(Kernel::HLERequestContext& co
         rb.Push(RESULT_SUCCESS);
         return ResultCode(ErrorModule::HIPC, ErrorDescription::RemoteProcessDead);
     }
+    case IPC::CommandType::ControlWithContext:
     case IPC::CommandType::Control: {
         Core::System::GetInstance().ServiceManager().InvokeControlRequest(context);
         break;
     }
+    case IPC::CommandType::RequestWithContext:
     case IPC::CommandType::Request: {
         InvokeRequest(context);
         break;


### PR DESCRIPTION
As far as I know, "Token" can be completely ignored and can still use our default IPC parser for Request & Control. This is needed for 5.x.x sysmodules and games too will need this soon enough when they start becoming 5.x.x