### PR TITLE
web_service/CMakeLists: Make the CPPHTTPLIB_OPENSSL_SUPPORT constrained to the web_service library only

### DIFF
--- a/src/web_service/CMakeLists.txt
+++ b/src/web_service/CMakeLists.txt
@@ -12,5 +12,5 @@ create_target_directory_groups(web_service)
 get_directory_property(OPENSSL_LIBS
         DIRECTORY ${CMAKE_SOURCE_DIR}/externals/libressl
         DEFINITION OPENSSL_LIBS)
-target_compile_definitions(web_service PUBLIC -DCPPHTTPLIB_OPENSSL_SUPPORT)
+target_compile_definitions(web_service PRIVATE -DCPPHTTPLIB_OPENSSL_SUPPORT)
 target_link_libraries(web_service PRIVATE common json-headers ${OPENSSL_LIBS} httplib lurlparser)


### PR DESCRIPTION
Given we link in httplib privately, we can also make the definition enabling OpenSSL support private as well. Prevents leaking a definition into other libraries that link with this one, like the core library.