### PR TITLE
core/kernel: Remove unnecessary inclusions

### DIFF
--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -18,7 +18,7 @@
 #include "core/hle/kernel/client_session.h"
 #include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/kernel/object.h"
-#include "core/hle/kernel/server_port.h"
+#include "core/hle/kernel/server_session.h"
 
 namespace IPC {
 

--- a/src/core/hle/kernel/client_session.cpp
+++ b/src/core/hle/kernel/client_session.cpp
@@ -8,6 +8,7 @@
 #include "core/hle/kernel/server_session.h"
 #include "core/hle/kernel/session.h"
 #include "core/hle/kernel/thread.h"
+#include "core/hle/result.h"
 
 namespace Kernel {
 

--- a/src/core/hle/kernel/client_session.h
+++ b/src/core/hle/kernel/client_session.h
@@ -6,9 +6,9 @@
 
 #include <memory>
 #include <string>
-#include "common/common_types.h"
 #include "core/hle/kernel/object.h"
-#include "core/hle/result.h"
+
+union ResultCode;
 
 namespace Kernel {
 

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -22,10 +22,15 @@
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/readable_event.h"
 #include "core/hle/kernel/server_session.h"
+#include "core/hle/kernel/thread.h"
 #include "core/hle/kernel/writable_event.h"
 #include "core/memory.h"
 
 namespace Kernel {
+
+SessionRequestHandler::SessionRequestHandler() = default;
+
+SessionRequestHandler::~SessionRequestHandler() = default;
 
 void SessionRequestHandler::ClientConnected(SharedPtr<ServerSession> server_session) {
     server_session->SetHleHandler(shared_from_this());

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -14,8 +14,6 @@
 #include "common/swap.h"
 #include "core/hle/ipc.h"
 #include "core/hle/kernel/object.h"
-#include "core/hle/kernel/server_session.h"
-#include "core/hle/kernel/thread.h"
 
 namespace Service {
 class ServiceFrameworkBase;
@@ -27,8 +25,12 @@ class Domain;
 class HandleTable;
 class HLERequestContext;
 class Process;
+class ServerSession;
+class Thread;
 class ReadableEvent;
 class WritableEvent;
+
+enum class ThreadWakeupReason;
 
 /**
  * Interface implemented by HLE Session handlers.
@@ -37,7 +39,8 @@ class WritableEvent;
  */
 class SessionRequestHandler : public std::enable_shared_from_this<SessionRequestHandler> {
 public:
-    virtual ~SessionRequestHandler() = default;
+    SessionRequestHandler();
+    virtual ~SessionRequestHandler();
 
     /**
      * Handles a sync request from the emulated application.

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <array>
 #include <atomic>
 #include <memory>
 #include <mutex>

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -14,7 +14,6 @@
 #include "common/common_types.h"
 #include "core/hle/kernel/handle_table.h"
 #include "core/hle/kernel/process_capability.h"
-#include "core/hle/kernel/thread.h"
 #include "core/hle/kernel/vm_manager.h"
 #include "core/hle/kernel/wait_object.h"
 #include "core/hle/result.h"
@@ -27,6 +26,7 @@ namespace Kernel {
 
 class KernelCore;
 class ResourceLimit;
+class Thread;
 
 struct AddressMapping {
     // Address and size must be page-aligned

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -6,6 +6,7 @@
 #include <utility>
 
 #include "common/assert.h"
+#include "common/common_types.h"
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/hle/ipc_helpers.h"

--- a/src/core/hle/kernel/server_session.h
+++ b/src/core/hle/kernel/server_session.h
@@ -8,7 +8,6 @@
 #include <string>
 #include <vector>
 
-#include "common/common_types.h"
 #include "core/hle/kernel/object.h"
 #include "core/hle/kernel/wait_object.h"
 #include "core/hle/result.h"

--- a/src/core/hle/kernel/wait_object.cpp
+++ b/src/core/hle/kernel/wait_object.cpp
@@ -4,11 +4,11 @@
 
 #include <algorithm>
 #include "common/assert.h"
+#include "common/common_types.h"
 #include "common/logging/log.h"
 #include "core/hle/kernel/object.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/thread.h"
-#include "core/hle/kernel/timer.h"
 
 namespace Kernel {
 

--- a/src/core/hle/kernel/wait_object.h
+++ b/src/core/hle/kernel/wait_object.h
@@ -6,7 +6,6 @@
 
 #include <vector>
 #include <boost/smart_ptr/intrusive_ptr.hpp>
-#include "common/common_types.h"
 #include "core/hle/kernel/object.h"
 
 namespace Kernel {

--- a/src/core/hle/kernel/writable_event.h
+++ b/src/core/hle/kernel/writable_event.h
@@ -4,9 +4,7 @@
 
 #pragma once
 
-#include "common/common_types.h"
 #include "core/hle/kernel/object.h"
-#include "core/hle/kernel/wait_object.h"
 
 namespace Kernel {
 

--- a/src/core/hle/service/am/applets/applets.cpp
+++ b/src/core/hle/service/am/applets/applets.cpp
@@ -6,7 +6,7 @@
 #include "common/assert.h"
 #include "core/core.h"
 #include "core/hle/kernel/readable_event.h"
-#include "core/hle/kernel/server_port.h"
+#include "core/hle/kernel/server_session.h"
 #include "core/hle/kernel/writable_event.h"
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/am/applets/applets.h"

--- a/src/core/hle/service/am/applets/applets.h
+++ b/src/core/hle/service/am/applets/applets.h
@@ -7,7 +7,7 @@
 #include <memory>
 #include <queue>
 #include "common/swap.h"
-#include "core/hle/kernel/kernel.h"
+#include "core/hle/kernel/object.h"
 #include "core/hle/kernel/writable_event.h"
 
 union ResultCode;

--- a/src/core/hle/service/nfp/nfp.cpp
+++ b/src/core/hle/service/nfp/nfp.cpp
@@ -9,9 +9,9 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/readable_event.h"
+#include "core/hle/kernel/thread.h"
 #include "core/hle/kernel/writable_event.h"
 #include "core/hle/lock.h"
-#include "core/hle/service/hid/hid.h"
 #include "core/hle/service/nfp/nfp.h"
 #include "core/hle/service/nfp/nfp_user.h"
 

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -19,6 +19,7 @@
 #include "core/core_timing.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/readable_event.h"
+#include "core/hle/kernel/thread.h"
 #include "core/hle/kernel/writable_event.h"
 #include "core/hle/service/nvdrv/nvdrv.h"
 #include "core/hle/service/nvflinger/buffer_queue.h"


### PR DESCRIPTION
Gets rid of a few unnecessary header dependencies in some source files, which lessens the likelihood of needing to rebuild those translation units if they were otherwise left in. This also uncovered a few places where we were relying on indirect inclusions of headers (which this also amends).