### PR TITLE
Audio output backend based on cubeb

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,9 @@
 [submodule "catch"]
     path = externals/catch
     url = https://github.com/philsquared/Catch.git
+[submodule "cubeb"]
+    path = externals/cubeb
+    url = https://github.com/kinetiknz/cubeb.git
 [submodule "dynarmic"]
     path = externals/dynarmic
     url = https://github.com/MerryMage/dynarmic.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ CMAKE_DEPENDENT_OPTION(YUZU_USE_BUNDLED_QT "Download bundled Qt binaries" ON "EN
 
 option(YUZU_USE_BUNDLED_UNICORN "Build/Download bundled Unicorn" ON)
 
+option(ENABLE_CUBEB "Enables the cubeb audio backend" ON)
+
 if(NOT EXISTS ${CMAKE_SOURCE_DIR}/.git/hooks/pre-commit)
     message(STATUS "Copying pre-commit hook")
     file(COPY hooks/pre-commit

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -54,3 +54,9 @@ endif()
 # Opus
 add_subdirectory(opus)
 target_include_directories(opus INTERFACE ./opus/include)
+
+# Cubeb
+if(ENABLE_CUBEB)
+    set(BUILD_TESTS OFF CACHE BOOL "")
+    add_subdirectory(cubeb)
+endif()

--- a/src/audio_core/CMakeLists.txt
+++ b/src/audio_core/CMakeLists.txt
@@ -2,6 +2,8 @@ add_library(audio_core STATIC
     audio_out.cpp
     audio_out.h
     buffer.h
+    cubeb_sink.cpp
+    cubeb_sink.h
     null_sink.h
     stream.cpp
     stream.h
@@ -14,3 +16,8 @@ add_library(audio_core STATIC
 create_target_directory_groups(audio_core)
 
 target_link_libraries(audio_core PUBLIC common core)
+
+if(ENABLE_CUBEB)
+    target_link_libraries(audio_core PRIVATE cubeb)
+    target_compile_definitions(audio_core PRIVATE -DHAVE_CUBEB=1)
+endif()

--- a/src/audio_core/CMakeLists.txt
+++ b/src/audio_core/CMakeLists.txt
@@ -2,8 +2,13 @@ add_library(audio_core STATIC
     audio_out.cpp
     audio_out.h
     buffer.h
+    null_sink.h
     stream.cpp
     stream.h
+    sink.h
+    sink_details.cpp
+    sink_details.h
+    sink_stream.h
 )
 
 create_target_directory_groups(audio_core)

--- a/src/audio_core/audio_out.cpp
+++ b/src/audio_core/audio_out.cpp
@@ -9,7 +9,7 @@
 namespace AudioCore {
 
 /// Returns the stream format from the specified number of channels
-static Stream::Format ChannelsToStreamFormat(int num_channels) {
+static Stream::Format ChannelsToStreamFormat(u32 num_channels) {
     switch (num_channels) {
     case 1:
         return Stream::Format::Mono16;
@@ -24,7 +24,7 @@ static Stream::Format ChannelsToStreamFormat(int num_channels) {
     return {};
 }
 
-StreamPtr AudioOut::OpenStream(int sample_rate, int num_channels,
+StreamPtr AudioOut::OpenStream(u32 sample_rate, u32 num_channels,
                                Stream::ReleaseCallback&& release_callback) {
     streams.push_back(std::make_shared<Stream>(sample_rate, ChannelsToStreamFormat(num_channels),
                                                std::move(release_callback)));

--- a/src/audio_core/audio_out.h
+++ b/src/audio_core/audio_out.h
@@ -13,15 +13,13 @@
 
 namespace AudioCore {
 
-using StreamPtr = std::shared_ptr<Stream>;
-
 /**
  * Represents an audio playback interface, used to open and play audio streams
  */
 class AudioOut {
 public:
     /// Opens a new audio stream
-    StreamPtr OpenStream(int sample_rate, int num_channels,
+    StreamPtr OpenStream(u32 sample_rate, u32 num_channels,
                          Stream::ReleaseCallback&& release_callback);
 
     /// Returns a vector of recently released buffers specified by tag for the specified stream
@@ -37,7 +35,7 @@ public:
     bool QueueBuffer(StreamPtr stream, Buffer::Tag tag, std::vector<u8>&& data);
 
 private:
-    /// Active audio streams on the interface
+    SinkPtr sink;
     std::vector<StreamPtr> streams;
 };
 

--- a/src/audio_core/audio_out.h
+++ b/src/audio_core/audio_out.h
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "audio_core/buffer.h"
+#include "audio_core/sink.h"
 #include "audio_core/stream.h"
 #include "common/common_types.h"
 
@@ -36,7 +37,6 @@ public:
 
 private:
     SinkPtr sink;
-    std::vector<StreamPtr> streams;
 };
 
 } // namespace AudioCore

--- a/src/audio_core/buffer.h
+++ b/src/audio_core/buffer.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "common/common_types.h"
@@ -33,5 +34,7 @@ private:
     Tag tag;
     std::vector<u8> data;
 };
+
+using BufferPtr = std::shared_ptr<Buffer>;
 
 } // namespace AudioCore

--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -1,0 +1,190 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <cstring>
+
+#include "audio_core/cubeb_sink.h"
+#include "audio_core/stream.h"
+#include "common/logging/log.h"
+
+namespace AudioCore {
+
+class SinkStreamImpl final : public SinkStream {
+public:
+    SinkStreamImpl(cubeb* ctx, cubeb_devid output_device) : ctx{ctx} {
+        cubeb_stream_params params;
+        params.rate = 48000;
+        params.channels = GetNumChannels();
+        params.format = CUBEB_SAMPLE_S16NE;
+        params.layout = CUBEB_LAYOUT_STEREO;
+
+        u32 minimum_latency = 0;
+        if (cubeb_get_min_latency(ctx, &params, &minimum_latency) != CUBEB_OK) {
+            LOG_CRITICAL(Audio_Sink, "Error getting minimum latency");
+        }
+
+        if (cubeb_stream_init(ctx, &stream_backend, "yuzu Audio Output", nullptr, nullptr,
+                              output_device, &params, std::max(512u, minimum_latency),
+                              &SinkStreamImpl::DataCallback, &SinkStreamImpl::StateCallback,
+                              this) != CUBEB_OK) {
+            LOG_CRITICAL(Audio_Sink, "Error initializing cubeb stream");
+            return;
+        }
+
+        if (cubeb_stream_start(stream_backend) != CUBEB_OK) {
+            LOG_CRITICAL(Audio_Sink, "Error starting cubeb stream");
+            return;
+        }
+    }
+
+    ~SinkStreamImpl() {
+        if (!ctx) {
+            return;
+        }
+
+        if (cubeb_stream_stop(stream_backend) != CUBEB_OK) {
+            LOG_CRITICAL(Audio_Sink, "Error stopping cubeb stream");
+        }
+
+        cubeb_stream_destroy(stream_backend);
+    }
+
+    void EnqueueSamples(u32 num_channels, const s16* samples, size_t sample_count) override {
+        if (!ctx) {
+            return;
+        }
+
+        queue.reserve(queue.size() + sample_count * GetNumChannels());
+
+        if (num_channels == 2) {
+            // Copy as-is
+            std::copy(samples, samples + sample_count * GetNumChannels(),
+                      std::back_inserter(queue));
+        } else if (num_channels == 6) {
+            // Downsample 6 channels to 2
+            const size_t sample_count_copy_size = sample_count * num_channels * 2;
+            queue.reserve(sample_count_copy_size);
+            for (size_t i = 0; i < sample_count * num_channels; i += num_channels) {
+                queue.push_back(samples[i]);
+                queue.push_back(samples[i + 1]);
+            }
+        } else {
+            ASSERT_MSG(false, "Unimplemented");
+        }
+    }
+
+    u32 GetNumChannels() const {
+        // Only support 2-channel stereo output for now
+        return 2;
+    }
+
+private:
+    std::vector<std::string> device_list;
+
+    cubeb* ctx{};
+    cubeb_stream* stream_backend{};
+
+    std::vector<s16> queue;
+
+    static long DataCallback(cubeb_stream* stream, void* user_data, const void* input_buffer,
+                             void* output_buffer, long num_frames);
+    static void StateCallback(cubeb_stream* stream, void* user_data, cubeb_state state);
+};
+
+CubebSink::CubebSink(std::string target_device_name) {
+    if (cubeb_init(&ctx, "yuzu", nullptr) != CUBEB_OK) {
+        LOG_CRITICAL(Audio_Sink, "cubeb_init failed");
+        return;
+    }
+
+    if (target_device_name != auto_device_name && !target_device_name.empty()) {
+        cubeb_device_collection collection;
+        if (cubeb_enumerate_devices(ctx, CUBEB_DEVICE_TYPE_OUTPUT, &collection) != CUBEB_OK) {
+            LOG_WARNING(Audio_Sink, "Audio output device enumeration not supported");
+        } else {
+            const auto collection_end{collection.device + collection.count};
+            const auto device{std::find_if(collection.device, collection_end,
+                                           [&](const cubeb_device_info& device) {
+                                               return target_device_name == device.friendly_name;
+                                           })};
+            if (device != collection_end) {
+                output_device = device->devid;
+            }
+            cubeb_device_collection_destroy(ctx, &collection);
+        }
+    }
+}
+
+CubebSink::~CubebSink() {
+    if (!ctx) {
+        return;
+    }
+
+    for (auto& sink_stream : sink_streams) {
+        sink_stream.reset();
+    }
+
+    cubeb_destroy(ctx);
+}
+
+SinkStream& CubebSink::AcquireSinkStream(u32 sample_rate, u32 num_channels) {
+    sink_streams.push_back(std::make_unique<SinkStreamImpl>(ctx, output_device));
+    return *sink_streams.back();
+}
+
+long SinkStreamImpl::DataCallback(cubeb_stream* stream, void* user_data, const void* input_buffer,
+                                  void* output_buffer, long num_frames) {
+    SinkStreamImpl* impl = static_cast<SinkStreamImpl*>(user_data);
+    u8* buffer = reinterpret_cast<u8*>(output_buffer);
+
+    if (!impl) {
+        return {};
+    }
+
+    const size_t frames_to_write{
+        std::min(impl->queue.size() / impl->GetNumChannels(), static_cast<size_t>(num_frames))};
+
+    memcpy(buffer, impl->queue.data(), frames_to_write * sizeof(s16) * impl->GetNumChannels());
+    impl->queue.erase(impl->queue.begin(),
+                      impl->queue.begin() + frames_to_write * impl->GetNumChannels());
+
+    if (frames_to_write < num_frames) {
+        // Fill the rest of the frames with silence
+        memset(buffer + frames_to_write * sizeof(s16) * impl->GetNumChannels(), 0,
+               (num_frames - frames_to_write) * sizeof(s16) * impl->GetNumChannels());
+    }
+
+    return num_frames;
+}
+
+void SinkStreamImpl::StateCallback(cubeb_stream* stream, void* user_data, cubeb_state state) {}
+
+std::vector<std::string> ListCubebSinkDevices() {
+    std::vector<std::string> device_list;
+    cubeb* ctx;
+
+    if (cubeb_init(&ctx, "Citra Device Enumerator", nullptr) != CUBEB_OK) {
+        LOG_CRITICAL(Audio_Sink, "cubeb_init failed");
+        return {};
+    }
+
+    cubeb_device_collection collection;
+    if (cubeb_enumerate_devices(ctx, CUBEB_DEVICE_TYPE_OUTPUT, &collection) != CUBEB_OK) {
+        LOG_WARNING(Audio_Sink, "Audio output device enumeration not supported");
+    } else {
+        for (size_t i = 0; i < collection.count; i++) {
+            const cubeb_device_info& device = collection.device[i];
+            if (device.friendly_name) {
+                device_list.emplace_back(device.friendly_name);
+            }
+        }
+        cubeb_device_collection_destroy(ctx, &collection);
+    }
+
+    cubeb_destroy(ctx);
+    return device_list;
+}
+
+} // namespace AudioCore

--- a/src/audio_core/cubeb_sink.h
+++ b/src/audio_core/cubeb_sink.h
@@ -1,0 +1,31 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <cubeb/cubeb.h>
+
+#include "audio_core/sink.h"
+
+namespace AudioCore {
+
+class CubebSink final : public Sink {
+public:
+    explicit CubebSink(std::string device_id);
+    ~CubebSink() override;
+
+    SinkStream& AcquireSinkStream(u32 sample_rate, u32 num_channels) override;
+
+private:
+    cubeb* ctx{};
+    cubeb_devid output_device{};
+    std::vector<SinkStreamPtr> sink_streams;
+};
+
+std::vector<std::string> ListCubebSinkDevices();
+
+} // namespace AudioCore

--- a/src/audio_core/null_sink.h
+++ b/src/audio_core/null_sink.h
@@ -1,0 +1,27 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "audio_core/sink.h"
+
+namespace AudioCore {
+
+class NullSink final : public Sink {
+public:
+    explicit NullSink(std::string){};
+    ~NullSink() override = default;
+
+    SinkStream& AcquireSinkStream(u32 /*sample_rate*/, u32 /*num_channels*/) override {
+        return null_sink_stream;
+    }
+
+private:
+    struct NullSinkStreamImpl final : SinkStream {
+        void EnqueueSamples(u32 /*num_channels*/, const s16* /*samples*/,
+                            size_t /*sample_count*/) override {}
+    } null_sink_stream;
+};
+
+} // namespace AudioCore

--- a/src/audio_core/sink.h
+++ b/src/audio_core/sink.h
@@ -1,0 +1,29 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+
+#include "audio_core/sink_stream.h"
+#include "common/common_types.h"
+
+namespace AudioCore {
+
+constexpr char auto_device_name[] = "auto";
+
+/**
+ * This class is an interface for an audio sink. An audio sink accepts samples in stereo signed
+ * PCM16 format to be output. Sinks *do not* handle resampling and expect the correct sample rate.
+ * They are dumb outputs.
+ */
+class Sink {
+public:
+    virtual ~Sink() = default;
+    virtual SinkStream& AcquireSinkStream(u32 sample_rate, u32 num_channels) = 0;
+};
+
+using SinkPtr = std::unique_ptr<Sink>;
+
+} // namespace AudioCore

--- a/src/audio_core/sink_details.cpp
+++ b/src/audio_core/sink_details.cpp
@@ -8,12 +8,18 @@
 #include <vector>
 #include "audio_core/null_sink.h"
 #include "audio_core/sink_details.h"
+#ifdef HAVE_CUBEB
+#include "audio_core/cubeb_sink.h"
+#endif
 #include "common/logging/log.h"
 
 namespace AudioCore {
 
 // g_sink_details is ordered in terms of desirability, with the best choice at the top.
 const std::vector<SinkDetails> g_sink_details = {
+#ifdef HAVE_CUBEB
+    SinkDetails{"cubeb", &std::make_unique<CubebSink, std::string>, &ListCubebSinkDevices},
+#endif
     SinkDetails{"null", &std::make_unique<NullSink, std::string>,
                 [] { return std::vector<std::string>{"null"}; }},
 };

--- a/src/audio_core/sink_details.cpp
+++ b/src/audio_core/sink_details.cpp
@@ -1,0 +1,38 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <vector>
+#include "audio_core/null_sink.h"
+#include "audio_core/sink_details.h"
+#include "common/logging/log.h"
+
+namespace AudioCore {
+
+// g_sink_details is ordered in terms of desirability, with the best choice at the top.
+const std::vector<SinkDetails> g_sink_details = {
+    SinkDetails{"null", &std::make_unique<NullSink, std::string>,
+                [] { return std::vector<std::string>{"null"}; }},
+};
+
+const SinkDetails& GetSinkDetails(std::string sink_id) {
+    auto iter =
+        std::find_if(g_sink_details.begin(), g_sink_details.end(),
+                     [sink_id](const auto& sink_detail) { return sink_detail.id == sink_id; });
+
+    if (sink_id == "auto" || iter == g_sink_details.end()) {
+        if (sink_id != "auto") {
+            LOG_ERROR(Audio, "AudioCore::SelectSink given invalid sink_id {}", sink_id);
+        }
+        // Auto-select.
+        // g_sink_details is ordered in terms of desirability, with the best choice at the front.
+        iter = g_sink_details.begin();
+    }
+
+    return *iter;
+}
+
+} // namespace AudioCore

--- a/src/audio_core/sink_details.h
+++ b/src/audio_core/sink_details.h
@@ -1,0 +1,32 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <vector>
+
+namespace AudioCore {
+
+class Sink;
+
+struct SinkDetails {
+    SinkDetails(const char* id_, std::function<std::unique_ptr<Sink>(std::string)> factory_,
+                std::function<std::vector<std::string>()> list_devices_)
+        : id(id_), factory(factory_), list_devices(list_devices_) {}
+
+    /// Name for this sink.
+    const char* id;
+    /// A method to call to construct an instance of this type of sink.
+    std::function<std::unique_ptr<Sink>(std::string device_id)> factory;
+    /// A method to call to list available devices.
+    std::function<std::vector<std::string>()> list_devices;
+};
+
+extern const std::vector<SinkDetails> g_sink_details;
+
+const SinkDetails& GetSinkDetails(std::string sink_id);
+
+} // namespace AudioCore

--- a/src/audio_core/sink_stream.h
+++ b/src/audio_core/sink_stream.h
@@ -1,0 +1,32 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+
+#include "common/common_types.h"
+
+namespace AudioCore {
+
+/**
+ * Accepts samples in stereo signed PCM16 format to be output. Sinks *do not* handle resampling and
+ * expect the correct sample rate. They are dumb outputs.
+ */
+class SinkStream {
+public:
+    virtual ~SinkStream() = default;
+
+    /**
+     * Feed stereo samples to sink.
+     * @param num_channels Number of channels used.
+     * @param samples Samples in interleaved stereo PCM16 format.
+     * @param sample_count Number of samples.
+     */
+    virtual void EnqueueSamples(u32 num_channels, const s16* samples, size_t sample_count) = 0;
+};
+
+using SinkStreamPtr = std::unique_ptr<SinkStream>;
+
+} // namespace AudioCore

--- a/src/audio_core/stream.h
+++ b/src/audio_core/stream.h
@@ -10,6 +10,7 @@
 #include <queue>
 
 #include "audio_core/buffer.h"
+#include "audio_core/sink_stream.h"
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "core/core_timing.h"
@@ -31,7 +32,8 @@ public:
     /// Callback function type, used to change guest state on a buffer being released
     using ReleaseCallback = std::function<void()>;
 
-    Stream(int sample_rate, Format format, ReleaseCallback&& release_callback);
+    Stream(u32 sample_rate, Format format, ReleaseCallback&& release_callback,
+           SinkStream& sink_stream);
 
     /// Plays the audio stream
     void Play();
@@ -85,7 +87,7 @@ private:
     /// Gets the number of core cycles when the specified buffer will be released
     s64 GetBufferReleaseCycles(const Buffer& buffer) const;
 
-    int sample_rate;                        ///< Sample rate of the stream
+    u32 sample_rate;                        ///< Sample rate of the stream
     Format format;                          ///< Format of the stream
     ReleaseCallback release_callback;       ///< Buffer release callback for the stream
     State state{State::Stopped};            ///< Playback state of the stream
@@ -93,6 +95,7 @@ private:
     BufferPtr active_buffer;                ///< Actively playing buffer in the stream
     std::queue<BufferPtr> queued_buffers;   ///< Buffers queued to be played in the stream
     std::queue<BufferPtr> released_buffers; ///< Buffers recently released from the stream
+    SinkStream& sink_stream;                ///< Output sink for the stream
 };
 
 using StreamPtr = std::shared_ptr<Stream>;

--- a/src/audio_core/stream.h
+++ b/src/audio_core/stream.h
@@ -16,8 +16,6 @@
 
 namespace AudioCore {
 
-using BufferPtr = std::shared_ptr<Buffer>;
-
 /**
  * Represents an audio stream, which is a sequence of queued buffers, to be outputed by AudioOut
  */
@@ -60,6 +58,17 @@ public:
         return queued_buffers.size();
     }
 
+    /// Gets the sample rate
+    u32 GetSampleRate() const {
+        return sample_rate;
+    }
+
+    /// Gets the number of channels
+    u32 GetNumChannels() const;
+
+    /// Gets the sample size in bytes
+    u32 GetSampleSize() const;
+
 private:
     /// Current state of the stream
     enum class State {
@@ -85,5 +94,7 @@ private:
     std::queue<BufferPtr> queued_buffers;   ///< Buffers queued to be played in the stream
     std::queue<BufferPtr> released_buffers; ///< Buffers recently released from the stream
 };
+
+using StreamPtr = std::shared_ptr<Stream>;
 
 } // namespace AudioCore

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -177,7 +177,6 @@ System::ResultStatus System::Init(EmuWindow* emu_window, u32 system_mode) {
     }
 
     gpu_core = std::make_unique<Tegra::GPU>();
-    audio_core = std::make_unique<AudioCore::AudioOut>();
     telemetry_session = std::make_unique<Core::TelemetrySession>();
     service_manager = std::make_shared<Service::SM::ServiceManager>();
 
@@ -229,7 +228,6 @@ void System::Shutdown() {
     service_manager.reset();
     telemetry_session.reset();
     gpu_core.reset();
-    audio_core.reset();
 
     // Close all CPU/threading state
     cpu_barrier->NotifyEnd();

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <string>
 #include <thread>
-#include "audio_core/audio_out.h"
 #include "common/common_types.h"
 #include "core/arm/exclusive_monitor.h"
 #include "core/core_cpu.h"
@@ -132,11 +131,6 @@ public:
         return *gpu_core;
     }
 
-    /// Gets the AudioCore interface
-    AudioCore::AudioOut& AudioCore() {
-        return *audio_core;
-    }
-
     /// Gets the scheduler for the CPU core that is currently running
     Kernel::Scheduler& CurrentScheduler() {
         return *CurrentCpuCore().Scheduler();
@@ -201,7 +195,6 @@ private:
     /// AppLoader used to load the current executing application
     std::unique_ptr<Loader::AppLoader> app_loader;
     std::unique_ptr<Tegra::GPU> gpu_core;
-    std::unique_ptr<AudioCore::AudioOut> audio_core;
     std::shared_ptr<Tegra::DebugContext> debug_context;
     Kernel::SharedPtr<Kernel::Process> current_process;
     std::shared_ptr<ExclusiveMonitor> cpu_exclusive_monitor;

--- a/src/core/hle/service/audio/audout_u.h
+++ b/src/core/hle/service/audio/audout_u.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "audio_core/audio_out.h"
 #include "core/hle/service/service.h"
 
 namespace Kernel {
@@ -33,6 +34,7 @@ public:
 
 private:
     std::shared_ptr<IAudioOut> audio_out_interface;
+    std::unique_ptr<AudioCore::AudioOut> audio_core;
 
     void ListAudioOutsImpl(Kernel::HLERequestContext& ctx);
     void OpenAudioOutImpl(Kernel::HLERequestContext& ctx);


### PR DESCRIPTION
Adds an audio output backend based on [cubeb](https://github.com/kinetiknz/cubeb). Summary of the changes:
* Adds cubeb as a dependency, much like Citra this can be disabled via a CMake flag
* Adds `Sink` interface, this is the main interface for an audio output, much like Citra
* Adds `SinkStream` interface, this is the a sub-interface of `Sink` for outputting a single stream of audio via the Sink interface. The idea is that we will support multiple output streams, and the audio library will do the mixing for us.
* Implements `Sink` and `SinkStream` with cubeb, and integrates this into `AudioOut`.
* Integrates this all with `audout:u` service for audio output. The idea though is that we should be able to use this design with `audren`, etc. as well in the near future.
* As a side-note, I moved the `AudioOut` creation to `audout:u`. This is because right now we need to initialize cubeb on the same thread that we create streams on. This will need to be improved if we want `audren`, etc. to use this.

Games that use the `audout:u` service should now play audio. It works really well if the games are running at or near 60fps. Games tested:
* One Piece
* Snipper Clips
* Sonic Mania
* Minecraft Story Mode

I also tested both SDL and Qt frontends.

Edit: No audio tab in settings yet. I'll add that either as a followon change or separate PR.