### PR TITLE
cubeb_sink: Get rid of variable shadowing within CubebSink's constructor

### DIFF
--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -119,10 +119,10 @@ CubebSink::CubebSink(std::string target_device_name) {
             LOG_WARNING(Audio_Sink, "Audio output device enumeration not supported");
         } else {
             const auto collection_end{collection.device + collection.count};
-            const auto device{std::find_if(collection.device, collection_end,
-                                           [&](const cubeb_device_info& device) {
-                                               return target_device_name == device.friendly_name;
-                                           })};
+            const auto device{
+                std::find_if(collection.device, collection_end, [&](const cubeb_device_info& info) {
+                    return target_device_name == info.friendly_name;
+                })};
             if (device != collection_end) {
                 output_device = device->devid;
             }


### PR DESCRIPTION
The parameter of the lambda was shadowing the variable that was being assigned to.