### PR TITLE
Added FMUL asserts

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -337,7 +337,6 @@ union Instruction {
         BitField<44, 2, u64> tab5c68_0;
         BitField<47, 1, u64> cc;
         BitField<48, 1, u64> negate_b;
-        BitField<50, 1, u64> saturate;
     } fmul;
 
     union {

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -332,7 +332,12 @@ union Instruction {
     } ipa;
 
     union {
+        BitField<39, 2, u64> tab5cb8_2;
+        BitField<41, 3, u64> tab5c68_1;
+        BitField<44, 2, u64> tab5c68_0;
+        BitField<47, 1, u64> cc;
         BitField<48, 1, u64> negate_b;
+        BitField<50, 1, u64> saturate;
     } fmul;
 
     union {

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1046,7 +1046,6 @@ private:
                            instr.fmul.tab5c68_0
                                .Value()); // SMO typical sends 1 here which seems to be the default
                 ASSERT_MSG(instr.fmul.cc == 0, "FMUL cc is not implemented");
-                ASSERT_MSG(instr.fmul.saturate == 0, "FMUL saturate is not implemented");
 
                 op_b = GetOperandAbsNeg(op_b, false, instr.fmul.negate_b);
                 regs.SetRegisterToFloat(instr.gpr0, 0, op_a + " * " + op_b, 1, 1,

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1038,6 +1038,16 @@ private:
             case OpCode::Id::FMUL_R:
             case OpCode::Id::FMUL_IMM: {
                 // FMUL does not have 'abs' bits and only the second operand has a 'neg' bit.
+                ASSERT_MSG(instr.fmul.tab5cb8_2 == 0, "FMUL tab5cb8_2({}) is not implemented",
+                           instr.fmul.tab5cb8_2.Value());
+                ASSERT_MSG(instr.fmul.tab5c68_1 == 0, "FMUL tab5cb8_1({}) is not implemented",
+                           instr.fmul.tab5c68_1.Value());
+                ASSERT_MSG(instr.fmul.tab5c68_0 == 1, "FMUL tab5cb8_0({}) is not implemented",
+                           instr.fmul.tab5c68_0
+                               .Value()); // SMO typical sends 1 here which seems to be the default
+                ASSERT_MSG(instr.fmul.cc == 0, "FMUL cc is not implemented");
+                ASSERT_MSG(instr.fmul.saturate == 0, "FMUL saturate is not implemented");
+
                 op_b = GetOperandAbsNeg(op_b, false, instr.fmul.negate_b);
                 regs.SetRegisterToFloat(instr.gpr0, 0, op_a + " * " + op_b, 1, 1,
                                         instr.alu.saturate_d);


### PR DESCRIPTION
Added Asserts for cc, tab5c68_0, tab5c68_1 and tab5cb8_2 bit fields for FMUL.
tab5c68_0 assert could be wrong but typically the only value I've seen in SMO is 1. I'm assuming this is the default.