### PR TITLE
settings: Add support for setting the RTC manually

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -96,8 +96,7 @@ struct System::Impl {
         kernel.Initialize();
 
         const auto current_time = std::chrono::duration_cast<std::chrono::seconds>(
-                                      std::chrono::system_clock::now().time_since_epoch())
-                                      .count();
+            std::chrono::system_clock::now().time_since_epoch());
         Settings::values.custom_rtc_differential =
             Settings::values.custom_rtc.value_or(current_time) - current_time;
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -30,6 +30,7 @@
 #include "core/hle/service/sm/sm.h"
 #include "core/loader/loader.h"
 #include "core/perf_stats.h"
+#include "core/settings.h"
 #include "core/telemetry_session.h"
 #include "frontend/applets/software_keyboard.h"
 #include "video_core/debug_utils/debug_utils.h"
@@ -93,6 +94,12 @@ struct System::Impl {
 
         CoreTiming::Init();
         kernel.Initialize();
+
+        const auto current_time = std::chrono::duration_cast<std::chrono::seconds>(
+                                      std::chrono::system_clock::now().time_since_epoch())
+                                      .count();
+        Settings::values.custom_rtc_differential =
+            Settings::values.custom_rtc.value_or(current_time) - current_time;
 
         // Create a default fs if one doesn't already exist.
         if (virtual_filesystem == nullptr)

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -16,10 +16,9 @@
 
 namespace Service::Time {
 
-static s64 GetSecondsSinceEpoch() {
+static std::chrono::seconds GetSecondsSinceEpoch() {
     return std::chrono::duration_cast<std::chrono::seconds>(
-               std::chrono::system_clock::now().time_since_epoch())
-               .count() +
+               std::chrono::system_clock::now().time_since_epoch()) +
            Settings::values.custom_rtc_differential;
 }
 
@@ -76,7 +75,7 @@ public:
 
 private:
     void GetCurrentTime(Kernel::HLERequestContext& ctx) {
-        const s64 time_since_epoch{GetSecondsSinceEpoch()};
+        const s64 time_since_epoch{GetSecondsSinceEpoch().count()};
         LOG_DEBUG(Service_Time, "called");
 
         IPC::ResponseBuilder rb{ctx, 4};
@@ -272,8 +271,7 @@ void Module::Interface::GetClockSnapshot(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto initial_type = rp.PopRaw<u8>();
 
-    const s64 time_since_epoch{GetSecondsSinceEpoch()};
-
+    const s64 time_since_epoch{GetSecondsSinceEpoch().count()};
     const std::time_t time(time_since_epoch);
     const std::tm* tm = std::localtime(&time);
     if (tm == nullptr) {

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -12,8 +12,16 @@
 #include "core/hle/kernel/client_session.h"
 #include "core/hle/service/time/interface.h"
 #include "core/hle/service/time/time.h"
+#include "core/settings.h"
 
 namespace Service::Time {
+
+static s64 GetSecondsSinceEpoch() {
+    return std::chrono::duration_cast<std::chrono::seconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+               .count() +
+           Settings::values.custom_rtc_differential;
+}
 
 static void PosixToCalendar(u64 posix_time, CalendarTime& calendar_time,
                             CalendarAdditionalInfo& additional_info,
@@ -68,9 +76,7 @@ public:
 
 private:
     void GetCurrentTime(Kernel::HLERequestContext& ctx) {
-        const s64 time_since_epoch{std::chrono::duration_cast<std::chrono::seconds>(
-                                       std::chrono::system_clock::now().time_since_epoch())
-                                       .count()};
+        const s64 time_since_epoch{GetSecondsSinceEpoch()};
         LOG_DEBUG(Service_Time, "called");
 
         IPC::ResponseBuilder rb{ctx, 4};
@@ -266,9 +272,7 @@ void Module::Interface::GetClockSnapshot(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto initial_type = rp.PopRaw<u8>();
 
-    const s64 time_since_epoch{std::chrono::duration_cast<std::chrono::seconds>(
-                                   std::chrono::system_clock::now().time_since_epoch())
-                                   .count()};
+    const s64 time_since_epoch{GetSecondsSinceEpoch()};
 
     const std::time_t time(time_since_epoch);
     const std::tm* tm = std::localtime(&time);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -351,10 +351,11 @@ struct Values {
     bool use_docked_mode;
     bool enable_nfc;
     std::optional<u32> rng_seed;
-    std::optional<std::chrono::seconds> custom_rtc; // Measured in seconds since epoch
-    std::chrono::seconds
-        custom_rtc_differential; // Set on game boot, reset on stop. Seconds difference between
-                                 // current time and `custom_rtc`
+    // Measured in seconds since epoch
+    std::optional<std::chrono::seconds> custom_rtc;
+    // Set on game boot, reset on stop. Seconds difference between current time and `custom_rtc`
+    std::chrono::seconds custom_rtc_differential;
+
     s32 current_user;
     s32 language_index;
 

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <atomic>
+#include <chrono>
 #include <map>
 #include <optional>
 #include <string>
@@ -350,9 +351,10 @@ struct Values {
     bool use_docked_mode;
     bool enable_nfc;
     std::optional<u32> rng_seed;
-    std::optional<s64> custom_rtc; // Measured in seconds since epoch
-    s64 custom_rtc_differential;   // Set on game boot, reset on stop. Seconds difference between
-                                   // current time and `custom_rtc`
+    std::optional<std::chrono::seconds> custom_rtc; // Measured in seconds since epoch
+    std::chrono::seconds
+        custom_rtc_differential; // Set on game boot, reset on stop. Seconds difference between
+                                 // current time and `custom_rtc`
     s32 current_user;
     s32 language_index;
 

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -350,6 +350,9 @@ struct Values {
     bool use_docked_mode;
     bool enable_nfc;
     std::optional<u32> rng_seed;
+    std::optional<s64> custom_rtc; // Measured in seconds since epoch
+    s64 custom_rtc_differential;   // Set on game boot, reset on stop. Seconds difference between
+                                   // current time and `custom_rtc`
     s32 current_user;
     s32 language_index;
 

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -419,11 +419,18 @@ void Config::ReadValues() {
 
     Settings::values.language_index = qt_config->value("language_index", 1).toInt();
 
-    const auto enabled = qt_config->value("rng_seed_enabled", false).toBool();
-    if (enabled) {
+    const auto rng_seed_enabled = qt_config->value("rng_seed_enabled", false).toBool();
+    if (rng_seed_enabled) {
         Settings::values.rng_seed = qt_config->value("rng_seed", 0).toULongLong();
     } else {
         Settings::values.rng_seed = std::nullopt;
+    }
+
+    const auto custom_rtc_enabled = qt_config->value("custom_rtc_enabled", false).toBool();
+    if (custom_rtc_enabled) {
+        Settings::values.custom_rtc = qt_config->value("custom_rtc", 0).toULongLong();
+    } else {
+        Settings::values.custom_rtc = std::nullopt;
     }
 
     qt_config->endGroup();
@@ -652,6 +659,9 @@ void Config::SaveValues() {
 
     qt_config->setValue("rng_seed_enabled", Settings::values.rng_seed.has_value());
     qt_config->setValue("rng_seed", Settings::values.rng_seed.value_or(0));
+
+    qt_config->setValue("custom_rtc_enabled", Settings::values.custom_rtc.has_value());
+    qt_config->setValue("custom_rtc", Settings::values.custom_rtc.value_or(0));
 
     qt_config->endGroup();
 

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -428,7 +428,8 @@ void Config::ReadValues() {
 
     const auto custom_rtc_enabled = qt_config->value("custom_rtc_enabled", false).toBool();
     if (custom_rtc_enabled) {
-        Settings::values.custom_rtc = qt_config->value("custom_rtc", 0).toULongLong();
+        Settings::values.custom_rtc =
+            std::chrono::seconds(qt_config->value("custom_rtc", 0).toULongLong());
     } else {
         Settings::values.custom_rtc = std::nullopt;
     }
@@ -661,7 +662,8 @@ void Config::SaveValues() {
     qt_config->setValue("rng_seed", Settings::values.rng_seed.value_or(0));
 
     qt_config->setValue("custom_rtc_enabled", Settings::values.custom_rtc.has_value());
-    qt_config->setValue("custom_rtc", Settings::values.custom_rtc.value_or(0));
+    qt_config->setValue("custom_rtc",
+                        Settings::values.custom_rtc.value_or(std::chrono::seconds{}).count());
 
     qt_config->endGroup();
 

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -663,7 +663,8 @@ void Config::SaveValues() {
 
     qt_config->setValue("custom_rtc_enabled", Settings::values.custom_rtc.has_value());
     qt_config->setValue("custom_rtc",
-                        Settings::values.custom_rtc.value_or(std::chrono::seconds{}).count());
+                        QVariant::fromValue<long long>(
+                            Settings::values.custom_rtc.value_or(std::chrono::seconds{}).count()));
 
     qt_config->endGroup();
 

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -51,6 +51,12 @@ ConfigureSystem::ConfigureSystem(QWidget* parent) : QWidget(parent), ui(new Ui::
             ui->rng_seed_edit->setText(QStringLiteral("00000000"));
     });
 
+    connect(ui->custom_rtc_checkbox, &QCheckBox::stateChanged, this, [this](bool checked) {
+        ui->custom_rtc_edit->setEnabled(checked);
+        if (!checked)
+            ui->custom_rtc_edit->setDateTime(QDateTime::currentDateTime());
+    });
+
     this->setConfiguration();
 }
 
@@ -67,6 +73,12 @@ void ConfigureSystem::setConfiguration() {
     const auto rng_seed =
         QString("%1").arg(Settings::values.rng_seed.value_or(0), 8, 16, QLatin1Char{'0'}).toUpper();
     ui->rng_seed_edit->setText(rng_seed);
+
+    ui->custom_rtc_checkbox->setChecked(Settings::values.custom_rtc.has_value());
+    ui->custom_rtc_edit->setEnabled(Settings::values.custom_rtc.has_value());
+
+    const auto rtc_time = Settings::values.custom_rtc.value_or(QDateTime::currentSecsSinceEpoch());
+    ui->custom_rtc_edit->setDateTime(QDateTime::fromSecsSinceEpoch(rtc_time));
 }
 
 void ConfigureSystem::ReadSystemSettings() {}
@@ -81,6 +93,11 @@ void ConfigureSystem::applyConfiguration() {
         Settings::values.rng_seed = ui->rng_seed_edit->text().toULongLong(nullptr, 16);
     else
         Settings::values.rng_seed = std::nullopt;
+
+    if (ui->custom_rtc_checkbox->isChecked())
+        Settings::values.custom_rtc = ui->custom_rtc_edit->dateTime().toSecsSinceEpoch();
+    else
+        Settings::values.custom_rtc = std::nullopt;
 
     Settings::Apply();
 }

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -77,8 +77,9 @@ void ConfigureSystem::setConfiguration() {
     ui->custom_rtc_checkbox->setChecked(Settings::values.custom_rtc.has_value());
     ui->custom_rtc_edit->setEnabled(Settings::values.custom_rtc.has_value());
 
-    const auto rtc_time = Settings::values.custom_rtc.value_or(QDateTime::currentSecsSinceEpoch());
-    ui->custom_rtc_edit->setDateTime(QDateTime::fromSecsSinceEpoch(rtc_time));
+    const auto rtc_time = Settings::values.custom_rtc.value_or(
+        std::chrono::seconds(QDateTime::currentSecsSinceEpoch()));
+    ui->custom_rtc_edit->setDateTime(QDateTime::fromSecsSinceEpoch(rtc_time.count()));
 }
 
 void ConfigureSystem::ReadSystemSettings() {}
@@ -95,7 +96,8 @@ void ConfigureSystem::applyConfiguration() {
         Settings::values.rng_seed = std::nullopt;
 
     if (ui->custom_rtc_checkbox->isChecked())
-        Settings::values.custom_rtc = ui->custom_rtc_edit->dateTime().toSecsSinceEpoch();
+        Settings::values.custom_rtc =
+            std::chrono::seconds(ui->custom_rtc_edit->dateTime().toSecsSinceEpoch());
     else
         Settings::values.custom_rtc = std::nullopt;
 

--- a/src/yuzu/configuration/configure_system.ui
+++ b/src/yuzu/configuration/configure_system.ui
@@ -22,6 +22,13 @@
         <string>System Settings</string>
        </property>
        <layout class="QGridLayout" name="gridLayout">
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_sound">
+          <property name="text">
+           <string>Sound output mode</string>
+          </property>
+         </widget>
+        </item>
         <item row="1" column="1">
          <widget class="QComboBox" name="combo_language">
           <property name="toolTip">
@@ -114,27 +121,6 @@
           </item>
          </widget>
         </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_console_id">
-          <property name="text">
-           <string>Console ID:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_sound">
-          <property name="text">
-           <string>Sound output mode</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_birthday">
-          <property name="text">
-           <string>Birthday</string>
-          </property>
-         </widget>
-        </item>
         <item row="0" column="1">
          <layout class="QHBoxLayout" name="horizontalLayout_birthday2">
           <item>
@@ -206,6 +192,20 @@
           </item>
          </layout>
         </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_console_id">
+          <property name="text">
+           <string>Console ID:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_birthday">
+          <property name="text">
+           <string>Birthday</string>
+          </property>
+         </widget>
+        </item>
         <item row="3" column="1">
          <widget class="QPushButton" name="button_regenerate_console_id">
           <property name="sizePolicy">
@@ -241,6 +241,13 @@
           </item>
          </widget>
         </item>
+        <item row="5" column="0">
+         <widget class="QCheckBox" name="rng_seed_checkbox">
+          <property name="text">
+           <string>RNG Seed</string>
+          </property>
+         </widget>
+        </item>
         <item row="1" column="0">
          <widget class="QLabel" name="label_language">
           <property name="text">
@@ -248,14 +255,7 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
-         <widget class="QCheckBox" name="rng_seed_checkbox">
-          <property name="text">
-           <string>RNG Seed</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
+        <item row="5" column="1">
          <widget class="QLineEdit" name="rng_seed_edit">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -273,6 +273,27 @@
           </property>
           <property name="maxLength">
            <number>8</number>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QCheckBox" name="custom_rtc_checkbox">
+          <property name="text">
+           <string>Custom RTC</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QDateTimeEdit" name="custom_rtc_edit">
+          <property name="minimumDate">
+           <date>
+            <year>1970</year>
+            <month>1</month>
+            <day>1</day>
+           </date>
+          </property>
+          <property name="displayFormat">
+           <string>d MMM yyyy h:mm:ss AP</string>
           </property>
          </widget>
         </item>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -334,7 +334,8 @@ void Config::ReadValues() {
 
     const auto custom_rtc_enabled = sdl2_config->GetBoolean("System", "custom_rtc_enabled", false);
     if (custom_rtc_enabled) {
-        Settings::values.custom_rtc = sdl2_config->GetInteger("System", "custom_rtc", 0);
+        Settings::values.custom_rtc =
+            std::chrono::seconds(sdl2_config->GetInteger("System", "custom_rtc", 0));
     } else {
         Settings::values.custom_rtc = std::nullopt;
     }

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -325,11 +325,18 @@ void Config::ReadValues() {
     Settings::values.current_user = std::clamp<int>(
         sdl2_config->GetInteger("System", "current_user", 0), 0, Service::Account::MAX_USERS - 1);
 
-    const auto enabled = sdl2_config->GetBoolean("System", "rng_seed_enabled", false);
-    if (enabled) {
+    const auto rng_seed_enabled = sdl2_config->GetBoolean("System", "rng_seed_enabled", false);
+    if (rng_seed_enabled) {
         Settings::values.rng_seed = sdl2_config->GetInteger("System", "rng_seed", 0);
     } else {
         Settings::values.rng_seed = std::nullopt;
+    }
+
+    const auto custom_rtc_enabled = sdl2_config->GetBoolean("System", "custom_rtc_enabled", false);
+    if (custom_rtc_enabled) {
+        Settings::values.custom_rtc = sdl2_config->GetInteger("System", "custom_rtc", 0);
+    } else {
+        Settings::values.custom_rtc = std::nullopt;
     }
 
     // Core

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -186,8 +186,8 @@ rng_seed =
 # Sets the current time (in seconds since 12:00 AM Jan 1, 1970) that will be used by the time service
 # This will auto-increment, with the time set being the time the game is started
 # This override will only occur if custom_rtc_enabled is true, otherwise the current time is used
-custom_rtc_enabled = 
-custom_rtc = 
+custom_rtc_enabled =
+custom_rtc =
 
 # Sets the account username, max length is 32 characters
 # yuzu (default)

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -183,6 +183,12 @@ enable_nfc =
 rng_seed_enabled =
 rng_seed =
 
+# Sets the current time (in seconds since 12:00 AM Jan 1, 1970) that will be used by the time service
+# This will auto-increment, with the time set being the time the game is started
+# This override will only occur if custom_rtc_enabled is true, otherwise the current time is used
+custom_rtc_enabled = 
+custom_rtc = 
+
 # Sets the account username, max length is 32 characters
 # yuzu (default)
 username = yuzu


### PR DESCRIPTION
This PR allows the user to set the current time reported to the game manually via settings. On game boot, the system stores a differential between the requested time and the current time (where negative is a time in the past and if this feature isn't enabled it will be 0). This is done so that the clock still increments, just relative to requested time (without this, random crashes will occur in audio-related code). Then, when the game requests the current time via `time:u`, the system will add the differential to the current time in seconds and use that for the service.

Tested against Cave Story, was successfully able to dis/enable the seasonal palette.

UI:
![image](https://user-images.githubusercontent.com/5064800/50531653-c625ea80-0adb-11e9-900f-368331a06973.png)
