### PR TITLE
 gl_shader_manager: Amend sign differences in an assertion comparison in SetShaderUniformBlockBinding()

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -13,14 +13,16 @@ namespace Impl {
 static void SetShaderUniformBlockBinding(GLuint shader, const char* name,
                                          Maxwell3D::Regs::ShaderStage binding,
                                          size_t expected_size) {
-    GLuint ub_index = glGetUniformBlockIndex(shader, name);
-    if (ub_index != GL_INVALID_INDEX) {
-        GLint ub_size = 0;
-        glGetActiveUniformBlockiv(shader, ub_index, GL_UNIFORM_BLOCK_DATA_SIZE, &ub_size);
-        ASSERT_MSG(static_cast<size_t>(ub_size) == expected_size,
-                   "Uniform block size did not match! Got {}, expected {}", ub_size, expected_size);
-        glUniformBlockBinding(shader, ub_index, static_cast<GLuint>(binding));
+    const GLuint ub_index = glGetUniformBlockIndex(shader, name);
+    if (ub_index == GL_INVALID_INDEX) {
+        return;
     }
+
+    GLint ub_size = 0;
+    glGetActiveUniformBlockiv(shader, ub_index, GL_UNIFORM_BLOCK_DATA_SIZE, &ub_size);
+    ASSERT_MSG(static_cast<size_t>(ub_size) == expected_size,
+               "Uniform block size did not match! Got {}, expected {}", ub_size, expected_size);
+    glUniformBlockBinding(shader, ub_index, static_cast<GLuint>(binding));
 }
 
 void SetShaderUniformBlockBindings(GLuint shader) {

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -17,9 +17,8 @@ static void SetShaderUniformBlockBinding(GLuint shader, const char* name,
     if (ub_index != GL_INVALID_INDEX) {
         GLint ub_size = 0;
         glGetActiveUniformBlockiv(shader, ub_index, GL_UNIFORM_BLOCK_DATA_SIZE, &ub_size);
-        ASSERT_MSG(ub_size == expected_size,
-                   "Uniform block size did not match! Got {}, expected {}",
-                   static_cast<int>(ub_size), expected_size);
+        ASSERT_MSG(static_cast<size_t>(ub_size) == expected_size,
+                   "Uniform block size did not match! Got {}, expected {}", ub_size, expected_size);
         glUniformBlockBinding(shader, ub_index, static_cast<GLuint>(binding));
     }
 }


### PR DESCRIPTION
Ensures both operands have the same sign in the comparison.

While we're at it, we can get rid of the redundant casting of ub_size to an int. This type will always be trivial and alias a built-in type (not doing so would break backwards compatibility at a standard level).