### PR TITLE
config: Removed setting icon config

### DIFF
--- a/src/yuzu/configuration/configure_gamelist.cpp
+++ b/src/yuzu/configuration/configure_gamelist.cpp
@@ -56,7 +56,6 @@ void ConfigureGameList::setConfiguration() {
 
 void ConfigureGameList::applyConfiguration() {
     UISettings::values.show_unknown = ui->show_unknown->isChecked();
-    UISettings::values.icon_size = ui->icon_size_combobox->currentData().toUInt();
     UISettings::values.row_1_text_id = ui->row_1_text_combobox->currentData().toUInt();
     UISettings::values.row_2_text_id = ui->row_2_text_combobox->currentData().toUInt();
     Settings::Apply();


### PR DESCRIPTION
This config update causes not ideal behavior. i.e. If your first added a directory to the gamelist(which will have an icon size of 0) thereafter the icon size will remain to be zero until the config file is manually changed again. (Even if a proper game dump is imported into NAND)