### PR TITLE
GPU/Shader: Implemented SSY and SYNC as a set_target/jump pair.

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -598,6 +598,13 @@ public:
         Unknown,
     };
 
+    /// Returns whether an opcode has an execution predicate field or not (ie, whether it can be
+    /// conditionally executed).
+    static bool IsPredicatedInstruction(Id opcode) {
+        // TODO(Subv): Add the rest of unpredicated instructions.
+        return opcode != Id::SSY;
+    }
+
     class Matcher {
     public:
         Matcher(const char* const name, u16 mask, u16 expected, OpCode::Id id, OpCode::Type type)

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -837,7 +837,11 @@ private:
         ASSERT_MSG(instr.pred.full_pred != Pred::NeverExecute,
                    "NeverExecute predicate not implemented");
 
-        if (instr.pred.pred_index != static_cast<u64>(Pred::UnusedIndex)) {
+        // Some instructions (like SSY) don't have a predicate field, they are always
+        // unconditionally executed.
+        bool can_be_predicated = OpCode::IsPredicatedInstruction(opcode->GetId());
+
+        if (can_be_predicated && instr.pred.pred_index != static_cast<u64>(Pred::UnusedIndex)) {
             shader.AddLine("if (" +
                            GetPredicateCondition(instr.pred.pred_index, instr.negate_pred != 0) +
                            ')');
@@ -1709,7 +1713,7 @@ private:
         }
 
         // Close the predicate condition scope.
-        if (instr.pred.pred_index != static_cast<u64>(Pred::UnusedIndex)) {
+        if (can_be_predicated && instr.pred.pred_index != static_cast<u64>(Pred::UnusedIndex)) {
             --shader.scope;
             shader.AddLine('}');
         }


### PR DESCRIPTION
Also don't attempt to predicate instructions that don't have a predicate field.

This is used by SMO, Splatoon 2, and some other games.