### PR TITLE
partition_filesystem: Remove dynamic_cast in PrintDebugInfo()

### DIFF
--- a/src/core/file_sys/partition_filesystem.cpp
+++ b/src/core/file_sys/partition_filesystem.cpp
@@ -97,9 +97,8 @@ void PartitionFilesystem::PrintDebugInfo() const {
     LOG_DEBUG(Service_FS, "Magic:                  {:.4}", pfs_header.magic);
     LOG_DEBUG(Service_FS, "Files:                  {}", pfs_header.num_entries);
     for (u32 i = 0; i < pfs_header.num_entries; i++) {
-        LOG_DEBUG(Service_FS, " > File {}:              {} (0x{:X} bytes, at 0x{:X})", i,
-                  pfs_files[i]->GetName(), pfs_files[i]->GetSize(),
-                  dynamic_cast<OffsetVfsFile*>(pfs_files[i].get())->GetOffset());
+        LOG_DEBUG(Service_FS, " > File {}:              {} (0x{:X} bytes)", i,
+                  pfs_files[i]->GetName(), pfs_files[i]->GetSize());
     }
 }
 


### PR DESCRIPTION
We shouldn't be upcasting our file instances. Given a PartitionFilesystem is currently designed to accept any arbitrary VfsFile instances, casting to a more specific type than that is just bad design and shows an interface design issue.