### PR TITLE
HID: Update controllers less often

### DIFF
--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -18,9 +18,9 @@ namespace Service::HID {
 
 // Updating period for each HID device.
 // TODO(shinyquagsire23): These need better values.
-constexpr u64 pad_update_ticks = CoreTiming::BASE_CLOCK_RATE / 10000;
-constexpr u64 accelerometer_update_ticks = CoreTiming::BASE_CLOCK_RATE / 10000;
-constexpr u64 gyroscope_update_ticks = CoreTiming::BASE_CLOCK_RATE / 10000;
+constexpr u64 pad_update_ticks = CoreTiming::BASE_CLOCK_RATE / 100;
+constexpr u64 accelerometer_update_ticks = CoreTiming::BASE_CLOCK_RATE / 100;
+constexpr u64 gyroscope_update_ticks = CoreTiming::BASE_CLOCK_RATE / 100;
 
 class IAppletResource final : public ServiceFramework<IAppletResource> {
 public:


### PR DESCRIPTION
This value still isn't ideal, but the previous value is causing extremely significant lag when you have controllers mapped. This is because controller updates aren't free right now because each button poll causes an sdl update, which under the covers locks a mutex, polls all connected devices, and updates internal state. Doing this many many times a frame caused games to slow to a crawl. As not much is playable yet, I suspect getting a correct value here doesn't matter yet, and this value should be changed when we reverse a proper value for it.

A full fix should probably involve changing the input common to not update sdl when polling every button