### PR TITLE
maxwell_to_gl: Implement PrimitiveTopology::Lines

### DIFF
--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -107,6 +107,8 @@ inline GLenum PrimitiveTopology(Maxwell::PrimitiveTopology topology) {
     switch (topology) {
     case Maxwell::PrimitiveTopology::Points:
         return GL_POINTS;
+    case Maxwell::PrimitiveTopology::Lines:
+        return GL_LINES;
     case Maxwell::PrimitiveTopology::LineStrip:
         return GL_LINE_STRIP;
     case Maxwell::PrimitiveTopology::Triangles:


### PR DESCRIPTION
Used by Splatoon 2's debug menu. (However, it still doesn't render properly because it uses quads. GL_QUADS was deprecated as of OpenGL 3.1, so I'll leave this up to people more experienced than me)