### PR TITLE
gl_shader_decompiler: Correct return value of WriteTexsInstruction()

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -750,8 +750,8 @@ private:
         }
     }
 
-    std::string WriteTexsInstruction(const Instruction& instr, const std::string& coord,
-                                     const std::string& texture) {
+    void WriteTexsInstruction(const Instruction& instr, const std::string& coord,
+                              const std::string& texture) {
         // Add an extra scope and declare the texture coords inside to prevent
         // overwriting them in case they are used as outputs of the texs instruction.
         shader.AddLine('{');


### PR DESCRIPTION
This should be returning void, not a std::string