### PR TITLE
registered_cache: Get rid of variable shadowing in ProcessFiles()

### DIFF
--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -216,11 +216,11 @@ void RegisteredCache::ProcessFiles(const std::vector<NcaID>& ids) {
 
         const auto section0 = nca->GetSubdirectories()[0];
 
-        for (const auto& file : section0->GetFiles()) {
-            if (file->GetExtension() != "cnmt")
+        for (const auto& section0_file : section0->GetFiles()) {
+            if (section0_file->GetExtension() != "cnmt")
                 continue;
 
-            meta.insert_or_assign(nca->GetTitleId(), CNMT(file));
+            meta.insert_or_assign(nca->GetTitleId(), CNMT(section0_file));
             meta_id.insert_or_assign(nca->GetTitleId(), id);
             break;
         }


### PR DESCRIPTION
Prevents compiler warnings.