### PR TITLE
Port citra-emu/citra#3979 game_list: move SearchField to game_list_p.h and fix untranslated text

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -26,10 +26,10 @@
 #include "yuzu/main.h"
 #include "yuzu/ui_settings.h"
 
-GameList::SearchField::KeyReleaseEater::KeyReleaseEater(GameList* gamelist) : gamelist{gamelist} {}
+GameListSearchField::KeyReleaseEater::KeyReleaseEater(GameList* gamelist) : gamelist{gamelist} {}
 
 // EventFilter in order to process systemkeys while editing the searchfield
-bool GameList::SearchField::KeyReleaseEater::eventFilter(QObject* obj, QEvent* event) {
+bool GameListSearchField::KeyReleaseEater::eventFilter(QObject* obj, QEvent* event) {
     // If it isn't a KeyRelease event then continue with standard event processing
     if (event->type() != QEvent::KeyRelease)
         return QObject::eventFilter(obj, event);
@@ -88,21 +88,21 @@ bool GameList::SearchField::KeyReleaseEater::eventFilter(QObject* obj, QEvent* e
     return QObject::eventFilter(obj, event);
 }
 
-void GameList::SearchField::setFilterResult(int visible, int total) {
+void GameListSearchField::setFilterResult(int visible, int total) {
     label_filter_result->setText(tr("%1 of %n result(s)", "", total).arg(visible));
 }
 
-void GameList::SearchField::clear() {
+void GameListSearchField::clear() {
     edit_filter->setText("");
 }
 
-void GameList::SearchField::setFocus() {
+void GameListSearchField::setFocus() {
     if (edit_filter->isVisible()) {
         edit_filter->setFocus();
     }
 }
 
-GameList::SearchField::SearchField(GameList* parent) : QWidget{parent} {
+GameListSearchField::GameListSearchField(GameList* parent) : QWidget{parent} {
     KeyReleaseEater* keyReleaseEater = new KeyReleaseEater(parent);
     layout_filter = new QHBoxLayout;
     layout_filter->setMargin(8);
@@ -202,7 +202,7 @@ GameList::GameList(FileSys::VirtualFilesystem vfs, GMainWindow* parent)
     this->main_window = parent;
     layout = new QVBoxLayout;
     tree_view = new QTreeView;
-    search_field = new SearchField(this);
+    search_field = new GameListSearchField(this);
     item_model = new QStandardItemModel(tree_view);
     tree_view->setModel(item_model);
 

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -22,6 +22,7 @@
 #include "yuzu/compatibility_list.h"
 
 class GameListWorker;
+class GameListSearchField;
 class GMainWindow;
 
 namespace FileSys {
@@ -41,33 +42,6 @@ public:
         COLUMN_FILE_TYPE,
         COLUMN_SIZE,
         COLUMN_COUNT, // Number of columns
-    };
-
-    class SearchField : public QWidget {
-    public:
-        void setFilterResult(int visible, int total);
-        void clear();
-        void setFocus();
-        explicit SearchField(GameList* parent = nullptr);
-
-    private:
-        class KeyReleaseEater : public QObject {
-        public:
-            explicit KeyReleaseEater(GameList* gamelist);
-
-        private:
-            GameList* gamelist = nullptr;
-            QString edit_filter_text_old;
-
-        protected:
-            bool eventFilter(QObject* obj, QEvent* event) override;
-        };
-        QHBoxLayout* layout_filter = nullptr;
-        QTreeView* tree_view = nullptr;
-        QLabel* label_filter = nullptr;
-        QLineEdit* edit_filter = nullptr;
-        QLabel* label_filter_result = nullptr;
-        QToolButton* button_filter_close = nullptr;
     };
 
     explicit GameList(std::shared_ptr<FileSys::VfsFilesystem> vfs, GMainWindow* parent = nullptr);
@@ -105,7 +79,7 @@ private:
     void RefreshGameDirectory();
 
     std::shared_ptr<FileSys::VfsFilesystem> vfs;
-    SearchField* search_field;
+    GameListSearchField* search_field;
     GMainWindow* main_window = nullptr;
     QVBoxLayout* layout = nullptr;
     QTreeView* tree_view = nullptr;
@@ -113,6 +87,8 @@ private:
     GameListWorker* current_worker = nullptr;
     QFileSystemWatcher* watcher = nullptr;
     CompatibilityList compatibility_list;
+
+    friend class GameListSearchField;
 };
 
 Q_DECLARE_METATYPE(GameListOpenTarget);

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -16,6 +16,7 @@
 #include <QObject>
 #include <QStandardItem>
 #include <QString>
+#include <QWidget>
 
 #include "common/common_types.h"
 #include "common/logging/log.h"
@@ -175,4 +176,43 @@ public:
     bool operator<(const QStandardItem& other) const override {
         return data(SizeRole).toULongLong() < other.data(SizeRole).toULongLong();
     }
+};
+
+class GameList;
+class QHBoxLayout;
+class QTreeView;
+class QLabel;
+class QLineEdit;
+class QToolButton;
+
+class GameListSearchField : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit GameListSearchField(GameList* parent = nullptr);
+
+    void setFilterResult(int visible, int total);
+
+    void clear();
+    void setFocus();
+
+private:
+    class KeyReleaseEater : public QObject {
+    public:
+        explicit KeyReleaseEater(GameList* gamelist);
+
+    private:
+        GameList* gamelist = nullptr;
+        QString edit_filter_text_old;
+
+    protected:
+        // EventFilter in order to process systemkeys while editing the searchfield
+        bool eventFilter(QObject* obj, QEvent* event) override;
+    };
+    QHBoxLayout* layout_filter = nullptr;
+    QTreeView* tree_view = nullptr;
+    QLabel* label_filter = nullptr;
+    QLineEdit* edit_filter = nullptr;
+    QLabel* label_filter_result = nullptr;
+    QToolButton* button_filter_close = nullptr;
 };


### PR DESCRIPTION
See citra-emu/citra#3979 for more details. 

Original description: `Previously the whole filter is left untranslated. After a bit of investigating, I found that my IDE says that reference to "tr" was ambigious. I looked at the ts file and found that these texts are in the context of GameList. Probably the default tr function called was not in GameList class. This explicitly set it and fixed the untranslated text.`