### PR TITLE
Port fixup of "gdbstub: Get rid of a few signed/unsigned comparisons" from citra

### DIFF
--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -743,7 +743,7 @@ static bool IsDataAvailable() {
     fd_set fd_socket;
 
     FD_ZERO(&fd_socket);
-    FD_SET(static_cast<u32>(gdbserver_socket), &fd_socket);
+    FD_SET(gdbserver_socket, &fd_socket);
 
     struct timeval t;
     t.tv_sec = 0;


### PR DESCRIPTION
According to @wwylele comment, there's no need to cast to u32

See citra-emu/citra#4031, #723 for details.