### PR TITLE
graphic_breakpoints: Correct translation of strings in BreakpointModel's data() function

### DIFF
--- a/src/yuzu/debugger/graphics/graphics_breakpoints.cpp
+++ b/src/yuzu/debugger/graphics/graphics_breakpoints.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <map>
 #include <QLabel>
 #include <QMetaType>
 #include <QPushButton>
@@ -32,21 +31,8 @@ QVariant BreakPointModel::data(const QModelIndex& index, int role) const {
     switch (role) {
     case Qt::DisplayRole: {
         if (index.column() == 0) {
-            static const std::map<Tegra::DebugContext::Event, QString> map = {
-                {Tegra::DebugContext::Event::MaxwellCommandLoaded, tr("Maxwell command loaded")},
-                {Tegra::DebugContext::Event::MaxwellCommandProcessed,
-                 tr("Maxwell command processed")},
-                {Tegra::DebugContext::Event::IncomingPrimitiveBatch,
-                 tr("Incoming primitive batch")},
-                {Tegra::DebugContext::Event::FinishedPrimitiveBatch,
-                 tr("Finished primitive batch")},
-            };
-
-            DEBUG_ASSERT(map.size() ==
-                         static_cast<std::size_t>(Tegra::DebugContext::Event::NumEvents));
-            return (map.find(event) != map.end()) ? map.at(event) : QString();
+            return DebugContextEventToString(event);
         }
-
         break;
     }
 
@@ -126,6 +112,23 @@ void BreakPointModel::OnResumed() {
     emit dataChanged(createIndex(static_cast<int>(active_breakpoint), 0),
                      createIndex(static_cast<int>(active_breakpoint), 0));
     active_breakpoint = context->active_breakpoint;
+}
+
+QString BreakPointModel::DebugContextEventToString(Tegra::DebugContext::Event event) {
+    switch (event) {
+    case Tegra::DebugContext::Event::MaxwellCommandLoaded:
+        return tr("Maxwell command loaded");
+    case Tegra::DebugContext::Event::MaxwellCommandProcessed:
+        return tr("Maxwell command processed");
+    case Tegra::DebugContext::Event::IncomingPrimitiveBatch:
+        return tr("Incoming primitive batch");
+    case Tegra::DebugContext::Event::FinishedPrimitiveBatch:
+        return tr("Finished primitive batch");
+    case Tegra::DebugContext::Event::NumEvents:
+        break;
+    }
+
+    return tr("Unknown debug context event");
 }
 
 GraphicsBreakPointsWidget::GraphicsBreakPointsWidget(

--- a/src/yuzu/debugger/graphics/graphics_breakpoints_p.h
+++ b/src/yuzu/debugger/graphics/graphics_breakpoints_p.h
@@ -29,6 +29,8 @@ public:
     void OnResumed();
 
 private:
+    static QString DebugContextEventToString(Tegra::DebugContext::Event event);
+
     std::weak_ptr<Tegra::DebugContext> context_weak;
     bool at_breakpoint;
     Tegra::DebugContext::Event active_breakpoint;


### PR DESCRIPTION
`tr()` will not function properly on static/global data like this, as the object is only ever constructed once, so the strings won't translate if the language is changed without restarting the program, which is undesirable. Instead we can just turn the map into a plain old function that maps the values to their equivalent strings. This is also lessens the memory allocated, since it's only allocating memory for the strings themselves, and not an encompassing map as well.