### PR TITLE
partition_filesystem: Use std::move where applicable

### DIFF
--- a/src/core/file_sys/partition_filesystem.cpp
+++ b/src/core/file_sys/partition_filesystem.cpp
@@ -65,8 +65,8 @@ PartitionFilesystem::PartitionFilesystem(std::shared_ptr<VfsFile> file) {
         std::string name(
             reinterpret_cast<const char*>(&file_data[strtab_offset + entry.strtab_offset]));
 
-        pfs_files.emplace_back(
-            std::make_shared<OffsetVfsFile>(file, entry.size, content_offset + entry.offset, name));
+        pfs_files.emplace_back(std::make_shared<OffsetVfsFile>(
+            file, entry.size, content_offset + entry.offset, std::move(name)));
     }
 
     status = Loader::ResultStatus::Success;
@@ -109,7 +109,7 @@ bool PartitionFilesystem::ReplaceFileWithSubdirectory(VirtualFile file, VirtualD
         return false;
 
     const std::ptrdiff_t offset = std::distance(pfs_files.begin(), iter);
-    pfs_files[offset] = pfs_files.back();
+    pfs_files[offset] = std::move(pfs_files.back());
     pfs_files.pop_back();
 
     pfs_dirs.emplace_back(std::move(dir));


### PR DESCRIPTION
Avoids copying a std::string instance and avoids unnecessary atomic reference count incrementing and decrementing.