### PR TITLE
qt: Add help option to open yuzu folder

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -454,6 +454,7 @@ void GMainWindow::ConnectMenuEvents() {
     connect(ui.action_Fullscreen, &QAction::triggered, this, &GMainWindow::ToggleFullscreen);
 
     // Help
+    connect(ui.action_Open_yuzu_Folder, &QAction::triggered, this, &GMainWindow::OnOpenYuzuFolder);
     connect(ui.action_Rederive, &QAction::triggered, this,
             std::bind(&GMainWindow::OnReinitializeKeys, this, ReinitializeKeyBehavior::Warning));
     connect(ui.action_About, &QAction::triggered, this, &GMainWindow::OnAbout);
@@ -1372,6 +1373,11 @@ void GMainWindow::OnLoadAmiibo() {
         QMessageBox::warning(this, tr("Error loading Amiibo data"),
                              tr("Unable to load Amiibo data."));
     }
+}
+
+void GMainWindow::OnOpenYuzuFolder() {
+    QDesktopServices::openUrl(QUrl::fromLocalFile(
+        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::UserDir))));
 }
 
 void GMainWindow::OnAbout() {

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -167,6 +167,7 @@ private slots:
     void OnMenuRecentFile();
     void OnConfigure();
     void OnLoadAmiibo();
+    void OnOpenYuzuFolder();
     void OnAbout();
     void OnToggleFilterBar();
     void OnDisplayTitleBars(bool);

--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -110,6 +110,7 @@
      <string>&amp;Help</string>
     </property>
     <addaction name="action_Report_Compatibility"/>
+    <addaction name="action_Open_yuzu_Folder" />
     <addaction name="separator"/>
     <addaction name="action_About"/>
    </widget>
@@ -275,6 +276,11 @@
      </property>
      <property name="visible">
        <bool>false</bool>
+     </property>
+   </action>
+   <action name="action_Open_yuzu_Folder">
+     <property name="text">
+       <string>Open yuzu Folder</string>
      </property>
    </action>
   </widget>


### PR DESCRIPTION
Opens a windows explorer/file manager window at the user's yuzu folder (`%APPDATA%/yuzu` on windows).

Meant to make following guide or making configuration changes easier.