### PR TITLE
Implement a Better Ignore Assert

### DIFF
--- a/src/common/assert.cpp
+++ b/src/common/assert.cpp
@@ -4,8 +4,4 @@
 
 #include "common/assert.h"
 
-#include "common/common_funcs.h"
-
-void assert_handle_failure() {
-    Crash();
-}
+void assert_handle_failure() {}


### PR DESCRIPTION
**DO NOT MERGE**

This one prints the assert message to the log unlike #615. At least it helps us figure if an assert was broken from user log.