### PR TITLE
vm_manager: Make vma_map private

### DIFF
--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -39,15 +39,15 @@ SharedPtr<SharedMemory> SharedMemory::Create(KernelCore& kernel, SharedPtr<Proce
                 shared_memory->backing_block.get());
         }
     } else {
-        auto& vm_manager = shared_memory->owner_process->VMManager();
+        const auto& vm_manager = shared_memory->owner_process->VMManager();
 
         // The memory is already available and mapped in the owner process.
-        auto vma = vm_manager.FindVMA(address);
-        ASSERT_MSG(vma != vm_manager.vma_map.end(), "Invalid memory address");
+        const auto vma = vm_manager.FindVMA(address);
+        ASSERT_MSG(vm_manager.IsValidHandle(vma), "Invalid memory address");
         ASSERT_MSG(vma->second.backing_block, "Backing block doesn't exist for address");
 
         // The returned VMA might be a bigger one encompassing the desired address.
-        auto vma_offset = address - vma->first;
+        const auto vma_offset = address - vma->first;
         ASSERT_MSG(vma_offset + size <= vma->second.size,
                    "Shared memory exceeds bounds of mapped block");
 

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -87,6 +87,10 @@ VMManager::VMAHandle VMManager::FindVMA(VAddr target) const {
     }
 }
 
+bool VMManager::IsValidHandle(VMAHandle handle) const {
+    return handle != vma_map.cend();
+}
+
 ResultVal<VMManager::VMAHandle> VMManager::MapMemoryBlock(VAddr target,
                                                           std::shared_ptr<std::vector<u8>> block,
                                                           std::size_t offset, u64 size,

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -125,14 +125,13 @@ void RemoveDebugHook(PageTable& page_table, VAddr base, u64 size, MemoryHookPoin
  * using a VMA from the current process
  */
 static u8* GetPointerFromVMA(const Kernel::Process& process, VAddr vaddr) {
+    const auto& vm_manager = process.VMManager();
+
+    const auto it = vm_manager.FindVMA(vaddr);
+    ASSERT(vm_manager.IsValidHandle(it));
+
     u8* direct_pointer = nullptr;
-
-    auto& vm_manager = process.VMManager();
-
-    auto it = vm_manager.FindVMA(vaddr);
-    ASSERT(it != vm_manager.vma_map.end());
-
-    auto& vma = it->second;
+    const auto& vma = it->second;
     switch (vma.type) {
     case Kernel::VMAType::AllocatedMemoryBlock:
         direct_pointer = vma.backing_block->data() + vma.offset;

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -128,7 +128,7 @@ static u8* GetPointerFromVMA(const Kernel::Process& process, VAddr vaddr) {
     const auto& vm_manager = process.VMManager();
 
     const auto it = vm_manager.FindVMA(vaddr);
-    ASSERT(vm_manager.IsValidHandle(it));
+    DEBUG_ASSERT(vm_manager.IsValidHandle(it));
 
     u8* direct_pointer = nullptr;
     const auto& vma = it->second;


### PR DESCRIPTION
This was only ever public so that code could check whether or not a handle was valid. Instead of exposing the object directly and allowing external code to potentially mess with the map contents, we just provide a member function that allows checking whether or not a handle is valid.

This makes all member variables of the VMManager class except for the page table private.