### PR TITLE
kernel/shared_memory: Make data members private, plus minor interface changes

### DIFF
--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -136,4 +136,8 @@ u8* SharedMemory::GetPointer(std::size_t offset) {
     return backing_block->data() + backing_block_offset + offset;
 }
 
+const u8* SharedMemory::GetPointer(std::size_t offset) const {
+    return backing_block->data() + backing_block_offset + offset;
+}
+
 } // namespace Kernel

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -61,7 +61,7 @@ SharedPtr<SharedMemory> SharedMemory::Create(KernelCore& kernel, SharedPtr<Proce
 }
 
 SharedPtr<SharedMemory> SharedMemory::CreateForApplet(
-    KernelCore& kernel, std::shared_ptr<std::vector<u8>> heap_block, u32 offset, u32 size,
+    KernelCore& kernel, std::shared_ptr<std::vector<u8>> heap_block, std::size_t offset, u64 size,
     MemoryPermission permissions, MemoryPermission other_permissions, std::string name) {
     SharedPtr<SharedMemory> shared_memory(new SharedMemory(kernel));
 

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -132,7 +132,7 @@ VMAPermission SharedMemory::ConvertPermissions(MemoryPermission permission) {
     return static_cast<VMAPermission>(masked_permissions);
 }
 
-u8* SharedMemory::GetPointer(u32 offset) {
+u8* SharedMemory::GetPointer(std::size_t offset) {
     return backing_block->data() + backing_block_offset + offset;
 }
 

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -81,6 +81,11 @@ public:
         return HANDLE_TYPE;
     }
 
+    /// Gets the size of the underlying memory block in bytes.
+    u64 GetSize() const {
+        return size;
+    }
+
     /**
      * Converts the specified MemoryPermission into the equivalent VMAPermission.
      * @param permission The MemoryPermission to convert.
@@ -112,26 +117,26 @@ public:
      */
     u8* GetPointer(u32 offset = 0);
 
-    /// Process that created this shared memory block.
-    SharedPtr<Process> owner_process;
-    /// Address of shared memory block in the owner process if specified.
-    VAddr base_address;
-    /// Backing memory for this shared memory block.
-    std::shared_ptr<std::vector<u8>> backing_block;
-    /// Offset into the backing block for this shared memory.
-    std::size_t backing_block_offset;
-    /// Size of the memory block. Page-aligned.
-    u64 size;
-    /// Permission restrictions applied to the process which created the block.
-    MemoryPermission permissions;
-    /// Permission restrictions applied to other processes mapping the block.
-    MemoryPermission other_permissions;
-    /// Name of shared memory object.
-    std::string name;
-
 private:
     explicit SharedMemory(KernelCore& kernel);
     ~SharedMemory() override;
+
+    /// Backing memory for this shared memory block.
+    std::shared_ptr<std::vector<u8>> backing_block;
+    /// Offset into the backing block for this shared memory.
+    std::size_t backing_block_offset = 0;
+    /// Size of the memory block. Page-aligned.
+    u64 size = 0;
+    /// Permission restrictions applied to the process which created the block.
+    MemoryPermission permissions{};
+    /// Permission restrictions applied to other processes mapping the block.
+    MemoryPermission other_permissions{};
+    /// Process that created this shared memory block.
+    SharedPtr<Process> owner_process;
+    /// Address of shared memory block in the owner process if specified.
+    VAddr base_address = 0;
+    /// Name of shared memory object.
+    std::string name;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -64,7 +64,7 @@ public:
      */
     static SharedPtr<SharedMemory> CreateForApplet(KernelCore& kernel,
                                                    std::shared_ptr<std::vector<u8>> heap_block,
-                                                   u32 offset, u32 size,
+                                                   std::size_t offset, u64 size,
                                                    MemoryPermission permissions,
                                                    MemoryPermission other_permissions,
                                                    std::string name = "Unknown Applet");

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -113,9 +113,16 @@ public:
     /**
      * Gets a pointer to the shared memory block
      * @param offset Offset from the start of the shared memory block to get pointer
-     * @return Pointer to the shared memory block from the specified offset
+     * @return A pointer to the shared memory block from the specified offset
      */
     u8* GetPointer(std::size_t offset = 0);
+
+    /**
+     * Gets a constant pointer to the shared memory block
+     * @param offset Offset from the start of the shared memory block to get pointer
+     * @return A constant pointer to the shared memory block from the specified offset
+     */
+    const u8* GetPointer(std::size_t offset = 0) const;
 
 private:
     explicit SharedMemory(KernelCore& kernel);

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -99,16 +99,16 @@ public:
      * @param permissions Memory block map permissions (specified by SVC field)
      * @param other_permissions Memory block map other permissions (specified by SVC field)
      */
-    ResultCode Map(Process* target_process, VAddr address, MemoryPermission permissions,
+    ResultCode Map(Process& target_process, VAddr address, MemoryPermission permissions,
                    MemoryPermission other_permissions);
 
     /**
      * Unmaps a shared memory block from the specified address in system memory
-     * @param target_process Process from which to umap the memory block.
+     * @param target_process Process from which to unmap the memory block.
      * @param address Address in system memory where the shared memory block is mapped
      * @return Result code of the unmap operation
      */
-    ResultCode Unmap(Process* target_process, VAddr address);
+    ResultCode Unmap(Process& target_process, VAddr address);
 
     /**
      * Gets a pointer to the shared memory block

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -115,7 +115,7 @@ public:
      * @param offset Offset from the start of the shared memory block to get pointer
      * @return Pointer to the shared memory block from the specified offset
      */
-    u8* GetPointer(u32 offset = 0);
+    u8* GetPointer(std::size_t offset = 0);
 
 private:
     explicit SharedMemory(KernelCore& kernel);

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -796,7 +796,7 @@ static ResultCode MapSharedMemory(Handle shared_memory_handle, VAddr addr, u64 s
         return ERR_INVALID_MEMORY_RANGE;
     }
 
-    return shared_memory->Map(current_process, addr, permissions_type, MemoryPermission::DontCare);
+    return shared_memory->Map(*current_process, addr, permissions_type, MemoryPermission::DontCare);
 }
 
 static ResultCode UnmapSharedMemory(Handle shared_memory_handle, VAddr addr, u64 size) {
@@ -826,7 +826,7 @@ static ResultCode UnmapSharedMemory(Handle shared_memory_handle, VAddr addr, u64
         return ERR_INVALID_MEMORY_RANGE;
     }
 
-    return shared_memory->Unmap(current_process, addr);
+    return shared_memory->Unmap(*current_process, addr);
 }
 
 /// Query process memory


### PR DESCRIPTION
Makes it nicer to reason about the internals of the shared memory instances, by exposing only what is necessary to non-kernel code. In particular, we don't need to directly expose any of the memory-specific data members. Each commit contains rationale to clarify themselves