### PR TITLE
yuzu/main: Apply the [[maybe_unused]] attribute to the parameter of SetDiscordEnabled

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1565,7 +1565,7 @@ void GMainWindow::UpdateUITheme() {
     emit UpdateThemedIcons();
 }
 
-void GMainWindow::SetDiscordEnabled(bool state) {
+void GMainWindow::SetDiscordEnabled([[maybe_unused]] bool state) {
 #ifdef USE_DISCORD_PRESENCE
     if (state) {
         discord_rpc = std::make_unique<DiscordRPC::DiscordImpl>();


### PR DESCRIPTION
Depending on whether or not `USE_DISCORD_PRESENCE` is defined, the "state" parameter can be used or unused. If `USE_DISCORD_PRESENCE` is not defined, the parameter will be considered unused, which can lead to compiler warnings. So, we can explicitly mark it with `[[maybe_unused]]` to inform the compiler that this is intentional.