### PR TITLE
Port citra-emu/citra#4369: "compatdb: Use a seperate endpoint for testcase submission"

### DIFF
--- a/src/common/telemetry.h
+++ b/src/common/telemetry.h
@@ -153,6 +153,7 @@ struct VisitorInterface : NonCopyable {
 
     /// Completion method, called once all fields have been visited
     virtual void Complete() = 0;
+    virtual bool SubmitTestcase() = 0;
 };
 
 /**
@@ -178,6 +179,9 @@ struct NullVisitor : public VisitorInterface {
     void Visit(const Field<std::chrono::microseconds>& /*field*/) override {}
 
     void Complete() override {}
+    bool SubmitTestcase() override {
+        return false;
+    }
 };
 
 /// Appends build-specific information to the given FieldCollection,

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -184,4 +184,13 @@ TelemetrySession::~TelemetrySession() {
     backend = nullptr;
 }
 
+bool TelemetrySession::SubmitTestcase() {
+#ifdef ENABLE_WEB_SERVICE
+    field_collection.Accept(*backend);
+    return backend->SubmitTestcase();
+#else
+    return false;
+#endif
+}
+
 } // namespace Core

--- a/src/core/telemetry_session.h
+++ b/src/core/telemetry_session.h
@@ -31,6 +31,12 @@ public:
         field_collection.AddField(type, name, std::move(value));
     }
 
+    /**
+     * Submits a Testcase.
+     * @returns A bool indicating whether the submission succeeded
+     */
+    bool SubmitTestcase();
+
 private:
     Telemetry::FieldCollection field_collection; ///< Tracks all added fields for the session
     std::unique_ptr<Telemetry::VisitorInterface> backend; ///< Backend interface that logs fields

--- a/src/web_service/telemetry_json.h
+++ b/src/web_service/telemetry_json.h
@@ -35,6 +35,7 @@ public:
     void Visit(const Telemetry::Field<std::chrono::microseconds>& field) override;
 
     void Complete() override;
+    bool SubmitTestcase() override;
 
 private:
     struct Impl;

--- a/src/yuzu/compatdb.cpp
+++ b/src/yuzu/compatdb.cpp
@@ -5,6 +5,7 @@
 #include <QButtonGroup>
 #include <QMessageBox>
 #include <QPushButton>
+#include <QtConcurrent/qtconcurrentrun.h>
 #include "common/logging/log.h"
 #include "common/telemetry.h"
 #include "core/core.h"
@@ -23,6 +24,8 @@ CompatDB::CompatDB(QWidget* parent)
     connect(ui->radioButton_IntroMenu, &QRadioButton::clicked, this, &CompatDB::EnableNext);
     connect(ui->radioButton_WontBoot, &QRadioButton::clicked, this, &CompatDB::EnableNext);
     connect(button(NextButton), &QPushButton::clicked, this, &CompatDB::Submit);
+    connect(&testcase_watcher, &QFutureWatcher<bool>::finished, this,
+            &CompatDB::OnTestcaseSubmitted);
 }
 
 CompatDB::~CompatDB() = default;
@@ -48,15 +51,35 @@ void CompatDB::Submit() {
         }
         break;
     case CompatDBPage::Final:
+        back();
         LOG_DEBUG(Frontend, "Compatibility Rating: {}", compatibility->checkedId());
         Core::Telemetry().AddField(Telemetry::FieldType::UserFeedback, "Compatibility",
                                    compatibility->checkedId());
-        // older versions of QT don't support the "NoCancelButtonOnLastPage" option, this is a
-        // workaround
+
+        button(NextButton)->setEnabled(false);
+        button(NextButton)->setText(tr("Submitting"));
         button(QWizard::CancelButton)->setVisible(false);
+
+        testcase_watcher.setFuture(QtConcurrent::run(
+            [this]() { return Core::System::GetInstance().TelemetrySession().SubmitTestcase(); }));
         break;
     default:
         LOG_ERROR(Frontend, "Unexpected page: {}", currentId());
+    }
+}
+
+void CompatDB::OnTestcaseSubmitted() {
+    if (!testcase_watcher.result()) {
+        QMessageBox::critical(this, tr("Communication error"),
+                              tr("An error occured while sending the Testcase"));
+        button(NextButton)->setEnabled(true);
+        button(NextButton)->setText(tr("Next"));
+        button(QWizard::CancelButton)->setVisible(true);
+    } else {
+        next();
+        // older versions of QT don't support the "NoCancelButtonOnLastPage" option, this is a
+        // workaround
+        button(QWizard::CancelButton)->setVisible(false);
     }
 }
 

--- a/src/yuzu/compatdb.h
+++ b/src/yuzu/compatdb.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <QFutureWatcher>
 #include <QWizard>
 
 namespace Ui {
@@ -19,8 +20,11 @@ public:
     ~CompatDB();
 
 private:
+    QFutureWatcher<bool> testcase_watcher;
+
     std::unique_ptr<Ui::CompatDB> ui;
 
     void Submit();
+    void OnTestcaseSubmitted();
     void EnableNext();
 };


### PR DESCRIPTION
See citra-emu/citra#4369 for more details.

**Original description:**
This PR switches the endpoint for testcases to `api.citra-emu.org/gamedb/testcase` instead of sending them as part of Telemetry. It also adds basic error handling to the compatdb wizard and shows the user a popup in case submission failed.

It also moves the `Report compatibility` button to the emulation tab. This was done to get more users to submit testcase cause it's way more likely a user will visit this tab, than the help tab. If you've got any opinions on this change, don't hesitate to voice them.