### PR TITLE
service/sockets: Add missing socket services

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -225,6 +225,8 @@ add_library(core STATIC
     hle/service/sm/sm.h
     hle/service/sockets/bsd.cpp
     hle/service/sockets/bsd.h
+    hle/service/sockets/ethc.cpp
+    hle/service/sockets/ethc.h
     hle/service/sockets/nsd.cpp
     hle/service/sockets/nsd.h
     hle/service/sockets/sfdnsres.cpp

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -109,4 +109,26 @@ BSD::BSD(const char* name) : ServiceFramework(name) {
     RegisterHandlers(functions);
 }
 
+BSDCFG::BSDCFG() : ServiceFramework{"bsdcfg"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "SetIfUp"},
+        {1, nullptr, "SetIfUpWithEvent"},
+        {2, nullptr, "CancelIf"},
+        {3, nullptr, "SetIfDown"},
+        {4, nullptr, "GetIfState"},
+        {5, nullptr, "DhcpRenew"},
+        {6, nullptr, "AddStaticArpEntry"},
+        {7, nullptr, "RemoveArpEntry"},
+        {8, nullptr, "LookupArpEntry"},
+        {9, nullptr, "LookupArpEntry2"},
+        {10, nullptr, "ClearArpEntries"},
+        {11, nullptr, "ClearArpEntries2"},
+        {12, nullptr, "PrintArpEntries"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
 } // namespace Service::Sockets

--- a/src/core/hle/service/sockets/bsd.h
+++ b/src/core/hle/service/sockets/bsd.h
@@ -26,4 +26,9 @@ private:
     u32 next_fd = 1;
 };
 
+class BSDCFG final : public ServiceFramework<BSDCFG> {
+public:
+    explicit BSDCFG();
+};
+
 } // namespace Service::Sockets

--- a/src/core/hle/service/sockets/ethc.cpp
+++ b/src/core/hle/service/sockets/ethc.cpp
@@ -1,0 +1,38 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/sockets/ethc.h"
+
+namespace Service::Sockets {
+
+ETHC_C::ETHC_C() : ServiceFramework{"ethc:c"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "Initialize"},
+        {1, nullptr, "Cancel"},
+        {2, nullptr, "GetResult"},
+        {3, nullptr, "GetMediaList"},
+        {4, nullptr, "SetMediaType"},
+        {5, nullptr, "GetMediaType"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+ETHC_I::ETHC_I() : ServiceFramework{"ethc:i"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "GetReadableHandle"},
+        {1, nullptr, "Cancel"},
+        {2, nullptr, "GetResult"},
+        {3, nullptr, "GetInterfaceList"},
+        {4, nullptr, "GetInterfaceCount"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+} // namespace Service::Sockets

--- a/src/core/hle/service/sockets/ethc.h
+++ b/src/core/hle/service/sockets/ethc.h
@@ -1,0 +1,21 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service::Sockets {
+
+class ETHC_C final : public ServiceFramework<ETHC_C> {
+public:
+    explicit ETHC_C();
+};
+
+class ETHC_I final : public ServiceFramework<ETHC_I> {
+public:
+    explicit ETHC_I();
+};
+
+} // namespace Service::Sockets

--- a/src/core/hle/service/sockets/sockets.cpp
+++ b/src/core/hle/service/sockets/sockets.cpp
@@ -12,6 +12,8 @@ namespace Service::Sockets {
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<BSD>("bsd:s")->InstallAsService(service_manager);
     std::make_shared<BSD>("bsd:u")->InstallAsService(service_manager);
+    std::make_shared<BSDCFG>()->InstallAsService(service_manager);
+
     std::make_shared<NSD>("nsd:a")->InstallAsService(service_manager);
     std::make_shared<NSD>("nsd:u")->InstallAsService(service_manager);
     std::make_shared<SFDNSRES>()->InstallAsService(service_manager);

--- a/src/core/hle/service/sockets/sockets.cpp
+++ b/src/core/hle/service/sockets/sockets.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "core/hle/service/sockets/bsd.h"
+#include "core/hle/service/sockets/ethc.h"
 #include "core/hle/service/sockets/nsd.h"
 #include "core/hle/service/sockets/sfdnsres.h"
 #include "core/hle/service/sockets/sockets.h"
@@ -14,8 +15,12 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<BSD>("bsd:u")->InstallAsService(service_manager);
     std::make_shared<BSDCFG>()->InstallAsService(service_manager);
 
+    std::make_shared<ETHC_C>()->InstallAsService(service_manager);
+    std::make_shared<ETHC_I>()->InstallAsService(service_manager);
+
     std::make_shared<NSD>("nsd:a")->InstallAsService(service_manager);
     std::make_shared<NSD>("nsd:u")->InstallAsService(service_manager);
+
     std::make_shared<SFDNSRES>()->InstallAsService(service_manager);
 }
 


### PR DESCRIPTION
Adds the skeleton for bsdcfg, ethc:c and ethc:i, using the information provided by Switch Brew