### PR TITLE
service/am: Add missing am services

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -114,6 +114,12 @@ add_library(core STATIC
     hle/service/am/applet_ae.h
     hle/service/am/applet_oe.cpp
     hle/service/am/applet_oe.h
+    hle/service/am/idle.cpp
+    hle/service/am/idle.h
+    hle/service/am/omm.cpp
+    hle/service/am/omm.h
+    hle/service/am/spsm.cpp
+    hle/service/am/spsm.h
     hle/service/aoc/aoc_u.cpp
     hle/service/aoc/aoc_u.h
     hle/service/apm/apm.cpp

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -11,6 +11,9 @@
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/am/applet_ae.h"
 #include "core/hle/service/am/applet_oe.h"
+#include "core/hle/service/am/idle.h"
+#include "core/hle/service/am/omm.h"
+#include "core/hle/service/am/spsm.h"
 #include "core/hle/service/apm/apm.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/hle/service/nvflinger/nvflinger.h"
@@ -689,6 +692,9 @@ void InstallInterfaces(SM::ServiceManager& service_manager,
                        std::shared_ptr<NVFlinger::NVFlinger> nvflinger) {
     std::make_shared<AppletAE>(nvflinger)->InstallAsService(service_manager);
     std::make_shared<AppletOE>(nvflinger)->InstallAsService(service_manager);
+    std::make_shared<IdleSys>()->InstallAsService(service_manager);
+    std::make_shared<OMM>()->InstallAsService(service_manager);
+    std::make_shared<SPSM>()->InstallAsService(service_manager);
 }
 
 IHomeMenuFunctions::IHomeMenuFunctions() : ServiceFramework("IHomeMenuFunctions") {

--- a/src/core/hle/service/am/idle.cpp
+++ b/src/core/hle/service/am/idle.cpp
@@ -1,0 +1,24 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/am/idle.h"
+
+namespace Service::AM {
+
+IdleSys::IdleSys() : ServiceFramework{"idle:sys"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "GetAutoPowerDownEvent"},
+        {1, nullptr, "Unknown1"},
+        {2, nullptr, "Unknown2"},
+        {3, nullptr, "Unknown3"},
+        {4, nullptr, "Unknown4"},
+        {5, nullptr, "Unknown5"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+} // namespace Service::AM

--- a/src/core/hle/service/am/idle.h
+++ b/src/core/hle/service/am/idle.h
@@ -1,0 +1,16 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service::AM {
+
+class IdleSys final : public ServiceFramework<IdleSys> {
+public:
+    explicit IdleSys();
+};
+
+} // namespace Service::AM

--- a/src/core/hle/service/am/omm.cpp
+++ b/src/core/hle/service/am/omm.cpp
@@ -1,0 +1,42 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/am/omm.h"
+
+namespace Service::AM {
+
+OMM::OMM() : ServiceFramework{"omm"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "GetOperationMode"},
+        {1, nullptr, "GetOperationModeChangeEvent"},
+        {2, nullptr, "EnableAudioVisual"},
+        {3, nullptr, "DisableAudioVisual"},
+        {4, nullptr, "EnterSleepAndWait"},
+        {5, nullptr, "GetCradleStatus"},
+        {6, nullptr, "FadeInDisplay"},
+        {7, nullptr, "FadeOutDisplay"},
+        {8, nullptr, "Unknown1"},
+        {9, nullptr, "Unknown2"},
+        {10, nullptr, "Unknown3"},
+        {11, nullptr, "Unknown4"},
+        {12, nullptr, "Unknown5"},
+        {13, nullptr, "Unknown6"},
+        {14, nullptr, "Unknown7"},
+        {15, nullptr, "Unknown8"},
+        {16, nullptr, "Unknown9"},
+        {17, nullptr, "Unknown10"},
+        {18, nullptr, "Unknown11"},
+        {19, nullptr, "Unknown12"},
+        {20, nullptr, "Unknown13"},
+        {21, nullptr, "Unknown14"},
+        {22, nullptr, "Unknown15"},
+        {23, nullptr, "Unknown16"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+} // namespace Service::AM

--- a/src/core/hle/service/am/omm.h
+++ b/src/core/hle/service/am/omm.h
@@ -1,0 +1,16 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service::AM {
+
+class OMM final : public ServiceFramework<OMM> {
+public:
+    explicit OMM();
+};
+
+} // namespace Service::AM

--- a/src/core/hle/service/am/spsm.cpp
+++ b/src/core/hle/service/am/spsm.cpp
@@ -1,0 +1,30 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/am/spsm.h"
+
+namespace Service::AM {
+
+SPSM::SPSM() : ServiceFramework{"spsm"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "GetState"},
+        {1, nullptr, "SleepSystemAndWaitAwake"},
+        {2, nullptr, "Unknown1"},
+        {3, nullptr, "Unknown2"},
+        {4, nullptr, "GetNotificationMessageEventHandle"},
+        {5, nullptr, "Unknown3"},
+        {6, nullptr, "Unknown4"},
+        {7, nullptr, "Unknown5"},
+        {8, nullptr, "AnalyzePerformanceLogForLastSleepWakeSequence"},
+        {9, nullptr, "ChangeHomeButtonLongPressingTime"},
+        {10, nullptr, "Unknown6"},
+        {11, nullptr, "Unknown7"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+} // namespace Service::AM

--- a/src/core/hle/service/am/spsm.h
+++ b/src/core/hle/service/am/spsm.h
@@ -1,0 +1,16 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service::AM {
+
+class SPSM final : public ServiceFramework<SPSM> {
+public:
+    explicit SPSM();
+};
+
+} // Service::AM


### PR DESCRIPTION
Adds the basic skeleton for missing am services idle:sys, omm, and spsm based off the information provided by Switch Brew.