### PR TITLE
profile_manager: Save and load ProfileData from disk

### DIFF
--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -21,17 +21,6 @@
 
 namespace Service::Account {
 
-// TODO: RE this structure
-struct UserData {
-    INSERT_PADDING_WORDS(1);
-    u32 icon_id;
-    u8 bg_color_id;
-    INSERT_PADDING_BYTES(0x7);
-    INSERT_PADDING_BYTES(0x10);
-    INSERT_PADDING_BYTES(0x60);
-};
-static_assert(sizeof(UserData) == 0x80, "UserData structure has incorrect size");
-
 // Smallest JPEG https://github.com/mathiasbynens/small/blob/master/jpeg.jpg
 // used as a backup should the one on disk not exist
 constexpr u32 backup_jpeg_size = 107;
@@ -72,9 +61,11 @@ private:
     void Get(Kernel::HLERequestContext& ctx) {
         LOG_INFO(Service_ACC, "called user_id={}", user_id.Format());
         ProfileBase profile_base{};
-        std::array<u8, MAX_DATA> data{};
+        ProfileData data{};
         if (profile_manager.GetProfileBaseAndData(user_id, profile_base, data)) {
-            ctx.WriteBuffer(data);
+            std::array<u8, sizeof(ProfileData)> raw_data;
+            std::memcpy(raw_data.data(), &data, sizeof(ProfileData));
+            ctx.WriteBuffer(raw_data);
             IPC::ResponseBuilder rb{ctx, 16};
             rb.Push(RESULT_SUCCESS);
             rb.PushRaw(profile_base);

--- a/src/core/hle/service/acc/profile_manager.cpp
+++ b/src/core/hle/service/acc/profile_manager.cpp
@@ -18,7 +18,7 @@ struct UserRaw {
     UUID uuid2;
     u64 timestamp;
     ProfileUsername username;
-    INSERT_PADDING_BYTES(0x80);
+    ProfileData extra_data;
 };
 static_assert(sizeof(UserRaw) == 0xC8, "UserRaw has incorrect size.");
 
@@ -346,7 +346,7 @@ void ProfileManager::ParseUserSaveFile() {
             continue;
         }
 
-        AddUser({user.uuid, user.username, user.timestamp, {}, false});
+        AddUser({user.uuid, user.username, user.timestamp, user.extra_data, false});
     }
 
     std::stable_partition(profiles.begin(), profiles.end(),
@@ -361,6 +361,7 @@ void ProfileManager::WriteUserSaveFile() {
         raw.users[i].uuid2 = profiles[i].user_uuid;
         raw.users[i].uuid = profiles[i].user_uuid;
         raw.users[i].timestamp = profiles[i].creation_time;
+        raw.users[i].extra_data = profiles[i].data;
     }
 
     const auto raw_path =

--- a/src/core/hle/service/acc/profile_manager.h
+++ b/src/core/hle/service/acc/profile_manager.h
@@ -13,7 +13,6 @@
 
 namespace Service::Account {
 constexpr std::size_t MAX_USERS = 8;
-constexpr std::size_t MAX_DATA = 128;
 constexpr u128 INVALID_UUID{{0, 0}};
 
 struct UUID {
@@ -50,8 +49,19 @@ static_assert(sizeof(UUID) == 16, "UUID is an invalid size!");
 
 constexpr std::size_t profile_username_size = 32;
 using ProfileUsername = std::array<u8, profile_username_size>;
-using ProfileData = std::array<u8, MAX_DATA>;
 using UserIDArray = std::array<UUID, MAX_USERS>;
+
+/// Contains extra data related to a user.
+/// TODO: RE this structure
+struct ProfileData {
+    INSERT_PADDING_WORDS(1);
+    u32 icon_id;
+    u8 bg_color_id;
+    INSERT_PADDING_BYTES(0x7);
+    INSERT_PADDING_BYTES(0x10);
+    INSERT_PADDING_BYTES(0x60);
+};
+static_assert(sizeof(ProfileData) == 0x80, "ProfileData structure has incorrect size");
 
 /// This holds general information about a users profile. This is where we store all the information
 /// based on a specific user


### PR DESCRIPTION
The ProfileData is a 0x80-sized structure that stores various pieces of miscellaneous data for the account. Previously, it was simply ignored and always 0, which is not hw-accurate. Even though it is still not used by yuzu, only games/applications, we can now avoid neutering the profiles.dat by loading and saving this data.