### PR TITLE
gl_shader_decompiler: Implement H* instructions

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -335,6 +335,26 @@ enum class IsberdMode : u64 {
 
 enum class IsberdShift : u64 { None = 0, U16 = 1, B32 = 2 };
 
+enum class HalfType : u64 {
+    H0_H1 = 0,
+    F32 = 1,
+    H0_H0 = 2,
+    H1_H1 = 3,
+};
+
+enum class HalfMerge : u64 {
+    H0_H1 = 0,
+    F32 = 1,
+    Mrg_H0 = 2,
+    Mrg_H1 = 3,
+};
+
+enum class HalfPrecision : u64 {
+    None = 0,
+    FTZ = 1,
+    FMZ = 2,
+};
+
 enum class IpaInterpMode : u64 {
     Linear = 0,
     Perspective = 1,

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -615,6 +615,29 @@ union Instruction {
     } half_imm;
 
     union {
+        union {
+            BitField<37, 2, HalfPrecision> precision;
+            BitField<32, 1, u64> saturate;
+
+            BitField<30, 1, u64> negate_c;
+            BitField<35, 2, HalfType> type_c;
+        } rr;
+
+        BitField<57, 2, HalfPrecision> precision;
+        BitField<52, 1, u64> saturate;
+
+        BitField<49, 2, HalfMerge> merge;
+
+        BitField<47, 2, HalfType> type_a;
+
+        BitField<56, 1, u64> negate_b;
+        BitField<28, 2, HalfType> type_b;
+
+        BitField<51, 1, u64> negate_c;
+        BitField<53, 2, HalfType> type_reg39;
+    } hfma2;
+
+    union {
         BitField<40, 1, u64> invert;
     } popc;
 
@@ -1212,6 +1235,10 @@ public:
         HMUL2_C,
         HMUL2_R,
         HMUL2_IMM,
+        HFMA2_CR,
+        HFMA2_RC,
+        HFMA2_RR,
+        HFMA2_IMM_R,
         POPC_C,
         POPC_R,
         POPC_IMM,
@@ -1290,6 +1317,7 @@ public:
         Bfe,
         Shift,
         Ffma,
+        Hfma2,
         Flow,
         Synch,
         Memory,
@@ -1464,6 +1492,10 @@ private:
             INST("0111100-1-------", Id::HMUL2_C, Type::ArithmeticHalf, "HMUL2_C"),
             INST("0101110100001---", Id::HMUL2_R, Type::ArithmeticHalf, "HMUL2_R"),
             INST("0111100-0-------", Id::HMUL2_IMM, Type::ArithmeticHalfImmediate, "HMUL2_IMM"),
+            INST("01110---1-------", Id::HFMA2_CR, Type::Hfma2, "HFMA2_CR"),
+            INST("01100---1-------", Id::HFMA2_RC, Type::Hfma2, "HFMA2_RC"),
+            INST("0101110100000---", Id::HFMA2_RR, Type::Hfma2, "HFMA2_RR"),
+            INST("01110---0-------", Id::HFMA2_IMM_R, Type::Hfma2, "HFMA2_R_IMM"),
             INST("0101000010000---", Id::MUFU, Type::Arithmetic, "MUFU"),
             INST("0100110010010---", Id::RRO_C, Type::Arithmetic, "RRO_C"),
             INST("0101110010010---", Id::RRO_R, Type::Arithmetic, "RRO_R"),

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -832,6 +832,21 @@ union Instruction {
     } fset;
 
     union {
+        BitField<49, 1, u64> bf;
+        BitField<35, 3, PredCondition> cond;
+        BitField<50, 1, u64> ftz;
+        BitField<45, 2, PredOperation> op;
+        BitField<43, 1, u64> negate_a;
+        BitField<44, 1, u64> abs_a;
+        BitField<47, 2, HalfType> type_a;
+        BitField<31, 1, u64> negate_b;
+        BitField<30, 1, u64> abs_b;
+        BitField<28, 2, HalfType> type_b;
+        BitField<42, 1, u64> neg_pred;
+        BitField<39, 3, u64> pred39;
+    } hset2;
+
+    union {
         BitField<39, 3, u64> pred39;
         BitField<42, 1, u64> neg_pred;
         BitField<44, 1, u64> bf;
@@ -1257,6 +1272,7 @@ public:
         HFMA2_RR,
         HFMA2_IMM_R,
         HSETP2_R,
+        HSET2_R,
         POPC_C,
         POPC_R,
         POPC_IMM,
@@ -1343,6 +1359,7 @@ public:
         FloatSetPredicate,
         IntegerSet,
         IntegerSetPredicate,
+        HalfSet,
         HalfSetPredicate,
         PredicateSetPredicate,
         PredicateSetRegister,
@@ -1516,6 +1533,7 @@ private:
             INST("0101110100000---", Id::HFMA2_RR, Type::Hfma2, "HFMA2_RR"),
             INST("01110---0-------", Id::HFMA2_IMM_R, Type::Hfma2, "HFMA2_R_IMM"),
             INST("0101110100100---", Id::HSETP2_R, Type::HalfSetPredicate, "HSETP_R"),
+            INST("0101110100011---", Id::HSET2_R, Type::HalfSet, "HSET2_R"),
             INST("0101000010000---", Id::MUFU, Type::Arithmetic, "MUFU"),
             INST("0100110010010---", Id::RRO_C, Type::Arithmetic, "RRO_C"),
             INST("0101110010010---", Id::RRO_R, Type::Arithmetic, "RRO_R"),

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -574,6 +574,22 @@ union Instruction {
     } alu_integer;
 
     union {
+        BitField<39, 1, u64> ftz;
+        BitField<32, 1, u64> saturate;
+        BitField<49, 2, HalfMerge> merge;
+
+        BitField<43, 1, u64> negate_a;
+        BitField<44, 1, u64> abs_a;
+        BitField<47, 2, HalfType> type_a;
+
+        BitField<31, 1, u64> negate_b;
+        BitField<30, 1, u64> abs_b;
+        BitField<47, 2, HalfType> type_b;
+
+        BitField<35, 2, HalfType> type_c;
+    } alu_half;
+
+    union {
         BitField<40, 1, u64> invert;
     } popc;
 
@@ -1165,6 +1181,10 @@ public:
         LEA_RZ,
         LEA_IMM,
         LEA_HI,
+        HADD2_C,
+        HADD2_R,
+        HMUL2_C,
+        HMUL2_R,
         POPC_C,
         POPC_R,
         POPC_IMM,
@@ -1238,6 +1258,7 @@ public:
         ArithmeticImmediate,
         ArithmeticInteger,
         ArithmeticIntegerImmediate,
+        ArithmeticHalf,
         Bfe,
         Shift,
         Ffma,
@@ -1409,6 +1430,10 @@ private:
             INST("001101101101----", Id::LEA_IMM, Type::ArithmeticInteger, "LEA_IMM"),
             INST("010010111101----", Id::LEA_RZ, Type::ArithmeticInteger, "LEA_RZ"),
             INST("00011000--------", Id::LEA_HI, Type::ArithmeticInteger, "LEA_HI"),
+            INST("0111101-1-------", Id::HADD2_C, Type::ArithmeticHalf, "HADD2_C"),
+            INST("0101110100010---", Id::HADD2_R, Type::ArithmeticHalf, "HADD2_R"),
+            INST("0111100-1-------", Id::HMUL2_C, Type::ArithmeticHalf, "HMUL2_C"),
+            INST("0101110100001---", Id::HMUL2_R, Type::ArithmeticHalf, "HMUL2_R"),
             INST("0101000010000---", Id::MUFU, Type::Arithmetic, "MUFU"),
             INST("0100110010010---", Id::RRO_C, Type::Arithmetic, "RRO_C"),
             INST("0101110010010---", Id::RRO_R, Type::Arithmetic, "RRO_R"),

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -590,6 +590,31 @@ union Instruction {
     } alu_half;
 
     union {
+        BitField<39, 2, HalfPrecision> precision;
+        BitField<39, 1, u64> ftz;
+        BitField<52, 1, u64> saturate;
+        BitField<49, 2, HalfMerge> merge;
+
+        BitField<43, 1, u64> negate_a;
+        BitField<44, 1, u64> abs_a;
+        BitField<47, 2, HalfType> type_a;
+    } alu_half_imm;
+
+    union {
+        BitField<29, 1, u64> first_negate;
+        BitField<20, 9, u64> first;
+
+        BitField<56, 1, u64> second_negate;
+        BitField<30, 9, u64> second;
+
+        u32 PackImmediates() const {
+            // Immediates are half floats shifted.
+            constexpr u32 imm_shift = 6;
+            return static_cast<u32>((first << imm_shift) | (second << (16 + imm_shift)));
+        }
+    } half_imm;
+
+    union {
         BitField<40, 1, u64> invert;
     } popc;
 
@@ -1183,8 +1208,10 @@ public:
         LEA_HI,
         HADD2_C,
         HADD2_R,
+        HADD2_IMM,
         HMUL2_C,
         HMUL2_R,
+        HMUL2_IMM,
         POPC_C,
         POPC_R,
         POPC_IMM,
@@ -1259,6 +1286,7 @@ public:
         ArithmeticInteger,
         ArithmeticIntegerImmediate,
         ArithmeticHalf,
+        ArithmeticHalfImmediate,
         Bfe,
         Shift,
         Ffma,
@@ -1432,8 +1460,10 @@ private:
             INST("00011000--------", Id::LEA_HI, Type::ArithmeticInteger, "LEA_HI"),
             INST("0111101-1-------", Id::HADD2_C, Type::ArithmeticHalf, "HADD2_C"),
             INST("0101110100010---", Id::HADD2_R, Type::ArithmeticHalf, "HADD2_R"),
+            INST("0111101-0-------", Id::HADD2_IMM, Type::ArithmeticHalfImmediate, "HADD2_IMM"),
             INST("0111100-1-------", Id::HMUL2_C, Type::ArithmeticHalf, "HMUL2_C"),
             INST("0101110100001---", Id::HMUL2_R, Type::ArithmeticHalf, "HMUL2_R"),
+            INST("0111100-0-------", Id::HMUL2_IMM, Type::ArithmeticHalfImmediate, "HMUL2_IMM"),
             INST("0101000010000---", Id::MUFU, Type::Arithmetic, "MUFU"),
             INST("0100110010010---", Id::RRO_C, Type::Arithmetic, "RRO_C"),
             INST("0101110010010---", Id::RRO_R, Type::Arithmetic, "RRO_R"),

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -801,6 +801,23 @@ union Instruction {
     } csetp;
 
     union {
+        BitField<35, 4, PredCondition> cond;
+        BitField<49, 1, u64> h_and;
+        BitField<6, 1, u64> ftz;
+        BitField<45, 2, PredOperation> op;
+        BitField<3, 3, u64> pred3;
+        BitField<0, 3, u64> pred0;
+        BitField<43, 1, u64> negate_a;
+        BitField<44, 1, u64> abs_a;
+        BitField<47, 2, HalfType> type_a;
+        BitField<31, 1, u64> negate_b;
+        BitField<30, 1, u64> abs_b;
+        BitField<28, 2, HalfType> type_b;
+        BitField<42, 1, u64> neg_pred;
+        BitField<39, 3, u64> pred39;
+    } hsetp2;
+
+    union {
         BitField<39, 3, u64> pred39;
         BitField<42, 1, u64> neg_pred;
         BitField<43, 1, u64> neg_a;
@@ -1239,6 +1256,7 @@ public:
         HFMA2_RC,
         HFMA2_RR,
         HFMA2_IMM_R,
+        HSETP2_R,
         POPC_C,
         POPC_R,
         POPC_IMM,
@@ -1325,6 +1343,7 @@ public:
         FloatSetPredicate,
         IntegerSet,
         IntegerSetPredicate,
+        HalfSetPredicate,
         PredicateSetPredicate,
         PredicateSetRegister,
         Conversion,
@@ -1496,6 +1515,7 @@ private:
             INST("01100---1-------", Id::HFMA2_RC, Type::Hfma2, "HFMA2_RC"),
             INST("0101110100000---", Id::HFMA2_RR, Type::Hfma2, "HFMA2_RR"),
             INST("01110---0-------", Id::HFMA2_IMM_R, Type::Hfma2, "HFMA2_R_IMM"),
+            INST("0101110100100---", Id::HSETP2_R, Type::HalfSetPredicate, "HSETP_R"),
             INST("0101000010000---", Id::MUFU, Type::Arithmetic, "MUFU"),
             INST("0100110010010---", Id::RRO_C, Type::Arithmetic, "RRO_C"),
             INST("0101110010010---", Id::RRO_R, Type::Arithmetic, "RRO_R"),


### PR DESCRIPTION
Initially I didn't want to implement all these instructions at once but it's what the games I tested it with (Xenoblade and L.A.Noire) used. Sadly I didn't see any progression in these titles, probably because of all the other missing features.

I think it deserves an explanation of how this instructions work since they are not handled like `F*` or `I*` instructions.
Most `H*` instructions operate in ~a perverted way~ pairs, that means that they can `ADD`, `MUL` or `FMA` two values at once. These values are packed in registers, immediates... The trick is that when a result is obtained they can do one of four things:
* Set the pair result as-is to the register.
* Set the pair result just to the low part of the register (`Mrg_H0`).
* Set the pair result just to the high part of the register (`Mrg_H1`).
* Set the pair result as a float. This captures the low value of the pair.

These "pairs" are handled as a `vec2` which adds unwanted extra precision to the operations but they don't require vendor specific instructions (`NV_gpu_shader5`, `AMD_gpu_shader_half_float`), but these can be easily added in the future.

Just like values can be packed in an specific manner, they can also be unpacked in four similar ways (`H0_H1`, `H0_H0`, `H1_H1` and `F32`). Immediates are packed in a 6 shifted manner. That is for ALU instructions.

`HSETP2` operates on both components of the pair and decides with a flag (`h_and`) if they both have to satisfy the condition (on) or just one (off).

`HSET2` also operates on components, returning a pair of half floats with `bf` enabled (a shifted `0x3f00` on success). In other words, if low success, low gets a `0x3f00`, if high success it gets a `0x3f00` (or `0xffff` if `bf` is off).

I hope this helps to explain why output like this one is emitted:
```glsl
// 1: HSET2_R (0x5d1a03b003c72814)
reg_20_vs = (uintBitsToFloat((((((unpackHalf2x16(floatBitsToUint(reg_40_vs)).x) >= (unpackHalf2x16(floatBitsToUint(reg_60_vs)).x)) && (true)) ? 0x00003c00 : 0) | ((((unpackHalf2x16(floatBitsToUint(reg_40_vs)).y) >= (unpackHalf2x16(floatBitsToUint(reg_60_vs)).y)) && (true)) ? 0x3c000000 : 0))));
```
