### PR TITLE
video_core: Implement point_size and add point state sync

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -641,7 +641,11 @@ public:
 
                 u32 vb_element_base;
 
-                INSERT_PADDING_WORDS(0x40);
+                INSERT_PADDING_WORDS(0x38);
+
+                float point_size;
+
+                INSERT_PADDING_WORDS(0x7);
 
                 u32 zeta_enable;
 
@@ -1017,6 +1021,7 @@ ASSERT_REG_POSITION(stencil_front_func_mask, 0x4E6);
 ASSERT_REG_POSITION(stencil_front_mask, 0x4E7);
 ASSERT_REG_POSITION(screen_y_control, 0x4EB);
 ASSERT_REG_POSITION(vb_element_base, 0x50D);
+ASSERT_REG_POSITION(point_size, 0x546);
 ASSERT_REG_POSITION(zeta_enable, 0x54E);
 ASSERT_REG_POSITION(tsc, 0x557);
 ASSERT_REG_POSITION(tic, 0x55D);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -452,6 +452,7 @@ void RasterizerOpenGL::DrawArrays() {
     SyncCullMode();
     SyncAlphaTest();
     SyncTransformFeedback();
+    SyncPointState();
 
     // TODO(bunnei): Sync framebuffer_scale uniform here
     // TODO(bunnei): Sync scissorbox uniform(s) here
@@ -903,6 +904,12 @@ void RasterizerOpenGL::SyncTransformFeedback() {
         LOG_CRITICAL(Render_OpenGL, "Transform feedbacks are not implemented");
         UNREACHABLE();
     }
+}
+
+void RasterizerOpenGL::SyncPointState() {
+    const auto& regs = Core::System::GetInstance().GPU().Maxwell3D().regs;
+
+    state.point.size = regs.point_size;
 }
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -164,6 +164,9 @@ private:
     /// Syncs the transform feedback state to match the guest state
     void SyncTransformFeedback();
 
+    /// Syncs the point state to match the guest state
+    void SyncPointState();
+
     bool has_ARB_direct_state_access = false;
     bool has_ARB_multi_bind = false;
     bool has_ARB_separate_shader_objects = false;

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -79,6 +79,8 @@ OpenGLState::OpenGLState() {
     viewport.height = 0;
 
     clip_distance = {};
+
+    point.size = 1;
 }
 
 void OpenGLState::Apply() const {
@@ -281,6 +283,11 @@ void OpenGLState::Apply() const {
                 glDisable(GL_CLIP_DISTANCE0 + static_cast<GLenum>(i));
             }
         }
+    }
+
+    // Point
+    if (point.size != cur_state.point.size) {
+        glPointSize(point.size);
     }
 
     cur_state = *this;

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -141,6 +141,10 @@ public:
         GLsizei height;
     } viewport;
 
+    struct {
+        float size; // GL_POINT_SIZE
+    } point;
+
     std::array<bool, 2> clip_distance; // GL_CLIP_DISTANCE
 
     OpenGLState();


### PR DESCRIPTION
As a side note: nouveau supports a smaller max point size than NVidia's blob driver (2047), that might be issues on some games on drivers that don't support big point sizes, but there isn't really a way to workaround that.

Test [pointSize.zip](https://github.com/yuzu-emu/yuzu/files/2426938/pointSize.zip)