### PR TITLE
file_sys/submission_package: Replace includes with forward declarations where applicable

### DIFF
--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -19,8 +19,8 @@
 
 namespace FileSys {
 NSP::NSP(VirtualFile file_)
-    : file(std::move(file_)),
-      pfs(std::make_shared<PartitionFilesystem>(file)), status{Loader::ResultStatus::Success} {
+    : file(std::move(file_)), status{Loader::ResultStatus::Success},
+      pfs(std::make_shared<PartitionFilesystem>(file)) {
     if (pfs->GetStatus() != Loader::ResultStatus::Success) {
         status = pfs->GetStatus();
         return;

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -2,9 +2,15 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
+#include <cstring>
+#include <string_view>
+
 #include <fmt/ostream.h>
-#include "common/assert.h"
+
 #include "common/hex_util.h"
+#include "common/logging/log.h"
+#include "core/crypto/key_manager.h"
 #include "core/file_sys/content_archive.h"
 #include "core/file_sys/nca_metadata.h"
 #include "core/file_sys/partition_filesystem.h"

--- a/src/core/file_sys/submission_package.h
+++ b/src/core/file_sys/submission_package.h
@@ -4,19 +4,22 @@
 
 #pragma once
 
-#include <array>
 #include <map>
+#include <memory>
 #include <vector>
 #include "common/common_types.h"
-#include "common/swap.h"
-#include "core/file_sys/content_archive.h"
-#include "core/file_sys/romfs_factory.h"
 #include "core/file_sys/vfs.h"
-#include "core/loader/loader.h"
+
+namespace Loader {
+enum class ResultStatus : u16;
+}
 
 namespace FileSys {
 
+class NCA;
 class PartitionFilesystem;
+
+enum class ContentRecordType : u8;
 
 class NSP : public ReadOnlyVfsDirectory {
 public:


### PR DESCRIPTION
Gets rid of some indirect inclusions and makes sure we don't add header dependencies where they're not necessary, which minimizes rebuilds when code is changed. While we're in the area, this also amends the initializer list order, which gets rid of a compiler warning (and makes it harder to introduce initialization bugs).