### PR TITLE
hle/service, hle/sm: Minor cleanup

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -110,9 +110,7 @@ void ServiceFrameworkBase::InstallAsNamedPort() {
     ASSERT(port == nullptr);
 
     auto& kernel = Core::System::GetInstance().Kernel();
-    SharedPtr<ServerPort> server_port;
-    SharedPtr<ClientPort> client_port;
-    std::tie(server_port, client_port) =
+    auto [server_port, client_port] =
         ServerPort::CreatePortPair(kernel, max_sessions, service_name);
     server_port->SetHleHandler(shared_from_this());
     kernel.AddNamedPort(service_name, std::move(client_port));
@@ -122,9 +120,7 @@ Kernel::SharedPtr<Kernel::ClientPort> ServiceFrameworkBase::CreatePort() {
     ASSERT(port == nullptr);
 
     auto& kernel = Core::System::GetInstance().Kernel();
-    Kernel::SharedPtr<Kernel::ServerPort> server_port;
-    Kernel::SharedPtr<Kernel::ClientPort> client_port;
-    std::tie(server_port, client_port) =
+    auto [server_port, client_port] =
         Kernel::ServerPort::CreatePortPair(kernel, max_sessions, service_name);
     port = MakeResult<Kernel::SharedPtr<Kernel::ServerPort>>(std::move(server_port)).Unwrap();
     port->SetHleHandler(shared_from_this());

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -144,8 +144,7 @@ void ServiceFrameworkBase::ReportUnimplementedFunction(Kernel::HLERequestContext
     }
     buf.push_back('}');
 
-    LOG_ERROR(Service, "unknown / unimplemented {}", fmt::to_string(buf));
-    UNIMPLEMENTED();
+    UNIMPLEMENTED_MSG("Unknown / unimplemented {}", fmt::to_string(buf));
 }
 
 void ServiceFrameworkBase::InvokeRequest(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -122,7 +122,7 @@ Kernel::SharedPtr<Kernel::ClientPort> ServiceFrameworkBase::CreatePort() {
     auto& kernel = Core::System::GetInstance().Kernel();
     auto [server_port, client_port] =
         Kernel::ServerPort::CreatePortPair(kernel, max_sessions, service_name);
-    port = MakeResult<Kernel::SharedPtr<Kernel::ServerPort>>(std::move(server_port)).Unwrap();
+    port = MakeResult(std::move(server_port)).Unwrap();
     port->SetHleHandler(shared_from_this());
     return client_port;
 }

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -70,10 +70,6 @@
 #include "core/hle/service/vi/vi.h"
 #include "core/hle/service/wlan/wlan.h"
 
-using Kernel::ClientPort;
-using Kernel::ServerPort;
-using Kernel::SharedPtr;
-
 namespace Service {
 
 /**
@@ -111,7 +107,7 @@ void ServiceFrameworkBase::InstallAsNamedPort() {
 
     auto& kernel = Core::System::GetInstance().Kernel();
     auto [server_port, client_port] =
-        ServerPort::CreatePortPair(kernel, max_sessions, service_name);
+        Kernel::ServerPort::CreatePortPair(kernel, max_sessions, service_name);
     server_port->SetHleHandler(shared_from_this());
     kernel.AddNamedPort(service_name, std::move(client_port));
 }

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -54,9 +54,7 @@ ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> ServiceManager::RegisterService
         return ERR_ALREADY_REGISTERED;
 
     auto& kernel = Core::System::GetInstance().Kernel();
-    Kernel::SharedPtr<Kernel::ServerPort> server_port;
-    Kernel::SharedPtr<Kernel::ClientPort> client_port;
-    std::tie(server_port, client_port) =
+    auto [server_port, client_port] =
         Kernel::ServerPort::CreatePortPair(kernel, max_sessions, name);
 
     registered_services.emplace(std::move(name), std::move(client_port));

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -58,7 +58,7 @@ ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> ServiceManager::RegisterService
         Kernel::ServerPort::CreatePortPair(kernel, max_sessions, name);
 
     registered_services.emplace(std::move(name), std::move(client_port));
-    return MakeResult<Kernel::SharedPtr<Kernel::ServerPort>>(std::move(server_port));
+    return MakeResult(std::move(server_port));
 }
 
 ResultCode ServiceManager::UnregisterService(const std::string& name) {
@@ -81,7 +81,7 @@ ResultVal<Kernel::SharedPtr<Kernel::ClientPort>> ServiceManager::GetServicePort(
         return ERR_SERVICE_NOT_REGISTERED;
     }
 
-    return MakeResult<Kernel::SharedPtr<Kernel::ClientPort>>(it->second);
+    return MakeResult(it->second);
 }
 
 ResultVal<Kernel::SharedPtr<Kernel::ClientSession>> ServiceManager::ConnectToService(


### PR DESCRIPTION
Tidies up the pre-C++17 code to use structured bindings where applicable and cleans up a few other minor things along the way.