### PR TITLE
 core_timing: Make GetGlobalTimeUs() return std::chrono::microseconds

### DIFF
--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -226,8 +226,8 @@ void Idle() {
     downcount = 0;
 }
 
-u64 GetGlobalTimeUs() {
-    return GetTicks() * 1000000 / BASE_CLOCK_RATE;
+std::chrono::microseconds GetGlobalTimeUs() {
+    return std::chrono::microseconds{GetTicks() * 1000000 / BASE_CLOCK_RATE};
 }
 
 int GetDowncount() {

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -17,6 +17,7 @@
  *   ScheduleEvent(periodInCycles - cyclesLate, callback, "whatever")
  */
 
+#include <chrono>
 #include <functional>
 #include <string>
 #include "common/common_types.h"
@@ -86,7 +87,7 @@ void ClearPendingEvents();
 
 void ForceExceptionCheck(s64 cycles);
 
-u64 GetGlobalTimeUs();
+std::chrono::microseconds GetGlobalTimeUs();
 
 int GetDowncount();
 

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -76,7 +76,7 @@ double PerfStats::GetLastFrameTimeScale() {
 void FrameLimiter::DoFrameLimiting(microseconds current_system_time_us) {
     // Max lag caused by slow frames. Can be adjusted to compensate for too many slow frames. Higher
     // values increase the time needed to recover and limit framerate again after spikes.
-    constexpr microseconds MAX_LAG_TIME_US = 25ms;
+    constexpr microseconds MAX_LAG_TIME_US = 25us;
 
     if (!Settings::values.toggle_framelimit) {
         return;
@@ -84,7 +84,7 @@ void FrameLimiter::DoFrameLimiting(microseconds current_system_time_us) {
 
     auto now = Clock::now();
 
-    frame_limiting_delta_err += microseconds(current_system_time_us - previous_system_time_us);
+    frame_limiting_delta_err += current_system_time_us - previous_system_time_us;
     frame_limiting_delta_err -= duration_cast<microseconds>(now - previous_walltime);
     frame_limiting_delta_err =
         std::clamp(frame_limiting_delta_err, -MAX_LAG_TIME_US, MAX_LAG_TIME_US);

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -40,22 +40,21 @@ void PerfStats::EndGameFrame() {
     game_frames += 1;
 }
 
-PerfStats::Results PerfStats::GetAndResetStats(u64 current_system_time_us) {
+PerfStats::Results PerfStats::GetAndResetStats(microseconds current_system_time_us) {
     std::lock_guard<std::mutex> lock(object_mutex);
 
-    auto now = Clock::now();
+    const auto now = Clock::now();
     // Walltime elapsed since stats were reset
-    auto interval = duration_cast<DoubleSecs>(now - reset_point).count();
+    const auto interval = duration_cast<DoubleSecs>(now - reset_point).count();
 
-    auto system_us_per_second =
-        static_cast<double>(current_system_time_us - reset_point_system_us) / interval;
+    const auto system_us_per_second = (current_system_time_us - reset_point_system_us) / interval;
 
     Results results{};
     results.system_fps = static_cast<double>(system_frames) / interval;
     results.game_fps = static_cast<double>(game_frames) / interval;
     results.frametime = duration_cast<DoubleSecs>(accumulated_frametime).count() /
                         static_cast<double>(system_frames);
-    results.emulation_speed = system_us_per_second / 1'000'000.0;
+    results.emulation_speed = system_us_per_second.count() / 1'000'000.0;
 
     // Reset counters
     reset_point = now;
@@ -74,7 +73,7 @@ double PerfStats::GetLastFrameTimeScale() {
     return duration_cast<DoubleSecs>(previous_frame_length).count() / FRAME_LENGTH;
 }
 
-void FrameLimiter::DoFrameLimiting(u64 current_system_time_us) {
+void FrameLimiter::DoFrameLimiting(microseconds current_system_time_us) {
     // Max lag caused by slow frames. Can be adjusted to compensate for too many slow frames. Higher
     // values increase the time needed to recover and limit framerate again after spikes.
     constexpr microseconds MAX_LAG_TIME_US = 25ms;

--- a/src/core/perf_stats.h
+++ b/src/core/perf_stats.h
@@ -33,7 +33,7 @@ public:
     void EndSystemFrame();
     void EndGameFrame();
 
-    Results GetAndResetStats(u64 current_system_time_us);
+    Results GetAndResetStats(std::chrono::microseconds current_system_time_us);
 
     /**
      * Gets the ratio between walltime and the emulated time of the previous system frame. This is
@@ -47,7 +47,7 @@ private:
     /// Point when the cumulative counters were reset
     Clock::time_point reset_point = Clock::now();
     /// System time when the cumulative counters were reset
-    u64 reset_point_system_us = 0;
+    std::chrono::microseconds reset_point_system_us{0};
 
     /// Cumulative duration (excluding v-sync/frame-limiting) of frames since last reset
     Clock::duration accumulated_frametime = Clock::duration::zero();
@@ -68,11 +68,11 @@ class FrameLimiter {
 public:
     using Clock = std::chrono::high_resolution_clock;
 
-    void DoFrameLimiting(u64 current_system_time_us);
+    void DoFrameLimiting(std::chrono::microseconds current_system_time_us);
 
 private:
     /// Emulated system time (in microseconds) at the last limiter invocation
-    u64 previous_system_time_us = 0;
+    std::chrono::microseconds previous_system_time_us{0};
     /// Walltime at the last limiter invocation
     Clock::time_point previous_walltime = Clock::now();
 


### PR DESCRIPTION
Enforces the time unit being returned and also allows using the standard time utilities to manipulate it.