### PR TITLE
card_image: Ensure program_nca_status is always initialized

### DIFF
--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -20,7 +20,9 @@ namespace FileSys {
 
 constexpr std::array<const char*, 0x4> partition_names = {"update", "normal", "secure", "logo"};
 
-XCI::XCI(VirtualFile file_) : file(std::move(file_)), partitions(0x4) {
+XCI::XCI(VirtualFile file_)
+    : file(std::move(file_)), program_nca_status{Loader::ResultStatus::ErrorXCIMissingProgramNCA},
+      partitions(0x4) {
     if (file->ReadObject(&header) != sizeof(GamecardHeader)) {
         status = Loader::ResultStatus::ErrorBadXCIHeader;
         return;


### PR DESCRIPTION
If any of the error paths before the NCA retrieval are taken, it'll result in `program_nca_status` being left in an inconsistent state. So we initialize it by default with a value indicating an error.