### PR TITLE
service: Add bpc and pcv services

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -169,6 +169,7 @@ void FileBackend::Write(const Entry& entry) {
     SUB(Service, AOC)                                                                              \
     SUB(Service, APM)                                                                              \
     SUB(Service, BCAT)                                                                             \
+    SUB(Service, BPC)                                                                              \
     SUB(Service, BTM)                                                                              \
     SUB(Service, Fatal)                                                                            \
     SUB(Service, FGM)                                                                              \
@@ -188,6 +189,7 @@ void FileBackend::Write(const Entry& entry) {
     SUB(Service, NVDRV)                                                                            \
     SUB(Service, PCIE)                                                                             \
     SUB(Service, PCTL)                                                                             \
+    SUB(Service, PCV)                                                                              \
     SUB(Service, PREPO)                                                                            \
     SUB(Service, SET)                                                                              \
     SUB(Service, SM)                                                                               \

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -56,6 +56,7 @@ enum class Class : ClassType {
     Service_APM,       ///< The APM (Performance) service
     Service_Audio,     ///< The Audio (Audio control) service
     Service_BCAT,      ///< The BCAT service
+    Service_BPC,       ///< The BPC service
     Service_BTM,       ///< The BTM service
     Service_Fatal,     ///< The Fatal service
     Service_FGM,       ///< The FGM service
@@ -75,6 +76,7 @@ enum class Class : ClassType {
     Service_NVDRV,     ///< The NVDRV (Nvidia driver) service
     Service_PCIE,      ///< The PCIe service
     Service_PCTL,      ///< The PCTL (Parental control) service
+    Service_PCV,       ///< The PCV (Parental control) service
     Service_PREPO,     ///< The PREPO (Play report) service
     Service_SET,       ///< The SET (Settings) service
     Service_SM,        ///< The SM (Service manager) service

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -154,6 +154,8 @@ add_library(core STATIC
     hle/service/bcat/bcat.h
     hle/service/bcat/module.cpp
     hle/service/bcat/module.h
+    hle/service/bpc/bpc.cpp
+    hle/service/bpc/bpc.h
     hle/service/btdrv/btdrv.cpp
     hle/service/btdrv/btdrv.h
     hle/service/btm/btm.cpp
@@ -247,6 +249,8 @@ add_library(core STATIC
     hle/service/pctl/module.h
     hle/service/pctl/pctl.cpp
     hle/service/pctl/pctl.h
+    hle/service/pcv/pcv.cpp
+    hle/service/pcv/pcv.h
     hle/service/pm/pm.cpp
     hle/service/pm/pm.h
     hle/service/prepo/prepo.cpp

--- a/src/core/hle/service/bpc/bpc.cpp
+++ b/src/core/hle/service/bpc/bpc.cpp
@@ -1,0 +1,57 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+
+#include "core/hle/service/bpc/bpc.h"
+#include "core/hle/service/service.h"
+#include "core/hle/service/sm/sm.h"
+
+namespace Service::BPC {
+
+class BPC final : public ServiceFramework<BPC> {
+public:
+    explicit BPC() : ServiceFramework{"bpc"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "ShutdownSystem"},
+            {1, nullptr, "RebootSystem"},
+            {2, nullptr, "GetWakeupReason"},
+            {3, nullptr, "GetShutdownReason"},
+            {4, nullptr, "GetAcOk"},
+            {5, nullptr, "GetBoardPowerControlEvent"},
+            {6, nullptr, "GetSleepButtonState"},
+            {7, nullptr, "GetPowerEvent"},
+            {8, nullptr, "Unknown1"},
+            {9, nullptr, "Unknown2"},
+            {10, nullptr, "Unknown3"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+class BPC_R final : public ServiceFramework<BPC_R> {
+public:
+    explicit BPC_R() : ServiceFramework{"bpc:r"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "GetExternalRtcValue"},
+            {1, nullptr, "SetExternalRtcValue"},
+            {2, nullptr, "ReadExternalRtcResetFlag"},
+            {3, nullptr, "ClearExternalRtcResetFlag"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+void InstallInterfaces(SM::ServiceManager& sm) {
+    std::make_shared<BPC>()->InstallAsService(sm);
+    std::make_shared<BPC_R>()->InstallAsService(sm);
+}
+
+} // namespace Service::BPC

--- a/src/core/hle/service/bpc/bpc.h
+++ b/src/core/hle/service/bpc/bpc.h
@@ -1,0 +1,15 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace Service::SM {
+class ServiceManager;
+}
+
+namespace Service::BPC {
+
+void InstallInterfaces(SM::ServiceManager& sm);
+
+} // namespace Service::BPC

--- a/src/core/hle/service/pcv/pcv.cpp
+++ b/src/core/hle/service/pcv/pcv.cpp
@@ -1,0 +1,84 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+
+#include "core/hle/service/pcv/pcv.h"
+#include "core/hle/service/service.h"
+#include "core/hle/service/sm/sm.h"
+
+namespace Service::PCV {
+
+class PCV final : public ServiceFramework<PCV> {
+public:
+    explicit PCV() : ServiceFramework{"pcv"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "SetPowerEnabled"},
+            {1, nullptr, "SetClockEnabled"},
+            {2, nullptr, "SetClockRate"},
+            {3, nullptr, "GetClockRate"},
+            {4, nullptr, "GetState"},
+            {5, nullptr, "GetPossibleClockRates"},
+            {6, nullptr, "SetMinVClockRate"},
+            {7, nullptr, "SetReset"},
+            {8, nullptr, "SetVoltageEnabled"},
+            {9, nullptr, "GetVoltageEnabled"},
+            {10, nullptr, "GetVoltageRange"},
+            {11, nullptr, "SetVoltageValue"},
+            {12, nullptr, "GetVoltageValue"},
+            {13, nullptr, "GetTemperatureThresholds"},
+            {14, nullptr, "SetTemperature"},
+            {15, nullptr, "Initialize"},
+            {16, nullptr, "IsInitialized"},
+            {17, nullptr, "Finalize"},
+            {18, nullptr, "PowerOn"},
+            {19, nullptr, "PowerOff"},
+            {20, nullptr, "ChangeVoltage"},
+            {21, nullptr, "GetPowerClockInfoEvent"},
+            {22, nullptr, "GetOscillatorClock"},
+            {23, nullptr, "GetDvfsTable"},
+            {24, nullptr, "GetModuleStateTable"},
+            {25, nullptr, "GetPowerDomainStateTable"},
+            {26, nullptr, "GetFuseInfo"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+class PCV_ARB final : public ServiceFramework<PCV_ARB> {
+public:
+    explicit PCV_ARB() : ServiceFramework{"pcv:arb"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "ReleaseControl"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+class PCV_IMM final : public ServiceFramework<PCV_IMM> {
+public:
+    explicit PCV_IMM() : ServiceFramework{"pcv:imm"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "SetClockRate"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+void InstallInterfaces(SM::ServiceManager& sm) {
+    std::make_shared<PCV>()->InstallAsService(sm);
+    std::make_shared<PCV_ARB>()->InstallAsService(sm);
+    std::make_shared<PCV_IMM>()->InstallAsService(sm);
+}
+
+} // namespace Service::PCV

--- a/src/core/hle/service/pcv/pcv.h
+++ b/src/core/hle/service/pcv/pcv.h
@@ -1,0 +1,15 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace Service::SM {
+class ServiceManager;
+}
+
+namespace Service::PCV {
+
+void InstallInterfaces(SM::ServiceManager& sm);
+
+} // namespace Service::PCV

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -21,6 +21,7 @@
 #include "core/hle/service/apm/apm.h"
 #include "core/hle/service/audio/audio.h"
 #include "core/hle/service/bcat/bcat.h"
+#include "core/hle/service/bpc/bpc.h"
 #include "core/hle/service/btdrv/btdrv.h"
 #include "core/hle/service/btm/btm.h"
 #include "core/hle/service/erpt/erpt.h"
@@ -47,6 +48,7 @@
 #include "core/hle/service/nvdrv/nvdrv.h"
 #include "core/hle/service/pcie/pcie.h"
 #include "core/hle/service/pctl/pctl.h"
+#include "core/hle/service/pcv/pcv.h"
 #include "core/hle/service/pm/pm.h"
 #include "core/hle/service/prepo/prepo.h"
 #include "core/hle/service/service.h"
@@ -204,6 +206,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm) {
     APM::InstallInterfaces(*sm);
     Audio::InstallInterfaces(*sm);
     BCAT::InstallInterfaces(*sm);
+    BPC::InstallInterfaces(*sm);
     BtDrv::InstallInterfaces(*sm);
     BTM::InstallInterfaces(*sm);
     ERPT::InstallInterfaces(*sm);
@@ -230,6 +233,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm) {
     Nvidia::InstallInterfaces(*sm);
     PCIe::InstallInterfaces(*sm);
     PCTL::InstallInterfaces(*sm);
+    PCV::InstallInterfaces(*sm);
     PlayReport::InstallInterfaces(*sm);
     PM::InstallInterfaces(*sm);
     Set::InstallInterfaces(*sm);


### PR DESCRIPTION
Adds the basic skeleton for the remaining pcv-related services based off information on Switch Brew.