### PR TITLE
Revert "Update MACOSX_DEPLOYMENT_TARGET to 10.14"

### DIFF
--- a/.travis/macos/build.sh
+++ b/.travis/macos/build.sh
@@ -2,7 +2,7 @@
 
 set -o pipefail
 
-export MACOSX_DEPLOYMENT_TARGET=10.14
+export MACOSX_DEPLOYMENT_TARGET=10.13
 export Qt5_DIR=$(brew --prefix)/opt/qt5
 export UNICORNDIR=$(pwd)/externals/unicorn
 export PATH="/usr/local/opt/ccache/libexec:$PATH"


### PR DESCRIPTION
Reverts yuzu-emu/yuzu#1581.
The next time, please be more careful when making such changes or approving them.

[**Reason:**](https://github.com/citra-emu/citra/pull/4385#issuecomment-433700338)
> 
> 
> What features?
> 
> AFAIK 10.14 and 10.13 use XCode 10 and thus the same libs so there is 0 benefit and the drawback of supporting only the most recent OSX version which many users still don't use because it has tons of issues. For yuzu this might be ok since you can't run yuzu on osx anyway, but for Citra i don't like that at all
>Also travis currently does not support building with osx 10.14

