### PR TITLE
kernel/mutex: Amend behavior of TransferMutexOwnership()

### DIFF
--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -47,7 +47,7 @@ static std::pair<SharedPtr<Thread>, u32> GetHighestPriorityMutexWaitingThread(
 /// Update the mutex owner field of all threads waiting on the mutex to point to the new owner.
 static void TransferMutexOwnership(VAddr mutex_addr, SharedPtr<Thread> current_thread,
                                    SharedPtr<Thread> new_owner) {
-    const auto& threads = current_thread->GetMutexWaitingThreads();
+    const auto threads = current_thread->GetMutexWaitingThreads();
     for (const auto& thread : threads) {
         if (thread->GetMutexWaitAddress() != mutex_addr)
             continue;


### PR DESCRIPTION
This was the result of a typo accidentally introduced in e51d715700a35a8f14e5b804b6f7553c9a40888b. This restores the previous correct behavior.

The behavior with the reference was incorrect and would cause some games to fail to boot.