### PR TITLE
UI: Remove border from Game List

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -214,6 +214,7 @@ GameList::GameList(FileSys::VirtualFilesystem vfs, GMainWindow* parent)
     tree_view->setEditTriggers(QHeaderView::NoEditTriggers);
     tree_view->setUniformRowHeights(true);
     tree_view->setContextMenuPolicy(Qt::CustomContextMenu);
+    tree_view->setStyleSheet("QTreeView{ border: none; }");
 
     item_model->insertColumns(0, UISettings::values.show_add_ons ? COLUMN_COUNT : COLUMN_COUNT - 1);
     item_model->setHeaderData(COLUMN_NAME, Qt::Horizontal, tr("Name"));


### PR DESCRIPTION
I think that removing border from Game List causes main window to appear more clean.

It's just a small and subjective UI tweak so I understand if you don't like this change.

**Preview:**
<img width="1041" alt="yuzu1" src="https://user-images.githubusercontent.com/719641/49318653-aeb60a80-f4f9-11e8-8ae6-80181695306f.png">

