### PR TITLE
pl_u: Eliminate mutable file-scope state

### DIFF
--- a/src/core/hle/service/ns/pl_u.h
+++ b/src/core/hle/service/ns/pl_u.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <memory>
-#include "core/hle/kernel/shared_memory.h"
 #include "core/hle/service/service.h"
 
 namespace Service::NS {
@@ -23,11 +22,8 @@ private:
     void GetSharedMemoryNativeHandle(Kernel::HLERequestContext& ctx);
     void GetSharedFontInOrderOfPriority(Kernel::HLERequestContext& ctx);
 
-    /// Handle to shared memory region designated for a shared font
-    Kernel::SharedPtr<Kernel::SharedMemory> shared_font_mem;
-
-    /// Backing memory for the shared font data
-    std::shared_ptr<std::vector<u8>> shared_font;
+    struct Impl;
+    std::unique_ptr<Impl> impl;
 };
 
 } // namespace Service::NS


### PR DESCRIPTION
Converts the PL_U internals to use the PImpl idiom and makes the state part of the Impl struct, eliminating mutable global/file state.