### PR TITLE
HLE/ACC: Write a single whole user id in ListAllUsers and ListOpenUsers.

### DIFF
--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -95,16 +95,18 @@ void Module::Interface::GetUserExistence(Kernel::HLERequestContext& ctx) {
 
 void Module::Interface::ListAllUsers(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_ACC, "(STUBBED) called");
-    constexpr std::array<u128, 10> user_ids{DEFAULT_USER_ID};
-    ctx.WriteBuffer(user_ids.data(), user_ids.size());
+    // TODO(Subv): There is only one user for now.
+    const std::vector<u128> user_ids = {DEFAULT_USER_ID};
+    ctx.WriteBuffer(user_ids.data(), user_ids.size() * sizeof(u128));
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void Module::Interface::ListOpenUsers(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_ACC, "(STUBBED) called");
-    constexpr std::array<u128, 10> user_ids{DEFAULT_USER_ID};
-    ctx.WriteBuffer(user_ids.data(), user_ids.size());
+    // TODO(Subv): There is only one user for now.
+    const std::vector<u128> user_ids = {DEFAULT_USER_ID};
+    ctx.WriteBuffer(user_ids.data(), user_ids.size() * sizeof(u128));
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }


### PR DESCRIPTION
We only emulate a single user id for now.