### PR TITLE
GPU: Remove unmapped surfaces from the rasterizer cache and fix our nvmap::Free behavior.

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
@@ -8,6 +8,8 @@
 #include "core/core.h"
 #include "core/hle/service/nvdrv/devices/nvhost_as_gpu.h"
 #include "core/hle/service/nvdrv/devices/nvmap.h"
+#include "video_core/renderer_base.h"
+#include "video_core/video_core.h"
 
 namespace Service::Nvidia::Devices {
 
@@ -153,6 +155,9 @@ u32 nvhost_as_gpu::UnmapBuffer(const std::vector<u8>& input, std::vector<u8>& ou
     auto itr = buffer_mappings.find(params.offset);
 
     ASSERT_MSG(itr != buffer_mappings.end(), "Tried to unmap invalid mapping");
+
+    // Remove this memory region from the rasterizer cache.
+    VideoCore::g_renderer->Rasterizer()->FlushAndInvalidateRegion(params.offset, itr->second.size);
 
     params.offset = gpu.memory_manager->UnmapBuffer(params.offset, itr->second.size);
 

--- a/src/core/hle/service/nvdrv/devices/nvmap.h
+++ b/src/core/hle/service/nvdrv/devices/nvmap.h
@@ -94,7 +94,7 @@ private:
     struct IocFreeParams {
         u32_le handle;
         INSERT_PADDING_BYTES(4);
-        u64_le refcount;
+        u64_le address;
         u32_le size;
         u32_le flags;
     };


### PR DESCRIPTION
This fixes the Puyo Puyo crash after the logo screens.