### PR TITLE
(DO NOT MERGE) Implemented Shader Dumper for RE

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -38,6 +38,8 @@ add_library(video_core STATIC
     renderer_opengl/gl_shader_cache.h
     renderer_opengl/gl_shader_decompiler.cpp
     renderer_opengl/gl_shader_decompiler.h
+    renderer_opengl/gl_shader_dumper.cpp
+    renderer_opengl/gl_shader_dumper.h
     renderer_opengl/gl_shader_gen.cpp
     renderer_opengl/gl_shader_gen.h
     renderer_opengl/gl_shader_manager.cpp

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -30,7 +30,11 @@ using Tegra::Shader::SubOp;
 constexpr u32 PROGRAM_END = MAX_PROGRAM_CODE_LENGTH;
 constexpr u32 PROGRAM_HEADER_SIZE = sizeof(Tegra::Shader::Header);
 
+<<<<<<< HEAD
 enum : u32 { POSITION_VARYING_LOCATION = 0, GENERIC_VARYING_START_LOCATION = 1 };
+=======
+constexpr u32 POSITION_VARYING_LOCATION = 15;
+>>>>>>> glsl_decompiler: Implement geometry shaders
 
 constexpr u32 MAX_GEOMETRY_BUFFERS = 6;
 constexpr u32 MAX_ATTRIBUTES = 0x100; // Size in vec4s, this value is untested
@@ -506,7 +510,11 @@ public:
     /// Returns the GLSL sampler used for the input shader sampler, and creates a new one if
     /// necessary.
     std::string AccessSampler(const Sampler& sampler, Tegra::Shader::TextureType type,
+<<<<<<< HEAD
                               bool is_array, bool is_shadow) {
+=======
+                              bool is_array) {
+>>>>>>> glsl_decompiler: Implement geometry shaders
         const auto offset = static_cast<std::size_t>(sampler.index.Value());
 
         // If this sampler has already been used, return the existing mapping.
@@ -515,14 +523,22 @@ public:
                          [&](const SamplerEntry& entry) { return entry.GetOffset() == offset; });
 
         if (itr != used_samplers.end()) {
+<<<<<<< HEAD
             ASSERT(itr->GetType() == type && itr->IsArray() == is_array &&
                    itr->IsShadow() == is_shadow);
+=======
+            ASSERT(itr->GetType() == type && itr->IsArray() == is_array);
+>>>>>>> glsl_decompiler: Implement geometry shaders
             return itr->GetName();
         }
 
         // Otherwise create a new mapping for this sampler
         const std::size_t next_index = used_samplers.size();
+<<<<<<< HEAD
         const SamplerEntry entry{stage, offset, next_index, type, is_array, is_shadow};
+=======
+        const SamplerEntry entry{stage, offset, next_index, type, is_array};
+>>>>>>> glsl_decompiler: Implement geometry shaders
         used_samplers.emplace_back(entry);
         return entry.GetName();
     }
@@ -559,10 +575,14 @@ private:
             // TODO(bunnei): Use proper number of elements for these
             u32 idx =
                 static_cast<u32>(element.first) - static_cast<u32>(Attribute::Index::Attribute_0);
+<<<<<<< HEAD
             if (stage != Maxwell3D::Regs::ShaderStage::Vertex) {
                 // If inputs are varyings, add an offset
                 idx += GENERIC_VARYING_START_LOCATION;
             }
+=======
+            ASSERT(idx != POSITION_VARYING_LOCATION);
+>>>>>>> glsl_decompiler: Implement geometry shaders
 
             std::string attr{GetInputAttribute(element.first, element.second)};
             if (stage == Maxwell3D::Regs::ShaderStage::Geometry) {
@@ -583,11 +603,18 @@ private:
         }
         for (const auto& index : declr_output_attribute) {
             // TODO(bunnei): Use proper number of elements for these
+<<<<<<< HEAD
             const u32 idx = static_cast<u32>(index) -
                             static_cast<u32>(Attribute::Index::Attribute_0) +
                             GENERIC_VARYING_START_LOCATION;
             declarations.AddLine("layout (location = " + std::to_string(idx) + ") out vec4 " +
                                  GetOutputAttribute(index) + ';');
+=======
+            declarations.AddLine("layout (location = " +
+                                 std::to_string(static_cast<u32>(index) -
+                                                static_cast<u32>(Attribute::Index::Attribute_0)) +
+                                 ") out vec4 " + GetOutputAttribute(index) + ';');
+>>>>>>> glsl_decompiler: Implement geometry shaders
         }
         declarations.AddNewLine();
     }
@@ -710,7 +737,11 @@ private:
                                   const Tegra::Shader::IpaMode& input_mode,
                                   boost::optional<Register> vertex = {}) {
         auto GeometryPass = [&](const std::string& name) {
+<<<<<<< HEAD
             if (stage == Maxwell3D::Regs::ShaderStage::Geometry && vertex) {
+=======
+            if (stage == Maxwell3D::Regs::ShaderStage::Geometry && vertex.has_value()) {
+>>>>>>> glsl_decompiler: Implement geometry shaders
                 return "gs_" + name + '[' + GetRegisterAsInteger(vertex.value(), 0, false) + ']';
             }
             return name;

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.h
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.h
@@ -20,6 +20,6 @@ std::string GetCommonDeclarations();
 
 boost::optional<ProgramResult> DecompileProgram(const ProgramCode& program_code, u32 main_offset,
                                                 Maxwell3D::Regs::ShaderStage stage,
-                                                const std::string& suffix);
+                                                const std::string& suffix, bool& faulty_shader);
 
 } // namespace OpenGL::GLShader::Decompiler

--- a/src/video_core/renderer_opengl/gl_shader_dumper.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_dumper.cpp
@@ -14,7 +14,6 @@ std::string n2hexstr(I w, size_t hex_len = sizeof(I) << 1) {
 }
 
 std::string ShaderDumper::hashName() {
-    u64 hash = Common::ComputeHash64(program.data(), sizeof(u64) * program.size());
     return n2hexstr(hash);
 }
 
@@ -28,7 +27,7 @@ bool IsSchedInstruction(u32 offset, u32 main_offset) {
 
 void ShaderDumper::dump() {
     FileUtil::IOFile sFile;
-    std::string name = prefix + hashName();
+    std::string name = prefix + hashName() + ".bin";
     sFile.Open(name, "wb");
     u32 start_offset = 10;
     u32 offset = start_offset;
@@ -50,5 +49,13 @@ void ShaderDumper::dump() {
         sFile.WriteArray<u64>(&fill, 1);
         size += 8;
     }
+    sFile.Close();
+}
+
+void ShaderDumper::dumpText(const std::string& s) {
+    FileUtil::IOFile sFile;
+    std::string name = prefix + hashName() + ".txt";
+    sFile.Open(name, "w");
+    sFile.WriteString(s);
     sFile.Close();
 }

--- a/src/video_core/renderer_opengl/gl_shader_dumper.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_dumper.cpp
@@ -1,0 +1,54 @@
+
+#include "common/file_util.h"
+#include "common/hash.h"
+#include "video_core/engines/shader_bytecode.h"
+#include "video_core/renderer_opengl/gl_shader_dumper.h"
+
+template <typename I>
+std::string n2hexstr(I w, size_t hex_len = sizeof(I) << 1) {
+    static const char* digits = "0123456789ABCDEF";
+    std::string rc(hex_len, '0');
+    for (size_t i = 0, j = (hex_len - 1) * 4; i < hex_len; ++i, j -= 4)
+        rc[i] = digits[(w >> j) & 0x0f];
+    return rc;
+}
+
+std::string ShaderDumper::hashName() {
+    u64 hash = Common::ComputeHash64(program.data(), sizeof(u64) * program.size());
+    return n2hexstr(hash);
+}
+
+bool IsSchedInstruction(u32 offset, u32 main_offset) {
+    // sched instructions appear once every 4 instructions.
+    static constexpr size_t SchedPeriod = 4;
+    u32 absolute_offset = offset - main_offset;
+
+    return (absolute_offset % SchedPeriod) == 0;
+}
+
+void ShaderDumper::dump() {
+    FileUtil::IOFile sFile;
+    std::string name = prefix + hashName();
+    sFile.Open(name, "wb");
+    u32 start_offset = 10;
+    u32 offset = start_offset;
+    u64 size = 0;
+    while (true) { // dump until hitting not finding a valid instruction
+        u64 inst = program[offset];
+        if (!IsSchedInstruction(offset, start_offset)) {
+            if (inst == 0) {
+                break;
+            }
+        }
+        sFile.WriteArray<u64>(&inst, 1);
+        size += 8;
+        offset += 1;
+    }
+    u64 fill = 0;
+    // Align to 32 bytes for nvdisasm
+    while ((size % 0x20) != 0) {
+        sFile.WriteArray<u64>(&fill, 1);
+        size += 8;
+    }
+    sFile.Close();
+}

--- a/src/video_core/renderer_opengl/gl_shader_dumper.h
+++ b/src/video_core/renderer_opengl/gl_shader_dumper.h
@@ -5,17 +5,20 @@
 #include <vector>
 
 #include "common/common_types.h"
+#include "common/hash.h"
 
 class ShaderDumper {
 public:
     ShaderDumper(const std::vector<u64>& prog, std::string prefix) : program(prog) {
+        this->hash = Common::ComputeHash64(program.data(), sizeof(u64) * program.size());
         this->prefix = prefix;
     }
     void dump();
+    void dumpText(const std::string& s);
 
 private:
     std::string hashName();
-
+    u64 hash;
     std::string prefix;
     const std::vector<u64>& program;
 };

--- a/src/video_core/renderer_opengl/gl_shader_dumper.h
+++ b/src/video_core/renderer_opengl/gl_shader_dumper.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <array>
+#include <string>
+#include <vector>
+
+#include "common/common_types.h"
+
+class ShaderDumper {
+public:
+    ShaderDumper(const std::vector<u64>& prog, std::string prefix) : program(prog) {
+        this->prefix = prefix;
+    }
+    void dump();
+
+private:
+    std::string hashName();
+
+    std::string prefix;
+    const std::vector<u64>& program;
+};

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -18,6 +18,7 @@ ProgramResult GenerateVertexShader(const ShaderSetup& setup) {
     out += "#extension GL_ARB_separate_shader_objects : enable\n\n";
     out += Decompiler::GetCommonDeclarations();
 
+<<<<<<< HEAD
     out += R"(
 out gl_PerVertex {
     vec4 gl_Position;
@@ -28,6 +29,17 @@ layout(std140) uniform vs_config {
     uvec4 instance_id;
     uvec4 flip_stage;
 };
+=======
+    out += R"(out gl_PerVertex {
+        vec4 gl_Position;
+    };
+
+    layout(std140) uniform vs_config {
+        vec4 viewport_flip;
+        uvec4 instance_id;
+        uvec4 flip_stage;
+    };
+>>>>>>> glsl_decompiler: Implement geometry shaders
 )";
 
     if (setup.IsDualProgram()) {
@@ -95,6 +107,7 @@ ProgramResult GenerateGeometryShader(const ShaderSetup& setup) {
 out gl_PerVertex {
     vec4 gl_Position;
 };
+<<<<<<< HEAD
 
 layout (std140) uniform gs_config {
     vec4 viewport_flip;
@@ -102,6 +115,15 @@ layout (std140) uniform gs_config {
     uvec4 flip_stage;
 };
 
+=======
+
+layout (std140) uniform gs_config {
+    vec4 viewport_flip;
+    uvec4 instance_id;
+    uvec4 flip_stage;
+};
+
+>>>>>>> glsl_decompiler: Implement geometry shaders
 void main() {
     exec_geometry();
 }

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -83,10 +83,12 @@ void main() {
     if (faultyA) {
         ShaderDumper s(setup.program.code, "VS");
         s.dump();
+        s.dumpText(out);
     }
     if (faultyB) {
         ShaderDumper s(setup.program.code_b, "VS");
         s.dump();
+        s.dumpText(out);
     }
     return {out, program.second};
 }
@@ -122,6 +124,7 @@ void main() {
     if (faulty) {
         ShaderDumper s(setup.program.code, "GS");
         s.dump();
+        s.dumpText(out);
     }
     return {out, program.second};
 }
@@ -162,6 +165,7 @@ void main() {
     if (faulty) {
         ShaderDumper s(setup.program.code, "FM");
         s.dump();
+        s.dumpText(out);
     }
     return {out, program.second};
 }


### PR DESCRIPTION
Here's a simple shader dumper to use with nvdisasm. It will only dump shaders marked as faulty. It should be used for debugging purposes mostly. In order to use it do the next:

CUDA Toolkit 8.0+ must be installed. https://developer.nvidia.com/cuda-downloads

1. fetch this pr into a separate branch and build it.
2. run yuzu with the game with faulty shaders. 
3. All shaders will be next to Yuzu's executable.
4. dissassemble a shader by using "nvdisasm -b SM52 <shader_name> > myasm.txt"
5. enjoy and happy Reverse Engineering!

Edit to dump specific shaders on certain assert/error, add "faulty =true;" next to it in shader_decompiler.cpp