### PR TITLE
game_list: Resolve variable shadowing within LoadCompatibilityList()

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -366,7 +366,7 @@ void GameList::LoadCompatibilityList() {
     QJsonDocument json = QJsonDocument::fromJson(string_content.toUtf8());
     QJsonArray arr = json.array();
 
-    for (const QJsonValue& value : arr) {
+    for (const QJsonValueRef& value : arr) {
         QJsonObject game = value.toObject();
 
         if (game.contains("compatibility") && game["compatibility"].isDouble()) {
@@ -374,7 +374,7 @@ void GameList::LoadCompatibilityList() {
             QString directory = game["directory"].toString();
             QJsonArray ids = game["releases"].toArray();
 
-            for (const QJsonValue& value : ids) {
+            for (const QJsonValueRef& value : ids) {
                 QJsonObject object = value.toObject();
                 QString id = object["id"].toString();
                 compatibility_list.emplace(

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -374,9 +374,9 @@ void GameList::LoadCompatibilityList() {
             QString directory = game["directory"].toString();
             QJsonArray ids = game["releases"].toArray();
 
-            for (const QJsonValueRef& value : ids) {
-                QJsonObject object = value.toObject();
-                QString id = object["id"].toString();
+            for (const QJsonValueRef& id_ref : ids) {
+                QJsonObject id_object = id_ref.toObject();
+                QString id = id_object["id"].toString();
                 compatibility_list.emplace(
                     id.toUpper().toStdString(),
                     std::make_pair(QString::number(compatibility), directory));


### PR DESCRIPTION
"value" is already a used variable name within the outermost ranged-for loop, so this variable was shadowing the outer one. This isn't a bug, but it will get rid of a -Wshadow warning. While we're at it, we can use QJsonValueRef, to avoid implicit conversions to QJsonValue here.