### PR TITLE
Build: Reintroduce Appveyor deploy

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -163,3 +163,13 @@ artifacts:
     name: build
     type: zip
 
+deploy:
+  provider: GitHub
+  release: $(appveyor_repo_tag_name)
+  auth_token:
+    secure: QqePPnXbkzmXct5c8hZ2X5AbsthbI6cS1Sr+VBzcD8oUOIjfWJJKXVAQGUbQAbb0
+  artifact: update,build
+  draft: false
+  prerelease: false
+  on:
+    appveyor_repo_tag: true


### PR DESCRIPTION
This was erroneously removed when we added travis mingw builds. We still
want to push MSVC builds to github for the time being