### PR TITLE
travis: Make macOS builds utilize Xcode 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - os: osx
       env: NAME="macos build"
       sudo: false
-      osx_image: xcode9.3
+      osx_image: xcode10
       install: "./.travis/macos/deps.sh"
       script: "./.travis/macos/build.sh"
       after_success: "./.travis/macos/upload.sh"


### PR DESCRIPTION
Keeps the used toolchain up to date and finally allows the use of `<optional>` and `<variant>` standard library headers within the codebase.