### PR TITLE
gl_rasterizer_cache: Use GL_STREAM_COPY for PBOs

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -452,7 +452,7 @@ static void CopySurface(const Surface& src_surface, const Surface& dst_surface,
     const std::size_t buffer_size = std::max(src_params.size_in_bytes, dst_params.size_in_bytes);
 
     glBindBuffer(GL_PIXEL_PACK_BUFFER, copy_pbo_handle);
-    glBufferData(GL_PIXEL_PACK_BUFFER, buffer_size, nullptr, GL_STREAM_DRAW);
+    glBufferData(GL_PIXEL_PACK_BUFFER, buffer_size, nullptr, GL_STREAM_COPY);
     if (source_format.compressed) {
         glGetCompressedTextureImage(src_surface->Texture().handle, src_attachment,
                                     static_cast<GLsizei>(src_params.size_in_bytes), nullptr);


### PR DESCRIPTION
Since the data is doing the path CPU -> GPU -> GPU, `_COPY` is the most approximate hint. Using `GL_STREAM_DRAW` generated a performance warning on Nvidia's stack. Changing this hint removed the warning.