### PR TITLE
Fixed the sRGB pixel format

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -201,7 +201,6 @@ struct SurfaceParams {
     static PixelFormat PixelFormatFromRenderTargetFormat(Tegra::RenderTargetFormat format) {
         switch (format) {
         case Tegra::RenderTargetFormat::RGBA8_SRGB:
-            return PixelFormat::SRGBA8;
         case Tegra::RenderTargetFormat::RGBA8_UNORM:
             return PixelFormat::ABGR8;
         case Tegra::RenderTargetFormat::BGRA8_UNORM:

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -200,6 +200,8 @@ struct SurfaceParams {
 
     static PixelFormat PixelFormatFromRenderTargetFormat(Tegra::RenderTargetFormat format) {
         switch (format) {
+        // TODO (Hexagon12): Converting SRGBA to RGBA is a hack and doesn't completely correct the
+        // gamma.
         case Tegra::RenderTargetFormat::RGBA8_SRGB:
         case Tegra::RenderTargetFormat::RGBA8_UNORM:
             return PixelFormat::ABGR8;


### PR DESCRIPTION
This PR fixes the returning TextureFormat for RGBA8_SRGB to ABGR8, instead of SRGBA8.

Games like Splatoon 2, Super Mario Odyssey, 1-2-Switch will now render with the close-to-correct gamma (no dark tints anymore).