### PR TITLE
common/quaternion: Ensure that w is always initialized

### DIFF
--- a/src/common/quaternion.h
+++ b/src/common/quaternion.h
@@ -12,7 +12,7 @@ template <typename T>
 class Quaternion {
 public:
     Math::Vec3<T> xyz;
-    T w;
+    T w{};
 
     Quaternion<decltype(-T{})> Inverse() const {
         return {-xyz, w};


### PR DESCRIPTION
Previously `xyz` was always being zero initialized due to its constructor, but `w` wasn't. Ensures that we always have a deterministic initial state. Unlikely to matter too much, but prevents potential errors in the future with regards to uninitialized reads.