### PR TITLE
Correctly sets default system language for yuzu-CLI

### DIFF
--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -138,6 +138,8 @@ void Config::ReadValues() {
     } else {
         Settings::values.rng_seed = std::nullopt;
     }
+    
+    Settings::values.language_index = sdl2_config->GetInteger("System", "language_index", 1);
 
     // Miscellaneous
     Settings::values.log_filter = sdl2_config->Get("Miscellaneous", "log_filter", "*:Trace");


### PR DESCRIPTION
A user reported that yuzu_cmd runs games in Japanese rather than the correct default of English (like yuzu-qt does correctly), this change fixes that.