### PR TITLE
Invalid default value of username in yuzu_cmd

### DIFF
--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -555,9 +555,11 @@ VirtualFile RegisteredCacheUnion::GetEntryUnparsed(RegisteredCacheEntry entry) c
 
 VirtualFile RegisteredCacheUnion::GetEntryRaw(u64 title_id, ContentRecordType type) const {
     for (const auto& c : caches) {
-        const auto res = c->GetEntryRaw(title_id, type);
-        if (res != nullptr)
-            return res;
+        if (c != nullptr) {
+            const auto res = c->GetEntryRaw(title_id, type);
+            if (res != nullptr)
+                return res;
+        }
     }
 
     return nullptr;

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -555,11 +555,12 @@ VirtualFile RegisteredCacheUnion::GetEntryUnparsed(RegisteredCacheEntry entry) c
 
 VirtualFile RegisteredCacheUnion::GetEntryRaw(u64 title_id, ContentRecordType type) const {
     for (const auto& c : caches) {
-        if (c != nullptr) {
-            const auto res = c->GetEntryRaw(title_id, type);
-            if (res != nullptr)
-                return res;
+        if (c == nullptr) {
+            continue;
         }
+        const auto res = c->GetEntryRaw(title_id, type);
+        if (res != nullptr)
+            return res;
     }
 
     return nullptr;

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -555,9 +555,6 @@ VirtualFile RegisteredCacheUnion::GetEntryUnparsed(RegisteredCacheEntry entry) c
 
 VirtualFile RegisteredCacheUnion::GetEntryRaw(u64 title_id, ContentRecordType type) const {
     for (const auto& c : caches) {
-        if (c == nullptr) {
-            continue;
-        }
         const auto res = c->GetEntryRaw(title_id, type);
         if (res != nullptr)
             return res;

--- a/src/core/hle/service/acc/profile_manager.cpp
+++ b/src/core/hle/service/acc/profile_manager.cpp
@@ -92,6 +92,8 @@ ResultCode ProfileManager::CreateNewUser(UUID uuid, const ProfileUsername& usern
 /// we're loading a string straight from the config
 ResultCode ProfileManager::CreateNewUser(UUID uuid, const std::string& username) {
     ProfileUsername username_output;
+
+    ASSERT(username != "");
     if (username.size() > username_output.size()) {
         std::copy_n(username.begin(), username_output.size(), username_output.begin());
     } else {

--- a/src/core/hle/service/acc/profile_manager.cpp
+++ b/src/core/hle/service/acc/profile_manager.cpp
@@ -25,7 +25,7 @@ const UUID& UUID::Generate() {
 ProfileManager::ProfileManager() {
     // TODO(ogniK): Create the default user we have for now until loading/saving users is added
     auto user_uuid = UUID{1, 0};
-    CreateNewUser(user_uuid, Settings::values.username);
+    ASSERT(CreateNewUser(user_uuid, Settings::values.username).IsSuccess());
     OpenUser(user_uuid);
 }
 
@@ -91,9 +91,8 @@ ResultCode ProfileManager::CreateNewUser(UUID uuid, const ProfileUsername& usern
 /// specifically by allowing an std::string for the username. This is required specifically since
 /// we're loading a string straight from the config
 ResultCode ProfileManager::CreateNewUser(UUID uuid, const std::string& username) {
-    ProfileUsername username_output;
+    ProfileUsername username_output{};
 
-    ASSERT(username != "");
     if (username.size() > username_output.size()) {
         std::copy_n(username.begin(), username_output.size(), username_output.begin());
     } else {

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -126,7 +126,8 @@ void Config::ReadValues() {
     // System
     Settings::values.use_docked_mode = sdl2_config->GetBoolean("System", "use_docked_mode", false);
     Settings::values.username = sdl2_config->Get("System", "username", "yuzu");
-    Settings::values.username = Settings::values.username == "" ? "yuzu" : Settings::values.username;
+    Settings::values.username =
+        Settings::values.username == "" ? "yuzu" : Settings::values.username;
 
     // Miscellaneous
     Settings::values.log_filter = sdl2_config->Get("Miscellaneous", "log_filter", "*:Trace");

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -126,8 +126,9 @@ void Config::ReadValues() {
     // System
     Settings::values.use_docked_mode = sdl2_config->GetBoolean("System", "use_docked_mode", false);
     Settings::values.username = sdl2_config->Get("System", "username", "yuzu");
-    Settings::values.username =
-        Settings::values.username == "" ? "yuzu" : Settings::values.username;
+    if (Settings::values.username.empty()) {
+        Settings::values.username = "yuzu";
+    }
 
     // Miscellaneous
     Settings::values.log_filter = sdl2_config->Get("Miscellaneous", "log_filter", "*:Trace");

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -125,6 +125,8 @@ void Config::ReadValues() {
 
     // System
     Settings::values.use_docked_mode = sdl2_config->GetBoolean("System", "use_docked_mode", false);
+    Settings::values.username = sdl2_config->Get("System", "username", "yuzu");
+    Settings::values.username = Settings::values.username == "" ? "yuzu" : Settings::values.username;
 
     // Miscellaneous
     Settings::values.log_filter = sdl2_config->Get("Miscellaneous", "log_filter", "*:Trace");

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -176,7 +176,7 @@ use_docked_mode =
 
 # Sets the account username, max length is 32 characters
 # yuzu (default)
-username =
+username = yuzu
 
 # Sets the systems language index
 # 0: Japanese, 1: English (default), 2: French, 3: German, 4: Italian, 5: Spanish, 6: Chinese,


### PR DESCRIPTION
The default username value for yuzu_cmd was "" instead of  "yuzu".
It caused the creation of an userprofile with uninitialized stack data as username.
The username is never used, so it's not really an issue currently.

I also added a nullptr check in `RegisteredCacheUnion`. The cache can contains nullptr entries.