### PR TITLE
logging/text_formatter: Use empty braces for initializing CONSOLE_SCREEN_BUFFER_INFO instance

### DIFF
--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -42,7 +42,7 @@ void PrintColoredMessage(const Entry& entry) {
         return;
     }
 
-    CONSOLE_SCREEN_BUFFER_INFO original_info = {0};
+    CONSOLE_SCREEN_BUFFER_INFO original_info = {};
     GetConsoleScreenBufferInfo(console_handle, &original_info);
 
     WORD color = 0;


### PR DESCRIPTION
The previous form of initializing done here is a C-ism, an empty set of braces is sufficient for initializing (and doesn't potentially cause missing brace warnings, given the first member of the struct is a COORD struct).