### PR TITLE
kernel/timer: Make data members private where applicable

### DIFF
--- a/src/core/hle/kernel/timer.h
+++ b/src/core/hle/kernel/timer.h
@@ -32,13 +32,17 @@ public:
         return HANDLE_TYPE;
     }
 
-    ResetType reset_type; ///< The ResetType of this timer
+    ResetType GetResetType() const {
+        return reset_type;
+    }
 
-    bool signaled;    ///< Whether the timer has been signaled or not
-    std::string name; ///< Name of timer (optional)
+    u64 GetInitialDelay() const {
+        return initial_delay;
+    }
 
-    u64 initial_delay;  ///< The delay until the timer fires for the first time
-    u64 interval_delay; ///< The delay until the timer fires after the first time
+    u64 GetIntervalDelay() const {
+        return interval_delay;
+    }
 
     bool ShouldWait(Thread* thread) const override;
     void Acquire(Thread* thread) override;
@@ -66,6 +70,14 @@ public:
 private:
     Timer();
     ~Timer() override;
+
+    ResetType reset_type; ///< The ResetType of this timer
+
+    u64 initial_delay;  ///< The delay until the timer fires for the first time
+    u64 interval_delay; ///< The delay until the timer fires after the first time
+
+    bool signaled;    ///< Whether the timer has been signaled or not
+    std::string name; ///< Name of timer (optional)
 
     /// Handle used as userdata to reference this object when inserting into the CoreTiming queue.
     Handle callback_handle;

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -328,11 +328,11 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeTimer::GetChildren() const {
     const auto& timer = static_cast<const Kernel::Timer&>(object);
 
     list.push_back(std::make_unique<WaitTreeText>(
-        tr("reset type = %1").arg(GetResetTypeQString(timer.reset_type))));
+        tr("reset type = %1").arg(GetResetTypeQString(timer.GetResetType()))));
     list.push_back(
-        std::make_unique<WaitTreeText>(tr("initial delay = %1").arg(timer.initial_delay)));
+        std::make_unique<WaitTreeText>(tr("initial delay = %1").arg(timer.GetInitialDelay())));
     list.push_back(
-        std::make_unique<WaitTreeText>(tr("interval delay = %1").arg(timer.interval_delay)));
+        std::make_unique<WaitTreeText>(tr("interval delay = %1").arg(timer.GetIntervalDelay())));
     return list;
 }
 


### PR DESCRIPTION
Instead, we can just expose functions that return the queryable state instead of letting anything modify it.