### PR TITLE
service/sm: Take std::string by const reference in UnregisterService

### DIFF
--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -63,7 +63,7 @@ ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> ServiceManager::RegisterService
     return MakeResult<Kernel::SharedPtr<Kernel::ServerPort>>(std::move(server_port));
 }
 
-ResultCode ServiceManager::UnregisterService(std::string name) {
+ResultCode ServiceManager::UnregisterService(const std::string& name) {
     CASCADE_CODE(ValidateServiceName(name));
 
     const auto iter = registered_services.find(name);

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -50,7 +50,7 @@ public:
 
     ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> RegisterService(std::string name,
                                                                      unsigned int max_sessions);
-    ResultCode UnregisterService(std::string name);
+    ResultCode UnregisterService(const std::string& name);
     ResultVal<Kernel::SharedPtr<Kernel::ClientPort>> GetServicePort(const std::string& name);
     ResultVal<Kernel::SharedPtr<Kernel::ClientSession>> ConnectToService(const std::string& name);
 


### PR DESCRIPTION
Avoids the need to create a copy of the std::string instance (potentially allocating).

The only reason RegisterService takes its argument by value is because it's std::moved internally