### PR TITLE
Update MACOSX_DEPLOYMENT_TARGET to 10.14

### DIFF
--- a/.travis/macos/build.sh
+++ b/.travis/macos/build.sh
@@ -2,7 +2,7 @@
 
 set -o pipefail
 
-export MACOSX_DEPLOYMENT_TARGET=10.13
+export MACOSX_DEPLOYMENT_TARGET=10.14
 export Qt5_DIR=$(brew --prefix)/opt/qt5
 export UNICORNDIR=$(pwd)/externals/unicorn
 export PATH="/usr/local/opt/ccache/libexec:$PATH"


### PR DESCRIPTION
Enables the usage of further C++ std functions introduced in macOS 10.14.

~~This PR is also required for #1578 for `std::optional::value()`.~~   
