### PR TITLE
key_manager: Use isxdigit instead of isdigit when reading key file

### DIFF
--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -395,7 +395,7 @@ static bool ValidCryptoRevisionString(std::string_view base, size_t begin, size_
     if (base.size() < begin + length)
         return false;
     return std::all_of(base.begin() + begin, base.begin() + begin + length,
-                       [](u8 c) { return std::isdigit(c); });
+                       [](u8 c) { return std::isxdigit(c); });
 }
 
 void KeyManager::LoadFromFile(const std::string& filename, bool is_title_keys) {


### PR DESCRIPTION
Crypto revisions are hex numbers and this function only checks if the string is valid for stoul in base 16, so it should be isxdigit.