### PR TITLE
configure_system: Contrain profile usernames to 32 characters

### DIFF
--- a/src/core/hle/service/acc/profile_manager.h
+++ b/src/core/hle/service/acc/profile_manager.h
@@ -57,7 +57,8 @@ struct UUID {
 };
 static_assert(sizeof(UUID) == 16, "UUID is an invalid size!");
 
-using ProfileUsername = std::array<u8, 0x20>;
+constexpr std::size_t profile_username_size = 32;
+using ProfileUsername = std::array<u8, profile_username_size>;
 using ProfileData = std::array<u8, MAX_DATA>;
 using UserIDArray = std::array<UUID, MAX_USERS>;
 

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -56,6 +56,8 @@ add_executable(yuzu
     main.h
     ui_settings.cpp
     ui_settings.h
+    util/limitable_input_dialog.cpp
+    util/limitable_input_dialog.h
     util/spinbox.cpp
     util/spinbox.h
     util/util.cpp

--- a/src/yuzu/util/limitable_input_dialog.cpp
+++ b/src/yuzu/util/limitable_input_dialog.cpp
@@ -1,0 +1,59 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <QDialogButtonBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QPushButton>
+#include <QVBoxLayout>
+#include "yuzu/util/limitable_input_dialog.h"
+
+LimitableInputDialog::LimitableInputDialog(QWidget* parent) : QDialog{parent} {
+    CreateUI();
+    ConnectEvents();
+}
+
+LimitableInputDialog::~LimitableInputDialog() = default;
+
+void LimitableInputDialog::CreateUI() {
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
+    text_label = new QLabel(this);
+    text_entry = new QLineEdit(this);
+    buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
+
+    auto* const layout = new QVBoxLayout;
+    layout->addWidget(text_label);
+    layout->addWidget(text_entry);
+    layout->addWidget(buttons);
+
+    setLayout(layout);
+}
+
+void LimitableInputDialog::ConnectEvents() {
+    connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+}
+
+QString LimitableInputDialog::GetText(QWidget* parent, const QString& title, const QString& text,
+                                      int min_character_limit, int max_character_limit) {
+    Q_ASSERT(min_character_limit <= max_character_limit);
+
+    LimitableInputDialog dialog{parent};
+    dialog.setWindowTitle(title);
+    dialog.text_label->setText(text);
+    dialog.text_entry->setMaxLength(max_character_limit);
+
+    auto* const ok_button = dialog.buttons->button(QDialogButtonBox::Ok);
+    ok_button->setEnabled(false);
+    connect(dialog.text_entry, &QLineEdit::textEdited, [&](const QString& new_text) {
+        ok_button->setEnabled(new_text.length() >= min_character_limit);
+    });
+
+    if (dialog.exec() != QDialog::Accepted) {
+        return {};
+    }
+
+    return dialog.text_entry->text();
+}

--- a/src/yuzu/util/limitable_input_dialog.h
+++ b/src/yuzu/util/limitable_input_dialog.h
@@ -1,0 +1,31 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+
+class QDialogButtonBox;
+class QLabel;
+class QLineEdit;
+
+/// A QDialog that functions similarly to QInputDialog, however, it allows
+/// restricting the minimum and total number of characters that can be entered.
+class LimitableInputDialog final : public QDialog {
+    Q_OBJECT
+public:
+    explicit LimitableInputDialog(QWidget* parent = nullptr);
+    ~LimitableInputDialog() override;
+
+    static QString GetText(QWidget* parent, const QString& title, const QString& text,
+                           int min_character_limit, int max_character_limit);
+
+private:
+    void CreateUI();
+    void ConnectEvents();
+
+    QLabel* text_label;
+    QLineEdit* text_entry;
+    QDialogButtonBox* buttons;
+};


### PR DESCRIPTION
Previously, we would let a user enter an unbounded name and then silently truncate away characters that went over the 32-character limit. This is kind of bad from the UX point of view, because we're essentially not doing what the user intended in certain scenarios.

Instead, we clamp it to 32 characters and make that visually apparent in the dialog box to provide a name for a user.