### PR TITLE
control_metadata: Correct typo in language name (Portugese -> Portuguese)

### DIFF
--- a/src/core/file_sys/control_metadata.cpp
+++ b/src/core/file_sys/control_metadata.cpp
@@ -8,13 +8,23 @@
 
 namespace FileSys {
 
-const std::array<const char*, 15> LANGUAGE_NAMES = {
-    "AmericanEnglish", "BritishEnglish", "Japanese",
-    "French",          "German",         "LatinAmericanSpanish",
-    "Spanish",         "Italian",        "Dutch",
-    "CanadianFrench",  "Portugese",      "Russian",
-    "Korean",          "Taiwanese",      "Chinese",
-};
+const std::array<const char*, 15> LANGUAGE_NAMES{{
+    "AmericanEnglish",
+    "BritishEnglish",
+    "Japanese",
+    "French",
+    "German",
+    "LatinAmericanSpanish",
+    "Spanish",
+    "Italian",
+    "Dutch",
+    "CanadianFrench",
+    "Portuguese",
+    "Russian",
+    "Korean",
+    "Taiwanese",
+    "Chinese",
+}};
 
 std::string LanguageEntry::GetApplicationName() const {
     return Common::StringFromFixedZeroTerminatedBuffer(application_name.data(),


### PR DESCRIPTION
While we're at it, organize the array linearly, since clang formats the array elements quite wide length-wise with the addition of the missing 'u'.

Technically also fixes patch lookup and icon lookup with Portuguese, though I doubt anyone has actually run into this issue.