### PR TITLE
audout_u/audren_u: Ensure null terminators are written out in ListAudioOutsImpl(), ListAudioDeviceName(), and GetActiveAudioDeviceName()

### DIFF
--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <array>
 #include <vector>
 #include "common/logging/log.h"
 #include "core/core_timing.h"
@@ -167,7 +168,7 @@ void AudOutU::ListAudioOutsImpl(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_Audio, "(STUBBED) called");
     IPC::RequestParser rp{ctx};
 
-    const std::string audio_interface = "AudioInterface";
+    constexpr std::array<char, 15> audio_interface{{"AudioInterface"}};
     ctx.WriteBuffer(audio_interface);
 
     IPC::ResponseBuilder rb = rp.MakeBuilder(3, 0, 0);

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <array>
+
 #include "common/alignment.h"
 #include "common/logging/log.h"
 #include "core/core_timing.h"
@@ -298,7 +300,7 @@ private:
         LOG_WARNING(Service_Audio, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
 
-        const std::string audio_interface = "AudioInterface";
+        constexpr std::array<char, 15> audio_interface{{"AudioInterface"}};
         ctx.WriteBuffer(audio_interface);
 
         IPC::ResponseBuilder rb = rp.MakeBuilder(3, 0, 0);
@@ -323,7 +325,7 @@ private:
         LOG_WARNING(Service_Audio, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
 
-        const std::string audio_interface = "AudioDevice";
+        constexpr std::array<char, 12> audio_interface{{"AudioDevice"}};
         ctx.WriteBuffer(audio_interface);
 
         IPC::ResponseBuilder rb = rp.MakeBuilder(3, 0, 0);


### PR DESCRIPTION
This also has the benefit of not using a data type that potentially allocates for a fixed string value.