### PR TITLE
kernel/error: Amend several error codes

### DIFF
--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -12,7 +12,6 @@ namespace ErrCodes {
 enum {
     // TODO(Subv): Remove these 3DS OS error codes.
     SessionClosedByRemote = 26,
-    PortNameTooLong = 30,
     NoPendingSessions = 35,
     InvalidBufferDescriptor = 48,
     MaxConnectionsReached = 52,
@@ -39,7 +38,7 @@ enum {
 // TODO(bunnei): Replace these with correct errors for Switch OS
 constexpr ResultCode ERR_HANDLE_TABLE_FULL(ErrorModule::Kernel, ErrCodes::HandleTableFull);
 constexpr ResultCode ERR_SESSION_CLOSED_BY_REMOTE(-1);
-constexpr ResultCode ERR_PORT_NAME_TOO_LONG(-1);
+constexpr ResultCode ERR_PORT_NAME_TOO_LONG(ErrorModule::Kernel, ErrCodes::TooLarge);
 constexpr ResultCode ERR_MAX_CONNECTIONS_REACHED(-1);
 constexpr ResultCode ERR_INVALID_ENUM_VALUE(ErrorModule::Kernel, ErrCodes::InvalidEnumValue);
 constexpr ResultCode ERR_INVALID_ENUM_VALUE_FND(-1);

--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -14,9 +14,9 @@ enum {
     SessionClosedByRemote = 26,
     NoPendingSessions = 35,
     InvalidBufferDescriptor = 48,
-    MaxConnectionsReached = 52,
 
     // Confirmed Switch OS error codes
+    MaxConnectionsReached = 7,
     InvalidAddress = 102,
     HandleTableFull = 105,
     InvalidMemoryState = 106,
@@ -29,6 +29,7 @@ enum {
     TooLarge = 119,
     InvalidEnumValue = 120,
     InvalidState = 125,
+    ResourceLimitExceeded = 132,
 };
 }
 
@@ -39,7 +40,8 @@ enum {
 constexpr ResultCode ERR_HANDLE_TABLE_FULL(ErrorModule::Kernel, ErrCodes::HandleTableFull);
 constexpr ResultCode ERR_SESSION_CLOSED_BY_REMOTE(-1);
 constexpr ResultCode ERR_PORT_NAME_TOO_LONG(ErrorModule::Kernel, ErrCodes::TooLarge);
-constexpr ResultCode ERR_MAX_CONNECTIONS_REACHED(-1);
+constexpr ResultCode ERR_MAX_CONNECTIONS_REACHED(ErrorModule::Kernel,
+                                                 ErrCodes::MaxConnectionsReached);
 constexpr ResultCode ERR_INVALID_ENUM_VALUE(ErrorModule::Kernel, ErrCodes::InvalidEnumValue);
 constexpr ResultCode ERR_INVALID_ENUM_VALUE_FND(-1);
 constexpr ResultCode ERR_INVALID_COMBINATION(-1);

--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -45,7 +45,8 @@ constexpr ResultCode ERR_MAX_CONNECTIONS_REACHED(-1);
 constexpr ResultCode ERR_INVALID_ENUM_VALUE(ErrorModule::Kernel, ErrCodes::InvalidEnumValue);
 constexpr ResultCode ERR_INVALID_ENUM_VALUE_FND(-1);
 constexpr ResultCode ERR_INVALID_COMBINATION(-1);
-constexpr ResultCode ERR_INVALID_COMBINATION_KERNEL(-1);
+constexpr ResultCode ERR_INVALID_COMBINATION_KERNEL(ErrorModule::Kernel,
+                                                    ErrCodes::InvalidCombination);
 constexpr ResultCode ERR_OUT_OF_MEMORY(-1);
 constexpr ResultCode ERR_INVALID_ADDRESS(ErrorModule::Kernel, ErrCodes::InvalidAddress);
 constexpr ResultCode ERR_INVALID_ADDRESS_STATE(ErrorModule::Kernel, ErrCodes::InvalidMemoryState);

--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -15,13 +15,13 @@ enum {
     SessionClosedByRemote = 26,
     PortNameTooLong = 30,
     NoPendingSessions = 35,
-    WrongPermission = 46,
     InvalidBufferDescriptor = 48,
     MaxConnectionsReached = 52,
 
     // Confirmed Switch OS error codes
     InvalidAddress = 102,
     InvalidMemoryState = 106,
+    InvalidMemoryPermissions = 108,
     InvalidProcessorId = 113,
     InvalidHandle = 114,
     InvalidCombination = 116,
@@ -40,7 +40,6 @@ enum {
 constexpr ResultCode ERR_OUT_OF_HANDLES(-1);
 constexpr ResultCode ERR_SESSION_CLOSED_BY_REMOTE(-1);
 constexpr ResultCode ERR_PORT_NAME_TOO_LONG(-1);
-constexpr ResultCode ERR_WRONG_PERMISSION(-1);
 constexpr ResultCode ERR_MAX_CONNECTIONS_REACHED(-1);
 constexpr ResultCode ERR_INVALID_ENUM_VALUE(ErrorModule::Kernel, ErrCodes::InvalidEnumValue);
 constexpr ResultCode ERR_INVALID_ENUM_VALUE_FND(-1);
@@ -50,6 +49,8 @@ constexpr ResultCode ERR_INVALID_COMBINATION_KERNEL(ErrorModule::Kernel,
 constexpr ResultCode ERR_OUT_OF_MEMORY(-1);
 constexpr ResultCode ERR_INVALID_ADDRESS(ErrorModule::Kernel, ErrCodes::InvalidAddress);
 constexpr ResultCode ERR_INVALID_ADDRESS_STATE(ErrorModule::Kernel, ErrCodes::InvalidMemoryState);
+constexpr ResultCode ERR_INVALID_MEMORY_PERMISSIONS(ErrorModule::Kernel,
+                                                    ErrCodes::InvalidMemoryPermissions);
 constexpr ResultCode ERR_INVALID_HANDLE(ErrorModule::Kernel, ErrCodes::InvalidHandle);
 constexpr ResultCode ERR_INVALID_STATE(ErrorModule::Kernel, ErrCodes::InvalidState);
 constexpr ResultCode ERR_INVALID_POINTER(-1);

--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -11,7 +11,6 @@ namespace Kernel {
 namespace ErrCodes {
 enum {
     // TODO(Subv): Remove these 3DS OS error codes.
-    OutOfHandles = 19,
     SessionClosedByRemote = 26,
     PortNameTooLong = 30,
     NoPendingSessions = 35,
@@ -20,6 +19,7 @@ enum {
 
     // Confirmed Switch OS error codes
     InvalidAddress = 102,
+    HandleTableFull = 105,
     InvalidMemoryState = 106,
     InvalidMemoryPermissions = 108,
     InvalidProcessorId = 113,
@@ -37,7 +37,7 @@ enum {
 // double check that the code matches before re-using the constant.
 
 // TODO(bunnei): Replace these with correct errors for Switch OS
-constexpr ResultCode ERR_OUT_OF_HANDLES(-1);
+constexpr ResultCode ERR_HANDLE_TABLE_FULL(ErrorModule::Kernel, ErrCodes::HandleTableFull);
 constexpr ResultCode ERR_SESSION_CLOSED_BY_REMOTE(-1);
 constexpr ResultCode ERR_PORT_NAME_TOO_LONG(-1);
 constexpr ResultCode ERR_MAX_CONNECTIONS_REACHED(-1);

--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -26,7 +26,7 @@ ResultVal<Handle> HandleTable::Create(SharedPtr<Object> obj) {
     u16 slot = next_free_slot;
     if (slot >= generations.size()) {
         LOG_ERROR(Kernel, "Unable to allocate Handle, too many slots in use.");
-        return ERR_OUT_OF_HANDLES;
+        return ERR_HANDLE_TABLE_FULL;
     }
     next_free_slot = generations[slot];
 

--- a/src/core/hle/kernel/handle_table.h
+++ b/src/core/hle/kernel/handle_table.h
@@ -47,7 +47,7 @@ public:
     /**
      * Allocates a handle for the given object.
      * @return The created Handle or one of the following errors:
-     *           - `ERR_OUT_OF_HANDLES`: the maximum number of handles has been exceeded.
+     *           - `ERR_HANDLE_TABLE_FULL`: the maximum number of handles has been exceeded.
      */
     ResultVal<Handle> Create(SharedPtr<Object> obj);
 

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -101,7 +101,7 @@ ResultCode SharedMemory::Map(Process* target_process, VAddr address, MemoryPermi
         static_cast<u32>(this->permissions) & ~static_cast<u32>(other_permissions)) {
         LOG_ERROR(Kernel, "cannot map id={}, address=0x{:X} name={}, permissions don't match",
                   GetObjectId(), address, name);
-        return ERR_WRONG_PERMISSION;
+        return ERR_INVALID_MEMORY_PERMISSIONS;
     }
 
     VAddr target_address = address;


### PR DESCRIPTION
Amends several error codes that are in use with the correct values, allowing us to toss away several of the lingering 3DS constants.