### PR TITLE
kernel/thread: Use a regular pointer for the owner/current process

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -129,7 +129,7 @@ public:
 };
 
 std::unique_ptr<Dynarmic::A64::Jit> ARM_Dynarmic::MakeJit() const {
-    auto& current_process = Core::CurrentProcess();
+    auto* current_process = Core::CurrentProcess();
     auto** const page_table = current_process->VMManager().page_table.pointers.data();
 
     Dynarmic::A64::UserConfig config;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -136,7 +136,8 @@ struct System::Impl {
         if (virtual_filesystem == nullptr)
             virtual_filesystem = std::make_shared<FileSys::RealVfsFilesystem>();
 
-        kernel.MakeCurrentProcess(Kernel::Process::Create(kernel, "main"));
+        auto main_process = Kernel::Process::Create(kernel, "main");
+        kernel.MakeCurrentProcess(main_process.get());
 
         cpu_barrier = std::make_shared<CpuBarrier>();
         cpu_exclusive_monitor = Cpu::MakeExclusiveMonitor(cpu_cores.size());
@@ -361,11 +362,11 @@ const std::shared_ptr<Kernel::Scheduler>& System::Scheduler(std::size_t core_ind
     return impl->cpu_cores[core_index]->Scheduler();
 }
 
-Kernel::SharedPtr<Kernel::Process>& System::CurrentProcess() {
+Kernel::Process* System::CurrentProcess() {
     return impl->kernel.CurrentProcess();
 }
 
-const Kernel::SharedPtr<Kernel::Process>& System::CurrentProcess() const {
+const Kernel::Process* System::CurrentProcess() const {
     return impl->kernel.CurrentProcess();
 }
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -174,11 +174,11 @@ public:
     /// Gets the scheduler for the CPU core with the specified index
     const std::shared_ptr<Kernel::Scheduler>& Scheduler(std::size_t core_index);
 
-    /// Provides a reference to the current process
-    Kernel::SharedPtr<Kernel::Process>& CurrentProcess();
+    /// Provides a pointer to the current process
+    Kernel::Process* CurrentProcess();
 
-    /// Provides a constant reference to the current process.
-    const Kernel::SharedPtr<Kernel::Process>& CurrentProcess() const;
+    /// Provides a constant pointer to the current process.
+    const Kernel::Process* CurrentProcess() const;
 
     /// Provides a reference to the kernel instance.
     Kernel::KernelCore& Kernel();
@@ -246,7 +246,7 @@ inline TelemetrySession& Telemetry() {
     return System::GetInstance().TelemetrySession();
 }
 
-inline Kernel::SharedPtr<Kernel::Process>& CurrentProcess() {
+inline Kernel::Process* CurrentProcess() {
     return System::GetInstance().CurrentProcess();
 }
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -116,7 +116,7 @@ struct KernelCore::Impl {
         next_thread_id = 1;
 
         process_list.clear();
-        current_process.reset();
+        current_process = nullptr;
 
         handle_table.Clear();
         resource_limits.fill(nullptr);
@@ -207,7 +207,7 @@ struct KernelCore::Impl {
 
     // Lists all processes that exist in the current session.
     std::vector<SharedPtr<Process>> process_list;
-    SharedPtr<Process> current_process;
+    Process* current_process = nullptr;
 
     Kernel::HandleTable handle_table;
     std::array<SharedPtr<ResourceLimit>, 4> resource_limits;
@@ -266,15 +266,15 @@ void KernelCore::AppendNewProcess(SharedPtr<Process> process) {
     impl->process_list.push_back(std::move(process));
 }
 
-void KernelCore::MakeCurrentProcess(SharedPtr<Process> process) {
-    impl->current_process = std::move(process);
+void KernelCore::MakeCurrentProcess(Process* process) {
+    impl->current_process = process;
 }
 
-SharedPtr<Process>& KernelCore::CurrentProcess() {
+Process* KernelCore::CurrentProcess() {
     return impl->current_process;
 }
 
-const SharedPtr<Process>& KernelCore::CurrentProcess() const {
+const Process* KernelCore::CurrentProcess() const {
     return impl->current_process;
 }
 

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -66,13 +66,13 @@ public:
     void AppendNewProcess(SharedPtr<Process> process);
 
     /// Makes the given process the new current process.
-    void MakeCurrentProcess(SharedPtr<Process> process);
+    void MakeCurrentProcess(Process* process);
 
-    /// Retrieves a reference to the current process.
-    SharedPtr<Process>& CurrentProcess();
+    /// Retrieves a pointer to the current process.
+    Process* CurrentProcess();
 
-    /// Retrieves a const reference to the current process.
-    const SharedPtr<Process>& CurrentProcess() const;
+    /// Retrieves a const pointer to the current process.
+    const Process* CurrentProcess() const;
 
     /// Adds a port to the named port table
     void AddNamedPort(std::string name, SharedPtr<ClientPort> port);

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -9,7 +9,7 @@
 #include "common/logging/log.h"
 #include "core/arm/arm_interface.h"
 #include "core/core.h"
-#include "core/core_timing.h"
+#include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/scheduler.h"
 
@@ -78,16 +78,16 @@ void Scheduler::SwitchContext(Thread* new_thread) {
         // Cancel any outstanding wakeup events for this thread
         new_thread->CancelWakeupTimer();
 
-        auto previous_process = Core::CurrentProcess();
+        auto* const previous_process = Core::CurrentProcess();
 
         current_thread = new_thread;
 
         ready_queue.remove(new_thread->GetPriority(), new_thread);
         new_thread->SetStatus(ThreadStatus::Running);
 
-        const auto thread_owner_process = current_thread->GetOwnerProcess();
+        auto* const thread_owner_process = current_thread->GetOwnerProcess();
         if (previous_process != thread_owner_process) {
-            Core::CurrentProcess() = thread_owner_process;
+            Core::System::GetInstance().Kernel().MakeCurrentProcess(thread_owner_process);
             SetCurrentPageTable(&Core::CurrentProcess()->VMManager().page_table);
         }
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -89,7 +89,7 @@ public:
     static ResultVal<SharedPtr<Thread>> Create(KernelCore& kernel, std::string name,
                                                VAddr entry_point, u32 priority, u64 arg,
                                                s32 processor_id, VAddr stack_top,
-                                               SharedPtr<Process> owner_process);
+                                               Process& owner_process);
 
     std::string GetName() const override {
         return name;
@@ -262,11 +262,11 @@ public:
         return processor_id;
     }
 
-    SharedPtr<Process>& GetOwnerProcess() {
+    Process* GetOwnerProcess() {
         return owner_process;
     }
 
-    const SharedPtr<Process>& GetOwnerProcess() const {
+    const Process* GetOwnerProcess() const {
         return owner_process;
     }
 
@@ -386,7 +386,7 @@ private:
     u64 tpidr_el0 = 0;     ///< TPIDR_EL0 read/write system register.
 
     /// Process that owns this thread
-    SharedPtr<Process> owner_process;
+    Process* owner_process;
 
     /// Objects that the thread is waiting on, in the same order as they were
     /// passed to WaitSynchronization1/N.

--- a/src/tests/core/arm/arm_test_common.cpp
+++ b/src/tests/core/arm/arm_test_common.cpp
@@ -15,7 +15,8 @@ namespace ArmTests {
 TestEnvironment::TestEnvironment(bool mutable_memory_)
     : mutable_memory(mutable_memory_), test_memory(std::make_shared<TestMemory>(this)) {
 
-    Core::CurrentProcess() = Kernel::Process::Create(kernel, "");
+    auto process = Kernel::Process::Create(kernel, "");
+    kernel.MakeCurrentProcess(process.get());
     page_table = &Core::CurrentProcess()->VMManager().page_table;
 
     std::fill(page_table->pointers.begin(), page_table->pointers.end(), nullptr);


### PR DESCRIPTION
There's no real need to use a shared pointer in these cases, and only makes object management more fragile in terms of how easy it would be to introduce cycles. Instead, just do the simple thing of using a regular pointer. Much of this is just a hold-over from citra anyways.

It also doesn't make sense from a behavioral point of view for a process' thread to prolong the lifetime of the process itself (the process is supposed to own the thread, not the other way around).