### PR TITLE
Kernel/SVC: Corrected the behavior of svcSetThreadCoreMask for core values -2 and -3.

### DIFF
--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -21,7 +21,9 @@ enum {
 
     // Confirmed Switch OS error codes
     MisalignedAddress = 102,
+    InvalidProcessorId = 113,
     InvalidHandle = 114,
+    InvalidCombination = 116,
     Timeout = 117,
     SynchronizationCanceled = 118,
     TooLarge = 119,

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -460,13 +460,13 @@ void Thread::UpdatePriority() {
 
 void Thread::ChangeCore(u32 core, u64 mask) {
     ideal_core = core;
-    mask = mask;
+    affinity_mask = mask;
 
     if (status != THREADSTATUS_READY) {
         return;
     }
 
-    boost::optional<s32> new_processor_id{GetNextProcessorId(mask)};
+    boost::optional<s32> new_processor_id{GetNextProcessorId(affinity_mask)};
 
     if (!new_processor_id) {
         new_processor_id = processor_id;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -476,7 +476,7 @@ void Thread::ChangeCore(u32 core, u64 mask) {
         new_processor_id = ideal_core;
     }
 
-    ASSERT(new_processor_id < 4);
+    ASSERT(*new_processor_id < 4);
 
     // Add thread to new core's scheduler
     auto& next_scheduler = Core::System().GetInstance().Scheduler(*new_processor_id);


### PR DESCRIPTION
-2 means 'Use the default core from the parent process'.
-3 means 'Don't change the ideal core, only update the mask'.