### PR TITLE
kernel/object: Remove unnecessary std::move from DynamicObjectCast()

### DIFF
--- a/src/core/hle/kernel/object.h
+++ b/src/core/hle/kernel/object.h
@@ -6,7 +6,6 @@
 
 #include <atomic>
 #include <string>
-#include <utility>
 
 #include <boost/smart_ptr/intrusive_ptr.hpp>
 
@@ -97,7 +96,7 @@ using SharedPtr = boost::intrusive_ptr<T>;
 template <typename T>
 inline SharedPtr<T> DynamicObjectCast(SharedPtr<Object> object) {
     if (object != nullptr && object->GetHandleType() == T::HANDLE_TYPE) {
-        return boost::static_pointer_cast<T>(std::move(object));
+        return boost::static_pointer_cast<T>(object);
     }
     return nullptr;
 }

--- a/src/core/hle/kernel/wait_object.h
+++ b/src/core/hle/kernel/wait_object.h
@@ -69,7 +69,7 @@ private:
 template <>
 inline SharedPtr<WaitObject> DynamicObjectCast<WaitObject>(SharedPtr<Object> object) {
     if (object != nullptr && object->IsWaitable()) {
-        return boost::static_pointer_cast<WaitObject>(std::move(object));
+        return boost::static_pointer_cast<WaitObject>(object);
     }
     return nullptr;
 }


### PR DESCRIPTION
`boost::static_pointer_cast` for `boost::intrusive_ptr` (what `SharedPtr` is), takes its parameter by const reference. Given that, it means that this `std::move` doesn't actually do anything other than obscure what the function's actual behavior is, so we can remove this. To clarify, this would only do something if the parameter was either taking its argument by value, by non-const ref, or by rvalue-reference.