### PR TITLE
audio_core/sink_details: Change std::string parameter into std::string_view

### DIFF
--- a/src/audio_core/sink_details.cpp
+++ b/src/audio_core/sink_details.cpp
@@ -24,7 +24,7 @@ const std::vector<SinkDetails> g_sink_details = {
                 [] { return std::vector<std::string>{"null"}; }},
 };
 
-const SinkDetails& GetSinkDetails(std::string sink_id) {
+const SinkDetails& GetSinkDetails(std::string_view sink_id) {
     auto iter =
         std::find_if(g_sink_details.begin(), g_sink_details.end(),
                      [sink_id](const auto& sink_detail) { return sink_detail.id == sink_id; });

--- a/src/audio_core/sink_details.h
+++ b/src/audio_core/sink_details.h
@@ -6,6 +6,8 @@
 
 #include <functional>
 #include <memory>
+#include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 
@@ -30,6 +32,6 @@ struct SinkDetails {
 
 extern const std::vector<SinkDetails> g_sink_details;
 
-const SinkDetails& GetSinkDetails(std::string sink_id);
+const SinkDetails& GetSinkDetails(std::string_view sink_id);
 
 } // namespace AudioCore


### PR DESCRIPTION
The given string is only ever used for lookup and comparison, so we can just utilize a non-owning view to string data here