### PR TITLE
svc: Add missing error checks in svcArbitrateLock/svcArbitrateUnlock

### DIFF
--- a/src/common/alignment.h
+++ b/src/common/alignment.h
@@ -25,4 +25,10 @@ constexpr bool Is4KBAligned(T value) {
     return (value & 0xFFF) == 0;
 }
 
+template <typename T>
+constexpr bool IsWordAligned(T value) {
+    static_assert(std::is_unsigned_v<T>, "T must be an unsigned value.");
+    return (value & 0b11) == 0;
+}
+
 } // namespace Common

--- a/src/common/alignment.h
+++ b/src/common/alignment.h
@@ -19,4 +19,10 @@ constexpr T AlignDown(T value, std::size_t size) {
     return static_cast<T>(value - value % size);
 }
 
+template <typename T>
+constexpr bool Is4KBAligned(T value) {
+    static_assert(std::is_unsigned_v<T>, "T must be an unsigned value.");
+    return (value & 0xFFF) == 0;
+}
+
 } // namespace Common

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -350,6 +350,10 @@ static ResultCode ArbitrateLock(Handle holding_thread_handle, VAddr mutex_addr,
         return ERR_INVALID_ADDRESS_STATE;
     }
 
+    if (!Common::IsWordAligned(mutex_addr)) {
+        return ERR_INVALID_ADDRESS;
+    }
+
     auto& handle_table = Core::System::GetInstance().Kernel().HandleTable();
     return Mutex::TryAcquire(handle_table, mutex_addr, holding_thread_handle,
                              requesting_thread_handle);
@@ -361,6 +365,10 @@ static ResultCode ArbitrateUnlock(VAddr mutex_addr) {
 
     if (Memory::IsKernelVirtualAddress(mutex_addr)) {
         return ERR_INVALID_ADDRESS_STATE;
+    }
+
+    if (!Common::IsWordAligned(mutex_addr)) {
+        return ERR_INVALID_ADDRESS;
     }
 
     return Mutex::Release(mutex_addr);

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <vector>
 
+#include "common/alignment.h"
 #include "common/assert.h"
 #include "common/logging/log.h"
 #include "common/microprofile.h"
@@ -36,9 +37,6 @@
 
 namespace Kernel {
 namespace {
-constexpr bool Is4KBAligned(VAddr address) {
-    return (address & 0xFFF) == 0;
-}
 
 // Checks if address + size is greater than the given address
 // This can return false if the size causes an overflow of a 64-bit type
@@ -69,11 +67,11 @@ bool IsInsideNewMapRegion(const VMManager& vm, VAddr address, u64 size) {
 // in the same order.
 ResultCode MapUnmapMemorySanityChecks(const VMManager& vm_manager, VAddr dst_addr, VAddr src_addr,
                                       u64 size) {
-    if (!Is4KBAligned(dst_addr) || !Is4KBAligned(src_addr)) {
+    if (!Common::Is4KBAligned(dst_addr) || !Common::Is4KBAligned(src_addr)) {
         return ERR_INVALID_ADDRESS;
     }
 
-    if (size == 0 || !Is4KBAligned(size)) {
+    if (size == 0 || !Common::Is4KBAligned(size)) {
         return ERR_INVALID_SIZE;
     }
 
@@ -570,11 +568,11 @@ static ResultCode MapSharedMemory(Handle shared_memory_handle, VAddr addr, u64 s
               "called, shared_memory_handle=0x{:X}, addr=0x{:X}, size=0x{:X}, permissions=0x{:08X}",
               shared_memory_handle, addr, size, permissions);
 
-    if (!Is4KBAligned(addr)) {
+    if (!Common::Is4KBAligned(addr)) {
         return ERR_INVALID_ADDRESS;
     }
 
-    if (size == 0 || !Is4KBAligned(size)) {
+    if (size == 0 || !Common::Is4KBAligned(size)) {
         return ERR_INVALID_SIZE;
     }
 
@@ -599,11 +597,11 @@ static ResultCode UnmapSharedMemory(Handle shared_memory_handle, VAddr addr, u64
     LOG_WARNING(Kernel_SVC, "called, shared_memory_handle=0x{:08X}, addr=0x{:X}, size=0x{:X}",
                 shared_memory_handle, addr, size);
 
-    if (!Is4KBAligned(addr)) {
+    if (!Common::Is4KBAligned(addr)) {
         return ERR_INVALID_ADDRESS;
     }
 
-    if (size == 0 || !Is4KBAligned(size)) {
+    if (size == 0 || !Common::Is4KBAligned(size)) {
         return ERR_INVALID_SIZE;
     }
 


### PR DESCRIPTION
The kernel itself checks whether or not the provided addresses are word aligned before continuing, so we should be doing the same.