### PR TITLE
yuzu/configure_gamelist: Mark combo-box strings as translatable

### DIFF
--- a/src/yuzu/configuration/configure_gamelist.cpp
+++ b/src/yuzu/configuration/configure_gamelist.cpp
@@ -2,11 +2,14 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "core/core.h"
+#include <array>
+#include <utility>
+
+#include "common/common_types.h"
 #include "core/settings.h"
 #include "ui_configure_gamelist.h"
-#include "ui_settings.h"
 #include "yuzu/configuration/configure_gamelist.h"
+#include "yuzu/ui_settings.h"
 
 ConfigureGameList::ConfigureGameList(QWidget* parent)
     : QWidget(parent), ui(new Ui::ConfigureGameList) {
@@ -39,11 +42,11 @@ void ConfigureGameList::setConfiguration() {
 }
 
 void ConfigureGameList::InitializeIconSizeComboBox() {
-    static const std::vector<std::pair<u32, std::string>> default_icon_sizes{
+    static const std::array<std::pair<u32, std::string>, 5> default_icon_sizes{{
         std::make_pair(0, "None"),        std::make_pair(32, "Small"),
         std::make_pair(64, "Standard"),   std::make_pair(128, "Large"),
         std::make_pair(256, "Full Size"),
-    };
+    }};
 
     for (const auto& size : default_icon_sizes) {
         ui->icon_size_combobox->addItem(QString::fromStdString(size.second + " (" +
@@ -54,12 +57,12 @@ void ConfigureGameList::InitializeIconSizeComboBox() {
 }
 
 void ConfigureGameList::InitializeRowComboBoxes() {
-    static const std::vector<std::string> row_text_names{
+    static const std::array<std::string, 4> row_text_names{{
         "Filename",
         "Filetype",
         "Title ID",
         "Title Name",
-    };
+    }};
 
     for (size_t i = 0; i < row_text_names.size(); ++i) {
         ui->row_1_text_combobox->addItem(QString::fromStdString(row_text_names[i]),

--- a/src/yuzu/configuration/configure_gamelist.cpp
+++ b/src/yuzu/configuration/configure_gamelist.cpp
@@ -11,6 +11,23 @@
 #include "yuzu/configuration/configure_gamelist.h"
 #include "yuzu/ui_settings.h"
 
+namespace {
+constexpr std::array<std::pair<u32, const char*>, 5> default_icon_sizes{{
+    std::make_pair(0, QT_TR_NOOP("None")),
+    std::make_pair(32, QT_TR_NOOP("Small (32x32)")),
+    std::make_pair(64, QT_TR_NOOP("Standard (64x64)")),
+    std::make_pair(128, QT_TR_NOOP("Large (128x128)")),
+    std::make_pair(256, QT_TR_NOOP("Full Size (256x256)")),
+}};
+
+constexpr std::array<const char*, 4> row_text_names{{
+    QT_TR_NOOP("Filename"),
+    QT_TR_NOOP("Filetype"),
+    QT_TR_NOOP("Title ID"),
+    QT_TR_NOOP("Title Name"),
+}};
+} // Anonymous namespace
+
 ConfigureGameList::ConfigureGameList(QWidget* parent)
     : QWidget(parent), ui(new Ui::ConfigureGameList) {
     ui->setupUi(this);
@@ -41,33 +58,39 @@ void ConfigureGameList::setConfiguration() {
         ui->row_2_text_combobox->findData(UISettings::values.row_2_text_id));
 }
 
-void ConfigureGameList::InitializeIconSizeComboBox() {
-    static const std::array<std::pair<u32, std::string>, 5> default_icon_sizes{{
-        std::make_pair(0, "None"),        std::make_pair(32, "Small"),
-        std::make_pair(64, "Standard"),   std::make_pair(128, "Large"),
-        std::make_pair(256, "Full Size"),
-    }};
+void ConfigureGameList::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+        return;
+    }
 
+    QWidget::changeEvent(event);
+}
+
+void ConfigureGameList::RetranslateUI() {
+    ui->retranslateUi(this);
+
+    for (int i = 0; i < ui->icon_size_combobox->count(); i++) {
+        ui->icon_size_combobox->setItemText(i, tr(default_icon_sizes[i].second));
+    }
+
+    for (int i = 0; i < ui->row_1_text_combobox->count(); i++) {
+        const QString name = tr(row_text_names[i]);
+
+        ui->row_1_text_combobox->setItemText(i, name);
+        ui->row_2_text_combobox->setItemText(i, name);
+    }
+}
+
+void ConfigureGameList::InitializeIconSizeComboBox() {
     for (const auto& size : default_icon_sizes) {
-        ui->icon_size_combobox->addItem(QString::fromStdString(size.second + " (" +
-                                                               std::to_string(size.first) + "x" +
-                                                               std::to_string(size.first) + ")"),
-                                        size.first);
+        ui->icon_size_combobox->addItem(size.second, size.first);
     }
 }
 
 void ConfigureGameList::InitializeRowComboBoxes() {
-    static const std::array<std::string, 4> row_text_names{{
-        "Filename",
-        "Filetype",
-        "Title ID",
-        "Title Name",
-    }};
-
     for (size_t i = 0; i < row_text_names.size(); ++i) {
-        ui->row_1_text_combobox->addItem(QString::fromStdString(row_text_names[i]),
-                                         QVariant::fromValue(i));
-        ui->row_2_text_combobox->addItem(QString::fromStdString(row_text_names[i]),
-                                         QVariant::fromValue(i));
+        ui->row_1_text_combobox->addItem(row_text_names[i], QVariant::fromValue(i));
+        ui->row_2_text_combobox->addItem(row_text_names[i], QVariant::fromValue(i));
     }
 }

--- a/src/yuzu/configuration/configure_gamelist.cpp
+++ b/src/yuzu/configuration/configure_gamelist.cpp
@@ -12,6 +12,33 @@ ConfigureGameList::ConfigureGameList(QWidget* parent)
     : QWidget(parent), ui(new Ui::ConfigureGameList) {
     ui->setupUi(this);
 
+    InitializeIconSizeComboBox();
+    InitializeRowComboBoxes();
+
+    this->setConfiguration();
+}
+
+ConfigureGameList::~ConfigureGameList() = default;
+
+void ConfigureGameList::applyConfiguration() {
+    UISettings::values.show_unknown = ui->show_unknown->isChecked();
+    UISettings::values.icon_size = ui->icon_size_combobox->currentData().toUInt();
+    UISettings::values.row_1_text_id = ui->row_1_text_combobox->currentData().toUInt();
+    UISettings::values.row_2_text_id = ui->row_2_text_combobox->currentData().toUInt();
+    Settings::Apply();
+}
+
+void ConfigureGameList::setConfiguration() {
+    ui->show_unknown->setChecked(UISettings::values.show_unknown);
+    ui->icon_size_combobox->setCurrentIndex(
+        ui->icon_size_combobox->findData(UISettings::values.icon_size));
+    ui->row_1_text_combobox->setCurrentIndex(
+        ui->row_1_text_combobox->findData(UISettings::values.row_1_text_id));
+    ui->row_2_text_combobox->setCurrentIndex(
+        ui->row_2_text_combobox->findData(UISettings::values.row_2_text_id));
+}
+
+void ConfigureGameList::InitializeIconSizeComboBox() {
     static const std::vector<std::pair<u32, std::string>> default_icon_sizes{
         std::make_pair(0, "None"),        std::make_pair(32, "Small"),
         std::make_pair(64, "Standard"),   std::make_pair(128, "Large"),
@@ -24,7 +51,9 @@ ConfigureGameList::ConfigureGameList(QWidget* parent)
                                                                std::to_string(size.first) + ")"),
                                         size.first);
     }
+}
 
+void ConfigureGameList::InitializeRowComboBoxes() {
     static const std::vector<std::string> row_text_names{
         "Filename",
         "Filetype",
@@ -38,26 +67,4 @@ ConfigureGameList::ConfigureGameList(QWidget* parent)
         ui->row_2_text_combobox->addItem(QString::fromStdString(row_text_names[i]),
                                          QVariant::fromValue(i));
     }
-
-    this->setConfiguration();
-}
-
-ConfigureGameList::~ConfigureGameList() {}
-
-void ConfigureGameList::setConfiguration() {
-    ui->show_unknown->setChecked(UISettings::values.show_unknown);
-    ui->icon_size_combobox->setCurrentIndex(
-        ui->icon_size_combobox->findData(UISettings::values.icon_size));
-    ui->row_1_text_combobox->setCurrentIndex(
-        ui->row_1_text_combobox->findData(UISettings::values.row_1_text_id));
-    ui->row_2_text_combobox->setCurrentIndex(
-        ui->row_2_text_combobox->findData(UISettings::values.row_2_text_id));
-}
-
-void ConfigureGameList::applyConfiguration() {
-    UISettings::values.show_unknown = ui->show_unknown->isChecked();
-    UISettings::values.icon_size = ui->icon_size_combobox->currentData().toUInt();
-    UISettings::values.row_1_text_id = ui->row_1_text_combobox->currentData().toUInt();
-    UISettings::values.row_2_text_id = ui->row_2_text_combobox->currentData().toUInt();
-    Settings::Apply();
 }

--- a/src/yuzu/configuration/configure_gamelist.h
+++ b/src/yuzu/configuration/configure_gamelist.h
@@ -23,6 +23,8 @@ public:
 private:
     void setConfiguration();
 
-private:
+    void InitializeIconSizeComboBox();
+    void InitializeRowComboBoxes();
+
     std::unique_ptr<Ui::ConfigureGameList> ui;
 };

--- a/src/yuzu/configuration/configure_gamelist.h
+++ b/src/yuzu/configuration/configure_gamelist.h
@@ -23,6 +23,9 @@ public:
 private:
     void setConfiguration();
 
+    void changeEvent(QEvent*) override;
+    void RetranslateUI();
+
     void InitializeIconSizeComboBox();
     void InitializeRowComboBoxes();
 


### PR DESCRIPTION
While we're at it, also hook up the dialog to handle dynamic translations automatically, by handling the LanguageChange event