### PR TITLE
OpenGL: Use MakeCurrent/DoneCurrent for multithreaded rendering.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -15,6 +15,7 @@
 #include "common/microprofile.h"
 #include "common/scope_exit.h"
 #include "core/core.h"
+#include "core/frontend/emu_window.h"
 #include "core/hle/kernel/process.h"
 #include "core/settings.h"
 #include "video_core/engines/maxwell_3d.h"
@@ -22,6 +23,7 @@
 #include "video_core/renderer_opengl/gl_shader_gen.h"
 #include "video_core/renderer_opengl/maxwell_to_gl.h"
 #include "video_core/renderer_opengl/renderer_opengl.h"
+#include "video_core/video_core.h"
 
 using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 using PixelFormat = SurfaceParams::PixelFormat;
@@ -394,6 +396,8 @@ void RasterizerOpenGL::Clear() {
     if (clear_mask == 0)
         return;
 
+    ScopeAcquireGLContext acquire_context;
+
     auto [dirty_color_surface, dirty_depth_surface] =
         ConfigureFramebuffers(use_color_fb, use_depth_fb);
 
@@ -419,6 +423,8 @@ void RasterizerOpenGL::DrawArrays() {
 
     MICROPROFILE_SCOPE(OpenGL_Drawing);
     const auto& regs = Core::System().GetInstance().GPU().Maxwell3D().regs;
+
+    ScopeAcquireGLContext acquire_context;
 
     auto [dirty_color_surface, dirty_depth_surface] =
         ConfigureFramebuffers(true, regs.zeta.Address() != 0);

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -31,6 +31,13 @@ struct ScreenInfo {
     TextureInfo texture;
 };
 
+/// Helper class to acquire/release OpenGL context within a given scope
+class ScopeAcquireGLContext : NonCopyable {
+public:
+    ScopeAcquireGLContext();
+    ~ScopeAcquireGLContext();
+};
+
 class RendererOpenGL : public RendererBase {
 public:
     RendererOpenGL();

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -20,7 +20,10 @@
 EmuThread::EmuThread(GRenderWindow* render_window) : render_window(render_window) {}
 
 void EmuThread::run() {
-    render_window->MakeCurrent();
+    if (!Settings::values.use_multi_core) {
+        // Single core mode must acquire OpenGL context for entire emulation session
+        render_window->MakeCurrent();
+    }
 
     MicroProfileOnThreadCreate("EmuThread");
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -374,6 +374,8 @@ bool GMainWindow::LoadROM(const QString& filename) {
 
     const Core::System::ResultStatus result{system.Load(render_window, filename.toStdString())};
 
+    render_window->DoneCurrent();
+
     if (result != Core::System::ResultStatus::Success) {
         switch (result) {
         case Core::System::ResultStatus::ErrorGetLoader:
@@ -916,6 +918,7 @@ int main(int argc, char* argv[]) {
     QCoreApplication::setApplicationName("yuzu");
 
     QApplication::setAttribute(Qt::AA_X11InitThreads);
+    QApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);
     QApplication app(argc, argv);
 
     // Qt changes the locale and causes issues in float conversion using std::to_string() when

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -148,6 +148,11 @@ int main(int argc, char** argv) {
 
     std::unique_ptr<EmuWindow_SDL2> emu_window{std::make_unique<EmuWindow_SDL2>(fullscreen)};
 
+    if (!Settings::values.use_multi_core) {
+        // Single core mode must acquire OpenGL context for entire emulation session
+        emu_window->MakeCurrent();
+    }
+
     Core::System& system{Core::System::GetInstance()};
 
     SCOPE_EXIT({ system.Shutdown(); });


### PR DESCRIPTION
A simpler approach to fixing rendering with the "multi core" feature without doing shared context stuff, or serializing graphics calls. This is _probably_ fine. YMMV.