### PR TITLE
 service/set: Implement MakeLanguageCode

### DIFF
--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -112,7 +112,7 @@ void SET::GetLanguageCode(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
-    rb.Push(static_cast<u64>(available_language_codes[Settings::values.language_index]));
+    rb.PushEnum(available_language_codes[Settings::values.language_index]);
 }
 
 SET::SET() : ServiceFramework("set") {

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -35,6 +35,8 @@ constexpr std::array<LanguageCode, 17> available_language_codes = {{
 constexpr std::size_t pre4_0_0_max_entries = 0xF;
 constexpr std::size_t post4_0_0_max_entries = 0x40;
 
+constexpr ResultCode ERR_INVALID_LANGUAGE{ErrorModule::Settings, 625};
+
 LanguageCode GetLanguageCodeFromIndex(std::size_t index) {
     return available_language_codes.at(index);
 }
@@ -65,6 +67,21 @@ void SET::GetAvailableLanguageCodes(Kernel::HLERequestContext& ctx) {
         ctx.WriteBuffer(available_language_codes);
     }
     PushResponseLanguageCode(ctx, pre4_0_0_max_entries);
+}
+
+void SET::MakeLanguageCode(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto index = rp.Pop<u32>();
+
+    if (index >= available_language_codes.size()) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ERR_INVALID_LANGUAGE);
+        return;
+    }
+
+    IPC::ResponseBuilder rb{ctx, 4};
+    rb.Push(RESULT_SUCCESS);
+    rb.PushEnum(available_language_codes[index]);
 }
 
 void SET::GetAvailableLanguageCodes2(Kernel::HLERequestContext& ctx) {
@@ -102,7 +119,7 @@ SET::SET() : ServiceFramework("set") {
     static const FunctionInfo functions[] = {
         {0, &SET::GetLanguageCode, "GetLanguageCode"},
         {1, &SET::GetAvailableLanguageCodes, "GetAvailableLanguageCodes"},
-        {2, nullptr, "MakeLanguageCode"},
+        {2, &SET::MakeLanguageCode, "MakeLanguageCode"},
         {3, &SET::GetAvailableLanguageCodeCount, "GetAvailableLanguageCodeCount"},
         {4, nullptr, "GetRegionCode"},
         {5, &SET::GetAvailableLanguageCodes2, "GetAvailableLanguageCodes2"},

--- a/src/core/hle/service/set/set.h
+++ b/src/core/hle/service/set/set.h
@@ -38,6 +38,7 @@ public:
 private:
     void GetLanguageCode(Kernel::HLERequestContext& ctx);
     void GetAvailableLanguageCodes(Kernel::HLERequestContext& ctx);
+    void MakeLanguageCode(Kernel::HLERequestContext& ctx);
     void GetAvailableLanguageCodes2(Kernel::HLERequestContext& ctx);
     void GetAvailableLanguageCodeCount(Kernel::HLERequestContext& ctx);
     void GetAvailableLanguageCodeCount2(Kernel::HLERequestContext& ctx);


### PR DESCRIPTION
This simply converts a provided index into its respective language code. i.e. making a language code from an index.