### PR TITLE
video_core: Use nested namespaces where applicable

### DIFF
--- a/src/video_core/engines/fermi_2d.cpp
+++ b/src/video_core/engines/fermi_2d.cpp
@@ -6,8 +6,7 @@
 #include "video_core/engines/fermi_2d.h"
 #include "video_core/textures/decoders.h"
 
-namespace Tegra {
-namespace Engines {
+namespace Tegra::Engines {
 
 Fermi2D::Fermi2D(MemoryManager& memory_manager) : memory_manager(memory_manager) {}
 
@@ -69,5 +68,4 @@ void Fermi2D::HandleSurfaceCopy() {
     }
 }
 
-} // namespace Engines
-} // namespace Tegra
+} // namespace Tegra::Engines

--- a/src/video_core/engines/fermi_2d.h
+++ b/src/video_core/engines/fermi_2d.h
@@ -12,8 +12,7 @@
 #include "video_core/gpu.h"
 #include "video_core/memory_manager.h"
 
-namespace Tegra {
-namespace Engines {
+namespace Tegra::Engines {
 
 #define FERMI2D_REG_INDEX(field_name)                                                              \
     (offsetof(Tegra::Engines::Fermi2D::Regs, field_name) / sizeof(u32))
@@ -110,5 +109,4 @@ ASSERT_REG_POSITION(operation, 0xAB);
 ASSERT_REG_POSITION(trigger, 0xB5);
 #undef ASSERT_REG_POSITION
 
-} // namespace Engines
-} // namespace Tegra
+} // namespace Tegra::Engines

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -17,8 +17,7 @@
 #include "video_core/memory_manager.h"
 #include "video_core/textures/texture.h"
 
-namespace Tegra {
-namespace Engines {
+namespace Tegra::Engines {
 
 #define MAXWELL3D_REG_INDEX(field_name)                                                            \
     (offsetof(Tegra::Engines::Maxwell3D::Regs, field_name) / sizeof(u32))
@@ -898,5 +897,4 @@ ASSERT_REG_POSITION(tex_info_buffers.size[0], 0xD2F);
 
 #undef ASSERT_REG_POSITION
 
-} // namespace Engines
-} // namespace Tegra
+} // namespace Tegra::Engines

--- a/src/video_core/engines/maxwell_compute.h
+++ b/src/video_core/engines/maxwell_compute.h
@@ -6,8 +6,7 @@
 
 #include "common/common_types.h"
 
-namespace Tegra {
-namespace Engines {
+namespace Tegra::Engines {
 
 class MaxwellCompute final {
 public:
@@ -18,5 +17,4 @@ public:
     void WriteReg(u32 method, u32 value);
 };
 
-} // namespace Engines
-} // namespace Tegra
+} // namespace Tegra::Engines

--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -12,8 +12,7 @@
 #include "video_core/gpu.h"
 #include "video_core/memory_manager.h"
 
-namespace Tegra {
-namespace Engines {
+namespace Tegra::Engines {
 
 class MaxwellDMA final {
 public:
@@ -151,5 +150,4 @@ ASSERT_REG_POSITION(src_params, 0x1CA);
 
 #undef ASSERT_REG_POSITION
 
-} // namespace Engines
-} // namespace Tegra
+} // namespace Tegra::Engines

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -15,8 +15,7 @@
 #include "common/bit_field.h"
 #include "common/common_types.h"
 
-namespace Tegra {
-namespace Shader {
+namespace Tegra::Shader {
 
 struct Register {
     /// Number of registers
@@ -109,8 +108,7 @@ union Sampler {
     u64 value{};
 };
 
-} // namespace Shader
-} // namespace Tegra
+} // namespace Tegra::Shader
 
 namespace std {
 
@@ -127,8 +125,7 @@ struct make_unsigned<Tegra::Shader::Register> {
 
 } // namespace std
 
-namespace Tegra {
-namespace Shader {
+namespace Tegra::Shader {
 
 enum class Pred : u64 {
     UnusedIndex = 0x7,
@@ -784,5 +781,4 @@ private:
     }
 };
 
-} // namespace Shader
-} // namespace Tegra
+} // namespace Tegra::Shader

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -12,8 +12,7 @@
 #include "video_core/renderer_opengl/gl_rasterizer.h"
 #include "video_core/renderer_opengl/gl_shader_decompiler.h"
 
-namespace GLShader {
-namespace Decompiler {
+namespace GLShader::Decompiler {
 
 using Tegra::Shader::Attribute;
 using Tegra::Shader::Instruction;
@@ -1845,5 +1844,4 @@ boost::optional<ProgramResult> DecompileProgram(const ProgramCode& program_code,
     return boost::none;
 }
 
-} // namespace Decompiler
-} // namespace GLShader
+} // namespace GLShader::Decompiler

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.h
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.h
@@ -12,8 +12,7 @@
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/renderer_opengl/gl_shader_gen.h"
 
-namespace GLShader {
-namespace Decompiler {
+namespace GLShader::Decompiler {
 
 using Tegra::Engines::Maxwell3D;
 
@@ -23,5 +22,4 @@ boost::optional<ProgramResult> DecompileProgram(const ProgramCode& program_code,
                                                 Maxwell3D::Regs::ShaderStage stage,
                                                 const std::string& suffix);
 
-} // namespace Decompiler
-} // namespace GLShader
+} // namespace GLShader::Decompiler

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -10,8 +10,7 @@
 #include "video_core/textures/decoders.h"
 #include "video_core/textures/texture.h"
 
-namespace Tegra {
-namespace Texture {
+namespace Tegra::Texture {
 
 /**
  * Calculates the offset of an (x, y) position within a swizzled texture.
@@ -186,5 +185,4 @@ std::vector<u8> DecodeTexture(const std::vector<u8>& texture_data, TextureFormat
     return rgba_data;
 }
 
-} // namespace Texture
-} // namespace Tegra
+} // namespace Tegra::Texture

--- a/src/video_core/textures/decoders.h
+++ b/src/video_core/textures/decoders.h
@@ -8,8 +8,7 @@
 #include "common/common_types.h"
 #include "video_core/textures/texture.h"
 
-namespace Tegra {
-namespace Texture {
+namespace Tegra::Texture {
 
 /**
  * Unswizzles a swizzled texture without changing its format.
@@ -33,5 +32,4 @@ void CopySwizzledData(u32 width, u32 height, u32 bytes_per_pixel, u32 out_bytes_
 std::vector<u8> DecodeTexture(const std::vector<u8>& texture_data, TextureFormat format, u32 width,
                               u32 height);
 
-} // namespace Texture
-} // namespace Tegra
+} // namespace Tegra::Texture

--- a/src/video_core/textures/texture.h
+++ b/src/video_core/textures/texture.h
@@ -10,8 +10,7 @@
 #include "common/common_types.h"
 #include "video_core/memory_manager.h"
 
-namespace Tegra {
-namespace Texture {
+namespace Tegra::Texture {
 
 enum class TextureFormat : u32 {
     R32_G32_B32_A32 = 0x01,
@@ -260,5 +259,4 @@ struct FullTextureInfo {
 /// Returns the number of bytes per pixel of the input texture format.
 u32 BytesPerPixel(TextureFormat format);
 
-} // namespace Texture
-} // namespace Tegra
+} // namespace Tegra::Texture


### PR DESCRIPTION
Compresses a few namespace specifiers to be more compact.