### PR TITLE
core/memory, core/hle/kernel: Use std::move where applicable

### DIFF
--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <utility>
+
 #include <boost/range/algorithm_ext/erase.hpp>
 #include "common/assert.h"
 #include "common/common_funcs.h"
@@ -19,10 +21,10 @@ namespace Kernel {
 
 void SessionRequestHandler::ClientConnected(SharedPtr<ServerSession> server_session) {
     server_session->SetHleHandler(shared_from_this());
-    connected_sessions.push_back(server_session);
+    connected_sessions.push_back(std::move(server_session));
 }
 
-void SessionRequestHandler::ClientDisconnected(SharedPtr<ServerSession> server_session) {
+void SessionRequestHandler::ClientDisconnected(const SharedPtr<ServerSession>& server_session) {
     server_session->SetHleHandler(nullptr);
     boost::range::remove_erase(connected_sessions, server_session);
 }

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -59,12 +59,12 @@ public:
      * associated ServerSession.
      * @param server_session ServerSession associated with the connection.
      */
-    void ClientDisconnected(SharedPtr<ServerSession> server_session);
+    void ClientDisconnected(const SharedPtr<ServerSession>& server_session);
 
 protected:
     /// List of sessions that are connected to this handler.
     /// A ServerSession whose server endpoint is an HLE implementation is kept alive by this list
-    // for the duration of the connection.
+    /// for the duration of the connection.
     std::vector<SharedPtr<ServerSession>> connected_sessions;
 };
 

--- a/src/core/hle/kernel/object_address_table.cpp
+++ b/src/core/hle/kernel/object_address_table.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <utility>
+
 #include "common/assert.h"
 #include "core/hle/kernel/object_address_table.h"
 
@@ -11,7 +13,7 @@ ObjectAddressTable g_object_address_table;
 
 void ObjectAddressTable::Insert(VAddr addr, SharedPtr<Object> obj) {
     ASSERT_MSG(objects.find(addr) == objects.end(), "Object already exists with addr=0x{:X}", addr);
-    objects[addr] = obj;
+    objects[addr] = std::move(obj);
 }
 
 void ObjectAddressTable::Close(VAddr addr) {

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <utility>
+
 #include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/kernel/process.h"
@@ -113,7 +115,7 @@ void Scheduler::Reschedule() {
 void Scheduler::AddThread(SharedPtr<Thread> thread, u32 priority) {
     std::lock_guard<std::mutex> lock(scheduler_mutex);
 
-    thread_list.push_back(thread);
+    thread_list.push_back(std::move(thread));
     ready_queue.prepare(priority);
 }
 

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <tuple>
+#include <utility>
 
 #include "core/core.h"
 #include "core/hle/ipc_helpers.h"
@@ -158,7 +159,7 @@ ServerSession::SessionPair ServerSession::CreateSessionPair(const std::string& n
     std::shared_ptr<Session> parent(new Session);
     parent->client = client_session.get();
     parent->server = server_session.get();
-    parent->port = port;
+    parent->port = std::move(port);
 
     client_session->parent = parent;
     server_session->parent = parent;

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <cstring>
+#include <utility>
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/hle/kernel/errors.h"
@@ -21,7 +21,7 @@ SharedPtr<SharedMemory> SharedMemory::Create(SharedPtr<Process> owner_process, u
                                              MemoryRegion region, std::string name) {
     SharedPtr<SharedMemory> shared_memory(new SharedMemory);
 
-    shared_memory->owner_process = owner_process;
+    shared_memory->owner_process = std::move(owner_process);
     shared_memory->name = std::move(name);
     shared_memory->size = size;
     shared_memory->permissions = permissions;
@@ -87,7 +87,7 @@ SharedPtr<SharedMemory> SharedMemory::CreateForApplet(std::shared_ptr<std::vecto
     shared_memory->size = size;
     shared_memory->permissions = permissions;
     shared_memory->other_permissions = other_permissions;
-    shared_memory->backing_block = heap_block;
+    shared_memory->backing_block = std::move(heap_block);
     shared_memory->backing_block_offset = offset;
     shared_memory->base_address = Memory::HEAP_VADDR + offset;
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -400,7 +400,7 @@ SharedPtr<Thread> SetupMainThread(VAddr entry_point, u32 priority,
 
     // Initialize new "main" thread
     auto thread_res = Thread::Create("main", entry_point, priority, 0, THREADPROCESSORID_0,
-                                     Memory::STACK_AREA_VADDR_END, owner_process);
+                                     Memory::STACK_AREA_VADDR_END, std::move(owner_process));
 
     SharedPtr<Thread> thread = std::move(thread_res).Unwrap();
 

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <iterator>
+#include <utility>
 #include "common/assert.h"
 #include "common/logging/log.h"
 #include "core/arm/arm_interface.h"
@@ -117,7 +118,7 @@ ResultVal<VMManager::VMAHandle> VMManager::MapMemoryBlock(VAddr target,
     final_vma.type = VMAType::AllocatedMemoryBlock;
     final_vma.permissions = VMAPermission::ReadWrite;
     final_vma.meminfo_state = state;
-    final_vma.backing_block = block;
+    final_vma.backing_block = std::move(block);
     final_vma.offset = offset;
     UpdatePageTableForVMA(final_vma);
 
@@ -160,7 +161,7 @@ ResultVal<VMManager::VMAHandle> VMManager::MapMMIO(VAddr target, PAddr paddr, u6
     final_vma.permissions = VMAPermission::ReadWrite;
     final_vma.meminfo_state = state;
     final_vma.paddr = paddr;
-    final_vma.mmio_handler = mmio_handler;
+    final_vma.mmio_handler = std::move(mmio_handler);
     UpdatePageTableForVMA(final_vma);
 
     return MakeResult<VMAHandle>(MergeAdjacent(vma_handle));

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -5,6 +5,8 @@
 #include <algorithm>
 #include <array>
 #include <cstring>
+#include <utility>
+
 #include <boost/optional.hpp>
 #include "common/assert.h"
 #include "common/common_types.h"
@@ -74,7 +76,7 @@ void MapIoRegion(PageTable& page_table, VAddr base, u64 size, MemoryHookPointer 
     MapPages(page_table, base / PAGE_SIZE, size / PAGE_SIZE, nullptr, PageType::Special);
 
     auto interval = boost::icl::discrete_interval<VAddr>::closed(base, base + size - 1);
-    SpecialRegion region{SpecialRegion::Type::IODevice, mmio_handler};
+    SpecialRegion region{SpecialRegion::Type::IODevice, std::move(mmio_handler)};
     page_table.special_regions.add(std::make_pair(interval, std::set<SpecialRegion>{region}));
 }
 
@@ -89,13 +91,13 @@ void UnmapRegion(PageTable& page_table, VAddr base, u64 size) {
 
 void AddDebugHook(PageTable& page_table, VAddr base, u64 size, MemoryHookPointer hook) {
     auto interval = boost::icl::discrete_interval<VAddr>::closed(base, base + size - 1);
-    SpecialRegion region{SpecialRegion::Type::DebugHook, hook};
+    SpecialRegion region{SpecialRegion::Type::DebugHook, std::move(hook)};
     page_table.special_regions.add(std::make_pair(interval, std::set<SpecialRegion>{region}));
 }
 
 void RemoveDebugHook(PageTable& page_table, VAddr base, u64 size, MemoryHookPointer hook) {
     auto interval = boost::icl::discrete_interval<VAddr>::closed(base, base + size - 1);
-    SpecialRegion region{SpecialRegion::Type::DebugHook, hook};
+    SpecialRegion region{SpecialRegion::Type::DebugHook, std::move(hook)};
     page_table.special_regions.subtract(std::make_pair(interval, std::set<SpecialRegion>{region}));
 }
 


### PR DESCRIPTION
Avoids a few pointless copies/atomic reference count increases/decreases.