### PR TITLE
filesystem: De-globalize registered_cache_union

### DIFF
--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -794,7 +794,7 @@ void KeyManager::DeriveBase() {
 
 void KeyManager::DeriveETicket(PartitionDataManager& data) {
     // ETicket keys
-    const auto es = Service::FileSystem::GetUnionContents()->GetEntry(
+    const auto es = Service::FileSystem::GetUnionContents().GetEntry(
         0x0100000000000033, FileSys::ContentRecordType::Program);
 
     if (es == nullptr)

--- a/src/core/file_sys/romfs_factory.cpp
+++ b/src/core/file_sys/romfs_factory.cpp
@@ -48,7 +48,7 @@ ResultVal<VirtualFile> RomFSFactory::Open(u64 title_id, StorageId storage, Conte
 
     switch (storage) {
     case StorageId::None:
-        res = Service::FileSystem::GetUnionContents()->GetEntry(title_id, type);
+        res = Service::FileSystem::GetUnionContents().GetEntry(title_id, type);
         break;
     case StorageId::NandSystem:
         res = Service::FileSystem::GetSystemNANDContents()->GetEntry(title_id, type);

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -32,14 +32,14 @@ static std::vector<u64> AccumulateAOCTitleIDs() {
     std::vector<u64> add_on_content;
     const auto rcu = FileSystem::GetUnionContents();
     const auto list =
-        rcu->ListEntriesFilter(FileSys::TitleType::AOC, FileSys::ContentRecordType::Data);
+        rcu.ListEntriesFilter(FileSys::TitleType::AOC, FileSys::ContentRecordType::Data);
     std::transform(list.begin(), list.end(), std::back_inserter(add_on_content),
                    [](const FileSys::RegisteredCacheEntry& rce) { return rce.title_id; });
     add_on_content.erase(
         std::remove_if(
             add_on_content.begin(), add_on_content.end(),
             [&rcu](u64 tid) {
-                return rcu->GetEntry(tid, FileSys::ContentRecordType::Data)->GetStatus() !=
+                return rcu.GetEntry(tid, FileSys::ContentRecordType::Data)->GetStatus() !=
                        Loader::ResultStatus::Success;
             }),
         add_on_content.end());

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -329,20 +329,9 @@ ResultVal<FileSys::VirtualDir> OpenSDMC() {
     return sdmc_factory->Open();
 }
 
-std::shared_ptr<FileSys::RegisteredCacheUnion> registered_cache_union;
-
-std::shared_ptr<FileSys::RegisteredCacheUnion> GetUnionContents() {
-    if (registered_cache_union == nullptr) {
-        registered_cache_union =
-            std::make_shared<FileSys::RegisteredCacheUnion>(std::vector<FileSys::RegisteredCache*>{
-                GetSystemNANDContents(), GetUserNANDContents(), GetSDMCContents()});
-    }
-
-    return registered_cache_union;
-}
-
-void ClearUnionContents() {
-    registered_cache_union = nullptr;
+FileSys::RegisteredCacheUnion GetUnionContents() {
+    return FileSys::RegisteredCacheUnion{
+        {GetSystemNANDContents(), GetUserNANDContents(), GetSDMCContents()}};
 }
 
 FileSys::RegisteredCache* GetSystemNANDContents() {
@@ -395,7 +384,6 @@ void CreateFactories(FileSys::VfsFilesystem& vfs, bool overwrite) {
         bis_factory = nullptr;
         save_data_factory = nullptr;
         sdmc_factory = nullptr;
-        ClearUnionContents();
     }
 
     auto nand_directory = vfs.OpenDirectory(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir),

--- a/src/core/hle/service/filesystem/filesystem.h
+++ b/src/core/hle/service/filesystem/filesystem.h
@@ -48,8 +48,7 @@ ResultVal<FileSys::VirtualDir> OpenSaveData(FileSys::SaveDataSpaceId space,
 ResultVal<FileSys::VirtualDir> OpenSaveDataSpace(FileSys::SaveDataSpaceId space);
 ResultVal<FileSys::VirtualDir> OpenSDMC();
 
-std::shared_ptr<FileSys::RegisteredCacheUnion> GetUnionContents();
-void ClearUnionContents();
+FileSys::RegisteredCacheUnion GetUnionContents();
 
 FileSys::RegisteredCache* GetSystemNANDContents();
 FileSys::RegisteredCache* GetUserNANDContents();

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -97,11 +97,11 @@ GameListWorker::~GameListWorker() = default;
 
 void GameListWorker::AddInstalledTitlesToGameList() {
     const auto cache = Service::FileSystem::GetUnionContents();
-    const auto installed_games = cache->ListEntriesFilter(FileSys::TitleType::Application,
-                                                          FileSys::ContentRecordType::Program);
+    const auto installed_games = cache.ListEntriesFilter(FileSys::TitleType::Application,
+                                                         FileSys::ContentRecordType::Program);
 
     for (const auto& game : installed_games) {
-        const auto file = cache->GetEntryUnparsed(game);
+        const auto file = cache.GetEntryUnparsed(game);
         std::unique_ptr<Loader::AppLoader> loader = Loader::GetLoader(file);
         if (!loader)
             continue;
@@ -112,7 +112,7 @@ void GameListWorker::AddInstalledTitlesToGameList() {
         loader->ReadProgramId(program_id);
 
         const FileSys::PatchManager patch{program_id};
-        const auto control = cache->GetEntry(game.title_id, FileSys::ContentRecordType::Control);
+        const auto control = cache.GetEntry(game.title_id, FileSys::ContentRecordType::Control);
         if (control != nullptr)
             GetMetadataFromControlNCA(patch, *control, icon, name);
 
@@ -141,11 +141,11 @@ void GameListWorker::AddInstalledTitlesToGameList() {
         emit EntryReady(list);
     }
 
-    const auto control_data = cache->ListEntriesFilter(FileSys::TitleType::Application,
-                                                       FileSys::ContentRecordType::Control);
+    const auto control_data = cache.ListEntriesFilter(FileSys::TitleType::Application,
+                                                      FileSys::ContentRecordType::Control);
 
     for (const auto& entry : control_data) {
-        auto nca = cache->GetEntry(entry);
+        auto nca = cache.GetEntry(entry);
         if (nca != nullptr) {
             nca_control_map.insert_or_assign(entry.title_id, std::move(nca));
         }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -905,7 +905,7 @@ void GMainWindow::OnGameListDumpRomFS(u64 program_id, const std::string& game_pa
     }
 
     const auto installed = Service::FileSystem::GetUnionContents();
-    auto romfs_title_id = SelectRomFSDumpTarget(*installed, program_id);
+    const auto romfs_title_id = SelectRomFSDumpTarget(installed, program_id);
 
     if (!romfs_title_id) {
         failed();
@@ -920,7 +920,7 @@ void GMainWindow::OnGameListDumpRomFS(u64 program_id, const std::string& game_pa
     if (*romfs_title_id == program_id) {
         romfs = file;
     } else {
-        romfs = installed->GetEntry(*romfs_title_id, FileSys::ContentRecordType::Data)->GetRomFS();
+        romfs = installed.GetEntry(*romfs_title_id, FileSys::ContentRecordType::Data)->GetRomFS();
     }
 
     const auto extracted = FileSys::ExtractRomFS(romfs, FileSys::RomFSExtractionType::Full);


### PR DESCRIPTION
We can just return a new instance of this when it's requested. This only ever holds pointers to the existing registed caches, so it's not a large object. Plus, this also gets rid of the need to keep around a separate member function just to properly clear out the union.

Gets rid of one of five globals in the filesystem code.