### PR TITLE
loader/nso: Check if read succeeded in IdentifyFile() before checking magic value

### DIFF
--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -55,13 +55,15 @@ AppLoader_NSO::AppLoader_NSO(FileSys::VirtualFile file) : AppLoader(std::move(fi
 
 FileType AppLoader_NSO::IdentifyType(const FileSys::VirtualFile& file) {
     u32 magic = 0;
-    file->ReadObject(&magic);
-
-    if (Common::MakeMagic('N', 'S', 'O', '0') == magic) {
-        return FileType::NSO;
+    if (file->ReadObject(&magic) != sizeof(magic)) {
+        return FileType::Error;
     }
 
-    return FileType::Error;
+    if (Common::MakeMagic('N', 'S', 'O', '0') != magic) {
+        return FileType::Error;
+    }
+
+    return FileType::NSO;
 }
 
 static std::vector<u8> DecompressSegment(const std::vector<u8>& compressed_data,


### PR DESCRIPTION
We should always assume the filesystem is volatile and check each IO operation. While we're at it reorganize checks so that early-out errors are near one another.