### PR TITLE
Services/FS: Return the correct error code when trying to mount a nonexistent savedata.

### DIFF
--- a/src/core/file_sys/errors.h
+++ b/src/core/file_sys/errors.h
@@ -11,6 +11,7 @@ namespace FileSys {
 namespace ErrCodes {
 enum {
     NotFound = 1,
+    SaveDataNotFound = 1002,
 };
 }
 


### PR DESCRIPTION
We still have to test what exactly AM::EnsureSaveData does.