### PR TITLE
gl_rasterizer: Enable clip distances when set in register and in shader

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -42,6 +42,7 @@ public:
         static constexpr std::size_t NumVertexArrays = 32;
         static constexpr std::size_t NumVertexAttributes = 32;
         static constexpr std::size_t NumTextureSamplers = 32;
+        static constexpr std::size_t NumClipDistances = 8;
         static constexpr std::size_t MaxShaderProgram = 6;
         static constexpr std::size_t MaxShaderStage = 5;
         // Maximum number of const buffers per shader stage.

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -142,7 +142,8 @@ private:
     void SyncViewport(OpenGLState& current_state);
 
     /// Syncs the clip enabled status to match the guest state
-    void SyncClipEnabled();
+    void SyncClipEnabled(
+        const std::array<bool, Tegra::Engines::Maxwell3D::Regs::NumClipDistances>& clip_mask);
 
     /// Syncs the clip coefficients to match the guest state
     void SyncClipCoef();

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -525,6 +525,7 @@ public:
                 ((header.vtg.clip_distances >> index) & 1) == 0,
                 "Shader is setting gl_ClipDistance{} without enabling it in the header", index);
 
+            clip_distances[index] = true;
             fixed_pipeline_output_attributes_used.insert(attribute);
             shader.AddLine(dest + '[' + std::to_string(index) + "] = " + src + ';');
             break;
@@ -600,6 +601,11 @@ public:
     /// Returns a list of samplers used in the shader.
     const std::vector<SamplerEntry>& GetSamplers() const {
         return used_samplers;
+    }
+
+    /// Returns an array of the used clip distances.
+    const std::array<bool, Maxwell::NumClipDistances>& GetClipDistances() const {
+        return clip_distances;
     }
 
     /// Returns the GLSL sampler used for the input shader sampler, and creates a new one if
@@ -975,6 +981,7 @@ private:
     const std::string& suffix;
     const Tegra::Shader::Header& header;
     std::unordered_set<Attribute::Index> fixed_pipeline_output_attributes_used;
+    std::array<bool, Maxwell::NumClipDistances> clip_distances{};
     u64 local_memory_size;
 };
 
@@ -997,7 +1004,8 @@ public:
 
     /// Returns entries in the shader that are useful for external functions
     ShaderEntries GetEntries() const {
-        return {regs.GetConstBuffersDeclarations(), regs.GetSamplers(), shader_length};
+        return {regs.GetConstBuffersDeclarations(), regs.GetSamplers(), regs.GetClipDistances(),
+                shader_length};
     }
 
 private:

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -163,6 +163,7 @@ private:
 struct ShaderEntries {
     std::vector<ConstBufferEntry> const_buffer_entries;
     std::vector<SamplerEntry> texture_samplers;
+    std::array<bool, Tegra::Engines::Maxwell3D::Regs::NumClipDistances> clip_distances;
     std::size_t shader_length;
 };
 


### PR DESCRIPTION
Intel's blob driver crops parts of the screen when clip distances are enabled but not set in a shader. This enables them when they are set in the register and in the shader as a workaround for this issue.