### PR TITLE
address_arbiter: Correct assignment within an assertion statement in WakeThreads()

### DIFF
--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -65,7 +65,7 @@ static void WakeThreads(std::vector<SharedPtr<Thread>>& waiting_threads, s32 num
 
     // Signal the waiting threads.
     for (size_t i = 0; i < last; i++) {
-        ASSERT(waiting_threads[i]->status = THREADSTATUS_WAIT_ARB);
+        ASSERT(waiting_threads[i]->status == THREADSTATUS_WAIT_ARB);
         waiting_threads[i]->SetWaitSynchronizationResult(RESULT_SUCCESS);
         waiting_threads[i]->arb_wait_address = 0;
         waiting_threads[i]->ResumeFromWait();


### PR DESCRIPTION
This was introduced within 4f81bc4e1bd12e4df7410c6790ba818d8dbba9c0, and considering there's no comment indicating that this is intentional, this is very likely a bug.