### PR TITLE
gl_stream_buffer: Add missing header guard

### DIFF
--- a/src/video_core/renderer_opengl/gl_stream_buffer.h
+++ b/src/video_core/renderer_opengl/gl_stream_buffer.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <tuple>
 #include <glad/glad.h>
 #include "common/common_types.h"


### PR DESCRIPTION
Prevents potential compilation errors from occuring due to multiple inclusions