### PR TITLE
video_core: Eliminate the g_renderer global variable

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -187,7 +187,7 @@ System::ResultStatus System::Init(EmuWindow& emu_window) {
         return ResultStatus::ErrorVideoCore;
     }
 
-    gpu_core = std::make_unique<Tegra::GPU>(*renderer->Rasterizer());
+    gpu_core = std::make_unique<Tegra::GPU>(renderer->Rasterizer());
 
     // Create threads for CPU cores 1-3, and build thread_to_cpu map
     // CPU core 0 is run on the main thread

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -18,6 +18,7 @@
 #include "core/loader/loader.h"
 #include "core/settings.h"
 #include "file_sys/vfs_real.h"
+#include "video_core/renderer_base.h"
 #include "video_core/video_core.h"
 
 namespace Core {
@@ -174,7 +175,6 @@ System::ResultStatus System::Init(EmuWindow& emu_window) {
         cpu_cores[index] = std::make_shared<Cpu>(cpu_exclusive_monitor, cpu_barrier, index);
     }
 
-    gpu_core = std::make_unique<Tegra::GPU>();
     telemetry_session = std::make_unique<Core::TelemetrySession>();
     service_manager = std::make_shared<Service::SM::ServiceManager>();
 
@@ -182,9 +182,12 @@ System::ResultStatus System::Init(EmuWindow& emu_window) {
     Service::Init(service_manager);
     GDBStub::Init();
 
-    if (!VideoCore::Init(emu_window)) {
+    renderer = VideoCore::CreateRenderer(emu_window);
+    if (!renderer->Init()) {
         return ResultStatus::ErrorVideoCore;
     }
+
+    gpu_core = std::make_unique<Tegra::GPU>(*renderer->Rasterizer());
 
     // Create threads for CPU cores 1-3, and build thread_to_cpu map
     // CPU core 0 is run on the main thread
@@ -217,7 +220,7 @@ void System::Shutdown() {
                          perf_results.frametime * 1000.0);
 
     // Shutdown emulation session
-    VideoCore::Shutdown();
+    renderer.reset();
     GDBStub::Shutdown();
     Service::Shutdown();
     Kernel::Shutdown();

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -27,6 +27,10 @@ namespace Service::SM {
 class ServiceManager;
 }
 
+namespace VideoCore {
+class RendererBase;
+}
+
 namespace Core {
 
 class System {
@@ -127,9 +131,24 @@ public:
     /// Gets a CPU interface to the CPU core with the specified index
     Cpu& CpuCore(size_t core_index);
 
-    /// Gets the GPU interface
+    /// Gets a mutable reference to the GPU interface
     Tegra::GPU& GPU() {
         return *gpu_core;
+    }
+
+    /// Gets an immutable reference to the GPU interface.
+    const Tegra::GPU& GPU() const {
+        return *gpu_core;
+    }
+
+    /// Gets a mutable reference to the renderer.
+    VideoCore::RendererBase& Renderer() {
+        return *renderer;
+    }
+
+    /// Gets an immutable reference to the renderer.
+    const VideoCore::RendererBase& Renderer() const {
+        return *renderer;
     }
 
     /// Gets the scheduler for the CPU core that is currently running
@@ -195,6 +214,7 @@ private:
 
     /// AppLoader used to load the current executing application
     std::unique_ptr<Loader::AppLoader> app_loader;
+    std::unique_ptr<VideoCore::RendererBase> renderer;
     std::unique_ptr<Tegra::GPU> gpu_core;
     std::shared_ptr<Tegra::DebugContext> debug_context;
     Kernel::SharedPtr<Kernel::Process> current_process;

--- a/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
@@ -30,9 +30,9 @@ void nvdisp_disp0::flip(u32 buffer_handle, u32 offset, u32 format, u32 width, u3
         addr,      offset,   width, height, stride, static_cast<PixelFormat>(format),
         transform, crop_rect};
 
-    Core::System::GetInstance().perf_stats.EndGameFrame();
-
-    VideoCore::g_renderer->SwapBuffers(framebuffer);
+    auto& instance = Core::System::GetInstance();
+    instance.perf_stats.EndGameFrame();
+    instance.Renderer().SwapBuffers(framebuffer);
 }
 
 } // namespace Service::Nvidia::Devices

--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
@@ -150,15 +150,16 @@ u32 nvhost_as_gpu::UnmapBuffer(const std::vector<u8>& input, std::vector<u8>& ou
 
     LOG_DEBUG(Service_NVDRV, "called, offset=0x{:X}", params.offset);
 
-    auto& gpu = Core::System::GetInstance().GPU();
-
-    auto itr = buffer_mappings.find(params.offset);
-
+    const auto itr = buffer_mappings.find(params.offset);
     ASSERT_MSG(itr != buffer_mappings.end(), "Tried to unmap invalid mapping");
 
-    // Remove this memory region from the rasterizer cache.
-    VideoCore::g_renderer->Rasterizer()->FlushAndInvalidateRegion(params.offset, itr->second.size);
+    auto& system_instance = Core::System::GetInstance();
 
+    // Remove this memory region from the rasterizer cache.
+    system_instance.Renderer().Rasterizer()->FlushAndInvalidateRegion(params.offset,
+                                                                      itr->second.size);
+
+    auto& gpu = system_instance.GPU();
     params.offset = gpu.memory_manager->UnmapBuffer(params.offset, itr->second.size);
 
     buffer_mappings.erase(itr->second.offset);

--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
@@ -156,8 +156,8 @@ u32 nvhost_as_gpu::UnmapBuffer(const std::vector<u8>& input, std::vector<u8>& ou
     auto& system_instance = Core::System::GetInstance();
 
     // Remove this memory region from the rasterizer cache.
-    system_instance.Renderer().Rasterizer()->FlushAndInvalidateRegion(params.offset,
-                                                                      itr->second.size);
+    system_instance.Renderer().Rasterizer().FlushAndInvalidateRegion(params.offset,
+                                                                     itr->second.size);
 
     auto& gpu = system_instance.GPU();
     params.offset = gpu.memory_manager->UnmapBuffer(params.offset, itr->second.size);

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -127,9 +127,11 @@ void NVFlinger::Compose() {
         MicroProfileFlip();
 
         if (buffer == boost::none) {
+            auto& system_instance = Core::System::GetInstance();
+
             // There was no queued buffer to draw, render previous frame
-            Core::System::GetInstance().perf_stats.EndGameFrame();
-            VideoCore::g_renderer->SwapBuffers({});
+            system_instance.perf_stats.EndGameFrame();
+            system_instance.Renderer().SwapBuffers({});
             continue;
         }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -355,16 +355,16 @@ void RasterizerFlushVirtualRegion(VAddr start, u64 size, FlushMode mode) {
         const u64 overlap_size = overlap_end - overlap_start;
 
         for (const auto& gpu_address : gpu_addresses) {
-            auto* rasterizer = system_instance.Renderer().Rasterizer();
+            auto& rasterizer = system_instance.Renderer().Rasterizer();
             switch (mode) {
             case FlushMode::Flush:
-                rasterizer->FlushRegion(gpu_address, overlap_size);
+                rasterizer.FlushRegion(gpu_address, overlap_size);
                 break;
             case FlushMode::Invalidate:
-                rasterizer->InvalidateRegion(gpu_address, overlap_size);
+                rasterizer.InvalidateRegion(gpu_address, overlap_size);
                 break;
             case FlushMode::FlushAndInvalidate:
-                rasterizer->FlushAndInvalidateRegion(gpu_address, overlap_size);
+                rasterizer.FlushAndInvalidateRegion(gpu_address, overlap_size);
                 break;
             }
         }

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/core.h"
 #include "core/gdbstub/gdbstub.h"
 #include "core/hle/service/hid/hid.h"
 #include "core/settings.h"
@@ -19,8 +20,9 @@ void Apply() {
 
     VideoCore::g_toggle_framelimit_enabled = values.toggle_framelimit;
 
-    if (VideoCore::g_renderer) {
-        VideoCore::g_renderer->UpdateCurrentFramebufferLayout();
+    auto& system_instance = Core::System::GetInstance();
+    if (system_instance.IsPoweredOn()) {
+        system_instance.Renderer().UpdateCurrentFramebufferLayout();
     }
 
     Service::HID::ReloadInputDevices();

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -17,6 +17,10 @@
 #include "video_core/memory_manager.h"
 #include "video_core/textures/texture.h"
 
+namespace VideoCore {
+class RasterizerInterface;
+}
+
 namespace Tegra::Engines {
 
 #define MAXWELL3D_REG_INDEX(field_name)                                                            \
@@ -24,7 +28,7 @@ namespace Tegra::Engines {
 
 class Maxwell3D final {
 public:
-    explicit Maxwell3D(MemoryManager& memory_manager);
+    explicit Maxwell3D(VideoCore::RasterizerInterface& rasterizer, MemoryManager& memory_manager);
     ~Maxwell3D() = default;
 
     /// Register structure of the Maxwell3D engine.
@@ -818,6 +822,8 @@ public:
     Texture::FullTextureInfo GetStageTexture(Regs::ShaderStage stage, size_t offset) const;
 
 private:
+    VideoCore::RasterizerInterface& rasterizer;
+
     std::unordered_map<u32, std::vector<u32>> uploaded_macros;
 
     /// Macro method that is currently being executed / being fed parameters.

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -7,12 +7,13 @@
 #include "video_core/engines/maxwell_compute.h"
 #include "video_core/engines/maxwell_dma.h"
 #include "video_core/gpu.h"
+#include "video_core/rasterizer_interface.h"
 
 namespace Tegra {
 
-GPU::GPU() {
+GPU::GPU(VideoCore::RasterizerInterface& rasterizer) {
     memory_manager = std::make_unique<MemoryManager>();
-    maxwell_3d = std::make_unique<Engines::Maxwell3D>(*memory_manager);
+    maxwell_3d = std::make_unique<Engines::Maxwell3D>(rasterizer, *memory_manager);
     fermi_2d = std::make_unique<Engines::Fermi2D>(*memory_manager);
     maxwell_compute = std::make_unique<Engines::MaxwellCompute>();
     maxwell_dma = std::make_unique<Engines::MaxwellDMA>(*memory_manager);

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -11,6 +11,10 @@
 #include "core/hle/service/nvflinger/buffer_queue.h"
 #include "video_core/memory_manager.h"
 
+namespace VideoCore {
+class RasterizerInterface;
+}
+
 namespace Tegra {
 
 enum class RenderTargetFormat : u32 {
@@ -98,7 +102,7 @@ enum class EngineID {
 
 class GPU final {
 public:
-    GPU();
+    explicit GPU(VideoCore::RasterizerInterface& rasterizer);
     ~GPU();
 
     /// Processes a command list stored at the specified address in GPU memory.

--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -7,6 +7,8 @@
 #include "video_core/renderer_base.h"
 #include "video_core/renderer_opengl/gl_rasterizer.h"
 
+namespace VideoCore {
+
 RendererBase::RendererBase(EmuWindow& window) : render_window{window} {}
 RendererBase::~RendererBase() = default;
 
@@ -21,3 +23,5 @@ void RendererBase::RefreshRasterizerSetting() {
         rasterizer = std::make_unique<RasterizerOpenGL>(render_window);
     }
 }
+
+} // namespace VideoCore

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -13,6 +13,8 @@
 
 class EmuWindow;
 
+namespace VideoCore {
+
 class RendererBase : NonCopyable {
 public:
     /// Used to reference a framebuffer
@@ -44,7 +46,7 @@ public:
         return m_current_frame;
     }
 
-    VideoCore::RasterizerInterface* Rasterizer() const {
+    RasterizerInterface* Rasterizer() const {
         return rasterizer.get();
     }
 
@@ -52,7 +54,9 @@ public:
 
 protected:
     EmuWindow& render_window; ///< Reference to the render window handle.
-    std::unique_ptr<VideoCore::RasterizerInterface> rasterizer;
+    std::unique_ptr<RasterizerInterface> rasterizer;
     f32 m_current_fps = 0.0f; ///< Current framerate, should be set by the renderer
     int m_current_frame = 0;  ///< Current frame, should be set by the renderer
 };
+
+} // namespace VideoCore

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -46,8 +46,12 @@ public:
         return m_current_frame;
     }
 
-    RasterizerInterface* Rasterizer() const {
-        return rasterizer.get();
+    RasterizerInterface& Rasterizer() {
+        return *rasterizer;
+    }
+
+    const RasterizerInterface& Rasterizer() const {
+        return *rasterizer;
     }
 
     void RefreshRasterizerSetting();

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -160,8 +160,8 @@ void RendererOpenGL::LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuf
     // only allows rows to have a memory alignement of 4.
     ASSERT(framebuffer.stride % 4 == 0);
 
-    if (!Rasterizer()->AccelerateDisplay(framebuffer, framebuffer_addr, framebuffer.stride,
-                                         screen_info)) {
+    if (!rasterizer->AccelerateDisplay(framebuffer, framebuffer_addr, framebuffer.stride,
+                                       screen_info)) {
         // Reset the screen info's display texture to its own permanent texture
         screen_info.display_texture = screen_info.texture.resource.handle;
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -103,7 +103,7 @@ ScopeAcquireGLContext::~ScopeAcquireGLContext() {
     }
 }
 
-RendererOpenGL::RendererOpenGL(EmuWindow& window) : RendererBase{window} {}
+RendererOpenGL::RendererOpenGL(EmuWindow& window) : VideoCore::RendererBase{window} {}
 RendererOpenGL::~RendererOpenGL() = default;
 
 /// Swap buffers (render frame)

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -41,7 +41,7 @@ private:
     EmuWindow& emu_window;
 };
 
-class RendererOpenGL : public RendererBase {
+class RendererOpenGL : public VideoCore::RendererBase {
 public:
     explicit RendererOpenGL(EmuWindow& window);
     ~RendererOpenGL() override;

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -3,37 +3,16 @@
 // Refer to the license.txt file included.
 
 #include <memory>
-#include "common/logging/log.h"
 #include "video_core/renderer_base.h"
 #include "video_core/renderer_opengl/renderer_opengl.h"
 #include "video_core/video_core.h"
 
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Video Core namespace
-
 namespace VideoCore {
-
-std::unique_ptr<RendererBase> g_renderer; ///< Renderer plugin
 
 std::atomic<bool> g_toggle_framelimit_enabled;
 
-/// Initialize the video core
-bool Init(EmuWindow& emu_window) {
-    g_renderer = std::make_unique<RendererOpenGL>(emu_window);
-    if (g_renderer->Init()) {
-        LOG_DEBUG(Render, "initialized OK");
-    } else {
-        LOG_CRITICAL(Render, "initialization failed !");
-        return false;
-    }
-    return true;
-}
-
-/// Shutdown the video core
-void Shutdown() {
-    g_renderer.reset();
-
-    LOG_DEBUG(Render, "shutdown OK");
+std::unique_ptr<RendererBase> CreateRenderer(EmuWindow& emu_window) {
+    return std::make_unique<RendererOpenGL>(emu_window);
 }
 
 } // namespace VideoCore

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -8,25 +8,23 @@
 #include <memory>
 
 class EmuWindow;
-class RendererBase;
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-// Video Core namespace
 
 namespace VideoCore {
 
-enum class Renderer { Software, OpenGL };
+class RendererBase;
 
-extern std::unique_ptr<RendererBase> g_renderer; ///< Renderer plugin
+enum class Renderer { Software, OpenGL };
 
 // TODO: Wrap these in a user settings struct along with any other graphics settings (often set from
 // qt ui)
 extern std::atomic<bool> g_toggle_framelimit_enabled;
 
-/// Initialize the video core
-bool Init(EmuWindow& emu_window);
-
-/// Shutdown the video core
-void Shutdown();
+/**
+ * Creates a renderer instance.
+ *
+ * @note The returned renderer instance is simply allocated. Its Init()
+ *       function still needs to be called to fully complete its setup.
+ */
+std::unique_ptr<RendererBase> CreateRenderer(EmuWindow& emu_window);
 
 } // namespace VideoCore

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -445,7 +445,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
 
         case Core::System::ResultStatus::ErrorVideoCore:
             QMessageBox::critical(
-                this, tr("An error occured in the video core."),
+                this, tr("An error occurred initializing the video core."),
                 tr("yuzu has encountered an error while running the video core, please see the "
                    "log for more details."
                    "For more information on accessing the log, please see the following page: "
@@ -459,7 +459,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
         default:
             QMessageBox::critical(
                 this, tr("Error while loading ROM!"),
-                tr("An unknown error occured. Please see the log for more details."));
+                tr("An unknown error occurred. Please see the log for more details."));
             break;
         }
         return false;

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -187,7 +187,7 @@ int main(int argc, char** argv) {
         LOG_CRITICAL(Frontend, "Failed to determine system mode!");
         return -1;
     case Core::System::ResultStatus::ErrorVideoCore:
-        LOG_CRITICAL(Frontend, "VideoCore not initialized");
+        LOG_CRITICAL(Frontend, "Failed to initialize VideoCore!");
         return -1;
     case Core::System::ResultStatus::Success:
         break; // Expected case


### PR DESCRIPTION
We move the initialization of the renderer to the core class, while keeping the creation of it and any other specifics in video_core. This way we can ensure that the renderer is initialized and doesn't give unfettered access to the renderer. This also makes dependencies on types more explicit.

For example, the GPU class doesn't need to depend on the existence of a renderer, it only needs to care about whether or not it has a rasterizer, but since it was accessing the global variable, it was also making the renderer a part of its dependency chain. By adjusting the interface, we can get rid of this dependency.