### PR TITLE
Send the correct RequestUpdateAudioRenderer revision in the output header

### DIFF
--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -150,7 +150,7 @@ private:
         UpdateDataHeader() {}
 
         UpdateDataHeader(const AudioRendererParameter& config) {
-            revision = Common::MakeMagic('R', 'E', 'V', '4');
+            revision = Common::MakeMagic('R', 'E', 'V', '4'); // 5.1.0 Revision
             behavior_size = 0xb0;
             memory_pools_size = (config.effect_count + (config.voice_count * 4)) * 0x10;
             voices_size = config.voice_count * 0x10;

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -150,7 +150,7 @@ private:
         UpdateDataHeader() {}
 
         UpdateDataHeader(const AudioRendererParameter& config) {
-            revision = config.revision;
+            revision = Common::MakeMagic('R', 'E', 'V', '4');
             behavior_size = 0xb0;
             memory_pools_size = (config.effect_count + (config.voice_count * 4)) * 0x10;
             voices_size = config.voice_count * 0x10;


### PR DESCRIPTION
Hardware test on a 5.1.0 console shows the latest revision is sent instead of the one provided by the AudioRendererParameter. As of 5.1.0, REV4 is the latest revision.