### PR TITLE
CMakeLists: Make mbedtls and cubeb not install headers and libraries

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -36,7 +36,7 @@ add_subdirectory(lz4/contrib/cmake_unofficial)
 target_include_directories(lz4_static INTERFACE ./lz4/lib)
 
 # mbedtls
-add_subdirectory(mbedtls)
+add_subdirectory(mbedtls EXCLUDE_FROM_ALL)
 target_include_directories(mbedtls PUBLIC ./mbedtls/include)
 
 # MicroProfile
@@ -62,5 +62,5 @@ target_include_directories(opus INTERFACE ./opus/include)
 # Cubeb
 if(ENABLE_CUBEB)
     set(BUILD_TESTS OFF CACHE BOOL "")
-    add_subdirectory(cubeb)
+    add_subdirectory(cubeb EXCLUDE_FROM_ALL)
 endif()


### PR DESCRIPTION
This PR makes it so that `make install` does not install the mbedtls or cubeb headers and static libraries.