### PR TITLE
file_sys/{nca_patch, patch_manager}: Amend unnecessary/missing includes.

### DIFF
--- a/src/core/file_sys/nca_patch.cpp
+++ b/src/core/file_sys/nca_patch.cpp
@@ -2,6 +2,10 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+
 #include "common/assert.h"
 #include "core/crypto/aes_util.h"
 #include "core/file_sys/nca_patch.h"

--- a/src/core/file_sys/nca_patch.cpp
+++ b/src/core/file_sys/nca_patch.cpp
@@ -17,9 +17,9 @@ BKTR::BKTR(VirtualFile base_romfs_, VirtualFile bktr_romfs_, RelocationBlock rel
            std::vector<SubsectionBucket> subsection_buckets_, bool is_encrypted_,
            Core::Crypto::Key128 key_, u64 base_offset_, u64 ivfc_offset_,
            std::array<u8, 8> section_ctr_)
-    : base_romfs(std::move(base_romfs_)), bktr_romfs(std::move(bktr_romfs_)),
-      relocation(relocation_), relocation_buckets(std::move(relocation_buckets_)),
+    : relocation(relocation_), relocation_buckets(std::move(relocation_buckets_)),
       subsection(subsection_), subsection_buckets(std::move(subsection_buckets_)),
+      base_romfs(std::move(base_romfs_)), bktr_romfs(std::move(bktr_romfs_)),
       encrypted(is_encrypted_), key(key_), base_offset(base_offset_), ivfc_offset(ivfc_offset_),
       section_ctr(section_ctr_) {
     for (size_t i = 0; i < relocation.number_buckets - 1; ++i) {

--- a/src/core/file_sys/nca_patch.h
+++ b/src/core/file_sys/nca_patch.h
@@ -5,10 +5,13 @@
 #pragma once
 
 #include <array>
+#include <memory>
 #include <vector>
-#include <common/common_funcs.h>
+
+#include "common/common_funcs.h"
+#include "common/common_types.h"
+#include "common/swap.h"
 #include "core/crypto/key_manager.h"
-#include "core/file_sys/romfs.h"
 
 namespace FileSys {
 

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -2,6 +2,10 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <array>
+#include <cstddef>
+
+#include "common/logging/log.h"
 #include "core/file_sys/content_archive.h"
 #include "core/file_sys/control_metadata.h"
 #include "core/file_sys/patch_manager.h"

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <map>
+#include <memory>
 #include <string>
 #include "common/common_types.h"
 #include "core/file_sys/nca_metadata.h"


### PR DESCRIPTION
In some cases includes weren't necessary in a header, or some were missing from the cpp files. This amends the relevant files to fix those. While we're at it, this also corrects the initializer list for BKTR to avoid compiler warnings.