### PR TITLE
gl_state: Remove unused type alias

### DIFF
--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -4,6 +4,7 @@
 
 #include <iterator>
 #include <glad/glad.h>
+#include "common/assert.h"
 #include "common/logging/log.h"
 #include "video_core/renderer_opengl/gl_state.h"
 

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -7,11 +7,7 @@
 #include <array>
 #include <glad/glad.h>
 
-#include "video_core/engines/maxwell_3d.h"
-
 namespace OpenGL {
-
-using Regs = Tegra::Engines::Maxwell3D::Regs;
 
 namespace TextureUnits {
 


### PR DESCRIPTION
This isn't used anywhere within the header, so we can remove it, along with the include that was previously necessary. This also uncovers an indirect include in the cpp file for the assertion macros.