### PR TITLE
loader: Add support for packed updates

### DIFF
--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -206,7 +206,7 @@ VirtualFile PatchManager::PatchRomFS(VirtualFile romfs, u64 ivfc_offset, Content
             romfs = new_nca->GetRomFS();
         }
     } else if (update_raw != nullptr) {
-        const auto new_nca = std::make_shared<NCA>(update, romfs, ivfc_offset);
+        const auto new_nca = std::make_shared<NCA>(update_raw, romfs, ivfc_offset);
         if (new_nca->GetStatus() == Loader::ResultStatus::Success &&
             new_nca->GetRomFS() != nullptr) {
             LOG_INFO(Loader, "    RomFS: Update (PACKED) applied successfully");
@@ -231,7 +231,8 @@ static bool IsDirValidAndNonEmpty(const VirtualDir& dir) {
     return dir != nullptr && (!dir->GetFiles().empty() || !dir->GetSubdirectories().empty());
 }
 
-std::map<PatchType, std::string> PatchManager::GetPatchVersionNames(VirtualFile update_raw) const {
+std::map<std::string, std::string, std::less<>> PatchManager::GetPatchVersionNames(
+    VirtualFile update_raw) const {
     std::map<std::string, std::string, std::less<>> out;
     const auto installed = Service::FileSystem::GetUnionContents();
 
@@ -253,7 +254,7 @@ std::map<PatchType, std::string> PatchManager::GetPatchVersionNames(VirtualFile 
                     FormatTitleVersion(meta_ver.get(), TitleVersionFormat::ThreeElements));
             }
         } else if (update_raw != nullptr) {
-            out[PatchType::Update] = "PACKED";
+            out.insert_or_assign("Update", "PACKED");
         }
     }
 

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -209,7 +209,7 @@ VirtualFile PatchManager::PatchRomFS(VirtualFile romfs, u64 ivfc_offset, Content
         const auto new_nca = std::make_shared<NCA>(update, romfs, ivfc_offset);
         if (new_nca->GetStatus() == Loader::ResultStatus::Success &&
             new_nca->GetRomFS() != nullptr) {
-            LOG_INFO(Loader, "    RomFS: Update (XCI) applied successfully");
+            LOG_INFO(Loader, "    RomFS: Update (PACKED) applied successfully");
             romfs = new_nca->GetRomFS();
         }
     }
@@ -253,7 +253,7 @@ std::map<PatchType, std::string> PatchManager::GetPatchVersionNames(VirtualFile 
                     FormatTitleVersion(meta_ver.get(), TitleVersionFormat::ThreeElements));
             }
         } else if (update_raw != nullptr) {
-            out[PatchType::Update] = "XCI";
+            out[PatchType::Update] = "PACKED";
         }
     }
 

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -51,7 +51,8 @@ public:
 
     // Returns a vector of pairs between patch names and patch versions.
     // i.e. Update 3.2.2 will return {"Update", "3.2.2"}
-    std::map<std::string, std::string, std::less<>> GetPatchVersionNames() const;
+    std::map<std::string, std::string, std::less<>> GetPatchVersionNames(
+        VirtualFile update_raw = nullptr) const;
 
     // Given title_id of the program, attempts to get the control data of the update and parse it,
     // falling back to the base control data.

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -46,7 +46,8 @@ public:
     // - Game Updates
     // - LayeredFS
     VirtualFile PatchRomFS(VirtualFile base, u64 ivfc_offset,
-                           ContentRecordType type = ContentRecordType::Program) const;
+                           ContentRecordType type = ContentRecordType::Program,
+                           VirtualFile update_raw = nullptr) const;
 
     // Returns a vector of pairs between patch names and patch versions.
     // i.e. Update 3.2.2 will return {"Update", "3.2.2"}

--- a/src/core/file_sys/romfs_factory.cpp
+++ b/src/core/file_sys/romfs_factory.cpp
@@ -24,6 +24,7 @@ RomFSFactory::RomFSFactory(Loader::AppLoader& app_loader) {
         LOG_ERROR(Service_FS, "Unable to read RomFS!");
     }
 
+    app_loader.ReadUpdateRaw(update_raw);
     updatable = app_loader.IsRomFSUpdatable();
     ivfc_offset = app_loader.ReadRomFSIVFCOffset();
 }
@@ -35,7 +36,8 @@ ResultVal<VirtualFile> RomFSFactory::OpenCurrentProcess() {
         return MakeResult<VirtualFile>(file);
 
     const PatchManager patch_manager(Core::CurrentProcess()->GetTitleID());
-    return MakeResult<VirtualFile>(patch_manager.PatchRomFS(file, ivfc_offset));
+    return MakeResult<VirtualFile>(
+        patch_manager.PatchRomFS(file, ivfc_offset, ContentRecordType::Program, update_raw));
 }
 
 ResultVal<VirtualFile> RomFSFactory::Open(u64 title_id, StorageId storage, ContentRecordType type) {

--- a/src/core/file_sys/romfs_factory.cpp
+++ b/src/core/file_sys/romfs_factory.cpp
@@ -24,12 +24,15 @@ RomFSFactory::RomFSFactory(Loader::AppLoader& app_loader) {
         LOG_ERROR(Service_FS, "Unable to read RomFS!");
     }
 
-    app_loader.ReadUpdateRaw(update_raw);
     updatable = app_loader.IsRomFSUpdatable();
     ivfc_offset = app_loader.ReadRomFSIVFCOffset();
 }
 
 RomFSFactory::~RomFSFactory() = default;
+
+void RomFSFactory::SetPackedUpdate(VirtualFile update_raw) {
+    this->update_raw = std::move(update_raw);
+}
 
 ResultVal<VirtualFile> RomFSFactory::OpenCurrentProcess() {
     if (!updatable)

--- a/src/core/file_sys/romfs_factory.h
+++ b/src/core/file_sys/romfs_factory.h
@@ -37,6 +37,7 @@ public:
 
 private:
     VirtualFile file;
+    VirtualFile update_raw;
     bool updatable;
     u64 ivfc_offset;
 };

--- a/src/core/file_sys/romfs_factory.h
+++ b/src/core/file_sys/romfs_factory.h
@@ -32,6 +32,7 @@ public:
     explicit RomFSFactory(Loader::AppLoader& app_loader);
     ~RomFSFactory();
 
+    void SetPackedUpdate(VirtualFile update_raw);
     ResultVal<VirtualFile> OpenCurrentProcess();
     ResultVal<VirtualFile> Open(u64 title_id, StorageId storage, ContentRecordType type);
 

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -259,8 +259,11 @@ void NSP::ReadNCAs(const std::vector<VirtualFile>& files) {
                 auto next_nca = std::make_shared<NCA>(next_file);
                 if (next_nca->GetType() == NCAContentType::Program)
                     program_status[cnmt.GetTitleID()] = next_nca->GetStatus();
-                if (next_nca->GetStatus() == Loader::ResultStatus::Success)
+                if (next_nca->GetStatus() == Loader::ResultStatus::Success ||
+                    (next_nca->GetStatus() == Loader::ResultStatus::ErrorMissingBKTRBaseRomFS &&
+                     (cnmt.GetTitleID() & 0x800) != 0)) {
                     ncas_title[rec.type] = std::move(next_nca);
+                }
             }
 
             break;

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -264,6 +264,15 @@ ResultCode RegisterBIS(std::unique_ptr<FileSys::BISFactory>&& factory) {
     return RESULT_SUCCESS;
 }
 
+void SetPackedUpdate(FileSys::VirtualFile update_raw) {
+    LOG_TRACE(Service_FS, "Setting packed update for romfs");
+
+    if (romfs_factory == nullptr)
+        return;
+
+    romfs_factory->SetPackedUpdate(std::move(update_raw));
+}
+
 ResultVal<FileSys::VirtualFile> OpenRomFSCurrentProcess() {
     LOG_TRACE(Service_FS, "Opening RomFS for current process");
 

--- a/src/core/hle/service/filesystem/filesystem.h
+++ b/src/core/hle/service/filesystem/filesystem.h
@@ -39,6 +39,7 @@ ResultCode RegisterSaveData(std::unique_ptr<FileSys::SaveDataFactory>&& factory)
 ResultCode RegisterSDMC(std::unique_ptr<FileSys::SDMCFactory>&& factory);
 ResultCode RegisterBIS(std::unique_ptr<FileSys::BISFactory>&& factory);
 
+void SetPackedUpdate(FileSys::VirtualFile update_raw);
 ResultVal<FileSys::VirtualFile> OpenRomFSCurrentProcess();
 ResultVal<FileSys::VirtualFile> OpenRomFS(u64 title_id, FileSys::StorageId storage_id,
                                           FileSys::ContentRecordType type);

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -93,7 +93,7 @@ std::string GetFileTypeString(FileType type) {
     return "unknown";
 }
 
-constexpr std::array<const char*, 58> RESULT_MESSAGES{
+constexpr std::array<const char*, 59> RESULT_MESSAGES{
     "The operation completed successfully.",
     "The loader requested to load is already loaded.",
     "The operation is not implemented.",
@@ -152,6 +152,7 @@ constexpr std::array<const char*, 58> RESULT_MESSAGES{
     "The BKTR-type NCA has a bad Relocation bucket.",
     "The BKTR-type NCA has a bad Subsection bucket.",
     "The BKTR-type NCA is missing the base RomFS.",
+    "The NSP or XCI does not contain an update in addition to the base game.",
 };
 
 std::ostream& operator<<(std::ostream& os, ResultStatus status) {

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -114,6 +114,7 @@ enum class ResultStatus : u16 {
     ErrorBadRelocationBuckets,
     ErrorBadSubsectionBuckets,
     ErrorMissingBKTRBaseRomFS,
+    ErrorNoPackedUpdate,
 };
 
 std::ostream& operator<<(std::ostream& os, ResultStatus status);
@@ -196,10 +197,19 @@ public:
     /**
      * Get the RomFS of the application
      * Since the RomFS can be huge, we return a file reference instead of copying to a buffer
-     * @param dir The directory containing the RomFS
+     * @param file The directory containing the RomFS
      * @return ResultStatus result of function
      */
-    virtual ResultStatus ReadRomFS(FileSys::VirtualFile& dir) {
+    virtual ResultStatus ReadRomFS(FileSys::VirtualFile& file) {
+        return ResultStatus::ErrorNotImplemented;
+    }
+
+    /**
+     * Get the raw update of the application, should it come packed with one
+     * @param file The raw update NCA file (Program-type
+     * @return ResultStatus result of function
+     */
+    virtual ResultStatus ReadUpdateRaw(FileSys::VirtualFile& file) {
         return ResultStatus::ErrorNotImplemented;
     }
 

--- a/src/core/loader/nax.cpp
+++ b/src/core/loader/nax.cpp
@@ -72,6 +72,10 @@ ResultStatus AppLoader_NAX::ReadRomFS(FileSys::VirtualFile& dir) {
     return nca_loader->ReadRomFS(dir);
 }
 
+u64 AppLoader_NAX::ReadRomFSIVFCOffset() const {
+    return nca_loader->ReadRomFSIVFCOffset();
+}
+
 ResultStatus AppLoader_NAX::ReadProgramId(u64& out_program_id) {
     return nca_loader->ReadProgramId(out_program_id);
 }

--- a/src/core/loader/nax.h
+++ b/src/core/loader/nax.h
@@ -36,6 +36,7 @@ public:
     ResultStatus Load(Kernel::Process& process) override;
 
     ResultStatus ReadRomFS(FileSys::VirtualFile& dir) override;
+    u64 ReadRomFSIVFCOffset() const override;
     ResultStatus ReadProgramId(u64& out_program_id) override;
 
 private:

--- a/src/core/loader/nsp.cpp
+++ b/src/core/loader/nsp.cpp
@@ -10,8 +10,10 @@
 #include "core/file_sys/control_metadata.h"
 #include "core/file_sys/nca_metadata.h"
 #include "core/file_sys/patch_manager.h"
+#include "core/file_sys/registered_cache.h"
 #include "core/file_sys/submission_package.h"
 #include "core/hle/kernel/process.h"
+#include "core/hle/service/filesystem/filesystem.h"
 #include "core/loader/deconstructed_rom_directory.h"
 #include "core/loader/nca.h"
 #include "core/loader/nsp.h"
@@ -90,6 +92,10 @@ ResultStatus AppLoader_NSP::Load(Kernel::Process& process) {
     const auto result = secondary_loader->Load(process);
     if (result != ResultStatus::Success)
         return result;
+
+    FileSys::VirtualFile update_raw;
+    if (ReadUpdateRaw(update_raw) == ResultStatus::Success && update_raw != nullptr)
+        Service::FileSystem::SetPackedUpdate(std::move(update_raw));
 
     is_loaded = true;
 

--- a/src/core/loader/nsp.cpp
+++ b/src/core/loader/nsp.cpp
@@ -96,8 +96,12 @@ ResultStatus AppLoader_NSP::Load(Kernel::Process& process) {
     return ResultStatus::Success;
 }
 
-ResultStatus AppLoader_NSP::ReadRomFS(FileSys::VirtualFile& dir) {
-    return secondary_loader->ReadRomFS(dir);
+ResultStatus AppLoader_NSP::ReadRomFS(FileSys::VirtualFile& file) {
+    return secondary_loader->ReadRomFS(file);
+}
+
+u64 AppLoader_NSP::ReadRomFSIVFCOffset() const {
+    return secondary_loader->ReadRomFSIVFCOffset();
 }
 
 ResultStatus AppLoader_NSP::ReadProgramId(u64& out_program_id) {

--- a/src/core/loader/nsp.cpp
+++ b/src/core/loader/nsp.cpp
@@ -104,6 +104,24 @@ u64 AppLoader_NSP::ReadRomFSIVFCOffset() const {
     return secondary_loader->ReadRomFSIVFCOffset();
 }
 
+ResultStatus AppLoader_NSP::ReadUpdateRaw(FileSys::VirtualFile& file) {
+    if (nsp->IsExtractedType())
+        return ResultStatus::ErrorNoPackedUpdate;
+
+    const auto read =
+        nsp->GetNCAFile(FileSys::GetUpdateTitleID(title_id), FileSys::ContentRecordType::Program);
+
+    if (read == nullptr)
+        return ResultStatus::ErrorNoPackedUpdate;
+    const auto nca_test = std::make_shared<FileSys::NCA>(read);
+
+    if (nca_test->GetStatus() != ResultStatus::ErrorMissingBKTRBaseRomFS)
+        return nca_test->GetStatus();
+
+    file = read;
+    return ResultStatus::Success;
+}
+
 ResultStatus AppLoader_NSP::ReadProgramId(u64& out_program_id) {
     if (title_id == 0)
         return ResultStatus::ErrorNotInitialized;

--- a/src/core/loader/nsp.h
+++ b/src/core/loader/nsp.h
@@ -37,7 +37,8 @@ public:
 
     ResultStatus Load(Kernel::Process& process) override;
 
-    ResultStatus ReadRomFS(FileSys::VirtualFile& dir) override;
+    ResultStatus ReadRomFS(FileSys::VirtualFile& file) override;
+    u64 ReadRomFSIVFCOffset() const override;
     ResultStatus ReadProgramId(u64& out_program_id) override;
     ResultStatus ReadIcon(std::vector<u8>& buffer) override;
     ResultStatus ReadTitle(std::string& title) override;

--- a/src/core/loader/nsp.h
+++ b/src/core/loader/nsp.h
@@ -39,6 +39,7 @@ public:
 
     ResultStatus ReadRomFS(FileSys::VirtualFile& file) override;
     u64 ReadRomFSIVFCOffset() const override;
+    ResultStatus ReadUpdateRaw(FileSys::VirtualFile& file) override;
     ResultStatus ReadProgramId(u64& out_program_id) override;
     ResultStatus ReadIcon(std::vector<u8>& buffer) override;
     ResultStatus ReadTitle(std::string& title) override;

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -13,6 +13,7 @@
 #include "core/file_sys/romfs.h"
 #include "core/file_sys/submission_package.h"
 #include "core/hle/kernel/process.h"
+#include "core/hle/service/filesystem/filesystem.h"
 #include "core/loader/nca.h"
 #include "core/loader/xci.h"
 
@@ -65,6 +66,10 @@ ResultStatus AppLoader_XCI::Load(Kernel::Process& process) {
     const auto result = nca_loader->Load(process);
     if (result != ResultStatus::Success)
         return result;
+
+    FileSys::VirtualFile update_raw;
+    if (ReadUpdateRaw(update_raw) == ResultStatus::Success && update_raw != nullptr)
+        Service::FileSystem::SetPackedUpdate(std::move(update_raw));
 
     is_loaded = true;
 

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -68,10 +68,13 @@ ResultStatus AppLoader_XCI::Load(Kernel::Process& process) {
     return ResultStatus::Success;
 }
 
-ResultStatus AppLoader_XCI::ReadRomFS(FileSys::VirtualFile& dir) {
-    return nca_loader->ReadRomFS(dir);
+ResultStatus AppLoader_XCI::ReadRomFS(FileSys::VirtualFile& file) {
+    return nca_loader->ReadRomFS(file);
 }
 
+u64 AppLoader_XCI::ReadRomFSIVFCOffset() const {
+    return nca_loader->ReadRomFSIVFCOffset();
+}
 ResultStatus AppLoader_XCI::ReadProgramId(u64& out_program_id) {
     return nca_loader->ReadProgramId(out_program_id);
 }

--- a/src/core/loader/xci.h
+++ b/src/core/loader/xci.h
@@ -37,7 +37,8 @@ public:
 
     ResultStatus Load(Kernel::Process& process) override;
 
-    ResultStatus ReadRomFS(FileSys::VirtualFile& dir) override;
+    ResultStatus ReadRomFS(FileSys::VirtualFile& file) override;
+    u64 ReadRomFSIVFCOffset() const override;
     ResultStatus ReadProgramId(u64& out_program_id) override;
     ResultStatus ReadIcon(std::vector<u8>& buffer) override;
     ResultStatus ReadTitle(std::string& title) override;

--- a/src/core/loader/xci.h
+++ b/src/core/loader/xci.h
@@ -39,6 +39,7 @@ public:
 
     ResultStatus ReadRomFS(FileSys::VirtualFile& file) override;
     u64 ReadRomFSIVFCOffset() const override;
+    ResultStatus ReadUpdateRaw(FileSys::VirtualFile& file) override;
     ResultStatus ReadProgramId(u64& out_program_id) override;
     ResultStatus ReadIcon(std::vector<u8>& buffer) override;
     ResultStatus ReadTitle(std::string& title) override;

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -69,7 +69,14 @@ QString FormatPatchNameVersions(const FileSys::PatchManager& patch_manager,
         if (kv.second.empty()) {
             out.append(fmt::format("{}\n", kv.first).c_str());
         } else {
-            out.append(fmt::format("{} ({})\n", kv.first, kv.second).c_str());
+            auto ver = kv.second;
+
+            // Display container name for packed updates
+            if (ver == "PACKED" && kv.first == FileSys::PatchType::Update)
+                ver = Loader::GetFileTypeString(loader.GetFileType());
+
+            out.append(
+                fmt::format("{} ({})\n", FileSys::FormatPatchTypeName(kv.first), ver).c_str());
         }
     }
 

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -72,11 +72,10 @@ QString FormatPatchNameVersions(const FileSys::PatchManager& patch_manager,
             auto ver = kv.second;
 
             // Display container name for packed updates
-            if (ver == "PACKED" && kv.first == FileSys::PatchType::Update)
+            if (ver == "PACKED" && kv.first == "Update")
                 ver = Loader::GetFileTypeString(loader.GetFileType());
 
-            out.append(
-                fmt::format("{} ({})\n", FileSys::FormatPatchTypeName(kv.first), ver).c_str());
+            out.append(fmt::format("{} ({})\n", kv.first, ver).c_str());
         }
     }
 

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -57,9 +57,12 @@ QString FormatGameName(const std::string& physical_name) {
     return physical_name_as_qstring;
 }
 
-QString FormatPatchNameVersions(const FileSys::PatchManager& patch_manager, bool updatable = true) {
+QString FormatPatchNameVersions(const FileSys::PatchManager& patch_manager,
+                                Loader::AppLoader& loader, bool updatable = true) {
     QString out;
-    for (const auto& kv : patch_manager.GetPatchVersionNames()) {
+    FileSys::VirtualFile update_raw;
+    loader.ReadUpdateRaw(update_raw);
+    for (const auto& kv : patch_manager.GetPatchVersionNames(update_raw)) {
         if (!updatable && kv.first == "Update")
             continue;
 
@@ -116,7 +119,7 @@ void GameListWorker::AddInstalledTitlesToGameList() {
                 QString::fromStdString(Loader::GetFileTypeString(loader->GetFileType())),
                 program_id),
             new GameListItemCompat(compatibility),
-            new GameListItem(FormatPatchNameVersions(patch)),
+            new GameListItem(FormatPatchNameVersions(patch, *loader)),
             new GameListItem(
                 QString::fromStdString(Loader::GetFileTypeString(loader->GetFileType()))),
             new GameListItemSize(file->GetSize()),
@@ -206,7 +209,8 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
                     QString::fromStdString(Loader::GetFileTypeString(loader->GetFileType())),
                     program_id),
                 new GameListItemCompat(compatibility),
-                new GameListItem(FormatPatchNameVersions(patch, loader->IsRomFSUpdatable())),
+                new GameListItem(
+                    FormatPatchNameVersions(patch, *loader, loader->IsRomFSUpdatable())),
                 new GameListItem(
                     QString::fromStdString(Loader::GetFileTypeString(loader->GetFileType()))),
                 new GameListItemSize(FileUtil::GetSize(physical_name)),


### PR DESCRIPTION
Add support for updates that are included inside of the game XCI file (commonly known as Rev1/2/3+ carts). The XCI version will only be applied if there is no installed title.

Todo Before Merge:
- [x] Test on more games (will need to manually repack updates in)

Ex:
![packed updates](https://user-images.githubusercontent.com/5064800/46017100-ac23d880-c0a4-11e8-8d5b-48642fc6b741.PNG)