### PR TITLE
gl_rasterizer: Flip triangles when regs.viewport_transform[0].scale_y is negative.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -775,10 +775,13 @@ void RasterizerOpenGL::SyncCullMode() {
         state.cull.front_face = MaxwellToGL::FrontFace(regs.cull.front_face);
         state.cull.mode = MaxwellToGL::CullFace(regs.cull.cull_face);
 
+        const bool flip_triangles{regs.screen_y_control.triangle_rast_flip == 0 ||
+                                  regs.viewport_transform[0].scale_y < 0.0f};
+
         // If the GPU is configured to flip the rasterized triangles, then we need to flip the
         // notion of front and back. Note: We flip the triangles when the value of the register is 0
         // because OpenGL already does it for us.
-        if (regs.screen_y_control.triangle_rast_flip == 0) {
+        if (flip_triangles) {
             if (state.cull.front_face == GL_CCW)
                 state.cull.front_face = GL_CW;
             else if (state.cull.front_face == GL_CW)


### PR DESCRIPTION
Fixes a regression with Binding of Isaac.