### PR TITLE
Fixed invalid cast in loader

### DIFF
--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -126,7 +126,7 @@ constexpr std::array<const char*, 36> RESULT_MESSAGES{
 };
 
 std::string GetMessageForResultStatus(ResultStatus status) {
-    return GetMessageForResultStatus(static_cast<size_t>(status));
+    return GetMessageForResultStatus(static_cast<u16>(status));
 }
 
 std::string GetMessageForResultStatus(u16 status) {


### PR DESCRIPTION
GetMessageForResultStatus takes a u16, not a size_t.