### PR TITLE
gl_rasterizer_cache: Improve accuracy of caching and copies.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -53,8 +53,6 @@ static VAddr TryGetCpuAddr(Tegra::GPUVAddr gpu_addr) {
     params.width = Common::AlignUp(config.tic.Width(), GetCompressionFactor(params.pixel_format));
     params.height = Common::AlignUp(config.tic.Height(), GetCompressionFactor(params.pixel_format));
     params.unaligned_height = config.tic.Height();
-    params.cache_width = Common::AlignUp(params.width, 8);
-    params.cache_height = Common::AlignUp(params.height, 8);
     params.target = SurfaceTargetFromTextureType(config.tic.texture_type);
 
     switch (params.target) {
@@ -89,8 +87,6 @@ static VAddr TryGetCpuAddr(Tegra::GPUVAddr gpu_addr) {
     params.width = config.width;
     params.height = config.height;
     params.unaligned_height = config.height;
-    params.cache_width = Common::AlignUp(params.width, 8);
-    params.cache_height = Common::AlignUp(params.height, 8);
     params.target = SurfaceTarget::Texture2D;
     params.depth = 1;
     params.size_in_bytes = params.SizeInBytes();
@@ -110,8 +106,6 @@ static VAddr TryGetCpuAddr(Tegra::GPUVAddr gpu_addr) {
     params.width = zeta_width;
     params.height = zeta_height;
     params.unaligned_height = zeta_height;
-    params.cache_width = Common::AlignUp(params.width, 8);
-    params.cache_height = Common::AlignUp(params.height, 8);
     params.target = SurfaceTarget::Texture2D;
     params.depth = 1;
     params.size_in_bytes = params.SizeInBytes();

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -680,8 +680,8 @@ struct SurfaceParams {
 
     /// Checks if surfaces are compatible for caching
     bool IsCompatibleSurface(const SurfaceParams& other) const {
-        return std::tie(pixel_format, type, cache_width, cache_height) ==
-               std::tie(other.pixel_format, other.type, other.cache_width, other.cache_height);
+        return std::tie(pixel_format, type, width, height) ==
+               std::tie(other.pixel_format, other.type, other.width, other.height);
     }
 
     VAddr addr;
@@ -696,10 +696,6 @@ struct SurfaceParams {
     u32 unaligned_height;
     size_t size_in_bytes;
     SurfaceTarget target;
-
-    // Parameters used for caching only
-    u32 cache_width;
-    u32 cache_height;
 };
 
 }; // namespace OpenGL


### PR DESCRIPTION
Two changes to the rasterizer cache here:
* Removes cache key variables `cache_width` and `cache_height`. This was an inaccurate workaround to improve performance for games that did lots of copies with similar sized surfaces. This is no longer needed, since the brunt of the slow down here was from creating/destroying lots of textures, which are now long-lived with the reserve cache. 
* Changes `RecreateSurface` to always blit, not just when the format is the same. This fixes several rendering bugs in SMO, I'm sure other games. There might be some performance impact here. This also can cause OpenGL errors, since we do not currently support blitting all of the possible configurations for rasterizer cache surfaces.

For example, this improves rendering in Ruined Kingdom a ton, without having to turn on the "Use accurate framebuffers" setting.

![image](https://user-images.githubusercontent.com/6956688/45394784-755bb600-b600-11e8-8524-a25f380aa964.png)
