### PR TITLE
svc: Log parameters in SetMemoryAttribute()

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -40,7 +40,9 @@ static ResultCode SetHeapSize(VAddr* heap_addr, u64 heap_size) {
 }
 
 static ResultCode SetMemoryAttribute(VAddr addr, u64 size, u32 state0, u32 state1) {
-    LOG_WARNING(Kernel_SVC, "(STUBBED) called, addr=0x{:X}", addr);
+    LOG_WARNING(Kernel_SVC,
+                "(STUBBED) called, addr=0x{:X}, size=0x{:X}, state0=0x{:X}, state1=0x{:X}", addr,
+                size, state0, state1);
     return RESULT_SUCCESS;
 }
 


### PR DESCRIPTION
Provides slightly more context than only logging out the address value.