### PR TITLE
client_port: Make all data members private

### DIFF
--- a/src/core/hle/kernel/client_port.cpp
+++ b/src/core/hle/kernel/client_port.cpp
@@ -14,8 +14,8 @@
 
 namespace Kernel {
 
-ClientPort::ClientPort() {}
-ClientPort::~ClientPort() {}
+ClientPort::ClientPort() = default;
+ClientPort::~ClientPort() = default;
 
 ResultVal<SharedPtr<ClientSession>> ClientPort::Connect() {
     // Note: Threads do not wait for the server endpoint to call
@@ -38,6 +38,14 @@ ResultVal<SharedPtr<ClientSession>> ClientPort::Connect() {
     server_port->WakeupAllWaitingThreads();
 
     return MakeResult(std::get<SharedPtr<ClientSession>>(sessions));
+}
+
+void ClientPort::ConnectionClosed() {
+    if (active_sessions == 0) {
+        return;
+    }
+
+    --active_sessions;
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/client_port.h
+++ b/src/core/hle/kernel/client_port.h
@@ -37,14 +37,20 @@ public:
      */
     ResultVal<SharedPtr<ClientSession>> Connect();
 
-    SharedPtr<ServerPort> server_port; ///< ServerPort associated with this client port.
-    u32 max_sessions;    ///< Maximum number of simultaneous sessions the port can have
-    u32 active_sessions; ///< Number of currently open sessions to this port
-    std::string name;    ///< Name of client port (optional)
+    /**
+     * Signifies that a previously active connection has been closed,
+     * decreasing the total number of active connections to this port.
+     */
+    void ConnectionClosed();
 
 private:
     ClientPort();
     ~ClientPort() override;
+
+    SharedPtr<ServerPort> server_port; ///< ServerPort associated with this client port.
+    u32 max_sessions = 0;    ///< Maximum number of simultaneous sessions the port can have
+    u32 active_sessions = 0; ///< Number of currently open sessions to this port
+    std::string name;        ///< Name of client port (optional)
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -27,7 +27,7 @@ ServerSession::~ServerSession() {
 
     // Decrease the port's connection count.
     if (parent->port)
-        parent->port->active_sessions--;
+        parent->port->ConnectionClosed();
 
     // TODO(Subv): Wake up all the ClientSession's waiting threads and set
     // the SendSyncRequest result to 0xC920181A.


### PR DESCRIPTION
These members don't need to be entirely exposed, we can instead expose an API to operate on them without directly needing to mutate them

We can also guard against overflow/API misuse this way as well, given active_sessions is an unsigned value.