### PR TITLE
travis: Use pre-built image for clang-format target

### DIFF
--- a/.travis/clang-format/build.sh
+++ b/.travis/clang-format/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-docker run -v $(pwd):/yuzu ubuntu:18.04 /bin/bash -ex /yuzu/.travis/clang-format/docker.sh
+docker run --env-file .travis/common/travis-ci.env -v $(pwd):/yuzu -v "$HOME/.ccache":/root/.ccache citraemu/build-environments:linux-clang-format /bin/bash -ex /yuzu/.travis/clang-format/docker.sh

--- a/.travis/clang-format/deps.sh
+++ b/.travis/clang-format/deps.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -ex
 
-docker pull ubuntu:18.04
+docker pull citraemu/build-environments:linux-clang-format

--- a/.travis/clang-format/docker.sh
+++ b/.travis/clang-format/docker.sh
@@ -1,8 +1,5 @@
 #!/bin/bash -ex
 
-apt-get update
-apt-get install -y clang-format-6.0
-
 # Run clang-format
 cd /yuzu
 ./.travis/clang-format/script.sh


### PR DESCRIPTION
Based on citra-emu/citra#4129. Requires citra-emu/build-environments#7.