### PR TITLE
yuzu/wait_tree: Pass QString by value and std::move in the initializer list for WaitTreeText

### DIFF
--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -75,7 +75,7 @@ std::vector<std::unique_ptr<WaitTreeThread>> WaitTreeItem::MakeThreadItemList() 
     return item_list;
 }
 
-WaitTreeText::WaitTreeText(const QString& t) : text(t) {}
+WaitTreeText::WaitTreeText(QString t) : text(std::move(t)) {}
 WaitTreeText::~WaitTreeText() = default;
 
 QString WaitTreeText::GetText() const {

--- a/src/yuzu/debugger/wait_tree.h
+++ b/src/yuzu/debugger/wait_tree.h
@@ -52,7 +52,7 @@ private:
 class WaitTreeText : public WaitTreeItem {
     Q_OBJECT
 public:
-    explicit WaitTreeText(const QString& text);
+    explicit WaitTreeText(QString text);
     ~WaitTreeText() override;
 
     QString GetText() const override;


### PR DESCRIPTION
Just a trivial modernization that potentially avoids copying strings in certain scenarios