### PR TITLE
Fixed uninitialized memory due to missing returns in canary

### DIFF
--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -128,6 +128,7 @@ std::string SaveDataFactory::GetFullPath(SaveDataSpaceId space, SaveDataType typ
         return fmt::format("{}save/cache/{:016X}", out, title_id);
     default:
         ASSERT_MSG(false, "Unrecognized SaveDataType: {:02X}", static_cast<u8>(type));
+        return fmt::format("{}save/unknown_{:X}/{:016X}", out, static_cast<u8>(type), title_id);
     }
 }
 

--- a/src/core/hle/kernel/object.cpp
+++ b/src/core/hle/kernel/object.cpp
@@ -32,6 +32,7 @@ bool Object::IsWaitable() const {
     }
 
     UNREACHABLE();
+    return false;
 }
 
 } // namespace Kernel

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -187,6 +187,7 @@ T Read(const VAddr vaddr) {
     default:
         UNREACHABLE();
     }
+    return {};
 }
 
 template <typename T>

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -164,6 +164,7 @@ public:
                     return 3;
                 default:
                     UNREACHABLE();
+                    return 1;
                 }
             }
 
@@ -871,6 +872,7 @@ public:
                             return 4;
                         }
                         UNREACHABLE();
+                        return 1;
                     }
 
                     GPUVAddr StartAddress() const {

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -1065,6 +1065,7 @@ union Instruction {
             LOG_CRITICAL(HW_GPU, "Unhandled texture_info: {}",
                          static_cast<u32>(texture_info.Value()));
             UNREACHABLE();
+            return TextureType::Texture1D;
         }
 
         TextureProcessMode GetTextureProcessMode() const {
@@ -1145,6 +1146,7 @@ union Instruction {
             LOG_CRITICAL(HW_GPU, "Unhandled texture_info: {}",
                          static_cast<u32>(texture_info.Value()));
             UNREACHABLE();
+            return TextureType::Texture1D;
         }
 
         TextureProcessMode GetTextureProcessMode() const {

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -102,6 +102,7 @@ u32 RenderTargetBytesPerPixel(RenderTargetFormat format) {
         return 1;
     default:
         UNIMPLEMENTED_MSG("Unimplemented render target format {}", static_cast<u32>(format));
+        return 1;
     }
 }
 
@@ -119,6 +120,7 @@ u32 DepthFormatBytesPerPixel(DepthFormat format) {
         return 2;
     default:
         UNIMPLEMENTED_MSG("Unimplemented Depth format {}", static_cast<u32>(format));
+        return 1;
     }
 }
 

--- a/src/video_core/macro_interpreter.cpp
+++ b/src/video_core/macro_interpreter.cpp
@@ -171,6 +171,7 @@ u32 MacroInterpreter::GetALUResult(ALUOperation operation, u32 src_a, u32 src_b)
 
     default:
         UNIMPLEMENTED_MSG("Unimplemented ALU operation {}", static_cast<u32>(operation));
+        return 0;
     }
 }
 
@@ -268,6 +269,7 @@ bool MacroInterpreter::EvaluateBranchCondition(BranchCondition cond, u32 value) 
         return value != 0;
     }
     UNREACHABLE();
+    return true;
 }
 
 } // namespace Tegra

--- a/src/video_core/morton.cpp
+++ b/src/video_core/morton.cpp
@@ -192,6 +192,7 @@ static MortonCopyFn GetSwizzleFunction(MortonSwizzleMode mode, Surface::PixelFor
         return linear_to_morton_fns[static_cast<std::size_t>(format)];
     }
     UNREACHABLE();
+    return morton_to_linear_fns[static_cast<std::size_t>(format)];
 }
 
 /// 8x8 Z-Order coordinate from 2D coordinates

--- a/src/video_core/renderer_opengl/gl_shader_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_cache.h
@@ -67,6 +67,7 @@ public:
                                        6, "ShaderTrianglesAdjacency");
         default:
             UNREACHABLE_MSG("Unknown primitive mode.");
+            return LazyGeometryProgram(geometry_programs.points, "points", 1, "ShaderPoints");
         }
     }
 

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -364,6 +364,7 @@ public:
             return value;
         default:
             UNREACHABLE_MSG("Unimplemented conversion size: {}", static_cast<u32>(size));
+            return value;
         }
     }
 
@@ -626,6 +627,7 @@ public:
             return "floatBitsToInt(" + value + ')';
         } else {
             UNREACHABLE();
+            return value;
         }
     }
 
@@ -2064,6 +2066,8 @@ private:
                             std::to_string(instr.alu.GetSignedImm20_20())};
                 default:
                     UNREACHABLE();
+                    return {regs.GetRegisterAsInteger(instr.gpr39, 0, false),
+                            std::to_string(instr.alu.GetSignedImm20_20())};
                 }
             }();
             const std::string offset = '(' + packed_shift + " & 0xff)";
@@ -3314,6 +3318,7 @@ private:
                     return std::to_string(instr.r2p.immediate_mask);
                 default:
                     UNREACHABLE();
+                    return std::to_string(instr.r2p.immediate_mask);
                 }
             }();
             const std::string mask = '(' + regs.GetRegisterAsInteger(instr.gpr8, 0, false) +
@@ -3777,7 +3782,9 @@ private:
                 }
                 break;
             }
-            default: { UNIMPLEMENTED_MSG("Unhandled instruction: {}", opcode->get().GetName()); }
+            default: {
+                UNIMPLEMENTED_MSG("Unhandled instruction: {}", opcode->get().GetName());
+            }
             }
 
             break;

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -3784,6 +3784,7 @@ private:
             }
             default: {
                 UNIMPLEMENTED_MSG("Unhandled instruction: {}", opcode->get().GetName());
+                break;
             }
             }
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -427,6 +427,7 @@ static const char* GetSource(GLenum source) {
         RET(OTHER);
     default:
         UNREACHABLE();
+        return "Unknown source";
     }
 #undef RET
 }
@@ -445,6 +446,7 @@ static const char* GetType(GLenum type) {
         RET(MARKER);
     default:
         UNREACHABLE();
+        return "Unknown type";
     }
 #undef RET
 }

--- a/src/video_core/surface.cpp
+++ b/src/video_core/surface.cpp
@@ -65,6 +65,7 @@ PixelFormat PixelFormatFromDepthFormat(Tegra::DepthFormat format) {
     default:
         LOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
         UNREACHABLE();
+        return PixelFormat::S8Z24;
     }
 }
 
@@ -141,6 +142,7 @@ PixelFormat PixelFormatFromRenderTargetFormat(Tegra::RenderTargetFormat format) 
     default:
         LOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
         UNREACHABLE();
+        return PixelFormat::RGBA8_SRGB;
     }
 }
 
@@ -327,6 +329,7 @@ PixelFormat PixelFormatFromTextureFormat(Tegra::Texture::TextureFormat format,
         LOG_CRITICAL(HW_GPU, "Unimplemented format={}, component_type={}", static_cast<u32>(format),
                      static_cast<u32>(component_type));
         UNREACHABLE();
+        return PixelFormat::ABGR8U;
     }
 }
 
@@ -346,6 +349,7 @@ ComponentType ComponentTypeFromTexture(Tegra::Texture::ComponentType type) {
     default:
         LOG_CRITICAL(HW_GPU, "Unimplemented component type={}", static_cast<u32>(type));
         UNREACHABLE();
+        return ComponentType::UNorm;
     }
 }
 
@@ -393,6 +397,7 @@ ComponentType ComponentTypeFromRenderTarget(Tegra::RenderTargetFormat format) {
     default:
         LOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
         UNREACHABLE();
+        return ComponentType::UNorm;
     }
 }
 
@@ -403,6 +408,7 @@ PixelFormat PixelFormatFromGPUPixelFormat(Tegra::FramebufferConfig::PixelFormat 
     default:
         LOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
         UNREACHABLE();
+        return PixelFormat::ABGR8U;
     }
 }
 
@@ -418,6 +424,7 @@ ComponentType ComponentTypeFromDepthFormat(Tegra::DepthFormat format) {
     default:
         LOG_CRITICAL(HW_GPU, "Unimplemented format={}", static_cast<u32>(format));
         UNREACHABLE();
+        return ComponentType::UNorm;
     }
 }
 

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -226,7 +226,7 @@ u32 BytesPerPixel(TextureFormat format) {
         return 8;
     default:
         UNIMPLEMENTED_MSG("Format not implemented");
-        break;
+        return 1;
     }
 }
 

--- a/src/yuzu/debugger/graphics/graphics_surface.cpp
+++ b/src/yuzu/debugger/graphics/graphics_surface.cpp
@@ -30,6 +30,7 @@ static Tegra::Texture::TextureFormat ConvertToTextureFormat(
         return Tegra::Texture::TextureFormat::A2B10G10R10;
     default:
         UNIMPLEMENTED_MSG("Unimplemented RT format");
+        return Tegra::Texture::TextureFormat::A8R8G8B8;
     }
 }
 


### PR DESCRIPTION
Functions which are supposed to crash on non-canary builds usually don't return anything which leads to uninitialized memory being used.

This PR is mainly to address the issues with #1340 , with it we should be able to use #1340 instead of #615 
Should also fix some oddity in crashes we might get