### PR TITLE
patch_manager: Add support for applying LayeredFS patches to ExeFS

### DIFF
--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -57,6 +57,15 @@ VirtualDir PatchManager::PatchExeFS(VirtualDir exefs) const {
     if (exefs == nullptr)
         return exefs;
 
+    if (Settings::values.dump_exefs) {
+        LOG_INFO(Loader, "Dumping ExeFS for title_id={:016X}", title_id);
+        const auto dump_dir = Service::FileSystem::GetModificationDumpRoot(title_id);
+        if (dump_dir != nullptr) {
+            const auto exefs_dir = GetOrCreateDirectoryRelative(dump_dir, "/exefs");
+            VfsRawCopyD(exefs, exefs_dir);
+        }
+    }
+
     const auto installed = Service::FileSystem::GetUnionContents();
 
     // Game Updates

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -159,6 +159,7 @@ struct Values {
     bool use_gdbstub;
     u16 gdbstub_port;
     std::string program_args;
+    bool dump_exefs;
     bool dump_nso;
 
     // WebService

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -153,6 +153,7 @@ void Config::ReadValues() {
     Settings::values.use_gdbstub = qt_config->value("use_gdbstub", false).toBool();
     Settings::values.gdbstub_port = qt_config->value("gdbstub_port", 24689).toInt();
     Settings::values.program_args = qt_config->value("program_args", "").toString().toStdString();
+    Settings::values.dump_exefs = qt_config->value("dump_exefs", false).toBool();
     Settings::values.dump_nso = qt_config->value("dump_nso", false).toBool();
     qt_config->endGroup();
 
@@ -297,6 +298,7 @@ void Config::SaveValues() {
     qt_config->setValue("use_gdbstub", Settings::values.use_gdbstub);
     qt_config->setValue("gdbstub_port", Settings::values.gdbstub_port);
     qt_config->setValue("program_args", QString::fromStdString(Settings::values.program_args));
+    qt_config->setValue("dump_exefs", Settings::values.dump_exefs);
     qt_config->setValue("dump_nso", Settings::values.dump_nso);
     qt_config->endGroup();
 

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -34,6 +34,7 @@ void ConfigureDebug::setConfiguration() {
     ui->toggle_console->setChecked(UISettings::values.show_console);
     ui->log_filter_edit->setText(QString::fromStdString(Settings::values.log_filter));
     ui->homebrew_args_edit->setText(QString::fromStdString(Settings::values.program_args));
+    ui->dump_exefs->setChecked(Settings::values.dump_exefs);
     ui->dump_decompressed_nso->setChecked(Settings::values.dump_nso);
 }
 
@@ -43,6 +44,7 @@ void ConfigureDebug::applyConfiguration() {
     UISettings::values.show_console = ui->toggle_console->isChecked();
     Settings::values.log_filter = ui->log_filter_edit->text().toStdString();
     Settings::values.program_args = ui->homebrew_args_edit->text().toStdString();
+    Settings::values.dump_exefs = ui->dump_exefs->isChecked();
     Settings::values.dump_nso = ui->dump_decompressed_nso->isChecked();
     Debugger::ToggleConsole();
     Log::Filter filter;

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -145,6 +145,16 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="dump_exefs">
+        <property name="whatsThis">
+         <string>When checked, any game that yuzu loads will have its ExeFS dumped</string>
+        </property>
+        <property name="text">
+         <string>Dump ExeFS</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -148,7 +148,7 @@
       <item>
        <widget class="QCheckBox" name="dump_exefs">
         <property name="whatsThis">
-         <string>When checked, any game that yuzu loads will have its ExeFS dumped</string>
+         <string>When checked, any game that yuzu loads will have its ExeFS dumped to the yuzu/dump directory.</string>
         </property>
         <property name="text">
          <string>Dump ExeFS</string>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -148,6 +148,7 @@ void Config::ReadValues() {
     Settings::values.gdbstub_port =
         static_cast<u16>(sdl2_config->GetInteger("Debugging", "gdbstub_port", 24689));
     Settings::values.program_args = sdl2_config->Get("Debugging", "program_args", "");
+    Settings::values.dump_exefs = sdl2_config->GetBoolean("Debugging", "dump_exefs", false);
     Settings::values.dump_nso = sdl2_config->GetBoolean("Debugging", "dump_nso", false);
 
     // Web Service

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -206,6 +206,8 @@ log_filter = *:Trace
 # Port for listening to GDB connections.
 use_gdbstub=false
 gdbstub_port=24689
+# Determines whether or not yuzu will dump the ExeFS of all games it attempts to load while loading them
+dump_exefs=false
 # Determines whether or not yuzu will dump all NSOs it attempts to load while loading them
 dump_nso=false
 


### PR DESCRIPTION
As requested by someone in discord, this adds the ability to replace the compressed NSOs in the ExeFS.

The directory structure is:
- mod_dir/
    - exefs/
        - <ips/ipswitch patches also go here, but are ignored by lfs>
        - main

These patches will be listed as LayeredExeFS in the game list to avoid collision/confusion with normal RomFS-based LayeredFS. ex: 
![exefs1](https://user-images.githubusercontent.com/5064800/48808218-201dde00-ecee-11e8-8a57-addbf7abd86d.PNG)

Here is an example I did replacing the Puyo Puyo main NSO with a null file:
![exefs2](https://user-images.githubusercontent.com/5064800/48808238-2dd36380-ecee-11e8-880e-393d0cdfc1af.PNG)
(as expected; a null file is not a valid NSO)

Finally, to make modding easier, this adds a checkbox to the UI options to `Dump ExeFS`
![exefs3](https://user-images.githubusercontent.com/5064800/48808492-0761f800-ecef-11e8-8e15-fe9883925ff0.PNG)
When this box is checked, any game booted will have its ExeFS dumped to `yuzu/dump/<title id>/exefs`