### PR TITLE
content_archive: Add support for titlekey cryptography

### DIFF
--- a/src/core/file_sys/content_archive.h
+++ b/src/core/file_sys/content_archive.h
@@ -95,7 +95,9 @@ protected:
     bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
 
 private:
+    u8 GetCryptoRevision() const;
     boost::optional<Core::Crypto::Key128> GetKeyAreaKey(NCASectionCryptoType type) const;
+    boost::optional<Core::Crypto::Key128> GetTitlekey() const;
     VirtualFile Decrypt(NCASectionHeader header, VirtualFile in, u64 starting_offset) const;
 
     std::vector<VirtualDir> dirs;


### PR DESCRIPTION
This is the complement to #849. 

For this to work you will need:
- The titlekey for the game. This is stored in the file `%YUZU_DIR%/keys/title.keys` (hactool location is also supported, but deprecated). Lines in this file should follow the format `00112233445566778899AABBCCDDEEFF=00112233445566778899AABBCCDDEEFF`, where the first hex number is the Rights ID and the second is the (encrypted) title key. The Rights ID is *not* equivalent to the title id (it does start with it though).
- The correct **titlek**ey **e**ncryption **k**ey (titlekek). This depends on the game and currently there are five known (`titlekek_00`->`titlekek_04`). Put them in `%YUZU_DIR%/keys/prod.keys`.
- The NCA header key (`header_key`). Same place as titlekeks.

Tested on: Splatoon 2, ARMS