### PR TITLE
audout_u: Remove std::move in OpenAudioOutImpl()

### DIFF
--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -194,7 +194,7 @@ void AudOutU::OpenAudioOutImpl(Kernel::HLERequestContext& ctx) {
     // TODO(bunnei): Support more than one IAudioOut interface. When we add this, ListAudioOutsImpl
     // will likely need to be updated as well.
     ASSERT_MSG(!audio_out_interface, "Unimplemented");
-    audio_out_interface = std::make_shared<IAudioOut>(std::move(params), *audio_core);
+    audio_out_interface = std::make_shared<IAudioOut>(params, *audio_core);
 
     IPC::ResponseBuilder rb{ctx, 6, 0, 1};
     rb.Push(RESULT_SUCCESS);


### PR DESCRIPTION
Previously the code was using the values from params further below after it was std::moved. Thankfully, given AudoutParams is a trivially copyable struct, the values would have simply been copied in this instance and not invalidated to garbage values.