### PR TITLE
service/fsp_srv: Correct returned value in GetGlobalAccessLogMode()

### DIFF
--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -796,9 +796,18 @@ void FSP_SRV::OpenSaveDataInfoReaderBySaveDataSpaceId(Kernel::HLERequestContext&
 void FSP_SRV::GetGlobalAccessLogMode(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_FS, "(STUBBED) called");
 
+    enum class LogMode : u32 {
+        Off,
+        Log,
+        RedirectToSdCard,
+        LogToSdCard = Log | RedirectToSdCard,
+    };
+
+    // Given we always want to receive logging information,
+    // we always specify logging as enabled.
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u32>(5);
+    rb.PushEnum(LogMode::Log);
 }
 
 void FSP_SRV::OpenDataStorageByCurrentProcess(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
Based off RE, the backing code only ever seems to use 0-2 as the range of values 1 being a generic log enable, with 2 indicating logging should go to the SD card. These are used as a set of flags internally.

Given we only care about receiving the log in general, we can just always signify that we want logging in general. The rest of the values are provided for completeness.