### PR TITLE
core: Remove unnessesary nullptr checks

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -50,11 +50,11 @@ FileSys::VirtualFile GetGameFileFromPath(const FileSys::VirtualFilesystem& vfs,
         std::vector<FileSys::VirtualFile> concat;
         for (u8 i = 0; i < 0x10; ++i) {
             auto next = dir->GetFile(fmt::format("{:02X}", i));
-            if (next != nullptr)
+            if (next)
                 concat.push_back(std::move(next));
             else {
                 next = dir->GetFile(fmt::format("{:02x}", i));
-                if (next != nullptr)
+                if (next)
                     concat.push_back(std::move(next));
                 else
                     break;

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -136,7 +136,7 @@ void ClearPendingEvents() {
 }
 
 void ScheduleEvent(s64 cycles_into_future, const EventType* event_type, u64 userdata) {
-    ASSERT(event_type != nullptr);
+    ASSERT(event_type);
     s64 timeout = GetTicks() + cycles_into_future;
     // If this event needs to be scheduled before the next advance(), force one early
     if (!is_global_timer_sane)

--- a/src/core/crypto/partition_data_manager.cpp
+++ b/src/core/crypto/partition_data_manager.cpp
@@ -294,7 +294,7 @@ FileSys::VirtualFile FindFileInDirWithNames(const FileSys::VirtualDir& dir,
     auto upper = name;
     std::transform(upper.begin(), upper.end(), upper.begin(), [](u8 c) { return std::toupper(c); });
     for (const auto& fname : {name, name + ".bin", upper, upper + ".BIN"}) {
-        if (dir->GetFile(fname) != nullptr)
+        if (dir->GetFile(fname))
             return dir->GetFile(fname);
     }
 
@@ -325,7 +325,7 @@ PartitionDataManager::PartitionDataManager(const FileSys::VirtualDir& sysdata_di
 PartitionDataManager::~PartitionDataManager() = default;
 
 bool PartitionDataManager::HasBoot0() const {
-    return boot0 != nullptr;
+    return boot0;
 }
 
 FileSys::VirtualFile PartitionDataManager::GetBoot0Raw() const {
@@ -400,7 +400,7 @@ std::array<u8, 16> PartitionDataManager::GetKeyblobKeySource(std::size_t revisio
 }
 
 bool PartitionDataManager::HasFuses() const {
-    return fuses != nullptr;
+    return fuses;
 }
 
 FileSys::VirtualFile PartitionDataManager::GetFusesRaw() const {
@@ -416,7 +416,7 @@ std::array<u8, 16> PartitionDataManager::GetSecureBootKey() const {
 }
 
 bool PartitionDataManager::HasKFuses() const {
-    return kfuses != nullptr;
+    return kfuses;
 }
 
 FileSys::VirtualFile PartitionDataManager::GetKFusesRaw() const {
@@ -424,7 +424,7 @@ FileSys::VirtualFile PartitionDataManager::GetKFusesRaw() const {
 }
 
 bool PartitionDataManager::HasPackage2(Package2Type type) const {
-    return package2.at(static_cast<size_t>(type)) != nullptr;
+    return package2.at(static_cast<size_t>(type));
 }
 
 FileSys::VirtualFile PartitionDataManager::GetPackage2Raw(Package2Type type) const {
@@ -571,7 +571,7 @@ std::array<u8, 16> PartitionDataManager::GetAESKeyGenerationSource(Package2Type 
 }
 
 bool PartitionDataManager::HasProdInfo() const {
-    return prodinfo != nullptr;
+    return prodinfo;
 }
 
 FileSys::VirtualFile PartitionDataManager::GetProdInfoRaw() const {
@@ -587,7 +587,7 @@ void PartitionDataManager::DecryptProdInfo(std::array<u8, 0x20> bis_key) {
 
 std::array<u8, 576> PartitionDataManager::GetETicketExtendedKek() const {
     std::array<u8, 0x240> out{};
-    if (prodinfo_decrypted != nullptr)
+    if (prodinfo_decrypted)
         prodinfo_decrypted->Read(out.data(), out.size(), 0x3890);
     return out;
 }

--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -44,7 +44,7 @@ XCI::XCI(VirtualFile file_)
     for (XCIPartition partition :
          {XCIPartition::Update, XCIPartition::Normal, XCIPartition::Secure, XCIPartition::Logo}) {
         auto raw = main_hfs.GetFile(partition_names[static_cast<std::size_t>(partition)]);
-        if (raw != nullptr)
+        if (raw)
             partitions[static_cast<std::size_t>(partition)] =
                 std::make_shared<PartitionFilesystem>(raw);
     }
@@ -123,7 +123,7 @@ u64 XCI::GetProgramTitleID() const {
 }
 
 bool XCI::HasProgramNCA() const {
-    return program != nullptr;
+    return program;
 }
 
 VirtualFile XCI::GetProgramNCAFile() const {
@@ -147,7 +147,7 @@ std::shared_ptr<NCA> XCI::GetNCAByType(NCAContentType type) const {
 
 VirtualFile XCI::GetNCAFileByType(NCAContentType type) const {
     auto nca = GetNCAByType(type);
-    if (nca != nullptr)
+    if (nca)
         return nca->GetBaseFile();
     return nullptr;
 }

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -352,7 +352,7 @@ bool NCA::ReadPFS0Section(const NCASectionHeader& section, const NCASectionTable
     const u64 size = MEDIA_OFFSET_MULTIPLIER * (entry.media_end_offset - entry.media_offset);
 
     auto dec = Decrypt(section, std::make_shared<OffsetVfsFile>(file, size, offset), offset);
-    if (dec != nullptr) {
+    if (dec) {
         auto npfs = std::make_shared<PartitionFilesystem>(std::move(dec));
 
         if (npfs->GetStatus() == Loader::ResultStatus::Success) {

--- a/src/core/file_sys/content_archive.h
+++ b/src/core/file_sys/content_archive.h
@@ -70,7 +70,7 @@ static_assert(sizeof(NCAHeader) == 0x400, "NCAHeader has incorrect size.");
 
 inline bool IsDirectoryExeFS(const std::shared_ptr<VfsDirectory>& pfs) {
     // According to switchbrew, an exefs must only contain these two files:
-    return pfs->GetFile("main") != nullptr && pfs->GetFile("main.npdm") != nullptr;
+    return pfs->GetFile("main") && pfs->GetFile("main.npdm");
 }
 
 // An implementation of VfsDirectory that represents a Nintendo Content Archive (NCA) conatiner.

--- a/src/core/file_sys/fsmitm_romfsbuild.cpp
+++ b/src/core/file_sys/fsmitm_romfsbuild.cpp
@@ -145,7 +145,7 @@ void RomFSBuildContext::VisitDirectory(VirtualDir root_romfs, VirtualDir ext,
             child->path_len = child->cur_path_ofs + static_cast<u32>(kv.first.size());
             child->path = parent->path + "/" + kv.first;
 
-            if (ext != nullptr && ext->GetFileRelative(child->path + ".stub") != nullptr)
+            if (ext && ext->GetFileRelative(child->path + ".stub"))
                 continue;
 
             // Sanity check on path_len
@@ -161,7 +161,7 @@ void RomFSBuildContext::VisitDirectory(VirtualDir root_romfs, VirtualDir ext,
             child->path_len = child->cur_path_ofs + static_cast<u32>(kv.first.size());
             child->path = parent->path + "/" + kv.first;
 
-            if (ext != nullptr && ext->GetFileRelative(child->path + ".stub") != nullptr)
+            if (ext && ext->GetFileRelative(child->path + ".stub"))
                 continue;
 
             // Sanity check on path_len
@@ -169,12 +169,12 @@ void RomFSBuildContext::VisitDirectory(VirtualDir root_romfs, VirtualDir ext,
 
             child->source = root_romfs->GetFileRelative(child->path);
 
-            if (ext != nullptr) {
+            if (ext) {
                 const auto ips = ext->GetFileRelative(child->path + ".ips");
 
-                if (ips != nullptr) {
+                if (ips) {
                     auto patched = PatchIPS(child->source, ips);
-                    if (patched != nullptr)
+                    if (patched)
                         child->source = std::move(patched);
                 }
             }

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -166,7 +166,7 @@ VirtualFile NSP::GetNCAFile(u64 title_id, ContentRecordType type) const {
     if (extracted)
         LOG_WARNING(Service_FS, "called on an NSP that is of type extracted.");
     const auto nca = GetNCA(title_id, type);
-    if (nca != nullptr)
+    if (nca)
         return nca->GetBaseFile();
     return nullptr;
 }

--- a/src/core/file_sys/vfs.cpp
+++ b/src/core/file_sys/vfs.cpp
@@ -31,9 +31,9 @@ bool VfsFilesystem::IsWritable() const {
 
 VfsEntryType VfsFilesystem::GetEntryType(std::string_view path_) const {
     const auto path = FileUtil::SanitizePath(path_);
-    if (root->GetFileRelative(path) != nullptr)
+    if (root->GetFileRelative(path))
         return VfsEntryType::File;
-    if (root->GetDirectoryRelative(path) != nullptr)
+    if (root->GetDirectoryRelative(path))
         return VfsEntryType::Directory;
 
     return VfsEntryType::None;
@@ -65,7 +65,7 @@ VirtualFile VfsFilesystem::CopyFile(std::string_view old_path_, std::string_view
     if (old_file == nullptr)
         return nullptr;
     auto new_file = OpenFile(new_path, Mode::Read);
-    if (new_file != nullptr)
+    if (new_file)
         return nullptr;
     new_file = CreateFile(new_path, Mode::Write);
     if (new_file == nullptr)
@@ -115,7 +115,7 @@ VirtualDir VfsFilesystem::CopyDirectory(std::string_view old_path_, std::string_
     if (old_dir == nullptr)
         return nullptr;
     auto new_dir = OpenDirectory(new_path, Mode::Read);
-    if (new_dir != nullptr)
+    if (new_dir)
         return nullptr;
     new_dir = CreateDirectory(new_path, Mode::Write);
     if (new_dir == nullptr)

--- a/src/core/file_sys/vfs_layered.cpp
+++ b/src/core/file_sys/vfs_layered.cpp
@@ -26,7 +26,7 @@ VirtualDir LayeredVfsDirectory::MakeLayeredDirectory(std::vector<VirtualDir> dir
 std::shared_ptr<VfsFile> LayeredVfsDirectory::GetFileRelative(std::string_view path) const {
     for (const auto& layer : dirs) {
         const auto file = layer->GetFileRelative(path);
-        if (file != nullptr)
+        if (file)
             return file;
     }
 
@@ -38,7 +38,7 @@ std::shared_ptr<VfsDirectory> LayeredVfsDirectory::GetDirectoryRelative(
     std::vector<VirtualDir> out;
     for (const auto& layer : dirs) {
         auto dir = layer->GetDirectoryRelative(path);
-        if (dir != nullptr)
+        if (dir)
             out.push_back(std::move(dir));
     }
 

--- a/src/core/file_sys/vfs_real.cpp
+++ b/src/core/file_sys/vfs_real.cpp
@@ -260,7 +260,7 @@ std::size_t RealVfsFile::Write(const u8* data, std::size_t length, std::size_t o
 }
 
 bool RealVfsFile::Rename(std::string_view name) {
-    return base.MoveFile(path, parent_path + DIR_SEP + std::string(name)) != nullptr;
+    return base.MoveFile(path, parent_path + DIR_SEP + std::string(name));
 }
 
 bool RealVfsFile::Close() {
@@ -404,7 +404,7 @@ bool RealVfsDirectory::DeleteFile(std::string_view name) {
 
 bool RealVfsDirectory::Rename(std::string_view name) {
     const std::string new_name = (parent_path + DIR_SEP).append(name);
-    return base.MoveFile(path, new_name) != nullptr;
+    return base.MoveFile(path, new_name);
 }
 
 std::string RealVfsDirectory::GetFullPath() const {

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -117,7 +117,7 @@ public:
 
         AlignWithPadding();
 
-        const bool request_has_domain_header{context.GetDomainMessageHeader() != nullptr};
+        const bool request_has_domain_header{context.GetDomainMessageHeader()};
         if (context.Session()->IsDomain() && request_has_domain_header) {
             IPC::DomainMessageHeader domain_header{};
             domain_header.num_objects = num_domain_objects;

--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -19,7 +19,7 @@ HandleTable::HandleTable() {
 }
 
 ResultVal<Handle> HandleTable::Create(SharedPtr<Object> obj) {
-    DEBUG_ASSERT(obj != nullptr);
+    DEBUG_ASSERT(obj);
 
     u16 slot = next_free_slot;
     if (slot >= generations.size()) {
@@ -68,7 +68,7 @@ bool HandleTable::IsValid(Handle handle) const {
     std::size_t slot = GetSlot(handle);
     u16 generation = GetGeneration(handle);
 
-    return slot < MAX_COUNT && objects[slot] != nullptr && generations[slot] == generation;
+    return slot < MAX_COUNT && objects[slot] && generations[slot] == generation;
 }
 
 SharedPtr<Object> HandleTable::GetGeneric(Handle handle) const {

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -241,12 +241,12 @@ ResultCode HLERequestContext::WriteToOutgoingCommandBuffer(Thread& thread) {
         // services don't deal with handles directly. However, the guest applications might check
         // for specific values in each of these descriptors.
         for (auto& object : copy_objects) {
-            ASSERT(object != nullptr);
+            ASSERT(object);
             dst_cmdbuf[current_offset++] = handle_table.Create(object).Unwrap();
         }
 
         for (auto& object : move_objects) {
-            ASSERT(object != nullptr);
+            ASSERT(object);
             dst_cmdbuf[current_offset++] = handle_table.Create(object).Unwrap();
         }
     }

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -72,7 +72,7 @@ static void ThreadWakeupCallback(u64 thread_handle, [[maybe_unused]] int cycles_
         // Threads waking up by timeout from WaitProcessWideKey do not perform priority inheritance
         // and don't have a lock owner unless SignalProcessWideKey was called first and the thread
         // wasn't awakened due to the mutex already being acquired.
-        if (lock_owner != nullptr) {
+        if (lock_owner) {
             lock_owner->RemoveMutexWaiter(thread);
         }
     }

--- a/src/core/hle/kernel/object.h
+++ b/src/core/hle/kernel/object.h
@@ -94,7 +94,7 @@ using SharedPtr = boost::intrusive_ptr<T>;
  */
 template <typename T>
 inline SharedPtr<T> DynamicObjectCast(SharedPtr<Object> object) {
-    if (object != nullptr && object->GetHandleType() == T::HANDLE_TYPE) {
+    if (object && object->GetHandleType() == T::HANDLE_TYPE) {
         return boost::static_pointer_cast<T>(object);
     }
     return nullptr;

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -27,7 +27,7 @@ Scheduler::~Scheduler() {
 
 bool Scheduler::HaveReadyThreads() const {
     std::lock_guard<std::mutex> lock(scheduler_mutex);
-    return ready_queue.get_first() != nullptr;
+    return ready_queue.get_first();
 }
 
 Thread* Scheduler::GetCurrentThread() const {

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -50,7 +50,7 @@ bool ServerSession::ShouldWait(Thread* thread) const {
     if (parent->client == nullptr)
         return false;
     // Wait if we have no pending requests, or if we're currently handling a request.
-    return pending_requesting_threads.empty() || currently_handling != nullptr;
+    return pending_requesting_threads.empty() || currently_handling;
 }
 
 void ServerSession::Acquire(Thread* thread) {
@@ -114,7 +114,7 @@ ResultCode ServerSession::HandleSyncRequest(SharedPtr<Thread> thread) {
     if (IsDomain() && context.GetDomainMessageHeader()) {
         result = HandleDomainSyncRequest(context);
         // If there is no domain header, the regular session handler is used
-    } else if (hle_handler != nullptr) {
+    } else if (hle_handler) {
         // If this ServerSession has an associated HLE handler, forward the request to it.
         result = hle_handler->HandleSyncRequest(context);
     }
@@ -124,7 +124,7 @@ ResultCode ServerSession::HandleSyncRequest(SharedPtr<Thread> thread) {
         // svcReplyAndReceive for LLE servers.
         thread->SetStatus(ThreadStatus::WaitIPC);
 
-        if (hle_handler != nullptr) {
+        if (hle_handler) {
             // For HLE services, we put the request threads to sleep for a short duration to
             // simulate IPC overhead, but only if the HLE handler didn't put the thread to sleep for
             // other reasons like an async callback. The IPC overhead is needed to prevent

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -34,7 +34,7 @@ SharedPtr<SharedMemory> SharedMemory::Create(KernelCore& kernel, SharedPtr<Proce
         shared_memory->backing_block_offset = 0;
 
         // Refresh the address mappings for the current process.
-        if (Core::CurrentProcess() != nullptr) {
+        if (Core::CurrentProcess()) {
             Core::CurrentProcess()->VMManager().RefreshMemoryBlockMappings(
                 shared_memory->backing_block.get());
         }

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -931,7 +931,7 @@ static ResultCode SignalProcessWideKey(VAddr condition_variable_addr, s32 target
             thread->ResumeFromWait();
 
             auto* const lock_owner = thread->GetLockOwner();
-            if (lock_owner != nullptr) {
+            if (lock_owner) {
                 lock_owner->RemoveMutexWaiter(thread);
             }
 
@@ -1045,7 +1045,7 @@ static ResultCode ResetSignal(Handle handle) {
     const auto& handle_table = Core::CurrentProcess()->GetHandleTable();
     auto event = handle_table.Get<Event>(handle);
 
-    ASSERT(event != nullptr);
+    ASSERT(event);
 
     event->Clear();
     return RESULT_SUCCESS;

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -334,7 +334,7 @@ public:
     }
 
     bool HasWakeupCallback() const {
-        return wakeup_callback != nullptr;
+        return wakeup_callback;
     }
 
     void SetWakeupCallback(WakeupCallback callback) {

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -91,7 +91,7 @@ ResultVal<VMManager::VMAHandle> VMManager::MapMemoryBlock(VAddr target,
                                                           std::shared_ptr<std::vector<u8>> block,
                                                           std::size_t offset, u64 size,
                                                           MemoryState state) {
-    ASSERT(block != nullptr);
+    ASSERT(block);
     ASSERT(offset + size <= block->size());
 
     // This is the appropriately sized VMA that will turn into our allocation.
@@ -121,7 +121,7 @@ ResultVal<VMManager::VMAHandle> VMManager::MapMemoryBlock(VAddr target,
 
 ResultVal<VMManager::VMAHandle> VMManager::MapBackingMemory(VAddr target, u8* memory, u64 size,
                                                             MemoryState state) {
-    ASSERT(memory != nullptr);
+    ASSERT(memory);
 
     // This is the appropriately sized VMA that will turn into our allocation.
     CASCADE_RESULT(VMAIter vma_handle, CarveVMA(target, size));

--- a/src/core/hle/kernel/wait_object.h
+++ b/src/core/hle/kernel/wait_object.h
@@ -68,7 +68,7 @@ private:
 // Specialization of DynamicObjectCast for WaitObjects
 template <>
 inline SharedPtr<WaitObject> DynamicObjectCast<WaitObject>(SharedPtr<Object> object) {
-    if (object != nullptr && object->IsWaitable()) {
+    if (object && object->IsWaitable()) {
         return boost::static_pointer_cast<WaitObject>(object);
     }
     return nullptr;

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -135,7 +135,7 @@ ResultCode VfsDirectoryServiceWrapper::RenameFile(const std::string& src_path_,
         return c_res;
 
     auto dest = backing->GetFileRelative(dest_path);
-    ASSERT_MSG(dest != nullptr, "Newly created file with success cannot be found.");
+    ASSERT_MSG(dest, "Newly created file with success cannot be found.");
 
     ASSERT_MSG(dest->WriteBytes(src->ReadAllBytes()) == src->GetSize(),
                "Could not write all of the bytes but everything else has succeded.");
@@ -220,9 +220,9 @@ ResultVal<FileSys::EntryType> VfsDirectoryServiceWrapper::GetEntryType(
     if (filename.empty())
         return MakeResult(FileSys::EntryType::Directory);
 
-    if (dir->GetFile(filename) != nullptr)
+    if (dir->GetFile(filename))
         return MakeResult(FileSys::EntryType::File);
-    if (dir->GetSubdirectory(filename) != nullptr)
+    if (dir->GetSubdirectory(filename))
         return MakeResult(FileSys::EntryType::Directory);
     return FileSys::ERROR_PATH_NOT_FOUND;
 }

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -28,7 +28,7 @@ AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(FileSys
 
     // Title ID
     const auto npdm = dir->GetFile("main.npdm");
-    if (npdm != nullptr) {
+    if (npdm) {
         const auto res = metadata.Load(npdm);
         if (res == ResultStatus::Success)
             title_id = metadata.GetTitleID();
@@ -38,7 +38,7 @@ AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(FileSys
     FileSys::VirtualFile icon_file = nullptr;
     for (const auto& language : FileSys::LANGUAGE_NAMES) {
         icon_file = dir->GetFile("icon_" + std::string(language) + ".dat");
-        if (icon_file != nullptr) {
+        if (icon_file) {
             icon_data = icon_file->ReadAllBytes();
             break;
         }
@@ -68,7 +68,7 @@ AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(FileSys
             nacp_file = *nacp_iter;
     }
 
-    if (nacp_file != nullptr) {
+    if (nacp_file) {
         FileSys::NACP nacp(nacp_file);
         name = nacp.GetApplicationName();
     }
@@ -167,7 +167,7 @@ ResultStatus AppLoader_DeconstructedRomDirectory::Load(Kernel::Process& process)
         });
 
     // Register the RomFS if a ".romfs" file was found
-    if (romfs_iter != files.end() && *romfs_iter != nullptr) {
+    if (romfs_iter != files.end() && *romfs_iter) {
         romfs = *romfs_iter;
         Service::FileSystem::RegisterRomFS(std::make_unique<FileSys::RomFSFactory>(*this));
     }

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -351,7 +351,7 @@ SectionID ElfReader::GetSectionByName(const char* name, int firstSection) const 
     for (int i = firstSection; i < header->e_shnum; i++) {
         const char* secname = GetSectionName(i);
 
-        if (secname != nullptr && strcmp(name, secname) == 0)
+        if (secname && strcmp(name, secname) == 0)
             return i;
     }
     return -1;

--- a/src/core/loader/nca.cpp
+++ b/src/core/loader/nca.cpp
@@ -54,7 +54,7 @@ ResultStatus AppLoader_NCA::Load(Kernel::Process& process) {
     if (load_result != ResultStatus::Success)
         return load_result;
 
-    if (nca->GetRomFS() != nullptr && nca->GetRomFS()->GetSize() > 0)
+    if (nca->GetRomFS() && nca->GetRomFS()->GetSize() > 0)
         Service::FileSystem::RegisterRomFS(std::make_unique<FileSys::RomFSFactory>(*this));
 
     is_loaded = true;

--- a/src/core/loader/nsp.cpp
+++ b/src/core/loader/nsp.cpp
@@ -45,14 +45,14 @@ FileType AppLoader_NSP::IdentifyType(const FileSys::VirtualFile& file) {
 
     if (nsp.GetStatus() == ResultStatus::Success) {
         // Extracted Type case
-        if (nsp.IsExtractedType() && nsp.GetExeFS() != nullptr &&
-            FileSys::IsDirectoryExeFS(nsp.GetExeFS()) && nsp.GetRomFS() != nullptr) {
+        if (nsp.IsExtractedType() && nsp.GetExeFS() && FileSys::IsDirectoryExeFS(nsp.GetExeFS()) &&
+            nsp.GetRomFS()) {
             return FileType::NSP;
         }
 
         // Non-Ectracted Type case
         if (!nsp.IsExtractedType() &&
-            nsp.GetNCA(nsp.GetFirstTitleID(), FileSys::ContentRecordType::Program) != nullptr &&
+            nsp.GetNCA(nsp.GetFirstTitleID(), FileSys::ContentRecordType::Program) &&
             AppLoader_NCA::IdentifyType(nsp.GetNCAFile(
                 nsp.GetFirstTitleID(), FileSys::ContentRecordType::Program)) == FileType::NCA) {
             return FileType::NSP;
@@ -94,7 +94,7 @@ ResultStatus AppLoader_NSP::Load(Kernel::Process& process) {
         return result;
 
     FileSys::VirtualFile update_raw;
-    if (ReadUpdateRaw(update_raw) == ResultStatus::Success && update_raw != nullptr)
+    if (ReadUpdateRaw(update_raw) == ResultStatus::Success && update_raw)
         Service::FileSystem::SetPackedUpdate(std::move(update_raw));
 
     is_loaded = true;

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -39,7 +39,7 @@ FileType AppLoader_XCI::IdentifyType(const FileSys::VirtualFile& file) {
     FileSys::XCI xci(file);
 
     if (xci.GetStatus() == ResultStatus::Success &&
-        xci.GetNCAByType(FileSys::NCAContentType::Program) != nullptr &&
+        xci.GetNCAByType(FileSys::NCAContentType::Program) &&
         AppLoader_NCA::IdentifyType(xci.GetNCAFileByType(FileSys::NCAContentType::Program)) ==
             FileType::NCA) {
         return FileType::XCI;
@@ -67,7 +67,7 @@ ResultStatus AppLoader_XCI::Load(Kernel::Process& process) {
         return result;
 
     FileSys::VirtualFile update_raw;
-    if (ReadUpdateRaw(update_raw) == ResultStatus::Success && update_raw != nullptr)
+    if (ReadUpdateRaw(update_raw) == ResultStatus::Success && update_raw)
         Service::FileSystem::SetPackedUpdate(std::move(update_raw));
 
     is_loaded = true;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -70,7 +70,7 @@ static void MapPages(PageTable& page_table, VAddr base, u64 size, u8* memory, Pa
         page_table.pointers[base] = memory;
 
         base += 1;
-        if (memory != nullptr)
+        if (memory)
             memory += PAGE_SIZE;
     }
 }

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -133,7 +133,7 @@ TelemetrySession::TelemetrySession() {
 
         if (name.empty()) {
             auto [nacp, icon_file] = FileSys::PatchManager(program_id).GetControlMetadata();
-            if (nacp != nullptr)
+            if (nacp)
                 name = nacp->GetApplicationName();
         }
 


### PR DESCRIPTION
Make if-statements more readable by removing `!= nullptr`.

``` C++
if(pointer != nullptr) {
// do something
}
```
equals to
``` C++
if(pointer) {
// do something
}
```