### PR TITLE
externals/CMakeLists: Add EXCLUDE_FROM_ALL to lz4's add_subdirectory() command

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -32,7 +32,7 @@ add_subdirectory(inih)
 
 # lz4
 set(LZ4_BUNDLED_MODE ON)
-add_subdirectory(lz4/contrib/cmake_unofficial)
+add_subdirectory(lz4/contrib/cmake_unofficial EXCLUDE_FROM_ALL)
 target_include_directories(lz4_static INTERFACE ./lz4/lib)
 
 # mbedtls


### PR DESCRIPTION
We don't need to build the lz4 CLI tool, or anything else. We just want to build in the library statically, so we specify this to ensure that. Now, we don't potentially build unnecessary targets.