### PR TITLE
Fixed VAOs Float types only returning GL_FLOAT

### DIFF
--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -82,8 +82,20 @@ inline GLenum VertexType(Maxwell::VertexAttribute attrib) {
         return {};
     }
 
-    case Maxwell::VertexAttribute::Type::Float:
-        return GL_FLOAT;
+    case Maxwell::VertexAttribute::Type::Float: {
+        switch (attrib.size) {
+        case Maxwell::VertexAttribute::Size::Size_16:
+        case Maxwell::VertexAttribute::Size::Size_16_16:
+        case Maxwell::VertexAttribute::Size::Size_16_16_16:
+        case Maxwell::VertexAttribute::Size::Size_16_16_16_16:
+            return GL_HALF_FLOAT;
+        case Maxwell::VertexAttribute::Size::Size_32:
+        case Maxwell::VertexAttribute::Size::Size_32_32:
+        case Maxwell::VertexAttribute::Size::Size_32_32_32:
+        case Maxwell::VertexAttribute::Size::Size_32_32_32_32:
+            return GL_FLOAT;
+        }
+    }
     }
 
     LOG_CRITICAL(Render_OpenGL, "Unimplemented vertex type={}", attrib.TypeString());


### PR DESCRIPTION
This fixes a TON of game graphical issues.