### PR TITLE
core/core: Remove unnecessary sm/controller include

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -24,7 +24,6 @@
 #include "core/hle/kernel/scheduler.h"
 #include "core/hle/kernel/thread.h"
 #include "core/hle/service/service.h"
-#include "core/hle/service/sm/controller.h"
 #include "core/hle/service/sm/sm.h"
 #include "core/loader/loader.h"
 #include "core/perf_stats.h"

--- a/src/core/hle/service/sm/controller.cpp
+++ b/src/core/hle/service/sm/controller.cpp
@@ -57,4 +57,6 @@ Controller::Controller() : ServiceFramework("IpcController") {
     RegisterHandlers(functions);
 }
 
+Controller::~Controller() = default;
+
 } // namespace Service::SM

--- a/src/core/hle/service/sm/controller.h
+++ b/src/core/hle/service/sm/controller.h
@@ -11,7 +11,7 @@ namespace Service::SM {
 class Controller final : public ServiceFramework<Controller> {
 public:
     Controller();
-    ~Controller() = default;
+    ~Controller() override;
 
 private:
     void ConvertSessionToDomain(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -15,6 +15,7 @@
 
 namespace Service::SM {
 
+ServiceManager::ServiceManager() = default;
 ServiceManager::~ServiceManager() = default;
 
 void ServiceManager::InvokeControlRequest(Kernel::HLERequestContext& context) {

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -46,6 +46,7 @@ class ServiceManager {
 public:
     static void InstallInterfaces(std::shared_ptr<ServiceManager> self);
 
+    ServiceManager();
     ~ServiceManager();
 
     ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> RegisterService(std::string name,


### PR DESCRIPTION
The only reason this include was necessary, was because the constructor wasn't defaulted in the cpp file and the compiler would inline it wherever it was used. However, given Controller is forward declared, all those inlined constructors would see an incomplete type, causing a compilation failure. So, we just place the constructor in the cpp file, where it can see the complete type definition, allowing us to remove this include.