### PR TITLE
service/service: Make FunctionInfo constructor constexpr

### DIFF
--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -48,7 +48,7 @@ class IProfile final : public ServiceFramework<IProfile> {
 public:
     explicit IProfile(UUID user_id, ProfileManager& profile_manager)
         : ServiceFramework("IProfile"), profile_manager(profile_manager), user_id(user_id) {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IProfile::Get, "Get"},
             {1, &IProfile::GetBase, "GetBase"},
             {10, &IProfile::GetImageSize, "GetImageSize"},
@@ -137,7 +137,7 @@ private:
 class IManagerForApplication final : public ServiceFramework<IManagerForApplication> {
 public:
     IManagerForApplication() : ServiceFramework("IManagerForApplication") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IManagerForApplication::CheckAvailability, "CheckAvailability"},
             {1, &IManagerForApplication::GetAccountId, "GetAccountId"},
             {2, nullptr, "EnsureIdTokenCacheAsync"},

--- a/src/core/hle/service/acc/acc_aa.cpp
+++ b/src/core/hle/service/acc/acc_aa.cpp
@@ -8,7 +8,7 @@ namespace Service::Account {
 
 ACC_AA::ACC_AA(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> profile_manager)
     : Module::Interface(std::move(module), std::move(profile_manager), "acc:aa") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "EnsureCacheAsync"},
         {1, nullptr, "LoadCache"},
         {2, nullptr, "GetDeviceAccountId"},

--- a/src/core/hle/service/acc/acc_su.cpp
+++ b/src/core/hle/service/acc/acc_su.cpp
@@ -8,7 +8,7 @@ namespace Service::Account {
 
 ACC_SU::ACC_SU(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> profile_manager)
     : Module::Interface(std::move(module), std::move(profile_manager), "acc:su") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &ACC_SU::GetUserCount, "GetUserCount"},
         {1, &ACC_SU::GetUserExistence, "GetUserExistence"},
         {2, &ACC_SU::ListAllUsers, "ListAllUsers"},

--- a/src/core/hle/service/acc/acc_u0.cpp
+++ b/src/core/hle/service/acc/acc_u0.cpp
@@ -8,7 +8,7 @@ namespace Service::Account {
 
 ACC_U0::ACC_U0(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> profile_manager)
     : Module::Interface(std::move(module), std::move(profile_manager), "acc:u0") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &ACC_U0::GetUserCount, "GetUserCount"},
         {1, &ACC_U0::GetUserExistence, "GetUserExistence"},
         {2, &ACC_U0::ListAllUsers, "ListAllUsers"},

--- a/src/core/hle/service/acc/acc_u1.cpp
+++ b/src/core/hle/service/acc/acc_u1.cpp
@@ -8,7 +8,7 @@ namespace Service::Account {
 
 ACC_U1::ACC_U1(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> profile_manager)
     : Module::Interface(std::move(module), std::move(profile_manager), "acc:u1") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &ACC_U1::GetUserCount, "GetUserCount"},
         {1, &ACC_U1::GetUserExistence, "GetUserExistence"},
         {2, &ACC_U1::ListAllUsers, "ListAllUsers"},

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -54,7 +54,7 @@ static_assert(sizeof(LaunchParameters) == 0x88);
 
 IWindowController::IWindowController() : ServiceFramework("IWindowController") {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "CreateWindow"},
         {1, &IWindowController::GetAppletResourceUserId, "GetAppletResourceUserId"},
         {10, &IWindowController::AcquireForegroundRights, "AcquireForegroundRights"},
@@ -84,7 +84,7 @@ void IWindowController::AcquireForegroundRights(Kernel::HLERequestContext& ctx) 
 }
 
 IAudioController::IAudioController() : ServiceFramework("IAudioController") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &IAudioController::SetExpectedMasterVolume, "SetExpectedMasterVolume"},
         {1, &IAudioController::GetMainAppletExpectedMasterVolume,
          "GetMainAppletExpectedMasterVolume"},
@@ -120,7 +120,7 @@ void IAudioController::GetLibraryAppletExpectedMasterVolume(Kernel::HLERequestCo
 
 IDisplayController::IDisplayController() : ServiceFramework("IDisplayController") {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "GetLastForegroundCaptureImage"},
         {1, nullptr, "UpdateLastForegroundCaptureImage"},
         {2, nullptr, "GetLastApplicationCaptureImage"},
@@ -166,7 +166,7 @@ IDebugFunctions::~IDebugFunctions() = default;
 ISelfController::ISelfController(std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
     : ServiceFramework("ISelfController"), nvflinger(std::move(nvflinger)) {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "Exit"},
         {1, &ISelfController::LockExit, "LockExit"},
         {2, &ISelfController::UnlockExit, "UnlockExit"},
@@ -399,7 +399,7 @@ void AppletMessageQueue::OperationModeChanged() {
 ICommonStateGetter::ICommonStateGetter(std::shared_ptr<AppletMessageQueue> msg_queue)
     : ServiceFramework("ICommonStateGetter"), msg_queue(std::move(msg_queue)) {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &ICommonStateGetter::GetEventHandle, "GetEventHandle"},
         {1, &ICommonStateGetter::ReceiveMessage, "ReceiveMessage"},
         {2, nullptr, "GetThisAppletKind"},
@@ -497,7 +497,7 @@ void ICommonStateGetter::GetDefaultDisplayResolution(Kernel::HLERequestContext& 
 IStorage::IStorage(std::vector<u8> buffer)
     : ServiceFramework("IStorage"), buffer(std::move(buffer)) {
     // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IStorage::Open, "Open"},
             {1, nullptr, "OpenTransferStorage"},
         };
@@ -536,7 +536,7 @@ public:
     explicit ILibraryAppletAccessor(std::shared_ptr<Applets::Applet> applet)
         : ServiceFramework("ILibraryAppletAccessor"), applet(std::move(applet)) {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &ILibraryAppletAccessor::GetAppletStateChangedEvent, "GetAppletStateChangedEvent"},
             {1, &ILibraryAppletAccessor::IsCompleted, "IsCompleted"},
             {10, &ILibraryAppletAccessor::Start, "Start"},
@@ -691,7 +691,7 @@ void IStorage::Open(Kernel::HLERequestContext& ctx) {
 IStorageAccessor::IStorageAccessor(IStorage& storage)
     : ServiceFramework("IStorageAccessor"), backing(storage) {
     // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IStorageAccessor::GetSize, "GetSize"},
             {10, &IStorageAccessor::Write, "Write"},
             {11, &IStorageAccessor::Read, "Read"},
@@ -758,7 +758,7 @@ void IStorageAccessor::Read(Kernel::HLERequestContext& ctx) {
 }
 
 ILibraryAppletCreator::ILibraryAppletCreator() : ServiceFramework("ILibraryAppletCreator") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &ILibraryAppletCreator::CreateLibraryApplet, "CreateLibraryApplet"},
         {1, nullptr, "TerminateAllLibraryApplets"},
         {2, nullptr, "AreAnyLibraryAppletsLeft"},
@@ -848,7 +848,7 @@ void ILibraryAppletCreator::CreateTransferMemoryStorage(Kernel::HLERequestContex
 
 IApplicationFunctions::IApplicationFunctions() : ServiceFramework("IApplicationFunctions") {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {1, &IApplicationFunctions::PopLaunchParameter, "PopLaunchParameter"},
         {10, nullptr, "CreateApplicationAndPushAndRequestToStart"},
         {11, nullptr, "CreateApplicationAndPushAndRequestToStartForQuest"},
@@ -1053,7 +1053,7 @@ void InstallInterfaces(SM::ServiceManager& service_manager,
 
 IHomeMenuFunctions::IHomeMenuFunctions() : ServiceFramework("IHomeMenuFunctions") {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {10, &IHomeMenuFunctions::RequestToGetForeground, "RequestToGetForeground"},
         {11, nullptr, "LockForeground"},
         {12, nullptr, "UnlockForeground"},
@@ -1079,7 +1079,7 @@ void IHomeMenuFunctions::RequestToGetForeground(Kernel::HLERequestContext& ctx) 
 
 IGlobalStateController::IGlobalStateController() : ServiceFramework("IGlobalStateController") {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "RequestToEnterSleep"},
         {1, nullptr, "EnterSleep"},
         {2, nullptr, "StartSleepSequence"},
@@ -1101,7 +1101,7 @@ IGlobalStateController::~IGlobalStateController() = default;
 
 IApplicationCreator::IApplicationCreator() : ServiceFramework("IApplicationCreator") {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "CreateApplication"},
         {1, nullptr, "PopLaunchRequestedApplication"},
         {10, nullptr, "CreateSystemApplication"},
@@ -1117,7 +1117,7 @@ IApplicationCreator::~IApplicationCreator() = default;
 IProcessWindingController::IProcessWindingController()
     : ServiceFramework("IProcessWindingController") {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "GetLaunchReason"},
         {11, nullptr, "OpenCallingLibraryApplet"},
         {21, nullptr, "PushContext"},

--- a/src/core/hle/service/am/applet_ae.cpp
+++ b/src/core/hle/service/am/applet_ae.cpp
@@ -16,7 +16,7 @@ public:
                                  std::shared_ptr<AppletMessageQueue> msg_queue)
         : ServiceFramework("ILibraryAppletProxy"), nvflinger(std::move(nvflinger)),
           msg_queue(std::move(msg_queue)) {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &ILibraryAppletProxy::GetCommonStateGetter, "GetCommonStateGetter"},
             {1, &ILibraryAppletProxy::GetSelfController, "GetSelfController"},
             {2, &ILibraryAppletProxy::GetWindowController, "GetWindowController"},
@@ -113,7 +113,7 @@ public:
                                 std::shared_ptr<AppletMessageQueue> msg_queue)
         : ServiceFramework("ISystemAppletProxy"), nvflinger(std::move(nvflinger)),
           msg_queue(std::move(msg_queue)) {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &ISystemAppletProxy::GetCommonStateGetter, "GetCommonStateGetter"},
             {1, &ISystemAppletProxy::GetSelfController, "GetSelfController"},
             {2, &ISystemAppletProxy::GetWindowController, "GetWindowController"},
@@ -242,7 +242,7 @@ AppletAE::AppletAE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger,
     : ServiceFramework("appletAE"), nvflinger(std::move(nvflinger)),
       msg_queue(std::move(msg_queue)) {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {100, &AppletAE::OpenSystemAppletProxy, "OpenSystemAppletProxy"},
         {200, &AppletAE::OpenLibraryAppletProxyOld, "OpenLibraryAppletProxyOld"},
         {201, &AppletAE::OpenLibraryAppletProxy, "OpenLibraryAppletProxy"},

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -17,7 +17,7 @@ public:
         : ServiceFramework("IApplicationProxy"), nvflinger(std::move(nvflinger)),
           msg_queue(std::move(msg_queue)) {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IApplicationProxy::GetCommonStateGetter, "GetCommonStateGetter"},
             {1, &IApplicationProxy::GetSelfController, "GetSelfController"},
             {2, &IApplicationProxy::GetWindowController, "GetWindowController"},
@@ -114,7 +114,7 @@ AppletOE::AppletOE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger,
                    std::shared_ptr<AppletMessageQueue> msg_queue)
     : ServiceFramework("appletOE"), nvflinger(std::move(nvflinger)),
       msg_queue(std::move(msg_queue)) {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &AppletOE::OpenApplicationProxy, "OpenApplicationProxy"},
     };
     RegisterHandlers(functions);

--- a/src/core/hle/service/am/idle.cpp
+++ b/src/core/hle/service/am/idle.cpp
@@ -8,7 +8,7 @@ namespace Service::AM {
 
 IdleSys::IdleSys() : ServiceFramework{"idle:sys"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "GetAutoPowerDownEvent"},
         {1, nullptr, "Unknown1"},
         {2, nullptr, "Unknown2"},

--- a/src/core/hle/service/am/omm.cpp
+++ b/src/core/hle/service/am/omm.cpp
@@ -8,7 +8,7 @@ namespace Service::AM {
 
 OMM::OMM() : ServiceFramework{"omm"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "GetOperationMode"},
         {1, nullptr, "GetOperationModeChangeEvent"},
         {2, nullptr, "EnableAudioVisual"},

--- a/src/core/hle/service/am/spsm.cpp
+++ b/src/core/hle/service/am/spsm.cpp
@@ -8,7 +8,7 @@ namespace Service::AM {
 
 SPSM::SPSM() : ServiceFramework{"spsm"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "GetState"},
         {1, nullptr, "SleepSystemAndWaitAwake"},
         {2, nullptr, "Unknown1"},

--- a/src/core/hle/service/am/tcap.cpp
+++ b/src/core/hle/service/am/tcap.cpp
@@ -8,7 +8,7 @@ namespace Service::AM {
 
 TCAP::TCAP() : ServiceFramework{"tcap"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "GetContinuousHighSkinTemperatureEvent"},
         {1, nullptr, "SetOperationMode"},
         {2, nullptr, "LoadAndApplySettings"},

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -50,7 +50,7 @@ static std::vector<u64> AccumulateAOCTitleIDs() {
 }
 
 AOC_U::AOC_U() : ServiceFramework("aoc:u"), add_on_content(AccumulateAOCTitleIDs()) {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "CountAddOnContentByApplicationId"},
         {1, nullptr, "ListAddOnContentByApplicationId"},
         {2, &AOC_U::CountAddOnContent, "CountAddOnContent"},

--- a/src/core/hle/service/apm/interface.cpp
+++ b/src/core/hle/service/apm/interface.cpp
@@ -12,7 +12,7 @@ namespace Service::APM {
 class ISession final : public ServiceFramework<ISession> {
 public:
     ISession() : ServiceFramework("ISession") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &ISession::SetPerformanceConfiguration, "SetPerformanceConfiguration"},
             {1, &ISession::GetPerformanceConfiguration, "GetPerformanceConfiguration"},
         };
@@ -61,7 +61,7 @@ private:
 
 APM::APM(std::shared_ptr<Module> apm, const char* name)
     : ServiceFramework(name), apm(std::move(apm)) {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &APM::OpenSession, "OpenSession"},
         {1, nullptr, "GetPerformanceMode"},
     };
@@ -80,7 +80,7 @@ void APM::OpenSession(Kernel::HLERequestContext& ctx) {
 
 APM_Sys::APM_Sys() : ServiceFramework{"apm:sys"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "RequestPerformanceMode"},
         {1, &APM_Sys::GetPerformanceEvent, "GetPerformanceEvent"},
         {2, nullptr, "GetThrottlingState"},

--- a/src/core/hle/service/arp/arp.cpp
+++ b/src/core/hle/service/arp/arp.cpp
@@ -17,7 +17,7 @@ class ARP_R final : public ServiceFramework<ARP_R> {
 public:
     explicit ARP_R() : ServiceFramework{"arp:r"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "GetApplicationLaunchProperty"},
             {1, nullptr, "GetApplicationLaunchPropertyWithApplicationId"},
             {2, nullptr, "GetApplicationControlProperty"},
@@ -33,7 +33,7 @@ class IRegistrar final : public ServiceFramework<IRegistrar> {
 public:
     explicit IRegistrar() : ServiceFramework{"IRegistrar"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Issue"},
             {1, nullptr, "SetApplicationLaunchProperty"},
             {2, nullptr, "SetApplicationControlProperty"},
@@ -48,7 +48,7 @@ class ARP_W final : public ServiceFramework<ARP_W> {
 public:
     explicit ARP_W() : ServiceFramework{"arp:w"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &ARP_W::AcquireRegistrar, "AcquireRegistrar"},
             {1, nullptr, "DeleteProperties"},
         };

--- a/src/core/hle/service/audio/audctl.cpp
+++ b/src/core/hle/service/audio/audctl.cpp
@@ -8,7 +8,7 @@ namespace Service::Audio {
 
 AudCtl::AudCtl() : ServiceFramework{"audctl"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "GetTargetVolume"},
         {1, nullptr, "SetTargetVolume"},
         {2, nullptr, "GetTargetVolumeMin"},

--- a/src/core/hle/service/audio/auddbg.cpp
+++ b/src/core/hle/service/audio/auddbg.cpp
@@ -8,7 +8,7 @@ namespace Service::Audio {
 
 AudDbg::AudDbg(const char* name) : ServiceFramework{name} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "RequestSuspendForDebug"},
         {1, nullptr, "RequestResumeForDebug"},
     };

--- a/src/core/hle/service/audio/audin_a.cpp
+++ b/src/core/hle/service/audio/audin_a.cpp
@@ -8,7 +8,7 @@ namespace Service::Audio {
 
 AudInA::AudInA() : ServiceFramework{"audin:a"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "RequestSuspendAudioIns"},
         {1, nullptr, "RequestResumeAudioIns"},
         {2, nullptr, "GetAudioInsProcessMasterVolume"},

--- a/src/core/hle/service/audio/audin_u.cpp
+++ b/src/core/hle/service/audio/audin_u.cpp
@@ -12,7 +12,7 @@ namespace Service::Audio {
 class IAudioIn final : public ServiceFramework<IAudioIn> {
 public:
     IAudioIn() : ServiceFramework("IAudioIn") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "GetAudioInState"},
             {1, nullptr, "StartAudioIn"},
             {2, nullptr, "StopAudioIn"},
@@ -34,7 +34,7 @@ public:
 };
 
 AudInU::AudInU() : ServiceFramework("audin:u") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "ListAudioIns"},    {1, nullptr, "OpenAudioIn"},      {2, nullptr, "Unknown"},
         {3, nullptr, "OpenAudioInAuto"}, {4, nullptr, "ListAudioInsAuto"},
     };

--- a/src/core/hle/service/audio/audout_a.cpp
+++ b/src/core/hle/service/audio/audout_a.cpp
@@ -8,7 +8,7 @@ namespace Service::Audio {
 
 AudOutA::AudOutA() : ServiceFramework{"audout:a"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "RequestSuspendAudioOuts"},
         {1, nullptr, "RequestResumeAudioOuts"},
         {2, nullptr, "GetAudioOutsProcessMasterVolume"},

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -51,7 +51,7 @@ public:
         : ServiceFramework("IAudioOut"), audio_core(audio_core),
           device_name(std::move(device_name)), audio_params(audio_params) {
 
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IAudioOut::GetAudioOutState, "GetAudioOutState"},
             {1, &IAudioOut::StartAudioOut, "StartAudioOut"},
             {2, &IAudioOut::StopAudioOut, "StopAudioOut"},
@@ -247,10 +247,15 @@ void AudOutU::OpenAudioOutImpl(Kernel::HLERequestContext& ctx) {
 }
 
 AudOutU::AudOutU() : ServiceFramework("audout:u") {
-    static const FunctionInfo functions[] = {{0, &AudOutU::ListAudioOutsImpl, "ListAudioOuts"},
-                                             {1, &AudOutU::OpenAudioOutImpl, "OpenAudioOut"},
-                                             {2, &AudOutU::ListAudioOutsImpl, "ListAudioOutsAuto"},
-                                             {3, &AudOutU::OpenAudioOutImpl, "OpenAudioOutAuto"}};
+    // clang-format off
+    static constexpr FunctionInfo functions[] = {
+        {0, &AudOutU::ListAudioOutsImpl, "ListAudioOuts"},
+        {1, &AudOutU::OpenAudioOutImpl, "OpenAudioOut"},
+        {2, &AudOutU::ListAudioOutsImpl, "ListAudioOutsAuto"},
+        {3, &AudOutU::OpenAudioOutImpl, "OpenAudioOutAuto"},
+    };
+    // clang-format on
+
     RegisterHandlers(functions);
     audio_core = std::make_unique<AudioCore::AudioOut>();
 }

--- a/src/core/hle/service/audio/audrec_a.cpp
+++ b/src/core/hle/service/audio/audrec_a.cpp
@@ -8,7 +8,7 @@ namespace Service::Audio {
 
 AudRecA::AudRecA() : ServiceFramework{"audrec:a"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "RequestSuspendFinalOutputRecorders"},
         {1, nullptr, "RequestResumeFinalOutputRecorders"},
     };

--- a/src/core/hle/service/audio/audrec_u.cpp
+++ b/src/core/hle/service/audio/audrec_u.cpp
@@ -12,7 +12,7 @@ namespace Service::Audio {
 class IFinalOutputRecorder final : public ServiceFramework<IFinalOutputRecorder> {
 public:
     IFinalOutputRecorder() : ServiceFramework("IFinalOutputRecorder") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "GetFinalOutputRecorderState"},
             {1, nullptr, "StartFinalOutputRecorder"},
             {2, nullptr, "StopFinalOutputRecorder"},
@@ -30,7 +30,7 @@ public:
 };
 
 AudRecU::AudRecU() : ServiceFramework("audrec:u") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "OpenFinalOutputRecorder"},
     };
     RegisterHandlers(functions);

--- a/src/core/hle/service/audio/audren_a.cpp
+++ b/src/core/hle/service/audio/audren_a.cpp
@@ -8,7 +8,7 @@ namespace Service::Audio {
 
 AudRenA::AudRenA() : ServiceFramework{"audren:a"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "RequestSuspendAudioRenderers"},
         {1, nullptr, "RequestResumeAudioRenderers"},
         {2, nullptr, "GetAudioRenderersProcessMasterVolume"},

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -25,7 +25,7 @@ public:
     explicit IAudioRenderer(AudioCore::AudioRendererParameter audren_params)
         : ServiceFramework("IAudioRenderer") {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IAudioRenderer::GetSampleRate, "GetSampleRate"},
             {1, &IAudioRenderer::GetSampleCount, "GetSampleCount"},
             {2, &IAudioRenderer::GetMixBufferCount, "GetMixBufferCount"},
@@ -145,7 +145,7 @@ private:
 class IAudioDevice final : public ServiceFramework<IAudioDevice> {
 public:
     IAudioDevice() : ServiceFramework("IAudioDevice") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IAudioDevice::ListAudioDeviceName, "ListAudioDeviceName"},
             {1, &IAudioDevice::SetAudioDeviceOutputVolume, "SetAudioDeviceOutputVolume"},
             {2, nullptr, "GetAudioDeviceOutputVolume"},
@@ -229,7 +229,7 @@ private:
 }; // namespace Audio
 
 AudRenU::AudRenU() : ServiceFramework("audren:u") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &AudRenU::OpenAudioRenderer, "OpenAudioRenderer"},
         {1, &AudRenU::GetAudioRendererWorkBufferSize, "GetAudioRendererWorkBufferSize"},
         {2, &AudRenU::GetAudioDevice, "GetAudioDevice"},

--- a/src/core/hle/service/audio/codecctl.cpp
+++ b/src/core/hle/service/audio/codecctl.cpp
@@ -10,7 +10,7 @@
 namespace Service::Audio {
 
 CodecCtl::CodecCtl() : ServiceFramework("codecctl") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "InitializeCodecController"},
         {1, nullptr, "FinalizeCodecController"},
         {2, nullptr, "SleepCodecController"},

--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -30,7 +30,7 @@ public:
                                 u32 channel_count)
         : ServiceFramework("IHardwareOpusDecoderManager"), decoder(std::move(decoder)),
           sample_rate(sample_rate), channel_count(channel_count) {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IHardwareOpusDecoderManager::DecodeInterleaved, "DecodeInterleaved"},
             {1, nullptr, "SetContext"},
             {2, nullptr, "DecodeInterleavedForMultiStream"},
@@ -204,7 +204,7 @@ void HwOpus::OpenOpusDecoder(Kernel::HLERequestContext& ctx) {
 }
 
 HwOpus::HwOpus() : ServiceFramework("hwopus") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &HwOpus::OpenOpusDecoder, "OpenOpusDecoder"},
         {1, &HwOpus::GetWorkBufferSize, "GetWorkBufferSize"},
         {2, nullptr, "OpenOpusDecoderForMultiStream"},

--- a/src/core/hle/service/bcat/bcat.cpp
+++ b/src/core/hle/service/bcat/bcat.cpp
@@ -8,7 +8,7 @@ namespace Service::BCAT {
 
 BCAT::BCAT(std::shared_ptr<Module> module, const char* name)
     : Module::Interface(std::move(module), name) {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &BCAT::CreateBcatService, "CreateBcatService"},
     };
     RegisterHandlers(functions);

--- a/src/core/hle/service/bcat/module.cpp
+++ b/src/core/hle/service/bcat/module.cpp
@@ -12,7 +12,7 @@ namespace Service::BCAT {
 class IBcatService final : public ServiceFramework<IBcatService> {
 public:
     IBcatService() : ServiceFramework("IBcatService") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {10100, nullptr, "RequestSyncDeliveryCache"},
             {10101, nullptr, "RequestSyncDeliveryCacheWithDirectoryName"},
             {10200, nullptr, "CancelSyncDeliveryCacheRequest"},

--- a/src/core/hle/service/bpc/bpc.cpp
+++ b/src/core/hle/service/bpc/bpc.cpp
@@ -14,7 +14,7 @@ class BPC final : public ServiceFramework<BPC> {
 public:
     explicit BPC() : ServiceFramework{"bpc"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "ShutdownSystem"},
             {1, nullptr, "RebootSystem"},
             {2, nullptr, "GetWakeupReason"},
@@ -37,7 +37,7 @@ class BPC_R final : public ServiceFramework<BPC_R> {
 public:
     explicit BPC_R() : ServiceFramework{"bpc:r"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "GetExternalRtcValue"},
             {1, nullptr, "SetExternalRtcValue"},
             {2, nullptr, "ReadExternalRtcResetFlag"},

--- a/src/core/hle/service/btdrv/btdrv.cpp
+++ b/src/core/hle/service/btdrv/btdrv.cpp
@@ -18,7 +18,7 @@ class Bt final : public ServiceFramework<Bt> {
 public:
     explicit Bt() : ServiceFramework{"bt"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Unknown0"},
             {1, nullptr, "Unknown1"},
             {2, nullptr, "Unknown2"},
@@ -54,7 +54,7 @@ class BtDrv final : public ServiceFramework<BtDrv> {
 public:
     explicit BtDrv() : ServiceFramework{"btdrv"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Unknown"},
             {1, nullptr, "Init"},
             {2, nullptr, "Enable"},

--- a/src/core/hle/service/btm/btm.cpp
+++ b/src/core/hle/service/btm/btm.cpp
@@ -19,7 +19,7 @@ class IBtmUserCore final : public ServiceFramework<IBtmUserCore> {
 public:
     explicit IBtmUserCore() : ServiceFramework{"IBtmUserCore"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IBtmUserCore::GetScanEvent, "GetScanEvent"},
             {1, nullptr, "Unknown1"},
             {2, nullptr, "Unknown2"},
@@ -110,7 +110,7 @@ class BTM_USR final : public ServiceFramework<BTM_USR> {
 public:
     explicit BTM_USR() : ServiceFramework{"btm:u"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &BTM_USR::GetCoreImpl, "GetCoreImpl"},
         };
         // clang-format on
@@ -131,7 +131,7 @@ class BTM final : public ServiceFramework<BTM> {
 public:
     explicit BTM() : ServiceFramework{"btm"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Unknown1"},
             {1, nullptr, "Unknown2"},
             {2, nullptr, "RegisterSystemEventForConnectedDeviceConditionImpl"},
@@ -165,7 +165,7 @@ class BTM_DBG final : public ServiceFramework<BTM_DBG> {
 public:
     explicit BTM_DBG() : ServiceFramework{"btm:dbg"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "RegisterSystemEventForDiscoveryImpl"},
             {1, nullptr, "Unknown1"},
             {2, nullptr, "Unknown2"},
@@ -186,7 +186,7 @@ class IBtmSystemCore final : public ServiceFramework<IBtmSystemCore> {
 public:
     explicit IBtmSystemCore() : ServiceFramework{"IBtmSystemCore"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "StartGamepadPairingImpl"},
             {1, nullptr, "CancelGamepadPairingImpl"},
             {2, nullptr, "ClearGamepadPairingDatabaseImpl"},
@@ -208,7 +208,7 @@ class BTM_SYS final : public ServiceFramework<BTM_SYS> {
 public:
     explicit BTM_SYS() : ServiceFramework{"btm:sys"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &BTM_SYS::GetCoreImpl, "GetCoreImpl"},
         };
         // clang-format on

--- a/src/core/hle/service/caps/caps.cpp
+++ b/src/core/hle/service/caps/caps.cpp
@@ -14,7 +14,7 @@ class CAPS_A final : public ServiceFramework<CAPS_A> {
 public:
     explicit CAPS_A() : ServiceFramework{"caps:a"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Unknown1"},
             {1, nullptr, "Unknown2"},
             {2, nullptr, "Unknown3"},
@@ -52,7 +52,7 @@ class CAPS_C final : public ServiceFramework<CAPS_C> {
 public:
     explicit CAPS_C() : ServiceFramework{"caps:c"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {2001, nullptr, "Unknown1"},
             {2002, nullptr, "Unknown2"},
             {2011, nullptr, "Unknown3"},
@@ -74,7 +74,7 @@ class CAPS_SC final : public ServiceFramework<CAPS_SC> {
 public:
     explicit CAPS_SC() : ServiceFramework{"caps:sc"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {1, nullptr, "Unknown1"},
             {2, nullptr, "Unknown2"},
             {1001, nullptr, "Unknown3"},
@@ -96,7 +96,7 @@ class CAPS_SS final : public ServiceFramework<CAPS_SS> {
 public:
     explicit CAPS_SS() : ServiceFramework{"caps:ss"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {201, nullptr, "Unknown1"},
             {202, nullptr, "Unknown2"},
             {203, nullptr, "Unknown3"},
@@ -112,7 +112,7 @@ class CAPS_SU final : public ServiceFramework<CAPS_SU> {
 public:
     explicit CAPS_SU() : ServiceFramework{"caps:su"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {201, nullptr, "SaveScreenShot"},
             {203, nullptr, "SaveScreenShotEx0"},
         };
@@ -126,7 +126,7 @@ class CAPS_U final : public ServiceFramework<CAPS_U> {
 public:
     explicit CAPS_U() : ServiceFramework{"caps:u"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {102, nullptr, "GetAlbumFileListByAruid"},
             {103, nullptr, "DeleteAlbumFileByAruid"},
             {104, nullptr, "GetAlbumFileSizeByAruid"},

--- a/src/core/hle/service/erpt/erpt.cpp
+++ b/src/core/hle/service/erpt/erpt.cpp
@@ -14,7 +14,7 @@ class ErrorReportContext final : public ServiceFramework<ErrorReportContext> {
 public:
     explicit ErrorReportContext() : ServiceFramework{"erpt:c"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "SubmitContext"},
             {1, nullptr, "CreateReport"},
             {2, nullptr, "SetInitialLaunchSettingsCompletionTime"},
@@ -35,7 +35,7 @@ class ErrorReportSession final : public ServiceFramework<ErrorReportSession> {
 public:
     explicit ErrorReportSession() : ServiceFramework{"erpt:r"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "OpenReport"},
             {1, nullptr, "OpenManager"},
         };

--- a/src/core/hle/service/es/es.cpp
+++ b/src/core/hle/service/es/es.cpp
@@ -10,7 +10,7 @@ class ETicket final : public ServiceFramework<ETicket> {
 public:
     explicit ETicket() : ServiceFramework{"es"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {1, nullptr, "ImportTicket"},
             {2, nullptr, "ImportTicketCertificateSet"},
             {3, nullptr, "DeleteTicket"},

--- a/src/core/hle/service/eupld/eupld.cpp
+++ b/src/core/hle/service/eupld/eupld.cpp
@@ -14,7 +14,7 @@ class ErrorUploadContext final : public ServiceFramework<ErrorUploadContext> {
 public:
     explicit ErrorUploadContext() : ServiceFramework{"eupld:c"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "SetUrl"},
             {1, nullptr, "ImportCrt"},
             {2, nullptr, "ImportPki"},
@@ -30,7 +30,7 @@ class ErrorUploadRequest final : public ServiceFramework<ErrorUploadRequest> {
 public:
     explicit ErrorUploadRequest() : ServiceFramework{"eupld:r"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
             {1, nullptr, "UploadAll"},
             {2, nullptr, "UploadSelected"},

--- a/src/core/hle/service/fatal/fatal_u.cpp
+++ b/src/core/hle/service/fatal/fatal_u.cpp
@@ -7,7 +7,7 @@
 namespace Service::Fatal {
 
 Fatal_U::Fatal_U(std::shared_ptr<Module> module) : Module::Interface(std::move(module), "fatal:u") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &Fatal_U::ThrowFatal, "ThrowFatal"},
         {1, &Fatal_U::ThrowFatalWithPolicy, "ThrowFatalWithPolicy"},
         {2, &Fatal_U::ThrowFatalWithCpuContext, "ThrowFatalWithCpuContext"},

--- a/src/core/hle/service/fgm/fgm.cpp
+++ b/src/core/hle/service/fgm/fgm.cpp
@@ -16,7 +16,7 @@ class IRequest final : public ServiceFramework<IRequest> {
 public:
     explicit IRequest() : ServiceFramework{"IRequest"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
             {1, nullptr, "Set"},
             {2, nullptr, "Get"},
@@ -32,7 +32,7 @@ class FGM final : public ServiceFramework<FGM> {
 public:
     explicit FGM(const char* name) : ServiceFramework{name} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &FGM::Initialize, "Initialize"},
         };
         // clang-format on
@@ -54,7 +54,7 @@ class FGM_DBG final : public ServiceFramework<FGM_DBG> {
 public:
     explicit FGM_DBG() : ServiceFramework{"fgm:dbg"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
             {1, nullptr, "Read"},
             {2, nullptr, "Cancel"},

--- a/src/core/hle/service/filesystem/fsp_ldr.cpp
+++ b/src/core/hle/service/filesystem/fsp_ldr.cpp
@@ -9,7 +9,7 @@ namespace Service::FileSystem {
 
 FSP_LDR::FSP_LDR() : ServiceFramework{"fsp:ldr"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "OpenCodeFileSystem"},
         {1, nullptr, "IsArchivedProgram"},
         {2, nullptr, "SetCurrentProcess"},

--- a/src/core/hle/service/filesystem/fsp_pr.cpp
+++ b/src/core/hle/service/filesystem/fsp_pr.cpp
@@ -9,7 +9,7 @@ namespace Service::FileSystem {
 
 FSP_PR::FSP_PR() : ServiceFramework{"fsp:pr"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "RegisterProgram"},
         {1, nullptr, "UnregisterProgram"},
         {2, nullptr, "SetCurrentProcess"},

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -44,7 +44,7 @@ class IStorage final : public ServiceFramework<IStorage> {
 public:
     explicit IStorage(FileSys::VirtualFile backend_)
         : ServiceFramework("IStorage"), backend(std::move(backend_)) {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IStorage::Read, "Read"},
             {1, nullptr, "Write"},
             {2, nullptr, "Flush"},
@@ -102,7 +102,7 @@ class IFile final : public ServiceFramework<IFile> {
 public:
     explicit IFile(FileSys::VirtualFile backend_)
         : ServiceFramework("IFile"), backend(std::move(backend_)) {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IFile::Read, "Read"},       {1, &IFile::Write, "Write"},
             {2, &IFile::Flush, "Flush"},     {3, &IFile::SetSize, "SetSize"},
             {4, &IFile::GetSize, "GetSize"}, {5, nullptr, "OperateRange"},
@@ -232,7 +232,7 @@ class IDirectory final : public ServiceFramework<IDirectory> {
 public:
     explicit IDirectory(FileSys::VirtualDir backend_)
         : ServiceFramework("IDirectory"), backend(std::move(backend_)) {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IDirectory::Read, "Read"},
             {1, &IDirectory::GetEntryCount, "GetEntryCount"},
         };
@@ -291,7 +291,7 @@ class IFileSystem final : public ServiceFramework<IFileSystem> {
 public:
     explicit IFileSystem(FileSys::VirtualDir backend)
         : ServiceFramework("IFileSystem"), backend(std::move(backend)) {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IFileSystem::CreateFile, "CreateFile"},
             {1, &IFileSystem::DeleteFile, "DeleteFile"},
             {2, &IFileSystem::CreateDirectory, "CreateDirectory"},
@@ -487,7 +487,7 @@ class ISaveDataInfoReader final : public ServiceFramework<ISaveDataInfoReader> {
 public:
     explicit ISaveDataInfoReader(FileSys::SaveDataSpaceId space)
         : ServiceFramework("ISaveDataInfoReader") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &ISaveDataInfoReader::ReadSaveDataInfo, "ReadSaveDataInfo"},
         };
         RegisterHandlers(functions);
@@ -626,7 +626,7 @@ private:
 
 FSP_SRV::FSP_SRV() : ServiceFramework("fsp-srv") {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "MountContent"},
         {1, &FSP_SRV::Initialize, "Initialize"},
         {2, nullptr, "OpenDataFileSystemByCurrentProcess"},

--- a/src/core/hle/service/friend/friend.cpp
+++ b/src/core/hle/service/friend/friend.cpp
@@ -12,7 +12,7 @@ namespace Service::Friend {
 class IFriendService final : public ServiceFramework<IFriendService> {
 public:
     IFriendService() : ServiceFramework("IFriendService") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "GetCompletionEvent"},
             {1, nullptr, "Cancel"},
             {10100, nullptr, "GetFriendListIds"},

--- a/src/core/hle/service/friend/interface.cpp
+++ b/src/core/hle/service/friend/interface.cpp
@@ -8,7 +8,7 @@ namespace Service::Friend {
 
 Friend::Friend(std::shared_ptr<Module> module, const char* name)
     : Interface(std::move(module), name) {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &Friend::CreateFriendService, "CreateFriendService"},
         {1, nullptr, "CreateNotificationService"},
         {2, nullptr, "CreateDaemonSuspendSessionService"},

--- a/src/core/hle/service/grc/grc.cpp
+++ b/src/core/hle/service/grc/grc.cpp
@@ -14,7 +14,7 @@ class GRC final : public ServiceFramework<GRC> {
 public:
     explicit GRC() : ServiceFramework{"grc:c"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {1, nullptr, "OpenContinuousRecorder"},
             {2, nullptr, "OpenGameMovieTrimmer"},
         };

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -59,7 +59,7 @@ enum class HidController : std::size_t {
 class IAppletResource final : public ServiceFramework<IAppletResource> {
 public:
     IAppletResource() : ServiceFramework("IAppletResource") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IAppletResource::GetSharedMemoryHandle, "GetSharedMemoryHandle"},
         };
         RegisterHandlers(functions);
@@ -157,7 +157,7 @@ private:
 class IActiveVibrationDeviceList final : public ServiceFramework<IActiveVibrationDeviceList> {
 public:
     IActiveVibrationDeviceList() : ServiceFramework("IActiveVibrationDeviceList") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IActiveVibrationDeviceList::ActivateVibrationDevice, "ActivateVibrationDevice"},
         };
         RegisterHandlers(functions);
@@ -176,7 +176,7 @@ class Hid final : public ServiceFramework<Hid> {
 public:
     Hid() : ServiceFramework("hid") {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &Hid::CreateAppletResource, "CreateAppletResource"},
             {1, &Hid::ActivateDebugPad, "ActivateDebugPad"},
             {11, &Hid::ActivateTouchScreen, "ActivateTouchScreen"},
@@ -651,7 +651,7 @@ class HidDbg final : public ServiceFramework<HidDbg> {
 public:
     explicit HidDbg() : ServiceFramework{"hid:dbg"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "DeactivateDebugPad"},
             {1, nullptr, "SetDebugPadAutoPilotState"},
             {2, nullptr, "UnsetDebugPadAutoPilotState"},
@@ -734,7 +734,7 @@ class HidSys final : public ServiceFramework<HidSys> {
 public:
     explicit HidSys() : ServiceFramework{"hid:sys"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {31, nullptr, "SendKeyboardLockKeyEvent"},
             {101, nullptr, "AcquireHomeButtonEventHandle"},
             {111, nullptr, "ActivateHomeButton"},
@@ -851,7 +851,7 @@ class HidTmp final : public ServiceFramework<HidTmp> {
 public:
     explicit HidTmp() : ServiceFramework{"hid:tmp"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "GetConsoleSixAxisSensorCalibrationValues"},
         };
         // clang-format on
@@ -864,7 +864,7 @@ class HidBus final : public ServiceFramework<HidBus> {
 public:
     explicit HidBus() : ServiceFramework{"hidbus"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {1, nullptr, "GetBusHandle"},
             {2, nullptr, "IsExternalDeviceConnected"},
             {3, nullptr, "Initialize"},

--- a/src/core/hle/service/hid/irs.cpp
+++ b/src/core/hle/service/hid/irs.cpp
@@ -13,7 +13,7 @@ namespace Service::HID {
 
 IRS::IRS() : ServiceFramework{"irs"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {302, &IRS::ActivateIrsensor, "ActivateIrsensor"},
         {303, &IRS::DeactivateIrsensor, "DeactivateIrsensor"},
         {304, &IRS::GetIrsensorSharedMemoryHandle, "GetIrsensorSharedMemoryHandle"},
@@ -177,7 +177,7 @@ IRS::~IRS() = default;
 
 IRS_SYS::IRS_SYS() : ServiceFramework{"irs:sys"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {500, nullptr, "SetAppletResourceUserId"},
         {501, nullptr, "RegisterAppletResourceUserId"},
         {502, nullptr, "UnregisterAppletResourceUserId"},

--- a/src/core/hle/service/hid/xcd.cpp
+++ b/src/core/hle/service/hid/xcd.cpp
@@ -8,7 +8,7 @@ namespace Service::HID {
 
 XCD_SYS::XCD_SYS() : ServiceFramework{"xcd:sys"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "GetDataFormat"},
         {1, nullptr, "SetDataFormat"},
         {2, nullptr, "GetMcuState"},

--- a/src/core/hle/service/lbl/lbl.cpp
+++ b/src/core/hle/service/lbl/lbl.cpp
@@ -17,7 +17,7 @@ class LBL final : public ServiceFramework<LBL> {
 public:
     explicit LBL() : ServiceFramework{"lbl"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "SaveCurrentSetting"},
             {1, nullptr, "LoadCurrentSetting"},
             {2, nullptr, "SetCurrentBrightnessSetting"},

--- a/src/core/hle/service/ldn/ldn.cpp
+++ b/src/core/hle/service/ldn/ldn.cpp
@@ -15,7 +15,7 @@ class IMonitorService final : public ServiceFramework<IMonitorService> {
 public:
     explicit IMonitorService() : ServiceFramework{"IMonitorService"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "GetStateForMonitor"},
             {1, nullptr, "GetNetworkInfoForMonitor"},
             {2, nullptr, "GetIpv4AddressForMonitor"},
@@ -35,7 +35,7 @@ class LDNM final : public ServiceFramework<LDNM> {
 public:
     explicit LDNM() : ServiceFramework{"ldn:m"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &LDNM::CreateMonitorService, "CreateMonitorService"}
         };
         // clang-format on
@@ -56,7 +56,7 @@ class ILocalCommunicationService final : public ServiceFramework<ILocalCommunica
 public:
     explicit ILocalCommunicationService(const char* name) : ServiceFramework{name} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "GetState"},
             {1, nullptr, "GetNetworkInfo"},
             {2, nullptr, "GetIpv4Address"},
@@ -95,7 +95,7 @@ class LDNS final : public ServiceFramework<LDNS> {
 public:
     explicit LDNS() : ServiceFramework{"ldn:s"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &LDNS::CreateSystemLocalCommunicationService, "CreateSystemLocalCommunicationService"},
         };
         // clang-format on
@@ -116,7 +116,7 @@ class LDNU final : public ServiceFramework<LDNU> {
 public:
     explicit LDNU() : ServiceFramework{"ldn:u"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &LDNU::CreateUserLocalCommunicationService, "CreateUserLocalCommunicationService"},
         };
         // clang-format on

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -35,7 +35,7 @@ class DebugMonitor final : public ServiceFramework<DebugMonitor> {
 public:
     explicit DebugMonitor() : ServiceFramework{"ldr:dmnt"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "AddProcessToDebugLaunchQueue"},
             {1, nullptr, "ClearDebugLaunchQueue"},
             {2, nullptr, "GetNsoInfos"},
@@ -50,7 +50,7 @@ class ProcessManager final : public ServiceFramework<ProcessManager> {
 public:
     explicit ProcessManager() : ServiceFramework{"ldr:pm"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "CreateProcess"},
             {1, nullptr, "GetProgramInfo"},
             {2, nullptr, "RegisterTitle"},
@@ -66,7 +66,7 @@ class Shell final : public ServiceFramework<Shell> {
 public:
     explicit Shell() : ServiceFramework{"ldr:shel"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "AddProcessToLaunchQueue"},
             {1, nullptr, "ClearLaunchQueue"},
         };
@@ -80,7 +80,7 @@ class RelocatableObject final : public ServiceFramework<RelocatableObject> {
 public:
     explicit RelocatableObject() : ServiceFramework{"ldr:ro"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &RelocatableObject::LoadNro, "LoadNro"},
             {1, &RelocatableObject::UnloadNro, "UnloadNro"},
             {2, &RelocatableObject::LoadNrr, "LoadNrr"},

--- a/src/core/hle/service/lm/lm.cpp
+++ b/src/core/hle/service/lm/lm.cpp
@@ -16,7 +16,7 @@ namespace Service::LM {
 class ILogger final : public ServiceFramework<ILogger> {
 public:
     ILogger() : ServiceFramework("ILogger") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0x00000000, &ILogger::Initialize, "Initialize"},
             {0x00000001, &ILogger::SetDestination, "SetDestination"},
         };
@@ -195,7 +195,7 @@ private:
 class LM final : public ServiceFramework<LM> {
 public:
     explicit LM() : ServiceFramework{"lm"} {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0x00000000, &LM::OpenLogger, "OpenLogger"},
         };
         RegisterHandlers(functions);

--- a/src/core/hle/service/mig/mig.cpp
+++ b/src/core/hle/service/mig/mig.cpp
@@ -14,7 +14,7 @@ class MIG_USR final : public ServiceFramework<MIG_USR> {
 public:
     explicit MIG_USR() : ServiceFramework{"mig:usr"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {10, nullptr, "TryGetLastMigrationInfo"},
             {100, nullptr, "CreateServer"},
             {101, nullptr, "ResumeServer"},

--- a/src/core/hle/service/mii/mii.cpp
+++ b/src/core/hle/service/mii/mii.cpp
@@ -17,7 +17,7 @@ class IDatabaseService final : public ServiceFramework<IDatabaseService> {
 public:
     explicit IDatabaseService() : ServiceFramework{"IDatabaseService"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "IsUpdated"},
             {1, nullptr, "IsFullDatabase"},
             {2, nullptr, "GetCount"},
@@ -53,7 +53,7 @@ class MiiDBModule final : public ServiceFramework<MiiDBModule> {
 public:
     explicit MiiDBModule(const char* name) : ServiceFramework{name} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &MiiDBModule::GetDatabaseService, "GetDatabaseService"},
         };
         // clang-format on
@@ -75,7 +75,7 @@ class MiiImg final : public ServiceFramework<MiiImg> {
 public:
     explicit MiiImg() : ServiceFramework{"miiimg"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
             {10, nullptr, "Reload"},
             {11, nullptr, "GetCount"},

--- a/src/core/hle/service/mm/mm_u.cpp
+++ b/src/core/hle/service/mm/mm_u.cpp
@@ -13,7 +13,7 @@ class MM_U final : public ServiceFramework<MM_U> {
 public:
     explicit MM_U() : ServiceFramework{"mm:u"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &MM_U::Initialize, "Initialize"},
             {1, &MM_U::Finalize, "Finalize"},
             {2, &MM_U::SetAndWait, "SetAndWait"},

--- a/src/core/hle/service/ncm/ncm.cpp
+++ b/src/core/hle/service/ncm/ncm.cpp
@@ -14,7 +14,7 @@ class LocationResolver final : public ServiceFramework<LocationResolver> {
 public:
     explicit LocationResolver() : ServiceFramework{"lr"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "OpenLocationResolver"},
             {1, nullptr, "OpenRegisteredLocationResolver"},
             {2, nullptr, "RefreshLocationResolver"},
@@ -30,7 +30,7 @@ class NCM final : public ServiceFramework<NCM> {
 public:
     explicit NCM() : ServiceFramework{"ncm"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "CreateContentStorage"},
             {1, nullptr, "CreateContentMetaDatabase"},
             {2, nullptr, "VerifyContentStorage"},

--- a/src/core/hle/service/nfc/nfc.cpp
+++ b/src/core/hle/service/nfc/nfc.cpp
@@ -18,7 +18,7 @@ class IAm final : public ServiceFramework<IAm> {
 public:
     explicit IAm() : ServiceFramework{"NFC::IAm"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
             {1, nullptr, "Finalize"},
             {2, nullptr, "NotifyForegroundApplet"},
@@ -33,7 +33,7 @@ class NFC_AM final : public ServiceFramework<NFC_AM> {
 public:
     explicit NFC_AM() : ServiceFramework{"nfc:am"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &NFC_AM::CreateAmInterface, "CreateAmInterface"},
         };
         // clang-format on
@@ -55,7 +55,7 @@ class MFIUser final : public ServiceFramework<MFIUser> {
 public:
     explicit MFIUser() : ServiceFramework{"NFC::MFIUser"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
             {1, nullptr, "Finalize"},
             {2, nullptr, "ListDevices"},
@@ -81,7 +81,7 @@ class NFC_MF_U final : public ServiceFramework<NFC_MF_U> {
 public:
     explicit NFC_MF_U() : ServiceFramework{"nfc:mf:u"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &NFC_MF_U::CreateUserInterface, "CreateUserInterface"},
         };
         // clang-format on
@@ -103,7 +103,7 @@ class IUser final : public ServiceFramework<IUser> {
 public:
     explicit IUser() : ServiceFramework{"NFC::IUser"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IUser::InitializeOld, "InitializeOld"},
             {1, &IUser::FinalizeOld, "FinalizeOld"},
             {2, &IUser::GetStateOld, "GetStateOld"},
@@ -173,7 +173,7 @@ class NFC_U final : public ServiceFramework<NFC_U> {
 public:
     explicit NFC_U() : ServiceFramework{"nfc:user"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &NFC_U::CreateUserInterface, "CreateUserInterface"},
         };
         // clang-format on
@@ -195,7 +195,7 @@ class ISystem final : public ServiceFramework<ISystem> {
 public:
     explicit ISystem() : ServiceFramework{"ISystem"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
             {1, nullptr, "Finalize"},
             {2, nullptr, "GetState"},
@@ -231,7 +231,7 @@ class NFC_SYS final : public ServiceFramework<NFC_SYS> {
 public:
     explicit NFC_SYS() : ServiceFramework{"nfc:sys"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &NFC_SYS::CreateSystemInterface, "CreateSystemInterface"},
         };
         // clang-format on

--- a/src/core/hle/service/nfp/nfp.cpp
+++ b/src/core/hle/service/nfp/nfp.cpp
@@ -35,7 +35,7 @@ class IUser final : public ServiceFramework<IUser> {
 public:
     IUser(Module::Interface& nfp_interface)
         : ServiceFramework("NFP::IUser"), nfp_interface(nfp_interface) {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IUser::Initialize, "Initialize"},
             {1, &IUser::Finalize, "Finalize"},
             {2, &IUser::ListDevices, "ListDevices"},

--- a/src/core/hle/service/nfp/nfp_user.cpp
+++ b/src/core/hle/service/nfp/nfp_user.cpp
@@ -8,7 +8,7 @@ namespace Service::NFP {
 
 NFP_User::NFP_User(std::shared_ptr<Module> module)
     : Module::Interface(std::move(module), "nfp:user") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &NFP_User::CreateUserInterface, "CreateUserInterface"},
     };
     RegisterHandlers(functions);

--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -15,7 +15,7 @@ namespace Service::NIFM {
 class IScanRequest final : public ServiceFramework<IScanRequest> {
 public:
     explicit IScanRequest() : ServiceFramework("IScanRequest") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Submit"},
             {1, nullptr, "IsProcessing"},
             {2, nullptr, "GetResult"},
@@ -28,7 +28,7 @@ public:
 class IRequest final : public ServiceFramework<IRequest> {
 public:
     explicit IRequest() : ServiceFramework("IRequest") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IRequest::GetRequestState, "GetRequestState"},
             {1, &IRequest::GetResult, "GetResult"},
             {2, &IRequest::GetSystemEventReadableHandles, "GetSystemEventReadableHandles"},
@@ -115,7 +115,7 @@ private:
 class INetworkProfile final : public ServiceFramework<INetworkProfile> {
 public:
     explicit INetworkProfile() : ServiceFramework("INetworkProfile") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Update"},
             {1, nullptr, "PersistOld"},
             {2, nullptr, "Persist"},
@@ -197,7 +197,7 @@ private:
 };
 
 IGeneralService::IGeneralService() : ServiceFramework("IGeneralService") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {1, &IGeneralService::GetClientId, "GetClientId"},
         {2, &IGeneralService::CreateScanRequest, "CreateScanRequest"},
         {4, &IGeneralService::CreateRequest, "CreateRequest"},
@@ -242,7 +242,7 @@ IGeneralService::IGeneralService() : ServiceFramework("IGeneralService") {
 class NetworkInterface final : public ServiceFramework<NetworkInterface> {
 public:
     explicit NetworkInterface(const char* name) : ServiceFramework{name} {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {4, &NetworkInterface::CreateGeneralServiceOld, "CreateGeneralServiceOld"},
             {5, &NetworkInterface::CreateGeneralService, "CreateGeneralService"},
         };

--- a/src/core/hle/service/nim/nim.cpp
+++ b/src/core/hle/service/nim/nim.cpp
@@ -19,7 +19,7 @@ class NIM final : public ServiceFramework<NIM> {
 public:
     explicit NIM() : ServiceFramework{"nim"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "CreateSystemUpdateTask"},
             {1, nullptr, "DestroySystemUpdateTask"},
             {2, nullptr, "ListSystemUpdateTask"},
@@ -77,7 +77,7 @@ class NIM_ECA final : public ServiceFramework<NIM_ECA> {
 public:
     explicit NIM_ECA() : ServiceFramework{"nim:eca"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "CreateServerInterface"},
             {1, nullptr, "RefreshDebugAvailability"},
             {2, nullptr, "ClearDebugResponse"},
@@ -93,7 +93,7 @@ class NIM_SHP final : public ServiceFramework<NIM_SHP> {
 public:
     explicit NIM_SHP() : ServiceFramework{"nim:shp"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "RequestDeviceAuthenticationToken"},
             {1, nullptr, "RequestCachedDeviceAuthenticationToken"},
             {100, nullptr, "RequestRegisterDeviceAccount"},
@@ -128,7 +128,7 @@ class IEnsureNetworkClockAvailabilityService final
 public:
     IEnsureNetworkClockAvailabilityService()
         : ServiceFramework("IEnsureNetworkClockAvailabilityService") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IEnsureNetworkClockAvailabilityService::StartTask, "StartTask"},
             {1, &IEnsureNetworkClockAvailabilityService::GetFinishNotificationEvent,
              "GetFinishNotificationEvent"},
@@ -202,7 +202,7 @@ class NTC final : public ServiceFramework<NTC> {
 public:
     explicit NTC() : ServiceFramework{"ntc"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &NTC::OpenEnsureNetworkClockAvailabilityService, "OpenEnsureNetworkClockAvailabilityService"},
             {100, &NTC::SuspendAutonomicTimeCorrection, "SuspendAutonomicTimeCorrection"},
             {101, &NTC::ResumeAutonomicTimeCorrection, "ResumeAutonomicTimeCorrection"},

--- a/src/core/hle/service/npns/npns.cpp
+++ b/src/core/hle/service/npns/npns.cpp
@@ -14,7 +14,7 @@ class NPNS_S final : public ServiceFramework<NPNS_S> {
 public:
     explicit NPNS_S() : ServiceFramework{"npns:s"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {1, nullptr, "ListenAll"},
             {2, nullptr, "ListenTo"},
             {3, nullptr, "Receive"},
@@ -57,7 +57,7 @@ class NPNS_U final : public ServiceFramework<NPNS_U> {
 public:
     explicit NPNS_U() : ServiceFramework{"npns:u"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {1, nullptr, "ListenAll"},
             {2, nullptr, "ListenTo"},
             {3, nullptr, "Receive"},

--- a/src/core/hle/service/ns/ns.cpp
+++ b/src/core/hle/service/ns/ns.cpp
@@ -16,7 +16,7 @@ class IAccountProxyInterface final : public ServiceFramework<IAccountProxyInterf
 public:
     explicit IAccountProxyInterface() : ServiceFramework{"IAccountProxyInterface"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "CreateUserAccount"},
         };
         // clang-format on
@@ -29,7 +29,7 @@ class IApplicationManagerInterface final : public ServiceFramework<IApplicationM
 public:
     explicit IApplicationManagerInterface() : ServiceFramework{"IApplicationManagerInterface"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "ListApplicationRecord"},
             {1, nullptr, "GenerateApplicationRecordCount"},
             {2, nullptr, "GetApplicationRecordUpdateSystemEvent"},
@@ -311,7 +311,7 @@ class IApplicationVersionInterface final : public ServiceFramework<IApplicationV
 public:
     explicit IApplicationVersionInterface() : ServiceFramework{"IApplicationVersionInterface"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "GetLaunchRequiredVersion"},
             {1, nullptr, "UpgradeLaunchRequiredVersion"},
             {35, nullptr, "UpdateVersionList"},
@@ -332,7 +332,7 @@ class IContentManagerInterface final : public ServiceFramework<IContentManagerIn
 public:
     explicit IContentManagerInterface() : ServiceFramework{"IContentManagerInterface"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {11, nullptr, "CalculateApplicationOccupiedSize"},
             {43, nullptr, "CheckSdCardMountStatus"},
             {47, nullptr, "GetTotalSpaceSize"},
@@ -352,7 +352,7 @@ class IDocumentInterface final : public ServiceFramework<IDocumentInterface> {
 public:
     explicit IDocumentInterface() : ServiceFramework{"IDocumentInterface"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {21, nullptr, "GetApplicationContentPath"},
             {23, nullptr, "ResolveApplicationContentPath"},
         };
@@ -366,7 +366,7 @@ class IDownloadTaskInterface final : public ServiceFramework<IDownloadTaskInterf
 public:
     explicit IDownloadTaskInterface() : ServiceFramework{"IDownloadTaskInterface"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {701, nullptr, "ClearTaskStatusList"},
             {702, nullptr, "RequestDownloadTaskList"},
             {703, nullptr, "RequestEnsureDownloadTask"},
@@ -387,7 +387,7 @@ class IECommerceInterface final : public ServiceFramework<IECommerceInterface> {
 public:
     explicit IECommerceInterface() : ServiceFramework{"IECommerceInterface"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "RequestLinkDevice"},
         };
         // clang-format on
@@ -400,7 +400,7 @@ class IFactoryResetInterface final : public ServiceFramework<IFactoryResetInterf
 public:
     explicit IFactoryResetInterface() : ServiceFramework{"IFactoryResetInterface"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {100, nullptr, "ResetToFactorySettings"},
             {101, nullptr, "ResetToFactorySettingsWithoutUserSaveData"},
             {102, nullptr, "ResetToFactorySettingsForRefurbishment "},
@@ -415,7 +415,7 @@ class NS final : public ServiceFramework<NS> {
 public:
     explicit NS(const char* name) : ServiceFramework{name} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {7992, &NS::PushInterface<IECommerceInterface>, "GetECommerceInterface"},
             {7993, &NS::PushInterface<IApplicationVersionInterface>, "GetApplicationVersionInterface"},
             {7994, &NS::PushInterface<IFactoryResetInterface>, "GetFactoryResetInterface"},
@@ -445,7 +445,7 @@ class NS_DEV final : public ServiceFramework<NS_DEV> {
 public:
     explicit NS_DEV() : ServiceFramework{"ns:dev"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "LaunchProgram"},
             {1, nullptr, "TerminateProcess"},
             {2, nullptr, "TerminateProgram"},
@@ -469,7 +469,7 @@ class ISystemUpdateControl final : public ServiceFramework<ISystemUpdateControl>
 public:
     explicit ISystemUpdateControl() : ServiceFramework{"ISystemUpdateControl"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "HasDownloaded"},
             {1, nullptr, "RequestCheckLatestUpdate"},
             {2, nullptr, "RequestDownloadLatestUpdate"},
@@ -504,7 +504,7 @@ class NS_SU final : public ServiceFramework<NS_SU> {
 public:
     explicit NS_SU() : ServiceFramework{"ns:su"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "GetBackgroundNetworkUpdateState"},
             {1, &NS_SU::OpenSystemUpdateControl, "OpenSystemUpdateControl"},
             {2, nullptr, "NotifyExFatDriverRequired"},
@@ -538,7 +538,7 @@ class NS_VM final : public ServiceFramework<NS_VM> {
 public:
     explicit NS_VM() : ServiceFramework{"ns:vm"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {1200, nullptr, "NeedsUpdateVulnerability"},
             {1201, nullptr, "UpdateSafeSystemVersionForDebug"},
             {1202, nullptr, "GetSafeSystemVersion"},

--- a/src/core/hle/service/ns/pl_u.cpp
+++ b/src/core/hle/service/ns/pl_u.cpp
@@ -151,7 +151,7 @@ struct PL_U::Impl {
 };
 
 PL_U::PL_U() : ServiceFramework("pl:u"), impl{std::make_unique<Impl>()} {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &PL_U::RequestLoad, "RequestLoad"},
         {1, &PL_U::GetLoadState, "GetLoadState"},
         {2, &PL_U::GetSize, "GetSize"},

--- a/src/core/hle/service/nvdrv/interface.cpp
+++ b/src/core/hle/service/nvdrv/interface.cpp
@@ -110,7 +110,7 @@ void NVDRV::DumpGraphicsMemoryInfo(Kernel::HLERequestContext& ctx) {
 
 NVDRV::NVDRV(std::shared_ptr<Module> nvdrv, const char* name)
     : ServiceFramework(name), nvdrv(std::move(nvdrv)) {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &NVDRV::Open, "Open"},
         {1, &NVDRV::Ioctl, "Ioctl"},
         {2, &NVDRV::Close, "Close"},

--- a/src/core/hle/service/nvdrv/nvmemp.cpp
+++ b/src/core/hle/service/nvdrv/nvmemp.cpp
@@ -9,7 +9,7 @@
 namespace Service::Nvidia {
 
 NVMEMP::NVMEMP() : ServiceFramework("nvmemp") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &NVMEMP::Cmd0, "Cmd0"},
         {1, &NVMEMP::Cmd1, "Cmd1"},
     };

--- a/src/core/hle/service/pcie/pcie.cpp
+++ b/src/core/hle/service/pcie/pcie.cpp
@@ -14,7 +14,7 @@ class ISession final : public ServiceFramework<ISession> {
 public:
     explicit ISession() : ServiceFramework{"ISession"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "QueryFunctions"},
             {1, nullptr, "AcquireFunction"},
             {2, nullptr, "ReleaseFunction"},
@@ -47,7 +47,7 @@ class PCIe final : public ServiceFramework<PCIe> {
 public:
     explicit PCIe() : ServiceFramework{"pcie"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "RegisterClassDriver"},
             {1, nullptr, "QueryFunctionsUnregistered"},
         };

--- a/src/core/hle/service/pctl/module.cpp
+++ b/src/core/hle/service/pctl/module.cpp
@@ -12,7 +12,7 @@ namespace Service::PCTL {
 class IParentalControlService final : public ServiceFramework<IParentalControlService> {
 public:
     IParentalControlService() : ServiceFramework("IParentalControlService") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {1, &IParentalControlService::Initialize, "Initialize"},
             {1001, &IParentalControlService::CheckFreeCommunicationPermission,
              "CheckFreeCommunicationPermission"},

--- a/src/core/hle/service/pctl/pctl.cpp
+++ b/src/core/hle/service/pctl/pctl.cpp
@@ -8,7 +8,7 @@ namespace Service::PCTL {
 
 PCTL::PCTL(std::shared_ptr<Module> module, const char* name)
     : Module::Interface(std::move(module), name) {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &PCTL::CreateService, "CreateService"},
         {1, &PCTL::CreateServiceWithoutInitialize, "CreateServiceWithoutInitialize"},
     };

--- a/src/core/hle/service/pcv/pcv.cpp
+++ b/src/core/hle/service/pcv/pcv.cpp
@@ -14,7 +14,7 @@ class PCV final : public ServiceFramework<PCV> {
 public:
     explicit PCV() : ServiceFramework{"pcv"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "SetPowerEnabled"},
             {1, nullptr, "SetClockEnabled"},
             {2, nullptr, "SetClockRate"},
@@ -53,7 +53,7 @@ class PCV_ARB final : public ServiceFramework<PCV_ARB> {
 public:
     explicit PCV_ARB() : ServiceFramework{"pcv:arb"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "ReleaseControl"},
         };
         // clang-format on
@@ -66,7 +66,7 @@ class PCV_IMM final : public ServiceFramework<PCV_IMM> {
 public:
     explicit PCV_IMM() : ServiceFramework{"pcv:imm"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "SetClockRate"},
         };
         // clang-format on

--- a/src/core/hle/service/pm/pm.cpp
+++ b/src/core/hle/service/pm/pm.cpp
@@ -11,7 +11,7 @@ namespace Service::PM {
 class BootMode final : public ServiceFramework<BootMode> {
 public:
     explicit BootMode() : ServiceFramework{"pm:bm"} {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &BootMode::GetBootMode, "GetBootMode"},
             {1, nullptr, "SetMaintenanceBoot"},
         };
@@ -31,7 +31,7 @@ private:
 class DebugMonitor final : public ServiceFramework<DebugMonitor> {
 public:
     explicit DebugMonitor() : ServiceFramework{"pm:dmnt"} {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "IsDebugMode"},
             {1, nullptr, "GetDebugProcesses"},
             {2, nullptr, "StartDebugProcess"},
@@ -47,7 +47,7 @@ public:
 class Info final : public ServiceFramework<Info> {
 public:
     explicit Info() : ServiceFramework{"pm:info"} {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "GetTitleId"},
         };
         RegisterHandlers(functions);
@@ -57,7 +57,7 @@ public:
 class Shell final : public ServiceFramework<Shell> {
 public:
     explicit Shell() : ServiceFramework{"pm:shell"} {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "LaunchProcess"},
             {1, nullptr, "TerminateProcessByPid"},
             {2, nullptr, "TerminateProcessByTitleId"},

--- a/src/core/hle/service/prepo/prepo.cpp
+++ b/src/core/hle/service/prepo/prepo.cpp
@@ -13,7 +13,7 @@ class PlayReport final : public ServiceFramework<PlayReport> {
 public:
     explicit PlayReport(const char* name) : ServiceFramework{name} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {10100, nullptr, "SaveReportOld"},
             {10101, &PlayReport::SaveReportWithUserOld, "SaveReportWithUserOld"},
             {10102, nullptr, "SaveReport"},

--- a/src/core/hle/service/psc/psc.cpp
+++ b/src/core/hle/service/psc/psc.cpp
@@ -16,7 +16,7 @@ class PSC_C final : public ServiceFramework<PSC_C> {
 public:
     explicit PSC_C() : ServiceFramework{"psc:c"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Unknown1"},
             {1, nullptr, "Unknown2"},
             {2, nullptr, "Unknown3"},
@@ -35,7 +35,7 @@ class IPmModule final : public ServiceFramework<IPmModule> {
 public:
     explicit IPmModule() : ServiceFramework{"IPmModule"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
             {1, nullptr, "GetRequest"},
             {2, nullptr, "Acknowledge"},
@@ -51,7 +51,7 @@ class PSC_M final : public ServiceFramework<PSC_M> {
 public:
     explicit PSC_M() : ServiceFramework{"psc:m"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &PSC_M::GetPmModule, "GetPmModule"},
         };
         // clang-format on

--- a/src/core/hle/service/ptm/psm.cpp
+++ b/src/core/hle/service/ptm/psm.cpp
@@ -19,7 +19,7 @@ class PSM final : public ServiceFramework<PSM> {
 public:
     explicit PSM() : ServiceFramework{"psm"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &PSM::GetBatteryChargePercentage, "GetBatteryChargePercentage"},
             {1, &PSM::GetChargerType, "GetChargerType"},
             {2, nullptr, "EnableBatteryCharging"},

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -122,9 +122,6 @@ class ServiceFramework : public ServiceFrameworkBase {
 protected:
     /// Contains information about a request type which is handled by the service.
     struct FunctionInfo : FunctionInfoBase {
-        // TODO(yuriks): This function could be constexpr, but clang is the only compiler that
-        // doesn't emit an ICE or a wrong diagnostic because of the static_cast.
-
         /**
          * Constructs a FunctionInfo for a function.
          *
@@ -134,7 +131,8 @@ protected:
          *     the request
          * @param name human-friendly name for the request. Used mostly for logging purposes.
          */
-        FunctionInfo(u32 expected_header, HandlerFnP<Self> handler_callback, const char* name)
+        constexpr FunctionInfo(u32 expected_header, HandlerFnP<Self> handler_callback,
+                               const char* name)
             : FunctionInfoBase{
                   expected_header,
                   // Type-erase member function pointer by casting it down to the base class.

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -116,7 +116,7 @@ void SET::GetLanguageCode(Kernel::HLERequestContext& ctx) {
 }
 
 SET::SET() : ServiceFramework("set") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &SET::GetLanguageCode, "GetLanguageCode"},
         {1, &SET::GetAvailableLanguageCodes, "GetAvailableLanguageCodes"},
         {2, &SET::MakeLanguageCode, "MakeLanguageCode"},

--- a/src/core/hle/service/set/set_cal.cpp
+++ b/src/core/hle/service/set/set_cal.cpp
@@ -7,7 +7,7 @@
 namespace Service::Set {
 
 SET_CAL::SET_CAL() : ServiceFramework("set:cal") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "GetBluetoothBdAddress"},
         {1, nullptr, "GetConfigurationId1"},
         {2, nullptr, "GetAccelerometerOffset"},

--- a/src/core/hle/service/set/set_fd.cpp
+++ b/src/core/hle/service/set/set_fd.cpp
@@ -7,7 +7,7 @@
 namespace Service::Set {
 
 SET_FD::SET_FD() : ServiceFramework("set:fd") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {2, nullptr, "SetSettingsItemValue"},
         {3, nullptr, "ResetSettingsItemValue"},
         {4, nullptr, "CreateSettingsItemKeyIterator"},

--- a/src/core/hle/service/set/set_sys.cpp
+++ b/src/core/hle/service/set/set_sys.cpp
@@ -29,7 +29,7 @@ void SET_SYS::SetColorSetId(Kernel::HLERequestContext& ctx) {
 }
 
 SET_SYS::SET_SYS() : ServiceFramework("set:sys") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "SetLanguageCode"},
         {1, nullptr, "SetNetworkSettings"},
         {2, nullptr, "GetNetworkSettings"},

--- a/src/core/hle/service/sm/controller.cpp
+++ b/src/core/hle/service/sm/controller.cpp
@@ -51,7 +51,7 @@ void Controller::QueryPointerBufferSize(Kernel::HLERequestContext& ctx) {
 }
 
 Controller::Controller() : ServiceFramework("IpcController") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0x00000000, &Controller::ConvertSessionToDomain, "ConvertSessionToDomain"},
         {0x00000001, nullptr, "ConvertDomainToSession"},
         {0x00000002, &Controller::DuplicateSession, "DuplicateSession"},

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -179,7 +179,7 @@ void SM::UnregisterService(Kernel::HLERequestContext& ctx) {
 
 SM::SM(std::shared_ptr<ServiceManager> service_manager)
     : ServiceFramework("sm:", 4), service_manager(std::move(service_manager)) {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0x00000000, &SM::Initialize, "Initialize"},
         {0x00000001, &SM::GetService, "GetService"},
         {0x00000002, &SM::RegisterService, "RegisterService"},

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -73,7 +73,7 @@ void BSD::Close(Kernel::HLERequestContext& ctx) {
 }
 
 BSD::BSD(const char* name) : ServiceFramework(name) {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &BSD::RegisterClient, "RegisterClient"},
         {1, &BSD::StartMonitoring, "StartMonitoring"},
         {2, &BSD::Socket, "Socket"},
@@ -113,7 +113,7 @@ BSD::~BSD() = default;
 
 BSDCFG::BSDCFG() : ServiceFramework{"bsdcfg"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "SetIfUp"},
         {1, nullptr, "SetIfUpWithEvent"},
         {2, nullptr, "CancelIf"},

--- a/src/core/hle/service/sockets/ethc.cpp
+++ b/src/core/hle/service/sockets/ethc.cpp
@@ -8,7 +8,7 @@ namespace Service::Sockets {
 
 ETHC_C::ETHC_C() : ServiceFramework{"ethc:c"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "Initialize"},
         {1, nullptr, "Cancel"},
         {2, nullptr, "GetResult"},
@@ -25,7 +25,7 @@ ETHC_C::~ETHC_C() = default;
 
 ETHC_I::ETHC_I() : ServiceFramework{"ethc:i"} {
     // clang-format off
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "GetReadableHandle"},
         {1, nullptr, "Cancel"},
         {2, nullptr, "GetResult"},

--- a/src/core/hle/service/sockets/nsd.cpp
+++ b/src/core/hle/service/sockets/nsd.cpp
@@ -7,7 +7,7 @@
 namespace Service::Sockets {
 
 NSD::NSD(const char* name) : ServiceFramework(name) {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {10, nullptr, "GetSettingName"},
         {11, nullptr, "GetEnvironmentIdentifier"},
         {12, nullptr, "GetDeviceId"},

--- a/src/core/hle/service/sockets/sfdnsres.cpp
+++ b/src/core/hle/service/sockets/sfdnsres.cpp
@@ -18,7 +18,7 @@ void SFDNSRES::GetAddrInfo(Kernel::HLERequestContext& ctx) {
 }
 
 SFDNSRES::SFDNSRES() : ServiceFramework("sfdnsres") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "SetDnsAddressesPrivate"},
         {1, nullptr, "GetDnsAddressPrivate"},
         {2, nullptr, "GetHostByName"},

--- a/src/core/hle/service/spl/csrng.cpp
+++ b/src/core/hle/service/spl/csrng.cpp
@@ -7,7 +7,7 @@
 namespace Service::SPL {
 
 CSRNG::CSRNG(std::shared_ptr<Module> module) : Module::Interface(std::move(module), "csrng") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &CSRNG::GetRandomBytes, "GetRandomBytes"},
     };
     RegisterHandlers(functions);

--- a/src/core/hle/service/spl/spl.cpp
+++ b/src/core/hle/service/spl/spl.cpp
@@ -7,7 +7,7 @@
 namespace Service::SPL {
 
 SPL::SPL(std::shared_ptr<Module> module) : Module::Interface(std::move(module), "spl:") {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, nullptr, "GetConfig"},
         {1, nullptr, "UserExpMod"},
         {2, nullptr, "GenerateAesKek"},

--- a/src/core/hle/service/ssl/ssl.cpp
+++ b/src/core/hle/service/ssl/ssl.cpp
@@ -13,7 +13,7 @@ namespace Service::SSL {
 class ISslConnection final : public ServiceFramework<ISslConnection> {
 public:
     ISslConnection() : ServiceFramework("ISslConnection") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "SetSocketDescriptor"},
             {1, nullptr, "SetHostName"},
             {2, nullptr, "SetVerifyOption"},
@@ -48,7 +48,7 @@ public:
 class ISslContext final : public ServiceFramework<ISslContext> {
 public:
     ISslContext() : ServiceFramework("ISslContext") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &ISslContext::SetOption, "SetOption"},
             {1, nullptr, "GetOption"},
             {2, &ISslContext::CreateConnection, "CreateConnection"},
@@ -89,7 +89,7 @@ class SSL final : public ServiceFramework<SSL> {
 public:
     explicit SSL() : ServiceFramework{"ssl"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &SSL::CreateContext, "CreateContext"},
             {1, nullptr, "GetContextCount"},
             {2, nullptr, "GetCertificates"},

--- a/src/core/hle/service/time/interface.cpp
+++ b/src/core/hle/service/time/interface.cpp
@@ -8,7 +8,7 @@ namespace Service::Time {
 
 Time::Time(std::shared_ptr<Module> time, const char* name)
     : Module::Interface(std::move(time), name) {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &Time::GetStandardUserSystemClock, "GetStandardUserSystemClock"},
         {1, &Time::GetStandardNetworkSystemClock, "GetStandardNetworkSystemClock"},
         {2, &Time::GetStandardSteadyClock, "GetStandardSteadyClock"},

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -56,7 +56,7 @@ static u64 CalendarToPosix(const CalendarTime& calendar_time,
 class ISystemClock final : public ServiceFramework<ISystemClock> {
 public:
     ISystemClock() : ServiceFramework("ISystemClock") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &ISystemClock::GetCurrentTime, "GetCurrentTime"},
             {1, nullptr, "SetCurrentTime"},
             {2, &ISystemClock::GetSystemClockContext, "GetSystemClockContext"},
@@ -91,7 +91,7 @@ private:
 class ISteadyClock final : public ServiceFramework<ISteadyClock> {
 public:
     ISteadyClock() : ServiceFramework("ISteadyClock") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &ISteadyClock::GetCurrentTimePoint, "GetCurrentTimePoint"},
         };
         RegisterHandlers(functions);
@@ -112,7 +112,7 @@ private:
 class ITimeZoneService final : public ServiceFramework<ITimeZoneService> {
 public:
     ITimeZoneService() : ServiceFramework("ITimeZoneService") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &ITimeZoneService::GetDeviceLocationName, "GetDeviceLocationName"},
             {1, nullptr, "SetDeviceLocationName"},
             {2, &ITimeZoneService::GetTotalLocationNameCount, "GetTotalLocationNameCount"},

--- a/src/core/hle/service/usb/usb.cpp
+++ b/src/core/hle/service/usb/usb.cpp
@@ -17,7 +17,7 @@ class IDsInterface final : public ServiceFramework<IDsInterface> {
 public:
     explicit IDsInterface() : ServiceFramework{"IDsInterface"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "GetDsEndpoint"},
             {1, nullptr, "GetSetupEvent"},
             {2, nullptr, "Unknown"},
@@ -42,7 +42,7 @@ class USB_DS final : public ServiceFramework<USB_DS> {
 public:
     explicit USB_DS() : ServiceFramework{"usb:ds"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "BindDevice"},
             {1, nullptr, "BindClientProcess"},
             {2, nullptr, "GetDsInterface"},
@@ -66,7 +66,7 @@ class IClientEpSession final : public ServiceFramework<IClientEpSession> {
 public:
     explicit IClientEpSession() : ServiceFramework{"IClientEpSession"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Open"},
             {1, nullptr, "Close"},
             {2, nullptr, "Unknown1"},
@@ -87,7 +87,7 @@ class IClientIfSession final : public ServiceFramework<IClientIfSession> {
 public:
     explicit IClientIfSession() : ServiceFramework{"IClientIfSession"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Unknown1"},
             {1, nullptr, "SetInterface"},
             {2, nullptr, "GetInterface"},
@@ -109,7 +109,7 @@ class USB_HS final : public ServiceFramework<USB_HS> {
 public:
     explicit USB_HS() : ServiceFramework{"usb:hs"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "BindClientProcess"},
             {1, nullptr, "QueryAllInterfaces"},
             {2, nullptr, "QueryAvailableInterfaces"},
@@ -130,7 +130,7 @@ class IPdSession final : public ServiceFramework<IPdSession> {
 public:
     explicit IPdSession() : ServiceFramework{"IPdSession"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "BindNoticeEvent"},
             {1, nullptr, "UnbindNoticeEvent"},
             {2, nullptr, "GetStatus"},
@@ -149,7 +149,7 @@ class USB_PD final : public ServiceFramework<USB_PD> {
 public:
     explicit USB_PD() : ServiceFramework{"usb:pd"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &USB_PD::GetPdSession, "GetPdSession"},
         };
         // clang-format on
@@ -171,7 +171,7 @@ class IPdCradleSession final : public ServiceFramework<IPdCradleSession> {
 public:
     explicit IPdCradleSession() : ServiceFramework{"IPdCradleSession"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "VdmUserWrite"},
             {1, nullptr, "VdmUserRead"},
             {2, nullptr, "Vdm20Init"},
@@ -192,7 +192,7 @@ class USB_PD_C final : public ServiceFramework<USB_PD_C> {
 public:
     explicit USB_PD_C() : ServiceFramework{"usb:pd:c"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &USB_PD_C::GetPdCradleSession, "GetPdCradleSession"},
         };
         // clang-format on
@@ -214,7 +214,7 @@ class USB_PM final : public ServiceFramework<USB_PM> {
 public:
     explicit USB_PM() : ServiceFramework{"usb:pm"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Unknown1"},
             {1, nullptr, "Unknown2"},
             {2, nullptr, "Unknown3"},

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -472,7 +472,7 @@ class IHOSBinderDriver final : public ServiceFramework<IHOSBinderDriver> {
 public:
     explicit IHOSBinderDriver(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
         : ServiceFramework("IHOSBinderDriver"), nv_flinger(std::move(nv_flinger)) {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, &IHOSBinderDriver::TransactParcel, "TransactParcel"},
             {1, &IHOSBinderDriver::AdjustRefcount, "AdjustRefcount"},
             {2, &IHOSBinderDriver::GetNativeHandle, "GetNativeHandle"},
@@ -623,7 +623,7 @@ private:
 class ISystemDisplayService final : public ServiceFramework<ISystemDisplayService> {
 public:
     explicit ISystemDisplayService() : ServiceFramework("ISystemDisplayService") {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {1200, nullptr, "GetZOrderCountMin"},
             {1202, nullptr, "GetZOrderCountMax"},
             {1203, nullptr, "GetDisplayLogicalResolution"},
@@ -722,7 +722,7 @@ class IManagerDisplayService final : public ServiceFramework<IManagerDisplayServ
 public:
     explicit IManagerDisplayService(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
         : ServiceFramework("IManagerDisplayService"), nv_flinger(std::move(nv_flinger)) {
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {200, nullptr, "AllocateProcessHeapBlock"},
             {201, nullptr, "FreeProcessHeapBlock"},
             {1020, &IManagerDisplayService::CloseDisplay, "CloseDisplay"},
@@ -1074,7 +1074,7 @@ private:
 IApplicationDisplayService::IApplicationDisplayService(
     std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
     : ServiceFramework("IApplicationDisplayService"), nv_flinger(std::move(nv_flinger)) {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {100, &IApplicationDisplayService::GetRelayService, "GetRelayService"},
         {101, &IApplicationDisplayService::GetSystemDisplayService, "GetSystemDisplayService"},
         {102, &IApplicationDisplayService::GetManagerDisplayService, "GetManagerDisplayService"},

--- a/src/core/hle/service/vi/vi_m.cpp
+++ b/src/core/hle/service/vi/vi_m.cpp
@@ -8,7 +8,7 @@ namespace Service::VI {
 
 VI_M::VI_M(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
     : Module::Interface(std::move(module), "vi:m", std::move(nv_flinger)) {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {2, &VI_M::GetDisplayService, "GetDisplayService"},
         {3, nullptr, "GetDisplayServiceWithProxyNameExchange"},
     };

--- a/src/core/hle/service/vi/vi_s.cpp
+++ b/src/core/hle/service/vi/vi_s.cpp
@@ -8,7 +8,7 @@ namespace Service::VI {
 
 VI_S::VI_S(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
     : Module::Interface(std::move(module), "vi:s", std::move(nv_flinger)) {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {1, &VI_S::GetDisplayService, "GetDisplayService"},
         {3, nullptr, "GetDisplayServiceWithProxyNameExchange"},
     };

--- a/src/core/hle/service/vi/vi_u.cpp
+++ b/src/core/hle/service/vi/vi_u.cpp
@@ -8,7 +8,7 @@ namespace Service::VI {
 
 VI_U::VI_U(std::shared_ptr<Module> module, std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
     : Module::Interface(std::move(module), "vi:u", std::move(nv_flinger)) {
-    static const FunctionInfo functions[] = {
+    static constexpr FunctionInfo functions[] = {
         {0, &VI_U::GetDisplayService, "GetDisplayService"},
     };
     RegisterHandlers(functions);

--- a/src/core/hle/service/wlan/wlan.cpp
+++ b/src/core/hle/service/wlan/wlan.cpp
@@ -14,7 +14,7 @@ class WLANInfra final : public ServiceFramework<WLANInfra> {
 public:
     explicit WLANInfra() : ServiceFramework{"wlan:inf"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Unknown1"},
             {1, nullptr, "Unknown2"},
             {2, nullptr, "GetMacAddress"},
@@ -54,7 +54,7 @@ class WLANLocal final : public ServiceFramework<WLANLocal> {
 public:
     explicit WLANLocal() : ServiceFramework{"wlan:lcl"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Unknown1"},
             {1, nullptr, "Unknown2"},
             {2, nullptr, "Unknown3"},
@@ -115,7 +115,7 @@ class WLANLocalGetFrame final : public ServiceFramework<WLANLocalGetFrame> {
 public:
     explicit WLANLocalGetFrame() : ServiceFramework{"wlan:lg"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Unknown"},
         };
         // clang-format on
@@ -128,7 +128,7 @@ class WLANSocketGetFrame final : public ServiceFramework<WLANSocketGetFrame> {
 public:
     explicit WLANSocketGetFrame() : ServiceFramework{"wlan:sg"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Unknown"},
         };
         // clang-format on
@@ -141,7 +141,7 @@ class WLANSocketManager final : public ServiceFramework<WLANSocketManager> {
 public:
     explicit WLANSocketManager() : ServiceFramework{"wlan:soc"} {
         // clang-format off
-        static const FunctionInfo functions[] = {
+        static constexpr FunctionInfo functions[] = {
             {0, nullptr, "Unknown1"},
             {1, nullptr, "Unknown2"},
             {2, nullptr, "Unknown3"},


### PR DESCRIPTION
The comment about the constexprness of the constructor causing ICEs was made quite a while ago and doesn't seem to apply anymore on MSVC. This allows all of the function lookup-tables to be constexpr as well. Making this to also see if GCC is finally able to handle this.