### PR TITLE
hwopus: DecodeInterleavedWithPerformance: Fix ordering of output parameters.

### DIFF
--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -77,8 +77,8 @@ private:
         IPC::ResponseBuilder rb{ctx, 6};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u32>(consumed);
-        rb.Push<u64>(performance);
         rb.Push<u32>(sample_count);
+        rb.Push<u64>(performance);
         ctx.WriteBuffer(samples.data(), samples.size() * sizeof(s16));
     }
 


### PR DESCRIPTION
hwopus: DecodeInterleavedWithPerformance: Fix ordering of output parameters.
- Fixes audio in Pokemon: Let's Go Pikachu and Let's Go Eevee.

Thank you to @gdkchan for spotting the issue here.

Fixes #1715.