### PR TITLE
Port citra-emu/citra#4382: "configure_general: Add an option to reset defaults"

### DIFF
--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <QMessageBox>
+#include "common/file_util.h"
 #include "core/core.h"
 #include "core/settings.h"
 #include "ui_configure_general.h"
@@ -23,6 +25,9 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
             [] { UISettings::values.is_game_list_reload_pending.exchange(true); });
 
     ui->use_cpu_jit->setEnabled(!Core::System::GetInstance().IsPoweredOn());
+
+    connect(ui->button_reset_defaults, &QPushButton::clicked, this,
+            &ConfigureGeneral::ResetDefaults);
 }
 
 ConfigureGeneral::~ConfigureGeneral() = default;
@@ -33,6 +38,17 @@ void ConfigureGeneral::setConfiguration() {
     ui->toggle_user_on_boot->setChecked(UISettings::values.select_user_on_boot);
     ui->theme_combobox->setCurrentIndex(ui->theme_combobox->findData(UISettings::values.theme));
     ui->use_cpu_jit->setChecked(Settings::values.use_cpu_jit);
+}
+
+void ConfigureGeneral::ResetDefaults() {
+    QMessageBox::StandardButton answer = QMessageBox::question(
+        this, tr("yuzu"),
+        tr("Are you sure you want to <b>reset your settings</b> and close yuzu?"),
+        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+    if (answer == QMessageBox::No)
+        return;
+    FileUtil::Delete(FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + "qt-config.ini");
+    std::exit(0);
 }
 
 void ConfigureGeneral::applyConfiguration() {

--- a/src/yuzu/configuration/configure_general.h
+++ b/src/yuzu/configuration/configure_general.h
@@ -20,6 +20,7 @@ public:
     explicit ConfigureGeneral(QWidget* parent = nullptr);
     ~ConfigureGeneral() override;
 
+    void ResetDefaults();
     void applyConfiguration();
 
 private:

--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -97,6 +97,13 @@
        </layout>
       </widget>
      </item>
+     <item alignment="Qt::AlignRight">
+      <widget class="QPushButton" name="button_reset_defaults">
+       <property name="text">
+        <string>Reset All Settings</string>
+       </property>
+      </widget>
+     </item>
      <item>
       <spacer name="verticalSpacer">
        <property name="orientation">


### PR DESCRIPTION
See citra-emu/citra#4382 for more details.

**Original description:**
I think this change is fairly self-explanatory.

When the button is clicked, the settings file gets deleted and Citra gets closed.

Screenshots:
![unbenannt1](https://user-images.githubusercontent.com/20753089/47609067-83428a80-da38-11e8-9eb9-2f74520c63a6.PNG)
![unbenannt2](https://user-images.githubusercontent.com/20753089/47609068-83db2100-da38-11e8-8c2d-dc0e09a5247d.PNG)