### PR TITLE
core/core_cpu: Replace exclusive monitor include with forward declaration

### DIFF
--- a/src/core/core_cpu.cpp
+++ b/src/core/core_cpu.cpp
@@ -9,6 +9,7 @@
 #ifdef ARCHITECTURE_x86_64
 #include "core/arm/dynarmic/arm_dynarmic.h"
 #endif
+#include "core/arm/exclusive_monitor.h"
 #include "core/arm/unicorn/arm_unicorn.h"
 #include "core/core_cpu.h"
 #include "core/core_timing.h"
@@ -65,6 +66,8 @@ Cpu::Cpu(std::shared_ptr<ExclusiveMonitor> exclusive_monitor,
 
     scheduler = std::make_shared<Kernel::Scheduler>(arm_interface.get());
 }
+
+Cpu::~Cpu() = default;
 
 std::shared_ptr<ExclusiveMonitor> Cpu::MakeExclusiveMonitor(std::size_t num_cores) {
     if (Settings::values.use_cpu_jit) {

--- a/src/core/core_cpu.h
+++ b/src/core/core_cpu.h
@@ -6,11 +6,10 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <cstddef>
 #include <memory>
 #include <mutex>
-#include <string>
 #include "common/common_types.h"
-#include "core/arm/exclusive_monitor.h"
 
 namespace Kernel {
 class Scheduler;
@@ -19,6 +18,7 @@ class Scheduler;
 namespace Core {
 
 class ARM_Interface;
+class ExclusiveMonitor;
 
 constexpr unsigned NUM_CPU_CORES{4};
 
@@ -43,6 +43,7 @@ class Cpu {
 public:
     Cpu(std::shared_ptr<ExclusiveMonitor> exclusive_monitor,
         std::shared_ptr<CpuBarrier> cpu_barrier, std::size_t core_index);
+    ~Cpu();
 
     void RunLoop(bool tight_loop = true);
 


### PR DESCRIPTION
We don't need to include this as a dependency within the header. A regular forward declaration will suffice here.