### PR TITLE
CoreTiming: Keep Cores synced

### DIFF
--- a/src/core/core_cpu.h
+++ b/src/core/core_cpu.h
@@ -30,7 +30,7 @@ public:
 
     void NotifyEnd();
 
-    bool Rendezvous();
+    bool Rendezvous(bool main_core);
 
 private:
     unsigned cores_waiting{NUM_CPU_CORES};

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -93,7 +93,7 @@ void UnregisterAllEvents() {
 
 void Init() {
     std::unique_lock<std::mutex> lock(mutex);
-    std::fill(downcount.begin(), downcount.end(), MAX_SLICE_LENGTH);
+    downcount.fill(MAX_SLICE_LENGTH);
     slice_length = MAX_SLICE_LENGTH;
     next_slice_length = MAX_SLICE_LENGTH;
     global_timer = 0;
@@ -183,8 +183,7 @@ void ForceExceptionCheck(s64 cycles) {
     if (downcount[0] > cycles) {
         // downcount is always (much) smaller than MAX_INT so we can safely cast cycles to an int
         // here. Account for cycles already executed by adjusting the g.slice_length
-        s64 crop_time = downcount[0] - static_cast<int>(cycles);
-        slice_length -= crop_time;
+        slice_length -= downcount[0] - static_cast<int>(cycles);
         downcount[0] = static_cast<int>(cycles);
         if (next_slice_length <= 0)
             next_slice_length = MAX_SLICE_LENGTH;
@@ -201,7 +200,7 @@ void MoveEvents() {
 
 void Advance() {
     std::unique_lock<std::mutex> lock(mutex);
-    size_t current_core = Core::System::GetInstance().CurrentCoreIndex();
+    const size_t current_core = Core::System::GetInstance().CurrentCoreIndex();
     if (current_core != 0) {
         downcount[current_core] = MAX_SLICE_LENGTH;
         return;

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -81,6 +81,7 @@ void MoveEvents();
 /// Pretend that the main CPU has executed enough cycles to reach the next event.
 void Idle();
 
+/// Checks if the Main Core executed less then MAX_SLICE_LENGTH
 bool MainSliceWasCropped();
 
 /// Clear all pending events. This should ONLY be done on exit.

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -40,7 +40,6 @@ void Shutdown();
  * doing something evil
  */
 u64 GetTicks();
-u64 GetIdleTicks();
 void AddTicks(u64 ticks);
 
 /**
@@ -81,6 +80,8 @@ void MoveEvents();
 
 /// Pretend that the main CPU has executed enough cycles to reach the next event.
 void Idle();
+
+bool MainSliceWasCropped();
 
 /// Clear all pending events. This should ONLY be done on exit.
 void ClearPendingEvents();


### PR DESCRIPTION
Keep Cores synced by having each core it's own downcount and let the main core run an intermediate run if it's slice_length was cropped

This is untested again, and has probably a lot of bugs. So please test and give me feadback