### PR TITLE
service: Mark MakeFunctionString with the [[maybe_unused]] attribute.

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -80,8 +80,8 @@ namespace Service {
  * Creates a function string for logging, complete with the name (or header code, depending
  * on what's passed in) the port name, and all the cmd_buff arguments.
  */
-static std::string MakeFunctionString(const char* name, const char* port_name,
-                                      const u32* cmd_buff) {
+[[maybe_unused]] static std::string MakeFunctionString(const char* name, const char* port_name,
+                                                       const u32* cmd_buff) {
     // Number of params == bits 0-5 + bits 6-11
     int num_params = (cmd_buff[0] & 0x3F) + ((cmd_buff[0] >> 6) & 0x3F);
 


### PR DESCRIPTION
When yuzu is compiled in release mode this function is unused, however, when compiled in debug mode, it's used within a LOG_TRACE statement. This prevents erroneous compilation warnings about an unused function (that isn't actually totally unused).