### PR TITLE
core: Make converting constructors explicit where applicable

### DIFF
--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -35,7 +35,7 @@ static constexpr u128 DEFAULT_USER_ID{1ull, 0ull};
 
 class IProfile final : public ServiceFramework<IProfile> {
 public:
-    IProfile(u128 user_id) : ServiceFramework("IProfile"), user_id(user_id) {
+    explicit IProfile(u128 user_id) : ServiceFramework("IProfile"), user_id(user_id) {
         static const FunctionInfo functions[] = {
             {0, nullptr, "Get"},
             {1, &IProfile::GetBase, "GetBase"},

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -146,7 +146,7 @@ protected:
      * @param max_sessions Maximum number of sessions that can be
      * connected to this service at the same time.
      */
-    ServiceFramework(const char* service_name, u32 max_sessions = DefaultMaxSessions)
+    explicit ServiceFramework(const char* service_name, u32 max_sessions = DefaultMaxSessions)
         : ServiceFrameworkBase(service_name, max_sessions, Invoker) {}
 
     /// Registers handlers in the service.

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -190,7 +190,7 @@ private:
     u32 entryPoint;
 
 public:
-    ElfReader(void* ptr);
+    explicit ElfReader(void* ptr);
 
     u32 Read32(int off) const {
         return base32[off >> 2];

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -79,7 +79,7 @@ enum class ResultStatus {
 /// Interface for loading an application
 class AppLoader : NonCopyable {
 public:
-    AppLoader(FileSys::VirtualFile file) : file(std::move(file)) {}
+    explicit AppLoader(FileSys::VirtualFile file) : file(std::move(file)) {}
     virtual ~AppLoader() {}
 
     /**

--- a/src/core/tracer/recorder.h
+++ b/src/core/tracer/recorder.h
@@ -32,7 +32,7 @@ public:
      * Recorder constructor
      * @param initial_state Initial recorder state
      */
-    Recorder(const InitialState& initial_state);
+    explicit Recorder(const InitialState& initial_state);
 
     /// Finish recording of this Citrace and save it using the given filename.
     void Finish(const std::string& filename);


### PR DESCRIPTION
Avoids unwanted implicit conversions. Thankfully, given the large amount of cleanup in past PRs, only this tiny amount is left over to cover.