### PR TITLE
nvflinger: Use std::string_view in OpenDisplay()

### DIFF
--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -43,7 +43,7 @@ NVFlinger::~NVFlinger() {
     CoreTiming::UnscheduleEvent(composition_event, 0);
 }
 
-u64 NVFlinger::OpenDisplay(const std::string& name) {
+u64 NVFlinger::OpenDisplay(std::string_view name) {
     LOG_WARNING(Service, "Opening display {}", name);
 
     // TODO(Subv): Currently we only support the Default display.

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -3,8 +3,11 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <boost/optional.hpp>
 
 #include "common/alignment.h"
+#include "common/assert.h"
+#include "common/logging/log.h"
 #include "common/microprofile.h"
 #include "common/scope_exit.h"
 #include "core/core.h"

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <string_view>
 #include <boost/optional.hpp>
 #include "core/hle/kernel/event.h"
 
@@ -41,7 +42,7 @@ public:
     ~NVFlinger();
 
     /// Opens the specified display and returns the id.
-    u64 OpenDisplay(const std::string& name);
+    u64 OpenDisplay(std::string_view name);
 
     /// Creates a layer on the specified display and returns the layer id.
     u64 CreateLayer(u64 display_id);

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -5,8 +5,11 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <string_view>
-#include <boost/optional.hpp>
+#include <vector>
+
+#include "common/common_types.h"
 #include "core/hle/kernel/event.h"
 
 namespace CoreTiming {


### PR DESCRIPTION
We don't need to use a `std::string` here, given all that's done is comparing the character sequence against another. This allows passing regular `const char*` without needing to heap allocate.