### PR TITLE
aoc: Fix various bugs in current AOC implementation

### DIFF
--- a/src/core/file_sys/control_metadata.cpp
+++ b/src/core/file_sys/control_metadata.cpp
@@ -56,6 +56,10 @@ u64 NACP::GetTitleId() const {
     return raw->title_id;
 }
 
+u64 NACP::GetDLCBaseTitleId() const {
+    return raw->dlc_base_title_id;
+}
+
 std::string NACP::GetVersionString() const {
     return Common::StringFromFixedZeroTerminatedBuffer(raw->version_string.data(), 0x10);
 }

--- a/src/core/file_sys/control_metadata.h
+++ b/src/core/file_sys/control_metadata.h
@@ -79,6 +79,7 @@ public:
     std::string GetApplicationName(Language language = Language::Default) const;
     std::string GetDeveloperName(Language language = Language::Default) const;
     u64 GetTitleId() const;
+    u64 GetDLCBaseTitleId() const;
     std::string GetVersionString() const;
 
 private:

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -7,8 +7,10 @@
 #include <vector>
 #include "common/logging/log.h"
 #include "core/file_sys/content_archive.h"
+#include "core/file_sys/control_metadata.h"
 #include "core/file_sys/nca_metadata.h"
 #include "core/file_sys/partition_filesystem.h"
+#include "core/file_sys/patch_manager.h"
 #include "core/file_sys/registered_cache.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/process.h"
@@ -19,7 +21,7 @@
 namespace Service::AOC {
 
 constexpr u64 DLC_BASE_TITLE_ID_MASK = 0xFFFFFFFFFFFFE000;
-constexpr u64 DLC_BASE_TO_AOC_ID_MASK = 0x1000;
+constexpr u64 DLC_BASE_TO_AOC_ID = 0x1000;
 
 static bool CheckAOCTitleIDMatchesBase(u64 base, u64 aoc) {
     return (aoc & DLC_BASE_TITLE_ID_MASK) == base;
@@ -105,7 +107,16 @@ void AOC_U::ListAddOnContent(Kernel::HLERequestContext& ctx) {
 void AOC_U::GetAddOnContentBaseId(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
-    rb.Push(Core::System::GetInstance().CurrentProcess()->GetTitleID() | DLC_BASE_TO_AOC_ID_MASK);
+    const auto title_id = Core::System::GetInstance().CurrentProcess()->GetTitleID();
+    FileSys::PatchManager pm{title_id};
+
+    const auto res = pm.GetControlMetadata();
+    if (res.first == nullptr) {
+        rb.Push(title_id + DLC_BASE_TO_AOC_ID);
+        return;
+    }
+
+    rb.Push(res.first->GetDLCBaseTitleId());
 }
 
 void AOC_U::PrepareAddOnContent(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -97,8 +97,9 @@ void AOC_U::ListAddOnContent(Kernel::HLERequestContext& ctx) {
 
     ctx.WriteBuffer(out);
 
-    IPC::ResponseBuilder rb{ctx, 2};
+    IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
+    rb.Push(count);
 }
 
 void AOC_U::GetAddOnContentBaseId(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
1. Returns buffer size in ListAddOnContent, which is what the signature should be and should fix the bugs in games like Rocket League where it tries to access DLC not owned and svcBreaks.
2. Reads DLC base ID from Control metadata, which is how HOS seems to do it. If this cannot be found, it falls back to base TID + 0x1000, which is also the HOS fallback.