### PR TITLE
savedata_factory: Add TemporaryStorage SaveDataType

### DIFF
--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -85,10 +85,10 @@ std::string SaveDataFactory::GetFullPath(SaveDataSpaceId space, SaveDataType typ
 
     switch (space) {
     case SaveDataSpaceId::NandSystem:
-        out = "/system/save/";
+        out = "/system/";
         break;
     case SaveDataSpaceId::NandUser:
-        out = "/user/save/";
+        out = "/user/";
         break;
     default:
         ASSERT_MSG(false, "Unrecognized SaveDataSpaceId: {:02X}", static_cast<u8>(space));
@@ -96,9 +96,12 @@ std::string SaveDataFactory::GetFullPath(SaveDataSpaceId space, SaveDataType typ
 
     switch (type) {
     case SaveDataType::SystemSaveData:
-        return fmt::format("{}{:016X}/{:016X}{:016X}", out, save_id, user_id[1], user_id[0]);
+        return fmt::format("{}save/{:016X}/{:016X}{:016X}", out, save_id, user_id[1], user_id[0]);
     case SaveDataType::SaveData:
-        return fmt::format("{}{:016X}/{:016X}{:016X}/{:016X}", out, 0, user_id[1], user_id[0],
+        return fmt::format("{}save/{:016X}/{:016X}{:016X}/{:016X}", out, 0, user_id[1], user_id[0],
+                           title_id);
+    case SaveDataType::TemporaryStorage:
+        return fmt::format("{}temp/{:016X}/{:016X}{:016X}/{:016X}", out, 0, user_id[1], user_id[0],
                            title_id);
     default:
         ASSERT_MSG(false, "Unrecognized SaveDataType: {:02X}", static_cast<u8>(type));


### PR DESCRIPTION
Seems to be used by NSO NES Emulator.

According to Subv, TemporaryStorage is stored at the same structure as SaveData, just with /temp instead of /save.