### PR TITLE
program_metadata: Take std::vector by const reference in Load()

### DIFF
--- a/src/core/file_sys/program_metadata.cpp
+++ b/src/core/file_sys/program_metadata.cpp
@@ -26,7 +26,7 @@ Loader::ResultStatus ProgramMetadata::Load(const std::string& file_path) {
     return result;
 }
 
-Loader::ResultStatus ProgramMetadata::Load(const std::vector<u8> file_data, size_t offset) {
+Loader::ResultStatus ProgramMetadata::Load(const std::vector<u8>& file_data, size_t offset) {
     size_t total_size = static_cast<size_t>(file_data.size() - offset);
     if (total_size < sizeof(Header))
         return Loader::ResultStatus::Error;

--- a/src/core/file_sys/program_metadata.h
+++ b/src/core/file_sys/program_metadata.h
@@ -38,7 +38,7 @@ enum class ProgramFilePermission : u64 {
 class ProgramMetadata {
 public:
     Loader::ResultStatus Load(const std::string& file_path);
-    Loader::ResultStatus Load(const std::vector<u8> file_data, size_t offset = 0);
+    Loader::ResultStatus Load(const std::vector<u8>& file_data, size_t offset = 0);
 
     bool Is64BitProgram() const;
     ProgramAddressSpaceType GetAddressSpaceType() const;


### PR DESCRIPTION
This is only ever read from in the function itself, it's not moved or copied anywhere else, so this is kind of wasteful. Given it has a const qualifier, it was likely intended to be a reference anyways, however the ampersand was forgotten.