### PR TITLE
scheduler: Clear exclusive state when switching contexts

### DIFF
--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -116,6 +116,8 @@ public:
      */
     virtual void LoadContext(const ThreadContext& ctx) = 0;
 
+    virtual void ClearExclusiveState() = 0;
+
     /// Prepare core for thread reschedule (if needed to correctly handle state)
     virtual void PrepareReschedule() = 0;
 };

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -226,6 +226,10 @@ void ARM_Dynarmic::ClearInstructionCache() {
     jit->ClearCache();
 }
 
+void ARM_Dynarmic::ClearExclusiveState() {
+    jit->ClearExclusiveState();
+}
+
 void ARM_Dynarmic::PageTableChanged() {
     jit = MakeJit(cb);
     current_page_table = Memory::GetCurrentPageTable();

--- a/src/core/arm/dynarmic/arm_dynarmic.h
+++ b/src/core/arm/dynarmic/arm_dynarmic.h
@@ -39,6 +39,7 @@ public:
     void LoadContext(const ThreadContext& ctx) override;
 
     void PrepareReschedule() override;
+    void ClearExclusiveState() override;
 
     void ClearInstructionCache() override;
     void PageTableChanged() override;

--- a/src/core/arm/unicorn/arm_unicorn.cpp
+++ b/src/core/arm/unicorn/arm_unicorn.cpp
@@ -263,6 +263,8 @@ void ARM_Unicorn::PrepareReschedule() {
     CHECKED(uc_emu_stop(uc));
 }
 
+void ARM_Unicorn::ClearExclusiveState() {}
+
 void ARM_Unicorn::ClearInstructionCache() {}
 
 void ARM_Unicorn::RecordBreak(GDBStub::BreakpointAddress bkpt) {

--- a/src/core/arm/unicorn/arm_unicorn.h
+++ b/src/core/arm/unicorn/arm_unicorn.h
@@ -31,6 +31,7 @@ public:
     void SaveContext(ThreadContext& ctx) override;
     void LoadContext(const ThreadContext& ctx) override;
     void PrepareReschedule() override;
+    void ClearExclusiveState() override;
     void ExecuteInstructions(int num_instructions);
     void Run() override;
     void Step() override;

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -85,6 +85,7 @@ void Scheduler::SwitchContext(Thread* new_thread) {
 
         cpu_core->LoadContext(new_thread->context);
         cpu_core->SetTlsAddress(new_thread->GetTLSAddress());
+        cpu_core->ClearExclusiveState();
     } else {
         current_thread = nullptr;
         // Note: We do not reset the current process and current page table when idling because


### PR DESCRIPTION
Exclusive state should not be shared between disparate threads.

On Horizon this would be implicit in the `ERET` instruction when the kernel returns to usermode.

Split off from #638.