### PR TITLE
 svc: Return process title ID if queried in GetInfo()

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -319,8 +319,7 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
         *result = Core::CurrentProcess()->is_virtual_address_memory_enabled;
         break;
     case GetInfoType::TitleId:
-        LOG_WARNING(Kernel_SVC, "(STUBBED) Attempted to query titleid, returned 0");
-        *result = 0;
+        *result = Core::CurrentProcess()->program_id;
         break;
     case GetInfoType::PrivilegedProcessId:
         LOG_WARNING(Kernel_SVC,


### PR DESCRIPTION
We already have the variable itself set up to perform this task, so we can just return its value from the currently executing process instead of always stubbing it to zero.