### PR TITLE
hle/service: Make constructors explicit where applicable

### DIFF
--- a/src/core/hle/service/acc/acc.h
+++ b/src/core/hle/service/acc/acc.h
@@ -12,7 +12,7 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        Interface(std::shared_ptr<Module> module, const char* name);
+        explicit Interface(std::shared_ptr<Module> module, const char* name);
 
         void GetUserExistence(Kernel::HLERequestContext& ctx);
         void ListAllUsers(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -72,7 +72,7 @@ public:
 
 class ISelfController final : public ServiceFramework<ISelfController> {
 public:
-    ISelfController(std::shared_ptr<NVFlinger::NVFlinger> nvflinger);
+    explicit ISelfController(std::shared_ptr<NVFlinger::NVFlinger> nvflinger);
 
 private:
     void SetFocusHandlingMode(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/am/applet_ae.cpp
+++ b/src/core/hle/service/am/applet_ae.cpp
@@ -12,7 +12,7 @@ namespace Service::AM {
 
 class ILibraryAppletProxy final : public ServiceFramework<ILibraryAppletProxy> {
 public:
-    ILibraryAppletProxy(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
+    explicit ILibraryAppletProxy(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
         : ServiceFramework("ILibraryAppletProxy"), nvflinger(std::move(nvflinger)) {
         static const FunctionInfo functions[] = {
             {0, &ILibraryAppletProxy::GetCommonStateGetter, "GetCommonStateGetter"},

--- a/src/core/hle/service/am/applet_ae.h
+++ b/src/core/hle/service/am/applet_ae.h
@@ -17,7 +17,7 @@ namespace AM {
 
 class AppletAE final : public ServiceFramework<AppletAE> {
 public:
-    AppletAE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger);
+    explicit AppletAE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger);
     ~AppletAE() = default;
 
 private:

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -12,7 +12,7 @@ namespace Service::AM {
 
 class IApplicationProxy final : public ServiceFramework<IApplicationProxy> {
 public:
-    IApplicationProxy(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
+    explicit IApplicationProxy(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
         : ServiceFramework("IApplicationProxy"), nvflinger(std::move(nvflinger)) {
         static const FunctionInfo functions[] = {
             {0, &IApplicationProxy::GetCommonStateGetter, "GetCommonStateGetter"},

--- a/src/core/hle/service/am/applet_oe.h
+++ b/src/core/hle/service/am/applet_oe.h
@@ -17,7 +17,7 @@ namespace AM {
 
 class AppletOE final : public ServiceFramework<AppletOE> {
 public:
-    AppletOE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger);
+    explicit AppletOE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger);
     ~AppletOE() = default;
 
 private:

--- a/src/core/hle/service/apm/interface.h
+++ b/src/core/hle/service/apm/interface.h
@@ -10,7 +10,7 @@ namespace Service::APM {
 
 class APM final : public ServiceFramework<APM> {
 public:
-    APM(std::shared_ptr<Module> apm, const char* name);
+    explicit APM(std::shared_ptr<Module> apm, const char* name);
     ~APM() = default;
 
 private:

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -17,7 +17,7 @@ constexpr u64 audio_ticks{static_cast<u64>(CoreTiming::BASE_CLOCK_RATE / 200)};
 
 class IAudioRenderer final : public ServiceFramework<IAudioRenderer> {
 public:
-    IAudioRenderer(AudioRendererParameter audren_params)
+    explicit IAudioRenderer(AudioRendererParameter audren_params)
         : ServiceFramework("IAudioRenderer"), worker_params(audren_params) {
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetAudioRendererSampleRate"},
@@ -176,7 +176,7 @@ private:
     struct UpdateDataHeader {
         UpdateDataHeader() {}
 
-        UpdateDataHeader(const AudioRendererParameter& config) {
+        explicit UpdateDataHeader(const AudioRendererParameter& config) {
             revision = Common::MakeMagic('R', 'E', 'V', '4'); // 5.1.0 Revision
             behavior_size = 0xb0;
             memory_pools_size = (config.effect_count + (config.voice_count * 4)) * 0x10;

--- a/src/core/hle/service/bcat/module.h
+++ b/src/core/hle/service/bcat/module.h
@@ -12,7 +12,7 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        Interface(std::shared_ptr<Module> module, const char* name);
+        explicit Interface(std::shared_ptr<Module> module, const char* name);
 
         void CreateBcatService(Kernel::HLERequestContext& ctx);
 

--- a/src/core/hle/service/fatal/fatal.h
+++ b/src/core/hle/service/fatal/fatal.h
@@ -12,7 +12,7 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        Interface(std::shared_ptr<Module> module, const char* name);
+        explicit Interface(std::shared_ptr<Module> module, const char* name);
 
         void ThrowFatalWithPolicy(Kernel::HLERequestContext& ctx);
         void ThrowFatalWithCpuContext(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/friend/friend.h
+++ b/src/core/hle/service/friend/friend.h
@@ -12,7 +12,7 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        Interface(std::shared_ptr<Module> module, const char* name);
+        explicit Interface(std::shared_ptr<Module> module, const char* name);
 
         void CreateFriendService(Kernel::HLERequestContext& ctx);
 

--- a/src/core/hle/service/nfp/nfp.h
+++ b/src/core/hle/service/nfp/nfp.h
@@ -12,7 +12,7 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        Interface(std::shared_ptr<Module> module, const char* name);
+        explicit Interface(std::shared_ptr<Module> module, const char* name);
 
         void CreateUserInterface(Kernel::HLERequestContext& ctx);
 

--- a/src/core/hle/service/nifm/nifm.h
+++ b/src/core/hle/service/nifm/nifm.h
@@ -12,7 +12,7 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        Interface(std::shared_ptr<Module> module, const char* name);
+        explicit Interface(std::shared_ptr<Module> module, const char* name);
 
         void CreateGeneralServiceOld(Kernel::HLERequestContext& ctx);
         void CreateGeneralService(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/nvdrv/devices/nvdisp_disp0.h
+++ b/src/core/hle/service/nvdrv/devices/nvdisp_disp0.h
@@ -17,7 +17,7 @@ class nvmap;
 
 class nvdisp_disp0 final : public nvdevice {
 public:
-    nvdisp_disp0(std::shared_ptr<nvmap> nvmap_dev) : nvdevice(), nvmap_dev(std::move(nvmap_dev)) {}
+    explicit nvdisp_disp0(std::shared_ptr<nvmap> nvmap_dev) : nvmap_dev(std::move(nvmap_dev)) {}
     ~nvdisp_disp0() = default;
 
     u32 ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) override;

--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.h
@@ -18,7 +18,7 @@ class nvmap;
 
 class nvhost_as_gpu final : public nvdevice {
 public:
-    nvhost_as_gpu(std::shared_ptr<nvmap> nvmap_dev) : nvmap_dev(std::move(nvmap_dev)) {}
+    explicit nvhost_as_gpu(std::shared_ptr<nvmap> nvmap_dev) : nvmap_dev(std::move(nvmap_dev)) {}
     ~nvhost_as_gpu() override = default;
 
     u32 ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) override;

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
@@ -18,7 +18,7 @@ constexpr u32 NVGPU_IOCTL_CHANNEL_SUBMIT_GPFIFO(0x8);
 
 class nvhost_gpu final : public nvdevice {
 public:
-    nvhost_gpu(std::shared_ptr<nvmap> nvmap_dev) : nvmap_dev(std::move(nvmap_dev)) {}
+    explicit nvhost_gpu(std::shared_ptr<nvmap> nvmap_dev) : nvmap_dev(std::move(nvmap_dev)) {}
     ~nvhost_gpu() override = default;
 
     u32 ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) override;

--- a/src/core/hle/service/pctl/module.h
+++ b/src/core/hle/service/pctl/module.h
@@ -12,7 +12,7 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        Interface(std::shared_ptr<Module> module, const char* name);
+        explicit Interface(std::shared_ptr<Module> module, const char* name);
 
         void CreateService(Kernel::HLERequestContext& ctx);
         void CreateServiceWithoutInitialize(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -22,7 +22,7 @@ namespace Service::SM {
 /// Interface to "sm:" service
 class SM final : public ServiceFramework<SM> {
 public:
-    SM(std::shared_ptr<ServiceManager> service_manager);
+    explicit SM(std::shared_ptr<ServiceManager> service_manager);
     ~SM() override;
 
 private:

--- a/src/core/hle/service/spl/module.h
+++ b/src/core/hle/service/spl/module.h
@@ -12,7 +12,7 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        Interface(std::shared_ptr<Module> module, const char* name);
+        explicit Interface(std::shared_ptr<Module> module, const char* name);
 
         void GetRandomBytes(Kernel::HLERequestContext& ctx);
 

--- a/src/core/hle/service/time/time.h
+++ b/src/core/hle/service/time/time.h
@@ -57,7 +57,7 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        Interface(std::shared_ptr<Module> time, const char* name);
+        explicit Interface(std::shared_ptr<Module> time, const char* name);
 
         void GetStandardUserSystemClock(Kernel::HLERequestContext& ctx);
         void GetStandardNetworkSystemClock(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -579,7 +579,7 @@ private:
 
 class ISystemDisplayService final : public ServiceFramework<ISystemDisplayService> {
 public:
-    ISystemDisplayService() : ServiceFramework("ISystemDisplayService") {
+    explicit ISystemDisplayService() : ServiceFramework("ISystemDisplayService") {
         static const FunctionInfo functions[] = {
             {1200, nullptr, "GetZOrderCountMin"},
             {1202, nullptr, "GetZOrderCountMax"},
@@ -777,7 +777,7 @@ private:
 
 class IApplicationDisplayService final : public ServiceFramework<IApplicationDisplayService> {
 public:
-    IApplicationDisplayService(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+    explicit IApplicationDisplayService(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
     ~IApplicationDisplayService() = default;
 
 private:

--- a/src/core/hle/service/vi/vi.h
+++ b/src/core/hle/service/vi/vi.h
@@ -24,8 +24,8 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        Interface(std::shared_ptr<Module> module, const char* name,
-                  std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+        explicit Interface(std::shared_ptr<Module> module, const char* name,
+                           std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
 
         void GetDisplayService(Kernel::HLERequestContext& ctx);
 


### PR DESCRIPTION
Prevents implicit construction and makes these lingering non-explicit constructors consistent with the rest of the other classes in services.