### PR TITLE
configure_input: Add Controller Setup Profiles and simplify input UI

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -31,6 +31,8 @@ add_executable(yuzu
     configuration/configure_input.h
     configuration/configure_input_player.cpp
     configuration/configure_input_player.h
+    configuration/configure_input_simple.cpp
+    configuration/configure_input_simple.h
     configuration/configure_mouse_advanced.cpp
     configuration/configure_mouse_advanced.h
     configuration/configure_system.cpp
@@ -85,6 +87,7 @@ set(UIS
     configuration/configure_graphics.ui
     configuration/configure_input.ui
     configuration/configure_input_player.ui
+    configuration/configure_input_simple.ui
     configuration/configure_mouse_advanced.ui
     configuration/configure_system.ui
     configuration/configure_touchscreen_advanced.ui

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -4,6 +4,7 @@
 
 #include <QSettings>
 #include "common/file_util.h"
+#include "configure_input_simple.h"
 #include "core/hle/service/acc/profile_manager.h"
 #include "core/hle/service/hid/controllers/npad.h"
 #include "input_common/main.h"
@@ -342,6 +343,13 @@ void Config::ReadTouchscreenValues() {
     qt_config->endGroup();
 }
 
+void Config::ApplyDefaultProfileIfInputInvalid() {
+    if (!std::any_of(Settings::values.players.begin(), Settings::values.players.end(),
+                     [](const Settings::PlayerInput& in) { return in.connected; })) {
+        ApplyInputProfileConfiguration(UISettings::values.profile_index);
+    }
+}
+
 void Config::ReadValues() {
     qt_config->beginGroup("Controls");
 
@@ -507,6 +515,8 @@ void Config::ReadValues() {
     UISettings::values.callout_flags = qt_config->value("calloutFlags", 0).toUInt();
     UISettings::values.show_console = qt_config->value("showConsole", false).toBool();
     UISettings::values.profile_index = qt_config->value("profileIndex", 0).toUInt();
+
+    ApplyDefaultProfileIfInputInvalid();
 
     qt_config->endGroup();
 }

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -506,6 +506,7 @@ void Config::ReadValues() {
     UISettings::values.first_start = qt_config->value("firstStart", true).toBool();
     UISettings::values.callout_flags = qt_config->value("calloutFlags", 0).toUInt();
     UISettings::values.show_console = qt_config->value("showConsole", false).toBool();
+    UISettings::values.profile_index = qt_config->value("profileIndex", 0).toUInt();
 
     qt_config->endGroup();
 }
@@ -695,6 +696,7 @@ void Config::SaveValues() {
     qt_config->setValue("firstStart", UISettings::values.first_start);
     qt_config->setValue("calloutFlags", UISettings::values.callout_flags);
     qt_config->setValue("showConsole", UISettings::values.show_console);
+    qt_config->setValue("profileIndex", UISettings::values.profile_index);
     qt_config->endGroup();
 }
 

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -34,6 +34,7 @@ private:
     void ReadKeyboardValues();
     void ReadMouseValues();
     void ReadTouchscreenValues();
+    void ApplyDefaultProfileIfInputInvalid();
 
     void SaveValues();
     void SavePlayerValues();

--- a/src/yuzu/configuration/configure.ui
+++ b/src/yuzu/configuration/configure.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>461</width>
-    <height>500</height>
+    <height>659</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,17 +24,17 @@
        <string>General</string>
       </attribute>
      </widget>
-      <widget class="ConfigureGameList" name="gameListTab">
-        <attribute name="title">
-          <string>Game List</string>
-        </attribute>
-      </widget>
+     <widget class="ConfigureGameList" name="gameListTab">
+      <attribute name="title">
+       <string>Game List</string>
+      </attribute>
+     </widget>
      <widget class="ConfigureSystem" name="systemTab">
       <attribute name="title">
        <string>System</string>
       </attribute>
      </widget>
-     <widget class="ConfigureInput" name="inputTab">
+     <widget class="ConfigureInputSimple" name="inputTab">
       <attribute name="title">
        <string>Input</string>
       </attribute>
@@ -54,11 +54,11 @@
        <string>Debug</string>
       </attribute>
      </widget>
-      <widget class="ConfigureWeb" name="webTab">
-        <attribute name="title">
-          <string>Web</string>
-        </attribute>
-      </widget>
+     <widget class="ConfigureWeb" name="webTab">
+      <attribute name="title">
+       <string>Web</string>
+      </attribute>
+     </widget>
     </widget>
    </item>
    <item>
@@ -77,12 +77,12 @@
    <header>configuration/configure_general.h</header>
    <container>1</container>
   </customwidget>
-   <customwidget>
-     <class>ConfigureGameList</class>
-     <extends>QWidget</extends>
-     <header>configuration/configure_gamelist.h</header>
-     <container>1</container>
-   </customwidget>
+  <customwidget>
+   <class>ConfigureGameList</class>
+   <extends>QWidget</extends>
+   <header>configuration/configure_gamelist.h</header>
+   <container>1</container>
+  </customwidget>
   <customwidget>
    <class>ConfigureSystem</class>
    <extends>QWidget</extends>
@@ -102,9 +102,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ConfigureInput</class>
+   <class>ConfigureInputSimple</class>
    <extends>QWidget</extends>
-   <header>configuration/configure_input.h</header>
+   <header>configuration/configure_input_simple.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -113,12 +113,12 @@
    <header>configuration/configure_graphics.h</header>
    <container>1</container>
   </customwidget>
-   <customwidget>
-     <class>ConfigureWeb</class>
-     <extends>QWidget</extends>
-     <header>configuration/configure_web.h</header>
-     <container>1</container>
-   </customwidget>
+  <customwidget>
+   <class>ConfigureWeb</class>
+   <extends>QWidget</extends>
+   <header>configuration/configure_web.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <resources/>
  <connections>

--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -34,7 +34,7 @@ void CallConfigureDialog(ConfigureInput& parent, Args&&... args) {
 } // Anonymous namespace
 
 ConfigureInput::ConfigureInput(QWidget* parent)
-    : QWidget(parent), ui(std::make_unique<Ui::ConfigureInput>()) {
+    : QDialog(parent), ui(std::make_unique<Ui::ConfigureInput>()) {
     ui->setupUi(this);
 
     players_controller = {

--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -20,6 +20,33 @@
 #include "yuzu/configuration/configure_input_player.h"
 #include "yuzu/configuration/configure_mouse_advanced.h"
 
+void OnDockedModeChanged(bool last_state, bool new_state) {
+    if (last_state == new_state) {
+        return;
+    }
+
+    Core::System& system{Core::System::GetInstance()};
+    if (!system.IsPoweredOn()) {
+        return;
+    }
+    Service::SM::ServiceManager& sm = system.ServiceManager();
+
+    // Message queue is shared between these services, we just need to signal an operation
+    // change to one and it will handle both automatically
+    auto applet_oe = sm.GetService<Service::AM::AppletOE>("appletOE");
+    auto applet_ae = sm.GetService<Service::AM::AppletAE>("appletAE");
+    bool has_signalled = false;
+
+    if (applet_oe != nullptr) {
+        applet_oe->GetMessageQueue()->OperationModeChanged();
+        has_signalled = true;
+    }
+
+    if (applet_ae != nullptr && !has_signalled) {
+        applet_ae->GetMessageQueue()->OperationModeChanged();
+    }
+}
+
 namespace {
 template <typename Dialog, typename... Args>
 void CallConfigureDialog(ConfigureInput& parent, Args&&... args) {
@@ -89,37 +116,6 @@ ConfigureInput::ConfigureInput(QWidget* parent)
 }
 
 ConfigureInput::~ConfigureInput() = default;
-
-void ConfigureInput::OnDockedModeChanged(bool last_state, bool new_state) {
-    if (ui->use_docked_mode->isChecked() && ui->handheld_connected->isChecked()) {
-        ui->handheld_connected->setChecked(false);
-    }
-
-    if (last_state == new_state) {
-        return;
-    }
-
-    Core::System& system{Core::System::GetInstance()};
-    if (!system.IsPoweredOn()) {
-        return;
-    }
-    Service::SM::ServiceManager& sm = system.ServiceManager();
-
-    // Message queue is shared between these services, we just need to signal an operation
-    // change to one and it will handle both automatically
-    auto applet_oe = sm.GetService<Service::AM::AppletOE>("appletOE");
-    auto applet_ae = sm.GetService<Service::AM::AppletAE>("appletAE");
-    bool has_signalled = false;
-
-    if (applet_oe != nullptr) {
-        applet_oe->GetMessageQueue()->OperationModeChanged();
-        has_signalled = true;
-    }
-
-    if (applet_ae != nullptr && !has_signalled) {
-        applet_ae->GetMessageQueue()->OperationModeChanged();
-    }
-}
 
 void ConfigureInput::applyConfiguration() {
     for (std::size_t i = 0; i < players_controller.size(); ++i) {

--- a/src/yuzu/configuration/configure_input.h
+++ b/src/yuzu/configuration/configure_input.h
@@ -7,8 +7,8 @@
 #include <array>
 #include <memory>
 
+#include <QDialog>
 #include <QKeyEvent>
-#include <QWidget>
 
 #include "ui_configure_input.h"
 
@@ -20,7 +20,7 @@ namespace Ui {
 class ConfigureInput;
 }
 
-class ConfigureInput : public QWidget {
+class ConfigureInput : public QDialog {
     Q_OBJECT
 
 public:

--- a/src/yuzu/configuration/configure_input.h
+++ b/src/yuzu/configuration/configure_input.h
@@ -20,6 +20,8 @@ namespace Ui {
 class ConfigureInput;
 }
 
+void OnDockedModeChanged(bool last_state, bool new_state);
+
 class ConfigureInput : public QDialog {
     Q_OBJECT
 
@@ -32,8 +34,6 @@ public:
 
 private:
     void updateUIEnabled();
-
-    void OnDockedModeChanged(bool last_state, bool new_state);
 
     /// Load configuration settings.
     void loadConfiguration();

--- a/src/yuzu/configuration/configure_input.ui
+++ b/src/yuzu/configuration/configure_input.ui
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>ConfigureInput</class>
- <widget class="QWidget" name="ConfigureInput">
+ <widget class="QDialog" name="ConfigureInput">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>473</width>
-    <height>685</height>
+    <width>384</width>
+    <height>576</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -478,6 +478,13 @@
          </property>
         </spacer>
        </item>
+       <item>
+        <widget class="QDialogButtonBox" name="buttonBox">
+         <property name="standardButtons">
+          <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+         </property>
+        </widget>
+       </item>
       </layout>
      </item>
     </layout>
@@ -485,5 +492,38 @@
   </layout>
  </widget>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ConfigureInput</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>294</x>
+     <y>553</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>191</x>
+     <y>287</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ConfigureInput</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>294</x>
+     <y>553</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>191</x>
+     <y>287</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <utility>
 #include <QColorDialog>
+#include <QGridLayout>
 #include <QMenu>
 #include <QMessageBox>
 #include <QTimer>

--- a/src/yuzu/configuration/configure_input_simple.cpp
+++ b/src/yuzu/configuration/configure_input_simple.cpp
@@ -1,0 +1,140 @@
+// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <array>
+#include <cstring>
+#include <functional>
+#include <tuple>
+
+#include <QDialog>
+
+#include "ui_configure_input_simple.h"
+#include "yuzu/configuration/configure_input.h"
+#include "yuzu/configuration/configure_input_player.h"
+#include "yuzu/configuration/configure_input_simple.h"
+#include "yuzu/ui_settings.h"
+
+namespace {
+
+template <typename Dialog, typename... Args>
+void CallConfigureDialog(ConfigureInputSimple* caller, Args&&... args) {
+    caller->applyConfiguration();
+    Dialog dialog(caller, std::forward<Args>(args)...);
+
+    const auto res = dialog.exec();
+    if (res == QDialog::Accepted) {
+        dialog.applyConfiguration();
+    }
+}
+
+// OnProfileSelect functions should (when applicable):
+// - Set controller types
+// - Set controller enabled
+// - Set docked mode
+// - Set advanced controller config/enabled (i.e. debug, kbd, mouse, touch)
+//
+// OnProfileSelect function should NOT however:
+// - Reset any button mappings
+// - Open any dialogs
+// - Block in any way
+
+constexpr std::size_t HANDHELD_INDEX = 8;
+
+void HandheldOnProfileSelect() {
+    Settings::values.players[HANDHELD_INDEX].connected = true;
+    Settings::values.players[HANDHELD_INDEX].type = Settings::ControllerType::DualJoycon;
+
+    for (std::size_t player = 0; player < HANDHELD_INDEX; ++player) {
+        Settings::values.players[player].connected = false;
+    }
+
+    Settings::values.use_docked_mode = false;
+    Settings::values.keyboard_enabled = false;
+    Settings::values.mouse_enabled = false;
+    Settings::values.debug_pad_enabled = false;
+    Settings::values.touchscreen.enabled = true;
+}
+
+void DualJoyconsDockedOnProfileSelect() {
+    Settings::values.players[0].connected = true;
+    Settings::values.players[0].type = Settings::ControllerType::DualJoycon;
+
+    for (std::size_t player = 1; player <= HANDHELD_INDEX; ++player) {
+        Settings::values.players[player].connected = false;
+    }
+
+    Settings::values.use_docked_mode = true;
+    Settings::values.keyboard_enabled = false;
+    Settings::values.mouse_enabled = false;
+    Settings::values.debug_pad_enabled = false;
+    Settings::values.touchscreen.enabled = false;
+}
+
+// Name, OnProfileSelect (called when selected in drop down), OnConfigure (called when configure
+// is clicked)
+using InputProfile =
+    std::tuple<QString, std::function<void()>, std::function<void(ConfigureInputSimple*)>>;
+
+const std::array<InputProfile, 3> INPUT_PROFILES{{
+    {ConfigureInputSimple::tr("Single Player - Handheld - Undocked"), HandheldOnProfileSelect,
+     [](ConfigureInputSimple* caller) {
+         CallConfigureDialog<ConfigureInputPlayer>(caller, HANDHELD_INDEX, false);
+     }},
+    {ConfigureInputSimple::tr("Single Player - Dual Joycons - Docked"),
+     DualJoyconsDockedOnProfileSelect,
+     [](ConfigureInputSimple* caller) {
+         CallConfigureDialog<ConfigureInputPlayer>(caller, 1, false);
+     }},
+    {ConfigureInputSimple::tr("Custom"), [] {}, CallConfigureDialog<ConfigureInput>},
+}};
+
+} // namespace
+
+void ApplyInputProfileConfiguration(int profile_index) {
+    std::get<1>(
+        INPUT_PROFILES.at(std::min(profile_index, static_cast<int>(INPUT_PROFILES.size() - 1))))();
+}
+
+ConfigureInputSimple::ConfigureInputSimple(QWidget* parent)
+    : QWidget(parent), ui(std::make_unique<Ui::ConfigureInputSimple>()) {
+    ui->setupUi(this);
+
+    for (const auto& profile : INPUT_PROFILES) {
+        ui->profile_combobox->addItem(std::get<0>(profile), std::get<0>(profile));
+    }
+
+    connect(ui->profile_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &ConfigureInputSimple::OnSelectProfile);
+    connect(ui->profile_configure, &QPushButton::pressed, this, &ConfigureInputSimple::OnConfigure);
+
+    this->loadConfiguration();
+}
+
+ConfigureInputSimple::~ConfigureInputSimple() = default;
+
+void ConfigureInputSimple::applyConfiguration() {
+    auto index = ui->profile_combobox->currentIndex();
+    // Make the stored index for "Custom" very large so that if new profiles are added it
+    // doesn't change.
+    if (index >= static_cast<int>(INPUT_PROFILES.size() - 1))
+        index = std::numeric_limits<int>::max();
+
+    UISettings::values.profile_index = index;
+}
+
+void ConfigureInputSimple::loadConfiguration() {
+    const auto index = UISettings::values.profile_index;
+    if (index >= static_cast<int>(INPUT_PROFILES.size()) || index < 0)
+        ui->profile_combobox->setCurrentIndex(static_cast<int>(INPUT_PROFILES.size() - 1));
+    else
+        ui->profile_combobox->setCurrentIndex(index);
+}
+
+void ConfigureInputSimple::OnSelectProfile(int index) {
+    ApplyInputProfileConfiguration(index);
+}
+
+void ConfigureInputSimple::OnConfigure() {
+    std::get<2>(INPUT_PROFILES.at(ui->profile_combobox->currentIndex()))(this);
+}

--- a/src/yuzu/configuration/configure_input_simple.cpp
+++ b/src/yuzu/configuration/configure_input_simple.cpp
@@ -132,7 +132,9 @@ void ConfigureInputSimple::loadConfiguration() {
 }
 
 void ConfigureInputSimple::OnSelectProfile(int index) {
+    const auto old_docked = Settings::values.use_docked_mode;
     ApplyInputProfileConfiguration(index);
+    OnDockedModeChanged(old_docked, Settings::values.use_docked_mode);
 }
 
 void ConfigureInputSimple::OnConfigure() {

--- a/src/yuzu/configuration/configure_input_simple.h
+++ b/src/yuzu/configuration/configure_input_simple.h
@@ -1,0 +1,40 @@
+﻿// Copyright 2016 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+
+#include <QWidget>
+
+class QPushButton;
+class QString;
+class QTimer;
+
+namespace Ui {
+class ConfigureInputSimple;
+}
+
+// Used by configuration loader to apply a profile if the input is invalid.
+void ApplyInputProfileConfiguration(int profile_index);
+
+class ConfigureInputSimple : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ConfigureInputSimple(QWidget* parent = nullptr);
+    ~ConfigureInputSimple() override;
+
+    /// Save all button configurations to settings file
+    void applyConfiguration();
+
+private:
+    /// Load configuration settings.
+    void loadConfiguration();
+
+    void OnSelectProfile(int index);
+    void OnConfigure();
+
+    std::unique_ptr<Ui::ConfigureInputSimple> ui;
+};

--- a/src/yuzu/configuration/configure_input_simple.ui
+++ b/src/yuzu/configuration/configure_input_simple.ui
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureInputSimple</class>
+ <widget class="QWidget" name="ConfigureInputSimple">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>473</width>
+    <height>685</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>ConfigureInputSimple</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_5">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QGroupBox" name="gridGroupBox">
+       <property name="title">
+        <string>Profile</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="1" column="2">
+         <widget class="QPushButton" name="profile_configure">
+          <property name="text">
+           <string>Configure</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="1" column="3">
+         <spacer name="horizontalSpacer_2">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="profile_combobox">
+          <property name="minimumSize">
+           <size>
+            <width>250</width>
+            <height>0</height>
+           </size>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1" colspan="2">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Choose a controller configuration:</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/yuzu/ui_settings.h
+++ b/src/yuzu/ui_settings.h
@@ -58,6 +58,9 @@ struct Values {
     // logging
     bool show_console;
 
+    // Controllers
+    uint32_t profile_index;
+
     // Game List
     bool show_unknown;
     bool show_add_ons;

--- a/src/yuzu/ui_settings.h
+++ b/src/yuzu/ui_settings.h
@@ -59,7 +59,7 @@ struct Values {
     bool show_console;
 
     // Controllers
-    uint32_t profile_index;
+    int profile_index;
 
     // Game List
     bool show_unknown;


### PR DESCRIPTION
Greatly simplifies the current input UI, while still allowing power users to tweak advanced settings. Adds 'input profiles', which are easy autoconfigurations to make getting started easy and fast. Also has a custom option which brings up the current, full UI.

For the profiles, clicking configure will open the button mapping. For custom, it opens the current UI in a dialog.

Currently there are two profiles:
- `Single Player - Handheld - Undocked` (Default)
- `Single Player - Dual Joycons - Docked`
along with `Custom` which will open the current UI when configured.
From my testing, most booting games will work with one or both of these profiles. If a game doesn't work, file an issue report with the game and we can add a new profile.

Examples:
![image](https://user-images.githubusercontent.com/5064800/48921210-276af600-ee6c-11e8-8367-6fa5313d1ef1.png)
