### PR TITLE
audio_core/time_stretch: Silence truncation warnings in Process()

### DIFF
--- a/src/audio_core/time_stretch.cpp
+++ b/src/audio_core/time_stretch.cpp
@@ -61,8 +61,8 @@ size_t TimeStretcher::Process(const s16* in, size_t num_in, s16* out, size_t num
     LOG_DEBUG(Audio, "{:5}/{:5} ratio:{:0.6f} backlog:{:0.6f}", num_in, num_out, m_stretch_ratio,
               backlog_fullness);
 
-    m_sound_touch.putSamples(in, num_in);
-    return m_sound_touch.receiveSamples(out, num_out);
+    m_sound_touch.putSamples(in, static_cast<u32>(num_in));
+    return m_sound_touch.receiveSamples(out, static_cast<u32>(num_out));
 }
 
 } // namespace AudioCore


### PR DESCRIPTION
The SoundTouch API only accepts `uint` amount of samples.