### PR TITLE
fsmitm_romfsbuild: Minor changes

### DIFF
--- a/src/core/file_sys/fsmitm_romfsbuild.cpp
+++ b/src/core/file_sys/fsmitm_romfsbuild.cpp
@@ -345,7 +345,7 @@ std::map<u64, VirtualFile> RomFSBuildContext::Build() {
 
     std::vector<u8> header_data(sizeof(RomFSHeader));
     std::memcpy(header_data.data(), &header, header_data.size());
-    out.emplace(0, std::make_shared<VectorVfsFile>(header_data));
+    out.emplace(0, std::make_shared<VectorVfsFile>(std::move(header_data)));
 
     std::vector<u8> metadata(file_hash_table_size + file_table_size + dir_hash_table_size +
                              dir_table_size);
@@ -358,7 +358,7 @@ std::map<u64, VirtualFile> RomFSBuildContext::Build() {
                 file_hash_table.size() * sizeof(u32));
     index += file_hash_table.size() * sizeof(u32);
     std::memcpy(metadata.data() + index, file_table.data(), file_table.size());
-    out.emplace(header.dir_hash_table_ofs, std::make_shared<VectorVfsFile>(metadata));
+    out.emplace(header.dir_hash_table_ofs, std::make_shared<VectorVfsFile>(std::move(metadata)));
 
     return out;
 }

--- a/src/core/file_sys/fsmitm_romfsbuild.cpp
+++ b/src/core/file_sys/fsmitm_romfsbuild.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <cstring>
+#include "common/alignment.h"
 #include "common/assert.h"
 #include "core/file_sys/fsmitm_romfsbuild.h"
 #include "core/file_sys/vfs.h"
@@ -182,7 +183,7 @@ bool RomFSBuildContext::AddDirectory(std::shared_ptr<RomFSBuildDirectoryContext>
     // Add a new directory.
     num_dirs++;
     dir_table_size +=
-        sizeof(RomFSDirectoryEntry) + ((dir_ctx->path_len - dir_ctx->cur_path_ofs + 3) & ~3);
+        sizeof(RomFSDirectoryEntry) + Common::AlignUp(dir_ctx->path_len - dir_ctx->cur_path_ofs, 4);
     dir_ctx->parent = parent_dir_ctx;
     directories.emplace(dir_ctx->path, dir_ctx);
 
@@ -200,7 +201,7 @@ bool RomFSBuildContext::AddFile(std::shared_ptr<RomFSBuildDirectoryContext> pare
     // Add a new file.
     num_files++;
     file_table_size +=
-        sizeof(RomFSFileEntry) + ((file_ctx->path_len - file_ctx->cur_path_ofs + 3) & ~3);
+        sizeof(RomFSFileEntry) + Common::AlignUp(file_ctx->path_len - file_ctx->cur_path_ofs, 4);
     file_ctx->parent = parent_dir_ctx;
     files.emplace(file_ctx->path, file_ctx);
 
@@ -241,12 +242,12 @@ std::map<u64, VirtualFile> RomFSBuildContext::Build() {
     std::shared_ptr<RomFSBuildFileContext> prev_file = nullptr;
     for (const auto& it : files) {
         cur_file = it.second;
-        file_partition_size = (file_partition_size + 0xFULL) & ~0xFULL;
+        file_partition_size = Common::AlignUp(file_partition_size, 16);
         cur_file->offset = file_partition_size;
         file_partition_size += cur_file->size;
         cur_file->entry_offset = entry_offset;
-        entry_offset +=
-            sizeof(RomFSFileEntry) + ((cur_file->path_len - cur_file->cur_path_ofs + 3) & ~3);
+        entry_offset += sizeof(RomFSFileEntry) +
+                        Common::AlignUp(cur_file->path_len - cur_file->cur_path_ofs, 4);
         prev_file = cur_file;
     }
     // Assign deferred parent/sibling ownership.
@@ -263,8 +264,8 @@ std::map<u64, VirtualFile> RomFSBuildContext::Build() {
     for (const auto& it : directories) {
         cur_dir = it.second;
         cur_dir->entry_offset = entry_offset;
-        entry_offset +=
-            sizeof(RomFSDirectoryEntry) + ((cur_dir->path_len - cur_dir->cur_path_ofs + 3) & ~3);
+        entry_offset += sizeof(RomFSDirectoryEntry) +
+                        Common::AlignUp(cur_dir->path_len - cur_dir->cur_path_ofs, 4);
     }
     // Assign deferred parent/sibling ownership.
     for (auto it = directories.rbegin(); it->second != root; ++it) {
@@ -297,7 +298,7 @@ std::map<u64, VirtualFile> RomFSBuildContext::Build() {
         out.emplace(cur_file->offset + ROMFS_FILEPARTITION_OFS, cur_file->source);
         std::memcpy(file_table.data() + cur_file->entry_offset, &cur_entry, sizeof(RomFSFileEntry));
         std::memset(file_table.data() + cur_file->entry_offset + sizeof(RomFSFileEntry), 0,
-                    (cur_entry.name_size + 3) & ~3);
+                    Common::AlignUp(cur_entry.name_size, 4));
         std::memcpy(file_table.data() + cur_file->entry_offset + sizeof(RomFSFileEntry),
                     cur_file->path.data() + cur_file->cur_path_ofs, name_size);
     }
@@ -324,10 +325,8 @@ std::map<u64, VirtualFile> RomFSBuildContext::Build() {
 
         std::memcpy(dir_table.data() + cur_dir->entry_offset, &cur_entry,
                     sizeof(RomFSDirectoryEntry));
-        std::memcpy(dir_table.data() + cur_dir->entry_offset, &cur_entry,
-                    sizeof(RomFSDirectoryEntry));
         std::memset(dir_table.data() + cur_dir->entry_offset + sizeof(RomFSDirectoryEntry), 0,
-                    (cur_entry.name_size + 3) & ~3);
+                    Common::AlignUp(cur_entry.name_size, 4));
         std::memcpy(dir_table.data() + cur_dir->entry_offset + sizeof(RomFSDirectoryEntry),
                     cur_dir->path.data() + cur_dir->cur_path_ofs, name_size);
     }
@@ -339,7 +338,7 @@ std::map<u64, VirtualFile> RomFSBuildContext::Build() {
     header.dir_hash_table_size = dir_hash_table_size;
     header.dir_table_size = dir_table_size;
     header.file_partition_ofs = ROMFS_FILEPARTITION_OFS;
-    header.dir_hash_table_ofs = (header.file_partition_ofs + file_partition_size + 3ULL) & ~3ULL;
+    header.dir_hash_table_ofs = Common::AlignUp(header.file_partition_ofs + file_partition_size, 4);
     header.dir_table_ofs = header.dir_hash_table_ofs + header.dir_hash_table_size;
     header.file_hash_table_ofs = header.dir_table_ofs + header.dir_table_size;
     header.file_table_ofs = header.file_hash_table_ofs + header.file_hash_table_size;


### PR DESCRIPTION
Two minor changes. One replaces bit arithmetic with a named equivalent, while the other avoids large std::vector copies.