### PR TITLE
Implement SetMemoryPermission

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -122,6 +122,12 @@ static ResultCode SetHeapSize(VAddr* heap_addr, u64 heap_size) {
     return RESULT_SUCCESS;
 }
 
+static ResultCode SetMemoryPermission(VAddr addr, u64 size, u32 prot) {
+    LOG_WARNING(Kernel_SVC, "(STUBBED) called, addr=0x{:X}, size=0x{:X}, prot=0x{:X}", addr, size,
+                prot);
+    return RESULT_SUCCESS;
+}
+
 static ResultCode SetMemoryAttribute(VAddr addr, u64 size, u32 state0, u32 state1) {
     LOG_WARNING(Kernel_SVC,
                 "(STUBBED) called, addr=0x{:X}, size=0x{:X}, state0=0x{:X}, state1=0x{:X}", addr,
@@ -1259,7 +1265,7 @@ struct FunctionDef {
 static const FunctionDef SVC_Table[] = {
     {0x00, nullptr, "Unknown"},
     {0x01, SvcWrap<SetHeapSize>, "SetHeapSize"},
-    {0x02, nullptr, "SetMemoryPermission"},
+    {0x02, SvcWrap<SetMemoryPermission>, "SetMemoryPermission"},
     {0x03, SvcWrap<SetMemoryAttribute>, "SetMemoryAttribute"},
     {0x04, SvcWrap<MapMemory>, "MapMemory"},
     {0x05, SvcWrap<UnmapMemory>, "UnmapMemory"},

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -121,6 +121,11 @@ void SvcWrap() {
     FuncReturn(func(Param(0), Param(1), Param(2)).raw);
 }
 
+template <ResultCode func(u64, u64, u32)>
+void SvcWrap() {
+    FuncReturn(func(Param(0), Param(1), static_cast<u32>(Param(2))).raw);
+}
+
 template <ResultCode func(u32, u64, u64, u32)>
 void SvcWrap() {
     FuncReturn(


### PR DESCRIPTION
~~Rayman Legends: Definitive Edition goes from an instant crash on boot into a fully working menu.~~

~~Rayman Legends: Definitive Edition was crashing on boot before and is now playable.~~

Rayman Legends: Definitive Edition was crashing on boot before and now is playable now without the uniformity check of the memory. To provide these checks some changes to the memory manger may be required (see comment by @lioncash).

Impementation based off suggested code by @lioncash

![3](https://user-images.githubusercontent.com/27208977/48033127-5e49c800-e15a-11e8-8820-87969eec4712.PNG)

