### PR TITLE
Fixed HID crash when launching more than 1 game & signaled styleset change event

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -427,6 +427,9 @@ void Controller_NPad::VibrateController(const std::vector<u32>& controller_ids,
 }
 
 Kernel::SharedPtr<Kernel::Event> Controller_NPad::GetStyleSetChangedEvent() const {
+    // TODO(ogniK): Figure out the best time to signal this event. This event seems that it should
+    // be signalled at least once, and signaled after a new controller is connected?
+    styleset_changed_event->Signal();
     return styleset_changed_event;
 }
 

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -96,6 +96,8 @@ public:
         // TODO(shinyquagsire23): Other update callbacks? (accel, gyro?)
 
         CoreTiming::ScheduleEvent(pad_update_ticks, pad_update_event);
+
+        ReloadInputDevices();
     }
 
     void ActivateController(HidController controller) {


### PR DESCRIPTION
This should fix crashes when launching multiple games in yuzu. The styleset event should be signaled at least once by the looks of it and will need to be signaled again when a new controller is connected.