### PR TITLE
service: Remove unused g_kernel_named_ports variable

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -74,8 +74,6 @@ using Kernel::SharedPtr;
 
 namespace Service {
 
-std::unordered_map<std::string, SharedPtr<ClientPort>> g_kernel_named_ports;
-
 /**
  * Creates a function string for logging, complete with the name (or header code, depending
  * on what's passed in) the port name, and all the cmd_buff arguments.


### PR DESCRIPTION
With the named port functionality all migrated over to the kernel, there's no need to keep this around anymore.