### PR TITLE
rasterizer_cache: Remove reliance on the System singleton

### DIFF
--- a/src/video_core/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache.h
@@ -10,10 +10,8 @@
 #include <boost/range/iterator_range_core.hpp>
 
 #include "common/common_types.h"
-#include "core/core.h"
 #include "core/settings.h"
 #include "video_core/rasterizer_interface.h"
-#include "video_core/renderer_base.h"
 
 class RasterizerCacheObject {
 public:
@@ -64,6 +62,8 @@ class RasterizerCache : NonCopyable {
     friend class RasterizerCacheObject;
 
 public:
+    explicit RasterizerCache(VideoCore::RasterizerInterface& rasterizer) : rasterizer{rasterizer} {}
+
     /// Write any cached resources overlapping the specified region back to memory
     void FlushRegion(Tegra::GPUVAddr addr, size_t size) {
         const auto& objects{GetSortedObjectsFromRegion(addr, size)};
@@ -109,14 +109,12 @@ protected:
     void Register(const T& object) {
         object->SetIsRegistered(true);
         object_cache.add({GetInterval(object), ObjectSet{object}});
-        auto& rasterizer = Core::System::GetInstance().Renderer().Rasterizer();
         rasterizer.UpdatePagesCachedCount(object->GetAddr(), object->GetSizeInBytes(), 1);
     }
 
     /// Unregisters an object from the cache
     void Unregister(const T& object) {
         object->SetIsRegistered(false);
-        auto& rasterizer = Core::System::GetInstance().Renderer().Rasterizer();
         rasterizer.UpdatePagesCachedCount(object->GetAddr(), object->GetSizeInBytes(), -1);
 
         // Only flush if use_accurate_gpu_emulation is enabled, as it incurs a performance hit
@@ -177,4 +175,5 @@ private:
 
     ObjectCache object_cache; ///< Cache of objects
     u64 modified_ticks{};     ///< Counter of cache state ticks, used for in-order flushing
+    VideoCore::RasterizerInterface& rasterizer;
 };

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -9,10 +9,12 @@
 #include "core/core.h"
 #include "core/memory.h"
 #include "video_core/renderer_opengl/gl_buffer_cache.h"
+#include "video_core/renderer_opengl/gl_rasterizer.h"
 
 namespace OpenGL {
 
-OGLBufferCache::OGLBufferCache(std::size_t size) : stream_buffer(GL_ARRAY_BUFFER, size) {}
+OGLBufferCache::OGLBufferCache(RasterizerOpenGL& rasterizer, std::size_t size)
+    : RasterizerCache{rasterizer}, stream_buffer(GL_ARRAY_BUFFER, size) {}
 
 GLintptr OGLBufferCache::UploadMemory(Tegra::GPUVAddr gpu_addr, std::size_t size,
                                       std::size_t alignment, bool cache) {

--- a/src/video_core/renderer_opengl/gl_buffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.h
@@ -15,6 +15,8 @@
 
 namespace OpenGL {
 
+class RasterizerOpenGL;
+
 struct CachedBufferEntry final : public RasterizerCacheObject {
     VAddr GetAddr() const override {
         return addr;
@@ -35,7 +37,7 @@ struct CachedBufferEntry final : public RasterizerCacheObject {
 
 class OGLBufferCache final : public RasterizerCache<std::shared_ptr<CachedBufferEntry>> {
 public:
-    explicit OGLBufferCache(std::size_t size);
+    explicit OGLBufferCache(RasterizerOpenGL& rasterizer, std::size_t size);
 
     /// Uploads data from a guest GPU address. Returns host's buffer offset where it's been
     /// allocated.

--- a/src/video_core/renderer_opengl/gl_primitive_assembler.cpp
+++ b/src/video_core/renderer_opengl/gl_primitive_assembler.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include "common/assert.h"
 #include "common/common_types.h"
+#include "core/core.h"
 #include "core/memory.h"
 #include "video_core/renderer_opengl/gl_buffer_cache.h"
 #include "video_core/renderer_opengl/gl_primitive_assembler.h"

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -79,7 +79,8 @@ struct DrawParameters {
 };
 
 RasterizerOpenGL::RasterizerOpenGL(Core::Frontend::EmuWindow& window, ScreenInfo& info)
-    : emu_window{window}, screen_info{info}, buffer_cache(STREAM_BUFFER_SIZE) {
+    : res_cache{*this}, shader_cache{*this}, emu_window{window}, screen_info{info},
+      buffer_cache(*this, STREAM_BUFFER_SIZE) {
     // Create sampler objects
     for (std::size_t i = 0; i < texture_samplers.size(); ++i) {
         texture_samplers[i].Create();

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -15,6 +15,7 @@
 #include "core/memory.h"
 #include "core/settings.h"
 #include "video_core/engines/maxwell_3d.h"
+#include "video_core/renderer_opengl/gl_rasterizer.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
 #include "video_core/renderer_opengl/gl_state.h"
 #include "video_core/renderer_opengl/utils.h"
@@ -1172,7 +1173,8 @@ void CachedSurface::UploadGLTexture(GLuint read_fb_handle, GLuint draw_fb_handle
         UploadGLMipmapTexture(i, read_fb_handle, draw_fb_handle);
 }
 
-RasterizerCacheOpenGL::RasterizerCacheOpenGL() {
+RasterizerCacheOpenGL::RasterizerCacheOpenGL(RasterizerOpenGL& rasterizer)
+    : RasterizerCache{rasterizer} {
     read_framebuffer.Create();
     draw_framebuffer.Create();
     copy_pbo.Create();

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -264,6 +264,8 @@ struct hash<SurfaceReserveKey> {
 
 namespace OpenGL {
 
+class RasterizerOpenGL;
+
 class CachedSurface final : public RasterizerCacheObject {
 public:
     CachedSurface(const SurfaceParams& params);
@@ -311,7 +313,7 @@ private:
 
 class RasterizerCacheOpenGL final : public RasterizerCache<Surface> {
 public:
-    RasterizerCacheOpenGL();
+    explicit RasterizerCacheOpenGL(RasterizerOpenGL& rasterizer);
 
     /// Get a surface based on the texture configuration
     Surface GetTextureSurface(const Tegra::Texture::FullTextureInfo& config,

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -6,10 +6,10 @@
 #include "core/core.h"
 #include "core/memory.h"
 #include "video_core/engines/maxwell_3d.h"
+#include "video_core/renderer_opengl/gl_rasterizer.h"
 #include "video_core/renderer_opengl/gl_shader_cache.h"
 #include "video_core/renderer_opengl/gl_shader_manager.h"
 #include "video_core/renderer_opengl/utils.h"
-#include "video_core/utils.h"
 
 namespace OpenGL {
 
@@ -134,6 +134,8 @@ GLuint CachedShader::LazyGeometryProgram(OGLProgram& target_program,
     LabelGLObject(GL_PROGRAM, target_program.handle, addr, debug_name);
     return target_program.handle;
 };
+
+ShaderCacheOpenGL::ShaderCacheOpenGL(RasterizerOpenGL& rasterizer) : RasterizerCache{rasterizer} {}
 
 Shader ShaderCacheOpenGL::GetStageProgram(Maxwell::ShaderProgram program) {
     const VAddr program_addr{GetShaderAddress(program)};

--- a/src/video_core/renderer_opengl/gl_shader_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_cache.h
@@ -16,6 +16,8 @@
 namespace OpenGL {
 
 class CachedShader;
+class RasterizerOpenGL;
+
 using Shader = std::shared_ptr<CachedShader>;
 using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 
@@ -104,6 +106,8 @@ private:
 
 class ShaderCacheOpenGL final : public RasterizerCache<Shader> {
 public:
+    explicit ShaderCacheOpenGL(RasterizerOpenGL& rasterizer);
+
     /// Gets the current specified shader stage program
     Shader GetStageProgram(Maxwell::ShaderProgram program);
 };


### PR DESCRIPTION
Rather than have a transparent dependency, we can make it explicit in the interface. This also gets rid of the need to put the core include in a header.