### PR TITLE
shader_bytecode: Fixup half float's operator B encoding

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -609,7 +609,7 @@ union Instruction {
 
         BitField<31, 1, u64> negate_b;
         BitField<30, 1, u64> abs_b;
-        BitField<47, 2, HalfType> type_b;
+        BitField<28, 2, HalfType> type_b;
 
         BitField<35, 2, HalfType> type_c;
     } alu_half;


### PR DESCRIPTION
Fixes half float instructions encoding. It had the same location as the operator A (which is wrong).
Offset was taken from https://github.com/envytools/envytools/blob/3f3155131fcdbed1617bb777959a208a412fcbcb/envydis/gm107.c#L1128-L1134