### PR TITLE
Port citra-emu/citra#4336: "Only redefine some 64-bit file operation for MSVC"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ endif()
 # On modern Unixes, this is typically already the case. The lone exception is
 # glibc, which may default to 32 bits. glibc allows this to be configured
 # by setting _FILE_OFFSET_BITS.
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR MINGW)
     add_definitions(-D_FILE_OFFSET_BITS=64)
 endif()
 

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -15,21 +15,24 @@
 #ifdef _WIN32
 #include <windows.h>
 // windows.h needs to be included before other windows headers
-#include <commdlg.h> // for GetSaveFileName
-#include <direct.h>  // getcwd
+#include <direct.h> // getcwd
 #include <io.h>
 #include <shellapi.h>
 #include <shlobj.h> // for SHGetFolderPath
 #include <tchar.h>
 #include "common/string_util.h"
 
-// 64 bit offsets for windows
+#ifdef _MSC_VER
+// 64 bit offsets for MSVC
 #define fseeko _fseeki64
 #define ftello _ftelli64
-#define atoll _atoi64
+#define fileno _fileno
+#endif
+
+// 64 bit offsets for MSVC and MinGW. MinGW also needs this for using _wstat64
 #define stat _stat64
 #define fstat _fstat64
-#define fileno _fileno
+
 #else
 #ifdef __APPLE__
 #include <sys/param.h>


### PR DESCRIPTION
See citra-emu/citra#4336 for more details.