### PR TITLE
Shaders: Use the correct shader type when sampling textures.

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -524,9 +524,11 @@ public:
         LDG, // Load from global memory
         STG, // Store in global memory
         TEX,
-        TEXQ, // Texture Query
-        TEXS, // Texture Fetch with scalar/non-vec4 source/destinations
-        TLDS, // Texture Load with scalar/non-vec4 source/destinations
+        TEXQ,  // Texture Query
+        TEXS,  // Texture Fetch with scalar/non-vec4 source/destinations
+        TLDS,  // Texture Load with scalar/non-vec4 source/destinations
+        TLD4,  // Texture Load 4
+        TLD4S, // Texture Load 4 with scalar / non - vec4 source / destinations
         EXIT,
         IPA,
         FFMA_IMM, // Fused Multiply and Add
@@ -740,6 +742,8 @@ private:
             INST("1101111101001---", Id::TEXQ, Type::Memory, "TEXQ"),
             INST("1101100---------", Id::TEXS, Type::Memory, "TEXS"),
             INST("1101101---------", Id::TLDS, Type::Memory, "TLDS"),
+            INST("110010----111---", Id::TLD4, Type::Memory, "TLD4"),
+            INST("1101111100------", Id::TLD4S, Type::Memory, "TLD4S"),
             INST("111000110000----", Id::EXIT, Type::Trivial, "EXIT"),
             INST("11100000--------", Id::IPA, Type::Trivial, "IPA"),
             INST("0011001-1-------", Id::FFMA_IMM, Type::Ffma, "FFMA_IMM"),

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -11,6 +11,7 @@
 #include <vector>
 #include "common/common_types.h"
 #include "common/hash.h"
+#include "video_core/engines/shader_bytecode.h"
 
 namespace GLShader {
 
@@ -72,8 +73,9 @@ class SamplerEntry {
     using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 
 public:
-    SamplerEntry(Maxwell::ShaderStage stage, size_t offset, size_t index)
-        : offset(offset), stage(stage), sampler_index(index) {}
+    SamplerEntry(Maxwell::ShaderStage stage, size_t offset, size_t index,
+                 Tegra::Shader::TextureType type, bool is_array)
+        : offset(offset), stage(stage), sampler_index(index), type(type), is_array(is_array) {}
 
     size_t GetOffset() const {
         return offset;
@@ -88,8 +90,41 @@ public:
     }
 
     std::string GetName() const {
-        return std::string(TextureSamplerNames[static_cast<size_t>(stage)]) + '[' +
-               std::to_string(sampler_index) + ']';
+        return std::string(TextureSamplerNames[static_cast<size_t>(stage)]) + '_' +
+               std::to_string(sampler_index);
+    }
+
+    std::string GetTypeString() const {
+        using Tegra::Shader::TextureType;
+        std::string glsl_type;
+
+        switch (type) {
+        case TextureType::Texture1D:
+            glsl_type = "sampler1D";
+            break;
+        case TextureType::Texture2D:
+            glsl_type = "sampler2D";
+            break;
+        case TextureType::Texture3D:
+            glsl_type = "sampler3D";
+            break;
+        case TextureType::TextureCube:
+            glsl_type = "samplerCube";
+            break;
+        default:
+            UNIMPLEMENTED();
+        }
+        if (is_array)
+            glsl_type += "Array";
+        return glsl_type;
+    }
+
+    Tegra::Shader::TextureType GetType() const {
+        return type;
+    }
+
+    bool IsArray() const {
+        return is_array;
     }
 
     static std::string GetArrayName(Maxwell::ShaderStage stage) {
@@ -100,11 +135,14 @@ private:
     static constexpr std::array<const char*, Maxwell::MaxShaderStage> TextureSamplerNames = {
         "tex_vs", "tex_tessc", "tex_tesse", "tex_gs", "tex_fs",
     };
+
     /// Offset in TSC memory from which to read the sampler object, as specified by the sampling
     /// instruction.
     size_t offset;
-    Maxwell::ShaderStage stage; ///< Shader stage where this sampler was used.
-    size_t sampler_index;       ///< Value used to index into the generated GLSL sampler array.
+    Maxwell::ShaderStage stage;      ///< Shader stage where this sampler was used.
+    size_t sampler_index;            ///< Value used to index into the generated GLSL sampler array.
+    Tegra::Shader::TextureType type; ///< The type used to sample this texture (Texture2D, etc)
+    bool is_array; ///< Whether the texture is being sampled as an array texture or not.
 };
 
 struct ShaderEntries {


### PR DESCRIPTION
Note that this won't completely work until the textures are uploaded as their right types (Currently we use TEXTURE_2D for everything).
Also note that the sampler type should change depending on the data type of the texture being used (usampler for unsigned textures, isampler for signed, etc), not doing so is an error and produces undefined results after sampling. This will come in a future PR.

The coord parameters come from different registers depending on the type of the texture being sampled.

It is currently unknown how the TLD4S instruction encodes the texture type so we always assume Texture2D for now.