### PR TITLE
Port citra-emu/citra#4327: "travis: Ignore binary files when checking for trailing whitespace"

### DIFF
--- a/.travis/clang-format/script.sh
+++ b/.travis/clang-format/script.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -ex
 
-if grep -nr '\s$' src *.yml *.txt *.md Doxyfile .gitignore .gitmodules .travis* dist/*.desktop \
+if grep -nrI '\s$' src *.yml *.txt *.md Doxyfile .gitignore .gitmodules .travis* dist/*.desktop \
                  dist/*.svg dist/*.xml; then
     echo Trailing whitespace found, aborting
     exit 1


### PR DESCRIPTION
See citra-emu/citra#4327 for more details.