### PR TITLE
gl_rasterizer_cache: Avoid superfluous surface copies.

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -285,8 +285,6 @@ Texture::TICEntry Maxwell3D::GetTICEntry(u32 tic_index) const {
 
     // TODO(Subv): Different data types for separate components are not supported
     ASSERT(r_type == g_type && r_type == b_type && r_type == a_type);
-    // TODO(Subv): Only UNORM formats are supported for now.
-    ASSERT(r_type == Texture::ComponentType::UNORM);
 
     return tic_entry;
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -46,6 +46,8 @@ struct FormatTuple {
     params.height = Common::AlignUp(config.tic.Height(), GetCompressionFactor(params.pixel_format));
     params.unaligned_height = config.tic.Height();
     params.size_in_bytes = params.SizeInBytes();
+    params.cache_width = Common::AlignUp(params.width, 16);
+    params.cache_height = Common::AlignUp(params.height, 16);
     return params;
 }
 
@@ -63,6 +65,8 @@ struct FormatTuple {
     params.height = config.height;
     params.unaligned_height = config.height;
     params.size_in_bytes = params.SizeInBytes();
+    params.cache_width = Common::AlignUp(params.width, 16);
+    params.cache_height = Common::AlignUp(params.height, 16);
     return params;
 }
 
@@ -82,6 +86,8 @@ struct FormatTuple {
     params.height = zeta_height;
     params.unaligned_height = zeta_height;
     params.size_in_bytes = params.SizeInBytes();
+    params.cache_width = Common::AlignUp(params.width, 16);
+    params.cache_height = Common::AlignUp(params.height, 16);
     return params;
 }
 
@@ -680,12 +686,12 @@ Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params) {
             // If use_accurate_framebuffers is enabled, always load from memory
             FlushSurface(surface);
             UnregisterSurface(surface);
-        } else if (surface->GetSurfaceParams() != params) {
-            // If surface parameters changed, recreate the surface from the old one
-            return RecreateSurface(surface, params);
-        } else {
+        } else if (surface->GetSurfaceParams().IsCompatibleSurface(params)) {
             // Use the cached surface as-is
             return surface;
+        } else {
+            // If surface parameters changed, recreate the surface from the old one
+            return RecreateSurface(surface, params);
         }
     }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <vector>
 #include <boost/icl/interval_map.hpp>
+
 #include "common/common_types.h"
 #include "common/math_util.h"
 #include "video_core/engines/maxwell_3d.h"
@@ -546,6 +547,12 @@ struct SurfaceParams {
         return !operator==(other);
     }
 
+    /// Checks if surfaces are compatible for caching
+    bool IsCompatibleSurface(const SurfaceParams& other) const {
+        return std::tie(pixel_format, type, cache_width, cache_height) ==
+               std::tie(other.pixel_format, other.type, other.cache_width, other.cache_height);
+    }
+
     Tegra::GPUVAddr addr;
     bool is_tiled;
     u32 block_height;
@@ -556,6 +563,10 @@ struct SurfaceParams {
     u32 height;
     u32 unaligned_height;
     size_t size_in_bytes;
+
+    // Parameters used for caching only
+    u32 cache_width;
+    u32 cache_height;
 };
 
 class CachedSurface final {


### PR DESCRIPTION
Loosens restrictions for what necessitates a surface copy. Avoids lots of superfluous copies in games, particularly where small non-power-of-2 textures are uses as power-of-2 surfaces. Tested all of my games, no visual defects with this change. Doubles the framerate in One Piece.

![image](https://user-images.githubusercontent.com/6956688/43696201-f0c9290c-990a-11e8-9b4e-2c18ae9fca9c.png)

![image](https://user-images.githubusercontent.com/6956688/43696193-e2f6b524-990a-11e8-8d17-cc97ee90e768.png)
