### PR TITLE
Fixed smo softlock due to incorrect effect state updating

### DIFF
--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -30,7 +30,7 @@ public:
         return info;
     }
 
-    VoiceInfo& Info() {
+    VoiceInfo& GetInfo() {
         return info;
     }
 
@@ -61,7 +61,7 @@ public:
         return info;
     }
 
-    EffectInStatus& Info() {
+    EffectInStatus& GetInfo() {
         return info;
     }
 
@@ -120,7 +120,7 @@ std::vector<u8> AudioRenderer::UpdateAudioRenderer(const std::vector<u8>& input_
     std::size_t voice_offset{sizeof(UpdateDataHeader) + config.behavior_size +
                              config.memory_pools_size + config.voice_resource_size};
     for (auto& voice : voices) {
-        std::memcpy(&voice.Info(), input_params.data() + voice_offset, sizeof(VoiceInfo));
+        std::memcpy(&voice.GetInfo(), input_params.data() + voice_offset, sizeof(VoiceInfo));
         voice_offset += sizeof(VoiceInfo);
     }
 
@@ -128,7 +128,7 @@ std::vector<u8> AudioRenderer::UpdateAudioRenderer(const std::vector<u8>& input_
                               config.memory_pools_size + config.voice_resource_size +
                               config.voices_size};
     for (auto& effect : effects) {
-        std::memcpy(&effect.Info(), input_params.data() + effect_offset, sizeof(EffectInStatus));
+        std::memcpy(&effect.GetInfo(), input_params.data() + effect_offset, sizeof(EffectInStatus));
         effect_offset += sizeof(EffectInStatus);
     }
 
@@ -285,7 +285,8 @@ void AudioRenderer::VoiceState::RefreshBuffer() {
         break;
     }
 
-    samples = Interpolate(interp_state, std::move(samples), Info().sample_rate, STREAM_SAMPLE_RATE);
+    samples =
+        Interpolate(interp_state, std::move(samples), GetInfo().sample_rate, STREAM_SAMPLE_RATE);
 
     is_refresh_pending = false;
 }

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -58,7 +58,7 @@ public:
     }
 
     const EffectInStatus& GetInfo() const {
-        info;
+        return info;
     }
 
     EffectInStatus& Info() {

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -51,9 +51,30 @@ private:
     VoiceInfo info{};
 };
 
+class AudioRenderer::EffectState {
+public:
+    const EffectOutStatus& GetOutStatus() const {
+        return out_status;
+    }
+
+    const EffectInStatus& GetInfo() const {
+        info;
+    }
+
+    EffectInStatus& Info() {
+        return info;
+    }
+
+    void UpdateState();
+
+private:
+    EffectOutStatus out_status{};
+    EffectInStatus info{};
+};
 AudioRenderer::AudioRenderer(AudioRendererParameter params,
                              Kernel::SharedPtr<Kernel::Event> buffer_event)
-    : worker_params{params}, buffer_event{buffer_event}, voices(params.voice_count) {
+    : worker_params{params}, buffer_event{buffer_event}, voices(params.voice_count),
+      effects(params.effect_count) {
 
     audio_out = std::make_unique<AudioCore::AudioOut>();
     stream = audio_out->OpenStream(STREAM_SAMPLE_RATE, STREAM_NUM_CHANNELS, "AudioRenderer",
@@ -96,11 +117,29 @@ std::vector<u8> AudioRenderer::UpdateAudioRenderer(const std::vector<u8>& input_
                 memory_pool_count * sizeof(MemoryPoolInfo));
 
     // Copy VoiceInfo structs
-    std::size_t offset{sizeof(UpdateDataHeader) + config.behavior_size + config.memory_pools_size +
-                       config.voice_resource_size};
+    std::size_t voice_offset{sizeof(UpdateDataHeader) + config.behavior_size +
+                             config.memory_pools_size + config.voice_resource_size};
     for (auto& voice : voices) {
-        std::memcpy(&voice.Info(), input_params.data() + offset, sizeof(VoiceInfo));
-        offset += sizeof(VoiceInfo);
+        std::memcpy(&voice.Info(), input_params.data() + voice_offset, sizeof(VoiceInfo));
+        voice_offset += sizeof(VoiceInfo);
+    }
+
+    std::size_t effect_offset{sizeof(UpdateDataHeader) + config.behavior_size +
+                              config.memory_pools_size + config.voice_resource_size +
+                              config.voices_size};
+    for (auto& effect : effects) {
+        std::memcpy(&effect.Info(), input_params.data() + effect_offset, sizeof(EffectInStatus));
+        effect_offset += sizeof(EffectInStatus);
+    }
+
+    // Update memory pool state
+    std::vector<MemoryPoolEntry> memory_pool(memory_pool_count);
+    for (std::size_t index = 0; index < memory_pool.size(); ++index) {
+        if (mem_pool_info[index].pool_state == MemoryPoolStates::RequestAttach) {
+            memory_pool[index].state = MemoryPoolStates::Attached;
+        } else if (mem_pool_info[index].pool_state == MemoryPoolStates::RequestDetach) {
+            memory_pool[index].state = MemoryPoolStates::Detached;
+        }
     }
 
     // Update voices
@@ -114,14 +153,8 @@ std::vector<u8> AudioRenderer::UpdateAudioRenderer(const std::vector<u8>& input_
         }
     }
 
-    // Update memory pool state
-    std::vector<MemoryPoolEntry> memory_pool(memory_pool_count);
-    for (std::size_t index = 0; index < memory_pool.size(); ++index) {
-        if (mem_pool_info[index].pool_state == MemoryPoolStates::RequestAttach) {
-            memory_pool[index].state = MemoryPoolStates::Attached;
-        } else if (mem_pool_info[index].pool_state == MemoryPoolStates::RequestDetach) {
-            memory_pool[index].state = MemoryPoolStates::Detached;
-        }
+    for (auto& effect : effects) {
+        effect.UpdateState();
     }
 
     // Release previous buffers and queue next ones for playback
@@ -144,6 +177,14 @@ std::vector<u8> AudioRenderer::UpdateAudioRenderer(const std::vector<u8>& input_
         voice_out_status_offset += sizeof(VoiceOutStatus);
     }
 
+    std::size_t effect_out_status_offset{
+        sizeof(UpdateDataHeader) + response_data.memory_pools_size + response_data.voices_size +
+        response_data.voice_resource_size};
+    for (const auto& effect : effects) {
+        std::memcpy(output_params.data() + effect_out_status_offset, &effect.GetOutStatus(),
+                    sizeof(EffectOutStatus));
+        effect_out_status_offset += sizeof(EffectOutStatus);
+    }
     return output_params;
 }
 
@@ -247,6 +288,23 @@ void AudioRenderer::VoiceState::RefreshBuffer() {
     samples = Interpolate(interp_state, std::move(samples), Info().sample_rate, STREAM_SAMPLE_RATE);
 
     is_refresh_pending = false;
+}
+
+void AudioRenderer::EffectState::UpdateState() {
+    if (info.is_new) {
+        out_status.state = EffectStatus::New;
+    } else {
+        if (info.type == Effect::Aux) {
+            ASSERT_MSG(Memory::Read32(info.aux_info.return_buffer_info) == 0,
+                       "Aux buffers tried to update");
+            ASSERT_MSG(Memory::Read32(info.aux_info.send_buffer_info) == 0,
+                       "Aux buffers tried to update");
+            ASSERT_MSG(Memory::Read32(info.aux_info.return_buffer_base) == 0,
+                       "Aux buffers tried to update");
+            ASSERT_MSG(Memory::Read32(info.aux_info.send_buffer_base) == 0,
+                       "Aux buffers tried to update");
+        }
+    }
 }
 
 static constexpr s16 ClampToS16(s32 value) {

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -171,7 +171,7 @@ static_assert(sizeof(EffectInStatus) == 0xc0, "EffectInStatus is an invalid size
 
 struct EffectOutStatus {
     EffectStatus state;
-    INSERT_PADDING_BYTES(15);
+    INSERT_PADDING_BYTES(0xf);
 };
 static_assert(sizeof(EffectOutStatus) == 0x10, "EffectOutStatus is an invalid size");
 

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -220,8 +220,8 @@ public:
     Stream::State GetStreamState() const;
 
 private:
-    class VoiceState;
     class EffectState;
+    class VoiceState;
 
     AudioRendererParameter worker_params;
     Kernel::SharedPtr<Kernel::Event> buffer_event;


### PR DESCRIPTION
The explanation, after effects are initialized in smo, nothing actually changes the state. It expects the state to always be initialized. With the previous testing, updating the states much like how we handle the memory pools continue to have the softlock(which is why I said it probably wasn't effects) after further examination it seems like effects need to be initialized but the state remains unchanged until further notice. For now, assertions are added for the aux buffers to see if they update, unable to check as I haven't gotten smo to actually update them yet.