### PR TITLE
externals: Update catch to 2.3.0

### DIFF
--- a/src/tests/common/param_package.cpp
+++ b/src/tests/common/param_package.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <math.h>
 #include "common/param_package.h"
 

--- a/src/tests/core/core_timing.cpp
+++ b/src/tests/core/core_timing.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2+
 // Refer to the license.txt file included.
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 #include <array>
 #include <bitset>

--- a/src/tests/glad.cpp
+++ b/src/tests/glad.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 #include <glad/glad.h>
 
 // This is not an actual test, but a work-around for issue #2183.

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #define CATCH_CONFIG_MAIN
-#include <catch.hpp>
+#include <catch2/catch.hpp>
 
 // Catch provides the main function since we've given it the
 // CATCH_CONFIG_MAIN preprocessor directive.


### PR DESCRIPTION
Updates the library from 2.2.3 to 2.3.0. The changelog can be seen [here](https://github.com/catchorg/Catch2/releases)