### PR TITLE
service/audio: Add missing services

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -126,17 +126,27 @@ add_library(core STATIC
     hle/service/apm/apm.h
     hle/service/apm/interface.cpp
     hle/service/apm/interface.h
+    hle/service/audio/audctl.cpp
+    hle/service/audio/audctl.h
+    hle/service/audio/auddbg.cpp
+    hle/service/audio/auddbg.h
+    hle/service/audio/audin_a.cpp
+    hle/service/audio/audin_a.h
     hle/service/audio/audin_u.cpp
     hle/service/audio/audin_u.h
     hle/service/audio/audio.cpp
     hle/service/audio/audio.h
+    hle/service/audio/audout_a.cpp
+    hle/service/audio/audout_a.h
     hle/service/audio/audout_u.cpp
     hle/service/audio/audout_u.h
+    hle/service/audio/audrec_a.cpp
+    hle/service/audio/audrec_a.h
     hle/service/audio/audrec_u.cpp
     hle/service/audio/audrec_u.h
+    hle/service/audio/audren_a.cpp
+    hle/service/audio/audren_a.h
     hle/service/audio/audren_u.cpp
-    hle/service/audio/audren_u.cpp
-    hle/service/audio/audren_u.h
     hle/service/audio/audren_u.h
     hle/service/audio/codecctl.cpp
     hle/service/audio/codecctl.h

--- a/src/core/hle/service/audio/audctl.cpp
+++ b/src/core/hle/service/audio/audctl.cpp
@@ -1,0 +1,45 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/audio/audctl.h"
+
+namespace Service::Audio {
+
+AudCtl::AudCtl() : ServiceFramework{"audctl"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "GetTargetVolume"},
+        {1, nullptr, "SetTargetVolume"},
+        {2, nullptr, "GetTargetVolumeMin"},
+        {3, nullptr, "GetTargetVolumeMax"},
+        {4, nullptr, "IsTargetMute"},
+        {5, nullptr, "SetTargetMute"},
+        {6, nullptr, "IsTargetConnected"},
+        {7, nullptr, "SetDefaultTarget"},
+        {8, nullptr, "GetDefaultTarget"},
+        {9, nullptr, "GetAudioOutputMode"},
+        {10, nullptr, "SetAudioOutputMode"},
+        {11, nullptr, "SetForceMutePolicy"},
+        {12, nullptr, "GetForceMutePolicy"},
+        {13, nullptr, "GetOutputModeSetting"},
+        {14, nullptr, "SetOutputModeSetting"},
+        {15, nullptr, "SetOutputTarget"},
+        {16, nullptr, "SetInputTargetForceEnabled"},
+        {17, nullptr, "SetHeadphoneOutputLevelMode"},
+        {18, nullptr, "GetHeadphoneOutputLevelMode"},
+        {19, nullptr, "AcquireAudioVolumeUpdateEventForPlayReport"},
+        {20, nullptr, "AcquireAudioOutputDeviceUpdateEventForPlayReport"},
+        {21, nullptr, "GetAudioOutputTargetForPlayReport"},
+        {22, nullptr, "NotifyHeadphoneVolumeWarningDisplayedEvent"},
+        {23, nullptr, "SetSystemOutputMasterVolume"},
+        {24, nullptr, "GetSystemOutputMasterVolume"},
+        {25, nullptr, "GetAudioVolumeDataForPlayReport"},
+        {26, nullptr, "UpdateHeadphoneSettings"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+} // namespace Service::Audio

--- a/src/core/hle/service/audio/audctl.h
+++ b/src/core/hle/service/audio/audctl.h
@@ -1,0 +1,16 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service::Audio {
+
+class AudCtl final : public ServiceFramework<AudCtl> {
+public:
+    explicit AudCtl();
+};
+
+} // namespace Service::Audio

--- a/src/core/hle/service/audio/auddbg.cpp
+++ b/src/core/hle/service/audio/auddbg.cpp
@@ -1,0 +1,20 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/audio/auddbg.h"
+
+namespace Service::Audio {
+
+AudDbg::AudDbg(const char* name) : ServiceFramework{name} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "RequestSuspendForDebug"},
+        {1, nullptr, "RequestResumeForDebug"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+} // namespace Service::Audio

--- a/src/core/hle/service/audio/auddbg.h
+++ b/src/core/hle/service/audio/auddbg.h
@@ -1,0 +1,16 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service::Audio {
+
+class AudDbg final : public ServiceFramework<AudDbg> {
+public:
+    explicit AudDbg(const char* name);
+};
+
+} // namespace Service::Audio

--- a/src/core/hle/service/audio/audin_a.cpp
+++ b/src/core/hle/service/audio/audin_a.cpp
@@ -1,0 +1,24 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/audio/audin_a.h"
+
+namespace Service::Audio {
+
+AudInA::AudInA() : ServiceFramework{"audin:a"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "RequestSuspendAudioIns"},
+        {1, nullptr, "RequestResumeAudioIns"},
+        {2, nullptr, "GetAudioInsProcessMasterVolume"},
+        {3, nullptr, "SetAudioInsProcessMasterVolume"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+} // namespace Service::Audio

--- a/src/core/hle/service/audio/audin_a.h
+++ b/src/core/hle/service/audio/audin_a.h
@@ -1,0 +1,16 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service::Audio {
+
+class AudInA final : public ServiceFramework<AudInA> {
+public:
+    explicit AudInA();
+};
+
+} // namespace Service::Audio

--- a/src/core/hle/service/audio/audio.cpp
+++ b/src/core/hle/service/audio/audio.cpp
@@ -2,10 +2,16 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/hle/service/audio/audctl.h"
+#include "core/hle/service/audio/auddbg.h"
+#include "core/hle/service/audio/audin_a.h"
 #include "core/hle/service/audio/audin_u.h"
 #include "core/hle/service/audio/audio.h"
+#include "core/hle/service/audio/audout_a.h"
 #include "core/hle/service/audio/audout_u.h"
+#include "core/hle/service/audio/audrec_a.h"
 #include "core/hle/service/audio/audrec_u.h"
+#include "core/hle/service/audio/audren_a.h"
 #include "core/hle/service/audio/audren_u.h"
 #include "core/hle/service/audio/codecctl.h"
 #include "core/hle/service/audio/hwopus.h"
@@ -13,12 +19,22 @@
 namespace Service::Audio {
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {
+    std::make_shared<AudCtl>()->InstallAsService(service_manager);
+    std::make_shared<AudOutA>()->InstallAsService(service_manager);
     std::make_shared<AudOutU>()->InstallAsService(service_manager);
+    std::make_shared<AudInA>()->InstallAsService(service_manager);
     std::make_shared<AudInU>()->InstallAsService(service_manager);
+    std::make_shared<AudRecA>()->InstallAsService(service_manager);
     std::make_shared<AudRecU>()->InstallAsService(service_manager);
+    std::make_shared<AudRenA>()->InstallAsService(service_manager);
     std::make_shared<AudRenU>()->InstallAsService(service_manager);
     std::make_shared<CodecCtl>()->InstallAsService(service_manager);
     std::make_shared<HwOpus>()->InstallAsService(service_manager);
+
+    std::make_shared<AudDbg>("audin:d")->InstallAsService(service_manager);
+    std::make_shared<AudDbg>("audout:d")->InstallAsService(service_manager);
+    std::make_shared<AudDbg>("audrec:d")->InstallAsService(service_manager);
+    std::make_shared<AudDbg>("audren:d")->InstallAsService(service_manager);
 }
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audout_a.cpp
+++ b/src/core/hle/service/audio/audout_a.cpp
@@ -1,0 +1,26 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/audio/audout_a.h"
+
+namespace Service::Audio {
+
+AudOutA::AudOutA() : ServiceFramework{"audout:a"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "RequestSuspendAudioOuts"},
+        {1, nullptr, "RequestResumeAudioOuts"},
+        {2, nullptr, "GetAudioOutsProcessMasterVolume"},
+        {3, nullptr, "SetAudioOutsProcessMasterVolume"},
+        {4, nullptr, "GetAudioOutsProcessRecordVolume"},
+        {5, nullptr, "SetAudioOutsProcessRecordVolume"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+} // namespace Service::Audio

--- a/src/core/hle/service/audio/audout_a.h
+++ b/src/core/hle/service/audio/audout_a.h
@@ -1,0 +1,16 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service::Audio {
+
+class AudOutA final : public ServiceFramework<AudOutA> {
+public:
+    explicit AudOutA();
+};
+
+} // namespace Service::Audio

--- a/src/core/hle/service/audio/audrec_a.cpp
+++ b/src/core/hle/service/audio/audrec_a.cpp
@@ -1,0 +1,22 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/audio/audrec_a.h"
+
+namespace Service::Audio {
+
+AudRecA::AudRecA() : ServiceFramework{"audrec:a"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "RequestSuspendFinalOutputRecorders"},
+        {1, nullptr, "RequestResumeFinalOutputRecorders"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+} // namespace Service::Audio

--- a/src/core/hle/service/audio/audrec_a.h
+++ b/src/core/hle/service/audio/audrec_a.h
@@ -1,0 +1,16 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service::Audio {
+
+class AudRecA final : public ServiceFramework<AudRecA> {
+public:
+    explicit AudRecA();
+};
+
+} // namespace Service::Audio

--- a/src/core/hle/service/audio/audren_a.cpp
+++ b/src/core/hle/service/audio/audren_a.cpp
@@ -1,0 +1,28 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/audio/audren_a.h"
+
+namespace Service::Audio {
+
+AudRenA::AudRenA() : ServiceFramework{"audren:a"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "RequestSuspendAudioRenderers"},
+        {1, nullptr, "RequestResumeAudioRenderers"},
+        {2, nullptr, "GetAudioRenderersProcessMasterVolume"},
+        {3, nullptr, "SetAudioRenderersProcessMasterVolume"},
+        {4, nullptr, "RegisterAppletResourceUserId"},
+        {5, nullptr, "UnregisterAppletResourceUserId"},
+        {6, nullptr, "GetAudioRenderersProcessRecordVolume"},
+        {7, nullptr, "SetAudioRenderersProcessRecordVolume"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+} // namespace Service::Audio

--- a/src/core/hle/service/audio/audren_a.h
+++ b/src/core/hle/service/audio/audren_a.h
@@ -1,0 +1,16 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service::Audio {
+
+class AudRenA final : public ServiceFramework<AudRenA> {
+public:
+    explicit AudRenA();
+};
+
+} // namespace Service::Audio


### PR DESCRIPTION
Adds the missing audctl service, as well as the :a and :d services for audin, audout, audrec, and audren.