### PR TITLE
nvdrv: Get rid of global std::weak_ptr

### DIFF
--- a/src/core/hle/service/nvdrv/nvdrv.cpp
+++ b/src/core/hle/service/nvdrv/nvdrv.cpp
@@ -16,19 +16,18 @@
 #include "core/hle/service/nvdrv/interface.h"
 #include "core/hle/service/nvdrv/nvdrv.h"
 #include "core/hle/service/nvdrv/nvmemp.h"
+#include "core/hle/service/nvflinger/nvflinger.h"
 
 namespace Service::Nvidia {
 
-std::weak_ptr<Module> nvdrv;
-
-void InstallInterfaces(SM::ServiceManager& service_manager) {
+void InstallInterfaces(SM::ServiceManager& service_manager, NVFlinger::NVFlinger& nvflinger) {
     auto module_ = std::make_shared<Module>();
     std::make_shared<NVDRV>(module_, "nvdrv")->InstallAsService(service_manager);
     std::make_shared<NVDRV>(module_, "nvdrv:a")->InstallAsService(service_manager);
     std::make_shared<NVDRV>(module_, "nvdrv:s")->InstallAsService(service_manager);
     std::make_shared<NVDRV>(module_, "nvdrv:t")->InstallAsService(service_manager);
     std::make_shared<NVMEMP>()->InstallAsService(service_manager);
-    nvdrv = module_;
+    nvflinger.SetNVDrvInstance(module_);
 }
 
 Module::Module() {

--- a/src/core/hle/service/nvdrv/nvdrv.h
+++ b/src/core/hle/service/nvdrv/nvdrv.h
@@ -10,6 +10,10 @@
 #include "common/common_types.h"
 #include "core/hle/service/service.h"
 
+namespace Service::NVFlinger {
+class NVFlinger;
+}
+
 namespace Service::Nvidia {
 
 namespace Devices {
@@ -56,8 +60,6 @@ private:
 };
 
 /// Registers all NVDRV services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
-
-extern std::weak_ptr<Module> nvdrv;
+void InstallInterfaces(SM::ServiceManager& service_manager, NVFlinger::NVFlinger& nvflinger);
 
 } // namespace Service::Nvidia

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -46,6 +46,10 @@ NVFlinger::~NVFlinger() {
     CoreTiming::UnscheduleEvent(composition_event, 0);
 }
 
+void NVFlinger::SetNVDrvInstance(std::shared_ptr<Nvidia::Module> instance) {
+    nvdrv = std::move(instance);
+}
+
 u64 NVFlinger::OpenDisplay(std::string_view name) {
     LOG_WARNING(Service, "Opening display {}", name);
 
@@ -141,9 +145,6 @@ void NVFlinger::Compose() {
         auto& igbp_buffer = buffer->igbp_buffer;
 
         // Now send the buffer to the GPU for drawing.
-        auto nvdrv = Nvidia::nvdrv.lock();
-        ASSERT(nvdrv);
-
         // TODO(Subv): Support more than just disp0. The display device selection is probably based
         // on which display we're drawing (Default, Internal, External, etc)
         auto nvdisp = nvdrv->GetDevice<Nvidia::Devices::nvdisp_disp0>("/dev/nvdisp_disp0");

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -16,6 +16,10 @@ namespace CoreTiming {
 struct EventType;
 }
 
+namespace Service::Nvidia {
+class Module;
+}
+
 namespace Service::NVFlinger {
 
 class BufferQueue;
@@ -44,6 +48,9 @@ public:
     NVFlinger();
     ~NVFlinger();
 
+    /// Sets the NVDrv module instance to use to send buffers to the GPU.
+    void SetNVDrvInstance(std::shared_ptr<Nvidia::Module> instance);
+
     /// Opens the specified display and returns the id.
     u64 OpenDisplay(std::string_view name);
 
@@ -69,6 +76,8 @@ private:
 
     /// Returns the layer identified by the specified id in the desired display.
     Layer& GetLayer(u64 display_id, u64 layer_id);
+
+    std::shared_ptr<Nvidia::Module> nvdrv;
 
     std::vector<Display> displays;
     std::vector<std::shared_ptr<BufferQueue>> buffer_queues;

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -238,7 +238,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm) {
     NIFM::InstallInterfaces(*sm);
     NIM::InstallInterfaces(*sm);
     NS::InstallInterfaces(*sm);
-    Nvidia::InstallInterfaces(*sm);
+    Nvidia::InstallInterfaces(*sm, *nv_flinger);
     PCIe::InstallInterfaces(*sm);
     PCTL::InstallInterfaces(*sm);
     PCV::InstallInterfaces(*sm);


### PR DESCRIPTION
Rather than use global state, we can simply pass the instance into the NVFlinger instance directly.