### PR TITLE
 fsp_srv: Emplace entries first when building index instead of emplacing last

### DIFF
--- a/src/core/file_sys/directory.h
+++ b/src/core/file_sys/directory.h
@@ -4,8 +4,9 @@
 
 #pragma once
 
-#include <array>
 #include <cstddef>
+#include <iterator>
+#include <string_view>
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 
@@ -21,9 +22,14 @@ enum EntryType : u8 {
 
 // Structure of a directory entry, from
 // http://switchbrew.org/index.php?title=Filesystem_services#DirectoryEntry
-const size_t FILENAME_LENGTH = 0x300;
 struct Entry {
-    char filename[FILENAME_LENGTH];
+    Entry(std::string_view view, EntryType entry_type, u64 entry_size)
+        : type{entry_type}, file_size{entry_size} {
+        const size_t copy_size = view.copy(filename, std::size(filename) - 1);
+        filename[copy_size] = '\0';
+    }
+
+    char filename[0x300];
     INSERT_PADDING_BYTES(4);
     EntryType type;
     INSERT_PADDING_BYTES(3);

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -196,11 +196,7 @@ static void BuildEntryIndex(std::vector<FileSys::Entry>& entries, const std::vec
     entries.reserve(entries.size() + new_data.size());
 
     for (const auto& new_entry : new_data) {
-        auto& entry = entries.emplace_back();
-        entry.filename[0] = '\0';
-        std::strncat(entry.filename, new_entry->GetName().c_str(), FileSys::FILENAME_LENGTH - 1);
-        entry.type = type;
-        entry.file_size = new_entry->GetSize();
+        entries.emplace_back(new_entry->GetName(), type, new_entry->GetSize());
     }
 }
 

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -193,13 +193,14 @@ private:
 template <typename T>
 static void BuildEntryIndex(std::vector<FileSys::Entry>& entries, const std::vector<T>& new_data,
                             FileSys::EntryType type) {
+    entries.reserve(entries.size() + new_data.size());
+
     for (const auto& new_entry : new_data) {
-        FileSys::Entry entry;
+        auto& entry = entries.emplace_back();
         entry.filename[0] = '\0';
         std::strncat(entry.filename, new_entry->GetName().c_str(), FileSys::FILENAME_LENGTH - 1);
         entry.type = type;
         entry.file_size = new_entry->GetSize();
-        entries.emplace_back(std::move(entry));
     }
 }
 


### PR DESCRIPTION
The current way were doing it would require copying a 768 character buffer (part of the Entry struct) to the new element in the vector. Given it's a plain array, std::move won't eliminate that.

Instead, we can emplace an instance directly into the destination buffer and then fill it out, avoiding the need to perform any unnecessary copies.

Given this is done in a loop, we can request the destination to allocate all of the necessary memory ahead of time, avoiding the need to potentially keep reallocating over and over on every few insertions into the vector.

This makes it slightly better when it comes to building the filesystem index, and we keep the sanitizing logic for the filename within the same struct its in, as opposed to being off in some other separate module.