### PR TITLE
svc: Implement svcCreateResourceLimit, svcGetResourceLimitCurrentValue(), svcGetResourceLimitLimitValue(), and svcSetResourceLimitLimitValue()

### DIFF
--- a/src/core/hle/kernel/resource_limit.h
+++ b/src/core/hle/kernel/resource_limit.h
@@ -14,7 +14,7 @@ namespace Kernel {
 
 class KernelCore;
 
-enum class ResourceType {
+enum class ResourceType : u32 {
     PhysicalMemory,
     Threads,
     Events,
@@ -24,6 +24,10 @@ enum class ResourceType {
     // Used as a count, not an actual type.
     ResourceTypeCount
 };
+
+constexpr bool IsValidResourceType(ResourceType type) {
+    return type < ResourceType::ResourceTypeCount;
+}
 
 class ResourceLimit final : public Object {
 public:

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1346,6 +1346,24 @@ static ResultCode GetProcessInfo(u64* out, Handle process_handle, u32 type) {
     return RESULT_SUCCESS;
 }
 
+static ResultCode CreateResourceLimit(Handle* out_handle) {
+    LOG_DEBUG(Kernel_SVC, "called");
+
+    auto& kernel = Core::System::GetInstance().Kernel();
+    auto resource_limit = ResourceLimit::Create(kernel);
+
+    auto* const current_process = kernel.CurrentProcess();
+    ASSERT(current_process != nullptr);
+
+    const auto handle = current_process->GetHandleTable().Create(std::move(resource_limit));
+    if (handle.Failed()) {
+        return handle.Code();
+    }
+
+    *out_handle = *handle;
+    return RESULT_SUCCESS;
+}
+
 namespace {
 struct FunctionDef {
     using Func = void();
@@ -1482,7 +1500,7 @@ static const FunctionDef SVC_Table[] = {
     {0x7A, nullptr, "StartProcess"},
     {0x7B, nullptr, "TerminateProcess"},
     {0x7C, SvcWrap<GetProcessInfo>, "GetProcessInfo"},
-    {0x7D, nullptr, "CreateResourceLimit"},
+    {0x7D, SvcWrap<CreateResourceLimit>, "CreateResourceLimit"},
     {0x7E, nullptr, "SetResourceLimitLimitValue"},
     {0x7F, nullptr, "CallSecureMonitor"},
 };

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -105,6 +105,38 @@ ResultCode MapUnmapMemorySanityChecks(const VMManager& vm_manager, VAddr dst_add
 
     return RESULT_SUCCESS;
 }
+
+enum class ResourceLimitValueType {
+    CurrentValue,
+    LimitValue,
+};
+
+ResultVal<s64> RetrieveResourceLimitValue(Handle resource_limit, u32 resource_type,
+                                          ResourceLimitValueType value_type) {
+    const auto type = static_cast<ResourceType>(resource_type);
+    if (!IsValidResourceType(type)) {
+        LOG_ERROR(Kernel_SVC, "Invalid resource limit type: '{}'", resource_type);
+        return ERR_INVALID_ENUM_VALUE;
+    }
+
+    const auto& kernel = Core::System::GetInstance().Kernel();
+    const auto* const current_process = kernel.CurrentProcess();
+    ASSERT(current_process != nullptr);
+
+    const auto resource_limit_object =
+        current_process->GetHandleTable().Get<ResourceLimit>(resource_limit);
+    if (!resource_limit_object) {
+        LOG_ERROR(Kernel_SVC, "Handle to non-existent resource limit instance used. Handle={:08X}",
+                  resource_limit);
+        return ERR_INVALID_HANDLE;
+    }
+
+    if (value_type == ResourceLimitValueType::CurrentValue) {
+        return MakeResult(resource_limit_object->GetCurrentResourceValue(type));
+    }
+
+    return MakeResult(resource_limit_object->GetMaxResourceValue(type));
+}
 } // Anonymous namespace
 
 /// Set the process heap to a given Size. It can both extend and shrink the heap.
@@ -1368,26 +1400,27 @@ static ResultCode GetResourceLimitLimitValue(u64* out_value, Handle resource_lim
                                              u32 resource_type) {
     LOG_DEBUG(Kernel_SVC, "called. Handle={:08X}, Resource type={}", resource_limit, resource_type);
 
-    const auto type = static_cast<ResourceType>(resource_type);
-    if (!IsValidResourceType(type)) {
-        LOG_ERROR(Kernel_SVC, "Invalid resource limit type: '{}'.", resource_type);
-        return ERR_INVALID_ENUM_VALUE;
+    const auto limit_value = RetrieveResourceLimitValue(resource_limit, resource_type,
+                                                        ResourceLimitValueType::LimitValue);
+    if (limit_value.Failed()) {
+        return limit_value.Code();
     }
 
-    const auto& kernel = Core::System::GetInstance().Kernel();
-    const auto* const current_process = kernel.CurrentProcess();
-    ASSERT(current_process != nullptr);
+    *out_value = static_cast<u64>(*limit_value);
+    return RESULT_SUCCESS;
+}
 
-    const auto resource_limit_object =
-        current_process->GetHandleTable().Get<ResourceLimit>(resource_limit);
-    if (!resource_limit_object) {
-        LOG_ERROR(Kernel_SVC, "Handle to non-existent resource limit instance used. Handle={:08X}",
-                  resource_limit);
-        return ERR_INVALID_HANDLE;
+static ResultCode GetResourceLimitCurrentValue(u64* out_value, Handle resource_limit,
+                                               u32 resource_type) {
+    LOG_DEBUG(Kernel_SVC, "called. Handle={:08X}, Resource type={}", resource_limit, resource_type);
+
+    const auto current_value = RetrieveResourceLimitValue(resource_limit, resource_type,
+                                                          ResourceLimitValueType::CurrentValue);
+    if (current_value.Failed()) {
+        return current_value.Code();
     }
 
-    const s64 limit_value = resource_limit_object->GetMaxResourceValue(type);
-    *out_value = static_cast<u64>(limit_value);
+    *out_value = static_cast<u64>(*current_value);
     return RESULT_SUCCESS;
 }
 
@@ -1451,7 +1484,7 @@ static const FunctionDef SVC_Table[] = {
     {0x2E, nullptr, "GetFutureThreadInfo"},
     {0x2F, nullptr, "GetLastThreadInfo"},
     {0x30, SvcWrap<GetResourceLimitLimitValue>, "GetResourceLimitLimitValue"},
-    {0x31, nullptr, "GetResourceLimitCurrentValue"},
+    {0x31, SvcWrap<GetResourceLimitCurrentValue>, "GetResourceLimitCurrentValue"},
     {0x32, SvcWrap<SetThreadActivity>, "SetThreadActivity"},
     {0x33, SvcWrap<GetThreadContext>, "GetThreadContext"},
     {0x34, SvcWrap<WaitForAddress>, "WaitForAddress"},

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -43,6 +43,14 @@ void SvcWrap() {
     FuncReturn(func(static_cast<u32>(Param(0)), static_cast<u32>(Param(1))).raw);
 }
 
+template <ResultCode func(u32*)>
+void SvcWrap() {
+    u32 param = 0;
+    const u32 retval = func(&param).raw;
+    Core::CurrentArmInterface().SetReg(1, param);
+    FuncReturn(retval);
+}
+
 template <ResultCode func(u32*, u32)>
 void SvcWrap() {
     u32 param_1 = 0;


### PR DESCRIPTION
Implements the four resource limit API functions that are exposed as part of the service call interface. Specifically:

1. svcCreateResourceLimit
Attempts to create a resource limit instance and allocate a handle for it within the current process' handle table. If this isn't able to occur, then a relevant error is returned where applicable. Currently, error conditions occur if: 
    - Allocation of the resource limit instance itself fails.
    - If the handle couldn't be allocated for the resource instance.

2. svcGetResourceLimitLimitValue
Attempts to retrieve the limiting value for a particular resource category from a provided resource limit instance (provided as a handle). If this cannot be done, then a relevant error is returned. Currently, error conditions occur if: 
    - An invalid resource category is provided.
    - An invalid handle is provided.

3. svcGetResourceLimitCurrentValue
Almost the same as 2. except the current value for the category is returned instead of the limit value. Error cases remain the same.

4. svcSetResourceLimitLimitValue
Sets the limit value for a particular resource category. If this isn't able to be done then a relevant error is returned. Currently, error conditions occur if:
    - An invalid resource category is provided.
    - An invalid handle is provided
    - An attempt is made to lower the limit value below the current value for a particular resource category.

This PR will be followed up by dropping in the resource limit checks where appropriate.