### PR TITLE
Add UI support for extracted NCA folders

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -265,8 +265,17 @@ void GameList::ValidateEntry(const QModelIndex& item) {
     if (file_path.isEmpty())
         return;
     std::string std_file_path(file_path.toStdString());
-    if (!FileUtil::Exists(std_file_path) || FileUtil::IsDirectory(std_file_path))
+    if (!FileUtil::Exists(std_file_path))
         return;
+    if (FileUtil::IsDirectory(std_file_path)) {
+        QDir dir(std_file_path.c_str());
+        QStringList matching_main = dir.entryList(QStringList("main"), QDir::Files);
+        if (matching_main.size() == 1) {
+            emit GameChosen(dir.path() + DIR_SEP + matching_main[0]);
+        }
+        return;
+    }
+
     // Users usually want to run a diffrent game after closing one
     search_field->clear();
     emit GameChosen(file_path);
@@ -368,10 +377,10 @@ static bool IsExtractedNCAMain(const std::string& file_name) {
     return QFileInfo(file_name.c_str()).fileName() == "main";
 }
 
-static QString FormatGameName(std::string physical_name) {
-    QFileInfo fileInfo(physical_name.c_str());
+static QString FormatGameName(const std::string& physical_name) {
+    QFileInfo file_info(physical_name.c_str());
     if (IsExtractedNCAMain(physical_name)) {
-        return fileInfo.dir().dirName();
+        return file_info.dir().path();
     } else {
         return QString::fromStdString(physical_name);
     }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -13,6 +13,7 @@
 #include <QMessageBox>
 #include <QtGui>
 #include <QtWidgets>
+#include "common/common_paths.h"
 #include "common/logging/backend.h"
 #include "common/logging/filter.h"
 #include "common/logging/log.h"
@@ -568,9 +569,12 @@ void GMainWindow::OnMenuLoadFile() {
 void GMainWindow::OnMenuLoadFolder() {
     QDir dir = QFileDialog::getExistingDirectory(this, tr("Open Extracted ROM Directory"));
 
-    QStringList matchingMain = dir.entryList(QStringList() << "main", QDir::Files);
-    if (matchingMain.size() == 1) {
-        BootGame(matchingMain[0]);
+    QStringList matching_main = dir.entryList(QStringList("main"), QDir::Files);
+    if (matching_main.size() == 1) {
+        BootGame(dir.path() + DIR_SEP + matching_main[0]);
+    } else {
+        QMessageBox::warning(this, tr("Invalid Directory Selected"),
+                             tr("The directory you have selected does not contain a 'main' file."));
     }
 }
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -550,6 +550,8 @@ void GMainWindow::OnMenuLoadFile() {
     for (const auto& piece : game_list->supported_file_extensions)
         extensions += "*." + piece + " ";
 
+    extensions += "main ";
+
     QString file_filter = tr("Switch Executable") + " (" + extensions + ")";
     file_filter += ";;" + tr("All Files (*.*)");
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -278,6 +278,7 @@ void GMainWindow::ConnectWidgetEvents() {
 void GMainWindow::ConnectMenuEvents() {
     // File
     connect(ui.action_Load_File, &QAction::triggered, this, &GMainWindow::OnMenuLoadFile);
+    connect(ui.action_Load_Folder, &QAction::triggered, this, &GMainWindow::OnMenuLoadFolder);
     connect(ui.action_Select_Game_List_Root, &QAction::triggered, this,
             &GMainWindow::OnMenuSelectGameListRoot);
     connect(ui.action_Exit, &QAction::triggered, this, &QMainWindow::close);
@@ -561,6 +562,15 @@ void GMainWindow::OnMenuLoadFile() {
         UISettings::values.roms_path = QFileInfo(filename).path();
 
         BootGame(filename);
+    }
+}
+
+void GMainWindow::OnMenuLoadFolder() {
+    QDir dir = QFileDialog::getExistingDirectory(this, tr("Open Extracted ROM Directory"));
+
+    QStringList matchingMain = dir.entryList(QStringList() << "main", QDir::Files);
+    if (matchingMain.size() == 1) {
+        BootGame(matchingMain[0]);
     }
 }
 

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -123,6 +123,7 @@ private slots:
     void OnGameListLoadFile(QString game_path);
     void OnGameListOpenSaveFolder(u64 program_id);
     void OnMenuLoadFile();
+    void OnMenuLoadFolder();
     /// Called whenever a user selects the "File->Select Game List Root" menu item
     void OnMenuSelectGameListRoot();
     void OnMenuRecentFile();

--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -58,6 +58,7 @@
      </property>
     </widget>
     <addaction name="action_Load_File"/>
+    <addaction name="action_Load_Folder"/>
     <addaction name="separator"/>
     <addaction name="action_Select_Game_List_Root"/>
     <addaction name="menu_recent_files"/>
@@ -104,6 +105,11 @@
   <action name="action_Load_File">
    <property name="text">
     <string>Load File...</string>
+   </property>
+  </action>
+  <action name="action_Load_Folder">
+   <property name="text">
+    <string>Load Folder...</string>
    </property>
   </action>
   <action name="action_Load_Symbol_Map">


### PR DESCRIPTION
This is *NOT* for entrie *.nca files, only the extracted directory containing the main, romfs, etc.. files

Mainly:

- Able to select 'main' files from Load File without having to change extensions to all.
- Added a 'Load Folder' to pick a extracted NCA directory.
- Game list looks for 'main' files now and uses the name of the directory they are in as display.
