### PR TITLE
gl_shader_decompiler: Reserve element memory beforehand in BuildRegisterList()

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -507,6 +507,8 @@ private:
 
     /// Build the GLSL register list.
     void BuildRegisterList() {
+        regs.reserve(Register::NumRegisters);
+
         for (size_t index = 0; index < Register::NumRegisters; ++index) {
             regs.emplace_back(index, suffix);
         }


### PR DESCRIPTION
Avoids potentially perfoming multiple reallocations when we know the total amount of memory we need beforehand.