### PR TITLE
filesystem: Clear registered union paths on factory creation

### DIFF
--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -341,6 +341,10 @@ std::shared_ptr<FileSys::RegisteredCacheUnion> GetUnionContents() {
     return registered_cache_union;
 }
 
+void ClearUnionContents() {
+    registered_cache_union = nullptr;
+}
+
 FileSys::RegisteredCache* GetSystemNANDContents() {
     LOG_TRACE(Service_FS, "Opening System NAND Contents");
 
@@ -391,6 +395,7 @@ void CreateFactories(FileSys::VfsFilesystem& vfs, bool overwrite) {
         bis_factory = nullptr;
         save_data_factory = nullptr;
         sdmc_factory = nullptr;
+        ClearUnionContents();
     }
 
     auto nand_directory = vfs.OpenDirectory(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir),

--- a/src/core/hle/service/filesystem/filesystem.h
+++ b/src/core/hle/service/filesystem/filesystem.h
@@ -49,6 +49,7 @@ ResultVal<FileSys::VirtualDir> OpenSaveDataSpace(FileSys::SaveDataSpaceId space)
 ResultVal<FileSys::VirtualDir> OpenSDMC();
 
 std::shared_ptr<FileSys::RegisteredCacheUnion> GetUnionContents();
+void ClearUnionContents();
 
 FileSys::RegisteredCache* GetSystemNANDContents();
 FileSys::RegisteredCache* GetUserNANDContents();


### PR DESCRIPTION
Avoids a crash when the user tries to change the NAND or SDMC directory.
Thanks to @MysticExile for finding this.