### PR TITLE
GLRenderer: Remove unused vertex buffer and increase the size of the stream buffer to 128 MB.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -75,14 +75,11 @@ RasterizerOpenGL::RasterizerOpenGL() {
     // Clipping plane 0 is always enabled for PICA fixed clip plane z <= 0
     state.clip_distance[0] = true;
 
-    // Generate VBO, VAO and UBO
-    vertex_buffer = OGLStreamBuffer::MakeBuffer(GLAD_GL_ARB_buffer_storage, GL_ARRAY_BUFFER);
-    vertex_buffer->Create(VERTEX_BUFFER_SIZE, VERTEX_BUFFER_SIZE / 2);
+    // Generate VAO and UBO
     sw_vao.Create();
     uniform_buffer.Create();
 
     state.draw.vertex_array = sw_vao.handle;
-    state.draw.vertex_buffer = vertex_buffer->GetHandle();
     state.draw.uniform_buffer = uniform_buffer.handle;
     state.Apply();
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -87,7 +87,6 @@ RasterizerOpenGL::RasterizerOpenGL() {
     framebuffer.Create();
 
     hw_vao.Create();
-    hw_vao_enabled_attributes.fill(false);
 
     stream_buffer = OGLStreamBuffer::MakeBuffer(has_ARB_buffer_storage, GL_ARRAY_BUFFER);
     stream_buffer->Create(STREAM_BUFFER_SIZE, STREAM_BUFFER_SIZE / 2);
@@ -178,8 +177,6 @@ std::pair<u8*, GLintptr> RasterizerOpenGL::SetupVertexArrays(u8* array_ptr,
         glVertexAttribFormat(index, attrib.ComponentCount(), MaxwellToGL::VertexType(attrib),
                              attrib.IsNormalized() ? GL_TRUE : GL_FALSE, attrib.offset);
         glVertexAttribBinding(index, attrib.buffer);
-
-        hw_vao_enabled_attributes[index] = true;
     }
 
     return {array_ptr, buffer_offset};

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -141,13 +141,10 @@ private:
                Tegra::Engines::Maxwell3D::Regs::MaxShaderStage>
         ssbos;
 
-    static constexpr size_t VERTEX_BUFFER_SIZE = 128 * 1024 * 1024;
-    std::unique_ptr<OGLStreamBuffer> vertex_buffer;
+    static constexpr size_t STREAM_BUFFER_SIZE = 128 * 1024 * 1024;
+    std::unique_ptr<OGLStreamBuffer> stream_buffer;
     OGLBuffer uniform_buffer;
     OGLFramebuffer framebuffer;
-
-    static constexpr size_t STREAM_BUFFER_SIZE = 4 * 1024 * 1024;
-    std::unique_ptr<OGLStreamBuffer> stream_buffer;
 
     size_t CalculateVertexArraysSize() const;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -134,7 +134,6 @@ private:
     std::unique_ptr<GLShader::ProgramManager> shader_program_manager;
     OGLVertexArray sw_vao;
     OGLVertexArray hw_vao;
-    std::array<bool, 16> hw_vao_enabled_attributes;
 
     std::array<SamplerInfo, GLShader::NumTextureSamplers> texture_samplers;
     std::array<std::array<OGLBuffer, Tegra::Engines::Maxwell3D::Regs::MaxConstBuffers>,


### PR DESCRIPTION
The stream buffer is where all the vertex data is copied, some games require this to be much bigger than the 4 MB we used to have.