### PR TITLE
Mutex: Do not assert when the mutex waiting threads list isn't empty on mutex release.

### DIFF
--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -104,7 +104,6 @@ ResultCode Mutex::Release(VAddr address) {
 
     // There are no more threads waiting for the mutex, release it completely.
     if (thread == nullptr) {
-        ASSERT(GetCurrentThread()->wait_mutex_threads.empty());
         Memory::Write32(address, 0);
         return RESULT_SUCCESS;
     }


### PR DESCRIPTION
A thread may own multiple mutexes at the same time, and only release one of them while other threads are waiting for the other mutexes.