### PR TITLE
nvhost_ctrl: Fix NvOsGetConfigU32 for Snipper Clips.

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -40,7 +40,7 @@ u32 nvhost_ctrl::NvOsGetConfigU32(const std::vector<u8>& input, std::vector<u8>&
         } else if (!strcmp(params.param_str.data(), "NVRM_GPU_PREVENT_USE")) {
             params.config_str[0] = '0';
         } else {
-            params.config_str[0] = '\0';
+            params.config_str[0] = '0';
         }
     } else {
         UNIMPLEMENTED(); // unknown domain? Only nv has been seen so far on hardware


### PR DESCRIPTION
This gets Snipper Clips booting. I'm not sure why this was changed before, but there seem to be no other regressions going back to this...

![image](https://user-images.githubusercontent.com/6956688/42423931-df654aa6-82d0-11e8-979c-caf64eead8d3.png)
