### PR TITLE
kernel/thread: Deduplicate scheduler switching code

### DIFF
--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -374,6 +374,8 @@ private:
     explicit Thread(KernelCore& kernel);
     ~Thread() override;
 
+    void ChangeScheduler();
+
     Core::ARM_Interface::ThreadContext context{};
 
     u32 thread_id = 0;


### PR DESCRIPTION
The code in both places was the same verbatim, so we can extract it to a function to deduplicate the logic.