### PR TITLE
svc: Implement SetThreadActivity (thread suspension)

### DIFF
--- a/src/core/hle/kernel/errors.h
+++ b/src/core/hle/kernel/errors.h
@@ -27,7 +27,7 @@ constexpr ResultCode ERR_SYNCHRONIZATION_CANCELED{ErrorModule::Kernel, 118};
 constexpr ResultCode ERR_OUT_OF_RANGE{ErrorModule::Kernel, 119};
 constexpr ResultCode ERR_INVALID_ENUM_VALUE{ErrorModule::Kernel, 120};
 constexpr ResultCode ERR_NOT_FOUND{ErrorModule::Kernel, 121};
-constexpr ResultCode ERR_ALREADY_REGISTERED{ErrorModule::Kernel, 122};
+constexpr ResultCode ERR_BUSY{ErrorModule::Kernel, 122};
 constexpr ResultCode ERR_SESSION_CLOSED_BY_REMOTE{ErrorModule::Kernel, 123};
 constexpr ResultCode ERR_INVALID_STATE{ErrorModule::Kernel, 125};
 constexpr ResultCode ERR_RESOURCE_LIMIT_EXCEEDED{ErrorModule::Kernel, 132};

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -50,7 +50,7 @@ void Thread::Stop() {
 
     // Clean up thread from ready queue
     // This is only needed when the thread is terminated forcefully (SVC TerminateProcess)
-    if (status == ThreadStatus::Ready) {
+    if (status == ThreadStatus::Ready || status == ThreadStatus::Paused) {
         scheduler->UnscheduleThread(this, current_priority);
     }
 
@@ -139,6 +139,11 @@ void Thread::ResumeFromWait() {
     }
 
     wakeup_callback = nullptr;
+
+    if (activity == ThreadActivity::Paused) {
+        status = ThreadStatus::Paused;
+        return;
+    }
 
     status = ThreadStatus::Ready;
 
@@ -386,6 +391,23 @@ bool Thread::InvokeWakeupCallback(ThreadWakeupReason reason, SharedPtr<Thread> t
                                   SharedPtr<WaitObject> object, std::size_t index) {
     ASSERT(wakeup_callback);
     return wakeup_callback(reason, std::move(thread), std::move(object), index);
+}
+
+void Thread::SetActivity(ThreadActivity value) {
+    activity = value;
+
+    if (value == ThreadActivity::Paused) {
+        // Set status if not waiting
+        if (status == ThreadStatus::Ready) {
+            status = ThreadStatus::Paused;
+        } else if (status == ThreadStatus::Running) {
+            status = ThreadStatus::Paused;
+            Core::System::GetInstance().CpuCore(processor_id).PrepareReschedule();
+        }
+    } else if (status == ThreadStatus::Paused) {
+        // Ready to reschedule
+        ResumeFromWait();
+    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -44,6 +44,7 @@ enum ThreadProcessorId : s32 {
 enum class ThreadStatus {
     Running,      ///< Currently running
     Ready,        ///< Ready to run
+    Paused,       ///< Paused by SetThreadActivity or debug
     WaitHLEEvent, ///< Waiting for hle event to finish
     WaitSleep,    ///< Waiting due to a SleepThread SVC
     WaitIPC,      ///< Waiting for the reply from an IPC request
@@ -58,6 +59,11 @@ enum class ThreadStatus {
 enum class ThreadWakeupReason {
     Signal, // The thread was woken up by WakeupAllWaitingThreads due to an object signal.
     Timeout // The thread was woken up due to a wait timeout.
+};
+
+enum class ThreadActivity : u32 {
+    Normal = 0,
+    Paused = 1,
 };
 
 class Thread final : public WaitObject {
@@ -370,6 +376,12 @@ public:
         return affinity_mask;
     }
 
+    ThreadActivity GetActivity() const {
+        return activity;
+    }
+
+    void SetActivity(ThreadActivity value);
+
 private:
     explicit Thread(KernelCore& kernel);
     ~Thread() override;
@@ -438,6 +450,8 @@ private:
     TLSMemoryPtr tls_memory = std::make_shared<TLSMemory>();
 
     std::string name;
+
+    ThreadActivity activity = ThreadActivity::Normal;
 };
 
 /**

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -264,8 +264,9 @@ QColor WaitTreeThread::GetColor() const {
     case Kernel::ThreadStatus::Running:
         return QColor(Qt::GlobalColor::darkGreen);
     case Kernel::ThreadStatus::Ready:
-    case Kernel::ThreadStatus::Paused:
         return QColor(Qt::GlobalColor::darkBlue);
+    case Kernel::ThreadStatus::Paused:
+        return QColor(Qt::GlobalColor::lightGray);
     case Kernel::ThreadStatus::WaitHLEEvent:
     case Kernel::ThreadStatus::WaitIPC:
         return QColor(Qt::GlobalColor::darkRed);

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -221,6 +221,9 @@ QString WaitTreeThread::GetText() const {
     case Kernel::ThreadStatus::Ready:
         status = tr("ready");
         break;
+    case Kernel::ThreadStatus::Paused:
+        status = tr("paused");
+        break;
     case Kernel::ThreadStatus::WaitHLEEvent:
         status = tr("waiting for HLE return");
         break;
@@ -261,6 +264,7 @@ QColor WaitTreeThread::GetColor() const {
     case Kernel::ThreadStatus::Running:
         return QColor(Qt::GlobalColor::darkGreen);
     case Kernel::ThreadStatus::Ready:
+    case Kernel::ThreadStatus::Paused:
         return QColor(Qt::GlobalColor::darkBlue);
     case Kernel::ThreadStatus::WaitHLEEvent:
     case Kernel::ThreadStatus::WaitIPC:


### PR DESCRIPTION
Implementation of SetThreadActivity.

Adds a new `Paused` thread status, which is essentially `Ready` but with `activity == 1`.
Allows waits to complete before entering `Paused` status.
Permits threads to be paused before started.

Emulator behavior matches console in my test application.