### PR TITLE
mm_u: Move interface class into the cpp file

### DIFF
--- a/src/core/hle/service/mm/mm_u.cpp
+++ b/src/core/hle/service/mm/mm_u.cpp
@@ -14,12 +14,12 @@ public:
     explicit MM_U() : ServiceFramework{"mm:u"} {
         // clang-format off
         static const FunctionInfo functions[] = {
-            {0, nullptr, "InitializeOld"},
-            {1, nullptr, "FinalizeOld"},
-            {2, nullptr, "SetAndWaitOld"},
-            {3, nullptr, "GetOld"},
+            {0, &MM_U::Initialize, "InitializeOld"},
+            {1, &MM_U::Finalize, "FinalizeOld"},
+            {2, &MM_U::SetAndWait, "SetAndWaitOld"},
+            {3, &MM_U::Get, "GetOld"},
             {4, &MM_U::Initialize, "Initialize"},
-            {5, nullptr, "Finalize"},
+            {5, &MM_U::Finalize, "Finalize"},
             {6, &MM_U::SetAndWait, "SetAndWait"},
             {7, &MM_U::Get, "Get"},
         };
@@ -30,6 +30,12 @@ public:
 
 private:
     void Initialize(Kernel::HLERequestContext& ctx) {
+        LOG_WARNING(Service_MM, "(STUBBED) called");
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+    }
+
+    void Finalize(Kernel::HLERequestContext& ctx) {
         LOG_WARNING(Service_MM, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/mm/mm_u.cpp
+++ b/src/core/hle/service/mm/mm_u.cpp
@@ -9,42 +9,57 @@
 
 namespace Service::MM {
 
+class MM_U final : public ServiceFramework<MM_U> {
+public:
+    explicit MM_U() : ServiceFramework{"mm:u"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "InitializeOld"},
+            {1, nullptr, "FinalizeOld"},
+            {2, nullptr, "SetAndWaitOld"},
+            {3, nullptr, "GetOld"},
+            {4, &MM_U::Initialize, "Initialize"},
+            {5, nullptr, "Finalize"},
+            {6, &MM_U::SetAndWait, "SetAndWait"},
+            {7, &MM_U::Get, "Get"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+
+private:
+    void Initialize(Kernel::HLERequestContext& ctx) {
+        LOG_WARNING(Service_MM, "(STUBBED) called");
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+    }
+
+    void SetAndWait(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        min = rp.Pop<u32>();
+        max = rp.Pop<u32>();
+        current = min;
+
+        LOG_WARNING(Service_MM, "(STUBBED) called, min=0x{:X}, max=0x{:X}", min, max);
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+    }
+
+    void Get(Kernel::HLERequestContext& ctx) {
+        LOG_WARNING(Service_MM, "(STUBBED) called");
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push(current);
+    }
+
+    u32 min{0};
+    u32 max{0};
+    u32 current{0};
+};
+
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     std::make_shared<MM_U>()->InstallAsService(service_manager);
-}
-
-void MM_U::Initialize(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_MM, "(STUBBED) called");
-    IPC::ResponseBuilder rb{ctx, 2};
-    rb.Push(RESULT_SUCCESS);
-}
-
-void MM_U::SetAndWait(Kernel::HLERequestContext& ctx) {
-    IPC::RequestParser rp{ctx};
-    min = rp.Pop<u32>();
-    max = rp.Pop<u32>();
-    current = min;
-
-    LOG_WARNING(Service_MM, "(STUBBED) called, min=0x{:X}, max=0x{:X}", min, max);
-    IPC::ResponseBuilder rb{ctx, 2};
-    rb.Push(RESULT_SUCCESS);
-}
-
-void MM_U::Get(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_MM, "(STUBBED) called");
-    IPC::ResponseBuilder rb{ctx, 3};
-    rb.Push(RESULT_SUCCESS);
-    rb.Push(current);
-}
-
-MM_U::MM_U() : ServiceFramework("mm:u") {
-    static const FunctionInfo functions[] = {
-        {0, nullptr, "InitializeOld"},        {1, nullptr, "FinalizeOld"},
-        {2, nullptr, "SetAndWaitOld"},        {3, nullptr, "GetOld"},
-        {4, &MM_U::Initialize, "Initialize"}, {5, nullptr, "Finalize"},
-        {6, &MM_U::SetAndWait, "SetAndWait"}, {7, &MM_U::Get, "Get"},
-    };
-    RegisterHandlers(functions);
 }
 
 } // namespace Service::MM

--- a/src/core/hle/service/mm/mm_u.h
+++ b/src/core/hle/service/mm/mm_u.h
@@ -8,21 +8,6 @@
 
 namespace Service::MM {
 
-class MM_U final : public ServiceFramework<MM_U> {
-public:
-    MM_U();
-    ~MM_U() = default;
-
-private:
-    void Initialize(Kernel::HLERequestContext& ctx);
-    void SetAndWait(Kernel::HLERequestContext& ctx);
-    void Get(Kernel::HLERequestContext& ctx);
-
-    u32 min{0};
-    u32 max{0};
-    u32 current{0};
-};
-
 /// Registers all MM services with the specified service manager.
 void InstallInterfaces(SM::ServiceManager& service_manager);
 


### PR DESCRIPTION
Moves it into the cpp file so any changes to it don't require rebuilds of everything else that includes the mm_u header. While we're at it, we can forward all of the old functions to passthrough to the implementations to make it consistent.