### PR TITLE
kernel/svc: Implement svcCreateEvent and svcSignalEvent

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1647,6 +1647,21 @@ static ResultCode ClearEvent(Handle handle) {
     return ERR_INVALID_HANDLE;
 }
 
+static ResultCode SignalEvent(Handle handle) {
+    LOG_DEBUG(Kernel_SVC, "called. Handle=0x{:08X}", handle);
+
+    HandleTable& handle_table = Core::CurrentProcess()->GetHandleTable();
+    auto writable_event = handle_table.Get<WritableEvent>(handle);
+
+    if (!writable_event) {
+        LOG_ERROR(Kernel_SVC, "Non-existent writable event handle used (0x{:08X})", handle);
+        return ERR_INVALID_HANDLE;
+    }
+
+    writable_event->Signal();
+    return RESULT_SUCCESS;
+}
+
 static ResultCode GetProcessInfo(u64* out, Handle process_handle, u32 type) {
     LOG_DEBUG(Kernel_SVC, "called, handle=0x{:08X}, type=0x{:X}", process_handle, type);
 
@@ -1782,7 +1797,7 @@ static const FunctionDef SVC_Table[] = {
     {0x0E, SvcWrap<GetThreadCoreMask>, "GetThreadCoreMask"},
     {0x0F, SvcWrap<SetThreadCoreMask>, "SetThreadCoreMask"},
     {0x10, SvcWrap<GetCurrentProcessorNumber>, "GetCurrentProcessorNumber"},
-    {0x11, nullptr, "SignalEvent"},
+    {0x11, SvcWrap<SignalEvent>, "SignalEvent"},
     {0x12, SvcWrap<ClearEvent>, "ClearEvent"},
     {0x13, SvcWrap<MapSharedMemory>, "MapSharedMemory"},
     {0x14, SvcWrap<UnmapSharedMemory>, "UnmapSharedMemory"},

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -35,7 +35,6 @@
 #include "core/hle/lock.h"
 #include "core/hle/result.h"
 #include "core/hle/service/service.h"
-#include "core/settings.h"
 
 namespace Kernel {
 namespace {

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -59,6 +59,19 @@ void SvcWrap() {
     FuncReturn(retval);
 }
 
+template <ResultCode func(u32*, u32*)>
+void SvcWrap() {
+    u32 param_1 = 0;
+    u32 param_2 = 0;
+    const u32 retval = func(&param_1, &param_2).raw;
+
+    auto& arm_interface = Core::CurrentArmInterface();
+    arm_interface.SetReg(1, param_1);
+    arm_interface.SetReg(2, param_2);
+
+    FuncReturn(retval);
+}
+
 template <ResultCode func(u32*, u64)>
 void SvcWrap() {
     u32 param_1 = 0;


### PR DESCRIPTION
Both are fairly trivial to implement, given the event types are now split up. With this, all of the central event functions that operate on ReadableEvent and WritableEvent are implemented

---

svcCreateEvent operates by creating both a readable and writable event and then attempts to add both to the current process' handle table. If adding either of the events to the handle table fails, then the relevant error from the handle table is returned. 

If adding the readable event after the writable event to the table fails, then the writable event is removed from the handle table and the relevant error from the handle table is returned.

---

svcSignalEvent simply does a handle table lookup for a writable event instance identified by the given handle value. If a writable event cannot be found for the given handle, then an invalid handle error is returned. If a writable event is found, then it simply signals the event, as one would expect.