### PR TITLE
Revert "Port #3616 from Citra: "appveyor: set jobs to 4 for mingw""

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -53,7 +53,7 @@ build_script:
           # https://www.appveyor.com/docs/build-phase
           msbuild msvc_build/yuzu.sln /maxcpucount /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
         } else {
-          C:\msys64\usr\bin\bash.exe -lc 'mingw32-make -j4 -C mingw_build/ 2>&1'
+          C:\msys64\usr\bin\bash.exe -lc 'mingw32-make -C mingw_build/ 2>&1'
         }
 
 after_build:


### PR DESCRIPTION
Reverts yuzu-emu/yuzu#838

So far this has broken mingw builds.