### PR TITLE
gl_shader_decompiler: Implement VSETP

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -214,7 +214,7 @@ enum class IMinMaxExchange : u64 {
     XHi = 3,
 };
 
-enum class VmadType : u64 {
+enum class VideoType : u64 {
     Size16_Low = 0,
     Size16_High = 1,
     Size32 = 2,
@@ -783,6 +783,14 @@ union Instruction {
     } psetp;
 
     union {
+        BitField<43, 4, PredCondition> cond;
+        BitField<45, 2, PredOperation> op;
+        BitField<3, 3, u64> pred3;
+        BitField<0, 3, u64> pred0;
+        BitField<39, 3, u64> pred39;
+    } vsetp;
+
+    union {
         BitField<12, 3, u64> pred12;
         BitField<15, 1, u64> neg_pred12;
         BitField<24, 2, PredOperation> cond;
@@ -1154,15 +1162,17 @@ union Instruction {
     union {
         BitField<48, 1, u64> signed_a;
         BitField<38, 1, u64> is_byte_chunk_a;
-        BitField<36, 2, VmadType> type_a;
+        BitField<36, 2, VideoType> type_a;
         BitField<36, 2, u64> byte_height_a;
 
         BitField<49, 1, u64> signed_b;
         BitField<50, 1, u64> use_register_b;
         BitField<30, 1, u64> is_byte_chunk_b;
-        BitField<28, 2, VmadType> type_b;
+        BitField<28, 2, VideoType> type_b;
         BitField<28, 2, u64> byte_height_b;
+    } video;
 
+    union {
         BitField<51, 2, VmadShr> shr;
         BitField<55, 1, u64> saturate; // Saturates the result (a * b + c)
         BitField<47, 1, u64> cc;

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -1246,6 +1246,7 @@ public:
         OUT_R, // Emit vertex/primitive
         ISBERD,
         VMAD,
+        VSETP,
         FFMA_IMM, // Fused Multiply and Add
         FFMA_CR,
         FFMA_RC,
@@ -1501,6 +1502,7 @@ private:
             INST("1111101111100---", Id::OUT_R, Type::Trivial, "OUT_R"),
             INST("1110111111010---", Id::ISBERD, Type::Trivial, "ISBERD"),
             INST("01011111--------", Id::VMAD, Type::Trivial, "VMAD"),
+            INST("0101000011110---", Id::VSETP, Type::Trivial, "VSETP"),
             INST("0011001-1-------", Id::FFMA_IMM, Type::Ffma, "FFMA_IMM"),
             INST("010010011-------", Id::FFMA_CR, Type::Ffma, "FFMA_CR"),
             INST("010100011-------", Id::FFMA_RC, Type::Ffma, "FFMA_RC"),

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -3362,6 +3362,30 @@ private:
                                           instr.vmad.cc);
                 break;
             }
+            case OpCode::Id::VSETP: {
+                const std::string op_a = GetVideoOperandA(instr);
+                const std::string op_b = GetVideoOperandB(instr);
+
+                // We can't use the constant predicate as destination.
+                ASSERT(instr.vsetp.pred3 != static_cast<u64>(Pred::UnusedIndex));
+
+                const std::string second_pred = GetPredicateCondition(instr.vsetp.pred39, false);
+
+                const std::string combiner = GetPredicateCombiner(instr.vsetp.op);
+
+                const std::string predicate = GetPredicateComparison(instr.vsetp.cond, op_a, op_b);
+                // Set the primary predicate to the result of Predicate OP SecondPredicate
+                SetPredicate(instr.vsetp.pred3,
+                             '(' + predicate + ") " + combiner + " (" + second_pred + ')');
+
+                if (instr.vsetp.pred0 != static_cast<u64>(Pred::UnusedIndex)) {
+                    // Set the secondary predicate to the result of !Predicate OP SecondPredicate,
+                    // if enabled
+                    SetPredicate(instr.vsetp.pred0,
+                                 "!(" + predicate + ") " + combiner + " (" + second_pred + ')');
+                }
+                break;
+            }
             default: {
                 LOG_CRITICAL(HW_GPU, "Unhandled instruction: {}", opcode->GetName());
                 UNREACHABLE();


### PR DESCRIPTION
`VSETP`'s behavior similar to `VMAD` but it compares two operands. Thankfully it doesn't do anything weird (like not shifting heights when comparing) so it's pretty straightforward using `VMAD`'s operand unpacking.

This PR also abstracted `VMAD` into a "video" subset (don't blame me for the name, that's how NVidia calls them). The invalid encoding I commented in `VMAD` in fact just killed the shader, I addressed it to emit an `UNREACHABLE()`.

As a side note, this instruction is used to compare `SR_INVOCATION_INFO's third byte <= 0` and then use that predicate to `@PX MOV32I RX, 0x80000000`. RX is then used to determine which `amem` buffer index to write to. Geometry shaders are guarded with `min()` for these high values so it should behave as expected (this was originally added to protect them against nouveau's tailing dead code).