### PR TITLE
Report resolution scaling support for vi and am

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -471,11 +471,15 @@ void ICommonStateGetter::GetDefaultDisplayResolution(Kernel::HLERequestContext& 
     rb.Push(RESULT_SUCCESS);
 
     if (Settings::values.use_docked_mode) {
-        rb.Push(static_cast<u32>(Service::VI::DisplayResolution::DockedWidth));
-        rb.Push(static_cast<u32>(Service::VI::DisplayResolution::DockedHeight));
+        rb.Push(static_cast<u32>(Service::VI::DisplayResolution::DockedWidth) *
+                static_cast<u32>(Settings::values.resolution_factor));
+        rb.Push(static_cast<u32>(Service::VI::DisplayResolution::DockedHeight) *
+                static_cast<u32>(Settings::values.resolution_factor));
     } else {
-        rb.Push(static_cast<u32>(Service::VI::DisplayResolution::UndockedWidth));
-        rb.Push(static_cast<u32>(Service::VI::DisplayResolution::UndockedHeight));
+        rb.Push(static_cast<u32>(Service::VI::DisplayResolution::UndockedWidth) *
+                static_cast<u32>(Settings::values.resolution_factor));
+        rb.Push(static_cast<u32>(Service::VI::DisplayResolution::UndockedHeight) *
+                static_cast<u32>(Settings::values.resolution_factor));
     }
 
     LOG_DEBUG(Service_AM, "called");

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -494,7 +494,9 @@ private:
 
         if (transaction == TransactionId::Connect) {
             IGBPConnectRequestParcel request{ctx.ReadBuffer()};
-            IGBPConnectResponseParcel response{1280, 720};
+            IGBPConnectResponseParcel response{
+                static_cast<u32>(1280 * Settings::values.resolution_factor),
+                static_cast<u32>(720 * Settings::values.resolution_factor)};
             ctx.WriteBuffer(response.Serialize());
         } else if (transaction == TransactionId::SetPreallocatedBuffer) {
             IGBPSetPreallocatedBufferRequestParcel request{ctx.ReadBuffer()};
@@ -670,11 +672,15 @@ private:
         rb.Push(RESULT_SUCCESS);
 
         if (Settings::values.use_docked_mode) {
-            rb.Push(static_cast<u32>(Service::VI::DisplayResolution::DockedWidth));
-            rb.Push(static_cast<u32>(Service::VI::DisplayResolution::DockedHeight));
+            rb.Push(static_cast<u32>(Service::VI::DisplayResolution::DockedWidth) *
+                    static_cast<u32>(Settings::values.resolution_factor));
+            rb.Push(static_cast<u32>(Service::VI::DisplayResolution::DockedHeight) *
+                    static_cast<u32>(Settings::values.resolution_factor));
         } else {
-            rb.Push(static_cast<u32>(Service::VI::DisplayResolution::UndockedWidth));
-            rb.Push(static_cast<u32>(Service::VI::DisplayResolution::UndockedHeight));
+            rb.Push(static_cast<u32>(Service::VI::DisplayResolution::UndockedWidth) *
+                    static_cast<u32>(Settings::values.resolution_factor));
+            rb.Push(static_cast<u32>(Service::VI::DisplayResolution::UndockedHeight) *
+                    static_cast<u32>(Settings::values.resolution_factor));
         }
 
         rb.PushRaw<float>(60.0f);
@@ -879,11 +885,15 @@ private:
         rb.Push(RESULT_SUCCESS);
 
         if (Settings::values.use_docked_mode) {
-            rb.Push(static_cast<u64>(DisplayResolution::DockedWidth));
-            rb.Push(static_cast<u64>(DisplayResolution::DockedHeight));
+            rb.Push(static_cast<u64>(DisplayResolution::DockedWidth) *
+                    static_cast<u32>(Settings::values.resolution_factor));
+            rb.Push(static_cast<u64>(DisplayResolution::DockedHeight) *
+                    static_cast<u32>(Settings::values.resolution_factor));
         } else {
-            rb.Push(static_cast<u64>(DisplayResolution::UndockedWidth));
-            rb.Push(static_cast<u64>(DisplayResolution::UndockedHeight));
+            rb.Push(static_cast<u64>(DisplayResolution::UndockedWidth) *
+                    static_cast<u32>(Settings::values.resolution_factor));
+            rb.Push(static_cast<u64>(DisplayResolution::UndockedHeight) *
+                    static_cast<u32>(Settings::values.resolution_factor));
         }
     }
 
@@ -900,6 +910,8 @@ private:
     void ListDisplays(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
         DisplayInfo display_info;
+        display_info.width *= static_cast<u64>(Settings::values.resolution_factor);
+        display_info.height *= static_cast<u64>(Settings::values.resolution_factor);
         ctx.WriteBuffer(&display_info, sizeof(DisplayInfo));
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -495,8 +495,10 @@ private:
         if (transaction == TransactionId::Connect) {
             IGBPConnectRequestParcel request{ctx.ReadBuffer()};
             IGBPConnectResponseParcel response{
-                static_cast<u32>(1280 * Settings::values.resolution_factor),
-                static_cast<u32>(720 * Settings::values.resolution_factor)};
+                static_cast<u32>(static_cast<u32>(DisplayResolution::UndockedWidth) *
+                                 Settings::values.resolution_factor),
+                static_cast<u32>(static_cast<u32>(DisplayResolution::UndockedHeight) *
+                                 Settings::values.resolution_factor)};
             ctx.WriteBuffer(response.Serialize());
         } else if (transaction == TransactionId::SetPreallocatedBuffer) {
             IGBPSetPreallocatedBufferRequestParcel request{ctx.ReadBuffer()};

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -23,31 +23,31 @@
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <item>
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <item>
-              <widget class="QCheckBox" name="toggle_frame_limit">
-                <property name="text">
-                  <string>Limit Speed Percent</string>
-                </property>
-              </widget>
-            </item>
-            <item>
-              <widget class="QSpinBox" name="frame_limit">
-                <property name="suffix">
-                  <string>%</string>
-                </property>
-                <property name="minimum">
-                  <number>1</number>
-                </property>
-                <property name="maximum">
-                  <number>9999</number>
-                </property>
-                <property name="value">
-                  <number>100</number>
-                </property>
-              </widget>
-            </item>
-          </layout>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QCheckBox" name="toggle_frame_limit">
+            <property name="text">
+             <string>Limit Speed Percent</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="frame_limit">
+            <property name="suffix">
+             <string>%</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>9999</number>
+            </property>
+            <property name="value">
+             <number>100</number>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
         <item>
          <widget class="QCheckBox" name="use_accurate_gpu_emulation">
@@ -61,7 +61,7 @@
           <item>
            <widget class="QLabel" name="label">
             <property name="text">
-             <string>Internal Resolution:(Currently does nothing.)</string>
+             <string>Internal Resolution</string>
             </property>
            </widget>
           </item>
@@ -96,27 +96,27 @@
           </item>
          </layout>
         </item>
-         <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_6">
-             <item>
-               <widget class="QLabel" name="bg_label">
-                 <property name="text">
-                   <string>Background Color:</string>
-                 </property>
-               </widget>
-             </item>
-             <item>
-               <widget class="QPushButton" name="bg_button">
-                 <property name="maximumSize">
-                   <size>
-                     <width>40</width>
-                     <height>16777215</height>
-                   </size>
-                 </property>
-               </widget>
-             </item>
-           </layout>
-         </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <widget class="QLabel" name="bg_label">
+            <property name="text">
+             <string>Background Color:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="bg_button">
+            <property name="maximumSize">
+             <size>
+              <width>40</width>
+              <height>16777215</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
        </layout>
       </widget>
      </item>


### PR DESCRIPTION
Specifying an internal resolution in yuzu now will report the scaled changes to vi and am.