### PR TITLE
telemetry_session: Don't allocate std::string instances for program lifetime in GetTelemetryId() and RegenerateTelemetryId()

### DIFF
--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -19,8 +19,8 @@ static u64 GenerateTelemetryId() {
 
 u64 GetTelemetryId() {
     u64 telemetry_id{};
-    static const std::string& filename{FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) +
-                                       "telemetry_id"};
+    const std::string filename{FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) +
+                               "telemetry_id"};
 
     if (FileUtil::Exists(filename)) {
         FileUtil::IOFile file(filename, "rb");
@@ -44,8 +44,8 @@ u64 GetTelemetryId() {
 
 u64 RegenerateTelemetryId() {
     const u64 new_telemetry_id{GenerateTelemetryId()};
-    static const std::string& filename{FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) +
-                                       "telemetry_id"};
+    const std::string filename{FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) +
+                               "telemetry_id"};
 
     FileUtil::IOFile file(filename, "wb");
     if (!file.IsOpen()) {


### PR DESCRIPTION
Given these functions aren't intended to be used frequently, there's no need to keep the std::string instances allocated for the whole lifetime of the program. It's just a waste of memory.