### PR TITLE
Implemented various hwopus functions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "unicorn"]
     path = externals/unicorn
     url = https://github.com/yuzu-emu/unicorn
+[submodule "externals/opus"]
+	path = externals/opus
+	url = https://github.com/ogniK5377/opus.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,6 +22,6 @@
 [submodule "unicorn"]
     path = externals/unicorn
     url = https://github.com/yuzu-emu/unicorn
-[submodule "externals/opus"]
+[submodule "opus"]
 	path = externals/opus
 	url = https://github.com/ogniK5377/opus.git

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -50,3 +50,7 @@ if (ARCHITECTURE_x86_64)
     target_include_directories(xbyak INTERFACE ./xbyak/xbyak)
     target_compile_definitions(xbyak INTERFACE XBYAK_NO_OP_NAMES)
 endif()
+
+# Opus
+add_subdirectory(opus)
+target_include_directories(opus INTERFACE ./opus/include)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -310,7 +310,7 @@ add_library(core STATIC
 create_target_directory_groups(core)
 
 target_link_libraries(core PUBLIC common PRIVATE audio_core video_core)
-target_link_libraries(core PUBLIC Boost::boost PRIVATE fmt lz4_static unicorn)
+target_link_libraries(core PUBLIC Boost::boost PRIVATE fmt lz4_static unicorn opus)
 
 if (ARCHITECTURE_x86_64)
     target_sources(core PRIVATE

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -310,7 +310,7 @@ add_library(core STATIC
 create_target_directory_groups(core)
 
 target_link_libraries(core PUBLIC common PRIVATE audio_core video_core)
-target_link_libraries(core PUBLIC Boost::boost PRIVATE fmt lz4_static unicorn opus)
+target_link_libraries(core PUBLIC Boost::boost PRIVATE fmt lz4_static opus unicorn)
 
 if (ARCHITECTURE_x86_64)
     target_sources(core PRIVATE

--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <string>
+#include <cstring>
 #include <opus.h>
 #include "common/logging/log.h"
 #include "core/hle/ipc_helpers.h"
@@ -90,6 +90,11 @@ private:
     u32 channel_count;
 };
 
+static size_t WorkerBufferSize(u32 channel_count) {
+    ASSERT_MSG(channel_count == 1 || channel_count == 2, "Invalid channel count");
+    return opus_decoder_get_size(static_cast<int>(channel_count));
+}
+
 void HwOpus::GetWorkBufferSize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     auto sample_rate = rp.Pop<u32>();
@@ -133,11 +138,6 @@ void HwOpus::OpenOpusDecoder(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<IHardwareOpusDecoderManager>(std::move(decoder), sample_rate,
                                                      channel_count);
-}
-
-size_t HwOpus::WorkerBufferSize(u32 channel_count) {
-    ASSERT_MSG(channel_count == 1 || channel_count == 2, "Invalid channel count");
-    return opus_decoder_get_size(static_cast<int>(channel_count));
 }
 
 HwOpus::HwOpus() : ServiceFramework("hwopus") {

--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -12,7 +12,7 @@
 namespace Service::Audio {
 
 struct OpusDeleter {
-    void operator()(void* ptr) {
+    void operator()(void* ptr) const {
         operator delete(ptr);
     }
 };

--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -56,6 +56,7 @@ private:
 
     bool Decoder_DecodeInterleaved(u32& consumed, u32& sample_count, const std::vector<u8>& input,
                                    std::vector<opus_int16>& output) {
+        size_t raw_output_sz = output.size() * sizeof(opus_int16);
         if (sizeof(OpusHeader) > input.size())
             return false;
         OpusHeader hdr{};
@@ -67,11 +68,11 @@ private:
         auto decoded_sample_count = opus_packet_get_nb_samples(
             frame, static_cast<opus_int32>(input.size() - sizeof(OpusHeader)),
             static_cast<opus_int32>(sample_rate));
-        if (decoded_sample_count * channel_count * sizeof(u16) > output.size())
+        if (decoded_sample_count * channel_count * sizeof(u16) > raw_output_sz)
             return false;
         auto out_sample_count =
             opus_decode(decoder.get(), frame, hdr.sz, output.data(),
-                        (static_cast<int>(output.size() / sizeof(s16) / channel_count)), 0);
+                        (static_cast<int>(raw_output_sz / sizeof(s16) / channel_count)), 0);
         if (out_sample_count < 0)
             return false;
         sample_count = out_sample_count;

--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -1,7 +1,7 @@
 // Copyright 2018 yuzu emulator team
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
-
+#include <opus.h>
 #include "common/logging/log.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/hle_ipc.h"
@@ -9,19 +9,140 @@
 
 namespace Service::Audio {
 
+class IHardwareOpusDecoderManager final : public ServiceFramework<IHardwareOpusDecoderManager> {
+public:
+    IHardwareOpusDecoderManager(OpusDecoder* decoder, u32 sample_rate, u32 channel_count)
+        : ServiceFramework("IHardwareOpusDecoderManager"), decoder(decoder),
+          sample_rate(sample_rate), channel_count(channel_count) {
+        static const FunctionInfo functions[] = {
+            {0, &IHardwareOpusDecoderManager::DecodeInterleaved, "DecodeInterleaved"},
+            {1, nullptr, "SetContext"},
+            {2, nullptr, "DecodeInterleavedForMultiStream"},
+            {3, nullptr, "SetContextForMultiStream"},
+            {4, nullptr, "Unknown4"},
+            {5, nullptr, "Unknown5"},
+            {6, nullptr, "Unknown6"},
+            {7, nullptr, "Unknown7"},
+        };
+        RegisterHandlers(functions);
+    }
+
+    ~IHardwareOpusDecoderManager() {
+        std::free(decoder);
+    }
+
+private:
+    void DecodeInterleaved(Kernel::HLERequestContext& ctx) {
+        u32 consumed = 0;
+        u32 sample_count = 0;
+        std::vector<s16> samples(ctx.GetWriteBufferSize() / sizeof(s16));
+        if (!Decoder_DecodeInterleaved(&consumed, &sample_count, samples.data(),
+                                       samples.size() * sizeof(s16), ctx.ReadBuffer())) {
+            IPC::ResponseBuilder rb{ctx, 2};
+            // TODO(ogniK): Use correct error code
+            rb.Push(ResultCode(-1));
+            return;
+        }
+        IPC::ResponseBuilder rb{ctx, 4};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push<u32>(consumed);
+        rb.Push<u32>(sample_count);
+        ctx.WriteBuffer(samples.data(), samples.size() * sizeof(s16));
+    }
+
+    bool Decoder_DecodeInterleaved(u32* consumed, u32* sample_count, s16* output, size_t output_sz,
+                                   std::vector<u8> input) {
+        if (sizeof(OpusHeader) > input.size())
+            return false;
+        OpusHeader hdr{};
+        std::memcpy(&hdr, input.data(), sizeof(OpusHeader));
+        if (sizeof(OpusHeader) + static_cast<u32>(hdr.sz) > input.size()) {
+            return false;
+        }
+        auto frame = input.data() + sizeof(OpusHeader);
+        auto decoded_sample_count = opus_packet_get_nb_samples(
+            frame, static_cast<opus_int32>(input.size() - sizeof(OpusHeader)),
+            static_cast<opus_int32>(sample_rate));
+        if (decoded_sample_count * channel_count * sizeof(u16) > output_sz)
+            return false;
+        auto out_sample_count =
+            opus_decode(decoder, frame, hdr.sz, output,
+                        (static_cast<int>(output_sz / sizeof(s16) / channel_count)), 0);
+        if (out_sample_count < 0)
+            return false;
+        *sample_count = out_sample_count;
+        *consumed = static_cast<u32>(sizeof(OpusHeader) + hdr.sz);
+        return true;
+    }
+
+    struct OpusHeader {
+        u32_be sz; // Needs to be BE for some odd reason
+        INSERT_PADDING_WORDS(1);
+    };
+    static_assert(sizeof(OpusHeader) == 0x8, "OpusHeader is an invalid size");
+
+    OpusDecoder* decoder;
+    u32 sample_rate;
+    u32 channel_count;
+};
+
 void HwOpus::GetWorkBufferSize(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_Audio, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    auto sample_rate = rp.Pop<u32>();
+    auto channel_count = rp.Pop<u32>();
+    ASSERT_MSG(sample_rate == 48000 || sample_rate == 24000 || sample_rate == 16000 ||
+                   sample_rate == 12000 || sample_rate == 8000,
+               "Invalid sample rate");
+    ASSERT_MSG(channel_count == 1 || channel_count == 2, "Invalid channel count");
+    u32 worker_buffer_sz = static_cast<u32>(WorkerBufferSize(channel_count));
+    LOG_DEBUG(Audio, "called worker_buffer_sz={}", worker_buffer_sz);
+
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u32>(0x4000);
+    rb.Push<u32>(worker_buffer_sz);
+}
+
+void HwOpus::OpenOpusDecoder(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    auto sample_rate = rp.Pop<u32>();
+    auto channel_count = rp.Pop<u32>();
+    auto buffer_sz = rp.Pop<u32>();
+    LOG_DEBUG(Audio, "called sample_rate={}, channel_count={}, buffer_size={}", sample_rate,
+              channel_count, buffer_sz);
+    ASSERT_MSG(sample_rate == 48000 || sample_rate == 24000 || sample_rate == 16000 ||
+                   sample_rate == 12000 || sample_rate == 8000,
+               "Invalid sample rate");
+    ASSERT_MSG(channel_count == 1 || channel_count == 2, "Invalid channel count");
+
+    size_t worker_sz = WorkerBufferSize(channel_count);
+    ASSERT_MSG(buffer_sz < worker_sz, "Worker buffer too large");
+
+    OpusDecoder* decoder = (OpusDecoder*)std::malloc(worker_sz);
+    if (opus_decoder_init(decoder, sample_rate, channel_count)) {
+        std::free(decoder);
+        IPC::ResponseBuilder rb{ctx, 2};
+        // TODO(ogniK): Use correct error code
+        rb.Push(ResultCode(-1));
+        return;
+    }
+
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    rb.Push(RESULT_SUCCESS);
+    rb.PushIpcInterface<IHardwareOpusDecoderManager>(std::move(decoder), sample_rate,
+                                                     channel_count);
+}
+
+size_t HwOpus::WorkerBufferSize(u32 channel_count) {
+    ASSERT_MSG(channel_count == 1 || channel_count == 2, "Invalid channel count");
+    return opus_decoder_get_size(static_cast<int>(channel_count));
 }
 
 HwOpus::HwOpus() : ServiceFramework("hwopus") {
     static const FunctionInfo functions[] = {
-        {0, nullptr, "Initialize"},
+        {0, &HwOpus::OpenOpusDecoder, "OpenOpusDecoder"},
         {1, &HwOpus::GetWorkBufferSize, "GetWorkBufferSize"},
-        {2, nullptr, "InitializeMultiStream"},
-        {3, nullptr, "GetWorkBufferSizeMultiStream"},
+        {2, nullptr, "OpenOpusDecoderForMultiStream"},
+        {3, nullptr, "GetWorkBufferSizeForMultiStream"},
     };
     RegisterHandlers(functions);
 }

--- a/src/core/hle/service/audio/hwopus.h
+++ b/src/core/hle/service/audio/hwopus.h
@@ -16,7 +16,6 @@ public:
 private:
     void OpenOpusDecoder(Kernel::HLERequestContext& ctx);
     void GetWorkBufferSize(Kernel::HLERequestContext& ctx);
-    size_t WorkerBufferSize(u32 channel_count);
 };
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/hwopus.h
+++ b/src/core/hle/service/audio/hwopus.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <opus.h>
 #include "core/hle/service/service.h"
 
 namespace Service::Audio {
@@ -14,7 +15,9 @@ public:
     ~HwOpus() = default;
 
 private:
+    void OpenOpusDecoder(Kernel::HLERequestContext& ctx);
     void GetWorkBufferSize(Kernel::HLERequestContext& ctx);
+    size_t WorkerBufferSize(u32 channel_count);
 };
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/hwopus.h
+++ b/src/core/hle/service/audio/hwopus.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <opus.h>
 #include "core/hle/service/service.h"
 
 namespace Service::Audio {


### PR DESCRIPTION
Implemented OpenOpusDecoder, GetWorkBufferSize and DecodeInterleaved. We now can get decoded opus samples. With this Pokemon Quest and Touhou both go in-game and render 3d. If there's any issues with the CMake let me know, I haven't messed with CMake a lot

<img width="1280" alt="2018-07-28_22-41-688ce234-8c33-4dc6-944b-05ddbb615c35-6f7882be" src="https://user-images.githubusercontent.com/25727384/43356773-750a9112-92ba-11e8-99a1-0b5afafda7e2.png">
<img width="1280" alt="2018-07-28_22-42-4dca9a2c-f4cf-420c-b27c-07ba80c74d12-ec3683b3" src="https://user-images.githubusercontent.com/25727384/43356774-7696732a-92ba-11e8-953c-ff3cfcb729da.png">
<img width="1280" alt="2018-07-28_22-32-24e122cc-4dde-45ee-8cce-0c8368549010-0d9de9c4" src="https://user-images.githubusercontent.com/25727384/43356777-79992982-92ba-11e8-963f-b4860d7c3410.png">
