### PR TITLE
Introduce 3D Swizzle seamlessly 

### DIFF
--- a/src/video_core/engines/fermi_2d.cpp
+++ b/src/video_core/engines/fermi_2d.cpp
@@ -62,14 +62,16 @@ void Fermi2D::HandleSurfaceCopy() {
         u8* dst_buffer = Memory::GetPointer(dest_cpu);
         if (!regs.src.linear && regs.dst.linear) {
             // If the input is tiled and the output is linear, deswizzle the input and copy it over.
-            Texture::CopySwizzledData(regs.src.width, regs.src.height, src_bytes_per_pixel,
-                                      dst_bytes_per_pixel, src_buffer, dst_buffer, true,
-                                      regs.src.BlockHeight());
+            Texture::CopySwizzledData(regs.src.width, regs.src.height, regs.src.depth,
+                                      src_bytes_per_pixel, dst_bytes_per_pixel, src_buffer,
+                                      dst_buffer, true, regs.src.BlockHeight(),
+                                      regs.src.BlockDepth());
         } else {
             // If the input is linear and the output is tiled, swizzle the input and copy it over.
-            Texture::CopySwizzledData(regs.src.width, regs.src.height, src_bytes_per_pixel,
-                                      dst_bytes_per_pixel, dst_buffer, src_buffer, false,
-                                      regs.dst.BlockHeight());
+            Texture::CopySwizzledData(regs.src.width, regs.src.height, regs.src.depth,
+                                      src_bytes_per_pixel, dst_bytes_per_pixel, dst_buffer,
+                                      src_buffer, false, regs.dst.BlockHeight(),
+                                      regs.dst.BlockDepth());
         }
     }
 }

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -68,12 +68,14 @@ void MaxwellDMA::HandleCopy() {
 
     if (regs.exec.is_dst_linear && !regs.exec.is_src_linear) {
         // If the input is tiled and the output is linear, deswizzle the input and copy it over.
-        Texture::CopySwizzledData(regs.src_params.size_x, regs.src_params.size_y, 1, 1, src_buffer,
-                                  dst_buffer, true, regs.src_params.BlockHeight());
+        Texture::CopySwizzledData(regs.src_params.size_x, regs.src_params.size_y,
+                                  regs.src_params.size_z, 1, 1, src_buffer, dst_buffer, true,
+                                  regs.src_params.BlockHeight(), regs.src_params.BlockDepth());
     } else {
         // If the input is linear and the output is tiled, swizzle the input and copy it over.
-        Texture::CopySwizzledData(regs.dst_params.size_x, regs.dst_params.size_y, 1, 1, dst_buffer,
-                                  src_buffer, false, regs.dst_params.BlockHeight());
+        Texture::CopySwizzledData(regs.dst_params.size_x, regs.dst_params.size_y,
+                                  regs.dst_params.size_z, 1, 1, dst_buffer, src_buffer, false,
+                                  regs.dst_params.BlockHeight(), regs.dst_params.BlockDepth());
     }
 }
 

--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -43,6 +43,10 @@ public:
             u32 BlockHeight() const {
                 return 1 << block_height;
             }
+
+            u32 BlockDepth() const {
+                return 1 << block_depth;
+            }
         };
 
         static_assert(sizeof(Parameters) == 24, "Parameters has wrong size");

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -323,8 +323,8 @@ static bool IsFormatBCn(PixelFormat format) {
 }
 
 template <bool morton_to_gl, PixelFormat format>
-void MortonCopy(u32 stride, u32 block_height, u32 height, u8* gl_buffer, std::size_t gl_buffer_size,
-                VAddr addr) {
+void MortonCopy(u32 stride, u32 block_height, u32 height, u32 block_depth, u32 depth, u8* gl_buffer,
+                std::size_t gl_buffer_size, VAddr addr) {
     constexpr u32 bytes_per_pixel = SurfaceParams::GetFormatBpp(format) / CHAR_BIT;
     constexpr u32 gl_bytes_per_pixel = CachedSurface::GetGLBytesPerPixel(format);
 
@@ -333,7 +333,7 @@ void MortonCopy(u32 stride, u32 block_height, u32 height, u8* gl_buffer, std::si
         // pixel values.
         const u32 tile_size{IsFormatBCn(format) ? 4U : 1U};
         const std::vector<u8> data = Tegra::Texture::UnswizzleTexture(
-            addr, tile_size, bytes_per_pixel, stride, height, block_height);
+            addr, tile_size, bytes_per_pixel, stride, height, depth, block_height, block_depth);
         const std::size_t size_to_copy{std::min(gl_buffer_size, data.size())};
         memcpy(gl_buffer, data.data(), size_to_copy);
     } else {
@@ -345,7 +345,7 @@ void MortonCopy(u32 stride, u32 block_height, u32 height, u8* gl_buffer, std::si
     }
 }
 
-static constexpr std::array<void (*)(u32, u32, u32, u8*, std::size_t, VAddr),
+static constexpr std::array<void (*)(u32, u32, u32, u32, u32, u8*, std::size_t, VAddr),
                             SurfaceParams::MaxPixelFormat>
     morton_to_gl_fns = {
         // clang-format off
@@ -403,7 +403,7 @@ static constexpr std::array<void (*)(u32, u32, u32, u8*, std::size_t, VAddr),
         // clang-format on
 };
 
-static constexpr std::array<void (*)(u32, u32, u32, u8*, std::size_t, VAddr),
+static constexpr std::array<void (*)(u32, u32, u32, u32, u32, u8*, std::size_t, VAddr),
                             SurfaceParams::MaxPixelFormat>
     gl_to_morton_fns = {
         // clang-format off
@@ -827,25 +827,27 @@ void CachedSurface::LoadGLBuffer() {
 
     if (params.is_tiled) {
         gl_buffer.resize(total_size);
+        u32 depth = params.depth;
+        u32 block_depth = params.block_depth;
 
         ASSERT_MSG(params.block_width == 1, "Block width is defined as {} on texture type {}",
                    params.block_width, static_cast<u32>(params.target));
-        ASSERT_MSG(params.block_depth == 1, "Block depth is defined as {} on texture type {}",
-                   params.block_depth, static_cast<u32>(params.target));
 
-        // TODO(bunnei): This only unswizzles and copies a 2D texture - we do not yet know how to do
-        // this for 3D textures, etc.
         switch (params.target) {
         case SurfaceParams::SurfaceTarget::Texture2D:
-            // Pass impl. to the fallback code below
+            // TODO(Blinkhawk): Eliminate this condition once all texture types are implemented.
+            depth = 1U;
+            block_depth = 1U;
             break;
         case SurfaceParams::SurfaceTarget::Texture2DArray:
         case SurfaceParams::SurfaceTarget::TextureCubemap:
+            depth = 1U;
+            block_depth = 1U;
             for (std::size_t index = 0; index < params.depth; ++index) {
                 const std::size_t offset{index * copy_size};
                 morton_to_gl_fns[static_cast<std::size_t>(params.pixel_format)](
-                    params.width, params.block_height, params.height, gl_buffer.data() + offset,
-                    copy_size, params.addr + offset);
+                    params.width, params.block_height, params.height, 1U, 1U,
+                    gl_buffer.data() + offset, copy_size, params.addr + offset);
             }
             break;
         default:
@@ -854,9 +856,11 @@ void CachedSurface::LoadGLBuffer() {
             UNREACHABLE();
         }
 
+        const std::size_t size = copy_size * depth;
+
         morton_to_gl_fns[static_cast<std::size_t>(params.pixel_format)](
-            params.width, params.block_height, params.height, gl_buffer.data(), copy_size,
-            params.addr);
+            params.width, params.block_height, params.height, block_depth, depth, gl_buffer.data(),
+            size, params.addr);
     } else {
         const u8* const texture_src_data_end{texture_src_data + total_size};
         gl_buffer.assign(texture_src_data, texture_src_data_end);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -833,27 +833,10 @@ void CachedSurface::LoadGLBuffer() {
         ASSERT_MSG(params.block_width == 1, "Block width is defined as {} on texture type {}",
                    params.block_width, static_cast<u32>(params.target));
 
-        switch (params.target) {
-        case SurfaceParams::SurfaceTarget::Texture2D:
+        if (params.target == SurfaceParams::SurfaceTarget::Texture2D) {
             // TODO(Blinkhawk): Eliminate this condition once all texture types are implemented.
             depth = 1U;
             block_depth = 1U;
-            break;
-        case SurfaceParams::SurfaceTarget::Texture2DArray:
-        case SurfaceParams::SurfaceTarget::TextureCubemap:
-            depth = 1U;
-            block_depth = 1U;
-            for (std::size_t index = 0; index < params.depth; ++index) {
-                const std::size_t offset{index * copy_size};
-                morton_to_gl_fns[static_cast<std::size_t>(params.pixel_format)](
-                    params.width, params.block_height, params.height, 1U, 1U,
-                    gl_buffer.data() + offset, copy_size, params.addr + offset);
-            }
-            break;
-        default:
-            LOG_CRITICAL(HW_GPU, "Unimplemented tiled load for target={}",
-                         static_cast<u32>(params.target));
-            UNREACHABLE();
         }
 
         const std::size_t size = copy_size * depth;

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -51,18 +51,18 @@ void Precise3DProcessBlock(u8* swizzled_data, u8* unswizzled_data, const bool un
                            const u32 xy_block_size, const u32 layer_z, const u32 stride_x,
                            const u32 bytes_per_pixel, const u32 out_bytes_per_pixel) {
     std::array<u8*, 2> data_ptrs;
-    u32 z_adress = tile_offset;
+    u32 z_address = tile_offset;
     const u32 gob_size_x = 64;
     const u32 gob_size_y = 8;
     const u32 gob_size_z = 1;
     const u32 gob_size = gob_size_x * gob_size_y * gob_size_z;
     for (u32 z = z_start; z < z_end; z++) {
-        u32 y_adress = z_adress;
+        u32 y_address = z_address;
         u32 pixel_base = layer_z * z + y_start * stride_x;
         for (u32 y = y_start; y < y_end; y++) {
             const auto& table = legacy_swizzle_table[y % gob_size_y];
             for (u32 x = x_start; x < x_end; x++) {
-                const u32 swizzle_offset{y_adress + table[x * bytes_per_pixel % gob_size_x]};
+                const u32 swizzle_offset{y_address + table[x * bytes_per_pixel % gob_size_x]};
                 const u32 pixel_index{x * out_bytes_per_pixel + pixel_base};
                 data_ptrs[unswizzle] = swizzled_data + swizzle_offset;
                 data_ptrs[!unswizzle] = unswizzled_data + pixel_index;
@@ -70,9 +70,9 @@ void Precise3DProcessBlock(u8* swizzled_data, u8* unswizzled_data, const bool un
             }
             pixel_base += stride_x;
             if ((y + 1) % gob_size_y == 0)
-                y_adress += gob_size;
+                y_address += gob_size;
         }
-        z_adress += xy_block_size;
+        z_address += xy_block_size;
     }
 }
 
@@ -136,7 +136,7 @@ void Fast3DProcessBlock(u8* swizzled_data, u8* unswizzled_data, const bool unswi
                         const u32 xy_block_size, const u32 layer_z, const u32 stride_x,
                         const u32 bytes_per_pixel, const u32 out_bytes_per_pixel) {
     std::array<u8*, 2> data_ptrs;
-    u32 z_adress = tile_offset;
+    u32 z_address = tile_offset;
     const u32 x_startb = x_start * bytes_per_pixel;
     const u32 x_endb = x_end * bytes_per_pixel;
     const u32 copy_size = 16;
@@ -145,12 +145,12 @@ void Fast3DProcessBlock(u8* swizzled_data, u8* unswizzled_data, const bool unswi
     const u32 gob_size_z = 1;
     const u32 gob_size = gob_size_x * gob_size_y * gob_size_z;
     for (u32 z = z_start; z < z_end; z++) {
-        u32 y_adress = z_adress;
+        u32 y_address = z_address;
         u32 pixel_base = layer_z * z + y_start * stride_x;
         for (u32 y = y_start; y < y_end; y++) {
             const auto& table = fast_swizzle_table[y % gob_size_y];
             for (u32 xb = x_startb; xb < x_endb; xb += copy_size) {
-                const u32 swizzle_offset{y_adress + table[(xb / copy_size) % 4]};
+                const u32 swizzle_offset{y_address + table[(xb / copy_size) % 4]};
                 const u32 out_x = xb * out_bytes_per_pixel / bytes_per_pixel;
                 const u32 pixel_index{out_x + pixel_base};
                 data_ptrs[unswizzle] = swizzled_data + swizzle_offset;
@@ -159,9 +159,9 @@ void Fast3DProcessBlock(u8* swizzled_data, u8* unswizzled_data, const bool unswi
             }
             pixel_base += stride_x;
             if ((y + 1) % gob_size_y == 0)
-                y_adress += gob_size;
+                y_address += gob_size;
         }
-        z_adress += xy_block_size;
+        z_address += xy_block_size;
     }
 }
 
@@ -214,14 +214,15 @@ void Fast3DSwizzledData(u8* swizzled_data, u8* unswizzled_data, const bool unswi
     }
 }
 
-void CopySwizzledData(u32 width, u32 height, u32 bytes_per_pixel, u32 out_bytes_per_pixel,
-                      u8* swizzled_data, u8* unswizzled_data, bool unswizzle, u32 block_height) {
+void CopySwizzledData(u32 width, u32 height, u32 depth, u32 bytes_per_pixel,
+                      u32 out_bytes_per_pixel, u8* swizzled_data, u8* unswizzled_data,
+                      bool unswizzle, u32 block_height, u32 block_depth) {
     if (bytes_per_pixel % 3 != 0 && (width * bytes_per_pixel) % 16 == 0) {
-        Fast3DSwizzledData(swizzled_data, unswizzled_data, unswizzle, width, height, 1U,
-                           bytes_per_pixel, out_bytes_per_pixel, block_height, 1U);
+        Fast3DSwizzledData(swizzled_data, unswizzled_data, unswizzle, width, height, depth,
+                           bytes_per_pixel, out_bytes_per_pixel, block_height, block_depth);
     } else {
-        Precise3DSwizzledData(swizzled_data, unswizzled_data, unswizzle, width, height, 1U,
-                              bytes_per_pixel, out_bytes_per_pixel, block_height, 1U);
+        Precise3DSwizzledData(swizzled_data, unswizzled_data, unswizzle, width, height, depth,
+                              bytes_per_pixel, out_bytes_per_pixel, block_height, block_depth);
     }
 }
 
@@ -269,10 +270,11 @@ u32 BytesPerPixel(TextureFormat format) {
 }
 
 std::vector<u8> UnswizzleTexture(VAddr address, u32 tile_size, u32 bytes_per_pixel, u32 width,
-                                 u32 height, u32 block_height) {
+                                 u32 height, u32 depth, u32 block_height, u32 block_depth) {
     std::vector<u8> unswizzled_data(width * height * bytes_per_pixel);
-    CopySwizzledData(width / tile_size, height / tile_size, bytes_per_pixel, bytes_per_pixel,
-                     Memory::GetPointer(address), unswizzled_data.data(), true, block_height);
+    CopySwizzledData(width / tile_size, height / tile_size, depth, bytes_per_pixel, bytes_per_pixel,
+                     Memory::GetPointer(address), unswizzled_data.data(), true, block_height,
+                     block_depth);
     return unswizzled_data;
 }
 

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -271,7 +271,7 @@ u32 BytesPerPixel(TextureFormat format) {
 
 std::vector<u8> UnswizzleTexture(VAddr address, u32 tile_size, u32 bytes_per_pixel, u32 width,
                                  u32 height, u32 depth, u32 block_height, u32 block_depth) {
-    std::vector<u8> unswizzled_data(width * height * bytes_per_pixel);
+    std::vector<u8> unswizzled_data(width * height * depth * bytes_per_pixel);
     CopySwizzledData(width / tile_size, height / tile_size, depth, bytes_per_pixel, bytes_per_pixel,
                      Memory::GetPointer(address), unswizzled_data.data(), true, block_height,
                      block_depth);

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -45,11 +45,11 @@ constexpr auto fast_swizzle_table = SwizzleTable<8, 4, 16>();
  * Instead of going gob by gob, we map the coordinates inside a block and manage from
  * those. Block_Width is assumed to be 1.
  */
-void Precise3DProcessBlock(u8* swizzled_data, u8* unswizzled_data, const bool unswizzle,
-                           const u32 x_start, const u32 y_start, const u32 z_start, const u32 x_end,
-                           const u32 y_end, const u32 z_end, const u32 tile_offset,
-                           const u32 xy_block_size, const u32 layer_z, const u32 stride_x,
-                           const u32 bytes_per_pixel, const u32 out_bytes_per_pixel) {
+void PreciseProcessBlock(u8* swizzled_data, u8* unswizzled_data, const bool unswizzle,
+                         const u32 x_start, const u32 y_start, const u32 z_start, const u32 x_end,
+                         const u32 y_end, const u32 z_end, const u32 tile_offset,
+                         const u32 xy_block_size, const u32 layer_z, const u32 stride_x,
+                         const u32 bytes_per_pixel, const u32 out_bytes_per_pixel) {
     std::array<u8*, 2> data_ptrs;
     u32 z_address = tile_offset;
     const u32 gob_size_x = 64;
@@ -77,64 +77,15 @@ void Precise3DProcessBlock(u8* swizzled_data, u8* unswizzled_data, const bool un
 }
 
 /**
- * This function unswizzles or swizzles a texture by mapping Linear to BlockLinear Textue.
- * The body of this function takes care of splitting the swizzled texture into blocks,
- * and managing the extents of it. Once all the parameters of a single block are obtained,
- * the function calls '3DProcessBlock' to process that particular Block.
- *
- * Documentation for the memory layout and decoding can be found at:
- *  https://envytools.readthedocs.io/en/latest/hw/memory/g80-surface.html#blocklinear-surfaces
- */
-void Precise3DSwizzledData(u8* swizzled_data, u8* unswizzled_data, const bool unswizzle,
-                           const u32 width, const u32 height, const u32 depth,
-                           const u32 bytes_per_pixel, const u32 out_bytes_per_pixel,
-                           const u32 block_height, const u32 block_depth) {
-    auto div_ceil = [](const u32 x, const u32 y) { return ((x + y - 1) / y); };
-    const u32 stride_x = width * out_bytes_per_pixel;
-    const u32 layer_z = height * stride_x;
-    const u32 gob_x_bytes = 64;
-    const u32 gob_elements_x = gob_x_bytes / bytes_per_pixel;
-    const u32 gob_elements_y = 8;
-    const u32 gob_elements_z = 1;
-    const u32 block_x_elements = gob_elements_x;
-    const u32 block_y_elements = gob_elements_y * block_height;
-    const u32 block_z_elements = gob_elements_z * block_depth;
-    const u32 blocks_on_x = div_ceil(width, block_x_elements);
-    const u32 blocks_on_y = div_ceil(height, block_y_elements);
-    const u32 blocks_on_z = div_ceil(depth, block_z_elements);
-    const u32 blocks = blocks_on_x * blocks_on_y * blocks_on_z;
-    const u32 gob_size = gob_x_bytes * gob_elements_y * gob_elements_z;
-    const u32 xy_block_size = gob_size * block_height;
-    const u32 block_size = xy_block_size * block_depth;
-    u32 tile_offset = 0;
-    for (u32 zb = 0; zb < blocks_on_z; zb++) {
-        const u32 z_start = zb * block_z_elements;
-        const u32 z_end = std::min(depth, z_start + block_z_elements);
-        for (u32 yb = 0; yb < blocks_on_y; yb++) {
-            const u32 y_start = yb * block_y_elements;
-            const u32 y_end = std::min(height, y_start + block_y_elements);
-            for (u32 xb = 0; xb < blocks_on_x; xb++) {
-                const u32 x_start = xb * block_x_elements;
-                const u32 x_end = std::min(width, x_start + block_x_elements);
-                Precise3DProcessBlock(swizzled_data, unswizzled_data, unswizzle, x_start, y_start,
-                                      z_start, x_end, y_end, z_end, tile_offset, xy_block_size,
-                                      layer_z, stride_x, bytes_per_pixel, out_bytes_per_pixel);
-                tile_offset += block_size;
-            }
-        }
-    }
-}
-
-/**
  * This function manages ALL the GOBs(Group of Bytes) Inside a single block.
  * Instead of going gob by gob, we map the coordinates inside a block and manage from
  * those. Block_Width is assumed to be 1.
  */
-void Fast3DProcessBlock(u8* swizzled_data, u8* unswizzled_data, const bool unswizzle,
-                        const u32 x_start, const u32 y_start, const u32 z_start, const u32 x_end,
-                        const u32 y_end, const u32 z_end, const u32 tile_offset,
-                        const u32 xy_block_size, const u32 layer_z, const u32 stride_x,
-                        const u32 bytes_per_pixel, const u32 out_bytes_per_pixel) {
+void FastProcessBlock(u8* swizzled_data, u8* unswizzled_data, const bool unswizzle,
+                      const u32 x_start, const u32 y_start, const u32 z_start, const u32 x_end,
+                      const u32 y_end, const u32 z_end, const u32 tile_offset,
+                      const u32 xy_block_size, const u32 layer_z, const u32 stride_x,
+                      const u32 bytes_per_pixel, const u32 out_bytes_per_pixel) {
     std::array<u8*, 2> data_ptrs;
     u32 z_address = tile_offset;
     const u32 x_startb = x_start * bytes_per_pixel;
@@ -169,15 +120,15 @@ void Fast3DProcessBlock(u8* swizzled_data, u8* unswizzled_data, const bool unswi
  * This function unswizzles or swizzles a texture by mapping Linear to BlockLinear Textue.
  * The body of this function takes care of splitting the swizzled texture into blocks,
  * and managing the extents of it. Once all the parameters of a single block are obtained,
- * the function calls '3DProcessBlock' to process that particular Block.
+ * the function calls 'ProcessBlock' to process that particular Block.
  *
  * Documentation for the memory layout and decoding can be found at:
  *  https://envytools.readthedocs.io/en/latest/hw/memory/g80-surface.html#blocklinear-surfaces
  */
-void Fast3DSwizzledData(u8* swizzled_data, u8* unswizzled_data, const bool unswizzle,
-                        const u32 width, const u32 height, const u32 depth,
-                        const u32 bytes_per_pixel, const u32 out_bytes_per_pixel,
-                        const u32 block_height, const u32 block_depth) {
+template <bool fast>
+void SwizzledData(u8* swizzled_data, u8* unswizzled_data, const bool unswizzle, const u32 width,
+                  const u32 height, const u32 depth, const u32 bytes_per_pixel,
+                  const u32 out_bytes_per_pixel, const u32 block_height, const u32 block_depth) {
     auto div_ceil = [](const u32 x, const u32 y) { return ((x + y - 1) / y); };
     const u32 stride_x = width * out_bytes_per_pixel;
     const u32 layer_z = height * stride_x;
@@ -205,9 +156,15 @@ void Fast3DSwizzledData(u8* swizzled_data, u8* unswizzled_data, const bool unswi
             for (u32 xb = 0; xb < blocks_on_x; xb++) {
                 const u32 x_start = xb * block_x_elements;
                 const u32 x_end = std::min(width, x_start + block_x_elements);
-                Fast3DProcessBlock(swizzled_data, unswizzled_data, unswizzle, x_start, y_start,
-                                   z_start, x_end, y_end, z_end, tile_offset, xy_block_size,
-                                   layer_z, stride_x, bytes_per_pixel, out_bytes_per_pixel);
+                if (fast) {
+                    FastProcessBlock(swizzled_data, unswizzled_data, unswizzle, x_start, y_start,
+                                     z_start, x_end, y_end, z_end, tile_offset, xy_block_size,
+                                     layer_z, stride_x, bytes_per_pixel, out_bytes_per_pixel);
+                } else {
+                    PreciseProcessBlock(swizzled_data, unswizzled_data, unswizzle, x_start, y_start,
+                                        z_start, x_end, y_end, z_end, tile_offset, xy_block_size,
+                                        layer_z, stride_x, bytes_per_pixel, out_bytes_per_pixel);
+                }
                 tile_offset += block_size;
             }
         }
@@ -218,11 +175,11 @@ void CopySwizzledData(u32 width, u32 height, u32 depth, u32 bytes_per_pixel,
                       u32 out_bytes_per_pixel, u8* swizzled_data, u8* unswizzled_data,
                       bool unswizzle, u32 block_height, u32 block_depth) {
     if (bytes_per_pixel % 3 != 0 && (width * bytes_per_pixel) % 16 == 0) {
-        Fast3DSwizzledData(swizzled_data, unswizzled_data, unswizzle, width, height, depth,
+        SwizzledData<true>(swizzled_data, unswizzled_data, unswizzle, width, height, depth,
                            bytes_per_pixel, out_bytes_per_pixel, block_height, block_depth);
     } else {
-        Precise3DSwizzledData(swizzled_data, unswizzled_data, unswizzle, width, height, depth,
-                              bytes_per_pixel, out_bytes_per_pixel, block_height, block_depth);
+        SwizzledData<false>(swizzled_data, unswizzled_data, unswizzle, width, height, depth,
+                            bytes_per_pixel, out_bytes_per_pixel, block_height, block_depth);
     }
 }
 

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -98,6 +98,74 @@ static void FastSwizzleData(u32 width, u32 height, u32 bytes_per_pixel, u32 out_
     }
 }
 
+void Precise3DProcessGobs(u8* swizzled_data, u8* unswizzled_data, bool unswizzle, const u32 x_start,
+                       const u32 y_start, const u32 z_start, const u32 x_end, const u32 y_end,
+                       const u32 z_end, const u32 tile_offset, const u32 xy_block_size,
+                       const u32 layer_z, const u32 stride_x, const u32 bytes_per_pixel,
+                       const u32 out_bytes_per_pixel) {
+    std::array<u8*, 2> data_ptrs;
+    u32 z_adress = tile_offset;
+    const u32 gob_size = 64 * 8 * 1;
+    for (u32 z = z_start; z < z_end; z++) {
+        u32 y_adress = z_adress;
+        u32 pixel_base = layer_z * z + y_start * stride_x;
+        for (u32 y = y_start; y < y_end; y++) {
+            const auto& table = legacy_swizzle_table[y % 8];
+            for (u32 x = x_start; x < x_end; x++) {
+                const u32 swizzle_offset{y_adress + table[x * bytes_per_pixel % 64]};
+                const u32 pixel_index{x * out_bytes_per_pixel + pixel_base};
+                data_ptrs[unswizzle] = swizzled_data + swizzle_offset;
+                data_ptrs[!unswizzle] = unswizzled_data + pixel_index;
+                std::memcpy(data_ptrs[0], data_ptrs[1], bytes_per_pixel);
+            }
+            pixel_base += stride_x;
+            if ((y + 1) % 8 == 0)
+                y_adress += gob_size;
+        }
+        z_adress += xy_block_size;
+    }
+}
+
+void Precise3DSwizzledData(u8* swizzled_data, u8* unswizzled_data, bool unswizzle, u32 width,
+                        u32 height, u32 depth, u32 bytes_per_pixel, u32 out_bytes_per_pixel,
+                        u32 block_height, u32 block_depth) {
+    auto div_ceil = [](u32 x, u32 y) { return ((x + y - 1) / y); };
+
+    const u32 stride_x = width * out_bytes_per_pixel;
+    const u32 layer_z = height * stride_x;
+    const u32 gob_x_bytes = 64;
+    const u32 gob_elements_x = gob_x_bytes / bytes_per_pixel;
+    const u32 gob_elements_y = 8;
+    const u32 gob_elements_z = 1;
+    const u32 block_x_elements = gob_elements_x;
+    const u32 block_y_elements = gob_elements_y * block_height;
+    const u32 block_z_elements = gob_elements_z * block_depth;
+    const u32 blocks_on_x = div_ceil(width, block_x_elements);
+    const u32 blocks_on_y = div_ceil(height, block_y_elements);
+    const u32 blocks_on_z = div_ceil(depth, block_z_elements);
+    const u32 blocks = blocks_on_x * blocks_on_y * blocks_on_z;
+    const u32 gob_size = gob_x_bytes * gob_elements_y * gob_elements_z;
+    const u32 xy_block_size = gob_size * block_height;
+    const u32 block_size = xy_block_size * block_depth;
+    u32 tile_offset = 0;
+    for (u32 zb = 0; zb < blocks_on_z; zb++) {
+        const u32 z_start = zb * block_z_elements;
+        const u32 z_end = std::min(depth, z_start + block_z_elements);
+        for (u32 yb = 0; yb < blocks_on_y; yb++) {
+            const u32 y_start = yb * block_y_elements;
+            const u32 y_end = std::min(height, y_start + block_y_elements);
+            for (u32 xb = 0; xb < blocks_on_x; xb++) {
+                const u32 x_start = xb * block_x_elements;
+                const u32 x_end = std::min(width, x_start + block_x_elements);
+                Precise3DProcessGobs(swizzled_data, unswizzled_data, unswizzle, x_start, y_start,
+                                  z_start, x_end, y_end, z_end, tile_offset, xy_block_size, layer_z,
+                                  stride_x, bytes_per_pixel, out_bytes_per_pixel);
+                tile_offset += block_size;
+            }
+        }
+    }
+}
+
 void Fast3DProcessGobs(u8* swizzled_data, u8* unswizzled_data, bool unswizzle, const u32 x_start,
                        const u32 y_start, const u32 z_start, const u32 x_end, const u32 y_end,
                        const u32 z_end, const u32 tile_offset, const u32 xy_block_size,
@@ -148,7 +216,7 @@ void Fast3DSwizzledData(u8* swizzled_data, u8* unswizzled_data, bool unswizzle, 
     const u32 blocks_on_y = div_ceil(height, block_y_elements);
     const u32 blocks_on_z = div_ceil(depth, block_z_elements);
     const u32 blocks = blocks_on_x * blocks_on_y * blocks_on_z;
-    const u32 gob_size = 64 * 8 * 1;
+    const u32 gob_size = gob_x_bytes * gob_elements_y * gob_elements_z;
     const u32 xy_block_size = gob_size * block_height;
     const u32 block_size = xy_block_size * block_depth;
     u32 tile_offset = 0;
@@ -176,8 +244,8 @@ void CopySwizzledData(u32 width, u32 height, u32 bytes_per_pixel, u32 out_bytes_
         Fast3DSwizzledData(swizzled_data, unswizzled_data, unswizzle, width, height, 1U,
                            bytes_per_pixel, out_bytes_per_pixel, block_height, 1U);
     } else {
-        LegacySwizzleData(width, height, bytes_per_pixel, out_bytes_per_pixel, swizzled_data,
-                          unswizzled_data, unswizzle, block_height);
+        Precise3DSwizzledData(swizzled_data, unswizzled_data, unswizzle, width, height, 1U,
+                           bytes_per_pixel, out_bytes_per_pixel, block_height, 1U);
     }
 }
 

--- a/src/video_core/textures/decoders.h
+++ b/src/video_core/textures/decoders.h
@@ -14,17 +14,14 @@ namespace Tegra::Texture {
  * Unswizzles a swizzled texture without changing its format.
  */
 std::vector<u8> UnswizzleTexture(VAddr address, u32 tile_size, u32 bytes_per_pixel, u32 width,
-                                 u32 height, u32 block_height = TICEntry::DefaultBlockHeight);
-
-/**
- * Unswizzles a swizzled depth texture without changing its format.
- */
-std::vector<u8> UnswizzleDepthTexture(VAddr address, DepthFormat format, u32 width, u32 height,
-                                      u32 block_height = TICEntry::DefaultBlockHeight);
+                                 u32 height, u32 depth,
+                                 u32 block_height = TICEntry::DefaultBlockHeight,
+                                 u32 block_depth = TICEntry::DefaultBlockHeight);
 
 /// Copies texture data from a buffer and performs swizzling/unswizzling as necessary.
-void CopySwizzledData(u32 width, u32 height, u32 bytes_per_pixel, u32 out_bytes_per_pixel,
-                      u8* swizzled_data, u8* unswizzled_data, bool unswizzle, u32 block_height);
+void CopySwizzledData(u32 width, u32 height, u32 depth, u32 bytes_per_pixel,
+                      u32 out_bytes_per_pixel, u8* swizzled_data, u8* unswizzled_data,
+                      bool unswizzle, u32 block_height, u32 block_depth);
 
 /**
  * Decodes an unswizzled texture into a A8R8G8B8 texture.

--- a/src/video_core/textures/texture.h
+++ b/src/video_core/textures/texture.h
@@ -141,6 +141,7 @@ static_assert(sizeof(TextureHandle) == 4, "TextureHandle has wrong size");
 
 struct TICEntry {
     static constexpr u32 DefaultBlockHeight = 16;
+    static constexpr u32 DefaultBlockDepth = 1;
 
     union {
         u32 raw;

--- a/src/yuzu/debugger/graphics/graphics_surface.cpp
+++ b/src/yuzu/debugger/graphics/graphics_surface.cpp
@@ -386,8 +386,9 @@ void GraphicsSurfaceWidget::OnUpdate() {
 
     // TODO(bunnei): Will not work with BCn formats that swizzle 4x4 tiles.
     // Needs to be fixed if we plan to use this feature more, otherwise we may remove it.
-    auto unswizzled_data = Tegra::Texture::UnswizzleTexture(
-        *address, 1, Tegra::Texture::BytesPerPixel(surface_format), surface_width, surface_height);
+    auto unswizzled_data =
+        Tegra::Texture::UnswizzleTexture(*address, 1, Tegra::Texture::BytesPerPixel(surface_format),
+                                         surface_width, surface_height, 1U);
 
     auto texture_data = Tegra::Texture::DecodeTexture(unswizzled_data, surface_format,
                                                       surface_width, surface_height);


### PR DESCRIPTION
The way we handled textures, in general, is very complex and hard to debug/check. This PR introduces a new algorithm for handling textures with the added bonus of being a lot faster and being able to tackle 3D Textures.

Some Pros of the new version:
- Faster texture unswizzling, about 6 times faster in most cases.
- Ability to decode 3D Textures.
- Easier to infer from logic, the structure of a blocklinear texture.
- No complex adress calculations.

Cons:
- More complex algorithm than old version (6 nested loops).
- Still does not handle block_width but it's easier to implement if we ever have to use it.
- Differs from most documentation is it tackles the problem from a geometric perspective rather than an adress perspective.

What it means for the User:
- this PR opens the door for many new features and bug fixes.
- Upcoming implementations like DMA, won't hit performance that hard.
- Faster loading times and more FPS on certain games.