### PR TITLE
file_util: Use an enum class for GetUserPath()

### DIFF
--- a/src/common/common_paths.h
+++ b/src/common/common_paths.h
@@ -26,7 +26,7 @@
 #define USA_DIR "USA"
 #define JAP_DIR "JAP"
 
-// Subdirs in the User dir returned by GetUserPath(D_USER_IDX)
+// Subdirs in the User dir returned by GetUserPath(UserPath::UserDir)
 #define CONFIG_DIR "config"
 #define CACHE_DIR "cache"
 #define SDMC_DIR "sdmc"
@@ -35,11 +35,11 @@
 #define LOG_DIR "log"
 
 // Filenames
-// Files in the directory returned by GetUserPath(D_CONFIG_IDX)
+// Files in the directory returned by GetUserPath(UserPath::ConfigDir)
 #define EMU_CONFIG "emu.ini"
 #define DEBUGGER_CONFIG "debugger.ini"
 #define LOGGER_CONFIG "logger.ini"
-// Files in the directory returned by GetUserPath(D_LOGS_IDX)
+// Files in the directory returned by GetUserPath(UserPath::LogDir)
 #define LOG_FILE "yuzu_log.txt"
 
 // Sys files

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <sstream>
+#include <unordered_map>
 #include "common/assert.h"
 #include "common/common_funcs.h"
 #include "common/common_paths.h"
@@ -681,67 +682,68 @@ std::string GetSysDirectory() {
 
 // Returns a string with a yuzu data dir or file in the user's home
 // directory. To be used in "multi-user" mode (that is, installed).
-const std::string& GetUserPath(const unsigned int DirIDX, const std::string& newPath) {
-    static std::string paths[NUM_PATH_INDICES];
+const std::string& GetUserPath(UserPath path, const std::string& new_path) {
+    static std::unordered_map<UserPath, std::string> paths;
+    auto& user_path = paths[UserPath::UserDir];
 
     // Set up all paths and files on the first run
-    if (paths[D_USER_IDX].empty()) {
+    if (user_path.empty()) {
 #ifdef _WIN32
-        paths[D_USER_IDX] = GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
-        if (!FileUtil::IsDirectory(paths[D_USER_IDX])) {
-            paths[D_USER_IDX] = AppDataRoamingDirectory() + DIR_SEP EMU_DATA_DIR DIR_SEP;
+        user_path = GetExeDirectory() + DIR_SEP USERDATA_DIR DIR_SEP;
+        if (!FileUtil::IsDirectory(user_path)) {
+            user_path = AppDataRoamingDirectory() + DIR_SEP EMU_DATA_DIR DIR_SEP;
         } else {
             LOG_INFO(Common_Filesystem, "Using the local user directory");
         }
 
-        paths[D_CONFIG_IDX] = paths[D_USER_IDX] + CONFIG_DIR DIR_SEP;
-        paths[D_CACHE_IDX] = paths[D_USER_IDX] + CACHE_DIR DIR_SEP;
+        paths.emplace(UserPath::ConfigDir, user_path + CONFIG_DIR DIR_SEP);
+        paths.emplace(UserPath::CacheDir, user_path + CACHE_DIR DIR_SEP);
 #else
         if (FileUtil::Exists(ROOT_DIR DIR_SEP USERDATA_DIR)) {
-            paths[D_USER_IDX] = ROOT_DIR DIR_SEP USERDATA_DIR DIR_SEP;
-            paths[D_CONFIG_IDX] = paths[D_USER_IDX] + CONFIG_DIR DIR_SEP;
-            paths[D_CACHE_IDX] = paths[D_USER_IDX] + CACHE_DIR DIR_SEP;
+            user_path = ROOT_DIR DIR_SEP USERDATA_DIR DIR_SEP;
+            paths.emplace(UserPath::ConfigDir, user_path + CONFIG_DIR DIR_SEP);
+            paths.emplace(UserPath::CacheDir, user_path + CACHE_DIR DIR_SEP);
         } else {
             std::string data_dir = GetUserDirectory("XDG_DATA_HOME");
             std::string config_dir = GetUserDirectory("XDG_CONFIG_HOME");
             std::string cache_dir = GetUserDirectory("XDG_CACHE_HOME");
 
-            paths[D_USER_IDX] = data_dir + DIR_SEP EMU_DATA_DIR DIR_SEP;
-            paths[D_CONFIG_IDX] = config_dir + DIR_SEP EMU_DATA_DIR DIR_SEP;
-            paths[D_CACHE_IDX] = cache_dir + DIR_SEP EMU_DATA_DIR DIR_SEP;
+            user_path = data_dir + DIR_SEP EMU_DATA_DIR DIR_SEP;
+            paths.emplace(UserPath::ConfigDir, config_dir + DIR_SEP EMU_DATA_DIR DIR_SEP);
+            paths.emplace(UserPath::CacheDir, cache_dir + DIR_SEP EMU_DATA_DIR DIR_SEP);
         }
 #endif
-        paths[D_SDMC_IDX] = paths[D_USER_IDX] + SDMC_DIR DIR_SEP;
-        paths[D_NAND_IDX] = paths[D_USER_IDX] + NAND_DIR DIR_SEP;
-        paths[D_SYSDATA_IDX] = paths[D_USER_IDX] + SYSDATA_DIR DIR_SEP;
+        paths.emplace(UserPath::SDMCDir, user_path + SDMC_DIR DIR_SEP);
+        paths.emplace(UserPath::NANDDir, user_path + NAND_DIR DIR_SEP);
+        paths.emplace(UserPath::SysDataDir, user_path + SYSDATA_DIR DIR_SEP);
         // TODO: Put the logs in a better location for each OS
-        paths[D_LOGS_IDX] = paths[D_USER_IDX] + LOG_DIR DIR_SEP;
+        paths.emplace(UserPath::LogDir, user_path + LOG_DIR DIR_SEP);
     }
 
-    if (!newPath.empty()) {
-        if (!FileUtil::IsDirectory(newPath)) {
-            LOG_ERROR(Common_Filesystem, "Invalid path specified {}", newPath);
-            return paths[DirIDX];
+    if (!new_path.empty()) {
+        if (!FileUtil::IsDirectory(new_path)) {
+            LOG_ERROR(Common_Filesystem, "Invalid path specified {}", new_path);
+            return paths[path];
         } else {
-            paths[DirIDX] = newPath;
+            paths[path] = new_path;
         }
 
-        switch (DirIDX) {
-        case D_ROOT_IDX:
-            paths[D_USER_IDX] = paths[D_ROOT_IDX] + DIR_SEP;
+        switch (path) {
+        case UserPath::RootDir:
+            user_path = paths[UserPath::RootDir] + DIR_SEP;
             break;
 
-        case D_USER_IDX:
-            paths[D_USER_IDX] = paths[D_ROOT_IDX] + DIR_SEP;
-            paths[D_CONFIG_IDX] = paths[D_USER_IDX] + CONFIG_DIR DIR_SEP;
-            paths[D_CACHE_IDX] = paths[D_USER_IDX] + CACHE_DIR DIR_SEP;
-            paths[D_SDMC_IDX] = paths[D_USER_IDX] + SDMC_DIR DIR_SEP;
-            paths[D_NAND_IDX] = paths[D_USER_IDX] + NAND_DIR DIR_SEP;
+        case UserPath::UserDir:
+            user_path = paths[UserPath::RootDir] + DIR_SEP;
+            paths[UserPath::ConfigDir] = user_path + CONFIG_DIR DIR_SEP;
+            paths[UserPath::CacheDir] = user_path + CACHE_DIR DIR_SEP;
+            paths[UserPath::SDMCDir] = user_path + SDMC_DIR DIR_SEP;
+            paths[UserPath::NANDDir] = user_path + NAND_DIR DIR_SEP;
             break;
         }
     }
 
-    return paths[DirIDX];
+    return paths[path];
 }
 
 size_t WriteStringToFile(bool text_file, const std::string& str, const char* filename) {

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -16,20 +16,19 @@
 #include "common/string_util.h"
 #endif
 
-// User directory indices for GetUserPath
-enum {
-    D_USER_IDX,
-    D_ROOT_IDX,
-    D_CONFIG_IDX,
-    D_CACHE_IDX,
-    D_SDMC_IDX,
-    D_NAND_IDX,
-    D_SYSDATA_IDX,
-    D_LOGS_IDX,
-    NUM_PATH_INDICES
-};
-
 namespace FileUtil {
+
+// User paths for GetUserPath
+enum class UserPath {
+    CacheDir,
+    ConfigDir,
+    LogDir,
+    NANDDir,
+    RootDir,
+    SDMCDir,
+    SysDataDir,
+    UserDir,
+};
 
 // FileSystem tree node/
 struct FSTEntry {
@@ -123,7 +122,7 @@ bool SetCurrentDir(const std::string& directory);
 
 // Returns a pointer to a string with a yuzu data dir in the user's home
 // directory. To be used in "multi-user" mode (that is, installed).
-const std::string& GetUserPath(const unsigned int DirIDX, const std::string& newPath = "");
+const std::string& GetUserPath(UserPath path, const std::string& new_path = "");
 
 // Returns the path to where the sys file are
 std::string GetSysDirectory();

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -272,9 +272,9 @@ void RegisterFileSystems() {
     sdmc_factory = nullptr;
 
     auto nand_directory = std::make_shared<FileSys::RealVfsDirectory>(
-        FileUtil::GetUserPath(D_NAND_IDX), FileSys::Mode::Write);
+        FileUtil::GetUserPath(FileUtil::UserPath::NANDDir), FileSys::Mode::Write);
     auto sd_directory = std::make_shared<FileSys::RealVfsDirectory>(
-        FileUtil::GetUserPath(D_SDMC_IDX), FileSys::Mode::Write);
+        FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir), FileSys::Mode::Write);
 
     auto savedata = std::make_unique<FileSys::SaveDataFactory>(std::move(nand_directory));
     save_data_factory = std::move(savedata);

--- a/src/core/hle/service/ns/pl_u.cpp
+++ b/src/core/hle/service/ns/pl_u.cpp
@@ -42,7 +42,7 @@ PL_U::PL_U() : ServiceFramework("pl:u") {
     RegisterHandlers(functions);
 
     // Attempt to load shared font data from disk
-    const std::string filepath{FileUtil::GetUserPath(D_SYSDATA_IDX) + SHARED_FONT};
+    const std::string filepath{FileUtil::GetUserPath(FileUtil::UserPath::SysDataDir) + SHARED_FONT};
     FileUtil::CreateFullPath(filepath); // Create path if not already created
     FileUtil::IOFile file(filepath, "rb");
 

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -37,7 +37,8 @@ static u64 GenerateTelemetryId() {
 
 u64 GetTelemetryId() {
     u64 telemetry_id{};
-    static const std::string& filename{FileUtil::GetUserPath(D_CONFIG_IDX) + "telemetry_id"};
+    static const std::string& filename{FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) +
+                                       "telemetry_id"};
 
     if (FileUtil::Exists(filename)) {
         FileUtil::IOFile file(filename, "rb");
@@ -61,7 +62,8 @@ u64 GetTelemetryId() {
 
 u64 RegenerateTelemetryId() {
     const u64 new_telemetry_id{GenerateTelemetryId()};
-    static const std::string& filename{FileUtil::GetUserPath(D_CONFIG_IDX) + "telemetry_id"};
+    static const std::string& filename{FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) +
+                                       "telemetry_id"};
 
     FileUtil::IOFile file(filename, "wb");
     if (!file.IsOpen()) {

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -10,7 +10,7 @@
 
 Config::Config() {
     // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
-    qt_config_loc = FileUtil::GetUserPath(D_CONFIG_IDX) + "qt-config.ini";
+    qt_config_loc = FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + "qt-config.ini";
     FileUtil::CreateFullPath(qt_config_loc);
     qt_config = new QSettings(QString::fromStdString(qt_config_loc), QSettings::IniFormat);
 

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -19,7 +19,7 @@ ConfigureDebug::ConfigureDebug(QWidget* parent) : QWidget(parent), ui(new Ui::Co
     ui->setupUi(this);
     this->setConfiguration();
     connect(ui->open_log_button, &QPushButton::pressed, []() {
-        QString path = QString::fromStdString(FileUtil::GetUserPath(D_LOGS_IDX));
+        QString path = QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::LogDir));
         QDesktopServices::openUrl(QUrl::fromLocalFile(path));
     });
 }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -909,6 +909,16 @@ void GMainWindow::UpdateUITheme() {
 #undef main
 #endif
 
+static void InitializeLogging() {
+    Log::Filter log_filter;
+    log_filter.ParseFilterString(Settings::values.log_filter);
+    Log::SetGlobalFilter(log_filter);
+
+    const std::string& log_dir = FileUtil::GetUserPath(FileUtil::UserPath::LogDir);
+    FileUtil::CreateFullPath(log_dir);
+    Log::AddBackend(std::make_unique<Log::FileBackend>(log_dir + LOG_FILE));
+}
+
 int main(int argc, char* argv[]) {
     MicroProfileOnThreadCreate("Frontend");
     SCOPE_EXIT({ MicroProfileShutdown(); });
@@ -927,13 +937,7 @@ int main(int argc, char* argv[]) {
 
     GMainWindow main_window;
     // After settings have been loaded by GMainWindow, apply the filter
-    Log::Filter log_filter;
-    log_filter.ParseFilterString(Settings::values.log_filter);
-    Log::SetGlobalFilter(log_filter);
-    FileUtil::CreateFullPath(FileUtil::GetUserPath(D_LOGS_IDX));
-    Log::AddBackend(
-        std::make_unique<Log::FileBackend>(FileUtil::GetUserPath(D_LOGS_IDX) + LOG_FILE));
-
+    InitializeLogging();
     main_window.show();
     return app.exec();
 }

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -15,7 +15,7 @@
 
 Config::Config() {
     // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
-    sdl2_config_loc = FileUtil::GetUserPath(D_CONFIG_IDX) + "sdl2-config.ini";
+    sdl2_config_loc = FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + "sdl2-config.ini";
     sdl2_config = std::make_unique<INIReader>(sdl2_config_loc);
 
     Reload();

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -56,6 +56,18 @@ static void PrintVersion() {
     std::cout << "yuzu " << Common::g_scm_branch << " " << Common::g_scm_desc << std::endl;
 }
 
+static void InitializeLogging() {
+    Log::Filter log_filter(Log::Level::Debug);
+    log_filter.ParseFilterString(Settings::values.log_filter);
+    Log::SetGlobalFilter(log_filter);
+
+    Log::AddBackend(std::make_unique<Log::ColorConsoleBackend>());
+
+    const std::string& log_dir = FileUtil::GetUserPath(FileUtil::UserPath::LogDir);
+    FileUtil::CreateFullPath(log_dir);
+    Log::AddBackend(std::make_unique<Log::FileBackend>(log_dir + LOG_FILE));
+}
+
 /// Application entry point
 int main(int argc, char** argv) {
     Config config;
@@ -124,14 +136,7 @@ int main(int argc, char** argv) {
     LocalFree(argv_w);
 #endif
 
-    Log::Filter log_filter(Log::Level::Debug);
-    log_filter.ParseFilterString(Settings::values.log_filter);
-    Log::SetGlobalFilter(log_filter);
-
-    Log::AddBackend(std::make_unique<Log::ColorConsoleBackend>());
-    FileUtil::CreateFullPath(FileUtil::GetUserPath(D_LOGS_IDX));
-    Log::AddBackend(
-        std::make_unique<Log::FileBackend>(FileUtil::GetUserPath(D_LOGS_IDX) + LOG_FILE));
+    InitializeLogging();
 
     MicroProfileOnThreadCreate("EmuThread");
     SCOPE_EXIT({ MicroProfileShutdown(); });


### PR DESCRIPTION
Instead of using an unsigned int as a parameter and expecting a user to always pass in the correct values, we can just convert the enum into an enum class and use that type as the parameter type instead, which makes the interface more type safe.

We also get rid of the bookkeeping "NUM_" element in the enum by just using an unordered map. This function is generally low-frequency in terms of calls (and I'd hope so, considering otherwise would mean we're slamming the disk with IO all the time) so I'd consider this acceptable in this case.