### PR TITLE
audio_core: Replace includes with forward declarations where applicable.

### DIFF
--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -7,6 +7,7 @@
 
 #include "audio_core/sink.h"
 #include "audio_core/sink_details.h"
+#include "audio_core/sink_stream.h"
 #include "audio_core/stream.h"
 #include "common/assert.h"
 #include "common/logging/log.h"

--- a/src/audio_core/stream.h
+++ b/src/audio_core/stream.h
@@ -11,12 +11,15 @@
 #include <queue>
 
 #include "audio_core/buffer.h"
-#include "audio_core/sink_stream.h"
-#include "common/assert.h"
 #include "common/common_types.h"
-#include "core/core_timing.h"
+
+namespace CoreTiming {
+struct EventType;
+}
 
 namespace AudioCore {
+
+class SinkStream;
 
 /**
  * Represents an audio stream, which is a sequence of queued buffers, to be outputed by AudioOut

--- a/src/audio_core/time_stretch.h
+++ b/src/audio_core/time_stretch.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <array>
 #include <cstddef>
 #include <SoundTouch.h>
 #include "common/common_types.h"


### PR DESCRIPTION
Avoids propagating includes in headers where avoidable.