### PR TITLE
kernel/process: Set ideal core from metadata

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -50,6 +50,7 @@ SharedPtr<ResourceLimit> Process::GetResourceLimit() const {
 
 void Process::LoadFromMetadata(const FileSys::ProgramMetadata& metadata) {
     program_id = metadata.GetTitleID();
+    ideal_processor = metadata.GetMainThreadCore();
     is_64bit_process = metadata.Is64BitProgram();
     vm_manager.Reset(metadata.GetAddressSpaceType());
 }


### PR DESCRIPTION
A very trivial change. If metadata is available, the process should use it to retrieve the desired core for the process to run on.