### PR TITLE
GPU: Corrected the size of the MUFU subop field, and removed incorrect "min" operation.

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -165,7 +165,6 @@ enum class SubOp : u64 {
     Lg2 = 0x3,
     Rcp = 0x4,
     Rsq = 0x5,
-    Min = 0x8,
 };
 
 enum class F2iRoundingOp : u64 {
@@ -209,7 +208,7 @@ union Instruction {
     } pred;
     BitField<19, 1, u64> negate_pred;
     BitField<20, 8, Register> gpr20;
-    BitField<20, 7, SubOp> sub_op;
+    BitField<20, 4, SubOp> sub_op;
     BitField<28, 8, Register> gpr28;
     BitField<39, 8, Register> gpr39;
     BitField<48, 16, u64> opcode;

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -907,10 +907,6 @@ private:
                     regs.SetRegisterToFloat(instr.gpr0, 0, "inversesqrt(" + op_a + ')', 1, 1,
                                             instr.alu.saturate_d);
                     break;
-                case SubOp::Min:
-                    regs.SetRegisterToFloat(instr.gpr0, 0, "min(" + op_a + "," + op_b + ')', 1, 1,
-                                            instr.alu.saturate_d);
-                    break;
                 default:
                     NGLOG_CRITICAL(HW_GPU, "Unhandled MUFU sub op: {0:x}",
                                    static_cast<unsigned>(instr.sub_op.Value()));


### PR DESCRIPTION
The field is 4 bits long. Operation 8 is unknown but it's most certainly not 'min'. 
nouveau does not emit this operation.