### PR TITLE
service/audio/audout_u: Amend constructor initialization list order

### DIFF
--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -46,8 +46,8 @@ class IAudioOut final : public ServiceFramework<IAudioOut> {
 public:
     IAudioOut(AudoutParams audio_params, AudioCore::AudioOut& audio_core, std::string&& device_name,
               std::string&& unique_name)
-        : ServiceFramework("IAudioOut"), audio_core(audio_core), audio_params(audio_params),
-          device_name(std::move(device_name)) {
+        : ServiceFramework("IAudioOut"), audio_core(audio_core),
+          device_name(std::move(device_name)), audio_params(audio_params) {
 
         static const FunctionInfo functions[] = {
             {0, &IAudioOut::GetAudioOutState, "GetAudioOutState"},


### PR DESCRIPTION
Orders the constructor initializer list the same way the members of the class are declared. Prevents -Wreorder warnings