### PR TITLE
video_core: Implement LDG through heuristics based on IR

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -87,6 +87,7 @@ add_library(video_core STATIC
     shader/decode.cpp
     shader/shader_ir.cpp
     shader/shader_ir.h
+    shader/track.cpp
     surface.cpp
     surface.h
     textures/astc.cpp

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -208,6 +208,8 @@ enum class UniformType : u64 {
     SignedShort = 3,
     Single = 4,
     Double = 5,
+    Quad = 6,
+    UnsignedQuad = 7,
 };
 
 enum class StoreType : u64 {
@@ -783,6 +785,12 @@ union Instruction {
     union {
         BitField<44, 2, u64> unknown;
     } st_l;
+
+    union {
+        BitField<48, 3, UniformType> type;
+        BitField<46, 2, u64> cache_mode;
+        BitField<20, 24, s64> immediate_offset;
+    } ldg;
 
     union {
         BitField<0, 3, u64> pred0;

--- a/src/video_core/renderer_opengl/gl_global_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_global_cache.cpp
@@ -4,8 +4,13 @@
 
 #include <glad/glad.h>
 
+#include "common/assert.h"
+#include "common/logging/log.h"
+#include "core/core.h"
+#include "core/memory.h"
 #include "video_core/renderer_opengl/gl_global_cache.h"
 #include "video_core/renderer_opengl/gl_rasterizer.h"
+#include "video_core/renderer_opengl/gl_shader_decompiler.h"
 #include "video_core/renderer_opengl/utils.h"
 
 namespace OpenGL {
@@ -18,7 +23,72 @@ CachedGlobalRegion::CachedGlobalRegion(VAddr addr, u32 size) : addr{addr}, size{
     LabelGLObject(GL_BUFFER, buffer.handle, addr, "GlobalMemory");
 }
 
+void CachedGlobalRegion::Reload(u32 size_) {
+    constexpr auto max_size = static_cast<u32>(RasterizerOpenGL::MaxGlobalMemorySize);
+
+    size = size_;
+    if (size > max_size) {
+        size = max_size;
+        LOG_CRITICAL(HW_GPU, "Global region size {} exceeded the expected size {}!", size_,
+                     max_size);
+    }
+
+    // TODO(Rodrigo): Get rid of Memory::GetPointer with a staging buffer
+    glBindBuffer(GL_SHADER_STORAGE_BUFFER, buffer.handle);
+    glBufferData(GL_SHADER_STORAGE_BUFFER, size, Memory::GetPointer(addr), GL_DYNAMIC_DRAW);
+}
+
+GlobalRegion GlobalRegionCacheOpenGL::TryGetReservedGlobalRegion(VAddr addr, u32 size) const {
+    const auto search{reserve.find(addr)};
+    if (search == reserve.end()) {
+        return {};
+    }
+    return search->second;
+}
+
+GlobalRegion GlobalRegionCacheOpenGL::GetUncachedGlobalRegion(VAddr addr, u32 size) {
+    GlobalRegion region{TryGetReservedGlobalRegion(addr, size)};
+    if (!region) {
+        // No reserved surface available, create a new one and reserve it
+        region = std::make_shared<CachedGlobalRegion>(addr, size);
+        ReserveGlobalRegion(region);
+    }
+    region->Reload(size);
+    return region;
+}
+
+void GlobalRegionCacheOpenGL::ReserveGlobalRegion(const GlobalRegion& region) {
+    reserve[region->GetAddr()] = region;
+}
+
 GlobalRegionCacheOpenGL::GlobalRegionCacheOpenGL(RasterizerOpenGL& rasterizer)
     : RasterizerCache{rasterizer} {}
+
+GlobalRegion GlobalRegionCacheOpenGL::GetGlobalRegion(
+    const GLShader::GlobalMemoryEntry& global_region,
+    Tegra::Engines::Maxwell3D::Regs::ShaderStage stage) {
+
+    auto& gpu{Core::System::GetInstance().GPU()};
+    const auto cbufs = gpu.Maxwell3D().state.shader_stages[static_cast<u64>(stage)];
+    const auto cbuf_addr = gpu.MemoryManager().GpuToCpuAddress(
+        cbufs.const_buffers[global_region.GetCbufIndex()].address + global_region.GetCbufOffset());
+    ASSERT(cbuf_addr);
+
+    const auto actual_addr_gpu = Memory::Read64(*cbuf_addr);
+    const auto size = Memory::Read32(*cbuf_addr + 8);
+    const auto actual_addr = gpu.MemoryManager().GpuToCpuAddress(actual_addr_gpu);
+    ASSERT(actual_addr);
+
+    // Look up global region in the cache based on address
+    GlobalRegion region = TryGet(*actual_addr);
+
+    if (!region) {
+        // No global region found - create a new one
+        region = GetUncachedGlobalRegion(*actual_addr, size);
+        Register(region);
+    }
+
+    return region;
+}
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_global_cache.h
+++ b/src/video_core/renderer_opengl/gl_global_cache.h
@@ -5,9 +5,13 @@
 #pragma once
 
 #include <memory>
+#include <unordered_map>
+
 #include <glad/glad.h>
 
+#include "common/assert.h"
 #include "common/common_types.h"
+#include "video_core/engines/maxwell_3d.h"
 #include "video_core/rasterizer_cache.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 
@@ -40,6 +44,9 @@ public:
         return buffer.handle;
     }
 
+    /// Reloads the global region from guest memory
+    void Reload(u32 size_);
+
     // TODO(Rodrigo): When global memory is written (STG), implement flushing
     void Flush() override {
         UNIMPLEMENTED();
@@ -55,6 +62,17 @@ private:
 class GlobalRegionCacheOpenGL final : public RasterizerCache<GlobalRegion> {
 public:
     explicit GlobalRegionCacheOpenGL(RasterizerOpenGL& rasterizer);
+
+    /// Gets the current specified shader stage program
+    GlobalRegion GetGlobalRegion(const GLShader::GlobalMemoryEntry& descriptor,
+                                 Tegra::Engines::Maxwell3D::Regs::ShaderStage stage);
+
+private:
+    GlobalRegion TryGetReservedGlobalRegion(VAddr addr, u32 size) const;
+    GlobalRegion GetUncachedGlobalRegion(VAddr addr, u32 size);
+    void ReserveGlobalRegion(const GlobalRegion& region);
+
+    std::unordered_map<VAddr, GlobalRegion> reserve;
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -138,6 +138,16 @@ private:
                           GLenum primitive_mode, u32 current_bindpoint);
 
     /**
+     * Configures the current global memory regions to use for the draw command.
+     * @param stage The shader stage to configure buffers for.
+     * @param shader The shader object that contains the specified stage.
+     * @param current_bindpoint The offset at which to start counting new buffer bindpoints.
+     * @returns The next available bindpoint for use in the next shader stage.
+     */
+    u32 SetupGlobalRegions(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage, Shader& shader,
+                           GLenum primitive_mode, u32 current_bindpoint);
+
+    /**
      * Configures the current textures to use for the draw command.
      * @param stage The shader stage to configure textures for.
      * @param shader The shader object that contains the specified stage.

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -108,11 +108,23 @@ CachedShader::CachedShader(VAddr addr, Maxwell::ShaderProgram program_type)
 }
 
 GLuint CachedShader::GetProgramResourceIndex(const GLShader::ConstBufferEntry& buffer) {
-    const auto search{resource_cache.find(buffer.GetHash())};
-    if (search == resource_cache.end()) {
+    const auto search{cbuf_resource_cache.find(buffer.GetHash())};
+    if (search == cbuf_resource_cache.end()) {
         const GLuint index{
             glGetProgramResourceIndex(program.handle, GL_UNIFORM_BLOCK, buffer.GetName().c_str())};
-        resource_cache[buffer.GetHash()] = index;
+        cbuf_resource_cache[buffer.GetHash()] = index;
+        return index;
+    }
+
+    return search->second;
+}
+
+GLuint CachedShader::GetProgramResourceIndex(const GLShader::GlobalMemoryEntry& global_mem) {
+    const auto search{gmem_resource_cache.find(global_mem.GetHash())};
+    if (search == gmem_resource_cache.end()) {
+        const GLuint index{glGetProgramResourceIndex(program.handle, GL_SHADER_STORAGE_BLOCK,
+                                                     global_mem.GetName().c_str())};
+        gmem_resource_cache[global_mem.GetHash()] = index;
         return index;
     }
 

--- a/src/video_core/renderer_opengl/gl_shader_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_cache.h
@@ -76,6 +76,9 @@ public:
     /// Gets the GL program resource location for the specified resource, caching as needed
     GLuint GetProgramResourceIndex(const GLShader::ConstBufferEntry& buffer);
 
+    /// Gets the GL program resource location for the specified resource, caching as needed
+    GLuint GetProgramResourceIndex(const GLShader::GlobalMemoryEntry& global_mem);
+
     /// Gets the GL uniform location for the specified resource, caching as needed
     GLint GetUniformLocation(const GLShader::SamplerEntry& sampler);
 
@@ -107,7 +110,8 @@ private:
         OGLProgram triangles_adjacency;
     } geometry_programs;
 
-    std::map<u32, GLuint> resource_cache;
+    std::map<u32, GLuint> cbuf_resource_cache;
+    std::map<u32, GLuint> gmem_resource_cache;
     std::map<u32, GLint> uniform_cache;
 };
 

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.h
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.h
@@ -71,9 +71,43 @@ private:
     Maxwell::ShaderStage stage{};
 };
 
+class GlobalMemoryEntry {
+public:
+    explicit GlobalMemoryEntry(u32 cbuf_index, u32 cbuf_offset, Maxwell::ShaderStage stage,
+                               std::string name)
+        : cbuf_index{cbuf_index}, cbuf_offset{cbuf_offset}, stage{stage}, name{std::move(name)} {}
+
+    u32 GetCbufIndex() const {
+        return cbuf_index;
+    }
+
+    u32 GetCbufOffset() const {
+        return cbuf_offset;
+    }
+
+    const std::string& GetName() const {
+        return name;
+    }
+
+    Maxwell::ShaderStage GetStage() const {
+        return stage;
+    }
+
+    u32 GetHash() const {
+        return (static_cast<u32>(stage) << 24) | (cbuf_index << 16) | cbuf_offset;
+    }
+
+private:
+    u32 cbuf_index{};
+    u32 cbuf_offset{};
+    Maxwell::ShaderStage stage{};
+    std::string name;
+};
+
 struct ShaderEntries {
     std::vector<ConstBufferEntry> const_buffers;
     std::vector<SamplerEntry> samplers;
+    std::vector<GlobalMemoryEntry> global_memory_entries;
     std::array<bool, Maxwell::NumClipDistances> clip_distances{};
     std::size_t shader_length{};
 };

--- a/src/video_core/shader/track.cpp
+++ b/src/video_core/shader/track.cpp
@@ -1,0 +1,76 @@
+// Copyright 2018 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <utility>
+#include <variant>
+
+#include "video_core/shader/shader_ir.h"
+
+namespace VideoCommon::Shader {
+
+namespace {
+std::pair<Node, s64> FindOperation(const BasicBlock& code, s64 cursor,
+                                   OperationCode operation_code) {
+    for (; cursor >= 0; --cursor) {
+        const Node node = code[cursor];
+        if (const auto operation = std::get_if<OperationNode>(node)) {
+            if (operation->GetCode() == operation_code)
+                return {node, cursor};
+        }
+    }
+    return {};
+}
+} // namespace
+
+Node ShaderIR::TrackCbuf(Node tracked, const BasicBlock& code, s64 cursor) {
+    if (const auto cbuf = std::get_if<CbufNode>(tracked)) {
+        // Cbuf found, but it has to be immediate
+        return std::holds_alternative<ImmediateNode>(*cbuf->GetOffset()) ? tracked : nullptr;
+    }
+    if (const auto gpr = std::get_if<GprNode>(tracked)) {
+        if (gpr->GetIndex() == Tegra::Shader::Register::ZeroIndex) {
+            return nullptr;
+        }
+        // Reduce the cursor in one to avoid infinite loops when the instruction sets the same
+        // register that it uses as operand
+        const auto [source, new_cursor] = TrackRegister(gpr, code, cursor - 1);
+        if (!source) {
+            return nullptr;
+        }
+        return TrackCbuf(source, code, new_cursor);
+    }
+    if (const auto operation = std::get_if<OperationNode>(tracked)) {
+        for (std::size_t i = 0; i < operation->GetOperandsCount(); ++i) {
+            if (const auto found = TrackCbuf((*operation)[i], code, cursor)) {
+                // Cbuf found in operand
+                return found;
+            }
+        }
+        return nullptr;
+    }
+    return nullptr;
+}
+
+std::pair<Node, s64> ShaderIR::TrackRegister(const GprNode* tracked, const BasicBlock& code,
+                                             s64 cursor) {
+    for (; cursor >= 0; --cursor) {
+        const auto [found_node, new_cursor] = FindOperation(code, cursor, OperationCode::Assign);
+        if (!found_node) {
+            return {};
+        }
+        const auto operation = std::get_if<OperationNode>(found_node);
+        ASSERT(operation);
+
+        const auto& target = (*operation)[0];
+        if (const auto gpr_target = std::get_if<GprNode>(target)) {
+            if (gpr_target->GetIndex() == tracked->GetIndex()) {
+                return {(*operation)[1], new_cursor};
+            }
+        }
+    }
+    return {};
+}
+
+} // namespace VideoCommon::Shader


### PR DESCRIPTION
This PR uses #1927 as a base implementing #1603 that's itself a continuation of #1323, based on gdkchan's approach for LDG.

About the heuristic itself: it takes the LDG low address register and does a desperate recursive search for any constant buffer that operates on it (returning the first one found), including register proxies.

As difference compared to #1603 and #1323, this one:
* Returns global memory entries through shader entries instead of a global state in Maxwell3D;
* uses SSBOs instead of UBOs; and
* it uses a fixed size for SSBOs.

It has the same graphical issues as #1603, but from what I've seen the heuristic is doing fine (it points to the right constant buffer as base); which means that there's an error elsewhere (some LDG addresses are calculated using XMAD). From some debugging, text textures are fine: the problem is in the shader itself.

The giant diff is because it includes #1927, the last two commits are from this PR.

Edit: It's still broken on AMD's proprietary stack.