### PR TITLE
kernel/{process, thread}: Amend behavior related to IDs

### DIFF
--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -201,11 +201,11 @@ void RegisterModule(std::string name, VAddr beg, VAddr end, bool add_elf_ext) {
     modules.push_back(std::move(module));
 }
 
-static Kernel::Thread* FindThreadById(int id) {
+static Kernel::Thread* FindThreadById(s64 id) {
     for (u32 core = 0; core < Core::NUM_CPU_CORES; core++) {
         const auto& threads = Core::System::GetInstance().Scheduler(core).GetThreadList();
         for (auto& thread : threads) {
-            if (thread->GetThreadID() == static_cast<u32>(id)) {
+            if (thread->GetThreadID() == static_cast<u64>(id)) {
                 current_core = core;
                 return thread.get();
             }

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -112,7 +112,7 @@ struct KernelCore::Impl {
 
     void Shutdown() {
         next_object_id = 0;
-        next_process_id = 10;
+        next_process_id = Process::ProcessIDMin;
         next_thread_id = 1;
 
         process_list.clear();
@@ -153,9 +153,7 @@ struct KernelCore::Impl {
     }
 
     std::atomic<u32> next_object_id{0};
-    // TODO(Subv): Start the process ids from 10 for now, as lower PIDs are
-    // reserved for low-level services
-    std::atomic<u64> next_process_id{10};
+    std::atomic<u64> next_process_id{Process::ProcessIDMin};
     std::atomic<u64> next_thread_id{1};
 
     // Lists all processes that exist in the current session.

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -155,7 +155,7 @@ struct KernelCore::Impl {
     std::atomic<u32> next_object_id{0};
     // TODO(Subv): Start the process ids from 10 for now, as lower PIDs are
     // reserved for low-level services
-    std::atomic<u32> next_process_id{10};
+    std::atomic<u64> next_process_id{10};
     std::atomic<u32> next_thread_id{1};
 
     // Lists all processes that exist in the current session.
@@ -246,7 +246,7 @@ u32 KernelCore::CreateNewThreadID() {
     return impl->next_thread_id++;
 }
 
-u32 KernelCore::CreateNewProcessID() {
+u64 KernelCore::CreateNewProcessID() {
     return impl->next_process_id++;
 }
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -156,7 +156,7 @@ struct KernelCore::Impl {
     // TODO(Subv): Start the process ids from 10 for now, as lower PIDs are
     // reserved for low-level services
     std::atomic<u64> next_process_id{10};
-    std::atomic<u32> next_thread_id{1};
+    std::atomic<u64> next_thread_id{1};
 
     // Lists all processes that exist in the current session.
     std::vector<SharedPtr<Process>> process_list;
@@ -242,7 +242,7 @@ u32 KernelCore::CreateNewObjectID() {
     return impl->next_object_id++;
 }
 
-u32 KernelCore::CreateNewThreadID() {
+u64 KernelCore::CreateNewThreadID() {
     return impl->next_thread_id++;
 }
 

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -91,7 +91,7 @@ private:
     u64 CreateNewProcessID();
 
     /// Creates a new thread ID, incrementing the internal thread ID counter.
-    u32 CreateNewThreadID();
+    u64 CreateNewThreadID();
 
     /// Creates a timer callback handle for the given timer.
     ResultVal<Handle> CreateTimerCallbackHandle(const SharedPtr<Timer>& timer);

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -88,7 +88,7 @@ private:
     u32 CreateNewObjectID();
 
     /// Creates a new process ID, incrementing the internal process ID counter;
-    u32 CreateNewProcessID();
+    u64 CreateNewProcessID();
 
     /// Creates a new thread ID, incrementing the internal thread ID counter.
     u32 CreateNewThreadID();

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -120,6 +120,18 @@ struct CodeSet final {
 
 class Process final : public WaitObject {
 public:
+    enum : u64 {
+        /// Lowest allowed process ID for a kernel initial process.
+        InitialKIPIDMin = 1,
+        /// Highest allowed process ID for a kernel initial process.
+        InitialKIPIDMax = 80,
+
+        /// Lowest allowed process ID for a userland process.
+        ProcessIDMin = 81,
+        /// Highest allowed process ID for a userland process.
+        ProcessIDMax = 0xFFFFFFFFFFFFFFFF,
+    };
+
     static constexpr std::size_t RANDOM_ENTROPY_SIZE = 4;
 
     static SharedPtr<Process> Create(KernelCore& kernel, std::string&& name);

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -162,7 +162,7 @@ public:
     }
 
     /// Gets the unique ID that identifies this particular process.
-    u32 GetProcessID() const {
+    u64 GetProcessID() const {
         return process_id;
     }
 
@@ -288,10 +288,10 @@ private:
     ProcessStatus status;
 
     /// The ID of this process
-    u32 process_id = 0;
+    u64 process_id = 0;
 
     /// Title ID corresponding to the process
-    u64 program_id;
+    u64 program_id = 0;
 
     /// Resource limit descriptor for this process
     SharedPtr<ResourceLimit> resource_limit;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -365,7 +365,7 @@ static ResultCode GetThreadId(u32* thread_id, Handle thread_handle) {
 }
 
 /// Get the ID of the specified process
-static ResultCode GetProcessId(u32* process_id, Handle process_handle) {
+static ResultCode GetProcessId(u64* process_id, Handle process_handle) {
     LOG_TRACE(Kernel_SVC, "called process=0x{:08X}", process_handle);
 
     const auto& handle_table = Core::CurrentProcess()->GetHandleTable();

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -350,7 +350,7 @@ static ResultCode SendSyncRequest(Handle handle) {
 }
 
 /// Get the ID for the specified thread.
-static ResultCode GetThreadId(u32* thread_id, Handle thread_handle) {
+static ResultCode GetThreadId(u64* thread_id, Handle thread_handle) {
     LOG_TRACE(Kernel_SVC, "called thread=0x{:08X}", thread_handle);
 
     const auto& handle_table = Core::CurrentProcess()->GetHandleTable();

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -73,7 +73,15 @@ void SvcWrap() {
 template <ResultCode func(u32*, u64)>
 void SvcWrap() {
     u32 param_1 = 0;
-    u32 retval = func(&param_1, Param(1)).raw;
+    const u32 retval = func(&param_1, Param(1)).raw;
+    Core::CurrentArmInterface().SetReg(1, param_1);
+    FuncReturn(retval);
+}
+
+template <ResultCode func(u64*, u32)>
+void SvcWrap() {
+    u64 param_1 = 0;
+    const u32 retval = func(&param_1, static_cast<u32>(Param(1))).raw;
     Core::CurrentArmInterface().SetReg(1, param_1);
     FuncReturn(retval);
 }

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -151,7 +151,7 @@ public:
      * Gets the thread's thread ID
      * @return The thread's ID
      */
-    u32 GetThreadID() const {
+    u64 GetThreadID() const {
         return thread_id;
     }
 
@@ -379,7 +379,7 @@ private:
 
     Core::ARM_Interface::ThreadContext context{};
 
-    u32 thread_id = 0;
+    u64 thread_id = 0;
 
     ThreadStatus status = ThreadStatus::Dormant;
 


### PR DESCRIPTION
Kernel process and thread IDs are internally 64-bit values, not 32-bit, so this amends the relevant interfaces where they're used. In particular, `svcGetThreadId` and `svcGetProcessId` both have 64-bit out parameters.

This also closes a hole in svcGetProcessId, where we weren't handling passed in thread handles properly. The proper behavior is to attempt to read the owning process' ID if a thread handle is passed in instead of a direct process handle. While still technically not covering the whole function's behavior (it also handles debug objects), this is adequate for the time being, given we don't currently implement the debug objects at all, and that games are very unlikely to try and use that in a release.