### PR TITLE
profile_manager: Use std::optional instead of boost::optional

### DIFF
--- a/src/core/hle/service/acc/profile_manager.h
+++ b/src/core/hle/service/acc/profile_manager.h
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <array>
+#include <optional>
 
-#include "boost/optional.hpp"
 #include "common/common_types.h"
 #include "common/swap.h"
 #include "core/hle/result.h"
@@ -96,13 +96,13 @@ public:
     ResultCode AddUser(const ProfileInfo& user);
     ResultCode CreateNewUser(UUID uuid, const ProfileUsername& username);
     ResultCode CreateNewUser(UUID uuid, const std::string& username);
-    boost::optional<UUID> GetUser(std::size_t index) const;
-    boost::optional<std::size_t> GetUserIndex(const UUID& uuid) const;
-    boost::optional<std::size_t> GetUserIndex(const ProfileInfo& user) const;
-    bool GetProfileBase(boost::optional<std::size_t> index, ProfileBase& profile) const;
+    std::optional<UUID> GetUser(std::size_t index) const;
+    std::optional<std::size_t> GetUserIndex(const UUID& uuid) const;
+    std::optional<std::size_t> GetUserIndex(const ProfileInfo& user) const;
+    bool GetProfileBase(std::optional<std::size_t> index, ProfileBase& profile) const;
     bool GetProfileBase(UUID uuid, ProfileBase& profile) const;
     bool GetProfileBase(const ProfileInfo& user, ProfileBase& profile) const;
-    bool GetProfileBaseAndData(boost::optional<std::size_t> index, ProfileBase& profile,
+    bool GetProfileBaseAndData(std::optional<std::size_t> index, ProfileBase& profile,
                                ProfileData& data) const;
     bool GetProfileBaseAndData(UUID uuid, ProfileBase& profile, ProfileData& data) const;
     bool GetProfileBaseAndData(const ProfileInfo& user, ProfileBase& profile,
@@ -120,16 +120,16 @@ public:
     bool CanSystemRegisterUser() const;
 
     bool RemoveUser(UUID uuid);
-    bool SetProfileBase(UUID uuid, const ProfileBase& profile);
+    bool SetProfileBase(UUID uuid, const ProfileBase& profile_new);
 
 private:
     void ParseUserSaveFile();
     void WriteUserSaveFile();
+    std::optional<std::size_t> AddToProfiles(const ProfileInfo& profile);
+    bool RemoveProfileAtIndex(std::size_t index);
 
     std::array<ProfileInfo, MAX_USERS> profiles{};
     std::size_t user_count = 0;
-    boost::optional<std::size_t> AddToProfiles(const ProfileInfo& profile);
-    bool RemoveProfileAtIndex(std::size_t index);
     UUID last_opened_user{INVALID_UUID};
 };
 

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -743,7 +743,7 @@ void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
 
     Account::ProfileManager profile_manager{};
     const auto uuid = profile_manager.GetUser(Settings::values.current_user);
-    ASSERT(uuid != boost::none);
+    ASSERT(uuid != std::nullopt);
     params.current_user = uuid->uuid;
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -153,7 +153,7 @@ void ConfigureSystem::UpdateCurrentUser() {
     ui->pm_add->setEnabled(profile_manager->GetUserCount() < Service::Account::MAX_USERS);
 
     const auto& current_user = profile_manager->GetUser(Settings::values.current_user);
-    ASSERT(current_user != boost::none);
+    ASSERT(current_user != std::nullopt);
     const auto username = GetAccountUsername(*current_user);
 
     scene->clear();
@@ -252,7 +252,7 @@ void ConfigureSystem::AddUser() {
 void ConfigureSystem::RenameUser() {
     const auto user = tree_view->currentIndex().row();
     const auto uuid = profile_manager->GetUser(user);
-    ASSERT(uuid != boost::none);
+    ASSERT(uuid != std::nullopt);
     const auto username = GetAccountUsername(*uuid);
 
     Service::Account::ProfileBase profile;
@@ -292,7 +292,7 @@ void ConfigureSystem::RenameUser() {
 void ConfigureSystem::DeleteUser() {
     const auto index = tree_view->currentIndex().row();
     const auto uuid = profile_manager->GetUser(index);
-    ASSERT(uuid != boost::none);
+    ASSERT(uuid != std::nullopt);
     const auto username = GetAccountUsername(*uuid);
 
     const auto confirm =
@@ -320,7 +320,7 @@ void ConfigureSystem::DeleteUser() {
 void ConfigureSystem::SetUserImage() {
     const auto index = tree_view->currentIndex().row();
     const auto uuid = profile_manager->GetUser(index);
-    ASSERT(uuid != boost::none);
+    ASSERT(uuid != std::nullopt);
     const auto username = GetAccountUsername(*uuid);
 
     const auto file = QFileDialog::getOpenFileName(this, tr("Select User Image"), QString(),

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -785,7 +785,7 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
         ASSERT(index != -1 && index < 8);
 
         const auto user_id = manager.GetUser(index);
-        ASSERT(user_id != boost::none);
+        ASSERT(user_id != std::nullopt);
         path = nand_dir + FileSys::SaveDataFactory::GetFullPath(FileSys::SaveDataSpaceId::NandUser,
                                                                 FileSys::SaveDataType::SaveData,
                                                                 program_id, user_id->uuid, 0);


### PR DESCRIPTION
Now that we can actually use std::optional on macOS, we don't need to continue using boost::optional here.