### PR TITLE
svc: Implement svcGetThreadContext

### DIFF
--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -22,10 +22,16 @@ public:
         std::array<u64, 31> cpu_registers;
         u64 sp;
         u64 pc;
-        u64 pstate;
+        u32 pstate;
+        std::array<u8, 4> padding;
         std::array<u128, 32> vector_registers;
-        u64 fpcr;
+        u32 fpcr;
+        u32 fpsr;
+        u64 tpidr;
     };
+    // Internally within the kernel, it expects the AArch64 version of the
+    // thread context to be 800 bytes in size.
+    static_assert(sizeof(ThreadContext) == 0x320);
 
     /// Runs the CPU until an event happens
     virtual void Run() = 0;

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -247,15 +247,19 @@ void ARM_Dynarmic::SaveContext(ThreadContext& ctx) {
     ctx.pstate = jit->GetPstate();
     ctx.vector_registers = jit->GetVectors();
     ctx.fpcr = jit->GetFpcr();
+    ctx.fpsr = jit->GetFpsr();
+    ctx.tpidr = cb->tpidr_el0;
 }
 
 void ARM_Dynarmic::LoadContext(const ThreadContext& ctx) {
     jit->SetRegisters(ctx.cpu_registers);
     jit->SetSP(ctx.sp);
     jit->SetPC(ctx.pc);
-    jit->SetPstate(static_cast<u32>(ctx.pstate));
+    jit->SetPstate(ctx.pstate);
     jit->SetVectors(ctx.vector_registers);
-    jit->SetFpcr(static_cast<u32>(ctx.fpcr));
+    jit->SetFpcr(ctx.fpcr);
+    jit->SetFpsr(ctx.fpsr);
+    SetTPIDR_EL0(ctx.tpidr);
 }
 
 void ARM_Dynarmic::PrepareReschedule() {

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -130,7 +130,7 @@ public:
 
 std::unique_ptr<Dynarmic::A64::Jit> ARM_Dynarmic::MakeJit() const {
     auto& current_process = Core::CurrentProcess();
-    auto** const page_table = current_process->vm_manager.page_table.pointers.data();
+    auto** const page_table = current_process->VMManager().page_table.pointers.data();
 
     Dynarmic::A64::UserConfig config;
 
@@ -139,7 +139,7 @@ std::unique_ptr<Dynarmic::A64::Jit> ARM_Dynarmic::MakeJit() const {
 
     // Memory
     config.page_table = reinterpret_cast<void**>(page_table);
-    config.page_table_address_space_bits = current_process->vm_manager.GetAddressSpaceWidth();
+    config.page_table_address_space_bits = current_process->VMManager().GetAddressSpaceWidth();
     config.silently_mirror_page_table = false;
 
     // Multi-process state

--- a/src/core/file_sys/romfs_factory.cpp
+++ b/src/core/file_sys/romfs_factory.cpp
@@ -34,7 +34,7 @@ ResultVal<VirtualFile> RomFSFactory::OpenCurrentProcess() {
     if (!updatable)
         return MakeResult<VirtualFile>(file);
 
-    const PatchManager patch_manager(Core::CurrentProcess()->program_id);
+    const PatchManager patch_manager(Core::CurrentProcess()->GetTitleID());
     return MakeResult<VirtualFile>(patch_manager.PatchRomFS(file, ivfc_offset));
 }
 

--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -81,7 +81,7 @@ std::string SaveDataFactory::GetFullPath(SaveDataSpaceId space, SaveDataType typ
     // According to switchbrew, if a save is of type SaveData and the title id field is 0, it should
     // be interpreted as the title id of the current process.
     if (type == SaveDataType::SaveData && title_id == 0)
-        title_id = Core::CurrentProcess()->program_id;
+        title_id = Core::CurrentProcess()->GetTitleID();
 
     std::string out;
 

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -587,7 +587,7 @@ static void HandleQuery() {
                        strlen("Xfer:features:read:target.xml:")) == 0) {
         SendReply(target_xml);
     } else if (strncmp(query, "Offsets", strlen("Offsets")) == 0) {
-        const VAddr base_address = Core::CurrentProcess()->vm_manager.GetCodeRegionBaseAddress();
+        const VAddr base_address = Core::CurrentProcess()->VMManager().GetCodeRegionBaseAddress();
         std::string buffer = fmt::format("TextSeg={:0x}", base_address);
         SendReply(buffer.c_str());
     } else if (strncmp(query, "fThreadInfo", strlen("fThreadInfo")) == 0) {
@@ -909,7 +909,7 @@ static void ReadMemory() {
         SendReply("E01");
     }
 
-    const auto& vm_manager = Core::CurrentProcess()->vm_manager;
+    const auto& vm_manager = Core::CurrentProcess()->VMManager();
     if (addr < vm_manager.GetCodeRegionBaseAddress() ||
         addr >= vm_manager.GetMapRegionEndAddress()) {
         return SendReply("E00");

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -250,7 +250,7 @@ static void RegWrite(std::size_t id, u64 val, Kernel::Thread* thread = nullptr) 
     } else if (id == PC_REGISTER) {
         thread->context.pc = val;
     } else if (id == PSTATE_REGISTER) {
-        thread->context.pstate = val;
+        thread->context.pstate = static_cast<u32>(val);
     } else if (id > PSTATE_REGISTER && id < FPCR_REGISTER) {
         thread->context.vector_registers[id - (PSTATE_REGISTER + 1)][0] = val;
     }

--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -31,6 +31,7 @@ enum {
     TooLarge = 119,
     InvalidEnumValue = 120,
     NoSuchEntry = 121,
+    AlreadyRegistered = 122,
     InvalidState = 125,
     ResourceLimitExceeded = 132,
 };
@@ -58,6 +59,7 @@ constexpr ResultCode ERR_INVALID_MEMORY_PERMISSIONS(ErrorModule::Kernel,
 constexpr ResultCode ERR_INVALID_HANDLE(ErrorModule::Kernel, ErrCodes::InvalidHandle);
 constexpr ResultCode ERR_INVALID_PROCESSOR_ID(ErrorModule::Kernel, ErrCodes::InvalidProcessorId);
 constexpr ResultCode ERR_INVALID_SIZE(ErrorModule::Kernel, ErrCodes::InvalidSize);
+constexpr ResultCode ERR_ALREADY_REGISTERED(ErrorModule::Kernel, ErrCodes::AlreadyRegistered);
 constexpr ResultCode ERR_INVALID_STATE(ErrorModule::Kernel, ErrCodes::InvalidState);
 constexpr ResultCode ERR_INVALID_THREAD_PRIORITY(ErrorModule::Kernel,
                                                  ErrCodes::InvalidThreadPriority);

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -47,6 +47,7 @@ SharedPtr<Process> Process::Create(KernelCore& kernel, std::string&& name) {
 
 void Process::LoadFromMetadata(const FileSys::ProgramMetadata& metadata) {
     program_id = metadata.GetTitleID();
+    is_64bit_process = metadata.Is64BitProgram();
     vm_manager.Reset(metadata.GetAddressSpaceType());
 }
 

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -189,6 +189,11 @@ public:
         return is_virtual_address_memory_enabled;
     }
 
+    /// Whether this process is an AArch64 or AArch32 process.
+    bool Is64BitProcess() const {
+        return is_64bit_process;
+    }
+
     /**
      * Loads process-specifics configuration info with metadata provided
      * by an executable.
@@ -286,6 +291,11 @@ private:
     /// page as a bitmask.
     /// This vector will grow as more pages are allocated for new threads.
     std::vector<std::bitset<8>> tls_slots;
+
+    /// Whether or not this process is AArch64, or AArch32.
+    /// By default, we currently assume this is true, unless otherwise
+    /// specified by metadata provided to the process during loading.
+    bool is_64bit_process = true;
 
     std::string name;
 };

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -135,6 +135,16 @@ public:
         return HANDLE_TYPE;
     }
 
+    /// Gets a reference to the process' memory manager.
+    Kernel::VMManager& VMManager() {
+        return vm_manager;
+    }
+
+    /// Gets a const reference to the process' memory manager.
+    const Kernel::VMManager& VMManager() const {
+        return vm_manager;
+    }
+
     /// Gets the current status of the process
     ProcessStatus GetStatus() const {
         return status;
@@ -145,6 +155,40 @@ public:
         return process_id;
     }
 
+    /// Gets the title ID corresponding to this process.
+    u64 GetTitleID() const {
+        return program_id;
+    }
+
+    /// Gets the resource limit descriptor for this process
+    ResourceLimit& GetResourceLimit() {
+        return *resource_limit;
+    }
+
+    /// Gets the resource limit descriptor for this process
+    const ResourceLimit& GetResourceLimit() const {
+        return *resource_limit;
+    }
+
+    /// Gets the default CPU ID for this process
+    u8 GetDefaultProcessorID() const {
+        return ideal_processor;
+    }
+
+    /// Gets the bitmask of allowed CPUs that this process' threads can run on.
+    u32 GetAllowedProcessorMask() const {
+        return allowed_processor_mask;
+    }
+
+    /// Gets the bitmask of allowed thread priorities.
+    u32 GetAllowedThreadPriorityMask() const {
+        return allowed_thread_priority_mask;
+    }
+
+    u32 IsVirtualMemoryEnabled() const {
+        return is_virtual_address_memory_enabled;
+    }
+
     /**
      * Loads process-specifics configuration info with metadata provided
      * by an executable.
@@ -152,30 +196,6 @@ public:
      * @param metadata The provided metadata to load process specific info.
      */
     void LoadFromMetadata(const FileSys::ProgramMetadata& metadata);
-
-    /// Title ID corresponding to the process
-    u64 program_id;
-
-    /// Resource limit descriptor for this process
-    SharedPtr<ResourceLimit> resource_limit;
-
-    /// The process may only call SVCs which have the corresponding bit set.
-    std::bitset<0x80> svc_access_mask;
-    /// Maximum size of the handle table for the process.
-    unsigned int handle_table_size = 0x200;
-    /// Special memory ranges mapped into this processes address space. This is used to give
-    /// processes access to specific I/O regions and device memory.
-    boost::container::static_vector<AddressMapping, 8> address_mappings;
-    ProcessFlags flags;
-    /// Kernel compatibility version for this process
-    u16 kernel_version = 0;
-    /// The default CPU for this process, threads are scheduled on this cpu by default.
-    u8 ideal_processor = 0;
-    /// Bitmask of allowed CPUs that this process' threads can run on. TODO(Subv): Actually parse
-    /// this value from the process header.
-    u32 allowed_processor_mask = THREADPROCESSORID_DEFAULT_MASK;
-    u32 allowed_thread_priority_mask = 0xFFFFFFFF;
-    u32 is_virtual_address_memory_enabled = 0;
 
     /**
      * Parses a list of kernel capability descriptors (as found in the ExHeader) and applies them
@@ -212,17 +232,42 @@ public:
 
     ResultCode UnmapMemory(VAddr dst_addr, VAddr src_addr, u64 size);
 
-    VMManager vm_manager;
-
 private:
     explicit Process(KernelCore& kernel);
     ~Process() override;
+
+    /// Memory manager for this process.
+    Kernel::VMManager vm_manager;
 
     /// Current status of the process
     ProcessStatus status;
 
     /// The ID of this process
     u32 process_id = 0;
+
+    /// Title ID corresponding to the process
+    u64 program_id;
+
+    /// Resource limit descriptor for this process
+    SharedPtr<ResourceLimit> resource_limit;
+
+    /// The process may only call SVCs which have the corresponding bit set.
+    std::bitset<0x80> svc_access_mask;
+    /// Maximum size of the handle table for the process.
+    u32 handle_table_size = 0x200;
+    /// Special memory ranges mapped into this processes address space. This is used to give
+    /// processes access to specific I/O regions and device memory.
+    boost::container::static_vector<AddressMapping, 8> address_mappings;
+    ProcessFlags flags;
+    /// Kernel compatibility version for this process
+    u16 kernel_version = 0;
+    /// The default CPU for this process, threads are scheduled on this cpu by default.
+    u8 ideal_processor = 0;
+    /// Bitmask of allowed CPUs that this process' threads can run on. TODO(Subv): Actually parse
+    /// this value from the process header.
+    u32 allowed_processor_mask = THREADPROCESSORID_DEFAULT_MASK;
+    u32 allowed_thread_priority_mask = 0xFFFFFFFF;
+    u32 is_virtual_address_memory_enabled = 0;
 
     // Memory used to back the allocations in the regular heap. A single vector is used to cover
     // the entire virtual address space extents that bound the allocations, including any holes.

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -88,7 +88,7 @@ void Scheduler::SwitchContext(Thread* new_thread) {
 
         if (previous_process != current_thread->owner_process) {
             Core::CurrentProcess() = current_thread->owner_process;
-            SetCurrentPageTable(&Core::CurrentProcess()->vm_manager.page_table);
+            SetCurrentPageTable(&Core::CurrentProcess()->VMManager().page_table);
         }
 
         cpu_core.LoadContext(new_thread->context);

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -64,6 +64,11 @@ void SvcWrap() {
     FuncReturn(func(Param(0), (s32)Param(1)).raw);
 }
 
+template <ResultCode func(u64, u32)>
+void SvcWrap() {
+    FuncReturn(func(Param(0), static_cast<u32>(Param(1))).raw);
+}
+
 template <ResultCode func(u64*, u64)>
 void SvcWrap() {
     u64 param_1 = 0;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -259,10 +259,10 @@ void Thread::BoostPriority(u32 priority) {
 SharedPtr<Thread> SetupMainThread(KernelCore& kernel, VAddr entry_point, u32 priority,
                                   Process& owner_process) {
     // Setup page table so we can write to memory
-    SetCurrentPageTable(&owner_process.vm_manager.page_table);
+    SetCurrentPageTable(&owner_process.VMManager().page_table);
 
     // Initialize new "main" thread
-    const VAddr stack_top = owner_process.vm_manager.GetTLSIORegionEndAddress();
+    const VAddr stack_top = owner_process.VMManager().GetTLSIORegionEndAddress();
     auto thread_res = Thread::Create(kernel, "main", entry_point, priority, 0, THREADPROCESSORID_0,
                                      stack_top, &owner_process);
 

--- a/src/core/hle/service/fatal/fatal.cpp
+++ b/src/core/hle/service/fatal/fatal.cpp
@@ -51,7 +51,7 @@ enum class FatalType : u32 {
 };
 
 static void GenerateErrorReport(ResultCode error_code, const FatalInfo& info) {
-    const auto title_id = Core::CurrentProcess()->program_id;
+    const auto title_id = Core::CurrentProcess()->GetTitleID();
     std::string crash_report =
         fmt::format("Yuzu {}-{} crash report\n"
                     "Title ID:                        {:016x}\n"

--- a/src/core/hle/service/ns/pl_u.cpp
+++ b/src/core/hle/service/ns/pl_u.cpp
@@ -317,9 +317,9 @@ void PL_U::GetSharedMemoryAddressOffset(Kernel::HLERequestContext& ctx) {
 
 void PL_U::GetSharedMemoryNativeHandle(Kernel::HLERequestContext& ctx) {
     // Map backing memory for the font data
-    Core::CurrentProcess()->vm_manager.MapMemoryBlock(SHARED_FONT_MEM_VADDR, impl->shared_font, 0,
-                                                      SHARED_FONT_MEM_SIZE,
-                                                      Kernel::MemoryState::Shared);
+    Core::CurrentProcess()->VMManager().MapMemoryBlock(SHARED_FONT_MEM_VADDR, impl->shared_font, 0,
+                                                       SHARED_FONT_MEM_SIZE,
+                                                       Kernel::MemoryState::Shared);
 
     // Create shared font memory object
     auto& kernel = Core::System::GetInstance().Kernel();

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -132,7 +132,7 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(Kernel::Process& process)
     process.LoadFromMetadata(metadata);
 
     // Load NSO modules
-    const VAddr base_address = process.vm_manager.GetCodeRegionBaseAddress();
+    const VAddr base_address = process.VMManager().GetCodeRegionBaseAddress();
     VAddr next_load_addr = base_address;
     for (const auto& module : {"rtld", "main", "subsdk0", "subsdk1", "subsdk2", "subsdk3",
                                "subsdk4", "subsdk5", "subsdk6", "subsdk7", "sdk"}) {

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -395,7 +395,7 @@ ResultStatus AppLoader_ELF::Load(Kernel::Process& process) {
     if (buffer.size() != file->GetSize())
         return ResultStatus::ErrorIncorrectELFFileSize;
 
-    const VAddr base_address = process.vm_manager.GetCodeRegionBaseAddress();
+    const VAddr base_address = process.VMManager().GetCodeRegionBaseAddress();
     ElfReader elf_reader(&buffer[0]);
     SharedPtr<CodeSet> codeset = elf_reader.LoadInto(base_address);
     codeset->name = file->GetName();

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -181,7 +181,7 @@ ResultStatus AppLoader_NRO::Load(Kernel::Process& process) {
     }
 
     // Load NRO
-    const VAddr base_address = process.vm_manager.GetCodeRegionBaseAddress();
+    const VAddr base_address = process.VMManager().GetCodeRegionBaseAddress();
 
     if (!LoadNro(file, base_address)) {
         return ResultStatus::ErrorLoadingNRO;

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -159,7 +159,7 @@ ResultStatus AppLoader_NSO::Load(Kernel::Process& process) {
     }
 
     // Load module
-    const VAddr base_address = process.vm_manager.GetCodeRegionBaseAddress();
+    const VAddr base_address = process.VMManager().GetCodeRegionBaseAddress();
     LoadModule(file, base_address);
     LOG_DEBUG(Loader, "loaded module {} @ 0x{:X}", file->GetName(), base_address);
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -119,7 +119,7 @@ void RemoveDebugHook(PageTable& page_table, VAddr base, u64 size, MemoryHookPoin
 static u8* GetPointerFromVMA(const Kernel::Process& process, VAddr vaddr) {
     u8* direct_pointer = nullptr;
 
-    auto& vm_manager = process.vm_manager;
+    auto& vm_manager = process.VMManager();
 
     auto it = vm_manager.FindVMA(vaddr);
     ASSERT(it != vm_manager.vma_map.end());
@@ -214,7 +214,7 @@ void Write(const VAddr vaddr, const T data) {
 }
 
 bool IsValidVirtualAddress(const Kernel::Process& process, const VAddr vaddr) {
-    auto& page_table = process.vm_manager.page_table;
+    const auto& page_table = process.VMManager().page_table;
 
     const u8* page_pointer = page_table.pointers[vaddr >> PAGE_BITS];
     if (page_pointer)
@@ -363,7 +363,7 @@ void RasterizerFlushVirtualRegion(VAddr start, u64 size, FlushMode mode) {
         }
     };
 
-    const auto& vm_manager = Core::CurrentProcess()->vm_manager;
+    const auto& vm_manager = Core::CurrentProcess()->VMManager();
 
     CheckRegion(vm_manager.GetCodeRegionBaseAddress(), vm_manager.GetCodeRegionEndAddress());
     CheckRegion(vm_manager.GetHeapRegionBaseAddress(), vm_manager.GetHeapRegionEndAddress());
@@ -387,7 +387,7 @@ u64 Read64(const VAddr addr) {
 
 void ReadBlock(const Kernel::Process& process, const VAddr src_addr, void* dest_buffer,
                const std::size_t size) {
-    auto& page_table = process.vm_manager.page_table;
+    const auto& page_table = process.VMManager().page_table;
 
     std::size_t remaining_size = size;
     std::size_t page_index = src_addr >> PAGE_BITS;
@@ -452,7 +452,7 @@ void Write64(const VAddr addr, const u64 data) {
 
 void WriteBlock(const Kernel::Process& process, const VAddr dest_addr, const void* src_buffer,
                 const std::size_t size) {
-    auto& page_table = process.vm_manager.page_table;
+    const auto& page_table = process.VMManager().page_table;
     std::size_t remaining_size = size;
     std::size_t page_index = dest_addr >> PAGE_BITS;
     std::size_t page_offset = dest_addr & PAGE_MASK;
@@ -498,7 +498,7 @@ void WriteBlock(const VAddr dest_addr, const void* src_buffer, const std::size_t
 }
 
 void ZeroBlock(const Kernel::Process& process, const VAddr dest_addr, const std::size_t size) {
-    auto& page_table = process.vm_manager.page_table;
+    const auto& page_table = process.VMManager().page_table;
     std::size_t remaining_size = size;
     std::size_t page_index = dest_addr >> PAGE_BITS;
     std::size_t page_offset = dest_addr & PAGE_MASK;
@@ -540,7 +540,7 @@ void ZeroBlock(const Kernel::Process& process, const VAddr dest_addr, const std:
 
 void CopyBlock(const Kernel::Process& process, VAddr dest_addr, VAddr src_addr,
                const std::size_t size) {
-    auto& page_table = process.vm_manager.page_table;
+    const auto& page_table = process.VMManager().page_table;
     std::size_t remaining_size = size;
     std::size_t page_index = src_addr >> PAGE_BITS;
     std::size_t page_offset = src_addr & PAGE_MASK;

--- a/src/tests/core/arm/arm_test_common.cpp
+++ b/src/tests/core/arm/arm_test_common.cpp
@@ -16,7 +16,7 @@ TestEnvironment::TestEnvironment(bool mutable_memory_)
     : mutable_memory(mutable_memory_), test_memory(std::make_shared<TestMemory>(this)) {
 
     Core::CurrentProcess() = Kernel::Process::Create(kernel, "");
-    page_table = &Core::CurrentProcess()->vm_manager.page_table;
+    page_table = &Core::CurrentProcess()->VMManager().page_table;
 
     std::fill(page_table->pointers.begin(), page_table->pointers.end(), nullptr);
     page_table->special_regions.clear();

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -622,9 +622,9 @@ void GMainWindow::BootGame(const QString& filename) {
     std::string title_name;
     const auto res = Core::System::GetInstance().GetGameName(title_name);
     if (res != Loader::ResultStatus::Success) {
-        const u64 program_id = Core::System::GetInstance().CurrentProcess()->program_id;
+        const u64 title_id = Core::System::GetInstance().CurrentProcess()->GetTitleID();
 
-        const auto [nacp, icon_file] = FileSys::PatchManager(program_id).GetControlMetadata();
+        const auto [nacp, icon_file] = FileSys::PatchManager(title_id).GetControlMetadata();
         if (nacp != nullptr)
             title_name = nacp->GetApplicationName();
 


### PR DESCRIPTION
Finally puts in a non-stubbed version of this. Each commit should be fairly self-explanatory. I'd also recommend looking at the commits individually in order to view the changes better, given a large amount of it is the commit that makes the data members private.