### PR TITLE
hle_ipc: Introduce generic WriteBuffer overload for multiple container types

### DIFF
--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -301,10 +301,6 @@ size_t HLERequestContext::WriteBuffer(const void* buffer, size_t size, int buffe
     return size;
 }
 
-size_t HLERequestContext::WriteBuffer(const std::vector<u8>& buffer, int buffer_index) const {
-    return WriteBuffer(buffer.data(), buffer.size(), buffer_index);
-}
-
 size_t HLERequestContext::GetReadBufferSize(int buffer_index) const {
     const bool is_buffer_a{BufferDescriptorA().size() && BufferDescriptorA()[buffer_index].Size()};
     return is_buffer_a ? BufferDescriptorA()[buffer_index].Size()

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -168,7 +168,7 @@ void AudOutU::ListAudioOutsImpl(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
 
     const std::string audio_interface = "AudioInterface";
-    ctx.WriteBuffer(audio_interface.c_str(), audio_interface.size());
+    ctx.WriteBuffer(audio_interface);
 
     IPC::ResponseBuilder rb = rp.MakeBuilder(3, 0, 0);
 

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -299,7 +299,7 @@ private:
         IPC::RequestParser rp{ctx};
 
         const std::string audio_interface = "AudioInterface";
-        ctx.WriteBuffer(audio_interface.c_str(), audio_interface.size());
+        ctx.WriteBuffer(audio_interface);
 
         IPC::ResponseBuilder rb = rp.MakeBuilder(3, 0, 0);
         rb.Push(RESULT_SUCCESS);
@@ -324,7 +324,7 @@ private:
         IPC::RequestParser rp{ctx};
 
         const std::string audio_interface = "AudioDevice";
-        ctx.WriteBuffer(audio_interface.c_str(), audio_interface.size());
+        ctx.WriteBuffer(audio_interface);
 
         IPC::ResponseBuilder rb = rp.MakeBuilder(3, 0, 0);
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -31,7 +31,7 @@ void SET::GetAvailableLanguageCodes(Kernel::HLERequestContext& ctx) {
         LanguageCode::ZH_HANS,
         LanguageCode::ZH_HANT,
     }};
-    ctx.WriteBuffer(available_language_codes.data(), available_language_codes.size());
+    ctx.WriteBuffer(available_language_codes);
 
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);


### PR DESCRIPTION
This introduces a slightly more generic variant of WriteBuffer(). Notably, this variant doesn't constrain the arguments to only accepting std::vector instances. It accepts whatever adheres to the ContiguousContainer concept in the C++ standard library.

This essentially means, `std::array`, `std::string`, and `std::vector` can be used directly with this interface. The interface no longer forces you to solely use containers that dynamically allocate.

To ensure our overloads play nice with one another, we only enable the container-based WriteBuffer if the argument is not a pointer, otherwise we fall back to the pointer-based one.

This overload makes it less error-prone when writing elements out, as one must ensure that the container size is multiplied by the element size in order to make the size be in terms of bytes. This overload does that work for us.