### PR TITLE
add check for GL extension support

### DIFF
--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -79,6 +79,7 @@ private:
     void ConnectWidgetEvents();
     void ConnectMenuEvents();
 
+    bool SupportsRequiredGLExtensions();
     bool LoadROM(const QString& filename);
     void BootGame(const QString& filename);
     void ShutdownGame();

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
@@ -78,6 +78,24 @@ void EmuWindow_SDL2::Fullscreen() {
     SDL_MaximizeWindow(render_window);
 }
 
+bool EmuWindow_SDL2::SupportsRequiredGLExtensions() {
+    std::vector<std::string> unsupported_ext;
+
+    if (!GLAD_GL_ARB_program_interface_query)
+        unsupported_ext.push_back("ARB_program_interface_query");
+    if (!GLAD_GL_ARB_separate_shader_objects)
+        unsupported_ext.push_back("ARB_separate_shader_objects");
+    if (!GLAD_GL_ARB_shader_storage_buffer_object)
+        unsupported_ext.push_back("ARB_shader_storage_buffer_object");
+    if (!GLAD_GL_ARB_vertex_attrib_binding)
+        unsupported_ext.push_back("ARB_vertex_attrib_binding");
+
+    for (const std::string& ext : unsupported_ext)
+        NGLOG_CRITICAL(Frontend, "Unsupported GL extension: {}", ext);
+
+    return unsupported_ext.empty();
+}
+
 EmuWindow_SDL2::EmuWindow_SDL2(bool fullscreen) {
     InputCommon::Init();
 
@@ -125,6 +143,11 @@ EmuWindow_SDL2::EmuWindow_SDL2(bool fullscreen) {
 
     if (!gladLoadGLLoader(static_cast<GLADloadproc>(SDL_GL_GetProcAddress))) {
         NGLOG_CRITICAL(Frontend, "Failed to initialize GL functions! Exiting...");
+        exit(1);
+    }
+
+    if (!SupportsRequiredGLExtensions()) {
+        NGLOG_CRITICAL(Frontend, "GPU does not support all required OpenGL extensions! Exiting...");
         exit(1);
     }
 

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.h
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.h
@@ -46,6 +46,9 @@ private:
     /// Called when user passes the fullscreen parameter flag
     void Fullscreen();
 
+    /// Whether the GPU and driver supports the OpenGL extension required
+    bool SupportsRequiredGLExtensions();
+
     /// Called when a configuration change affects the minimal size of the window
     void OnMinimalClientAreaChangeRequest(
         const std::pair<unsigned, unsigned>& minimal_size) override;


### PR DESCRIPTION
Checks if the hardware supports supports the required OpenGL extensions before the game attempts to boot.
![image](https://user-images.githubusercontent.com/28246325/40746364-e5060c0e-641f-11e8-9798-bcb3bd016ac0.png)
resolves #336 