### PR TITLE
am/applets: Minor cleanup

### DIFF
--- a/src/core/hle/service/am/applets/applets.cpp
+++ b/src/core/hle/service/am/applets/applets.cpp
@@ -98,10 +98,8 @@ Applet::Applet() = default;
 
 Applet::~Applet() = default;
 
-void Applet::Initialize(std::shared_ptr<AppletDataBroker> broker_) {
-    broker = std::move(broker_);
-
-    const auto common = broker->PopNormalDataToApplet();
+void Applet::Initialize() {
+    const auto common = broker.PopNormalDataToApplet();
     ASSERT(common != nullptr);
 
     const auto common_data = common->GetData();

--- a/src/core/hle/service/am/applets/applets.h
+++ b/src/core/hle/service/am/applets/applets.h
@@ -4,13 +4,15 @@
 
 #pragma once
 
-#include <functional>
 #include <memory>
 #include <queue>
 #include "common/swap.h"
-#include "core/hle/kernel/event.h"
 
 union ResultCode;
+
+namespace Kernel {
+class Event;
+}
 
 namespace Service::AM {
 

--- a/src/core/hle/service/am/applets/applets.h
+++ b/src/core/hle/service/am/applets/applets.h
@@ -43,19 +43,26 @@ public:
 
 private:
     // Queues are named from applet's perspective
-    std::queue<std::unique_ptr<IStorage>>
-        in_channel; // PopNormalDataToApplet and PushNormalDataFromGame
-    std::queue<std::unique_ptr<IStorage>>
-        out_channel; // PopNormalDataToGame and PushNormalDataFromApplet
-    std::queue<std::unique_ptr<IStorage>>
-        in_interactive_channel; // PopInteractiveDataToApplet and PushInteractiveDataFromGame
-    std::queue<std::unique_ptr<IStorage>>
-        out_interactive_channel; // PopInteractiveDataToGame and PushInteractiveDataFromApplet
+
+    // PopNormalDataToApplet and PushNormalDataFromGame
+    std::queue<std::unique_ptr<IStorage>> in_channel;
+
+    // PopNormalDataToGame and PushNormalDataFromApplet
+    std::queue<std::unique_ptr<IStorage>> out_channel;
+
+    // PopInteractiveDataToApplet and PushInteractiveDataFromGame
+    std::queue<std::unique_ptr<IStorage>> in_interactive_channel;
+
+    // PopInteractiveDataToGame and PushInteractiveDataFromApplet
+    std::queue<std::unique_ptr<IStorage>> out_interactive_channel;
 
     Kernel::SharedPtr<Kernel::Event> state_changed_event;
-    Kernel::SharedPtr<Kernel::Event> pop_out_data_event; // Signaled on PushNormalDataFromApplet
-    Kernel::SharedPtr<Kernel::Event>
-        pop_interactive_out_data_event; // Signaled on PushInteractiveDataFromApplet
+
+    // Signaled on PushNormalDataFromApplet
+    Kernel::SharedPtr<Kernel::Event> pop_out_data_event;
+
+    // Signaled on PushInteractiveDataFromApplet
+    Kernel::SharedPtr<Kernel::Event> pop_interactive_out_data_event;
 };
 
 class Applet {

--- a/src/core/hle/service/am/applets/applets.h
+++ b/src/core/hle/service/am/applets/applets.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <queue>
 #include "common/swap.h"
+#include "core/hle/kernel/kernel.h"
 
 union ResultCode;
 
@@ -72,7 +73,7 @@ public:
     Applet();
     virtual ~Applet();
 
-    virtual void Initialize(std::shared_ptr<AppletDataBroker> broker);
+    virtual void Initialize();
 
     virtual bool TransactionComplete() const = 0;
     virtual ResultCode GetStatus() const = 0;
@@ -81,6 +82,14 @@ public:
 
     bool IsInitialized() const {
         return initialized;
+    }
+
+    AppletDataBroker& GetBroker() {
+        return broker;
+    }
+
+    const AppletDataBroker& GetBroker() const {
+        return broker;
     }
 
 protected:
@@ -94,8 +103,8 @@ protected:
     };
     static_assert(sizeof(CommonArguments) == 0x20, "CommonArguments has incorrect size.");
 
-    CommonArguments common_args;
-    std::shared_ptr<AppletDataBroker> broker;
+    CommonArguments common_args{};
+    AppletDataBroker broker;
     bool initialized = false;
 };
 

--- a/src/core/hle/service/am/applets/software_keyboard.h
+++ b/src/core/hle/service/am/applets/software_keyboard.h
@@ -55,7 +55,7 @@ public:
     SoftwareKeyboard();
     ~SoftwareKeyboard() override;
 
-    void Initialize(std::shared_ptr<AppletDataBroker> broker) override;
+    void Initialize() override;
 
     bool TransactionComplete() const override;
     ResultCode GetStatus() const override;

--- a/src/core/hle/service/am/applets/software_keyboard.h
+++ b/src/core/hle/service/am/applets/software_keyboard.h
@@ -4,7 +4,12 @@
 
 #pragma once
 
+#include <array>
+#include <string>
+#include <vector>
+
 #include "common/common_funcs.h"
+#include "common/swap.h"
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/am/applets/applets.h"
 


### PR DESCRIPTION
Mostly just cleans up the comment locations to get rid of wonky wrapping, making it nicer to read vertically. It also cleans up the inclusions and moves the broker instance itself into the Applet instance.