### PR TITLE
gl_shader_decompiler: Get rid of variable shadowing within LEA instructions

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1510,8 +1510,6 @@ private:
             case OpCode::Id::LEA_IMM:
             case OpCode::Id::LEA_RZ:
             case OpCode::Id::LEA_HI: {
-                std::string op_a;
-                std::string op_b;
                 std::string op_c;
 
                 switch (opcode->GetId()) {


### PR DESCRIPTION
These variables are already defined within an outer scope.