### PR TITLE
Set default windows size to native res 1280x720

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -321,7 +321,6 @@ void GMainWindow::InitializeHotkeys() {
 }
 
 void GMainWindow::SetDefaultUIGeometry() {
-    // geometry: 55% of the window contents are in the upper screen half, 45% in the lower half
     const QRect screenRect = QApplication::desktop()->screenGeometry(this);
 
     const int w = screenRect.width() * 2 / 3;
@@ -329,7 +328,7 @@ void GMainWindow::SetDefaultUIGeometry() {
     const int x = (screenRect.x() + screenRect.width()) / 2 - w / 2;
     const int y = (screenRect.y() + screenRect.height()) / 2 - h * 55 / 100;
 
-    setGeometry(x, y, w, h);
+    setGeometry(x, y, 1280, 720);
 }
 
 void GMainWindow::RestoreUIState() {


### PR DESCRIPTION
I do believe that the current SetDefaultUIGeometry() in yuzu is cater for 3DS which has upper and lower screen .This change is to set the windows size as native res of switch 1280x720 when startup .