### PR TITLE
Implement ISystemDisplayService::GetDisplayMode

### DIFF
--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -609,7 +609,7 @@ public:
             {3000, nullptr, "ListDisplayModes"},
             {3001, nullptr, "ListDisplayRgbRanges"},
             {3002, nullptr, "ListDisplayContentTypes"},
-            {3200, nullptr, "GetDisplayMode"},
+            {3200, &ISystemDisplayService::GetDisplayMode, "GetDisplayMode"},
             {3201, nullptr, "SetDisplayMode"},
             {3202, nullptr, "GetDisplayUnderscan"},
             {3203, nullptr, "SetDisplayUnderscan"},
@@ -659,6 +659,24 @@ private:
         rb.Push(RESULT_SUCCESS);
         LOG_WARNING(Service_VI, "(STUBBED) called, layer_id=0x{:08X}, visibility={}", layer_id,
                     visibility);
+    }
+
+    void GetDisplayMode(Kernel::HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 6};
+        rb.Push(RESULT_SUCCESS);
+
+        if (Settings::values.use_docked_mode) {
+            rb.Push(static_cast<u32>(Service::VI::DisplayResolution::DockedWidth));
+            rb.Push(static_cast<u32>(Service::VI::DisplayResolution::DockedHeight));
+        } else {
+            rb.Push(static_cast<u32>(Service::VI::DisplayResolution::UndockedWidth));
+            rb.Push(static_cast<u32>(Service::VI::DisplayResolution::UndockedHeight));
+        }
+
+        rb.PushRaw<float>(60.0f);
+        rb.Push<u32>(0);
+
+        LOG_DEBUG(Service_VI, "called");
     }
 };
 


### PR DESCRIPTION
Used by Shovel Knight.

>[   8.022335] Service <Error> core\hle\service\service.cpp:ReportUnimplementedFunction:153: unknown / unimplemented function 'GetDisplayMode': port='ISystemDisplayService' cmd_buf={[0]=0x4, [1]=0xA, [2]=0x0, [3]=0x0, [4]=0x49434653, [5]=0x0, [6]=0xC80, [7]=0x0, [8]=0x0}
>[   8.022337] Debug <Critical> core\hle\service\service.cpp:ReportUnimplementedFunction:154: Unimplemented code!