### PR TITLE
gl_rasterizer: Fix glVertexAttribFormat for integers

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -169,8 +169,13 @@ std::pair<u8*, GLintptr> RasterizerOpenGL::SetupVertexArrays(u8* array_ptr,
         ASSERT(buffer.IsEnabled());
 
         glEnableVertexAttribArray(index);
-        glVertexAttribFormat(index, attrib.ComponentCount(), MaxwellToGL::VertexType(attrib),
-                             attrib.IsNormalized() ? GL_TRUE : GL_FALSE, attrib.offset);
+        if (attrib.type == Tegra::Engines::Maxwell3D::Regs::VertexAttribute::Type::SignedInt ||
+            attrib.type == Tegra::Engines::Maxwell3D::Regs::VertexAttribute::Type::UnsignedInt)
+            glVertexAttribIFormat(index, attrib.ComponentCount(), MaxwellToGL::VertexType(attrib),
+                                  attrib.offset);
+        else
+            glVertexAttribFormat(index, attrib.ComponentCount(), MaxwellToGL::VertexType(attrib),
+                                 attrib.IsNormalized() ? GL_TRUE : GL_FALSE, attrib.offset);
         glVertexAttribBinding(index, attrib.buffer);
     }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -170,12 +170,13 @@ std::pair<u8*, GLintptr> RasterizerOpenGL::SetupVertexArrays(u8* array_ptr,
 
         glEnableVertexAttribArray(index);
         if (attrib.type == Tegra::Engines::Maxwell3D::Regs::VertexAttribute::Type::SignedInt ||
-            attrib.type == Tegra::Engines::Maxwell3D::Regs::VertexAttribute::Type::UnsignedInt)
+            attrib.type == Tegra::Engines::Maxwell3D::Regs::VertexAttribute::Type::UnsignedInt) {
             glVertexAttribIFormat(index, attrib.ComponentCount(), MaxwellToGL::VertexType(attrib),
                                   attrib.offset);
-        else
+        } else {
             glVertexAttribFormat(index, attrib.ComponentCount(), MaxwellToGL::VertexType(attrib),
                                  attrib.IsNormalized() ? GL_TRUE : GL_FALSE, attrib.offset);
+        }
         glVertexAttribBinding(index, attrib.buffer);
     }
 


### PR DESCRIPTION
Thanks to @gdkchan research on the issue, this fixes one pieces incorrect verts on the arms.
<img width="1280" alt="2018-08-05_11-27-c8d0f15b-0059-4fe5-a538-4dcb837b4f82-07a35069" src="https://user-images.githubusercontent.com/25727384/43681820-133b1ad0-98a3-11e8-87f4-e4929331e8d9.png">
