### PR TITLE
kernel/thread: Remove unimplemented function prototype

### DIFF
--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -288,12 +288,6 @@ Thread* GetCurrentThread();
 void WaitCurrentThread_Sleep();
 
 /**
- * Waits the current thread from an ArbitrateAddress call
- * @param wait_address Arbitration address used to resume from wait
- */
-void WaitCurrentThread_ArbitrateAddress(VAddr wait_address);
-
-/**
  * Stops the current thread and removes it from the thread_list
  */
 void ExitCurrentThread();


### PR DESCRIPTION
Given there's no implementation, we may as well remove the code entirely.