### PR TITLE
Added GetAudioRendererSampleRate, GetAudioRendererSampleCount & GetAudioRendererMixBufferCount

### DIFF
--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -27,7 +27,7 @@ AudioRenderer::AudioRenderer(AudioRendererParameter params,
 }
 
 u32 AudioRenderer::GetSampleRate() const {
-    return STREAM_SAMPLE_RATE;
+    return worker_params.sample_rate;
 }
 
 u32 AudioRenderer::GetSampleCount() const {

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -26,6 +26,18 @@ AudioRenderer::AudioRenderer(AudioRendererParameter params,
     QueueMixedBuffer(2);
 }
 
+u32 AudioRenderer::GetSampleRate() const {
+    return STREAM_SAMPLE_RATE;
+}
+
+u32 AudioRenderer::GetSampleCount() const {
+    return worker_params.sample_count;
+}
+
+u32 AudioRenderer::GetMixBufferCount() const {
+    return worker_params.mix_buffer_count;
+}
+
 std::vector<u8> AudioRenderer::UpdateAudioRenderer(const std::vector<u8>& input_params) {
     // Copy UpdateDataHeader struct
     UpdateDataHeader config{};

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -26,7 +26,7 @@ enum class PlayState : u8 {
 struct AudioRendererParameter {
     u32_le sample_rate;
     u32_le sample_count;
-    u32_le unknown_8;
+    u32_le mix_buffer_count;
     u32_le unknown_c;
     u32_le voice_count;
     u32_le sink_count;
@@ -160,6 +160,9 @@ public:
     std::vector<u8> UpdateAudioRenderer(const std::vector<u8>& input_params);
     void QueueMixedBuffer(Buffer::Tag tag);
     void ReleaseAndQueueBuffers();
+    u32 GetSampleRate() const;
+    u32 GetSampleCount() const;
+    u32 GetMixBufferCount() const;
 
 private:
     class VoiceState {

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -20,9 +20,9 @@ public:
     explicit IAudioRenderer(AudioCore::AudioRendererParameter audren_params)
         : ServiceFramework("IAudioRenderer") {
         static const FunctionInfo functions[] = {
-            {0, nullptr, "GetAudioRendererSampleRate"},
-            {1, nullptr, "GetAudioRendererSampleCount"},
-            {2, nullptr, "GetAudioRendererMixBufferCount"},
+            {0, &IAudioRenderer::GetAudioRendererSampleRate, "GetAudioRendererSampleRate"},
+            {1, &IAudioRenderer::GetAudioRendererSampleCount, "GetAudioRendererSampleCount"},
+            {2, &IAudioRenderer::GetAudioRendererMixBufferCount, "GetAudioRendererMixBufferCount"},
             {3, nullptr, "GetAudioRendererState"},
             {4, &IAudioRenderer::RequestUpdateAudioRenderer, "RequestUpdateAudioRenderer"},
             {5, &IAudioRenderer::StartAudioRenderer, "StartAudioRenderer"},
@@ -43,6 +43,29 @@ public:
 private:
     void UpdateAudioCallback() {
         system_event->Signal();
+    }
+
+    void GetAudioRendererSampleRate(Kernel::HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push<u32>(
+            renderer->GetSampleRate()); // Switch uses the worker_params value, but we always
+                                        // have a fixed sample rate so return that instead
+        LOG_WARNING(Service_Audio, "(STUBBED) called");
+    }
+
+    void GetAudioRendererSampleCount(Kernel::HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push<u32>(renderer->GetSampleCount());
+        LOG_DEBUG(Service_Audio, "called");
+    }
+
+    void GetAudioRendererMixBufferCount(Kernel::HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push<u32>(renderer->GetMixBufferCount());
+        LOG_DEBUG(Service_Audio, "called");
     }
 
     void RequestUpdateAudioRenderer(Kernel::HLERequestContext& ctx) {
@@ -189,7 +212,7 @@ void AudRenU::GetAudioRendererWorkBufferSize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     auto params = rp.PopRaw<AudioCore::AudioRendererParameter>();
 
-    u64 buffer_sz = Common::AlignUp(4 * params.unknown_8, 0x40);
+    u64 buffer_sz = Common::AlignUp(4 * params.mix_buffer_count, 0x40);
     buffer_sz += params.unknown_c * 1024;
     buffer_sz += 0x940 * (params.unknown_c + 1);
     buffer_sz += 0x3F0 * params.voice_count;
@@ -197,7 +220,7 @@ void AudRenU::GetAudioRendererWorkBufferSize(Kernel::HLERequestContext& ctx) {
     buffer_sz += Common::AlignUp(8 * params.voice_count, 0x10);
     buffer_sz +=
         Common::AlignUp((0x3C0 * (params.sink_count + params.unknown_c) + 4 * params.sample_count) *
-                            (params.unknown_8 + 6),
+                            (params.mix_buffer_count + 6),
                         0x40);
 
     if (IsFeatureSupported(AudioFeatures::Splitter, params.revision)) {

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -48,10 +48,8 @@ private:
     void GetAudioRendererSampleRate(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u32>(
-            renderer->GetSampleRate()); // Switch uses the worker_params value, but we always
-                                        // have a fixed sample rate so return that instead
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        rb.Push<u32>(renderer->GetSampleRate());
+        LOG_DEBUG(Service_Audio, "called");
     }
 
     void GetAudioRendererSampleCount(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
~~GetAudioRendererSampleRate is set as a "STUB" as a game could check if the sample rate it sent and the sample rate it wants don't match. Just a thought of something which could happen so keeping it as stub for the mean time~~
GetAudioRendererSampleRate now is accurate as request by @bunnei 