### PR TITLE
renderer_opengl: Implement a new shader cache.

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -27,6 +27,8 @@ add_library(video_core STATIC
     renderer_opengl/gl_rasterizer_cache.cpp
     renderer_opengl/gl_rasterizer_cache.h
     renderer_opengl/gl_resource_manager.h
+    renderer_opengl/gl_shader_cache.cpp
+    renderer_opengl/gl_shader_cache.h
     renderer_opengl/gl_shader_decompiler.cpp
     renderer_opengl/gl_shader_decompiler.h
     renderer_opengl/gl_shader_gen.cpp

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(video_core STATIC
     macro_interpreter.h
     memory_manager.cpp
     memory_manager.h
+    rasterizer_cache.h
     rasterizer_interface.h
     renderer_base.cpp
     renderer_base.h

--- a/src/video_core/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache.h
@@ -1,0 +1,116 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <unordered_map>
+#include <boost/icl/interval_map.hpp>
+#include <boost/range/iterator_range.hpp>
+
+#include "common/common_types.h"
+#include "core/memory.h"
+#include "video_core/memory_manager.h"
+
+template <class T>
+class RasterizerCache : NonCopyable {
+public:
+    /// Mark the specified region as being invalidated
+    void InvalidateRegion(Tegra::GPUVAddr region_addr, size_t region_size) {
+        for (auto iter = cached_objects.cbegin(); iter != cached_objects.cend();) {
+            const auto& object{iter->second};
+
+            ++iter;
+
+            if (object->GetAddr() <= (region_addr + region_size) &&
+                region_addr <= (object->GetAddr() + object->GetSizeInBytes())) {
+                // Regions overlap, so invalidate
+                Unregister(object);
+            }
+        }
+    }
+
+protected:
+    /// Tries to get an object from the cache with the specified address
+    T TryGet(Tegra::GPUVAddr addr) const {
+        const auto& search{cached_objects.find(addr)};
+        if (search != cached_objects.end()) {
+            return search->second;
+        }
+
+        return nullptr;
+    }
+
+    /// Gets a reference to the cache
+    const std::unordered_map<Tegra::GPUVAddr, T>& GetCache() const {
+        return cached_objects;
+    }
+
+    /// Register an object into the cache
+    void Register(const T& object) {
+        const auto& search{cached_objects.find(object->GetAddr())};
+        if (search != cached_objects.end()) {
+            // Registered already
+            return;
+        }
+
+        cached_objects[object->GetAddr()] = object;
+        UpdatePagesCachedCount(object->GetAddr(), object->GetSizeInBytes(), 1);
+    }
+
+    /// Unregisters an object from the cache
+    void Unregister(const T& object) {
+        const auto& search{cached_objects.find(object->GetAddr())};
+        if (search == cached_objects.end()) {
+            // Unregistered already
+            return;
+        }
+
+        UpdatePagesCachedCount(object->GetAddr(), object->GetSizeInBytes(), -1);
+        cached_objects.erase(search);
+    }
+
+private:
+    using PageMap = boost::icl::interval_map<u64, int>;
+
+    template <typename Map, typename Interval>
+    constexpr auto RangeFromInterval(Map& map, const Interval& interval) {
+        return boost::make_iterator_range(map.equal_range(interval));
+    }
+
+    /// Increase/decrease the number of object in pages touching the specified region
+    void UpdatePagesCachedCount(Tegra::GPUVAddr addr, u64 size, int delta) {
+        const u64 page_start{addr >> Tegra::MemoryManager::PAGE_BITS};
+        const u64 page_end{(addr + size) >> Tegra::MemoryManager::PAGE_BITS};
+
+        // Interval maps will erase segments if count reaches 0, so if delta is negative we have to
+        // subtract after iterating
+        const auto pages_interval = PageMap::interval_type::right_open(page_start, page_end);
+        if (delta > 0)
+            cached_pages.add({pages_interval, delta});
+
+        for (const auto& pair : RangeFromInterval(cached_pages, pages_interval)) {
+            const auto interval = pair.first & pages_interval;
+            const int count = pair.second;
+
+            const Tegra::GPUVAddr interval_start_addr = boost::icl::first(interval)
+                                                        << Tegra::MemoryManager::PAGE_BITS;
+            const Tegra::GPUVAddr interval_end_addr = boost::icl::last_next(interval)
+                                                      << Tegra::MemoryManager::PAGE_BITS;
+            const u64 interval_size = interval_end_addr - interval_start_addr;
+
+            if (delta > 0 && count == delta)
+                Memory::RasterizerMarkRegionCached(interval_start_addr, interval_size, true);
+            else if (delta < 0 && count == -delta)
+                Memory::RasterizerMarkRegionCached(interval_start_addr, interval_size, false);
+            else
+                ASSERT(count >= 0);
+        }
+
+        if (delta < 0)
+            cached_pages.add({pages_interval, delta});
+    }
+
+    std::unordered_map<Tegra::GPUVAddr, T> cached_objects;
+    PageMap cached_pages;
+};

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -178,19 +178,6 @@ std::pair<u8*, GLintptr> RasterizerOpenGL::SetupVertexArrays(u8* array_ptr,
     return {array_ptr, buffer_offset};
 }
 
-static GLShader::ProgramCode GetShaderProgramCode(Maxwell::ShaderProgram program) {
-    auto& gpu = Core::System::GetInstance().GPU().Maxwell3D();
-
-    // Fetch program code from memory
-    GLShader::ProgramCode program_code(GLShader::MAX_PROGRAM_CODE_LENGTH);
-    auto& shader_config = gpu.regs.shader_config[static_cast<size_t>(program)];
-    const u64 gpu_address{gpu.regs.code_address.CodeAddress() + shader_config.offset};
-    const boost::optional<VAddr> cpu_address{gpu.memory_manager.GpuToCpuAddress(gpu_address)};
-    Memory::ReadBlock(*cpu_address, program_code.data(), program_code.size() * sizeof(u64));
-
-    return program_code;
-}
-
 std::pair<u8*, GLintptr> RasterizerOpenGL::SetupShaders(u8* buffer_ptr, GLintptr buffer_offset) {
     auto& gpu = Core::System::GetInstance().GPU().Maxwell3D();
 
@@ -224,31 +211,17 @@ std::pair<u8*, GLintptr> RasterizerOpenGL::SetupShaders(u8* buffer_ptr, GLintptr
         buffer_ptr += sizeof(ubo);
         buffer_offset += sizeof(ubo);
 
-        GLShader::ShaderSetup setup{GetShaderProgramCode(program)};
-        GLShader::ShaderEntries shader_resources;
+        const Tegra::GPUVAddr addr{gpu.regs.code_address.CodeAddress() + shader_config.offset};
+        Shader shader{shader_cache.GetStageProgram(program)};
 
         switch (program) {
-        case Maxwell::ShaderProgram::VertexA: {
-            // VertexB is always enabled, so when VertexA is enabled, we have two vertex shaders.
-            // Conventional HW does not support this, so we combine VertexA and VertexB into one
-            // stage here.
-            setup.SetProgramB(GetShaderProgramCode(Maxwell::ShaderProgram::VertexB));
-            GLShader::MaxwellVSConfig vs_config{setup};
-            shader_resources =
-                shader_program_manager->UseProgrammableVertexShader(vs_config, setup);
-            break;
-        }
-
+        case Maxwell::ShaderProgram::VertexA:
         case Maxwell::ShaderProgram::VertexB: {
-            GLShader::MaxwellVSConfig vs_config{setup};
-            shader_resources =
-                shader_program_manager->UseProgrammableVertexShader(vs_config, setup);
+            shader_program_manager->UseProgrammableVertexShader(shader->GetProgramHandle());
             break;
         }
         case Maxwell::ShaderProgram::Fragment: {
-            GLShader::MaxwellFSConfig fs_config{setup};
-            shader_resources =
-                shader_program_manager->UseProgrammableFragmentShader(fs_config, setup);
+            shader_program_manager->UseProgrammableFragmentShader(shader->GetProgramHandle());
             break;
         }
         default:
@@ -257,18 +230,14 @@ std::pair<u8*, GLintptr> RasterizerOpenGL::SetupShaders(u8* buffer_ptr, GLintptr
             UNREACHABLE();
         }
 
-        GLuint gl_stage_program = shader_program_manager->GetCurrentProgramStage(
-            static_cast<Maxwell::ShaderStage>(stage));
-
         // Configure the const buffers for this shader stage.
-        std::tie(buffer_ptr, buffer_offset, current_constbuffer_bindpoint) = SetupConstBuffers(
-            buffer_ptr, buffer_offset, static_cast<Maxwell::ShaderStage>(stage), gl_stage_program,
-            current_constbuffer_bindpoint, shader_resources.const_buffer_entries);
+        std::tie(buffer_ptr, buffer_offset, current_constbuffer_bindpoint) =
+            SetupConstBuffers(buffer_ptr, buffer_offset, static_cast<Maxwell::ShaderStage>(stage),
+                              shader, current_constbuffer_bindpoint);
 
         // Configure the textures for this shader stage.
-        current_texture_bindpoint =
-            SetupTextures(static_cast<Maxwell::ShaderStage>(stage), gl_stage_program,
-                          current_texture_bindpoint, shader_resources.texture_samplers);
+        current_texture_bindpoint = SetupTextures(static_cast<Maxwell::ShaderStage>(stage), shader,
+                                                  current_texture_bindpoint);
 
         // When VertexA is enabled, we have dual vertex shaders
         if (program == Maxwell::ShaderProgram::VertexA) {
@@ -580,6 +549,7 @@ void RasterizerOpenGL::FlushRegion(Tegra::GPUVAddr addr, u64 size) {
 void RasterizerOpenGL::InvalidateRegion(Tegra::GPUVAddr addr, u64 size) {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
     res_cache.InvalidateRegion(addr, size);
+    shader_cache.InvalidateRegion(addr, size);
 }
 
 void RasterizerOpenGL::FlushAndInvalidateRegion(Tegra::GPUVAddr addr, u64 size) {
@@ -669,15 +639,17 @@ void RasterizerOpenGL::SamplerInfo::SyncWithConfig(const Tegra::Texture::TSCEntr
     }
 }
 
-std::tuple<u8*, GLintptr, u32> RasterizerOpenGL::SetupConstBuffers(
-    u8* buffer_ptr, GLintptr buffer_offset, Maxwell::ShaderStage stage, GLuint program,
-    u32 current_bindpoint, const std::vector<GLShader::ConstBufferEntry>& entries) {
+std::tuple<u8*, GLintptr, u32> RasterizerOpenGL::SetupConstBuffers(u8* buffer_ptr,
+                                                                   GLintptr buffer_offset,
+                                                                   Maxwell::ShaderStage stage,
+                                                                   Shader& shader,
+                                                                   u32 current_bindpoint) {
     const auto& gpu = Core::System::GetInstance().GPU();
     const auto& maxwell3d = gpu.Maxwell3D();
+    const auto& shader_stage = maxwell3d.state.shader_stages[static_cast<size_t>(stage)];
+    const auto& entries = shader->GetShaderEntries().const_buffer_entries;
 
     // Upload only the enabled buffers from the 16 constbuffers of each shader stage
-    const auto& shader_stage = maxwell3d.state.shader_stages[static_cast<size_t>(stage)];
-
     for (u32 bindpoint = 0; bindpoint < entries.size(); ++bindpoint) {
         const auto& used_buffer = entries[bindpoint];
         const auto& buffer = shader_stage.const_buffers[used_buffer.GetIndex()];
@@ -716,12 +688,9 @@ std::tuple<u8*, GLintptr, u32> RasterizerOpenGL::SetupConstBuffers(
                           stream_buffer.GetHandle(), const_buffer_offset, size);
 
         // Now configure the bindpoint of the buffer inside the shader
-        const std::string buffer_name = used_buffer.GetName();
-        const GLuint index =
-            glGetProgramResourceIndex(program, GL_UNIFORM_BLOCK, buffer_name.c_str());
-        if (index != GL_INVALID_INDEX) {
-            glUniformBlockBinding(program, index, current_bindpoint + bindpoint);
-        }
+        glUniformBlockBinding(shader->GetProgramHandle(),
+                              shader->GetProgramResourceIndex(used_buffer.GetName()),
+                              current_bindpoint + bindpoint);
     }
 
     state.Apply();
@@ -729,10 +698,10 @@ std::tuple<u8*, GLintptr, u32> RasterizerOpenGL::SetupConstBuffers(
     return {buffer_ptr, buffer_offset, current_bindpoint + static_cast<u32>(entries.size())};
 }
 
-u32 RasterizerOpenGL::SetupTextures(Maxwell::ShaderStage stage, GLuint program, u32 current_unit,
-                                    const std::vector<GLShader::SamplerEntry>& entries) {
+u32 RasterizerOpenGL::SetupTextures(Maxwell::ShaderStage stage, Shader& shader, u32 current_unit) {
     const auto& gpu = Core::System::GetInstance().GPU();
     const auto& maxwell3d = gpu.Maxwell3D();
+    const auto& entries = shader->GetShaderEntries().texture_samplers;
 
     ASSERT_MSG(current_unit + entries.size() <= std::size(state.texture_units),
                "Exceeded the number of active textures.");
@@ -742,12 +711,9 @@ u32 RasterizerOpenGL::SetupTextures(Maxwell::ShaderStage stage, GLuint program, 
         u32 current_bindpoint = current_unit + bindpoint;
 
         // Bind the uniform to the sampler.
-        GLint uniform = glGetUniformLocation(program, entry.GetName().c_str());
-        if (uniform == -1) {
-            continue;
-        }
 
-        glProgramUniform1i(program, uniform, current_bindpoint);
+        glProgramUniform1i(shader->GetProgramHandle(), shader->GetUniformLocation(entry.GetName()),
+                           current_bindpoint);
 
         const auto texture = maxwell3d.GetStageTexture(entry.GetStage(), entry.GetOffset());
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -571,12 +571,10 @@ void RasterizerOpenGL::NotifyMaxwellRegisterChanged(u32 method) {}
 
 void RasterizerOpenGL::FlushAll() {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
-    res_cache.FlushRegion(0, Kernel::VMManager::MAX_ADDRESS);
 }
 
 void RasterizerOpenGL::FlushRegion(Tegra::GPUVAddr addr, u64 size) {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
-    res_cache.FlushRegion(addr, size);
 }
 
 void RasterizerOpenGL::InvalidateRegion(Tegra::GPUVAddr addr, u64 size) {
@@ -586,8 +584,7 @@ void RasterizerOpenGL::InvalidateRegion(Tegra::GPUVAddr addr, u64 size) {
 
 void RasterizerOpenGL::FlushAndInvalidateRegion(Tegra::GPUVAddr addr, u64 size) {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
-    res_cache.FlushRegion(addr, size);
-    res_cache.InvalidateRegion(addr, size);
+    InvalidateRegion(addr, size);
 }
 
 bool RasterizerOpenGL::AccelerateDisplayTransfer(const void* config) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -17,6 +17,7 @@
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
+#include "video_core/renderer_opengl/gl_shader_cache.h"
 #include "video_core/renderer_opengl/gl_shader_gen.h"
 #include "video_core/renderer_opengl/gl_shader_manager.h"
 #include "video_core/renderer_opengl/gl_state.h"
@@ -99,26 +100,23 @@ private:
     /*
      * Configures the current constbuffers to use for the draw command.
      * @param stage The shader stage to configure buffers for.
-     * @param program The OpenGL program object that contains the specified stage.
+     * @param shader The shader object that contains the specified stage.
      * @param current_bindpoint The offset at which to start counting new buffer bindpoints.
-     * @param entries Vector describing the buffers that are actually used in the guest shader.
      * @returns The next available bindpoint for use in the next shader stage.
      */
     std::tuple<u8*, GLintptr, u32> SetupConstBuffers(
         u8* buffer_ptr, GLintptr buffer_offset, Tegra::Engines::Maxwell3D::Regs::ShaderStage stage,
-        GLuint program, u32 current_bindpoint,
-        const std::vector<GLShader::ConstBufferEntry>& entries);
+        Shader& shader, u32 current_bindpoint);
 
     /*
      * Configures the current textures to use for the draw command.
      * @param stage The shader stage to configure textures for.
-     * @param program The OpenGL program object that contains the specified stage.
+     * @param shader The shader object that contains the specified stage.
      * @param current_unit The offset at which to start counting unused texture units.
-     * @param entries Vector describing the textures that are actually used in the guest shader.
      * @returns The next available bindpoint for use in the next shader stage.
      */
-    u32 SetupTextures(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage, GLuint program,
-                      u32 current_unit, const std::vector<GLShader::SamplerEntry>& entries);
+    u32 SetupTextures(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage, Shader& shader,
+                      u32 current_unit);
 
     /// Syncs the viewport to match the guest state
     void SyncViewport(const MathUtil::Rectangle<u32>& surfaces_rect);
@@ -157,6 +155,7 @@ private:
     OpenGLState state;
 
     RasterizerCacheOpenGL res_cache;
+    ShaderCacheOpenGL shader_cache;
 
     Core::Frontend::EmuWindow& emu_window;
 

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -1,0 +1,131 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/assert.h"
+#include "core/core.h"
+#include "core/memory.h"
+#include "video_core/engines/maxwell_3d.h"
+#include "video_core/renderer_opengl/gl_shader_cache.h"
+#include "video_core/renderer_opengl/gl_shader_manager.h"
+
+namespace OpenGL {
+
+/// Gets the address for the specified shader stage program
+static Tegra::GPUVAddr GetShaderAddress(Maxwell::ShaderProgram program) {
+    auto& gpu = Core::System::GetInstance().GPU().Maxwell3D();
+
+    GLShader::ProgramCode program_code(GLShader::MAX_PROGRAM_CODE_LENGTH);
+    auto& shader_config = gpu.regs.shader_config[static_cast<size_t>(program)];
+    return gpu.regs.code_address.CodeAddress() + shader_config.offset;
+}
+
+/// Gets the shader program code from memory for the specified address
+static GLShader::ProgramCode GetShaderCode(Tegra::GPUVAddr addr) {
+    auto& gpu = Core::System::GetInstance().GPU().Maxwell3D();
+
+    GLShader::ProgramCode program_code(GLShader::MAX_PROGRAM_CODE_LENGTH);
+    const boost::optional<VAddr> cpu_address{gpu.memory_manager.GpuToCpuAddress(addr)};
+    Memory::ReadBlock(*cpu_address, program_code.data(), program_code.size() * sizeof(u64));
+
+    return program_code;
+}
+
+/// Helper function to set shader uniform block bindings for a single shader stage
+static void SetShaderUniformBlockBinding(GLuint shader, const char* name,
+                                         Maxwell::ShaderStage binding, size_t expected_size) {
+    const GLuint ub_index = glGetUniformBlockIndex(shader, name);
+    if (ub_index == GL_INVALID_INDEX) {
+        return;
+    }
+
+    GLint ub_size = 0;
+    glGetActiveUniformBlockiv(shader, ub_index, GL_UNIFORM_BLOCK_DATA_SIZE, &ub_size);
+    ASSERT_MSG(static_cast<size_t>(ub_size) == expected_size,
+               "Uniform block size did not match! Got {}, expected {}", ub_size, expected_size);
+    glUniformBlockBinding(shader, ub_index, static_cast<GLuint>(binding));
+}
+
+/// Sets shader uniform block bindings for an entire shader program
+static void SetShaderUniformBlockBindings(GLuint shader) {
+    SetShaderUniformBlockBinding(shader, "vs_config", Maxwell::ShaderStage::Vertex,
+                                 sizeof(GLShader::MaxwellUniformData));
+    SetShaderUniformBlockBinding(shader, "gs_config", Maxwell::ShaderStage::Geometry,
+                                 sizeof(GLShader::MaxwellUniformData));
+    SetShaderUniformBlockBinding(shader, "fs_config", Maxwell::ShaderStage::Fragment,
+                                 sizeof(GLShader::MaxwellUniformData));
+}
+
+CachedShader::CachedShader(Tegra::GPUVAddr addr, Maxwell::ShaderProgram program_type)
+    : addr{addr}, program_type{program_type}, setup{GetShaderCode(addr)} {
+
+    GLShader::ProgramResult program_result;
+    GLenum gl_type{};
+
+    switch (program_type) {
+    case Maxwell::ShaderProgram::VertexA:
+        // VertexB is always enabled, so when VertexA is enabled, we have two vertex shaders.
+        // Conventional HW does not support this, so we combine VertexA and VertexB into one
+        // stage here.
+        setup.SetProgramB(GetShaderCode(GetShaderAddress(Maxwell::ShaderProgram::VertexB)));
+    case Maxwell::ShaderProgram::VertexB:
+        program_result = GLShader::GenerateVertexShader(setup);
+        gl_type = GL_VERTEX_SHADER;
+        break;
+    case Maxwell::ShaderProgram::Fragment:
+        program_result = GLShader::GenerateFragmentShader(setup);
+        gl_type = GL_FRAGMENT_SHADER;
+        break;
+    default:
+        LOG_CRITICAL(HW_GPU, "Unimplemented program_type={}", static_cast<u32>(program_type));
+        UNREACHABLE();
+        return;
+    }
+
+    entries = program_result.second;
+
+    OGLShader shader;
+    shader.Create(program_result.first.c_str(), gl_type);
+    program.Create(true, shader.handle);
+    SetShaderUniformBlockBindings(program.handle);
+}
+
+GLuint CachedShader::GetProgramResourceIndex(const std::string& name) {
+    auto search{resource_cache.find(name)};
+    if (search == resource_cache.end()) {
+        const GLuint index{
+            glGetProgramResourceIndex(program.handle, GL_UNIFORM_BLOCK, name.c_str())};
+        resource_cache[name] = index;
+        return index;
+    }
+
+    return search->second;
+}
+
+GLint CachedShader::GetUniformLocation(const std::string& name) {
+    auto search{uniform_cache.find(name)};
+    if (search == uniform_cache.end()) {
+        const GLint index{glGetUniformLocation(program.handle, name.c_str())};
+        uniform_cache[name] = index;
+        return index;
+    }
+
+    return search->second;
+}
+
+Shader ShaderCacheOpenGL::GetStageProgram(Maxwell::ShaderProgram program) {
+    const Tegra::GPUVAddr program_addr{GetShaderAddress(program)};
+
+    // Look up shader in the cache based on address
+    Shader shader{TryGet(program_addr)};
+
+    if (!shader) {
+        // No shader found - create a new one
+        shader = std::make_shared<CachedShader>(program_addr, program);
+        Register(shader);
+    }
+
+    return shader;
+}
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_shader_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_cache.h
@@ -1,0 +1,69 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+
+#include "common/common_types.h"
+#include "video_core/memory_manager.h"
+#include "video_core/rasterizer_cache.h"
+#include "video_core/renderer_opengl/gl_resource_manager.h"
+#include "video_core/renderer_opengl/gl_shader_gen.h"
+
+namespace OpenGL {
+
+class CachedShader;
+using Shader = std::shared_ptr<CachedShader>;
+using Maxwell = Tegra::Engines::Maxwell3D::Regs;
+
+class CachedShader final {
+public:
+    CachedShader(Tegra::GPUVAddr addr, Maxwell::ShaderProgram program_type);
+
+    /// Gets the address of the shader in guest memory, required for cache management
+    Tegra::GPUVAddr GetAddr() const {
+        return addr;
+    }
+
+    /// Gets the size of the shader in guest memory, required for cache management
+    size_t GetSizeInBytes() const {
+        return sizeof(GLShader::ProgramCode);
+    }
+
+    /// Gets the shader entries for the shader
+    const GLShader::ShaderEntries& GetShaderEntries() const {
+        return entries;
+    }
+
+    /// Gets the GL program handle for the shader
+    GLuint GetProgramHandle() const {
+        return program.handle;
+    }
+
+    /// Gets the GL program resource location for the specified resource, caching as needed
+    GLuint GetProgramResourceIndex(const std::string& name);
+
+    /// Gets the GL uniform location for the specified resource, caching as needed
+    GLint GetUniformLocation(const std::string& name);
+
+private:
+    Tegra::GPUVAddr addr;
+    Maxwell::ShaderProgram program_type;
+    GLShader::ShaderSetup setup;
+    GLShader::ShaderEntries entries;
+    OGLProgram program;
+
+    std::unordered_map<std::string, GLuint> resource_cache;
+    std::unordered_map<std::string, GLint> uniform_cache;
+};
+
+class ShaderCacheOpenGL final : public RasterizerCache<Shader> {
+public:
+    /// Gets the current specified shader stage program
+    Shader GetStageProgram(Maxwell::ShaderProgram program);
+};
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -13,7 +13,7 @@ using Tegra::Engines::Maxwell3D;
 
 static constexpr u32 PROGRAM_OFFSET{10};
 
-ProgramResult GenerateVertexShader(const ShaderSetup& setup, const MaxwellVSConfig& config) {
+ProgramResult GenerateVertexShader(const ShaderSetup& setup) {
     std::string out = "#version 430 core\n";
     out += "#extension GL_ARB_separate_shader_objects : enable\n\n";
     out += Decompiler::GetCommonDeclarations();
@@ -75,7 +75,7 @@ void main() {
     return {out, program.second};
 }
 
-ProgramResult GenerateFragmentShader(const ShaderSetup& setup, const MaxwellFSConfig& config) {
+ProgramResult GenerateFragmentShader(const ShaderSetup& setup) {
     std::string out = "#version 430 core\n";
     out += "#extension GL_ARB_separate_shader_objects : enable\n\n";
     out += Decompiler::GetCommonDeclarations();

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -3,38 +3,9 @@
 // Refer to the license.txt file included.
 
 #include "core/core.h"
-#include "core/hle/kernel/process.h"
-#include "video_core/engines/maxwell_3d.h"
 #include "video_core/renderer_opengl/gl_shader_manager.h"
 
 namespace OpenGL::GLShader {
-
-namespace Impl {
-static void SetShaderUniformBlockBinding(GLuint shader, const char* name,
-                                         Maxwell3D::Regs::ShaderStage binding,
-                                         size_t expected_size) {
-    const GLuint ub_index = glGetUniformBlockIndex(shader, name);
-    if (ub_index == GL_INVALID_INDEX) {
-        return;
-    }
-
-    GLint ub_size = 0;
-    glGetActiveUniformBlockiv(shader, ub_index, GL_UNIFORM_BLOCK_DATA_SIZE, &ub_size);
-    ASSERT_MSG(static_cast<size_t>(ub_size) == expected_size,
-               "Uniform block size did not match! Got {}, expected {}", ub_size, expected_size);
-    glUniformBlockBinding(shader, ub_index, static_cast<GLuint>(binding));
-}
-
-void SetShaderUniformBlockBindings(GLuint shader) {
-    SetShaderUniformBlockBinding(shader, "vs_config", Maxwell3D::Regs::ShaderStage::Vertex,
-                                 sizeof(MaxwellUniformData));
-    SetShaderUniformBlockBinding(shader, "gs_config", Maxwell3D::Regs::ShaderStage::Geometry,
-                                 sizeof(MaxwellUniformData));
-    SetShaderUniformBlockBinding(shader, "fs_config", Maxwell3D::Regs::ShaderStage::Fragment,
-                                 sizeof(MaxwellUniformData));
-}
-
-} // namespace Impl
 
 void MaxwellUniformData::SetFromRegs(const Maxwell3D::State::ShaderStageInfo& shader_stage) {
     const auto& gpu = Core::System::GetInstance().GPU().Maxwell3D();

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -4,12 +4,9 @@
 
 #pragma once
 
-#include <tuple>
-#include <unordered_map>
-#include <boost/functional/hash.hpp>
 #include <glad/glad.h>
+
 #include "video_core/renderer_opengl/gl_resource_manager.h"
-#include "video_core/renderer_opengl/gl_shader_gen.h"
 #include "video_core/renderer_opengl/maxwell_to_gl.h"
 
 namespace OpenGL::GLShader {
@@ -18,10 +15,6 @@ namespace OpenGL::GLShader {
 static constexpr size_t NumTextureSamplers = 32;
 
 using Tegra::Engines::Maxwell3D;
-
-namespace Impl {
-void SetShaderUniformBlockBindings(GLuint shader);
-} // namespace Impl
 
 /// Uniform structure for the Uniform Buffer Object, all vectors must be 16-byte aligned
 // NOTE: Always keep a vec4 at the end. The GL spec is not clear whether the alignment at
@@ -36,102 +29,22 @@ static_assert(sizeof(MaxwellUniformData) == 32, "MaxwellUniformData structure si
 static_assert(sizeof(MaxwellUniformData) < 16384,
               "MaxwellUniformData structure must be less than 16kb as per the OpenGL spec");
 
-class OGLShaderStage {
-public:
-    OGLShaderStage() = default;
-
-    void Create(const ProgramResult& program_result, GLenum type) {
-        OGLShader shader;
-        shader.Create(program_result.first.c_str(), type);
-        program.Create(true, shader.handle);
-        Impl::SetShaderUniformBlockBindings(program.handle);
-        entries = program_result.second;
-    }
-    GLuint GetHandle() const {
-        return program.handle;
-    }
-
-    ShaderEntries GetEntries() const {
-        return entries;
-    }
-
-private:
-    OGLProgram program;
-    ShaderEntries entries;
-};
-
-// TODO(wwylele): beautify this doc
-// This is a shader cache designed for translating PICA shader to GLSL shader.
-// The double cache is needed because diffent KeyConfigType, which includes a hash of the code
-// region (including its leftover unused code) can generate the same GLSL code.
-template <typename KeyConfigType,
-          ProgramResult (*CodeGenerator)(const ShaderSetup&, const KeyConfigType&),
-          GLenum ShaderType>
-class ShaderCache {
-public:
-    ShaderCache() = default;
-
-    using Result = std::pair<GLuint, ShaderEntries>;
-
-    Result Get(const KeyConfigType& key, const ShaderSetup& setup) {
-        auto map_it = shader_map.find(key);
-        if (map_it == shader_map.end()) {
-            ProgramResult program = CodeGenerator(setup, key);
-
-            auto [iter, new_shader] = shader_cache.emplace(program.first, OGLShaderStage{});
-            OGLShaderStage& cached_shader = iter->second;
-            if (new_shader) {
-                cached_shader.Create(program, ShaderType);
-            }
-            shader_map[key] = &cached_shader;
-            return {cached_shader.GetHandle(), program.second};
-        } else {
-            return {map_it->second->GetHandle(), map_it->second->GetEntries()};
-        }
-    }
-
-private:
-    std::unordered_map<KeyConfigType, OGLShaderStage*> shader_map;
-    std::unordered_map<std::string, OGLShaderStage> shader_cache;
-};
-
-using VertexShaders = ShaderCache<MaxwellVSConfig, &GenerateVertexShader, GL_VERTEX_SHADER>;
-
-using FragmentShaders = ShaderCache<MaxwellFSConfig, &GenerateFragmentShader, GL_FRAGMENT_SHADER>;
-
 class ProgramManager {
 public:
     ProgramManager() {
         pipeline.Create();
     }
 
-    ShaderEntries UseProgrammableVertexShader(const MaxwellVSConfig& config,
-                                              const ShaderSetup& setup) {
-        ShaderEntries result;
-        std::tie(current.vs, result) = vertex_shaders.Get(config, setup);
-        return result;
+    void UseProgrammableVertexShader(GLuint program) {
+        vs = program;
     }
 
-    ShaderEntries UseProgrammableFragmentShader(const MaxwellFSConfig& config,
-                                                const ShaderSetup& setup) {
-        ShaderEntries result;
-        std::tie(current.fs, result) = fragment_shaders.Get(config, setup);
-        return result;
-    }
-
-    GLuint GetCurrentProgramStage(Maxwell3D::Regs::ShaderStage stage) const {
-        switch (stage) {
-        case Maxwell3D::Regs::ShaderStage::Vertex:
-            return current.vs;
-        case Maxwell3D::Regs::ShaderStage::Fragment:
-            return current.fs;
-        }
-
-        UNREACHABLE();
+    void UseProgrammableFragmentShader(GLuint program) {
+        fs = program;
     }
 
     void UseTrivialGeometryShader() {
-        current.gs = 0;
+        gs = 0;
     }
 
     void ApplyTo(OpenGLState& state) {
@@ -140,35 +53,16 @@ public:
                            GL_VERTEX_SHADER_BIT | GL_GEOMETRY_SHADER_BIT | GL_FRAGMENT_SHADER_BIT,
                            0);
 
-        glUseProgramStages(pipeline.handle, GL_VERTEX_SHADER_BIT, current.vs);
-        glUseProgramStages(pipeline.handle, GL_GEOMETRY_SHADER_BIT, current.gs);
-        glUseProgramStages(pipeline.handle, GL_FRAGMENT_SHADER_BIT, current.fs);
+        glUseProgramStages(pipeline.handle, GL_VERTEX_SHADER_BIT, vs);
+        glUseProgramStages(pipeline.handle, GL_GEOMETRY_SHADER_BIT, gs);
+        glUseProgramStages(pipeline.handle, GL_FRAGMENT_SHADER_BIT, fs);
         state.draw.shader_program = 0;
         state.draw.program_pipeline = pipeline.handle;
     }
 
 private:
-    struct ShaderTuple {
-        GLuint vs = 0, gs = 0, fs = 0;
-        bool operator==(const ShaderTuple& rhs) const {
-            return std::tie(vs, gs, fs) == std::tie(rhs.vs, rhs.gs, rhs.fs);
-        }
-        struct Hash {
-            std::size_t operator()(const ShaderTuple& tuple) const {
-                std::size_t hash = 0;
-                boost::hash_combine(hash, tuple.vs);
-                boost::hash_combine(hash, tuple.gs);
-                boost::hash_combine(hash, tuple.fs);
-                return hash;
-            }
-        };
-    };
-    ShaderTuple current;
-    VertexShaders vertex_shaders;
-    FragmentShaders fragment_shaders;
-
-    std::unordered_map<ShaderTuple, OGLProgram, ShaderTuple::Hash> program_cache;
     OGLPipeline pipeline;
+    GLuint vs{}, fs{}, gs{};
 };
 
 } // namespace OpenGL::GLShader


### PR DESCRIPTION
This rewrites our shader cache to be a bit more efficient. Summary of changes:
* Refactor the existing rasterizer cache/invalidation code out of the surface cache, so we can reuse it to cache and invalidate things other than textures and framebuffers.
* Use this to cache shaders based on address. This avoids having to memcpy and hash a 32Kb shader for each shader stage every draw call.
* Caches the results of `glGetProgramResourceIndex` and `glGetUniformLocation` so we do not need to call them every stage of every draw. 

With my testing, there seems to be about a 2X speedup in SMO ingame (so still single digit/low double digit framerates). Please test thoroughly - I'm interested to know of any perf or accuracy regressions, or if this even helps a lot in other games.

Thanks @degasus for the tips for this approach.