### PR TITLE
[HACK] Preliminary implementation of LDG

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -27,6 +27,8 @@ add_library(video_core STATIC
     renderer_base.h
     renderer_opengl/gl_buffer_cache.cpp
     renderer_opengl/gl_buffer_cache.h
+    renderer_opengl/gl_global_cache.cpp
+    renderer_opengl/gl_global_cache.h
     renderer_opengl/gl_primitive_assembler.cpp
     renderer_opengl/gl_primitive_assembler.h
     renderer_opengl/gl_rasterizer.cpp

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -395,6 +395,15 @@ Texture::FullTextureInfo Maxwell3D::GetStageTexture(Regs::ShaderStage stage,
     return tex_info;
 }
 
+std::string Maxwell3D::CreateGlobalMemoryRegion(std::tuple<u64, u64, u64> iadd_data) {
+    state.global_memory_uniforms.emplace(std::get<1>(iadd_data), std::get<2>(iadd_data));
+    return fmt::format("global_memory_region_{}", state.global_memory_uniforms.size() - 1);
+}
+
+std::set<std::pair<u64, u64>> Maxwell3D::ListGlobalMemoryRegions() const {
+    return state.global_memory_uniforms;
+}
+
 u32 Maxwell3D::GetRegisterValue(u32 method) const {
     ASSERT_MSG(method < Regs::NUM_REGS, "Invalid Maxwell3D register");
     return regs.reg_array[method];

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -246,6 +246,11 @@ void Maxwell3D::DrawArrays() {
     }
 }
 
+bool operator<(const Maxwell3D::GlobalMemoryDescriptor& lhs,
+               const Maxwell3D::GlobalMemoryDescriptor& rhs) {
+    return std::tie(lhs.cbuf_index, lhs.cbuf_offset) < std::tie(rhs.cbuf_index, rhs.cbuf_offset);
+}
+
 void Maxwell3D::ProcessCBBind(Regs::ShaderStage stage) {
     // Bind the buffer currently in CB_ADDRESS to the specified index in the desired shader stage.
     auto& shader = state.shader_stages[static_cast<std::size_t>(stage)];
@@ -393,15 +398,6 @@ Texture::FullTextureInfo Maxwell3D::GetStageTexture(Regs::ShaderStage stage,
     }
 
     return tex_info;
-}
-
-std::string Maxwell3D::CreateGlobalMemoryRegion(std::tuple<u64, u64, u64> iadd_data) {
-    state.global_memory_uniforms.emplace(std::get<1>(iadd_data), std::get<2>(iadd_data));
-    return fmt::format("global_memory_region_{}", state.global_memory_uniforms.size() - 1);
-}
-
-std::set<std::pair<u64, u64>> Maxwell3D::ListGlobalMemoryRegions() const {
-    return state.global_memory_uniforms;
 }
 
 u32 Maxwell3D::GetRegisterValue(u32 method) const {

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <set>
 #include <unordered_map>
 #include <vector>
 #include "common/assert.h"
@@ -961,6 +962,8 @@ public:
 
         std::array<ShaderStageInfo, Regs::MaxShaderStage> shader_stages;
         u32 current_instance = 0; ///< Current instance to be used to simulate instanced rendering.
+
+        std::set<std::pair<u64, u64>> global_memory_uniforms;
     };
 
     State state{};
@@ -977,6 +980,9 @@ public:
 
     /// Returns the texture information for a specific texture in a specific shader stage.
     Texture::FullTextureInfo GetStageTexture(Regs::ShaderStage stage, std::size_t offset) const;
+
+    std::string CreateGlobalMemoryRegion(std::tuple<u64, u64, u64> iadd_data);
+    std::set<std::pair<u64, u64>> ListGlobalMemoryRegions() const;
 
 private:
     VideoCore::RasterizerInterface& rasterizer;

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -32,6 +32,12 @@ public:
     explicit Maxwell3D(VideoCore::RasterizerInterface& rasterizer, MemoryManager& memory_manager);
     ~Maxwell3D() = default;
 
+    /// Structure representing a global memory region
+    struct GlobalMemoryDescriptor {
+        u64 cbuf_index;
+        u64 cbuf_offset;
+    };
+
     /// Register structure of the Maxwell3D engine.
     /// TODO(Subv): This structure will need to be made bigger as more registers are discovered.
     struct Regs {
@@ -963,7 +969,7 @@ public:
         std::array<ShaderStageInfo, Regs::MaxShaderStage> shader_stages;
         u32 current_instance = 0; ///< Current instance to be used to simulate instanced rendering.
 
-        std::set<std::pair<u64, u64>> global_memory_uniforms;
+        std::set<GlobalMemoryDescriptor> global_memory_uniforms;
     };
 
     State state{};
@@ -980,9 +986,6 @@ public:
 
     /// Returns the texture information for a specific texture in a specific shader stage.
     Texture::FullTextureInfo GetStageTexture(Regs::ShaderStage stage, std::size_t offset) const;
-
-    std::string CreateGlobalMemoryRegion(std::tuple<u64, u64, u64> iadd_data);
-    std::set<std::pair<u64, u64>> ListGlobalMemoryRegions() const;
 
 private:
     VideoCore::RasterizerInterface& rasterizer;
@@ -1028,6 +1031,9 @@ private:
     /// Handles a write to the VERTEX_END_GL register, triggering a draw.
     void DrawArrays();
 };
+
+bool operator<(const Maxwell3D::GlobalMemoryDescriptor& lhs,
+               const Maxwell3D::GlobalMemoryDescriptor& rhs);
 
 #define ASSERT_REG_POSITION(field_name, position)                                                  \
     static_assert(offsetof(Maxwell3D::Regs, field_name) == position * 4,                           \

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -205,6 +205,8 @@ enum class UniformType : u64 {
     SignedShort = 3,
     Single = 4,
     Double = 5,
+    Quad = 6,
+    UnsignedQuad = 7,
 };
 
 enum class IMinMaxExchange : u64 {
@@ -657,6 +659,14 @@ union Instruction {
         BitField<48, 3, UniformType> type;
         BitField<44, 2, u64> unknown;
     } ld_c;
+
+    union {
+        BitField<48, 3, UniformType> type;
+        BitField<46, 2, u64> cache_mode;
+        BitField<20, 24, s64> offset_immediate;
+        BitField<8, 8, Register> offset_register;
+        BitField<0, 8, Register> output;
+    } ld_g;
 
     union {
         BitField<0, 3, u64> pred0;

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -661,11 +661,9 @@ union Instruction {
     } ld_c;
 
     union {
-        BitField<48, 3, UniformType> type;
+        BitField<48, 3, UniformType> size;
         BitField<46, 2, u64> cache_mode;
         BitField<20, 24, s64> offset_immediate;
-        BitField<8, 8, Register> offset_register;
-        BitField<0, 8, Register> output;
     } ld_g;
 
     union {

--- a/src/video_core/renderer_opengl/gl_global_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_global_cache.cpp
@@ -1,0 +1,55 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/assert.h"
+#include "core/core.h"
+#include "core/memory.h"
+#include "video_core/engines/maxwell_3d.h"
+#include "video_core/renderer_opengl/gl_global_cache.h"
+#include "video_core/renderer_opengl/gl_shader_cache.h"
+#include "video_core/renderer_opengl/gl_shader_manager.h"
+#include "video_core/utils.h"
+
+namespace OpenGL {
+
+CachedGlobalRegion::CachedGlobalRegion(VAddr addr, u32 size) : addr{addr}, size{size} {
+    std::vector<u8> new_data(size);
+    Memory::ReadBlock(addr, new_data.data(), new_data.size());
+
+    buffer.Create();
+    glBindBuffer(GL_UNIFORM_BUFFER, buffer.handle);
+    glBufferData(GL_UNIFORM_BUFFER, new_data.size(), new_data.data(), GL_STATIC_READ);
+
+    VideoCore::LabelGLObject(GL_BUFFER, buffer.handle, addr);
+}
+
+GlobalRegion GlobalRegionCacheOpenGL::GetGlobalRegion(
+    Tegra::Engines::Maxwell3D::GlobalMemoryDescriptor global_region,
+    Tegra::Engines::Maxwell3D::Regs::ShaderStage stage) {
+    auto& gpu{Core::System::GetInstance().GPU()};
+    const auto cbufs = gpu.Maxwell3D().state.shader_stages[static_cast<u64>(stage)];
+    const auto cbuf_addr{gpu.MemoryManager().GpuToCpuAddress(
+        cbufs.const_buffers[global_region.cbuf_index].address + global_region.cbuf_offset)};
+
+    ASSERT(cbuf_addr != boost::none);
+
+    const auto actual_addr_gpu = Memory::Read64(cbuf_addr.get());
+    const auto size = Memory::Read32(cbuf_addr.get() + 8);
+    const auto actual_addr{gpu.MemoryManager().GpuToCpuAddress(actual_addr_gpu)};
+
+    ASSERT(actual_addr != boost::none);
+
+    // Look up global region in the cache based on address
+    GlobalRegion region{TryGet(*actual_addr)};
+
+    if (!region) {
+        // No global region found - create a new one
+        region = std::make_shared<CachedGlobalRegion>(*actual_addr, size);
+        Register(region);
+    }
+
+    return region;
+}
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_global_cache.h
+++ b/src/video_core/renderer_opengl/gl_global_cache.h
@@ -1,0 +1,57 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <map>
+#include <memory>
+
+#include "common/common_types.h"
+#include "video_core/rasterizer_cache.h"
+#include "video_core/renderer_opengl/gl_resource_manager.h"
+#include "video_core/renderer_opengl/gl_shader_gen.h"
+
+namespace OpenGL {
+
+class CachedGlobalRegion;
+using GlobalRegion = std::shared_ptr<CachedGlobalRegion>;
+using Maxwell = Tegra::Engines::Maxwell3D::Regs;
+
+class CachedGlobalRegion final : public RasterizerCacheObject {
+public:
+    CachedGlobalRegion(VAddr addr, u32 size);
+
+    /// Gets the address of the shader in guest memory, required for cache management
+    VAddr GetAddr() const {
+        return addr;
+    }
+
+    /// Gets the size of the shader in guest memory, required for cache management
+    std::size_t GetSizeInBytes() const {
+        return size;
+    }
+
+    /// Gets the GL program handle for the buffer
+    GLuint GetBufferHandle() const {
+        return buffer.handle;
+    }
+
+    // We do not have to flush this cache as things in it are never modified by us.
+    void Flush() override {}
+
+private:
+    VAddr addr;
+    u32 size;
+
+    OGLBuffer buffer;
+};
+
+class GlobalRegionCacheOpenGL final : public RasterizerCache<GlobalRegion> {
+public:
+    /// Gets the current specified shader stage program
+    GlobalRegion GetGlobalRegion(Tegra::Engines::Maxwell3D::GlobalMemoryDescriptor descriptor,
+                                 Tegra::Engines::Maxwell3D::Regs::ShaderStage stage);
+};
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -263,6 +263,7 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
     // shaders. The constbuffer bindpoint starts after the shader stage configuration bind points.
     u32 current_constbuffer_bindpoint = Tegra::Engines::Maxwell3D::Regs::MaxShaderStage;
     u32 current_texture_bindpoint = 0;
+    u32 current_global_bindpoint = 0;
 
     for (std::size_t index = 0; index < Maxwell::MaxShaderProgram; ++index) {
         const auto& shader_config = gpu.regs.shader_config[index];
@@ -327,6 +328,45 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
         if (program == Maxwell::ShaderProgram::VertexA) {
             // VertexB was combined with VertexA, so we skip the VertexB iteration
             index++;
+        }
+
+        auto& maxwell3d{Core::System::GetInstance().GPU().Maxwell3D()};
+        const auto regions = maxwell3d.ListGlobalMemoryRegions();
+        size_t i = 0;
+        for (const auto& global_region : regions) {
+            auto& gpu{Core::System::GetInstance().GPU()};
+            const auto cbufs = gpu.Maxwell3D().state.shader_stages[static_cast<u64>(stage)];
+            const auto cbuf_addr{gpu.MemoryManager().GpuToCpuAddress(
+                cbufs.const_buffers[global_region.first].address + global_region.second)};
+
+            ASSERT(cbuf_addr != boost::none);
+
+            const auto actual_addr_gpu = Memory::Read64(cbuf_addr.get());
+            const auto size = Memory::Read32(cbuf_addr.get() + 8);
+            const auto actual_addr{gpu.MemoryManager().GpuToCpuAddress(actual_addr_gpu)};
+
+            ASSERT(actual_addr != boost::none);
+
+            const auto uniform_name = fmt::format("global_memory_region_declblock_{}", i);
+            const auto b_index = glGetProgramResourceIndex(shader->GetProgramHandle(),
+                                                           GL_UNIFORM_BLOCK, uniform_name.c_str());
+            if (b_index != GL_INVALID_INDEX) {
+
+                std::vector<u8> new_data(size);
+                Memory::ReadBlock(actual_addr.get(), new_data.data(), new_data.size());
+
+                GLuint gm_ubo{};
+                glGenBuffers(1, &gm_ubo);
+                glBindBuffer(GL_UNIFORM_BUFFER, gm_ubo);
+                glBufferData(GL_UNIFORM_BUFFER, new_data.size(), new_data.data(), GL_STATIC_READ);
+
+                glBindBufferBase(GL_UNIFORM_BUFFER, current_constbuffer_bindpoint, gm_ubo);
+                glUniformBlockBinding(shader->GetProgramHandle(), b_index,
+                                      current_constbuffer_bindpoint);
+                ++current_constbuffer_bindpoint;
+            }
+
+            ++i;
         }
     }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -263,7 +263,6 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
     // shaders. The constbuffer bindpoint starts after the shader stage configuration bind points.
     u32 current_constbuffer_bindpoint = Tegra::Engines::Maxwell3D::Regs::MaxShaderStage;
     u32 current_texture_bindpoint = 0;
-    u32 current_global_bindpoint = 0;
 
     for (std::size_t index = 0; index < Maxwell::MaxShaderProgram; ++index) {
         const auto& shader_config = gpu.regs.shader_config[index];
@@ -331,37 +330,19 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
         }
 
         auto& maxwell3d{Core::System::GetInstance().GPU().Maxwell3D()};
-        const auto regions = maxwell3d.ListGlobalMemoryRegions();
+        auto& regions = maxwell3d.state.global_memory_uniforms;
         size_t i = 0;
         for (const auto& global_region : regions) {
-            auto& gpu{Core::System::GetInstance().GPU()};
-            const auto cbufs = gpu.Maxwell3D().state.shader_stages[static_cast<u64>(stage)];
-            const auto cbuf_addr{gpu.MemoryManager().GpuToCpuAddress(
-                cbufs.const_buffers[global_region.first].address + global_region.second)};
-
-            ASSERT(cbuf_addr != boost::none);
-
-            const auto actual_addr_gpu = Memory::Read64(cbuf_addr.get());
-            const auto size = Memory::Read32(cbuf_addr.get() + 8);
-            const auto actual_addr{gpu.MemoryManager().GpuToCpuAddress(actual_addr_gpu)};
-
-            ASSERT(actual_addr != boost::none);
+            const auto region = global_cache.GetGlobalRegion(
+                global_region, static_cast<Maxwell::ShaderStage>(stage));
 
             const auto uniform_name = fmt::format("global_memory_region_declblock_{}", i);
-            const auto b_index = glGetProgramResourceIndex(shader->GetProgramHandle(),
+            const auto b_index = glGetProgramResourceIndex(shader->GetProgramHandle(primitive_mode),
                                                            GL_UNIFORM_BLOCK, uniform_name.c_str());
             if (b_index != GL_INVALID_INDEX) {
-
-                std::vector<u8> new_data(size);
-                Memory::ReadBlock(actual_addr.get(), new_data.data(), new_data.size());
-
-                GLuint gm_ubo{};
-                glGenBuffers(1, &gm_ubo);
-                glBindBuffer(GL_UNIFORM_BUFFER, gm_ubo);
-                glBufferData(GL_UNIFORM_BUFFER, new_data.size(), new_data.data(), GL_STATIC_READ);
-
-                glBindBufferBase(GL_UNIFORM_BUFFER, current_constbuffer_bindpoint, gm_ubo);
-                glUniformBlockBinding(shader->GetProgramHandle(), b_index,
+                glBindBufferBase(GL_UNIFORM_BUFFER, current_constbuffer_bindpoint,
+                                 region->GetBufferHandle());
+                glUniformBlockBinding(shader->GetProgramHandle(primitive_mode), b_index,
                                       current_constbuffer_bindpoint);
                 ++current_constbuffer_bindpoint;
             }
@@ -688,6 +669,7 @@ void RasterizerOpenGL::InvalidateRegion(VAddr addr, u64 size) {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
     res_cache.InvalidateRegion(addr, size);
     shader_cache.InvalidateRegion(addr, size);
+    global_cache.InvalidateRegion(addr, size);
     buffer_cache.InvalidateRegion(addr, size);
 }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -23,6 +23,7 @@
 #include "video_core/rasterizer_cache.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/gl_buffer_cache.h"
+#include "video_core/renderer_opengl/gl_global_cache.h"
 #include "video_core/renderer_opengl/gl_primitive_assembler.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
@@ -183,6 +184,7 @@ private:
 
     RasterizerCacheOpenGL res_cache;
     ShaderCacheOpenGL shader_cache;
+    GlobalRegionCacheOpenGL global_cache;
 
     Core::Frontend::EmuWindow& emu_window;
 

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -12,6 +12,7 @@
 
 #include "common/assert.h"
 #include "common/common_types.h"
+#include "core/core.h"
 #include "video_core/engines/shader_bytecode.h"
 #include "video_core/engines/shader_header.h"
 #include "video_core/renderer_opengl/gl_rasterizer.h"
@@ -604,6 +605,18 @@ private:
         }
         declarations.AddNewLine();
     }
+
+        const auto& regions{
+            Core::System::GetInstance().GPU().Maxwell3D().ListGlobalMemoryRegions()};
+        for (size_t i = 0; i < regions.size(); ++i) {
+            declarations.AddLine("layout(std140) uniform " +
+                                 fmt::format("global_memory_region_declblock_{}", i));
+            declarations.AddLine('{');
+            declarations.AddLine("    vec4 global_memory_region_" + std::to_string(i) + "[0x400];");
+            declarations.AddLine("};");
+            declarations.AddNewLine();
+        }
+        declarations.AddNewLine();
 
     /// Generates declarations for samplers.
     void GenerateSamplers() {
@@ -1520,6 +1533,11 @@ private:
                 } else {
                     op_b += regs.GetUniform(instr.cbuf34.index, instr.cbuf34.offset,
                                             GLSLRegister::Type::Integer);
+                    if (opcode->GetId() == OpCode::Id::IADD_C) {
+                        s_last_iadd = last_iadd;
+                        last_iadd = std::make_tuple<Register, u64, u64>(
+                            instr.gpr8.Value(), instr.cbuf34.index, instr.cbuf34.offset);
+                    }
                 }
             }
 
@@ -2512,6 +2530,64 @@ private:
                 shader.AddLine('}');
                 break;
             }
+            case OpCode::Id::LDG: {
+                // Determine number of GPRs to fill with data
+                u64 count = 1;
+
+                switch (instr.ld_g.type) {
+                case Tegra::Shader::UniformType::Single:
+                    count = 1;
+                    break;
+                case Tegra::Shader::UniformType::Double:
+                    count = 2;
+                    break;
+                case Tegra::Shader::UniformType::Quad:
+                case Tegra::Shader::UniformType::UnsignedQuad:
+                    count = 4;
+                    break;
+                default:
+                    UNREACHABLE_MSG("Unimplemented LDG size!");
+                }
+
+                auto [gpr_index, index, offset] = last_iadd;
+
+                // The last IADD might be the upper u32 of address, so instead take the one before
+                // that.
+                if (gpr_index == 0xFF)
+                    std::tie(gpr_index, index, offset) = s_last_iadd;
+
+                const auto gpr = regs.GetRegisterAsInteger(gpr_index);
+                const auto constbuffer =
+                    regs.GetUniform(index, offset, GLSLRegister::Type::UnsignedInteger);
+                const auto memory =
+                    Core::System::GetInstance().GPU().Maxwell3D().CreateGlobalMemoryRegion(
+                        {0, index, offset * 4});
+
+                const auto immediate = std::to_string(instr.ld_g.offset_immediate.Value());
+                const auto o_register =
+                    regs.GetRegisterAsInteger(instr.ld_g.offset_register, 0, false);
+                const auto address = "( " + immediate + " + " + o_register + " )";
+                const auto base_sub = address + " - " + constbuffer;
+
+                // New scope to prevent potential conflicts
+                shader.AddLine("{");
+                ++shader.scope;
+
+                shader.AddLine("uint final_offset = " + base_sub + ";");
+                for (size_t out = 0; out < count; ++out) {
+                    const u64 reg_id = instr.ld_g.output.Value() + out;
+                    const auto this_memory =
+                        fmt::format("{}[(final_offset + {}) / 16][((final_offset + {}) / 4) % 4]",
+                                    memory, out * 4, out * 4);
+
+                    regs.SetRegisterToFloat(reg_id, 0, this_memory, 1, 1);
+                }
+
+                --shader.scope;
+                shader.AddLine("}");
+
+                break;
+            }
             default: {
                 LOG_CRITICAL(HW_GPU, "Unhandled memory instruction: {}", opcode->GetName());
                 UNREACHABLE();
@@ -3206,9 +3282,12 @@ private:
     ShaderWriter declarations;
     GLSLRegisterManager regs{shader, declarations, stage, suffix, header};
 
+    std::tuple<Register, u64, u64> last_iadd{};
+    std::tuple<Register, u64, u64> s_last_iadd{};
+
     // Declarations
     std::set<std::string> declr_predicates;
-}; // namespace Decompiler
+};
 
 std::string GetCommonDeclarations() {
     return fmt::format("#define MAX_CONSTBUFFER_ELEMENTS {}\n",

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -487,6 +487,7 @@ public:
         GenerateInputAttrs();
         GenerateOutputAttrs();
         GenerateConstBuffers();
+        GenerateGlobalRegions();
         GenerateSamplers();
         GenerateGeometry();
     }
@@ -606,8 +607,10 @@ private:
         declarations.AddNewLine();
     }
 
+    /// Generates declarations for global memory regions.
+    void GenerateGlobalRegions() {
         const auto& regions{
-            Core::System::GetInstance().GPU().Maxwell3D().ListGlobalMemoryRegions()};
+            Core::System::GetInstance().GPU().Maxwell3D().state.global_memory_uniforms};
         for (size_t i = 0; i < regions.size(); ++i) {
             declarations.AddLine("layout(std140) uniform " +
                                  fmt::format("global_memory_region_declblock_{}", i));
@@ -617,6 +620,7 @@ private:
             declarations.AddNewLine();
         }
         declarations.AddNewLine();
+    }
 
     /// Generates declarations for samplers.
     void GenerateSamplers() {
@@ -1535,8 +1539,8 @@ private:
                                             GLSLRegister::Type::Integer);
                     if (opcode->GetId() == OpCode::Id::IADD_C) {
                         s_last_iadd = last_iadd;
-                        last_iadd = std::make_tuple<Register, u64, u64>(
-                            instr.gpr8.Value(), instr.cbuf34.index, instr.cbuf34.offset);
+                        last_iadd = IADDReference{instr.gpr8.Value(), instr.cbuf34.index,
+                                                  instr.cbuf34.offset};
                     }
                 }
             }
@@ -2534,7 +2538,7 @@ private:
                 // Determine number of GPRs to fill with data
                 u64 count = 1;
 
-                switch (instr.ld_g.type) {
+                switch (instr.ld_g.size) {
                 case Tegra::Shader::UniformType::Single:
                     count = 1;
                     break;
@@ -2553,29 +2557,37 @@ private:
 
                 // The last IADD might be the upper u32 of address, so instead take the one before
                 // that.
-                if (gpr_index == 0xFF)
-                    std::tie(gpr_index, index, offset) = s_last_iadd;
+                if (gpr_index == Register::ZeroIndex) {
+                    gpr_index = s_last_iadd.out;
+                    index = s_last_iadd.cbuf_index;
+                    offset = s_last_iadd.cbuf_offset;
+                }
 
                 const auto gpr = regs.GetRegisterAsInteger(gpr_index);
                 const auto constbuffer =
                     regs.GetUniform(index, offset, GLSLRegister::Type::UnsignedInteger);
-                const auto memory =
-                    Core::System::GetInstance().GPU().Maxwell3D().CreateGlobalMemoryRegion(
-                        {0, index, offset * 4});
+
+                Core::System::GetInstance().GPU().Maxwell3D().state.global_memory_uniforms.insert(
+                    {index, offset * 4});
+                const auto memory = fmt::format("global_memory_region_{}",
+                                                Core::System::GetInstance()
+                                                        .GPU()
+                                                        .Maxwell3D()
+                                                        .state.global_memory_uniforms.size() -
+                                                    1);
 
                 const auto immediate = std::to_string(instr.ld_g.offset_immediate.Value());
-                const auto o_register =
-                    regs.GetRegisterAsInteger(instr.ld_g.offset_register, 0, false);
+                const auto o_register = regs.GetRegisterAsInteger(instr.gpr8, 0, false);
                 const auto address = "( " + immediate + " + " + o_register + " )";
                 const auto base_sub = address + " - " + constbuffer;
 
                 // New scope to prevent potential conflicts
-                shader.AddLine("{");
+                shader.AddLine('{');
                 ++shader.scope;
 
                 shader.AddLine("uint final_offset = " + base_sub + ";");
                 for (size_t out = 0; out < count; ++out) {
-                    const u64 reg_id = instr.ld_g.output.Value() + out;
+                    const u64 reg_id = instr.gpr0.Value() + out;
                     const auto this_memory =
                         fmt::format("{}[(final_offset + {}) / 16][((final_offset + {}) / 4) % 4]",
                                     memory, out * 4, out * 4);
@@ -2584,7 +2596,7 @@ private:
                 }
 
                 --shader.scope;
-                shader.AddLine("}");
+                shader.AddLine('}');
 
                 break;
             }
@@ -3282,8 +3294,14 @@ private:
     ShaderWriter declarations;
     GLSLRegisterManager regs{shader, declarations, stage, suffix, header};
 
-    std::tuple<Register, u64, u64> last_iadd{};
-    std::tuple<Register, u64, u64> s_last_iadd{};
+    struct IADDReference {
+        Register out;
+        u64 cbuf_index;
+        u64 cbuf_offset;
+    };
+
+    IADDReference last_iadd{};
+    IADDReference s_last_iadd{};
 
     // Declarations
     std::set<std::string> declr_predicates;


### PR DESCRIPTION
Massive thanks to @gdkchan for the impl idea and tons of help in the beginning, @Subv for bug fixes and help at the end, and @bunnei for reminding me how to read from memory.

Works by approximating the value of the final address using the last IADD_C operation and then reading 16kb following that address. Best way to describe it is a 'hackeuristic'

My current understanding of font vertex shaders is that:
`IADD_C ...`
`IADD_C ...`
`<...>`
`LDG [R0], R0`

Where the two IADDs are to calculate upper and lower of the final offset. This works by taking the constbuffer operand of the lower one (high is always 0 is testing, ignored for now) and reading 16kb (max ubo size) from that into a UBO and presenting that to the shader.

Works in:
- SMO
- BotW
- ARMS

Doesn't work in:
- Splatoon 2
- Mario Tennis Aces
- Some parts in game in SMO (background text in map)

Current issues that need to be resolved:
- [ ] Games that render rectangles instead of text (list above)
- [x] Some sort of caching. Currently has rampant RAM usage and tons of `OpenGL using system RAM` errors.
- [x] Profile for performance impact

Overall, when it does work its pretty cool:
![botw2](https://user-images.githubusercontent.com/5064800/45581347-48aad700-b86a-11e8-8932-e78d9a1f48ea.PNG)
![arms](https://user-images.githubusercontent.com/5064800/45581349-4b0d3100-b86a-11e8-9e61-1b91bb599d78.PNG)
![smo2](https://user-images.githubusercontent.com/5064800/45581353-52ccd580-b86a-11e8-8a4e-fb36ad59a0ef.PNG)

Not working results in rectangles for characters:
![splatoonbooot](https://user-images.githubusercontent.com/5064800/45581833-9d068480-b873-11e8-9057-0051913966d1.PNG)

