### PR TITLE
Revert "Add support for viewport_transfom_enable register"

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -896,13 +896,7 @@ public:
 
                 Cull cull;
 
-                u32 pixel_center_integer;
-
-                INSERT_PADDING_WORDS(0x1);
-
-                u32 viewport_transform_enabled;
-
-                INSERT_PADDING_WORDS(0x25);
+                INSERT_PADDING_WORDS(0x28);
 
                 struct {
                     u32 enable;
@@ -1222,8 +1216,6 @@ ASSERT_REG_POSITION(index_array, 0x5F2);
 ASSERT_REG_POSITION(polygon_offset_clamp, 0x61F);
 ASSERT_REG_POSITION(instanced_arrays, 0x620);
 ASSERT_REG_POSITION(cull, 0x646);
-ASSERT_REG_POSITION(pixel_center_integer, 0x649);
-ASSERT_REG_POSITION(viewport_transform_enabled, 0x64B);
 ASSERT_REG_POSITION(logic_op, 0x671);
 ASSERT_REG_POSITION(clear_buffers, 0x674);
 ASSERT_REG_POSITION(color_mask, 0x680);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -985,25 +985,13 @@ u32 RasterizerOpenGL::SetupTextures(Maxwell::ShaderStage stage, Shader& shader,
 
 void RasterizerOpenGL::SyncViewport(OpenGLState& current_state) {
     const auto& regs = Core::System::GetInstance().GPU().Maxwell3D().regs;
-    const bool geometry_shaders_enabled =
-        regs.IsShaderConfigEnabled(static_cast<size_t>(Maxwell::ShaderProgram::Geometry));
-    const std::size_t viewport_count =
-        geometry_shaders_enabled ? Tegra::Engines::Maxwell3D::Regs::NumViewports : 1;
-    for (std::size_t i = 0; i < viewport_count; i++) {
+    for (std::size_t i = 0; i < Tegra::Engines::Maxwell3D::Regs::NumViewports; i++) {
+        const MathUtil::Rectangle<s32> viewport_rect{regs.viewport_transform[i].GetRect()};
         auto& viewport = current_state.viewports[i];
-        const auto& src = regs.viewports[i];
-        if (regs.viewport_transform_enabled) {
-            const MathUtil::Rectangle<s32> viewport_rect{regs.viewport_transform[i].GetRect()};
-            viewport.x = viewport_rect.left;
-            viewport.y = viewport_rect.bottom;
-            viewport.width = viewport_rect.GetWidth();
-            viewport.height = viewport_rect.GetHeight();
-        } else {
-            viewport.x = src.x;
-            viewport.y = src.y;
-            viewport.width = src.width;
-            viewport.height = src.height;
-        }
+        viewport.x = viewport_rect.left;
+        viewport.y = viewport_rect.bottom;
+        viewport.width = viewport_rect.GetWidth();
+        viewport.height = viewport_rect.GetHeight();
         viewport.depth_range_far = regs.viewports[i].depth_range_far;
         viewport.depth_range_near = regs.viewports[i].depth_range_near;
     }
@@ -1177,11 +1165,7 @@ void RasterizerOpenGL::SyncLogicOpState() {
 
 void RasterizerOpenGL::SyncScissorTest(OpenGLState& current_state) {
     const auto& regs = Core::System::GetInstance().GPU().Maxwell3D().regs;
-    const bool geometry_shaders_enabled =
-        regs.IsShaderConfigEnabled(static_cast<size_t>(Maxwell::ShaderProgram::Geometry));
-    const std::size_t viewport_count =
-        geometry_shaders_enabled ? Tegra::Engines::Maxwell3D::Regs::NumViewports : 1;
-    for (std::size_t i = 0; i < viewport_count; i++) {
+    for (std::size_t i = 0; i < Tegra::Engines::Maxwell3D::Regs::NumViewports; i++) {
         const auto& src = regs.scissor_test[i];
         auto& dst = current_state.viewports[i].scissor;
         dst.enabled = (src.enable != 0);


### PR DESCRIPTION
Reverts yuzu-emu/yuzu#1794

I'm pretty sure this partially broke the fish eye effect in SMO. Just opening this PR and tagging as Canary to enable others to easily test.

@Tinob do you mind taking a look when you get a chance?