### PR TITLE
bit_field: Convert ToBool() into explicit operator bool

### DIFF
--- a/src/common/bit_field.h
+++ b/src/common/bit_field.h
@@ -178,8 +178,7 @@ public:
         return ExtractValue(storage);
     }
 
-    // TODO: we may want to change this to explicit operator bool() if it's bug-free in VS2015
-    constexpr FORCE_INLINE bool ToBool() const {
+    constexpr explicit operator bool() const {
         return Value() != 0;
     }
 


### PR DESCRIPTION
Gets rid of a TODO that is long overdue.