### PR TITLE
file_sys/errors: Clean up error code values

### DIFF
--- a/src/core/file_sys/errors.h
+++ b/src/core/file_sys/errors.h
@@ -11,9 +11,11 @@ namespace FileSys {
 namespace ErrCodes {
 enum {
     NotFound = 1,
-    TitleNotFound = 1002,
+    EntityNotFound = 1002,
     SdCardNotFound = 2001,
     RomFSNotFound = 2520,
+    InvalidOffset = 6061,
+    InvalidSize = 6062,
 };
 }
 
@@ -28,5 +30,10 @@ constexpr ResultCode ERROR_UNEXPECTED_FILE_OR_DIRECTORY(-1);
 constexpr ResultCode ERROR_DIRECTORY_ALREADY_EXISTS(-1);
 constexpr ResultCode ERROR_FILE_ALREADY_EXISTS(-1);
 constexpr ResultCode ERROR_DIRECTORY_NOT_EMPTY(-1);
+
+constexpr ResultCode ERROR_ENTITY_NOT_FOUND{ErrorModule::FS, ErrCodes::EntityNotFound};
+constexpr ResultCode ERROR_SD_CARD_NOT_FOUND{ErrorModule::FS, ErrCodes::SdCardNotFound};
+constexpr ResultCode ERROR_INVALID_OFFSET{ErrorModule::FS, ErrCodes::InvalidOffset};
+constexpr ResultCode ERROR_INVALID_SIZE{ErrorModule::FS, ErrCodes::InvalidSize};
 
 } // namespace FileSys

--- a/src/core/file_sys/errors.h
+++ b/src/core/file_sys/errors.h
@@ -8,16 +8,6 @@
 
 namespace FileSys {
 
-// TODO(bunnei): Replace these with correct errors for Switch OS
-constexpr ResultCode ERROR_INVALID_PATH(-1);
-constexpr ResultCode ERROR_UNSUPPORTED_OPEN_FLAGS(-1);
-constexpr ResultCode ERROR_INVALID_OPEN_FLAGS(-1);
-constexpr ResultCode ERROR_FILE_NOT_FOUND(-1);
-constexpr ResultCode ERROR_UNEXPECTED_FILE_OR_DIRECTORY(-1);
-constexpr ResultCode ERROR_DIRECTORY_ALREADY_EXISTS(-1);
-constexpr ResultCode ERROR_FILE_ALREADY_EXISTS(-1);
-constexpr ResultCode ERROR_DIRECTORY_NOT_EMPTY(-1);
-
 constexpr ResultCode ERROR_PATH_NOT_FOUND{ErrorModule::FS, 1};
 constexpr ResultCode ERROR_ENTITY_NOT_FOUND{ErrorModule::FS, 1002};
 constexpr ResultCode ERROR_SD_CARD_NOT_FOUND{ErrorModule::FS, 2001};

--- a/src/core/file_sys/errors.h
+++ b/src/core/file_sys/errors.h
@@ -8,19 +8,6 @@
 
 namespace FileSys {
 
-namespace ErrCodes {
-enum {
-    NotFound = 1,
-    EntityNotFound = 1002,
-    SdCardNotFound = 2001,
-    RomFSNotFound = 2520,
-    InvalidOffset = 6061,
-    InvalidSize = 6062,
-};
-}
-
-constexpr ResultCode ERROR_PATH_NOT_FOUND(ErrorModule::FS, ErrCodes::NotFound);
-
 // TODO(bunnei): Replace these with correct errors for Switch OS
 constexpr ResultCode ERROR_INVALID_PATH(-1);
 constexpr ResultCode ERROR_UNSUPPORTED_OPEN_FLAGS(-1);
@@ -31,9 +18,10 @@ constexpr ResultCode ERROR_DIRECTORY_ALREADY_EXISTS(-1);
 constexpr ResultCode ERROR_FILE_ALREADY_EXISTS(-1);
 constexpr ResultCode ERROR_DIRECTORY_NOT_EMPTY(-1);
 
-constexpr ResultCode ERROR_ENTITY_NOT_FOUND{ErrorModule::FS, ErrCodes::EntityNotFound};
-constexpr ResultCode ERROR_SD_CARD_NOT_FOUND{ErrorModule::FS, ErrCodes::SdCardNotFound};
-constexpr ResultCode ERROR_INVALID_OFFSET{ErrorModule::FS, ErrCodes::InvalidOffset};
-constexpr ResultCode ERROR_INVALID_SIZE{ErrorModule::FS, ErrCodes::InvalidSize};
+constexpr ResultCode ERROR_PATH_NOT_FOUND{ErrorModule::FS, 1};
+constexpr ResultCode ERROR_ENTITY_NOT_FOUND{ErrorModule::FS, 1002};
+constexpr ResultCode ERROR_SD_CARD_NOT_FOUND{ErrorModule::FS, 2001};
+constexpr ResultCode ERROR_INVALID_OFFSET{ErrorModule::FS, 6061};
+constexpr ResultCode ERROR_INVALID_SIZE{ErrorModule::FS, 6062};
 
 } // namespace FileSys

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -19,8 +19,6 @@
 enum class ErrorDescription : u32 {
     Success = 0,
     RemoteProcessDead = 301,
-    InvalidOffset = 6061,
-    InvalidLength = 6062,
 };
 
 /**

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -303,7 +303,7 @@ ResultVal<FileSys::VirtualDir> OpenSaveData(FileSys::SaveDataSpaceId space,
               static_cast<u8>(space), save_struct.DebugInfo());
 
     if (save_data_factory == nullptr) {
-        return ResultCode(ErrorModule::FS, FileSys::ErrCodes::TitleNotFound);
+        return FileSys::ERROR_ENTITY_NOT_FOUND;
     }
 
     return save_data_factory->Open(space, save_struct);
@@ -313,7 +313,7 @@ ResultVal<FileSys::VirtualDir> OpenSaveDataSpace(FileSys::SaveDataSpaceId space)
     LOG_TRACE(Service_FS, "Opening Save Data Space for space_id={:01X}", static_cast<u8>(space));
 
     if (save_data_factory == nullptr) {
-        return ResultCode(ErrorModule::FS, FileSys::ErrCodes::TitleNotFound);
+        return FileSys::ERROR_ENTITY_NOT_FOUND;
     }
 
     return MakeResult(save_data_factory->GetSaveDataSpaceDirectory(space));
@@ -323,7 +323,7 @@ ResultVal<FileSys::VirtualDir> OpenSDMC() {
     LOG_TRACE(Service_FS, "Opening SDMC");
 
     if (sdmc_factory == nullptr) {
-        return ResultCode(ErrorModule::FS, FileSys::ErrCodes::SdCardNotFound);
+        return FileSys::ERROR_SD_CARD_NOT_FOUND;
     }
 
     return sdmc_factory->Open();

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -63,12 +63,12 @@ private:
         // Error checking
         if (length < 0) {
             IPC::ResponseBuilder rb{ctx, 2};
-            rb.Push(ResultCode(ErrorModule::FS, ErrorDescription::InvalidLength));
+            rb.Push(FileSys::ERROR_INVALID_SIZE);
             return;
         }
         if (offset < 0) {
             IPC::ResponseBuilder rb{ctx, 2};
-            rb.Push(ResultCode(ErrorModule::FS, ErrorDescription::InvalidOffset));
+            rb.Push(FileSys::ERROR_INVALID_OFFSET);
             return;
         }
 
@@ -108,12 +108,12 @@ private:
         // Error checking
         if (length < 0) {
             IPC::ResponseBuilder rb{ctx, 2};
-            rb.Push(ResultCode(ErrorModule::FS, ErrorDescription::InvalidLength));
+            rb.Push(FileSys::ERROR_INVALID_SIZE);
             return;
         }
         if (offset < 0) {
             IPC::ResponseBuilder rb{ctx, 2};
-            rb.Push(ResultCode(ErrorModule::FS, ErrorDescription::InvalidOffset));
+            rb.Push(FileSys::ERROR_INVALID_OFFSET);
             return;
         }
 
@@ -139,12 +139,12 @@ private:
         // Error checking
         if (length < 0) {
             IPC::ResponseBuilder rb{ctx, 2};
-            rb.Push(ResultCode(ErrorModule::FS, ErrorDescription::InvalidLength));
+            rb.Push(FileSys::ERROR_INVALID_SIZE);
             return;
         }
         if (offset < 0) {
             IPC::ResponseBuilder rb{ctx, 2};
-            rb.Push(ResultCode(ErrorModule::FS, ErrorDescription::InvalidOffset));
+            rb.Push(FileSys::ERROR_INVALID_OFFSET);
             return;
         }
 
@@ -744,7 +744,7 @@ void FSP_SRV::MountSaveData(Kernel::HLERequestContext& ctx) {
 
     if (dir.Failed()) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 0};
-        rb.Push(ResultCode(ErrorModule::FS, FileSys::ErrCodes::TitleNotFound));
+        rb.Push(FileSys::ERROR_ENTITY_NOT_FOUND);
         return;
     }
 
@@ -836,7 +836,7 @@ void FSP_SRV::OpenRomStorage(Kernel::HLERequestContext& ctx) {
               static_cast<u8>(storage_id), title_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
-    rb.Push(ResultCode(ErrorModule::FS, FileSys::ErrCodes::TitleNotFound));
+    rb.Push(FileSys::ERROR_ENTITY_NOT_FOUND);
 }
 
 } // namespace Service::FileSystem


### PR DESCRIPTION
Makes the error code definitions more succinct that they previously were. We also only keep around the error code values that we actually make use of. While we're at it, we can also move the two random straggling error codes out of result.h and into file_sys/errors with the rest of the filesystem error codes.