### PR TITLE
control_metadata: Move language name array definition to the cpp file

### DIFF
--- a/src/core/file_sys/control_metadata.cpp
+++ b/src/core/file_sys/control_metadata.cpp
@@ -31,15 +31,15 @@ NACP::NACP(VirtualFile file) : raw(std::make_unique<RawNACP>()) {
 const LanguageEntry& NACP::GetLanguageEntry(Language language) const {
     if (language != Language::Default) {
         return raw->language_entries.at(static_cast<u8>(language));
-    } else {
-        for (const auto& language_entry : raw->language_entries) {
-            if (!language_entry.GetApplicationName().empty())
-                return language_entry;
-        }
-
-        // Fallback to English
-        return GetLanguageEntry(Language::AmericanEnglish);
     }
+
+    for (const auto& language_entry : raw->language_entries) {
+        if (!language_entry.GetApplicationName().empty())
+            return language_entry;
+    }
+
+    // Fallback to English
+    return GetLanguageEntry(Language::AmericanEnglish);
 }
 
 std::string NACP::GetApplicationName(Language language) const {

--- a/src/core/file_sys/control_metadata.cpp
+++ b/src/core/file_sys/control_metadata.cpp
@@ -8,6 +8,14 @@
 
 namespace FileSys {
 
+const std::array<const char*, 15> LANGUAGE_NAMES = {
+    "AmericanEnglish", "BritishEnglish", "Japanese",
+    "French",          "German",         "LatinAmericanSpanish",
+    "Spanish",         "Italian",        "Dutch",
+    "CanadianFrench",  "Portugese",      "Russian",
+    "Korean",          "Taiwanese",      "Chinese",
+};
+
 std::string LanguageEntry::GetApplicationName() const {
     return Common::StringFromFixedZeroTerminatedBuffer(application_name.data(), 0x200);
 }

--- a/src/core/file_sys/control_metadata.h
+++ b/src/core/file_sys/control_metadata.h
@@ -66,12 +66,7 @@ enum class Language : u8 {
     Default = 255,
 };
 
-static constexpr std::array<const char*, 15> LANGUAGE_NAMES = {
-    "AmericanEnglish", "BritishEnglish", "Japanese",
-    "French",          "German",         "LatinAmericanSpanish",
-    "Spanish",         "Italian",        "Dutch",
-    "CanadianFrench",  "Portugese",      "Russian",
-    "Korean",          "Taiwanese",      "Chinese"};
+extern const std::array<const char*, 15> LANGUAGE_NAMES;
 
 // A class representing the format used by NX metadata files, typically named Control.nacp.
 // These store application name, dev name, title id, and other miscellaneous data.


### PR DESCRIPTION
This is used in two different translation units (deconstructed_rom_directory and patch_manager). This means we'd be pointlessly duplicating the whole array twice due to it being defined within the header. While we're at it, we can also do minor tidy up in `GetLanguageEntry()`.