### PR TITLE
game_list: Remove unnecessary QString initialization in KeyReleaseEater

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -17,10 +17,7 @@
 #include "game_list_p.h"
 #include "ui_settings.h"
 
-GameList::SearchField::KeyReleaseEater::KeyReleaseEater(GameList* gamelist) {
-    this->gamelist = gamelist;
-    edit_filter_text_old = "";
-}
+GameList::SearchField::KeyReleaseEater::KeyReleaseEater(GameList* gamelist) : gamelist{gamelist} {}
 
 // EventFilter in order to process systemkeys while editing the searchfield
 bool GameList::SearchField::KeyReleaseEater::eventFilter(QObject* obj, QEvent* event) {


### PR DESCRIPTION
QString initializes to an empty string by default, so this does nothing meaningful. While we're at it, use a constructor initializer list for initializing the gamelist member variable.