### PR TITLE
sdmc_factory: Remove unnecessary core include

### DIFF
--- a/src/core/file_sys/sdmc_factory.cpp
+++ b/src/core/file_sys/sdmc_factory.cpp
@@ -3,7 +3,6 @@
 // Refer to the license.txt file included.
 
 #include <memory>
-#include "core/core.h"
 #include "core/file_sys/sdmc_factory.h"
 
 namespace FileSys {

--- a/src/core/file_sys/sdmc_factory.h
+++ b/src/core/file_sys/sdmc_factory.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "core/file_sys/vfs.h"
 #include "core/hle/result.h"
 
 namespace FileSys {


### PR DESCRIPTION
This doesn't require the central core header to be included, it just needs the vfs headers.