### PR TITLE
svc: Add a stub for UserExceptionContextAddr.

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -363,6 +363,11 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
                     "(STUBBED) Attempted to query priviledged process id bounds, returned 0");
         *result = 0;
         break;
+    case GetInfoType::UserExceptionContextAddr:
+        NGLOG_WARNING(Kernel_SVC,
+                      "(STUBBED) Attempted to query user exception context address, returned 0");
+        *result = 0;
+        break;
     default:
         UNIMPLEMENTED();
     }


### PR DESCRIPTION
Stops yuzu from asserting on some libnx homebrew.