### PR TITLE
config: Fixed icon size get set to 0

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -125,7 +125,7 @@ void Config::ReadValues() {
 
     qt_config->beginGroup("UIGameList");
     UISettings::values.show_unknown = qt_config->value("show_unknown", true).toBool();
-    UISettings::values.icon_size = qt_config->value("icon_size", 48).toUInt();
+    UISettings::values.icon_size = qt_config->value("icon_size", 64).toUInt();
     UISettings::values.row_1_text_id = qt_config->value("row_1_text_id", 0).toUInt();
     UISettings::values.row_2_text_id = qt_config->value("row_2_text_id", 3).toUInt();
     qt_config->endGroup();


### PR DESCRIPTION
48 Is not a valid icon size. If you use anything in the configuration menu, the icon size combobox will be empty(since 48 is not an option). This will result in icon_size = 0 being written to the config file.