### PR TITLE
lm: Handle threads and modules within the logger

### DIFF
--- a/src/core/hle/service/lm/lm.cpp
+++ b/src/core/hle/service/lm/lm.cpp
@@ -160,7 +160,7 @@ private:
         if (header.IsTailLog()) {
             switch (header.severity) {
             case MessageHeader::Severity::Trace:
-                LOG_TRACE(Debug_Emulated, "{}", log_stream.str());
+                LOG_DEBUG(Debug_Emulated, "{}", log_stream.str());
                 break;
             case MessageHeader::Severity::Info:
                 LOG_INFO(Debug_Emulated, "{}", log_stream.str());

--- a/src/core/hle/service/lm/lm.cpp
+++ b/src/core/hle/service/lm/lm.cpp
@@ -92,7 +92,11 @@ private:
 
         // Parse out log metadata
         u32 line{};
-        std::string message, filename, function;
+        std::string module;
+        std::string message;
+        std::string filename;
+        std::string function;
+        std::string thread;
         while (addr < end_addr) {
             const Field field{static_cast<Field>(Memory::Read8(addr++))};
             const size_t length{Memory::Read8(addr++)};
@@ -102,6 +106,8 @@ private:
             }
 
             switch (field) {
+            case Field::Skip:
+                break;
             case Field::Message:
                 message = Memory::ReadCString(addr, length);
                 break;
@@ -113,6 +119,12 @@ private:
                 break;
             case Field::Function:
                 function = Memory::ReadCString(addr, length);
+                break;
+            case Field::Module:
+                module = Memory::ReadCString(addr, length);
+                break;
+            case Field::Thread:
+                thread = Memory::ReadCString(addr, length);
                 break;
             }
 
@@ -128,11 +140,17 @@ private:
         if (!filename.empty()) {
             log_stream << filename << ':';
         }
+        if (!module.empty()) {
+            log_stream << module << ':';
+        }
         if (!function.empty()) {
             log_stream << function << ':';
         }
         if (line) {
             log_stream << std::to_string(line) << ':';
+        }
+        if (!thread.empty()) {
+            log_stream << thread << ':';
         }
         if (log_stream.str().length() > 0 && log_stream.str().back() == ':') {
             log_stream << ' ';


### PR DESCRIPTION
The thread field serves to indicate which thread a log is related to and provides the length of the thread's name, so we can print that out, ditto for modules.

Now we can know what threads are potentially spawning off logging messages (for example Lydie & Suelle bounces between `MainThread` and `LoadingThread` when initializing the game).

This also drops the log type used for trace logs down to `LOG_DEBUG`, because `LOG_TRACE` is only enabled when yuzu is compiled in debug mode. Debug mode is also quite slow, and so we're potentially throwing away logging messages that can provide value when trying to boot games.