### PR TITLE
Implement audren audio output

### DIFF
--- a/src/audio_core/CMakeLists.txt
+++ b/src/audio_core/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_library(audio_core STATIC
     audio_out.cpp
     audio_out.h
+    audio_renderer.cpp
+    audio_renderer.h
     buffer.h
     cubeb_sink.cpp
     cubeb_sink.h

--- a/src/audio_core/CMakeLists.txt
+++ b/src/audio_core/CMakeLists.txt
@@ -4,6 +4,8 @@ add_library(audio_core STATIC
     buffer.h
     cubeb_sink.cpp
     cubeb_sink.h
+    codec.cpp
+    codec.h
     null_sink.h
     stream.cpp
     stream.h

--- a/src/audio_core/audio_out.cpp
+++ b/src/audio_core/audio_out.cpp
@@ -36,7 +36,7 @@ StreamPtr AudioOut::OpenStream(u32 sample_rate, u32 num_channels, std::string&& 
 
     return std::make_shared<Stream>(
         sample_rate, ChannelsToStreamFormat(num_channels), std::move(release_callback),
-        sink->AcquireSinkStream(sample_rate, num_channels), std::move(name));
+        sink->AcquireSinkStream(sample_rate, num_channels, name), std::move(name));
 }
 
 std::vector<Buffer::Tag> AudioOut::GetTagsAndReleaseBuffers(StreamPtr stream, size_t max_count) {

--- a/src/audio_core/audio_out.cpp
+++ b/src/audio_core/audio_out.cpp
@@ -27,16 +27,16 @@ static Stream::Format ChannelsToStreamFormat(u32 num_channels) {
     return {};
 }
 
-StreamPtr AudioOut::OpenStream(u32 sample_rate, u32 num_channels,
+StreamPtr AudioOut::OpenStream(u32 sample_rate, u32 num_channels, std::string&& name,
                                Stream::ReleaseCallback&& release_callback) {
     if (!sink) {
         const SinkDetails& sink_details = GetSinkDetails(Settings::values.sink_id);
         sink = sink_details.factory(Settings::values.audio_device_id);
     }
 
-    return std::make_shared<Stream>(sample_rate, ChannelsToStreamFormat(num_channels),
-                                    std::move(release_callback),
-                                    sink->AcquireSinkStream(sample_rate, num_channels));
+    return std::make_shared<Stream>(
+        sample_rate, ChannelsToStreamFormat(num_channels), std::move(release_callback),
+        sink->AcquireSinkStream(sample_rate, num_channels), std::move(name));
 }
 
 std::vector<Buffer::Tag> AudioOut::GetTagsAndReleaseBuffers(StreamPtr stream, size_t max_count) {

--- a/src/audio_core/audio_out.cpp
+++ b/src/audio_core/audio_out.cpp
@@ -51,7 +51,7 @@ void AudioOut::StopStream(StreamPtr stream) {
     stream->Stop();
 }
 
-bool AudioOut::QueueBuffer(StreamPtr stream, Buffer::Tag tag, std::vector<u8>&& data) {
+bool AudioOut::QueueBuffer(StreamPtr stream, Buffer::Tag tag, std::vector<s16>&& data) {
     return stream->QueueBuffer(std::make_shared<Buffer>(tag, std::move(data)));
 }
 

--- a/src/audio_core/audio_out.h
+++ b/src/audio_core/audio_out.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "audio_core/buffer.h"
@@ -20,7 +21,7 @@ namespace AudioCore {
 class AudioOut {
 public:
     /// Opens a new audio stream
-    StreamPtr OpenStream(u32 sample_rate, u32 num_channels,
+    StreamPtr OpenStream(u32 sample_rate, u32 num_channels, std::string&& name,
                          Stream::ReleaseCallback&& release_callback);
 
     /// Returns a vector of recently released buffers specified by tag for the specified stream

--- a/src/audio_core/audio_out.h
+++ b/src/audio_core/audio_out.h
@@ -34,7 +34,7 @@ public:
     void StopStream(StreamPtr stream);
 
     /// Queues a buffer into the specified audio stream, returns true on success
-    bool QueueBuffer(StreamPtr stream, Buffer::Tag tag, std::vector<u8>&& data);
+    bool QueueBuffer(StreamPtr stream, Buffer::Tag tag, std::vector<s16>&& data);
 
 private:
     SinkPtr sink;

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -1,0 +1,234 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "audio_core/audio_renderer.h"
+#include "common/assert.h"
+#include "common/logging/log.h"
+#include "core/memory.h"
+
+namespace AudioCore {
+
+constexpr u32 STREAM_SAMPLE_RATE{48000};
+constexpr u32 STREAM_NUM_CHANNELS{2};
+
+AudioRenderer::AudioRenderer(AudioRendererParameter params,
+                             Kernel::SharedPtr<Kernel::Event> buffer_event)
+    : worker_params{params}, buffer_event{buffer_event}, voices(params.voice_count) {
+
+    audio_core = std::make_unique<AudioCore::AudioOut>();
+    stream = audio_core->OpenStream(STREAM_SAMPLE_RATE, STREAM_NUM_CHANNELS, "AudioRenderer",
+                                    [=]() { buffer_event->Signal(); });
+    audio_core->StartStream(stream);
+
+    QueueMixedBuffer(0);
+    QueueMixedBuffer(1);
+    QueueMixedBuffer(2);
+}
+
+std::vector<u8> AudioRenderer::UpdateAudioRenderer(const std::vector<u8>& input_params) {
+    // Copy UpdateDataHeader struct
+    UpdateDataHeader config{};
+    std::memcpy(&config, input_params.data(), sizeof(UpdateDataHeader));
+    u32 memory_pool_count = worker_params.effect_count + (worker_params.voice_count * 4);
+
+    // Copy MemoryPoolInfo structs
+    std::vector<MemoryPoolInfo> mem_pool_info(memory_pool_count);
+    std::memcpy(mem_pool_info.data(),
+                input_params.data() + sizeof(UpdateDataHeader) + config.behavior_size,
+                memory_pool_count * sizeof(MemoryPoolInfo));
+
+    // Copy VoiceInfo structs
+    size_t offset{sizeof(UpdateDataHeader) + config.behavior_size + config.memory_pools_size +
+                  config.voice_resource_size};
+    for (auto& voice : voices) {
+        std::memcpy(&voice.Info(), input_params.data() + offset, sizeof(VoiceInfo));
+        offset += sizeof(VoiceInfo);
+    }
+
+    // Update voices
+    for (auto& voice : voices) {
+        voice.UpdateState();
+        if (!voice.GetInfo().is_in_use) {
+            continue;
+        }
+        if (voice.GetInfo().is_new) {
+            voice.SetWaveIndex(voice.GetInfo().wave_buffer_head);
+        }
+    }
+
+    // Update memory pool state
+    std::vector<MemoryPoolEntry> memory_pool(memory_pool_count);
+    for (size_t index = 0; index < memory_pool.size(); ++index) {
+        if (mem_pool_info[index].pool_state == MemoryPoolStates::RequestAttach) {
+            memory_pool[index].state = MemoryPoolStates::Attached;
+        } else if (mem_pool_info[index].pool_state == MemoryPoolStates::RequestDetach) {
+            memory_pool[index].state = MemoryPoolStates::Detached;
+        }
+    }
+
+    // Release previous buffers and queue next ones for playback
+    ReleaseAndQueueBuffers();
+
+    // Copy output header
+    UpdateDataHeader response_data{worker_params};
+    std::vector<u8> output_params(response_data.total_size);
+    std::memcpy(output_params.data(), &response_data, sizeof(UpdateDataHeader));
+
+    // Copy output memory pool entries
+    std::memcpy(output_params.data() + sizeof(UpdateDataHeader), memory_pool.data(),
+                response_data.memory_pools_size);
+
+    // Copy output voice status
+    size_t voice_out_status_offset{sizeof(UpdateDataHeader) + response_data.memory_pools_size};
+    for (const auto& voice : voices) {
+        std::memcpy(output_params.data() + voice_out_status_offset, &voice.GetOutStatus(),
+                    sizeof(VoiceOutStatus));
+        voice_out_status_offset += sizeof(VoiceOutStatus);
+    }
+
+    return output_params;
+}
+
+void AudioRenderer::VoiceState::SetWaveIndex(size_t index) {
+    wave_index = index & 3;
+    is_refresh_pending = true;
+}
+
+std::vector<s16> AudioRenderer::VoiceState::DequeueSamples(size_t sample_count) {
+    if (!IsPlaying()) {
+        return {};
+    }
+
+    if (is_refresh_pending) {
+        RefreshBuffer();
+    }
+
+    const size_t max_size{samples.size() - offset};
+    const size_t dequeue_offset{offset};
+    size_t size{sample_count * STREAM_NUM_CHANNELS};
+    if (size > max_size) {
+        size = max_size;
+    }
+
+    out_status.played_sample_count += size / STREAM_NUM_CHANNELS;
+    offset += size;
+
+    const auto& wave_buffer{info.wave_buffer[wave_index]};
+    if (offset == samples.size()) {
+        offset = 0;
+
+        if (!wave_buffer.is_looping) {
+            SetWaveIndex(wave_index + 1);
+        }
+
+        out_status.wave_buffer_consumed++;
+
+        if (wave_buffer.end_of_stream) {
+            info.play_state = PlayState::Paused;
+        }
+    }
+
+    return {samples.begin() + dequeue_offset, samples.begin() + dequeue_offset + size};
+}
+
+void AudioRenderer::VoiceState::UpdateState() {
+    if (is_in_use && !info.is_in_use) {
+        // No longer in use, reset state
+        is_refresh_pending = true;
+        wave_index = 0;
+        offset = 0;
+        out_status = {};
+    }
+    is_in_use = info.is_in_use;
+}
+
+void AudioRenderer::VoiceState::RefreshBuffer() {
+    std::vector<s16> new_samples(info.wave_buffer[wave_index].buffer_sz / sizeof(s16));
+    Memory::ReadBlock(info.wave_buffer[wave_index].buffer_addr, new_samples.data(),
+                      info.wave_buffer[wave_index].buffer_sz);
+
+    switch (static_cast<Codec::PcmFormat>(info.sample_format)) {
+    case Codec::PcmFormat::Int16: {
+        // PCM16 is played as-is
+        break;
+    }
+    case Codec::PcmFormat::Adpcm: {
+        // Decode ADPCM to PCM16
+        Codec::ADPCM_Coeff coeffs;
+        Memory::ReadBlock(info.additional_params_addr, coeffs.data(), sizeof(Codec::ADPCM_Coeff));
+        new_samples = Codec::DecodeADPCM(reinterpret_cast<u8*>(new_samples.data()),
+                                         new_samples.size() * sizeof(s16), coeffs, adpcm_state);
+        break;
+    }
+    default:
+        LOG_CRITICAL(Audio, "Unimplemented sample_format={}", info.sample_format);
+        UNREACHABLE();
+        break;
+    }
+
+    switch (info.channel_count) {
+    case 1:
+        // 1 channel is upsampled to 2 channel
+        samples.resize(new_samples.size() * 2);
+        for (size_t index = 0; index < new_samples.size(); ++index) {
+            samples[index * 2] = new_samples[index];
+            samples[index * 2 + 1] = new_samples[index];
+        }
+        break;
+    case 2: {
+        // 2 channel is played as is
+        samples = std::move(new_samples);
+        break;
+    }
+    default:
+        LOG_CRITICAL(Audio, "Unimplemented channel_count={}", info.channel_count);
+        UNREACHABLE();
+        break;
+    }
+
+    is_refresh_pending = false;
+}
+
+static constexpr s16 ClampToS16(s32 value) {
+    return static_cast<s16>(std::clamp(value, -32768, 32767));
+}
+
+void AudioRenderer::QueueMixedBuffer(Buffer::Tag tag) {
+    constexpr size_t BUFFER_SIZE{512};
+    std::vector<s16> buffer(BUFFER_SIZE * stream->GetNumChannels());
+
+    for (auto& voice : voices) {
+        if (!voice.IsPlaying()) {
+            continue;
+        }
+
+        size_t offset{};
+        s64 samples_remaining{BUFFER_SIZE};
+        while (samples_remaining > 0) {
+            const std::vector<s16> samples{voice.DequeueSamples(samples_remaining)};
+
+            if (samples.empty()) {
+                break;
+            }
+
+            samples_remaining -= samples.size();
+
+            for (const auto& sample : samples) {
+                const s32 buffer_sample{buffer[offset]};
+                buffer[offset++] =
+                    ClampToS16(buffer_sample + static_cast<s32>(sample * voice.GetInfo().volume));
+            }
+        }
+    }
+    audio_core->QueueBuffer(stream, tag, std::move(buffer));
+}
+
+void AudioRenderer::ReleaseAndQueueBuffers() {
+    const auto released_buffers{audio_core->GetTagsAndReleaseBuffers(stream, 2)};
+    for (const auto& tag : released_buffers) {
+        QueueMixedBuffer(tag);
+    }
+}
+
+} // namespace AudioCore

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -1,0 +1,206 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+#include <memory>
+#include <vector>
+
+#include "audio_core/audio_out.h"
+#include "audio_core/codec.h"
+#include "audio_core/stream.h"
+#include "common/common_types.h"
+#include "common/swap.h"
+#include "core/hle/kernel/event.h"
+
+namespace AudioCore {
+
+enum class PlayState : u8 {
+    Started = 0,
+    Stopped = 1,
+    Paused = 2,
+};
+
+struct AudioRendererParameter {
+    u32_le sample_rate;
+    u32_le sample_count;
+    u32_le unknown_8;
+    u32_le unknown_c;
+    u32_le voice_count;
+    u32_le sink_count;
+    u32_le effect_count;
+    u32_le unknown_1c;
+    u8 unknown_20;
+    INSERT_PADDING_BYTES(3);
+    u32_le splitter_count;
+    u32_le unknown_2c;
+    INSERT_PADDING_WORDS(1);
+    u32_le revision;
+};
+static_assert(sizeof(AudioRendererParameter) == 52, "AudioRendererParameter is an invalid size");
+
+enum class MemoryPoolStates : u32 { // Should be LE
+    Invalid = 0x0,
+    Unknown = 0x1,
+    RequestDetach = 0x2,
+    Detached = 0x3,
+    RequestAttach = 0x4,
+    Attached = 0x5,
+    Released = 0x6,
+};
+
+struct MemoryPoolEntry {
+    MemoryPoolStates state;
+    u32_le unknown_4;
+    u32_le unknown_8;
+    u32_le unknown_c;
+};
+static_assert(sizeof(MemoryPoolEntry) == 0x10, "MemoryPoolEntry has wrong size");
+
+struct MemoryPoolInfo {
+    u64_le pool_address;
+    u64_le pool_size;
+    MemoryPoolStates pool_state;
+    INSERT_PADDING_WORDS(3); // Unknown
+};
+static_assert(sizeof(MemoryPoolInfo) == 0x20, "MemoryPoolInfo has wrong size");
+struct BiquadFilter {
+    u8 enable;
+    INSERT_PADDING_BYTES(1);
+    std::array<s16_le, 3> numerator;
+    std::array<s16_le, 2> denominator;
+};
+static_assert(sizeof(BiquadFilter) == 0xc, "BiquadFilter has wrong size");
+
+struct WaveBuffer {
+    u64_le buffer_addr;
+    u64_le buffer_sz;
+    s32_le start_sample_offset;
+    s32_le end_sample_offset;
+    u8 is_looping;
+    u8 end_of_stream;
+    u8 sent_to_server;
+    INSERT_PADDING_BYTES(5);
+    u64 context_addr;
+    u64 context_sz;
+    INSERT_PADDING_BYTES(8);
+};
+static_assert(sizeof(WaveBuffer) == 0x38, "WaveBuffer has wrong size");
+
+struct VoiceInfo {
+    u32_le id;
+    u32_le node_id;
+    u8 is_new;
+    u8 is_in_use;
+    PlayState play_state;
+    u8 sample_format;
+    u32_le sample_rate;
+    u32_le priority;
+    u32_le sorting_order;
+    u32_le channel_count;
+    float_le pitch;
+    float_le volume;
+    std::array<BiquadFilter, 2> biquad_filter;
+    u32_le wave_buffer_count;
+    u32_le wave_buffer_head;
+    INSERT_PADDING_WORDS(1);
+    u64_le additional_params_addr;
+    u64_le additional_params_sz;
+    u32_le mix_id;
+    u32_le splitter_info_id;
+    std::array<WaveBuffer, 4> wave_buffer;
+    std::array<u32_le, 6> voice_channel_resource_ids;
+    INSERT_PADDING_BYTES(24);
+};
+static_assert(sizeof(VoiceInfo) == 0x170, "VoiceInfo is wrong size");
+
+struct VoiceOutStatus {
+    u64_le played_sample_count;
+    u32_le wave_buffer_consumed;
+    u32_le voice_drops_count;
+};
+static_assert(sizeof(VoiceOutStatus) == 0x10, "VoiceOutStatus has wrong size");
+
+struct UpdateDataHeader {
+    UpdateDataHeader() {}
+
+    explicit UpdateDataHeader(const AudioRendererParameter& config) {
+        revision = Common::MakeMagic('R', 'E', 'V', '4'); // 5.1.0 Revision
+        behavior_size = 0xb0;
+        memory_pools_size = (config.effect_count + (config.voice_count * 4)) * 0x10;
+        voices_size = config.voice_count * 0x10;
+        voice_resource_size = 0x0;
+        effects_size = config.effect_count * 0x10;
+        mixes_size = 0x0;
+        sinks_size = config.sink_count * 0x20;
+        performance_manager_size = 0x10;
+        total_size = sizeof(UpdateDataHeader) + behavior_size + memory_pools_size + voices_size +
+                     effects_size + sinks_size + performance_manager_size;
+    }
+
+    u32_le revision;
+    u32_le behavior_size;
+    u32_le memory_pools_size;
+    u32_le voices_size;
+    u32_le voice_resource_size;
+    u32_le effects_size;
+    u32_le mixes_size;
+    u32_le sinks_size;
+    u32_le performance_manager_size;
+    INSERT_PADDING_WORDS(6);
+    u32_le total_size;
+};
+static_assert(sizeof(UpdateDataHeader) == 0x40, "UpdateDataHeader has wrong size");
+
+class AudioRenderer {
+public:
+    AudioRenderer(AudioRendererParameter params, Kernel::SharedPtr<Kernel::Event> buffer_event);
+    std::vector<u8> UpdateAudioRenderer(const std::vector<u8>& input_params);
+    void QueueMixedBuffer(Buffer::Tag tag);
+    void ReleaseAndQueueBuffers();
+
+private:
+    class VoiceState {
+    public:
+        bool IsPlaying() const {
+            return is_in_use && info.play_state == PlayState::Started;
+        }
+
+        const VoiceOutStatus& GetOutStatus() const {
+            return out_status;
+        }
+
+        const VoiceInfo& GetInfo() const {
+            return info;
+        }
+
+        VoiceInfo& Info() {
+            return info;
+        }
+
+        void SetWaveIndex(size_t index);
+        std::vector<s16> DequeueSamples(size_t sample_count);
+        void UpdateState();
+        void RefreshBuffer();
+
+    private:
+        bool is_in_use{};
+        bool is_refresh_pending{};
+        size_t wave_index{};
+        size_t offset{};
+        Codec::ADPCMState adpcm_state{};
+        std::vector<s16> samples;
+        VoiceOutStatus out_status{};
+        VoiceInfo info{};
+    };
+
+    AudioRendererParameter worker_params;
+    Kernel::SharedPtr<Kernel::Event> buffer_event;
+    std::vector<VoiceState> voices;
+    std::unique_ptr<AudioCore::AudioOut> audio_core;
+    AudioCore::StreamPtr stream;
+};
+
+} // namespace AudioCore

--- a/src/audio_core/buffer.h
+++ b/src/audio_core/buffer.h
@@ -18,11 +18,16 @@ class Buffer {
 public:
     using Tag = u64;
 
-    Buffer(Tag tag, std::vector<u8>&& data) : tag{tag}, data{std::move(data)} {}
+    Buffer(Tag tag, std::vector<s16>&& samples) : tag{tag}, samples{std::move(samples)} {}
 
     /// Returns the raw audio data for the buffer
-    const std::vector<u8>& GetData() const {
-        return data;
+    std::vector<s16>& Samples() {
+        return samples;
+    }
+
+    /// Returns the raw audio data for the buffer
+    const std::vector<s16>& GetSamples() const {
+        return samples;
     }
 
     /// Returns the buffer tag, this is provided by the game to the audout service
@@ -32,7 +37,7 @@ public:
 
 private:
     Tag tag;
-    std::vector<u8> data;
+    std::vector<s16> samples;
 };
 
 using BufferPtr = std::shared_ptr<Buffer>;

--- a/src/audio_core/codec.cpp
+++ b/src/audio_core/codec.cpp
@@ -1,0 +1,77 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+
+#include "audio_core/codec.h"
+
+namespace AudioCore::Codec {
+
+std::vector<s16> DecodeADPCM(const u8* const data, size_t size, const ADPCM_Coeff& coeff,
+                             ADPCMState& state) {
+    // GC-ADPCM with scale factor and variable coefficients.
+    // Frames are 8 bytes long containing 14 samples each.
+    // Samples are 4 bits (one nibble) long.
+
+    constexpr size_t FRAME_LEN = 8;
+    constexpr size_t SAMPLES_PER_FRAME = 14;
+    constexpr std::array<int, 16> SIGNED_NIBBLES = {
+        {0, 1, 2, 3, 4, 5, 6, 7, -8, -7, -6, -5, -4, -3, -2, -1}};
+
+    const size_t sample_count = (size / FRAME_LEN) * SAMPLES_PER_FRAME;
+    const size_t ret_size =
+        sample_count % 2 == 0 ? sample_count : sample_count + 1; // Ensure multiple of two.
+    std::vector<s16> ret(ret_size);
+
+    int yn1 = state.yn1, yn2 = state.yn2;
+
+    const size_t NUM_FRAMES =
+        (sample_count + (SAMPLES_PER_FRAME - 1)) / SAMPLES_PER_FRAME; // Round up.
+    for (size_t framei = 0; framei < NUM_FRAMES; framei++) {
+        const int frame_header = data[framei * FRAME_LEN];
+        const int scale = 1 << (frame_header & 0xF);
+        const int idx = (frame_header >> 4) & 0x7;
+
+        // Coefficients are fixed point with 11 bits fractional part.
+        const int coef1 = coeff[idx * 2 + 0];
+        const int coef2 = coeff[idx * 2 + 1];
+
+        // Decodes an audio sample. One nibble produces one sample.
+        const auto decode_sample = [&](const int nibble) -> s16 {
+            const int xn = nibble * scale;
+            // We first transform everything into 11 bit fixed point, perform the second order
+            // digital filter, then transform back.
+            // 0x400 == 0.5 in 11 bit fixed point.
+            // Filter: y[n] = x[n] + 0.5 + c1 * y[n-1] + c2 * y[n-2]
+            int val = ((xn << 11) + 0x400 + coef1 * yn1 + coef2 * yn2) >> 11;
+            // Clamp to output range.
+            val = std::clamp<s32>(val, -32768, 32767);
+            // Advance output feedback.
+            yn2 = yn1;
+            yn1 = val;
+            return static_cast<s16>(val);
+        };
+
+        size_t outputi = framei * SAMPLES_PER_FRAME;
+        size_t datai = framei * FRAME_LEN + 1;
+        for (size_t i = 0; i < SAMPLES_PER_FRAME && outputi < sample_count; i += 2) {
+            const s16 sample1 = decode_sample(SIGNED_NIBBLES[data[datai] >> 4]);
+            ret[outputi] = sample1;
+            outputi++;
+
+            const s16 sample2 = decode_sample(SIGNED_NIBBLES[data[datai] & 0xF]);
+            ret[outputi] = sample2;
+            outputi++;
+
+            datai++;
+        }
+    }
+
+    state.yn1 = yn1;
+    state.yn2 = yn2;
+
+    return ret;
+}
+
+} // namespace AudioCore::Codec

--- a/src/audio_core/codec.h
+++ b/src/audio_core/codec.h
@@ -1,0 +1,44 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+#include <vector>
+
+#include "common/common_types.h"
+
+namespace AudioCore::Codec {
+
+enum class PcmFormat : u32 {
+    Invalid = 0,
+    Int8 = 1,
+    Int16 = 2,
+    Int24 = 3,
+    Int32 = 4,
+    PcmFloat = 5,
+    Adpcm = 6,
+};
+
+/// See: Codec::DecodeADPCM
+struct ADPCMState {
+    // Two historical samples from previous processed buffer,
+    // required for ADPCM decoding
+    s16 yn1; ///< y[n-1]
+    s16 yn2; ///< y[n-2]
+};
+
+using ADPCM_Coeff = std::array<s16, 16>;
+
+/**
+ * @param data Pointer to buffer that contains ADPCM data to decode
+ * @param size Size of buffer in bytes
+ * @param coeff ADPCM coefficients
+ * @param state ADPCM state, this is updated with new state
+ * @return Decoded stereo signed PCM16 data, sample_count in length
+ */
+std::vector<s16> DecodeADPCM(const u8* const data, size_t size, const ADPCM_Coeff& coeff,
+                             ADPCMState& state);
+
+}; // namespace AudioCore::Codec

--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -13,7 +13,7 @@ namespace AudioCore {
 
 class SinkStreamImpl final : public SinkStream {
 public:
-    SinkStreamImpl(cubeb* ctx, cubeb_devid output_device) : ctx{ctx} {
+    SinkStreamImpl(cubeb* ctx, cubeb_devid output_device, const std::string& name) : ctx{ctx} {
         cubeb_stream_params params;
         params.rate = 48000;
         params.channels = GetNumChannels();
@@ -25,8 +25,8 @@ public:
             LOG_CRITICAL(Audio_Sink, "Error getting minimum latency");
         }
 
-        if (cubeb_stream_init(ctx, &stream_backend, "yuzu Audio Output", nullptr, nullptr,
-                              output_device, &params, std::max(512u, minimum_latency),
+        if (cubeb_stream_init(ctx, &stream_backend, name.c_str(), nullptr, nullptr, output_device,
+                              &params, std::max(512u, minimum_latency),
                               &SinkStreamImpl::DataCallback, &SinkStreamImpl::StateCallback,
                               this) != CUBEB_OK) {
             LOG_CRITICAL(Audio_Sink, "Error initializing cubeb stream");
@@ -129,8 +129,9 @@ CubebSink::~CubebSink() {
     cubeb_destroy(ctx);
 }
 
-SinkStream& CubebSink::AcquireSinkStream(u32 sample_rate, u32 num_channels) {
-    sink_streams.push_back(std::make_unique<SinkStreamImpl>(ctx, output_device));
+SinkStream& CubebSink::AcquireSinkStream(u32 sample_rate, u32 num_channels,
+                                         const std::string& name) {
+    sink_streams.push_back(std::make_unique<SinkStreamImpl>(ctx, output_device, name));
     return *sink_streams.back();
 }
 

--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -13,14 +13,24 @@ namespace AudioCore {
 
 class SinkStreamImpl final : public SinkStream {
 public:
-    SinkStreamImpl(cubeb* ctx, cubeb_devid output_device, const std::string& name) : ctx{ctx} {
-        cubeb_stream_params params;
-        params.rate = 48000;
-        params.channels = GetNumChannels();
-        params.format = CUBEB_SAMPLE_S16NE;
-        params.layout = CUBEB_LAYOUT_STEREO;
+    SinkStreamImpl(cubeb* ctx, u32 sample_rate, u32 num_channels_, cubeb_devid output_device,
+                   const std::string& name)
+        : ctx{ctx}, num_channels{num_channels_} {
 
-        u32 minimum_latency = 0;
+        if (num_channels == 6) {
+            // 6-channel audio does not seem to work with cubeb + SDL, so we downsample this to 2
+            // channel for now
+            is_6_channel = true;
+            num_channels = 2;
+        }
+
+        cubeb_stream_params params{};
+        params.rate = sample_rate;
+        params.channels = num_channels;
+        params.format = CUBEB_SAMPLE_S16NE;
+        params.layout = num_channels == 1 ? CUBEB_LAYOUT_MONO : CUBEB_LAYOUT_STEREO;
+
+        u32 minimum_latency{};
         if (cubeb_get_min_latency(ctx, &params, &minimum_latency) != CUBEB_OK) {
             LOG_CRITICAL(Audio_Sink, "Error getting minimum latency");
         }
@@ -58,11 +68,7 @@ public:
 
         queue.reserve(queue.size() + sample_count * GetNumChannels());
 
-        if (num_channels == 2) {
-            // Copy as-is
-            std::copy(samples, samples + sample_count * GetNumChannels(),
-                      std::back_inserter(queue));
-        } else if (num_channels == 6) {
+        if (is_6_channel) {
             // Downsample 6 channels to 2
             const size_t sample_count_copy_size = sample_count * num_channels * 2;
             queue.reserve(sample_count_copy_size);
@@ -71,13 +77,14 @@ public:
                 queue.push_back(samples[i + 1]);
             }
         } else {
-            ASSERT_MSG(false, "Unimplemented");
+            // Copy as-is
+            std::copy(samples, samples + sample_count * GetNumChannels(),
+                      std::back_inserter(queue));
         }
     }
 
     u32 GetNumChannels() const {
-        // Only support 2-channel stereo output for now
-        return 2;
+        return num_channels;
     }
 
 private:
@@ -85,6 +92,8 @@ private:
 
     cubeb* ctx{};
     cubeb_stream* stream_backend{};
+    u32 num_channels{};
+    bool is_6_channel{};
 
     std::vector<s16> queue;
 
@@ -131,7 +140,8 @@ CubebSink::~CubebSink() {
 
 SinkStream& CubebSink::AcquireSinkStream(u32 sample_rate, u32 num_channels,
                                          const std::string& name) {
-    sink_streams.push_back(std::make_unique<SinkStreamImpl>(ctx, output_device, name));
+    sink_streams.push_back(
+        std::make_unique<SinkStreamImpl>(ctx, sample_rate, num_channels, output_device, name));
     return *sink_streams.back();
 }
 

--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -61,25 +61,24 @@ public:
         cubeb_stream_destroy(stream_backend);
     }
 
-    void EnqueueSamples(u32 num_channels, const s16* samples, size_t sample_count) override {
+    void EnqueueSamples(u32 num_channels, const std::vector<s16>& samples) override {
         if (!ctx) {
             return;
         }
 
-        queue.reserve(queue.size() + sample_count * GetNumChannels());
+        queue.reserve(queue.size() + samples.size() * GetNumChannels());
 
         if (is_6_channel) {
             // Downsample 6 channels to 2
-            const size_t sample_count_copy_size = sample_count * num_channels * 2;
+            const size_t sample_count_copy_size = samples.size() * 2;
             queue.reserve(sample_count_copy_size);
-            for (size_t i = 0; i < sample_count * num_channels; i += num_channels) {
+            for (size_t i = 0; i < samples.size(); i += num_channels) {
                 queue.push_back(samples[i]);
                 queue.push_back(samples[i + 1]);
             }
         } else {
             // Copy as-is
-            std::copy(samples, samples + sample_count * GetNumChannels(),
-                      std::back_inserter(queue));
+            std::copy(samples.begin(), samples.end(), std::back_inserter(queue));
         }
     }
 

--- a/src/audio_core/cubeb_sink.h
+++ b/src/audio_core/cubeb_sink.h
@@ -18,7 +18,8 @@ public:
     explicit CubebSink(std::string device_id);
     ~CubebSink() override;
 
-    SinkStream& AcquireSinkStream(u32 sample_rate, u32 num_channels) override;
+    SinkStream& AcquireSinkStream(u32 sample_rate, u32 num_channels,
+                                  const std::string& name) override;
 
 private:
     cubeb* ctx{};

--- a/src/audio_core/null_sink.h
+++ b/src/audio_core/null_sink.h
@@ -20,8 +20,7 @@ public:
 
 private:
     struct NullSinkStreamImpl final : SinkStream {
-        void EnqueueSamples(u32 /*num_channels*/, const s16* /*samples*/,
-                            size_t /*sample_count*/) override {}
+        void EnqueueSamples(u32 /*num_channels*/, const std::vector<s16>& /*samples*/) override {}
     } null_sink_stream;
 };
 

--- a/src/audio_core/null_sink.h
+++ b/src/audio_core/null_sink.h
@@ -13,7 +13,8 @@ public:
     explicit NullSink(std::string){};
     ~NullSink() override = default;
 
-    SinkStream& AcquireSinkStream(u32 /*sample_rate*/, u32 /*num_channels*/) override {
+    SinkStream& AcquireSinkStream(u32 /*sample_rate*/, u32 /*num_channels*/,
+                                  const std::string& /*name*/) override {
         return null_sink_stream;
     }
 

--- a/src/audio_core/sink.h
+++ b/src/audio_core/sink.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 
 #include "audio_core/sink_stream.h"
 #include "common/common_types.h"
@@ -21,7 +22,8 @@ constexpr char auto_device_name[] = "auto";
 class Sink {
 public:
     virtual ~Sink() = default;
-    virtual SinkStream& AcquireSinkStream(u32 sample_rate, u32 num_channels) = 0;
+    virtual SinkStream& AcquireSinkStream(u32 sample_rate, u32 num_channels,
+                                          const std::string& name) = 0;
 };
 
 using SinkPtr = std::unique_ptr<Sink>;

--- a/src/audio_core/sink_stream.h
+++ b/src/audio_core/sink_stream.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "common/common_types.h"
 
@@ -22,9 +23,8 @@ public:
      * Feed stereo samples to sink.
      * @param num_channels Number of channels used.
      * @param samples Samples in interleaved stereo PCM16 format.
-     * @param sample_count Number of samples.
      */
-    virtual void EnqueueSamples(u32 num_channels, const s16* samples, size_t sample_count) = 0;
+    virtual void EnqueueSamples(u32 num_channels, const std::vector<s16>& samples) = 0;
 };
 
 using SinkStreamPtr = std::unique_ptr<SinkStream>;

--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -37,12 +37,12 @@ u32 Stream::GetSampleSize() const {
 }
 
 Stream::Stream(u32 sample_rate, Format format, ReleaseCallback&& release_callback,
-               SinkStream& sink_stream)
+               SinkStream& sink_stream, std::string&& name_)
     : sample_rate{sample_rate}, format{format}, release_callback{std::move(release_callback)},
-      sink_stream{sink_stream} {
+      sink_stream{sink_stream}, name{std::move(name_)} {
 
     release_event = CoreTiming::RegisterEvent(
-        "Stream::Release", [this](u64 userdata, int cycles_late) { ReleaseActiveBuffer(); });
+        name, [this](u64 userdata, int cycles_late) { ReleaseActiveBuffer(); });
 }
 
 void Stream::Play() {
@@ -104,6 +104,7 @@ void Stream::PlayNextBuffer() {
 }
 
 void Stream::ReleaseActiveBuffer() {
+    ASSERT(active_buffer);
     released_buffers.push(std::move(active_buffer));
     release_callback();
     PlayNextBuffer();

--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -32,10 +32,6 @@ u32 Stream::GetNumChannels() const {
     return {};
 }
 
-u32 Stream::GetSampleSize() const {
-    return GetNumChannels() * 2;
-}
-
 Stream::Stream(u32 sample_rate, Format format, ReleaseCallback&& release_callback,
                SinkStream& sink_stream, std::string&& name_)
     : sample_rate{sample_rate}, format{format}, release_callback{std::move(release_callback)},
@@ -55,17 +51,15 @@ void Stream::Stop() {
 }
 
 s64 Stream::GetBufferReleaseCycles(const Buffer& buffer) const {
-    const size_t num_samples{buffer.GetData().size() / GetSampleSize()};
+    const size_t num_samples{buffer.GetSamples().size() / GetNumChannels()};
     return CoreTiming::usToCycles((static_cast<u64>(num_samples) * 1000000) / sample_rate);
 }
 
-static std::vector<s16> GetVolumeAdjustedSamples(const std::vector<u8>& data) {
-    std::vector<s16> samples(data.size() / sizeof(s16));
-    std::memcpy(samples.data(), data.data(), data.size());
+static void VolumeAdjustSamples(std::vector<s16>& samples) {
     const float volume{std::clamp(Settings::values.volume, 0.0f, 1.0f)};
 
     if (volume == 1.0f) {
-        return samples;
+        return;
     }
 
     // Implementation of a volume slider with a dynamic range of 60 dB
@@ -73,8 +67,6 @@ static std::vector<s16> GetVolumeAdjustedSamples(const std::vector<u8>& data) {
     for (auto& sample : samples) {
         sample = static_cast<s16>(sample * volume_scale_factor);
     }
-
-    return samples;
 }
 
 void Stream::PlayNextBuffer() {
@@ -96,9 +88,8 @@ void Stream::PlayNextBuffer() {
     active_buffer = queued_buffers.front();
     queued_buffers.pop();
 
-    const size_t sample_count{active_buffer->GetData().size() / GetSampleSize()};
-    sink_stream.EnqueueSamples(
-        GetNumChannels(), GetVolumeAdjustedSamples(active_buffer->GetData()).data(), sample_count);
+    VolumeAdjustSamples(active_buffer->Samples());
+    sink_stream.EnqueueSamples(GetNumChannels(), active_buffer->GetSamples());
 
     CoreTiming::ScheduleEventThreadsafe(GetBufferReleaseCycles(*active_buffer), release_event, {});
 }

--- a/src/audio_core/stream.h
+++ b/src/audio_core/stream.h
@@ -69,9 +69,6 @@ public:
     /// Gets the number of channels
     u32 GetNumChannels() const;
 
-    /// Gets the sample size in bytes
-    u32 GetSampleSize() const;
-
 private:
     /// Current state of the stream
     enum class State {

--- a/src/audio_core/stream.h
+++ b/src/audio_core/stream.h
@@ -6,6 +6,7 @@
 
 #include <functional>
 #include <memory>
+#include <string>
 #include <vector>
 #include <queue>
 
@@ -33,7 +34,7 @@ public:
     using ReleaseCallback = std::function<void()>;
 
     Stream(u32 sample_rate, Format format, ReleaseCallback&& release_callback,
-           SinkStream& sink_stream);
+           SinkStream& sink_stream, std::string&& name_);
 
     /// Plays the audio stream
     void Play();
@@ -96,6 +97,7 @@ private:
     std::queue<BufferPtr> queued_buffers;   ///< Buffers queued to be played in the stream
     std::queue<BufferPtr> released_buffers; ///< Buffers recently released from the stream
     SinkStream& sink_stream;                ///< Output sink for the stream
+    std::string name;                       ///< Name of the stream, must be unique
 };
 
 using StreamPtr = std::shared_ptr<Stream>;

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -4,6 +4,8 @@
 
 #include <array>
 #include <vector>
+
+#include "audio_core/codec.h"
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/hle/ipc_helpers.h"
@@ -200,7 +202,7 @@ void AudOutU::OpenAudioOutImpl(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
     rb.Push<u32>(DefaultSampleRate);
     rb.Push<u32>(params.channel_count);
-    rb.Push<u32>(static_cast<u32>(PcmFormat::Int16));
+    rb.Push<u32>(static_cast<u32>(AudioCore::Codec::PcmFormat::Int16));
     rb.Push<u32>(static_cast<u32>(AudioState::Stopped));
     rb.PushIpcInterface<Audio::IAudioOut>(audio_out_interface);
 }

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -48,7 +48,7 @@ public:
         buffer_event = Kernel::Event::Create(Kernel::ResetType::Sticky, "IAudioOutBufferReleased");
 
         stream = audio_core.OpenStream(audio_params.sample_rate, audio_params.channel_count,
-                                       [=]() { buffer_event->Signal(); });
+                                       "IAudioOut", [=]() { buffer_event->Signal(); });
     }
 
 private:

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -113,10 +113,10 @@ private:
         std::memcpy(&audio_buffer, input_buffer.data(), sizeof(AudioBuffer));
         const u64 tag{rp.Pop<u64>()};
 
-        std::vector<u8> data(audio_buffer.buffer_size);
-        Memory::ReadBlock(audio_buffer.buffer, data.data(), data.size());
+        std::vector<s16> samples(audio_buffer.buffer_size / sizeof(s16));
+        Memory::ReadBlock(audio_buffer.buffer, samples.data(), audio_buffer.buffer_size);
 
-        if (!audio_core.QueueBuffer(stream, tag, std::move(data))) {
+        if (!audio_core.QueueBuffer(stream, tag, std::move(samples))) {
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ResultCode(ErrorModule::Audio, ErrCodes::BufferCountExceeded));
         }

--- a/src/core/hle/service/audio/audout_u.h
+++ b/src/core/hle/service/audio/audout_u.h
@@ -38,16 +38,6 @@ private:
 
     void ListAudioOutsImpl(Kernel::HLERequestContext& ctx);
     void OpenAudioOutImpl(Kernel::HLERequestContext& ctx);
-
-    enum class PcmFormat : u32 {
-        Invalid = 0,
-        Int8 = 1,
-        Int16 = 2,
-        Int24 = 3,
-        Int32 = 4,
-        PcmFloat = 5,
-        Adpcm = 6,
-    };
 };
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audren_u.h
+++ b/src/core/hle/service/audio/audren_u.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "audio_core/audio_renderer.h"
 #include "core/hle/service/service.h"
 
 namespace Kernel {
@@ -11,24 +12,6 @@ class HLERequestContext;
 }
 
 namespace Service::Audio {
-
-struct AudioRendererParameter {
-    u32_le sample_rate;
-    u32_le sample_count;
-    u32_le unknown_8;
-    u32_le unknown_c;
-    u32_le voice_count;
-    u32_le sink_count;
-    u32_le effect_count;
-    u32_le unknown_1c;
-    u8 unknown_20;
-    INSERT_PADDING_BYTES(3);
-    u32_le splitter_count;
-    u32_le unknown_2c;
-    INSERT_PADDING_WORDS(1);
-    u32_le revision;
-};
-static_assert(sizeof(AudioRendererParameter) == 52, "AudioRendererParameter is an invalid size");
 
 class AudRenU final : public ServiceFramework<AudRenU> {
 public:


### PR DESCRIPTION
This implements audio playback for audren_u, e.g. `AudioRenderer`. This should add audio output for most games. Similar to our audout_u implementation, there is no time stretching, etc., so this relies on games running at or around 60fps to sound correct.

This leverages the same AudioCore backend, the `AudioOut` class, that we use for `audout_u`. Similar to Ryujinx's impl, we use a single 48000Hz 2-channel stream. Voices are mixed into this stream (regardless of sample rate) with 1-channel buffers being upsampled to 2-channel. I chose to go this route because creating lots of smaller streams for voices (configured with their correct sample rate and channel count) did not work out too well - some games ended up created way to many streams, which led to cubeb being unstable. Initial support is for PCM16 and ADPCM.

That being said, this seems to work well enough. In the future, we might want to create a new stream for each unique sample rate, and mix into the right one - but this can be done later.

Tested with: Cave Story+, the Binding of Isaac, Puyo Puyo Tetris, Disgaea 5, Super Mario Odyssey, and Stardew Valley

Thanks @ogniK5377 for most of the RE work for this, as well as Ryujinx, whose impl. inspired ours.

Suggest reviewing commit by commit.