### PR TITLE
set: Add missing log call in GetAvailableLanguageCodeCount()

### DIFF
--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -45,6 +45,8 @@ void SET::GetAvailableLanguageCodeCount(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.Push(static_cast<u32>(available_language_codes.size()));
+
+    LOG_DEBUG(Service_SET, "called");
 }
 
 SET::SET() : ServiceFramework("set") {


### PR DESCRIPTION
Forgot to include this in 22f448b6327044076959e338811ee576f3dcf093