### PR TITLE
qt: Add UI to manage emulated user profiles

### DIFF
--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -3,8 +3,11 @@
 // Refer to the license.txt file included.
 
 #include <array>
+#include "common/common_paths.h"
 #include "common/common_types.h"
+#include "common/file_util.h"
 #include "common/logging/log.h"
+#include "common/string_util.h"
 #include "common/swap.h"
 #include "core/core_timing.h"
 #include "core/hle/ipc_helpers.h"
@@ -16,6 +19,9 @@
 #include "core/hle/service/acc/profile_manager.h"
 
 namespace Service::Account {
+
+constexpr u32 MAX_JPEG_IMAGE_SIZE = 0x20000;
+
 // TODO: RE this structure
 struct UserData {
     INSERT_PADDING_WORDS(1);
@@ -26,6 +32,11 @@ struct UserData {
     INSERT_PADDING_BYTES(0x60);
 };
 static_assert(sizeof(UserData) == 0x80, "UserData structure has incorrect size");
+
+static std::string GetImagePath(const std::string& username) {
+    return FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + "users" + DIR_SEP + username +
+           ".jpg";
+}
 
 class IProfile final : public ServiceFramework<IProfile> {
 public:
@@ -38,6 +49,15 @@ public:
             {11, &IProfile::LoadImage, "LoadImage"},
         };
         RegisterHandlers(functions);
+
+        ProfileBase profile_base{};
+        if (profile_manager.GetProfileBase(user_id, profile_base)) {
+            image = std::make_unique<FileUtil::IOFile>(
+                GetImagePath(Common::StringFromFixedZeroTerminatedBuffer(
+                    reinterpret_cast<const char*>(profile_base.username.data()),
+                    profile_base.username.size())),
+                "rb");
+        }
     }
 
 private:
@@ -73,11 +93,11 @@ private:
     }
 
     void LoadImage(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
+        LOG_DEBUG(Service_ACC, "called");
         // smallest jpeg https://github.com/mathiasbynens/small/blob/master/jpeg.jpg
-        // TODO(mailwl): load actual profile image from disk, width 256px, max size 0x20000
-        constexpr u32 jpeg_size = 107;
-        static constexpr std::array<u8, jpeg_size> jpeg{
+        // used as a backup should the one on disk not exist
+        constexpr u32 backup_jpeg_size = 107;
+        static constexpr std::array<u8, backup_jpeg_size> backup_jpeg{
             0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0x00, 0x03, 0x02, 0x02, 0x02, 0x02, 0x02, 0x03,
             0x02, 0x02, 0x02, 0x03, 0x03, 0x03, 0x03, 0x04, 0x06, 0x04, 0x04, 0x04, 0x04, 0x04,
             0x08, 0x06, 0x06, 0x05, 0x06, 0x09, 0x08, 0x0a, 0x0a, 0x09, 0x08, 0x09, 0x09, 0x0a,
@@ -87,22 +107,38 @@ private:
             0xff, 0xcc, 0x00, 0x06, 0x00, 0x10, 0x10, 0x05, 0xff, 0xda, 0x00, 0x08, 0x01, 0x01,
             0x00, 0x00, 0x3f, 0x00, 0xd2, 0xcf, 0x20, 0xff, 0xd9,
         };
-        ctx.WriteBuffer(jpeg);
+
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u32>(jpeg_size);
+
+        if (image == nullptr) {
+            ctx.WriteBuffer(backup_jpeg);
+            rb.Push<u32>(backup_jpeg_size);
+        } else {
+            const auto size = std::min<u32>(image->GetSize(), MAX_JPEG_IMAGE_SIZE);
+            std::vector<u8> buffer(size);
+            image->ReadBytes(buffer.data(), buffer.size());
+
+            ctx.WriteBuffer(buffer.data(), buffer.size());
+            rb.Push<u32>(buffer.size());
+        }
     }
 
     void GetImageSize(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
-        constexpr u32 jpeg_size = 107;
+        LOG_DEBUG(Service_ACC, "called");
+        constexpr u32 backup_jpeg_size = 107;
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u32>(jpeg_size);
+
+        if (image == nullptr)
+            rb.Push<u32>(backup_jpeg_size);
+        else
+            rb.Push<u32>(std::min<u32>(image->GetSize(), MAX_JPEG_IMAGE_SIZE));
     }
 
     const ProfileManager& profile_manager;
     UUID user_id; ///< The user id this profile refers to.
+    std::unique_ptr<FileUtil::IOFile> image = nullptr;
 };
 
 class IManagerForApplication final : public ServiceFramework<IManagerForApplication> {

--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -106,6 +106,8 @@ private:
         const FileUtil::IOFile image(GetImagePath(user_id), "rb");
 
         if (!image.IsOpen()) {
+            LOG_WARNING(Service_ACC,
+                        "Failed to load user provided image! Falling back to built-in backup...");
             ctx.WriteBuffer(backup_jpeg);
             rb.Push<u32>(backup_jpeg_size);
         } else {
@@ -126,10 +128,13 @@ private:
 
         const FileUtil::IOFile image(GetImagePath(user_id), "rb");
 
-        if (!image.IsOpen())
+        if (!image.IsOpen()) {
+            LOG_WARNING(Service_ACC,
+                        "Failed to load user provided image! Falling back to built-in backup...");
             rb.Push<u32>(backup_jpeg_size);
-        else
+        } else {
             rb.Push<u32>(std::min<u32>(image.GetSize(), MAX_JPEG_IMAGE_SIZE));
+        }
     }
 
     const ProfileManager& profile_manager;

--- a/src/core/hle/service/acc/profile_manager.cpp
+++ b/src/core/hle/service/acc/profile_manager.cpp
@@ -323,7 +323,7 @@ void ProfileManager::WriteUserSaveFile() {
 
     FileUtil::IOFile save(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
                               "/system/save/8000000000000010/su/avators/profiles.dat",
-                          "rb");
+                          "wb");
 
     save.Resize(sizeof(ProfileDataRaw));
     save.Seek(0, SEEK_SET);

--- a/src/core/hle/service/acc/profile_manager.cpp
+++ b/src/core/hle/service/acc/profile_manager.cpp
@@ -23,10 +23,12 @@ const UUID& UUID::Generate() {
 }
 
 ProfileManager::ProfileManager() {
-    // TODO(ogniK): Create the default user we have for now until loading/saving users is added
-    auto user_uuid = UUID{1, 0};
-    ASSERT(CreateNewUser(user_uuid, Settings::values.username).IsSuccess());
-    OpenUser(user_uuid);
+    for (std::size_t i = 0; i < Settings::values.users.size(); ++i) {
+        const auto& val = Settings::values.users[i];
+        ASSERT(CreateNewUser(val.second, val.first).IsSuccess());
+    }
+
+    OpenUser(Settings::values.users[Settings::values.current_user].second);
 }
 
 ProfileManager::~ProfileManager() = default;

--- a/src/core/hle/service/acc/profile_manager.h
+++ b/src/core/hle/service/acc/profile_manager.h
@@ -96,6 +96,7 @@ public:
     ResultCode AddUser(const ProfileInfo& user);
     ResultCode CreateNewUser(UUID uuid, const ProfileUsername& username);
     ResultCode CreateNewUser(UUID uuid, const std::string& username);
+    boost::optional<UUID> GetUser(std::size_t index) const;
     boost::optional<std::size_t> GetUserIndex(const UUID& uuid) const;
     boost::optional<std::size_t> GetUserIndex(const ProfileInfo& user) const;
     bool GetProfileBase(boost::optional<std::size_t> index, ProfileBase& profile) const;
@@ -109,6 +110,7 @@ public:
     std::size_t GetUserCount() const;
     std::size_t GetOpenUserCount() const;
     bool UserExists(UUID uuid) const;
+    bool UserExistsIndex(std::size_t index) const;
     void OpenUser(UUID uuid);
     void CloseUser(UUID uuid);
     UserIDArray GetOpenUsers() const;

--- a/src/core/hle/service/acc/profile_manager.h
+++ b/src/core/hle/service/acc/profile_manager.h
@@ -45,6 +45,15 @@ struct UUID {
     std::string Format() const {
         return fmt::format("0x{:016X}{:016X}", uuid[1], uuid[0]);
     }
+
+    std::string FormatSwitch() const {
+        std::array<u8, 16> s{};
+        std::memcpy(s.data(), uuid.data(), sizeof(u128));
+        return fmt::format("{:02x}{:02x}{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{:02x}-{:02x}{"
+                           ":02x}{:02x}{:02x}{:02x}{:02x}",
+                           s[0], s[1], s[2], s[3], s[4], s[5], s[6], s[7], s[8], s[9], s[10], s[11],
+                           s[12], s[13], s[14], s[15]);
+    }
 };
 static_assert(sizeof(UUID) == 16, "UUID is an invalid size!");
 
@@ -108,7 +117,13 @@ public:
 
     bool CanSystemRegisterUser() const;
 
+    bool RemoveUser(UUID uuid);
+    bool SetProfileBase(UUID uuid, const ProfileBase& profile);
+
 private:
+    void ParseUserSaveFile();
+    void WriteUserSaveFile();
+
     std::array<ProfileInfo, MAX_USERS> profiles{};
     std::size_t user_count = 0;
     boost::optional<std::size_t> AddToProfiles(const ProfileInfo& profile);

--- a/src/core/hle/service/acc/profile_manager.h
+++ b/src/core/hle/service/acc/profile_manager.h
@@ -36,7 +36,7 @@ struct UUID {
     }
 
     // TODO(ogniK): Properly generate uuids based on RFC-4122
-    const UUID& Generate();
+    static UUID Generate();
 
     // Set the UUID to {0,0} to be considered an invalid user
     void Invalidate() {

--- a/src/core/hle/service/acc/profile_manager.h
+++ b/src/core/hle/service/acc/profile_manager.h
@@ -81,7 +81,7 @@ static_assert(sizeof(ProfileBase) == 0x38, "ProfileBase is an invalid size");
 /// objects
 class ProfileManager {
 public:
-    ProfileManager(); // TODO(ogniK): Load from system save
+    ProfileManager();
     ~ProfileManager();
 
     ResultCode AddUser(const ProfileInfo& user);

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -4,11 +4,13 @@
 
 #include <array>
 #include <cinttypes>
+#include <cstring>
 #include <stack>
 #include "core/core.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/event.h"
 #include "core/hle/kernel/process.h"
+#include "core/hle/service/acc/profile_manager.h"
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/am/applet_ae.h"
 #include "core/hle/service/am/applet_oe.h"
@@ -734,8 +736,10 @@ void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
     std::vector<u8> buffer(POP_LAUNCH_PARAMETER_BUFFER_SIZE);
 
     std::memcpy(buffer.data(), header_data.data(), header_data.size());
-    const auto current_uuid = Settings::values.users[Settings::values.current_user].second.uuid;
-    std::memcpy(buffer.data() + header_data.size(), current_uuid.data(), sizeof(u128));
+
+    Account::ProfileManager profile_manager{};
+    const auto uuid = profile_manager.GetAllUsers()[Settings::values.current_user].uuid;
+    std::memcpy(buffer.data() + header_data.size(), uuid.data(), sizeof(u128));
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
 

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -26,6 +26,8 @@
 
 namespace Service::AM {
 
+constexpr std::size_t POP_LAUNCH_PARAMETER_BUFFER_SIZE = 0x88;
+
 IWindowController::IWindowController() : ServiceFramework("IWindowController") {
     // clang-format off
     static const FunctionInfo functions[] = {
@@ -724,16 +726,16 @@ void IApplicationFunctions::EndBlockingHomeButton(Kernel::HLERequestContext& ctx
 }
 
 void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
-    constexpr std::array<u8, 0x88> data{{
+    constexpr std::array<u8, 0x8> header_data{
         0xca, 0x97, 0x94, 0xc7, // Magic
         1,    0,    0,    0,    // IsAccountSelected (bool)
-        1,    0,    0,    0,    // User Id (word 0)
-        0,    0,    0,    0,    // User Id (word 1)
-        0,    0,    0,    0,    // User Id (word 2)
-        0,    0,    0,    0     // User Id (word 3)
-    }};
+    };
 
-    std::vector<u8> buffer(data.begin(), data.end());
+    std::vector<u8> buffer(POP_LAUNCH_PARAMETER_BUFFER_SIZE);
+
+    std::memcpy(buffer.data(), header_data.data(), header_data.size());
+    const auto current_uuid = Settings::values.users[Settings::values.current_user].second.uuid;
+    std::memcpy(buffer.data() + header_data.size(), current_uuid.data(), sizeof(u128));
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
 

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <string>
 #include "common/common_types.h"
+#include "core/hle/service/acc/profile_manager.h"
 
 namespace Settings {
 
@@ -114,7 +115,8 @@ struct Values {
     // System
     bool use_docked_mode;
     bool enable_nfc;
-    std::string username;
+    int current_user;
+    std::vector<std::pair<std::string, Service::Account::UUID>> users;
     int language_index;
 
     // Controls

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -8,7 +8,6 @@
 #include <atomic>
 #include <string>
 #include "common/common_types.h"
-#include "core/hle/service/acc/profile_manager.h"
 
 namespace Settings {
 
@@ -116,7 +115,6 @@ struct Values {
     bool use_docked_mode;
     bool enable_nfc;
     int current_user;
-    std::vector<std::pair<std::string, Service::Account::UUID>> users;
     int language_index;
 
     // Controls

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -125,7 +125,8 @@ void Config::ReadValues() {
     Settings::values.use_docked_mode = qt_config->value("use_docked_mode", false).toBool();
     Settings::values.enable_nfc = qt_config->value("enable_nfc", true).toBool();
 
-    Settings::values.current_user = std::clamp(qt_config->value("current_user", 0).toInt(), 0, 7);
+    Settings::values.current_user = std::clamp<int>(qt_config->value("current_user", 0).toInt(), 0,
+                                                    Service::Account::MAX_USERS - 1);
 
     Settings::values.language_index = qt_config->value("language_index", 1).toInt();
     qt_config->endGroup();

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -4,6 +4,7 @@
 
 #include <QSettings>
 #include "common/file_util.h"
+#include "core/hle/service/acc/profile_manager.h"
 #include "input_common/main.h"
 #include "yuzu/configuration/config.h"
 #include "yuzu/ui_settings.h"
@@ -124,23 +125,7 @@ void Config::ReadValues() {
     Settings::values.use_docked_mode = qt_config->value("use_docked_mode", false).toBool();
     Settings::values.enable_nfc = qt_config->value("enable_nfc", true).toBool();
 
-    Settings::values.users.clear();
-    const auto size = qt_config->beginReadArray("users");
-    for (int i = 0; i < size; ++i) {
-        qt_config->setArrayIndex(i);
-        const Service::Account::UUID uuid(qt_config->value("uuid_low").toULongLong(),
-                                          qt_config->value("uuid_high").toULongLong());
-        Settings::values.users.emplace_back(qt_config->value("username").toString().toStdString(),
-                                            uuid);
-    }
-
-    qt_config->endArray();
-
-    if (Settings::values.users.empty())
-        Settings::values.users.emplace_back("yuzu", Service::Account::UUID{}.Generate());
-
-    Settings::values.current_user =
-        std::clamp(qt_config->value("current_user", 0).toInt(), 0, size);
+    Settings::values.current_user = std::clamp(qt_config->value("current_user", 0).toInt(), 0, 7);
 
     Settings::values.language_index = qt_config->value("language_index", 1).toInt();
     qt_config->endGroup();
@@ -279,17 +264,6 @@ void Config::SaveValues() {
     qt_config->setValue("use_docked_mode", Settings::values.use_docked_mode);
     qt_config->setValue("enable_nfc", Settings::values.enable_nfc);
     qt_config->setValue("current_user", Settings::values.current_user);
-
-    qt_config->beginWriteArray("users", Settings::values.users.size());
-    for (std::size_t i = 0; i < Settings::values.users.size(); ++i) {
-        qt_config->setArrayIndex(i);
-        const auto& user = Settings::values.users[i];
-        qt_config->setValue("uuid_low", user.second.uuid[0]);
-        qt_config->setValue("uuid_high", user.second.uuid[1]);
-        qt_config->setValue("username", QString::fromStdString(user.first));
-    }
-
-    qt_config->endArray();
 
     qt_config->setValue("language_index", Settings::values.language_index);
     qt_config->endGroup();

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -163,7 +163,7 @@ void ConfigureSystem::UpdateCurrentUser() {
 
 void ConfigureSystem::ReadSystemSettings() {}
 
-std::string ConfigureSystem::GetAccountUsername(Service::Account::UUID uuid) {
+std::string ConfigureSystem::GetAccountUsername(Service::Account::UUID uuid) const {
     Service::Account::ProfileBase profile;
     if (!profile_manager->GetProfileBase(uuid, profile))
         return "";

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -2,7 +2,12 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <QGraphicsItem>
+#include <QList>
 #include <QMessageBox>
+#include <qinputdialog.h>
+#include "common/common_paths.h"
+#include "common/logging/backend.h"
 #include "core/core.h"
 #include "core/settings.h"
 #include "ui_configure_system.h"
@@ -24,6 +29,17 @@ static const std::array<int, 12> days_in_month = {{
     31,
 }};
 
+// Same backup JPEG used by acc IProfile::GetImage if no jpeg found
+static constexpr std::array<u8, 107> backup_jpeg{
+    0xff, 0xd8, 0xff, 0xdb, 0x00, 0x43, 0x00, 0x03, 0x02, 0x02, 0x02, 0x02, 0x02, 0x03, 0x02, 0x02,
+    0x02, 0x03, 0x03, 0x03, 0x03, 0x04, 0x06, 0x04, 0x04, 0x04, 0x04, 0x04, 0x08, 0x06, 0x06, 0x05,
+    0x06, 0x09, 0x08, 0x0a, 0x0a, 0x09, 0x08, 0x09, 0x09, 0x0a, 0x0c, 0x0f, 0x0c, 0x0a, 0x0b, 0x0e,
+    0x0b, 0x09, 0x09, 0x0d, 0x11, 0x0d, 0x0e, 0x0f, 0x10, 0x10, 0x11, 0x10, 0x0a, 0x0c, 0x12, 0x13,
+    0x12, 0x10, 0x13, 0x0f, 0x10, 0x10, 0x10, 0xff, 0xc9, 0x00, 0x0b, 0x08, 0x00, 0x01, 0x00, 0x01,
+    0x01, 0x01, 0x11, 0x00, 0xff, 0xcc, 0x00, 0x06, 0x00, 0x10, 0x10, 0x05, 0xff, 0xda, 0x00, 0x08,
+    0x01, 0x01, 0x00, 0x00, 0x3f, 0x00, 0xd2, 0xcf, 0x20, 0xff, 0xd9,
+};
+
 ConfigureSystem::ConfigureSystem(QWidget* parent) : QWidget(parent), ui(new Ui::ConfigureSystem) {
     ui->setupUi(this);
     connect(ui->combo_birthmonth,
@@ -32,6 +48,44 @@ ConfigureSystem::ConfigureSystem(QWidget* parent) : QWidget(parent), ui(new Ui::
     connect(ui->button_regenerate_console_id, &QPushButton::clicked, this,
             &ConfigureSystem::refreshConsoleID);
 
+    layout = new QVBoxLayout;
+    tree_view = new QTreeView;
+    item_model = new QStandardItemModel(tree_view);
+    tree_view->setModel(item_model);
+
+    tree_view->setAlternatingRowColors(true);
+    tree_view->setSelectionMode(QHeaderView::SingleSelection);
+    tree_view->setSelectionBehavior(QHeaderView::SelectRows);
+    tree_view->setVerticalScrollMode(QHeaderView::ScrollPerPixel);
+    tree_view->setHorizontalScrollMode(QHeaderView::ScrollPerPixel);
+    tree_view->setSortingEnabled(true);
+    tree_view->setEditTriggers(QHeaderView::NoEditTriggers);
+    tree_view->setUniformRowHeights(true);
+    tree_view->setIconSize({64, 64});
+    tree_view->setContextMenuPolicy(Qt::NoContextMenu);
+
+    item_model->insertColumns(0, 1);
+    item_model->setHeaderData(0, Qt::Horizontal, "Users");
+
+    // We must register all custom types with the Qt Automoc system so that we are able to use it
+    // with signals/slots. In this case, QList falls under the umbrells of custom types.
+    qRegisterMetaType<QList<QStandardItem*>>("QList<QStandardItem*>");
+
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+    layout->addWidget(tree_view);
+
+    ui->scrollArea->setLayout(layout);
+
+    connect(tree_view, &QTreeView::clicked, this, &ConfigureSystem::SelectUser);
+
+    connect(ui->pm_add, &QPushButton::pressed, this, &ConfigureSystem::AddUser);
+    connect(ui->pm_rename, &QPushButton::pressed, this, &ConfigureSystem::RenameUser);
+    connect(ui->pm_remove, &QPushButton::pressed, this, &ConfigureSystem::DeleteUser);
+
+    scene = new QGraphicsScene;
+    ui->current_user_icon->setScene(scene);
+
     this->setConfiguration();
 }
 
@@ -39,8 +93,51 @@ ConfigureSystem::~ConfigureSystem() = default;
 
 void ConfigureSystem::setConfiguration() {
     enabled = !Core::System::GetInstance().IsPoweredOn();
-    ui->edit_username->setText(QString::fromStdString(Settings::values.username));
+
     ui->combo_language->setCurrentIndex(Settings::values.language_index);
+
+    item_model->removeRows(0, item_model->rowCount());
+    list_items.clear();
+
+    std::transform(Settings::values.users.begin(), Settings::values.users.end(),
+                   std::back_inserter(list_items),
+                   [](const std::pair<std::string, Service::Account::UUID>& user) {
+                       const auto icon_url = QString::fromStdString(
+                           FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + "users" +
+                           DIR_SEP + user.first + ".jpg");
+                       QPixmap icon{icon_url};
+
+                       if (!icon) {
+                           icon.fill(QColor::fromRgb(0, 0, 0));
+                           icon.loadFromData(backup_jpeg.data(), backup_jpeg.size());
+                       }
+
+                       return QList{new QStandardItem{
+                           icon.scaled(64, 64, Qt::IgnoreAspectRatio, Qt::SmoothTransformation),
+                           QString::fromStdString(user.first + "\n" + user.second.Format())}};
+                   });
+
+    for (const auto& item : list_items)
+        item_model->appendRow(item);
+
+    UpdateCurrentUser();
+}
+
+void ConfigureSystem::UpdateCurrentUser() {
+    const auto& current_user = Settings::values.users[Settings::values.current_user];
+    const auto icon_url =
+        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + "users" +
+                               DIR_SEP + current_user.first + ".jpg");
+    QPixmap icon{icon_url};
+
+    if (!icon) {
+        icon.fill(QColor::fromRgb(0, 0, 0));
+        icon.loadFromData(backup_jpeg.data(), backup_jpeg.size());
+    }
+
+    scene->clear();
+    scene->addPixmap(icon.scaled(48, 48, Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+    ui->current_user_username->setText(QString::fromStdString(current_user.first));
 }
 
 void ConfigureSystem::ReadSystemSettings() {}
@@ -48,7 +145,7 @@ void ConfigureSystem::ReadSystemSettings() {}
 void ConfigureSystem::applyConfiguration() {
     if (!enabled)
         return;
-    Settings::values.username = ui->edit_username->text().toStdString();
+
     Settings::values.language_index = ui->combo_language->currentIndex();
     Settings::Apply();
 }
@@ -91,4 +188,68 @@ void ConfigureSystem::refreshConsoleID() {
     u64 console_id{};
     ui->label_console_id->setText(
         tr("Console ID: 0x%1").arg(QString::number(console_id, 16).toUpper()));
+}
+
+void ConfigureSystem::SelectUser(const QModelIndex& index) {
+    Settings::values.current_user =
+        std::clamp<std::size_t>(index.row(), 0, Settings::values.users.size() - 1);
+
+    UpdateCurrentUser();
+
+    if (Settings::values.users.size() >= 2)
+        ui->pm_remove->setEnabled(true);
+    else
+        ui->pm_remove->setEnabled(false);
+
+    ui->pm_rename->setEnabled(true);
+}
+
+void ConfigureSystem::AddUser() {
+    Service::Account::UUID uuid;
+    uuid.Generate();
+
+    bool ok = false;
+    const auto username =
+        QInputDialog::getText(this, tr("Enter Username"), tr("Enter a username for the new user:"),
+                              QLineEdit::Normal, QString(), &ok);
+
+    Settings::values.users.emplace_back(username.toStdString(), uuid);
+
+    setConfiguration();
+}
+
+void ConfigureSystem::RenameUser() {
+    const auto user = tree_view->currentIndex().row();
+
+    bool ok = false;
+    const auto new_username = QInputDialog::getText(
+        this, tr("Enter Username"), tr("Enter a new username:"), QLineEdit::Normal,
+        QString::fromStdString(Settings::values.users[user].first), &ok);
+
+    if (!ok)
+        return;
+
+    Settings::values.users[user].first = new_username.toStdString();
+
+    setConfiguration();
+}
+
+void ConfigureSystem::DeleteUser() {
+    const auto user = Settings::values.users.begin() + tree_view->currentIndex().row();
+    const auto confirm = QMessageBox::question(
+        this, tr("Confirm Delete"),
+        tr("You are about to delete user with name %1. Are you sure?").arg(user->first.c_str()));
+
+    if (confirm == QMessageBox::No)
+        return;
+
+    if (Settings::values.current_user == tree_view->currentIndex().row())
+        Settings::values.current_user = 0;
+
+    Settings::values.users.erase(user);
+
+    setConfiguration();
+
+    ui->pm_remove->setEnabled(false);
+    ui->pm_rename->setEnabled(false);
 }

--- a/src/yuzu/configuration/configure_system.h
+++ b/src/yuzu/configuration/configure_system.h
@@ -10,11 +10,11 @@
 #include <QWidget>
 #include "core/hle/service/acc/profile_manager.h"
 
-class QVBoxLayout;
-class QTreeView;
-class QStandardItemModel;
 class QGraphicsScene;
 class QStandardItem;
+class QStandardItemModel;
+class QTreeView;
+class QVBoxLayout;
 
 namespace Ui {
 class ConfigureSystem;
@@ -45,7 +45,7 @@ public slots:
 
 private:
     void ReadSystemSettings();
-    std::string GetAccountUsername(Service::Account::UUID uuid);
+    std::string GetAccountUsername(Service::Account::UUID uuid) const;
 
     QVBoxLayout* layout;
     QTreeView* tree_view;

--- a/src/yuzu/configuration/configure_system.h
+++ b/src/yuzu/configuration/configure_system.h
@@ -8,7 +8,11 @@
 
 #include <QList>
 #include <QWidget>
-#include "core/hle/service/acc/profile_manager.h"
+
+namespace Service::Account {
+class ProfileManager;
+struct UUID;
+} // namespace Service::Account
 
 class QGraphicsScene;
 class QStandardItem;

--- a/src/yuzu/configuration/configure_system.h
+++ b/src/yuzu/configuration/configure_system.h
@@ -5,12 +5,16 @@
 #pragma once
 
 #include <memory>
-#include <QGraphicsScene>
+
 #include <QList>
-#include <QStandardItemModel>
-#include <QTreeView>
-#include <QVBoxLayout>
 #include <QWidget>
+#include "core/hle/service/acc/profile_manager.h"
+
+class QVBoxLayout;
+class QTreeView;
+class QStandardItemModel;
+class QGraphicsScene;
+class QStandardItem;
 
 namespace Ui {
 class ConfigureSystem;
@@ -26,6 +30,7 @@ public:
     void applyConfiguration();
     void setConfiguration();
 
+    void PopulateUserList();
     void UpdateCurrentUser();
 
 public slots:
@@ -36,9 +41,11 @@ public slots:
     void AddUser();
     void RenameUser();
     void DeleteUser();
+    void SetUserImage();
 
 private:
     void ReadSystemSettings();
+    std::string GetAccountUsername(Service::Account::UUID uuid);
 
     QVBoxLayout* layout;
     QTreeView* tree_view;
@@ -50,8 +57,9 @@ private:
     std::unique_ptr<Ui::ConfigureSystem> ui;
     bool enabled;
 
-    std::u16string username;
     int birthmonth, birthday;
     int language_index;
     int sound_index;
+
+    std::unique_ptr<Service::Account::ProfileManager> profile_manager;
 };

--- a/src/yuzu/configuration/configure_system.h
+++ b/src/yuzu/configuration/configure_system.h
@@ -5,6 +5,11 @@
 #pragma once
 
 #include <memory>
+#include <QGraphicsScene>
+#include <QList>
+#include <QStandardItemModel>
+#include <QTreeView>
+#include <QVBoxLayout>
 #include <QWidget>
 
 namespace Ui {
@@ -21,12 +26,26 @@ public:
     void applyConfiguration();
     void setConfiguration();
 
+    void UpdateCurrentUser();
+
 public slots:
     void updateBirthdayComboBox(int birthmonth_index);
     void refreshConsoleID();
 
+    void SelectUser(const QModelIndex& index);
+    void AddUser();
+    void RenameUser();
+    void DeleteUser();
+
 private:
     void ReadSystemSettings();
+
+    QVBoxLayout* layout;
+    QTreeView* tree_view;
+    QStandardItemModel* item_model;
+    QGraphicsScene* scene;
+
+    std::vector<QList<QStandardItem*>> list_items;
 
     std::unique_ptr<Ui::ConfigureSystem> ui;
     bool enabled;

--- a/src/yuzu/configuration/configure_system.ui
+++ b/src/yuzu/configuration/configure_system.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>360</width>
-    <height>377</height>
+    <height>483</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -22,34 +22,28 @@
         <string>System Settings</string>
        </property>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_username">
-          <property name="text">
-           <string>Username</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QLineEdit" name="edit_username">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maxLength">
-           <number>32</number>
-          </property>
-         </widget>
-        </item>
         <item row="1" column="0">
+         <widget class="QLabel" name="label_language">
+          <property name="text">
+           <string>Language</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
          <widget class="QLabel" name="label_birthday">
           <property name="text">
            <string>Birthday</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_console_id">
+          <property name="text">
+           <string>Console ID:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
          <layout class="QHBoxLayout" name="horizontalLayout_birthday2">
           <item>
            <widget class="QComboBox" name="combo_birthmonth">
@@ -120,14 +114,7 @@
           </item>
          </layout>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_language">
-          <property name="text">
-           <string>Language</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
+        <item row="1" column="1">
          <widget class="QComboBox" name="combo_language">
           <property name="toolTip">
            <string>Note: this can be overridden when region setting is auto-select</string>
@@ -187,31 +174,31 @@
             <string>Russian (Русский)</string>
            </property>
           </item>
-           <item>
-             <property name="text">
-               <string>Taiwanese</string>
-             </property>
-           </item>
-           <item>
-             <property name="text">
-               <string>British English</string>
-             </property>
-           </item>
-           <item>
-             <property name="text">
-               <string>Canadian French</string>
-             </property>
-           </item>
-           <item>
-             <property name="text">
-               <string>Latin American Spanish</string>
-             </property>
-           </item>
-           <item>
-             <property name="text">
-               <string>Simplified Chinese</string>
-             </property>
-           </item>
+          <item>
+           <property name="text">
+            <string>Taiwanese</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>British English</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Canadian French</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Latin American Spanish</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Simplified Chinese</string>
+           </property>
+          </item>
           <item>
            <property name="text">
             <string>Traditional Chinese (正體中文)</string>
@@ -219,14 +206,14 @@
           </item>
          </widget>
         </item>
-        <item row="3" column="0">
+        <item row="2" column="0">
          <widget class="QLabel" name="label_sound">
           <property name="text">
            <string>Sound output mode</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="2" column="1">
          <widget class="QComboBox" name="combo_sound">
           <item>
            <property name="text">
@@ -245,14 +232,7 @@
           </item>
          </widget>
         </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_console_id">
-          <property name="text">
-           <string>Console ID:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
+        <item row="3" column="1">
          <widget class="QPushButton" name="button_regenerate_console_id">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -272,6 +252,133 @@
       </widget>
      </item>
      <item>
+      <widget class="QGroupBox" name="gridGroupBox">
+       <property name="title">
+        <string>Profile Manager</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetNoConstraint</enum>
+        </property>
+        <item row="0" column="0">
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Current User</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QGraphicsView" name="current_user_icon">
+            <property name="minimumSize">
+             <size>
+              <width>48</width>
+              <height>48</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>48</width>
+              <height>48</height>
+             </size>
+            </property>
+            <property name="verticalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+            <property name="horizontalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+            <property name="interactive">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="current_user_username">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Username</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="0">
+         <widget class="QScrollArea" name="scrollArea">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="frameShape">
+           <enum>QFrame::StyledPanel</enum>
+          </property>
+          <property name="widgetResizable">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pm_add">
+            <property name="text">
+             <string>Add</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pm_rename">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Rename</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="pm_remove">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Remove</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
       <widget class="QLabel" name="label_disable_info">
        <property name="text">
         <string>System settings are available only when game is not running.</string>
@@ -280,19 +387,6 @@
         <bool>true</bool>
        </property>
       </widget>
-     </item>
-     <item>
-      <spacer name="verticalSpacer">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>40</height>
-        </size>
-       </property>
-      </spacer>
      </item>
     </layout>
    </item>

--- a/src/yuzu/configuration/configure_system.ui
+++ b/src/yuzu/configuration/configure_system.ui
@@ -334,6 +334,16 @@
         <item row="2" column="0">
          <layout class="QHBoxLayout" name="horizontalLayout_3">
           <item>
+           <widget class="QPushButton" name="pm_set_image">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Set Image</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <spacer name="horizontalSpacer">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -128,24 +128,8 @@ void Config::ReadValues() {
     Settings::values.enable_nfc = sdl2_config->GetBoolean("System", "enable_nfc", true);
     const auto size = sdl2_config->GetInteger("System", "users_size", 0);
 
-    Settings::values.users.clear();
-    for (std::size_t i = 0; i < size; ++i) {
-        const auto uuid_low = std::stoull(
-            sdl2_config->Get("System", fmt::format("users_{}_uuid_low", i), "0"), nullptr, 0);
-        const auto uuid_high = std::stoull(
-            sdl2_config->Get("System", fmt::format("users_{}_uuid_high", i), "0"), nullptr, 0);
-        Settings::values.users.emplace_back(
-            sdl2_config->Get("System", fmt::format("users_{}_username", i), ""),
-            Service::Account::UUID{uuid_low, uuid_high});
-    }
-
-    if (Settings::values.users.empty()) {
-        Settings::values.users.emplace_back("yuzu", Service::Account::UUID{1, 0});
-        LOG_WARNING(
-            Config,
-            "You are using the default UUID of {1, 0}! This might cause issues down the road! "
-            "Please consider randomizing a UUID and adding it to the sdl2_config.ini file.");
-    }
+    Settings::values.current_user =
+        std::clamp<int>(sdl2_config->GetInteger("System", "current_user", 0), 0, 7);
 
     // Miscellaneous
     Settings::values.log_filter = sdl2_config->Get("Miscellaneous", "log_filter", "*:Trace");

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -8,6 +8,7 @@
 #include "common/file_util.h"
 #include "common/logging/log.h"
 #include "common/param_package.h"
+#include "core/hle/service/acc/profile_manager.h"
 #include "core/settings.h"
 #include "input_common/main.h"
 #include "yuzu_cmd/config.h"
@@ -128,8 +129,8 @@ void Config::ReadValues() {
     Settings::values.enable_nfc = sdl2_config->GetBoolean("System", "enable_nfc", true);
     const auto size = sdl2_config->GetInteger("System", "users_size", 0);
 
-    Settings::values.current_user =
-        std::clamp<int>(sdl2_config->GetInteger("System", "current_user", 0), 0, 7);
+    Settings::values.current_user = std::clamp<int>(
+        sdl2_config->GetInteger("System", "current_user", 0), 0, Service::Account::MAX_USERS - 1);
 
     // Miscellaneous
     Settings::values.log_filter = sdl2_config->Get("Miscellaneous", "log_filter", "*:Trace");

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -126,9 +126,25 @@ void Config::ReadValues() {
     // System
     Settings::values.use_docked_mode = sdl2_config->GetBoolean("System", "use_docked_mode", false);
     Settings::values.enable_nfc = sdl2_config->GetBoolean("System", "enable_nfc", true);
-    Settings::values.username = sdl2_config->Get("System", "username", "yuzu");
-    if (Settings::values.username.empty()) {
-        Settings::values.username = "yuzu";
+    const auto size = sdl2_config->GetInteger("System", "users_size", 0);
+
+    Settings::values.users.clear();
+    for (std::size_t i = 0; i < size; ++i) {
+        const auto uuid_low = std::stoull(
+            sdl2_config->Get("System", fmt::format("users_{}_uuid_low", i), "0"), nullptr, 0);
+        const auto uuid_high = std::stoull(
+            sdl2_config->Get("System", fmt::format("users_{}_uuid_high", i), "0"), nullptr, 0);
+        Settings::values.users.emplace_back(
+            sdl2_config->Get("System", fmt::format("users_{}_username", i), ""),
+            Service::Account::UUID{uuid_low, uuid_high});
+    }
+
+    if (Settings::values.users.empty()) {
+        Settings::values.users.emplace_back("yuzu", Service::Account::UUID{1, 0});
+        LOG_WARNING(
+            Config,
+            "You are using the default UUID of {1, 0}! This might cause issues down the road! "
+            "Please consider randomizing a UUID and adding it to the sdl2_config.ini file.");
     }
 
     // Miscellaneous


### PR DESCRIPTION
tl;dr multiple users and user icons

This adds a UI to manage emulated users along with config support for multiple users and loading of custom icons for users.

For icons, yuzu looks in `%YUZU_DIR%/config/users/<username>.jpg`. It must be a JPEG less than 20kb in size due to switch restrictions. Should no suitable icon be found, a gray background will be used.

The UI allows adding, renaming, and deleting users. When a new user is made, the UUID will be randomly generated. 

Additionally, the right-click open save data menu will let you pick the user.

![settings](https://user-images.githubusercontent.com/5064800/46708868-cc0fdc00-cc0e-11e8-8e72-b75811b5c74c.PNG)
(NSO NES - icon and name in top left corner)
![ppt](https://user-images.githubusercontent.com/5064800/46708869-cc0fdc00-cc0e-11e8-89f2-490e8e89f441.PNG)
(Puyo Puyo - custom name in blue box in bottom left corner)