### PR TITLE
game_list: Add Qt SmoothTransformation to picture scaling

### DIFF
--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -68,7 +68,7 @@ public:
         if (!picture.loadFromData(picture_data.data(), static_cast<u32>(picture_data.size()))) {
             picture = GetDefaultIcon(size);
         }
-        picture = picture.scaled(size, size);
+        picture = picture.scaled(size, size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
 
         setData(picture, Qt::DecorationRole);
     }


### PR DESCRIPTION
As per @jroweboy 's request - makes the icons less crispy at low resolutions.

Example:
![less crisp](https://user-images.githubusercontent.com/5064800/45911813-44406a00-bde6-11e8-8cee-78b7e991c338.PNG)
