### PR TITLE
apm/interface: Remove redundant declaration of InstallInterfaces()

### DIFF
--- a/src/core/hle/service/apm/interface.h
+++ b/src/core/hle/service/apm/interface.h
@@ -19,7 +19,4 @@ private:
     std::shared_ptr<Module> apm;
 };
 
-/// Registers all AM services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
-
 } // namespace Service::APM


### PR DESCRIPTION
This is already declared in apm/apm.h