### PR TITLE
gl_rasterizer: Remove default clip distance

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -107,8 +107,6 @@ RasterizerOpenGL::RasterizerOpenGL(Core::Frontend::EmuWindow& window, ScreenInfo
 
     ASSERT_MSG(has_ARB_separate_shader_objects, "has_ARB_separate_shader_objects is unsupported");
     OpenGLState::ApplyDefaultState();
-    // Clipping plane 0 is always enabled for PICA fixed clip plane z <= 0
-    state.clip_distance[0] = true;
 
     // Create render framebuffer
     framebuffer.Create();


### PR DESCRIPTION
Remove an expression carried from Citra. While we have to implement clip distances at some point, having it enabled when it's never set explicitly is wrong.

Fixes a half-black screen issue on Windows' Intel driver.