### PR TITLE
kernel/event: Make data members private

### DIFF
--- a/src/core/hle/kernel/event.h
+++ b/src/core/hle/kernel/event.h
@@ -31,10 +31,9 @@ public:
         return HANDLE_TYPE;
     }
 
-    ResetType reset_type; ///< Current ResetType
-
-    bool signaled;    ///< Whether the event has already been signaled
-    std::string name; ///< Name of event (optional)
+    ResetType GetResetType() const {
+        return reset_type;
+    }
 
     bool ShouldWait(Thread* thread) const override;
     void Acquire(Thread* thread) override;
@@ -47,6 +46,11 @@ public:
 private:
     Event();
     ~Event() override;
+
+    ResetType reset_type; ///< Current ResetType
+
+    bool signaled;    ///< Whether the event has already been signaled
+    std::string name; ///< Name of event (optional)
 };
 
 } // namespace Kernel

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -316,7 +316,7 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeEvent::GetChildren() const {
 
     list.push_back(std::make_unique<WaitTreeText>(
         tr("reset type = %1")
-            .arg(GetResetTypeQString(static_cast<const Kernel::Event&>(object).reset_type))));
+            .arg(GetResetTypeQString(static_cast<const Kernel::Event&>(object).GetResetType()))));
     return list;
 }
 


### PR DESCRIPTION
Instead we can simply provide accessors to the required data instead of giving external read/write access to the variables directly.