### PR TITLE
 kernel/svc: Implement the resource limit svcGetInfo option

### DIFF
--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -42,9 +42,10 @@ ResultVal<Handle> HandleTable::Create(SharedPtr<Object> obj) {
     u16 generation = next_generation++;
 
     // Overflow count so it fits in the 15 bits dedicated to the generation in the handle.
-    // CTR-OS doesn't use generation 0, so skip straight to 1.
-    if (next_generation >= (1 << 15))
+    // Horizon OS uses zero to represent an invalid handle, so skip to 1.
+    if (next_generation >= (1 << 15)) {
         next_generation = 1;
+    }
 
     generations[slot] = generation;
     objects[slot] = std::move(obj);

--- a/src/core/hle/kernel/handle_table.h
+++ b/src/core/hle/kernel/handle_table.h
@@ -13,6 +13,7 @@
 namespace Kernel {
 
 enum KernelHandle : Handle {
+    InvalidHandle = 0,
     CurrentThread = 0xFFFF8000,
     CurrentProcess = 0xFFFF8001,
 };

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -44,6 +44,10 @@ SharedPtr<Process> Process::Create(KernelCore& kernel, std::string&& name) {
     return process;
 }
 
+SharedPtr<ResourceLimit> Process::GetResourceLimit() const {
+    return resource_limit;
+}
+
 void Process::LoadFromMetadata(const FileSys::ProgramMetadata& metadata) {
     program_id = metadata.GetTitleID();
     is_64bit_process = metadata.Is64BitProgram();

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -171,14 +171,7 @@ public:
     }
 
     /// Gets the resource limit descriptor for this process
-    ResourceLimit& GetResourceLimit() {
-        return *resource_limit;
-    }
-
-    /// Gets the resource limit descriptor for this process
-    const ResourceLimit& GetResourceLimit() const {
-        return *resource_limit;
-    }
+    SharedPtr<ResourceLimit> GetResourceLimit() const;
 
     /// Gets the default CPU ID for this process
     u8 GetDefaultProcessorID() const {


### PR DESCRIPTION
Allows a process to register the resource limit as part of its handle table.