### PR TITLE
svc: Correct always true assertion case in SetThreadCoreMask

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -795,8 +795,9 @@ static ResultCode SetThreadCoreMask(Handle thread_handle, u32 core, u64 mask) {
         return ERR_INVALID_HANDLE;
     }
 
-    if (core == THREADPROCESSORID_DEFAULT) {
-        ASSERT(thread->owner_process->ideal_processor != THREADPROCESSORID_DEFAULT);
+    if (core == static_cast<u32>(THREADPROCESSORID_DEFAULT)) {
+        ASSERT(thread->owner_process->ideal_processor !=
+               static_cast<u8>(THREADPROCESSORID_DEFAULT));
         // Set the target CPU to the one specified in the process' exheader.
         core = thread->owner_process->ideal_processor;
         mask = 1ull << core;
@@ -811,7 +812,7 @@ static ResultCode SetThreadCoreMask(Handle thread_handle, u32 core, u64 mask) {
 
     if (core == OnlyChangeMask) {
         core = thread->ideal_core;
-    } else if (core >= Core::NUM_CPU_CORES && core != -1) {
+    } else if (core >= Core::NUM_CPU_CORES && core != static_cast<u32>(-1)) {
         return ResultCode(ErrorModule::Kernel, ErrCodes::InvalidProcessorId);
     }
 


### PR DESCRIPTION
The reason this would never be true is that `ideal_processor` is a `u8` and `THREADPROCESSORID_DEFAULT` is an `s32`. In this case, it boils down to how arithmetic conversions are performed before performing the comparison.

If an unsigned value has a lesser conversion rank (aka smaller size) than the signed type being compared, then the unsigned value is promoted to the signed value (i.e. `u8 -> s32` happens before the comparison). No sign-extension occurs here either.

---

An alternative phrasing:

Say we have a variable named core and it's given a value of `-2`.

```cpp
u8 core = -2;
```

This becomes `254` due to the lack of sign. During integral promotion to the signed type, this still remains as `254`, and therefore the condition will always be true, because no matter what value the `u8` is given it will never be `-2` in terms of 32 bits.

Now, if one type was a `s32` and one was a `u32`, this would be entirely different, since they have the same bit width (and the signed type would be converted to unsigned instead of the other way around) but would still have its representation preserved in terms of bits, allowing the comparison to be false in some cases, as opposed to being true all the time.

---

We also get rid of two signed/unsigned comparison warnings while we're at it.