### PR TITLE
XCI: Add function for checking the existence of the program NCA

### DIFF
--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -122,14 +122,16 @@ u64 XCI::GetProgramTitleID() const {
     return secure_partition->GetProgramTitleID();
 }
 
-std::shared_ptr<NCA> XCI::GetProgramNCA() const {
-    return program;
+bool XCI::HasProgramNCA() const {
+    return program != nullptr;
 }
 
 VirtualFile XCI::GetProgramNCAFile() const {
-    if (GetProgramNCA() == nullptr)
+    if (!HasProgramNCA()) {
         return nullptr;
-    return GetProgramNCA()->GetBaseFile();
+    }
+
+    return program->GetBaseFile();
 }
 
 const std::vector<std::shared_ptr<NCA>>& XCI::GetNCAs() const {

--- a/src/core/file_sys/card_image.h
+++ b/src/core/file_sys/card_image.h
@@ -80,7 +80,7 @@ public:
 
     u64 GetProgramTitleID() const;
 
-    std::shared_ptr<NCA> GetProgramNCA() const;
+    bool HasProgramNCA() const;
     VirtualFile GetProgramNCAFile() const;
     const std::vector<std::shared_ptr<NCA>>& GetNCAs() const;
     std::shared_ptr<NCA> GetNCAByType(NCAContentType type) const;

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -59,8 +59,7 @@ ResultStatus AppLoader_XCI::Load(Kernel::Process& process) {
     if (xci->GetProgramNCAStatus() != ResultStatus::Success)
         return xci->GetProgramNCAStatus();
 
-    const auto nca = xci->GetProgramNCA();
-    if (nca == nullptr && !Core::Crypto::KeyManager::KeyFileExists(false))
+    if (!xci->HasProgramNCA() && !Core::Crypto::KeyManager::KeyFileExists(false))
         return ResultStatus::ErrorMissingProductionKeyFile;
 
     const auto result = nca_loader->Load(process);


### PR DESCRIPTION
The only reason the getter existed was to check whether or not the program NCA was null. Instead, we can just provide a function to query for the existence of it, instead of exposing it entirely, getting rid of the need to interact with shared_ptr here.