### PR TITLE
video_core: Get rid of global variable g_toggle_framelimit_enabled

### DIFF
--- a/src/core/hle/service/nvflinger/buffer_queue.h
+++ b/src/core/hle/service/nvflinger/buffer_queue.h
@@ -6,6 +6,7 @@
 
 #include <vector>
 #include <boost/optional.hpp>
+#include "common/common_funcs.h"
 #include "common/math_util.h"
 #include "common/swap.h"
 #include "core/hle/kernel/event.h"

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -7,22 +7,18 @@
 #include "core/hle/service/hid/hid.h"
 #include "core/settings.h"
 #include "video_core/renderer_base.h"
-#include "video_core/video_core.h"
 
 namespace Settings {
 
 Values values = {};
 
 void Apply() {
-
     GDBStub::SetServerPort(values.gdbstub_port);
     GDBStub::ToggleServer(values.use_gdbstub);
 
-    VideoCore::g_toggle_framelimit_enabled = values.toggle_framelimit;
-
     auto& system_instance = Core::System::GetInstance();
     if (system_instance.IsPoweredOn()) {
-        system_instance.Renderer().UpdateCurrentFramebufferLayout();
+        system_instance.Renderer().RefreshBaseSettings();
     }
 
     Service::HID::ReloadInputDevices();

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/assert.h"
 #include "video_core/engines/fermi_2d.h"
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/engines/maxwell_compute.h"
@@ -10,6 +11,15 @@
 #include "video_core/rasterizer_interface.h"
 
 namespace Tegra {
+
+u32 FramebufferConfig::BytesPerPixel(PixelFormat format) {
+    switch (format) {
+    case PixelFormat::ABGR8:
+        return 4;
+    }
+
+    UNREACHABLE();
+}
 
 GPU::GPU(VideoCore::RasterizerInterface& rasterizer) {
     memory_manager = std::make_unique<MemoryManager>();

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -6,7 +6,6 @@
 
 #include <memory>
 #include <unordered_map>
-#include <vector>
 #include "common/common_types.h"
 #include "core/hle/service/nvflinger/buffer_queue.h"
 #include "video_core/memory_manager.h"
@@ -65,14 +64,7 @@ struct FramebufferConfig {
     /**
      * Returns the number of bytes per pixel.
      */
-    static u32 BytesPerPixel(PixelFormat format) {
-        switch (format) {
-        case PixelFormat::ABGR8:
-            return 4;
-        }
-
-        UNREACHABLE();
-    }
+    static u32 BytesPerPixel(PixelFormat format);
 
     VAddr address;
     u32 offset;

--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -4,24 +4,35 @@
 
 #include <memory>
 #include "core/frontend/emu_window.h"
+#include "core/settings.h"
 #include "video_core/renderer_base.h"
 #include "video_core/renderer_opengl/gl_rasterizer.h"
 
 namespace VideoCore {
 
-RendererBase::RendererBase(EmuWindow& window) : render_window{window} {}
+RendererBase::RendererBase(EmuWindow& window) : render_window{window} {
+    RefreshBaseSettings();
+}
+
 RendererBase::~RendererBase() = default;
 
-void RendererBase::UpdateCurrentFramebufferLayout() {
-    const Layout::FramebufferLayout& layout = render_window.GetFramebufferLayout();
+void RendererBase::RefreshBaseSettings() {
+    RefreshRasterizerSetting();
+    UpdateCurrentFramebufferLayout();
 
-    render_window.UpdateCurrentFramebufferLayout(layout.width, layout.height);
+    renderer_settings.use_framelimiter = Settings::values.toggle_framelimit;
 }
 
 void RendererBase::RefreshRasterizerSetting() {
     if (rasterizer == nullptr) {
         rasterizer = std::make_unique<RasterizerOpenGL>(render_window);
     }
+}
+
+void RendererBase::UpdateCurrentFramebufferLayout() {
+    const Layout::FramebufferLayout& layout = render_window.GetFramebufferLayout();
+
+    render_window.UpdateCurrentFramebufferLayout(layout.width, layout.height);
 }
 
 } // namespace VideoCore

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -17,9 +17,6 @@ namespace VideoCore {
 
 class RendererBase : NonCopyable {
 public:
-    /// Used to reference a framebuffer
-    enum kFramebuffer { kFramebuffer_VirtualXFB = 0, kFramebuffer_EFB, kFramebuffer_Texture };
-
     explicit RendererBase(EmuWindow& window);
     virtual ~RendererBase();
 

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <boost/optional.hpp>
-#include "common/assert.h"
 #include "common/common_types.h"
 #include "video_core/gpu.h"
 #include "video_core/rasterizer_interface.h"
@@ -14,6 +14,10 @@
 class EmuWindow;
 
 namespace VideoCore {
+
+struct RendererSettings {
+    std::atomic_bool use_framelimiter{false};
+};
 
 class RendererBase : NonCopyable {
 public:
@@ -28,9 +32,6 @@ public:
 
     /// Shutdown the renderer
     virtual void ShutDown() = 0;
-
-    /// Updates the framebuffer layout of the contained render window handle.
-    void UpdateCurrentFramebufferLayout();
 
     // Getter/setter functions:
     // ------------------------
@@ -51,13 +52,23 @@ public:
         return *rasterizer;
     }
 
-    void RefreshRasterizerSetting();
+    /// Refreshes the settings common to all renderers
+    void RefreshBaseSettings();
 
 protected:
+    /// Refreshes settings specific to the rasterizer.
+    void RefreshRasterizerSetting();
+
     EmuWindow& render_window; ///< Reference to the render window handle.
     std::unique_ptr<RasterizerInterface> rasterizer;
     f32 m_current_fps = 0.0f; ///< Current framerate, should be set by the renderer
     int m_current_frame = 0;  ///< Current frame, should be set by the renderer
+
+    RendererSettings renderer_settings;
+
+private:
+    /// Updates the framebuffer layout of the contained render window handle.
+    void UpdateCurrentFramebufferLayout();
 };
 
 } // namespace VideoCore

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -9,8 +9,6 @@
 
 namespace VideoCore {
 
-std::atomic<bool> g_toggle_framelimit_enabled;
-
 std::unique_ptr<RendererBase> CreateRenderer(EmuWindow& emu_window) {
     return std::make_unique<RendererOpenGL>(emu_window);
 }

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <atomic>
 #include <memory>
 
 class EmuWindow;
@@ -12,10 +11,6 @@ class EmuWindow;
 namespace VideoCore {
 
 class RendererBase;
-
-// TODO: Wrap these in a user settings struct along with any other graphics settings (often set from
-// qt ui)
-extern std::atomic<bool> g_toggle_framelimit_enabled;
 
 /**
  * Creates a renderer instance.

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -13,8 +13,6 @@ namespace VideoCore {
 
 class RendererBase;
 
-enum class Renderer { Software, OpenGL };
-
 // TODO: Wrap these in a user settings struct along with any other graphics settings (often set from
 // qt ui)
 extern std::atomic<bool> g_toggle_framelimit_enabled;


### PR DESCRIPTION
Instead, we make a struct for renderer settings and allow the renderer to update all of these settings, getting rid of the need for global-scoped variables.

This also uncovered a few indirect inclusions for certain headers, which this also fixes.

With this, we get rid of all main accessible global state within the video core 🎉