### PR TITLE
wait_tree: Silence warning about all code paths not returning a value

### DIFF
--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -5,6 +5,7 @@
 #include "yuzu/debugger/wait_tree.h"
 #include "yuzu/util/util.h"
 
+#include "common/assert.h"
 #include "core/core.h"
 #include "core/hle/kernel/event.h"
 #include "core/hle/kernel/handle_table.h"
@@ -169,6 +170,8 @@ QString WaitTreeWaitObject::GetResetTypeQString(Kernel::ResetType reset_type) {
     case Kernel::ResetType::Pulse:
         return tr("pulse");
     }
+    UNREACHABLE();
+    return {};
 }
 
 WaitTreeObjectList::WaitTreeObjectList(


### PR DESCRIPTION
If code execution hits this spot, something has gone very wrong, so mark the path as unreachable. This silences a warning on MSVC.