### PR TITLE
gl_shader_decompiler: Fix TEXS mask and dest.

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -766,13 +766,16 @@ private:
         // goes into gpr28+0 and gpr28+1
         size_t texs_offset{};
 
+        size_t src_elem{};
         for (const auto& dest : {instr.gpr0.Value(), instr.gpr28.Value()}) {
+            size_t dest_elem{};
             for (unsigned elem = 0; elem < 2; ++elem) {
-                if (!instr.texs.IsComponentEnabled(elem)) {
+                if (!instr.texs.IsComponentEnabled(src_elem++)) {
                     // Skip disabled components
                     continue;
                 }
-                regs.SetRegisterToFloat(dest, elem + texs_offset, texture, 1, 4, false, elem);
+                regs.SetRegisterToFloat(dest, elem + texs_offset, texture, 1, 4, false,
+                                        dest_elem++);
             }
 
             if (!instr.texs.HasTwoDestinations()) {


### PR DESCRIPTION
Fixes some bugs with our TEXS impl. Gets One Piece: Unlimited World Red looking 👌 

![image](https://user-images.githubusercontent.com/6956688/43683027-bbc97680-9851-11e8-9c53-7bd48b2939cb.png)
