### PR TITLE
savedata_factory: Add DeviceSaveData and fix TemporaryStorage

### DIFF
--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -51,6 +51,13 @@ ResultVal<VirtualDir> SaveDataFactory::Open(SaveDataSpaceId space, SaveDataDescr
                     meta.title_id);
     }
 
+    if (meta.type == SaveDataType::DeviceSaveData && meta.user_id != u128{0, 0}) {
+        LOG_WARNING(Service_FS,
+                    "Possibly incorrect SaveDataDescriptor, type is DeviceSaveData but user_id is "
+                    "non-zero ({:016X}{:016X})",
+                    meta.user_id[1], meta.user_id[0]);
+    }
+
     std::string save_directory =
         GetFullPath(space, meta.type, meta.title_id, meta.user_id, meta.save_id);
 
@@ -100,6 +107,7 @@ std::string SaveDataFactory::GetFullPath(SaveDataSpaceId space, SaveDataType typ
     case SaveDataType::SystemSaveData:
         return fmt::format("{}save/{:016X}/{:016X}{:016X}", out, save_id, user_id[1], user_id[0]);
     case SaveDataType::SaveData:
+    case SaveDataType::DeviceSaveData:
         return fmt::format("{}save/{:016X}/{:016X}{:016X}/{:016X}", out, 0, user_id[1], user_id[0],
                            title_id);
     case SaveDataType::TemporaryStorage:

--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -99,6 +99,9 @@ std::string SaveDataFactory::GetFullPath(SaveDataSpaceId space, SaveDataType typ
     case SaveDataSpaceId::NandUser:
         out = "/user/";
         break;
+    case SaveDataSpaceId::TemporaryStorage:
+        out = "/temp/";
+        break;
     default:
         ASSERT_MSG(false, "Unrecognized SaveDataSpaceId: {:02X}", static_cast<u8>(space));
     }
@@ -111,7 +114,7 @@ std::string SaveDataFactory::GetFullPath(SaveDataSpaceId space, SaveDataType typ
         return fmt::format("{}save/{:016X}/{:016X}{:016X}/{:016X}", out, 0, user_id[1], user_id[0],
                            title_id);
     case SaveDataType::TemporaryStorage:
-        return fmt::format("{}temp/{:016X}/{:016X}{:016X}/{:016X}", out, 0, user_id[1], user_id[0],
+        return fmt::format("{}{:016X}/{:016X}{:016X}/{:016X}", out, 0, user_id[1], user_id[0],
                            title_id);
     default:
         ASSERT_MSG(false, "Unrecognized SaveDataType: {:02X}", static_cast<u8>(type));


### PR DESCRIPTION
Based on:
- Info from @SciresM that `DeviceSaveData` is the same as normal save data in terms of path.
- Info from @ogniK5377 that `DeviceSaveData` must have user ID 0 and can be likened to a global, user-less save.
- Also adds the `TemporaryStorage` SaveDataSpaceId, which is required to avoid an assert. Keeps the same path though.