### PR TITLE
gl_rasterizer: Use baseInstance instead of moving the buffer points.

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -444,6 +444,8 @@ QStringList GMainWindow::GetUnsupportedGLExtensions() {
         unsupported_ext.append("ARB_vertex_type_10f_11f_11f_rev");
     if (!GLAD_GL_ARB_texture_mirror_clamp_to_edge)
         unsupported_ext.append("ARB_texture_mirror_clamp_to_edge");
+    if (!GLAD_GL_ARB_base_instance)
+        unsupported_ext.append("ARB_base_instance");
 
     // Extensions required to support some texture formats.
     if (!GLAD_GL_EXT_texture_compression_s3tc)

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
@@ -91,6 +91,8 @@ bool EmuWindow_SDL2::SupportsRequiredGLExtensions() {
         unsupported_ext.push_back("ARB_vertex_type_10f_11f_11f_rev");
     if (!GLAD_GL_ARB_texture_mirror_clamp_to_edge)
         unsupported_ext.push_back("ARB_texture_mirror_clamp_to_edge");
+    if (!GLAD_GL_ARB_base_instance)
+        unsupported_ext.push_back("ARB_base_instance");
 
     // Extensions required to support some texture formats.
     if (!GLAD_GL_EXT_texture_compression_s3tc)


### PR DESCRIPTION
This hopefully helps our cache not to redundant upload the vertex buffer.

But bad luck, it has no impact at all on SMO. It still might help to fix the worst case.