### PR TITLE
configure_input: Make analog mapping strings translatable

### DIFF
--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -152,9 +152,9 @@ ConfigureInput::ConfigureInput(QWidget* parent)
             }
         }
         connect(analog_map_stick[analog_id], &QPushButton::released, [=]() {
-            QMessageBox::information(
-                this, "Information",
-                "After pressing OK, first move your joystick horizontally, and then vertically.");
+            QMessageBox::information(this, tr("Information"),
+                                     tr("After pressing OK, first move your joystick horizontally, "
+                                        "and then vertically."));
             handleClick(
                 analog_map_stick[analog_id],
                 [=](const Common::ParamPackage& params) { analogs_param[analog_id] = params; },


### PR DESCRIPTION
These strings are user-facing, so they should be specified as translatable with `tr()`.