### PR TITLE
GPU: Stub the SSY shader instruction.

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -410,6 +410,7 @@ class OpCode {
 public:
     enum class Id {
         KIL,
+        SSY,
         BFE_C,
         BFE_R,
         BFE_IMM,
@@ -596,6 +597,7 @@ private:
         std::vector<Matcher> table = {
 #define INST(bitstring, op, type, name) Detail::GetMatcher(bitstring, op, type, name)
             INST("111000110011----", Id::KIL, Type::Flow, "KIL"),
+            INST("111000101001----", Id::SSY, Type::Flow, "SSY"),
             INST("111000100100----", Id::BRA, Type::Flow, "BRA"),
             INST("1110111111011---", Id::LD_A, Type::Memory, "LD_A"),
             INST("1110111110010---", Id::LD_C, Type::Memory, "LD_C"),

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1435,6 +1435,11 @@ private:
                 regs.SetRegisterToInputAttibute(instr.gpr0, attribute.element, attribute.index);
                 break;
             }
+            case OpCode::Id::SSY: {
+                // The SSY opcode tells the GPU where to re-converge divergent execution paths, we
+                // can ignore this when generating GLSL code.
+                break;
+            }
             default: {
                 NGLOG_CRITICAL(HW_GPU, "Unhandled instruction: {}", opcode->GetName());
                 UNREACHABLE();


### PR DESCRIPTION
This instruction tells the GPU where the flow reconverges in a non-uniform control flow scenario, we can ignore this when generating GLSL code.