### PR TITLE
gl_state: Pack sampler bindings into a single ARB_multi_bind

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -41,6 +41,7 @@ public:
         static constexpr std::size_t NumCBData = 16;
         static constexpr std::size_t NumVertexArrays = 32;
         static constexpr std::size_t NumVertexAttributes = 32;
+        static constexpr std::size_t NumTextureSamplers = 32;
         static constexpr std::size_t MaxShaderProgram = 6;
         static constexpr std::size_t MaxShaderStage = 5;
         // Maximum number of const buffers per shader stage.

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -184,7 +184,7 @@ private:
              OGLVertexArray>
         vertex_array_cache;
 
-    std::array<SamplerInfo, GLShader::NumTextureSamplers> texture_samplers;
+    std::array<SamplerInfo, Tegra::Engines::Maxwell3D::Regs::NumTextureSamplers> texture_samplers;
 
     static constexpr std::size_t STREAM_BUFFER_SIZE = 128 * 1024 * 1024;
     OGLBufferCache buffer_cache;

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -11,9 +11,6 @@
 
 namespace OpenGL::GLShader {
 
-/// Number of OpenGL texture samplers that can be used in the fragment shader
-static constexpr std::size_t NumTextureSamplers = 32;
-
 using Tegra::Engines::Maxwell3D;
 
 /// Uniform structure for the Uniform Buffer Object, all vectors must be 16-byte aligned

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <glad/glad.h>
+#include "video_core/engines/maxwell_3d.h"
 
 namespace OpenGL {
 
@@ -114,7 +115,7 @@ public:
             target = GL_TEXTURE_2D;
         }
     };
-    std::array<TextureUnit, 32> texture_units;
+    std::array<TextureUnit, Tegra::Engines::Maxwell3D::Regs::NumTextureSamplers> texture_units;
 
     struct {
         GLuint read_framebuffer; // GL_READ_FRAMEBUFFER_BINDING


### PR DESCRIPTION
My original idea was to just update the intervals that changed, but it proved to be more complex and it would result in more OpenGL calls. This just packs deltas into a single `glBindSamplers`.