### PR TITLE
system_archive: Implement open source NgWord2

### DIFF
--- a/src/core/file_sys/system_archive/ng_word.cpp
+++ b/src/core/file_sys/system_archive/ng_word.cpp
@@ -39,4 +39,43 @@ VirtualDir NgWord1() {
     return std::make_shared<VectorVfsDirectory>(files, std::vector<VirtualDir>{}, "data");
 }
 
+namespace NgWord2Data {
+
+constexpr std::size_t NUMBER_AC_NX_FILES = 0x10;
+
+// Should this archive replacement mysteriously not work on a future game, consider updating.
+constexpr std::array<u8, 4> VERSION_DAT{0x0, 0x0, 0x0, 0x15}; // 5.1.0 System Version
+
+constexpr std::array<u8, 0x2C> AC_NX_DATA{
+    0x1F, 0x8B, 0x08, 0x08, 0xD5, 0x2C, 0x09, 0x5C, 0x04, 0x00, 0x61, 0x63, 0x72, 0x61, 0x77,
+    0x00, 0xED, 0xC1, 0x01, 0x0D, 0x00, 0x00, 0x00, 0xC2, 0x20, 0xFB, 0xA7, 0xB6, 0xC7, 0x07,
+    0x0C, 0x00, 0x00, 0x00, 0xC8, 0x3B, 0x11, 0x00, 0x1C, 0xC7, 0x00, 0x10, 0x00, 0x00,
+}; // Deserializes to no bad words
+
+} // namespace NgWord2Data
+
+VirtualDir NgWord2() {
+    std::vector<VirtualFile> files(NgWord2Data::NUMBER_AC_NX_FILES * 3);
+
+    for (std::size_t i = 0; i < NgWord2Data::NUMBER_AC_NX_FILES; ++i) {
+        files[3 * i] = std::make_shared<ArrayVfsFile<NgWord2Data::AC_NX_DATA.size()>>(
+            NgWord2Data::AC_NX_DATA, fmt::format("ac_{}_b1_nx", i));
+        files[3 * i + 1] = std::make_shared<ArrayVfsFile<NgWord2Data::AC_NX_DATA.size()>>(
+            NgWord2Data::AC_NX_DATA, fmt::format("ac_{}_b2_nx", i));
+        files[3 * i + 2] = std::make_shared<ArrayVfsFile<NgWord2Data::AC_NX_DATA.size()>>(
+            NgWord2Data::AC_NX_DATA, fmt::format("ac_{}_not_b_nx", i));
+    }
+
+    files.push_back(std::make_shared<ArrayVfsFile<NgWord2Data::AC_NX_DATA.size()>>(
+        NgWord2Data::AC_NX_DATA, "ac_common_b1_nx"));
+    files.push_back(std::make_shared<ArrayVfsFile<NgWord2Data::AC_NX_DATA.size()>>(
+        NgWord2Data::AC_NX_DATA, "ac_common_b2_nx"));
+    files.push_back(std::make_shared<ArrayVfsFile<NgWord2Data::AC_NX_DATA.size()>>(
+        NgWord2Data::AC_NX_DATA, "ac_common_not_b_nx"));
+    files.push_back(std::make_shared<ArrayVfsFile<NgWord2Data::VERSION_DAT.size()>>(
+        NgWord2Data::VERSION_DAT, "version.dat"));
+
+    return std::make_shared<VectorVfsDirectory>(files, std::vector<VirtualDir>{}, "data");
+}
+
 } // namespace FileSys::SystemArchive

--- a/src/core/file_sys/system_archive/ng_word.h
+++ b/src/core/file_sys/system_archive/ng_word.h
@@ -9,5 +9,6 @@
 namespace FileSys::SystemArchive {
 
 VirtualDir NgWord1();
+VirtualDir NgWord2();
 
 } // namespace FileSys::SystemArchive

--- a/src/core/file_sys/system_archive/system_archive.cpp
+++ b/src/core/file_sys/system_archive/system_archive.cpp
@@ -56,7 +56,7 @@ constexpr std::array<SystemArchiveDescriptor, SYSTEM_ARCHIVE_COUNT> SYSTEM_ARCHI
     {0x0100000000000820, "PlatformConfigCopper", nullptr},
     {0x0100000000000821, "PlatformConfigHoag", nullptr},
     {0x0100000000000822, "ControllerFirmware", nullptr},
-    {0x0100000000000823, "NgWord2", nullptr},
+    {0x0100000000000823, "NgWord2", &NgWord2},
     {0x0100000000000824, "PlatformConfigIcosaMariko", nullptr},
     {0x0100000000000825, "ApplicationBlackList", nullptr},
     {0x0100000000000826, "RebootlessSystemUpdateVersion", nullptr},


### PR DESCRIPTION
This provides an open-source impl of system archive `0100000000000823`. This is used by Super Mario Party and Minecraft, as well as many other games. With this, the games will not `svcBreak` without a NAND and will impose no bad word restrictions (as the data provided deserializes to an empty list).