### PR TITLE
gl_shader_gen: Implement dual vertex shader mode.

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -398,27 +398,6 @@ u32 Maxwell3D::GetRegisterValue(u32 method) const {
     return regs.reg_array[method];
 }
 
-bool Maxwell3D::IsShaderStageEnabled(Regs::ShaderStage stage) const {
-    // The Vertex stage is always enabled.
-    if (stage == Regs::ShaderStage::Vertex)
-        return true;
-
-    switch (stage) {
-    case Regs::ShaderStage::TesselationControl:
-        return regs.shader_config[static_cast<size_t>(Regs::ShaderProgram::TesselationControl)]
-                   .enable != 0;
-    case Regs::ShaderStage::TesselationEval:
-        return regs.shader_config[static_cast<size_t>(Regs::ShaderProgram::TesselationEval)]
-                   .enable != 0;
-    case Regs::ShaderStage::Geometry:
-        return regs.shader_config[static_cast<size_t>(Regs::ShaderProgram::Geometry)].enable != 0;
-    case Regs::ShaderStage::Fragment:
-        return regs.shader_config[static_cast<size_t>(Regs::ShaderProgram::Fragment)].enable != 0;
-    }
-
-    UNREACHABLE();
-}
-
 void Maxwell3D::ProcessClearBuffers() {
     ASSERT(regs.clear_buffers.R == regs.clear_buffers.G &&
            regs.clear_buffers.R == regs.clear_buffers.B &&

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -379,6 +379,14 @@ public:
             }
         };
 
+        bool IsShaderConfigEnabled(size_t index) const {
+            // The VertexB is always enabled.
+            if (index == static_cast<size_t>(Regs::ShaderProgram::VertexB)) {
+                return true;
+            }
+            return shader_config[index].enable != 0;
+        }
+
         union {
             struct {
                 INSERT_PADDING_WORDS(0x45);
@@ -779,9 +787,6 @@ public:
 
     /// Returns the texture information for a specific texture in a specific shader stage.
     Texture::FullTextureInfo GetStageTexture(Regs::ShaderStage stage, size_t offset) const;
-
-    /// Returns whether the specified shader stage is enabled or not.
-    bool IsShaderStageEnabled(Regs::ShaderStage stage) const;
 
 private:
     std::unordered_map<u32, std::vector<u32>> uploaded_macros;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -216,14 +216,12 @@ void RasterizerOpenGL::SetupShaders(u8* buffer_ptr, GLintptr buffer_offset) {
         auto& shader_config = gpu.regs.shader_config[index];
         const Maxwell::ShaderProgram program{static_cast<Maxwell::ShaderProgram>(index)};
 
-        const size_t stage{index == 0 ? 0 : index - 1}; // Stage indices are 0 - 5
-
-        const bool is_enabled = gpu.IsShaderStageEnabled(static_cast<Maxwell::ShaderStage>(stage));
-
         // Skip stages that are not enabled
-        if (!is_enabled) {
+        if (!gpu.regs.IsShaderConfigEnabled(index)) {
             continue;
         }
+
+        const size_t stage{index == 0 ? 0 : index - 1}; // Stage indices are 0 - 5
 
         GLShader::MaxwellUniformData ubo{};
         ubo.SetFromRegs(gpu.state.shader_stages[stage]);
@@ -628,9 +626,6 @@ u32 RasterizerOpenGL::SetupConstBuffers(Maxwell::ShaderStage stage, GLuint progr
     auto& gpu = Core::System::GetInstance().GPU();
     auto& maxwell3d = gpu.Get3DEngine();
 
-    ASSERT_MSG(maxwell3d.IsShaderStageEnabled(stage),
-               "Attempted to upload constbuffer of disabled shader stage");
-
     // Reset all buffer draw state for this stage.
     for (auto& buffer : state.draw.const_buffers[static_cast<size_t>(stage)]) {
         buffer.bindpoint = 0;
@@ -696,9 +691,6 @@ u32 RasterizerOpenGL::SetupTextures(Maxwell::ShaderStage stage, GLuint program, 
                                     const std::vector<GLShader::SamplerEntry>& entries) {
     auto& gpu = Core::System::GetInstance().GPU();
     auto& maxwell3d = gpu.Get3DEngine();
-
-    ASSERT_MSG(maxwell3d.IsShaderStageEnabled(stage),
-               "Attempted to upload textures of disabled shader stage");
 
     ASSERT_MSG(current_unit + entries.size() <= std::size(state.texture_units),
                "Exceeded the number of active textures.");

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -181,6 +181,19 @@ std::pair<u8*, GLintptr> RasterizerOpenGL::SetupVertexArrays(u8* array_ptr,
     return {array_ptr, buffer_offset};
 }
 
+static GLShader::ProgramCode GetShaderProgramCode(Maxwell::ShaderProgram program) {
+    auto& gpu = Core::System().GetInstance().GPU().Maxwell3D();
+
+    // Fetch program code from memory
+    GLShader::ProgramCode program_code;
+    auto& shader_config = gpu.regs.shader_config[static_cast<size_t>(program)];
+    const u64 gpu_address{gpu.regs.code_address.CodeAddress() + shader_config.offset};
+    const boost::optional<VAddr> cpu_address{gpu.memory_manager.GpuToCpuAddress(gpu_address)};
+    Memory::ReadBlock(*cpu_address, program_code.data(), program_code.size() * sizeof(u64));
+
+    return program_code;
+}
+
 void RasterizerOpenGL::SetupShaders(u8* buffer_ptr, GLintptr buffer_offset) {
     // Helper function for uploading uniform data
     const auto copy_buffer = [&](GLuint handle, GLintptr offset, GLsizeiptr size) {
@@ -193,18 +206,17 @@ void RasterizerOpenGL::SetupShaders(u8* buffer_ptr, GLintptr buffer_offset) {
     };
 
     auto& gpu = Core::System().GetInstance().GPU().Maxwell3D();
-    ASSERT_MSG(!gpu.regs.shader_config[0].enable, "VertexA is unsupported!");
 
     // Next available bindpoints to use when uploading the const buffers and textures to the GLSL
     // shaders. The constbuffer bindpoint starts after the shader stage configuration bind points.
     u32 current_constbuffer_bindpoint = uniform_buffers.size();
     u32 current_texture_bindpoint = 0;
 
-    for (unsigned index = 1; index < Maxwell::MaxShaderProgram; ++index) {
+    for (size_t index = 0; index < Maxwell::MaxShaderProgram; ++index) {
         auto& shader_config = gpu.regs.shader_config[index];
         const Maxwell::ShaderProgram program{static_cast<Maxwell::ShaderProgram>(index)};
 
-        const auto& stage = index - 1; // Stage indices are 0 - 5
+        const size_t stage{index == 0 ? 0 : index - 1}; // Stage indices are 0 - 5
 
         const bool is_enabled = gpu.IsShaderStageEnabled(static_cast<Maxwell::ShaderStage>(stage));
 
@@ -228,16 +240,21 @@ void RasterizerOpenGL::SetupShaders(u8* buffer_ptr, GLintptr buffer_offset) {
         buffer_ptr += sizeof(GLShader::MaxwellUniformData);
         buffer_offset += sizeof(GLShader::MaxwellUniformData);
 
-        // Fetch program code from memory
-        GLShader::ProgramCode program_code;
-        const u64 gpu_address{gpu.regs.code_address.CodeAddress() + shader_config.offset};
-        const boost::optional<VAddr> cpu_address{gpu.memory_manager.GpuToCpuAddress(gpu_address)};
-        Memory::ReadBlock(*cpu_address, program_code.data(), program_code.size() * sizeof(u64));
-        GLShader::ShaderSetup setup{std::move(program_code)};
-
+        GLShader::ShaderSetup setup{GetShaderProgramCode(program)};
         GLShader::ShaderEntries shader_resources;
 
         switch (program) {
+        case Maxwell::ShaderProgram::VertexA: {
+            // VertexB is always enabled, so when VertexA is enabled, we have two vertex shaders.
+            // Conventional HW does not support this, so we combine VertexA and VertexB into one
+            // stage here.
+            setup.SetProgramB(GetShaderProgramCode(Maxwell::ShaderProgram::VertexB));
+            GLShader::MaxwellVSConfig vs_config{setup};
+            shader_resources =
+                shader_program_manager->UseProgrammableVertexShader(vs_config, setup);
+            break;
+        }
+
         case Maxwell::ShaderProgram::VertexB: {
             GLShader::MaxwellVSConfig vs_config{setup};
             shader_resources =
@@ -268,6 +285,12 @@ void RasterizerOpenGL::SetupShaders(u8* buffer_ptr, GLintptr buffer_offset) {
         current_texture_bindpoint =
             SetupTextures(static_cast<Maxwell::ShaderStage>(stage), gl_stage_program,
                           current_texture_bindpoint, shader_resources.texture_samplers);
+
+        // When VertexA is enabled, we have dual vertex shaders
+        if (program == Maxwell::ShaderProgram::VertexA) {
+            // VertexB was combined with VertexA, so we skip the VertexB iteration
+            index++;
+        }
     }
 
     shader_program_manager->UseTrivialGeometryShader();

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.h
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.h
@@ -20,7 +20,8 @@ using Tegra::Engines::Maxwell3D;
 std::string GetCommonDeclarations();
 
 boost::optional<ProgramResult> DecompileProgram(const ProgramCode& program_code, u32 main_offset,
-                                                Maxwell3D::Regs::ShaderStage stage);
+                                                Maxwell3D::Regs::ShaderStage stage,
+                                                const std::string& suffix);
 
 } // namespace Decompiler
 } // namespace GLShader


### PR DESCRIPTION
- When VertexA shader stage is enabled, we combine with VertexB program to make a single Vertex Shader stage.

With this change, Farming Simulator boots.

![image](https://user-images.githubusercontent.com/6956688/42669360-f5eb2ca0-8622-11e8-9b32-6fc52f4695b1.png)
