### PR TITLE
Fixed RequestUpdateAudioRenderer deadlocks and calculated section sizes properly

### DIFF
--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -120,7 +120,7 @@ private:
         NGLOG_WARNING(Service_Audio, "(STUBBED) called");
     }
 
-    enum class MemoryPoolStates : u32_le {
+    enum class MemoryPoolStates : u32 { // Should be LE
         Invalid = 0x0,
         Unknown = 0x1,
         RequestDetatch = 0x2,

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -315,7 +315,7 @@ void AudRenU::GetAudioRendererWorkBufferSize(Kernel::HLERequestContext& ctx) {
                             (params.unknown8 + 6),
                         0x40);
 
-    if (IsFeatureSupported(AudioFeatures::Splitter, params.magic)) {
+    if (IsFeatureSupported(AudioFeatures::Splitter, params.revision)) {
         u32 count = params.unknownC + 1;
         u64 node_count = Common::AlignUp(count, 0x40);
         u64 node_state_buffer_sz =
@@ -331,7 +331,7 @@ void AudRenU::GetAudioRendererWorkBufferSize(Kernel::HLERequestContext& ctx) {
     }
 
     buffer_sz += 0x20 * (params.effect_count + 4 * params.voice_count) + 0x50;
-    if (IsFeatureSupported(AudioFeatures::Splitter, params.magic)) {
+    if (IsFeatureSupported(AudioFeatures::Splitter, params.revision)) {
         buffer_sz += 0xE0 * params.unknown2c;
         buffer_sz += 0x20 * params.splitter_count;
         buffer_sz += Common::AlignUp(4 * params.unknown2c, 0x10);

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -76,10 +76,10 @@ private:
         std::memcpy(output.data(), &response_data, sizeof(AudioRendererResponse));
         std::vector<MemoryPoolEntry> memory_pool(memory_pool_count);
         for (unsigned i = 0; i < memory_pool.size(); i++) {
-            if (mem_pool_info[i].pool_state == MemoryPoolStates::MPS_RequestAttach)
-                memory_pool[i].state = MemoryPoolStates::MPS_Attached;
-            else if (mem_pool_info[i].pool_state == MemoryPoolStates::MPS_RequestDetatch)
-                memory_pool[i].state = MemoryPoolStates::MPS_Detatched;
+            if (mem_pool_info[i].pool_state == MemoryPoolStates::RequestAttach)
+                memory_pool[i].state = MemoryPoolStates::Attached;
+            else if (mem_pool_info[i].pool_state == MemoryPoolStates::RequestDetatch)
+                memory_pool[i].state = MemoryPoolStates::Detatched;
             else
                 memory_pool[i].state = mem_pool_info[i].pool_state;
         }
@@ -120,8 +120,18 @@ private:
         NGLOG_WARNING(Service_Audio, "(STUBBED) called");
     }
 
+    enum class MemoryPoolStates : u32_le {
+        Invalid = 0x0,
+        Unknown = 0x1,
+        RequestDetatch = 0x2,
+        Detatched = 0x3,
+        RequestAttach = 0x4,
+        Attached = 0x5,
+        Released = 0x6,
+    };
+
     struct MemoryPoolEntry {
-        u32_le state;
+        MemoryPoolStates state;
         u32_le unknown_4;
         u32_le unknown_8;
         u32_le unknown_c;
@@ -131,20 +141,10 @@ private:
     struct MemoryPoolInfo {
         u64_le pool_address;
         u64_le pool_size;
-        u32_le pool_state;
+        MemoryPoolStates pool_state;
         INSERT_PADDING_WORDS(3); // Unknown
     };
     static_assert(sizeof(MemoryPoolInfo) == 0x20, "MemoryPoolInfo has wrong size");
-
-    enum MemoryPoolStates : u32 {
-        MPS_Invalid = 0x0,
-        MPS_Unknown = 0x1,
-        MPS_RequestDetatch = 0x2,
-        MPS_Detatched = 0x3,
-        MPS_RequestAttach = 0x4,
-        MPS_Attached = 0x5,
-        MPS_Released = 0x6,
-    };
 
     struct AudioRendererConfig {
         u32 revision;

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -332,9 +332,9 @@ void AudRenU::GetAudioRendererWorkBufferSize(Kernel::HLERequestContext& ctx) {
 
     buffer_sz += 0x20 * (params.effect_count + 4 * params.voice_count) + 0x50;
     if (IsFeatureSupported(AudioFeatures::Splitter, params.revision)) {
-        buffer_sz += 0xE0 * params.unknown2c;
+        buffer_sz += 0xE0 * params.unknown_2c;
         buffer_sz += 0x20 * params.splitter_count;
-        buffer_sz += Common::AlignUp(4 * params.unknown2c, 0x10);
+        buffer_sz += Common::AlignUp(4 * params.unknown_2c, 0x10);
     }
     buffer_sz = Common::AlignUp(buffer_sz, 0x40) + 0x170 * params.sink_count;
     u64 output_sz = buffer_sz + 0x280 * params.sink_count + 0x4B0 * params.effect_count +

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -17,8 +17,8 @@ constexpr u64 audio_ticks{static_cast<u64>(CoreTiming::BASE_CLOCK_RATE / 200)};
 
 class IAudioRenderer final : public ServiceFramework<IAudioRenderer> {
 public:
-    IAudioRenderer(AudioRendererParameters _worker_params)
-        : ServiceFramework("IAudioRenderer"), worker_params(_worker_params) {
+    IAudioRenderer(AudioRendererParameters audren_params)
+        : ServiceFramework("IAudioRenderer"), worker_params(audren_params) {
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetAudioRendererSampleRate"},
             {1, nullptr, "GetAudioRendererSampleCount"},
@@ -304,19 +304,19 @@ void AudRenU::GetAudioRendererWorkBufferSize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     auto params = rp.PopRaw<AudioRendererParameters>();
 
-    u64 buffer_sz = Common::AlignUp(4 * params.unknown8, 0x40);
-    buffer_sz += params.unknownC * 1024;
-    buffer_sz += 0x940 * (params.unknownC + 1);
+    u64 buffer_sz = Common::AlignUp(4 * params.unknown_8, 0x40);
+    buffer_sz += params.unknown_c * 1024;
+    buffer_sz += 0x940 * (params.unknown_c + 1);
     buffer_sz += 0x3F0 * params.voice_count;
-    buffer_sz += Common::AlignUp(8 * (params.unknownC + 1), 0x10);
+    buffer_sz += Common::AlignUp(8 * (params.unknown_c + 1), 0x10);
     buffer_sz += Common::AlignUp(8 * params.voice_count, 0x10);
     buffer_sz +=
-        Common::AlignUp((0x3C0 * (params.sink_count + params.unknownC) + 4 * params.sample_count) *
-                            (params.unknown8 + 6),
+        Common::AlignUp((0x3C0 * (params.sink_count + params.unknown_c) + 4 * params.sample_count) *
+                            (params.unknown_8 + 6),
                         0x40);
 
     if (IsFeatureSupported(AudioFeatures::Splitter, params.revision)) {
-        u32 count = params.unknownC + 1;
+        u32 count = params.unknown_c + 1;
         u64 node_count = Common::AlignUp(count, 0x40);
         u64 node_state_buffer_sz =
             4 * (node_count * node_count) + 0xC * node_count + 2 * (node_count / 8);
@@ -340,11 +340,11 @@ void AudRenU::GetAudioRendererWorkBufferSize(Kernel::HLERequestContext& ctx) {
     u64 output_sz = buffer_sz + 0x280 * params.sink_count + 0x4B0 * params.effect_count +
                     ((params.voice_count * 256) | 0x40);
 
-    if (params.unknown1c >= 1) {
+    if (params.unknown_1c >= 1) {
         output_sz = Common::AlignUp(((16 * params.sink_count + 16 * params.effect_count +
                                       16 * params.voice_count + 16) +
                                      0x658) *
-                                            (params.unknown1c + 1) +
+                                            (params.unknown_1c + 1) +
                                         0xc0,
                                     0x40) +
                     output_sz;

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -78,8 +78,8 @@ private:
         for (unsigned i = 0; i < memory_pool.size(); i++) {
             if (mem_pool_info[i].pool_state == MemoryPoolStates::RequestAttach)
                 memory_pool[i].state = MemoryPoolStates::Attached;
-            else if (mem_pool_info[i].pool_state == MemoryPoolStates::RequestDetatch)
-                memory_pool[i].state = MemoryPoolStates::Detatched;
+            else if (mem_pool_info[i].pool_state == MemoryPoolStates::RequestDetach)
+                memory_pool[i].state = MemoryPoolStates::Detached;
             else
                 memory_pool[i].state = mem_pool_info[i].pool_state;
         }
@@ -123,8 +123,8 @@ private:
     enum class MemoryPoolStates : u32 { // Should be LE
         Invalid = 0x0,
         Unknown = 0x1,
-        RequestDetatch = 0x2,
-        Detatched = 0x3,
+        RequestDetach = 0x2,
+        Detached = 0x3,
         RequestAttach = 0x4,
         Attached = 0x5,
         Released = 0x6,

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -163,7 +163,7 @@ private:
 
     struct AudioRendererResponse {
         AudioRendererResponse(const AudioRendererParameters& config) {
-            revision = config.magic;
+            revision = config.revision;
             error_info_size = 0xb0;
             memory_pools_size = (config.effect_count + (config.voice_count * 4)) * 0x10;
             voices_size = config.voice_count * 0x10;

--- a/src/core/hle/service/audio/audren_u.h
+++ b/src/core/hle/service/audio/audren_u.h
@@ -22,11 +22,11 @@ struct AudioRendererParameters {
     u32_le effect_count;
     u32_le unknown1c;
     u8 unknown20;
-    u8 padding1[3];
+    INSERT_PADDING_BYTES(3);
     u32_le splitter_count;
     u32_le unknown2c;
-    u8 padding2[4];
-    u32_le magic;
+    INSERT_PADDING_WORDS(1);
+    u32_le revision;
 };
 static_assert(sizeof(AudioRendererParameters) == 52, "AudioRendererParameters is an invalid size");
 

--- a/src/core/hle/service/audio/audren_u.h
+++ b/src/core/hle/service/audio/audren_u.h
@@ -12,6 +12,24 @@ class HLERequestContext;
 
 namespace Service::Audio {
 
+struct AudioRendererParameters {
+    u32_le sample_rate;
+    u32_le sample_count;
+    u32_le unknown8;
+    u32_le unknownC;
+    u32_le voice_count;
+    u32_le sink_count;
+    u32_le effect_count;
+    u32_le unknown1c;
+    u8 unknown20;
+    u8 padding1[3];
+    u32_le splitter_count;
+    u32_le unknown2c;
+    u8 padding2[4];
+    u32_le magic;
+};
+static_assert(sizeof(AudioRendererParameters) == 52, "AudioRendererParameters is an invalid size");
+
 class AudRenU final : public ServiceFramework<AudRenU> {
 public:
     explicit AudRenU();
@@ -21,25 +39,6 @@ private:
     void OpenAudioRenderer(Kernel::HLERequestContext& ctx);
     void GetAudioRendererWorkBufferSize(Kernel::HLERequestContext& ctx);
     void GetAudioDevice(Kernel::HLERequestContext& ctx);
-
-    struct AudioRendererParameters {
-        u32_le sample_rate;
-        u32_le sample_count;
-        u32_le unknown8;
-        u32_le unknownC;
-        u32_le voice_count;
-        u32_le sink_count;
-        u32_le effect_count;
-        u32_le unknown1c;
-        u8 unknown20;
-        u8 padding1[3];
-        u32_le splitter_count;
-        u32_le unknown2c;
-        u8 padding2[4];
-        u32_le magic;
-    };
-    static_assert(sizeof(AudioRendererParameters) == 52,
-                  "AudioRendererParameters is an invalid size");
 
     enum class AudioFeatures : u32 {
         Splitter,

--- a/src/core/hle/service/audio/audren_u.h
+++ b/src/core/hle/service/audio/audren_u.h
@@ -15,16 +15,16 @@ namespace Service::Audio {
 struct AudioRendererParameters {
     u32_le sample_rate;
     u32_le sample_count;
-    u32_le unknown8;
-    u32_le unknownC;
+    u32_le unknown_8;
+    u32_le unknown_c;
     u32_le voice_count;
     u32_le sink_count;
     u32_le effect_count;
-    u32_le unknown1c;
-    u8 unknown20;
+    u32_le unknown_1c;
+    u8 unknown_20;
     INSERT_PADDING_BYTES(3);
     u32_le splitter_count;
-    u32_le unknown2c;
+    u32_le unknown_2c;
     INSERT_PADDING_WORDS(1);
     u32_le revision;
 };


### PR DESCRIPTION
This fixes RequestUpdateAudioRenderer deadlocks in games like Puyo Puyo Tetris and games which require a proper section size in games such as Retro City Rampage. This fix causes various games to start rendering or trying to render. This is an iteration on #577