### PR TITLE
Stop all threads on svcBreak

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -389,6 +389,12 @@ static void Break(u32 reason, u64 info1, u64 info2) {
             "Emulated program broke execution! reason=0x{:016X}, info1=0x{:016X}, info2=0x{:016X}",
             reason, info1, info2);
         ASSERT(false);
+
+        Core::CurrentProcess()->PrepareForTermination();
+
+        // Kill the current thread
+        GetCurrentThread()->Stop();
+        Core::System::GetInstance().PrepareReschedule();
     }
 }
 


### PR DESCRIPTION
This should help diagnose crashes easier and prevent many users thinking that a game is still running when in fact it's just an audio thread still running(this is typically not killed when svcBreak is hit since the game expects us to do this)