### PR TITLE
kernel/process: Make CodeSet a regular non-inherited object

### DIFF
--- a/src/core/hle/kernel/object.cpp
+++ b/src/core/hle/kernel/object.cpp
@@ -25,7 +25,6 @@ bool Object::IsWaitable() const {
     case HandleType::Process:
     case HandleType::AddressArbiter:
     case HandleType::ResourceLimit:
-    case HandleType::CodeSet:
     case HandleType::ClientPort:
     case HandleType::ClientSession:
         return false;

--- a/src/core/hle/kernel/object.h
+++ b/src/core/hle/kernel/object.h
@@ -26,7 +26,6 @@ enum class HandleType : u32 {
     AddressArbiter,
     Timer,
     ResourceLimit,
-    CodeSet,
     ClientPort,
     ServerPort,
     ClientSession,

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -61,26 +61,15 @@ enum class ProcessStatus { Created, Running, Exited };
 
 class ResourceLimit;
 
-struct CodeSet final : public Object {
+struct CodeSet final {
     struct Segment {
         std::size_t offset = 0;
         VAddr addr = 0;
         u32 size = 0;
     };
 
-    static SharedPtr<CodeSet> Create(KernelCore& kernel, std::string name);
-
-    std::string GetTypeName() const override {
-        return "CodeSet";
-    }
-    std::string GetName() const override {
-        return name;
-    }
-
-    static const HandleType HANDLE_TYPE = HandleType::CodeSet;
-    HandleType GetHandleType() const override {
-        return HANDLE_TYPE;
-    }
+    explicit CodeSet();
+    ~CodeSet();
 
     Segment& CodeSegment() {
         return segments[0];
@@ -109,14 +98,7 @@ struct CodeSet final : public Object {
     std::shared_ptr<std::vector<u8>> memory;
 
     std::array<Segment, 3> segments;
-    VAddr entrypoint;
-
-    /// Name of the process
-    std::string name;
-
-private:
-    explicit CodeSet(KernelCore& kernel);
-    ~CodeSet() override;
+    VAddr entrypoint = 0;
 };
 
 class Process final : public Object {
@@ -219,7 +201,7 @@ public:
      */
     void PrepareForTermination();
 
-    void LoadModule(SharedPtr<CodeSet> module_, VAddr base_addr);
+    void LoadModule(CodeSet module_, VAddr base_addr);
 
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // Memory Management


### PR DESCRIPTION
These only exist to ferry data into a Process instance and end up going out of scope quite early. Because of this, we can just make it a plain struct for holding things and just std::move it into the relevant function. There's no need to make this inherit from the kernel's Object type.