### PR TITLE
kernel: Remove unnecessary includes

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -10,7 +10,7 @@
 #include "core/arm/dynarmic/arm_dynarmic.h"
 #include "core/core.h"
 #include "core/core_timing.h"
-#include "core/hle/kernel/memory.h"
+#include "core/hle/kernel/process.h"
 #include "core/hle/kernel/svc.h"
 #include "core/memory.h"
 

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -2,15 +2,17 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
+#include <vector>
+
 #include "common/assert.h"
-#include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "core/core.h"
 #include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/thread.h"
-#include "core/hle/lock.h"
+#include "core/hle/result.h"
 #include "core/memory.h"
 
 namespace Kernel {

--- a/src/core/hle/kernel/address_arbiter.h
+++ b/src/core/hle/kernel/address_arbiter.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
-#include "core/hle/result.h"
+#include "common/common_types.h"
+
+union ResultCode;
 
 namespace Kernel {
 

--- a/src/core/hle/kernel/client_port.cpp
+++ b/src/core/hle/kernel/client_port.cpp
@@ -2,7 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "common/assert.h"
+#include <tuple>
+
 #include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/client_session.h"
 #include "core/hle/kernel/errors.h"

--- a/src/core/hle/kernel/client_session.cpp
+++ b/src/core/hle/kernel/client_session.cpp
@@ -2,8 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "common/assert.h"
-
 #include "core/hle/kernel/client_session.h"
 #include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/hle_ipc.h"

--- a/src/core/hle/kernel/event.cpp
+++ b/src/core/hle/kernel/event.cpp
@@ -3,8 +3,6 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
-#include <map>
-#include <vector>
 #include "common/assert.h"
 #include "core/hle/kernel/event.h"
 #include "core/hle/kernel/kernel.h"

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <utility>
 
 #include <boost/range/algorithm_ext/erase.hpp>

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <array>
-#include <iterator>
 #include <memory>
 #include <string>
 #include <type_traits>

--- a/src/core/hle/kernel/memory.cpp
+++ b/src/core/hle/kernel/memory.cpp
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 #include <cinttypes>
-#include <map>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -12,10 +11,9 @@
 #include "common/common_types.h"
 #include "common/logging/log.h"
 #include "core/hle/kernel/memory.h"
+#include "core/hle/kernel/process.h"
 #include "core/hle/kernel/vm_manager.h"
-#include "core/hle/result.h"
 #include "core/memory.h"
-#include "core/memory_setup.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 

--- a/src/core/hle/kernel/memory.h
+++ b/src/core/hle/kernel/memory.h
@@ -5,12 +5,15 @@
 #pragma once
 
 #include <memory>
+#include <vector>
+
 #include "common/common_types.h"
-#include "core/hle/kernel/process.h"
 
 namespace Kernel {
 
 class VMManager;
+enum class MemoryRegion : u16;
+struct AddressMapping;
 
 struct MemoryRegionInfo {
     u64 base; // Not an address, but offset from start of FCRAM

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -3,8 +3,11 @@
 // Refer to the license.txt file included.
 
 #include <map>
+#include <utility>
 #include <vector>
+
 #include <boost/range/algorithm_ext/erase.hpp>
+
 #include "common/assert.h"
 #include "core/core.h"
 #include "core/hle/kernel/errors.h"
@@ -13,6 +16,7 @@
 #include "core/hle/kernel/mutex.h"
 #include "core/hle/kernel/object_address_table.h"
 #include "core/hle/kernel/thread.h"
+#include "core/hle/result.h"
 
 namespace Kernel {
 

--- a/src/core/hle/kernel/mutex.h
+++ b/src/core/hle/kernel/mutex.h
@@ -4,12 +4,10 @@
 
 #pragma once
 
-#include <string>
 #include "common/common_types.h"
-#include "common/swap.h"
 #include "core/hle/kernel/kernel.h"
-#include "core/hle/kernel/wait_object.h"
-#include "core/hle/result.h"
+
+union ResultCode;
 
 namespace Kernel {
 

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -2,8 +2,12 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <utility>
 
+#include "common/assert.h"
+#include "common/logging/log.h"
+#include "core/arm/arm_interface.h"
 #include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/kernel/process.h"

--- a/src/core/hle/kernel/scheduler.h
+++ b/src/core/hle/kernel/scheduler.h
@@ -8,8 +8,9 @@
 #include <vector>
 #include "common/common_types.h"
 #include "common/thread_queue_list.h"
-#include "core/arm/arm_interface.h"
 #include "core/hle/kernel/thread.h"
+
+class ARM_Interface;
 
 namespace Kernel {
 

--- a/src/core/hle/kernel/server_port.h
+++ b/src/core/hle/kernel/server_port.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <tuple>
+#include <vector>
 #include "common/common_types.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/wait_object.h"

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -5,6 +5,8 @@
 #include <tuple>
 #include <utility>
 
+#include "common/assert.h"
+#include "common/logging/log.h"
 #include "core/core.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/client_port.h"

--- a/src/core/hle/kernel/server_session.h
+++ b/src/core/hle/kernel/server_session.h
@@ -6,12 +6,12 @@
 
 #include <memory>
 #include <string>
-#include "common/assert.h"
+#include <vector>
+
 #include "common/common_types.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/wait_object.h"
 #include "core/hle/result.h"
-#include "core/memory.h"
 
 namespace Kernel {
 

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -3,6 +3,8 @@
 // Refer to the license.txt file included.
 
 #include <utility>
+
+#include "common/assert.h"
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/hle/kernel/errors.h"

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -4,7 +4,10 @@
 
 #pragma once
 
+#include <memory>
 #include <string>
+#include <vector>
+
 #include "common/common_types.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -5,7 +5,10 @@
 #include <algorithm>
 #include <cinttypes>
 #include <iterator>
+#include <mutex>
+#include <vector>
 
+#include "common/assert.h"
 #include "common/logging/log.h"
 #include "common/microprofile.h"
 #include "common/string_util.h"

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -4,8 +4,11 @@
 
 #include <algorithm>
 #include <cinttypes>
-#include <list>
 #include <vector>
+
+#include <boost/optional.hpp>
+#include <boost/range/algorithm_ext/erase.hpp>
+
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "common/logging/log.h"
@@ -19,7 +22,6 @@
 #include "core/hle/kernel/handle_table.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/memory.h"
-#include "core/hle/kernel/mutex.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/thread.h"
 #include "core/hle/result.h"

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -4,12 +4,11 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <vector>
-#include <boost/container/flat_map.hpp>
-#include <boost/container/flat_set.hpp>
+
 #include "common/common_types.h"
 #include "core/arm/arm_interface.h"
 #include "core/hle/kernel/kernel.h"

--- a/src/core/hle/kernel/wait_object.cpp
+++ b/src/core/hle/kernel/wait_object.cpp
@@ -5,11 +5,9 @@
 #include <algorithm>
 #include "common/assert.h"
 #include "common/logging/log.h"
-#include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/memory.h"
 #include "core/hle/kernel/process.h"
-#include "core/hle/kernel/resource_limit.h"
 #include "core/hle/kernel/thread.h"
 #include "core/hle/kernel/timer.h"
 


### PR DESCRIPTION
Removes unnecessary direct dependencies in some headers and also gets rid of indirect dependencies that were being relied on to be included.