### PR TITLE
file_sys/errors: Remove redundant object constructor calls

### DIFF
--- a/src/core/file_sys/errors.h
+++ b/src/core/file_sys/errors.h
@@ -20,13 +20,13 @@ enum {
 constexpr ResultCode ERROR_PATH_NOT_FOUND(ErrorModule::FS, ErrCodes::NotFound);
 
 // TODO(bunnei): Replace these with correct errors for Switch OS
-constexpr ResultCode ERROR_INVALID_PATH(ResultCode(-1));
-constexpr ResultCode ERROR_UNSUPPORTED_OPEN_FLAGS(ResultCode(-1));
-constexpr ResultCode ERROR_INVALID_OPEN_FLAGS(ResultCode(-1));
-constexpr ResultCode ERROR_FILE_NOT_FOUND(ResultCode(-1));
-constexpr ResultCode ERROR_UNEXPECTED_FILE_OR_DIRECTORY(ResultCode(-1));
-constexpr ResultCode ERROR_DIRECTORY_ALREADY_EXISTS(ResultCode(-1));
-constexpr ResultCode ERROR_FILE_ALREADY_EXISTS(ResultCode(-1));
-constexpr ResultCode ERROR_DIRECTORY_NOT_EMPTY(ResultCode(-1));
+constexpr ResultCode ERROR_INVALID_PATH(-1);
+constexpr ResultCode ERROR_UNSUPPORTED_OPEN_FLAGS(-1);
+constexpr ResultCode ERROR_INVALID_OPEN_FLAGS(-1);
+constexpr ResultCode ERROR_FILE_NOT_FOUND(-1);
+constexpr ResultCode ERROR_UNEXPECTED_FILE_OR_DIRECTORY(-1);
+constexpr ResultCode ERROR_DIRECTORY_ALREADY_EXISTS(-1);
+constexpr ResultCode ERROR_FILE_ALREADY_EXISTS(-1);
+constexpr ResultCode ERROR_DIRECTORY_NOT_EMPTY(-1);
 
 } // namespace FileSys


### PR DESCRIPTION
Given we're already constructing the error code, we don't need to call the constructor inside of it.