### PR TITLE
service: Add the pcie service

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -185,6 +185,7 @@ void FileBackend::Write(const Entry& entry) {
     SUB(Service, NIFM)                                                                             \
     SUB(Service, NS)                                                                               \
     SUB(Service, NVDRV)                                                                            \
+    SUB(Service, PCIE)                                                                             \
     SUB(Service, PCTL)                                                                             \
     SUB(Service, PREPO)                                                                            \
     SUB(Service, SET)                                                                              \

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -72,6 +72,7 @@ enum class Class : ClassType {
     Service_NIFM,      ///< The NIFM (Network interface) service
     Service_NS,        ///< The NS services
     Service_NVDRV,     ///< The NVDRV (Nvidia driver) service
+    Service_PCIE,      ///< The PCIe service
     Service_PCTL,      ///< The PCTL (Parental control) service
     Service_PREPO,     ///< The PREPO (Play report) service
     Service_SET,       ///< The SET (Settings) service

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -225,6 +225,8 @@ add_library(core STATIC
     hle/service/nvflinger/buffer_queue.h
     hle/service/nvflinger/nvflinger.cpp
     hle/service/nvflinger/nvflinger.h
+    hle/service/pcie/pcie.cpp
+    hle/service/pcie/pcie.h
     hle/service/pctl/module.cpp
     hle/service/pctl/module.h
     hle/service/pctl/pctl.cpp

--- a/src/core/hle/service/pcie/pcie.cpp
+++ b/src/core/hle/service/pcie/pcie.cpp
@@ -1,0 +1,64 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+
+#include "core/hle/service/pcie/pcie.h"
+#include "core/hle/service/service.h"
+#include "core/hle/service/sm/sm.h"
+
+namespace Service::PCIe {
+
+class ISession final : public ServiceFramework<ISession> {
+public:
+    explicit ISession() : ServiceFramework{"ISession"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "QueryFunctions"},
+            {1, nullptr, "AcquireFunction"},
+            {2, nullptr, "ReleaseFunction"},
+            {3, nullptr, "GetFunctionState"},
+            {4, nullptr, "GetBarProfile"},
+            {5, nullptr, "ReadConfig"},
+            {6, nullptr, "WriteConfig"},
+            {7, nullptr, "ReadBarRegion"},
+            {8, nullptr, "WriteBarRegion"},
+            {9, nullptr, "FindCapability"},
+            {10, nullptr, "FindExtendedCapability"},
+            {11, nullptr, "MapDma"},
+            {12, nullptr, "UnmapDma"},
+            {13, nullptr, "UnmapDmaBusAddress"},
+            {14, nullptr, "GetDmaBusAddress"},
+            {15, nullptr, "GetDmaBusAddressRange"},
+            {16, nullptr, "SetDmaEnable"},
+            {17, nullptr, "AcquireIrq"},
+            {18, nullptr, "ReleaseIrq"},
+            {19, nullptr, "SetIrqEnable"},
+            {20, nullptr, "SetAspmEnable"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+class PCIe final : public ServiceFramework<PCIe> {
+public:
+    explicit PCIe() : ServiceFramework{"pcie"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "RegisterClassDriver"},
+            {1, nullptr, "QueryFunctionsUnregistered"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+void InstallInterfaces(SM::ServiceManager& sm) {
+    std::make_shared<PCIe>()->InstallAsService(sm);
+}
+
+} // namespace Service::PCIe

--- a/src/core/hle/service/pcie/pcie.h
+++ b/src/core/hle/service/pcie/pcie.h
@@ -1,0 +1,15 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace Service::SM {
+class ServiceManager;
+}
+
+namespace Service::PCIe {
+
+void InstallInterfaces(SM::ServiceManager& sm);
+
+} // namespace Service::PCIe

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -44,6 +44,7 @@
 #include "core/hle/service/nim/nim.h"
 #include "core/hle/service/ns/ns.h"
 #include "core/hle/service/nvdrv/nvdrv.h"
+#include "core/hle/service/pcie/pcie.h"
 #include "core/hle/service/pctl/pctl.h"
 #include "core/hle/service/pm/pm.h"
 #include "core/hle/service/prepo/prepo.h"
@@ -225,6 +226,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm) {
     NIM::InstallInterfaces(*sm);
     NS::InstallInterfaces(*sm);
     Nvidia::InstallInterfaces(*sm);
+    PCIe::InstallInterfaces(*sm);
     PCTL::InstallInterfaces(*sm);
     PlayReport::InstallInterfaces(*sm);
     PM::InstallInterfaces(*sm);


### PR DESCRIPTION
Adds the basic skeleton of the pcie service based off information on Switch Brew.