### PR TITLE
kernel/errors: Amend invalid thread priority and invalid processor ID error codes

### DIFF
--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -21,6 +21,7 @@ enum {
     HandleTableFull = 105,
     InvalidMemoryState = 106,
     InvalidMemoryPermissions = 108,
+    InvalidThreadPriority = 112,
     InvalidProcessorId = 113,
     InvalidHandle = 114,
     InvalidCombination = 116,
@@ -36,7 +37,7 @@ enum {
 // WARNING: The kernel is quite inconsistent in it's usage of errors code. Make sure to always
 // double check that the code matches before re-using the constant.
 
-// TODO(bunnei): Replace these with correct errors for Switch OS
+// TODO(bunnei): Replace -1 with correct errors for Switch OS
 constexpr ResultCode ERR_HANDLE_TABLE_FULL(ErrorModule::Kernel, ErrCodes::HandleTableFull);
 constexpr ResultCode ERR_SESSION_CLOSED_BY_REMOTE(-1);
 constexpr ResultCode ERR_PORT_NAME_TOO_LONG(ErrorModule::Kernel, ErrCodes::TooLarge);
@@ -53,15 +54,16 @@ constexpr ResultCode ERR_INVALID_ADDRESS_STATE(ErrorModule::Kernel, ErrCodes::In
 constexpr ResultCode ERR_INVALID_MEMORY_PERMISSIONS(ErrorModule::Kernel,
                                                     ErrCodes::InvalidMemoryPermissions);
 constexpr ResultCode ERR_INVALID_HANDLE(ErrorModule::Kernel, ErrCodes::InvalidHandle);
+constexpr ResultCode ERR_INVALID_PROCESSOR_ID(ErrorModule::Kernel, ErrCodes::InvalidProcessorId);
 constexpr ResultCode ERR_INVALID_STATE(ErrorModule::Kernel, ErrCodes::InvalidState);
+constexpr ResultCode ERR_INVALID_THREAD_PRIORITY(ErrorModule::Kernel,
+                                                 ErrCodes::InvalidThreadPriority);
 constexpr ResultCode ERR_INVALID_POINTER(-1);
 constexpr ResultCode ERR_INVALID_OBJECT_ADDR(-1);
 constexpr ResultCode ERR_NOT_AUTHORIZED(-1);
 /// Alternate code returned instead of ERR_INVALID_HANDLE in some code paths.
 constexpr ResultCode ERR_INVALID_HANDLE_OS(-1);
 constexpr ResultCode ERR_NOT_FOUND(-1);
-constexpr ResultCode ERR_OUT_OF_RANGE(-1);
-constexpr ResultCode ERR_OUT_OF_RANGE_KERNEL(-1);
 constexpr ResultCode RESULT_TIMEOUT(ErrorModule::Kernel, ErrCodes::Timeout);
 /// Returned when Accept() is called on a port with no sessions to be accepted.
 constexpr ResultCode ERR_NO_PENDING_SESSIONS(-1);

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -378,7 +378,7 @@ static ResultCode GetThreadPriority(u32* priority, Handle handle) {
 /// Sets the priority for the specified thread
 static ResultCode SetThreadPriority(Handle handle, u32 priority) {
     if (priority > THREADPRIO_LOWEST) {
-        return ERR_OUT_OF_RANGE;
+        return ERR_INVALID_THREAD_PRIORITY;
     }
 
     auto& kernel = Core::System::GetInstance().Kernel();
@@ -523,7 +523,7 @@ static ResultCode CreateThread(Handle* out_handle, VAddr entry_point, u64 arg, V
     std::string name = fmt::format("unknown-{:X}", entry_point);
 
     if (priority > THREADPRIO_LOWEST) {
-        return ERR_OUT_OF_RANGE;
+        return ERR_INVALID_THREAD_PRIORITY;
     }
 
     SharedPtr<ResourceLimit>& resource_limit = Core::CurrentProcess()->resource_limit;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -544,8 +544,8 @@ static ResultCode CreateThread(Handle* out_handle, VAddr entry_point, u64 arg, V
     case THREADPROCESSORID_3:
         break;
     default:
-        ASSERT_MSG(false, "Unsupported thread processor ID: {}", processor_id);
-        break;
+        LOG_ERROR(Kernel_SVC, "Invalid thread processor ID: {}", processor_id);
+        return ERR_INVALID_PROCESSOR_ID;
     }
 
     auto& kernel = Core::System::GetInstance().Kernel();

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -227,12 +227,12 @@ ResultVal<SharedPtr<Thread>> Thread::Create(KernelCore& kernel, std::string name
     // Check if priority is in ranged. Lowest priority -> highest priority id.
     if (priority > THREADPRIO_LOWEST) {
         LOG_ERROR(Kernel_SVC, "Invalid thread priority: {}", priority);
-        return ERR_OUT_OF_RANGE;
+        return ERR_INVALID_THREAD_PRIORITY;
     }
 
     if (processor_id > THREADPROCESSORID_MAX) {
         LOG_ERROR(Kernel_SVC, "Invalid processor id: {}", processor_id);
-        return ERR_OUT_OF_RANGE_KERNEL;
+        return ERR_INVALID_PROCESSOR_ID;
     }
 
     // TODO(yuriks): Other checks, returning 0xD9001BEA


### PR DESCRIPTION
This also alters the behavior of CreateThread to return an error like the kernel does if the processor ID is out of range, rather than continuing onwards and (likely) performing hot garbage.