### PR TITLE
vfs: Remove InterpretAsDirectory and related functions

### DIFF
--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -168,10 +168,6 @@ VirtualDir XCI::GetParentDirectory() const {
     return file->GetContainingDirectory();
 }
 
-bool XCI::ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) {
-    return false;
-}
-
 Loader::ResultStatus XCI::AddNCAFromPartition(XCIPartition part) {
     if (partitions[static_cast<std::size_t>(part)] == nullptr) {
         return Loader::ResultStatus::ErrorXCIMissingPartition;

--- a/src/core/file_sys/card_image.h
+++ b/src/core/file_sys/card_image.h
@@ -94,9 +94,6 @@ public:
 
     VirtualDir GetParentDirectory() const override;
 
-protected:
-    bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
-
 private:
     Loader::ResultStatus AddNCAFromPartition(XCIPartition part);
 

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -546,7 +546,4 @@ u64 NCA::GetBaseIVFCOffset() const {
     return ivfc_offset;
 }
 
-bool NCA::ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) {
-    return false;
-}
 } // namespace FileSys

--- a/src/core/file_sys/content_archive.h
+++ b/src/core/file_sys/content_archive.h
@@ -100,9 +100,6 @@ public:
     // Returns the base ivfc offset used in BKTR patching.
     u64 GetBaseIVFCOffset() const;
 
-protected:
-    bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
-
 private:
     bool CheckSupportedNCA(const NCAHeader& header);
     bool HandlePotentialHeaderDecryption();

--- a/src/core/file_sys/partition_filesystem.cpp
+++ b/src/core/file_sys/partition_filesystem.cpp
@@ -83,7 +83,7 @@ std::vector<std::shared_ptr<VfsFile>> PartitionFilesystem::GetFiles() const {
 }
 
 std::vector<std::shared_ptr<VfsDirectory>> PartitionFilesystem::GetSubdirectories() const {
-    return pfs_dirs;
+    return {};
 }
 
 std::string PartitionFilesystem::GetName() const {
@@ -102,19 +102,5 @@ void PartitionFilesystem::PrintDebugInfo() const {
         LOG_DEBUG(Service_FS, " > File {}:              {} (0x{:X} bytes)", i,
                   pfs_files[i]->GetName(), pfs_files[i]->GetSize());
     }
-}
-
-bool PartitionFilesystem::ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) {
-    const auto iter = std::find(pfs_files.begin(), pfs_files.end(), file);
-    if (iter == pfs_files.end())
-        return false;
-
-    const std::ptrdiff_t offset = std::distance(pfs_files.begin(), iter);
-    pfs_files[offset] = std::move(pfs_files.back());
-    pfs_files.pop_back();
-
-    pfs_dirs.emplace_back(std::move(dir));
-
-    return true;
 }
 } // namespace FileSys

--- a/src/core/file_sys/partition_filesystem.h
+++ b/src/core/file_sys/partition_filesystem.h
@@ -35,9 +35,6 @@ public:
     std::shared_ptr<VfsDirectory> GetParentDirectory() const override;
     void PrintDebugInfo() const;
 
-protected:
-    bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
-
 private:
     struct Header {
         u32_le magic;
@@ -84,7 +81,6 @@ private:
     std::size_t content_offset = 0;
 
     std::vector<VirtualFile> pfs_files;
-    std::vector<VirtualDir> pfs_dirs;
 };
 
 } // namespace FileSys

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -205,10 +205,6 @@ VirtualDir NSP::GetParentDirectory() const {
     return file->GetContainingDirectory();
 }
 
-bool NSP::ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) {
-    return false;
-}
-
 void NSP::InitializeExeFSAndRomFS(const std::vector<VirtualFile>& files) {
     exefs = pfs;
 

--- a/src/core/file_sys/submission_package.h
+++ b/src/core/file_sys/submission_package.h
@@ -55,9 +55,6 @@ public:
 
     VirtualDir GetParentDirectory() const override;
 
-protected:
-    bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
-
 private:
     void InitializeExeFSAndRomFS(const std::vector<VirtualFile>& files);
     void ReadNCAs(const std::vector<VirtualFile>& files);

--- a/src/core/file_sys/vfs.h
+++ b/src/core/file_sys/vfs.h
@@ -262,36 +262,8 @@ public:
     // item name -> type.
     virtual std::map<std::string, VfsEntryType, std::less<>> GetEntries() const;
 
-    // Interprets the file with name file instead as a directory of type directory.
-    // The directory must have a constructor that takes a single argument of type
-    // std::shared_ptr<VfsFile>. Allows to reinterpret container files (i.e NCA, zip, XCI, etc) as a
-    // subdirectory in one call.
-    template <typename Directory>
-    bool InterpretAsDirectory(std::string_view file) {
-        auto file_p = GetFile(file);
-
-        if (file_p == nullptr) {
-            return false;
-        }
-
-        return ReplaceFileWithSubdirectory(file_p, std::make_shared<Directory>(file_p));
-    }
-
-    bool InterpretAsDirectory(const std::function<VirtualDir(VirtualFile)>& function,
-                              const std::string& file) {
-        auto file_p = GetFile(file);
-        if (file_p == nullptr)
-            return false;
-        return ReplaceFileWithSubdirectory(file_p, function(file_p));
-    }
-
     // Returns the full path of this directory as a string, recursively
     virtual std::string GetFullPath() const;
-
-protected:
-    // Backend for InterpretAsDirectory.
-    // Removes all references to file and adds a reference to dir in the directory's implementation.
-    virtual bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) = 0;
 };
 
 // A convenience partial-implementation of VfsDirectory that stubs out methods that should only work

--- a/src/core/file_sys/vfs_layered.cpp
+++ b/src/core/file_sys/vfs_layered.cpp
@@ -126,7 +126,4 @@ bool LayeredVfsDirectory::Rename(std::string_view name_) {
     return true;
 }
 
-bool LayeredVfsDirectory::ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) {
-    return false;
-}
 } // namespace FileSys

--- a/src/core/file_sys/vfs_layered.h
+++ b/src/core/file_sys/vfs_layered.h
@@ -39,9 +39,6 @@ public:
     bool DeleteFile(std::string_view name) override;
     bool Rename(std::string_view name) override;
 
-protected:
-    bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
-
 private:
     std::vector<VirtualDir> dirs;
     std::string name;

--- a/src/core/file_sys/vfs_real.cpp
+++ b/src/core/file_sys/vfs_real.cpp
@@ -430,7 +430,4 @@ std::map<std::string, VfsEntryType, std::less<>> RealVfsDirectory::GetEntries() 
     return out;
 }
 
-bool RealVfsDirectory::ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) {
-    return false;
-}
 } // namespace FileSys

--- a/src/core/file_sys/vfs_real.h
+++ b/src/core/file_sys/vfs_real.h
@@ -100,9 +100,6 @@ public:
     std::string GetFullPath() const override;
     std::map<std::string, VfsEntryType, std::less<>> GetEntries() const override;
 
-protected:
-    bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
-
 private:
     RealVfsDirectory(RealVfsFilesystem& base, const std::string& path, Mode perms = Mode::Read);
 

--- a/src/core/file_sys/vfs_vector.cpp
+++ b/src/core/file_sys/vfs_vector.cpp
@@ -132,11 +132,4 @@ void VectorVfsDirectory::AddFile(VirtualFile file) {
 void VectorVfsDirectory::AddDirectory(VirtualDir dir) {
     dirs.push_back(std::move(dir));
 }
-
-bool VectorVfsDirectory::ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) {
-    if (!DeleteFile(file->GetName()))
-        return false;
-    dirs.emplace_back(std::move(dir));
-    return true;
-}
 } // namespace FileSys

--- a/src/core/file_sys/vfs_vector.h
+++ b/src/core/file_sys/vfs_vector.h
@@ -57,9 +57,6 @@ public:
     virtual void AddFile(VirtualFile file);
     virtual void AddDirectory(VirtualDir dir);
 
-protected:
-    bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
-
 private:
     std::vector<VirtualFile> files;
     std::vector<VirtualDir> dirs;

--- a/src/core/file_sys/xts_archive.cpp
+++ b/src/core/file_sys/xts_archive.cpp
@@ -163,7 +163,4 @@ std::shared_ptr<VfsDirectory> NAX::GetParentDirectory() const {
     return file->GetContainingDirectory();
 }
 
-bool NAX::ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) {
-    return false;
-}
 } // namespace FileSys

--- a/src/core/file_sys/xts_archive.h
+++ b/src/core/file_sys/xts_archive.h
@@ -51,9 +51,6 @@ public:
 
     std::shared_ptr<VfsDirectory> GetParentDirectory() const override;
 
-protected:
-    bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
-
 private:
     Loader::ResultStatus Parse(std::string_view path);
 


### PR DESCRIPTION
When writing VFS, it initally seemed useful to include a function to in-place convert container files into directories in one homogenous directory structure, but re-evaluating it now there have been plenty of chances to use it and there has always been a better way. Removing as it is unused and likely will not be used.

This removes the two overloads of `InterpretAsDirectory` and its backend function `ReplaceFileWithSubdirectory`. Most of these implementations were just stubbed as a sidenote.