### PR TITLE
Use Ninja for Travis builds

### DIFF
--- a/.travis/linux/docker.sh
+++ b/.travis/linux/docker.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 apt-get update
-apt-get install -y build-essential git libqt5opengl5-dev libsdl2-dev libssl-dev python qtbase5-dev wget
+apt-get install -y build-essential git libqt5opengl5-dev libsdl2-dev libssl-dev python qtbase5-dev wget ninja-build
 
 # Get a recent version of CMake
 wget https://cmake.org/files/v3.10/cmake-3.10.1-Linux-x86_64.sh
@@ -10,7 +10,7 @@ sh cmake-3.10.1-Linux-x86_64.sh --exclude-subdir --prefix=/ --skip-license
 cd /yuzu
 
 mkdir build && cd build
-cmake .. -DYUZU_BUILD_UNICORN=ON -DCMAKE_BUILD_TYPE=Release
-make -j4
+cmake .. -DYUZU_BUILD_UNICORN=ON -DCMAKE_BUILD_TYPE=Release -G Ninja
+ninja
 
 ctest -VV -C Release


### PR DESCRIPTION
`ninja` is _the fast_ build system. It trades run-time complexity of `make` for simple rules with very limited logic that are generated by a more sentient system, like CMake. In practice that means more of CPUs' duty cycle is spent in the compiler and not in the build system resulting in faster builds.

[This build](https://travis-ci.org/yuzu-emu/yuzu/builds/384673023) completed in 13m47s, [one of the recent builds](https://travis-ci.org/yuzu-emu/yuzu/builds/384502149) took 14m19s. Note the improvement may not be as pronounced due to noisy environment and the quoted time including downloading and setup of build environment.