### PR TITLE
kernel/svc: Sanitize core and priority masks within CreateThread

### DIFF
--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -173,13 +173,13 @@ public:
         return ideal_core;
     }
 
-    /// Gets the bitmask of allowed CPUs that this process' threads can run on.
-    u64 GetAllowedProcessorMask() const {
+    /// Gets the bitmask of allowed cores that this process' threads can run on.
+    u64 GetCoreMask() const {
         return capabilities.GetCoreMask();
     }
 
     /// Gets the bitmask of allowed thread priorities.
-    u64 GetAllowedThreadPriorityMask() const {
+    u64 GetPriorityMask() const {
         return capabilities.GetPriorityMask();
     }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -715,8 +715,8 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
 
     enum class GetInfoType : u64 {
         // 1.0.0+
-        AllowedCpuIdBitmask = 0,
-        AllowedThreadPrioBitmask = 1,
+        AllowedCPUCoreMask = 0,
+        AllowedThreadPriorityMask = 1,
         MapRegionBaseAddr = 2,
         MapRegionSize = 3,
         HeapRegionBaseAddr = 4,
@@ -747,8 +747,8 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
     const auto info_id_type = static_cast<GetInfoType>(info_id);
 
     switch (info_id_type) {
-    case GetInfoType::AllowedCpuIdBitmask:
-    case GetInfoType::AllowedThreadPrioBitmask:
+    case GetInfoType::AllowedCPUCoreMask:
+    case GetInfoType::AllowedThreadPriorityMask:
     case GetInfoType::MapRegionBaseAddr:
     case GetInfoType::MapRegionSize:
     case GetInfoType::HeapRegionBaseAddr:
@@ -774,12 +774,12 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
         }
 
         switch (info_id_type) {
-        case GetInfoType::AllowedCpuIdBitmask:
-            *result = process->GetAllowedProcessorMask();
+        case GetInfoType::AllowedCPUCoreMask:
+            *result = process->GetCoreMask();
             return RESULT_SUCCESS;
 
-        case GetInfoType::AllowedThreadPrioBitmask:
-            *result = process->GetAllowedThreadPriorityMask();
+        case GetInfoType::AllowedThreadPriorityMask:
+            *result = process->GetPriorityMask();
             return RESULT_SUCCESS;
 
         case GetInfoType::MapRegionBaseAddr:

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1233,13 +1233,7 @@ static ResultCode CreateThread(Handle* out_handle, VAddr entry_point, u64 arg, V
         ASSERT(processor_id != THREADPROCESSORID_IDEAL);
     }
 
-    switch (processor_id) {
-    case THREADPROCESSORID_0:
-    case THREADPROCESSORID_1:
-    case THREADPROCESSORID_2:
-    case THREADPROCESSORID_3:
-        break;
-    default:
+    if (processor_id < THREADPROCESSORID_0 || processor_id > THREADPROCESSORID_3) {
         LOG_ERROR(Kernel_SVC, "Invalid thread processor ID: {}", processor_id);
         return ERR_INVALID_PROCESSOR_ID;
     }

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1239,8 +1239,9 @@ static ResultCode CreateThread(Handle* out_handle, VAddr entry_point, u64 arg, V
     }
 
     if (priority > THREADPRIO_LOWEST) {
-        LOG_ERROR(Kernel_SVC, "An invalid priority was specified, expected {} but got {}",
-                  THREADPRIO_LOWEST, priority);
+        LOG_ERROR(Kernel_SVC,
+                  "Invalid thread priority specified ({}). Must be within the range 0-64",
+                  priority);
         return ERR_INVALID_THREAD_PRIORITY;
     }
 


### PR DESCRIPTION
Given #1928 is now merged and we handle the kernel capability descriptors, we can properly sanitize the given core and priority values given to CreateThread by comparing against the masks specified by metadata like how the kernel itself does. 