### PR TITLE
yuzu: Fix two stupid errors made in #1141

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -893,6 +893,7 @@ void GMainWindow::OnStartGame() {
 
     ui.action_Pause->setEnabled(true);
     ui.action_Stop->setEnabled(true);
+    ui.action_Restart->setEnabled(true);
 }
 
 void GMainWindow::OnPauseGame() {
@@ -901,7 +902,6 @@ void GMainWindow::OnPauseGame() {
     ui.action_Start->setEnabled(true);
     ui.action_Pause->setEnabled(false);
     ui.action_Stop->setEnabled(true);
-    ui.action_Restart->setEnabled(true);
 }
 
 void GMainWindow::OnStopGame() {

--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -74,6 +74,7 @@
     <addaction name="action_Start"/>
     <addaction name="action_Pause"/>
     <addaction name="action_Stop"/>
+    <addaction name="action_Restart"/>
     <addaction name="separator"/>
     <addaction name="action_Configure"/>
    </widget>


### PR DESCRIPTION
In https://github.com/yuzu-emu/yuzu/pull/1141, I forgot to actually add the Restart option to the menu and I also added `ui.action_Restart->setEnabled(true);` in the wrong place. This PR aims to fix this.