### PR TITLE
video_core: Add asserts for CS, TFB and alpha testing

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -461,7 +461,11 @@ public:
                     u32 entry;
                 } macros;
 
-                INSERT_PADDING_WORDS(0x1B8);
+                INSERT_PADDING_WORDS(0x189);
+
+                u32 tfb_enabled;
+
+                INSERT_PADDING_WORDS(0x2E);
 
                 RenderTargetConfig rt[NumRenderTargets];
 
@@ -594,7 +598,9 @@ public:
 
                 u32 depth_write_enabled;
 
-                INSERT_PADDING_WORDS(0x7);
+                u32 alpha_test_enabled;
+
+                INSERT_PADDING_WORDS(0x6);
 
                 u32 d3d_cull_mode;
 
@@ -977,6 +983,7 @@ private:
                   "Field " #field_name " has invalid position")
 
 ASSERT_REG_POSITION(macros, 0x45);
+ASSERT_REG_POSITION(tfb_enabled, 0x1D1);
 ASSERT_REG_POSITION(rt, 0x200);
 ASSERT_REG_POSITION(viewport_transform[0], 0x280);
 ASSERT_REG_POSITION(viewport, 0x300);
@@ -996,6 +1003,7 @@ ASSERT_REG_POSITION(zeta_height, 0x48b);
 ASSERT_REG_POSITION(depth_test_enable, 0x4B3);
 ASSERT_REG_POSITION(independent_blend_enable, 0x4B9);
 ASSERT_REG_POSITION(depth_write_enabled, 0x4BA);
+ASSERT_REG_POSITION(alpha_test_enabled, 0x4BB);
 ASSERT_REG_POSITION(d3d_cull_mode, 0x4C2);
 ASSERT_REG_POSITION(depth_test_func, 0x4C3);
 ASSERT_REG_POSITION(blend, 0x4CF);

--- a/src/video_core/engines/maxwell_compute.cpp
+++ b/src/video_core/engines/maxwell_compute.cpp
@@ -2,12 +2,29 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/logging/log.h"
+#include "core/core.h"
 #include "video_core/engines/maxwell_compute.h"
 
 namespace Tegra {
 namespace Engines {
 
-void MaxwellCompute::WriteReg(u32 method, u32 value) {}
+void MaxwellCompute::WriteReg(u32 method, u32 value) {
+    ASSERT_MSG(method < Regs::NUM_REGS,
+               "Invalid MaxwellCompute register, increase the size of the Regs structure");
+
+    regs.reg_array[method] = value;
+
+    switch (method) {
+    case MAXWELL_COMPUTE_REG_INDEX(compute): {
+        LOG_CRITICAL(HW_GPU, "Compute shaders are not implemented");
+        UNREACHABLE();
+        break;
+    }
+    default:
+        break;
+    }
+}
 
 } // namespace Engines
 } // namespace Tegra

--- a/src/video_core/engines/maxwell_compute.h
+++ b/src/video_core/engines/maxwell_compute.h
@@ -4,17 +4,53 @@
 
 #pragma once
 
+#include <array>
+#include "common/assert.h"
+#include "common/bit_field.h"
+#include "common/common_funcs.h"
 #include "common/common_types.h"
 
 namespace Tegra::Engines {
+
+#define MAXWELL_COMPUTE_REG_INDEX(field_name)                                                      \
+    (offsetof(Tegra::Engines::MaxwellCompute::Regs, field_name) / sizeof(u32))
 
 class MaxwellCompute final {
 public:
     MaxwellCompute() = default;
     ~MaxwellCompute() = default;
 
+    struct Regs {
+        static constexpr std::size_t NUM_REGS = 0xCF8;
+
+        union {
+            struct {
+                INSERT_PADDING_WORDS(0x281);
+
+                union {
+                    u32 compute_end;
+                    BitField<0, 1, u32> unknown;
+                } compute;
+
+                INSERT_PADDING_WORDS(0xA76);
+            };
+            std::array<u32, NUM_REGS> reg_array;
+        };
+    } regs{};
+
+    static_assert(sizeof(Regs) == Regs::NUM_REGS * sizeof(u32),
+                  "MaxwellCompute Regs has wrong size");
+
     /// Write the value to the register identified by method.
     void WriteReg(u32 method, u32 value);
 };
+
+#define ASSERT_REG_POSITION(field_name, position)                                                  \
+    static_assert(offsetof(MaxwellCompute::Regs, field_name) == position * 4,                      \
+                  "Field " #field_name " has invalid position")
+
+ASSERT_REG_POSITION(compute, 0x281);
+
+#undef ASSERT_REG_POSITION
 
 } // namespace Tegra::Engines

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -450,6 +450,8 @@ void RasterizerOpenGL::DrawArrays() {
     SyncBlendState();
     SyncLogicOpState();
     SyncCullMode();
+    SyncAlphaTest();
+    SyncTransformFeedback();
 
     // TODO(bunnei): Sync framebuffer_scale uniform here
     // TODO(bunnei): Sync scissorbox uniform(s) here
@@ -881,6 +883,26 @@ void RasterizerOpenGL::SyncLogicOpState() {
                "Blending and logic op can't be enabled at the same time.");
 
     state.logic_op.operation = MaxwellToGL::LogicOp(regs.logic_op.operation);
+}
+
+void RasterizerOpenGL::SyncAlphaTest() {
+    const auto& regs = Core::System::GetInstance().GPU().Maxwell3D().regs;
+
+    // TODO(Rodrigo): Alpha testing is a legacy OpenGL feature, but it can be
+    // implemented with a test+discard in fragment shaders.
+    if (regs.alpha_test_enabled != 0) {
+        LOG_CRITICAL(Render_OpenGL, "Alpha testing is not implemented");
+        UNREACHABLE();
+    }
+}
+
+void RasterizerOpenGL::SyncTransformFeedback() {
+    const auto& regs = Core::System::GetInstance().GPU().Maxwell3D().regs;
+
+    if (regs.tfb_enabled != 0) {
+        LOG_CRITICAL(Render_OpenGL, "Transform feedbacks are not implemented");
+        UNREACHABLE();
+    }
 }
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -158,6 +158,12 @@ private:
     /// Syncs the LogicOp state to match the guest state
     void SyncLogicOpState();
 
+    /// Syncs the alpha test state to match the guest state
+    void SyncAlphaTest();
+
+    /// Syncs the transform feedback state to match the guest state
+    void SyncTransformFeedback();
+
     bool has_ARB_direct_state_access = false;
     bool has_ARB_multi_bind = false;
     bool has_ARB_separate_shader_objects = false;


### PR DESCRIPTION
Add asserts for compute shader dispatching, transform feedback being enabled and alpha testing. These have in common that they'll probably break rendering without logging.

Edit: Dispatching method offset was taken from [here](https://github.com/envytools/envytools/blob/1934618b979b6eb3af28380db3b1745eb50e746d/rnndb/graph/gf100_compute.xml#L127).