### PR TITLE
services/sm: Amend error code constants

### DIFF
--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -15,6 +15,10 @@
 
 namespace Service::SM {
 
+constexpr ResultCode ERR_ALREADY_REGISTERED(ErrorModule::SM, 4);
+constexpr ResultCode ERR_INVALID_NAME(ErrorModule::SM, 6);
+constexpr ResultCode ERR_SERVICE_NOT_REGISTERED(ErrorModule::SM, 7);
+
 ServiceManager::ServiceManager() = default;
 ServiceManager::~ServiceManager() = default;
 
@@ -24,10 +28,10 @@ void ServiceManager::InvokeControlRequest(Kernel::HLERequestContext& context) {
 
 static ResultCode ValidateServiceName(const std::string& name) {
     if (name.size() <= 0 || name.size() > 8) {
-        return ERR_INVALID_NAME_SIZE;
+        return ERR_INVALID_NAME;
     }
     if (name.find('\0') != std::string::npos) {
-        return ERR_NAME_CONTAINS_NUL;
+        return ERR_INVALID_NAME;
     }
     return RESULT_SUCCESS;
 }

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -36,12 +36,6 @@ private:
     std::shared_ptr<ServiceManager> service_manager;
 };
 
-constexpr ResultCode ERR_SERVICE_NOT_REGISTERED(-1);
-constexpr ResultCode ERR_MAX_CONNECTIONS_REACHED(-1);
-constexpr ResultCode ERR_INVALID_NAME_SIZE(-1);
-constexpr ResultCode ERR_NAME_CONTAINS_NUL(-1);
-constexpr ResultCode ERR_ALREADY_REGISTERED(-1);
-
 class ServiceManager {
 public:
     static void InstallInterfaces(std::shared_ptr<ServiceManager> self);


### PR DESCRIPTION
Courtesy of @ogniK5377.

This also moves them into the cpp file and limits the visibility to where they're directly used. It also gets rid of unused or duplicate error codes.