### PR TITLE
file-sys: Default heavy-weight class destructors in the cpp file

### DIFF
--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -463,6 +463,8 @@ NCA::NCA(VirtualFile file_, VirtualFile bktr_base_romfs_, u64 bktr_base_ivfc_off
     status = Loader::ResultStatus::Success;
 }
 
+NCA::~NCA() = default;
+
 Loader::ResultStatus NCA::GetStatus() const {
     return status;
 }

--- a/src/core/file_sys/content_archive.h
+++ b/src/core/file_sys/content_archive.h
@@ -81,6 +81,8 @@ class NCA : public ReadOnlyVfsDirectory {
 public:
     explicit NCA(VirtualFile file, VirtualFile bktr_base_romfs = nullptr,
                  u64 bktr_base_ivfc_offset = 0);
+    ~NCA() override;
+
     Loader::ResultStatus GetStatus() const;
 
     std::vector<std::shared_ptr<VfsFile>> GetFiles() const override;

--- a/src/core/file_sys/control_metadata.cpp
+++ b/src/core/file_sys/control_metadata.cpp
@@ -20,6 +20,8 @@ NACP::NACP(VirtualFile file) : raw(std::make_unique<RawNACP>()) {
     file->ReadObject(raw.get());
 }
 
+NACP::~NACP() = default;
+
 const LanguageEntry& NACP::GetLanguageEntry(Language language) const {
     if (language != Language::Default) {
         return raw->language_entries.at(static_cast<u8>(language));

--- a/src/core/file_sys/control_metadata.h
+++ b/src/core/file_sys/control_metadata.h
@@ -78,6 +78,8 @@ static constexpr std::array<const char*, 15> LANGUAGE_NAMES = {
 class NACP {
 public:
     explicit NACP(VirtualFile file);
+    ~NACP();
+
     const LanguageEntry& GetLanguageEntry(Language language = Language::Default) const;
     std::string GetApplicationName(Language language = Language::Default) const;
     std::string GetDeveloperName(Language language = Language::Default) const;

--- a/src/core/file_sys/nca_metadata.cpp
+++ b/src/core/file_sys/nca_metadata.cpp
@@ -51,6 +51,8 @@ CNMT::CNMT(CNMTHeader header, OptionalHeader opt_header, std::vector<ContentReco
     : header(std::move(header)), opt_header(std::move(opt_header)),
       content_records(std::move(content_records)), meta_records(std::move(meta_records)) {}
 
+CNMT::~CNMT() = default;
+
 u64 CNMT::GetTitleID() const {
     return header.title_id;
 }

--- a/src/core/file_sys/nca_metadata.h
+++ b/src/core/file_sys/nca_metadata.h
@@ -87,6 +87,7 @@ public:
     explicit CNMT(VirtualFile file);
     CNMT(CNMTHeader header, OptionalHeader opt_header, std::vector<ContentRecord> content_records,
          std::vector<MetaRecord> meta_records);
+    ~CNMT();
 
     u64 GetTitleID() const;
     u32 GetTitleVersion() const;

--- a/src/core/file_sys/partition_filesystem.cpp
+++ b/src/core/file_sys/partition_filesystem.cpp
@@ -72,6 +72,8 @@ PartitionFilesystem::PartitionFilesystem(std::shared_ptr<VfsFile> file) {
     status = Loader::ResultStatus::Success;
 }
 
+PartitionFilesystem::~PartitionFilesystem() = default;
+
 Loader::ResultStatus PartitionFilesystem::GetStatus() const {
     return status;
 }

--- a/src/core/file_sys/partition_filesystem.h
+++ b/src/core/file_sys/partition_filesystem.h
@@ -25,6 +25,8 @@ namespace FileSys {
 class PartitionFilesystem : public ReadOnlyVfsDirectory {
 public:
     explicit PartitionFilesystem(std::shared_ptr<VfsFile> file);
+    ~PartitionFilesystem() override;
+
     Loader::ResultStatus GetStatus() const;
 
     std::vector<std::shared_ptr<VfsFile>> GetFiles() const override;

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -41,6 +41,8 @@ std::string FormatPatchTypeName(PatchType type) {
 
 PatchManager::PatchManager(u64 title_id) : title_id(title_id) {}
 
+PatchManager::~PatchManager() = default;
+
 VirtualDir PatchManager::PatchExeFS(VirtualDir exefs) const {
     LOG_INFO(Loader, "Patching ExeFS for title_id={:016X}", title_id);
 

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -34,6 +34,7 @@ std::string FormatPatchTypeName(PatchType type);
 class PatchManager {
 public:
     explicit PatchManager(u64 title_id);
+    ~PatchManager();
 
     // Currently tracked ExeFS patches:
     // - Game Updates

--- a/src/core/file_sys/program_metadata.cpp
+++ b/src/core/file_sys/program_metadata.cpp
@@ -12,6 +12,10 @@
 
 namespace FileSys {
 
+ProgramMetadata::ProgramMetadata() = default;
+
+ProgramMetadata::~ProgramMetadata() = default;
+
 Loader::ResultStatus ProgramMetadata::Load(VirtualFile file) {
     std::size_t total_size = static_cast<std::size_t>(file->GetSize());
     if (total_size < sizeof(Header))

--- a/src/core/file_sys/program_metadata.h
+++ b/src/core/file_sys/program_metadata.h
@@ -36,6 +36,9 @@ enum class ProgramFilePermission : u64 {
  */
 class ProgramMetadata {
 public:
+    ProgramMetadata();
+    ~ProgramMetadata();
+
     Loader::ResultStatus Load(VirtualFile file);
 
     bool Is64BitProgram() const;

--- a/src/core/file_sys/romfs_factory.cpp
+++ b/src/core/file_sys/romfs_factory.cpp
@@ -28,6 +28,8 @@ RomFSFactory::RomFSFactory(Loader::AppLoader& app_loader) {
     ivfc_offset = app_loader.ReadRomFSIVFCOffset();
 }
 
+RomFSFactory::~RomFSFactory() = default;
+
 ResultVal<VirtualFile> RomFSFactory::OpenCurrentProcess() {
     if (!updatable)
         return MakeResult<VirtualFile>(file);

--- a/src/core/file_sys/romfs_factory.h
+++ b/src/core/file_sys/romfs_factory.h
@@ -30,6 +30,7 @@ enum class StorageId : u8 {
 class RomFSFactory {
 public:
     explicit RomFSFactory(Loader::AppLoader& app_loader);
+    ~RomFSFactory();
 
     ResultVal<VirtualFile> OpenCurrentProcess();
     ResultVal<VirtualFile> Open(u64 title_id, StorageId storage, ContentRecordType type);

--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -20,6 +20,8 @@ std::string SaveDataDescriptor::DebugInfo() const {
 
 SaveDataFactory::SaveDataFactory(VirtualDir save_directory) : dir(std::move(save_directory)) {}
 
+SaveDataFactory::~SaveDataFactory() = default;
+
 ResultVal<VirtualDir> SaveDataFactory::Open(SaveDataSpaceId space, SaveDataDescriptor meta) {
     if (meta.type == SaveDataType::SystemSaveData || meta.type == SaveDataType::SaveData) {
         if (meta.zero_1 != 0) {

--- a/src/core/file_sys/savedata_factory.h
+++ b/src/core/file_sys/savedata_factory.h
@@ -48,6 +48,7 @@ static_assert(sizeof(SaveDataDescriptor) == 0x40, "SaveDataDescriptor has incorr
 class SaveDataFactory {
 public:
     explicit SaveDataFactory(VirtualDir dir);
+    ~SaveDataFactory();
 
     ResultVal<VirtualDir> Open(SaveDataSpaceId space, SaveDataDescriptor meta);
 

--- a/src/core/file_sys/submission_package.h
+++ b/src/core/file_sys/submission_package.h
@@ -24,7 +24,7 @@ enum class ContentRecordType : u8;
 class NSP : public ReadOnlyVfsDirectory {
 public:
     explicit NSP(VirtualFile file);
-    ~NSP();
+    ~NSP() override;
 
     Loader::ResultStatus GetStatus() const;
     Loader::ResultStatus GetProgramStatus(u64 title_id) const;

--- a/src/core/file_sys/vfs_concat.cpp
+++ b/src/core/file_sys/vfs_concat.cpp
@@ -27,6 +27,8 @@ ConcatenatedVfsFile::ConcatenatedVfsFile(std::vector<VirtualFile> files_, std::s
     }
 }
 
+ConcatenatedVfsFile::~ConcatenatedVfsFile() = default;
+
 std::string ConcatenatedVfsFile::GetName() const {
     if (files.empty())
         return "";

--- a/src/core/file_sys/vfs_concat.h
+++ b/src/core/file_sys/vfs_concat.h
@@ -22,6 +22,8 @@ class ConcatenatedVfsFile : public VfsFile {
     ConcatenatedVfsFile(std::vector<VirtualFile> files, std::string name);
 
 public:
+    ~ConcatenatedVfsFile() override;
+
     std::string GetName() const override;
     std::size_t GetSize() const override;
     bool Resize(std::size_t new_size) override;

--- a/src/core/file_sys/vfs_offset.cpp
+++ b/src/core/file_sys/vfs_offset.cpp
@@ -14,6 +14,8 @@ OffsetVfsFile::OffsetVfsFile(std::shared_ptr<VfsFile> file_, std::size_t size_, 
     : file(file_), offset(offset_), size(size_), name(std::move(name_)),
       parent(parent_ == nullptr ? file->GetContainingDirectory() : std::move(parent_)) {}
 
+OffsetVfsFile::~OffsetVfsFile() = default;
+
 std::string OffsetVfsFile::GetName() const {
     return name.empty() ? file->GetName() : name;
 }

--- a/src/core/file_sys/vfs_offset.h
+++ b/src/core/file_sys/vfs_offset.h
@@ -19,6 +19,7 @@ class OffsetVfsFile : public VfsFile {
 public:
     OffsetVfsFile(std::shared_ptr<VfsFile> file, std::size_t size, std::size_t offset = 0,
                   std::string new_name = "", VirtualDir new_parent = nullptr);
+    ~OffsetVfsFile() override;
 
     std::string GetName() const override;
     std::size_t GetSize() const override;

--- a/src/core/file_sys/vfs_vector.cpp
+++ b/src/core/file_sys/vfs_vector.cpp
@@ -13,6 +13,8 @@ VectorVfsDirectory::VectorVfsDirectory(std::vector<VirtualFile> files_,
     : files(std::move(files_)), dirs(std::move(dirs_)), parent(std::move(parent_)),
       name(std::move(name_)) {}
 
+VectorVfsDirectory::~VectorVfsDirectory() = default;
+
 std::vector<std::shared_ptr<VfsFile>> VectorVfsDirectory::GetFiles() const {
     return files;
 }

--- a/src/core/file_sys/vfs_vector.h
+++ b/src/core/file_sys/vfs_vector.h
@@ -15,6 +15,7 @@ public:
     explicit VectorVfsDirectory(std::vector<VirtualFile> files = {},
                                 std::vector<VirtualDir> dirs = {}, std::string name = "",
                                 VirtualDir parent = nullptr);
+    ~VectorVfsDirectory() override;
 
     std::vector<std::shared_ptr<VfsFile>> GetFiles() const override;
     std::vector<std::shared_ptr<VfsDirectory>> GetSubdirectories() const override;

--- a/src/core/file_sys/xts_archive.cpp
+++ b/src/core/file_sys/xts_archive.cpp
@@ -72,6 +72,8 @@ NAX::NAX(VirtualFile file_, std::array<u8, 0x10> nca_id)
                                Common::HexArrayToString(nca_id, false)));
 }
 
+NAX::~NAX() = default;
+
 Loader::ResultStatus NAX::Parse(std::string_view path) {
     if (file->ReadObject(header.get()) != sizeof(NAXHeader))
         return Loader::ResultStatus::ErrorBadNAXHeader;

--- a/src/core/file_sys/xts_archive.h
+++ b/src/core/file_sys/xts_archive.h
@@ -33,6 +33,7 @@ class NAX : public ReadOnlyVfsDirectory {
 public:
     explicit NAX(VirtualFile file);
     explicit NAX(VirtualFile file, std::array<u8, 0x10> nca_id);
+    ~NAX() override;
 
     Loader::ResultStatus GetStatus() const;
 


### PR DESCRIPTION
Several classes have a lot of non-trivial members within them, or don't but likely should have the destructor defaulted in the cpp file for future-proofing/being more friendly to forward declarations.

Leaving the destructor unspecified allows the compiler to inline the destruction code all over the place, which is generally undesirable from a code bloat perspective.