### PR TITLE
gl_state: Temporarily disable culling and depth test.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -795,7 +795,9 @@ void RasterizerOpenGL::SyncClipCoef() {
 void RasterizerOpenGL::SyncCullMode() {
     const auto& regs = Core::System::GetInstance().GPU().Maxwell3D().regs;
 
-    state.cull.enabled = regs.cull.enabled != 0;
+    // TODO(bunnei): Enable the below once more things work - until then, this may hide regressions
+    // state.cull.enabled = regs.cull.enabled != 0;
+    state.cull.enabled = false;
 
     if (state.cull.enabled) {
         state.cull.front_face = MaxwellToGL::FrontFace(regs.cull.front_face);


### PR DESCRIPTION
Stole the idea from Ryujinx... Until we thoroughly understand how these work (and have games that really need them), we should just disable them. Depth test and culling issues hide games that might be rendering,  and make it difficult to keep track of what might be rendering (and what isn't).