### PR TITLE
Implement render target formats RGBA8_SNORM and RG8_SNORM.

### DIFF
--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -67,6 +67,7 @@ u32 RenderTargetBytesPerPixel(RenderTargetFormat format) {
     case RenderTargetFormat::R16_UINT:
     case RenderTargetFormat::R16_SINT:
     case RenderTargetFormat::R16_FLOAT:
+    case RenderTargetFormat::RG8_SNORM:
         return 2;
     case RenderTargetFormat::R8_UNORM:
         return 1;

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -50,6 +50,7 @@ u32 RenderTargetBytesPerPixel(RenderTargetFormat format) {
     case RenderTargetFormat::RG32_FLOAT:
         return 8;
     case RenderTargetFormat::RGBA8_UNORM:
+    case RenderTargetFormat::RGBA8_SNORM:
     case RenderTargetFormat::RGBA8_SRGB:
     case RenderTargetFormat::RGB10_A2_UNORM:
     case RenderTargetFormat::BGRA8_UNORM:

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -26,6 +26,7 @@ enum class RenderTargetFormat : u32 {
     RGB10_A2_UNORM = 0xD1,
     RGBA8_UNORM = 0xD5,
     RGBA8_SRGB = 0xD6,
+    RGBA8_SNORM = 0xD7,
     RG16_UNORM = 0xDA,
     RG16_SNORM = 0xDB,
     RG16_SINT = 0xDC,

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -35,6 +35,7 @@ enum class RenderTargetFormat : u32 {
     R11G11B10_FLOAT = 0xE0,
     R32_FLOAT = 0xE5,
     B5G6R5_UNORM = 0xE8,
+    RG8_SNORM = 0xEB,
     R16_UNORM = 0xEE,
     R16_SNORM = 0xEF,
     R16_SINT = 0xF0,

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -92,7 +92,8 @@ struct FormatTuple {
 }
 
 static constexpr std::array<FormatTuple, SurfaceParams::MaxPixelFormat> tex_format_tuples = {{
-    {GL_RGBA8, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, ComponentType::UNorm, false}, // ABGR8
+    {GL_RGBA8, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, ComponentType::UNorm, false}, // ABGR8U
+    {GL_RGBA8, GL_RGBA, GL_BYTE, ComponentType::SNorm, false},                     // ABGR8S
     {GL_RGB, GL_RGB, GL_UNSIGNED_SHORT_5_6_5_REV, ComponentType::UNorm, false},    // B5G6R5
     {GL_RGB10_A2, GL_RGBA, GL_UNSIGNED_INT_2_10_10_10_REV, ComponentType::UNorm,
      false}, // A2B10G10R10
@@ -231,31 +232,33 @@ void MortonCopy(u32 stride, u32 block_height, u32 height, std::vector<u8>& gl_bu
 static constexpr std::array<void (*)(u32, u32, u32, std::vector<u8>&, Tegra::GPUVAddr),
                             SurfaceParams::MaxPixelFormat>
     morton_to_gl_fns = {
-        MortonCopy<true, PixelFormat::ABGR8>,        MortonCopy<true, PixelFormat::B5G6R5>,
-        MortonCopy<true, PixelFormat::A2B10G10R10>,  MortonCopy<true, PixelFormat::A1B5G5R5>,
-        MortonCopy<true, PixelFormat::R8>,           MortonCopy<true, PixelFormat::RGBA16F>,
-        MortonCopy<true, PixelFormat::R11FG11FB10F>, MortonCopy<true, PixelFormat::RGBA32UI>,
-        MortonCopy<true, PixelFormat::DXT1>,         MortonCopy<true, PixelFormat::DXT23>,
-        MortonCopy<true, PixelFormat::DXT45>,        MortonCopy<true, PixelFormat::DXN1>,
-        MortonCopy<true, PixelFormat::DXN2UNORM>,    MortonCopy<true, PixelFormat::DXN2SNORM>,
-        MortonCopy<true, PixelFormat::BC7U>,         MortonCopy<true, PixelFormat::ASTC_2D_4X4>,
-        MortonCopy<true, PixelFormat::G8R8>,         MortonCopy<true, PixelFormat::BGRA8>,
-        MortonCopy<true, PixelFormat::RGBA32F>,      MortonCopy<true, PixelFormat::RG32F>,
-        MortonCopy<true, PixelFormat::R32F>,         MortonCopy<true, PixelFormat::R16F>,
-        MortonCopy<true, PixelFormat::R16UNORM>,     MortonCopy<true, PixelFormat::R16S>,
-        MortonCopy<true, PixelFormat::R16UI>,        MortonCopy<true, PixelFormat::R16I>,
-        MortonCopy<true, PixelFormat::RG16>,         MortonCopy<true, PixelFormat::RG16F>,
-        MortonCopy<true, PixelFormat::RG16UI>,       MortonCopy<true, PixelFormat::RG16I>,
-        MortonCopy<true, PixelFormat::RG16S>,        MortonCopy<true, PixelFormat::RGB32F>,
-        MortonCopy<true, PixelFormat::SRGBA8>,       MortonCopy<true, PixelFormat::Z24S8>,
-        MortonCopy<true, PixelFormat::S8Z24>,        MortonCopy<true, PixelFormat::Z32F>,
-        MortonCopy<true, PixelFormat::Z16>,          MortonCopy<true, PixelFormat::Z32FS8>,
+        MortonCopy<true, PixelFormat::ABGR8U>,      MortonCopy<true, PixelFormat::ABGR8S>,
+        MortonCopy<true, PixelFormat::B5G6R5>,      MortonCopy<true, PixelFormat::A2B10G10R10>,
+        MortonCopy<true, PixelFormat::A1B5G5R5>,    MortonCopy<true, PixelFormat::R8>,
+        MortonCopy<true, PixelFormat::RGBA16F>,     MortonCopy<true, PixelFormat::R11FG11FB10F>,
+        MortonCopy<true, PixelFormat::RGBA32UI>,    MortonCopy<true, PixelFormat::DXT1>,
+        MortonCopy<true, PixelFormat::DXT23>,       MortonCopy<true, PixelFormat::DXT45>,
+        MortonCopy<true, PixelFormat::DXN1>,        MortonCopy<true, PixelFormat::DXN2UNORM>,
+        MortonCopy<true, PixelFormat::DXN2SNORM>,   MortonCopy<true, PixelFormat::BC7U>,
+        MortonCopy<true, PixelFormat::ASTC_2D_4X4>, MortonCopy<true, PixelFormat::G8R8>,
+        MortonCopy<true, PixelFormat::BGRA8>,       MortonCopy<true, PixelFormat::RGBA32F>,
+        MortonCopy<true, PixelFormat::RG32F>,       MortonCopy<true, PixelFormat::R32F>,
+        MortonCopy<true, PixelFormat::R16F>,        MortonCopy<true, PixelFormat::R16UNORM>,
+        MortonCopy<true, PixelFormat::R16S>,        MortonCopy<true, PixelFormat::R16UI>,
+        MortonCopy<true, PixelFormat::R16I>,        MortonCopy<true, PixelFormat::RG16>,
+        MortonCopy<true, PixelFormat::RG16F>,       MortonCopy<true, PixelFormat::RG16UI>,
+        MortonCopy<true, PixelFormat::RG16I>,       MortonCopy<true, PixelFormat::RG16S>,
+        MortonCopy<true, PixelFormat::RGB32F>,      MortonCopy<true, PixelFormat::SRGBA8>,
+        MortonCopy<true, PixelFormat::Z24S8>,       MortonCopy<true, PixelFormat::S8Z24>,
+        MortonCopy<true, PixelFormat::Z32F>,        MortonCopy<true, PixelFormat::Z16>,
+        MortonCopy<true, PixelFormat::Z32FS8>,
 };
 
 static constexpr std::array<void (*)(u32, u32, u32, std::vector<u8>&, Tegra::GPUVAddr),
                             SurfaceParams::MaxPixelFormat>
     gl_to_morton_fns = {
-        MortonCopy<false, PixelFormat::ABGR8>,
+        MortonCopy<false, PixelFormat::ABGR8U>,
+        MortonCopy<false, PixelFormat::ABGR8S>,
         MortonCopy<false, PixelFormat::B5G6R5>,
         MortonCopy<false, PixelFormat::A2B10G10R10>,
         MortonCopy<false, PixelFormat::A1B5G5R5>,

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -133,6 +133,7 @@ static constexpr std::array<FormatTuple, SurfaceParams::MaxPixelFormat> tex_form
     {GL_RG16_SNORM, GL_RG, GL_SHORT, ComponentType::SNorm, false},             // RG16S
     {GL_RGB32F, GL_RGB, GL_FLOAT, ComponentType::Float, false},                // RGB32F
     {GL_SRGB8_ALPHA8, GL_RGBA, GL_UNSIGNED_INT_8_8_8_8_REV, ComponentType::UNorm, false}, // SRGBA8
+    {GL_RG8, GL_RG, GL_BYTE, ComponentType::SNorm, false},                                // RG8S
 
     // DepthStencil formats
     {GL_DEPTH24_STENCIL8, GL_DEPTH_STENCIL, GL_UNSIGNED_INT_24_8, ComponentType::UNorm,
@@ -249,9 +250,9 @@ static constexpr std::array<void (*)(u32, u32, u32, std::vector<u8>&, Tegra::GPU
         MortonCopy<true, PixelFormat::RG16F>,       MortonCopy<true, PixelFormat::RG16UI>,
         MortonCopy<true, PixelFormat::RG16I>,       MortonCopy<true, PixelFormat::RG16S>,
         MortonCopy<true, PixelFormat::RGB32F>,      MortonCopy<true, PixelFormat::SRGBA8>,
-        MortonCopy<true, PixelFormat::Z24S8>,       MortonCopy<true, PixelFormat::S8Z24>,
-        MortonCopy<true, PixelFormat::Z32F>,        MortonCopy<true, PixelFormat::Z16>,
-        MortonCopy<true, PixelFormat::Z32FS8>,
+        MortonCopy<true, PixelFormat::RG8S>,        MortonCopy<true, PixelFormat::Z24S8>,
+        MortonCopy<true, PixelFormat::S8Z24>,       MortonCopy<true, PixelFormat::Z32F>,
+        MortonCopy<true, PixelFormat::Z16>,         MortonCopy<true, PixelFormat::Z32FS8>,
 };
 
 static constexpr std::array<void (*)(u32, u32, u32, std::vector<u8>&, Tegra::GPUVAddr),
@@ -293,6 +294,7 @@ static constexpr std::array<void (*)(u32, u32, u32, std::vector<u8>&, Tegra::GPU
         MortonCopy<false, PixelFormat::RG16S>,
         MortonCopy<false, PixelFormat::RGB32F>,
         MortonCopy<false, PixelFormat::SRGBA8>,
+        MortonCopy<false, PixelFormat::RG8S>,
         MortonCopy<false, PixelFormat::Z24S8>,
         MortonCopy<false, PixelFormat::S8Z24>,
         MortonCopy<false, PixelFormat::Z32F>,

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -57,15 +57,16 @@ struct SurfaceParams {
         RG16S = 31,
         RGB32F = 32,
         SRGBA8 = 33,
+        RG8S = 34,
 
         MaxColorFormat,
 
         // DepthStencil formats
-        Z24S8 = 34,
-        S8Z24 = 35,
-        Z32F = 36,
-        Z16 = 37,
-        Z32FS8 = 38,
+        Z24S8 = 35,
+        S8Z24 = 36,
+        Z32F = 37,
+        Z16 = 38,
+        Z32FS8 = 39,
 
         MaxDepthStencilFormat,
 
@@ -137,6 +138,7 @@ struct SurfaceParams {
             1, // RG16S
             1, // RGB32F
             1, // SRGBA8
+            1, // RG8S
             1, // Z24S8
             1, // S8Z24
             1, // Z32F
@@ -187,6 +189,7 @@ struct SurfaceParams {
             32,  // RG16S
             96,  // RGB32F
             32,  // SRGBA8
+            16,  // RG8S
             32,  // Z24S8
             32,  // S8Z24
             32,  // Z32F
@@ -257,6 +260,8 @@ struct SurfaceParams {
             return PixelFormat::RG16;
         case Tegra::RenderTargetFormat::RG16_SNORM:
             return PixelFormat::RG16S;
+        case Tegra::RenderTargetFormat::RG8_SNORM:
+            return PixelFormat::RG8S;
         case Tegra::RenderTargetFormat::R16_FLOAT:
             return PixelFormat::R16F;
         case Tegra::RenderTargetFormat::R16_UNORM:
@@ -418,6 +423,7 @@ struct SurfaceParams {
         case Tegra::RenderTargetFormat::RGBA8_SNORM:
         case Tegra::RenderTargetFormat::RG16_SNORM:
         case Tegra::RenderTargetFormat::R16_SNORM:
+        case Tegra::RenderTargetFormat::RG8_SNORM:
             return ComponentType::SNorm;
         case Tegra::RenderTargetFormat::RGBA16_FLOAT:
         case Tegra::RenderTargetFormat::R11G11B10_FLOAT:

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -23,48 +23,49 @@ using PageMap = boost::icl::interval_map<u64, int>;
 
 struct SurfaceParams {
     enum class PixelFormat {
-        ABGR8 = 0,
-        B5G6R5 = 1,
-        A2B10G10R10 = 2,
-        A1B5G5R5 = 3,
-        R8 = 4,
-        RGBA16F = 5,
-        R11FG11FB10F = 6,
-        RGBA32UI = 7,
-        DXT1 = 8,
-        DXT23 = 9,
-        DXT45 = 10,
-        DXN1 = 11, // This is also known as BC4
-        DXN2UNORM = 12,
-        DXN2SNORM = 13,
-        BC7U = 14,
-        ASTC_2D_4X4 = 15,
-        G8R8 = 16,
-        BGRA8 = 17,
-        RGBA32F = 18,
-        RG32F = 19,
-        R32F = 20,
-        R16F = 21,
-        R16UNORM = 22,
-        R16S = 23,
-        R16UI = 24,
-        R16I = 25,
-        RG16 = 26,
-        RG16F = 27,
-        RG16UI = 28,
-        RG16I = 29,
-        RG16S = 30,
-        RGB32F = 31,
-        SRGBA8 = 32,
+        ABGR8U = 0,
+        ABGR8S = 1,
+        B5G6R5 = 2,
+        A2B10G10R10 = 3,
+        A1B5G5R5 = 4,
+        R8 = 5,
+        RGBA16F = 6,
+        R11FG11FB10F = 7,
+        RGBA32UI = 8,
+        DXT1 = 9,
+        DXT23 = 10,
+        DXT45 = 11,
+        DXN1 = 12, // This is also known as BC4
+        DXN2UNORM = 13,
+        DXN2SNORM = 14,
+        BC7U = 15,
+        ASTC_2D_4X4 = 16,
+        G8R8 = 17,
+        BGRA8 = 18,
+        RGBA32F = 19,
+        RG32F = 20,
+        R32F = 21,
+        R16F = 22,
+        R16UNORM = 23,
+        R16S = 24,
+        R16UI = 25,
+        R16I = 26,
+        RG16 = 27,
+        RG16F = 28,
+        RG16UI = 29,
+        RG16I = 30,
+        RG16S = 31,
+        RGB32F = 32,
+        SRGBA8 = 33,
 
         MaxColorFormat,
 
         // DepthStencil formats
-        Z24S8 = 33,
-        S8Z24 = 34,
-        Z32F = 35,
-        Z16 = 36,
-        Z32FS8 = 37,
+        Z24S8 = 34,
+        S8Z24 = 35,
+        Z32F = 36,
+        Z16 = 37,
+        Z32FS8 = 38,
 
         MaxDepthStencilFormat,
 
@@ -102,7 +103,8 @@ struct SurfaceParams {
             return 0;
 
         constexpr std::array<u32, MaxPixelFormat> compression_factor_table = {{
-            1, // ABGR8
+            1, // ABGR8U
+            1, // ABGR8S
             1, // B5G6R5
             1, // A2B10G10R10
             1, // A1B5G5R5
@@ -151,7 +153,8 @@ struct SurfaceParams {
             return 0;
 
         constexpr std::array<u32, MaxPixelFormat> bpp_table = {{
-            32,  // ABGR8
+            32,  // ABGR8U
+            32,  // ABGR8S
             16,  // B5G6R5
             32,  // A2B10G10R10
             16,  // A1B5G5R5
@@ -223,7 +226,9 @@ struct SurfaceParams {
         // gamma.
         case Tegra::RenderTargetFormat::RGBA8_SRGB:
         case Tegra::RenderTargetFormat::RGBA8_UNORM:
-            return PixelFormat::ABGR8;
+            return PixelFormat::ABGR8U;
+        case Tegra::RenderTargetFormat::RGBA8_SNORM:
+            return PixelFormat::ABGR8S;
         case Tegra::RenderTargetFormat::BGRA8_UNORM:
             return PixelFormat::BGRA8;
         case Tegra::RenderTargetFormat::RGB10_A2_UNORM:
@@ -275,7 +280,15 @@ struct SurfaceParams {
         // TODO(Subv): Properly implement this
         switch (format) {
         case Tegra::Texture::TextureFormat::A8R8G8B8:
-            return PixelFormat::ABGR8;
+            switch (component_type) {
+            case Tegra::Texture::ComponentType::UNORM:
+                return PixelFormat::ABGR8U;
+            case Tegra::Texture::ComponentType::SNORM:
+                return PixelFormat::ABGR8S;
+            }
+            LOG_CRITICAL(HW_GPU, "Unimplemented component_type={}",
+                         static_cast<u32>(component_type));
+            UNREACHABLE();
         case Tegra::Texture::TextureFormat::B5G6R5:
             return PixelFormat::B5G6R5;
         case Tegra::Texture::TextureFormat::A2B10G10R10:
@@ -402,6 +415,7 @@ struct SurfaceParams {
         case Tegra::RenderTargetFormat::R16_UNORM:
         case Tegra::RenderTargetFormat::B5G6R5_UNORM:
             return ComponentType::UNorm;
+        case Tegra::RenderTargetFormat::RGBA8_SNORM:
         case Tegra::RenderTargetFormat::RG16_SNORM:
         case Tegra::RenderTargetFormat::R16_SNORM:
             return ComponentType::SNorm;
@@ -429,7 +443,7 @@ struct SurfaceParams {
     static PixelFormat PixelFormatFromGPUPixelFormat(Tegra::FramebufferConfig::PixelFormat format) {
         switch (format) {
         case Tegra::FramebufferConfig::PixelFormat::ABGR8:
-            return PixelFormat::ABGR8;
+            return PixelFormat::ABGR8U;
         default:
             LOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
             UNREACHABLE();


### PR DESCRIPTION
- Used by Super Mario Odyssey.