### PR TITLE
applets: Implement HLE controller selector applet

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -84,6 +84,8 @@ add_library(core STATIC
     file_sys/vfs_vector.h
     file_sys/xts_archive.cpp
     file_sys/xts_archive.h
+    frontend/applets/controller.cpp
+    frontend/applets/controller.h
     frontend/applets/profile_select.cpp
     frontend/applets/profile_select.h
     frontend/applets/software_keyboard.cpp
@@ -169,6 +171,8 @@ add_library(core STATIC
     hle/service/am/applet_oe.h
     hle/service/am/applets/applets.cpp
     hle/service/am/applets/applets.h
+    hle/service/am/applets/controller.cpp
+    hle/service/am/applets/controller.h
     hle/service/am/applets/profile_select.cpp
     hle/service/am/applets/profile_select.h
     hle/service/am/applets/software_keyboard.cpp

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -25,13 +25,13 @@
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/scheduler.h"
 #include "core/hle/kernel/thread.h"
-#include "core/hle/service/am/applets/software_keyboard.h"
 #include "core/hle/service/service.h"
 #include "core/hle/service/sm/sm.h"
 #include "core/loader/loader.h"
 #include "core/perf_stats.h"
 #include "core/settings.h"
 #include "core/telemetry_session.h"
+#include "frontend/applets/controller.h"
 #include "frontend/applets/profile_select.h"
 #include "frontend/applets/software_keyboard.h"
 #include "frontend/applets/web_browser.h"
@@ -107,6 +107,8 @@ struct System::Impl {
             virtual_filesystem = std::make_shared<FileSys::RealVfsFilesystem>();
 
         /// Create default implementations of applets if one is not provided.
+        if (controller_applet == nullptr)
+            controller_applet = std::make_unique<Core::Frontend::DefaultControllerApplet>();
         if (profile_selector == nullptr)
             profile_selector = std::make_unique<Core::Frontend::DefaultProfileSelectApplet>();
         if (software_keyboard == nullptr)
@@ -248,6 +250,7 @@ struct System::Impl {
     bool is_powered_on = false;
 
     /// Frontend applets
+    std::unique_ptr<Core::Frontend::ControllerApplet> controller_applet;
     std::unique_ptr<Core::Frontend::ProfileSelectApplet> profile_selector;
     std::unique_ptr<Core::Frontend::SoftwareKeyboardApplet> software_keyboard;
     std::unique_ptr<Core::Frontend::WebBrowserApplet> web_browser;
@@ -451,6 +454,14 @@ void System::SetFilesystem(std::shared_ptr<FileSys::VfsFilesystem> vfs) {
 
 std::shared_ptr<FileSys::VfsFilesystem> System::GetFilesystem() const {
     return impl->virtual_filesystem;
+}
+
+void System::SetControllerApplet(std::unique_ptr<Core::Frontend::ControllerApplet> applet) {
+    impl->controller_applet = std::move(applet);
+}
+
+const Core::Frontend::ControllerApplet& System::GetControllerApplet() const {
+    return *impl->controller_applet;
 }
 
 void System::SetProfileSelector(std::unique_ptr<Frontend::ProfileSelectApplet> applet) {

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -213,6 +213,7 @@ struct System::Impl {
         app_loader.reset();
 
         // Clear all applets
+        controller_applet.reset();
         profile_selector.reset();
         software_keyboard.reset();
         web_browser.reset();

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -14,6 +14,7 @@
 
 namespace Core::Frontend {
 class EmuWindow;
+class ControllerApplet;
 class ProfileSelectApplet;
 class SoftwareKeyboardApplet;
 class WebBrowserApplet;
@@ -252,6 +253,10 @@ public:
     void SetFilesystem(std::shared_ptr<FileSys::VfsFilesystem> vfs);
 
     std::shared_ptr<FileSys::VfsFilesystem> GetFilesystem() const;
+
+    void SetControllerApplet(std::unique_ptr<Core::Frontend::ControllerApplet> applet);
+
+    const Core::Frontend::ControllerApplet& GetControllerApplet() const;
 
     void SetProfileSelector(std::unique_ptr<Frontend::ProfileSelectApplet> applet);
 

--- a/src/core/frontend/applets/controller.cpp
+++ b/src/core/frontend/applets/controller.cpp
@@ -1,0 +1,38 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/core.h"
+#include "core/frontend/applets/controller.h"
+#include "core/hle/service/hid/controllers/npad.h"
+#include "core/hle/service/hid/hid.h"
+#include "core/hle/service/sm/sm.h"
+
+namespace Core::Frontend {
+
+ControllerApplet::~ControllerApplet() = default;
+
+DefaultControllerApplet::~DefaultControllerApplet() = default;
+
+void DefaultControllerApplet::ReconfigureControllers(std::function<void(bool)> completed,
+                                                     ControllerParameters parameters) const {
+    LOG_WARNING(Service_HID, "(STUBBED) called, automatically setting controller types to best fit "
+                             "in configuration, may be incorrect!");
+
+    const auto& npad =
+        Core::System::GetInstance()
+            .ServiceManager()
+            .GetService<Service::HID::Hid>("hid")
+            ->GetAppletResource()
+            ->GetController<Service::HID::Controller_NPad>(Service::HID::HidController::NPad);
+
+    for (auto& player : Settings::values.players) {
+        const auto prio = Service::HID::Controller_NPad::MapSettingsTypeToNPad(player.type);
+        player.type =
+            Service::HID::Controller_NPad::MapNPadTypeToSettings(npad.DecideBestController(prio));
+    }
+
+    completed(true);
+}
+
+} // namespace Core::Frontend

--- a/src/core/frontend/applets/controller.h
+++ b/src/core/frontend/applets/controller.h
@@ -1,0 +1,47 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <string>
+#include "common/bit_field.h"
+#include "common/common_types.h"
+
+namespace Core::Frontend {
+
+struct ControllerParameters {
+    u8 min_players;
+    u8 max_players;
+    bool keep_current_connected;
+    bool merge_dual_joycons;
+    bool allowed_single_layout;
+
+    bool allowed_pro_controller;
+    bool allowed_handheld;
+    bool allowed_joycon_dual;
+    bool allowed_joycon_left;
+    bool allowed_joycon_right;
+
+    bool horizontal_single_joycons;
+};
+
+class ControllerApplet {
+public:
+    virtual ~ControllerApplet();
+
+    virtual void ReconfigureControllers(std::function<void(bool)> completed,
+                                        ControllerParameters parameters) const = 0;
+};
+
+class DefaultControllerApplet final : public ControllerApplet {
+public:
+    ~DefaultControllerApplet() override;
+
+    void ReconfigureControllers(std::function<void(bool)> completed,
+                                ControllerParameters parameters) const override;
+};
+
+} // namespace Core::Frontend

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -20,6 +20,7 @@
 #include "core/hle/service/am/applet_ae.h"
 #include "core/hle/service/am/applet_oe.h"
 #include "core/hle/service/am/applets/applets.h"
+#include "core/hle/service/am/applets/controller.h"
 #include "core/hle/service/am/applets/profile_select.h"
 #include "core/hle/service/am/applets/software_keyboard.h"
 #include "core/hle/service/am/applets/stub_applet.h"
@@ -43,6 +44,7 @@ constexpr ResultCode ERR_NO_MESSAGES{ErrorModule::AM, 0x3};
 constexpr ResultCode ERR_SIZE_OUT_OF_BOUNDS{ErrorModule::AM, 0x1F7};
 
 enum class AppletId : u32 {
+    Controller = 0x0C,
     ProfileSelect = 0x10,
     SoftwareKeyboard = 0x11,
     LibAppletOff = 0x17,
@@ -790,6 +792,8 @@ ILibraryAppletCreator::~ILibraryAppletCreator() = default;
 
 static std::shared_ptr<Applets::Applet> GetAppletFromId(AppletId id) {
     switch (id) {
+    case AppletId::Controller:
+        return std::make_shared<Applets::Controller>();
     case AppletId::ProfileSelect:
         return std::make_shared<Applets::ProfileSelect>();
     case AppletId::SoftwareKeyboard:

--- a/src/core/hle/service/am/applets/controller.cpp
+++ b/src/core/hle/service/am/applets/controller.cpp
@@ -1,0 +1,96 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/core.h"
+#include "core/frontend/applets/controller.h"
+#include "core/hle/service/am/applets/controller.h"
+#include "core/hle/service/hid/controllers/npad.h"
+
+namespace Service::AM::Applets {
+
+static Core::Frontend::ControllerParameters ConvertToFrontendParameters(
+    ControllerConfigPrivate config_private, ControllerConfig config) {
+    Core::Frontend::ControllerParameters params{};
+
+    params.min_players = config.minimum_player_count;
+    params.max_players = config.maximum_player_count;
+    params.keep_current_connected = config.keep_current_connections;
+    params.merge_dual_joycons = config.permit_dual_joycons;
+    params.allowed_single_layout = config.enable_single_mode;
+
+    params.horizontal_single_joycons = config_private.npad_hold_type;
+
+    HID::Controller_NPad::NPadType styleset;
+    styleset.raw = config_private.npad_style_set;
+    params.allowed_pro_controller = styleset.pro_controller;
+    params.allowed_handheld = styleset.handheld;
+    params.allowed_joycon_dual = styleset.joycon_dual;
+    params.allowed_joycon_left = styleset.joycon_left;
+    params.allowed_joycon_right = styleset.joycon_right;
+
+    return params;
+}
+
+Controller::Controller() = default;
+
+Controller::~Controller() = default;
+
+void Controller::Initialize() {
+    Applet::Initialize();
+
+    const auto private_config_storage = broker.PopNormalDataToApplet();
+    ASSERT(private_config_storage != nullptr);
+    const auto& private_controller_config = private_config_storage->GetData();
+
+    ASSERT(private_controller_config.size() >= sizeof(ControllerConfigPrivate));
+    std::memcpy(&private_config, private_controller_config.data(), sizeof(ControllerConfigPrivate));
+
+    const auto config_storage = broker.PopNormalDataToApplet();
+    ASSERT(config_storage != nullptr);
+    const auto& controller_config = config_storage->GetData();
+
+    ASSERT(controller_config.size() >= sizeof(ControllerConfig));
+    std::memcpy(&config, controller_config.data(), sizeof(ControllerConfig));
+}
+
+bool Controller::TransactionComplete() const {
+    return complete;
+}
+
+ResultCode Controller::GetStatus() const {
+    return complete ? RESULT_SUCCESS : ResultCode(0x2c80);
+}
+
+void Controller::ExecuteInteractive() {
+    UNREACHABLE_MSG("Tried to interact with non-interactable applet.");
+}
+
+void Controller::Execute() {
+    if (complete) {
+        UNREACHABLE();
+    }
+
+    const auto& frontend{Core::System::GetInstance().GetControllerApplet()};
+
+    const auto parameters = ConvertToFrontendParameters(private_config, config);
+
+    frontend.ReconfigureControllers([this](bool ok) { ConfigurationComplete(ok); }, parameters);
+}
+
+void Controller::ConfigurationComplete(bool ok) {
+    ControllerConfigOutput out{};
+
+    out.player_code = 0;
+    out.selected_npad_id = static_cast<u32>(
+        HID::Controller_NPad::MapSettingsTypeToNPad(Settings::values.players[0].type));
+    out.result = !ok;
+
+    complete = true;
+
+    std::vector<u8> out_data(sizeof(ControllerConfigOutput));
+    std::memcpy(out_data.data(), &out, sizeof(ControllerConfigOutput));
+    broker.PushNormalDataFromApplet(IStorage{out_data});
+    broker.SignalStateChanged();
+}
+} // namespace Service::AM::Applets

--- a/src/core/hle/service/am/applets/controller.cpp
+++ b/src/core/hle/service/am/applets/controller.cpp
@@ -59,7 +59,7 @@ bool Controller::TransactionComplete() const {
 }
 
 ResultCode Controller::GetStatus() const {
-    return complete ? RESULT_SUCCESS : ResultCode(0x2c80);
+    return RESULT_SUCCESS;
 }
 
 void Controller::ExecuteInteractive() {

--- a/src/core/hle/service/am/applets/controller.h
+++ b/src/core/hle/service/am/applets/controller.h
@@ -1,0 +1,61 @@
+// Copyright 2018 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/am/am.h"
+#include "core/hle/service/am/applets/applets.h"
+
+namespace Service::AM::Applets {
+
+struct ControllerConfigPrivate {
+    u32 private_arg_size; // unknown, seems to be an offset of some kind
+    u32 normal_arg_size;
+    u32 flags;
+    u32 npad_style_set;
+    u32 npad_hold_type;
+};
+static_assert(sizeof(ControllerConfigPrivate) == 0x14,
+              "ControllerConfigPrivate has incorrect size");
+
+struct ControllerConfig {
+    u8 minimum_player_count;
+    u8 maximum_player_count;
+    u8 keep_current_connections;
+    u8 left_justify;
+    u8 permit_dual_joycons;
+    u8 enable_single_mode;
+    INSERT_PADDING_BYTES(0x216);
+};
+static_assert(sizeof(ControllerConfig) == 0x21C, "ControllerConfig has incorrect size");
+
+struct ControllerConfigOutput {
+    u8 player_code;
+    INSERT_PADDING_BYTES(0x3);
+    u32 selected_npad_id;
+    u32 result;
+};
+static_assert(sizeof(ControllerConfigOutput) == 0xC, "ControllerConfigOutput has incorrect size");
+
+class Controller final : public Applet {
+public:
+    Controller();
+    ~Controller() override;
+
+    void Initialize() override;
+
+    bool TransactionComplete() const override;
+    ResultCode GetStatus() const override;
+    void ExecuteInteractive() override;
+    void Execute() override;
+
+    void ConfigurationComplete(bool ok);
+
+private:
+    ControllerConfigPrivate private_config;
+    ControllerConfig config;
+    bool complete = false;
+};
+
+} // namespace Service::AM::Applets

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -128,6 +128,10 @@ public:
     // Specifically for cheat engine and other features.
     u32 GetAndResetPressState();
 
+    NPadControllerType DecideBestController(NPadControllerType priority) const;
+
+    static NPadControllerType MapSettingsTypeToNPad(Settings::ControllerType type);
+    static Settings::ControllerType MapNPadTypeToSettings(NPadControllerType type);
     static std::size_t NPadIdToIndex(u32 npad_id);
     static u32 IndexToNPad(std::size_t index);
 
@@ -315,11 +319,9 @@ private:
     std::array<ControllerHolder, 10> connected_controllers{};
     bool can_controllers_vibrate{true};
 
-    void InitNewlyAddedControler(std::size_t controller_idx);
+    void InitNewlyAddedController(std::size_t controller_idx);
     bool IsControllerSupported(NPadControllerType controller) const;
-    NPadControllerType DecideBestController(NPadControllerType priority) const;
     void RequestPadStateUpdate(u32 npad_id);
     std::array<ControllerPad, 10> npad_pad_states{};
-    bool IsControllerSupported(NPadControllerType controller);
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #pragma once
+#include "core/hle/service/service.h"
 
 #include "controllers/controller_base.h"
 #include "core/hle/service/service.h"

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -3,6 +3,8 @@
 // Refer to the license.txt file included.
 
 #pragma once
+
+#include "controllers/controller_base.h"
 #include "core/hle/service/service.h"
 
 #include "controllers/controller_base.h"

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -7,6 +7,8 @@ add_executable(yuzu
     Info.plist
     about_dialog.cpp
     about_dialog.h
+    applets/controller.cpp
+    applets/controller.h
     applets/profile_select.cpp
     applets/profile_select.h
     applets/software_keyboard.cpp

--- a/src/yuzu/applets/controller.cpp
+++ b/src/yuzu/applets/controller.cpp
@@ -1,0 +1,65 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <QDialogButtonBox>
+#include <QLabel>
+#include "core/hle/lock.h"
+#include "core/hle/service/hid/hid.h"
+#include "yuzu/applets/controller.h"
+#include "yuzu/configuration/configure_input_simple.h"
+#include "yuzu/main.h"
+
+QtControllerAppletDialog::QtControllerAppletDialog(
+    QWidget* parent, Core::Frontend::ControllerParameters parameters) {
+    layout = new QVBoxLayout;
+    buttons = new QDialogButtonBox;
+    buttons->addButton(tr("Cancel"), QDialogButtonBox::RejectRole);
+    buttons->addButton(tr("OK"), QDialogButtonBox::AcceptRole);
+
+    connect(buttons, &QDialogButtonBox::accepted, this, &QtControllerAppletDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QtControllerAppletDialog::reject);
+
+    input = new ConfigureInputSimple(this, parameters);
+    layout->addWidget(input);
+    layout->addWidget(buttons);
+    setLayout(layout);
+}
+
+QtControllerAppletDialog::~QtControllerAppletDialog() = default;
+
+void QtControllerAppletDialog::accept() {
+    input->applyConfiguration();
+    ok = true;
+    QDialog::accept();
+}
+
+void QtControllerAppletDialog::reject() {
+    ok = false;
+    QDialog::reject();
+}
+
+bool QtControllerAppletDialog::GetStatus() const {
+    return ok;
+}
+
+QtControllerApplet::QtControllerApplet(GMainWindow& parent) {
+    connect(this, &QtControllerApplet::MainWindowReconfigureControllers, &parent,
+            &GMainWindow::ControllerAppletReconfigureControllers, Qt::QueuedConnection);
+    connect(&parent, &GMainWindow::ControllerAppletReconfigureFinished, this,
+            &QtControllerApplet::MainWindowReconfigureFinished, Qt::QueuedConnection);
+}
+
+QtControllerApplet::~QtControllerApplet() = default;
+
+void QtControllerApplet::ReconfigureControllers(
+    std::function<void(bool)> completed, Core::Frontend::ControllerParameters parameters) const {
+    this->completed = std::move(completed);
+    emit MainWindowReconfigureControllers(parameters);
+}
+
+void QtControllerApplet::MainWindowReconfigureFinished(bool ok) {
+    // Acquire the HLE mutex
+    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+    completed(ok);
+}

--- a/src/yuzu/applets/controller.h
+++ b/src/yuzu/applets/controller.h
@@ -1,0 +1,55 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <QDialog>
+#include "core/frontend/applets/controller.h"
+
+class ConfigureInputSimple;
+class GMainWindow;
+class QDialogButtonBox;
+class QVBoxLayout;
+
+class QtControllerAppletDialog final : public QDialog {
+    Q_OBJECT
+
+public:
+    QtControllerAppletDialog(QWidget* parent, Core::Frontend::ControllerParameters parameters);
+    ~QtControllerAppletDialog() override;
+
+    void accept() override;
+    void reject() override;
+
+    bool GetStatus() const;
+
+private:
+    bool ok = false;
+
+    QVBoxLayout* layout;
+
+    QDialogButtonBox* buttons;
+    ConfigureInputSimple* input;
+
+    Core::Frontend::ControllerParameters parameters;
+};
+
+class QtControllerApplet final : public QObject, public Core::Frontend::ControllerApplet {
+    Q_OBJECT
+
+public:
+    explicit QtControllerApplet(GMainWindow& parent);
+    ~QtControllerApplet() override;
+
+    void ReconfigureControllers(std::function<void(bool)> completed,
+                                Core::Frontend::ControllerParameters parameters) const override;
+
+signals:
+    void MainWindowReconfigureControllers(Core::Frontend::ControllerParameters parameters) const;
+
+private:
+    void MainWindowReconfigureFinished(bool ok);
+
+    mutable std::function<void(bool)> completed;
+};

--- a/src/yuzu/configuration/configure_input_simple.h
+++ b/src/yuzu/configuration/configure_input_simple.h
@@ -5,8 +5,11 @@
 #pragma once
 
 #include <memory>
+#include <optional>
 
 #include <QWidget>
+
+#include "core/frontend/applets/controller.h"
 
 class QPushButton;
 class QString;
@@ -23,7 +26,9 @@ class ConfigureInputSimple : public QWidget {
     Q_OBJECT
 
 public:
-    explicit ConfigureInputSimple(QWidget* parent = nullptr);
+    explicit ConfigureInputSimple(
+        QWidget* parent = nullptr,
+        std::optional<Core::Frontend::ControllerParameters> constraints = std::nullopt);
     ~ConfigureInputSimple() override;
 
     /// Save all button configurations to settings file
@@ -36,5 +41,9 @@ private:
     void OnSelectProfile(int index);
     void OnConfigure();
 
+    void UpdateErrors();
+
     std::unique_ptr<Ui::ConfigureInputSimple> ui;
+    std::optional<Core::Frontend::ControllerParameters> constraints;
+    bool is_valid = true;
 };

--- a/src/yuzu/configuration/configure_input_simple.ui
+++ b/src/yuzu/configuration/configure_input_simple.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>473</width>
-    <height>685</height>
+    <height>247</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -89,6 +89,16 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item>
+    <widget class="QTextBrowser" name="error_view">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>120</height>
+      </size>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -33,6 +33,7 @@ class WaitTreeWidget;
 enum class GameListOpenTarget;
 
 namespace Core::Frontend {
+struct ControllerParameters;
 struct SoftwareKeyboardParameters;
 } // namespace Core::Frontend
 
@@ -102,7 +103,10 @@ signals:
     // Signal that tells widgets to update icons to use the current theme
     void UpdateThemedIcons();
 
+    void ControllerAppletReconfigureFinished(bool ok);
+
     void ProfileSelectorFinishedSelection(std::optional<Service::Account::UUID> uuid);
+
     void SoftwareKeyboardFinishedText(std::optional<std::u16string> text);
     void SoftwareKeyboardFinishedCheckDialog();
 
@@ -111,7 +115,11 @@ signals:
 
 public slots:
     void OnLoadComplete();
+    void ControllerAppletReconfigureControllers(
+        const Core::Frontend::ControllerParameters& parameters);
+
     void ProfileSelectorSelectProfile();
+
     void SoftwareKeyboardGetText(const Core::Frontend::SoftwareKeyboardParameters& parameters);
     void SoftwareKeyboardInvokeCheckDialog(std::u16string error_message);
     void WebBrowserOpenPage(std::string_view filename, std::string_view arguments);


### PR DESCRIPTION
This implements the controller selector applet (0x0C).

- For SDL, this will simply pick the best controller layout according to the parameters and log a warning.
- For Qt, this will open a version of the input tab of config with an error display. You must resolve all of these error before continuing.

Example Qt frontend:
![unknown 2](https://user-images.githubusercontent.com/5064800/50407323-d4ee6380-07a2-11e9-9d3a-6e2dbdcb387d.png)

The biggest user of this is Snipperclips+, but Undertale has also been shown to use it.