### PR TITLE
service: Add the grc:c service

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -156,6 +156,8 @@ add_library(core STATIC
     hle/service/friend/friend.h
     hle/service/friend/interface.cpp
     hle/service/friend/interface.h
+    hle/service/grc/grc.cpp
+    hle/service/grc/grc.h
     hle/service/hid/hid.cpp
     hle/service/hid/hid.h
     hle/service/ldr/ldr.cpp

--- a/src/core/hle/service/grc/grc.cpp
+++ b/src/core/hle/service/grc/grc.cpp
@@ -1,0 +1,31 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+
+#include "core/hle/service/grc/grc.h"
+#include "core/hle/service/service.h"
+#include "core/hle/service/sm/sm.h"
+
+namespace Service::GRC {
+
+class GRC final : public ServiceFramework<GRC> {
+public:
+    explicit GRC() : ServiceFramework{"grc:c"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {1, nullptr, "OpenContinuousRecorder"},
+            {2, nullptr, "OpenGameMovieTrimmer"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+void InstallInterfaces(SM::ServiceManager& sm) {
+    std::make_shared<GRC>()->InstallAsService(sm);
+}
+
+} // namespace Service::GRC

--- a/src/core/hle/service/grc/grc.h
+++ b/src/core/hle/service/grc/grc.h
@@ -1,0 +1,15 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace Service::SM {
+class ServiceManager;
+}
+
+namespace Service::GRC {
+
+void InstallInterfaces(SM::ServiceManager& sm);
+
+} // namespace Service::GRC

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -27,6 +27,7 @@
 #include "core/hle/service/fatal/fatal.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/hle/service/friend/friend.h"
+#include "core/hle/service/grc/grc.h"
 #include "core/hle/service/hid/hid.h"
 #include "core/hle/service/ldr/ldr.h"
 #include "core/hle/service/lm/lm.h"
@@ -198,6 +199,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm) {
     Fatal::InstallInterfaces(*sm);
     FileSystem::InstallInterfaces(*sm);
     Friend::InstallInterfaces(*sm);
+    GRC::InstallInterfaces(*sm);
     HID::InstallInterfaces(*sm);
     LDR::InstallInterfaces(*sm);
     LM::InstallInterfaces(*sm);


### PR DESCRIPTION
Adds the basic skeleton for the grc:c service based off the information provided by Switch Brew.