### PR TITLE
gl_rasterizer_cache: Several improvements

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -799,7 +799,6 @@ Surface RasterizerCacheOpenGL::RecreateSurface(const Surface& surface,
                                                const SurfaceParams& new_params) {
     // Verify surface is compatible for blitting
     const auto& params{surface->GetSurfaceParams()};
-    ASSERT(params.type == new_params.type);
 
     // Create a new surface with the new parameters, and blit the previous surface to it
     Surface new_surface{std::make_shared<CachedSurface>(new_params)};


### PR DESCRIPTION
Several improvements to the rasterizer cache, mostly to improve performance.

* The biggest change here is to "remember" previously used unique surfaces (a unique surface is defined by unique set of address+format+type+width+height+etc.). This avoids scenarios where surfaces are constantly created/destroyed because they are being reused with different parameters. Note, there is still only one "active" surface at a time for a given cached address.
* Uses BlitTexture instead of PBOs to copy surfaces when the format is the same, I assume this is a little bit faster (please correct if I am wrong).
* Implements compressed texture copies in RecreateSurface. This should be mostly unused, but I happened to implement it by mistake.

Suggest reviewing commit by commit. I noticed a slight perf increase in SMO (couple fps in game), not sure how this translates to other titles - Please test. CC @degasus if I'm doing anything wrong/unnecessary here.