### PR TITLE
RasterizerGL: Ignore invalid/unset vertex attributes.

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -93,6 +93,7 @@ public:
 
         struct VertexAttribute {
             enum class Size : u32 {
+                Invalid = 0x0,
                 Size_32_32_32_32 = 0x01,
                 Size_32_32_32 = 0x02,
                 Size_16_16_16_16 = 0x03,
@@ -256,6 +257,10 @@ public:
 
             bool IsNormalized() const {
                 return (type == Type::SignedNorm) || (type == Type::UnsignedNorm);
+            }
+
+            bool IsValid() const {
+                return size != Size::Invalid;
             }
         };
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -161,11 +161,16 @@ std::pair<u8*, GLintptr> RasterizerOpenGL::SetupVertexArrays(u8* array_ptr,
     // assume every shader uses them all.
     for (unsigned index = 0; index < 16; ++index) {
         auto& attrib = regs.vertex_attrib_format[index];
+
+        // Ignore invalid attributes.
+        if (!attrib.IsValid())
+            continue;
+
+        auto& buffer = regs.vertex_array[attrib.buffer];
         LOG_TRACE(HW_GPU, "vertex attrib {}, count={}, size={}, type={}, offset={}, normalize={}",
                   index, attrib.ComponentCount(), attrib.SizeString(), attrib.TypeString(),
                   attrib.offset.Value(), attrib.IsNormalized());
 
-        auto& buffer = regs.vertex_array[attrib.buffer];
         ASSERT(buffer.IsEnabled());
 
         glEnableVertexAttribArray(index);


### PR DESCRIPTION
This should make the es2gears example not crash anymore.