### PR TITLE
kernel/thread: Include thread-related enums within the kernel namespace

### DIFF
--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -15,6 +15,12 @@
 #include "core/hle/kernel/wait_object.h"
 #include "core/hle/result.h"
 
+namespace Kernel {
+
+class KernelCore;
+class Process;
+class Scheduler;
+
 enum ThreadPriority : u32 {
     THREADPRIO_HIGHEST = 0,       ///< Highest thread priority
     THREADPRIO_USERLAND_MAX = 24, ///< Highest thread priority for userland apps
@@ -53,12 +59,6 @@ enum class ThreadWakeupReason {
     Signal, // The thread was woken up by WakeupAllWaitingThreads due to an object signal.
     Timeout // The thread was woken up due to a wait timeout.
 };
-
-namespace Kernel {
-
-class KernelCore;
-class Process;
-class Scheduler;
 
 class Thread final : public WaitObject {
 public:

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -514,7 +514,7 @@ private:
                 ctx.SleepClientThread(
                     Kernel::GetCurrentThread(), "IHOSBinderDriver::DequeueBuffer", -1,
                     [=](Kernel::SharedPtr<Kernel::Thread> thread, Kernel::HLERequestContext& ctx,
-                        ThreadWakeupReason reason) {
+                        Kernel::ThreadWakeupReason reason) {
                         // Repeat TransactParcel DequeueBuffer when a buffer is available
                         auto buffer_queue = nv_flinger->GetBufferQueue(id);
                         boost::optional<u32> slot = buffer_queue->DequeueBuffer(width, height);

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -191,7 +191,7 @@ ResultStatus AppLoader_NRO::Load(Kernel::SharedPtr<Kernel::Process>& process) {
     process->svc_access_mask.set();
     process->resource_limit =
         kernel.ResourceLimitForCategory(Kernel::ResourceLimitCategory::APPLICATION);
-    process->Run(base_addr, THREADPRIO_DEFAULT, Memory::DEFAULT_STACK_SIZE);
+    process->Run(base_addr, Kernel::THREADPRIO_DEFAULT, Memory::DEFAULT_STACK_SIZE);
 
     is_loaded = true;
     return ResultStatus::Success;

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -157,7 +157,8 @@ ResultStatus AppLoader_NSO::Load(Kernel::SharedPtr<Kernel::Process>& process) {
     process->svc_access_mask.set();
     process->resource_limit =
         kernel.ResourceLimitForCategory(Kernel::ResourceLimitCategory::APPLICATION);
-    process->Run(Memory::PROCESS_IMAGE_VADDR, THREADPRIO_DEFAULT, Memory::DEFAULT_STACK_SIZE);
+    process->Run(Memory::PROCESS_IMAGE_VADDR, Kernel::THREADPRIO_DEFAULT,
+                 Memory::DEFAULT_STACK_SIZE);
 
     is_loaded = true;
     return ResultStatus::Success;

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -213,35 +213,35 @@ QString WaitTreeThread::GetText() const {
     const auto& thread = static_cast<const Kernel::Thread&>(object);
     QString status;
     switch (thread.status) {
-    case ThreadStatus::Running:
+    case Kernel::ThreadStatus::Running:
         status = tr("running");
         break;
-    case ThreadStatus::Ready:
+    case Kernel::ThreadStatus::Ready:
         status = tr("ready");
         break;
-    case ThreadStatus::WaitHLEEvent:
+    case Kernel::ThreadStatus::WaitHLEEvent:
         status = tr("waiting for HLE return");
         break;
-    case ThreadStatus::WaitSleep:
+    case Kernel::ThreadStatus::WaitSleep:
         status = tr("sleeping");
         break;
-    case ThreadStatus::WaitIPC:
+    case Kernel::ThreadStatus::WaitIPC:
         status = tr("waiting for IPC reply");
         break;
-    case ThreadStatus::WaitSynchAll:
-    case ThreadStatus::WaitSynchAny:
+    case Kernel::ThreadStatus::WaitSynchAll:
+    case Kernel::ThreadStatus::WaitSynchAny:
         status = tr("waiting for objects");
         break;
-    case ThreadStatus::WaitMutex:
+    case Kernel::ThreadStatus::WaitMutex:
         status = tr("waiting for mutex");
         break;
-    case ThreadStatus::WaitArb:
+    case Kernel::ThreadStatus::WaitArb:
         status = tr("waiting for address arbiter");
         break;
-    case ThreadStatus::Dormant:
+    case Kernel::ThreadStatus::Dormant:
         status = tr("dormant");
         break;
-    case ThreadStatus::Dead:
+    case Kernel::ThreadStatus::Dead:
         status = tr("dead");
         break;
     }
@@ -254,23 +254,23 @@ QString WaitTreeThread::GetText() const {
 QColor WaitTreeThread::GetColor() const {
     const auto& thread = static_cast<const Kernel::Thread&>(object);
     switch (thread.status) {
-    case ThreadStatus::Running:
+    case Kernel::ThreadStatus::Running:
         return QColor(Qt::GlobalColor::darkGreen);
-    case ThreadStatus::Ready:
+    case Kernel::ThreadStatus::Ready:
         return QColor(Qt::GlobalColor::darkBlue);
-    case ThreadStatus::WaitHLEEvent:
-    case ThreadStatus::WaitIPC:
+    case Kernel::ThreadStatus::WaitHLEEvent:
+    case Kernel::ThreadStatus::WaitIPC:
         return QColor(Qt::GlobalColor::darkRed);
-    case ThreadStatus::WaitSleep:
+    case Kernel::ThreadStatus::WaitSleep:
         return QColor(Qt::GlobalColor::darkYellow);
-    case ThreadStatus::WaitSynchAll:
-    case ThreadStatus::WaitSynchAny:
-    case ThreadStatus::WaitMutex:
-    case ThreadStatus::WaitArb:
+    case Kernel::ThreadStatus::WaitSynchAll:
+    case Kernel::ThreadStatus::WaitSynchAny:
+    case Kernel::ThreadStatus::WaitMutex:
+    case Kernel::ThreadStatus::WaitArb:
         return QColor(Qt::GlobalColor::red);
-    case ThreadStatus::Dormant:
+    case Kernel::ThreadStatus::Dormant:
         return QColor(Qt::GlobalColor::darkCyan);
-    case ThreadStatus::Dead:
+    case Kernel::ThreadStatus::Dead:
         return QColor(Qt::GlobalColor::gray);
     default:
         return WaitTreeItem::GetColor();
@@ -284,13 +284,13 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeThread::GetChildren() const {
 
     QString processor;
     switch (thread.processor_id) {
-    case ThreadProcessorId::THREADPROCESSORID_DEFAULT:
+    case Kernel::ThreadProcessorId::THREADPROCESSORID_DEFAULT:
         processor = tr("default");
         break;
-    case ThreadProcessorId::THREADPROCESSORID_0:
-    case ThreadProcessorId::THREADPROCESSORID_1:
-    case ThreadProcessorId::THREADPROCESSORID_2:
-    case ThreadProcessorId::THREADPROCESSORID_3:
+    case Kernel::ThreadProcessorId::THREADPROCESSORID_0:
+    case Kernel::ThreadProcessorId::THREADPROCESSORID_1:
+    case Kernel::ThreadProcessorId::THREADPROCESSORID_2:
+    case Kernel::ThreadProcessorId::THREADPROCESSORID_3:
         processor = tr("core %1").arg(thread.processor_id);
         break;
     default:
@@ -314,8 +314,8 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeThread::GetChildren() const {
     else
         list.push_back(std::make_unique<WaitTreeText>(tr("not waiting for mutex")));
 
-    if (thread.status == ThreadStatus::WaitSynchAny ||
-        thread.status == ThreadStatus::WaitSynchAll) {
+    if (thread.status == Kernel::ThreadStatus::WaitSynchAny ||
+        thread.status == Kernel::ThreadStatus::WaitSynchAll) {
         list.push_back(std::make_unique<WaitTreeObjectList>(thread.wait_objects,
                                                             thread.IsSleepingOnWaitAll()));
     }


### PR DESCRIPTION
Previously, these were sitting outside of the Kernel namespace, which doesn't really make sense, given they're related to the Thread class which is within the Kernel namespace. This gets a few identifiers out of the global namespace