### PR TITLE
Workaround for BOTW (and others?) deadlock on boot

### DIFF
--- a/src/core/hle/kernel/readable_event.cpp
+++ b/src/core/hle/kernel/readable_event.cpp
@@ -36,7 +36,8 @@ void ReadableEvent::Clear() {
 
 ResultCode ReadableEvent::Reset() {
     if (!signaled) {
-        return ERR_INVALID_STATE;
+        // Returning ERR_INVALID_STATE here causes downstream deadlocks, unclear why.
+        return RESULT_SUCCESS;
     }
 
     Clear();


### PR DESCRIPTION
The latest merges into canary result in a deadlock when booting BOTW at the least, looks caused by:

kernel/svc: Correct behavior of svcResetSignal() #1861
https://github.com/yuzu-emu/yuzu/pull/1861

This is a targeted workaround, I'm not sure why this fixes it or if the code is even in error (maybe this reveals another bug), but hopefully useful for merging into canary to unblock others.