### PR TITLE
GL renderer: Pick the streambuffer from citra and use them.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -139,7 +139,6 @@ private:
     /// Syncs the blend state to match the guest state
     void SyncBlendState();
 
-    bool has_ARB_buffer_storage = false;
     bool has_ARB_direct_state_access = false;
     bool has_ARB_separate_shader_objects = false;
     bool has_ARB_vertex_attrib_binding = false;
@@ -160,7 +159,7 @@ private:
         ssbos;
 
     static constexpr size_t STREAM_BUFFER_SIZE = 128 * 1024 * 1024;
-    std::unique_ptr<OGLStreamBuffer> stream_buffer;
+    OGLStreamBuffer stream_buffer;
     OGLBuffer uniform_buffer;
     OGLFramebuffer framebuffer;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -169,7 +169,9 @@ private:
 
     std::array<OGLBuffer, Tegra::Engines::Maxwell3D::Regs::MaxShaderStage> uniform_buffers;
 
-    void SetupShaders(u8* buffer_ptr, GLintptr buffer_offset);
+    std::pair<u8*, GLintptr> SetupShaders(u8* buffer_ptr, GLintptr buffer_offset);
+
+    std::pair<u8*, GLintptr> AlignBuffer(u8* buffer_ptr, GLintptr buffer_offset, size_t alignment);
 
     enum class AccelDraw { Disabled, Arrays, Indexed };
     AccelDraw accelerate_draw = AccelDraw::Disabled;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -171,6 +171,10 @@ private:
 
     std::pair<u8*, GLintptr> AlignBuffer(u8* buffer_ptr, GLintptr buffer_offset, size_t alignment);
 
+    std::tuple<u8*, GLintptr, GLintptr> UploadMemory(u8* buffer_ptr, GLintptr buffer_offset,
+                                                     Tegra::GPUVAddr gpu_addr, size_t size,
+                                                     size_t alignment = 4);
+
     enum class AccelDraw { Disabled, Arrays, Indexed };
     AccelDraw accelerate_draw = AccelDraw::Disabled;
 };

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstddef>
 #include <memory>
+#include <tuple>
 #include <utility>
 #include <vector>
 #include <glad/glad.h>
@@ -100,9 +101,10 @@ private:
      * @param entries Vector describing the buffers that are actually used in the guest shader.
      * @returns The next available bindpoint for use in the next shader stage.
      */
-    u32 SetupConstBuffers(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage, GLuint program,
-                          u32 current_bindpoint,
-                          const std::vector<GLShader::ConstBufferEntry>& entries);
+    std::tuple<u8*, GLintptr, u32> SetupConstBuffers(
+        u8* buffer_ptr, GLintptr buffer_offset, Tegra::Engines::Maxwell3D::Regs::ShaderStage stage,
+        GLuint program, u32 current_bindpoint,
+        const std::vector<GLShader::ConstBufferEntry>& entries);
 
     /*
      * Configures the current textures to use for the draw command.
@@ -154,9 +156,6 @@ private:
     OGLVertexArray hw_vao;
 
     std::array<SamplerInfo, GLShader::NumTextureSamplers> texture_samplers;
-    std::array<std::array<OGLBuffer, Tegra::Engines::Maxwell3D::Regs::MaxConstBuffers>,
-               Tegra::Engines::Maxwell3D::Regs::MaxShaderStage>
-        ssbos;
 
     static constexpr size_t STREAM_BUFFER_SIZE = 128 * 1024 * 1024;
     OGLStreamBuffer stream_buffer;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -162,12 +162,11 @@ private:
     OGLStreamBuffer stream_buffer;
     OGLBuffer uniform_buffer;
     OGLFramebuffer framebuffer;
+    GLint uniform_buffer_alignment;
 
     size_t CalculateVertexArraysSize() const;
 
     std::pair<u8*, GLintptr> SetupVertexArrays(u8* array_ptr, GLintptr buffer_offset);
-
-    std::array<OGLBuffer, Tegra::Engines::Maxwell3D::Regs::MaxShaderStage> uniform_buffers;
 
     std::pair<u8*, GLintptr> SetupShaders(u8* buffer_ptr, GLintptr buffer_offset);
 

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -209,10 +209,13 @@ void OpenGLState::Apply() const {
             const auto& current = cur_state.draw.const_buffers[stage][buffer_id];
             const auto& new_state = draw.const_buffers[stage][buffer_id];
 
-            if (current.enabled != new_state.enabled || current.bindpoint != new_state.bindpoint ||
-                current.ssbo != new_state.ssbo) {
+            if (std::tie(current.enabled, current.bindpoint, current.ssbo, current.size,
+                         current.offset) != std::tie(new_state.enabled, new_state.bindpoint,
+                                                     new_state.ssbo, new_state.size,
+                                                     new_state.offset)) {
                 if (new_state.enabled) {
-                    glBindBufferBase(GL_UNIFORM_BUFFER, new_state.bindpoint, new_state.ssbo);
+                    glBindBufferRange(GL_UNIFORM_BUFFER, new_state.bindpoint, new_state.ssbo,
+                                      new_state.offset, new_state.size);
                 }
             }
         }

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -203,24 +203,6 @@ void OpenGLState::Apply() const {
         }
     }
 
-    // Constbuffers
-    for (std::size_t stage = 0; stage < draw.const_buffers.size(); ++stage) {
-        for (std::size_t buffer_id = 0; buffer_id < draw.const_buffers[stage].size(); ++buffer_id) {
-            const auto& current = cur_state.draw.const_buffers[stage][buffer_id];
-            const auto& new_state = draw.const_buffers[stage][buffer_id];
-
-            if (std::tie(current.enabled, current.bindpoint, current.ssbo, current.size,
-                         current.offset) != std::tie(new_state.enabled, new_state.bindpoint,
-                                                     new_state.ssbo, new_state.size,
-                                                     new_state.offset)) {
-                if (new_state.enabled) {
-                    glBindBufferRange(GL_UNIFORM_BUFFER, new_state.bindpoint, new_state.ssbo,
-                                      new_state.offset, new_state.size);
-                }
-            }
-        }
-    }
-
     // Framebuffer
     if (draw.read_framebuffer != cur_state.draw.read_framebuffer) {
         glBindFramebuffer(GL_READ_FRAMEBUFFER, draw.read_framebuffer);

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -123,6 +123,8 @@ public:
             bool enabled = false;
             GLuint bindpoint;
             GLuint ssbo;
+            GLsizeiptr size;
+            GLintptr offset;
         };
         std::array<std::array<ConstBufferConfig, Regs::MaxConstBuffers>, 5> const_buffers;
     } draw;

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -119,14 +119,6 @@ public:
         GLuint uniform_buffer;   // GL_UNIFORM_BUFFER_BINDING
         GLuint shader_program;   // GL_CURRENT_PROGRAM
         GLuint program_pipeline; // GL_PROGRAM_PIPELINE_BINDING
-        struct ConstBufferConfig {
-            bool enabled = false;
-            GLuint bindpoint;
-            GLuint ssbo;
-            GLsizeiptr size;
-            GLintptr offset;
-        };
-        std::array<std::array<ConstBufferConfig, Regs::MaxConstBuffers>, 5> const_buffers;
     } draw;
 
     struct {

--- a/src/video_core/renderer_opengl/gl_stream_buffer.cpp
+++ b/src/video_core/renderer_opengl/gl_stream_buffer.cpp
@@ -9,174 +9,91 @@
 #include "video_core/renderer_opengl/gl_state.h"
 #include "video_core/renderer_opengl/gl_stream_buffer.h"
 
-class OrphanBuffer : public OGLStreamBuffer {
-public:
-    explicit OrphanBuffer(GLenum target) : OGLStreamBuffer(target) {}
-    ~OrphanBuffer() override;
+OGLStreamBuffer::OGLStreamBuffer(GLenum target, GLsizeiptr size, bool prefer_coherent)
+    : gl_target(target), buffer_size(size) {
+    gl_buffer.Create();
+    glBindBuffer(gl_target, gl_buffer.handle);
 
-private:
-    void Create(size_t size, size_t sync_subdivide) override;
-    void Release() override;
+    GLsizeiptr allocate_size = size;
+    if (target == GL_ARRAY_BUFFER) {
+        // On AMD GPU there is a strange crash in indexed drawing. The crash happens when the buffer
+        // read position is near the end and is an out-of-bound access to the vertex buffer. This is
+        // probably a bug in the driver and is related to the usage of vec3<byte> attributes in the
+        // vertex array. Doubling the allocation size for the vertex buffer seems to avoid the
+        // crash.
+        allocate_size *= 2;
+    }
 
-    std::pair<u8*, GLintptr> Map(size_t size, size_t alignment) override;
-    void Unmap() override;
+    if (GLAD_GL_ARB_buffer_storage) {
+        persistent = true;
+        coherent = prefer_coherent;
+        GLbitfield flags =
+            GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | (coherent ? GL_MAP_COHERENT_BIT : 0);
+        glBufferStorage(gl_target, allocate_size, nullptr, flags);
+        mapped_ptr = static_cast<u8*>(glMapBufferRange(
+            gl_target, 0, buffer_size, flags | (coherent ? 0 : GL_MAP_FLUSH_EXPLICIT_BIT)));
+    } else {
+        glBufferData(gl_target, allocate_size, nullptr, GL_STREAM_DRAW);
+    }
+}
 
-    std::vector<u8> data;
-};
-
-class StorageBuffer : public OGLStreamBuffer {
-public:
-    explicit StorageBuffer(GLenum target) : OGLStreamBuffer(target) {}
-    ~StorageBuffer() override;
-
-private:
-    void Create(size_t size, size_t sync_subdivide) override;
-    void Release() override;
-
-    std::pair<u8*, GLintptr> Map(size_t size, size_t alignment) override;
-    void Unmap() override;
-
-    struct Fence {
-        OGLSync sync;
-        size_t offset;
-    };
-    std::deque<Fence> head;
-    std::deque<Fence> tail;
-
-    u8* mapped_ptr;
-};
-
-OGLStreamBuffer::OGLStreamBuffer(GLenum target) {
-    gl_target = target;
+OGLStreamBuffer::~OGLStreamBuffer() {
+    if (persistent) {
+        glBindBuffer(gl_target, gl_buffer.handle);
+        glUnmapBuffer(gl_target);
+    }
+    gl_buffer.Release();
 }
 
 GLuint OGLStreamBuffer::GetHandle() const {
     return gl_buffer.handle;
 }
 
-std::unique_ptr<OGLStreamBuffer> OGLStreamBuffer::MakeBuffer(bool storage_buffer, GLenum target) {
-    if (storage_buffer) {
-        return std::make_unique<StorageBuffer>(target);
-    }
-    return std::make_unique<OrphanBuffer>(target);
+GLsizeiptr OGLStreamBuffer::GetSize() const {
+    return buffer_size;
 }
 
-OrphanBuffer::~OrphanBuffer() {
-    Release();
-}
-
-void OrphanBuffer::Create(size_t size, size_t /*sync_subdivide*/) {
-    buffer_pos = 0;
-    buffer_size = size;
-    data.resize(buffer_size);
-
-    if (gl_buffer.handle == 0) {
-        gl_buffer.Create();
-        glBindBuffer(gl_target, gl_buffer.handle);
-    }
-
-    glBufferData(gl_target, static_cast<GLsizeiptr>(buffer_size), nullptr, GL_STREAM_DRAW);
-}
-
-void OrphanBuffer::Release() {
-    gl_buffer.Release();
-}
-
-std::pair<u8*, GLintptr> OrphanBuffer::Map(size_t size, size_t alignment) {
-    buffer_pos = Common::AlignUp(buffer_pos, alignment);
-
-    if (buffer_pos + size > buffer_size) {
-        Create(std::max(buffer_size, size), 0);
-    }
-
-    mapped_size = size;
-    return std::make_pair(&data[buffer_pos], static_cast<GLintptr>(buffer_pos));
-}
-
-void OrphanBuffer::Unmap() {
-    glBufferSubData(gl_target, static_cast<GLintptr>(buffer_pos),
-                    static_cast<GLsizeiptr>(mapped_size), &data[buffer_pos]);
-    buffer_pos += mapped_size;
-}
-
-StorageBuffer::~StorageBuffer() {
-    Release();
-}
-
-void StorageBuffer::Create(size_t size, size_t sync_subdivide) {
-    if (gl_buffer.handle != 0)
-        return;
-
-    buffer_pos = 0;
-    buffer_size = size;
-    buffer_sync_subdivide = std::max<size_t>(sync_subdivide, 1);
-
-    gl_buffer.Create();
-    glBindBuffer(gl_target, gl_buffer.handle);
-
-    glBufferStorage(gl_target, static_cast<GLsizeiptr>(buffer_size), nullptr,
-                    GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT);
-    mapped_ptr = reinterpret_cast<u8*>(
-        glMapBufferRange(gl_target, 0, static_cast<GLsizeiptr>(buffer_size),
-                         GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_FLUSH_EXPLICIT_BIT));
-}
-
-void StorageBuffer::Release() {
-    if (gl_buffer.handle == 0)
-        return;
-
-    glUnmapBuffer(gl_target);
-
-    gl_buffer.Release();
-    head.clear();
-    tail.clear();
-}
-
-std::pair<u8*, GLintptr> StorageBuffer::Map(size_t size, size_t alignment) {
+std::tuple<u8*, GLintptr, bool> OGLStreamBuffer::Map(GLsizeiptr size, GLintptr alignment) {
     ASSERT(size <= buffer_size);
-
-    OGLSync sync;
-
-    buffer_pos = Common::AlignUp(buffer_pos, alignment);
-    size_t effective_offset = Common::AlignDown(buffer_pos, buffer_sync_subdivide);
-
-    if (!head.empty() &&
-        (effective_offset > head.back().offset || buffer_pos + size > buffer_size)) {
-        ASSERT(head.back().sync.handle == 0);
-        head.back().sync.Create();
-    }
-
-    if (buffer_pos + size > buffer_size) {
-        if (!tail.empty()) {
-            std::swap(sync, tail.back().sync);
-            tail.clear();
-        }
-        std::swap(tail, head);
-        buffer_pos = 0;
-        effective_offset = 0;
-    }
-
-    while (!tail.empty() && buffer_pos + size > tail.front().offset) {
-        std::swap(sync, tail.front().sync);
-        tail.pop_front();
-    }
-
-    if (sync.handle != 0) {
-        glClientWaitSync(sync.handle, GL_SYNC_FLUSH_COMMANDS_BIT, GL_TIMEOUT_IGNORED);
-        sync.Release();
-    }
-
-    if (head.empty() || effective_offset > head.back().offset) {
-        head.emplace_back();
-        head.back().offset = effective_offset;
-    }
-
+    ASSERT(alignment <= buffer_size);
     mapped_size = size;
-    return std::make_pair(&mapped_ptr[buffer_pos], static_cast<GLintptr>(buffer_pos));
+
+    if (alignment > 0) {
+        buffer_pos = Common::AlignUp<size_t>(buffer_pos, alignment);
+    }
+
+    bool invalidate = false;
+    if (buffer_pos + size > buffer_size) {
+        buffer_pos = 0;
+        invalidate = true;
+
+        if (persistent) {
+            glUnmapBuffer(gl_target);
+        }
+    }
+
+    if (invalidate | !persistent) {
+        GLbitfield flags = GL_MAP_WRITE_BIT | (persistent ? GL_MAP_PERSISTENT_BIT : 0) |
+                           (coherent ? GL_MAP_COHERENT_BIT : GL_MAP_FLUSH_EXPLICIT_BIT) |
+                           (invalidate ? GL_MAP_INVALIDATE_BUFFER_BIT : GL_MAP_UNSYNCHRONIZED_BIT);
+        mapped_ptr = static_cast<u8*>(
+            glMapBufferRange(gl_target, buffer_pos, buffer_size - buffer_pos, flags));
+        mapped_offset = buffer_pos;
+    }
+
+    return std::make_tuple(mapped_ptr + buffer_pos - mapped_offset, buffer_pos, invalidate);
 }
 
-void StorageBuffer::Unmap() {
-    glFlushMappedBufferRange(gl_target, static_cast<GLintptr>(buffer_pos),
-                             static_cast<GLsizeiptr>(mapped_size));
-    buffer_pos += mapped_size;
+void OGLStreamBuffer::Unmap(GLsizeiptr size) {
+    ASSERT(size <= mapped_size);
+
+    if (!coherent && size > 0) {
+        glFlushMappedBufferRange(gl_target, buffer_pos - mapped_offset, size);
+    }
+
+    if (!persistent) {
+        glUnmapBuffer(gl_target);
+    }
+
+    buffer_pos += size;
 }

--- a/src/video_core/renderer_opengl/gl_stream_buffer.h
+++ b/src/video_core/renderer_opengl/gl_stream_buffer.h
@@ -2,35 +2,41 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#pragma once
-
-#include <memory>
+#include <tuple>
 #include <glad/glad.h>
 #include "common/common_types.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 
 class OGLStreamBuffer : private NonCopyable {
 public:
-    explicit OGLStreamBuffer(GLenum target);
-    virtual ~OGLStreamBuffer() = default;
-
-public:
-    static std::unique_ptr<OGLStreamBuffer> MakeBuffer(bool storage_buffer, GLenum target);
-
-    virtual void Create(size_t size, size_t sync_subdivide) = 0;
-    virtual void Release() {}
+    explicit OGLStreamBuffer(GLenum target, GLsizeiptr size, bool prefer_coherent = false);
+    ~OGLStreamBuffer();
 
     GLuint GetHandle() const;
+    GLsizeiptr GetSize() const;
 
-    virtual std::pair<u8*, GLintptr> Map(size_t size, size_t alignment) = 0;
-    virtual void Unmap() = 0;
+    /*
+     * Allocates a linear chunk of memory in the GPU buffer with at least "size" bytes
+     * and the optional alignment requirement.
+     * If the buffer is full, the whole buffer is reallocated which invalidates old chunks.
+     * The return values are the pointer to the new chunk, the offset within the buffer,
+     * and the invalidation flag for previous chunks.
+     * The actual used size must be specified on unmapping the chunk.
+     */
+    std::tuple<u8*, GLintptr, bool> Map(GLsizeiptr size, GLintptr alignment = 0);
 
-protected:
+    void Unmap(GLsizeiptr size);
+
+private:
     OGLBuffer gl_buffer;
     GLenum gl_target;
 
-    size_t buffer_pos = 0;
-    size_t buffer_size = 0;
-    size_t buffer_sync_subdivide = 0;
-    size_t mapped_size = 0;
+    bool coherent = false;
+    bool persistent = false;
+
+    GLintptr buffer_pos = 0;
+    GLsizeiptr buffer_size = 0;
+    GLintptr mapped_offset = 0;
+    GLsizeiptr mapped_size = 0;
+    u8* mapped_ptr = nullptr;
 };


### PR DESCRIPTION
This PR replaces the current stream_buffer implementation with the updated one from citra. The new implementation supports two new features:
- The reserved and the used memory don't have to match. Only the used memory size matters for the buffer usage.
- It reports when the old uploads are invalidated. But this is not used in yuzu.

The next patches also uses this stream buffer in the missing places: Stage constant uploads without glCopy and constant buffer upload without glBufferData.

~~I've tried to touch as less code as possible, but I dislike that the one glBindBufferRange call is in gl_rasterizer and the second one is in gl_state. Maybe we should clean this up. Honestly, I'd like to get this kind of buffer handling out of gl_state...~~ I've pushed another commit which drops this code from gl_state. It is hopefully cleaner in gl_rasterizer.