### PR TITLE
loaders: Make GetFileType() a const qualified member function

### DIFF
--- a/src/core/loader/deconstructed_rom_directory.h
+++ b/src/core/loader/deconstructed_rom_directory.h
@@ -33,7 +33,7 @@ public:
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);
 
-    FileType GetFileType() override {
+    FileType GetFileType() const override {
         return IdentifyType(file);
     }
 

--- a/src/core/loader/elf.h
+++ b/src/core/loader/elf.h
@@ -22,7 +22,7 @@ public:
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);
 
-    FileType GetFileType() override {
+    FileType GetFileType() const override {
         return IdentifyType(file);
     }
 

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -131,7 +131,7 @@ public:
      * Returns the type of this file
      * @return FileType corresponding to the loaded file
      */
-    virtual FileType GetFileType() = 0;
+    virtual FileType GetFileType() const = 0;
 
     /**
      * Load the application and return the created Process instance

--- a/src/core/loader/nax.cpp
+++ b/src/core/loader/nax.cpp
@@ -37,7 +37,7 @@ FileType AppLoader_NAX::IdentifyType(const FileSys::VirtualFile& file) {
     return IdentifyTypeImpl(nax);
 }
 
-FileType AppLoader_NAX::GetFileType() {
+FileType AppLoader_NAX::GetFileType() const {
     return IdentifyTypeImpl(*nax);
 }
 

--- a/src/core/loader/nax.h
+++ b/src/core/loader/nax.h
@@ -31,7 +31,7 @@ public:
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);
 
-    FileType GetFileType() override;
+    FileType GetFileType() const override;
 
     ResultStatus Load(Kernel::Process& process) override;
 

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -29,7 +29,7 @@ public:
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);
 
-    FileType GetFileType() override {
+    FileType GetFileType() const override {
         return IdentifyType(file);
     }
 

--- a/src/core/loader/nro.h
+++ b/src/core/loader/nro.h
@@ -33,7 +33,7 @@ public:
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);
 
-    FileType GetFileType() override {
+    FileType GetFileType() const override {
         return IdentifyType(file);
     }
 

--- a/src/core/loader/nso.h
+++ b/src/core/loader/nso.h
@@ -37,7 +37,7 @@ public:
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);
 
-    FileType GetFileType() override {
+    FileType GetFileType() const override {
         return IdentifyType(file);
     }
 

--- a/src/core/loader/nsp.h
+++ b/src/core/loader/nsp.h
@@ -31,7 +31,7 @@ public:
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);
 
-    FileType GetFileType() override {
+    FileType GetFileType() const override {
         return IdentifyType(file);
     }
 

--- a/src/core/loader/xci.h
+++ b/src/core/loader/xci.h
@@ -31,7 +31,7 @@ public:
      */
     static FileType IdentifyType(const FileSys::VirtualFile& file);
 
-    FileType GetFileType() override {
+    FileType GetFileType() const override {
         return IdentifyType(file);
     }
 

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -99,12 +99,14 @@ QList<QStandardItem*> MakeGameListEntry(const std::string& path, const std::stri
         compatibility = it->second.first;
     }
 
+    const auto file_type = loader.GetFileType();
+    const auto file_type_string = QString::fromStdString(Loader::GetFileTypeString(file_type));
+
     QList<QStandardItem*> list{
-        new GameListItemPath(
-            FormatGameName(path), icon, QString::fromStdString(name),
-            QString::fromStdString(Loader::GetFileTypeString(loader.GetFileType())), program_id),
+        new GameListItemPath(FormatGameName(path), icon, QString::fromStdString(name),
+                             file_type_string, program_id),
         new GameListItemCompat(compatibility),
-        new GameListItem(QString::fromStdString(Loader::GetFileTypeString(loader.GetFileType()))),
+        new GameListItem(file_type_string),
         new GameListItemSize(FileUtil::GetSize(path)),
     };
 

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -198,12 +198,16 @@ void GameListWorker::AddFstEntriesToGameList(const std::string& dir_path, unsign
         const bool is_dir = FileUtil::IsDirectory(physical_name);
         if (!is_dir &&
             (HasSupportedFileExtension(physical_name) || IsExtractedNCAMain(physical_name))) {
-            std::unique_ptr<Loader::AppLoader> loader =
-                Loader::GetLoader(vfs->OpenFile(physical_name, FileSys::Mode::Read));
-            if (!loader || ((loader->GetFileType() == Loader::FileType::Unknown ||
-                             loader->GetFileType() == Loader::FileType::Error) &&
-                            !UISettings::values.show_unknown))
+            auto loader = Loader::GetLoader(vfs->OpenFile(physical_name, FileSys::Mode::Read));
+            if (!loader) {
                 return true;
+            }
+
+            const auto file_type = loader->GetFileType();
+            if ((file_type == Loader::FileType::Unknown || file_type == Loader::FileType::Error) &&
+                !UISettings::values.show_unknown) {
+                return true;
+            }
 
             std::vector<u8> icon;
             const auto res1 = loader->ReadIcon(icon);


### PR DESCRIPTION
No Loader implementations actually modify instance state via this function (and it would be questionable to do that in the first place given the name), so we can make this a const member function. While we're at it, this also gets rid of trivially removable duplicated calls to the function, given the backing operation for it isn't always trivial, reducing the amount of work done to simply display an entry in the game list