### PR TITLE
Port citra-emu/citra#4311: "Remove "#" in the version number"

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -29,7 +29,7 @@ if ($ENV{CI})
       if (BUILD_VERSION)
         # This leaves a trailing space on the last word, but we actually want that
         # because of how it's styled in the title bar.
-        set(BUILD_FULLNAME "${REPO_NAME} #${BUILD_VERSION} ")
+        set(BUILD_FULLNAME "${REPO_NAME} ${BUILD_VERSION} ")
       else()
         set(BUILD_FULLNAME "")
       endif()


### PR DESCRIPTION
See citra-emu/citra#4311 for more details.

`So that people can stop using it in issue/pr comments and randomly link some other issue/pr unintentionally.`