### PR TITLE
svc_wrap: Convert the PARAM macro into a function

### DIFF
--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -13,7 +13,9 @@
 
 namespace Kernel {
 
-#define PARAM(n) Core::CurrentArmInterface().GetReg(n)
+static inline u64 Param(int n) {
+    return Core::CurrentArmInterface().GetReg(n);
+}
 
 /**
  * HLE a function return from the current ARM userland process
@@ -28,23 +30,23 @@ static inline void FuncReturn(u64 res) {
 
 template <ResultCode func(u64)>
 void SvcWrap() {
-    FuncReturn(func(PARAM(0)).raw);
+    FuncReturn(func(Param(0)).raw);
 }
 
 template <ResultCode func(u32)>
 void SvcWrap() {
-    FuncReturn(func((u32)PARAM(0)).raw);
+    FuncReturn(func((u32)Param(0)).raw);
 }
 
 template <ResultCode func(u32, u32)>
 void SvcWrap() {
-    FuncReturn(func((u32)PARAM(0), (u32)PARAM(1)).raw);
+    FuncReturn(func((u32)Param(0), (u32)Param(1)).raw);
 }
 
 template <ResultCode func(u32*, u32)>
 void SvcWrap() {
     u32 param_1 = 0;
-    u32 retval = func(&param_1, (u32)PARAM(1)).raw;
+    u32 retval = func(&param_1, (u32)Param(1)).raw;
     Core::CurrentArmInterface().SetReg(1, param_1);
     FuncReturn(retval);
 }
@@ -52,39 +54,39 @@ void SvcWrap() {
 template <ResultCode func(u32*, u64)>
 void SvcWrap() {
     u32 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1)).raw;
+    u32 retval = func(&param_1, Param(1)).raw;
     Core::CurrentArmInterface().SetReg(1, param_1);
     FuncReturn(retval);
 }
 
 template <ResultCode func(u64, s32)>
 void SvcWrap() {
-    FuncReturn(func(PARAM(0), (s32)PARAM(1)).raw);
+    FuncReturn(func(Param(0), (s32)Param(1)).raw);
 }
 
 template <ResultCode func(u64*, u64)>
 void SvcWrap() {
     u64 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1)).raw;
+    u32 retval = func(&param_1, Param(1)).raw;
     Core::CurrentArmInterface().SetReg(1, param_1);
     FuncReturn(retval);
 }
 
 template <ResultCode func(u32, u64)>
 void SvcWrap() {
-    FuncReturn(func((u32)(PARAM(0) & 0xFFFFFFFF), PARAM(1)).raw);
+    FuncReturn(func((u32)(Param(0) & 0xFFFFFFFF), Param(1)).raw);
 }
 
 template <ResultCode func(u32, u32, u64)>
 void SvcWrap() {
-    FuncReturn(func((u32)(PARAM(0) & 0xFFFFFFFF), (u32)(PARAM(1) & 0xFFFFFFFF), PARAM(2)).raw);
+    FuncReturn(func((u32)(Param(0) & 0xFFFFFFFF), (u32)(Param(1) & 0xFFFFFFFF), Param(2)).raw);
 }
 
 template <ResultCode func(u32, u32*, u64*)>
 void SvcWrap() {
     u32 param_1 = 0;
     u64 param_2 = 0;
-    ResultCode retval = func((u32)(PARAM(2) & 0xFFFFFFFF), &param_1, &param_2);
+    ResultCode retval = func((u32)(Param(2) & 0xFFFFFFFF), &param_1, &param_2);
     Core::CurrentArmInterface().SetReg(1, param_1);
     Core::CurrentArmInterface().SetReg(2, param_2);
     FuncReturn(retval.raw);
@@ -93,46 +95,46 @@ void SvcWrap() {
 template <ResultCode func(u64, u64, u32, u32)>
 void SvcWrap() {
     FuncReturn(
-        func(PARAM(0), PARAM(1), (u32)(PARAM(3) & 0xFFFFFFFF), (u32)(PARAM(3) & 0xFFFFFFFF)).raw);
+        func(Param(0), Param(1), (u32)(Param(3) & 0xFFFFFFFF), (u32)(Param(3) & 0xFFFFFFFF)).raw);
 }
 
 template <ResultCode func(u32, u64, u32)>
 void SvcWrap() {
-    FuncReturn(func((u32)PARAM(0), PARAM(1), (u32)PARAM(2)).raw);
+    FuncReturn(func((u32)Param(0), Param(1), (u32)Param(2)).raw);
 }
 
 template <ResultCode func(u64, u64, u64)>
 void SvcWrap() {
-    FuncReturn(func(PARAM(0), PARAM(1), PARAM(2)).raw);
+    FuncReturn(func(Param(0), Param(1), Param(2)).raw);
 }
 
 template <ResultCode func(u32, u64, u64, u32)>
 void SvcWrap() {
-    FuncReturn(func((u32)PARAM(0), PARAM(1), PARAM(2), (u32)PARAM(3)).raw);
+    FuncReturn(func((u32)Param(0), Param(1), Param(2), (u32)Param(3)).raw);
 }
 
 template <ResultCode func(u32, u64, u64)>
 void SvcWrap() {
-    FuncReturn(func((u32)PARAM(0), PARAM(1), PARAM(2)).raw);
+    FuncReturn(func((u32)Param(0), Param(1), Param(2)).raw);
 }
 
 template <ResultCode func(u32*, u64, u64, s64)>
 void SvcWrap() {
     u32 param_1 = 0;
-    ResultCode retval = func(&param_1, PARAM(1), (u32)(PARAM(2) & 0xFFFFFFFF), (s64)PARAM(3));
+    ResultCode retval = func(&param_1, Param(1), (u32)(Param(2) & 0xFFFFFFFF), (s64)Param(3));
     Core::CurrentArmInterface().SetReg(1, param_1);
     FuncReturn(retval.raw);
 }
 
 template <ResultCode func(u64, u64, u32, s64)>
 void SvcWrap() {
-    FuncReturn(func(PARAM(0), PARAM(1), (u32)PARAM(2), (s64)PARAM(3)).raw);
+    FuncReturn(func(Param(0), Param(1), (u32)Param(2), (s64)Param(3)).raw);
 }
 
 template <ResultCode func(u64*, u64, u64, u64)>
 void SvcWrap() {
     u64 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1), PARAM(2), PARAM(3)).raw;
+    u32 retval = func(&param_1, Param(1), Param(2), Param(3)).raw;
     Core::CurrentArmInterface().SetReg(1, param_1);
     FuncReturn(retval);
 }
@@ -141,7 +143,7 @@ template <ResultCode func(u32*, u64, u64, u64, u32, s32)>
 void SvcWrap() {
     u32 param_1 = 0;
     u32 retval =
-        func(&param_1, PARAM(1), PARAM(2), PARAM(3), (u32)PARAM(4), (s32)(PARAM(5) & 0xFFFFFFFF))
+        func(&param_1, Param(1), Param(2), Param(3), (u32)Param(4), (s32)(Param(5) & 0xFFFFFFFF))
             .raw;
     Core::CurrentArmInterface().SetReg(1, param_1);
     FuncReturn(retval);
@@ -151,13 +153,13 @@ template <ResultCode func(MemoryInfo*, PageInfo*, u64)>
 void SvcWrap() {
     MemoryInfo memory_info = {};
     PageInfo page_info = {};
-    u32 retval = func(&memory_info, &page_info, PARAM(2)).raw;
+    u32 retval = func(&memory_info, &page_info, Param(2)).raw;
 
-    Memory::Write64(PARAM(0), memory_info.base_address);
-    Memory::Write64(PARAM(0) + 8, memory_info.size);
-    Memory::Write32(PARAM(0) + 16, memory_info.type);
-    Memory::Write32(PARAM(0) + 20, memory_info.attributes);
-    Memory::Write32(PARAM(0) + 24, memory_info.permission);
+    Memory::Write64(Param(0), memory_info.base_address);
+    Memory::Write64(Param(0) + 8, memory_info.size);
+    Memory::Write32(Param(0) + 16, memory_info.type);
+    Memory::Write32(Param(0) + 20, memory_info.attributes);
+    Memory::Write32(Param(0) + 24, memory_info.permission);
 
     FuncReturn(retval);
 }
@@ -165,7 +167,7 @@ void SvcWrap() {
 template <ResultCode func(u32*, u64, u64, u32)>
 void SvcWrap() {
     u32 param_1 = 0;
-    u32 retval = func(&param_1, PARAM(1), PARAM(2), (u32)(PARAM(3) & 0xFFFFFFFF)).raw;
+    u32 retval = func(&param_1, Param(1), Param(2), (u32)(Param(3) & 0xFFFFFFFF)).raw;
     Core::CurrentArmInterface().SetReg(1, param_1);
     FuncReturn(retval);
 }
@@ -174,7 +176,7 @@ template <ResultCode func(Handle*, u64, u32, u32)>
 void SvcWrap() {
     u32 param_1 = 0;
     u32 retval =
-        func(&param_1, PARAM(1), (u32)(PARAM(2) & 0xFFFFFFFF), (u32)(PARAM(3) & 0xFFFFFFFF)).raw;
+        func(&param_1, Param(1), (u32)(Param(2) & 0xFFFFFFFF), (u32)(Param(3) & 0xFFFFFFFF)).raw;
     Core::CurrentArmInterface().SetReg(1, param_1);
     FuncReturn(retval);
 }
@@ -182,14 +184,14 @@ void SvcWrap() {
 template <ResultCode func(u64, u32, s32, s64)>
 void SvcWrap() {
     FuncReturn(
-        func(PARAM(0), (u32)(PARAM(1) & 0xFFFFFFFF), (s32)(PARAM(2) & 0xFFFFFFFF), (s64)PARAM(3))
+        func(Param(0), (u32)(Param(1) & 0xFFFFFFFF), (s32)(Param(2) & 0xFFFFFFFF), (s64)Param(3))
             .raw);
 }
 
 template <ResultCode func(u64, u32, s32, s32)>
 void SvcWrap() {
-    FuncReturn(func(PARAM(0), (u32)(PARAM(1) & 0xFFFFFFFF), (s32)(PARAM(2) & 0xFFFFFFFF),
-                    (s32)(PARAM(3) & 0xFFFFFFFF))
+    FuncReturn(func(Param(0), (u32)(Param(1) & 0xFFFFFFFF), (s32)(Param(2) & 0xFFFFFFFF),
+                    (s32)(Param(3) & 0xFFFFFFFF))
                    .raw);
 }
 
@@ -219,20 +221,17 @@ void SvcWrap() {
 
 template <void func(s64)>
 void SvcWrap() {
-    func((s64)PARAM(0));
+    func((s64)Param(0));
 }
 
 template <void func(u64, u64 len)>
 void SvcWrap() {
-    func(PARAM(0), PARAM(1));
+    func(Param(0), Param(1));
 }
 
 template <void func(u64, u64, u64)>
 void SvcWrap() {
-    func(PARAM(0), PARAM(1), PARAM(2));
+    func(Param(0), Param(1), Param(2));
 }
-
-#undef PARAM
-#undef FuncReturn
 
 } // namespace Kernel


### PR DESCRIPTION
This can just be a regular function, getting rid of the need to also explicitly undef the define at the end of the file. Given FuncReturn() was already converted into a function, it's #undef can also be removed.