### PR TITLE
ui_settings: Place definition of the theme array within the cpp file

### DIFF
--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -13,7 +13,7 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
 
     ui->setupUi(this);
 
-    for (auto theme : UISettings::themes) {
+    for (const auto& theme : UISettings::themes) {
         ui->theme_combobox->addItem(theme.first, theme.second);
     }
 

--- a/src/yuzu/ui_settings.cpp
+++ b/src/yuzu/ui_settings.cpp
@@ -6,5 +6,11 @@
 
 namespace UISettings {
 
+const Themes themes{{
+    {"Default", "default"},
+    {"Dark", "qdarkstyle"},
+}};
+
 Values values = {};
-}
+
+} // namespace UISettings

--- a/src/yuzu/ui_settings.h
+++ b/src/yuzu/ui_settings.h
@@ -15,9 +15,8 @@ namespace UISettings {
 using ContextualShortcut = std::pair<QString, int>;
 using Shortcut = std::pair<QString, ContextualShortcut>;
 
-static const std::array<std::pair<QString, QString>, 2> themes = {
-    {std::make_pair(QString("Default"), QString("default")),
-     std::make_pair(QString("Dark"), QString("qdarkstyle"))}};
+using Themes = std::array<std::pair<const char*, const char*>, 2>;
+extern const Themes themes;
 
 struct Values {
     QByteArray geometry;


### PR DESCRIPTION
Placing the array wholesale into the header places a copy of the whole array into every translation unit that uses the data, which is wasteful. Particularly given that this array is referenced from three different translation units.

This also changes the array to contain pairs of const char*, rather than QString instances. This way, the string data is able to be fixed into the read-only segment of the program, as well as eliminate static constructors/heap allocation immediately on program start.