### PR TITLE
service: Add migration services

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -180,6 +180,7 @@ void FileBackend::Write(const Entry& entry) {
     SUB(Service, LBL)                                                                              \
     SUB(Service, LDN)                                                                              \
     SUB(Service, LM)                                                                               \
+    SUB(Service, Migration)                                                                        \
     SUB(Service, Mii)                                                                              \
     SUB(Service, MM)                                                                               \
     SUB(Service, NCM)                                                                              \

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -67,6 +67,7 @@ enum class Class : ClassType {
     Service_LBL,       ///< The LBL (LCD backlight) service
     Service_LDN,       ///< The LDN (Local domain network) service
     Service_LM,        ///< The LM (Logger) service
+    Service_Migration, ///< The migration service
     Service_Mii,       ///< The Mii service
     Service_MM,        ///< The MM (Multimedia) service
     Service_NCM,       ///< The NCM service

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -204,6 +204,8 @@ add_library(core STATIC
     hle/service/ldr/ldr.h
     hle/service/lm/lm.cpp
     hle/service/lm/lm.h
+    hle/service/mig/mig.cpp
+    hle/service/mig/mig.h
     hle/service/mii/mii.cpp
     hle/service/mii/mii.h
     hle/service/mm/mm_u.cpp

--- a/src/core/hle/service/mig/mig.cpp
+++ b/src/core/hle/service/mig/mig.cpp
@@ -1,0 +1,34 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+
+#include "core/hle/service/mig/mig.h"
+#include "core/hle/service/service.h"
+#include "core/hle/service/sm/sm.h"
+
+namespace Service::Migration {
+
+class MIG_USR final : public ServiceFramework<MIG_USR> {
+public:
+    explicit MIG_USR() : ServiceFramework{"mig:usr"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {10, nullptr, "TryGetLastMigrationInfo"},
+            {100, nullptr, "CreateServer"},
+            {101, nullptr, "ResumeServer"},
+            {200, nullptr, "CreateClient"},
+            {201, nullptr, "ResumeClient"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+void InstallInterfaces(SM::ServiceManager& sm) {
+    std::make_shared<MIG_USR>()->InstallAsService(sm);
+}
+
+} // namespace Service::Migration

--- a/src/core/hle/service/mig/mig.h
+++ b/src/core/hle/service/mig/mig.h
@@ -1,0 +1,15 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace Service::SM {
+class ServiceManager;
+}
+
+namespace Service::Migration {
+
+void InstallInterfaces(SM::ServiceManager& sm);
+
+} // namespace Service::Migration

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -38,6 +38,7 @@
 #include "core/hle/service/ldn/ldn.h"
 #include "core/hle/service/ldr/ldr.h"
 #include "core/hle/service/lm/lm.h"
+#include "core/hle/service/mig/mig.h"
 #include "core/hle/service/mii/mii.h"
 #include "core/hle/service/mm/mm_u.h"
 #include "core/hle/service/ncm/ncm.h"
@@ -224,6 +225,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm) {
     LDN::InstallInterfaces(*sm);
     LDR::InstallInterfaces(*sm);
     LM::InstallInterfaces(*sm);
+    Migration::InstallInterfaces(*sm);
     Mii::InstallInterfaces(*sm);
     MM::InstallInterfaces(*sm);
     NCM::InstallInterfaces(*sm);


### PR DESCRIPTION
Adds the basic skeleton for the mig:usr service based off information provided by Switch Brew.