### PR TITLE
kernel/handle_table: Minor changes

### DIFF
--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -12,6 +12,15 @@
 #include "core/hle/kernel/thread.h"
 
 namespace Kernel {
+namespace {
+constexpr u16 GetSlot(Handle handle) {
+    return handle >> 15;
+}
+
+constexpr u16 GetGeneration(Handle handle) {
+    return handle & 0x7FFF;
+}
+} // Anonymous namespace
 
 HandleTable::HandleTable() {
     next_generation = 1;

--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -18,6 +18,8 @@ HandleTable::HandleTable() {
     Clear();
 }
 
+HandleTable::~HandleTable() = default;
+
 ResultVal<Handle> HandleTable::Create(SharedPtr<Object> obj) {
     DEBUG_ASSERT(obj != nullptr);
 

--- a/src/core/hle/kernel/handle_table.h
+++ b/src/core/hle/kernel/handle_table.h
@@ -90,11 +90,8 @@ public:
     void Clear();
 
 private:
-    /**
-     * This is the maximum limit of handles allowed per process in CTR-OS. It can be further
-     * reduced by ExHeader values, but this is not emulated here.
-     */
-    static const std::size_t MAX_COUNT = 4096;
+    /// This is the maximum limit of handles allowed per process in Horizon
+    static constexpr std::size_t MAX_COUNT = 1024;
 
     static u16 GetSlot(Handle handle) {
         return handle >> 15;

--- a/src/core/hle/kernel/handle_table.h
+++ b/src/core/hle/kernel/handle_table.h
@@ -93,13 +93,6 @@ private:
     /// This is the maximum limit of handles allowed per process in Horizon
     static constexpr std::size_t MAX_COUNT = 1024;
 
-    static u16 GetSlot(Handle handle) {
-        return handle >> 15;
-    }
-    static u16 GetGeneration(Handle handle) {
-        return handle & 0x7FFF;
-    }
-
     /// Stores the Object referenced by the handle or null if the slot is empty.
     std::array<SharedPtr<Object>, MAX_COUNT> objects;
 

--- a/src/core/hle/kernel/handle_table.h
+++ b/src/core/hle/kernel/handle_table.h
@@ -43,6 +43,7 @@ enum KernelHandle : Handle {
 class HandleTable final : NonCopyable {
 public:
     HandleTable();
+    ~HandleTable();
 
     /**
      * Allocates a handle for the given object.


### PR DESCRIPTION
Minor individual changes. Mostly cleanup-related except for one commit. In particular, one makes the size of the handle table match the number of allowed entries to that of Horizon OS itself (1024 as opposed to 4096)