### PR TITLE
Added ability to change username & language code in the settings ui. Added IProfile::Get and SET::GetLanguageCode for libnx tests

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -650,7 +650,7 @@ void IApplicationFunctions::GetDesiredLanguage(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
     rb.Push(
-        static_cast<u64>(Service::Set::available_language_codes[Settings::values.language_index]));
+        static_cast<u64>(Service::Set::GetLanguageCodeFromIndex(Settings::values.language_index)));
     LOG_DEBUG(Service_AM, "called");
 }
 

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -649,7 +649,8 @@ void IApplicationFunctions::GetDesiredLanguage(Kernel::HLERequestContext& ctx) {
     // TODO(bunnei): This should be configurable
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
-    rb.Push(static_cast<u64>(Service::Set::LanguageCode::EN_US));
+    rb.Push(
+        static_cast<u64>(Service::Set::available_language_codes[Settings::values.language_index]));
     LOG_DEBUG(Service_AM, "called");
 }
 

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -49,9 +49,17 @@ void SET::GetAvailableLanguageCodeCount(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_SET, "called");
 }
 
+void SET::GetLanguageCode(Kernel::HLERequestContext& ctx) {
+    IPC::ResponseBuilder rb{ctx, 4};
+    rb.Push(RESULT_SUCCESS);
+    rb.Push(static_cast<u64>(LanguageCode::EN_US));
+
+    LOG_DEBUG(Service_SET, "called");
+}
+
 SET::SET() : ServiceFramework("set") {
     static const FunctionInfo functions[] = {
-        {0, nullptr, "GetLanguageCode"},
+        {0, &SET::GetLanguageCode, "GetLanguageCode"},
         {1, &SET::GetAvailableLanguageCodes, "GetAvailableLanguageCodes"},
         {2, nullptr, "MakeLanguageCode"},
         {3, &SET::GetAvailableLanguageCodeCount, "GetAvailableLanguageCodeCount"},

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -12,6 +12,30 @@
 
 namespace Service::Set {
 
+constexpr std::array<LanguageCode, 17> available_language_codes = {{
+    LanguageCode::JA,
+    LanguageCode::EN_US,
+    LanguageCode::FR,
+    LanguageCode::DE,
+    LanguageCode::IT,
+    LanguageCode::ES,
+    LanguageCode::ZH_CN,
+    LanguageCode::KO,
+    LanguageCode::NL,
+    LanguageCode::PT,
+    LanguageCode::RU,
+    LanguageCode::ZH_TW,
+    LanguageCode::EN_GB,
+    LanguageCode::FR_CA,
+    LanguageCode::ES_419,
+    LanguageCode::ZH_HANS,
+    LanguageCode::ZH_HANT,
+}};
+
+LanguageCode GetLanguageCodeFromIndex(size_t index) {
+    return available_language_codes.at(index);
+}
+
 void SET::GetAvailableLanguageCodes(Kernel::HLERequestContext& ctx) {
     ctx.WriteBuffer(available_language_codes);
 

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -8,28 +8,9 @@
 #include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/client_session.h"
 #include "core/hle/service/set/set.h"
+#include "core/settings.h"
 
 namespace Service::Set {
-
-constexpr std::array<LanguageCode, 17> available_language_codes = {{
-    LanguageCode::JA,
-    LanguageCode::EN_US,
-    LanguageCode::FR,
-    LanguageCode::DE,
-    LanguageCode::IT,
-    LanguageCode::ES,
-    LanguageCode::ZH_CN,
-    LanguageCode::KO,
-    LanguageCode::NL,
-    LanguageCode::PT,
-    LanguageCode::RU,
-    LanguageCode::ZH_TW,
-    LanguageCode::EN_GB,
-    LanguageCode::FR_CA,
-    LanguageCode::ES_419,
-    LanguageCode::ZH_HANS,
-    LanguageCode::ZH_HANT,
-}};
 
 void SET::GetAvailableLanguageCodes(Kernel::HLERequestContext& ctx) {
     ctx.WriteBuffer(available_language_codes);
@@ -52,9 +33,9 @@ void SET::GetAvailableLanguageCodeCount(Kernel::HLERequestContext& ctx) {
 void SET::GetLanguageCode(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
-    rb.Push(static_cast<u64>(LanguageCode::EN_US));
+    rb.Push(static_cast<u64>(available_language_codes[Settings::values.language_index]));
 
-    LOG_DEBUG(Service_SET, "called");
+    LOG_DEBUG(Service_SET, "called {}", Settings::values.language_index);
 }
 
 SET::SET() : ServiceFramework("set") {

--- a/src/core/hle/service/set/set.h
+++ b/src/core/hle/service/set/set.h
@@ -28,26 +28,7 @@ enum class LanguageCode : u64 {
     ZH_HANS = 0x00736E61482D687A,
     ZH_HANT = 0x00746E61482D687A,
 };
-
-constexpr std::array<LanguageCode, 17> available_language_codes = {{
-    LanguageCode::JA,
-    LanguageCode::EN_US,
-    LanguageCode::FR,
-    LanguageCode::DE,
-    LanguageCode::IT,
-    LanguageCode::ES,
-    LanguageCode::ZH_CN,
-    LanguageCode::KO,
-    LanguageCode::NL,
-    LanguageCode::PT,
-    LanguageCode::RU,
-    LanguageCode::ZH_TW,
-    LanguageCode::EN_GB,
-    LanguageCode::FR_CA,
-    LanguageCode::ES_419,
-    LanguageCode::ZH_HANS,
-    LanguageCode::ZH_HANT,
-}};
+LanguageCode GetLanguageCodeFromIndex(size_t idx);
 
 class SET final : public ServiceFramework<SET> {
 public:

--- a/src/core/hle/service/set/set.h
+++ b/src/core/hle/service/set/set.h
@@ -29,6 +29,26 @@ enum class LanguageCode : u64 {
     ZH_HANT = 0x00746E61482D687A,
 };
 
+constexpr std::array<LanguageCode, 17> available_language_codes = {{
+    LanguageCode::JA,
+    LanguageCode::EN_US,
+    LanguageCode::FR,
+    LanguageCode::DE,
+    LanguageCode::IT,
+    LanguageCode::ES,
+    LanguageCode::ZH_CN,
+    LanguageCode::KO,
+    LanguageCode::NL,
+    LanguageCode::PT,
+    LanguageCode::RU,
+    LanguageCode::ZH_TW,
+    LanguageCode::EN_GB,
+    LanguageCode::FR_CA,
+    LanguageCode::ES_419,
+    LanguageCode::ZH_HANS,
+    LanguageCode::ZH_HANT,
+}};
+
 class SET final : public ServiceFramework<SET> {
 public:
     explicit SET();

--- a/src/core/hle/service/set/set.h
+++ b/src/core/hle/service/set/set.h
@@ -35,6 +35,7 @@ public:
     ~SET() = default;
 
 private:
+    void GetLanguageCode(Kernel::HLERequestContext& ctx);
     void GetAvailableLanguageCodes(Kernel::HLERequestContext& ctx);
     void GetAvailableLanguageCodeCount(Kernel::HLERequestContext& ctx);
 };

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -113,6 +113,7 @@ struct Values {
     // System
     bool use_docked_mode;
     std::string username;
+    int language_index;
 
     // Controls
     std::array<std::string, NativeButton::NumButtons> buttons;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -112,6 +112,7 @@ static const std::array<const char*, NumAnalogs> mapping = {{
 struct Values {
     // System
     bool use_docked_mode;
+    std::string username;
 
     // Controls
     std::array<std::string, NativeButton::NumButtons> buttons;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -99,6 +99,7 @@ void Config::ReadValues() {
     qt_config->beginGroup("System");
     Settings::values.use_docked_mode = qt_config->value("use_docked_mode", false).toBool();
     Settings::values.username = qt_config->value("username", "yuzu").toString().toStdString();
+    Settings::values.language_index = qt_config->value("language_index", 1).toInt();
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");
@@ -203,6 +204,7 @@ void Config::SaveValues() {
     qt_config->beginGroup("System");
     qt_config->setValue("use_docked_mode", Settings::values.use_docked_mode);
     qt_config->setValue("username", QString::fromStdString(Settings::values.username));
+    qt_config->setValue("language_index", Settings::values.language_index);
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -98,6 +98,7 @@ void Config::ReadValues() {
 
     qt_config->beginGroup("System");
     Settings::values.use_docked_mode = qt_config->value("use_docked_mode", false).toBool();
+    Settings::values.username = qt_config->value("username", "yuzu").toString().toStdString();
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");
@@ -201,6 +202,7 @@ void Config::SaveValues() {
 
     qt_config->beginGroup("System");
     qt_config->setValue("use_docked_mode", Settings::values.use_docked_mode);
+    qt_config->setValue("username", QString::fromStdString(Settings::values.username));
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -40,6 +40,7 @@ ConfigureSystem::~ConfigureSystem() {}
 void ConfigureSystem::setConfiguration() {
     enabled = !Core::System::GetInstance().IsPoweredOn();
     ui->edit_username->setText(QString::fromStdString(Settings::values.username));
+    ui->combo_language->setCurrentIndex(Settings::values.language_index);
 }
 
 void ConfigureSystem::ReadSystemSettings() {}
@@ -48,6 +49,7 @@ void ConfigureSystem::applyConfiguration() {
     if (!enabled)
         return;
     Settings::values.username = ui->edit_username->text().toStdString();
+    Settings::values.language_index = ui->combo_language->currentIndex();
     Settings::Apply();
 }
 

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -4,9 +4,10 @@
 
 #include <QMessageBox>
 #include "core/core.h"
+#include "core/settings.h"
 #include "ui_configure_system.h"
 #include "yuzu/configuration/configure_system.h"
-#include "yuzu/ui_settings.h"
+#include "yuzu/main.h"
 
 static const std::array<int, 12> days_in_month = {{
     31,
@@ -38,6 +39,7 @@ ConfigureSystem::~ConfigureSystem() {}
 
 void ConfigureSystem::setConfiguration() {
     enabled = !Core::System::GetInstance().IsPoweredOn();
+    ui->edit_username->setText(QString::fromStdString(Settings::values.username));
 }
 
 void ConfigureSystem::ReadSystemSettings() {}
@@ -45,6 +47,8 @@ void ConfigureSystem::ReadSystemSettings() {}
 void ConfigureSystem::applyConfiguration() {
     if (!enabled)
         return;
+    Settings::values.username = ui->edit_username->text().toStdString();
+    Settings::Apply();
 }
 
 void ConfigureSystem::updateBirthdayComboBox(int birthmonth_index) {

--- a/src/yuzu/configuration/configure_system.ui
+++ b/src/yuzu/configuration/configure_system.ui
@@ -38,7 +38,7 @@
            </sizepolicy>
           </property>
           <property name="maxLength">
-           <number>10</number>
+           <number>32</number>
           </property>
          </widget>
         </item>

--- a/src/yuzu/configuration/configure_system.ui
+++ b/src/yuzu/configuration/configure_system.ui
@@ -164,7 +164,7 @@
           </item>
           <item>
            <property name="text">
-            <string>Simplified Chinese (简体中文)</string>
+            <string>Chinese</string>
            </property>
           </item>
           <item>
@@ -187,6 +187,31 @@
             <string>Russian (Русский)</string>
            </property>
           </item>
+           <item>
+             <property name="text">
+               <string>Taiwanese</string>
+             </property>
+           </item>
+           <item>
+             <property name="text">
+               <string>British English</string>
+             </property>
+           </item>
+           <item>
+             <property name="text">
+               <string>Canadian French</string>
+             </property>
+           </item>
+           <item>
+             <property name="text">
+               <string>Latin American Spanish</string>
+             </property>
+           </item>
+           <item>
+             <property name="text">
+               <string>Simplified Chinese</string>
+             </property>
+           </item>
           <item>
            <property name="text">
             <string>Traditional Chinese (正體中文)</string>

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -166,6 +166,16 @@ use_virtual_sd =
 # 1: Yes, 0 (default): No
 use_docked_mode =
 
+# Sets the account username, max length is 32 characters
+# yuzu (default)
+username =
+
+# Sets the systems language index
+# 0: Japanese, 1: English (default), 2: French, 3: German, 4: Italian, 5: Spanish, 6: Chinese,
+# 7: Korean, 8: Dutch, 9: Portuguese, 10: Russian, 11: Taiwanese, 12: British English, 13: Canadian French,
+# 14: Latin American Spanish, 15: Simplified Chinese, 16: Traditional Chinese
+language_index =
+
 # The system region that yuzu will use during emulation
 # -1: Auto-select (default), 0: Japan, 1: USA, 2: Europe, 3: Australia, 4: China, 5: Korea, 6: Taiwan
 region_value =


### PR DESCRIPTION
Currently, the additional languages added to the language list need to be translated. By default the username will be "yuzu" and the language will be english
<img width="1280" alt="2018-07-28_16-24-8937c5af-9140-4272-8cad-739c989e56aa-d48d6310" src="https://user-images.githubusercontent.com/25727384/43353757-f3b9dadc-9282-11e8-9882-f3a999a4bf6d.png">
