### PR TITLE
Reworked incorrect nifm stubs

### DIFF
--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -65,7 +65,7 @@ private:
         LOG_WARNING(Service_NIFM, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u32>(0);
+        rb.Push<u32>(3);
     }
 
     void GetResult(Kernel::HLERequestContext& ctx) {
@@ -113,11 +113,12 @@ public:
     IGeneralService();
 
 private:
+    const u32 client_id = 1;
     void GetClientId(Kernel::HLERequestContext& ctx) {
         LOG_WARNING(Service_NIFM, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u64>(0);
+        rb.Push<u64>(client_id); // Client ID needs to be non zero otherwise it's considered invalid
     }
     void CreateScanRequest(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
@@ -145,6 +146,7 @@ private:
 
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<INetworkProfile>();
+        rb.PushRaw<u128>(uuid);
 
         LOG_DEBUG(Service_NIFM, "called");
     }

--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -113,8 +113,8 @@ public:
     IGeneralService();
 
 private:
-    const u32 client_id = 1;
     void GetClientId(Kernel::HLERequestContext& ctx) {
+        static constexpr u32 client_id = 1;
         LOG_WARNING(Service_NIFM, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
@@ -142,7 +142,12 @@ private:
         rb.Push(RESULT_SUCCESS);
     }
     void CreateTemporaryNetworkProfile(Kernel::HLERequestContext& ctx) {
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        ASSERT_MSG(ctx.GetReadBufferSize() == 0x17c, "NetworkProfileData is not the correct size");
+        u128 uuid{};
+        auto buffer = ctx.ReadBuffer();
+        std::memcpy(&uuid, buffer.data() + 8, sizeof(u128));
+
+        IPC::ResponseBuilder rb{ctx, 6, 0, 1};
 
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<INetworkProfile>();


### PR DESCRIPTION
Need confirmation on `CreateTemporaryNetworkProfile`, unsure which game uses it but according to reversing. It should return a uuid which we currently don't do.

Any 0 client id is considered an invalid client id.

GetRequestState 0 is considered invalid.