### PR TITLE
Avoid initializing single-joycon layouts with handheld controller

### DIFF
--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -16,6 +16,14 @@
 
 namespace Service::HID {
 
+int GetNumberLayoutsForController(size_t controller_id) {
+    if (controller_id == Controller_Handheld) {
+        return HID_NUM_LAYOUTS_HANDHELD;
+    } else {
+        return HID_NUM_LAYOUTS;
+    }
+}
+
 // Updating period for each HID device.
 // TODO(shinyquagsire23): These need better values.
 constexpr u64 pad_update_ticks = CoreTiming::BASE_CLOCK_RATE / 10000;
@@ -83,10 +91,7 @@ private:
         controller_header.left_color_buttons = JOYCON_BUTTONS_NEON_BLUE;
 
         for (size_t controller = 0; controller < mem.controllers.size(); controller++) {
-            for (int index = 0;
-                 index <
-                 (controller != Controller_Handheld ? HID_NUM_LAYOUTS : HID_NUM_LAYOUTS_HANDHELD);
-                 index++) {
+            for (int index = 0; index < GetNumberLayoutsForController(controller); index++) {
                 ControllerLayout& layout = mem.controllers[controller].layouts[index];
                 layout.header.num_entries = HID_NUM_ENTRIES;
                 layout.header.max_entry_index = HID_NUM_ENTRIES - 1;

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -83,7 +83,10 @@ private:
         controller_header.left_color_buttons = JOYCON_BUTTONS_NEON_BLUE;
 
         for (size_t controller = 0; controller < mem.controllers.size(); controller++) {
-            for (int index = 0; index < HID_NUM_LAYOUTS; index++) {
+            for (int index = 0;
+                 index <
+                 (controller != Controller_Handheld ? HID_NUM_LAYOUTS : HID_NUM_LAYOUTS_HANDHELD);
+                 index++) {
                 ControllerLayout& layout = mem.controllers[controller].layouts[index];
                 layout.header.num_entries = HID_NUM_ENTRIES;
                 layout.header.max_entry_index = HID_NUM_ENTRIES - 1;

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -16,14 +16,6 @@
 
 namespace Service::HID {
 
-int GetNumberLayoutsForController(size_t controller_id) {
-    if (controller_id == Controller_Handheld) {
-        return HID_NUM_LAYOUTS_HANDHELD;
-    } else {
-        return HID_NUM_LAYOUTS;
-    }
-}
-
 // Updating period for each HID device.
 // TODO(shinyquagsire23): These need better values.
 constexpr u64 pad_update_ticks = CoreTiming::BASE_CLOCK_RATE / 10000;
@@ -91,7 +83,11 @@ private:
         controller_header.left_color_buttons = JOYCON_BUTTONS_NEON_BLUE;
 
         for (size_t controller = 0; controller < mem.controllers.size(); controller++) {
-            for (int index = 0; index < GetNumberLayoutsForController(controller); index++) {
+            for (int index = 0; index < HID_NUM_LAYOUTS; index++) {
+                // TODO(DarkLordZach): Is this layout/controller config actually invalid?
+                if (controller == Controller_Handheld && index == Layout_Single)
+                    continue;
+
                 ControllerLayout& layout = mem.controllers[controller].layouts[index];
                 layout.header.num_entries = HID_NUM_ENTRIES;
                 layout.header.max_entry_index = HID_NUM_ENTRIES - 1;

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -13,7 +13,6 @@ namespace Service::HID {
 
 constexpr u32 HID_NUM_ENTRIES = 17;
 constexpr u32 HID_NUM_LAYOUTS = 7;
-constexpr u32 HID_NUM_LAYOUTS_HANDHELD = 2;
 constexpr s32 HID_JOYSTICK_MAX = 0x8000;
 constexpr s32 HID_JOYSTICK_MIN = -0x8000;
 

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -13,6 +13,7 @@ namespace Service::HID {
 
 constexpr u32 HID_NUM_ENTRIES = 17;
 constexpr u32 HID_NUM_LAYOUTS = 7;
+constexpr u32 HID_NUM_LAYOUTS_HANDHELD = 2;
 constexpr s32 HID_JOYSTICK_MAX = 0x8000;
 constexpr s32 HID_JOYSTICK_MIN = -0x8000;
 


### PR DESCRIPTION
This fixes the odyssey crash introduced by #557.

(this explanation might be 100% wrong sorry)

So, when initializing the layouts for controllers in the hid module, right now it initializes all layouts on all controllers. However, it is not possible with the hardware to have a single joycon layout (id # 3, 4, or 5) with the handheld controller (Switch OS does not allow it). I added a check in the loop to see if its the handheld and if it is, not try to make the extra layouts. Apparently odyssey uses this and crashes on it for some reason.