### PR TITLE
gl_shader_manager: Remove unimplemented function prototype

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -10,8 +10,9 @@
 namespace GLShader {
 
 namespace Impl {
-void SetShaderUniformBlockBinding(GLuint shader, const char* name,
-                                  Maxwell3D::Regs::ShaderStage binding, size_t expected_size) {
+static void SetShaderUniformBlockBinding(GLuint shader, const char* name,
+                                         Maxwell3D::Regs::ShaderStage binding,
+                                         size_t expected_size) {
     GLuint ub_index = glGetUniformBlockIndex(shader, name);
     if (ub_index != GL_INVALID_INDEX) {
         GLint ub_size = 0;

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -21,7 +21,6 @@ using Tegra::Engines::Maxwell3D;
 
 namespace Impl {
 void SetShaderUniformBlockBindings(GLuint shader);
-void SetShaderSamplerBindings(GLuint shader);
 } // namespace Impl
 
 /// Uniform structure for the Uniform Buffer Object, all vectors must be 16-byte aligned


### PR DESCRIPTION
This was just a linker error waiting to happen.