### PR TITLE
debug_pad: Avoid loading input for nonexistent buttons (Home and Screenshot)

### DIFF
--- a/src/core/hle/service/hid/controllers/debug_pad.cpp
+++ b/src/core/hle/service/hid/controllers/debug_pad.cpp
@@ -71,8 +71,9 @@ void Controller_DebugPad::OnUpdate(u8* data, std::size_t size) {
 
 void Controller_DebugPad::OnLoadInputDevices() {
     std::transform(Settings::values.debug_pad_buttons.begin(),
-                   Settings::values.debug_pad_buttons.end(), buttons.begin(),
-                   Input::CreateDevice<Input::ButtonDevice>);
+                   Settings::values.debug_pad_buttons.begin() +
+                       Settings::NativeButton::NUM_BUTTONS_HID,
+                   buttons.begin(), Input::CreateDevice<Input::ButtonDevice>);
     std::transform(Settings::values.debug_pad_analogs.begin(),
                    Settings::values.debug_pad_analogs.end(), analogs.begin(),
                    Input::CreateDevice<Input::AnalogDevice>);


### PR DESCRIPTION
Prevents memory exceptions when the debug pad is enabled.