### PR TITLE
loader: Make AppLoader_NCA rely on directory loading code

### DIFF
--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -20,6 +20,10 @@ namespace Loader {
 AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(FileSys::VirtualFile file)
     : AppLoader(std::move(file)) {}
 
+AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(
+    FileSys::VirtualDir directory)
+    : AppLoader(directory->GetFile("main")), dir(std::move(directory)) {}
+
 FileType AppLoader_DeconstructedRomDirectory::IdentifyType(const FileSys::VirtualFile& file) {
     if (FileSys::IsDirectoryExeFS(file->GetContainingDirectory())) {
         return FileType::DeconstructedRomDirectory;
@@ -34,7 +38,12 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(
         return ResultStatus::ErrorAlreadyLoaded;
     }
 
-    const FileSys::VirtualDir dir = file->GetContainingDirectory();
+    if (dir == nullptr) {
+        if (file == nullptr)
+            return ResultStatus::ErrorInvalidFormat;
+        const FileSys::VirtualDir dir = file->GetContainingDirectory();
+    }
+
     const FileSys::VirtualFile npdm = dir->GetFile("main.npdm");
     if (npdm == nullptr)
         return ResultStatus::ErrorInvalidFormat;

--- a/src/core/loader/deconstructed_rom_directory.h
+++ b/src/core/loader/deconstructed_rom_directory.h
@@ -22,6 +22,9 @@ class AppLoader_DeconstructedRomDirectory final : public AppLoader {
 public:
     explicit AppLoader_DeconstructedRomDirectory(FileSys::VirtualFile main_file);
 
+    // Overload to accept exefs directory. Must contain 'main' and 'main.npdm'
+    explicit AppLoader_DeconstructedRomDirectory(FileSys::VirtualDir directory);
+
     /**
      * Returns the type of the file
      * @param file std::shared_ptr<VfsFile> open file
@@ -40,6 +43,7 @@ public:
 private:
     FileSys::ProgramMetadata metadata;
     FileSys::VirtualFile romfs;
+    FileSys::VirtualDir dir;
 };
 
 } // namespace Loader

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -10,6 +10,7 @@
 #include "core/file_sys/program_metadata.h"
 #include "core/hle/kernel/object.h"
 #include "core/loader/loader.h"
+#include "deconstructed_rom_directory.h"
 
 namespace Loader {
 
@@ -41,6 +42,7 @@ private:
     FileSys::ProgramMetadata metadata;
 
     std::unique_ptr<FileSys::NCA> nca;
+    std::unique_ptr<AppLoader_DeconstructedRomDirectory> directory_loader;
 };
 
 } // namespace Loader


### PR DESCRIPTION
Eliminates duplicate code shared between their `Load` methods, after all the only difference is how the romfs is handled.