### PR TITLE
yuzu/configuration: Minor clean-up related changes

### DIFF
--- a/src/yuzu/configuration/configure_audio.h
+++ b/src/yuzu/configuration/configure_audio.h
@@ -21,10 +21,9 @@ public:
     void applyConfiguration();
     void retranslateUi();
 
-public slots:
+private:
     void updateAudioDevices(int sink_index);
 
-private:
     void setConfiguration();
     void setOutputSinkFromSinkID();
     void setAudioDeviceFromDeviceID();

--- a/src/yuzu/configuration/configure_audio.h
+++ b/src/yuzu/configuration/configure_audio.h
@@ -16,7 +16,7 @@ class ConfigureAudio : public QWidget {
 
 public:
     explicit ConfigureAudio(QWidget* parent = nullptr);
-    ~ConfigureAudio();
+    ~ConfigureAudio() override;
 
     void applyConfiguration();
     void retranslateUi();

--- a/src/yuzu/configuration/configure_debug.h
+++ b/src/yuzu/configuration/configure_debug.h
@@ -16,7 +16,7 @@ class ConfigureDebug : public QWidget {
 
 public:
     explicit ConfigureDebug(QWidget* parent = nullptr);
-    ~ConfigureDebug();
+    ~ConfigureDebug() override;
 
     void applyConfiguration();
 

--- a/src/yuzu/configuration/configure_debug.h
+++ b/src/yuzu/configuration/configure_debug.h
@@ -23,6 +23,5 @@ public:
 private:
     void setConfiguration();
 
-private:
     std::unique_ptr<Ui::ConfigureDebug> ui;
 };

--- a/src/yuzu/configuration/configure_dialog.h
+++ b/src/yuzu/configuration/configure_dialog.h
@@ -18,7 +18,7 @@ class ConfigureDialog : public QDialog {
 
 public:
     explicit ConfigureDialog(QWidget* parent, const HotkeyRegistry& registry);
-    ~ConfigureDialog();
+    ~ConfigureDialog() override;
 
     void applyConfiguration();
 

--- a/src/yuzu/configuration/configure_dialog.h
+++ b/src/yuzu/configuration/configure_dialog.h
@@ -25,6 +25,5 @@ public:
 private:
     void setConfiguration();
 
-private:
     std::unique_ptr<Ui::ConfigureDialog> ui;
 };

--- a/src/yuzu/configuration/configure_gamelist.h
+++ b/src/yuzu/configuration/configure_gamelist.h
@@ -16,7 +16,7 @@ class ConfigureGameList : public QWidget {
 
 public:
     explicit ConfigureGameList(QWidget* parent = nullptr);
-    ~ConfigureGameList();
+    ~ConfigureGameList() override;
 
     void applyConfiguration();
 

--- a/src/yuzu/configuration/configure_general.h
+++ b/src/yuzu/configuration/configure_general.h
@@ -18,7 +18,7 @@ class ConfigureGeneral : public QWidget {
 
 public:
     explicit ConfigureGeneral(QWidget* parent = nullptr);
-    ~ConfigureGeneral();
+    ~ConfigureGeneral() override;
 
     void PopulateHotkeyList(const HotkeyRegistry& registry);
     void applyConfiguration();

--- a/src/yuzu/configuration/configure_graphics.h
+++ b/src/yuzu/configuration/configure_graphics.h
@@ -16,7 +16,7 @@ class ConfigureGraphics : public QWidget {
 
 public:
     explicit ConfigureGraphics(QWidget* parent = nullptr);
-    ~ConfigureGraphics();
+    ~ConfigureGraphics() override;
 
     void applyConfiguration();
 

--- a/src/yuzu/configuration/configure_graphics.h
+++ b/src/yuzu/configuration/configure_graphics.h
@@ -23,7 +23,6 @@ public:
 private:
     void setConfiguration();
 
-private:
     std::unique_ptr<Ui::ConfigureGraphics> ui;
     QColor bg_color;
 };

--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -88,6 +88,8 @@ ConfigureInput::ConfigureInput(QWidget* parent)
             [this] { CallConfigureDialog<ConfigureTouchscreenAdvanced>(*this); });
 }
 
+ConfigureInput::~ConfigureInput() = default;
+
 void ConfigureInput::OnDockedModeChanged(bool last_state, bool new_state) {
     if (ui->use_docked_mode->isChecked() && ui->handheld_connected->isChecked()) {
         ui->handheld_connected->setChecked(false);

--- a/src/yuzu/configuration/configure_input.h
+++ b/src/yuzu/configuration/configure_input.h
@@ -25,6 +25,7 @@ class ConfigureInput : public QWidget {
 
 public:
     explicit ConfigureInput(QWidget* parent = nullptr);
+    ~ConfigureInput() override;
 
     /// Save all button configurations to settings file
     void applyConfiguration();

--- a/src/yuzu/configuration/configure_web.h
+++ b/src/yuzu/configuration/configure_web.h
@@ -22,13 +22,12 @@ public:
     void applyConfiguration();
     void retranslateUi();
 
-public slots:
+private:
     void RefreshTelemetryID();
     void OnLoginChanged();
     void VerifyLogin();
     void OnLoginVerified();
 
-private:
     void setConfiguration();
 
     bool user_verified = true;

--- a/src/yuzu/configuration/configure_web.h
+++ b/src/yuzu/configuration/configure_web.h
@@ -17,7 +17,7 @@ class ConfigureWeb : public QWidget {
 
 public:
     explicit ConfigureWeb(QWidget* parent = nullptr);
-    ~ConfigureWeb();
+    ~ConfigureWeb() override;
 
     void applyConfiguration();
     void retranslateUi();


### PR DESCRIPTION
Narrows the visible scope of functions, remove redundant uses of the private access specifier, and gets rid of a case where a compilation failure could potentially occur.