### PR TITLE
partition_filesystem: Return pfs_dirs member variable within GetSubdirectories()

### DIFF
--- a/src/core/file_sys/partition_filesystem.cpp
+++ b/src/core/file_sys/partition_filesystem.cpp
@@ -76,7 +76,7 @@ std::vector<std::shared_ptr<VfsFile>> PartitionFilesystem::GetFiles() const {
 }
 
 std::vector<std::shared_ptr<VfsDirectory>> PartitionFilesystem::GetSubdirectories() const {
-    return {};
+    return pfs_dirs;
 }
 
 std::string PartitionFilesystem::GetName() const {


### PR DESCRIPTION
This should be returned here, otherwise pfs_dirs is effectively only ever added to, but never read.