### PR TITLE
service/filesystem: Add fsp:ldr and fsp:pr services

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -172,6 +172,10 @@ add_library(core STATIC
     hle/service/fatal/fatal_u.h
     hle/service/filesystem/filesystem.cpp
     hle/service/filesystem/filesystem.h
+    hle/service/filesystem/fsp_ldr.cpp
+    hle/service/filesystem/fsp_ldr.h
+    hle/service/filesystem/fsp_pr.cpp
+    hle/service/filesystem/fsp_pr.h
     hle/service/filesystem/fsp_srv.cpp
     hle/service/filesystem/fsp_srv.h
     hle/service/fgm/fgm.cpp

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -14,6 +14,8 @@
 #include "core/file_sys/vfs_offset.h"
 #include "core/file_sys/vfs_real.h"
 #include "core/hle/service/filesystem/filesystem.h"
+#include "core/hle/service/filesystem/fsp_ldr.h"
+#include "core/hle/service/filesystem/fsp_pr.h"
 #include "core/hle/service/filesystem/fsp_srv.h"
 
 namespace Service::FileSystem {
@@ -298,6 +300,8 @@ void RegisterFileSystems() {
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     RegisterFileSystems();
+    std::make_shared<FSP_LDR>()->InstallAsService(service_manager);
+    std::make_shared<FSP_PR>()->InstallAsService(service_manager);
     std::make_shared<FSP_SRV>()->InstallAsService(service_manager);
 }
 

--- a/src/core/hle/service/filesystem/fsp_ldr.cpp
+++ b/src/core/hle/service/filesystem/fsp_ldr.cpp
@@ -1,0 +1,24 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/filesystem/fsp_ldr.h"
+#include "core/hle/service/service.h"
+
+namespace Service::FileSystem {
+
+FSP_LDR::FSP_LDR() : ServiceFramework{"fsp:ldr"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "OpenCodeFileSystem"},
+        {1, nullptr, "IsArchivedProgram"},
+        {2, nullptr, "SetCurrentProcess"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+} // namespace Service::FileSystem

--- a/src/core/hle/service/filesystem/fsp_ldr.h
+++ b/src/core/hle/service/filesystem/fsp_ldr.h
@@ -1,0 +1,16 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service::FileSystem {
+
+class FSP_LDR final : public ServiceFramework<FSP_LDR> {
+public:
+    explicit FSP_LDR();
+};
+
+} // namespace Service::FileSystem

--- a/src/core/hle/service/filesystem/fsp_pr.cpp
+++ b/src/core/hle/service/filesystem/fsp_pr.cpp
@@ -1,0 +1,25 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/filesystem/fsp_pr.h"
+#include "core/hle/service/service.h"
+
+namespace Service::FileSystem {
+
+FSP_PR::FSP_PR() : ServiceFramework{"fsp:pr"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "RegisterProgram"},
+        {1, nullptr, "UnregisterProgram"},
+        {2, nullptr, "SetCurrentProcess"},
+        {256, nullptr, "SetEnabledProgramVerification"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+} // namespace Service::FileSystem

--- a/src/core/hle/service/filesystem/fsp_pr.h
+++ b/src/core/hle/service/filesystem/fsp_pr.h
@@ -1,0 +1,16 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service::FileSystem {
+
+class FSP_PR final : public ServiceFramework<FSP_PR> {
+public:
+    explicit FSP_PR();
+};
+
+} // namespace Service::FileSystem


### PR DESCRIPTION
Adds the basic skeleton for the remaining fsp services based off information provided by Switch Brew.