### PR TITLE
time_stretch: Remove unused m_channel_count member variable

### DIFF
--- a/src/audio_core/time_stretch.cpp
+++ b/src/audio_core/time_stretch.cpp
@@ -10,8 +10,7 @@
 
 namespace AudioCore {
 
-TimeStretcher::TimeStretcher(u32 sample_rate, u32 channel_count)
-    : m_sample_rate(sample_rate), m_channel_count(channel_count) {
+TimeStretcher::TimeStretcher(u32 sample_rate, u32 channel_count) : m_sample_rate{sample_rate} {
     m_sound_touch.setChannels(channel_count);
     m_sound_touch.setSampleRate(sample_rate);
     m_sound_touch.setPitch(1.0);

--- a/src/audio_core/time_stretch.h
+++ b/src/audio_core/time_stretch.h
@@ -27,7 +27,6 @@ public:
 
 private:
     u32 m_sample_rate;
-    u32 m_channel_count;
     soundtouch::SoundTouch m_sound_touch;
     double m_stretch_ratio = 1.0;
 };


### PR DESCRIPTION
This is only stored to, but never read from.