### PR TITLE
renderer_opengl: Correct forward declaration of FramebufferLayout

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -17,7 +17,7 @@ class EmuWindow;
 }
 
 namespace Layout {
-class FramebufferLayout;
+struct FramebufferLayout;
 }
 
 namespace OpenGL {


### PR DESCRIPTION
This is actually a struct, not a class, which can lead to compilation warnings.