### PR TITLE
Rasterizer: Use PBOs to reinterpret texture formats when games re-use the same memory.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -87,7 +87,8 @@ private:
 
     /// Configures the color and depth framebuffer states and returns the dirty <Color, Depth>
     /// surfaces if writing was enabled.
-    std::pair<Surface, Surface> ConfigureFramebuffers(bool using_color_fb, bool using_depth_fb);
+    std::pair<Surface, Surface> ConfigureFramebuffers(bool using_color_fb, bool using_depth_fb,
+                                                      bool preserve_contents);
 
     /// Binds the framebuffer color and depth surface
     void BindFramebufferSurfaces(const Surface& color_surface, const Surface& depth_surface,

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -798,12 +798,58 @@ Surface RasterizerCacheOpenGL::RecreateSurface(const Surface& surface,
     // Verify surface is compatible for blitting
     const auto& params{surface->GetSurfaceParams()};
     ASSERT(params.type == new_params.type);
+    ASSERT_MSG(params.GetCompressionFactor(params.pixel_format) == 1,
+               "Compressed texture reinterpretation is not supported");
 
     // Create a new surface with the new parameters, and blit the previous surface to it
     Surface new_surface{std::make_shared<CachedSurface>(new_params)};
-    BlitTextures(surface->Texture().handle, params.GetRect(), new_surface->Texture().handle,
-                 new_surface->GetSurfaceParams().GetRect(), params.type, read_framebuffer.handle,
-                 draw_framebuffer.handle);
+
+    auto source_format = GetFormatTuple(params.pixel_format, params.component_type);
+    auto dest_format = GetFormatTuple(new_params.pixel_format, new_params.component_type);
+
+    size_t buffer_size = std::max(params.SizeInBytes(), new_params.SizeInBytes());
+
+    // Use a Pixel Buffer Object to download the previous texture and then upload it to the new one
+    // using the new format.
+    OGLBuffer pbo;
+    pbo.Create();
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo.handle);
+    glBufferData(GL_PIXEL_PACK_BUFFER, buffer_size, nullptr, GL_STREAM_DRAW_ARB);
+    glGetTextureImage(surface->Texture().handle, 0, source_format.format, source_format.type,
+                      params.SizeInBytes(), nullptr);
+
+    // If the new texture is bigger than the previous one, we need to fill in the rest with data
+    // from the CPU.
+    if (params.SizeInBytes() < new_params.SizeInBytes()) {
+        // Upload the rest of the memory.
+        if (new_params.is_tiled) {
+            // TODO(Subv): We might have to de-tile the subtexture and re-tile it with the rest of
+            // the data in this case. Games like Super Mario Odyssey seem to hit this case when
+            // drawing, it re-uses the memory of a previous texture as a bigger framebuffer but it
+            // doesn't clear it beforehand, the texture is already full of zeros.
+            LOG_CRITICAL(HW_GPU, "Trying to upload extra texture data from the CPU during "
+                                 "reinterpretation but the texture is tiled.");
+        }
+        size_t remaining_size = new_params.SizeInBytes() - params.SizeInBytes();
+        auto address = Core::System::GetInstance().GPU().memory_manager->GpuToCpuAddress(
+            new_params.addr + params.SizeInBytes());
+        std::vector<u8> data(remaining_size);
+        Memory::ReadBlock(*address, data.data(), data.size());
+        glBufferSubData(GL_PIXEL_PACK_BUFFER, params.SizeInBytes(), remaining_size, data.data());
+    }
+
+    glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
+
+    const auto& dest_rect{new_params.GetRect()};
+
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo.handle);
+    glTextureSubImage2D(
+        new_surface->Texture().handle, 0, 0, 0, static_cast<GLsizei>(dest_rect.GetWidth()),
+        static_cast<GLsizei>(dest_rect.GetHeight()), dest_format.format, dest_format.type, nullptr);
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
+
+    pbo.Release();
 
     // Update cache accordingly
     UnregisterSurface(surface);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -722,7 +722,8 @@ public:
     Surface GetTextureSurface(const Tegra::Texture::FullTextureInfo& config);
 
     /// Get the color and depth surfaces based on the framebuffer configuration
-    SurfaceSurfaceRect_Tuple GetFramebufferSurfaces(bool using_color_fb, bool using_depth_fb);
+    SurfaceSurfaceRect_Tuple GetFramebufferSurfaces(bool using_color_fb, bool using_depth_fb,
+                                                    bool preserve_contents);
 
     /// Flushes the surface to Switch memory
     void FlushSurface(const Surface& surface);
@@ -738,7 +739,7 @@ public:
 
 private:
     void LoadSurface(const Surface& surface);
-    Surface GetSurface(const SurfaceParams& params);
+    Surface GetSurface(const SurfaceParams& params, bool preserve_contents = true);
 
     /// Recreates a surface with new parameters
     Surface RecreateSurface(const Surface& surface, const SurfaceParams& new_params);


### PR DESCRIPTION
We were previously using a framebuffer blit, which internally converts the formats, instead of using the raw data and interpreting it as the new format.

This shouldn't have much impact on anything since most reinterpretations happen because games stopped using a texture and re-used the memory for another unrelated one that they're about to clear.