### PR TITLE
Properly rename functions of Fatal Module & add ThrowFatal to this module

### DIFF
--- a/src/core/hle/service/fatal/fatal.cpp
+++ b/src/core/hle/service/fatal/fatal.cpp
@@ -13,7 +13,7 @@ namespace Service::Fatal {
 Module::Interface::Interface(std::shared_ptr<Module> module, const char* name)
     : ServiceFramework(name), module(std::move(module)) {}
 
-void Module::Interface::FatalSimple(Kernel::HLERequestContext& ctx) {
+void Module::Interface::ThrowFatalWithPolicy(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     u32 error_code = rp.Pop<u32>();
     NGLOG_WARNING(Service_Fatal, "(STUBBED) called, error_code=0x{:X}", error_code);
@@ -21,7 +21,7 @@ void Module::Interface::FatalSimple(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
 }
 
-void Module::Interface::TransitionToFatalError(Kernel::HLERequestContext& ctx) {
+void Module::Interface::ThrowFatalWithCpuContext(Kernel::HLERequestContext& ctx) {
     NGLOG_WARNING(Service_Fatal, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/fatal/fatal.h
+++ b/src/core/hle/service/fatal/fatal.h
@@ -14,8 +14,8 @@ public:
     public:
         Interface(std::shared_ptr<Module> module, const char* name);
 
-        void FatalSimple(Kernel::HLERequestContext& ctx);
-        void TransitionToFatalError(Kernel::HLERequestContext& ctx);
+        void ThrowFatalWithPolicy(Kernel::HLERequestContext& ctx);
+        void ThrowFatalWithCpuContext(Kernel::HLERequestContext& ctx);
 
     protected:
         std::shared_ptr<Module> module;

--- a/src/core/hle/service/fatal/fatal_u.cpp
+++ b/src/core/hle/service/fatal/fatal_u.cpp
@@ -8,8 +8,9 @@ namespace Service::Fatal {
 
 Fatal_U::Fatal_U(std::shared_ptr<Module> module) : Module::Interface(std::move(module), "fatal:u") {
     static const FunctionInfo functions[] = {
-        {1, &Fatal_U::FatalSimple, "FatalSimple"},
-        {2, &Fatal_U::TransitionToFatalError, "TransitionToFatalError"},
+        {0, nullptr, "ThrowFatal"},
+        {1, &Fatal_U::ThrowFatalWithPolicy, "ThrowFatalWithPolicy"},
+        {2, &Fatal_U::ThrowFatalWithCpuContext, "ThrowFatalWithCpuContext"},
     };
     RegisterHandlers(functions);
 }


### PR DESCRIPTION
I have rename these functions and add ThrowFatal according to switchbrew : http://switchbrew.org/index.php?title=Fatal_services