### PR TITLE
nso/nro: Add support for passing command-line arguments to executable

### DIFF
--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -141,8 +141,8 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(Kernel::Process& process)
         const FileSys::VirtualFile module_file = dir->GetFile(module);
         if (module_file != nullptr) {
             const VAddr load_addr = next_load_addr;
-            next_load_addr =
-                AppLoader_NSO::LoadModule(module_file, load_addr, std::strcmp(module, "rtld") == 0, pm);
+            next_load_addr = AppLoader_NSO::LoadModule(module_file, load_addr,
+                                                       std::strcmp(module, "rtld") == 0, pm);
             LOG_DEBUG(Loader, "loaded module {} @ 0x{:X}", module, load_addr);
             // Register module with GDBStub
             GDBStub::RegisterModule(module, load_addr, next_load_addr - 1, false);

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <cinttypes>
+#include <cstring>
 #include "common/common_funcs.h"
 #include "common/file_util.h"
 #include "common/logging/log.h"
@@ -140,7 +141,8 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(Kernel::Process& process)
         const FileSys::VirtualFile module_file = dir->GetFile(module);
         if (module_file != nullptr) {
             const VAddr load_addr = next_load_addr;
-            next_load_addr = AppLoader_NSO::LoadModule(module_file, load_addr, pm);
+            next_load_addr =
+                AppLoader_NSO::LoadModule(module_file, load_addr, std::strcmp(module, "rtld") == 0, pm);
             LOG_DEBUG(Loader, "loaded module {} @ 0x{:X}", module, load_addr);
             // Register module with GDBStub
             GDBStub::RegisterModule(module, load_addr, next_load_addr - 1, false);

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -154,12 +154,14 @@ bool AppLoader_NRO::LoadNro(FileSys::VirtualFile file, VAddr load_base) {
 
     if (!Settings::values.program_args.empty()) {
         const auto arg_data = Settings::values.program_args;
-        codeset->DataSegment().size += 0x9000;
-        NSOArgumentHeader args_header{0x9000, static_cast<u32_le>(arg_data.size()), {}};
-        program_image.resize(static_cast<u32>(program_image.size()) + 0x9000);
-        std::memcpy(program_image.data() + program_image.size() - 0x9000, &args_header,
-                    sizeof(NSOArgumentHeader));
-        std::memcpy(program_image.data() + program_image.size() - 0x8FE0, arg_data.data(),
+        codeset->DataSegment().size += NSO_ARGUMENT_DATA_ALLOCATION_SIZE;
+        NSOArgumentHeader args_header{
+            NSO_ARGUMENT_DATA_ALLOCATION_SIZE, static_cast<u32_le>(arg_data.size()), {}};
+        const auto end_offset = program_image.size();
+        program_image.resize(static_cast<u32>(program_image.size()) +
+                             NSO_ARGUMENT_DATA_ALLOCATION_SIZE);
+        std::memcpy(program_image.data() + end_offset, &args_header, sizeof(NSOArgumentHeader));
+        std::memcpy(program_image.data() + end_offset + sizeof(NSOArgumentHeader), arg_data.data(),
                     arg_data.size());
     }
 

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -155,7 +155,7 @@ bool AppLoader_NRO::LoadNro(FileSys::VirtualFile file, VAddr load_base) {
     if (!Settings::values.program_args.empty()) {
         const auto arg_data = Settings::values.program_args;
         codeset->DataSegment().size += 0x9000;
-        NSOArgumentHeader args_header{0x9000, arg_data.size(), {}};
+        NSOArgumentHeader args_header{0x9000, static_cast<u32_le>(arg_data.size()), {}};
         program_image.resize(static_cast<u32>(program_image.size()) + 0x9000);
         std::memcpy(program_image.data() + program_image.size() - 0x9000, &args_header,
                     sizeof(NSOArgumentHeader));

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -129,12 +129,14 @@ VAddr AppLoader_NSO::LoadModule(FileSys::VirtualFile file, VAddr load_base,
 
     if (should_pass_arguments && !Settings::values.program_args.empty()) {
         const auto arg_data = Settings::values.program_args;
-        codeset->DataSegment().size += 0x9000;
-        NSOArgumentHeader args_header{0x9000, static_cast<u32_le>(arg_data.size()), {}};
-        program_image.resize(static_cast<u32>(program_image.size()) + 0x9000);
-        std::memcpy(program_image.data() + program_image.size() - 0x9000, &args_header,
-                    sizeof(NSOArgumentHeader));
-        std::memcpy(program_image.data() + program_image.size() - 0x8FE0, arg_data.data(),
+        codeset->DataSegment().size += NSO_ARGUMENT_DATA_ALLOCATION_SIZE;
+        NSOArgumentHeader args_header{
+            NSO_ARGUMENT_DATA_ALLOCATION_SIZE, static_cast<u32_le>(arg_data.size()), {}};
+        const auto end_offset = program_image.size();
+        program_image.resize(static_cast<u32>(program_image.size()) +
+                             NSO_ARGUMENT_DATA_ALLOCATION_SIZE);
+        std::memcpy(program_image.data() + end_offset, &args_header, sizeof(NSOArgumentHeader));
+        std::memcpy(program_image.data() + end_offset + sizeof(NSOArgumentHeader), arg_data.data(),
                     arg_data.size());
     }
 

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -130,7 +130,7 @@ VAddr AppLoader_NSO::LoadModule(FileSys::VirtualFile file, VAddr load_base,
     if (should_pass_arguments && !Settings::values.program_args.empty()) {
         const auto arg_data = Settings::values.program_args;
         codeset->DataSegment().size += 0x9000;
-        NSOArgumentHeader args_header{0x9000, arg_data.size(), {}};
+        NSOArgumentHeader args_header{0x9000, static_cast<u32_le>(arg_data.size()), {}};
         program_image.resize(static_cast<u32>(program_image.size()) + 0x9000);
         std::memcpy(program_image.data() + program_image.size() - 0x9000, &args_header,
                     sizeof(NSOArgumentHeader));

--- a/src/core/loader/nso.h
+++ b/src/core/loader/nso.h
@@ -11,6 +11,8 @@
 
 namespace Loader {
 
+constexpr u64 NSO_ARGUMENT_DATA_ALLOCATION_SIZE = 0x9000;
+
 struct NSOArgumentHeader {
     u32_le allocated_size;
     u32_le actual_size;

--- a/src/core/loader/nso.h
+++ b/src/core/loader/nso.h
@@ -11,6 +11,13 @@
 
 namespace Loader {
 
+struct NSOArgumentHeader {
+    u32_le allocated_size;
+    u32_le actual_size;
+    INSERT_PADDING_BYTES(0x18);
+};
+static_assert(sizeof(NSOArgumentHeader) == 0x20, "NSOArgumentHeader has incorrect size.");
+
 /// Loads an NSO file
 class AppLoader_NSO final : public AppLoader, Linker {
 public:
@@ -27,7 +34,7 @@ public:
         return IdentifyType(file);
     }
 
-    static VAddr LoadModule(FileSys::VirtualFile file, VAddr load_base,
+    static VAddr LoadModule(FileSys::VirtualFile file, VAddr load_base, bool should_pass_arguments,
                             boost::optional<FileSys::PatchManager> pm = boost::none);
 
     ResultStatus Load(Kernel::Process& process) override;

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -155,6 +155,7 @@ struct Values {
     // Debugging
     bool use_gdbstub;
     u16 gdbstub_port;
+    std::string program_args;
 
     // WebService
     bool enable_telemetry;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -134,6 +134,7 @@ void Config::ReadValues() {
     qt_config->beginGroup("Debugging");
     Settings::values.use_gdbstub = qt_config->value("use_gdbstub", false).toBool();
     Settings::values.gdbstub_port = qt_config->value("gdbstub_port", 24689).toInt();
+    Settings::values.program_args = qt_config->value("program_args", "").toString().toStdString();
     qt_config->endGroup();
 
     qt_config->beginGroup("WebService");
@@ -269,6 +270,7 @@ void Config::SaveValues() {
     qt_config->beginGroup("Debugging");
     qt_config->setValue("use_gdbstub", Settings::values.use_gdbstub);
     qt_config->setValue("gdbstub_port", Settings::values.gdbstub_port);
+    qt_config->setValue("program_args", QString::fromStdString(Settings::values.program_args));
     qt_config->endGroup();
 
     qt_config->beginGroup("WebService");

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -33,6 +33,7 @@ void ConfigureDebug::setConfiguration() {
     ui->toggle_console->setEnabled(!Core::System::GetInstance().IsPoweredOn());
     ui->toggle_console->setChecked(UISettings::values.show_console);
     ui->log_filter_edit->setText(QString::fromStdString(Settings::values.log_filter));
+    ui->homebrew_args_edit->setText(QString::fromStdString(Settings::values.program_args));
 }
 
 void ConfigureDebug::applyConfiguration() {
@@ -40,6 +41,7 @@ void ConfigureDebug::applyConfiguration() {
     Settings::values.gdbstub_port = ui->gdbport_spinbox->value();
     UISettings::values.show_console = ui->toggle_console->isChecked();
     Settings::values.log_filter = ui->log_filter_edit->text().toStdString();
+    Settings::values.program_args = ui->homebrew_args_edit->text().toStdString();
     Debugger::ToggleConsole();
     Log::Filter filter;
     filter.ParseFilterString(Settings::values.log_filter);

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -107,6 +107,29 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_3">
+     <property name="title">
+      <string>Homebrew</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Arguments String</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="homebrew_args_edit"/>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -138,6 +138,7 @@ void Config::ReadValues() {
     Settings::values.use_gdbstub = sdl2_config->GetBoolean("Debugging", "use_gdbstub", false);
     Settings::values.gdbstub_port =
         static_cast<u16>(sdl2_config->GetInteger("Debugging", "gdbstub_port", 24689));
+    Settings::values.program_args = sdl2_config->Get("Debugging", "program_args", "");
 
     // Web Service
     Settings::values.enable_telemetry =

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -56,9 +56,10 @@ static void PrintHelp(const char* argv0) {
     std::cout << "Usage: " << argv0
               << " [options] <filename>\n"
                  "-g, --gdbport=NUMBER  Enable gdb stub on port NUMBER\n"
-                 "-f, --fullscreen     Start in fullscreen mode\n"
+                 "-f, --fullscreen      Start in fullscreen mode\n"
                  "-h, --help            Display this help and exit\n"
-                 "-v, --version         Output version information and exit\n";
+                 "-v, --version         Output version information and exit\n"
+                 "-p, --program         Pass following string as arguments to executable\n";
 }
 
 static void PrintVersion() {
@@ -103,15 +104,13 @@ int main(int argc, char** argv) {
     bool fullscreen = false;
 
     static struct option long_options[] = {
-        {"gdbport", required_argument, 0, 'g'},
-        {"fullscreen", no_argument, 0, 'f'},
-        {"help", no_argument, 0, 'h'},
-        {"version", no_argument, 0, 'v'},
-        {0, 0, 0, 0},
+        {"gdbport", required_argument, 0, 'g'}, {"fullscreen", no_argument, 0, 'f'},
+        {"help", no_argument, 0, 'h'},          {"version", no_argument, 0, 'v'},
+        {"program", optional_argument, 0, 'p'}, {0, 0, 0, 0},
     };
 
     while (optind < argc) {
-        char arg = getopt_long(argc, argv, "g:fhv", long_options, &option_index);
+        char arg = getopt_long(argc, argv, "g:fhvp::", long_options, &option_index);
         if (arg != -1) {
             switch (arg) {
             case 'g':
@@ -135,6 +134,10 @@ int main(int argc, char** argv) {
             case 'v':
                 PrintVersion();
                 return 0;
+            case 'p':
+                Settings::values.program_args = argv[optind];
+                ++optind;
+                break;
             }
         } else {
 #ifdef _WIN32


### PR DESCRIPTION
- Adds necessary framework and structs to pass an arguments string into an NSO/NRO.
- Will pass into normal games, but only to the `rtld` NSO.
- Can be set in UI
![argsstr](https://user-images.githubusercontent.com/5064800/46260966-02d14e00-c4bb-11e8-8317-8358a9da3904.PNG)
- Can be passed in via command line (for yuzu-cmd) using the `-p` or `--program` options.
(e.g. `yuzu-cmd -p "-h -l" program.nro` will execute the nro and pass `-h -l` to it)

- Created the following tester homebrew: https://github.com/DarkLordZach/echo-homebrew

- WIP as no libnx homebrew currently runs in yuzu because of HID problems