### PR TITLE
Fix deadlocks caused from HID having too many layouts

### DIFF
--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -12,7 +12,7 @@ namespace Service::HID {
 // Begin enums and output structs
 
 constexpr u32 HID_NUM_ENTRIES = 17;
-constexpr u32 HID_NUM_LAYOUTS = 7;
+constexpr u32 HID_NUM_LAYOUTS = 2;
 constexpr s32 HID_JOYSTICK_MAX = 0x8000;
 constexpr s32 HID_JOYSTICK_MIN = -0x8000;
 


### PR DESCRIPTION
Games such as SMO deadlock if we have more than 2 layouts