### PR TITLE
acc: Add missing function table entries for GetUserCount

### DIFF
--- a/src/core/hle/service/acc/acc_su.cpp
+++ b/src/core/hle/service/acc/acc_su.cpp
@@ -8,7 +8,7 @@ namespace Service::Account {
 
 ACC_SU::ACC_SU(std::shared_ptr<Module> module) : Module::Interface(std::move(module), "acc:su") {
     static const FunctionInfo functions[] = {
-        {0, nullptr, "GetUserCount"},
+        {0, &ACC_SU::GetUserCount, "GetUserCount"},
         {1, &ACC_SU::GetUserExistence, "GetUserExistence"},
         {2, &ACC_SU::ListAllUsers, "ListAllUsers"},
         {3, &ACC_SU::ListOpenUsers, "ListOpenUsers"},

--- a/src/core/hle/service/acc/acc_u1.cpp
+++ b/src/core/hle/service/acc/acc_u1.cpp
@@ -8,7 +8,7 @@ namespace Service::Account {
 
 ACC_U1::ACC_U1(std::shared_ptr<Module> module) : Module::Interface(std::move(module), "acc:u1") {
     static const FunctionInfo functions[] = {
-        {0, nullptr, "GetUserCount"},
+        {0, &ACC_U1::GetUserCount, "GetUserCount"},
         {1, &ACC_U1::GetUserExistence, "GetUserExistence"},
         {2, &ACC_U1::ListAllUsers, "ListAllUsers"},
         {3, &ACC_U1::ListOpenUsers, "ListOpenUsers"},


### PR DESCRIPTION
Given this is stubbed within the common module in 5ac7b84, it should be added to the other relevant tables as well.