### PR TITLE
emu_window: Ensure WindowConfig members are always initialized

### DIFF
--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -34,9 +34,9 @@ class EmuWindow {
 public:
     /// Data structure to store emuwindow configuration
     struct WindowConfig {
-        bool fullscreen;
-        int res_width;
-        int res_height;
+        bool fullscreen = false;
+        int res_width = 0;
+        int res_height = 0;
         std::pair<unsigned, unsigned> min_client_area_size;
     };
 


### PR DESCRIPTION
Previously we weren't always initializing all members of the struct. Prevents potentially wonky behavior from occurring.