### PR TITLE
video_core: Move OpenGL specific utils to its renderer

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -51,6 +51,8 @@ add_library(video_core STATIC
     renderer_opengl/maxwell_to_gl.h
     renderer_opengl/renderer_opengl.cpp
     renderer_opengl/renderer_opengl.h
+    renderer_opengl/utils.cpp
+    renderer_opengl/utils.h
     textures/astc.cpp
     textures/astc.h
     textures/decoders.cpp

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -16,6 +16,7 @@
 #include "core/settings.h"
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
+#include "video_core/renderer_opengl/utils.h"
 #include "video_core/textures/astc.h"
 #include "video_core/textures/decoders.h"
 #include "video_core/utils.h"
@@ -865,8 +866,8 @@ CachedSurface::CachedSurface(const SurfaceParams& params)
     glTexParameteri(SurfaceTargetToGL(params.target), GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
     glTexParameteri(SurfaceTargetToGL(params.target), GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-    VideoCore::LabelGLObject(GL_TEXTURE, texture.handle, params.addr,
-                             SurfaceParams::SurfaceTargetName(params.target));
+    LabelGLObject(GL_TEXTURE, texture.handle, params.addr,
+                  SurfaceParams::SurfaceTargetName(params.target));
 
     // Clamp size to mapped GPU memory region
     // TODO(bunnei): Super Mario Odyssey maps a 0x40000 byte region and then uses it for a 0x80000

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -8,6 +8,7 @@
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/renderer_opengl/gl_shader_cache.h"
 #include "video_core/renderer_opengl/gl_shader_manager.h"
+#include "video_core/renderer_opengl/utils.h"
 #include "video_core/utils.h"
 
 namespace OpenGL {
@@ -89,7 +90,7 @@ CachedShader::CachedShader(VAddr addr, Maxwell::ShaderProgram program_type)
         shader.Create(program_result.first.c_str(), gl_type);
         program.Create(true, shader.handle);
         SetShaderUniformBlockBindings(program.handle);
-        VideoCore::LabelGLObject(GL_PROGRAM, program.handle, addr);
+        LabelGLObject(GL_PROGRAM, program.handle, addr);
     } else {
         // Store shader's code to lazily build it on draw
         geometry_programs.code = program_result.first;
@@ -130,7 +131,7 @@ GLuint CachedShader::LazyGeometryProgram(OGLProgram& target_program,
     shader.Create(source.c_str(), GL_GEOMETRY_SHADER);
     target_program.Create(true, shader.handle);
     SetShaderUniformBlockBindings(target_program.handle);
-    VideoCore::LabelGLObject(GL_PROGRAM, target_program.handle, addr, debug_name);
+    LabelGLObject(GL_PROGRAM, target_program.handle, addr, debug_name);
     return target_program.handle;
 };
 

--- a/src/video_core/renderer_opengl/utils.cpp
+++ b/src/video_core/renderer_opengl/utils.cpp
@@ -1,0 +1,38 @@
+// Copyright 2014 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <string>
+#include <fmt/format.h>
+#include <glad/glad.h>
+#include "common/common_types.h"
+#include "video_core/renderer_opengl/utils.h"
+
+namespace OpenGL {
+
+void LabelGLObject(GLenum identifier, GLuint handle, VAddr addr, std::string extra_info) {
+    if (!GLAD_GL_KHR_debug) {
+        return; // We don't need to throw an error as this is just for debugging
+    }
+    const std::string nice_addr = fmt::format("0x{:016x}", addr);
+    std::string object_label;
+
+    if (extra_info.empty()) {
+        switch (identifier) {
+        case GL_TEXTURE:
+            object_label = "Texture@" + nice_addr;
+            break;
+        case GL_PROGRAM:
+            object_label = "Shader@" + nice_addr;
+            break;
+        default:
+            object_label = fmt::format("Object(0x{:x})@{}", identifier, nice_addr);
+            break;
+        }
+    } else {
+        object_label = extra_info + '@' + nice_addr;
+    }
+    glObjectLabel(identifier, handle, -1, static_cast<const GLchar*>(object_label.c_str()));
+}
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/utils.h
+++ b/src/video_core/renderer_opengl/utils.h
@@ -1,0 +1,15 @@
+// Copyright 2014 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+#include <glad/glad.h>
+#include "common/common_types.h"
+
+namespace OpenGL {
+
+void LabelGLObject(GLenum identifier, GLuint handle, VAddr addr, std::string extra_info = "");
+
+} // namespace OpenGL

--- a/src/video_core/utils.h
+++ b/src/video_core/utils.h
@@ -161,30 +161,4 @@ static inline void MortonCopyPixels128(u32 width, u32 height, u32 bytes_per_pixe
     }
 }
 
-static void LabelGLObject(GLenum identifier, GLuint handle, VAddr addr,
-                          std::string extra_info = "") {
-    if (!GLAD_GL_KHR_debug) {
-        return; // We don't need to throw an error as this is just for debugging
-    }
-    const std::string nice_addr = fmt::format("0x{:016x}", addr);
-    std::string object_label;
-
-    if (extra_info.empty()) {
-        switch (identifier) {
-        case GL_TEXTURE:
-            object_label = "Texture@" + nice_addr;
-            break;
-        case GL_PROGRAM:
-            object_label = "Shader@" + nice_addr;
-            break;
-        default:
-            object_label = fmt::format("Object(0x{:x})@{}", identifier, nice_addr);
-            break;
-        }
-    } else {
-        object_label = extra_info + '@' + nice_addr;
-    }
-    glObjectLabel(identifier, handle, -1, static_cast<const GLchar*>(object_label.c_str()));
-}
-
 } // namespace VideoCore


### PR DESCRIPTION
`video_core/utils.h` had OpenGL-specific code that depended on `glad/glad.h` (which was not included). Instead of adding it, which also poluted the symbols, a new file for those utils was created.