### PR TITLE
yuzu: fix title bar display

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -608,7 +608,7 @@ void GMainWindow::BootGame(const QString& filename) {
     }
 
     setWindowTitle(QString("yuzu %1| %4 | %2-%3")
-                       .arg(Common::g_build_name, Common::g_scm_branch, Common::g_scm_desc,
+                       .arg(Common::g_build_fullname, Common::g_scm_branch, Common::g_scm_desc,
                             QString::fromStdString(title_name)));
 
     render_window->show();
@@ -643,7 +643,7 @@ void GMainWindow::ShutdownGame() {
     game_list->show();
     game_list->setFilterFocus();
     setWindowTitle(QString("yuzu %1| %2-%3")
-                       .arg(Common::g_build_name, Common::g_scm_branch, Common::g_scm_desc));
+                       .arg(Common::g_build_fullname, Common::g_scm_branch, Common::g_scm_desc));
 
     // Disable status bar updates
     status_bar_update_timer.stop();


### PR DESCRIPTION
Previously the version number got hidden after starting a game.

note: did not check clang format