### PR TITLE
service: Add btm services

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -169,6 +169,7 @@ void FileBackend::Write(const Entry& entry) {
     SUB(Service, AOC)                                                                              \
     SUB(Service, APM)                                                                              \
     SUB(Service, BCAT)                                                                             \
+    SUB(Service, BTM)                                                                              \
     SUB(Service, Fatal)                                                                            \
     SUB(Service, Friend)                                                                           \
     SUB(Service, FS)                                                                               \

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -56,6 +56,7 @@ enum class Class : ClassType {
     Service_APM,       ///< The APM (Performance) service
     Service_Audio,     ///< The Audio (Audio control) service
     Service_BCAT,      ///< The BCAT service
+    Service_BTM,       ///< The BTM service
     Service_Fatal,     ///< The Fatal service
     Service_Friend,    ///< The friend service
     Service_FS,        ///< The FS (Filesystem) service

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -142,6 +142,8 @@ add_library(core STATIC
     hle/service/bcat/module.h
     hle/service/btdrv/btdrv.cpp
     hle/service/btdrv/btdrv.h
+    hle/service/btm/btm.cpp
+    hle/service/btm/btm.h
     hle/service/erpt/erpt.cpp
     hle/service/erpt/erpt.h
     hle/service/es/es.cpp

--- a/src/core/hle/service/btm/btm.cpp
+++ b/src/core/hle/service/btm/btm.cpp
@@ -4,6 +4,9 @@
 
 #include <memory>
 
+#include "common/logging/log.h"
+#include "core/hle/ipc_helpers.h"
+#include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/service/btm/btm.h"
 #include "core/hle/service/service.h"
 #include "core/hle/service/sm/sm.h"
@@ -65,16 +68,47 @@ public:
     }
 };
 
+class IBtmSystemCore final : public ServiceFramework<IBtmSystemCore> {
+public:
+    explicit IBtmSystemCore() : ServiceFramework{"IBtmSystemCore"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "StartGamepadPairingImpl"},
+            {1, nullptr, "CancelGamepadPairingImpl"},
+            {2, nullptr, "ClearGamepadPairingDatabaseImpl"},
+            {3, nullptr, "GetPairedGamepadCountImpl"},
+            {4, nullptr, "EnableRadioImpl"},
+            {5, nullptr, "DisableRadioImpl"},
+            {6, nullptr, "GetRadioOnOffImpl"},
+            {7, nullptr, "AcquireRadioEventImpl"},
+            {8, nullptr, "AcquireGamepadPairingEventImpl"},
+            {9, nullptr, "IsGamepadPairingStartedImpl"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
 class BTM_SYS final : public ServiceFramework<BTM_SYS> {
 public:
     explicit BTM_SYS() : ServiceFramework{"btm:sys"} {
         // clang-format off
         static const FunctionInfo functions[] = {
-            {0, nullptr, "GetCoreImpl"},
+            {0, &BTM_SYS::GetCoreImpl, "GetCoreImpl"},
         };
         // clang-format on
 
         RegisterHandlers(functions);
+    }
+
+private:
+    void GetCoreImpl(Kernel::HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushIpcInterface<IBtmSystemCore>();
+
+        LOG_DEBUG(Service_BTM, "called");
     }
 };
 

--- a/src/core/hle/service/btm/btm.cpp
+++ b/src/core/hle/service/btm/btm.cpp
@@ -1,0 +1,87 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+
+#include "core/hle/service/btm/btm.h"
+#include "core/hle/service/service.h"
+#include "core/hle/service/sm/sm.h"
+
+namespace Service::BTM {
+
+class BTM final : public ServiceFramework<BTM> {
+public:
+    explicit BTM() : ServiceFramework{"btm"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "Unknown1"},
+            {1, nullptr, "Unknown2"},
+            {2, nullptr, "RegisterSystemEventForConnectedDeviceConditionImpl"},
+            {3, nullptr, "Unknown3"},
+            {4, nullptr, "Unknown4"},
+            {5, nullptr, "Unknown5"},
+            {6, nullptr, "Unknown6"},
+            {7, nullptr, "Unknown7"},
+            {8, nullptr, "RegisterSystemEventForRegisteredDeviceInfoImpl"},
+            {9, nullptr, "Unknown8"},
+            {10, nullptr, "Unknown9"},
+            {11, nullptr, "Unknown10"},
+            {12, nullptr, "Unknown11"},
+            {13, nullptr, "Unknown12"},
+            {14, nullptr, "EnableRadioImpl"},
+            {15, nullptr, "DisableRadioImpl"},
+            {16, nullptr, "Unknown13"},
+            {17, nullptr, "Unknown14"},
+            {18, nullptr, "Unknown15"},
+            {19, nullptr, "Unknown16"},
+            {20, nullptr, "Unknown17"},
+            {21, nullptr, "Unknown18"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+class BTM_DBG final : public ServiceFramework<BTM_DBG> {
+public:
+    explicit BTM_DBG() : ServiceFramework{"btm:dbg"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "RegisterSystemEventForDiscoveryImpl"},
+            {1, nullptr, "Unknown1"},
+            {2, nullptr, "Unknown2"},
+            {3, nullptr, "Unknown3"},
+            {4, nullptr, "Unknown4"},
+            {5, nullptr, "Unknown5"},
+            {6, nullptr, "Unknown6"},
+            {7, nullptr, "Unknown7"},
+            {8, nullptr, "Unknown8"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+class BTM_SYS final : public ServiceFramework<BTM_SYS> {
+public:
+    explicit BTM_SYS() : ServiceFramework{"btm:sys"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "GetCoreImpl"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+void InstallInterfaces(SM::ServiceManager& sm) {
+    std::make_shared<BTM>()->InstallAsService(sm);
+    std::make_shared<BTM_DBG>()->InstallAsService(sm);
+    std::make_shared<BTM_SYS>()->InstallAsService(sm);
+}
+
+} // namespace Service::BTM

--- a/src/core/hle/service/btm/btm.h
+++ b/src/core/hle/service/btm/btm.h
@@ -1,0 +1,15 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace Service::SM {
+class ServiceManager;
+}
+
+namespace Service::BTM {
+
+void InstallInterfaces(SM::ServiceManager& sm);
+
+} // namespace Service::BTM

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -22,6 +22,7 @@
 #include "core/hle/service/audio/audio.h"
 #include "core/hle/service/bcat/bcat.h"
 #include "core/hle/service/btdrv/btdrv.h"
+#include "core/hle/service/btm/btm.h"
 #include "core/hle/service/erpt/erpt.h"
 #include "core/hle/service/es/es.h"
 #include "core/hle/service/eupld/eupld.h"
@@ -201,6 +202,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm) {
     Audio::InstallInterfaces(*sm);
     BCAT::InstallInterfaces(*sm);
     BtDrv::InstallInterfaces(*sm);
+    BTM::InstallInterfaces(*sm);
     ERPT::InstallInterfaces(*sm);
     ES::InstallInterfaces(*sm);
     EUPLD::InstallInterfaces(*sm);


### PR DESCRIPTION
Adds the basic skeleton for the btm services based off the information on Switch Brew and SwIPC.