### PR TITLE
yuzu/util: Antialias game list compatibility pixmaps

### DIFF
--- a/src/yuzu/util/util.cpp
+++ b/src/yuzu/util/util.cpp
@@ -30,8 +30,9 @@ QPixmap CreateCirclePixmapFromColor(const QColor& color) {
     QPixmap circle_pixmap(16, 16);
     circle_pixmap.fill(Qt::transparent);
     QPainter painter(&circle_pixmap);
+    painter.setRenderHint(QPainter::Antialiasing);
     painter.setPen(color);
     painter.setBrush(color);
-    painter.drawEllipse(0, 0, 15, 15);
+    painter.drawEllipse({circle_pixmap.width() / 2.0, circle_pixmap.height() / 2.0}, 7.0, 7.0);
     return circle_pixmap;
 }


### PR DESCRIPTION
We pass a hint to the QPainter instance that we want anti-aliasing on the compatibility icons, which prevents the circles from looking fairly jagged, and actually makes them look circular.

![](https://user-images.githubusercontent.com/712067/45617067-3209a900-ba3f-11e8-8aeb-76de3c5b0c8a.png)

Top: Before
Bottom: After