### PR TITLE
submission_package: Cleanup and bug fixes

### DIFF
--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -23,13 +23,16 @@ void SetTicketKeys(const std::vector<VirtualFile>& files) {
     Core::Crypto::KeyManager keys;
 
     for (const auto& ticket_file : files) {
+        if (ticket_file == nullptr) {
+            continue;
+        }
+
         if (ticket_file->GetExtension() != "tik") {
             continue;
         }
 
-        if (ticket_file == nullptr ||
-            ticket_file->GetSize() <
-                Core::Crypto::TICKET_FILE_TITLEKEY_OFFSET + sizeof(Core::Crypto::Key128)) {
+        if (ticket_file->GetSize() <
+            Core::Crypto::TICKET_FILE_TITLEKEY_OFFSET + sizeof(Core::Crypto::Key128)) {
             continue;
         }
 

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -53,22 +53,15 @@ NSP::NSP(VirtualFile file_)
         return;
     }
 
+    const auto files = pfs->GetFiles();
+
     if (IsDirectoryExeFS(pfs)) {
         extracted = true;
-        exefs = pfs;
-
-        const auto& files = pfs->GetFiles();
-        const auto romfs_iter =
-            std::find_if(files.begin(), files.end(), [](const FileSys::VirtualFile& file) {
-                return file->GetName().find(".romfs") != std::string::npos;
-            });
-        if (romfs_iter != files.end())
-            romfs = *romfs_iter;
+        InitializeExeFSAndRomFS(files);
         return;
     }
 
     extracted = false;
-    const auto files = pfs->GetFiles();
 
     SetTicketKeys(files);
     ReadNCAs(files);
@@ -210,6 +203,20 @@ VirtualDir NSP::GetParentDirectory() const {
 
 bool NSP::ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) {
     return false;
+}
+
+void NSP::InitializeExeFSAndRomFS(const std::vector<VirtualFile>& files) {
+    exefs = pfs;
+
+    const auto romfs_iter = std::find_if(files.begin(), files.end(), [](const VirtualFile& file) {
+        return file->GetName().find(".romfs") != std::string::npos;
+    });
+
+    if (romfs_iter == files.end()) {
+        return;
+    }
+
+    romfs = *romfs_iter;
 }
 
 void NSP::ReadNCAs(const std::vector<VirtualFile>& files) {

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -38,8 +38,11 @@ void SetTicketKeys(const std::vector<VirtualFile>& files) {
 
         Core::Crypto::Key128 key{};
         ticket_file->Read(key.data(), key.size(), Core::Crypto::TICKET_FILE_TITLEKEY_OFFSET);
-        std::string_view name_only(ticket_file->GetName());
-        name_only.remove_suffix(4);
+
+        // We get the name without the extension in order to create the rights ID.
+        std::string name_only(ticket_file->GetName());
+        name_only.erase(name_only.size() - 4);
+
         const auto rights_id_raw = Common::HexStringToArray<16>(name_only);
         u128 rights_id;
         std::memcpy(rights_id.data(), rights_id_raw.data(), sizeof(u128));

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -61,8 +61,6 @@ NSP::NSP(VirtualFile file_)
         return;
     }
 
-    extracted = false;
-
     SetTicketKeys(files);
     ReadNCAs(files);
 }

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -207,7 +207,7 @@ void NSP::InitializeExeFSAndRomFS(const std::vector<VirtualFile>& files) {
     exefs = pfs;
 
     const auto romfs_iter = std::find_if(files.begin(), files.end(), [](const VirtualFile& file) {
-        return file->GetName().find(".romfs") != std::string::npos;
+        return file->GetName().rfind(".romfs") != std::string::npos;
     });
 
     if (romfs_iter == files.end()) {

--- a/src/core/file_sys/submission_package.h
+++ b/src/core/file_sys/submission_package.h
@@ -59,6 +59,8 @@ protected:
     bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
 
 private:
+    void ReadNCAs(const std::vector<VirtualFile>& files);
+
     VirtualFile file;
 
     bool extracted;

--- a/src/core/file_sys/submission_package.h
+++ b/src/core/file_sys/submission_package.h
@@ -64,7 +64,7 @@ private:
 
     VirtualFile file;
 
-    bool extracted;
+    bool extracted = false;
     Loader::ResultStatus status;
     std::map<u64, Loader::ResultStatus> program_status;
 

--- a/src/core/file_sys/submission_package.h
+++ b/src/core/file_sys/submission_package.h
@@ -59,6 +59,7 @@ protected:
     bool ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) override;
 
 private:
+    void InitializeExeFSAndRomFS(const std::vector<VirtualFile>& files);
     void ReadNCAs(const std::vector<VirtualFile>& files);
 
     VirtualFile file;


### PR DESCRIPTION
Just a little cleanup that moves functionally separate behaviors into their own functions. Along the way I also uncovered some bugs, which I've fixed in their own commits. Notably a null check being in the wrong place, and a dangling string view. This also correct a potential case where it would be possible to perform an uninitialized read just by using the public API.