### PR TITLE
file_sys/directory: Remove unused DirectoryBackend class

### DIFF
--- a/src/core/file_sys/directory.h
+++ b/src/core/file_sys/directory.h
@@ -39,27 +39,4 @@ static_assert(sizeof(Entry) == 0x310, "Directory Entry struct isn't exactly 0x31
 static_assert(offsetof(Entry, type) == 0x304, "Wrong offset for type in Entry.");
 static_assert(offsetof(Entry, file_size) == 0x308, "Wrong offset for file_size in Entry.");
 
-class DirectoryBackend : NonCopyable {
-public:
-    DirectoryBackend() {}
-    virtual ~DirectoryBackend() {}
-
-    /**
-     * List files contained in the directory
-     * @param count Number of entries to return at once in entries
-     * @param entries Buffer to read data into
-     * @return Number of entries listed
-     */
-    virtual u64 Read(const u64 count, Entry* entries) = 0;
-
-    /// Returns the number of entries still left to read.
-    virtual u64 GetEntryCount() const = 0;
-
-    /**
-     * Close the directory
-     * @return true if the directory closed correctly
-     */
-    virtual bool Close() const = 0;
-};
-
 } // namespace FileSys


### PR DESCRIPTION
This isn't used at all, so we can just get rid of it.