### PR TITLE
shader_bytecode: Add constexpr to default constructor of Attribute and Sampler

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -67,7 +67,7 @@ private:
 };
 
 union Attribute {
-    Attribute() = default;
+    constexpr Attribute() = default;
 
     constexpr explicit Attribute(u64 value) : value(value) {}
 
@@ -96,7 +96,7 @@ union Attribute {
 };
 
 union Sampler {
-    Sampler() = default;
+    constexpr Sampler() = default;
 
     constexpr explicit Sampler(u64 value) : value(value) {}
 


### PR DESCRIPTION
We already have a constexpr constructor that takes a paremeter, so the other constructor should have it too.