### PR TITLE
hle/service: Default constructors and destructors in the cpp file where applicable

### DIFF
--- a/src/core/hle/service/acc/acc_aa.cpp
+++ b/src/core/hle/service/acc/acc_aa.cpp
@@ -18,4 +18,6 @@ ACC_AA::ACC_AA(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> p
     RegisterHandlers(functions);
 }
 
+ACC_AA::~ACC_AA() = default;
+
 } // namespace Service::Account

--- a/src/core/hle/service/acc/acc_aa.h
+++ b/src/core/hle/service/acc/acc_aa.h
@@ -12,6 +12,7 @@ class ACC_AA final : public Module::Interface {
 public:
     explicit ACC_AA(std::shared_ptr<Module> module,
                     std::shared_ptr<ProfileManager> profile_manager);
+    ~ACC_AA() override;
 };
 
 } // namespace Service::Account

--- a/src/core/hle/service/acc/acc_su.cpp
+++ b/src/core/hle/service/acc/acc_su.cpp
@@ -51,4 +51,6 @@ ACC_SU::ACC_SU(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> p
     RegisterHandlers(functions);
 }
 
+ACC_SU::~ACC_SU() = default;
+
 } // namespace Service::Account

--- a/src/core/hle/service/acc/acc_su.h
+++ b/src/core/hle/service/acc/acc_su.h
@@ -13,6 +13,7 @@ class ACC_SU final : public Module::Interface {
 public:
     explicit ACC_SU(std::shared_ptr<Module> module,
                     std::shared_ptr<ProfileManager> profile_manager);
+    ~ACC_SU() override;
 };
 
 } // namespace Account

--- a/src/core/hle/service/acc/acc_u0.cpp
+++ b/src/core/hle/service/acc/acc_u0.cpp
@@ -31,4 +31,6 @@ ACC_U0::ACC_U0(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> p
     RegisterHandlers(functions);
 }
 
+ACC_U0::~ACC_U0() = default;
+
 } // namespace Service::Account

--- a/src/core/hle/service/acc/acc_u0.h
+++ b/src/core/hle/service/acc/acc_u0.h
@@ -12,6 +12,7 @@ class ACC_U0 final : public Module::Interface {
 public:
     explicit ACC_U0(std::shared_ptr<Module> module,
                     std::shared_ptr<ProfileManager> profile_manager);
+    ~ACC_U0() override;
 };
 
 } // namespace Service::Account

--- a/src/core/hle/service/acc/acc_u1.cpp
+++ b/src/core/hle/service/acc/acc_u1.cpp
@@ -38,4 +38,6 @@ ACC_U1::ACC_U1(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> p
     RegisterHandlers(functions);
 }
 
+ACC_U1::~ACC_U1() = default;
+
 } // namespace Service::Account

--- a/src/core/hle/service/acc/acc_u1.h
+++ b/src/core/hle/service/acc/acc_u1.h
@@ -12,6 +12,7 @@ class ACC_U1 final : public Module::Interface {
 public:
     explicit ACC_U1(std::shared_ptr<Module> module,
                     std::shared_ptr<ProfileManager> profile_manager);
+    ~ACC_U1() override;
 };
 
 } // namespace Service::Account

--- a/src/core/hle/service/acc/profile_manager.cpp
+++ b/src/core/hle/service/acc/profile_manager.cpp
@@ -29,6 +29,8 @@ ProfileManager::ProfileManager() {
     OpenUser(user_uuid);
 }
 
+ProfileManager::~ProfileManager() = default;
+
 /// After a users creation it needs to be "registered" to the system. AddToProfiles handles the
 /// internal management of the users profiles
 boost::optional<size_t> ProfileManager::AddToProfiles(const ProfileInfo& user) {

--- a/src/core/hle/service/acc/profile_manager.h
+++ b/src/core/hle/service/acc/profile_manager.h
@@ -82,6 +82,8 @@ static_assert(sizeof(ProfileBase) == 0x38, "ProfileBase is an invalid size");
 class ProfileManager {
 public:
     ProfileManager(); // TODO(ogniK): Load from system save
+    ~ProfileManager();
+
     ResultCode AddUser(const ProfileInfo& user);
     ResultCode CreateNewUser(UUID uuid, const ProfileUsername& username);
     ResultCode CreateNewUser(UUID uuid, const std::string& username);

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -35,6 +35,8 @@ IWindowController::IWindowController() : ServiceFramework("IWindowController") {
     RegisterHandlers(functions);
 }
 
+IWindowController::~IWindowController() = default;
+
 void IWindowController::GetAppletResourceUserId(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 4};
@@ -60,6 +62,8 @@ IAudioController::IAudioController() : ServiceFramework("IAudioController") {
     };
     RegisterHandlers(functions);
 }
+
+IAudioController::~IAudioController() = default;
 
 void IAudioController::SetExpectedMasterVolume(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
@@ -116,7 +120,10 @@ IDisplayController::IDisplayController() : ServiceFramework("IDisplayController"
     RegisterHandlers(functions);
 }
 
+IDisplayController::~IDisplayController() = default;
+
 IDebugFunctions::IDebugFunctions() : ServiceFramework("IDebugFunctions") {}
+IDebugFunctions::~IDebugFunctions() = default;
 
 ISelfController::ISelfController(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
     : ServiceFramework("ISelfController"), nvflinger(std::move(nvflinger)) {
@@ -164,6 +171,8 @@ ISelfController::ISelfController(std::shared_ptr<NVFlinger::NVFlinger> nvflinger
     launchable_event =
         Kernel::Event::Create(kernel, Kernel::ResetType::Sticky, "ISelfController:LaunchableEvent");
 }
+
+ISelfController::~ISelfController() = default;
 
 void ISelfController::SetFocusHandlingMode(Kernel::HLERequestContext& ctx) {
     // Takes 3 input u8s with each field located immediately after the previous u8, these are
@@ -336,6 +345,8 @@ ICommonStateGetter::ICommonStateGetter() : ServiceFramework("ICommonStateGetter"
     auto& kernel = Core::System::GetInstance().Kernel();
     event = Kernel::Event::Create(kernel, Kernel::ResetType::OneShot, "ICommonStateGetter:Event");
 }
+
+ICommonStateGetter::~ICommonStateGetter() = default;
 
 void ICommonStateGetter::GetBootMode(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 3};
@@ -573,6 +584,8 @@ ILibraryAppletCreator::ILibraryAppletCreator() : ServiceFramework("ILibraryApple
     RegisterHandlers(functions);
 }
 
+ILibraryAppletCreator::~ILibraryAppletCreator() = default;
+
 void ILibraryAppletCreator::CreateLibraryApplet(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
 
@@ -637,6 +650,8 @@ IApplicationFunctions::IApplicationFunctions() : ServiceFramework("IApplicationF
     };
     RegisterHandlers(functions);
 }
+
+IApplicationFunctions::~IApplicationFunctions() = default;
 
 void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
     constexpr std::array<u8, 0x88> data{{
@@ -760,6 +775,8 @@ IHomeMenuFunctions::IHomeMenuFunctions() : ServiceFramework("IHomeMenuFunctions"
     RegisterHandlers(functions);
 }
 
+IHomeMenuFunctions::~IHomeMenuFunctions() = default;
+
 void IHomeMenuFunctions::RequestToGetForeground(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
@@ -783,6 +800,8 @@ IGlobalStateController::IGlobalStateController() : ServiceFramework("IGlobalStat
     RegisterHandlers(functions);
 }
 
+IGlobalStateController::~IGlobalStateController() = default;
+
 IApplicationCreator::IApplicationCreator() : ServiceFramework("IApplicationCreator") {
     static const FunctionInfo functions[] = {
         {0, nullptr, "CreateApplication"},
@@ -792,6 +811,8 @@ IApplicationCreator::IApplicationCreator() : ServiceFramework("IApplicationCreat
     };
     RegisterHandlers(functions);
 }
+
+IApplicationCreator::~IApplicationCreator() = default;
 
 IProcessWindingController::IProcessWindingController()
     : ServiceFramework("IProcessWindingController") {
@@ -807,4 +828,6 @@ IProcessWindingController::IProcessWindingController()
     };
     RegisterHandlers(functions);
 }
+
+IProcessWindingController::~IProcessWindingController() = default;
 } // namespace Service::AM

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -42,6 +42,7 @@ enum SystemLanguage {
 class IWindowController final : public ServiceFramework<IWindowController> {
 public:
     IWindowController();
+    ~IWindowController() override;
 
 private:
     void GetAppletResourceUserId(Kernel::HLERequestContext& ctx);
@@ -51,6 +52,7 @@ private:
 class IAudioController final : public ServiceFramework<IAudioController> {
 public:
     IAudioController();
+    ~IAudioController() override;
 
 private:
     void SetExpectedMasterVolume(Kernel::HLERequestContext& ctx);
@@ -63,16 +65,19 @@ private:
 class IDisplayController final : public ServiceFramework<IDisplayController> {
 public:
     IDisplayController();
+    ~IDisplayController() override;
 };
 
 class IDebugFunctions final : public ServiceFramework<IDebugFunctions> {
 public:
     IDebugFunctions();
+    ~IDebugFunctions() override;
 };
 
 class ISelfController final : public ServiceFramework<ISelfController> {
 public:
     explicit ISelfController(std::shared_ptr<NVFlinger::NVFlinger> nvflinger);
+    ~ISelfController() override;
 
 private:
     void SetFocusHandlingMode(Kernel::HLERequestContext& ctx);
@@ -98,6 +103,7 @@ private:
 class ICommonStateGetter final : public ServiceFramework<ICommonStateGetter> {
 public:
     ICommonStateGetter();
+    ~ICommonStateGetter() override;
 
 private:
     enum class FocusState : u8 {
@@ -124,6 +130,7 @@ private:
 class ILibraryAppletCreator final : public ServiceFramework<ILibraryAppletCreator> {
 public:
     ILibraryAppletCreator();
+    ~ILibraryAppletCreator() override;
 
 private:
     void CreateLibraryApplet(Kernel::HLERequestContext& ctx);
@@ -133,6 +140,7 @@ private:
 class IApplicationFunctions final : public ServiceFramework<IApplicationFunctions> {
 public:
     IApplicationFunctions();
+    ~IApplicationFunctions() override;
 
 private:
     void PopLaunchParameter(Kernel::HLERequestContext& ctx);
@@ -150,6 +158,7 @@ private:
 class IHomeMenuFunctions final : public ServiceFramework<IHomeMenuFunctions> {
 public:
     IHomeMenuFunctions();
+    ~IHomeMenuFunctions() override;
 
 private:
     void RequestToGetForeground(Kernel::HLERequestContext& ctx);
@@ -158,16 +167,19 @@ private:
 class IGlobalStateController final : public ServiceFramework<IGlobalStateController> {
 public:
     IGlobalStateController();
+    ~IGlobalStateController() override;
 };
 
 class IApplicationCreator final : public ServiceFramework<IApplicationCreator> {
 public:
     IApplicationCreator();
+    ~IApplicationCreator() override;
 };
 
 class IProcessWindingController final : public ServiceFramework<IProcessWindingController> {
 public:
     IProcessWindingController();
+    ~IProcessWindingController() override;
 };
 
 /// Registers all AM services with the specified service manager.

--- a/src/core/hle/service/am/applet_ae.cpp
+++ b/src/core/hle/service/am/applet_ae.cpp
@@ -222,4 +222,6 @@ AppletAE::AppletAE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
     RegisterHandlers(functions);
 }
 
+AppletAE::~AppletAE() = default;
+
 } // namespace Service::AM

--- a/src/core/hle/service/am/applet_ae.h
+++ b/src/core/hle/service/am/applet_ae.h
@@ -18,7 +18,7 @@ namespace AM {
 class AppletAE final : public ServiceFramework<AppletAE> {
 public:
     explicit AppletAE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger);
-    ~AppletAE() = default;
+    ~AppletAE() override;
 
 private:
     void OpenSystemAppletProxy(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -103,4 +103,6 @@ AppletOE::AppletOE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
     RegisterHandlers(functions);
 }
 
+AppletOE::~AppletOE() = default;
+
 } // namespace Service::AM

--- a/src/core/hle/service/am/applet_oe.h
+++ b/src/core/hle/service/am/applet_oe.h
@@ -18,7 +18,7 @@ namespace AM {
 class AppletOE final : public ServiceFramework<AppletOE> {
 public:
     explicit AppletOE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger);
-    ~AppletOE() = default;
+    ~AppletOE() override;
 
 private:
     void OpenApplicationProxy(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/am/idle.cpp
+++ b/src/core/hle/service/am/idle.cpp
@@ -21,4 +21,6 @@ IdleSys::IdleSys() : ServiceFramework{"idle:sys"} {
     RegisterHandlers(functions);
 }
 
+IdleSys::~IdleSys() = default;
+
 } // namespace Service::AM

--- a/src/core/hle/service/am/idle.h
+++ b/src/core/hle/service/am/idle.h
@@ -11,6 +11,7 @@ namespace Service::AM {
 class IdleSys final : public ServiceFramework<IdleSys> {
 public:
     explicit IdleSys();
+    ~IdleSys() override;
 };
 
 } // namespace Service::AM

--- a/src/core/hle/service/am/omm.cpp
+++ b/src/core/hle/service/am/omm.cpp
@@ -39,4 +39,6 @@ OMM::OMM() : ServiceFramework{"omm"} {
     RegisterHandlers(functions);
 }
 
+OMM::~OMM() = default;
+
 } // namespace Service::AM

--- a/src/core/hle/service/am/omm.h
+++ b/src/core/hle/service/am/omm.h
@@ -11,6 +11,7 @@ namespace Service::AM {
 class OMM final : public ServiceFramework<OMM> {
 public:
     explicit OMM();
+    ~OMM() override;
 };
 
 } // namespace Service::AM

--- a/src/core/hle/service/am/spsm.cpp
+++ b/src/core/hle/service/am/spsm.cpp
@@ -27,4 +27,6 @@ SPSM::SPSM() : ServiceFramework{"spsm"} {
     RegisterHandlers(functions);
 }
 
+SPSM::~SPSM() = default;
+
 } // namespace Service::AM

--- a/src/core/hle/service/am/spsm.h
+++ b/src/core/hle/service/am/spsm.h
@@ -11,6 +11,7 @@ namespace Service::AM {
 class SPSM final : public ServiceFramework<SPSM> {
 public:
     explicit SPSM();
+    ~SPSM() override;
 };
 
 } // namespace Service::AM

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -23,6 +23,8 @@ AOC_U::AOC_U() : ServiceFramework("aoc:u") {
     RegisterHandlers(functions);
 }
 
+AOC_U::~AOC_U() = default;
+
 void AOC_U::CountAddOnContent(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/aoc/aoc_u.h
+++ b/src/core/hle/service/aoc/aoc_u.h
@@ -11,7 +11,7 @@ namespace Service::AOC {
 class AOC_U final : public ServiceFramework<AOC_U> {
 public:
     AOC_U();
-    ~AOC_U() = default;
+    ~AOC_U() override;
 
 private:
     void CountAddOnContent(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/apm/apm.cpp
+++ b/src/core/hle/service/apm/apm.cpp
@@ -9,6 +9,9 @@
 
 namespace Service::APM {
 
+Module::Module() = default;
+Module::~Module() = default;
+
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     auto module_ = std::make_shared<Module>();
     std::make_shared<APM>(module_, "apm")->InstallAsService(service_manager);

--- a/src/core/hle/service/apm/apm.h
+++ b/src/core/hle/service/apm/apm.h
@@ -15,8 +15,8 @@ enum class PerformanceMode : u8 {
 
 class Module final {
 public:
-    Module() = default;
-    ~Module() = default;
+    Module();
+    ~Module();
 };
 
 /// Registers all AM services with the specified service manager.

--- a/src/core/hle/service/apm/interface.cpp
+++ b/src/core/hle/service/apm/interface.cpp
@@ -70,6 +70,8 @@ APM::APM(std::shared_ptr<Module> apm, const char* name)
     RegisterHandlers(functions);
 }
 
+APM::~APM() = default;
+
 void APM::OpenSession(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
@@ -92,6 +94,8 @@ APM_Sys::APM_Sys() : ServiceFramework{"apm:sys"} {
 
     RegisterHandlers(functions);
 }
+
+APM_Sys::~APM_Sys() = default;
 
 void APM_Sys::GetPerformanceEvent(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};

--- a/src/core/hle/service/apm/interface.h
+++ b/src/core/hle/service/apm/interface.h
@@ -11,7 +11,7 @@ namespace Service::APM {
 class APM final : public ServiceFramework<APM> {
 public:
     explicit APM(std::shared_ptr<Module> apm, const char* name);
-    ~APM() = default;
+    ~APM() override;
 
 private:
     void OpenSession(Kernel::HLERequestContext& ctx);
@@ -22,6 +22,7 @@ private:
 class APM_Sys final : public ServiceFramework<APM_Sys> {
 public:
     explicit APM_Sys();
+    ~APM_Sys() override;
 
 private:
     void GetPerformanceEvent(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/audio/audctl.cpp
+++ b/src/core/hle/service/audio/audctl.cpp
@@ -42,4 +42,6 @@ AudCtl::AudCtl() : ServiceFramework{"audctl"} {
     RegisterHandlers(functions);
 }
 
+AudCtl::~AudCtl() = default;
+
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audctl.h
+++ b/src/core/hle/service/audio/audctl.h
@@ -11,6 +11,7 @@ namespace Service::Audio {
 class AudCtl final : public ServiceFramework<AudCtl> {
 public:
     explicit AudCtl();
+    ~AudCtl() override;
 };
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/auddbg.cpp
+++ b/src/core/hle/service/audio/auddbg.cpp
@@ -17,4 +17,6 @@ AudDbg::AudDbg(const char* name) : ServiceFramework{name} {
     RegisterHandlers(functions);
 }
 
+AudDbg::~AudDbg() = default;
+
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/auddbg.h
+++ b/src/core/hle/service/audio/auddbg.h
@@ -11,6 +11,7 @@ namespace Service::Audio {
 class AudDbg final : public ServiceFramework<AudDbg> {
 public:
     explicit AudDbg(const char* name);
+    ~AudDbg() override;
 };
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audin_a.cpp
+++ b/src/core/hle/service/audio/audin_a.cpp
@@ -19,4 +19,6 @@ AudInA::AudInA() : ServiceFramework{"audin:a"} {
     RegisterHandlers(functions);
 }
 
+AudInA::~AudInA() = default;
+
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audin_a.h
+++ b/src/core/hle/service/audio/audin_a.h
@@ -11,6 +11,7 @@ namespace Service::Audio {
 class AudInA final : public ServiceFramework<AudInA> {
 public:
     explicit AudInA();
+    ~AudInA() override;
 };
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audin_u.cpp
+++ b/src/core/hle/service/audio/audin_u.cpp
@@ -41,4 +41,6 @@ AudInU::AudInU() : ServiceFramework("audin:u") {
     RegisterHandlers(functions);
 }
 
+AudInU::~AudInU() = default;
+
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audin_u.h
+++ b/src/core/hle/service/audio/audin_u.h
@@ -15,7 +15,7 @@ namespace Service::Audio {
 class AudInU final : public ServiceFramework<AudInU> {
 public:
     explicit AudInU();
-    ~AudInU() = default;
+    ~AudInU() override;
 };
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audout_a.cpp
+++ b/src/core/hle/service/audio/audout_a.cpp
@@ -21,4 +21,6 @@ AudOutA::AudOutA() : ServiceFramework{"audout:a"} {
     RegisterHandlers(functions);
 }
 
+AudOutA::~AudOutA() = default;
+
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audout_a.h
+++ b/src/core/hle/service/audio/audout_a.h
@@ -11,6 +11,7 @@ namespace Service::Audio {
 class AudOutA final : public ServiceFramework<AudOutA> {
 public:
     explicit AudOutA();
+    ~AudOutA() override;
 };
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -218,4 +218,6 @@ AudOutU::AudOutU() : ServiceFramework("audout:u") {
     audio_core = std::make_unique<AudioCore::AudioOut>();
 }
 
+AudOutU::~AudOutU() = default;
+
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audout_u.h
+++ b/src/core/hle/service/audio/audout_u.h
@@ -30,7 +30,7 @@ class IAudioOut;
 class AudOutU final : public ServiceFramework<AudOutU> {
 public:
     AudOutU();
-    ~AudOutU() = default;
+    ~AudOutU() override;
 
 private:
     std::shared_ptr<IAudioOut> audio_out_interface;

--- a/src/core/hle/service/audio/audrec_a.cpp
+++ b/src/core/hle/service/audio/audrec_a.cpp
@@ -17,4 +17,6 @@ AudRecA::AudRecA() : ServiceFramework{"audrec:a"} {
     RegisterHandlers(functions);
 }
 
+AudRecA::~AudRecA() = default;
+
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audrec_a.h
+++ b/src/core/hle/service/audio/audrec_a.h
@@ -11,6 +11,7 @@ namespace Service::Audio {
 class AudRecA final : public ServiceFramework<AudRecA> {
 public:
     explicit AudRecA();
+    ~AudRecA() override;
 };
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audrec_u.cpp
+++ b/src/core/hle/service/audio/audrec_u.cpp
@@ -36,4 +36,6 @@ AudRecU::AudRecU() : ServiceFramework("audrec:u") {
     RegisterHandlers(functions);
 }
 
+AudRecU::~AudRecU() = default;
+
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audrec_u.h
+++ b/src/core/hle/service/audio/audrec_u.h
@@ -15,7 +15,7 @@ namespace Service::Audio {
 class AudRecU final : public ServiceFramework<AudRecU> {
 public:
     explicit AudRecU();
-    ~AudRecU() = default;
+    ~AudRecU() override;
 };
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audren_a.cpp
+++ b/src/core/hle/service/audio/audren_a.cpp
@@ -23,4 +23,6 @@ AudRenA::AudRenA() : ServiceFramework{"audren:a"} {
     RegisterHandlers(functions);
 }
 
+AudRenA::~AudRenA() = default;
+
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audren_a.h
+++ b/src/core/hle/service/audio/audren_a.h
@@ -11,6 +11,7 @@ namespace Service::Audio {
 class AudRenA final : public ServiceFramework<AudRenA> {
 public:
     explicit AudRenA();
+    ~AudRenA() override;
 };
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -198,6 +198,8 @@ AudRenU::AudRenU() : ServiceFramework("audren:u") {
     RegisterHandlers(functions);
 }
 
+AudRenU::~AudRenU() = default;
+
 void AudRenU::OpenAudioRenderer(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     auto params = rp.PopRaw<AudioCore::AudioRendererParameter>();

--- a/src/core/hle/service/audio/audren_u.h
+++ b/src/core/hle/service/audio/audren_u.h
@@ -16,7 +16,7 @@ namespace Service::Audio {
 class AudRenU final : public ServiceFramework<AudRenU> {
 public:
     explicit AudRenU();
-    ~AudRenU() = default;
+    ~AudRenU() override;
 
 private:
     void OpenAudioRenderer(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/audio/codecctl.cpp
+++ b/src/core/hle/service/audio/codecctl.cpp
@@ -28,4 +28,6 @@ CodecCtl::CodecCtl() : ServiceFramework("codecctl") {
     RegisterHandlers(functions);
 }
 
+CodecCtl::~CodecCtl() = default;
+
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/codecctl.h
+++ b/src/core/hle/service/audio/codecctl.h
@@ -15,7 +15,7 @@ namespace Service::Audio {
 class CodecCtl final : public ServiceFramework<CodecCtl> {
 public:
     explicit CodecCtl();
-    ~CodecCtl() = default;
+    ~CodecCtl() override;
 };
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -151,4 +151,6 @@ HwOpus::HwOpus() : ServiceFramework("hwopus") {
     RegisterHandlers(functions);
 }
 
+HwOpus::~HwOpus() = default;
+
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/hwopus.h
+++ b/src/core/hle/service/audio/hwopus.h
@@ -11,7 +11,7 @@ namespace Service::Audio {
 class HwOpus final : public ServiceFramework<HwOpus> {
 public:
     explicit HwOpus();
-    ~HwOpus() = default;
+    ~HwOpus() override;
 
 private:
     void OpenOpusDecoder(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/bcat/bcat.cpp
+++ b/src/core/hle/service/bcat/bcat.cpp
@@ -13,4 +13,6 @@ BCAT::BCAT(std::shared_ptr<Module> module, const char* name)
     };
     RegisterHandlers(functions);
 }
+
+BCAT::~BCAT() = default;
 } // namespace Service::BCAT

--- a/src/core/hle/service/bcat/bcat.h
+++ b/src/core/hle/service/bcat/bcat.h
@@ -11,6 +11,7 @@ namespace Service::BCAT {
 class BCAT final : public Module::Interface {
 public:
     explicit BCAT(std::shared_ptr<Module> module, const char* name);
+    ~BCAT() override;
 };
 
 } // namespace Service::BCAT

--- a/src/core/hle/service/bcat/module.cpp
+++ b/src/core/hle/service/bcat/module.cpp
@@ -42,6 +42,8 @@ void Module::Interface::CreateBcatService(Kernel::HLERequestContext& ctx) {
 Module::Interface::Interface(std::shared_ptr<Module> module, const char* name)
     : ServiceFramework(name), module(std::move(module)) {}
 
+Module::Interface::~Interface() = default;
+
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     auto module = std::make_shared<Module>();
     std::make_shared<BCAT>(module, "bcat:a")->InstallAsService(service_manager);

--- a/src/core/hle/service/bcat/module.h
+++ b/src/core/hle/service/bcat/module.h
@@ -13,6 +13,7 @@ public:
     class Interface : public ServiceFramework<Interface> {
     public:
         explicit Interface(std::shared_ptr<Module> module, const char* name);
+        ~Interface() override;
 
         void CreateBcatService(Kernel::HLERequestContext& ctx);
 

--- a/src/core/hle/service/fatal/fatal.cpp
+++ b/src/core/hle/service/fatal/fatal.cpp
@@ -13,6 +13,8 @@ namespace Service::Fatal {
 Module::Interface::Interface(std::shared_ptr<Module> module, const char* name)
     : ServiceFramework(name), module(std::move(module)) {}
 
+Module::Interface::~Interface() = default;
+
 void Module::Interface::ThrowFatalWithPolicy(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp(ctx);
     u32 error_code = rp.Pop<u32>();

--- a/src/core/hle/service/fatal/fatal.h
+++ b/src/core/hle/service/fatal/fatal.h
@@ -13,6 +13,7 @@ public:
     class Interface : public ServiceFramework<Interface> {
     public:
         explicit Interface(std::shared_ptr<Module> module, const char* name);
+        ~Interface() override;
 
         void ThrowFatalWithPolicy(Kernel::HLERequestContext& ctx);
         void ThrowFatalWithCpuContext(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/fatal/fatal_p.cpp
+++ b/src/core/hle/service/fatal/fatal_p.cpp
@@ -9,4 +9,6 @@ namespace Service::Fatal {
 Fatal_P::Fatal_P(std::shared_ptr<Module> module)
     : Module::Interface(std::move(module), "fatal:p") {}
 
+Fatal_P::~Fatal_P() = default;
+
 } // namespace Service::Fatal

--- a/src/core/hle/service/fatal/fatal_p.h
+++ b/src/core/hle/service/fatal/fatal_p.h
@@ -11,6 +11,7 @@ namespace Service::Fatal {
 class Fatal_P final : public Module::Interface {
 public:
     explicit Fatal_P(std::shared_ptr<Module> module);
+    ~Fatal_P() override;
 };
 
 } // namespace Service::Fatal

--- a/src/core/hle/service/fatal/fatal_u.cpp
+++ b/src/core/hle/service/fatal/fatal_u.cpp
@@ -15,4 +15,6 @@ Fatal_U::Fatal_U(std::shared_ptr<Module> module) : Module::Interface(std::move(m
     RegisterHandlers(functions);
 }
 
+Fatal_U::~Fatal_U() = default;
+
 } // namespace Service::Fatal

--- a/src/core/hle/service/fatal/fatal_u.h
+++ b/src/core/hle/service/fatal/fatal_u.h
@@ -11,6 +11,7 @@ namespace Service::Fatal {
 class Fatal_U final : public Module::Interface {
 public:
     explicit Fatal_U(std::shared_ptr<Module> module);
+    ~Fatal_U() override;
 };
 
 } // namespace Service::Fatal

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -40,6 +40,8 @@ static FileSys::VirtualDir GetDirectoryRelativeWrapped(FileSys::VirtualDir base,
 VfsDirectoryServiceWrapper::VfsDirectoryServiceWrapper(FileSys::VirtualDir backing_)
     : backing(std::move(backing_)) {}
 
+VfsDirectoryServiceWrapper::~VfsDirectoryServiceWrapper() = default;
+
 std::string VfsDirectoryServiceWrapper::GetName() const {
     return backing->GetName();
 }

--- a/src/core/hle/service/filesystem/filesystem.h
+++ b/src/core/hle/service/filesystem/filesystem.h
@@ -64,6 +64,7 @@ void InstallInterfaces(SM::ServiceManager& service_manager, const FileSys::Virtu
 class VfsDirectoryServiceWrapper {
 public:
     explicit VfsDirectoryServiceWrapper(FileSys::VirtualDir backing);
+    ~VfsDirectoryServiceWrapper();
 
     /**
      * Get a descriptive name for the archive (e.g. "RomFS", "SaveData", etc.)

--- a/src/core/hle/service/filesystem/fsp_ldr.cpp
+++ b/src/core/hle/service/filesystem/fsp_ldr.cpp
@@ -19,4 +19,6 @@ FSP_LDR::FSP_LDR() : ServiceFramework{"fsp:ldr"} {
     RegisterHandlers(functions);
 }
 
+FSP_LDR::~FSP_LDR() = default;
+
 } // namespace Service::FileSystem

--- a/src/core/hle/service/filesystem/fsp_ldr.h
+++ b/src/core/hle/service/filesystem/fsp_ldr.h
@@ -11,6 +11,7 @@ namespace Service::FileSystem {
 class FSP_LDR final : public ServiceFramework<FSP_LDR> {
 public:
     explicit FSP_LDR();
+    ~FSP_LDR() override;
 };
 
 } // namespace Service::FileSystem

--- a/src/core/hle/service/filesystem/fsp_pr.cpp
+++ b/src/core/hle/service/filesystem/fsp_pr.cpp
@@ -20,4 +20,6 @@ FSP_PR::FSP_PR() : ServiceFramework{"fsp:pr"} {
     RegisterHandlers(functions);
 }
 
+FSP_PR::~FSP_PR() = default;
+
 } // namespace Service::FileSystem

--- a/src/core/hle/service/filesystem/fsp_pr.h
+++ b/src/core/hle/service/filesystem/fsp_pr.h
@@ -11,6 +11,7 @@ namespace Service::FileSystem {
 class FSP_PR final : public ServiceFramework<FSP_PR> {
 public:
     explicit FSP_PR();
+    ~FSP_PR() override;
 };
 
 } // namespace Service::FileSystem

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -520,6 +520,8 @@ FSP_SRV::FSP_SRV() : ServiceFramework("fsp-srv") {
     RegisterHandlers(functions);
 }
 
+FSP_SRV::~FSP_SRV() = default;
+
 void FSP_SRV::Initialize(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_FS, "(STUBBED) called");
 

--- a/src/core/hle/service/filesystem/fsp_srv.h
+++ b/src/core/hle/service/filesystem/fsp_srv.h
@@ -16,7 +16,7 @@ namespace Service::FileSystem {
 class FSP_SRV final : public ServiceFramework<FSP_SRV> {
 public:
     explicit FSP_SRV();
-    ~FSP_SRV() = default;
+    ~FSP_SRV() override;
 
 private:
     void Initialize(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/friend/friend.cpp
+++ b/src/core/hle/service/friend/friend.cpp
@@ -118,6 +118,8 @@ void Module::Interface::CreateFriendService(Kernel::HLERequestContext& ctx) {
 Module::Interface::Interface(std::shared_ptr<Module> module, const char* name)
     : ServiceFramework(name), module(std::move(module)) {}
 
+Module::Interface::~Interface() = default;
+
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     auto module = std::make_shared<Module>();
     std::make_shared<Friend>(module, "friend:a")->InstallAsService(service_manager);

--- a/src/core/hle/service/friend/friend.h
+++ b/src/core/hle/service/friend/friend.h
@@ -13,6 +13,7 @@ public:
     class Interface : public ServiceFramework<Interface> {
     public:
         explicit Interface(std::shared_ptr<Module> module, const char* name);
+        ~Interface() override;
 
         void CreateFriendService(Kernel::HLERequestContext& ctx);
 

--- a/src/core/hle/service/friend/interface.cpp
+++ b/src/core/hle/service/friend/interface.cpp
@@ -16,4 +16,6 @@ Friend::Friend(std::shared_ptr<Module> module, const char* name)
     RegisterHandlers(functions);
 }
 
+Friend::~Friend() = default;
+
 } // namespace Service::Friend

--- a/src/core/hle/service/friend/interface.h
+++ b/src/core/hle/service/friend/interface.h
@@ -11,6 +11,7 @@ namespace Service::Friend {
 class Friend final : public Module::Interface {
 public:
     explicit Friend(std::shared_ptr<Module> module, const char* name);
+    ~Friend() override;
 };
 
 } // namespace Service::Friend

--- a/src/core/hle/service/hid/irs.cpp
+++ b/src/core/hle/service/hid/irs.cpp
@@ -33,6 +33,8 @@ IRS::IRS() : ServiceFramework{"irs"} {
     RegisterHandlers(functions);
 }
 
+IRS::~IRS() = default;
+
 IRS_SYS::IRS_SYS() : ServiceFramework{"irs:sys"} {
     // clang-format off
     static const FunctionInfo functions[] = {
@@ -45,5 +47,7 @@ IRS_SYS::IRS_SYS() : ServiceFramework{"irs:sys"} {
 
     RegisterHandlers(functions);
 }
+
+IRS_SYS::~IRS_SYS() = default;
 
 } // namespace Service::HID

--- a/src/core/hle/service/hid/irs.h
+++ b/src/core/hle/service/hid/irs.h
@@ -11,11 +11,13 @@ namespace Service::HID {
 class IRS final : public ServiceFramework<IRS> {
 public:
     explicit IRS();
+    ~IRS() override;
 };
 
 class IRS_SYS final : public ServiceFramework<IRS_SYS> {
 public:
     explicit IRS_SYS();
+    ~IRS_SYS() override;
 };
 
 } // namespace Service::HID

--- a/src/core/hle/service/hid/xcd.cpp
+++ b/src/core/hle/service/hid/xcd.cpp
@@ -34,4 +34,6 @@ XCD_SYS::XCD_SYS() : ServiceFramework{"xcd:sys"} {
     RegisterHandlers(functions);
 }
 
+XCD_SYS::~XCD_SYS() = default;
+
 } // namespace Service::HID

--- a/src/core/hle/service/hid/xcd.h
+++ b/src/core/hle/service/hid/xcd.h
@@ -11,6 +11,7 @@ namespace Service::HID {
 class XCD_SYS final : public ServiceFramework<XCD_SYS> {
 public:
     explicit XCD_SYS();
+    ~XCD_SYS() override;
 };
 
 } // namespace Service::HID

--- a/src/core/hle/service/nfp/nfp.cpp
+++ b/src/core/hle/service/nfp/nfp.cpp
@@ -14,6 +14,8 @@ namespace Service::NFP {
 Module::Interface::Interface(std::shared_ptr<Module> module, const char* name)
     : ServiceFramework(name), module(std::move(module)) {}
 
+Module::Interface::~Interface() = default;
+
 class IUser final : public ServiceFramework<IUser> {
 public:
     IUser() : ServiceFramework("IUser") {

--- a/src/core/hle/service/nfp/nfp.h
+++ b/src/core/hle/service/nfp/nfp.h
@@ -13,6 +13,7 @@ public:
     class Interface : public ServiceFramework<Interface> {
     public:
         explicit Interface(std::shared_ptr<Module> module, const char* name);
+        ~Interface() override;
 
         void CreateUserInterface(Kernel::HLERequestContext& ctx);
 

--- a/src/core/hle/service/nfp/nfp_user.cpp
+++ b/src/core/hle/service/nfp/nfp_user.cpp
@@ -14,4 +14,6 @@ NFP_User::NFP_User(std::shared_ptr<Module> module)
     RegisterHandlers(functions);
 }
 
+NFP_User::~NFP_User() = default;
+
 } // namespace Service::NFP

--- a/src/core/hle/service/nfp/nfp_user.h
+++ b/src/core/hle/service/nfp/nfp_user.h
@@ -11,6 +11,7 @@ namespace Service::NFP {
 class NFP_User final : public Module::Interface {
 public:
     explicit NFP_User(std::shared_ptr<Module> module);
+    ~NFP_User() override;
 };
 
 } // namespace Service::NFP

--- a/src/core/hle/service/ns/pl_u.cpp
+++ b/src/core/hle/service/ns/pl_u.cpp
@@ -247,6 +247,8 @@ PL_U::PL_U() : ServiceFramework("pl:u") {
     }
 }
 
+PL_U::~PL_U() = default;
+
 void PL_U::RequestLoad(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const u32 shared_font_type{rp.Pop<u32>()};

--- a/src/core/hle/service/ns/pl_u.h
+++ b/src/core/hle/service/ns/pl_u.h
@@ -13,7 +13,7 @@ namespace Service::NS {
 class PL_U final : public ServiceFramework<PL_U> {
 public:
     PL_U();
-    ~PL_U() = default;
+    ~PL_U() override;
 
 private:
     void RequestLoad(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
@@ -13,6 +13,9 @@
 
 namespace Service::Nvidia::Devices {
 
+nvdisp_disp0::nvdisp_disp0(std::shared_ptr<nvmap> nvmap_dev) : nvmap_dev(std::move(nvmap_dev)) {}
+nvdisp_disp0 ::~nvdisp_disp0() = default;
+
 u32 nvdisp_disp0::ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) {
     UNIMPLEMENTED_MSG("Unimplemented ioctl");
     return 0;

--- a/src/core/hle/service/nvdrv/devices/nvdisp_disp0.h
+++ b/src/core/hle/service/nvdrv/devices/nvdisp_disp0.h
@@ -17,8 +17,8 @@ class nvmap;
 
 class nvdisp_disp0 final : public nvdevice {
 public:
-    explicit nvdisp_disp0(std::shared_ptr<nvmap> nvmap_dev) : nvmap_dev(std::move(nvmap_dev)) {}
-    ~nvdisp_disp0() = default;
+    explicit nvdisp_disp0(std::shared_ptr<nvmap> nvmap_dev);
+    ~nvdisp_disp0();
 
     u32 ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) override;
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
@@ -3,6 +3,8 @@
 // Refer to the license.txt file included.
 
 #include <cstring>
+#include <utility>
+
 #include "common/assert.h"
 #include "common/logging/log.h"
 #include "core/core.h"
@@ -13,6 +15,9 @@
 #include "video_core/renderer_base.h"
 
 namespace Service::Nvidia::Devices {
+
+nvhost_as_gpu::nvhost_as_gpu(std::shared_ptr<nvmap> nvmap_dev) : nvmap_dev(std::move(nvmap_dev)) {}
+nvhost_as_gpu::~nvhost_as_gpu() = default;
 
 u32 nvhost_as_gpu::ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) {
     LOG_DEBUG(Service_NVDRV, "called, command=0x{:08X}, input_size=0x{:X}, output_size=0x{:X}",

--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.h
@@ -6,7 +6,6 @@
 
 #include <memory>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 #include "common/common_types.h"
 #include "common/swap.h"
@@ -18,8 +17,8 @@ class nvmap;
 
 class nvhost_as_gpu final : public nvdevice {
 public:
-    explicit nvhost_as_gpu(std::shared_ptr<nvmap> nvmap_dev) : nvmap_dev(std::move(nvmap_dev)) {}
-    ~nvhost_as_gpu() override = default;
+    explicit nvhost_as_gpu(std::shared_ptr<nvmap> nvmap_dev);
+    ~nvhost_as_gpu() override;
 
     u32 ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) override;
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -11,6 +11,9 @@
 
 namespace Service::Nvidia::Devices {
 
+nvhost_ctrl::nvhost_ctrl() = default;
+nvhost_ctrl::~nvhost_ctrl() = default;
+
 u32 nvhost_ctrl::ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) {
     LOG_DEBUG(Service_NVDRV, "called, command=0x{:08X}, input_size=0x{:X}, output_size=0x{:X}",
               command.raw, input.size(), output.size());

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
@@ -13,8 +13,8 @@ namespace Service::Nvidia::Devices {
 
 class nvhost_ctrl final : public nvdevice {
 public:
-    nvhost_ctrl() = default;
-    ~nvhost_ctrl() override = default;
+    nvhost_ctrl();
+    ~nvhost_ctrl() override;
 
     u32 ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) override;
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
@@ -9,6 +9,9 @@
 
 namespace Service::Nvidia::Devices {
 
+nvhost_ctrl_gpu::nvhost_ctrl_gpu() = default;
+nvhost_ctrl_gpu::~nvhost_ctrl_gpu() = default;
+
 u32 nvhost_ctrl_gpu::ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) {
     LOG_DEBUG(Service_NVDRV, "called, command=0x{:08X}, input_size=0x{:X}, output_size=0x{:X}",
               command.raw, input.size(), output.size());

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.h
@@ -13,8 +13,8 @@ namespace Service::Nvidia::Devices {
 
 class nvhost_ctrl_gpu final : public nvdevice {
 public:
-    nvhost_ctrl_gpu() = default;
-    ~nvhost_ctrl_gpu() override = default;
+    nvhost_ctrl_gpu();
+    ~nvhost_ctrl_gpu() override;
 
     u32 ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) override;
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
@@ -14,6 +14,9 @@
 
 namespace Service::Nvidia::Devices {
 
+nvhost_gpu::nvhost_gpu(std::shared_ptr<nvmap> nvmap_dev) : nvmap_dev(std::move(nvmap_dev)) {}
+nvhost_gpu::~nvhost_gpu() = default;
+
 u32 nvhost_gpu::ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) {
     LOG_DEBUG(Service_NVDRV, "called, command=0x{:08X}, input_size=0x{:X}, output_size=0x{:X}",
               command.raw, input.size(), output.size());

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
@@ -20,8 +20,8 @@ constexpr u32 NVGPU_IOCTL_CHANNEL_KICKOFF_PB(0x1b);
 
 class nvhost_gpu final : public nvdevice {
 public:
-    explicit nvhost_gpu(std::shared_ptr<nvmap> nvmap_dev) : nvmap_dev(std::move(nvmap_dev)) {}
-    ~nvhost_gpu() override = default;
+    explicit nvhost_gpu(std::shared_ptr<nvmap> nvmap_dev);
+    ~nvhost_gpu() override;
 
     u32 ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) override;
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_nvdec.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvdec.cpp
@@ -10,6 +10,9 @@
 
 namespace Service::Nvidia::Devices {
 
+nvhost_nvdec::nvhost_nvdec() = default;
+nvhost_nvdec::~nvhost_nvdec() = default;
+
 u32 nvhost_nvdec::ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) {
     LOG_DEBUG(Service_NVDRV, "called, command=0x{:08X}, input_size=0x{:X}, output_size=0x{:X}",
               command.raw, input.size(), output.size());

--- a/src/core/hle/service/nvdrv/devices/nvhost_nvdec.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvdec.h
@@ -13,8 +13,8 @@ namespace Service::Nvidia::Devices {
 
 class nvhost_nvdec final : public nvdevice {
 public:
-    nvhost_nvdec() = default;
-    ~nvhost_nvdec() override = default;
+    nvhost_nvdec();
+    ~nvhost_nvdec() override;
 
     u32 ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) override;
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_nvjpg.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvjpg.cpp
@@ -10,6 +10,9 @@
 
 namespace Service::Nvidia::Devices {
 
+nvhost_nvjpg::nvhost_nvjpg() = default;
+nvhost_nvjpg::~nvhost_nvjpg() = default;
+
 u32 nvhost_nvjpg::ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) {
     LOG_DEBUG(Service_NVDRV, "called, command=0x{:08X}, input_size=0x{:X}, output_size=0x{:X}",
               command.raw, input.size(), output.size());

--- a/src/core/hle/service/nvdrv/devices/nvhost_nvjpg.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvjpg.h
@@ -13,8 +13,8 @@ namespace Service::Nvidia::Devices {
 
 class nvhost_nvjpg final : public nvdevice {
 public:
-    nvhost_nvjpg() = default;
-    ~nvhost_nvjpg() override = default;
+    nvhost_nvjpg();
+    ~nvhost_nvjpg() override;
 
     u32 ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) override;
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_vic.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_vic.cpp
@@ -10,6 +10,9 @@
 
 namespace Service::Nvidia::Devices {
 
+nvhost_vic::nvhost_vic() = default;
+nvhost_vic::~nvhost_vic() = default;
+
 u32 nvhost_vic::ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) {
     LOG_DEBUG(Service_NVDRV, "called, command=0x{:08X}, input_size=0x{:X}, output_size=0x{:X}",
               command.raw, input.size(), output.size());

--- a/src/core/hle/service/nvdrv/devices/nvhost_vic.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_vic.h
@@ -13,8 +13,8 @@ namespace Service::Nvidia::Devices {
 
 class nvhost_vic final : public nvdevice {
 public:
-    nvhost_vic() = default;
-    ~nvhost_vic() override = default;
+    nvhost_vic();
+    ~nvhost_vic() override;
 
     u32 ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) override;
 

--- a/src/core/hle/service/nvdrv/devices/nvmap.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvmap.cpp
@@ -11,6 +11,9 @@
 
 namespace Service::Nvidia::Devices {
 
+nvmap::nvmap() = default;
+nvmap::~nvmap() = default;
+
 VAddr nvmap::GetObjectAddress(u32 handle) const {
     auto object = GetObject(handle);
     ASSERT(object);

--- a/src/core/hle/service/nvdrv/devices/nvmap.h
+++ b/src/core/hle/service/nvdrv/devices/nvmap.h
@@ -16,8 +16,8 @@ namespace Service::Nvidia::Devices {
 
 class nvmap final : public nvdevice {
 public:
-    nvmap() = default;
-    ~nvmap() override = default;
+    nvmap();
+    ~nvmap() override;
 
     /// Returns the allocated address of an nvmap object given its handle.
     VAddr GetObjectAddress(u32 handle) const;

--- a/src/core/hle/service/nvdrv/interface.cpp
+++ b/src/core/hle/service/nvdrv/interface.cpp
@@ -112,4 +112,6 @@ NVDRV::NVDRV(std::shared_ptr<Module> nvdrv, const char* name)
     query_event = Kernel::Event::Create(kernel, Kernel::ResetType::OneShot, "NVDRV::query_event");
 }
 
+NVDRV::~NVDRV() = default;
+
 } // namespace Service::Nvidia

--- a/src/core/hle/service/nvdrv/interface.h
+++ b/src/core/hle/service/nvdrv/interface.h
@@ -14,7 +14,7 @@ namespace Service::Nvidia {
 class NVDRV final : public ServiceFramework<NVDRV> {
 public:
     NVDRV(std::shared_ptr<Module> nvdrv, const char* name);
-    ~NVDRV() = default;
+    ~NVDRV();
 
 private:
     void Open(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/nvdrv/nvdrv.cpp
+++ b/src/core/hle/service/nvdrv/nvdrv.cpp
@@ -45,6 +45,8 @@ Module::Module() {
     devices["/dev/nvhost-vic"] = std::make_shared<Devices::nvhost_vic>();
 }
 
+Module::~Module() = default;
+
 u32 Module::Open(const std::string& device_name) {
     ASSERT_MSG(devices.find(device_name) != devices.end(), "Trying to open unknown device {}",
                device_name);

--- a/src/core/hle/service/nvdrv/nvdrv.h
+++ b/src/core/hle/service/nvdrv/nvdrv.h
@@ -30,7 +30,7 @@ static_assert(sizeof(IoctlFence) == 8, "IoctlFence has wrong size");
 class Module final {
 public:
     Module();
-    ~Module() = default;
+    ~Module();
 
     /// Returns a pointer to one of the available devices, identified by its name.
     template <typename T>

--- a/src/core/hle/service/nvdrv/nvmemp.cpp
+++ b/src/core/hle/service/nvdrv/nvmemp.cpp
@@ -16,6 +16,8 @@ NVMEMP::NVMEMP() : ServiceFramework("nvmemp") {
     RegisterHandlers(functions);
 }
 
+NVMEMP::~NVMEMP() = default;
+
 void NVMEMP::Cmd0(Kernel::HLERequestContext& ctx) {
     UNIMPLEMENTED();
 }

--- a/src/core/hle/service/nvdrv/nvmemp.h
+++ b/src/core/hle/service/nvdrv/nvmemp.h
@@ -11,7 +11,7 @@ namespace Service::Nvidia {
 class NVMEMP final : public ServiceFramework<NVMEMP> {
 public:
     NVMEMP();
-    ~NVMEMP() = default;
+    ~NVMEMP();
 
 private:
     void Cmd0(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/nvflinger/buffer_queue.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue.cpp
@@ -18,6 +18,8 @@ BufferQueue::BufferQueue(u32 id, u64 layer_id) : id(id), layer_id(layer_id) {
         Kernel::Event::Create(kernel, Kernel::ResetType::Sticky, "BufferQueue NativeHandle");
 }
 
+BufferQueue::~BufferQueue() = default;
+
 void BufferQueue::SetPreallocatedBuffer(u32 slot, const IGBPBuffer& igbp_buffer) {
     Buffer buffer{};
     buffer.slot = slot;

--- a/src/core/hle/service/nvflinger/buffer_queue.h
+++ b/src/core/hle/service/nvflinger/buffer_queue.h
@@ -46,7 +46,7 @@ public:
     };
 
     BufferQueue(u32 id, u64 layer_id);
-    ~BufferQueue() = default;
+    ~BufferQueue();
 
     enum class BufferTransformFlags : u32 {
         /// No transform flags are set

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -160,10 +160,13 @@ void NVFlinger::Compose() {
 }
 
 Layer::Layer(u64 id, std::shared_ptr<BufferQueue> queue) : id(id), buffer_queue(std::move(queue)) {}
+Layer::~Layer() = default;
 
 Display::Display(u64 id, std::string name) : id(id), name(std::move(name)) {
     auto& kernel = Core::System::GetInstance().Kernel();
     vsync_event = Kernel::Event::Create(kernel, Kernel::ResetType::Pulse, "Display VSync Event");
 }
+
+Display::~Display() = default;
 
 } // namespace Service::NVFlinger

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -26,7 +26,7 @@ class BufferQueue;
 
 struct Layer {
     Layer(u64 id, std::shared_ptr<BufferQueue> queue);
-    ~Layer() = default;
+    ~Layer();
 
     u64 id;
     std::shared_ptr<BufferQueue> buffer_queue;
@@ -34,7 +34,7 @@ struct Layer {
 
 struct Display {
     Display(u64 id, std::string name);
-    ~Display() = default;
+    ~Display();
 
     u64 id;
     std::string name;

--- a/src/core/hle/service/pctl/module.cpp
+++ b/src/core/hle/service/pctl/module.cpp
@@ -142,6 +142,8 @@ void Module::Interface::CreateServiceWithoutInitialize(Kernel::HLERequestContext
 Module::Interface::Interface(std::shared_ptr<Module> module, const char* name)
     : ServiceFramework(name), module(std::move(module)) {}
 
+Module::Interface::~Interface() = default;
+
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     auto module = std::make_shared<Module>();
     std::make_shared<PCTL>(module, "pctl")->InstallAsService(service_manager);

--- a/src/core/hle/service/pctl/module.h
+++ b/src/core/hle/service/pctl/module.h
@@ -13,6 +13,7 @@ public:
     class Interface : public ServiceFramework<Interface> {
     public:
         explicit Interface(std::shared_ptr<Module> module, const char* name);
+        ~Interface() override;
 
         void CreateService(Kernel::HLERequestContext& ctx);
         void CreateServiceWithoutInitialize(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/pctl/pctl.cpp
+++ b/src/core/hle/service/pctl/pctl.cpp
@@ -14,4 +14,6 @@ PCTL::PCTL(std::shared_ptr<Module> module, const char* name)
     };
     RegisterHandlers(functions);
 }
+
+PCTL::~PCTL() = default;
 } // namespace Service::PCTL

--- a/src/core/hle/service/pctl/pctl.h
+++ b/src/core/hle/service/pctl/pctl.h
@@ -11,6 +11,7 @@ namespace Service::PCTL {
 class PCTL final : public Module::Interface {
 public:
     explicit PCTL(std::shared_ptr<Module> module, const char* name);
+    ~PCTL() override;
 };
 
 } // namespace Service::PCTL

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -112,4 +112,6 @@ SET::SET() : ServiceFramework("set") {
     RegisterHandlers(functions);
 }
 
+SET::~SET() = default;
+
 } // namespace Service::Set

--- a/src/core/hle/service/set/set.h
+++ b/src/core/hle/service/set/set.h
@@ -33,7 +33,7 @@ LanguageCode GetLanguageCodeFromIndex(size_t idx);
 class SET final : public ServiceFramework<SET> {
 public:
     explicit SET();
-    ~SET() = default;
+    ~SET() override;
 
 private:
     void GetLanguageCode(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/set/set_cal.cpp
+++ b/src/core/hle/service/set/set_cal.cpp
@@ -44,4 +44,6 @@ SET_CAL::SET_CAL() : ServiceFramework("set:cal") {
     RegisterHandlers(functions);
 }
 
+SET_CAL::~SET_CAL() = default;
+
 } // namespace Service::Set

--- a/src/core/hle/service/set/set_cal.h
+++ b/src/core/hle/service/set/set_cal.h
@@ -11,7 +11,7 @@ namespace Service::Set {
 class SET_CAL final : public ServiceFramework<SET_CAL> {
 public:
     explicit SET_CAL();
-    ~SET_CAL() = default;
+    ~SET_CAL();
 };
 
 } // namespace Service::Set

--- a/src/core/hle/service/set/set_fd.cpp
+++ b/src/core/hle/service/set/set_fd.cpp
@@ -20,4 +20,6 @@ SET_FD::SET_FD() : ServiceFramework("set:fd") {
     RegisterHandlers(functions);
 }
 
+SET_FD::~SET_FD() = default;
+
 } // namespace Service::Set

--- a/src/core/hle/service/set/set_fd.h
+++ b/src/core/hle/service/set/set_fd.h
@@ -11,7 +11,7 @@ namespace Service::Set {
 class SET_FD final : public ServiceFramework<SET_FD> {
 public:
     explicit SET_FD();
-    ~SET_FD() = default;
+    ~SET_FD() override;
 };
 
 } // namespace Service::Set

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -109,6 +109,8 @@ BSD::BSD(const char* name) : ServiceFramework(name) {
     RegisterHandlers(functions);
 }
 
+BSD::~BSD() = default;
+
 BSDCFG::BSDCFG() : ServiceFramework{"bsdcfg"} {
     // clang-format off
     static const FunctionInfo functions[] = {
@@ -130,5 +132,7 @@ BSDCFG::BSDCFG() : ServiceFramework{"bsdcfg"} {
 
     RegisterHandlers(functions);
 }
+
+BSDCFG::~BSDCFG() = default;
 
 } // namespace Service::Sockets

--- a/src/core/hle/service/sockets/bsd.h
+++ b/src/core/hle/service/sockets/bsd.h
@@ -12,7 +12,7 @@ namespace Service::Sockets {
 class BSD final : public ServiceFramework<BSD> {
 public:
     explicit BSD(const char* name);
-    ~BSD() = default;
+    ~BSD() override;
 
 private:
     void RegisterClient(Kernel::HLERequestContext& ctx);
@@ -29,6 +29,7 @@ private:
 class BSDCFG final : public ServiceFramework<BSDCFG> {
 public:
     explicit BSDCFG();
+    ~BSDCFG() override;
 };
 
 } // namespace Service::Sockets

--- a/src/core/hle/service/sockets/ethc.cpp
+++ b/src/core/hle/service/sockets/ethc.cpp
@@ -21,6 +21,8 @@ ETHC_C::ETHC_C() : ServiceFramework{"ethc:c"} {
     RegisterHandlers(functions);
 }
 
+ETHC_C::~ETHC_C() = default;
+
 ETHC_I::ETHC_I() : ServiceFramework{"ethc:i"} {
     // clang-format off
     static const FunctionInfo functions[] = {
@@ -34,5 +36,7 @@ ETHC_I::ETHC_I() : ServiceFramework{"ethc:i"} {
 
     RegisterHandlers(functions);
 }
+
+ETHC_I::~ETHC_I() = default;
 
 } // namespace Service::Sockets

--- a/src/core/hle/service/sockets/ethc.h
+++ b/src/core/hle/service/sockets/ethc.h
@@ -11,11 +11,13 @@ namespace Service::Sockets {
 class ETHC_C final : public ServiceFramework<ETHC_C> {
 public:
     explicit ETHC_C();
+    ~ETHC_C() override;
 };
 
 class ETHC_I final : public ServiceFramework<ETHC_I> {
 public:
     explicit ETHC_I();
+    ~ETHC_I() override;
 };
 
 } // namespace Service::Sockets

--- a/src/core/hle/service/sockets/nsd.cpp
+++ b/src/core/hle/service/sockets/nsd.cpp
@@ -29,4 +29,6 @@ NSD::NSD(const char* name) : ServiceFramework(name) {
     RegisterHandlers(functions);
 }
 
+NSD::~NSD() = default;
+
 } // namespace Service::Sockets

--- a/src/core/hle/service/sockets/nsd.h
+++ b/src/core/hle/service/sockets/nsd.h
@@ -12,7 +12,7 @@ namespace Service::Sockets {
 class NSD final : public ServiceFramework<NSD> {
 public:
     explicit NSD(const char* name);
-    ~NSD() = default;
+    ~NSD() override;
 };
 
 } // namespace Service::Sockets

--- a/src/core/hle/service/sockets/sfdnsres.cpp
+++ b/src/core/hle/service/sockets/sfdnsres.cpp
@@ -34,4 +34,6 @@ SFDNSRES::SFDNSRES() : ServiceFramework("sfdnsres") {
     RegisterHandlers(functions);
 }
 
+SFDNSRES::~SFDNSRES() = default;
+
 } // namespace Service::Sockets

--- a/src/core/hle/service/sockets/sfdnsres.h
+++ b/src/core/hle/service/sockets/sfdnsres.h
@@ -12,7 +12,7 @@ namespace Service::Sockets {
 class SFDNSRES final : public ServiceFramework<SFDNSRES> {
 public:
     explicit SFDNSRES();
-    ~SFDNSRES() = default;
+    ~SFDNSRES() override;
 
 private:
     void GetAddrInfo(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/spl/csrng.cpp
+++ b/src/core/hle/service/spl/csrng.cpp
@@ -13,4 +13,6 @@ CSRNG::CSRNG(std::shared_ptr<Module> module) : Module::Interface(std::move(modul
     RegisterHandlers(functions);
 }
 
+CSRNG::~CSRNG() = default;
+
 } // namespace Service::SPL

--- a/src/core/hle/service/spl/csrng.h
+++ b/src/core/hle/service/spl/csrng.h
@@ -11,6 +11,7 @@ namespace Service::SPL {
 class CSRNG final : public Module::Interface {
 public:
     explicit CSRNG(std::shared_ptr<Module> module);
+    ~CSRNG() override;
 };
 
 } // namespace Service::SPL

--- a/src/core/hle/service/spl/module.cpp
+++ b/src/core/hle/service/spl/module.cpp
@@ -16,6 +16,8 @@ namespace Service::SPL {
 Module::Interface::Interface(std::shared_ptr<Module> module, const char* name)
     : ServiceFramework(name), module(std::move(module)) {}
 
+Module::Interface::~Interface() = default;
+
 void Module::Interface::GetRandomBytes(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
 

--- a/src/core/hle/service/spl/module.h
+++ b/src/core/hle/service/spl/module.h
@@ -13,6 +13,7 @@ public:
     class Interface : public ServiceFramework<Interface> {
     public:
         explicit Interface(std::shared_ptr<Module> module, const char* name);
+        ~Interface() override;
 
         void GetRandomBytes(Kernel::HLERequestContext& ctx);
 

--- a/src/core/hle/service/spl/spl.cpp
+++ b/src/core/hle/service/spl/spl.cpp
@@ -42,4 +42,6 @@ SPL::SPL(std::shared_ptr<Module> module) : Module::Interface(std::move(module), 
     RegisterHandlers(functions);
 }
 
+SPL::~SPL() = default;
+
 } // namespace Service::SPL

--- a/src/core/hle/service/spl/spl.h
+++ b/src/core/hle/service/spl/spl.h
@@ -11,6 +11,7 @@ namespace Service::SPL {
 class SPL final : public Module::Interface {
 public:
     explicit SPL(std::shared_ptr<Module> module);
+    ~SPL() override;
 };
 
 } // namespace Service::SPL

--- a/src/core/hle/service/time/interface.cpp
+++ b/src/core/hle/service/time/interface.cpp
@@ -29,4 +29,6 @@ Time::Time(std::shared_ptr<Module> time, const char* name)
     RegisterHandlers(functions);
 }
 
+Time::~Time() = default;
+
 } // namespace Service::Time

--- a/src/core/hle/service/time/interface.h
+++ b/src/core/hle/service/time/interface.h
@@ -11,6 +11,7 @@ namespace Service::Time {
 class Time final : public Module::Interface {
 public:
     explicit Time(std::shared_ptr<Module> time, const char* name);
+    ~Time() override;
 };
 
 } // namespace Service::Time

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -210,6 +210,8 @@ void Module::Interface::GetStandardLocalSystemClock(Kernel::HLERequestContext& c
 Module::Interface::Interface(std::shared_ptr<Module> time, const char* name)
     : ServiceFramework(name), time(std::move(time)) {}
 
+Module::Interface::~Interface() = default;
+
 void InstallInterfaces(SM::ServiceManager& service_manager) {
     auto time = std::make_shared<Module>();
     std::make_shared<Time>(time, "time:a")->InstallAsService(service_manager);

--- a/src/core/hle/service/time/time.h
+++ b/src/core/hle/service/time/time.h
@@ -58,6 +58,7 @@ public:
     class Interface : public ServiceFramework<Interface> {
     public:
         explicit Interface(std::shared_ptr<Module> time, const char* name);
+        ~Interface() override;
 
         void GetStandardUserSystemClock(Kernel::HLERequestContext& ctx);
         void GetStandardNetworkSystemClock(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -984,6 +984,8 @@ Module::Interface::Interface(std::shared_ptr<Module> module, const char* name,
                              std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
     : ServiceFramework(name), module(std::move(module)), nv_flinger(std::move(nv_flinger)) {}
 
+Module::Interface::~Interface() = default;
+
 void Module::Interface::GetDisplayService(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_VI, "(STUBBED) called");
 

--- a/src/core/hle/service/vi/vi.h
+++ b/src/core/hle/service/vi/vi.h
@@ -26,6 +26,7 @@ public:
     public:
         explicit Interface(std::shared_ptr<Module> module, const char* name,
                            std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+        ~Interface() override;
 
         void GetDisplayService(Kernel::HLERequestContext& ctx);
 

--- a/src/core/hle/service/vi/vi_m.cpp
+++ b/src/core/hle/service/vi/vi_m.cpp
@@ -15,4 +15,6 @@ VI_M::VI_M(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger>
     RegisterHandlers(functions);
 }
 
+VI_M::~VI_M() = default;
+
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_m.h
+++ b/src/core/hle/service/vi/vi_m.h
@@ -11,6 +11,7 @@ namespace Service::VI {
 class VI_M final : public Module::Interface {
 public:
     explicit VI_M(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+    ~VI_M() override;
 };
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_s.cpp
+++ b/src/core/hle/service/vi/vi_s.cpp
@@ -15,4 +15,6 @@ VI_S::VI_S(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger>
     RegisterHandlers(functions);
 }
 
+VI_S::~VI_S() = default;
+
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_s.h
+++ b/src/core/hle/service/vi/vi_s.h
@@ -11,6 +11,7 @@ namespace Service::VI {
 class VI_S final : public Module::Interface {
 public:
     explicit VI_S(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+    ~VI_S() override;
 };
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_u.cpp
+++ b/src/core/hle/service/vi/vi_u.cpp
@@ -14,4 +14,6 @@ VI_U::VI_U(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger>
     RegisterHandlers(functions);
 }
 
+VI_U::~VI_U() = default;
+
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_u.h
+++ b/src/core/hle/service/vi/vi_u.h
@@ -11,6 +11,7 @@ namespace Service::VI {
 class VI_U final : public Module::Interface {
 public:
     explicit VI_U(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+    ~VI_U() override;
 };
 
 } // namespace Service::VI


### PR DESCRIPTION
When a destructor isn't defaulted into a cpp file, it can cause the use of forward declarations to seemingly fail to compile for non-obvious reasons. It also allows inlining of the construction/destruction logic all over the place where a constructor or destructor is invoked, which can lead to code bloat. This isn't so much a worry here, given the services won't be created and destroyed frequently.

The cause of the above mentioned non-obvious errors can be demonstrated as follows:

------- Demonstrative example, if you know how the described error happens, skip forwards -------

Assume we have the following in the header, which we'll call "thing.h":

```cpp
#include <memory>

// Forward declaration. For example purposes, assume the definition
// of Object is in some header named "object.h"
class Object;

class Thing {
public:
    // assume no constructors or destructors are specified here,
    // or the constructors/destructors are defined as:
    //
    // Thing() = default;
    // ~Thing() = default;
    //

    // ... Some interface member functions would be defined here

private:
    std::shared_ptr<Object> obj;
};
```

If this header is included in a cpp file, (which we'll call "main.cpp"), this will result in a compilation error, because even though no destructor is specified, the destructor will still need to be generated by the compiler because `std::shared_ptr`'s destructor is *not* [trivial](https://en.cppreference.com/w/cpp/language/destructor#Trivial_destructor) (in other words, it does something other than nothing), as `std::shared_ptr`'s destructor needs to do two things:

1. Decrement the shared reference count of the object being pointed to, and if the reference count decrements to zero,

2. Free the Object instance's memory (aka deallocate the memory it's pointing to).

And so the compiler generates the code for the destructor doing this inside `main.cpp`.

Now, keep in mind, the Object forward declaration is not a complete type. All it does is tell the compiler "a type named Object exists" and allows us to use the name in certain situations to avoid a header dependency. So the compiler needs to generate destruction code for Object, but the compiler doesn't know *how* to destruct it. A forward declaration doesn't tell the compiler anything about Object's constructor or destructor. So, the compiler will issue an error in this case because it's undefined behavior to try and deallocate (or construct) an incomplete type and `std::shared_ptr` and `std::unique_ptr` make sure this isn't the case internally.

Now, if we had defaulted the destructor in `"thing.cpp"`, where we also include `"object.h"`, this would never be an issue, as the destructor would only have its code generated in one place, and it would be in a place where the full class definition of Object would be visible to the compiler.

---------------------- End example ----------------------------

Given these service classes are more than certainly going to change in the future, this defaults the constructors and destructors into the relevant cpp files to make the construction and destruction of all of
the services consistent and unlikely to run into cases where forward declarations are indirectly causing compilation errors. It also has the plus of avoiding the need to rebuild several services if destruction logic changes, since it would only be necessary to recompile the single cpp file.

Thanks for reading my novel about forward declarations, constructors, and destructors.