### PR TITLE
 kernel/process: Use accessors instead of class members for referencing segment array

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -142,9 +142,9 @@ void Process::LoadModule(SharedPtr<CodeSet> module_, VAddr base_addr) {
     };
 
     // Map CodeSet segments
-    MapSegment(module_->code, VMAPermission::ReadExecute, MemoryState::CodeStatic);
-    MapSegment(module_->rodata, VMAPermission::Read, MemoryState::CodeMutable);
-    MapSegment(module_->data, VMAPermission::ReadWrite, MemoryState::CodeMutable);
+    MapSegment(module_->CodeSegment(), VMAPermission::ReadExecute, MemoryState::CodeStatic);
+    MapSegment(module_->RODataSegment(), VMAPermission::Read, MemoryState::CodeMutable);
+    MapSegment(module_->DataSegment(), VMAPermission::ReadWrite, MemoryState::CodeMutable);
 }
 
 ResultVal<VAddr> Process::HeapAllocate(VAddr target, u64 size, VMAPermission perms) {

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -55,6 +55,12 @@ enum class ProcessStatus { Created, Running, Exited };
 class ResourceLimit;
 
 struct CodeSet final : public Object {
+    struct Segment {
+        size_t offset = 0;
+        VAddr addr = 0;
+        u32 size = 0;
+    };
+
     static SharedPtr<CodeSet> Create(std::string name);
 
     std::string GetTypeName() const override {
@@ -69,23 +75,37 @@ struct CodeSet final : public Object {
         return HANDLE_TYPE;
     }
 
-    /// Name of the process
-    std::string name;
+    Segment& CodeSegment() {
+        return segments[0];
+    }
+
+    const Segment& CodeSegment() const {
+        return segments[0];
+    }
+
+    Segment& RODataSegment() {
+        return segments[1];
+    }
+
+    const Segment& RODataSegment() const {
+        return segments[1];
+    }
+
+    Segment& DataSegment() {
+        return segments[2];
+    }
+
+    const Segment& DataSegment() const {
+        return segments[2];
+    }
 
     std::shared_ptr<std::vector<u8>> memory;
 
-    struct Segment {
-        size_t offset = 0;
-        VAddr addr = 0;
-        u32 size = 0;
-    };
-
     Segment segments[3];
-    Segment& code = segments[0];
-    Segment& rodata = segments[1];
-    Segment& data = segments[2];
-
     VAddr entrypoint;
+
+    /// Name of the process
+    std::string name;
 
 private:
     CodeSet();

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <array>
 #include <bitset>
 #include <cstddef>
 #include <memory>
@@ -101,7 +102,7 @@ struct CodeSet final : public Object {
 
     std::shared_ptr<std::vector<u8>> memory;
 
-    Segment segments[3];
+    std::array<Segment, 3> segments;
     VAddr entrypoint;
 
     /// Name of the process

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -311,11 +311,11 @@ SharedPtr<CodeSet> ElfReader::LoadInto(u32 vaddr) {
             CodeSet::Segment* codeset_segment;
             u32 permission_flags = p->p_flags & (PF_R | PF_W | PF_X);
             if (permission_flags == (PF_R | PF_X)) {
-                codeset_segment = &codeset->code;
+                codeset_segment = &codeset->CodeSegment();
             } else if (permission_flags == (PF_R)) {
-                codeset_segment = &codeset->rodata;
+                codeset_segment = &codeset->RODataSegment();
             } else if (permission_flags == (PF_R | PF_W)) {
-                codeset_segment = &codeset->data;
+                codeset_segment = &codeset->DataSegment();
             } else {
                 LOG_ERROR(Loader, "Unexpected ELF PT_LOAD segment id {} with flags {:X}", i,
                           p->p_flags);

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -159,7 +159,7 @@ bool AppLoader_NRO::LoadNro(FileSys::VirtualFile file, VAddr load_base) {
         // Resize program image to include .bss section and page align each section
         bss_size = PageAlignSize(mod_header.bss_end_offset - mod_header.bss_start_offset);
     }
-    codeset->data.size += bss_size;
+    codeset->DataSegment().size += bss_size;
     program_image.resize(static_cast<u32>(program_image.size()) + bss_size);
 
     // Load codeset for current process

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -127,7 +127,7 @@ VAddr AppLoader_NSO::LoadModule(FileSys::VirtualFile file, VAddr load_base) {
         // Resize program image to include .bss section and page align each section
         bss_size = PageAlignSize(mod_header.bss_end_offset - mod_header.bss_start_offset);
     }
-    codeset->data.size += bss_size;
+    codeset->DataSegment().size += bss_size;
     const u32 image_size{PageAlignSize(static_cast<u32>(program_image.size()) + bss_size)};
     program_image.resize(image_size);
 


### PR DESCRIPTION
Using member variables for referencing the segments array increases the size of the class in memory for little benefit. The same behavior can be achieved through the use of accessors that just return the relevant segment.