### PR TITLE
service/prepo: Move class into the cpp file

### DIFF
--- a/src/core/hle/service/prepo/prepo.cpp
+++ b/src/core/hle/service/prepo/prepo.cpp
@@ -1,36 +1,47 @@
-#include <cinttypes>
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 #include "common/logging/log.h"
 #include "core/hle/ipc_helpers.h"
-#include "core/hle/kernel/event.h"
 #include "core/hle/service/prepo/prepo.h"
+#include "core/hle/service/service.h"
 
 namespace Service::PlayReport {
-PlayReport::PlayReport(const char* name) : ServiceFramework(name) {
-    static const FunctionInfo functions[] = {
-        {10100, nullptr, "SaveReport"},
-        {10101, &PlayReport::SaveReportWithUser, "SaveReportWithUser"},
-        {10200, nullptr, "RequestImmediateTransmission"},
-        {10300, nullptr, "GetTransmissionStatus"},
-        {20100, nullptr, "SaveSystemReport"},
-        {20200, nullptr, "SetOperationMode"},
-        {20101, nullptr, "SaveSystemReportWithUser"},
-        {30100, nullptr, "ClearStorage"},
-        {40100, nullptr, "IsUserAgreementCheckEnabled"},
-        {40101, nullptr, "SetUserAgreementCheckEnabled"},
-        {90100, nullptr, "GetStorageUsage"},
-        {90200, nullptr, "GetStatistics"},
-        {90201, nullptr, "GetThroughputHistory"},
-        {90300, nullptr, "GetLastUploadError"},
-    };
-    RegisterHandlers(functions);
-};
 
-void PlayReport::SaveReportWithUser(Kernel::HLERequestContext& ctx) {
-    // TODO(ogniK): Do we want to add play report?
-    LOG_WARNING(Service_PREPO, "(STUBBED) called");
+class PlayReport final : public ServiceFramework<PlayReport> {
+public:
+    explicit PlayReport(const char* name) : ServiceFramework{name} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {10100, nullptr, "SaveReport"},
+            {10101, &PlayReport::SaveReportWithUser, "SaveReportWithUser"},
+            {10200, nullptr, "RequestImmediateTransmission"},
+            {10300, nullptr, "GetTransmissionStatus"},
+            {20100, nullptr, "SaveSystemReport"},
+            {20200, nullptr, "SetOperationMode"},
+            {20101, nullptr, "SaveSystemReportWithUser"},
+            {30100, nullptr, "ClearStorage"},
+            {40100, nullptr, "IsUserAgreementCheckEnabled"},
+            {40101, nullptr, "SetUserAgreementCheckEnabled"},
+            {90100, nullptr, "GetStorageUsage"},
+            {90200, nullptr, "GetStatistics"},
+            {90201, nullptr, "GetThroughputHistory"},
+            {90300, nullptr, "GetLastUploadError"},
+        };
+        // clang-format on
 
-    IPC::ResponseBuilder rb{ctx, 2};
-    rb.Push(RESULT_SUCCESS);
+        RegisterHandlers(functions);
+    }
+
+private:
+    void SaveReportWithUser(Kernel::HLERequestContext& ctx) {
+        // TODO(ogniK): Do we want to add play report?
+        LOG_WARNING(Service_PREPO, "(STUBBED) called");
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+    }
 };
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {

--- a/src/core/hle/service/prepo/prepo.h
+++ b/src/core/hle/service/prepo/prepo.h
@@ -4,21 +4,11 @@
 
 #pragma once
 
-#include <memory>
-#include <string>
-#include "core/hle/kernel/event.h"
-#include "core/hle/service/service.h"
+namespace Service::SM {
+class ServiceManager;
+}
 
 namespace Service::PlayReport {
-
-class PlayReport final : public ServiceFramework<PlayReport> {
-public:
-    explicit PlayReport(const char* name);
-    ~PlayReport() = default;
-
-private:
-    void SaveReportWithUser(Kernel::HLERequestContext& ctx);
-};
 
 void InstallInterfaces(SM::ServiceManager& service_manager);
 


### PR DESCRIPTION
This doesn't need to be exposed within the header and be kept in the translation unit, eliminating the need to include anything within the header.