### PR TITLE
arm_dynarmic: Remove IsExecuting check from PrepareReschedule

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -243,9 +243,7 @@ void ARM_Dynarmic::LoadContext(const ThreadContext& ctx) {
 }
 
 void ARM_Dynarmic::PrepareReschedule() {
-    if (jit->IsExecuting()) {
-        jit->HaltExecution();
-    }
+    jit->HaltExecution();
 }
 
 void ARM_Dynarmic::ClearInstructionCache() {


### PR DESCRIPTION
No longer required. HaltExecution is a no-op if it is not currently executing.