### PR TITLE
Port citra-emu/citra#4258: "Meta: Add gitattributes file"

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+dist/languages/* linguist-vendored
+dist/qt_themes/* linguist-vendored
+externals/* linguist-vendored
+*.h linguist-language=cpp


### PR DESCRIPTION
See citra-emu/citra#4258 for more details.

Original description: `Github Linguist will read this file when calculating language stats for
the repository. We can use this to exclude any vendored dependencies in
externals and dist. Also makes all h files be considered cpp`

I'm not sure if I should remove `dist/languages/*` as it's currently not in yuzu, but will certainly be added in the future.