### PR TITLE
crypto: Various crypto fixes for quickstart guide

### DIFF
--- a/src/core/crypto/partition_data_manager.cpp
+++ b/src/core/crypto/partition_data_manager.cpp
@@ -303,8 +303,8 @@ FileSys::VirtualFile FindFileInDirWithNames(const FileSys::VirtualDir& dir,
 
 PartitionDataManager::PartitionDataManager(const FileSys::VirtualDir& sysdata_dir)
     : boot0(FindFileInDirWithNames(sysdata_dir, "BOOT0")),
-      fuses(FindFileInDirWithNames(sysdata_dir, "fuse")),
-      kfuses(FindFileInDirWithNames(sysdata_dir, "kfuse")),
+      fuses(FindFileInDirWithNames(sysdata_dir, "fuses")),
+      kfuses(FindFileInDirWithNames(sysdata_dir, "kfuses")),
       package2({
           FindFileInDirWithNames(sysdata_dir, "BCPKG2-1-Normal-Main"),
           FindFileInDirWithNames(sysdata_dir, "BCPKG2-2-Normal-Sub"),

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1428,8 +1428,12 @@ void GMainWindow::OnReinitializeKeys(ReinitializeKeyBehavior behavior) {
             QMessageBox::warning(
                 this, tr("Warning Missing Derivation Components"),
                 tr("The following are missing from your configuration that may hinder key "
-                   "derivation. It will be attempted but may not complete.\n\n") +
-                    errors);
+                   "derivation. It will be attempted but may not complete.<br><br>") +
+                    errors +
+                    tr("<br><br>You can get all of these and dump all of your games easily by "
+                       "following <a href='https://yuzu-emu.org/help/quickstart/quickstart/'>the "
+                       "quickstart guide</a>. Alternatively, you can use another method of dumping "
+                       "to obtain all of your keys."));
         }
 
         QProgressDialog prog;


### PR DESCRIPTION
Mainly rename fuse and kfuse to fuses and kfuses which is what hekate uses and link to the guide in the error popup.