### PR TITLE
svc: Return ERR_INVALID_ENUM_VALUE from svcGetInfo

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -671,7 +671,8 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
         break;
     }
     default:
-        UNIMPLEMENTED();
+        LOG_WARNING(Kernel_SVC, "(STUBBED) Unimplemented svcGetInfo id=0x{:016X}", info_id);
+        return ERR_INVALID_ENUM_VALUE;
     }
 
     return RESULT_SUCCESS;


### PR DESCRIPTION
libnx uses this behavior for firmware version detection: https://github.com/switchbrew/libnx/commit/6ef26bff1a77e2ac0c9d026024a4f010889a67e6

Before, `UNIMPLEMENTED()` would crash the emulator.