### PR TITLE
Added better asserts to IPA, Renamed IPA modes to match mesa

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -243,7 +243,8 @@ enum class TextureType : u64 {
     TextureCube = 3,
 };
 
-enum class IpaMode : u64 { Pass = 0, None = 1, Constant = 2, Sc = 3 };
+enum class IpaInterpMode : u64 { Linear = 0, Perspective = 1, Flat = 2, Sc = 3 };
+enum class IpaSampleMode : u64 { Default = 0, Centroid = 1, Offset = 2 };
 
 union Instruction {
     Instruction& operator=(const Instruction& instr) {
@@ -328,7 +329,9 @@ union Instruction {
     } alu;
 
     union {
-        BitField<54, 3, IpaMode> mode;
+        BitField<51, 1, u64> saturate;
+        BitField<52, 2, IpaSampleMode> sample_mode;
+        BitField<54, 2, IpaInterpMode> interp_mode;
     } ipa;
 
     union {

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -2110,8 +2110,12 @@ private:
             case OpCode::Id::IPA: {
                 const auto& attribute = instr.attribute.fmt28;
                 const auto& reg = instr.gpr0;
-                switch (instr.ipa.mode) {
-                case Tegra::Shader::IpaMode::Pass:
+                ASSERT_MSG(instr.ipa.sample_mode == Tegra::Shader::IpaSampleMode::Default,
+                           "Unhandled IPA sample mode: {}",
+                           static_cast<u32>(instr.ipa.sample_mode.Value()));
+                ASSERT_MSG(instr.ipa.saturate == 0, "IPA saturate not implemented");
+                switch (instr.ipa.interp_mode) {
+                case Tegra::Shader::IpaInterpMode::Linear:
                     if (stage == Maxwell3D::Regs::ShaderStage::Fragment &&
                         attribute.index == Attribute::Index::Position) {
                         switch (attribute.element) {
@@ -2132,12 +2136,12 @@ private:
                         regs.SetRegisterToInputAttibute(reg, attribute.element, attribute.index);
                     }
                     break;
-                case Tegra::Shader::IpaMode::None:
+                case Tegra::Shader::IpaInterpMode::Perspective:
                     regs.SetRegisterToInputAttibute(reg, attribute.element, attribute.index);
                     break;
                 default:
                     LOG_CRITICAL(HW_GPU, "Unhandled IPA mode: {}",
-                                 static_cast<u32>(instr.ipa.mode.Value()));
+                                 static_cast<u32>(instr.ipa.interp_mode.Value()));
                     UNREACHABLE();
                     regs.SetRegisterToInputAttibute(reg, attribute.element, attribute.index);
                 }


### PR DESCRIPTION
IpaMode is changed to IpaInterpMode
IpaMode is supposed to be 2 bits, not 3
Added IpaSampleMode
Added Saturate

Renamed modes based on
https://github.com/mesa3d/mesa/blob/d27c7918916cdc8092959124955f887592e37d72/src/gallium/drivers/nouveau/codegen/nv50_ir_emit_gm107.cpp#L2530