### PR TITLE
svc: Use proper random entropy generation algorithm

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -17,6 +17,7 @@
 #include "core/hle/kernel/thread.h"
 #include "core/hle/kernel/vm_manager.h"
 #include "core/memory.h"
+#include "core/settings.h"
 
 namespace Kernel {
 
@@ -34,6 +35,11 @@ SharedPtr<Process> Process::Create(KernelCore& kernel, std::string&& name) {
     process->program_id = 0;
     process->process_id = kernel.CreateNewProcessID();
     process->svc_access_mask.set();
+
+    std::mt19937 rng(Settings::values.rng_seed.value_or(0));
+    std::uniform_int_distribution<u64> distribution;
+    std::generate(process->random_entropy.begin(), process->random_entropy.end(),
+                  [&] { return distribution(rng); });
 
     kernel.AppendNewProcess(process);
     return process;

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -8,6 +8,7 @@
 #include <bitset>
 #include <cstddef>
 #include <memory>
+#include <random>
 #include <string>
 #include <vector>
 #include <boost/container/static_vector.hpp>
@@ -119,6 +120,8 @@ struct CodeSet final {
 
 class Process final : public Object {
 public:
+    static constexpr std::size_t RANDOM_ENTROPY_SIZE = 4;
+
     static SharedPtr<Process> Create(KernelCore& kernel, std::string&& name);
 
     std::string GetTypeName() const override {
@@ -210,6 +213,11 @@ public:
     /// Updates the total running time, adding the given ticks to it.
     void UpdateCPUTimeTicks(u64 ticks) {
         total_process_running_time_ticks += ticks;
+    }
+
+    /// Gets 8 bytes of random data for svcGetInfo RandomEntropy
+    u64 GetRandomEntropy(std::size_t index) const {
+        return random_entropy.at(index);
     }
 
     /**
@@ -320,6 +328,9 @@ private:
 
     /// Per-process handle table for storing created object handles in.
     HandleTable handle_table;
+
+    /// Random values for svcGetInfo RandomEntropy
+    std::array<u64, RANDOM_ENTROPY_SIZE> random_entropy;
 
     std::string name;
 };

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -559,7 +559,16 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
         *result = 0;
         break;
     case GetInfoType::RandomEntropy:
-        *result = Settings::values.rng_seed.value_or(0);
+        if (handle != 0) {
+            return ERR_INVALID_HANDLE;
+        }
+
+        if (info_sub_id >= Process::RANDOM_ENTROPY_SIZE) {
+            return ERR_INVALID_COMBINATION_KERNEL;
+        }
+
+        *result = current_process->GetRandomEntropy(info_sub_id);
+        return RESULT_SUCCESS;
         break;
     case GetInfoType::ASLRRegionBaseAddr:
         *result = vm_manager.GetASLRRegionBaseAddress();

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -115,7 +115,7 @@ struct Values {
     // System
     bool use_docked_mode;
     bool enable_nfc;
-    std::optional<u64> rng_seed;
+    std::optional<u32> rng_seed;
     s32 current_user;
     s32 language_index;
 

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -140,7 +140,7 @@ ConfigureSystem::ConfigureSystem(QWidget* parent)
     connect(ui->rng_seed_checkbox, &QCheckBox::stateChanged, this, [this](bool checked) {
         ui->rng_seed_edit->setEnabled(checked);
         if (!checked)
-            ui->rng_seed_edit->setText(QStringLiteral("0000000000000000"));
+            ui->rng_seed_edit->setText(QStringLiteral("00000000"));
     });
 
     scene = new QGraphicsScene;
@@ -165,9 +165,8 @@ void ConfigureSystem::setConfiguration() {
     ui->rng_seed_checkbox->setChecked(Settings::values.rng_seed.has_value());
     ui->rng_seed_edit->setEnabled(Settings::values.rng_seed.has_value());
 
-    const auto rng_seed = QString("%1")
-                              .arg(Settings::values.rng_seed.value_or(0), 16, 16, QLatin1Char{'0'})
-                              .toUpper();
+    const auto rng_seed =
+        QString("%1").arg(Settings::values.rng_seed.value_or(0), 8, 16, QLatin1Char{'0'}).toUpper();
     ui->rng_seed_edit->setText(rng_seed);
 }
 

--- a/src/yuzu/configuration/configure_system.ui
+++ b/src/yuzu/configuration/configure_system.ui
@@ -269,10 +269,10 @@
            </font>
           </property>
           <property name="inputMask">
-           <string>HHHHHHHHHHHHHHHH</string>
+           <string>HHHHHHHH</string>
           </property>
           <property name="maxLength">
-           <number>16</number>
+           <number>8</number>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
Addresses outlying concerns with #1670.

- Use 32-bit random seed to match kernel behavior
- Use random generator to generate per-core values for svcGetInfo RandomEntropy