### PR TITLE
file_sys: Remove unused variables

### DIFF
--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -713,7 +713,6 @@ void KeyManager::DeriveBase() {
 
     const auto sbk = GetKey(S128KeyType::SecureBoot);
     const auto tsec = GetKey(S128KeyType::TSEC);
-    const auto master_source = GetKey(S128KeyType::Source, static_cast<u64>(SourceKeyType::Master));
 
     for (size_t i = 0; i < revisions.size(); ++i) {
         if (!revisions[i])

--- a/src/core/file_sys/vfs.cpp
+++ b/src/core/file_sys/vfs.cpp
@@ -472,10 +472,14 @@ bool VfsRawCopy(const VirtualFile& src, const VirtualFile& dest, std::size_t blo
     std::vector<u8> temp(std::min(block_size, src->GetSize()));
     for (std::size_t i = 0; i < src->GetSize(); i += block_size) {
         const auto read = std::min(block_size, src->GetSize() - i);
-        const auto block = src->Read(temp.data(), read, i);
 
-        if (dest->Write(temp.data(), read, i) != read)
+        if (src->Read(temp.data(), read, i) != read) {
             return false;
+        }
+
+        if (dest->Write(temp.data(), read, i) != read) {
+            return false;
+        }
     }
 
     return true;


### PR DESCRIPTION
Gets rid of trivial compiler warnings.