### PR TITLE
file_sys: Add support for loading IPS patches

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -34,6 +34,8 @@ add_library(core STATIC
     file_sys/errors.h
     file_sys/fsmitm_romfsbuild.cpp
     file_sys/fsmitm_romfsbuild.h
+    file_sys/ips_layer.cpp
+    file_sys/ips_layer.h
     file_sys/mode.h
     file_sys/nca_metadata.cpp
     file_sys/nca_metadata.h

--- a/src/core/file_sys/ips_layer.cpp
+++ b/src/core/file_sys/ips_layer.cpp
@@ -1,0 +1,88 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/assert.h"
+#include "common/swap.h"
+#include "core/file_sys/ips_layer.h"
+#include "core/file_sys/vfs_vector.h"
+
+namespace FileSys {
+
+enum class IPSFileType {
+    IPS,
+    IPS32,
+    Error,
+};
+
+static IPSFileType IdentifyMagic(const std::vector<u8>& magic) {
+    if (magic.size() != 5)
+        return IPSFileType::Error;
+    if (magic == std::vector<u8>{'P', 'A', 'T', 'C', 'H'})
+        return IPSFileType::IPS;
+    if (magic == std::vector<u8>{'I', 'P', 'S', '3', '2'})
+        return IPSFileType::IPS32;
+    return IPSFileType::Error;
+}
+
+VirtualFile PatchIPS(const VirtualFile& in, const VirtualFile& ips) {
+    if (in == nullptr || ips == nullptr)
+        return nullptr;
+
+    const auto type = IdentifyMagic(ips->ReadBytes(0x5));
+    if (type == IPSFileType::Error)
+        return nullptr;
+
+    auto in_data = in->ReadAllBytes();
+
+    std::vector<u8> temp(type == IPSFileType::IPS ? 3 : 4);
+    u64 offset = 5; // After header
+    while (ips->Read(temp.data(), temp.size(), offset) == temp.size()) {
+        offset += temp.size();
+        if (type == IPSFileType::IPS32 && temp == std::vector<u8>{'E', 'E', 'O', 'F'} ||
+            type == IPSFileType::IPS && temp == std::vector<u8>{'E', 'O', 'F'}) {
+            break;
+        }
+
+        u32 real_offset{};
+        if (type == IPSFileType::IPS32)
+            real_offset = (temp[0] << 24) | (temp[1] << 16) | (temp[2] << 8) | temp[3];
+        else
+            real_offset = (temp[0] << 16) | (temp[1] << 8) | temp[2];
+
+        u16 data_size{};
+        if (ips->ReadObject(&data_size, offset) != sizeof(u16))
+            return nullptr;
+        data_size = Common::swap16(data_size);
+        offset += sizeof(u16);
+
+        if (data_size == 0) { // RLE
+            u16 rle_size{};
+            if (ips->ReadObject(&rle_size, offset) != sizeof(u16))
+                return nullptr;
+            rle_size = Common::swap16(data_size);
+            offset += sizeof(u16);
+
+            const auto data = ips->ReadByte(offset++);
+            if (data == boost::none)
+                return nullptr;
+
+            if (real_offset + rle_size > in_data.size())
+                rle_size = in_data.size() - real_offset;
+            std::memset(in_data.data() + real_offset, data.get(), rle_size);
+        } else { // Standard Patch
+            auto read = data_size;
+            if (real_offset + read > in_data.size())
+                read = in_data.size() - real_offset;
+            if (ips->Read(in_data.data() + real_offset, read, offset) != data_size)
+                return nullptr;
+            offset += data_size;
+        }
+    }
+
+    if (temp != std::vector<u8>{'E', 'E', 'O', 'F'} && temp != std::vector<u8>{'E', 'O', 'F'})
+        return nullptr;
+    return std::make_shared<VectorVfsFile>(in_data, in->GetName(), in->GetContainingDirectory());
+}
+
+} // namespace FileSys

--- a/src/core/file_sys/ips_layer.h
+++ b/src/core/file_sys/ips_layer.h
@@ -1,0 +1,15 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+
+#include "core/file_sys/vfs.h"
+
+namespace FileSys {
+
+VirtualFile PatchIPS(const VirtualFile& in, const VirtualFile& ips);
+
+} // namespace FileSys

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -50,7 +50,7 @@ public:
 
     // Returns a vector of pairs between patch names and patch versions.
     // i.e. Update 3.2.2 will return {"Update", "3.2.2"}
-    std::map<std::string, std::string> GetPatchVersionNames() const;
+    std::map<std::string, std::string, std::less<>> GetPatchVersionNames() const;
 
     // Given title_id of the program, attempts to get the control data of the update and parse it,
     // falling back to the base control data.

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -34,6 +34,14 @@ public:
     // - Game Updates
     VirtualDir PatchExeFS(VirtualDir exefs) const;
 
+    // Currently tracked NSO patches:
+    // - IPS
+    std::vector<u8> PatchNSO(const std::vector<u8>& nso) const;
+
+    // Checks to see if PatchNSO() will have any effect given the NSO's build ID.
+    // Used to prevent expensive copies in NSO loader.
+    bool HasNSOPatch(const std::array<u8, 0x20>& build_id) const;
+
     // Currently tracked RomFS patches:
     // - Game Updates
     // - LayeredFS

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -24,14 +24,6 @@ enum class TitleVersionFormat : u8 {
 std::string FormatTitleVersion(u32 version,
                                TitleVersionFormat format = TitleVersionFormat::ThreeElements);
 
-enum class PatchType {
-    Update,
-    LayeredFS,
-    DLC,
-};
-
-std::string FormatPatchTypeName(PatchType type);
-
 // A centralized class to manage patches to games.
 class PatchManager {
 public:
@@ -49,8 +41,8 @@ public:
                            ContentRecordType type = ContentRecordType::Program) const;
 
     // Returns a vector of pairs between patch names and patch versions.
-    // i.e. Update v80 will return {Update, 80}
-    std::map<PatchType, std::string> GetPatchVersionNames() const;
+    // i.e. Update 3.2.2 will return {"Update", "3.2.2"}
+    std::map<std::string, std::string> GetPatchVersionNames() const;
 
     // Given title_id of the program, attempts to get the control data of the update and parse it,
     // falling back to the base control data.

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -130,6 +130,7 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(Kernel::Process& process)
     }
 
     process.LoadFromMetadata(metadata);
+    const FileSys::PatchManager pm(metadata.GetTitleID());
 
     // Load NSO modules
     const VAddr base_address = process.VMManager().GetCodeRegionBaseAddress();
@@ -139,9 +140,7 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(Kernel::Process& process)
         const FileSys::VirtualFile module_file = dir->GetFile(module);
         if (module_file != nullptr) {
             const VAddr load_addr = next_load_addr;
-            next_load_addr = AppLoader_NSO::LoadModule(
-                module_file, load_addr,
-                std::make_shared<FileSys::PatchManager>(metadata.GetTitleID()));
+            next_load_addr = AppLoader_NSO::LoadModule(module_file, load_addr, pm);
             LOG_DEBUG(Loader, "loaded module {} @ 0x{:X}", module, load_addr);
             // Register module with GDBStub
             GDBStub::RegisterModule(module, load_addr, next_load_addr - 1, false);

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -139,7 +139,9 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(Kernel::Process& process)
         const FileSys::VirtualFile module_file = dir->GetFile(module);
         if (module_file != nullptr) {
             const VAddr load_addr = next_load_addr;
-            next_load_addr = AppLoader_NSO::LoadModule(module_file, load_addr);
+            next_load_addr = AppLoader_NSO::LoadModule(
+                module_file, load_addr,
+                std::make_shared<FileSys::PatchManager>(metadata.GetTitleID()));
             LOG_DEBUG(Loader, "loaded module {} @ 0x{:X}", module, load_addr);
             // Register module with GDBStub
             GDBStub::RegisterModule(module, load_addr, next_load_addr - 1, false);

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -94,7 +94,7 @@ static constexpr u32 PageAlignSize(u32 size) {
 }
 
 VAddr AppLoader_NSO::LoadModule(FileSys::VirtualFile file, VAddr load_base,
-                                std::shared_ptr<FileSys::PatchManager> pm) {
+                                boost::optional<FileSys::PatchManager> pm) {
     if (file == nullptr)
         return {};
 
@@ -144,7 +144,7 @@ VAddr AppLoader_NSO::LoadModule(FileSys::VirtualFile file, VAddr load_base,
     program_image.resize(image_size);
 
     // Apply patches if necessary
-    if (pm != nullptr && pm->HasNSOPatch(nso_header.build_id)) {
+    if (pm != boost::none && pm->HasNSOPatch(nso_header.build_id)) {
         std::vector<u8> pi_header(program_image.size() + 0x100);
         std::memcpy(pi_header.data(), &nso_header, sizeof(NsoHeader));
         std::memcpy(pi_header.data() + 0x100, program_image.data(), program_image.size());

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -36,8 +36,7 @@ struct NsoHeader {
     INSERT_PADDING_WORDS(1);
     u8 flags;
     std::array<NsoSegmentHeader, 3> segments; // Text, RoData, Data (in that order)
-    u32_le bss_size;
-    INSERT_PADDING_BYTES(0x1c);
+    std::array<u8, 0x20> build_id;
     std::array<u32_le, 3> segments_compressed_size;
 
     bool IsSegmentCompressed(size_t segment_num) const {

--- a/src/core/loader/nso.h
+++ b/src/core/loader/nso.h
@@ -28,7 +28,7 @@ public:
     }
 
     static VAddr LoadModule(FileSys::VirtualFile file, VAddr load_base,
-                            std::shared_ptr<FileSys::PatchManager> pm = nullptr);
+                            boost::optional<FileSys::PatchManager> pm = boost::none);
 
     ResultStatus Load(Kernel::Process& process) override;
 };

--- a/src/core/loader/nso.h
+++ b/src/core/loader/nso.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "common/common_types.h"
+#include "core/file_sys/patch_manager.h"
 #include "core/loader/linker.h"
 #include "core/loader/loader.h"
 
@@ -26,7 +27,8 @@ public:
         return IdentifyType(file);
     }
 
-    static VAddr LoadModule(FileSys::VirtualFile file, VAddr load_base);
+    static VAddr LoadModule(FileSys::VirtualFile file, VAddr load_base,
+                            std::shared_ptr<FileSys::PatchManager> pm = nullptr);
 
     ResultStatus Load(Kernel::Process& process) override;
 };

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -60,14 +60,13 @@ QString FormatGameName(const std::string& physical_name) {
 QString FormatPatchNameVersions(const FileSys::PatchManager& patch_manager, bool updatable = true) {
     QString out;
     for (const auto& kv : patch_manager.GetPatchVersionNames()) {
-        if (!updatable && kv.first == FileSys::PatchType::Update)
+        if (!updatable && kv.first == "Update")
             continue;
 
         if (kv.second.empty()) {
-            out.append(fmt::format("{}\n", FileSys::FormatPatchTypeName(kv.first)).c_str());
+            out.append(fmt::format("{}\n", kv.first).c_str());
         } else {
-            out.append(fmt::format("{} ({})\n", FileSys::FormatPatchTypeName(kv.first), kv.second)
-                           .c_str());
+            out.append(fmt::format("{} ({})\n", kv.first, kv.second).c_str());
         }
     }
 


### PR DESCRIPTION
How to Use:
```
yuzu/load
  - <title id>
    - <mod name>
      - exefs
        - <nso build id>.ips
```
You can have multiple ips files in the exefs dir (for different versions for ex). You can also pair the exefs dir with a sibling romfs dir to make one mod with LFS and IPS.

This also changes the Add-Ons column slightly. Now instead of saying just `LayeredFS` (or `IPS` as you might have expected) It will say the name of the mod (<mod name> in ex above) and the in parenthesis what it uses (LFS and/or IPS)

Example: 
![inlisti s](https://user-images.githubusercontent.com/5064800/46252362-e939f300-c435-11e8-8f90-dd214e1d2cb3.PNG)
