### PR TITLE
aoc_u: Implement functions and add support for DLC loading

### DIFF
--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <array>
 #include <cstddef>
 
@@ -185,7 +186,7 @@ std::map<PatchType, std::string> PatchManager::GetPatchVersionNames() const {
 
         list += fmt::format("{}", dlc_match.back().title_id & 0x7FF);
 
-        out[PatchType::DLC] = list;
+        out.insert_or_assign(PatchType::DLC, std::move(list));
     }
 
     return out;

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -33,7 +33,7 @@ std::string FormatTitleVersion(u32 version, TitleVersionFormat format) {
     return fmt::format("v{}.{}.{}", bytes[3], bytes[2], bytes[1]);
 }
 
-constexpr std::array<const char*, 2> PATCH_TYPE_NAMES{
+constexpr std::array<const char*, 3> PATCH_TYPE_NAMES{
     "Update",
     "LayeredFS",
     "DLC",
@@ -141,7 +141,7 @@ std::map<PatchType, std::string> PatchManager::GetPatchVersionNames() const {
     std::map<PatchType, std::string> out;
     const auto installed = Service::FileSystem::GetUnionContents();
 
-    // Update
+    // Game Updates
     const auto update_tid = GetUpdateTitleID(title_id);
     PatchManager update{update_tid};
     auto [nacp, discard_icon_file] = update.GetControlMetadata();
@@ -160,6 +160,7 @@ std::map<PatchType, std::string> PatchManager::GetPatchVersionNames() const {
         }
     }
 
+    // LayeredFS
     const auto lfs_dir = Service::FileSystem::GetModificationLoadRoot(title_id);
     if (lfs_dir != nullptr && lfs_dir->GetSize() > 0)
         out.insert_or_assign(PatchType::LayeredFS, "");

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -27,6 +27,7 @@ std::string FormatTitleVersion(u32 version,
 enum class PatchType {
     Update,
     LayeredFS,
+    DLC,
 };
 
 std::string FormatPatchTypeName(PatchType type);

--- a/src/core/file_sys/romfs_factory.cpp
+++ b/src/core/file_sys/romfs_factory.cpp
@@ -39,36 +39,35 @@ ResultVal<VirtualFile> RomFSFactory::OpenCurrentProcess() {
 }
 
 ResultVal<VirtualFile> RomFSFactory::Open(u64 title_id, StorageId storage, ContentRecordType type) {
+    std::shared_ptr<NCA> res;
+
     switch (storage) {
-    case StorageId::NandSystem: {
-        const auto res = Service::FileSystem::GetSystemNANDContents()->GetEntry(title_id, type);
-        if (res == nullptr) {
-            // TODO(DarkLordZach): Find the right error code to use here
-            return ResultCode(-1);
-        }
-        const auto romfs = res->GetRomFS();
-        if (romfs == nullptr) {
-            // TODO(DarkLordZach): Find the right error code to use here
-            return ResultCode(-1);
-        }
-        return MakeResult<VirtualFile>(romfs);
-    }
-    case StorageId::NandUser: {
-        const auto res = Service::FileSystem::GetUserNANDContents()->GetEntry(title_id, type);
-        if (res == nullptr) {
-            // TODO(DarkLordZach): Find the right error code to use here
-            return ResultCode(-1);
-        }
-        const auto romfs = res->GetRomFS();
-        if (romfs == nullptr) {
-            // TODO(DarkLordZach): Find the right error code to use here
-            return ResultCode(-1);
-        }
-        return MakeResult<VirtualFile>(romfs);
-    }
+    case StorageId::None:
+        res = Service::FileSystem::GetUnionContents()->GetEntry(title_id, type);
+        break;
+    case StorageId::NandSystem:
+        res = Service::FileSystem::GetSystemNANDContents()->GetEntry(title_id, type);
+        break;
+    case StorageId::NandUser:
+        res = Service::FileSystem::GetUserNANDContents()->GetEntry(title_id, type);
+        break;
+    case StorageId::SdCard:
+        res = Service::FileSystem::GetSDMCContents()->GetEntry(title_id, type);
+        break;
     default:
         UNIMPLEMENTED_MSG("Unimplemented storage_id={:02X}", static_cast<u8>(storage));
     }
+
+    if (res == nullptr) {
+        // TODO(DarkLordZach): Find the right error code to use here
+        return ResultCode(-1);
+    }
+    const auto romfs = res->GetRomFS();
+    if (romfs == nullptr) {
+        // TODO(DarkLordZach): Find the right error code to use here
+        return ResultCode(-1);
+    }
+    return MakeResult<VirtualFile>(romfs);
 }
 
 } // namespace FileSys

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -2,11 +2,26 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <numeric>
 #include "common/logging/log.h"
+#include "core/file_sys/content_archive.h"
+#include "core/file_sys/nca_metadata.h"
+#include "core/file_sys/partition_filesystem.h"
+#include "core/file_sys/registered_cache.h"
 #include "core/hle/ipc_helpers.h"
+#include "core/hle/kernel/process.h"
 #include "core/hle/service/aoc/aoc_u.h"
+#include "core/hle/service/filesystem/filesystem.h"
+#include "core/loader/loader.h"
 
 namespace Service::AOC {
+
+constexpr u64 DLC_BASE_TITLE_ID_MASK = 0xFFFFFFFFFFFFE000;
+constexpr u64 DLC_BASE_TO_AOC_ID_MASK = 0x1000;
+
+bool CheckAOCTitleIDMatchesBase(u64 base, u64 aoc) {
+    return (aoc & DLC_BASE_TITLE_ID_MASK) == base;
+}
 
 AOC_U::AOC_U() : ServiceFramework("aoc:u") {
     static const FunctionInfo functions[] = {
@@ -17,10 +32,25 @@ AOC_U::AOC_U() : ServiceFramework("aoc:u") {
         {4, nullptr, "GetAddOnContentBaseIdByApplicationId"},
         {5, nullptr, "GetAddOnContentBaseId"},
         {6, nullptr, "PrepareAddOnContentByApplicationId"},
-        {7, nullptr, "PrepareAddOnContent"},
+        {7, &AOC_U::PrepareAddOnContent, "PrepareAddOnContent"},
         {8, nullptr, "GetAddOnContentListChangedEvent"},
     };
     RegisterHandlers(functions);
+
+    // Accumulate AOC title ids
+    const auto rcu = FileSystem::GetUnionContents();
+    const auto list =
+        rcu->ListEntriesFilter(FileSys::TitleType::AOC, FileSys::ContentRecordType::Data);
+    std::transform(list.begin(), list.end(), std::back_inserter(add_on_content),
+                   [](const FileSys::RegisteredCacheEntry& rce) { return rce.title_id; });
+    add_on_content.erase(
+        std::remove_if(
+            add_on_content.begin(), add_on_content.end(),
+            [&rcu](u64 tid) {
+                return rcu->GetEntry(tid, FileSys::ContentRecordType::Data)->GetStatus() !=
+                       Loader::ResultStatus::Success;
+            }),
+        add_on_content.end());
 }
 
 AOC_U::~AOC_U() = default;
@@ -28,15 +58,57 @@ AOC_U::~AOC_U() = default;
 void AOC_U::CountAddOnContent(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u64>(0);
-    LOG_WARNING(Service_AOC, "(STUBBED) called");
+
+    const auto current = Core::System::GetInstance().CurrentProcess()->program_id;
+    rb.Push<u32>(std::count_if(add_on_content.begin(), add_on_content.end(), [&current](u64 tid) {
+        return (tid & DLC_BASE_TITLE_ID_MASK) == current;
+    }));
 }
 
 void AOC_U::ListAddOnContent(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+
+    const auto offset = rp.PopRaw<u32>();
+    auto count = rp.PopRaw<u32>();
+
+    const auto current = Core::System::GetInstance().CurrentProcess()->program_id;
+
+    std::vector<u32> out;
+    for (size_t i = 0; i < add_on_content.size(); ++i) {
+        if ((add_on_content[i] & DLC_BASE_TITLE_ID_MASK) == current)
+            out.push_back(static_cast<u32>(add_on_content[i] & 0x7FF));
+    }
+
+    if (out.size() <= offset) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        // TODO(DarkLordZach): Find the correct error code.
+        rb.Push(ResultCode(-1));
+        return;
+    }
+
+    count = std::min<size_t>(out.size() - offset, count);
+    out = std::vector<u32>(out.begin() + offset, out.begin() + offset + count);
+
+    ctx.WriteBuffer(out);
+
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(RESULT_SUCCESS);
+}
+
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
     rb.Push<u64>(0);
     LOG_WARNING(Service_AOC, "(STUBBED) called");
+
+void AOC_U::PrepareAddOnContent(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+
+    const auto aoc_id = rp.PopRaw<u32>();
+
+    LOG_WARNING(Service_AOC, "(STUBBED) called with aoc_id={:08X}", aoc_id);
+
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(RESULT_SUCCESS);
 }
 
 void InstallInterfaces(SM::ServiceManager& service_manager) {

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -30,7 +30,7 @@ AOC_U::AOC_U() : ServiceFramework("aoc:u") {
         {2, &AOC_U::CountAddOnContent, "CountAddOnContent"},
         {3, &AOC_U::ListAddOnContent, "ListAddOnContent"},
         {4, nullptr, "GetAddOnContentBaseIdByApplicationId"},
-        {5, nullptr, "GetAddOnContentBaseId"},
+        {5, &AOC_U::GetAddOnContentBaseId, "GetAddOnContentBaseId"},
         {6, nullptr, "PrepareAddOnContentByApplicationId"},
         {7, &AOC_U::PrepareAddOnContent, "PrepareAddOnContent"},
         {8, nullptr, "GetAddOnContentListChangedEvent"},
@@ -95,10 +95,11 @@ void AOC_U::ListAddOnContent(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
 }
 
+void AOC_U::GetAddOnContentBaseId(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u64>(0);
-    LOG_WARNING(Service_AOC, "(STUBBED) called");
+    rb.Push(Core::System::GetInstance().CurrentProcess()->program_id | DLC_BASE_TO_AOC_ID_MASK);
+}
 
 void AOC_U::PrepareAddOnContent(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};

--- a/src/core/hle/service/aoc/aoc_u.h
+++ b/src/core/hle/service/aoc/aoc_u.h
@@ -16,6 +16,9 @@ public:
 private:
     void CountAddOnContent(Kernel::HLERequestContext& ctx);
     void ListAddOnContent(Kernel::HLERequestContext& ctx);
+    void PrepareAddOnContent(Kernel::HLERequestContext& ctx);
+
+    std::vector<u64> add_on_content;
 };
 
 /// Registers all AOC services with the specified service manager.

--- a/src/core/hle/service/aoc/aoc_u.h
+++ b/src/core/hle/service/aoc/aoc_u.h
@@ -16,6 +16,7 @@ public:
 private:
     void CountAddOnContent(Kernel::HLERequestContext& ctx);
     void ListAddOnContent(Kernel::HLERequestContext& ctx);
+    void GetAddOnContentBaseId(Kernel::HLERequestContext& ctx);
     void PrepareAddOnContent(Kernel::HLERequestContext& ctx);
 
     std::vector<u64> add_on_content;


### PR DESCRIPTION
Implements the necessary aoc:u service commands that games use to list and use add on content (2, 3, 5, 7). Also makes it so `StorageId::None` will read from all locations so DLC can be loaded.

DLC will show in the game list as `DLC(...)` where ... is a list of the DLC IDs that will be loaded. The DLC ID is the title id of that particular DLC bitwise AND with 0x7FF.

If your installed DLC doesn't show, it is most likely titlekeys. Each DLC has a different titlekey than the base game.

![dlc1](https://user-images.githubusercontent.com/5064800/46147913-c8ef1600-c234-11e8-9f3d-c62ef05625c3.PNG)
![dlc2](https://user-images.githubusercontent.com/5064800/46147915-c987ac80-c234-11e8-894d-ff7fe9442d05.PNG)
![dlc3](https://user-images.githubusercontent.com/5064800/46147916-c987ac80-c234-11e8-927d-a726d757c350.PNG)
