### PR TITLE
service: Add ldr services

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -154,6 +154,8 @@ add_library(core STATIC
     hle/service/friend/interface.h
     hle/service/hid/hid.cpp
     hle/service/hid/hid.h
+    hle/service/ldr/ldr.cpp
+    hle/service/ldr/ldr.h
     hle/service/lm/lm.cpp
     hle/service/lm/lm.h
     hle/service/mm/mm_u.cpp

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -1,0 +1,81 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+
+#include "core/hle/service/ldr/ldr.h"
+#include "core/hle/service/service.h"
+
+namespace Service::LDR {
+
+class DebugMonitor final : public ServiceFramework<DebugMonitor> {
+public:
+    explicit DebugMonitor() : ServiceFramework{"ldr:dmnt"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "AddProcessToDebugLaunchQueue"},
+            {1, nullptr, "ClearDebugLaunchQueue"},
+            {2, nullptr, "GetNsoInfos"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+class ProcessManager final : public ServiceFramework<ProcessManager> {
+public:
+    explicit ProcessManager() : ServiceFramework{"ldr:pm"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "CreateProcess"},
+            {1, nullptr, "GetProgramInfo"},
+            {2, nullptr, "RegisterTitle"},
+            {3, nullptr, "UnregisterTitle"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+class Shell final : public ServiceFramework<Shell> {
+public:
+    explicit Shell() : ServiceFramework{"ldr:shel"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "AddProcessToLaunchQueue"},
+            {1, nullptr, "ClearLaunchQueue"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+class RelocatableObject final : public ServiceFramework<RelocatableObject> {
+public:
+    explicit RelocatableObject() : ServiceFramework{"ldr:ro"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "LoadNro"},
+            {1, nullptr, "UnloadNro"},
+            {2, nullptr, "LoadNrr"},
+            {3, nullptr, "UnloadNrr"},
+            {4, nullptr, "Initialize"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+void InstallInterfaces(SM::ServiceManager& sm) {
+    std::make_shared<DebugMonitor>()->InstallAsService(sm);
+    std::make_shared<ProcessManager>()->InstallAsService(sm);
+    std::make_shared<Shell>()->InstallAsService(sm);
+    std::make_shared<RelocatableObject>()->InstallAsService(sm);
+}
+
+} // namespace Service::LDR

--- a/src/core/hle/service/ldr/ldr.h
+++ b/src/core/hle/service/ldr/ldr.h
@@ -1,0 +1,16 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace Service::SM {
+class ServiceManager;
+}
+
+namespace Service::LDR {
+
+/// Registers all LDR services with the specified service manager.
+void InstallInterfaces(SM::ServiceManager& sm);
+
+} // namespace Service::LDR

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -26,6 +26,7 @@
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/hle/service/friend/friend.h"
 #include "core/hle/service/hid/hid.h"
+#include "core/hle/service/ldr/ldr.h"
 #include "core/hle/service/lm/lm.h"
 #include "core/hle/service/mm/mm_u.h"
 #include "core/hle/service/nfp/nfp.h"
@@ -194,6 +195,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm) {
     FileSystem::InstallInterfaces(*sm);
     Friend::InstallInterfaces(*sm);
     HID::InstallInterfaces(*sm);
+    LDR::InstallInterfaces(*sm);
     LM::InstallInterfaces(*sm);
     MM::InstallInterfaces(*sm);
     NFP::InstallInterfaces(*sm);


### PR DESCRIPTION
Adds the skeleton for the ldr-related services based off the information provided on Switch Brew.