### PR TITLE
shader_bytecode: Parenthesize conditional expression within GetTextureType()

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -518,7 +518,7 @@ union Instruction {
                 return TextureType::Texture1D;
             }
             if (texture_info == 2 || texture_info == 8 || texture_info == 12 ||
-                texture_info >= 4 && texture_info <= 6) {
+                (texture_info >= 4 && texture_info <= 6)) {
                 return TextureType::Texture2D;
             }
             if (texture_info == 7) {


### PR DESCRIPTION
Resolves a `-Wlogical-op-parentheses` warning.