### PR TITLE
Perf: Call shrink_to_fit after page-table vector resizing to actually reduce vector capacity

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -53,6 +53,14 @@ void PageTable::Resize(std::size_t address_space_width_in_bits) {
 
     pointers.resize(num_page_table_entries);
     attributes.resize(num_page_table_entries);
+
+    // The default is a 39-bit address space, which causes an initial 1GB allocation size. If the
+    // vector size is subsequently decreased (via resize), the vector might not automatically
+    // actually reallocate/resize its underlying allocation, which wastes up to ~800 MB for
+    // 36-bit titles. Call shrink_to_fit to reduce capacity to what's actually in use.
+
+    pointers.shrink_to_fit();
+    attributes.shrink_to_fit();
 }
 
 static void MapPages(PageTable& page_table, VAddr base, u64 size, u8* memory, PageType type) {


### PR DESCRIPTION
When Yuzu loads a title, it defaults to assuming a 39-bit address space (before loading title metadata). This causes roughly 1 GB in allocations for VMManager's page-table vectors.

For a 36-bit title (such as BOTW), VMManager does resize the vectors to the lower size (~128MB), but the uCRT at least isn't actually lowering the vectors' capacity - the 800 MB is still committed.

This change just adds std::vector::shrink_to_fit calls after the resizes, which successfully frees the space in my testing. This would invalidate any references to the vector data, but in the event of a Resize I don't think (?) there should be any.

This does lower memory usage in steady-state in BOTW by ~800 MB as seen through task manager. Another approach would be to default to a 36-bit address space (though a comment references 39-bit as sane for metadata-less titles), or refactoring to read title metadata before system initialization, but this is certainly the least-invasive change.