### PR TITLE
Logging: Change the TimeStretch::Process log from debug to trace level.

### DIFF
--- a/src/audio_core/time_stretch.cpp
+++ b/src/audio_core/time_stretch.cpp
@@ -59,7 +59,7 @@ std::size_t TimeStretcher::Process(const s16* in, std::size_t num_in, s16* out,
     m_stretch_ratio = std::max(m_stretch_ratio, 0.05);
     m_sound_touch.setTempo(m_stretch_ratio);
 
-    LOG_DEBUG(Audio, "{:5}/{:5} ratio:{:0.6f} backlog:{:0.6f}", num_in, num_out, m_stretch_ratio,
+    LOG_TRACE(Audio, "{:5}/{:5} ratio:{:0.6f} backlog:{:0.6f}", num_in, num_out, m_stretch_ratio,
               backlog_fullness);
 
     m_sound_touch.putSamples(in, static_cast<u32>(num_in));


### PR DESCRIPTION
This function is called too many times and makes the debug logging basically unusable due to the spam.