### PR TITLE
video_core: Remove unimplemented Start() function prototype

### DIFF
--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -23,9 +23,6 @@ extern std::unique_ptr<RendererBase> g_renderer; ///< Renderer plugin
 // qt ui)
 extern std::atomic<bool> g_toggle_framelimit_enabled;
 
-/// Start the video core
-void Start();
-
 /// Initialize the video core
 bool Init(EmuWindow& emu_window);
 


### PR DESCRIPTION
Given this has no definition, we can just remove it entirely.