### PR TITLE
yuzu/configuration/configure_web: Amend verification string

### DIFF
--- a/src/yuzu/configuration/configure_web.cpp
+++ b/src/yuzu/configuration/configure_web.cpp
@@ -89,7 +89,7 @@ void ConfigureWeb::OnLoginChanged() {
 
 void ConfigureWeb::VerifyLogin() {
     ui->button_verify_login->setDisabled(true);
-    ui->button_verify_login->setText(tr("Verifying"));
+    ui->button_verify_login->setText(tr("Verifying..."));
     verify_watcher.setFuture(
         QtConcurrent::run([this, username = ui->edit_username->text().toStdString(),
                            token = ui->edit_token->text().toStdString()]() {

--- a/src/yuzu/configuration/configure_web.cpp
+++ b/src/yuzu/configuration/configure_web.cpp
@@ -90,11 +90,10 @@ void ConfigureWeb::OnLoginChanged() {
 void ConfigureWeb::VerifyLogin() {
     ui->button_verify_login->setDisabled(true);
     ui->button_verify_login->setText(tr("Verifying..."));
-    verify_watcher.setFuture(
-        QtConcurrent::run([this, username = ui->edit_username->text().toStdString(),
-                           token = ui->edit_token->text().toStdString()]() {
-            return Core::VerifyLogin(username, token);
-        }));
+    verify_watcher.setFuture(QtConcurrent::run([username = ui->edit_username->text().toStdString(),
+                                                token = ui->edit_token->text().toStdString()] {
+        return Core::VerifyLogin(username, token);
+    }));
 }
 
 void ConfigureWeb::OnLoginVerified() {


### PR DESCRIPTION
It's general practice to use an ellipsis to indicate an ongoing action within a UI. While we're at it, this also removes an unused lambda capture in the same function.