### PR TITLE
[WIP] Asynchronous GPU command processing

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -93,6 +93,8 @@ add_library(core STATIC
     frontend/framebuffer_layout.cpp
     frontend/framebuffer_layout.h
     frontend/input.h
+    frontend/scope_acquire_window_context.cpp
+    frontend/scope_acquire_window_context.h
     gdbstub/gdbstub.cpp
     gdbstub/gdbstub.h
     hle/ipc.h

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -118,10 +118,12 @@ struct System::Impl {
             return ResultStatus::ErrorVideoCore;
         }
 
+        is_powered_on = true;
+
         gpu_core = std::make_unique<Tegra::GPU>(renderer->Rasterizer());
 
         cpu_core_manager.Initialize(system);
-        is_powered_on = true;
+
         LOG_DEBUG(Core, "Initialized OK");
 
         // Reset counters and set time origin to current frame

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -120,7 +120,7 @@ struct System::Impl {
 
         is_powered_on = true;
 
-        gpu_core = std::make_unique<Tegra::GPU>(renderer->Rasterizer());
+        gpu_core = std::make_unique<Tegra::GPU>(*renderer);
 
         cpu_core_manager.Initialize(system);
 

--- a/src/core/frontend/scope_acquire_window_context.cpp
+++ b/src/core/frontend/scope_acquire_window_context.cpp
@@ -1,0 +1,18 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/frontend/emu_window.h"
+#include "core/frontend/scope_acquire_window_context.h"
+
+namespace Core::Frontend {
+
+ScopeAcquireWindowContext::ScopeAcquireWindowContext(Core::Frontend::EmuWindow& emu_window_)
+    : emu_window{emu_window_} {
+    emu_window.MakeCurrent();
+}
+ScopeAcquireWindowContext::~ScopeAcquireWindowContext() {
+    emu_window.DoneCurrent();
+}
+
+} // namespace Core::Frontend

--- a/src/core/frontend/scope_acquire_window_context.h
+++ b/src/core/frontend/scope_acquire_window_context.h
@@ -1,0 +1,23 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common/common_types.h"
+
+namespace Core::Frontend {
+
+class EmuWindow;
+
+/// Helper class to acquire/release window context within a given scope
+class ScopeAcquireWindowContext : NonCopyable {
+public:
+    explicit ScopeAcquireWindowContext(Core::Frontend::EmuWindow& window);
+    ~ScopeAcquireWindowContext();
+
+private:
+    Core::Frontend::EmuWindow& emu_window;
+};
+
+} // namespace Core::Frontend

--- a/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
@@ -36,7 +36,7 @@ void nvdisp_disp0::flip(u32 buffer_handle, u32 offset, u32 format, u32 width, u3
 
     auto& instance = Core::System::GetInstance();
     instance.GetPerfStats().EndGameFrame();
-    instance.Renderer().SwapBuffers(framebuffer);
+    instance.GPU().SwapBuffers(framebuffer);
 }
 
 } // namespace Service::Nvidia::Devices

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -141,7 +141,7 @@ void NVFlinger::Compose() {
 
             // There was no queued buffer to draw, render previous frame
             system_instance.GetPerfStats().EndGameFrame();
-            system_instance.Renderer().SwapBuffers({});
+            system_instance.GPU().SwapBuffers({});
             continue;
         }
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -166,9 +166,6 @@ T Read(const VAddr vaddr) {
         return value;
     }
 
-    // The memory access might do an MMIO or cached access, so we have to lock the HLE kernel state
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
-
     PageType type = current_page_table->attributes[vaddr >> PAGE_BITS];
     switch (type) {
     case PageType::Unmapped:
@@ -198,9 +195,6 @@ void Write(const VAddr vaddr, const T data) {
         std::memcpy(&page_pointer[vaddr & PAGE_MASK], &data, sizeof(T));
         return;
     }
-
-    // The memory access might do an MMIO or cached access, so we have to lock the HLE kernel state
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
 
     PageType type = current_page_table->attributes[vaddr >> PAGE_BITS];
     switch (type) {

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -386,6 +386,7 @@ struct Values {
     bool use_frame_limit;
     u16 frame_limit;
     bool use_accurate_gpu_emulation;
+    bool use_asynchronous_gpu_emulation;
 
     float bg_red;
     float bg_green;

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -160,6 +160,8 @@ TelemetrySession::TelemetrySession() {
     AddField(Telemetry::FieldType::UserConfig, "Renderer_FrameLimit", Settings::values.frame_limit);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_UseAccurateGpuEmulation",
              Settings::values.use_accurate_gpu_emulation);
+    AddField(Telemetry::FieldType::UserConfig, "Renderer_UseAsynchronousGpuEmulation",
+             Settings::values.use_asynchronous_gpu_emulation);
     AddField(Telemetry::FieldType::UserConfig, "System_UseDockedMode",
              Settings::values.use_docked_mode);
 }

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -17,6 +17,8 @@ add_library(video_core STATIC
     engines/shader_header.h
     gpu.cpp
     gpu.h
+    gpu_thread.cpp
+    gpu_thread.h
     macro_interpreter.cpp
     macro_interpreter.h
     memory_manager.cpp

--- a/src/video_core/dma_pusher.h
+++ b/src/video_core/dma_pusher.h
@@ -61,9 +61,10 @@ public:
     ~DmaPusher();
 
     void Push(CommandList&& entries) {
-        dma_pushbuffer.push(std::move(entries));
+        dma_writebuffer.push_back(std::move(entries));
     }
 
+    void QueuePendingCalls();
     void DispatchCalls();
 
 private:
@@ -75,8 +76,9 @@ private:
 
     GPU& gpu;
 
-    std::queue<CommandList> dma_pushbuffer; ///< Queue of command lists to be processed
-    std::size_t dma_pushbuffer_subindex{};  ///< Index within a command list within the pushbuffer
+    std::vector<CommandList> dma_writebuffer;
+    std::queue<CommandList> dma_readbuffer;
+    std::size_t dma_pushbuffer_subindex{}; ///< Index within a command list within the pushbuffer
 
     struct DmaState {
         u32 method;            ///< Current method

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -61,6 +61,17 @@ const DmaPusher& GPU::DmaPusher() const {
     return *dma_pusher;
 }
 
+void GPU::PushGPUEntries(Tegra::CommandList&& entries) {
+    dma_pusher->Push(std::move(entries));
+    dma_pusher->QueuePendingCalls();
+    dma_pusher->DispatchCalls();
+}
+
+void GPU::SwapBuffers(
+    std::optional<std::reference_wrapper<const Tegra::FramebufferConfig>> framebuffer) {
+    renderer.SwapBuffers(std::move(framebuffer));
+}
+
 u32 RenderTargetBytesPerPixel(RenderTargetFormat format) {
     ASSERT(format != RenderTargetFormat::NONE);
 

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -9,7 +9,7 @@
 #include "video_core/engines/maxwell_compute.h"
 #include "video_core/engines/maxwell_dma.h"
 #include "video_core/gpu.h"
-#include "video_core/rasterizer_interface.h"
+#include "video_core/renderer_base.h"
 
 namespace Tegra {
 
@@ -24,7 +24,8 @@ u32 FramebufferConfig::BytesPerPixel(PixelFormat format) {
     UNREACHABLE();
 }
 
-GPU::GPU(VideoCore::RasterizerInterface& rasterizer) {
+GPU::GPU(VideoCore::RendererBase& renderer) : renderer{renderer} {
+    auto& rasterizer{renderer.Rasterizer()};
     memory_manager = std::make_unique<Tegra::MemoryManager>();
     dma_pusher = std::make_unique<Tegra::DmaPusher>(*this);
     maxwell_3d = std::make_unique<Engines::Maxwell3D>(rasterizer, *memory_manager);

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <functional>
 #include <memory>
 #include <vector>
 #include "common/common_types.h"
@@ -13,6 +14,7 @@
 #include "video_core/memory_manager.h"
 
 namespace VideoCore {
+class GPUThread;
 class RendererBase;
 } // namespace VideoCore
 
@@ -163,9 +165,13 @@ public:
     void SwapBuffers(
         std::optional<std::reference_wrapper<const Tegra::FramebufferConfig>> framebuffer);
 
+    /// Waits the caller until the thread is idle, and then calls the callback
+    void WaitUntilIdle(std::function<void()> callback);
+
 private:
     std::unique_ptr<Tegra::DmaPusher> dma_pusher;
     std::unique_ptr<Tegra::MemoryManager> memory_manager;
+    std::unique_ptr<VideoCore::GPUThread> gpu_thread;
 
     /// Mapping of command subchannels to their bound engine ids.
     std::array<EngineID, 8> bound_engines = {};

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -156,6 +156,13 @@ public:
     /// Returns a const reference to the GPU DMA pusher.
     const Tegra::DmaPusher& DmaPusher() const;
 
+    /// Push GPU command entries to be processed
+    void PushGPUEntries(Tegra::CommandList&& entries);
+
+    /// Swap buffers (render frame)
+    void SwapBuffers(
+        std::optional<std::reference_wrapper<const Tegra::FramebufferConfig>> framebuffer);
+
 private:
     std::unique_ptr<Tegra::DmaPusher> dma_pusher;
     std::unique_ptr<Tegra::MemoryManager> memory_manager;

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -13,8 +13,8 @@
 #include "video_core/memory_manager.h"
 
 namespace VideoCore {
-class RasterizerInterface;
-}
+class RendererBase;
+} // namespace VideoCore
 
 namespace Tegra {
 
@@ -117,7 +117,7 @@ enum class EngineID {
 
 class GPU final {
 public:
-    explicit GPU(VideoCore::RasterizerInterface& rasterizer);
+    explicit GPU(VideoCore::RendererBase& renderer);
     ~GPU();
 
     struct MethodCall {
@@ -173,6 +173,8 @@ private:
     std::unique_ptr<Engines::MaxwellDMA> maxwell_dma;
     /// Inline memory engine
     std::unique_ptr<Engines::KeplerMemory> kepler_memory;
+
+    VideoCore::RendererBase& renderer;
 };
 
 } // namespace Tegra

--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -1,0 +1,115 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/frontend/scope_acquire_window_context.h"
+#include "video_core/gpu.h"
+#include "video_core/gpu_thread.h"
+#include "video_core/renderer_base.h"
+
+namespace {
+static void RunThread(VideoCore::RendererBase& renderer, Tegra::DmaPusher& dma_pusher,
+                      VideoCore::GPUThreadState& state) {
+
+    Core::Frontend::ScopeAcquireWindowContext acquire_context{renderer.GetRenderWindow()};
+
+    while (state.is_running) {
+        bool is_dma_pending{};
+        bool is_swapbuffers_pending{};
+
+        {
+            // Wait for CPU thread to send GPU commands
+            std::unique_lock<std::mutex> lock{state.signal_mutex};
+            state.signal_condition.wait(lock, [&] {
+                return state.is_dma_pending || state.is_swapbuffers_pending || !state.is_running;
+            });
+
+            if (!state.is_running) {
+                return;
+            }
+
+            is_dma_pending = state.is_dma_pending;
+            is_swapbuffers_pending = state.is_swapbuffers_pending;
+
+            if (is_dma_pending) {
+                dma_pusher.QueuePendingCalls();
+                state.is_dma_pending = false;
+            }
+        }
+
+        if (is_dma_pending) {
+            // Process pending DMA pushbuffer commands
+            std::lock_guard<std::recursive_mutex> lock{state.running_mutex};
+            dma_pusher.DispatchCalls();
+        }
+
+        if (is_swapbuffers_pending) {
+            // Process pending SwapBuffers
+            renderer.SwapBuffers(state.pending_swapbuffers_config);
+            state.is_swapbuffers_pending = false;
+            state.signal_condition.notify_one();
+        }
+    }
+}
+} // Anonymous namespace
+
+namespace VideoCore {
+
+GPUThread::GPUThread(RendererBase& renderer, Tegra::DmaPusher& dma_pusher)
+    : dma_pusher{dma_pusher} {
+    thread = std::make_unique<std::thread>(RunThread, std::ref(renderer), std::ref(dma_pusher),
+                                           std::ref(state));
+}
+
+GPUThread::~GPUThread() {
+    {
+        // Notify GPU thread that a shutdown is pending
+        std::lock_guard<std::mutex> lock{state.signal_mutex};
+        state.is_running = false;
+    }
+
+    state.signal_condition.notify_one();
+    thread->join();
+}
+
+void GPUThread::PushGPUEntries(Tegra::CommandList&& entries) {
+    if (entries.empty()) {
+        return;
+    }
+
+    {
+        // Notify GPU thread that data is available
+        std::lock_guard<std::mutex> lock{state.signal_mutex};
+        dma_pusher.Push(std::move(entries));
+        state.is_dma_pending = true;
+    }
+
+    state.signal_condition.notify_one();
+}
+
+void GPUThread::SwapBuffers(
+    std::optional<std::reference_wrapper<const Tegra::FramebufferConfig>> framebuffer) {
+
+    {
+        // Notify GPU thread that we should SwapBuffers
+        std::lock_guard<std::mutex> lock{state.signal_mutex};
+        state.pending_swapbuffers_config = framebuffer;
+        state.is_swapbuffers_pending = true;
+    }
+
+    state.signal_condition.notify_one();
+
+    {
+        // Wait for SwapBuffers
+        std::unique_lock<std::mutex> lock{state.signal_mutex};
+        state.signal_condition.wait(lock, [this] { return !state.is_swapbuffers_pending; });
+    }
+}
+
+void GPUThread::WaitUntilIdle(std::function<void()> callback) {
+    // Needs to be a recursive mutex, as this can be called by the GPU thread
+    std::unique_lock<std::recursive_mutex> lock{state.running_mutex};
+    callback();
+}
+
+} // namespace VideoCore

--- a/src/video_core/gpu_thread.h
+++ b/src/video_core/gpu_thread.h
@@ -1,0 +1,56 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <condition_variable>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <thread>
+
+#include "video_core/dma_pusher.h"
+
+namespace Tegra {
+struct FramebufferConfig;
+}
+
+namespace VideoCore {
+
+class RendererBase;
+
+struct GPUThreadState final {
+    bool is_running{true};
+    bool is_dma_pending{};
+    bool is_swapbuffers_pending{};
+    std::optional<Tegra::FramebufferConfig> pending_swapbuffers_config;
+    std::condition_variable signal_condition;
+    std::condition_variable running_condition;
+    std::mutex signal_mutex;
+    std::recursive_mutex running_mutex;
+};
+
+class GPUThread final {
+public:
+    explicit GPUThread(RendererBase& renderer, Tegra::DmaPusher& dma_pusher);
+    ~GPUThread();
+
+    /// Push GPU command entries to be processed
+    void PushGPUEntries(Tegra::CommandList&& entries);
+
+    /// Swap buffers (render frame)
+    void SwapBuffers(
+        std::optional<std::reference_wrapper<const Tegra::FramebufferConfig>> framebuffer);
+
+    /// Waits the caller until the thread is idle, and then calls the callback
+    void WaitUntilIdle(std::function<void()> callback);
+
+private:
+    GPUThreadState state;
+    std::unique_ptr<std::thread> thread;
+    Tegra::DmaPusher& dma_pusher;
+};
+
+} // namespace VideoCore

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -632,8 +632,6 @@ void RasterizerOpenGL::Clear() {
         return;
     }
 
-    ScopeAcquireGLContext acquire_context{emu_window};
-
     ConfigureFramebuffers(clear_state, use_color, use_depth || use_stencil, false,
                           regs.clear_buffers.RT.Value());
     if (regs.clear_flags.scissor) {
@@ -666,8 +664,6 @@ void RasterizerOpenGL::DrawArrays() {
     MICROPROFILE_SCOPE(OpenGL_Drawing);
     auto& gpu = Core::System::GetInstance().GPU().Maxwell3D();
     const auto& regs = gpu.regs;
-
-    ScopeAcquireGLContext acquire_context{emu_window};
 
     ConfigureFramebuffers(state);
     SyncColorMask();

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -751,16 +751,19 @@ void RasterizerOpenGL::FlushRegion(VAddr addr, u64 size) {
 
     if (Settings::values.use_accurate_gpu_emulation) {
         // Only flush if use_accurate_gpu_emulation is enabled, as it incurs a performance hit
-        res_cache.FlushRegion(addr, size);
+        Core::System::GetInstance().GPU().WaitUntilIdle(
+            [this, addr, size]() { res_cache.FlushRegion(addr, size); });
     }
 }
 
 void RasterizerOpenGL::InvalidateRegion(VAddr addr, u64 size) {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
-    res_cache.InvalidateRegion(addr, size);
-    shader_cache.InvalidateRegion(addr, size);
-    global_cache.InvalidateRegion(addr, size);
-    buffer_cache.InvalidateRegion(addr, size);
+    Core::System::GetInstance().GPU().WaitUntilIdle([this, addr, size]() {
+        res_cache.InvalidateRegion(addr, size);
+        shader_cache.InvalidateRegion(addr, size);
+        global_cache.InvalidateRegion(addr, size);
+        buffer_cache.InvalidateRegion(addr, size);
+    });
 }
 
 void RasterizerOpenGL::FlushAndInvalidateRegion(VAddr addr, u64 size) {

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -14,6 +14,7 @@
 #include "core/core.h"
 #include "core/core_timing.h"
 #include "core/frontend/emu_window.h"
+#include "core/frontend/scope_acquire_window_context.h"
 #include "core/memory.h"
 #include "core/perf_stats.h"
 #include "core/settings.h"
@@ -97,18 +98,6 @@ static std::array<GLfloat, 3 * 2> MakeOrthographicMatrix(const float width, cons
     return matrix;
 }
 
-ScopeAcquireGLContext::ScopeAcquireGLContext(Core::Frontend::EmuWindow& emu_window_)
-    : emu_window{emu_window_} {
-    if (Settings::values.use_multi_core) {
-        emu_window.MakeCurrent();
-    }
-}
-ScopeAcquireGLContext::~ScopeAcquireGLContext() {
-    if (Settings::values.use_multi_core) {
-        emu_window.DoneCurrent();
-    }
-}
-
 RendererOpenGL::RendererOpenGL(Core::Frontend::EmuWindow& window)
     : VideoCore::RendererBase{window} {}
 
@@ -117,7 +106,6 @@ RendererOpenGL::~RendererOpenGL() = default;
 /// Swap buffers (render frame)
 void RendererOpenGL::SwapBuffers(
     std::optional<std::reference_wrapper<const Tegra::FramebufferConfig>> framebuffer) {
-    ScopeAcquireGLContext acquire_context{render_window};
 
     Core::System::GetInstance().GetPerfStats().EndSystemFrame();
 
@@ -508,7 +496,7 @@ static void APIENTRY DebugHandler(GLenum source, GLenum type, GLuint id, GLenum 
 
 /// Initialize the renderer
 bool RendererOpenGL::Init() {
-    ScopeAcquireGLContext acquire_context{render_window};
+    Core::Frontend::ScopeAcquireWindowContext acquire_context{render_window};
 
     if (GLAD_GL_KHR_debug) {
         glEnable(GL_DEBUG_OUTPUT);

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -39,16 +39,6 @@ struct ScreenInfo {
     TextureInfo texture;
 };
 
-/// Helper class to acquire/release OpenGL context within a given scope
-class ScopeAcquireGLContext : NonCopyable {
-public:
-    explicit ScopeAcquireGLContext(Core::Frontend::EmuWindow& window);
-    ~ScopeAcquireGLContext();
-
-private:
-    Core::Frontend::EmuWindow& emu_window;
-};
-
 class RendererOpenGL : public VideoCore::RendererBase {
 public:
     explicit RendererOpenGL(Core::Frontend::EmuWindow& window);

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -21,7 +21,7 @@
 EmuThread::EmuThread(GRenderWindow* render_window) : render_window(render_window) {}
 
 void EmuThread::run() {
-    if (!Settings::values.use_multi_core) {
+    if (!Settings::values.use_asynchronous_gpu_emulation) {
         // Single core mode must acquire OpenGL context for entire emulation session
         render_window->MakeCurrent();
     }

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -372,6 +372,8 @@ void Config::ReadValues() {
     Settings::values.frame_limit = qt_config->value("frame_limit", 100).toInt();
     Settings::values.use_accurate_gpu_emulation =
         qt_config->value("use_accurate_gpu_emulation", false).toBool();
+    Settings::values.use_asynchronous_gpu_emulation =
+        qt_config->value("use_asynchronous_gpu_emulation", true).toBool();
 
     Settings::values.bg_red = qt_config->value("bg_red", 0.0).toFloat();
     Settings::values.bg_green = qt_config->value("bg_green", 0.0).toFloat();
@@ -622,6 +624,8 @@ void Config::SaveValues() {
     qt_config->setValue("use_frame_limit", Settings::values.use_frame_limit);
     qt_config->setValue("frame_limit", Settings::values.frame_limit);
     qt_config->setValue("use_accurate_gpu_emulation", Settings::values.use_accurate_gpu_emulation);
+    qt_config->setValue("use_asynchronous_gpu_emulation",
+                        Settings::values.use_asynchronous_gpu_emulation);
 
     // Cast to double because Qt's written float values are not human-readable
     qt_config->setValue("bg_red", (double)Settings::values.bg_red);

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -76,6 +76,7 @@ void ConfigureGraphics::setConfiguration() {
     ui->toggle_frame_limit->setChecked(Settings::values.use_frame_limit);
     ui->frame_limit->setValue(Settings::values.frame_limit);
     ui->use_accurate_gpu_emulation->setChecked(Settings::values.use_accurate_gpu_emulation);
+    ui->use_asynchronous_gpu_emulation->setChecked(Settings::values.use_asynchronous_gpu_emulation);
     bg_color = QColor::fromRgbF(Settings::values.bg_red, Settings::values.bg_green,
                                 Settings::values.bg_blue);
     ui->bg_button->setStyleSheet(
@@ -88,6 +89,8 @@ void ConfigureGraphics::applyConfiguration() {
     Settings::values.use_frame_limit = ui->toggle_frame_limit->isChecked();
     Settings::values.frame_limit = ui->frame_limit->value();
     Settings::values.use_accurate_gpu_emulation = ui->use_accurate_gpu_emulation->isChecked();
+    Settings::values.use_asynchronous_gpu_emulation =
+        ui->use_asynchronous_gpu_emulation->isChecked();
     Settings::values.bg_red = static_cast<float>(bg_color.redF());
     Settings::values.bg_green = static_cast<float>(bg_color.greenF());
     Settings::values.bg_blue = static_cast<float>(bg_color.blueF());

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -56,6 +56,13 @@
           </property>
          </widget>
         </item>
+         <item>
+         <widget class="QCheckBox" name="use_asynchronous_gpu_emulation">
+          <property name="text">
+           <string>Use asynchronous GPU emulation</string>
+          </property>
+         </widget>
+        </item>
         <item>
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -344,6 +344,8 @@ void Config::ReadValues() {
         static_cast<u16>(sdl2_config->GetInteger("Renderer", "frame_limit", 100));
     Settings::values.use_accurate_gpu_emulation =
         sdl2_config->GetBoolean("Renderer", "use_accurate_gpu_emulation", false);
+    Settings::values.use_asynchronous_gpu_emulation =
+        sdl2_config->GetBoolean("Renderer", "use_asynchronous_gpu_emulation", true);
 
     Settings::values.bg_red = (float)sdl2_config->GetReal("Renderer", "bg_red", 0.0);
     Settings::values.bg_green = (float)sdl2_config->GetReal("Renderer", "bg_green", 0.0);

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -114,6 +114,10 @@ frame_limit =
 # 0 (default): Off (fast), 1 : On (slow)
 use_accurate_gpu_emulation =
 
+# Whether to use asynchronous GPU emulation
+# 0 : Off (slow), 1 (default): On (fast)
+use_asynchronous_gpu_emulation =
+
 # The clear color for the renderer. What shows up on the sides of the bottom screen.
 # Must be in range of 0.0-1.0. Defaults to 1.0 for all.
 bg_red =


### PR DESCRIPTION
This moves GPU command processing to another thread. This works by letting the CPU core (main) thread push GPU commands via the `DmaPusher::Push` interface, while the GPU thread waits for commands to be available. After a push, the main thread signals that commands are available, and the GPU thread wakes up and continues to process these until the command queue is empty.

There are no "emulated" CPU <-> GPU synchronization mechanisms here, so it's possible that this might cause issues. As such, it's behind a user setting. That being said, it seems quite stable, and I do not notice any bugs/regressions with the games that I have.

We do need some synchronization for things to work, of course. Currently, this implementation:
* Waits for all previously queued GPU commands to be processed before calling SwapBuffers
* Waits for all previously queued GPU commands to be processed before letting the main thread invalidate or flush GPU data
* Uses SwapBuffers as a barrier - e.g., wait until SwapBuffers (end of frame) has been handled by the GPU before allowing the main thread to continue to the next frame

Recommend reviewing commit-by-commit.

This is WIP because it needs lots of testing still. There are probably improvements we can also make to make this a little more parallel - the current synchronization is just my first attempt.