### PR TITLE
gl_shader_cache: Remove unused program_code vector in GetShaderAddress()

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -14,9 +14,8 @@ namespace OpenGL {
 /// Gets the address for the specified shader stage program
 static Tegra::GPUVAddr GetShaderAddress(Maxwell::ShaderProgram program) {
     auto& gpu = Core::System::GetInstance().GPU().Maxwell3D();
-
-    GLShader::ProgramCode program_code(GLShader::MAX_PROGRAM_CODE_LENGTH);
     auto& shader_config = gpu.regs.shader_config[static_cast<size_t>(program)];
+
     return gpu.regs.code_address.CodeAddress() + shader_config.offset;
 }
 


### PR DESCRIPTION
Given std::vector is a type with a non-trivial destructor, this variable cannot be optimized away by the compiler, even if unused. Because of that, something that was intended to be fairly lightweight, was actually allocating 32KB and deallocating it at the end of the function.