### PR TITLE
Revert "Port citra #3616"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ build_script:
           # https://www.appveyor.com/docs/build-phase
           msbuild msvc_build/yuzu.sln /maxcpucount /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
         } else {
-          C:\msys64\usr\bin\bash.exe -lc 'mingw32-make -j4 -C mingw_build/ 2>&1'
+          C:\msys64\usr\bin\bash.exe -lc 'mingw32-make -C mingw_build/ 2>&1'
         }
 
 after_build:


### PR DESCRIPTION
Reverts yuzu-emu/yuzu#507

This broke mingw builds. @jroweboy (or someone else), feel free to submit a followup fix if you understand the issue. Log: https://ci.appveyor.com/project/yuzubot/yuzu-nightly/build/1.0.671