### PR TITLE
renderer_opengl: Namespace OpenGL code

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -25,6 +25,8 @@
 #include "video_core/renderer_opengl/renderer_opengl.h"
 #include "video_core/video_core.h"
 
+namespace OpenGL {
+
 using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 using PixelFormat = SurfaceParams::PixelFormat;
 using SurfaceType = SurfaceParams::SurfaceType;
@@ -874,3 +876,5 @@ void RasterizerOpenGL::SyncLogicOpState() {
 
     state.logic_op.operation = MaxwellToGL::LogicOp(regs.logic_op.operation);
 }
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -22,11 +22,13 @@
 #include "video_core/renderer_opengl/gl_state.h"
 #include "video_core/renderer_opengl/gl_stream_buffer.h"
 
-struct ScreenInfo;
-
 namespace Core::Frontend {
 class EmuWindow;
 }
+
+namespace OpenGL {
+
+struct ScreenInfo;
 
 class RasterizerOpenGL : public VideoCore::RasterizerInterface {
 public:
@@ -184,3 +186,5 @@ private:
     enum class AccelDraw { Disabled, Arrays, Indexed };
     AccelDraw accelerate_draw = AccelDraw::Disabled;
 };
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -19,6 +19,8 @@
 #include "video_core/textures/decoders.h"
 #include "video_core/utils.h"
 
+namespace OpenGL {
+
 using SurfaceType = SurfaceParams::SurfaceType;
 using PixelFormat = SurfaceParams::PixelFormat;
 using ComponentType = SurfaceParams::ComponentType;
@@ -967,3 +969,5 @@ void RasterizerCacheOpenGL::UpdatePagesCachedCount(Tegra::GPUVAddr addr, u64 siz
     if (delta < 0)
         cached_pages.add({pages_interval, delta});
 }
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -16,6 +16,8 @@
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/textures/texture.h"
 
+namespace OpenGL {
+
 class CachedSurface;
 using Surface = std::shared_ptr<CachedSurface>;
 using SurfaceSurfaceRect_Tuple = std::tuple<Surface, Surface, MathUtil::Rectangle<u32>>;
@@ -759,3 +761,5 @@ private:
     OGLFramebuffer read_framebuffer;
     OGLFramebuffer draw_framebuffer;
 };
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_resource_manager.h
+++ b/src/video_core/renderer_opengl/gl_resource_manager.h
@@ -10,6 +10,8 @@
 #include "video_core/renderer_opengl/gl_shader_util.h"
 #include "video_core/renderer_opengl/gl_state.h"
 
+namespace OpenGL {
+
 class OGLTexture : private NonCopyable {
 public:
     OGLTexture() = default;
@@ -331,3 +333,5 @@ public:
 
     GLuint handle = 0;
 };
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -15,7 +15,7 @@
 #include "video_core/renderer_opengl/gl_rasterizer.h"
 #include "video_core/renderer_opengl/gl_shader_decompiler.h"
 
-namespace GLShader::Decompiler {
+namespace OpenGL::GLShader::Decompiler {
 
 using Tegra::Shader::Attribute;
 using Tegra::Shader::Instruction;
@@ -2176,4 +2176,4 @@ boost::optional<ProgramResult> DecompileProgram(const ProgramCode& program_code,
     return boost::none;
 }
 
-} // namespace GLShader::Decompiler
+} // namespace OpenGL::GLShader::Decompiler

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.h
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.h
@@ -12,7 +12,7 @@
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/renderer_opengl/gl_shader_gen.h"
 
-namespace GLShader::Decompiler {
+namespace OpenGL::GLShader::Decompiler {
 
 using Tegra::Engines::Maxwell3D;
 
@@ -22,4 +22,4 @@ boost::optional<ProgramResult> DecompileProgram(const ProgramCode& program_code,
                                                 Maxwell3D::Regs::ShaderStage stage,
                                                 const std::string& suffix);
 
-} // namespace GLShader::Decompiler
+} // namespace OpenGL::GLShader::Decompiler

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -7,7 +7,7 @@
 #include "video_core/renderer_opengl/gl_shader_decompiler.h"
 #include "video_core/renderer_opengl/gl_shader_gen.h"
 
-namespace GLShader {
+namespace OpenGL::GLShader {
 
 using Tegra::Engines::Maxwell3D;
 
@@ -103,4 +103,4 @@ void main() {
     return {out, program.second};
 }
 
-} // namespace GLShader
+} // namespace OpenGL::GLShader

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -12,7 +12,7 @@
 #include "common/common_types.h"
 #include "common/hash.h"
 
-namespace GLShader {
+namespace OpenGL::GLShader {
 
 constexpr size_t MAX_PROGRAM_CODE_LENGTH{0x1000};
 
@@ -191,20 +191,20 @@ ProgramResult GenerateVertexShader(const ShaderSetup& setup, const MaxwellVSConf
  */
 ProgramResult GenerateFragmentShader(const ShaderSetup& setup, const MaxwellFSConfig& config);
 
-} // namespace GLShader
+} // namespace OpenGL::GLShader
 
 namespace std {
 
 template <>
-struct hash<GLShader::MaxwellVSConfig> {
-    size_t operator()(const GLShader::MaxwellVSConfig& k) const {
+struct hash<OpenGL::GLShader::MaxwellVSConfig> {
+    size_t operator()(const OpenGL::GLShader::MaxwellVSConfig& k) const {
         return k.Hash();
     }
 };
 
 template <>
-struct hash<GLShader::MaxwellFSConfig> {
-    size_t operator()(const GLShader::MaxwellFSConfig& k) const {
+struct hash<OpenGL::GLShader::MaxwellFSConfig> {
+    size_t operator()(const OpenGL::GLShader::MaxwellFSConfig& k) const {
         return k.Hash();
     }
 };

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -7,7 +7,7 @@
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/renderer_opengl/gl_shader_manager.h"
 
-namespace GLShader {
+namespace OpenGL::GLShader {
 
 namespace Impl {
 static void SetShaderUniformBlockBinding(GLuint shader, const char* name,
@@ -49,4 +49,4 @@ void MaxwellUniformData::SetFromRegs(const Maxwell3D::State::ShaderStageInfo& sh
     instance_id[0] = state.current_instance;
 }
 
-} // namespace GLShader
+} // namespace OpenGL::GLShader

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -12,7 +12,7 @@
 #include "video_core/renderer_opengl/gl_shader_gen.h"
 #include "video_core/renderer_opengl/maxwell_to_gl.h"
 
-namespace GLShader {
+namespace OpenGL::GLShader {
 
 /// Number of OpenGL texture samplers that can be used in the fragment shader
 static constexpr size_t NumTextureSamplers = 32;
@@ -171,4 +171,4 @@ private:
     OGLPipeline pipeline;
 };
 
-} // namespace GLShader
+} // namespace OpenGL::GLShader

--- a/src/video_core/renderer_opengl/gl_shader_util.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_util.cpp
@@ -8,7 +8,7 @@
 #include "common/logging/log.h"
 #include "video_core/renderer_opengl/gl_shader_util.h"
 
-namespace GLShader {
+namespace OpenGL::GLShader {
 
 GLuint LoadShader(const char* source, GLenum type) {
     const char* debug_type;
@@ -47,4 +47,4 @@ GLuint LoadShader(const char* source, GLenum type) {
     return shader_id;
 }
 
-} // namespace GLShader
+} // namespace OpenGL::GLShader

--- a/src/video_core/renderer_opengl/gl_shader_util.h
+++ b/src/video_core/renderer_opengl/gl_shader_util.h
@@ -10,7 +10,7 @@
 #include "common/assert.h"
 #include "common/logging/log.h"
 
-namespace GLShader {
+namespace OpenGL::GLShader {
 
 /**
  * Utility function to log the source code of a list of shaders.
@@ -89,4 +89,4 @@ GLuint LoadProgram(bool separable_program, T... shaders) {
     return program_id;
 }
 
-} // namespace GLShader
+} // namespace OpenGL::GLShader

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -7,6 +7,8 @@
 #include "common/logging/log.h"
 #include "video_core/renderer_opengl/gl_state.h"
 
+namespace OpenGL {
+
 OpenGLState OpenGLState::cur_state;
 
 OpenGLState::OpenGLState() {
@@ -338,3 +340,5 @@ OpenGLState& OpenGLState::ResetFramebuffer(GLuint handle) {
     }
     return *this;
 }
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -9,6 +9,8 @@
 
 #include "video_core/engines/maxwell_3d.h"
 
+namespace OpenGL {
+
 using Regs = Tegra::Engines::Maxwell3D::Regs;
 
 namespace TextureUnits {
@@ -163,3 +165,5 @@ public:
 private:
     static OpenGLState cur_state;
 };
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_stream_buffer.cpp
+++ b/src/video_core/renderer_opengl/gl_stream_buffer.cpp
@@ -9,6 +9,8 @@
 #include "video_core/renderer_opengl/gl_state.h"
 #include "video_core/renderer_opengl/gl_stream_buffer.h"
 
+namespace OpenGL {
+
 OGLStreamBuffer::OGLStreamBuffer(GLenum target, GLsizeiptr size, bool prefer_coherent)
     : gl_target(target), buffer_size(size) {
     gl_buffer.Create();
@@ -97,3 +99,5 @@ void OGLStreamBuffer::Unmap(GLsizeiptr size) {
 
     buffer_pos += size;
 }
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_stream_buffer.h
+++ b/src/video_core/renderer_opengl/gl_stream_buffer.h
@@ -9,6 +9,8 @@
 #include "common/common_types.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 
+namespace OpenGL {
+
 class OGLStreamBuffer : private NonCopyable {
 public:
     explicit OGLStreamBuffer(GLenum target, GLsizeiptr size, bool prefer_coherent = false);
@@ -42,3 +44,5 @@ private:
     GLsizeiptr mapped_size = 0;
     u8* mapped_ptr = nullptr;
 };
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -10,6 +10,8 @@
 #include "common/logging/log.h"
 #include "video_core/engines/maxwell_3d.h"
 
+namespace OpenGL {
+
 using GLvec2 = std::array<GLfloat, 2>;
 using GLvec3 = std::array<GLfloat, 3>;
 using GLvec4 = std::array<GLfloat, 4>;
@@ -360,3 +362,4 @@ inline GLenum LogicOp(Maxwell::LogicOperation operation) {
 }
 
 } // namespace MaxwellToGL
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -20,6 +20,8 @@
 #include "video_core/renderer_opengl/renderer_opengl.h"
 #include "video_core/utils.h"
 
+namespace OpenGL {
+
 static const char vertex_shader[] = R"(
 #version 150 core
 
@@ -476,3 +478,5 @@ bool RendererOpenGL::Init() {
 
 /// Shutdown the renderer
 void RendererOpenGL::ShutDown() {}
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -16,6 +16,8 @@ namespace Core::Frontend {
 class EmuWindow;
 }
 
+namespace OpenGL {
+
 /// Structure used for storing information about the textures for the Switch screen
 struct TextureInfo {
     OGLTexture resource;
@@ -98,3 +100,5 @@ private:
     Tegra::FramebufferConfig::TransformFlags framebuffer_transform_flags;
     MathUtil::Rectangle<int> framebuffer_crop_rect;
 };
+
+} // namespace OpenGL

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -10,7 +10,7 @@
 namespace VideoCore {
 
 std::unique_ptr<RendererBase> CreateRenderer(Core::Frontend::EmuWindow& emu_window) {
-    return std::make_unique<RendererOpenGL>(emu_window);
+    return std::make_unique<OpenGL::RendererOpenGL>(emu_window);
 }
 
 } // namespace VideoCore


### PR DESCRIPTION
Namespaces all OpenGL code under the OpenGL namespace.

Prevents polluting the global namespace and allows clear distinction between other renderers' code in the future.