### PR TITLE
file_sys: Implement open source system archives

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -61,6 +61,10 @@ add_library(core STATIC
     file_sys/sdmc_factory.h
     file_sys/submission_package.cpp
     file_sys/submission_package.h
+    file_sys/system_archive/ng_word.cpp
+    file_sys/system_archive/ng_word.h
+    file_sys/system_archive/system_archive.cpp
+    file_sys/system_archive/system_archive.h
     file_sys/vfs.cpp
     file_sys/vfs.h
     file_sys/vfs_concat.cpp

--- a/src/core/file_sys/system_archive/ng_word.cpp
+++ b/src/core/file_sys/system_archive/ng_word.cpp
@@ -1,0 +1,42 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <fmt/format.h>
+#include "common/common_types.h"
+#include "core/file_sys/system_archive/ng_word.h"
+#include "core/file_sys/vfs_vector.h"
+
+namespace FileSys::SystemArchive {
+
+namespace NgWord1Data {
+
+constexpr std::size_t NUMBER_WORD_TXT_FILES = 0x10;
+
+// Should this archive replacement mysteriously not work on a future game, consider updating.
+constexpr std::array<u8, 4> VERSION_DAT{0x0, 0x0, 0x0, 0x19}; // 5.1.0 System Version
+
+constexpr std::array<u8, 30> WORD_TXT{
+    0xFE, 0xFF, 0x00, 0x5E, 0x00, 0x76, 0x00, 0x65, 0x00, 0x72, 0x00, 0x79, 0x00, 0x62, 0x00,
+    0x61, 0x00, 0x64, 0x00, 0x77, 0x00, 0x6F, 0x00, 0x72, 0x00, 0x64, 0x00, 0x24, 0x00, 0x0A,
+}; // "^verybadword$" in UTF-16
+
+} // namespace NgWord1Data
+
+VirtualDir NgWord1() {
+    std::vector<VirtualFile> files(NgWord1Data::NUMBER_WORD_TXT_FILES);
+
+    for (std::size_t i = 0; i < NgWord1Data::NUMBER_WORD_TXT_FILES; ++i) {
+        files[i] = std::make_shared<ArrayVfsFile<NgWord1Data::WORD_TXT.size()>>(
+            NgWord1Data::WORD_TXT, fmt::format("{}.txt", i));
+    }
+
+    files.push_back(std::make_shared<ArrayVfsFile<NgWord1Data::WORD_TXT.size()>>(
+        NgWord1Data::WORD_TXT, "common.txt"));
+    files.push_back(std::make_shared<ArrayVfsFile<NgWord1Data::VERSION_DAT.size()>>(
+        NgWord1Data::VERSION_DAT, "version.dat"));
+
+    return std::make_shared<VectorVfsDirectory>(files, std::vector<VirtualDir>{}, "data");
+}
+
+} // namespace FileSys::SystemArchive

--- a/src/core/file_sys/system_archive/ng_word.h
+++ b/src/core/file_sys/system_archive/ng_word.h
@@ -1,0 +1,13 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/file_sys/vfs_types.h"
+
+namespace FileSys::SystemArchive {
+
+VirtualDir NgWord1();
+
+} // namespace FileSys::SystemArchive

--- a/src/core/file_sys/system_archive/system_archive.cpp
+++ b/src/core/file_sys/system_archive/system_archive.cpp
@@ -1,0 +1,91 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <functional>
+#include "common/logging/log.h"
+#include "core/file_sys/romfs.h"
+#include "core/file_sys/system_archive/ng_word.h"
+#include "core/file_sys/system_archive/system_archive.h"
+
+namespace FileSys::SystemArchive {
+
+constexpr u64 SYSTEM_ARCHIVE_BASE_TITLE_ID = 0x0100000000000800;
+constexpr std::size_t SYSTEM_ARCHIVE_COUNT = 0x28;
+
+using SystemArchiveSupplier = std::function<VirtualDir()>;
+
+struct SystemArchiveDescriptor {
+    u64 title_id;
+    const char* name;
+    SystemArchiveSupplier supplier;
+};
+
+const static std::array<SystemArchiveDescriptor, SYSTEM_ARCHIVE_COUNT> SYSTEM_ARCHIVES = {{
+    {0x0100000000000800, "CertStore", nullptr},
+    {0x0100000000000801, "ErrorMessage", nullptr},
+    {0x0100000000000802, "MiiModel", nullptr},
+    {0x0100000000000803, "BrowserDll", nullptr},
+    {0x0100000000000804, "Help", nullptr},
+    {0x0100000000000805, "SharedFont", nullptr},
+    {0x0100000000000806, "NgWord", &NgWord1},
+    {0x0100000000000807, "SsidList", nullptr},
+    {0x0100000000000808, "Dictionary", nullptr},
+    {0x0100000000000809, "SystemVersion", nullptr},
+    {0x010000000000080A, "AvatarImage", nullptr},
+    {0x010000000000080B, "LocalNews", nullptr},
+    {0x010000000000080C, "Eula", nullptr},
+    {0x010000000000080D, "UrlBlackList", nullptr},
+    {0x010000000000080E, "TimeZoneBinary", nullptr},
+    {0x010000000000080F, "CertStoreCruiser", nullptr},
+    {0x0100000000000810, "FontNintendoExtension", nullptr},
+    {0x0100000000000811, "FontStandard", nullptr},
+    {0x0100000000000812, "FontKorean", nullptr},
+    {0x0100000000000813, "FontChineseTraditional", nullptr},
+    {0x0100000000000814, "FontChineseSimple", nullptr},
+    {0x0100000000000815, "FontBfcpx", nullptr},
+    {0x0100000000000816, "SystemUpdate", nullptr},
+    {0x0100000000000817, "0100000000000817", nullptr},
+    {0x0100000000000818, "FirmwareDebugSettings", nullptr},
+    {0x0100000000000819, "BootImagePackage", nullptr},
+    {0x010000000000081A, "BootImagePackageSafe", nullptr},
+    {0x010000000000081B, "BootImagePackageExFat", nullptr},
+    {0x010000000000081C, "BottImagePackageExFatSafe", nullptr},
+    {0x010000000000081D, "FatalMessage", nullptr},
+    {0x010000000000081E, "ControllerIcon", nullptr},
+    {0x010000000000081F, "PlatformConfigIcosa", nullptr},
+    {0x0100000000000820, "PlatformConfigCopper", nullptr},
+    {0x0100000000000821, "PlatformConfigHoag", nullptr},
+    {0x0100000000000822, "ControllerFirmware", nullptr},
+    {0x0100000000000823, "NgWord2", nullptr},
+    {0x0100000000000824, "PlatformConfigIcosaMariko", nullptr},
+    {0x0100000000000825, "ApplicationBlackList", nullptr},
+    {0x0100000000000826, "RebootlessSystemUpdateVersion", nullptr},
+    {0x0100000000000827, "ContentActionTable", nullptr},
+}};
+
+VirtualFile SynthesizeSystemArchive(u64 title_id) {
+    if (title_id < SYSTEM_ARCHIVES.front().title_id || title_id > SYSTEM_ARCHIVES.back().title_id)
+        return nullptr;
+
+    const auto desc = SYSTEM_ARCHIVES[title_id - SYSTEM_ARCHIVE_BASE_TITLE_ID];
+
+    LOG_INFO(Service_FS, "Synthesizing system archive '{}' (0x{:016X}).", desc.name, desc.title_id);
+
+    if (desc.supplier == nullptr)
+        return nullptr;
+
+    const auto dir = desc.supplier();
+
+    if (dir == nullptr)
+        return nullptr;
+
+    const auto romfs = CreateRomFS(dir);
+
+    if (romfs == nullptr)
+        return nullptr;
+
+    LOG_INFO(Service_FS, "    - System archive generation successful!");
+    return romfs;
+}
+} // namespace FileSys::SystemArchive

--- a/src/core/file_sys/system_archive/system_archive.cpp
+++ b/src/core/file_sys/system_archive/system_archive.cpp
@@ -21,7 +21,7 @@ struct SystemArchiveDescriptor {
     SystemArchiveSupplier supplier;
 };
 
-const static std::array<SystemArchiveDescriptor, SYSTEM_ARCHIVE_COUNT> SYSTEM_ARCHIVES = {{
+const std::array<SystemArchiveDescriptor, SYSTEM_ARCHIVE_COUNT> SYSTEM_ARCHIVES = {{
     {0x0100000000000800, "CertStore", nullptr},
     {0x0100000000000801, "ErrorMessage", nullptr},
     {0x0100000000000802, "MiiModel", nullptr},
@@ -50,7 +50,7 @@ const static std::array<SystemArchiveDescriptor, SYSTEM_ARCHIVE_COUNT> SYSTEM_AR
     {0x0100000000000819, "BootImagePackage", nullptr},
     {0x010000000000081A, "BootImagePackageSafe", nullptr},
     {0x010000000000081B, "BootImagePackageExFat", nullptr},
-    {0x010000000000081C, "BottImagePackageExFatSafe", nullptr},
+    {0x010000000000081C, "BootImagePackageExFatSafe", nullptr},
     {0x010000000000081D, "FatalMessage", nullptr},
     {0x010000000000081E, "ControllerIcon", nullptr},
     {0x010000000000081F, "PlatformConfigIcosa", nullptr},
@@ -64,11 +64,11 @@ const static std::array<SystemArchiveDescriptor, SYSTEM_ARCHIVE_COUNT> SYSTEM_AR
     {0x0100000000000827, "ContentActionTable", nullptr},
 }};
 
-VirtualFile SynthesizeSystemArchive(u64 title_id) {
+VirtualFile SynthesizeSystemArchive(const u64 title_id) {
     if (title_id < SYSTEM_ARCHIVES.front().title_id || title_id > SYSTEM_ARCHIVES.back().title_id)
         return nullptr;
 
-    const auto desc = SYSTEM_ARCHIVES[title_id - SYSTEM_ARCHIVE_BASE_TITLE_ID];
+    const auto& desc = SYSTEM_ARCHIVES[title_id - SYSTEM_ARCHIVE_BASE_TITLE_ID];
 
     LOG_INFO(Service_FS, "Synthesizing system archive '{}' (0x{:016X}).", desc.name, desc.title_id);
 

--- a/src/core/file_sys/system_archive/system_archive.h
+++ b/src/core/file_sys/system_archive/system_archive.h
@@ -1,0 +1,14 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common/common_types.h"
+#include "core/file_sys/vfs_types.h"
+
+namespace FileSys::SystemArchive {
+
+VirtualFile SynthesizeSystemArchive(u64 title_id);
+
+} // namespace FileSys::SystemArchive

--- a/src/core/file_sys/vfs_vector.cpp
+++ b/src/core/file_sys/vfs_vector.cpp
@@ -3,7 +3,6 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
-#include <cstring>
 #include <utility>
 #include "core/file_sys/vfs_vector.h"
 

--- a/src/core/file_sys/vfs_vector.h
+++ b/src/core/file_sys/vfs_vector.h
@@ -8,6 +8,58 @@
 
 namespace FileSys {
 
+// An implementation of VfsFile that is backed by a statically-sized array
+template <std::size_t size>
+class ArrayVfsFile : public VfsFile {
+public:
+    ArrayVfsFile(std::array<u8, size> data, std::string name = "", VirtualDir parent = nullptr)
+        : data(std::move(data)), name(std::move(name)), parent(std::move(parent)) {}
+
+    std::string GetName() const override {
+        return name;
+    }
+
+    std::size_t GetSize() const override {
+        return size;
+    }
+
+    bool Resize(std::size_t new_size) override {
+        return false;
+    }
+
+    std::shared_ptr<VfsDirectory> GetContainingDirectory() const override {
+        return parent;
+    }
+
+    bool IsWritable() const override {
+        return false;
+    }
+
+    bool IsReadable() const override {
+        return true;
+    }
+
+    std::size_t Read(u8* data_, std::size_t length, std::size_t offset) const override {
+        const auto read = std::min(length, size - offset);
+        std::memcpy(data_, data.data() + offset, read);
+        return read;
+    }
+
+    std::size_t Write(const u8* data, std::size_t length, std::size_t offset) override {
+        return 0;
+    }
+
+    bool Rename(std::string_view name) override {
+        this->name = name;
+        return true;
+    }
+
+private:
+    std::array<u8, size> data;
+    std::string name;
+    VirtualDir parent;
+};
+
 // An implementation of VfsFile that is backed by a vector optionally supplied upon construction
 class VectorVfsFile : public VfsFile {
 public:

--- a/src/core/file_sys/vfs_vector.h
+++ b/src/core/file_sys/vfs_vector.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstring>
 #include "core/file_sys/vfs.h"
 
 namespace FileSys {
@@ -13,7 +14,7 @@ template <std::size_t size>
 class ArrayVfsFile : public VfsFile {
 public:
     ArrayVfsFile(std::array<u8, size> data, std::string name = "", VirtualDir parent = nullptr)
-        : data(std::move(data)), name(std::move(name)), parent(std::move(parent)) {}
+        : data(data), name(std::move(name)), parent(std::move(parent)) {}
 
     std::string GetName() const override {
         return name;


### PR DESCRIPTION
This adds:
- A framework for synthesizing system archives and returning them to the game, using a table of functions similar to our HLE impl.
- A fallback to this framework if the user doesn't have the correct archive in NAND
- An implementation of NgWord (806) under this.

This works vastly different from citra's impl, which used externally generated romfses packed into cpp files. This stores the actual contents of the files within the archive (i.e. version.dat for NgWord) and then synthesizes the directory structure and romfs on the fly, resulting in cleaner more updatable code.

Tested in Ultra Street Fighter II, which performs exactly the same with or without it.