### PR TITLE
hle_ipc: Amend usage of buffer_index within one of HLERequestContext's WriteBuffer() overloads

### DIFF
--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -302,7 +302,7 @@ size_t HLERequestContext::WriteBuffer(const void* buffer, size_t size, int buffe
 }
 
 size_t HLERequestContext::WriteBuffer(const std::vector<u8>& buffer, int buffer_index) const {
-    return WriteBuffer(buffer.data(), buffer.size());
+    return WriteBuffer(buffer.data(), buffer.size(), buffer_index);
 }
 
 size_t HLERequestContext::GetReadBufferSize(int buffer_index) const {


### PR DESCRIPTION
Previously, the buffer_index parameter was unused, causing all writes to use the buffer index of zero, which is not necessarily what is wanted all the time.

Thankfully, all current usages don't use a buffer index other than zero, so this just prevents a bug before it has a chance to spring.

