### PR TITLE
dynarmic: Update to 550d662

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -134,6 +134,9 @@ std::unique_ptr<Dynarmic::A64::Jit> ARM_Dynarmic::MakeJit() const {
     config.dczid_el0 = 4;
     config.ctr_el0 = 0x8444c004;
 
+    // Unpredictable instructions
+    config.define_unpredictable_behaviour = true;
+
     return std::make_unique<Dynarmic::A64::Jit>(config);
 }
 


### PR DESCRIPTION
**Blockers**:

* CNTFRQ_EL0 value is not set. (dynarmic defaults to 600000000 which may not be appropriate for the switch.)

Summary:

* A32 changes
* A few instruction implementations.
* Implemented CNTFRQ_EL0 register access.
* Defined unpredictable instruction `STXR W9, W9, [X0]` used in Crash N-Sane Trilogy.

API was changed in this update.

Changelog:

```
550d662 load_store_exclusive: Define s == t state to be Constraint_NONE
0b69381 A64/translate: Allow for unpredictable behaviour to be defined
6d236d4 system: Implement MRS CNTFRQ_EL0
6cbb6fb A32/testenv: Add missing headers
6729328 externals: Update xbyak to v5.67
1812bd2 Squashed 'externals/xbyak/' changes from 2794cde7..671fc805
9a95802 externals: Document subtrees
714a840 A64: Implement SQ{ADD, SUB}, and UQ{ADD, SUB}'s vector variants
8cab459 A64: Implement UQADD/UQSUB's scalar variants
18a8151 ir: Add opcodes for unsigned saturating add and subtract
a5660ee x64/reg_alloc: Use type alias for array returned by GetArgumentInfo()
29489b5 ir/value: Use type alias CoprocessorInfo for std::array<u8, 8>
e23ba26 status_register_access: Add support for bits 0 and 1 of mask to MSR
55190bd fuzz_with_unicorn: Split utility functions into fuzz_util
23b049d A32/translate/load_store: Correct detection of writeback
7ec9f15 A32/translate: Add TranslateSingleInstruction
efeecb4 A32/ir_emitter: Bug fix: IREmitter::ExceptionRaised using incorrect opcode
08d1d19 A32/decoders: Split instruction list into include file
2d929cc tests: Refactor unicorn_emu to allow for A32 unicorn
f672368 microinstruction: Improve assert messages
7ebff50 emit_x64_vector: EmitVectorNarrow16: AVX512 implementation
edce230 emit_x64_vector: EmitVectorNarrow32: prefer pblendw to loading constant
```