### PR TITLE
Allow assertions to not exit on the release build

### DIFF
--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -27,6 +27,7 @@ __declspec(noinline, noreturn)
     exit(1); // Keeps GCC's mouth shut about this actually returning
 }
 
+#ifdef _DEBUG
 #define ASSERT(_a_)                                                                                \
     do                                                                                             \
         if (!(_a_)) {                                                                              \
@@ -40,17 +41,25 @@ __declspec(noinline, noreturn)
             assert_noinline_call([&] { LOG_CRITICAL(Debug, "Assertion Failed!\n" __VA_ARGS__); }); \
         }                                                                                          \
     while (0)
+#else // not debug
+#define ASSERT(_a_)                                                                                \
+    do                                                                                             \
+        if (!(_a_)) {                                                                              \
+            LOG_CRITICAL(Debug, "Assertion Failed!");                                              \
+        }                                                                                          \
+    while (0)
+
+#define ASSERT_MSG(_a_, ...)                                                                       \
+    if (!(_a_)) {                                                                                  \
+        LOG_CRITICAL(Debug, "Assertion Failed!\n" __VA_ARGS__);                                    \
+    }
+#endif
 
 #define UNREACHABLE() ASSERT_MSG(false, "Unreachable code!")
 #define UNREACHABLE_MSG(...) ASSERT_MSG(false, __VA_ARGS__)
 
-#ifdef _DEBUG
 #define DEBUG_ASSERT(_a_) ASSERT(_a_)
 #define DEBUG_ASSERT_MSG(_a_, ...) ASSERT_MSG(_a_, __VA_ARGS__)
-#else // not debug
-#define DEBUG_ASSERT(_a_)
-#define DEBUG_ASSERT_MSG(_a_, _desc_, ...)
-#endif
 
 #define UNIMPLEMENTED() ASSERT_MSG(false, "Unimplemented code!")
 #define UNIMPLEMENTED_MSG(...) ASSERT_MSG(false, __VA_ARGS__)


### PR DESCRIPTION
Very often the release build just exits on an assertion. This allows the release build to just go on instead of failing. Allows a lot of games to be booted at least, without failing on a not implemented error.