### PR TITLE
Removed the use of rp.MakeBuilder in the yuzu codebase

### DIFF
--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -290,13 +290,6 @@ public:
         Skip(CommandIdSize, false);
     }
 
-    ResponseBuilder MakeBuilder(u32 normal_params_size, u32 num_handles_to_copy,
-                                u32 num_handles_to_move,
-                                ResponseBuilder::Flags flags = ResponseBuilder::Flags::None) const {
-        return ResponseBuilder{*context, normal_params_size, num_handles_to_copy,
-                               num_handles_to_move, flags};
-    }
-
     template <typename T>
     T Pop();
 

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -462,7 +462,7 @@ private:
 
         std::memcpy(&buffer[offset], data.data(), data.size());
 
-        IPC::ResponseBuilder rb{rp.MakeBuilder(2, 0, 0)};
+        IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
 
         LOG_DEBUG(Service_AM, "called, offset={}", offset);
@@ -478,7 +478,7 @@ private:
 
         ctx.WriteBuffer(buffer.data() + offset, size);
 
-        IPC::ResponseBuilder rb{rp.MakeBuilder(2, 0, 0)};
+        IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
 
         LOG_DEBUG(Service_AM, "called, offset={}", offset);
@@ -568,7 +568,7 @@ private:
         IPC::RequestParser rp{ctx};
         storage_stack.push(rp.PopIpcInterface<AM::IStorage>());
 
-        IPC::ResponseBuilder rb{rp.MakeBuilder(2, 0, 0)};
+        IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
 
         LOG_DEBUG(Service_AM, "called");
@@ -616,7 +616,7 @@ void ILibraryAppletCreator::CreateStorage(Kernel::HLERequestContext& ctx) {
     const u64 size{rp.Pop<u64>()};
     std::vector<u8> buffer(size);
 
-    IPC::ResponseBuilder rb{rp.MakeBuilder(2, 0, 1)};
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<AM::IStorage>(std::move(buffer));
 

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -190,7 +190,7 @@ void AudOutU::ListAudioOutsImpl(Kernel::HLERequestContext& ctx) {
 
     ctx.WriteBuffer(DefaultDevice);
 
-    IPC::ResponseBuilder rb = rp.MakeBuilder(3, 0, 0);
+    IPC::ResponseBuilder rb{ctx, 3};
 
     rb.Push(RESULT_SUCCESS);
     rb.Push<u32>(1); // Amount of audio devices

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -137,7 +137,7 @@ private:
         constexpr std::array<char, 15> audio_interface{{"AudioInterface"}};
         ctx.WriteBuffer(audio_interface);
 
-        IPC::ResponseBuilder rb = rp.MakeBuilder(3, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u32>(1);
     }
@@ -151,7 +151,7 @@ private:
         auto file_buffer = ctx.ReadBuffer();
         auto end = std::find(file_buffer.begin(), file_buffer.end(), '\0');
 
-        IPC::ResponseBuilder rb = rp.MakeBuilder(2, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
 
@@ -162,7 +162,7 @@ private:
         constexpr std::array<char, 12> audio_interface{{"AudioDevice"}};
         ctx.WriteBuffer(audio_interface);
 
-        IPC::ResponseBuilder rb = rp.MakeBuilder(3, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u32>(1);
     }

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -108,7 +108,7 @@ void SM::GetService(Kernel::HLERequestContext& ctx) {
 
     auto client_port = service_manager->GetServicePort(name);
     if (client_port.Failed()) {
-        IPC::ResponseBuilder rb = rp.MakeBuilder(2, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(client_port.Code());
         LOG_ERROR(Service_SM, "called service={} -> error 0x{:08X}", name, client_port.Code().raw);
         if (name.length() == 0)
@@ -121,8 +121,7 @@ void SM::GetService(Kernel::HLERequestContext& ctx) {
     ASSERT(session.Succeeded());
     if (session.Succeeded()) {
         LOG_DEBUG(Service_SM, "called service={} -> session={}", name, (*session)->GetObjectId());
-        IPC::ResponseBuilder rb =
-            rp.MakeBuilder(2, 0, 1, IPC::ResponseBuilder::Flags::AlwaysMoveHandles);
+        IPC::ResponseBuilder rb{ctx, 2, 0, 1, IPC::ResponseBuilder::Flags::AlwaysMoveHandles};
         rb.Push(session.Code());
         rb.PushMoveObjects(std::move(session).Unwrap());
     }

--- a/src/core/hle/service/ssl/ssl.cpp
+++ b/src/core/hle/service/ssl/ssl.cpp
@@ -71,7 +71,7 @@ private:
         LOG_WARNING(Service_SSL, "(STUBBED) called");
         IPC::RequestParser rp{ctx};
 
-        IPC::ResponseBuilder rb = rp.MakeBuilder(2, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
 

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -650,7 +650,7 @@ private:
         u64 layer_id = rp.Pop<u64>();
         u64 z_value = rp.Pop<u64>();
 
-        IPC::ResponseBuilder rb = rp.MakeBuilder(2, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
 
@@ -658,7 +658,7 @@ private:
         IPC::RequestParser rp{ctx};
         u64 layer_id = rp.Pop<u64>();
         bool visibility = rp.Pop<bool>();
-        IPC::ResponseBuilder rb = rp.MakeBuilder(2, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
         LOG_WARNING(Service_VI, "(STUBBED) called, layer_id=0x{:08X}, visibility={}", layer_id,
                     visibility);
@@ -747,7 +747,7 @@ private:
         IPC::RequestParser rp{ctx};
         u64 display = rp.Pop<u64>();
 
-        IPC::ResponseBuilder rb = rp.MakeBuilder(2, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
 
@@ -761,7 +761,7 @@ private:
 
         u64 layer_id = nv_flinger->CreateLayer(display);
 
-        IPC::ResponseBuilder rb = rp.MakeBuilder(4, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
         rb.Push(layer_id);
     }
@@ -772,7 +772,7 @@ private:
         u32 stack = rp.Pop<u32>();
         u64 layer_id = rp.Pop<u64>();
 
-        IPC::ResponseBuilder rb = rp.MakeBuilder(2, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
 
@@ -780,7 +780,7 @@ private:
         IPC::RequestParser rp{ctx};
         u64 layer_id = rp.Pop<u64>();
         bool visibility = rp.Pop<bool>();
-        IPC::ResponseBuilder rb = rp.MakeBuilder(2, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
         LOG_WARNING(Service_VI, "(STUBBED) called, layer_id=0x{:X}, visibility={}", layer_id,
                     visibility);
@@ -837,7 +837,7 @@ private:
 
         ASSERT_MSG(name == "Default", "Non-default displays aren't supported yet");
 
-        IPC::ResponseBuilder rb = rp.MakeBuilder(4, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u64>(nv_flinger->OpenDisplay(name));
     }
@@ -847,7 +847,7 @@ private:
         IPC::RequestParser rp{ctx};
         u64 display_id = rp.Pop<u64>();
 
-        IPC::ResponseBuilder rb = rp.MakeBuilder(2, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
 
@@ -856,7 +856,7 @@ private:
         IPC::RequestParser rp{ctx};
         u64 display_id = rp.Pop<u64>();
 
-        IPC::ResponseBuilder rb = rp.MakeBuilder(6, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 6};
         rb.Push(RESULT_SUCCESS);
 
         if (Settings::values.use_docked_mode) {
@@ -874,7 +874,7 @@ private:
         u32 scaling_mode = rp.Pop<u32>();
         u64 unknown = rp.Pop<u64>();
 
-        IPC::ResponseBuilder rb = rp.MakeBuilder(2, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
 
@@ -882,7 +882,7 @@ private:
         IPC::RequestParser rp{ctx};
         DisplayInfo display_info;
         ctx.WriteBuffer(&display_info, sizeof(DisplayInfo));
-        IPC::ResponseBuilder rb = rp.MakeBuilder(4, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u64>(1);
         LOG_WARNING(Service_VI, "(STUBBED) called");
@@ -903,7 +903,7 @@ private:
         u32 buffer_queue_id = nv_flinger->GetBufferQueueId(display_id, layer_id);
 
         NativeWindow native_window{buffer_queue_id};
-        IPC::ResponseBuilder rb = rp.MakeBuilder(4, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u64>(ctx.WriteBuffer(native_window.Serialize()));
     }
@@ -922,7 +922,7 @@ private:
         u32 buffer_queue_id = nv_flinger->GetBufferQueueId(display_id, layer_id);
 
         NativeWindow native_window{buffer_queue_id};
-        IPC::ResponseBuilder rb = rp.MakeBuilder(6, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 6};
         rb.Push(RESULT_SUCCESS);
         rb.Push(layer_id);
         rb.Push<u64>(ctx.WriteBuffer(native_window.Serialize()));
@@ -934,7 +934,7 @@ private:
         IPC::RequestParser rp{ctx};
         u64 layer_id = rp.Pop<u64>();
 
-        IPC::ResponseBuilder rb = rp.MakeBuilder(2, 0, 0);
+        IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
 
@@ -945,7 +945,7 @@ private:
 
         auto vsync_event = nv_flinger->GetVsyncEvent(display_id);
 
-        IPC::ResponseBuilder rb = rp.MakeBuilder(2, 1, 0);
+        IPC::ResponseBuilder rb{ctx, 2, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushCopyObjects(vsync_event);
     }


### PR DESCRIPTION
Due to keeping the code style consistent in the yuzu codebase. `rb = rp.MakeBuilder(...)` was replaced with `rb{ctx, ...}`