### PR TITLE
savedata_factory: Make SaveDataDescriptor's DebugInfo() function a const member function

### DIFF
--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -11,7 +11,7 @@
 
 namespace FileSys {
 
-std::string SaveDataDescriptor::DebugInfo() {
+std::string SaveDataDescriptor::DebugInfo() const {
     return fmt::format("[type={:02X}, title_id={:016X}, user_id={:016X}{:016X}, save_id={:016X}]",
                        static_cast<u8>(type), title_id, user_id[1], user_id[0], save_id);
 }

--- a/src/core/file_sys/savedata_factory.h
+++ b/src/core/file_sys/savedata_factory.h
@@ -37,7 +37,7 @@ struct SaveDataDescriptor {
     u64_le zero_2;
     u64_le zero_3;
 
-    std::string DebugInfo();
+    std::string DebugInfo() const;
 };
 static_assert(sizeof(SaveDataDescriptor) == 0x40, "SaveDataDescriptor has incorrect size.");
 


### PR DESCRIPTION
This function doesn't alter class state.