### PR TITLE
svcBreak, Signalling to the debugger should not kill execution

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -308,12 +308,12 @@ static void Break(u64 reason, u64 info1, u64 info2) {
             Debug_Emulated,
             "Emulated program broke execution! reason=0x{:016X}, info1=0x{:016X}, info2=0x{:016X}",
             reason, info1, info2);
+        ASSERT(false);
     } else {
         LOG_ERROR(
             Debug_Emulated,
             "Emulated program broke execution! reason=0x{:016X}, info1=0x{:016X}, info2=0x{:016X}",
             reason, info1, info2);
-        ASSERT(false);
     }
 }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -301,19 +301,27 @@ static ResultCode ArbitrateUnlock(VAddr mutex_addr) {
     return Mutex::Release(mutex_addr);
 }
 
+struct BreakReason {
+    union {
+        u64 raw;
+        BitField<31, 1, u64> dont_kill_application;
+    };
+};
+
 /// Break program execution
 static void Break(u64 reason, u64 info1, u64 info2) {
-    if ((reason & (1 << 31)) == 0) {
+    BreakReason break_reason{reason};
+    if (break_reason.dont_kill_application) {
+        LOG_ERROR(
+            Debug_Emulated,
+            "Emulated program broke execution! reason=0x{:016X}, info1=0x{:016X}, info2=0x{:016X}",
+            reason, info1, info2);
+    } else {
         LOG_CRITICAL(
             Debug_Emulated,
             "Emulated program broke execution! reason=0x{:016X}, info1=0x{:016X}, info2=0x{:016X}",
             reason, info1, info2);
         ASSERT(false);
-    } else {
-        LOG_ERROR(
-            Debug_Emulated,
-            "Emulated program broke execution! reason=0x{:016X}, info1=0x{:016X}, info2=0x{:016X}",
-            reason, info1, info2);
     }
 }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -303,11 +303,18 @@ static ResultCode ArbitrateUnlock(VAddr mutex_addr) {
 
 /// Break program execution
 static void Break(u64 reason, u64 info1, u64 info2) {
-    LOG_CRITICAL(
-        Debug_Emulated,
-        "Emulated program broke execution! reason=0x{:016X}, info1=0x{:016X}, info2=0x{:016X}",
-        reason, info1, info2);
-    ASSERT(false);
+    if ((reason & (1 << 31)) == 0) {
+        LOG_CRITICAL(
+            Debug_Emulated,
+            "Emulated program broke execution! reason=0x{:016X}, info1=0x{:016X}, info2=0x{:016X}",
+            reason, info1, info2);
+    } else {
+        LOG_ERROR(
+            Debug_Emulated,
+            "Emulated program broke execution! reason=0x{:016X}, info1=0x{:016X}, info2=0x{:016X}",
+            reason, info1, info2);
+        ASSERT(false);
+    }
 }
 
 /// Used to output a message on a debug hardware unit - does nothing on a retail unit


### PR DESCRIPTION
When loading NROs, svcBreak is called to signal to the debugger that a new "module" is loaded. As no debugger is technically attached we shouldn't be killing the execution of the program.