### PR TITLE
nro/nso: Minor error handling changes

### DIFF
--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -141,7 +141,7 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(Kernel::Process& process)
         const FileSys::VirtualFile module_file = dir->GetFile(module);
         if (module_file != nullptr) {
             const VAddr load_addr = next_load_addr;
-            next_load_addr = AppLoader_NSO::LoadModule(module_file, load_addr,
+            next_load_addr = AppLoader_NSO::LoadModule(*module_file, load_addr,
                                                        std::strcmp(module, "rtld") == 0, pm);
             LOG_DEBUG(Loader, "loaded module {} @ 0x{:X}", module, load_addr);
             // Register module with GDBStub

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -93,7 +93,7 @@ std::string GetFileTypeString(FileType type) {
     return "unknown";
 }
 
-constexpr std::array<const char*, 59> RESULT_MESSAGES{
+constexpr std::array<const char*, 60> RESULT_MESSAGES{
     "The operation completed successfully.",
     "The loader requested to load is already loaded.",
     "The operation is not implemented.",
@@ -128,6 +128,7 @@ constexpr std::array<const char*, 59> RESULT_MESSAGES{
     "The RomFS could not be found.",
     "The ELF file has incorrect size as determined by the header.",
     "There was a general error loading the NRO into emulated memory.",
+    "There was a general error loading the NSO into emulated memory.",
     "There is no icon available.",
     "There is no control data available.",
     "The NAX file has a bad header.",

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -90,6 +90,7 @@ enum class ResultStatus : u16 {
     ErrorNoRomFS,
     ErrorIncorrectELFFileSize,
     ErrorLoadingNRO,
+    ErrorLoadingNSO,
     ErrorNoIcon,
     ErrorNoControl,
     ErrorBadNAXHeader,

--- a/src/core/loader/nro.h
+++ b/src/core/loader/nro.h
@@ -41,7 +41,7 @@ public:
     bool IsRomFSUpdatable() const override;
 
 private:
-    bool LoadNro(FileSys::VirtualFile file, VAddr load_base);
+    bool LoadNro(const FileSys::VfsFile& file, VAddr load_base);
 
     std::vector<u8> icon_data;
     std::unique_ptr<FileSys::NACP> nacp;

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -93,17 +93,14 @@ static constexpr u32 PageAlignSize(u32 size) {
     return (size + Memory::PAGE_MASK) & ~Memory::PAGE_MASK;
 }
 
-VAddr AppLoader_NSO::LoadModule(FileSys::VirtualFile file, VAddr load_base,
+VAddr AppLoader_NSO::LoadModule(const FileSys::VfsFile& file, VAddr load_base,
                                 bool should_pass_arguments,
                                 boost::optional<FileSys::PatchManager> pm) {
-    if (file == nullptr)
-        return {};
-
-    if (file->GetSize() < sizeof(NsoHeader))
+    if (file.GetSize() < sizeof(NsoHeader))
         return {};
 
     NsoHeader nso_header{};
-    if (sizeof(NsoHeader) != file->ReadObject(&nso_header))
+    if (sizeof(NsoHeader) != file.ReadObject(&nso_header))
         return {};
 
     if (nso_header.magic != Common::MakeMagic('N', 'S', 'O', '0'))
@@ -114,7 +111,7 @@ VAddr AppLoader_NSO::LoadModule(FileSys::VirtualFile file, VAddr load_base,
     std::vector<u8> program_image;
     for (std::size_t i = 0; i < nso_header.segments.size(); ++i) {
         std::vector<u8> data =
-            file->ReadBytes(nso_header.segments_compressed_size[i], nso_header.segments[i].offset);
+            file.ReadBytes(nso_header.segments_compressed_size[i], nso_header.segments[i].offset);
         if (nso_header.IsSegmentCompressed(i)) {
             data = DecompressSegment(data, nso_header.segments[i]);
         }
@@ -172,7 +169,7 @@ VAddr AppLoader_NSO::LoadModule(FileSys::VirtualFile file, VAddr load_base,
     Core::CurrentProcess()->LoadModule(std::move(codeset), load_base);
 
     // Register module with GDBStub
-    GDBStub::RegisterModule(file->GetName(), load_base, load_base);
+    GDBStub::RegisterModule(file.GetName(), load_base, load_base);
 
     return load_base + image_size;
 }
@@ -184,7 +181,7 @@ ResultStatus AppLoader_NSO::Load(Kernel::Process& process) {
 
     // Load module
     const VAddr base_address = process.VMManager().GetCodeRegionBaseAddress();
-    LoadModule(file, base_address, true);
+    LoadModule(*file, base_address, true);
     LOG_DEBUG(Loader, "loaded module {} @ 0x{:X}", file->GetName(), base_address);
 
     process.Run(base_address, Kernel::THREADPRIO_DEFAULT, Memory::DEFAULT_STACK_SIZE);

--- a/src/core/loader/nso.h
+++ b/src/core/loader/nso.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include "common/common_types.h"
 #include "core/file_sys/patch_manager.h"
 #include "core/loader/linker.h"
@@ -36,9 +37,9 @@ public:
         return IdentifyType(file);
     }
 
-    static VAddr LoadModule(const FileSys::VfsFile& file, VAddr load_base,
-                            bool should_pass_arguments,
-                            boost::optional<FileSys::PatchManager> pm = boost::none);
+    static std::optional<VAddr> LoadModule(const FileSys::VfsFile& file, VAddr load_base,
+                                           bool should_pass_arguments,
+                                           std::optional<FileSys::PatchManager> pm = {});
 
     ResultStatus Load(Kernel::Process& process) override;
 };

--- a/src/core/loader/nso.h
+++ b/src/core/loader/nso.h
@@ -36,7 +36,8 @@ public:
         return IdentifyType(file);
     }
 
-    static VAddr LoadModule(FileSys::VirtualFile file, VAddr load_base, bool should_pass_arguments,
+    static VAddr LoadModule(const FileSys::VfsFile& file, VAddr load_base,
+                            bool should_pass_arguments,
                             boost::optional<FileSys::PatchManager> pm = boost::none);
 
     ResultStatus Load(Kernel::Process& process) override;


### PR DESCRIPTION
Minor individual changes. Notably, this handles the case where loading an NSO happens to fail. Instead of continuing onwards, we now bail out and report the error.