### PR TITLE
gl_rasterizer: Implement quads topology

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -27,6 +27,8 @@ add_library(video_core STATIC
     renderer_base.h
     renderer_opengl/gl_buffer_cache.cpp
     renderer_opengl/gl_buffer_cache.h
+    renderer_opengl/gl_primitive_assembler.cpp
+    renderer_opengl/gl_primitive_assembler.h
     renderer_opengl/gl_rasterizer.cpp
     renderer_opengl/gl_rasterizer.h
     renderer_opengl/gl_rasterizer_cache.cpp

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -744,6 +744,12 @@ public:
                         return static_cast<GPUVAddr>((static_cast<GPUVAddr>(end_addr_high) << 32) |
                                                      end_addr_low);
                     }
+
+                    /// Adjust the index buffer offset so it points to the first desired index.
+                    GPUVAddr IndexStart() const {
+                        return StartAddress() + static_cast<size_t>(first) *
+                                                    static_cast<size_t>(FormatSizeInBytes());
+                    }
                 } index_array;
 
                 INSERT_PADDING_WORDS(0x7);

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -34,7 +34,7 @@ GLintptr OGLBufferCache::UploadMemory(Tegra::GPUVAddr gpu_addr, std::size_t size
     }
 
     AlignBuffer(alignment);
-    GLintptr uploaded_offset = buffer_offset;
+    const GLintptr uploaded_offset = buffer_offset;
 
     Memory::ReadBlock(*cpu_addr, buffer_ptr, size);
 
@@ -57,11 +57,21 @@ GLintptr OGLBufferCache::UploadHostMemory(const void* raw_pointer, std::size_t s
                                           std::size_t alignment) {
     AlignBuffer(alignment);
     std::memcpy(buffer_ptr, raw_pointer, size);
-    GLintptr uploaded_offset = buffer_offset;
+    const GLintptr uploaded_offset = buffer_offset;
 
     buffer_ptr += size;
     buffer_offset += size;
     return uploaded_offset;
+}
+
+std::tuple<u8*, GLintptr> OGLBufferCache::ReserveMemory(std::size_t size, std::size_t alignment) {
+    AlignBuffer(alignment);
+    u8* const uploaded_ptr = buffer_ptr;
+    const GLintptr uploaded_offset = buffer_offset;
+
+    buffer_ptr += size;
+    buffer_offset += size;
+    return std::make_tuple(uploaded_ptr, uploaded_offset);
 }
 
 void OGLBufferCache::Map(std::size_t max_size) {
@@ -74,6 +84,7 @@ void OGLBufferCache::Map(std::size_t max_size) {
         InvalidateAll();
     }
 }
+
 void OGLBufferCache::Unmap() {
     stream_buffer.Unmap(buffer_offset - buffer_offset_base);
 }
@@ -84,7 +95,7 @@ GLuint OGLBufferCache::GetHandle() const {
 
 void OGLBufferCache::AlignBuffer(std::size_t alignment) {
     // Align the offset, not the mapped pointer
-    GLintptr offset_aligned =
+    const GLintptr offset_aligned =
         static_cast<GLintptr>(Common::AlignUp(static_cast<std::size_t>(buffer_offset), alignment));
     buffer_ptr += offset_aligned - buffer_offset;
     buffer_offset = offset_aligned;

--- a/src/video_core/renderer_opengl/gl_buffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.h
@@ -6,6 +6,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <tuple>
 
 #include "common/common_types.h"
 #include "video_core/rasterizer_cache.h"
@@ -33,10 +34,16 @@ class OGLBufferCache final : public RasterizerCache<std::shared_ptr<CachedBuffer
 public:
     explicit OGLBufferCache(std::size_t size);
 
+    /// Uploads data from a guest GPU address. Returns host's buffer offset where it's been
+    /// allocated.
     GLintptr UploadMemory(Tegra::GPUVAddr gpu_addr, std::size_t size, std::size_t alignment = 4,
                           bool cache = true);
 
+    /// Uploads from a host memory. Returns host's buffer offset where it's been allocated.
     GLintptr UploadHostMemory(const void* raw_pointer, std::size_t size, std::size_t alignment = 4);
+
+    /// Reserves memory to be used by host's CPU. Returns mapped address and offset.
+    std::tuple<u8*, GLintptr> ReserveMemory(std::size_t size, std::size_t alignment = 4);
 
     void Map(std::size_t max_size);
     void Unmap();

--- a/src/video_core/renderer_opengl/gl_primitive_assembler.cpp
+++ b/src/video_core/renderer_opengl/gl_primitive_assembler.cpp
@@ -1,0 +1,64 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <array>
+#include "common/assert.h"
+#include "common/common_types.h"
+#include "core/memory.h"
+#include "video_core/renderer_opengl/gl_buffer_cache.h"
+#include "video_core/renderer_opengl/gl_primitive_assembler.h"
+
+namespace OpenGL {
+
+constexpr u32 TRIANGLES_PER_QUAD = 6;
+constexpr std::array<u32, TRIANGLES_PER_QUAD> QUAD_MAP = {0, 1, 2, 0, 2, 3};
+
+PrimitiveAssembler::PrimitiveAssembler(OGLBufferCache& buffer_cache) : buffer_cache(buffer_cache) {}
+
+PrimitiveAssembler::~PrimitiveAssembler() = default;
+
+std::size_t PrimitiveAssembler::CalculateQuadSize(u32 count) const {
+    ASSERT_MSG(count % 4 == 0, "Quad count is expected to be a multiple of 4");
+    return (count / 4) * TRIANGLES_PER_QUAD * sizeof(GLuint);
+}
+
+GLintptr PrimitiveAssembler::MakeQuadArray(u32 first, u32 count) {
+    const std::size_t size{CalculateQuadSize(count)};
+    auto [dst_pointer, index_offset] = buffer_cache.ReserveMemory(size);
+
+    for (u32 primitive = 0; primitive < count / 4; ++primitive) {
+        for (u32 i = 0; i < TRIANGLES_PER_QUAD; ++i) {
+            const u32 index = first + primitive * 4 + QUAD_MAP[i];
+            std::memcpy(dst_pointer, &index, sizeof(index));
+            dst_pointer += sizeof(index);
+        }
+    }
+
+    return index_offset;
+}
+
+GLintptr PrimitiveAssembler::MakeQuadIndexed(Tegra::GPUVAddr gpu_addr, std::size_t index_size,
+                                             u32 count) {
+    const std::size_t map_size{CalculateQuadSize(count)};
+    auto [dst_pointer, index_offset] = buffer_cache.ReserveMemory(map_size);
+
+    auto& memory_manager = Core::System::GetInstance().GPU().MemoryManager();
+    const boost::optional<VAddr> cpu_addr{memory_manager.GpuToCpuAddress(gpu_addr)};
+    const u8* source{Memory::GetPointer(*cpu_addr)};
+
+    for (u32 primitive = 0; primitive < count / 4; ++primitive) {
+        for (std::size_t i = 0; i < TRIANGLES_PER_QUAD; ++i) {
+            const u32 index = primitive * 4 + QUAD_MAP[i];
+            const u8* src_offset = source + (index * index_size);
+
+            std::memcpy(dst_pointer, src_offset, index_size);
+            dst_pointer += index_size;
+        }
+    }
+
+    return index_offset;
+}
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_primitive_assembler.h
+++ b/src/video_core/renderer_opengl/gl_primitive_assembler.h
@@ -1,0 +1,33 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <vector>
+#include <glad/glad.h>
+
+#include "common/common_types.h"
+#include "video_core/memory_manager.h"
+
+namespace OpenGL {
+
+class OGLBufferCache;
+
+class PrimitiveAssembler {
+public:
+    explicit PrimitiveAssembler(OGLBufferCache& buffer_cache);
+    ~PrimitiveAssembler();
+
+    /// Calculates the size required by MakeQuadArray and MakeQuadIndexed.
+    std::size_t CalculateQuadSize(u32 count) const;
+
+    GLintptr MakeQuadArray(u32 first, u32 count);
+
+    GLintptr MakeQuadIndexed(Tegra::GPUVAddr gpu_addr, std::size_t index_size, u32 count);
+
+private:
+    OGLBufferCache& buffer_cache;
+};
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -23,6 +23,7 @@
 #include "video_core/rasterizer_cache.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/gl_buffer_cache.h"
+#include "video_core/renderer_opengl/gl_primitive_assembler.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/renderer_opengl/gl_shader_cache.h"
@@ -38,6 +39,7 @@ class EmuWindow;
 namespace OpenGL {
 
 struct ScreenInfo;
+struct DrawParameters;
 
 class RasterizerOpenGL : public VideoCore::RasterizerInterface {
 public:
@@ -192,11 +194,16 @@ private:
     static constexpr std::size_t STREAM_BUFFER_SIZE = 128 * 1024 * 1024;
     OGLBufferCache buffer_cache;
     OGLFramebuffer framebuffer;
+    PrimitiveAssembler primitive_assembler{buffer_cache};
     GLint uniform_buffer_alignment;
 
     std::size_t CalculateVertexArraysSize() const;
 
+    std::size_t CalculateIndexBufferSize() const;
+
     void SetupVertexArrays();
+
+    DrawParameters SetupDraw();
 
     void SetupShaders();
 


### PR DESCRIPTION
It handles quad arrays with first index and indexed quads with base vertex. These [tests](https://github.com/yuzu-emu/yuzu/files/2444551/quad-tests.7z.zip) use `gl_VertexID` to choose colors and are rendered with quads. I added another microprofile entry for primitive assembly and abstracted draw dispatching in a struct.

Conflicts with #1425 .