### PR TITLE
service: Use nested namespace specifiers where applicable

### DIFF
--- a/src/core/hle/service/acc/acc_su.h
+++ b/src/core/hle/service/acc/acc_su.h
@@ -6,8 +6,7 @@
 
 #include "core/hle/service/acc/acc.h"
 
-namespace Service {
-namespace Account {
+namespace Service::Account {
 
 class ACC_SU final : public Module::Interface {
 public:
@@ -16,5 +15,4 @@ public:
     ~ACC_SU() override;
 };
 
-} // namespace Account
-} // namespace Service
+} // namespace Service::Account

--- a/src/core/hle/service/nvflinger/buffer_queue.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue.cpp
@@ -9,8 +9,7 @@
 #include "core/core.h"
 #include "core/hle/service/nvflinger/buffer_queue.h"
 
-namespace Service {
-namespace NVFlinger {
+namespace Service::NVFlinger {
 
 BufferQueue::BufferQueue(u32 id, u64 layer_id) : id(id), layer_id(layer_id) {
     auto& kernel = Core::System::GetInstance().Kernel();
@@ -104,5 +103,4 @@ u32 BufferQueue::Query(QueryType type) {
     return 0;
 }
 
-} // namespace NVFlinger
-} // namespace Service
+} // namespace Service::NVFlinger

--- a/src/core/hle/service/nvflinger/buffer_queue.h
+++ b/src/core/hle/service/nvflinger/buffer_queue.h
@@ -15,8 +15,7 @@ namespace CoreTiming {
 struct EventType;
 }
 
-namespace Service {
-namespace NVFlinger {
+namespace Service::NVFlinger {
 
 struct IGBPBuffer {
     u32_le magic;
@@ -98,5 +97,4 @@ private:
     Kernel::SharedPtr<Kernel::Event> buffer_wait_event;
 };
 
-} // namespace NVFlinger
-} // namespace Service
+} // namespace Service::NVFlinger


### PR DESCRIPTION
There were a few places where nested namespace specifiers weren't being used where they could be within the service code. This amends that to make the namespacing a tiny bit more compact.