### PR TITLE
kernel/thread: Use owner_process when setting the page table in SetupMainThread()

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -125,7 +125,7 @@ void Process::Run(VAddr entry_point, s32 main_thread_priority, u32 stack_size) {
     vm_manager.LogLayout();
     status = ProcessStatus::Running;
 
-    Kernel::SetupMainThread(kernel, entry_point, main_thread_priority, this);
+    Kernel::SetupMainThread(kernel, entry_point, main_thread_priority, *this);
 }
 
 void Process::LoadModule(SharedPtr<CodeSet> module_, VAddr base_addr) {

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -311,13 +311,13 @@ void Thread::BoostPriority(u32 priority) {
 }
 
 SharedPtr<Thread> SetupMainThread(KernelCore& kernel, VAddr entry_point, u32 priority,
-                                  SharedPtr<Process> owner_process) {
+                                  Process& owner_process) {
     // Setup page table so we can write to memory
-    SetCurrentPageTable(&Core::CurrentProcess()->vm_manager.page_table);
+    SetCurrentPageTable(&owner_process.vm_manager.page_table);
 
     // Initialize new "main" thread
     auto thread_res = Thread::Create(kernel, "main", entry_point, priority, 0, THREADPROCESSORID_0,
-                                     Memory::STACK_AREA_VADDR_END, std::move(owner_process));
+                                     Memory::STACK_AREA_VADDR_END, &owner_process);
 
     SharedPtr<Thread> thread = std::move(thread_res).Unwrap();
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -281,7 +281,7 @@ private:
  * @return A shared pointer to the main thread
  */
 SharedPtr<Thread> SetupMainThread(KernelCore& kernel, VAddr entry_point, u32 priority,
-                                  SharedPtr<Process> owner_process);
+                                  Process& owner_process);
 
 /**
  * Gets the current thread


### PR DESCRIPTION
The owning process of a thread is required to exist before the thread, so we can enforce this API-wise by using a reference. We can also avoid the reliance on the system instance by using that parameter to access the page table that needs to be set.

It essentially avoids unnecessary indirection for information that's already available.