### PR TITLE
GPU: Fixed ghosting when drawing with blending disabled

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -318,6 +318,7 @@ public:
             Equation equation_a;
             Factor factor_source_a;
             Factor factor_dest_a;
+            INSERT_PADDING_WORDS(1);
         };
 
         union {
@@ -432,7 +433,27 @@ public:
                     };
                 } rt_control;
 
-                INSERT_PADDING_WORDS(0xCF);
+                INSERT_PADDING_WORDS(0x31);
+
+                u32 independent_blend_enable;
+
+                INSERT_PADDING_WORDS(0x15);
+
+                struct {
+                    u32 separate_alpha;
+                    Blend::Equation equation_rgb;
+                    Blend::Factor factor_source_rgb;
+                    Blend::Factor factor_dest_rgb;
+                    Blend::Equation equation_a;
+                    Blend::Factor factor_source_a;
+                    INSERT_PADDING_WORDS(1);
+                    Blend::Factor factor_dest_a;
+
+                    u32 enable_common;
+                    u32 enable[NumRenderTargets];
+                } blend;
+
+                INSERT_PADDING_WORDS(0x77);
 
                 struct {
                     u32 tsc_address_high;
@@ -557,9 +578,7 @@ public:
 
                 } vertex_array[NumVertexArrays];
 
-                Blend blend;
-
-                INSERT_PADDING_WORDS(0x39);
+                Blend independent_blend[NumRenderTargets];
 
                 struct {
                     u32 limit_high;
@@ -722,6 +741,8 @@ ASSERT_REG_POSITION(vertex_buffer, 0x35D);
 ASSERT_REG_POSITION(zeta, 0x3F8);
 ASSERT_REG_POSITION(vertex_attrib_format[0], 0x458);
 ASSERT_REG_POSITION(rt_control, 0x487);
+ASSERT_REG_POSITION(independent_blend_enable, 0x4B9);
+ASSERT_REG_POSITION(blend, 0x4CF);
 ASSERT_REG_POSITION(tsc, 0x557);
 ASSERT_REG_POSITION(tic, 0x55D);
 ASSERT_REG_POSITION(code_address, 0x582);
@@ -729,7 +750,7 @@ ASSERT_REG_POSITION(draw, 0x585);
 ASSERT_REG_POSITION(index_array, 0x5F2);
 ASSERT_REG_POSITION(query, 0x6C0);
 ASSERT_REG_POSITION(vertex_array[0], 0x700);
-ASSERT_REG_POSITION(blend, 0x780);
+ASSERT_REG_POSITION(independent_blend, 0x780);
 ASSERT_REG_POSITION(vertex_array_limit[0], 0x7C0);
 ASSERT_REG_POSITION(shader_config[0], 0x800);
 ASSERT_REG_POSITION(const_buffer, 0x8E0);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -455,32 +455,7 @@ void RasterizerOpenGL::DrawArrays() {
     }
 }
 
-void RasterizerOpenGL::NotifyMaxwellRegisterChanged(u32 method) {
-    const auto& regs = Core::System().GetInstance().GPU().Maxwell3D().regs;
-    switch (method) {
-    case MAXWELL3D_REG_INDEX(blend.separate_alpha):
-        ASSERT_MSG(false, "unimplemented");
-        break;
-    case MAXWELL3D_REG_INDEX(blend.equation_rgb):
-        state.blend.rgb_equation = MaxwellToGL::BlendEquation(regs.blend.equation_rgb);
-        break;
-    case MAXWELL3D_REG_INDEX(blend.factor_source_rgb):
-        state.blend.src_rgb_func = MaxwellToGL::BlendFunc(regs.blend.factor_source_rgb);
-        break;
-    case MAXWELL3D_REG_INDEX(blend.factor_dest_rgb):
-        state.blend.dst_rgb_func = MaxwellToGL::BlendFunc(regs.blend.factor_dest_rgb);
-        break;
-    case MAXWELL3D_REG_INDEX(blend.equation_a):
-        state.blend.a_equation = MaxwellToGL::BlendEquation(regs.blend.equation_a);
-        break;
-    case MAXWELL3D_REG_INDEX(blend.factor_source_a):
-        state.blend.src_a_func = MaxwellToGL::BlendFunc(regs.blend.factor_source_a);
-        break;
-    case MAXWELL3D_REG_INDEX(blend.factor_dest_a):
-        state.blend.dst_a_func = MaxwellToGL::BlendFunc(regs.blend.factor_dest_a);
-        break;
-    }
-}
+void RasterizerOpenGL::NotifyMaxwellRegisterChanged(u32 method) {}
 
 void RasterizerOpenGL::FlushAll() {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -121,14 +121,8 @@ private:
     /// Syncs the depth offset to match the guest state
     void SyncDepthOffset();
 
-    /// Syncs the blend enabled status to match the guest state
-    void SyncBlendEnabled();
-
-    /// Syncs the blend functions to match the guest state
-    void SyncBlendFuncs();
-
-    /// Syncs the blend color to match the guest state
-    void SyncBlendColor();
+    /// Syncs the blend state to match the guest state
+    void SyncBlendState();
 
     bool has_ARB_buffer_storage;
     bool has_ARB_direct_state_access;


### PR DESCRIPTION
This fixes the Splatoon 2's elongated squids during the boot screen.