### PR TITLE
Revert "Shader: Use the right sampler type in the TEX, TEXS and TLDS …"

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -11,7 +11,6 @@
 #include <vector>
 #include "common/common_types.h"
 #include "common/hash.h"
-#include "video_core/engines/shader_bytecode.h"
 
 namespace GLShader {
 
@@ -73,9 +72,8 @@ class SamplerEntry {
     using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 
 public:
-    SamplerEntry(Maxwell::ShaderStage stage, size_t offset, size_t index,
-                 Tegra::Shader::TextureType type, bool is_array)
-        : offset(offset), stage(stage), sampler_index(index), type(type), is_array(is_array) {}
+    SamplerEntry(Maxwell::ShaderStage stage, size_t offset, size_t index)
+        : offset(offset), stage(stage), sampler_index(index) {}
 
     size_t GetOffset() const {
         return offset;
@@ -90,41 +88,8 @@ public:
     }
 
     std::string GetName() const {
-        return std::string(TextureSamplerNames[static_cast<size_t>(stage)]) + '_' +
-               std::to_string(sampler_index);
-    }
-
-    std::string GetTypeString() const {
-        using Tegra::Shader::TextureType;
-        std::string glsl_type;
-
-        switch (type) {
-        case TextureType::Texture1D:
-            glsl_type = "sampler1D";
-            break;
-        case TextureType::Texture2D:
-            glsl_type = "sampler2D";
-            break;
-        case TextureType::Texture3D:
-            glsl_type = "sampler3D";
-            break;
-        case TextureType::TextureCube:
-            glsl_type = "samplerCube";
-            break;
-        default:
-            UNIMPLEMENTED();
-        }
-        if (is_array)
-            glsl_type += "Array";
-        return glsl_type;
-    }
-
-    Tegra::Shader::TextureType GetType() const {
-        return type;
-    }
-
-    bool IsArray() const {
-        return is_array;
+        return std::string(TextureSamplerNames[static_cast<size_t>(stage)]) + '[' +
+               std::to_string(sampler_index) + ']';
     }
 
     static std::string GetArrayName(Maxwell::ShaderStage stage) {
@@ -135,14 +100,11 @@ private:
     static constexpr std::array<const char*, Maxwell::MaxShaderStage> TextureSamplerNames = {
         "tex_vs", "tex_tessc", "tex_tesse", "tex_gs", "tex_fs",
     };
-
     /// Offset in TSC memory from which to read the sampler object, as specified by the sampling
     /// instruction.
     size_t offset;
-    Maxwell::ShaderStage stage;      ///< Shader stage where this sampler was used.
-    size_t sampler_index;            ///< Value used to index into the generated GLSL sampler array.
-    Tegra::Shader::TextureType type; ///< The type used to sample this texture (Texture2D, etc)
-    bool is_array; ///< Whether the texture is being sampled as an array texture or not.
+    Maxwell::ShaderStage stage; ///< Shader stage where this sampler was used.
+    size_t sampler_index;       ///< Value used to index into the generated GLSL sampler array.
 };
 
 struct ShaderEntries {


### PR DESCRIPTION
This reverts commit 3ef4b3d4b445960576f10d1ba6521580d03e3da8. This commit had broken rendering in a lot of games (SMO, Splatoon, ARMS, etc.).

While we believe this change is technically correct, the amount of work to fix these rendering issues is a lot more than I think we expected. By breaking rendering in these games potentially indefinitely, it prohibits progress in other GPU work, and potentially hides other regressions.

I think this commit should be reintroduced as part of a change that actually implements these texture modes. I plan on working on this, but it could take me a bit, and there are likely other parts of these games we want to work on in the meantime.