### PR TITLE
XCI and Encrypted NCA Support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,6 +25,9 @@
 [submodule "unicorn"]
     path = externals/unicorn
     url = https://github.com/yuzu-emu/unicorn
+[submodule "externals/mbedtls"]
+	path = externals/mbedtls
+	url = https://github.com/DarkLordZach/mbedtls
 [submodule "opus"]
 	path = externals/opus
 	url = https://github.com/ogniK5377/opus.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -25,9 +25,9 @@
 [submodule "unicorn"]
     path = externals/unicorn
     url = https://github.com/yuzu-emu/unicorn
-[submodule "externals/mbedtls"]
-	path = externals/mbedtls
-	url = https://github.com/DarkLordZach/mbedtls
+[submodule "mbedtls"]
+    path = externals/mbedtls
+    url = https://github.com/DarkLordZach/mbedtls
 [submodule "opus"]
-	path = externals/opus
-	url = https://github.com/ogniK5377/opus.git
+    path = externals/opus
+    url = https://github.com/ogniK5377/opus.git

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -35,6 +35,10 @@ set(LZ4_BUNDLED_MODE ON)
 add_subdirectory(lz4/contrib/cmake_unofficial)
 target_include_directories(lz4_static INTERFACE ./lz4/lib)
 
+# mbedtls
+add_subdirectory(mbedtls)
+target_include_directories(mbedtls PUBLIC ./mbedtls/include)
+
 # MicroProfile
 add_library(microprofile INTERFACE)
 target_include_directories(microprofile INTERFACE ./microprofile)

--- a/src/common/common_paths.h
+++ b/src/common/common_paths.h
@@ -32,6 +32,7 @@
 #define SDMC_DIR "sdmc"
 #define NAND_DIR "nand"
 #define SYSDATA_DIR "sysdata"
+#define KEYS_DIR "keys"
 #define LOG_DIR "log"
 
 // Filenames

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -738,10 +738,11 @@ const std::string& GetUserPath(UserPath path, const std::string& new_path) {
 
 std::string GetHactoolConfigurationPath() {
 #ifdef _WIN32
-    char path[MAX_PATH];
-    if (SHGetFolderPathA(nullptr, CSIDL_PROFILE, nullptr, 0, path) != S_OK)
+    PWSTR pw_local_path = nullptr;
+    if (SHGetKnownFolderPath(FOLDERID_Profile, 0, nullptr, &pw_local_path) != S_OK)
         return "";
-    std::string local_path = Common::StringFromFixedZeroTerminatedBuffer(path, MAX_PATH);
+    std::string local_path = Common::UTF16ToUTF8(pw_local_path);
+    CoTaskMemFree(pw_local_path);
     return local_path + "\\.switch";
 #else
     return GetHomeDirectory() + "/.switch";

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -706,6 +706,7 @@ const std::string& GetUserPath(UserPath path, const std::string& new_path) {
         paths.emplace(UserPath::SDMCDir, user_path + SDMC_DIR DIR_SEP);
         paths.emplace(UserPath::NANDDir, user_path + NAND_DIR DIR_SEP);
         paths.emplace(UserPath::SysDataDir, user_path + SYSDATA_DIR DIR_SEP);
+        paths.emplace(UserPath::KeysDir, user_path + KEYS_DIR DIR_SEP);
         // TODO: Put the logs in a better location for each OS
         paths.emplace(UserPath::LogDir, user_path + LOG_DIR DIR_SEP);
     }

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -739,7 +739,7 @@ const std::string& GetUserPath(UserPath path, const std::string& new_path) {
 std::string GetHactoolConfigurationPath() {
 #ifdef _WIN32
     char path[MAX_PATH];
-    if (SHGetFolderPathA(NULL, CSIDL_PROFILE, NULL, 0, path) != S_OK)
+    if (SHGetFolderPathA(nullptr, CSIDL_PROFILE, nullptr, 0, path) != S_OK)
         return "";
     std::string local_path = Common::StringFromFixedZeroTerminatedBuffer(path, MAX_PATH);
     return local_path + "\\.switch";

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -736,6 +736,18 @@ const std::string& GetUserPath(UserPath path, const std::string& new_path) {
     return paths[path];
 }
 
+std::string GetHactoolConfigurationPath() {
+#ifdef _WIN32
+    char path[MAX_PATH];
+    if (SHGetFolderPathA(NULL, CSIDL_PROFILE, NULL, 0, path) != S_OK)
+        return "";
+    std::string local_path = Common::StringFromFixedZeroTerminatedBuffer(path, MAX_PATH);
+    return local_path + "\\.switch";
+#else
+    return GetHomeDirectory() + "/.switch";
+#endif
+}
+
 size_t WriteStringToFile(bool text_file, const std::string& str, const char* filename) {
     return FileUtil::IOFile(filename, text_file ? "w" : "wb").WriteBytes(str.data(), str.size());
 }

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -23,6 +23,7 @@ namespace FileUtil {
 enum class UserPath {
     CacheDir,
     ConfigDir,
+    KeysDir,
     LogDir,
     NANDDir,
     RootDir,

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -125,6 +125,8 @@ bool SetCurrentDir(const std::string& directory);
 // directory. To be used in "multi-user" mode (that is, installed).
 const std::string& GetUserPath(UserPath path, const std::string& new_path = "");
 
+std::string GetHactoolConfigurationPath();
+
 // Returns the path to where the sys file are
 std::string GetSysDirectory();
 

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -212,6 +212,7 @@ void FileBackend::Write(const Entry& entry) {
     CLS(Input)                                                                                     \
     CLS(Network)                                                                                   \
     CLS(Loader)                                                                                    \
+    CLS(Crypto)                                                                                    \
     CLS(WebService)
 
 // GetClassName is a macro defined by Windows.h, grrr...

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -97,6 +97,7 @@ enum class Class : ClassType {
     Audio_DSP,         ///< The HLE implementation of the DSP
     Audio_Sink,        ///< Emulator audio output backend
     Loader,            ///< ROM loader
+    Crypto,            ///< Cryptographic engine/functions
     Input,             ///< Input emulation
     Network,           ///< Network emulation
     WebService,        ///< Interface to yuzu Web Services

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(core STATIC
     core_timing.h
     core_timing_util.cpp
     core_timing_util.h
+    crypto/aes_util.cpp
     crypto/aes_util.h
     crypto/encryption_layer.cpp
     crypto/encryption_layer.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -12,6 +12,15 @@ add_library(core STATIC
     core_timing.h
     core_timing_util.cpp
     core_timing_util.h
+    crypto/aes_util.h
+    crypto/encryption_layer.cpp
+    crypto/encryption_layer.h
+    crypto/key_manager.cpp
+    crypto/key_manager.h
+    crypto/ctr_encryption_layer.cpp
+    crypto/ctr_encryption_layer.h
+    file_sys/card_image.cpp
+    file_sys/card_image.h
     file_sys/content_archive.cpp
     file_sys/content_archive.h
     file_sys/control_metadata.cpp
@@ -317,6 +326,8 @@ add_library(core STATIC
     loader/nro.h
     loader/nso.cpp
     loader/nso.h
+    loader/xci.cpp
+    loader/xci.h
     memory.cpp
     memory.h
     memory_hook.cpp

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -348,7 +348,7 @@ add_library(core STATIC
 create_target_directory_groups(core)
 
 target_link_libraries(core PUBLIC common PRIVATE audio_core video_core)
-target_link_libraries(core PUBLIC Boost::boost PRIVATE fmt lz4_static opus unicorn)
+target_link_libraries(core PUBLIC Boost::boost PRIVATE fmt lz4_static mbedtls opus unicorn)
 
 if (ARCHITECTURE_x86_64)
     target_sources(core PRIVATE

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -101,8 +101,10 @@ System::ResultStatus System::Load(EmuWindow* emu_window, const std::string& file
                      static_cast<int>(system_mode.second));
 
         switch (system_mode.second) {
-        case Loader::ResultStatus::ErrorEncrypted:
-            return ResultStatus::ErrorLoader_ErrorEncrypted;
+        case Loader::ResultStatus::ErrorMissingKeys:
+            return ResultStatus::ErrorLoader_ErrorMissingKeys;
+        case Loader::ResultStatus::ErrorDecrypting:
+            return ResultStatus::ErrorLoader_ErrorDecrypting;
         case Loader::ResultStatus::ErrorInvalidFormat:
             return ResultStatus::ErrorLoader_ErrorInvalidFormat;
         case Loader::ResultStatus::ErrorUnsupportedArch:
@@ -126,8 +128,10 @@ System::ResultStatus System::Load(EmuWindow* emu_window, const std::string& file
         System::Shutdown();
 
         switch (load_result) {
-        case Loader::ResultStatus::ErrorEncrypted:
-            return ResultStatus::ErrorLoader_ErrorEncrypted;
+        case Loader::ResultStatus::ErrorMissingKeys:
+            return ResultStatus::ErrorLoader_ErrorMissingKeys;
+        case Loader::ResultStatus::ErrorDecrypting:
+            return ResultStatus::ErrorLoader_ErrorDecrypting;
         case Loader::ResultStatus::ErrorInvalidFormat:
             return ResultStatus::ErrorLoader_ErrorInvalidFormat;
         case Loader::ResultStatus::ErrorUnsupportedArch:

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -43,12 +43,14 @@ public:
 
     /// Enumeration representing the return values of the System Initialize and Load process.
     enum class ResultStatus : u32 {
-        Success,                    ///< Succeeded
-        ErrorNotInitialized,        ///< Error trying to use core prior to initialization
-        ErrorGetLoader,             ///< Error finding the correct application loader
-        ErrorSystemMode,            ///< Error determining the system mode
-        ErrorLoader,                ///< Error loading the specified application
-        ErrorLoader_ErrorEncrypted, ///< Error loading the specified application due to encryption
+        Success,                      ///< Succeeded
+        ErrorNotInitialized,          ///< Error trying to use core prior to initialization
+        ErrorGetLoader,               ///< Error finding the correct application loader
+        ErrorSystemMode,              ///< Error determining the system mode
+        ErrorLoader,                  ///< Error loading the specified application
+        ErrorLoader_ErrorMissingKeys, ///< Error because the key/keys needed to run could not be
+                                      ///< found.
+        ErrorLoader_ErrorDecrypting,  ///< Error loading the specified application due to encryption
         ErrorLoader_ErrorInvalidFormat, ///< Error loading the specified application due to an
                                         /// invalid format
         ErrorSystemFiles,               ///< Error in finding system files

--- a/src/core/crypto/aes_util.cpp
+++ b/src/core/crypto/aes_util.cpp
@@ -1,0 +1,6 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+namespace Crypto {
+} // namespace Crypto

--- a/src/core/crypto/aes_util.cpp
+++ b/src/core/crypto/aes_util.cpp
@@ -2,5 +2,103 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-namespace Crypto {
-} // namespace Crypto
+#include "core/crypto/aes_util.h"
+#include "mbedtls/cipher.h"
+
+namespace Core::Crypto {
+static_assert(static_cast<size_t>(Mode::CTR) == static_cast<size_t>(MBEDTLS_CIPHER_AES_128_CTR), "CTR mode is incorrect.");
+static_assert(static_cast<size_t>(Mode::ECB) == static_cast<size_t>(MBEDTLS_CIPHER_AES_128_ECB), "ECB mode is incorrect.");
+static_assert(static_cast<size_t>(Mode::XTS) == static_cast<size_t>(MBEDTLS_CIPHER_AES_128_XTS), "XTS mode is incorrect.");
+
+template<typename Key, size_t KeySize>
+Crypto::AESCipher<Key, KeySize>::AESCipher(Key key, Mode mode) {
+    mbedtls_cipher_init(encryption_context.get());
+    mbedtls_cipher_init(decryption_context.get());
+
+    ASSERT_MSG((mbedtls_cipher_setup(
+            encryption_context.get(),
+            mbedtls_cipher_info_from_type(static_cast<mbedtls_cipher_type_t>(mode))) ||
+                mbedtls_cipher_setup(decryption_context.get(),
+                                     mbedtls_cipher_info_from_type(
+                                             static_cast<mbedtls_cipher_type_t>(mode)))) == 0,
+               "Failed to initialize mbedtls ciphers.");
+
+    ASSERT(
+            !mbedtls_cipher_setkey(encryption_context.get(), key.data(), KeySize * 8, MBEDTLS_ENCRYPT));
+    ASSERT(
+            !mbedtls_cipher_setkey(decryption_context.get(), key.data(), KeySize * 8, MBEDTLS_DECRYPT));
+    //"Failed to set key on mbedtls ciphers.");
+}
+
+template<typename Key, size_t KeySize>
+AESCipher<Key, KeySize>::~AESCipher() {
+    mbedtls_cipher_free(encryption_context.get());
+    mbedtls_cipher_free(decryption_context.get());
+}
+
+template<typename Key, size_t KeySize>
+void AESCipher<Key, KeySize>::SetIV(std::vector<u8> iv) {
+    ASSERT_MSG((mbedtls_cipher_set_iv(encryption_context.get(), iv.data(), iv.size()) ||
+                mbedtls_cipher_set_iv(decryption_context.get(), iv.data(), iv.size())) == 0,
+               "Failed to set IV on mbedtls ciphers.");
+}
+
+template<typename Key, size_t KeySize>
+void AESCipher<Key, KeySize>::Transcode(const u8* src, size_t size, u8* dest, Op op)  {
+    size_t written = 0;
+
+    const auto context = op == Op::Encrypt ? encryption_context.get() : decryption_context.get();
+
+    mbedtls_cipher_reset(context);
+
+    if (mbedtls_cipher_get_cipher_mode(context) == MBEDTLS_MODE_XTS) {
+        mbedtls_cipher_update(context, src, size,
+                              dest, &written);
+        if (written != size)
+            LOG_WARNING(Crypto, "Not all data was decrypted requested={:016X}, actual={:016X}.",
+                        size, written);
+    } else {
+        const auto block_size = mbedtls_cipher_get_block_size(context);
+
+        for (size_t offset = 0; offset < size; offset += block_size) {
+            auto length = std::min<size_t>(block_size, size - offset);
+            mbedtls_cipher_update(context, src + offset, length,
+                                  dest + offset, &written);
+            if (written != length)
+                LOG_WARNING(Crypto,
+                            "Not all data was decrypted requested={:016X}, actual={:016X}.",
+                            length, written);
+        }
+    }
+
+    mbedtls_cipher_finish(context, nullptr, nullptr);
+}
+
+template<typename Key, size_t KeySize>
+void AESCipher<Key, KeySize>::XTSTranscode(const u8* src, size_t size, u8* dest, size_t sector_id, size_t sector_size,
+                                           Op op) {
+    if (size % sector_size > 0) {
+        LOG_CRITICAL(Crypto, "Data size must be a multiple of sector size.");
+        return;
+    }
+
+    for (size_t i = 0; i < size; i += sector_size) {
+        SetIV(CalculateNintendoTweak(sector_id++));
+        Transcode<u8, u8>(src + i, sector_size,
+                          dest + i, op);
+    }
+}
+
+template<typename Key, size_t KeySize>
+std::vector<u8> AESCipher<Key, KeySize>::CalculateNintendoTweak(size_t sector_id) {
+    std::vector<u8> out(0x10);
+    for (size_t i = 0xF; i <= 0xF; --i) {
+        out[i] = sector_id & 0xFF;
+        sector_id >>= 8;
+    }
+    return out;
+}
+
+template class AESCipher<Key128>;
+template class AESCipher<Key256>;
+}

--- a/src/core/crypto/aes_util.h
+++ b/src/core/crypto/aes_util.h
@@ -6,113 +6,53 @@
 
 #include "common/assert.h"
 #include "core/file_sys/vfs.h"
-#include "mbedtls/cipher.h"
 
-namespace Crypto {
+namespace Core::Crypto {
 
 enum class Mode {
-    CTR = MBEDTLS_CIPHER_AES_128_CTR,
-    ECB = MBEDTLS_CIPHER_AES_128_ECB,
-    XTS = MBEDTLS_CIPHER_AES_128_XTS,
+    CTR = 11,
+    ECB = 2,
+    XTS = 70,
 };
 
 enum class Op {
-    ENCRYPT,
-    DECRYPT,
+    Encrypt,
+    Decrypt,
 };
 
+struct mbedtls_cipher_context_t;
+
 template <typename Key, size_t KeySize = sizeof(Key)>
-struct AESCipher {
+class AESCipher {
     static_assert(std::is_same_v<Key, std::array<u8, KeySize>>, "Key must be std::array of u8.");
     static_assert(KeySize == 0x10 || KeySize == 0x20, "KeySize must be 128 or 256.");
 
-    AESCipher(Key key, Mode mode) {
-        mbedtls_cipher_init(&encryption_context);
-        mbedtls_cipher_init(&decryption_context);
+public:
+    AESCipher(Key key, Mode mode);
 
-        ASSERT_MSG((mbedtls_cipher_setup(
-                        &encryption_context,
-                        mbedtls_cipher_info_from_type(static_cast<mbedtls_cipher_type_t>(mode))) ||
-                    mbedtls_cipher_setup(&decryption_context,
-                                         mbedtls_cipher_info_from_type(
-                                             static_cast<mbedtls_cipher_type_t>(mode)))) == 0,
-                   "Failed to initialize mbedtls ciphers.");
+    ~AESCipher();
 
-        ASSERT(
-            !mbedtls_cipher_setkey(&encryption_context, key.data(), KeySize * 8, MBEDTLS_ENCRYPT));
-        ASSERT(
-            !mbedtls_cipher_setkey(&decryption_context, key.data(), KeySize * 8, MBEDTLS_DECRYPT));
-        //"Failed to set key on mbedtls ciphers.");
-    }
-
-    ~AESCipher() {
-        mbedtls_cipher_free(&encryption_context);
-        mbedtls_cipher_free(&decryption_context);
-    }
-
-    void SetIV(std::vector<u8> iv) {
-        ASSERT_MSG((mbedtls_cipher_set_iv(&encryption_context, iv.data(), iv.size()) ||
-                    mbedtls_cipher_set_iv(&decryption_context, iv.data(), iv.size())) == 0,
-                   "Failed to set IV on mbedtls ciphers.");
-    }
+    void SetIV(std::vector<u8> iv);
 
     template <typename Source, typename Dest>
     void Transcode(const Source* src, size_t size, Dest* dest, Op op) {
-        size_t written = 0;
-
-        const auto context = op == Op::ENCRYPT ? &encryption_context : &decryption_context;
-
-        mbedtls_cipher_reset(context);
-
-        if (mbedtls_cipher_get_cipher_mode(context) == MBEDTLS_MODE_XTS) {
-            mbedtls_cipher_update(context, reinterpret_cast<const u8*>(src), size,
-                                  reinterpret_cast<u8*>(dest), &written);
-            if (written != size)
-                LOG_WARNING(Crypto, "Not all data was decrypted requested={:016X}, actual={:016X}.",
-                            size, written);
-        } else {
-            const auto block_size = mbedtls_cipher_get_block_size(context);
-
-            for (size_t offset = 0; offset < size; offset += block_size) {
-                auto length = std::min<size_t>(block_size, size - offset);
-                mbedtls_cipher_update(context, reinterpret_cast<const u8*>(src) + offset, length,
-                                      reinterpret_cast<u8*>(dest) + offset, &written);
-                if (written != length)
-                    LOG_WARNING(Crypto,
-                                "Not all data was decrypted requested={:016X}, actual={:016X}.",
-                                length, written);
-            }
-        }
-
-        mbedtls_cipher_finish(context, nullptr, nullptr);
+        Transcode(reinterpret_cast<const u8*>(src), size, reinterpret_cast<u8*>(dest), op);
     }
+
+    void Transcode(const u8* src, size_t size, u8* dest, Op op);
 
     template <typename Source, typename Dest>
     void XTSTranscode(const Source* src, size_t size, Dest* dest, size_t sector_id,
                       size_t sector_size, Op op) {
-        if (size % sector_size > 0) {
-            LOG_CRITICAL(Crypto, "Data size must be a multiple of sector size.");
-            return;
-        }
-
-        for (size_t i = 0; i < size; i += sector_size) {
-            SetIV(CalculateNintendoTweak(sector_id++));
-            Transcode<u8, u8>(reinterpret_cast<const u8*>(src) + i, sector_size,
-                              reinterpret_cast<u8*>(dest) + i, op);
-        }
+        XTSTranscode(reinterpret_cast<const u8*>(src), size, reinterpret_cast<u8*>(dest), sector_id, sector_size, op);
     }
+
+    void XTSTranscode(const u8* src, size_t size, u8* dest, size_t sector_id, size_t sector_size, Op op);
 
 private:
-    mbedtls_cipher_context_t encryption_context;
-    mbedtls_cipher_context_t decryption_context;
+    std::unique_ptr<mbedtls_cipher_context_t> encryption_context;
+    std::unique_ptr<mbedtls_cipher_context_t> decryption_context;
 
-    static std::vector<u8> CalculateNintendoTweak(size_t sector_id) {
-        std::vector<u8> out(0x10);
-        for (size_t i = 0xF; i <= 0xF; --i) {
-            out[i] = sector_id & 0xFF;
-            sector_id >>= 8;
-        }
-        return out;
-    }
+    static std::vector<u8> CalculateNintendoTweak(size_t sector_id);
 };
 } // namespace Crypto

--- a/src/core/crypto/aes_util.h
+++ b/src/core/crypto/aes_util.h
@@ -4,10 +4,15 @@
 
 #pragma once
 
+#include <memory>
+#include <type_traits>
+#include <vector>
 #include "common/assert.h"
 #include "core/file_sys/vfs.h"
 
 namespace Core::Crypto {
+
+struct CipherContext;
 
 enum class Mode {
     CTR = 11,
@@ -19,8 +24,6 @@ enum class Op {
     Encrypt,
     Decrypt,
 };
-
-struct CipherContext;
 
 template <typename Key, size_t KeySize = sizeof(Key)>
 class AESCipher {

--- a/src/core/crypto/aes_util.h
+++ b/src/core/crypto/aes_util.h
@@ -20,7 +20,7 @@ enum class Op {
     Decrypt,
 };
 
-struct mbedtls_cipher_context_t;
+struct CipherContext;
 
 template <typename Key, size_t KeySize = sizeof(Key)>
 class AESCipher {
@@ -44,15 +44,16 @@ public:
     template <typename Source, typename Dest>
     void XTSTranscode(const Source* src, size_t size, Dest* dest, size_t sector_id,
                       size_t sector_size, Op op) {
-        XTSTranscode(reinterpret_cast<const u8*>(src), size, reinterpret_cast<u8*>(dest), sector_id, sector_size, op);
+        XTSTranscode(reinterpret_cast<const u8*>(src), size, reinterpret_cast<u8*>(dest), sector_id,
+                     sector_size, op);
     }
 
-    void XTSTranscode(const u8* src, size_t size, u8* dest, size_t sector_id, size_t sector_size, Op op);
+    void XTSTranscode(const u8* src, size_t size, u8* dest, size_t sector_id, size_t sector_size,
+                      Op op);
 
 private:
-    std::unique_ptr<mbedtls_cipher_context_t> encryption_context;
-    std::unique_ptr<mbedtls_cipher_context_t> decryption_context;
+    std::unique_ptr<CipherContext> ctx;
 
     static std::vector<u8> CalculateNintendoTweak(size_t sector_id);
 };
-} // namespace Crypto
+} // namespace Core::Crypto

--- a/src/core/crypto/aes_util.h
+++ b/src/core/crypto/aes_util.h
@@ -1,0 +1,118 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common/assert.h"
+#include "core/file_sys/vfs.h"
+#include "mbedtls/cipher.h"
+
+namespace Crypto {
+
+enum class Mode {
+    CTR = MBEDTLS_CIPHER_AES_128_CTR,
+    ECB = MBEDTLS_CIPHER_AES_128_ECB,
+    XTS = MBEDTLS_CIPHER_AES_128_XTS,
+};
+
+enum class Op {
+    ENCRYPT,
+    DECRYPT,
+};
+
+template <typename Key, size_t KeySize = sizeof(Key)>
+struct AESCipher {
+    static_assert(std::is_same_v<Key, std::array<u8, KeySize>>, "Key must be std::array of u8.");
+    static_assert(KeySize == 0x10 || KeySize == 0x20, "KeySize must be 128 or 256.");
+
+    AESCipher(Key key, Mode mode) {
+        mbedtls_cipher_init(&encryption_context);
+        mbedtls_cipher_init(&decryption_context);
+
+        ASSERT_MSG((mbedtls_cipher_setup(
+                        &encryption_context,
+                        mbedtls_cipher_info_from_type(static_cast<mbedtls_cipher_type_t>(mode))) ||
+                    mbedtls_cipher_setup(&decryption_context,
+                                         mbedtls_cipher_info_from_type(
+                                             static_cast<mbedtls_cipher_type_t>(mode)))) == 0,
+                   "Failed to initialize mbedtls ciphers.");
+
+        ASSERT(
+            !mbedtls_cipher_setkey(&encryption_context, key.data(), KeySize * 8, MBEDTLS_ENCRYPT));
+        ASSERT(
+            !mbedtls_cipher_setkey(&decryption_context, key.data(), KeySize * 8, MBEDTLS_DECRYPT));
+        //"Failed to set key on mbedtls ciphers.");
+    }
+
+    ~AESCipher() {
+        mbedtls_cipher_free(&encryption_context);
+        mbedtls_cipher_free(&decryption_context);
+    }
+
+    void SetIV(std::vector<u8> iv) {
+        ASSERT_MSG((mbedtls_cipher_set_iv(&encryption_context, iv.data(), iv.size()) ||
+                    mbedtls_cipher_set_iv(&decryption_context, iv.data(), iv.size())) == 0,
+                   "Failed to set IV on mbedtls ciphers.");
+    }
+
+    template <typename Source, typename Dest>
+    void Transcode(const Source* src, size_t size, Dest* dest, Op op) {
+        size_t written = 0;
+
+        const auto context = op == Op::ENCRYPT ? &encryption_context : &decryption_context;
+
+        mbedtls_cipher_reset(context);
+
+        if (mbedtls_cipher_get_cipher_mode(context) == MBEDTLS_MODE_XTS) {
+            mbedtls_cipher_update(context, reinterpret_cast<const u8*>(src), size,
+                                  reinterpret_cast<u8*>(dest), &written);
+            if (written != size)
+                LOG_WARNING(Crypto, "Not all data was decrypted requested={:016X}, actual={:016X}.",
+                            size, written);
+        } else {
+            const auto block_size = mbedtls_cipher_get_block_size(context);
+
+            for (size_t offset = 0; offset < size; offset += block_size) {
+                auto length = std::min<size_t>(block_size, size - offset);
+                mbedtls_cipher_update(context, reinterpret_cast<const u8*>(src) + offset, length,
+                                      reinterpret_cast<u8*>(dest) + offset, &written);
+                if (written != length)
+                    LOG_WARNING(Crypto,
+                                "Not all data was decrypted requested={:016X}, actual={:016X}.",
+                                length, written);
+            }
+        }
+
+        mbedtls_cipher_finish(context, nullptr, nullptr);
+    }
+
+    template <typename Source, typename Dest>
+    void XTSTranscode(const Source* src, size_t size, Dest* dest, size_t sector_id,
+                      size_t sector_size, Op op) {
+        if (size % sector_size > 0) {
+            LOG_CRITICAL(Crypto, "Data size must be a multiple of sector size.");
+            return;
+        }
+
+        for (size_t i = 0; i < size; i += sector_size) {
+            SetIV(CalculateNintendoTweak(sector_id++));
+            Transcode<u8, u8>(reinterpret_cast<const u8*>(src) + i, sector_size,
+                              reinterpret_cast<u8*>(dest) + i, op);
+        }
+    }
+
+private:
+    mbedtls_cipher_context_t encryption_context;
+    mbedtls_cipher_context_t decryption_context;
+
+    static std::vector<u8> CalculateNintendoTweak(size_t sector_id) {
+        std::vector<u8> out(0x10);
+        for (size_t i = 0xF; i <= 0xF; --i) {
+            out[i] = sector_id & 0xFF;
+            sector_id >>= 8;
+        }
+        return out;
+    }
+};
+} // namespace Crypto

--- a/src/core/crypto/ctr_encryption_layer.cpp
+++ b/src/core/crypto/ctr_encryption_layer.cpp
@@ -1,0 +1,56 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/assert.h"
+#include "core/crypto/ctr_encryption_layer.h"
+
+namespace Crypto {
+CTREncryptionLayer::CTREncryptionLayer(FileSys::VirtualFile base_, Key128 key_, size_t base_offset)
+    : EncryptionLayer(std::move(base_)), base_offset(base_offset), cipher(key_, Mode::CTR),
+      iv(16, 0) {}
+
+size_t CTREncryptionLayer::Read(u8* data, size_t length, size_t offset) const {
+    if (length == 0)
+        return 0;
+
+    const auto sector_offset = offset & 0xF;
+    if (sector_offset == 0) {
+        UpdateIV(base_offset + offset);
+        std::vector<u8> raw = base->ReadBytes(length, offset);
+        if (raw.size() != length)
+            return Read(data, raw.size(), offset);
+        cipher.Transcode(raw.data(), length, data, Op::DECRYPT);
+        return length;
+    }
+
+    // offset does not fall on block boundary (0x10)
+    std::vector<u8> block = base->ReadBytes(0x10, offset - sector_offset);
+    UpdateIV(base_offset + offset - sector_offset);
+    cipher.Transcode(block.data(), block.size(), block.data(), Op::DECRYPT);
+    size_t read = 0x10 - sector_offset;
+
+    if (length + sector_offset < 0x10) {
+        memcpy_s(data, length, block.data() + sector_offset, std::min<u64>(length, read));
+        return read;
+    }
+
+    memcpy_s(data, length, block.data() + sector_offset, read);
+    return read + Read(data + read, length - read, offset + read);
+}
+
+void CTREncryptionLayer::SetIV(std::vector<u8> iv_) {
+    const auto length = std::min<size_t>(iv_.size(), iv.size());
+    for (size_t i = 0; i < length; ++i)
+        iv[i] = iv_[i];
+}
+
+void CTREncryptionLayer::UpdateIV(size_t offset) const {
+    offset >>= 4;
+    for (size_t i = 0; i < 8; ++i) {
+        iv[16 - i - 1] = offset & 0xFF;
+        offset >>= 8;
+    }
+    cipher.SetIV(iv);
+}
+} // namespace Crypto

--- a/src/core/crypto/ctr_encryption_layer.cpp
+++ b/src/core/crypto/ctr_encryption_layer.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <string.h>
+#include <cstring>
 #include "common/assert.h"
 #include "core/crypto/ctr_encryption_layer.h"
 
@@ -33,11 +33,10 @@ size_t CTREncryptionLayer::Read(u8* data, size_t length, size_t offset) const {
     size_t read = 0x10 - sector_offset;
 
     if (length + sector_offset < 0x10) {
-        memcpy(data, block.data() + sector_offset, std::min<u64>(length, read));
+        std::memcpy(data, block.data() + sector_offset, std::min<u64>(length, read));
         return read;
     }
-
-    memcpy(data, block.data() + sector_offset, read);
+    std::memcpy(data, block.data() + sector_offset, read);
     return read + Read(data + read, length - read, offset + read);
 }
 

--- a/src/core/crypto/ctr_encryption_layer.cpp
+++ b/src/core/crypto/ctr_encryption_layer.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <string.h>
 #include "common/assert.h"
 #include "core/crypto/ctr_encryption_layer.h"
 

--- a/src/core/crypto/ctr_encryption_layer.h
+++ b/src/core/crypto/ctr_encryption_layer.h
@@ -1,0 +1,31 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "aes_util.h"
+#include "encryption_layer.h"
+#include "key_manager.h"
+
+namespace Crypto {
+
+// Sits on top of a VirtualFile and provides CTR-mode AES decription.
+struct CTREncryptionLayer : public EncryptionLayer {
+    CTREncryptionLayer(FileSys::VirtualFile base, Key128 key, size_t base_offset);
+
+    size_t Read(u8* data, size_t length, size_t offset) const override;
+
+    void SetIV(std::vector<u8> iv);
+
+private:
+    size_t base_offset;
+
+    // Must be mutable as operations modify cipher contexts.
+    mutable AESCipher<Key128> cipher;
+    mutable std::vector<u8> iv;
+
+    void UpdateIV(size_t offset) const;
+};
+
+} // namespace Crypto

--- a/src/core/crypto/ctr_encryption_layer.h
+++ b/src/core/crypto/ctr_encryption_layer.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <vector>
 #include "core/crypto/aes_util.h"
 #include "core/crypto/encryption_layer.h"
 #include "core/crypto/key_manager.h"

--- a/src/core/crypto/ctr_encryption_layer.h
+++ b/src/core/crypto/ctr_encryption_layer.h
@@ -4,19 +4,20 @@
 
 #pragma once
 
-#include "aes_util.h"
-#include "encryption_layer.h"
-#include "key_manager.h"
+#include "core/crypto/aes_util.h"
+#include "core/crypto/encryption_layer.h"
+#include "core/crypto/key_manager.h"
 
-namespace Crypto {
+namespace Core::Crypto {
 
 // Sits on top of a VirtualFile and provides CTR-mode AES decription.
-struct CTREncryptionLayer : public EncryptionLayer {
+class CTREncryptionLayer : public EncryptionLayer {
+public:
     CTREncryptionLayer(FileSys::VirtualFile base, Key128 key, size_t base_offset);
 
     size_t Read(u8* data, size_t length, size_t offset) const override;
 
-    void SetIV(std::vector<u8> iv);
+    void SetIV(const std::vector<u8>& iv);
 
 private:
     size_t base_offset;
@@ -28,4 +29,4 @@ private:
     void UpdateIV(size_t offset) const;
 };
 
-} // namespace Crypto
+} // namespace Core::Crypto

--- a/src/core/crypto/encryption_layer.cpp
+++ b/src/core/crypto/encryption_layer.cpp
@@ -4,7 +4,7 @@
 
 #include "core/crypto/encryption_layer.h"
 
-namespace Crypto {
+namespace Core::Crypto {
 
 EncryptionLayer::EncryptionLayer(FileSys::VirtualFile base_) : base(std::move(base_)) {}
 
@@ -39,4 +39,4 @@ size_t EncryptionLayer::Write(const u8* data, size_t length, size_t offset) {
 bool EncryptionLayer::Rename(std::string_view name) {
     return base->Rename(name);
 }
-} // namespace Crypto
+} // namespace Core::Crypto

--- a/src/core/crypto/encryption_layer.cpp
+++ b/src/core/crypto/encryption_layer.cpp
@@ -1,0 +1,42 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/crypto/encryption_layer.h"
+
+namespace Crypto {
+
+EncryptionLayer::EncryptionLayer(FileSys::VirtualFile base_) : base(std::move(base_)) {}
+
+std::string EncryptionLayer::GetName() const {
+    return base->GetName();
+}
+
+size_t EncryptionLayer::GetSize() const {
+    return base->GetSize();
+}
+
+bool EncryptionLayer::Resize(size_t new_size) {
+    return false;
+}
+
+std::shared_ptr<FileSys::VfsDirectory> EncryptionLayer::GetContainingDirectory() const {
+    return base->GetContainingDirectory();
+}
+
+bool EncryptionLayer::IsWritable() const {
+    return false;
+}
+
+bool EncryptionLayer::IsReadable() const {
+    return true;
+}
+
+size_t EncryptionLayer::Write(const u8* data, size_t length, size_t offset) {
+    return 0;
+}
+
+bool EncryptionLayer::Rename(std::string_view name) {
+    return base->Rename(name);
+}
+} // namespace Crypto

--- a/src/core/crypto/encryption_layer.h
+++ b/src/core/crypto/encryption_layer.h
@@ -10,7 +10,8 @@ namespace Core::Crypto {
 
 // Basically non-functional class that implements all of the methods that are irrelevant to an
 // EncryptionLayer. Reduces duplicate code.
-struct EncryptionLayer : public FileSys::VfsFile {
+class EncryptionLayer : public FileSys::VfsFile {
+public:
     explicit EncryptionLayer(FileSys::VirtualFile base);
 
     size_t Read(u8* data, size_t length, size_t offset) const override = 0;

--- a/src/core/crypto/encryption_layer.h
+++ b/src/core/crypto/encryption_layer.h
@@ -1,0 +1,30 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+#include "core/file_sys/vfs.h"
+
+namespace Crypto {
+
+// Basically non-functional class that implements all of the methods that are irrelevant to an
+// EncryptionLayer. Reduces duplicate code.
+struct EncryptionLayer : public FileSys::VfsFile {
+    explicit EncryptionLayer(FileSys::VirtualFile base);
+
+    size_t Read(u8* data, size_t length, size_t offset) const override = 0;
+
+    std::string GetName() const override;
+    size_t GetSize() const override;
+    bool Resize(size_t new_size) override;
+    std::shared_ptr<FileSys::VfsDirectory> GetContainingDirectory() const override;
+    bool IsWritable() const override;
+    bool IsReadable() const override;
+    size_t Write(const u8* data, size_t length, size_t offset) override;
+    bool Rename(std::string_view name) override;
+
+protected:
+    FileSys::VirtualFile base;
+};
+
+} // namespace Crypto

--- a/src/core/crypto/encryption_layer.h
+++ b/src/core/crypto/encryption_layer.h
@@ -3,9 +3,10 @@
 // Refer to the license.txt file included.
 
 #pragma once
+
 #include "core/file_sys/vfs.h"
 
-namespace Crypto {
+namespace Core::Crypto {
 
 // Basically non-functional class that implements all of the methods that are irrelevant to an
 // EncryptionLayer. Reduces duplicate code.
@@ -27,4 +28,4 @@ protected:
     FileSys::VirtualFile base;
 };
 
-} // namespace Crypto
+} // namespace Core::Crypto

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -5,238 +5,15 @@
 #include <fstream>
 #include <locale>
 #include <sstream>
+#include <mbedtls/sha256.h>
 #include "common/assert.h"
+#include "common/common_paths.h"
+#include "common/file_util.h"
 #include "common/logging/log.h"
 #include "core/crypto/key_manager.h"
-#include "mbedtls/sha256.h"
+#include "core/settings.h"
 
-namespace Crypto {
-KeyManager keys = {};
-
-std::unordered_map<KeyIndex<S128KeyType>, SHA256Hash> KeyManager::s128_hash_prod = {
-    {{S128KeyType::MASTER, 0, 0},
-     "0EE359BE3C864BB0782E1D70A718A0342C551EED28C369754F9C4F691BECF7CA"_array32},
-    {{S128KeyType::MASTER, 1, 0},
-     "4FE707B7E4ABDAF727C894AAF13B1351BFE2AC90D875F73B2E20FA94B9CC661E"_array32},
-    {{S128KeyType::MASTER, 2, 0},
-     "79277C0237A2252EC3DFAC1F7C359C2B3D121E9DB15BB9AB4C2B4408D2F3AE09"_array32},
-    {{S128KeyType::MASTER, 3, 0},
-     "4F36C565D13325F65EE134073C6A578FFCB0008E02D69400836844EAB7432754"_array32},
-    {{S128KeyType::MASTER, 4, 0},
-     "75ff1d95d26113550ee6fcc20acb58e97edeb3a2ff52543ed5aec63bdcc3da50"_array32},
-    {{S128KeyType::PACKAGE1, 0, 0},
-     "4543CD1B7CAD7EE0466A3DE2086A0EF923805DCEA6C741541CDDB14F54F97B40"_array32},
-    {{S128KeyType::PACKAGE1, 1, 0},
-     "4A11DA019D26470C9B805F1721364830DC0096DD66EAC453B0D14455E5AF5CF8"_array32},
-    {{S128KeyType::PACKAGE1, 2, 0},
-     "CCA867360B3318246FBF0B8A86473176ED486DFE229772B941A02E84D50A3155"_array32},
-    {{S128KeyType::PACKAGE1, 3, 0},
-     "E65C383CDF526DFFAA77682868EBFA9535EE60D8075C961BBC1EDE5FBF7E3C5F"_array32},
-    {{S128KeyType::PACKAGE1, 4, 0},
-     "28ae73d6ae8f7206fca549e27097714e599df1208e57099416ff429b71370162"_array32},
-    {{S128KeyType::PACKAGE2, 0, 0},
-     "94D6F38B9D0456644E21DFF4707D092B70179B82D1AA2F5B6A76B8F9ED948264"_array32},
-    {{S128KeyType::PACKAGE2, 1, 0},
-     "7794F24FA879D378FEFDC8776B949B88AD89386410BE9025D463C619F1530509"_array32},
-    {{S128KeyType::PACKAGE2, 2, 0},
-     "5304BDDE6AC8E462961B5DB6E328B1816D245D36D6574BB78938B74D4418AF35"_array32},
-    {{S128KeyType::PACKAGE2, 3, 0},
-     "BE1E52C4345A979DDD4924375B91C902052C2E1CF8FBF2FAA42E8F26D5125B60"_array32},
-    {{S128KeyType::PACKAGE2, 4, 0},
-     "631b45d349ab8f76a050fe59512966fb8dbaf0755ef5b6903048bf036cfa611e"_array32},
-    {{S128KeyType::TITLEKEK, 0, 0},
-     "C2FA30CAC6AE1680466CB54750C24550E8652B3B6F38C30B49DADF067B5935E9"_array32},
-    {{S128KeyType::TITLEKEK, 1, 0},
-     "0D6B8F3746AD910D36438A859C11E8BE4310112425D63751D09B5043B87DE598"_array32},
-    {{S128KeyType::TITLEKEK, 2, 0},
-     "D09E18D3DB6BC7393536896F728528736FBEFCDD15C09D9D612FDE5C7BDCD821"_array32},
-    {{S128KeyType::TITLEKEK, 3, 0},
-     "47C6F9F7E99BB1F56DCDC93CDBD340EA82DCCD74DD8F3535ADA20ECF79D438ED"_array32},
-    {{S128KeyType::TITLEKEK, 4, 0},
-     "128610de8424cb29e08f9ee9a81c9e6ffd3c6662854aad0c8f937e0bcedc4d88"_array32},
-    {{S128KeyType::ETICKET_RSA_KEK, 0, 0},
-     "46cccf288286e31c931379de9efa288c95c9a15e40b00a4c563a8be244ece515"_array32},
-    {{S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::Application)},
-     "592957F44FE5DB5EC6B095F568910E31A226D3B7FE42D64CFB9CE4051E90AEB6"_array32},
-    {{S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::Application)},
-     "C2252A0FBF9D339ABC3D681351D00452F926E7CA0C6CA85F659078DE3FA647F3"_array32},
-    {{S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::Application)},
-     "7C7722824B2F7C4938C40F3EA93E16CB69D3285EB133490EF8ECCD2C4B52DF41"_array32},
-    {{S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::Application)},
-     "AFBB8EBFB2094F1CF71E330826AE06D64414FCA128C464618DF30EED92E62BE6"_array32},
-    {{S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::Application)},
-     "5dc10eb81918da3f2fa90f69c8542511963656cfb31fb7c779581df8faf1f2f5"_array32},
-    {{S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::Ocean)},
-     "AA2C65F0E27F730807A13F2ED5B99BE5183165B87C50B6ED48F5CAC2840687EB"_array32},
-    {{S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::Ocean)},
-     "860185F2313A14F7006A029CB21A52750E7718C1E94FFB98C0AE2207D1A60165"_array32},
-    {{S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::Ocean)},
-     "7283FB1EFBD42438DADF363FDB776ED355C98737A2AAE75D0E9283CE1C12A2E4"_array32},
-    {{S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::Ocean)},
-     "9881C2D3AB70B14C8AA12016FC73ADAD93C6AD9FB59A9ECAD312B6F89E2413EC"_array32},
-    {{S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::Ocean)},
-     "eaa6a8d242b89e174928fa9549a0f66ec1562e2576fac896f438a2b3c1fb6005"_array32},
-    {{S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::System)},
-     "194CF6BD14554DA8D457E14CBFE04E55C8FB8CA52E0AFB3D7CB7084AE435B801"_array32},
-    {{S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::System)},
-     "CE1DB7BB6E5962384889DB7A396AFD614F82F69DC38A33D2DEAF47F3E4B964B7"_array32},
-    {{S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::System)},
-     "42238DE5685DEF4FDE7BE42C0097CEB92447006386D6B5D5AAA2C9AFD2E28422"_array32},
-    {{S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::System)},
-     "1F6847F268E9D9C5D1AD4D7E226A63B833BF02071446957A962EF065521879C1"_array32},
-    {{S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::System)},
-     "644007f9913c3602399d4d75cc34faeb7f1faad18b23e34187b16fdc45f4980f"_array32},
-};
-
-std::unordered_map<KeyIndex<S256KeyType>, SHA256Hash> KeyManager::s256_hash_prod = {
-    {{S256KeyType::HEADER, 0, 0},
-     "8E03DE24818D96CE4F2A09B43AF979E679974F7570713A61EED8B314864A11D5"_array32},
-    {{S256KeyType::SD_SAVE, 0, 0},
-     "13020ee72d0f8b8f9112dc738b829fdb017102499a7c2259b52aeefc0a273f5c"_array32},
-    {{S256KeyType::SD_NCA, 0, 0},
-     "8a1c05b4f88bae5b04d77f632e6acfc8893c4a05fd701f53585daafc996b532a"_array32},
-};
-
-// TODO(DarkLordZach): Find missing hashes for dev keys.
-
-std::unordered_map<KeyIndex<S128KeyType>, SHA256Hash> KeyManager::s128_hash_dev = {
-    {{S128KeyType::MASTER, 0, 0},
-     "779dd8b533a2fb670f27b308cb8d0151c4a107568b817429172b7f80aa592c25"_array32},
-    {{S128KeyType::MASTER, 1, 0},
-     "0175c8bc49771576f75527be719098db4ebaf77707206749415663aa3a9ea9cc"_array32},
-    {{S128KeyType::MASTER, 2, 0},
-     "4f0b4d724e5a8787268157c7ce0767c26d2e2021832aa7020f306d6e260eea42"_array32},
-    {{S128KeyType::MASTER, 3, 0},
-     "7b5a29586c1f84f66fbfabb94518fc45408bb8e5445253d063dda7cfef2a818c"_array32},
-    {{S128KeyType::MASTER, 4, 0},
-     "87a61dbb05a8755de7fe069562aab38ebfb266c9eb835f09fa62dacc89c98341"_array32},
-    {{S128KeyType::PACKAGE1, 0, 0},
-     "166510bc63ae50391ebe4ee4ff90ca31cd0e2dd0ff6be839a2f573ec146cc23a"_array32},
-    {{S128KeyType::PACKAGE1, 1, 0},
-     "f74cd01b86743139c920ec54a8116c669eea805a0be1583e13fc5bc8de68645b"_array32},
-    {{S128KeyType::PACKAGE1, 2, 0},
-     "d0cdecd513bb6aa3d9dc6244c977dc8a5a7ea157d0a8747d79e7581146e1f768"_array32},
-    {{S128KeyType::PACKAGE1, 3, 0},
-     "aa39394d626b3b79f5b7ccc07378b5996b6d09bf0eb6771b0b40c9077fbfde8c"_array32},
-    {{S128KeyType::PACKAGE1, 4, 0},
-     "8f4754b8988c0e673fc2bbea0534cdd6075c815c9270754ae980aef3e4f0a508"_array32},
-    {{S128KeyType::PACKAGE2, 0, 0},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::PACKAGE2, 1, 0},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::PACKAGE2, 2, 0},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::PACKAGE2, 3, 0},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::PACKAGE2, 4, 0},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::TITLEKEK, 0, 0},
-     "C2FA30CAC6AE1680466CB54750C24550E8652B3B6F38C30B49DADF067B5935E9"_array32},
-    {{S128KeyType::TITLEKEK, 1, 0},
-     "0D6B8F3746AD910D36438A859C11E8BE4310112425D63751D09B5043B87DE598"_array32},
-    {{S128KeyType::TITLEKEK, 2, 0},
-     "D09E18D3DB6BC7393536896F728528736FBEFCDD15C09D9D612FDE5C7BDCD821"_array32},
-    {{S128KeyType::TITLEKEK, 3, 0},
-     "47C6F9F7E99BB1F56DCDC93CDBD340EA82DCCD74DD8F3535ADA20ECF79D438ED"_array32},
-    {{S128KeyType::TITLEKEK, 4, 0},
-     "128610de8424cb29e08f9ee9a81c9e6ffd3c6662854aad0c8f937e0bcedc4d88"_array32},
-    {{S128KeyType::ETICKET_RSA_KEK, 0, 0},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::Application)},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::Application)},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::Application)},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::Application)},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::Application)},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::Ocean)},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::Ocean)},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::Ocean)},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::Ocean)},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::Ocean)},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::System)},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::System)},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::System)},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::System)},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::System)},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-};
-
-std::unordered_map<KeyIndex<S256KeyType>, SHA256Hash> KeyManager::s256_hash_dev = {
-    {{S256KeyType::HEADER, 0, 0},
-     "ecde86a76e37ac4fd7591d3aa55c00cc77d8595fc27968052ec18a177d939060"_array32},
-    {{S256KeyType::SD_SAVE, 0, 0},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-    {{S256KeyType::SD_NCA, 0, 0},
-     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
-};
-
-std::unordered_map<std::string, KeyIndex<S128KeyType>> KeyManager::s128_file_id = {
-    {"master_key_00", {S128KeyType::MASTER, 0, 0}},
-    {"master_key_01", {S128KeyType::MASTER, 1, 0}},
-    {"master_key_02", {S128KeyType::MASTER, 2, 0}},
-    {"master_key_03", {S128KeyType::MASTER, 3, 0}},
-    {"master_key_04", {S128KeyType::MASTER, 4, 0}},
-    {"package1_key_00", {S128KeyType::PACKAGE1, 0, 0}},
-    {"package1_key_01", {S128KeyType::PACKAGE1, 1, 0}},
-    {"package1_key_02", {S128KeyType::PACKAGE1, 2, 0}},
-    {"package1_key_03", {S128KeyType::PACKAGE1, 3, 0}},
-    {"package1_key_04", {S128KeyType::PACKAGE1, 4, 0}},
-    {"package2_key_00", {S128KeyType::PACKAGE2, 0, 0}},
-    {"package2_key_01", {S128KeyType::PACKAGE2, 1, 0}},
-    {"package2_key_02", {S128KeyType::PACKAGE2, 2, 0}},
-    {"package2_key_03", {S128KeyType::PACKAGE2, 3, 0}},
-    {"package2_key_04", {S128KeyType::PACKAGE2, 4, 0}},
-    {"titlekek_00", {S128KeyType::TITLEKEK, 0, 0}},
-    {"titlekek_01", {S128KeyType::TITLEKEK, 1, 0}},
-    {"titlekek_02", {S128KeyType::TITLEKEK, 2, 0}},
-    {"titlekek_03", {S128KeyType::TITLEKEK, 3, 0}},
-    {"titlekek_04", {S128KeyType::TITLEKEK, 4, 0}},
-    {"eticket_rsa_kek", {S128KeyType::ETICKET_RSA_KEK, 0, 0}},
-    {"key_area_key_application_00",
-     {S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::Application)}},
-    {"key_area_key_application_01",
-     {S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::Application)}},
-    {"key_area_key_application_02",
-     {S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::Application)}},
-    {"key_area_key_application_03",
-     {S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::Application)}},
-    {"key_area_key_application_04",
-     {S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::Application)}},
-    {"key_area_key_ocean_00", {S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::Ocean)}},
-    {"key_area_key_ocean_01", {S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::Ocean)}},
-    {"key_area_key_ocean_02", {S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::Ocean)}},
-    {"key_area_key_ocean_03", {S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::Ocean)}},
-    {"key_area_key_ocean_04", {S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::Ocean)}},
-    {"key_area_key_system_00",
-     {S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::System)}},
-    {"key_area_key_system_01",
-     {S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::System)}},
-    {"key_area_key_system_02",
-     {S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::System)}},
-    {"key_area_key_system_03",
-     {S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::System)}},
-    {"key_area_key_system_04",
-     {S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::System)}},
-};
-
-std::unordered_map<std::string, KeyIndex<S256KeyType>> KeyManager::s256_file_id = {
-    {"header_key", {S256KeyType::HEADER, 0, 0}},
-    {"sd_card_save_key", {S256KeyType::SD_SAVE, 0, 0}},
-    {"sd_card_nca_key", {S256KeyType::SD_NCA, 0, 0}},
-};
+namespace Core::Crypto {
 
 static u8 ToHexNibble(char c1) {
     if (c1 >= 65 && c1 <= 70)
@@ -271,8 +48,20 @@ std::array<u8, 32> operator""_array32(const char* str, size_t len) {
     return HexStringToArray<32>(str);
 }
 
-void KeyManager::SetValidationMode(bool dev) {
-    dev_mode = dev;
+KeyManager::KeyManager() {
+    // Initialize keys
+    std::string keys_dir = FileUtil::GetHactoolConfigurationPath();
+    if (Settings::values.use_dev_keys) {
+        dev_mode = true;
+        if (FileUtil::Exists(keys_dir + DIR_SEP + "dev.keys"))
+            LoadFromFile(keys_dir + DIR_SEP + "dev.keys", false);
+    } else {
+        dev_mode = false;
+        if (FileUtil::Exists(keys_dir + DIR_SEP + "prod.keys"))
+            LoadFromFile(keys_dir + DIR_SEP + "prod.keys", false);
+    }
+    if (FileUtil::Exists(keys_dir + DIR_SEP + "title.keys"))
+        LoadFromFile(keys_dir + DIR_SEP + "title.keys", true);
 }
 
 void KeyManager::LoadFromFile(std::string_view filename_, bool is_title_keys) {
@@ -299,7 +88,7 @@ void KeyManager::LoadFromFile(std::string_view filename_, bool is_title_keys) {
             auto rights_id_raw = HexStringToArray<16>(out[0]);
             u128 rights_id = *reinterpret_cast<std::array<u64, 2>*>(&rights_id_raw);
             Key128 key = HexStringToArray<16>(out[1]);
-            SetKey(S128KeyType::TITLEKEY, key, rights_id[1], rights_id[0]);
+            SetKey(S128KeyType::Titlekey, key, rights_id[1], rights_id[0]);
         } else {
             std::transform(out[0].begin(), out[0].end(), out[0].begin(), ::tolower);
             if (s128_file_id.find(out[0]) != s128_file_id.end()) {
@@ -315,24 +104,24 @@ void KeyManager::LoadFromFile(std::string_view filename_, bool is_title_keys) {
     }
 }
 
-bool KeyManager::HasKey(S128KeyType id, u64 field1, u64 field2) {
+bool KeyManager::HasKey(S128KeyType id, u64 field1, u64 field2) const {
     return s128_keys.find({id, field1, field2}) != s128_keys.end();
 }
 
-bool KeyManager::HasKey(S256KeyType id, u64 field1, u64 field2) {
+bool KeyManager::HasKey(S256KeyType id, u64 field1, u64 field2) const {
     return s256_keys.find({id, field1, field2}) != s256_keys.end();
 }
 
-Key128 KeyManager::GetKey(S128KeyType id, u64 field1, u64 field2) {
+Key128 KeyManager::GetKey(S128KeyType id, u64 field1, u64 field2) const {
     if (!HasKey(id, field1, field2))
         return {};
-    return s128_keys[{id, field1, field2}];
+    return s128_keys.at({id, field1, field2});
 }
 
-Key256 KeyManager::GetKey(S256KeyType id, u64 field1, u64 field2) {
+Key256 KeyManager::GetKey(S256KeyType id, u64 field1, u64 field2) const {
     if (!HasKey(id, field1, field2))
         return {};
-    return s256_keys[{id, field1, field2}];
+    return s256_keys.at({id, field1, field2});
 }
 
 void KeyManager::SetKey(S128KeyType id, Key128 key, u64 field1, u64 field2) {
@@ -343,68 +132,53 @@ void KeyManager::SetKey(S256KeyType id, Key256 key, u64 field1, u64 field2) {
     s256_keys[{id, field1, field2}] = key;
 }
 
-bool KeyManager::ValidateKey(S128KeyType key, u64 field1, u64 field2) {
-    auto& hash = dev_mode ? s128_hash_dev : s128_hash_prod;
+std::unordered_map<std::string, KeyIndex<S128KeyType>> KeyManager::s128_file_id = {
+    {"master_key_00", {S128KeyType::Master, 0, 0}},
+    {"master_key_01", {S128KeyType::Master, 1, 0}},
+    {"master_key_02", {S128KeyType::Master, 2, 0}},
+    {"master_key_03", {S128KeyType::Master, 3, 0}},
+    {"master_key_04", {S128KeyType::Master, 4, 0}},
+    {"package1_key_00", {S128KeyType::Package1, 0, 0}},
+    {"package1_key_01", {S128KeyType::Package1, 1, 0}},
+    {"package1_key_02", {S128KeyType::Package1, 2, 0}},
+    {"package1_key_03", {S128KeyType::Package1, 3, 0}},
+    {"package1_key_04", {S128KeyType::Package1, 4, 0}},
+    {"package2_key_00", {S128KeyType::Package2, 0, 0}},
+    {"package2_key_01", {S128KeyType::Package2, 1, 0}},
+    {"package2_key_02", {S128KeyType::Package2, 2, 0}},
+    {"package2_key_03", {S128KeyType::Package2, 3, 0}},
+    {"package2_key_04", {S128KeyType::Package2, 4, 0}},
+    {"titlekek_00", {S128KeyType::Titlekek, 0, 0}},
+    {"titlekek_01", {S128KeyType::Titlekek, 1, 0}},
+    {"titlekek_02", {S128KeyType::Titlekek, 2, 0}},
+    {"titlekek_03", {S128KeyType::Titlekek, 3, 0}},
+    {"titlekek_04", {S128KeyType::Titlekek, 4, 0}},
+    {"eticket_rsa_kek", {S128KeyType::ETicketRSAKek, 0, 0}},
+    {"key_area_key_application_00",
+     {S128KeyType::KeyArea, 0, static_cast<u64>(KeyAreaKeyType::Application)}},
+    {"key_area_key_application_01",
+     {S128KeyType::KeyArea, 1, static_cast<u64>(KeyAreaKeyType::Application)}},
+    {"key_area_key_application_02",
+     {S128KeyType::KeyArea, 2, static_cast<u64>(KeyAreaKeyType::Application)}},
+    {"key_area_key_application_03",
+     {S128KeyType::KeyArea, 3, static_cast<u64>(KeyAreaKeyType::Application)}},
+    {"key_area_key_application_04",
+     {S128KeyType::KeyArea, 4, static_cast<u64>(KeyAreaKeyType::Application)}},
+    {"key_area_key_ocean_00", {S128KeyType::KeyArea, 0, static_cast<u64>(KeyAreaKeyType::Ocean)}},
+    {"key_area_key_ocean_01", {S128KeyType::KeyArea, 1, static_cast<u64>(KeyAreaKeyType::Ocean)}},
+    {"key_area_key_ocean_02", {S128KeyType::KeyArea, 2, static_cast<u64>(KeyAreaKeyType::Ocean)}},
+    {"key_area_key_ocean_03", {S128KeyType::KeyArea, 3, static_cast<u64>(KeyAreaKeyType::Ocean)}},
+    {"key_area_key_ocean_04", {S128KeyType::KeyArea, 4, static_cast<u64>(KeyAreaKeyType::Ocean)}},
+    {"key_area_key_system_00", {S128KeyType::KeyArea, 0, static_cast<u64>(KeyAreaKeyType::System)}},
+    {"key_area_key_system_01", {S128KeyType::KeyArea, 1, static_cast<u64>(KeyAreaKeyType::System)}},
+    {"key_area_key_system_02", {S128KeyType::KeyArea, 2, static_cast<u64>(KeyAreaKeyType::System)}},
+    {"key_area_key_system_03", {S128KeyType::KeyArea, 3, static_cast<u64>(KeyAreaKeyType::System)}},
+    {"key_area_key_system_04", {S128KeyType::KeyArea, 4, static_cast<u64>(KeyAreaKeyType::System)}},
+};
 
-    KeyIndex<S128KeyType> id = {key, field1, field2};
-    if (key == S128KeyType::SD_SEED || key == S128KeyType::TITLEKEY ||
-        hash.find(id) == hash.end()) {
-        LOG_WARNING(Crypto, "Could not validate [{}]", id.DebugInfo());
-        return true;
-    }
-
-    if (!HasKey(key, field1, field2)) {
-        LOG_CRITICAL(Crypto,
-                     "System has requested validation of [{}], but user has not added it. Add this "
-                     "key to use functionality.",
-                     id.DebugInfo());
-        return false;
-    }
-
-    SHA256Hash key_hash{};
-    const auto a_key = GetKey(key, field1, field2);
-    mbedtls_sha256(a_key.data(), a_key.size(), key_hash.data(), 0);
-    if (key_hash != hash[id]) {
-        LOG_CRITICAL(Crypto,
-                     "The hash of the provided key for [{}] does not match the one on file. This "
-                     "means you probably have an incorrect key. If you believe this to be in "
-                     "error, contact the yuzu devs.",
-                     id.DebugInfo());
-        return false;
-    }
-
-    return true;
-}
-
-bool KeyManager::ValidateKey(S256KeyType key, u64 field1, u64 field2) {
-    auto& hash = dev_mode ? s256_hash_dev : s256_hash_prod;
-
-    KeyIndex<S256KeyType> id = {key, field1, field2};
-    if (hash.find(id) == hash.end()) {
-        LOG_ERROR(Crypto, "Could not validate [{}]", id.DebugInfo());
-        return true;
-    }
-
-    if (!HasKey(key, field1, field2)) {
-        LOG_ERROR(Crypto,
-                  "System has requested validation of [{}], but user has not added it. Add this "
-                  "key to use functionality.",
-                  id.DebugInfo());
-        return false;
-    }
-
-    SHA256Hash key_hash{};
-    const auto a_key = GetKey(key, field1, field2);
-    mbedtls_sha256(a_key.data(), a_key.size(), key_hash.data(), 0);
-    if (key_hash != hash[id]) {
-        LOG_CRITICAL(Crypto,
-                     "The hash of the provided key for [{}] does not match the one on file. This "
-                     "means you probably have an incorrect key. If you believe this to be in "
-                     "error, contact the yuzu devs.",
-                     id.DebugInfo());
-        return false;
-    }
-
-    return true;
-}
-} // namespace Crypto
+std::unordered_map<std::string, KeyIndex<S256KeyType>> KeyManager::s256_file_id = {
+    {"header_key", {S256KeyType::Header, 0, 0}},
+    {"sd_card_save_key", {S256KeyType::SDSave, 0, 0}},
+    {"sd_card_nca_key", {S256KeyType::SDNCA, 0, 0}},
+};
+} // namespace Core::Crypto

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -53,8 +53,8 @@ std::array<u8, 32> operator""_array32(const char* str, size_t len) {
 
 KeyManager::KeyManager() {
     // Initialize keys
-    std::string hactool_keys_dir = FileUtil::GetHactoolConfigurationPath();
-    std::string yuzu_keys_dir = FileUtil::GetUserPath(FileUtil::UserPath::KeysDir);
+    const std::string hactool_keys_dir = FileUtil::GetHactoolConfigurationPath();
+    const std::string yuzu_keys_dir = FileUtil::GetUserPath(FileUtil::UserPath::KeysDir);
     if (Settings::values.use_dev_keys) {
         dev_mode = true;
         AttemptLoadKeyFile(yuzu_keys_dir, hactool_keys_dir, "dev.keys", false);
@@ -109,9 +109,9 @@ void KeyManager::LoadFromFile(std::string_view filename_, bool is_title_keys) {
 
 void KeyManager::AttemptLoadKeyFile(std::string_view dir1_, std::string_view dir2_,
                                     std::string_view filename_, bool title) {
-    std::string dir1(dir1_);
-    std::string dir2(dir2_);
-    std::string filename(filename_);
+    const std::string dir1(dir1_);
+    const std::string dir2(dir2_);
+    const std::string filename(filename_);
     if (FileUtil::Exists(dir1 + DIR_SEP + filename))
         LoadFromFile(dir1 + DIR_SEP + filename, title);
     else if (FileUtil::Exists(dir2 + DIR_SEP + filename))
@@ -144,6 +144,23 @@ void KeyManager::SetKey(S128KeyType id, Key128 key, u64 field1, u64 field2) {
 
 void KeyManager::SetKey(S256KeyType id, Key256 key, u64 field1, u64 field2) {
     s256_keys[{id, field1, field2}] = key;
+}
+
+bool KeyManager::KeyFileExists(bool title) {
+    const std::string hactool_keys_dir = FileUtil::GetHactoolConfigurationPath();
+    const std::string yuzu_keys_dir = FileUtil::GetUserPath(FileUtil::UserPath::KeysDir);
+    if (title) {
+        return FileUtil::Exists(hactool_keys_dir + DIR_SEP + "title.keys") ||
+               FileUtil::Exists(yuzu_keys_dir + DIR_SEP + "title.keys");
+    }
+
+    if (Settings::values.use_dev_keys) {
+        return FileUtil::Exists(hactool_keys_dir + DIR_SEP + "dev.keys") ||
+               FileUtil::Exists(yuzu_keys_dir + DIR_SEP + "dev.keys");
+    }
+
+    return FileUtil::Exists(hactool_keys_dir + DIR_SEP + "prod.keys") ||
+           FileUtil::Exists(yuzu_keys_dir + DIR_SEP + "prod.keys");
 }
 
 const std::unordered_map<std::string, KeyIndex<S128KeyType>> KeyManager::s128_file_id = {

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -1,0 +1,410 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <fstream>
+#include <locale>
+#include <sstream>
+#include "common/assert.h"
+#include "common/logging/log.h"
+#include "core/crypto/key_manager.h"
+#include "mbedtls/sha256.h"
+
+namespace Crypto {
+KeyManager keys = {};
+
+std::unordered_map<KeyIndex<S128KeyType>, SHA256Hash> KeyManager::s128_hash_prod = {
+    {{S128KeyType::MASTER, 0, 0},
+     "0EE359BE3C864BB0782E1D70A718A0342C551EED28C369754F9C4F691BECF7CA"_array32},
+    {{S128KeyType::MASTER, 1, 0},
+     "4FE707B7E4ABDAF727C894AAF13B1351BFE2AC90D875F73B2E20FA94B9CC661E"_array32},
+    {{S128KeyType::MASTER, 2, 0},
+     "79277C0237A2252EC3DFAC1F7C359C2B3D121E9DB15BB9AB4C2B4408D2F3AE09"_array32},
+    {{S128KeyType::MASTER, 3, 0},
+     "4F36C565D13325F65EE134073C6A578FFCB0008E02D69400836844EAB7432754"_array32},
+    {{S128KeyType::MASTER, 4, 0},
+     "75ff1d95d26113550ee6fcc20acb58e97edeb3a2ff52543ed5aec63bdcc3da50"_array32},
+    {{S128KeyType::PACKAGE1, 0, 0},
+     "4543CD1B7CAD7EE0466A3DE2086A0EF923805DCEA6C741541CDDB14F54F97B40"_array32},
+    {{S128KeyType::PACKAGE1, 1, 0},
+     "4A11DA019D26470C9B805F1721364830DC0096DD66EAC453B0D14455E5AF5CF8"_array32},
+    {{S128KeyType::PACKAGE1, 2, 0},
+     "CCA867360B3318246FBF0B8A86473176ED486DFE229772B941A02E84D50A3155"_array32},
+    {{S128KeyType::PACKAGE1, 3, 0},
+     "E65C383CDF526DFFAA77682868EBFA9535EE60D8075C961BBC1EDE5FBF7E3C5F"_array32},
+    {{S128KeyType::PACKAGE1, 4, 0},
+     "28ae73d6ae8f7206fca549e27097714e599df1208e57099416ff429b71370162"_array32},
+    {{S128KeyType::PACKAGE2, 0, 0},
+     "94D6F38B9D0456644E21DFF4707D092B70179B82D1AA2F5B6A76B8F9ED948264"_array32},
+    {{S128KeyType::PACKAGE2, 1, 0},
+     "7794F24FA879D378FEFDC8776B949B88AD89386410BE9025D463C619F1530509"_array32},
+    {{S128KeyType::PACKAGE2, 2, 0},
+     "5304BDDE6AC8E462961B5DB6E328B1816D245D36D6574BB78938B74D4418AF35"_array32},
+    {{S128KeyType::PACKAGE2, 3, 0},
+     "BE1E52C4345A979DDD4924375B91C902052C2E1CF8FBF2FAA42E8F26D5125B60"_array32},
+    {{S128KeyType::PACKAGE2, 4, 0},
+     "631b45d349ab8f76a050fe59512966fb8dbaf0755ef5b6903048bf036cfa611e"_array32},
+    {{S128KeyType::TITLEKEK, 0, 0},
+     "C2FA30CAC6AE1680466CB54750C24550E8652B3B6F38C30B49DADF067B5935E9"_array32},
+    {{S128KeyType::TITLEKEK, 1, 0},
+     "0D6B8F3746AD910D36438A859C11E8BE4310112425D63751D09B5043B87DE598"_array32},
+    {{S128KeyType::TITLEKEK, 2, 0},
+     "D09E18D3DB6BC7393536896F728528736FBEFCDD15C09D9D612FDE5C7BDCD821"_array32},
+    {{S128KeyType::TITLEKEK, 3, 0},
+     "47C6F9F7E99BB1F56DCDC93CDBD340EA82DCCD74DD8F3535ADA20ECF79D438ED"_array32},
+    {{S128KeyType::TITLEKEK, 4, 0},
+     "128610de8424cb29e08f9ee9a81c9e6ffd3c6662854aad0c8f937e0bcedc4d88"_array32},
+    {{S128KeyType::ETICKET_RSA_KEK, 0, 0},
+     "46cccf288286e31c931379de9efa288c95c9a15e40b00a4c563a8be244ece515"_array32},
+    {{S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::Application)},
+     "592957F44FE5DB5EC6B095F568910E31A226D3B7FE42D64CFB9CE4051E90AEB6"_array32},
+    {{S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::Application)},
+     "C2252A0FBF9D339ABC3D681351D00452F926E7CA0C6CA85F659078DE3FA647F3"_array32},
+    {{S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::Application)},
+     "7C7722824B2F7C4938C40F3EA93E16CB69D3285EB133490EF8ECCD2C4B52DF41"_array32},
+    {{S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::Application)},
+     "AFBB8EBFB2094F1CF71E330826AE06D64414FCA128C464618DF30EED92E62BE6"_array32},
+    {{S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::Application)},
+     "5dc10eb81918da3f2fa90f69c8542511963656cfb31fb7c779581df8faf1f2f5"_array32},
+    {{S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::Ocean)},
+     "AA2C65F0E27F730807A13F2ED5B99BE5183165B87C50B6ED48F5CAC2840687EB"_array32},
+    {{S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::Ocean)},
+     "860185F2313A14F7006A029CB21A52750E7718C1E94FFB98C0AE2207D1A60165"_array32},
+    {{S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::Ocean)},
+     "7283FB1EFBD42438DADF363FDB776ED355C98737A2AAE75D0E9283CE1C12A2E4"_array32},
+    {{S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::Ocean)},
+     "9881C2D3AB70B14C8AA12016FC73ADAD93C6AD9FB59A9ECAD312B6F89E2413EC"_array32},
+    {{S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::Ocean)},
+     "eaa6a8d242b89e174928fa9549a0f66ec1562e2576fac896f438a2b3c1fb6005"_array32},
+    {{S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::System)},
+     "194CF6BD14554DA8D457E14CBFE04E55C8FB8CA52E0AFB3D7CB7084AE435B801"_array32},
+    {{S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::System)},
+     "CE1DB7BB6E5962384889DB7A396AFD614F82F69DC38A33D2DEAF47F3E4B964B7"_array32},
+    {{S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::System)},
+     "42238DE5685DEF4FDE7BE42C0097CEB92447006386D6B5D5AAA2C9AFD2E28422"_array32},
+    {{S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::System)},
+     "1F6847F268E9D9C5D1AD4D7E226A63B833BF02071446957A962EF065521879C1"_array32},
+    {{S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::System)},
+     "644007f9913c3602399d4d75cc34faeb7f1faad18b23e34187b16fdc45f4980f"_array32},
+};
+
+std::unordered_map<KeyIndex<S256KeyType>, SHA256Hash> KeyManager::s256_hash_prod = {
+    {{S256KeyType::HEADER, 0, 0},
+     "8E03DE24818D96CE4F2A09B43AF979E679974F7570713A61EED8B314864A11D5"_array32},
+    {{S256KeyType::SD_SAVE, 0, 0},
+     "13020ee72d0f8b8f9112dc738b829fdb017102499a7c2259b52aeefc0a273f5c"_array32},
+    {{S256KeyType::SD_NCA, 0, 0},
+     "8a1c05b4f88bae5b04d77f632e6acfc8893c4a05fd701f53585daafc996b532a"_array32},
+};
+
+// TODO(DarkLordZach): Find missing hashes for dev keys.
+
+std::unordered_map<KeyIndex<S128KeyType>, SHA256Hash> KeyManager::s128_hash_dev = {
+    {{S128KeyType::MASTER, 0, 0},
+     "779dd8b533a2fb670f27b308cb8d0151c4a107568b817429172b7f80aa592c25"_array32},
+    {{S128KeyType::MASTER, 1, 0},
+     "0175c8bc49771576f75527be719098db4ebaf77707206749415663aa3a9ea9cc"_array32},
+    {{S128KeyType::MASTER, 2, 0},
+     "4f0b4d724e5a8787268157c7ce0767c26d2e2021832aa7020f306d6e260eea42"_array32},
+    {{S128KeyType::MASTER, 3, 0},
+     "7b5a29586c1f84f66fbfabb94518fc45408bb8e5445253d063dda7cfef2a818c"_array32},
+    {{S128KeyType::MASTER, 4, 0},
+     "87a61dbb05a8755de7fe069562aab38ebfb266c9eb835f09fa62dacc89c98341"_array32},
+    {{S128KeyType::PACKAGE1, 0, 0},
+     "166510bc63ae50391ebe4ee4ff90ca31cd0e2dd0ff6be839a2f573ec146cc23a"_array32},
+    {{S128KeyType::PACKAGE1, 1, 0},
+     "f74cd01b86743139c920ec54a8116c669eea805a0be1583e13fc5bc8de68645b"_array32},
+    {{S128KeyType::PACKAGE1, 2, 0},
+     "d0cdecd513bb6aa3d9dc6244c977dc8a5a7ea157d0a8747d79e7581146e1f768"_array32},
+    {{S128KeyType::PACKAGE1, 3, 0},
+     "aa39394d626b3b79f5b7ccc07378b5996b6d09bf0eb6771b0b40c9077fbfde8c"_array32},
+    {{S128KeyType::PACKAGE1, 4, 0},
+     "8f4754b8988c0e673fc2bbea0534cdd6075c815c9270754ae980aef3e4f0a508"_array32},
+    {{S128KeyType::PACKAGE2, 0, 0},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::PACKAGE2, 1, 0},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::PACKAGE2, 2, 0},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::PACKAGE2, 3, 0},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::PACKAGE2, 4, 0},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::TITLEKEK, 0, 0},
+     "C2FA30CAC6AE1680466CB54750C24550E8652B3B6F38C30B49DADF067B5935E9"_array32},
+    {{S128KeyType::TITLEKEK, 1, 0},
+     "0D6B8F3746AD910D36438A859C11E8BE4310112425D63751D09B5043B87DE598"_array32},
+    {{S128KeyType::TITLEKEK, 2, 0},
+     "D09E18D3DB6BC7393536896F728528736FBEFCDD15C09D9D612FDE5C7BDCD821"_array32},
+    {{S128KeyType::TITLEKEK, 3, 0},
+     "47C6F9F7E99BB1F56DCDC93CDBD340EA82DCCD74DD8F3535ADA20ECF79D438ED"_array32},
+    {{S128KeyType::TITLEKEK, 4, 0},
+     "128610de8424cb29e08f9ee9a81c9e6ffd3c6662854aad0c8f937e0bcedc4d88"_array32},
+    {{S128KeyType::ETICKET_RSA_KEK, 0, 0},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::Application)},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::Application)},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::Application)},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::Application)},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::Application)},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::Ocean)},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::Ocean)},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::Ocean)},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::Ocean)},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::Ocean)},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::System)},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::System)},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::System)},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::System)},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::System)},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+};
+
+std::unordered_map<KeyIndex<S256KeyType>, SHA256Hash> KeyManager::s256_hash_dev = {
+    {{S256KeyType::HEADER, 0, 0},
+     "ecde86a76e37ac4fd7591d3aa55c00cc77d8595fc27968052ec18a177d939060"_array32},
+    {{S256KeyType::SD_SAVE, 0, 0},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+    {{S256KeyType::SD_NCA, 0, 0},
+     "0000000000000000000000000000000000000000000000000000000000000000"_array32},
+};
+
+std::unordered_map<std::string, KeyIndex<S128KeyType>> KeyManager::s128_file_id = {
+    {"master_key_00", {S128KeyType::MASTER, 0, 0}},
+    {"master_key_01", {S128KeyType::MASTER, 1, 0}},
+    {"master_key_02", {S128KeyType::MASTER, 2, 0}},
+    {"master_key_03", {S128KeyType::MASTER, 3, 0}},
+    {"master_key_04", {S128KeyType::MASTER, 4, 0}},
+    {"package1_key_00", {S128KeyType::PACKAGE1, 0, 0}},
+    {"package1_key_01", {S128KeyType::PACKAGE1, 1, 0}},
+    {"package1_key_02", {S128KeyType::PACKAGE1, 2, 0}},
+    {"package1_key_03", {S128KeyType::PACKAGE1, 3, 0}},
+    {"package1_key_04", {S128KeyType::PACKAGE1, 4, 0}},
+    {"package2_key_00", {S128KeyType::PACKAGE2, 0, 0}},
+    {"package2_key_01", {S128KeyType::PACKAGE2, 1, 0}},
+    {"package2_key_02", {S128KeyType::PACKAGE2, 2, 0}},
+    {"package2_key_03", {S128KeyType::PACKAGE2, 3, 0}},
+    {"package2_key_04", {S128KeyType::PACKAGE2, 4, 0}},
+    {"titlekek_00", {S128KeyType::TITLEKEK, 0, 0}},
+    {"titlekek_01", {S128KeyType::TITLEKEK, 1, 0}},
+    {"titlekek_02", {S128KeyType::TITLEKEK, 2, 0}},
+    {"titlekek_03", {S128KeyType::TITLEKEK, 3, 0}},
+    {"titlekek_04", {S128KeyType::TITLEKEK, 4, 0}},
+    {"eticket_rsa_kek", {S128KeyType::ETICKET_RSA_KEK, 0, 0}},
+    {"key_area_key_application_00",
+     {S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::Application)}},
+    {"key_area_key_application_01",
+     {S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::Application)}},
+    {"key_area_key_application_02",
+     {S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::Application)}},
+    {"key_area_key_application_03",
+     {S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::Application)}},
+    {"key_area_key_application_04",
+     {S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::Application)}},
+    {"key_area_key_ocean_00", {S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::Ocean)}},
+    {"key_area_key_ocean_01", {S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::Ocean)}},
+    {"key_area_key_ocean_02", {S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::Ocean)}},
+    {"key_area_key_ocean_03", {S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::Ocean)}},
+    {"key_area_key_ocean_04", {S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::Ocean)}},
+    {"key_area_key_system_00",
+     {S128KeyType::KEY_AREA, 0, static_cast<u64>(KeyAreaKeyType::System)}},
+    {"key_area_key_system_01",
+     {S128KeyType::KEY_AREA, 1, static_cast<u64>(KeyAreaKeyType::System)}},
+    {"key_area_key_system_02",
+     {S128KeyType::KEY_AREA, 2, static_cast<u64>(KeyAreaKeyType::System)}},
+    {"key_area_key_system_03",
+     {S128KeyType::KEY_AREA, 3, static_cast<u64>(KeyAreaKeyType::System)}},
+    {"key_area_key_system_04",
+     {S128KeyType::KEY_AREA, 4, static_cast<u64>(KeyAreaKeyType::System)}},
+};
+
+std::unordered_map<std::string, KeyIndex<S256KeyType>> KeyManager::s256_file_id = {
+    {"header_key", {S256KeyType::HEADER, 0, 0}},
+    {"sd_card_save_key", {S256KeyType::SD_SAVE, 0, 0}},
+    {"sd_card_nca_key", {S256KeyType::SD_NCA, 0, 0}},
+};
+
+static u8 ToHexNibble(char c1) {
+    if (c1 >= 65 && c1 <= 70)
+        return c1 - 55;
+    if (c1 >= 97 && c1 <= 102)
+        return c1 - 87;
+    if (c1 >= 48 && c1 <= 57)
+        return c1 - 48;
+    throw std::logic_error("Invalid hex digit");
+}
+
+template <size_t Size>
+static std::array<u8, Size> HexStringToArray(std::string_view str) {
+    std::array<u8, Size> out{};
+    for (size_t i = 0; i < 2 * Size; i += 2) {
+        auto d1 = str[i];
+        auto d2 = str[i + 1];
+        out[i / 2] = (ToHexNibble(d1) << 4) | ToHexNibble(d2);
+    }
+    return out;
+}
+
+std::array<u8, 16> operator""_array16(const char* str, size_t len) {
+    if (len != 32)
+        throw std::logic_error("Not of correct size.");
+    return HexStringToArray<16>(str);
+}
+
+std::array<u8, 32> operator""_array32(const char* str, size_t len) {
+    if (len != 64)
+        throw std::logic_error("Not of correct size.");
+    return HexStringToArray<32>(str);
+}
+
+void KeyManager::SetValidationMode(bool dev) {
+    dev_mode = dev;
+}
+
+void KeyManager::LoadFromFile(std::string_view filename_, bool is_title_keys) {
+    const auto filename = std::string(filename_);
+    std::ifstream file(filename);
+    if (!file.is_open())
+        return;
+
+    std::string line;
+    while (std::getline(file, line)) {
+        std::vector<std::string> out;
+        std::stringstream stream(line);
+        std::string item;
+        while (std::getline(stream, item, '='))
+            out.push_back(std::move(item));
+
+        if (out.size() != 2)
+            continue;
+
+        out[0].erase(std::remove(out[0].begin(), out[0].end(), ' '), out[0].end());
+        out[1].erase(std::remove(out[1].begin(), out[1].end(), ' '), out[1].end());
+
+        if (is_title_keys) {
+            auto rights_id_raw = HexStringToArray<16>(out[0]);
+            u128 rights_id = *reinterpret_cast<std::array<u64, 2>*>(&rights_id_raw);
+            Key128 key = HexStringToArray<16>(out[1]);
+            SetKey(S128KeyType::TITLEKEY, key, rights_id[1], rights_id[0]);
+        } else {
+            std::transform(out[0].begin(), out[0].end(), out[0].begin(), ::tolower);
+            if (s128_file_id.find(out[0]) != s128_file_id.end()) {
+                const auto index = s128_file_id[out[0]];
+                Key128 key = HexStringToArray<16>(out[1]);
+                SetKey(index.type, key, index.field1, index.field2);
+            } else if (s256_file_id.find(out[0]) != s256_file_id.end()) {
+                const auto index = s256_file_id[out[0]];
+                Key256 key = HexStringToArray<32>(out[1]);
+                SetKey(index.type, key, index.field1, index.field2);
+            }
+        }
+    }
+}
+
+bool KeyManager::HasKey(S128KeyType id, u64 field1, u64 field2) {
+    return s128_keys.find({id, field1, field2}) != s128_keys.end();
+}
+
+bool KeyManager::HasKey(S256KeyType id, u64 field1, u64 field2) {
+    return s256_keys.find({id, field1, field2}) != s256_keys.end();
+}
+
+Key128 KeyManager::GetKey(S128KeyType id, u64 field1, u64 field2) {
+    if (!HasKey(id, field1, field2))
+        return {};
+    return s128_keys[{id, field1, field2}];
+}
+
+Key256 KeyManager::GetKey(S256KeyType id, u64 field1, u64 field2) {
+    if (!HasKey(id, field1, field2))
+        return {};
+    return s256_keys[{id, field1, field2}];
+}
+
+void KeyManager::SetKey(S128KeyType id, Key128 key, u64 field1, u64 field2) {
+    s128_keys[{id, field1, field2}] = key;
+}
+
+void KeyManager::SetKey(S256KeyType id, Key256 key, u64 field1, u64 field2) {
+    s256_keys[{id, field1, field2}] = key;
+}
+
+bool KeyManager::ValidateKey(S128KeyType key, u64 field1, u64 field2) {
+    auto& hash = dev_mode ? s128_hash_dev : s128_hash_prod;
+
+    KeyIndex<S128KeyType> id = {key, field1, field2};
+    if (key == S128KeyType::SD_SEED || key == S128KeyType::TITLEKEY ||
+        hash.find(id) == hash.end()) {
+        LOG_WARNING(Crypto, "Could not validate [{}]", id.DebugInfo());
+        return true;
+    }
+
+    if (!HasKey(key, field1, field2)) {
+        LOG_CRITICAL(Crypto,
+                     "System has requested validation of [{}], but user has not added it. Add this "
+                     "key to use functionality.",
+                     id.DebugInfo());
+        return false;
+    }
+
+    SHA256Hash key_hash{};
+    const auto a_key = GetKey(key, field1, field2);
+    mbedtls_sha256(a_key.data(), a_key.size(), key_hash.data(), 0);
+    if (key_hash != hash[id]) {
+        LOG_CRITICAL(Crypto,
+                     "The hash of the provided key for [{}] does not match the one on file. This "
+                     "means you probably have an incorrect key. If you believe this to be in "
+                     "error, contact the yuzu devs.",
+                     id.DebugInfo());
+        return false;
+    }
+
+    return true;
+}
+
+bool KeyManager::ValidateKey(S256KeyType key, u64 field1, u64 field2) {
+    auto& hash = dev_mode ? s256_hash_dev : s256_hash_prod;
+
+    KeyIndex<S256KeyType> id = {key, field1, field2};
+    if (hash.find(id) == hash.end()) {
+        LOG_ERROR(Crypto, "Could not validate [{}]", id.DebugInfo());
+        return true;
+    }
+
+    if (!HasKey(key, field1, field2)) {
+        LOG_ERROR(Crypto,
+                  "System has requested validation of [{}], but user has not added it. Add this "
+                  "key to use functionality.",
+                  id.DebugInfo());
+        return false;
+    }
+
+    SHA256Hash key_hash{};
+    const auto a_key = GetKey(key, field1, field2);
+    mbedtls_sha256(a_key.data(), a_key.size(), key_hash.data(), 0);
+    if (key_hash != hash[id]) {
+        LOG_CRITICAL(Crypto,
+                     "The hash of the provided key for [{}] does not match the one on file. This "
+                     "means you probably have an incorrect key. If you believe this to be in "
+                     "error, contact the yuzu devs.",
+                     id.DebugInfo());
+        return false;
+    }
+
+    return true;
+}
+} // namespace Crypto

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -1,0 +1,116 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+#include <array>
+#include <unordered_map>
+#include <vector>
+#include "common/common_types.h"
+
+namespace Crypto {
+
+typedef std::array<u8, 0x10> Key128;
+typedef std::array<u8, 0x20> Key256;
+typedef std::array<u8, 0x20> SHA256Hash;
+
+static_assert(sizeof(Key128) == 16, "Key128 must be 128 bytes big.");
+static_assert(sizeof(Key256) == 32, "Key128 must be 128 bytes big.");
+
+enum class S256KeyType : u64 {
+    HEADER,  //
+    SD_SAVE, //
+    SD_NCA,  //
+};
+
+enum class S128KeyType : u64 {
+    MASTER,          // f1=crypto revision
+    PACKAGE1,        // f1=crypto revision
+    PACKAGE2,        // f1=crypto revision
+    TITLEKEK,        // f1=crypto revision
+    ETICKET_RSA_KEK, //
+    KEY_AREA,        // f1=crypto revision f2=type {app, ocean, system}
+    SD_SEED,         //
+    TITLEKEY,        // f1=rights id LSB f2=rights id MSB
+};
+
+enum class KeyAreaKeyType : u8 {
+    Application,
+    Ocean,
+    System,
+};
+
+template <typename KeyType>
+struct KeyIndex {
+    KeyType type;
+    u64 field1;
+    u64 field2;
+
+    std::string DebugInfo() {
+        u8 key_size = 16;
+        if (std::is_same_v<KeyType, S256KeyType>)
+            key_size = 32;
+        return fmt::format("key_size={:02X}, key={:02X}, field1={:016X}, field2={:016X}", key_size,
+                           static_cast<u8>(type), field1, field2);
+    }
+};
+
+// The following two (== and hash) are so KeyIndex can be a key in unordered_map
+
+template <typename KeyType>
+bool operator==(const KeyIndex<KeyType>& lhs, const KeyIndex<KeyType>& rhs) {
+    return lhs.type == rhs.type && lhs.field1 == rhs.field1 && lhs.field2 == rhs.field2;
+}
+
+} // namespace Crypto
+
+namespace std {
+template <typename KeyType>
+struct hash<Crypto::KeyIndex<KeyType>> {
+    size_t operator()(const Crypto::KeyIndex<KeyType>& k) const {
+        using std::hash;
+
+        return ((hash<u64>()(static_cast<u64>(k.type)) ^ (hash<u64>()(k.field1) << 1)) >> 1) ^
+               (hash<u64>()(k.field2) << 1);
+    }
+};
+} // namespace std
+
+namespace Crypto {
+
+std::array<u8, 0x10> operator"" _array16(const char* str, size_t len);
+std::array<u8, 0x20> operator"" _array32(const char* str, size_t len);
+
+struct KeyManager {
+    void SetValidationMode(bool dev);
+    void LoadFromFile(std::string_view filename, bool is_title_keys);
+
+    bool HasKey(S128KeyType id, u64 field1 = 0, u64 field2 = 0);
+    bool HasKey(S256KeyType id, u64 field1 = 0, u64 field2 = 0);
+
+    Key128 GetKey(S128KeyType id, u64 field1 = 0, u64 field2 = 0);
+    Key256 GetKey(S256KeyType id, u64 field1 = 0, u64 field2 = 0);
+
+    void SetKey(S128KeyType id, Key128 key, u64 field1 = 0, u64 field2 = 0);
+    void SetKey(S256KeyType id, Key256 key, u64 field1 = 0, u64 field2 = 0);
+
+    bool ValidateKey(S128KeyType key, u64 field1 = 0, u64 field2 = 0);
+    bool ValidateKey(S256KeyType key, u64 field1 = 0, u64 field2 = 0);
+
+private:
+    std::unordered_map<KeyIndex<S128KeyType>, Key128> s128_keys;
+    std::unordered_map<KeyIndex<S256KeyType>, Key256> s256_keys;
+
+    bool dev_mode = false;
+
+    static std::unordered_map<KeyIndex<S128KeyType>, SHA256Hash> s128_hash_prod;
+    static std::unordered_map<KeyIndex<S256KeyType>, SHA256Hash> s256_hash_prod;
+    static std::unordered_map<KeyIndex<S128KeyType>, SHA256Hash> s128_hash_dev;
+    static std::unordered_map<KeyIndex<S256KeyType>, SHA256Hash> s256_hash_dev;
+    static std::unordered_map<std::string, KeyIndex<S128KeyType>> s128_file_id;
+    static std::unordered_map<std::string, KeyIndex<S256KeyType>> s256_file_id;
+};
+
+extern KeyManager keys;
+
+} // namespace Crypto

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -107,6 +107,8 @@ private:
 
     bool dev_mode;
     void LoadFromFile(std::string_view filename, bool is_title_keys);
+    void AttemptLoadKeyFile(std::string_view dir1, std::string_view dir2, std::string_view filename,
+                            bool title);
 
     static std::unordered_map<std::string, KeyIndex<S128KeyType>> s128_file_id;
     static std::unordered_map<std::string, KeyIndex<S256KeyType>> s256_file_id;

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -6,6 +6,7 @@
 #include <array>
 #include <unordered_map>
 #include <vector>
+#include <fmt/format.h>
 #include "common/common_types.h"
 
 namespace Crypto {

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 #include <fmt/format.h>
@@ -50,7 +51,7 @@ struct KeyIndex {
 
     std::string DebugInfo() const {
         u8 key_size = 16;
-        if (std::is_same_v<KeyType, S256KeyType>)
+        if constexpr (std::is_same_v<KeyType, S256KeyType>)
             key_size = 32;
         return fmt::format("key_size={:02X}, key={:02X}, field1={:016X}, field2={:016X}", key_size,
                            static_cast<u8>(type), field1, field2);
@@ -110,7 +111,7 @@ private:
     void AttemptLoadKeyFile(std::string_view dir1, std::string_view dir2, std::string_view filename,
                             bool title);
 
-    static std::unordered_map<std::string, KeyIndex<S128KeyType>> s128_file_id;
-    static std::unordered_map<std::string, KeyIndex<S256KeyType>> s256_file_id;
+    const static std::unordered_map<std::string, KeyIndex<S128KeyType>> s128_file_id;
+    const static std::unordered_map<std::string, KeyIndex<S256KeyType>> s256_file_id;
 };
 } // namespace Core::Crypto

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -111,7 +111,7 @@ private:
     void AttemptLoadKeyFile(std::string_view dir1, std::string_view dir2, std::string_view filename,
                             bool title);
 
-    const static std::unordered_map<std::string, KeyIndex<S128KeyType>> s128_file_id;
-    const static std::unordered_map<std::string, KeyIndex<S256KeyType>> s256_file_id;
+    static const std::unordered_map<std::string, KeyIndex<S128KeyType>> s128_file_id;
+    static const std::unordered_map<std::string, KeyIndex<S256KeyType>> s256_file_id;
 };
 } // namespace Core::Crypto

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -3,36 +3,37 @@
 // Refer to the license.txt file included.
 
 #pragma once
+
 #include <array>
 #include <unordered_map>
 #include <vector>
 #include <fmt/format.h>
 #include "common/common_types.h"
 
-namespace Crypto {
+namespace Core::Crypto {
 
-typedef std::array<u8, 0x10> Key128;
-typedef std::array<u8, 0x20> Key256;
-typedef std::array<u8, 0x20> SHA256Hash;
+using Key128 = std::array<u8, 0x10>;
+using Key256 = std::array<u8, 0x20>;
+using SHA256Hash = std::array<u8, 0x20>;
 
 static_assert(sizeof(Key128) == 16, "Key128 must be 128 bytes big.");
 static_assert(sizeof(Key256) == 32, "Key128 must be 128 bytes big.");
 
 enum class S256KeyType : u64 {
-    HEADER,  //
-    SD_SAVE, //
-    SD_NCA,  //
+    Header, //
+    SDSave, //
+    SDNCA,  //
 };
 
 enum class S128KeyType : u64 {
-    MASTER,          // f1=crypto revision
-    PACKAGE1,        // f1=crypto revision
-    PACKAGE2,        // f1=crypto revision
-    TITLEKEK,        // f1=crypto revision
-    ETICKET_RSA_KEK, //
-    KEY_AREA,        // f1=crypto revision f2=type {app, ocean, system}
-    SD_SEED,         //
-    TITLEKEY,        // f1=rights id LSB f2=rights id MSB
+    Master,        // f1=crypto revision
+    Package1,      // f1=crypto revision
+    Package2,      // f1=crypto revision
+    Titlekek,      // f1=crypto revision
+    ETicketRSAKek, //
+    KeyArea,       // f1=crypto revision f2=type {app, ocean, system}
+    SDSeed,        //
+    Titlekey,      // f1=rights id LSB f2=rights id MSB
 };
 
 enum class KeyAreaKeyType : u8 {
@@ -47,7 +48,7 @@ struct KeyIndex {
     u64 field1;
     u64 field2;
 
-    std::string DebugInfo() {
+    std::string DebugInfo() const {
         u8 key_size = 16;
         if (std::is_same_v<KeyType, S256KeyType>)
             key_size = 32;
@@ -60,15 +61,20 @@ struct KeyIndex {
 
 template <typename KeyType>
 bool operator==(const KeyIndex<KeyType>& lhs, const KeyIndex<KeyType>& rhs) {
-    return lhs.type == rhs.type && lhs.field1 == rhs.field1 && lhs.field2 == rhs.field2;
+    return std::tie(lhs.type, lhs.field1, lhs.field2) == std::tie(rhs.type, rhs.field1, rhs.field2);
 }
 
-} // namespace Crypto
+template <typename KeyType>
+bool operator!=(const KeyIndex<KeyType>& lhs, const KeyIndex<KeyType>& rhs) {
+    return !operator==(lhs, rhs);
+}
+
+} // namespace Core::Crypto
 
 namespace std {
 template <typename KeyType>
-struct hash<Crypto::KeyIndex<KeyType>> {
-    size_t operator()(const Crypto::KeyIndex<KeyType>& k) const {
+struct hash<Core::Crypto::KeyIndex<KeyType>> {
+    size_t operator()(const Core::Crypto::KeyIndex<KeyType>& k) const {
         using std::hash;
 
         return ((hash<u64>()(static_cast<u64>(k.type)) ^ (hash<u64>()(k.field1) << 1)) >> 1) ^
@@ -77,41 +83,32 @@ struct hash<Crypto::KeyIndex<KeyType>> {
 };
 } // namespace std
 
-namespace Crypto {
+namespace Core::Crypto {
 
 std::array<u8, 0x10> operator"" _array16(const char* str, size_t len);
 std::array<u8, 0x20> operator"" _array32(const char* str, size_t len);
 
-struct KeyManager {
-    void SetValidationMode(bool dev);
-    void LoadFromFile(std::string_view filename, bool is_title_keys);
+class KeyManager {
+public:
+    KeyManager();
 
-    bool HasKey(S128KeyType id, u64 field1 = 0, u64 field2 = 0);
-    bool HasKey(S256KeyType id, u64 field1 = 0, u64 field2 = 0);
+    bool HasKey(S128KeyType id, u64 field1 = 0, u64 field2 = 0) const;
+    bool HasKey(S256KeyType id, u64 field1 = 0, u64 field2 = 0) const;
 
-    Key128 GetKey(S128KeyType id, u64 field1 = 0, u64 field2 = 0);
-    Key256 GetKey(S256KeyType id, u64 field1 = 0, u64 field2 = 0);
+    Key128 GetKey(S128KeyType id, u64 field1 = 0, u64 field2 = 0) const;
+    Key256 GetKey(S256KeyType id, u64 field1 = 0, u64 field2 = 0) const;
 
     void SetKey(S128KeyType id, Key128 key, u64 field1 = 0, u64 field2 = 0);
     void SetKey(S256KeyType id, Key256 key, u64 field1 = 0, u64 field2 = 0);
-
-    bool ValidateKey(S128KeyType key, u64 field1 = 0, u64 field2 = 0);
-    bool ValidateKey(S256KeyType key, u64 field1 = 0, u64 field2 = 0);
 
 private:
     std::unordered_map<KeyIndex<S128KeyType>, Key128> s128_keys;
     std::unordered_map<KeyIndex<S256KeyType>, Key256> s256_keys;
 
-    bool dev_mode = false;
+    bool dev_mode;
+    void LoadFromFile(std::string_view filename, bool is_title_keys);
 
-    static std::unordered_map<KeyIndex<S128KeyType>, SHA256Hash> s128_hash_prod;
-    static std::unordered_map<KeyIndex<S256KeyType>, SHA256Hash> s256_hash_prod;
-    static std::unordered_map<KeyIndex<S128KeyType>, SHA256Hash> s128_hash_dev;
-    static std::unordered_map<KeyIndex<S256KeyType>, SHA256Hash> s256_hash_dev;
     static std::unordered_map<std::string, KeyIndex<S128KeyType>> s128_file_id;
     static std::unordered_map<std::string, KeyIndex<S256KeyType>> s256_file_id;
 };
-
-extern KeyManager keys;
-
-} // namespace Crypto
+} // namespace Core::Crypto

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -102,6 +102,8 @@ public:
     void SetKey(S128KeyType id, Key128 key, u64 field1 = 0, u64 field2 = 0);
     void SetKey(S256KeyType id, Key256 key, u64 field1 = 0, u64 field2 = 0);
 
+    static bool KeyFileExists(bool title);
+
 private:
     std::unordered_map<KeyIndex<S128KeyType>, Key128> s128_keys;
     std::unordered_map<KeyIndex<S256KeyType>, Key256> s256_keys;

--- a/src/core/crypto/sha_util.cpp
+++ b/src/core/crypto/sha_util.cpp
@@ -1,0 +1,5 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+namespace Crypto {} // namespace Crypto

--- a/src/core/crypto/sha_util.h
+++ b/src/core/crypto/sha_util.h
@@ -1,0 +1,20 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common/assert.h"
+#include "core/file_sys/vfs.h"
+#include "key_manager.h"
+#include "mbedtls/cipher.h"
+
+namespace Crypto {
+typedef std::array<u8, 0x20> SHA256Hash;
+
+inline SHA256Hash operator"" _HASH(const char* data, size_t len) {
+    if (len != 0x40)
+        return {};
+}
+
+} // namespace Crypto

--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -1,0 +1,150 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <array>
+#include <string>
+#include <core/loader/loader.h>
+#include "core/file_sys/card_image.h"
+#include "core/file_sys/partition_filesystem.h"
+#include "core/file_sys/vfs_offset.h"
+
+namespace FileSys {
+
+XCI::XCI(VirtualFile file_) : file(std::move(file_)), partitions(0x4) {
+    if (file->ReadObject(&header) != sizeof(GamecardHeader)) {
+        status = Loader::ResultStatus::ErrorInvalidFormat;
+        return;
+    }
+
+    if (header.magic != Common::MakeMagic('H', 'E', 'A', 'D')) {
+        status = Loader::ResultStatus::ErrorInvalidFormat;
+        return;
+    }
+
+    PartitionFilesystem main_hfs(
+        std::make_shared<OffsetVfsFile>(file, header.hfs_size, header.hfs_offset));
+
+    if (main_hfs.GetStatus() != Loader::ResultStatus::Success) {
+        status = main_hfs.GetStatus();
+        return;
+    }
+
+    const static std::array<std::string, 0x4> partition_names = {"update", "normal", "secure",
+                                                                 "logo"};
+
+    for (XCIPartition partition :
+         {XCIPartition::Update, XCIPartition::Normal, XCIPartition::Secure, XCIPartition::Logo}) {
+        auto raw = main_hfs.GetFile(partition_names[static_cast<size_t>(partition)]);
+        if (raw != nullptr)
+            partitions[static_cast<size_t>(partition)] = std::make_shared<PartitionFilesystem>(raw);
+    }
+
+    auto result = AddNCAFromPartition(XCIPartition::Secure);
+    if (result != Loader::ResultStatus::Success) {
+        status = result;
+        return;
+    }
+    result = AddNCAFromPartition(XCIPartition::Update);
+    if (result != Loader::ResultStatus::Success) {
+        status = result;
+        return;
+    }
+
+    result = AddNCAFromPartition(XCIPartition::Normal);
+    if (result != Loader::ResultStatus::Success) {
+        status = result;
+        return;
+    }
+
+    if (GetFormatVersion() >= 0x2) {
+        result = AddNCAFromPartition(XCIPartition::Logo);
+        if (result != Loader::ResultStatus::Success) {
+            status = result;
+            return;
+        }
+    }
+
+    status = Loader::ResultStatus::Success;
+}
+
+Loader::ResultStatus XCI::GetStatus() const {
+    return status;
+}
+
+VirtualDir XCI::GetPartition(XCIPartition partition) const {
+    return partitions[static_cast<size_t>(partition)];
+}
+
+VirtualDir XCI::GetSecurePartition() const {
+    return GetPartition(XCIPartition::Secure);
+}
+
+VirtualDir XCI::GetNormalPartition() const {
+    return GetPartition(XCIPartition::Normal);
+}
+
+VirtualDir XCI::GetUpdatePartition() const {
+    return GetPartition(XCIPartition::Update);
+}
+
+VirtualDir XCI::GetLogoPartition() const {
+    return GetPartition(XCIPartition::Logo);
+}
+
+std::shared_ptr<NCA> XCI::GetNCAByType(NCAContentType type) const {
+    for (const auto& nca : ncas) {
+        if (nca->GetType() == type)
+            return nca;
+    }
+
+    return nullptr;
+}
+
+VirtualFile XCI::GetNCAFileByType(NCAContentType type) const {
+    auto nca = GetNCAByType(type);
+    if (nca != nullptr)
+        return nca->GetBaseFile();
+    return nullptr;
+}
+
+std::vector<std::shared_ptr<VfsFile>> XCI::GetFiles() const {
+    return {};
+}
+
+std::vector<std::shared_ptr<VfsDirectory>> XCI::GetSubdirectories() const {
+    return std::vector<std::shared_ptr<VfsDirectory>>();
+}
+
+std::string XCI::GetName() const {
+    return file->GetName();
+}
+
+std::shared_ptr<VfsDirectory> XCI::GetParentDirectory() const {
+    return file->GetContainingDirectory();
+}
+
+bool XCI::ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) {
+    return false;
+}
+
+Loader::ResultStatus XCI::AddNCAFromPartition(XCIPartition part) {
+    if (partitions[static_cast<size_t>(part)] == nullptr) {
+        return Loader::ResultStatus::ErrorInvalidFormat;
+    }
+
+    for (VirtualFile file : partitions[static_cast<size_t>(part)]->GetFiles()) {
+        if (file->GetExtension() != "nca")
+            continue;
+        auto nca = std::make_shared<NCA>(file);
+        if (nca->GetStatus() == Loader::ResultStatus::Success)
+            ncas.push_back(std::move(nca));
+    }
+
+    return Loader::ResultStatus::Success;
+}
+
+u8 XCI::GetFormatVersion() const {
+    return GetLogoPartition() == nullptr ? 0x1 : 0x2;
+}
+} // namespace FileSys

--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -93,8 +93,9 @@ VirtualDir XCI::GetLogoPartition() const {
 }
 
 std::shared_ptr<NCA> XCI::GetNCAByType(NCAContentType type) const {
-    auto iter = std::find_if(ncas.begin(), ncas.end(),
-                             [type](std::shared_ptr<NCA> nca) { return nca->GetType() == type; });
+    const auto iter =
+        std::find_if(ncas.begin(), ncas.end(),
+                     [type](const std::shared_ptr<NCA>& nca) { return nca->GetType() == type; });
     return iter == ncas.end() ? nullptr : *iter;
 }
 

--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -45,6 +45,7 @@ XCI::XCI(VirtualFile file_) : file(std::move(file_)), partitions(0x4) {
         status = result;
         return;
     }
+
     result = AddNCAFromPartition(XCIPartition::Update);
     if (result != Loader::ResultStatus::Success) {
         status = result;

--- a/src/core/file_sys/card_image.h
+++ b/src/core/file_sys/card_image.h
@@ -4,10 +4,13 @@
 
 #pragma once
 
+#include <array>
 #include <vector>
+#include "common/common_types.h"
 #include "common/swap.h"
 #include "core/file_sys/content_archive.h"
 #include "core/file_sys/vfs.h"
+#include "core/loader/loader.h"
 
 namespace FileSys {
 

--- a/src/core/file_sys/card_image.h
+++ b/src/core/file_sys/card_image.h
@@ -1,0 +1,93 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <vector>
+#include "common/swap.h"
+#include "core/file_sys/content_archive.h"
+#include "core/file_sys/vfs.h"
+
+namespace FileSys {
+
+enum class GamecardSize : u8 {
+    S_1GB = 0xFA,
+    S_2GB = 0xF8,
+    S_4GB = 0xF0,
+    S_8GB = 0xE0,
+    S_16GB = 0xE1,
+    S_32GB = 0xE2,
+};
+
+struct GamecardInfo {
+    std::array<u8, 0x70> data;
+};
+static_assert(sizeof(GamecardInfo) == 0x70, "GamecardInfo has incorrect size.");
+
+struct GamecardHeader {
+    std::array<u8, 0x100> signature;
+    u32_le magic;
+    u32_le secure_area_start;
+    u32_le backup_area_start;
+    u8 kek_index;
+    GamecardSize size;
+    u8 header_version;
+    u8 flags;
+    u64_le package_id;
+    u64_le valid_data_end;
+    u128 info_iv;
+    u64_le hfs_offset;
+    u64_le hfs_size;
+    std::array<u8, 0x20> hfs_header_hash;
+    std::array<u8, 0x20> initial_data_hash;
+    u32_le secure_mode_flag;
+    u32_le title_key_flag;
+    u32_le key_flag;
+    u32_le normal_area_end;
+    GamecardInfo info;
+};
+static_assert(sizeof(GamecardHeader) == 0x200, "GamecardHeader has incorrect size.");
+
+enum class XCIPartition : u8 { Update, Normal, Secure, Logo };
+
+class XCI : public ReadOnlyVfsDirectory {
+public:
+    explicit XCI(VirtualFile file);
+
+    Loader::ResultStatus GetStatus() const;
+
+    u8 GetFormatVersion() const;
+
+    VirtualDir GetPartition(XCIPartition partition) const;
+    VirtualDir GetSecurePartition() const;
+    VirtualDir GetNormalPartition() const;
+    VirtualDir GetUpdatePartition() const;
+    VirtualDir GetLogoPartition() const;
+
+    std::shared_ptr<NCA> GetNCAByType(NCAContentType type) const;
+    VirtualFile GetNCAFileByType(NCAContentType type) const;
+
+    std::vector<std::shared_ptr<VfsFile>> GetFiles() const override;
+
+    std::vector<std::shared_ptr<VfsDirectory>> GetSubdirectories() const override;
+
+    std::string GetName() const override;
+
+    std::shared_ptr<VfsDirectory> GetParentDirectory() const override;
+
+protected:
+    bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
+
+private:
+    Loader::ResultStatus AddNCAFromPartition(XCIPartition part);
+
+    VirtualFile file;
+    GamecardHeader header{};
+
+    Loader::ResultStatus status;
+
+    std::vector<VirtualDir> partitions;
+    std::vector<std::shared_ptr<NCA>> ncas;
+};
+} // namespace FileSys

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -156,9 +156,9 @@ NCA::NCA(VirtualFile file_) : file(std::move(file_)) {
             encrypted = true;
         } else {
             if (!keys.HasKey(Core::Crypto::S256KeyType::Header))
-                status = Loader::ResultStatus::ErrorEncrypted;
+                status = Loader::ResultStatus::ErrorMissingKeys;
             else
-                status = Loader::ResultStatus::ErrorInvalidFormat;
+                status = Loader::ResultStatus::ErrorDecrypting;
             return;
         }
     }
@@ -194,6 +194,9 @@ NCA::NCA(VirtualFile file_) : file(std::move(file_)) {
             if (dec != nullptr) {
                 files.emplace_back();
                 romfs = files.back();
+            } else {
+                status = Loader::ResultStatus::ErrorMissingKeys;
+                return;
             }
         } else if (section.raw.header.filesystem_type == NCASectionFilesystemType::PFS0) {
             u64 offset = (static_cast<u64>(header.section_tables[i].media_offset) *
@@ -211,6 +214,9 @@ NCA::NCA(VirtualFile file_) : file(std::move(file_)) {
                     if (IsDirectoryExeFS(dirs.back()))
                         exefs = dirs.back();
                 }
+            } else {
+                status = Loader::ResultStatus::ErrorMissingKeys;
+                return;
             }
         }
     }

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -6,9 +6,12 @@
 #include <utility>
 
 #include "common/logging/log.h"
+#include "core/crypto/aes_util.h"
+#include "core/crypto/ctr_encryption_layer.h"
 #include "core/file_sys/content_archive.h"
 #include "core/file_sys/vfs_offset.h"
 #include "core/loader/loader.h"
+#include "mbedtls/cipher.h"
 #include "romfs.h"
 
 namespace FileSys {
@@ -29,10 +32,18 @@ enum class NCASectionFilesystemType : u8 {
 struct NCASectionHeaderBlock {
     INSERT_PADDING_BYTES(3);
     NCASectionFilesystemType filesystem_type;
-    u8 crypto_type;
+    NCASectionCryptoType crypto_type;
     INSERT_PADDING_BYTES(3);
 };
 static_assert(sizeof(NCASectionHeaderBlock) == 0x8, "NCASectionHeaderBlock has incorrect size.");
+
+struct NCASectionRaw {
+    NCASectionHeaderBlock header;
+    std::array<u8, 0x138> block_data;
+    std::array<u8, 0x8> section_ctr;
+    INSERT_PADDING_BYTES(0xB8);
+};
+static_assert(sizeof(NCASectionRaw) == 0x200, "NCASectionRaw has incorrect size.");
 
 struct PFS0Superblock {
     NCASectionHeaderBlock header_block;
@@ -43,62 +54,155 @@ struct PFS0Superblock {
     u64_le hash_table_size;
     u64_le pfs0_header_offset;
     u64_le pfs0_size;
-    INSERT_PADDING_BYTES(432);
+    INSERT_PADDING_BYTES(0x1B0);
 };
 static_assert(sizeof(PFS0Superblock) == 0x200, "PFS0Superblock has incorrect size.");
 
 struct RomFSSuperblock {
     NCASectionHeaderBlock header_block;
     IVFCHeader ivfc;
+    INSERT_PADDING_BYTES(0x118);
 };
-static_assert(sizeof(RomFSSuperblock) == 0xE8, "RomFSSuperblock has incorrect size.");
+static_assert(sizeof(RomFSSuperblock) == 0x200, "RomFSSuperblock has incorrect size.");
+
+union NCASectionHeader {
+    NCASectionRaw raw;
+    PFS0Superblock pfs0;
+    RomFSSuperblock romfs;
+};
+static_assert(sizeof(NCASectionHeader) == 0x200, "NCASectionHeader has incorrect size.");
+
+bool IsValidNCA(const NCAHeader& header) {
+    // TODO(DarkLordZach): Add NCA2/NCA0 support.
+    return header.magic == Common::MakeMagic('N', 'C', 'A', '3');
+}
+
+Crypto::Key128 NCA::GetKeyAreaKey(NCASectionCryptoType type) {
+    u8 master_key_id = header.crypto_type;
+    if (header.crypto_type_2 > master_key_id)
+        master_key_id = header.crypto_type_2;
+    if (master_key_id > 0)
+        --master_key_id;
+
+    std::vector<u8> key_area(header.key_area.begin(), header.key_area.end());
+    if (!Crypto::keys.ValidateKey(Crypto::S128KeyType::KEY_AREA, master_key_id, header.key_index)) {
+        status = Loader::ResultStatus::ErrorEncrypted;
+        return {};
+    }
+    Crypto::AESCipher<Crypto::Key128> cipher(
+        Crypto::keys.GetKey(Crypto::S128KeyType::KEY_AREA, master_key_id, header.key_index),
+        Crypto::Mode::ECB);
+    cipher.Transcode(key_area.data(), key_area.size(), key_area.data(), Crypto::Op::DECRYPT);
+
+    Crypto::Key128 out;
+    if (type == NCASectionCryptoType::XTS)
+        std::copy(key_area.begin(), key_area.begin() + 0x10, out.begin());
+    else if (type == NCASectionCryptoType::CTR)
+        std::copy(key_area.begin() + 0x20, key_area.begin() + 0x30, out.begin());
+    else
+        LOG_CRITICAL(Crypto, "Called GetKeyAreaKey on invalid NCASectionCryptoType type={:02X}",
+                     static_cast<u8>(type));
+
+    u128 out_128 = *reinterpret_cast<u128*>(&out);
+    LOG_DEBUG(Crypto, "called with crypto_rev={:02X}, kak_index={:02X}, key={:016X}{:016X}",
+              master_key_id, header.key_index, out_128[1], out_128[0]);
+
+    return out;
+}
+
+VirtualFile NCA::Decrypt(NCASectionHeader header, VirtualFile in, u64 starting_offset) {
+    if (!encrypted)
+        return in;
+
+    switch (header.raw.header.crypto_type) {
+    case NCASectionCryptoType::NONE:
+        LOG_DEBUG(Crypto, "called with mode=NONE");
+        return in;
+    case NCASectionCryptoType::CTR:
+        LOG_DEBUG(Crypto, "called with mode=CTR, starting_offset={:016X}", starting_offset);
+        {
+            auto out = std::make_shared<Crypto::CTREncryptionLayer>(
+                std::move(in), GetKeyAreaKey(NCASectionCryptoType::CTR), starting_offset);
+            std::vector<u8> iv(16, 0);
+            for (u8 i = 0; i < 8; ++i)
+                iv[i] = header.raw.section_ctr[0x8 - i - 1];
+            out->SetIV(iv);
+            return out;
+        }
+    case NCASectionCryptoType::XTS:
+        // TODO(DarkLordZach): Implement XTSEncryptionLayer and title key encryption.
+    default:
+        LOG_ERROR(Crypto, "called with unhandled crypto type={:02X}",
+                  static_cast<u8>(header.raw.header.crypto_type));
+        return nullptr;
+    }
+}
 
 NCA::NCA(VirtualFile file_) : file(std::move(file_)) {
     if (sizeof(NCAHeader) != file->ReadObject(&header))
-        LOG_CRITICAL(Loader, "File reader errored out during header read.");
+        LOG_ERROR(Loader, "File reader errored out during header read.");
+
+    encrypted = false;
 
     if (!IsValidNCA(header)) {
-        status = Loader::ResultStatus::ErrorInvalidFormat;
-        return;
+        NCAHeader dec_header{};
+        if (!Crypto::keys.ValidateKey(Crypto::S256KeyType::HEADER)) {
+            status = Loader::ResultStatus::ErrorEncrypted;
+            return;
+        }
+        Crypto::AESCipher<Crypto::Key256> cipher(Crypto::keys.GetKey(Crypto::S256KeyType::HEADER),
+                                                 Crypto::Mode::XTS);
+        cipher.XTSTranscode(&header, sizeof(NCAHeader), &dec_header, 0, 0x200, Crypto::Op::DECRYPT);
+        if (IsValidNCA(dec_header)) {
+            header = dec_header;
+            encrypted = true;
+        } else {
+            status = Loader::ResultStatus::ErrorInvalidFormat;
+            return;
+        }
     }
 
-    std::ptrdiff_t number_sections =
+    const std::ptrdiff_t number_sections =
         std::count_if(std::begin(header.section_tables), std::end(header.section_tables),
                       [](NCASectionTableEntry entry) { return entry.media_offset > 0; });
 
+    std::vector<NCASectionHeader> sections(number_sections);
+    const auto length_sections = SECTION_HEADER_SIZE * number_sections;
+
+    if (encrypted) {
+        auto raw = file->ReadBytes(length_sections, SECTION_HEADER_OFFSET);
+        if (!Crypto::keys.ValidateKey(Crypto::S256KeyType::HEADER)) {
+            status = Loader::ResultStatus::ErrorEncrypted;
+            return;
+        }
+        Crypto::AESCipher<Crypto::Key256> cipher(Crypto::keys.GetKey(Crypto::S256KeyType::HEADER),
+                                                 Crypto::Mode::XTS);
+        cipher.XTSTranscode(raw.data(), length_sections, sections.data(), 2, SECTION_HEADER_SIZE,
+                            Crypto::Op::DECRYPT);
+    } else {
+        file->ReadBytes(sections.data(), length_sections, SECTION_HEADER_OFFSET);
+    }
+
     for (std::ptrdiff_t i = 0; i < number_sections; ++i) {
-        // Seek to beginning of this section.
-        NCASectionHeaderBlock block{};
-        if (sizeof(NCASectionHeaderBlock) !=
-            file->ReadObject(&block, SECTION_HEADER_OFFSET + i * SECTION_HEADER_SIZE))
-            LOG_CRITICAL(Loader, "File reader errored out during header read.");
+        auto section = sections[i];
 
-        if (block.filesystem_type == NCASectionFilesystemType::ROMFS) {
-            RomFSSuperblock sb{};
-            if (sizeof(RomFSSuperblock) !=
-                file->ReadObject(&sb, SECTION_HEADER_OFFSET + i * SECTION_HEADER_SIZE))
-                LOG_CRITICAL(Loader, "File reader errored out during header read.");
-
+        if (section.raw.header.filesystem_type == NCASectionFilesystemType::ROMFS) {
             const size_t romfs_offset =
                 header.section_tables[i].media_offset * MEDIA_OFFSET_MULTIPLIER +
-                sb.ivfc.levels[IVFC_MAX_LEVEL - 1].offset;
-            const size_t romfs_size = sb.ivfc.levels[IVFC_MAX_LEVEL - 1].size;
-            files.emplace_back(std::make_shared<OffsetVfsFile>(file, romfs_size, romfs_offset));
+                section.romfs.ivfc.levels[IVFC_MAX_LEVEL - 1].offset;
+            const size_t romfs_size = section.romfs.ivfc.levels[IVFC_MAX_LEVEL - 1].size;
+            files.emplace_back(
+                Decrypt(section, std::make_shared<OffsetVfsFile>(file, romfs_size, romfs_offset),
+                        romfs_offset));
             romfs = files.back();
-        } else if (block.filesystem_type == NCASectionFilesystemType::PFS0) {
-            PFS0Superblock sb{};
-            // Seek back to beginning of this section.
-            if (sizeof(PFS0Superblock) !=
-                file->ReadObject(&sb, SECTION_HEADER_OFFSET + i * SECTION_HEADER_SIZE))
-                LOG_CRITICAL(Loader, "File reader errored out during header read.");
-
+        } else if (section.raw.header.filesystem_type == NCASectionFilesystemType::PFS0) {
             u64 offset = (static_cast<u64>(header.section_tables[i].media_offset) *
                           MEDIA_OFFSET_MULTIPLIER) +
-                         sb.pfs0_header_offset;
+                         section.pfs0.pfs0_header_offset;
             u64 size = MEDIA_OFFSET_MULTIPLIER * (header.section_tables[i].media_end_offset -
                                                   header.section_tables[i].media_offset);
             auto npfs = std::make_shared<PartitionFilesystem>(
-                std::make_shared<OffsetVfsFile>(file, size, offset));
+                Decrypt(section, std::make_shared<OffsetVfsFile>(file, size, offset), offset));
 
             if (npfs->GetStatus() == Loader::ResultStatus::Success) {
                 dirs.emplace_back(npfs);
@@ -151,6 +255,10 @@ VirtualFile NCA::GetRomFS() const {
 
 VirtualDir NCA::GetExeFS() const {
     return exefs;
+}
+
+VirtualFile NCA::GetBaseFile() const {
+    return file;
 }
 
 bool NCA::ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) {

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -188,11 +188,11 @@ NCA::NCA(VirtualFile file_) : file(std::move(file_)) {
                 header.section_tables[i].media_offset * MEDIA_OFFSET_MULTIPLIER +
                 section.romfs.ivfc.levels[IVFC_MAX_LEVEL - 1].offset;
             const size_t romfs_size = section.romfs.ivfc.levels[IVFC_MAX_LEVEL - 1].size;
-            const auto dec =
+            auto dec =
                 Decrypt(section, std::make_shared<OffsetVfsFile>(file, romfs_size, romfs_offset),
                         romfs_offset);
             if (dec != nullptr) {
-                files.emplace_back();
+                files.push_back(std::move(dec));
                 romfs = files.back();
             } else {
                 status = Loader::ResultStatus::ErrorMissingKeys;
@@ -204,13 +204,13 @@ NCA::NCA(VirtualFile file_) : file(std::move(file_)) {
                          section.pfs0.pfs0_header_offset;
             u64 size = MEDIA_OFFSET_MULTIPLIER * (header.section_tables[i].media_end_offset -
                                                   header.section_tables[i].media_offset);
-            const auto dec =
+            auto dec =
                 Decrypt(section, std::make_shared<OffsetVfsFile>(file, size, offset), offset);
             if (dec != nullptr) {
-                auto npfs = std::make_shared<PartitionFilesystem>(dec);
+                auto npfs = std::make_shared<PartitionFilesystem>(std::move(dec));
 
                 if (npfs->GetStatus() == Loader::ResultStatus::Success) {
-                    dirs.emplace_back(npfs);
+                    dirs.push_back(std::move(npfs));
                     if (IsDirectoryExeFS(dirs.back()))
                         exefs = dirs.back();
                 }

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -76,7 +76,7 @@ bool IsValidNCA(const NCAHeader& header) {
     return header.magic == Common::MakeMagic('N', 'C', 'A', '3');
 }
 
-Core::Crypto::Key128 NCA::GetKeyAreaKey(NCASectionCryptoType type) {
+Core::Crypto::Key128 NCA::GetKeyAreaKey(NCASectionCryptoType type) const {
     u8 master_key_id = header.crypto_type;
     if (header.crypto_type_2 > master_key_id)
         master_key_id = header.crypto_type_2;
@@ -105,7 +105,7 @@ Core::Crypto::Key128 NCA::GetKeyAreaKey(NCASectionCryptoType type) {
     return out;
 }
 
-VirtualFile NCA::Decrypt(NCASectionHeader header, VirtualFile in, u64 starting_offset) {
+VirtualFile NCA::Decrypt(NCASectionHeader header, VirtualFile in, u64 starting_offset) const {
     if (!encrypted)
         return in;
 

--- a/src/core/file_sys/content_archive.h
+++ b/src/core/file_sys/content_archive.h
@@ -9,12 +9,12 @@
 #include <string>
 #include <vector>
 
-#include "core/loader/loader.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
 #include "core/crypto/key_manager.h"
 #include "core/file_sys/partition_filesystem.h"
+#include "core/loader/loader.h"
 
 namespace FileSys {
 enum class NCAContentType : u8 {
@@ -107,7 +107,8 @@ private:
 
     bool encrypted;
 
-    Crypto::Key128 GetKeyAreaKey(NCASectionCryptoType type);
+    Core::Crypto::KeyManager keys;
+    Core::Crypto::Key128 GetKeyAreaKey(NCASectionCryptoType type);
 
     VirtualFile Decrypt(NCASectionHeader header, VirtualFile in, u64 starting_offset);
 };

--- a/src/core/file_sys/content_archive.h
+++ b/src/core/file_sys/content_archive.h
@@ -17,6 +17,9 @@
 #include "core/loader/loader.h"
 
 namespace FileSys {
+
+union NCASectionHeader;
+
 enum class NCAContentType : u8 {
     Program = 0,
     Meta = 1,
@@ -61,8 +64,6 @@ struct NCAHeader {
 };
 static_assert(sizeof(NCAHeader) == 0x400, "NCAHeader has incorrect size.");
 
-union NCASectionHeader;
-
 inline bool IsDirectoryExeFS(const std::shared_ptr<VfsDirectory>& pfs) {
     // According to switchbrew, an exefs must only contain these two files:
     return pfs->GetFile("main") != nullptr && pfs->GetFile("main.npdm") != nullptr;
@@ -94,6 +95,9 @@ protected:
     bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
 
 private:
+    Core::Crypto::Key128 GetKeyAreaKey(NCASectionCryptoType type) const;
+    VirtualFile Decrypt(NCASectionHeader header, VirtualFile in, u64 starting_offset) const;
+
     std::vector<VirtualDir> dirs;
     std::vector<VirtualFile> files;
 
@@ -108,9 +112,6 @@ private:
     bool encrypted;
 
     Core::Crypto::KeyManager keys;
-    Core::Crypto::Key128 GetKeyAreaKey(NCASectionCryptoType type);
-
-    VirtualFile Decrypt(NCASectionHeader header, VirtualFile in, u64 starting_offset);
 };
 
 } // namespace FileSys

--- a/src/core/file_sys/content_archive.h
+++ b/src/core/file_sys/content_archive.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "core/loader/loader.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
@@ -108,7 +109,7 @@ private:
 
     Crypto::Key128 GetKeyAreaKey(NCASectionCryptoType type);
 
-    VirtualFile Decrypt(NCASectionHeader header, VirtualFile in, size_t starting_offset);
+    VirtualFile Decrypt(NCASectionHeader header, VirtualFile in, u64 starting_offset);
 };
 
 } // namespace FileSys

--- a/src/core/file_sys/content_archive.h
+++ b/src/core/file_sys/content_archive.h
@@ -8,7 +8,7 @@
 #include <memory>
 #include <string>
 #include <vector>
-
+#include <boost/optional.hpp>
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
@@ -95,7 +95,7 @@ protected:
     bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
 
 private:
-    Core::Crypto::Key128 GetKeyAreaKey(NCASectionCryptoType type) const;
+    boost::optional<Core::Crypto::Key128> GetKeyAreaKey(NCASectionCryptoType type) const;
     VirtualFile Decrypt(NCASectionHeader header, VirtualFile in, u64 starting_offset) const;
 
     std::vector<VirtualDir> dirs;

--- a/src/core/file_sys/vfs.cpp
+++ b/src/core/file_sys/vfs.cpp
@@ -285,6 +285,27 @@ bool ReadOnlyVfsDirectory::Rename(std::string_view name) {
     return false;
 }
 
+bool DeepEquals(const VirtualFile& file1, const VirtualFile& file2, size_t block_size) {
+    if (file1->GetSize() != file2->GetSize())
+        return false;
+
+    std::vector<u8> f1_v(block_size);
+    std::vector<u8> f2_v(block_size);
+    for (size_t i = 0; i < file1->GetSize(); i += block_size) {
+        auto f1_vs = file1->Read(f1_v.data(), block_size, i);
+        auto f2_vs = file2->Read(f2_v.data(), block_size, i);
+
+        if (f1_vs != f2_vs)
+            return false;
+        for (size_t j = 0; j < f1_vs; ++j) {
+            if (f1_v[j] != f2_v[j])
+                return false;
+        }
+    }
+
+    return true;
+}
+
 bool VfsRawCopy(VirtualFile src, VirtualFile dest) {
     if (src == nullptr || dest == nullptr)
         return false;

--- a/src/core/file_sys/vfs.cpp
+++ b/src/core/file_sys/vfs.cpp
@@ -297,10 +297,9 @@ bool DeepEquals(const VirtualFile& file1, const VirtualFile& file2, size_t block
 
         if (f1_vs != f2_vs)
             return false;
-        for (size_t j = 0; j < f1_vs; ++j) {
-            if (f1_v[j] != f2_v[j])
-                return false;
-        }
+        auto iters = std::mismatch(f1_v.begin(), f1_v.end(), f2_v.begin(), f2_v.end());
+        if (iters.first != f1_v.end() && iters.second != f2_v.end())
+            return false;
     }
 
     return true;

--- a/src/core/file_sys/vfs.h
+++ b/src/core/file_sys/vfs.h
@@ -245,6 +245,9 @@ struct ReadOnlyVfsDirectory : public VfsDirectory {
     bool Rename(std::string_view name) override;
 };
 
+// Compare the two files, byte-for-byte, in increments specificed by block_size
+bool DeepEquals(const VirtualFile& file1, const VirtualFile& file2, size_t block_size = 0x200);
+
 // A method that copies the raw data between two different implementations of VirtualFile. If you
 // are using the same implementation, it is probably better to use the Copy method in the parent
 // directory of src/dest.

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -13,6 +13,7 @@
 #include "core/loader/nca.h"
 #include "core/loader/nro.h"
 #include "core/loader/nso.h"
+#include "core/loader/xci.h"
 
 namespace Loader {
 
@@ -35,6 +36,7 @@ FileType IdentifyFile(FileSys::VirtualFile file) {
     CHECK_TYPE(NSO)
     CHECK_TYPE(NRO)
     CHECK_TYPE(NCA)
+    CHECK_TYPE(XCI)
 
 #undef CHECK_TYPE
 
@@ -60,6 +62,8 @@ FileType GuessFromFilename(const std::string& name) {
         return FileType::NSO;
     if (extension == "nca")
         return FileType::NCA;
+    if (extension == "xci")
+        return FileType::XCI;
 
     return FileType::Unknown;
 }
@@ -74,6 +78,8 @@ const char* GetFileTypeString(FileType type) {
         return "NSO";
     case FileType::NCA:
         return "NCA";
+    case FileType::XCI:
+        return "XCI";
     case FileType::DeconstructedRomDirectory:
         return "Directory";
     case FileType::Error:
@@ -110,6 +116,9 @@ static std::unique_ptr<AppLoader> GetFileLoader(FileSys::VirtualFile file, FileT
     // NX NCA file format.
     case FileType::NCA:
         return std::make_unique<AppLoader_NCA>(std::move(file));
+
+    case FileType::XCI:
+        return std::make_unique<AppLoader_XCI>(std::move(file));
 
     // NX deconstructed ROM directory.
     case FileType::DeconstructedRomDirectory:

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -31,6 +31,7 @@ enum class FileType {
     NSO,
     NRO,
     NCA,
+    XCI,
     DeconstructedRomDirectory,
 };
 

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -73,7 +73,8 @@ enum class ResultStatus {
     ErrorNotUsed,
     ErrorAlreadyLoaded,
     ErrorMemoryAllocationFailed,
-    ErrorEncrypted,
+    ErrorMissingKeys,
+    ErrorDecrypting,
     ErrorUnsupportedArch,
 };
 

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -49,6 +49,8 @@ ResultStatus AppLoader_XCI::Load(Kernel::SharedPtr<Kernel::Process>& process) {
     }
 
     if (xci->GetNCAFileByType(FileSys::NCAContentType::Program) == nullptr) {
+        if (!Core::Crypto::KeyManager::KeyFileExists(false))
+            return ResultStatus::ErrorMissingKeys;
         return ResultStatus::ErrorDecrypting;
     }
 

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -49,7 +49,7 @@ ResultStatus AppLoader_XCI::Load(Kernel::SharedPtr<Kernel::Process>& process) {
     }
 
     if (xci->GetNCAFileByType(FileSys::NCAContentType::Program) == nullptr) {
-        return ResultStatus::ErrorEncrypted;
+        return ResultStatus::ErrorDecrypting;
     }
 
     auto result = nca_loader->Load(process);

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -28,14 +28,17 @@ AppLoader_XCI::AppLoader_XCI(FileSys::VirtualFile file)
       nca_loader(std::make_unique<AppLoader_NCA>(
           xci->GetNCAFileByType(FileSys::NCAContentType::Program))) {}
 
+AppLoader_XCI::~AppLoader_XCI() = default;
+
 FileType AppLoader_XCI::IdentifyType(const FileSys::VirtualFile& file) {
     FileSys::XCI xci(file);
 
     if (xci.GetStatus() == ResultStatus::Success &&
         xci.GetNCAByType(FileSys::NCAContentType::Program) != nullptr &&
         AppLoader_NCA::IdentifyType(xci.GetNCAFileByType(FileSys::NCAContentType::Program)) ==
-            FileType::NCA)
+            FileType::NCA) {
         return FileType::XCI;
+    }
 
     return FileType::Error;
 }
@@ -61,7 +64,5 @@ ResultStatus AppLoader_XCI::ReadRomFS(FileSys::VirtualFile& dir) {
 ResultStatus AppLoader_XCI::ReadProgramId(u64& out_program_id) {
     return nca_loader->ReadProgramId(out_program_id);
 }
-
-AppLoader_XCI::~AppLoader_XCI() = default;
 
 } // namespace Loader

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -1,0 +1,67 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <vector>
+
+#include "common/file_util.h"
+#include "common/logging/log.h"
+#include "common/string_util.h"
+#include "common/swap.h"
+#include "core/core.h"
+#include "core/file_sys/content_archive.h"
+#include "core/file_sys/control_metadata.h"
+#include "core/file_sys/program_metadata.h"
+#include "core/file_sys/romfs.h"
+#include "core/gdbstub/gdbstub.h"
+#include "core/hle/kernel/process.h"
+#include "core/hle/kernel/resource_limit.h"
+#include "core/hle/service/filesystem/filesystem.h"
+#include "core/loader/nso.h"
+#include "core/loader/xci.h"
+#include "core/memory.h"
+
+namespace Loader {
+
+AppLoader_XCI::AppLoader_XCI(FileSys::VirtualFile file)
+    : AppLoader(file), xci(std::make_unique<FileSys::XCI>(file)),
+      nca_loader(std::make_unique<AppLoader_NCA>(
+          xci->GetNCAFileByType(FileSys::NCAContentType::Program))) {}
+
+FileType AppLoader_XCI::IdentifyType(const FileSys::VirtualFile& file) {
+    FileSys::XCI xci(file);
+
+    if (xci.GetStatus() == ResultStatus::Success &&
+        xci.GetNCAByType(FileSys::NCAContentType::Program) != nullptr &&
+        AppLoader_NCA::IdentifyType(xci.GetNCAFileByType(FileSys::NCAContentType::Program)) ==
+            FileType::NCA)
+        return FileType::XCI;
+
+    return FileType::Error;
+}
+
+ResultStatus AppLoader_XCI::Load(Kernel::SharedPtr<Kernel::Process>& process) {
+    if (is_loaded) {
+        return ResultStatus::ErrorAlreadyLoaded;
+    }
+
+    auto result = nca_loader->Load(process);
+    if (result != ResultStatus::Success)
+        return result;
+
+    is_loaded = true;
+
+    return ResultStatus::Success;
+}
+
+ResultStatus AppLoader_XCI::ReadRomFS(FileSys::VirtualFile& dir) {
+    return nca_loader->ReadRomFS(dir);
+}
+
+ResultStatus AppLoader_XCI::ReadProgramId(u64& out_program_id) {
+    return nca_loader->ReadProgramId(out_program_id);
+}
+
+AppLoader_XCI::~AppLoader_XCI() = default;
+
+} // namespace Loader

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -48,6 +48,10 @@ ResultStatus AppLoader_XCI::Load(Kernel::SharedPtr<Kernel::Process>& process) {
         return ResultStatus::ErrorAlreadyLoaded;
     }
 
+    if (xci->GetNCAFileByType(FileSys::NCAContentType::Program) == nullptr) {
+        return ResultStatus::ErrorEncrypted;
+    }
+
     auto result = nca_loader->Load(process);
     if (result != ResultStatus::Success)
         return result;

--- a/src/core/loader/xci.h
+++ b/src/core/loader/xci.h
@@ -4,7 +4,10 @@
 
 #pragma once
 
+#include <memory>
+#include "common/common_types.h"
 #include "core/file_sys/card_image.h"
+#include "core/loader/loader.h"
 #include "core/loader/nca.h"
 
 namespace Loader {

--- a/src/core/loader/xci.h
+++ b/src/core/loader/xci.h
@@ -4,19 +4,15 @@
 
 #pragma once
 
-#include <string>
-#include "common/common_types.h"
-#include "core/file_sys/content_archive.h"
-#include "core/file_sys/program_metadata.h"
-#include "core/hle/kernel/kernel.h"
-#include "core/loader/loader.h"
+#include "core/file_sys/card_image.h"
+#include "core/loader/nca.h"
 
 namespace Loader {
 
-/// Loads an NCA file
-class AppLoader_NCA final : public AppLoader {
+/// Loads an XCI file
+class AppLoader_XCI final : public AppLoader {
 public:
-    explicit AppLoader_NCA(FileSys::VirtualFile file);
+    explicit AppLoader_XCI(FileSys::VirtualFile file);
 
     /**
      * Returns the type of the file
@@ -32,15 +28,15 @@ public:
     ResultStatus Load(Kernel::SharedPtr<Kernel::Process>& process) override;
 
     ResultStatus ReadRomFS(FileSys::VirtualFile& dir) override;
-
     ResultStatus ReadProgramId(u64& out_program_id) override;
 
-    ~AppLoader_NCA();
+    ~AppLoader_XCI();
 
 private:
     FileSys::ProgramMetadata metadata;
 
-    std::unique_ptr<FileSys::NCA> nca;
+    std::unique_ptr<FileSys::XCI> xci;
+    std::unique_ptr<AppLoader_NCA> nca_loader;
 };
 
 } // namespace Loader

--- a/src/core/loader/xci.h
+++ b/src/core/loader/xci.h
@@ -13,6 +13,7 @@ namespace Loader {
 class AppLoader_XCI final : public AppLoader {
 public:
     explicit AppLoader_XCI(FileSys::VirtualFile file);
+    ~AppLoader_XCI();
 
     /**
      * Returns the type of the file
@@ -29,8 +30,6 @@ public:
 
     ResultStatus ReadRomFS(FileSys::VirtualFile& dir) override;
     ResultStatus ReadProgramId(u64& out_program_id) override;
-
-    ~AppLoader_XCI();
 
 private:
     FileSys::ProgramMetadata metadata;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -137,6 +137,8 @@ struct Values {
 
     std::string log_filter;
 
+    bool use_dev_keys;
+
     // Audio
     std::string sink_id;
     std::string audio_device_id;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -109,6 +109,7 @@ void Config::ReadValues() {
 
     qt_config->beginGroup("Miscellaneous");
     Settings::values.log_filter = qt_config->value("log_filter", "*:Info").toString().toStdString();
+    Settings::values.use_dev_keys = qt_config->value("use_dev_keys", false).toBool();
     qt_config->endGroup();
 
     qt_config->beginGroup("Debugging");
@@ -218,6 +219,7 @@ void Config::SaveValues() {
 
     qt_config->beginGroup("Miscellaneous");
     qt_config->setValue("log_filter", QString::fromStdString(Settings::values.log_filter));
+    qt_config->setValue("use_dev_keys", Settings::values.use_dev_keys);
     qt_config->endGroup();
 
     qt_config->beginGroup("Debugging");

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -365,7 +365,7 @@ void GameList::LoadInterfaceLayout() {
     item_model->sort(header->sortIndicatorSection(), header->sortIndicatorOrder());
 }
 
-const QStringList GameList::supported_file_extensions = {"nso", "nro", "nca"};
+const QStringList GameList::supported_file_extensions = {"nso", "nro", "nca", "xci"};
 
 static bool HasSupportedFileExtension(const std::string& file_name) {
     QFileInfo file = QFileInfo(file_name.c_str());

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -13,6 +13,7 @@
 #include <QMessageBox>
 #include <QtGui>
 #include <QtWidgets>
+#include <core/crypto/key_manager.h>
 #include "common/common_paths.h"
 #include "common/logging/backend.h"
 #include "common/logging/filter.h"
@@ -87,6 +88,19 @@ GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr) {
     setAcceptDrops(true);
     ui.setupUi(this);
     statusBar()->hide();
+
+    // Initialize keys
+    std::string keys_dir = FileUtil::GetHactoolConfigurationPath();
+    if (Settings::values.use_dev_keys) {
+        Crypto::keys.SetValidationMode(true);
+        if (FileUtil::Exists(keys_dir + DIR_SEP + "dev.keys"))
+            Crypto::keys.LoadFromFile(keys_dir + DIR_SEP + "dev.keys", false);
+    } else {
+        if (FileUtil::Exists(keys_dir + DIR_SEP + "prod.keys"))
+            Crypto::keys.LoadFromFile(keys_dir + DIR_SEP + "prod.keys", false);
+    }
+    if (FileUtil::Exists(keys_dir + DIR_SEP + "title.keys"))
+        Crypto::keys.LoadFromFile(keys_dir + DIR_SEP + "title.keys", true);
 
     default_theme_paths = QIcon::themeSearchPaths();
     UpdateUITheme();

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -456,7 +456,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
                 this, tr("Error while loading ROM!"),
                 tr(("The game you are trying to load is encrypted and the required keys to load "
                     "the game could not be found in your configuration. " +
-                    file_text + " Please refer to <a href=''>How to Dump Keys</a> for help.")
+                    file_text + " Please refer to the yuzu wiki for help.")
                        .c_str()));
             break;
         }
@@ -465,8 +465,8 @@ bool GMainWindow::LoadROM(const QString& filename) {
                 this, tr("Error while loading ROM!"),
                 tr("There was a general error while decrypting the game. This means that the keys "
                    "necessary were found, but were either incorrect, the game itself was not a "
-                   "valid game or the game uses an unhandled cryptographic scheme. Please refer to "
-                   "<a href=''>How to Dump Keys</a> to double check that you have the correct "
+                   "valid game or the game uses an unhandled cryptographic scheme. Please double "
+                   "check that you have the correct "
                    "keys."));
             break;
         }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -13,7 +13,6 @@
 #include <QMessageBox>
 #include <QtGui>
 #include <QtWidgets>
-#include <core/crypto/key_manager.h>
 #include "common/common_paths.h"
 #include "common/logging/backend.h"
 #include "common/logging/filter.h"
@@ -24,6 +23,7 @@
 #include "common/scope_exit.h"
 #include "common/string_util.h"
 #include "core/core.h"
+#include "core/crypto/key_manager.h"
 #include "core/gdbstub/gdbstub.h"
 #include "core/loader/loader.h"
 #include "core/settings.h"
@@ -88,19 +88,6 @@ GMainWindow::GMainWindow() : config(new Config()), emu_thread(nullptr) {
     setAcceptDrops(true);
     ui.setupUi(this);
     statusBar()->hide();
-
-    // Initialize keys
-    std::string keys_dir = FileUtil::GetHactoolConfigurationPath();
-    if (Settings::values.use_dev_keys) {
-        Crypto::keys.SetValidationMode(true);
-        if (FileUtil::Exists(keys_dir + DIR_SEP + "dev.keys"))
-            Crypto::keys.LoadFromFile(keys_dir + DIR_SEP + "dev.keys", false);
-    } else {
-        if (FileUtil::Exists(keys_dir + DIR_SEP + "prod.keys"))
-            Crypto::keys.LoadFromFile(keys_dir + DIR_SEP + "prod.keys", false);
-    }
-    if (FileUtil::Exists(keys_dir + DIR_SEP + "title.keys"))
-        Crypto::keys.LoadFromFile(keys_dir + DIR_SEP + "title.keys", true);
 
     default_theme_paths = QIcon::themeSearchPaths();
     UpdateUITheme();

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -119,6 +119,7 @@ void Config::ReadValues() {
 
     // Miscellaneous
     Settings::values.log_filter = sdl2_config->Get("Miscellaneous", "log_filter", "*:Trace");
+    Settings::values.use_dev_keys = sdl2_config->GetBoolean("Miscellaneous", "use_dev_keys", false);
 
     // Debugging
     Settings::values.use_gdbstub = sdl2_config->GetBoolean("Debugging", "use_gdbstub", false);

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -73,19 +73,6 @@ static void InitializeLogging() {
 int main(int argc, char** argv) {
     Config config;
 
-    // Initialize keys
-    std::string keys_dir = FileUtil::GetHactoolConfigurationPath();
-    if (Settings::values.use_dev_keys) {
-        Crypto::keys.SetValidationMode(true);
-        if (FileUtil::Exists(keys_dir + DIR_SEP + "dev.keys"))
-            Crypto::keys.LoadFromFile(keys_dir + DIR_SEP + "dev.keys", false);
-    } else {
-        if (FileUtil::Exists(keys_dir + DIR_SEP + "prod.keys"))
-            Crypto::keys.LoadFromFile(keys_dir + DIR_SEP + "prod.keys", false);
-    }
-    if (FileUtil::Exists(keys_dir + DIR_SEP + "title.keys"))
-        Crypto::keys.LoadFromFile(keys_dir + DIR_SEP + "title.keys", true);
-
     int option_index = 0;
     bool use_gdbstub = Settings::values.use_gdbstub;
     u32 gdb_port = static_cast<u32>(Settings::values.gdbstub_port);

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -175,13 +175,13 @@ int main(int argc, char** argv) {
         return -1;
     case Core::System::ResultStatus::ErrorLoader_ErrorMissingKeys:
         LOG_CRITICAL(Frontend, "The game you are trying to load is encrypted and the keys required "
-                               "could not be found. Please refer to <LINK> for help");
+                               "could not be found. Please refer to the yuzu wiki for help");
         return -1;
     case Core::System::ResultStatus::ErrorLoader_ErrorDecrypting:
         LOG_CRITICAL(Frontend, "The game you are trying to load is encrypted and there was a "
                                "general error while decrypting. This could mean that the keys are "
                                "incorrect, game is invalid or game uses an unsupported method of "
-                               "crypto. Please refer to <LINK> to double-check your keys");
+                               "crypto. Please double-check your keys");
         return -1;
     case Core::System::ResultStatus::ErrorLoader_ErrorInvalidFormat:
         LOG_CRITICAL(Frontend, "Error while loading ROM: The ROM format is not supported.");

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -173,11 +173,15 @@ int main(int argc, char** argv) {
     case Core::System::ResultStatus::ErrorLoader:
         LOG_CRITICAL(Frontend, "Failed to load ROM!");
         return -1;
-    case Core::System::ResultStatus::ErrorLoader_ErrorEncrypted:
-        LOG_CRITICAL(Frontend, "The game that you are trying to load must be decrypted before "
-                               "being used with yuzu. \n\n For more information on dumping and "
-                               "decrypting games, please refer to: "
-                               "https://yuzu-emu.org/wiki/dumping-game-cartridges/");
+    case Core::System::ResultStatus::ErrorLoader_ErrorMissingKeys:
+        LOG_CRITICAL(Frontend, "The game you are trying to load is encrypted and the keys required "
+                               "could not be found. Please refer to <LINK> for help");
+        return -1;
+    case Core::System::ResultStatus::ErrorLoader_ErrorDecrypting:
+        LOG_CRITICAL(Frontend, "The game you are trying to load is encrypted and there was a "
+                               "general error while decrypting. This could mean that the keys are "
+                               "incorrect, game is invalid or game uses an unsupported method of "
+                               "crypto. Please refer to <LINK> to double-check your keys");
         return -1;
     case Core::System::ResultStatus::ErrorLoader_ErrorInvalidFormat:
         LOG_CRITICAL(Frontend, "Error while loading ROM: The ROM format is not supported.");

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -23,6 +23,7 @@
 #include "yuzu_cmd/emu_window/emu_window_sdl2.h"
 
 #include <getopt.h>
+#include "core/crypto/key_manager.h"
 #ifndef _MSC_VER
 #include <unistd.h>
 #endif
@@ -71,6 +72,20 @@ static void InitializeLogging() {
 /// Application entry point
 int main(int argc, char** argv) {
     Config config;
+
+    // Initialize keys
+    std::string keys_dir = FileUtil::GetHactoolConfigurationPath();
+    if (Settings::values.use_dev_keys) {
+        Crypto::keys.SetValidationMode(true);
+        if (FileUtil::Exists(keys_dir + DIR_SEP + "dev.keys"))
+            Crypto::keys.LoadFromFile(keys_dir + DIR_SEP + "dev.keys", false);
+    } else {
+        if (FileUtil::Exists(keys_dir + DIR_SEP + "prod.keys"))
+            Crypto::keys.LoadFromFile(keys_dir + DIR_SEP + "prod.keys", false);
+    }
+    if (FileUtil::Exists(keys_dir + DIR_SEP + "title.keys"))
+        Crypto::keys.LoadFromFile(keys_dir + DIR_SEP + "title.keys", true);
+
     int option_index = 0;
     bool use_gdbstub = Settings::values.use_gdbstub;
     u32 gdb_port = static_cast<u32>(Settings::values.gdbstub_port);


### PR DESCRIPTION
First of all, a massive thanks to @SciresM and his amazing [hactool](https://github.com/sciresm/hactool). Without it, this probably would not have been possible.

**Technical Overview**
- Add [mbedtls](https://tls.mbed.org/) dependency for crypto operations. (Crypto++ from Citra couldn't be used due to a lack of AES-XTS support).
- `KeyManager` to contain/load keys. When needed, keys are loaded from the same place hactool loads them from. 
- Keys are stored in `%YUZU_DIR%/keys/prod.keys` if using production, `%YUZU_DIR%/keys/dev.keys` if using dev, and `%YUZU_DIR%/keys/title.keys` for titlekeys. (There is a fallback to the hactool config dir if the yuzu versions cannot be found)
- Dev mode (using dev keys) can be enabled by finding the `use_dev_mode` key in qt/sdl2 config (depending on frontend).
- Encryption implemented using VFS. `EncryptionLayer` is an incomplete class that overrides everything except `Read` in `VfsFile` to cut down on duplicate code in subclasses.
- `CTREncryptionLayer` for CTR-mode encryption scheme.
- `Key128`, `Key256`, `SHA256Hash` for convenience (typedefs of `std::array<u8, *>`)
- `AESCipher<KeyType>` added as a C++ wrapper around mbedtls.

**Feature Overview**
- Supports the running of encrypted NCA files with the correct NCA header key and key area key. **NCAs using titlekey crypto are not supported with this PR.** (decided to make that separate)
- By extension, supports the execution of XCI files. 
- Adds support in the game list for the recognition and display of XCI/eNCA files.

Tested on: 1-2-Switch, Cave Story+, DOOM, Hyrule Warriors, I Am Setsuna, Minecraft Story Mode, Puyo Puyo Tetrix, Rocket League, Snipperclips Plus, Sonic Forces, Binding of Isaac, and Tiny Barbarian DX.