### PR TITLE
yuzu: Add a missing "!" to fix the stuck-in-fullscreen bug

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1612,7 +1612,7 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
         return;
     }
 
-    if (ui.action_Fullscreen->isChecked()) {
+    if (!ui.action_Fullscreen->isChecked()) {
         UISettings::values.geometry = saveGeometry();
         UISettings::values.renderwindow_geometry = render_window->saveGeometry();
     }


### PR DESCRIPTION
When @adityaruplaha ported https://github.com/yuzu-emu/yuzu/commit/958c98bdaedc8b496f62967142e5bf4f448260b2 from Citra to yuzu, he forgot a `!`, causing the stuck-in-fullscreen bug to reappear.