### PR TITLE
[WIP] Initial implementation of MapPhysicalMemory

### DIFF
--- a/src/core/file_sys/program_metadata.cpp
+++ b/src/core/file_sys/program_metadata.cpp
@@ -63,6 +63,10 @@ u32 ProgramMetadata::GetMainThreadStackSize() const {
     return npdm_header.main_stack_size;
 }
 
+u32 ProgramMetadata::GetSystemResourceSize() const {
+    return npdm_header.system_resource_size;
+}
+
 u64 ProgramMetadata::GetTitleID() const {
     return aci_header.title_id;
 }

--- a/src/core/file_sys/program_metadata.h
+++ b/src/core/file_sys/program_metadata.h
@@ -50,6 +50,7 @@ public:
     u32 GetMainThreadStackSize() const;
     u64 GetTitleID() const;
     u64 GetFilesystemPermissions() const;
+    u32 GetSystemResourceSize() const;
 
     void Print() const;
 
@@ -68,7 +69,8 @@ private:
         u8 reserved_3;
         u8 main_thread_priority;
         u8 main_thread_cpu;
-        std::array<u8, 8> reserved_4;
+        std::array<u8, 4> reserved_4;
+        u32 system_resource_size;
         u32_le process_category;
         u32_le main_stack_size;
         std::array<u8, 0x10> application_name;

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -45,6 +45,7 @@ SharedPtr<Process> Process::Create(KernelCore& kernel, std::string&& name) {
 }
 
 void Process::LoadFromMetadata(const FileSys::ProgramMetadata& metadata) {
+    system_resource_size = metadata.GetSystemResourceSize();
     program_id = metadata.GetTitleID();
     is_64bit_process = metadata.Is64BitProgram();
     vm_manager.Reset(metadata.GetAddressSpaceType());

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -170,6 +170,10 @@ public:
         return program_id;
     }
 
+    u32 GetSystemResourceSize() const {
+        return system_resource_size;
+    }
+
     /// Gets the resource limit descriptor for this process
     ResourceLimit& GetResourceLimit() {
         return *resource_limit;
@@ -278,6 +282,8 @@ private:
 
     /// Title ID corresponding to the process
     u64 program_id;
+
+    u32 system_resource_size = 0;
 
     /// Resource limit descriptor for this process
     SharedPtr<ResourceLimit> resource_limit;

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -170,6 +170,8 @@ public:
         return program_id;
     }
 
+    /// Gets the extra system resources we can allocate which is typically passed to
+    /// MapPhysicalMemory
     u32 GetSystemResourceSize() const {
         return system_resource_size;
     }
@@ -283,6 +285,7 @@ private:
     /// Title ID corresponding to the process
     u64 program_id;
 
+    /// The extra system resources we can allocate which is typically passed to MapPhysicalMemory
     u32 system_resource_size = 0;
 
     /// Resource limit descriptor for this process

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -80,10 +80,16 @@ ResultCode MapUnmapMemorySanityChecks(const VMManager& vm_manager, VAddr dst_add
     }
 
     if (!vm_manager.IsInsideAddressSpace(src_addr, size)) {
+        LOG_ERROR(Kernel_SVC,
+                  "Source is not inside the address space, addr=0x{:016X}, size=0x{:016X}",
+                  src_addr, size);
         return ERR_INVALID_ADDRESS_STATE;
     }
 
     if (!vm_manager.IsInsideNewMapRegion(dst_addr, size)) {
+        LOG_ERROR(Kernel_SVC,
+                  "Destination is not inside the new map region, addr=0x{:016X}, size=0x{:016X}",
+                  dst_addr, size);
         return ERR_INVALID_MEMORY_RANGE;
     }
 
@@ -1617,14 +1623,24 @@ static ResultCode MapPhysicalMemory(VAddr addr, u64 size) {
     LOG_DEBUG(Kernel_SVC, "called, addr=0x{:08X}, size=0x{:X}", addr, size);
 
     if (!Common::Is4KBAligned(addr)) {
+        LOG_ERROR(Kernel_SVC, "Address is not aligned to 4KB, 0x{:016X}", addr);
         return ERR_INVALID_ADDRESS;
     }
 
-    if (size == 0 || !Common::Is4KBAligned(size)) {
+    if (size == 0) {
+        LOG_ERROR(Kernel_SVC, "Size is 0");
+        return ERR_INVALID_SIZE;
+    }
+
+    if (!Common::Is4KBAligned(size)) {
+        LOG_ERROR(Kernel_SVC, "Size is not aligned to 4KB, 0x{:016X}", size);
         return ERR_INVALID_SIZE;
     }
 
     if (!IsValidAddressRange(addr, size)) {
+        LOG_ERROR(Kernel_SVC,
+                  "Address is not a valid address range, addr=0x{:016X}, size=0x{:016X}", addr,
+                  size);
         return ERR_INVALID_ADDRESS_STATE;
     }
 
@@ -1632,10 +1648,15 @@ static ResultCode MapPhysicalMemory(VAddr addr, u64 size) {
     auto& vm_manager = current_process->VMManager();
 
     if (current_process->GetSystemResourceSize() == 0) {
+        LOG_ERROR(Kernel_SVC, "The system resource size is 0");
         return ERR_INVALID_STATE;
     }
 
     if (!vm_manager.IsInsideMapRegion(addr, size)) {
+        LOG_ERROR(Kernel_SVC,
+                  "Destination does not fit within the map region, addr=0x{:016X}, "
+                  "size=0x{:016X}",
+                  addr, size);
         return ERR_INVALID_MEMORY_RANGE;
     }
 
@@ -1645,14 +1666,24 @@ static ResultCode MapPhysicalMemory(VAddr addr, u64 size) {
 static ResultCode UnmapPhysicalMemory(VAddr addr, u64 size) {
     LOG_DEBUG(Kernel_SVC, "called, addr=0x{:08X}, size=0x{:X}", addr, size);
     if (!Common::Is4KBAligned(addr)) {
+        LOG_ERROR(Kernel_SVC, "Address is not aligned to 4KB, 0x{:016X}", addr);
         return ERR_INVALID_ADDRESS;
     }
 
-    if (size == 0 || !Common::Is4KBAligned(size)) {
+    if (size == 0) {
+        LOG_ERROR(Kernel_SVC, "Size is 0");
+        return ERR_INVALID_SIZE;
+    }
+
+    if (!Common::Is4KBAligned(size)) {
+        LOG_ERROR(Kernel_SVC, "Size is not aligned to 4KB, 0x{:016X}", size);
         return ERR_INVALID_SIZE;
     }
 
     if (!IsValidAddressRange(addr, size)) {
+        LOG_ERROR(Kernel_SVC,
+                  "Address is not a valid address range, addr=0x{:016X}, size=0x{:016X}", addr,
+                  size);
         return ERR_INVALID_ADDRESS_STATE;
     }
 
@@ -1660,10 +1691,15 @@ static ResultCode UnmapPhysicalMemory(VAddr addr, u64 size) {
     auto& vm_manager = current_process->VMManager();
 
     if (current_process->GetSystemResourceSize() == 0) {
+        LOG_ERROR(Kernel_SVC, "The system resource size is 0");
         return ERR_INVALID_STATE;
     }
 
     if (!vm_manager.IsInsideMapRegion(addr, size)) {
+        LOG_ERROR(Kernel_SVC,
+                  "Destination does not fit within the map region, addr=0x{:016X}, "
+                  "size=0x{:016X}",
+                  addr, size);
         return ERR_INVALID_MEMORY_RANGE;
     }
 

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -145,6 +145,11 @@ void SvcWrap() {
     FuncReturn(func(static_cast<u32>(Param(0)), Param(1), Param(2)).raw);
 }
 
+template <ResultCode func(u64, u64)>
+void SvcWrap() {
+    FuncReturn(func(Param(0), Param(1)).raw);
+}
+
 template <ResultCode func(u32*, u64, u64, s64)>
 void SvcWrap() {
     u32 param_1 = 0;

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -164,8 +164,10 @@ ResultVal<VAddr> VMManager::FindFreeRegion(u64 size) const {
     return MakeResult<VAddr>(target);
 }
 
-constexpr bool FallsInAddress(VAddr addr_start, VAddr addr_end, VAddr start_range) {
-    return (addr_start >= start_range && addr_end >= start_range);
+constexpr bool AreOverlapping(VAddr addr_start, VAddr addr_end, VAddr region_start,
+                              VAddr region_end) {
+    return std::max(addr_end, region_end) - std::min(addr_start, region_start) <
+           (addr_end - addr_start) + (region_end - region_start);
 }
 
 ResultCode VMManager::MapPhysicalMemory(VAddr addr, u64 size) {
@@ -173,6 +175,10 @@ ResultCode VMManager::MapPhysicalMemory(VAddr addr, u64 size) {
     const auto end = GetMapRegionEndAddress();
 
     if (!IsInsideMapRegion(addr, size)) {
+        LOG_ERROR(
+            Kernel,
+            "Address and size does not fall inside the map region, addr=0x{:016X}, size=0x{:016X}",
+            addr, size);
         return ERR_INVALID_ADDRESS;
     }
 
@@ -208,11 +214,12 @@ ResultCode VMManager::MapPhysicalMemory(VAddr addr, u64 size) {
         }
 
         // We're not processing addresses yet, lets keep skipping
-        if (!IsInsideAddressRange(addr, size, vma_start, vma_end)) {
+        if (!AreOverlapping(addr, addr + size, vma_start, vma_end)) {
             continue;
         }
 
-        const auto offset_in_vma = vma_start + (addr - vma_start);
+        // If we fall within the vma, get the offset of where we begin in the said vma
+        const auto offset_in_vma = vma_start + ((addr + size - remaining_to_map) - vma_start);
         const auto remaining_vma_size = (vma_end - offset_in_vma);
         // Our vma is already mapped
         if (is_mapped) {
@@ -235,6 +242,13 @@ ResultCode VMManager::MapPhysicalMemory(VAddr addr, u64 size) {
                 if (last_result.IsSuccess()) {
                     personal_heap_usage += remaining_to_map;
                     mapped_regions.push_back(std::make_pair(offset_in_vma, remaining_to_map));
+                } else {
+                    LOG_ERROR(Kernel,
+                              "Failed to map entire VMA with error 0x{:X}, addr=0x{:016X}, "
+                              "size=0x{:016X}, vma_start={:016X}, vma_end={:016X}, "
+                              "offset_in_vma={:016X}, remaining_to_map={:016X}",
+                              last_result.raw, addr, size, vma_start, vma_end, offset_in_vma,
+                              remaining_to_map);
                 }
                 break;
             } else {
@@ -250,6 +264,13 @@ ResultCode VMManager::MapPhysicalMemory(VAddr addr, u64 size) {
                     personal_heap_usage += remaining_vma_size;
                     remaining_to_map -= remaining_vma_size;
                     mapped_regions.push_back(std::make_pair(offset_in_vma, remaining_vma_size));
+                } else {
+                    LOG_ERROR(Kernel,
+                              "Failed to map partial VMA with error 0x{:X}, addr=0x{:016X}, "
+                              "size=0x{:016X}, vma_start={:016X}, vma_end={:016X}, "
+                              "offset_in_vma={:016X}, remaining_to_map={:016X}",
+                              last_result.raw, addr, size, vma_start, vma_end, offset_in_vma,
+                              remaining_to_map);
                 }
                 continue;
             }
@@ -278,6 +299,7 @@ ResultCode VMManager::UnmapPhysicalMemory(VAddr addr, u64 size) {
 
     // We have nothing mapped, we can just map directly
     if (personal_heap_usage == 0) {
+        LOG_WARNING(Kernel, "Unmap physical memory called when our personal usage is empty");
         return RESULT_SUCCESS;
     }
 
@@ -305,11 +327,11 @@ ResultCode VMManager::UnmapPhysicalMemory(VAddr addr, u64 size) {
         }
 
         // We're not processing addresses yet, lets keep skipping
-        if (!IsInsideAddressRange(addr, size, vma_start, vma_end)) {
+        if (!AreOverlapping(addr, addr + size, vma_start, vma_end)) {
             continue;
         }
 
-        const auto offset_in_vma = vma_start + (addr - vma_start);
+        const auto offset_in_vma = vma_start + ((addr + size - remaining_to_unmap) - vma_start);
         const auto remaining_vma_size = (vma_end - offset_in_vma);
         // Our vma is already unmapped
         if (is_unmapped) {
@@ -329,6 +351,13 @@ ResultCode VMManager::UnmapPhysicalMemory(VAddr addr, u64 size) {
                 if (last_result.IsSuccess()) {
                     personal_heap_usage -= remaining_to_unmap;
                     unmapped_regions.push_back(std::make_pair(offset_in_vma, remaining_to_unmap));
+                } else {
+                    LOG_ERROR(Kernel,
+                              "Failed to unmap entire VMA with error 0x{:X}, addr=0x{:016X}, "
+                              "size=0x{:016X}, vma_start={:016X}, vma_end={:016X}, "
+                              "offset_in_vma={:016X}, remaining_to_map={:016X}",
+                              last_result.raw, addr, size, vma_start, vma_end, offset_in_vma,
+                              remaining_to_unmap);
                 }
                 break;
             } else {
@@ -340,6 +369,13 @@ ResultCode VMManager::UnmapPhysicalMemory(VAddr addr, u64 size) {
                     personal_heap_usage -= remaining_vma_size;
                     remaining_to_unmap -= remaining_vma_size;
                     unmapped_regions.push_back(std::make_pair(offset_in_vma, remaining_vma_size));
+                } else {
+                    LOG_ERROR(Kernel,
+                              "Failed to unmap partial VMA with error 0x{:X}, addr=0x{:016X}, "
+                              "size=0x{:016X}, vma_start={:016X}, vma_end={:016X}, "
+                              "offset_in_vma={:016X}, remaining_to_map={:016X}",
+                              last_result.raw, addr, size, vma_start, vma_end, offset_in_vma,
+                              remaining_to_unmap);
                 }
                 continue;
             }

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -305,19 +305,12 @@ ResultCode VMManager::UnmapPhysicalMemory(VAddr addr, u64 size) {
 
     auto vma = FindVMA(base);
     u64 remaining_to_unmap = size;
-    auto last_result = RESULT_SUCCESS;
     // Needed just in case we fail to map a region, we'll unmap everything.
     std::vector<std::pair<u64, u64>> unmapped_regions;
     while (vma != vma_map.end() && vma->second.base <= end && remaining_to_unmap > 0) {
         const auto vma_start = vma->second.base;
         const auto vma_end = vma_start + vma->second.size;
         const auto is_unmapped = vma->second.meminfo_state != MemoryState::Mapped;
-        // Something failed, lets bail out
-        if (last_result.IsError()) {
-            break;
-        }
-        last_result = RESULT_SUCCESS;
-
         // Allows us to use continue without worrying about incrementing the vma
         SCOPE_EXIT({ vma++; });
 
@@ -347,48 +340,36 @@ ResultCode VMManager::UnmapPhysicalMemory(VAddr addr, u64 size) {
             // We're mapped, so lets unmap
             if (remaining_vma_size >= remaining_to_unmap) {
                 // The rest of what we need to unmap fits in this region
-                last_result = UnmapRange(offset_in_vma, remaining_to_unmap);
-                if (last_result.IsSuccess()) {
-                    personal_heap_usage -= remaining_to_unmap;
-                    unmapped_regions.push_back(std::make_pair(offset_in_vma, remaining_to_unmap));
-                } else {
-                    LOG_ERROR(Kernel,
-                              "Failed to unmap entire VMA with error 0x{:X}, addr=0x{:016X}, "
-                              "size=0x{:016X}, vma_start={:016X}, vma_end={:016X}, "
-                              "offset_in_vma={:016X}, remaining_to_map={:016X}",
-                              last_result.raw, addr, size, vma_start, vma_end, offset_in_vma,
-                              remaining_to_unmap);
-                }
+                unmapped_regions.push_back(std::make_pair(offset_in_vma, remaining_to_unmap));
                 break;
             } else {
                 // We only partially fit here, lets unmap what we can
-                last_result = UnmapRange(offset_in_vma, remaining_vma_size);
-
                 // Update our usage and continue to the next vma
-                if (last_result.IsSuccess()) {
-                    personal_heap_usage -= remaining_vma_size;
-                    remaining_to_unmap -= remaining_vma_size;
-                    unmapped_regions.push_back(std::make_pair(offset_in_vma, remaining_vma_size));
-                } else {
-                    LOG_ERROR(Kernel,
-                              "Failed to unmap partial VMA with error 0x{:X}, addr=0x{:016X}, "
-                              "size=0x{:016X}, vma_start={:016X}, vma_end={:016X}, "
-                              "offset_in_vma={:016X}, remaining_to_map={:016X}",
-                              last_result.raw, addr, size, vma_start, vma_end, offset_in_vma,
-                              remaining_to_unmap);
-                }
+                remaining_to_unmap -= remaining_vma_size;
+                unmapped_regions.push_back(std::make_pair(offset_in_vma, remaining_vma_size));
                 continue;
             }
         }
     }
-
-    // We failed to unmap something, lets remap everything back
-    if (last_result.IsError() && !unmapped_regions.empty()) {
-        for (const auto [mapped_addr, mapped_size] : unmapped_regions) {
-            if (MapMemoryBlock(mapped_addr, std::make_shared<std::vector<u8>>(mapped_size, 0), 0,
-                               mapped_size, MemoryState::Mapped)
-                    .Succeeded()) {
-                personal_heap_usage += mapped_size;
+    auto last_result = RESULT_SUCCESS;
+    if (!unmapped_regions.empty()) {
+        for (auto it = unmapped_regions.begin(); it != unmapped_regions.end(); ++it) {
+            last_result = UnmapRange((*it).first, (*it).second);
+            if (last_result.IsSuccess()) {
+                personal_heap_usage -= (*it).second;
+            } else {
+                LOG_ERROR(Kernel,
+                          "Failed to unmap region addr=0x{:016X}, size=0x{:016X} with error=0x{:X}",
+                          (*it).first, (*it).second, last_result.raw);
+                while (it != unmapped_regions.begin()) {
+                    if (MapMemoryBlock((*it).first,
+                                       std::make_shared<std::vector<u8>>((*it).second, 0), 0,
+                                       (*it).second, MemoryState::Mapped)
+                            .Succeeded()) {
+                        personal_heap_usage += (*it).second;
+                    }
+                    --it;
+                }
             }
         }
     }


### PR DESCRIPTION
This PR adds PersonalMmHeapUsage, UnmapPhysicalMemory, and MapPhysicalMemory. It seems a lot of games can have this disabled which we originally did but a few games seem to require it. Notable that it seemed to have fixed a few unknown unmapped reads in a few games. When MapPhysicalMemory or UnmapPhysicalMemory fails, we need to redo what we've done. This could be improved but for now, we're iterating a vector and restoring what we did.