### PR TITLE
Prevent PixelFormatFromRenderTargetFormat from returning an uninitialized value

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -250,6 +250,7 @@ struct SurfaceParams {
         default:
             LOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
             UNREACHABLE();
+            return PixelFormat::ABGR8U;
         }
     }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -250,7 +250,7 @@ struct SurfaceParams {
         default:
             LOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
             UNREACHABLE();
-            return PixelFormat::ABGR8U;
+            return PixelFormat::ABGR8;
         }
     }
 


### PR DESCRIPTION
Fixes Star Allies crashing on canary. Usually I would implement what it's trying to use, but #848 has it already. (R16_UNORM)