### PR TITLE
math_util: Always initialize members of Rectangle

### DIFF
--- a/src/common/math_util.h
+++ b/src/common/math_util.h
@@ -19,12 +19,12 @@ inline bool IntervalsIntersect(unsigned start0, unsigned length0, unsigned start
 
 template <class T>
 struct Rectangle {
-    T left;
-    T top;
-    T right;
-    T bottom;
+    T left{};
+    T top{};
+    T right{};
+    T bottom{};
 
-    Rectangle() {}
+    Rectangle() = default;
 
     Rectangle(T left, T top, T right, T bottom)
         : left(left), top(top), right(right), bottom(bottom) {}


### PR DESCRIPTION
Prevents potentially using the members uninitialized.