### PR TITLE
exclusive_monitor: Use consistent type alias for u64

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -257,7 +257,7 @@ void ARM_Dynarmic::PageTableChanged() {
 DynarmicExclusiveMonitor::DynarmicExclusiveMonitor(size_t core_count) : monitor(core_count) {}
 DynarmicExclusiveMonitor::~DynarmicExclusiveMonitor() = default;
 
-void DynarmicExclusiveMonitor::SetExclusive(size_t core_index, u64 addr) {
+void DynarmicExclusiveMonitor::SetExclusive(size_t core_index, VAddr addr) {
     // Size doesn't actually matter.
     monitor.Mark(core_index, addr, 16);
 }
@@ -266,28 +266,27 @@ void DynarmicExclusiveMonitor::ClearExclusive() {
     monitor.Clear();
 }
 
-bool DynarmicExclusiveMonitor::ExclusiveWrite8(size_t core_index, u64 vaddr, u8 value) {
+bool DynarmicExclusiveMonitor::ExclusiveWrite8(size_t core_index, VAddr vaddr, u8 value) {
     return monitor.DoExclusiveOperation(core_index, vaddr, 1,
                                         [&] { Memory::Write8(vaddr, value); });
 }
 
-bool DynarmicExclusiveMonitor::ExclusiveWrite16(size_t core_index, u64 vaddr, u16 value) {
+bool DynarmicExclusiveMonitor::ExclusiveWrite16(size_t core_index, VAddr vaddr, u16 value) {
     return monitor.DoExclusiveOperation(core_index, vaddr, 2,
                                         [&] { Memory::Write16(vaddr, value); });
 }
 
-bool DynarmicExclusiveMonitor::ExclusiveWrite32(size_t core_index, u64 vaddr, u32 value) {
+bool DynarmicExclusiveMonitor::ExclusiveWrite32(size_t core_index, VAddr vaddr, u32 value) {
     return monitor.DoExclusiveOperation(core_index, vaddr, 4,
                                         [&] { Memory::Write32(vaddr, value); });
 }
 
-bool DynarmicExclusiveMonitor::ExclusiveWrite64(size_t core_index, u64 vaddr, u64 value) {
+bool DynarmicExclusiveMonitor::ExclusiveWrite64(size_t core_index, VAddr vaddr, u64 value) {
     return monitor.DoExclusiveOperation(core_index, vaddr, 8,
                                         [&] { Memory::Write64(vaddr, value); });
 }
 
-bool DynarmicExclusiveMonitor::ExclusiveWrite128(size_t core_index, u64 vaddr,
-                                                 std::array<std::uint64_t, 2> value) {
+bool DynarmicExclusiveMonitor::ExclusiveWrite128(size_t core_index, VAddr vaddr, u128 value) {
     return monitor.DoExclusiveOperation(core_index, vaddr, 16, [&] {
         Memory::Write64(vaddr, value[0]);
         Memory::Write64(vaddr, value[1]);

--- a/src/core/arm/dynarmic/arm_dynarmic.h
+++ b/src/core/arm/dynarmic/arm_dynarmic.h
@@ -68,15 +68,14 @@ public:
     explicit DynarmicExclusiveMonitor(size_t core_count);
     ~DynarmicExclusiveMonitor();
 
-    void SetExclusive(size_t core_index, u64 addr) override;
+    void SetExclusive(size_t core_index, VAddr addr) override;
     void ClearExclusive() override;
 
-    bool ExclusiveWrite8(size_t core_index, u64 vaddr, u8 value) override;
-    bool ExclusiveWrite16(size_t core_index, u64 vaddr, u16 value) override;
-    bool ExclusiveWrite32(size_t core_index, u64 vaddr, u32 value) override;
-    bool ExclusiveWrite64(size_t core_index, u64 vaddr, u64 value) override;
-    bool ExclusiveWrite128(size_t core_index, u64 vaddr,
-                           std::array<std::uint64_t, 2> value) override;
+    bool ExclusiveWrite8(size_t core_index, VAddr vaddr, u8 value) override;
+    bool ExclusiveWrite16(size_t core_index, VAddr vaddr, u16 value) override;
+    bool ExclusiveWrite32(size_t core_index, VAddr vaddr, u32 value) override;
+    bool ExclusiveWrite64(size_t core_index, VAddr vaddr, u64 value) override;
+    bool ExclusiveWrite128(size_t core_index, VAddr vaddr, u128 value) override;
 
 private:
     friend class ARM_Dynarmic;

--- a/src/core/arm/exclusive_monitor.h
+++ b/src/core/arm/exclusive_monitor.h
@@ -4,20 +4,18 @@
 
 #pragma once
 
-#include <array>
 #include "common/common_types.h"
 
 class ExclusiveMonitor {
 public:
     virtual ~ExclusiveMonitor();
 
-    virtual void SetExclusive(size_t core_index, u64 addr) = 0;
+    virtual void SetExclusive(size_t core_index, VAddr addr) = 0;
     virtual void ClearExclusive() = 0;
 
-    virtual bool ExclusiveWrite8(size_t core_index, u64 vaddr, u8 value) = 0;
-    virtual bool ExclusiveWrite16(size_t core_index, u64 vaddr, u16 value) = 0;
-    virtual bool ExclusiveWrite32(size_t core_index, u64 vaddr, u32 value) = 0;
-    virtual bool ExclusiveWrite64(size_t core_index, u64 vaddr, u64 value) = 0;
-    virtual bool ExclusiveWrite128(size_t core_index, u64 vaddr,
-                                   std::array<std::uint64_t, 2> value) = 0;
+    virtual bool ExclusiveWrite8(size_t core_index, VAddr vaddr, u8 value) = 0;
+    virtual bool ExclusiveWrite16(size_t core_index, VAddr vaddr, u16 value) = 0;
+    virtual bool ExclusiveWrite32(size_t core_index, VAddr vaddr, u32 value) = 0;
+    virtual bool ExclusiveWrite64(size_t core_index, VAddr vaddr, u64 value) = 0;
+    virtual bool ExclusiveWrite128(size_t core_index, VAddr vaddr, u128 value) = 0;
 };


### PR DESCRIPTION
Uses the same type aliases we use for virtual addresses, and converts one lingering usage of `std::array<uint64_t, 2>` to `u128` for consistency.