### PR TITLE
yuzu: Fix input UI direction order for the right stick

### DIFF
--- a/src/yuzu/configuration/configure_input.ui
+++ b/src/yuzu/configuration/configure_input.ui
@@ -472,7 +472,7 @@ Capture:</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
+        <item row="0" column="0">
          <layout class="QVBoxLayout" name="buttonRStickLeftVerticalLayout">
           <item>
            <widget class="QLabel" name="labelRStickLeft">
@@ -490,7 +490,7 @@ Capture:</string>
           </item>
          </layout>
         </item>
-        <item row="0" column="0">
+        <item row="1" column="0">
          <layout class="QVBoxLayout" name="buttonRStickUpVerticalLayout">
           <item>
            <widget class="QLabel" name="labelRStickUp">


### PR DESCRIPTION
![unbenannt](https://user-images.githubusercontent.com/20753089/44691146-c777d580-aa5d-11e8-934b-af03dcc65e84.PNG)
Left is this PR, right is latest Canary.

It is advised to review this PR commit-by-commit cause of the sheer complexity of the code changes :P