### PR TITLE
GPU: Allow using the old NV04 values for the depth test function.

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -281,14 +281,26 @@ public:
         };
 
         enum class ComparisonOp : u32 {
-            Never = 0,
-            Less = 1,
-            Equal = 2,
-            LessEqual = 3,
-            Greater = 4,
-            NotEqual = 5,
-            GreaterEqual = 6,
-            Always = 7,
+            // These values are used by Nouveau and most games, they correspond to the OpenGL token
+            // values for these operations.
+            Never = 0x200,
+            Less = 0x201,
+            Equal = 0x202,
+            LessEqual = 0x203,
+            Greater = 0x204,
+            NotEqual = 0x205,
+            GreaterEqual = 0x206,
+            Always = 0x207,
+
+            // These values are used by some games, they seem to be NV04 values.
+            NeverOld = 1,
+            LessOld = 2,
+            EqualOld = 3,
+            LessEqualOld = 4,
+            GreaterOld = 5,
+            NotEqualOld = 6,
+            GreaterEqualOld = 7,
+            AlwaysOld = 8,
         };
 
         struct Cull {
@@ -482,7 +494,7 @@ public:
 
                 u32 d3d_cull_mode;
 
-                BitField<0, 3, ComparisonOp> depth_test_func;
+                ComparisonOp depth_test_func;
 
                 INSERT_PADDING_WORDS(0xB);
 

--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -211,20 +211,28 @@ inline GLenum SwizzleSource(Tegra::Texture::SwizzleSource source) {
 inline GLenum ComparisonOp(Maxwell::ComparisonOp comparison) {
     switch (comparison) {
     case Maxwell::ComparisonOp::Never:
+    case Maxwell::ComparisonOp::NeverOld:
         return GL_NEVER;
     case Maxwell::ComparisonOp::Less:
+    case Maxwell::ComparisonOp::LessOld:
         return GL_LESS;
     case Maxwell::ComparisonOp::Equal:
+    case Maxwell::ComparisonOp::EqualOld:
         return GL_EQUAL;
     case Maxwell::ComparisonOp::LessEqual:
+    case Maxwell::ComparisonOp::LessEqualOld:
         return GL_LEQUAL;
     case Maxwell::ComparisonOp::Greater:
+    case Maxwell::ComparisonOp::GreaterOld:
         return GL_GREATER;
     case Maxwell::ComparisonOp::NotEqual:
+    case Maxwell::ComparisonOp::NotEqualOld:
         return GL_NOTEQUAL;
     case Maxwell::ComparisonOp::GreaterEqual:
+    case Maxwell::ComparisonOp::GreaterEqualOld:
         return GL_GEQUAL;
     case Maxwell::ComparisonOp::Always:
+    case Maxwell::ComparisonOp::AlwaysOld:
         return GL_ALWAYS;
     }
     LOG_CRITICAL(Render_OpenGL, "Unimplemented comparison op={}", static_cast<u32>(comparison));


### PR DESCRIPTION
These seem to be just a valid as the GL token values. Thanks @ReinUsesLisp

This restores graphical output to Disgaea 5