### PR TITLE
loader/{nca, xci}: Remove unnecessary includes and unused member variables

### DIFF
--- a/src/core/loader/nca.cpp
+++ b/src/core/loader/nca.cpp
@@ -3,27 +3,21 @@
 // Refer to the license.txt file included.
 
 #include <utility>
-#include <vector>
 
 #include "common/file_util.h"
 #include "common/logging/log.h"
-#include "common/string_util.h"
-#include "common/swap.h"
-#include "core/core.h"
 #include "core/file_sys/content_archive.h"
-#include "core/file_sys/program_metadata.h"
-#include "core/gdbstub/gdbstub.h"
 #include "core/hle/kernel/process.h"
-#include "core/hle/kernel/resource_limit.h"
 #include "core/hle/service/filesystem/filesystem.h"
+#include "core/loader/deconstructed_rom_directory.h"
 #include "core/loader/nca.h"
-#include "core/loader/nso.h"
-#include "core/memory.h"
 
 namespace Loader {
 
 AppLoader_NCA::AppLoader_NCA(FileSys::VirtualFile file_)
     : AppLoader(std::move(file_)), nca(std::make_unique<FileSys::NCA>(file)) {}
+
+AppLoader_NCA::~AppLoader_NCA() = default;
 
 FileType AppLoader_NCA::IdentifyType(const FileSys::VirtualFile& file) {
     FileSys::NCA nca(file);
@@ -82,7 +76,5 @@ ResultStatus AppLoader_NCA::ReadProgramId(u64& out_program_id) {
     out_program_id = nca->GetTitleId();
     return ResultStatus::Success;
 }
-
-AppLoader_NCA::~AppLoader_NCA() = default;
 
 } // namespace Loader

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -4,20 +4,24 @@
 
 #pragma once
 
-#include <string>
 #include "common/common_types.h"
-#include "core/file_sys/content_archive.h"
-#include "core/file_sys/program_metadata.h"
+#include "core/file_sys/vfs.h"
 #include "core/hle/kernel/object.h"
 #include "core/loader/loader.h"
-#include "deconstructed_rom_directory.h"
+
+namespace FileSys {
+class NCA;
+}
 
 namespace Loader {
+
+class AppLoader_DeconstructedRomDirectory;
 
 /// Loads an NCA file
 class AppLoader_NCA final : public AppLoader {
 public:
     explicit AppLoader_NCA(FileSys::VirtualFile file);
+    ~AppLoader_NCA() override;
 
     /**
      * Returns the type of the file
@@ -35,12 +39,7 @@ public:
     ResultStatus ReadRomFS(FileSys::VirtualFile& dir) override;
     ResultStatus ReadProgramId(u64& out_program_id) override;
 
-    ~AppLoader_NCA();
-
 private:
-    FileSys::ProgramMetadata metadata;
-
-    FileSys::NCAHeader header;
     std::unique_ptr<FileSys::NCA> nca;
     std::unique_ptr<AppLoader_DeconstructedRomDirectory> directory_loader;
 };

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -4,22 +4,14 @@
 
 #include <vector>
 
-#include "common/file_util.h"
-#include "common/logging/log.h"
-#include "common/string_util.h"
-#include "common/swap.h"
-#include "core/core.h"
+#include "common/common_types.h"
+#include "core/file_sys/card_image.h"
 #include "core/file_sys/content_archive.h"
 #include "core/file_sys/control_metadata.h"
-#include "core/file_sys/program_metadata.h"
 #include "core/file_sys/romfs.h"
-#include "core/gdbstub/gdbstub.h"
 #include "core/hle/kernel/process.h"
-#include "core/hle/kernel/resource_limit.h"
-#include "core/hle/service/filesystem/filesystem.h"
-#include "core/loader/nso.h"
+#include "core/loader/nca.h"
 #include "core/loader/xci.h"
-#include "core/memory.h"
 
 namespace Loader {
 

--- a/src/core/loader/xci.h
+++ b/src/core/loader/xci.h
@@ -6,11 +6,17 @@
 
 #include <memory>
 #include "common/common_types.h"
-#include "core/file_sys/card_image.h"
+#include "core/file_sys/vfs.h"
 #include "core/loader/loader.h"
-#include "core/loader/nca.h"
+
+namespace FileSys {
+class NACP;
+class XCI;
+} // namespace FileSys
 
 namespace Loader {
+
+class AppLoader_NCA;
 
 /// Loads an XCI file
 class AppLoader_XCI final : public AppLoader {
@@ -37,8 +43,6 @@ public:
     ResultStatus ReadTitle(std::string& title) override;
 
 private:
-    FileSys::ProgramMetadata metadata;
-
     std::unique_ptr<FileSys::XCI> xci;
     std::unique_ptr<AppLoader_NCA> nca_loader;
 


### PR DESCRIPTION
Many of these aren't necessary and will cause this file to be required to be recompiled whenever any changes to those files are made, which lengthens compile times for no reason.
