### PR TITLE
game_list: Optimize game list refresh

### DIFF
--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -176,7 +176,7 @@ Loader::ResultStatus XCI::AddNCAFromPartition(XCIPartition part) {
     for (const VirtualFile& file : partitions[static_cast<std::size_t>(part)]->GetFiles()) {
         if (file->GetExtension() != "nca")
             continue;
-        auto nca = std::make_shared<NCA>(file);
+        auto nca = std::make_shared<NCA>(file, nullptr, 0, keys);
         // TODO(DarkLordZach): Add proper Rev1+ Support
         if (nca->IsUpdate())
             continue;

--- a/src/core/file_sys/card_image.h
+++ b/src/core/file_sys/card_image.h
@@ -9,6 +9,7 @@
 #include <vector>
 #include "common/common_types.h"
 #include "common/swap.h"
+#include "core/crypto/key_manager.h"
 #include "core/file_sys/vfs.h"
 
 namespace Loader {
@@ -107,5 +108,7 @@ private:
     std::shared_ptr<NSP> secure_partition;
     std::shared_ptr<NCA> program;
     std::vector<std::shared_ptr<NCA>> ncas;
+
+    Core::Crypto::KeyManager keys;
 };
 } // namespace FileSys

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -101,8 +101,9 @@ static bool IsValidNCA(const NCAHeader& header) {
     return header.magic == Common::MakeMagic('N', 'C', 'A', '3');
 }
 
-NCA::NCA(VirtualFile file_, VirtualFile bktr_base_romfs_, u64 bktr_base_ivfc_offset)
-    : file(std::move(file_)), bktr_base_romfs(std::move(bktr_base_romfs_)) {
+NCA::NCA(VirtualFile file_, VirtualFile bktr_base_romfs_, u64 bktr_base_ivfc_offset,
+         Core::Crypto::KeyManager keys_)
+    : file(std::move(file_)), bktr_base_romfs(std::move(bktr_base_romfs_)), keys(std::move(keys_)) {
     if (file == nullptr) {
         status = Loader::ResultStatus::ErrorNullFile;
         return;

--- a/src/core/file_sys/content_archive.h
+++ b/src/core/file_sys/content_archive.h
@@ -79,7 +79,8 @@ inline bool IsDirectoryExeFS(const std::shared_ptr<VfsDirectory>& pfs) {
 class NCA : public ReadOnlyVfsDirectory {
 public:
     explicit NCA(VirtualFile file, VirtualFile bktr_base_romfs = nullptr,
-                 u64 bktr_base_ivfc_offset = 0);
+                 u64 bktr_base_ivfc_offset = 0,
+                 Core::Crypto::KeyManager keys = Core::Crypto::KeyManager());
     ~NCA() override;
 
     Loader::ResultStatus GetStatus() const;

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -106,9 +106,12 @@ static ContentRecordType GetCRTypeFromNCAType(NCAContentType type) {
 
 VirtualFile RegisteredCache::OpenFileOrDirectoryConcat(const VirtualDir& dir,
                                                        std::string_view path) const {
-    if (dir->GetFileRelative(path) != nullptr)
-        return dir->GetFileRelative(path);
-    if (dir->GetDirectoryRelative(path) != nullptr) {
+    const auto file = dir->GetFileRelative(path);
+    if (file != nullptr)
+        return file;
+
+    const auto nca_dir = dir->GetDirectoryRelative(path);
+    if (nca_dir != nullptr) {
         const auto nca_dir = dir->GetDirectoryRelative(path);
         VirtualFile file = nullptr;
 
@@ -225,7 +228,7 @@ void RegisteredCache::ProcessFiles(const std::vector<NcaID>& ids) {
 
         if (file == nullptr)
             continue;
-        const auto nca = std::make_shared<NCA>(parser(file, id));
+        const auto nca = std::make_shared<NCA>(parser(file, id), nullptr, 0, keys);
         if (nca->GetStatus() != Loader::ResultStatus::Success ||
             nca->GetType() != NCAContentType::Meta) {
             continue;
@@ -315,7 +318,7 @@ std::unique_ptr<NCA> RegisteredCache::GetEntry(u64 title_id, ContentRecordType t
     const auto raw = GetEntryRaw(title_id, type);
     if (raw == nullptr)
         return nullptr;
-    return std::make_unique<NCA>(raw);
+    return std::make_unique<NCA>(raw, nullptr, 0, keys);
 }
 
 std::unique_ptr<NCA> RegisteredCache::GetEntry(RegisteredCacheEntry entry) const {

--- a/src/core/file_sys/registered_cache.h
+++ b/src/core/file_sys/registered_cache.h
@@ -12,6 +12,7 @@
 #include <vector>
 #include <boost/container/flat_map.hpp>
 #include "common/common_types.h"
+#include "core/crypto/key_manager.h"
 #include "core/file_sys/vfs.h"
 
 namespace FileSys {
@@ -133,6 +134,8 @@ private:
 
     VirtualDir dir;
     RegisteredCacheParsingFunction parser;
+    Core::Crypto::KeyManager keys;
+
     // maps tid -> NcaID of meta
     boost::container::flat_map<u64, NcaID> meta_id;
     // maps tid -> meta

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -252,7 +252,7 @@ void NSP::ReadNCAs(const std::vector<VirtualFile>& files) {
                     continue;
                 }
 
-                auto next_nca = std::make_shared<NCA>(next_file);
+                auto next_nca = std::make_shared<NCA>(next_file, nullptr, 0, keys);
                 if (next_nca->GetType() == NCAContentType::Program)
                     program_status[cnmt.GetTitleID()] = next_nca->GetStatus();
                 if (next_nca->GetStatus() == Loader::ResultStatus::Success ||

--- a/src/core/file_sys/submission_package.h
+++ b/src/core/file_sys/submission_package.h
@@ -70,6 +70,8 @@ private:
     std::map<u64, std::map<ContentRecordType, std::shared_ptr<NCA>>> ncas;
     std::vector<VirtualFile> ticket_files;
 
+    Core::Crypto::KeyManager keys;
+
     VirtualFile romfs;
     VirtualDir exefs;
 };

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -319,9 +319,16 @@ ResultVal<FileSys::VirtualDir> OpenSDMC() {
     return sdmc_factory->Open();
 }
 
-std::unique_ptr<FileSys::RegisteredCacheUnion> GetUnionContents() {
-    return std::make_unique<FileSys::RegisteredCacheUnion>(std::vector<FileSys::RegisteredCache*>{
-        GetSystemNANDContents(), GetUserNANDContents(), GetSDMCContents()});
+std::shared_ptr<FileSys::RegisteredCacheUnion> registered_cache_union;
+
+std::shared_ptr<FileSys::RegisteredCacheUnion> GetUnionContents() {
+    if (registered_cache_union == nullptr) {
+        registered_cache_union =
+            std::make_shared<FileSys::RegisteredCacheUnion>(std::vector<FileSys::RegisteredCache*>{
+                GetSystemNANDContents(), GetUserNANDContents(), GetSDMCContents()});
+    }
+
+    return registered_cache_union;
 }
 
 FileSys::RegisteredCache* GetSystemNANDContents() {

--- a/src/core/hle/service/filesystem/filesystem.h
+++ b/src/core/hle/service/filesystem/filesystem.h
@@ -47,7 +47,7 @@ ResultVal<FileSys::VirtualDir> OpenSaveData(FileSys::SaveDataSpaceId space,
                                             FileSys::SaveDataDescriptor save_struct);
 ResultVal<FileSys::VirtualDir> OpenSDMC();
 
-std::unique_ptr<FileSys::RegisteredCacheUnion> GetUnionContents();
+std::shared_ptr<FileSys::RegisteredCacheUnion> GetUnionContents();
 
 FileSys::RegisteredCache* GetSystemNANDContents();
 FileSys::RegisteredCache* GetUserNANDContents();

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -162,6 +162,7 @@ void Config::ReadValues() {
 
     qt_config->beginGroup("UIGameList");
     UISettings::values.show_unknown = qt_config->value("show_unknown", true).toBool();
+    UISettings::values.show_add_ons = qt_config->value("show_add_ons", true).toBool();
     UISettings::values.icon_size = qt_config->value("icon_size", 64).toUInt();
     UISettings::values.row_1_text_id = qt_config->value("row_1_text_id", 3).toUInt();
     UISettings::values.row_2_text_id = qt_config->value("row_2_text_id", 2).toUInt();
@@ -298,6 +299,7 @@ void Config::SaveValues() {
 
     qt_config->beginGroup("UIGameList");
     qt_config->setValue("show_unknown", UISettings::values.show_unknown);
+    qt_config->setValue("show_add_ons", UISettings::values.show_add_ons);
     qt_config->setValue("icon_size", UISettings::values.icon_size);
     qt_config->setValue("row_1_text_id", UISettings::values.row_1_text_id);
     qt_config->setValue("row_2_text_id", UISettings::values.row_2_text_id);

--- a/src/yuzu/configuration/configure_gamelist.cpp
+++ b/src/yuzu/configuration/configure_gamelist.cpp
@@ -42,6 +42,7 @@ ConfigureGameList::~ConfigureGameList() = default;
 
 void ConfigureGameList::applyConfiguration() {
     UISettings::values.show_unknown = ui->show_unknown->isChecked();
+    UISettings::values.show_add_ons = ui->show_add_ons->isChecked();
     UISettings::values.icon_size = ui->icon_size_combobox->currentData().toUInt();
     UISettings::values.row_1_text_id = ui->row_1_text_combobox->currentData().toUInt();
     UISettings::values.row_2_text_id = ui->row_2_text_combobox->currentData().toUInt();
@@ -50,6 +51,7 @@ void ConfigureGameList::applyConfiguration() {
 
 void ConfigureGameList::setConfiguration() {
     ui->show_unknown->setChecked(UISettings::values.show_unknown);
+    ui->show_add_ons->setChecked(UISettings::values.show_add_ons);
     ui->icon_size_combobox->setCurrentIndex(
         ui->icon_size_combobox->findData(UISettings::values.icon_size));
     ui->row_1_text_combobox->setCurrentIndex(

--- a/src/yuzu/configuration/configure_gamelist.ui
+++ b/src/yuzu/configuration/configure_gamelist.ui
@@ -1,126 +1,133 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>ConfigureGameList</class>
-  <widget class="QWidget" name="ConfigureGeneral">
-    <property name="geometry">
-      <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>300</width>
-        <height>377</height>
-      </rect>
-    </property>
-    <property name="windowTitle">
-      <string>Form</string>
-    </property>
-    <layout class="QHBoxLayout" name="HorizontalLayout">
-      <item>
-        <layout class="QVBoxLayout" name="VerticalLayout">
+ <widget class="QWidget" name="ConfigureGameList">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>377</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QHBoxLayout" name="HorizontalLayout">
+   <item>
+    <layout class="QVBoxLayout" name="VerticalLayout">
+     <item>
+      <widget class="QGroupBox" name="GeneralGroupBox">
+       <property name="title">
+        <string>General</string>
+       </property>
+       <layout class="QHBoxLayout" name="GeneralHorizontalLayout">
+        <item>
+         <layout class="QVBoxLayout" name="GeneralVerticalLayout">
           <item>
-            <widget class="QGroupBox" name="GeneralGroupBox">
-              <property name="title">
-                <string>General</string>
-              </property>
-              <layout class="QHBoxLayout" name="GeneralHorizontalLayout">
-                <item>
-                  <layout class="QVBoxLayout" name="GeneralVerticalLayout">
-                    <item>
-                      <widget class="QCheckBox" name="show_unknown">
-                        <property name="text">
-                          <string>Show files with type 'Unknown'</string>
-                        </property>
-                      </widget>
-                    </item>
-                  </layout>
-                </item>
-              </layout>
-            </widget>
+           <widget class="QCheckBox" name="show_unknown">
+            <property name="text">
+             <string>Show files with type 'Unknown'</string>
+            </property>
+           </widget>
           </item>
           <item>
-            <widget class="QGroupBox" name="IconSizeGroupBox">
-              <property name="title">
-                <string>Icon Size</string>
+           <widget class="QCheckBox" name="show_add_ons">
+            <property name="text">
+             <string>Show Add-Ons Column</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="IconSizeGroupBox">
+       <property name="title">
+        <string>Icon Size</string>
+       </property>
+       <layout class="QHBoxLayout" name="icon_size_qhbox_layout">
+        <item>
+         <layout class="QVBoxLayout" name="icon_size_qvbox_layout">
+          <item>
+           <layout class="QHBoxLayout" name="icon_size_qhbox_layout_2">
+            <item>
+             <widget class="QLabel" name="icon_size_label">
+              <property name="text">
+               <string>Icon Size:</string>
               </property>
-              <layout class="QHBoxLayout" name="icon_size_qhbox_layout">
-                <item>
-                  <layout class="QVBoxLayout" name="icon_size_qvbox_layout">
-                    <item>
-                      <layout class="QHBoxLayout" name="icon_size_qhbox_layout_2">
-                        <item>
-                          <widget class="QLabel" name="icon_size_label">
-                            <property name="text">
-                              <string>Icon Size:</string>
-                            </property>
-                          </widget>
-                        </item>
-                        <item>
-                          <widget class="QComboBox" name="icon_size_combobox"/>
-                        </item>
-                      </layout>
-                    </item>
-                  </layout>
-                </item>
-              </layout>
-            </widget>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="icon_size_combobox"/>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="RowGroupBox">
+       <property name="title">
+        <string>Row Text</string>
+       </property>
+       <layout class="QHBoxLayout" name="RowHorizontalLayout">
+        <item>
+         <layout class="QVBoxLayout" name="RowVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="row_1_qhbox_layout">
+            <item>
+             <widget class="QLabel" name="row_1_label">
+              <property name="text">
+               <string>Row 1 Text:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="row_1_text_combobox"/>
+            </item>
+           </layout>
           </item>
           <item>
-            <widget class="QGroupBox" name="RowGroupBox">
-              <property name="title">
-                <string>Row Text</string>
+           <layout class="QHBoxLayout" name="row_2_qhbox_layout">
+            <item>
+             <widget class="QLabel" name="row_2_label">
+              <property name="text">
+               <string>Row 2 Text:</string>
               </property>
-              <layout class="QHBoxLayout" name="RowHorizontalLayout">
-                <item>
-                  <layout class="QVBoxLayout" name="RowVerticalLayout">
-                    <item>
-                      <layout class="QHBoxLayout" name="row_1_qhbox_layout">
-                        <item>
-                          <widget class="QLabel" name="row_1_label">
-                            <property name="text">
-                              <string>Row 1 Text:</string>
-                            </property>
-                          </widget>
-                        </item>
-                        <item>
-                          <widget class="QComboBox" name="row_1_text_combobox"/>
-                        </item>
-                      </layout>
-                    </item>
-                    <item>
-                      <layout class="QHBoxLayout" name="row_2_qhbox_layout">
-                        <item>
-                          <widget class="QLabel" name="row_2_label">
-                            <property name="text">
-                              <string>Row 2 Text:</string>
-                            </property>
-                          </widget>
-                        </item>
-                        <item>
-                          <widget class="QComboBox" name="row_2_text_combobox"/>
-                        </item>
-                      </layout>
-                    </item>
-                  </layout>
-                </item>
-              </layout>
-            </widget>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="row_2_text_combobox"/>
+            </item>
+           </layout>
           </item>
-          <item>
-            <spacer name="verticalSpacer">
-              <property name="orientation">
-                <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-                <size>
-                  <width>20</width>
-                  <height>40</height>
-                </size>
-              </property>
-            </spacer>
-          </item>
-        </layout>
-      </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
     </layout>
-  </widget>
+   </item>
+  </layout>
+ </widget>
  <resources/>
  <connections/>
 </ui>

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -215,12 +215,18 @@ GameList::GameList(FileSys::VirtualFilesystem vfs, GMainWindow* parent)
     tree_view->setUniformRowHeights(true);
     tree_view->setContextMenuPolicy(Qt::CustomContextMenu);
 
-    item_model->insertColumns(0, COLUMN_COUNT);
+    item_model->insertColumns(0, UISettings::values.show_add_ons ? COLUMN_COUNT : COLUMN_COUNT - 1);
     item_model->setHeaderData(COLUMN_NAME, Qt::Horizontal, tr("Name"));
     item_model->setHeaderData(COLUMN_COMPATIBILITY, Qt::Horizontal, tr("Compatibility"));
-    item_model->setHeaderData(COLUMN_ADD_ONS, Qt::Horizontal, tr("Add-ons"));
-    item_model->setHeaderData(COLUMN_FILE_TYPE, Qt::Horizontal, tr("File type"));
-    item_model->setHeaderData(COLUMN_SIZE, Qt::Horizontal, tr("Size"));
+
+    if (UISettings::values.show_add_ons) {
+        item_model->setHeaderData(COLUMN_ADD_ONS, Qt::Horizontal, tr("Add-ons"));
+        item_model->setHeaderData(COLUMN_FILE_TYPE, Qt::Horizontal, tr("File type"));
+        item_model->setHeaderData(COLUMN_SIZE, Qt::Horizontal, tr("Size"));
+    } else {
+        item_model->setHeaderData(COLUMN_FILE_TYPE - 1, Qt::Horizontal, tr("File type"));
+        item_model->setHeaderData(COLUMN_SIZE - 1, Qt::Horizontal, tr("Size"));
+    }
 
     connect(tree_view, &QTreeView::activated, this, &GameList::ValidateEntry);
     connect(tree_view, &QTreeView::customContextMenuRequested, this, &GameList::PopupContextMenu);
@@ -394,6 +400,25 @@ void GameList::PopulateAsync(const QString& dir_path, bool deep_scan) {
     }
 
     tree_view->setEnabled(false);
+
+    // Update the columns in case UISettings has changed
+    item_model->removeColumns(0, item_model->columnCount());
+    item_model->insertColumns(0, UISettings::values.show_add_ons ? COLUMN_COUNT : COLUMN_COUNT - 1);
+    item_model->setHeaderData(COLUMN_NAME, Qt::Horizontal, tr("Name"));
+    item_model->setHeaderData(COLUMN_COMPATIBILITY, Qt::Horizontal, tr("Compatibility"));
+
+    if (UISettings::values.show_add_ons) {
+        item_model->setHeaderData(COLUMN_ADD_ONS, Qt::Horizontal, tr("Add-ons"));
+        item_model->setHeaderData(COLUMN_FILE_TYPE, Qt::Horizontal, tr("File type"));
+        item_model->setHeaderData(COLUMN_SIZE, Qt::Horizontal, tr("Size"));
+    } else {
+        item_model->setHeaderData(COLUMN_FILE_TYPE - 1, Qt::Horizontal, tr("File type"));
+        item_model->setHeaderData(COLUMN_SIZE - 1, Qt::Horizontal, tr("Size"));
+        item_model->removeColumns(COLUMN_COUNT - 1, 1);
+    }
+
+    LoadInterfaceLayout();
+
     // Delete any rows that might already exist if we're repopulating
     item_model->removeRows(0, item_model->rowCount());
 

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -123,17 +123,22 @@ void GameListWorker::AddInstalledTitlesToGameList() {
         if (it != compatibility_list.end())
             compatibility = it->second.first;
 
-        emit EntryReady({
+        QList<QStandardItem*> list{
             new GameListItemPath(
                 FormatGameName(file->GetFullPath()), icon, QString::fromStdString(name),
                 QString::fromStdString(Loader::GetFileTypeString(loader->GetFileType())),
                 program_id),
             new GameListItemCompat(compatibility),
-            new GameListItem(FormatPatchNameVersions(patch, *loader)),
             new GameListItem(
                 QString::fromStdString(Loader::GetFileTypeString(loader->GetFileType()))),
             new GameListItemSize(file->GetSize()),
-        });
+        };
+
+        if (UISettings::values.show_add_ons) {
+            list.insert(2, new GameListItem(FormatPatchNameVersions(patch, *loader)));
+        }
+
+        emit EntryReady(list);
     }
 
     const auto control_data = cache->ListEntriesFilter(FileSys::TitleType::Application,
@@ -216,18 +221,23 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
             if (it != compatibility_list.end())
                 compatibility = it->second.first;
 
-            emit EntryReady({
+            QList<QStandardItem*> list{
                 new GameListItemPath(
                     FormatGameName(physical_name), icon, QString::fromStdString(name),
                     QString::fromStdString(Loader::GetFileTypeString(loader->GetFileType())),
                     program_id),
                 new GameListItemCompat(compatibility),
                 new GameListItem(
-                    FormatPatchNameVersions(patch, *loader, loader->IsRomFSUpdatable())),
-                new GameListItem(
                     QString::fromStdString(Loader::GetFileTypeString(loader->GetFileType()))),
                 new GameListItemSize(FileUtil::GetSize(physical_name)),
-            });
+            };
+
+            if (UISettings::values.show_add_ons) {
+                list.insert(2, new GameListItem(FormatPatchNameVersions(
+                                   patch, *loader, loader->IsRomFSUpdatable())));
+            }
+
+            emit EntryReady(std::move(list));
         } else if (is_dir && recursion > 0) {
             watch_list.append(QString::fromStdString(physical_name));
             AddFstEntriesToGameList(physical_name, recursion - 1);

--- a/src/yuzu/ui_settings.h
+++ b/src/yuzu/ui_settings.h
@@ -59,6 +59,7 @@ struct Values {
 
     // Game List
     bool show_unknown;
+    bool show_add_ons;
     uint32_t icon_size;
     uint8_t row_1_text_id;
     uint8_t row_2_text_id;


### PR DESCRIPTION
When using a large game list with yuzu (20+ titles), the refresh takes an upwards of 15 seconds, which is really unreasonable. This PR adds some fixes to mitigate this.

1. Share a `KeyManager` instance between NCAs in an NCA container (e.g. NSP/XCI/RegisteredCache). Since each instance of `KeyManager` needs to read all the keyfiles and parse them, this can cut down on time for users with a large concentration of installed/NSP/XCI titles or who have large key files.
2. Avoid recreating a new `RegisteredCacheUnion` on every request for the installed titles. Now it will only initialize it on first use and then return a `shared_ptr` to that instead of creating a new one and returning a `unique_ptr`. This should save a lot of time for users with large or very populated NAND/SD partitions as it avoids re-parsing all the metadata for every game.
3. Make the Add-ons column optional. Most of the time in the game list is spent with the Add-ons column as it has to search for updates, DLC, mods, etc. for their existence and version. An option has been added to control whether or not this column will show (default: show). When it is turned off, it can have as much as a 70% improvement (my testing) for users with large installed partitions or mod counts.