### PR TITLE
Fixed renderdoc input/output textures not working due to multiple render targets

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1023,7 +1023,7 @@ private:
             // TODO(Subv): Figure out how dual-source blending is configured in the Switch.
             for (u32 component = 0; component < 4; ++component) {
                 if (header.IsColorComponentOutputEnabled(render_target, component)) {
-                    shader.AddLine(fmt::format("color[{}][{}] = {};", render_target, component,
+                    shader.AddLine(fmt::format("FragColor{}[{}] = {};", render_target, component,
                                                regs.GetRegisterAsFloat(current_reg)));
                     ++current_reg;
                 }

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -88,7 +88,14 @@ ProgramResult GenerateFragmentShader(const ShaderSetup& setup) {
             .get_value_or({});
     out += R"(
 in vec4 position;
-layout(location = 0) out vec4 color[8];
+layout(location = 0) out vec4 FragColor0;
+layout(location = 1) out vec4 FragColor1;
+layout(location = 2) out vec4 FragColor2;
+layout(location = 3) out vec4 FragColor3;
+layout(location = 4) out vec4 FragColor4;
+layout(location = 5) out vec4 FragColor5;
+layout(location = 6) out vec4 FragColor6;
+layout(location = 7) out vec4 FragColor7;
 
 layout (std140) uniform fs_config {
     vec4 viewport_flip;


### PR DESCRIPTION
Before:
<img width="1202" alt="2018-09-10_16-03-44cbd72d-cda7-4bdb-9b97-8e0907e5e846-4df88e2a" src="https://user-images.githubusercontent.com/25727384/45336537-555bd080-b5c7-11e8-94c6-8386b0bc8e86.png">

After:
<img width="1200" alt="2018-09-10_16-03-0c59df2c-b4b1-48c1-bfa9-137df596fd1b-9553077e" src="https://user-images.githubusercontent.com/25727384/45336521-4b39d200-b5c7-11e8-94f3-464c29d5c122.png">
