### PR TITLE
core: Add missing const variants of getters for the System class

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -312,6 +312,10 @@ Cpu& System::CurrentCpuCore() {
     return impl->CurrentCpuCore();
 }
 
+const Cpu& System::CurrentCpuCore() const {
+    return impl->CurrentCpuCore();
+}
+
 System::ResultStatus System::RunLoop(bool tight_loop) {
     return impl->RunLoop(tight_loop);
 }
@@ -342,7 +346,11 @@ PerfStatsResults System::GetAndResetPerfStats() {
     return impl->GetAndResetPerfStats();
 }
 
-Core::TelemetrySession& System::TelemetrySession() const {
+TelemetrySession& System::TelemetrySession() {
+    return *impl->telemetry_session;
+}
+
+const TelemetrySession& System::TelemetrySession() const {
     return *impl->telemetry_session;
 }
 
@@ -350,11 +358,19 @@ ARM_Interface& System::CurrentArmInterface() {
     return CurrentCpuCore().ArmInterface();
 }
 
-std::size_t System::CurrentCoreIndex() {
+const ARM_Interface& System::CurrentArmInterface() const {
+    return CurrentCpuCore().ArmInterface();
+}
+
+std::size_t System::CurrentCoreIndex() const {
     return CurrentCpuCore().CoreIndex();
 }
 
 Kernel::Scheduler& System::CurrentScheduler() {
+    return CurrentCpuCore().Scheduler();
+}
+
+const Kernel::Scheduler& System::CurrentScheduler() const {
     return CurrentCpuCore().Scheduler();
 }
 
@@ -378,6 +394,10 @@ ARM_Interface& System::ArmInterface(std::size_t core_index) {
     return CpuCore(core_index).ArmInterface();
 }
 
+const ARM_Interface& System::ArmInterface(std::size_t core_index) const {
+    return CpuCore(core_index).ArmInterface();
+}
+
 Cpu& System::CpuCore(std::size_t core_index) {
     ASSERT(core_index < NUM_CPU_CORES);
     return *impl->cpu_cores[core_index];
@@ -389,6 +409,10 @@ const Cpu& System::CpuCore(std::size_t core_index) const {
 }
 
 ExclusiveMonitor& System::Monitor() {
+    return *impl->cpu_exclusive_monitor;
+}
+
+const ExclusiveMonitor& System::Monitor() const {
     return *impl->cpu_exclusive_monitor;
 }
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -129,11 +129,11 @@ public:
      */
     bool IsPoweredOn() const;
 
-    /**
-     * Returns a reference to the telemetry session for this emulation session.
-     * @returns Reference to the telemetry session.
-     */
-    Core::TelemetrySession& TelemetrySession() const;
+    /// Gets a reference to the telemetry session for this emulation session.
+    Core::TelemetrySession& TelemetrySession();
+
+    /// Gets a reference to the telemetry session for this emulation session.
+    const Core::TelemetrySession& TelemetrySession() const;
 
     /// Prepare the core emulation for a reschedule
     void PrepareReschedule();
@@ -144,14 +144,23 @@ public:
     /// Gets an ARM interface to the CPU core that is currently running
     ARM_Interface& CurrentArmInterface();
 
+    /// Gets an ARM interface to the CPU core that is currently running
+    const ARM_Interface& CurrentArmInterface() const;
+
     /// Gets the index of the currently running CPU core
-    std::size_t CurrentCoreIndex();
+    std::size_t CurrentCoreIndex() const;
 
     /// Gets the scheduler for the CPU core that is currently running
     Kernel::Scheduler& CurrentScheduler();
 
-    /// Gets an ARM interface to the CPU core with the specified index
+    /// Gets the scheduler for the CPU core that is currently running
+    const Kernel::Scheduler& CurrentScheduler() const;
+
+    /// Gets a reference to an ARM interface for the CPU core with the specified index
     ARM_Interface& ArmInterface(std::size_t core_index);
+
+    /// Gets a const reference to an ARM interface from the CPU core with the specified index
+    const ARM_Interface& ArmInterface(std::size_t core_index) const;
 
     /// Gets a CPU interface to the CPU core with the specified index
     Cpu& CpuCore(std::size_t core_index);
@@ -159,8 +168,11 @@ public:
     /// Gets a CPU interface to the CPU core with the specified index
     const Cpu& CpuCore(std::size_t core_index) const;
 
-    /// Gets the exclusive monitor
+    /// Gets a reference to the exclusive monitor
     ExclusiveMonitor& Monitor();
+
+    /// Gets a constant reference to the exclusive monitor
+    const ExclusiveMonitor& Monitor() const;
 
     /// Gets a mutable reference to the GPU interface
     Tegra::GPU& GPU();
@@ -229,6 +241,9 @@ private:
 
     /// Returns the currently running CPU core
     Cpu& CurrentCpuCore();
+
+    /// Returns the currently running CPU core
+    const Cpu& CurrentCpuCore() const;
 
     /**
      * Initialize the emulated system.

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -32,7 +32,7 @@ namespace Kernel {
  */
 static void ThreadWakeupCallback(u64 thread_handle, [[maybe_unused]] int cycles_late) {
     const auto proper_handle = static_cast<Handle>(thread_handle);
-    auto& system = Core::System::GetInstance();
+    const auto& system = Core::System::GetInstance();
 
     // Lock the global kernel mutex when we enter the kernel HLE.
     std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
@@ -90,7 +90,7 @@ static void ThreadWakeupCallback(u64 thread_handle, [[maybe_unused]] int cycles_
 /// The timer callback event, called when a timer is fired
 static void TimerCallback(u64 timer_handle, int cycles_late) {
     const auto proper_handle = static_cast<Handle>(timer_handle);
-    auto& system = Core::System::GetInstance();
+    const auto& system = Core::System::GetInstance();
     SharedPtr<Timer> timer = system.Kernel().RetrieveTimerFromCallbackHandleTable(proper_handle);
 
     if (timer == nullptr) {

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -572,7 +572,7 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
             return ERR_INVALID_HANDLE;
         }
 
-        auto& system = Core::System::GetInstance();
+        const auto& system = Core::System::GetInstance();
         const auto& scheduler = system.CurrentScheduler();
         const auto* const current_thread = scheduler.GetCurrentThread();
         const bool same_thread = current_thread == thread;


### PR DESCRIPTION
Many of the Current<Thing> getters (as well as a few others) were missing const qualified variants, which makes it a pain to retrieve certain things from const qualified references to System.

Makes the interface a little more complete for different scenarios