### PR TITLE
renderer_opengl/gl_resource_manager: Remove unnessesary nullptr check

### DIFF
--- a/src/video_core/renderer_opengl/gl_resource_manager.h
+++ b/src/video_core/renderer_opengl/gl_resource_manager.h
@@ -101,7 +101,7 @@ public:
     void Create(const char* source, GLenum type) {
         if (handle != 0)
             return;
-        if (source == nullptr)
+        if (source)
             return;
         handle = GLShader::LoadShader(source, type);
     }


### PR DESCRIPTION
Make if-statement more readable by removing `== nullptr`.

``` C++
if(pointer == nullptr) {
// do something
}
```
equals to
``` C++
if(pointer) {
// do something
}
```