### PR TITLE
stream: Preserve enum class type in GetState()

### DIFF
--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -79,7 +79,7 @@ u32 AudioRenderer::GetMixBufferCount() const {
     return worker_params.mix_buffer_count;
 }
 
-u32 AudioRenderer::GetState() const {
+Stream::State AudioRenderer::GetStreamState() const {
     return stream->GetState();
 }
 

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -170,7 +170,7 @@ public:
     u32 GetSampleRate() const;
     u32 GetSampleCount() const;
     u32 GetMixBufferCount() const;
-    u32 GetState() const;
+    Stream::State GetStreamState() const;
 
 private:
     class VoiceState;

--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -53,8 +53,8 @@ void Stream::Stop() {
     ASSERT_MSG(false, "Unimplemented");
 }
 
-u32 Stream::GetState() const {
-    return static_cast<u32>(state);
+Stream::State Stream::GetState() const {
+    return state;
 }
 
 s64 Stream::GetBufferReleaseCycles(const Buffer& buffer) const {

--- a/src/audio_core/stream.h
+++ b/src/audio_core/stream.h
@@ -33,6 +33,12 @@ public:
         Multi51Channel16,
     };
 
+    /// Current state of the stream
+    enum class State {
+        Stopped,
+        Playing,
+    };
+
     /// Callback function type, used to change guest state on a buffer being released
     using ReleaseCallback = std::function<void()>;
 
@@ -73,15 +79,9 @@ public:
     u32 GetNumChannels() const;
 
     /// Get the state
-    u32 GetState() const;
+    State GetState() const;
 
 private:
-    /// Current state of the stream
-    enum class State {
-        Stopped,
-        Playing,
-    };
-
     /// Plays the next queued buffer in the audio stream, starting playback if necessary
     void PlayNextBuffer();
 

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -65,7 +65,7 @@ private:
     void GetAudioRendererState(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u32>(renderer->GetState());
+        rb.Push<u32>(static_cast<u32>(renderer->GetStreamState()));
         LOG_DEBUG(Service_Audio, "called");
     }
 


### PR DESCRIPTION
Preserves the meaning/type-safetiness of the stream state instead of making it an opaque u32. This makes it usable for other things outside of the service HLE context.