### PR TITLE
filesystem: Move dir retrieval after path checking in DeleteFile()

### DIFF
--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -60,17 +60,20 @@ ResultCode VfsDirectoryServiceWrapper::CreateFile(const std::string& path_, u64 
 
 ResultCode VfsDirectoryServiceWrapper::DeleteFile(const std::string& path_) const {
     std::string path(FileUtil::SanitizePath(path_));
-    auto dir = GetDirectoryRelativeWrapped(backing, FileUtil::GetParentPath(path));
     if (path.empty()) {
         // TODO(DarkLordZach): Why do games call this and what should it do? Works as is but...
         return RESULT_SUCCESS;
     }
-    if (dir->GetFile(FileUtil::GetFilename(path)) == nullptr)
+
+    auto dir = GetDirectoryRelativeWrapped(backing, FileUtil::GetParentPath(path));
+    if (dir->GetFile(FileUtil::GetFilename(path)) == nullptr) {
         return FileSys::ERROR_PATH_NOT_FOUND;
+    }
     if (!dir->DeleteFile(FileUtil::GetFilename(path))) {
         // TODO(DarkLordZach): Find a better error code for this
         return ResultCode(-1);
     }
+
     return RESULT_SUCCESS;
 }
 


### PR DESCRIPTION
We don't need to do the lookup if the path is considered empty currently.