### PR TITLE
file_sys: Allow for custom NAND/SD directories

### DIFF
--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -127,6 +127,8 @@ struct Values {
 
     // Data Storage
     bool use_virtual_sd;
+    std::string nand_dir;
+    std::string sdmc_dir;
 
     // Renderer
     float resolution_factor;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -102,6 +102,20 @@ void Config::ReadValues() {
 
     qt_config->beginGroup("Data Storage");
     Settings::values.use_virtual_sd = qt_config->value("use_virtual_sd", true).toBool();
+    FileUtil::GetUserPath(
+        FileUtil::UserPath::NANDDir,
+        qt_config
+            ->value("nand_directory",
+                    QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)))
+            .toString()
+            .toStdString());
+    FileUtil::GetUserPath(
+        FileUtil::UserPath::SDMCDir,
+        qt_config
+            ->value("sdmc_directory",
+                    QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)))
+            .toString()
+            .toStdString());
     qt_config->endGroup();
 
     qt_config->beginGroup("System");
@@ -222,6 +236,10 @@ void Config::SaveValues() {
 
     qt_config->beginGroup("Data Storage");
     qt_config->setValue("use_virtual_sd", Settings::values.use_virtual_sd);
+    qt_config->setValue("nand_directory",
+                        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)));
+    qt_config->setValue("sdmc_directory",
+                        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)));
     qt_config->endGroup();
 
     qt_config->beginGroup("System");

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -372,6 +372,10 @@ void GMainWindow::ConnectMenuEvents() {
             &GMainWindow::OnMenuInstallToNAND);
     connect(ui.action_Select_Game_List_Root, &QAction::triggered, this,
             &GMainWindow::OnMenuSelectGameListRoot);
+    connect(ui.action_Select_NAND_Directory, &QAction::triggered, this,
+            [this] { OnMenuSelectEmulatedDirectory(false); });
+    connect(ui.action_Select_SDMC_Directory, &QAction::triggered, this,
+            [this] { OnMenuSelectEmulatedDirectory(true); });
     connect(ui.action_Exit, &QAction::triggered, this, &QMainWindow::close);
 
     // Emulation
@@ -884,6 +888,16 @@ void GMainWindow::OnMenuSelectGameListRoot() {
     if (!dir_path.isEmpty()) {
         UISettings::values.gamedir = dir_path;
         game_list->PopulateAsync(dir_path, UISettings::values.gamedir_deepscan);
+    }
+}
+
+void GMainWindow::OnMenuSelectEmulatedDirectory(bool is_sdmc) {
+    QString dir_path = QFileDialog::getExistingDirectory(this, tr("Select Directory"));
+    if (!dir_path.isEmpty()) {
+        FileUtil::GetUserPath(is_sdmc ? FileUtil::UserPath::SDMCDir : FileUtil::UserPath::NANDDir,
+                              dir_path.toStdString());
+        Service::FileSystem::CreateFactories(vfs);
+        game_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
     }
 }
 

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -32,6 +32,11 @@ namespace Tegra {
 class DebugContext;
 }
 
+enum class EmulatedDirectoryTarget {
+    NAND,
+    SDMC,
+};
+
 class GMainWindow : public QMainWindow {
     Q_OBJECT
 
@@ -138,8 +143,7 @@ private slots:
     /// Called whenever a user selects the "File->Select Game List Root" menu item
     void OnMenuSelectGameListRoot();
     /// Called whenever a user select the "File->Select -- Directory" where -- is NAND or SD Card
-    /// (false for nand, true for sdmc)
-    void OnMenuSelectEmulatedDirectory(bool is_sdmc);
+    void OnMenuSelectEmulatedDirectory(EmulatedDirectoryTarget target);
     void OnMenuRecentFile();
     void OnConfigure();
     void OnAbout();

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -137,6 +137,9 @@ private slots:
     void OnMenuInstallToNAND();
     /// Called whenever a user selects the "File->Select Game List Root" menu item
     void OnMenuSelectGameListRoot();
+    /// Called whenever a user select the "File->Select -- Directory" where -- is NAND or SD Card
+    /// (false for nand, true for sdmc)
+    void OnMenuSelectEmulatedDirectory(bool is_sdmc);
     void OnMenuRecentFile();
     void OnConfigure();
     void OnAbout();

--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -65,6 +65,9 @@
     <addaction name="action_Select_Game_List_Root"/>
     <addaction name="menu_recent_files"/>
     <addaction name="separator"/>
+    <addaction name="action_Select_NAND_Directory"/>
+    <addaction name="action_Select_SDMC_Directory"/>
+    <addaction name="separator"/>
     <addaction name="action_Exit"/>
    </widget>
    <widget class="QMenu" name="menu_Emulation">
@@ -202,6 +205,22 @@
    </property>
    <property name="toolTip">
     <string>Selects a folder to display in the game list</string>
+   </property>
+  </action>
+  <action name="action_Select_NAND_Directory">
+   <property name="text">
+    <string>Select NAND Directory...</string>
+   </property>
+   <property name="toolTip">
+    <string>Selects a folder to use as the root of the emulated NAND</string>
+   </property>
+  </action>
+  <action name="action_Select_SDMC_Directory">
+   <property name="text">
+    <string>Select SD Card Directory...</string>
+   </property>
+   <property name="toolTip">
+    <string>Selects a folder to use as the root of the emulated SD card</string>
    </property>
   </action>
   <action name="action_Fullscreen">

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -114,6 +114,12 @@ void Config::ReadValues() {
     // Data Storage
     Settings::values.use_virtual_sd =
         sdl2_config->GetBoolean("Data Storage", "use_virtual_sd", true);
+    FileUtil::GetUserPath(FileUtil::UserPath::NANDDir,
+                          sdl2_config->Get("Data Storage", "nand_directory",
+                                           FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)));
+    FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir,
+                          sdl2_config->Get("Data Storage", "nand_directory",
+                                           FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)));
 
     // System
     Settings::values.use_docked_mode = sdl2_config->GetBoolean("System", "use_docked_mode", false);


### PR DESCRIPTION
Resolves request #1206.

- Stores the NAND/SD directory in configuration file.
- Can be changed via menu options in QT UI.
- **NOTE:** Does *not* move the contents of NAND/SD dirs, you have to do that yourself.