### PR TITLE
hid: Add support for multiplayer and multilayout controllers

### DIFF
--- a/src/core/frontend/input.h
+++ b/src/core/frontend/input.h
@@ -132,4 +132,11 @@ using MotionDevice = InputDevice<std::tuple<Math::Vec3<float>, Math::Vec3<float>
  */
 using TouchDevice = InputDevice<std::tuple<float, float, bool>>;
 
+/**
+ * A mouse device is an input device that returns a tuple of two floats and four ints.
+ * The first two floats are X and Y device coordinates of the mouse (from 0-1).
+ * The s32s are the mouse wheel.
+ */
+using MouseDevice = InputDevice<std::tuple<float, float, s32, s32>>;
+
 } // namespace Input

--- a/src/core/hle/service/hid/controllers/debug_pad.cpp
+++ b/src/core/hle/service/hid/controllers/debug_pad.cpp
@@ -34,6 +34,29 @@ void Controller_DebugPad::OnUpdate(u8* data, std::size_t size) {
     cur_entry.sampling_number = last_entry.sampling_number + 1;
     cur_entry.sampling_number2 = cur_entry.sampling_number;
     // TODO(ogniK): Update debug pad states
+    cur_entry.attribute.connected.Assign(1);
+    auto& pad = cur_entry.pad_state;
+
+    pad.a.Assign(0);
+    pad.b.Assign(0);
+    pad.x.Assign(0);
+    pad.y.Assign(0);
+    pad.l.Assign(0);
+    pad.r.Assign(0);
+    pad.zl.Assign(0);
+    pad.zr.Assign(0);
+    pad.plus.Assign(0);
+    pad.minus.Assign(0);
+    pad.d_left.Assign(0);
+    pad.d_up.Assign(0);
+    pad.d_right.Assign(0);
+    pad.d_down.Assign(0);
+
+    cur_entry.l_stick.x = 0;
+    cur_entry.l_stick.y = 0;
+
+    cur_entry.r_stick.x = 0;
+    cur_entry.r_stick.y = 0;
 
     std::memcpy(data, &shared_memory, sizeof(SharedMemory));
 }

--- a/src/core/hle/service/hid/controllers/debug_pad.h
+++ b/src/core/hle/service/hid/controllers/debug_pad.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include "common/bit_field.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
@@ -35,11 +36,40 @@ private:
     };
     static_assert(sizeof(AnalogStick) == 0x8);
 
+    struct PadState {
+        union {
+            u32_le raw{};
+            BitField<0, 1, u32_le> a;
+            BitField<1, 1, u32_le> b;
+            BitField<2, 1, u32_le> x;
+            BitField<3, 1, u32_le> y;
+            BitField<4, 1, u32_le> l;
+            BitField<5, 1, u32_le> r;
+            BitField<6, 1, u32_le> zl;
+            BitField<7, 1, u32_le> zr;
+            BitField<8, 1, u32_le> plus;
+            BitField<9, 1, u32_le> minus;
+            BitField<10, 1, u32_le> d_left;
+            BitField<11, 1, u32_le> d_up;
+            BitField<12, 1, u32_le> d_right;
+            BitField<13, 1, u32_le> d_down;
+        };
+    };
+    static_assert(sizeof(PadState) == 0x4, "PadState is an invalid size");
+
+    struct Attributes {
+        union {
+            u32_le raw{};
+            BitField<0, 1, u32_le> connected;
+        };
+    };
+    static_assert(sizeof(Attributes) == 0x4, "Attributes is an invalid size");
+
     struct PadStates {
         s64_le sampling_number;
         s64_le sampling_number2;
-        u32_le attribute;
-        u32_le button_state;
+        Attributes attribute;
+        PadState pad_state;
         AnalogStick r_stick;
         AnalogStick l_stick;
     };

--- a/src/core/hle/service/hid/controllers/debug_pad.h
+++ b/src/core/hle/service/hid/controllers/debug_pad.h
@@ -9,7 +9,9 @@
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
+#include "core/frontend/input.h"
 #include "core/hle/service/hid/controllers/controller_base.h"
+#include "core/settings.h"
 
 namespace Service::HID {
 class Controller_DebugPad final : public ControllerBase {
@@ -82,5 +84,10 @@ private:
     };
     static_assert(sizeof(SharedMemory) == 0x400, "SharedMemory is an invalid size");
     SharedMemory shared_memory{};
+
+    std::array<std::unique_ptr<Input::ButtonDevice>, Settings::NativeButton::NUM_BUTTONS_HID>
+        buttons;
+    std::array<std::unique_ptr<Input::AnalogDevice>, Settings::NativeAnalog::NUM_STICKS_HID>
+        analogs;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/keyboard.cpp
+++ b/src/core/hle/service/hid/controllers/keyboard.cpp
@@ -10,6 +10,7 @@
 
 namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3800;
+constexpr u8 KEYS_PER_BYTE = 8;
 
 Controller_Keyboard::Controller_Keyboard() = default;
 Controller_Keyboard::~Controller_Keyboard() = default;
@@ -37,8 +38,8 @@ void Controller_Keyboard::OnUpdate(u8* data, std::size_t size) {
     cur_entry.sampling_number2 = cur_entry.sampling_number;
 
     for (std::size_t i = 0; i < keyboard_keys.size(); ++i) {
-        for (std::size_t k = 0; k < 8; ++k) {
-            cur_entry.key[i / 8] |= (keyboard_keys[i]->GetStatus() << k);
+        for (std::size_t k = 0; k < KEYS_PER_BYTE; ++k) {
+            cur_entry.key[i / KEYS_PER_BYTE] |= (keyboard_keys[i]->GetStatus() << k);
         }
     }
 

--- a/src/core/hle/service/hid/controllers/keyboard.h
+++ b/src/core/hle/service/hid/controllers/keyboard.h
@@ -8,7 +8,9 @@
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
+#include "core/frontend/input.h"
 #include "core/hle/service/hid/controllers/controller_base.h"
+#include "core/settings.h"
 
 namespace Service::HID {
 class Controller_Keyboard final : public ControllerBase {
@@ -46,5 +48,10 @@ private:
     };
     static_assert(sizeof(SharedMemory) == 0x400, "SharedMemory is an invalid size");
     SharedMemory shared_memory{};
+
+    std::array<std::unique_ptr<Input::ButtonDevice>, Settings::NativeKeyboard::NumKeyboardKeys>
+        keyboard_keys;
+    std::array<std::unique_ptr<Input::ButtonDevice>, Settings::NativeKeyboard::NumKeyboardMods>
+        keyboard_mods;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/mouse.cpp
+++ b/src/core/hle/service/hid/controllers/mouse.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include "common/common_types.h"
 #include "core/core_timing.h"
+#include "core/frontend/emu_window.h"
 #include "core/hle/service/hid/controllers/mouse.h"
 
 namespace Service::HID {
@@ -14,7 +15,6 @@ Controller_Mouse::Controller_Mouse() = default;
 Controller_Mouse::~Controller_Mouse() = default;
 
 void Controller_Mouse::OnInit() {}
-
 void Controller_Mouse::OnRelease() {}
 
 void Controller_Mouse::OnUpdate(u8* data, std::size_t size) {
@@ -34,10 +34,29 @@ void Controller_Mouse::OnUpdate(u8* data, std::size_t size) {
 
     cur_entry.sampling_number = last_entry.sampling_number + 1;
     cur_entry.sampling_number2 = cur_entry.sampling_number;
-    // TODO(ogniK): Update mouse states
+
+    if (Settings::values.mouse_enabled) {
+        const auto [px, py, sx, sy] = mouse_device->GetStatus();
+        const auto x = static_cast<s32>(px * Layout::ScreenUndocked::Width);
+        const auto y = static_cast<s32>(py * Layout::ScreenUndocked::Height);
+        cur_entry.x = x;
+        cur_entry.y = y;
+        cur_entry.delta_x = x - last_entry.x;
+        cur_entry.delta_y = y - last_entry.y;
+        cur_entry.mouse_wheel_x = sx;
+        cur_entry.mouse_wheel_y = sy;
+
+        for (std::size_t i = 0; i < mouse_button_devices.size(); ++i) {
+            cur_entry.button |= (mouse_button_devices[i]->GetStatus() << i);
+        }
+    }
 
     std::memcpy(data + SHARED_MEMORY_OFFSET, &shared_memory, sizeof(SharedMemory));
 }
 
-void Controller_Mouse::OnLoadInputDevices() {}
+void Controller_Mouse::OnLoadInputDevices() {
+    mouse_device = Input::CreateDevice<Input::MouseDevice>(Settings::values.mouse_device);
+    std::transform(Settings::values.mouse_buttons.begin(), Settings::values.mouse_buttons.end(),
+                   mouse_button_devices.begin(), Input::CreateDevice<Input::ButtonDevice>);
+}
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/mouse.h
+++ b/src/core/hle/service/hid/controllers/mouse.h
@@ -7,7 +7,9 @@
 #include <array>
 #include "common/common_types.h"
 #include "common/swap.h"
+#include "core/frontend/input.h"
 #include "core/hle/service/hid/controllers/controller_base.h"
+#include "core/settings.h"
 
 namespace Service::HID {
 class Controller_Mouse final : public ControllerBase {
@@ -35,7 +37,8 @@ private:
         s32_le y;
         s32_le delta_x;
         s32_le delta_y;
-        s32_le mouse_wheel;
+        s32_le mouse_wheel_x;
+        s32_le mouse_wheel_y;
         s32_le button;
         s32_le attribute;
     };
@@ -46,5 +49,9 @@ private:
         std::array<MouseState, 17> mouse_states;
     };
     SharedMemory shared_memory{};
+
+    std::unique_ptr<Input::MouseDevice> mouse_device;
+    std::array<std::unique_ptr<Input::ButtonDevice>, Settings::NativeMouseButton::NumMouseButtons>
+        mouse_button_devices;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -712,6 +712,37 @@ void Controller_NPad::SetVibrationEnabled(bool can_vibrate) {
     can_controllers_vibrate = can_vibrate;
 }
 
+void Controller_NPad::ClearAllConnectedControllers() {
+    std::for_each(connected_controllers.begin(), connected_controllers.end(),
+                  [](ControllerHolder& controller) {
+                      if (controller.is_connected && controller.type != NPadControllerType::None) {
+                          controller.type = NPadControllerType::None;
+                          controller.is_connected = false;
+                      }
+                  });
+}
+void Controller_NPad::DisconnectAllConnectedControllers() {
+    std::for_each(connected_controllers.begin(), connected_controllers.end(),
+                  [](ControllerHolder& controller) { controller.is_connected = false; });
+}
+
+void Controller_NPad::ConnectAllDisconnectedControllers() {
+    std::for_each(connected_controllers.begin(), connected_controllers.end(),
+                  [](ControllerHolder& controller) {
+                      if (controller.type != NPadControllerType::None && !controller.is_connected) {
+                          controller.is_connected = false;
+                      }
+                  });
+}
+
+void Controller_NPad::ClearAllControllers() {
+    std::for_each(connected_controllers.begin(), connected_controllers.end(),
+                  [](ControllerHolder& controller) {
+                      controller.type = NPadControllerType::None;
+                      controller.is_connected = false;
+                  });
+}
+
 bool Controller_NPad::IsControllerSupported(NPadControllerType controller) const {
     const bool support_handheld =
         std::find(supported_npad_id_types.begin(), supported_npad_id_types.end(), NPAD_HANDHELD) !=

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -79,21 +79,31 @@ void Controller_NPad::InitNewlyAddedControler(std::size_t controller_idx) {
         controller.joy_styles.handheld.Assign(1);
         controller.device_type.handheld.Assign(1);
         controller.pad_assignment = NPadAssignments::Dual;
+        controller.properties.is_vertical.Assign(1);
+        controller.properties.use_plus.Assign(1);
+        controller.properties.use_minus.Assign(1);
         break;
     case NPadControllerType::JoyDual:
         controller.joy_styles.joycon_dual.Assign(1);
         controller.device_type.joycon_left.Assign(1);
         controller.device_type.joycon_right.Assign(1);
+        controller.properties.is_vertical.Assign(1);
+        controller.properties.use_plus.Assign(1);
+        controller.properties.use_minus.Assign(1);
         controller.pad_assignment = NPadAssignments::Dual;
         break;
     case NPadControllerType::JoyLeft:
         controller.joy_styles.joycon_left.Assign(1);
         controller.device_type.joycon_left.Assign(1);
+        controller.properties.is_horizontal.Assign(1);
+        controller.properties.use_minus.Assign(1);
         controller.pad_assignment = NPadAssignments::Single;
         break;
     case NPadControllerType::JoyRight:
         controller.joy_styles.joycon_right.Assign(1);
         controller.device_type.joycon_right.Assign(1);
+        controller.properties.is_horizontal.Assign(1);
+        controller.properties.use_plus.Assign(1);
         controller.pad_assignment = NPadAssignments::Single;
         break;
     case NPadControllerType::Pokeball:
@@ -104,6 +114,9 @@ void Controller_NPad::InitNewlyAddedControler(std::size_t controller_idx) {
     case NPadControllerType::ProController:
         controller.joy_styles.pro_controller.Assign(1);
         controller.device_type.pro_controller.Assign(1);
+        controller.properties.is_vertical.Assign(1);
+        controller.properties.use_plus.Assign(1);
+        controller.properties.use_minus.Assign(1);
         controller.pad_assignment = NPadAssignments::Single;
         break;
     }
@@ -118,9 +131,6 @@ void Controller_NPad::InitNewlyAddedControler(std::size_t controller_idx) {
     controller.right_color.body_color = JOYCON_BODY_NEON_RED;
     controller.right_color.button_color = JOYCON_BUTTONS_NEON_RED;
 
-    controller.properties.is_vertical.Assign(1); // TODO(ogniK): Swap joycons orientations
-    controller.properties.use_plus.Assign(1);
-    controller.properties.use_minus.Assign(1);
     controller.battery_level[0] = BATTERY_FULL;
     controller.battery_level[1] = BATTERY_FULL;
     controller.battery_level[2] = BATTERY_FULL;
@@ -202,8 +212,8 @@ void Controller_NPad::RequestPadStateUpdate(u32 npad_id) {
     pad_state.r_stick_right.Assign(buttons[RStick_Right - BUTTON_HID_BEGIN]->GetStatus());
     pad_state.r_stick_down.Assign(buttons[RStick_Down - BUTTON_HID_BEGIN]->GetStatus());
 
-    pad_state.sl.Assign(buttons[SL - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.sr.Assign(buttons[SR - BUTTON_HID_BEGIN]->GetStatus());
+    pad_state.left_sl.Assign(buttons[SL - BUTTON_HID_BEGIN]->GetStatus());
+    pad_state.left_sr.Assign(buttons[SR - BUTTON_HID_BEGIN]->GetStatus());
 
     const auto [stick_l_x_f, stick_l_y_f] =
         sticks[static_cast<std::size_t>(JoystickId::Joystick_Left)]->GetStatus();
@@ -307,6 +317,7 @@ void Controller_NPad::OnUpdate(u8* data, std::size_t data_len) {
             pad_state.l_stick = temp_lstick_entry;
             pad_state.r_stick = temp_rstick_entry;
         }
+
         libnx_entry.connection_status.raw = 0;
 
         switch (controller_type) {

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -5,12 +5,17 @@
 #pragma once
 
 #include <array>
+#include "common/bit_field.h"
 #include "common/common_types.h"
 #include "core/frontend/input.h"
+#include "core/hle/kernel/event.h"
 #include "core/hle/service/hid/controllers/controller_base.h"
 #include "core/settings.h"
 
 namespace Service::HID {
+
+constexpr u32 NPAD_HANDHELD = 32;
+constexpr u32 NPAD_UNKNOWN = 16; // TODO(ogniK): What is this?
 
 class Controller_NPad final : public ControllerBase {
 public:
@@ -117,6 +122,9 @@ public:
     void DisconnectAllConnectedControllers();
     void ConnectAllDisconnectedControllers();
     void ClearAllControllers();
+
+    static std::size_t NPadIdToIndex(u32 npad_id);
+    static u32 IndexToNPad(std::size_t index);
 
 private:
     struct CommonHeader {
@@ -304,10 +312,7 @@ private:
     bool IsControllerSupported(NPadControllerType controller) const;
     NPadControllerType DecideBestController(NPadControllerType priority) const;
     void RequestPadStateUpdate(u32 npad_id);
-    std::size_t NPadIdToIndex(u32 npad_id);
-    u32 IndexToNPad(std::size_t index);
     std::array<ControllerPad, 10> npad_pad_states{};
-    NPadControllerType DecideBestController(NPadControllerType priority);
     bool IsControllerSupported(NPadControllerType controller);
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -285,9 +285,14 @@ private:
 
     NPadType style{};
     std::array<NPadEntry, 10> shared_memory_entries{};
-    std::array<std::unique_ptr<Input::ButtonDevice>, Settings::NativeButton::NUM_BUTTONS_HID>
+    std::array<
+        std::array<std::unique_ptr<Input::ButtonDevice>, Settings::NativeButton::NUM_BUTTONS_HID>,
+        10>
         buttons;
-    std::array<std::unique_ptr<Input::AnalogDevice>, Settings::NativeAnalog::NUM_STICKS_HID> sticks;
+    std::array<
+        std::array<std::unique_ptr<Input::AnalogDevice>, Settings::NativeAnalog::NUM_STICKS_HID>,
+        10>
+        sticks;
     std::vector<u32> supported_npad_id_types{};
     NpadHoldType hold_type{NpadHoldType::Vertical};
     Kernel::SharedPtr<Kernel::Event> styleset_changed_event;

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -272,7 +272,7 @@ private:
     static_assert(sizeof(NPadEntry) == 0x5000, "NPadEntry is an invalid size");
 
     struct ControllerHolder {
-        Controller_NPad::NPadControllerType type;
+        NPadControllerType type;
         bool is_connected;
     };
 
@@ -295,5 +295,7 @@ private:
     std::size_t NPadIdToIndex(u32 npad_id);
     u32 IndexToNPad(std::size_t index);
     std::array<ControllerPad, 10> npad_pad_states{};
+    NPadControllerType DecideBestController(NPadControllerType priority);
+    bool IsControllerSupported(NPadControllerType controller);
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -165,8 +165,11 @@ private:
             BitField<23, 1, u64_le> r_stick_down;
 
             // Not always active?
-            BitField<24, 1, u64_le> sl;
-            BitField<25, 1, u64_le> sr;
+            BitField<24, 1, u64_le> left_sl;
+            BitField<25, 1, u64_le> left_sr;
+
+            BitField<26, 1, u64_le> right_sl;
+            BitField<27, 1, u64_le> right_sr;
         };
     };
     static_assert(sizeof(ControllerPadState) == 8, "ControllerPadState is an invalid size");

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -113,6 +113,10 @@ public:
     void DisconnectNPad(u32 npad_id);
     LedPattern GetLedPattern(u32 npad_id);
     void SetVibrationEnabled(bool can_vibrate);
+    void ClearAllConnectedControllers();
+    void DisconnectAllConnectedControllers();
+    void ConnectAllDisconnectedControllers();
+    void ClearAllControllers();
 
 private:
     struct CommonHeader {

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -107,6 +107,7 @@ public:
     Vibration GetLastVibration() const;
 
     void AddNewController(NPadControllerType controller);
+    void AddNewControllerAt(NPadControllerType controller, u32 npad_id);
 
     void ConnectNPad(u32 npad_id);
     void DisconnectNPad(u32 npad_id);
@@ -189,12 +190,17 @@ private:
     };
     static_assert(sizeof(ConnectionState) == 4, "ConnectionState is an invalid size");
 
-    struct GenericStates {
-        s64_le timestamp;
-        s64_le timestamp2;
+    struct ControllerPad {
         ControllerPadState pad_states;
         AnalogPosition l_stick;
         AnalogPosition r_stick;
+    };
+    static_assert(sizeof(ControllerPad) == 0x18, "ControllerPad is an invalid size");
+
+    struct GenericStates {
+        s64_le timestamp;
+        s64_le timestamp2;
+        ControllerPad pad;
         ConnectionState connection_status;
     };
     static_assert(sizeof(GenericStates) == 0x30, "NPadGenericStates is an invalid size");
@@ -285,5 +291,9 @@ private:
     void InitNewlyAddedControler(std::size_t controller_idx);
     bool IsControllerSupported(NPadControllerType controller) const;
     NPadControllerType DecideBestController(NPadControllerType priority) const;
+    void RequestPadStateUpdate(u32 npad_id);
+    std::size_t NPadIdToIndex(u32 npad_id);
+    u32 IndexToNPad(std::size_t index);
+    std::array<ControllerPad, 10> npad_pad_states{};
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/touchscreen.cpp
+++ b/src/core/hle/service/hid/controllers/touchscreen.cpp
@@ -42,19 +42,19 @@ void Controller_Touchscreen::OnUpdate(u8* data, std::size_t size) {
     const auto [x, y, pressed] = touch_device->GetStatus();
     auto& touch_entry = cur_entry.states[0];
     touch_entry.attribute.raw = 0;
-    if (pressed) {
+    if (pressed && Settings::values.touchscreen.enabled) {
         if (cur_entry.entry_count == 0) {
             touch_entry.attribute.start_touch.Assign(1);
         }
         touch_entry.x = static_cast<u16>(x * Layout::ScreenUndocked::Width);
         touch_entry.y = static_cast<u16>(y * Layout::ScreenUndocked::Height);
-        touch_entry.diameter_x = 15;
-        touch_entry.diameter_y = 15;
-        touch_entry.rotation_angle = 0;
+        touch_entry.diameter_x = Settings::values.touchscreen.diameter_x;
+        touch_entry.diameter_y = Settings::values.touchscreen.diameter_y;
+        touch_entry.rotation_angle = Settings::values.touchscreen.rotation_angle;
         const u64 tick = CoreTiming::GetTicks();
         touch_entry.delta_time = tick - last_touch;
         last_touch = tick;
-        touch_entry.finger = 0;
+        touch_entry.finger = Settings::values.touchscreen.finger;
         cur_entry.entry_count = 1;
     } else {
         if (cur_entry.entry_count == 1) {
@@ -67,6 +67,6 @@ void Controller_Touchscreen::OnUpdate(u8* data, std::size_t size) {
 }
 
 void Controller_Touchscreen::OnLoadInputDevices() {
-    touch_device = Input::CreateDevice<Input::TouchDevice>(Settings::values.touch_device);
+    touch_device = Input::CreateDevice<Input::TouchDevice>(Settings::values.touchscreen.device);
 }
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/touchscreen.cpp
+++ b/src/core/hle/service/hid/controllers/touchscreen.cpp
@@ -43,9 +43,6 @@ void Controller_Touchscreen::OnUpdate(u8* data, std::size_t size) {
     auto& touch_entry = cur_entry.states[0];
     touch_entry.attribute.raw = 0;
     if (pressed && Settings::values.touchscreen.enabled) {
-        if (cur_entry.entry_count == 0) {
-            touch_entry.attribute.start_touch.Assign(1);
-        }
         touch_entry.x = static_cast<u16>(x * Layout::ScreenUndocked::Width);
         touch_entry.y = static_cast<u16>(y * Layout::ScreenUndocked::Height);
         touch_entry.diameter_x = Settings::values.touchscreen.diameter_x;
@@ -57,9 +54,6 @@ void Controller_Touchscreen::OnUpdate(u8* data, std::size_t size) {
         touch_entry.finger = Settings::values.touchscreen.finger;
         cur_entry.entry_count = 1;
     } else {
-        if (cur_entry.entry_count == 1) {
-            touch_entry.attribute.end_touch.Assign(1);
-        }
         cur_entry.entry_count = 0;
     }
 

--- a/src/core/hle/service/hid/controllers/touchscreen.cpp
+++ b/src/core/hle/service/hid/controllers/touchscreen.cpp
@@ -41,7 +41,11 @@ void Controller_Touchscreen::OnUpdate(u8* data, std::size_t size) {
 
     const auto [x, y, pressed] = touch_device->GetStatus();
     auto& touch_entry = cur_entry.states[0];
+    touch_entry.attribute.raw = 0;
     if (pressed) {
+        if (cur_entry.entry_count == 0) {
+            touch_entry.attribute.start_touch.Assign(1);
+        }
         touch_entry.x = static_cast<u16>(x * Layout::ScreenUndocked::Width);
         touch_entry.y = static_cast<u16>(y * Layout::ScreenUndocked::Height);
         touch_entry.diameter_x = 15;
@@ -53,6 +57,9 @@ void Controller_Touchscreen::OnUpdate(u8* data, std::size_t size) {
         touch_entry.finger = 0;
         cur_entry.entry_count = 1;
     } else {
+        if (cur_entry.entry_count == 1) {
+            touch_entry.attribute.end_touch.Assign(1);
+        }
         cur_entry.entry_count = 0;
     }
 

--- a/src/core/hle/service/hid/controllers/touchscreen.h
+++ b/src/core/hle/service/hid/controllers/touchscreen.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "common/bit_field.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
@@ -29,9 +30,18 @@ public:
     void OnLoadInputDevices() override;
 
 private:
+    struct Attributes {
+        union {
+            u32 raw{};
+            BitField<0, 1, u32_le> start_touch;
+            BitField<1, 1, u32_le> end_touch;
+        };
+    };
+    static_assert(sizeof(Attributes) == 0x4, "Attributes is an invalid size");
+
     struct TouchState {
         u64_le delta_time;
-        u32_le attribute;
+        Attributes attribute;
         u32_le finger;
         u32_le x;
         u32_le y;

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -34,8 +34,8 @@
 namespace Service::HID {
 
 // Updating period for each HID device.
-// TODO(shinyquagsire23): These need better values.
-constexpr u64 pad_update_ticks = CoreTiming::BASE_CLOCK_RATE / 100;
+// TODO(ogniK): Find actual polling rate of hid
+constexpr u64 pad_update_ticks = CoreTiming::BASE_CLOCK_RATE / 66;
 constexpr u64 accelerometer_update_ticks = CoreTiming::BASE_CLOCK_RATE / 100;
 constexpr u64 gyroscope_update_ticks = CoreTiming::BASE_CLOCK_RATE / 100;
 constexpr std::size_t SHARED_MEMORY_SIZE = 0x40000;

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -10,6 +10,56 @@
 
 namespace Settings {
 
+namespace NativeButton {
+const std::array<const char*, NumButtons> mapping = {{
+    "button_a",
+    "button_b",
+    "button_x",
+    "button_y",
+    "button_lstick",
+    "button_rstick",
+    "button_l",
+    "button_r",
+    "button_zl",
+    "button_zr",
+    "button_plus",
+    "button_minus",
+    "button_dleft",
+    "button_dup",
+    "button_dright",
+    "button_ddown",
+    "button_lstick_left",
+    "button_lstick_up",
+    "button_lstick_right",
+    "button_lstick_down",
+    "button_rstick_left",
+    "button_rstick_up",
+    "button_rstick_right",
+    "button_rstick_down",
+    "button_sl",
+    "button_sr",
+    "button_home",
+    "button_screenshot",
+}};
+}
+
+namespace NativeAnalog {
+const std::array<const char*, NumAnalogs> mapping = {{
+    "lstick",
+    "rstick",
+}};
+}
+
+namespace NativeMouseButton {
+const std::array<const char*, NumMouseButtons> mapping = {{
+    "left",
+    "right",
+    "middle",
+    "forward",
+    "back",
+}};
+}
+
 Values values = {};
 
 void Apply() {

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -341,6 +341,46 @@ constexpr int NUM_KEYBOARD_MODS_HID = NumKeyboardMods;
 
 } // namespace NativeKeyboard
 
+using ButtonsRaw = std::array<std::string, NativeButton::NumButtons>;
+using AnalogsRaw = std::array<std::string, NativeAnalog::NumAnalogs>;
+using MouseButtonsRaw = std::array<std::string, NativeMouseButton::NumMouseButtons>;
+using KeyboardKeysRaw = std::array<std::string, NativeKeyboard::NumKeyboardKeys>;
+using KeyboardModsRaw = std::array<std::string, NativeKeyboard::NumKeyboardMods>;
+
+constexpr u32 JOYCON_BODY_NEON_RED = 0xFF3C28;
+constexpr u32 JOYCON_BUTTONS_NEON_RED = 0x1E0A0A;
+constexpr u32 JOYCON_BODY_NEON_BLUE = 0x0AB9E6;
+constexpr u32 JOYCON_BUTTONS_NEON_BLUE = 0x001E1E;
+
+enum class ControllerType {
+    ProController,
+    DualJoycon,
+    RightJoycon,
+    LeftJoycon,
+};
+
+struct PlayerInput {
+    bool connected;
+    ControllerType type;
+    ButtonsRaw buttons;
+    AnalogsRaw analogs;
+
+    u32 body_color_right;
+    u32 button_color_right;
+    u32 body_color_left;
+    u32 button_color_left;
+};
+
+struct TouchscreenInput {
+    bool enabled;
+    std::string device;
+
+    u32 finger;
+    u32 diameter_x;
+    u32 diameter_y;
+    u32 rotation_angle;
+};
+
 struct Values {
     // System
     bool use_docked_mode;
@@ -350,8 +390,8 @@ struct Values {
     s32 language_index;
 
     // Controls
-    std::array<std::string, NativeButton::NumButtons> buttons;
-    std::array<std::string, NativeAnalog::NumAnalogs> analogs;
+    std::array<PlayerInput, 10> players;
+
     bool mouse_enabled;
     std::string mouse_device;
     MouseButtonsRaw mouse_buttons;
@@ -359,8 +399,13 @@ struct Values {
     bool keyboard_enabled;
     KeyboardKeysRaw keyboard_keys;
     KeyboardModsRaw keyboard_mods;
+
+    bool debug_pad_enabled;
+    ButtonsRaw debug_pad_buttons;
+    AnalogsRaw debug_pad_analogs;
+
     std::string motion_device;
-    std::string touch_device;
+    TouchscreenInput touchscreen;
     std::atomic_bool is_device_reload_pending{true};
 
     // Core

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -60,36 +60,7 @@ constexpr int BUTTON_NS_END = NumButtons;
 constexpr int NUM_BUTTONS_HID = BUTTON_HID_END - BUTTON_HID_BEGIN;
 constexpr int NUM_BUTTONS_NS = BUTTON_NS_END - BUTTON_NS_BEGIN;
 
-static const std::array<const char*, NumButtons> mapping = {{
-    "button_a",
-    "button_b",
-    "button_x",
-    "button_y",
-    "button_lstick",
-    "button_rstick",
-    "button_l",
-    "button_r",
-    "button_zl",
-    "button_zr",
-    "button_plus",
-    "button_minus",
-    "button_dleft",
-    "button_dup",
-    "button_dright",
-    "button_ddown",
-    "button_lstick_left",
-    "button_lstick_up",
-    "button_lstick_right",
-    "button_lstick_down",
-    "button_rstick_left",
-    "button_rstick_up",
-    "button_rstick_right",
-    "button_rstick_down",
-    "button_sl",
-    "button_sr",
-    "button_home",
-    "button_screenshot",
-}};
+extern const std::array<const char*, NumButtons> mapping;
 
 } // namespace NativeButton
 
@@ -105,10 +76,7 @@ constexpr int STICK_HID_BEGIN = LStick;
 constexpr int STICK_HID_END = NumAnalogs;
 constexpr int NUM_STICKS_HID = NumAnalogs;
 
-static const std::array<const char*, NumAnalogs> mapping = {{
-    "lstick",
-    "rstick",
-}};
+extern const std::array<const char*, NumAnalogs> mapping;
 } // namespace NativeAnalog
 
 namespace NativeMouseButton {
@@ -126,13 +94,7 @@ constexpr int MOUSE_HID_BEGIN = Left;
 constexpr int MOUSE_HID_END = NumMouseButtons;
 constexpr int NUM_MOUSE_HID = NumMouseButtons;
 
-static const std::array<const char*, NumMouseButtons> mapping = {{
-    "left",
-    "right",
-    "middle",
-    "forward",
-    "back",
-}};
+extern const std::array<const char*, NumMouseButtons> mapping;
 } // namespace NativeMouseButton
 
 namespace NativeKeyboard {

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -111,6 +111,30 @@ static const std::array<const char*, NumAnalogs> mapping = {{
 }};
 } // namespace NativeAnalog
 
+namespace NativeMouseButton {
+enum Values {
+    Left,
+    Right,
+    Middle,
+    Forward,
+    Back,
+
+    NumMouseButtons,
+};
+
+constexpr int MOUSE_HID_BEGIN = Left;
+constexpr int MOUSE_HID_END = NumMouseButtons;
+constexpr int NUM_MOUSE_HID = NumMouseButtons;
+
+static const std::array<const char*, NumMouseButtons> mapping = {{
+    "left",
+    "right",
+    "middle",
+    "forward",
+    "back",
+}};
+} // namespace NativeMouseButton
+
 struct Values {
     // System
     bool use_docked_mode;
@@ -122,6 +146,9 @@ struct Values {
     // Controls
     std::array<std::string, NativeButton::NumButtons> buttons;
     std::array<std::string, NativeAnalog::NumAnalogs> analogs;
+    bool mouse_enabled;
+    std::string mouse_device;
+    MouseButtonsRaw mouse_buttons;
     std::string motion_device;
     std::string touch_device;
     std::atomic_bool is_device_reload_pending{true};

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -135,6 +135,212 @@ static const std::array<const char*, NumMouseButtons> mapping = {{
 }};
 } // namespace NativeMouseButton
 
+namespace NativeKeyboard {
+enum Keys {
+    None,
+    Error,
+
+    A = 4,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    J,
+    K,
+    L,
+    M,
+    N,
+    O,
+    P,
+    Q,
+    R,
+    S,
+    T,
+    U,
+    V,
+    W,
+    X,
+    Y,
+    Z,
+    N1,
+    N2,
+    N3,
+    N4,
+    N5,
+    N6,
+    N7,
+    N8,
+    N9,
+    N0,
+    Enter,
+    Escape,
+    Backspace,
+    Tab,
+    Space,
+    Minus,
+    Equal,
+    LeftBrace,
+    RightBrace,
+    Backslash,
+    Tilde,
+    Semicolon,
+    Apostrophe,
+    Grave,
+    Comma,
+    Dot,
+    Slash,
+    CapsLockKey,
+
+    F1,
+    F2,
+    F3,
+    F4,
+    F5,
+    F6,
+    F7,
+    F8,
+    F9,
+    F10,
+    F11,
+    F12,
+
+    SystemRequest,
+    ScrollLockKey,
+    Pause,
+    Insert,
+    Home,
+    PageUp,
+    Delete,
+    End,
+    PageDown,
+    Right,
+    Left,
+    Down,
+    Up,
+
+    NumLockKey,
+    KPSlash,
+    KPAsterisk,
+    KPMinus,
+    KPPlus,
+    KPEnter,
+    KP1,
+    KP2,
+    KP3,
+    KP4,
+    KP5,
+    KP6,
+    KP7,
+    KP8,
+    KP9,
+    KP0,
+    KPDot,
+
+    Key102,
+    Compose,
+    Power,
+    KPEqual,
+
+    F13,
+    F14,
+    F15,
+    F16,
+    F17,
+    F18,
+    F19,
+    F20,
+    F21,
+    F22,
+    F23,
+    F24,
+
+    Open,
+    Help,
+    Properties,
+    Front,
+    Stop,
+    Repeat,
+    Undo,
+    Cut,
+    Copy,
+    Paste,
+    Find,
+    Mute,
+    VolumeUp,
+    VolumeDown,
+    CapsLockActive,
+    NumLockActive,
+    ScrollLockActive,
+    KPComma,
+
+    KPLeftParenthesis,
+    KPRightParenthesis,
+
+    LeftControlKey = 0xE0,
+    LeftShiftKey,
+    LeftAltKey,
+    LeftMetaKey,
+    RightControlKey,
+    RightShiftKey,
+    RightAltKey,
+    RightMetaKey,
+
+    MediaPlayPause,
+    MediaStopCD,
+    MediaPrevious,
+    MediaNext,
+    MediaEject,
+    MediaVolumeUp,
+    MediaVolumeDown,
+    MediaMute,
+    MediaWebsite,
+    MediaBack,
+    MediaForward,
+    MediaStop,
+    MediaFind,
+    MediaScrollUp,
+    MediaScrollDown,
+    MediaEdit,
+    MediaSleep,
+    MediaCoffee,
+    MediaRefresh,
+    MediaCalculator,
+
+    NumKeyboardKeys,
+};
+
+static_assert(NumKeyboardKeys == 0xFC, "Incorrect number of keyboard keys.");
+
+enum Modifiers {
+    LeftControl,
+    LeftShift,
+    LeftAlt,
+    LeftMeta,
+    RightControl,
+    RightShift,
+    RightAlt,
+    RightMeta,
+    CapsLock,
+    ScrollLock,
+    NumLock,
+
+    NumKeyboardMods,
+};
+
+constexpr int KEYBOARD_KEYS_HID_BEGIN = None;
+constexpr int KEYBOARD_KEYS_HID_END = NumKeyboardKeys;
+constexpr int NUM_KEYBOARD_KEYS_HID = NumKeyboardKeys;
+
+constexpr int KEYBOARD_MODS_HID_BEGIN = LeftControl;
+constexpr int KEYBOARD_MODS_HID_END = NumKeyboardMods;
+constexpr int NUM_KEYBOARD_MODS_HID = NumKeyboardMods;
+
+} // namespace NativeKeyboard
+
 struct Values {
     // System
     bool use_docked_mode;
@@ -149,6 +355,10 @@ struct Values {
     bool mouse_enabled;
     std::string mouse_device;
     MouseButtonsRaw mouse_buttons;
+
+    bool keyboard_enabled;
+    KeyboardKeysRaw keyboard_keys;
+    KeyboardModsRaw keyboard_mods;
     std::string motion_device;
     std::string touch_device;
     std::atomic_bool is_device_reload_pending{true};

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -31,6 +31,8 @@ add_executable(yuzu
     configuration/configure_mouse_advanced.h
     configuration/configure_system.cpp
     configuration/configure_system.h
+    configuration/configure_touchscreen_advanced.cpp
+    configuration/configure_touchscreen_advanced.h
     configuration/configure_web.cpp
     configuration/configure_web.h
     debugger/graphics/graphics_breakpoint_observer.cpp
@@ -80,6 +82,7 @@ set(UIS
     configuration/configure_input.ui
     configuration/configure_mouse_advanced.ui
     configuration/configure_system.ui
+    configuration/configure_touchscreen_advanced.ui
     configuration/configure_web.ui
     hotkeys.ui
     main.ui

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -27,6 +27,8 @@ add_executable(yuzu
     configuration/configure_graphics.h
     configuration/configure_input.cpp
     configuration/configure_input.h
+    configuration/configure_input_player.cpp
+    configuration/configure_input_player.h
     configuration/configure_mouse_advanced.cpp
     configuration/configure_mouse_advanced.h
     configuration/configure_system.cpp
@@ -80,6 +82,7 @@ set(UIS
     configuration/configure_general.ui
     configuration/configure_graphics.ui
     configuration/configure_input.ui
+    configuration/configure_input_player.ui
     configuration/configure_mouse_advanced.ui
     configuration/configure_system.ui
     configuration/configure_touchscreen_advanced.ui

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -27,6 +27,8 @@ add_executable(yuzu
     configuration/configure_graphics.h
     configuration/configure_input.cpp
     configuration/configure_input.h
+    configuration/configure_mouse_advanced.cpp
+    configuration/configure_mouse_advanced.h
     configuration/configure_system.cpp
     configuration/configure_system.h
     configuration/configure_web.cpp
@@ -76,6 +78,7 @@ set(UIS
     configuration/configure_general.ui
     configuration/configure_graphics.ui
     configuration/configure_input.ui
+    configuration/configure_mouse_advanced.ui
     configuration/configure_system.ui
     configuration/configure_web.ui
     hotkeys.ui

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -5,6 +5,7 @@
 #include <QSettings>
 #include "common/file_util.h"
 #include "core/hle/service/acc/profile_manager.h"
+#include "core/hle/service/hid/controllers/npad.h"
 #include "input_common/main.h"
 #include "yuzu/configuration/config.h"
 #include "yuzu/ui_settings.h"
@@ -262,8 +263,11 @@ void Config::ReadPlayerValues() {
         }
     }
 
-    std::stable_partition(Settings::values.players.begin(), Settings::values.players.end(),
-                          [](const auto& player) { return player.connected; });
+    std::stable_partition(
+        Settings::values.players.begin(),
+        Settings::values.players.begin() +
+            Service::HID::Controller_NPad::NPadIdToIndex(Service::HID::NPAD_HANDHELD),
+        [](const auto& player) { return player.connected; });
 }
 
 void Config::ReadDebugValues() {

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -47,39 +47,283 @@ const std::array<std::array<int, 5>, Settings::NativeAnalog::NumAnalogs> Config:
     },
 }};
 
+const std::array<int, Settings::NativeMouseButton::NumMouseButtons> Config::default_mouse_buttons =
+    {
+        Qt::Key_BracketLeft, Qt::Key_BracketRight, Qt::Key_Apostrophe, Qt::Key_Minus, Qt::Key_Equal,
+};
+
+const std::array<int, Settings::NativeKeyboard::NumKeyboardKeys> Config::default_keyboard_keys = {
+    0,
+    0,
+    0,
+    0,
+    Qt::Key_A,
+    Qt::Key_B,
+    Qt::Key_C,
+    Qt::Key_D,
+    Qt::Key_E,
+    Qt::Key_F,
+    Qt::Key_G,
+    Qt::Key_H,
+    Qt::Key_I,
+    Qt::Key_J,
+    Qt::Key_K,
+    Qt::Key_L,
+    Qt::Key_M,
+    Qt::Key_N,
+    Qt::Key_O,
+    Qt::Key_P,
+    Qt::Key_Q,
+    Qt::Key_R,
+    Qt::Key_S,
+    Qt::Key_T,
+    Qt::Key_U,
+    Qt::Key_V,
+    Qt::Key_W,
+    Qt::Key_X,
+    Qt::Key_Y,
+    Qt::Key_Z,
+    Qt::Key_1,
+    Qt::Key_2,
+    Qt::Key_3,
+    Qt::Key_4,
+    Qt::Key_5,
+    Qt::Key_6,
+    Qt::Key_7,
+    Qt::Key_8,
+    Qt::Key_9,
+    Qt::Key_0,
+    Qt::Key_Enter,
+    Qt::Key_Escape,
+    Qt::Key_Backspace,
+    Qt::Key_Tab,
+    Qt::Key_Space,
+    Qt::Key_Minus,
+    Qt::Key_Equal,
+    Qt::Key_BracketLeft,
+    Qt::Key_BracketRight,
+    Qt::Key_Backslash,
+    Qt::Key_Dead_Tilde,
+    Qt::Key_Semicolon,
+    Qt::Key_Apostrophe,
+    Qt::Key_Dead_Grave,
+    Qt::Key_Comma,
+    Qt::Key_Period,
+    Qt::Key_Slash,
+    Qt::Key_CapsLock,
+
+    Qt::Key_F1,
+    Qt::Key_F2,
+    Qt::Key_F3,
+    Qt::Key_F4,
+    Qt::Key_F5,
+    Qt::Key_F6,
+    Qt::Key_F7,
+    Qt::Key_F8,
+    Qt::Key_F9,
+    Qt::Key_F10,
+    Qt::Key_F11,
+    Qt::Key_F12,
+
+    Qt::Key_SysReq,
+    Qt::Key_ScrollLock,
+    Qt::Key_Pause,
+    Qt::Key_Insert,
+    Qt::Key_Home,
+    Qt::Key_PageUp,
+    Qt::Key_Delete,
+    Qt::Key_End,
+    Qt::Key_PageDown,
+    Qt::Key_Right,
+    Qt::Key_Left,
+    Qt::Key_Down,
+    Qt::Key_Up,
+
+    Qt::Key_NumLock,
+    Qt::Key_Slash,
+    Qt::Key_Asterisk,
+    Qt::Key_Minus,
+    Qt::Key_Plus,
+    Qt::Key_Enter,
+    Qt::Key_1,
+    Qt::Key_2,
+    Qt::Key_3,
+    Qt::Key_4,
+    Qt::Key_5,
+    Qt::Key_6,
+    Qt::Key_7,
+    Qt::Key_8,
+    Qt::Key_9,
+    Qt::Key_0,
+    Qt::Key_Period,
+
+    0,
+    0,
+    Qt::Key_PowerOff,
+    Qt::Key_Equal,
+
+    Qt::Key_F13,
+    Qt::Key_F14,
+    Qt::Key_F15,
+    Qt::Key_F16,
+    Qt::Key_F17,
+    Qt::Key_F18,
+    Qt::Key_F19,
+    Qt::Key_F20,
+    Qt::Key_F21,
+    Qt::Key_F22,
+    Qt::Key_F23,
+    Qt::Key_F24,
+
+    Qt::Key_Open,
+    Qt::Key_Help,
+    Qt::Key_Menu,
+    0,
+    Qt::Key_Stop,
+    Qt::Key_AudioRepeat,
+    Qt::Key_Undo,
+    Qt::Key_Cut,
+    Qt::Key_Copy,
+    Qt::Key_Paste,
+    Qt::Key_Find,
+    Qt::Key_VolumeMute,
+    Qt::Key_VolumeUp,
+    Qt::Key_VolumeDown,
+    Qt::Key_CapsLock,
+    Qt::Key_NumLock,
+    Qt::Key_ScrollLock,
+    Qt::Key_Comma,
+
+    Qt::Key_ParenLeft,
+    Qt::Key_ParenRight,
+};
+
+const std::array<int, Settings::NativeKeyboard::NumKeyboardMods> Config::default_keyboard_mods = {
+    Qt::Key_Control, Qt::Key_Shift, Qt::Key_Alt,   Qt::Key_ApplicationLeft,
+    Qt::Key_Control, Qt::Key_Shift, Qt::Key_AltGr, Qt::Key_ApplicationRight,
+};
+
 void Config::ReadValues() {
     qt_config->beginGroup("Controls");
-    for (int i = 0; i < Settings::NativeButton::NumButtons; ++i) {
-        std::string default_param = InputCommon::GenerateKeyboardParam(default_buttons[i]);
-        Settings::values.buttons[i] =
+    for (std::size_t p = 0; p < 10; ++p) {
+        Settings::values.players[p].connected =
+            qt_config->value(QString("player_%1_connected").arg(p), false).toBool();
+
+        Settings::values.players[p].type = static_cast<Settings::ControllerType>(
             qt_config
-                ->value(Settings::NativeButton::mapping[i], QString::fromStdString(default_param))
+                ->value(QString("player_%1_type").arg(p),
+                        static_cast<u8>(Settings::ControllerType::DualJoycon))
+                .toUInt());
+
+        Settings::values.players[p].body_color_left =
+            qt_config
+                ->value(QString("player_%1_body_color_left").arg(p),
+                        Settings::JOYCON_BODY_NEON_BLUE)
+                .toUInt();
+        Settings::values.players[p].body_color_right =
+            qt_config
+                ->value(QString("player_%1_body_color_right").arg(p),
+                        Settings::JOYCON_BODY_NEON_RED)
+                .toUInt();
+        Settings::values.players[p].button_color_left =
+            qt_config
+                ->value(QString("player_%1_button_color_left").arg(p),
+                        Settings::JOYCON_BUTTONS_NEON_BLUE)
+                .toUInt();
+        Settings::values.players[p].button_color_right =
+            qt_config
+                ->value(QString("player_%1_button_color_right").arg(p),
+                        Settings::JOYCON_BUTTONS_NEON_RED)
+                .toUInt();
+
+        for (int i = 0; i < Settings::NativeButton::NumButtons; ++i) {
+            std::string default_param = InputCommon::GenerateKeyboardParam(default_buttons[i]);
+            Settings::values.players[p].buttons[i] =
+                qt_config
+                    ->value(QString("player_%1_").arg(p) + Settings::NativeButton::mapping[i],
+                            QString::fromStdString(default_param))
+                    .toString()
+                    .toStdString();
+            if (Settings::values.players[p].buttons[i].empty())
+                Settings::values.players[p].buttons[i] = default_param;
+        }
+
+        for (int i = 0; i < Settings::NativeAnalog::NumAnalogs; ++i) {
+            std::string default_param = InputCommon::GenerateAnalogParamFromKeys(
+                default_analogs[i][0], default_analogs[i][1], default_analogs[i][2],
+                default_analogs[i][3], default_analogs[i][4], 0.5f);
+            Settings::values.players[p].analogs[i] =
+                qt_config
+                    ->value(QString("player_%1_").arg(p) + Settings::NativeAnalog::mapping[i],
+                            QString::fromStdString(default_param))
+                    .toString()
+                    .toStdString();
+            if (Settings::values.players[p].analogs[i].empty())
+                Settings::values.players[p].analogs[i] = default_param;
+        }
+    }
+
+    std::stable_partition(Settings::values.players.begin(), Settings::values.players.end(),
+                          [](const auto& player) { return player.connected; });
+
+    Settings::values.motion_device =
+        qt_config->value("motion_device", "engine:motion_emu,update_period:100,sensitivity:0.01")
+            .toString()
+            .toStdString();
+
+    Settings::values.mouse_enabled = qt_config->value("mouse_enabled", false).toBool();
+
+    for (int i = 0; i < Settings::NativeMouseButton::NumMouseButtons; ++i) {
+        std::string default_param = InputCommon::GenerateKeyboardParam(default_mouse_buttons[i]);
+        Settings::values.mouse_buttons[i] =
+            qt_config
+                ->value(QString("mouse_") + Settings::NativeMouseButton::mapping[i],
+                        QString::fromStdString(default_param))
                 .toString()
                 .toStdString();
-        if (Settings::values.buttons[i].empty())
-            Settings::values.buttons[i] = default_param;
+        if (Settings::values.mouse_buttons[i].empty())
+            Settings::values.mouse_buttons[i] = default_param;
+    }
+
+    Settings::values.keyboard_enabled = qt_config->value("keyboard_enabled", false).toBool();
+
+    Settings::values.debug_pad_enabled = qt_config->value("debug_pad_enabled", false).toBool();
+    for (int i = 0; i < Settings::NativeButton::NumButtons; ++i) {
+        std::string default_param = InputCommon::GenerateKeyboardParam(default_buttons[i]);
+        Settings::values.debug_pad_buttons[i] =
+            qt_config
+                ->value(QString("debug_pad_") + Settings::NativeButton::mapping[i],
+                        QString::fromStdString(default_param))
+                .toString()
+                .toStdString();
+        if (Settings::values.debug_pad_buttons[i].empty())
+            Settings::values.debug_pad_buttons[i] = default_param;
     }
 
     for (int i = 0; i < Settings::NativeAnalog::NumAnalogs; ++i) {
         std::string default_param = InputCommon::GenerateAnalogParamFromKeys(
             default_analogs[i][0], default_analogs[i][1], default_analogs[i][2],
             default_analogs[i][3], default_analogs[i][4], 0.5f);
-        Settings::values.analogs[i] =
+        Settings::values.debug_pad_analogs[i] =
             qt_config
-                ->value(Settings::NativeAnalog::mapping[i], QString::fromStdString(default_param))
+                ->value(QString("debug_pad_") + Settings::NativeAnalog::mapping[i],
+                        QString::fromStdString(default_param))
                 .toString()
                 .toStdString();
-        if (Settings::values.analogs[i].empty())
-            Settings::values.analogs[i] = default_param;
+        if (Settings::values.debug_pad_analogs[i].empty())
+            Settings::values.debug_pad_analogs[i] = default_param;
     }
 
-    Settings::values.motion_device =
-        qt_config->value("motion_device", "engine:motion_emu,update_period:100,sensitivity:0.01")
-            .toString()
-            .toStdString();
-    Settings::values.touch_device =
-        qt_config->value("touch_device", "engine:emu_window").toString().toStdString();
+    Settings::values.touchscreen.enabled = qt_config->value("touchscreen_enabled", true).toBool();
+    Settings::values.touchscreen.device =
+        qt_config->value("touchscreen_device", "engine:emu_window").toString().toStdString();
 
+    Settings::values.touchscreen.finger = qt_config->value("touchscreen_finger", 0).toUInt();
+    Settings::values.touchscreen.rotation_angle = qt_config->value("touchscreen_angle", 0).toUInt();
+    Settings::values.touchscreen.diameter_x =
+        qt_config->value("touchscreen_diameter_x", 15).toUInt();
+    Settings::values.touchscreen.diameter_y =
+        qt_config->value("touchscreen_diameter_y", 15).toUInt();
     qt_config->endGroup();
 
     qt_config->beginGroup("Core");
@@ -124,6 +368,20 @@ void Config::ReadValues() {
                     QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)))
             .toString()
             .toStdString());
+    qt_config->endGroup();
+
+    std::transform(default_keyboard_keys.begin(), default_keyboard_keys.end(),
+                   Settings::values.keyboard_keys.begin(), InputCommon::GenerateKeyboardParam);
+    std::transform(default_keyboard_mods.begin(), default_keyboard_mods.end(),
+                   Settings::values.keyboard_keys.begin() +
+                       Settings::NativeKeyboard::LeftControlKey,
+                   InputCommon::GenerateKeyboardParam);
+    std::transform(default_keyboard_mods.begin(), default_keyboard_mods.end(),
+                   Settings::values.keyboard_mods.begin(), InputCommon::GenerateKeyboardParam);
+
+    qt_config->beginGroup("Core");
+    Settings::values.use_cpu_jit = qt_config->value("use_cpu_jit", true).toBool();
+    Settings::values.use_multi_core = qt_config->value("use_multi_core", false).toBool();
     qt_config->endGroup();
 
     qt_config->beginGroup("System");
@@ -232,16 +490,65 @@ void Config::ReadValues() {
 
 void Config::SaveValues() {
     qt_config->beginGroup("Controls");
+    for (int p = 0; p < 10; ++p) {
+        qt_config->setValue(QString("player_%1_connected").arg(p),
+                            Settings::values.players[p].connected);
+        qt_config->setValue(QString("player_%1_type").arg(p),
+                            static_cast<u8>(Settings::values.players[p].type));
+
+        qt_config->setValue(QString("player_%1_body_color_left").arg(p),
+                            Settings::values.players[p].body_color_left);
+        qt_config->setValue(QString("player_%1_body_color_right").arg(p),
+                            Settings::values.players[p].body_color_right);
+        qt_config->setValue(QString("player_%1_button_color_left").arg(p),
+                            Settings::values.players[p].button_color_left);
+        qt_config->setValue(QString("player_%1_button_color_right").arg(p),
+                            Settings::values.players[p].button_color_right);
+
+        for (int i = 0; i < Settings::NativeButton::NumButtons; ++i) {
+            qt_config->setValue(QString("player_%1_").arg(p) +
+                                    QString::fromStdString(Settings::NativeButton::mapping[i]),
+                                QString::fromStdString(Settings::values.players[p].buttons[i]));
+        }
+        for (int i = 0; i < Settings::NativeAnalog::NumAnalogs; ++i) {
+            qt_config->setValue(QString("player_%1_").arg(p) +
+                                    QString::fromStdString(Settings::NativeAnalog::mapping[i]),
+                                QString::fromStdString(Settings::values.players[p].analogs[i]));
+        }
+    }
+
+    qt_config->setValue("motion_device", QString::fromStdString(Settings::values.motion_device));
+
+    qt_config->setValue("mouse_enabled", Settings::values.mouse_enabled);
+
+    for (int i = 0; i < Settings::NativeMouseButton::NumMouseButtons; ++i) {
+        qt_config->setValue(QString("mouse_") +
+                                QString::fromStdString(Settings::NativeMouseButton::mapping[i]),
+                            QString::fromStdString(Settings::values.mouse_buttons[i]));
+    }
+
+    qt_config->setValue("keyboard_enabled", Settings::values.keyboard_enabled);
+
+    qt_config->setValue("debug_pad_enabled", Settings::values.debug_pad_enabled);
     for (int i = 0; i < Settings::NativeButton::NumButtons; ++i) {
-        qt_config->setValue(QString::fromStdString(Settings::NativeButton::mapping[i]),
-                            QString::fromStdString(Settings::values.buttons[i]));
+        qt_config->setValue(QString("debug_pad_") +
+                                QString::fromStdString(Settings::NativeButton::mapping[i]),
+                            QString::fromStdString(Settings::values.debug_pad_buttons[i]));
     }
     for (int i = 0; i < Settings::NativeAnalog::NumAnalogs; ++i) {
-        qt_config->setValue(QString::fromStdString(Settings::NativeAnalog::mapping[i]),
-                            QString::fromStdString(Settings::values.analogs[i]));
+        qt_config->setValue(QString("debug_pad_") +
+                                QString::fromStdString(Settings::NativeAnalog::mapping[i]),
+                            QString::fromStdString(Settings::values.debug_pad_analogs[i]));
     }
-    qt_config->setValue("motion_device", QString::fromStdString(Settings::values.motion_device));
-    qt_config->setValue("touch_device", QString::fromStdString(Settings::values.touch_device));
+
+    qt_config->setValue("touchscreen_enabled", Settings::values.touchscreen.enabled);
+    qt_config->setValue("touchscreen_device",
+                        QString::fromStdString(Settings::values.touchscreen.device));
+
+    qt_config->setValue("touchscreen_finger", Settings::values.touchscreen.finger);
+    qt_config->setValue("touchscreen_angle", Settings::values.touchscreen.rotation_angle);
+    qt_config->setValue("touchscreen_diameter_x", Settings::values.touchscreen.diameter_x);
+    qt_config->setValue("touchscreen_diameter_y", Settings::values.touchscreen.diameter_y);
     qt_config->endGroup();
 
     qt_config->beginGroup("Core");
@@ -280,7 +587,6 @@ void Config::SaveValues() {
     qt_config->setValue("use_docked_mode", Settings::values.use_docked_mode);
     qt_config->setValue("enable_nfc", Settings::values.enable_nfc);
     qt_config->setValue("current_user", Settings::values.current_user);
-
     qt_config->setValue("language_index", Settings::values.language_index);
 
     qt_config->setValue("rng_seed_enabled", Settings::values.rng_seed.has_value());

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -22,6 +22,10 @@ public:
 
     static const std::array<int, Settings::NativeButton::NumButtons> default_buttons;
     static const std::array<std::array<int, 5>, Settings::NativeAnalog::NumAnalogs> default_analogs;
+    static const std::array<int, Settings::NativeMouseButton::NumMouseButtons>
+        default_mouse_buttons;
+    static const std::array<int, Settings::NativeKeyboard::NumKeyboardKeys> default_keyboard_keys;
+    static const std::array<int, Settings::NativeKeyboard::NumKeyboardMods> default_keyboard_mods;
 
 private:
     void ReadValues();

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -29,7 +29,17 @@ public:
 
 private:
     void ReadValues();
+    void ReadPlayerValues();
+    void ReadDebugValues();
+    void ReadKeyboardValues();
+    void ReadMouseValues();
+    void ReadTouchscreenValues();
+
     void SaveValues();
+    void SavePlayerValues();
+    void SaveDebugValues();
+    void SaveMouseValues();
+    void SaveTouchscreenValues();
 
     std::unique_ptr<QSettings> qt_config;
     std::string qt_config_loc;

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -3,10 +3,6 @@
 // Refer to the license.txt file included.
 
 #include "core/core.h"
-#include "core/hle/service/am/am.h"
-#include "core/hle/service/am/applet_ae.h"
-#include "core/hle/service/am/applet_oe.h"
-#include "core/hle/service/sm/sm.h"
 #include "core/settings.h"
 #include "ui_configure_general.h"
 #include "yuzu/configuration/configure_general.h"
@@ -36,39 +32,11 @@ void ConfigureGeneral::setConfiguration() {
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing);
     ui->theme_combobox->setCurrentIndex(ui->theme_combobox->findData(UISettings::values.theme));
     ui->use_cpu_jit->setChecked(Settings::values.use_cpu_jit);
-    ui->use_docked_mode->setChecked(Settings::values.use_docked_mode);
     ui->enable_nfc->setChecked(Settings::values.enable_nfc);
 }
 
 void ConfigureGeneral::PopulateHotkeyList(const HotkeyRegistry& registry) {
     ui->widget->Populate(registry);
-}
-
-void ConfigureGeneral::OnDockedModeChanged(bool last_state, bool new_state) {
-    if (last_state == new_state) {
-        return;
-    }
-
-    Core::System& system{Core::System::GetInstance()};
-    if (!system.IsPoweredOn()) {
-        return;
-    }
-    Service::SM::ServiceManager& sm = system.ServiceManager();
-
-    // Message queue is shared between these services, we just need to signal an operation
-    // change to one and it will handle both automatically
-    auto applet_oe = sm.GetService<Service::AM::AppletOE>("appletOE");
-    auto applet_ae = sm.GetService<Service::AM::AppletAE>("appletAE");
-    bool has_signalled = false;
-
-    if (applet_oe != nullptr) {
-        applet_oe->GetMessageQueue()->OperationModeChanged();
-        has_signalled = true;
-    }
-
-    if (applet_ae != nullptr && !has_signalled) {
-        applet_ae->GetMessageQueue()->OperationModeChanged();
-    }
 }
 
 void ConfigureGeneral::applyConfiguration() {
@@ -78,9 +46,5 @@ void ConfigureGeneral::applyConfiguration() {
         ui->theme_combobox->itemData(ui->theme_combobox->currentIndex()).toString();
 
     Settings::values.use_cpu_jit = ui->use_cpu_jit->isChecked();
-    const bool pre_docked_mode = Settings::values.use_docked_mode;
-    Settings::values.use_docked_mode = ui->use_docked_mode->isChecked();
-    OnDockedModeChanged(pre_docked_mode, Settings::values.use_docked_mode);
-
     Settings::values.enable_nfc = ui->enable_nfc->isChecked();
 }

--- a/src/yuzu/configuration/configure_general.h
+++ b/src/yuzu/configuration/configure_general.h
@@ -25,7 +25,6 @@ public:
 
 private:
     void setConfiguration();
-    void OnDockedModeChanged(bool last_state, bool new_state);
 
     std::unique_ptr<Ui::ConfigureGeneral> ui;
 };

--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>300</width>
-    <height>377</height>
+    <height>407</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -71,13 +71,6 @@
        <layout class="QHBoxLayout" name="EmulationHorizontalLayout">
         <item>
          <layout class="QVBoxLayout" name="EmulationVerticalLayout">
-          <item>
-           <widget class="QCheckBox" name="use_docked_mode">
-            <property name="text">
-             <string>Enable docked mode</string>
-            </property>
-           </widget>
-          </item>
           <item>
            <widget class="QCheckBox" name="enable_nfc">
             <property name="text">

--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -9,334 +9,164 @@
 #include <QMessageBox>
 #include <QTimer>
 #include "common/param_package.h"
+#include "configuration/configure_touchscreen_advanced.h"
+#include "core/core.h"
 #include "input_common/main.h"
+#include "ui_configure_input.h"
+#include "ui_configure_input_player.h"
+#include "ui_configure_mouse_advanced.h"
+#include "ui_configure_touchscreen_advanced.h"
 #include "yuzu/configuration/config.h"
 #include "yuzu/configuration/configure_input.h"
-
-const std::array<std::string, ConfigureInput::ANALOG_SUB_BUTTONS_NUM>
-    ConfigureInput::analog_sub_buttons{{
-        "up",
-        "down",
-        "left",
-        "right",
-        "modifier",
-    }};
-
-static QString getKeyName(int key_code) {
-    switch (key_code) {
-    case Qt::Key_Shift:
-        return QObject::tr("Shift");
-    case Qt::Key_Control:
-        return QObject::tr("Ctrl");
-    case Qt::Key_Alt:
-        return QObject::tr("Alt");
-    case Qt::Key_Meta:
-        return "";
-    default:
-        return QKeySequence(key_code).toString();
-    }
-}
-
-static void SetAnalogButton(const Common::ParamPackage& input_param,
-                            Common::ParamPackage& analog_param, const std::string& button_name) {
-    if (analog_param.Get("engine", "") != "analog_from_button") {
-        analog_param = {
-            {"engine", "analog_from_button"},
-            {"modifier_scale", "0.5"},
-        };
-    }
-    analog_param.Set(button_name, input_param.Serialize());
-}
-
-static QString ButtonToText(const Common::ParamPackage& param) {
-    if (!param.Has("engine")) {
-        return QObject::tr("[not set]");
-    } else if (param.Get("engine", "") == "keyboard") {
-        return getKeyName(param.Get("code", 0));
-    } else if (param.Get("engine", "") == "sdl") {
-        if (param.Has("hat")) {
-            return QString(QObject::tr("Hat %1 %2"))
-                .arg(param.Get("hat", "").c_str(), param.Get("direction", "").c_str());
-        }
-        if (param.Has("axis")) {
-            return QString(QObject::tr("Axis %1%2"))
-                .arg(param.Get("axis", "").c_str(), param.Get("direction", "").c_str());
-        }
-        if (param.Has("button")) {
-            return QString(QObject::tr("Button %1")).arg(param.Get("button", "").c_str());
-        }
-        return QString();
-    } else {
-        return QObject::tr("[unknown]");
-    }
-};
-
-static QString AnalogToText(const Common::ParamPackage& param, const std::string& dir) {
-    if (!param.Has("engine")) {
-        return QObject::tr("[not set]");
-    } else if (param.Get("engine", "") == "analog_from_button") {
-        return ButtonToText(Common::ParamPackage{param.Get(dir, "")});
-    } else if (param.Get("engine", "") == "sdl") {
-        if (dir == "modifier") {
-            return QString(QObject::tr("[unused]"));
-        }
-
-        if (dir == "left" || dir == "right") {
-            return QString(QObject::tr("Axis %1")).arg(param.Get("axis_x", "").c_str());
-        } else if (dir == "up" || dir == "down") {
-            return QString(QObject::tr("Axis %1")).arg(param.Get("axis_y", "").c_str());
-        }
-        return QString();
-    } else {
-        return QObject::tr("[unknown]");
-    }
-};
+#include "yuzu/configuration/configure_input_player.h"
+#include "yuzu/configuration/configure_mouse_advanced.h"
 
 ConfigureInput::ConfigureInput(QWidget* parent)
-    : QWidget(parent), ui(std::make_unique<Ui::ConfigureInput>()),
-      timeout_timer(std::make_unique<QTimer>()), poll_timer(std::make_unique<QTimer>()) {
-
+    : QWidget(parent), ui(std::make_unique<Ui::ConfigureInput>()) {
     ui->setupUi(this);
-    setFocusPolicy(Qt::ClickFocus);
 
-    button_map = {
-        ui->buttonA,          ui->buttonB,        ui->buttonX,           ui->buttonY,
-        ui->buttonLStick,     ui->buttonRStick,   ui->buttonL,           ui->buttonR,
-        ui->buttonZL,         ui->buttonZR,       ui->buttonPlus,        ui->buttonMinus,
-        ui->buttonDpadLeft,   ui->buttonDpadUp,   ui->buttonDpadRight,   ui->buttonDpadDown,
-        ui->buttonLStickLeft, ui->buttonLStickUp, ui->buttonLStickRight, ui->buttonLStickDown,
-        ui->buttonRStickLeft, ui->buttonRStickUp, ui->buttonRStickRight, ui->buttonRStickDown,
-        ui->buttonSL,         ui->buttonSR,       ui->buttonHome,        ui->buttonScreenshot,
+    players_enabled = {
+        ui->player1_checkbox, ui->player2_checkbox, ui->player3_checkbox, ui->player4_checkbox,
+        ui->player5_checkbox, ui->player6_checkbox, ui->player7_checkbox, ui->player8_checkbox,
     };
 
-    analog_map_buttons = {{
-        {
-            ui->buttonLStickUp,
-            ui->buttonLStickDown,
-            ui->buttonLStickLeft,
-            ui->buttonLStickRight,
-            ui->buttonLStickMod,
-        },
-        {
-            ui->buttonRStickUp,
-            ui->buttonRStickDown,
-            ui->buttonRStickLeft,
-            ui->buttonRStickRight,
-            ui->buttonRStickMod,
-        },
-    }};
+    player_controller = {
+        ui->player1_combobox, ui->player2_combobox, ui->player3_combobox, ui->player4_combobox,
+        ui->player5_combobox, ui->player6_combobox, ui->player7_combobox, ui->player8_combobox,
+    };
 
-    analog_map_stick = {ui->buttonLStickAnalog, ui->buttonRStickAnalog};
+    player_configure = {
+        ui->player1_configure, ui->player2_configure, ui->player3_configure, ui->player4_configure,
+        ui->player5_configure, ui->player6_configure, ui->player7_configure, ui->player8_configure,
+    };
 
-    for (int button_id = 0; button_id < Settings::NativeButton::NumButtons; button_id++) {
-        if (!button_map[button_id])
-            continue;
-        button_map[button_id]->setContextMenuPolicy(Qt::CustomContextMenu);
-        connect(button_map[button_id], &QPushButton::released, [=]() {
-            handleClick(
-                button_map[button_id],
-                [=](const Common::ParamPackage& params) { buttons_param[button_id] = params; },
-                InputCommon::Polling::DeviceType::Button);
-        });
-        connect(button_map[button_id], &QPushButton::customContextMenuRequested,
-                [=](const QPoint& menu_location) {
-                    QMenu context_menu;
-                    context_menu.addAction(tr("Clear"), [&] {
-                        buttons_param[button_id].Clear();
-                        button_map[button_id]->setText(tr("[not set]"));
-                    });
-                    context_menu.addAction(tr("Restore Default"), [&] {
-                        buttons_param[button_id] = Common::ParamPackage{
-                            InputCommon::GenerateKeyboardParam(Config::default_buttons[button_id])};
-                        button_map[button_id]->setText(ButtonToText(buttons_param[button_id]));
-                    });
-                    context_menu.exec(button_map[button_id]->mapToGlobal(menu_location));
-                });
+    for (auto* controller_box : player_controller) {
+        controller_box->addItems(
+            {"Pro Controller", "Dual Joycons", "Single Right Joycon", "Single Left Joycon"});
     }
-
-    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
-        for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; sub_button_id++) {
-            if (!analog_map_buttons[analog_id][sub_button_id])
-                continue;
-            analog_map_buttons[analog_id][sub_button_id]->setContextMenuPolicy(
-                Qt::CustomContextMenu);
-            connect(analog_map_buttons[analog_id][sub_button_id], &QPushButton::released, [=]() {
-                handleClick(analog_map_buttons[analog_id][sub_button_id],
-                            [=](const Common::ParamPackage& params) {
-                                SetAnalogButton(params, analogs_param[analog_id],
-                                                analog_sub_buttons[sub_button_id]);
-                            },
-                            InputCommon::Polling::DeviceType::Button);
-            });
-            connect(analog_map_buttons[analog_id][sub_button_id],
-                    &QPushButton::customContextMenuRequested, [=](const QPoint& menu_location) {
-                        QMenu context_menu;
-                        context_menu.addAction(tr("Clear"), [&] {
-                            analogs_param[analog_id].Erase(analog_sub_buttons[sub_button_id]);
-                            analog_map_buttons[analog_id][sub_button_id]->setText(tr("[not set]"));
-                        });
-                        context_menu.addAction(tr("Restore Default"), [&] {
-                            Common::ParamPackage params{InputCommon::GenerateKeyboardParam(
-                                Config::default_analogs[analog_id][sub_button_id])};
-                            SetAnalogButton(params, analogs_param[analog_id],
-                                            analog_sub_buttons[sub_button_id]);
-                            analog_map_buttons[analog_id][sub_button_id]->setText(AnalogToText(
-                                analogs_param[analog_id], analog_sub_buttons[sub_button_id]));
-                        });
-                        context_menu.exec(analog_map_buttons[analog_id][sub_button_id]->mapToGlobal(
-                            menu_location));
-                    });
-        }
-        connect(analog_map_stick[analog_id], &QPushButton::released, [=]() {
-            QMessageBox::information(this, tr("Information"),
-                                     tr("After pressing OK, first move your joystick horizontally, "
-                                        "and then vertically."));
-            handleClick(
-                analog_map_stick[analog_id],
-                [=](const Common::ParamPackage& params) { analogs_param[analog_id] = params; },
-                InputCommon::Polling::DeviceType::Analog);
-        });
-    }
-
-    connect(ui->buttonClearAll, &QPushButton::released, [this] { ClearAll(); });
-    connect(ui->buttonRestoreDefaults, &QPushButton::released, [this]() { restoreDefaults(); });
-
-    timeout_timer->setSingleShot(true);
-    connect(timeout_timer.get(), &QTimer::timeout, [this]() { setPollingResult({}, true); });
-
-    connect(poll_timer.get(), &QTimer::timeout, [this]() {
-        Common::ParamPackage params;
-        for (auto& poller : device_pollers) {
-            params = poller->GetNextInput();
-            if (params.Has("engine")) {
-                setPollingResult(params, false);
-                return;
-            }
-        }
-    });
 
     this->loadConfiguration();
+    updateUIEnabled();
 
-    // TODO(wwylele): enable this when we actually emulate it
-    ui->buttonHome->setEnabled(false);
+    connect(ui->restore_defaults_button, &QPushButton::pressed, this,
+            &ConfigureInput::restoreDefaults);
+
+    for (auto* enabled : players_enabled)
+        connect(enabled, &QCheckBox::stateChanged, this, &ConfigureInput::updateUIEnabled);
+    connect(ui->use_docked_mode, &QCheckBox::stateChanged, this, &ConfigureInput::updateUIEnabled);
+    connect(ui->handheld_connected, &QCheckBox::stateChanged, this,
+            &ConfigureInput::updateUIEnabled);
+    connect(ui->mouse_enabled, &QCheckBox::stateChanged, this, &ConfigureInput::updateUIEnabled);
+    connect(ui->keyboard_enabled, &QCheckBox::stateChanged, this, &ConfigureInput::updateUIEnabled);
+    connect(ui->debug_enabled, &QCheckBox::stateChanged, this, &ConfigureInput::updateUIEnabled);
+    connect(ui->touchscreen_enabled, &QCheckBox::stateChanged, this,
+            &ConfigureInput::updateUIEnabled);
+
+    for (std::size_t i = 0; i < player_configure.size(); ++i) {
+        connect(player_configure[i], &QPushButton::pressed, this,
+                [this, i]() { CallConfigureDialog<ConfigureInputPlayer>(i, false); });
+    }
+
+    connect(ui->handheld_configure, &QPushButton::pressed, this,
+            [this]() { CallConfigureDialog<ConfigureInputPlayer>(8, false); });
+
+    connect(ui->debug_configure, &QPushButton::pressed, this,
+            [this]() { CallConfigureDialog<ConfigureInputPlayer>(9, true); });
+
+    connect(ui->mouse_advanced, &QPushButton::pressed, this,
+            [this]() { CallConfigureDialog<ConfigureMouseAdvanced>(); });
+
+    connect(ui->touchscreen_advanced, &QPushButton::pressed, this,
+            [this]() { CallConfigureDialog<ConfigureTouchscreenAdvanced>(); });
+
+    ui->use_docked_mode->setEnabled(!Core::System::GetInstance().IsPoweredOn());
+}
+
+template <typename Dialog, typename... Args>
+void ConfigureInput::CallConfigureDialog(Args... args) {
+    this->applyConfiguration();
+    Dialog dialog(this, args...);
+
+    const auto res = dialog.exec();
+    if (res == QDialog::Accepted) {
+        dialog.applyConfiguration();
+    }
 }
 
 void ConfigureInput::applyConfiguration() {
-    std::transform(buttons_param.begin(), buttons_param.end(), Settings::values.buttons.begin(),
-                   [](const Common::ParamPackage& param) { return param.Serialize(); });
-    std::transform(analogs_param.begin(), analogs_param.end(), Settings::values.analogs.begin(),
-                   [](const Common::ParamPackage& param) { return param.Serialize(); });
+    for (std::size_t i = 0; i < 8; ++i) {
+        Settings::values.players[i].connected = players_enabled[i]->isChecked();
+        Settings::values.players[i].type =
+            static_cast<Settings::ControllerType>(player_controller[i]->currentIndex());
+    }
+
+    Settings::values.use_docked_mode = ui->use_docked_mode->isChecked();
+    Settings::values.players[8].connected = ui->handheld_connected->isChecked();
+    Settings::values.debug_pad_enabled = ui->debug_enabled->isChecked();
+    Settings::values.mouse_enabled = ui->mouse_enabled->isChecked();
+    Settings::values.keyboard_enabled = ui->keyboard_enabled->isChecked();
+    Settings::values.touchscreen.enabled = ui->touchscreen_enabled->isChecked();
+}
+
+void ConfigureInput::updateUIEnabled() {
+    for (std::size_t i = 0; i < 8; ++i) {
+        const auto enabled = players_enabled[i]->checkState() == Qt::Checked;
+
+        player_controller[i]->setEnabled(enabled);
+        player_configure[i]->setEnabled(enabled);
+    }
+
+    bool hit_disabled = false;
+    for (auto* player : players_enabled) {
+        if (hit_disabled)
+            player->setDisabled(true);
+        else
+            player->setEnabled(true);
+        if (!player->isChecked())
+            hit_disabled = true;
+    }
+
+    ui->handheld_connected->setEnabled(!ui->use_docked_mode->isChecked());
+    ui->handheld_configure->setEnabled(ui->handheld_connected->isChecked() &&
+                                       !ui->use_docked_mode->isChecked());
+    ui->mouse_advanced->setEnabled(ui->mouse_enabled->isChecked());
+    ui->debug_configure->setEnabled(ui->debug_enabled->isChecked());
+    ui->touchscreen_advanced->setEnabled(ui->touchscreen_enabled->isChecked());
 }
 
 void ConfigureInput::loadConfiguration() {
-    std::transform(Settings::values.buttons.begin(), Settings::values.buttons.end(),
-                   buttons_param.begin(),
-                   [](const std::string& str) { return Common::ParamPackage(str); });
-    std::transform(Settings::values.analogs.begin(), Settings::values.analogs.end(),
-                   analogs_param.begin(),
-                   [](const std::string& str) { return Common::ParamPackage(str); });
-    updateButtonLabels();
+    std::stable_partition(Settings::values.players.begin(), Settings::values.players.end(),
+                          [](const auto& player) { return player.connected; });
+
+    for (std::size_t i = 0; i < 8; ++i) {
+        players_enabled[i]->setChecked(Settings::values.players[i].connected);
+        player_controller[i]->setCurrentIndex(static_cast<u8>(Settings::values.players[i].type));
+    }
+
+    ui->use_docked_mode->setChecked(Settings::values.use_docked_mode);
+    ui->handheld_connected->setChecked(Settings::values.players[8].connected);
+    ui->debug_enabled->setChecked(Settings::values.debug_pad_enabled);
+    ui->mouse_enabled->setChecked(Settings::values.mouse_enabled);
+    ui->keyboard_enabled->setChecked(Settings::values.keyboard_enabled);
+    ui->touchscreen_enabled->setChecked(Settings::values.touchscreen.enabled);
+
+    updateUIEnabled();
 }
 
 void ConfigureInput::restoreDefaults() {
-    for (int button_id = 0; button_id < Settings::NativeButton::NumButtons; button_id++) {
-        buttons_param[button_id] = Common::ParamPackage{
-            InputCommon::GenerateKeyboardParam(Config::default_buttons[button_id])};
+    players_enabled[0]->setCheckState(Qt::Checked);
+    player_controller[0]->setCurrentIndex(1);
+
+    for (std::size_t i = 1; i < 8; ++i) {
+        players_enabled[i]->setCheckState(Qt::Unchecked);
+        player_controller[i]->setCurrentIndex(0);
     }
 
-    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
-        for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; sub_button_id++) {
-            Common::ParamPackage params{InputCommon::GenerateKeyboardParam(
-                Config::default_analogs[analog_id][sub_button_id])};
-            SetAnalogButton(params, analogs_param[analog_id], analog_sub_buttons[sub_button_id]);
-        }
-    }
-    updateButtonLabels();
-}
-
-void ConfigureInput::ClearAll() {
-    for (int button_id = 0; button_id < Settings::NativeButton::NumButtons; button_id++) {
-        if (button_map[button_id] && button_map[button_id]->isEnabled())
-            buttons_param[button_id].Clear();
-    }
-    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
-        for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; sub_button_id++) {
-            if (analog_map_buttons[analog_id][sub_button_id] &&
-                analog_map_buttons[analog_id][sub_button_id]->isEnabled())
-                analogs_param[analog_id].Erase(analog_sub_buttons[sub_button_id]);
-        }
-    }
-    updateButtonLabels();
-}
-
-void ConfigureInput::updateButtonLabels() {
-    for (int button = 0; button < Settings::NativeButton::NumButtons; button++) {
-        button_map[button]->setText(ButtonToText(buttons_param[button]));
-    }
-
-    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
-        for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; sub_button_id++) {
-            if (analog_map_buttons[analog_id][sub_button_id]) {
-                analog_map_buttons[analog_id][sub_button_id]->setText(
-                    AnalogToText(analogs_param[analog_id], analog_sub_buttons[sub_button_id]));
-            }
-        }
-        analog_map_stick[analog_id]->setText(tr("Set Analog Stick"));
-    }
-}
-
-void ConfigureInput::handleClick(QPushButton* button,
-                                 std::function<void(const Common::ParamPackage&)> new_input_setter,
-                                 InputCommon::Polling::DeviceType type) {
-    button->setText(tr("[press key]"));
-    button->setFocus();
-
-    input_setter = new_input_setter;
-
-    device_pollers = InputCommon::Polling::GetPollers(type);
-
-    // Keyboard keys can only be used as button devices
-    want_keyboard_keys = type == InputCommon::Polling::DeviceType::Button;
-
-    for (auto& poller : device_pollers) {
-        poller->Start();
-    }
-
-    grabKeyboard();
-    grabMouse();
-    timeout_timer->start(5000); // Cancel after 5 seconds
-    poll_timer->start(200);     // Check for new inputs every 200ms
-}
-
-void ConfigureInput::setPollingResult(const Common::ParamPackage& params, bool abort) {
-    releaseKeyboard();
-    releaseMouse();
-    timeout_timer->stop();
-    poll_timer->stop();
-    for (auto& poller : device_pollers) {
-        poller->Stop();
-    }
-
-    if (!abort) {
-        (*input_setter)(params);
-    }
-
-    updateButtonLabels();
-    input_setter = {};
-}
-
-void ConfigureInput::keyPressEvent(QKeyEvent* event) {
-    if (!input_setter || !event)
-        return;
-
-    if (event->key() != Qt::Key_Escape) {
-        if (want_keyboard_keys) {
-            setPollingResult(Common::ParamPackage{InputCommon::GenerateKeyboardParam(event->key())},
-                             false);
-        } else {
-            // Escape key wasn't pressed and we don't want any keyboard keys, so don't stop polling
-            return;
-        }
-    }
-    setPollingResult({}, true);
+    ui->use_docked_mode->setCheckState(Qt::Unchecked);
+    ui->handheld_connected->setCheckState(Qt::Unchecked);
+    ui->mouse_enabled->setCheckState(Qt::Unchecked);
+    ui->keyboard_enabled->setCheckState(Qt::Unchecked);
+    ui->debug_enabled->setCheckState(Qt::Unchecked);
+    ui->touchscreen_enabled->setCheckState(Qt::Checked);
+    updateUIEnabled();
 }

--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -149,6 +149,8 @@ void ConfigureInput::updateUIEnabled() {
     bool hit_disabled = false;
     for (auto* player : players_controller) {
         player->setDisabled(hit_disabled);
+        if (hit_disabled)
+            player->setCurrentIndex(0);
         if (!hit_disabled && player->currentIndex() == 0)
             hit_disabled = true;
     }

--- a/src/yuzu/configuration/configure_input.h
+++ b/src/yuzu/configuration/configure_input.h
@@ -43,6 +43,8 @@ private:
     template <typename Dialog, typename... Args>
     void CallConfigureDialog(Args&&... args);
 
+    void OnDockedModeChanged(bool last_state, bool new_state);
+
     /// Load configuration settings.
     void loadConfiguration();
     /// Restore all buttons to their default values.
@@ -50,7 +52,6 @@ private:
 
     std::unique_ptr<Ui::ConfigureInput> ui;
 
-    std::array<QCheckBox*, 8> players_enabled;
-    std::array<QComboBox*, 8> player_controller;
-    std::array<QPushButton*, 8> player_configure;
+    std::array<QComboBox*, 8> players_controller;
+    std::array<QPushButton*, 8> players_configure;
 };

--- a/src/yuzu/configuration/configure_input.h
+++ b/src/yuzu/configuration/configure_input.h
@@ -18,6 +18,7 @@
 #include "core/settings.h"
 #include "input_common/main.h"
 #include "ui_configure_input.h"
+#include "yuzu/configuration/config.h"
 
 class QPushButton;
 class QString;
@@ -37,57 +38,19 @@ public:
     void applyConfiguration();
 
 private:
-    std::unique_ptr<Ui::ConfigureInput> ui;
+    void updateUIEnabled();
 
-    std::unique_ptr<QTimer> timeout_timer;
-    std::unique_ptr<QTimer> poll_timer;
-
-    /// This will be the the setting function when an input is awaiting configuration.
-    std::optional<std::function<void(const Common::ParamPackage&)>> input_setter;
-
-    std::array<Common::ParamPackage, Settings::NativeButton::NumButtons> buttons_param;
-    std::array<Common::ParamPackage, Settings::NativeAnalog::NumAnalogs> analogs_param;
-
-    static constexpr int ANALOG_SUB_BUTTONS_NUM = 5;
-
-    /// Each button input is represented by a QPushButton.
-    std::array<QPushButton*, Settings::NativeButton::NumButtons> button_map;
-
-    /// A group of five QPushButtons represent one analog input. The buttons each represent up,
-    /// down, left, right, and modifier, respectively.
-    std::array<std::array<QPushButton*, ANALOG_SUB_BUTTONS_NUM>, Settings::NativeAnalog::NumAnalogs>
-        analog_map_buttons;
-
-    /// Analog inputs are also represented each with a single button, used to configure with an
-    /// actual analog stick
-    std::array<QPushButton*, Settings::NativeAnalog::NumAnalogs> analog_map_stick;
-
-    static const std::array<std::string, ANALOG_SUB_BUTTONS_NUM> analog_sub_buttons;
-
-    std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> device_pollers;
-
-    /// A flag to indicate if keyboard keys are okay when configuring an input. If this is false,
-    /// keyboard events are ignored.
-    bool want_keyboard_keys = false;
+    template <typename Dialog, typename... Args>
+    void CallConfigureDialog(Args... args);
 
     /// Load configuration settings.
     void loadConfiguration();
     /// Restore all buttons to their default values.
     void restoreDefaults();
-    /// Clear all input configuration
-    void ClearAll();
 
-    /// Update UI to reflect current configuration.
-    void updateButtonLabels();
+    std::unique_ptr<Ui::ConfigureInput> ui;
 
-    /// Called when the button was pressed.
-    void handleClick(QPushButton* button,
-                     std::function<void(const Common::ParamPackage&)> new_input_setter,
-                     InputCommon::Polling::DeviceType type);
-
-    /// Finish polling and configure input using the input_setter
-    void setPollingResult(const Common::ParamPackage& params, bool abort);
-
-    /// Handle key press events.
-    void keyPressEvent(QKeyEvent* event) override;
+    std::array<QCheckBox*, 8> players_enabled;
+    std::array<QComboBox*, 8> player_controller;
+    std::array<QPushButton*, 8> player_configure;
 };

--- a/src/yuzu/configuration/configure_input.h
+++ b/src/yuzu/configuration/configure_input.h
@@ -41,7 +41,7 @@ private:
     void updateUIEnabled();
 
     template <typename Dialog, typename... Args>
-    void CallConfigureDialog(Args... args);
+    void CallConfigureDialog(Args&&... args);
 
     /// Load configuration settings.
     void loadConfiguration();

--- a/src/yuzu/configuration/configure_input.ui
+++ b/src/yuzu/configuration/configure_input.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>473</width>
-    <height>677</height>
+    <height>685</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -46,62 +46,6 @@
           </property>
           <property name="alignment">
            <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QCheckBox" name="player1_checkbox">
-          <property name="text">
-           <string>Player 1</string>
-          </property>
-         </widget>
-        </item>
-        <item row="7" column="1">
-         <widget class="QCheckBox" name="player7_checkbox">
-          <property name="text">
-           <string>Player 7</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QCheckBox" name="player4_checkbox">
-          <property name="text">
-           <string>Player 4</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="QCheckBox" name="player5_checkbox">
-          <property name="text">
-           <string>Player 5</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="QCheckBox" name="player6_checkbox">
-          <property name="text">
-           <string>Player 6</string>
-          </property>
-         </widget>
-        </item>
-        <item row="8" column="1">
-         <widget class="QCheckBox" name="player8_checkbox">
-          <property name="text">
-           <string>Player 8</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QCheckBox" name="player3_checkbox">
-          <property name="text">
-           <string>Player 3</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QCheckBox" name="player2_checkbox">
-          <property name="text">
-           <string>Player 2</string>
           </property>
          </widget>
         </item>
@@ -250,13 +194,65 @@
           </property>
          </spacer>
         </item>
-        <item row="0" column="1">
-         <widget class="QLabel" name="label_2">
-          <property name="text">
-           <string>Enabled</string>
+        <item row="1" column="1">
+         <widget class="QLabel" name="label_3">
+          <property name="minimumSize">
+           <size>
+            <width>55</width>
+            <height>0</height>
+           </size>
           </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
+          <property name="text">
+           <string>Player 1</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Player 2</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QLabel" name="label_5">
+          <property name="text">
+           <string>Player 3</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QLabel" name="label_6">
+          <property name="text">
+           <string>Player 4</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QLabel" name="label_7">
+          <property name="text">
+           <string>Player 5</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="QLabel" name="label_8">
+          <property name="text">
+           <string>Player 6</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="1">
+         <widget class="QLabel" name="label_9">
+          <property name="text">
+           <string>Player 7</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="1">
+         <widget class="QLabel" name="label_10">
+          <property name="text">
+           <string>Player 8</string>
           </property>
          </widget>
         </item>

--- a/src/yuzu/configuration/configure_input.ui
+++ b/src/yuzu/configuration/configure_input.ui
@@ -317,7 +317,7 @@
         <item row="1" column="1">
          <widget class="QCheckBox" name="handheld_connected">
           <property name="text">
-           <string>Connected</string>
+           <string>Joycons Docked</string>
           </property>
          </widget>
         </item>

--- a/src/yuzu/configuration/configure_input.ui
+++ b/src/yuzu/configuration/configure_input.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>343</width>
+    <width>473</width>
     <height>677</height>
    </rect>
   </property>
@@ -15,740 +15,474 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_5">
    <item>
-    <layout class="QGridLayout" name="buttons">
-     <item row="3" column="1">
-      <widget class="QGroupBox" name="misc">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QGroupBox" name="gridGroupBox">
        <property name="title">
-        <string>Misc.</string>
+        <string>Players</string>
        </property>
-       <property name="flat">
-        <bool>false</bool>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_6">
-        <item row="0" column="0">
-         <layout class="QVBoxLayout" name="buttonMiscMinusVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelMinus">
-            <property name="text">
-             <string>Minus:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonMinus">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="1" column="2">
+         <widget class="QComboBox" name="player1_combobox">
+          <property name="minimumSize">
+           <size>
+            <width>110</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
         </item>
-        <item row="0" column="1">
-         <layout class="QVBoxLayout" name="buttonMiscPlusVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelPlus">
-            <property name="text">
-             <string>Plus:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonPlus">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
+        <item row="1" column="3">
+         <widget class="QPushButton" name="player1_configure">
+          <property name="text">
+           <string>Configure</string>
+          </property>
+         </widget>
         </item>
-        <item row="1" column="0">
-         <layout class="QVBoxLayout" name="buttonMiscHomeVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelHome">
-            <property name="text">
-             <string>Home:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonHome">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
+        <item row="0" column="2">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Controller Type</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
         </item>
         <item row="1" column="1">
-         <layout class="QVBoxLayout" name="buttonMiscScrCapVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelScrCap">
-            <property name="text">
-             <string>Screen
-Capture:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonScreenshot">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
+         <widget class="QCheckBox" name="player1_checkbox">
+          <property name="text">
+           <string>Player 1</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="1">
+         <widget class="QCheckBox" name="player7_checkbox">
+          <property name="text">
+           <string>Player 7</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QCheckBox" name="player4_checkbox">
+          <property name="text">
+           <string>Player 4</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QCheckBox" name="player5_checkbox">
+          <property name="text">
+           <string>Player 5</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="1">
+         <widget class="QCheckBox" name="player6_checkbox">
+          <property name="text">
+           <string>Player 6</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="1">
+         <widget class="QCheckBox" name="player8_checkbox">
+          <property name="text">
+           <string>Player 8</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QCheckBox" name="player3_checkbox">
+          <property name="text">
+           <string>Player 3</string>
+          </property>
+         </widget>
         </item>
         <item row="2" column="1">
-         <spacer name="verticalSpacer">
+         <widget class="QCheckBox" name="player2_checkbox">
+          <property name="text">
+           <string>Player 2</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="2">
+         <widget class="QComboBox" name="player2_combobox">
+          <property name="minimumSize">
+           <size>
+            <width>110</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="2">
+         <widget class="QComboBox" name="player3_combobox">
+          <property name="minimumSize">
+           <size>
+            <width>110</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="2">
+         <widget class="QComboBox" name="player4_combobox">
+          <property name="minimumSize">
+           <size>
+            <width>110</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="2">
+         <widget class="QComboBox" name="player5_combobox">
+          <property name="minimumSize">
+           <size>
+            <width>110</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="2">
+         <widget class="QComboBox" name="player6_combobox">
+          <property name="minimumSize">
+           <size>
+            <width>110</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="2">
+         <widget class="QComboBox" name="player7_combobox">
+          <property name="minimumSize">
+           <size>
+            <width>110</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="2">
+         <widget class="QComboBox" name="player8_combobox">
+          <property name="minimumSize">
+           <size>
+            <width>110</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="3">
+         <widget class="QPushButton" name="player2_configure">
+          <property name="text">
+           <string>Configure</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="3">
+         <widget class="QPushButton" name="player3_configure">
+          <property name="text">
+           <string>Configure</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="3">
+         <widget class="QPushButton" name="player4_configure">
+          <property name="text">
+           <string>Configure</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="3">
+         <widget class="QPushButton" name="player5_configure">
+          <property name="text">
+           <string>Configure</string>
+          </property>
+         </widget>
+        </item>
+        <item row="6" column="3">
+         <widget class="QPushButton" name="player6_configure">
+          <property name="text">
+           <string>Configure</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="3">
+         <widget class="QPushButton" name="player7_configure">
+          <property name="text">
+           <string>Configure</string>
+          </property>
+         </widget>
+        </item>
+        <item row="8" column="3">
+         <widget class="QPushButton" name="player8_configure">
+          <property name="text">
+           <string>Configure</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <spacer name="horizontalSpacer">
           <property name="orientation">
-           <enum>Qt::Vertical</enum>
+           <enum>Qt::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
-            <width>20</width>
-            <height>40</height>
+            <width>40</width>
+            <height>20</height>
            </size>
           </property>
          </spacer>
         </item>
-       </layout>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QGroupBox" name="faceButtons">
-       <property name="title">
-        <string>Face Buttons</string>
-       </property>
-       <property name="flat">
-        <bool>false</bool>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="0" column="0">
-         <layout class="QVBoxLayout" name="buttonFaceButtonsAVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelA">
-            <property name="text">
-             <string>A:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonA">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
+        <item row="0" column="4">
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
         <item row="0" column="1">
-         <layout class="QVBoxLayout" name="buttonFaceButtonsBVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelB">
-            <property name="text">
-             <string>B:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonB">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="0">
-         <layout class="QVBoxLayout" name="buttonFaceButtonsXVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelX">
-            <property name="text">
-             <string>X:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonX">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="1">
-         <layout class="QVBoxLayout" name="buttonFaceButtonsYVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelY">
-            <property name="text">
-             <string>Y:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonY">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>Enabled</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>
      </item>
-     <item row="0" column="1">
-      <widget class="QGroupBox" name="Dpad">
+     <item>
+      <widget class="QGroupBox" name="gridGroupBox">
        <property name="title">
-        <string>Directional Pad</string>
-       </property>
-       <property name="flat">
-        <bool>false</bool>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
+        <string>Handheld</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_2">
+        <item row="1" column="2">
+         <spacer name="horizontalSpacer_5">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>72</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="1" column="4">
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="1" column="3">
+         <widget class="QPushButton" name="handheld_configure">
+          <property name="text">
+           <string>Configure</string>
+          </property>
+         </widget>
+        </item>
         <item row="1" column="0">
-         <layout class="QVBoxLayout" name="buttonDpadUpVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelDpadUp">
-            <property name="text">
-             <string>Up:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonDpadUp">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
         </item>
         <item row="1" column="1">
-         <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelDpadDown">
-            <property name="text">
-             <string>Down:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonDpadDown">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="0" column="0">
-         <layout class="QVBoxLayout" name="buttonDpadLeftVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelDpadLeft">
-            <property name="text">
-             <string>Left:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonDpadLeft">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
+         <widget class="QCheckBox" name="handheld_connected">
+          <property name="text">
+           <string>Connected</string>
+          </property>
+         </widget>
         </item>
         <item row="0" column="1">
-         <layout class="QVBoxLayout" name="buttonDpadRightVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelDpadRight">
-            <property name="text">
-             <string>Right:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonDpadRight">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
+         <widget class="QCheckBox" name="use_docked_mode">
+          <property name="text">
+           <string>Use Docked Mode</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QGroupBox" name="shoulderButtons">
+     <item>
+      <widget class="QGroupBox" name="gridGroupBox">
        <property name="title">
-        <string>Shoulder Buttons</string>
-       </property>
-       <property name="flat">
-        <bool>false</bool>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
+        <string>Other</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_3">
-        <item row="0" column="0">
-         <layout class="QVBoxLayout" name="buttonShoulderButtonsLVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelL">
-            <property name="text">
-             <string>L:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonL">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="0" column="1">
-         <layout class="QVBoxLayout" name="buttonShoulderButtonsRVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelR">
-            <property name="text">
-             <string>R:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonR">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="0">
-         <layout class="QVBoxLayout" name="buttonShoulderButtonsZLVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelZL">
-            <property name="text">
-             <string>ZL:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonZL">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
         <item row="1" column="1">
-         <layout class="QVBoxLayout" name="buttonShoulderButtonsZRVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelZR">
-            <property name="text">
-             <string>ZR:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonZR">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="2" column="0">
-         <layout class="QVBoxLayout" name="buttonShoulderButtonsSLVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelSL">
-            <property name="text">
-             <string>SL:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonSL">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="2" column="1">
-         <layout class="QVBoxLayout" name="buttonShoulderButtonsSRVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelSR">
-            <property name="text">
-             <string>SR:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonSR">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QGroupBox" name="RStick">
-       <property name="title">
-        <string>Right Stick</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-       <property name="flat">
-        <bool>false</bool>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_5">
-        <item row="1" column="1">
-         <layout class="QVBoxLayout" name="buttonRStickDownVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelRStickDown">
-            <property name="text">
-             <string>Down:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonRStickDown">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="0" column="1">
-         <layout class="QVBoxLayout" name="buttonRStickRightVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelRStickRight">
-            <property name="text">
-             <string>Right:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonRStickRight">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="3" column="0" colspan="2">
-         <widget class="QPushButton" name="buttonRStickAnalog">
+         <widget class="QCheckBox" name="keyboard_enabled">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>23</height>
+           </size>
+          </property>
           <property name="text">
-           <string>Set Analog Stick</string>
+           <string>Keyboard</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <layout class="QVBoxLayout" name="buttonRStickLeftVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelRStickLeft">
-            <property name="text">
-             <string>Left:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonRStickLeft">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="0">
-         <layout class="QVBoxLayout" name="buttonRStickUpVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelRStickUp">
-            <property name="text">
-             <string>Up:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonRStickUp">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="2" column="0">
-         <layout class="QVBoxLayout" name="buttonRStickPressedVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelRStickPressed">
-            <property name="text">
-             <string>Pressed:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonRStick">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
         <item row="2" column="1">
-         <layout class="QVBoxLayout" name="buttonRStickModVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelRStickMod">
-            <property name="text">
-             <string>Modifier:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonRStickMod">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QGroupBox" name="LStick">
-       <property name="title">
-        <string>Left Stick</string>
-       </property>
-       <property name="flat">
-        <bool>false</bool>
-       </property>
-       <property name="checkable">
-        <bool>false</bool>
-       </property>
-       <layout class="QGridLayout" name="gridLayout_4">
-        <item row="1" column="1">
-         <layout class="QVBoxLayout" name="buttonLStickDownVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelLStickDown">
-            <property name="text">
-             <string>Down:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonLStickDown">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="4" column="0" colspan="2">
-         <widget class="QPushButton" name="buttonLStickAnalog">
+         <widget class="QCheckBox" name="debug_enabled">
           <property name="text">
-           <string>Set Analog Stick</string>
+           <string>Debug Controller</string>
           </property>
          </widget>
-        </item>
-        <item row="0" column="1">
-         <layout class="QVBoxLayout" name="buttonLStickRightVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelLStickRight">
-            <property name="text">
-             <string>Right:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonLStickRight">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="0" column="0">
-         <layout class="QVBoxLayout" name="buttonLStickLeftVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelLStickLeft">
-            <property name="text">
-             <string>Left:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonLStickLeft">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="1" column="0">
-         <layout class="QVBoxLayout" name="buttonLStickUpVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelLStickUp">
-            <property name="text">
-             <string>Up:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonLStickUp">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item row="3" column="0">
-         <layout class="QVBoxLayout" name="buttonLStickModVerticalLayout">
-          <item>
-           <widget class="QLabel" name="labelLStickMod">
-            <property name="text">
-             <string>Modifier:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonLStickMod">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
         </item>
         <item row="3" column="1">
-         <layout class="QVBoxLayout" name="buttonLStickPressedVerticalLayout" stretch="0,0">
-          <item>
-           <widget class="QLabel" name="labelLStickPressed">
-            <property name="text">
-             <string>Pressed:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="buttonLStick">
-            <property name="text">
-             <string/>
-            </property>
-           </widget>
-          </item>
-         </layout>
+         <widget class="QCheckBox" name="touchscreen_enabled">
+          <property name="text">
+           <string>Touchscreen</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QCheckBox" name="mouse_enabled">
+          <property name="minimumSize">
+           <size>
+            <width>0</width>
+            <height>23</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Mouse</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="4">
+         <spacer name="horizontalSpacer_7">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="0" column="2">
+         <spacer name="horizontalSpacer_8">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>76</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="0" column="0">
+         <spacer name="horizontalSpacer_6">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="3" column="3">
+         <widget class="QPushButton" name="touchscreen_advanced">
+          <property name="text">
+           <string>Advanced</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="3">
+         <widget class="QPushButton" name="debug_configure">
+          <property name="text">
+           <string>Configure</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="3">
+         <widget class="QPushButton" name="mouse_advanced">
+          <property name="text">
+           <string>Advanced</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </widget>
      </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <spacer name="horizontalSpacer">
+      <spacer name="verticalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>40</width>
-         <height>20</height>
+         <width>20</width>
+         <height>40</height>
         </size>
        </property>
       </spacer>
      </item>
      <item>
-      <widget class="QPushButton" name="buttonClearAll">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="sizeIncrement">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="baseSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="layoutDirection">
-        <enum>Qt::LeftToRight</enum>
-       </property>
-       <property name="text">
-        <string>Clear All</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="buttonRestoreDefaults">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="sizeIncrement">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="baseSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="layoutDirection">
-        <enum>Qt::LeftToRight</enum>
-       </property>
-       <property name="text">
-        <string>Restore Defaults</string>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QPushButton" name="restore_defaults_button">
+         <property name="text">
+          <string>Restore Defaults</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_9">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </item>
     </layout>
    </item>

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -325,6 +325,8 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, u8 player_index, boo
     ui->buttonHome->setEnabled(false);
 }
 
+ConfigureInputPlayer::~ConfigureInputPlayer() = default;
+
 void ConfigureInputPlayer::applyConfiguration() {
     auto& buttons =
         debug ? Settings::values.debug_pad_buttons : Settings::values.players[player_index].buttons;

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -41,7 +41,7 @@ static void LayerGridElements(QGridLayout* grid, QWidget* item, QWidget* onTopOf
     grid->addWidget(item, row, column, rowSpan, columnSpan);
 }
 
-static QString getKeyName(int key_code) {
+static QString GetKeyName(int key_code) {
     switch (key_code) {
     case Qt::Key_Shift:
         return QObject::tr("Shift");
@@ -71,7 +71,7 @@ static QString ButtonToText(const Common::ParamPackage& param) {
     if (!param.Has("engine")) {
         return QObject::tr("[not set]");
     } else if (param.Get("engine", "") == "keyboard") {
-        return getKeyName(param.Get("code", 0));
+        return GetKeyName(param.Get("code", 0));
     } else if (param.Get("engine", "") == "sdl") {
         if (param.Has("hat")) {
             return QString(QObject::tr("Hat %1 %2"))
@@ -486,7 +486,7 @@ void ConfigureInputPlayer::setPollingResult(const Common::ParamPackage& params, 
     }
 
     updateButtonLabels();
-    input_setter = boost::none;
+    input_setter = std::nullopt;
 }
 
 void ConfigureInputPlayer::keyPressEvent(QKeyEvent* event) {

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -1,0 +1,506 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+#include <QColorDialog>
+#include <QMenu>
+#include <QMessageBox>
+#include <QTimer>
+#include "common/assert.h"
+#include "common/param_package.h"
+#include "input_common/main.h"
+#include "ui_configure_input_player.h"
+#include "yuzu/configuration/config.h"
+#include "yuzu/configuration/configure_input_player.h"
+
+const std::array<std::string, ConfigureInputPlayer::ANALOG_SUB_BUTTONS_NUM>
+    ConfigureInputPlayer::analog_sub_buttons{{
+        "up",
+        "down",
+        "left",
+        "right",
+        "modifier",
+    }};
+
+static void MoveGridElement(QGridLayout* grid, int row_old, int column_old, int row_new,
+                            int column_new) {
+    const auto item = grid->itemAtPosition(row_old, column_old);
+    // grid->removeItem(item);
+    grid->addItem(item, row_new, column_new);
+}
+
+static void LayerGridElements(QGridLayout* grid, QWidget* item, QWidget* onTopOf) {
+    const int index1 = grid->indexOf(item);
+    const int index2 = grid->indexOf(onTopOf);
+    int row, column, rowSpan, columnSpan;
+    grid->getItemPosition(index2, &row, &column, &rowSpan, &columnSpan);
+    grid->takeAt(index1);
+    grid->addWidget(item, row, column, rowSpan, columnSpan);
+}
+
+static QString getKeyName(int key_code) {
+    switch (key_code) {
+    case Qt::Key_Shift:
+        return QObject::tr("Shift");
+    case Qt::Key_Control:
+        return QObject::tr("Ctrl");
+    case Qt::Key_Alt:
+        return QObject::tr("Alt");
+    case Qt::Key_Meta:
+        return "";
+    default:
+        return QKeySequence(key_code).toString();
+    }
+}
+
+static void SetAnalogButton(const Common::ParamPackage& input_param,
+                            Common::ParamPackage& analog_param, const std::string& button_name) {
+    if (analog_param.Get("engine", "") != "analog_from_button") {
+        analog_param = {
+            {"engine", "analog_from_button"},
+            {"modifier_scale", "0.5"},
+        };
+    }
+    analog_param.Set(button_name, input_param.Serialize());
+}
+
+static QString ButtonToText(const Common::ParamPackage& param) {
+    if (!param.Has("engine")) {
+        return QObject::tr("[not set]");
+    } else if (param.Get("engine", "") == "keyboard") {
+        return getKeyName(param.Get("code", 0));
+    } else if (param.Get("engine", "") == "sdl") {
+        if (param.Has("hat")) {
+            return QString(QObject::tr("Hat %1 %2"))
+                .arg(param.Get("hat", "").c_str(), param.Get("direction", "").c_str());
+        }
+        if (param.Has("axis")) {
+            return QString(QObject::tr("Axis %1%2"))
+                .arg(param.Get("axis", "").c_str(), param.Get("direction", "").c_str());
+        }
+        if (param.Has("button")) {
+            return QString(QObject::tr("Button %1")).arg(param.Get("button", "").c_str());
+        }
+        return QString();
+    } else {
+        return QObject::tr("[unknown]");
+    }
+};
+
+static QString AnalogToText(const Common::ParamPackage& param, const std::string& dir) {
+    if (!param.Has("engine")) {
+        return QObject::tr("[not set]");
+    } else if (param.Get("engine", "") == "analog_from_button") {
+        return ButtonToText(Common::ParamPackage{param.Get(dir, "")});
+    } else if (param.Get("engine", "") == "sdl") {
+        if (dir == "modifier") {
+            return QString(QObject::tr("[unused]"));
+        }
+
+        if (dir == "left" || dir == "right") {
+            return QString(QObject::tr("Axis %1")).arg(param.Get("axis_x", "").c_str());
+        } else if (dir == "up" || dir == "down") {
+            return QString(QObject::tr("Axis %1")).arg(param.Get("axis_y", "").c_str());
+        }
+        return QString();
+    } else {
+        return QObject::tr("[unknown]");
+    }
+};
+
+ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, u8 player_index, bool debug)
+    : QDialog(parent), ui(std::make_unique<Ui::ConfigureInputPlayer>()),
+      timeout_timer(std::make_unique<QTimer>()), poll_timer(std::make_unique<QTimer>()),
+      player_index(player_index), debug(debug) {
+
+    ui->setupUi(this);
+    setFocusPolicy(Qt::ClickFocus);
+
+    button_map = {
+        ui->buttonA,          ui->buttonB,        ui->buttonX,           ui->buttonY,
+        ui->buttonLStick,     ui->buttonRStick,   ui->buttonL,           ui->buttonR,
+        ui->buttonZL,         ui->buttonZR,       ui->buttonPlus,        ui->buttonMinus,
+        ui->buttonDpadLeft,   ui->buttonDpadUp,   ui->buttonDpadRight,   ui->buttonDpadDown,
+        ui->buttonLStickLeft, ui->buttonLStickUp, ui->buttonLStickRight, ui->buttonLStickDown,
+        ui->buttonRStickLeft, ui->buttonRStickUp, ui->buttonRStickRight, ui->buttonRStickDown,
+        ui->buttonSL,         ui->buttonSR,       ui->buttonHome,        ui->buttonScreenshot,
+    };
+
+    analog_map_buttons = {{
+        {
+            ui->buttonLStickUp,
+            ui->buttonLStickDown,
+            ui->buttonLStickLeft,
+            ui->buttonLStickRight,
+            ui->buttonLStickMod,
+        },
+        {
+            ui->buttonRStickUp,
+            ui->buttonRStickDown,
+            ui->buttonRStickLeft,
+            ui->buttonRStickRight,
+            ui->buttonRStickMod,
+        },
+    }};
+
+    debug_hidden = {
+        ui->buttonSL,         ui->labelSL,
+        ui->buttonSR,         ui->labelSR,
+        ui->buttonLStick,     ui->labelLStickPressed,
+        ui->buttonRStick,     ui->labelRStickPressed,
+        ui->buttonHome,       ui->labelHome,
+        ui->buttonScreenshot, ui->labelScreenshot,
+    };
+
+    auto layout = Settings::values.players[player_index].type;
+    if (debug)
+        layout = Settings::ControllerType::DualJoycon;
+
+    switch (layout) {
+    case Settings::ControllerType::ProController:
+    case Settings::ControllerType::DualJoycon:
+        layout_hidden = {
+            ui->buttonSL,
+            ui->labelSL,
+            ui->buttonSR,
+            ui->labelSR,
+        };
+        break;
+    case Settings::ControllerType::LeftJoycon:
+        layout_hidden = {
+            ui->right_body_button,
+            ui->right_buttons_button,
+            ui->right_body_label,
+            ui->right_buttons_label,
+            ui->buttonR,
+            ui->labelR,
+            ui->buttonZR,
+            ui->labelZR,
+            ui->labelHome,
+            ui->buttonHome,
+            ui->buttonPlus,
+            ui->labelPlus,
+            ui->RStick,
+            ui->faceButtons,
+        };
+        break;
+    case Settings::ControllerType::RightJoycon:
+        layout_hidden = {
+            ui->left_body_button, ui->left_buttons_button,
+            ui->left_body_label,  ui->left_buttons_label,
+            ui->buttonL,          ui->labelL,
+            ui->buttonZL,         ui->labelZL,
+            ui->labelScreenshot,  ui->buttonScreenshot,
+            ui->buttonMinus,      ui->labelMinus,
+            ui->LStick,           ui->Dpad,
+        };
+        break;
+    }
+
+    if (debug || layout == Settings::ControllerType::ProController) {
+        ui->controller_color->hide();
+    } else {
+        if (layout == Settings::ControllerType::LeftJoycon ||
+            layout == Settings::ControllerType::RightJoycon) {
+            ui->horizontalSpacer_4->setGeometry({0, 0, 0, 0});
+
+            LayerGridElements(ui->buttons, ui->shoulderButtons, ui->Dpad);
+            LayerGridElements(ui->buttons, ui->misc, ui->RStick);
+            LayerGridElements(ui->buttons, ui->Dpad, ui->faceButtons);
+            LayerGridElements(ui->buttons, ui->RStick, ui->LStick);
+        }
+    }
+
+    for (auto* widget : layout_hidden)
+        widget->setVisible(false);
+
+    analog_map_stick = {ui->buttonLStickAnalog, ui->buttonRStickAnalog};
+
+    for (int button_id = 0; button_id < Settings::NativeButton::NumButtons; button_id++) {
+        if (!button_map[button_id])
+            continue;
+        button_map[button_id]->setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(button_map[button_id], &QPushButton::released, [=]() {
+            handleClick(
+                button_map[button_id],
+                [=](const Common::ParamPackage& params) { buttons_param[button_id] = params; },
+                InputCommon::Polling::DeviceType::Button);
+        });
+        connect(button_map[button_id], &QPushButton::customContextMenuRequested,
+                [=](const QPoint& menu_location) {
+                    QMenu context_menu;
+                    context_menu.addAction(tr("Clear"), [&] {
+                        buttons_param[button_id].Clear();
+                        button_map[button_id]->setText(tr("[not set]"));
+                    });
+                    context_menu.addAction(tr("Restore Default"), [&] {
+                        buttons_param[button_id] = Common::ParamPackage{
+                            InputCommon::GenerateKeyboardParam(Config::default_buttons[button_id])};
+                        button_map[button_id]->setText(ButtonToText(buttons_param[button_id]));
+                    });
+                    context_menu.exec(button_map[button_id]->mapToGlobal(menu_location));
+                });
+    }
+
+    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
+        for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; sub_button_id++) {
+            if (!analog_map_buttons[analog_id][sub_button_id])
+                continue;
+            analog_map_buttons[analog_id][sub_button_id]->setContextMenuPolicy(
+                Qt::CustomContextMenu);
+            connect(analog_map_buttons[analog_id][sub_button_id], &QPushButton::released, [=]() {
+                handleClick(analog_map_buttons[analog_id][sub_button_id],
+                            [=](const Common::ParamPackage& params) {
+                                SetAnalogButton(params, analogs_param[analog_id],
+                                                analog_sub_buttons[sub_button_id]);
+                            },
+                            InputCommon::Polling::DeviceType::Button);
+            });
+            connect(analog_map_buttons[analog_id][sub_button_id],
+                    &QPushButton::customContextMenuRequested, [=](const QPoint& menu_location) {
+                        QMenu context_menu;
+                        context_menu.addAction(tr("Clear"), [&] {
+                            analogs_param[analog_id].Erase(analog_sub_buttons[sub_button_id]);
+                            analog_map_buttons[analog_id][sub_button_id]->setText(tr("[not set]"));
+                        });
+                        context_menu.addAction(tr("Restore Default"), [&] {
+                            Common::ParamPackage params{InputCommon::GenerateKeyboardParam(
+                                Config::default_analogs[analog_id][sub_button_id])};
+                            SetAnalogButton(params, analogs_param[analog_id],
+                                            analog_sub_buttons[sub_button_id]);
+                            analog_map_buttons[analog_id][sub_button_id]->setText(AnalogToText(
+                                analogs_param[analog_id], analog_sub_buttons[sub_button_id]));
+                        });
+                        context_menu.exec(analog_map_buttons[analog_id][sub_button_id]->mapToGlobal(
+                            menu_location));
+                    });
+        }
+        connect(analog_map_stick[analog_id], &QPushButton::released, [=]() {
+            QMessageBox::information(this, tr("Information"),
+                                     tr("After pressing OK, first move your joystick horizontally, "
+                                        "and then vertically."));
+            handleClick(
+                analog_map_stick[analog_id],
+                [=](const Common::ParamPackage& params) { analogs_param[analog_id] = params; },
+                InputCommon::Polling::DeviceType::Analog);
+        });
+    }
+
+    connect(ui->buttonClearAll, &QPushButton::released, [this] { ClearAll(); });
+    connect(ui->buttonRestoreDefaults, &QPushButton::released, [this]() { restoreDefaults(); });
+
+    timeout_timer->setSingleShot(true);
+    connect(timeout_timer.get(), &QTimer::timeout, [this]() { setPollingResult({}, true); });
+
+    connect(poll_timer.get(), &QTimer::timeout, [this]() {
+        Common::ParamPackage params;
+        for (auto& poller : device_pollers) {
+            params = poller->GetNextInput();
+            if (params.Has("engine")) {
+                setPollingResult(params, false);
+                return;
+            }
+        }
+    });
+
+    controller_color_buttons = {
+        ui->left_body_button,
+        ui->left_buttons_button,
+        ui->right_body_button,
+        ui->right_buttons_button,
+    };
+
+    for (std::size_t i = 0; i < controller_color_buttons.size(); ++i) {
+        connect(controller_color_buttons[i], &QPushButton::clicked, this,
+                std::bind(&ConfigureInputPlayer::OnControllerButtonClick, this, i));
+    }
+
+    this->loadConfiguration();
+    this->resize(0, 0);
+
+    // TODO(wwylele): enable this when we actually emulate it
+    ui->buttonHome->setEnabled(false);
+}
+
+void ConfigureInputPlayer::applyConfiguration() {
+    auto& buttons =
+        debug ? Settings::values.debug_pad_buttons : Settings::values.players[player_index].buttons;
+    auto& analogs =
+        debug ? Settings::values.debug_pad_analogs : Settings::values.players[player_index].analogs;
+
+    std::transform(buttons_param.begin(), buttons_param.end(), buttons.begin(),
+                   [](const Common::ParamPackage& param) { return param.Serialize(); });
+    std::transform(analogs_param.begin(), analogs_param.end(), analogs.begin(),
+                   [](const Common::ParamPackage& param) { return param.Serialize(); });
+
+    if (debug)
+        return;
+
+    std::array<u32, 4> colors{};
+    std::transform(controller_colors.begin(), controller_colors.end(), colors.begin(),
+                   [](QColor color) { return color.rgb(); });
+
+    Settings::values.players[player_index].body_color_left = colors[0];
+    Settings::values.players[player_index].button_color_left = colors[1];
+    Settings::values.players[player_index].body_color_right = colors[2];
+    Settings::values.players[player_index].button_color_right = colors[3];
+}
+
+void ConfigureInputPlayer::OnControllerButtonClick(int i) {
+    const QColor new_bg_color = QColorDialog::getColor(controller_colors[i]);
+    if (!new_bg_color.isValid())
+        return;
+    controller_colors[i] = new_bg_color;
+    controller_color_buttons[i]->setStyleSheet(
+        QString("QPushButton { background-color: %1 }").arg(controller_colors[i].name()));
+}
+
+void ConfigureInputPlayer::loadConfiguration() {
+    if (debug) {
+        std::transform(Settings::values.debug_pad_buttons.begin(),
+                       Settings::values.debug_pad_buttons.end(), buttons_param.begin(),
+                       [](const std::string& str) { return Common::ParamPackage(str); });
+        std::transform(Settings::values.debug_pad_analogs.begin(),
+                       Settings::values.debug_pad_analogs.end(), analogs_param.begin(),
+                       [](const std::string& str) { return Common::ParamPackage(str); });
+    } else {
+        std::transform(Settings::values.players[player_index].buttons.begin(),
+                       Settings::values.players[player_index].buttons.end(), buttons_param.begin(),
+                       [](const std::string& str) { return Common::ParamPackage(str); });
+        std::transform(Settings::values.players[player_index].analogs.begin(),
+                       Settings::values.players[player_index].analogs.end(), analogs_param.begin(),
+                       [](const std::string& str) { return Common::ParamPackage(str); });
+    }
+
+    updateButtonLabels();
+
+    if (debug)
+        return;
+
+    std::array<u32, 4> colors = {
+        Settings::values.players[player_index].body_color_left,
+        Settings::values.players[player_index].button_color_left,
+        Settings::values.players[player_index].body_color_right,
+        Settings::values.players[player_index].button_color_right,
+    };
+
+    std::transform(colors.begin(), colors.end(), controller_colors.begin(),
+                   [](u32 rgb) { return QColor::fromRgb(rgb); });
+
+    for (std::size_t i = 0; i < colors.size(); ++i) {
+        controller_color_buttons[i]->setStyleSheet(
+            QString("QPushButton { background-color: %1 }").arg(controller_colors[i].name()));
+    }
+}
+
+void ConfigureInputPlayer::restoreDefaults() {
+    for (int button_id = 0; button_id < Settings::NativeButton::NumButtons; button_id++) {
+        buttons_param[button_id] = Common::ParamPackage{
+            InputCommon::GenerateKeyboardParam(Config::default_buttons[button_id])};
+    }
+
+    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
+        for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; sub_button_id++) {
+            Common::ParamPackage params{InputCommon::GenerateKeyboardParam(
+                Config::default_analogs[analog_id][sub_button_id])};
+            SetAnalogButton(params, analogs_param[analog_id], analog_sub_buttons[sub_button_id]);
+        }
+    }
+    updateButtonLabels();
+}
+
+void ConfigureInputPlayer::ClearAll() {
+    for (int button_id = 0; button_id < Settings::NativeButton::NumButtons; button_id++) {
+        if (button_map[button_id] && button_map[button_id]->isEnabled())
+            buttons_param[button_id].Clear();
+    }
+    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
+        for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; sub_button_id++) {
+            if (analog_map_buttons[analog_id][sub_button_id] &&
+                analog_map_buttons[analog_id][sub_button_id]->isEnabled())
+                analogs_param[analog_id].Erase(analog_sub_buttons[sub_button_id]);
+        }
+    }
+
+    updateButtonLabels();
+}
+
+void ConfigureInputPlayer::updateButtonLabels() {
+    for (int button = 0; button < Settings::NativeButton::NumButtons; button++) {
+        button_map[button]->setText(ButtonToText(buttons_param[button]));
+    }
+
+    for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; analog_id++) {
+        for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; sub_button_id++) {
+            if (analog_map_buttons[analog_id][sub_button_id]) {
+                analog_map_buttons[analog_id][sub_button_id]->setText(
+                    AnalogToText(analogs_param[analog_id], analog_sub_buttons[sub_button_id]));
+            }
+        }
+        analog_map_stick[analog_id]->setText(tr("Set Analog Stick"));
+    }
+}
+
+void ConfigureInputPlayer::handleClick(
+    QPushButton* button, std::function<void(const Common::ParamPackage&)> new_input_setter,
+    InputCommon::Polling::DeviceType type) {
+    button->setText(tr("[press key]"));
+    button->setFocus();
+
+    const auto iter = std::find(button_map.begin(), button_map.end(), button);
+    ASSERT(iter != button_map.end());
+    const auto index = std::distance(button_map.begin(), iter);
+    ASSERT(index < Settings::NativeButton::NumButtons && index >= 0);
+
+    input_setter = new_input_setter;
+
+    device_pollers = InputCommon::Polling::GetPollers(type);
+
+    // Keyboard keys can only be used as button devices
+    want_keyboard_keys = type == InputCommon::Polling::DeviceType::Button;
+
+    for (auto& poller : device_pollers) {
+        poller->Start();
+    }
+
+    grabKeyboard();
+    grabMouse();
+    timeout_timer->start(5000); // Cancel after 5 seconds
+    poll_timer->start(200);     // Check for new inputs every 200ms
+}
+
+void ConfigureInputPlayer::setPollingResult(const Common::ParamPackage& params, bool abort) {
+    releaseKeyboard();
+    releaseMouse();
+    timeout_timer->stop();
+    poll_timer->stop();
+    for (auto& poller : device_pollers) {
+        poller->Stop();
+    }
+
+    if (!abort) {
+        (*input_setter)(params);
+    }
+
+    updateButtonLabels();
+    input_setter = boost::none;
+}
+
+void ConfigureInputPlayer::keyPressEvent(QKeyEvent* event) {
+    if (!input_setter || !event)
+        return;
+
+    if (event->key() != Qt::Key_Escape) {
+        if (want_keyboard_keys) {
+            setPollingResult(Common::ParamPackage{InputCommon::GenerateKeyboardParam(event->key())},
+                             false);
+        } else {
+            // Escape key wasn't pressed and we don't want any keyboard keys, so don't stop polling
+            return;
+        }
+    }
+    setPollingResult({}, true);
+}

--- a/src/yuzu/configuration/configure_input_player.h
+++ b/src/yuzu/configuration/configure_input_player.h
@@ -7,11 +7,11 @@
 #include <array>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <QDialog>
 #include <QKeyEvent>
-#include <boost/optional.hpp>
 #include "common/param_package.h"
 #include "core/settings.h"
 #include "input_common/main.h"
@@ -44,7 +44,7 @@ private:
     std::unique_ptr<QTimer> poll_timer;
 
     /// This will be the the setting function when an input is awaiting configuration.
-    boost::optional<std::function<void(const Common::ParamPackage&)>> input_setter;
+    std::optional<std::function<void(const Common::ParamPackage&)>> input_setter;
 
     std::array<Common::ParamPackage, Settings::NativeButton::NumButtons> buttons_param;
     std::array<Common::ParamPackage, Settings::NativeAnalog::NumAnalogs> analogs_param;

--- a/src/yuzu/configuration/configure_input_player.h
+++ b/src/yuzu/configuration/configure_input_player.h
@@ -1,0 +1,102 @@
+﻿// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <QDialog>
+#include <QKeyEvent>
+#include <boost/optional.hpp>
+#include "common/param_package.h"
+#include "core/settings.h"
+#include "input_common/main.h"
+#include "ui_configure_input.h"
+
+class QPushButton;
+class QString;
+class QTimer;
+
+namespace Ui {
+class ConfigureInputPlayer;
+}
+
+class ConfigureInputPlayer : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit ConfigureInputPlayer(QWidget* parent, u8 player_index, bool debug = false);
+
+    /// Save all button configurations to settings file
+    void applyConfiguration();
+
+private:
+    std::unique_ptr<Ui::ConfigureInputPlayer> ui;
+
+    u8 player_index;
+    bool debug;
+
+    std::unique_ptr<QTimer> timeout_timer;
+    std::unique_ptr<QTimer> poll_timer;
+
+    /// This will be the the setting function when an input is awaiting configuration.
+    boost::optional<std::function<void(const Common::ParamPackage&)>> input_setter;
+
+    std::array<Common::ParamPackage, Settings::NativeButton::NumButtons> buttons_param;
+    std::array<Common::ParamPackage, Settings::NativeAnalog::NumAnalogs> analogs_param;
+
+    static constexpr int ANALOG_SUB_BUTTONS_NUM = 5;
+
+    /// Each button input is represented by a QPushButton.
+    std::array<QPushButton*, Settings::NativeButton::NumButtons> button_map;
+
+    std::vector<QWidget*> debug_hidden;
+    std::vector<QWidget*> layout_hidden;
+
+    /// A group of five QPushButtons represent one analog input. The buttons each represent up,
+    /// down, left, right, and modifier, respectively.
+    std::array<std::array<QPushButton*, ANALOG_SUB_BUTTONS_NUM>, Settings::NativeAnalog::NumAnalogs>
+        analog_map_buttons;
+
+    /// Analog inputs are also represented each with a single button, used to configure with an
+    /// actual analog stick
+    std::array<QPushButton*, Settings::NativeAnalog::NumAnalogs> analog_map_stick;
+
+    static const std::array<std::string, ANALOG_SUB_BUTTONS_NUM> analog_sub_buttons;
+
+    std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> device_pollers;
+
+    /// A flag to indicate if keyboard keys are okay when configuring an input. If this is false,
+    /// keyboard events are ignored.
+    bool want_keyboard_keys = false;
+
+    std::array<QPushButton*, 4> controller_color_buttons;
+    std::array<QColor, 4> controller_colors;
+
+    void OnControllerButtonClick(int i);
+
+    /// Load configuration settings.
+    void loadConfiguration();
+    /// Restore all buttons to their default values.
+    void restoreDefaults();
+    /// Clear all input configuration
+    void ClearAll();
+
+    /// Update UI to reflect current configuration.
+    void updateButtonLabels();
+
+    /// Called when the button was pressed.
+    void handleClick(QPushButton* button,
+                     std::function<void(const Common::ParamPackage&)> new_input_setter,
+                     InputCommon::Polling::DeviceType type);
+
+    /// Finish polling and configure input using the input_setter
+    void setPollingResult(const Common::ParamPackage& params, bool abort);
+
+    /// Handle key press events.
+    void keyPressEvent(QKeyEvent* event) override;
+};

--- a/src/yuzu/configuration/configure_input_player.h
+++ b/src/yuzu/configuration/configure_input_player.h
@@ -30,6 +30,7 @@ class ConfigureInputPlayer : public QDialog {
 
 public:
     explicit ConfigureInputPlayer(QWidget* parent, u8 player_index, bool debug = false);
+    ~ConfigureInputPlayer() override;
 
     /// Save all button configurations to settings file
     void applyConfiguration();

--- a/src/yuzu/configuration/configure_input_player.ui
+++ b/src/yuzu/configuration/configure_input_player.ui
@@ -235,6 +235,12 @@
            <layout class="QHBoxLayout" name="buttonDpadLeftHorizontalLayout">
             <item>
              <widget class="QLabel" name="labelDpadLeft">
+              <property name="minimumSize">
+               <size>
+                <width>80</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="text">
                <string>Left:</string>
               </property>
@@ -257,6 +263,12 @@
            <layout class="QHBoxLayout" name="buttonDpadRightHorizontalLayout">
             <item>
              <widget class="QLabel" name="labelDpadRight">
+              <property name="minimumSize">
+               <size>
+                <width>80</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="text">
                <string>Right:</string>
               </property>
@@ -294,6 +306,12 @@
            <layout class="QHBoxLayout" name="buttonFaceButtonsAHorizontalLayout">
             <item>
              <widget class="QLabel" name="labelA">
+              <property name="minimumSize">
+               <size>
+                <width>80</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="text">
                <string>A:</string>
               </property>
@@ -316,6 +334,12 @@
            <layout class="QHBoxLayout" name="buttonFaceButtonsBHorizontalLayout">
             <item>
              <widget class="QLabel" name="labelB">
+              <property name="minimumSize">
+               <size>
+                <width>80</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="text">
                <string>B:</string>
               </property>
@@ -1016,22 +1040,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item>
-    <widget class="QLabel" name="override_label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Check the box to override the global default key with this one for this game only.</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-    </widget>
    </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout"/>

--- a/src/yuzu/configuration/configure_input_player.ui
+++ b/src/yuzu/configuration/configure_input_player.ui
@@ -1,0 +1,1156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureInputPlayer</class>
+ <widget class="QDialog" name="ConfigureInputPlayer">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>408</width>
+    <height>731</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Configure Input</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_5">
+   <item>
+    <layout class="QGridLayout" name="buttons">
+     <item row="1" column="1">
+      <widget class="QGroupBox" name="RStick">
+       <property name="title">
+        <string>Right Stick</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_5">
+        <item row="1" column="1">
+         <layout class="QVBoxLayout" name="buttonRStickDownVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonRStickDownHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelRStickDown">
+              <property name="text">
+               <string>Down:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonRStickDown">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="0" column="1">
+         <layout class="QVBoxLayout" name="buttonRStickRightVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonRStickRightHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelRStickRight">
+              <property name="text">
+               <string>Right:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonRStickRight">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="3" column="0" colspan="2">
+         <widget class="QPushButton" name="buttonRStickAnalog">
+          <property name="text">
+           <string>Set Analog Stick</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <layout class="QVBoxLayout" name="buttonRStickLeftVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonRStickLeftHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelRStickLeft">
+              <property name="text">
+               <string>Left:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonRStickLeft">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="0">
+         <layout class="QVBoxLayout" name="buttonRStickUpVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonRStickUpHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelRStickUp">
+              <property name="text">
+               <string>Up:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonRStickUp">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="2" column="0">
+         <layout class="QVBoxLayout" name="buttonRStickPressedVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonRStickPressedHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelRStickPressed">
+              <property name="text">
+               <string>Pressed:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonRStick">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="2" column="1">
+         <layout class="QVBoxLayout" name="buttonRStickModVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonRStickModHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelRStickMod">
+              <property name="text">
+               <string>Modifier:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonRStickMod">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QGroupBox" name="Dpad">
+       <property name="title">
+        <string>Directional Pad</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="1" column="0">
+         <layout class="QVBoxLayout" name="buttonDpadUpVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonDpadUpHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelDpadUp">
+              <property name="text">
+               <string>Up:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonDpadUp">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="1">
+         <layout class="QVBoxLayout" name="buttonDpadDownVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonDpadDownHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelDpadDown">
+              <property name="text">
+               <string>Down:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonDpadDown">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="0" column="0">
+         <layout class="QVBoxLayout" name="buttonDpadLeftVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonDpadLeftHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelDpadLeft">
+              <property name="text">
+               <string>Left:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonDpadLeft">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="0" column="1">
+         <layout class="QVBoxLayout" name="buttonDpadRightVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonDpadRightHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelDpadRight">
+              <property name="text">
+               <string>Right:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonDpadRight">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QGroupBox" name="faceButtons">
+       <property name="title">
+        <string>Face Buttons</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <layout class="QVBoxLayout" name="buttonFaceButtonsAVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonFaceButtonsAHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelA">
+              <property name="text">
+               <string>A:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonA">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="0" column="1">
+         <layout class="QVBoxLayout" name="buttonFaceButtonsBVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonFaceButtonsBHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelB">
+              <property name="text">
+               <string>B:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonB">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="0">
+         <layout class="QVBoxLayout" name="buttonFaceButtonsXVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonFaceButtonsXHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelX">
+              <property name="text">
+               <string>X:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonX">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="1">
+         <layout class="QVBoxLayout" name="buttonFaceButtonsYVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonFaceButtonsYHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelY">
+              <property name="text">
+               <string>Y:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonY">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="5" column="0" colspan="2">
+      <widget class="QGroupBox" name="controller_color">
+       <property name="title">
+        <string>Controller Color</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_10" columnstretch="0,0,0,0,0,0,0">
+        <item row="0" column="0">
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLabel" name="left_body_label">
+          <property name="text">
+           <string>Left Body</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="6">
+         <spacer name="horizontalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLabel" name="left_buttons_label">
+          <property name="minimumSize">
+           <size>
+            <width>90</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Left Buttons</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="5">
+         <widget class="QPushButton" name="right_buttons_button">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>32</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="4">
+         <widget class="QLabel" name="right_body_label">
+          <property name="text">
+           <string>Right Body</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="4">
+         <widget class="QLabel" name="right_buttons_label">
+          <property name="minimumSize">
+           <size>
+            <width>90</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>Right Buttons</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QPushButton" name="left_buttons_button">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>32</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QPushButton" name="left_body_button">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>32</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="5">
+         <widget class="QPushButton" name="right_body_button">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>32</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>40</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="3">
+         <spacer name="horizontalSpacer_4">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeType">
+           <enum>QSizePolicy::Fixed</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QGroupBox" name="LStick">
+       <property name="title">
+        <string>Left Stick</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_4">
+        <item row="1" column="1">
+         <layout class="QVBoxLayout" name="buttonLStickUpVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonLStickUpHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelLStickUp">
+              <property name="text">
+               <string>Up:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonLStickUp">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="0" column="2">
+         <layout class="QVBoxLayout" name="buttonLStickRightVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonLStickRightHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelLStickRight">
+              <property name="text">
+               <string>Right:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonLStickRight">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="4" column="1" colspan="2">
+         <widget class="QPushButton" name="buttonLStickAnalog">
+          <property name="text">
+           <string>Set Analog Stick</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <layout class="QVBoxLayout" name="buttonLStickLeftVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonLStickLeftHorizontalLayout_2">
+            <item>
+             <widget class="QLabel" name="labelLStickLeft">
+              <property name="text">
+               <string>Left:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonLStickLeft">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="2">
+         <layout class="QVBoxLayout" name="buttonLStickDownVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonLStickDownHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelLStickDown">
+              <property name="text">
+               <string>Down:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonLStickDown">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="3" column="2">
+         <layout class="QVBoxLayout" name="buttonLStickModVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonLStickModHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelLStickMod">
+              <property name="text">
+               <string>Modifier:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonLStickMod">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="3" column="1">
+         <layout class="QVBoxLayout" name="buttonLStickPressedVerticalLayout" stretch="0,0">
+          <item>
+           <layout class="QHBoxLayout" name="buttonLStickPressedHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelLStickPressed">
+              <property name="text">
+               <string>Pressed:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonLStick">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QGroupBox" name="shoulderButtons">
+       <property name="title">
+        <string>Shoulder Buttons</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_3">
+        <item row="3" column="0">
+         <layout class="QVBoxLayout" name="buttonShoulderButtonsSLVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonShoulderButtonsSLHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelSL">
+              <property name="text">
+               <string>SL:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonSL">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="2" column="1">
+         <layout class="QVBoxLayout" name="buttonShoulderButtonsZRVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonShoulderButtonsZRHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelZR">
+              <property name="text">
+               <string>ZR:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonZR">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="3" column="1">
+         <layout class="QVBoxLayout" name="buttonShoulderButtonsSRVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonShoulderButtonsSRHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelSR">
+              <property name="text">
+               <string>SR:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonSR">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="0" column="1">
+         <layout class="QVBoxLayout" name="buttonShoulderButtonsZLVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonShoulderButtonsZLHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelZL">
+              <property name="text">
+               <string>ZL:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonZL">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="0" column="0">
+         <layout class="QVBoxLayout" name="buttonShoulderButtonsLVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonShoulderButtonsLHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelL">
+              <property name="text">
+               <string>L:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonL">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="2" column="0">
+         <layout class="QVBoxLayout" name="buttonShoulderButtonsRVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonShoulderButtonsRHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelR">
+              <property name="text">
+               <string>R:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonR">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QGroupBox" name="misc">
+       <property name="title">
+        <string>Misc.</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_6">
+        <item row="1" column="0">
+         <layout class="QVBoxLayout" name="buttonMiscMinusVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonMiscMinusHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelMinus">
+              <property name="text">
+               <string>Minus:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonMinus">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="3" column="1">
+         <spacer name="verticalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="0" column="0">
+         <layout class="QVBoxLayout" name="buttonMiscPlusVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonMiscPlusHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelPlus">
+              <property name="text">
+               <string>Plus:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonPlus">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="0" column="1">
+         <layout class="QVBoxLayout" name="buttonMiscHomeVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonMiscHomeHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelHome">
+              <property name="text">
+               <string>Home:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonHome">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="1">
+         <layout class="QVBoxLayout" name="buttonMiscScrCapVerticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="buttonMiscScrCapHorizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelScreenshot">
+              <property name="text">
+               <string>Screen Capture:</string>
+              </property>
+              <property name="wordWrap">
+               <bool>false</bool>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonScreenshot">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>80</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="override_label">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Check the box to override the global default key with this one for this game only.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="buttonClearAll">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="sizeIncrement">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="baseSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
+       </property>
+       <property name="text">
+        <string>Clear All</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="buttonRestoreDefaults">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="sizeIncrement">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="baseSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
+       </property>
+       <property name="text">
+        <string>Restore Defaults</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ConfigureInputPlayer</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>371</x>
+     <y>730</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>229</x>
+     <y>375</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ConfigureInputPlayer</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>371</x>
+     <y>730</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>229</x>
+     <y>375</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/yuzu/configuration/configure_mouse_advanced.cpp
+++ b/src/yuzu/configuration/configure_mouse_advanced.cpp
@@ -1,0 +1,211 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+#include <QKeyEvent>
+#include <QMenu>
+#include <QMessageBox>
+#include <QTimer>
+#include "common/assert.h"
+#include "common/param_package.h"
+#include "input_common/main.h"
+#include "ui_configure_mouse_advanced.h"
+#include "yuzu/configuration/config.h"
+#include "yuzu/configuration/configure_mouse_advanced.h"
+
+static QString getKeyName(int key_code) {
+    switch (key_code) {
+    case Qt::Key_Shift:
+        return QObject::tr("Shift");
+    case Qt::Key_Control:
+        return QObject::tr("Ctrl");
+    case Qt::Key_Alt:
+        return QObject::tr("Alt");
+    case Qt::Key_Meta:
+        return "";
+    default:
+        return QKeySequence(key_code).toString();
+    }
+}
+
+static QString ButtonToText(const Common::ParamPackage& param) {
+    if (!param.Has("engine")) {
+        return QObject::tr("[not set]");
+    } else if (param.Get("engine", "") == "keyboard") {
+        return getKeyName(param.Get("code", 0));
+    } else if (param.Get("engine", "") == "sdl") {
+        if (param.Has("hat")) {
+            return QString(QObject::tr("Hat %1 %2"))
+                .arg(param.Get("hat", "").c_str(), param.Get("direction", "").c_str());
+        }
+        if (param.Has("axis")) {
+            return QString(QObject::tr("Axis %1%2"))
+                .arg(param.Get("axis", "").c_str(), param.Get("direction", "").c_str());
+        }
+        if (param.Has("button")) {
+            return QString(QObject::tr("Button %1")).arg(param.Get("button", "").c_str());
+        }
+        return QString();
+    } else {
+        return QObject::tr("[unknown]");
+    }
+}
+
+ConfigureMouseAdvanced::ConfigureMouseAdvanced(QWidget* parent)
+    : QDialog(parent), ui(std::make_unique<Ui::ConfigureMouseAdvanced>()),
+      timeout_timer(std::make_unique<QTimer>()), poll_timer(std::make_unique<QTimer>()) {
+    ui->setupUi(this);
+    setFocusPolicy(Qt::ClickFocus);
+
+    button_map = {
+        ui->left_button, ui->right_button, ui->middle_button, ui->forward_button, ui->back_button,
+    };
+
+    for (int button_id = 0; button_id < Settings::NativeMouseButton::NumMouseButtons; button_id++) {
+        if (!button_map[button_id])
+            continue;
+        button_map[button_id]->setContextMenuPolicy(Qt::CustomContextMenu);
+        connect(button_map[button_id], &QPushButton::released, [=]() {
+            handleClick(
+                button_map[button_id],
+                [=](const Common::ParamPackage& params) { buttons_param[button_id] = params; },
+                InputCommon::Polling::DeviceType::Button);
+        });
+        connect(button_map[button_id], &QPushButton::customContextMenuRequested,
+                [=](const QPoint& menu_location) {
+                    QMenu context_menu;
+                    context_menu.addAction(tr("Clear"), [&] {
+                        buttons_param[button_id].Clear();
+                        button_map[button_id]->setText(tr("[not set]"));
+                    });
+                    context_menu.addAction(tr("Restore Default"), [&] {
+                        buttons_param[button_id] =
+                            Common::ParamPackage{InputCommon::GenerateKeyboardParam(
+                                Config::default_mouse_buttons[button_id])};
+                        button_map[button_id]->setText(ButtonToText(buttons_param[button_id]));
+                    });
+                    context_menu.exec(button_map[button_id]->mapToGlobal(menu_location));
+                });
+    }
+
+    connect(ui->buttonClearAll, &QPushButton::released, [this] { ClearAll(); });
+    connect(ui->buttonRestoreDefaults, &QPushButton::released, [this]() { restoreDefaults(); });
+
+    timeout_timer->setSingleShot(true);
+    connect(timeout_timer.get(), &QTimer::timeout, [this]() { setPollingResult({}, true); });
+
+    connect(poll_timer.get(), &QTimer::timeout, [this]() {
+        Common::ParamPackage params;
+        for (auto& poller : device_pollers) {
+            params = poller->GetNextInput();
+            if (params.Has("engine")) {
+                setPollingResult(params, false);
+                return;
+            }
+        }
+    });
+
+    loadConfiguration();
+    resize(0, 0);
+}
+
+void ConfigureMouseAdvanced::applyConfiguration() {
+    std::transform(buttons_param.begin(), buttons_param.end(),
+                   Settings::values.mouse_buttons.begin(),
+                   [](const Common::ParamPackage& param) { return param.Serialize(); });
+}
+
+void ConfigureMouseAdvanced::loadConfiguration() {
+    std::transform(Settings::values.mouse_buttons.begin(), Settings::values.mouse_buttons.end(),
+                   buttons_param.begin(),
+                   [](const std::string& str) { return Common::ParamPackage(str); });
+    updateButtonLabels();
+}
+
+void ConfigureMouseAdvanced::restoreDefaults() {
+    for (int button_id = 0; button_id < Settings::NativeMouseButton::NumMouseButtons; button_id++) {
+        buttons_param[button_id] = Common::ParamPackage{
+            InputCommon::GenerateKeyboardParam(Config::default_mouse_buttons[button_id])};
+    }
+
+    updateButtonLabels();
+}
+
+void ConfigureMouseAdvanced::ClearAll() {
+    for (int i = 0; i < Settings::NativeMouseButton::NumMouseButtons; ++i) {
+        if (button_map[i] && button_map[i]->isEnabled())
+            buttons_param[i].Clear();
+    }
+
+    updateButtonLabels();
+}
+
+void ConfigureMouseAdvanced::updateButtonLabels() {
+    for (int button = 0; button < Settings::NativeMouseButton::NumMouseButtons; button++) {
+        button_map[button]->setText(ButtonToText(buttons_param[button]));
+    }
+}
+
+void ConfigureMouseAdvanced::handleClick(
+    QPushButton* button, std::function<void(const Common::ParamPackage&)> new_input_setter,
+    InputCommon::Polling::DeviceType type) {
+    button->setText(tr("[press key]"));
+    button->setFocus();
+
+    const auto iter = std::find(button_map.begin(), button_map.end(), button);
+    ASSERT(iter != button_map.end());
+    const auto index = std::distance(button_map.begin(), iter);
+    ASSERT(index < Settings::NativeButton::NumButtons && index >= 0);
+
+    input_setter = new_input_setter;
+
+    device_pollers = InputCommon::Polling::GetPollers(type);
+
+    // Keyboard keys can only be used as button devices
+    want_keyboard_keys = type == InputCommon::Polling::DeviceType::Button;
+
+    for (auto& poller : device_pollers) {
+        poller->Start();
+    }
+
+    grabKeyboard();
+    grabMouse();
+    timeout_timer->start(5000); // Cancel after 5 seconds
+    poll_timer->start(200);     // Check for new inputs every 200ms
+}
+
+void ConfigureMouseAdvanced::setPollingResult(const Common::ParamPackage& params, bool abort) {
+    releaseKeyboard();
+    releaseMouse();
+    timeout_timer->stop();
+    poll_timer->stop();
+    for (auto& poller : device_pollers) {
+        poller->Stop();
+    }
+
+    if (!abort) {
+        (*input_setter)(params);
+    }
+
+    updateButtonLabels();
+    input_setter = boost::none;
+}
+
+void ConfigureMouseAdvanced::keyPressEvent(QKeyEvent* event) {
+    if (!input_setter || !event)
+        return;
+
+    if (event->key() != Qt::Key_Escape) {
+        if (want_keyboard_keys) {
+            setPollingResult(Common::ParamPackage{InputCommon::GenerateKeyboardParam(event->key())},
+                             false);
+        } else {
+            // Escape key wasn't pressed and we don't want any keyboard keys, so don't stop polling
+            return;
+        }
+    }
+    setPollingResult({}, true);
+}

--- a/src/yuzu/configuration/configure_mouse_advanced.cpp
+++ b/src/yuzu/configuration/configure_mouse_advanced.cpp
@@ -112,6 +112,8 @@ ConfigureMouseAdvanced::ConfigureMouseAdvanced(QWidget* parent)
     resize(0, 0);
 }
 
+ConfigureMouseAdvanced::~ConfigureMouseAdvanced() = default;
+
 void ConfigureMouseAdvanced::applyConfiguration() {
     std::transform(buttons_param.begin(), buttons_param.end(),
                    Settings::values.mouse_buttons.begin(),

--- a/src/yuzu/configuration/configure_mouse_advanced.cpp
+++ b/src/yuzu/configuration/configure_mouse_advanced.cpp
@@ -16,7 +16,7 @@
 #include "yuzu/configuration/config.h"
 #include "yuzu/configuration/configure_mouse_advanced.h"
 
-static QString getKeyName(int key_code) {
+static QString GetKeyName(int key_code) {
     switch (key_code) {
     case Qt::Key_Shift:
         return QObject::tr("Shift");
@@ -35,7 +35,7 @@ static QString ButtonToText(const Common::ParamPackage& param) {
     if (!param.Has("engine")) {
         return QObject::tr("[not set]");
     } else if (param.Get("engine", "") == "keyboard") {
-        return getKeyName(param.Get("code", 0));
+        return GetKeyName(param.Get("code", 0));
     } else if (param.Get("engine", "") == "sdl") {
         if (param.Has("hat")) {
             return QString(QObject::tr("Hat %1 %2"))
@@ -191,7 +191,7 @@ void ConfigureMouseAdvanced::setPollingResult(const Common::ParamPackage& params
     }
 
     updateButtonLabels();
-    input_setter = boost::none;
+    input_setter = std::nullopt;
 }
 
 void ConfigureMouseAdvanced::keyPressEvent(QKeyEvent* event) {

--- a/src/yuzu/configuration/configure_mouse_advanced.h
+++ b/src/yuzu/configuration/configure_mouse_advanced.h
@@ -5,9 +5,9 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 #include <QDialog>
 #include <QWidget>
-#include <boost/optional.hpp>
 #include "core/settings.h"
 
 class QCheckBox;
@@ -30,7 +30,7 @@ private:
     std::unique_ptr<Ui::ConfigureMouseAdvanced> ui;
 
     /// This will be the the setting function when an input is awaiting configuration.
-    boost::optional<std::function<void(const Common::ParamPackage&)>> input_setter;
+    std::optional<std::function<void(const Common::ParamPackage&)>> input_setter;
 
     std::array<QPushButton*, Settings::NativeMouseButton::NumMouseButtons> button_map;
     std::array<Common::ParamPackage, Settings::NativeMouseButton::NumMouseButtons> buttons_param;

--- a/src/yuzu/configuration/configure_mouse_advanced.h
+++ b/src/yuzu/configuration/configure_mouse_advanced.h
@@ -23,6 +23,7 @@ class ConfigureMouseAdvanced : public QDialog {
 
 public:
     explicit ConfigureMouseAdvanced(QWidget* parent);
+    ~ConfigureMouseAdvanced() override;
 
     void applyConfiguration();
 

--- a/src/yuzu/configuration/configure_mouse_advanced.h
+++ b/src/yuzu/configuration/configure_mouse_advanced.h
@@ -1,0 +1,67 @@
+﻿// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <QDialog>
+#include <QWidget>
+#include <boost/optional.hpp>
+#include "core/settings.h"
+
+class QCheckBox;
+class QPushButton;
+class QTimer;
+
+namespace Ui {
+class ConfigureMouseAdvanced;
+}
+
+class ConfigureMouseAdvanced : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit ConfigureMouseAdvanced(QWidget* parent);
+
+    void applyConfiguration();
+
+private:
+    std::unique_ptr<Ui::ConfigureMouseAdvanced> ui;
+
+    /// This will be the the setting function when an input is awaiting configuration.
+    boost::optional<std::function<void(const Common::ParamPackage&)>> input_setter;
+
+    std::array<QPushButton*, Settings::NativeMouseButton::NumMouseButtons> button_map;
+    std::array<Common::ParamPackage, Settings::NativeMouseButton::NumMouseButtons> buttons_param;
+
+    std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> device_pollers;
+
+    std::unique_ptr<QTimer> timeout_timer;
+    std::unique_ptr<QTimer> poll_timer;
+
+    /// A flag to indicate if keyboard keys are okay when configuring an input. If this is false,
+    /// keyboard events are ignored.
+    bool want_keyboard_keys = false;
+
+    /// Load configuration settings.
+    void loadConfiguration();
+    /// Restore all buttons to their default values.
+    void restoreDefaults();
+    /// Clear all input configuration
+    void ClearAll();
+
+    /// Update UI to reflect current configuration.
+    void updateButtonLabels();
+
+    /// Called when the button was pressed.
+    void handleClick(QPushButton* button,
+                     std::function<void(const Common::ParamPackage&)> new_input_setter,
+                     InputCommon::Polling::DeviceType type);
+
+    /// Finish polling and configure input using the input_setter
+    void setPollingResult(const Common::ParamPackage& params, bool abort);
+
+    /// Handle key press events.
+    void keyPressEvent(QKeyEvent* event) override;
+};

--- a/src/yuzu/configuration/configure_mouse_advanced.ui
+++ b/src/yuzu/configuration/configure_mouse_advanced.ui
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureMouseAdvanced</class>
+ <widget class="QDialog" name="ConfigureMouseAdvanced">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>250</width>
+    <height>261</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Configure Mouse</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="gridGroupBox">
+     <property name="title">
+      <string>Mouse Buttons</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="4">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="3">
+       <layout class="QVBoxLayout" name="verticalLayout_4">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Right:</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QPushButton" name="right_button">
+          <property name="minimumSize">
+           <size>
+            <width>75</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="0">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="1">
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Middle:</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QPushButton" name="middle_button">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="3" column="1">
+       <layout class="QVBoxLayout" name="verticalLayout_5">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <item>
+           <widget class="QLabel" name="label_4">
+            <property name="minimumSize">
+             <size>
+              <width>54</width>
+              <height>0</height>
+             </size>
+            </property>
+            <property name="text">
+             <string>Back:</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QPushButton" name="back_button">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="0" column="1">
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Left:</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QPushButton" name="left_button">
+          <property name="minimumSize">
+           <size>
+            <width>75</width>
+            <height>0</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="3" column="3">
+       <layout class="QVBoxLayout" name="verticalLayout_6">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <item>
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Forward:</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <widget class="QPushButton" name="forward_button">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
+     <item>
+      <widget class="QPushButton" name="buttonClearAll">
+       <property name="text">
+        <string>Clear All</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="buttonRestoreDefaults">
+       <property name="text">
+        <string>Restore Defaults</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ConfigureMouseAdvanced</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>124</x>
+     <y>266</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>124</x>
+     <y>143</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ConfigureMouseAdvanced</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>124</x>
+     <y>266</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>124</x>
+     <y>143</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/yuzu/configuration/configure_touchscreen_advanced.cpp
+++ b/src/yuzu/configuration/configure_touchscreen_advanced.cpp
@@ -1,0 +1,48 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+#include <QMenu>
+#include <QMessageBox>
+#include <QTimer>
+#include "common/assert.h"
+#include "common/param_package.h"
+#include "input_common/main.h"
+#include "ui_configure_touchscreen_advanced.h"
+#include "yuzu/configuration/config.h"
+#include "yuzu/configuration/configure_touchscreen_advanced.h"
+
+ConfigureTouchscreenAdvanced::ConfigureTouchscreenAdvanced(QWidget* parent)
+    : QDialog(parent), ui(std::make_unique<Ui::ConfigureTouchscreenAdvanced>()) {
+    ui->setupUi(this);
+
+    connect(ui->restore_defaults_button, &QPushButton::pressed, this,
+            &ConfigureTouchscreenAdvanced::restoreDefaults);
+
+    this->loadConfiguration();
+    this->resize(0, 0);
+}
+
+void ConfigureTouchscreenAdvanced::applyConfiguration() {
+    Settings::values.touchscreen.finger = ui->finger_box->value();
+    Settings::values.touchscreen.diameter_x = ui->diameter_x_box->value();
+    Settings::values.touchscreen.diameter_y = ui->diameter_y_box->value();
+    Settings::values.touchscreen.rotation_angle = ui->angle_box->value();
+}
+
+void ConfigureTouchscreenAdvanced::loadConfiguration() {
+    ui->finger_box->setValue(Settings::values.touchscreen.finger);
+    ui->diameter_x_box->setValue(Settings::values.touchscreen.diameter_x);
+    ui->diameter_y_box->setValue(Settings::values.touchscreen.diameter_y);
+    ui->angle_box->setValue(Settings::values.touchscreen.rotation_angle);
+}
+
+void ConfigureTouchscreenAdvanced::restoreDefaults() {
+    ui->finger_box->setValue(0);
+    ui->diameter_x_box->setValue(15);
+    ui->diameter_y_box->setValue(15);
+    ui->angle_box->setValue(0);
+}

--- a/src/yuzu/configuration/configure_touchscreen_advanced.cpp
+++ b/src/yuzu/configuration/configure_touchscreen_advanced.cpp
@@ -2,15 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <algorithm>
 #include <memory>
-#include <utility>
-#include <QMenu>
-#include <QMessageBox>
-#include <QTimer>
-#include "common/assert.h"
-#include "common/param_package.h"
-#include "input_common/main.h"
 #include "ui_configure_touchscreen_advanced.h"
 #include "yuzu/configuration/config.h"
 #include "yuzu/configuration/configure_touchscreen_advanced.h"
@@ -22,9 +14,11 @@ ConfigureTouchscreenAdvanced::ConfigureTouchscreenAdvanced(QWidget* parent)
     connect(ui->restore_defaults_button, &QPushButton::pressed, this,
             &ConfigureTouchscreenAdvanced::restoreDefaults);
 
-    this->loadConfiguration();
-    this->resize(0, 0);
+    loadConfiguration();
+    resize(0, 0);
 }
+
+ConfigureTouchscreenAdvanced::~ConfigureTouchscreenAdvanced() = default;
 
 void ConfigureTouchscreenAdvanced::applyConfiguration() {
     Settings::values.touchscreen.finger = ui->finger_box->value();

--- a/src/yuzu/configuration/configure_touchscreen_advanced.h
+++ b/src/yuzu/configuration/configure_touchscreen_advanced.h
@@ -1,0 +1,31 @@
+﻿// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <QDialog>
+#include <QWidget>
+#include "yuzu/configuration/config.h"
+
+namespace Ui {
+class ConfigureTouchscreenAdvanced;
+}
+
+class ConfigureTouchscreenAdvanced : public QDialog {
+    Q_OBJECT
+
+public:
+    explicit ConfigureTouchscreenAdvanced(QWidget* parent);
+
+    void applyConfiguration();
+
+private:
+    /// Load configuration settings.
+    void loadConfiguration();
+    /// Restore all buttons to their default values.
+    void restoreDefaults();
+
+    std::unique_ptr<Ui::ConfigureTouchscreenAdvanced> ui;
+};

--- a/src/yuzu/configuration/configure_touchscreen_advanced.h
+++ b/src/yuzu/configuration/configure_touchscreen_advanced.h
@@ -18,6 +18,7 @@ class ConfigureTouchscreenAdvanced : public QDialog {
 
 public:
     explicit ConfigureTouchscreenAdvanced(QWidget* parent);
+    ~ConfigureTouchscreenAdvanced() override;
 
     void applyConfiguration();
 

--- a/src/yuzu/configuration/configure_touchscreen_advanced.ui
+++ b/src/yuzu/configuration/configure_touchscreen_advanced.ui
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureTouchscreenAdvanced</class>
+ <widget class="QDialog" name="ConfigureTouchscreenAdvanced">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>298</width>
+    <height>339</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Configure Touchscreen</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label_2">
+     <property name="minimumSize">
+      <size>
+       <width>280</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Warning: The settings in this page affect the inner workings of yuzu's emulated touchscreen. Changing them may result in undesirable behavior, such as the touchscreen partially or not working. You should only use this page if you know what you are doing.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="gridGroupBox">
+     <property name="title">
+      <string>Touch Parameters</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Touch Diameter Y</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Finger</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Touch Diameter X</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QSpinBox" name="finger_box">
+        <property name="minimumSize">
+         <size>
+          <width>80</width>
+          <height>0</height>
+         </size>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Rotational Angle</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QSpinBox" name="diameter_x_box"/>
+      </item>
+      <item row="2" column="2">
+       <widget class="QSpinBox" name="diameter_y_box"/>
+      </item>
+      <item row="3" column="2">
+       <widget class="QSpinBox" name="angle_box"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="restore_defaults_button">
+       <property name="text">
+        <string>Restore Defaults</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ConfigureTouchscreenAdvanced</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>140</x>
+     <y>318</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>140</x>
+     <y>169</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ConfigureTouchscreenAdvanced</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>140</x>
+     <y>318</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>140</x>
+     <y>169</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -65,30 +65,272 @@ static const std::array<std::array<int, 5>, Settings::NativeAnalog::NumAnalogs> 
     },
 }};
 
+static const std::array<int, Settings::NativeMouseButton::NumMouseButtons> default_mouse_buttons = {
+    SDL_SCANCODE_LEFTBRACKET, SDL_SCANCODE_RIGHTBRACKET, SDL_SCANCODE_APOSTROPHE,
+    SDL_SCANCODE_MINUS,       SDL_SCANCODE_EQUALS,
+};
+
+static const std::array<int, 0x8A> keyboard_keys = {
+    0,
+    0,
+    0,
+    0,
+    SDL_SCANCODE_A,
+    SDL_SCANCODE_B,
+    SDL_SCANCODE_C,
+    SDL_SCANCODE_D,
+    SDL_SCANCODE_E,
+    SDL_SCANCODE_F,
+    SDL_SCANCODE_G,
+    SDL_SCANCODE_H,
+    SDL_SCANCODE_I,
+    SDL_SCANCODE_J,
+    SDL_SCANCODE_K,
+    SDL_SCANCODE_L,
+    SDL_SCANCODE_M,
+    SDL_SCANCODE_N,
+    SDL_SCANCODE_O,
+    SDL_SCANCODE_P,
+    SDL_SCANCODE_Q,
+    SDL_SCANCODE_R,
+    SDL_SCANCODE_S,
+    SDL_SCANCODE_T,
+    SDL_SCANCODE_U,
+    SDL_SCANCODE_V,
+    SDL_SCANCODE_W,
+    SDL_SCANCODE_X,
+    SDL_SCANCODE_Y,
+    SDL_SCANCODE_Z,
+    SDL_SCANCODE_1,
+    SDL_SCANCODE_2,
+    SDL_SCANCODE_3,
+    SDL_SCANCODE_4,
+    SDL_SCANCODE_5,
+    SDL_SCANCODE_6,
+    SDL_SCANCODE_7,
+    SDL_SCANCODE_8,
+    SDL_SCANCODE_9,
+    SDL_SCANCODE_0,
+    SDL_SCANCODE_RETURN,
+    SDL_SCANCODE_ESCAPE,
+    SDL_SCANCODE_BACKSPACE,
+    SDL_SCANCODE_TAB,
+    SDL_SCANCODE_SPACE,
+    SDL_SCANCODE_MINUS,
+    SDL_SCANCODE_EQUALS,
+    SDL_SCANCODE_LEFTBRACKET,
+    SDL_SCANCODE_RIGHTBRACKET,
+    SDL_SCANCODE_BACKSLASH,
+    0,
+    SDL_SCANCODE_SEMICOLON,
+    SDL_SCANCODE_APOSTROPHE,
+    SDL_SCANCODE_GRAVE,
+    SDL_SCANCODE_COMMA,
+    SDL_SCANCODE_PERIOD,
+    SDL_SCANCODE_SLASH,
+    SDL_SCANCODE_CAPSLOCK,
+
+    SDL_SCANCODE_F1,
+    SDL_SCANCODE_F2,
+    SDL_SCANCODE_F3,
+    SDL_SCANCODE_F4,
+    SDL_SCANCODE_F5,
+    SDL_SCANCODE_F6,
+    SDL_SCANCODE_F7,
+    SDL_SCANCODE_F8,
+    SDL_SCANCODE_F9,
+    SDL_SCANCODE_F10,
+    SDL_SCANCODE_F11,
+    SDL_SCANCODE_F12,
+
+    0,
+    SDL_SCANCODE_SCROLLLOCK,
+    SDL_SCANCODE_PAUSE,
+    SDL_SCANCODE_INSERT,
+    SDL_SCANCODE_HOME,
+    SDL_SCANCODE_PAGEUP,
+    SDL_SCANCODE_DELETE,
+    SDL_SCANCODE_END,
+    SDL_SCANCODE_PAGEDOWN,
+    SDL_SCANCODE_RIGHT,
+    SDL_SCANCODE_LEFT,
+    SDL_SCANCODE_DOWN,
+    SDL_SCANCODE_UP,
+
+    SDL_SCANCODE_NUMLOCKCLEAR,
+    SDL_SCANCODE_KP_DIVIDE,
+    SDL_SCANCODE_KP_MULTIPLY,
+    SDL_SCANCODE_KP_MINUS,
+    SDL_SCANCODE_KP_PLUS,
+    SDL_SCANCODE_KP_ENTER,
+    SDL_SCANCODE_KP_1,
+    SDL_SCANCODE_KP_2,
+    SDL_SCANCODE_KP_3,
+    SDL_SCANCODE_KP_4,
+    SDL_SCANCODE_KP_5,
+    SDL_SCANCODE_KP_6,
+    SDL_SCANCODE_KP_7,
+    SDL_SCANCODE_KP_8,
+    SDL_SCANCODE_KP_9,
+    SDL_SCANCODE_KP_0,
+    SDL_SCANCODE_KP_PERIOD,
+
+    0,
+    0,
+    SDL_SCANCODE_POWER,
+    SDL_SCANCODE_KP_EQUALS,
+
+    SDL_SCANCODE_F13,
+    SDL_SCANCODE_F14,
+    SDL_SCANCODE_F15,
+    SDL_SCANCODE_F16,
+    SDL_SCANCODE_F17,
+    SDL_SCANCODE_F18,
+    SDL_SCANCODE_F19,
+    SDL_SCANCODE_F20,
+    SDL_SCANCODE_F21,
+    SDL_SCANCODE_F22,
+    SDL_SCANCODE_F23,
+    SDL_SCANCODE_F24,
+
+    0,
+    SDL_SCANCODE_HELP,
+    SDL_SCANCODE_MENU,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    SDL_SCANCODE_KP_COMMA,
+    SDL_SCANCODE_KP_LEFTPAREN,
+    SDL_SCANCODE_KP_RIGHTPAREN,
+    0,
+    0,
+    0,
+    0,
+};
+
+static const std::array<int, 8> keyboard_mods{
+    SDL_SCANCODE_LCTRL, SDL_SCANCODE_LSHIFT, SDL_SCANCODE_LALT, SDL_SCANCODE_LGUI,
+    SDL_SCANCODE_RCTRL, SDL_SCANCODE_RSHIFT, SDL_SCANCODE_RALT, SDL_SCANCODE_RGUI,
+};
+
 void Config::ReadValues() {
     // Controls
+    for (std::size_t p = 0; p < Settings::values.players.size(); ++p) {
+        const auto group = fmt::format("ControlsP{}", p);
+        for (int i = 0; i < Settings::NativeButton::NumButtons; ++i) {
+            std::string default_param = InputCommon::GenerateKeyboardParam(default_buttons[i]);
+            Settings::values.players[p].buttons[i] =
+                sdl2_config->Get(group, Settings::NativeButton::mapping[i], default_param);
+            if (Settings::values.players[p].buttons[i].empty())
+                Settings::values.players[p].buttons[i] = default_param;
+        }
+
+        for (int i = 0; i < Settings::NativeAnalog::NumAnalogs; ++i) {
+            std::string default_param = InputCommon::GenerateAnalogParamFromKeys(
+                default_analogs[i][0], default_analogs[i][1], default_analogs[i][2],
+                default_analogs[i][3], default_analogs[i][4], 0.5f);
+            Settings::values.players[p].analogs[i] =
+                sdl2_config->Get(group, Settings::NativeAnalog::mapping[i], default_param);
+            if (Settings::values.players[p].analogs[i].empty())
+                Settings::values.players[p].analogs[i] = default_param;
+        }
+    }
+
+    Settings::values.mouse_enabled =
+        sdl2_config->GetBoolean("ControlsGeneral", "mouse_enabled", false);
+    for (int i = 0; i < Settings::NativeMouseButton::NumMouseButtons; ++i) {
+        std::string default_param = InputCommon::GenerateKeyboardParam(default_mouse_buttons[i]);
+        Settings::values.mouse_buttons[i] = sdl2_config->Get(
+            "ControlsGeneral", std::string("mouse_") + Settings::NativeMouseButton::mapping[i],
+            default_param);
+        if (Settings::values.mouse_buttons[i].empty())
+            Settings::values.mouse_buttons[i] = default_param;
+    }
+
+    Settings::values.motion_device = sdl2_config->Get(
+        "ControlsGeneral", "motion_device", "engine:motion_emu,update_period:100,sensitivity:0.01");
+
+    Settings::values.keyboard_enabled =
+        sdl2_config->GetBoolean("ControlsGeneral", "keyboard_enabled", false);
+
+    Settings::values.debug_pad_enabled =
+        sdl2_config->GetBoolean("ControlsGeneral", "debug_pad_enabled", false);
     for (int i = 0; i < Settings::NativeButton::NumButtons; ++i) {
         std::string default_param = InputCommon::GenerateKeyboardParam(default_buttons[i]);
-        Settings::values.buttons[i] =
-            sdl2_config->Get("Controls", Settings::NativeButton::mapping[i], default_param);
-        if (Settings::values.buttons[i].empty())
-            Settings::values.buttons[i] = default_param;
+        Settings::values.debug_pad_buttons[i] = sdl2_config->Get(
+            "ControlsGeneral", std::string("debug_pad_") + Settings::NativeButton::mapping[i],
+            default_param);
+        if (Settings::values.debug_pad_buttons[i].empty())
+            Settings::values.debug_pad_buttons[i] = default_param;
     }
 
     for (int i = 0; i < Settings::NativeAnalog::NumAnalogs; ++i) {
         std::string default_param = InputCommon::GenerateAnalogParamFromKeys(
             default_analogs[i][0], default_analogs[i][1], default_analogs[i][2],
             default_analogs[i][3], default_analogs[i][4], 0.5f);
-        Settings::values.analogs[i] =
-            sdl2_config->Get("Controls", Settings::NativeAnalog::mapping[i], default_param);
-        if (Settings::values.analogs[i].empty())
-            Settings::values.analogs[i] = default_param;
+        Settings::values.debug_pad_analogs[i] = sdl2_config->Get(
+            "ControlsGeneral", std::string("debug_pad_") + Settings::NativeAnalog::mapping[i],
+            default_param);
+        if (Settings::values.debug_pad_analogs[i].empty())
+            Settings::values.debug_pad_analogs[i] = default_param;
     }
 
-    Settings::values.motion_device = sdl2_config->Get(
-        "Controls", "motion_device", "engine:motion_emu,update_period:100,sensitivity:0.01");
-    Settings::values.touch_device =
-        sdl2_config->Get("Controls", "touch_device", "engine:emu_window");
+    Settings::values.touchscreen.enabled =
+        sdl2_config->GetBoolean("ControlsGeneral", "touch_enabled", true);
+    Settings::values.touchscreen.device =
+        sdl2_config->Get("ControlsGeneral", "touch_device", "engine:emu_window");
+    Settings::values.touchscreen.finger =
+        sdl2_config->GetInteger("ControlsGeneral", "touch_finger", 0);
+    Settings::values.touchscreen.rotation_angle =
+        sdl2_config->GetInteger("ControlsGeneral", "touch_angle", 0);
+    Settings::values.touchscreen.diameter_x =
+        sdl2_config->GetInteger("ControlsGeneral", "touch_diameter_x", 15);
+    Settings::values.touchscreen.diameter_y =
+        sdl2_config->GetInteger("ControlsGeneral", "touch_diameter_y", 15);
+
+    std::transform(keyboard_keys.begin(), keyboard_keys.end(),
+                   Settings::values.keyboard_keys.begin(), InputCommon::GenerateKeyboardParam);
+    std::transform(keyboard_mods.begin(), keyboard_mods.end(),
+                   Settings::values.keyboard_keys.begin() +
+                       Settings::NativeKeyboard::LeftControlKey,
+                   InputCommon::GenerateKeyboardParam);
+    std::transform(keyboard_mods.begin(), keyboard_mods.end(),
+                   Settings::values.keyboard_mods.begin(), InputCommon::GenerateKeyboardParam);
+
+    // Data Storage
+    Settings::values.use_virtual_sd =
+        sdl2_config->GetBoolean("Data Storage", "use_virtual_sd", true);
+    FileUtil::GetUserPath(FileUtil::UserPath::NANDDir,
+                          sdl2_config->Get("Data Storage", "nand_directory",
+                                           FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)));
+    FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir,
+                          sdl2_config->Get("Data Storage", "sdmc_directory",
+                                           FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)));
+
+    // System
+    Settings::values.use_docked_mode = sdl2_config->GetBoolean("System", "use_docked_mode", false);
+    Settings::values.enable_nfc = sdl2_config->GetBoolean("System", "enable_nfc", true);
+    const auto size = sdl2_config->GetInteger("System", "users_size", 0);
+
+    Settings::values.current_user = std::clamp<int>(
+        sdl2_config->GetInteger("System", "current_user", 0), 0, Service::Account::MAX_USERS - 1);
+
+	const auto enabled = sdl2_config->GetBoolean("System", "rng_seed_enabled", false);
+	if (enabled) {
+		Settings::values.rng_seed = sdl2_config->GetInteger("System", "rng_seed", 0);
+	}
+	else {
+		Settings::values.rng_seed = std::nullopt;
+	}
 
     // Core
     Settings::values.use_cpu_jit = sdl2_config->GetBoolean("Core", "use_cpu_jit", true);
@@ -113,31 +355,6 @@ void Config::ReadValues() {
         sdl2_config->GetBoolean("Audio", "enable_audio_stretching", true);
     Settings::values.audio_device_id = sdl2_config->Get("Audio", "output_device", "auto");
     Settings::values.volume = sdl2_config->GetReal("Audio", "volume", 1);
-
-    // Data Storage
-    Settings::values.use_virtual_sd =
-        sdl2_config->GetBoolean("Data Storage", "use_virtual_sd", true);
-    FileUtil::GetUserPath(FileUtil::UserPath::NANDDir,
-                          sdl2_config->Get("Data Storage", "nand_directory",
-                                           FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)));
-    FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir,
-                          sdl2_config->Get("Data Storage", "sdmc_directory",
-                                           FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)));
-
-    // System
-    Settings::values.use_docked_mode = sdl2_config->GetBoolean("System", "use_docked_mode", false);
-    Settings::values.enable_nfc = sdl2_config->GetBoolean("System", "enable_nfc", true);
-    const auto size = sdl2_config->GetInteger("System", "users_size", 0);
-
-    Settings::values.current_user = std::clamp<int>(
-        sdl2_config->GetInteger("System", "current_user", 0), 0, Service::Account::MAX_USERS - 1);
-
-    const auto enabled = sdl2_config->GetBoolean("System", "rng_seed_enabled", false);
-    if (enabled) {
-        Settings::values.rng_seed = sdl2_config->GetInteger("System", "rng_seed", 0);
-    } else {
-        Settings::values.rng_seed = std::nullopt;
-    }
 
     Settings::values.language_index = sdl2_config->GetInteger("System", "language_index", 1);
 

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -324,13 +324,12 @@ void Config::ReadValues() {
     Settings::values.current_user = std::clamp<int>(
         sdl2_config->GetInteger("System", "current_user", 0), 0, Service::Account::MAX_USERS - 1);
 
-	const auto enabled = sdl2_config->GetBoolean("System", "rng_seed_enabled", false);
-	if (enabled) {
-		Settings::values.rng_seed = sdl2_config->GetInteger("System", "rng_seed", 0);
-	}
-	else {
-		Settings::values.rng_seed = std::nullopt;
-	}
+    const auto enabled = sdl2_config->GetBoolean("System", "rng_seed_enabled", false);
+    if (enabled) {
+        Settings::values.rng_seed = sdl2_config->GetInteger("System", "rng_seed", 0);
+    } else {
+        Settings::values.rng_seed = std::nullopt;
+    }
 
     // Core
     Settings::values.use_cpu_jit = sdl2_config->GetBoolean("Core", "use_cpu_jit", true);


### PR DESCRIPTION
The fabled "HID 2" successor to #1444. This would not have been possible without HOS legend @ogniK5377 for his backend work to make this possible!

- Adds full UI support to change the connectivity, type/layouts and buttons for all eight players, the handheld controller, the debug controller, mouse, keyboard, and finally touchscreen.
- Moves the docked mode setting to the input tab as it directly affects whether or not handheld can be enabled
- Automatically rotates the left and right joycons when used in a single-joycon configuration
- Will automatically change your configuration to the closest supported one if the game rejects it
- Avoids reloading the game list on every config change

here are some pics of the UI:
![hid2-1](https://user-images.githubusercontent.com/5064800/47890166-15c1a000-de24-11e8-8b01-c20557fc75c2.PNG)
![hid2-2](https://user-images.githubusercontent.com/5064800/47890167-15c1a000-de24-11e8-8fb0-b195785373e3.PNG)
![hid-2-3](https://user-images.githubusercontent.com/5064800/47890168-165a3680-de24-11e8-8765-511232bf9a58.PNG)
![hid-2-4](https://user-images.githubusercontent.com/5064800/47890169-165a3680-de24-11e8-8b37-c5723ca92199.PNG)