### PR TITLE
Nvdrv/devices/nvhost_gpu : Add some IoctlCommands with their params

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
@@ -63,13 +63,13 @@ private:
         u32_le timeout;
     };
     static_assert(sizeof(IoctlChannelSetTimeout) == 4, "IoctlChannelSetTimeout is incorrect size");
-    
+
     struct IoctlAllocGPFIFO {
         u32_le num_entries;
         u32_le flags;
     };
     static_assert(sizeof(IoctlAllocGPFIFO) == 8, "IoctlAllocGPFIFO is incorrect size");
-    
+
     struct IoctlClientData {
         u64_le data;
     };
@@ -89,18 +89,18 @@ private:
         INSERT_PADDING_WORDS(1);
     };
     static_assert(sizeof(IoctlSetErrorNotifier) == 24, "IoctlSetErrorNotifier is incorrect size");
-    
+
     struct IoctlChannelSetPriority {
         u32_le priority;
     };
     static_assert(sizeof(IoctlChannelSetPriority) == 4, "IoctlChannelSetPriority is incorrect size");
-    
+
     struct IoctlEventIdControl {
         u32_le cmd;    // 0=disable, 1=enable, 2=clear
         u32_le id;
     };
     static_assert(sizeof(IoctlEventIdControl) == 8, "IoctlEventIdControl is incorrect size");
-    
+
     struct IoctlGetErrorNotification {
         u64_le timestamp;
         u32_le info32;
@@ -108,13 +108,13 @@ private:
         u16_le status;       // always 0xFFFF
     };
     static_assert(sizeof(IoctlGetErrorNotification) == 16, "IoctlGetErrorNotification is incorrect size");
-    
+
     struct IoctlFence {
         u32_le id;
         u32_le value;
     };
     static_assert(sizeof(IoctlFence) == 8, "IoctlFence is incorrect size");
-    
+
     struct IoctlAllocGpfifoEx {
         u32_le num_entries;
         u32_le flags;

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
@@ -93,7 +93,8 @@ private:
     struct IoctlChannelSetPriority {
         u32_le priority;
     };
-    static_assert(sizeof(IoctlChannelSetPriority) == 4, "IoctlChannelSetPriority is incorrect size");
+    static_assert(sizeof(IoctlChannelSetPriority) == 4,
+                  "IoctlChannelSetPriority is incorrect size");
 
     struct IoctlEventIdControl {
         u32_le cmd; // 0=disable, 1=enable, 2=clear
@@ -125,7 +126,7 @@ private:
         u32_le unk3;
         u32_le unk4;
         u32_le unk5;
-     };
+    };
     static_assert(sizeof(IoctlAllocGpfifoEx) == 32, "IoctlAllocGpfifoEx is incorrect size");
 
     struct IoctlAllocGpfifoEx2 {

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
@@ -96,7 +96,7 @@ private:
     static_assert(sizeof(IoctlChannelSetPriority) == 4, "IoctlChannelSetPriority is incorrect size");
 
     struct IoctlEventIdControl {
-        u32_le cmd;    // 0=disable, 1=enable, 2=clear
+        u32_le cmd; // 0=disable, 1=enable, 2=clear
         u32_le id;
     };
     static_assert(sizeof(IoctlEventIdControl) == 8, "IoctlEventIdControl is incorrect size");
@@ -105,9 +105,10 @@ private:
         u64_le timestamp;
         u32_le info32;
         u16_le info16;
-        u16_le status;       // always 0xFFFF
+        u16_le status; // always 0xFFFF
     };
-    static_assert(sizeof(IoctlGetErrorNotification) == 16, "IoctlGetErrorNotification is incorrect size");
+    static_assert(sizeof(IoctlGetErrorNotification) == 16, 
+                  "IoctlGetErrorNotification is incorrect size");
 
     struct IoctlFence {
         u32_le id;

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
@@ -97,16 +97,15 @@ private:
     
     struct IoctlEventIdControl {
         u32_le cmd;    // 0=disable, 1=enable, 2=clear
-        u32_le id;     
-        
+        u32_le id;
     };
     static_assert(sizeof(IoctlEventIdControl) == 8, "IoctlEventIdControl is incorrect size");
     
     struct IoctlGetErrorNotification {
-        u64_le timestamp;    
-        u32_le info32;       
-        u16_le info16;       
-        u16_le status;       // always 0xFFFF       
+        u64_le timestamp;
+        u32_le info32;
+        u16_le info16;
+        u16_le status;       // always 0xFFFF
     };
     static_assert(sizeof(IoctlGetErrorNotification) == 16, "IoctlGetErrorNotification is incorrect size");
     

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
@@ -26,11 +26,19 @@ public:
 private:
     enum class IoctlCommand : u32_le {
         IocSetNVMAPfdCommand = 0x40044801,
+        IocAllocGPFIFOCommand = 0x40084805,
         IocSetClientDataCommand = 0x40084714,
         IocGetClientDataCommand = 0x80084715,
         IocZCullBind = 0xc010480b,
         IocSetErrorNotifierCommand = 0xC018480C,
         IocChannelSetPriorityCommand = 0x4004480D,
+        IocEnableCommand = 0x0000480E,
+        IocDisableCommand = 0x0000480F,
+        IocPreemptCommand = 0x00004810,
+        IocForceResetCommand = 0x00004811,
+        IocEventIdControlCommand = 0x40084812,
+        IocGetErrorNotificationCommand = 0xC0104817,
+        IocAllocGPFIFOExCommand = 0x40204818,
         IocAllocGPFIFOEx2Command = 0xC020481A,
         IocAllocObjCtxCommand = 0xC0104809,
         IocChannelGetWaitbaseCommand = 0xC0080003,
@@ -55,7 +63,13 @@ private:
         u32_le timeout;
     };
     static_assert(sizeof(IoctlChannelSetTimeout) == 4, "IoctlChannelSetTimeout is incorrect size");
-
+    
+    struct IoctlAllocGPFIFO {
+        u32_le num_entries;
+        u32_le flags;
+    };
+    static_assert(sizeof(IoctlAllocGPFIFO) == 8, "IoctlAllocGPFIFO is incorrect size");
+    
     struct IoctlClientData {
         u64_le data;
     };
@@ -75,12 +89,44 @@ private:
         INSERT_PADDING_WORDS(1);
     };
     static_assert(sizeof(IoctlSetErrorNotifier) == 24, "IoctlSetErrorNotifier is incorrect size");
-
+    
+    struct IoctlChannelSetPriority {
+        u32_le priority;
+    };
+    static_assert(sizeof(IoctlChannelSetPriority) == 4, "IoctlChannelSetPriority is incorrect size");
+    
+    struct IoctlEventIdControl {
+        u32_le cmd;    // 0=disable, 1=enable, 2=clear
+        u32_le id;     
+        
+    };
+    static_assert(sizeof(IoctlEventIdControl) == 8, "IoctlEventIdControl is incorrect size");
+    
+    struct IoctlGetErrorNotification {
+        u64_le timestamp;    
+        u32_le info32;       
+        u16_le info16;       
+        u16_le status;       // always 0xFFFF       
+    };
+    static_assert(sizeof(IoctlGetErrorNotification) == 16, "IoctlGetErrorNotification is incorrect size");
+    
     struct IoctlFence {
         u32_le id;
         u32_le value;
     };
     static_assert(sizeof(IoctlFence) == 8, "IoctlFence is incorrect size");
+    
+    struct IoctlAllocGpfifoEx {
+        u32_le num_entries;
+        u32_le flags;
+        u32_le unk0;
+        u32_le unk1;
+        u32_le unk2;
+        u32_le unk3;
+        u32_le unk4;
+        u32_le unk5;
+     };
+    static_assert(sizeof(IoctlAllocGpfifoEx) == 32, "IoctlAllocGpfifoEx is incorrect size");
 
     struct IoctlAllocGpfifoEx2 {
         u32_le num_entries;   // in

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
@@ -107,7 +107,7 @@ private:
         u16_le info16;
         u16_le status; // always 0xFFFF
     };
-    static_assert(sizeof(IoctlGetErrorNotification) == 16, 
+    static_assert(sizeof(IoctlGetErrorNotification) == 16,
                   "IoctlGetErrorNotification is incorrect size");
 
     struct IoctlFence {


### PR DESCRIPTION
according to switchbrew : 
http://switchbrew.org/index.php?title=NV_services#Channel_Ioctls

Should also be rebase because nvhost_gpu, nvhost-vic, nvhost-nvdec, nvhost-nvjpg use the same IoctlCommands.