### PR TITLE
gl_rasterizer_cache: Use CPU address for caching surfaces, and misc. changes.

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
@@ -10,6 +10,7 @@
 #include "common/common_types.h"
 #include "common/swap.h"
 #include "core/hle/service/nvdrv/devices/nvdevice.h"
+#include "video_core/memory_manager.h"
 
 namespace Service::Nvidia::Devices {
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -251,8 +251,8 @@ std::string ReadCString(VAddr vaddr, std::size_t max_length) {
     return string;
 }
 
-void RasterizerMarkRegionCached(Tegra::GPUVAddr gpu_addr, u64 size, bool cached) {
-    if (gpu_addr == 0) {
+void RasterizerMarkRegionCached(VAddr vaddr, u64 size, bool cached) {
+    if (vaddr == 0) {
         return;
     }
 
@@ -261,19 +261,8 @@ void RasterizerMarkRegionCached(Tegra::GPUVAddr gpu_addr, u64 size, bool cached)
     // CPU pages, hence why we iterate on a CPU page basis (note: GPU page size is different). This
     // assumes the specified GPU address region is contiguous as well.
 
-    u64 num_pages = ((gpu_addr + size - 1) >> PAGE_BITS) - (gpu_addr >> PAGE_BITS) + 1;
-    for (unsigned i = 0; i < num_pages; ++i, gpu_addr += PAGE_SIZE) {
-        boost::optional<VAddr> maybe_vaddr =
-            Core::System::GetInstance().GPU().memory_manager->GpuToCpuAddress(gpu_addr);
-        // The GPU <-> CPU virtual memory mapping is not 1:1
-        if (!maybe_vaddr) {
-            LOG_ERROR(HW_Memory,
-                      "Trying to flush a cached region to an invalid physical address {:016X}",
-                      gpu_addr);
-            continue;
-        }
-        VAddr vaddr = *maybe_vaddr;
-
+    u64 num_pages = ((vaddr + size - 1) >> PAGE_BITS) - (vaddr >> PAGE_BITS) + 1;
+    for (unsigned i = 0; i < num_pages; ++i, vaddr += PAGE_SIZE) {
         PageType& page_type = current_page_table->attributes[vaddr >> PAGE_BITS];
 
         if (cached) {
@@ -344,29 +333,19 @@ void RasterizerFlushVirtualRegion(VAddr start, u64 size, FlushMode mode) {
 
         const VAddr overlap_start = std::max(start, region_start);
         const VAddr overlap_end = std::min(end, region_end);
-
-        const std::vector<Tegra::GPUVAddr> gpu_addresses =
-            system_instance.GPU().memory_manager->CpuToGpuAddress(overlap_start);
-
-        if (gpu_addresses.empty()) {
-            return;
-        }
-
         const u64 overlap_size = overlap_end - overlap_start;
 
-        for (const auto& gpu_address : gpu_addresses) {
-            auto& rasterizer = system_instance.Renderer().Rasterizer();
-            switch (mode) {
-            case FlushMode::Flush:
-                rasterizer.FlushRegion(gpu_address, overlap_size);
-                break;
-            case FlushMode::Invalidate:
-                rasterizer.InvalidateRegion(gpu_address, overlap_size);
-                break;
-            case FlushMode::FlushAndInvalidate:
-                rasterizer.FlushAndInvalidateRegion(gpu_address, overlap_size);
-                break;
-            }
+        auto& rasterizer = system_instance.Renderer().Rasterizer();
+        switch (mode) {
+        case FlushMode::Flush:
+            rasterizer.FlushRegion(overlap_start, overlap_size);
+            break;
+        case FlushMode::Invalidate:
+            rasterizer.InvalidateRegion(overlap_start, overlap_size);
+            break;
+        case FlushMode::FlushAndInvalidate:
+            rasterizer.FlushAndInvalidateRegion(overlap_start, overlap_size);
+            break;
         }
     };
 

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -11,7 +11,6 @@
 #include <boost/icl/interval_map.hpp>
 #include "common/common_types.h"
 #include "core/memory_hook.h"
-#include "video_core/memory_manager.h"
 
 namespace Kernel {
 class Process;
@@ -179,7 +178,7 @@ enum class FlushMode {
 /**
  * Mark each page touching the region as cached.
  */
-void RasterizerMarkRegionCached(Tegra::GPUVAddr gpu_addr, u64 size, bool cached);
+void RasterizerMarkRegionCached(VAddr vaddr, u64 size, bool cached);
 
 /**
  * Flushes and invalidates any externally cached rasterizer resources touching the given virtual

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -29,14 +29,14 @@ public:
     virtual void FlushAll() = 0;
 
     /// Notify rasterizer that any caches of the specified region should be flushed to Switch memory
-    virtual void FlushRegion(Tegra::GPUVAddr addr, u64 size) = 0;
+    virtual void FlushRegion(VAddr addr, u64 size) = 0;
 
     /// Notify rasterizer that any caches of the specified region should be invalidated
-    virtual void InvalidateRegion(Tegra::GPUVAddr addr, u64 size) = 0;
+    virtual void InvalidateRegion(VAddr addr, u64 size) = 0;
 
     /// Notify rasterizer that any caches of the specified region should be flushed to Switch memory
     /// and invalidated
-    virtual void FlushAndInvalidateRegion(Tegra::GPUVAddr addr, u64 size) = 0;
+    virtual void FlushAndInvalidateRegion(VAddr addr, u64 size) = 0;
 
     /// Attempt to use a faster method to perform a display transfer with is_texture_copy = 0
     virtual bool AccelerateDisplayTransfer(const void* config) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -542,17 +542,17 @@ void RasterizerOpenGL::FlushAll() {
     res_cache.FlushRegion(0, Kernel::VMManager::MAX_ADDRESS);
 }
 
-void RasterizerOpenGL::FlushRegion(Tegra::GPUVAddr addr, u64 size) {
+void RasterizerOpenGL::FlushRegion(VAddr addr, u64 size) {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
     res_cache.FlushRegion(addr, size);
 }
 
-void RasterizerOpenGL::InvalidateRegion(Tegra::GPUVAddr addr, u64 size) {
+void RasterizerOpenGL::InvalidateRegion(VAddr addr, u64 size) {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
     res_cache.InvalidateRegion(addr, size);
 }
 
-void RasterizerOpenGL::FlushAndInvalidateRegion(Tegra::GPUVAddr addr, u64 size) {
+void RasterizerOpenGL::FlushAndInvalidateRegion(VAddr addr, u64 size) {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
     res_cache.FlushRegion(addr, size);
     res_cache.InvalidateRegion(addr, size);

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -37,9 +37,9 @@ public:
     void Clear() override;
     void NotifyMaxwellRegisterChanged(u32 method) override;
     void FlushAll() override;
-    void FlushRegion(Tegra::GPUVAddr addr, u64 size) override;
-    void InvalidateRegion(Tegra::GPUVAddr addr, u64 size) override;
-    void FlushAndInvalidateRegion(Tegra::GPUVAddr addr, u64 size) override;
+    void FlushRegion(VAddr addr, u64 size) override;
+    void InvalidateRegion(VAddr addr, u64 size) override;
+    void FlushAndInvalidateRegion(VAddr addr, u64 size) override;
     bool AccelerateDisplayTransfer(const void* config) override;
     bool AccelerateTextureCopy(const void* config) override;
     bool AccelerateFill(const void* config) override;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -782,7 +782,6 @@ Surface RasterizerCacheOpenGL::RecreateSurface(const Surface& surface,
                                                const SurfaceParams& new_params) {
     // Verify surface is compatible for blitting
     const auto& params{surface->GetSurfaceParams()};
-    ASSERT(params.type == new_params.type);
 
     // Create a new surface with the new parameters, and blit the previous surface to it
     Surface new_surface{std::make_shared<CachedSurface>(new_params)};

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -783,8 +783,6 @@ Surface RasterizerCacheOpenGL::RecreateSurface(const Surface& surface,
     // Verify surface is compatible for blitting
     const auto& params{surface->GetSurfaceParams()};
     ASSERT(params.type == new_params.type);
-    ASSERT_MSG(params.GetCompressionFactor(params.pixel_format) == 1,
-               "Compressed texture reinterpretation is not supported");
 
     // Create a new surface with the new parameters, and blit the previous surface to it
     Surface new_surface{std::make_shared<CachedSurface>(new_params)};
@@ -801,9 +799,12 @@ Surface RasterizerCacheOpenGL::RecreateSurface(const Surface& surface,
 
     glBindBuffer(GL_PIXEL_PACK_BUFFER, pbo.handle);
     glBufferData(GL_PIXEL_PACK_BUFFER, buffer_size, nullptr, GL_STREAM_DRAW_ARB);
-    glGetTextureImage(surface->Texture().handle, 0, source_format.format, source_format.type,
-                      params.SizeInBytes(), nullptr);
-
+    if (source_format.compressed) {
+        glGetCompressedTextureImage(surface->Texture().handle, 0, params.SizeInBytes(), nullptr);
+    } else {
+        glGetTextureImage(surface->Texture().handle, 0, source_format.format, source_format.type,
+                          params.SizeInBytes(), nullptr);
+    }
     // If the new texture is bigger than the previous one, we need to fill in the rest with data
     // from the CPU.
     if (params.SizeInBytes() < new_params.SizeInBytes()) {
@@ -827,9 +828,32 @@ Surface RasterizerCacheOpenGL::RecreateSurface(const Surface& surface,
     const auto& dest_rect{new_params.GetRect()};
 
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, pbo.handle);
-    glTextureSubImage2D(
-        new_surface->Texture().handle, 0, 0, 0, static_cast<GLsizei>(dest_rect.GetWidth()),
-        static_cast<GLsizei>(dest_rect.GetHeight()), dest_format.format, dest_format.type, nullptr);
+    if (dest_format.compressed) {
+        OpenGLState cur_state = OpenGLState::GetCurState();
+
+        GLuint old_tex = cur_state.texture_units[0].texture_2d;
+        cur_state.texture_units[0].texture_2d = new_surface->Texture().handle;
+        cur_state.Apply();
+
+        // Ensure no bad interactions with GL_UNPACK_ALIGNMENT
+        ASSERT(new_params.width * CachedSurface::GetGLBytesPerPixel(new_params.pixel_format) % 4 ==
+               0);
+        glPixelStorei(GL_UNPACK_ROW_LENGTH, static_cast<GLint>(params.width));
+        glActiveTexture(GL_TEXTURE0);
+        glCompressedTexImage2D(GL_TEXTURE_2D, 0, dest_format.internal_format,
+                               static_cast<GLsizei>(dest_rect.GetWidth()),
+                               static_cast<GLsizei>(dest_rect.GetHeight()), 0,
+                               static_cast<GLsizei>(new_params.SizeInBytes()), nullptr);
+        glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
+
+        cur_state.texture_units[0].texture_2d = old_tex;
+        cur_state.Apply();
+    } else {
+        glTextureSubImage2D(new_surface->Texture().handle, 0, 0, 0,
+                            static_cast<GLsizei>(dest_rect.GetWidth()),
+                            static_cast<GLsizei>(dest_rect.GetHeight()), dest_format.format,
+                            dest_format.type, nullptr);
+    }
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
 
     pbo.Release();

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -626,12 +626,9 @@ struct SurfaceParams {
                GetFormatBpp(pixel_format) / CHAR_BIT;
     }
 
-    /// Returns the CPU virtual address for this surface
-    VAddr GetCpuAddr() const;
-
     /// Returns true if the specified region overlaps with this surface's region in Switch memory
-    bool IsOverlappingRegion(Tegra::GPUVAddr region_addr, size_t region_size) const {
-        return addr <= (region_addr + region_size) && region_addr <= (addr + size_in_bytes);
+    bool IsOverlappingRegion(VAddr region_addr, size_t region_size) const {
+        return cpu_addr <= (region_addr + region_size) && region_addr <= (cpu_addr + size_in_bytes);
     }
 
     /// Creates SurfaceParams from a texture configuration
@@ -647,9 +644,9 @@ struct SurfaceParams {
                                               Tegra::DepthFormat format);
 
     bool operator==(const SurfaceParams& other) const {
-        return std::tie(addr, is_tiled, block_height, pixel_format, component_type, type, width,
+        return std::tie(cpu_addr, is_tiled, block_height, pixel_format, component_type, type, width,
                         height, unaligned_height, size_in_bytes) ==
-               std::tie(other.addr, other.is_tiled, other.block_height, other.pixel_format,
+               std::tie(other.cpu_addr, other.is_tiled, other.block_height, other.pixel_format,
                         other.component_type, other.type, other.width, other.height,
                         other.unaligned_height, other.size_in_bytes);
     }
@@ -664,7 +661,7 @@ struct SurfaceParams {
                std::tie(other.pixel_format, other.type, other.cache_width, other.cache_height);
     }
 
-    Tegra::GPUVAddr addr;
+    VAddr cpu_addr;
     bool is_tiled;
     u32 block_height;
     PixelFormat pixel_format;
@@ -732,10 +729,10 @@ public:
     Surface TryFindFramebufferSurface(VAddr cpu_addr) const;
 
     /// Write any cached resources overlapping the region back to memory (if dirty)
-    void FlushRegion(Tegra::GPUVAddr addr, size_t size);
+    void FlushRegion(VAddr addr, size_t size);
 
     /// Mark the specified region as being invalidated
-    void InvalidateRegion(Tegra::GPUVAddr addr, size_t size);
+    void InvalidateRegion(VAddr addr, size_t size);
 
 private:
     void LoadSurface(const Surface& surface);
@@ -751,9 +748,9 @@ private:
     void UnregisterSurface(const Surface& surface);
 
     /// Increase/decrease the number of surface in pages touching the specified region
-    void UpdatePagesCachedCount(Tegra::GPUVAddr addr, u64 size, int delta);
+    void UpdatePagesCachedCount(VAddr addr, u64 size, int delta);
 
-    std::unordered_map<Tegra::GPUVAddr, Surface> surface_cache;
+    std::unordered_map<VAddr, Surface> surface_cache;
     PageMap cached_pages;
 
     OGLFramebuffer read_framebuffer;


### PR DESCRIPTION
* Caches rasterizer surfaces based on their true address, not GPU virtual address.
* Adds support for compressed surface copies. This probably shouldn't be used, by I accidentally added it and it seems to work.
* Removes assert for color <-> depth copies, since this should work now.

Unfortunately, I believe these changes introduce a bit of a performance hit. There are probably more superfluous surface copies happening now, such as when a region of memory is reused as a render target and then cleared.
