### PR TITLE
service/time: Minor cleanup

### DIFF
--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -266,12 +266,10 @@ void Module::Interface::GetClockSnapshot(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto initial_type = rp.PopRaw<u8>();
 
-    ClockSnapshot clock_snapshot{};
-
     const s64 time_since_epoch{std::chrono::duration_cast<std::chrono::seconds>(
                                    std::chrono::system_clock::now().time_since_epoch())
                                    .count()};
-    CalendarTime calendar_time{};
+
     const std::time_t time(time_since_epoch);
     const std::tm* tm = std::localtime(&time);
     if (tm == nullptr) {
@@ -280,16 +278,19 @@ void Module::Interface::GetClockSnapshot(Kernel::HLERequestContext& ctx) {
         rb.Push(ResultCode(-1)); // TODO(ogniK): Find appropriate error code
         return;
     }
-    SteadyClockTimePoint steady_clock_time_point{CoreTiming::cyclesToMs(CoreTiming::GetTicks()) /
-                                                 1000};
 
-    LocationName location_name{"UTC"};
+    const SteadyClockTimePoint steady_clock_time_point{
+        CoreTiming::cyclesToMs(CoreTiming::GetTicks()) / 1000, {}};
+
+    CalendarTime calendar_time{};
     calendar_time.year = tm->tm_year + 1900;
     calendar_time.month = tm->tm_mon + 1;
     calendar_time.day = tm->tm_mday;
     calendar_time.hour = tm->tm_hour;
     calendar_time.minute = tm->tm_min;
     calendar_time.second = tm->tm_sec;
+
+    ClockSnapshot clock_snapshot{};
     clock_snapshot.system_posix_time = time_since_epoch;
     clock_snapshot.network_posix_time = time_since_epoch;
     clock_snapshot.system_calendar_time = calendar_time;
@@ -302,9 +303,10 @@ void Module::Interface::GetClockSnapshot(Kernel::HLERequestContext& ctx) {
     clock_snapshot.network_calendar_info = additional_info;
 
     clock_snapshot.steady_clock_timepoint = steady_clock_time_point;
-    clock_snapshot.location_name = location_name;
+    clock_snapshot.location_name = LocationName{"UTC"};
     clock_snapshot.clock_auto_adjustment_enabled = 1;
     clock_snapshot.type = initial_type;
+
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
     ctx.WriteBuffer(&clock_snapshot, sizeof(ClockSnapshot));

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -264,7 +264,7 @@ void Module::Interface::GetClockSnapshot(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_Time, "called");
 
     IPC::RequestParser rp{ctx};
-    auto unknown_u8 = rp.PopRaw<u8>();
+    const auto initial_type = rp.PopRaw<u8>();
 
     ClockSnapshot clock_snapshot{};
 
@@ -304,7 +304,7 @@ void Module::Interface::GetClockSnapshot(Kernel::HLERequestContext& ctx) {
     clock_snapshot.steady_clock_timepoint = steady_clock_time_point;
     clock_snapshot.location_name = location_name;
     clock_snapshot.clock_auto_adjustment_enabled = 1;
-    clock_snapshot.ipc_u8 = unknown_u8;
+    clock_snapshot.type = initial_type;
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
     ctx.WriteBuffer(&clock_snapshot, sizeof(ClockSnapshot));

--- a/src/core/hle/service/time/time.h
+++ b/src/core/hle/service/time/time.h
@@ -22,7 +22,6 @@ struct CalendarTime {
     u8 hour;
     u8 minute;
     u8 second;
-    INSERT_PADDING_BYTES(1);
 };
 static_assert(sizeof(CalendarTime) == 0x8, "CalendarTime structure has incorrect size");
 
@@ -30,7 +29,7 @@ struct CalendarAdditionalInfo {
     u32_le day_of_week;
     u32_le day_of_year;
     std::array<u8, 8> name;
-    INSERT_PADDING_BYTES(1);
+    u8 is_dst;
     s32_le utc_offset;
 };
 static_assert(sizeof(CalendarAdditionalInfo) == 0x18,
@@ -42,8 +41,10 @@ struct TimeZoneRule {
 };
 
 struct SteadyClockTimePoint {
+    using SourceID = std::array<u8, 16>;
+
     u64_le value;
-    INSERT_PADDING_WORDS(4);
+    SourceID source_id;
 };
 static_assert(sizeof(SteadyClockTimePoint) == 0x18, "SteadyClockTimePoint is incorrect size");
 
@@ -66,8 +67,9 @@ struct ClockSnapshot {
     SteadyClockTimePoint steady_clock_timepoint;
     LocationName location_name;
     u8 clock_auto_adjustment_enabled;
-    u8 ipc_u8;
-    INSERT_PADDING_BYTES(2);
+    u8 type;
+    u8 version;
+    INSERT_PADDING_BYTES(1);
 };
 static_assert(sizeof(ClockSnapshot) == 0xd0, "ClockSnapshot is an invalid size");
 


### PR DESCRIPTION
Fills in a bit of the data structures a little more based off RE and cleans up GetClockSnapshot to move variables closer to where they're actually used.