### PR TITLE
loader: Remove address mapping remnants from citra

### DIFF
--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -118,7 +118,6 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(
 
     process->program_id = metadata.GetTitleID();
     process->svc_access_mask.set();
-    process->address_mappings = default_address_mappings;
     process->resource_limit =
         Kernel::ResourceLimit::GetForCategory(Kernel::ResourceLimitCategory::APPLICATION);
     process->Run(Memory::PROCESS_IMAGE_VADDR, metadata.GetMainThreadPriority(),

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -398,7 +398,6 @@ ResultStatus AppLoader_ELF::Load(Kernel::SharedPtr<Kernel::Process>& process) {
 
     process->LoadModule(codeset, codeset->entrypoint);
     process->svc_access_mask.set();
-    process->address_mappings = default_address_mappings;
 
     // Attach the default resource limit (APPLICATION) to the process
     process->resource_limit =

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -17,12 +17,6 @@
 
 namespace Loader {
 
-const std::initializer_list<Kernel::AddressMapping> default_address_mappings = {
-    {0x1FF50000, 0x8000, true},    // part of DSP RAM
-    {0x1FF70000, 0x8000, true},    // part of DSP RAM
-    {0x1F000000, 0x600000, false}, // entire VRAM
-};
-
 FileType IdentifyFile(FileSys::VirtualFile file) {
     FileType type;
 

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <algorithm>
-#include <initializer_list>
 #include <memory>
 #include <string>
 #include <utility>
@@ -206,12 +205,6 @@ protected:
     FileSys::VirtualFile file;
     bool is_loaded = false;
 };
-
-/**
- * Common address mappings found in most games, used for binary formats that don't have this
- * information.
- */
-extern const std::initializer_list<Kernel::AddressMapping> default_address_mappings;
 
 /**
  * Identifies a bootable file and return a suitable loader

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -186,7 +186,6 @@ ResultStatus AppLoader_NRO::Load(Kernel::SharedPtr<Kernel::Process>& process) {
     }
 
     process->svc_access_mask.set();
-    process->address_mappings = default_address_mappings;
     process->resource_limit =
         Kernel::ResourceLimit::GetForCategory(Kernel::ResourceLimitCategory::APPLICATION);
     process->Run(base_addr, THREADPRIO_DEFAULT, Memory::DEFAULT_STACK_SIZE);

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -152,7 +152,6 @@ ResultStatus AppLoader_NSO::Load(Kernel::SharedPtr<Kernel::Process>& process) {
     LOG_DEBUG(Loader, "loaded module {} @ 0x{:X}", file->GetName(), Memory::PROCESS_IMAGE_VADDR);
 
     process->svc_access_mask.set();
-    process->address_mappings = default_address_mappings;
     process->resource_limit =
         Kernel::ResourceLimit::GetForCategory(Kernel::ResourceLimitCategory::APPLICATION);
     process->Run(Memory::PROCESS_IMAGE_VADDR, THREADPRIO_DEFAULT, Memory::DEFAULT_STACK_SIZE);


### PR DESCRIPTION
These mappings are leftovers from citra and don't apply to the Switch.