### PR TITLE
filesystem/maxwell_3d: Various changes to boot Project Octopath Traveller

### DIFF
--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -455,7 +455,7 @@ FSP_SRV::FSP_SRV() : ServiceFramework("fsp-srv") {
         {34, nullptr, "GetCacheStorageSize"},
         {51, &FSP_SRV::MountSaveData, "MountSaveData"},
         {52, nullptr, "OpenSaveDataFileSystemBySystemSaveDataId"},
-        {53, nullptr, "OpenReadOnlySaveDataFileSystem"},
+        {53, &FSP_SRV::OpenReadOnlySaveDataFileSystem, "OpenReadOnlySaveDataFileSystem"},
         {57, nullptr, "ReadSaveDataFileSystemExtraDataBySaveDataSpaceId"},
         {58, nullptr, "ReadSaveDataFileSystemExtraData"},
         {59, nullptr, "WriteSaveDataFileSystemExtraData"},
@@ -582,6 +582,11 @@ void FSP_SRV::MountSaveData(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<IFileSystem>(std::move(filesystem));
+}
+
+void FSP_SRV::OpenReadOnlySaveDataFileSystem(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service_FS, "(STUBBED) called, delegating to 51 OpenSaveDataFilesystem");
+    MountSaveData(ctx);
 }
 
 void FSP_SRV::GetGlobalAccessLogMode(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -26,6 +26,17 @@
 
 namespace Service::FileSystem {
 
+enum class FileSystemType : u8 {
+    Invalid0 = 0,
+    Invalid1 = 1,
+    Logo = 2,
+    ContentControl = 3,
+    ContentManual = 4,
+    ContentMeta = 5,
+    ContentData = 6,
+    ApplicationPackage = 7,
+};
+
 class IStorage final : public ServiceFramework<IStorage> {
 public:
     explicit IStorage(FileSys::VirtualFile backend_)
@@ -420,7 +431,7 @@ FSP_SRV::FSP_SRV() : ServiceFramework("fsp-srv") {
         {0, nullptr, "MountContent"},
         {1, &FSP_SRV::Initialize, "Initialize"},
         {2, nullptr, "OpenDataFileSystemByCurrentProcess"},
-        {7, nullptr, "OpenFileSystemWithPatch"},
+        {7, &FSP_SRV::OpenFileSystemWithPatch, "OpenFileSystemWithPatch"},
         {8, nullptr, "OpenFileSystemWithId"},
         {9, nullptr, "OpenDataFileSystemByApplicationId"},
         {11, nullptr, "OpenBisFileSystem"},
@@ -514,6 +525,16 @@ void FSP_SRV::Initialize(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
+}
+
+void FSP_SRV::OpenFileSystemWithPatch(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+
+    const auto type = rp.PopRaw<FileSystemType>();
+    const auto title_id = rp.PopRaw<u64>();
+
+    IPC::ResponseBuilder rb{ctx, 2, 0, 0};
+    rb.Push(ResultCode(-1));
 }
 
 void FSP_SRV::MountSdCard(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/filesystem/fsp_srv.h
+++ b/src/core/hle/service/filesystem/fsp_srv.h
@@ -24,6 +24,7 @@ private:
     void MountSdCard(Kernel::HLERequestContext& ctx);
     void CreateSaveData(Kernel::HLERequestContext& ctx);
     void MountSaveData(Kernel::HLERequestContext& ctx);
+    void OpenReadOnlySaveDataFileSystem(Kernel::HLERequestContext& ctx);
     void GetGlobalAccessLogMode(Kernel::HLERequestContext& ctx);
     void OpenDataStorageByCurrentProcess(Kernel::HLERequestContext& ctx);
     void OpenDataStorageByDataId(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/filesystem/fsp_srv.h
+++ b/src/core/hle/service/filesystem/fsp_srv.h
@@ -20,6 +20,7 @@ public:
 
 private:
     void Initialize(Kernel::HLERequestContext& ctx);
+    void OpenFileSystemWithPatch(Kernel::HLERequestContext& ctx);
     void MountSdCard(Kernel::HLERequestContext& ctx);
     void CreateSaveData(Kernel::HLERequestContext& ctx);
     void MountSaveData(Kernel::HLERequestContext& ctx);

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -5,6 +5,7 @@
 #include <cinttypes>
 #include "common/assert.h"
 #include "core/core.h"
+#include "core/core_timing.h"
 #include "core/memory.h"
 #include "video_core/debug_utils/debug_utils.h"
 #include "video_core/engines/maxwell_3d.h"
@@ -194,8 +195,8 @@ void Maxwell3D::ProcessQueryGet() {
             // wait queues.
             LongQueryResult query_result{};
             query_result.value = result;
-            // TODO(Subv): Generate a real GPU timestamp and write it here instead of 0
-            query_result.timestamp = 0;
+            // TODO(Subv): Generate a real GPU timestamp and write it here instead of CoreTiming
+            query_result.timestamp = CoreTiming::GetTicks();
             Memory::WriteBlock(*address, &query_result, sizeof(query_result));
         }
         break;


### PR DESCRIPTION
The timestamp CoreTiming change is full credit to @gdkchan 

This allows octopath to boot and produces the following dazzling screenshots:

![](https://cdn.discordapp.com/attachments/451185149032529930/485285992488632321/unknown.png)

![](https://cdn.discordapp.com/attachments/451185149032529930/485286082771157000/unknown.png)
