### PR TITLE
service/acc: Correct error case within TrySelectUserWithoutInteraction()

### DIFF
--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -252,8 +252,10 @@ void Module::Interface::TrySelectUserWithoutInteraction(Kernel::HLERequestContex
         rb.PushRaw<u128>(INVALID_UUID);
         return;
     }
-    auto user_list = profile_manager->GetAllUsers();
-    if (user_list.empty()) {
+
+    const auto user_list = profile_manager->GetAllUsers();
+    if (std::all_of(user_list.begin(), user_list.end(),
+                    [](const auto& user) { return user.uuid == INVALID_UUID; })) {
         rb.Push(ResultCode(-1)); // TODO(ogniK): Find the correct error code
         rb.PushRaw<u128>(INVALID_UUID);
         return;


### PR DESCRIPTION
empty() in this case will always return false, since the returned container is a std::array. Instead, check if all given users are invalid before returning the error code.