### PR TITLE
video_core/renderer_base: Remove GL include from the renderer base class files

### DIFF
--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -5,7 +5,6 @@
 #include "core/frontend/emu_window.h"
 #include "core/settings.h"
 #include "video_core/renderer_base.h"
-#include "video_core/renderer_opengl/gl_rasterizer.h"
 
 namespace VideoCore {
 


### PR DESCRIPTION
Keeps the base class source files implementation-agnostic.