### PR TITLE
Frontend: Migrate to QOpenGLWindow and support shared contexts

### DIFF
--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -13,6 +13,23 @@
 namespace Core::Frontend {
 
 /**
+ * Represents a graphics context that can be used for background computation or drawing. If the
+ * graphics backend doesn't require the context, then the implementation of these methods can be
+ * stubs
+ */
+class GraphicsContext {
+public:
+    /// Makes the graphics context current for the caller thread
+    virtual void MakeCurrent() = 0;
+
+    /// Releases (dunno if this is the "right" word) the context from the caller thread
+    virtual void DoneCurrent() = 0;
+
+    /// Swap buffers to display the next frame
+    virtual void SwapBuffers() = 0;
+};
+
+/**
  * Abstraction class used to provide an interface between emulation code and the frontend
  * (e.g. SDL, QGLWidget, GLFW, etc...).
  *
@@ -30,7 +47,7 @@ namespace Core::Frontend {
  * - DO NOT TREAT THIS CLASS AS A GUI TOOLKIT ABSTRACTION LAYER. That's not what it is. Please
  *   re-read the upper points again and think about it if you don't see this.
  */
-class EmuWindow {
+class EmuWindow : public GraphicsContext {
 public:
     /// Data structure to store emuwindow configuration
     struct WindowConfig {
@@ -40,17 +57,21 @@ public:
         std::pair<unsigned, unsigned> min_client_area_size;
     };
 
-    /// Swap buffers to display the next frame
-    virtual void SwapBuffers() = 0;
-
     /// Polls window events
     virtual void PollEvents() = 0;
 
-    /// Makes the graphics context current for the caller thread
-    virtual void MakeCurrent() = 0;
-
-    /// Releases (dunno if this is the "right" word) the GLFW context from the caller thread
-    virtual void DoneCurrent() = 0;
+    /**
+     * Returns a GraphicsContext that the frontend provides that is shared with the emu window. This
+     * context can be used from other threads for background graphics computation. If the frontend
+     * is using a graphics backend that doesn't need anything specific to run on a different thread,
+     * then it can use a stubbed implemenation for GraphicsContext.
+     *
+     * If the return value is null, then the core should assume that the frontend cannot provide a
+     * Shared Context
+     */
+    virtual std::unique_ptr<GraphicsContext> CreateSharedContext() const {
+        return nullptr;
+    }
 
     /**
      * Signal that a touch pressed event has occurred (e.g. mouse click pressed)

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -371,14 +371,23 @@ void GRenderWindow::InitRenderTarget() {
 
     child = new GGLWidgetInternal(this, shared_context.get());
     container = QWidget::createWindowContainer(child, this);
+
     QBoxLayout* layout = new QHBoxLayout(this);
+    layout->addWidget(container);
+    layout->setMargin(0);
+    setLayout(layout);
+
+    // Reset minimum size to avoid unwanted resizes when this function is called for a second time.
+    setMinimumSize(1, 1);
+
+    // Show causes the window to actually be created and the OpenGL context as well, but we don't
+    // want the widget to be shown yet, so immediately hide it.
+    show();
+    hide();
 
     resize(Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height);
     child->resize(Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height);
     container->resize(Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height);
-    layout->addWidget(container);
-    layout->setMargin(0);
-    setLayout(layout);
 
     OnMinimalClientAreaChangeRequest(GetActiveConfig().min_client_area_size);
 
@@ -386,10 +395,6 @@ void GRenderWindow::InitRenderTarget() {
     NotifyClientAreaSizeChanged(std::pair<unsigned, unsigned>(child->width(), child->height()));
 
     BackupGeometry();
-    // show causes the window to actually be created and the gl context as well
-    show();
-    // but we don't want the widget to be shown yet, so immediately hide it
-    hide();
 }
 
 void GRenderWindow::CaptureScreenshot(u16 res_scale, const QString& screenshot_path) {

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -393,6 +393,8 @@ void GRenderWindow::InitRenderTarget() {
     BackupGeometry();
     // show causes the window to actually be created and the gl context as well
     show();
+    // but we don't want the widget to be shown yet, so immediately hide it
+    hide();
 }
 
 void GRenderWindow::CaptureScreenshot(u16 res_scale, const QString& screenshot_path) {

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -340,21 +340,16 @@ std::unique_ptr<Core::Frontend::GraphicsContext> GRenderWindow::CreateSharedCont
 }
 
 void GRenderWindow::InitRenderTarget() {
-    if (shared_context) {
-        shared_context.reset();
-    }
+    shared_context.reset();
+    context.reset();
 
-    if (context) {
-        context.reset();
-    }
+    delete child;
+    child = nullptr;
 
-    if (child) {
-        delete child;
-    }
+    delete container;
+    container = nullptr;
 
-    if (layout()) {
-        delete layout();
-    }
+    delete layout();
 
     first_frame = false;
 
@@ -375,7 +370,7 @@ void GRenderWindow::InitRenderTarget() {
     fmt.setSwapInterval(false);
 
     child = new GGLWidgetInternal(this, shared_context.get());
-    QWidget* container = QWidget::createWindowContainer(child, this);
+    container = QWidget::createWindowContainer(child, this);
     QBoxLayout* layout = new QHBoxLayout(this);
 
     resize(Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height);

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -119,24 +119,19 @@ public:
     void PollEvents() override;
     std::unique_ptr<Core::Frontend::GraphicsContext> CreateSharedContext() const override;
 
+    void ForwardKeyPressEvent(QKeyEvent* event);
+    void ForwardKeyReleaseEvent(QKeyEvent* event);
+
     void BackupGeometry();
     void RestoreGeometry();
     void restoreGeometry(const QByteArray& geometry); // overridden
     QByteArray saveGeometry();                        // overridden
 
-    qreal windowPixelRatio() const;
+    qreal GetWindowPixelRatio() const;
+    std::pair<unsigned, unsigned> ScaleTouch(const QPointF pos) const;
 
     void closeEvent(QCloseEvent* event) override;
-
-    void keyPressEvent(QKeyEvent* event) override;
-    void keyReleaseEvent(QKeyEvent* event) override;
-
-    void mousePressEvent(QMouseEvent* event) override;
-    void mouseMoveEvent(QMouseEvent* event) override;
-    void mouseReleaseEvent(QMouseEvent* event) override;
-
     bool event(QEvent* event) override;
-
     void focusOutEvent(QFocusEvent* event) override;
 
     void OnClientAreaResized(unsigned width, unsigned height);
@@ -158,7 +153,6 @@ signals:
     void FirstFrameDisplayed();
 
 private:
-    std::pair<unsigned, unsigned> ScaleTouch(const QPointF pos) const;
     void TouchBeginEvent(const QTouchEvent* event);
     void TouchUpdateEvent(const QTouchEvent* event);
     void TouchEndEvent();

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -7,9 +7,9 @@
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
-#include <QGLWidget>
 #include <QImage>
 #include <QThread>
+#include <QWidget>
 #include "common/thread.h"
 #include "core/core.h"
 #include "core/frontend/emu_window.h"
@@ -21,6 +21,8 @@ class QTouchEvent;
 class GGLWidgetInternal;
 class GMainWindow;
 class GRenderWindow;
+class QSurface;
+class QOpenGLContext;
 
 class EmuThread : public QThread {
     Q_OBJECT
@@ -115,6 +117,7 @@ public:
     void MakeCurrent() override;
     void DoneCurrent() override;
     void PollEvents() override;
+    std::unique_ptr<Core::Frontend::GraphicsContext> CreateSharedContext() const override;
 
     void BackupGeometry();
     void RestoreGeometry();
@@ -168,6 +171,11 @@ private:
     QByteArray geometry;
 
     EmuThread* emu_thread;
+    // Context that backs the GGLWidgetInternal (and will be used by core to render)
+    std::unique_ptr<QOpenGLContext> context;
+    // Context that will be shared between all newly created contexts. This should never be made
+    // current
+    std::unique_ptr<QOpenGLContext> shared_context;
 
     /// Temporary storage of the screenshot taken
     QImage screenshot_image;

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -166,7 +166,8 @@ private:
     void OnMinimalClientAreaChangeRequest(
         const std::pair<unsigned, unsigned>& minimal_size) override;
 
-    GGLWidgetInternal* child;
+    QWidget* container = nullptr;
+    GGLWidgetInternal* child = nullptr;
 
     QByteArray geometry;
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2032,7 +2032,8 @@ int main(int argc, char* argv[]) {
     QCoreApplication::setOrganizationName("yuzu team");
     QCoreApplication::setApplicationName("yuzu");
 
-    QApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);
+    // Enables the core to make the qt created contexts current on std::threads
+    QCoreApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);
     QApplication app(argc, argv);
 
     // Qt changes the locale and causes issues in float conversion using std::to_string() when

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1965,6 +1965,18 @@ void GMainWindow::dragMoveEvent(QDragMoveEvent* event) {
     event->acceptProposedAction();
 }
 
+void GMainWindow::keyPressEvent(QKeyEvent* event) {
+    if (render_window) {
+        render_window->ForwardKeyPressEvent(event);
+    }
+}
+
+void GMainWindow::keyReleaseEvent(QKeyEvent* event) {
+    if (render_window) {
+        render_window->ForwardKeyReleaseEvent(event);
+    }
+}
+
 bool GMainWindow::ConfirmChangeGame() {
     if (emu_thread == nullptr)
         return true;

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -251,4 +251,8 @@ protected:
     void dropEvent(QDropEvent* event) override;
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dragMoveEvent(QDragMoveEvent* event) override;
+
+    // Overrides used to forward signals to the render window when the focus moves out.
+    void keyPressEvent(QKeyEvent* event) override;
+    void keyReleaseEvent(QKeyEvent* event) override;
 };

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.h
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.h
@@ -27,6 +27,8 @@ public:
     /// Releases the GL context from the caller thread
     void DoneCurrent() override;
 
+    std::unique_ptr<Core::Frontend::GraphicsContext> CreateSharedContext() const override;
+
     /// Whether the window is still open, and a close request hasn't yet been sent
     bool IsOpen() const;
 


### PR DESCRIPTION
Since QT5, QGLWidget has been deprecated and superseded with QOpenGLWidget and other classes. I replace usages of QGLWidget with the comparable QOpenGLWindow, which gives us the bonus ability to easily create shared contexts.

To support shared contexts, frontends can now implement the GraphicsContext class and the core can attempt to get a shared context from the frontend by calling GetSharedContext. If the rendering backend doesn't need shared contexts, then it just doesn't request a shared context from the frontend. If the backend does request a shared context, it should be ready to handle the case where the frontend returns nullptr (ie: because its not supported on this platform or frontend)

In this PR, I added shared context support to the QT and SDL frontends, but I haven't had a chance to extensively test shared contexts yet. We've had several suggested features that could benefit from shared context support, so I wanted to put it out there that the code is ready, but I also understand if others think we should wait until we have code that actually uses shared contexts.

Looking for feedback about the changes I made to EmuWindow to add a new function to get a shared context. I couldn't think of a better way to enable the video core to get a shared context where needed while still letting the frontend actually create that context.