### PR TITLE
Port citra-emu/citra#4269: "OSX: Set MACOSX_DEPLOYMENT_TARGET to 10.13"

### DIFF
--- a/.travis/macos/build.sh
+++ b/.travis/macos/build.sh
@@ -2,7 +2,7 @@
 
 set -o pipefail
 
-export MACOSX_DEPLOYMENT_TARGET=10.12
+export MACOSX_DEPLOYMENT_TARGET=10.13
 export Qt5_DIR=$(brew --prefix)/opt/qt5
 export UNICORNDIR=$(pwd)/externals/unicorn
 export PATH="/usr/local/opt/ccache/libexec:$PATH"


### PR DESCRIPTION
See https://github.com/citra-emu/citra/pull/4269 for the reasons behind this.