### PR TITLE
Shaders: Write all the enabled color outputs when a fragment shader exits.

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -87,7 +87,7 @@ ProgramResult GenerateFragmentShader(const ShaderSetup& setup, const MaxwellFSCo
             .get_value_or({});
     out += R"(
 in vec4 position;
-out vec4 color;
+layout(location = 0) out vec4 color[8];
 
 layout (std140) uniform fs_config {
     vec4 viewport_flip;


### PR DESCRIPTION
We were only writing to the first render target before.
Note that this is only the GLSL side of the implementation, supporting multiple render targets requires more changes in the OpenGL renderer.