### PR TITLE
common/misc: Deduplicate code in GetLastErrorMsg()

### DIFF
--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string>
+
 #if !defined(ARCHITECTURE_x86_64) && !defined(ARCHITECTURE_ARM)
 #include <cstdlib> // for exit
 #endif
@@ -90,7 +92,7 @@ __declspec(dllimport) void __stdcall DebugBreak(void);
 // Call directly after the command or use the error num.
 // This function might change the error code.
 // Defined in Misc.cpp.
-const char* GetLastErrorMsg();
+std::string GetLastErrorMsg();
 
 namespace Common {
 

--- a/src/common/misc.cpp
+++ b/src/common/misc.cpp
@@ -4,34 +4,28 @@
 
 #include <cstddef>
 #ifdef _WIN32
-#include <windows.h>
+#include <Windows.h>
 #else
 #include <cerrno>
 #include <cstring>
 #endif
 
-// Neither Android nor OS X support TLS
-#if defined(__APPLE__) || (ANDROID && __clang__)
-#define __thread
-#endif
+#include "common/common_funcs.h"
 
 // Generic function to get last error message.
 // Call directly after the command or use the error num.
 // This function might change the error code.
-const char* GetLastErrorMsg() {
+std::string GetLastErrorMsg() {
     static const size_t buff_size = 255;
+    char err_str[buff_size];
 
 #ifdef _WIN32
-    static __declspec(thread) char err_str[buff_size] = {};
-
     FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, GetLastError(),
                    MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), err_str, buff_size, nullptr);
 #else
-    static __thread char err_str[buff_size] = {};
-
     // Thread safe (XSI-compliant)
     strerror_r(errno, err_str, buff_size);
 #endif
 
-    return err_str;
+    return std::string(err_str, buff_size);
 }


### PR DESCRIPTION
Android and macOS have supported thread_local for quite a while, but most importantly is that we don't even really need it. Instead of using a thread-local buffer, we can just return a non-static buffer as a std::string, avoiding the need for that quality entirely.