### PR TITLE
ring_buffer: Use std::hardware_destructive_interference_size to determine alignment size for avoiding false sharing

### DIFF
--- a/src/common/ring_buffer.h
+++ b/src/common/ring_buffer.h
@@ -30,7 +30,7 @@ class RingBuffer {
     static_assert(capacity < std::numeric_limits<std::size_t>::max() / 2 / granularity);
     static_assert((capacity & (capacity - 1)) == 0, "capacity must be a power of two");
     // Ensure lock-free.
-    static_assert(std::atomic<std::size_t>::is_always_lock_free);
+    static_assert(std::atomic_size_t::is_always_lock_free);
 
 public:
     /// Pushes slots into the ring buffer


### PR DESCRIPTION
MSVC 19.11 (A.K.A. VS 15.3)'s C++ standard library implements [P0154R1](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2016/p0154r1.html) which defines two new constants within the `<new>` header, `std::hardware_destructive_interference_size` and `std::hardware_constructive_interference_size`.

`std::hardware_destructive_interference_size` defines the minimum recommended offset between two concurrently-accessed objects to avoid performance degradation due to contention introduced by the implementation (with the lower-bound being at least `alignof(max_align_t)`). In other words, the minimum recommended offset to avoid false-sharing.

`std::hardware_constructive_interference_size` on the other hand defines the maximum recommended size of contiguous memory occupied with by two objects accessed with temporal locality by concurrent threads (also defined to be at least `alignof(max_align_t)`). In other words, the recommended size to promote true-sharing.

So we can simply use this facility to determine the ideal alignment size. Unfortunately, only MSVC supports this right now, so we need to enclose it within an ifdef for the time being.