### PR TITLE
Shaders: Implemented I2F_C and F2I_C, along with the negation bits of the conversion instructions.

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1250,6 +1250,10 @@ private:
                     op_a = "abs(" + op_a + ')';
                 }
 
+                if (instr.conversion.negate_a) {
+                    op_a = "-(" + op_a + ')';
+                }
+
                 regs.SetRegisterToInteger(instr.gpr0, instr.conversion.is_output_signed, 0, op_a, 1,
                                           1, instr.alu.saturate_d, 0, instr.conversion.dest_size);
                 break;
@@ -1289,6 +1293,14 @@ private:
                 ASSERT_MSG(instr.conversion.src_size == Register::Size::Word, "Unimplemented");
                 std::string op_a = regs.GetRegisterAsFloat(instr.gpr20);
 
+                if (instr.conversion.abs_a) {
+                    op_a = "abs(" + op_a + ')';
+                }
+
+                if (instr.conversion.negate_a) {
+                    op_a = "-(" + op_a + ')';
+                }
+
                 switch (instr.conversion.f2f.rounding) {
                 case Tegra::Shader::F2fRoundingOp::None:
                     break;
@@ -1309,10 +1321,6 @@ private:
                                  static_cast<u32>(instr.conversion.f2f.rounding.Value()));
                     UNREACHABLE();
                     break;
-                }
-
-                if (instr.conversion.abs_a) {
-                    op_a = "abs(" + op_a + ')';
                 }
 
                 regs.SetRegisterToFloat(instr.gpr0, 0, op_a, 1, 1, instr.alu.saturate_d);

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1306,6 +1306,10 @@ private:
                     op_a = "abs(" + op_a + ')';
                 }
 
+                if (instr.conversion.negate_a) {
+                    op_a = "-(" + op_a + ')';
+                }
+
                 switch (instr.conversion.f2i.rounding) {
                 case Tegra::Shader::F2iRoundingOp::None:
                     break;

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1261,6 +1261,10 @@ private:
                     op_a = "abs(" + op_a + ')';
                 }
 
+                if (instr.conversion.negate_a) {
+                    op_a = "-(" + op_a + ')';
+                }
+
                 regs.SetRegisterToFloat(instr.gpr0, 0, op_a, 1, 1);
                 break;
             }

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1298,9 +1298,17 @@ private:
                 regs.SetRegisterToFloat(instr.gpr0, 0, op_a, 1, 1, instr.alu.saturate_d);
                 break;
             }
-            case OpCode::Id::F2I_R: {
+            case OpCode::Id::F2I_R:
+            case OpCode::Id::F2I_C: {
                 ASSERT_MSG(instr.conversion.src_size == Register::Size::Word, "Unimplemented");
-                std::string op_a = regs.GetRegisterAsFloat(instr.gpr20);
+                std::string op_a{};
+
+                if (instr.is_b_gpr) {
+                    op_a = regs.GetRegisterAsFloat(instr.gpr20);
+                } else {
+                    op_a = regs.GetUniform(instr.cbuf34.index, instr.cbuf34.offset,
+                                           GLSLRegister::Type::Float);
+                }
 
                 if (instr.conversion.abs_a) {
                     op_a = "abs(" + op_a + ')';


### PR DESCRIPTION
I2F_C and F2I_C are used by Super Mario Odyssey.

For some reason we weren't using the negation bits of the various conversion instructions, that's a pretty big bug, considering I've seen I2I and F2F being used to change the sign of values, I wonder if that fixes anything.