### PR TITLE
file_sys/registered_cache: Use regular const references instead of std::shared_ptr for InstallEntry()

### DIFF
--- a/src/core/file_sys/registered_cache.h
+++ b/src/core/file_sys/registered_cache.h
@@ -104,17 +104,16 @@ public:
 
     // Raw copies all the ncas from the xci/nsp to the csache. Does some quick checks to make sure
     // there is a meta NCA and all of them are accessible.
-    InstallResult InstallEntry(std::shared_ptr<XCI> xci, bool overwrite_if_exists = false,
+    InstallResult InstallEntry(const XCI& xci, bool overwrite_if_exists = false,
                                const VfsCopyFunction& copy = &VfsRawCopy);
-    InstallResult InstallEntry(std::shared_ptr<NSP> nsp, bool overwrite_if_exists = false,
+    InstallResult InstallEntry(const NSP& nsp, bool overwrite_if_exists = false,
                                const VfsCopyFunction& copy = &VfsRawCopy);
 
     // Due to the fact that we must use Meta-type NCAs to determine the existance of files, this
     // poses quite a challenge. Instead of creating a new meta NCA for this file, yuzu will create a
     // dir inside the NAND called 'yuzu_meta' and store the raw CNMT there.
     // TODO(DarkLordZach): Author real meta-type NCAs and install those.
-    InstallResult InstallEntry(std::shared_ptr<NCA> nca, TitleType type,
-                               bool overwrite_if_exists = false,
+    InstallResult InstallEntry(const NCA& nca, TitleType type, bool overwrite_if_exists = false,
                                const VfsCopyFunction& copy = &VfsRawCopy);
 
 private:
@@ -128,7 +127,7 @@ private:
     std::optional<NcaID> GetNcaIDFromMetadata(u64 title_id, ContentRecordType type) const;
     VirtualFile GetFileAtID(NcaID id) const;
     VirtualFile OpenFileOrDirectoryConcat(const VirtualDir& dir, std::string_view path) const;
-    InstallResult RawInstallNCA(std::shared_ptr<NCA> nca, const VfsCopyFunction& copy,
+    InstallResult RawInstallNCA(const NCA& nca, const VfsCopyFunction& copy,
                                 bool overwrite_if_exists, std::optional<NcaID> override_id = {});
     bool RawInstallYuzuMeta(const CNMT& cnmt);
 

--- a/src/core/file_sys/registered_cache.h
+++ b/src/core/file_sys/registered_cache.h
@@ -6,7 +6,6 @@
 
 #include <array>
 #include <functional>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1105,14 +1105,14 @@ void GMainWindow::OnMenuInstallToNAND() {
             return;
         }
         const auto res =
-            Service::FileSystem::GetUserNANDContents()->InstallEntry(nsp, false, qt_raw_copy);
+            Service::FileSystem::GetUserNANDContents()->InstallEntry(*nsp, false, qt_raw_copy);
         if (res == FileSys::InstallResult::Success) {
             success();
         } else {
             if (res == FileSys::InstallResult::ErrorAlreadyExists) {
                 if (overwrite()) {
                     const auto res2 = Service::FileSystem::GetUserNANDContents()->InstallEntry(
-                        nsp, true, qt_raw_copy);
+                        *nsp, true, qt_raw_copy);
                     if (res2 == FileSys::InstallResult::Success) {
                         success();
                     } else {
@@ -1167,10 +1167,10 @@ void GMainWindow::OnMenuInstallToNAND() {
         FileSys::InstallResult res;
         if (index >= static_cast<size_t>(FileSys::TitleType::Application)) {
             res = Service::FileSystem::GetUserNANDContents()->InstallEntry(
-                nca, static_cast<FileSys::TitleType>(index), false, qt_raw_copy);
+                *nca, static_cast<FileSys::TitleType>(index), false, qt_raw_copy);
         } else {
             res = Service::FileSystem::GetSystemNANDContents()->InstallEntry(
-                nca, static_cast<FileSys::TitleType>(index), false, qt_raw_copy);
+                *nca, static_cast<FileSys::TitleType>(index), false, qt_raw_copy);
         }
 
         if (res == FileSys::InstallResult::Success) {
@@ -1178,7 +1178,7 @@ void GMainWindow::OnMenuInstallToNAND() {
         } else if (res == FileSys::InstallResult::ErrorAlreadyExists) {
             if (overwrite()) {
                 const auto res2 = Service::FileSystem::GetUserNANDContents()->InstallEntry(
-                    nca, static_cast<FileSys::TitleType>(index), true, qt_raw_copy);
+                    *nca, static_cast<FileSys::TitleType>(index), true, qt_raw_copy);
                 if (res2 == FileSys::InstallResult::Success) {
                     success();
                 } else {


### PR DESCRIPTION
These parameters don't need to utilize a shared lifecycle directly in the interface. Instead, the caller should provide a regular reference for the function to use. This also allows the type system to flag attempts to pass nullptr and makes it more generic, since it can now be used in contexts where a shared_ptr isn't being used (in other words, we don't constrain the usage of the interface to a particular mode of memory management).