### PR TITLE
process: Make a few member variables private where applicable

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -128,6 +128,64 @@ void Process::Run(VAddr entry_point, s32 main_thread_priority, u32 stack_size) {
     Kernel::SetupMainThread(kernel, entry_point, main_thread_priority, *this);
 }
 
+/**
+ * Finds a free location for the TLS section of a thread.
+ * @param tls_slots The TLS page array of the thread's owner process.
+ * Returns a tuple of (page, slot, alloc_needed) where:
+ * page: The index of the first allocated TLS page that has free slots.
+ * slot: The index of the first free slot in the indicated page.
+ * alloc_needed: Whether there's a need to allocate a new TLS page (All pages are full).
+ */
+static std::tuple<std::size_t, std::size_t, bool> FindFreeThreadLocalSlot(
+    const std::vector<std::bitset<8>>& tls_slots) {
+    // Iterate over all the allocated pages, and try to find one where not all slots are used.
+    for (std::size_t page = 0; page < tls_slots.size(); ++page) {
+        const auto& page_tls_slots = tls_slots[page];
+        if (!page_tls_slots.all()) {
+            // We found a page with at least one free slot, find which slot it is
+            for (std::size_t slot = 0; slot < page_tls_slots.size(); ++slot) {
+                if (!page_tls_slots.test(slot)) {
+                    return std::make_tuple(page, slot, false);
+                }
+            }
+        }
+    }
+
+    return std::make_tuple(0, 0, true);
+}
+
+VAddr Process::MarkNextAvailableTLSSlotAsUsed(Thread& thread) {
+    auto [available_page, available_slot, needs_allocation] = FindFreeThreadLocalSlot(tls_slots);
+
+    if (needs_allocation) {
+        tls_slots.emplace_back(0); // The page is completely available at the start
+        available_page = tls_slots.size() - 1;
+        available_slot = 0; // Use the first slot in the new page
+
+        // Allocate some memory from the end of the linear heap for this region.
+        auto& tls_memory = thread.GetTLSMemory();
+        tls_memory->insert(tls_memory->end(), Memory::PAGE_SIZE, 0);
+
+        vm_manager.RefreshMemoryBlockMappings(tls_memory.get());
+
+        vm_manager.MapMemoryBlock(Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE,
+                                  tls_memory, 0, Memory::PAGE_SIZE, MemoryState::ThreadLocal);
+    }
+
+    tls_slots[available_page].set(available_slot);
+
+    return Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE +
+           available_slot * Memory::TLS_ENTRY_SIZE;
+}
+
+void Process::FreeTLSSlot(VAddr tls_address) {
+    const VAddr tls_base = tls_address - Memory::TLS_AREA_VADDR;
+    const VAddr tls_page = tls_base / Memory::PAGE_SIZE;
+    const VAddr tls_slot = (tls_base % Memory::PAGE_SIZE) / Memory::TLS_ENTRY_SIZE;
+
+    tls_slots[tls_page].reset(tls_slot);
+}
+
 void Process::LoadModule(SharedPtr<CodeSet> module_, VAddr base_addr) {
     const auto MapSegment = [&](CodeSet::Segment& segment, VMAPermission permissions,
                                 MemoryState memory_state) {

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -176,7 +176,24 @@ public:
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // Memory Management
 
+    // Marks the next available region as used and returns the address of the slot.
+    VAddr MarkNextAvailableTLSSlotAsUsed(Thread& thread);
+
+    // Frees a used TLS slot identified by the given address
+    void FreeTLSSlot(VAddr tls_address);
+
+    ResultVal<VAddr> HeapAllocate(VAddr target, u64 size, VMAPermission perms);
+    ResultCode HeapFree(VAddr target, u32 size);
+
+    ResultCode MirrorMemory(VAddr dst_addr, VAddr src_addr, u64 size);
+
+    ResultCode UnmapMemory(VAddr dst_addr, VAddr src_addr, u64 size);
+
     VMManager vm_manager;
+
+private:
+    explicit Process(KernelCore& kernel);
+    ~Process() override;
 
     // Memory used to back the allocations in the regular heap. A single vector is used to cover
     // the entire virtual address space extents that bound the allocations, including any holes.
@@ -197,17 +214,6 @@ public:
     std::vector<std::bitset<8>> tls_slots;
 
     std::string name;
-
-    ResultVal<VAddr> HeapAllocate(VAddr target, u64 size, VMAPermission perms);
-    ResultCode HeapFree(VAddr target, u32 size);
-
-    ResultCode MirrorMemory(VAddr dst_addr, VAddr src_addr, u64 size);
-
-    ResultCode UnmapMemory(VAddr dst_addr, VAddr src_addr, u64 size);
-
-private:
-    explicit Process(KernelCore& kernel);
-    ~Process() override;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -131,6 +131,16 @@ public:
         return HANDLE_TYPE;
     }
 
+    /// Gets the current status of the process
+    ProcessStatus GetStatus() const {
+        return status;
+    }
+
+    /// Gets the unique ID that identifies this particular process.
+    u32 GetProcessID() const {
+        return process_id;
+    }
+
     /// Title ID corresponding to the process
     u64 program_id;
 
@@ -154,11 +164,6 @@ public:
     u32 allowed_processor_mask = THREADPROCESSORID_DEFAULT_MASK;
     u32 allowed_thread_priority_mask = 0xFFFFFFFF;
     u32 is_virtual_address_memory_enabled = 0;
-    /// Current status of the process
-    ProcessStatus status;
-
-    /// The ID of this process
-    u32 process_id = 0;
 
     /**
      * Parses a list of kernel capability descriptors (as found in the ExHeader) and applies them
@@ -170,6 +175,12 @@ public:
      * Applies address space changes and launches the process main thread.
      */
     void Run(VAddr entry_point, s32 main_thread_priority, u32 stack_size);
+
+    /**
+     * Prepares a process for termination by stopping all of its threads
+     * and clearing any other resources.
+     */
+    void PrepareForTermination();
 
     void LoadModule(SharedPtr<CodeSet> module_, VAddr base_addr);
 
@@ -194,6 +205,12 @@ public:
 private:
     explicit Process(KernelCore& kernel);
     ~Process() override;
+
+    /// Current status of the process
+    ProcessStatus status;
+
+    /// The ID of this process
+    u32 process_id = 0;
 
     // Memory used to back the allocations in the regular heap. A single vector is used to cover
     // the entire virtual address space extents that bound the allocations, including any holes.

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -62,6 +62,9 @@ enum class ThreadWakeupReason {
 
 class Thread final : public WaitObject {
 public:
+    using TLSMemory = std::vector<u8>;
+    using TLSMemoryPtr = std::shared_ptr<TLSMemory>;
+
     /**
      * Creates and returns a new thread. The new thread is immediately scheduled
      * @param kernel The kernel instance this thread will be created under.
@@ -132,6 +135,14 @@ public:
      */
     u32 GetThreadId() const {
         return thread_id;
+    }
+
+    TLSMemoryPtr& GetTLSMemory() {
+        return tls_memory;
+    }
+
+    const TLSMemoryPtr& GetTLSMemory() const {
+        return tls_memory;
     }
 
     /**
@@ -269,7 +280,7 @@ private:
     explicit Thread(KernelCore& kernel);
     ~Thread() override;
 
-    std::shared_ptr<std::vector<u8>> tls_memory = std::make_shared<std::vector<u8>>();
+    TLSMemoryPtr tls_memory = std::make_shared<TLSMemory>();
 };
 
 /**


### PR DESCRIPTION
Mainly to make it easier to reason about certain aspects of a process, and to make it easier to do a few planned changes in the future. This just gets the cleanup out of the way so its not necessary to include it alongside said planned changes.