### PR TITLE
string_util: Remove unnecessary ifdef in UTF16ToUTF8() and UTF8ToUTF16()

### DIFF
--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -196,27 +196,13 @@ std::string ReplaceAll(std::string result, const std::string& src, const std::st
 #ifdef _WIN32
 
 std::string UTF16ToUTF8(const std::u16string& input) {
-#if _MSC_VER >= 1900
-    // Workaround for missing char16_t/char32_t instantiations in MSVC2015
-    std::wstring_convert<std::codecvt_utf8_utf16<__int16>, __int16> convert;
-    std::basic_string<__int16> tmp_buffer(input.cbegin(), input.cend());
-    return convert.to_bytes(tmp_buffer);
-#else
     std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
     return convert.to_bytes(input);
-#endif
 }
 
 std::u16string UTF8ToUTF16(const std::string& input) {
-#if _MSC_VER >= 1900
-    // Workaround for missing char16_t/char32_t instantiations in MSVC2015
-    std::wstring_convert<std::codecvt_utf8_utf16<__int16>, __int16> convert;
-    auto tmp_buffer = convert.from_bytes(input);
-    return std::u16string(tmp_buffer.cbegin(), tmp_buffer.cend());
-#else
     std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> convert;
     return convert.from_bytes(input);
-#endif
 }
 
 static std::wstring CPToUTF16(u32 code_page, const std::string& input) {


### PR DESCRIPTION
VS 2017 provides the char16_t and char32_t types, so the ifdef isn't necessary anymore.