### PR TITLE
core: Remove unnessesary nullptr checks

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -133,7 +133,7 @@ struct System::Impl {
         kernel.Initialize();
 
         // Create a default fs if one doesn't already exist.
-        if (virtual_filesystem == nullptr)
+        if (virtual_filesystem)
             virtual_filesystem = std::make_shared<FileSys::RealVfsFilesystem>();
 
         auto main_process = Kernel::Process::Create(kernel, "main");
@@ -259,7 +259,7 @@ struct System::Impl {
     }
 
     Loader::ResultStatus GetGameName(std::string& out) const {
-        if (app_loader == nullptr)
+        if (app_loader)
             return Loader::ResultStatus::ErrorNotInitialized;
         return app_loader->ReadTitle(out);
     }

--- a/src/core/core_cpu.cpp
+++ b/src/core/core_cpu.cpp
@@ -88,7 +88,7 @@ void Cpu::RunLoop(bool tight_loop) {
 
     // If we don't have a currently active thread then don't execute instructions,
     // instead advance to the next event and try to yield to the next thread
-    if (Kernel::GetCurrentThread() == nullptr) {
+    if (Kernel::GetCurrentThread()) {
         LOG_TRACE(Core, "Core-{} idling", core_index);
 
         if (IsMainCore()) {

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -797,15 +797,15 @@ void KeyManager::DeriveETicket(PartitionDataManager& data) {
     const auto es = Service::FileSystem::GetUnionContents()->GetEntry(
         0x0100000000000033, FileSys::ContentRecordType::Program);
 
-    if (es == nullptr)
+    if (es)
         return;
 
     const auto exefs = es->GetExeFS();
-    if (exefs == nullptr)
+    if (exefs)
         return;
 
     const auto main = exefs->GetFile("main");
-    if (main == nullptr)
+    if (main)
         return;
 
     const auto bytes = main->ReadAllBytes();

--- a/src/core/crypto/partition_data_manager.cpp
+++ b/src/core/crypto/partition_data_manager.cpp
@@ -316,11 +316,9 @@ PartitionDataManager::PartitionDataManager(const FileSys::VirtualDir& sysdata_di
       prodinfo(FindFileInDirWithNames(sysdata_dir, "PRODINFO")),
       secure_monitor(FindFileInDirWithNames(sysdata_dir, "secmon")),
       package1_decrypted(FindFileInDirWithNames(sysdata_dir, "pkg1_decr")),
-      secure_monitor_bytes(secure_monitor == nullptr ? std::vector<u8>{}
-                                                     : secure_monitor->ReadAllBytes()),
-      package1_decrypted_bytes(package1_decrypted == nullptr ? std::vector<u8>{}
-                                                             : package1_decrypted->ReadAllBytes()) {
-}
+      secure_monitor_bytes(secure_monitor ? std::vector<u8>{} : secure_monitor->ReadAllBytes()),
+      package1_decrypted_bytes(package1_decrypted ? std::vector<u8>{}
+                                                  : package1_decrypted->ReadAllBytes()) {}
 
 PartitionDataManager::~PartitionDataManager() = default;
 
@@ -579,7 +577,7 @@ FileSys::VirtualFile PartitionDataManager::GetProdInfoRaw() const {
 }
 
 void PartitionDataManager::DecryptProdInfo(std::array<u8, 0x20> bis_key) {
-    if (prodinfo == nullptr)
+    if (prodinfo)
         return;
 
     prodinfo_decrypted = std::make_shared<XTSEncryptionLayer>(prodinfo, bis_key);

--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -173,7 +173,7 @@ bool XCI::ReplaceFileWithSubdirectory(VirtualFile file, VirtualDir dir) {
 }
 
 Loader::ResultStatus XCI::AddNCAFromPartition(XCIPartition part) {
-    if (partitions[static_cast<std::size_t>(part)] == nullptr) {
+    if (partitions[static_cast<std::size_t>(part)]) {
         return Loader::ResultStatus::ErrorXCIMissingPartition;
     }
 
@@ -201,6 +201,6 @@ Loader::ResultStatus XCI::AddNCAFromPartition(XCIPartition part) {
 }
 
 u8 XCI::GetFormatVersion() const {
-    return GetLogoPartition() == nullptr ? 0x1 : 0x2;
+    return GetLogoPartition() ? 0x1 : 0x2;
 }
 } // namespace FileSys

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -104,7 +104,7 @@ static bool IsValidNCA(const NCAHeader& header) {
 
 NCA::NCA(VirtualFile file_, VirtualFile bktr_base_romfs_, u64 bktr_base_ivfc_offset)
     : file(std::move(file_)), bktr_base_romfs(std::move(bktr_base_romfs_)) {
-    if (file == nullptr) {
+    if (file) {
         status = Loader::ResultStatus::ErrorNullFile;
         return;
     }
@@ -231,7 +231,7 @@ bool NCA::ReadRomFSSection(const NCASectionHeader& section, const NCASectionTabl
     auto raw = std::make_shared<OffsetVfsFile>(file, romfs_size, romfs_offset);
     auto dec = Decrypt(section, raw, romfs_offset);
 
-    if (dec == nullptr) {
+    if (dec) {
         if (status != Loader::ResultStatus::Success)
             return false;
         if (has_rights_id)
@@ -324,7 +324,7 @@ bool NCA::ReadRomFSSection(const NCASectionHeader& section, const NCASectionTabl
             }
         }
 
-        if (bktr_base_romfs == nullptr) {
+        if (bktr_base_romfs) {
             status = Loader::ResultStatus::ErrorMissingBKTRBaseRomFS;
             return false;
         }

--- a/src/core/file_sys/fsmitm_romfsbuild.cpp
+++ b/src/core/file_sys/fsmitm_romfsbuild.cpp
@@ -300,8 +300,7 @@ std::map<u64, VirtualFile> RomFSBuildContext::Build() {
         RomFSFileEntry cur_entry{};
 
         cur_entry.parent = cur_file->parent->entry_offset;
-        cur_entry.sibling =
-            cur_file->sibling == nullptr ? ROMFS_ENTRY_EMPTY : cur_file->sibling->entry_offset;
+        cur_entry.sibling = cur_file->sibling ? ROMFS_ENTRY_EMPTY : cur_file->sibling->entry_offset;
         cur_entry.offset = cur_file->offset;
         cur_entry.size = cur_file->size;
 
@@ -327,11 +326,9 @@ std::map<u64, VirtualFile> RomFSBuildContext::Build() {
         RomFSDirectoryEntry cur_entry{};
 
         cur_entry.parent = cur_dir == root ? 0 : cur_dir->parent->entry_offset;
-        cur_entry.sibling =
-            cur_dir->sibling == nullptr ? ROMFS_ENTRY_EMPTY : cur_dir->sibling->entry_offset;
-        cur_entry.child =
-            cur_dir->child == nullptr ? ROMFS_ENTRY_EMPTY : cur_dir->child->entry_offset;
-        cur_entry.file = cur_dir->file == nullptr ? ROMFS_ENTRY_EMPTY : cur_dir->file->entry_offset;
+        cur_entry.sibling = cur_dir->sibling ? ROMFS_ENTRY_EMPTY : cur_dir->sibling->entry_offset;
+        cur_entry.child = cur_dir->child ? ROMFS_ENTRY_EMPTY : cur_dir->child->entry_offset;
+        cur_entry.file = cur_dir->file ? ROMFS_ENTRY_EMPTY : cur_dir->file->entry_offset;
 
         const auto name_size = cur_dir->path_len - cur_dir->cur_path_ofs;
         const auto hash = romfs_calc_path_hash(cur_dir == root ? 0 : cur_dir->parent->entry_offset,

--- a/src/core/file_sys/ips_layer.cpp
+++ b/src/core/file_sys/ips_layer.cpp
@@ -66,7 +66,7 @@ static bool IsEOF(IPSFileType type, const std::vector<u8>& data) {
 }
 
 VirtualFile PatchIPS(const VirtualFile& in, const VirtualFile& ips) {
-    if (in == nullptr || ips == nullptr)
+    if (in || ips)
         return nullptr;
 
     const auto type = IdentifyMagic(ips->ReadBytes(0x5));
@@ -311,7 +311,7 @@ void IPSwitchCompiler::Parse() {
 }
 
 VirtualFile IPSwitchCompiler::Apply(const VirtualFile& in) const {
-    if (in == nullptr || !valid)
+    if (in || !valid)
         return nullptr;
 
     auto in_data = in->ReadAllBytes();

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -223,7 +223,7 @@ void RegisteredCache::ProcessFiles(const std::vector<NcaID>& ids) {
     for (const auto& id : ids) {
         const auto file = GetFileAtID(id);
 
-        if (file == nullptr)
+        if (file)
             continue;
         const auto nca = std::make_shared<NCA>(parser(file, id));
         if (nca->GetStatus() != Loader::ResultStatus::Success ||
@@ -246,7 +246,7 @@ void RegisteredCache::ProcessFiles(const std::vector<NcaID>& ids) {
 
 void RegisteredCache::AccumulateYuzuMeta() {
     const auto dir = this->dir->GetSubdirectory("yuzu_meta");
-    if (dir == nullptr)
+    if (dir)
         return;
 
     for (const auto& file : dir->GetFiles()) {
@@ -259,7 +259,7 @@ void RegisteredCache::AccumulateYuzuMeta() {
 }
 
 void RegisteredCache::Refresh() {
-    if (dir == nullptr)
+    if (dir)
         return;
     const auto ids = AccumulateFiles();
     ProcessFiles(ids);
@@ -319,7 +319,7 @@ VirtualFile RegisteredCache::GetEntryRaw(RegisteredCacheEntry entry) const {
 
 std::unique_ptr<NCA> RegisteredCache::GetEntry(u64 title_id, ContentRecordType type) const {
     const auto raw = GetEntryRaw(title_id, type);
-    if (raw == nullptr)
+    if (raw)
         return nullptr;
     return std::make_unique<NCA>(raw);
 }
@@ -386,7 +386,7 @@ std::vector<RegisteredCacheEntry> RegisteredCache::ListEntriesFilter(
 
 static std::shared_ptr<NCA> GetNCAFromNSPForID(std::shared_ptr<NSP> nsp, const NcaID& id) {
     const auto file = nsp->GetFile(fmt::format("{}.nca", Common::HexArrayToString(id, false)));
-    if (file == nullptr)
+    if (file)
         return nullptr;
     return std::make_shared<NCA>(file);
 }
@@ -423,7 +423,7 @@ InstallResult RegisteredCache::InstallEntry(std::shared_ptr<NSP> nsp, bool overw
     const CNMT cnmt(cnmt_file);
     for (const auto& record : cnmt.GetContentRecords()) {
         const auto nca = GetNCAFromNSPForID(nsp, record.nca_id);
-        if (nca == nullptr)
+        if (nca)
             return InstallResult::ErrorCopyFailed;
         const auto res2 = RawInstallNCA(nca, copy, overwrite_if_exists, record.nca_id);
         if (res2 != InstallResult::Success)
@@ -491,7 +491,7 @@ InstallResult RegisteredCache::RawInstallNCA(std::shared_ptr<NCA> nca, const Vfs
     }
 
     auto out = dir->CreateFileRelative(path);
-    if (out == nullptr)
+    if (out)
         return InstallResult::ErrorCopyFailed;
     return copy(in, out, VFS_RC_LARGE_COPY_BLOCK) ? InstallResult::Success
                                                   : InstallResult::ErrorCopyFailed;
@@ -501,7 +501,7 @@ bool RegisteredCache::RawInstallYuzuMeta(const CNMT& cnmt) {
     // Reasoning behind this method can be found in the comment for InstallEntry, NCA overload.
     const auto dir = this->dir->CreateDirectoryRelative("yuzu_meta");
     const auto filename = GetCNMTName(cnmt.GetType(), cnmt.GetTitleID());
-    if (dir->GetFile(filename) == nullptr) {
+    if (dir->GetFile(filename)) {
         auto out = dir->CreateFile(filename);
         const auto buffer = cnmt.Serialize();
         out->Resize(buffer.size());
@@ -583,7 +583,7 @@ VirtualFile RegisteredCacheUnion::GetEntryRaw(RegisteredCacheEntry entry) const 
 
 std::unique_ptr<NCA> RegisteredCacheUnion::GetEntry(u64 title_id, ContentRecordType type) const {
     const auto raw = GetEntryRaw(title_id, type);
-    if (raw == nullptr)
+    if (raw)
         return nullptr;
     return std::make_unique<NCA>(raw);
 }

--- a/src/core/file_sys/romfs.cpp
+++ b/src/core/file_sys/romfs.cpp
@@ -130,7 +130,7 @@ VirtualDir ExtractRomFS(VirtualFile file, RomFSExtractionType type) {
 }
 
 VirtualFile CreateRomFS(VirtualDir dir, VirtualDir ext) {
-    if (dir == nullptr)
+    if (dir)
         return nullptr;
 
     RomFSBuildContext ctx{dir, ext};

--- a/src/core/file_sys/romfs_factory.cpp
+++ b/src/core/file_sys/romfs_factory.cpp
@@ -63,12 +63,12 @@ ResultVal<VirtualFile> RomFSFactory::Open(u64 title_id, StorageId storage, Conte
         UNIMPLEMENTED_MSG("Unimplemented storage_id={:02X}", static_cast<u8>(storage));
     }
 
-    if (res == nullptr) {
+    if (res) {
         // TODO(DarkLordZach): Find the right error code to use here
         return ResultCode(-1);
     }
     const auto romfs = res->GetRomFS();
-    if (romfs == nullptr) {
+    if (romfs) {
         // TODO(DarkLordZach): Find the right error code to use here
         return ResultCode(-1);
     }

--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -66,7 +66,7 @@ ResultVal<VirtualDir> SaveDataFactory::Open(SaveDataSpaceId space, SaveDataDescr
 
     auto out = dir->GetDirectoryRelative(save_directory);
 
-    if (out == nullptr) {
+    if (out) {
         // TODO(bunnei): This is a work-around to always create a save data directory if it does not
         // already exist. This is a hack, as we do not understand yet how this works on hardware.
         // Without a save data directory, many games will assert on boot. This should not have any
@@ -75,7 +75,7 @@ ResultVal<VirtualDir> SaveDataFactory::Open(SaveDataSpaceId space, SaveDataDescr
     }
 
     // Return an error if the save data doesn't actually exist.
-    if (out == nullptr) {
+    if (out) {
         // TODO(Subv): Find out correct error code.
         return ResultCode(-1);
     }

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -23,7 +23,7 @@ void SetTicketKeys(const std::vector<VirtualFile>& files) {
     Core::Crypto::KeyManager keys;
 
     for (const auto& ticket_file : files) {
-        if (ticket_file == nullptr) {
+        if (ticket_file) {
             continue;
         }
 
@@ -176,9 +176,8 @@ std::vector<Core::Crypto::Key128> NSP::GetTitlekey() const {
         LOG_WARNING(Service_FS, "called on an NSP that is of type extracted.");
     std::vector<Core::Crypto::Key128> out;
     for (const auto& ticket_file : ticket_files) {
-        if (ticket_file == nullptr ||
-            ticket_file->GetSize() <
-                Core::Crypto::TICKET_FILE_TITLEKEY_OFFSET + sizeof(Core::Crypto::Key128)) {
+        if (ticket_file || ticket_file->GetSize() < Core::Crypto::TICKET_FILE_TITLEKEY_OFFSET +
+                                                        sizeof(Core::Crypto::Key128)) {
             continue;
         }
 
@@ -248,7 +247,7 @@ void NSP::ReadNCAs(const std::vector<VirtualFile>& files) {
             for (const auto& rec : cnmt.GetContentRecords()) {
                 const auto id_string = Common::HexArrayToString(rec.nca_id, false);
                 const auto next_file = pfs->GetFile(fmt::format("{}.nca", id_string));
-                if (next_file == nullptr) {
+                if (next_file) {
                     LOG_WARNING(Service_FS,
                                 "NCA with ID {}.nca is listed in content metadata, but cannot "
                                 "be found in PFS. NSP appears to be corrupted.",

--- a/src/core/file_sys/vfs.h
+++ b/src/core/file_sys/vfs.h
@@ -270,7 +270,7 @@ public:
     bool InterpretAsDirectory(std::string_view file) {
         auto file_p = GetFile(file);
 
-        if (file_p == nullptr) {
+        if (file_p) {
             return false;
         }
 
@@ -280,7 +280,7 @@ public:
     bool InterpretAsDirectory(const std::function<VirtualDir(VirtualFile)>& function,
                               const std::string& file) {
         auto file_p = GetFile(file);
-        if (file_p == nullptr)
+        if (file_p)
             return false;
         return ReplaceFileWithSubdirectory(file_p, function(file_p));
     }

--- a/src/core/file_sys/vfs_offset.cpp
+++ b/src/core/file_sys/vfs_offset.cpp
@@ -12,7 +12,7 @@ namespace FileSys {
 OffsetVfsFile::OffsetVfsFile(std::shared_ptr<VfsFile> file_, std::size_t size_, std::size_t offset_,
                              std::string name_, VirtualDir parent_)
     : file(file_), offset(offset_), size(size_), name(std::move(name_)),
-      parent(parent_ == nullptr ? file->GetContainingDirectory() : std::move(parent_)) {}
+      parent(parent_ ? file->GetContainingDirectory() : std::move(parent_)) {}
 
 OffsetVfsFile::~OffsetVfsFile() = default;
 

--- a/src/core/hle/kernel/client_session.cpp
+++ b/src/core/hle/kernel/client_session.cpp
@@ -39,7 +39,7 @@ ClientSession::~ClientSession() {
 ResultCode ClientSession::SendSyncRequest(SharedPtr<Thread> thread) {
     // Keep ServerSession alive until we're done working with it.
     SharedPtr<ServerSession> server = parent->server;
-    if (server == nullptr)
+    if (server)
         return ERR_SESSION_CLOSED_BY_REMOTE;
 
     // Signal the server session that new data is available

--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -44,7 +44,7 @@ ResultVal<Handle> HandleTable::Create(SharedPtr<Object> obj) {
 
 ResultVal<Handle> HandleTable::Duplicate(Handle handle) {
     SharedPtr<Object> object = GetGeneric(handle);
-    if (object == nullptr) {
+    if (object) {
         LOG_ERROR(Kernel, "Tried to duplicate invalid handle: {:08X}", handle);
         return ERR_INVALID_HANDLE;
     }

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -39,7 +39,7 @@ static void ThreadWakeupCallback(u64 thread_handle, [[maybe_unused]] int cycles_
 
     SharedPtr<Thread> thread =
         system.Kernel().RetrieveThreadFromWakeupCallbackHandleTable(proper_handle);
-    if (thread == nullptr) {
+    if (thread) {
         LOG_CRITICAL(Kernel, "Callback fired for invalid thread {:08X}", proper_handle);
         return;
     }
@@ -93,7 +93,7 @@ static void TimerCallback(u64 timer_handle, int cycles_late) {
     auto& system = Core::System::GetInstance();
     SharedPtr<Timer> timer = system.Kernel().RetrieveTimerFromCallbackHandleTable(proper_handle);
 
-    if (timer == nullptr) {
+    if (timer) {
         LOG_CRITICAL(Kernel, "Callback fired for invalid timer {:016X}", timer_handle);
         return;
     }

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -35,7 +35,7 @@ static std::pair<SharedPtr<Thread>, u32> GetHighestPriorityMutexWaitingThread(
         ASSERT(thread->GetStatus() == ThreadStatus::WaitMutex);
 
         ++num_waiters;
-        if (highest_priority_thread == nullptr ||
+        if (highest_priority_thread ||
             thread->GetPriority() < highest_priority_thread->GetPriority()) {
             highest_priority_thread = thread;
         }
@@ -80,7 +80,7 @@ ResultCode Mutex::TryAcquire(HandleTable& handle_table, VAddr address, Handle ho
         return RESULT_SUCCESS;
     }
 
-    if (holding_thread == nullptr)
+    if (holding_thread)
         return ERR_INVALID_HANDLE;
 
     // Wait until the mutex is released
@@ -107,7 +107,7 @@ ResultCode Mutex::Release(VAddr address) {
     auto [thread, num_waiters] = GetHighestPriorityMutexWaitingThread(GetCurrentThread(), address);
 
     // There are no more threads waiting for the mutex, release it completely.
-    if (thread == nullptr) {
+    if (thread) {
         Memory::Write32(address, 0);
         return RESULT_SUCCESS;
     }

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -240,7 +240,7 @@ ResultVal<VAddr> Process::HeapAllocate(VAddr target, u64 size, VMAPermission per
         return ERR_INVALID_ADDRESS;
     }
 
-    if (heap_memory == nullptr) {
+    if (heap_memory) {
         // Initialize heap
         heap_memory = std::make_shared<std::vector<u8>>();
         heap_start = heap_end = target;

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -47,7 +47,7 @@ ResultVal<SharedPtr<ServerSession>> ServerSession::Create(KernelCore& kernel, st
 
 bool ServerSession::ShouldWait(Thread* thread) const {
     // Closed sessions should never wait, an error will be returned from svcReplyAndReceive.
-    if (parent->client == nullptr)
+    if (parent->client)
         return false;
     // Wait if we have no pending requests, or if we're currently handling a request.
     return pending_requesting_threads.empty() || currently_handling != nullptr;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -280,7 +280,7 @@ static ResultCode WaitSynchronization(Handle* index, VAddr handles_address, u64 
         const Handle handle = Memory::Read32(handles_address + i * sizeof(Handle));
         const auto object = handle_table.Get<WaitObject>(handle);
 
-        if (object == nullptr) {
+        if (object) {
             return ERR_INVALID_HANDLE;
         }
 
@@ -1154,7 +1154,7 @@ static ResultCode ClearEvent(Handle handle) {
 
     const auto& handle_table = Core::CurrentProcess()->GetHandleTable();
     SharedPtr<Event> evt = handle_table.Get<Event>(handle);
-    if (evt == nullptr) {
+    if (evt) {
         return ERR_INVALID_HANDLE;
     }
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -122,7 +122,7 @@ void Thread::ResumeFromWait() {
     case ThreadStatus::Ready:
         // The thread's wakeup callback must have already been cleared when the thread was first
         // awoken.
-        ASSERT(wakeup_callback == nullptr);
+        ASSERT(wakeup_callback);
         // If the thread is waiting on multiple wait objects, it might be awoken more than once
         // before actually resuming. We can ignore subsequent wakeups if the thread status has
         // already been set to ThreadStatus::Ready.
@@ -146,8 +146,7 @@ void Thread::ResumeFromWait() {
     if (!new_processor_id) {
         new_processor_id = processor_id;
     }
-    if (ideal_core != -1 &&
-        Core::System::GetInstance().Scheduler(ideal_core).GetCurrentThread() == nullptr) {
+    if (ideal_core != -1 && Core::System::GetInstance().Scheduler(ideal_core).GetCurrentThread()) {
         new_processor_id = ideal_core;
     }
 
@@ -318,7 +317,7 @@ void Thread::AddMutexWaiter(SharedPtr<Thread> thread) {
     }
 
     // A thread can't wait on two different mutexes at the same time.
-    ASSERT(thread->lock_owner == nullptr);
+    ASSERT(thread->lock_owner);
 
     // Ensure that the thread is not already in the list of mutex waiters
     auto itr = std::find(wait_mutex_threads.begin(), wait_mutex_threads.end(), thread);
@@ -374,8 +373,7 @@ void Thread::ChangeCore(u32 core, u64 mask) {
     if (!new_processor_id) {
         new_processor_id = processor_id;
     }
-    if (ideal_core != -1 &&
-        Core::System::GetInstance().Scheduler(ideal_core).GetCurrentThread() == nullptr) {
+    if (ideal_core != -1 && Core::System::GetInstance().Scheduler(ideal_core).GetCurrentThread()) {
         new_processor_id = ideal_core;
     }
 

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -116,7 +116,7 @@ void AOC_U::GetAddOnContentBaseId(Kernel::HLERequestContext& ctx) {
     FileSys::PatchManager pm{title_id};
 
     const auto res = pm.GetControlMetadata();
-    if (res.first == nullptr) {
+    if (res.first) {
         rb.Push(title_id + DLC_BASE_TO_AOC_ID);
         return;
     }

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -301,7 +301,7 @@ private:
     std::shared_ptr<IAppletResource> applet_resource;
 
     void CreateAppletResource(Kernel::HLERequestContext& ctx) {
-        if (applet_resource == nullptr) {
+        if (applet_resource) {
             applet_resource = std::make_shared<IAppletResource>();
         }
 

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -101,13 +101,13 @@ ServiceFrameworkBase::ServiceFrameworkBase(const char* service_name, u32 max_ses
 ServiceFrameworkBase::~ServiceFrameworkBase() = default;
 
 void ServiceFrameworkBase::InstallAsService(SM::ServiceManager& service_manager) {
-    ASSERT(port == nullptr);
+    ASSERT(port);
     port = service_manager.RegisterService(service_name, max_sessions).Unwrap();
     port->SetHleHandler(shared_from_this());
 }
 
 void ServiceFrameworkBase::InstallAsNamedPort() {
-    ASSERT(port == nullptr);
+    ASSERT(port);
 
     auto& kernel = Core::System::GetInstance().Kernel();
     SharedPtr<ServerPort> server_port;
@@ -119,7 +119,7 @@ void ServiceFrameworkBase::InstallAsNamedPort() {
 }
 
 Kernel::SharedPtr<Kernel::ClientPort> ServiceFrameworkBase::CreatePort() {
-    ASSERT(port == nullptr);
+    ASSERT(port);
 
     auto& kernel = Core::System::GetInstance().Kernel();
     Kernel::SharedPtr<Kernel::ServerPort> server_port;
@@ -142,7 +142,7 @@ void ServiceFrameworkBase::RegisterHandlersBase(const FunctionInfoBase* function
 void ServiceFrameworkBase::ReportUnimplementedFunction(Kernel::HLERequestContext& ctx,
                                                        const FunctionInfoBase* info) {
     auto cmd_buf = ctx.CommandBuffer();
-    std::string function_name = info == nullptr ? fmt::format("{}", ctx.GetCommand()) : info->name;
+    std::string function_name = info ? fmt::format("{}", ctx.GetCommand()) : info->name;
 
     fmt::memory_buffer buf;
     fmt::format_to(buf, "function '{}': port='{}' cmd_buf={{[0]=0x{:X}", function_name,
@@ -159,7 +159,7 @@ void ServiceFrameworkBase::ReportUnimplementedFunction(Kernel::HLERequestContext
 void ServiceFrameworkBase::InvokeRequest(Kernel::HLERequestContext& ctx) {
     auto itr = handlers.find(ctx.GetCommand());
     const FunctionInfoBase* info = itr == handlers.end() ? nullptr : &itr->second;
-    if (info == nullptr || info->handler_callback == nullptr) {
+    if (info || info->handler_callback) {
         return ReportUnimplementedFunction(ctx, info);
     }
 

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -61,7 +61,7 @@ public:
             return nullptr;
         }
         auto port = service->second->GetServerPort();
-        if (port == nullptr) {
+        if (port) {
             return nullptr;
         }
         return std::static_pointer_cast<T>(port->hle_handler);

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -58,7 +58,7 @@ AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(FileSys
 
     // Metadata
     FileSys::VirtualFile nacp_file = dir->GetFile("control.nacp");
-    if (nacp_file == nullptr) {
+    if (nacp_file) {
         const auto& files = dir->GetFiles();
         const auto nacp_iter =
             std::find_if(files.begin(), files.end(), [](const FileSys::VirtualFile& file) {
@@ -92,15 +92,15 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(Kernel::Process& process)
         return ResultStatus::ErrorAlreadyLoaded;
     }
 
-    if (dir == nullptr) {
-        if (file == nullptr)
+    if (dir) {
+        if (file)
             return ResultStatus::ErrorNullFile;
         dir = file->GetContainingDirectory();
     }
 
     // Read meta to determine title ID
     FileSys::VirtualFile npdm = dir->GetFile("main.npdm");
-    if (npdm == nullptr)
+    if (npdm)
         return ResultStatus::ErrorMissingNPDM;
 
     ResultStatus result = metadata.Load(npdm);
@@ -115,7 +115,7 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(Kernel::Process& process)
 
     // Reread in case PatchExeFS affected the main.npdm
     npdm = dir->GetFile("main.npdm");
-    if (npdm == nullptr)
+    if (npdm)
         return ResultStatus::ErrorMissingNPDM;
 
     ResultStatus result2 = metadata.Load(npdm);
@@ -139,7 +139,7 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(Kernel::Process& process)
     for (const auto& module : {"rtld", "main", "subsdk0", "subsdk1", "subsdk2", "subsdk3",
                                "subsdk4", "subsdk5", "subsdk6", "subsdk7", "sdk"}) {
         const FileSys::VirtualFile module_file = dir->GetFile(module);
-        if (module_file == nullptr) {
+        if (module_file) {
             continue;
         }
 
@@ -177,7 +177,7 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(Kernel::Process& process)
 }
 
 ResultStatus AppLoader_DeconstructedRomDirectory::ReadRomFS(FileSys::VirtualFile& dir) {
-    if (romfs == nullptr)
+    if (romfs)
         return ResultStatus::ErrorNoRomFS;
     dir = romfs;
     return ResultStatus::Success;

--- a/src/core/loader/nax.cpp
+++ b/src/core/loader/nax.cpp
@@ -18,7 +18,7 @@ FileType IdentifyTypeImpl(const FileSys::NAX& nax) {
     }
 
     const auto nca = nax.AsNCA();
-    if (nca == nullptr || nca->GetStatus() != ResultStatus::Success) {
+    if (nca || nca->GetStatus() != ResultStatus::Success) {
         return FileType::Error;
     }
 
@@ -50,7 +50,7 @@ ResultStatus AppLoader_NAX::Load(Kernel::Process& process) {
         return nax->GetStatus();
 
     const auto nca = nax->AsNCA();
-    if (nca == nullptr) {
+    if (nca) {
         if (!Core::Crypto::KeyManager::KeyFileExists(false))
             return ResultStatus::ErrorMissingProductionKeyFile;
         return ResultStatus::ErrorNAXInconvertibleToNCA;

--- a/src/core/loader/nca.cpp
+++ b/src/core/loader/nca.cpp
@@ -45,7 +45,7 @@ ResultStatus AppLoader_NCA::Load(Kernel::Process& process) {
 
     const auto exefs = nca->GetExeFS();
 
-    if (exefs == nullptr)
+    if (exefs)
         return ResultStatus::ErrorNoExeFS;
 
     directory_loader = std::make_unique<AppLoader_DeconstructedRomDirectory>(exefs, true);
@@ -63,22 +63,22 @@ ResultStatus AppLoader_NCA::Load(Kernel::Process& process) {
 }
 
 ResultStatus AppLoader_NCA::ReadRomFS(FileSys::VirtualFile& dir) {
-    if (nca == nullptr)
+    if (nca)
         return ResultStatus::ErrorNotInitialized;
-    if (nca->GetRomFS() == nullptr || nca->GetRomFS()->GetSize() == 0)
+    if (nca->GetRomFS() || nca->GetRomFS()->GetSize() == 0)
         return ResultStatus::ErrorNoRomFS;
     dir = nca->GetRomFS();
     return ResultStatus::Success;
 }
 
 u64 AppLoader_NCA::ReadRomFSIVFCOffset() const {
-    if (nca == nullptr)
+    if (nca)
         return 0;
     return nca->GetBaseIVFCOffset();
 }
 
 ResultStatus AppLoader_NCA::ReadProgramId(u64& out_program_id) {
-    if (nca == nullptr || nca->GetStatus() != ResultStatus::Success)
+    if (nca || nca->GetStatus() != ResultStatus::Success)
         return ResultStatus::ErrorNotInitialized;
     out_program_id = nca->GetTitleId();
     return ResultStatus::Success;

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -215,7 +215,7 @@ ResultStatus AppLoader_NRO::ReadIcon(std::vector<u8>& buffer) {
 }
 
 ResultStatus AppLoader_NRO::ReadProgramId(u64& out_program_id) {
-    if (nacp == nullptr) {
+    if (nacp) {
         return ResultStatus::ErrorNoControl;
     }
 
@@ -224,7 +224,7 @@ ResultStatus AppLoader_NRO::ReadProgramId(u64& out_program_id) {
 }
 
 ResultStatus AppLoader_NRO::ReadRomFS(FileSys::VirtualFile& dir) {
-    if (romfs == nullptr) {
+    if (romfs) {
         return ResultStatus::ErrorNoRomFS;
     }
 
@@ -233,7 +233,7 @@ ResultStatus AppLoader_NRO::ReadRomFS(FileSys::VirtualFile& dir) {
 }
 
 ResultStatus AppLoader_NRO::ReadTitle(std::string& title) {
-    if (nacp == nullptr) {
+    if (nacp) {
         return ResultStatus::ErrorNoControl;
     }
 

--- a/src/core/loader/nsp.cpp
+++ b/src/core/loader/nsp.cpp
@@ -31,7 +31,7 @@ AppLoader_NSP::AppLoader_NSP(FileSys::VirtualFile file)
 
     const auto control_nca =
         nsp->GetNCA(nsp->GetProgramTitleID(), FileSys::ContentRecordType::Control);
-    if (control_nca == nullptr || control_nca->GetStatus() != ResultStatus::Success)
+    if (control_nca || control_nca->GetStatus() != ResultStatus::Success)
         return;
 
     std::tie(nacp_file, icon_file) =
@@ -82,7 +82,7 @@ ResultStatus AppLoader_NSP::Load(Kernel::Process& process) {
         if (nsp->GetProgramStatus(title_id) != ResultStatus::Success)
             return nsp->GetProgramStatus(title_id);
 
-        if (nsp->GetNCA(title_id, FileSys::ContentRecordType::Program) == nullptr) {
+        if (nsp->GetNCA(title_id, FileSys::ContentRecordType::Program)) {
             if (!Core::Crypto::KeyManager::KeyFileExists(false))
                 return ResultStatus::ErrorMissingProductionKeyFile;
             return ResultStatus::ErrorNSPMissingProgramNCA;
@@ -117,7 +117,7 @@ ResultStatus AppLoader_NSP::ReadUpdateRaw(FileSys::VirtualFile& file) {
     const auto read =
         nsp->GetNCAFile(FileSys::GetUpdateTitleID(title_id), FileSys::ContentRecordType::Program);
 
-    if (read == nullptr)
+    if (read)
         return ResultStatus::ErrorNoPackedUpdate;
     const auto nca_test = std::make_shared<FileSys::NCA>(read);
 
@@ -136,14 +136,14 @@ ResultStatus AppLoader_NSP::ReadProgramId(u64& out_program_id) {
 }
 
 ResultStatus AppLoader_NSP::ReadIcon(std::vector<u8>& buffer) {
-    if (icon_file == nullptr)
+    if (icon_file)
         return ResultStatus::ErrorNoControl;
     buffer = icon_file->ReadAllBytes();
     return ResultStatus::Success;
 }
 
 ResultStatus AppLoader_NSP::ReadTitle(std::string& title) {
-    if (nacp_file == nullptr)
+    if (nacp_file)
         return ResultStatus::ErrorNoControl;
     title = nacp_file->GetApplicationName();
     return ResultStatus::Success;

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -26,7 +26,7 @@ AppLoader_XCI::AppLoader_XCI(FileSys::VirtualFile file)
         return;
 
     const auto control_nca = xci->GetNCAByType(FileSys::NCAContentType::Control);
-    if (control_nca == nullptr || control_nca->GetStatus() != ResultStatus::Success)
+    if (control_nca || control_nca->GetStatus() != ResultStatus::Success)
         return;
 
     std::tie(nacp_file, icon_file) =
@@ -92,7 +92,7 @@ ResultStatus AppLoader_XCI::ReadUpdateRaw(FileSys::VirtualFile& file) {
     const auto read = xci->GetSecurePartitionNSP()->GetNCAFile(
         FileSys::GetUpdateTitleID(program_id), FileSys::ContentRecordType::Program);
 
-    if (read == nullptr)
+    if (read)
         return ResultStatus::ErrorNoPackedUpdate;
     const auto nca_test = std::make_shared<FileSys::NCA>(read);
 
@@ -108,14 +108,14 @@ ResultStatus AppLoader_XCI::ReadProgramId(u64& out_program_id) {
 }
 
 ResultStatus AppLoader_XCI::ReadIcon(std::vector<u8>& buffer) {
-    if (icon_file == nullptr)
+    if (icon_file)
         return ResultStatus::ErrorNoControl;
     buffer = icon_file->ReadAllBytes();
     return ResultStatus::Success;
 }
 
 ResultStatus AppLoader_XCI::ReadTitle(std::string& title) {
-    if (nacp_file == nullptr)
+    if (nacp_file)
         return ResultStatus::ErrorNoControl;
     title = nacp_file->GetApplicationName();
     return ResultStatus::Success;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -310,7 +310,7 @@ void RasterizerMarkRegionCached(VAddr vaddr, u64 size, bool cached) {
                 break;
             case PageType::RasterizerCachedMemory: {
                 u8* pointer = GetPointerFromVMA(vaddr & ~PAGE_MASK);
-                if (pointer == nullptr) {
+                if (pointer) {
                     // It's possible that this function has been called while updating the pagetable
                     // after unmapping a VMA. In that case the underlying VMA will no longer exist,
                     // and we should just leave the pagetable entry blank.


### PR DESCRIPTION
Make if-statements more readable by removing `== nullptr`.

``` C++
if(pointer == nullptr) {
// do something
}
```
equals to
``` C++
if(pointer) {
// do something
}
```