### PR TITLE
file_sys/directory: Amend path buffer size for directory entries

### DIFF
--- a/src/core/file_sys/directory.h
+++ b/src/core/file_sys/directory.h
@@ -29,8 +29,8 @@ struct Entry {
         filename[copy_size] = '\0';
     }
 
-    char filename[0x300];
-    INSERT_PADDING_BYTES(4);
+    char filename[0x301];
+    INSERT_PADDING_BYTES(3);
     EntryType type;
     INSERT_PADDING_BYTES(3);
     u64 file_size;


### PR DESCRIPTION
The path buffer is actually 0x301 (769) characters in length, with the extra character being intended for the null-terminator.