### PR TITLE
Backport review comment from citra-emu/citra#4418

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -13,7 +13,7 @@
 #include <vector>
 #ifdef _WIN32
 #include <share.h>   // For _SH_DENYWR
-#include <windows.h> // For OutputDebugStringA
+#include <windows.h> // For OutputDebugStringW
 #else
 #define _SH_DENYWR 0
 #endif
@@ -148,7 +148,7 @@ void FileBackend::Write(const Entry& entry) {
 
 void DebuggerBackend::Write(const Entry& entry) {
 #ifdef _WIN32
-    ::OutputDebugStringA(FormatLogMessage(entry).append(1, '\n').c_str());
+    ::OutputDebugStringW(Common::UTF8ToUTF16W(FormatLogMessage(entry).append(1, '\n')).c_str());
 #endif
 }
 


### PR DESCRIPTION
Yay for even needing to do this.

**Original reason:**
As Windows multi-byte character codec is unspecified while we always assume std::string uses UTF-8 in our code base, this can output gibberish when the string contains non-ASCII characters. ::OutputDebugStringW combined with Common::UTF8ToUTF16W is preferred here.