### PR TITLE
perf_stats: Change MAX_LAG_TIME_US to an appropriate value

### DIFF
--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -76,7 +76,7 @@ double PerfStats::GetLastFrameTimeScale() {
 void FrameLimiter::DoFrameLimiting(microseconds current_system_time_us) {
     // Max lag caused by slow frames. Can be adjusted to compensate for too many slow frames. Higher
     // values increase the time needed to recover and limit framerate again after spikes.
-    constexpr microseconds MAX_LAG_TIME_US = 25us;
+    constexpr microseconds MAX_LAG_TIME_US = 25000us;
 
     if (!Settings::values.toggle_framelimit) {
         return;


### PR DESCRIPTION
25us is far too small, and would result in std::this_thread::sleep_for
being called with this as a maximum value. This means that a guest
application that produces frames instantly would only be limited to
40 kHz.

25ms is a more appropriate value, as it allows for a 60 Hz refresh
rate while providing enough slack in the negative region.