### PR TITLE
svc: Fully implement svcSignalToAddress and svcWaitForAddress

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -40,6 +40,8 @@ add_library(core STATIC
     hle/config_mem.h
     hle/ipc.h
     hle/ipc_helpers.h
+    hle/kernel/address_arbiter.cpp
+    hle/kernel/address_arbiter.h
     hle/kernel/client_port.cpp
     hle/kernel/client_port.h
     hle/kernel/client_session.cpp

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -14,160 +14,161 @@
 #include "core/memory.h"
 
 namespace Kernel {
-    namespace AddressArbiter {
+namespace AddressArbiter {
 
-        // Performs actual address waiting logic.
-        ResultCode WaitForAddress(VAddr address, s64 timeout) {
-            SharedPtr<Thread> current_thread = GetCurrentThread();
-            current_thread->arb_wait_address = address;
-            current_thread->status = THREADSTATUS_WAIT_ARB;
-            current_thread->wakeup_callback = nullptr;
+// Performs actual address waiting logic.
+ResultCode WaitForAddress(VAddr address, s64 timeout) {
+    SharedPtr<Thread> current_thread = GetCurrentThread();
+    current_thread->arb_wait_address = address;
+    current_thread->status = THREADSTATUS_WAIT_ARB;
+    current_thread->wakeup_callback = nullptr;
 
-            current_thread->WakeAfterDelay(timeout);
+    current_thread->WakeAfterDelay(timeout);
 
-            Core::System::GetInstance().CpuCore(current_thread->processor_id).PrepareReschedule();
-            // This should never actually execute.
-            return RESULT_SUCCESS;
-        }
+    Core::System::GetInstance().CpuCore(current_thread->processor_id).PrepareReschedule();
+    // This should never actually execute.
+    return RESULT_SUCCESS;
+}
 
-        // Gets the threads waiting on an address.
-        void GetThreadsWaitingOnAddress(std::vector<SharedPtr<Thread>> &waiting_threads, VAddr address) {
-            auto RetrieveWaitingThreads =
-                [](size_t core_index, std::vector<SharedPtr<Thread>>& waiting_threads, VAddr arb_addr) {
-                const auto& scheduler = Core::System::GetInstance().Scheduler(core_index);
-                auto& thread_list = scheduler->GetThreadList();
+// Gets the threads waiting on an address.
+void GetThreadsWaitingOnAddress(std::vector<SharedPtr<Thread>>& waiting_threads, VAddr address) {
+    auto RetrieveWaitingThreads =
+        [](size_t core_index, std::vector<SharedPtr<Thread>>& waiting_threads, VAddr arb_addr) {
+            const auto& scheduler = Core::System::GetInstance().Scheduler(core_index);
+            auto& thread_list = scheduler->GetThreadList();
 
-                for (auto& thread : thread_list) {
-                    if (thread->arb_wait_address == arb_addr)
-                        waiting_threads.push_back(thread);
-                }
-            };
-
-            // Retrieve a list of all threads that are waiting for this address.
-            RetrieveWaitingThreads(0, waiting_threads, address);
-            RetrieveWaitingThreads(1, waiting_threads, address);
-            RetrieveWaitingThreads(2, waiting_threads, address);
-            RetrieveWaitingThreads(3, waiting_threads, address);
-            // Sort them by priority, such that the highest priority ones come first.
-            std::sort(waiting_threads.begin(), waiting_threads.end(),
-                [](const SharedPtr<Thread>& lhs, const SharedPtr<Thread>& rhs) {
-                return lhs->current_priority < rhs->current_priority;
-            });
-        }
-
-        // Wake up num_to_wake (or all) threads in a vector.
-        void WakeThreads(std::vector<SharedPtr<Thread>> &waiting_threads, s32 num_to_wake) {
-            // Only process up to 'target' threads, unless 'target' is <= 0, in which case process
-            // them all.
-            size_t last = waiting_threads.size();
-            if (num_to_wake > 0)
-                last = num_to_wake;
-
-            // Signal the waiting threads.
-            // TODO: Rescheduling should not occur while waking threads. How can it be prevented?
-            for (size_t i = 0; i < last; i++) {
-                ASSERT(waiting_threads[i]->status = THREADSTATUS_WAIT_ARB);
-                waiting_threads[i]->SetWaitSynchronizationResult(RESULT_SUCCESS);
-                waiting_threads[i]->arb_wait_address = 0;
-                waiting_threads[i]->ResumeFromWait();
+            for (auto& thread : thread_list) {
+                if (thread->arb_wait_address == arb_addr)
+                    waiting_threads.push_back(thread);
             }
+        };
 
-        }
+    // Retrieve a list of all threads that are waiting for this address.
+    RetrieveWaitingThreads(0, waiting_threads, address);
+    RetrieveWaitingThreads(1, waiting_threads, address);
+    RetrieveWaitingThreads(2, waiting_threads, address);
+    RetrieveWaitingThreads(3, waiting_threads, address);
+    // Sort them by priority, such that the highest priority ones come first.
+    std::sort(waiting_threads.begin(), waiting_threads.end(),
+              [](const SharedPtr<Thread>& lhs, const SharedPtr<Thread>& rhs) {
+                  return lhs->current_priority < rhs->current_priority;
+              });
+}
 
-        // Signals an address being waited on.
-        ResultCode SignalToAddress(VAddr address, s32 num_to_wake) {
-            // Get threads waiting on the address.
-            std::vector<SharedPtr<Thread>> waiting_threads;
-            GetThreadsWaitingOnAddress(waiting_threads, address);
+// Wake up num_to_wake (or all) threads in a vector.
+void WakeThreads(std::vector<SharedPtr<Thread>>& waiting_threads, s32 num_to_wake) {
+    // Only process up to 'target' threads, unless 'target' is <= 0, in which case process
+    // them all.
+    size_t last = waiting_threads.size();
+    if (num_to_wake > 0)
+        last = num_to_wake;
 
-            WakeThreads(waiting_threads, num_to_wake);
-            return RESULT_SUCCESS;
-        }
+    // Signal the waiting threads.
+    // TODO: Rescheduling should not occur while waking threads. How can it be prevented?
+    for (size_t i = 0; i < last; i++) {
+        ASSERT(waiting_threads[i]->status = THREADSTATUS_WAIT_ARB);
+        waiting_threads[i]->SetWaitSynchronizationResult(RESULT_SUCCESS);
+        waiting_threads[i]->arb_wait_address = 0;
+        waiting_threads[i]->ResumeFromWait();
+    }
+}
 
-        // Signals an address being waited on and increments its value if equal to the value argument.
-        ResultCode IncrementAndSignalToAddressIfEqual(VAddr address, s32 value, s32 num_to_wake) {
-            // Ensure that we can write to the address.
-            if (!Memory::IsValidVirtualAddress(address)) {
-                return ERR_INVALID_ADDRESS_STATE;
-            }
+// Signals an address being waited on.
+ResultCode SignalToAddress(VAddr address, s32 num_to_wake) {
+    // Get threads waiting on the address.
+    std::vector<SharedPtr<Thread>> waiting_threads;
+    GetThreadsWaitingOnAddress(waiting_threads, address);
 
-            if ((s32)Memory::Read32(address) == value) {
-                Memory::Write32(address, (u32)(value + 1));
-            } else {
-                return ERR_INVALID_STATE;
-            }
+    WakeThreads(waiting_threads, num_to_wake);
+    return RESULT_SUCCESS;
+}
 
-            return SignalToAddress(address, num_to_wake);
-        }
+// Signals an address being waited on and increments its value if equal to the value argument.
+ResultCode IncrementAndSignalToAddressIfEqual(VAddr address, s32 value, s32 num_to_wake) {
+    // Ensure that we can write to the address.
+    if (!Memory::IsValidVirtualAddress(address)) {
+        return ERR_INVALID_ADDRESS_STATE;
+    }
 
-        // Signals an address being waited on and modifies its value based on waiting thread count if equal to the value argument.
-        ResultCode ModifyByWaitingCountAndSignalToAddressIfEqual(VAddr address, s32 value, s32 num_to_wake) {
-            // Ensure that we can write to the address.
-            if (!Memory::IsValidVirtualAddress(address)) {
-                return ERR_INVALID_ADDRESS_STATE;
-            }
+    if ((s32)Memory::Read32(address) == value) {
+        Memory::Write32(address, (u32)(value + 1));
+    } else {
+        return ERR_INVALID_STATE;
+    }
 
-            // Get threads waiting on the address.
-            std::vector<SharedPtr<Thread>> waiting_threads;
-            GetThreadsWaitingOnAddress(waiting_threads, address);
+    return SignalToAddress(address, num_to_wake);
+}
 
-            // Determine the modified value depending on the waiting count.
-            s32 updated_value;
-            if (waiting_threads.size() == 0) {
-                updated_value = value - 1;
-            } else if (num_to_wake <= 0 || waiting_threads.size() <= num_to_wake) {
-                updated_value = value + 1;
-            } else {
-                updated_value = value;
-            }
+// Signals an address being waited on and modifies its value based on waiting thread count if equal
+// to the value argument.
+ResultCode ModifyByWaitingCountAndSignalToAddressIfEqual(VAddr address, s32 value,
+                                                         s32 num_to_wake) {
+    // Ensure that we can write to the address.
+    if (!Memory::IsValidVirtualAddress(address)) {
+        return ERR_INVALID_ADDRESS_STATE;
+    }
 
-            if ((s32)Memory::Read32(address) == value) {
-                Memory::Write32(address, (u32)(updated_value));
-            } else {
-                return ERR_INVALID_STATE;
-            }
+    // Get threads waiting on the address.
+    std::vector<SharedPtr<Thread>> waiting_threads;
+    GetThreadsWaitingOnAddress(waiting_threads, address);
 
-            WakeThreads(waiting_threads, num_to_wake);
-            return RESULT_SUCCESS;
-        }
+    // Determine the modified value depending on the waiting count.
+    s32 updated_value;
+    if (waiting_threads.size() == 0) {
+        updated_value = value - 1;
+    } else if (num_to_wake <= 0 || waiting_threads.size() <= num_to_wake) {
+        updated_value = value + 1;
+    } else {
+        updated_value = value;
+    }
 
-        // Waits on an address if the value passed is less than the argument value, optionally decrementing.
-        ResultCode WaitForAddressIfLessThan(VAddr address, s32 value, s64 timeout, bool should_decrement) {
-            // Ensure that we can read the address.
-            if (!Memory::IsValidVirtualAddress(address)) {
-                return ERR_INVALID_ADDRESS_STATE;
-            }
+    if ((s32)Memory::Read32(address) == value) {
+        Memory::Write32(address, (u32)(updated_value));
+    } else {
+        return ERR_INVALID_STATE;
+    }
 
-            s32 cur_value = (s32)Memory::Read32(address);
-            if (cur_value < value) {
-                Memory::Write32(address, (u32)(cur_value - 1));
-            } else {
-                return ERR_INVALID_STATE;
-            }
-            // Short-circuit without rescheduling, if timeout is zero.
-            if (timeout == 0) {
-                return RESULT_TIMEOUT;
-            }
+    WakeThreads(waiting_threads, num_to_wake);
+    return RESULT_SUCCESS;
+}
 
-            return WaitForAddress(address, timeout);
-        }
+// Waits on an address if the value passed is less than the argument value, optionally decrementing.
+ResultCode WaitForAddressIfLessThan(VAddr address, s32 value, s64 timeout, bool should_decrement) {
+    // Ensure that we can read the address.
+    if (!Memory::IsValidVirtualAddress(address)) {
+        return ERR_INVALID_ADDRESS_STATE;
+    }
 
-        // Waits on an address if the value passed is equal to the argument value.
-        ResultCode WaitForAddressIfEqual(VAddr address, s32 value, s64 timeout) {
-            // Ensure that we can read the address.
-            if (!Memory::IsValidVirtualAddress(address)) {
-                return ERR_INVALID_ADDRESS_STATE;
-            }
-            // Only wait for the address if equal.
-            if ((s32)Memory::Read32(address) != value) {
-                return ERR_INVALID_STATE;
-            }
-            // Short-circuit without rescheduling, if timeout is zero.
-            if (timeout == 0) {
-                return RESULT_TIMEOUT;
-            }
+    s32 cur_value = (s32)Memory::Read32(address);
+    if (cur_value < value) {
+        Memory::Write32(address, (u32)(cur_value - 1));
+    } else {
+        return ERR_INVALID_STATE;
+    }
+    // Short-circuit without rescheduling, if timeout is zero.
+    if (timeout == 0) {
+        return RESULT_TIMEOUT;
+    }
 
-            return WaitForAddress(address, timeout);
-        }
-    } // namespace AddressArbiter
+    return WaitForAddress(address, timeout);
+}
+
+// Waits on an address if the value passed is equal to the argument value.
+ResultCode WaitForAddressIfEqual(VAddr address, s32 value, s64 timeout) {
+    // Ensure that we can read the address.
+    if (!Memory::IsValidVirtualAddress(address)) {
+        return ERR_INVALID_ADDRESS_STATE;
+    }
+    // Only wait for the address if equal.
+    if ((s32)Memory::Read32(address) != value) {
+        return ERR_INVALID_STATE;
+    }
+    // Short-circuit without rescheduling, if timeout is zero.
+    if (timeout == 0) {
+        return RESULT_TIMEOUT;
+    }
+
+    return WaitForAddress(address, timeout);
+}
+} // namespace AddressArbiter
 } // namespace Kernel

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -27,24 +27,122 @@ namespace Kernel {
             current_thread->WakeAfterDelay(timeout);
 
             Core::System::GetInstance().CpuCore(current_thread->processor_id).PrepareReschedule();
-            return RESULT_SUCCESS;
+            return current_thread->arb_wait_result;
+        }
+
+        // Gets the threads waiting on an address.
+        void GetThreadsWaitingOnAddress(std::vector<SharedPtr<Thread>> &waiting_threads, VAddr address) {
+            auto RetrieveWaitingThreads =
+                [](size_t core_index, std::vector<SharedPtr<Thread>>& waiting_threads, VAddr arb_addr) {
+                const auto& scheduler = Core::System::GetInstance().Scheduler(core_index);
+                auto& thread_list = scheduler->GetThreadList();
+
+                for (auto& thread : thread_list) {
+                    if (thread->arb_wait_address == arb_addr)
+                        waiting_threads.push_back(thread);
+                }
+            };
+
+            // Retrieve a list of all threads that are waiting for this address.
+            RetrieveWaitingThreads(0, waiting_threads, address);
+            RetrieveWaitingThreads(1, waiting_threads, address);
+            RetrieveWaitingThreads(2, waiting_threads, address);
+            RetrieveWaitingThreads(3, waiting_threads, address);
+            // Sort them by priority, such that the highest priority ones come first.
+            std::sort(waiting_threads.begin(), waiting_threads.end(),
+                [](const SharedPtr<Thread>& lhs, const SharedPtr<Thread>& rhs) {
+                return lhs->current_priority < rhs->current_priority;
+            });
+        }
+
+        // Wake up num_to_wake (or all) threads in a vector.
+        void WakeThreads(std::vector<SharedPtr<Thread>> &waiting_threads, s32 num_to_wake) {
+            // Only process up to 'target' threads, unless 'target' is <= 0, in which case process
+            // them all.
+            size_t last = waiting_threads.size();
+            if (num_to_wake > 0)
+                last = num_to_wake;
+
+            // Signal the waiting threads.
+            // TODO: Rescheduling should not occur while waking threads. How can it be prevented?
+            for (size_t i = 0; i < last; i++) {
+                ASSERT(waiting_threads[i]->status = THREADSTATUS_WAIT_ARB);
+                waiting_threads[i]->arb_wait_result = RESULT_SUCCESS;
+                waiting_threads[i]->ResumeFromWait();
+            }
+
         }
 
         // Signals an address being waited on.
-        ResultCode SignalToAddress(VAddr address, s32 value, s32 num_to_wake) {
-            // TODO
+        ResultCode SignalToAddress(VAddr address, s32 num_to_wake) {
+            // Get threads waiting on the address.
+            std::vector<SharedPtr<Thread>> waiting_threads;
+            GetThreadsWaitingOnAddress(waiting_threads, address);
+
+            WakeThreads(waiting_threads, num_to_wake);
             return RESULT_SUCCESS;
         }
 
         // Signals an address being waited on and increments its value if equal to the value argument.
         ResultCode IncrementAndSignalToAddressIfEqual(VAddr address, s32 value, s32 num_to_wake) {
-            // TODO
-            return RESULT_SUCCESS;
+            // Ensure that we can write to the address.
+            if (!Memory::IsValidVirtualAddress(address)) {
+                return ERR_INVALID_ADDRESS_STATE;
+            }
+
+            s32 cur_value;
+            // Get value, incrementing if equal.
+            {
+                // Increment if Equal must be an atomic operation.
+                std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+                cur_value = (s32)Memory::Read32(address);
+                if (cur_value == value) {
+                    Memory::Write32(address, (u32)(cur_value + 1));
+                }
+            }
+            if (cur_value != value) {
+                return ERR_INVALID_STATE;
+            }
+
+            return SignalToAddress(address, num_to_wake);
         }
 
         // Signals an address being waited on and modifies its value based on waiting thread count if equal to the value argument.
         ResultCode ModifyByWaitingCountAndSignalToAddressIfEqual(VAddr address, s32 value, s32 num_to_wake) {
-            // TODO
+            // Ensure that we can write to the address.
+            if (!Memory::IsValidVirtualAddress(address)) {
+                return ERR_INVALID_ADDRESS_STATE;
+            }
+
+            // Get threads waiting on the address.
+            std::vector<SharedPtr<Thread>> waiting_threads;
+            GetThreadsWaitingOnAddress(waiting_threads, address);
+
+            // Determine the modified value depending on the waiting count.
+            s32 updated_value;
+            if (waiting_threads.size() == 0) {
+                updated_value = value - 1;
+            } else if (num_to_wake <= 0 || waiting_threads.size() <= num_to_wake) {
+                updated_value = value + 1;
+            } else {
+                updated_value = value;
+            }
+            s32 cur_value;
+            // Perform an atomic update if equal.
+            {
+                std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+                cur_value = (s32)Memory::Read32(address);
+                if (cur_value == value) {
+                    Memory::Write32(address, (u32)(updated_value));
+                }
+            }
+
+            // Only continue if equal.
+            if (cur_value != value) {
+                return ERR_INVALID_STATE;
+            }
+
+            WakeThreads(waiting_threads, num_to_wake);
             return RESULT_SUCCESS;
         }
 

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -5,13 +5,30 @@
 #include "common/assert.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
+#include "core/core.h"
+#include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/thread.h"
+#include "core/hle/lock.h"
 #include "core/memory.h"
 
 namespace Kernel {
     namespace AddressArbiter {
+
+        // Performs actual address waiting logic.
+        ResultCode WaitForAddress(VAddr address, s64 timeout) {
+            SharedPtr<Thread> current_thread = GetCurrentThread();
+            current_thread->arb_wait_address = address;
+            current_thread->arb_wait_result = RESULT_TIMEOUT;
+            current_thread->status = THREADSTATUS_WAIT_ARB;
+            current_thread->wakeup_callback = nullptr;
+
+            current_thread->WakeAfterDelay(timeout);
+
+            Core::System::GetInstance().CpuCore(current_thread->processor_id).PrepareReschedule();
+            return RESULT_SUCCESS;
+        }
 
         // Signals an address being waited on.
         ResultCode SignalToAddress(VAddr address, s32 value, s32 num_to_wake) {
@@ -33,14 +50,48 @@ namespace Kernel {
 
         // Waits on an address if the value passed is less than the argument value, optionally decrementing.
         ResultCode WaitForAddressIfLessThan(VAddr address, s32 value, s64 timeout, bool should_decrement) {
-            // TODO
-            return RESULT_SUCCESS;
+            // Ensure that we can read the address.
+            if (!Memory::IsValidVirtualAddress(address)) {
+                return ERR_INVALID_ADDRESS_STATE;
+            }
+
+            s32 cur_value;
+            // Get value, decrementing if less than
+            {
+                // Decrement if less than must be an atomic operation.
+                std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+                cur_value = (s32)Memory::Read32(address);
+                if (cur_value < value) {
+                    Memory::Write32(address, (u32)(cur_value - 1));
+                }
+            }
+            if (cur_value >= value) {
+                return ERR_INVALID_STATE;
+            }
+            // Short-circuit without rescheduling, if timeout is zero.
+            if (timeout == 0) {
+                return RESULT_TIMEOUT;
+            }
+
+            return WaitForAddress(address, timeout);
         }
 
         // Waits on an address if the value passed is equal to the argument value.
         ResultCode WaitForAddressIfEqual(VAddr address, s32 value, s64 timeout) {
-            // TODO
-            return RESULT_SUCCESS;
+            // Ensure that we can read the address.
+            if (!Memory::IsValidVirtualAddress(address)) {
+                return ERR_INVALID_ADDRESS_STATE;
+            }
+            // Only wait for the address if equal.
+            if ((s32)Memory::Read32(address) != value) {
+                return ERR_INVALID_STATE;
+            }
+            // Short-circuit without rescheduling, if timeout is zero.
+            if (timeout == 0) {
+                return RESULT_TIMEOUT;
+            }
+
+            return WaitForAddress(address, timeout);
         }
     } // namespace AddressArbiter
 } // namespace Kernel

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -1,0 +1,46 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/assert.h"
+#include "common/common_funcs.h"
+#include "common/common_types.h"
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/kernel/process.h"
+#include "core/hle/kernel/thread.h"
+#include "core/memory.h"
+
+namespace Kernel {
+    namespace AddressArbiter {
+
+        // Signals an address being waited on.
+        ResultCode SignalToAddress(VAddr address, s32 value, s32 num_to_wake) {
+            // TODO
+            return RESULT_SUCCESS;
+        }
+
+        // Signals an address being waited on and increments its value if equal to the value argument.
+        ResultCode IncrementAndSignalToAddressIfEqual(VAddr address, s32 value, s32 num_to_wake) {
+            // TODO
+            return RESULT_SUCCESS;
+        }
+
+        // Signals an address being waited on and modifies its value based on waiting thread count if equal to the value argument.
+        ResultCode ModifyByWaitingCountAndSignalToAddressIfEqual(VAddr address, s32 value, s32 num_to_wake) {
+            // TODO
+            return RESULT_SUCCESS;
+        }
+
+        // Waits on an address if the value passed is less than the argument value, optionally decrementing.
+        ResultCode WaitForAddressIfLessThan(VAddr address, s32 value, s64 timeout, bool should_decrement) {
+            // TODO
+            return RESULT_SUCCESS;
+        }
+
+        // Waits on an address if the value passed is equal to the argument value.
+        ResultCode WaitForAddressIfEqual(VAddr address, s32 value, s64 timeout) {
+            // TODO
+            return RESULT_SUCCESS;
+        }
+    } // namespace AddressArbiter
+} // namespace Kernel

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -68,6 +68,7 @@ namespace Kernel {
             for (size_t i = 0; i < last; i++) {
                 ASSERT(waiting_threads[i]->status = THREADSTATUS_WAIT_ARB);
                 waiting_threads[i]->arb_wait_result = RESULT_SUCCESS;
+                waiting_threads[i]->arb_wait_address = 0;
                 waiting_threads[i]->ResumeFromWait();
             }
 

--- a/src/core/hle/kernel/address_arbiter.h
+++ b/src/core/hle/kernel/address_arbiter.h
@@ -21,7 +21,7 @@ namespace Kernel {
             ModifyByWaitingCountAndSignalIfEqual = 2,
         };
 
-        ResultCode SignalToAddress(VAddr address, s32 value, s32 num_to_wake);
+        ResultCode SignalToAddress(VAddr address, s32 num_to_wake);
         ResultCode IncrementAndSignalToAddressIfEqual(VAddr address, s32 value, s32 num_to_wake);
         ResultCode ModifyByWaitingCountAndSignalToAddressIfEqual(VAddr address, s32 value, s32 num_to_wake);
 

--- a/src/core/hle/kernel/address_arbiter.h
+++ b/src/core/hle/kernel/address_arbiter.h
@@ -8,25 +8,25 @@
 
 namespace Kernel {
 
-    namespace AddressArbiter {
-        enum class ArbitrationType {
-            WaitIfLessThan = 0,
-            DecrementAndWaitIfLessThan = 1,
-            WaitIfEqual = 2,
-        };
+namespace AddressArbiter {
+enum class ArbitrationType {
+    WaitIfLessThan = 0,
+    DecrementAndWaitIfLessThan = 1,
+    WaitIfEqual = 2,
+};
 
-        enum class SignalType {
-            Signal = 0,
-            IncrementAndSignalIfEqual = 1,
-            ModifyByWaitingCountAndSignalIfEqual = 2,
-        };
+enum class SignalType {
+    Signal = 0,
+    IncrementAndSignalIfEqual = 1,
+    ModifyByWaitingCountAndSignalIfEqual = 2,
+};
 
-        ResultCode SignalToAddress(VAddr address, s32 num_to_wake);
-        ResultCode IncrementAndSignalToAddressIfEqual(VAddr address, s32 value, s32 num_to_wake);
-        ResultCode ModifyByWaitingCountAndSignalToAddressIfEqual(VAddr address, s32 value, s32 num_to_wake);
+ResultCode SignalToAddress(VAddr address, s32 num_to_wake);
+ResultCode IncrementAndSignalToAddressIfEqual(VAddr address, s32 value, s32 num_to_wake);
+ResultCode ModifyByWaitingCountAndSignalToAddressIfEqual(VAddr address, s32 value, s32 num_to_wake);
 
-        ResultCode WaitForAddressIfLessThan(VAddr address, s32 value, s64 timeout, bool should_decrement);
-        ResultCode WaitForAddressIfEqual(VAddr address, s32 value, s64 timeout);
-    } // namespace AddressArbiter
+ResultCode WaitForAddressIfLessThan(VAddr address, s32 value, s64 timeout, bool should_decrement);
+ResultCode WaitForAddressIfEqual(VAddr address, s32 value, s64 timeout);
+} // namespace AddressArbiter
 
 } // namespace Kernel

--- a/src/core/hle/kernel/address_arbiter.h
+++ b/src/core/hle/kernel/address_arbiter.h
@@ -1,0 +1,32 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/result.h"
+
+namespace Kernel {
+
+    namespace AddressArbiter {
+        enum class ArbitrationType {
+            WaitIfLessThan = 0,
+            DecrementAndWaitIfLessThan = 1,
+            WaitIfEqual = 2,
+        };
+
+        enum class SignalType {
+            Signal = 0,
+            IncrementAndSignalIfEqual = 1,
+            ModifyByWaitingCountAndSignalIfEqual = 2,
+        };
+
+        ResultCode SignalToAddress(VAddr address, s32 value, s32 num_to_wake);
+        ResultCode IncrementAndSignalToAddressIfEqual(VAddr address, s32 value, s32 num_to_wake);
+        ResultCode ModifyByWaitingCountAndSignalToAddressIfEqual(VAddr address, s32 value, s32 num_to_wake);
+
+        ResultCode WaitForAddressIfLessThan(VAddr address, s32 value, s64 timeout, bool should_decrement);
+        ResultCode WaitForAddressIfEqual(VAddr address, s32 value, s64 timeout);
+    } // namespace AddressArbiter
+
+} // namespace Kernel

--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -20,13 +20,15 @@ enum {
     MaxConnectionsReached = 52,
 
     // Confirmed Switch OS error codes
-    MisalignedAddress = 102,
+    InvalidAddress = 102,
+    InvalidMemoryState = 106,
     InvalidProcessorId = 113,
     InvalidHandle = 114,
     InvalidCombination = 116,
     Timeout = 117,
     SynchronizationCanceled = 118,
     TooLarge = 119,
+    InvalidEnumValue = 120,
 };
 }
 
@@ -39,13 +41,13 @@ constexpr ResultCode ERR_SESSION_CLOSED_BY_REMOTE(-1);
 constexpr ResultCode ERR_PORT_NAME_TOO_LONG(-1);
 constexpr ResultCode ERR_WRONG_PERMISSION(-1);
 constexpr ResultCode ERR_MAX_CONNECTIONS_REACHED(-1);
-constexpr ResultCode ERR_INVALID_ENUM_VALUE(-1);
+constexpr ResultCode ERR_INVALID_ENUM_VALUE(ErrorModule::Kernel, ErrCodes::InvalidEnumValue);
 constexpr ResultCode ERR_INVALID_ENUM_VALUE_FND(-1);
 constexpr ResultCode ERR_INVALID_COMBINATION(-1);
 constexpr ResultCode ERR_INVALID_COMBINATION_KERNEL(-1);
 constexpr ResultCode ERR_OUT_OF_MEMORY(-1);
-constexpr ResultCode ERR_INVALID_ADDRESS(-1);
-constexpr ResultCode ERR_INVALID_ADDRESS_STATE(-1);
+constexpr ResultCode ERR_INVALID_ADDRESS(ErrorModule::Kernel, ErrCodes::InvalidAddress);
+constexpr ResultCode ERR_INVALID_ADDRESS_STATE(ErrorModule::Kernel, ErrCodes::InvalidMemoryState);
 constexpr ResultCode ERR_INVALID_HANDLE(ErrorModule::Kernel, ErrCodes::InvalidHandle);
 constexpr ResultCode ERR_INVALID_POINTER(-1);
 constexpr ResultCode ERR_INVALID_OBJECT_ADDR(-1);

--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -29,6 +29,7 @@ enum {
     SynchronizationCanceled = 118,
     TooLarge = 119,
     InvalidEnumValue = 120,
+    InvalidState = 125,
 };
 }
 
@@ -49,6 +50,7 @@ constexpr ResultCode ERR_OUT_OF_MEMORY(-1);
 constexpr ResultCode ERR_INVALID_ADDRESS(ErrorModule::Kernel, ErrCodes::InvalidAddress);
 constexpr ResultCode ERR_INVALID_ADDRESS_STATE(ErrorModule::Kernel, ErrCodes::InvalidMemoryState);
 constexpr ResultCode ERR_INVALID_HANDLE(ErrorModule::Kernel, ErrCodes::InvalidHandle);
+constexpr ResultCode ERR_INVALID_STATE(ErrorModule::Kernel, ErrCodes::InvalidState);
 constexpr ResultCode ERR_INVALID_POINTER(-1);
 constexpr ResultCode ERR_INVALID_OBJECT_ADDR(-1);
 constexpr ResultCode ERR_NOT_AUTHORIZED(-1);

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -59,7 +59,7 @@ ResultCode Mutex::TryAcquire(VAddr address, Handle holding_thread_handle,
                              Handle requesting_thread_handle) {
     // The mutex address must be 4-byte aligned
     if ((address % sizeof(u32)) != 0) {
-        return ResultCode(ErrorModule::Kernel, ErrCodes::MisalignedAddress);
+        return ResultCode(ErrorModule::Kernel, ErrCodes::InvalidAddress);
     }
 
     SharedPtr<Thread> holding_thread = g_handle_table.Get<Thread>(holding_thread_handle);
@@ -97,7 +97,7 @@ ResultCode Mutex::TryAcquire(VAddr address, Handle holding_thread_handle,
 ResultCode Mutex::Release(VAddr address) {
     // The mutex address must be 4-byte aligned
     if ((address % sizeof(u32)) != 0) {
-        return ResultCode(ErrorModule::Kernel, ErrCodes::MisalignedAddress);
+        return ResultCode(ErrorModule::Kernel, ErrCodes::InvalidAddress);
     }
 
     auto [thread, num_waiters] = GetHighestPriorityMutexWaitingThread(GetCurrentThread(), address);

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -693,7 +693,7 @@ static ResultCode SignalProcessWideKey(VAddr condition_variable_addr, s32 target
 // Wait for an address (via Address Arbiter)
 static ResultCode WaitForAddress(VAddr address, u32 type, s32 value, s64 timeout) {
     NGLOG_WARNING(Kernel_SVC, "called, address=0x{:X}, type=0x{:X}, value=0x{:X}, timeout={}",
-        address, type, value, timeout);
+                  address, type, value, timeout);
     // If the passed address is a kernel virtual address, return invalid memory state.
     if ((address + 0x8000000000LL) < 0x7FFFE00000LL) {
         return ERR_INVALID_ADDRESS_STATE;
@@ -704,21 +704,22 @@ static ResultCode WaitForAddress(VAddr address, u32 type, s32 value, s64 timeout
     }
 
     switch ((AddressArbiter::ArbitrationType)type) {
-        case AddressArbiter::ArbitrationType::WaitIfLessThan:
-            return AddressArbiter::WaitForAddressIfLessThan(address, value, timeout, false);
-        case AddressArbiter::ArbitrationType::DecrementAndWaitIfLessThan:
-            return AddressArbiter::WaitForAddressIfLessThan(address, value, timeout, true);
-        case AddressArbiter::ArbitrationType::WaitIfEqual:
-            return AddressArbiter::WaitForAddressIfEqual(address, value, timeout);
-        default:
-            return ERR_INVALID_ENUM_VALUE;
+    case AddressArbiter::ArbitrationType::WaitIfLessThan:
+        return AddressArbiter::WaitForAddressIfLessThan(address, value, timeout, false);
+    case AddressArbiter::ArbitrationType::DecrementAndWaitIfLessThan:
+        return AddressArbiter::WaitForAddressIfLessThan(address, value, timeout, true);
+    case AddressArbiter::ArbitrationType::WaitIfEqual:
+        return AddressArbiter::WaitForAddressIfEqual(address, value, timeout);
+    default:
+        return ERR_INVALID_ENUM_VALUE;
     }
 }
 
 // Signals to an address (via Address Arbiter)
 static ResultCode SignalToAddress(VAddr address, u32 type, s32 value, s32 num_to_wake) {
-    NGLOG_WARNING(Kernel_SVC, "called, address=0x{:X}, type=0x{:X}, value=0x{:X}, num_to_wake=0x{:X}",
-        address, type, value, num_to_wake);
+    NGLOG_WARNING(Kernel_SVC,
+                  "called, address=0x{:X}, type=0x{:X}, value=0x{:X}, num_to_wake=0x{:X}", address,
+                  type, value, num_to_wake);
     // If the passed address is a kernel virtual address, return invalid memory state.
     if ((address + 0x8000000000LL) < 0x7FFFE00000LL) {
         return ERR_INVALID_ADDRESS_STATE;
@@ -729,14 +730,15 @@ static ResultCode SignalToAddress(VAddr address, u32 type, s32 value, s32 num_to
     }
 
     switch ((AddressArbiter::SignalType)type) {
-        case AddressArbiter::SignalType::Signal:
-            return AddressArbiter::SignalToAddress(address, num_to_wake);
-        case AddressArbiter::SignalType::IncrementAndSignalIfEqual:
-            return AddressArbiter::IncrementAndSignalToAddressIfEqual(address, value, num_to_wake);
-        case AddressArbiter::SignalType::ModifyByWaitingCountAndSignalIfEqual:
-            return AddressArbiter::ModifyByWaitingCountAndSignalToAddressIfEqual(address, value, num_to_wake);
-        default:
-            return ERR_INVALID_ENUM_VALUE;
+    case AddressArbiter::SignalType::Signal:
+        return AddressArbiter::SignalToAddress(address, num_to_wake);
+    case AddressArbiter::SignalType::IncrementAndSignalIfEqual:
+        return AddressArbiter::IncrementAndSignalToAddressIfEqual(address, value, num_to_wake);
+    case AddressArbiter::SignalType::ModifyByWaitingCountAndSignalIfEqual:
+        return AddressArbiter::ModifyByWaitingCountAndSignalToAddressIfEqual(address, value,
+                                                                             num_to_wake);
+    default:
+        return ERR_INVALID_ENUM_VALUE;
     }
 }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -695,7 +695,7 @@ static ResultCode WaitForAddress(VAddr address, u32 type, s32 value, s64 timeout
     NGLOG_WARNING(Kernel_SVC, "called, address=0x{:X}, type=0x{:X}, value=0x{:X}, timeout={}",
                   address, type, value, timeout);
     // If the passed address is a kernel virtual address, return invalid memory state.
-    if ((address + 0x8000000000LL) < 0x7FFFE00000LL) {
+    if (Memory::IsKernelVirtualAddress(address)) {
         return ERR_INVALID_ADDRESS_STATE;
     }
     // If the address is not properly aligned to 4 bytes, return invalid address.
@@ -703,7 +703,7 @@ static ResultCode WaitForAddress(VAddr address, u32 type, s32 value, s64 timeout
         return ERR_INVALID_ADDRESS;
     }
 
-    switch ((AddressArbiter::ArbitrationType)type) {
+    switch (static_cast<AddressArbiter::ArbitrationType>(type)) {
     case AddressArbiter::ArbitrationType::WaitIfLessThan:
         return AddressArbiter::WaitForAddressIfLessThan(address, value, timeout, false);
     case AddressArbiter::ArbitrationType::DecrementAndWaitIfLessThan:
@@ -721,7 +721,7 @@ static ResultCode SignalToAddress(VAddr address, u32 type, s32 value, s32 num_to
                   "called, address=0x{:X}, type=0x{:X}, value=0x{:X}, num_to_wake=0x{:X}", address,
                   type, value, num_to_wake);
     // If the passed address is a kernel virtual address, return invalid memory state.
-    if ((address + 0x8000000000LL) < 0x7FFFE00000LL) {
+    if (Memory::IsKernelVirtualAddress(address)) {
         return ERR_INVALID_ADDRESS_STATE;
     }
     // If the address is not properly aligned to 4 bytes, return invalid address.
@@ -729,7 +729,7 @@ static ResultCode SignalToAddress(VAddr address, u32 type, s32 value, s32 num_to
         return ERR_INVALID_ADDRESS;
     }
 
-    switch ((AddressArbiter::SignalType)type) {
+    switch (static_cast<AddressArbiter::SignalType>(type)) {
     case AddressArbiter::SignalType::Signal:
         return AddressArbiter::SignalToAddress(address, num_to_wake);
     case AddressArbiter::SignalType::IncrementAndSignalIfEqual:

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -692,6 +692,8 @@ static ResultCode SignalProcessWideKey(VAddr condition_variable_addr, s32 target
 
 // Wait for an address (via Address Arbiter)
 static ResultCode WaitForAddress(VAddr address, u32 type, s32 value, s64 timeout) {
+    NGLOG_WARNING(Kernel_SVC, "called, address=0x{:X}, type=0x{:X}, value=0x{:X}, timeout={}",
+        address, type, value, timeout);
     // If the passed address is a kernel virtual address, return invalid memory state.
     if ((address + 0x8000000000LL) < 0x7FFFE00000LL) {
         return ERR_INVALID_ADDRESS_STATE;
@@ -715,6 +717,8 @@ static ResultCode WaitForAddress(VAddr address, u32 type, s32 value, s64 timeout
 
 // Signals to an address (via Address Arbiter)
 static ResultCode SignalToAddress(VAddr address, u32 type, s32 value, s32 num_to_wake) {
+    NGLOG_WARNING(Kernel_SVC, "called, address=0x{:X}, type=0x{:X}, value=0x{:X}, num_to_wake=0x{:X}",
+        address, type, value, num_to_wake);
     // If the passed address is a kernel virtual address, return invalid memory state.
     if ((address + 0x8000000000LL) < 0x7FFFE00000LL) {
         return ERR_INVALID_ADDRESS_STATE;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -726,7 +726,7 @@ static ResultCode SignalToAddress(VAddr address, u32 type, s32 value, s32 num_to
 
     switch ((AddressArbiter::SignalType)type) {
         case AddressArbiter::SignalType::Signal:
-            return AddressArbiter::SignalToAddress(address, value, num_to_wake);
+            return AddressArbiter::SignalToAddress(address, num_to_wake);
         case AddressArbiter::SignalType::IncrementAndSignalIfEqual:
             return AddressArbiter::IncrementAndSignalToAddressIfEqual(address, value, num_to_wake);
         case AddressArbiter::SignalType::ModifyByWaitingCountAndSignalIfEqual:

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -181,12 +181,16 @@ void SvcWrap() {
 
 template <ResultCode func(u64, u32, s32, s64)>
 void SvcWrap() {
-    FuncReturn(func(PARAM(0), (u32)(PARAM(1) & 0xFFFFFFFF), (s32)(PARAM(2) & 0xFFFFFFFF), (s64)PARAM(3)).raw);
+    FuncReturn(
+        func(PARAM(0), (u32)(PARAM(1) & 0xFFFFFFFF), (s32)(PARAM(2) & 0xFFFFFFFF), (s64)PARAM(3))
+            .raw);
 }
 
 template <ResultCode func(u64, u32, s32, s32)>
 void SvcWrap() {
-    FuncReturn(func(PARAM(0), (u32)(PARAM(1) & 0xFFFFFFFF), (s32)(PARAM(2) & 0xFFFFFFFF), (s32)(PARAM(3) & 0xFFFFFFFF)).raw);
+    FuncReturn(func(PARAM(0), (u32)(PARAM(1) & 0xFFFFFFFF), (s32)(PARAM(2) & 0xFFFFFFFF),
+                    (s32)(PARAM(3) & 0xFFFFFFFF))
+                   .raw);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -179,6 +179,16 @@ void SvcWrap() {
     FuncReturn(retval);
 }
 
+template <ResultCode func(u64, u32, s32, s64)>
+void SvcWrap() {
+    FuncReturn(func(PARAM(0), (u32)(PARAM(1) & 0xFFFFFFFF), (s32)(PARAM(2) & 0xFFFFFFFF), (s64)PARAM(3)).raw);
+}
+
+template <ResultCode func(u64, u32, s32, s32)>
+void SvcWrap() {
+    FuncReturn(func(PARAM(0), (u32)(PARAM(1) & 0xFFFFFFFF), (s32)(PARAM(2) & 0xFFFFFFFF), (s32)(PARAM(3) & 0xFFFFFFFF)).raw);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Function wrappers that return type u32
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -140,6 +140,11 @@ static void ThreadWakeupCallback(u64 thread_handle, int cycles_late) {
         }
     }
 
+    if (thread->arb_wait_address != 0) {
+        ASSERT(thread->status == THREADSTATUS_WAIT_ARB);
+        thread->arb_wait_address = 0;
+    }
+
     if (resume)
         thread->ResumeFromWait();
 }
@@ -179,6 +184,7 @@ void Thread::ResumeFromWait() {
     case THREADSTATUS_WAIT_SLEEP:
     case THREADSTATUS_WAIT_IPC:
     case THREADSTATUS_WAIT_MUTEX:
+    case THREADSTATUS_WAIT_ARB:
         break;
 
     case THREADSTATUS_READY:

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -230,8 +230,10 @@ public:
     VAddr condvar_wait_address;
     VAddr mutex_wait_address;   ///< If waiting on a Mutex, this is the mutex address
     Handle wait_handle;         ///< The handle used to wait for the mutex.
-    VAddr arb_wait_address;     ///< If waiting for an AddressArbiter, this is the address
-    ResultCode arb_wait_result; ///< If waiting for an AddressArbiter, this is the result that will be returned.
+
+    // If waiting for an AddressArbiter, this is the address being waited on.
+    VAddr arb_wait_address;
+    ResultCode arb_wait_result{RESULT_SUCCESS}; ///< Result returned when done waiting on AddressArbiter.
 
     std::string name;
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -228,8 +228,8 @@ public:
 
     // If waiting on a ConditionVariable, this is the ConditionVariable  address
     VAddr condvar_wait_address;
-    VAddr mutex_wait_address;   ///< If waiting on a Mutex, this is the mutex address
-    Handle wait_handle;         ///< The handle used to wait for the mutex.
+    VAddr mutex_wait_address; ///< If waiting on a Mutex, this is the mutex address
+    Handle wait_handle;       ///< The handle used to wait for the mutex.
 
     // If waiting for an AddressArbiter, this is the address being waited on.
     VAddr arb_wait_address{0};

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -233,7 +233,6 @@ public:
 
     // If waiting for an AddressArbiter, this is the address being waited on.
     VAddr arb_wait_address{0};
-    ResultCode arb_wait_result{RESULT_SUCCESS}; ///< Result returned when done waiting on AddressArbiter.
 
     std::string name;
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -45,6 +45,7 @@ enum ThreadStatus {
     THREADSTATUS_WAIT_SYNCH_ANY, ///< Waiting due to WaitSynch1 or WaitSynchN with wait_all = false
     THREADSTATUS_WAIT_SYNCH_ALL, ///< Waiting due to WaitSynchronizationN with wait_all = true
     THREADSTATUS_WAIT_MUTEX,     ///< Waiting due to an ArbitrateLock/WaitProcessWideKey svc
+    THREADSTATUS_WAIT_ARB,       ///< Waiting due to a SignalToAddress/WaitForAddress svc
     THREADSTATUS_DORMANT,        ///< Created but not yet made ready
     THREADSTATUS_DEAD            ///< Run to completion, or forcefully terminated
 };

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -228,8 +228,10 @@ public:
 
     // If waiting on a ConditionVariable, this is the ConditionVariable  address
     VAddr condvar_wait_address;
-    VAddr mutex_wait_address; ///< If waiting on a Mutex, this is the mutex address
-    Handle wait_handle;       ///< The handle used to wait for the mutex.
+    VAddr mutex_wait_address;   ///< If waiting on a Mutex, this is the mutex address
+    Handle wait_handle;         ///< The handle used to wait for the mutex.
+    VAddr arb_wait_address;     ///< If waiting for an AddressArbiter, this is the address
+    ResultCode arb_wait_result; ///< If waiting for an AddressArbiter, this is the result that will be returned.
 
     std::string name;
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -232,7 +232,7 @@ public:
     Handle wait_handle;         ///< The handle used to wait for the mutex.
 
     // If waiting for an AddressArbiter, this is the address being waited on.
-    VAddr arb_wait_address;
+    VAddr arb_wait_address{0};
     ResultCode arb_wait_result{RESULT_SUCCESS}; ///< Result returned when done waiting on AddressArbiter.
 
     std::string name;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -241,6 +241,10 @@ bool IsValidVirtualAddress(const VAddr vaddr) {
     return IsValidVirtualAddress(*Core::CurrentProcess(), vaddr);
 }
 
+bool IsKernelVirtualAddress(const VAddr vaddr) {
+    return KERNEL_REGION_VADDR <= vaddr && vaddr < KERNEL_REGION_END;
+}
+
 bool IsValidPhysicalAddress(const PAddr paddr) {
     return GetPhysicalPointer(paddr) != nullptr;
 }

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -188,6 +188,11 @@ enum : VAddr {
     MAP_REGION_VADDR = NEW_MAP_REGION_VADDR_END,
     MAP_REGION_SIZE = 0x1000000000,
     MAP_REGION_VADDR_END = MAP_REGION_VADDR + MAP_REGION_SIZE,
+
+    /// Kernel Virtual Address Range
+    KERNEL_REGION_VADDR = 0xFFFFFF8000000000,
+    KERNEL_REGION_SIZE = 0x7FFFE00000,
+    KERNEL_REGION_END = KERNEL_REGION_VADDR + KERNEL_REGION_SIZE,
 };
 
 /// Currently active page table
@@ -197,6 +202,8 @@ PageTable* GetCurrentPageTable();
 /// Determines if the given VAddr is valid for the specified process.
 bool IsValidVirtualAddress(const Kernel::Process& process, const VAddr vaddr);
 bool IsValidVirtualAddress(const VAddr addr);
+/// Determines if the given VAddr is a kernel address
+bool IsKernelVirtualAddress(const VAddr addr);
 
 bool IsValidPhysicalAddress(const PAddr addr);
 

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -213,7 +213,7 @@ QString WaitTreeThread::GetText() const {
     case THREADSTATUS_WAIT_MUTEX:
         status = tr("waiting for mutex");
         break;
-    case THREADSTATUS_WAIT_MUTEX:
+    case THREADSTATUS_WAIT_ARB:
         status = tr("waiting for address arbiter");
         break;
     case THREADSTATUS_DORMANT:

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -213,6 +213,9 @@ QString WaitTreeThread::GetText() const {
     case THREADSTATUS_WAIT_MUTEX:
         status = tr("waiting for mutex");
         break;
+    case THREADSTATUS_WAIT_MUTEX:
+        status = tr("waiting for address arbiter");
+        break;
     case THREADSTATUS_DORMANT:
         status = tr("dormant");
         break;
@@ -240,6 +243,7 @@ QColor WaitTreeThread::GetColor() const {
     case THREADSTATUS_WAIT_SYNCH_ALL:
     case THREADSTATUS_WAIT_SYNCH_ANY:
     case THREADSTATUS_WAIT_MUTEX:
+    case THREADSTATUS_WAIT_ARB:
         return QColor(Qt::GlobalColor::red);
     case THREADSTATUS_DORMANT:
         return QColor(Qt::GlobalColor::darkCyan);


### PR DESCRIPTION
These SVCs were introduced in 4.0.0, and are used by newer games to implement intra-process Event primitives (Mario Tennis Aces uses them, for example).

I also modified the "MisalignedAddress" error code to reflect its true meaning as "InvalidAddress", and further filled in several ERR_ definitions to return console-accurate codes.