### PR TITLE
gl_rasterizer: Implement a VAO cache.

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -127,6 +127,7 @@ public:
                 BitField<21, 6, Size> size;
                 BitField<27, 3, Type> type;
                 BitField<31, 1, u32> bgra;
+                u32 hex;
             };
 
             u32 ComponentCount() const {
@@ -261,6 +262,10 @@ public:
 
             bool IsValid() const {
                 return size != Size::Invalid;
+            }
+
+            bool operator<(const VertexAttribute& other) const {
+                return hex < other.hex;
             }
         };
 
@@ -545,7 +550,7 @@ public:
 
                 INSERT_PADDING_WORDS(0x5B);
 
-                VertexAttribute vertex_attrib_format[NumVertexAttributes];
+                std::array<VertexAttribute, NumVertexAttributes> vertex_attrib_format;
 
                 INSERT_PADDING_WORDS(0xF);
 
@@ -964,7 +969,7 @@ ASSERT_REG_POSITION(stencil_back_func_ref, 0x3D5);
 ASSERT_REG_POSITION(stencil_back_mask, 0x3D6);
 ASSERT_REG_POSITION(stencil_back_func_mask, 0x3D7);
 ASSERT_REG_POSITION(zeta, 0x3F8);
-ASSERT_REG_POSITION(vertex_attrib_format[0], 0x458);
+ASSERT_REG_POSITION(vertex_attrib_format, 0x458);
 ASSERT_REG_POSITION(rt_control, 0x487);
 ASSERT_REG_POSITION(zeta_width, 0x48a);
 ASSERT_REG_POSITION(zeta_height, 0x48b);

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cstddef>
+#include <map>
 #include <memory>
 #include <tuple>
 #include <utility>
@@ -168,14 +169,15 @@ private:
     ScreenInfo& screen_info;
 
     std::unique_ptr<GLShader::ProgramManager> shader_program_manager;
-    OGLVertexArray sw_vao;
-    OGLVertexArray hw_vao;
+    std::map<std::array<Tegra::Engines::Maxwell3D::Regs::VertexAttribute,
+                        Tegra::Engines::Maxwell3D::Regs::NumVertexAttributes>,
+             OGLVertexArray>
+        vertex_array_cache;
 
     std::array<SamplerInfo, GLShader::NumTextureSamplers> texture_samplers;
 
     static constexpr size_t STREAM_BUFFER_SIZE = 128 * 1024 * 1024;
     OGLBufferCache buffer_cache;
-    OGLBuffer uniform_buffer;
     OGLFramebuffer framebuffer;
     GLint uniform_buffer_alignment;
 


### PR DESCRIPTION
This patch caches VAO objects instead of re-emiting all pointers per draw call.
Configuring this pointers is known as a fast task, but it yields too many GL
calls. So for better performance, just bind the VAO instead of 16 pointers.