### PR TITLE
yuzu/main: Simplify OnMenuLoadFile()

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -908,22 +908,20 @@ void GMainWindow::OnGameListNavigateToGamedbEntry(u64 program_id,
 }
 
 void GMainWindow::OnMenuLoadFile() {
-    QString extensions;
-    for (const auto& piece : game_list->supported_file_extensions)
-        extensions += "*." + piece + " ";
+    const QString extensions =
+        QString("*.").append(GameList::supported_file_extensions.join(" *.")).append(" main");
+    const QString file_filter = tr("Switch Executable (%1);;All Files (*.*)",
+                                   "%1 is an identifier for the Switch executable file extensions.")
+                                    .arg(extensions);
+    const QString filename = QFileDialog::getOpenFileName(
+        this, tr("Load File"), UISettings::values.roms_path, file_filter);
 
-    extensions += "main ";
-
-    QString file_filter = tr("Switch Executable") + " (" + extensions + ")";
-    file_filter += ";;" + tr("All Files (*.*)");
-
-    QString filename = QFileDialog::getOpenFileName(this, tr("Load File"),
-                                                    UISettings::values.roms_path, file_filter);
-    if (!filename.isEmpty()) {
-        UISettings::values.roms_path = QFileInfo(filename).path();
-
-        BootGame(filename);
+    if (filename.isEmpty()) {
+        return;
     }
+
+    UISettings::values.roms_path = QFileInfo(filename).path();
+    BootGame(filename);
 }
 
 void GMainWindow::OnMenuLoadFolder() {


### PR DESCRIPTION
We can utilize QStringList's join() function to perform all of the appending in a single function call.

While we're at it, make the extension list a single translatable string and add a disambiguation comment to explain to translators what %1 actually is. Providing the complete string is also friendlier to translators for languages that might not have the same ordering or writing direction as English. This way they don't have to decipher multiple fragmented pieces of text.