### PR TITLE
Add support for decrypted NCA files

### DIFF
--- a/src/common/common_types.h
+++ b/src/common/common_types.h
@@ -48,9 +48,6 @@ using PAddr = u64; ///< Represents a pointer in the ARM11 physical address space
 using u128 = std::array<std::uint64_t, 2>;
 static_assert(sizeof(u128) == 16, "u128 must be 128 bits wide");
 
-using u256 = std::array<std::uint64_t, 4>;
-static_assert(sizeof(u256) == 32, "u256 must be 256 bits wide");
-
 // An inheritable class to disallow the copy constructor and operator= functions
 class NonCopyable {
 protected:

--- a/src/common/common_types.h
+++ b/src/common/common_types.h
@@ -48,6 +48,9 @@ using PAddr = u64; ///< Represents a pointer in the ARM11 physical address space
 using u128 = std::array<std::uint64_t, 2>;
 static_assert(sizeof(u128) == 16, "u128 must be 128 bits wide");
 
+using u256 = std::array<std::uint64_t, 4>;
+static_assert(sizeof(u256) == 32, "u256 must be 256 bits wide");
+
 // An inheritable class to disallow the copy constructor and operator= functions
 class NonCopyable {
 protected:

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -257,6 +257,8 @@ add_library(core STATIC
     loader/linker.h
     loader/loader.cpp
     loader/loader.h
+    loader/nca.cpp
+    loader/nca.h
     loader/nro.cpp
     loader/nro.h
     loader/nso.cpp

--- a/src/core/file_sys/partition_filesystem.cpp
+++ b/src/core/file_sys/partition_filesystem.cpp
@@ -19,6 +19,7 @@ Loader::ResultStatus PartitionFilesystem::Load(const std::string& file_path, siz
     if (file.GetSize() < sizeof(Header))
         return Loader::ResultStatus::Error;
 
+    file.Seek(offset, SEEK_SET);
     // For cartridges, HFSs can get very large, so we need to calculate the size up to
     // the actual content itself instead of just blindly reading in the entire file.
     Header pfs_header;

--- a/src/core/file_sys/partition_filesystem.cpp
+++ b/src/core/file_sys/partition_filesystem.cpp
@@ -26,7 +26,16 @@ Loader::ResultStatus PartitionFilesystem::Load(const std::string& file_path, siz
     if (!file.ReadBytes(&pfs_header, sizeof(Header)))
         return Loader::ResultStatus::Error;
 
-    bool is_hfs = (memcmp(pfs_header.magic.data(), "HFS", 3) == 0);
+    bool is_hfs;
+
+    if (pfs_header.magic == Common::MakeMagic('H', 'F', 'S', '0')) {
+        is_hfs = true;
+    } else if (pfs_header.magic == Common::MakeMagic('P', 'F', 'S', '0')) {
+        is_hfs = false;
+    } else {
+        return Loader::ResultStatus::ErrorInvalidFormat;
+    }
+
     size_t entry_size = is_hfs ? sizeof(HFSEntry) : sizeof(PFSEntry);
     size_t metadata_size =
         sizeof(Header) + (pfs_header.num_entries * entry_size) + pfs_header.strtab_size;
@@ -51,7 +60,13 @@ Loader::ResultStatus PartitionFilesystem::Load(const std::vector<u8>& file_data,
         return Loader::ResultStatus::Error;
 
     memcpy(&pfs_header, &file_data[offset], sizeof(Header));
-    is_hfs = (memcmp(pfs_header.magic.data(), "HFS", 3) == 0);
+    if (pfs_header.magic == Common::MakeMagic('H', 'F', 'S', '0')) {
+        is_hfs = true;
+    } else if (pfs_header.magic == Common::MakeMagic('P', 'F', 'S', '0')) {
+        is_hfs = false;
+    } else {
+        return Loader::ResultStatus::ErrorInvalidFormat;
+    }
 
     size_t entries_offset = offset + sizeof(Header);
     size_t entry_size = is_hfs ? sizeof(HFSEntry) : sizeof(PFSEntry);
@@ -114,7 +129,7 @@ u64 PartitionFilesystem::GetFileSize(const std::string& name) const {
 }
 
 void PartitionFilesystem::Print() const {
-    NGLOG_DEBUG(Service_FS, "Magic:                  {:.4}", pfs_header.magic.data());
+    NGLOG_DEBUG(Service_FS, "Magic:                  {}", pfs_header.magic);
     NGLOG_DEBUG(Service_FS, "Files:                  {}", pfs_header.num_entries);
     for (u32 i = 0; i < pfs_header.num_entries; i++) {
         NGLOG_DEBUG(Service_FS, " > File {}:              {} (0x{:X} bytes, at 0x{:X})", i,

--- a/src/core/file_sys/partition_filesystem.cpp
+++ b/src/core/file_sys/partition_filesystem.cpp
@@ -26,15 +26,12 @@ Loader::ResultStatus PartitionFilesystem::Load(const std::string& file_path, siz
     if (!file.ReadBytes(&pfs_header, sizeof(Header)))
         return Loader::ResultStatus::Error;
 
-    bool is_hfs;
-
-    if (pfs_header.magic == Common::MakeMagic('H', 'F', 'S', '0')) {
-        is_hfs = true;
-    } else if (pfs_header.magic == Common::MakeMagic('P', 'F', 'S', '0')) {
-        is_hfs = false;
-    } else {
+    if (pfs_header.magic != Common::MakeMagic('H', 'F', 'S', '0') &&
+        pfs_header.magic != Common::MakeMagic('P', 'F', 'S', '0')) {
         return Loader::ResultStatus::ErrorInvalidFormat;
     }
+
+    bool is_hfs = pfs_header.magic == Common::MakeMagic('H', 'F', 'S', '0');
 
     size_t entry_size = is_hfs ? sizeof(HFSEntry) : sizeof(PFSEntry);
     size_t metadata_size =
@@ -60,13 +57,12 @@ Loader::ResultStatus PartitionFilesystem::Load(const std::vector<u8>& file_data,
         return Loader::ResultStatus::Error;
 
     memcpy(&pfs_header, &file_data[offset], sizeof(Header));
-    if (pfs_header.magic == Common::MakeMagic('H', 'F', 'S', '0')) {
-        is_hfs = true;
-    } else if (pfs_header.magic == Common::MakeMagic('P', 'F', 'S', '0')) {
-        is_hfs = false;
-    } else {
+    if (pfs_header.magic != Common::MakeMagic('H', 'F', 'S', '0') &&
+        pfs_header.magic != Common::MakeMagic('P', 'F', 'S', '0')) {
         return Loader::ResultStatus::ErrorInvalidFormat;
     }
+
+    is_hfs = pfs_header.magic == Common::MakeMagic('H', 'F', 'S', '0');
 
     size_t entries_offset = offset + sizeof(Header);
     size_t entry_size = is_hfs ? sizeof(HFSEntry) : sizeof(PFSEntry);

--- a/src/core/file_sys/partition_filesystem.h
+++ b/src/core/file_sys/partition_filesystem.h
@@ -37,7 +37,7 @@ public:
 
 private:
     struct Header {
-        std::array<char, 4> magic;
+        u32_le magic;
         u32_le num_entries;
         u32_le strtab_size;
         INSERT_PADDING_BYTES(0x4);

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -9,6 +9,7 @@
 #include "core/hle/kernel/process.h"
 #include "core/loader/deconstructed_rom_directory.h"
 #include "core/loader/elf.h"
+#include "core/loader/nca.h"
 #include "core/loader/nro.h"
 #include "core/loader/nso.h"
 
@@ -32,6 +33,7 @@ FileType IdentifyFile(FileUtil::IOFile& file, const std::string& filepath) {
     CHECK_TYPE(ELF)
     CHECK_TYPE(NSO)
     CHECK_TYPE(NRO)
+    CHECK_TYPE(NCA)
 
 #undef CHECK_TYPE
 
@@ -57,6 +59,8 @@ FileType GuessFromExtension(const std::string& extension_) {
         return FileType::NRO;
     else if (extension == ".nso")
         return FileType::NSO;
+    else if (extension == ".nca")
+        return FileType::NCA;
 
     return FileType::Unknown;
 }
@@ -69,6 +73,8 @@ const char* GetFileTypeString(FileType type) {
         return "NRO";
     case FileType::NSO:
         return "NSO";
+    case FileType::NCA:
+        return "NCA";
     case FileType::DeconstructedRomDirectory:
         return "Directory";
     case FileType::Error:
@@ -103,6 +109,10 @@ static std::unique_ptr<AppLoader> GetFileLoader(FileUtil::IOFile&& file, FileTyp
     // NX NRO file format.
     case FileType::NRO:
         return std::make_unique<AppLoader_NRO>(std::move(file), filepath);
+
+    // NX NCA file format.
+    case FileType::NCA:
+        return std::make_unique<AppLoader_NCA>(std::move(file), filepath);
 
     // NX deconstructed ROM directory.
     case FileType::DeconstructedRomDirectory:

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -29,6 +29,7 @@ enum class FileType {
     ELF,
     NSO,
     NRO,
+    NCA,
     DeconstructedRomDirectory,
 };
 

--- a/src/core/loader/nca.cpp
+++ b/src/core/loader/nca.cpp
@@ -5,21 +5,18 @@
 #include <vector>
 
 #include "common/common_funcs.h"
-#include "common/common_paths.h"
 #include "common/file_util.h"
 #include "common/logging/log.h"
 #include "common/swap.h"
 #include "core/core.h"
-#include "core/file_sys/disk_filesystem.h"
 #include "core/file_sys/program_metadata.h"
 #include "core/file_sys/romfs_factory.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/resource_limit.h"
 #include "core/hle/service/filesystem/filesystem.h"
-#include "core/loader/nro.h"
+#include "core/loader/nca.h"
+#include "core/loader/nso.h"
 #include "core/memory.h"
-#include "nca.h"
-#include "nso.h"
 
 namespace Loader {
 
@@ -140,25 +137,25 @@ static bool IsPfsExeFs(const FileSys::PartitionFilesystem& pfs) {
     return pfs.GetFileSize("main") > 0 && pfs.GetFileSize("main.npdm") > 0;
 }
 
-u8 Nca::GetExeFsPfsId() {
-    for (int i = 0; i < pfs.size(); ++i) {
+boost::optional<u8> Nca::GetExeFsPfsId() {
+    for (size_t i = 0; i < pfs.size(); ++i) {
         if (IsPfsExeFs(pfs[i]))
             return i;
     }
 
-    return -1;
+    return boost::none;
 }
 
 u64 Nca::GetExeFsFileOffset(const std::string& file_name) {
-    if (GetExeFsPfsId() == 255)
+    if (GetExeFsPfsId() == boost::none)
         return 0;
-    return pfs[GetExeFsPfsId()].GetFileOffset(file_name) + pfs_offset[GetExeFsPfsId()];
+    return pfs[*GetExeFsPfsId()].GetFileOffset(file_name) + pfs_offset[*GetExeFsPfsId()];
 }
 
 u64 Nca::GetExeFsFileSize(const std::string& file_name) {
-    if (GetExeFsPfsId() == 255)
+    if (GetExeFsPfsId() == boost::none)
         return 0;
-    return pfs[GetExeFsPfsId()].GetFileSize(file_name);
+    return pfs[*GetExeFsPfsId()].GetFileSize(file_name);
 }
 
 u64 Nca::GetRomFsOffset() {

--- a/src/core/loader/nca.cpp
+++ b/src/core/loader/nca.cpp
@@ -1,0 +1,33 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <vector>
+
+#include "common/common_funcs.h"
+#include "common/file_util.h"
+#include "common/logging/log.h"
+#include "common/swap.h"
+#include "core/core.h"
+#include "core/hle/kernel/process.h"
+#include "core/hle/kernel/resource_limit.h"
+#include "core/loader/nro.h"
+#include "core/memory.h"
+#include "nca.h"
+
+namespace Loader {
+
+AppLoader_NCA::AppLoader_NCA(FileUtil::IOFile&& file, std::string filepath)
+    : AppLoader(std::move(file)), filepath(std::move(filepath)) {}
+
+FileType AppLoader_NCA::IdentifyType(FileUtil::IOFile& file, const std::string&) {
+    // Check for NCA header here -- that part might be enc. too :(
+    return FileType::Error;
+}
+
+ResultStatus AppLoader_NCA::Load(Kernel::SharedPtr<Kernel::Process>& process) {
+    NGLOG_CRITICAL(Loader, "UNIMPLEMENTED!");
+    return ResultStatus::Error;
+}
+
+} // namespace Loader

--- a/src/core/loader/nca.cpp
+++ b/src/core/loader/nca.cpp
@@ -17,11 +17,109 @@
 
 namespace Loader {
 
+enum NcaContentType {
+    NCT_PROGRAM = 0,
+    NCT_META = 1,
+    NCT_CONTROL = 2,
+    NCT_MANUAL = 3,
+    NCT_DATA = 4
+};
+
+struct NcaHeader {
+    u8 rsa_signature_1[0x100];
+    u8 rsa_signature_2[0x100];
+    u32 magic;
+    u8 is_system;
+    u8 content_type;
+    u8 crypto_type;
+    u8 key_index;
+    u64 size;
+    u64 title_id;
+    INSERT_PADDING_BYTES(0x4);
+    u32 sdk_version;
+    u8 crypto_type_2;
+    INSERT_PADDING_BYTES(0x9);
+    u128 rights_id;
+    u128 section_tables[0x4];
+    u256 hash_tables[0x4];
+    u128 key_area[0x4];
+    INSERT_PADDING_BYTES(0xC0);
+    INSERT_PADDING_BYTES(0x800);
+};
+static_assert(sizeof(NcaHeader) == 0xC00, "NcaHeader has incorrect size.");
+
+/**
+ * Adapted from hactool/aes.c, void aes_xts_decrypt(aes_ctx_t *ctx, void *dst,
+ *      const void *src, size_t l, size_t sector, size_t sector_size)
+ * and from various other functions in aes.c (get_tweak, aes_setiv, aes_decrypt)
+ *
+ * Copyright (c) 2018, SciresM
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ */
+template <size_t size>
+static std::array<u8, size> AesXtsDecrypt(std::array<u8, size> in, size_t sector_size) {
+    std::array<u8, 0x10> tweak;
+    ASSERT(size % sector_size == 0);
+
+    u8 sector = 0;
+
+    for (size_t i = 0; i < size; i += sector_size) {
+
+        // Get tweak
+        size_t sector_temp = sector++;
+        for (int i = 0xF; i >= 0; --i) {
+            tweak[i] = static_cast<u8>(sector_temp);
+            sector_temp >>= 8;
+        }
+
+        // Decrypt using lib or something
+    }
+}
+
+/**
+ * Adapted from hactool/nca.c, int nca_decrypt_header(nca_ctx_t *ctx)
+ *
+ * Copyright (c) 2018, SciresM
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ */
+static NcaHeader DecryptHeader(std::array<u8, 0xC00> enc_data) {
+    // Just in case its decrypted.
+    NcaHeader* header = reinterpret_cast<NcaHeader*>(enc_data.data());
+    if (header->magic == Common::MakeMagic('N', 'C', 'A', '2') ||
+        header->magic == Common::MakeMagic('N', 'C', 'A', '3'))
+        return *header;
+
+    std::array<u8, 0xC00> dec = AesXtsDecrypt(enc_data, 0x200);
+
+    header = reinterpret_cast<NcaHeader*>(dec.data());
+    return *header;
+}
+
+static bool IsValidNca(const NcaHeader& header) {
+    return header.magic == Common::MakeMagic('N', 'C', 'A', '2') ||
+           header.magic == Common::MakeMagic('N', 'C', 'A', '3');
+}
+
 AppLoader_NCA::AppLoader_NCA(FileUtil::IOFile&& file, std::string filepath)
     : AppLoader(std::move(file)), filepath(std::move(filepath)) {}
 
 FileType AppLoader_NCA::IdentifyType(FileUtil::IOFile& file, const std::string&) {
-    // Check for NCA header here -- that part might be enc. too :(
+
+    std::array<u8, 0xC00> header_enc_array{};
+    if (1 != file.ReadArray(header_enc_array.data(), 0xC00))
+        return FileType::Error;
+
+    NcaHeader header = DecryptHeader(header_enc_array);
+
+    if (IsValidNca(header) && header.content_type == NCT_PROGRAM)
+        return FileType::NCA;
+
     return FileType::Error;
 }
 

--- a/src/core/loader/nca.cpp
+++ b/src/core/loader/nca.cpp
@@ -15,9 +15,6 @@
 #include "core/memory.h"
 #include "nca.h"
 
-#include "../../../externals/cryptopp/cryptopp/aes.h"
-using CryptoPP::AES;
-
 namespace Loader {
 
 enum NcaContentType {
@@ -42,10 +39,10 @@ struct NcaHeader {
     u32 sdk_version;
     u8 crypto_type_2;
     INSERT_PADDING_BYTES(0x9);
-    u128 rights_id;
-    u128 section_tables[0x4];
-    u256 hash_tables[0x4];
-    u128 key_area[0x4];
+    u8 rights_id[0x10];
+    u8 section_tables[0x4][0x10];
+    u8 hash_tables[0x4][0x20];
+    u8 key_area[0x4][0x10];
     INSERT_PADDING_BYTES(0xC0);
     INSERT_PADDING_BYTES(0x800);
 };
@@ -112,9 +109,9 @@ AppLoader_NCA::AppLoader_NCA(FileUtil::IOFile&& file, std::string filepath)
     : AppLoader(std::move(file)), filepath(std::move(filepath)) {}
 
 FileType AppLoader_NCA::IdentifyType(FileUtil::IOFile& file, const std::string&) {
-
+    file.Seek(0, SEEK_SET);
     std::array<u8, 0xC00> header_enc_array{};
-    if (1 != file.ReadArray(header_enc_array.data(), 0xC00))
+    if (0xC00 != file.ReadBytes(header_enc_array.data(), 0xC00))
         return FileType::Error;
 
     // NcaHeader header = DecryptHeader(header_enc_array);

--- a/src/core/loader/nca.cpp
+++ b/src/core/loader/nca.cpp
@@ -34,8 +34,8 @@ enum NcaContentType {
 enum NcaSectionFilesystemType { NSFS_PFS0 = 0x2, NSFS_ROMFS = 0x3 };
 
 struct NcaSectionTableEntry {
-    u32 media_offset;
-    u32 media_end_offset;
+    u32_le media_offset;
+    u32_le media_end_offset;
     INSERT_PADDING_BYTES(0x8);
 };
 static_assert(sizeof(NcaSectionTableEntry) == 0x10, "NcaSectionTableEntry has incorrect size.");
@@ -43,15 +43,15 @@ static_assert(sizeof(NcaSectionTableEntry) == 0x10, "NcaSectionTableEntry has in
 struct NcaHeader {
     u8 rsa_signature_1[0x100];
     u8 rsa_signature_2[0x100];
-    u32 magic;
+    u32_le magic;
     u8 is_system;
     u8 content_type;
     u8 crypto_type;
     u8 key_index;
-    u64 size;
-    u64 title_id;
+    u64_le size;
+    u64_le title_id;
     INSERT_PADDING_BYTES(0x4);
-    u32 sdk_version;
+    u32_le sdk_version;
     u8 crypto_type_2;
     INSERT_PADDING_BYTES(15);
     u8 rights_id[0x10];
@@ -73,12 +73,12 @@ static_assert(sizeof(NcaSectionHeaderBlock) == 0x8, "NcaSectionHeaderBlock has i
 struct Pfs0Superblock {
     NcaSectionHeaderBlock header_block;
     std::array<u8, 0x20> hash;
-    u32 size;
+    u32_le size;
     INSERT_PADDING_BYTES(4);
-    u64 hash_table_offset;
-    u64 hash_table_size;
-    u64 pfs0_header_offset;
-    u64 pfs0_size;
+    u64_le hash_table_offset;
+    u64_le hash_table_size;
+    u64_le pfs0_header_offset;
+    u64_le pfs0_size;
     INSERT_PADDING_BYTES(432);
 };
 static_assert(sizeof(Pfs0Superblock) == 0x200, "Pfs0Superblock has incorrect size.");

--- a/src/core/loader/nca.cpp
+++ b/src/core/loader/nca.cpp
@@ -283,7 +283,10 @@ ResultStatus AppLoader_NCA::Load(Kernel::SharedPtr<Kernel::Process>& process) {
     process->Run(Memory::PROCESS_IMAGE_VADDR, metadata.GetMainThreadPriority(),
                  metadata.GetMainThreadStackSize());
 
-    return ResultStatus::Error;
+    // Load the RomFS
+
+    is_loaded = true;
+    return ResultStatus::Success;
 }
 
 } // namespace Loader

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -20,7 +20,7 @@ struct Nca {
 
     FileSys::PartitionFilesystem GetPfs(u8 id);
 
-    u8 GetExeFsPfsId();
+    boost::optional<u8> GetExeFsPfsId();
 
     u64 GetExeFsFileOffset(const std::string& file_name);
     u64 GetExeFsFileSize(const std::string& file_name);

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -28,6 +28,8 @@ struct Nca {
     u64 GetRomFsOffset();
     u64 GetRomFsSize();
 
+    bool IsValid();
+
     std::vector<u8> GetExeFsFile(const std::string& file_name);
 
 private:
@@ -36,6 +38,8 @@ private:
 
     u64 romfs_offset = 0;
     u64 romfs_size = 0;
+
+    bool valid = false;
 
     FileUtil::IOFile file;
     std::string path;

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -14,19 +14,30 @@
 
 namespace Loader {
 
-class Nca {
-    FileSys::PartitionFilesystem GetPFS(u8 id);
+// TODO(DarkLordZach): Add support for encrypted.
+struct Nca {
+    Nca(FileUtil::IOFile&& file, std::string path);
+
+    FileSys::PartitionFilesystem GetPfs(u8 id);
 
     u8 GetExeFsPfsId();
 
-    u64 GetExeFsFileOffset();
-    u64 GetExeFsFileSize();
+    u64 GetExeFsFileOffset(const std::string& file_name);
+    u64 GetExeFsFileSize(const std::string& file_name);
 
-    u64 GetRomFSOffset();
-    u64 GetRomFSSize();
+    u64 GetRomFsOffset();
+    u64 GetRomFsSize();
+
+    std::vector<u8> GetExeFsFile(const std::string& file_name);
 
 private:
     std::vector<FileSys::PartitionFilesystem> pfs;
+    std::vector<u64> pfs_offset;
+
+    u64 romfs_offset;
+    u64 romfs_size;
+
+    FileUtil::IOFile file;
     std::string path;
 };
 

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -12,7 +12,7 @@
 
 namespace Loader {
 
-/// Loads an NRO file
+/// Loads an NCA file
 class AppLoader_NCA final : public AppLoader, Linker {
 public:
     AppLoader_NCA(FileUtil::IOFile&& file, std::string filepath);

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -34,8 +34,8 @@ private:
     std::vector<FileSys::PartitionFilesystem> pfs;
     std::vector<u64> pfs_offset;
 
-    u64 romfs_offset;
-    u64 romfs_size;
+    u64 romfs_offset = 0;
+    u64 romfs_size = 0;
 
     FileUtil::IOFile file;
     std::string path;
@@ -60,9 +60,14 @@ public:
 
     ResultStatus Load(Kernel::SharedPtr<Kernel::Process>& process) override;
 
+    ResultStatus ReadRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
+                           u64& size) override;
+
 private:
     std::string filepath;
     FileSys::ProgramMetadata metadata;
+
+    std::unique_ptr<Nca> nca;
 };
 
 } // namespace Loader

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -1,0 +1,38 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+#include "common/common_types.h"
+#include "core/hle/kernel/kernel.h"
+#include "core/loader/linker.h"
+#include "core/loader/loader.h"
+
+namespace Loader {
+
+/// Loads an NRO file
+class AppLoader_NCA final : public AppLoader, Linker {
+public:
+    AppLoader_NCA(FileUtil::IOFile&& file, std::string filepath);
+
+    /**
+     * Returns the type of the file
+     * @param file FileUtil::IOFile open file
+     * @param filepath Path of the file that we are opening.
+     * @return FileType found, or FileType::Error if this loader doesn't know it
+     */
+    static FileType IdentifyType(FileUtil::IOFile& file, const std::string& filepath);
+
+    FileType GetFileType() override {
+        return IdentifyType(file, filepath);
+    }
+
+    ResultStatus Load(Kernel::SharedPtr<Kernel::Process>& process) override;
+
+private:
+    std::string filepath;
+};
+
+} // namespace Loader

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -6,11 +6,29 @@
 
 #include <string>
 #include "common/common_types.h"
+#include "core/file_sys/partition_filesystem.h"
+#include "core/file_sys/program_metadata.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/loader/linker.h"
 #include "core/loader/loader.h"
 
 namespace Loader {
+
+class Nca {
+    FileSys::PartitionFilesystem GetPFS(u8 id);
+
+    u8 GetExeFsPfsId();
+
+    u64 GetExeFsFileOffset();
+    u64 GetExeFsFileSize();
+
+    u64 GetRomFSOffset();
+    u64 GetRomFSSize();
+
+private:
+    std::vector<FileSys::PartitionFilesystem> pfs;
+    std::string path;
+};
 
 /// Loads an NCA file
 class AppLoader_NCA final : public AppLoader, Linker {
@@ -33,6 +51,7 @@ public:
 
 private:
     std::string filepath;
+    FileSys::ProgramMetadata metadata;
 };
 
 } // namespace Loader

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -9,44 +9,14 @@
 #include "core/file_sys/partition_filesystem.h"
 #include "core/file_sys/program_metadata.h"
 #include "core/hle/kernel/kernel.h"
-#include "core/loader/linker.h"
 #include "core/loader/loader.h"
 
 namespace Loader {
 
-// TODO(DarkLordZach): Add support for encrypted.
-struct Nca {
-    Nca(FileUtil::IOFile&& file, std::string path);
-
-    FileSys::PartitionFilesystem GetPfs(u8 id);
-
-    boost::optional<u8> GetExeFsPfsId();
-
-    u64 GetExeFsFileOffset(const std::string& file_name);
-    u64 GetExeFsFileSize(const std::string& file_name);
-
-    u64 GetRomFsOffset();
-    u64 GetRomFsSize();
-
-    bool IsValid();
-
-    std::vector<u8> GetExeFsFile(const std::string& file_name);
-
-private:
-    std::vector<FileSys::PartitionFilesystem> pfs;
-    std::vector<u64> pfs_offset;
-
-    u64 romfs_offset = 0;
-    u64 romfs_size = 0;
-
-    bool valid = false;
-
-    FileUtil::IOFile file;
-    std::string path;
-};
+class Nca;
 
 /// Loads an NCA file
-class AppLoader_NCA final : public AppLoader, Linker {
+class AppLoader_NCA final : public AppLoader {
 public:
     AppLoader_NCA(FileUtil::IOFile&& file, std::string filepath);
 
@@ -66,6 +36,8 @@ public:
 
     ResultStatus ReadRomFS(std::shared_ptr<FileUtil::IOFile>& romfs_file, u64& offset,
                            u64& size) override;
+
+    ~AppLoader_NCA();
 
 private:
     std::string filepath;

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -66,6 +66,20 @@ FileType AppLoader_NSO::IdentifyType(FileUtil::IOFile& file, const std::string&)
     return FileType::Error;
 }
 
+static std::vector<u8> DecompressSegment(const std::vector<u8>& compressed_data,
+                                         const NsoSegmentHeader& header) {
+    std::vector<u8> uncompressed_data;
+    uncompressed_data.resize(header.size);
+    const int bytes_uncompressed = LZ4_decompress_safe(
+        reinterpret_cast<const char*>(compressed_data.data()),
+        reinterpret_cast<char*>(uncompressed_data.data()), compressed_data.size(), header.size);
+
+    ASSERT_MSG(bytes_uncompressed == header.size && bytes_uncompressed == uncompressed_data.size(),
+               "{} != {} != {}", bytes_uncompressed, header.size, uncompressed_data.size());
+
+    return uncompressed_data;
+}
+
 static std::vector<u8> ReadSegment(FileUtil::IOFile& file, const NsoSegmentHeader& header,
                                    int compressed_size) {
     std::vector<u8> compressed_data;
@@ -77,20 +91,60 @@ static std::vector<u8> ReadSegment(FileUtil::IOFile& file, const NsoSegmentHeade
         return {};
     }
 
-    std::vector<u8> uncompressed_data;
-    uncompressed_data.resize(header.size);
-    const int bytes_uncompressed = LZ4_decompress_safe(
-        reinterpret_cast<const char*>(compressed_data.data()),
-        reinterpret_cast<char*>(uncompressed_data.data()), compressed_size, header.size);
-
-    ASSERT_MSG(bytes_uncompressed == header.size && bytes_uncompressed == uncompressed_data.size(),
-               "{} != {} != {}", bytes_uncompressed, header.size, uncompressed_data.size());
-
-    return uncompressed_data;
+    return DecompressSegment(compressed_data, header);
 }
 
 static constexpr u32 PageAlignSize(u32 size) {
     return (size + Memory::PAGE_MASK) & ~Memory::PAGE_MASK;
+}
+
+VAddr AppLoader_NSO::LoadModule(const std::string& name, const std::vector<u8>& file_data,
+                                VAddr load_base) {
+    NsoHeader nso_header{};
+    memcpy(&nso_header, file_data.data(), sizeof(NsoHeader));
+
+    if (nso_header.magic != Common::MakeMagic('N', 'S', 'O', '0'))
+        return {};
+
+    // Build program image
+    Kernel::SharedPtr<Kernel::CodeSet> codeset = Kernel::CodeSet::Create("");
+    std::vector<u8> program_image;
+    for (int i = 0; i < nso_header.segments.size(); ++i) {
+        std::vector<u8> compressed_data{};
+        for (int j = 0; j < nso_header.segments_compressed_size[i]; ++j)
+            compressed_data[j] = file_data[nso_header.segments[i].offset + j];
+        std::vector<u8> data = DecompressSegment(compressed_data, nso_header.segments[i]);
+        program_image.resize(nso_header.segments[i].location);
+        program_image.insert(program_image.end(), data.begin(), data.end());
+        codeset->segments[i].addr = nso_header.segments[i].location;
+        codeset->segments[i].offset = nso_header.segments[i].location;
+        codeset->segments[i].size = PageAlignSize(static_cast<u32>(data.size()));
+    }
+
+    // MOD header pointer is at .text offset + 4
+    u32 module_offset;
+    std::memcpy(&module_offset, program_image.data() + 4, sizeof(u32));
+
+    // Read MOD header
+    ModHeader mod_header{};
+    // Default .bss to size in segment header if MOD0 section doesn't exist
+    u32 bss_size{PageAlignSize(nso_header.segments[2].bss_size)};
+    std::memcpy(&mod_header, program_image.data() + module_offset, sizeof(ModHeader));
+    const bool has_mod_header{mod_header.magic == Common::MakeMagic('M', 'O', 'D', '0')};
+    if (has_mod_header) {
+        // Resize program image to include .bss section and page align each section
+        bss_size = PageAlignSize(mod_header.bss_end_offset - mod_header.bss_start_offset);
+    }
+    codeset->data.size += bss_size;
+    const u32 image_size{PageAlignSize(static_cast<u32>(program_image.size()) + bss_size)};
+    program_image.resize(image_size);
+
+    // Load codeset for current process
+    codeset->name = name;
+    codeset->memory = std::make_shared<std::vector<u8>>(std::move(program_image));
+    Core::CurrentProcess()->LoadModule(codeset, load_base);
+
+    return load_base + image_size;
 }
 
 VAddr AppLoader_NSO::LoadModule(const std::string& path, VAddr load_base) {

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -81,7 +81,7 @@ static std::vector<u8> DecompressSegment(const std::vector<u8>& compressed_data,
 }
 
 static std::vector<u8> ReadSegment(FileUtil::IOFile& file, const NsoSegmentHeader& header,
-                                   int compressed_size) {
+                                   size_t compressed_size) {
     std::vector<u8> compressed_data;
     compressed_data.resize(compressed_size);
 
@@ -103,7 +103,8 @@ VAddr AppLoader_NSO::LoadModule(const std::string& name, const std::vector<u8>& 
     if (file_data.size() < sizeof(NsoHeader))
         return {};
 
-    const NsoHeader nso_header = *reinterpret_cast<const NsoHeader* const>(file_data.data());
+    NsoHeader nso_header;
+    std::memcpy(&nso_header, file_data.data(), sizeof(NsoHeader));
 
     if (nso_header.magic != Common::MakeMagic('N', 'S', 'O', '0'))
         return {};

--- a/src/core/loader/nso.h
+++ b/src/core/loader/nso.h
@@ -29,6 +29,9 @@ public:
         return IdentifyType(file, filepath);
     }
 
+    static VAddr LoadModule(const std::string& name, const std::vector<u8>& file_data,
+                            VAddr load_base);
+
     static VAddr LoadModule(const std::string& path, VAddr load_base);
 
     ResultStatus Load(Kernel::SharedPtr<Kernel::Process>& process) override;

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -356,7 +356,7 @@ void GameList::LoadInterfaceLayout() {
     item_model->sort(header->sortIndicatorSection(), header->sortIndicatorOrder());
 }
 
-const QStringList GameList::supported_file_extensions = {"nso", "nro"};
+const QStringList GameList::supported_file_extensions = {"nso", "nro", "nca"};
 
 static bool HasSupportedFileExtension(const std::string& file_name) {
     QFileInfo file = QFileInfo(file_name.c_str());


### PR DESCRIPTION
IMPORTANT: Must be decrypted before hand. Use `hactool --titlekey=<titlekey here> --plaintext=<out file> <in file` to decrypt an nca.

This *should* work. I have tested a bit but I only have 3 games to test (mk8dx, botw, and kingdom battle) all worked, let me know if you encounter issues on another game.

So this adds:
- Ability to pick nca files in 'Load File'
- Scans for nca files in game list
- Will show encrypted nca files in list as Unknown type.
- Runs games in nca format

Big thanks to @shinyquagsire23 for helping out.