### PR TITLE
svc: Reorganize svcGetInfo, handle more error cases for existing implemented info categories

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -705,7 +705,8 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
             return ERR_INVALID_ENUM_VALUE;
         }
 
-        const auto* process = Core::CurrentProcess();
+        const auto& current_process_handle_table = Core::CurrentProcess()->GetHandleTable();
+        const auto process = current_process_handle_table.Get<Process>(static_cast<Handle>(handle));
         if (!process) {
             return ERR_INVALID_HANDLE;
         }


### PR DESCRIPTION
Makes the behaviour for implemented info categories more closely match how the kernel itself handles it. This also fixes a minor bug with how the process instance was being retrieved. We weren't going through the handle table when we should have been. See the second commit message for a more in-depth explanation about that.