### PR TITLE
Port #3513 (partly) from Citra: .gitignore: Add CMakeLists.txt.user to Project/editor files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ src/common/scm_rev.cpp
 .idea/
 .vs/
 .vscode/
+CMakeLists.txt.user
 
 # *nix related
 # Common convention for backup or temporary files


### PR DESCRIPTION
I only ported the first part of the original PR, as the second part has no relevance for yuzu.

See https://github.com/citra-emu/citra/pull/3513/ for more details.