### PR TITLE
game_list: Handle plurals within setFilterResult() better

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -89,15 +89,7 @@ bool GameList::SearchField::KeyReleaseEater::eventFilter(QObject* obj, QEvent* e
 }
 
 void GameList::SearchField::setFilterResult(int visible, int total) {
-    QString result_of_text = tr("of");
-    QString result_text;
-    if (total == 1) {
-        result_text = tr("result");
-    } else {
-        result_text = tr("results");
-    }
-    label_filter_result->setText(
-        QString("%1 %2 %3 %4").arg(visible).arg(result_of_text).arg(total).arg(result_text));
+    label_filter_result->setText(tr("%1 of %n result(s)", "", total).arg(visible));
 }
 
 void GameList::SearchField::clear() {


### PR DESCRIPTION
Qt provides an overload of `tr()` that operates on quantities in relation to pluralization. This also allows the translation to adapt based on the target language rules better.

For example, the previous code would result in an incorrect translation for the French language (which doesn't use the pluralized version of "result" in the case of a total of zero. While in English it's correct to use the pluralized version of "result", that is, "results"

---

For example:

- English: "0 results"

- French: "0 résultat" (uses the singular form)

In French, the noun being counted is singular if the quantity is `0` or `1`. In English, on the other hand, if the noun being counted has a quantity of `0` or `N > 1`, then the noun is pluralized.

---

For another example in a language that has different counting methods than the above, consider English and Irish. Irish has a special form of a grammatical number called a [dual](https://en.wikipedia.org/wiki/Dual_(grammatical_number)#Celtic_languages), which alters how a word is written when `N` of something is `2`. This won't appear in this case with a direct number "2", but it would change if we ever used "Two" to refer to two of something. For example:

- English: "Zero results"
- Irish: "Toradh ar bith"
<br/>

- English: "One result"
- Irish: "Toradh amháin"
<br/>

- English: "Two results"
- Irish: "Dhá thorthaí" ← Dual case
<br/>

Which is an important distinction to make between singular and plural, because in other situations, "two" on its own would be written as "dó" in Irish. There's also a few other cases where the order the words are placed *and* whether or not the plural or singular variant of the word is used *and* whether or not the word is placed after or between a set of numbers can vary. Counting in Irish also differs depending on whether or not you're counting things (like above) or counting people, in which case an entirely different set of numbers are used.

It's not important for this case, but it's provided as an example as to why one should never assume the placement of values in text will be like that of English or other languages. Some languages have very different ways to represent counting, and breaking up the translated string like this isn't advisable because it makes it extremely difficult to get right depending on what language a translator is translating text into due to the ambiguity of the strings being presented for translation.

In this case a translator would see three fragmented strings on Transifex (and not necessarily grouped beside one another, but even then, it would still be annoying to decipher):

- "of"
- "result"
- "results"

There is no way a translator is going to know what those sets of words are actually used for unless they look at the code to see what is being done with them (which they shouldn't have to do).