### PR TITLE
gl_stream_buffer: Fix use of bitwise OR instead of logical OR in Map()

### DIFF
--- a/src/video_core/renderer_opengl/gl_stream_buffer.cpp
+++ b/src/video_core/renderer_opengl/gl_stream_buffer.cpp
@@ -74,7 +74,7 @@ std::tuple<u8*, GLintptr, bool> OGLStreamBuffer::Map(GLsizeiptr size, GLintptr a
         }
     }
 
-    if (invalidate | !persistent) {
+    if (invalidate || !persistent) {
         GLbitfield flags = GL_MAP_WRITE_BIT | (persistent ? GL_MAP_PERSISTENT_BIT : 0) |
                            (coherent ? GL_MAP_COHERENT_BIT : GL_MAP_FLUSH_EXPLICIT_BIT) |
                            (invalidate ? GL_MAP_INVALIDATE_BUFFER_BIT : GL_MAP_UNSYNCHRONIZED_BIT);


### PR DESCRIPTION
This was very likely intended to be a logical OR based off the conditioning and testing of inversion in one case.

Even if this was intentional, this is the kind of non-obvious thing one should be clarifying with a comment.