### PR TITLE
ips_layer: Add support for IPSwitch executable patches

### DIFF
--- a/src/common/hex_util.cpp
+++ b/src/common/hex_util.cpp
@@ -30,7 +30,7 @@ std::vector<u8> HexStringToVector(std::string_view str, bool little_endian) {
     return out;
 }
 
-std::string HexVectorToString(std::vector<u8> vector, bool upper) {
+std::string HexVectorToString(const std::vector<u8>& vector, bool upper) {
     std::string out;
     for (u8 c : vector)
         out += fmt::format(upper ? "{:02X}" : "{:02x}", c);

--- a/src/common/hex_util.cpp
+++ b/src/common/hex_util.cpp
@@ -18,6 +18,25 @@ u8 ToHexNibble(char c1) {
     return 0;
 }
 
+std::vector<u8> HexStringToVector(std::string_view str, bool little_endian) {
+    std::vector<u8> out(str.size() / 2);
+    if (little_endian) {
+        for (std::size_t i = str.size() - 2; i <= str.size(); i -= 2)
+            out[i / 2] = (ToHexNibble(str[i]) << 4) | ToHexNibble(str[i + 1]);
+    } else {
+        for (std::size_t i = 0; i < str.size(); i += 2)
+            out[i / 2] = (ToHexNibble(str[i]) << 4) | ToHexNibble(str[i + 1]);
+    }
+    return out;
+}
+
+std::string HexVectorToString(std::vector<u8> vector, bool upper) {
+    std::string out;
+    for (u8 c : vector)
+        out += fmt::format(upper ? "{:02X}" : "{:02x}", c);
+    return out;
+}
+
 std::array<u8, 16> operator""_array16(const char* str, std::size_t len) {
     if (len != 32) {
         LOG_ERROR(Common,

--- a/src/common/hex_util.h
+++ b/src/common/hex_util.h
@@ -7,12 +7,15 @@
 #include <array>
 #include <cstddef>
 #include <string>
+#include <vector>
 #include <fmt/format.h>
 #include "common/common_types.h"
 
 namespace Common {
 
 u8 ToHexNibble(char c1);
+
+std::vector<u8> HexStringToVector(std::string_view str, bool little_endian);
 
 template <std::size_t Size, bool le = false>
 std::array<u8, Size> HexStringToArray(std::string_view str) {
@@ -26,6 +29,8 @@ std::array<u8, Size> HexStringToArray(std::string_view str) {
     }
     return out;
 }
+
+std::string HexVectorToString(std::vector<u8> vector, bool upper = true);
 
 template <std::size_t Size>
 std::string HexArrayToString(std::array<u8, Size> array, bool upper = true) {

--- a/src/common/hex_util.h
+++ b/src/common/hex_util.h
@@ -30,7 +30,7 @@ std::array<u8, Size> HexStringToArray(std::string_view str) {
     return out;
 }
 
-std::string HexVectorToString(std::vector<u8> vector, bool upper = true);
+std::string HexVectorToString(const std::vector<u8>& vector, bool upper = true);
 
 template <std::size_t Size>
 std::string HexArrayToString(std::array<u8, Size> array, bool upper = true) {

--- a/src/core/file_sys/ips_layer.h
+++ b/src/core/file_sys/ips_layer.h
@@ -22,6 +22,7 @@ public:
     VirtualFile Apply(const VirtualFile& in) const;
 
 private:
+    void ParseFlag(const std::string& flag);
     void Parse();
 
     bool valid = false;

--- a/src/core/file_sys/ips_layer.h
+++ b/src/core/file_sys/ips_layer.h
@@ -12,4 +12,30 @@ namespace FileSys {
 
 VirtualFile PatchIPS(const VirtualFile& in, const VirtualFile& ips);
 
+class IPSwitchCompiler {
+public:
+    explicit IPSwitchCompiler(VirtualFile patch_text);
+    std::array<u8, 0x20> GetBuildID() const;
+    bool IsValid() const;
+    VirtualFile Apply(const VirtualFile& in) const;
+
+private:
+    void Parse();
+
+    bool valid;
+
+    struct IPSwitchPatch {
+        std::string name;
+        bool enabled;
+        std::map<u32, std::vector<u8>> records;
+    };
+
+    VirtualFile patch_text;
+    std::vector<IPSwitchPatch> patches;
+    std::array<u8, 0x20> nso_build_id;
+    bool is_little_endian;
+    u64 offset_shift;
+    bool print_values;
+};
+
 } // namespace FileSys

--- a/src/core/file_sys/ips_layer.h
+++ b/src/core/file_sys/ips_layer.h
@@ -34,8 +34,9 @@ private:
     std::vector<IPSwitchPatch> patches;
     std::array<u8, 0x20> nso_build_id;
     bool is_little_endian;
-    u64 offset_shift;
+    s64 offset_shift;
     bool print_values;
+    std::string last_comment;
 };
 
 } // namespace FileSys

--- a/src/core/file_sys/ips_layer.h
+++ b/src/core/file_sys/ips_layer.h
@@ -15,6 +15,8 @@ VirtualFile PatchIPS(const VirtualFile& in, const VirtualFile& ips);
 class IPSwitchCompiler {
 public:
     explicit IPSwitchCompiler(VirtualFile patch_text);
+    ~IPSwitchCompiler();
+
     std::array<u8, 0x20> GetBuildID() const;
     bool IsValid() const;
     VirtualFile Apply(const VirtualFile& in) const;
@@ -22,7 +24,7 @@ public:
 private:
     void Parse();
 
-    bool valid;
+    bool valid = false;
 
     struct IPSwitchPatch {
         std::string name;
@@ -32,11 +34,11 @@ private:
 
     VirtualFile patch_text;
     std::vector<IPSwitchPatch> patches;
-    std::array<u8, 0x20> nso_build_id;
-    bool is_little_endian;
-    s64 offset_shift;
-    bool print_values;
-    std::string last_comment;
+    std::array<u8, 0x20> nso_build_id{};
+    bool is_little_endian = false;
+    s64 offset_shift = 0;
+    bool print_values = false;
+    std::string last_comment = "";
 };
 
 } // namespace FileSys

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -76,7 +76,7 @@ VirtualDir PatchManager::PatchExeFS(VirtualDir exefs) const {
 static std::vector<VirtualFile> CollectPatches(const std::vector<VirtualDir>& patch_dirs,
                                                const std::string& build_id) {
     std::vector<VirtualFile> out;
-    ips.reserve(patch_dirs.size());
+    out.reserve(patch_dirs.size());
     for (const auto& subdir : patch_dirs) {
         auto exefs_dir = subdir->GetSubdirectory("exefs");
         if (exefs_dir != nullptr) {

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -273,11 +273,13 @@ std::map<std::string, std::string, std::less<>> PatchManager::GetPatchVersionNam
     if (mod_dir != nullptr && mod_dir->GetSize() > 0) {
         for (const auto& mod : mod_dir->GetSubdirectories()) {
             std::string types;
-            if (IsDirValidAndNonEmpty(mod->GetSubdirectory("exefs"))) {
+
+            const auto exefs_dir = mod->GetSubdirectory("exefs");
+            if (IsDirValidAndNonEmpty(exefs_dir)) {
                 bool ips = false;
                 bool ipswitch = false;
 
-                for (const auto& file : mod->GetSubdirectory("exefs")->GetFiles()) {
+                for (const auto& file : exefs_dir->GetFiles()) {
                     if (file->GetExtension() == "ips")
                         ips = true;
                     else if (file->GetExtension() == "pchtxt")

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -73,27 +73,38 @@ VirtualDir PatchManager::PatchExeFS(VirtualDir exefs) const {
     return exefs;
 }
 
-static std::vector<VirtualFile> CollectIPSPatches(const std::vector<VirtualDir>& patch_dirs,
-                                                  const std::string& build_id) {
-    std::vector<VirtualFile> ips;
+static std::vector<VirtualFile> CollectPatches(const std::vector<VirtualDir>& patch_dirs,
+                                               const std::string& build_id) {
+    std::vector<VirtualFile> out;
     ips.reserve(patch_dirs.size());
     for (const auto& subdir : patch_dirs) {
         auto exefs_dir = subdir->GetSubdirectory("exefs");
         if (exefs_dir != nullptr) {
             for (const auto& file : exefs_dir->GetFiles()) {
-                if (file->GetExtension() != "ips")
-                    continue;
-                auto name = file->GetName();
-                const auto p1 = name.substr(0, name.find('.'));
-                const auto this_build_id = p1.substr(0, p1.find_last_not_of('0') + 1);
+                if (file->GetExtension() == "ips") {
+                    auto name = file->GetName();
+                    const auto p1 = name.substr(0, name.find('.'));
+                    const auto this_build_id = p1.substr(0, p1.find_last_not_of('0') + 1);
 
-                if (build_id == this_build_id)
-                    ips.push_back(file);
+                    if (build_id == this_build_id)
+                        out.push_back(file);
+                } else if (file->GetExtension() == "pchtxt") {
+                    IPSwitchCompiler compiler{file};
+                    if (!compiler.IsValid())
+                        continue;
+
+                    auto this_build_id = Common::HexArrayToString(compiler.GetBuildID());
+                    this_build_id =
+                        this_build_id.substr(0, this_build_id.find_last_not_of('0') + 1);
+
+                    if (build_id == this_build_id)
+                        out.push_back(file);
+                }
             }
         }
     }
 
-    return ips;
+    return out;
 }
 
 std::vector<u8> PatchManager::PatchNSO(const std::vector<u8>& nso) const {
@@ -115,15 +126,24 @@ std::vector<u8> PatchManager::PatchNSO(const std::vector<u8>& nso) const {
     auto patch_dirs = load_dir->GetSubdirectories();
     std::sort(patch_dirs.begin(), patch_dirs.end(),
               [](const VirtualDir& l, const VirtualDir& r) { return l->GetName() < r->GetName(); });
-    const auto ips = CollectIPSPatches(patch_dirs, build_id);
+    const auto patches = CollectPatches(patch_dirs, build_id);
 
     auto out = nso;
-    for (const auto& ips_file : ips) {
-        LOG_INFO(Loader, "    - Appling IPS patch from mod \"{}\"",
-                 ips_file->GetContainingDirectory()->GetParentDirectory()->GetName());
-        const auto patched = PatchIPS(std::make_shared<VectorVfsFile>(out), ips_file);
-        if (patched != nullptr)
-            out = patched->ReadAllBytes();
+    for (const auto& patch_file : patches) {
+        if (patch_file->GetExtension() == "ips") {
+            LOG_INFO(Loader, "    - Applying IPS patch from mod \"{}\"",
+                     patch_file->GetContainingDirectory()->GetParentDirectory()->GetName());
+            const auto patched = PatchIPS(std::make_shared<VectorVfsFile>(out), patch_file);
+            if (patched != nullptr)
+                out = patched->ReadAllBytes();
+        } else if (patch_file->GetExtension() == "pchtxt") {
+            LOG_INFO(Loader, "    - Applying IPSwitch patch from mod \"{}\"",
+                     patch_file->GetContainingDirectory()->GetParentDirectory()->GetName());
+            const IPSwitchCompiler compiler{patch_file};
+            const auto patched = compiler.Apply(std::make_shared<VectorVfsFile>(out));
+            if (patched != nullptr)
+                out = patched->ReadAllBytes();
+        }
     }
 
     if (out.size() < 0x100)
@@ -143,7 +163,7 @@ bool PatchManager::HasNSOPatch(const std::array<u8, 32>& build_id_) const {
     std::sort(patch_dirs.begin(), patch_dirs.end(),
               [](const VirtualDir& l, const VirtualDir& r) { return l->GetName() < r->GetName(); });
 
-    return !CollectIPSPatches(patch_dirs, build_id).empty();
+    return !CollectPatches(patch_dirs, build_id).empty();
 }
 
 static void ApplyLayeredFS(VirtualFile& romfs, u64 title_id, ContentRecordType type) {
@@ -253,8 +273,22 @@ std::map<std::string, std::string, std::less<>> PatchManager::GetPatchVersionNam
     if (mod_dir != nullptr && mod_dir->GetSize() > 0) {
         for (const auto& mod : mod_dir->GetSubdirectories()) {
             std::string types;
-            if (IsDirValidAndNonEmpty(mod->GetSubdirectory("exefs")))
-                AppendCommaIfNotEmpty(types, "IPS");
+            if (IsDirValidAndNonEmpty(mod->GetSubdirectory("exefs"))) {
+                bool ips = false;
+                bool ipswitch = false;
+
+                for (const auto& file : mod->GetSubdirectory("exefs")->GetFiles()) {
+                    if (file->GetExtension() == "ips")
+                        ips = true;
+                    else if (file->GetExtension() == "pchtxt")
+                        ipswitch = true;
+                }
+
+                if (ips)
+                    AppendCommaIfNotEmpty(types, "IPS");
+                if (ipswitch)
+                    AppendCommaIfNotEmpty(types, "IPSwitch");
+            }
             if (IsDirValidAndNonEmpty(mod->GetSubdirectory("romfs")))
                 AppendCommaIfNotEmpty(types, "LayeredFS");
 

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -36,6 +36,7 @@ public:
 
     // Currently tracked NSO patches:
     // - IPS
+    // - IPSwitch
     std::vector<u8> PatchNSO(const std::vector<u8>& nso) const;
 
     // Checks to see if PatchNSO() will have any effect given the NSO's build ID.


### PR DESCRIPTION
IPSwitch (pronounced IPS-witch) is a patch description format created by @3096 to be easier to use than IPS. The format revolves around 'patch text' files which look similar to the following:
```
// Crash game if it tries to delete save
@disabled
00176ACC DEADBEEF
``` 
(credit to Dualie Artist on Splatoon Modding Hub discord)

This PR adds support for parsing these patch texts instead of requiring the user to use homebrew to compile them to IPS and then using that.

The files (extension `.pchtxt`) go into the exefs folder of a mod and can be named anything desired (as the file contains the NSO build ID within it).

A full specification as well as examples and the homebrew can be found [here](https://github.com/3096/ipswitch).

**DEPENDENT ON PR #1415 -- WANTED TO GET REVIEW AND SUCH OUT OF THE WAY**
*Includes a rebase so it compiles/can be tested -- actual PR starts at commit 3025afe*