### PR TITLE
common: Convert type traits templates over to variable template versions where applicable

### DIFF
--- a/src/common/alignment.h
+++ b/src/common/alignment.h
@@ -9,13 +9,13 @@ namespace Common {
 
 template <typename T>
 constexpr T AlignUp(T value, size_t size) {
-    static_assert(std::is_unsigned<T>::value, "T must be an unsigned value.");
+    static_assert(std::is_unsigned_v<T>, "T must be an unsigned value.");
     return static_cast<T>(value + (size - value % size) % size);
 }
 
 template <typename T>
 constexpr T AlignDown(T value, size_t size) {
-    static_assert(std::is_unsigned<T>::value, "T must be an unsigned value.");
+    static_assert(std::is_unsigned_v<T>, "T must be an unsigned value.");
     return static_cast<T>(value - value % size);
 }
 

--- a/src/common/bit_set.h
+++ b/src/common/bit_set.h
@@ -96,7 +96,7 @@ static inline int LeastSignificantSetBit(u64 val) {
 
 template <typename IntTy>
 class BitSet {
-    static_assert(!std::is_signed<IntTy>::value, "BitSet should not be used with signed types");
+    static_assert(!std::is_signed_v<IntTy>, "BitSet should not be used with signed types");
 
 public:
     // A reference to a particular bit, returned from operator[].

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -207,7 +207,7 @@ public:
 
     template <typename T>
     size_t ReadArray(T* data, size_t length) const {
-        static_assert(std::is_trivially_copyable<T>(),
+        static_assert(std::is_trivially_copyable_v<T>,
                       "Given array does not consist of trivially copyable objects");
 
         if (!IsOpen())
@@ -218,7 +218,7 @@ public:
 
     template <typename T>
     size_t WriteArray(const T* data, size_t length) {
-        static_assert(std::is_trivially_copyable<T>(),
+        static_assert(std::is_trivially_copyable_v<T>,
                       "Given array does not consist of trivially copyable objects");
         if (!IsOpen())
             return -1;
@@ -227,19 +227,19 @@ public:
 
     template <typename T>
     size_t ReadBytes(T* data, size_t length) const {
-        static_assert(std::is_trivially_copyable<T>(), "T must be trivially copyable");
+        static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
         return ReadArray(reinterpret_cast<char*>(data), length);
     }
 
     template <typename T>
     size_t WriteBytes(const T* data, size_t length) {
-        static_assert(std::is_trivially_copyable<T>(), "T must be trivially copyable");
+        static_assert(std::is_trivially_copyable_v<T>, "T must be trivially copyable");
         return WriteArray(reinterpret_cast<const char*>(data), length);
     }
 
     template <typename T>
     size_t WriteObject(const T& object) {
-        static_assert(!std::is_pointer<T>::value, "Given object is a pointer");
+        static_assert(!std::is_pointer_v<T>, "WriteObject arguments must not be a pointer");
         return WriteArray(&object, 1);
     }
 

--- a/src/common/hash.h
+++ b/src/common/hash.h
@@ -28,7 +28,7 @@ static inline u64 ComputeHash64(const void* data, size_t len) {
  */
 template <typename T>
 static inline u64 ComputeStructHash64(const T& data) {
-    static_assert(std::is_trivially_copyable<T>(),
+    static_assert(std::is_trivially_copyable_v<T>,
                   "Type passed to ComputeStructHash64 must be trivially copyable");
     return ComputeHash64(&data, sizeof(data));
 }
@@ -38,7 +38,7 @@ template <typename T>
 struct HashableStruct {
     // In addition to being trivially copyable, T must also have a trivial default constructor,
     // because any member initialization would be overridden by memset
-    static_assert(std::is_trivial<T>(), "Type passed to HashableStruct must be trivial");
+    static_assert(std::is_trivial_v<T>, "Type passed to HashableStruct must be trivial");
     /*
      * We use a union because "implicitly-defined copy/move constructor for a union X copies the
      * object representation of X." and "implicitly-defined copy assignment operator for a union X

--- a/src/common/x64/xbyak_util.h
+++ b/src/common/x64/xbyak_util.h
@@ -34,7 +34,7 @@ inline bool IsWithin2G(const Xbyak::CodeGenerator& code, uintptr_t target) {
 
 template <typename T>
 inline void CallFarFunction(Xbyak::CodeGenerator& code, const T f) {
-    static_assert(std::is_pointer<T>(), "Argument must be a (function) pointer.");
+    static_assert(std::is_pointer_v<T>, "Argument must be a (function) pointer.");
     size_t addr = reinterpret_cast<size_t>(f);
     if (IsWithin2G(code, addr)) {
         code.call(f);


### PR DESCRIPTION
Uses the C++17 inline variable variants. Just a modernization cleanup