### PR TITLE
Implemented Mipmaps

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -731,11 +731,15 @@ void RasterizerOpenGL::SamplerInfo::SyncWithConfig(const Tegra::Texture::TSCEntr
 
     if (mag_filter != config.mag_filter) {
         mag_filter = config.mag_filter;
-        glSamplerParameteri(s, GL_TEXTURE_MAG_FILTER, MaxwellToGL::TextureFilterMode(mag_filter));
+        glSamplerParameteri(
+            s, GL_TEXTURE_MAG_FILTER,
+            MaxwellToGL::TextureFilterMode(mag_filter, Tegra::Texture::TextureMipmapFilter::None));
     }
-    if (min_filter != config.min_filter) {
+    if (min_filter != config.min_filter || mip_filter != config.mip_filter) {
         min_filter = config.min_filter;
-        glSamplerParameteri(s, GL_TEXTURE_MIN_FILTER, MaxwellToGL::TextureFilterMode(min_filter));
+        mip_filter = config.mip_filter;
+        glSamplerParameteri(s, GL_TEXTURE_MIN_FILTER,
+                            MaxwellToGL::TextureFilterMode(min_filter, mip_filter));
     }
 
     if (wrap_u != config.wrap_u) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -93,6 +93,7 @@ private:
     private:
         Tegra::Texture::TextureFilter mag_filter;
         Tegra::Texture::TextureFilter min_filter;
+        Tegra::Texture::TextureMipmapFilter mip_filter;
         Tegra::Texture::WrapMode wrap_u;
         Tegra::Texture::WrapMode wrap_v;
         Tegra::Texture::WrapMode wrap_p;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -878,6 +878,8 @@ CachedSurface::CachedSurface(const SurfaceParams& params)
     glTexParameteri(SurfaceTargetToGL(params.target), GL_TEXTURE_MAG_FILTER, GL_LINEAR);
     glTexParameteri(SurfaceTargetToGL(params.target), GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(SurfaceTargetToGL(params.target), GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+    glTexParameteri(SurfaceTargetToGL(params.target), GL_TEXTURE_MAX_LEVEL,
+                    params.max_mip_level - 1);
     if (params.max_mip_level == 1) {
         glTexParameterf(SurfaceTargetToGL(params.target), GL_TEXTURE_LOD_BIAS, 1000.0);
     }
@@ -1196,20 +1198,6 @@ void CachedSurface::UploadGLTexture(GLuint read_fb_handle, GLuint draw_fb_handle
 
     for (u32 i = 0; i < params.max_mip_level; i++)
         UploadGLMipmapTexture(i, read_fb_handle, draw_fb_handle);
-
-    if (params.max_mip_level == 1) {
-        const GLuint target_tex = texture.handle;
-        OpenGLState cur_state = OpenGLState::GetCurState();
-        const auto& old_tex = cur_state.texture_units[0];
-        SCOPE_EXIT({
-            cur_state.texture_units[0] = old_tex;
-            cur_state.Apply();
-        });
-        cur_state.texture_units[0].texture = target_tex;
-        cur_state.texture_units[0].target = SurfaceTargetToGL(params.target);
-        cur_state.Apply();
-        glGenerateMipmap(SurfaceTargetToGL(params.target));
-    }
 }
 
 RasterizerCacheOpenGL::RasterizerCacheOpenGL() {

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -95,10 +95,13 @@ std::size_t SurfaceParams::InnerMipmapMemorySize(u32 mip_level, bool force_gl, b
     const u32 compression_factor{GetCompressionFactor(pixel_format)};
     const u32 bytes_per_pixel{GetBytesPerPixel(pixel_format)};
     u32 m_depth = (layer_only ? 1U : depth);
-    u32 m_width = uncompressed ? width : std::max(1U, width / compression_factor);
-    u32 m_height = uncompressed ? height : std::max(1U, height / compression_factor);
-    m_width = std::max(1U, m_width >> mip_level);
-    m_height = std::max(1U, m_height >> mip_level);
+    u32 m_width = MipWidth(mip_level);
+    u32 m_height = MipHeight(mip_level);
+    m_width = uncompressed ? m_width
+                           : std::max(1U, (m_width + compression_factor - 1) / compression_factor);
+    m_height = uncompressed
+                   ? m_height
+                   : std::max(1U, (m_height + compression_factor - 1) / compression_factor);
     m_depth = std::max(1U, m_depth >> mip_level);
     u32 m_block_height = MipBlockHeight(mip_level, m_height);
     u32 m_block_depth = MipBlockDepth(mip_level);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -103,7 +103,7 @@ std::size_t SurfaceParams::InnerMipmapMemorySize(u32 mip_level, bool force_gl, b
                    ? m_height
                    : std::max(1U, (m_height + compression_factor - 1) / compression_factor);
     m_depth = std::max(1U, m_depth >> mip_level);
-    u32 m_block_height = MipBlockHeight(mip_level, m_height);
+    u32 m_block_height = MipBlockHeight(mip_level);
     u32 m_block_depth = MipBlockDepth(mip_level);
     return Tegra::Texture::CalculateSize(force_gl ? false : is_tiled, bytes_per_pixel, m_width,
                                          m_height, m_depth, m_block_height, m_block_depth);
@@ -111,7 +111,7 @@ std::size_t SurfaceParams::InnerMipmapMemorySize(u32 mip_level, bool force_gl, b
 
 std::size_t SurfaceParams::InnerMemorySize(bool force_gl, bool layer_only,
                                            bool uncompressed) const {
-    std::size_t block_size_bytes = 512 * block_height * block_depth; // 512 is GOB size
+    std::size_t block_size_bytes = Tegra::Texture::GetGOBSize() * block_height * block_depth;
     std::size_t size = 0;
     for (u32 i = 0; i < max_mip_level; i++) {
         size += InnerMipmapMemorySize(i, force_gl, layer_only, uncompressed);
@@ -1043,8 +1043,8 @@ void CachedSurface::FlushGLBuffer() {
     glPixelStorei(GL_PACK_ROW_LENGTH, static_cast<GLint>(params.width));
     ASSERT(!tuple.compressed);
     glBindBuffer(GL_PIXEL_PACK_BUFFER, 0);
-    glGetTextureImage(texture.handle, 0, tuple.format, tuple.type, static_cast<GLsizei>(gl_buffer[0].size()),
-                      gl_buffer[0].data());
+    glGetTextureImage(texture.handle, 0, tuple.format, tuple.type,
+                      static_cast<GLsizei>(gl_buffer[0].size()), gl_buffer[0].data());
     glPixelStorei(GL_PACK_ROW_LENGTH, 0);
     ConvertFormatAsNeeded_FlushGLBuffer(gl_buffer[0], params.pixel_format, params.width,
                                         params.height);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1325,6 +1325,8 @@ void RasterizerCacheOpenGL::AccurateCopySurface(const Surface& src_surface,
                                                 const Surface& dst_surface) {
     const auto& src_params{src_surface->GetSurfaceParams()};
     const auto& dst_params{dst_surface->GetSurfaceParams()};
+    auto* start = Memory::GetPointer(src_params.addr);
+    std::fill(start, start + dst_params.MemorySize(), 0);
     FlushRegion(src_params.addr, dst_params.MemorySize());
     LoadSurface(dst_surface);
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -919,7 +919,7 @@ struct SurfaceParams {
         u32 height = MipHeight(mip_level);
         u32 bh = block_height;
         // Magical block resizing algorithm, needs more testing.
-        while (bh != 1 && height / bh <= 16) {
+        while (bh > 1 && (height +  bh - 1) / bh <= 16) {
             bh = bh >> 1;
         }
         return bh;
@@ -929,7 +929,7 @@ struct SurfaceParams {
         u32 depth = MipDepth(mip_level);
         u32 bd = block_depth;
         // Magical block resizing algorithm, needs more testing.
-        while (bd != 1 && depth / bd <= 16) {
+        while (bd > 1 && depth / bd <= 16) {
             bd = bd >> 1;
         }
         return bd;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -834,7 +834,7 @@ struct SurfaceParams {
     }
 
     /// Returns the rectangle corresponding to this surface
-    MathUtil::Rectangle<u32> GetRect() const;
+    MathUtil::Rectangle<u32> GetRect(u32 mip_level = 0) const;
 
     /// Returns the total size of this surface in bytes, adjusted for compression
     std::size_t SizeInBytesRaw(bool ignore_tiled = false) const {
@@ -865,7 +865,7 @@ struct SurfaceParams {
 
     /// Returns the exact size of memory occupied by the texture in VRAM, including mipmaps.
     std::size_t MemorySize() const {
-        std::size_t size = InnerMemorySize(is_layered);
+        std::size_t size = InnerMemorySize(false, is_layered);
         if (is_layered)
             return size * depth;
         return size;
@@ -874,12 +874,65 @@ struct SurfaceParams {
     /// Returns the exact size of the memory occupied by a layer in a texture in VRAM, including
     /// mipmaps.
     std::size_t LayerMemorySize() const {
-        return InnerMemorySize(true);
+        return InnerMemorySize(false, true);
     }
 
     /// Returns the size of a layer of this surface in OpenGL.
-    std::size_t LayerSizeGL() const {
-        return SizeInBytesRaw(true) / depth;
+    std::size_t LayerSizeGL(u32 mip_level) const {
+        return InnerMipmapMemorySize(mip_level, true, is_layered, false);
+    }
+
+    std::size_t GetMipmapSizeGL(u32 mip_level, bool ignore_compressed = true) const {
+        std::size_t size = InnerMipmapMemorySize(mip_level, true, is_layered, ignore_compressed);
+        if (is_layered)
+            return size * depth;
+        return size;
+    }
+
+    std::size_t GetMipmapLevelOffset(u32 mip_level) const {
+        std::size_t offset = 0;
+        for (u32 i = 0; i < mip_level; i++)
+            offset += InnerMipmapMemorySize(i, false, is_layered);
+        return offset;
+    }
+
+    std::size_t GetMipmapLevelOffsetGL(u32 mip_level) const {
+        std::size_t offset = 0;
+        for (u32 i = 0; i < mip_level; i++)
+            offset += InnerMipmapMemorySize(i, true, is_layered);
+        return offset;
+    }
+
+    u32 MipWidth(u32 mip_level) const {
+        return std::max(1U, width >> mip_level);
+    }
+
+    u32 MipHeight(u32 mip_level) const {
+        return std::max(1U, height >> mip_level);
+    }
+
+    u32 MipDepth(u32 mip_level) const {
+        return std::max(1U, depth >> mip_level);
+    }
+
+    u32 MipBlockHeight(u32 mip_level) const {
+        u32 height = MipHeight(mip_level);
+        u32 bh = block_height;
+        // Magical block resizing algorithm, needs more testing.
+        while (bh != 1 && height / bh <= 16) {
+            bh = bh >> 1;
+        }
+        return bh;
+    }
+
+    u32 MipBlockDepth(u32 mip_level) const {
+        u32 depth = MipDepth(mip_level);
+        u32 bd = block_depth;
+        // Magical block resizing algorithm, needs more testing.
+        while (bd != 1 && depth / bd <= 16) {
+            bd = bd >> 1;
+        }
+        return bd;
     }
 
     /// Creates SurfaceParams from a texture configuration
@@ -940,7 +993,10 @@ struct SurfaceParams {
     } rt;
 
 private:
-    std::size_t InnerMemorySize(bool layer_only = false) const;
+    std::size_t InnerMipmapMemorySize(u32 mip_level, bool force_gl = false, bool layer_only = false,
+                                      bool uncompressed = false) const;
+    std::size_t InnerMemorySize(bool force_gl = false, bool layer_only = false,
+                                bool uncompressed = false) const;
 };
 
 }; // namespace OpenGL
@@ -1002,8 +1058,10 @@ public:
     void UploadGLTexture(GLuint read_fb_handle, GLuint draw_fb_handle);
 
 private:
+    void UploadGLMipmapTexture(u32 mip_map, GLuint read_fb_handle, GLuint draw_fb_handle);
+
     OGLTexture texture;
-    std::vector<u8> gl_buffer;
+    std::vector<std::vector<u8>> gl_buffer;
     SurfaceParams params;
     GLenum gl_target;
     std::size_t cached_size_in_bytes;

--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -165,7 +165,6 @@ inline GLenum TextureFilterMode(Tegra::Texture::TextureFilter filter_mode,
     return {};
 }
 
-
 inline GLenum WrapMode(Tegra::Texture::WrapMode wrap_mode) {
     switch (wrap_mode) {
     case Tegra::Texture::WrapMode::Wrap:

--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -135,18 +135,36 @@ inline GLenum PrimitiveTopology(Maxwell::PrimitiveTopology topology) {
     return {};
 }
 
-inline GLenum TextureFilterMode(Tegra::Texture::TextureFilter filter_mode) {
+inline GLenum TextureFilterMode(Tegra::Texture::TextureFilter filter_mode,
+                                Tegra::Texture::TextureMipmapFilter mip_filter_mode) {
     switch (filter_mode) {
-    case Tegra::Texture::TextureFilter::Linear:
-        return GL_LINEAR;
-    case Tegra::Texture::TextureFilter::Nearest:
-        return GL_NEAREST;
+    case Tegra::Texture::TextureFilter::Linear: {
+        switch (mip_filter_mode) {
+        case Tegra::Texture::TextureMipmapFilter::None:
+            return GL_LINEAR;
+        case Tegra::Texture::TextureMipmapFilter::Nearest:
+            return GL_NEAREST_MIPMAP_LINEAR;
+        case Tegra::Texture::TextureMipmapFilter::Linear:
+            return GL_LINEAR_MIPMAP_LINEAR;
+        }
+    }
+    case Tegra::Texture::TextureFilter::Nearest: {
+        switch (mip_filter_mode) {
+        case Tegra::Texture::TextureMipmapFilter::None:
+            return GL_NEAREST;
+        case Tegra::Texture::TextureMipmapFilter::Nearest:
+            return GL_NEAREST_MIPMAP_NEAREST;
+        case Tegra::Texture::TextureMipmapFilter::Linear:
+            return GL_LINEAR_MIPMAP_NEAREST;
+        }
+    }
     }
     LOG_CRITICAL(Render_OpenGL, "Unimplemented texture filter mode={}",
                  static_cast<u32>(filter_mode));
     UNREACHABLE();
     return {};
 }
+
 
 inline GLenum WrapMode(Tegra::Texture::WrapMode wrap_mode) {
     switch (wrap_mode) {

--- a/src/video_core/textures/decoders.h
+++ b/src/video_core/textures/decoders.h
@@ -10,6 +10,12 @@
 
 namespace Tegra::Texture {
 
+// GOBSize constant. Calculated by 64 bytes in x multiplied by 8 y coords, represents
+// an small rect of (64/bytes_per_pixel)X8.
+inline std::size_t GetGOBSize() {
+    return 512;
+}
+
 /**
  * Unswizzles a swizzled texture without changing its format.
  */


### PR DESCRIPTION
This is an initial implementation of mipmaps. I've tried to make it as accurate as possible even though there's a innocent workaround: sometimes game will set a mip filter on a texture without mipmaps, instead of forcing out the mip filter, we generate mipmaps on that texture.

- [x] Ensure the magical block size algorithm works in every case.
- [x] Test this PR in many different games.
- [x] Fix the Invalid Image Size when loading compressed mipmaps.

