### PR TITLE
externals: update fmt to version 5.1.0

### DIFF
--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -103,7 +103,7 @@ template <typename... Args>
 void FmtLogMessage(Class log_class, Level log_level, const char* filename, unsigned int line_num,
                    const char* function, const char* format, const Args&... args) {
     FmtLogMessageImpl(log_class, log_level, filename, line_num, function, format,
-                      fmt::make_args(args...));
+                      fmt::make_format_args(args...));
 }
 
 } // namespace Log


### PR DESCRIPTION
Previously, we were on 4.1.0, which was a major version behind. Changelog can be seen [here](https://github.com/fmtlib/fmt/releases). Notably, [compile-time format string checking](http://fmtlib.net/dev/api.html#compile-time-format-string-checks) was introduced in 5.0.0