### PR TITLE
card_image: Simplify return statement of GetSubdirectories()

### DIFF
--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -107,11 +107,11 @@ VirtualFile XCI::GetNCAFileByType(NCAContentType type) const {
     return nullptr;
 }
 
-std::vector<std::shared_ptr<VfsFile>> XCI::GetFiles() const {
+std::vector<VirtualFile> XCI::GetFiles() const {
     return {};
 }
 
-std::vector<std::shared_ptr<VfsDirectory>> XCI::GetSubdirectories() const {
+std::vector<VirtualDir> XCI::GetSubdirectories() const {
     return {};
 }
 
@@ -119,7 +119,7 @@ std::string XCI::GetName() const {
     return file->GetName();
 }
 
-std::shared_ptr<VfsDirectory> XCI::GetParentDirectory() const {
+VirtualDir XCI::GetParentDirectory() const {
     return file->GetContainingDirectory();
 }
 

--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -112,7 +112,7 @@ std::vector<std::shared_ptr<VfsFile>> XCI::GetFiles() const {
 }
 
 std::vector<std::shared_ptr<VfsDirectory>> XCI::GetSubdirectories() const {
-    return std::vector<std::shared_ptr<VfsDirectory>>();
+    return {};
 }
 
 std::string XCI::GetName() const {

--- a/src/core/file_sys/card_image.h
+++ b/src/core/file_sys/card_image.h
@@ -71,13 +71,13 @@ public:
     std::shared_ptr<NCA> GetNCAByType(NCAContentType type) const;
     VirtualFile GetNCAFileByType(NCAContentType type) const;
 
-    std::vector<std::shared_ptr<VfsFile>> GetFiles() const override;
+    std::vector<VirtualFile> GetFiles() const override;
 
-    std::vector<std::shared_ptr<VfsDirectory>> GetSubdirectories() const override;
+    std::vector<VirtualDir> GetSubdirectories() const override;
 
     std::string GetName() const override;
 
-    std::shared_ptr<VfsDirectory> GetParentDirectory() const override;
+    VirtualDir GetParentDirectory() const override;
 
 protected:
     bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;


### PR DESCRIPTION
We don't need to write out the construction long-form, we can just let the language itself work it out off the return type.