### PR TITLE
 file_util, vfs: Use std::string_view where applicable

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -802,66 +802,80 @@ void SplitFilename83(const std::string& filename, std::array<char, 9>& short_nam
     }
 }
 
-std::vector<std::string> SplitPathComponents(const std::string& filename) {
-    auto copy(filename);
+std::vector<std::string> SplitPathComponents(std::string_view filename) {
+    std::string copy(filename);
     std::replace(copy.begin(), copy.end(), '\\', '/');
     std::vector<std::string> out;
 
-    std::stringstream stream(filename);
+    std::stringstream stream(copy);
     std::string item;
-    while (std::getline(stream, item, '/'))
+    while (std::getline(stream, item, '/')) {
         out.push_back(std::move(item));
+    }
 
     return out;
 }
 
-std::string GetParentPath(const std::string& path) {
-    auto out = path;
-    const auto name_bck_index = out.find_last_of('\\');
-    const auto name_fwd_index = out.find_last_of('/');
+std::string_view GetParentPath(std::string_view path) {
+    const auto name_bck_index = path.rfind('\\');
+    const auto name_fwd_index = path.rfind('/');
     size_t name_index;
-    if (name_bck_index == std::string::npos || name_fwd_index == std::string::npos)
-        name_index = std::min<size_t>(name_bck_index, name_fwd_index);
-    else
-        name_index = std::max<size_t>(name_bck_index, name_fwd_index);
 
-    return out.erase(name_index);
+    if (name_bck_index == std::string_view::npos || name_fwd_index == std::string_view::npos) {
+        name_index = std::min(name_bck_index, name_fwd_index);
+    } else {
+        name_index = std::max(name_bck_index, name_fwd_index);
+    }
+
+    return path.substr(0, name_index);
 }
 
-std::string GetPathWithoutTop(std::string path) {
-    if (path.empty())
-        return "";
-    while (path[0] == '\\' || path[0] == '/') {
-        path = path.substr(1);
-        if (path.empty())
-            return "";
+std::string_view GetPathWithoutTop(std::string_view path) {
+    if (path.empty()) {
+        return path;
     }
-    const auto name_bck_index = path.find_first_of('\\');
-    const auto name_fwd_index = path.find_first_of('/');
+
+    while (path[0] == '\\' || path[0] == '/') {
+        path.remove_suffix(1);
+        if (path.empty()) {
+            return path;
+        }
+    }
+
+    const auto name_bck_index = path.find('\\');
+    const auto name_fwd_index = path.find('/');
     return path.substr(std::min(name_bck_index, name_fwd_index) + 1);
 }
 
-std::string GetFilename(std::string path) {
-    std::replace(path.begin(), path.end(), '\\', '/');
-    auto name_index = path.find_last_of('/');
-    if (name_index == std::string::npos)
-        return "";
+std::string_view GetFilename(std::string_view path) {
+    const auto name_index = path.find_last_of("\\/");
+
+    if (name_index == std::string_view::npos) {
+        return {};
+    }
+
     return path.substr(name_index + 1);
 }
 
-std::string GetExtensionFromFilename(const std::string& name) {
-    size_t index = name.find_last_of('.');
-    if (index == std::string::npos)
-        return "";
+std::string_view GetExtensionFromFilename(std::string_view name) {
+    const size_t index = name.rfind('.');
+
+    if (index == std::string_view::npos) {
+        return {};
+    }
 
     return name.substr(index + 1);
 }
 
-std::string RemoveTrailingSlash(const std::string& path) {
-    if (path.empty())
+std::string_view RemoveTrailingSlash(std::string_view path) {
+    if (path.empty()) {
         return path;
-    if (path.back() == '\\' || path.back() == '/')
-        return path.substr(0, path.size() - 1);
+    }
+
+    if (path.back() == '\\' || path.back() == '/') {
+        path.remove_suffix(1);
+        return path;
+    }
 
     return path;
 }

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -9,6 +9,7 @@
 #include <fstream>
 #include <functional>
 #include <string>
+#include <string_view>
 #include <type_traits>
 #include <vector>
 #include "common/common_types.h"
@@ -151,22 +152,22 @@ void SplitFilename83(const std::string& filename, std::array<char, 9>& short_nam
 
 // Splits the path on '/' or '\' and put the components into a vector
 // i.e. "C:\Users\Yuzu\Documents\save.bin" becomes {"C:", "Users", "Yuzu", "Documents", "save.bin" }
-std::vector<std::string> SplitPathComponents(const std::string& filename);
+std::vector<std::string> SplitPathComponents(std::string_view filename);
 
 // Gets all of the text up to the last '/' or '\' in the path.
-std::string GetParentPath(const std::string& path);
+std::string_view GetParentPath(std::string_view path);
 
 // Gets all of the text after the first '/' or '\' in the path.
-std::string GetPathWithoutTop(std::string path);
+std::string_view GetPathWithoutTop(std::string_view path);
 
 // Gets the filename of the path
-std::string GetFilename(std::string path);
+std::string_view GetFilename(std::string_view path);
 
 // Gets the extension of the filename
-std::string GetExtensionFromFilename(const std::string& name);
+std::string_view GetExtensionFromFilename(std::string_view name);
 
 // Removes the final '/' or '\' if one exists
-std::string RemoveTrailingSlash(const std::string& path);
+std::string_view RemoveTrailingSlash(std::string_view path);
 
 // Creates a new vector containing indices [first, last) from the original.
 template <typename T>

--- a/src/core/file_sys/vfs.h
+++ b/src/core/file_sys/vfs.h
@@ -205,9 +205,12 @@ struct VfsDirectory : NonCopyable {
     template <typename Directory>
     bool InterpretAsDirectory(std::string_view file) {
         auto file_p = GetFile(file);
-        if (file_p == nullptr)
+
+        if (file_p == nullptr) {
             return false;
-        return ReplaceFileWithSubdirectory(file, std::make_shared<Directory>(file_p));
+        }
+
+        return ReplaceFileWithSubdirectory(file_p, std::make_shared<Directory>(file_p));
     }
 
 protected:

--- a/src/core/file_sys/vfs_offset.cpp
+++ b/src/core/file_sys/vfs_offset.cpp
@@ -80,7 +80,7 @@ size_t OffsetVfsFile::WriteBytes(const std::vector<u8>& data, size_t r_offset) {
     return file->Write(data.data(), TrimToFit(data.size(), r_offset), offset + r_offset);
 }
 
-bool OffsetVfsFile::Rename(const std::string& name) {
+bool OffsetVfsFile::Rename(std::string_view name) {
     return file->Rename(name);
 }
 

--- a/src/core/file_sys/vfs_offset.h
+++ b/src/core/file_sys/vfs_offset.h
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include <memory>
+#include <string_view>
+
 #include "core/file_sys/vfs.h"
 
 namespace FileSys {
@@ -30,7 +33,7 @@ struct OffsetVfsFile : public VfsFile {
     bool WriteByte(u8 data, size_t offset) override;
     size_t WriteBytes(const std::vector<u8>& data, size_t offset) override;
 
-    bool Rename(const std::string& name) override;
+    bool Rename(std::string_view name) override;
 
     size_t GetOffset() const;
 

--- a/src/core/file_sys/vfs_real.h
+++ b/src/core/file_sys/vfs_real.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #include "common/file_util.h"
 #include "core/file_sys/mode.h"
 #include "core/file_sys/vfs.h"
@@ -24,7 +26,7 @@ struct RealVfsFile : public VfsFile {
     bool IsReadable() const override;
     size_t Read(u8* data, size_t length, size_t offset) const override;
     size_t Write(const u8* data, size_t length, size_t offset) override;
-    bool Rename(const std::string& name) override;
+    bool Rename(std::string_view name) override;
 
 private:
     bool Close();
@@ -47,11 +49,11 @@ struct RealVfsDirectory : public VfsDirectory {
     bool IsReadable() const override;
     std::string GetName() const override;
     std::shared_ptr<VfsDirectory> GetParentDirectory() const override;
-    std::shared_ptr<VfsDirectory> CreateSubdirectory(const std::string& name) override;
-    std::shared_ptr<VfsFile> CreateFile(const std::string& name) override;
-    bool DeleteSubdirectory(const std::string& name) override;
-    bool DeleteFile(const std::string& name) override;
-    bool Rename(const std::string& name) override;
+    std::shared_ptr<VfsDirectory> CreateSubdirectory(std::string_view name) override;
+    std::shared_ptr<VfsFile> CreateFile(std::string_view name) override;
+    bool DeleteSubdirectory(std::string_view name) override;
+    bool DeleteFile(std::string_view name) override;
+    bool Rename(std::string_view name) override;
 
 protected:
     bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -24,7 +24,7 @@ namespace Service::FileSystem {
 constexpr u64 EMULATED_SD_REPORTED_SIZE = 32000000000;
 
 static FileSys::VirtualDir GetDirectoryRelativeWrapped(FileSys::VirtualDir base,
-                                                       const std::string& dir_name) {
+                                                       std::string_view dir_name) {
     if (dir_name.empty() || dir_name == "." || dir_name == "/" || dir_name == "\\")
         return base;
 

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -49,7 +49,8 @@ FileType GuessFromFilename(const std::string& name) {
     if (name == "main")
         return FileType::DeconstructedRomDirectory;
 
-    const std::string extension = Common::ToLower(FileUtil::GetExtensionFromFilename(name));
+    const std::string extension =
+        Common::ToLower(std::string(FileUtil::GetExtensionFromFilename(name)));
 
     if (extension == "elf")
         return FileType::ELF;


### PR DESCRIPTION
Avoids constructing std::string instances where avoidable.