### PR TITLE
partition_filesystem: Ensure all class members of PartitionFilesystem are initialized

### DIFF
--- a/src/core/file_sys/partition_filesystem.h
+++ b/src/core/file_sys/partition_filesystem.h
@@ -42,6 +42,8 @@ private:
         u32_le num_entries;
         u32_le strtab_size;
         INSERT_PADDING_BYTES(0x4);
+
+        bool HasValidMagicValue() const;
     };
 
     static_assert(sizeof(Header) == 0x10, "PFS/HFS header structure size is wrong");
@@ -73,11 +75,11 @@ private:
 
 #pragma pack(pop)
 
-    Loader::ResultStatus status;
+    Loader::ResultStatus status{};
 
-    Header pfs_header;
-    bool is_hfs;
-    size_t content_offset;
+    Header pfs_header{};
+    bool is_hfs = false;
+    size_t content_offset = 0;
 
     std::vector<VirtualFile> pfs_files;
     std::vector<VirtualDir> pfs_dirs;


### PR DESCRIPTION
Previously `is_hfs` and `pfs_header` members wouldn't be initialized in the constructor, as they were stored in locals instead. This would result in things like GetName() and PrintDebugInfo() behaving incorrectly.

This also removes redundant checks related to reading in the header.