### PR TITLE
gl_shader_manager: Take ShaderSetup instances by const reference in UseProgrammableVertexShader() and UseProgrammableFragmentShader()

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -105,14 +105,14 @@ public:
     }
 
     ShaderEntries UseProgrammableVertexShader(const MaxwellVSConfig& config,
-                                              const ShaderSetup setup) {
+                                              const ShaderSetup& setup) {
         ShaderEntries result;
         std::tie(current.vs, result) = vertex_shaders.Get(config, setup);
         return result;
     }
 
     ShaderEntries UseProgrammableFragmentShader(const MaxwellFSConfig& config,
-                                                const ShaderSetup setup) {
+                                                const ShaderSetup& setup) {
         ShaderEntries result;
         std::tie(current.fs, result) = fragment_shaders.Get(config, setup);
         return result;


### PR DESCRIPTION
Avoids performing unnecessary copies of 65560 byte sized ShaderSetup instances, considering it's only used as part of lookup and not modified.

Given the parameters were already const, it's likely taking these parameters by reference was intended but the ampersand was forgotten.