### PR TITLE
gpu: Make memory_manager private

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
@@ -56,9 +56,9 @@ u32 nvhost_as_gpu::AllocateSpace(const std::vector<u8>& input, std::vector<u8>& 
     auto& gpu = Core::System::GetInstance().GPU();
     const u64 size{static_cast<u64>(params.pages) * static_cast<u64>(params.page_size)};
     if (params.flags & 1) {
-        params.offset = gpu.memory_manager->AllocateSpace(params.offset, size, 1);
+        params.offset = gpu.MemoryManager().AllocateSpace(params.offset, size, 1);
     } else {
-        params.offset = gpu.memory_manager->AllocateSpace(size, params.align);
+        params.offset = gpu.MemoryManager().AllocateSpace(size, params.align);
     }
 
     std::memcpy(output.data(), &params, output.size());
@@ -88,7 +88,7 @@ u32 nvhost_as_gpu::Remap(const std::vector<u8>& input, std::vector<u8>& output) 
         u64 size = static_cast<u64>(entry.pages) << 0x10;
         ASSERT(size <= object->size);
 
-        Tegra::GPUVAddr returned = gpu.memory_manager->MapBufferEx(object->addr, offset, size);
+        Tegra::GPUVAddr returned = gpu.MemoryManager().MapBufferEx(object->addr, offset, size);
         ASSERT(returned == offset);
     }
     std::memcpy(output.data(), entries.data(), output.size());
@@ -125,9 +125,9 @@ u32 nvhost_as_gpu::MapBufferEx(const std::vector<u8>& input, std::vector<u8>& ou
     auto& gpu = Core::System::GetInstance().GPU();
 
     if (params.flags & 1) {
-        params.offset = gpu.memory_manager->MapBufferEx(object->addr, params.offset, object->size);
+        params.offset = gpu.MemoryManager().MapBufferEx(object->addr, params.offset, object->size);
     } else {
-        params.offset = gpu.memory_manager->MapBufferEx(object->addr, object->size);
+        params.offset = gpu.MemoryManager().MapBufferEx(object->addr, object->size);
     }
 
     // Create a new mapping entry for this operation.
@@ -161,7 +161,7 @@ u32 nvhost_as_gpu::UnmapBuffer(const std::vector<u8>& input, std::vector<u8>& ou
                                                                      itr->second.size);
 
     auto& gpu = system_instance.GPU();
-    params.offset = gpu.memory_manager->UnmapBuffer(params.offset, itr->second.size);
+    params.offset = gpu.MemoryManager().UnmapBuffer(params.offset, itr->second.size);
 
     buffer_mappings.erase(itr->second.offset);
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -264,7 +264,7 @@ void RasterizerMarkRegionCached(Tegra::GPUVAddr gpu_addr, u64 size, bool cached)
     u64 num_pages = ((gpu_addr + size - 1) >> PAGE_BITS) - (gpu_addr >> PAGE_BITS) + 1;
     for (unsigned i = 0; i < num_pages; ++i, gpu_addr += PAGE_SIZE) {
         boost::optional<VAddr> maybe_vaddr =
-            Core::System::GetInstance().GPU().memory_manager->GpuToCpuAddress(gpu_addr);
+            Core::System::GetInstance().GPU().MemoryManager().GpuToCpuAddress(gpu_addr);
         // The GPU <-> CPU virtual memory mapping is not 1:1
         if (!maybe_vaddr) {
             LOG_ERROR(HW_Memory,
@@ -346,7 +346,7 @@ void RasterizerFlushVirtualRegion(VAddr start, u64 size, FlushMode mode) {
         const VAddr overlap_end = std::min(end, region_end);
 
         const std::vector<Tegra::GPUVAddr> gpu_addresses =
-            system_instance.GPU().memory_manager->CpuToGpuAddress(overlap_start);
+            system_instance.GPU().MemoryManager().CpuToGpuAddress(overlap_start);
 
         if (gpu_addresses.empty()) {
             return;

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -22,7 +22,7 @@ u32 FramebufferConfig::BytesPerPixel(PixelFormat format) {
 }
 
 GPU::GPU(VideoCore::RasterizerInterface& rasterizer) {
-    memory_manager = std::make_unique<MemoryManager>();
+    memory_manager = std::make_unique<Tegra::MemoryManager>();
     maxwell_3d = std::make_unique<Engines::Maxwell3D>(rasterizer, *memory_manager);
     fermi_2d = std::make_unique<Engines::Fermi2D>(*memory_manager);
     maxwell_compute = std::make_unique<Engines::MaxwellCompute>();
@@ -31,12 +31,20 @@ GPU::GPU(VideoCore::RasterizerInterface& rasterizer) {
 
 GPU::~GPU() = default;
 
+Engines::Maxwell3D& GPU::Maxwell3D() {
+    return *maxwell_3d;
+}
+
 const Engines::Maxwell3D& GPU::Maxwell3D() const {
     return *maxwell_3d;
 }
 
-Engines::Maxwell3D& GPU::Maxwell3D() {
-    return *maxwell_3d;
+MemoryManager& GPU::MemoryManager() {
+    return *memory_manager;
+}
+
+const MemoryManager& GPU::MemoryManager() const {
+    return *memory_manager;
 }
 
 u32 RenderTargetBytesPerPixel(RenderTargetFormat format) {

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -117,17 +117,23 @@ public:
     /// Processes a command list stored at the specified address in GPU memory.
     void ProcessCommandList(GPUVAddr address, u32 size);
 
-    /// Returns a const reference to the Maxwell3D GPU engine.
-    const Engines::Maxwell3D& Maxwell3D() const;
-
     /// Returns a reference to the Maxwell3D GPU engine.
     Engines::Maxwell3D& Maxwell3D();
 
-    std::unique_ptr<MemoryManager> memory_manager;
+    /// Returns a const reference to the Maxwell3D GPU engine.
+    const Engines::Maxwell3D& Maxwell3D() const;
+
+    /// Returns a reference to the GPU memory manager.
+    Tegra::MemoryManager& MemoryManager();
+
+    /// Returns a const reference to the GPU memory manager.
+    const Tegra::MemoryManager& MemoryManager() const;
 
 private:
     /// Writes a single register in the engine bound to the specified subchannel
     void WriteReg(u32 method, u32 subchannel, u32 value, u32 remaining_params);
+
+    std::unique_ptr<Tegra::MemoryManager> memory_manager;
 
     /// Mapping of command subchannels to their bound engine ids.
     std::unordered_map<u32, EngineID> bound_engines;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -425,8 +425,8 @@ std::tuple<u8*, GLintptr, GLintptr> RasterizerOpenGL::UploadMemory(u8* buffer_pt
     std::tie(buffer_ptr, buffer_offset) = AlignBuffer(buffer_ptr, buffer_offset, alignment);
     GLintptr uploaded_offset = buffer_offset;
 
-    const auto& memory_manager = Core::System::GetInstance().GPU().memory_manager;
-    const boost::optional<VAddr> cpu_addr{memory_manager->GpuToCpuAddress(gpu_addr)};
+    auto& memory_manager = Core::System::GetInstance().GPU().MemoryManager();
+    const boost::optional<VAddr> cpu_addr{memory_manager.GpuToCpuAddress(gpu_addr)};
     Memory::ReadBlock(*cpu_addr, buffer_ptr, size);
 
     buffer_ptr += size;

--- a/src/yuzu/debugger/graphics/graphics_surface.cpp
+++ b/src/yuzu/debugger/graphics/graphics_surface.cpp
@@ -382,7 +382,7 @@ void GraphicsSurfaceWidget::OnUpdate() {
     // TODO: Implement a good way to visualize alpha components!
 
     QImage decoded_image(surface_width, surface_height, QImage::Format_ARGB32);
-    boost::optional<VAddr> address = gpu.memory_manager->GpuToCpuAddress(surface_address);
+    boost::optional<VAddr> address = gpu.MemoryManager().GpuToCpuAddress(surface_address);
 
     // TODO(bunnei): Will not work with BCn formats that swizzle 4x4 tiles.
     // Needs to be fixed if we plan to use this feature more, otherwise we may remove it.
@@ -443,7 +443,7 @@ void GraphicsSurfaceWidget::SaveSurface() {
             pixmap->save(&file, "PNG");
     } else if (selectedFilter == bin_filter) {
         auto& gpu = Core::System::GetInstance().GPU();
-        boost::optional<VAddr> address = gpu.memory_manager->GpuToCpuAddress(surface_address);
+        boost::optional<VAddr> address = gpu.MemoryManager().GpuToCpuAddress(surface_address);
 
         const u8* buffer = Memory::GetPointer(*address);
         ASSERT_MSG(buffer != nullptr, "Memory not accessible");


### PR DESCRIPTION
Makes the class interface consistent and provides accessors for obtaining a reference to the memory manager instance.

Given we also return references, this makes our more flimsy uses of const apparent, given const doesn't propagate through pointers in the way one would typically expect. This makes our mutable state more apparent in some places.