### PR TITLE
yuzu/game_list_worker: Minor cleanup and code deduplication

### DIFF
--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -163,13 +163,12 @@ void GameListWorker::AddInstalledTitlesToGameList() {
 void GameListWorker::FillControlMap(const std::string& dir_path) {
     const auto nca_control_callback = [this](u64* num_entries_out, const std::string& directory,
                                              const std::string& virtual_name) -> bool {
-        const std::string physical_name = directory + DIR_SEP + virtual_name;
-
         if (stop_processing) {
             // Breaks the callback loop
             return false;
         }
 
+        const std::string physical_name = directory + DIR_SEP + virtual_name;
         const QFileInfo file_info(QString::fromStdString(physical_name));
         if (!file_info.isDir() && file_info.suffix() == QStringLiteral("nca")) {
             auto nca =
@@ -188,12 +187,13 @@ void GameListWorker::FillControlMap(const std::string& dir_path) {
 void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsigned int recursion) {
     const auto callback = [this, recursion](u64* num_entries_out, const std::string& directory,
                                             const std::string& virtual_name) -> bool {
-        std::string physical_name = directory + DIR_SEP + virtual_name;
+        if (stop_processing) {
+            // Breaks the callback loop.
+            return false;
+        }
 
-        if (stop_processing)
-            return false; // Breaks the callback loop.
-
-        bool is_dir = FileUtil::IsDirectory(physical_name);
+        const std::string physical_name = directory + DIR_SEP + virtual_name;
+        const bool is_dir = FileUtil::IsDirectory(physical_name);
         if (!is_dir &&
             (HasSupportedFileExtension(physical_name) || IsExtractedNCAMain(physical_name))) {
             std::unique_ptr<Loader::AppLoader> loader =

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -155,14 +155,15 @@ void GameListWorker::AddInstalledTitlesToGameList() {
 void GameListWorker::FillControlMap(const std::string& dir_path) {
     const auto nca_control_callback = [this](u64* num_entries_out, const std::string& directory,
                                              const std::string& virtual_name) -> bool {
-        std::string physical_name = directory + DIR_SEP + virtual_name;
+        const std::string physical_name = directory + DIR_SEP + virtual_name;
 
-        if (stop_processing)
-            return false; // Breaks the callback loop.
+        if (stop_processing) {
+            // Breaks the callback loop
+            return false;
+        }
 
-        bool is_dir = FileUtil::IsDirectory(physical_name);
-        QFileInfo file_info(physical_name.c_str());
-        if (!is_dir && file_info.suffix().toStdString() == "nca") {
+        const QFileInfo file_info(QString::fromStdString(physical_name));
+        if (!file_info.isDir() && file_info.suffix() == QStringLiteral("nca")) {
             auto nca =
                 std::make_unique<FileSys::NCA>(vfs->OpenFile(physical_name, FileSys::Mode::Read));
             if (nca->GetType() == FileSys::NCAContentType::Control) {


### PR DESCRIPTION
Cleans up string usage in FillControlMap() and moves the creation of game list entries to its own function to get rid of code being duplicated twice.