### PR TITLE
 hle_ipc: Make GetDomainMessageHeader return a regular pointer

### DIFF
--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -117,8 +117,7 @@ public:
 
         AlignWithPadding();
 
-        const bool request_has_domain_header{context.GetDomainMessageHeader() != nullptr};
-        if (context.Session()->IsDomain() && request_has_domain_header) {
+        if (context.Session()->IsDomain() && context.HasDomainMessageHeader()) {
             IPC::DomainMessageHeader domain_header{};
             domain_header.num_objects = num_domain_objects;
             PushRaw(domain_header);

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -165,6 +165,10 @@ public:
         return domain_message_header.get();
     }
 
+    bool HasDomainMessageHeader() const {
+        return domain_message_header != nullptr;
+    }
+
     /// Helper function to read a buffer using the appropriate buffer descriptor
     std::vector<u8> ReadBuffer(int buffer_index = 0) const;
 

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -161,8 +161,8 @@ public:
         return buffer_c_desciptors;
     }
 
-    const std::shared_ptr<IPC::DomainMessageHeader>& GetDomainMessageHeader() const {
-        return domain_message_header;
+    const IPC::DomainMessageHeader* GetDomainMessageHeader() const {
+        return domain_message_header.get();
     }
 
     /// Helper function to read a buffer using the appropriate buffer descriptor

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -63,7 +63,7 @@ void ServerSession::Acquire(Thread* thread) {
 }
 
 ResultCode ServerSession::HandleDomainSyncRequest(Kernel::HLERequestContext& context) {
-    auto& domain_message_header = context.GetDomainMessageHeader();
+    auto* const domain_message_header = context.GetDomainMessageHeader();
     if (domain_message_header) {
         // Set domain handlers in HLE context, used for domain objects (IPC interfaces) as inputs
         context.SetDomainRequestHandlers(domain_request_handlers);

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -111,7 +111,7 @@ ResultCode ServerSession::HandleSyncRequest(SharedPtr<Thread> thread) {
 
     ResultCode result = RESULT_SUCCESS;
     // If the session has been converted to a domain, handle the domain request
-    if (IsDomain() && context.GetDomainMessageHeader()) {
+    if (IsDomain() && context.HasDomainMessageHeader()) {
         result = HandleDomainSyncRequest(context);
         // If there is no domain header, the regular session handler is used
     } else if (hle_handler != nullptr) {


### PR DESCRIPTION
A fairly trivial change. We don't need shared ownership semantics here.