### PR TITLE
rasterizer: Fix Layered Textures Loading and Cubemaps

### DIFF
--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -320,13 +320,13 @@ std::vector<u8> DecodeTexture(const std::vector<u8>& texture_data, TextureFormat
 std::size_t CalculateSize(bool tiled, u32 bytes_per_pixel, u32 width, u32 height, u32 depth,
                           u32 block_height, u32 block_depth) {
     if (tiled) {
-        const u32 gobs_in_x = 64 / bytes_per_pixel;
+        const u32 gobs_in_x = 64;
         const u32 gobs_in_y = 8;
         const u32 gobs_in_z = 1;
-        const u32 aligned_width = Common::AlignUp(width, gobs_in_x);
+        const u32 aligned_width = Common::AlignUp(width * bytes_per_pixel, gobs_in_x);
         const u32 aligned_height = Common::AlignUp(height, gobs_in_y * block_height);
         const u32 aligned_depth = Common::AlignUp(depth, gobs_in_z * block_depth);
-        return aligned_width * aligned_height * aligned_depth * bytes_per_pixel;
+        return aligned_width * aligned_height * aligned_depth;
     } else {
         return width * height * depth * bytes_per_pixel;
     }


### PR DESCRIPTION
This pull request fixes several issues concerning texture arrays and cubemaps. Before we were reading this types of textures naively without calculating the spacing between them (the mipmaps). With this PR, we correct this issue and add the ability to interpret cubemaps correctly.

As many issues this fixes, it may also bring to light new issues as this textures weren't working correctly and things not shown before will now be shown.