### PR TITLE
Preliminary implementation of LDG (continuation)

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -30,6 +30,8 @@ add_library(video_core STATIC
     renderer_base.h
     renderer_opengl/gl_buffer_cache.cpp
     renderer_opengl/gl_buffer_cache.h
+    renderer_opengl/gl_global_cache.cpp
+    renderer_opengl/gl_global_cache.h
     renderer_opengl/gl_primitive_assembler.cpp
     renderer_opengl/gl_primitive_assembler.h
     renderer_opengl/gl_rasterizer.cpp

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -319,6 +319,11 @@ void Maxwell3D::DrawArrays() {
     }
 }
 
+bool operator<(const Maxwell3D::GlobalMemoryDescriptor& lhs,
+               const Maxwell3D::GlobalMemoryDescriptor& rhs) {
+    return std::tie(lhs.cbuf_index, lhs.cbuf_offset) < std::tie(rhs.cbuf_index, rhs.cbuf_offset);
+}
+
 void Maxwell3D::ProcessCBBind(Regs::ShaderStage stage) {
     // Bind the buffer currently in CB_ADDRESS to the specified index in the desired shader stage.
     auto& shader = state.shader_stages[static_cast<std::size_t>(stage)];
@@ -466,15 +471,6 @@ Texture::FullTextureInfo Maxwell3D::GetStageTexture(Regs::ShaderStage stage,
     }
 
     return tex_info;
-}
-
-std::string Maxwell3D::CreateGlobalMemoryRegion(std::tuple<u64, u64, u64> iadd_data) {
-    state.global_memory_uniforms.emplace(std::get<1>(iadd_data), std::get<2>(iadd_data));
-    return fmt::format("global_memory_region_{}", state.global_memory_uniforms.size() - 1);
-}
-
-std::set<std::pair<u64, u64>> Maxwell3D::ListGlobalMemoryRegions() const {
-    return state.global_memory_uniforms;
 }
 
 u32 Maxwell3D::GetRegisterValue(u32 method) const {

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -468,6 +468,15 @@ Texture::FullTextureInfo Maxwell3D::GetStageTexture(Regs::ShaderStage stage,
     return tex_info;
 }
 
+std::string Maxwell3D::CreateGlobalMemoryRegion(std::tuple<u64, u64, u64> iadd_data) {
+    state.global_memory_uniforms.emplace(std::get<1>(iadd_data), std::get<2>(iadd_data));
+    return fmt::format("global_memory_region_{}", state.global_memory_uniforms.size() - 1);
+}
+
+std::set<std::pair<u64, u64>> Maxwell3D::ListGlobalMemoryRegions() const {
+    return state.global_memory_uniforms;
+}
+
 u32 Maxwell3D::GetRegisterValue(u32 method) const {
     ASSERT_MSG(method < Regs::NUM_REGS, "Invalid Maxwell3D register");
     return regs.reg_array[method];

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <set>
 #include <unordered_map>
 #include <vector>
 #include "common/assert.h"
@@ -1037,6 +1038,8 @@ public:
 
         std::array<ShaderStageInfo, Regs::MaxShaderStage> shader_stages;
         u32 current_instance = 0; ///< Current instance to be used to simulate instanced rendering.
+
+        std::set<std::pair<u64, u64>> global_memory_uniforms;
     };
 
     State state{};
@@ -1068,6 +1071,9 @@ public:
     const MacroMemory& GetMacroMemory() const {
         return macro_memory;
     }
+
+    std::string CreateGlobalMemoryRegion(std::tuple<u64, u64, u64> iadd_data);
+    std::set<std::pair<u64, u64>> ListGlobalMemoryRegions() const;
 
 private:
     void InitializeRegisterDefaults();

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -32,6 +32,12 @@ public:
     explicit Maxwell3D(VideoCore::RasterizerInterface& rasterizer, MemoryManager& memory_manager);
     ~Maxwell3D() = default;
 
+    /// Structure representing a global memory region
+    struct GlobalMemoryDescriptor {
+        u64 cbuf_index;
+        u64 cbuf_offset;
+    };
+
     /// Register structure of the Maxwell3D engine.
     /// TODO(Subv): This structure will need to be made bigger as more registers are discovered.
     struct Regs {
@@ -1039,7 +1045,7 @@ public:
         std::array<ShaderStageInfo, Regs::MaxShaderStage> shader_stages;
         u32 current_instance = 0; ///< Current instance to be used to simulate instanced rendering.
 
-        std::set<std::pair<u64, u64>> global_memory_uniforms;
+        std::set<GlobalMemoryDescriptor> global_memory_uniforms;
     };
 
     State state{};
@@ -1128,6 +1134,9 @@ private:
     /// Handles a write to the VERTEX_END_GL register, triggering a draw.
     void DrawArrays();
 };
+
+bool operator<(const Maxwell3D::GlobalMemoryDescriptor& lhs,
+               const Maxwell3D::GlobalMemoryDescriptor& rhs);
 
 #define ASSERT_REG_POSITION(field_name, position)                                                  \
     static_assert(offsetof(Maxwell3D::Regs, field_name) == position * 4,                           \

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -1,4 +1,4 @@
-﻿// Copyright 2018 yuzu Emulator Project
+// Copyright 2018 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -208,6 +208,8 @@ enum class UniformType : u64 {
     SignedShort = 3,
     Single = 4,
     Double = 5,
+    Quad = 6,
+    UnsignedQuad = 7,
 };
 
 enum class StoreType : u64 {
@@ -778,6 +780,14 @@ union Instruction {
     union {
         BitField<44, 2, u64> unknown;
     } st_l;
+    
+    union {
+        BitField<48, 3, UniformType> type;
+        BitField<46, 2, u64> cache_mode;
+        BitField<20, 24, s64> offset_immediate;
+        BitField<8, 8, Register> offset_register;
+        BitField<0, 8, Register> output;
+    } ld_g;
 
     union {
         BitField<0, 3, u64> pred0;

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -780,13 +780,11 @@ union Instruction {
     union {
         BitField<44, 2, u64> unknown;
     } st_l;
-    
+
     union {
         BitField<48, 3, UniformType> type;
         BitField<46, 2, u64> cache_mode;
         BitField<20, 24, s64> offset_immediate;
-        BitField<8, 8, Register> offset_register;
-        BitField<0, 8, Register> output;
     } ld_g;
 
     union {

--- a/src/video_core/renderer_opengl/gl_global_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_global_cache.cpp
@@ -29,7 +29,7 @@ GlobalRegionCacheOpenGL::GlobalRegionCacheOpenGL(RasterizerOpenGL& rasterizer)
     : RasterizerCache{rasterizer} {}
 
 GlobalRegion GlobalRegionCacheOpenGL::GetGlobalRegion(
-    Tegra::Engines::Maxwell3D::GlobalMemoryDescriptor global_region,
+    const Tegra::Engines::Maxwell3D::GlobalMemoryDescriptor& global_region,
     Tegra::Engines::Maxwell3D::Regs::ShaderStage stage) {
     auto& gpu{Core::System::GetInstance().GPU()};
     const auto cbufs = gpu.Maxwell3D().state.shader_stages[static_cast<u64>(stage)];

--- a/src/video_core/renderer_opengl/gl_global_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_global_cache.cpp
@@ -1,0 +1,59 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/assert.h"
+#include "core/core.h"
+#include "core/memory.h"
+#include "video_core/engines/maxwell_3d.h"
+#include "video_core/renderer_opengl/gl_global_cache.h"
+#include "video_core/renderer_opengl/gl_rasterizer.h"
+#include "video_core/renderer_opengl/gl_shader_cache.h"
+#include "video_core/renderer_opengl/gl_shader_manager.h"
+#include "video_core/renderer_opengl/utils.h"
+
+namespace OpenGL {
+
+CachedGlobalRegion::CachedGlobalRegion(VAddr addr, u32 size) : addr{addr}, size{size} {
+    std::vector<u8> new_data(size);
+    Memory::ReadBlock(addr, new_data.data(), new_data.size());
+
+    buffer.Create();
+    glBindBuffer(GL_UNIFORM_BUFFER, buffer.handle);
+    glBufferData(GL_UNIFORM_BUFFER, new_data.size(), new_data.data(), GL_STATIC_READ);
+
+    VideoCore::LabelGLObject(GL_BUFFER, buffer.handle, addr);
+}
+
+GlobalRegionCacheOpenGL::GlobalRegionCacheOpenGL(RasterizerOpenGL& rasterizer)
+    : RasterizerCache{rasterizer} {}
+
+GlobalRegion GlobalRegionCacheOpenGL::GetGlobalRegion(
+    Tegra::Engines::Maxwell3D::GlobalMemoryDescriptor global_region,
+    Tegra::Engines::Maxwell3D::Regs::ShaderStage stage) {
+    auto& gpu{Core::System::GetInstance().GPU()};
+    const auto cbufs = gpu.Maxwell3D().state.shader_stages[static_cast<u64>(stage)];
+    const auto cbuf_addr{gpu.MemoryManager().GpuToCpuAddress(
+        cbufs.const_buffers[global_region.cbuf_index].address + global_region.cbuf_offset)};
+
+    ASSERT(cbuf_addr);
+
+    const auto actual_addr_gpu = Memory::Read64(*cbuf_addr);
+    const auto size = Memory::Read32(*cbuf_addr + 8);
+    const auto actual_addr{gpu.MemoryManager().GpuToCpuAddress(actual_addr_gpu)};
+
+    ASSERT(actual_addr);
+
+    // Look up global region in the cache based on address
+    GlobalRegion region{TryGet(*actual_addr)};
+
+    if (!region) {
+        // No global region found - create a new one
+        region = std::make_shared<CachedGlobalRegion>(*actual_addr, size);
+        Register(region);
+    }
+
+    return region;
+}
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_global_cache.h
+++ b/src/video_core/renderer_opengl/gl_global_cache.h
@@ -1,0 +1,60 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <map>
+#include <memory>
+
+#include "common/common_types.h"
+#include "video_core/rasterizer_cache.h"
+#include "video_core/renderer_opengl/gl_resource_manager.h"
+#include "video_core/renderer_opengl/gl_shader_gen.h"
+
+namespace OpenGL {
+
+class RasterizerOpenGL;
+class CachedGlobalRegion;
+using GlobalRegion = std::shared_ptr<CachedGlobalRegion>;
+using Maxwell = Tegra::Engines::Maxwell3D::Regs;
+
+class CachedGlobalRegion final : public RasterizerCacheObject {
+public:
+    CachedGlobalRegion(VAddr addr, u32 size);
+
+    /// Gets the address of the shader in guest memory, required for cache management
+    VAddr GetAddr() const {
+        return addr;
+    }
+
+    /// Gets the size of the shader in guest memory, required for cache management
+    std::size_t GetSizeInBytes() const {
+        return size;
+    }
+
+    /// Gets the GL program handle for the buffer
+    GLuint GetBufferHandle() const {
+        return buffer.handle;
+    }
+
+    // We do not have to flush this cache as things in it are never modified by us.
+    void Flush() override {}
+
+private:
+    VAddr addr;
+    u32 size;
+
+    OGLBuffer buffer;
+};
+
+class GlobalRegionCacheOpenGL final : public RasterizerCache<GlobalRegion> {
+public:
+    explicit GlobalRegionCacheOpenGL(RasterizerOpenGL& rasterizer);
+
+    /// Gets the current specified shader stage program
+    GlobalRegion GetGlobalRegion(Tegra::Engines::Maxwell3D::GlobalMemoryDescriptor descriptor,
+                                 Tegra::Engines::Maxwell3D::Regs::ShaderStage stage);
+};
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_global_cache.h
+++ b/src/video_core/renderer_opengl/gl_global_cache.h
@@ -53,8 +53,9 @@ public:
     explicit GlobalRegionCacheOpenGL(RasterizerOpenGL& rasterizer);
 
     /// Gets the current specified shader stage program
-    GlobalRegion GetGlobalRegion(Tegra::Engines::Maxwell3D::GlobalMemoryDescriptor descriptor,
-                                 Tegra::Engines::Maxwell3D::Regs::ShaderStage stage);
+    GlobalRegion GetGlobalRegion(
+        const Tegra::Engines::Maxwell3D::GlobalMemoryDescriptor& descriptor,
+        Tegra::Engines::Maxwell3D::Regs::ShaderStage stage);
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_global_cache.h
+++ b/src/video_core/renderer_opengl/gl_global_cache.h
@@ -17,7 +17,24 @@ namespace OpenGL {
 class RasterizerOpenGL;
 class CachedGlobalRegion;
 using GlobalRegion = std::shared_ptr<CachedGlobalRegion>;
-using Maxwell = Tegra::Engines::Maxwell3D::Regs;
+
+/// Helper class for caching global region uniform locations
+class CachedGlobalRegionUniform {
+public:
+    CachedGlobalRegionUniform(std::size_t index) : index{index} {}
+
+    std::string GetName() const {
+        return fmt::format("global_memory_region_declblock_{}", index);
+    }
+
+    u32 GetHash() const {
+        // This needs to be unique from ConstBufferEntry::GetHash and SamplerEntry::GetHash
+        return (static_cast<u32>(index) << 16) | 0xFFFF;
+    }
+
+private:
+    std::size_t index{};
+};
 
 class CachedGlobalRegion final : public RasterizerCacheObject {
 public:

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -81,7 +81,7 @@ struct DrawParameters {
 
 RasterizerOpenGL::RasterizerOpenGL(Core::Frontend::EmuWindow& window, ScreenInfo& info)
     : res_cache{*this}, shader_cache{*this}, emu_window{window}, screen_info{info},
-      buffer_cache(*this, STREAM_BUFFER_SIZE) {
+      buffer_cache(*this, STREAM_BUFFER_SIZE), global_cache{*this} {
     // Create sampler objects
     for (std::size_t i = 0; i < texture_samplers.size(); ++i) {
         texture_samplers[i].Create();
@@ -269,7 +269,6 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
     // shaders. The constbuffer bindpoint starts after the shader stage configuration bind points.
     u32 current_constbuffer_bindpoint = Tegra::Engines::Maxwell3D::Regs::MaxShaderStage;
     u32 current_texture_bindpoint = 0;
-    u32 current_global_bindpoint = 0;
 
     for (std::size_t index = 0; index < Maxwell::MaxShaderProgram; ++index) {
         const auto& shader_config = gpu.regs.shader_config[index];
@@ -337,37 +336,19 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
         }
 
         auto& maxwell3d{Core::System::GetInstance().GPU().Maxwell3D()};
-        const auto regions = maxwell3d.ListGlobalMemoryRegions();
+        auto& regions = maxwell3d.state.global_memory_uniforms;
         size_t i = 0;
         for (const auto& global_region : regions) {
-            auto& gpu{Core::System::GetInstance().GPU()};
-            const auto cbufs = gpu.Maxwell3D().state.shader_stages[static_cast<u64>(stage)];
-            const auto cbuf_addr{gpu.MemoryManager().GpuToCpuAddress(
-                cbufs.const_buffers[global_region.first].address + global_region.second)};
-
-            ASSERT(cbuf_addr != boost::none);
-
-            const auto actual_addr_gpu = Memory::Read64(cbuf_addr.get());
-            const auto size = Memory::Read32(cbuf_addr.get() + 8);
-            const auto actual_addr{gpu.MemoryManager().GpuToCpuAddress(actual_addr_gpu)};
-
-            ASSERT(actual_addr != boost::none);
+            const auto region = global_cache.GetGlobalRegion(
+                global_region, static_cast<Maxwell::ShaderStage>(stage));
 
             const auto uniform_name = fmt::format("global_memory_region_declblock_{}", i);
-            const auto b_index = glGetProgramResourceIndex(shader->GetProgramHandle(),
+            const auto b_index = glGetProgramResourceIndex(shader->GetProgramHandle(primitive_mode),
                                                            GL_UNIFORM_BLOCK, uniform_name.c_str());
             if (b_index != GL_INVALID_INDEX) {
-
-                std::vector<u8> new_data(size);
-                Memory::ReadBlock(actual_addr.get(), new_data.data(), new_data.size());
-
-                GLuint gm_ubo{};
-                glGenBuffers(1, &gm_ubo);
-                glBindBuffer(GL_UNIFORM_BUFFER, gm_ubo);
-                glBufferData(GL_UNIFORM_BUFFER, new_data.size(), new_data.data(), GL_STATIC_READ);
-
-                glBindBufferBase(GL_UNIFORM_BUFFER, current_constbuffer_bindpoint, gm_ubo);
-                glUniformBlockBinding(shader->GetProgramHandle(), b_index,
+                glBindBufferBase(GL_UNIFORM_BUFFER, current_constbuffer_bindpoint,
+                                 region->GetBufferHandle());
+                glUniformBlockBinding(shader->GetProgramHandle(primitive_mode), b_index,
                                       current_constbuffer_bindpoint);
                 ++current_constbuffer_bindpoint;
             }
@@ -735,6 +716,7 @@ void RasterizerOpenGL::InvalidateRegion(VAddr addr, u64 size) {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
     res_cache.InvalidateRegion(addr, size);
     shader_cache.InvalidateRegion(addr, size);
+    global_cache.InvalidateRegion(addr, size);
     buffer_cache.InvalidateRegion(addr, size);
 }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -269,6 +269,7 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
     // shaders. The constbuffer bindpoint starts after the shader stage configuration bind points.
     u32 current_constbuffer_bindpoint = Tegra::Engines::Maxwell3D::Regs::MaxShaderStage;
     u32 current_texture_bindpoint = 0;
+    u32 current_global_bindpoint = 0;
 
     for (std::size_t index = 0; index < Maxwell::MaxShaderProgram; ++index) {
         const auto& shader_config = gpu.regs.shader_config[index];
@@ -333,6 +334,45 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
         if (program == Maxwell::ShaderProgram::VertexA) {
             // VertexB was combined with VertexA, so we skip the VertexB iteration
             index++;
+        }
+
+        auto& maxwell3d{Core::System::GetInstance().GPU().Maxwell3D()};
+        const auto regions = maxwell3d.ListGlobalMemoryRegions();
+        size_t i = 0;
+        for (const auto& global_region : regions) {
+            auto& gpu{Core::System::GetInstance().GPU()};
+            const auto cbufs = gpu.Maxwell3D().state.shader_stages[static_cast<u64>(stage)];
+            const auto cbuf_addr{gpu.MemoryManager().GpuToCpuAddress(
+                cbufs.const_buffers[global_region.first].address + global_region.second)};
+
+            ASSERT(cbuf_addr != boost::none);
+
+            const auto actual_addr_gpu = Memory::Read64(cbuf_addr.get());
+            const auto size = Memory::Read32(cbuf_addr.get() + 8);
+            const auto actual_addr{gpu.MemoryManager().GpuToCpuAddress(actual_addr_gpu)};
+
+            ASSERT(actual_addr != boost::none);
+
+            const auto uniform_name = fmt::format("global_memory_region_declblock_{}", i);
+            const auto b_index = glGetProgramResourceIndex(shader->GetProgramHandle(),
+                                                           GL_UNIFORM_BLOCK, uniform_name.c_str());
+            if (b_index != GL_INVALID_INDEX) {
+
+                std::vector<u8> new_data(size);
+                Memory::ReadBlock(actual_addr.get(), new_data.data(), new_data.size());
+
+                GLuint gm_ubo{};
+                glGenBuffers(1, &gm_ubo);
+                glBindBuffer(GL_UNIFORM_BUFFER, gm_ubo);
+                glBufferData(GL_UNIFORM_BUFFER, new_data.size(), new_data.data(), GL_STATIC_READ);
+
+                glBindBufferBase(GL_UNIFORM_BUFFER, current_constbuffer_bindpoint, gm_ubo);
+                glUniformBlockBinding(shader->GetProgramHandle(), b_index,
+                                      current_constbuffer_bindpoint);
+                ++current_constbuffer_bindpoint;
+            }
+
+            ++i;
         }
     }
 }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -267,7 +267,7 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
 
     // Next available bindpoints to use when uploading the const buffers and textures to the GLSL
     // shaders. The constbuffer bindpoint starts after the shader stage configuration bind points.
-    u32 current_constbuffer_bindpoint = Tegra::Engines::Maxwell3D::Regs::MaxShaderStage;
+    u32 current_buffer_bindpoint = Tegra::Engines::Maxwell3D::Regs::MaxShaderStage;
     u32 current_texture_bindpoint = 0;
 
     for (std::size_t index = 0; index < Maxwell::MaxShaderProgram; ++index) {
@@ -321,9 +321,14 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
         }
 
         // Configure the const buffers for this shader stage.
-        current_constbuffer_bindpoint =
+        current_buffer_bindpoint =
             SetupConstBuffers(static_cast<Maxwell::ShaderStage>(stage), shader, primitive_mode,
-                              current_constbuffer_bindpoint);
+                              current_buffer_bindpoint);
+
+        // Configure global memory regions for this shader stage.
+        current_buffer_bindpoint =
+            SetupGlobalRegions(static_cast<Maxwell::ShaderStage>(stage), shader, primitive_mode,
+                               current_buffer_bindpoint);
 
         // Configure the textures for this shader stage.
         current_texture_bindpoint = SetupTextures(static_cast<Maxwell::ShaderStage>(stage), shader,
@@ -333,27 +338,6 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
         if (program == Maxwell::ShaderProgram::VertexA) {
             // VertexB was combined with VertexA, so we skip the VertexB iteration
             index++;
-        }
-
-        auto& maxwell3d{Core::System::GetInstance().GPU().Maxwell3D()};
-        auto& regions = maxwell3d.state.global_memory_uniforms;
-        size_t i = 0;
-        for (const auto& global_region : regions) {
-            const auto region = global_cache.GetGlobalRegion(
-                global_region, static_cast<Maxwell::ShaderStage>(stage));
-
-            const auto uniform_name = fmt::format("global_memory_region_declblock_{}", i);
-            const auto b_index = glGetProgramResourceIndex(shader->GetProgramHandle(primitive_mode),
-                                                           GL_UNIFORM_BLOCK, uniform_name.c_str());
-            if (b_index != GL_INVALID_INDEX) {
-                glBindBufferBase(GL_UNIFORM_BUFFER, current_constbuffer_bindpoint,
-                                 region->GetBufferHandle());
-                glUniformBlockBinding(shader->GetProgramHandle(primitive_mode), b_index,
-                                      current_constbuffer_bindpoint);
-                ++current_constbuffer_bindpoint;
-            }
-
-            ++i;
         }
     }
 }
@@ -939,6 +923,29 @@ u32 RasterizerOpenGL::SetupConstBuffers(Maxwell::ShaderStage stage, Shader& shad
                        bind_buffers.data(), bind_offsets.data(), bind_sizes.data());
 
     return current_bindpoint + static_cast<u32>(entries.size());
+}
+
+u32 RasterizerOpenGL::SetupGlobalRegions(Maxwell::ShaderStage stage, Shader& shader,
+                                         GLenum primitive_mode, u32 current_bindpoint) {
+    std::size_t global_region_index{};
+    const auto& maxwell3d{Core::System::GetInstance().GPU().Maxwell3D()};
+    for (const auto& global_region : maxwell3d.state.global_memory_uniforms) {
+        const auto& region{
+            global_cache.GetGlobalRegion(global_region, static_cast<Maxwell::ShaderStage>(stage))};
+        const GLenum b_index{
+            shader->GetProgramResourceIndex(CachedGlobalRegionUniform{global_region_index})};
+
+        if (b_index != GL_INVALID_INDEX) {
+            glBindBufferBase(GL_UNIFORM_BUFFER, current_bindpoint, region->GetBufferHandle());
+            glUniformBlockBinding(shader->GetProgramHandle(primitive_mode), b_index,
+                                  current_bindpoint);
+            ++current_bindpoint;
+        }
+
+        ++global_region_index;
+    }
+
+    return current_bindpoint;
 }
 
 u32 RasterizerOpenGL::SetupTextures(Maxwell::ShaderStage stage, Shader& shader,

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -23,6 +23,7 @@
 #include "video_core/rasterizer_cache.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/gl_buffer_cache.h"
+#include "video_core/renderer_opengl/gl_global_cache.h"
 #include "video_core/renderer_opengl/gl_primitive_assembler.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
@@ -193,6 +194,7 @@ private:
 
     RasterizerCacheOpenGL res_cache;
     ShaderCacheOpenGL shader_cache;
+    GlobalRegionCacheOpenGL global_cache;
 
     Core::Frontend::EmuWindow& emu_window;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -119,7 +119,7 @@ private:
                                bool using_depth_fb = true, bool preserve_contents = true,
                                std::optional<std::size_t> single_color_target = {});
 
-    /*
+    /**
      * Configures the current constbuffers to use for the draw command.
      * @param stage The shader stage to configure buffers for.
      * @param shader The shader object that contains the specified stage.
@@ -129,7 +129,17 @@ private:
     u32 SetupConstBuffers(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage, Shader& shader,
                           GLenum primitive_mode, u32 current_bindpoint);
 
-    /*
+    /**
+     * Configures the current global memory regions to use for the draw command.
+     * @param stage The shader stage to configure buffers for.
+     * @param shader The shader object that contains the specified stage.
+     * @param current_bindpoint The offset at which to start counting new buffer bindpoints.
+     * @returns The next available bindpoint for use in the next shader stage.
+     */
+    u32 SetupGlobalRegions(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage, Shader& shader,
+                           GLenum primitive_mode, u32 current_bindpoint);
+
+    /**
      * Configures the current textures to use for the draw command.
      * @param stage The shader stage to configure textures for.
      * @param shader The shader object that contains the specified stage.

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -98,18 +98,6 @@ CachedShader::CachedShader(VAddr addr, Maxwell::ShaderProgram program_type)
     }
 }
 
-GLuint CachedShader::GetProgramResourceIndex(const GLShader::ConstBufferEntry& buffer) {
-    const auto search{resource_cache.find(buffer.GetHash())};
-    if (search == resource_cache.end()) {
-        const GLuint index{
-            glGetProgramResourceIndex(program.handle, GL_UNIFORM_BLOCK, buffer.GetName().c_str())};
-        resource_cache[buffer.GetHash()] = index;
-        return index;
-    }
-
-    return search->second;
-}
-
 GLint CachedShader::GetUniformLocation(const GLShader::SamplerEntry& sampler) {
     const auto search{uniform_cache.find(sampler.GetHash())};
     if (search == uniform_cache.end()) {

--- a/src/video_core/renderer_opengl/gl_shader_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_cache.h
@@ -71,7 +71,18 @@ public:
     }
 
     /// Gets the GL program resource location for the specified resource, caching as needed
-    GLuint GetProgramResourceIndex(const GLShader::ConstBufferEntry& buffer);
+    template <typename T>
+    GLuint GetProgramResourceIndex(const T& buffer) {
+        const auto& search{resource_cache.find(buffer.GetHash())};
+        if (search == resource_cache.end()) {
+            const GLuint index{glGetProgramResourceIndex(program.handle, GL_UNIFORM_BLOCK,
+                                                         buffer.GetName().c_str())};
+            resource_cache[buffer.GetHash()] = index;
+            return index;
+        }
+
+        return search->second;
+    }
 
     /// Gets the GL uniform location for the specified resource, caching as needed
     GLint GetUniformLocation(const GLShader::SamplerEntry& sampler);

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -586,6 +586,7 @@ public:
         GenerateInputAttrs();
         GenerateOutputAttrs();
         GenerateConstBuffers();
+        GenerateGlobalRegions();
         GenerateSamplers();
         GenerateGeometry();
     }
@@ -707,9 +708,11 @@ private:
         declarations.AddNewLine();
     }
 
+    /// Generates declarations for global memory regions.
+    void GenerateGlobalRegions() {
         const auto& regions{
-            Core::System::GetInstance().GPU().Maxwell3D().ListGlobalMemoryRegions()};
-        for (size_t i = 0; i < regions.size(); ++i) {
+            Core::System::GetInstance().GPU().Maxwell3D().state.global_memory_uniforms};
+        for (std::size_t i = 0; i < regions.size(); ++i) {
             declarations.AddLine("layout(std140) uniform " +
                                  fmt::format("global_memory_region_declblock_{}", i));
             declarations.AddLine('{');
@@ -718,6 +721,7 @@ private:
             declarations.AddNewLine();
         }
         declarations.AddNewLine();
+    }
 
     /// Generates declarations for samplers.
     void GenerateSamplers() {
@@ -1847,10 +1851,10 @@ private:
                 } else {
                     op_b += regs.GetUniform(instr.cbuf34.index, instr.cbuf34.offset,
                                             GLSLRegister::Type::Integer);
-                    if (opcode->GetId() == OpCode::Id::IADD_C) {
+                    if (opcode->get().GetId() == OpCode::Id::IADD_C) {
                         s_last_iadd = last_iadd;
-                        last_iadd = std::make_tuple<Register, u64, u64>(
-                            instr.gpr8.Value(), instr.cbuf34.index, instr.cbuf34.offset);
+                        last_iadd = IADDReference{instr.gpr8.Value(), instr.cbuf34.index,
+                                                  instr.cbuf34.offset};
                     }
                 }
             }
@@ -3167,29 +3171,37 @@ private:
 
                 // The last IADD might be the upper u32 of address, so instead take the one before
                 // that.
-                if (gpr_index == 0xFF)
-                    std::tie(gpr_index, index, offset) = s_last_iadd;
+                if (gpr_index == Register::ZeroIndex) {
+                    gpr_index = s_last_iadd.out;
+                    index = s_last_iadd.cbuf_index;
+                    offset = s_last_iadd.cbuf_offset;
+                }
 
                 const auto gpr = regs.GetRegisterAsInteger(gpr_index);
                 const auto constbuffer =
                     regs.GetUniform(index, offset, GLSLRegister::Type::UnsignedInteger);
-                const auto memory =
-                    Core::System::GetInstance().GPU().Maxwell3D().CreateGlobalMemoryRegion(
-                        {0, index, offset * 4});
+
+                Core::System::GetInstance().GPU().Maxwell3D().state.global_memory_uniforms.insert(
+                    {index, offset * 4});
+                const auto memory = fmt::format("global_memory_region_{}",
+                                                Core::System::GetInstance()
+                                                        .GPU()
+                                                        .Maxwell3D()
+                                                        .state.global_memory_uniforms.size() -
+                                                    1);
 
                 const auto immediate = std::to_string(instr.ld_g.offset_immediate.Value());
-                const auto o_register =
-                    regs.GetRegisterAsInteger(instr.ld_g.offset_register, 0, false);
+                const auto o_register = regs.GetRegisterAsInteger(instr.gpr8, 0, false);
                 const auto address = "( " + immediate + " + " + o_register + " )";
                 const auto base_sub = address + " - " + constbuffer;
 
                 // New scope to prevent potential conflicts
-                shader.AddLine("{");
+                shader.AddLine('{');
                 ++shader.scope;
 
                 shader.AddLine("uint final_offset = " + base_sub + ";");
                 for (std::size_t out = 0; out < count; ++out) {
-                    const u64 reg_id = instr.ld_g.output.Value() + out;
+                    const u64 reg_id = instr.gpr0.Value() + out;
                     const auto this_memory =
                         fmt::format("{}[(final_offset + {}) / 16][((final_offset + {}) / 4) % 4]",
                                     memory, out * 4, out * 4);
@@ -3198,7 +3210,7 @@ private:
                 }
 
                 --shader.scope;
-                shader.AddLine("}");
+                shader.AddLine('}');
 
                 break;
             }
@@ -3999,8 +4011,14 @@ private:
     ShaderWriter declarations;
     GLSLRegisterManager regs{shader, declarations, stage, suffix, header};
 
-    std::tuple<Register, u64, u64> last_iadd{};
-    std::tuple<Register, u64, u64> s_last_iadd{};
+    struct IADDReference {
+        Register out;
+        u64 cbuf_index;
+        u64 cbuf_offset;
+    };
+
+    IADDReference last_iadd{};
+    IADDReference s_last_iadd{};
 
     // Declarations
     std::set<std::string> declr_predicates;

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -57,7 +57,8 @@ public:
     }
 
     u32 GetHash() const {
-        return (static_cast<u32>(stage) << 16) | index;
+        // This needs to be unique from CachedGlobalRegionUniform::GetHash
+        return (static_cast<u32>(stage) << 12) | index;
     }
 
 private:
@@ -138,7 +139,8 @@ public:
     }
 
     u32 GetHash() const {
-        return (static_cast<u32>(stage) << 16) | static_cast<u32>(sampler_index);
+        // This needs to be unique from CachedGlobalRegionUniform::GetHash
+        return (static_cast<u32>(stage) << 12) | static_cast<u32>(sampler_index);
     }
 
     static std::string GetArrayName(Maxwell::ShaderStage stage) {


### PR DESCRIPTION
This is a continuation of #1323. Since that PR is pretty old, I preferred to open a new one rather than push there.

This is mostly @DarkLordZach's implementation (see #1323 for details), with improvements to performance. The big changes here are:
* Cache uniform locations, as `glGetProgramResourceIndex` is very slow
* Keep global region UBOs long-lived, as constant resource construction/destruction is slow
* Misc. refactoring and cleanup

From my testing, LDG in Super Mario Odyssey now incurs a fairly minimal performance hit, so this should be Canary ready soon. Please test other games!

![image](https://user-images.githubusercontent.com/6956688/47612983-5d2ee180-da5c-11e8-99f8-b2fb9736e9cc.png)

I'm aware that this should probably use SSBOs, but I do not plan on doing that with this change.