### PR TITLE
yuzu: Fix truncation warnings within UI code

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -680,7 +680,7 @@ void Config::SaveValues() {
         qt_config->setValue("title_id", QVariant::fromValue<u64>(elem.first));
         qt_config->beginWriteArray("disabled");
         for (std::size_t j = 0; j < elem.second.size(); ++j) {
-            qt_config->setArrayIndex(j);
+            qt_config->setArrayIndex(static_cast<int>(j));
             qt_config->setValue("d", QString::fromStdString(elem.second[j]));
         }
         qt_config->endArray();

--- a/src/yuzu/configuration/configure_per_general.cpp
+++ b/src/yuzu/configuration/configure_per_general.cpp
@@ -120,7 +120,7 @@ void ConfigurePerGameGeneral::loadConfiguration() {
 
         QPixmap map;
         const auto bytes = control.second->ReadAllBytes();
-        map.loadFromData(bytes.data(), bytes.size());
+        map.loadFromData(bytes.data(), static_cast<u32>(bytes.size()));
 
         scene->addPixmap(map.scaled(ui->icon_view->width(), ui->icon_view->height(),
                                     Qt::IgnoreAspectRatio, Qt::SmoothTransformation));
@@ -130,7 +130,7 @@ void ConfigurePerGameGeneral::loadConfiguration() {
             scene->clear();
 
             QPixmap map;
-            map.loadFromData(bytes.data(), bytes.size());
+            map.loadFromData(bytes.data(), static_cast<u32>(bytes.size()));
 
             scene->addPixmap(map.scaled(ui->icon_view->width(), ui->icon_view->height(),
                                         Qt::IgnoreAspectRatio, Qt::SmoothTransformation));


### PR DESCRIPTION
In these scenarios, Qt's API only accepts a 32-bit value, so there's nothing we can do about these except explicitly cast the values.