### PR TITLE
 system_archive: Use a regular function pointer instead of std::function for the file-scope system archive array

### DIFF
--- a/src/core/file_sys/system_archive/ng_word.cpp
+++ b/src/core/file_sys/system_archive/ng_word.cpp
@@ -26,7 +26,7 @@ constexpr std::array<u8, 30> WORD_TXT{
 VirtualDir NgWord1() {
     std::vector<VirtualFile> files(NgWord1Data::NUMBER_WORD_TXT_FILES);
 
-    for (std::size_t i = 0; i < NgWord1Data::NUMBER_WORD_TXT_FILES; ++i) {
+    for (std::size_t i = 0; i < files.size(); ++i) {
         files[i] = std::make_shared<ArrayVfsFile<NgWord1Data::WORD_TXT.size()>>(
             NgWord1Data::WORD_TXT, fmt::format("{}.txt", i));
     }

--- a/src/core/file_sys/system_archive/system_archive.cpp
+++ b/src/core/file_sys/system_archive/system_archive.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <functional>
 #include "common/logging/log.h"
 #include "core/file_sys/romfs.h"
 #include "core/file_sys/system_archive/ng_word.h"
@@ -13,7 +12,7 @@ namespace FileSys::SystemArchive {
 constexpr u64 SYSTEM_ARCHIVE_BASE_TITLE_ID = 0x0100000000000800;
 constexpr std::size_t SYSTEM_ARCHIVE_COUNT = 0x28;
 
-using SystemArchiveSupplier = std::function<VirtualDir()>;
+using SystemArchiveSupplier = VirtualDir (*)();
 
 struct SystemArchiveDescriptor {
     u64 title_id;
@@ -21,7 +20,7 @@ struct SystemArchiveDescriptor {
     SystemArchiveSupplier supplier;
 };
 
-const std::array<SystemArchiveDescriptor, SYSTEM_ARCHIVE_COUNT> SYSTEM_ARCHIVES = {{
+constexpr std::array<SystemArchiveDescriptor, SYSTEM_ARCHIVE_COUNT> SYSTEM_ARCHIVES{{
     {0x0100000000000800, "CertStore", nullptr},
     {0x0100000000000801, "ErrorMessage", nullptr},
     {0x0100000000000802, "MiiModel", nullptr},


### PR DESCRIPTION
This allows the array to be constexpr. std::function is also allowed to allocate memory, which makes its constructor non-trivial, we definitely don't want to have all of these execute at runtime, taking up time before the application can actually load.