### PR TITLE
GPU: Only configure the used framebuffers during clear.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -85,7 +85,7 @@ private:
 
     /// Configures the color and depth framebuffer states and returns the dirty <Color, Depth>
     /// surfaces if writing was enabled.
-    std::pair<Surface, Surface> ConfigureFramebuffers();
+    std::pair<Surface, Surface> ConfigureFramebuffers(bool using_color_fb, bool using_depth_fb);
 
     /// Binds the framebuffer color and depth surface
     void BindFramebufferSurfaces(const Surface& color_surface, const Surface& depth_surface,

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -326,12 +326,17 @@ struct SurfaceParams {
         return addr <= (region_addr + region_size) && region_addr <= (addr + size_in_bytes);
     }
 
-    /// Creates SurfaceParams from a texture configation
+    /// Creates SurfaceParams from a texture configuration
     static SurfaceParams CreateForTexture(const Tegra::Texture::FullTextureInfo& config);
 
-    /// Creates SurfaceParams from a framebuffer configation
+    /// Creates SurfaceParams from a framebuffer configuration
     static SurfaceParams CreateForFramebuffer(
         const Tegra::Engines::Maxwell3D::Regs::RenderTargetConfig& config);
+
+    /// Creates SurfaceParams for a depth buffer configuration
+    static SurfaceParams CreateForDepthBuffer(
+        const Tegra::Engines::Maxwell3D::Regs::RenderTargetConfig& config,
+        Tegra::GPUVAddr zeta_address, Tegra::DepthFormat format);
 
     Tegra::GPUVAddr addr;
     bool is_tiled;


### PR DESCRIPTION
Don't try to configure the color buffer if it is not being cleared, it may not be completely valid at this point.