### PR TITLE
vm_manager: Add missing commas to string literal array elements in GetMemoryStateName()

### DIFF
--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -16,30 +16,20 @@
 namespace Kernel {
 
 static const char* GetMemoryStateName(MemoryState state) {
-    static const char* names[] = {
-        "Unmapped",
-        "Io",
-        "Normal",
-        "CodeStatic",
-        "CodeMutable",
-        "Heap",
-        "Shared",
-        "Unknown1"
-        "ModuleCodeStatic",
-        "ModuleCodeMutable",
-        "IpcBuffer0",
-        "Mapped",
-        "ThreadLocal",
-        "TransferMemoryIsolated",
-        "TransferMemory",
-        "ProcessMemory",
-        "Unknown2"
-        "IpcBuffer1",
-        "IpcBuffer3",
-        "KernelStack",
+    static constexpr const char* names[] = {
+        "Unmapped",         "Io",
+        "Normal",           "CodeStatic",
+        "CodeMutable",      "Heap",
+        "Shared",           "Unknown1",
+        "ModuleCodeStatic", "ModuleCodeMutable",
+        "IpcBuffer0",       "Mapped",
+        "ThreadLocal",      "TransferMemoryIsolated",
+        "TransferMemory",   "ProcessMemory",
+        "Unknown2",         "IpcBuffer1",
+        "IpcBuffer3",       "KernelStack",
     };
 
-    return names[(int)state];
+    return names[static_cast<int>(state)];
 }
 
 bool VirtualMemoryArea::CanBeMergedWith(const VirtualMemoryArea& next) const {


### PR DESCRIPTION
Without these, this would perform concatenation, which is definitely not what we want here.