### PR TITLE
param_package: Minor changes

### DIFF
--- a/src/common/param_package.cpp
+++ b/src/common/param_package.cpp
@@ -12,10 +12,11 @@ namespace Common {
 
 constexpr char KEY_VALUE_SEPARATOR = ':';
 constexpr char PARAM_SEPARATOR = ',';
+
 constexpr char ESCAPE_CHARACTER = '$';
-const std::string KEY_VALUE_SEPARATOR_ESCAPE{ESCAPE_CHARACTER, '0'};
-const std::string PARAM_SEPARATOR_ESCAPE{ESCAPE_CHARACTER, '1'};
-const std::string ESCAPE_CHARACTER_ESCAPE{ESCAPE_CHARACTER, '2'};
+constexpr char KEY_VALUE_SEPARATOR_ESCAPE[] = "$0";
+constexpr char PARAM_SEPARATOR_ESCAPE[] = "$1";
+constexpr char ESCAPE_CHARACTER_ESCAPE[] = "$2";
 
 ParamPackage::ParamPackage(const std::string& serialized) {
     std::vector<std::string> pairs;

--- a/src/common/param_package.cpp
+++ b/src/common/param_package.cpp
@@ -3,7 +3,9 @@
 // Refer to the license.txt file included.
 
 #include <array>
+#include <utility>
 #include <vector>
+
 #include "common/logging/log.h"
 #include "common/param_package.h"
 #include "common/string_util.h"
@@ -36,7 +38,7 @@ ParamPackage::ParamPackage(const std::string& serialized) {
             part = Common::ReplaceAll(part, ESCAPE_CHARACTER_ESCAPE, {ESCAPE_CHARACTER});
         }
 
-        Set(key_value[0], key_value[1]);
+        Set(key_value[0], std::move(key_value[1]));
     }
 }
 
@@ -102,8 +104,8 @@ float ParamPackage::Get(const std::string& key, float default_value) const {
     }
 }
 
-void ParamPackage::Set(const std::string& key, const std::string& value) {
-    data.insert_or_assign(key, value);
+void ParamPackage::Set(const std::string& key, std::string value) {
+    data.insert_or_assign(key, std::move(value));
 }
 
 void ParamPackage::Set(const std::string& key, int value) {

--- a/src/common/param_package.cpp
+++ b/src/common/param_package.cpp
@@ -103,15 +103,15 @@ float ParamPackage::Get(const std::string& key, float default_value) const {
 }
 
 void ParamPackage::Set(const std::string& key, const std::string& value) {
-    data[key] = value;
+    data.insert_or_assign(key, value);
 }
 
 void ParamPackage::Set(const std::string& key, int value) {
-    data[key] = std::to_string(value);
+    data.insert_or_assign(key, std::to_string(value));
 }
 
 void ParamPackage::Set(const std::string& key, float value) {
-    data[key] = std::to_string(value);
+    data.insert_or_assign(key, std::to_string(value));
 }
 
 bool ParamPackage::Has(const std::string& key) const {

--- a/src/common/param_package.h
+++ b/src/common/param_package.h
@@ -28,7 +28,7 @@ public:
     std::string Get(const std::string& key, const std::string& default_value) const;
     int Get(const std::string& key, int default_value) const;
     float Get(const std::string& key, float default_value) const;
-    void Set(const std::string& key, const std::string& value);
+    void Set(const std::string& key, std::string value);
     void Set(const std::string& key, int value);
     void Set(const std::string& key, float value);
     bool Has(const std::string& key) const;


### PR DESCRIPTION
Minor changes to avoid constructing std::string instances (and make it more straightforward to modify some string_util functions to take std::string_view instead of std::string).