### PR TITLE
video_core/CMakeLists: Add missing gl_buffer_cache.h

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(video_core STATIC
     renderer_base.cpp
     renderer_base.h
     renderer_opengl/gl_buffer_cache.cpp
+    renderer_opengl/gl_buffer_cache.h
     renderer_opengl/gl_rasterizer.cpp
     renderer_opengl/gl_rasterizer.h
     renderer_opengl/gl_rasterizer_cache.cpp


### PR DESCRIPTION
Without this, the header file won't show up by default within IDEs such as Visual Studio.