### PR TITLE
nvhost_as_gpu: Flush/invalidate CPU VAddr on UnmapBuffer.

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
@@ -167,10 +167,11 @@ u32 nvhost_as_gpu::UnmapBuffer(const std::vector<u8>& input, std::vector<u8>& ou
     auto& system_instance = Core::System::GetInstance();
 
     // Remove this memory region from the rasterizer cache.
-    system_instance.Renderer().Rasterizer().FlushAndInvalidateRegion(params.offset,
-                                                                     itr->second.size);
-
     auto& gpu = system_instance.GPU();
+    auto cpu_addr = gpu.MemoryManager().GpuToCpuAddress(params.offset);
+    ASSERT(cpu_addr);
+    system_instance.Renderer().Rasterizer().FlushAndInvalidateRegion(*cpu_addr, itr->second.size);
+
     params.offset = gpu.MemoryManager().UnmapBuffer(params.offset, itr->second.size);
 
     buffer_mappings.erase(itr->second.offset);


### PR DESCRIPTION
(fixes a fairly obvious bug)