### PR TITLE
service/audio: Replace includes with forward declarations where applicable

### DIFF
--- a/src/core/hle/service/audio/audio.cpp
+++ b/src/core/hle/service/audio/audio.cpp
@@ -15,6 +15,7 @@
 #include "core/hle/service/audio/audren_u.h"
 #include "core/hle/service/audio/codecctl.h"
 #include "core/hle/service/audio/hwopus.h"
+#include "core/hle/service/service.h"
 
 namespace Service::Audio {
 

--- a/src/core/hle/service/audio/audio.h
+++ b/src/core/hle/service/audio/audio.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
-#include "core/hle/service/service.h"
+namespace Service::SM {
+class ServiceManager;
+}
 
 namespace Service::Audio {
 

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -3,15 +3,20 @@
 // Refer to the license.txt file included.
 
 #include <array>
+#include <cstring>
 #include <vector>
 
+#include "audio_core/audio_out.h"
 #include "audio_core/codec.h"
+#include "common/common_funcs.h"
 #include "common/logging/log.h"
+#include "common/swap.h"
 #include "core/core.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/event.h"
 #include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/service/audio/audout_u.h"
+#include "core/memory.h"
 
 namespace Service::Audio {
 
@@ -24,6 +29,18 @@ enum {
 
 constexpr std::array<char, 10> DefaultDevice{{"DeviceOut"}};
 constexpr int DefaultSampleRate{48000};
+
+struct AudoutParams {
+    s32_le sample_rate;
+    u16_le channel_count;
+    INSERT_PADDING_BYTES(2);
+};
+static_assert(sizeof(AudoutParams) == 0x8, "AudoutParams is an invalid size");
+
+enum class AudioState : u32 {
+    Started,
+    Stopped,
+};
 
 class IAudioOut final : public ServiceFramework<IAudioOut> {
 public:

--- a/src/core/hle/service/audio/audout_u.h
+++ b/src/core/hle/service/audio/audout_u.h
@@ -4,26 +4,17 @@
 
 #pragma once
 
-#include "audio_core/audio_out.h"
 #include "core/hle/service/service.h"
+
+namespace AudioCore {
+class AudioOut;
+}
 
 namespace Kernel {
 class HLERequestContext;
 }
 
 namespace Service::Audio {
-
-struct AudoutParams {
-    s32_le sample_rate;
-    u16_le channel_count;
-    INSERT_PADDING_BYTES(2);
-};
-static_assert(sizeof(AudoutParams) == 0x8, "AudoutParams is an invalid size");
-
-enum class AudioState : u32 {
-    Started,
-    Stopped,
-};
 
 class IAudioOut;
 

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -2,12 +2,14 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <array>
+#include <memory>
 
+#include "audio_core/audio_renderer.h"
 #include "common/alignment.h"
+#include "common/common_funcs.h"
 #include "common/logging/log.h"
-#include "core/core_timing.h"
-#include "core/core_timing_util.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/event.h"
 #include "core/hle/kernel/hle_ipc.h"

--- a/src/core/hle/service/audio/audren_u.h
+++ b/src/core/hle/service/audio/audren_u.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include "audio_core/audio_renderer.h"
 #include "core/hle/service/service.h"
 
 namespace Kernel {

--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -3,7 +3,12 @@
 // Refer to the license.txt file included.
 
 #include <cstring>
+#include <memory>
+#include <vector>
+
 #include <opus.h>
+
+#include "common/common_funcs.h"
 #include "common/logging/log.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/hle_ipc.h"


### PR DESCRIPTION
A few headers were including other headers when a forward declaration can be used instead, allowing the include to be moved to the cpp file.