### PR TITLE
mutex: Pass SharedPtr to GetHighestPriorityMutexWaitingThread() by reference

### DIFF
--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -19,7 +19,7 @@ namespace Kernel {
 /// Returns the number of threads that are waiting for a mutex, and the highest priority one among
 /// those.
 static std::pair<SharedPtr<Thread>, u32> GetHighestPriorityMutexWaitingThread(
-    SharedPtr<Thread> current_thread, VAddr mutex_addr) {
+    const SharedPtr<Thread>& current_thread, VAddr mutex_addr) {
 
     SharedPtr<Thread> highest_priority_thread;
     u32 num_waiters = 0;


### PR DESCRIPTION
The pointed to thread's members are simply observed in this case, so we don't need to copy it here.