### PR TITLE
gl_rasterizer_cache: Add RGBA16U to PixelFormatFromTextureFormat.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -354,7 +354,15 @@ struct SurfaceParams {
                          static_cast<u32>(component_type));
             UNREACHABLE();
         case Tegra::Texture::TextureFormat::R16_G16_B16_A16:
-            return PixelFormat::RGBA16F;
+            switch (component_type) {
+            case Tegra::Texture::ComponentType::UNORM:
+                return PixelFormat::RGBA16U;
+            case Tegra::Texture::ComponentType::FLOAT:
+                return PixelFormat::RGBA16F;
+            }
+            LOG_CRITICAL(HW_GPU, "Unimplemented component_type={}",
+                         static_cast<u32>(component_type));
+            UNREACHABLE();
         case Tegra::Texture::TextureFormat::BF10GF11RF11:
             return PixelFormat::R11FG11FB10F;
         case Tegra::Texture::TextureFormat::R32_G32_B32_A32:


### PR DESCRIPTION
- Used by Breath of the Wild.