### PR TITLE
vm_manager/svc: Modify MemoryState enum, and correct error handling for svcQueryMemory

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -150,7 +150,7 @@ void Process::Run(VAddr entry_point, s32 main_thread_priority, u32 stack_size) {
     vm_manager
         .MapMemoryBlock(vm_manager.GetTLSIORegionEndAddress() - stack_size,
                         std::make_shared<std::vector<u8>>(stack_size, 0), 0, stack_size,
-                        MemoryState::Mapped)
+                        MemoryState::Stack)
         .Unwrap();
 
     vm_manager.LogLayout();

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -262,8 +262,7 @@ public:
     ResultVal<VAddr> HeapAllocate(VAddr target, u64 size, VMAPermission perms);
     ResultCode HeapFree(VAddr target, u32 size);
 
-    ResultCode MirrorMemory(VAddr dst_addr, VAddr src_addr, u64 size,
-                            MemoryState state = MemoryState::Mapped);
+    ResultCode MirrorMemory(VAddr dst_addr, VAddr src_addr, u64 size, MemoryState state);
 
     ResultCode UnmapMemory(VAddr dst_addr, VAddr src_addr, u64 size);
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -273,7 +273,7 @@ static ResultCode MapMemory(VAddr dst_addr, VAddr src_addr, u64 size) {
         return result;
     }
 
-    return current_process->MirrorMemory(dst_addr, src_addr, size);
+    return current_process->MirrorMemory(dst_addr, src_addr, size, MemoryState::Stack);
 }
 
 /// Unmaps a region that was previously mapped with svcMapMemory
@@ -1086,7 +1086,7 @@ static ResultCode QueryProcessMemory(MemoryInfo* memory_info, PageInfo* /*page_i
         memory_info->base_address = vma->second.base;
         memory_info->permission = static_cast<u32>(vma->second.permissions);
         memory_info->size = vma->second.size;
-        memory_info->type = static_cast<u32>(vma->second.meminfo_state);
+        memory_info->type = ToSvcMemoryState(vma->second.meminfo_state);
     } else {
         memory_info->base_address = 0;
         memory_info->permission = static_cast<u32>(VMAPermission::None);

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1912,7 +1912,7 @@ static const FunctionDef SVC_Table[] = {
     {0x73, nullptr, "SetProcessMemoryPermission"},
     {0x74, nullptr, "MapProcessMemory"},
     {0x75, nullptr, "UnmapProcessMemory"},
-    {0x76, nullptr, "QueryProcessMemory"},
+    {0x76, SvcWrap<QueryProcessMemory>, "QueryProcessMemory"},
     {0x77, nullptr, "MapProcessCodeMemory"},
     {0x78, nullptr, "UnmapProcessCodeMemory"},
     {0x79, nullptr, "CreateProcess"},

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1086,6 +1086,9 @@ static ResultCode QueryProcessMemory(VAddr memory_info_address, VAddr page_info_
     Memory::Write32(memory_info_address + 16, memory_info.state);
     Memory::Write32(memory_info_address + 20, memory_info.attributes);
     Memory::Write32(memory_info_address + 24, memory_info.permission);
+    Memory::Write32(memory_info_address + 32, memory_info.ipc_ref_count);
+    Memory::Write32(memory_info_address + 28, memory_info.device_ref_count);
+    Memory::Write32(memory_info_address + 36, 0);
 
     // Page info appears to be currently unused by the kernel and is always set to zero.
     Memory::Write32(page_info_address, 0);

--- a/src/core/hle/kernel/svc.h
+++ b/src/core/hle/kernel/svc.h
@@ -8,22 +8,6 @@
 
 namespace Kernel {
 
-struct MemoryInfo {
-    u64 base_address;
-    u64 size;
-    u32 type;
-    u32 attributes;
-    u32 permission;
-    u32 device_refcount;
-    u32 ipc_refcount;
-    INSERT_PADDING_WORDS(1);
-};
-static_assert(sizeof(MemoryInfo) == 0x28, "MemoryInfo has incorrect size.");
-
-struct PageInfo {
-    u64 flags;
-};
-
 void CallSVC(u32 immediate);
 
 } // namespace Kernel

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -199,7 +199,7 @@ void SvcWrap() {
 
     Memory::Write64(Param(0), memory_info.base_address);
     Memory::Write64(Param(0) + 8, memory_info.size);
-    Memory::Write32(Param(0) + 16, memory_info.type);
+    Memory::Write32(Param(0) + 16, memory_info.state);
     Memory::Write32(Param(0) + 20, memory_info.attributes);
     Memory::Write32(Param(0) + 24, memory_info.permission);
 

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -130,6 +130,11 @@ void SvcWrap() {
         func(Param(0), Param(1), static_cast<u32>(Param(3)), static_cast<u32>(Param(3))).raw);
 }
 
+template <ResultCode func(u64, u64, u32, u64)>
+void SvcWrap() {
+    FuncReturn(func(Param(0), Param(1), static_cast<u32>(Param(2)), Param(3)).raw);
+}
+
 template <ResultCode func(u32, u64, u32)>
 void SvcWrap() {
     FuncReturn(func(static_cast<u32>(Param(0)), Param(1), static_cast<u32>(Param(2))).raw);

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -7,7 +7,7 @@
 #include "common/common_types.h"
 #include "core/arm/arm_interface.h"
 #include "core/core.h"
-#include "core/hle/kernel/svc.h"
+#include "core/hle/kernel/vm_manager.h"
 #include "core/hle/result.h"
 #include "core/memory.h"
 

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -7,9 +7,7 @@
 #include "common/common_types.h"
 #include "core/arm/arm_interface.h"
 #include "core/core.h"
-#include "core/hle/kernel/vm_manager.h"
 #include "core/hle/result.h"
-#include "core/memory.h"
 
 namespace Kernel {
 
@@ -188,21 +186,6 @@ void SvcWrap() {
                       static_cast<s32>(Param(5)))
                      .raw;
     Core::CurrentArmInterface().SetReg(1, param_1);
-    FuncReturn(retval);
-}
-
-template <ResultCode func(MemoryInfo*, PageInfo*, u64)>
-void SvcWrap() {
-    MemoryInfo memory_info = {};
-    PageInfo page_info = {};
-    u32 retval = func(&memory_info, &page_info, Param(2)).raw;
-
-    Memory::Write64(Param(0), memory_info.base_address);
-    Memory::Write64(Param(0) + 8, memory_info.size);
-    Memory::Write32(Param(0) + 16, memory_info.state);
-    Memory::Write32(Param(0) + 20, memory_info.attributes);
-    Memory::Write32(Param(0) + 24, memory_info.permission);
-
     FuncReturn(retval);
 }
 

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -28,7 +28,7 @@ static const char* GetMemoryStateName(MemoryState state) {
         "IpcBuffer0",       "Stack",
         "ThreadLocal",      "TransferMemoryIsolated",
         "TransferMemory",   "ProcessMemory",
-        "Unknown2",         "IpcBuffer1",
+        "Inaccessible",     "IpcBuffer1",
         "IpcBuffer3",       "KernelStack",
     };
 
@@ -312,10 +312,10 @@ MemoryInfo VMManager::QueryMemory(VAddr address) const {
         memory_info.size = vma->second.size;
         memory_info.state = ToSvcMemoryState(vma->second.meminfo_state);
     } else {
-        memory_info.base_address = 0;
+        memory_info.base_address = address_space_end;
         memory_info.permission = static_cast<u32>(VMAPermission::None);
-        memory_info.size = 0;
-        memory_info.state = static_cast<u32>(MemoryState::Unmapped);
+        memory_info.size = 0 - address_space_end;
+        memory_info.state = static_cast<u32>(MemoryState::Inaccessible);
     }
 
     return memory_info;

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -25,14 +25,14 @@ static const char* GetMemoryStateName(MemoryState state) {
         "CodeMutable",      "Heap",
         "Shared",           "Unknown1",
         "ModuleCodeStatic", "ModuleCodeMutable",
-        "IpcBuffer0",       "Mapped",
+        "IpcBuffer0",       "Stack",
         "ThreadLocal",      "TransferMemoryIsolated",
         "TransferMemory",   "ProcessMemory",
         "Unknown2",         "IpcBuffer1",
         "IpcBuffer3",       "KernelStack",
     };
 
-    return names[static_cast<int>(state)];
+    return names[ToSvcMemoryState(state)];
 }
 
 bool VirtualMemoryArea::CanBeMergedWith(const VirtualMemoryArea& next) const {

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -302,6 +302,25 @@ ResultCode VMManager::HeapFree(VAddr target, u64 size) {
     return RESULT_SUCCESS;
 }
 
+MemoryInfo VMManager::QueryMemory(VAddr address) const {
+    const auto vma = FindVMA(address);
+    MemoryInfo memory_info{};
+
+    if (IsValidHandle(vma)) {
+        memory_info.base_address = vma->second.base;
+        memory_info.permission = static_cast<u32>(vma->second.permissions);
+        memory_info.size = vma->second.size;
+        memory_info.state = ToSvcMemoryState(vma->second.meminfo_state);
+    } else {
+        memory_info.base_address = 0;
+        memory_info.permission = static_cast<u32>(VMAPermission::None);
+        memory_info.size = 0;
+        memory_info.state = static_cast<u32>(MemoryState::Unmapped);
+    }
+
+    return memory_info;
+}
+
 ResultCode VMManager::MirrorMemory(VAddr dst_addr, VAddr src_addr, u64 size, MemoryState state) {
     const auto vma = FindVMA(src_addr);
 

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -43,27 +43,112 @@ enum class VMAPermission : u8 {
     ReadWriteExecute = Read | Write | Execute,
 };
 
-/// Set of values returned in MemoryInfo.state by svcQueryMemory.
+// clang-format off
+/// Represents memory states and any relevant flags, as used by the kernel.
+/// svcQueryMemory interprets these by masking away all but the first eight
+/// bits when storing memory state into a MemoryInfo instance.
 enum class MemoryState : u32 {
-    Unmapped = 0x0,
-    Io = 0x1,
-    Normal = 0x2,
-    CodeStatic = 0x3,
-    CodeMutable = 0x4,
-    Heap = 0x5,
-    Shared = 0x6,
-    ModuleCodeStatic = 0x8,
-    ModuleCodeMutable = 0x9,
-    IpcBuffer0 = 0xA,
-    Mapped = 0xB,
-    ThreadLocal = 0xC,
-    TransferMemoryIsolated = 0xD,
-    TransferMemory = 0xE,
-    ProcessMemory = 0xF,
-    IpcBuffer1 = 0x11,
-    IpcBuffer3 = 0x12,
-    KernelStack = 0x13,
+    Mask                            = 0xFF,
+    FlagProtect                     = 1U << 8,
+    FlagDebug                       = 1U << 9,
+    FlagIPC0                        = 1U << 10,
+    FlagIPC3                        = 1U << 11,
+    FlagIPC1                        = 1U << 12,
+    FlagMapped                      = 1U << 13,
+    FlagCode                        = 1U << 14,
+    FlagAlias                       = 1U << 15,
+    FlagModule                      = 1U << 16,
+    FlagTransfer                    = 1U << 17,
+    FlagQueryPhysicalAddressAllowed = 1U << 18,
+    FlagSharedDevice                = 1U << 19,
+    FlagSharedDeviceAligned         = 1U << 20,
+    FlagIPCBuffer                   = 1U << 21,
+    FlagMemoryPoolAllocated         = 1U << 22,
+    FlagMapProcess                  = 1U << 23,
+    FlagUncached                    = 1U << 24,
+    FlagCodeMemory                  = 1U << 25,
+
+    // Convenience flag sets to reduce repetition
+    IPCFlags = FlagIPC0 | FlagIPC3 | FlagIPC1,
+
+    CodeFlags = FlagDebug | IPCFlags | FlagMapped | FlagCode | FlagQueryPhysicalAddressAllowed |
+                FlagSharedDevice | FlagSharedDeviceAligned | FlagMemoryPoolAllocated,
+
+    DataFlags = FlagProtect | IPCFlags | FlagMapped | FlagAlias | FlagTransfer |
+                FlagQueryPhysicalAddressAllowed | FlagSharedDevice | FlagSharedDeviceAligned |
+                FlagMemoryPoolAllocated | FlagIPCBuffer | FlagUncached,
+
+    Unmapped               = 0x00,
+    Io                     = 0x01 | FlagMapped,
+    Normal                 = 0x02 | FlagMapped | FlagQueryPhysicalAddressAllowed,
+    CodeStatic             = 0x03 | CodeFlags  | FlagMapProcess,
+    CodeMutable            = 0x04 | CodeFlags  | FlagMapProcess | FlagCodeMemory,
+    Heap                   = 0x05 | DataFlags  | FlagCodeMemory,
+    Shared                 = 0x06 | FlagMapped | FlagMemoryPoolAllocated,
+    ModuleCodeStatic       = 0x08 | CodeFlags  | FlagModule | FlagMapProcess,
+    ModuleCodeMutable      = 0x09 | DataFlags  | FlagModule | FlagMapProcess | FlagCodeMemory,
+
+    IpcBuffer0             = 0x0A | FlagMapped | FlagQueryPhysicalAddressAllowed | FlagMemoryPoolAllocated |
+                                    IPCFlags | FlagSharedDevice | FlagSharedDeviceAligned,
+
+    Stack                  = 0x0B | FlagMapped | IPCFlags | FlagQueryPhysicalAddressAllowed |
+                                    FlagSharedDevice | FlagSharedDeviceAligned | FlagMemoryPoolAllocated,
+
+    ThreadLocal            = 0x0C | FlagMapped | FlagMemoryPoolAllocated,
+
+    TransferMemoryIsolated = 0x0D | IPCFlags | FlagMapped | FlagQueryPhysicalAddressAllowed |
+                                    FlagSharedDevice | FlagSharedDeviceAligned | FlagMemoryPoolAllocated |
+                                    FlagUncached,
+
+    TransferMemory         = 0x0E | FlagIPC3   | FlagIPC1   | FlagMapped | FlagQueryPhysicalAddressAllowed |
+                                    FlagSharedDevice | FlagSharedDeviceAligned | FlagMemoryPoolAllocated,
+
+    ProcessMemory          = 0x0F | FlagIPC3   | FlagIPC1   | FlagMapped | FlagMemoryPoolAllocated,
+
+    IpcBuffer1             = 0x11 | FlagIPC3   | FlagIPC1   | FlagMapped | FlagQueryPhysicalAddressAllowed |
+                                    FlagSharedDevice | FlagSharedDeviceAligned | FlagMemoryPoolAllocated,
+
+    IpcBuffer3             = 0x12 | FlagIPC3   | FlagMapped | FlagQueryPhysicalAddressAllowed |
+                                    FlagSharedDeviceAligned | FlagMemoryPoolAllocated,
+
+    KernelStack            = 0x13 | FlagMapped,
 };
+// clang-format on
+
+constexpr MemoryState operator|(MemoryState lhs, MemoryState rhs) {
+    return static_cast<MemoryState>(u32(lhs) | u32(rhs));
+}
+
+constexpr MemoryState operator&(MemoryState lhs, MemoryState rhs) {
+    return static_cast<MemoryState>(u32(lhs) & u32(rhs));
+}
+
+constexpr MemoryState operator^(MemoryState lhs, MemoryState rhs) {
+    return static_cast<MemoryState>(u32(lhs) ^ u32(rhs));
+}
+
+constexpr MemoryState operator~(MemoryState lhs) {
+    return static_cast<MemoryState>(~u32(lhs));
+}
+
+constexpr MemoryState& operator|=(MemoryState& lhs, MemoryState rhs) {
+    lhs = lhs | rhs;
+    return lhs;
+}
+
+constexpr MemoryState& operator&=(MemoryState& lhs, MemoryState rhs) {
+    lhs = lhs & rhs;
+    return lhs;
+}
+
+constexpr MemoryState& operator^=(MemoryState& lhs, MemoryState rhs) {
+    lhs = lhs ^ rhs;
+    return lhs;
+}
+
+constexpr u32 ToSvcMemoryState(MemoryState state) {
+    return static_cast<u32>(state & MemoryState::Mask);
+}
 
 /**
  * Represents a VMA in an address space. A VMA is a contiguous region of virtual addressing space
@@ -186,8 +271,7 @@ public:
     ResultVal<VAddr> HeapAllocate(VAddr target, u64 size, VMAPermission perms);
     ResultCode HeapFree(VAddr target, u64 size);
 
-    ResultCode MirrorMemory(VAddr dst_addr, VAddr src_addr, u64 size,
-                            MemoryState state = MemoryState::Mapped);
+    ResultCode MirrorMemory(VAddr dst_addr, VAddr src_addr, u64 size, MemoryState state);
 
     /**
      * Scans all VMAs and updates the page table range of any that use the given vector as backing

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -159,8 +159,8 @@ struct MemoryInfo {
     u32 state;
     u32 attributes;
     u32 permission;
-    u32 device_refcount;
-    u32 ipc_refcount;
+    u32 ipc_ref_count;
+    u32 device_ref_count;
 };
 static_assert(sizeof(MemoryInfo) == 0x28, "MemoryInfo has incorrect size.");
 

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -150,6 +150,21 @@ constexpr u32 ToSvcMemoryState(MemoryState state) {
     return static_cast<u32>(state & MemoryState::Mask);
 }
 
+struct MemoryInfo {
+    u64 base_address;
+    u64 size;
+    u32 type;
+    u32 attributes;
+    u32 permission;
+    u32 device_refcount;
+    u32 ipc_refcount;
+};
+static_assert(sizeof(MemoryInfo) == 0x28, "MemoryInfo has incorrect size.");
+
+struct PageInfo {
+    u32 flags;
+};
+
 /**
  * Represents a VMA in an address space. A VMA is a contiguous region of virtual addressing space
  * with homogeneous attributes across its extents. In this particular implementation each VMA is

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -153,7 +153,7 @@ constexpr u32 ToSvcMemoryState(MemoryState state) {
 struct MemoryInfo {
     u64 base_address;
     u64 size;
-    u32 type;
+    u32 state;
     u32 attributes;
     u32 permission;
     u32 device_refcount;
@@ -287,6 +287,14 @@ public:
     ResultCode HeapFree(VAddr target, u64 size);
 
     ResultCode MirrorMemory(VAddr dst_addr, VAddr src_addr, u64 size, MemoryState state);
+
+    /// Queries the memory manager for information about the given address.
+    ///
+    /// @param address The address to query the memory manager about for information.
+    ///
+    /// @return A MemoryInfo instance containing information about the given address.
+    ///
+    MemoryInfo QueryMemory(VAddr address) const;
 
     /**
      * Scans all VMAs and updates the page table range of any that use the given vector as backing

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -105,6 +105,9 @@ enum class MemoryState : u32 {
 
     ProcessMemory          = 0x0F | FlagIPC3   | FlagIPC1   | FlagMapped | FlagMemoryPoolAllocated,
 
+    // Used to signify an inaccessible or invalid memory region with memory queries
+    Inaccessible           = 0x10,
+
     IpcBuffer1             = 0x11 | FlagIPC3   | FlagIPC1   | FlagMapped | FlagQueryPhysicalAddressAllowed |
                                     FlagSharedDevice | FlagSharedDeviceAligned | FlagMemoryPoolAllocated,
 


### PR DESCRIPTION
Puts the proper memory states in place along with their relevant flags, which will make modifications in the future nicer (particularly, with implementing svcSetMemoryAttribute).

At the same time, this also fixes up svcQueryMemory. Previously, it was possible for memory to get steamrolled, even in error cases where nothing should happen. Since the memory writes were occurring within the SvcWrap handler, this means that those memory writes were happening regardless of the result from the function.

Because of that, it meant that when, say, an invalid process handle is passed to svcQueryProcessMemory, instead of just bailing out, it was bailing out *and* writing 64 bytes into memory (wherever the memory info address is pointing). This means arbitrary stuff in memory can get overwritten, which is, uh, definitely not what we want

This also corrects the structure size of PageInfo (it should be 4 bytes, not 8 bytes), and corrects how things were being written out to memory in terms of the structures themselves. Previously, we weren't writing out the reference count members of MemoryInfo and also neglecting to zero out the trailing padding bits of the structure. We also were just doing nothing with the `PageInfo` parameter, when it should be zeroed out.

Not doing this is particularly bad, since it can result in wrong behavior for correct code in *userland* in the following scenario (error handling omitted for brevity):

```cpp
MemoryInfo info;                 // Put on the stack, not guaranteed to be zeroed out.
svcQueryMemory(&info, ...);

if (info.device_refcount == ...) // Whoops, uninitialized read despite being fine API-wise
```

and also can cause comparison issues if the userland code decides to use a `std::memcmp`-like means of comparing two `MemoryInfo` structures. If we don't zero out the padding bits, then those comparisons become non-deterministic, since the padding bits can be assumed to have whatever value is in memory at their point of instantiation/creation.

We also weren't marking ranges returned from invalid queries as inaccessible, but were signifying them as unmapped. The specified sizes and address were also incorrect in this case. The address should indicate the end of the address space, and the specified size should be the equivalent of `0 - address_space_end`.

And finally, given svcQueryProcessMemory is exactly the same as svcQueryMemory, but with a handle parameter for specifying a process instance, we can enable this svc, as the helper function that svcQueryMemory calls into is exactly what svcQueryProcessMemory does.
