### PR TITLE
rasterizer_interface: Remove renderer-specific ScreenInfo type from AccelerateDraw() in RasterizerInterface

### DIFF
--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -8,8 +8,6 @@
 #include "video_core/gpu.h"
 #include "video_core/memory_manager.h"
 
-struct ScreenInfo;
-
 namespace VideoCore {
 
 class RasterizerInterface {
@@ -55,7 +53,7 @@ public:
 
     /// Attempt to use a faster method to display the framebuffer to screen
     virtual bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
-                                   u32 pixel_stride, ScreenInfo& screen_info) {
+                                   u32 pixel_stride) {
         return false;
     }
 

--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <memory>
 #include "core/frontend/emu_window.h"
 #include "core/settings.h"
 #include "video_core/renderer_base.h"
@@ -17,16 +16,9 @@ RendererBase::RendererBase(Core::Frontend::EmuWindow& window) : render_window{wi
 RendererBase::~RendererBase() = default;
 
 void RendererBase::RefreshBaseSettings() {
-    RefreshRasterizerSetting();
     UpdateCurrentFramebufferLayout();
 
     renderer_settings.use_framelimiter = Settings::values.toggle_framelimit;
-}
-
-void RendererBase::RefreshRasterizerSetting() {
-    if (rasterizer == nullptr) {
-        rasterizer = std::make_unique<RasterizerOpenGL>(render_window);
-    }
 }
 
 void RendererBase::UpdateCurrentFramebufferLayout() {

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -58,9 +58,6 @@ public:
     void RefreshBaseSettings();
 
 protected:
-    /// Refreshes settings specific to the rasterizer.
-    void RefreshRasterizerSetting();
-
     Core::Frontend::EmuWindow& render_window; ///< Reference to the render window handle.
     std::unique_ptr<RasterizerInterface> rasterizer;
     f32 m_current_fps = 0.0f; ///< Current framerate, should be set by the renderer

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -36,8 +36,8 @@ MICROPROFILE_DEFINE(OpenGL_Drawing, "OpenGL", "Drawing", MP_RGB(128, 128, 192));
 MICROPROFILE_DEFINE(OpenGL_Blits, "OpenGL", "Blits", MP_RGB(100, 100, 255));
 MICROPROFILE_DEFINE(OpenGL_CacheManagement, "OpenGL", "Cache Mgmt", MP_RGB(100, 255, 100));
 
-RasterizerOpenGL::RasterizerOpenGL(Core::Frontend::EmuWindow& window)
-    : emu_window{window}, stream_buffer(GL_ARRAY_BUFFER, STREAM_BUFFER_SIZE) {
+RasterizerOpenGL::RasterizerOpenGL(Core::Frontend::EmuWindow& window, ScreenInfo& info)
+    : emu_window{window}, screen_info{info}, stream_buffer(GL_ARRAY_BUFFER, STREAM_BUFFER_SIZE) {
     // Create sampler objects
     for (size_t i = 0; i < texture_samplers.size(); ++i) {
         texture_samplers[i].Create();
@@ -574,8 +574,7 @@ bool RasterizerOpenGL::AccelerateFill(const void* config) {
 }
 
 bool RasterizerOpenGL::AccelerateDisplay(const Tegra::FramebufferConfig& config,
-                                         VAddr framebuffer_addr, u32 pixel_stride,
-                                         ScreenInfo& screen_info) {
+                                         VAddr framebuffer_addr, u32 pixel_stride) {
     if (!framebuffer_addr) {
         return {};
     }

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -30,7 +30,7 @@ class EmuWindow;
 
 class RasterizerOpenGL : public VideoCore::RasterizerInterface {
 public:
-    explicit RasterizerOpenGL(Core::Frontend::EmuWindow& renderer);
+    explicit RasterizerOpenGL(Core::Frontend::EmuWindow& renderer, ScreenInfo& info);
     ~RasterizerOpenGL() override;
 
     void DrawArrays() override;
@@ -43,8 +43,8 @@ public:
     bool AccelerateDisplayTransfer(const void* config) override;
     bool AccelerateTextureCopy(const void* config) override;
     bool AccelerateFill(const void* config) override;
-    bool AccelerateDisplay(const Tegra::FramebufferConfig& framebuffer, VAddr framebuffer_addr,
-                           u32 pixel_stride, ScreenInfo& screen_info) override;
+    bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
+                           u32 pixel_stride) override;
     bool AccelerateDrawBatch(bool is_indexed) override;
 
     /// OpenGL shader generated for a given Maxwell register state
@@ -150,6 +150,8 @@ private:
     RasterizerCacheOpenGL res_cache;
 
     Core::Frontend::EmuWindow& emu_window;
+
+    ScreenInfo& screen_info;
 
     std::unique_ptr<GLShader::ProgramManager> shader_program_manager;
     OGLVertexArray sw_vao;

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -131,7 +131,7 @@ void RendererOpenGL::SwapBuffers(boost::optional<const Tegra::FramebufferConfig&
         }
 
         // Load the framebuffer from memory, draw it to the screen, and swap buffers
-        LoadFBToScreenInfo(*framebuffer, screen_info);
+        LoadFBToScreenInfo(*framebuffer);
         DrawScreen();
         render_window.SwapBuffers();
     }
@@ -148,8 +148,7 @@ void RendererOpenGL::SwapBuffers(boost::optional<const Tegra::FramebufferConfig&
 /**
  * Loads framebuffer from emulated memory into the active OpenGL texture.
  */
-void RendererOpenGL::LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuffer,
-                                        ScreenInfo& screen_info) {
+void RendererOpenGL::LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuffer) {
     const u32 bytes_per_pixel{Tegra::FramebufferConfig::BytesPerPixel(framebuffer.pixel_format)};
     const u64 size_in_bytes{framebuffer.stride * framebuffer.height * bytes_per_pixel};
     const VAddr framebuffer_addr{framebuffer.address + framebuffer.offset};
@@ -162,8 +161,7 @@ void RendererOpenGL::LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuf
     // only allows rows to have a memory alignement of 4.
     ASSERT(framebuffer.stride % 4 == 0);
 
-    if (!rasterizer->AccelerateDisplay(framebuffer, framebuffer_addr, framebuffer.stride,
-                                       screen_info)) {
+    if (!rasterizer->AccelerateDisplay(framebuffer, framebuffer_addr, framebuffer.stride)) {
         // Reset the screen info's display texture to its own permanent texture
         screen_info.display_texture = screen_info.texture.resource.handle;
 
@@ -281,7 +279,7 @@ void RendererOpenGL::CreateRasterizer() {
         return;
     }
 
-    rasterizer = std::make_unique<RasterizerOpenGL>(render_window);
+    rasterizer = std::make_unique<RasterizerOpenGL>(render_window, screen_info);
 }
 
 void RendererOpenGL::ConfigureFramebufferTexture(TextureInfo& texture,

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -16,6 +16,7 @@
 #include "core/memory.h"
 #include "core/settings.h"
 #include "core/tracer/recorder.h"
+#include "video_core/renderer_opengl/gl_rasterizer.h"
 #include "video_core/renderer_opengl/renderer_opengl.h"
 #include "video_core/utils.h"
 
@@ -142,7 +143,6 @@ void RendererOpenGL::SwapBuffers(boost::optional<const Tegra::FramebufferConfig&
 
     // Restore the rasterizer state
     prev_state.Apply();
-    RefreshRasterizerSetting();
 }
 
 /**
@@ -274,6 +274,14 @@ void RendererOpenGL::InitOpenGLObjects() {
 
     // Clear screen to black
     LoadColorToActiveGLTexture(0, 0, 0, 0, screen_info.texture);
+}
+
+void RendererOpenGL::CreateRasterizer() {
+    if (rasterizer) {
+        return;
+    }
+
+    rasterizer = std::make_unique<RasterizerOpenGL>(render_window);
 }
 
 void RendererOpenGL::ConfigureFramebufferTexture(TextureInfo& texture,
@@ -463,8 +471,7 @@ bool RendererOpenGL::Init() {
     }
 
     InitOpenGLObjects();
-
-    RefreshRasterizerSetting();
+    CreateRasterizer();
 
     return true;
 }

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -68,7 +68,7 @@ private:
     void UpdateFramerate();
 
     // Loads framebuffer from emulated memory into the display information structure
-    void LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuffer, ScreenInfo& screen_info);
+    void LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuffer);
     // Fills active OpenGL texture with the given RGBA color.
     void LoadColorToActiveGLTexture(u8 color_r, u8 color_g, u8 color_b, u8 color_a,
                                     const TextureInfo& texture);

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -59,6 +59,8 @@ public:
 
 private:
     void InitOpenGLObjects();
+    void CreateRasterizer();
+
     void ConfigureFramebufferTexture(TextureInfo& texture,
                                      const Tegra::FramebufferConfig& framebuffer);
     void DrawScreen();


### PR DESCRIPTION
This is an OpenGL renderer-specific data type. Given that, this type shouldn't be used within the base interface for the rasterizer. Instead, we can pass this information to the rasterizer via reference.