### PR TITLE
nvhost_gpu: Don't over copy IoctlSubmitGpfifo.

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
@@ -147,7 +147,7 @@ u32 nvhost_gpu::SubmitGPFIFO(const std::vector<u8>& input, std::vector<u8>& outp
     }
     params.fence_out.id = 0;
     params.fence_out.value = 0;
-    std::memcpy(output.data(), &params, output.size());
+    std::memcpy(output.data(), &params, sizeof(IoctlSubmitGpfifo));
     return 0;
 }
 


### PR DESCRIPTION
- Fixes a crash with Super Mario Odyssey.