### PR TITLE
Device handle should not be a random id, instead it's the current npad id

### DIFF
--- a/src/core/hle/service/nfp/nfp.cpp
+++ b/src/core/hle/service/nfp/nfp.cpp
@@ -317,8 +317,8 @@ private:
     }
 
     bool has_attached_handle{};
-    const u64 device_handle{Common::MakeMagic('Y', 'U', 'Z', 'U')};
-    const u32 npad_id{0}; // Player 1 controller
+    const u64 device_handle{0}; // Npad device 1
+    const u32 npad_id{0};       // Player 1 controller
     State state{State::NonInitialized};
     DeviceState device_state{DeviceState::Initialized};
     Kernel::EventPair deactivate_event;


### PR DESCRIPTION
Found during hardware testing when working on amiibo spoofing