### PR TITLE
process/vm_manager: Initial modifications to load NPDM metadata

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -129,7 +129,8 @@ public:
 };
 
 std::unique_ptr<Dynarmic::A64::Jit> ARM_Dynarmic::MakeJit() const {
-    auto** const page_table = Core::CurrentProcess()->vm_manager.page_table.pointers.data();
+    auto& current_process = Core::CurrentProcess();
+    auto** const page_table = current_process->vm_manager.page_table.pointers.data();
 
     Dynarmic::A64::UserConfig config;
 
@@ -138,7 +139,7 @@ std::unique_ptr<Dynarmic::A64::Jit> ARM_Dynarmic::MakeJit() const {
 
     // Memory
     config.page_table = reinterpret_cast<void**>(page_table);
-    config.page_table_address_space_bits = Memory::ADDRESS_SPACE_BITS;
+    config.page_table_address_space_bits = current_process->vm_manager.GetAddressSpaceWidth();
     config.silently_mirror_page_table = false;
 
     // Multi-process state

--- a/src/core/file_sys/program_metadata.cpp
+++ b/src/core/file_sys/program_metadata.cpp
@@ -83,10 +83,12 @@ void ProgramMetadata::Print() const {
 
     auto address_space = "Unknown";
     switch (npdm_header.address_space_type) {
-    case ProgramAddressSpaceType::Is64Bit:
+    case ProgramAddressSpaceType::Is36Bit:
+    case ProgramAddressSpaceType::Is39Bit:
         address_space = "64-bit";
         break;
     case ProgramAddressSpaceType::Is32Bit:
+    case ProgramAddressSpaceType::Is32BitNoMap:
         address_space = "32-bit";
         break;
     }

--- a/src/core/file_sys/program_metadata.h
+++ b/src/core/file_sys/program_metadata.h
@@ -17,8 +17,10 @@ enum class ResultStatus : u16;
 namespace FileSys {
 
 enum class ProgramAddressSpaceType : u8 {
-    Is64Bit = 1,
-    Is32Bit = 2,
+    Is32Bit = 0,
+    Is36Bit = 1,
+    Is32BitNoMap = 2,
+    Is39Bit = 3,
 };
 
 enum class ProgramFilePermission : u64 {

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -127,7 +127,7 @@ void Process::Run(VAddr entry_point, s32 main_thread_priority, u32 stack_size) {
     // TODO(bunnei): This is heap area that should be allocated by the kernel and not mapped as part
     // of the user address space.
     vm_manager
-        .MapMemoryBlock(Memory::STACK_AREA_VADDR_END - stack_size,
+        .MapMemoryBlock(vm_manager.GetTLSIORegionEndAddress() - stack_size,
                         std::make_shared<std::vector<u8>>(stack_size, 0), 0, stack_size,
                         MemoryState::Mapped)
         .Unwrap();
@@ -193,6 +193,7 @@ static std::tuple<std::size_t, std::size_t, bool> FindFreeThreadLocalSlot(
 
 VAddr Process::MarkNextAvailableTLSSlotAsUsed(Thread& thread) {
     auto [available_page, available_slot, needs_allocation] = FindFreeThreadLocalSlot(tls_slots);
+    const VAddr tls_begin = vm_manager.GetTLSIORegionBaseAddress();
 
     if (needs_allocation) {
         tls_slots.emplace_back(0); // The page is completely available at the start
@@ -205,18 +206,17 @@ VAddr Process::MarkNextAvailableTLSSlotAsUsed(Thread& thread) {
 
         vm_manager.RefreshMemoryBlockMappings(tls_memory.get());
 
-        vm_manager.MapMemoryBlock(Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE,
-                                  tls_memory, 0, Memory::PAGE_SIZE, MemoryState::ThreadLocal);
+        vm_manager.MapMemoryBlock(tls_begin + available_page * Memory::PAGE_SIZE, tls_memory, 0,
+                                  Memory::PAGE_SIZE, MemoryState::ThreadLocal);
     }
 
     tls_slots[available_page].set(available_slot);
 
-    return Memory::TLS_AREA_VADDR + available_page * Memory::PAGE_SIZE +
-           available_slot * Memory::TLS_ENTRY_SIZE;
+    return tls_begin + available_page * Memory::PAGE_SIZE + available_slot * Memory::TLS_ENTRY_SIZE;
 }
 
 void Process::FreeTLSSlot(VAddr tls_address) {
-    const VAddr tls_base = tls_address - Memory::TLS_AREA_VADDR;
+    const VAddr tls_base = tls_address - vm_manager.GetTLSIORegionBaseAddress();
     const VAddr tls_page = tls_base / Memory::PAGE_SIZE;
     const VAddr tls_slot = (tls_base % Memory::PAGE_SIZE) / Memory::TLS_ENTRY_SIZE;
 
@@ -240,8 +240,8 @@ void Process::LoadModule(SharedPtr<CodeSet> module_, VAddr base_addr) {
 }
 
 ResultVal<VAddr> Process::HeapAllocate(VAddr target, u64 size, VMAPermission perms) {
-    if (target < Memory::HEAP_VADDR || target + size > Memory::HEAP_VADDR_END ||
-        target + size < target) {
+    if (target < vm_manager.GetHeapRegionBaseAddress() ||
+        target + size > vm_manager.GetHeapRegionEndAddress() || target + size < target) {
         return ERR_INVALID_ADDRESS;
     }
 
@@ -276,8 +276,8 @@ ResultVal<VAddr> Process::HeapAllocate(VAddr target, u64 size, VMAPermission per
 }
 
 ResultCode Process::HeapFree(VAddr target, u32 size) {
-    if (target < Memory::HEAP_VADDR || target + size > Memory::HEAP_VADDR_END ||
-        target + size < target) {
+    if (target < vm_manager.GetHeapRegionBaseAddress() ||
+        target + size > vm_manager.GetHeapRegionEndAddress() || target + size < target) {
         return ERR_INVALID_ADDRESS;
     }
 

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -17,6 +17,10 @@
 #include "core/hle/kernel/thread.h"
 #include "core/hle/kernel/vm_manager.h"
 
+namespace FileSys {
+class ProgramMetadata;
+}
+
 namespace Kernel {
 
 class KernelCore;
@@ -140,6 +144,14 @@ public:
     u32 GetProcessID() const {
         return process_id;
     }
+
+    /**
+     * Loads process-specifics configuration info with metadata provided
+     * by an executable.
+     *
+     * @param metadata The provided metadata to load process specific info.
+     */
+    void LoadFromMetadata(const FileSys::ProgramMetadata& metadata);
 
     /// Title ID corresponding to the process
     u64 program_id;

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -8,6 +8,7 @@
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/hle/kernel/errors.h"
+#include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/shared_memory.h"
 #include "core/memory.h"
 
@@ -71,7 +72,8 @@ SharedPtr<SharedMemory> SharedMemory::CreateForApplet(
     shared_memory->other_permissions = other_permissions;
     shared_memory->backing_block = std::move(heap_block);
     shared_memory->backing_block_offset = offset;
-    shared_memory->base_address = Memory::HEAP_VADDR + offset;
+    shared_memory->base_address =
+        kernel.CurrentProcess()->vm_manager.GetHeapRegionBaseAddress() + offset;
 
     return shared_memory;
 }

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -51,8 +51,9 @@ static ResultCode SetHeapSize(VAddr* heap_addr, u64 heap_size) {
     }
 
     auto& process = *Core::CurrentProcess();
+    const VAddr heap_base = process.vm_manager.GetHeapRegionBaseAddress();
     CASCADE_RESULT(*heap_addr,
-                   process.HeapAllocate(Memory::HEAP_VADDR, heap_size, VMAPermission::ReadWrite));
+                   process.HeapAllocate(heap_base, heap_size, VMAPermission::ReadWrite));
     return RESULT_SUCCESS;
 }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -325,26 +325,27 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
     LOG_TRACE(Kernel_SVC, "called info_id=0x{:X}, info_sub_id=0x{:X}, handle=0x{:08X}", info_id,
               info_sub_id, handle);
 
-    const auto& vm_manager = Core::CurrentProcess()->vm_manager;
+    const auto& current_process = Core::CurrentProcess();
+    const auto& vm_manager = current_process->vm_manager;
 
     switch (static_cast<GetInfoType>(info_id)) {
     case GetInfoType::AllowedCpuIdBitmask:
-        *result = Core::CurrentProcess()->allowed_processor_mask;
+        *result = current_process->allowed_processor_mask;
         break;
     case GetInfoType::AllowedThreadPrioBitmask:
-        *result = Core::CurrentProcess()->allowed_thread_priority_mask;
+        *result = current_process->allowed_thread_priority_mask;
         break;
     case GetInfoType::MapRegionBaseAddr:
-        *result = Memory::MAP_REGION_VADDR;
+        *result = vm_manager.GetMapRegionBaseAddress();
         break;
     case GetInfoType::MapRegionSize:
-        *result = Memory::MAP_REGION_SIZE;
+        *result = vm_manager.GetMapRegionSize();
         break;
     case GetInfoType::HeapRegionBaseAddr:
-        *result = Memory::HEAP_VADDR;
+        *result = vm_manager.GetHeapRegionBaseAddress();
         break;
     case GetInfoType::HeapRegionSize:
-        *result = Memory::HEAP_SIZE;
+        *result = vm_manager.GetHeapRegionSize();
         break;
     case GetInfoType::TotalMemoryUsage:
         *result = vm_manager.GetTotalMemoryUsage();
@@ -359,22 +360,35 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
         *result = 0;
         break;
     case GetInfoType::AddressSpaceBaseAddr:
-        *result = vm_manager.GetAddressSpaceBaseAddr();
+        *result = vm_manager.GetCodeRegionBaseAddress();
         break;
-    case GetInfoType::AddressSpaceSize:
-        *result = vm_manager.GetAddressSpaceSize();
+    case GetInfoType::AddressSpaceSize: {
+        const u64 width = vm_manager.GetAddressSpaceWidth();
+
+        switch (width) {
+        case 32:
+            *result = 0xFFE00000;
+            break;
+        case 36:
+            *result = 0xFF8000000;
+            break;
+        case 39:
+            *result = 0x7FF8000000;
+            break;
+        }
         break;
+    }
     case GetInfoType::NewMapRegionBaseAddr:
-        *result = Memory::NEW_MAP_REGION_VADDR;
+        *result = vm_manager.GetNewMapRegionBaseAddress();
         break;
     case GetInfoType::NewMapRegionSize:
-        *result = Memory::NEW_MAP_REGION_SIZE;
+        *result = vm_manager.GetNewMapRegionSize();
         break;
     case GetInfoType::IsVirtualAddressMemoryEnabled:
-        *result = Core::CurrentProcess()->is_virtual_address_memory_enabled;
+        *result = current_process->is_virtual_address_memory_enabled;
         break;
     case GetInfoType::TitleId:
-        *result = Core::CurrentProcess()->program_id;
+        *result = current_process->program_id;
         break;
     case GetInfoType::PrivilegedProcessId:
         LOG_WARNING(Kernel_SVC,

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -262,8 +262,9 @@ SharedPtr<Thread> SetupMainThread(KernelCore& kernel, VAddr entry_point, u32 pri
     SetCurrentPageTable(&owner_process.vm_manager.page_table);
 
     // Initialize new "main" thread
+    const VAddr stack_top = owner_process.vm_manager.GetTLSIORegionEndAddress();
     auto thread_res = Thread::Create(kernel, "main", entry_point, priority, 0, THREADPROCESSORID_0,
-                                     Memory::STACK_AREA_VADDR_END, &owner_process);
+                                     stack_top, &owner_process);
 
     SharedPtr<Thread> thread = std::move(thread_res).Unwrap();
 

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -474,14 +474,16 @@ u64 VMManager::GetTotalHeapUsage() const {
     return 0x0;
 }
 
-VAddr VMManager::GetAddressSpaceBaseAddr() const {
-    LOG_WARNING(Kernel, "(STUBBED) called");
-    return 0x8000000;
+VAddr VMManager::GetAddressSpaceBaseAddress() const {
+    return address_space_base;
+}
+
+VAddr VMManager::GetAddressSpaceEndAddress() const {
+    return address_space_end;
 }
 
 u64 VMManager::GetAddressSpaceSize() const {
-    LOG_WARNING(Kernel, "(STUBBED) called");
-    return MAX_ADDRESS;
+    return address_space_end - address_space_base;
 }
 
 u64 VMManager::GetAddressSpaceWidth() const {

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -205,6 +205,9 @@ public:
     /// Gets the total address space address size, used by svcGetInfo
     u64 GetAddressSpaceSize() const;
 
+    /// Gets the address space width in bits.
+    u64 GetAddressSpaceWidth() const;
+
     /// Gets the base address of the code region.
     VAddr GetCodeRegionBaseAddress() const;
 

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -12,6 +12,10 @@
 #include "core/memory.h"
 #include "core/memory_hook.h"
 
+namespace FileSys {
+enum class ProgramAddressSpaceType : u8;
+}
+
 namespace Kernel {
 
 enum class VMAType : u8 {
@@ -130,7 +134,7 @@ public:
     ~VMManager();
 
     /// Clears the address space map, re-initializing with a single free area.
-    void Reset();
+    void Reset(FileSys::ProgramAddressSpaceType type);
 
     /// Finds the VMA in which the given address is included in, or `vma_map.end()`.
     VMAHandle FindVMA(VAddr target) const;
@@ -195,11 +199,56 @@ public:
     /// Gets the total heap usage, used by svcGetInfo
     u64 GetTotalHeapUsage() const;
 
-    /// Gets the total address space base address, used by svcGetInfo
+    /// Gets the address space base address, used by svcGetInfo
     VAddr GetAddressSpaceBaseAddr() const;
 
     /// Gets the total address space address size, used by svcGetInfo
     u64 GetAddressSpaceSize() const;
+
+    /// Gets the base address of the code region.
+    VAddr GetCodeRegionBaseAddress() const;
+
+    /// Gets the end address of the code region.
+    VAddr GetCodeRegionEndAddress() const;
+
+    /// Gets the total size of the code region in bytes.
+    u64 GetCodeRegionSize() const;
+
+    /// Gets the base address of the heap region.
+    VAddr GetHeapRegionBaseAddress() const;
+
+    /// Gets the end address of the heap region;
+    VAddr GetHeapRegionEndAddress() const;
+
+    /// Gets the total size of the heap region in bytes.
+    u64 GetHeapRegionSize() const;
+
+    /// Gets the base address of the map region.
+    VAddr GetMapRegionBaseAddress() const;
+
+    /// Gets the end address of the map region.
+    VAddr GetMapRegionEndAddress() const;
+
+    /// Gets the total size of the map region in bytes.
+    u64 GetMapRegionSize() const;
+
+    /// Gets the base address of the new map region.
+    VAddr GetNewMapRegionBaseAddress() const;
+
+    /// Gets the end address of the new map region.
+    VAddr GetNewMapRegionEndAddress() const;
+
+    /// Gets the total size of the new map region in bytes.
+    u64 GetNewMapRegionSize() const;
+
+    /// Gets the base address of the TLS IO region.
+    VAddr GetTLSIORegionBaseAddress() const;
+
+    /// Gets the end address of the TLS IO region.
+    VAddr GetTLSIORegionEndAddress() const;
+
+    /// Gets the total size of the TLS IO region in bytes.
+    u64 GetTLSIORegionSize() const;
 
     /// Each VMManager has its own page table, which is set as the main one when the owning process
     /// is scheduled.
@@ -240,5 +289,36 @@ private:
 
     /// Updates the pages corresponding to this VMA so they match the VMA's attributes.
     void UpdatePageTableForVMA(const VirtualMemoryArea& vma);
+
+    /// Initializes memory region ranges to adhere to a given address space type.
+    void InitializeMemoryRegionRanges(FileSys::ProgramAddressSpaceType type);
+
+    /// Clears the underlying map and page table.
+    void Clear();
+
+    /// Clears out the VMA map, unmapping any previously mapped ranges.
+    void ClearVMAMap();
+
+    /// Clears out the page table
+    void ClearPageTable();
+
+    u32 address_space_width = 0;
+    VAddr address_space_base = 0;
+    VAddr address_space_end = 0;
+
+    VAddr code_region_base = 0;
+    VAddr code_region_end = 0;
+
+    VAddr heap_region_base = 0;
+    VAddr heap_region_end = 0;
+
+    VAddr map_region_base = 0;
+    VAddr map_region_end = 0;
+
+    VAddr new_map_region_base = 0;
+    VAddr new_map_region_end = 0;
+
+    VAddr tls_io_region_base = 0;
+    VAddr tls_io_region_end = 0;
 };
 } // namespace Kernel

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -115,12 +115,6 @@ struct VirtualMemoryArea {
 class VMManager final {
 public:
     /**
-     * The maximum amount of address space managed by the kernel.
-     * @todo This was selected arbitrarily, and should be verified for Switch OS.
-     */
-    static constexpr VAddr MAX_ADDRESS{0x1000000000ULL};
-
-    /**
      * A map covering the entirety of the managed address space, keyed by the `base` field of each
      * VMA. It must always be modified by splitting or merging VMAs, so that the invariant
      * `elem.base + elem.size == next.base` is preserved, and mergeable regions must always be
@@ -199,10 +193,13 @@ public:
     /// Gets the total heap usage, used by svcGetInfo
     u64 GetTotalHeapUsage() const;
 
-    /// Gets the address space base address, used by svcGetInfo
-    VAddr GetAddressSpaceBaseAddr() const;
+    /// Gets the address space base address
+    VAddr GetAddressSpaceBaseAddress() const;
 
-    /// Gets the total address space address size, used by svcGetInfo
+    /// Gets the address space end address
+    VAddr GetAddressSpaceEndAddress() const;
+
+    /// Gets the total address space address size in bytes
     u64 GetAddressSpaceSize() const;
 
     /// Gets the address space width in bits.

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -17,7 +17,6 @@
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/loader/deconstructed_rom_directory.h"
 #include "core/loader/nso.h"
-#include "core/memory.h"
 
 namespace Loader {
 
@@ -134,7 +133,8 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(
     process->LoadFromMetadata(metadata);
 
     // Load NSO modules
-    VAddr next_load_addr{Memory::PROCESS_IMAGE_VADDR};
+    const VAddr base_address = process->vm_manager.GetCodeRegionBaseAddress();
+    VAddr next_load_addr = base_address;
     for (const auto& module : {"rtld", "main", "subsdk0", "subsdk1", "subsdk2", "subsdk3",
                                "subsdk4", "subsdk5", "subsdk6", "subsdk7", "sdk"}) {
         const FileSys::VirtualFile module_file = dir->GetFile(module);
@@ -147,8 +147,7 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(
         }
     }
 
-    process->Run(Memory::PROCESS_IMAGE_VADDR, metadata.GetMainThreadPriority(),
-                 metadata.GetMainThreadStackSize());
+    process->Run(base_address, metadata.GetMainThreadPriority(), metadata.GetMainThreadStackSize());
 
     // Find the RomFS by searching for a ".romfs" file in this directory
     const auto& files = dir->GetFiles();

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -12,7 +12,6 @@
 #include "core/core.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
-#include "core/hle/kernel/resource_limit.h"
 #include "core/loader/elf.h"
 #include "core/memory.h"
 
@@ -400,13 +399,6 @@ ResultStatus AppLoader_ELF::Load(Kernel::SharedPtr<Kernel::Process>& process) {
     codeset->name = file->GetName();
 
     process->LoadModule(codeset, codeset->entrypoint);
-    process->svc_access_mask.set();
-
-    // Attach the default resource limit (APPLICATION) to the process
-    auto& kernel = Core::System::GetInstance().Kernel();
-    process->resource_limit =
-        kernel.ResourceLimitForCategory(Kernel::ResourceLimitCategory::APPLICATION);
-
     process->Run(codeset->entrypoint, 48, Memory::DEFAULT_STACK_SIZE);
 
     is_loaded = true;

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -16,7 +16,6 @@
 #include "core/gdbstub/gdbstub.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
-#include "core/hle/kernel/resource_limit.h"
 #include "core/loader/nro.h"
 #include "core/memory.h"
 
@@ -187,10 +186,6 @@ ResultStatus AppLoader_NRO::Load(Kernel::SharedPtr<Kernel::Process>& process) {
         return ResultStatus::ErrorLoadingNRO;
     }
 
-    auto& kernel = Core::System::GetInstance().Kernel();
-    process->svc_access_mask.set();
-    process->resource_limit =
-        kernel.ResourceLimitForCategory(Kernel::ResourceLimitCategory::APPLICATION);
     process->Run(base_addr, Kernel::THREADPRIO_DEFAULT, Memory::DEFAULT_STACK_SIZE);
 
     is_loaded = true;

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -16,6 +16,7 @@
 #include "core/gdbstub/gdbstub.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
+#include "core/hle/kernel/vm_manager.h"
 #include "core/loader/nro.h"
 #include "core/memory.h"
 
@@ -180,13 +181,13 @@ ResultStatus AppLoader_NRO::Load(Kernel::SharedPtr<Kernel::Process>& process) {
     }
 
     // Load NRO
-    static constexpr VAddr base_addr{Memory::PROCESS_IMAGE_VADDR};
+    const VAddr base_address = process->vm_manager.GetCodeRegionBaseAddress();
 
-    if (!LoadNro(file, base_addr)) {
+    if (!LoadNro(file, base_address)) {
         return ResultStatus::ErrorLoadingNRO;
     }
 
-    process->Run(base_addr, Kernel::THREADPRIO_DEFAULT, Memory::DEFAULT_STACK_SIZE);
+    process->Run(base_address, Kernel::THREADPRIO_DEFAULT, Memory::DEFAULT_STACK_SIZE);
 
     is_loaded = true;
     return ResultStatus::Success;

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -13,7 +13,6 @@
 #include "core/gdbstub/gdbstub.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
-#include "core/hle/kernel/resource_limit.h"
 #include "core/loader/nso.h"
 #include "core/memory.h"
 
@@ -162,10 +161,6 @@ ResultStatus AppLoader_NSO::Load(Kernel::SharedPtr<Kernel::Process>& process) {
     LoadModule(file, Memory::PROCESS_IMAGE_VADDR);
     LOG_DEBUG(Loader, "loaded module {} @ 0x{:X}", file->GetName(), Memory::PROCESS_IMAGE_VADDR);
 
-    auto& kernel = Core::System::GetInstance().Kernel();
-    process->svc_access_mask.set();
-    process->resource_limit =
-        kernel.ResourceLimitForCategory(Kernel::ResourceLimitCategory::APPLICATION);
     process->Run(Memory::PROCESS_IMAGE_VADDR, Kernel::THREADPRIO_DEFAULT,
                  Memory::DEFAULT_STACK_SIZE);
 

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -13,6 +13,7 @@
 #include "core/gdbstub/gdbstub.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
+#include "core/hle/kernel/vm_manager.h"
 #include "core/loader/nso.h"
 #include "core/memory.h"
 
@@ -158,11 +159,11 @@ ResultStatus AppLoader_NSO::Load(Kernel::SharedPtr<Kernel::Process>& process) {
     }
 
     // Load module
-    LoadModule(file, Memory::PROCESS_IMAGE_VADDR);
-    LOG_DEBUG(Loader, "loaded module {} @ 0x{:X}", file->GetName(), Memory::PROCESS_IMAGE_VADDR);
+    const VAddr base_address = process->vm_manager.GetCodeRegionBaseAddress();
+    LoadModule(file, base_address);
+    LOG_DEBUG(Loader, "loaded module {} @ 0x{:X}", file->GetName(), base_address);
 
-    process->Run(Memory::PROCESS_IMAGE_VADDR, Kernel::THREADPRIO_DEFAULT,
-                 Memory::DEFAULT_STACK_SIZE);
+    process->Run(base_address, Kernel::THREADPRIO_DEFAULT, Memory::DEFAULT_STACK_SIZE);
 
     is_loaded = true;
     return ResultStatus::Success;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -3,7 +3,6 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
-#include <array>
 #include <cstring>
 #include <utility>
 
@@ -41,6 +40,21 @@ PageTable* GetCurrentPageTable() {
     return current_page_table;
 }
 
+PageTable::PageTable() = default;
+
+PageTable::PageTable(std::size_t address_space_width_in_bits) {
+    Resize(address_space_width_in_bits);
+}
+
+PageTable::~PageTable() = default;
+
+void PageTable::Resize(std::size_t address_space_width_in_bits) {
+    const std::size_t num_page_table_entries = 1ULL << (address_space_width_in_bits - PAGE_BITS);
+
+    pointers.resize(num_page_table_entries);
+    attributes.resize(num_page_table_entries);
+}
+
 static void MapPages(PageTable& page_table, VAddr base, u64 size, u8* memory, PageType type) {
     LOG_DEBUG(HW_Memory, "Mapping {} onto {:016X}-{:016X}", fmt::ptr(memory), base * PAGE_SIZE,
               (base + size) * PAGE_SIZE);
@@ -50,7 +64,7 @@ static void MapPages(PageTable& page_table, VAddr base, u64 size, u8* memory, Pa
 
     VAddr end = base + size;
     while (base != end) {
-        ASSERT_MSG(base < PAGE_TABLE_NUM_ENTRIES, "out of range mapping at {:016X}", base);
+        ASSERT_MSG(base < page_table.pointers.size(), "out of range mapping at {:016X}", base);
 
         page_table.attributes[base] = type;
         page_table.pointers[base] = memory;

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -93,11 +93,6 @@ struct PageTable {
 
 /// Virtual user-space memory regions
 enum : VAddr {
-    /// Where the application text, data and bss reside.
-    PROCESS_IMAGE_VADDR = 0x08000000,
-    PROCESS_IMAGE_MAX_SIZE = 0x08000000,
-    PROCESS_IMAGE_VADDR_END = PROCESS_IMAGE_VADDR + PROCESS_IMAGE_MAX_SIZE,
-
     /// Read-only page containing kernel and system configuration values.
     CONFIG_MEMORY_VADDR = 0x1FF80000,
     CONFIG_MEMORY_SIZE = 0x00001000,
@@ -108,35 +103,11 @@ enum : VAddr {
     SHARED_PAGE_SIZE = 0x00001000,
     SHARED_PAGE_VADDR_END = SHARED_PAGE_VADDR + SHARED_PAGE_SIZE,
 
-    /// Area where TLS (Thread-Local Storage) buffers are allocated.
-    TLS_AREA_VADDR = 0x40000000,
+    /// TLS (Thread-Local Storage) related.
     TLS_ENTRY_SIZE = 0x200,
-    TLS_AREA_SIZE = 0x10000000,
-    TLS_AREA_VADDR_END = TLS_AREA_VADDR + TLS_AREA_SIZE,
 
     /// Application stack
-    STACK_AREA_VADDR = TLS_AREA_VADDR_END,
-    STACK_AREA_SIZE = 0x10000000,
-    STACK_AREA_VADDR_END = STACK_AREA_VADDR + STACK_AREA_SIZE,
     DEFAULT_STACK_SIZE = 0x100000,
-
-    /// Application heap
-    /// Size is confirmed to be a static value on fw 3.0.0
-    HEAP_VADDR = 0x108000000,
-    HEAP_SIZE = 0x180000000,
-    HEAP_VADDR_END = HEAP_VADDR + HEAP_SIZE,
-
-    /// New map region
-    /// Size is confirmed to be a static value on fw 3.0.0
-    NEW_MAP_REGION_VADDR = HEAP_VADDR_END,
-    NEW_MAP_REGION_SIZE = 0x80000000,
-    NEW_MAP_REGION_VADDR_END = NEW_MAP_REGION_VADDR + NEW_MAP_REGION_SIZE,
-
-    /// Map region
-    /// Size is confirmed to be a static value on fw 3.0.0
-    MAP_REGION_VADDR = NEW_MAP_REGION_VADDR_END,
-    MAP_REGION_SIZE = 0x1000000000,
-    MAP_REGION_VADDR_END = MAP_REGION_VADDR + MAP_REGION_SIZE,
 
     /// Kernel Virtual Address Range
     KERNEL_REGION_VADDR = 0xFFFFFF8000000000,

--- a/src/tests/core/arm/arm_test_common.cpp
+++ b/src/tests/core/arm/arm_test_common.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
+
 #include "core/core.h"
 #include "core/hle/kernel/process.h"
 #include "core/memory.h"
@@ -16,9 +18,10 @@ TestEnvironment::TestEnvironment(bool mutable_memory_)
     Core::CurrentProcess() = Kernel::Process::Create(kernel, "");
     page_table = &Core::CurrentProcess()->vm_manager.page_table;
 
-    page_table->pointers.fill(nullptr);
+    std::fill(page_table->pointers.begin(), page_table->pointers.end(), nullptr);
     page_table->special_regions.clear();
-    page_table->attributes.fill(Memory::PageType::Unmapped);
+    std::fill(page_table->attributes.begin(), page_table->attributes.end(),
+              Memory::PageType::Unmapped);
 
     Memory::MapIoRegion(*page_table, 0x00000000, 0x80000000, test_memory);
     Memory::MapIoRegion(*page_table, 0x80000000, 0x80000000, test_memory);


### PR DESCRIPTION
Previously we were never loading NPDM metadata in the event that it was available, which kind of sucks, because it means we'd be making assumptions about the address spaces. This also dehardcodes our assumption of a 36-bit address space (given it's possible for a game to demand a 39-bit one or 32-bit one).

Given we now read the basic NPDM metadata relating to the address space (and provide a fallback), we can finally provide proper values to the svcGetInfo service call for several categories. Note that this introduces the basics and will followed with another PR introducing more functionality (such as capability parsing, etc). This just gets the bulk of the cleaning out of the way first, such as the dehardcoding of addresses and whatnot.
