### PR TITLE
qt: Move Open yuzu Folder action from Help to File

### DIFF
--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -70,6 +70,8 @@
     <addaction name="separator"/>
     <addaction name="action_Load_Amiibo"/>
     <addaction name="separator"/>
+    <addaction name="action_Open_yuzu_Folder"/>
+    <addaction name="separator"/>
     <addaction name="action_Exit"/>
    </widget>
    <widget class="QMenu" name="menu_Emulation">
@@ -110,7 +112,6 @@
      <string>&amp;Help</string>
     </property>
     <addaction name="action_Report_Compatibility"/>
-    <addaction name="action_Open_yuzu_Folder" />
     <addaction name="separator"/>
     <addaction name="action_About"/>
    </widget>


### PR DESCRIPTION
As requested by @wwylele and @B3n30, it makes more sense for it to be in the `File` menu.