### PR TITLE
yuzu/configure_system: Mark the entropy mask string as nontranslatable

### DIFF
--- a/src/yuzu/configuration/configure_system.ui
+++ b/src/yuzu/configuration/configure_system.ui
@@ -269,7 +269,7 @@
            </font>
           </property>
           <property name="inputMask">
-           <string>HHHHHHHH</string>
+           <string notr="true">HHHHHHHH</string>
           </property>
           <property name="maxLength">
            <number>8</number>


### PR DESCRIPTION
There's no need for translators to concern themselves with the validation mask used by the entry field.