### PR TITLE
gl_shader_decompiler: Introduce a scoped object and style changes

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -3003,12 +3003,12 @@ private:
                 // TODO(Subv): Figure out how the sampler type is encoded in the TLD4S instruction.
                 const std::string sampler = GetSampler(
                     instr.sampler, Tegra::Shader::TextureType::Texture2D, false, depth_compare);
-                if (!depth_compare) {
-                    shader.AddLine("vec2 coords = vec2(" + op_a + ", " + op_b + ");");
-                } else {
+                if (depth_compare) {
                     // Note: TLD4S coordinate encoding works just like TEXS's
                     const std::string op_y = regs.GetRegisterAsFloat(instr.gpr8.Value() + 1);
                     shader.AddLine("vec3 coords = vec3(" + op_a + ", " + op_y + ", " + op_b + ");");
+                } else {
+                    shader.AddLine("vec2 coords = vec2(" + op_a + ", " + op_b + ");");
                 }
 
                 std::string texture = "textureGather(" + sampler + ", coords, " +

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -2972,15 +2972,13 @@ private:
                 if (depth_compare) {
                     regs.SetRegisterToFloat(instr.gpr0, 0, texture, 1, 1, false);
                 } else {
-                    shader.AddLine("vec4 texture_tmp = " + texture + ';');
                     std::size_t dest_elem{};
                     for (std::size_t elem = 0; elem < 4; ++elem) {
                         if (!instr.tex.IsComponentEnabled(elem)) {
                             // Skip disabled components
                             continue;
                         }
-                        regs.SetRegisterToFloat(instr.gpr0, elem, "texture_tmp", 1, 4, false,
-                                                dest_elem);
+                        regs.SetRegisterToFloat(instr.gpr0, elem, texture, 1, 4, false, dest_elem);
                         ++dest_elem;
                     }
                 }


### PR DESCRIPTION
This introduces an object to gain scope that will be automatically returned when it's destroyed (similar to `std::scoped_lock`. It also does some clean up in the code in regards to texture instruction generation. It should use a table, but I'll leave that for later.

Reintroduces the usage of multiple `texture` calls since it was being used in some places but not others. `WriteTexsInstruction` no longer takes `coords` as argument because it sometimes requires more arguments. All these values (`coords` included) have to be declared in the calling function and not the callee. 