### PR TITLE
nfp: Correct erroneous sizeof expression within GetTagInfo()

### DIFF
--- a/src/core/hle/service/nfp/nfp.cpp
+++ b/src/core/hle/service/nfp/nfp.cpp
@@ -212,7 +212,7 @@ private:
         IPC::ResponseBuilder rb{ctx, 2};
         auto amiibo = nfp_interface.GetAmiiboBuffer();
         TagInfo tag_info{};
-        std::memcpy(tag_info.uuid.data(), amiibo.uuid.data(), sizeof(tag_info.uuid.size()));
+        tag_info.uuid = amiibo.uuid;
         tag_info.uuid_length = static_cast<u8>(tag_info.uuid.size());
 
         tag_info.protocol = 1; // TODO(ogniK): Figure out actual values


### PR DESCRIPTION
The previous expression would copy sizeof(size_t) amount of bytes (8 on a 64-bit platform) rather than the full 10 bytes comprising the uuid member.