### PR TITLE
video_core: Minor style changes

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -88,19 +88,6 @@ RasterizerOpenGL::RasterizerOpenGL(Core::Frontend::EmuWindow& window, ScreenInfo
         state.texture_units[i].sampler = texture_samplers[i].sampler.handle;
     }
 
-    GLint ext_num;
-    glGetIntegerv(GL_NUM_EXTENSIONS, &ext_num);
-    for (GLint i = 0; i < ext_num; i++) {
-        const std::string_view extension{
-            reinterpret_cast<const char*>(glGetStringi(GL_EXTENSIONS, i))};
-
-        if (extension == "GL_ARB_direct_state_access") {
-            has_ARB_direct_state_access = true;
-        } else if (extension == "GL_ARB_multi_bind") {
-            has_ARB_multi_bind = true;
-        }
-    }
-
     OpenGLState::ApplyDefaultState();
 
     // Create render framebuffer

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -430,7 +430,7 @@ void RasterizerOpenGL::ConfigureFramebuffers(OpenGLState& current_state, bool us
     // TODO(bunnei): Figure out how the below register works. According to envytools, this should be
     // used to enable multiple render targets. However, it is left unset on all games that I have
     // tested.
-    ASSERT_MSG(regs.rt_separate_frag_data == 0, "Unimplemented");
+    UNIMPLEMENTED_IF(regs.rt_separate_frag_data != 0);
 
     // Bind the framebuffer surfaces
     current_state.draw.draw_framebuffer = framebuffer.handle;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -60,20 +60,6 @@ public:
     bool AccelerateDrawBatch(bool is_indexed) override;
     void UpdatePagesCachedCount(Tegra::GPUVAddr addr, u64 size, int delta) override;
 
-    /// OpenGL shader generated for a given Maxwell register state
-    struct MaxwellShader {
-        /// OpenGL shader resource
-        OGLProgram shader;
-    };
-
-    struct VertexShader {
-        OGLShader shader;
-    };
-
-    struct FragmentShader {
-        OGLShader shader;
-    };
-
     /// Maximum supported size that a constbuffer can have in bytes.
     static constexpr std::size_t MaxConstbufferSize = 0x10000;
     static_assert(MaxConstbufferSize % sizeof(GLvec4) == 0,

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -193,9 +193,6 @@ private:
     /// but are needed for correct emulation
     void CheckExtensions();
 
-    bool has_ARB_direct_state_access = false;
-    bool has_ARB_multi_bind = false;
-
     OpenGLState state;
 
     RasterizerCacheOpenGL res_cache;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -841,9 +841,10 @@ void CachedSurface::LoadGLBuffer() {
         const auto texture_src_data_end{texture_src_data + params.size_in_bytes_gl};
         gl_buffer[0].assign(texture_src_data, texture_src_data_end);
     }
-    for (u32 i = 0; i < params.max_mip_level; i++)
+    for (u32 i = 0; i < params.max_mip_level; i++) {
         ConvertFormatAsNeeded_LoadGLBuffer(gl_buffer[i], params.pixel_format, params.MipWidth(i),
                                            params.MipHeight(i), params.MipDepth(i));
+    }
 }
 
 MICROPROFILE_DEFINE(OpenGL_SurfaceFlush, "OpenGL", "Surface Flush", MP_RGB(128, 192, 64));

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -518,6 +518,8 @@ void GMainWindow::OnDisplayTitleBars(bool show) {
 QStringList GMainWindow::GetUnsupportedGLExtensions() {
     QStringList unsupported_ext;
 
+    if (!GLAD_GL_ARB_direct_state_access)
+        unsupported_ext.append("ARB_direct_state_access");
     if (!GLAD_GL_ARB_vertex_type_10f_11f_11f_rev)
         unsupported_ext.append("ARB_vertex_type_10f_11f_11f_rev");
     if (!GLAD_GL_ARB_texture_mirror_clamp_to_edge)

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
@@ -111,6 +111,8 @@ void EmuWindow_SDL2::Fullscreen() {
 bool EmuWindow_SDL2::SupportsRequiredGLExtensions() {
     std::vector<std::string> unsupported_ext;
 
+    if (!GLAD_GL_ARB_direct_state_access)
+        unsupported_ext.push_back("ARB_direct_state_access");
     if (!GLAD_GL_ARB_vertex_type_10f_11f_11f_rev)
         unsupported_ext.push_back("ARB_vertex_type_10f_11f_11f_rev");
     if (!GLAD_GL_ARB_texture_mirror_clamp_to_edge)


### PR DESCRIPTION
This removes unused structs and booleans from the rasterizer and adds the required dependency on `ARB_direct_state_access`, aside from two style changes in `gl_rasterizer_cache`.