### PR TITLE
svc_wrap: Correct register index for a wrapper specialization

### DIFF
--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -129,7 +129,7 @@ void SvcWrap() {
 template <ResultCode func(u64, u64, u32, u32)>
 void SvcWrap() {
     FuncReturn(
-        func(Param(0), Param(1), static_cast<u32>(Param(3)), static_cast<u32>(Param(3))).raw);
+        func(Param(0), Param(1), static_cast<u32>(Param(2)), static_cast<u32>(Param(3))).raw);
 }
 
 template <ResultCode func(u32, u64, u32)>


### PR DESCRIPTION
This would result in `svcSetMemoryAttribute` getting the wrong value for its third parameter. This is currently fine, given the service function is stubbed, however this will be unstubbed in a future change, so this needs to change.