### PR TITLE
service: Migrate global named port map to the KernelCore class

### DIFF
--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string>
+#include <unordered_map>
 #include "core/hle/kernel/object.h"
 
 template <typename T>
@@ -15,6 +17,7 @@ struct EventType;
 
 namespace Kernel {
 
+class ClientPort;
 class HandleTable;
 class Process;
 class ResourceLimit;
@@ -25,6 +28,9 @@ enum class ResourceLimitCategory : u8;
 
 /// Represents a single instance of the kernel.
 class KernelCore {
+private:
+    using NamedPortTable = std::unordered_map<std::string, SharedPtr<ClientPort>>;
+
 public:
     KernelCore();
     ~KernelCore();
@@ -58,6 +64,18 @@ public:
 
     /// Adds the given shared pointer to an internal list of active processes.
     void AppendNewProcess(SharedPtr<Process> process);
+
+    /// Adds a port to the named port table
+    void AddNamedPort(std::string name, SharedPtr<ClientPort> port);
+
+    /// Finds a port within the named port table with the given name.
+    NamedPortTable::iterator FindNamedPort(const std::string& name);
+
+    /// Finds a port within the named port table with the given name.
+    NamedPortTable::const_iterator FindNamedPort(const std::string& name) const;
+
+    /// Determines whether or not the given port is a valid named port.
+    bool IsValidNamedPort(NamedPortTable::const_iterator port) const;
 
 private:
     friend class Object;

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -12,6 +12,7 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/handle_table.h"
+#include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/server_port.h"
 #include "core/hle/kernel/thread.h"
@@ -114,7 +115,7 @@ void ServiceFrameworkBase::InstallAsNamedPort() {
     std::tie(server_port, client_port) =
         ServerPort::CreatePortPair(kernel, max_sessions, service_name);
     server_port->SetHleHandler(shared_from_this());
-    AddNamedPort(service_name, std::move(client_port));
+    kernel.AddNamedPort(service_name, std::move(client_port));
 }
 
 Kernel::SharedPtr<Kernel::ClientPort> ServiceFrameworkBase::CreatePort() {
@@ -197,11 +198,6 @@ ResultCode ServiceFrameworkBase::HandleSyncRequest(Kernel::HLERequestContext& co
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Module interface
 
-// TODO(yuriks): Move to kernel
-void AddNamedPort(std::string name, SharedPtr<ClientPort> port) {
-    g_kernel_named_ports.emplace(std::move(name), std::move(port));
-}
-
 /// Initialize ServiceManager
 void Init(std::shared_ptr<SM::ServiceManager>& sm, const FileSys::VirtualFilesystem& rfs) {
     // NVFlinger needs to be accessed by several services like Vi and AppletOE so we instantiate it
@@ -264,7 +260,6 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm, const FileSys::VirtualFilesys
 
 /// Shutdown ServiceManager
 void Shutdown() {
-    g_kernel_named_ports.clear();
     LOG_DEBUG(Service, "shutdown OK");
 }
 } // namespace Service

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -6,7 +6,6 @@
 
 #include <cstddef>
 #include <string>
-#include <unordered_map>
 #include <boost/container/flat_map.hpp>
 #include "common/common_types.h"
 #include "core/hle/kernel/hle_ipc.h"
@@ -186,11 +185,5 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm,
 
 /// Shutdown ServiceManager
 void Shutdown();
-
-/// Map of named ports managed by the kernel, which can be retrieved using the ConnectToPort SVC.
-extern std::unordered_map<std::string, Kernel::SharedPtr<Kernel::ClientPort>> g_kernel_named_ports;
-
-/// Adds a port to the named port table
-void AddNamedPort(std::string name, Kernel::SharedPtr<Kernel::ClientPort> port);
 
 } // namespace Service


### PR DESCRIPTION
Now that we have a class representing the kernel in some capacity, we now have a place to put the named port map, so we move it over and get rid of another piece of global state within the core.