### PR TITLE
svc: Do nothing in svcOutputDebugString() if given a length of zero

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -273,7 +273,7 @@ static void Break(u64 reason, u64 info1, u64 info2) {
 }
 
 /// Used to output a message on a debug hardware unit - does nothing on a retail unit
-static void OutputDebugString(VAddr address, s32 len) {
+static void OutputDebugString(VAddr address, u64 len) {
     std::string str(len, '\0');
     Memory::ReadBlock(address, str.data(), str.size());
     LOG_DEBUG(Debug_Emulated, "{}", str);

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -274,6 +274,10 @@ static void Break(u64 reason, u64 info1, u64 info2) {
 
 /// Used to output a message on a debug hardware unit - does nothing on a retail unit
 static void OutputDebugString(VAddr address, u64 len) {
+    if (len == 0) {
+        return;
+    }
+
     std::string str(len, '\0');
     Memory::ReadBlock(address, str.data(), str.size());
     LOG_DEBUG(Debug_Emulated, "{}", str);

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -222,9 +222,9 @@ void SvcWrap() {
     func((s64)PARAM(0));
 }
 
-template <void func(u64, s32 len)>
+template <void func(u64, u64 len)>
 void SvcWrap() {
-    func(PARAM(0), (s32)(PARAM(1) & 0xFFFFFFFF));
+    func(PARAM(0), PARAM(1));
 }
 
 template <void func(u64, u64, u64)>


### PR DESCRIPTION
This avoids constructing a std::string and calling into Memory::ReadBlock() if a game decides to be silly with how it's calling the service function. It's unlikely, but it's a trivial case to avoid.