### PR TITLE
file_util: return string by const reference for GetExeDirectory()

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -592,7 +592,7 @@ std::string GetBundleDirectory() {
 #endif
 
 #ifdef _WIN32
-std::string& GetExeDirectory() {
+const std::string& GetExeDirectory() {
     static std::string exe_path;
     if (exe_path.empty()) {
         wchar_t wchar_exe_path[2048];

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -133,7 +133,7 @@ std::string GetBundleDirectory();
 #endif
 
 #ifdef _WIN32
-std::string& GetExeDirectory();
+const std::string& GetExeDirectory();
 std::string AppDataRoamingDirectory();
 #endif
 


### PR DESCRIPTION
This disallows modifying the internal string buffer (which shouldn't be modified anyhow).