### PR TITLE
Port citra-emu/citra#4476: "web_service: move telemetry condition from TelemetrySession constructor to destructor"

### DIFF
--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -103,13 +103,8 @@ bool VerifyLogin(const std::string& username, const std::string& token) {
 
 TelemetrySession::TelemetrySession() {
 #ifdef ENABLE_WEB_SERVICE
-    if (Settings::values.enable_telemetry) {
-        backend = std::make_unique<WebService::TelemetryJson>(Settings::values.web_api_url,
-                                                              Settings::values.yuzu_username,
-                                                              Settings::values.yuzu_token);
-    } else {
-        backend = std::make_unique<Telemetry::NullVisitor>();
-    }
+    backend = std::make_unique<WebService::TelemetryJson>(
+        Settings::values.web_api_url, Settings::values.yuzu_username, Settings::values.yuzu_token);
 #else
     backend = std::make_unique<Telemetry::NullVisitor>();
 #endif
@@ -180,7 +175,8 @@ TelemetrySession::~TelemetrySession() {
     // This is just a placeholder to wrap up the session once the core completes and this is
     // destroyed. This will be moved elsewhere once we are actually doing real I/O with the service.
     field_collection.Accept(*backend);
-    backend->Complete();
+    if (Settings::values.enable_telemetry)
+        backend->Complete();
     backend = nullptr;
 }
 


### PR DESCRIPTION
See citra-emu/citra#4476 for more details.

**Original description:**
Fixes an issue where Testcases couldn't be sent when Telemetry was disabled, because both things are tied closely together in the backend.
See discussion on (Citra) Discord for more reasoning behind this.