### PR TITLE
Kernel/Mutex: Don't duplicate threads in the mutex waiter list.

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -706,8 +706,7 @@ static ResultCode SignalProcessWideKey(VAddr condition_variable_addr, s32 target
             Handle owner_handle = static_cast<Handle>(mutex_val & Mutex::MutexOwnerMask);
             auto owner = g_handle_table.Get<Thread>(owner_handle);
             ASSERT(owner);
-            ASSERT(thread->status != ThreadStatus::Running);
-            thread->status = ThreadStatus::WaitMutex;
+            ASSERT(thread->status == ThreadStatus::WaitMutex);
             thread->wakeup_callback = nullptr;
 
             owner->AddMutexWaiter(thread);


### PR DESCRIPTION
Exit from AddMutexWaiter early if the thread is already waiting for a mutex owned by the owner thread.

This accounts for the possibility of a thread that is waiting on a condition variable being awakened twice in a row.

Also added more validation asserts.

This should fix one of the random crashes in Breath Of The Wild.