### PR TITLE
file_sys: Add support for BKTR format (Game Updates)

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -35,8 +35,12 @@ add_library(core STATIC
     file_sys/mode.h
     file_sys/nca_metadata.cpp
     file_sys/nca_metadata.h
+    file_sys/nca_patch.cpp
+    file_sys/nca_patch.h
     file_sys/partition_filesystem.cpp
     file_sys/partition_filesystem.h
+    file_sys/patch_manager.cpp
+    file_sys/patch_manager.h
     file_sys/program_metadata.cpp
     file_sys/program_metadata.h
     file_sys/registered_cache.cpp

--- a/src/core/crypto/ctr_encryption_layer.cpp
+++ b/src/core/crypto/ctr_encryption_layer.cpp
@@ -21,7 +21,7 @@ size_t CTREncryptionLayer::Read(u8* data, size_t length, size_t offset) const {
         UpdateIV(base_offset + offset);
         std::vector<u8> raw = base->ReadBytes(length, offset);
         cipher.Transcode(raw.data(), raw.size(), data, Op::Decrypt);
-        return raw.size();
+        return length;
     }
 
     // offset does not fall on block boundary (0x10)

--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -52,11 +52,11 @@ XCI::XCI(VirtualFile file_) : file(std::move(file_)), partitions(0x4) {
     const auto secure_ncas = secure_partition->GetNCAsCollapsed();
     std::copy(secure_ncas.begin(), secure_ncas.end(), std::back_inserter(ncas));
 
-    program_nca_status = Loader::ResultStatus::ErrorXCIMissingProgramNCA;
     program =
         secure_partition->GetNCA(secure_partition->GetProgramTitleID(), ContentRecordType::Program);
-    if (program != nullptr)
-        program_nca_status = program->GetStatus();
+    program_nca_status = secure_partition->GetProgramStatus(secure_partition->GetProgramTitleID());
+    if (program_nca_status == Loader::ResultStatus::ErrorNSPMissingProgramNCA)
+        program_nca_status = Loader::ResultStatus::ErrorXCIMissingProgramNCA;
 
     auto result = AddNCAFromPartition(XCIPartition::Update);
     if (result != Loader::ResultStatus::Success) {

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -215,7 +215,7 @@ VirtualFile NCA::Decrypt(NCASectionHeader s_header, VirtualFile in, u64 starting
     }
 }
 
-NCA::NCA(VirtualFile file_, VirtualFile bktr_base_romfs_)
+NCA::NCA(VirtualFile file_, VirtualFile bktr_base_romfs_, u64 bktr_base_ivfc_offset)
     : file(std::move(file_)),
       bktr_base_romfs(bktr_base_romfs_ ? std::move(bktr_base_romfs_) : nullptr) {
     status = Loader::ResultStatus::Success;
@@ -292,6 +292,7 @@ NCA::NCA(VirtualFile file_, VirtualFile bktr_base_romfs_)
     is_update = std::find_if(sections.begin(), sections.end(), [](const NCASectionHeader& header) {
                     return header.raw.header.crypto_type == NCASectionCryptoType::BKTR;
                 }) != sections.end();
+    ivfc_offset = 0;
 
     for (std::ptrdiff_t i = 0; i < number_sections; ++i) {
         auto section = sections[i];
@@ -299,8 +300,8 @@ NCA::NCA(VirtualFile file_, VirtualFile bktr_base_romfs_)
         if (section.raw.header.filesystem_type == NCASectionFilesystemType::ROMFS) {
             const size_t base_offset =
                 header.section_tables[i].media_offset * MEDIA_OFFSET_MULTIPLIER;
-            const size_t romfs_offset =
-                base_offset + section.romfs.ivfc.levels[IVFC_MAX_LEVEL - 1].offset;
+            ivfc_offset = section.romfs.ivfc.levels[IVFC_MAX_LEVEL - 1].offset;
+            const size_t romfs_offset = base_offset + ivfc_offset;
             const size_t romfs_size = section.romfs.ivfc.levels[IVFC_MAX_LEVEL - 1].size;
             auto raw = std::make_shared<OffsetVfsFile>(file, romfs_size, romfs_offset);
             auto dec = Decrypt(section, raw, romfs_offset);
@@ -414,7 +415,7 @@ NCA::NCA(VirtualFile file_, VirtualFile bktr_base_romfs_)
                     bktr_base_romfs, std::make_shared<OffsetVfsFile>(file, romfs_size, base_offset),
                     relocation_block, relocation_buckets, subsection_block, subsection_buckets,
                     encrypted, encrypted ? key.get() : Core::Crypto::Key128{}, base_offset,
-                    romfs_offset - base_offset, section.raw.section_ctr);
+                    bktr_base_ivfc_offset, section.raw.section_ctr);
 
                 // BKTR applies to entire IVFC, so make an offset version to level 6
 
@@ -509,6 +510,10 @@ VirtualDir NCA::GetExeFS() const {
 
 VirtualFile NCA::GetBaseFile() const {
     return file;
+}
+
+u64 NCA::GetBaseIVFCOffset() const {
+    return ivfc_offset;
 }
 
 bool NCA::ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) {

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -425,9 +425,6 @@ NCA::NCA(VirtualFile file_, VirtualFile bktr_base_romfs_, u64 bktr_base_ivfc_off
             } else {
                 files.push_back(std::move(dec));
                 romfs = files.back();
-                const u64 raw_size =
-                    MEDIA_OFFSET_MULTIPLIER * (header.section_tables[i].media_end_offset -
-                                               header.section_tables[i].media_offset);
             }
         } else if (section.raw.header.filesystem_type == NCASectionFilesystemType::PFS0) {
             u64 offset = (static_cast<u64>(header.section_tables[i].media_offset) *

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -444,6 +444,12 @@ NCA::NCA(VirtualFile file_, VirtualFile bktr_base_romfs_, u64 bktr_base_ivfc_off
                     dirs.push_back(std::move(npfs));
                     if (IsDirectoryExeFS(dirs.back()))
                         exefs = dirs.back();
+                } else {
+                    if (has_rights_id)
+                        status = Loader::ResultStatus::ErrorIncorrectTitlekeyOrTitlekek;
+                    else
+                        status = Loader::ResultStatus::ErrorIncorrectKeyAreaKey;
+                    return;
                 }
             } else {
                 if (status != Loader::ResultStatus::Success)
@@ -491,8 +497,6 @@ NCAContentType NCA::GetType() const {
 u64 NCA::GetTitleId() const {
     if (is_update || status == Loader::ResultStatus::ErrorMissingBKTRBaseRomFS)
         return header.title_id | 0x800;
-    if (status != Loader::ResultStatus::Success)
-        return {};
     return header.title_id;
 }
 

--- a/src/core/file_sys/content_archive.h
+++ b/src/core/file_sys/content_archive.h
@@ -79,7 +79,8 @@ bool IsValidNCA(const NCAHeader& header);
 // After construction, use GetStatus to determine if the file is valid and ready to be used.
 class NCA : public ReadOnlyVfsDirectory {
 public:
-    explicit NCA(VirtualFile file, VirtualFile bktr_base_romfs = nullptr);
+    explicit NCA(VirtualFile file, VirtualFile bktr_base_romfs = nullptr,
+                 u64 bktr_base_ivfc_offset = 0);
     Loader::ResultStatus GetStatus() const;
 
     std::vector<std::shared_ptr<VfsFile>> GetFiles() const override;
@@ -95,6 +96,9 @@ public:
     VirtualDir GetExeFS() const;
 
     VirtualFile GetBaseFile() const;
+
+    // Returns the base ivfc offset used in BKTR patching.
+    u64 GetBaseIVFCOffset() const;
 
 protected:
     bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
@@ -112,6 +116,7 @@ private:
     VirtualDir exefs = nullptr;
     VirtualFile file;
     VirtualFile bktr_base_romfs;
+    u64 ivfc_offset;
 
     NCAHeader header{};
     bool has_rights_id{};

--- a/src/core/file_sys/content_archive.h
+++ b/src/core/file_sys/content_archive.h
@@ -79,7 +79,7 @@ bool IsValidNCA(const NCAHeader& header);
 // After construction, use GetStatus to determine if the file is valid and ready to be used.
 class NCA : public ReadOnlyVfsDirectory {
 public:
-    explicit NCA(VirtualFile file);
+    explicit NCA(VirtualFile file, VirtualFile bktr_base_romfs = nullptr);
     Loader::ResultStatus GetStatus() const;
 
     std::vector<std::shared_ptr<VfsFile>> GetFiles() const override;
@@ -89,13 +89,12 @@ public:
 
     NCAContentType GetType() const;
     u64 GetTitleId() const;
+    bool IsUpdate() const;
 
     VirtualFile GetRomFS() const;
     VirtualDir GetExeFS() const;
 
     VirtualFile GetBaseFile() const;
-
-    bool IsUpdate() const;
 
 protected:
     bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
@@ -112,14 +111,15 @@ private:
     VirtualFile romfs = nullptr;
     VirtualDir exefs = nullptr;
     VirtualFile file;
+    VirtualFile bktr_base_romfs;
 
     NCAHeader header{};
     bool has_rights_id{};
-    bool is_update{};
 
     Loader::ResultStatus status{};
 
     bool encrypted;
+    bool is_update;
 
     Core::Crypto::KeyManager keys;
 };

--- a/src/core/file_sys/nca_patch.cpp
+++ b/src/core/file_sys/nca_patch.cpp
@@ -51,7 +51,7 @@ size_t BKTR::Read(u8* data, size_t length, size_t offset) const {
 
     if (!bktr_read) {
         ASSERT_MSG(section_offset > ivfc_offset, "Offset calculation negative.");
-        return base_romfs->Read(data, length, section_offset);
+        return base_romfs->Read(data, length, section_offset - ivfc_offset);
     }
 
     if (!encrypted) {

--- a/src/core/file_sys/nca_patch.cpp
+++ b/src/core/file_sys/nca_patch.cpp
@@ -1,0 +1,208 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/assert.h"
+#include "core/crypto/aes_util.h"
+#include "core/file_sys/nca_patch.h"
+
+namespace FileSys {
+
+BKTR::BKTR(VirtualFile base_romfs_, VirtualFile bktr_romfs_, RelocationBlock relocation_,
+           std::vector<RelocationBucket> relocation_buckets_, SubsectionBlock subsection_,
+           std::vector<SubsectionBucket> subsection_buckets_, bool is_encrypted_,
+           Core::Crypto::Key128 key_, u64 base_offset_, u64 ivfc_offset_,
+           std::array<u8, 8> section_ctr_)
+    : base_romfs(std::move(base_romfs_)), bktr_romfs(std::move(bktr_romfs_)),
+      relocation(relocation_), relocation_buckets(std::move(relocation_buckets_)),
+      subsection(subsection_), subsection_buckets(std::move(subsection_buckets_)),
+      encrypted(is_encrypted_), key(key_), base_offset(base_offset_), ivfc_offset(ivfc_offset_),
+      section_ctr(std::move(section_ctr_)) {
+    for (size_t i = 0; i < relocation.number_buckets - 1; ++i) {
+        relocation_buckets[i].entries.push_back({relocation.base_offsets[i + 1], 0, 0});
+    }
+
+    for (size_t i = 0; i < subsection.number_buckets - 1; ++i) {
+        subsection_buckets[i].entries.push_back({subsection_buckets[i + 1].entries[0].address_patch,
+                                                 {0},
+                                                 subsection_buckets[i + 1].entries[0].ctr});
+    }
+
+    relocation_buckets.back().entries.push_back({relocation.size, 0, 0});
+}
+
+size_t BKTR::Read(u8* data, size_t length, size_t offset) const {
+    // Read out of bounds.
+    if (offset >= relocation.size)
+        return 0;
+    const auto relocation = GetRelocationEntry(offset);
+    const auto section_offset = offset - relocation.address_patch + relocation.address_source;
+    const auto bktr_read = relocation.from_patch;
+
+    const auto next_relocation = GetNextRelocationEntry(offset);
+
+    if (offset + length <= next_relocation.address_patch) {
+        if (bktr_read) {
+            if (!encrypted) {
+                return bktr_romfs->Read(data, length, section_offset);
+            }
+
+            const auto subsection = GetSubsectionEntry(section_offset);
+            Core::Crypto::AESCipher<Core::Crypto::Key128> cipher(key, Core::Crypto::Mode::CTR);
+
+            // Calculate AES IV
+            std::vector<u8> iv(16);
+            auto subsection_ctr = subsection.ctr;
+            auto offset_iv = section_offset + base_offset;
+            for (u8 i = 0; i < 8; ++i)
+                iv[i] = section_ctr[0x8 - i - 1];
+            offset_iv >>= 4;
+            for (size_t i = 0; i < 8; ++i) {
+                iv[0xF - i] = static_cast<u8>(offset_iv & 0xFF);
+                offset_iv >>= 8;
+            }
+            for (size_t i = 0; i < 4; ++i) {
+                iv[0x7 - i] = static_cast<u8>(subsection_ctr & 0xFF);
+                subsection_ctr >>= 8;
+            }
+            cipher.SetIV(iv);
+
+            const auto next_subsection = GetNextSubsectionEntry(section_offset);
+
+            if (section_offset + length <= next_subsection.address_patch) {
+                const auto block_offset = section_offset & 0xF;
+                if (block_offset != 0) {
+                    auto block = bktr_romfs->ReadBytes(0x10, section_offset & ~0xF);
+                    cipher.Transcode(block.data(), block.size(), block.data(),
+                                     Core::Crypto::Op::Decrypt);
+                    if (length + block_offset < 0x10) {
+                        std::memcpy(data, block.data() + block_offset,
+                                    std::min(length, block.size()));
+                        return std::min(length, block.size());
+                    }
+
+                    const auto read = 0x10 - block_offset;
+                    std::memcpy(data, block.data() + block_offset, read);
+                    return read + Read(data + read, length - read, offset + read);
+                }
+
+                const auto raw_read = bktr_romfs->Read(data, length, section_offset);
+                cipher.Transcode(data, raw_read, data, Core::Crypto::Op::Decrypt);
+                return raw_read;
+            } else {
+                const u64 partition = next_subsection.address_patch - section_offset;
+                return Read(data, partition, offset) +
+                       Read(data + partition, length - partition, offset + partition);
+            }
+        } else {
+            ASSERT(section_offset > ivfc_offset, "Offset calculation negative.");
+            return base_romfs->Read(data, length, section_offset);
+        }
+    } else {
+        const u64 partition = next_relocation.address_patch - offset;
+        return Read(data, partition, offset) +
+               Read(data + partition, length - partition, offset + partition);
+    }
+}
+
+template <bool Subsection, typename BlockType, typename BucketType>
+std::pair<size_t, size_t> BKTR::SearchBucketEntry(u64 offset, BlockType block,
+                                                  BucketType buckets) const {
+    if constexpr (Subsection) {
+        const auto last_bucket = buckets[block.number_buckets - 1];
+        if (offset >= last_bucket.entries[last_bucket.number_entries].address_patch)
+            return {block.number_buckets - 1, last_bucket.number_entries};
+    } else {
+        ASSERT_MSG(offset <= block.size, "Offset is out of bounds in BKTR relocation block.");
+    }
+
+    size_t bucket_id = 0;
+    for (size_t i = 1; i < block.number_buckets; ++i) {
+        if (block.base_offsets[i] <= offset)
+            ++bucket_id;
+    }
+
+    const auto bucket = buckets[bucket_id];
+
+    if (bucket.number_entries == 1)
+        return {bucket_id, 0};
+
+    size_t low = 0;
+    size_t mid = 0;
+    size_t high = bucket.number_entries - 1;
+    while (low <= high) {
+        mid = (low + high) / 2;
+        if (bucket.entries[mid].address_patch > offset) {
+            high = mid - 1;
+        } else {
+            if (mid == bucket.number_entries - 1 ||
+                bucket.entries[mid + 1].address_patch > offset) {
+                return {bucket_id, mid};
+            }
+
+            low = mid + 1;
+        }
+    }
+
+    UNREACHABLE_MSG("Offset could not be found in BKTR block.");
+}
+
+RelocationEntry BKTR::GetRelocationEntry(u64 offset) const {
+    const auto res = SearchBucketEntry<false>(offset, relocation, relocation_buckets);
+    return relocation_buckets[res.first].entries[res.second];
+}
+
+RelocationEntry BKTR::GetNextRelocationEntry(u64 offset) const {
+    const auto res = SearchBucketEntry<false>(offset, relocation, relocation_buckets);
+    const auto bucket = relocation_buckets[res.first];
+    if (res.second + 1 < bucket.entries.size())
+        return bucket.entries[res.second + 1];
+    return relocation_buckets[res.first + 1].entries[0];
+}
+
+SubsectionEntry BKTR::GetSubsectionEntry(u64 offset) const {
+    const auto res = SearchBucketEntry<true>(offset, subsection, subsection_buckets);
+    return subsection_buckets[res.first].entries[res.second];
+}
+
+SubsectionEntry BKTR::GetNextSubsectionEntry(u64 offset) const {
+    const auto res = SearchBucketEntry<true>(offset, subsection, subsection_buckets);
+    const auto bucket = subsection_buckets[res.first];
+    if (res.second + 1 < bucket.entries.size())
+        return bucket.entries[res.second + 1];
+    return subsection_buckets[res.first + 1].entries[0];
+}
+
+std::string BKTR::GetName() const {
+    return base_romfs->GetName();
+}
+
+size_t BKTR::GetSize() const {
+    return relocation.size;
+}
+
+bool BKTR::Resize(size_t new_size) {
+    return false;
+}
+
+std::shared_ptr<VfsDirectory> BKTR::GetContainingDirectory() const {
+    return base_romfs->GetContainingDirectory();
+}
+
+bool BKTR::IsWritable() const {
+    return false;
+}
+
+bool BKTR::IsReadable() const {
+    return true;
+}
+
+size_t BKTR::Write(const u8* data, size_t length, size_t offset) {
+    return 0;
+}
+
+bool BKTR::Rename(std::string_view name) {
+    return base_romfs->Rename(name);
+}
+
+} // namespace FileSys

--- a/src/core/file_sys/nca_patch.cpp
+++ b/src/core/file_sys/nca_patch.cpp
@@ -50,7 +50,7 @@ size_t BKTR::Read(u8* data, size_t length, size_t offset) const {
     }
 
     if (!bktr_read) {
-        ASSERT_MSG(section_offset > ivfc_offset, "Offset calculation negative.");
+        ASSERT_MSG(section_offset >= ivfc_offset, "Offset calculation negative.");
         return base_romfs->Read(data, length, section_offset - ivfc_offset);
     }
 
@@ -118,7 +118,7 @@ std::pair<size_t, size_t> BKTR::SearchBucketEntry(u64 offset, BlockType block,
 
     size_t bucket_id = std::count_if(block.base_offsets.begin() + 1,
                                      block.base_offsets.begin() + block.number_buckets,
-                                     [&offset](u64 base_offset) { return base_offset < offset; });
+                                     [&offset](u64 base_offset) { return base_offset <= offset; });
 
     const auto bucket = buckets[bucket_id];
 

--- a/src/core/file_sys/nca_patch.cpp
+++ b/src/core/file_sys/nca_patch.cpp
@@ -43,7 +43,7 @@ size_t BKTR::Read(u8* data, size_t length, size_t offset) const {
 
     const auto next_relocation = GetNextRelocationEntry(offset);
 
-    if (offset + length >= next_relocation.address_patch) {
+    if (offset + length > next_relocation.address_patch) {
         const u64 partition = next_relocation.address_patch - offset;
         return Read(data, partition, offset) +
                Read(data + partition, length - partition, offset + partition);

--- a/src/core/file_sys/nca_patch.h
+++ b/src/core/file_sys/nca_patch.h
@@ -4,9 +4,11 @@
 
 #pragma once
 
+#include <array>
+#include <vector>
+#include <common/common_funcs.h>
 #include "core/crypto/key_manager.h"
 #include "core/file_sys/romfs.h"
-#include "core/loader/loader.h"
 
 namespace FileSys {
 
@@ -91,6 +93,7 @@ public:
          std::vector<RelocationBucket> relocation_buckets, SubsectionBlock subsection,
          std::vector<SubsectionBucket> subsection_buckets, bool is_encrypted,
          Core::Crypto::Key128 key, u64 base_offset, u64 ivfc_offset, std::array<u8, 8> section_ctr);
+    ~BKTR() override;
 
     size_t Read(u8* data, size_t length, size_t offset) const override;
 

--- a/src/core/file_sys/nca_patch.h
+++ b/src/core/file_sys/nca_patch.h
@@ -1,0 +1,144 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/crypto/key_manager.h"
+#include "core/file_sys/romfs.h"
+#include "core/loader/loader.h"
+
+namespace FileSys {
+
+#pragma pack(push, 1)
+struct RelocationEntry {
+    u64_le address_patch;
+    u64_le address_source;
+    u32 from_patch;
+};
+#pragma pack(pop)
+static_assert(sizeof(RelocationEntry) == 0x14, "RelocationEntry has incorrect size.");
+
+struct RelocationBucketRaw {
+    INSERT_PADDING_BYTES(4);
+    u32_le number_entries;
+    u64_le end_offset;
+    std::array<RelocationEntry, 0x332> relocation_entries;
+    INSERT_PADDING_BYTES(8);
+};
+static_assert(sizeof(RelocationBucketRaw) == 0x4000, "RelocationBucketRaw has incorrect size.");
+
+// Vector version of RelocationBucketRaw
+struct RelocationBucket {
+    u32 number_entries;
+    u64 end_offset;
+    std::vector<RelocationEntry> entries;
+};
+
+struct RelocationBlock {
+    INSERT_PADDING_BYTES(4);
+    u32_le number_buckets;
+    u64_le size;
+    std::array<u64, 0x7FE> base_offsets;
+};
+static_assert(sizeof(RelocationBlock) == 0x4000, "RelocationBlock has incorrect size.");
+
+struct SubsectionEntry {
+    u64_le address_patch;
+    INSERT_PADDING_BYTES(0x4);
+    u32_le ctr;
+};
+static_assert(sizeof(SubsectionEntry) == 0x10, "SubsectionEntry has incorrect size.");
+
+struct SubsectionBucketRaw {
+    INSERT_PADDING_BYTES(4);
+    u32_le number_entries;
+    u64_le end_offset;
+    std::array<SubsectionEntry, 0x3FF> subsection_entries;
+};
+static_assert(sizeof(SubsectionBucketRaw) == 0x4000, "SubsectionBucketRaw has incorrect size.");
+
+// Vector version of SubsectionBucketRaw
+struct SubsectionBucket {
+    u32 number_entries;
+    u64 end_offset;
+    std::vector<SubsectionEntry> entries;
+};
+
+struct SubsectionBlock {
+    INSERT_PADDING_BYTES(4);
+    u32_le number_buckets;
+    u64_le size;
+    std::array<u64, 0x7FE> base_offsets;
+};
+static_assert(sizeof(SubsectionBlock) == 0x4000, "SubsectionBlock has incorrect size.");
+
+inline RelocationBucket ConvertRelocationBucketRaw(RelocationBucketRaw raw) {
+    return {raw.number_entries,
+            raw.end_offset,
+            {raw.relocation_entries.begin(), raw.relocation_entries.begin() + raw.number_entries}};
+}
+
+inline SubsectionBucket ConvertSubsectionBucketRaw(SubsectionBucketRaw raw) {
+    return {raw.number_entries,
+            raw.end_offset,
+            {raw.subsection_entries.begin(), raw.subsection_entries.begin() + raw.number_entries}};
+}
+
+class BKTR : public VfsFile {
+public:
+    BKTR(VirtualFile base_romfs, VirtualFile bktr_romfs, RelocationBlock relocation,
+         std::vector<RelocationBucket> relocation_buckets, SubsectionBlock subsection,
+         std::vector<SubsectionBucket> subsection_buckets, bool is_encrypted,
+         Core::Crypto::Key128 key, u64 base_offset, u64 ivfc_offset, std::array<u8, 8> section_ctr);
+
+    size_t Read(u8* data, size_t length, size_t offset) const override;
+
+    std::string GetName() const override;
+
+    size_t GetSize() const override;
+
+    bool Resize(size_t new_size) override;
+
+    std::shared_ptr<VfsDirectory> GetContainingDirectory() const override;
+
+    bool IsWritable() const override;
+
+    bool IsReadable() const override;
+
+    size_t Write(const u8* data, size_t length, size_t offset) override;
+
+    bool Rename(std::string_view name) override;
+
+private:
+    template <bool Subsection, typename BlockType, typename BucketType>
+    std::pair<size_t, size_t> SearchBucketEntry(u64 offset, BlockType block,
+                                                BucketType buckets) const;
+
+    RelocationEntry GetRelocationEntry(u64 offset) const;
+    RelocationEntry GetNextRelocationEntry(u64 offset) const;
+
+    SubsectionEntry GetSubsectionEntry(u64 offset) const;
+    SubsectionEntry GetNextSubsectionEntry(u64 offset) const;
+
+    RelocationBlock relocation;
+    std::vector<RelocationBucket> relocation_buckets;
+    SubsectionBlock subsection;
+    std::vector<SubsectionBucket> subsection_buckets;
+
+    // Should be the raw base romfs, decrypted.
+    VirtualFile base_romfs;
+    // Should be the raw BKTR romfs, (located at media_offset with size media_size).
+    VirtualFile bktr_romfs;
+
+    bool encrypted;
+    Core::Crypto::Key128 key;
+
+    // Base offset into NCA, used for IV calculation.
+    u64 base_offset;
+    // Distance between IVFC start and RomFS start, used for base reads
+    u64 ivfc_offset;
+    std::array<u8, 8> section_ctr;
+};
+
+} // namespace FileSys

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -2,10 +2,13 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/file_sys/content_archive.h"
 #include "core/file_sys/control_metadata.h"
 #include "core/file_sys/patch_manager.h"
 #include "core/file_sys/registered_cache.h"
+#include "core/file_sys/romfs.h"
 #include "core/hle/service/filesystem/filesystem.h"
+#include "core/loader/loader.h"
 
 namespace FileSys {
 

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -8,24 +8,19 @@
 
 namespace FileSys {
 
-union TitleVersion {
-    u32 version;
+constexpr u64 SINGLE_BYTE_MODULUS = 0x100;
 
-    struct {
-        u8 v_revision;
-        u8 v_micro;
-        u8 v_minor;
-        u8 v_major;
-    };
-};
+std::string FormatTitleVersion(u32 version, TitleVersionFormat format) {
+    std::array<u8, sizeof(u32)> bytes{};
+    bytes[0] = version % SINGLE_BYTE_MODULUS;
+    for (size_t i = 1; i < bytes.size(); ++i) {
+        version /= SINGLE_BYTE_MODULUS;
+        bytes[i] = version % SINGLE_BYTE_MODULUS;
+    }
 
-std::string FormatTitleVersion(u32 version_, bool full) {
-    TitleVersion ver{};
-    ver.version = version_;
-
-    if (full)
-        return fmt::format("v{}.{}.{}.{}", ver.v_major, ver.v_minor, ver.v_minor, ver.v_revision);
-    return fmt::format("v{}.{}.{}", ver.v_major, ver.v_minor, ver.v_micro);
+    if (format == TitleVersionFormat::FourElements)
+        return fmt::format("v{}.{}.{}.{}", bytes[3], bytes[2], bytes[1], bytes[0]);
+    return fmt::format("v{}.{}.{}", bytes[3], bytes[2], bytes[1]);
 }
 
 constexpr std::array<const char*, 1> PATCH_TYPE_NAMES{
@@ -49,8 +44,9 @@ VirtualDir PatchManager::PatchExeFS(VirtualDir exefs) const {
     const auto update = installed->GetEntry(update_tid, ContentRecordType::Program);
     if (update != nullptr) {
         if (update->GetStatus() == Loader::ResultStatus::ErrorMissingBKTRBaseRomFS &&
-            update->GetExeFS() != nullptr)
+            update->GetExeFS() != nullptr) {
             exefs = update->GetExeFS();
+        }
     }
 
     return exefs;
@@ -81,8 +77,9 @@ std::map<PatchType, u32> PatchManager::GetPatchVersionNames() const {
     const auto update_tid = GetUpdateTitleID(title_id);
     const auto update_version = installed->GetEntryVersion(update_tid);
     if (update_version != boost::none &&
-        installed->HasEntry(update_tid, ContentRecordType::Program))
+        installed->HasEntry(update_tid, ContentRecordType::Program)) {
         out[PatchType::Update] = update_version.get();
+    }
 
     return out;
 }

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -1,0 +1,90 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/file_sys/patch_manager.h"
+#include "core/file_sys/registered_cache.h"
+#include "core/hle/service/filesystem/filesystem.h"
+
+namespace FileSys {
+
+union TitleVersion {
+    u32 version;
+
+    struct {
+        u8 v_revision;
+        u8 v_micro;
+        u8 v_minor;
+        u8 v_major;
+    };
+};
+
+std::string FormatTitleVersion(u32 version_, bool full) {
+    TitleVersion ver{};
+    ver.version = version_;
+
+    if (full)
+        return fmt::format("v{}.{}.{}.{}", ver.v_major, ver.v_minor, ver.v_minor, ver.v_revision);
+    return fmt::format("v{}.{}.{}", ver.v_major, ver.v_minor, ver.v_micro);
+}
+
+constexpr std::array<const char*, 1> PATCH_TYPE_NAMES{
+    "Update",
+};
+
+std::string FormatPatchTypeName(PatchType type) {
+    return PATCH_TYPE_NAMES.at(static_cast<size_t>(type));
+}
+
+PatchManager::PatchManager(u64 title_id) : title_id(title_id) {}
+
+VirtualDir PatchManager::PatchExeFS(VirtualDir exefs) const {
+    if (exefs == nullptr)
+        return exefs;
+
+    const auto installed = Service::FileSystem::GetUnionContents();
+
+    // Game Updates
+    const auto update_tid = GetUpdateTitleID(title_id);
+    const auto update = installed->GetEntry(update_tid, ContentRecordType::Program);
+    if (update != nullptr) {
+        if (update->GetStatus() == Loader::ResultStatus::ErrorMissingBKTRBaseRomFS &&
+            update->GetExeFS() != nullptr)
+            exefs = update->GetExeFS();
+    }
+
+    return exefs;
+}
+
+VirtualFile PatchManager::PatchRomFS(VirtualFile romfs) const {
+    if (romfs == nullptr)
+        return romfs;
+
+    const auto installed = Service::FileSystem::GetUnionContents();
+
+    // Game Updates
+    const auto update_tid = GetUpdateTitleID(title_id);
+    const auto update = installed->GetEntryRaw(update_tid, ContentRecordType::Program);
+    if (update != nullptr) {
+        const auto nca = std::make_shared<NCA>(update, romfs);
+        if (nca->GetStatus() == Loader::ResultStatus::Success && nca->GetRomFS() != nullptr)
+            romfs = nca->GetRomFS();
+    }
+
+    return romfs;
+}
+
+std::map<PatchType, u32> PatchManager::GetPatchVersionNames() const {
+    std::map<PatchType, u32> out;
+    const auto installed = Service::FileSystem::GetUnionContents();
+
+    const auto update_tid = GetUpdateTitleID(title_id);
+    const auto update_version = installed->GetEntryVersion(update_tid);
+    if (update_version != boost::none &&
+        installed->HasEntry(update_tid, ContentRecordType::Program))
+        out[PatchType::Update] = update_version.get();
+
+    return out;
+}
+
+} // namespace FileSys

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -5,12 +5,19 @@
 #pragma once
 
 #include <map>
+#include <string>
 #include "common/common_types.h"
 #include "core/file_sys/vfs.h"
 
 namespace FileSys {
 
-std::string FormatTitleVersion(u32 version, bool full = false);
+enum class TitleVersionFormat : u8 {
+    ThreeElements, ///< vX.Y.Z
+    FourElements,  ///< vX.Y.Z.W
+};
+
+std::string FormatTitleVersion(u32 version,
+                               TitleVersionFormat format = TitleVersionFormat::ThreeElements);
 
 enum class PatchType {
     Update,

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -7,13 +7,14 @@
 #include <map>
 #include <string>
 #include "common/common_types.h"
+#include "core/file_sys/nca_metadata.h"
+#include "core/file_sys/romfs_factory.h"
 #include "core/file_sys/vfs.h"
-#include "nca_metadata.h"
-#include "romfs_factory.h"
 
 namespace FileSys {
 
 class NCA;
+class NACP;
 
 enum class TitleVersionFormat : u8 {
     ThreeElements, ///< vX.Y.Z
@@ -46,6 +47,14 @@ public:
     // Returns a vector of pairs between patch names and patch versions.
     // i.e. Update v80 will return {Update, 80}
     std::map<PatchType, std::string> GetPatchVersionNames() const;
+
+    // Given title_id of the program, attempts to get the control data of the update and parse it,
+    // falling back to the base control data.
+    std::pair<std::shared_ptr<NACP>, VirtualFile> GetControlMetadata() const;
+
+    // Version of GetControlMetadata that takes an arbitrary NCA
+    std::pair<std::shared_ptr<NACP>, VirtualFile> ParseControlNCA(
+        const std::shared_ptr<NCA>& nca) const;
 
 private:
     u64 title_id;

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -1,0 +1,42 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <map>
+#include "common/common_types.h"
+#include "core/file_sys/vfs.h"
+
+namespace FileSys {
+
+std::string FormatTitleVersion(u32 version, bool full = false);
+
+enum class PatchType {
+    Update,
+};
+
+std::string FormatPatchTypeName(PatchType type);
+
+// A centralized class to manage patches to games.
+class PatchManager {
+public:
+    explicit PatchManager(u64 title_id);
+
+    // Currently tracked ExeFS patches:
+    // - Game Updates
+    VirtualDir PatchExeFS(VirtualDir exefs) const;
+
+    // Currently tracked RomFS patches:
+    // - Game Updates
+    VirtualFile PatchRomFS(VirtualFile romfs) const;
+
+    // Returns a vector of pairs between patch names and patch versions.
+    // i.e. Update v80 will return {Update, 80}
+    std::map<PatchType, u32> GetPatchVersionNames() const;
+
+private:
+    u64 title_id;
+};
+
+} // namespace FileSys

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -8,8 +8,12 @@
 #include <string>
 #include "common/common_types.h"
 #include "core/file_sys/vfs.h"
+#include "nca_metadata.h"
+#include "romfs_factory.h"
 
 namespace FileSys {
+
+class NCA;
 
 enum class TitleVersionFormat : u8 {
     ThreeElements, ///< vX.Y.Z
@@ -36,7 +40,8 @@ public:
 
     // Currently tracked RomFS patches:
     // - Game Updates
-    VirtualFile PatchRomFS(VirtualFile romfs) const;
+    VirtualFile PatchRomFS(VirtualFile base, u64 ivfc_offset,
+                           ContentRecordType type = ContentRecordType::Program) const;
 
     // Returns a vector of pairs between patch names and patch versions.
     // i.e. Update v80 will return {Update, 80}

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -8,7 +8,6 @@
 #include <string>
 #include "common/common_types.h"
 #include "core/file_sys/nca_metadata.h"
-#include "core/file_sys/romfs_factory.h"
 #include "core/file_sys/vfs.h"
 
 namespace FileSys {

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -45,7 +45,7 @@ public:
 
     // Returns a vector of pairs between patch names and patch versions.
     // i.e. Update v80 will return {Update, 80}
-    std::map<PatchType, u32> GetPatchVersionNames() const;
+    std::map<PatchType, std::string> GetPatchVersionNames() const;
 
 private:
     u64 title_id;

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -281,10 +281,14 @@ VirtualFile RegisteredCache::GetEntryUnparsed(RegisteredCacheEntry entry) const 
 }
 
 boost::optional<u32> RegisteredCache::GetEntryVersion(u64 title_id) const {
-    if (meta.find(title_id) != meta.end())
-        return meta.at(title_id).GetTitleVersion();
-    if (yuzu_meta.find(title_id) != yuzu_meta.end())
-        return yuzu_meta.at(title_id).GetTitleVersion();
+    const auto meta_iter = meta.find(title_id);
+    if (meta_iter != meta.end())
+        return meta_iter->second.GetTitleVersion();
+
+    const auto yuzu_meta_iter = yuzu_meta.find(title_id);
+    if (yuzu_meta_iter != yuzu_meta.end())
+        return yuzu_meta_iter->second.GetTitleVersion();
+
     return boost::none;
 }
 
@@ -516,12 +520,9 @@ void RegisteredCacheUnion::Refresh() {
 }
 
 bool RegisteredCacheUnion::HasEntry(u64 title_id, ContentRecordType type) const {
-    for (const auto& c : caches) {
-        if (c->HasEntry(title_id, type))
-            return true;
-    }
-
-    return false;
+    return std::any_of(caches.begin(), caches.end(), [title_id, type](const auto& cache) {
+        return cache->HasEntry(title_id, type);
+    });
 }
 
 bool RegisteredCacheUnion::HasEntry(RegisteredCacheEntry entry) const {

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -280,6 +280,14 @@ VirtualFile RegisteredCache::GetEntryUnparsed(RegisteredCacheEntry entry) const 
     return GetEntryUnparsed(entry.title_id, entry.type);
 }
 
+boost::optional<u32> RegisteredCache::GetEntryVersion(u64 title_id) const {
+    if (meta.find(title_id) != meta.end())
+        return meta.at(title_id).GetTitleVersion();
+    if (yuzu_meta.find(title_id) != yuzu_meta.end())
+        return yuzu_meta.at(title_id).GetTitleVersion();
+    return boost::none;
+}
+
 VirtualFile RegisteredCache::GetEntryRaw(u64 title_id, ContentRecordType type) const {
     const auto id = GetNcaIDFromMetadata(title_id, type);
     if (id == boost::none)
@@ -497,5 +505,111 @@ bool RegisteredCache::RawInstallYuzuMeta(const CNMT& cnmt) {
                             return kv.second.GetType() == cnmt.GetType() &&
                                    kv.second.GetTitleID() == cnmt.GetTitleID();
                         }) != yuzu_meta.end();
+}
+
+RegisteredCacheUnion::RegisteredCacheUnion(std::vector<std::shared_ptr<RegisteredCache>> caches)
+    : caches(std::move(caches)) {}
+
+void RegisteredCacheUnion::Refresh() {
+    for (const auto& c : caches)
+        c->Refresh();
+}
+
+bool RegisteredCacheUnion::HasEntry(u64 title_id, ContentRecordType type) const {
+    for (const auto& c : caches) {
+        if (c->HasEntry(title_id, type))
+            return true;
+    }
+
+    return false;
+}
+
+bool RegisteredCacheUnion::HasEntry(RegisteredCacheEntry entry) const {
+    return HasEntry(entry.title_id, entry.type);
+}
+
+boost::optional<u32> RegisteredCacheUnion::GetEntryVersion(u64 title_id) const {
+    for (const auto& c : caches) {
+        const auto res = c->GetEntryVersion(title_id);
+        if (res != boost::none)
+            return res;
+    }
+
+    return boost::none;
+}
+
+VirtualFile RegisteredCacheUnion::GetEntryUnparsed(u64 title_id, ContentRecordType type) const {
+    for (const auto& c : caches) {
+        const auto res = c->GetEntryUnparsed(title_id, type);
+        if (res != nullptr)
+            return res;
+    }
+
+    return nullptr;
+}
+
+VirtualFile RegisteredCacheUnion::GetEntryUnparsed(RegisteredCacheEntry entry) const {
+    return GetEntryUnparsed(entry.title_id, entry.type);
+}
+
+VirtualFile RegisteredCacheUnion::GetEntryRaw(u64 title_id, ContentRecordType type) const {
+    for (const auto& c : caches) {
+        const auto res = c->GetEntryRaw(title_id, type);
+        if (res != nullptr)
+            return res;
+    }
+
+    return nullptr;
+}
+
+VirtualFile RegisteredCacheUnion::GetEntryRaw(RegisteredCacheEntry entry) const {
+    return GetEntryRaw(entry.title_id, entry.type);
+}
+
+std::shared_ptr<NCA> RegisteredCacheUnion::GetEntry(u64 title_id, ContentRecordType type) const {
+    const auto raw = GetEntryRaw(title_id, type);
+    if (raw == nullptr)
+        return nullptr;
+    return std::make_shared<NCA>(raw);
+}
+
+std::shared_ptr<NCA> RegisteredCacheUnion::GetEntry(RegisteredCacheEntry entry) const {
+    return GetEntry(entry.title_id, entry.type);
+}
+
+std::vector<RegisteredCacheEntry> RegisteredCacheUnion::ListEntries() const {
+    std::vector<RegisteredCacheEntry> out;
+    for (const auto& c : caches) {
+        c->IterateAllMetadata<RegisteredCacheEntry>(
+            out,
+            [](const CNMT& c, const ContentRecord& r) {
+                return RegisteredCacheEntry{c.GetTitleID(), r.type};
+            },
+            [](const CNMT& c, const ContentRecord& r) { return true; });
+    }
+    return out;
+}
+
+std::vector<RegisteredCacheEntry> RegisteredCacheUnion::ListEntriesFilter(
+    boost::optional<TitleType> title_type, boost::optional<ContentRecordType> record_type,
+    boost::optional<u64> title_id) const {
+    std::vector<RegisteredCacheEntry> out;
+    for (const auto& c : caches) {
+        c->IterateAllMetadata<RegisteredCacheEntry>(
+            out,
+            [](const CNMT& c, const ContentRecord& r) {
+                return RegisteredCacheEntry{c.GetTitleID(), r.type};
+            },
+            [&title_type, &record_type, &title_id](const CNMT& c, const ContentRecord& r) {
+                if (title_type != boost::none && title_type.get() != c.GetType())
+                    return false;
+                if (record_type != boost::none && record_type.get() != r.type)
+                    return false;
+                if (title_id != boost::none && title_id.get() != c.GetTitleID())
+                    return false;
+                return true;
+            });
+    }
+    return out;
 }
 } // namespace FileSys

--- a/src/core/file_sys/registered_cache.h
+++ b/src/core/file_sys/registered_cache.h
@@ -43,6 +43,10 @@ struct RegisteredCacheEntry {
     std::string DebugInfo() const;
 };
 
+constexpr inline u64 GetUpdateTitleID(u64 base_title_id) {
+    return base_title_id | 0x800;
+}
+
 // boost flat_map requires operator< for O(log(n)) lookups.
 bool operator<(const RegisteredCacheEntry& lhs, const RegisteredCacheEntry& rhs);
 
@@ -60,6 +64,8 @@ bool operator<(const RegisteredCacheEntry& lhs, const RegisteredCacheEntry& rhs)
  * 4GB splitting can be ignored.)
  */
 class RegisteredCache {
+    friend class RegisteredCacheUnion;
+
 public:
     // Parsing function defines the conversion from raw file to NCA. If there are other steps
     // besides creating the NCA from the file (e.g. NAX0 on SD Card), that should go in a custom
@@ -73,6 +79,8 @@ public:
 
     bool HasEntry(u64 title_id, ContentRecordType type) const;
     bool HasEntry(RegisteredCacheEntry entry) const;
+
+    boost::optional<u32> GetEntryVersion(u64 title_id) const;
 
     VirtualFile GetEntryUnparsed(u64 title_id, ContentRecordType type) const;
     VirtualFile GetEntryUnparsed(RegisteredCacheEntry entry) const;
@@ -129,6 +137,38 @@ private:
     boost::container::flat_map<u64, CNMT> meta;
     // maps tid -> meta for CNMT in yuzu_meta
     boost::container::flat_map<u64, CNMT> yuzu_meta;
+};
+
+// Combines multiple RegisteredCaches (i.e. SysNAND, UserNAND, SDMC) into one interface.
+class RegisteredCacheUnion {
+public:
+    explicit RegisteredCacheUnion(std::vector<std::shared_ptr<RegisteredCache>> caches);
+
+    void Refresh();
+
+    bool HasEntry(u64 title_id, ContentRecordType type) const;
+    bool HasEntry(RegisteredCacheEntry entry) const;
+
+    boost::optional<u32> GetEntryVersion(u64 title_id) const;
+
+    VirtualFile GetEntryUnparsed(u64 title_id, ContentRecordType type) const;
+    VirtualFile GetEntryUnparsed(RegisteredCacheEntry entry) const;
+
+    VirtualFile GetEntryRaw(u64 title_id, ContentRecordType type) const;
+    VirtualFile GetEntryRaw(RegisteredCacheEntry entry) const;
+
+    std::shared_ptr<NCA> GetEntry(u64 title_id, ContentRecordType type) const;
+    std::shared_ptr<NCA> GetEntry(RegisteredCacheEntry entry) const;
+
+    std::vector<RegisteredCacheEntry> ListEntries() const;
+    // If a parameter is not boost::none, it will be filtered for from all entries.
+    std::vector<RegisteredCacheEntry> ListEntriesFilter(
+        boost::optional<TitleType> title_type = boost::none,
+        boost::optional<ContentRecordType> record_type = boost::none,
+        boost::optional<u64> title_id = boost::none) const;
+
+private:
+    std::vector<std::shared_ptr<RegisteredCache>> caches;
 };
 
 } // namespace FileSys

--- a/src/core/file_sys/registered_cache.h
+++ b/src/core/file_sys/registered_cache.h
@@ -43,7 +43,7 @@ struct RegisteredCacheEntry {
     std::string DebugInfo() const;
 };
 
-constexpr inline u64 GetUpdateTitleID(u64 base_title_id) {
+constexpr u64 GetUpdateTitleID(u64 base_title_id) {
     return base_title_id | 0x800;
 }
 

--- a/src/core/file_sys/romfs_factory.cpp
+++ b/src/core/file_sys/romfs_factory.cpp
@@ -12,6 +12,7 @@
 #include "core/file_sys/patch_manager.h"
 #include "core/file_sys/registered_cache.h"
 #include "core/file_sys/romfs_factory.h"
+#include "core/hle/kernel/process.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/loader/loader.h"
 

--- a/src/core/file_sys/romfs_factory.cpp
+++ b/src/core/file_sys/romfs_factory.cpp
@@ -24,14 +24,15 @@ RomFSFactory::RomFSFactory(Loader::AppLoader& app_loader) {
     }
 
     updatable = app_loader.IsRomFSUpdatable();
+    ivfc_offset = app_loader.ReadRomFSIVFCOffset();
 }
 
 ResultVal<VirtualFile> RomFSFactory::OpenCurrentProcess() {
     if (!updatable)
         return MakeResult<VirtualFile>(file);
 
-    const PatchManager patch_manager(Core::CurrentProcess()->process_id);
-    return MakeResult<VirtualFile>(patch_manager.PatchRomFS(file));
+    const PatchManager patch_manager(Core::CurrentProcess()->program_id);
+    return MakeResult<VirtualFile>(patch_manager.PatchRomFS(file, ivfc_offset));
 }
 
 ResultVal<VirtualFile> RomFSFactory::Open(u64 title_id, StorageId storage, ContentRecordType type) {

--- a/src/core/file_sys/romfs_factory.h
+++ b/src/core/file_sys/romfs_factory.h
@@ -37,6 +37,7 @@ public:
 private:
     VirtualFile file;
     bool updatable;
+    u64 ivfc_offset;
 };
 
 } // namespace FileSys

--- a/src/core/file_sys/romfs_factory.h
+++ b/src/core/file_sys/romfs_factory.h
@@ -36,6 +36,7 @@ public:
 
 private:
     VirtualFile file;
+    bool updatable;
 };
 
 } // namespace FileSys

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -60,8 +60,11 @@ NSP::NSP(VirtualFile file_)
     for (const auto& outer_file : files) {
         if (outer_file->GetName().substr(outer_file->GetName().size() - 9) == ".cnmt.nca") {
             const auto nca = std::make_shared<NCA>(outer_file);
-            if (nca->GetStatus() != Loader::ResultStatus::Success)
+            if (nca->GetStatus() != Loader::ResultStatus::Success) {
+                program_status[nca->GetTitleId()] = nca->GetStatus();
                 continue;
+            }
+
             const auto section0 = nca->GetSubdirectories()[0];
 
             for (const auto& inner_file : section0->GetFiles()) {

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -10,6 +10,7 @@
 #include "core/file_sys/bis_factory.h"
 #include "core/file_sys/errors.h"
 #include "core/file_sys/mode.h"
+#include "core/file_sys/registered_cache.h"
 #include "core/file_sys/romfs_factory.h"
 #include "core/file_sys/savedata_factory.h"
 #include "core/file_sys/sdmc_factory.h"
@@ -19,7 +20,6 @@
 #include "core/hle/service/filesystem/fsp_ldr.h"
 #include "core/hle/service/filesystem/fsp_pr.h"
 #include "core/hle/service/filesystem/fsp_srv.h"
-#include "filesystem.h"
 
 namespace Service::FileSystem {
 

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -19,6 +19,7 @@
 #include "core/hle/service/filesystem/fsp_ldr.h"
 #include "core/hle/service/filesystem/fsp_pr.h"
 #include "core/hle/service/filesystem/fsp_srv.h"
+#include "filesystem.h"
 
 namespace Service::FileSystem {
 
@@ -305,6 +306,12 @@ ResultVal<FileSys::VirtualDir> OpenSDMC() {
     }
 
     return sdmc_factory->Open();
+}
+
+std::shared_ptr<FileSys::RegisteredCacheUnion> GetUnionContents() {
+    return std::make_shared<FileSys::RegisteredCacheUnion>(
+        std::vector<std::shared_ptr<FileSys::RegisteredCache>>{
+            GetSystemNANDContents(), GetUserNANDContents(), GetSDMCContents()});
 }
 
 std::shared_ptr<FileSys::RegisteredCache> GetSystemNANDContents() {

--- a/src/core/hle/service/filesystem/filesystem.h
+++ b/src/core/hle/service/filesystem/filesystem.h
@@ -13,6 +13,7 @@
 namespace FileSys {
 class BISFactory;
 class RegisteredCache;
+class RegisteredCacheUnion;
 class RomFSFactory;
 class SaveDataFactory;
 class SDMCFactory;
@@ -44,6 +45,8 @@ ResultVal<FileSys::VirtualFile> OpenRomFS(u64 title_id, FileSys::StorageId stora
 ResultVal<FileSys::VirtualDir> OpenSaveData(FileSys::SaveDataSpaceId space,
                                             FileSys::SaveDataDescriptor save_struct);
 ResultVal<FileSys::VirtualDir> OpenSDMC();
+
+std::shared_ptr<FileSys::RegisteredCacheUnion> GetUnionContents();
 
 std::shared_ptr<FileSys::RegisteredCache> GetSystemNANDContents();
 std::shared_ptr<FileSys::RegisteredCache> GetUserNANDContents();

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -189,4 +189,8 @@ ResultStatus AppLoader_DeconstructedRomDirectory::ReadTitle(std::string& title) 
     return ResultStatus::Success;
 }
 
+bool AppLoader_DeconstructedRomDirectory::IsRomFSUpdatable() {
+    return false;
+}
+
 } // namespace Loader

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -9,6 +9,7 @@
 #include "core/core.h"
 #include "core/file_sys/content_archive.h"
 #include "core/file_sys/control_metadata.h"
+#include "core/file_sys/patch_manager.h"
 #include "core/file_sys/romfs_factory.h"
 #include "core/gdbstub/gdbstub.h"
 #include "core/hle/kernel/kernel.h"
@@ -21,8 +22,9 @@
 
 namespace Loader {
 
-AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(FileSys::VirtualFile file_)
-    : AppLoader(std::move(file_)) {
+AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(FileSys::VirtualFile file_,
+                                                                         bool override_update)
+    : AppLoader(std::move(file_)), override_update(override_update) {
     const auto dir = file->GetContainingDirectory();
 
     // Icon
@@ -66,8 +68,9 @@ AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(FileSys
 }
 
 AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(
-    FileSys::VirtualDir directory)
-    : AppLoader(directory->GetFile("main")), dir(std::move(directory)) {}
+    FileSys::VirtualDir directory, bool override_update)
+    : AppLoader(directory->GetFile("main")), dir(std::move(directory)),
+      override_update(override_update) {}
 
 FileType AppLoader_DeconstructedRomDirectory::IdentifyType(const FileSys::VirtualFile& file) {
     if (FileSys::IsDirectoryExeFS(file->GetContainingDirectory())) {
@@ -89,13 +92,29 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(
         dir = file->GetContainingDirectory();
     }
 
-    const FileSys::VirtualFile npdm = dir->GetFile("main.npdm");
+    // Read meta to determine title ID
+    FileSys::VirtualFile npdm = dir->GetFile("main.npdm");
     if (npdm == nullptr)
         return ResultStatus::ErrorMissingNPDM;
 
     ResultStatus result = metadata.Load(npdm);
     if (result != ResultStatus::Success) {
         return result;
+    }
+
+    if (override_update) {
+        const FileSys::PatchManager patch_manager(metadata.GetTitleID());
+        dir = patch_manager.PatchExeFS(dir);
+    }
+
+    // Reread in case PatchExeFS affected the main.npdm
+    npdm = dir->GetFile("main.npdm");
+    if (npdm == nullptr)
+        return ResultStatus::ErrorMissingNPDM;
+
+    ResultStatus result2 = metadata.Load(npdm);
+    if (result2 != ResultStatus::Success) {
+        return result2;
     }
     metadata.Print();
 

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -189,7 +189,7 @@ ResultStatus AppLoader_DeconstructedRomDirectory::ReadTitle(std::string& title) 
     return ResultStatus::Success;
 }
 
-bool AppLoader_DeconstructedRomDirectory::IsRomFSUpdatable() {
+bool AppLoader_DeconstructedRomDirectory::IsRomFSUpdatable() const {
     return false;
 }
 

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -27,6 +27,14 @@ AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(FileSys
     : AppLoader(std::move(file_)), override_update(override_update) {
     const auto dir = file->GetContainingDirectory();
 
+    // Title ID
+    const auto npdm = dir->GetFile("main.npdm");
+    if (npdm != nullptr) {
+        const auto res = metadata.Load(npdm);
+        if (res == ResultStatus::Success)
+            title_id = metadata.GetTitleID();
+    }
+
     // Icon
     FileSys::VirtualFile icon_file = nullptr;
     for (const auto& language : FileSys::LANGUAGE_NAMES) {
@@ -138,7 +146,6 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(
     }
 
     auto& kernel = Core::System::GetInstance().Kernel();
-    title_id = metadata.GetTitleID();
     process->program_id = metadata.GetTitleID();
     process->svc_access_mask.set();
     process->resource_limit =

--- a/src/core/loader/deconstructed_rom_directory.h
+++ b/src/core/loader/deconstructed_rom_directory.h
@@ -44,7 +44,7 @@ public:
     ResultStatus ReadIcon(std::vector<u8>& buffer) override;
     ResultStatus ReadProgramId(u64& out_program_id) override;
     ResultStatus ReadTitle(std::string& title) override;
-    bool IsRomFSUpdatable() override;
+    bool IsRomFSUpdatable() const override;
 
 private:
     FileSys::ProgramMetadata metadata;

--- a/src/core/loader/deconstructed_rom_directory.h
+++ b/src/core/loader/deconstructed_rom_directory.h
@@ -20,10 +20,12 @@ namespace Loader {
  */
 class AppLoader_DeconstructedRomDirectory final : public AppLoader {
 public:
-    explicit AppLoader_DeconstructedRomDirectory(FileSys::VirtualFile main_file);
+    explicit AppLoader_DeconstructedRomDirectory(FileSys::VirtualFile main_file,
+                                                 bool override_update = false);
 
     // Overload to accept exefs directory. Must contain 'main' and 'main.npdm'
-    explicit AppLoader_DeconstructedRomDirectory(FileSys::VirtualDir directory);
+    explicit AppLoader_DeconstructedRomDirectory(FileSys::VirtualDir directory,
+                                                 bool override_update = false);
 
     /**
      * Returns the type of the file
@@ -51,6 +53,7 @@ private:
     std::vector<u8> icon_data;
     std::string name;
     u64 title_id{};
+    bool override_update;
 };
 
 } // namespace Loader

--- a/src/core/loader/deconstructed_rom_directory.h
+++ b/src/core/loader/deconstructed_rom_directory.h
@@ -44,6 +44,7 @@ public:
     ResultStatus ReadIcon(std::vector<u8>& buffer) override;
     ResultStatus ReadProgramId(u64& out_program_id) override;
     ResultStatus ReadTitle(std::string& title) override;
+    bool IsRomFSUpdatable() override;
 
 private:
     FileSys::ProgramMetadata metadata;

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -93,7 +93,7 @@ std::string GetFileTypeString(FileType type) {
     return "unknown";
 }
 
-constexpr std::array<const char*, 57> RESULT_MESSAGES{
+constexpr std::array<const char*, 58> RESULT_MESSAGES{
     "The operation completed successfully.",
     "The loader requested to load is already loaded.",
     "The operation is not implemented.",
@@ -143,7 +143,7 @@ constexpr std::array<const char*, 57> RESULT_MESSAGES{
     "The AES Key Generation Source could not be found.",
     "The SD Save Key Source could not be found.",
     "The SD NCA Key Source could not be found.",
-    "The NSP file is missing a Program-type NCA."};
+    "The NSP file is missing a Program-type NCA.",
     "The BKTR-type NCA has a bad BKTR header.",
     "The BKTR Subsection entry is not located immediately after the Relocation entry.",
     "The BKTR Subsection entry is not at the end of the media block.",

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -93,7 +93,7 @@ std::string GetFileTypeString(FileType type) {
     return "unknown";
 }
 
-constexpr std::array<const char*, 50> RESULT_MESSAGES{
+constexpr std::array<const char*, 57> RESULT_MESSAGES{
     "The operation completed successfully.",
     "The loader requested to load is already loaded.",
     "The operation is not implemented.",
@@ -144,6 +144,15 @@ constexpr std::array<const char*, 50> RESULT_MESSAGES{
     "The SD Save Key Source could not be found.",
     "The SD NCA Key Source could not be found.",
     "The NSP file is missing a Program-type NCA."};
+    "The BKTR-type NCA has a bad BKTR header.",
+    "The BKTR Subsection entry is not located immediately after the Relocation entry.",
+    "The BKTR Subsection entry is not at the end of the media block.",
+    "The BKTR-type NCA has a bad Relocation block.",
+    "The BKTR-type NCA has a bad Subsection block.",
+    "The BKTR-type NCA has a bad Relocation bucket.",
+    "The BKTR-type NCA has a bad Subsection bucket.",
+    "The BKTR-type NCA is missing the base RomFS.",
+};
 
 std::ostream& operator<<(std::ostream& os, ResultStatus status) {
     os << RESULT_MESSAGES.at(static_cast<size_t>(status));

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -107,6 +107,14 @@ enum class ResultStatus : u16 {
     ErrorMissingSDSaveKeySource,
     ErrorMissingSDNCAKeySource,
     ErrorNSPMissingProgramNCA,
+    ErrorBadBKTRHeader,
+    ErrorBKTRSubsectionNotAfterRelocation,
+    ErrorBKTRSubsectionNotAtEnd,
+    ErrorBadRelocationBlock,
+    ErrorBadSubsectionBlock,
+    ErrorBadRelocationBuckets,
+    ErrorBadSubsectionBuckets,
+    ErrorMissingBKTRBaseRomFS,
 };
 
 std::ostream& operator<<(std::ostream& os, ResultStatus status);
@@ -197,13 +205,13 @@ public:
     }
 
     /**
-     * Get the update RomFS of the application
-     * Since the RomFS can be huge, we return a file reference instead of copying to a buffer
-     * @param file The file containing the RomFS
-     * @return ResultStatus result of function
+     * Get whether or not updates can be applied to the RomFS.
+     * By default, this is true, however for formats where it cannot be guaranteed that the RomFS is
+     * the base game it should be set to false.
+     * @return bool whether or not updatable.
      */
-    virtual ResultStatus ReadUpdateRomFS(FileSys::VirtualFile& file) {
-        return ResultStatus::ErrorNotImplemented;
+    virtual bool IsRomFSUpdatable() {
+        return true;
     }
 
     /**

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -210,7 +210,7 @@ public:
      * the base game it should be set to false.
      * @return bool whether or not updatable.
      */
-    virtual bool IsRomFSUpdatable() {
+    virtual bool IsRomFSUpdatable() const {
         return true;
     }
 

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -215,6 +215,15 @@ public:
     }
 
     /**
+     * Gets the difference between the start of the IVFC header and the start of level 6 (RomFS)
+     * data. Needed for bktr patching.
+     * @return IVFC offset for romfs.
+     */
+    virtual u64 ReadRomFSIVFCOffset() const {
+        return 0;
+    }
+
+    /**
      * Get the title of the application
      * @param title Reference to store the application title into
      * @return ResultStatus result of function

--- a/src/core/loader/nca.cpp
+++ b/src/core/loader/nca.cpp
@@ -71,6 +71,12 @@ ResultStatus AppLoader_NCA::ReadRomFS(FileSys::VirtualFile& dir) {
     return ResultStatus::Success;
 }
 
+u64 AppLoader_NCA::ReadRomFSIVFCOffset() const {
+    if (nca == nullptr)
+        return 0;
+    return nca->GetBaseIVFCOffset();
+}
+
 ResultStatus AppLoader_NCA::ReadProgramId(u64& out_program_id) {
     if (nca == nullptr || nca->GetStatus() != ResultStatus::Success)
         return ResultStatus::ErrorNotInitialized;

--- a/src/core/loader/nca.cpp
+++ b/src/core/loader/nca.cpp
@@ -48,7 +48,7 @@ ResultStatus AppLoader_NCA::Load(Kernel::SharedPtr<Kernel::Process>& process) {
     if (exefs == nullptr)
         return ResultStatus::ErrorNoExeFS;
 
-    directory_loader = std::make_unique<AppLoader_DeconstructedRomDirectory>(exefs);
+    directory_loader = std::make_unique<AppLoader_DeconstructedRomDirectory>(exefs, true);
 
     const auto load_result = directory_loader->Load(process);
     if (load_result != ResultStatus::Success)

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -37,6 +37,7 @@ public:
     ResultStatus Load(Kernel::SharedPtr<Kernel::Process>& process) override;
 
     ResultStatus ReadRomFS(FileSys::VirtualFile& dir) override;
+    u64 ReadRomFSIVFCOffset() const override;
     ResultStatus ReadProgramId(u64& out_program_id) override;
 
 private:

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -233,7 +233,7 @@ ResultStatus AppLoader_NRO::ReadTitle(std::string& title) {
     return ResultStatus::Success;
 }
 
-bool AppLoader_NRO::IsRomFSUpdatable() {
+bool AppLoader_NRO::IsRomFSUpdatable() const {
     return false;
 }
 

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -232,4 +232,9 @@ ResultStatus AppLoader_NRO::ReadTitle(std::string& title) {
     title = nacp->GetApplicationName();
     return ResultStatus::Success;
 }
+
+bool AppLoader_NRO::IsRomFSUpdatable() {
+    return false;
+}
+
 } // namespace Loader

--- a/src/core/loader/nro.h
+++ b/src/core/loader/nro.h
@@ -39,7 +39,7 @@ public:
     ResultStatus ReadProgramId(u64& out_program_id) override;
     ResultStatus ReadRomFS(FileSys::VirtualFile& dir) override;
     ResultStatus ReadTitle(std::string& title) override;
-    bool IsRomFSUpdatable() override;
+    bool IsRomFSUpdatable() const override;
 
 private:
     bool LoadNro(FileSys::VirtualFile file, VAddr load_base);

--- a/src/core/loader/nro.h
+++ b/src/core/loader/nro.h
@@ -39,6 +39,7 @@ public:
     ResultStatus ReadProgramId(u64& out_program_id) override;
     ResultStatus ReadRomFS(FileSys::VirtualFile& dir) override;
     ResultStatus ReadTitle(std::string& title) override;
+    bool IsRomFSUpdatable() override;
 
 private:
     bool LoadNro(FileSys::VirtualFile file, VAddr load_base);

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -621,9 +621,7 @@ void GameListWorker::run() {
     stop_processing = false;
     watch_list.append(dir_path);
     FillControlMap(dir_path.toStdString());
-    AddInstalledTitlesToGameList(Service::FileSystem::GetUserNANDContents());
-    AddInstalledTitlesToGameList(Service::FileSystem::GetSystemNANDContents());
-    AddInstalledTitlesToGameList(Service::FileSystem::GetSDMCContents());
+    AddInstalledTitlesToGameList();
     AddFstEntriesToGameList(dir_path.toStdString(), deep_scan ? 256 : 0);
     nca_control_map.clear();
     emit Finished(watch_list);

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -486,29 +486,11 @@ void GameList::RefreshGameDirectory() {
 static void GetMetadataFromControlNCA(const FileSys::PatchManager& patch_manager,
                                       const std::shared_ptr<FileSys::NCA>& nca,
                                       std::vector<u8>& icon, std::string& name) {
-    const auto romfs = patch_manager.PatchRomFS(nca->GetRomFS(), nca->GetBaseIVFCOffset(),
-                                                FileSys::ContentRecordType::Control);
-    if (romfs == nullptr)
-        return;
-
-    const auto control_dir = FileSys::ExtractRomFS(romfs);
-    if (control_dir == nullptr)
-        return;
-
-    const auto nacp_file = control_dir->GetFile("control.nacp");
-    if (nacp_file == nullptr)
-        return;
-    FileSys::NACP nacp(nacp_file);
-    name = nacp.GetApplicationName();
-
-    FileSys::VirtualFile icon_file = nullptr;
-    for (const auto& language : FileSys::LANGUAGE_NAMES) {
-        icon_file = control_dir->GetFile("icon_" + std::string(language) + ".dat");
-        if (icon_file != nullptr) {
-            icon = icon_file->ReadAllBytes();
-            break;
-        }
-    }
+    auto [nacp, icon_file] = patch_manager.ParseControlNCA(nca);
+    if (icon_file != nullptr)
+        icon = icon_file->ReadAllBytes();
+    if (nacp != nullptr)
+        name = nacp->GetApplicationName();
 }
 
 GameListWorker::GameListWorker(

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -38,6 +38,7 @@ public:
     enum {
         COLUMN_NAME,
         COLUMN_COMPATIBILITY,
+        COLUMN_ADD_ONS,
         COLUMN_FILE_TYPE,
         COLUMN_SIZE,
         COLUMN_COUNT, // Number of columns

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -239,7 +239,7 @@ private:
     const std::unordered_map<std::string, std::pair<QString, QString>>& compatibility_list;
     std::atomic_bool stop_processing;
 
-    void AddInstalledTitlesToGameList(std::shared_ptr<FileSys::RegisteredCache> cache);
+    void AddInstalledTitlesToGameList();
     void FillControlMap(const std::string& dir_path);
     void AddFstEntriesToGameList(const std::string& dir_path, unsigned int recursion = 0);
 };

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -871,8 +871,8 @@ void GMainWindow::OnMenuInstallToNAND() {
         const auto id = nca->GetStatus();
 
         // Game updates necessary are missing base RomFS
-        if (nca->GetStatus() != Loader::ResultStatus::Success &&
-            nca->GetStatus() != Loader::ResultStatus::ErrorMissingBKTRBaseRomFS) {
+        if (id != Loader::ResultStatus::Success &&
+            id != Loader::ResultStatus::ErrorMissingBKTRBaseRomFS) {
             failed();
             return;
         }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -868,7 +868,11 @@ void GMainWindow::OnMenuInstallToNAND() {
     } else {
         const auto nca = std::make_shared<FileSys::NCA>(
             vfs->OpenFile(filename.toStdString(), FileSys::Mode::Read));
-        if (nca->GetStatus() != Loader::ResultStatus::Success) {
+        const auto id = nca->GetStatus();
+
+        // Game updates necessary are missing base RomFS
+        if (nca->GetStatus() != Loader::ResultStatus::Success &&
+            nca->GetStatus() != Loader::ResultStatus::ErrorMissingBKTRBaseRomFS) {
             failed();
             return;
         }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -592,8 +592,16 @@ void GMainWindow::BootGame(const QString& filename) {
 
     std::string title_name;
     const auto res = Core::System::GetInstance().GetGameName(title_name);
-    if (res != Loader::ResultStatus::Success)
-        title_name = FileUtil::GetFilename(filename.toStdString());
+    if (res != Loader::ResultStatus::Success) {
+        const u64 program_id = Core::System::GetInstance().CurrentProcess()->program_id;
+
+        const auto [nacp, icon_file] = FileSys::PatchManager(program_id).GetControlMetadata();
+        if (nacp != nullptr)
+            title_name = nacp->GetApplicationName();
+
+        if (title_name.empty())
+            title_name = FileUtil::GetFilename(filename.toStdString());
+    }
 
     setWindowTitle(QString("yuzu %1| %4 | %2-%3")
                        .arg(Common::g_build_name, Common::g_scm_branch, Common::g_scm_desc,

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -32,6 +32,8 @@
 #include "core/crypto/key_manager.h"
 #include "core/file_sys/card_image.h"
 #include "core/file_sys/content_archive.h"
+#include "core/file_sys/control_metadata.h"
+#include "core/file_sys/patch_manager.h"
 #include "core/file_sys/registered_cache.h"
 #include "core/file_sys/savedata_factory.h"
 #include "core/file_sys/submission_package.h"


### PR DESCRIPTION
This adds:
- Read Game Updates from yuzu NAND or SD and apply them to games.
- Does not apply updates to directories (as the romfs cannot be guaranteed to be the base game)
- Updates are installable through UI.

To use:
1. Install update NCA via menu option (select type `Game Update`)
2. Confirm it lists `Update` in the add-ons column.
3. Execute game. Keep in mind that most updated games have svc/hle issues.

Testing highly appreciated. I tested on Cave Story, ARMS, BotW, and Splatoon 2

Game list:
![update2](https://user-images.githubusercontent.com/5064800/44623404-87b4c080-a89a-11e8-9cd8-0e4e6fbf73cd.PNG)

Cave story option menu (post-update):
![cavestorysample](https://user-images.githubusercontent.com/5064800/44623407-956a4600-a89a-11e8-9044-c52a42c2c3b2.PNG)
