### PR TITLE
arm_interface: Remove unused tls_address member of ThreadContext

### DIFF
--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -20,9 +20,6 @@ public:
         u64 cpsr;
         std::array<u128, 32> fpu_registers;
         u64 fpscr;
-
-        // TODO(bunnei): Fix once we have proper support for tpidrro_el0, etc. in the JIT
-        VAddr tls_address;
     };
 
     /// Runs the CPU until an event happens

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -203,7 +203,6 @@ void ARM_Dynarmic::SaveContext(ARM_Interface::ThreadContext& ctx) {
     ctx.cpsr = jit->GetPstate();
     ctx.fpu_registers = jit->GetVectors();
     ctx.fpscr = jit->GetFpcr();
-    ctx.tls_address = cb->tpidrro_el0;
 }
 
 void ARM_Dynarmic::LoadContext(const ARM_Interface::ThreadContext& ctx) {
@@ -213,7 +212,6 @@ void ARM_Dynarmic::LoadContext(const ARM_Interface::ThreadContext& ctx) {
     jit->SetPstate(static_cast<u32>(ctx.cpsr));
     jit->SetVectors(ctx.fpu_registers);
     jit->SetFpcr(static_cast<u32>(ctx.fpscr));
-    cb->tpidrro_el0 = ctx.tls_address;
 }
 
 void ARM_Dynarmic::PrepareReschedule() {

--- a/src/core/arm/unicorn/arm_unicorn.cpp
+++ b/src/core/arm/unicorn/arm_unicorn.cpp
@@ -220,8 +220,6 @@ void ARM_Unicorn::SaveContext(ARM_Interface::ThreadContext& ctx) {
 
     CHECKED(uc_reg_read_batch(uc, uregs, tregs, 31));
 
-    ctx.tls_address = GetTlsAddress();
-
     for (int i = 0; i < 32; ++i) {
         uregs[i] = UC_ARM64_REG_Q0 + i;
         tregs[i] = &ctx.fpu_registers[i];
@@ -248,8 +246,6 @@ void ARM_Unicorn::LoadContext(const ARM_Interface::ThreadContext& ctx) {
     tregs[30] = (void*)&ctx.cpu_registers[30];
 
     CHECKED(uc_reg_write_batch(uc, uregs, tregs, 31));
-
-    SetTlsAddress(ctx.tls_address);
 
     for (auto i = 0; i < 32; ++i) {
         uregs[i] = UC_ARM64_REG_Q0 + i;


### PR DESCRIPTION
Currently, the TLS address is set within the scheduler, making this member unused.