### PR TITLE
Revert GetRequestState

### DIFF
--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -65,7 +65,7 @@ private:
         LOG_WARNING(Service_NIFM, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u32>(3);
+        rb.Push<u32>(0);
     }
 
     void GetResult(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
Even though setting this value to 3 is more correct. We break more games than we fix due to missing implementations. We should keep this as 0 for the time being