### PR TITLE
gl_shader_decompiler: Use used_shaders member variable directly within GenerateDeclarations()

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -441,7 +441,7 @@ public:
         declarations.AddNewLine();
 
         // Append the sampler2D array for the used textures.
-        size_t num_samplers = GetSamplers().size();
+        const size_t num_samplers = used_samplers.size();
         if (num_samplers > 0) {
             declarations.AddLine("uniform sampler2D " + SamplerEntry::GetArrayName(stage) + '[' +
                                  std::to_string(num_samplers) + "];");


### PR DESCRIPTION
Using the getter function intended for external code here makes an unnecessary copy of the already-accessible used_shaders vector.