### PR TITLE
Implemented Shader dumper for RE

### DIFF
--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -260,6 +260,14 @@ public:
         return WriteArray(str.c_str(), str.length());
     }
 
+    std::size_t WriteCString(const char* str) {
+        if (!IsOpen()) {
+            return std::numeric_limits<std::size_t>::max();
+        }
+        std::fputs(str, m_file);
+        return std::strlen(str);
+    }
+
     bool IsOpen() const {
         return nullptr != m_file;
     }

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -39,6 +39,8 @@ add_library(video_core STATIC
     renderer_opengl/gl_shader_cache.h
     renderer_opengl/gl_shader_decompiler.cpp
     renderer_opengl/gl_shader_decompiler.h
+    renderer_opengl/gl_shader_dumper.cpp
+    renderer_opengl/gl_shader_dumper.h
     renderer_opengl/gl_shader_gen.cpp
     renderer_opengl/gl_shader_gen.h
     renderer_opengl/gl_shader_manager.cpp

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.h
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.h
@@ -19,7 +19,7 @@ using Tegra::Engines::Maxwell3D;
 std::string GetCommonDeclarations();
 
 std::optional<ProgramResult> DecompileProgram(const ProgramCode& program_code, u32 main_offset,
-                                              Maxwell3D::Regs::ShaderStage stage,
-                                              const std::string& suffix);
+                                                Maxwell3D::Regs::ShaderStage stage,
+                                                const std::string& suffix, bool& faulty_shader);
 
 } // namespace OpenGL::GLShader::Decompiler

--- a/src/video_core/renderer_opengl/gl_shader_dumper.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_dumper.cpp
@@ -1,0 +1,54 @@
+
+#include "common/file_util.h"
+#include "common/hash.h"
+#include "video_core/engines/shader_bytecode.h"
+#include "video_core/renderer_opengl/gl_shader_dumper.h"
+
+template <typename I>
+std::string n2hexstr(I w, size_t hex_len = sizeof(I) << 1) {
+    static const char* digits = "0123456789ABCDEF";
+    std::string rc(hex_len, '0');
+    for (size_t i = 0, j = (hex_len - 1) * 4; i < hex_len; ++i, j -= 4)
+        rc[i] = digits[(w >> j) & 0x0f];
+    return rc;
+}
+
+std::string ShaderDumper::hashName() {
+    u64 hash = Common::ComputeHash64(program.data(), sizeof(u64) * program.size());
+    return n2hexstr(hash);
+}
+
+bool IsSchedInstruction(u32 offset, u32 main_offset) {
+    // sched instructions appear once every 4 instructions.
+    static constexpr size_t SchedPeriod = 4;
+    u32 absolute_offset = offset - main_offset;
+
+    return (absolute_offset % SchedPeriod) == 0;
+}
+
+void ShaderDumper::dump() {
+    FileUtil::IOFile sFile;
+    std::string name = prefix + hashName();
+    sFile.Open(name, "wb");
+    u32 start_offset = 10;
+    u32 offset = start_offset;
+    u64 size = 0;
+    while (true) { // dump until hitting not finding a valid instruction
+        u64 inst = program[offset];
+        if (!IsSchedInstruction(offset, start_offset)) {
+            if (inst == 0) {
+                break;
+            }
+        }
+        sFile.WriteArray<u64>(&inst, 1);
+        size += 8;
+        offset += 1;
+    }
+    u64 fill = 0;
+    // Align to 32 bytes for nvdisasm
+    while ((size % 0x20) != 0) {
+        sFile.WriteArray<u64>(&fill, 1);
+        size += 8;
+    }
+    sFile.Close();
+}

--- a/src/video_core/renderer_opengl/gl_shader_dumper.h
+++ b/src/video_core/renderer_opengl/gl_shader_dumper.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <array>
+#include <string>
+#include <vector>
+
+#include "common/common_types.h"
+
+class ShaderDumper {
+public:
+    ShaderDumper(const std::vector<u64>& prog, std::string prefix) : program(prog) {
+        this->prefix = prefix;
+    }
+    void dump();
+
+private:
+    std::string hashName();
+
+    std::string prefix;
+    const std::vector<u64>& program;
+};

--- a/src/video_core/renderer_opengl/gl_shader_dumper.h
+++ b/src/video_core/renderer_opengl/gl_shader_dumper.h
@@ -5,17 +5,29 @@
 #include <vector>
 
 #include "common/common_types.h"
+#include "common/hash.h"
 
 class ShaderDumper {
 public:
     ShaderDumper(const std::vector<u64>& prog, std::string prefix) : program(prog) {
+        this->hash = GenerateHash(program);
         this->prefix = prefix;
     }
     void dump();
+    void dumpText(const std::string out);
+
+    static bool IsProgramMarked(u64 hash);
+
+    static u64 GenerateHash(const std::vector<u64>& program) {
+        return Common::ComputeHash64(program.data(), sizeof(u64) * program.size());
+    }
 
 private:
     std::string hashName();
 
+
+
+    u64 hash;
     std::string prefix;
     const std::vector<u64>& program;
 };

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -80,21 +80,16 @@ void main() {
 }
 
 )";
-    if (setup.IsDualProgram()) {
-        ProgramResult program_b =
-            Decompiler::DecompileProgram(setup.program.code_b, PROGRAM_OFFSET,
-                                         Maxwell3D::Regs::ShaderStage::Vertex, "vertex_b", faultyB)
-                .get_value_or({});
-        out += program_b.first;
-    }
 
     if (faultyA) {
         ShaderDumper s(setup.program.code, "VS");
         s.dump();
+        s.dumpText(out);
     }
     if (faultyB) {
         ShaderDumper s(setup.program.code_b, "VS");
         s.dump();
+        s.dumpText(out);
     }
     return {out, program.second};
 }
@@ -134,6 +129,7 @@ void main() {
     if (faulty) {
         ShaderDumper s(setup.program.code, "GS");
         s.dump();
+        s.dumpText(out);
     }
     return {out, program.second};
 }
@@ -201,6 +197,7 @@ void main() {
     if (faulty) {
         ShaderDumper s(setup.program.code, "FM");
         s.dump();
+        s.dumpText(out);
     }
     return {out, program.second};
 }

--- a/src/video_core/renderer_opengl/gl_shader_util.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_util.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 #include <glad/glad.h>
 #include "common/assert.h"
+#include "common/file_util.h"
 #include "common/logging/log.h"
 #include "video_core/renderer_opengl/gl_shader_util.h"
 
@@ -41,7 +42,16 @@ GLuint LoadShader(const char* source, GLenum type) {
         if (result == GL_TRUE) {
             LOG_DEBUG(Render_OpenGL, "{}", shader_error);
         } else {
-            LOG_ERROR(Render_OpenGL, "Error compiling {} shader:\n{}", debug_type, shader_error);
+            static u32 error_shader_counter = 0;
+            FileUtil::IOFile sFile;
+            std::string name = "RejectedShader" + std::to_string(error_shader_counter) + ".txt";
+            sFile.Open(name, "w");
+            sFile.WriteCString(source);
+            sFile.WriteString("\n //");
+            sFile.WriteString(shader_error);
+            sFile.Close();
+            error_shader_counter++;
+            LOG_CRITICAL(Render_OpenGL, "Error compiling {} shader:\n{}", debug_type, shader_error);
         }
     }
     return shader_id;


### PR DESCRIPTION
Here's a simple shader dumper to use with nvdisasm. It will only dump shaders marked as faulty. It should be used for debugging purposes mostly. In order to use it do the next:

CUDA Toolkit 8.0+ must be installed. https://developer.nvidia.com/cuda-downloads

1. fetch this pr into a separate branch and build it.
2. run yuzu with the game with faulty shaders. 
3. All shaders will be next to Yuzu's executable.
4. dissassemble a shader by using "nvdisasm -b SM52 <shader_name> > myasm.txt"
5. enjoy and happy Reverse Engineering!

Edit to dump specific shaders on certain assert/error, add "faulty =true;" next to it in shader_decompiler.cpp

This pull request has been recreated from another one since it got corrupted.