### PR TITLE
.travis: Use Citras ccache for builds instead of yuzus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ matrix:
       install: "./.travis/linux/deps.sh"
       script: "./.travis/linux/build.sh"
       after_success: "./.travis/linux/upload.sh"
+      cache: ccache
     - os: osx
       env: NAME="macos build"
       sudo: false
@@ -27,6 +28,7 @@ matrix:
       install: "./.travis/macos/deps.sh"
       script: "./.travis/macos/build.sh"
       after_success: "./.travis/macos/upload.sh"
+      cache: ccache
 
 deploy:
   provider: releases
@@ -42,7 +44,3 @@ notifications:
   webhooks:
     urls:
       - https://api.yuzu-emu.org/code/travis/notify
-
-cache:
-  directories:
-    - $HOME/.ccache

--- a/.travis/linux/build.sh
+++ b/.travis/linux/build.sh
@@ -1,3 +1,4 @@
 #!/bin/bash -ex
 
-docker run -e CCACHE_DIR=/ccache -v $HOME/.ccache:/ccache --env-file .travis/common/travis-ci.env -v $(pwd):/yuzu ubuntu:18.04 /bin/bash /yuzu/.travis/linux/docker.sh
+mkdir -p "$HOME/.ccache"
+docker run --env-file .travis/common/travis-ci.env -v $(pwd):/yuzu -v "$HOME/.ccache":/root/.ccache ubuntu:18.04 /bin/bash /yuzu/.travis/linux/docker.sh

--- a/.travis/linux/docker.sh
+++ b/.travis/linux/docker.sh
@@ -5,14 +5,8 @@ apt-get install --no-install-recommends -y build-essential git libqt5opengl5-dev
 
 cd /yuzu
 
-export PATH=/usr/lib/ccache:$PATH
-ln -sf /usr/bin/ccache /usr/lib/ccache/cc
-ln -sf /usr/bin/ccache /usr/lib/ccache/c++
 mkdir build && cd build
-ccache --show-stats > ccache_before
-cmake .. -DYUZU_BUILD_UNICORN=ON -DCMAKE_BUILD_TYPE=Release -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -G Ninja
+cmake .. -DYUZU_BUILD_UNICORN=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/lib/ccache/gcc -DCMAKE_CXX_COMPILER=/usr/lib/ccache/g++ -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -G Ninja
 ninja
-ccache --show-stats > ccache_after
-diff -U100 ccache_before ccache_after || true
 
 ctest -VV -C Release

--- a/.travis/macos/build.sh
+++ b/.travis/macos/build.sh
@@ -5,14 +5,11 @@ set -o pipefail
 export MACOSX_DEPLOYMENT_TARGET=10.12
 export Qt5_DIR=$(brew --prefix)/opt/qt5
 export UNICORNDIR=$(pwd)/externals/unicorn
+export PATH="/usr/local/opt/ccache/libexec:$PATH"
 
 mkdir build && cd build
-export PATH=/usr/local/opt/ccache/libexec:$PATH
-ccache --show-stats > ccache_before
 cmake --version
 cmake .. -DYUZU_BUILD_UNICORN=ON -DCMAKE_BUILD_TYPE=Release -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON
 make -j4
-ccache --show-stats > ccache_after
-diff -U100 ccache_before ccache_after || true
 
 ctest -VV -C Release


### PR DESCRIPTION
Makes the code cleaner and makes it easier to port other changes from Citra that build ontop of this (e.g. travis mingw builds).