### PR TITLE
scheduler: Make HaveReadyThreads() a const member function

### DIFF
--- a/src/common/thread_queue_list.h
+++ b/src/common/thread_queue_list.h
@@ -26,9 +26,9 @@ struct ThreadQueueList {
     }
 
     // Only for debugging, returns priority level.
-    Priority contains(const T& uid) {
+    Priority contains(const T& uid) const {
         for (Priority i = 0; i < NUM_QUEUES; ++i) {
-            Queue& cur = queues[i];
+            const Queue& cur = queues[i];
             if (std::find(cur.data.cbegin(), cur.data.cend(), uid) != cur.data.cend()) {
                 return i;
             }
@@ -37,8 +37,8 @@ struct ThreadQueueList {
         return -1;
     }
 
-    T get_first() {
-        Queue* cur = first;
+    T get_first() const {
+        const Queue* cur = first;
         while (cur != nullptr) {
             if (!cur->data.empty()) {
                 return cur->data.front();

--- a/src/common/thread_queue_list.h
+++ b/src/common/thread_queue_list.h
@@ -16,7 +16,7 @@ struct ThreadQueueList {
     //               (dynamically resizable) circular buffers to remove their overhead when
     //               inserting and popping.
 
-    typedef unsigned int Priority;
+    using Priority = unsigned int;
 
     // Number of priority levels. (Valid levels are [0..NUM_QUEUES).)
     static const Priority NUM_QUEUES = N;

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -25,7 +25,7 @@ Scheduler::~Scheduler() {
     }
 }
 
-bool Scheduler::HaveReadyThreads() {
+bool Scheduler::HaveReadyThreads() const {
     std::lock_guard<std::mutex> lock(scheduler_mutex);
     return ready_queue.get_first() != nullptr;
 }

--- a/src/core/hle/kernel/scheduler.h
+++ b/src/core/hle/kernel/scheduler.h
@@ -21,7 +21,7 @@ public:
     ~Scheduler();
 
     /// Returns whether there are any threads that are ready to run.
-    bool HaveReadyThreads();
+    bool HaveReadyThreads() const;
 
     /// Reschedules to the next available thread (call after current thread is suspended)
     void Reschedule();


### PR DESCRIPTION
This function doesn't modify instance state, so the const qualifier can be added to it.