### PR TITLE
gl_rasterizer_cache: Implement formats BGRA8_UNORM/RGBA32_FLOAT/RG32_FLOAT

### DIFF
--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -35,6 +35,7 @@ u32 RenderTargetBytesPerPixel(RenderTargetFormat format) {
     case RenderTargetFormat::RGBA32_FLOAT:
         return 16;
     case RenderTargetFormat::RGBA16_FLOAT:
+    case RenderTargetFormat::RG32_FLOAT:
         return 8;
     case RenderTargetFormat::RGBA8_UNORM:
     case RenderTargetFormat::RGB10_A2_UNORM:

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -38,6 +38,7 @@ u32 RenderTargetBytesPerPixel(RenderTargetFormat format) {
         return 8;
     case RenderTargetFormat::RGBA8_UNORM:
     case RenderTargetFormat::RGB10_A2_UNORM:
+    case RenderTargetFormat::BGRA8_UNORM:
         return 4;
     default:
         UNIMPLEMENTED_MSG("Unimplemented render target format {}", static_cast<u32>(format));

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -18,6 +18,7 @@ enum class RenderTargetFormat : u32 {
     RGBA32_FLOAT = 0xC0,
     RGBA32_UINT = 0xC2,
     RGBA16_FLOAT = 0xCA,
+    BGRA8_UNORM = 0xCF,
     RGB10_A2_UNORM = 0xD1,
     RGBA8_UNORM = 0xD5,
     RGBA8_SRGB = 0xD6,

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -18,6 +18,7 @@ enum class RenderTargetFormat : u32 {
     RGBA32_FLOAT = 0xC0,
     RGBA32_UINT = 0xC2,
     RGBA16_FLOAT = 0xCA,
+    RG32_FLOAT = 0xCB,
     BGRA8_UNORM = 0xCF,
     RGB10_A2_UNORM = 0xD1,
     RGBA8_UNORM = 0xD5,

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -38,7 +38,8 @@ struct FormatTuple {
     params.addr = config.tic.Address();
     params.is_tiled = config.tic.IsTiled();
     params.block_height = params.is_tiled ? config.tic.BlockHeight() : 0,
-    params.pixel_format = PixelFormatFromTextureFormat(config.tic.format);
+    params.pixel_format =
+        PixelFormatFromTextureFormat(config.tic.format, config.tic.r_type.Value());
     params.component_type = ComponentTypeFromTexture(config.tic.r_type.Value());
     params.type = GetFormatType(params.pixel_format);
     params.width = Common::AlignUp(config.tic.Width(), GetCompressionFactor(params.pixel_format));
@@ -107,6 +108,7 @@ static constexpr std::array<FormatTuple, SurfaceParams::MaxPixelFormat> tex_form
     {GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE, ComponentType::UNorm, false}, // ASTC_2D_4X4
     {GL_RG8, GL_RG, GL_UNSIGNED_BYTE, ComponentType::UNorm, false},     // G8R8
     {GL_RGBA8, GL_BGRA, GL_UNSIGNED_BYTE, ComponentType::UNorm, false}, // BGRA8
+    {GL_RGBA32F, GL_RGBA, GL_FLOAT, ComponentType::Float, false},       // RGBA32F
 
     // DepthStencil formats
     {GL_DEPTH24_STENCIL8, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, ComponentType::UNorm,
@@ -199,8 +201,9 @@ static constexpr std::array<void (*)(u32, u32, u32, u8*, Tegra::GPUVAddr),
         MortonCopy<true, PixelFormat::DXT45>,        MortonCopy<true, PixelFormat::DXN1>,
         MortonCopy<true, PixelFormat::BC7U>,         MortonCopy<true, PixelFormat::ASTC_2D_4X4>,
         MortonCopy<true, PixelFormat::G8R8>,         MortonCopy<true, PixelFormat::BGRA8>,
-        MortonCopy<true, PixelFormat::Z24S8>,        MortonCopy<true, PixelFormat::S8Z24>,
-        MortonCopy<true, PixelFormat::Z32F>,         MortonCopy<true, PixelFormat::Z16>,
+        MortonCopy<true, PixelFormat::RGBA32F>,      MortonCopy<true, PixelFormat::Z24S8>,
+        MortonCopy<true, PixelFormat::S8Z24>,        MortonCopy<true, PixelFormat::Z32F>,
+        MortonCopy<true, PixelFormat::Z16>,
 };
 
 static constexpr std::array<void (*)(u32, u32, u32, u8*, Tegra::GPUVAddr),
@@ -223,6 +226,7 @@ static constexpr std::array<void (*)(u32, u32, u32, u8*, Tegra::GPUVAddr),
         nullptr,
         MortonCopy<false, PixelFormat::G8R8>,
         MortonCopy<false, PixelFormat::BGRA8>,
+        MortonCopy<false, PixelFormat::RGBA32F>,
         MortonCopy<false, PixelFormat::Z24S8>,
         MortonCopy<false, PixelFormat::S8Z24>,
         MortonCopy<false, PixelFormat::Z32F>,

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -106,6 +106,7 @@ static constexpr std::array<FormatTuple, SurfaceParams::MaxPixelFormat> tex_form
      true},                                                             // BC7U
     {GL_RGBA8, GL_RGBA, GL_UNSIGNED_BYTE, ComponentType::UNorm, false}, // ASTC_2D_4X4
     {GL_RG8, GL_RG, GL_UNSIGNED_BYTE, ComponentType::UNorm, false},     // G8R8
+    {GL_RGBA8, GL_BGRA, GL_UNSIGNED_BYTE, ComponentType::UNorm, false}, // BGRA8
 
     // DepthStencil formats
     {GL_DEPTH24_STENCIL8, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, ComponentType::UNorm,
@@ -197,9 +198,9 @@ static constexpr std::array<void (*)(u32, u32, u32, u8*, Tegra::GPUVAddr),
         MortonCopy<true, PixelFormat::DXT1>,         MortonCopy<true, PixelFormat::DXT23>,
         MortonCopy<true, PixelFormat::DXT45>,        MortonCopy<true, PixelFormat::DXN1>,
         MortonCopy<true, PixelFormat::BC7U>,         MortonCopy<true, PixelFormat::ASTC_2D_4X4>,
-        MortonCopy<true, PixelFormat::G8R8>,         MortonCopy<true, PixelFormat::Z24S8>,
-        MortonCopy<true, PixelFormat::S8Z24>,        MortonCopy<true, PixelFormat::Z32F>,
-        MortonCopy<true, PixelFormat::Z16>,
+        MortonCopy<true, PixelFormat::G8R8>,         MortonCopy<true, PixelFormat::BGRA8>,
+        MortonCopy<true, PixelFormat::Z24S8>,        MortonCopy<true, PixelFormat::S8Z24>,
+        MortonCopy<true, PixelFormat::Z32F>,         MortonCopy<true, PixelFormat::Z16>,
 };
 
 static constexpr std::array<void (*)(u32, u32, u32, u8*, Tegra::GPUVAddr),
@@ -213,7 +214,7 @@ static constexpr std::array<void (*)(u32, u32, u32, u8*, Tegra::GPUVAddr),
         MortonCopy<false, PixelFormat::RGBA16F>,
         MortonCopy<false, PixelFormat::R11FG11FB10F>,
         MortonCopy<false, PixelFormat::RGBA32UI>,
-        // TODO(Subv): Swizzling the DXT1/DXT23/DXT45/DXN1/BC7U formats is not yet supported
+        // TODO(Subv): Swizzling DXT1/DXT23/DXT45/DXN1/BC7U/ASTC_2D_4X4 formats is not supported
         nullptr,
         nullptr,
         nullptr,
@@ -221,6 +222,7 @@ static constexpr std::array<void (*)(u32, u32, u32, u8*, Tegra::GPUVAddr),
         nullptr,
         nullptr,
         MortonCopy<false, PixelFormat::G8R8>,
+        MortonCopy<false, PixelFormat::BGRA8>,
         MortonCopy<false, PixelFormat::Z24S8>,
         MortonCopy<false, PixelFormat::S8Z24>,
         MortonCopy<false, PixelFormat::Z32F>,

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -109,6 +109,7 @@ static constexpr std::array<FormatTuple, SurfaceParams::MaxPixelFormat> tex_form
     {GL_RG8, GL_RG, GL_UNSIGNED_BYTE, ComponentType::UNorm, false},     // G8R8
     {GL_RGBA8, GL_BGRA, GL_UNSIGNED_BYTE, ComponentType::UNorm, false}, // BGRA8
     {GL_RGBA32F, GL_RGBA, GL_FLOAT, ComponentType::Float, false},       // RGBA32F
+    {GL_RG32F, GL_RG, GL_FLOAT, ComponentType::Float, false},           // RG32F
 
     // DepthStencil formats
     {GL_DEPTH24_STENCIL8, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, ComponentType::UNorm,
@@ -201,9 +202,9 @@ static constexpr std::array<void (*)(u32, u32, u32, u8*, Tegra::GPUVAddr),
         MortonCopy<true, PixelFormat::DXT45>,        MortonCopy<true, PixelFormat::DXN1>,
         MortonCopy<true, PixelFormat::BC7U>,         MortonCopy<true, PixelFormat::ASTC_2D_4X4>,
         MortonCopy<true, PixelFormat::G8R8>,         MortonCopy<true, PixelFormat::BGRA8>,
-        MortonCopy<true, PixelFormat::RGBA32F>,      MortonCopy<true, PixelFormat::Z24S8>,
-        MortonCopy<true, PixelFormat::S8Z24>,        MortonCopy<true, PixelFormat::Z32F>,
-        MortonCopy<true, PixelFormat::Z16>,
+        MortonCopy<true, PixelFormat::RGBA32F>,      MortonCopy<true, PixelFormat::RG32F>,
+        MortonCopy<true, PixelFormat::Z24S8>,        MortonCopy<true, PixelFormat::S8Z24>,
+        MortonCopy<true, PixelFormat::Z32F>,         MortonCopy<true, PixelFormat::Z16>,
 };
 
 static constexpr std::array<void (*)(u32, u32, u32, u8*, Tegra::GPUVAddr),
@@ -227,6 +228,7 @@ static constexpr std::array<void (*)(u32, u32, u32, u8*, Tegra::GPUVAddr),
         MortonCopy<false, PixelFormat::G8R8>,
         MortonCopy<false, PixelFormat::BGRA8>,
         MortonCopy<false, PixelFormat::RGBA32F>,
+        MortonCopy<false, PixelFormat::RG32F>,
         MortonCopy<false, PixelFormat::Z24S8>,
         MortonCopy<false, PixelFormat::S8Z24>,
         MortonCopy<false, PixelFormat::Z32F>,

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -37,14 +37,15 @@ struct SurfaceParams {
         BC7U = 12,
         ASTC_2D_4X4 = 13,
         G8R8 = 14,
+        BGRA8 = 15,
 
         MaxColorFormat,
 
         // DepthStencil formats
-        Z24S8 = 15,
-        S8Z24 = 16,
-        Z32F = 17,
-        Z16 = 18,
+        Z24S8 = 16,
+        S8Z24 = 17,
+        Z32F = 18,
+        Z16 = 19,
 
         MaxDepthStencilFormat,
 
@@ -97,6 +98,7 @@ struct SurfaceParams {
             4, // BC7U
             4, // ASTC_2D_4X4
             1, // G8R8
+            1, // BGRA8
             1, // Z24S8
             1, // S8Z24
             1, // Z32F
@@ -127,6 +129,7 @@ struct SurfaceParams {
             128, // BC7U
             32,  // ASTC_2D_4X4
             16,  // G8R8
+            32,  // BGRA8
             32,  // Z24S8
             32,  // S8Z24
             32,  // Z32F
@@ -162,6 +165,8 @@ struct SurfaceParams {
         case Tegra::RenderTargetFormat::RGBA8_UNORM:
         case Tegra::RenderTargetFormat::RGBA8_SRGB:
             return PixelFormat::ABGR8;
+        case Tegra::RenderTargetFormat::BGRA8_UNORM:
+            return PixelFormat::BGRA8;
         case Tegra::RenderTargetFormat::RGB10_A2_UNORM:
             return PixelFormat::A2B10G10R10;
         case Tegra::RenderTargetFormat::RGBA16_FLOAT:
@@ -248,6 +253,10 @@ struct SurfaceParams {
             return Tegra::Texture::TextureFormat::BC7U;
         case PixelFormat::ASTC_2D_4X4:
             return Tegra::Texture::TextureFormat::ASTC_2D_4X4;
+        case PixelFormat::BGRA8:
+            // TODO(bunnei): This is fine for unswizzling (since we just need the right component
+            // sizes), but could be a bug if we used this function in different ways.
+            return Tegra::Texture::TextureFormat::A8R8G8B8;
         default:
             LOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
             UNREACHABLE();
@@ -286,6 +295,7 @@ struct SurfaceParams {
         switch (format) {
         case Tegra::RenderTargetFormat::RGBA8_UNORM:
         case Tegra::RenderTargetFormat::RGBA8_SRGB:
+        case Tegra::RenderTargetFormat::BGRA8_UNORM:
         case Tegra::RenderTargetFormat::RGB10_A2_UNORM:
             return ComponentType::UNorm;
         case Tegra::RenderTargetFormat::RGBA16_FLOAT:

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -39,14 +39,15 @@ struct SurfaceParams {
         G8R8 = 14,
         BGRA8 = 15,
         RGBA32F = 16,
+        RG32F = 17,
 
         MaxColorFormat,
 
         // DepthStencil formats
-        Z24S8 = 17,
-        S8Z24 = 18,
-        Z32F = 19,
-        Z16 = 20,
+        Z24S8 = 18,
+        S8Z24 = 19,
+        Z32F = 20,
+        Z16 = 21,
 
         MaxDepthStencilFormat,
 
@@ -101,6 +102,7 @@ struct SurfaceParams {
             1, // G8R8
             1, // BGRA8
             1, // RGBA32F
+            1, // RG32F
             1, // Z24S8
             1, // S8Z24
             1, // Z32F
@@ -133,6 +135,7 @@ struct SurfaceParams {
             16,  // G8R8
             32,  // BGRA8
             128, // RGBA32F
+            64,  // RG32F
             32,  // Z24S8
             32,  // S8Z24
             32,  // Z32F
@@ -176,6 +179,8 @@ struct SurfaceParams {
             return PixelFormat::RGBA16F;
         case Tegra::RenderTargetFormat::RGBA32_FLOAT:
             return PixelFormat::RGBA32F;
+        case Tegra::RenderTargetFormat::RG32_FLOAT:
+            return PixelFormat::RG32F;
         case Tegra::RenderTargetFormat::R11G11B10_FLOAT:
             return PixelFormat::R11FG11FB10F;
         case Tegra::RenderTargetFormat::RGBA32_UINT:
@@ -216,6 +221,8 @@ struct SurfaceParams {
             LOG_CRITICAL(HW_GPU, "Unimplemented component_type={}",
                          static_cast<u32>(component_type));
             UNREACHABLE();
+        case Tegra::Texture::TextureFormat::R32_G32:
+            return PixelFormat::RG32F;
         case Tegra::Texture::TextureFormat::DXT1:
             return PixelFormat::DXT1;
         case Tegra::Texture::TextureFormat::DXT23:
@@ -274,6 +281,8 @@ struct SurfaceParams {
             return Tegra::Texture::TextureFormat::A8R8G8B8;
         case PixelFormat::RGBA32F:
             return Tegra::Texture::TextureFormat::R32_G32_B32_A32;
+        case PixelFormat::RG32F:
+            return Tegra::Texture::TextureFormat::R32_G32;
         default:
             LOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
             UNREACHABLE();
@@ -320,6 +329,7 @@ struct SurfaceParams {
         case Tegra::RenderTargetFormat::RGBA16_FLOAT:
         case Tegra::RenderTargetFormat::R11G11B10_FLOAT:
         case Tegra::RenderTargetFormat::RGBA32_FLOAT:
+        case Tegra::RenderTargetFormat::RG32_FLOAT:
             return ComponentType::Float;
         case Tegra::RenderTargetFormat::RGBA32_UINT:
             return ComponentType::UInt;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -249,6 +249,7 @@ struct SurfaceParams {
         case PixelFormat::ASTC_2D_4X4:
             return Tegra::Texture::TextureFormat::ASTC_2D_4X4;
         default:
+            LOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
             UNREACHABLE();
         }
     }
@@ -264,6 +265,7 @@ struct SurfaceParams {
         case PixelFormat::Z16:
             return Tegra::DepthFormat::Z16_UNORM;
         default:
+            LOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
             UNREACHABLE();
         }
     }

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -72,6 +72,8 @@ u32 BytesPerPixel(TextureFormat format) {
         return 8;
     case TextureFormat::R32_G32_B32_A32:
         return 16;
+    case TextureFormat::R32_G32:
+        return 8;
     default:
         UNIMPLEMENTED_MSG("Format not implemented");
         break;
@@ -118,6 +120,7 @@ std::vector<u8> UnswizzleTexture(VAddr address, TextureFormat format, u32 width,
     case TextureFormat::G8R8:
     case TextureFormat::R16_G16_B16_A16:
     case TextureFormat::R32_G32_B32_A32:
+    case TextureFormat::R32_G32:
     case TextureFormat::BF10GF11RF11:
     case TextureFormat::ASTC_2D_4X4:
         CopySwizzledData(width, height, bytes_per_pixel, bytes_per_pixel, data,
@@ -174,6 +177,7 @@ std::vector<u8> DecodeTexture(const std::vector<u8>& texture_data, TextureFormat
     case TextureFormat::G8R8:
     case TextureFormat::BF10GF11RF11:
     case TextureFormat::R32_G32_B32_A32:
+    case TextureFormat::R32_G32:
         // TODO(Subv): For the time being just forward the same data without any decoding.
         rgba_data = texture_data;
         break;


### PR DESCRIPTION
Sorry for making these a single PR - because I'm adding three (and each commit depends on the last), it would have been kind of a pain to separate this into three PRs and rebase each after each was merged.