### PR TITLE
filesys/loader: std::move VirtualFile instances in constructors where applicable

### DIFF
--- a/src/core/file_sys/vfs_offset.cpp
+++ b/src/core/file_sys/vfs_offset.cpp
@@ -2,13 +2,15 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <utility>
+
 #include "core/file_sys/vfs_offset.h"
 
 namespace FileSys {
 
 OffsetVfsFile::OffsetVfsFile(std::shared_ptr<VfsFile> file_, size_t size_, size_t offset_,
-                             const std::string& name_)
-    : file(file_), offset(offset_), size(size_), name(name_) {}
+                             std::string name_)
+    : file(std::move(file_)), offset(offset_), size(size_), name(std::move(name_)) {}
 
 std::string OffsetVfsFile::GetName() const {
     return name.empty() ? file->GetName() : name;

--- a/src/core/file_sys/vfs_offset.h
+++ b/src/core/file_sys/vfs_offset.h
@@ -14,7 +14,7 @@ namespace FileSys {
 // the size of this wrapper.
 struct OffsetVfsFile : public VfsFile {
     OffsetVfsFile(std::shared_ptr<VfsFile> file, size_t size, size_t offset = 0,
-                  const std::string& new_name = "");
+                  std::string new_name = "");
 
     std::string GetName() const override;
     size_t GetSize() const override;

--- a/src/core/loader/nca.cpp
+++ b/src/core/loader/nca.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <utility>
 #include <vector>
 
 #include "common/file_util.h"
@@ -21,7 +22,7 @@
 
 namespace Loader {
 
-AppLoader_NCA::AppLoader_NCA(FileSys::VirtualFile file) : AppLoader(file) {}
+AppLoader_NCA::AppLoader_NCA(FileSys::VirtualFile file) : AppLoader(std::move(file)) {}
 
 FileType AppLoader_NCA::IdentifyType(const FileSys::VirtualFile& file) {
     // TODO(DarkLordZach): Assuming everything is decrypted. Add crypto support.

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <utility>
 #include <vector>
 
 #include "common/common_funcs.h"
@@ -48,7 +49,7 @@ struct ModHeader {
 };
 static_assert(sizeof(ModHeader) == 0x1c, "ModHeader has incorrect size.");
 
-AppLoader_NRO::AppLoader_NRO(FileSys::VirtualFile file) : AppLoader(file) {}
+AppLoader_NRO::AppLoader_NRO(FileSys::VirtualFile file) : AppLoader(std::move(file)) {}
 
 FileType AppLoader_NRO::IdentifyType(const FileSys::VirtualFile& file) {
     // Read NSO header


### PR DESCRIPTION
Avoids unnecessary atomic reference count increments and decrements