### PR TITLE
Fix clip distance and viewport

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -744,7 +744,20 @@ public:
 
                 u32 vb_element_base;
 
-                INSERT_PADDING_WORDS(0x38);
+                INSERT_PADDING_WORDS(0x36);
+
+                union {
+                    BitField<0, 1, u32> c0;
+                    BitField<1, 1, u32> c1;
+                    BitField<2, 1, u32> c2;
+                    BitField<3, 1, u32> c3;
+                    BitField<4, 1, u32> c4;
+                    BitField<5, 1, u32> c5;
+                    BitField<6, 1, u32> c6;
+                    BitField<7, 1, u32> c7;
+                } clip_distance_enabled;
+
+                INSERT_PADDING_WORDS(0x1);
 
                 float point_size;
 
@@ -1201,6 +1214,7 @@ ASSERT_REG_POSITION(stencil_front_mask, 0x4E7);
 ASSERT_REG_POSITION(frag_color_clamp, 0x4EA);
 ASSERT_REG_POSITION(screen_y_control, 0x4EB);
 ASSERT_REG_POSITION(vb_element_base, 0x50D);
+ASSERT_REG_POSITION(clip_distance_enabled, 0x544);
 ASSERT_REG_POSITION(point_size, 0x546);
 ASSERT_REG_POSITION(zeta_enable, 0x54E);
 ASSERT_REG_POSITION(multisample_control, 0x54F);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -628,6 +628,7 @@ void RasterizerOpenGL::DrawArrays() {
     SyncCullMode();
     SyncPrimitiveRestart();
     SyncScissorTest(state);
+    SyncClipEnabled();
     // Alpha Testing is synced on shaders.
     SyncTransformFeedback();
     SyncPointState();
@@ -1010,7 +1011,15 @@ void RasterizerOpenGL::SyncViewport(OpenGLState& current_state) {
 }
 
 void RasterizerOpenGL::SyncClipEnabled() {
-    UNREACHABLE();
+    const auto& regs = Core::System::GetInstance().GPU().Maxwell3D().regs;
+    state.clip_distance[0] = regs.clip_distance_enabled.c0 != 0;
+    state.clip_distance[1] = regs.clip_distance_enabled.c1 != 0;
+    state.clip_distance[2] = regs.clip_distance_enabled.c2 != 0;
+    state.clip_distance[3] = regs.clip_distance_enabled.c3 != 0;
+    state.clip_distance[4] = regs.clip_distance_enabled.c4 != 0;
+    state.clip_distance[5] = regs.clip_distance_enabled.c5 != 0;
+    state.clip_distance[6] = regs.clip_distance_enabled.c6 != 0;
+    state.clip_distance[7] = regs.clip_distance_enabled.c7 != 0;
 }
 
 void RasterizerOpenGL::SyncClipCoef() {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -993,18 +993,11 @@ void RasterizerOpenGL::SyncViewport(OpenGLState& current_state) {
     for (std::size_t i = 0; i < viewport_count; i++) {
         auto& viewport = current_state.viewports[i];
         const auto& src = regs.viewports[i];
-        if (regs.viewport_transform_enabled) {
-            const MathUtil::Rectangle<s32> viewport_rect{regs.viewport_transform[i].GetRect()};
-            viewport.x = viewport_rect.left;
-            viewport.y = viewport_rect.bottom;
-            viewport.width = viewport_rect.GetWidth();
-            viewport.height = viewport_rect.GetHeight();
-        } else {
-            viewport.x = src.x;
-            viewport.y = src.y;
-            viewport.width = src.width;
-            viewport.height = src.height;
-        }
+        const MathUtil::Rectangle<s32> viewport_rect{regs.viewport_transform[i].GetRect()};
+        viewport.x = viewport_rect.left;
+        viewport.y = viewport_rect.bottom;
+        viewport.width = viewport_rect.GetWidth();
+        viewport.height = viewport_rect.GetHeight();
         viewport.depth_range_far = regs.viewports[i].depth_range_far;
         viewport.depth_range_near = regs.viewports[i].depth_range_near;
     }

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -185,7 +185,7 @@ public:
         GLfloat clamp;
     } polygon_offset;
 
-    std::array<bool, 2> clip_distance; // GL_CLIP_DISTANCE
+    std::array<bool, 8> clip_distance; // GL_CLIP_DISTANCE
 
     OpenGLState();
 


### PR DESCRIPTION
fast fix for issues caused by the viewport_transform_enabled register and add the missing clipdistance enabled register that are needed for  https://github.com/yuzu-emu/yuzu/pull/1783 to work correctly