### PR TITLE
Fix arrayed texture LOD selection and depth comparison ordering

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1591,23 +1591,21 @@ private:
                                 process_mode == Tegra::Shader::TextureProcessMode::LL ||
                                 process_mode == Tegra::Shader::TextureProcessMode::LLA;
 
+        // LOD selection (either via bias or explicit textureLod) not supported in GL for
+        // sampler2DArrayShadow and samplerCubeArrayShadow.
         const bool gl_lod_supported = !(
             (texture_type == Tegra::Shader::TextureType::Texture2D && is_array && depth_compare) ||
-            (texture_type == Tegra::Shader::TextureType::TextureCube && !is_array &&
-             depth_compare));
+            (texture_type == Tegra::Shader::TextureType::TextureCube && is_array && depth_compare));
 
         const std::string read_method = lod_needed && gl_lod_supported ? "textureLod(" : "texture(";
         std::string texture = read_method + sampler + ", coord";
 
-        if (process_mode != Tegra::Shader::TextureProcessMode::None) {
+        UNIMPLEMENTED_IF(process_mode != Tegra::Shader::TextureProcessMode::None &&
+                         !gl_lod_supported);
+
+        if (process_mode != Tegra::Shader::TextureProcessMode::None && gl_lod_supported) {
             if (process_mode == Tegra::Shader::TextureProcessMode::LZ) {
-                if (gl_lod_supported) {
-                    texture += ", 0";
-                } else {
-                    // Lod 0 is emulated by a big negative bias
-                    // in scenarios that are not supported by glsl
-                    texture += ", -1000";
-                }
+                texture += ", 0.0";
             } else {
                 // If present, lod or bias are always stored in the register indexed by the
                 // gpr20
@@ -1645,14 +1643,14 @@ private:
         if (depth_compare && !is_array && texture_type == Tegra::Shader::TextureType::Texture1D) {
             coord += ",0.0";
         }
+        if (is_array) {
+            coord += ',' + regs.GetRegisterAsInteger(array_register);
+        }
         if (depth_compare) {
             // Depth is always stored in the register signaled by gpr20
             // or in the next register if lod or bias are used
             const u64 depth_register = instr.gpr20.Value() + (lod_bias_enabled ? 1 : 0);
             coord += ',' + regs.GetRegisterAsFloat(depth_register);
-        }
-        if (is_array) {
-            coord += ',' + regs.GetRegisterAsInteger(array_register);
         }
         coord += ");";
         return std::make_pair(
@@ -1686,14 +1684,14 @@ private:
             }
         }
 
+        if (is_array) {
+            coord += ',' + regs.GetRegisterAsInteger(array_register);
+        }
         if (depth_compare) {
             // Depth is always stored in the register signaled by gpr20
             // or in the next register if lod or bias are used
             const u64 depth_register = instr.gpr20.Value() + (lod_bias_enabled ? 1 : 0);
             coord += ',' + regs.GetRegisterAsFloat(depth_register);
-        }
-        if (is_array) {
-            coord += ',' + regs.GetRegisterAsInteger(array_register);
         }
         coord += ");";
 


### PR DESCRIPTION
Previously for arrayed shadow samplers, the array index and depth comparison values were swapped. Fixing this improves shadow rendering pretty decently in BOTW (see attached). There's still some missing shadows that need to be tracked down.

Also fixes invalid logic in GLSL LOD selection (attempting to select LOD with unsupported sampler types, leading to compile errors). Note that the online reference pages are a little inaccurate, the GLSL spec needs to be referenced.

![before](https://user-images.githubusercontent.com/45604170/50056794-91e31f00-0116-11e9-88cb-918c2eaed079.jpg)
![after](https://user-images.githubusercontent.com/45604170/50056793-91e31f00-0116-11e9-9b7a-ede48da9f985.jpg)