### PR TITLE
maxwell3d: Move FinishedPrimitiveBatch event after AcceleratedDrawBatch()

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -218,10 +218,6 @@ void Maxwell3D::DrawArrays() {
         debug_context->OnEvent(Tegra::DebugContext::Event::IncomingPrimitiveBatch, nullptr);
     }
 
-    if (debug_context) {
-        debug_context->OnEvent(Tegra::DebugContext::Event::FinishedPrimitiveBatch, nullptr);
-    }
-
     // Both instance configuration registers can not be set at the same time.
     ASSERT_MSG(!regs.draw.instance_next || !regs.draw.instance_cont,
                "Illegal combination of instancing parameters");
@@ -236,6 +232,10 @@ void Maxwell3D::DrawArrays() {
 
     const bool is_indexed{regs.index_array.count && !regs.vertex_buffer.count};
     rasterizer.AccelerateDrawBatch(is_indexed);
+
+    if (debug_context) {
+        debug_context->OnEvent(Tegra::DebugContext::Event::FinishedPrimitiveBatch, nullptr);
+    }
 
     // TODO(bunnei): Below, we reset vertex count so that we can use these registers to determine if
     // the game is trying to draw indexed or direct mode. This needs to be verified on HW still -


### PR DESCRIPTION
The start and finish events should likely not be right after one another like this, otherwise the batch will appear to complete immediately