### PR TITLE
 fsmitm_romfsbuild: Add support for stubbing and IPS patches in LFS

### DIFF
--- a/src/core/file_sys/fsmitm_romfsbuild.h
+++ b/src/core/file_sys/fsmitm_romfsbuild.h
@@ -40,7 +40,7 @@ struct RomFSFileEntry;
 
 class RomFSBuildContext {
 public:
-    explicit RomFSBuildContext(VirtualDir base);
+    explicit RomFSBuildContext(VirtualDir base, VirtualDir ext = nullptr);
     ~RomFSBuildContext();
 
     // This finalizes the context.
@@ -48,6 +48,7 @@ public:
 
 private:
     VirtualDir base;
+    VirtualDir ext;
     std::shared_ptr<RomFSBuildDirectoryContext> root;
     std::map<std::string, std::shared_ptr<RomFSBuildDirectoryContext>, std::less<>> directories;
     std::map<std::string, std::shared_ptr<RomFSBuildFileContext>, std::less<>> files;
@@ -59,7 +60,8 @@ private:
     u64 file_hash_table_size = 0;
     u64 file_partition_size = 0;
 
-    void VisitDirectory(VirtualDir filesys, std::shared_ptr<RomFSBuildDirectoryContext> parent);
+    void VisitDirectory(VirtualDir filesys, VirtualDir ext,
+                        std::shared_ptr<RomFSBuildDirectoryContext> parent);
 
     bool AddDirectory(std::shared_ptr<RomFSBuildDirectoryContext> parent_dir_ctx,
                       std::shared_ptr<RomFSBuildDirectoryContext> dir_ctx);

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -172,7 +172,7 @@ static void ApplyLayeredFS(VirtualFile& romfs, u64 title_id, ContentRecordType t
 
         auto ext_dir = subdir->GetSubdirectory("romfs_ext");
         if (ext_dir != nullptr)
-            layers.push_back(std::move(ext_dir));
+            layers_ext.push_back(std::move(ext_dir));
     }
     layers.push_back(std::move(extracted));
 
@@ -182,9 +182,6 @@ static void ApplyLayeredFS(VirtualFile& romfs, u64 title_id, ContentRecordType t
     }
 
     auto layered_ext = LayeredVfsDirectory::MakeLayeredDirectory(std::move(layers_ext));
-    if (layered_ext == nullptr) {
-        return;
-    }
 
     auto packed = CreateRomFS(std::move(layered), std::move(layered_ext));
     if (packed == nullptr) {

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -162,11 +162,17 @@ static void ApplyLayeredFS(VirtualFile& romfs, u64 title_id, ContentRecordType t
               [](const VirtualDir& l, const VirtualDir& r) { return l->GetName() < r->GetName(); });
 
     std::vector<VirtualDir> layers;
+    std::vector<VirtualDir> layers_ext;
     layers.reserve(patch_dirs.size() + 1);
+    layers_ext.reserve(patch_dirs.size() + 1);
     for (const auto& subdir : patch_dirs) {
         auto romfs_dir = subdir->GetSubdirectory("romfs");
         if (romfs_dir != nullptr)
             layers.push_back(std::move(romfs_dir));
+
+        auto ext_dir = subdir->GetSubdirectory("romfs_ext");
+        if (ext_dir != nullptr)
+            layers.push_back(std::move(ext_dir));
     }
     layers.push_back(std::move(extracted));
 
@@ -175,7 +181,12 @@ static void ApplyLayeredFS(VirtualFile& romfs, u64 title_id, ContentRecordType t
         return;
     }
 
-    auto packed = CreateRomFS(std::move(layered));
+    auto layered_ext = LayeredVfsDirectory::MakeLayeredDirectory(std::move(layers_ext));
+    if (layered_ext == nullptr) {
+        return;
+    }
+
+    auto packed = CreateRomFS(std::move(layered), std::move(layered_ext));
     if (packed == nullptr) {
         return;
     }

--- a/src/core/file_sys/romfs.cpp
+++ b/src/core/file_sys/romfs.cpp
@@ -129,11 +129,11 @@ VirtualDir ExtractRomFS(VirtualFile file, RomFSExtractionType type) {
     return out;
 }
 
-VirtualFile CreateRomFS(VirtualDir dir) {
+VirtualFile CreateRomFS(VirtualDir dir, VirtualDir ext) {
     if (dir == nullptr)
         return nullptr;
 
-    RomFSBuildContext ctx{dir};
+    RomFSBuildContext ctx{dir, ext};
     return ConcatenatedVfsFile::MakeConcatenatedFile(0, ctx.Build(), dir->GetName());
 }
 

--- a/src/core/file_sys/romfs.h
+++ b/src/core/file_sys/romfs.h
@@ -44,6 +44,6 @@ VirtualDir ExtractRomFS(VirtualFile file,
 
 // Converts a VFS filesystem into a RomFS binary
 // Returns nullptr on failure
-VirtualFile CreateRomFS(VirtualDir dir);
+VirtualFile CreateRomFS(VirtualDir dir, VirtualDir ext = nullptr);
 
 } // namespace FileSys


### PR DESCRIPTION
This PR extends the current LayeredFS functionality in yuzu with two new features:

*NOTE: Both of these are placed in a directory called `romfs_ext` which is a sibling to `romfs` in a mod. This is to prevent name conflicts with developer files. This dir follows the exact directory structure as the actual romfs.*
1. Add support for stubbing files. When patching, if there exists a file with the entire name of the current file but the extension `.stub`, it will be deleted from the final image.
    - For example, if you wish to delete `texture.dds` from a romfs, make a file in the same directory under LayeredFS called `texture.dds.stub`.
2. Add support for IPS patching files. This is useful when distributing the entire replacement file would be copyright infringement. Similar to stubbing above, but with the extension `.ips`.
    - For example, to patch `menu.dat` in romfs, create a file in the same directory under LayeredFS called `menu.dat.ips`.

Fair note of caution, `stub` is propagating. If one mod has a .stub for a file, it cannot be overridden by another mod, regardless of load order.

**DEPENDENT ON PR #1415 -- WANTED TO GET REVIEW AND SUCH OUT OF THE WAY**
*Includes a rebase so it compiles/can be tested -- actual PR starts at commit b5b03fb*