### PR TITLE
global: Use std::optional instead of boost::optional

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -185,7 +185,7 @@ struct System::Impl {
             LOG_CRITICAL(Core, "Failed to obtain loader for {}!", filepath);
             return ResultStatus::ErrorGetLoader;
         }
-        std::pair<boost::optional<u32>, Loader::ResultStatus> system_mode =
+        std::pair<std::optional<u32>, Loader::ResultStatus> system_mode =
             app_loader->LoadKernelSystemMode();
 
         if (system_mode.second != Loader::ResultStatus::Success) {

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -362,11 +362,11 @@ std::optional<std::pair<Key128, Key128>> ParseTicket(const TicketRaw& ticket,
     m_2 = m_2 ^ MGF1<0xDF>(m_1);
 
     const auto offset = FindTicketOffset(m_2);
-    if (offset)
+    if (!offset)
         return {};
-    ASSERT(offset.value() > 0);
+    ASSERT(*offset > 0);
 
-    std::memcpy(key_temp.data(), m_2.data() + offset.value(), key_temp.size());
+    std::memcpy(key_temp.data(), m_2.data() + *offset, key_temp.size());
 
     return std::make_pair(rights_id, key_temp);
 }
@@ -661,8 +661,8 @@ void KeyManager::DeriveSDSeedLazy() {
         return;
 
     const auto res = DeriveSDSeed();
-    if (res != std::nullopt)
-        SetKey(S128KeyType::SDSeed, res.value());
+    if (res)
+        SetKey(S128KeyType::SDSeed, *res);
 }
 
 static Key128 CalculateCMAC(const u8* source, size_t size, const Key128& key) {
@@ -889,9 +889,9 @@ void KeyManager::DeriveETicket(PartitionDataManager& data) {
 
     for (const auto& raw : res) {
         const auto pair = ParseTicket(raw, rsa_key);
-        if (pair)
+        if (!pair)
             continue;
-        const auto& [rid, key] = pair.value();
+        const auto& [rid, key] = *pair;
         u128 rights_id;
         std::memcpy(rights_id.data(), rid.data(), rid.size());
         SetKey(S128KeyType::Titlekey, key, rights_id[1], rights_id[0]);

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -141,28 +141,28 @@ Key128 DeriveKeyblobMACKey(const Key128& keyblob_key, const Key128& mac_source) 
     return mac_key;
 }
 
-boost::optional<Key128> DeriveSDSeed() {
+std::optional<Key128> DeriveSDSeed() {
     const FileUtil::IOFile save_43(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
                                        "/system/save/8000000000000043",
                                    "rb+");
     if (!save_43.IsOpen())
-        return boost::none;
+        return {};
 
     const FileUtil::IOFile sd_private(
         FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir) + "/Nintendo/Contents/private", "rb+");
     if (!sd_private.IsOpen())
-        return boost::none;
+        return {};
 
     std::array<u8, 0x10> private_seed{};
     if (sd_private.ReadBytes(private_seed.data(), private_seed.size()) != private_seed.size()) {
-        return boost::none;
+        return {};
     }
 
     std::array<u8, 0x10> buffer{};
     std::size_t offset = 0;
     for (; offset + 0x10 < save_43.GetSize(); ++offset) {
         if (!save_43.Seek(offset, SEEK_SET)) {
-            return boost::none;
+            return {};
         }
 
         save_43.ReadBytes(buffer.data(), buffer.size());
@@ -172,12 +172,12 @@ boost::optional<Key128> DeriveSDSeed() {
     }
 
     if (!save_43.Seek(offset + 0x10, SEEK_SET)) {
-        return boost::none;
+        return {};
     }
 
     Key128 seed{};
     if (save_43.ReadBytes(seed.data(), seed.size()) != seed.size()) {
-        return boost::none;
+        return {};
     }
     return seed;
 }
@@ -291,26 +291,26 @@ static std::array<u8, target_size> MGF1(const std::array<u8, in_size>& seed) {
 }
 
 template <size_t size>
-static boost::optional<u64> FindTicketOffset(const std::array<u8, size>& data) {
+static std::optional<u64> FindTicketOffset(const std::array<u8, size>& data) {
     u64 offset = 0;
     for (size_t i = 0x20; i < data.size() - 0x10; ++i) {
         if (data[i] == 0x1) {
             offset = i + 1;
             break;
         } else if (data[i] != 0x0) {
-            return boost::none;
+            return {};
         }
     }
 
     return offset;
 }
 
-boost::optional<std::pair<Key128, Key128>> ParseTicket(const TicketRaw& ticket,
+std::optional<std::pair<Key128, Key128>> ParseTicket(const TicketRaw& ticket,
                                                        const RSAKeyPair<2048>& key) {
     u32 cert_authority;
     std::memcpy(&cert_authority, ticket.data() + 0x140, sizeof(cert_authority));
     if (cert_authority == 0)
-        return boost::none;
+        return {};
     if (cert_authority != Common::MakeMagic('R', 'o', 'o', 't')) {
         LOG_INFO(Crypto,
                  "Attempting to parse ticket with non-standard certificate authority {:08X}.",
@@ -321,7 +321,7 @@ boost::optional<std::pair<Key128, Key128>> ParseTicket(const TicketRaw& ticket,
     std::memcpy(rights_id.data(), ticket.data() + 0x2A0, sizeof(Key128));
 
     if (rights_id == Key128{})
-        return boost::none;
+        return {};
 
     Key128 key_temp{};
 
@@ -356,17 +356,17 @@ boost::optional<std::pair<Key128, Key128>> ParseTicket(const TicketRaw& ticket,
     std::memcpy(m_2.data(), rsa_step.data() + 0x21, m_2.size());
 
     if (m_0 != 0)
-        return boost::none;
+        return {};
 
     m_1 = m_1 ^ MGF1<0x20>(m_2);
     m_2 = m_2 ^ MGF1<0xDF>(m_1);
 
     const auto offset = FindTicketOffset(m_2);
-    if (offset == boost::none)
-        return boost::none;
-    ASSERT(offset.get() > 0);
+    if (offset )
+        return {};
+    ASSERT(offset.value() > 0);
 
-    std::memcpy(key_temp.data(), m_2.data() + offset.get(), key_temp.size());
+    std::memcpy(key_temp.data(), m_2.data() + offset.value(), key_temp.size());
 
     return std::make_pair(rights_id, key_temp);
 }
@@ -661,8 +661,8 @@ void KeyManager::DeriveSDSeedLazy() {
         return;
 
     const auto res = DeriveSDSeed();
-    if (res != boost::none)
-        SetKey(S128KeyType::SDSeed, res.get());
+    if (res != std::nullopt)
+        SetKey(S128KeyType::SDSeed, res.value());
 }
 
 static Key128 CalculateCMAC(const u8* source, size_t size, const Key128& key) {
@@ -889,7 +889,7 @@ void KeyManager::DeriveETicket(PartitionDataManager& data) {
 
     for (const auto& raw : res) {
         const auto pair = ParseTicket(raw, rsa_key);
-        if (pair == boost::none)
+        if (pair )
             continue;
         const auto& [rid, key] = pair.value();
         u128 rights_id;

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -306,7 +306,7 @@ static std::optional<u64> FindTicketOffset(const std::array<u8, size>& data) {
 }
 
 std::optional<std::pair<Key128, Key128>> ParseTicket(const TicketRaw& ticket,
-                                                       const RSAKeyPair<2048>& key) {
+                                                     const RSAKeyPair<2048>& key) {
     u32 cert_authority;
     std::memcpy(&cert_authority, ticket.data() + 0x140, sizeof(cert_authority));
     if (cert_authority == 0)
@@ -362,7 +362,7 @@ std::optional<std::pair<Key128, Key128>> ParseTicket(const TicketRaw& ticket,
     m_2 = m_2 ^ MGF1<0xDF>(m_1);
 
     const auto offset = FindTicketOffset(m_2);
-    if (offset )
+    if (offset)
         return {};
     ASSERT(offset.value() > 0);
 
@@ -889,7 +889,7 @@ void KeyManager::DeriveETicket(PartitionDataManager& data) {
 
     for (const auto& raw : res) {
         const auto pair = ParseTicket(raw, rsa_key);
-        if (pair )
+        if (pair)
             continue;
         const auto& [rid, key] = pair.value();
         u128 rights_id;

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -6,9 +6,10 @@
 
 #include <array>
 #include <map>
+#include <optional>
 #include <string>
+
 #include <boost/container/flat_map.hpp>
-#include <boost/optional.hpp>
 #include <fmt/format.h>
 #include "common/common_types.h"
 #include "core/crypto/partition_data_manager.h"
@@ -191,14 +192,14 @@ Key128 DeriveMasterKey(const std::array<u8, 0x90>& keyblob, const Key128& master
 std::array<u8, 0x90> DecryptKeyblob(const std::array<u8, 0xB0>& encrypted_keyblob,
                                     const Key128& key);
 
-boost::optional<Key128> DeriveSDSeed();
+std::optional<Key128> DeriveSDSeed();
 Loader::ResultStatus DeriveSDKeys(std::array<Key256, 2>& sd_keys, KeyManager& keys);
 
 std::vector<TicketRaw> GetTicketblob(const FileUtil::IOFile& ticket_save);
 
 // Returns a pair of {rights_id, titlekey}. Fails if the ticket has no certificate authority (offset
 // 0x140-0x144 is zero)
-boost::optional<std::pair<Key128, Key128>> ParseTicket(
+std::optional<std::pair<Key128, Key128>> ParseTicket(
     const TicketRaw& ticket, const RSAKeyPair<2048>& eticket_extended_key);
 
 } // namespace Core::Crypto

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -199,7 +199,7 @@ std::vector<TicketRaw> GetTicketblob(const FileUtil::IOFile& ticket_save);
 
 // Returns a pair of {rights_id, titlekey}. Fails if the ticket has no certificate authority (offset
 // 0x140-0x144 is zero)
-std::optional<std::pair<Key128, Key128>> ParseTicket(
-    const TicketRaw& ticket, const RSAKeyPair<2048>& eticket_extended_key);
+std::optional<std::pair<Key128, Key128>> ParseTicket(const TicketRaw& ticket,
+                                                     const RSAKeyPair<2048>& eticket_extended_key);
 
 } // namespace Core::Crypto

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -474,8 +474,8 @@ VirtualFile NCA::Decrypt(const NCASectionHeader& s_header, VirtualFile in, u64 s
                 }
             }
 
-            auto out = std::make_shared<Core::Crypto::CTREncryptionLayer>(
-                std::move(in), key.value(), starting_offset);
+            auto out = std::make_shared<Core::Crypto::CTREncryptionLayer>(std::move(in), *key,
+                                                                          starting_offset);
             std::vector<u8> iv(16);
             for (u8 i = 0; i < 8; ++i)
                 iv[i] = s_header.raw.section_ctr[0x8 - i - 1];

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -310,13 +310,13 @@ bool NCA::ReadRomFSSection(const NCASectionHeader& section, const NCASectionTabl
             if (has_rights_id) {
                 status = Loader::ResultStatus::Success;
                 key = GetTitlekey();
-                if (key) {
+                if (!key) {
                     status = Loader::ResultStatus::ErrorMissingTitlekey;
                     return false;
                 }
             } else {
                 key = GetKeyAreaKey(NCASectionCryptoType::BKTR);
-                if (key) {
+                if (!key) {
                     status = Loader::ResultStatus::ErrorMissingKeyAreaKey;
                     return false;
                 }
@@ -331,7 +331,7 @@ bool NCA::ReadRomFSSection(const NCASectionHeader& section, const NCASectionTabl
         auto bktr = std::make_shared<BKTR>(
             bktr_base_romfs, std::make_shared<OffsetVfsFile>(file, romfs_size, base_offset),
             relocation_block, relocation_buckets, subsection_block, subsection_buckets, encrypted,
-            encrypted ? key.value() : Core::Crypto::Key128{}, base_offset, bktr_base_ivfc_offset,
+            encrypted ? *key : Core::Crypto::Key128{}, base_offset, bktr_base_ivfc_offset,
             section.raw.section_ctr);
 
         // BKTR applies to entire IVFC, so make an offset version to level 6
@@ -461,14 +461,14 @@ VirtualFile NCA::Decrypt(const NCASectionHeader& s_header, VirtualFile in, u64 s
             if (has_rights_id) {
                 status = Loader::ResultStatus::Success;
                 key = GetTitlekey();
-                if (key) {
+                if (!key) {
                     if (status == Loader::ResultStatus::Success)
                         status = Loader::ResultStatus::ErrorMissingTitlekey;
                     return nullptr;
                 }
             } else {
                 key = GetKeyAreaKey(NCASectionCryptoType::CTR);
-                if (key) {
+                if (!key) {
                     status = Loader::ResultStatus::ErrorMissingKeyAreaKey;
                     return nullptr;
                 }

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -4,9 +4,8 @@
 
 #include <algorithm>
 #include <cstring>
+#include <optional>
 #include <utility>
-
-#include <boost/optional.hpp>
 
 #include "common/logging/log.h"
 #include "core/crypto/aes_util.h"
@@ -306,18 +305,18 @@ bool NCA::ReadRomFSSection(const NCASectionHeader& section, const NCASectionTabl
         subsection_buckets.back().entries.push_back({section.bktr.relocation.offset, {0}, ctr_low});
         subsection_buckets.back().entries.push_back({size, {0}, 0});
 
-        boost::optional<Core::Crypto::Key128> key = boost::none;
+        std::optional<Core::Crypto::Key128> key = {};
         if (encrypted) {
             if (has_rights_id) {
                 status = Loader::ResultStatus::Success;
                 key = GetTitlekey();
-                if (key == boost::none) {
+                if (key) {
                     status = Loader::ResultStatus::ErrorMissingTitlekey;
                     return false;
                 }
             } else {
                 key = GetKeyAreaKey(NCASectionCryptoType::BKTR);
-                if (key == boost::none) {
+                if (key) {
                     status = Loader::ResultStatus::ErrorMissingKeyAreaKey;
                     return false;
                 }
@@ -332,7 +331,7 @@ bool NCA::ReadRomFSSection(const NCASectionHeader& section, const NCASectionTabl
         auto bktr = std::make_shared<BKTR>(
             bktr_base_romfs, std::make_shared<OffsetVfsFile>(file, romfs_size, base_offset),
             relocation_block, relocation_buckets, subsection_block, subsection_buckets, encrypted,
-            encrypted ? key.get() : Core::Crypto::Key128{}, base_offset, bktr_base_ivfc_offset,
+            encrypted ? key.value() : Core::Crypto::Key128{}, base_offset, bktr_base_ivfc_offset,
             section.raw.section_ctr);
 
         // BKTR applies to entire IVFC, so make an offset version to level 6
@@ -388,11 +387,11 @@ u8 NCA::GetCryptoRevision() const {
     return master_key_id;
 }
 
-boost::optional<Core::Crypto::Key128> NCA::GetKeyAreaKey(NCASectionCryptoType type) const {
+std::optional<Core::Crypto::Key128> NCA::GetKeyAreaKey(NCASectionCryptoType type) const {
     const auto master_key_id = GetCryptoRevision();
 
     if (!keys.HasKey(Core::Crypto::S128KeyType::KeyArea, master_key_id, header.key_index))
-        return boost::none;
+        return {};
 
     std::vector<u8> key_area(header.key_area.begin(), header.key_area.end());
     Core::Crypto::AESCipher<Core::Crypto::Key128> cipher(
@@ -416,25 +415,25 @@ boost::optional<Core::Crypto::Key128> NCA::GetKeyAreaKey(NCASectionCryptoType ty
     return out;
 }
 
-boost::optional<Core::Crypto::Key128> NCA::GetTitlekey() {
+std::optional<Core::Crypto::Key128> NCA::GetTitlekey() {
     const auto master_key_id = GetCryptoRevision();
 
     u128 rights_id{};
     memcpy(rights_id.data(), header.rights_id.data(), 16);
     if (rights_id == u128{}) {
         status = Loader::ResultStatus::ErrorInvalidRightsID;
-        return boost::none;
+        return {};
     }
 
     auto titlekey = keys.GetKey(Core::Crypto::S128KeyType::Titlekey, rights_id[1], rights_id[0]);
     if (titlekey == Core::Crypto::Key128{}) {
         status = Loader::ResultStatus::ErrorMissingTitlekey;
-        return boost::none;
+        return {};
     }
 
     if (!keys.HasKey(Core::Crypto::S128KeyType::Titlekek, master_key_id)) {
         status = Loader::ResultStatus::ErrorMissingTitlekek;
-        return boost::none;
+        return {};
     }
 
     Core::Crypto::AESCipher<Core::Crypto::Key128> cipher(
@@ -458,18 +457,18 @@ VirtualFile NCA::Decrypt(const NCASectionHeader& s_header, VirtualFile in, u64 s
     case NCASectionCryptoType::BKTR:
         LOG_DEBUG(Crypto, "called with mode=CTR, starting_offset={:016X}", starting_offset);
         {
-            boost::optional<Core::Crypto::Key128> key = boost::none;
+            std::optional<Core::Crypto::Key128> key = {};
             if (has_rights_id) {
                 status = Loader::ResultStatus::Success;
                 key = GetTitlekey();
-                if (key == boost::none) {
+                if (key) {
                     if (status == Loader::ResultStatus::Success)
                         status = Loader::ResultStatus::ErrorMissingTitlekey;
                     return nullptr;
                 }
             } else {
                 key = GetKeyAreaKey(NCASectionCryptoType::CTR);
-                if (key == boost::none) {
+                if (key) {
                     status = Loader::ResultStatus::ErrorMissingKeyAreaKey;
                     return nullptr;
                 }

--- a/src/core/file_sys/content_archive.h
+++ b/src/core/file_sys/content_archive.h
@@ -6,9 +6,10 @@
 
 #include <array>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
-#include <boost/optional.hpp>
+
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
@@ -111,8 +112,8 @@ private:
     bool ReadPFS0Section(const NCASectionHeader& section, const NCASectionTableEntry& entry);
 
     u8 GetCryptoRevision() const;
-    boost::optional<Core::Crypto::Key128> GetKeyAreaKey(NCASectionCryptoType type) const;
-    boost::optional<Core::Crypto::Key128> GetTitlekey();
+    std::optional<Core::Crypto::Key128> GetKeyAreaKey(NCASectionCryptoType type) const;
+    std::optional<Core::Crypto::Key128> GetTitlekey();
     VirtualFile Decrypt(const NCASectionHeader& header, VirtualFile in, u64 starting_offset);
 
     std::vector<VirtualDir> dirs;

--- a/src/core/file_sys/ips_layer.cpp
+++ b/src/core/file_sys/ips_layer.cpp
@@ -103,12 +103,12 @@ VirtualFile PatchIPS(const VirtualFile& in, const VirtualFile& ips) {
             offset += sizeof(u16);
 
             const auto data = ips->ReadByte(offset++);
-            if (data)
+            if (!data)
                 return nullptr;
 
             if (real_offset + rle_size > in_data.size())
                 rle_size = static_cast<u16>(in_data.size() - real_offset);
-            std::memset(in_data.data() + real_offset, data.value(), rle_size);
+            std::memset(in_data.data() + real_offset, *data, rle_size);
         } else { // Standard Patch
             auto read = data_size;
             if (real_offset + read > in_data.size())

--- a/src/core/file_sys/ips_layer.cpp
+++ b/src/core/file_sys/ips_layer.cpp
@@ -103,12 +103,12 @@ VirtualFile PatchIPS(const VirtualFile& in, const VirtualFile& ips) {
             offset += sizeof(u16);
 
             const auto data = ips->ReadByte(offset++);
-            if (data == boost::none)
+            if (data )
                 return nullptr;
 
             if (real_offset + rle_size > in_data.size())
                 rle_size = static_cast<u16>(in_data.size() - real_offset);
-            std::memset(in_data.data() + real_offset, data.get(), rle_size);
+            std::memset(in_data.data() + real_offset, data.value(), rle_size);
         } else { // Standard Patch
             auto read = data_size;
             if (real_offset + read > in_data.size())

--- a/src/core/file_sys/ips_layer.cpp
+++ b/src/core/file_sys/ips_layer.cpp
@@ -103,7 +103,7 @@ VirtualFile PatchIPS(const VirtualFile& in, const VirtualFile& ips) {
             offset += sizeof(u16);
 
             const auto data = ips->ReadByte(offset++);
-            if (data )
+            if (data)
                 return nullptr;
 
             if (real_offset + rle_size > in_data.size())

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -65,7 +65,7 @@ VirtualDir PatchManager::PatchExeFS(VirtualDir exefs) const {
     if (update != nullptr && update->GetExeFS() != nullptr &&
         update->GetStatus() == Loader::ResultStatus::ErrorMissingBKTRBaseRomFS) {
         LOG_INFO(Loader, "    ExeFS: Update ({}) applied successfully",
-                     FormatTitleVersion(installed->GetEntryVersion(update_tid).value_or(0)));
+                 FormatTitleVersion(installed->GetEntryVersion(update_tid).value_or(0)));
         exefs = update->GetExeFS();
     }
 
@@ -284,8 +284,7 @@ std::map<std::string, std::string, std::less<>> PatchManager::GetPatchVersionNam
                 out.insert_or_assign("Update", "");
             } else {
                 out.insert_or_assign(
-                    "Update",
-                    FormatTitleVersion(*meta_ver, TitleVersionFormat::ThreeElements));
+                    "Update", FormatTitleVersion(*meta_ver, TitleVersionFormat::ThreeElements));
             }
         } else if (update_raw != nullptr) {
             out.insert_or_assign("Update", "PACKED");

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -280,7 +280,7 @@ std::map<std::string, std::string, std::less<>> PatchManager::GetPatchVersionNam
     } else {
         if (installed->HasEntry(update_tid, ContentRecordType::Program)) {
             const auto meta_ver = installed->GetEntryVersion(update_tid);
-            if (meta_ver  || meta_ver.value() == 0) {
+            if (meta_ver || meta_ver.value() == 0) {
                 out.insert_or_assign("Update", "");
             } else {
                 out.insert_or_assign(

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -65,7 +65,7 @@ VirtualDir PatchManager::PatchExeFS(VirtualDir exefs) const {
     if (update != nullptr && update->GetExeFS() != nullptr &&
         update->GetStatus() == Loader::ResultStatus::ErrorMissingBKTRBaseRomFS) {
         LOG_INFO(Loader, "    ExeFS: Update ({}) applied successfully",
-                 FormatTitleVersion(installed->GetEntryVersion(update_tid).get_value_or(0)));
+                     FormatTitleVersion(installed->GetEntryVersion(update_tid).value_or(0)));
         exefs = update->GetExeFS();
     }
 
@@ -236,7 +236,7 @@ VirtualFile PatchManager::PatchRomFS(VirtualFile romfs, u64 ivfc_offset, Content
         if (new_nca->GetStatus() == Loader::ResultStatus::Success &&
             new_nca->GetRomFS() != nullptr) {
             LOG_INFO(Loader, "    RomFS: Update ({}) applied successfully",
-                     FormatTitleVersion(installed->GetEntryVersion(update_tid).get_value_or(0)));
+                     FormatTitleVersion(installed->GetEntryVersion(update_tid).value_or(0)));
             romfs = new_nca->GetRomFS();
         }
     } else if (update_raw != nullptr) {
@@ -280,12 +280,12 @@ std::map<std::string, std::string, std::less<>> PatchManager::GetPatchVersionNam
     } else {
         if (installed->HasEntry(update_tid, ContentRecordType::Program)) {
             const auto meta_ver = installed->GetEntryVersion(update_tid);
-            if (meta_ver == boost::none || meta_ver.get() == 0) {
+            if (meta_ver  || meta_ver.value() == 0) {
                 out.insert_or_assign("Update", "");
             } else {
                 out.insert_or_assign(
                     "Update",
-                    FormatTitleVersion(meta_ver.get(), TitleVersionFormat::ThreeElements));
+                    FormatTitleVersion(meta_ver.value(), TitleVersionFormat::ThreeElements));
             }
         } else if (update_raw != nullptr) {
             out.insert_or_assign("Update", "PACKED");

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -280,12 +280,12 @@ std::map<std::string, std::string, std::less<>> PatchManager::GetPatchVersionNam
     } else {
         if (installed->HasEntry(update_tid, ContentRecordType::Program)) {
             const auto meta_ver = installed->GetEntryVersion(update_tid);
-            if (meta_ver || meta_ver.value() == 0) {
+            if (meta_ver.value_or(0) == 0) {
                 out.insert_or_assign("Update", "");
             } else {
                 out.insert_or_assign(
                     "Update",
-                    FormatTitleVersion(meta_ver.value(), TitleVersionFormat::ThreeElements));
+                    FormatTitleVersion(*meta_ver, TitleVersionFormat::ThreeElements));
             }
         } else if (update_raw != nullptr) {
             out.insert_or_assign("Update", "PACKED");

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -175,7 +175,7 @@ static std::optional<NcaID> CheckMapForContentRecord(
 }
 
 std::optional<NcaID> RegisteredCache::GetNcaIDFromMetadata(u64 title_id,
-                                                             ContentRecordType type) const {
+                                                           ContentRecordType type) const {
     if (type == ContentRecordType::Meta && meta_id.find(title_id) != meta_id.end())
         return meta_id.at(title_id);
 
@@ -283,7 +283,7 @@ bool RegisteredCache::HasEntry(RegisteredCacheEntry entry) const {
 
 VirtualFile RegisteredCache::GetEntryUnparsed(u64 title_id, ContentRecordType type) const {
     const auto id = GetNcaIDFromMetadata(title_id, type);
-    if (id )
+    if (id)
         return nullptr;
 
     return GetFileAtID(id.value());
@@ -307,7 +307,7 @@ std::optional<u32> RegisteredCache::GetEntryVersion(u64 title_id) const {
 
 VirtualFile RegisteredCache::GetEntryRaw(u64 title_id, ContentRecordType type) const {
     const auto id = GetNcaIDFromMetadata(title_id, type);
-    if (id )
+    if (id)
         return nullptr;
 
     return parser(GetFileAtID(id.value()), id.value());
@@ -468,7 +468,7 @@ InstallResult RegisteredCache::RawInstallNCA(std::shared_ptr<NCA> nca, const Vfs
     // game is massive), we're going to cheat and only hash the first MB of the NCA.
     // Also, for XCIs the NcaID matters, so if the override id isn't none, use that.
     NcaID id{};
-    if (override_id ) {
+    if (override_id) {
         const auto& data = in->ReadBytes(0x100000);
         mbedtls_sha256(data.data(), data.size(), hash.data(), 0);
         memcpy(id.data(), hash.data(), 16);

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -159,28 +159,28 @@ VirtualFile RegisteredCache::GetFileAtID(NcaID id) const {
     return file;
 }
 
-static boost::optional<NcaID> CheckMapForContentRecord(
+static std::optional<NcaID> CheckMapForContentRecord(
     const boost::container::flat_map<u64, CNMT>& map, u64 title_id, ContentRecordType type) {
     if (map.find(title_id) == map.end())
-        return boost::none;
+        return {};
 
     const auto& cnmt = map.at(title_id);
 
     const auto iter = std::find_if(cnmt.GetContentRecords().begin(), cnmt.GetContentRecords().end(),
                                    [type](const ContentRecord& rec) { return rec.type == type; });
     if (iter == cnmt.GetContentRecords().end())
-        return boost::none;
+        return {};
 
-    return boost::make_optional(iter->nca_id);
+    return std::make_optional(iter->nca_id);
 }
 
-boost::optional<NcaID> RegisteredCache::GetNcaIDFromMetadata(u64 title_id,
+std::optional<NcaID> RegisteredCache::GetNcaIDFromMetadata(u64 title_id,
                                                              ContentRecordType type) const {
     if (type == ContentRecordType::Meta && meta_id.find(title_id) != meta_id.end())
         return meta_id.at(title_id);
 
     const auto res1 = CheckMapForContentRecord(yuzu_meta, title_id, type);
-    if (res1 != boost::none)
+    if (res1 != std::nullopt)
         return res1;
     return CheckMapForContentRecord(meta, title_id, type);
 }
@@ -283,17 +283,17 @@ bool RegisteredCache::HasEntry(RegisteredCacheEntry entry) const {
 
 VirtualFile RegisteredCache::GetEntryUnparsed(u64 title_id, ContentRecordType type) const {
     const auto id = GetNcaIDFromMetadata(title_id, type);
-    if (id == boost::none)
+    if (id )
         return nullptr;
 
-    return GetFileAtID(id.get());
+    return GetFileAtID(id.value());
 }
 
 VirtualFile RegisteredCache::GetEntryUnparsed(RegisteredCacheEntry entry) const {
     return GetEntryUnparsed(entry.title_id, entry.type);
 }
 
-boost::optional<u32> RegisteredCache::GetEntryVersion(u64 title_id) const {
+std::optional<u32> RegisteredCache::GetEntryVersion(u64 title_id) const {
     const auto meta_iter = meta.find(title_id);
     if (meta_iter != meta.end())
         return meta_iter->second.GetTitleVersion();
@@ -302,15 +302,15 @@ boost::optional<u32> RegisteredCache::GetEntryVersion(u64 title_id) const {
     if (yuzu_meta_iter != yuzu_meta.end())
         return yuzu_meta_iter->second.GetTitleVersion();
 
-    return boost::none;
+    return {};
 }
 
 VirtualFile RegisteredCache::GetEntryRaw(u64 title_id, ContentRecordType type) const {
     const auto id = GetNcaIDFromMetadata(title_id, type);
-    if (id == boost::none)
+    if (id )
         return nullptr;
 
-    return parser(GetFileAtID(id.get()), id.get());
+    return parser(GetFileAtID(id.value()), id.value());
 }
 
 VirtualFile RegisteredCache::GetEntryRaw(RegisteredCacheEntry entry) const {
@@ -364,8 +364,8 @@ std::vector<RegisteredCacheEntry> RegisteredCache::ListEntries() const {
 }
 
 std::vector<RegisteredCacheEntry> RegisteredCache::ListEntriesFilter(
-    boost::optional<TitleType> title_type, boost::optional<ContentRecordType> record_type,
-    boost::optional<u64> title_id) const {
+    std::optional<TitleType> title_type, std::optional<ContentRecordType> record_type,
+    std::optional<u64> title_id) const {
     std::vector<RegisteredCacheEntry> out;
     IterateAllMetadata<RegisteredCacheEntry>(
         out,
@@ -373,11 +373,11 @@ std::vector<RegisteredCacheEntry> RegisteredCache::ListEntriesFilter(
             return RegisteredCacheEntry{c.GetTitleID(), r.type};
         },
         [&title_type, &record_type, &title_id](const CNMT& c, const ContentRecord& r) {
-            if (title_type != boost::none && title_type.get() != c.GetType())
+            if (title_type != std::nullopt && title_type.value() != c.GetType())
                 return false;
-            if (record_type != boost::none && record_type.get() != r.type)
+            if (record_type != std::nullopt && record_type.value() != r.type)
                 return false;
-            if (title_id != boost::none && title_id.get() != c.GetTitleID())
+            if (title_id != std::nullopt && title_id.value() != c.GetTitleID())
                 return false;
             return true;
         });
@@ -459,7 +459,7 @@ InstallResult RegisteredCache::InstallEntry(std::shared_ptr<NCA> nca, TitleType 
 
 InstallResult RegisteredCache::RawInstallNCA(std::shared_ptr<NCA> nca, const VfsCopyFunction& copy,
                                              bool overwrite_if_exists,
-                                             boost::optional<NcaID> override_id) {
+                                             std::optional<NcaID> override_id) {
     const auto in = nca->GetBaseFile();
     Core::Crypto::SHA256Hash hash{};
 
@@ -468,12 +468,12 @@ InstallResult RegisteredCache::RawInstallNCA(std::shared_ptr<NCA> nca, const Vfs
     // game is massive), we're going to cheat and only hash the first MB of the NCA.
     // Also, for XCIs the NcaID matters, so if the override id isn't none, use that.
     NcaID id{};
-    if (override_id == boost::none) {
+    if (override_id ) {
         const auto& data = in->ReadBytes(0x100000);
         mbedtls_sha256(data.data(), data.size(), hash.data(), 0);
         memcpy(id.data(), hash.data(), 16);
     } else {
-        id = override_id.get();
+        id = override_id.value();
     }
 
     std::string path = GetRelativePathFromNcaID(id, false, true);
@@ -543,14 +543,14 @@ bool RegisteredCacheUnion::HasEntry(RegisteredCacheEntry entry) const {
     return HasEntry(entry.title_id, entry.type);
 }
 
-boost::optional<u32> RegisteredCacheUnion::GetEntryVersion(u64 title_id) const {
+std::optional<u32> RegisteredCacheUnion::GetEntryVersion(u64 title_id) const {
     for (const auto& c : caches) {
         const auto res = c->GetEntryVersion(title_id);
-        if (res != boost::none)
+        if (res != std::nullopt)
             return res;
     }
 
-    return boost::none;
+    return {};
 }
 
 VirtualFile RegisteredCacheUnion::GetEntryUnparsed(u64 title_id, ContentRecordType type) const {
@@ -609,8 +609,8 @@ std::vector<RegisteredCacheEntry> RegisteredCacheUnion::ListEntries() const {
 }
 
 std::vector<RegisteredCacheEntry> RegisteredCacheUnion::ListEntriesFilter(
-    boost::optional<TitleType> title_type, boost::optional<ContentRecordType> record_type,
-    boost::optional<u64> title_id) const {
+    std::optional<TitleType> title_type, std::optional<ContentRecordType> record_type,
+    std::optional<u64> title_id) const {
     std::vector<RegisteredCacheEntry> out;
     for (const auto& c : caches) {
         c->IterateAllMetadata<RegisteredCacheEntry>(
@@ -619,11 +619,11 @@ std::vector<RegisteredCacheEntry> RegisteredCacheUnion::ListEntriesFilter(
                 return RegisteredCacheEntry{c.GetTitleID(), r.type};
             },
             [&title_type, &record_type, &title_id](const CNMT& c, const ContentRecord& r) {
-                if (title_type != boost::none && title_type.get() != c.GetType())
+                if (title_type != std::nullopt && title_type.value() != c.GetType())
                     return false;
-                if (record_type != boost::none && record_type.get() != r.type)
+                if (record_type != std::nullopt && record_type.value() != r.type)
                     return false;
-                if (title_id != boost::none && title_id.get() != c.GetTitleID())
+                if (title_id != std::nullopt && title_id.value() != c.GetTitleID())
                     return false;
                 return true;
             });

--- a/src/core/file_sys/registered_cache.h
+++ b/src/core/file_sys/registered_cache.h
@@ -98,8 +98,7 @@ public:
     std::vector<RegisteredCacheEntry> ListEntries() const;
     // If a parameter is not std::nullopt, it will be filtered for from all entries.
     std::vector<RegisteredCacheEntry> ListEntriesFilter(
-        std::optional<TitleType> title_type = {},
-        std::optional<ContentRecordType> record_type = {},
+        std::optional<TitleType> title_type = {}, std::optional<ContentRecordType> record_type = {},
         std::optional<u64> title_id = {}) const;
 
     // Raw copies all the ncas from the xci/nsp to the csache. Does some quick checks to make sure
@@ -166,8 +165,7 @@ public:
     std::vector<RegisteredCacheEntry> ListEntries() const;
     // If a parameter is not std::nullopt, it will be filtered for from all entries.
     std::vector<RegisteredCacheEntry> ListEntriesFilter(
-        std::optional<TitleType> title_type = {},
-        std::optional<ContentRecordType> record_type = {},
+        std::optional<TitleType> title_type = {}, std::optional<ContentRecordType> record_type = {},
         std::optional<u64> title_id = {}) const;
 
 private:

--- a/src/core/file_sys/registered_cache.h
+++ b/src/core/file_sys/registered_cache.h
@@ -84,7 +84,7 @@ public:
     bool HasEntry(u64 title_id, ContentRecordType type) const;
     bool HasEntry(RegisteredCacheEntry entry) const;
 
-    boost::optional<u32> GetEntryVersion(u64 title_id) const;
+    std::optional<u32> GetEntryVersion(u64 title_id) const;
 
     VirtualFile GetEntryUnparsed(u64 title_id, ContentRecordType type) const;
     VirtualFile GetEntryUnparsed(RegisteredCacheEntry entry) const;
@@ -96,11 +96,11 @@ public:
     std::unique_ptr<NCA> GetEntry(RegisteredCacheEntry entry) const;
 
     std::vector<RegisteredCacheEntry> ListEntries() const;
-    // If a parameter is not boost::none, it will be filtered for from all entries.
+    // If a parameter is not std::nullopt, it will be filtered for from all entries.
     std::vector<RegisteredCacheEntry> ListEntriesFilter(
-        boost::optional<TitleType> title_type = boost::none,
-        boost::optional<ContentRecordType> record_type = boost::none,
-        boost::optional<u64> title_id = boost::none) const;
+        std::optional<TitleType> title_type = {},
+        std::optional<ContentRecordType> record_type = {},
+        std::optional<u64> title_id = {}) const;
 
     // Raw copies all the ncas from the xci/nsp to the csache. Does some quick checks to make sure
     // there is a meta NCA and all of them are accessible.
@@ -125,12 +125,11 @@ private:
     std::vector<NcaID> AccumulateFiles() const;
     void ProcessFiles(const std::vector<NcaID>& ids);
     void AccumulateYuzuMeta();
-    boost::optional<NcaID> GetNcaIDFromMetadata(u64 title_id, ContentRecordType type) const;
+    std::optional<NcaID> GetNcaIDFromMetadata(u64 title_id, ContentRecordType type) const;
     VirtualFile GetFileAtID(NcaID id) const;
     VirtualFile OpenFileOrDirectoryConcat(const VirtualDir& dir, std::string_view path) const;
     InstallResult RawInstallNCA(std::shared_ptr<NCA> nca, const VfsCopyFunction& copy,
-                                bool overwrite_if_exists,
-                                boost::optional<NcaID> override_id = boost::none);
+                                bool overwrite_if_exists, std::optional<NcaID> override_id = {});
     bool RawInstallYuzuMeta(const CNMT& cnmt);
 
     VirtualDir dir;
@@ -153,7 +152,7 @@ public:
     bool HasEntry(u64 title_id, ContentRecordType type) const;
     bool HasEntry(RegisteredCacheEntry entry) const;
 
-    boost::optional<u32> GetEntryVersion(u64 title_id) const;
+    std::optional<u32> GetEntryVersion(u64 title_id) const;
 
     VirtualFile GetEntryUnparsed(u64 title_id, ContentRecordType type) const;
     VirtualFile GetEntryUnparsed(RegisteredCacheEntry entry) const;
@@ -165,11 +164,11 @@ public:
     std::unique_ptr<NCA> GetEntry(RegisteredCacheEntry entry) const;
 
     std::vector<RegisteredCacheEntry> ListEntries() const;
-    // If a parameter is not boost::none, it will be filtered for from all entries.
+    // If a parameter is not std::nullopt, it will be filtered for from all entries.
     std::vector<RegisteredCacheEntry> ListEntriesFilter(
-        boost::optional<TitleType> title_type = boost::none,
-        boost::optional<ContentRecordType> record_type = boost::none,
-        boost::optional<u64> title_id = boost::none) const;
+        std::optional<TitleType> title_type = {},
+        std::optional<ContentRecordType> record_type = {},
+        std::optional<u64> title_id = {}) const;
 
 private:
     std::vector<RegisteredCache*> caches;

--- a/src/core/file_sys/vfs.cpp
+++ b/src/core/file_sys/vfs.cpp
@@ -167,13 +167,13 @@ std::string VfsFile::GetExtension() const {
 
 VfsDirectory::~VfsDirectory() = default;
 
-boost::optional<u8> VfsFile::ReadByte(std::size_t offset) const {
+std::optional<u8> VfsFile::ReadByte(std::size_t offset) const {
     u8 out{};
     std::size_t size = Read(&out, 1, offset);
     if (size == 1)
         return out;
 
-    return boost::none;
+    return {};
 }
 
 std::vector<u8> VfsFile::ReadBytes(std::size_t size, std::size_t offset) const {

--- a/src/core/file_sys/vfs.h
+++ b/src/core/file_sys/vfs.h
@@ -6,11 +6,12 @@
 
 #include <map>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <type_traits>
 #include <vector>
-#include <boost/optional.hpp>
+
 #include "common/common_types.h"
 #include "core/file_sys/vfs_types.h"
 
@@ -103,8 +104,8 @@ public:
     // into file. Returns number of bytes successfully written.
     virtual std::size_t Write(const u8* data, std::size_t length, std::size_t offset = 0) = 0;
 
-    // Reads exactly one byte at the offset provided, returning boost::none on error.
-    virtual boost::optional<u8> ReadByte(std::size_t offset = 0) const;
+    // Reads exactly one byte at the offset provided, returning std::nullopt on error.
+    virtual std::optional<u8> ReadByte(std::size_t offset = 0) const;
     // Reads size bytes starting at offset in file into a vector.
     virtual std::vector<u8> ReadBytes(std::size_t size, std::size_t offset = 0) const;
     // Reads all the bytes from the file into a vector. Equivalent to 'file->Read(file->GetSize(),

--- a/src/core/file_sys/vfs.h
+++ b/src/core/file_sys/vfs.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <map>
 #include <memory>
 #include <optional>

--- a/src/core/file_sys/vfs_offset.cpp
+++ b/src/core/file_sys/vfs_offset.cpp
@@ -57,11 +57,11 @@ std::size_t OffsetVfsFile::Write(const u8* data, std::size_t length, std::size_t
     return file->Write(data, TrimToFit(length, r_offset), offset + r_offset);
 }
 
-boost::optional<u8> OffsetVfsFile::ReadByte(std::size_t r_offset) const {
+std::optional<u8> OffsetVfsFile::ReadByte(std::size_t r_offset) const {
     if (r_offset < size)
         return file->ReadByte(offset + r_offset);
 
-    return boost::none;
+    return {};
 }
 
 std::vector<u8> OffsetVfsFile::ReadBytes(std::size_t r_size, std::size_t r_offset) const {

--- a/src/core/file_sys/vfs_offset.h
+++ b/src/core/file_sys/vfs_offset.h
@@ -29,7 +29,7 @@ public:
     bool IsReadable() const override;
     std::size_t Read(u8* data, std::size_t length, std::size_t offset) const override;
     std::size_t Write(const u8* data, std::size_t length, std::size_t offset) override;
-    boost::optional<u8> ReadByte(std::size_t offset) const override;
+    std::optional<u8> ReadByte(std::size_t offset) const override;
     std::vector<u8> ReadBytes(std::size_t size, std::size_t offset) const override;
     std::vector<u8> ReadAllBytes() const override;
     bool WriteByte(u8 data, std::size_t offset) override;

--- a/src/core/file_sys/vfs_static.h
+++ b/src/core/file_sys/vfs_static.h
@@ -53,10 +53,10 @@ public:
         return 0;
     }
 
-    boost::optional<u8> ReadByte(std::size_t offset) const override {
+    std::optional<u8> ReadByte(std::size_t offset) const override {
         if (offset < size)
             return value;
-        return boost::none;
+        return {};
     }
 
     std::vector<u8> ReadBytes(std::size_t length, std::size_t offset) const override {

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -4,9 +4,9 @@
 
 #include <algorithm>
 #include <cinttypes>
+#include <optional>
 #include <vector>
 
-#include <boost/optional.hpp>
 #include <boost/range/algorithm_ext/erase.hpp>
 
 #include "common/assert.h"
@@ -94,7 +94,7 @@ void Thread::CancelWakeupTimer() {
     CoreTiming::UnscheduleEventThreadsafe(kernel.ThreadWakeupCallbackEventType(), callback_handle);
 }
 
-static boost::optional<s32> GetNextProcessorId(u64 mask) {
+static std::optional<s32> GetNextProcessorId(u64 mask) {
     for (s32 index = 0; index < Core::NUM_CPU_CORES; ++index) {
         if (mask & (1ULL << index)) {
             if (!Core::System::GetInstance().Scheduler(index).GetCurrentThread()) {
@@ -142,7 +142,7 @@ void Thread::ResumeFromWait() {
 
     status = ThreadStatus::Ready;
 
-    boost::optional<s32> new_processor_id = GetNextProcessorId(affinity_mask);
+    std::optional<s32> new_processor_id = GetNextProcessorId(affinity_mask);
     if (!new_processor_id) {
         new_processor_id = processor_id;
     }
@@ -369,7 +369,7 @@ void Thread::ChangeCore(u32 core, u64 mask) {
         return;
     }
 
-    boost::optional<s32> new_processor_id{GetNextProcessorId(affinity_mask)};
+    std::optional<s32> new_processor_id{GetNextProcessorId(affinity_mask)};
 
     if (!new_processor_id) {
         new_processor_id = processor_id;

--- a/src/core/hle/service/acc/profile_manager.cpp
+++ b/src/core/hle/service/acc/profile_manager.cpp
@@ -195,7 +195,7 @@ std::size_t ProfileManager::GetOpenUserCount() const {
 
 /// Checks if a user id exists in our profile manager
 bool ProfileManager::UserExists(UUID uuid) const {
-    return GetUserIndex(uuid) != std::nullopt;
+    return GetUserIndex(uuid).has_value();
 }
 
 bool ProfileManager::UserExistsIndex(std::size_t index) const {

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -743,7 +743,7 @@ void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
 
     Account::ProfileManager profile_manager{};
     const auto uuid = profile_manager.GetUser(Settings::values.current_user);
-    ASSERT(uuid != std::nullopt);
+    ASSERT(uuid);
     params.current_user = uuid->uuid;
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};

--- a/src/core/hle/service/nvflinger/buffer_queue.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue.cpp
@@ -70,7 +70,7 @@ void BufferQueue::QueueBuffer(u32 slot, BufferTransformFlags transform,
     itr->crop_rect = crop_rect;
 }
 
-std::optional<const BufferQueue::Buffer&> BufferQueue::AcquireBuffer() {
+std::optional<const BufferQueue::Buffer> BufferQueue::AcquireBuffer() {
     auto itr = std::find_if(queue.begin(), queue.end(), [](const Buffer& buffer) {
         return buffer.status == Buffer::Status::Queued;
     });

--- a/src/core/hle/service/nvflinger/buffer_queue.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue.cpp
@@ -31,7 +31,7 @@ void BufferQueue::SetPreallocatedBuffer(u32 slot, const IGBPBuffer& igbp_buffer)
     buffer_wait_event->Signal();
 }
 
-boost::optional<u32> BufferQueue::DequeueBuffer(u32 width, u32 height) {
+std::optional<u32> BufferQueue::DequeueBuffer(u32 width, u32 height) {
     auto itr = std::find_if(queue.begin(), queue.end(), [&](const Buffer& buffer) {
         // Only consider free buffers. Buffers become free once again after they've been Acquired
         // and Released by the compositor, see the NVFlinger::Compose method.
@@ -44,7 +44,7 @@ boost::optional<u32> BufferQueue::DequeueBuffer(u32 width, u32 height) {
     });
 
     if (itr == queue.end()) {
-        return boost::none;
+        return {};
     }
 
     itr->status = Buffer::Status::Dequeued;
@@ -70,12 +70,12 @@ void BufferQueue::QueueBuffer(u32 slot, BufferTransformFlags transform,
     itr->crop_rect = crop_rect;
 }
 
-boost::optional<const BufferQueue::Buffer&> BufferQueue::AcquireBuffer() {
+std::optional<const BufferQueue::Buffer&> BufferQueue::AcquireBuffer() {
     auto itr = std::find_if(queue.begin(), queue.end(), [](const Buffer& buffer) {
         return buffer.status == Buffer::Status::Queued;
     });
     if (itr == queue.end())
-        return boost::none;
+        return {};
     itr->status = Buffer::Status::Acquired;
     return *itr;
 }

--- a/src/core/hle/service/nvflinger/buffer_queue.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue.cpp
@@ -70,7 +70,7 @@ void BufferQueue::QueueBuffer(u32 slot, BufferTransformFlags transform,
     itr->crop_rect = crop_rect;
 }
 
-std::optional<const BufferQueue::Buffer> BufferQueue::AcquireBuffer() {
+std::optional<std::reference_wrapper<const BufferQueue::Buffer>> BufferQueue::AcquireBuffer() {
     auto itr = std::find_if(queue.begin(), queue.end(), [](const Buffer& buffer) {
         return buffer.status == Buffer::Status::Queued;
     });

--- a/src/core/hle/service/nvflinger/buffer_queue.h
+++ b/src/core/hle/service/nvflinger/buffer_queue.h
@@ -4,8 +4,9 @@
 
 #pragma once
 
+#include <optional>
 #include <vector>
-#include <boost/optional.hpp>
+
 #include "common/common_funcs.h"
 #include "common/math_util.h"
 #include "common/swap.h"
@@ -73,11 +74,11 @@ public:
     };
 
     void SetPreallocatedBuffer(u32 slot, const IGBPBuffer& igbp_buffer);
-    boost::optional<u32> DequeueBuffer(u32 width, u32 height);
+    std::optional<u32> DequeueBuffer(u32 width, u32 height);
     const IGBPBuffer& RequestBuffer(u32 slot) const;
     void QueueBuffer(u32 slot, BufferTransformFlags transform,
                      const MathUtil::Rectangle<int>& crop_rect);
-    boost::optional<const Buffer&> AcquireBuffer();
+    std::optional<const Buffer&> AcquireBuffer();
     void ReleaseBuffer(u32 slot);
     u32 Query(QueryType type);
 

--- a/src/core/hle/service/nvflinger/buffer_queue.h
+++ b/src/core/hle/service/nvflinger/buffer_queue.h
@@ -78,7 +78,7 @@ public:
     const IGBPBuffer& RequestBuffer(u32 slot) const;
     void QueueBuffer(u32 slot, BufferTransformFlags transform,
                      const MathUtil::Rectangle<int>& crop_rect);
-    std::optional<const Buffer&> AcquireBuffer();
+    std::optional<const Buffer> AcquireBuffer();
     void ReleaseBuffer(u32 slot);
     u32 Query(QueryType type);
 

--- a/src/core/hle/service/nvflinger/buffer_queue.h
+++ b/src/core/hle/service/nvflinger/buffer_queue.h
@@ -78,7 +78,7 @@ public:
     const IGBPBuffer& RequestBuffer(u32 slot) const;
     void QueueBuffer(u32 slot, BufferTransformFlags transform,
                      const MathUtil::Rectangle<int>& crop_rect);
-    std::optional<const Buffer> AcquireBuffer();
+    std::optional<std::reference_wrapper<const Buffer>> AcquireBuffer();
     void ReleaseBuffer(u32 slot);
     u32 Query(QueryType type);
 

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -134,7 +134,7 @@ void NVFlinger::Compose() {
 
         MicroProfileFlip();
 
-        if (buffer) {
+        if (!buffer) {
             auto& system_instance = Core::System::GetInstance();
 
             // There was no queued buffer to draw, render previous frame
@@ -143,7 +143,7 @@ void NVFlinger::Compose() {
             continue;
         }
 
-        auto& igbp_buffer = buffer.value().get().igbp_buffer;
+        auto& igbp_buffer = buffer->get().igbp_buffer;
 
         // Now send the buffer to the GPU for drawing.
         // TODO(Subv): Support more than just disp0. The display device selection is probably based
@@ -153,9 +153,9 @@ void NVFlinger::Compose() {
 
         nvdisp->flip(igbp_buffer.gpu_buffer_id, igbp_buffer.offset, igbp_buffer.format,
                      igbp_buffer.width, igbp_buffer.height, igbp_buffer.stride,
-                     buffer.value().get().transform, buffer.value().get().crop_rect);
+                     buffer->get().transform, buffer->get().crop_rect);
 
-        buffer_queue->ReleaseBuffer(buffer.value().get().slot);
+        buffer_queue->ReleaseBuffer(buffer->get().slot);
     }
 }
 

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -3,7 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
-#include <boost/optional.hpp>
+#include <optional>
 
 #include "common/alignment.h"
 #include "common/assert.h"
@@ -134,7 +134,7 @@ void NVFlinger::Compose() {
 
         MicroProfileFlip();
 
-        if (buffer == boost::none) {
+        if (buffer) {
             auto& system_instance = Core::System::GetInstance();
 
             // There was no queued buffer to draw, render previous frame
@@ -143,7 +143,7 @@ void NVFlinger::Compose() {
             continue;
         }
 
-        auto& igbp_buffer = buffer->igbp_buffer;
+        auto& igbp_buffer = buffer.value().igbp_buffer;
 
         // Now send the buffer to the GPU for drawing.
         // TODO(Subv): Support more than just disp0. The display device selection is probably based
@@ -152,10 +152,10 @@ void NVFlinger::Compose() {
         ASSERT(nvdisp);
 
         nvdisp->flip(igbp_buffer.gpu_buffer_id, igbp_buffer.offset, igbp_buffer.format,
-                     igbp_buffer.width, igbp_buffer.height, igbp_buffer.stride, buffer->transform,
-                     buffer->crop_rect);
+                     igbp_buffer.width, igbp_buffer.height, igbp_buffer.stride, buffer.value().transform,
+                     buffer.value().crop_rect);
 
-        buffer_queue->ReleaseBuffer(buffer->slot);
+        buffer_queue->ReleaseBuffer(buffer.value().slot);
     }
 }
 

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -143,7 +143,7 @@ void NVFlinger::Compose() {
             continue;
         }
 
-        auto& igbp_buffer = buffer.value().igbp_buffer;
+        auto& igbp_buffer = buffer.value().get().igbp_buffer;
 
         // Now send the buffer to the GPU for drawing.
         // TODO(Subv): Support more than just disp0. The display device selection is probably based
@@ -152,10 +152,10 @@ void NVFlinger::Compose() {
         ASSERT(nvdisp);
 
         nvdisp->flip(igbp_buffer.gpu_buffer_id, igbp_buffer.offset, igbp_buffer.format,
-                     igbp_buffer.width, igbp_buffer.height, igbp_buffer.stride, buffer.value().transform,
-                     buffer.value().crop_rect);
+                     igbp_buffer.width, igbp_buffer.height, igbp_buffer.stride,
+                     buffer.value().get().transform, buffer.value().get().crop_rect);
 
-        buffer_queue->ReleaseBuffer(buffer.value().slot);
+        buffer_queue->ReleaseBuffer(buffer.value().get().slot);
     }
 }
 

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -6,9 +6,10 @@
 #include <array>
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <type_traits>
 #include <utility>
-#include <boost/optional.hpp>
+
 #include "common/alignment.h"
 #include "common/assert.h"
 #include "common/common_funcs.h"
@@ -506,9 +507,9 @@ private:
             IGBPDequeueBufferRequestParcel request{ctx.ReadBuffer()};
             const u32 width{request.data.width};
             const u32 height{request.data.height};
-            boost::optional<u32> slot = buffer_queue->DequeueBuffer(width, height);
+            std::optional<u32> slot = buffer_queue->DequeueBuffer(width, height);
 
-            if (slot != boost::none) {
+            if (slot != std::nullopt) {
                 // Buffer is available
                 IGBPDequeueBufferResponseParcel response{*slot};
                 ctx.WriteBuffer(response.Serialize());
@@ -520,7 +521,7 @@ private:
                         Kernel::ThreadWakeupReason reason) {
                         // Repeat TransactParcel DequeueBuffer when a buffer is available
                         auto buffer_queue = nv_flinger->GetBufferQueue(id);
-                        boost::optional<u32> slot = buffer_queue->DequeueBuffer(width, height);
+                        std::optional<u32> slot = buffer_queue->DequeueBuffer(width, height);
                         IGBPDequeueBufferResponseParcel response{*slot};
                         ctx.WriteBuffer(response.Serialize());
                         IPC::ResponseBuilder rb{ctx, 2};

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -509,7 +509,7 @@ private:
             const u32 height{request.data.height};
             std::optional<u32> slot = buffer_queue->DequeueBuffer(width, height);
 
-            if (slot != std::nullopt) {
+            if (slot) {
                 // Buffer is available
                 IGBPDequeueBufferResponseParcel response{*slot};
                 ctx.WriteBuffer(response.Serialize());

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -6,10 +6,11 @@
 
 #include <iosfwd>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
-#include <boost/optional.hpp>
+
 #include "common/common_types.h"
 #include "core/file_sys/vfs.h"
 
@@ -145,7 +146,7 @@ public:
      * information.
      * @returns A pair with the optional system mode, and and the status.
      */
-    virtual std::pair<boost::optional<u32>, ResultStatus> LoadKernelSystemMode() {
+    virtual std::pair<std::optional<u32>, ResultStatus> LoadKernelSystemMode() {
         // 96MB allocated to the application.
         return std::make_pair(2, ResultStatus::Success);
     }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -4,9 +4,9 @@
 
 #include <algorithm>
 #include <cstring>
+#include <optional>
 #include <utility>
 
-#include <boost/optional.hpp>
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "common/logging/log.h"

--- a/src/core/memory_hook.h
+++ b/src/core/memory_hook.h
@@ -5,7 +5,8 @@
 #pragma once
 
 #include <memory>
-#include <boost/optional.hpp>
+#include <optional>
+
 #include "common/common_types.h"
 
 namespace Memory {
@@ -18,19 +19,19 @@ namespace Memory {
  *
  * A hook may be mapped to multiple regions of memory.
  *
- * If a boost::none or false is returned from a function, the read/write request is passed through
+ * If a std::nullopt or false is returned from a function, the read/write request is passed through
  * to the underlying memory region.
  */
 class MemoryHook {
 public:
     virtual ~MemoryHook();
 
-    virtual boost::optional<bool> IsValidAddress(VAddr addr) = 0;
+    virtual std::optional<bool> IsValidAddress(VAddr addr) = 0;
 
-    virtual boost::optional<u8> Read8(VAddr addr) = 0;
-    virtual boost::optional<u16> Read16(VAddr addr) = 0;
-    virtual boost::optional<u32> Read32(VAddr addr) = 0;
-    virtual boost::optional<u64> Read64(VAddr addr) = 0;
+    virtual std::optional<u8> Read8(VAddr addr) = 0;
+    virtual std::optional<u16> Read16(VAddr addr) = 0;
+    virtual std::optional<u32> Read32(VAddr addr) = 0;
+    virtual std::optional<u64> Read64(VAddr addr) = 0;
 
     virtual bool ReadBlock(VAddr src_addr, void* dest_buffer, std::size_t size) = 0;
 

--- a/src/tests/core/arm/arm_test_common.cpp
+++ b/src/tests/core/arm/arm_test_common.cpp
@@ -64,11 +64,11 @@ void TestEnvironment::ClearWriteRecords() {
 
 TestEnvironment::TestMemory::~TestMemory() {}
 
-boost::optional<bool> TestEnvironment::TestMemory::IsValidAddress(VAddr addr) {
+std::optional<bool> TestEnvironment::TestMemory::IsValidAddress(VAddr addr) {
     return true;
 }
 
-boost::optional<u8> TestEnvironment::TestMemory::Read8(VAddr addr) {
+std::optional<u8> TestEnvironment::TestMemory::Read8(VAddr addr) {
     const auto iter = data.find(addr);
 
     if (iter == data.end()) {
@@ -79,15 +79,15 @@ boost::optional<u8> TestEnvironment::TestMemory::Read8(VAddr addr) {
     return iter->second;
 }
 
-boost::optional<u16> TestEnvironment::TestMemory::Read16(VAddr addr) {
+std::optional<u16> TestEnvironment::TestMemory::Read16(VAddr addr) {
     return *Read8(addr) | static_cast<u16>(*Read8(addr + 1)) << 8;
 }
 
-boost::optional<u32> TestEnvironment::TestMemory::Read32(VAddr addr) {
+std::optional<u32> TestEnvironment::TestMemory::Read32(VAddr addr) {
     return *Read16(addr) | static_cast<u32>(*Read16(addr + 2)) << 16;
 }
 
-boost::optional<u64> TestEnvironment::TestMemory::Read64(VAddr addr) {
+std::optional<u64> TestEnvironment::TestMemory::Read64(VAddr addr) {
     return *Read32(addr) | static_cast<u64>(*Read32(addr + 4)) << 32;
 }
 

--- a/src/tests/core/arm/arm_test_common.h
+++ b/src/tests/core/arm/arm_test_common.h
@@ -64,12 +64,12 @@ private:
 
         ~TestMemory() override;
 
-        boost::optional<bool> IsValidAddress(VAddr addr) override;
+        std::optional<bool> IsValidAddress(VAddr addr) override;
 
-        boost::optional<u8> Read8(VAddr addr) override;
-        boost::optional<u16> Read16(VAddr addr) override;
-        boost::optional<u32> Read32(VAddr addr) override;
-        boost::optional<u64> Read64(VAddr addr) override;
+        std::optional<u8> Read8(VAddr addr) override;
+        std::optional<u16> Read16(VAddr addr) override;
+        std::optional<u32> Read32(VAddr addr) override;
+        std::optional<u64> Read64(VAddr addr) override;
 
         bool ReadBlock(VAddr src_addr, void* dest_buffer, std::size_t size) override;
 

--- a/src/video_core/command_processor.cpp
+++ b/src/video_core/command_processor.cpp
@@ -81,7 +81,7 @@ void GPU::ProcessCommandLists(const std::vector<CommandListHeader>& commands) {
     for (auto entry : commands) {
         Tegra::GPUVAddr address = entry.Address();
         u32 size = entry.sz;
-        const boost::optional<VAddr> head_address = memory_manager->GpuToCpuAddress(address);
+        const std::optional<VAddr> head_address = memory_manager->GpuToCpuAddress(address);
         VAddr current_addr = *head_address;
         while (current_addr < *head_address + size * sizeof(CommandHeader)) {
             const CommandHeader header = {Memory::Read32(current_addr)};

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -167,7 +167,7 @@ void Maxwell3D::ProcessQueryGet() {
     GPUVAddr sequence_address = regs.query.QueryAddress();
     // Since the sequence address is given as a GPU VAddr, we have to convert it to an application
     // VAddr before writing.
-    boost::optional<VAddr> address = memory_manager.GpuToCpuAddress(sequence_address);
+    std::optional<VAddr> address = memory_manager.GpuToCpuAddress(sequence_address);
 
     // TODO(Subv): Support the other query units.
     ASSERT_MSG(regs.query.query_get.unit == Regs::QueryUnit::Crop,
@@ -285,7 +285,7 @@ void Maxwell3D::ProcessCBData(u32 value) {
     // Don't allow writing past the end of the buffer.
     ASSERT(regs.const_buffer.cb_pos + sizeof(u32) <= regs.const_buffer.cb_size);
 
-    boost::optional<VAddr> address =
+    std::optional<VAddr> address =
         memory_manager.GpuToCpuAddress(buffer_address + regs.const_buffer.cb_pos);
 
     Memory::Write32(*address, value);
@@ -298,7 +298,7 @@ Texture::TICEntry Maxwell3D::GetTICEntry(u32 tic_index) const {
     GPUVAddr tic_base_address = regs.tic.TICAddress();
 
     GPUVAddr tic_address_gpu = tic_base_address + tic_index * sizeof(Texture::TICEntry);
-    boost::optional<VAddr> tic_address_cpu = memory_manager.GpuToCpuAddress(tic_address_gpu);
+    std::optional<VAddr> tic_address_cpu = memory_manager.GpuToCpuAddress(tic_address_gpu);
 
     Texture::TICEntry tic_entry;
     Memory::ReadBlock(*tic_address_cpu, &tic_entry, sizeof(Texture::TICEntry));
@@ -322,7 +322,7 @@ Texture::TSCEntry Maxwell3D::GetTSCEntry(u32 tsc_index) const {
     GPUVAddr tsc_base_address = regs.tsc.TSCAddress();
 
     GPUVAddr tsc_address_gpu = tsc_base_address + tsc_index * sizeof(Texture::TSCEntry);
-    boost::optional<VAddr> tsc_address_cpu = memory_manager.GpuToCpuAddress(tsc_address_gpu);
+    std::optional<VAddr> tsc_address_cpu = memory_manager.GpuToCpuAddress(tsc_address_gpu);
 
     Texture::TSCEntry tsc_entry;
     Memory::ReadBlock(*tsc_address_cpu, &tsc_entry, sizeof(Texture::TSCEntry));
@@ -386,7 +386,7 @@ Texture::FullTextureInfo Maxwell3D::GetStageTexture(Regs::ShaderStage stage,
 
     ASSERT(tex_info_address < tex_info_buffer.address + tex_info_buffer.size);
 
-    boost::optional<VAddr> tex_address_cpu = memory_manager.GpuToCpuAddress(tex_info_address);
+    std::optional<VAddr> tex_address_cpu = memory_manager.GpuToCpuAddress(tex_info_address);
     Texture::TextureHandle tex_handle{Memory::Read32(*tex_address_cpu)};
 
     Texture::FullTextureInfo tex_info{};

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -1455,7 +1455,7 @@ public:
         Type type;
     };
 
-    static std::optional<const Matcher&> Decode(Instruction instr) {
+    static std::optional<const Matcher> Decode(Instruction instr) {
         static const auto table{GetDecodeTable()};
 
         const auto matches_instruction = [instr](const auto& matcher) {
@@ -1463,7 +1463,7 @@ public:
         };
 
         auto iter = std::find_if(table.begin(), table.end(), matches_instruction);
-        return iter != table.end() ? std::optional<const Matcher&>(*iter) : std::nullopt;
+        return iter != table.end() ? std::optional<const Matcher>(*iter) : std::nullopt;
     }
 
 private:

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -5,11 +5,10 @@
 #pragma once
 
 #include <bitset>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 #include "common/assert.h"
 #include "common/bit_field.h"
@@ -1456,7 +1455,7 @@ public:
         Type type;
     };
 
-    static boost::optional<const Matcher&> Decode(Instruction instr) {
+    static std::optional<const Matcher&> Decode(Instruction instr) {
         static const auto table{GetDecodeTable()};
 
         const auto matches_instruction = [instr](const auto& matcher) {
@@ -1464,7 +1463,7 @@ public:
         };
 
         auto iter = std::find_if(table.begin(), table.end(), matches_instruction);
-        return iter != table.end() ? boost::optional<const Matcher&>(*iter) : boost::none;
+        return iter != table.end() ? std::optional<const Matcher&>(*iter) : std::nullopt;
     }
 
 private:

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -1455,7 +1455,7 @@ public:
         Type type;
     };
 
-    static std::optional<const Matcher> Decode(Instruction instr) {
+    static std::optional<std::reference_wrapper<const Matcher>> Decode(Instruction instr) {
         static const auto table{GetDecodeTable()};
 
         const auto matches_instruction = [instr](const auto& matcher) {
@@ -1463,7 +1463,8 @@ public:
         };
 
         auto iter = std::find_if(table.begin(), table.end(), matches_instruction);
-        return iter != table.end() ? std::optional<const Matcher>(*iter) : std::nullopt;
+        return iter != table.end() ? std::optional<std::reference_wrapper<const Matcher>>(*iter)
+                                   : std::nullopt;
     }
 
 private:

--- a/src/video_core/macro_interpreter.cpp
+++ b/src/video_core/macro_interpreter.cpp
@@ -29,7 +29,7 @@ void MacroInterpreter::Execute(const std::vector<u32>& code, std::vector<u32> pa
 void MacroInterpreter::Reset() {
     registers = {};
     pc = 0;
-    delayed_pc = boost::none;
+    delayed_pc = {};
     method_address.raw = 0;
     parameters.clear();
     // The next parameter index starts at 1, because $r1 already has the value of the first
@@ -44,10 +44,10 @@ bool MacroInterpreter::Step(const std::vector<u32>& code, bool is_delay_slot) {
     pc += 4;
 
     // Update the program counter if we were delayed
-    if (delayed_pc != boost::none) {
+    if (delayed_pc != std::nullopt) {
         ASSERT(is_delay_slot);
         pc = *delayed_pc;
-        delayed_pc = boost::none;
+        delayed_pc = {};
     }
 
     switch (opcode.operation) {

--- a/src/video_core/macro_interpreter.cpp
+++ b/src/video_core/macro_interpreter.cpp
@@ -44,7 +44,7 @@ bool MacroInterpreter::Step(const std::vector<u32>& code, bool is_delay_slot) {
     pc += 4;
 
     // Update the program counter if we were delayed
-    if (delayed_pc != std::nullopt) {
+    if (delayed_pc) {
         ASSERT(is_delay_slot);
         pc = *delayed_pc;
         delayed_pc = {};

--- a/src/video_core/macro_interpreter.h
+++ b/src/video_core/macro_interpreter.h
@@ -5,8 +5,9 @@
 #pragma once
 
 #include <array>
+#include <optional>
 #include <vector>
-#include <boost/optional.hpp>
+
 #include "common/bit_field.h"
 #include "common/common_types.h"
 
@@ -149,7 +150,7 @@ private:
     Engines::Maxwell3D& maxwell3d;
 
     u32 pc; ///< Current program counter
-    boost::optional<u32>
+    std::optional<u32>
         delayed_pc; ///< Program counter to execute at after the delay slot is executed.
 
     static constexpr std::size_t NumMacroRegisters = 8;

--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -9,7 +9,7 @@
 namespace Tegra {
 
 GPUVAddr MemoryManager::AllocateSpace(u64 size, u64 align) {
-    boost::optional<GPUVAddr> gpu_addr = FindFreeBlock(size, align);
+    std::optional<GPUVAddr> gpu_addr = FindFreeBlock(size, align);
     ASSERT(gpu_addr);
 
     for (u64 offset = 0; offset < size; offset += PAGE_SIZE) {
@@ -34,7 +34,7 @@ GPUVAddr MemoryManager::AllocateSpace(GPUVAddr gpu_addr, u64 size, u64 align) {
 }
 
 GPUVAddr MemoryManager::MapBufferEx(VAddr cpu_addr, u64 size) {
-    boost::optional<GPUVAddr> gpu_addr = FindFreeBlock(size, PAGE_SIZE);
+    std::optional<GPUVAddr> gpu_addr = FindFreeBlock(size, PAGE_SIZE);
     ASSERT(gpu_addr);
 
     for (u64 offset = 0; offset < size; offset += PAGE_SIZE) {
@@ -97,7 +97,7 @@ GPUVAddr MemoryManager::GetRegionEnd(GPUVAddr region_start) const {
     return {};
 }
 
-boost::optional<GPUVAddr> MemoryManager::FindFreeBlock(u64 size, u64 align) {
+std::optional<GPUVAddr> MemoryManager::FindFreeBlock(u64 size, u64 align) {
     GPUVAddr gpu_addr = 0;
     u64 free_space = 0;
     align = (align + PAGE_MASK) & ~PAGE_MASK;
@@ -118,7 +118,7 @@ boost::optional<GPUVAddr> MemoryManager::FindFreeBlock(u64 size, u64 align) {
     return {};
 }
 
-boost::optional<VAddr> MemoryManager::GpuToCpuAddress(GPUVAddr gpu_addr) {
+std::optional<VAddr> MemoryManager::GpuToCpuAddress(GPUVAddr gpu_addr) {
     VAddr base_addr = PageSlot(gpu_addr);
 
     if (base_addr == static_cast<u64>(PageStatus::Allocated) ||

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -6,9 +6,8 @@
 
 #include <array>
 #include <memory>
+#include <optional>
 #include <vector>
-
-#include <boost/optional.hpp>
 
 #include "common/common_types.h"
 
@@ -27,7 +26,7 @@ public:
     GPUVAddr MapBufferEx(VAddr cpu_addr, GPUVAddr gpu_addr, u64 size);
     GPUVAddr UnmapBuffer(GPUVAddr gpu_addr, u64 size);
     GPUVAddr GetRegionEnd(GPUVAddr region_start) const;
-    boost::optional<VAddr> GpuToCpuAddress(GPUVAddr gpu_addr);
+    std::optional<VAddr> GpuToCpuAddress(GPUVAddr gpu_addr);
     std::vector<GPUVAddr> CpuToGpuAddress(VAddr cpu_addr) const;
 
     static constexpr u64 PAGE_BITS = 16;
@@ -35,7 +34,7 @@ public:
     static constexpr u64 PAGE_MASK = PAGE_SIZE - 1;
 
 private:
-    boost::optional<GPUVAddr> FindFreeBlock(u64 size, u64 align = 1);
+    std::optional<GPUVAddr> FindFreeBlock(u64 size, u64 align = 1);
     bool IsPageMapped(GPUVAddr gpu_addr);
     VAddr& PageSlot(GPUVAddr gpu_addr);
 

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -29,7 +29,7 @@ public:
     virtual ~RendererBase();
 
     /// Swap buffers (render frame)
-    virtual void SwapBuffers(std::optional<const Tegra::FramebufferConfig&> framebuffer) = 0;
+    virtual void SwapBuffers(std::optional<const Tegra::FramebufferConfig> framebuffer) = 0;
 
     /// Initialize the renderer
     virtual bool Init() = 0;

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -6,7 +6,8 @@
 
 #include <atomic>
 #include <memory>
-#include <boost/optional.hpp>
+#include <optional>
+
 #include "common/common_types.h"
 #include "video_core/gpu.h"
 #include "video_core/rasterizer_interface.h"
@@ -28,7 +29,7 @@ public:
     virtual ~RendererBase();
 
     /// Swap buffers (render frame)
-    virtual void SwapBuffers(boost::optional<const Tegra::FramebufferConfig&> framebuffer) = 0;
+    virtual void SwapBuffers(std::optional<const Tegra::FramebufferConfig&> framebuffer) = 0;
 
     /// Initialize the renderer
     virtual bool Init() = 0;

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -29,7 +29,8 @@ public:
     virtual ~RendererBase();
 
     /// Swap buffers (render frame)
-    virtual void SwapBuffers(std::optional<const Tegra::FramebufferConfig> framebuffer) = 0;
+    virtual void SwapBuffers(
+        std::optional<std::reference_wrapper<const Tegra::FramebufferConfig>> framebuffer) = 0;
 
     /// Initialize the renderer
     virtual bool Init() = 0;

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -17,7 +17,7 @@ OGLBufferCache::OGLBufferCache(std::size_t size) : stream_buffer(GL_ARRAY_BUFFER
 GLintptr OGLBufferCache::UploadMemory(Tegra::GPUVAddr gpu_addr, std::size_t size,
                                       std::size_t alignment, bool cache) {
     auto& memory_manager = Core::System::GetInstance().GPU().MemoryManager();
-    const boost::optional<VAddr> cpu_addr{memory_manager.GpuToCpuAddress(gpu_addr)};
+    const std::optional<VAddr> cpu_addr{memory_manager.GpuToCpuAddress(gpu_addr)};
 
     // Cache management is a big overhead, so only cache entries with a given size.
     // TODO: Figure out which size is the best for given games.

--- a/src/video_core/renderer_opengl/gl_primitive_assembler.cpp
+++ b/src/video_core/renderer_opengl/gl_primitive_assembler.cpp
@@ -45,7 +45,7 @@ GLintptr PrimitiveAssembler::MakeQuadIndexed(Tegra::GPUVAddr gpu_addr, std::size
     auto [dst_pointer, index_offset] = buffer_cache.ReserveMemory(map_size);
 
     auto& memory_manager = Core::System::GetInstance().GPU().MemoryManager();
-    const boost::optional<VAddr> cpu_addr{memory_manager.GpuToCpuAddress(gpu_addr)};
+    const std::optional<VAddr> cpu_addr{memory_manager.GpuToCpuAddress(gpu_addr)};
     const u8* source{Memory::GetPointer(*cpu_addr)};
 
     for (u32 primitive = 0; primitive < count / 4; ++primitive) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -401,7 +401,7 @@ void RasterizerOpenGL::UpdatePagesCachedCount(VAddr addr, u64 size, int delta) {
 
 void RasterizerOpenGL::ConfigureFramebuffers(bool using_color_fb, bool using_depth_fb,
                                              bool preserve_contents,
-                                             boost::optional<std::size_t> single_color_target) {
+                                             std::optional<std::size_t> single_color_target) {
     MICROPROFILE_SCOPE(OpenGL_Framebuffer);
     const auto& regs = Core::System::GetInstance().GPU().Maxwell3D().regs;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -8,12 +8,12 @@
 #include <cstddef>
 #include <map>
 #include <memory>
+#include <optional>
 #include <tuple>
 #include <utility>
 #include <vector>
 
 #include <boost/icl/interval_map.hpp>
-#include <boost/optional.hpp>
 #include <boost/range/iterator_range.hpp>
 #include <glad/glad.h>
 
@@ -110,7 +110,7 @@ private:
      */
     void ConfigureFramebuffers(bool use_color_fb = true, bool using_depth_fb = true,
                                bool preserve_contents = true,
-                               boost::optional<std::size_t> single_color_target = {});
+                               std::optional<std::size_t> single_color_target = {});
 
     /*
      * Configures the current constbuffers to use for the draw command.

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1600,7 +1600,8 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled arithmetic instruction: {}", opcode.value().get().GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled arithmetic instruction: {}",
+                             opcode.value().get().GetName());
                 UNREACHABLE();
             }
             }
@@ -1663,7 +1664,8 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled BFE instruction: {}", opcode.value().get().GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled BFE instruction: {}",
+                             opcode.value().get().GetName());
                 UNREACHABLE();
             }
             }
@@ -1705,7 +1707,8 @@ private:
                 regs.SetRegisterToInteger(instr.gpr0, true, 0, op_a + " << " + op_b, 1, 1);
                 break;
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled shift instruction: {}", opcode.value().get().GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled shift instruction: {}",
+                             opcode.value().get().GetName());
                 UNREACHABLE();
             }
             }
@@ -1959,7 +1962,8 @@ private:
                     op_b = regs.GetRegisterAsInteger(instr.gpr8);
                     op_a = std::to_string(instr.lea.imm.entry_a);
                     op_c = std::to_string(instr.lea.imm.entry_b);
-                    LOG_CRITICAL(HW_GPU, "Unhandled LEA subinstruction: {}", opcode.value().get().GetName());
+                    LOG_CRITICAL(HW_GPU, "Unhandled LEA subinstruction: {}",
+                                 opcode.value().get().GetName());
                     UNREACHABLE();
                 }
                 }
@@ -1982,7 +1986,8 @@ private:
             break;
         }
         case OpCode::Type::ArithmeticHalf: {
-            if (opcode.value().get().GetId() == OpCode::Id::HADD2_C || opcode.value().get().GetId() == OpCode::Id::HADD2_R) {
+            if (opcode.value().get().GetId() == OpCode::Id::HADD2_C ||
+                opcode.value().get().GetId() == OpCode::Id::HADD2_R) {
                 ASSERT_MSG(instr.alu_half.ftz == 0, "Unimplemented");
             }
             const bool negate_a =
@@ -2021,7 +2026,8 @@ private:
                 case OpCode::Id::HMUL2_R:
                     return '(' + op_a + " * " + op_b + ')';
                 default:
-                    LOG_CRITICAL(HW_GPU, "Unhandled half float instruction: {}", opcode.value().get().GetName());
+                    LOG_CRITICAL(HW_GPU, "Unhandled half float instruction: {}",
+                                 opcode.value().get().GetName());
                     UNREACHABLE();
                     return std::string("0");
                 }
@@ -2096,7 +2102,8 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled FFMA instruction: {}", opcode.value().get().GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled FFMA instruction: {}",
+                             opcode.value().get().GetName());
                 UNREACHABLE();
             }
             }
@@ -2298,7 +2305,8 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled conversion instruction: {}", opcode.value().get().GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled conversion instruction: {}",
+                             opcode.value().get().GetName());
                 UNREACHABLE();
             }
             }
@@ -2949,7 +2957,8 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled memory instruction: {}", opcode.value().get().GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled memory instruction: {}",
+                             opcode.value().get().GetName());
                 UNREACHABLE();
             }
             }
@@ -3151,7 +3160,8 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled predicate instruction: {}", opcode.value().get().GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled predicate instruction: {}",
+                             opcode.value().get().GetName());
                 UNREACHABLE();
             }
             }
@@ -3317,7 +3327,8 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled XMAD instruction: {}", opcode.value().get().GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled XMAD instruction: {}",
+                             opcode.value().get().GetName());
                 UNREACHABLE();
             }
             }

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -144,7 +144,7 @@ private:
         for (u32 offset = begin; offset != end && offset != PROGRAM_END; ++offset) {
             const Instruction instr = {program_code[offset]};
             if (const auto opcode = OpCode::Decode(instr)) {
-                switch (opcode.value().get().GetId()) {
+                switch (opcode->get().GetId()) {
                 case OpCode::Id::EXIT: {
                     // The EXIT instruction can be predicated, which means that the shader can
                     // conditionally end on this instruction. We have to consider the case where the
@@ -1464,8 +1464,8 @@ private:
             return offset + 1;
         }
 
-        shader.AddLine(fmt::format("// {}: {} (0x{:016x})", offset, opcode.value().get().GetName(),
-                                   instr.value));
+        shader.AddLine(
+            fmt::format("// {}: {} (0x{:016x})", offset, opcode->get().GetName(), instr.value));
 
         using Tegra::Shader::Pred;
         ASSERT_MSG(instr.pred.full_pred != Pred::NeverExecute,
@@ -1473,7 +1473,7 @@ private:
 
         // Some instructions (like SSY) don't have a predicate field, they are always
         // unconditionally executed.
-        bool can_be_predicated = OpCode::IsPredicatedInstruction(opcode.value().get().GetId());
+        bool can_be_predicated = OpCode::IsPredicatedInstruction(opcode->get().GetId());
 
         if (can_be_predicated && instr.pred.pred_index != static_cast<u64>(Pred::UnusedIndex)) {
             shader.AddLine("if (" +
@@ -1483,7 +1483,7 @@ private:
             ++shader.scope;
         }
 
-        switch (opcode.value().get().GetType()) {
+        switch (opcode->get().GetType()) {
         case OpCode::Type::Arithmetic: {
             std::string op_a = regs.GetRegisterAsFloat(instr.gpr8);
 
@@ -1500,7 +1500,7 @@ private:
                 }
             }
 
-            switch (opcode.value().get().GetId()) {
+            switch (opcode->get().GetId()) {
             case OpCode::Id::MOV_C:
             case OpCode::Id::MOV_R: {
                 // MOV does not have neither 'abs' nor 'neg' bits.
@@ -1601,14 +1601,14 @@ private:
             }
             default: {
                 LOG_CRITICAL(HW_GPU, "Unhandled arithmetic instruction: {}",
-                             opcode.value().get().GetName());
+                             opcode->get().GetName());
                 UNREACHABLE();
             }
             }
             break;
         }
         case OpCode::Type::ArithmeticImmediate: {
-            switch (opcode.value().get().GetId()) {
+            switch (opcode->get().GetId()) {
             case OpCode::Id::MOV32_IMM: {
                 regs.SetRegisterToFloat(instr.gpr0, 0, GetImmediate32(instr), 1, 1);
                 break;
@@ -1652,7 +1652,7 @@ private:
             std::string op_a = instr.bfe.negate_a ? "-" : "";
             op_a += regs.GetRegisterAsInteger(instr.gpr8);
 
-            switch (opcode.value().get().GetId()) {
+            switch (opcode->get().GetId()) {
             case OpCode::Id::BFE_IMM: {
                 std::string inner_shift =
                     '(' + op_a + " << " + std::to_string(instr.bfe.GetLeftShiftValue()) + ')';
@@ -1664,8 +1664,7 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled BFE instruction: {}",
-                             opcode.value().get().GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled BFE instruction: {}", opcode->get().GetName());
                 UNREACHABLE();
             }
             }
@@ -1687,7 +1686,7 @@ private:
                 }
             }
 
-            switch (opcode.value().get().GetId()) {
+            switch (opcode->get().GetId()) {
             case OpCode::Id::SHR_C:
             case OpCode::Id::SHR_R:
             case OpCode::Id::SHR_IMM: {
@@ -1707,8 +1706,7 @@ private:
                 regs.SetRegisterToInteger(instr.gpr0, true, 0, op_a + " << " + op_b, 1, 1);
                 break;
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled shift instruction: {}",
-                             opcode.value().get().GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled shift instruction: {}", opcode->get().GetName());
                 UNREACHABLE();
             }
             }
@@ -1718,7 +1716,7 @@ private:
             std::string op_a = regs.GetRegisterAsInteger(instr.gpr8);
             std::string op_b = std::to_string(instr.alu.imm20_32.Value());
 
-            switch (opcode.value().get().GetId()) {
+            switch (opcode->get().GetId()) {
             case OpCode::Id::IADD32I:
                 if (instr.iadd32i.negate_a)
                     op_a = "-(" + op_a + ')';
@@ -1740,7 +1738,7 @@ private:
             }
             default: {
                 LOG_CRITICAL(HW_GPU, "Unhandled ArithmeticIntegerImmediate instruction: {}",
-                             opcode.value().get().GetName());
+                             opcode->get().GetName());
                 UNREACHABLE();
             }
             }
@@ -1760,7 +1758,7 @@ private:
                 }
             }
 
-            switch (opcode.value().get().GetId()) {
+            switch (opcode->get().GetId()) {
             case OpCode::Id::IADD_C:
             case OpCode::Id::IADD_R:
             case OpCode::Id::IADD_IMM: {
@@ -1796,7 +1794,7 @@ private:
                     }
                 };
 
-                if (opcode.value().get().GetId() == OpCode::Id::IADD3_R) {
+                if (opcode->get().GetId() == OpCode::Id::IADD3_R) {
                     apply_height(instr.iadd3.height_a, op_a);
                     apply_height(instr.iadd3.height_b, op_b);
                     apply_height(instr.iadd3.height_c, op_c);
@@ -1812,7 +1810,7 @@ private:
                     op_c = "-(" + op_c + ')';
 
                 std::string result;
-                if (opcode.value().get().GetId() == OpCode::Id::IADD3_R) {
+                if (opcode->get().GetId() == OpCode::Id::IADD3_R) {
                     switch (instr.iadd3.mode) {
                     case Tegra::Shader::IAdd3Mode::RightShift:
                         // TODO(tech4me): According to
@@ -1887,7 +1885,7 @@ private:
                 const std::string op_c = regs.GetRegisterAsInteger(instr.gpr39);
                 std::string lut;
 
-                if (opcode.value().get().GetId() == OpCode::Id::LOP3_R) {
+                if (opcode->get().GetId() == OpCode::Id::LOP3_R) {
                     lut = '(' + std::to_string(instr.alu.lop3.GetImmLut28()) + ')';
                 } else {
                     lut = '(' + std::to_string(instr.alu.lop3.GetImmLut48()) + ')';
@@ -1917,7 +1915,7 @@ private:
             case OpCode::Id::LEA_HI: {
                 std::string op_c;
 
-                switch (opcode.value().get().GetId()) {
+                switch (opcode->get().GetId()) {
                 case OpCode::Id::LEA_R2: {
                     op_a = regs.GetRegisterAsInteger(instr.gpr20);
                     op_b = regs.GetRegisterAsInteger(instr.gpr39);
@@ -1963,7 +1961,7 @@ private:
                     op_a = std::to_string(instr.lea.imm.entry_a);
                     op_c = std::to_string(instr.lea.imm.entry_b);
                     LOG_CRITICAL(HW_GPU, "Unhandled LEA subinstruction: {}",
-                                 opcode.value().get().GetName());
+                                 opcode->get().GetName());
                     UNREACHABLE();
                 }
                 }
@@ -1978,7 +1976,7 @@ private:
             }
             default: {
                 LOG_CRITICAL(HW_GPU, "Unhandled ArithmeticInteger instruction: {}",
-                             opcode.value().get().GetName());
+                             opcode->get().GetName());
                 UNREACHABLE();
             }
             }
@@ -1986,21 +1984,21 @@ private:
             break;
         }
         case OpCode::Type::ArithmeticHalf: {
-            if (opcode.value().get().GetId() == OpCode::Id::HADD2_C ||
-                opcode.value().get().GetId() == OpCode::Id::HADD2_R) {
+            if (opcode->get().GetId() == OpCode::Id::HADD2_C ||
+                opcode->get().GetId() == OpCode::Id::HADD2_R) {
                 ASSERT_MSG(instr.alu_half.ftz == 0, "Unimplemented");
             }
             const bool negate_a =
-                opcode.value().get().GetId() != OpCode::Id::HMUL2_R && instr.alu_half.negate_a != 0;
+                opcode->get().GetId() != OpCode::Id::HMUL2_R && instr.alu_half.negate_a != 0;
             const bool negate_b =
-                opcode.value().get().GetId() != OpCode::Id::HMUL2_C && instr.alu_half.negate_b != 0;
+                opcode->get().GetId() != OpCode::Id::HMUL2_C && instr.alu_half.negate_b != 0;
 
             const std::string op_a =
                 GetHalfFloat(regs.GetRegisterAsInteger(instr.gpr8, 0, false), instr.alu_half.type_a,
                              instr.alu_half.abs_a != 0, negate_a);
 
             std::string op_b;
-            switch (opcode.value().get().GetId()) {
+            switch (opcode->get().GetId()) {
             case OpCode::Id::HADD2_C:
             case OpCode::Id::HMUL2_C:
                 op_b = regs.GetUniform(instr.cbuf34.index, instr.cbuf34.offset,
@@ -2018,7 +2016,7 @@ private:
             op_b = GetHalfFloat(op_b, instr.alu_half.type_b, instr.alu_half.abs_b != 0, negate_b);
 
             const std::string result = [&]() {
-                switch (opcode.value().get().GetId()) {
+                switch (opcode->get().GetId()) {
                 case OpCode::Id::HADD2_C:
                 case OpCode::Id::HADD2_R:
                     return '(' + op_a + " + " + op_b + ')';
@@ -2027,7 +2025,7 @@ private:
                     return '(' + op_a + " * " + op_b + ')';
                 default:
                     LOG_CRITICAL(HW_GPU, "Unhandled half float instruction: {}",
-                                 opcode.value().get().GetName());
+                                 opcode->get().GetName());
                     UNREACHABLE();
                     return std::string("0");
                 }
@@ -2038,7 +2036,7 @@ private:
             break;
         }
         case OpCode::Type::ArithmeticHalfImmediate: {
-            if (opcode.value().get().GetId() == OpCode::Id::HADD2_IMM) {
+            if (opcode->get().GetId() == OpCode::Id::HADD2_IMM) {
                 ASSERT_MSG(instr.alu_half_imm.ftz == 0, "Unimplemented");
             } else {
                 ASSERT_MSG(instr.alu_half_imm.precision == Tegra::Shader::HalfPrecision::None,
@@ -2052,7 +2050,7 @@ private:
             const std::string op_b = UnpackHalfImmediate(instr, true);
 
             const std::string result = [&]() {
-                switch (opcode.value().get().GetId()) {
+                switch (opcode->get().GetId()) {
                 case OpCode::Id::HADD2_IMM:
                     return op_a + " + " + op_b;
                 case OpCode::Id::HMUL2_IMM:
@@ -2078,7 +2076,7 @@ private:
             ASSERT_MSG(instr.ffma.tab5980_1 == 0, "FFMA tab5980_1({}) not implemented",
                        instr.ffma.tab5980_1.Value());
 
-            switch (opcode.value().get().GetId()) {
+            switch (opcode->get().GetId()) {
             case OpCode::Id::FFMA_CR: {
                 op_b += regs.GetUniform(instr.cbuf34.index, instr.cbuf34.offset,
                                         GLSLRegister::Type::Float);
@@ -2102,8 +2100,7 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled FFMA instruction: {}",
-                             opcode.value().get().GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled FFMA instruction: {}", opcode->get().GetName());
                 UNREACHABLE();
             }
             }
@@ -2114,14 +2111,14 @@ private:
             break;
         }
         case OpCode::Type::Hfma2: {
-            if (opcode.value().get().GetId() == OpCode::Id::HFMA2_RR) {
+            if (opcode->get().GetId() == OpCode::Id::HFMA2_RR) {
                 ASSERT_MSG(instr.hfma2.rr.precision == Tegra::Shader::HalfPrecision::None,
                            "Unimplemented");
             } else {
                 ASSERT_MSG(instr.hfma2.precision == Tegra::Shader::HalfPrecision::None,
                            "Unimplemented");
             }
-            const bool saturate = opcode.value().get().GetId() == OpCode::Id::HFMA2_RR
+            const bool saturate = opcode->get().GetId() == OpCode::Id::HFMA2_RR
                                       ? instr.hfma2.rr.saturate != 0
                                       : instr.hfma2.saturate != 0;
 
@@ -2129,7 +2126,7 @@ private:
                 GetHalfFloat(regs.GetRegisterAsInteger(instr.gpr8, 0, false), instr.hfma2.type_a);
             std::string op_b, op_c;
 
-            switch (opcode.value().get().GetId()) {
+            switch (opcode->get().GetId()) {
             case OpCode::Id::HFMA2_CR:
                 op_b = GetHalfFloat(regs.GetUniform(instr.cbuf34.index, instr.cbuf34.offset,
                                                     GLSLRegister::Type::UnsignedInteger),
@@ -2167,7 +2164,7 @@ private:
             break;
         }
         case OpCode::Type::Conversion: {
-            switch (opcode.value().get().GetId()) {
+            switch (opcode->get().GetId()) {
             case OpCode::Id::I2I_R: {
                 ASSERT_MSG(!instr.conversion.selector, "Unimplemented");
 
@@ -2306,14 +2303,14 @@ private:
             }
             default: {
                 LOG_CRITICAL(HW_GPU, "Unhandled conversion instruction: {}",
-                             opcode.value().get().GetName());
+                             opcode->get().GetName());
                 UNREACHABLE();
             }
             }
             break;
         }
         case OpCode::Type::Memory: {
-            switch (opcode.value().get().GetId()) {
+            switch (opcode->get().GetId()) {
             case OpCode::Id::LD_A: {
                 // Note: Shouldn't this be interp mode flat? As in no interpolation made.
                 ASSERT_MSG(instr.gpr8.Value() == Register::ZeroIndex,
@@ -2957,8 +2954,7 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled memory instruction: {}",
-                             opcode.value().get().GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled memory instruction: {}", opcode->get().GetName());
                 UNREACHABLE();
             }
             }
@@ -3052,7 +3048,7 @@ private:
                              instr.hsetp2.abs_a, instr.hsetp2.negate_a);
 
             const std::string op_b = [&]() {
-                switch (opcode.value().get().GetId()) {
+                switch (opcode->get().GetId()) {
                 case OpCode::Id::HSETP2_R:
                     return GetHalfFloat(regs.GetRegisterAsInteger(instr.gpr20, 0, false),
                                         instr.hsetp2.type_b, instr.hsetp2.abs_a,
@@ -3114,7 +3110,7 @@ private:
             break;
         }
         case OpCode::Type::PredicateSetPredicate: {
-            switch (opcode.value().get().GetId()) {
+            switch (opcode->get().GetId()) {
             case OpCode::Id::PSETP: {
                 const std::string op_a =
                     GetPredicateCondition(instr.psetp.pred12, instr.psetp.neg_pred12 != 0);
@@ -3161,7 +3157,7 @@ private:
             }
             default: {
                 LOG_CRITICAL(HW_GPU, "Unhandled predicate instruction: {}",
-                             opcode.value().get().GetName());
+                             opcode->get().GetName());
                 UNREACHABLE();
             }
             }
@@ -3249,7 +3245,7 @@ private:
                              instr.hset2.abs_a != 0, instr.hset2.negate_a != 0);
 
             const std::string op_b = [&]() {
-                switch (opcode.value().get().GetId()) {
+                switch (opcode->get().GetId()) {
                 case OpCode::Id::HSET2_R:
                     return GetHalfFloat(regs.GetRegisterAsInteger(instr.gpr20, 0, false),
                                         instr.hset2.type_b, instr.hset2.abs_b != 0,
@@ -3298,7 +3294,7 @@ private:
             const bool is_signed{instr.xmad.sign_a == 1};
 
             bool is_merge{};
-            switch (opcode.value().get().GetId()) {
+            switch (opcode->get().GetId()) {
             case OpCode::Id::XMAD_CR: {
                 is_merge = instr.xmad.merge_56;
                 op_b += regs.GetUniform(instr.cbuf34.index, instr.cbuf34.offset,
@@ -3327,8 +3323,7 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled XMAD instruction: {}",
-                             opcode.value().get().GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled XMAD instruction: {}", opcode->get().GetName());
                 UNREACHABLE();
             }
             }
@@ -3380,7 +3375,7 @@ private:
             break;
         }
         default: {
-            switch (opcode.value().get().GetId()) {
+            switch (opcode->get().GetId()) {
             case OpCode::Id::EXIT: {
                 if (stage == Maxwell3D::Regs::ShaderStage::Fragment) {
                     EmitFragmentOutputsWrite();
@@ -3575,7 +3570,7 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled instruction: {}", opcode.value().get().GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled instruction: {}", opcode->get().GetName());
                 UNREACHABLE();
             }
             }

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -810,7 +810,7 @@ private:
                                   std::optional<Register> vertex = {}) {
         auto GeometryPass = [&](const std::string& name) {
             if (stage == Maxwell3D::Regs::ShaderStage::Geometry && vertex) {
-                return "gs_" + name + '[' + GetRegisterAsInteger(vertex.value(), 0, false) + ']';
+                return "gs_" + name + '[' + GetRegisterAsInteger(*vertex, 0, false) + ']';
             }
             return name;
         };

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -3,12 +3,12 @@
 // Refer to the license.txt file included.
 
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 #include <string_view>
 #include <unordered_set>
 
-#include <boost/optional.hpp>
 #include <fmt/format.h>
 
 #include "common/assert.h"
@@ -144,7 +144,7 @@ private:
         for (u32 offset = begin; offset != end && offset != PROGRAM_END; ++offset) {
             const Instruction instr = {program_code[offset]};
             if (const auto opcode = OpCode::Decode(instr)) {
-                switch (opcode->GetId()) {
+                switch (opcode.value().GetId()) {
                 case OpCode::Id::EXIT: {
                     // The EXIT instruction can be predicated, which means that the shader can
                     // conditionally end on this instruction. We have to consider the case where the
@@ -430,7 +430,7 @@ public:
      */
     void SetRegisterToInputAttibute(const Register& reg, u64 elem, Attribute::Index attribute,
                                     const Tegra::Shader::IpaMode& input_mode,
-                                    boost::optional<Register> vertex = {}) {
+                                    std::optional<Register> vertex = {}) {
         const std::string dest = GetRegisterAsFloat(reg);
         const std::string src = GetInputAttribute(attribute, input_mode, vertex) + GetSwizzle(elem);
         shader.AddLine(dest + " = " + src + ';');
@@ -807,7 +807,7 @@ private:
     /// Generates code representing an input attribute register.
     std::string GetInputAttribute(Attribute::Index attribute,
                                   const Tegra::Shader::IpaMode& input_mode,
-                                  boost::optional<Register> vertex = {}) {
+                                  std::optional<Register> vertex = {}) {
         auto GeometryPass = [&](const std::string& name) {
             if (stage == Maxwell3D::Regs::ShaderStage::Geometry && vertex) {
                 return "gs_" + name + '[' + GetRegisterAsInteger(vertex.value(), 0, false) + ']';
@@ -1465,7 +1465,7 @@ private:
         }
 
         shader.AddLine(
-            fmt::format("// {}: {} (0x{:016x})", offset, opcode->GetName(), instr.value));
+            fmt::format("// {}: {} (0x{:016x})", offset, opcode.value().GetName(), instr.value));
 
         using Tegra::Shader::Pred;
         ASSERT_MSG(instr.pred.full_pred != Pred::NeverExecute,
@@ -1473,7 +1473,7 @@ private:
 
         // Some instructions (like SSY) don't have a predicate field, they are always
         // unconditionally executed.
-        bool can_be_predicated = OpCode::IsPredicatedInstruction(opcode->GetId());
+        bool can_be_predicated = OpCode::IsPredicatedInstruction(opcode.value().GetId());
 
         if (can_be_predicated && instr.pred.pred_index != static_cast<u64>(Pred::UnusedIndex)) {
             shader.AddLine("if (" +
@@ -1483,7 +1483,7 @@ private:
             ++shader.scope;
         }
 
-        switch (opcode->GetType()) {
+        switch (opcode.value().GetType()) {
         case OpCode::Type::Arithmetic: {
             std::string op_a = regs.GetRegisterAsFloat(instr.gpr8);
 
@@ -1500,7 +1500,7 @@ private:
                 }
             }
 
-            switch (opcode->GetId()) {
+            switch (opcode.value().GetId()) {
             case OpCode::Id::MOV_C:
             case OpCode::Id::MOV_R: {
                 // MOV does not have neither 'abs' nor 'neg' bits.
@@ -1600,14 +1600,14 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled arithmetic instruction: {}", opcode->GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled arithmetic instruction: {}", opcode.value().GetName());
                 UNREACHABLE();
             }
             }
             break;
         }
         case OpCode::Type::ArithmeticImmediate: {
-            switch (opcode->GetId()) {
+            switch (opcode.value().GetId()) {
             case OpCode::Id::MOV32_IMM: {
                 regs.SetRegisterToFloat(instr.gpr0, 0, GetImmediate32(instr), 1, 1);
                 break;
@@ -1651,7 +1651,7 @@ private:
             std::string op_a = instr.bfe.negate_a ? "-" : "";
             op_a += regs.GetRegisterAsInteger(instr.gpr8);
 
-            switch (opcode->GetId()) {
+            switch (opcode.value().GetId()) {
             case OpCode::Id::BFE_IMM: {
                 std::string inner_shift =
                     '(' + op_a + " << " + std::to_string(instr.bfe.GetLeftShiftValue()) + ')';
@@ -1663,7 +1663,7 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled BFE instruction: {}", opcode->GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled BFE instruction: {}", opcode.value().GetName());
                 UNREACHABLE();
             }
             }
@@ -1685,7 +1685,7 @@ private:
                 }
             }
 
-            switch (opcode->GetId()) {
+            switch (opcode.value().GetId()) {
             case OpCode::Id::SHR_C:
             case OpCode::Id::SHR_R:
             case OpCode::Id::SHR_IMM: {
@@ -1705,7 +1705,7 @@ private:
                 regs.SetRegisterToInteger(instr.gpr0, true, 0, op_a + " << " + op_b, 1, 1);
                 break;
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled shift instruction: {}", opcode->GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled shift instruction: {}", opcode.value().GetName());
                 UNREACHABLE();
             }
             }
@@ -1715,7 +1715,7 @@ private:
             std::string op_a = regs.GetRegisterAsInteger(instr.gpr8);
             std::string op_b = std::to_string(instr.alu.imm20_32.Value());
 
-            switch (opcode->GetId()) {
+            switch (opcode.value().GetId()) {
             case OpCode::Id::IADD32I:
                 if (instr.iadd32i.negate_a)
                     op_a = "-(" + op_a + ')';
@@ -1737,7 +1737,7 @@ private:
             }
             default: {
                 LOG_CRITICAL(HW_GPU, "Unhandled ArithmeticIntegerImmediate instruction: {}",
-                             opcode->GetName());
+                             opcode.value().GetName());
                 UNREACHABLE();
             }
             }
@@ -1757,7 +1757,7 @@ private:
                 }
             }
 
-            switch (opcode->GetId()) {
+            switch (opcode.value().GetId()) {
             case OpCode::Id::IADD_C:
             case OpCode::Id::IADD_R:
             case OpCode::Id::IADD_IMM: {
@@ -1793,7 +1793,7 @@ private:
                     }
                 };
 
-                if (opcode->GetId() == OpCode::Id::IADD3_R) {
+                if (opcode.value().GetId() == OpCode::Id::IADD3_R) {
                     apply_height(instr.iadd3.height_a, op_a);
                     apply_height(instr.iadd3.height_b, op_b);
                     apply_height(instr.iadd3.height_c, op_c);
@@ -1809,7 +1809,7 @@ private:
                     op_c = "-(" + op_c + ')';
 
                 std::string result;
-                if (opcode->GetId() == OpCode::Id::IADD3_R) {
+                if (opcode.value().GetId() == OpCode::Id::IADD3_R) {
                     switch (instr.iadd3.mode) {
                     case Tegra::Shader::IAdd3Mode::RightShift:
                         // TODO(tech4me): According to
@@ -1884,7 +1884,7 @@ private:
                 const std::string op_c = regs.GetRegisterAsInteger(instr.gpr39);
                 std::string lut;
 
-                if (opcode->GetId() == OpCode::Id::LOP3_R) {
+                if (opcode.value().GetId() == OpCode::Id::LOP3_R) {
                     lut = '(' + std::to_string(instr.alu.lop3.GetImmLut28()) + ')';
                 } else {
                     lut = '(' + std::to_string(instr.alu.lop3.GetImmLut48()) + ')';
@@ -1914,7 +1914,7 @@ private:
             case OpCode::Id::LEA_HI: {
                 std::string op_c;
 
-                switch (opcode->GetId()) {
+                switch (opcode.value().GetId()) {
                 case OpCode::Id::LEA_R2: {
                     op_a = regs.GetRegisterAsInteger(instr.gpr20);
                     op_b = regs.GetRegisterAsInteger(instr.gpr39);
@@ -1959,7 +1959,7 @@ private:
                     op_b = regs.GetRegisterAsInteger(instr.gpr8);
                     op_a = std::to_string(instr.lea.imm.entry_a);
                     op_c = std::to_string(instr.lea.imm.entry_b);
-                    LOG_CRITICAL(HW_GPU, "Unhandled LEA subinstruction: {}", opcode->GetName());
+                    LOG_CRITICAL(HW_GPU, "Unhandled LEA subinstruction: {}", opcode.value().GetName());
                     UNREACHABLE();
                 }
                 }
@@ -1974,7 +1974,7 @@ private:
             }
             default: {
                 LOG_CRITICAL(HW_GPU, "Unhandled ArithmeticInteger instruction: {}",
-                             opcode->GetName());
+                             opcode.value().GetName());
                 UNREACHABLE();
             }
             }
@@ -1982,20 +1982,20 @@ private:
             break;
         }
         case OpCode::Type::ArithmeticHalf: {
-            if (opcode->GetId() == OpCode::Id::HADD2_C || opcode->GetId() == OpCode::Id::HADD2_R) {
+            if (opcode.value().GetId() == OpCode::Id::HADD2_C || opcode.value().GetId() == OpCode::Id::HADD2_R) {
                 ASSERT_MSG(instr.alu_half.ftz == 0, "Unimplemented");
             }
             const bool negate_a =
-                opcode->GetId() != OpCode::Id::HMUL2_R && instr.alu_half.negate_a != 0;
+                opcode.value().GetId() != OpCode::Id::HMUL2_R && instr.alu_half.negate_a != 0;
             const bool negate_b =
-                opcode->GetId() != OpCode::Id::HMUL2_C && instr.alu_half.negate_b != 0;
+                opcode.value().GetId() != OpCode::Id::HMUL2_C && instr.alu_half.negate_b != 0;
 
             const std::string op_a =
                 GetHalfFloat(regs.GetRegisterAsInteger(instr.gpr8, 0, false), instr.alu_half.type_a,
                              instr.alu_half.abs_a != 0, negate_a);
 
             std::string op_b;
-            switch (opcode->GetId()) {
+            switch (opcode.value().GetId()) {
             case OpCode::Id::HADD2_C:
             case OpCode::Id::HMUL2_C:
                 op_b = regs.GetUniform(instr.cbuf34.index, instr.cbuf34.offset,
@@ -2013,7 +2013,7 @@ private:
             op_b = GetHalfFloat(op_b, instr.alu_half.type_b, instr.alu_half.abs_b != 0, negate_b);
 
             const std::string result = [&]() {
-                switch (opcode->GetId()) {
+                switch (opcode.value().GetId()) {
                 case OpCode::Id::HADD2_C:
                 case OpCode::Id::HADD2_R:
                     return '(' + op_a + " + " + op_b + ')';
@@ -2021,7 +2021,7 @@ private:
                 case OpCode::Id::HMUL2_R:
                     return '(' + op_a + " * " + op_b + ')';
                 default:
-                    LOG_CRITICAL(HW_GPU, "Unhandled half float instruction: {}", opcode->GetName());
+                    LOG_CRITICAL(HW_GPU, "Unhandled half float instruction: {}", opcode.value().GetName());
                     UNREACHABLE();
                     return std::string("0");
                 }
@@ -2032,7 +2032,7 @@ private:
             break;
         }
         case OpCode::Type::ArithmeticHalfImmediate: {
-            if (opcode->GetId() == OpCode::Id::HADD2_IMM) {
+            if (opcode.value().GetId() == OpCode::Id::HADD2_IMM) {
                 ASSERT_MSG(instr.alu_half_imm.ftz == 0, "Unimplemented");
             } else {
                 ASSERT_MSG(instr.alu_half_imm.precision == Tegra::Shader::HalfPrecision::None,
@@ -2046,7 +2046,7 @@ private:
             const std::string op_b = UnpackHalfImmediate(instr, true);
 
             const std::string result = [&]() {
-                switch (opcode->GetId()) {
+                switch (opcode.value().GetId()) {
                 case OpCode::Id::HADD2_IMM:
                     return op_a + " + " + op_b;
                 case OpCode::Id::HMUL2_IMM:
@@ -2072,7 +2072,7 @@ private:
             ASSERT_MSG(instr.ffma.tab5980_1 == 0, "FFMA tab5980_1({}) not implemented",
                        instr.ffma.tab5980_1.Value());
 
-            switch (opcode->GetId()) {
+            switch (opcode.value().GetId()) {
             case OpCode::Id::FFMA_CR: {
                 op_b += regs.GetUniform(instr.cbuf34.index, instr.cbuf34.offset,
                                         GLSLRegister::Type::Float);
@@ -2096,7 +2096,7 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled FFMA instruction: {}", opcode->GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled FFMA instruction: {}", opcode.value().GetName());
                 UNREACHABLE();
             }
             }
@@ -2107,14 +2107,14 @@ private:
             break;
         }
         case OpCode::Type::Hfma2: {
-            if (opcode->GetId() == OpCode::Id::HFMA2_RR) {
+            if (opcode.value().GetId() == OpCode::Id::HFMA2_RR) {
                 ASSERT_MSG(instr.hfma2.rr.precision == Tegra::Shader::HalfPrecision::None,
                            "Unimplemented");
             } else {
                 ASSERT_MSG(instr.hfma2.precision == Tegra::Shader::HalfPrecision::None,
                            "Unimplemented");
             }
-            const bool saturate = opcode->GetId() == OpCode::Id::HFMA2_RR
+            const bool saturate = opcode.value().GetId() == OpCode::Id::HFMA2_RR
                                       ? instr.hfma2.rr.saturate != 0
                                       : instr.hfma2.saturate != 0;
 
@@ -2122,7 +2122,7 @@ private:
                 GetHalfFloat(regs.GetRegisterAsInteger(instr.gpr8, 0, false), instr.hfma2.type_a);
             std::string op_b, op_c;
 
-            switch (opcode->GetId()) {
+            switch (opcode.value().GetId()) {
             case OpCode::Id::HFMA2_CR:
                 op_b = GetHalfFloat(regs.GetUniform(instr.cbuf34.index, instr.cbuf34.offset,
                                                     GLSLRegister::Type::UnsignedInteger),
@@ -2160,7 +2160,7 @@ private:
             break;
         }
         case OpCode::Type::Conversion: {
-            switch (opcode->GetId()) {
+            switch (opcode.value().GetId()) {
             case OpCode::Id::I2I_R: {
                 ASSERT_MSG(!instr.conversion.selector, "Unimplemented");
 
@@ -2298,14 +2298,14 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled conversion instruction: {}", opcode->GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled conversion instruction: {}", opcode.value().GetName());
                 UNREACHABLE();
             }
             }
             break;
         }
         case OpCode::Type::Memory: {
-            switch (opcode->GetId()) {
+            switch (opcode.value().GetId()) {
             case OpCode::Id::LD_A: {
                 // Note: Shouldn't this be interp mode flat? As in no interpolation made.
                 ASSERT_MSG(instr.gpr8.Value() == Register::ZeroIndex,
@@ -2949,7 +2949,7 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled memory instruction: {}", opcode->GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled memory instruction: {}", opcode.value().GetName());
                 UNREACHABLE();
             }
             }
@@ -3043,7 +3043,7 @@ private:
                              instr.hsetp2.abs_a, instr.hsetp2.negate_a);
 
             const std::string op_b = [&]() {
-                switch (opcode->GetId()) {
+                switch (opcode.value().GetId()) {
                 case OpCode::Id::HSETP2_R:
                     return GetHalfFloat(regs.GetRegisterAsInteger(instr.gpr20, 0, false),
                                         instr.hsetp2.type_b, instr.hsetp2.abs_a,
@@ -3105,7 +3105,7 @@ private:
             break;
         }
         case OpCode::Type::PredicateSetPredicate: {
-            switch (opcode->GetId()) {
+            switch (opcode.value().GetId()) {
             case OpCode::Id::PSETP: {
                 const std::string op_a =
                     GetPredicateCondition(instr.psetp.pred12, instr.psetp.neg_pred12 != 0);
@@ -3151,7 +3151,7 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled predicate instruction: {}", opcode->GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled predicate instruction: {}", opcode.value().GetName());
                 UNREACHABLE();
             }
             }
@@ -3239,7 +3239,7 @@ private:
                              instr.hset2.abs_a != 0, instr.hset2.negate_a != 0);
 
             const std::string op_b = [&]() {
-                switch (opcode->GetId()) {
+                switch (opcode.value().GetId()) {
                 case OpCode::Id::HSET2_R:
                     return GetHalfFloat(regs.GetRegisterAsInteger(instr.gpr20, 0, false),
                                         instr.hset2.type_b, instr.hset2.abs_b != 0,
@@ -3288,7 +3288,7 @@ private:
             const bool is_signed{instr.xmad.sign_a == 1};
 
             bool is_merge{};
-            switch (opcode->GetId()) {
+            switch (opcode.value().GetId()) {
             case OpCode::Id::XMAD_CR: {
                 is_merge = instr.xmad.merge_56;
                 op_b += regs.GetUniform(instr.cbuf34.index, instr.cbuf34.offset,
@@ -3317,7 +3317,7 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled XMAD instruction: {}", opcode->GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled XMAD instruction: {}", opcode.value().GetName());
                 UNREACHABLE();
             }
             }
@@ -3369,7 +3369,7 @@ private:
             break;
         }
         default: {
-            switch (opcode->GetId()) {
+            switch (opcode.value().GetId()) {
             case OpCode::Id::EXIT: {
                 if (stage == Maxwell3D::Regs::ShaderStage::Fragment) {
                     EmitFragmentOutputsWrite();
@@ -3564,7 +3564,7 @@ private:
                 break;
             }
             default: {
-                LOG_CRITICAL(HW_GPU, "Unhandled instruction: {}", opcode->GetName());
+                LOG_CRITICAL(HW_GPU, "Unhandled instruction: {}", opcode.value().GetName());
                 UNREACHABLE();
             }
             }
@@ -3705,9 +3705,9 @@ std::string GetCommonDeclarations() {
                        RasterizerOpenGL::MaxConstbufferSize / sizeof(GLvec4));
 }
 
-boost::optional<ProgramResult> DecompileProgram(const ProgramCode& program_code, u32 main_offset,
-                                                Maxwell3D::Regs::ShaderStage stage,
-                                                const std::string& suffix) {
+std::optional<ProgramResult> DecompileProgram(const ProgramCode& program_code, u32 main_offset,
+                                              Maxwell3D::Regs::ShaderStage stage,
+                                              const std::string& suffix) {
     try {
         const auto subroutines =
             ControlFlowAnalyzer(program_code, main_offset, suffix).GetSubroutines();
@@ -3716,7 +3716,7 @@ boost::optional<ProgramResult> DecompileProgram(const ProgramCode& program_code,
     } catch (const DecompileFail& exception) {
         LOG_ERROR(HW_GPU, "Shader decompilation failed: {}", exception.what());
     }
-    return boost::none;
+    return {};
 }
 
 } // namespace OpenGL::GLShader::Decompiler

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.h
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.h
@@ -6,8 +6,8 @@
 
 #include <array>
 #include <functional>
+#include <optional>
 #include <string>
-#include <boost/optional.hpp>
 #include "common/common_types.h"
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/renderer_opengl/gl_shader_gen.h"
@@ -18,8 +18,8 @@ using Tegra::Engines::Maxwell3D;
 
 std::string GetCommonDeclarations();
 
-boost::optional<ProgramResult> DecompileProgram(const ProgramCode& program_code, u32 main_offset,
-                                                Maxwell3D::Regs::ShaderStage stage,
-                                                const std::string& suffix);
+std::optional<ProgramResult> DecompileProgram(const ProgramCode& program_code, u32 main_offset,
+                                              Maxwell3D::Regs::ShaderStage stage,
+                                              const std::string& suffix);
 
 } // namespace OpenGL::GLShader::Decompiler

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -37,7 +37,7 @@ layout(std140) uniform vs_config {
     ProgramResult program =
         Decompiler::DecompileProgram(setup.program.code, PROGRAM_OFFSET,
                                      Maxwell3D::Regs::ShaderStage::Vertex, "vertex")
-            .get_value_or({});
+            .value_or(std::nullopt);
 
     out += program.first;
 
@@ -45,7 +45,7 @@ layout(std140) uniform vs_config {
         ProgramResult program_b =
             Decompiler::DecompileProgram(setup.program.code_b, PROGRAM_OFFSET,
                                          Maxwell3D::Regs::ShaderStage::Vertex, "vertex_b")
-                .get_value_or({});
+                .value_or(std::nullopt);
         out += program_b.first;
     }
 
@@ -90,7 +90,7 @@ ProgramResult GenerateGeometryShader(const ShaderSetup& setup) {
     ProgramResult program =
         Decompiler::DecompileProgram(setup.program.code, PROGRAM_OFFSET,
                                      Maxwell3D::Regs::ShaderStage::Geometry, "geometry")
-            .get_value_or({});
+            .value_or(std::nullopt);
     out += R"(
 out gl_PerVertex {
     vec4 gl_Position;
@@ -124,7 +124,7 @@ ProgramResult GenerateFragmentShader(const ShaderSetup& setup) {
     ProgramResult program =
         Decompiler::DecompileProgram(setup.program.code, PROGRAM_OFFSET,
                                      Maxwell3D::Regs::ShaderStage::Fragment, "fragment")
-            .get_value_or({});
+            .value_or(std::nullopt);
     out += R"(
 layout(location = 0) out vec4 FragColor0;
 layout(location = 1) out vec4 FragColor1;

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -37,7 +37,7 @@ layout(std140) uniform vs_config {
     ProgramResult program =
         Decompiler::DecompileProgram(setup.program.code, PROGRAM_OFFSET,
                                      Maxwell3D::Regs::ShaderStage::Vertex, "vertex")
-            .value_or(std::nullopt);
+            .value_or(ProgramResult());
 
     out += program.first;
 
@@ -45,7 +45,7 @@ layout(std140) uniform vs_config {
         ProgramResult program_b =
             Decompiler::DecompileProgram(setup.program.code_b, PROGRAM_OFFSET,
                                          Maxwell3D::Regs::ShaderStage::Vertex, "vertex_b")
-                .value_or(std::nullopt);
+                .value_or(ProgramResult());
         out += program_b.first;
     }
 
@@ -90,7 +90,7 @@ ProgramResult GenerateGeometryShader(const ShaderSetup& setup) {
     ProgramResult program =
         Decompiler::DecompileProgram(setup.program.code, PROGRAM_OFFSET,
                                      Maxwell3D::Regs::ShaderStage::Geometry, "geometry")
-            .value_or(std::nullopt);
+            .value_or(ProgramResult());
     out += R"(
 out gl_PerVertex {
     vec4 gl_Position;
@@ -124,7 +124,7 @@ ProgramResult GenerateFragmentShader(const ShaderSetup& setup) {
     ProgramResult program =
         Decompiler::DecompileProgram(setup.program.code, PROGRAM_OFFSET,
                                      Maxwell3D::Regs::ShaderStage::Fragment, "fragment")
-            .value_or(std::nullopt);
+            .value_or(ProgramResult());
     out += R"(
 layout(location = 0) out vec4 FragColor0;
 layout(location = 1) out vec4 FragColor1;

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -115,7 +115,7 @@ RendererOpenGL::RendererOpenGL(Core::Frontend::EmuWindow& window)
 RendererOpenGL::~RendererOpenGL() = default;
 
 /// Swap buffers (render frame)
-void RendererOpenGL::SwapBuffers(boost::optional<const Tegra::FramebufferConfig&> framebuffer) {
+void RendererOpenGL::SwapBuffers(std::optional<const Tegra::FramebufferConfig&> framebuffer) {
     ScopeAcquireGLContext acquire_context{render_window};
 
     Core::System::GetInstance().GetPerfStats().EndSystemFrame();
@@ -124,11 +124,11 @@ void RendererOpenGL::SwapBuffers(boost::optional<const Tegra::FramebufferConfig&
     OpenGLState prev_state = OpenGLState::GetCurState();
     state.Apply();
 
-    if (framebuffer != boost::none) {
+    if (framebuffer != std::nullopt) {
         // If framebuffer is provided, reload it from memory to a texture
-        if (screen_info.texture.width != (GLsizei)framebuffer->width ||
-            screen_info.texture.height != (GLsizei)framebuffer->height ||
-            screen_info.texture.pixel_format != framebuffer->pixel_format) {
+        if (screen_info.texture.width != (GLsizei)framebuffer.value().width ||
+            screen_info.texture.height != (GLsizei)framebuffer.value().height ||
+            screen_info.texture.pixel_format != framebuffer.value().pixel_format) {
             // Reallocate texture if the framebuffer size has changed.
             // This is expected to not happen very often and hence should not be a
             // performance problem.

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -127,9 +127,9 @@ void RendererOpenGL::SwapBuffers(
 
     if (framebuffer) {
         // If framebuffer is provided, reload it from memory to a texture
-        if (screen_info.texture.width != (GLsizei)framebuffer.value().get().width ||
-            screen_info.texture.height != (GLsizei)framebuffer.value().get().height ||
-            screen_info.texture.pixel_format != framebuffer.value().get().pixel_format) {
+        if (screen_info.texture.width != (GLsizei)framebuffer->get().width ||
+            screen_info.texture.height != (GLsizei)framebuffer->get().height ||
+            screen_info.texture.pixel_format != framebuffer->get().pixel_format) {
             // Reallocate texture if the framebuffer size has changed.
             // This is expected to not happen very often and hence should not be a
             // performance problem.

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -125,7 +125,7 @@ void RendererOpenGL::SwapBuffers(
     OpenGLState prev_state = OpenGLState::GetCurState();
     state.Apply();
 
-    if (framebuffer != std::nullopt) {
+    if (framebuffer) {
         // If framebuffer is provided, reload it from memory to a texture
         if (screen_info.texture.width != (GLsizei)framebuffer.value().get().width ||
             screen_info.texture.height != (GLsizei)framebuffer.value().get().height ||

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -115,7 +115,8 @@ RendererOpenGL::RendererOpenGL(Core::Frontend::EmuWindow& window)
 RendererOpenGL::~RendererOpenGL() = default;
 
 /// Swap buffers (render frame)
-void RendererOpenGL::SwapBuffers(std::optional<const Tegra::FramebufferConfig> framebuffer) {
+void RendererOpenGL::SwapBuffers(
+    std::optional<std::reference_wrapper<const Tegra::FramebufferConfig>> framebuffer) {
     ScopeAcquireGLContext acquire_context{render_window};
 
     Core::System::GetInstance().GetPerfStats().EndSystemFrame();
@@ -126,9 +127,9 @@ void RendererOpenGL::SwapBuffers(std::optional<const Tegra::FramebufferConfig> f
 
     if (framebuffer != std::nullopt) {
         // If framebuffer is provided, reload it from memory to a texture
-        if (screen_info.texture.width != (GLsizei)framebuffer.value().width ||
-            screen_info.texture.height != (GLsizei)framebuffer.value().height ||
-            screen_info.texture.pixel_format != framebuffer.value().pixel_format) {
+        if (screen_info.texture.width != (GLsizei)framebuffer.value().get().width ||
+            screen_info.texture.height != (GLsizei)framebuffer.value().get().height ||
+            screen_info.texture.pixel_format != framebuffer.value().get().pixel_format) {
             // Reallocate texture if the framebuffer size has changed.
             // This is expected to not happen very often and hence should not be a
             // performance problem.

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -115,7 +115,7 @@ RendererOpenGL::RendererOpenGL(Core::Frontend::EmuWindow& window)
 RendererOpenGL::~RendererOpenGL() = default;
 
 /// Swap buffers (render frame)
-void RendererOpenGL::SwapBuffers(std::optional<const Tegra::FramebufferConfig&> framebuffer) {
+void RendererOpenGL::SwapBuffers(std::optional<const Tegra::FramebufferConfig> framebuffer) {
     ScopeAcquireGLContext acquire_context{render_window};
 
     Core::System::GetInstance().GetPerfStats().EndSystemFrame();

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -51,7 +51,8 @@ public:
     ~RendererOpenGL() override;
 
     /// Swap buffers (render frame)
-    void SwapBuffers(std::optional<const Tegra::FramebufferConfig> framebuffer) override;
+    void SwapBuffers(
+        std::optional<std::reference_wrapper<const Tegra::FramebufferConfig>> framebuffer) override;
 
     /// Initialize the renderer
     bool Init() override;

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -51,7 +51,7 @@ public:
     ~RendererOpenGL() override;
 
     /// Swap buffers (render frame)
-    void SwapBuffers(boost::optional<const Tegra::FramebufferConfig&> framebuffer) override;
+    void SwapBuffers(std::optional<const Tegra::FramebufferConfig&> framebuffer) override;
 
     /// Initialize the renderer
     bool Init() override;

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -51,7 +51,7 @@ public:
     ~RendererOpenGL() override;
 
     /// Swap buffers (render frame)
-    void SwapBuffers(std::optional<const Tegra::FramebufferConfig&> framebuffer) override;
+    void SwapBuffers(std::optional<const Tegra::FramebufferConfig> framebuffer) override;
 
     /// Initialize the renderer
     bool Init() override;

--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -322,7 +322,7 @@ void ConfigureInput::setPollingResult(const Common::ParamPackage& params, bool a
     }
 
     updateButtonLabels();
-    input_setter = boost::none;
+    input_setter = {};
 }
 
 void ConfigureInput::keyPressEvent(QKeyEvent* event) {

--- a/src/yuzu/configuration/configure_input.h
+++ b/src/yuzu/configuration/configure_input.h
@@ -7,11 +7,13 @@
 #include <array>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
+
 #include <QKeyEvent>
 #include <QWidget>
-#include <boost/optional.hpp>
+
 #include "common/param_package.h"
 #include "core/settings.h"
 #include "input_common/main.h"
@@ -41,7 +43,7 @@ private:
     std::unique_ptr<QTimer> poll_timer;
 
     /// This will be the the setting function when an input is awaiting configuration.
-    boost::optional<std::function<void(const Common::ParamPackage&)>> input_setter;
+    std::optional<std::function<void(const Common::ParamPackage&)>> input_setter;
 
     std::array<Common::ParamPackage, Settings::NativeButton::NumButtons> buttons_param;
     std::array<Common::ParamPackage, Settings::NativeAnalog::NumAnalogs> analogs_param;

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -173,7 +173,7 @@ void ConfigureSystem::UpdateCurrentUser() {
     ui->pm_add->setEnabled(profile_manager->GetUserCount() < Service::Account::MAX_USERS);
 
     const auto& current_user = profile_manager->GetUser(Settings::values.current_user);
-    ASSERT(current_user != std::nullopt);
+    ASSERT(current_user);
     const auto username = GetAccountUsername(*profile_manager, *current_user);
 
     scene->clear();
@@ -261,7 +261,7 @@ void ConfigureSystem::AddUser() {
 void ConfigureSystem::RenameUser() {
     const auto user = tree_view->currentIndex().row();
     const auto uuid = profile_manager->GetUser(user);
-    ASSERT(uuid != std::nullopt);
+    ASSERT(uuid);
 
     Service::Account::ProfileBase profile;
     if (!profile_manager->GetProfileBase(*uuid, profile))
@@ -297,7 +297,7 @@ void ConfigureSystem::RenameUser() {
 void ConfigureSystem::DeleteUser() {
     const auto index = tree_view->currentIndex().row();
     const auto uuid = profile_manager->GetUser(index);
-    ASSERT(uuid != std::nullopt);
+    ASSERT(uuid);
     const auto username = GetAccountUsername(*profile_manager, *uuid);
 
     const auto confirm = QMessageBox::question(
@@ -324,7 +324,7 @@ void ConfigureSystem::DeleteUser() {
 void ConfigureSystem::SetUserImage() {
     const auto index = tree_view->currentIndex().row();
     const auto uuid = profile_manager->GetUser(index);
-    ASSERT(uuid != std::nullopt);
+    ASSERT(uuid);
 
     const auto file = QFileDialog::getOpenFileName(this, tr("Select User Image"), QString(),
                                                    tr("JPEG Images (*.jpg *.jpeg)"));

--- a/src/yuzu/debugger/graphics/graphics_surface.cpp
+++ b/src/yuzu/debugger/graphics/graphics_surface.cpp
@@ -382,7 +382,7 @@ void GraphicsSurfaceWidget::OnUpdate() {
     // TODO: Implement a good way to visualize alpha components!
 
     QImage decoded_image(surface_width, surface_height, QImage::Format_ARGB32);
-    boost::optional<VAddr> address = gpu.MemoryManager().GpuToCpuAddress(surface_address);
+    std::optional<VAddr> address = gpu.MemoryManager().GpuToCpuAddress(surface_address);
 
     // TODO(bunnei): Will not work with BCn formats that swizzle 4x4 tiles.
     // Needs to be fixed if we plan to use this feature more, otherwise we may remove it.
@@ -444,7 +444,7 @@ void GraphicsSurfaceWidget::SaveSurface() {
             pixmap->save(&file, "PNG");
     } else if (selectedFilter == bin_filter) {
         auto& gpu = Core::System::GetInstance().GPU();
-        boost::optional<VAddr> address = gpu.MemoryManager().GpuToCpuAddress(surface_address);
+        std::optional<VAddr> address = gpu.MemoryManager().GpuToCpuAddress(surface_address);
 
         const u8* buffer = Memory::GetPointer(*address);
         ASSERT_MSG(buffer != nullptr, "Memory not accessible");

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1560,7 +1560,7 @@ void GMainWindow::OnReinitializeKeys(ReinitializeKeyBehavior behavior) {
     }
 }
 
-boost::optional<u64> GMainWindow::SelectRomFSDumpTarget(
+std::optional<u64> GMainWindow::SelectRomFSDumpTarget(
     const FileSys::RegisteredCacheUnion& installed, u64 program_id) {
     const auto dlc_entries =
         installed.ListEntriesFilter(FileSys::TitleType::AOC, FileSys::ContentRecordType::Data);
@@ -1587,7 +1587,7 @@ boost::optional<u64> GMainWindow::SelectRomFSDumpTarget(
             this, tr("Select RomFS Dump Target"),
             tr("Please select which RomFS you would like to dump."), list, 0, false, &ok);
         if (!ok) {
-            return boost::none;
+            return {};
         }
 
         return romfs_tids[list.indexOf(res)];

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -786,7 +786,7 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
         ASSERT(index != -1 && index < 8);
 
         const auto user_id = manager.GetUser(index);
-        ASSERT(user_id != std::nullopt);
+        ASSERT(user_id);
         path = nand_dir + FileSys::SaveDataFactory::GetFullPath(FileSys::SaveDataSpaceId::NandUser,
                                                                 FileSys::SaveDataType::SaveData,
                                                                 program_id, user_id->uuid, 0);

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -178,8 +178,7 @@ private slots:
     void OnReinitializeKeys(ReinitializeKeyBehavior behavior);
 
 private:
-    std::optional<u64> SelectRomFSDumpTarget(const FileSys::RegisteredCacheUnion&,
-                                               u64 program_id);
+    std::optional<u64> SelectRomFSDumpTarget(const FileSys::RegisteredCacheUnion&, u64 program_id);
     void UpdateStatusBar();
 
     Ui::MainWindow ui;

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -5,12 +5,12 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <unordered_map>
 
 #include <QMainWindow>
 #include <QTimer>
 
-#include <boost/optional.hpp>
 #include "common/common_types.h"
 #include "core/core.h"
 #include "ui_main.h"
@@ -178,7 +178,7 @@ private slots:
     void OnReinitializeKeys(ReinitializeKeyBehavior behavior);
 
 private:
-    boost::optional<u64> SelectRomFSDumpTarget(const FileSys::RegisteredCacheUnion&,
+    std::optional<u64> SelectRomFSDumpTarget(const FileSys::RegisteredCacheUnion&,
                                                u64 program_id);
     void UpdateStatusBar();
 


### PR DESCRIPTION
This PR depends on PR #1570 and continues @lioncash work. `boost::optional` dependency of yuzu codebase should be completely eliminated by now.