### PR TITLE
thread: Convert ThreadStatus into an enum class

### DIFF
--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -20,7 +20,7 @@ namespace AddressArbiter {
 static ResultCode WaitForAddress(VAddr address, s64 timeout) {
     SharedPtr<Thread> current_thread = GetCurrentThread();
     current_thread->arb_wait_address = address;
-    current_thread->status = THREADSTATUS_WAIT_ARB;
+    current_thread->status = ThreadStatus::WaitArb;
     current_thread->wakeup_callback = nullptr;
 
     current_thread->WakeAfterDelay(timeout);
@@ -65,7 +65,7 @@ static void WakeThreads(std::vector<SharedPtr<Thread>>& waiting_threads, s32 num
 
     // Signal the waiting threads.
     for (size_t i = 0; i < last; i++) {
-        ASSERT(waiting_threads[i]->status == THREADSTATUS_WAIT_ARB);
+        ASSERT(waiting_threads[i]->status == ThreadStatus::WaitArb);
         waiting_threads[i]->SetWaitSynchronizationResult(RESULT_SUCCESS);
         waiting_threads[i]->arb_wait_address = 0;
         waiting_threads[i]->ResumeFromWait();

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -38,7 +38,7 @@ SharedPtr<Event> HLERequestContext::SleepClientThread(SharedPtr<Thread> thread,
     thread->wakeup_callback =
         [context = *this, callback](ThreadWakeupReason reason, SharedPtr<Thread> thread,
                                     SharedPtr<WaitObject> object, size_t index) mutable -> bool {
-        ASSERT(thread->status == THREADSTATUS_WAIT_HLE_EVENT);
+        ASSERT(thread->status == ThreadStatus::WaitHLEEvent);
         callback(thread, context, reason);
         context.WriteToOutgoingCommandBuffer(*thread);
         return true;
@@ -50,7 +50,7 @@ SharedPtr<Event> HLERequestContext::SleepClientThread(SharedPtr<Thread> thread,
     }
 
     event->Clear();
-    thread->status = THREADSTATUS_WAIT_HLE_EVENT;
+    thread->status = ThreadStatus::WaitHLEEvent;
     thread->wait_objects = {event};
     event->AddWaitingThread(thread);
 

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -28,7 +28,7 @@ static std::pair<SharedPtr<Thread>, u32> GetHighestPriorityMutexWaitingThread(
         if (thread->mutex_wait_address != mutex_addr)
             continue;
 
-        ASSERT(thread->status == THREADSTATUS_WAIT_MUTEX);
+        ASSERT(thread->status == ThreadStatus::WaitMutex);
 
         ++num_waiters;
         if (highest_priority_thread == nullptr ||
@@ -83,7 +83,7 @@ ResultCode Mutex::TryAcquire(VAddr address, Handle holding_thread_handle,
     GetCurrentThread()->mutex_wait_address = address;
     GetCurrentThread()->wait_handle = requesting_thread_handle;
 
-    GetCurrentThread()->status = THREADSTATUS_WAIT_MUTEX;
+    GetCurrentThread()->status = ThreadStatus::WaitMutex;
     GetCurrentThread()->wakeup_callback = nullptr;
 
     // Update the lock holder thread's priority to prevent priority inversion.
@@ -121,7 +121,7 @@ ResultCode Mutex::Release(VAddr address) {
     // Grant the mutex to the next waiting thread and resume it.
     Memory::Write32(address, mutex_value);
 
-    ASSERT(thread->status == THREADSTATUS_WAIT_MUTEX);
+    ASSERT(thread->status == ThreadStatus::WaitMutex);
     thread->ResumeFromWait();
 
     thread->lock_owner = nullptr;

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -110,10 +110,10 @@ ResultCode ServerSession::HandleSyncRequest(SharedPtr<Thread> thread) {
         result = hle_handler->HandleSyncRequest(context);
     }
 
-    if (thread->status == THREADSTATUS_RUNNING) {
+    if (thread->status == ThreadStatus::Running) {
         // Put the thread to sleep until the server replies, it will be awoken in
         // svcReplyAndReceive for LLE servers.
-        thread->status = THREADSTATUS_WAIT_IPC;
+        thread->status = ThreadStatus::WaitIPC;
 
         if (hle_handler != nullptr) {
             // For HLE services, we put the request threads to sleep for a short duration to

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -36,18 +36,18 @@ enum ThreadProcessorId : s32 {
                                      (1 << THREADPROCESSORID_2) | (1 << THREADPROCESSORID_3)
 };
 
-enum ThreadStatus {
-    THREADSTATUS_RUNNING,        ///< Currently running
-    THREADSTATUS_READY,          ///< Ready to run
-    THREADSTATUS_WAIT_HLE_EVENT, ///< Waiting for hle event to finish
-    THREADSTATUS_WAIT_SLEEP,     ///< Waiting due to a SleepThread SVC
-    THREADSTATUS_WAIT_IPC,       ///< Waiting for the reply from an IPC request
-    THREADSTATUS_WAIT_SYNCH_ANY, ///< Waiting due to WaitSynch1 or WaitSynchN with wait_all = false
-    THREADSTATUS_WAIT_SYNCH_ALL, ///< Waiting due to WaitSynchronizationN with wait_all = true
-    THREADSTATUS_WAIT_MUTEX,     ///< Waiting due to an ArbitrateLock/WaitProcessWideKey svc
-    THREADSTATUS_WAIT_ARB,       ///< Waiting due to a SignalToAddress/WaitForAddress svc
-    THREADSTATUS_DORMANT,        ///< Created but not yet made ready
-    THREADSTATUS_DEAD            ///< Run to completion, or forcefully terminated
+enum class ThreadStatus {
+    Running,      ///< Currently running
+    Ready,        ///< Ready to run
+    WaitHLEEvent, ///< Waiting for hle event to finish
+    WaitSleep,    ///< Waiting due to a SleepThread SVC
+    WaitIPC,      ///< Waiting for the reply from an IPC request
+    WaitSynchAny, ///< Waiting due to WaitSynch1 or WaitSynchN with wait_all = false
+    WaitSynchAll, ///< Waiting due to WaitSynchronizationN with wait_all = true
+    WaitMutex,    ///< Waiting due to an ArbitrateLock/WaitProcessWideKey svc
+    WaitArb,      ///< Waiting due to a SignalToAddress/WaitForAddress svc
+    Dormant,      ///< Created but not yet made ready
+    Dead          ///< Run to completion, or forcefully terminated
 };
 
 enum class ThreadWakeupReason {
@@ -194,14 +194,14 @@ public:
      * with wait_all = true.
      */
     bool IsSleepingOnWaitAll() const {
-        return status == THREADSTATUS_WAIT_SYNCH_ALL;
+        return status == ThreadStatus::WaitSynchAll;
     }
 
     ARM_Interface::ThreadContext context;
 
     u32 thread_id;
 
-    u32 status;
+    ThreadStatus status;
     VAddr entry_point;
     VAddr stack_top;
 

--- a/src/core/hle/kernel/wait_object.cpp
+++ b/src/core/hle/kernel/wait_object.cpp
@@ -38,9 +38,9 @@ SharedPtr<Thread> WaitObject::GetHighestPriorityReadyThread() {
 
     for (const auto& thread : waiting_threads) {
         // The list of waiting threads must not contain threads that are not waiting to be awakened.
-        ASSERT_MSG(thread->status == THREADSTATUS_WAIT_SYNCH_ANY ||
-                       thread->status == THREADSTATUS_WAIT_SYNCH_ALL ||
-                       thread->status == THREADSTATUS_WAIT_HLE_EVENT,
+        ASSERT_MSG(thread->status == ThreadStatus::WaitSynchAny ||
+                       thread->status == ThreadStatus::WaitSynchAll ||
+                       thread->status == ThreadStatus::WaitHLEEvent,
                    "Inconsistent thread statuses in waiting_threads");
 
         if (thread->current_priority >= candidate_priority)
@@ -49,10 +49,10 @@ SharedPtr<Thread> WaitObject::GetHighestPriorityReadyThread() {
         if (ShouldWait(thread.get()))
             continue;
 
-        // A thread is ready to run if it's either in THREADSTATUS_WAIT_SYNCH_ANY or
-        // in THREADSTATUS_WAIT_SYNCH_ALL and the rest of the objects it is waiting on are ready.
+        // A thread is ready to run if it's either in ThreadStatus::WaitSynchAny or
+        // in ThreadStatus::WaitSynchAll and the rest of the objects it is waiting on are ready.
         bool ready_to_run = true;
-        if (thread->status == THREADSTATUS_WAIT_SYNCH_ALL) {
+        if (thread->status == ThreadStatus::WaitSynchAll) {
             ready_to_run = std::none_of(thread->wait_objects.begin(), thread->wait_objects.end(),
                                         [&thread](const SharedPtr<WaitObject>& object) {
                                             return object->ShouldWait(thread.get());

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -194,32 +194,32 @@ QString WaitTreeThread::GetText() const {
     const auto& thread = static_cast<const Kernel::Thread&>(object);
     QString status;
     switch (thread.status) {
-    case THREADSTATUS_RUNNING:
+    case ThreadStatus::Running:
         status = tr("running");
         break;
-    case THREADSTATUS_READY:
+    case ThreadStatus::Ready:
         status = tr("ready");
         break;
-    case THREADSTATUS_WAIT_HLE_EVENT:
+    case ThreadStatus::WaitHLEEvent:
         status = tr("waiting for HLE return");
         break;
-    case THREADSTATUS_WAIT_SLEEP:
+    case ThreadStatus::WaitSleep:
         status = tr("sleeping");
         break;
-    case THREADSTATUS_WAIT_SYNCH_ALL:
-    case THREADSTATUS_WAIT_SYNCH_ANY:
+    case ThreadStatus::WaitSynchAll:
+    case ThreadStatus::WaitSynchAny:
         status = tr("waiting for objects");
         break;
-    case THREADSTATUS_WAIT_MUTEX:
+    case ThreadStatus::WaitMutex:
         status = tr("waiting for mutex");
         break;
-    case THREADSTATUS_WAIT_ARB:
+    case ThreadStatus::WaitArb:
         status = tr("waiting for address arbiter");
         break;
-    case THREADSTATUS_DORMANT:
+    case ThreadStatus::Dormant:
         status = tr("dormant");
         break;
-    case THREADSTATUS_DEAD:
+    case ThreadStatus::Dead:
         status = tr("dead");
         break;
     }
@@ -232,22 +232,22 @@ QString WaitTreeThread::GetText() const {
 QColor WaitTreeThread::GetColor() const {
     const auto& thread = static_cast<const Kernel::Thread&>(object);
     switch (thread.status) {
-    case THREADSTATUS_RUNNING:
+    case ThreadStatus::Running:
         return QColor(Qt::GlobalColor::darkGreen);
-    case THREADSTATUS_READY:
+    case ThreadStatus::Ready:
         return QColor(Qt::GlobalColor::darkBlue);
-    case THREADSTATUS_WAIT_HLE_EVENT:
+    case ThreadStatus::WaitHLEEvent:
         return QColor(Qt::GlobalColor::darkRed);
-    case THREADSTATUS_WAIT_SLEEP:
+    case ThreadStatus::WaitSleep:
         return QColor(Qt::GlobalColor::darkYellow);
-    case THREADSTATUS_WAIT_SYNCH_ALL:
-    case THREADSTATUS_WAIT_SYNCH_ANY:
-    case THREADSTATUS_WAIT_MUTEX:
-    case THREADSTATUS_WAIT_ARB:
+    case ThreadStatus::WaitSynchAll:
+    case ThreadStatus::WaitSynchAny:
+    case ThreadStatus::WaitMutex:
+    case ThreadStatus::WaitArb:
         return QColor(Qt::GlobalColor::red);
-    case THREADSTATUS_DORMANT:
+    case ThreadStatus::Dormant:
         return QColor(Qt::GlobalColor::darkCyan);
-    case THREADSTATUS_DEAD:
+    case ThreadStatus::Dead:
         return QColor(Qt::GlobalColor::gray);
     default:
         return WaitTreeItem::GetColor();
@@ -291,8 +291,8 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeThread::GetChildren() const {
     else
         list.push_back(std::make_unique<WaitTreeText>(tr("not waiting for mutex")));
 
-    if (thread.status == THREADSTATUS_WAIT_SYNCH_ANY ||
-        thread.status == THREADSTATUS_WAIT_SYNCH_ALL) {
+    if (thread.status == ThreadStatus::WaitSynchAny ||
+        thread.status == ThreadStatus::WaitSynchAll) {
         list.push_back(std::make_unique<WaitTreeObjectList>(thread.wait_objects,
                                                             thread.IsSleepingOnWaitAll()));
     }


### PR DESCRIPTION
Makes the thread status strongly typed, so implicit conversions can't happen. It also makes it easier to catch mistakes at compile time.