### PR TITLE
yuzu: Move compatibility list specifics to their own source files

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -9,6 +9,8 @@ add_executable(yuzu
     about_dialog.h
     bootmanager.cpp
     bootmanager.h
+    compatibility_list.cpp
+    compatibility_list.h
     configuration/config.cpp
     configuration/config.h
     configuration/configure_audio.cpp

--- a/src/yuzu/compatibility_list.cpp
+++ b/src/yuzu/compatibility_list.cpp
@@ -1,0 +1,18 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+
+#include <fmt/format.h>
+
+#include "yuzu/compatibility_list.h"
+
+CompatibilityList::const_iterator FindMatchingCompatibilityEntry(
+    const CompatibilityList& compatibility_list, u64 program_id) {
+    return std::find_if(compatibility_list.begin(), compatibility_list.end(),
+                        [program_id](const auto& element) {
+                            std::string pid = fmt::format("{:016X}", program_id);
+                            return element.first == pid;
+                        });
+}

--- a/src/yuzu/compatibility_list.h
+++ b/src/yuzu/compatibility_list.h
@@ -1,0 +1,17 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include <QString>
+
+#include "common/common_types.h"
+
+using CompatibilityList = std::unordered_map<std::string, std::pair<QString, QString>>;
+
+CompatibilityList::const_iterator FindMatchingCompatibilityEntry(
+    const CompatibilityList& compatibility_list, u64 program_id);

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -19,6 +19,7 @@
 #include "common/file_util.h"
 #include "common/logging/log.h"
 #include "core/file_sys/patch_manager.h"
+#include "yuzu/compatibility_list.h"
 #include "yuzu/game_list.h"
 #include "yuzu/game_list_p.h"
 #include "yuzu/game_list_worker.h"

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -89,7 +89,8 @@ signals:
     void GameChosen(QString game_path);
     void ShouldCancelWorker();
     void OpenFolderRequested(u64 program_id, GameListOpenTarget target);
-    void NavigateToGamedbEntryRequested(u64 program_id, CompatibilityList& compatibility_list);
+    void NavigateToGamedbEntryRequested(u64 program_id,
+                                        const CompatibilityList& compatibility_list);
 
 private slots:
     void onTextChanged(const QString& newText);

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <unordered_map>
-
 #include <QFileSystemWatcher>
 #include <QHBoxLayout>
 #include <QLabel>
@@ -21,6 +19,7 @@
 #include <QWidget>
 
 #include "common/common_types.h"
+#include "yuzu/compatibility_list.h"
 
 class GameListWorker;
 class GMainWindow;
@@ -90,9 +89,7 @@ signals:
     void GameChosen(QString game_path);
     void ShouldCancelWorker();
     void OpenFolderRequested(u64 program_id, GameListOpenTarget target);
-    void NavigateToGamedbEntryRequested(
-        u64 program_id,
-        std::unordered_map<std::string, std::pair<QString, QString>>& compatibility_list);
+    void NavigateToGamedbEntryRequested(u64 program_id, CompatibilityList& compatibility_list);
 
 private slots:
     void onTextChanged(const QString& newText);
@@ -114,7 +111,7 @@ private:
     QStandardItemModel* item_model = nullptr;
     GameListWorker* current_worker = nullptr;
     QFileSystemWatcher* watcher = nullptr;
-    std::unordered_map<std::string, std::pair<QString, QString>> compatibility_list;
+    CompatibilityList compatibility_list;
 };
 
 Q_DECLARE_METATYPE(GameListOpenTarget);

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -176,14 +176,3 @@ public:
         return data(SizeRole).toULongLong() < other.data(SizeRole).toULongLong();
     }
 };
-
-inline auto FindMatchingCompatibilityEntry(
-    const std::unordered_map<std::string, std::pair<QString, QString>>& compatibility_list,
-    u64 program_id) {
-    return std::find_if(
-        compatibility_list.begin(), compatibility_list.end(),
-        [program_id](const std::pair<std::string, std::pair<QString, QString>>& element) {
-            std::string pid = fmt::format("{:016X}", program_id);
-            return element.first == pid;
-        });
-}

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -20,6 +20,7 @@
 #include "core/file_sys/registered_cache.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/loader/loader.h"
+#include "yuzu/compatibility_list.h"
 #include "yuzu/game_list.h"
 #include "yuzu/game_list_p.h"
 #include "yuzu/game_list_worker.h"
@@ -75,9 +76,8 @@ QString FormatPatchNameVersions(const FileSys::PatchManager& patch_manager, bool
 }
 } // Anonymous namespace
 
-GameListWorker::GameListWorker(
-    FileSys::VirtualFilesystem vfs, QString dir_path, bool deep_scan,
-    const std::unordered_map<std::string, std::pair<QString, QString>>& compatibility_list)
+GameListWorker::GameListWorker(FileSys::VirtualFilesystem vfs, QString dir_path, bool deep_scan,
+                               const CompatibilityList& compatibility_list)
     : vfs(std::move(vfs)), dir_path(std::move(dir_path)), deep_scan(deep_scan),
       compatibility_list(compatibility_list) {}
 

--- a/src/yuzu/game_list_worker.h
+++ b/src/yuzu/game_list_worker.h
@@ -16,6 +16,7 @@
 #include <QString>
 
 #include "common/common_types.h"
+#include "yuzu/compatibility_list.h"
 
 class QStandardItem;
 
@@ -32,9 +33,8 @@ class GameListWorker : public QObject, public QRunnable {
     Q_OBJECT
 
 public:
-    GameListWorker(
-        std::shared_ptr<FileSys::VfsFilesystem> vfs, QString dir_path, bool deep_scan,
-        const std::unordered_map<std::string, std::pair<QString, QString>>& compatibility_list);
+    GameListWorker(std::shared_ptr<FileSys::VfsFilesystem> vfs, QString dir_path, bool deep_scan,
+                   const CompatibilityList& compatibility_list);
     ~GameListWorker() override;
 
     /// Starts the processing of directory tree information.
@@ -67,6 +67,6 @@ private:
     QStringList watch_list;
     QString dir_path;
     bool deep_scan;
-    const std::unordered_map<std::string, std::pair<QString, QString>>& compatibility_list;
+    const CompatibilityList& compatibility_list;
     std::atomic_bool stop_processing;
 };

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -727,7 +727,7 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
 }
 
 void GMainWindow::OnGameListNavigateToGamedbEntry(u64 program_id,
-                                                  CompatibilityList& compatibility_list) {
+                                                  const CompatibilityList& compatibility_list) {
     const auto it = FindMatchingCompatibilityEntry(compatibility_list, program_id);
 
     QString directory;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -47,6 +47,7 @@
 #include "video_core/debug_utils/debug_utils.h"
 #include "yuzu/about_dialog.h"
 #include "yuzu/bootmanager.h"
+#include "yuzu/compatibility_list.h"
 #include "yuzu/configuration/config.h"
 #include "yuzu/configuration/configure_dialog.h"
 #include "yuzu/debugger/console.h"
@@ -725,14 +726,11 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
     QDesktopServices::openUrl(QUrl::fromLocalFile(qpath));
 }
 
-void GMainWindow::OnGameListNavigateToGamedbEntry(
-    u64 program_id,
-    std::unordered_map<std::string, std::pair<QString, QString>>& compatibility_list) {
-
-    auto it = FindMatchingCompatibilityEntry(compatibility_list, program_id);
+void GMainWindow::OnGameListNavigateToGamedbEntry(u64 program_id,
+                                                  CompatibilityList& compatibility_list) {
+    const auto it = FindMatchingCompatibilityEntry(compatibility_list, program_id);
 
     QString directory;
-
     if (it != compatibility_list.end())
         directory = it->second.second;
 

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -13,6 +13,7 @@
 #include "common/common_types.h"
 #include "core/core.h"
 #include "ui_main.h"
+#include "yuzu/compatibility_list.h"
 #include "yuzu/hotkeys.h"
 
 class Config;
@@ -137,9 +138,7 @@ private slots:
     /// Called whenever a user selects a game in the game list widget.
     void OnGameListLoadFile(QString game_path);
     void OnGameListOpenFolder(u64 program_id, GameListOpenTarget target);
-    void OnGameListNavigateToGamedbEntry(
-        u64 program_id,
-        std::unordered_map<std::string, std::pair<QString, QString>>& compatibility_list);
+    void OnGameListNavigateToGamedbEntry(u64 program_id, CompatibilityList& compatibility_list);
     void OnMenuLoadFile();
     void OnMenuLoadFolder();
     void OnMenuInstallToNAND();

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -138,7 +138,8 @@ private slots:
     /// Called whenever a user selects a game in the game list widget.
     void OnGameListLoadFile(QString game_path);
     void OnGameListOpenFolder(u64 program_id, GameListOpenTarget target);
-    void OnGameListNavigateToGamedbEntry(u64 program_id, CompatibilityList& compatibility_list);
+    void OnGameListNavigateToGamedbEntry(u64 program_id,
+                                         const CompatibilityList& compatibility_list);
     void OnMenuLoadFile();
     void OnMenuLoadFolder();
     void OnMenuInstallToNAND();


### PR DESCRIPTION
Lets us keep the generic portions of the compatibility list code together, and allows us to introduce a type alias that makes it so we don't need to type out a very long type declaration anymore, making the immediate readability of some code better.