### PR TITLE
 gl_shader_gen: Use a std::vector to represent program code instead of std::array

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -179,7 +179,7 @@ static GLShader::ProgramCode GetShaderProgramCode(Maxwell::ShaderProgram program
     auto& gpu = Core::System::GetInstance().GPU().Maxwell3D();
 
     // Fetch program code from memory
-    GLShader::ProgramCode program_code;
+    GLShader::ProgramCode program_code(GLShader::MAX_PROGRAM_CODE_LENGTH);
     auto& shader_config = gpu.regs.shader_config[static_cast<size_t>(program)];
     const u64 gpu_address{gpu.regs.code_address.CodeAddress() + shader_config.offset};
     const boost::optional<VAddr> cpu_address{gpu.memory_manager.GpuToCpuAddress(gpu_address)};

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -115,7 +115,7 @@ struct ShaderEntries {
 using ProgramResult = std::pair<std::string, ShaderEntries>;
 
 struct ShaderSetup {
-    ShaderSetup(ProgramCode program_code) {
+    explicit ShaderSetup(ProgramCode program_code) {
         program.code = std::move(program_code);
     }
 


### PR DESCRIPTION
While convenient as a std::array, it's also quite a large set of data as well (32KB). It being an array also means data cannot be std::moved. Any situation where the code is being set or relocated means that a full copy of that 32KB data must be done.

If we use a std::vector we do need to allocate on the heap, however, it does allow us to std::move the data we have within the std::vector into another std::vector instance, eliminating the need to always copy the program data (as std::move in this case would just transfer the pointers and bare necessities over to the new vector instance).

That, and we aren't just tossing 32KB (64KB in the case of declaring a ShaderSetup instance) onto the stack at one time.