### PR TITLE
service: Add ncm services

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -177,6 +177,7 @@ void FileBackend::Write(const Entry& entry) {
     SUB(Service, LDN)                                                                              \
     SUB(Service, LM)                                                                               \
     SUB(Service, MM)                                                                               \
+    SUB(Service, NCM)                                                                              \
     SUB(Service, NFC)                                                                              \
     SUB(Service, NFP)                                                                              \
     SUB(Service, NIFM)                                                                             \

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -64,6 +64,7 @@ enum class Class : ClassType {
     Service_LDN,       ///< The LDN (Local domain network) service
     Service_LM,        ///< The LM (Logger) service
     Service_MM,        ///< The MM (Multimedia) service
+    Service_NCM,       ///< The NCM service
     Service_NFC,       ///< The NFC (Near-field communication) service
     Service_NFP,       ///< The NFP service
     Service_NIFM,      ///< The NIFM (Network interface) service

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -176,6 +176,8 @@ add_library(core STATIC
     hle/service/lm/lm.h
     hle/service/mm/mm_u.cpp
     hle/service/mm/mm_u.h
+    hle/service/ncm/ncm.cpp
+    hle/service/ncm/ncm.h
     hle/service/nfc/nfc.cpp
     hle/service/nfc/nfc.h
     hle/service/nfp/nfp.cpp

--- a/src/core/hle/service/ncm/ncm.cpp
+++ b/src/core/hle/service/ncm/ncm.cpp
@@ -1,0 +1,59 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+
+#include "core/hle/service/ncm/ncm.h"
+#include "core/hle/service/service.h"
+#include "core/hle/service/sm/sm.h"
+
+namespace Service::NCM {
+
+class LocationResolver final : public ServiceFramework<LocationResolver> {
+public:
+    explicit LocationResolver() : ServiceFramework{"lr"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "OpenLocationResolver"},
+            {1, nullptr, "OpenRegisteredLocationResolver"},
+            {2, nullptr, "RefreshLocationResolver"},
+            {3, nullptr, "OpenAddOnContentLocationResolver"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+class NCM final : public ServiceFramework<NCM> {
+public:
+    explicit NCM() : ServiceFramework{"ncm"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "CreateContentStorage"},
+            {1, nullptr, "CreateContentMetaDatabase"},
+            {2, nullptr, "VerifyContentStorage"},
+            {3, nullptr, "VerifyContentMetaDatabase"},
+            {4, nullptr, "OpenContentStorage"},
+            {5, nullptr, "OpenContentMetaDatabase"},
+            {6, nullptr, "CloseContentStorageForcibly"},
+            {7, nullptr, "CloseContentMetaDatabaseForcibly"},
+            {8, nullptr, "CleanupContentMetaDatabase"},
+            {9, nullptr, "OpenContentStorage2"},
+            {10, nullptr, "CloseContentStorage"},
+            {11, nullptr, "OpenContentMetaDatabase2"},
+            {12, nullptr, "CloseContentMetaDatabase"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+void InstallInterfaces(SM::ServiceManager& sm) {
+    std::make_shared<LocationResolver>()->InstallAsService(sm);
+    std::make_shared<NCM>()->InstallAsService(sm);
+}
+
+} // namespace Service::NCM

--- a/src/core/hle/service/ncm/ncm.h
+++ b/src/core/hle/service/ncm/ncm.h
@@ -1,0 +1,15 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace Service::SM {
+class ServiceManager;
+}
+
+namespace Service::NCM {
+
+void InstallInterfaces(SM::ServiceManager& sm);
+
+} // namespace Service::NCM

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -35,6 +35,7 @@
 #include "core/hle/service/ldr/ldr.h"
 #include "core/hle/service/lm/lm.h"
 #include "core/hle/service/mm/mm_u.h"
+#include "core/hle/service/ncm/ncm.h"
 #include "core/hle/service/nfc/nfc.h"
 #include "core/hle/service/nfp/nfp.h"
 #include "core/hle/service/nifm/nifm.h"
@@ -212,6 +213,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm) {
     LDR::InstallInterfaces(*sm);
     LM::InstallInterfaces(*sm);
     MM::InstallInterfaces(*sm);
+    NCM::InstallInterfaces(*sm);
     NFC::InstallInterfaces(*sm);
     NFP::InstallInterfaces(*sm);
     NIFM::InstallInterfaces(*sm);


### PR DESCRIPTION
Adds the basic skeleton for the ncm services based off information on Switch Brew.