### PR TITLE
Build - Upload fewer artifacts

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -162,10 +162,6 @@ artifacts:
   - path: $(BUILD_ZIP)
     name: build
     type: zip
-  - path: $(BUILD_SYMBOLS)
-    name: debugsymbols
-  - path: $(BUILD_UPDATE)
-    name: update
 
 deploy:
   provider: GitHub


### PR DESCRIPTION
Appveyor has a limit on artifact retention, and we hit the limit all the
time, so just lower the number of build artifacts to just the final zip

For reference, this cuts the total artifacts size down to 44MB from 104MB per build.