### PR TITLE
yuzu/web_browser: Minor cleanup

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -443,27 +443,31 @@ std::shared_ptr<FileSys::VfsFilesystem> System::GetFilesystem() const {
     return impl->virtual_filesystem;
 }
 
-void System::SetProfileSelector(std::unique_ptr<Core::Frontend::ProfileSelectApplet> applet) {
+void System::SetProfileSelector(std::unique_ptr<Frontend::ProfileSelectApplet> applet) {
     impl->profile_selector = std::move(applet);
 }
 
-const Core::Frontend::ProfileSelectApplet& System::GetProfileSelector() const {
+const Frontend::ProfileSelectApplet& System::GetProfileSelector() const {
     return *impl->profile_selector;
 }
 
-void System::SetSoftwareKeyboard(std::unique_ptr<Core::Frontend::SoftwareKeyboardApplet> applet) {
+void System::SetSoftwareKeyboard(std::unique_ptr<Frontend::SoftwareKeyboardApplet> applet) {
     impl->software_keyboard = std::move(applet);
 }
 
-const Core::Frontend::SoftwareKeyboardApplet& System::GetSoftwareKeyboard() const {
+const Frontend::SoftwareKeyboardApplet& System::GetSoftwareKeyboard() const {
     return *impl->software_keyboard;
 }
 
-void System::SetWebBrowser(std::unique_ptr<Core::Frontend::WebBrowserApplet> applet) {
+void System::SetWebBrowser(std::unique_ptr<Frontend::WebBrowserApplet> applet) {
     impl->web_browser = std::move(applet);
 }
 
-const Core::Frontend::WebBrowserApplet& System::GetWebBrowser() const {
+Frontend::WebBrowserApplet& System::GetWebBrowser() {
+    return *impl->web_browser;
+}
+
+const Frontend::WebBrowserApplet& System::GetWebBrowser() const {
     return *impl->web_browser;
 }
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -243,17 +243,18 @@ public:
 
     std::shared_ptr<FileSys::VfsFilesystem> GetFilesystem() const;
 
-    void SetProfileSelector(std::unique_ptr<Core::Frontend::ProfileSelectApplet> applet);
+    void SetProfileSelector(std::unique_ptr<Frontend::ProfileSelectApplet> applet);
 
-    const Core::Frontend::ProfileSelectApplet& GetProfileSelector() const;
+    const Frontend::ProfileSelectApplet& GetProfileSelector() const;
 
-    void SetSoftwareKeyboard(std::unique_ptr<Core::Frontend::SoftwareKeyboardApplet> applet);
+    void SetSoftwareKeyboard(std::unique_ptr<Frontend::SoftwareKeyboardApplet> applet);
 
-    const Core::Frontend::SoftwareKeyboardApplet& GetSoftwareKeyboard() const;
+    const Frontend::SoftwareKeyboardApplet& GetSoftwareKeyboard() const;
 
-    void SetWebBrowser(std::unique_ptr<Core::Frontend::WebBrowserApplet> applet);
+    void SetWebBrowser(std::unique_ptr<Frontend::WebBrowserApplet> applet);
 
-    const Core::Frontend::WebBrowserApplet& GetWebBrowser() const;
+    Frontend::WebBrowserApplet& GetWebBrowser();
+    const Frontend::WebBrowserApplet& GetWebBrowser() const;
 
 private:
     System();

--- a/src/core/frontend/applets/web_browser.cpp
+++ b/src/core/frontend/applets/web_browser.cpp
@@ -13,7 +13,7 @@ DefaultWebBrowserApplet::~DefaultWebBrowserApplet() = default;
 
 void DefaultWebBrowserApplet::OpenPage(std::string_view filename,
                                        std::function<void()> unpack_romfs_callback,
-                                       std::function<void()> finished_callback) const {
+                                       std::function<void()> finished_callback) {
     LOG_INFO(Service_AM,
              "(STUBBED) called - No suitable web browser implementation found to open website page "
              "at '{}'!",

--- a/src/core/frontend/applets/web_browser.h
+++ b/src/core/frontend/applets/web_browser.h
@@ -14,7 +14,7 @@ public:
     virtual ~WebBrowserApplet();
 
     virtual void OpenPage(std::string_view url, std::function<void()> unpack_romfs_callback,
-                          std::function<void()> finished_callback) const = 0;
+                          std::function<void()> finished_callback) = 0;
 };
 
 class DefaultWebBrowserApplet final : public WebBrowserApplet {
@@ -22,7 +22,7 @@ public:
     ~DefaultWebBrowserApplet() override;
 
     void OpenPage(std::string_view url, std::function<void()> unpack_romfs_callback,
-                  std::function<void()> finished_callback) const override;
+                  std::function<void()> finished_callback) override;
 };
 
 } // namespace Core::Frontend

--- a/src/core/hle/service/am/applets/web_browser.cpp
+++ b/src/core/hle/service/am/applets/web_browser.cpp
@@ -146,7 +146,7 @@ void WebBrowser::Execute() {
         return;
     }
 
-    const auto& frontend{Core::System::GetInstance().GetWebBrowser()};
+    auto& frontend{Core::System::GetInstance().GetWebBrowser()};
 
     frontend.OpenPage(filename, [this] { UnpackRomFS(); }, [this] { Finalize(); });
 }

--- a/src/core/hle/service/am/applets/web_browser.cpp
+++ b/src/core/hle/service/am/applets/web_browser.cpp
@@ -2,9 +2,16 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <array>
+#include <cstring>
+#include <vector>
+
+#include "common/assert.h"
+#include "common/common_funcs.h"
 #include "common/common_paths.h"
+#include "common/file_util.h"
 #include "common/hex_util.h"
-#include "common/logging/backend.h"
+#include "common/logging/log.h"
 #include "common/string_util.h"
 #include "core/core.h"
 #include "core/file_sys/content_archive.h"
@@ -12,7 +19,6 @@
 #include "core/file_sys/nca_metadata.h"
 #include "core/file_sys/registered_cache.h"
 #include "core/file_sys/romfs.h"
-#include "core/file_sys/romfs_factory.h"
 #include "core/file_sys/vfs_types.h"
 #include "core/frontend/applets/web_browser.h"
 #include "core/hle/kernel/process.h"

--- a/src/yuzu/applets/web_browser.cpp
+++ b/src/yuzu/applets/web_browser.cpp
@@ -87,8 +87,8 @@ QtWebBrowser::~QtWebBrowser() = default;
 
 void QtWebBrowser::OpenPage(std::string_view url, std::function<void()> unpack_romfs_callback,
                             std::function<void()> finished_callback) const {
-    this->unpack_romfs_callback = unpack_romfs_callback;
-    this->finished_callback = finished_callback;
+    this->unpack_romfs_callback = std::move(unpack_romfs_callback);
+    this->finished_callback = std::move(finished_callback);
 
     const auto index = url.find('?');
     if (index == std::string::npos) {

--- a/src/yuzu/applets/web_browser.cpp
+++ b/src/yuzu/applets/web_browser.cpp
@@ -86,7 +86,7 @@ QtWebBrowser::QtWebBrowser(GMainWindow& main_window) {
 QtWebBrowser::~QtWebBrowser() = default;
 
 void QtWebBrowser::OpenPage(std::string_view url, std::function<void()> unpack_romfs_callback,
-                            std::function<void()> finished_callback) const {
+                            std::function<void()> finished_callback) {
     this->unpack_romfs_callback = std::move(unpack_romfs_callback);
     this->finished_callback = std::move(finished_callback);
 

--- a/src/yuzu/applets/web_browser.h
+++ b/src/yuzu/applets/web_browser.h
@@ -38,7 +38,7 @@ public:
     ~QtWebBrowser() override;
 
     void OpenPage(std::string_view url, std::function<void()> unpack_romfs_callback,
-                  std::function<void()> finished_callback) const override;
+                  std::function<void()> finished_callback) override;
 
 signals:
     void MainWindowOpenPage(std::string_view filename, std::string_view additional_args) const;
@@ -47,6 +47,6 @@ private:
     void MainWindowUnpackRomFS();
     void MainWindowFinishedBrowsing();
 
-    mutable std::function<void()> unpack_romfs_callback;
-    mutable std::function<void()> finished_callback;
+    std::function<void()> unpack_romfs_callback;
+    std::function<void()> finished_callback;
 };

--- a/src/yuzu/applets/web_browser.h
+++ b/src/yuzu/applets/web_browser.h
@@ -43,11 +43,10 @@ public:
 signals:
     void MainWindowOpenPage(std::string_view filename, std::string_view additional_args) const;
 
-public slots:
+private:
     void MainWindowUnpackRomFS();
     void MainWindowFinishedBrowsing();
 
-private:
     mutable std::function<void()> unpack_romfs_callback;
     mutable std::function<void()> finished_callback;
 };


### PR DESCRIPTION
Just does a little cleanup for small details that be done slightly better.

- `std::move`s callbacks where necessary,
- Makes functions private where applicable
- Gets rid of the need to use mutable specifiers for implementations of the web browser applet.
- Adds missing includes