### PR TITLE
gl_shader_decompiler: Implement TEXS.F16

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -1049,6 +1049,7 @@ union Instruction {
         BitField<49, 1, u64> nodep_flag;
         BitField<50, 3, u64> component_mask_selector;
         BitField<53, 4, u64> texture_info;
+        BitField<60, 1, u64> fp32_flag;
 
         TextureType GetTextureType() const {
             // The TEXS instruction has a weird encoding for the texture type.
@@ -1549,7 +1550,7 @@ private:
             INST("1110111011011---", Id::STG, Type::Memory, "STG"),
             INST("110000----111---", Id::TEX, Type::Memory, "TEX"),
             INST("1101111101001---", Id::TXQ, Type::Memory, "TXQ"),
-            INST("1101100---------", Id::TEXS, Type::Memory, "TEXS"),
+            INST("1101-00---------", Id::TEXS, Type::Memory, "TEXS"),
             INST("1101101---------", Id::TLDS, Type::Memory, "TLDS"),
             INST("110010----111---", Id::TLD4, Type::Memory, "TLD4"),
             INST("1101111100------", Id::TLD4S, Type::Memory, "TLD4S"),

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -2766,22 +2766,21 @@ private:
                 const bool depth_compare =
                     instr.texs.UsesMiscMode(Tegra::Shader::TextureMiscMode::DC);
                 const auto process_mode = instr.texs.GetTextureProcessMode();
+
                 UNIMPLEMENTED_IF_MSG(instr.texs.UsesMiscMode(Tegra::Shader::TextureMiscMode::NODEP),
                                      "NODEP is not implemented");
 
                 const auto scope = shader.Scope();
 
-                const auto [coord, texture] =
+                auto [coord, texture] =
                     GetTEXSCode(instr, texture_type, process_mode, depth_compare, is_array);
 
                 shader.AddLine(coord);
 
-                if (!depth_compare) {
-                    shader.AddLine("vec4 texture_tmp = " + texture + ';');
-
-                } else {
-                    shader.AddLine("vec4 texture_tmp = vec4(" + texture + ");");
+                if (depth_compare) {
+                    texture = "vec4(" + texture + ')';
                 }
+                shader.AddLine("vec4 texture_tmp = " + texture + ';');
 
                 WriteTexsInstruction(instr, "texture_tmp");
                 break;


### PR DESCRIPTION
Implements `F16` variant for `TEXS`. It was hidden in bit 60 (0 is `F16` and 1 is `F32`), values are returned in packs like the other H* instructions.
* Used by Undertale
(and some other OpenGL ES games)