### PR TITLE
arm_interface: Replace kernel vm_manager include with a forward declaration

### DIFF
--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -6,7 +6,10 @@
 
 #include <array>
 #include "common/common_types.h"
-#include "core/hle/kernel/vm_manager.h"
+
+namespace Kernel {
+enum class VMAPermission : u8;
+}
 
 namespace Core {
 

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -15,6 +15,7 @@
 #include "core/gdbstub/gdbstub.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/svc.h"
+#include "core/hle/kernel/vm_manager.h"
 #include "core/memory.h"
 
 namespace Core {

--- a/src/core/arm/dynarmic/arm_dynarmic.h
+++ b/src/core/arm/dynarmic/arm_dynarmic.h
@@ -12,6 +12,10 @@
 #include "core/arm/exclusive_monitor.h"
 #include "core/arm/unicorn/arm_unicorn.h"
 
+namespace Memory {
+struct PageTable;
+}
+
 namespace Core {
 
 class ARM_Dynarmic_Callbacks;

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -16,6 +16,7 @@
 #include "core/hle/kernel/object.h"
 #include "core/hle/kernel/thread.h"
 #include "core/hle/result.h"
+#include "core/memory.h"
 
 namespace Kernel {
 

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -15,6 +15,7 @@
 #include "core/hle/kernel/thread.h"
 #include "core/hle/kernel/timer.h"
 #include "core/hle/kernel/wait_object.h"
+#include "core/memory.h"
 
 WaitTreeItem::WaitTreeItem() = default;
 WaitTreeItem::~WaitTreeItem() = default;


### PR DESCRIPTION
Avoids an unnecessary inclusion and also uncovers three places where indirect inclusions were relied upon, which allows us to also resolve those.