### PR TITLE
hid: Update all layouts and only show handheld as connected, fixes libnx input for P1_AUTO

### DIFF
--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -94,7 +94,6 @@ private:
                 layout.header.latest_entry = (layout.header.latest_entry + 1) % HID_NUM_ENTRIES;
 
                 ControllerInputEntry& entry = layout.entries[layout.header.latest_entry];
-                entry.connection_state = ConnectionState_Connected | ConnectionState_Wired;
                 entry.timestamp++;
                 // TODO(shinyquagsire23): Is this always identical to timestamp?
                 entry.timestamp_2++;
@@ -102,6 +101,8 @@ private:
                 // TODO(shinyquagsire23): More than just handheld input
                 if (controller != Controller_Handheld)
                     continue;
+
+                entry.connection_state = ConnectionState_Connected | ConnectionState_Wired;
 
                 // TODO(shinyquagsire23): Set up some LUTs for each layout mapping in the future?
                 // For now everything is just the default handheld layout, but split Joy-Con will

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -12,7 +12,7 @@ namespace Service::HID {
 // Begin enums and output structs
 
 constexpr u32 HID_NUM_ENTRIES = 17;
-constexpr u32 HID_NUM_LAYOUTS = 2;
+constexpr u32 HID_NUM_LAYOUTS = 7;
 constexpr s32 HID_JOYSTICK_MAX = 0x8000;
 constexpr s32 HID_JOYSTICK_MIN = -0x8000;
 


### PR DESCRIPTION
Probably breaks SMO but it's not like the input is working there anyhow, find a better "fix" pls.