### PR TITLE
gl_shader_manager: Make ProgramManager's GetCurrentProgramStage() a const member function

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -118,7 +118,7 @@ public:
         return result;
     }
 
-    GLuint GetCurrentProgramStage(Maxwell3D::Regs::ShaderStage stage) {
+    GLuint GetCurrentProgramStage(Maxwell3D::Regs::ShaderStage stage) const {
         switch (stage) {
         case Maxwell3D::Regs::ShaderStage::Vertex:
             return current.vs;


### PR DESCRIPTION
This function doesn't modify class state, so it can be made const.