### PR TITLE
gl_rasterizer: Fix issues with the rasterizer cache.

### DIFF
--- a/src/video_core/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache.h
@@ -5,12 +5,12 @@
 #pragma once
 
 #include <unordered_map>
-#include <boost/icl/interval_map.hpp>
-#include <boost/range/iterator_range.hpp>
 
 #include "common/common_types.h"
 #include "core/memory.h"
 #include "video_core/memory_manager.h"
+#include "video_core/rasterizer_interface.h"
+#include "video_core/renderer_base.h"
 
 template <class T>
 class RasterizerCache : NonCopyable {
@@ -54,8 +54,9 @@ protected:
             return;
         }
 
-        cached_objects[object->GetAddr()] = object;
-        UpdatePagesCachedCount(object->GetAddr(), object->GetSizeInBytes(), 1);
+        auto& rasterizer = Core::System::GetInstance().Renderer().Rasterizer();
+        rasterizer.UpdatePagesCachedCount(object->GetAddr(), object->GetSizeInBytes(), 1);
+        cached_objects[object->GetAddr()] = std::move(object);
     }
 
     /// Unregisters an object from the cache
@@ -66,51 +67,11 @@ protected:
             return;
         }
 
-        UpdatePagesCachedCount(object->GetAddr(), object->GetSizeInBytes(), -1);
+        auto& rasterizer = Core::System::GetInstance().Renderer().Rasterizer();
+        rasterizer.UpdatePagesCachedCount(object->GetAddr(), object->GetSizeInBytes(), -1);
         cached_objects.erase(search);
     }
 
 private:
-    using PageMap = boost::icl::interval_map<u64, int>;
-
-    template <typename Map, typename Interval>
-    constexpr auto RangeFromInterval(Map& map, const Interval& interval) {
-        return boost::make_iterator_range(map.equal_range(interval));
-    }
-
-    /// Increase/decrease the number of object in pages touching the specified region
-    void UpdatePagesCachedCount(Tegra::GPUVAddr addr, u64 size, int delta) {
-        const u64 page_start{addr >> Tegra::MemoryManager::PAGE_BITS};
-        const u64 page_end{(addr + size) >> Tegra::MemoryManager::PAGE_BITS};
-
-        // Interval maps will erase segments if count reaches 0, so if delta is negative we have to
-        // subtract after iterating
-        const auto pages_interval = PageMap::interval_type::right_open(page_start, page_end);
-        if (delta > 0)
-            cached_pages.add({pages_interval, delta});
-
-        for (const auto& pair : RangeFromInterval(cached_pages, pages_interval)) {
-            const auto interval = pair.first & pages_interval;
-            const int count = pair.second;
-
-            const Tegra::GPUVAddr interval_start_addr = boost::icl::first(interval)
-                                                        << Tegra::MemoryManager::PAGE_BITS;
-            const Tegra::GPUVAddr interval_end_addr = boost::icl::last_next(interval)
-                                                      << Tegra::MemoryManager::PAGE_BITS;
-            const u64 interval_size = interval_end_addr - interval_start_addr;
-
-            if (delta > 0 && count == delta)
-                Memory::RasterizerMarkRegionCached(interval_start_addr, interval_size, true);
-            else if (delta < 0 && count == -delta)
-                Memory::RasterizerMarkRegionCached(interval_start_addr, interval_size, false);
-            else
-                ASSERT(count >= 0);
-        }
-
-        if (delta < 0)
-            cached_pages.add({pages_interval, delta});
-    }
-
     std::unordered_map<Tegra::GPUVAddr, T> cached_objects;
-    PageMap cached_pages;
 };

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -60,5 +60,8 @@ public:
     virtual bool AccelerateDrawBatch(bool is_indexed) {
         return false;
     }
+
+    /// Increase/decrease the number of object in pages touching the specified region
+    virtual void UpdatePagesCachedCount(Tegra::GPUVAddr addr, u64 size, int delta) {}
 };
 } // namespace VideoCore

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -274,6 +274,44 @@ bool RasterizerOpenGL::AccelerateDrawBatch(bool is_indexed) {
     return true;
 }
 
+template <typename Map, typename Interval>
+constexpr auto RangeFromInterval(Map& map, const Interval& interval) {
+    return boost::make_iterator_range(map.equal_range(interval));
+}
+
+void RasterizerOpenGL::UpdatePagesCachedCount(Tegra::GPUVAddr addr, u64 size, int delta) {
+    const u64 page_start{addr >> Tegra::MemoryManager::PAGE_BITS};
+    const u64 page_end{(addr + size + Tegra::MemoryManager::PAGE_SIZE - 1) >>
+                       Tegra::MemoryManager::PAGE_BITS};
+
+    // Interval maps will erase segments if count reaches 0, so if delta is negative we have to
+    // subtract after iterating
+    const auto pages_interval = CachedPageMap::interval_type::right_open(page_start, page_end);
+    if (delta > 0)
+        cached_pages.add({pages_interval, delta});
+
+    for (const auto& pair : RangeFromInterval(cached_pages, pages_interval)) {
+        const auto interval = pair.first & pages_interval;
+        const int count = pair.second;
+
+        const Tegra::GPUVAddr interval_start_addr = boost::icl::first(interval)
+                                                    << Tegra::MemoryManager::PAGE_BITS;
+        const Tegra::GPUVAddr interval_end_addr = boost::icl::last_next(interval)
+                                                  << Tegra::MemoryManager::PAGE_BITS;
+        const u64 interval_size = interval_end_addr - interval_start_addr;
+
+        if (delta > 0 && count == delta)
+            Memory::RasterizerMarkRegionCached(interval_start_addr, interval_size, true);
+        else if (delta < 0 && count == -delta)
+            Memory::RasterizerMarkRegionCached(interval_start_addr, interval_size, false);
+        else
+            ASSERT(count >= 0);
+    }
+
+    if (delta < 0)
+        cached_pages.add({pages_interval, delta});
+}
+
 std::pair<Surface, Surface> RasterizerOpenGL::ConfigureFramebuffers(bool using_color_fb,
                                                                     bool using_depth_fb,
                                                                     bool preserve_contents) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -10,7 +10,11 @@
 #include <tuple>
 #include <utility>
 #include <vector>
+
+#include <boost/icl/interval_map.hpp>
+#include <boost/range/iterator_range.hpp>
 #include <glad/glad.h>
+
 #include "common/common_types.h"
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/memory_manager.h"
@@ -49,6 +53,7 @@ public:
     bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
                            u32 pixel_stride) override;
     bool AccelerateDrawBatch(bool is_indexed) override;
+    void UpdatePagesCachedCount(Tegra::GPUVAddr addr, u64 size, int delta) override;
 
     /// OpenGL shader generated for a given Maxwell register state
     struct MaxwellShader {
@@ -187,6 +192,9 @@ private:
 
     enum class AccelDraw { Disabled, Arrays, Indexed };
     AccelDraw accelerate_draw = AccelDraw::Disabled;
+
+    using CachedPageMap = boost::icl::interval_map<u64, int>;
+    CachedPageMap cached_pages;
 };
 
 } // namespace OpenGL


### PR DESCRIPTION
- Use a single cached page map.
- Fix calculation of ending page.