### PR TITLE
loader: Make ResultStatus directly compatible with fmt

### DIFF
--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -4,11 +4,14 @@
 
 #include <array>
 #include <string>
-#include <core/loader/loader.h>
+
+#include <fmt/ostream.h>
+
 #include "common/logging/log.h"
 #include "core/file_sys/card_image.h"
 #include "core/file_sys/partition_filesystem.h"
 #include "core/file_sys/vfs_offset.h"
+#include "core/loader/loader.h"
 
 namespace FileSys {
 
@@ -142,7 +145,7 @@ Loader::ResultStatus XCI::AddNCAFromPartition(XCIPartition part) {
             const u16 error_id = static_cast<u16>(nca->GetStatus());
             LOG_CRITICAL(Loader, "Could not load NCA {}/{}, failed with error code {:04X} ({})",
                          partition_names[static_cast<size_t>(part)], nca->GetName(), error_id,
-                         Loader::GetMessageForResultStatus(nca->GetStatus()));
+                         nca->GetStatus());
         }
     }
 

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <memory>
+#include <ostream>
 #include <string>
 #include "common/logging/log.h"
 #include "common/string_util.h"
@@ -119,14 +120,9 @@ constexpr std::array<const char*, 36> RESULT_MESSAGES{
     "There is no control data available.",
 };
 
-std::string GetMessageForResultStatus(ResultStatus status) {
-    return GetMessageForResultStatus(static_cast<u16>(status));
-}
-
-std::string GetMessageForResultStatus(u16 status) {
-    if (status >= 36)
-        return "";
-    return RESULT_MESSAGES[status];
+std::ostream& operator<<(std::ostream& os, ResultStatus status) {
+    os << RESULT_MESSAGES.at(static_cast<size_t>(status));
+    return os;
 }
 
 /**

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <algorithm>
+#include <iosfwd>
 #include <memory>
 #include <string>
 #include <utility>
@@ -94,8 +95,7 @@ enum class ResultStatus : u16 {
     ErrorNoControl,
 };
 
-std::string GetMessageForResultStatus(ResultStatus status);
-std::string GetMessageForResultStatus(u16 status);
+std::ostream& operator<<(std::ostream& os, ResultStatus status);
 
 /// Interface for loading an application
 class AppLoader : NonCopyable {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -6,7 +6,10 @@
 #include <clocale>
 #include <memory>
 #include <thread>
+
+#include <fmt/ostream.h>
 #include <glad/glad.h>
+
 #define QT_NO_OPENGL
 #include <QDesktopWidget>
 #include <QFileDialog>
@@ -454,7 +457,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
                         "While attempting to load the ROM requested, an error occured. Please "
                         "refer to the yuzu wiki for more information or the yuzu discord for "
                         "additional help.\n\nError Code: {:04X}-{:04X}\nError Description: {}",
-                        loader_id, error_id, Loader::GetMessageForResultStatus(error_id))));
+                        loader_id, error_id, static_cast<Loader::ResultStatus>(error_id))));
             } else {
                 QMessageBox::critical(
                     this, tr("Error while loading ROM!"),

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -7,6 +7,8 @@
 #include <string>
 #include <thread>
 
+#include <fmt/ostream.h>
+
 #include "common/common_paths.h"
 #include "common/logging/backend.h"
 #include "common/logging/filter.h"
@@ -194,7 +196,7 @@ int main(int argc, char** argv) {
                          "While attempting to load the ROM requested, an error occured. Please "
                          "refer to the yuzu wiki for more information or the yuzu discord for "
                          "additional help.\n\nError Code: {:04X}-{:04X}\nError Description: {}",
-                         loader_id, error_id, Loader::GetMessageForResultStatus(error_id));
+                         loader_id, error_id, static_cast<Loader::ResultStatus>(error_id));
         }
     }
 


### PR DESCRIPTION
We can make the enum class type compatible with fmt by providing an overload of `operator<<`.

While we're at it, perform proper bounds checking. If something exceeds the array, it should be a hard fail, because it's, without a doubt, a programmer error in this case.