### PR TITLE
maxwell_dma: Silence compilation warnings

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -13,8 +13,7 @@
 #include "video_core/renderer_base.h"
 #include "video_core/textures/texture.h"
 
-namespace Tegra {
-namespace Engines {
+namespace Tegra::Engines {
 
 /// First register id that is actually a Macro call.
 constexpr u32 MacroRegistersStart = 0xE00;
@@ -408,5 +407,4 @@ void Maxwell3D::ProcessClearBuffers() {
     rasterizer.Clear();
 }
 
-} // namespace Engines
-} // namespace Tegra
+} // namespace Tegra::Engines

--- a/src/video_core/engines/maxwell_compute.cpp
+++ b/src/video_core/engines/maxwell_compute.cpp
@@ -6,8 +6,7 @@
 #include "core/core.h"
 #include "video_core/engines/maxwell_compute.h"
 
-namespace Tegra {
-namespace Engines {
+namespace Tegra::Engines {
 
 void MaxwellCompute::WriteReg(u32 method, u32 value) {
     ASSERT_MSG(method < Regs::NUM_REGS,
@@ -26,5 +25,4 @@ void MaxwellCompute::WriteReg(u32 method, u32 value) {
     }
 }
 
-} // namespace Engines
-} // namespace Tegra
+} // namespace Tegra::Engines

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -91,9 +91,6 @@ void MaxwellDMA::HandleCopy() {
         rasterizer.InvalidateRegion(dest_cpu, dst_size);
     };
 
-    u8* src_buffer = Memory::GetPointer(source_cpu);
-    u8* dst_buffer = Memory::GetPointer(dest_cpu);
-
     if (regs.exec.is_dst_linear && !regs.exec.is_src_linear) {
         ASSERT(regs.src_params.size_z == 1);
         // If the input is tiled and the output is linear, deswizzle the input and copy it over.

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -80,7 +80,7 @@ void MaxwellDMA::HandleCopy() {
 
     std::size_t copy_size = regs.x_count * regs.y_count;
 
-    const auto FlushAndInvalidate = [&](u32 src_size, u32 dst_size) {
+    const auto FlushAndInvalidate = [&](u32 src_size, u64 dst_size) {
         // TODO(Subv): For now, manually flush the regions until we implement GPU-accelerated
         // copying.
         rasterizer.FlushRegion(source_cpu, src_size);

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -7,8 +7,7 @@
 #include "video_core/rasterizer_interface.h"
 #include "video_core/textures/decoders.h"
 
-namespace Tegra {
-namespace Engines {
+namespace Tegra::Engines {
 
 MaxwellDMA::MaxwellDMA(VideoCore::RasterizerInterface& rasterizer, MemoryManager& memory_manager)
     : memory_manager(memory_manager), rasterizer{rasterizer} {}
@@ -119,5 +118,4 @@ void MaxwellDMA::HandleCopy() {
     }
 }
 
-} // namespace Engines
-} // namespace Tegra
+} // namespace Tegra::Engines

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -78,7 +78,7 @@ void MaxwellDMA::HandleCopy() {
 
     ASSERT(regs.exec.enable_2d == 1);
 
-    std::size_t copy_size = regs.x_count * regs.y_count;
+    const std::size_t copy_size = regs.x_count * regs.y_count;
 
     const auto FlushAndInvalidate = [&](u32 src_size, u64 dst_size) {
         // TODO(Subv): For now, manually flush the regions until we implement GPU-accelerated
@@ -95,7 +95,7 @@ void MaxwellDMA::HandleCopy() {
         ASSERT(regs.src_params.size_z == 1);
         // If the input is tiled and the output is linear, deswizzle the input and copy it over.
 
-        u32 src_bytes_per_pixel = regs.src_pitch / regs.src_params.size_x;
+        const u32 src_bytes_per_pixel = regs.src_pitch / regs.src_params.size_x;
 
         FlushAndInvalidate(regs.src_pitch * regs.src_params.size_y,
                            copy_size * src_bytes_per_pixel);
@@ -108,7 +108,7 @@ void MaxwellDMA::HandleCopy() {
         ASSERT(regs.dst_params.size_z == 1);
         ASSERT(regs.src_pitch == regs.x_count);
 
-        u32 src_bpp = regs.src_pitch / regs.x_count;
+        const u32 src_bpp = regs.src_pitch / regs.x_count;
 
         FlushAndInvalidate(regs.src_pitch * regs.y_count,
                            regs.dst_params.size_x * regs.dst_params.size_y * src_bpp);


### PR DESCRIPTION
Silences unused variable and truncation compilation warnings. While we're at it, we can also convert the namespacing over to nested namespace specifiers to keep the source files consistent with the other ones in the same directory.