### PR TITLE
kernel/vm_manager: Reset region attributes when unmapping a VMA

### DIFF
--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -190,6 +190,7 @@ VMManager::VMAIter VMManager::Unmap(VMAIter vma_handle) {
     vma.type = VMAType::Free;
     vma.permissions = VMAPermission::None;
     vma.state = MemoryState::Unmapped;
+    vma.attribute = MemoryAttribute::None;
 
     vma.backing_block = nullptr;
     vma.offset = 0;


### PR DESCRIPTION
Like the other members related to memory regions, the attributes need to be reset back to their defaults as well.