### PR TITLE
Include QT imageformat dependencies with releases

### DIFF
--- a/.travis/linux-mingw/docker.sh
+++ b/.travis/linux-mingw/docker.sh
@@ -57,3 +57,4 @@ done
 
 pip3 install pefile
 python3 .travis/linux-mingw/scan_dll.py package/*.exe "package/"
+python3 .travis/linux-mingw/scan_dll.py package/imageformats/*.dll "package/"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -125,17 +125,6 @@ after_build:
           Copy-Item -path "$CMAKE_SOURCE_DIR/license.txt" -destination $RELEASE_DIST
           Copy-Item -path "$CMAKE_SOURCE_DIR/README.md" -destination $RELEASE_DIST
 
-          # copy all the dll dependencies to the release folder
-          . "./.appveyor/UtilityFunctions.ps1"
-          $DLLSearchPath = "C:\msys64\mingw64\bin;$env:PATH"
-          $MingwDLLs = RecursivelyGetDeps $DLLSearchPath "$RELEASE_DIST\yuzu.exe"
-          $MingwDLLs += RecursivelyGetDeps $DLLSearchPath  "$RELEASE_DIST\yuzu_cmd.exe"
-          Write-Host "Detected the following dependencies:"
-          Write-Host $MingwDLLs
-          foreach ($file in $MingwDLLs) {
-            Copy-Item -path "$file" -force -destination "$RELEASE_DIST"
-          }
-
           # copy the qt windows plugin dll to platforms
           Copy-Item -path "C:/msys64/mingw64/share/qt5/plugins/platforms/qwindows.dll" -force -destination "$RELEASE_DIST/platforms"
 
@@ -144,6 +133,18 @@ after_build:
 
           # copy the qt jpeg imageformat dll to platforms
           Copy-Item -path "C:/msys64/mingw64/share/qt5/plugins/imageformats/qjpeg.dll" -force -destination "$RELEASE_DIST/imageformats"
+          
+          # copy all the dll dependencies to the release folder
+          . "./.appveyor/UtilityFunctions.ps1"
+          $DLLSearchPath = "C:\msys64\mingw64\bin;$env:PATH"
+          $MingwDLLs = RecursivelyGetDeps $DLLSearchPath "$RELEASE_DIST\yuzu.exe"
+          $MingwDLLs += RecursivelyGetDeps $DLLSearchPath  "$RELEASE_DIST\yuzu_cmd.exe"
+          $MingwDLLs += RecursivelyGetDeps $DLLSearchPath  "$RELEASE_DIST\imageformats\qjpeg.dll"
+          Write-Host "Detected the following dependencies:"
+          Write-Host $MingwDLLs
+          foreach ($file in $MingwDLLs) {
+            Copy-Item -path "$file" -force -destination "$RELEASE_DIST"
+          }
 
           7z a -tzip $MINGW_BUILD_ZIP $RELEASE_DIST\*
           7z a $MINGW_SEVENZIP $RELEASE_DIST

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -133,7 +133,7 @@ after_build:
 
           # copy the qt jpeg imageformat dll to platforms
           Copy-Item -path "C:/msys64/mingw64/share/qt5/plugins/imageformats/qjpeg.dll" -force -destination "$RELEASE_DIST/imageformats"
-          
+
           # copy all the dll dependencies to the release folder
           . "./.appveyor/UtilityFunctions.ps1"
           $DLLSearchPath = "C:\msys64\mingw64\bin;$env:PATH"


### PR DESCRIPTION
**Problem:**
Game icons do not show in mingw builds

**Cause:**
Missing libjpeg dll

**Solution:**
This PR (hopefully). I don't currently have a Linux environment set up to fully test this.