### PR TITLE
gl_shader_decompiler: Implement TEX, fixes for TEXS.

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -261,6 +261,11 @@ union Instruction {
         BitField<50, 1, u64> saturate_a;
     } conversion;
 
+    union {
+        // TODO(bunnei): This is just a guess, needs to be verified
+        BitField<52, 1, u64> enable_g_component;
+    } texs;
+
     BitField<61, 1, u64> is_b_imm;
     BitField<60, 1, u64> is_b_gpr;
     BitField<59, 1, u64> is_c_gpr;

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -262,6 +262,14 @@ union Instruction {
     } conversion;
 
     union {
+        BitField<31, 4, u64> component_mask;
+
+        bool IsComponentEnabled(size_t component) const {
+            return ((1 << component) & component_mask) != 0;
+        }
+    } tex;
+
+    union {
         // TODO(bunnei): This is just a guess, needs to be verified
         BitField<52, 1, u64> enable_g_component;
     } texs;
@@ -286,6 +294,7 @@ public:
         KIL,
         LD_A,
         ST_A,
+        TEX,
         TEXQ, // Texture Query
         TEXS, // Texture Fetch with scalar/non-vec4 source/destinations
         TLDS, // Texture Load with scalar/non-vec4 source/destinations
@@ -447,6 +456,7 @@ private:
             INST("111000110011----", Id::KIL, Type::Flow, "KIL"),
             INST("1110111111011---", Id::LD_A, Type::Memory, "LD_A"),
             INST("1110111111110---", Id::ST_A, Type::Memory, "ST_A"),
+            INST("1100000000111---", Id::TEX, Type::Memory, "TEX"),
             INST("1101111101001---", Id::TEXQ, Type::Memory, "TEXQ"),
             INST("1101100---------", Id::TEXS, Type::Memory, "TEXS"),
             INST("1101101---------", Id::TLDS, Type::Memory, "TLDS"),


### PR DESCRIPTION
Summary of changes:
* Implement TEX shader instruction.
* Add support for both destination registers for TEXS shader instruction.
* There are some unverified assumptions here, denoted with TODOs. However, I tested with all games known to show graphics - no regressions.

With these changes, the videos in Sonic Mania are now fixed, making this game appear to be graphically complete in yuzu. Obligatory screenshot:

![image](https://user-images.githubusercontent.com/6956688/40819816-18d21260-652b-11e8-9120-c8cc1ea59d8c.png)


