### PR TITLE
core: Migrate current_process pointer to the kernel

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -174,8 +174,11 @@ public:
     /// Gets the scheduler for the CPU core with the specified index
     const std::shared_ptr<Kernel::Scheduler>& Scheduler(size_t core_index);
 
-    /// Gets the current process
+    /// Provides a reference to the current process
     Kernel::SharedPtr<Kernel::Process>& CurrentProcess();
+
+    /// Provides a constant reference to the current process.
+    const Kernel::SharedPtr<Kernel::Process>& CurrentProcess() const;
 
     /// Provides a reference to the kernel instance.
     Kernel::KernelCore& Kernel();

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -116,6 +116,7 @@ struct KernelCore::Impl {
         next_thread_id = 1;
 
         process_list.clear();
+        current_process.reset();
 
         handle_table.Clear();
         resource_limits.fill(nullptr);
@@ -206,6 +207,7 @@ struct KernelCore::Impl {
 
     // Lists all processes that exist in the current session.
     std::vector<SharedPtr<Process>> process_list;
+    SharedPtr<Process> current_process;
 
     Kernel::HandleTable handle_table;
     std::array<SharedPtr<ResourceLimit>, 4> resource_limits;
@@ -262,6 +264,18 @@ SharedPtr<Timer> KernelCore::RetrieveTimerFromCallbackHandleTable(Handle handle)
 
 void KernelCore::AppendNewProcess(SharedPtr<Process> process) {
     impl->process_list.push_back(std::move(process));
+}
+
+void KernelCore::MakeCurrentProcess(SharedPtr<Process> process) {
+    impl->current_process = std::move(process);
+}
+
+SharedPtr<Process>& KernelCore::CurrentProcess() {
+    return impl->current_process;
+}
+
+const SharedPtr<Process>& KernelCore::CurrentProcess() const {
+    return impl->current_process;
 }
 
 void KernelCore::AddNamedPort(std::string name, SharedPtr<ClientPort> port) {

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -65,6 +65,15 @@ public:
     /// Adds the given shared pointer to an internal list of active processes.
     void AppendNewProcess(SharedPtr<Process> process);
 
+    /// Makes the given process the new current process.
+    void MakeCurrentProcess(SharedPtr<Process> process);
+
+    /// Retrieves a reference to the current process.
+    SharedPtr<Process>& CurrentProcess();
+
+    /// Retrieves a const reference to the current process.
+    const SharedPtr<Process>& CurrentProcess() const;
+
     /// Adds a port to the named port table
     void AddNamedPort(std::string name, SharedPtr<ClientPort> port);
 


### PR DESCRIPTION
Given we now have the kernel as a class, it doesn't make sense to keep the current process pointer within the System class, as processes are related to the kernel.

This also gets rid of a subtle case where memory wouldn't be freed on core shutdown, as the current_process pointer would never be reset, causing the pointed to contents to continue to live.