### PR TITLE
[ns|fsp_srv]: Implement various functions to boot Checkpoint

### DIFF
--- a/src/core/file_sys/control_metadata.cpp
+++ b/src/core/file_sys/control_metadata.cpp
@@ -66,4 +66,10 @@ std::string NACP::GetVersionString() const {
     return Common::StringFromFixedZeroTerminatedBuffer(raw->version_string.data(),
                                                        raw->version_string.size());
 }
+
+std::vector<u8> NACP::GetRawBytes() const {
+    std::vector<u8> out(sizeof(RawNACP));
+    std::memcpy(out.data(), raw.get(), sizeof(RawNACP));
+    return out;
+}
 } // namespace FileSys

--- a/src/core/file_sys/control_metadata.h
+++ b/src/core/file_sys/control_metadata.h
@@ -81,6 +81,7 @@ public:
     u64 GetTitleId() const;
     u64 GetDLCBaseTitleId() const;
     std::string GetVersionString() const;
+    std::vector<u8> GetRawBytes() const;
 
 private:
     std::unique_ptr<RawNACP> raw;

--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -83,7 +83,7 @@ ResultVal<VirtualDir> SaveDataFactory::Open(SaveDataSpaceId space, SaveDataDescr
     return MakeResult<VirtualDir>(std::move(out));
 }
 
-VirtualDir SaveDataFactory::GetSaveDataSpaceDirectory(SaveDataSpaceId space) {
+VirtualDir SaveDataFactory::GetSaveDataSpaceDirectory(SaveDataSpaceId space) const {
     return dir->GetDirectoryRelative(GetSaveDataSpaceIdPath(space));
 }
 

--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -83,6 +83,24 @@ ResultVal<VirtualDir> SaveDataFactory::Open(SaveDataSpaceId space, SaveDataDescr
     return MakeResult<VirtualDir>(std::move(out));
 }
 
+VirtualDir SaveDataFactory::GetSaveDataSpaceDirectory(SaveDataSpaceId space) {
+    return dir->GetDirectoryRelative(GetSaveDataSpaceIdPath(space));
+}
+
+std::string SaveDataFactory::GetSaveDataSpaceIdPath(SaveDataSpaceId space) {
+    switch (space) {
+    case SaveDataSpaceId::NandSystem:
+        return "/system/";
+    case SaveDataSpaceId::NandUser:
+        return "/user/";
+    case SaveDataSpaceId::TemporaryStorage:
+        return "/temp/";
+    default:
+        ASSERT_MSG(false, "Unrecognized SaveDataSpaceId: {:02X}", static_cast<u8>(space));
+        return "/unrecognized/"; ///< To prevent corruption when ignoring asserts.
+    }
+}
+
 std::string SaveDataFactory::GetFullPath(SaveDataSpaceId space, SaveDataType type, u64 title_id,
                                          u128 user_id, u64 save_id) {
     // According to switchbrew, if a save is of type SaveData and the title id field is 0, it should
@@ -90,21 +108,7 @@ std::string SaveDataFactory::GetFullPath(SaveDataSpaceId space, SaveDataType typ
     if (type == SaveDataType::SaveData && title_id == 0)
         title_id = Core::CurrentProcess()->GetTitleID();
 
-    std::string out;
-
-    switch (space) {
-    case SaveDataSpaceId::NandSystem:
-        out = "/system/";
-        break;
-    case SaveDataSpaceId::NandUser:
-        out = "/user/";
-        break;
-    case SaveDataSpaceId::TemporaryStorage:
-        out = "/temp/";
-        break;
-    default:
-        ASSERT_MSG(false, "Unrecognized SaveDataSpaceId: {:02X}", static_cast<u8>(space));
-    }
+    std::string out = GetSaveDataSpaceIdPath(space);
 
     switch (type) {
     case SaveDataType::SystemSaveData:

--- a/src/core/file_sys/savedata_factory.h
+++ b/src/core/file_sys/savedata_factory.h
@@ -52,7 +52,7 @@ public:
 
     ResultVal<VirtualDir> Open(SaveDataSpaceId space, SaveDataDescriptor meta);
 
-    VirtualDir GetSaveDataSpaceDirectory(SaveDataSpaceId space);
+    VirtualDir GetSaveDataSpaceDirectory(SaveDataSpaceId space) const;
 
     static std::string GetSaveDataSpaceIdPath(SaveDataSpaceId space);
     static std::string GetFullPath(SaveDataSpaceId space, SaveDataType type, u64 title_id,

--- a/src/core/file_sys/savedata_factory.h
+++ b/src/core/file_sys/savedata_factory.h
@@ -52,6 +52,9 @@ public:
 
     ResultVal<VirtualDir> Open(SaveDataSpaceId space, SaveDataDescriptor meta);
 
+    VirtualDir GetSaveDataSpaceDirectory(SaveDataSpaceId space);
+
+    static std::string GetSaveDataSpaceIdPath(SaveDataSpaceId space);
     static std::string GetFullPath(SaveDataSpaceId space, SaveDataType type, u64 title_id,
                                    u128 user_id, u64 save_id);
 

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -309,6 +309,16 @@ ResultVal<FileSys::VirtualDir> OpenSaveData(FileSys::SaveDataSpaceId space,
     return save_data_factory->Open(space, save_struct);
 }
 
+ResultVal<FileSys::VirtualDir> OpenSaveDataSpace(FileSys::SaveDataSpaceId space) {
+    LOG_TRACE(Service_FS, "Opening Save Data Space for space_id={:01X}", static_cast<u8>(space));
+
+    if (save_data_factory == nullptr) {
+        return ResultCode(ErrorModule::FS, FileSys::ErrCodes::TitleNotFound);
+    }
+
+    return MakeResult(save_data_factory->GetSaveDataSpaceDirectory(space));
+}
+
 ResultVal<FileSys::VirtualDir> OpenSDMC() {
     LOG_TRACE(Service_FS, "Opening SDMC");
 

--- a/src/core/hle/service/filesystem/filesystem.h
+++ b/src/core/hle/service/filesystem/filesystem.h
@@ -45,6 +45,7 @@ ResultVal<FileSys::VirtualFile> OpenRomFS(u64 title_id, FileSys::StorageId stora
                                           FileSys::ContentRecordType type);
 ResultVal<FileSys::VirtualDir> OpenSaveData(FileSys::SaveDataSpaceId space,
                                             FileSys::SaveDataDescriptor save_struct);
+ResultVal<FileSys::VirtualDir> OpenSaveDataSpace(FileSys::SaveDataSpaceId space);
 ResultVal<FileSys::VirtualDir> OpenSDMC();
 
 std::unique_ptr<FileSys::RegisteredCacheUnion> GetUnionContents();

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -452,6 +452,7 @@ private:
 };
 
 FSP_SRV::FSP_SRV() : ServiceFramework("fsp-srv") {
+    // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "MountContent"},
         {1, &FSP_SRV::Initialize, "Initialize"},
@@ -485,7 +486,7 @@ FSP_SRV::FSP_SRV() : ServiceFramework("fsp-srv") {
         {58, nullptr, "ReadSaveDataFileSystemExtraData"},
         {59, nullptr, "WriteSaveDataFileSystemExtraData"},
         {60, nullptr, "OpenSaveDataInfoReader"},
-        {61, nullptr, "OpenSaveDataInfoReaderBySaveDataSpaceId"},
+        {61, &FSP_SRV::OpenSaveDataInfoReaderBySaveDataSpaceId, "OpenSaveDataInfoReaderBySaveDataSpaceId"},
         {62, nullptr, "OpenCacheStorageList"},
         {64, nullptr, "OpenSaveDataInternalStorageFileSystem"},
         {65, nullptr, "UpdateSaveDataMacForDebug"},
@@ -544,6 +545,7 @@ FSP_SRV::FSP_SRV() : ServiceFramework("fsp-srv") {
         {1009, nullptr, "GetAndClearMemoryReportInfo"},
         {1100, nullptr, "OverrideSaveDataTransferTokenSignVerificationKey"},
     };
+    // clang-format on
     RegisterHandlers(functions);
 }
 
@@ -616,6 +618,15 @@ void FSP_SRV::MountSaveData(Kernel::HLERequestContext& ctx) {
 void FSP_SRV::OpenReadOnlySaveDataFileSystem(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_FS, "(STUBBED) called, delegating to 51 OpenSaveDataFilesystem");
     MountSaveData(ctx);
+}
+
+void FSP_SRV::OpenSaveDataInfoReaderBySaveDataSpaceId(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto space = rp.PopRaw<FileSys::SaveDataSpaceId>();
+
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    rb.Push(RESULT_SUCCESS);
+    rb.PushIpcInterface<ISaveDataInfoReader>(std::make_shared<ISaveDataInfoReader>(space));
 }
 
 void FSP_SRV::GetGlobalAccessLogMode(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/filesystem/fsp_srv.h
+++ b/src/core/hle/service/filesystem/fsp_srv.h
@@ -25,6 +25,7 @@ private:
     void CreateSaveData(Kernel::HLERequestContext& ctx);
     void MountSaveData(Kernel::HLERequestContext& ctx);
     void OpenReadOnlySaveDataFileSystem(Kernel::HLERequestContext& ctx);
+    void OpenSaveDataInfoReaderBySaveDataSpaceId(Kernel::HLERequestContext& ctx);
     void GetGlobalAccessLogMode(Kernel::HLERequestContext& ctx);
     void OpenDataStorageByCurrentProcess(Kernel::HLERequestContext& ctx);
     void OpenDataStorageByDataId(Kernel::HLERequestContext& ctx);

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -12,10 +12,12 @@
 #include "common/swap.h"
 #include "core/core.h"
 #include "core/file_sys/control_metadata.h"
+#include "core/file_sys/romfs_factory.h"
 #include "core/file_sys/vfs_offset.h"
 #include "core/gdbstub/gdbstub.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/vm_manager.h"
+#include "core/hle/service/filesystem/filesystem.h"
 #include "core/loader/nro.h"
 #include "core/loader/nso.h"
 #include "core/memory.h"
@@ -207,6 +209,9 @@ ResultStatus AppLoader_NRO::Load(Kernel::Process& process) {
     if (!LoadNro(*file, base_address)) {
         return ResultStatus::ErrorLoadingNRO;
     }
+
+    if (romfs != nullptr)
+        Service::FileSystem::RegisterRomFS(std::make_unique<FileSys::RomFSFactory>(*this));
 
     process.Run(base_address, Kernel::THREADPRIO_DEFAULT, Memory::DEFAULT_STACK_SIZE);
 


### PR DESCRIPTION
This includes:
- `fsp_srv` 61: `OpenSaveDataInfoReaderBySaveDataSpaceId` - This returns an object capable of iterating over the currently present saves on the system.
- `fsp_srv` `ISaveDataInfoReader`: The aforementioned iterator object -- I implemented it by iterating over all of the directories in the SaveDataSpace (i.e. /nand/user/save) and filling a vector of SaveDataInfo objects using the directory data.
- `fsp_srv` `ISaveDataInfoReader` 0: `ReadSaveDataInfo` - Reads a game-provided number of entries from the total, resuming where left off between successive calls.
- `ns:am` 400: `GetApplicationControlData` - This returns the raw NACP and icon bytes given the title ID. The data source of this for this implementation is the registration cache (installed titles).

Finally, some basic tests to ensure the backup/restore functionality worked were conducted. Thanks to #1598, it works perfectly.

Screenshot:
![checkpoint1](https://user-images.githubusercontent.com/5064800/47620729-0c52d380-dac4-11e8-8c5e-005e40971c35.PNG)
