### PR TITLE
hid: Move core include to cpp file

### DIFF
--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -17,6 +17,7 @@
 #include "core/hle/service/hid/irs.h"
 #include "core/hle/service/hid/xcd.h"
 #include "core/hle/service/service.h"
+#include "core/settings.h"
 
 namespace Service::HID {
 

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -4,8 +4,10 @@
 
 #pragma once
 
+#include <array>
+#include "common/bit_field.h"
+#include "common/common_types.h"
 #include "core/hle/service/service.h"
-#include "core/settings.h"
 
 namespace Service::HID {
 


### PR DESCRIPTION
This isn't required to be in the header. Instead, directly include what this header needs and move it to the cpp file where it belongs.