### PR TITLE
Minor logging improvements

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <array>
 #include <chrono>
+#include <climits>
 #include <condition_variable>
 #include <memory>
 #include <thread>
@@ -94,7 +95,7 @@ private:
             }
             // Drain the logging queue. Only writes out up to MAX_LOGS_TO_WRITE to prevent a case
             // where a system is repeatedly spamming logs even on close.
-            constexpr int MAX_LOGS_TO_WRITE = 100;
+            const int MAX_LOGS_TO_WRITE = filter.IsDebug() ? INT_MAX : 100;
             int logs_written = 0;
             while (logs_written++ < MAX_LOGS_TO_WRITE && message_queue.Pop(entry)) {
                 write_logs(entry);

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -83,8 +83,10 @@ private:
                 }
             };
             while (true) {
-                std::unique_lock<std::mutex> lock(message_mutex);
-                message_cv.wait(lock, [&] { return !running || message_queue.Pop(entry); });
+                {
+                    std::unique_lock<std::mutex> lock(message_mutex);
+                    message_cv.wait(lock, [&] { return !running || message_queue.Pop(entry); });
+                }
                 if (!running) {
                     break;
                 }

--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -94,4 +94,11 @@ bool Filter::ParseFilterRule(const std::string::const_iterator begin,
 bool Filter::CheckMessage(Class log_class, Level level) const {
     return static_cast<u8>(level) >= static_cast<u8>(class_levels[static_cast<size_t>(log_class)]);
 }
+
+bool Filter::IsDebug() const {
+    return std::any_of(class_levels.begin(), class_levels.end(), [](const Level& l) {
+        return static_cast<u8>(l) <= static_cast<u8>(Level::Debug);
+    });
+}
+
 } // namespace Log

--- a/src/common/logging/filter.h
+++ b/src/common/logging/filter.h
@@ -47,6 +47,9 @@ public:
     /// Matches class/level combination against the filter, returning true if it passed.
     bool CheckMessage(Class log_class, Level level) const;
 
+    /// Returns true if any logging classes are set to debug
+    bool IsDebug() const;
+
 private:
     std::array<Level, (size_t)Class::Count> class_levels;
 };


### PR DESCRIPTION
* Don't lock the logging queue while writing. Removes the speed penalty for having the console window open
* If the logger has any classes set to debug, it will now dump all logs in the queue on exit instead of the last 100. 