### PR TITLE
yuzu/configuration: Remove unnecessary inclusions where applicable

### DIFF
--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -7,7 +7,6 @@
 #include "common/file_util.h"
 #include "common/logging/backend.h"
 #include "common/logging/filter.h"
-#include "common/logging/log.h"
 #include "core/core.h"
 #include "core/settings.h"
 #include "ui_configure_debug.h"

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <QColorDialog>
 #include <QGridLayout>
+#include <QKeyEvent>
 #include <QMenu>
 #include <QMessageBox>
 #include <QTimer>

--- a/src/yuzu/configuration/configure_input_player.h
+++ b/src/yuzu/configuration/configure_input_player.h
@@ -11,16 +11,20 @@
 #include <string>
 
 #include <QDialog>
-#include <QKeyEvent>
 
 #include "common/param_package.h"
 #include "core/settings.h"
-#include "input_common/main.h"
 #include "ui_configure_input.h"
 
+class QKeyEvent;
 class QPushButton;
 class QString;
 class QTimer;
+
+namespace InputCommon::Polling {
+class DevicePoller;
+enum class DeviceType;
+} // namespace InputCommon::Polling
 
 namespace Ui {
 class ConfigureInputPlayer;

--- a/src/yuzu/configuration/configure_per_general.cpp
+++ b/src/yuzu/configuration/configure_per_general.cpp
@@ -8,7 +8,6 @@
 
 #include <QHeaderView>
 #include <QMenu>
-#include <QMessageBox>
 #include <QStandardItemModel>
 #include <QString>
 #include <QTimer>

--- a/src/yuzu/configuration/configure_per_general.h
+++ b/src/yuzu/configuration/configure_per_general.h
@@ -7,16 +7,16 @@
 #include <memory>
 #include <vector>
 
-#include <QKeyEvent>
+#include <QDialog>
 #include <QList>
-#include <QWidget>
 
 #include "core/file_sys/vfs_types.h"
 
-class QTreeView;
 class QGraphicsScene;
 class QStandardItem;
 class QStandardItemModel;
+class QTreeView;
+class QVBoxLayout;
 
 namespace Ui {
 class ConfigurePerGameGeneral;

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -2,23 +2,19 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <algorithm>
+#include <array>
+#include <chrono>
+#include <optional>
+
 #include <QFileDialog>
 #include <QGraphicsItem>
-#include <QGraphicsScene>
-#include <QHeaderView>
 #include <QMessageBox>
-#include <QStandardItemModel>
-#include <QTreeView>
-#include <QVBoxLayout>
 #include "common/assert.h"
 #include "common/file_util.h"
-#include "common/string_util.h"
 #include "core/core.h"
 #include "core/settings.h"
 #include "ui_configure_system.h"
 #include "yuzu/configuration/configure_system.h"
-#include "yuzu/util/limitable_input_dialog.h"
 
 namespace {
 constexpr std::array<int, 12> days_in_month = {{

--- a/src/yuzu/configuration/configure_touchscreen_advanced.h
+++ b/src/yuzu/configuration/configure_touchscreen_advanced.h
@@ -6,8 +6,6 @@
 
 #include <memory>
 #include <QDialog>
-#include <QWidget>
-#include "yuzu/configuration/config.h"
 
 namespace Ui {
 class ConfigureTouchscreenAdvanced;


### PR DESCRIPTION
Removes a bit of unnecessary headers and gets rid of some direct dependencies on other headers. Reduces the amount of rebuilding necessary if certain headers change in the future.