### PR TITLE
patch_manager: Return a std::unique_ptr from ParseControlNCA() and GetControlMetadata() instead of a std::shared_ptr

### DIFF
--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -57,11 +57,10 @@ public:
 
     // Given title_id of the program, attempts to get the control data of the update and parse it,
     // falling back to the base control data.
-    std::pair<std::shared_ptr<NACP>, VirtualFile> GetControlMetadata() const;
+    std::pair<std::unique_ptr<NACP>, VirtualFile> GetControlMetadata() const;
 
     // Version of GetControlMetadata that takes an arbitrary NCA
-    std::pair<std::shared_ptr<NACP>, VirtualFile> ParseControlNCA(
-        const std::shared_ptr<NCA>& nca) const;
+    std::pair<std::unique_ptr<NACP>, VirtualFile> ParseControlNCA(const NCA& nca) const;
 
 private:
     u64 title_id;

--- a/src/core/loader/nsp.cpp
+++ b/src/core/loader/nsp.cpp
@@ -35,7 +35,7 @@ AppLoader_NSP::AppLoader_NSP(FileSys::VirtualFile file)
         return;
 
     std::tie(nacp_file, icon_file) =
-        FileSys::PatchManager(nsp->GetProgramTitleID()).ParseControlNCA(control_nca);
+        FileSys::PatchManager(nsp->GetProgramTitleID()).ParseControlNCA(*control_nca);
 }
 
 AppLoader_NSP::~AppLoader_NSP() = default;

--- a/src/core/loader/nsp.h
+++ b/src/core/loader/nsp.h
@@ -49,7 +49,7 @@ private:
     std::unique_ptr<AppLoader> secondary_loader;
 
     FileSys::VirtualFile icon_file;
-    std::shared_ptr<FileSys::NACP> nacp_file;
+    std::unique_ptr<FileSys::NACP> nacp_file;
     u64 title_id;
 };
 

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -30,7 +30,7 @@ AppLoader_XCI::AppLoader_XCI(FileSys::VirtualFile file)
         return;
 
     std::tie(nacp_file, icon_file) =
-        FileSys::PatchManager(xci->GetProgramTitleID()).ParseControlNCA(control_nca);
+        FileSys::PatchManager(xci->GetProgramTitleID()).ParseControlNCA(*control_nca);
 }
 
 AppLoader_XCI::~AppLoader_XCI() = default;

--- a/src/core/loader/xci.h
+++ b/src/core/loader/xci.h
@@ -49,7 +49,7 @@ private:
     std::unique_ptr<AppLoader_NCA> nca_loader;
 
     FileSys::VirtualFile icon_file;
-    std::shared_ptr<FileSys::NACP> nacp_file;
+    std::unique_ptr<FileSys::NACP> nacp_file;
 };
 
 } // namespace Loader

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -27,9 +27,8 @@
 #include "yuzu/ui_settings.h"
 
 namespace {
-void GetMetadataFromControlNCA(const FileSys::PatchManager& patch_manager,
-                               const std::shared_ptr<FileSys::NCA>& nca, std::vector<u8>& icon,
-                               std::string& name) {
+void GetMetadataFromControlNCA(const FileSys::PatchManager& patch_manager, const FileSys::NCA& nca,
+                               std::vector<u8>& icon, std::string& name) {
     auto [nacp, icon_file] = patch_manager.ParseControlNCA(nca);
     if (icon_file != nullptr)
         icon = icon_file->ReadAllBytes();
@@ -110,7 +109,7 @@ void GameListWorker::AddInstalledTitlesToGameList() {
         const FileSys::PatchManager patch{program_id};
         const auto& control = cache->GetEntry(game.title_id, FileSys::ContentRecordType::Control);
         if (control != nullptr)
-            GetMetadataFromControlNCA(patch, control, icon, name);
+            GetMetadataFromControlNCA(patch, *control, icon, name);
 
         auto it = FindMatchingCompatibilityEntry(compatibility_list, program_id);
 
@@ -197,8 +196,8 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
                 res2 == Loader::ResultStatus::Success) {
                 // Use from metadata pool.
                 if (nca_control_map.find(program_id) != nca_control_map.end()) {
-                    const auto nca = nca_control_map[program_id];
-                    GetMetadataFromControlNCA(patch, nca, icon, name);
+                    const auto& nca = nca_control_map[program_id];
+                    GetMetadataFromControlNCA(patch, *nca, icon, name);
                 }
             }
 


### PR DESCRIPTION
Neither of these functions require the use of shared ownership of the returned pointer. This makes it more difficult to create reference cycles with, and makes the interface more generic, as std::shared_ptr instances can be created from a std::unique_ptr, but the vice-versa isn't possible. This also alters relevant functions to take NCA arguments by const reference rather than a const reference to a std::shared_ptr. These functions don't alter the ownership of the memory used by the NCA instance, so we can make the interface more generic by not assuming anything about the type of smart pointer the NCA is contained within and make it the caller's responsibility to ensure the supplied NCA is valid.