### PR TITLE
CMake: Remove superfluous CMAKE_RUNTIME_OUTPUT_DIRECTORY assignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,8 +123,6 @@ else()
     # Avoid windows.h from including some usually unused libs like winsocks.h, since this might cause some redefinition errors.
     add_definitions(/DWIN32_LEAN_AND_MEAN)
 
-    # set up output paths for executable binaries (.exe-files, and .dll-files on DLL-capable platforms)
-    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
     set(CMAKE_CONFIGURATION_TYPES Debug Release CACHE STRING "" FORCE)
 
     # Tweak optimization settings


### PR DESCRIPTION
Setting it twice won't make any difference