### PR TITLE
file_sys: Add support for registration format

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -40,6 +40,8 @@ add_library(common STATIC
     file_util.cpp
     file_util.h
     hash.h
+    hex_util.cpp
+    hex_util.h
     logging/backend.cpp
     logging/backend.h
     logging/filter.cpp

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -750,6 +750,12 @@ std::string GetHactoolConfigurationPath() {
 #endif
 }
 
+std::string GetNANDRegistrationDir(bool system) {
+    if (system)
+        return GetUserPath(UserPath::NANDDir) + "system/Contents/registered/";
+    return GetUserPath(UserPath::NANDDir) + "user/Contents/registered/";
+}
+
 size_t WriteStringToFile(bool text_file, const std::string& str, const char* filename) {
     return FileUtil::IOFile(filename, text_file ? "w" : "wb").WriteBytes(str.data(), str.size());
 }

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -129,6 +129,8 @@ const std::string& GetUserPath(UserPath path, const std::string& new_path = "");
 
 std::string GetHactoolConfigurationPath();
 
+std::string GetNANDRegistrationDir(bool system = false);
+
 // Returns the path to where the sys file are
 std::string GetSysDirectory();
 

--- a/src/common/hex_util.cpp
+++ b/src/common/hex_util.cpp
@@ -1,0 +1,27 @@
+// Copyright 2013 Dolphin Emulator Project / 2014 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/hex_util.h"
+
+u8 ToHexNibble(char c1) {
+    if (c1 >= 65 && c1 <= 70)
+        return c1 - 55;
+    if (c1 >= 97 && c1 <= 102)
+        return c1 - 87;
+    if (c1 >= 48 && c1 <= 57)
+        return c1 - 48;
+    throw std::logic_error("Invalid hex digit");
+}
+
+std::array<u8, 16> operator""_array16(const char* str, size_t len) {
+    if (len != 32)
+        throw std::logic_error("Not of correct size.");
+    return HexStringToArray<16>(str);
+}
+
+std::array<u8, 32> operator""_array32(const char* str, size_t len) {
+    if (len != 64)
+        throw std::logic_error("Not of correct size.");
+    return HexStringToArray<32>(str);
+}

--- a/src/common/hex_util.h
+++ b/src/common/hex_util.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <array>
+#include <cstddef>
+#include <string>
 #include <fmt/format.h>
 #include "common/common_types.h"
 

--- a/src/common/hex_util.h
+++ b/src/common/hex_util.h
@@ -1,0 +1,35 @@
+// Copyright 2013 Dolphin Emulator Project / 2014 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+#include <fmt/format.h>
+#include "common/common_types.h"
+
+u8 ToHexNibble(char c1);
+
+template <size_t Size, bool le = false>
+std::array<u8, Size> HexStringToArray(std::string_view str) {
+    std::array<u8, Size> out{};
+    if constexpr (le) {
+        for (size_t i = 2 * Size - 2; i <= 2 * Size; i -= 2)
+            out[i / 2] = (ToHexNibble(str[i]) << 4) | ToHexNibble(str[i + 1]);
+    } else {
+        for (size_t i = 0; i < 2 * Size; i += 2)
+            out[i / 2] = (ToHexNibble(str[i]) << 4) | ToHexNibble(str[i + 1]);
+    }
+    return out;
+}
+
+template <size_t Size>
+std::string HexArrayToString(std::array<u8, Size> array, bool upper = true) {
+    std::string out;
+    for (u8 c : array)
+        out += fmt::format(upper ? "{:02X}" : "{:02x}", c);
+    return out;
+}
+
+std::array<u8, 0x10> operator"" _array16(const char* str, size_t len);
+std::array<u8, 0x20> operator"" _array32(const char* str, size_t len);

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -20,6 +20,8 @@ add_library(core STATIC
     crypto/key_manager.h
     crypto/ctr_encryption_layer.cpp
     crypto/ctr_encryption_layer.h
+    file_sys/bis_factory.cpp
+    file_sys/bis_factory.h
     file_sys/card_image.cpp
     file_sys/card_image.h
     file_sys/content_archive.cpp
@@ -29,10 +31,14 @@ add_library(core STATIC
     file_sys/directory.h
     file_sys/errors.h
     file_sys/mode.h
+    file_sys/nca_metadata.cpp
+    file_sys/nca_metadata.h
     file_sys/partition_filesystem.cpp
     file_sys/partition_filesystem.h
     file_sys/program_metadata.cpp
     file_sys/program_metadata.h
+    file_sys/registered_cache.cpp
+    file_sys/registered_cache.h
     file_sys/romfs.cpp
     file_sys/romfs.h
     file_sys/romfs_factory.cpp
@@ -43,6 +49,8 @@ add_library(core STATIC
     file_sys/sdmc_factory.h
     file_sys/vfs.cpp
     file_sys/vfs.h
+    file_sys/vfs_concat.cpp
+    file_sys/vfs_concat.h
     file_sys/vfs_offset.cpp
     file_sys/vfs_offset.h
     file_sys/vfs_real.cpp

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <utility>
 #include "common/logging/log.h"
+#include "common/string_util.h"
 #include "core/core.h"
 #include "core/core_timing.h"
 #include "core/gdbstub/gdbstub.h"

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -10,43 +10,12 @@
 #include <string_view>
 #include "common/common_paths.h"
 #include "common/file_util.h"
+#include "common/hex_util.h"
+#include "common/logging/log.h"
 #include "core/crypto/key_manager.h"
 #include "core/settings.h"
 
 namespace Core::Crypto {
-
-static u8 ToHexNibble(char c1) {
-    if (c1 >= 65 && c1 <= 70)
-        return c1 - 55;
-    if (c1 >= 97 && c1 <= 102)
-        return c1 - 87;
-    if (c1 >= 48 && c1 <= 57)
-        return c1 - 48;
-    throw std::logic_error("Invalid hex digit");
-}
-
-template <size_t Size>
-static std::array<u8, Size> HexStringToArray(std::string_view str) {
-    std::array<u8, Size> out{};
-    for (size_t i = 0; i < 2 * Size; i += 2) {
-        auto d1 = str[i];
-        auto d2 = str[i + 1];
-        out[i / 2] = (ToHexNibble(d1) << 4) | ToHexNibble(d2);
-    }
-    return out;
-}
-
-std::array<u8, 16> operator""_array16(const char* str, size_t len) {
-    if (len != 32)
-        throw std::logic_error("Not of correct size.");
-    return HexStringToArray<16>(str);
-}
-
-std::array<u8, 32> operator""_array32(const char* str, size_t len) {
-    if (len != 64)
-        throw std::logic_error("Not of correct size.");
-    return HexStringToArray<32>(str);
-}
 
 KeyManager::KeyManager() {
     // Initialize keys

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -87,9 +87,6 @@ struct hash<Core::Crypto::KeyIndex<KeyType>> {
 
 namespace Core::Crypto {
 
-std::array<u8, 0x10> operator"" _array16(const char* str, size_t len);
-std::array<u8, 0x20> operator"" _array32(const char* str, size_t len);
-
 class KeyManager {
 public:
     KeyManager();

--- a/src/core/file_sys/bis_factory.cpp
+++ b/src/core/file_sys/bis_factory.cpp
@@ -6,12 +6,19 @@
 
 namespace FileSys {
 
+static VirtualDir GetOrCreateDirectory(const VirtualDir& dir, std::string_view path) {
+    const auto res = dir->GetDirectoryRelative(path);
+    if (res == nullptr)
+        return dir->CreateDirectoryRelative(path);
+    return res;
+}
+
 BISFactory::BISFactory(VirtualDir nand_root_)
     : nand_root(std::move(nand_root_)),
       sysnand_cache(std::make_shared<RegisteredCache>(
-          nand_root->GetDirectoryRelative("/system/Contents/registered"))),
+          GetOrCreateDirectory(nand_root, "/system/Contents/registered"))),
       usrnand_cache(std::make_shared<RegisteredCache>(
-          nand_root->GetDirectoryRelative("/user/Contents/registered"))) {}
+          GetOrCreateDirectory(nand_root, "/user/Contents/registered"))) {}
 
 std::shared_ptr<RegisteredCache> BISFactory::GetSystemNANDContents() const {
     return sysnand_cache;

--- a/src/core/file_sys/bis_factory.cpp
+++ b/src/core/file_sys/bis_factory.cpp
@@ -1,0 +1,24 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/file_sys/bis_factory.h"
+
+namespace FileSys {
+
+BISFactory::BISFactory(VirtualDir nand_root_)
+    : nand_root(std::move(nand_root_)),
+      sysnand_cache(std::make_shared<RegisteredCache>(
+          nand_root->GetDirectoryRelative("/system/Contents/registered"))),
+      usrnand_cache(std::make_shared<RegisteredCache>(
+          nand_root->GetDirectoryRelative("/user/Contents/registered"))) {}
+
+std::shared_ptr<RegisteredCache> BISFactory::GetSystemNANDContents() const {
+    return sysnand_cache;
+}
+
+std::shared_ptr<RegisteredCache> BISFactory::GetUserNANDContents() const {
+    return usrnand_cache;
+}
+
+} // namespace FileSys

--- a/src/core/file_sys/bis_factory.h
+++ b/src/core/file_sys/bis_factory.h
@@ -1,0 +1,30 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include "core/loader/loader.h"
+#include "registered_cache.h"
+
+namespace FileSys {
+
+/// File system interface to the Built-In Storage
+/// This is currently missing accessors to BIS partitions, but seemed like a good place for the NAND
+/// registered caches.
+class BISFactory {
+public:
+    explicit BISFactory(VirtualDir nand_root);
+
+    std::shared_ptr<RegisteredCache> GetSystemNANDContents() const;
+    std::shared_ptr<RegisteredCache> GetUserNANDContents() const;
+
+private:
+    VirtualDir nand_root;
+
+    std::shared_ptr<RegisteredCache> sysnand_cache;
+    std::shared_ptr<RegisteredCache> usrnand_cache;
+};
+
+} // namespace FileSys

--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -93,6 +93,10 @@ VirtualDir XCI::GetLogoPartition() const {
     return GetPartition(XCIPartition::Logo);
 }
 
+const std::vector<std::shared_ptr<NCA>>& XCI::GetNCAs() const {
+    return ncas;
+}
+
 std::shared_ptr<NCA> XCI::GetNCAByType(NCAContentType type) const {
     const auto iter =
         std::find_if(ncas.begin(), ncas.end(),

--- a/src/core/file_sys/card_image.h
+++ b/src/core/file_sys/card_image.h
@@ -68,6 +68,7 @@ public:
     VirtualDir GetUpdatePartition() const;
     VirtualDir GetLogoPartition() const;
 
+    const std::vector<std::shared_ptr<NCA>>& GetNCAs() const;
     std::shared_ptr<NCA> GetNCAByType(NCAContentType type) const;
     VirtualFile GetNCAFileByType(NCAContentType type) const;
 

--- a/src/core/file_sys/control_metadata.cpp
+++ b/src/core/file_sys/control_metadata.cpp
@@ -16,7 +16,7 @@ std::string LanguageEntry::GetDeveloperName() const {
     return Common::StringFromFixedZeroTerminatedBuffer(developer_name.data(), 0x100);
 }
 
-NACP::NACP(VirtualFile file_) : file(std::move(file_)), raw(std::make_unique<RawNACP>()) {
+NACP::NACP(VirtualFile file) : raw(std::make_unique<RawNACP>()) {
     file->ReadObject(raw.get());
 }
 

--- a/src/core/file_sys/control_metadata.h
+++ b/src/core/file_sys/control_metadata.h
@@ -81,7 +81,6 @@ public:
     std::string GetVersionString() const;
 
 private:
-    VirtualFile file;
     std::unique_ptr<RawNACP> raw;
 };
 

--- a/src/core/file_sys/nca_metadata.cpp
+++ b/src/core/file_sys/nca_metadata.cpp
@@ -10,7 +10,7 @@
 
 namespace FileSys {
 
-CNMT::CNMT(VirtualFile file_) : file(std::move(file_)), header(std::make_unique<CNMTHeader>()) {
+CNMT::CNMT(VirtualFile file) : header(std::make_unique<CNMTHeader>()) {
     if (file->ReadObject(header.get()) != sizeof(CNMTHeader))
         return;
 
@@ -41,7 +41,7 @@ CNMT::CNMT(VirtualFile file_) : file(std::move(file_)), header(std::make_unique<
 
 CNMT::CNMT(CNMTHeader header, OptionalHeader opt_header, std::vector<ContentRecord> content_records,
            std::vector<MetaRecord> meta_records)
-    : file(nullptr), header(std::make_unique<CNMTHeader>(std::move(header))),
+    : header(std::make_unique<CNMTHeader>(std::move(header))),
       opt_header(std::make_unique<OptionalHeader>(std::move(opt_header))),
       content_records(std::move(content_records)), meta_records(std::move(meta_records)) {}
 

--- a/src/core/file_sys/nca_metadata.cpp
+++ b/src/core/file_sys/nca_metadata.cpp
@@ -1,0 +1,125 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/common_funcs.h"
+#include "common/swap.h"
+#include "content_archive.h"
+#include "core/file_sys/nca_metadata.h"
+
+namespace FileSys {
+
+CNMT::CNMT(VirtualFile file_) : file(std::move(file_)), header(std::make_unique<CNMTHeader>()) {
+    if (file->ReadObject(header.get()) != sizeof(CNMTHeader))
+        return;
+
+    // If type is {Application, Update, AOC} has opt-header.
+    if (static_cast<u8>(header->type) >= 0x80 && static_cast<u8>(header->type) <= 0x82) {
+        opt_header = std::make_unique<OptionalHeader>();
+        if (file->ReadObject(opt_header.get(), sizeof(CNMTHeader)) != sizeof(OptionalHeader)) {
+            opt_header = nullptr;
+        }
+    }
+
+    for (u16 i = 0; i < header->number_content_entries; ++i) {
+        auto& next = content_records.emplace_back(ContentRecord{});
+        if (file->ReadObject(&next, sizeof(CNMTHeader) + i * sizeof(ContentRecord) +
+                                        header->table_offset) != sizeof(ContentRecord)) {
+            content_records.erase(content_records.end() - 1);
+        }
+    }
+
+    for (u16 i = 0; i < header->number_meta_entries; ++i) {
+        auto& next = meta_records.emplace_back(MetaRecord{});
+        if (file->ReadObject(&next, sizeof(CNMTHeader) + i * sizeof(MetaRecord) +
+                                        header->table_offset) != sizeof(MetaRecord)) {
+            meta_records.erase(meta_records.end() - 1);
+        }
+    }
+}
+
+CNMT::CNMT(CNMTHeader header, OptionalHeader opt_header, std::vector<ContentRecord> content_records,
+           std::vector<MetaRecord> meta_records)
+    : file(nullptr), header(std::make_unique<CNMTHeader>(std::move(header))),
+      opt_header(std::make_unique<OptionalHeader>(std::move(opt_header))),
+      content_records(std::move(content_records)), meta_records(std::move(meta_records)) {}
+
+u64 CNMT::GetTitleID() const {
+    return header->title_id;
+}
+
+u32 CNMT::GetTitleVersion() const {
+    return header->title_version;
+}
+
+TitleType CNMT::GetType() const {
+    return header->type;
+}
+
+const std::vector<ContentRecord>& CNMT::GetContentRecords() const {
+    return content_records;
+}
+
+const std::vector<MetaRecord>& CNMT::GetMetaRecords() const {
+    return meta_records;
+}
+
+bool CNMT::UnionRecords(const CNMT& other) {
+    bool change = false;
+    for (const auto& rec : other.content_records) {
+        const auto iter = std::find_if(
+            content_records.begin(), content_records.end(),
+            [rec](const ContentRecord& r) { return r.nca_id == rec.nca_id && r.type == rec.type; });
+        if (iter == content_records.end()) {
+            content_records.emplace_back(rec);
+            ++header->number_content_entries;
+            change = true;
+        }
+    }
+    for (const auto& rec : other.meta_records) {
+        const auto iter =
+            std::find_if(meta_records.begin(), meta_records.end(), [rec](const MetaRecord& r) {
+                return r.title_id == rec.title_id && r.title_version == rec.title_version &&
+                       r.type == rec.type;
+            });
+        if (iter == meta_records.end()) {
+            meta_records.emplace_back(rec);
+            ++header->number_meta_entries;
+            change = true;
+        }
+    }
+    return change;
+}
+
+std::vector<u8> CNMT::Serialize() const {
+    if (header == nullptr)
+        return {};
+    std::vector<u8> out(sizeof(CNMTHeader));
+    out.reserve(0x100); // Avoid resizing -- average size.
+    memcpy(out.data(), header.get(), sizeof(CNMTHeader));
+    if (opt_header != nullptr) {
+        out.resize(out.size() + sizeof(OptionalHeader));
+        memcpy(out.data() + sizeof(CNMTHeader), opt_header.get(), sizeof(OptionalHeader));
+    }
+
+    auto offset = header->table_offset;
+
+    const auto dead_zone = offset + sizeof(CNMTHeader) - out.size();
+    if (dead_zone > 0)
+        out.resize(offset + sizeof(CNMTHeader));
+
+    for (const auto& rec : content_records) {
+        out.resize(out.size() + sizeof(ContentRecord));
+        memcpy(out.data() + offset + sizeof(CNMTHeader), &rec, sizeof(ContentRecord));
+        offset += sizeof(ContentRecord);
+    }
+
+    for (const auto& rec : meta_records) {
+        out.resize(out.size() + sizeof(MetaRecord));
+        memcpy(out.data() + offset + sizeof(CNMTHeader), &rec, sizeof(MetaRecord));
+        offset += sizeof(MetaRecord);
+    }
+
+    return out;
+}
+} // namespace FileSys

--- a/src/core/file_sys/nca_metadata.cpp
+++ b/src/core/file_sys/nca_metadata.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cstring>
 #include "common/common_funcs.h"
 #include "common/swap.h"
 #include "content_archive.h"
@@ -67,9 +68,10 @@ const std::vector<MetaRecord>& CNMT::GetMetaRecords() const {
 bool CNMT::UnionRecords(const CNMT& other) {
     bool change = false;
     for (const auto& rec : other.content_records) {
-        const auto iter = std::find_if(
-            content_records.begin(), content_records.end(),
-            [rec](const ContentRecord& r) { return r.nca_id == rec.nca_id && r.type == rec.type; });
+        const auto iter = std::find_if(content_records.begin(), content_records.end(),
+                                       [&rec](const ContentRecord& r) {
+                                           return r.nca_id == rec.nca_id && r.type == rec.type;
+                                       });
         if (iter == content_records.end()) {
             content_records.emplace_back(rec);
             ++header->number_content_entries;
@@ -78,7 +80,7 @@ bool CNMT::UnionRecords(const CNMT& other) {
     }
     for (const auto& rec : other.meta_records) {
         const auto iter =
-            std::find_if(meta_records.begin(), meta_records.end(), [rec](const MetaRecord& r) {
+            std::find_if(meta_records.begin(), meta_records.end(), [&rec](const MetaRecord& r) {
                 return r.title_id == rec.title_id && r.title_version == rec.title_version &&
                        r.type == rec.type;
             });

--- a/src/core/file_sys/nca_metadata.h
+++ b/src/core/file_sys/nca_metadata.h
@@ -96,7 +96,6 @@ public:
     std::vector<u8> Serialize() const;
 
 private:
-    VirtualFile file;
     std::unique_ptr<CNMTHeader> header;
     std::unique_ptr<OptionalHeader> opt_header;
     std::vector<ContentRecord> content_records;

--- a/src/core/file_sys/nca_metadata.h
+++ b/src/core/file_sys/nca_metadata.h
@@ -4,7 +4,11 @@
 
 #pragma once
 
+#include <cstring>
 #include <memory>
+#include <vector>
+#include "common/common_types.h"
+#include "common/swap.h"
 #include "core/file_sys/vfs.h"
 
 namespace FileSys {

--- a/src/core/file_sys/nca_metadata.h
+++ b/src/core/file_sys/nca_metadata.h
@@ -1,0 +1,105 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include "core/file_sys/vfs.h"
+
+namespace FileSys {
+class CNMT;
+
+struct CNMTHeader;
+struct OptionalHeader;
+
+enum class TitleType : u8 {
+    SystemProgram = 0x01,
+    SystemDataArchive = 0x02,
+    SystemUpdate = 0x03,
+    FirmwarePackageA = 0x04,
+    FirmwarePackageB = 0x05,
+    Application = 0x80,
+    Update = 0x81,
+    AOC = 0x82,
+    DeltaTitle = 0x83,
+};
+
+enum class ContentRecordType : u8 {
+    Meta = 0,
+    Program = 1,
+    Data = 2,
+    Control = 3,
+    Manual = 4,
+    Legal = 5,
+    Patch = 6,
+};
+
+struct ContentRecord {
+    std::array<u8, 0x20> hash;
+    std::array<u8, 0x10> nca_id;
+    std::array<u8, 0x6> size;
+    ContentRecordType type;
+    INSERT_PADDING_BYTES(1);
+};
+static_assert(sizeof(ContentRecord) == 0x38, "ContentRecord has incorrect size.");
+
+constexpr ContentRecord EMPTY_META_CONTENT_RECORD{{}, {}, {}, ContentRecordType::Meta, {}};
+
+struct MetaRecord {
+    u64_le title_id;
+    u32_le title_version;
+    TitleType type;
+    u8 install_byte;
+    INSERT_PADDING_BYTES(2);
+};
+static_assert(sizeof(MetaRecord) == 0x10, "MetaRecord has incorrect size.");
+
+struct OptionalHeader {
+    u64_le title_id;
+    u64_le minimum_version;
+};
+static_assert(sizeof(OptionalHeader) == 0x10, "OptionalHeader has incorrect size.");
+
+struct CNMTHeader {
+    u64_le title_id;
+    u32_le title_version;
+    TitleType type;
+    INSERT_PADDING_BYTES(1);
+    u16_le table_offset;
+    u16_le number_content_entries;
+    u16_le number_meta_entries;
+    INSERT_PADDING_BYTES(12);
+};
+static_assert(sizeof(CNMTHeader) == 0x20, "CNMTHeader has incorrect size.");
+
+// A class representing the format used by NCA metadata files, typically named {}.cnmt.nca or
+// meta0.ncd. These describe which NCA's belong with which titles in the registered cache.
+class CNMT {
+public:
+    explicit CNMT(VirtualFile file);
+    CNMT(CNMTHeader header, OptionalHeader opt_header, std::vector<ContentRecord> content_records,
+         std::vector<MetaRecord> meta_records);
+
+    u64 GetTitleID() const;
+    u32 GetTitleVersion() const;
+    TitleType GetType() const;
+
+    const std::vector<ContentRecord>& GetContentRecords() const;
+    const std::vector<MetaRecord>& GetMetaRecords() const;
+
+    bool UnionRecords(const CNMT& other);
+    std::vector<u8> Serialize() const;
+
+private:
+    VirtualFile file;
+    std::unique_ptr<CNMTHeader> header;
+    std::unique_ptr<OptionalHeader> opt_header;
+    std::vector<ContentRecord> content_records;
+    std::vector<MetaRecord> meta_records;
+
+    // TODO(DarkLordZach): According to switchbrew, for Patch-type there is additional data
+    // after the table. This is not documented, unfortunately.
+};
+
+} // namespace FileSys

--- a/src/core/file_sys/nca_metadata.h
+++ b/src/core/file_sys/nca_metadata.h
@@ -29,6 +29,9 @@ enum class TitleType : u8 {
     DeltaTitle = 0x83,
 };
 
+bool operator>=(TitleType lhs, TitleType rhs);
+bool operator<=(TitleType lhs, TitleType rhs);
+
 enum class ContentRecordType : u8 {
     Meta = 0,
     Program = 1,
@@ -96,8 +99,8 @@ public:
     std::vector<u8> Serialize() const;
 
 private:
-    std::unique_ptr<CNMTHeader> header;
-    std::unique_ptr<OptionalHeader> opt_header;
+    CNMTHeader header;
+    OptionalHeader opt_header;
     std::vector<ContentRecord> content_records;
     std::vector<MetaRecord> meta_records;
 

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -1,0 +1,435 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <regex>
+#include <mbedtls/sha256.h>
+#include "common/assert.h"
+#include "common/hex_util.h"
+#include "common/logging/log.h"
+#include "core/crypto/encryption_layer.h"
+#include "core/file_sys/card_image.h"
+#include "core/file_sys/nca_metadata.h"
+#include "core/file_sys/registered_cache.h"
+#include "core/file_sys/vfs_concat.h"
+
+namespace FileSys {
+std::string RegisteredCacheEntry::DebugInfo() const {
+    return fmt::format("title_id={:016X}, content_type={:02X}", title_id, static_cast<u8>(type));
+}
+
+bool operator<(const RegisteredCacheEntry& lhs, const RegisteredCacheEntry& rhs) {
+    return (lhs.title_id < rhs.title_id) || (lhs.title_id == rhs.title_id && lhs.type < rhs.type);
+}
+
+static bool FollowsTwoDigitDirFormat(std::string_view name) {
+    const static std::regex two_digit_regex(
+        "000000[0123456789abcdefABCDEF][0123456789abcdefABCDEF]");
+    return std::regex_match(name.begin(), name.end(), two_digit_regex);
+}
+
+static bool FollowsNcaIdFormat(std::string_view name) {
+    const static std::regex nca_id_regex("[0123456789abcdefABCDEF]+.nca");
+    return name.size() == 36 && std::regex_match(name.begin(), name.end(), nca_id_regex);
+}
+
+static std::string GetRelativePathFromNcaID(const std::array<u8, 16>& nca_id, bool second_hex_upper,
+                                            bool within_two_digit) {
+    if (!within_two_digit)
+        return fmt::format("/{}.nca", HexArrayToString(nca_id, second_hex_upper));
+
+    Core::Crypto::SHA256Hash hash{};
+    mbedtls_sha256(nca_id.data(), nca_id.size(), hash.data(), 0);
+    return fmt::format("/000000{:02X}/{}.nca", hash[0], HexArrayToString(nca_id, second_hex_upper));
+}
+
+static std::string GetCNMTName(TitleType type, u64 title_id) {
+    constexpr std::array<const char*, 9> TITLE_TYPE_NAMES{
+        "SystemProgram",
+        "SystemData",
+        "SystemUpdate",
+        "BootImagePackage",
+        "BootImagePackageSafe",
+        "Application",
+        "Patch",
+        "AddOnContent",
+        "" ///< Currently unknown 'DeltaTitle'
+    };
+
+    size_t index = static_cast<size_t>(type);
+    if (index >= 0x80)
+        index -= 0x80;
+    return fmt::format("{}_{:016x}.cnmt", TITLE_TYPE_NAMES[index], title_id);
+}
+
+static ContentRecordType GetCRTypeFromNCAType(NCAContentType type) {
+    switch (type) {
+    case NCAContentType::Program:
+        // TODO(DarkLordZach): Differentiate between Program and Patch
+        return ContentRecordType::Program;
+    case NCAContentType::Meta:
+        return ContentRecordType::Meta;
+    case NCAContentType::Control:
+        return ContentRecordType::Control;
+    case NCAContentType::Data:
+        return ContentRecordType::Data;
+    case NCAContentType::Manual:
+        // TODO(DarkLordZach): Peek at NCA contents to differentiate Manual and Legal.
+        return ContentRecordType::Manual;
+    default:
+        UNREACHABLE();
+    }
+}
+
+VirtualFile RegisteredCache::OpenFileOrDirectoryConcat(const VirtualDir& dir,
+                                                       std::string_view path) const {
+    if (dir->GetFileRelative(path) != nullptr)
+        return dir->GetFileRelative(path);
+    if (dir->GetDirectoryRelative(path) != nullptr) {
+        const auto nca_dir = dir->GetDirectoryRelative(path);
+        VirtualFile file = nullptr;
+
+        const auto files = nca_dir->GetFiles();
+        if (files.size() == 1 && files[0]->GetName() == "00")
+            file = files[0];
+        else {
+            std::vector<VirtualFile> concat;
+            for (u8 i = 0; i < 0x10; ++i) {
+                auto next = nca_dir->GetFile(fmt::format("{:02X}", i));
+                if (next != nullptr)
+                    concat.push_back(std::move(next));
+                else {
+                    next = nca_dir->GetFile(fmt::format("{:02x}", i));
+                    if (next != nullptr)
+                        concat.push_back(std::move(next));
+                    else
+                        break;
+                }
+            }
+
+            if (concat.empty())
+                return nullptr;
+
+            file = FileSys::ConcatenateFiles(concat);
+        }
+
+        return file;
+    }
+    return nullptr;
+}
+
+VirtualFile RegisteredCache::GetFileAtID(NcaID id) const {
+    VirtualFile file;
+    for (u8 i = 0; i < 4; ++i) {
+        file = OpenFileOrDirectoryConcat(
+            dir, GetRelativePathFromNcaID(id, (i & 0b10) == 0, (i & 0b01) == 0));
+        if (file != nullptr)
+            return file;
+    }
+    return file;
+}
+
+boost::optional<NcaID> RegisteredCache::GetNcaIDFromMetadata(u64 title_id,
+                                                             ContentRecordType type) const {
+    if (type == ContentRecordType::Meta && meta_id.find(title_id) != meta_id.end())
+        return meta_id.at(title_id);
+    if (meta.find(title_id) == meta.end())
+        return boost::none;
+
+    const auto& cnmt = meta.at(title_id);
+
+    const auto iter = std::find_if(cnmt.GetContentRecords().begin(), cnmt.GetContentRecords().end(),
+                                   [type](const ContentRecord& rec) { return rec.type == type; });
+    if (iter == cnmt.GetContentRecords().end())
+        return boost::none;
+
+    return boost::make_optional(iter->nca_id);
+}
+
+void RegisteredCache::AccumulateFiles(std::vector<NcaID>& ids) const {
+    for (const auto& d2_dir : dir->GetSubdirectories()) {
+        if (FollowsNcaIdFormat(d2_dir->GetName())) {
+            ids.push_back(HexStringToArray<0x10, true>(d2_dir->GetName().substr(0, 0x20)));
+            continue;
+        }
+
+        if (!FollowsTwoDigitDirFormat(d2_dir->GetName()))
+            continue;
+
+        for (const auto& nca_dir : d2_dir->GetSubdirectories()) {
+            if (!FollowsNcaIdFormat(nca_dir->GetName()))
+                continue;
+
+            ids.push_back(HexStringToArray<0x10, true>(nca_dir->GetName().substr(0, 0x20)));
+        }
+
+        for (const auto& nca_file : d2_dir->GetFiles()) {
+            if (!FollowsNcaIdFormat(nca_file->GetName()))
+                continue;
+
+            ids.push_back(HexStringToArray<0x10, true>(nca_file->GetName().substr(0, 0x20)));
+        }
+    }
+
+    for (const auto& d2_file : dir->GetFiles()) {
+        if (FollowsNcaIdFormat(d2_file->GetName()))
+            ids.push_back(HexStringToArray<0x10, true>(d2_file->GetName().substr(0, 0x20)));
+    }
+}
+
+void RegisteredCache::ProcessFiles(const std::vector<NcaID>& ids) {
+    for (const auto& id : ids) {
+        const auto file = GetFileAtID(id);
+
+        if (file == nullptr)
+            continue;
+        const auto nca = std::make_shared<NCA>(parser(file, id));
+        if (nca->GetStatus() != Loader::ResultStatus::Success ||
+            nca->GetType() != NCAContentType::Meta)
+            continue;
+
+        const auto section0 = nca->GetSubdirectories()[0];
+
+        for (const auto& file : section0->GetFiles()) {
+            if (file->GetExtension() != "cnmt")
+                continue;
+
+            meta.insert_or_assign(nca->GetTitleId(), CNMT(file));
+            meta_id.insert_or_assign(nca->GetTitleId(), id);
+            break;
+        }
+    }
+}
+
+void RegisteredCache::AccumulateYuzuMeta() {
+    const auto dir = this->dir->GetSubdirectory("yuzu_meta");
+    if (dir == nullptr)
+        return;
+
+    for (const auto& file : dir->GetFiles()) {
+        if (file->GetExtension() != "cnmt")
+            continue;
+
+        CNMT cnmt(file);
+        yuzu_meta.insert_or_assign(cnmt.GetTitleID(), std::move(cnmt));
+    }
+}
+
+void RegisteredCache::Refresh() {
+    if (dir == nullptr)
+        return;
+    std::vector<NcaID> ids;
+    AccumulateFiles(ids);
+    ProcessFiles(ids);
+    AccumulateYuzuMeta();
+}
+
+RegisteredCache::RegisteredCache(VirtualDir dir_, RegisteredCacheParsingFunction parsing_function)
+    : dir(std::move(dir_)), parser(std::move(parsing_function)) {
+    Refresh();
+}
+
+bool RegisteredCache::HasEntry(u64 title_id, ContentRecordType type) const {
+    return GetEntryRaw(title_id, type) != nullptr;
+}
+
+bool RegisteredCache::HasEntry(RegisteredCacheEntry entry) const {
+    return GetEntryRaw(entry) != nullptr;
+}
+
+VirtualFile RegisteredCache::GetEntryRaw(u64 title_id, ContentRecordType type) const {
+    const auto id = GetNcaIDFromMetadata(title_id, type);
+    if (id == boost::none)
+        return nullptr;
+
+    return parser(GetFileAtID(id.get()), id.get());
+}
+
+VirtualFile RegisteredCache::GetEntryRaw(RegisteredCacheEntry entry) const {
+    return GetEntryRaw(entry.title_id, entry.type);
+}
+
+std::shared_ptr<NCA> RegisteredCache::GetEntry(u64 title_id, ContentRecordType type) const {
+    const auto raw = GetEntryRaw(title_id, type);
+    if (raw == nullptr)
+        return nullptr;
+    return std::make_shared<NCA>(raw);
+}
+
+std::shared_ptr<NCA> RegisteredCache::GetEntry(RegisteredCacheEntry entry) const {
+    return GetEntry(entry.title_id, entry.type);
+}
+
+template <typename T>
+void RegisteredCache::IterateAllMetadata(
+    std::vector<T>& out, std::function<T(const CNMT&, const ContentRecord&)> proc,
+    std::function<bool(const CNMT&, const ContentRecord&)> filter) const {
+    for (const auto& kv : meta) {
+        const auto& cnmt = kv.second;
+        if (filter(cnmt, EMPTY_META_CONTENT_RECORD))
+            out.push_back(proc(cnmt, EMPTY_META_CONTENT_RECORD));
+        for (const auto& rec : cnmt.GetContentRecords()) {
+            if (GetFileAtID(rec.nca_id) != nullptr && filter(cnmt, rec)) {
+                out.push_back(proc(cnmt, rec));
+            }
+        }
+    }
+    for (const auto& kv : yuzu_meta) {
+        const auto& cnmt = kv.second;
+        for (const auto& rec : cnmt.GetContentRecords()) {
+            if (GetFileAtID(rec.nca_id) != nullptr && filter(cnmt, rec)) {
+                out.push_back(proc(cnmt, rec));
+            }
+        }
+    }
+}
+
+std::vector<RegisteredCacheEntry> RegisteredCache::ListEntries() const {
+    std::vector<RegisteredCacheEntry> out;
+    IterateAllMetadata<RegisteredCacheEntry>(
+        out,
+        [](const CNMT& c, const ContentRecord& r) {
+            return RegisteredCacheEntry{c.GetTitleID(), r.type};
+        },
+        [](const CNMT& c, const ContentRecord& r) { return true; });
+    return out;
+}
+
+std::vector<RegisteredCacheEntry> RegisteredCache::ListEntriesFilter(
+    boost::optional<TitleType> title_type, boost::optional<ContentRecordType> record_type,
+    boost::optional<u64> title_id) const {
+    std::vector<RegisteredCacheEntry> out;
+    IterateAllMetadata<RegisteredCacheEntry>(
+        out,
+        [](const CNMT& c, const ContentRecord& r) {
+            return RegisteredCacheEntry{c.GetTitleID(), r.type};
+        },
+        [&title_type, &record_type, &title_id](const CNMT& c, const ContentRecord& r) {
+            if (title_type != boost::none && title_type.get() != c.GetType())
+                return false;
+            if (record_type != boost::none && record_type.get() != r.type)
+                return false;
+            if (title_id != boost::none && title_id.get() != c.GetTitleID())
+                return false;
+            return true;
+        });
+    return out;
+}
+
+static std::shared_ptr<NCA> GetNCAFromXCIForID(std::shared_ptr<XCI> xci, const NcaID& id) {
+    const auto filename = fmt::format("{}.nca", HexArrayToString(id, false));
+    const auto iter =
+        std::find_if(xci->GetNCAs().begin(), xci->GetNCAs().end(),
+                     [&filename](std::shared_ptr<NCA> nca) { return nca->GetName() == filename; });
+    return iter == xci->GetNCAs().end() ? nullptr : *iter;
+}
+
+bool RegisteredCache::InstallEntry(std::shared_ptr<XCI> xci) {
+    const auto& ncas = xci->GetNCAs();
+    const auto& meta_iter = std::find_if(ncas.begin(), ncas.end(), [](std::shared_ptr<NCA> nca) {
+        return nca->GetType() == NCAContentType::Meta;
+    });
+
+    if (meta_iter == ncas.end()) {
+        LOG_ERROR(Loader, "The XCI you are attempting to install does not have a metadata NCA and "
+                          "is therefore malformed. Double check your encryption keys.");
+        return false;
+    }
+
+    // Install Metadata File
+    const auto meta_id_raw = (*meta_iter)->GetName().substr(0, 32);
+    const auto meta_id = HexStringToArray<16>(meta_id_raw);
+    if (!RawInstallNCA(*meta_iter, meta_id))
+        return false;
+
+    // Install all the other NCAs
+    const auto section0 = (*meta_iter)->GetSubdirectories()[0];
+    const auto cnmt_file = section0->GetFiles()[0];
+    const CNMT cnmt(cnmt_file);
+    for (const auto& record : cnmt.GetContentRecords()) {
+        const auto nca = GetNCAFromXCIForID(xci, record.nca_id);
+        if (nca == nullptr || !RawInstallNCA(nca, record.nca_id))
+            return false;
+    }
+
+    Refresh();
+    return true;
+}
+
+bool RegisteredCache::InstallEntry(std::shared_ptr<NCA> nca, TitleType type) {
+    CNMTHeader header{
+        nca->GetTitleId(), ///< Title ID
+        0,                 ///< Ignore/Default title version
+        type,              ///< Type
+        {},                ///< Padding
+        0x10,              ///< Default table offset
+        1,                 ///< 1 Content Entry
+        0,                 ///< No Meta Entries
+        {},                ///< Padding
+    };
+    OptionalHeader opt_header{0, 0};
+    ContentRecord c_rec{{}, {}, {}, GetCRTypeFromNCAType(nca->GetType()), {}};
+    const auto& data = nca->GetBaseFile()->ReadBytes(0x100000);
+    mbedtls_sha256(data.data(), data.size(), c_rec.hash.data(), 0);
+    memcpy(&c_rec.nca_id, &c_rec.hash, 16);
+    const CNMT new_cnmt(header, opt_header, {c_rec}, {});
+    return RawInstallYuzuMeta(new_cnmt) && RawInstallNCA(nca, c_rec.nca_id);
+}
+
+bool RegisteredCache::RawInstallNCA(std::shared_ptr<NCA> nca, boost::optional<NcaID> override_id) {
+    const auto in = nca->GetBaseFile();
+    Core::Crypto::SHA256Hash hash{};
+
+    // Calculate NcaID
+    // NOTE: Because computing the SHA256 of an entire NCA is quite expensive (especially if the
+    // game is massive), we're going to cheat and only hash the first MB of the NCA.
+    // Also, for XCIs the NcaID matters, so if the override id isn't none, use that.
+    NcaID id{};
+    if (override_id == boost::none) {
+        const auto& data = in->ReadBytes(0x100000);
+        mbedtls_sha256(data.data(), data.size(), hash.data(), 0);
+        memcpy(id.data(), hash.data(), 16);
+    } else {
+        id = override_id.get();
+    }
+
+    std::string path = GetRelativePathFromNcaID(id, false, true);
+
+    if (GetFileAtID(id) != nullptr) {
+        LOG_WARNING(Loader, "OW Attempt");
+        return false;
+    }
+
+    auto out = dir->CreateFileRelative(path);
+    if (out == nullptr)
+        return false;
+    return VfsRawCopy(in, out);
+}
+
+bool RegisteredCache::RawInstallYuzuMeta(const CNMT& cnmt) {
+    const auto dir = this->dir->CreateDirectoryRelative("yuzu_meta");
+    const auto filename = GetCNMTName(cnmt.GetType(), cnmt.GetTitleID());
+    if (dir->GetFile(filename) == nullptr) {
+        auto out = dir->CreateFile(filename);
+        const auto buffer = cnmt.Serialize();
+        out->Resize(buffer.size());
+        out->WriteBytes(buffer);
+    } else {
+        auto out = dir->GetFile(filename);
+        CNMT old_cnmt(out);
+        // Returns true on change
+        if (old_cnmt.UnionRecords(cnmt)) {
+            out->Resize(0);
+            const auto buffer = old_cnmt.Serialize();
+            out->Resize(buffer.size());
+            out->WriteBytes(buffer);
+        }
+    }
+    Refresh();
+    return std::find_if(yuzu_meta.begin(), yuzu_meta.end(),
+                        [&cnmt](const std::pair<const u64, CNMT>& kv) {
+                            return kv.second.GetType() == cnmt.GetType() &&
+                                   kv.second.GetTitleID() == cnmt.GetTitleID();
+                        }) != yuzu_meta.end();
+}
+} // namespace FileSys

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -427,7 +427,7 @@ bool RegisteredCache::RawInstallYuzuMeta(const CNMT& cnmt) {
     }
     Refresh();
     return std::find_if(yuzu_meta.begin(), yuzu_meta.end(),
-                        [&cnmt](const std::pair<const u64, CNMT>& kv) {
+                        [&cnmt](const std::pair<u64, CNMT>& kv) {
                             return kv.second.GetType() == cnmt.GetType() &&
                                    kv.second.GetTitleID() == cnmt.GetTitleID();
                         }) != yuzu_meta.end();

--- a/src/core/file_sys/registered_cache.h
+++ b/src/core/file_sys/registered_cache.h
@@ -23,6 +23,7 @@ class CNMT;
 
 using NcaID = std::array<u8, 0x10>;
 using RegisteredCacheParsingFunction = std::function<VirtualFile(const VirtualFile&, const NcaID&)>;
+using VfsCopyFunction = std::function<bool(VirtualFile, VirtualFile)>;
 
 struct RegisteredCacheEntry {
     u64 title_id;
@@ -76,13 +77,14 @@ public:
 
     // Raw copies all the ncas from the xci to the csache. Does some quick checks to make sure there
     // is a meta NCA and all of them are accessible.
-    bool InstallEntry(std::shared_ptr<XCI> xci);
+    bool InstallEntry(std::shared_ptr<XCI> xci, const VfsCopyFunction& copy = &VfsRawCopy);
 
     // Due to the fact that we must use Meta-type NCAs to determine the existance of files, this
     // poses quite a challenge. Instead of creating a new meta NCA for this file, yuzu will create a
     // dir inside the NAND called 'yuzu_meta' and store the raw CNMT there.
     // TODO(DarkLordZach): Author real meta-type NCAs and install those.
-    bool InstallEntry(std::shared_ptr<NCA> nca, TitleType type);
+    bool InstallEntry(std::shared_ptr<NCA> nca, TitleType type,
+                      const VfsCopyFunction& copy = &VfsRawCopy);
 
 private:
     template <typename T>
@@ -95,7 +97,8 @@ private:
     boost::optional<NcaID> GetNcaIDFromMetadata(u64 title_id, ContentRecordType type) const;
     VirtualFile GetFileAtID(NcaID id) const;
     VirtualFile OpenFileOrDirectoryConcat(const VirtualDir& dir, std::string_view path) const;
-    bool RawInstallNCA(std::shared_ptr<NCA> nca, boost::optional<NcaID> override_id = boost::none);
+    bool RawInstallNCA(std::shared_ptr<NCA> nca, const VfsCopyFunction& copy,
+                       boost::optional<NcaID> override_id = boost::none);
     bool RawInstallYuzuMeta(const CNMT& cnmt);
 
     VirtualDir dir;

--- a/src/core/file_sys/registered_cache.h
+++ b/src/core/file_sys/registered_cache.h
@@ -1,0 +1,108 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+#include <map>
+#include <memory>
+#include <string>
+#include <boost/container/flat_map.hpp>
+#include "common/common_funcs.h"
+#include "content_archive.h"
+#include "core/file_sys/vfs.h"
+#include "nca_metadata.h"
+
+namespace FileSys {
+class XCI;
+class CNMT;
+
+using NcaID = std::array<u8, 0x10>;
+using RegisteredCacheParsingFunction = std::function<VirtualFile(const VirtualFile&, const NcaID&)>;
+
+struct RegisteredCacheEntry {
+    u64 title_id;
+    ContentRecordType type;
+
+    std::string DebugInfo() const;
+};
+
+// boost flat_map requires operator< for O(log(n)) lookups.
+bool operator<(const RegisteredCacheEntry& lhs, const RegisteredCacheEntry& rhs);
+
+/*
+ * A class that catalogues NCAs in the registered directory structure.
+ * Nintendo's registered format follows this structure:
+ *
+ * Root
+ *   | 000000XX <- XX is the ____ two digits of the NcaID
+ *       | <hash>.nca <- hash is the NcaID (first half of SHA256 over entire file) (folder)
+ *         | 00
+ *         | 01 <- Actual content split along 4GB boundaries. (optional)
+ *
+ * (This impl also supports substituting the nca dir for an nca file, as that's more convenient when
+ * 4GB splitting can be ignored.)
+ */
+class RegisteredCache {
+public:
+    // Parsing function defines the conversion from raw file to NCA. If there are other steps
+    // besides creating the NCA from the file (e.g. NAX0 on SD Card), that should go in a custom
+    // parsing function.
+    RegisteredCache(VirtualDir dir,
+                    RegisteredCacheParsingFunction parsing_function =
+                        [](const VirtualFile& file, const NcaID& id) { return file; });
+
+    void Refresh();
+
+    bool HasEntry(u64 title_id, ContentRecordType type) const;
+    bool HasEntry(RegisteredCacheEntry entry) const;
+
+    VirtualFile GetEntryRaw(u64 title_id, ContentRecordType type) const;
+    VirtualFile GetEntryRaw(RegisteredCacheEntry entry) const;
+
+    std::shared_ptr<NCA> GetEntry(u64 title_id, ContentRecordType type) const;
+    std::shared_ptr<NCA> GetEntry(RegisteredCacheEntry entry) const;
+
+    std::vector<RegisteredCacheEntry> ListEntries() const;
+    // If a parameter is not boost::none, it will be filtered for from all entries.
+    std::vector<RegisteredCacheEntry> ListEntriesFilter(
+        boost::optional<TitleType> title_type = boost::none,
+        boost::optional<ContentRecordType> record_type = boost::none,
+        boost::optional<u64> title_id = boost::none) const;
+
+    // Raw copies all the ncas from the xci to the csache. Does some quick checks to make sure there
+    // is a meta NCA and all of them are accessible.
+    bool InstallEntry(std::shared_ptr<XCI> xci);
+
+    // Due to the fact that we must use Meta-type NCAs to determine the existance of files, this
+    // poses quite a challenge. Instead of creating a new meta NCA for this file, yuzu will create a
+    // dir inside the NAND called 'yuzu_meta' and store the raw CNMT there.
+    // TODO(DarkLordZach): Author real meta-type NCAs and install those.
+    bool InstallEntry(std::shared_ptr<NCA> nca, TitleType type);
+
+private:
+    template <typename T>
+    void IterateAllMetadata(std::vector<T>& out,
+                            std::function<T(const CNMT&, const ContentRecord&)> proc,
+                            std::function<bool(const CNMT&, const ContentRecord&)> filter) const;
+    void AccumulateFiles(std::vector<NcaID>& ids) const;
+    void ProcessFiles(const std::vector<NcaID>& ids);
+    void AccumulateYuzuMeta();
+    boost::optional<NcaID> GetNcaIDFromMetadata(u64 title_id, ContentRecordType type) const;
+    VirtualFile GetFileAtID(NcaID id) const;
+    VirtualFile OpenFileOrDirectoryConcat(const VirtualDir& dir, std::string_view path) const;
+    bool RawInstallNCA(std::shared_ptr<NCA> nca, boost::optional<NcaID> override_id = boost::none);
+    bool RawInstallYuzuMeta(const CNMT& cnmt);
+
+    VirtualDir dir;
+    RegisteredCacheParsingFunction parser;
+    // maps tid -> NcaID of meta
+    boost::container::flat_map<u64, NcaID> meta_id;
+    // maps tid -> meta
+    boost::container::flat_map<u64, CNMT> meta;
+    // maps tid -> meta for CNMT in yuzu_meta
+    boost::container::flat_map<u64, CNMT> yuzu_meta;
+};
+
+} // namespace FileSys

--- a/src/core/file_sys/registered_cache.h
+++ b/src/core/file_sys/registered_cache.h
@@ -5,14 +5,17 @@
 #pragma once
 
 #include <array>
+#include <functional>
 #include <map>
 #include <memory>
 #include <string>
+#include <vector>
 #include <boost/container/flat_map.hpp>
 #include "common/common_funcs.h"
+#include "common/common_types.h"
 #include "content_archive.h"
+#include "core/file_sys/nca_metadata.h"
 #include "core/file_sys/vfs.h"
-#include "nca_metadata.h"
 
 namespace FileSys {
 class XCI;
@@ -49,9 +52,9 @@ public:
     // Parsing function defines the conversion from raw file to NCA. If there are other steps
     // besides creating the NCA from the file (e.g. NAX0 on SD Card), that should go in a custom
     // parsing function.
-    RegisteredCache(VirtualDir dir,
-                    RegisteredCacheParsingFunction parsing_function =
-                        [](const VirtualFile& file, const NcaID& id) { return file; });
+    explicit RegisteredCache(VirtualDir dir,
+                             RegisteredCacheParsingFunction parsing_function =
+                                 [](const VirtualFile& file, const NcaID& id) { return file; });
 
     void Refresh();
 
@@ -86,7 +89,7 @@ private:
     void IterateAllMetadata(std::vector<T>& out,
                             std::function<T(const CNMT&, const ContentRecord&)> proc,
                             std::function<bool(const CNMT&, const ContentRecord&)> filter) const;
-    void AccumulateFiles(std::vector<NcaID>& ids) const;
+    std::vector<NcaID> AccumulateFiles() const;
     void ProcessFiles(const std::vector<NcaID>& ids);
     void AccumulateYuzuMeta();
     boost::optional<NcaID> GetNcaIDFromMetadata(u64 title_id, ContentRecordType type) const;

--- a/src/core/file_sys/romfs.cpp
+++ b/src/core/file_sys/romfs.cpp
@@ -65,7 +65,7 @@ void ProcessFile(VirtualFile file, size_t file_offset, size_t data_offset, u32 t
         auto entry = GetEntry<FileEntry>(file, file_offset + this_file_offset);
 
         parent->AddFile(std::make_shared<OffsetVfsFile>(
-            file, entry.first.size, entry.first.offset + data_offset, entry.second, parent));
+            file, entry.first.size, entry.first.offset + data_offset, entry.second));
 
         if (entry.first.sibling == ROMFS_ENTRY_EMPTY)
             break;
@@ -79,7 +79,7 @@ void ProcessDirectory(VirtualFile file, size_t dir_offset, size_t file_offset, s
     while (true) {
         auto entry = GetEntry<DirectoryEntry>(file, dir_offset + this_dir_offset);
         auto current = std::make_shared<VectorVfsDirectory>(
-            std::vector<VirtualFile>{}, std::vector<VirtualDir>{}, parent, entry.second);
+            std::vector<VirtualFile>{}, std::vector<VirtualDir>{}, entry.second);
 
         if (entry.first.child_file != ROMFS_ENTRY_EMPTY) {
             ProcessFile(file, file_offset, data_offset, entry.first.child_file, current);
@@ -108,9 +108,9 @@ VirtualDir ExtractRomFS(VirtualFile file) {
     const u64 file_offset = header.file_meta.offset;
     const u64 dir_offset = header.directory_meta.offset + 4;
 
-    const auto root =
+    auto root =
         std::make_shared<VectorVfsDirectory>(std::vector<VirtualFile>{}, std::vector<VirtualDir>{},
-                                             file->GetContainingDirectory(), file->GetName());
+                                             file->GetName(), file->GetContainingDirectory());
 
     ProcessDirectory(file, dir_offset, file_offset, header.data_offset, 0, root);
 

--- a/src/core/file_sys/vfs_concat.cpp
+++ b/src/core/file_sys/vfs_concat.cpp
@@ -68,6 +68,7 @@ size_t ConcatenatedVfsFile::Read(u8* data, size_t length, size_t offset) const {
         }
     }
 
+    // Check if the entry should be the last one. The loop above will make it end().
     if (entry == files.end() && offset < files.rbegin()->first + files.rbegin()->second->GetSize())
         --entry;
 

--- a/src/core/file_sys/vfs_concat.cpp
+++ b/src/core/file_sys/vfs_concat.cpp
@@ -9,17 +9,17 @@
 
 namespace FileSys {
 
-VirtualFile ConcatenateFiles(std::vector<VirtualFile> files, std::string_view name) {
+VirtualFile ConcatenateFiles(std::vector<VirtualFile> files, std::string name) {
     if (files.empty())
         return nullptr;
     if (files.size() == 1)
         return files[0];
 
-    return std::shared_ptr<VfsFile>(new ConcatenatedVfsFile(std::move(files), name));
+    return std::shared_ptr<VfsFile>(new ConcatenatedVfsFile(std::move(files), std::move(name)));
 }
 
-ConcatenatedVfsFile::ConcatenatedVfsFile(std::vector<VirtualFile> files_, std::string_view name)
-    : name(name) {
+ConcatenatedVfsFile::ConcatenatedVfsFile(std::vector<VirtualFile> files_, std::string name)
+    : name(std::move(name)) {
     size_t next_offset = 0;
     for (const auto& file : files_) {
         files[next_offset] = file;

--- a/src/core/file_sys/vfs_concat.cpp
+++ b/src/core/file_sys/vfs_concat.cpp
@@ -1,0 +1,93 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <utility>
+
+#include "core/file_sys/vfs_concat.h"
+
+namespace FileSys {
+
+VirtualFile ConcatenateFiles(std::vector<VirtualFile> files, std::string_view name) {
+    if (files.empty())
+        return nullptr;
+    if (files.size() == 1)
+        return files[0];
+
+    return std::shared_ptr<VfsFile>(new ConcatenatedVfsFile(std::move(files), name));
+}
+
+ConcatenatedVfsFile::ConcatenatedVfsFile(std::vector<VirtualFile> files_, std::string_view name)
+    : name(name) {
+    size_t next_offset = 0;
+    for (const auto& file : files_) {
+        files[next_offset] = file;
+        next_offset += file->GetSize();
+    }
+}
+
+std::string ConcatenatedVfsFile::GetName() const {
+    if (files.empty())
+        return "";
+    if (!name.empty())
+        return name;
+    return files.begin()->second->GetName();
+}
+
+size_t ConcatenatedVfsFile::GetSize() const {
+    if (files.empty())
+        return 0;
+    return files.rbegin()->first + files.rbegin()->second->GetSize();
+}
+
+bool ConcatenatedVfsFile::Resize(size_t new_size) {
+    return false;
+}
+
+std::shared_ptr<VfsDirectory> ConcatenatedVfsFile::GetContainingDirectory() const {
+    if (files.empty())
+        return nullptr;
+    return files.begin()->second->GetContainingDirectory();
+}
+
+bool ConcatenatedVfsFile::IsWritable() const {
+    return false;
+}
+
+bool ConcatenatedVfsFile::IsReadable() const {
+    return true;
+}
+
+size_t ConcatenatedVfsFile::Read(u8* data, size_t length, size_t offset) const {
+    auto entry = files.end();
+    for (auto iter = files.begin(); iter != files.end(); ++iter) {
+        if (iter->first > offset) {
+            entry = --iter;
+            break;
+        }
+    }
+
+    if (entry == files.end() && offset < files.rbegin()->first + files.rbegin()->second->GetSize())
+        --entry;
+
+    if (entry == files.end())
+        return 0;
+
+    const auto remaining = entry->second->GetSize() + offset - entry->first;
+    if (length > remaining) {
+        return entry->second->Read(data, remaining, offset - entry->first) +
+               Read(data + remaining, length - remaining, offset + remaining);
+    }
+
+    return entry->second->Read(data, length, offset - entry->first);
+}
+
+size_t ConcatenatedVfsFile::Write(const u8* data, size_t length, size_t offset) {
+    return 0;
+}
+
+bool ConcatenatedVfsFile::Rename(std::string_view name) {
+    return false;
+}
+} // namespace FileSys

--- a/src/core/file_sys/vfs_concat.h
+++ b/src/core/file_sys/vfs_concat.h
@@ -12,14 +12,14 @@
 namespace FileSys {
 
 // Wrapper function to allow for more efficient handling of files.size() == 0, 1 cases.
-VirtualFile ConcatenateFiles(std::vector<VirtualFile> files, std::string_view name = "");
+VirtualFile ConcatenateFiles(std::vector<VirtualFile> files, std::string name = "");
 
 // Class that wraps multiple vfs files and concatenates them, making reads seamless. Currently
 // read-only.
 class ConcatenatedVfsFile : public VfsFile {
-    friend VirtualFile ConcatenateFiles(std::vector<VirtualFile> files, std::string_view name);
+    friend VirtualFile ConcatenateFiles(std::vector<VirtualFile> files, std::string name);
 
-    ConcatenatedVfsFile(std::vector<VirtualFile> files, std::string_view name);
+    ConcatenatedVfsFile(std::vector<VirtualFile> files, std::string name);
 
 public:
     std::string GetName() const override;

--- a/src/core/file_sys/vfs_concat.h
+++ b/src/core/file_sys/vfs_concat.h
@@ -1,0 +1,41 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <string_view>
+#include <boost/container/flat_map.hpp>
+#include "core/file_sys/vfs.h"
+
+namespace FileSys {
+
+// Wrapper function to allow for more efficient handling of files.size() == 0, 1 cases.
+VirtualFile ConcatenateFiles(std::vector<VirtualFile> files, std::string_view name = "");
+
+// Class that wraps multiple vfs files and concatenates them, making reads seamless. Currently
+// read-only.
+class ConcatenatedVfsFile : public VfsFile {
+    friend VirtualFile ConcatenateFiles(std::vector<VirtualFile> files, std::string_view name);
+
+    ConcatenatedVfsFile(std::vector<VirtualFile> files, std::string_view name);
+
+public:
+    std::string GetName() const override;
+    size_t GetSize() const override;
+    bool Resize(size_t new_size) override;
+    std::shared_ptr<VfsDirectory> GetContainingDirectory() const override;
+    bool IsWritable() const override;
+    bool IsReadable() const override;
+    size_t Read(u8* data, size_t length, size_t offset) const override;
+    size_t Write(const u8* data, size_t length, size_t offset) override;
+    bool Rename(std::string_view name) override;
+
+private:
+    // Maps starting offset to file -- more efficient.
+    boost::container::flat_map<u64, VirtualFile> files;
+    std::string name;
+};
+
+} // namespace FileSys

--- a/src/core/file_sys/vfs_real.cpp
+++ b/src/core/file_sys/vfs_real.cpp
@@ -83,7 +83,10 @@ VirtualFile RealVfsFilesystem::OpenFile(std::string_view path_, Mode perms) {
 
 VirtualFile RealVfsFilesystem::CreateFile(std::string_view path_, Mode perms) {
     const auto path = FileUtil::SanitizePath(path_, FileUtil::DirectorySeparator::PlatformDefault);
-    if (!FileUtil::Exists(path) && !FileUtil::CreateEmptyFile(path))
+    if (!FileUtil::Exists(path) &&
+        !FileUtil::CreateFullPath(
+            FileUtil::SanitizePath(path, FileUtil::DirectorySeparator::ForwardSlash)) &&
+        !FileUtil::CreateEmptyFile(path))
         return nullptr;
     return OpenFile(path, perms);
 }
@@ -306,14 +309,14 @@ RealVfsDirectory::RealVfsDirectory(RealVfsFilesystem& base_, const std::string& 
 
 std::shared_ptr<VfsFile> RealVfsDirectory::GetFileRelative(std::string_view path) const {
     const auto full_path = FileUtil::SanitizePath(this->path + DIR_SEP + std::string(path));
-    if (!FileUtil::Exists(full_path))
+    if (!FileUtil::Exists(full_path) || FileUtil::IsDirectory(full_path))
         return nullptr;
     return base.OpenFile(full_path, perms);
 }
 
 std::shared_ptr<VfsDirectory> RealVfsDirectory::GetDirectoryRelative(std::string_view path) const {
     const auto full_path = FileUtil::SanitizePath(this->path + DIR_SEP + std::string(path));
-    if (!FileUtil::Exists(full_path))
+    if (!FileUtil::Exists(full_path) || !FileUtil::IsDirectory(full_path))
         return nullptr;
     return base.OpenDirectory(full_path, perms);
 }

--- a/src/core/file_sys/vfs_real.cpp
+++ b/src/core/file_sys/vfs_real.cpp
@@ -84,9 +84,11 @@ VirtualFile RealVfsFilesystem::OpenFile(std::string_view path_, Mode perms) {
 VirtualFile RealVfsFilesystem::CreateFile(std::string_view path_, Mode perms) {
     const auto path = FileUtil::SanitizePath(path_, FileUtil::DirectorySeparator::PlatformDefault);
     const auto path_fwd = FileUtil::SanitizePath(path, FileUtil::DirectorySeparator::ForwardSlash);
-    if (!FileUtil::Exists(path) && !FileUtil::CreateFullPath(path_fwd) &&
-        !FileUtil::CreateEmptyFile(path))
-        return nullptr;
+    if (!FileUtil::Exists(path)) {
+        FileUtil::CreateFullPath(path_fwd);
+        if (!FileUtil::CreateEmptyFile(path))
+            return nullptr;
+    }
     return OpenFile(path, perms);
 }
 
@@ -143,9 +145,11 @@ VirtualDir RealVfsFilesystem::OpenDirectory(std::string_view path_, Mode perms) 
 VirtualDir RealVfsFilesystem::CreateDirectory(std::string_view path_, Mode perms) {
     const auto path = FileUtil::SanitizePath(path_, FileUtil::DirectorySeparator::PlatformDefault);
     const auto path_fwd = FileUtil::SanitizePath(path, FileUtil::DirectorySeparator::ForwardSlash);
-    if (!FileUtil::Exists(path) && !FileUtil::CreateFullPath(path_fwd) &&
-        !FileUtil::CreateEmptyFile(path))
-        return nullptr;
+    if (!FileUtil::Exists(path)) {
+        FileUtil::CreateFullPath(path_fwd);
+        if (!FileUtil::CreateDir(path))
+            return nullptr;
+    }
     // Cannot use make_shared as RealVfsDirectory constructor is private
     return std::shared_ptr<RealVfsDirectory>(new RealVfsDirectory(*this, path, perms));
 }

--- a/src/core/file_sys/vfs_real.cpp
+++ b/src/core/file_sys/vfs_real.cpp
@@ -83,10 +83,12 @@ VirtualFile RealVfsFilesystem::OpenFile(std::string_view path_, Mode perms) {
 
 VirtualFile RealVfsFilesystem::CreateFile(std::string_view path_, Mode perms) {
     const auto path = FileUtil::SanitizePath(path_, FileUtil::DirectorySeparator::PlatformDefault);
-    if (!FileUtil::Exists(path) &&
-        !FileUtil::CreateFullPath(
-            FileUtil::SanitizePath(path, FileUtil::DirectorySeparator::ForwardSlash)) &&
-        !FileUtil::CreateEmptyFile(path))
+    if (!FileUtil::Exists(path))
+        return nullptr;
+    if (!FileUtil::CreateFullPath(
+            FileUtil::SanitizePath(path, FileUtil::DirectorySeparator::ForwardSlash)))
+        return nullptr;
+    if (!FileUtil::CreateEmptyFile(path))
         return nullptr;
     return OpenFile(path, perms);
 }
@@ -143,7 +145,12 @@ VirtualDir RealVfsFilesystem::OpenDirectory(std::string_view path_, Mode perms) 
 
 VirtualDir RealVfsFilesystem::CreateDirectory(std::string_view path_, Mode perms) {
     const auto path = FileUtil::SanitizePath(path_, FileUtil::DirectorySeparator::PlatformDefault);
-    if (!FileUtil::Exists(path) && !FileUtil::CreateDir(path))
+    if (!FileUtil::Exists(path))
+        return nullptr;
+    if (!FileUtil::CreateFullPath(
+            FileUtil::SanitizePath(path, FileUtil::DirectorySeparator::ForwardSlash)))
+        return nullptr;
+    if (!FileUtil::CreateDir(path))
         return nullptr;
     // Cannot use make_shared as RealVfsDirectory constructor is private
     return std::shared_ptr<RealVfsDirectory>(new RealVfsDirectory(*this, path, perms));

--- a/src/core/file_sys/vfs_real.cpp
+++ b/src/core/file_sys/vfs_real.cpp
@@ -83,12 +83,9 @@ VirtualFile RealVfsFilesystem::OpenFile(std::string_view path_, Mode perms) {
 
 VirtualFile RealVfsFilesystem::CreateFile(std::string_view path_, Mode perms) {
     const auto path = FileUtil::SanitizePath(path_, FileUtil::DirectorySeparator::PlatformDefault);
-    if (!FileUtil::Exists(path))
-        return nullptr;
-    if (!FileUtil::CreateFullPath(
-            FileUtil::SanitizePath(path, FileUtil::DirectorySeparator::ForwardSlash)))
-        return nullptr;
-    if (!FileUtil::CreateEmptyFile(path))
+    const auto path_fwd = FileUtil::SanitizePath(path, FileUtil::DirectorySeparator::ForwardSlash);
+    if (!FileUtil::Exists(path) && !FileUtil::CreateFullPath(path_fwd) &&
+        !FileUtil::CreateEmptyFile(path))
         return nullptr;
     return OpenFile(path, perms);
 }
@@ -145,12 +142,9 @@ VirtualDir RealVfsFilesystem::OpenDirectory(std::string_view path_, Mode perms) 
 
 VirtualDir RealVfsFilesystem::CreateDirectory(std::string_view path_, Mode perms) {
     const auto path = FileUtil::SanitizePath(path_, FileUtil::DirectorySeparator::PlatformDefault);
-    if (!FileUtil::Exists(path))
-        return nullptr;
-    if (!FileUtil::CreateFullPath(
-            FileUtil::SanitizePath(path, FileUtil::DirectorySeparator::ForwardSlash)))
-        return nullptr;
-    if (!FileUtil::CreateDir(path))
+    const auto path_fwd = FileUtil::SanitizePath(path, FileUtil::DirectorySeparator::ForwardSlash);
+    if (!FileUtil::Exists(path) && !FileUtil::CreateFullPath(path_fwd) &&
+        !FileUtil::CreateEmptyFile(path))
         return nullptr;
     // Cannot use make_shared as RealVfsDirectory constructor is private
     return std::shared_ptr<RealVfsDirectory>(new RealVfsDirectory(*this, path, perms));

--- a/src/core/file_sys/vfs_real.h
+++ b/src/core/file_sys/vfs_real.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <string_view>
-
 #include <boost/container/flat_map.hpp>
 #include "common/file_util.h"
 #include "core/file_sys/mode.h"

--- a/src/core/file_sys/vfs_vector.cpp
+++ b/src/core/file_sys/vfs_vector.cpp
@@ -8,8 +8,8 @@
 
 namespace FileSys {
 VectorVfsDirectory::VectorVfsDirectory(std::vector<VirtualFile> files_,
-                                       std::vector<VirtualDir> dirs_, VirtualDir parent_,
-                                       std::string name_)
+                                       std::vector<VirtualDir> dirs_, std::string name_,
+                                       VirtualDir parent_)
     : files(std::move(files_)), dirs(std::move(dirs_)), parent(std::move(parent_)),
       name(std::move(name_)) {}
 

--- a/src/core/file_sys/vfs_vector.h
+++ b/src/core/file_sys/vfs_vector.h
@@ -12,8 +12,8 @@ namespace FileSys {
 // Vector data is supplied upon construction.
 struct VectorVfsDirectory : public VfsDirectory {
     explicit VectorVfsDirectory(std::vector<VirtualFile> files = {},
-                                std::vector<VirtualDir> dirs = {}, VirtualDir parent = nullptr,
-                                std::string name = "");
+                                std::vector<VirtualDir> dirs = {}, std::string name = "",
+                                VirtualDir parent = nullptr);
 
     std::vector<std::shared_ptr<VfsFile>> GetFiles() const override;
     std::vector<std::shared_ptr<VfsDirectory>> GetSubdirectories() const override;

--- a/src/core/hle/service/filesystem/filesystem.h
+++ b/src/core/hle/service/filesystem/filesystem.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include "common/common_types.h"
+#include "core/file_sys/bis_factory.h"
 #include "core/file_sys/directory.h"
 #include "core/file_sys/mode.h"
 #include "core/file_sys/romfs_factory.h"
@@ -24,16 +25,15 @@ namespace FileSystem {
 ResultCode RegisterRomFS(std::unique_ptr<FileSys::RomFSFactory>&& factory);
 ResultCode RegisterSaveData(std::unique_ptr<FileSys::SaveDataFactory>&& factory);
 ResultCode RegisterSDMC(std::unique_ptr<FileSys::SDMCFactory>&& factory);
+ResultCode RegisterBIS(std::unique_ptr<FileSys::BISFactory>&& factory);
 
-// TODO(DarkLordZach): BIS Filesystem
-// ResultCode RegisterBIS(std::unique_ptr<FileSys::BISFactory>&& factory);
 ResultVal<FileSys::VirtualFile> OpenRomFS(u64 title_id);
 ResultVal<FileSys::VirtualDir> OpenSaveData(FileSys::SaveDataSpaceId space,
                                             FileSys::SaveDataDescriptor save_struct);
 ResultVal<FileSys::VirtualDir> OpenSDMC();
 
-// TODO(DarkLordZach): BIS Filesystem
-// ResultVal<std::unique_ptr<FileSys::FileSystemBackend>> OpenBIS();
+std::shared_ptr<FileSys::RegisteredCache> GetSystemNANDContents();
+std::shared_ptr<FileSys::RegisteredCache> GetUserNANDContents();
 
 /// Registers all Filesystem services with the specified service manager.
 void InstallInterfaces(SM::ServiceManager& service_manager, const FileSys::VirtualFilesystem& vfs);

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -46,6 +46,8 @@ FileType IdentifyFile(FileSys::VirtualFile file) {
 FileType GuessFromFilename(const std::string& name) {
     if (name == "main")
         return FileType::DeconstructedRomDirectory;
+    if (name == "00")
+        return FileType::NCA;
 
     const std::string extension =
         Common::ToLower(std::string(FileUtil::GetExtensionFromFilename(name)));

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -405,7 +405,6 @@ void GameList::RefreshGameDirectory() {
 
 static void GetMetadataFromControlNCA(const std::shared_ptr<FileSys::NCA>& nca,
                                       std::vector<u8>& icon, std::string& name) {
-
     const auto control_dir = FileSys::ExtractRomFS(nca->GetRomFS());
     if (control_dir == nullptr)
         return;

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -163,10 +163,13 @@ signals:
 
 private:
     FileSys::VirtualFilesystem vfs;
+    std::map<u64, std::shared_ptr<FileSys::NCA>> nca_control_map;
     QStringList watch_list;
     QString dir_path;
     bool deep_scan;
     std::atomic_bool stop_processing;
 
+    void AddInstalledTitlesToGameList();
+    void FillControlMap(const std::string& dir_path);
     void AddFstEntriesToGameList(const std::string& dir_path, unsigned int recursion = 0);
 };

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -682,7 +682,7 @@ void GMainWindow::OnMenuInstallToNAND() {
             }
 
             if (index >= 5)
-                index += 0x80;
+                index += 0x7B;
 
             if (Service::FileSystem::GetUserNANDContents()->InstallEntry(
                     nca, static_cast<FileSys::TitleType>(index))) {

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -125,6 +125,7 @@ private slots:
     void OnGameListOpenSaveFolder(u64 program_id);
     void OnMenuLoadFile();
     void OnMenuLoadFolder();
+    void OnMenuInstallToNAND();
     /// Called whenever a user selects the "File->Select Game List Root" menu item
     void OnMenuSelectGameListRoot();
     void OnMenuRecentFile();

--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -57,6 +57,8 @@
       <string>Recent Files</string>
      </property>
     </widget>
+     <addaction name="action_Install_File_NAND" />
+     <addaction name="separator"/>
     <addaction name="action_Load_File"/>
     <addaction name="action_Load_Folder"/>
     <addaction name="separator"/>
@@ -102,6 +104,11 @@
    <addaction name="menu_View"/>
    <addaction name="menu_Help"/>
   </widget>
+   <action name="action_Install_File_NAND">
+     <property name="text">
+       <string>Install File to NAND...</string>
+     </property>
+   </action>
   <action name="action_Load_File">
    <property name="text">
     <string>Load File...</string>


### PR DESCRIPTION
This adds support for parsing directories that use nintendo's 'registered' format, namely the internal user/system NAND and SD card and searching them for NCA files. This specific PR only adds support for sys/user NAND as sd card titles use an extra layer of encryption (NAX0, but stay tuned). 

**NON-DEVS/REVIEWERS:** Unfortunately, all of my games except MK8DX + Update are on my sd card, so testing the 'drag and drop' functionality is based all on that. Everyone who can, please, use HacDiskMount to dump you nand and see what shows up in the game list. Send me your results in discord.

Adds:
- `RegisteredCache` to scan directories for metadata and use that metadata to find all NCAs within.
**NOTE**: Instead of scanning for all NCAs, I decided to rather scan for meta NCAs and use those to determine which are which. This is because updates to games are registered under the same title id as the base, not the update title id, so the only way to differentiate them is to parse the meta and see. 
- Drag & drop support in user and system NAND. You should be able to use HacDiskMount and copy the `Contents` folder of your user or system nand into `%YUZU_DIR%/nand/<>` where `<>` is `user` or `system` and, provided you have all your keys in order, it should *just* work. You **cannot** however just drop any random NCA into this folder, for the reasons in the note above, but you can:
- Add `Install to NAND` menu option in frontend. This will:
    - For XCI: Copy all the NCAs into the cache, doing some sanity checking on the meta to make sure the NCAs will be accessible in the future.
    - For NCA: Creates a new metadata file (or appends to old one with same title id) a content record and then copies the NCA in. When picking the title type for installed NCAs, `Game` will do you fine for everything right now. System archives will use `System Archive`, but that's coming soon.
- Add a partial implementation of `BISFactory`, mainly as a class to store the registered caches for system/user NAND. This is because there really should only be one instance at a time per directory. I haven't tested multiple, but it likely won't work too well. Also, the constructor of `RegisteredCache` is quite expensive, especially with larger NANDs.

There are a few more things I would like to add before this gets merged:
- [x] Search installed NAND for icon/name when it cannot be found in the games dir
- [x] Provide some form of response to the user when installing titles besides freezing the program.
![install](https://user-images.githubusercontent.com/5064800/43976478-ba78eee4-9cae-11e8-8387-d59eaea236bc.PNG)
- [x] Add ability to detect and force overwrite of already installed titles.
- [ ] More thorough testing of drag/drop NAND (see note at top)

Finally, reviewers: No commit overwrites another, it's fine to go commit by commit. I tried to break it up as much as possible, it's just a lot. Sorry