### PR TITLE
lm: Implement SetDestination by doing nothing

### DIFF
--- a/src/core/hle/service/lm/lm.cpp
+++ b/src/core/hle/service/lm/lm.cpp
@@ -18,7 +18,7 @@ public:
     ILogger() : ServiceFramework("ILogger") {
         static const FunctionInfo functions[] = {
             {0x00000000, &ILogger::Initialize, "Initialize"},
-            {0x00000001, nullptr, "SetDestination"},
+            {0x00000001, &ILogger::SetDestination, "SetDestination"},
         };
         RegisterHandlers(functions);
     }
@@ -176,6 +176,17 @@ private:
                 break;
             }
         }
+    }
+
+    // This service function is intended to be used as a way to
+    // redirect logging output to different destinations, however,
+    // given we always want to see the logging output, it's sufficient
+    // to do nothing and return success here.
+    void SetDestination(Kernel::HLERequestContext& ctx) {
+        LOG_DEBUG(Service_LM, "called");
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
     }
 
     std::ostringstream log_stream;


### PR DESCRIPTION
This service function was likely intended to be a way to redirect where the output of a log went. e.g. Firing a log over a network, dumping over a tunneling session, etc, rather than kicking it to the default output.

Given we always want to see the log and not change its output destination. It's one of the lucky service functions where the easiest implementation is to just do nothing at all and return success.