### PR TITLE
Shaders: Corrected the 'abs' and 'neg' bit usage in the float arithmetic instructions.

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -283,6 +283,10 @@ union Instruction {
     } alu;
 
     union {
+        BitField<48, 1, u64> negate_b;
+    } fmul;
+
+    union {
         BitField<48, 1, u64> is_signed;
     } shift;
 


### PR DESCRIPTION
We should definitely audit our shader generator for more errors like this.