### PR TITLE
rasterizer_cache: Add missing virtual destructor to RasterizerCacheObject

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(video_core STATIC
     macro_interpreter.h
     memory_manager.cpp
     memory_manager.h
+    rasterizer_cache.cpp
     rasterizer_cache.h
     rasterizer_interface.h
     renderer_base.cpp

--- a/src/video_core/rasterizer_cache.cpp
+++ b/src/video_core/rasterizer_cache.cpp
@@ -1,0 +1,7 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "video_core/rasterizer_cache.h"
+
+RasterizerCacheObject::~RasterizerCacheObject() = default;

--- a/src/video_core/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache.h
@@ -17,6 +17,8 @@
 
 class RasterizerCacheObject {
 public:
+    virtual ~RasterizerCacheObject();
+
     /// Gets the address of the shader in guest memory, required for cache management
     virtual VAddr GetAddr() const = 0;
 


### PR DESCRIPTION
Ensures that destruction will always do the right thing in any context.