### PR TITLE
renderer_opengl: Use LOG_DEBUG for GL_DEBUG_SEVERITY_NOTIFICATION and GL_DEBUG_SEVERITY_LOW logs

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -432,7 +432,7 @@ static void APIENTRY DebugHandler(GLenum source, GLenum type, GLuint id, GLenum 
         break;
     case GL_DEBUG_SEVERITY_NOTIFICATION:
     case GL_DEBUG_SEVERITY_LOW:
-        LOG_TRACE(Render_OpenGL, format, str_source, str_type, id, message);
+        LOG_DEBUG(Render_OpenGL, format, str_source, str_type, id, message);
         break;
     }
 }


### PR DESCRIPTION
LOG_TRACE is only enabled on debug builds which can be quite slow when trying to debug graphics issues. Instead we can log the messages to the debug log, which is available on both release and debug builds.