### PR TITLE
file_sys/save_data_factory: Update SaveDataSpaceId enum

### DIFF
--- a/src/core/file_sys/savedata_factory.h
+++ b/src/core/file_sys/savedata_factory.h
@@ -17,8 +17,10 @@ namespace FileSys {
 enum class SaveDataSpaceId : u8 {
     NandSystem = 0,
     NandUser = 1,
-    SdCard = 2,
+    SdCardSystem = 2,
     TemporaryStorage = 3,
+    SdCardUser = 4,
+    ProperSystem = 100,
 };
 
 enum class SaveDataType : u8 {


### PR DESCRIPTION
Amends it with missing values deduced from RE (ProperSystem being from SwitchBrew for naming)

SdCardUser wasn't that difficult to discern given its used alongside SdCardSystem when creating the save data indexer, based off the usage of the string "saveDataIxrDbSd" nearby.