### PR TITLE
[Experimental][Proof of Concept] Cubemaps Fix

### DIFF
--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -136,7 +136,7 @@ struct Values {
     float resolution_factor;
     bool use_frame_limit;
     u16 frame_limit;
-    bool use_accurate_framebuffers;
+    bool use_accurate_gpu_emulation;
 
     float bg_red;
     float bg_green;

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -163,8 +163,8 @@ TelemetrySession::TelemetrySession() {
     AddField(Telemetry::FieldType::UserConfig, "Renderer_UseFrameLimit",
              Settings::values.use_frame_limit);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_FrameLimit", Settings::values.frame_limit);
-    AddField(Telemetry::FieldType::UserConfig, "Renderer_UseAccurateFramebuffers",
-             Settings::values.use_accurate_framebuffers);
+    AddField(Telemetry::FieldType::UserConfig, "Renderer_UseAccurateGpuEmulation",
+             Settings::values.use_accurate_gpu_emulation);
     AddField(Telemetry::FieldType::UserConfig, "System_UseDockedMode",
              Settings::values.use_docked_mode);
 }

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -448,7 +448,10 @@ public:
                 BitField<8, 3, u32> block_depth;
                 BitField<12, 1, InvMemoryLayout> type;
             } memory_layout;
-            u32 array_mode;
+            union {
+                BitField<0, 16, u32> array_mode;
+                BitField<16, 1, u32> volume;
+            };
             u32 layer_stride;
             u32 base_layer;
             INSERT_PADDING_WORDS(7);

--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -87,6 +87,16 @@ GPUVAddr MemoryManager::UnmapBuffer(GPUVAddr gpu_addr, u64 size) {
     return gpu_addr;
 }
 
+GPUVAddr MemoryManager::GetRegionEnd(GPUVAddr region_start) const {
+    for (const auto& region : mapped_regions) {
+        const GPUVAddr region_end{region.gpu_addr + region.size};
+        if (region_start >= region.gpu_addr && region_start < region_end) {
+            return region_end;
+        }
+    }
+    return {};
+}
+
 boost::optional<GPUVAddr> MemoryManager::FindFreeBlock(u64 size, u64 align) {
     GPUVAddr gpu_addr = 0;
     u64 free_space = 0;

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -26,6 +26,7 @@ public:
     GPUVAddr MapBufferEx(VAddr cpu_addr, u64 size);
     GPUVAddr MapBufferEx(VAddr cpu_addr, GPUVAddr gpu_addr, u64 size);
     GPUVAddr UnmapBuffer(GPUVAddr gpu_addr, u64 size);
+    GPUVAddr GetRegionEnd(GPUVAddr region_start) const;
     boost::optional<VAddr> GpuToCpuAddress(GPUVAddr gpu_addr);
     std::vector<GPUVAddr> CpuToGpuAddress(VAddr cpu_addr) const;
 

--- a/src/video_core/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache.h
@@ -105,22 +105,6 @@ protected:
         return nullptr;
     }
 
-    std::vector<T> GetInRange(Tegra::GPUVAddr addr, size_t size) {
-        std::vector<T> objects;
-        if (size == 0)
-            return objects;
-
-        const ObjectInterval interval{addr, addr + size};
-        for (auto& pair : boost::make_iterator_range(object_cache.equal_range(interval))) {
-            for (auto& cached_object : pair.second) {
-                if (!cached_object)
-                    continue;
-                objects.push_back(cached_object);
-            }
-        }
-        return objects;
-    }
-
     /// Register an object into the cache
     void Register(const T& object) {
         object->SetIsRegistered(true);

--- a/src/video_core/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache.h
@@ -119,8 +119,8 @@ protected:
         auto& rasterizer = Core::System::GetInstance().Renderer().Rasterizer();
         rasterizer.UpdatePagesCachedCount(object->GetAddr(), object->GetSizeInBytes(), -1);
 
-        // Only flush if use_accurate_framebuffers is enabled, as it incurs a performance hit
-        if (Settings::values.use_accurate_framebuffers) {
+        // Only flush if use_accurate_gpu_emulation is enabled, as it incurs a performance hit
+        if (Settings::values.use_accurate_gpu_emulation) {
             FlushObject(object);
         }
 

--- a/src/video_core/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache.h
@@ -11,6 +11,7 @@
 
 #include "common/common_types.h"
 #include "core/core.h"
+#include "core/settings.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_base.h"
 
@@ -87,7 +88,12 @@ protected:
     void Unregister(const T& object) {
         auto& rasterizer = Core::System::GetInstance().Renderer().Rasterizer();
         rasterizer.UpdatePagesCachedCount(object->GetAddr(), object->GetSizeInBytes(), -1);
-        object->Flush();
+
+        if (Settings::values.use_accurate_framebuffers) {
+            // Only flush if use_accurate_framebuffers is enabled, as it incurs a performance hit
+            object->Flush();
+        }
+
         object_cache.subtract({GetInterval(object), ObjectSet{object}});
     }
 

--- a/src/video_core/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache.h
@@ -15,45 +15,73 @@
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_base.h"
 
+class RasterizerCacheObject {
+public:
+    /// Gets the address of the shader in guest memory, required for cache management
+    virtual VAddr GetAddr() const = 0;
+
+    /// Gets the size of the shader in guest memory, required for cache management
+    virtual std::size_t GetSizeInBytes() const = 0;
+
+    /// Wriets any cached resources back to memory
+    virtual void Flush() = 0;
+
+    /// Sets whether the cached object should be considered registered
+    void SetIsRegistered(bool registered) {
+        is_registered = registered;
+    }
+
+    /// Returns true if the cached object is registered
+    bool IsRegistered() const {
+        return is_registered;
+    }
+
+    /// Returns true if the cached object is dirty
+    bool IsDirty() const {
+        return is_dirty;
+    }
+
+    /// Returns ticks from when this cached object was last modified
+    u64 GetLastModifiedTicks() const {
+        return last_modified_ticks;
+    }
+
+    /// Marks an object as recently modified, used to specify whether it is clean or dirty
+    template <class T>
+    void MarkAsModified(bool dirty, T& cache) {
+        is_dirty = dirty;
+        last_modified_ticks = cache.GetModifiedTicks();
+    }
+
+private:
+    bool is_registered{};      ///< Whether the object is currently registered with the cache
+    bool is_dirty{};           ///< Whether the object is dirty (out of sync with guest memory)
+    u64 last_modified_ticks{}; ///< When the object was last modified, used for in-order flushing
+};
+
 template <class T>
 class RasterizerCache : NonCopyable {
+    friend class RasterizerCacheObject;
+
 public:
-    /// Write any cached resources overlapping the region back to memory (if dirty)
+    /// Write any cached resources overlapping the specified region back to memory
     void FlushRegion(Tegra::GPUVAddr addr, size_t size) {
-        if (size == 0)
-            return;
-
-        const ObjectInterval interval{addr, addr + size};
-        for (auto& pair : boost::make_iterator_range(object_cache.equal_range(interval))) {
-            for (auto& cached_object : pair.second) {
-                if (!cached_object)
-                    continue;
-
-                cached_object->Flush();
-            }
+        const auto& objects{GetSortedObjectsFromRegion(addr, size)};
+        for (auto& object : objects) {
+            FlushObject(object);
         }
     }
 
     /// Mark the specified region as being invalidated
     void InvalidateRegion(VAddr addr, u64 size) {
-        if (size == 0)
-            return;
-
-        const ObjectInterval interval{addr, addr + size};
-        for (auto& pair : boost::make_iterator_range(object_cache.equal_range(interval))) {
-            for (auto& cached_object : pair.second) {
-                if (!cached_object)
-                    continue;
-
-                remove_objects.emplace(cached_object);
+        const auto& objects{GetSortedObjectsFromRegion(addr, size)};
+        for (auto& object : objects) {
+            if (!object->IsRegistered()) {
+                // Skip duplicates
+                continue;
             }
+            Unregister(object);
         }
-
-        for (auto& remove_object : remove_objects) {
-            Unregister(remove_object);
-        }
-
-        remove_objects.clear();
     }
 
     /// Invalidates everything in the cache
@@ -79,6 +107,7 @@ protected:
 
     /// Register an object into the cache
     void Register(const T& object) {
+        object->SetIsRegistered(true);
         object_cache.add({GetInterval(object), ObjectSet{object}});
         auto& rasterizer = Core::System::GetInstance().Renderer().Rasterizer();
         rasterizer.UpdatePagesCachedCount(object->GetAddr(), object->GetSizeInBytes(), 1);
@@ -86,18 +115,57 @@ protected:
 
     /// Unregisters an object from the cache
     void Unregister(const T& object) {
+        object->SetIsRegistered(false);
         auto& rasterizer = Core::System::GetInstance().Renderer().Rasterizer();
         rasterizer.UpdatePagesCachedCount(object->GetAddr(), object->GetSizeInBytes(), -1);
 
+        // Only flush if use_accurate_framebuffers is enabled, as it incurs a performance hit
         if (Settings::values.use_accurate_framebuffers) {
-            // Only flush if use_accurate_framebuffers is enabled, as it incurs a performance hit
-            object->Flush();
+            FlushObject(object);
         }
 
         object_cache.subtract({GetInterval(object), ObjectSet{object}});
     }
 
+    /// Returns a ticks counter used for tracking when cached objects were last modified
+    u64 GetModifiedTicks() {
+        return ++modified_ticks;
+    }
+
 private:
+    /// Returns a list of cached objects from the specified memory region, ordered by access time
+    std::vector<T> GetSortedObjectsFromRegion(VAddr addr, u64 size) {
+        if (size == 0) {
+            return {};
+        }
+
+        std::vector<T> objects;
+        const ObjectInterval interval{addr, addr + size};
+        for (auto& pair : boost::make_iterator_range(object_cache.equal_range(interval))) {
+            for (auto& cached_object : pair.second) {
+                if (!cached_object) {
+                    continue;
+                }
+                objects.push_back(cached_object);
+            }
+        }
+
+        std::sort(objects.begin(), objects.end(), [](const T& a, const T& b) -> bool {
+            return a->GetLastModifiedTicks() < b->GetLastModifiedTicks();
+        });
+
+        return objects;
+    }
+
+    /// Flushes the specified object, updating appropriate cache state as needed
+    void FlushObject(const T& object) {
+        if (!object->IsDirty()) {
+            return;
+        }
+        object->Flush();
+        object->MarkAsModified(false, *this);
+    }
+
     using ObjectSet = std::set<T>;
     using ObjectCache = boost::icl::interval_map<VAddr, ObjectSet>;
     using ObjectInterval = typename ObjectCache::interval_type;
@@ -107,6 +175,6 @@ private:
                                           object->GetAddr() + object->GetSizeInBytes());
     }
 
-    ObjectCache object_cache;
-    ObjectSet remove_objects;
+    ObjectCache object_cache; ///< Cache of objects
+    u64 modified_ticks{};     ///< Counter of cache state ticks, used for in-order flushing
 };

--- a/src/video_core/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache.h
@@ -105,6 +105,22 @@ protected:
         return nullptr;
     }
 
+    std::vector<T> GetInRange(Tegra::GPUVAddr addr, size_t size) {
+        std::vector<T> objects;
+        if (size == 0)
+            return objects;
+
+        const ObjectInterval interval{addr, addr + size};
+        for (auto& pair : boost::make_iterator_range(object_cache.equal_range(interval))) {
+            for (auto& cached_object : pair.second) {
+                if (!cached_object)
+                    continue;
+                objects.push_back(cached_object);
+            }
+        }
+        return objects;
+    }
+
     /// Register an object into the cache
     void Register(const T& object) {
         object->SetIsRegistered(true);

--- a/src/video_core/renderer_opengl/gl_buffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.h
@@ -15,17 +15,17 @@
 
 namespace OpenGL {
 
-struct CachedBufferEntry final {
-    VAddr GetAddr() const {
+struct CachedBufferEntry final : public RasterizerCacheObject {
+    VAddr GetAddr() const override {
         return addr;
     }
 
-    std::size_t GetSizeInBytes() const {
+    std::size_t GetSizeInBytes() const override {
         return size;
     }
 
     // We do not have to flush this cache as things in it are never modified by us.
-    void Flush() {}
+    void Flush() override {}
 
     VAddr addr;
     std::size_t size;

--- a/src/video_core/renderer_opengl/gl_buffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.h
@@ -24,6 +24,9 @@ struct CachedBufferEntry final {
         return size;
     }
 
+    // We do not have to flush this cache as things in it are never modified by us.
+    void Flush() {}
+
     VAddr addr;
     std::size_t size;
     GLintptr offset;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -428,7 +428,7 @@ void RasterizerOpenGL::ConfigureFramebuffers(bool using_color_fb, bool using_dep
             if (color_surface) {
                 // Assume that a surface will be written to if it is used as a framebuffer, even if
                 // the shader doesn't actually write to it.
-                color_surface->MarkAsDirty();
+                color_surface->MarkAsModified(true, res_cache);
             }
 
             glFramebufferTexture2D(
@@ -445,7 +445,7 @@ void RasterizerOpenGL::ConfigureFramebuffers(bool using_color_fb, bool using_dep
                 if (color_surface) {
                     // Assume that a surface will be written to if it is used as a framebuffer, even
                     // if the shader doesn't actually write to it.
-                    color_surface->MarkAsDirty();
+                    color_surface->MarkAsModified(true, res_cache);
                 }
 
                 buffers[index] = GL_COLOR_ATTACHMENT0 + regs.rt_control.GetMap(index);
@@ -469,7 +469,7 @@ void RasterizerOpenGL::ConfigureFramebuffers(bool using_color_fb, bool using_dep
     if (depth_surface) {
         // Assume that a surface will be written to if it is used as a framebuffer, even if
         // the shader doesn't actually write to it.
-        depth_surface->MarkAsDirty();
+        depth_surface->MarkAsModified(true, res_cache);
 
         if (regs.stencil_enable) {
             // Attach both depth and stencil
@@ -642,9 +642,6 @@ void RasterizerOpenGL::FlushRegion(VAddr addr, u64 size) {
         // Only flush if use_accurate_framebuffers is enabled, as it incurs a performance hit
         res_cache.FlushRegion(addr, size);
     }
-
-    shader_cache.FlushRegion(addr, size);
-    buffer_cache.FlushRegion(addr, size);
 }
 
 void RasterizerOpenGL::InvalidateRegion(VAddr addr, u64 size) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -424,6 +424,13 @@ void RasterizerOpenGL::ConfigureFramebuffers(bool using_color_fb, bool using_dep
             // Used when just a single color attachment is enabled, e.g. for clearing a color buffer
             Surface color_surface =
                 res_cache.GetColorBufferSurface(*single_color_target, preserve_contents);
+
+            if (color_surface) {
+                // Assume that a surface will be written to if it is used as a framebuffer, even if
+                // the shader doesn't actually write to it.
+                color_surface->MarkAsDirty();
+            }
+
             glFramebufferTexture2D(
                 GL_DRAW_FRAMEBUFFER,
                 GL_COLOR_ATTACHMENT0 + static_cast<GLenum>(*single_color_target), GL_TEXTURE_2D,
@@ -434,6 +441,13 @@ void RasterizerOpenGL::ConfigureFramebuffers(bool using_color_fb, bool using_dep
             std::array<GLenum, Maxwell::NumRenderTargets> buffers;
             for (std::size_t index = 0; index < Maxwell::NumRenderTargets; ++index) {
                 Surface color_surface = res_cache.GetColorBufferSurface(index, preserve_contents);
+
+                if (color_surface) {
+                    // Assume that a surface will be written to if it is used as a framebuffer, even
+                    // if the shader doesn't actually write to it.
+                    color_surface->MarkAsDirty();
+                }
+
                 buffers[index] = GL_COLOR_ATTACHMENT0 + regs.rt_control.GetMap(index);
                 glFramebufferTexture2D(
                     GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0 + static_cast<GLenum>(index),
@@ -453,6 +467,10 @@ void RasterizerOpenGL::ConfigureFramebuffers(bool using_color_fb, bool using_dep
     }
 
     if (depth_surface) {
+        // Assume that a surface will be written to if it is used as a framebuffer, even if
+        // the shader doesn't actually write to it.
+        depth_surface->MarkAsDirty();
+
         if (regs.stencil_enable) {
             // Attach both depth and stencil
             glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D,
@@ -617,7 +635,12 @@ void RasterizerOpenGL::DrawArrays() {
 
 void RasterizerOpenGL::FlushAll() {}
 
-void RasterizerOpenGL::FlushRegion(VAddr addr, u64 size) {}
+void RasterizerOpenGL::FlushRegion(VAddr addr, u64 size) {
+    MICROPROFILE_SCOPE(OpenGL_CacheManagement);
+    res_cache.FlushRegion(addr, size);
+    shader_cache.FlushRegion(addr, size);
+    buffer_cache.FlushRegion(addr, size);
+}
 
 void RasterizerOpenGL::InvalidateRegion(VAddr addr, u64 size) {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
@@ -627,6 +650,7 @@ void RasterizerOpenGL::InvalidateRegion(VAddr addr, u64 size) {
 }
 
 void RasterizerOpenGL::FlushAndInvalidateRegion(VAddr addr, u64 size) {
+    FlushRegion(addr, size);
     InvalidateRegion(addr, size);
 }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -638,8 +638,8 @@ void RasterizerOpenGL::FlushAll() {}
 void RasterizerOpenGL::FlushRegion(VAddr addr, u64 size) {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
 
-    if (Settings::values.use_accurate_framebuffers) {
-        // Only flush if use_accurate_framebuffers is enabled, as it incurs a performance hit
+    if (Settings::values.use_accurate_gpu_emulation) {
+        // Only flush if use_accurate_gpu_emulation is enabled, as it incurs a performance hit
         res_cache.FlushRegion(addr, size);
     }
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -637,7 +637,12 @@ void RasterizerOpenGL::FlushAll() {}
 
 void RasterizerOpenGL::FlushRegion(VAddr addr, u64 size) {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
-    res_cache.FlushRegion(addr, size);
+
+    if (Settings::values.use_accurate_framebuffers) {
+        // Only flush if use_accurate_framebuffers is enabled, as it incurs a performance hit
+        res_cache.FlushRegion(addr, size);
+    }
+
     shader_cache.FlushRegion(addr, size);
     buffer_cache.FlushRegion(addr, size);
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -905,8 +905,6 @@ void CachedSurface::LoadGLBuffer() {
     }
 
     ConvertFormatAsNeeded_LoadGLBuffer(gl_buffer, params.pixel_format, params.width, params.height);
-
-    dirty = false;
 }
 
 MICROPROFILE_DEFINE(OpenGL_SurfaceFlush, "OpenGL", "Surface Flush", MP_RGB(128, 192, 64));
@@ -1111,6 +1109,7 @@ Surface RasterizerCacheOpenGL::GetColorBufferSurface(std::size_t index, bool pre
 void RasterizerCacheOpenGL::LoadSurface(const Surface& surface) {
     surface->LoadGLBuffer();
     surface->UploadGLTexture(read_framebuffer.handle, draw_framebuffer.handle);
+    surface->MarkAsModified(false, *this);
 }
 
 Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params, bool preserve_contents) {

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1121,10 +1121,6 @@ void RasterizerCacheOpenGL::LoadSurface(const Surface& surface) {
     surface->UploadGLTexture(read_framebuffer.handle, draw_framebuffer.handle);
 }
 
-void RasterizerCacheOpenGL::FlushSurface(const Surface& surface) {
-    surface->FlushGLBuffer();
-}
-
 Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params, bool preserve_contents) {
     if (params.addr == 0 || params.height * params.width == 0) {
         return {};

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1197,11 +1197,11 @@ Surface RasterizerCacheOpenGL::RecreateSurface(const Surface& old_surface,
 
     // If the format is the same, just do a framebuffer blit. This is significantly faster than
     // using PBOs. The is also likely less accurate, as textures will be converted rather than
-    // reinterpreted. When use_accurate_framebuffers setting is enabled, perform a more accurate
+    // reinterpreted. When use_accurate_gpu_emulation setting is enabled, perform a more accurate
     // surface copy, where pixels are reinterpreted as a new format (without conversion). This
     // code path uses OpenGL PBOs and is quite slow.
     const bool is_blit{old_params.pixel_format == new_params.pixel_format ||
-                       !Settings::values.use_accurate_framebuffers};
+                       !Settings::values.use_accurate_gpu_emulation};
 
     switch (new_params.target) {
     case SurfaceParams::SurfaceTarget::Texture2D:

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -155,6 +155,7 @@ void SurfaceParams::InitCacheParameters(Tegra::GPUVAddr gpu_addr_) {
     params.rt.index = static_cast<u32>(index);
     params.rt.array_mode = config.array_mode;
     params.rt.layer_stride = config.layer_stride;
+    params.rt.volume = config.volume;
     params.rt.base_layer = config.base_layer;
 
     params.InitCacheParameters(config.Address());
@@ -1217,6 +1218,7 @@ Surface RasterizerCacheOpenGL::RecreateSurface(const Surface& old_surface,
     const bool is_blit{old_params.pixel_format == new_params.pixel_format};
 
     switch (new_params.target) {
+    case SurfaceParams::SurfaceTarget::Texture3D:
     case SurfaceParams::SurfaceTarget::Texture2D:
         if (is_blit) {
             BlitSurface(old_surface, new_surface, read_framebuffer.handle, draw_framebuffer.handle);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1127,8 +1127,8 @@ Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params, bool pres
         } else if (preserve_contents) {
             // If surface parameters changed and we care about keeping the previous data, recreate
             // the surface from the old one
-            Unregister(surface);
             Surface new_surface{RecreateSurface(surface, params)};
+            Unregister(surface);
             Register(new_surface);
             return new_surface;
         } else {
@@ -1218,13 +1218,15 @@ Surface RasterizerCacheOpenGL::RecreateSurface(const Surface& old_surface,
     const bool is_blit{old_params.pixel_format == new_params.pixel_format};
 
     switch (new_params.target) {
-    case SurfaceParams::SurfaceTarget::Texture3D:
     case SurfaceParams::SurfaceTarget::Texture2D:
         if (is_blit) {
             BlitSurface(old_surface, new_surface, read_framebuffer.handle, draw_framebuffer.handle);
         } else {
             CopySurface(old_surface, new_surface, copy_pbo.handle);
         }
+        break;
+    case SurfaceParams::SurfaceTarget::Texture3D:
+        AccurateCopySurface(old_surface, new_surface);
         break;
     case SurfaceParams::SurfaceTarget::TextureCubemap: {
         if (old_params.rt.array_mode != 1) {

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -742,7 +742,9 @@ struct SurfaceParams {
                         other.depth);
     }
 
-    VAddr addr;
+    /// Initializes parameters for caching, should be called after everything has been initialized
+    void InitCacheParameters(Tegra::GPUVAddr gpu_addr);
+
     bool is_tiled;
     u32 block_width;
     u32 block_height;
@@ -754,10 +756,13 @@ struct SurfaceParams {
     u32 height;
     u32 depth;
     u32 unaligned_height;
-    std::size_t size_in_bytes_total;
-    std::size_t size_in_bytes_2d;
     SurfaceTarget target;
     u32 max_mip_level;
+
+    // Parameters used for caching
+    VAddr addr;
+    std::size_t size_in_bytes_total;
+    std::size_t size_in_bytes_2d;
 
     // Render target specific parameters, not used in caching
     struct {

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -802,6 +802,18 @@ public:
         return params.size_in_bytes_total;
     }
 
+    void Flush() {
+        // There is no need to flush the surface if it hasn't been modified by us.
+        if (!dirty)
+            return;
+        FlushGLBuffer();
+        dirty = false;
+    }
+
+    void MarkAsDirty() {
+        dirty = true;
+    }
+
     const OGLTexture& Texture() const {
         return texture;
     }
@@ -833,6 +845,7 @@ private:
     std::vector<u8> gl_buffer;
     SurfaceParams params;
     GLenum gl_target;
+    bool dirty = false;
 };
 
 class RasterizerCacheOpenGL final : public RasterizerCache<Surface> {

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -132,6 +132,8 @@ struct SurfaceParams {
         case Tegra::Texture::TextureType::Texture2D:
         case Tegra::Texture::TextureType::Texture2DNoMipmap:
             return SurfaceTarget::Texture2D;
+        case Tegra::Texture::TextureType::Texture3D:
+            return SurfaceTarget::Texture3D;
         case Tegra::Texture::TextureType::TextureCubemap:
             return SurfaceTarget::TextureCubemap;
         case Tegra::Texture::TextureType::Texture1DArray:
@@ -791,6 +793,7 @@ struct SurfaceParams {
     struct {
         u32 index;
         u32 array_mode;
+        u32 volume;
         u32 layer_stride;
         u32 base_layer;
     } rt;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -819,28 +819,20 @@ struct hash<SurfaceReserveKey> {
 
 namespace OpenGL {
 
-class CachedSurface final {
+class CachedSurface final : public RasterizerCacheObject {
 public:
     CachedSurface(const SurfaceParams& params);
 
-    VAddr GetAddr() const {
+    VAddr GetAddr() const override {
         return params.addr;
     }
 
-    std::size_t GetSizeInBytes() const {
+    std::size_t GetSizeInBytes() const override {
         return cached_size_in_bytes;
     }
 
-    void Flush() {
-        // There is no need to flush the surface if it hasn't been modified by us.
-        if (!dirty)
-            return;
+    void Flush() override {
         FlushGLBuffer();
-        dirty = false;
-    }
-
-    void MarkAsDirty() {
-        dirty = true;
     }
 
     const OGLTexture& Texture() const {
@@ -868,7 +860,6 @@ private:
     SurfaceParams params;
     GLenum gl_target;
     std::size_t cached_size_in_bytes;
-    bool dirty = false;
 };
 
 class RasterizerCacheOpenGL final : public RasterizerCache<Surface> {

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -701,6 +701,14 @@ struct SurfaceParams {
         return SurfaceType::Invalid;
     }
 
+    /// Returns the sizer in bytes of the specified pixel format
+    static constexpr u32 GetBytesPerPixel(PixelFormat pixel_format) {
+        if (pixel_format == SurfaceParams::PixelFormat::Invalid) {
+            return 0;
+        }
+        return GetFormatBpp(pixel_format) / CHAR_BIT;
+    }
+
     /// Returns the rectangle corresponding to this surface
     MathUtil::Rectangle<u32> GetRect() const;
 
@@ -825,13 +833,6 @@ public:
 
     GLenum Target() const {
         return gl_target;
-    }
-
-    static constexpr unsigned int GetGLBytesPerPixel(SurfaceParams::PixelFormat format) {
-        if (format == SurfaceParams::PixelFormat::Invalid)
-            return 0;
-
-        return SurfaceParams::GetFormatBpp(format) / CHAR_BIT;
     }
 
     const SurfaceParams& GetSurfaceParams() const {

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -899,6 +899,9 @@ private:
     /// Tries to get a reserved surface for the specified parameters
     Surface TryGetReservedSurface(const SurfaceParams& params);
 
+    /// Performs a slow but accurate surface copy, flushing to RAM and reinterpreting the data
+    void AccurateCopySurface(const Surface& src_surface, const Surface& dst_surface);
+
     /// The surface reserve is a "backup" cache, this is where we put unique surfaces that have
     /// previously been used. This is to prevent surfaces from being constantly created and
     /// destroyed when used with different surface parameters.

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -783,6 +783,7 @@ struct SurfaceParams {
 
     // Parameters used for caching
     VAddr addr;
+    Tegra::GPUVAddr gpu_addr;
     std::size_t size_in_bytes;
     std::size_t size_in_bytes_gl;
 
@@ -802,7 +803,8 @@ struct SurfaceReserveKey : Common::HashableStruct<OpenGL::SurfaceParams> {
     static SurfaceReserveKey Create(const OpenGL::SurfaceParams& params) {
         SurfaceReserveKey res;
         res.state = params;
-        res.state.rt = {}; // Ignore rt config in caching
+        res.state.gpu_addr = {}; // Ignore GPU vaddr in caching
+        res.state.rt = {};       // Ignore rt config in caching
         return res;
     }
 };
@@ -826,7 +828,7 @@ public:
     }
 
     std::size_t GetSizeInBytes() const {
-        return params.size_in_bytes;
+        return cached_size_in_bytes;
     }
 
     void Flush() {
@@ -865,6 +867,7 @@ private:
     std::vector<u8> gl_buffer;
     SurfaceParams params;
     GLenum gl_target;
+    std::size_t cached_size_in_bytes;
     bool dirty = false;
 };
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -867,9 +867,6 @@ public:
     /// Get the color surface based on the framebuffer configuration and the specified render target
     Surface GetColorBufferSurface(std::size_t index, bool preserve_contents);
 
-    /// Flushes the surface to Switch memory
-    void FlushSurface(const Surface& surface);
-
     /// Tries to find a framebuffer using on the provided CPU address
     Surface TryFindFramebufferSurface(VAddr addr) const;
 

--- a/src/video_core/renderer_opengl/gl_shader_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_cache.h
@@ -19,22 +19,20 @@ class CachedShader;
 using Shader = std::shared_ptr<CachedShader>;
 using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 
-class CachedShader final {
+class CachedShader final : public RasterizerCacheObject {
 public:
     CachedShader(VAddr addr, Maxwell::ShaderProgram program_type);
 
-    /// Gets the address of the shader in guest memory, required for cache management
-    VAddr GetAddr() const {
+    VAddr GetAddr() const override {
         return addr;
     }
 
-    /// Gets the size of the shader in guest memory, required for cache management
-    std::size_t GetSizeInBytes() const {
+    std::size_t GetSizeInBytes() const override {
         return GLShader::MAX_PROGRAM_CODE_LENGTH * sizeof(u64);
     }
 
     // We do not have to flush this cache as things in it are never modified by us.
-    void Flush() {}
+    void Flush() override {}
 
     /// Gets the shader entries for the shader
     const GLShader::ShaderEntries& GetShaderEntries() const {

--- a/src/video_core/renderer_opengl/gl_shader_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_cache.h
@@ -33,6 +33,9 @@ public:
         return GLShader::MAX_PROGRAM_CODE_LENGTH * sizeof(u64);
     }
 
+    // We do not have to flush this cache as things in it are never modified by us.
+    void Flush() {}
+
     /// Gets the shader entries for the shader
     const GLShader::ShaderEntries& GetShaderEntries() const {
         return entries;

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1142,6 +1142,7 @@ private:
         case Tegra::Shader::TextureType::Texture2D: {
             return 2;
         }
+        case Tegra::Shader::TextureType::Texture3D:
         case Tegra::Shader::TextureType::TextureCube: {
             return 3;
         }

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -85,8 +85,8 @@ void Config::ReadValues() {
     Settings::values.resolution_factor = qt_config->value("resolution_factor", 1.0).toFloat();
     Settings::values.use_frame_limit = qt_config->value("use_frame_limit", true).toBool();
     Settings::values.frame_limit = qt_config->value("frame_limit", 100).toInt();
-    Settings::values.use_accurate_framebuffers =
-        qt_config->value("use_accurate_framebuffers", false).toBool();
+    Settings::values.use_accurate_gpu_emulation =
+        qt_config->value("use_accurate_gpu_emulation", false).toBool();
 
     Settings::values.bg_red = qt_config->value("bg_red", 0.0).toFloat();
     Settings::values.bg_green = qt_config->value("bg_green", 0.0).toFloat();
@@ -233,7 +233,7 @@ void Config::SaveValues() {
     qt_config->setValue("resolution_factor", (double)Settings::values.resolution_factor);
     qt_config->setValue("use_frame_limit", Settings::values.use_frame_limit);
     qt_config->setValue("frame_limit", Settings::values.frame_limit);
-    qt_config->setValue("use_accurate_framebuffers", Settings::values.use_accurate_framebuffers);
+    qt_config->setValue("use_accurate_gpu_emulation", Settings::values.use_accurate_gpu_emulation);
 
     // Cast to double because Qt's written float values are not human-readable
     qt_config->setValue("bg_red", (double)Settings::values.bg_red);

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -75,7 +75,7 @@ void ConfigureGraphics::setConfiguration() {
         static_cast<int>(FromResolutionFactor(Settings::values.resolution_factor)));
     ui->toggle_frame_limit->setChecked(Settings::values.use_frame_limit);
     ui->frame_limit->setValue(Settings::values.frame_limit);
-    ui->use_accurate_framebuffers->setChecked(Settings::values.use_accurate_framebuffers);
+    ui->use_accurate_gpu_emulation->setChecked(Settings::values.use_accurate_gpu_emulation);
     bg_color = QColor::fromRgbF(Settings::values.bg_red, Settings::values.bg_green,
                                 Settings::values.bg_blue);
     ui->bg_button->setStyleSheet(
@@ -87,7 +87,7 @@ void ConfigureGraphics::applyConfiguration() {
         ToResolutionFactor(static_cast<Resolution>(ui->resolution_factor_combobox->currentIndex()));
     Settings::values.use_frame_limit = ui->toggle_frame_limit->isChecked();
     Settings::values.frame_limit = ui->frame_limit->value();
-    Settings::values.use_accurate_framebuffers = ui->use_accurate_framebuffers->isChecked();
+    Settings::values.use_accurate_gpu_emulation = ui->use_accurate_gpu_emulation->isChecked();
     Settings::values.bg_red = static_cast<float>(bg_color.redF());
     Settings::values.bg_green = static_cast<float>(bg_color.greenF());
     Settings::values.bg_blue = static_cast<float>(bg_color.blueF());

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -50,9 +50,9 @@
           </layout>
         </item>
         <item>
-         <widget class="QCheckBox" name="use_accurate_framebuffers">
+         <widget class="QCheckBox" name="use_accurate_gpu_emulation">
           <property name="text">
-           <string>Use accurate framebuffers (slow)</string>
+           <string>Use accurate GPU emulation (slow)</string>
           </property>
          </widget>
         </item>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -99,8 +99,8 @@ void Config::ReadValues() {
     Settings::values.use_frame_limit = sdl2_config->GetBoolean("Renderer", "use_frame_limit", true);
     Settings::values.frame_limit =
         static_cast<u16>(sdl2_config->GetInteger("Renderer", "frame_limit", 100));
-    Settings::values.use_accurate_framebuffers =
-        sdl2_config->GetBoolean("Renderer", "use_accurate_framebuffers", false);
+    Settings::values.use_accurate_gpu_emulation =
+        sdl2_config->GetBoolean("Renderer", "use_accurate_gpu_emulation", false);
 
     Settings::values.bg_red = (float)sdl2_config->GetReal("Renderer", "bg_red", 0.0);
     Settings::values.bg_green = (float)sdl2_config->GetReal("Renderer", "bg_green", 0.0);

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -110,9 +110,9 @@ use_frame_limit =
 # 1 - 9999: Speed limit as a percentage of target game speed. 100 (default)
 frame_limit =
 
-# Whether to use accurate framebuffers
+# Whether to use accurate GPU emulation
 # 0 (default): Off (fast), 1 : On (slow)
-use_accurate_framebuffers =
+use_accurate_gpu_emulation =
 
 # The clear color for the renderer. What shows up on the sides of the bottom screen.
 # Must be in range of 0.0-1.0. Defaults to 1.0 for all.


### PR DESCRIPTION
This PR is experimental and should only be used for testing purposes.

This PR is less hacky than what we had before but there's still issues. In general, this PR tries to load cubemaps assuming a different layout where there's a magic_number of bytes (0x6000) between each face of a cubemap. This layout was obtained from hardware and generated cubemaps appear to respond positively to this change (they are now correctly aligned and loaded). Sadly the magic number repeats itself because the tested textures were all 128x128x4bytes, further testing is required to figure if the number is a constant or if it's calculateable based on address or size.

In SMO there's still an issue with some cubemaps but this is caused by the layers not being rendered correctly at all. Please test in other games and let me know.

Based on #1505