### PR TITLE
video_core: Make global EmuWindow instance part of the base renderer …

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -86,7 +86,7 @@ System::ResultStatus System::SingleStep() {
     return RunLoop(false);
 }
 
-System::ResultStatus System::Load(EmuWindow* emu_window, const std::string& filepath) {
+System::ResultStatus System::Load(EmuWindow& emu_window, const std::string& filepath) {
     app_loader = Loader::GetLoader(std::make_shared<FileSys::RealVfsFile>(filepath));
 
     if (!app_loader) {
@@ -163,7 +163,7 @@ Cpu& System::CpuCore(size_t core_index) {
     return *cpu_cores[core_index];
 }
 
-System::ResultStatus System::Init(EmuWindow* emu_window, u32 system_mode) {
+System::ResultStatus System::Init(EmuWindow& emu_window, u32 system_mode) {
     LOG_DEBUG(HW_Memory, "initialized OK");
 
     CoreTiming::Init();

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -81,11 +81,12 @@ public:
 
     /**
      * Load an executable application.
-     * @param emu_window Pointer to the host-system window used for video output and keyboard input.
+     * @param emu_window Reference to the host-system window used for video output and keyboard
+     *                   input.
      * @param filepath String path to the executable application to load on the host file system.
      * @returns ResultStatus code, indicating if the operation succeeded.
      */
-    ResultStatus Load(EmuWindow* emu_window, const std::string& filepath);
+    ResultStatus Load(EmuWindow& emu_window, const std::string& filepath);
 
     /**
      * Indicates if the emulated system is powered on (all subsystems initialized and able to run an
@@ -186,11 +187,12 @@ private:
 
     /**
      * Initialize the emulated system.
-     * @param emu_window Pointer to the host-system window used for video output and keyboard input.
+     * @param emu_window Reference to the host-system window used for video output and keyboard
+     *                   input.
      * @param system_mode The system mode.
      * @return ResultStatus code, indicating if the operation succeeded.
      */
-    ResultStatus Init(EmuWindow* emu_window, u32 system_mode);
+    ResultStatus Init(EmuWindow& emu_window, u32 system_mode);
 
     /// AppLoader used to load the current executing application
     std::unique_ptr<Loader::AppLoader> app_loader;

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -5,9 +5,8 @@
 #include "core/gdbstub/gdbstub.h"
 #include "core/hle/service/hid/hid.h"
 #include "core/settings.h"
+#include "video_core/renderer_base.h"
 #include "video_core/video_core.h"
-
-#include "core/frontend/emu_window.h"
 
 namespace Settings {
 
@@ -20,9 +19,8 @@ void Apply() {
 
     VideoCore::g_toggle_framelimit_enabled = values.toggle_framelimit;
 
-    if (VideoCore::g_emu_window) {
-        auto layout = VideoCore::g_emu_window->GetFramebufferLayout();
-        VideoCore::g_emu_window->UpdateCurrentFramebufferLayout(layout.width, layout.height);
+    if (VideoCore::g_renderer) {
+        VideoCore::g_renderer->UpdateCurrentFramebufferLayout();
     }
 
     Service::HID::ReloadInputDevices();

--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -2,14 +2,22 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <atomic>
 #include <memory>
+#include "core/frontend/emu_window.h"
 #include "video_core/renderer_base.h"
 #include "video_core/renderer_opengl/gl_rasterizer.h"
-#include "video_core/video_core.h"
+
+RendererBase::RendererBase(EmuWindow& window) : render_window{window} {}
+RendererBase::~RendererBase() = default;
+
+void RendererBase::UpdateCurrentFramebufferLayout() {
+    const Layout::FramebufferLayout& layout = render_window.GetFramebufferLayout();
+
+    render_window.UpdateCurrentFramebufferLayout(layout.width, layout.height);
+}
 
 void RendererBase::RefreshRasterizerSetting() {
     if (rasterizer == nullptr) {
-        rasterizer = std::make_unique<RasterizerOpenGL>();
+        rasterizer = std::make_unique<RasterizerOpenGL>(render_window);
     }
 }

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -18,22 +18,20 @@ public:
     /// Used to reference a framebuffer
     enum kFramebuffer { kFramebuffer_VirtualXFB = 0, kFramebuffer_EFB, kFramebuffer_Texture };
 
-    virtual ~RendererBase() {}
+    explicit RendererBase(EmuWindow& window);
+    virtual ~RendererBase();
 
     /// Swap buffers (render frame)
     virtual void SwapBuffers(boost::optional<const Tegra::FramebufferConfig&> framebuffer) = 0;
-
-    /**
-     * Set the emulator window to use for renderer
-     * @param window EmuWindow handle to emulator window to use for rendering
-     */
-    virtual void SetWindow(EmuWindow* window) = 0;
 
     /// Initialize the renderer
     virtual bool Init() = 0;
 
     /// Shutdown the renderer
     virtual void ShutDown() = 0;
+
+    /// Updates the framebuffer layout of the contained render window handle.
+    void UpdateCurrentFramebufferLayout();
 
     // Getter/setter functions:
     // ------------------------
@@ -53,9 +51,8 @@ public:
     void RefreshRasterizerSetting();
 
 protected:
+    EmuWindow& render_window; ///< Reference to the render window handle.
     std::unique_ptr<VideoCore::RasterizerInterface> rasterizer;
     f32 m_current_fps = 0.0f; ///< Current framerate, should be set by the renderer
     int m_current_frame = 0;  ///< Current frame, should be set by the renderer
-
-private:
 };

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -14,7 +14,6 @@
 #include "common/logging/log.h"
 #include "common/math_util.h"
 #include "common/microprofile.h"
-#include "common/scope_exit.h"
 #include "core/core.h"
 #include "core/frontend/emu_window.h"
 #include "core/hle/kernel/process.h"
@@ -37,7 +36,7 @@ MICROPROFILE_DEFINE(OpenGL_Drawing, "OpenGL", "Drawing", MP_RGB(128, 128, 192));
 MICROPROFILE_DEFINE(OpenGL_Blits, "OpenGL", "Blits", MP_RGB(100, 100, 255));
 MICROPROFILE_DEFINE(OpenGL_CacheManagement, "OpenGL", "Cache Mgmt", MP_RGB(100, 255, 100));
 
-RasterizerOpenGL::RasterizerOpenGL() {
+RasterizerOpenGL::RasterizerOpenGL(EmuWindow& window) : emu_window{window} {
     // Create sampler objects
     for (size_t i = 0; i < texture_samplers.size(); ++i) {
         texture_samplers[i].Create();
@@ -395,7 +394,7 @@ void RasterizerOpenGL::Clear() {
     if (clear_mask == 0)
         return;
 
-    ScopeAcquireGLContext acquire_context;
+    ScopeAcquireGLContext acquire_context{emu_window};
 
     auto [dirty_color_surface, dirty_depth_surface] =
         ConfigureFramebuffers(use_color_fb, use_depth_fb);
@@ -425,7 +424,7 @@ void RasterizerOpenGL::DrawArrays() {
     MICROPROFILE_SCOPE(OpenGL_Drawing);
     const auto& regs = Core::System::GetInstance().GPU().Maxwell3D().regs;
 
-    ScopeAcquireGLContext acquire_context;
+    ScopeAcquireGLContext acquire_context{emu_window};
 
     auto [dirty_color_surface, dirty_depth_surface] =
         ConfigureFramebuffers(true, regs.zeta.Address() != 0 && regs.zeta_enable != 0);

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -21,11 +21,12 @@
 #include "video_core/renderer_opengl/gl_state.h"
 #include "video_core/renderer_opengl/gl_stream_buffer.h"
 
+class EmuWindow;
 struct ScreenInfo;
 
 class RasterizerOpenGL : public VideoCore::RasterizerInterface {
 public:
-    RasterizerOpenGL();
+    explicit RasterizerOpenGL(EmuWindow& renderer);
     ~RasterizerOpenGL() override;
 
     void DrawArrays() override;
@@ -143,6 +144,8 @@ private:
     OpenGLState state;
 
     RasterizerCacheOpenGL res_cache;
+
+    EmuWindow& emu_window;
 
     std::unique_ptr<GLShader::ProgramManager> shader_program_manager;
     OGLVertexArray sw_vao;

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -34,23 +34,20 @@ struct ScreenInfo {
 /// Helper class to acquire/release OpenGL context within a given scope
 class ScopeAcquireGLContext : NonCopyable {
 public:
-    ScopeAcquireGLContext();
+    explicit ScopeAcquireGLContext(EmuWindow& window);
     ~ScopeAcquireGLContext();
+
+private:
+    EmuWindow& emu_window;
 };
 
 class RendererOpenGL : public RendererBase {
 public:
-    RendererOpenGL();
+    explicit RendererOpenGL(EmuWindow& window);
     ~RendererOpenGL() override;
 
     /// Swap buffers (render frame)
     void SwapBuffers(boost::optional<const Tegra::FramebufferConfig&> framebuffer) override;
-
-    /**
-     * Set the emulator window to use for renderer
-     * @param window EmuWindow handle to emulator window to use for rendering
-     */
-    void SetWindow(EmuWindow* window) override;
 
     /// Initialize the renderer
     bool Init() override;
@@ -71,8 +68,6 @@ private:
     // Fills active OpenGL texture with the given RGBA color.
     void LoadColorToActiveGLTexture(u8 color_r, u8 color_g, u8 color_b, u8 color_a,
                                     const TextureInfo& texture);
-
-    EmuWindow* render_window; ///< Handle to render window
 
     OpenGLState state;
 

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -13,16 +13,13 @@
 
 namespace VideoCore {
 
-EmuWindow* g_emu_window = nullptr;        ///< Frontend emulator window
 std::unique_ptr<RendererBase> g_renderer; ///< Renderer plugin
 
 std::atomic<bool> g_toggle_framelimit_enabled;
 
 /// Initialize the video core
-bool Init(EmuWindow* emu_window) {
-    g_emu_window = emu_window;
-    g_renderer = std::make_unique<RendererOpenGL>();
-    g_renderer->SetWindow(g_emu_window);
+bool Init(EmuWindow& emu_window) {
+    g_renderer = std::make_unique<RendererOpenGL>(emu_window);
     if (g_renderer->Init()) {
         LOG_DEBUG(Render, "initialized OK");
     } else {

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -18,7 +18,6 @@ namespace VideoCore {
 enum class Renderer { Software, OpenGL };
 
 extern std::unique_ptr<RendererBase> g_renderer; ///< Renderer plugin
-extern EmuWindow* g_emu_window;                  ///< Emu window
 
 // TODO: Wrap these in a user settings struct along with any other graphics settings (often set from
 // qt ui)
@@ -28,7 +27,7 @@ extern std::atomic<bool> g_toggle_framelimit_enabled;
 void Start();
 
 /// Initialize the video core
-bool Init(EmuWindow* emu_window);
+bool Init(EmuWindow& emu_window);
 
 /// Shutdown the video core
 void Shutdown();

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -402,7 +402,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
 
     system.SetGPUDebugContext(debug_context);
 
-    const Core::System::ResultStatus result{system.Load(render_window, filename.toStdString())};
+    const Core::System::ResultStatus result{system.Load(*render_window, filename.toStdString())};
 
     render_window->DoneCurrent();
 

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -162,7 +162,7 @@ int main(int argc, char** argv) {
 
     SCOPE_EXIT({ system.Shutdown(); });
 
-    const Core::System::ResultStatus load_result{system.Load(emu_window.get(), filepath)};
+    const Core::System::ResultStatus load_result{system.Load(*emu_window, filepath)};
 
     switch (load_result) {
     case Core::System::ResultStatus::ErrorGetLoader:


### PR DESCRIPTION
Makes the global a member of the RendererBase class. We also change this to be a reference. Passing any form of null pointer to these functions is incorrect entirely, especially given the code itself assumes that the pointer would always be in a valid state.

This also makes it easier to follow the lifecycle of instances being used, as we explicitly interact the renderer with the rasterizer, rather than it just operating on a global pointer.