### PR TITLE
settings: Add support for per game configuration

### DIFF
--- a/src/audio_core/audio_out.cpp
+++ b/src/audio_core/audio_out.cpp
@@ -30,8 +30,8 @@ static Stream::Format ChannelsToStreamFormat(u32 num_channels) {
 StreamPtr AudioOut::OpenStream(u32 sample_rate, u32 num_channels, std::string&& name,
                                Stream::ReleaseCallback&& release_callback) {
     if (!sink) {
-        const SinkDetails& sink_details = GetSinkDetails(Settings::values.sink_id);
-        sink = sink_details.factory(Settings::values.audio_device_id);
+        const SinkDetails& sink_details = GetSinkDetails(Settings::values->sink_id);
+        sink = sink_details.factory(Settings::values->audio_device_id);
     }
 
     return std::make_shared<Stream>(

--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -163,7 +163,7 @@ long CubebSinkStream::DataCallback(cubeb_stream* stream, void* user_data, const 
     const std::size_t samples_to_write = num_channels * num_frames;
     std::size_t samples_written;
 
-    if (Settings::values.enable_audio_stretching) {
+    if (Settings::values->enable_audio_stretching) {
         const std::vector<s16> in{impl->queue.Pop()};
         const std::size_t num_in{in.size() / num_channels};
         s16* const out{reinterpret_cast<s16*>(buffer)};

--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -63,7 +63,7 @@ s64 Stream::GetBufferReleaseCycles(const Buffer& buffer) const {
 }
 
 static void VolumeAdjustSamples(std::vector<s16>& samples) {
-    const float volume{std::clamp(Settings::values.volume, 0.0f, 1.0f)};
+    const float volume{std::clamp(Settings::values->volume, 0.0f, 1.0f)};
 
     if (volume == 1.0f) {
         return;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -38,7 +38,6 @@ namespace Core {
 
 /*static*/ System System::s_instance;
 
-namespace {
 FileSys::VirtualFile GetGameFileFromPath(const FileSys::VirtualFilesystem& vfs,
                                          const std::string& path) {
     // To account for split 00+01+etc files.
@@ -70,6 +69,7 @@ FileSys::VirtualFile GetGameFileFromPath(const FileSys::VirtualFilesystem& vfs,
     return vfs->OpenFile(path, FileSys::Mode::Read);
 }
 
+namespace {
 /// Runs a CPU core while the system is powered on
 void RunCpuCore(Cpu& cpu_state) {
     while (Core::System::GetInstance().IsPoweredOn()) {

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -136,6 +136,11 @@ struct System::Impl {
         if (virtual_filesystem == nullptr)
             virtual_filesystem = std::make_shared<FileSys::RealVfsFilesystem>();
 
+        // Force update title ID for per game settings in case any services use them
+        u64 title_id;
+        if (app_loader->ReadProgramId(title_id) == Loader::ResultStatus::Success)
+            Settings::values.SetCurrentTitleID(title_id);
+
         auto main_process = Kernel::Process::Create(kernel, "main");
         kernel.MakeCurrentProcess(main_process.get());
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -137,9 +137,11 @@ struct System::Impl {
             virtual_filesystem = std::make_shared<FileSys::RealVfsFilesystem>();
 
         // Force update title ID for per game settings in case any services use them
-        u64 title_id;
+        u64 title_id = 0;
         if (app_loader->ReadProgramId(title_id) == Loader::ResultStatus::Success)
             Settings::values.SetCurrentTitleID(title_id);
+        else
+            Settings::values.SetCurrentTitleID(Settings::DEFAULT_PER_GAME);
 
         // Write config to log
         Settings::values->LogSettings();

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -141,6 +141,9 @@ struct System::Impl {
         if (app_loader->ReadProgramId(title_id) == Loader::ResultStatus::Success)
             Settings::values.SetCurrentTitleID(title_id);
 
+        // Write config to log
+        Settings::values->LogSettings();
+
         auto main_process = Kernel::Process::Create(kernel, "main");
         kernel.MakeCurrentProcess(main_process.get());
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -9,6 +9,7 @@
 #include <string>
 
 #include "common/common_types.h"
+#include "core/file_sys/vfs_types.h"
 #include "core/hle/kernel/object.h"
 
 namespace Core::Frontend {
@@ -53,6 +54,9 @@ class PerfStats;
 class TelemetrySession;
 
 struct PerfStatsResults;
+
+FileSys::VirtualFile GetGameFileFromPath(const FileSys::VirtualFilesystem& vfs,
+                                         const std::string& path);
 
 class System {
 public:

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -30,6 +30,8 @@ public:
     explicit PatchManager(u64 title_id);
     ~PatchManager();
 
+    u64 GetTitleID() const;
+
     // Currently tracked ExeFS patches:
     // - Game Updates
     VirtualDir PatchExeFS(VirtualDir exefs) const;
@@ -63,6 +65,9 @@ public:
     std::pair<std::unique_ptr<NACP>, VirtualFile> ParseControlNCA(const NCA& nca) const;
 
 private:
+    std::vector<VirtualFile> CollectPatches(const std::vector<VirtualDir>& patch_dirs,
+                                            const std::string& build_id) const;
+
     u64 title_id;
 };
 

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -427,7 +427,7 @@ void ICommonStateGetter::GetDefaultDisplayResolution(Kernel::HLERequestContext& 
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
 
-    if (Settings::values.use_docked_mode) {
+    if (Settings::values->use_docked_mode) {
         rb.Push(static_cast<u32>(Service::VI::DisplayResolution::DockedWidth));
         rb.Push(static_cast<u32>(Service::VI::DisplayResolution::DockedHeight));
     } else {
@@ -439,7 +439,7 @@ void ICommonStateGetter::GetDefaultDisplayResolution(Kernel::HLERequestContext& 
 }
 
 void ICommonStateGetter::GetOperationMode(Kernel::HLERequestContext& ctx) {
-    const bool use_docked_mode{Settings::values.use_docked_mode};
+    const bool use_docked_mode{Settings::values->use_docked_mode};
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.Push(static_cast<u8>(use_docked_mode ? OperationMode::Docked : OperationMode::Handheld));
@@ -448,7 +448,7 @@ void ICommonStateGetter::GetOperationMode(Kernel::HLERequestContext& ctx) {
 }
 
 void ICommonStateGetter::GetPerformanceMode(Kernel::HLERequestContext& ctx) {
-    const bool use_docked_mode{Settings::values.use_docked_mode};
+    const bool use_docked_mode{Settings::values->use_docked_mode};
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.Push(static_cast<u32>(use_docked_mode ? APM::PerformanceMode::Docked

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -18,6 +18,7 @@
 #include "core/hle/service/aoc/aoc_u.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/loader/loader.h"
+#include "core/settings.h"
 
 namespace Service::AOC {
 
@@ -72,6 +73,13 @@ void AOC_U::CountAddOnContent(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
 
     const auto current = Core::System::GetInstance().CurrentProcess()->GetTitleID();
+
+    const auto& disabled = Settings::values[current].disabled_patches;
+    if (std::find(disabled.begin(), disabled.end(), "DLC") != disabled.end()) {
+        rb.Push<u32>(0);
+        return;
+    }
+
     rb.Push<u32>(static_cast<u32>(
         std::count_if(add_on_content.begin(), add_on_content.end(),
                       [current](u64 tid) { return CheckAOCTitleIDMatchesBase(tid, current); })));
@@ -90,6 +98,10 @@ void AOC_U::ListAddOnContent(Kernel::HLERequestContext& ctx) {
         if ((add_on_content[i] & DLC_BASE_TITLE_ID_MASK) == current)
             out.push_back(static_cast<u32>(add_on_content[i] & 0x7FF));
     }
+
+    const auto& disabled = Settings::values[current].disabled_patches;
+    if (std::find(disabled.begin(), disabled.end(), "DLC") != disabled.end())
+        out = {};
 
     if (out.size() < offset) {
         IPC::ResponseBuilder rb{ctx, 2};

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -131,11 +131,11 @@ void Controller_NPad::OnInit() {
 }
 
 void Controller_NPad::OnLoadInputDevices() {
-    std::transform(Settings::values.buttons.begin() + Settings::NativeButton::BUTTON_HID_BEGIN,
-                   Settings::values.buttons.begin() + Settings::NativeButton::BUTTON_HID_END,
+    std::transform(Settings::values->buttons.begin() + Settings::NativeButton::BUTTON_HID_BEGIN,
+                   Settings::values->buttons.begin() + Settings::NativeButton::BUTTON_HID_END,
                    buttons.begin(), Input::CreateDevice<Input::ButtonDevice>);
-    std::transform(Settings::values.analogs.begin() + Settings::NativeAnalog::STICK_HID_BEGIN,
-                   Settings::values.analogs.begin() + Settings::NativeAnalog::STICK_HID_END,
+    std::transform(Settings::values->analogs.begin() + Settings::NativeAnalog::STICK_HID_BEGIN,
+                   Settings::values->analogs.begin() + Settings::NativeAnalog::STICK_HID_END,
                    sticks.begin(), Input::CreateDevice<Input::AnalogDevice>);
 }
 
@@ -289,7 +289,7 @@ void Controller_NPad::OnUpdate(u8* data, std::size_t data_len) {
         case NPadControllerType::Handheld:
             handheld_entry.connection_status.raw = 0;
             handheld_entry.connection_status.IsConnected.Assign(1);
-            if (!Settings::values.use_docked_mode) {
+            if (!Settings::values->use_docked_mode) {
                 handheld_entry.connection_status.IsWired.Assign(1);
             }
             handheld_entry.pad_states.raw = pad_state.raw;

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -504,7 +504,7 @@ bool Controller_NPad::IsControllerSupported(NPadControllerType controller) const
             return false;
         }
         // Handheld should not be supported in docked mode
-        if (Settings::values.use_docked_mode) {
+        if (Settings::values->use_docked_mode) {
             return false;
         }
 
@@ -535,7 +535,7 @@ Controller_NPad::NPadControllerType Controller_NPad::DecideBestController(
     if (IsControllerSupported(priority)) {
         return priority;
     }
-    const auto is_docked = Settings::values.use_docked_mode;
+    const auto is_docked = Settings::values->use_docked_mode;
     if (is_docked && priority == NPadControllerType::Handheld) {
         priority = NPadControllerType::JoyDual;
         if (IsControllerSupported(priority)) {

--- a/src/core/hle/service/hid/controllers/touchscreen.cpp
+++ b/src/core/hle/service/hid/controllers/touchscreen.cpp
@@ -60,6 +60,6 @@ void Controller_Touchscreen::OnUpdate(u8* data, std::size_t size) {
 }
 
 void Controller_Touchscreen::OnLoadInputDevices() {
-    touch_device = Input::CreateDevice<Input::TouchDevice>(Settings::values.touch_device);
+    touch_device = Input::CreateDevice<Input::TouchDevice>(Settings::values->touch_device);
 }
 } // namespace Service::HID

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -668,7 +668,7 @@ private:
         IPC::ResponseBuilder rb{ctx, 6};
         rb.Push(RESULT_SUCCESS);
 
-        if (Settings::values.use_docked_mode) {
+        if (Settings::values->use_docked_mode) {
             rb.Push(static_cast<u32>(Service::VI::DisplayResolution::DockedWidth));
             rb.Push(static_cast<u32>(Service::VI::DisplayResolution::DockedHeight));
         } else {
@@ -877,7 +877,7 @@ private:
         IPC::ResponseBuilder rb{ctx, 6};
         rb.Push(RESULT_SUCCESS);
 
-        if (Settings::values.use_docked_mode) {
+        if (Settings::values->use_docked_mode) {
             rb.Push(static_cast<u64>(DisplayResolution::DockedWidth));
             rb.Push(static_cast<u64>(DisplayResolution::DockedHeight));
         } else {

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -252,6 +252,10 @@ public:
         return ResultStatus::ErrorNotImplemented;
     }
 
+    FileSys::VirtualFile GetFile() {
+        return file;
+    }
+
 protected:
     FileSys::VirtualFile file;
     bool is_loaded = false;

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -11,6 +11,7 @@
 #include <vector>
 #include <boost/optional.hpp>
 #include "common/common_types.h"
+#include "core/file_sys/control_metadata.h"
 #include "core/file_sys/vfs.h"
 
 namespace Kernel {
@@ -239,6 +240,15 @@ public:
      * @return ResultStatus result of function
      */
     virtual ResultStatus ReadTitle(std::string& title) {
+        return ResultStatus::ErrorNotImplemented;
+    }
+
+    /**
+     * Get the developer of the application
+     * @param developer Reference to store the application developer into
+     * @return ResultStatus result of function
+     */
+    virtual ResultStatus ReadDeveloper(std::string& developer) {
         return ResultStatus::ErrorNotImplemented;
     }
 

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -150,8 +150,8 @@ bool AppLoader_NRO::LoadNro(const FileSys::VfsFile& file, VAddr load_base) {
         codeset.segments[i].size = PageAlignSize(nro_header.segments[i].size);
     }
 
-    if (!Settings::values.program_args.empty()) {
-        const auto arg_data = Settings::values.program_args;
+    if (!Settings::values->program_args.empty()) {
+        const auto arg_data = Settings::values->program_args;
         codeset.DataSegment().size += NSO_ARGUMENT_DATA_ALLOCATION_SIZE;
         NSOArgumentHeader args_header{
             NSO_ARGUMENT_DATA_ALLOCATION_SIZE, static_cast<u32_le>(arg_data.size()), {}};

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -122,8 +122,8 @@ std::optional<VAddr> AppLoader_NSO::LoadModule(const FileSys::VfsFile& file, VAd
         codeset.segments[i].size = PageAlignSize(static_cast<u32>(data.size()));
     }
 
-    if (should_pass_arguments && !Settings::values.program_args.empty()) {
-        const auto arg_data = Settings::values.program_args;
+    if (should_pass_arguments && !Settings::values->program_args.empty()) {
+        const auto arg_data = Settings::values->program_args;
         codeset.DataSegment().size += NSO_ARGUMENT_DATA_ALLOCATION_SIZE;
         NSOArgumentHeader args_header{
             NSO_ARGUMENT_DATA_ALLOCATION_SIZE, static_cast<u32_le>(arg_data.size()), {}};

--- a/src/core/loader/nsp.cpp
+++ b/src/core/loader/nsp.cpp
@@ -148,4 +148,11 @@ ResultStatus AppLoader_NSP::ReadTitle(std::string& title) {
     title = nacp_file->GetApplicationName();
     return ResultStatus::Success;
 }
+
+ResultStatus AppLoader_NSP::ReadDeveloper(std::string& developer) {
+    if (nacp_file == nullptr)
+        return ResultStatus::ErrorNoControl;
+    developer = nacp_file->GetDeveloperName();
+    return ResultStatus::Success;
+}
 } // namespace Loader

--- a/src/core/loader/nsp.h
+++ b/src/core/loader/nsp.h
@@ -43,6 +43,7 @@ public:
     ResultStatus ReadProgramId(u64& out_program_id) override;
     ResultStatus ReadIcon(std::vector<u8>& buffer) override;
     ResultStatus ReadTitle(std::string& title) override;
+    ResultStatus ReadDeveloper(std::string& developer) override;
 
 private:
     std::unique_ptr<FileSys::NSP> nsp;

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -120,4 +120,11 @@ ResultStatus AppLoader_XCI::ReadTitle(std::string& title) {
     title = nacp_file->GetApplicationName();
     return ResultStatus::Success;
 }
+
+ResultStatus AppLoader_XCI::ReadDeveloper(std::string& developer) {
+    if (nacp_file == nullptr)
+        return ResultStatus::ErrorNoControl;
+    developer = nacp_file->GetDeveloperName();
+    return ResultStatus::Success;
+}
 } // namespace Loader

--- a/src/core/loader/xci.h
+++ b/src/core/loader/xci.h
@@ -43,6 +43,7 @@ public:
     ResultStatus ReadProgramId(u64& out_program_id) override;
     ResultStatus ReadIcon(std::vector<u8>& buffer) override;
     ResultStatus ReadTitle(std::string& title) override;
+    ResultStatus ReadDeveloper(std::string& developer) override;
 
 private:
     std::unique_ptr<FileSys::XCI> xci;

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -74,7 +74,7 @@ double PerfStats::GetLastFrameTimeScale() {
 }
 
 void FrameLimiter::DoFrameLimiting(microseconds current_system_time_us) {
-    if (!Settings::values.use_frame_limit) {
+    if (!Settings::values->use_frame_limit) {
         return;
     }
 

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -80,7 +80,7 @@ void FrameLimiter::DoFrameLimiting(microseconds current_system_time_us) {
 
     auto now = Clock::now();
 
-    const double sleep_scale = Settings::values.frame_limit / 100.0;
+    const double sleep_scale = Settings::values->frame_limit / 100.0;
 
     // Max lag caused by slow frames. Shouldn't be more than the length of a frame at the current
     // speed percent or it will clamp too much and prevent this from properly limiting to that

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -12,6 +12,76 @@ namespace Settings {
 
 Values values = {};
 
+Values::Values() : current_game(default_game) {}
+
+void Values::SetUpdateCurrentGameFunction(std::function<bool(u64, PerGameValues&)> new_function) {
+    update_current_game = std::move(new_function);
+}
+
+u64 Values::CurrentTitleID() {
+    return current_title_id;
+}
+
+void Values::SetCurrentTitleID(u64 title_id) {
+    // Ignore Updates
+    title_id &= ~0x800;
+
+    if (current_title_id == title_id)
+        return;
+
+    update_current_game(title_id, current_game);
+}
+
+PerGameValues& Values::operator[](u64 title_id) {
+    // Ignore Updates
+    title_id &= ~0x800;
+
+    if (current_title_id == title_id)
+        return current_game;
+
+    if (!update_current_game(title_id, current_game))
+        return default_game;
+
+    current_title_id = title_id;
+    return current_game;
+}
+
+const PerGameValues& Values::operator[](u64 title_id) const {
+    // Ignore Updates
+    title_id &= ~0x800;
+
+    if (current_title_id == title_id)
+        return current_game;
+
+    return default_game;
+}
+
+PerGameValues* Values::operator->() {
+    if (current_title_id == 0)
+        return &default_game;
+
+    return &current_game;
+}
+
+const PerGameValues* Values::operator->() const {
+    if (current_title_id == 0)
+        return &default_game;
+
+    return &current_game;
+}
+
+PerGameValues& Values::operator*() {
+    if (current_title_id == 0)
+        return default_game;
+    return current_game;
+}
+
+const PerGameValues& Values::operator*() const {
+    if (current_title_id == 0)
+        return default_game;
+    return current_game;
+}
+
 void Apply() {
     GDBStub::SetServerPort(values.gdbstub_port);
     GDBStub::ToggleServer(values.use_gdbstub);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -64,6 +64,7 @@ void Values::SetCurrentTitleID(u64 title_id) {
         return;
 
     update_current_game(title_id, current_game);
+    current_title_id = title_id;
 }
 
 PerGameValues& Values::operator[](u64 title_id) {

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -12,13 +12,47 @@ namespace Settings {
 
 Values values = {};
 
+void PerGameValues::LogSettings() {
+    LOG_INFO(Config, "Buttons:");
+    for (std::size_t i = 0; i < NativeButton::NumButtons; ++i)
+        LOG_INFO(Config, "  Button[{}]: ", buttons[i]);
+
+    LOG_INFO(Config, "Analogs:");
+    for (std::size_t i = 0; i < NativeAnalog::NumAnalogs; ++i)
+        LOG_INFO(Config, "  Analog[{}]: ", analogs[i]);
+
+    LOG_INFO(Config, "Motion Device: {}", motion_device);
+    LOG_INFO(Config, "Touch Device: {}", touch_device);
+
+    LOG_INFO(Config, "Docked Mode: {}", use_docked_mode);
+
+    LOG_INFO(Config, "Resolution Factor: {}", resolution_factor);
+    LOG_INFO(Config, "Frame Limit Enabled: {}", use_frame_limit);
+    LOG_INFO(Config, "Frame Limit: {}", frame_limit);
+
+    LOG_INFO(Config, "Background Red: {}", bg_red);
+    LOG_INFO(Config, "Background Green: {}", bg_green);
+    LOG_INFO(Config, "Background Blue: {}", bg_blue);
+
+    LOG_INFO(Config, "Audio Sink ID: {}", sink_id);
+    LOG_INFO(Config, "Audio Stretching: {}", enable_audio_stretching);
+    LOG_INFO(Config, "Audio Device ID: {}", audio_device_id);
+    LOG_INFO(Config, "Volume: {}", volume);
+
+    LOG_INFO(Config, "Program Arguments: {}", program_args);
+
+    LOG_INFO(Config, "Disabled Patches:");
+    for (const auto& patch : disabled_patches)
+        LOG_INFO(Config, "  - {}", patch);
+}
+
 Values::Values() : current_game(default_game) {}
 
 void Values::SetUpdateCurrentGameFunction(std::function<bool(u64, PerGameValues&)> new_function) {
     update_current_game = std::move(new_function);
 }
 
-u64 Values::CurrentTitleID() {
+u64 Values::CurrentTitleID() const {
     return current_title_id;
 }
 

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -116,6 +116,8 @@ static const std::array<const char*, NumAnalogs> mapping = {{
 } // namespace NativeAnalog
 
 struct PerGameValues {
+    void LogSettings();
+
     // Controls
     std::array<std::string, NativeButton::NumButtons> buttons;
     std::array<std::string, NativeAnalog::NumAnalogs> analogs;
@@ -154,7 +156,7 @@ struct Values {
     PerGameValues default_game;
 
     void SetUpdateCurrentGameFunction(std::function<bool(u64, PerGameValues&)> new_function);
-    u64 CurrentTitleID();
+    u64 CurrentTitleID() const;
     void SetCurrentTitleID(u64 title_id);
 
     PerGameValues& operator[](u64 title_id);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -129,7 +129,6 @@ struct PerGameValues {
     float resolution_factor;
     bool use_frame_limit;
     u16 frame_limit;
-    bool use_accurate_gpu_emulation;
 
     float bg_red;
     float bg_green;
@@ -176,7 +175,7 @@ struct Values {
     int language_index;
 
     // Renderer
-    bool use_accurate_framebuffers;
+    bool use_accurate_gpu_emulation;
 
     // Input
     std::atomic_bool is_device_reload_pending{true};

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -6,10 +6,15 @@
 
 #include <array>
 #include <atomic>
+#include <functional>
 #include <string>
+#include <vector>
 #include "common/common_types.h"
+#include "input_common/motion_emu.h"
 
 namespace Settings {
+
+constexpr u64 DEFAULT_PER_GAME = 0;
 
 namespace NativeButton {
 enum Values {
@@ -110,28 +115,15 @@ static const std::array<const char*, NumAnalogs> mapping = {{
 }};
 } // namespace NativeAnalog
 
-struct Values {
-    // System
-    bool use_docked_mode;
-    bool enable_nfc;
-    int current_user;
-    int language_index;
-
+struct PerGameValues {
     // Controls
     std::array<std::string, NativeButton::NumButtons> buttons;
     std::array<std::string, NativeAnalog::NumAnalogs> analogs;
     std::string motion_device;
     std::string touch_device;
-    std::atomic_bool is_device_reload_pending{true};
 
-    // Core
-    bool use_cpu_jit;
-    bool use_multi_core;
-
-    // Data Storage
-    bool use_virtual_sd;
-    std::string nand_dir;
-    std::string sdmc_dir;
+    // System
+    bool use_docked_mode;
 
     // Renderer
     float resolution_factor;
@@ -143,10 +135,6 @@ struct Values {
     float bg_green;
     float bg_blue;
 
-    std::string log_filter;
-
-    bool use_dev_keys;
-
     // Audio
     std::string sink_id;
     bool enable_audio_stretching;
@@ -154,15 +142,69 @@ struct Values {
     float volume;
 
     // Debugging
+    std::string program_args;
+
+    // Add-Ons
+    std::vector<std::string> disabled_patches;
+};
+
+struct Values {
+    Values();
+
+    // Per-Game
+    PerGameValues default_game;
+
+    void SetUpdateCurrentGameFunction(std::function<bool(u64, PerGameValues&)> new_function);
+    u64 CurrentTitleID();
+    void SetCurrentTitleID(u64 title_id);
+
+    PerGameValues& operator[](u64 title_id);
+    const PerGameValues& operator[](u64 title_id) const;
+    PerGameValues* operator->();
+    const PerGameValues* operator->() const;
+    PerGameValues& operator*();
+    const PerGameValues& operator*() const;
+
+    // Core
+    bool use_cpu_jit;
+    bool use_multi_core;
+
+    // System
+    std::string username;
+    bool enable_nfc;
+    int current_user;
+    int language_index;
+
+    // Renderer
+    bool use_accurate_framebuffers;
+
+    // Input
+    std::atomic_bool is_device_reload_pending{true};
+
+    // Data Storage
+    bool use_virtual_sd;
+    std::string nand_dir;
+    std::string sdmc_dir;
+
+    // Debugging
+    std::string log_filter;
+    bool use_dev_keys;
     bool use_gdbstub;
     u16 gdbstub_port;
-    std::string program_args;
 
     // WebService
     bool enable_telemetry;
     std::string web_api_url;
     std::string yuzu_username;
     std::string yuzu_token;
+
+private:
+    u64 current_title_id = 0;
+    PerGameValues current_game;
+
+    std::function<bool(u64, PerGameValues&)> update_current_game = [](u64 in, PerGameValues& val) {
+        return false;
+    };
 } extern values;
 
 void Apply();

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -152,21 +152,22 @@ TelemetrySession::TelemetrySession() {
     Telemetry::AppendOSInfo(field_collection);
 
     // Log user configuration information
-    AddField(Telemetry::FieldType::UserConfig, "Audio_SinkId", Settings::values.sink_id);
+    AddField(Telemetry::FieldType::UserConfig, "Audio_SinkId", Settings::values->sink_id);
     AddField(Telemetry::FieldType::UserConfig, "Audio_EnableAudioStretching",
-             Settings::values.enable_audio_stretching);
+             Settings::values->enable_audio_stretching);
     AddField(Telemetry::FieldType::UserConfig, "Core_UseCpuJit", Settings::values.use_cpu_jit);
     AddField(Telemetry::FieldType::UserConfig, "Core_UseMultiCore",
              Settings::values.use_multi_core);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_ResolutionFactor",
-             Settings::values.resolution_factor);
+             Settings::values->resolution_factor);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_UseFrameLimit",
-             Settings::values.use_frame_limit);
-    AddField(Telemetry::FieldType::UserConfig, "Renderer_FrameLimit", Settings::values.frame_limit);
-    AddField(Telemetry::FieldType::UserConfig, "Renderer_UseAccurateGpuEmulation",
+             Settings::values->use_frame_limit);
+    AddField(Telemetry::FieldType::UserConfig, "Renderer_FrameLimit",
+             Settings::values->frame_limit);
+    AddField(Telemetry::FieldType::UserConfig, "Renderer_UseAccurateFramebuffers",
              Settings::values.use_accurate_gpu_emulation);
     AddField(Telemetry::FieldType::UserConfig, "System_UseDockedMode",
-             Settings::values.use_docked_mode);
+             Settings::values->use_docked_mode);
 }
 
 TelemetrySession::~TelemetrySession() {

--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -18,7 +18,7 @@ RendererBase::~RendererBase() = default;
 void RendererBase::RefreshBaseSettings() {
     UpdateCurrentFramebufferLayout();
 
-    renderer_settings.use_framelimiter = Settings::values.use_frame_limit;
+    renderer_settings.use_framelimiter = Settings::values->use_frame_limit;
     renderer_settings.set_background_color = true;
 }
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -222,7 +222,7 @@ void RendererOpenGL::LoadColorToActiveGLTexture(u8 color_r, u8 color_g, u8 color
  * Initializes the OpenGL state and creates persistent objects.
  */
 void RendererOpenGL::InitOpenGLObjects() {
-    glClearColor(Settings::values.bg_red, Settings::values.bg_green, Settings::values.bg_blue,
+    glClearColor(Settings::values->bg_red, Settings::values->bg_green, Settings::values->bg_blue,
                  0.0f);
 
     // Link shaders and get variable locations
@@ -371,8 +371,8 @@ void RendererOpenGL::DrawScreenTriangles(const ScreenInfo& screen_info, float x,
 void RendererOpenGL::DrawScreen() {
     if (renderer_settings.set_background_color) {
         // Update background color before drawing
-        glClearColor(Settings::values.bg_red, Settings::values.bg_green, Settings::values.bg_blue,
-                     0.0f);
+        glClearColor(Settings::values->bg_red, Settings::values->bg_green,
+                     Settings::values->bg_blue, 0.0f);
     }
 
     const auto& layout = render_window.GetFramebufferLayout();

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -31,6 +31,8 @@ add_executable(yuzu
     configuration/configure_system.h
     configuration/configure_per_game_dialog.cpp
     configuration/configure_per_game_dialog.h
+    configuration/configure_per_general.cpp
+    configuration/configure_per_general.h
     configuration/configure_web.cpp
     configuration/configure_web.h
     debugger/graphics/graphics_breakpoint_observer.cpp
@@ -77,6 +79,7 @@ set(UIS
     configuration/configure_graphics.ui
     configuration/configure_input.ui
     configuration/configure_per_game.ui
+    configuration/configure_per_general.ui
     configuration/configure_system.ui
     configuration/configure_web.ui
     hotkeys.ui

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -29,6 +29,8 @@ add_executable(yuzu
     configuration/configure_input.h
     configuration/configure_system.cpp
     configuration/configure_system.h
+    configuration/configure_per_game_dialog.cpp
+    configuration/configure_per_game_dialog.h
     configuration/configure_web.cpp
     configuration/configure_web.h
     debugger/graphics/graphics_breakpoint_observer.cpp
@@ -74,6 +76,7 @@ set(UIS
     configuration/configure_general.ui
     configuration/configure_graphics.ui
     configuration/configure_input.ui
+    configuration/configure_per_game.ui
     configuration/configure_system.ui
     configuration/configure_web.ui
     hotkeys.ui

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -165,8 +165,6 @@ void Config::ReadPerGameSettings(Settings::PerGameValues& values) {
     values.resolution_factor = qt_config->value("resolution_factor", 1.0).toFloat();
     values.use_frame_limit = qt_config->value("use_frame_limit", true).toBool();
     values.frame_limit = qt_config->value("frame_limit", 100).toInt();
-    Settings::values.use_accurate_gpu_emulation =
-        qt_config->value("use_accurate_gpu_emulation", false).toBool();
 
     values.bg_red = qt_config->value("bg_red", 0.0).toFloat();
     values.bg_green = qt_config->value("bg_green", 0.0).toFloat();
@@ -316,8 +314,8 @@ void Config::ReadValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("Renderer");
-    Settings::values.use_accurate_framebuffers =
-        qt_config->value("use_accurate_framebuffers", false).toBool();
+    Settings::values.use_accurate_gpu_emulation =
+        qt_config->value("use_accurate_gpu_emulation", false).toBool();
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");
@@ -425,7 +423,6 @@ void Config::SavePerGameSettings(const Settings::PerGameValues& values) {
     qt_config->setValue("resolution_factor", (double)values.resolution_factor);
     qt_config->setValue("use_frame_limit", values.use_frame_limit);
     qt_config->setValue("frame_limit", values.frame_limit);
-    qt_config->setValue("use_accurate_gpu_emulation", Settings::values.use_accurate_gpu_emulation);
 
     // Cast to double because Qt's written float values are not human-readable
     qt_config->setValue("bg_red", (double)values.bg_red);
@@ -550,7 +547,7 @@ void Config::SaveValues() {
     qt_config->endGroup();
 
     qt_config->beginGroup("Renderer");
-    qt_config->setValue("use_accurate_framebuffers", Settings::values.use_accurate_framebuffers);
+    qt_config->setValue("use_accurate_gpu_emulation", Settings::values.use_accurate_gpu_emulation);
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -257,16 +257,17 @@ bool Config::UpdateCurrentGame(u64 title_id, Settings::PerGameValues& values) {
 
     const auto size = qt_config->beginReadArray("Per Game Settings");
 
-    for (std::size_t i = 0; i < size; ++i) {
+    for (int i = 0; i < size; ++i) {
         qt_config->setArrayIndex(i);
         const auto read_title_id = qt_config->value("title_id", 0).toULongLong();
-        if (read_title_id == title_id) {
-            PerGameValuesChange changes{};
-            ReadPerGameSettings(values);
-            ReadPerGameSettingsDelta(changes);
+        if (read_title_id != title_id)
+            continue;
 
-            values = ApplyValuesDelta(Settings::values.default_game, values, changes);
-        }
+        PerGameValuesChange changes{};
+        ReadPerGameSettings(values);
+        ReadPerGameSettingsDelta(changes);
+
+        values = ApplyValuesDelta(Settings::values.default_game, values, changes);
     }
 
     qt_config->endArray();
@@ -499,7 +500,7 @@ void Config::SaveValues() {
 
     const auto size = qt_config->beginReadArray("Per Game Settings");
 
-    for (std::size_t i = 0; i < size; ++i) {
+    for (int i = 0; i < size; ++i) {
         qt_config->setArrayIndex(i);
         const auto read_title_id = qt_config->value("title_id", 0).toULongLong();
         if (update_values.find(read_title_id) == update_values.end()) {
@@ -517,7 +518,7 @@ void Config::SaveValues() {
 
     qt_config->beginWriteArray("Per Game Settings", update_values.size());
 
-    std::size_t i = 0;
+    int i = 0;
     for (const auto& kv : update_values) {
         qt_config->setArrayIndex(i++);
         qt_config->setValue("title_id", kv.first);

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -512,7 +512,7 @@ void Config::SaveValues() {
         if (update_values.find(read_title_id) == update_values.end()) {
             ReadPerGameSettings(values);
 
-            PerGameValuesChange change;
+            PerGameValuesChange change{};
             ReadPerGameSettingsDelta(change);
 
             update_values.emplace(read_title_id, values);

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -301,14 +301,23 @@ void Config::ReadValues() {
             .toStdString());
     qt_config->endGroup();
 
+    qt_config->beginGroup("Core");
+    Settings::values.use_cpu_jit = qt_config->value("use_cpu_jit", true).toBool();
+    Settings::values.use_multi_core = qt_config->value("use_multi_core", false).toBool();
+    qt_config->endGroup();
+
     qt_config->beginGroup("System");
-    Settings::values.use_docked_mode = qt_config->value("use_docked_mode", false).toBool();
     Settings::values.enable_nfc = qt_config->value("enable_nfc", true).toBool();
 
     Settings::values.current_user = std::clamp<int>(qt_config->value("current_user", 0).toInt(), 0,
                                                     Service::Account::MAX_USERS - 1);
 
     Settings::values.language_index = qt_config->value("language_index", 1).toInt();
+    qt_config->endGroup();
+
+    qt_config->beginGroup("Renderer");
+    Settings::values.use_accurate_framebuffers =
+        qt_config->value("use_accurate_framebuffers", false).toBool();
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");
@@ -319,7 +328,6 @@ void Config::ReadValues() {
     qt_config->beginGroup("Debugging");
     Settings::values.use_gdbstub = qt_config->value("use_gdbstub", false).toBool();
     Settings::values.gdbstub_port = qt_config->value("gdbstub_port", 24689).toInt();
-    Settings::values.program_args = qt_config->value("program_args", "").toString().toStdString();
     qt_config->endGroup();
 
     qt_config->beginGroup("WebService");
@@ -529,12 +537,20 @@ void Config::SaveValues() {
                         QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)));
     qt_config->endGroup();
 
+    qt_config->beginGroup("Core");
+    qt_config->setValue("use_cpu_jit", Settings::values.use_cpu_jit);
+    qt_config->setValue("use_multi_core", Settings::values.use_multi_core);
+    qt_config->endGroup();
+
     qt_config->beginGroup("System");
-    qt_config->setValue("use_docked_mode", Settings::values.use_docked_mode);
     qt_config->setValue("enable_nfc", Settings::values.enable_nfc);
     qt_config->setValue("current_user", Settings::values.current_user);
 
     qt_config->setValue("language_index", Settings::values.language_index);
+    qt_config->endGroup();
+
+    qt_config->beginGroup("Renderer");
+    qt_config->setValue("use_accurate_framebuffers", Settings::values.use_accurate_framebuffers);
     qt_config->endGroup();
 
     qt_config->beginGroup("Miscellaneous");
@@ -545,7 +561,6 @@ void Config::SaveValues() {
     qt_config->beginGroup("Debugging");
     qt_config->setValue("use_gdbstub", Settings::values.use_gdbstub);
     qt_config->setValue("gdbstub_port", Settings::values.gdbstub_port);
-    qt_config->setValue("program_args", QString::fromStdString(Settings::values.program_args));
     qt_config->endGroup();
 
     qt_config->beginGroup("WebService");

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -668,9 +668,3 @@ PerGameValuesChange Config::GetPerGameSettingsDelta(u64 title_id) const {
 void Config::SetPerGameSettingsDelta(u64 title_id, PerGameValuesChange change) {
     update_values_delta.insert_or_assign(title_id, change);
 }
-
-Config::~Config() {
-    Save();
-
-    delete qt_config;
-}

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+﻿// Copyright 2014 Citra Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -64,19 +64,16 @@ public:
 private:
     void ReadValues();
     void SaveValues();
-    std::map<u64, Settings::PerGameValues> update_values;
-    std::map<u64, PerGameValuesChange> update_values_delta;
 
     void ReadPerGameSettings(Settings::PerGameValues& values) const;
     void ReadPerGameSettingsDelta(PerGameValuesChange& values) const;
     void SavePerGameSettings(const Settings::PerGameValues& values);
     void SavePerGameSettingsDelta(const PerGameValuesChange& values);
-    void ReadValues();
-    void SaveValues();
 
     bool UpdateCurrentGame(u64 title_id, Settings::PerGameValues& values);
 
-
     std::unique_ptr<QSettings> qt_config;
     std::string qt_config_loc;
+    std::map<u64, Settings::PerGameValues> update_values;
+    std::map<u64, PerGameValuesChange> update_values_delta;
 };

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -1,4 +1,4 @@
-﻿// Copyright 2014 Citra Emulator Project
+// Copyright 2014 Citra Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -12,6 +12,42 @@
 
 class QSettings;
 
+struct PerGameValuesChange {
+    // Controls
+    std::array<bool, Settings::NativeButton::NumButtons> buttons;
+    std::array<bool, Settings::NativeAnalog::NumAnalogs> analogs;
+    bool motion_device;
+    bool touch_device;
+
+    // System
+    bool use_docked_mode;
+
+    // Renderer
+    bool resolution_factor;
+    bool use_frame_limit;
+    bool frame_limit;
+
+    bool bg_red;
+    bool bg_green;
+    bool bg_blue;
+
+    // Audio
+    bool sink_id;
+    bool enable_audio_stretching;
+    bool audio_device_id;
+    bool volume;
+
+    // Debugging
+    bool program_args;
+};
+
+PerGameValuesChange CalculateValuesDelta(const Settings::PerGameValues& base,
+                                         const Settings::PerGameValues& changed);
+
+Settings::PerGameValues ApplyValuesDelta(const Settings::PerGameValues& base,
+                                         const Settings::PerGameValues& changed,
+                                         const PerGameValuesChange& changes);
+
 class Config {
 public:
     Config();
@@ -19,6 +55,8 @@ public:
 
     void Reload();
     void Save();
+    PerGameValuesChange GetPerGameSettingsDelta(u64 title_id) const;
+    void SetPerGameSettingsDelta(u64 title_id, PerGameValuesChange change);
 
     static const std::array<int, Settings::NativeButton::NumButtons> default_buttons;
     static const std::array<std::array<int, 5>, Settings::NativeAnalog::NumAnalogs> default_analogs;
@@ -26,6 +64,18 @@ public:
 private:
     void ReadValues();
     void SaveValues();
+    std::map<u64, Settings::PerGameValues> update_values;
+    std::map<u64, PerGameValuesChange> update_values_delta;
+
+    void ReadPerGameSettings(Settings::PerGameValues& values);
+    void ReadPerGameSettingsDelta(PerGameValuesChange& values);
+    void SavePerGameSettings(const Settings::PerGameValues& values);
+    void SavePerGameSettingsDelta(const PerGameValuesChange& values);
+    void ReadValues();
+    void SaveValues();
+
+    bool UpdateCurrentGame(u64 title_id, Settings::PerGameValues& values);
+
 
     std::unique_ptr<QSettings> qt_config;
     std::string qt_config_loc;

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -67,8 +67,8 @@ private:
     std::map<u64, Settings::PerGameValues> update_values;
     std::map<u64, PerGameValuesChange> update_values_delta;
 
-    void ReadPerGameSettings(Settings::PerGameValues& values);
-    void ReadPerGameSettingsDelta(PerGameValuesChange& values);
+    void ReadPerGameSettings(Settings::PerGameValues& values) const;
+    void ReadPerGameSettingsDelta(PerGameValuesChange& values) const;
     void SavePerGameSettings(const Settings::PerGameValues& values);
     void SavePerGameSettingsDelta(const PerGameValuesChange& values);
     void ReadValues();

--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -23,6 +23,10 @@ ConfigureAudio::ConfigureAudio(QWidget* parent)
 
     connect(ui->volume_slider, &QSlider::valueChanged, this,
             &ConfigureAudio::setVolumeIndicatorText);
+    connect(ui->volume_slider, &QSlider::valueChanged, this, [this]() {
+        if (!ui->volume_checkbox->isHidden())
+            ui->volume_checkbox->setChecked(true);
+    });
 
     this->setConfiguration();
     connect(ui->output_sink_combo_box,
@@ -35,6 +39,31 @@ ConfigureAudio::ConfigureAudio(QWidget* parent)
 
 ConfigureAudio::~ConfigureAudio() = default;
 
+void ConfigureAudio::setPerGame(bool per_game) {
+    ui->toggle_audio_stretching->setTristate(per_game);
+    ui->output_sink_checkbox->setHidden(!per_game);
+    ui->audio_device_checkbox->setHidden(!per_game);
+    ui->volume_checkbox->setHidden(!per_game);
+}
+
+void ConfigureAudio::loadValuesChange(const PerGameValuesChange& change) {
+    ui->toggle_audio_stretching->setCheckState(
+        change.enable_audio_stretching
+            ? (Settings::values->enable_audio_stretching ? Qt::Checked : Qt::Unchecked)
+            : Qt::PartiallyChecked);
+    ui->output_sink_checkbox->setChecked(change.sink_id);
+    ui->audio_device_checkbox->setChecked(change.audio_device_id);
+    ui->volume_checkbox->setChecked(change.volume);
+}
+
+void ConfigureAudio::mergeValuesChange(PerGameValuesChange& change) {
+    change.enable_audio_stretching =
+        ui->toggle_audio_stretching->checkState() != Qt::PartiallyChecked;
+    change.sink_id = ui->output_sink_checkbox->isChecked();
+    change.audio_device_id = ui->audio_device_checkbox->isChecked();
+    change.volume = ui->volume_checkbox->isChecked();
+}
+
 void ConfigureAudio::setConfiguration() {
     setOutputSinkFromSinkID();
 
@@ -43,15 +72,15 @@ void ConfigureAudio::setConfiguration() {
 
     setAudioDeviceFromDeviceID();
 
-    ui->toggle_audio_stretching->setChecked(Settings::values.enable_audio_stretching);
-    ui->volume_slider->setValue(Settings::values.volume * ui->volume_slider->maximum());
+    ui->toggle_audio_stretching->setChecked(Settings::values->enable_audio_stretching);
+    ui->volume_slider->setValue(Settings::values->volume * ui->volume_slider->maximum());
     setVolumeIndicatorText(ui->volume_slider->sliderPosition());
 }
 
 void ConfigureAudio::setOutputSinkFromSinkID() {
     int new_sink_index = 0;
 
-    const QString sink_id = QString::fromStdString(Settings::values.sink_id);
+    const QString sink_id = QString::fromStdString(Settings::values->sink_id);
     for (int index = 0; index < ui->output_sink_combo_box->count(); index++) {
         if (ui->output_sink_combo_box->itemText(index) == sink_id) {
             new_sink_index = index;
@@ -65,7 +94,7 @@ void ConfigureAudio::setOutputSinkFromSinkID() {
 void ConfigureAudio::setAudioDeviceFromDeviceID() {
     int new_device_index = -1;
 
-    const QString device_id = QString::fromStdString(Settings::values.audio_device_id);
+    const QString device_id = QString::fromStdString(Settings::values->audio_device_id);
     for (int index = 0; index < ui->audio_device_combo_box->count(); index++) {
         if (ui->audio_device_combo_box->itemText(index) == device_id) {
             new_device_index = index;
@@ -81,14 +110,14 @@ void ConfigureAudio::setVolumeIndicatorText(int percentage) {
 }
 
 void ConfigureAudio::applyConfiguration() {
-    Settings::values.sink_id =
+    Settings::values->sink_id =
         ui->output_sink_combo_box->itemText(ui->output_sink_combo_box->currentIndex())
             .toStdString();
-    Settings::values.enable_audio_stretching = ui->toggle_audio_stretching->isChecked();
-    Settings::values.audio_device_id =
+    Settings::values->enable_audio_stretching = ui->toggle_audio_stretching->isChecked();
+    Settings::values->audio_device_id =
         ui->audio_device_combo_box->itemText(ui->audio_device_combo_box->currentIndex())
             .toStdString();
-    Settings::values.volume =
+    Settings::values->volume =
         static_cast<float>(ui->volume_slider->sliderPosition()) / ui->volume_slider->maximum();
 }
 

--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -9,6 +9,7 @@
 #include "core/core.h"
 #include "core/settings.h"
 #include "ui_configure_audio.h"
+#include "yuzu/configuration/config.h"
 #include "yuzu/configuration/configure_audio.h"
 
 ConfigureAudio::ConfigureAudio(QWidget* parent)

--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -114,7 +114,10 @@ void ConfigureAudio::applyConfiguration() {
     Settings::values->sink_id =
         ui->output_sink_combo_box->itemText(ui->output_sink_combo_box->currentIndex())
             .toStdString();
-    Settings::values->enable_audio_stretching = ui->toggle_audio_stretching->isChecked();
+    Settings::values->enable_audio_stretching =
+        ui->toggle_audio_stretching->checkState() == Qt::PartiallyChecked
+            ? Settings::values.default_game.enable_audio_stretching
+            : ui->toggle_audio_stretching->isChecked();
     Settings::values->audio_device_id =
         ui->audio_device_combo_box->itemText(ui->audio_device_combo_box->currentIndex())
             .toStdString();

--- a/src/yuzu/configuration/configure_audio.h
+++ b/src/yuzu/configuration/configure_audio.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <QWidget>
+#include "yuzu/configuration/config.h"
 
 namespace Ui {
 class ConfigureAudio;
@@ -17,6 +18,10 @@ class ConfigureAudio : public QWidget {
 public:
     explicit ConfigureAudio(QWidget* parent = nullptr);
     ~ConfigureAudio();
+
+    void setPerGame(bool per_game);
+    void loadValuesChange(const PerGameValuesChange& change);
+    void mergeValuesChange(PerGameValuesChange& change);
 
     void applyConfiguration();
     void retranslateUi();

--- a/src/yuzu/configuration/configure_audio.h
+++ b/src/yuzu/configuration/configure_audio.h
@@ -6,7 +6,8 @@
 
 #include <memory>
 #include <QWidget>
-#include "yuzu/configuration/config.h"
+
+struct PerGameValuesChange;
 
 namespace Ui {
 class ConfigureAudio;

--- a/src/yuzu/configuration/configure_audio.ui
+++ b/src/yuzu/configuration/configure_audio.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>188</width>
+    <width>402</width>
     <height>246</height>
    </rect>
   </property>
@@ -29,18 +29,31 @@
         <item>
          <widget class="QComboBox" name="output_sink_combo_box"/>
         </item>
+        <item>
+         <widget class="QCheckBox" name="output_sink_checkbox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
-       <item>
-         <widget class="QCheckBox" name="toggle_audio_stretching">
-           <property name="toolTip">
-             <string>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</string>
-           </property>
-           <property name="text">
-             <string>Enable audio stretching</string>
-           </property>
-         </widget>
-       </item>
+      <item>
+       <widget class="QCheckBox" name="toggle_audio_stretching">
+        <property name="toolTip">
+         <string>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</string>
+        </property>
+        <property name="text">
+         <string>Enable audio stretching</string>
+        </property>
+       </widget>
+      </item>
       <item>
        <layout class="QHBoxLayout">
         <item>
@@ -52,6 +65,19 @@
         </item>
         <item>
          <widget class="QComboBox" name="audio_device_combo_box"/>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="audio_device_checkbox">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>
@@ -115,6 +141,13 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QCheckBox" name="volume_checkbox">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>
@@ -132,6 +165,16 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Check the box next to output engine, audio device, or volume to override the global default setting with this one for this game only.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -11,6 +11,7 @@
 #include "core/core.h"
 #include "core/settings.h"
 #include "ui_configure_debug.h"
+#include "yuzu/configuration/config.h"
 #include "yuzu/configuration/configure_debug.h"
 #include "yuzu/debugger/console.h"
 #include "yuzu/ui_settings.h"

--- a/src/yuzu/configuration/configure_debug.h
+++ b/src/yuzu/configuration/configure_debug.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <QWidget>
+#include "configuration/config.h"
 
 namespace Ui {
 class ConfigureDebug;
@@ -20,9 +21,12 @@ public:
 
     void applyConfiguration();
 
+    void setPerGame(bool per_game);
+    void loadValuesChange(const PerGameValuesChange& change);
+    void mergeValuesChange(PerGameValuesChange& change);
+
 private:
     void setConfiguration();
 
-private:
     std::unique_ptr<Ui::ConfigureDebug> ui;
 };

--- a/src/yuzu/configuration/configure_debug.h
+++ b/src/yuzu/configuration/configure_debug.h
@@ -6,7 +6,8 @@
 
 #include <memory>
 #include <QWidget>
-#include "configuration/config.h"
+
+struct PerGameValuesChange;
 
 namespace Ui {
 class ConfigureDebug;

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -124,6 +124,13 @@
         <item>
          <widget class="QLineEdit" name="homebrew_args_edit"/>
         </item>
+        <item>
+         <widget class="QCheckBox" name="program_args_checkbox">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>
@@ -141,6 +148,16 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="override_label">
+     <property name="text">
+      <string>Check the box next to the homebrew arguments string to override the global default setting with this one for this game only.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -12,6 +12,10 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, const HotkeyRegistry& registry
     : QDialog(parent), ui(new Ui::ConfigureDialog) {
     ui->setupUi(this);
     ui->generalTab->PopulateHotkeyList(registry);
+    ui->inputTab->setPerGame(false);
+    ui->graphicsTab->setPerGame(false);
+    ui->audioTab->setPerGame(false);
+    ui->debugTab->setPerGame(false);
     this->setConfiguration();
 }
 

--- a/src/yuzu/configuration/configure_gamelist.cpp
+++ b/src/yuzu/configuration/configure_gamelist.cpp
@@ -36,6 +36,16 @@ ConfigureGameList::ConfigureGameList(QWidget* parent)
     InitializeRowComboBoxes();
 
     this->setConfiguration();
+
+    // Force game list reload if any of the relevant settings are changed.
+    connect(ui->show_unknown, &QCheckBox::stateChanged, this,
+            &ConfigureGameList::RequestGameListUpdate);
+    connect(ui->icon_size_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &ConfigureGameList::RequestGameListUpdate);
+    connect(ui->row_1_text_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &ConfigureGameList::RequestGameListUpdate);
+    connect(ui->row_2_text_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &ConfigureGameList::RequestGameListUpdate);
 }
 
 ConfigureGameList::~ConfigureGameList() = default;
@@ -46,6 +56,10 @@ void ConfigureGameList::applyConfiguration() {
     UISettings::values.row_1_text_id = ui->row_1_text_combobox->currentData().toUInt();
     UISettings::values.row_2_text_id = ui->row_2_text_combobox->currentData().toUInt();
     Settings::Apply();
+}
+
+void ConfigureGameList::RequestGameListUpdate() {
+    UISettings::values.is_game_list_reload_pending.exchange(true);
 }
 
 void ConfigureGameList::setConfiguration() {

--- a/src/yuzu/configuration/configure_gamelist.h
+++ b/src/yuzu/configuration/configure_gamelist.h
@@ -20,6 +20,9 @@ public:
 
     void applyConfiguration();
 
+public slots:
+    void RequestGameListUpdate();
+
 private:
     void setConfiguration();
 

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -21,6 +21,9 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
 
     ui->use_cpu_jit->setEnabled(!Core::System::GetInstance().IsPoweredOn());
     ui->use_docked_mode->setEnabled(!Core::System::GetInstance().IsPoweredOn());
+
+    connect(ui->toggle_deepscan, &QCheckBox::stateChanged, this,
+            []() { UISettings::values.is_game_list_reload_pending.exchange(true); });
 }
 
 ConfigureGeneral::~ConfigureGeneral() = default;

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -30,7 +30,7 @@ void ConfigureGeneral::setConfiguration() {
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing);
     ui->theme_combobox->setCurrentIndex(ui->theme_combobox->findData(UISettings::values.theme));
     ui->use_cpu_jit->setChecked(Settings::values.use_cpu_jit);
-    ui->use_docked_mode->setChecked(Settings::values.use_docked_mode);
+    ui->use_docked_mode->setChecked(Settings::values->use_docked_mode);
     ui->enable_nfc->setChecked(Settings::values.enable_nfc);
 }
 
@@ -45,6 +45,6 @@ void ConfigureGeneral::applyConfiguration() {
         ui->theme_combobox->itemData(ui->theme_combobox->currentIndex()).toString();
 
     Settings::values.use_cpu_jit = ui->use_cpu_jit->isChecked();
-    Settings::values.use_docked_mode = ui->use_docked_mode->isChecked();
+    Settings::values->use_docked_mode = ui->use_docked_mode->isChecked();
     Settings::values.enable_nfc = ui->enable_nfc->isChecked();
 }

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -112,7 +112,9 @@ void ConfigureGraphics::mergeValuesChange(PerGameValuesChange& change) {
 void ConfigureGraphics::applyConfiguration() {
     Settings::values->resolution_factor =
         ToResolutionFactor(static_cast<Resolution>(ui->resolution_factor_combobox->currentIndex()));
-    Settings::values->use_frame_limit = ui->toggle_frame_limit->isChecked();
+    Settings::values->use_frame_limit = ui->toggle_frame_limit->checkState() == Qt::PartiallyChecked
+                                            ? Settings::values.default_game.use_frame_limit
+                                            : ui->toggle_frame_limit->isChecked();
     Settings::values->frame_limit = ui->frame_limit->value();
     Settings::values.use_accurate_gpu_emulation = ui->use_accurate_gpu_emulation->isChecked();
     Settings::values->bg_red = static_cast<float>(bg_color.redF());

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -86,7 +86,7 @@ void ConfigureGraphics::setConfiguration() {
 void ConfigureGraphics::setPerGame(bool per_game) {
     ui->bg_checkbox->setHidden(!per_game);
     ui->resolution_factor_checkbox->setHidden(!per_game);
-    ui->use_accurate_framebuffers->setHidden(per_game);
+    ui->use_accurate_gpu_emulation->setHidden(per_game);
     ui->override_label->setHidden(!per_game);
     ui->toggle_frame_limit->setTristate(per_game);
 }

--- a/src/yuzu/configuration/configure_graphics.h
+++ b/src/yuzu/configuration/configure_graphics.h
@@ -7,6 +7,8 @@
 #include <memory>
 #include <QWidget>
 
+struct PerGameValuesChange;
+
 namespace Ui {
 class ConfigureGraphics;
 }
@@ -19,6 +21,10 @@ public:
     ~ConfigureGraphics();
 
     void applyConfiguration();
+
+    void setPerGame(bool per_game);
+    void loadValuesChange(const PerGameValuesChange& change);
+    void mergeValuesChange(PerGameValuesChange& change);
 
 private:
     void setConfiguration();

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>402</width>
     <height>300</height>
    </rect>
   </property>
@@ -23,31 +23,31 @@
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <item>
-              <widget class="QCheckBox" name="toggle_frame_limit">
-                <property name="text">
-                  <string>Limit Speed Percent</string>
-                </property>
-              </widget>
-            </item>
-            <item>
-              <widget class="QSpinBox" name="frame_limit">
-                <property name="suffix">
-                  <string>%</string>
-                </property>
-                <property name="minimum">
-                  <number>1</number>
-                </property>
-                <property name="maximum">
-                  <number>9999</number>
-                </property>
-                <property name="value">
-                  <number>100</number>
-                </property>
-              </widget>
-            </item>
-          </layout>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QCheckBox" name="toggle_frame_limit">
+            <property name="text">
+             <string>Limit Speed Percent</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="frame_limit">
+            <property name="suffix">
+             <string>%</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>9999</number>
+            </property>
+            <property name="value">
+             <number>100</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
          <widget class="QCheckBox" name="use_accurate_gpu_emulation">
@@ -61,7 +61,7 @@
           <item>
            <widget class="QLabel" name="label">
             <property name="text">
-             <string>Internal Resolution:(Currently does nothing.)</string>
+             <string>Internal Resolution:</string>
             </property>
            </widget>
           </item>
@@ -94,29 +94,55 @@
             </item>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="resolution_factor_checkbox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
          </layout>
         </item>
-         <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_6">
-             <item>
-               <widget class="QLabel" name="bg_label">
-                 <property name="text">
-                   <string>Background Color:</string>
-                 </property>
-               </widget>
-             </item>
-             <item>
-               <widget class="QPushButton" name="bg_button">
-                 <property name="maximumSize">
-                   <size>
-                     <width>40</width>
-                     <height>16777215</height>
-                   </size>
-                 </property>
-               </widget>
-             </item>
-           </layout>
-         </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <widget class="QLabel" name="bg_label">
+            <property name="text">
+             <string>Background Color:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="bg_button">
+            <property name="maximumSize">
+             <size>
+              <width>40</width>
+              <height>16777215</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="bg_checkbox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
        </layout>
       </widget>
      </item>
@@ -134,6 +160,16 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="override_label">
+     <property name="text">
+      <string>Check the box next to internal resolution or background color to override the global default setting with this one for this game only.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -268,9 +268,9 @@ void ConfigureInput::applyConfiguration() {
 }
 
 void ConfigureInput::setPerGame(bool show) {
-    for (const auto button : buttons_delta)
+    for (auto* button : buttons_delta)
         button->setHidden(!show);
-    for (const auto analog : analogs_delta)
+    for (auto* analog : analogs_delta)
         analog->setHidden(!show);
     ui->override_label->setHidden(!show);
 }

--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -262,7 +262,7 @@ void ConfigureInput::applyConfiguration() {
     std::transform(analogs_delta.begin(), analogs_delta.end(), changes.analogs.begin(),
                    [](const QCheckBox* box) { return box->isChecked(); });
 
-    temp = ApplyValuesDelta(*Settings::values, temp, changes);
+    temp = ApplyValuesDelta(Settings::values.default_game, temp, changes);
     Settings::values->buttons = temp.buttons;
     Settings::values->analogs = temp.analogs;
 }

--- a/src/yuzu/configuration/configure_input.h
+++ b/src/yuzu/configuration/configure_input.h
@@ -16,6 +16,7 @@
 #include "core/settings.h"
 #include "input_common/main.h"
 #include "ui_configure_input.h"
+#include "yuzu/configuration/config.h"
 
 class QPushButton;
 class QString;
@@ -34,6 +35,10 @@ public:
     /// Save all button configurations to settings file
     void applyConfiguration();
 
+    void setPerGame(bool per_game);
+    void loadValuesChange(const PerGameValuesChange& change);
+    void mergeValuesChange(PerGameValuesChange& change);
+
 private:
     std::unique_ptr<Ui::ConfigureInput> ui;
 
@@ -45,6 +50,9 @@ private:
 
     std::array<Common::ParamPackage, Settings::NativeButton::NumButtons> buttons_param;
     std::array<Common::ParamPackage, Settings::NativeAnalog::NumAnalogs> analogs_param;
+
+    std::array<QCheckBox*, Settings::NativeButton::NumButtons> buttons_delta;
+    std::array<QCheckBox*, Settings::NativeAnalog::NumAnalogs> analogs_delta;
 
     static constexpr int ANALOG_SUB_BUTTONS_NUM = 5;
 

--- a/src/yuzu/configuration/configure_input.h
+++ b/src/yuzu/configuration/configure_input.h
@@ -16,7 +16,6 @@
 #include "core/settings.h"
 #include "input_common/main.h"
 #include "ui_configure_input.h"
-#include "yuzu/configuration/config.h"
 
 class QPushButton;
 class QString;

--- a/src/yuzu/configuration/configure_input.ui
+++ b/src/yuzu/configuration/configure_input.ui
@@ -31,11 +31,31 @@
         <item row="0" column="0">
          <layout class="QVBoxLayout" name="buttonMiscMinusVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelMinus">
-            <property name="text">
-             <string>Minus:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonMiscMinusHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelMinus">
+              <property name="text">
+               <string>Minus:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxMinus">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonMinus">
@@ -49,11 +69,31 @@
         <item row="0" column="1">
          <layout class="QVBoxLayout" name="buttonMiscPlusVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelPlus">
-            <property name="text">
-             <string>Plus:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonMiscPlusHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelPlus">
+              <property name="text">
+               <string>Plus:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxPlus">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonPlus">
@@ -67,33 +107,34 @@
         <item row="1" column="0">
          <layout class="QVBoxLayout" name="buttonMiscHomeVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelHome">
-            <property name="text">
-             <string>Home:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonMiscHomeHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelHome">
+              <property name="text">
+               <string>Home:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxHome">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonHome">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="1">
-         <layout class="QVBoxLayout" name="buttonMiscScrCapVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelScrCap">
-            <property name="text">
-             <string>Screen
-Capture:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonScreenshot">
             <property name="text">
              <string/>
             </property>
@@ -114,6 +155,47 @@ Capture:</string>
           </property>
          </spacer>
         </item>
+        <item row="1" column="1">
+         <layout class="QVBoxLayout" name="buttonMiscScrCapVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonMiscScrCapHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelScreenshot">
+              <property name="text">
+               <string>Screen Capture:</string>
+              </property>
+              <property name="wordWrap">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxScreenshot">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonScreenshot">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
        </layout>
       </widget>
      </item>
@@ -132,11 +214,31 @@ Capture:</string>
         <item row="0" column="0">
          <layout class="QVBoxLayout" name="buttonFaceButtonsAVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelA">
-            <property name="text">
-             <string>A:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonFaceButtonsAHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelA">
+              <property name="text">
+               <string>A:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxA">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonA">
@@ -150,11 +252,31 @@ Capture:</string>
         <item row="0" column="1">
          <layout class="QVBoxLayout" name="buttonFaceButtonsBVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelB">
-            <property name="text">
-             <string>B:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonFaceButtonsBHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelB">
+              <property name="text">
+               <string>B:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxB">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonB">
@@ -168,11 +290,31 @@ Capture:</string>
         <item row="1" column="0">
          <layout class="QVBoxLayout" name="buttonFaceButtonsXVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelX">
-            <property name="text">
-             <string>X:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonFaceButtonsXHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelX">
+              <property name="text">
+               <string>X:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxX">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonX">
@@ -186,11 +328,31 @@ Capture:</string>
         <item row="1" column="1">
          <layout class="QVBoxLayout" name="buttonFaceButtonsYVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelY">
-            <property name="text">
-             <string>Y:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonFaceButtonsYHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelY">
+              <property name="text">
+               <string>Y:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxY">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonY">
@@ -219,11 +381,31 @@ Capture:</string>
         <item row="1" column="0">
          <layout class="QVBoxLayout" name="buttonDpadUpVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelDpadUp">
-            <property name="text">
-             <string>Up:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonDpadUpHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelDpadUp">
+              <property name="text">
+               <string>Up:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxDpadUp">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonDpadUp">
@@ -237,11 +419,31 @@ Capture:</string>
         <item row="1" column="1">
          <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelDpadDown">
-            <property name="text">
-             <string>Down:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonDpadDownHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelDpadDown">
+              <property name="text">
+               <string>Down:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxDpadDown">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonDpadDown">
@@ -255,11 +457,31 @@ Capture:</string>
         <item row="0" column="0">
          <layout class="QVBoxLayout" name="buttonDpadLeftVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelDpadLeft">
-            <property name="text">
-             <string>Left:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonDpadLeftHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelDpadLeft">
+              <property name="text">
+               <string>Left:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxDpadLeft">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonDpadLeft">
@@ -273,11 +495,31 @@ Capture:</string>
         <item row="0" column="1">
          <layout class="QVBoxLayout" name="buttonDpadRightVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelDpadRight">
-            <property name="text">
-             <string>Right:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonDpadRightHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelDpadRight">
+              <property name="text">
+               <string>Right:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxDpadRight">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonDpadRight">
@@ -306,11 +548,31 @@ Capture:</string>
         <item row="0" column="0">
          <layout class="QVBoxLayout" name="buttonShoulderButtonsLVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelL">
-            <property name="text">
-             <string>L:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonShoulderButtonsLHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelL">
+              <property name="text">
+               <string>L:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxL">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonL">
@@ -324,11 +586,31 @@ Capture:</string>
         <item row="0" column="1">
          <layout class="QVBoxLayout" name="buttonShoulderButtonsRVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelR">
-            <property name="text">
-             <string>R:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonShoulderButtonsRHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelR">
+              <property name="text">
+               <string>R:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxR">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonR">
@@ -342,11 +624,31 @@ Capture:</string>
         <item row="1" column="0">
          <layout class="QVBoxLayout" name="buttonShoulderButtonsZLVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelZL">
-            <property name="text">
-             <string>ZL:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonShoulderButtonsZLHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelZL">
+              <property name="text">
+               <string>ZL:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxZL">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonZL">
@@ -360,11 +662,31 @@ Capture:</string>
         <item row="1" column="1">
          <layout class="QVBoxLayout" name="buttonShoulderButtonsZRVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelZR">
-            <property name="text">
-             <string>ZR:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonShoulderButtonsZRHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelZR">
+              <property name="text">
+               <string>ZR:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxZR">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonZR">
@@ -378,11 +700,31 @@ Capture:</string>
         <item row="2" column="0">
          <layout class="QVBoxLayout" name="buttonShoulderButtonsSLVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelSL">
-            <property name="text">
-             <string>SL:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonShoulderButtonsSLHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelSL">
+              <property name="text">
+               <string>SL:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxSL">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonSL">
@@ -396,11 +738,31 @@ Capture:</string>
         <item row="2" column="1">
          <layout class="QVBoxLayout" name="buttonShoulderButtonsSRVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelSR">
-            <property name="text">
-             <string>SR:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonShoulderButtonsSRHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelSR">
+              <property name="text">
+               <string>SR:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxSR">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonSR">
@@ -432,11 +794,31 @@ Capture:</string>
         <item row="1" column="1">
          <layout class="QVBoxLayout" name="buttonRStickDownVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelRStickDown">
-            <property name="text">
-             <string>Down:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonRStickDownHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelRStickDown">
+              <property name="text">
+               <string>Down:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxRStickDown">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonRStickDown">
@@ -450,11 +832,31 @@ Capture:</string>
         <item row="0" column="1">
          <layout class="QVBoxLayout" name="buttonRStickRightVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelRStickRight">
-            <property name="text">
-             <string>Right:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonRStickRightHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelRStickRight">
+              <property name="text">
+               <string>Right:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxRStickRight">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonRStickRight">
@@ -475,11 +877,31 @@ Capture:</string>
         <item row="0" column="0">
          <layout class="QVBoxLayout" name="buttonRStickLeftVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelRStickLeft">
-            <property name="text">
-             <string>Left:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonRStickLeftHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelRStickLeft">
+              <property name="text">
+               <string>Left:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxRStickLeft">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonRStickLeft">
@@ -493,11 +915,31 @@ Capture:</string>
         <item row="1" column="0">
          <layout class="QVBoxLayout" name="buttonRStickUpVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelRStickUp">
-            <property name="text">
-             <string>Up:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonRStickUpHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelRStickUp">
+              <property name="text">
+               <string>Up:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxRStickUp">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonRStickUp">
@@ -511,11 +953,31 @@ Capture:</string>
         <item row="2" column="0">
          <layout class="QVBoxLayout" name="buttonRStickPressedVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelRStickPressed">
-            <property name="text">
-             <string>Pressed:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonRStickPressedHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelRStickPressed">
+              <property name="text">
+               <string>Pressed:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxRStickPressed">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonRStick">
@@ -529,11 +991,31 @@ Capture:</string>
         <item row="2" column="1">
          <layout class="QVBoxLayout" name="buttonRStickModVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelRStickMod">
-            <property name="text">
-             <string>Modifier:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonRStickModHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelRStickMod">
+              <property name="text">
+               <string>Modifier:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxRStickMod">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonRStickMod">
@@ -562,11 +1044,31 @@ Capture:</string>
         <item row="1" column="1">
          <layout class="QVBoxLayout" name="buttonLStickDownVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelLStickDown">
-            <property name="text">
-             <string>Down:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonLStickDownHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelLStickDown">
+              <property name="text">
+               <string>Down:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxLStickDown">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonLStickDown">
@@ -587,11 +1089,31 @@ Capture:</string>
         <item row="0" column="1">
          <layout class="QVBoxLayout" name="buttonLStickRightVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelLStickRight">
-            <property name="text">
-             <string>Right:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonLStickRightHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelLStickRight">
+              <property name="text">
+               <string>Right:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxLStickRight">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonLStickRight">
@@ -605,11 +1127,31 @@ Capture:</string>
         <item row="0" column="0">
          <layout class="QVBoxLayout" name="buttonLStickLeftVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelLStickLeft">
-            <property name="text">
-             <string>Left:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonLStickLeftHorizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="labelLStickLeft">
+              <property name="text">
+               <string>Left:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxLStickLeft">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonLStickLeft">
@@ -623,11 +1165,31 @@ Capture:</string>
         <item row="1" column="0">
          <layout class="QVBoxLayout" name="buttonLStickUpVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelLStickUp">
-            <property name="text">
-             <string>Up:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonLStickUpHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelLStickUp">
+              <property name="text">
+               <string>Up:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxLStickUp">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonLStickUp">
@@ -641,11 +1203,31 @@ Capture:</string>
         <item row="3" column="0">
          <layout class="QVBoxLayout" name="buttonLStickModVerticalLayout">
           <item>
-           <widget class="QLabel" name="labelLStickMod">
-            <property name="text">
-             <string>Modifier:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonLStickModHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelLStickMod">
+              <property name="text">
+               <string>Modifier:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxLStickMod">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonLStickMod">
@@ -659,11 +1241,31 @@ Capture:</string>
         <item row="3" column="1">
          <layout class="QVBoxLayout" name="buttonLStickPressedVerticalLayout" stretch="0,0">
           <item>
-           <widget class="QLabel" name="labelLStickPressed">
-            <property name="text">
-             <string>Pressed:</string>
-            </property>
-           </widget>
+           <layout class="QHBoxLayout" name="buttonLStickPressedHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelLStickPressed">
+              <property name="text">
+               <string>Pressed:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QCheckBox" name="checkboxLStickPressed">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string/>
+              </property>
+              <property name="checkable">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
           <item>
            <widget class="QPushButton" name="buttonLStick">
@@ -678,6 +1280,22 @@ Capture:</string>
       </widget>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="override_label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Check the box to override the global default key with this one for this game only.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">

--- a/src/yuzu/configuration/configure_per_game.ui
+++ b/src/yuzu/configuration/configure_per_game.ui
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigurePerGameDialog</class>
+ <widget class="QDialog" name="ConfigurePerGameDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>461</width>
+    <height>500</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>yuzu Game Configuration</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="ConfigurePerGameGeneral" name="generalTab">
+      <attribute name="title">
+       <string>General</string>
+      </attribute>
+     </widget>
+      <widget class="ConfigureInput" name="inputTab">
+        <attribute name="title">
+          <string>Input</string>
+        </attribute>
+      </widget>
+      <widget class="ConfigureGraphics" name="graphicsTab">
+        <attribute name="title">
+          <string>Graphics</string>
+        </attribute>
+      </widget>
+      <widget class="ConfigureAudio" name="audioTab">
+        <attribute name="title">
+          <string>Audio</string>
+        </attribute>
+      </widget>
+      <widget class="ConfigureDebug" name="debugTab">
+        <attribute name="title">
+          <string>Debug</string>
+        </attribute>
+      </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ConfigurePerGameGeneral</class>
+   <extends>QWidget</extends>
+   <header>configuration/configure_per_general.h</header>
+   <container>1</container>
+  </customwidget>
+   <customwidget>
+     <class>ConfigureInput</class>
+     <extends>QWidget</extends>
+     <header>configuration/configure_input.h</header>
+     <container>1</container>
+   </customwidget>
+   <customwidget>
+     <class>ConfigureGraphics</class>
+     <extends>QWidget</extends>
+     <header>configuration/configure_graphics.h</header>
+     <container>1</container>
+   </customwidget>
+   <customwidget>
+     <class>ConfigureAudio</class>
+     <extends>QWidget</extends>
+     <header>configuration/configure_audio.h</header>
+     <container>1</container>
+   </customwidget>
+   <customwidget>
+     <class>ConfigureDebug</class>
+     <extends>QWidget</extends>
+     <header>configuration/configure_debug.h</header>
+     <container>1</container>
+   </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ConfigurePerGameDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>220</x>
+     <y>380</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>220</x>
+     <y>200</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ConfigurePerGameDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>220</x>
+     <y>380</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>220</x>
+     <y>200</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/yuzu/configuration/configure_per_game_dialog.cpp
+++ b/src/yuzu/configuration/configure_per_game_dialog.cpp
@@ -1,0 +1,45 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/settings.h"
+#include "ui_configure_per_game.h"
+#include "yuzu/configuration/config.h"
+#include "yuzu/configuration/configure_per_game_dialog.h"
+
+ConfigurePerGameDialog::ConfigurePerGameDialog(QWidget* parent, FileSys::VirtualFile file,
+                                               const PerGameValuesChange& change)
+    : QDialog(parent), ui(new Ui::ConfigurePerGameDialog) {
+    ui->setupUi(this);
+    ui->generalTab->loadFromFile(std::move(file));
+    ui->generalTab->loadValuesChange(change);
+    ui->inputTab->setPerGame(true);
+    ui->inputTab->loadValuesChange(change);
+    ui->graphicsTab->setPerGame(true);
+    ui->graphicsTab->loadValuesChange(change);
+    ui->audioTab->setPerGame(true);
+    ui->audioTab->loadValuesChange(change);
+    ui->debugTab->setPerGame(true);
+    ui->debugTab->loadValuesChange(change);
+    this->setConfiguration();
+}
+
+ConfigurePerGameDialog::~ConfigurePerGameDialog() = default;
+
+void ConfigurePerGameDialog::setConfiguration() {}
+
+PerGameValuesChange ConfigurePerGameDialog::applyConfiguration() {
+    PerGameValuesChange out{};
+    ui->generalTab->applyConfiguration();
+    ui->generalTab->mergeValuesChange(out);
+    ui->inputTab->applyConfiguration();
+    ui->inputTab->mergeValuesChange(out);
+    ui->graphicsTab->applyConfiguration();
+    ui->graphicsTab->mergeValuesChange(out);
+    ui->audioTab->applyConfiguration();
+    ui->audioTab->mergeValuesChange(out);
+    ui->debugTab->applyConfiguration();
+    ui->debugTab->mergeValuesChange(out);
+    Settings::Apply();
+    return out;
+}

--- a/src/yuzu/configuration/configure_per_game_dialog.cpp
+++ b/src/yuzu/configuration/configure_per_game_dialog.cpp
@@ -8,11 +8,11 @@
 #include "yuzu/configuration/config.h"
 #include "yuzu/configuration/configure_per_game_dialog.h"
 
-ConfigurePerGameDialog::ConfigurePerGameDialog(QWidget* parent, FileSys::VirtualFile file,
+ConfigurePerGameDialog::ConfigurePerGameDialog(QWidget* parent, Loader::AppLoader& loader,
                                                const PerGameValuesChange& change)
     : QDialog(parent), ui(new Ui::ConfigurePerGameDialog) {
     ui->setupUi(this);
-    ui->generalTab->loadFromFile(std::move(file));
+    ui->generalTab->loadGameData(loader);
     ui->generalTab->loadValuesChange(change);
     ui->inputTab->setPerGame(true);
     ui->inputTab->loadValuesChange(change);

--- a/src/yuzu/configuration/configure_per_game_dialog.cpp
+++ b/src/yuzu/configuration/configure_per_game_dialog.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/file_sys/vfs.h"
 #include "core/settings.h"
 #include "ui_configure_per_game.h"
 #include "yuzu/configuration/config.h"

--- a/src/yuzu/configuration/configure_per_game_dialog.h
+++ b/src/yuzu/configuration/configure_per_game_dialog.h
@@ -1,0 +1,29 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <QDialog>
+#include "core/file_sys/vfs.h"
+
+namespace Ui {
+class ConfigurePerGameDialog;
+}
+
+class ConfigurePerGameDialog : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit ConfigurePerGameDialog(QWidget* parent, FileSys::VirtualFile file,
+                                    const PerGameValuesChange& change);
+    ~ConfigurePerGameDialog();
+
+    PerGameValuesChange applyConfiguration();
+
+private:
+    void setConfiguration();
+
+    std::unique_ptr<Ui::ConfigurePerGameDialog> ui;
+};

--- a/src/yuzu/configuration/configure_per_game_dialog.h
+++ b/src/yuzu/configuration/configure_per_game_dialog.h
@@ -6,7 +6,10 @@
 
 #include <memory>
 #include <QDialog>
-#include "core/file_sys/vfs_types.h"
+
+namespace Loader {
+class AppLoader;
+}
 
 namespace Ui {
 class ConfigurePerGameDialog;
@@ -16,7 +19,7 @@ class ConfigurePerGameDialog : public QDialog {
     Q_OBJECT
 
 public:
-    explicit ConfigurePerGameDialog(QWidget* parent, FileSys::VirtualFile file,
+    explicit ConfigurePerGameDialog(QWidget* parent, Loader::AppLoader& file,
                                     const PerGameValuesChange& change);
     ~ConfigurePerGameDialog();
 

--- a/src/yuzu/configuration/configure_per_game_dialog.h
+++ b/src/yuzu/configuration/configure_per_game_dialog.h
@@ -6,7 +6,7 @@
 
 #include <memory>
 #include <QDialog>
-#include "core/file_sys/vfs.h"
+#include "core/file_sys/vfs_types.h"
 
 namespace Ui {
 class ConfigurePerGameDialog;

--- a/src/yuzu/configuration/configure_per_general.cpp
+++ b/src/yuzu/configuration/configure_per_general.cpp
@@ -73,6 +73,10 @@ void ConfigurePerGameGeneral::applyConfiguration() {
     }
 
     Settings::values->disabled_patches = disabled_add_ons;
+
+    Settings::values->use_docked_mode = ui->use_docked_mode->checkState() == Qt::PartiallyChecked
+                                            ? Settings::values.default_game.use_docked_mode
+                                            : ui->use_docked_mode->isChecked();
 }
 
 void ConfigurePerGameGeneral::loadFromFile(FileSys::VirtualFile file) {

--- a/src/yuzu/configuration/configure_per_general.cpp
+++ b/src/yuzu/configuration/configure_per_general.cpp
@@ -1,0 +1,174 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+#include <QMenu>
+#include <QMessageBox>
+#include <QStandardItemModel>
+#include <QString>
+#include <QTimer>
+#include <QTreeView>
+#include "common/param_package.h"
+#include "core/file_sys/control_metadata.h"
+#include "core/file_sys/patch_manager.h"
+#include "core/file_sys/xts_archive.h"
+#include "core/loader/loader.h"
+#include "input_common/main.h"
+#include "yuzu/configuration/config.h"
+#include "yuzu/configuration/configure_input.h"
+#include "yuzu/configuration/configure_per_general.h"
+
+ConfigurePerGameGeneral::ConfigurePerGameGeneral(QWidget* parent)
+    : QWidget(parent), ui(std::make_unique<Ui::ConfigurePerGameGeneral>()) {
+
+    ui->setupUi(this);
+    setFocusPolicy(Qt::ClickFocus);
+
+    layout = new QVBoxLayout;
+    tree_view = new QTreeView;
+    item_model = new QStandardItemModel(tree_view);
+    tree_view->setModel(item_model);
+    tree_view->setAlternatingRowColors(true);
+    tree_view->setSelectionMode(QHeaderView::SingleSelection);
+    tree_view->setSelectionBehavior(QHeaderView::SelectRows);
+    tree_view->setVerticalScrollMode(QHeaderView::ScrollPerPixel);
+    tree_view->setHorizontalScrollMode(QHeaderView::ScrollPerPixel);
+    tree_view->setSortingEnabled(true);
+    tree_view->setEditTriggers(QHeaderView::NoEditTriggers);
+    tree_view->setUniformRowHeights(true);
+    tree_view->setContextMenuPolicy(Qt::NoContextMenu);
+
+    item_model->insertColumns(0, 2);
+    item_model->setHeaderData(0, Qt::Horizontal, "Patch Name");
+    item_model->setHeaderData(1, Qt::Horizontal, "Version");
+
+    // We must register all custom types with the Qt Automoc system so that we are able to use it
+    // with signals/slots. In this case, QList falls under the umbrells of custom types.
+    qRegisterMetaType<QList<QStandardItem*>>("QList<QStandardItem*>");
+
+    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setSpacing(0);
+    layout->addWidget(tree_view);
+
+    ui->scrollArea->setLayout(layout);
+
+    scene = new QGraphicsScene;
+    ui->icon_view->setScene(scene);
+
+    this->loadConfiguration();
+}
+
+void ConfigurePerGameGeneral::applyConfiguration() {
+    std::vector<std::string> disabled_add_ons;
+
+    for (const auto& item : list_items) {
+        const auto disabled = item.front()->checkState() == Qt::Unchecked;
+        if (disabled)
+            disabled_add_ons.push_back(item.front()->text().toStdString());
+    }
+
+    Settings::values->disabled_patches = disabled_add_ons;
+}
+
+void ConfigurePerGameGeneral::loadFromFile(FileSys::VirtualFile file) {
+    this->file = std::move(file);
+    this->loadConfiguration();
+}
+
+void ConfigurePerGameGeneral::loadValuesChange(const PerGameValuesChange& change) {
+    ui->use_docked_mode->setCheckState(
+        change.use_docked_mode ? (Settings::values->use_docked_mode ? Qt::Checked : Qt::Unchecked)
+                               : Qt::PartiallyChecked);
+}
+
+void ConfigurePerGameGeneral::mergeValuesChange(PerGameValuesChange& change) {
+    change.use_docked_mode = ui->use_docked_mode->checkState() != Qt::PartiallyChecked;
+}
+
+void ConfigurePerGameGeneral::loadConfiguration() {
+    if (file == nullptr)
+        return;
+
+    const auto loader = Loader::GetLoader(file);
+
+    u64 program_id{};
+    if (loader->ReadProgramId(program_id) == Loader::ResultStatus::Success) {
+        ui->display_title_id->setText(fmt::format("{:016X}", program_id).c_str());
+
+        FileSys::PatchManager pm{program_id};
+        const auto control = pm.GetControlMetadata();
+
+        if (control.first != nullptr) {
+            ui->display_version->setText(QString::fromStdString(control.first->GetVersionString()));
+            ui->display_name->setText(QString::fromStdString(control.first->GetApplicationName()));
+            ui->display_developer->setText(
+                QString::fromStdString(control.first->GetDeveloperName()));
+        } else {
+            std::string title;
+            if (loader->ReadTitle(title) == Loader::ResultStatus::Success)
+                ui->display_name->setText(QString::fromStdString(title));
+
+            std::string developer;
+            if (loader->ReadDeveloper(developer) == Loader::ResultStatus::Success)
+                ui->display_developer->setText(QString::fromStdString(developer));
+
+            ui->display_version->setText("1.0.0");
+        }
+
+        if (control.second != nullptr) {
+            scene->clear();
+
+            QPixmap map;
+            const auto bytes = control.second->ReadAllBytes();
+            map.loadFromData(bytes.data(), bytes.size());
+
+            scene->addPixmap(map.scaled(ui->icon_view->width(), ui->icon_view->height(),
+                                        Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+        } else {
+            std::vector<u8> bytes;
+            if (loader->ReadIcon(bytes) == Loader::ResultStatus::Success) {
+                scene->clear();
+
+                QPixmap map;
+                map.loadFromData(bytes.data(), bytes.size());
+
+                scene->addPixmap(map.scaled(ui->icon_view->width(), ui->icon_view->height(),
+                                            Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
+            }
+        }
+
+        FileSys::VirtualFile update_raw;
+        loader->ReadUpdateRaw(update_raw);
+
+        const auto& disabled = Settings::values[program_id].disabled_patches;
+
+        for (const auto& patch : pm.GetPatchVersionNames(update_raw)) {
+            QStandardItem* first_item = new QStandardItem;
+            first_item->setText(QString::fromStdString(patch.first));
+            first_item->setCheckable(true);
+
+            const auto patch_disabled =
+                std::find(disabled.begin(), disabled.end(), patch.first) != disabled.end();
+
+            first_item->setCheckState(patch_disabled ? Qt::Unchecked : Qt::Checked);
+
+            list_items.push_back(QList<QStandardItem*>{
+                first_item, new QStandardItem{QString::fromStdString(patch.second)}});
+            item_model->appendRow(list_items.back());
+        }
+
+        tree_view->setColumnWidth(0, 5 * tree_view->width() / 16);
+    }
+
+    ui->display_filename->setText(QString::fromStdString(file->GetName()));
+
+    ui->display_format->setText(
+        QString::fromStdString(Loader::GetFileTypeString(loader->GetFileType())));
+
+    QLocale locale = this->locale();
+    QString valueText = locale.formattedDataSize(file->GetSize());
+    ui->display_size->setText(valueText);
+}

--- a/src/yuzu/configuration/configure_per_general.cpp
+++ b/src/yuzu/configuration/configure_per_general.cpp
@@ -1,10 +1,11 @@
-// Copyright 2016 Citra Emulator Project
+// Copyright 2018 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
 #include <algorithm>
 #include <memory>
 #include <utility>
+#include <QHeaderView>
 #include <QMenu>
 #include <QMessageBox>
 #include <QStandardItemModel>
@@ -23,7 +24,6 @@
 
 ConfigurePerGameGeneral::ConfigurePerGameGeneral(QWidget* parent)
     : QWidget(parent), ui(std::make_unique<Ui::ConfigurePerGameGeneral>()) {
-
     ui->setupUi(this);
     setFocusPolicy(Qt::ClickFocus);
 
@@ -42,8 +42,8 @@ ConfigurePerGameGeneral::ConfigurePerGameGeneral(QWidget* parent)
     tree_view->setContextMenuPolicy(Qt::NoContextMenu);
 
     item_model->insertColumns(0, 2);
-    item_model->setHeaderData(0, Qt::Horizontal, "Patch Name");
-    item_model->setHeaderData(1, Qt::Horizontal, "Version");
+    item_model->setHeaderData(0, Qt::Horizontal, tr("Patch Name"));
+    item_model->setHeaderData(1, Qt::Horizontal, tr("Version"));
 
     // We must register all custom types with the Qt Automoc system so that we are able to use it
     // with signals/slots. In this case, QList falls under the umbrells of custom types.
@@ -60,6 +60,8 @@ ConfigurePerGameGeneral::ConfigurePerGameGeneral(QWidget* parent)
 
     this->loadConfiguration();
 }
+
+ConfigurePerGameGeneral::~ConfigurePerGameGeneral() = default;
 
 void ConfigurePerGameGeneral::applyConfiguration() {
     std::vector<std::string> disabled_add_ons;
@@ -96,7 +98,7 @@ void ConfigurePerGameGeneral::loadConfiguration() {
 
     u64 program_id{};
     if (loader->ReadProgramId(program_id) == Loader::ResultStatus::Success) {
-        ui->display_title_id->setText(fmt::format("{:016X}", program_id).c_str());
+        ui->display_title_id->setText(QStringLiteral("%1").arg(program_id, 16, 16, QChar{'0'}));
 
         FileSys::PatchManager pm{program_id};
         const auto control = pm.GetControlMetadata();

--- a/src/yuzu/configuration/configure_per_general.cpp
+++ b/src/yuzu/configuration/configure_per_general.cpp
@@ -22,6 +22,7 @@
 #include "yuzu/configuration/configure_input.h"
 #include "yuzu/configuration/configure_per_general.h"
 #include "yuzu/ui_settings.h"
+#include "yuzu/util/util.h"
 
 ConfigurePerGameGeneral::ConfigurePerGameGeneral(QWidget* parent)
     : QWidget(parent), ui(std::make_unique<Ui::ConfigurePerGameGeneral>()) {
@@ -158,8 +159,7 @@ void ConfigurePerGameGeneral::loadGameData(Loader::AppLoader& loader) {
     ui->display_format->setText(
         QString::fromStdString(Loader::GetFileTypeString(loader.GetFileType())));
 
-    QLocale locale = this->locale();
-    QString valueText = locale.formattedDataSize(file->GetSize());
+    QString valueText = ReadableByteSize(file->GetSize());
     ui->display_size->setText(valueText);
 }
 

--- a/src/yuzu/configuration/configure_per_general.cpp
+++ b/src/yuzu/configuration/configure_per_general.cpp
@@ -21,6 +21,7 @@
 #include "yuzu/configuration/config.h"
 #include "yuzu/configuration/configure_input.h"
 #include "yuzu/configuration/configure_per_general.h"
+#include "yuzu/ui_settings.h"
 
 ConfigurePerGameGeneral::ConfigurePerGameGeneral(QWidget* parent)
     : QWidget(parent), ui(std::make_unique<Ui::ConfigurePerGameGeneral>()) {
@@ -59,6 +60,9 @@ ConfigurePerGameGeneral::ConfigurePerGameGeneral(QWidget* parent)
     ui->icon_view->setScene(scene);
 
     this->loadConfiguration();
+
+    connect(item_model, &QStandardItemModel::itemChanged, this,
+            []() { UISettings::values.is_game_list_reload_pending.exchange(true); });
 }
 
 ConfigurePerGameGeneral::~ConfigurePerGameGeneral() = default;

--- a/src/yuzu/configuration/configure_per_general.h
+++ b/src/yuzu/configuration/configure_per_general.h
@@ -17,6 +17,10 @@ class QStandardItem;
 class QStandardItemModel;
 class QTreeView;
 
+namespace Loader {
+class AppLoader;
+}
+
 namespace Ui {
 class ConfigurePerGameGeneral;
 }
@@ -31,16 +35,13 @@ public:
     /// Save all button configurations to settings file
     void applyConfiguration();
 
-    void loadFromFile(FileSys::VirtualFile file);
+    void loadGameData(Loader::AppLoader& file);
 
     void loadValuesChange(const PerGameValuesChange& change);
     void mergeValuesChange(PerGameValuesChange& change);
 
 private:
-    void loadConfiguration();
-
     std::unique_ptr<Ui::ConfigurePerGameGeneral> ui;
-    FileSys::VirtualFile file;
 
     QVBoxLayout* layout;
     QTreeView* tree_view;

--- a/src/yuzu/configuration/configure_per_general.h
+++ b/src/yuzu/configuration/configure_per_general.h
@@ -4,26 +4,18 @@
 
 #pragma once
 
-#include <array>
-#include <functional>
 #include <memory>
-#include <string>
-#include <unordered_map>
 #include <QKeyEvent>
 #include <QList>
 #include <QWidget>
-#include <boost/optional.hpp>
-#include "common/param_package.h"
 #include "core/file_sys/vfs.h"
-#include "core/settings.h"
-#include "input_common/main.h"
 #include "ui_configure_per_general.h"
 #include "yuzu/configuration/config.h"
 
-class QTreeView;
 class QGraphicsScene;
 class QStandardItem;
 class QStandardItemModel;
+class QTreeView;
 
 namespace Ui {
 class ConfigurePerGameGeneral;
@@ -34,6 +26,7 @@ class ConfigurePerGameGeneral : public QWidget {
 
 public:
     explicit ConfigurePerGameGeneral(QWidget* parent = nullptr);
+    ~ConfigurePerGameGeneral() override;
 
     /// Save all button configurations to settings file
     void applyConfiguration();
@@ -44,6 +37,8 @@ public:
     void mergeValuesChange(PerGameValuesChange& change);
 
 private:
+    void loadConfiguration();
+
     std::unique_ptr<Ui::ConfigurePerGameGeneral> ui;
     FileSys::VirtualFile file;
 
@@ -53,6 +48,4 @@ private:
     QGraphicsScene* scene;
 
     std::vector<QList<QStandardItem*>> list_items;
-
-    void loadConfiguration();
 };

--- a/src/yuzu/configuration/configure_per_general.h
+++ b/src/yuzu/configuration/configure_per_general.h
@@ -1,0 +1,58 @@
+﻿// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <QKeyEvent>
+#include <QList>
+#include <QWidget>
+#include <boost/optional.hpp>
+#include "common/param_package.h"
+#include "core/file_sys/vfs.h"
+#include "core/settings.h"
+#include "input_common/main.h"
+#include "ui_configure_per_general.h"
+#include "yuzu/configuration/config.h"
+
+class QTreeView;
+class QGraphicsScene;
+class QStandardItem;
+class QStandardItemModel;
+
+namespace Ui {
+class ConfigurePerGameGeneral;
+}
+
+class ConfigurePerGameGeneral : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ConfigurePerGameGeneral(QWidget* parent = nullptr);
+
+    /// Save all button configurations to settings file
+    void applyConfiguration();
+
+    void loadFromFile(FileSys::VirtualFile file);
+
+    void loadValuesChange(const PerGameValuesChange& change);
+    void mergeValuesChange(PerGameValuesChange& change);
+
+private:
+    std::unique_ptr<Ui::ConfigurePerGameGeneral> ui;
+    FileSys::VirtualFile file;
+
+    QVBoxLayout* layout;
+    QTreeView* tree_view;
+    QStandardItemModel* item_model;
+    QGraphicsScene* scene;
+
+    std::vector<QList<QStandardItem*>> list_items;
+
+    void loadConfiguration();
+};

--- a/src/yuzu/configuration/configure_per_general.ui
+++ b/src/yuzu/configuration/configure_per_general.ui
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigurePerGameGeneral</class>
+ <widget class="QWidget" name="ConfigurePerGameGeneral">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>540</width>
+    <height>589</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>ConfigurePerGameGeneral</string>
+  </property>
+  <layout class="QHBoxLayout" name="HorizontalLayout">
+   <item>
+    <layout class="QVBoxLayout" name="VerticalLayout">
+     <item>
+      <widget class="QGroupBox" name="GeneralGroupBox">
+       <property name="title">
+        <string>Info</string>
+       </property>
+       <layout class="QHBoxLayout" name="GeneralHorizontalLayout">
+        <item>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="6" column="1" colspan="2">
+           <widget class="QLineEdit" name="display_filename">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="display_name">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Developer</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1" colspan="2">
+           <widget class="QLineEdit" name="display_size">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Name</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Filename</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Version</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Format</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="display_version">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="display_format">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Size</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="display_developer">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Title ID</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="display_title_id">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2" rowspan="5">
+           <widget class="QGraphicsView" name="icon_view">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>128</width>
+              <height>128</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>128</width>
+              <height>128</height>
+             </size>
+            </property>
+            <property name="verticalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+            <property name="horizontalScrollBarPolicy">
+             <enum>Qt::ScrollBarAlwaysOff</enum>
+            </property>
+            <property name="sizeAdjustPolicy">
+             <enum>QAbstractScrollArea::AdjustToContents</enum>
+            </property>
+            <property name="interactive">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="PerformanceGroupBox">
+       <property name="title">
+        <string>Add-Ons</string>
+       </property>
+       <layout class="QHBoxLayout" name="PerformanceHorizontalLayout">
+        <item>
+         <widget class="QScrollArea" name="scrollArea">
+          <property name="widgetResizable">
+           <bool>true</bool>
+          </property>
+          <widget class="QWidget" name="scrollAreaWidgetContents">
+           <property name="geometry">
+            <rect>
+             <x>0</x>
+             <y>0</y>
+             <width>490</width>
+             <height>108</height>
+            </rect>
+           </property>
+          </widget>
+         </widget>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="PerformanceVerticalLayout"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="title">
+        <string>System</string>
+       </property>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QCheckBox" name="use_docked_mode">
+          <property name="text">
+           <string>Use Docked Mode</string>
+          </property>
+          <property name="tristate">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -37,43 +37,44 @@ public:
     QSize sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 };
 
-void HTMLDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option,
+void HTMLDelegate::paint(QPainter* painter, const QStyleOptionViewItem& _option,
                          const QModelIndex& index) const {
-    QStyleOptionViewItemV4 optionV4 = option;
-    initStyleOption(&optionV4, index);
+    auto option = _option;
+    initStyleOption(&option, index);
 
-    QStyle* style = optionV4.widget ? optionV4.widget->style() : QApplication::style();
+    QStyle* style = option.widget ? option.widget->style() : QApplication::style();
 
-    QTextDocument doc;
-    doc.setHtml(optionV4.text);
+    QTextDocument document;
+    document.setHtml(option.text);
 
     /// Painting item without text
-    optionV4.text = QString();
-    style->drawControl(QStyle::CE_ItemViewItem, &optionV4, painter);
+    option.text = QString();
+    style->drawControl(QStyle::CE_ItemViewItem, &option, painter);
 
     QAbstractTextDocumentLayout::PaintContext ctx;
 
     // Highlighting text if item is selected
-    if (optionV4.state & QStyle::State_Selected)
+    if (option.state & QStyle::State_Selected) {
         ctx.palette.setColor(QPalette::Text,
-                             optionV4.palette.color(QPalette::Active, QPalette::HighlightedText));
+                             option.palette.color(QPalette::Active, QPalette::HighlightedText));
+    }
 
-    QRect textRect = style->subElementRect(QStyle::SE_ItemViewItemText, &optionV4);
+    QRect textRect = style->subElementRect(QStyle::SE_ItemViewItemText, &option);
     painter->save();
     painter->translate(textRect.topLeft());
     painter->setClipRect(textRect.translated(-textRect.topLeft()));
-    doc.documentLayout()->draw(painter, ctx);
+    document.documentLayout()->draw(painter, ctx);
     painter->restore();
 }
 
-QSize HTMLDelegate::sizeHint(const QStyleOptionViewItem& option, const QModelIndex& index) const {
-    QStyleOptionViewItemV4 optionV4 = option;
-    initStyleOption(&optionV4, index);
+QSize HTMLDelegate::sizeHint(const QStyleOptionViewItem& _option, const QModelIndex& index) const {
+    auto option = _option;
+    initStyleOption(&option, index);
 
-    QTextDocument doc;
-    doc.setHtml(optionV4.text);
-    doc.setTextWidth(optionV4.rect.width());
-    return QSize(doc.idealWidth(), doc.size().height());
+    QTextDocument document;
+    document.setHtml(option.text);
+    document.setTextWidth(option.rect.width());
+    return QSize(document.idealWidth(), UISettings::values.icon_size);
 }
 
 GameListSearchField::KeyReleaseEater::KeyReleaseEater(GameList* gamelist) : gamelist{gamelist} {}

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -393,9 +393,8 @@ void GameList::PopupContextMenu(const QPoint& menu_location) {
     connect(copy_tid, &QAction::triggered, [&]() { emit CopyTIDRequested(program_id); });
     connect(navigate_to_gamedb_entry, &QAction::triggered,
             [&]() { emit NavigateToGamedbEntryRequested(program_id, compatibility_list); });
-    connect(properties, &QAction::triggered, [&]() {
-        emit OpenGamePropertiesDialogRequested(vfs->OpenFile(path, FileSys::Mode::Read));
-    });
+    connect(properties, &QAction::triggered,
+            [&]() { emit OpenGamePropertiesDialogRequested(path); });
 
     context_menu.exec(tree_view->viewport()->mapToGlobal(menu_location));
 }

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -52,6 +52,9 @@ public:
         if (option.state & QStyle::State_Selected) {
             ctx.palette.setColor(QPalette::Text,
                                  option.palette.color(QPalette::Active, QPalette::HighlightedText));
+        } else {
+            ctx.palette.setColor(QPalette::Text,
+                                 option.palette.color(QPalette::Normal, QPalette::Text));
         }
 
         QRect textRect = style->subElementRect(QStyle::SE_ItemViewItemText, &option);

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -69,7 +69,7 @@ signals:
     void OpenFolderRequested(u64 program_id, GameListOpenTarget target);
     void DumpRomFSRequested(u64 program_id, const std::string& game_path);
     void CopyTIDRequested(u64 program_id);
-    void OpenGamePropertiesDialogRequested(FileSys::VirtualFile file);
+    void OpenGamePropertiesDialogRequested(const std::string& file);
     void NavigateToGamedbEntryRequested(u64 program_id,
                                         const CompatibilityList& compatibility_list);
 

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -68,6 +68,7 @@ signals:
     void OpenFolderRequested(u64 program_id, GameListOpenTarget target);
     void DumpRomFSRequested(u64 program_id, const std::string& game_path);
     void CopyTIDRequested(u64 program_id);
+    void OpenGamePropertiesDialogRequested(FileSys::VirtualFile file);
     void NavigateToGamedbEntryRequested(u64 program_id,
                                         const CompatibilityList& compatibility_list);
 

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -19,6 +19,7 @@
 #include <QWidget>
 
 #include "common/common_types.h"
+#include "core/file_sys/vfs_types.h"
 #include "yuzu/compatibility_list.h"
 
 class GameListWorker;

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -95,7 +95,7 @@ public:
             if (row2.isEmpty())
                 return row1;
 
-            return row1 + "\n    " + row2;
+            return row1 + "<br>    " + row2;
         }
 
         return GameListItem::data(role);

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <utility>

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -75,7 +75,8 @@ QString FormatPatchNameVersions(const FileSys::PatchManager& patch_manager,
         const QString type = QString::fromStdString(kv.first);
 
         if (kv.second.empty()) {
-            out.append(QStringLiteral(patch_disabled ? "<s>%1</s><br>" : "%1<br>").arg(type));
+            out.append((patch_disabled ? QStringLiteral("<s>%1</s><br>") : QStringLiteral("%1<br>"))
+                           .arg(type));
         } else {
             auto ver = kv.second;
 
@@ -84,7 +85,9 @@ QString FormatPatchNameVersions(const FileSys::PatchManager& patch_manager,
                 ver = Loader::GetFileTypeString(loader.GetFileType());
             }
 
-            out.append(QStringLiteral(patch_disabled ? "<s>%1 (%2)</s><br>" : "%1 (%2)<br>").arg(type, QString::fromStdString(ver)));
+            out.append((patch_disabled ? QStringLiteral("<s>%1 (%2)</s><br>")
+                                       : QStringLiteral("%1 (%2)<br>"))
+                           .arg(type, QString::fromStdString(ver)));
         }
     }
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -984,7 +984,9 @@ void GMainWindow::OnGameListOpenProperties(FileSys::VirtualFile file) {
 
     config->SetPerGameSettingsDelta(title_id, dialog.applyConfiguration());
     config->Save();
-    game_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
+    const auto reload = UISettings::values.is_game_list_reload_pending.exchange(false);
+    if (reload)
+        game_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
 }
 
 void GMainWindow::OnMenuLoadFile() {
@@ -1355,7 +1357,11 @@ void GMainWindow::OnConfigure() {
             UpdateUITheme();
         if (UISettings::values.enable_discord_presence != old_discord_presence)
             SetDiscordEnabled(UISettings::values.enable_discord_presence);
-        game_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
+        const auto reload = UISettings::values.is_game_list_reload_pending.exchange(false);
+        if (reload) {
+            game_list->PopulateAsync(UISettings::values.gamedir,
+                                     UISettings::values.gamedir_deepscan);
+        }
         config->Save();
     }
 }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -979,11 +979,12 @@ void GMainWindow::OnGameListOpenProperties(FileSys::VirtualFile file) {
     Settings::values.SetCurrentTitleID(title_id);
     ConfigurePerGameDialog dialog{this, file, config->GetPerGameSettingsDelta(title_id)};
     auto result = dialog.exec();
-    if (result == QDialog::Accepted) {
-        config->SetPerGameSettingsDelta(title_id, dialog.applyConfiguration());
-        config->Save();
-        game_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
-    }
+    if (result != QDialog::Accepted)
+        return;
+
+    config->SetPerGameSettingsDelta(title_id, dialog.applyConfiguration());
+    config->Save();
+    game_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
 }
 
 void GMainWindow::OnMenuLoadFile() {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -339,21 +339,21 @@ void GMainWindow::InitializeHotkeys() {
             });
     connect(hotkey_registry.GetHotkey("Main Window", "Toggle Speed Limit", this),
             &QShortcut::activated, this, [&] {
-                Settings::values.use_frame_limit = !Settings::values.use_frame_limit;
+                Settings::values->use_frame_limit = !Settings::values->use_frame_limit;
                 UpdateStatusBar();
             });
     constexpr u16 SPEED_LIMIT_STEP = 5;
     connect(hotkey_registry.GetHotkey("Main Window", "Increase Speed Limit", this),
             &QShortcut::activated, this, [&] {
-                if (Settings::values.frame_limit < 9999 - SPEED_LIMIT_STEP) {
-                    Settings::values.frame_limit += SPEED_LIMIT_STEP;
+                if (Settings::values->frame_limit < 9999 - SPEED_LIMIT_STEP) {
+                    Settings::values->frame_limit += SPEED_LIMIT_STEP;
                     UpdateStatusBar();
                 }
             });
     connect(hotkey_registry.GetHotkey("Main Window", "Decrease Speed Limit", this),
             &QShortcut::activated, this, [&] {
-                if (Settings::values.frame_limit > SPEED_LIMIT_STEP) {
-                    Settings::values.frame_limit -= SPEED_LIMIT_STEP;
+                if (Settings::values->frame_limit > SPEED_LIMIT_STEP) {
+                    Settings::values->frame_limit -= SPEED_LIMIT_STEP;
                     UpdateStatusBar();
                 }
             });
@@ -1375,10 +1375,10 @@ void GMainWindow::UpdateStatusBar() {
 
     auto results = Core::System::GetInstance().GetAndResetPerfStats();
 
-    if (Settings::values.use_frame_limit) {
+    if (Settings::values->use_frame_limit) {
         emu_speed_label->setText(tr("Speed: %1% / %2%")
                                      .arg(results.emulation_speed * 100.0, 0, 'f', 0)
-                                     .arg(Settings::values.frame_limit));
+                                     .arg(Settings::values->frame_limit));
     } else {
         emu_speed_label->setText(tr("Speed: %1%").arg(results.emulation_speed * 100.0, 0, 'f', 0));
     }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -74,6 +74,8 @@ static FileSys::VirtualFile VfsDirectoryCreateFileWrapper(const FileSys::Virtual
 #include "yuzu/compatibility_list.h"
 #include "yuzu/configuration/config.h"
 #include "yuzu/configuration/configure_dialog.h"
+#include "yuzu/configuration/configure_per_game_dialog.h"
+#include "yuzu/configuration/configure_per_general.h"
 #include "yuzu/debugger/console.h"
 #include "yuzu/debugger/graphics/graphics_breakpoints.h"
 #include "yuzu/debugger/graphics/graphics_surface.h"
@@ -405,6 +407,8 @@ void GMainWindow::ConnectWidgetEvents() {
     connect(game_list, &GameList::CopyTIDRequested, this, &GMainWindow::OnGameListCopyTID);
     connect(game_list, &GameList::NavigateToGamedbEntryRequested, this,
             &GMainWindow::OnGameListNavigateToGamedbEntry);
+    connect(game_list, &GameList::OpenGamePropertiesDialogRequested, this,
+            &GMainWindow::OnGameListOpenProperties);
 
     connect(this, &GMainWindow::EmulationStarting, render_window,
             &GRenderWindow::OnEmulationStarting);
@@ -453,6 +457,7 @@ void GMainWindow::ConnectMenuEvents() {
     connect(ui.action_Fullscreen, &QAction::triggered, this, &GMainWindow::ToggleFullscreen);
 
     // Help
+    connect(ui.action_Open_yuzu_Folder, &QAction::triggered, this, &GMainWindow::OnOpenYuzuFolder);
     connect(ui.action_Rederive, &QAction::triggered, this,
             std::bind(&GMainWindow::OnReinitializeKeys, this, ReinitializeKeyBehavior::Warning));
     connect(ui.action_About, &QAction::triggered, this, &GMainWindow::OnAbout);
@@ -960,6 +965,27 @@ void GMainWindow::OnGameListNavigateToGamedbEntry(u64 program_id,
     QDesktopServices::openUrl(QUrl("https://yuzu-emu.org/game/" + directory));
 }
 
+void GMainWindow::OnGameListOpenProperties(FileSys::VirtualFile file) {
+
+    u64 title_id{};
+    if (Loader::GetLoader(file)->ReadProgramId(title_id) != Loader::ResultStatus::Success) {
+        QMessageBox::information(
+            this, tr("Per Game Configuration"),
+            tr("Per Game Configuration is not supported on games that do not have a title ID. "
+               "Please use a format that includes the title ID, such as NSP or XCI."));
+        return;
+    }
+
+    Settings::values.SetCurrentTitleID(title_id);
+    ConfigurePerGameDialog dialog{this, file, config->GetPerGameSettingsDelta(title_id)};
+    auto result = dialog.exec();
+    if (result == QDialog::Accepted) {
+        config->SetPerGameSettingsDelta(title_id, dialog.applyConfiguration());
+        config->Save();
+        game_list->PopulateAsync(UISettings::values.gamedir, UISettings::values.gamedir_deepscan);
+    }
+}
+
 void GMainWindow::OnMenuLoadFile() {
     const QString extensions =
         QString("*.").append(GameList::supported_file_extensions.join(" *.")).append(" main");
@@ -1317,6 +1343,7 @@ void GMainWindow::ToggleWindowMode() {
 }
 
 void GMainWindow::OnConfigure() {
+    Settings::values.SetCurrentTitleID(Settings::DEFAULT_PER_GAME);
     ConfigureDialog configureDialog(this, hotkey_registry);
     auto old_theme = UISettings::values.theme;
     const bool old_discord_presence = UISettings::values.enable_discord_presence;
@@ -1351,6 +1378,11 @@ void GMainWindow::OnLoadAmiibo() {
             nfc->LoadAmiibo(amiibo_buffer);
         }
     }
+}
+
+void GMainWindow::OnOpenYuzuFolder() {
+    QDesktopServices::openUrl(QUrl::fromLocalFile(
+        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::UserDir))));
 }
 
 void GMainWindow::OnAbout() {

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -167,6 +167,7 @@ private slots:
     void OnMenuRecentFile();
     void OnConfigure();
     void OnLoadAmiibo();
+    void OnOpenYuzuFolder();
     void OnAbout();
     void OnToggleFilterBar();
     void OnDisplayTitleBars(bool);

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -13,7 +13,7 @@
 #include <boost/optional.hpp>
 #include "common/common_types.h"
 #include "core/core.h"
-#include "core/file_sys/vfs.h"
+#include "core/file_sys/vfs_types.h"
 #include "ui_main.h"
 #include "yuzu/compatibility_list.h"
 #include "yuzu/hotkeys.h"

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -13,6 +13,7 @@
 #include <boost/optional.hpp>
 #include "common/common_types.h"
 #include "core/core.h"
+#include "core/file_sys/vfs.h"
 #include "ui_main.h"
 #include "yuzu/compatibility_list.h"
 #include "yuzu/hotkeys.h"
@@ -157,6 +158,7 @@ private slots:
     void OnGameListCopyTID(u64 program_id);
     void OnGameListNavigateToGamedbEntry(u64 program_id,
                                          const CompatibilityList& compatibility_list);
+    void OnGameListOpenProperties(FileSys::VirtualFile file);
     void OnMenuLoadFile();
     void OnMenuLoadFolder();
     void OnMenuInstallToNAND();

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -158,7 +158,7 @@ private slots:
     void OnGameListCopyTID(u64 program_id);
     void OnGameListNavigateToGamedbEntry(u64 program_id,
                                          const CompatibilityList& compatibility_list);
-    void OnGameListOpenProperties(FileSys::VirtualFile file);
+    void OnGameListOpenProperties(const std::string& file);
     void OnMenuLoadFile();
     void OnMenuLoadFolder();
     void OnMenuInstallToNAND();

--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -110,6 +110,7 @@
      <string>&amp;Help</string>
     </property>
     <addaction name="action_Report_Compatibility"/>
+    <addaction name="action_Open_yuzu_Folder"/>
     <addaction name="separator"/>
     <addaction name="action_About"/>
    </widget>
@@ -277,7 +278,12 @@
        <bool>false</bool>
      </property>
    </action>
-  </widget>
+  <action name="action_Open_yuzu_Folder">
+   <property name="text">
+    <string>Open yuzu Folder</string>
+   </property>
+  </action>
+ </widget>
  <resources/>
  <connections/>
 </ui>

--- a/src/yuzu/ui_settings.h
+++ b/src/yuzu/ui_settings.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <vector>
 #include <QByteArray>
 #include <QString>
@@ -62,6 +63,7 @@ struct Values {
     uint32_t icon_size;
     uint8_t row_1_text_id;
     uint8_t row_2_text_id;
+    std::atomic_bool is_game_list_reload_pending{false};
 };
 
 extern Values values;

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -149,7 +149,7 @@ void Config::ReadValues() {
         if (token.size() != 16)
             continue;
 
-        u64 val = std::stoull(token, nullptr, 16);
+        const u64 val = std::stoull(token, nullptr, 16);
         titles.push_back(val);
     }
 

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -180,8 +180,8 @@ void Config::ReadValues() {
         sdl2_config->GetInteger("System", "current_user", 0), 0, Service::Account::MAX_USERS - 1);
 
     // Renderer
-    Settings::values.use_accurate_framebuffers =
-        sdl2_config->GetBoolean("Renderer", "use_accurate_framebuffers", false);
+    Settings::values.use_accurate_gpu_emulation =
+        sdl2_config->GetBoolean("Renderer", "use_accurate_gpu_emulation", false);
 
     // Miscellaneous
     Settings::values.log_filter = sdl2_config->Get("Miscellaneous", "log_filter", "*:Trace");

--- a/src/yuzu_cmd/config.h
+++ b/src/yuzu_cmd/config.h
@@ -12,9 +12,13 @@ class INIReader;
 class Config {
     std::unique_ptr<INIReader> sdl2_config;
     std::string sdl2_config_loc;
+    std::vector<u64> titles;
 
     bool LoadINI(const std::string& default_contents = "", bool retry = true);
     void ReadValues();
+    void ReadValuesForTitleID(Settings::PerGameValues& values, const std::string& name);
+
+    bool UpdateCurrentGame(u64 title_id, Settings::PerGameValues& values);
 
 public:
     Config();

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -135,7 +135,7 @@ int main(int argc, char** argv) {
                 PrintVersion();
                 return 0;
             case 'p':
-                Settings::values.program_args = argv[optind];
+                Settings::values->program_args = argv[optind];
                 ++optind;
                 break;
             }


### PR DESCRIPTION
Adds the backend and frontend necessary to support a different configuration for each game the user executes.

- To prevent this from becoming a breeding ground for hacks, only extremely general settings were made per game (i.e. volume, input, docked mode, resolution). Specific things such as `use_accurate_gpu_emulation` were left global.
- To simplify use, `Settings::values` overrides `operator->` which will return the current config and various other convenience functions for managing per game configs
- UI added to configure games (right-click > Properties)
![pgc4](https://user-images.githubusercontent.com/5064800/47126373-45827c80-d256-11e8-88a0-db0021a47253.PNG)


Todo Before Merge:
- [x] Log settings on game boot (per request of Flame Sage)
- [x] More extensive UI testing for edge cases/such
- [ ] Fix HTMLDelegate issues with ~~sizing of game list~~(fixed) and alignment of text
