### PR TITLE
thread: Make the scheduler pointer a regular pointer

### DIFF
--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -169,7 +169,7 @@ void Thread::ResumeFromWait() {
     next_scheduler->ScheduleThread(this, current_priority);
 
     // Change thread's scheduler
-    scheduler = next_scheduler;
+    scheduler = next_scheduler.get();
 
     Core::System::GetInstance().CpuCore(processor_id).PrepareReschedule();
 }
@@ -233,7 +233,7 @@ ResultVal<SharedPtr<Thread>> Thread::Create(KernelCore& kernel, std::string name
     thread->name = std::move(name);
     thread->callback_handle = kernel.ThreadWakeupCallbackHandleTable().Create(thread).Unwrap();
     thread->owner_process = owner_process;
-    thread->scheduler = Core::System::GetInstance().Scheduler(processor_id);
+    thread->scheduler = Core::System::GetInstance().Scheduler(processor_id).get();
     thread->scheduler->AddThread(thread, priority);
     thread->tls_address = thread->owner_process->MarkNextAvailableTLSSlotAsUsed(*thread);
 
@@ -400,7 +400,7 @@ void Thread::ChangeCore(u32 core, u64 mask) {
     next_scheduler->ScheduleThread(this, current_priority);
 
     // Change thread's scheduler
-    scheduler = next_scheduler;
+    scheduler = next_scheduler.get();
 
     Core::System::GetInstance().CpuCore(processor_id).PrepareReschedule();
 }

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -419,7 +419,7 @@ private:
     /// available. In case of a timeout, the object will be nullptr.
     WakeupCallback wakeup_callback;
 
-    std::shared_ptr<Scheduler> scheduler;
+    Scheduler* scheduler = nullptr;
 
     u32 ideal_core{0xFFFFFFFF};
     u64 affinity_mask{0x1};


### PR DESCRIPTION
Conceptually, it doesn't make sense for a thread to be able to persist the lifetime of a scheduler. A scheduler should be taking care of the threads; the threads should not be taking care of the scheduler.

If the threads outlive the scheduler (or we simply don't actually terminate/shutdown the threads), then it should be considered a bug that we need to fix.

Attributing this to balika011, as they opened #1317 to attempt to fix this in a similar way, but my refactoring of the kernel code caused quite a few conflicts.