### PR TITLE
GPU: Fixed the index offset and implement BaseVertex when doing indexed rendering.

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -455,7 +455,11 @@ public:
                     u32 enable[NumRenderTargets];
                 } blend;
 
-                INSERT_PADDING_WORDS(0x77);
+                INSERT_PADDING_WORDS(0x2D);
+
+                u32 vb_element_base;
+
+                INSERT_PADDING_WORDS(0x49);
 
                 struct {
                     u32 tsc_address_high;
@@ -745,6 +749,7 @@ ASSERT_REG_POSITION(vertex_attrib_format[0], 0x458);
 ASSERT_REG_POSITION(rt_control, 0x487);
 ASSERT_REG_POSITION(independent_blend_enable, 0x4B9);
 ASSERT_REG_POSITION(blend, 0x4CF);
+ASSERT_REG_POSITION(vb_element_base, 0x50D);
 ASSERT_REG_POSITION(tsc, 0x557);
 ASSERT_REG_POSITION(tic, 0x55D);
 ASSERT_REG_POSITION(code_address, 0x582);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -421,7 +421,7 @@ void RasterizerOpenGL::DrawArrays() {
                                  MaxwellToGL::IndexFormat(regs.index_array.format),
                                  reinterpret_cast<const void*>(index_buffer_offset), base_vertex);
     } else {
-        glDrawArrays(primitive_mode, 0, regs.vertex_buffer.count);
+        glDrawArrays(primitive_mode, regs.vertex_buffer.first, regs.vertex_buffer.count);
     }
 
     // Disable scissor test

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -412,12 +412,14 @@ void RasterizerOpenGL::DrawArrays() {
 
     const GLenum primitive_mode{MaxwellToGL::PrimitiveTopology(regs.draw.topology)};
     if (is_indexed) {
-        const GLint index_min{static_cast<GLint>(regs.index_array.first)};
-        const GLint index_max{static_cast<GLint>(regs.index_array.first + regs.index_array.count)};
-        glDrawRangeElementsBaseVertex(primitive_mode, index_min, index_max, regs.index_array.count,
-                                      MaxwellToGL::IndexFormat(regs.index_array.format),
-                                      reinterpret_cast<const void*>(index_buffer_offset),
-                                      -index_min);
+        const GLint base_vertex{static_cast<GLint>(regs.vb_element_base)};
+
+        // Adjust the index buffer offset so it points to the first desired index.
+        index_buffer_offset += regs.index_array.first * regs.index_array.FormatSizeInBytes();
+
+        glDrawElementsBaseVertex(primitive_mode, regs.index_array.count,
+                                 MaxwellToGL::IndexFormat(regs.index_array.format),
+                                 reinterpret_cast<const void*>(index_buffer_offset), base_vertex);
     } else {
         glDrawArrays(primitive_mode, 0, regs.vertex_buffer.count);
     }


### PR DESCRIPTION
Also implemented offsetted drawing when doing non-indexed rendering.

This fixes Stardew Valley

Thanks @gdkchan for the original implementation!