### PR TITLE
vfs: Make type hierarchy objects classes instead of structs

### DIFF
--- a/src/core/file_sys/vfs.h
+++ b/src/core/file_sys/vfs.h
@@ -36,7 +36,7 @@ enum class VfsEntryType {
 // functionality, they will need to override.
 class VfsFilesystem : NonCopyable {
 public:
-    VfsFilesystem(VirtualDir root);
+    explicit VfsFilesystem(VirtualDir root);
     virtual ~VfsFilesystem();
 
     // Gets the friendly name for the filesystem.

--- a/src/core/file_sys/vfs.h
+++ b/src/core/file_sys/vfs.h
@@ -15,9 +15,9 @@
 
 namespace FileSys {
 
-struct VfsFilesystem;
-struct VfsFile;
-struct VfsDirectory;
+class VfsDirectory;
+class VfsFile;
+class VfsFilesystem;
 
 // Convenience typedefs to use Vfs* interfaces
 using VirtualFilesystem = std::shared_ptr<VfsFilesystem>;
@@ -34,7 +34,8 @@ enum class VfsEntryType {
 // A class representing an abstract filesystem. A default implementation given the root VirtualDir
 // is provided for convenience, but if the Vfs implementation has any additional state or
 // functionality, they will need to override.
-struct VfsFilesystem : NonCopyable {
+class VfsFilesystem : NonCopyable {
+public:
     VfsFilesystem(VirtualDir root);
     virtual ~VfsFilesystem();
 
@@ -81,7 +82,8 @@ protected:
 };
 
 // A class representing a file in an abstract filesystem.
-struct VfsFile : NonCopyable {
+class VfsFile : NonCopyable {
+public:
     virtual ~VfsFile();
 
     // Retrieves the file name.
@@ -179,7 +181,8 @@ struct VfsFile : NonCopyable {
 };
 
 // A class representing a directory in an abstract filesystem.
-struct VfsDirectory : NonCopyable {
+class VfsDirectory : NonCopyable {
+public:
     virtual ~VfsDirectory();
 
     // Retrives the file located at path as if the current directory was root. Returns nullptr if
@@ -295,7 +298,8 @@ protected:
 
 // A convenience partial-implementation of VfsDirectory that stubs out methods that should only work
 // if writable. This is to avoid redundant empty methods everywhere.
-struct ReadOnlyVfsDirectory : public VfsDirectory {
+class ReadOnlyVfsDirectory : public VfsDirectory {
+public:
     bool IsWritable() const override;
     bool IsReadable() const override;
     std::shared_ptr<VfsDirectory> CreateSubdirectory(std::string_view name) override;

--- a/src/core/file_sys/vfs_offset.h
+++ b/src/core/file_sys/vfs_offset.h
@@ -15,7 +15,8 @@ namespace FileSys {
 // Similar to seeking to an offset.
 // If the file is writable, operations that would write past the end of the offset file will expand
 // the size of this wrapper.
-struct OffsetVfsFile : public VfsFile {
+class OffsetVfsFile : public VfsFile {
+public:
     OffsetVfsFile(std::shared_ptr<VfsFile> file, size_t size, size_t offset = 0,
                   std::string new_name = "", VirtualDir new_parent = nullptr);
 

--- a/src/core/file_sys/vfs_vector.h
+++ b/src/core/file_sys/vfs_vector.h
@@ -10,7 +10,8 @@ namespace FileSys {
 
 // An implementation of VfsDirectory that maintains two vectors for subdirectories and files.
 // Vector data is supplied upon construction.
-struct VectorVfsDirectory : public VfsDirectory {
+class VectorVfsDirectory : public VfsDirectory {
+public:
     explicit VectorVfsDirectory(std::vector<VirtualFile> files = {},
                                 std::vector<VirtualDir> dirs = {}, VirtualDir parent = nullptr,
                                 std::string name = "");

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -23,7 +23,7 @@ class HLERequestContext;
 } // namespace Kernel
 
 namespace FileSys {
-struct VfsFilesystem;
+class VfsFilesystem;
 }
 
 namespace Service {


### PR DESCRIPTION
Given these are used to form a type hierarchy (and have invariants), these should really be classes. If they were just a plain set of data it would be preferable to use struct.