### PR TITLE
kernel/svc: Handle invalid address cases within svcArbitrateLock() and svcArbitrateUnlock()

### DIFF
--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -62,7 +62,7 @@ ResultCode Mutex::TryAcquire(HandleTable& handle_table, VAddr address, Handle ho
                              Handle requesting_thread_handle) {
     // The mutex address must be 4-byte aligned
     if ((address % sizeof(u32)) != 0) {
-        return ResultCode(ErrorModule::Kernel, ErrCodes::InvalidAddress);
+        return ERR_INVALID_ADDRESS;
     }
 
     SharedPtr<Thread> holding_thread = handle_table.Get<Thread>(holding_thread_handle);
@@ -100,7 +100,7 @@ ResultCode Mutex::TryAcquire(HandleTable& handle_table, VAddr address, Handle ho
 ResultCode Mutex::Release(VAddr address) {
     // The mutex address must be 4-byte aligned
     if ((address % sizeof(u32)) != 0) {
-        return ResultCode(ErrorModule::Kernel, ErrCodes::InvalidAddress);
+        return ERR_INVALID_ADDRESS;
     }
 
     auto [thread, num_waiters] = GetHighestPriorityMutexWaitingThread(GetCurrentThread(), address);

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -280,6 +280,10 @@ static ResultCode ArbitrateLock(Handle holding_thread_handle, VAddr mutex_addr,
               "requesting_current_thread_handle=0x{:08X}",
               holding_thread_handle, mutex_addr, requesting_thread_handle);
 
+    if (Memory::IsKernelVirtualAddress(mutex_addr)) {
+        return ERR_INVALID_ADDRESS_STATE;
+    }
+
     auto& handle_table = Core::System::GetInstance().Kernel().HandleTable();
     return Mutex::TryAcquire(handle_table, mutex_addr, holding_thread_handle,
                              requesting_thread_handle);
@@ -288,6 +292,10 @@ static ResultCode ArbitrateLock(Handle holding_thread_handle, VAddr mutex_addr,
 /// Unlock a mutex
 static ResultCode ArbitrateUnlock(VAddr mutex_addr) {
     LOG_TRACE(Kernel_SVC, "called mutex_addr=0x{:X}", mutex_addr);
+
+    if (Memory::IsKernelVirtualAddress(mutex_addr)) {
+        return ERR_INVALID_ADDRESS_STATE;
+    }
 
     return Mutex::Release(mutex_addr);
 }


### PR DESCRIPTION
The kernel does the equivalent of the following check before proceeding:

```cpp
if (address + 0x8000000000 < 0x7FFFE00000) {
    return ERR_INVALID_MEMORY_STATE;
}
```

which is essentially what our IsKernelVirtualAddress() function does. So we should also be checking for this.

The kernel also checks if the given input addresses are 4-byte aligned after the above check, however our `Mutex::TryAcquire()` and `Mutex::Release()` functions already handle this, so we don't need to add code for this case.