### PR TITLE
Port #3758 from Citra: "Add missing std::string import in text_formatter"

### DIFF
--- a/src/common/logging/text_formatter.h
+++ b/src/common/logging/text_formatter.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <cstddef>
+#include <string>
 
 namespace Log {
 


### PR DESCRIPTION
See https://github.com/citra-emu/citra/pull/3758 for more details.