### PR TITLE
GPU/DMA: Flush the source region and invalidate the destination region when doing a DMA transfer.

### DIFF
--- a/src/video_core/engines/kepler_memory.cpp
+++ b/src/video_core/engines/kepler_memory.cpp
@@ -5,10 +5,14 @@
 #include "common/logging/log.h"
 #include "core/memory.h"
 #include "video_core/engines/kepler_memory.h"
+#include "video_core/rasterizer_interface.h"
 
 namespace Tegra::Engines {
 
-KeplerMemory::KeplerMemory(MemoryManager& memory_manager) : memory_manager(memory_manager) {}
+KeplerMemory::KeplerMemory(VideoCore::RasterizerInterface& rasterizer,
+                           MemoryManager& memory_manager)
+    : memory_manager(memory_manager), rasterizer{rasterizer} {}
+
 KeplerMemory::~KeplerMemory() = default;
 
 void KeplerMemory::WriteReg(u32 method, u32 value) {
@@ -36,6 +40,11 @@ void KeplerMemory::ProcessData(u32 data) {
     GPUVAddr address = regs.dest.Address();
     VAddr dest_address =
         *memory_manager.GpuToCpuAddress(address + state.write_offset * sizeof(u32));
+
+    // We have to invalidate the destination region to evict any outdated surfaces from the cache.
+    // We do this before actually writing the new data because the destination address might contain
+    // a dirty surface that will have to be written back to memory.
+    rasterizer.InvalidateRegion(dest_address, sizeof(u32));
 
     Memory::Write32(dest_address, data);
 

--- a/src/video_core/engines/kepler_memory.h
+++ b/src/video_core/engines/kepler_memory.h
@@ -11,6 +11,10 @@
 #include "common/common_types.h"
 #include "video_core/memory_manager.h"
 
+namespace VideoCore {
+class RasterizerInterface;
+}
+
 namespace Tegra::Engines {
 
 #define KEPLERMEMORY_REG_INDEX(field_name)                                                         \
@@ -18,7 +22,7 @@ namespace Tegra::Engines {
 
 class KeplerMemory final {
 public:
-    KeplerMemory(MemoryManager& memory_manager);
+    KeplerMemory(VideoCore::RasterizerInterface& rasterizer, MemoryManager& memory_manager);
     ~KeplerMemory();
 
     /// Write the value to the register identified by method.
@@ -72,6 +76,7 @@ public:
 
 private:
     MemoryManager& memory_manager;
+    VideoCore::RasterizerInterface& rasterizer;
 
     void ProcessData(u32 data);
 };

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -4,12 +4,14 @@
 
 #include "core/memory.h"
 #include "video_core/engines/maxwell_dma.h"
+#include "video_core/rasterizer_interface.h"
 #include "video_core/textures/decoders.h"
 
 namespace Tegra {
 namespace Engines {
 
-MaxwellDMA::MaxwellDMA(MemoryManager& memory_manager) : memory_manager(memory_manager) {}
+MaxwellDMA::MaxwellDMA(VideoCore::RasterizerInterface& rasterizer, MemoryManager& memory_manager)
+    : memory_manager(memory_manager), rasterizer{rasterizer} {}
 
 void MaxwellDMA::WriteReg(u32 method, u32 value) {
     ASSERT_MSG(method < Regs::NUM_REGS,
@@ -44,38 +46,79 @@ void MaxwellDMA::HandleCopy() {
     ASSERT(regs.exec.query_mode == Regs::QueryMode::None);
     ASSERT(regs.exec.query_intr == Regs::QueryIntr::None);
     ASSERT(regs.exec.copy_mode == Regs::CopyMode::Unk2);
-    ASSERT(regs.src_params.pos_x == 0);
-    ASSERT(regs.src_params.pos_y == 0);
     ASSERT(regs.dst_params.pos_x == 0);
     ASSERT(regs.dst_params.pos_y == 0);
 
-    if (regs.exec.is_dst_linear == regs.exec.is_src_linear) {
-        std::size_t copy_size = regs.x_count;
+    if (!regs.exec.is_dst_linear && !regs.exec.is_src_linear) {
+        // If both the source and the destination are in block layout, assert.
+        UNREACHABLE_MSG("Tiled->Tiled DMA transfers are not yet implemented");
+        return;
+    }
 
+    if (regs.exec.is_dst_linear && regs.exec.is_src_linear) {
         // When the enable_2d bit is disabled, the copy is performed as if we were copying a 1D
-        // buffer of length `x_count`, otherwise we copy a 2D buffer of size (x_count, y_count).
-        if (regs.exec.enable_2d) {
-            copy_size = copy_size * regs.y_count;
+        // buffer of length `x_count`, otherwise we copy a 2D image of dimensions (x_count,
+        // y_count).
+        if (!regs.exec.enable_2d) {
+            Memory::CopyBlock(dest_cpu, source_cpu, regs.x_count);
+            return;
         }
 
-        Memory::CopyBlock(dest_cpu, source_cpu, copy_size);
+        // If both the source and the destination are in linear layout, perform a line-by-line
+        // copy. We're going to take a subrect of size (x_count, y_count) from the source
+        // rectangle. There is no need to manually flush/invalidate the regions because
+        // CopyBlock does that for us.
+        for (u32 line = 0; line < regs.y_count; ++line) {
+            const VAddr source_line = source_cpu + line * regs.src_pitch;
+            const VAddr dest_line = dest_cpu + line * regs.dst_pitch;
+            Memory::CopyBlock(dest_line, source_line, regs.x_count);
+        }
         return;
     }
 
     ASSERT(regs.exec.enable_2d == 1);
+
+    std::size_t copy_size = regs.x_count * regs.y_count;
+
+    const auto FlushAndInvalidate = [&](u32 src_size, u32 dst_size) {
+        // TODO(Subv): For now, manually flush the regions until we implement GPU-accelerated
+        // copying.
+        rasterizer.FlushRegion(source_cpu, src_size);
+
+        // We have to invalidate the destination region to evict any outdated surfaces from the
+        // cache. We do this before actually writing the new data because the destination address
+        // might contain a dirty surface that will have to be written back to memory.
+        rasterizer.InvalidateRegion(dest_cpu, dst_size);
+    };
+
     u8* src_buffer = Memory::GetPointer(source_cpu);
     u8* dst_buffer = Memory::GetPointer(dest_cpu);
 
     if (regs.exec.is_dst_linear && !regs.exec.is_src_linear) {
+        ASSERT(regs.src_params.size_z == 1);
         // If the input is tiled and the output is linear, deswizzle the input and copy it over.
-        Texture::CopySwizzledData(regs.src_params.size_x, regs.src_params.size_y,
-                                  regs.src_params.size_z, 1, 1, src_buffer, dst_buffer, true,
-                                  regs.src_params.BlockHeight(), regs.src_params.BlockDepth());
+
+        u32 src_bytes_per_pixel = regs.src_pitch / regs.src_params.size_x;
+
+        FlushAndInvalidate(regs.src_pitch * regs.src_params.size_y,
+                           copy_size * src_bytes_per_pixel);
+
+        Texture::UnswizzleSubrect(regs.x_count, regs.y_count, regs.dst_pitch,
+                                  regs.src_params.size_x, src_bytes_per_pixel, source_cpu, dest_cpu,
+                                  regs.src_params.BlockHeight(), regs.src_params.pos_x,
+                                  regs.src_params.pos_y);
     } else {
+        ASSERT(regs.dst_params.size_z == 1);
+        ASSERT(regs.src_pitch == regs.x_count);
+
+        u32 src_bpp = regs.src_pitch / regs.x_count;
+
+        FlushAndInvalidate(regs.src_pitch * regs.y_count,
+                           regs.dst_params.size_x * regs.dst_params.size_y * src_bpp);
+
         // If the input is linear and the output is tiled, swizzle the input and copy it over.
-        Texture::CopySwizzledData(regs.dst_params.size_x, regs.dst_params.size_y,
-                                  regs.dst_params.size_z, 1, 1, dst_buffer, src_buffer, false,
-                                  regs.dst_params.BlockHeight(), regs.dst_params.BlockDepth());
+        Texture::SwizzleSubrect(regs.x_count, regs.y_count, regs.src_pitch, regs.dst_params.size_x,
+                                src_bpp, dest_cpu, source_cpu, regs.dst_params.BlockHeight());
     }
 }
 

--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -12,11 +12,15 @@
 #include "video_core/gpu.h"
 #include "video_core/memory_manager.h"
 
+namespace VideoCore {
+class RasterizerInterface;
+}
+
 namespace Tegra::Engines {
 
 class MaxwellDMA final {
 public:
-    explicit MaxwellDMA(MemoryManager& memory_manager);
+    explicit MaxwellDMA(VideoCore::RasterizerInterface& rasterizer, MemoryManager& memory_manager);
     ~MaxwellDMA() = default;
 
     /// Write the value to the register identified by method.
@@ -133,6 +137,8 @@ public:
     MemoryManager& memory_manager;
 
 private:
+    VideoCore::RasterizerInterface& rasterizer;
+
     /// Performs the copy from the source buffer to the destination buffer as configured in the
     /// registers.
     void HandleCopy();

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -27,7 +27,7 @@ GPU::GPU(VideoCore::RasterizerInterface& rasterizer) {
     maxwell_3d = std::make_unique<Engines::Maxwell3D>(rasterizer, *memory_manager);
     fermi_2d = std::make_unique<Engines::Fermi2D>(rasterizer, *memory_manager);
     maxwell_compute = std::make_unique<Engines::MaxwellCompute>();
-    maxwell_dma = std::make_unique<Engines::MaxwellDMA>(*memory_manager);
+    maxwell_dma = std::make_unique<Engines::MaxwellDMA>(rasterizer, *memory_manager);
     kepler_memory = std::make_unique<Engines::KeplerMemory>(rasterizer, *memory_manager);
 }
 

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -28,7 +28,7 @@ GPU::GPU(VideoCore::RasterizerInterface& rasterizer) {
     fermi_2d = std::make_unique<Engines::Fermi2D>(rasterizer, *memory_manager);
     maxwell_compute = std::make_unique<Engines::MaxwellCompute>();
     maxwell_dma = std::make_unique<Engines::MaxwellDMA>(*memory_manager);
-    kepler_memory = std::make_unique<Engines::KeplerMemory>(*memory_manager);
+    kepler_memory = std::make_unique<Engines::KeplerMemory>(rasterizer, *memory_manager);
 }
 
 GPU::~GPU() = default;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -659,6 +659,12 @@ void RasterizerOpenGL::FlushAndInvalidateRegion(VAddr addr, u64 size) {
 bool RasterizerOpenGL::AccelerateSurfaceCopy(const Tegra::Engines::Fermi2D::Regs::Surface& src,
                                              const Tegra::Engines::Fermi2D::Regs::Surface& dst) {
     MICROPROFILE_SCOPE(OpenGL_Blits);
+
+    if (Settings::values.use_accurate_gpu_emulation) {
+        // Skip the accelerated copy and perform a slow but more accurate copy
+        return false;
+    }
+
     res_cache.FermiCopySurface(src, dst);
     return true;
 }

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -237,6 +237,46 @@ std::vector<u8> UnswizzleTexture(VAddr address, u32 tile_size, u32 bytes_per_pix
     return unswizzled_data;
 }
 
+void SwizzleSubrect(u32 subrect_width, u32 subrect_height, u32 source_pitch, u32 swizzled_width,
+                    u32 bytes_per_pixel, VAddr swizzled_data, VAddr unswizzled_data,
+                    u32 block_height) {
+    const u32 image_width_in_gobs{(swizzled_width * bytes_per_pixel + 63) / 64};
+    for (u32 line = 0; line < subrect_height; ++line) {
+        const u32 gob_address_y =
+            (line / (8 * block_height)) * 512 * block_height * image_width_in_gobs +
+            (line % (8 * block_height) / 8) * 512;
+        const auto& table = legacy_swizzle_table[line % 8];
+        for (u32 x = 0; x < subrect_width; ++x) {
+            const u32 gob_address = gob_address_y + (x * bytes_per_pixel / 64) * 512 * block_height;
+            const u32 swizzled_offset = gob_address + table[(x * bytes_per_pixel) % 64];
+            const VAddr source_line = unswizzled_data + line * source_pitch + x * bytes_per_pixel;
+            const VAddr dest_addr = swizzled_data + swizzled_offset;
+
+            Memory::CopyBlock(dest_addr, source_line, bytes_per_pixel);
+        }
+    }
+}
+
+void UnswizzleSubrect(u32 subrect_width, u32 subrect_height, u32 dest_pitch, u32 swizzled_width,
+                      u32 bytes_per_pixel, VAddr swizzled_data, VAddr unswizzled_data,
+                      u32 block_height, u32 offset_x, u32 offset_y) {
+    for (u32 line = 0; line < subrect_height; ++line) {
+        const u32 y2 = line + offset_y;
+        const u32 gob_address_y =
+            (y2 / (8 * block_height)) * 512 * block_height + (y2 % (8 * block_height) / 8) * 512;
+        const auto& table = legacy_swizzle_table[y2 % 8];
+        for (u32 x = 0; x < subrect_width; ++x) {
+            const u32 x2 = (x + offset_x) * bytes_per_pixel;
+            const u32 gob_address = gob_address_y + (x2 / 64) * 512 * block_height;
+            const u32 swizzled_offset = gob_address + table[x2 % 64];
+            const VAddr dest_line = unswizzled_data + line * dest_pitch + x * bytes_per_pixel;
+            const VAddr source_addr = swizzled_data + swizzled_offset;
+
+            Memory::CopyBlock(dest_line, source_addr, bytes_per_pixel);
+        }
+    }
+}
+
 std::vector<u8> DecodeTexture(const std::vector<u8>& texture_data, TextureFormat format, u32 width,
                               u32 height) {
     std::vector<u8> rgba_data;

--- a/src/video_core/textures/decoders.h
+++ b/src/video_core/textures/decoders.h
@@ -35,4 +35,13 @@ std::vector<u8> DecodeTexture(const std::vector<u8>& texture_data, TextureFormat
 std::size_t CalculateSize(bool tiled, u32 bytes_per_pixel, u32 width, u32 height, u32 depth,
                           u32 block_height, u32 block_depth);
 
+/// Copies an untiled subrectangle into a tiled surface.
+void SwizzleSubrect(u32 subrect_width, u32 subrect_height, u32 source_pitch, u32 swizzled_width,
+                    u32 bytes_per_pixel, VAddr swizzled_data, VAddr unswizzled_data,
+                    u32 block_height);
+/// Copies a tiled subrectangle into a linear surface.
+void UnswizzleSubrect(u32 subrect_width, u32 subrect_height, u32 dest_pitch, u32 swizzled_width,
+                      u32 bytes_per_pixel, VAddr swizzled_data, VAddr unswizzled_data,
+                      u32 block_height, u32 offset_x, u32 offset_y);
+
 } // namespace Tegra::Texture


### PR DESCRIPTION
Implements the rest of #1339, using the recently merged flushing code from #1497. Some of this is behind the `use_accurate_gpu_emulation` setting (as otherwise, we avoid flushing in many cases). This is mostly ported over as-is, and needs some testing - I'm not sure what games actually use this
In particular, let me know if there are things that do not work with the `use_accurate_gpu_emulation` setting turned off, and I will try to debug/fix. Also, please let me know if there are any major perf regressions (again, with the setting turned off).

cc @Hexagon12 to assist with testing.
cc @FernandoS27 to improve the swizzle code here, this is based on our old swizzling.
cc @Subv, purely FYI.