### PR TITLE
audio_out: Use Buffer::Tag alias in GetTagsAndReleaseBuffers()'s prototype

### DIFF
--- a/src/audio_core/audio_out.cpp
+++ b/src/audio_core/audio_out.cpp
@@ -39,7 +39,7 @@ StreamPtr AudioOut::OpenStream(u32 sample_rate, u32 num_channels,
                                     sink->AcquireSinkStream(sample_rate, num_channels));
 }
 
-std::vector<u64> AudioOut::GetTagsAndReleaseBuffers(StreamPtr stream, size_t max_count) {
+std::vector<Buffer::Tag> AudioOut::GetTagsAndReleaseBuffers(StreamPtr stream, size_t max_count) {
     return stream->GetTagsAndReleaseBuffers(max_count);
 }
 

--- a/src/audio_core/audio_out.h
+++ b/src/audio_core/audio_out.h
@@ -24,7 +24,7 @@ public:
                          Stream::ReleaseCallback&& release_callback);
 
     /// Returns a vector of recently released buffers specified by tag for the specified stream
-    std::vector<u64> GetTagsAndReleaseBuffers(StreamPtr stream, size_t max_count);
+    std::vector<Buffer::Tag> GetTagsAndReleaseBuffers(StreamPtr stream, size_t max_count);
 
     /// Starts an audio stream for playback
     void StartStream(StreamPtr stream);


### PR DESCRIPTION
This makes the `Buffer::Tag` usage consistent with the Stream class's prototype of `GetTagsAndReleaseBuffers()`.