### PR TITLE
kernel/thread: Make all instance variables private

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -86,7 +86,7 @@ public:
                 parent.jit->HaltExecution();
                 parent.SetPC(pc);
                 Kernel::Thread* thread = Kernel::GetCurrentThread();
-                parent.SaveContext(thread->context);
+                parent.SaveContext(thread->GetContext());
                 GDBStub::Break();
                 GDBStub::SendTrap(thread, 5);
                 return;

--- a/src/core/arm/unicorn/arm_unicorn.cpp
+++ b/src/core/arm/unicorn/arm_unicorn.cpp
@@ -195,7 +195,7 @@ void ARM_Unicorn::ExecuteInstructions(int num_instructions) {
             uc_reg_write(uc, UC_ARM64_REG_PC, &last_bkpt.address);
         }
         Kernel::Thread* thread = Kernel::GetCurrentThread();
-        SaveContext(thread->context);
+        SaveContext(thread->GetContext());
         if (last_bkpt_hit || GDBStub::GetCpuStepFlag()) {
             last_bkpt_hit = false;
             GDBStub::Break();

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -209,7 +209,7 @@ static Kernel::Thread* FindThreadById(int id) {
     for (u32 core = 0; core < Core::NUM_CPU_CORES; core++) {
         const auto& threads = Core::System::GetInstance().Scheduler(core)->GetThreadList();
         for (auto& thread : threads) {
-            if (thread->GetThreadId() == static_cast<u32>(id)) {
+            if (thread->GetThreadID() == static_cast<u32>(id)) {
                 current_core = core;
                 return thread.get();
             }
@@ -223,16 +223,18 @@ static u64 RegRead(std::size_t id, Kernel::Thread* thread = nullptr) {
         return 0;
     }
 
+    const auto& thread_context = thread->GetContext();
+
     if (id < SP_REGISTER) {
-        return thread->context.cpu_registers[id];
+        return thread_context.cpu_registers[id];
     } else if (id == SP_REGISTER) {
-        return thread->context.sp;
+        return thread_context.sp;
     } else if (id == PC_REGISTER) {
-        return thread->context.pc;
+        return thread_context.pc;
     } else if (id == PSTATE_REGISTER) {
-        return thread->context.pstate;
+        return thread_context.pstate;
     } else if (id > PSTATE_REGISTER && id < FPCR_REGISTER) {
-        return thread->context.vector_registers[id - UC_ARM64_REG_Q0][0];
+        return thread_context.vector_registers[id - UC_ARM64_REG_Q0][0];
     } else {
         return 0;
     }
@@ -243,16 +245,18 @@ static void RegWrite(std::size_t id, u64 val, Kernel::Thread* thread = nullptr) 
         return;
     }
 
+    auto& thread_context = thread->GetContext();
+
     if (id < SP_REGISTER) {
-        thread->context.cpu_registers[id] = val;
+        thread_context.cpu_registers[id] = val;
     } else if (id == SP_REGISTER) {
-        thread->context.sp = val;
+        thread_context.sp = val;
     } else if (id == PC_REGISTER) {
-        thread->context.pc = val;
+        thread_context.pc = val;
     } else if (id == PSTATE_REGISTER) {
-        thread->context.pstate = static_cast<u32>(val);
+        thread_context.pstate = static_cast<u32>(val);
     } else if (id > PSTATE_REGISTER && id < FPCR_REGISTER) {
-        thread->context.vector_registers[id - (PSTATE_REGISTER + 1)][0] = val;
+        thread_context.vector_registers[id - (PSTATE_REGISTER + 1)][0] = val;
     }
 }
 
@@ -595,7 +599,7 @@ static void HandleQuery() {
         for (u32 core = 0; core < Core::NUM_CPU_CORES; core++) {
             const auto& threads = Core::System::GetInstance().Scheduler(core)->GetThreadList();
             for (const auto& thread : threads) {
-                val += fmt::format("{:x}", thread->GetThreadId());
+                val += fmt::format("{:x}", thread->GetThreadID());
                 val += ",";
             }
         }
@@ -612,7 +616,7 @@ static void HandleQuery() {
             for (const auto& thread : threads) {
                 buffer +=
                     fmt::format(R"*(<thread id="{:x}" core="{:d}" name="Thread {:x}"></thread>)*",
-                                thread->GetThreadId(), core, thread->GetThreadId());
+                                thread->GetThreadID(), core, thread->GetThreadID());
             }
         }
         buffer += "</threads>";
@@ -693,7 +697,7 @@ static void SendSignal(Kernel::Thread* thread, u32 signal, bool full = true) {
     }
 
     if (thread) {
-        buffer += fmt::format(";thread:{:x};", thread->GetThreadId());
+        buffer += fmt::format(";thread:{:x};", thread->GetThreadID());
     }
 
     SendReply(buffer.c_str());
@@ -857,7 +861,9 @@ static void WriteRegister() {
     }
 
     // Update Unicorn context skipping scheduler, no running threads at this point
-    Core::System::GetInstance().ArmInterface(current_core).LoadContext(current_thread->context);
+    Core::System::GetInstance()
+        .ArmInterface(current_core)
+        .LoadContext(current_thread->GetContext());
 
     SendReply("OK");
 }
@@ -886,7 +892,9 @@ static void WriteRegisters() {
     }
 
     // Update Unicorn context skipping scheduler, no running threads at this point
-    Core::System::GetInstance().ArmInterface(current_core).LoadContext(current_thread->context);
+    Core::System::GetInstance()
+        .ArmInterface(current_core)
+        .LoadContext(current_thread->GetContext());
 
     SendReply("OK");
 }
@@ -960,7 +968,9 @@ static void Step() {
     if (command_length > 1) {
         RegWrite(PC_REGISTER, GdbHexToLong(command_buffer + 1), current_thread);
         // Update Unicorn context skipping scheduler, no running threads at this point
-        Core::System::GetInstance().ArmInterface(current_core).LoadContext(current_thread->context);
+        Core::System::GetInstance()
+            .ArmInterface(current_core)
+            .LoadContext(current_thread->GetContext());
     }
     step_loop = true;
     halt_loop = true;

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -144,15 +144,15 @@ void Process::PrepareForTermination() {
 
     const auto stop_threads = [this](const std::vector<SharedPtr<Thread>>& thread_list) {
         for (auto& thread : thread_list) {
-            if (thread->owner_process != this)
+            if (thread->GetOwnerProcess() != this)
                 continue;
 
             if (thread == GetCurrentThread())
                 continue;
 
             // TODO(Subv): When are the other running/ready threads terminated?
-            ASSERT_MSG(thread->status == ThreadStatus::WaitSynchAny ||
-                           thread->status == ThreadStatus::WaitSynchAll,
+            ASSERT_MSG(thread->GetStatus() == ThreadStatus::WaitSynchAny ||
+                           thread->GetStatus() == ThreadStatus::WaitSynchAll,
                        "Exiting processes with non-waiting threads is currently unimplemented");
 
             thread->Stop();

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -120,10 +120,10 @@ ResultCode ServerSession::HandleSyncRequest(SharedPtr<Thread> thread) {
         result = hle_handler->HandleSyncRequest(context);
     }
 
-    if (thread->status == ThreadStatus::Running) {
+    if (thread->GetStatus() == ThreadStatus::Running) {
         // Put the thread to sleep until the server replies, it will be awoken in
         // svcReplyAndReceive for LLE servers.
-        thread->status = ThreadStatus::WaitIPC;
+        thread->SetStatus(ThreadStatus::WaitIPC);
 
         if (hle_handler != nullptr) {
             // For HLE services, we put the request threads to sleep for a short duration to

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -70,7 +70,7 @@ void Thread::Stop() {
 
 void WaitCurrentThread_Sleep() {
     Thread* thread = GetCurrentThread();
-    thread->status = ThreadStatus::WaitSleep;
+    thread->SetStatus(ThreadStatus::WaitSleep);
 }
 
 void ExitCurrentThread() {
@@ -269,9 +269,9 @@ SharedPtr<Thread> SetupMainThread(KernelCore& kernel, VAddr entry_point, u32 pri
     SharedPtr<Thread> thread = std::move(thread_res).Unwrap();
 
     // Register 1 must be a handle to the main thread
-    thread->guest_handle = kernel.HandleTable().Create(thread).Unwrap();
-
-    thread->context.cpu_registers[1] = thread->guest_handle;
+    const Handle guest_handle = kernel.HandleTable().Create(thread).Unwrap();
+    thread->SetGuestHandle(guest_handle);
+    thread->GetContext().cpu_registers[1] = guest_handle;
 
     // Threads by default are dormant, wake up the main thread so it runs when the scheduler fires
     thread->ResumeFromWait();
@@ -297,6 +297,18 @@ VAddr Thread::GetCommandBufferAddress() const {
     // Offset from the start of TLS at which the IPC command buffer begins.
     static constexpr int CommandHeaderOffset = 0x80;
     return GetTLSAddress() + CommandHeaderOffset;
+}
+
+void Thread::SetStatus(ThreadStatus new_status) {
+    if (new_status == status) {
+        return;
+    }
+
+    if (status == ThreadStatus::Running) {
+        last_running_ticks = CoreTiming::GetTicks();
+    }
+
+    status = new_status;
 }
 
 void Thread::AddMutexWaiter(SharedPtr<Thread> thread) {
@@ -391,6 +403,18 @@ void Thread::ChangeCore(u32 core, u64 mask) {
     scheduler = next_scheduler;
 
     Core::System::GetInstance().CpuCore(processor_id).PrepareReschedule();
+}
+
+bool Thread::AllWaitObjectsReady() {
+    return std::none_of(
+        wait_objects.begin(), wait_objects.end(),
+        [this](const SharedPtr<WaitObject>& object) { return object->ShouldWait(this); });
+}
+
+bool Thread::InvokeWakeupCallback(ThreadWakeupReason reason, SharedPtr<Thread> thread,
+                                  SharedPtr<WaitObject> object, std::size_t index) {
+    ASSERT(wakeup_callback);
+    return wakeup_callback(reason, std::move(thread), std::move(object), index);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Many of the member variables of the thread class aren't even used outside of the class itself, so there's no need to make those variables public. This change follows in the steps of the previous changes that made other kernel types' members private.

The main motivation behind this is that the Thread class will likely change in the future as emulation becomes more accurate, and letting random bits of the emulator access data members of the Thread class directly makes it a pain to shuffle around and/or modify internals. Having all data members public like this also makes it difficult to reason about certain bits of behavior without first verifying what parts of the core actually use them.

Everything being public also generally follows the tendency for changes to be introduced in completely different translation units that would otherwise be better introduced as an addition to the Thread class' public interface.

This is just the initial change. I plan to follow this up with successive PRs that allow further clean-up to the Thread interface. The reason for that being that this PR is already quite large as it is.