### PR TITLE
Fixed GetAccountId stub, Added error code for OpenDirectory and added ActivateNpadWithRevision

### DIFF
--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -130,11 +130,10 @@ private:
 
     void GetAccountId(Kernel::HLERequestContext& ctx) {
         LOG_WARNING(Service_ACC, "(STUBBED) called");
-        // TODO(Subv): Find out what this actually does and implement it. Stub it as an error for
-        // now since we do not implement NNID. Returning a bogus id here will cause games to send
-        // invalid IPC requests after ListOpenUsers is called.
-        IPC::ResponseBuilder rb{ctx, 2};
-        rb.Push(ResultCode(-1));
+        // Should return a nintendo account ID
+        IPC::ResponseBuilder rb{ctx, 4};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushRaw<u64>(1);
     }
 };
 

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -197,7 +197,7 @@ ResultVal<FileSys::VirtualDir> VfsDirectoryServiceWrapper::OpenDirectory(const s
     auto dir = GetDirectoryRelativeWrapped(backing, path);
     if (dir == nullptr) {
         // TODO(DarkLordZach): Find a better error code for this
-        return ResultCode(-1);
+        return FileSys::ERROR_PATH_NOT_FOUND;
     }
     return MakeResult(dir);
 }

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -338,7 +338,7 @@ public:
             {106, &Hid::AcquireNpadStyleSetUpdateEventHandle, "AcquireNpadStyleSetUpdateEventHandle"},
             {107, &Hid::DisconnectNpad, "DisconnectNpad"},
             {108, &Hid::GetPlayerLedPattern, "GetPlayerLedPattern"},
-            {109, nullptr, "ActivateNpadWithRevision"},
+            {109, &Hid::ActivateNpadWithRevision, "ActivateNpadWithRevision"},
             {120, &Hid::SetNpadJoyHoldType, "SetNpadJoyHoldType"},
             {121, &Hid::GetNpadJoyHoldType, "GetNpadJoyHoldType"},
             {122, &Hid::SetNpadJoyAssignmentModeSingleByDefault, "SetNpadJoyAssignmentModeSingleByDefault"},
@@ -599,6 +599,12 @@ private:
     }
 
     void ActivateGesture(Kernel::HLERequestContext& ctx) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+        LOG_WARNING(Service_HID, "(STUBBED) called");
+    }
+
+    void ActivateNpadWithRevision(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
         LOG_WARNING(Service_HID, "(STUBBED) called");


### PR DESCRIPTION
With these, `Nintendo Entertainment System - Nintendo Switch Online` boots

![](http://puush.sucks.wang/2018-09/2018-09-19_23-22-8f34b42c-c04e-40db-b05d-47c3ead629cb-56c7ee18.png)

![](http://puush.sucks.wang/2018-09/2018-09-19_23-26-b709cf92-7e3a-42d5-9f86-8584ad595675-58861266.png)
