### PR TITLE
service/apm: Add the apm:sys service

### DIFF
--- a/src/core/hle/service/apm/apm.cpp
+++ b/src/core/hle/service/apm/apm.cpp
@@ -13,6 +13,7 @@ void InstallInterfaces(SM::ServiceManager& service_manager) {
     auto module_ = std::make_shared<Module>();
     std::make_shared<APM>(module_, "apm")->InstallAsService(service_manager);
     std::make_shared<APM>(module_, "apm:p")->InstallAsService(service_manager);
+    std::make_shared<APM_Sys>()->InstallAsService(service_manager);
 }
 
 } // namespace Service::APM

--- a/src/core/hle/service/apm/interface.cpp
+++ b/src/core/hle/service/apm/interface.cpp
@@ -74,6 +74,31 @@ void APM::OpenSession(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<ISession>();
+
+    LOG_DEBUG(Service_APM, "called");
+}
+
+APM_Sys::APM_Sys() : ServiceFramework{"apm:sys"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "RequestPerformanceMode"},
+        {1, &APM_Sys::GetPerformanceEvent, "GetPerformanceEvent"},
+        {2, nullptr, "GetThrottlingState"},
+        {3, nullptr, "GetLastThrottlingState"},
+        {4, nullptr, "ClearLastThrottlingState"},
+        {5, nullptr, "LoadAndApplySettings"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+void APM_Sys::GetPerformanceEvent(Kernel::HLERequestContext& ctx) {
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    rb.Push(RESULT_SUCCESS);
+    rb.PushIpcInterface<ISession>();
+
+    LOG_DEBUG(Service_APM, "called");
 }
 
 } // namespace Service::APM

--- a/src/core/hle/service/apm/interface.h
+++ b/src/core/hle/service/apm/interface.h
@@ -19,4 +19,12 @@ private:
     std::shared_ptr<Module> apm;
 };
 
+class APM_Sys final : public ServiceFramework<APM_Sys> {
+public:
+    explicit APM_Sys();
+
+private:
+    void GetPerformanceEvent(Kernel::HLERequestContext& ctx);
+};
+
 } // namespace Service::APM


### PR DESCRIPTION
Adds the basic skeleton of the apm:sys service based off the information on Switch Brew.