### PR TITLE
yuzu: Use Qt 5 signal/slots where applicable

### DIFF
--- a/src/yuzu/debugger/graphics/graphics_breakpoint_observer.cpp
+++ b/src/yuzu/debugger/graphics/graphics_breakpoint_observer.cpp
@@ -10,12 +10,12 @@ BreakPointObserverDock::BreakPointObserverDock(std::shared_ptr<Tegra::DebugConte
     : QDockWidget(title, parent), BreakPointObserver(debug_context) {
     qRegisterMetaType<Tegra::DebugContext::Event>("Tegra::DebugContext::Event");
 
-    connect(this, SIGNAL(Resumed()), this, SLOT(OnResumed()));
+    connect(this, &BreakPointObserverDock::Resumed, this, &BreakPointObserverDock::OnResumed);
 
     // NOTE: This signal is emitted from a non-GUI thread, but connect() takes
     //       care of delaying its handling to the GUI thread.
-    connect(this, SIGNAL(BreakPointHit(Tegra::DebugContext::Event, void*)), this,
-            SLOT(OnBreakPointHit(Tegra::DebugContext::Event, void*)), Qt::BlockingQueuedConnection);
+    connect(this, &BreakPointObserverDock::BreakPointHit, this,
+            &BreakPointObserverDock::OnBreakPointHit, Qt::BlockingQueuedConnection);
 }
 
 void BreakPointObserverDock::OnMaxwellBreakPointHit(Tegra::DebugContext::Event event, void* data) {

--- a/src/yuzu/debugger/graphics/graphics_breakpoint_observer.h
+++ b/src/yuzu/debugger/graphics/graphics_breakpoint_observer.h
@@ -23,11 +23,11 @@ public:
     void OnMaxwellBreakPointHit(Tegra::DebugContext::Event event, void* data) override;
     void OnMaxwellResume() override;
 
-private slots:
-    virtual void OnBreakPointHit(Tegra::DebugContext::Event event, void* data) = 0;
-    virtual void OnResumed() = 0;
-
 signals:
     void Resumed();
     void BreakPointHit(Tegra::DebugContext::Event event, void* data);
+
+private:
+    virtual void OnBreakPointHit(Tegra::DebugContext::Event event, void* data) = 0;
+    virtual void OnResumed() = 0;
 };

--- a/src/yuzu/debugger/graphics/graphics_breakpoints.cpp
+++ b/src/yuzu/debugger/graphics/graphics_breakpoints.cpp
@@ -144,21 +144,25 @@ GraphicsBreakPointsWidget::GraphicsBreakPointsWidget(
 
     qRegisterMetaType<Tegra::DebugContext::Event>("Tegra::DebugContext::Event");
 
-    connect(breakpoint_list, SIGNAL(doubleClicked(const QModelIndex&)), this,
-            SLOT(OnItemDoubleClicked(const QModelIndex&)));
+    connect(breakpoint_list, &QTreeView::doubleClicked, this,
+            &GraphicsBreakPointsWidget::OnItemDoubleClicked);
 
-    connect(resume_button, SIGNAL(clicked()), this, SLOT(OnResumeRequested()));
+    connect(resume_button, &QPushButton::clicked, this,
+            &GraphicsBreakPointsWidget::OnResumeRequested);
 
-    connect(this, SIGNAL(BreakPointHit(Tegra::DebugContext::Event, void*)), this,
-            SLOT(OnBreakPointHit(Tegra::DebugContext::Event, void*)), Qt::BlockingQueuedConnection);
-    connect(this, SIGNAL(Resumed()), this, SLOT(OnResumed()));
+    connect(this, &GraphicsBreakPointsWidget::BreakPointHit, this,
+            &GraphicsBreakPointsWidget::OnBreakPointHit, Qt::BlockingQueuedConnection);
+    connect(this, &GraphicsBreakPointsWidget::Resumed, this, &GraphicsBreakPointsWidget::OnResumed);
 
-    connect(this, SIGNAL(BreakPointHit(Tegra::DebugContext::Event, void*)), breakpoint_model,
-            SLOT(OnBreakPointHit(Tegra::DebugContext::Event)), Qt::BlockingQueuedConnection);
-    connect(this, SIGNAL(Resumed()), breakpoint_model, SLOT(OnResumed()));
+    connect(this, &GraphicsBreakPointsWidget::BreakPointHit, breakpoint_model,
+            &BreakPointModel::OnBreakPointHit, Qt::BlockingQueuedConnection);
+    connect(this, &GraphicsBreakPointsWidget::Resumed, breakpoint_model,
+            &BreakPointModel::OnResumed);
 
-    connect(this, SIGNAL(BreakPointsChanged(const QModelIndex&, const QModelIndex&)),
-            breakpoint_model, SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&)));
+    connect(this, &GraphicsBreakPointsWidget::BreakPointsChanged,
+            [this](const QModelIndex& top_left, const QModelIndex& bottom_right) {
+                breakpoint_model->dataChanged(top_left, bottom_right);
+            });
 
     QWidget* main_widget = new QWidget;
     auto main_layout = new QVBoxLayout;

--- a/src/yuzu/debugger/graphics/graphics_breakpoints.h
+++ b/src/yuzu/debugger/graphics/graphics_breakpoints.h
@@ -26,18 +26,17 @@ public:
     void OnMaxwellBreakPointHit(Tegra::DebugContext::Event event, void* data) override;
     void OnMaxwellResume() override;
 
-public slots:
-    void OnBreakPointHit(Tegra::DebugContext::Event event, void* data);
-    void OnItemDoubleClicked(const QModelIndex&);
-    void OnResumeRequested();
-    void OnResumed();
-
 signals:
     void Resumed();
     void BreakPointHit(Tegra::DebugContext::Event event, void* data);
     void BreakPointsChanged(const QModelIndex& topLeft, const QModelIndex& bottomRight);
 
 private:
+    void OnBreakPointHit(Tegra::DebugContext::Event event, void* data);
+    void OnItemDoubleClicked(const QModelIndex&);
+    void OnResumeRequested();
+    void OnResumed();
+
     QLabel* status_text;
     QPushButton* resume_button;
 

--- a/src/yuzu/debugger/graphics/graphics_breakpoints_p.h
+++ b/src/yuzu/debugger/graphics/graphics_breakpoints_p.h
@@ -25,7 +25,6 @@ public:
 
     bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
 
-public slots:
     void OnBreakPointHit(Tegra::DebugContext::Event event);
     void OnResumed();
 

--- a/src/yuzu/debugger/graphics/graphics_surface.cpp
+++ b/src/yuzu/debugger/graphics/graphics_surface.cpp
@@ -153,22 +153,24 @@ GraphicsSurfaceWidget::GraphicsSurfaceWidget(std::shared_ptr<Tegra::DebugContext
     save_surface = new QPushButton(QIcon::fromTheme("document-save"), tr("Save"));
 
     // Connections
-    connect(this, SIGNAL(Update()), this, SLOT(OnUpdate()));
-    connect(surface_source_list, SIGNAL(currentIndexChanged(int)), this,
-            SLOT(OnSurfaceSourceChanged(int)));
-    connect(surface_address_control, SIGNAL(ValueChanged(qint64)), this,
-            SLOT(OnSurfaceAddressChanged(qint64)));
-    connect(surface_width_control, SIGNAL(valueChanged(int)), this,
-            SLOT(OnSurfaceWidthChanged(int)));
-    connect(surface_height_control, SIGNAL(valueChanged(int)), this,
-            SLOT(OnSurfaceHeightChanged(int)));
-    connect(surface_format_control, SIGNAL(currentIndexChanged(int)), this,
-            SLOT(OnSurfaceFormatChanged(int)));
-    connect(surface_picker_x_control, SIGNAL(valueChanged(int)), this,
-            SLOT(OnSurfacePickerXChanged(int)));
-    connect(surface_picker_y_control, SIGNAL(valueChanged(int)), this,
-            SLOT(OnSurfacePickerYChanged(int)));
-    connect(save_surface, SIGNAL(clicked()), this, SLOT(SaveSurface()));
+    connect(this, &GraphicsSurfaceWidget::Update, this, &GraphicsSurfaceWidget::OnUpdate);
+    connect(surface_source_list,
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            &GraphicsSurfaceWidget::OnSurfaceSourceChanged);
+    connect(surface_address_control, &CSpinBox::ValueChanged, this,
+            &GraphicsSurfaceWidget::OnSurfaceAddressChanged);
+    connect(surface_width_control, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &GraphicsSurfaceWidget::OnSurfaceWidthChanged);
+    connect(surface_height_control, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &GraphicsSurfaceWidget::OnSurfaceHeightChanged);
+    connect(surface_format_control,
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this,
+            &GraphicsSurfaceWidget::OnSurfaceFormatChanged);
+    connect(surface_picker_x_control, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &GraphicsSurfaceWidget::OnSurfacePickerXChanged);
+    connect(surface_picker_y_control, static_cast<void (QSpinBox::*)(int)>(&QSpinBox::valueChanged),
+            this, &GraphicsSurfaceWidget::OnSurfacePickerYChanged);
+    connect(save_surface, &QPushButton::clicked, this, &GraphicsSurfaceWidget::SaveSurface);
 
     auto main_widget = new QWidget;
     auto main_layout = new QVBoxLayout;

--- a/src/yuzu/debugger/graphics/graphics_surface.h
+++ b/src/yuzu/debugger/graphics/graphics_surface.h
@@ -65,16 +65,15 @@ public slots:
     void OnSurfacePickerYChanged(int new_value);
     void OnUpdate();
 
-private slots:
+signals:
+    void Update();
+
+private:
     void OnBreakPointHit(Tegra::DebugContext::Event event, void* data) override;
     void OnResumed() override;
 
     void SaveSurface();
 
-signals:
-    void Update();
-
-private:
     QComboBox* surface_source_list;
     CSpinBox* surface_address_control;
     QSpinBox* surface_width_control;


### PR DESCRIPTION
Makes the signal/slot connections type-safe instead of string-based.