### PR TITLE
qt/main: Better file-existence checking within OnMenuRecentFile() and UpdateUITheme()

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -654,9 +654,8 @@ void GMainWindow::OnMenuRecentFile() {
     QAction* action = qobject_cast<QAction*>(sender());
     assert(action);
 
-    QString filename = action->data().toString();
-    QFileInfo file_info(filename);
-    if (file_info.exists()) {
+    const QString filename = action->data().toString();
+    if (QFileInfo::exists(filename)) {
         BootGame(filename);
     } else {
         // Display an error message and remove the file from the list.
@@ -947,15 +946,14 @@ void GMainWindow::UpdateUITheme() {
     QStringList theme_paths(default_theme_paths);
     if (UISettings::values.theme != UISettings::themes[0].second &&
         !UISettings::values.theme.isEmpty()) {
-        QString theme_uri(":" + UISettings::values.theme + "/style.qss");
+        const QString theme_uri(":" + UISettings::values.theme + "/style.qss");
         QFile f(theme_uri);
-        if (!f.exists()) {
-            LOG_ERROR(Frontend, "Unable to set style, stylesheet file not found");
-        } else {
-            f.open(QFile::ReadOnly | QFile::Text);
+        if (f.open(QFile::ReadOnly | QFile::Text)) {
             QTextStream ts(&f);
             qApp->setStyleSheet(ts.readAll());
             GMainWindow::setStyleSheet(ts.readAll());
+        } else {
+            LOG_ERROR(Frontend, "Unable to set style, stylesheet file not found");
         }
         theme_paths.append(QStringList{":/icons/default", ":/icons/" + UISettings::values.theme});
         QIcon::setThemeName(":/icons/" + UISettings::values.theme);


### PR DESCRIPTION
In OnMenuRecentFile() we don't need to construct a QFileInfo instance just to check if a file exists, we can just use the static member function to do that (which Qt's documentation also notes as quicker than constructing an instance).

In UpdateUITheme(), we just want to try and open the file and check the success of that operation. Technically speaking, between the existence check and the open call, the file can be deleted or moved, but still appear to succeed in code. i.e.

1. Existence check -> Returns true
2. File is moved/deleted/external drive the file is on fails/etc
3. Open is called, the return value of which isn't checked
4. Nonsense behavior

This way we combine the existence check and the open into one to prevent that.