### PR TITLE
hle/result: Make ResultVal's move constructor as noexcept

### DIFF
--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -227,7 +227,7 @@ public:
         }
     }
 
-    ResultVal(ResultVal&& o) : result_code(o.result_code) {
+    ResultVal(ResultVal&& o) noexcept : result_code(o.result_code) {
         if (!o.empty()) {
             new (&object) T(std::move(o.object));
         }


### PR DESCRIPTION
Many containers within the standard library (and potentially other libraries) provide different behaviors based on whether or not a move constructor/assignment operator can be guaranteed not to throw or not.

Notably, implementations will generally use `std::move_if_noexcept` (or an internal implementation of it) to provide strong exception guarantees. If a move constructor potentially throws (in other words, is not noexcept), then certain behaviors will create copies, rather than moving the values.

For example, consider `std::vector`. When a `std::vector` has resize() called on it, there are two ways the elements can be relocated to the new block of memory (if a reallocation happens), by copy, or by moving the existing elements into the new block of memory. If a type does not have a guarantee that it will not throw in the move constructor, a copy will happen. However, if it can be guaranteed that the move constructor won't throw, then the elements will be moved.

This just allows `ResultVal` to be moved instead of copied all the time if ever used in conjunction with containers for whatever reason.