### PR TITLE
Port citra-emu/citra#4245: "common/thread: remove YieldCPU()"

### DIFF
--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -87,14 +87,6 @@ private:
 
 void SleepCurrentThread(int ms);
 void SwitchCurrentThread(); // On Linux, this is equal to sleep 1ms
-
-// Use this function during a spin-wait to make the current thread
-// relax while another thread is working. This may be more efficient
-// than using events because event functions use kernel calls.
-inline void YieldCPU() {
-    std::this_thread::yield();
-}
-
 void SetCurrentThreadName(const char* name);
 
 } // namespace Common


### PR DESCRIPTION
Original description: `Simply use the standard library yield()`