### PR TITLE
common/assert: Make the UNIMPLEMENTED macro properly assert

### DIFF
--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -54,3 +54,6 @@ __declspec(noinline, noreturn)
 
 #define UNIMPLEMENTED() ASSERT_MSG(false, "Unimplemented code!")
 #define UNIMPLEMENTED_MSG(...) ASSERT_MSG(false, __VA_ARGS__)
+
+#define UNIMPLEMENTED_IF(cond) ASSERT_MSG(!(cond), "Unimplemented code!")
+#define UNIMPLEMENTED_IF_MSG(cond, ...) ASSERT_MSG(!(cond), __VA_ARGS__)

--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -52,5 +52,5 @@ __declspec(noinline, noreturn)
 #define DEBUG_ASSERT_MSG(_a_, _desc_, ...)
 #endif
 
-#define UNIMPLEMENTED() LOG_CRITICAL(Debug, "Unimplemented code!")
+#define UNIMPLEMENTED() ASSERT_MSG(false, "Unimplemented code!")
 #define UNIMPLEMENTED_MSG(...) ASSERT_MSG(false, __VA_ARGS__)


### PR DESCRIPTION
Previously it was only logging an error message which

1. Isn't what we only want it to do
2. Isn't what UNIMPLEMENTED_MSG does (it properly asserts).

This makes the behavior of the two macros uniform.

This also introduces two other macros that are likely more useful for the graphics and video code, UNIMPLEMENTED_IF and UNIMPLEMENTED_IF_MSG, which allows asserting on a conditional, like a regular assertion.

The rationale behind this is it allows a dev to disable unimplemented feature assertions (which can occur in an unrelated work area), while still enabling regular assertions, which act as behavior guards for conditions or states which must not occur. Previously, the only way a dev could temporarily disable asserts, was to disable the regular assertion macros, which has the downside of also disabling, well, the regular assertions which hold more sanitizing value, as opposed to unimplemented feature assertions.