### PR TITLE
Loading progress bar upgrades

### DIFF
--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -4,12 +4,21 @@
 
 #pragma once
 
+#include <functional>
 #include "common/common_types.h"
 #include "video_core/engines/fermi_2d.h"
 #include "video_core/gpu.h"
 #include "video_core/memory_manager.h"
 
 namespace VideoCore {
+
+enum class LoadCallbackStage {
+    Prepare,
+    Raw,
+    Binary,
+    Complete,
+};
+using DiskResourceLoadCallback = std::function<void(LoadCallbackStage, std::size_t, std::size_t)>;
 
 class RasterizerInterface {
 public:

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -14,8 +14,8 @@ namespace VideoCore {
 
 enum class LoadCallbackStage {
     Prepare,
-    Raw,
-    Binary,
+    Decompile,
+    Build,
     Complete,
 };
 using DiskResourceLoadCallback = std::function<void(LoadCallbackStage, std::size_t, std::size_t)>;

--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -28,6 +28,43 @@
 #include <QMovie>
 #endif
 
+constexpr const char* PROGRESSBAR_STYLE_PREPARE = R"(
+QProgressBar {}
+QProgressBar::chunk {})";
+
+constexpr const char* PROGRESSBAR_STYLE_RAW = R"(
+QProgressBar {
+  background-color: black;
+  border: 2px solid white;
+  border-radius: 4px;
+  padding: 2px;
+}
+QProgressBar::chunk {
+  background-color: #0ab9e6;
+})";
+
+constexpr const char* PROGRESSBAR_STYLE_BINARY = R"(
+QProgressBar {
+  background-color: black;
+  border: 2px solid white;
+  border-radius: 4px;
+  padding: 2px;
+}
+QProgressBar::chunk {
+ background-color: #ff3c28;
+})";
+
+constexpr const char* PROGRESSBAR_STYLE_COMPLETE = R"(
+QProgressBar {
+  background-color: black;
+  border: 2px solid white;
+  border-radius: 4px;
+  padding: 2px;
+}
+QProgressBar::chunk {
+  background-color: #ff3c28;
+})";
+
 LoadingScreen::LoadingScreen(QWidget* parent)
     : QWidget(parent), ui(std::make_unique<Ui::LoadingScreen>()),
       previous_stage(VideoCore::LoadCallbackStage::Complete) {
@@ -44,43 +81,10 @@ LoadingScreen::LoadingScreen(QWidget* parent)
         {VideoCore::LoadCallbackStage::Complete, tr("Launching...")},
     };
     progressbar_style = {
-        {VideoCore::LoadCallbackStage::Prepare,
-         R"(
-QProgressBar {}
-QProgressBar::chunk {})"},
-        {VideoCore::LoadCallbackStage::Raw,
-         R"(
-QProgressBar {
-  background-color: black;
-  border: 2px solid white;
-  border-radius: 4px;
-  padding: 2px;
-}
-QProgressBar::chunk {
-  background-color: #0ab9e6;
-})"},
-        {VideoCore::LoadCallbackStage::Binary,
-         R"(
-QProgressBar {
-  background-color: black;
-  border: 2px solid white;
-  border-radius: 4px;
-  padding: 2px;
-}
-QProgressBar::chunk {
- background-color: #ff3c28;
-})"},
-        {VideoCore::LoadCallbackStage::Complete,
-         R"(
-QProgressBar {
-  background-color: black;
-  border: 2px solid white;
-  border-radius: 4px;
-  padding: 2px;
-}
-QProgressBar::chunk {
-  background-color: #ff3c28;
-})"},
+        {VideoCore::LoadCallbackStage::Prepare, PROGRESSBAR_STYLE_PREPARE},
+        {VideoCore::LoadCallbackStage::Raw, PROGRESSBAR_STYLE_RAW},
+        {VideoCore::LoadCallbackStage::Binary, PROGRESSBAR_STYLE_BINARY},
+        {VideoCore::LoadCallbackStage::Complete, PROGRESSBAR_STYLE_COMPLETE},
     };
 }
 

--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -69,6 +69,7 @@ LoadingScreen::LoadingScreen(QWidget* parent)
     : QWidget(parent), ui(std::make_unique<Ui::LoadingScreen>()),
       previous_stage(VideoCore::LoadCallbackStage::Complete) {
     ui->setupUi(this);
+    setMinimumSize(1280, 720);
 
     connect(this, &LoadingScreen::LoadProgress, this, &LoadingScreen::OnLoadProgress,
             Qt::QueuedConnection);

--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -32,7 +32,7 @@ constexpr const char* PROGRESSBAR_STYLE_PREPARE = R"(
 QProgressBar {}
 QProgressBar::chunk {})";
 
-constexpr const char* PROGRESSBAR_STYLE_RAW = R"(
+constexpr const char* PROGRESSBAR_STYLE_DECOMPILE = R"(
 QProgressBar {
   background-color: black;
   border: 2px solid white;
@@ -43,7 +43,7 @@ QProgressBar::chunk {
   background-color: #0ab9e6;
 })";
 
-constexpr const char* PROGRESSBAR_STYLE_BINARY = R"(
+constexpr const char* PROGRESSBAR_STYLE_BUILD = R"(
 QProgressBar {
   background-color: black;
   border: 2px solid white;
@@ -76,14 +76,14 @@ LoadingScreen::LoadingScreen(QWidget* parent)
 
     stage_translations = {
         {VideoCore::LoadCallbackStage::Prepare, tr("Loading...")},
-        {VideoCore::LoadCallbackStage::Raw, tr("Preparing Shaders %1 / %2")},
-        {VideoCore::LoadCallbackStage::Binary, tr("Loading Shaders %1 / %2")},
+        {VideoCore::LoadCallbackStage::Decompile, tr("Preparing Shaders %1 / %2")},
+        {VideoCore::LoadCallbackStage::Build, tr("Loading Shaders %1 / %2")},
         {VideoCore::LoadCallbackStage::Complete, tr("Launching...")},
     };
     progressbar_style = {
         {VideoCore::LoadCallbackStage::Prepare, PROGRESSBAR_STYLE_PREPARE},
-        {VideoCore::LoadCallbackStage::Raw, PROGRESSBAR_STYLE_RAW},
-        {VideoCore::LoadCallbackStage::Binary, PROGRESSBAR_STYLE_BINARY},
+        {VideoCore::LoadCallbackStage::Decompile, PROGRESSBAR_STYLE_DECOMPILE},
+        {VideoCore::LoadCallbackStage::Build, PROGRESSBAR_STYLE_BUILD},
         {VideoCore::LoadCallbackStage::Complete, PROGRESSBAR_STYLE_COMPLETE},
     };
 }

--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -30,11 +30,11 @@
 #include <QMovie>
 #endif
 
-constexpr const char* PROGRESSBAR_STYLE_PREPARE = R"(
+constexpr const char PROGRESSBAR_STYLE_PREPARE[] = R"(
 QProgressBar {}
 QProgressBar::chunk {})";
 
-constexpr const char* PROGRESSBAR_STYLE_DECOMPILE = R"(
+constexpr const char PROGRESSBAR_STYLE_DECOMPILE[] = R"(
 QProgressBar {
   background-color: black;
   border: 2px solid white;
@@ -45,7 +45,7 @@ QProgressBar::chunk {
   background-color: #0ab9e6;
 })";
 
-constexpr const char* PROGRESSBAR_STYLE_BUILD = R"(
+constexpr const char PROGRESSBAR_STYLE_BUILD[] = R"(
 QProgressBar {
   background-color: black;
   border: 2px solid white;
@@ -56,7 +56,7 @@ QProgressBar::chunk {
  background-color: #ff3c28;
 })";
 
-constexpr const char* PROGRESSBAR_STYLE_COMPLETE = R"(
+constexpr const char PROGRESSBAR_STYLE_COMPLETE[] = R"(
 QProgressBar {
   background-color: #0ab9e6;
   border: 2px solid white;

--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -141,7 +141,7 @@ void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size
 
     QString estimate;
     // If theres a drastic slowdown in the rate, then display an estimate
-    if (now - previous_time > milliseconds{20}) {
+    if (now - previous_time > milliseconds{50} || slow_shader_compile_start) {
         if (!slow_shader_compile_start) {
             slow_shader_start = high_resolution_clock::now();
             slow_shader_compile_start = true;

--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -46,12 +46,8 @@ LoadingScreen::LoadingScreen(QWidget* parent)
     progressbar_style = {
         {VideoCore::LoadCallbackStage::Prepare,
          R"(
-QProgressBar {
-  background-color: black;
-}
-QProgressBar::chunk {
-  background-color: white;
-})"},
+QProgressBar {}
+QProgressBar::chunk {})"},
         {VideoCore::LoadCallbackStage::Raw,
          R"(
 QProgressBar {
@@ -114,7 +110,7 @@ void LoadingScreen::Prepare(Loader::AppLoader& loader) {
         ui->logo->setPixmap(map);
     }
 
-    OnLoadProgress(VideoCore::LoadCallbackStage::Prepare, 0, 100);
+    OnLoadProgress(VideoCore::LoadCallbackStage::Prepare, 0, 0);
 }
 
 void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size_t value,
@@ -124,6 +120,11 @@ void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size
     // reset the timer if the stage changes
     if (stage != previous_stage) {
         ui->progress_bar->setStyleSheet(progressbar_style[stage]);
+        if (stage == VideoCore::LoadCallbackStage::Prepare) {
+            ui->progress_bar->hide();
+        } else {
+            ui->progress_bar->show();
+        }
         previous_stage = stage;
         // reset back to fast shader compiling since the stage changed
         slow_shader_compile_start = false;

--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -120,8 +120,8 @@ void LoadingScreen::Prepare(Loader::AppLoader& loader) {
         map.loadFromData(buffer.data(), buffer.size());
         ui->banner->setPixmap(map);
 #else
-        backing_mem =
-            std::make_unique<QByteArray>(reinterpret_cast<char*>(buffer.data()), buffer.size());
+        backing_mem = std::make_unique<QByteArray>(reinterpret_cast<char*>(buffer.data()),
+                                                   static_cast<int>(buffer.size()));
         backing_buf = std::make_unique<QBuffer>(backing_mem.get());
         backing_buf->open(QIODevice::ReadOnly);
         animation = std::make_unique<QMovie>(backing_buf.get(), QByteArray());
@@ -132,7 +132,7 @@ void LoadingScreen::Prepare(Loader::AppLoader& loader) {
     }
     if (loader.ReadLogo(buffer) == Loader::ResultStatus::Success) {
         QPixmap map;
-        map.loadFromData(buffer.data(), buffer.size());
+        map.loadFromData(buffer.data(), static_cast<uint>(buffer.size()));
         ui->logo->setPixmap(map);
     }
 
@@ -163,7 +163,7 @@ void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size
     }
     // update the max of the progress bar if the number of shaders change
     if (total != previous_total) {
-        ui->progress_bar->setMaximum(total);
+        ui->progress_bar->setMaximum(static_cast<int>(total));
         previous_total = total;
     }
 
@@ -192,7 +192,7 @@ void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size
     // update labels and progress bar
     ui->stage->setText(stage_translations[stage].arg(value).arg(total));
     ui->value->setText(estimate);
-    ui->progress_bar->setValue(value);
+    ui->progress_bar->setValue(static_cast<int>(value));
     previous_time = now;
 }
 

--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <unordered_map>
 #include <QBuffer>
 #include <QByteArray>
 #include <QHBoxLayout>
@@ -13,10 +14,12 @@
 #include <QPixmap>
 #include <QProgressBar>
 #include <QStyleOption>
-#include <QWindow>
+#include <QTime>
+#include <QtConcurrent/QtConcurrentRun>
 #include "common/logging/log.h"
 #include "core/loader/loader.h"
 #include "ui_loading_screen.h"
+#include "video_core/rasterizer_interface.h"
 #include "yuzu/loading_screen.h"
 
 // Mingw seems to not have QMovie at all. If QMovie is missing then use a single frame instead of an
@@ -26,10 +29,63 @@
 #endif
 
 LoadingScreen::LoadingScreen(QWidget* parent)
-    : QWidget(parent), ui(std::make_unique<Ui::LoadingScreen>()) {
+    : QWidget(parent), ui(std::make_unique<Ui::LoadingScreen>()),
+      previous_stage(VideoCore::LoadCallbackStage::Complete) {
     ui->setupUi(this);
-    // Progress bar is hidden until we have a use for it.
-    ui->progress_bar->hide();
+
+    connect(this, &LoadingScreen::LoadProgress, this, &LoadingScreen::OnLoadProgress,
+            Qt::QueuedConnection);
+    qRegisterMetaType<VideoCore::LoadCallbackStage>();
+
+    stage_translations = {
+        {VideoCore::LoadCallbackStage::Prepare, tr("Loading...")},
+        {VideoCore::LoadCallbackStage::Raw, tr("Preparing Shaders %1 / %2")},
+        {VideoCore::LoadCallbackStage::Binary, tr("Loading Shaders %1 / %2")},
+        {VideoCore::LoadCallbackStage::Complete, tr("Launching...")},
+    };
+    progressbar_style = {
+        {VideoCore::LoadCallbackStage::Prepare,
+         R"(
+QProgressBar {
+  background-color: black;
+}
+QProgressBar::chunk {
+  background-color: white;
+})"},
+        {VideoCore::LoadCallbackStage::Raw,
+         R"(
+QProgressBar {
+  background-color: black;
+  border: 2px solid white;
+  border-radius: 4px;
+  padding: 2px;
+}
+QProgressBar::chunk {
+  background-color: #0ab9e6;
+})"},
+        {VideoCore::LoadCallbackStage::Binary,
+         R"(
+QProgressBar {
+  background-color: black;
+  border: 2px solid white;
+  border-radius: 4px;
+  padding: 2px;
+}
+QProgressBar::chunk {
+ background-color: #ff3c28;
+})"},
+        {VideoCore::LoadCallbackStage::Complete,
+         R"(
+QProgressBar {
+  background-color: black;
+  border: 2px solid white;
+  border-radius: 4px;
+  padding: 2px;
+}
+QProgressBar::chunk {
+  background-color: #ff3c28;
+})"},
+    };
 }
 
 LoadingScreen::~LoadingScreen() = default;
@@ -46,7 +102,7 @@ void LoadingScreen::Prepare(Loader::AppLoader& loader) {
             std::make_unique<QByteArray>(reinterpret_cast<char*>(buffer.data()), buffer.size());
         backing_buf = std::make_unique<QBuffer>(backing_mem.get());
         backing_buf->open(QIODevice::ReadOnly);
-        animation = std::make_unique<QMovie>(backing_buf.get(), QByteArray("GIF"));
+        animation = std::make_unique<QMovie>(backing_buf.get(), QByteArray());
         animation->start();
         ui->banner->setMovie(animation.get());
 #endif
@@ -57,14 +113,54 @@ void LoadingScreen::Prepare(Loader::AppLoader& loader) {
         map.loadFromData(buffer.data(), buffer.size());
         ui->logo->setPixmap(map);
     }
+
+    OnLoadProgress(VideoCore::LoadCallbackStage::Prepare, 0, 100);
 }
 
-void LoadingScreen::OnLoadProgress(std::size_t value, std::size_t total) {
+void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size_t value,
+                                   std::size_t total) {
+    using namespace std::chrono;
+    auto now = high_resolution_clock::now();
+    // reset the timer if the stage changes
+    if (stage != previous_stage) {
+        ui->progress_bar->setStyleSheet(progressbar_style[stage]);
+        previous_stage = stage;
+        // reset back to fast shader compiling since the stage changed
+        slow_shader_compile_start = false;
+    }
+    // update the max of the progress bar if the number of shaders change
     if (total != previous_total) {
         ui->progress_bar->setMaximum(total);
         previous_total = total;
     }
+
+    QString estimate;
+    // If theres a drastic slowdown in the rate, then display an estimate
+    if (now - previous_time > milliseconds{20}) {
+        if (!slow_shader_compile_start) {
+            slow_shader_start = high_resolution_clock::now();
+            slow_shader_compile_start = true;
+            slow_shader_first_value = value;
+        }
+        // only calculate an estimate time after a second has passed since stage change
+        auto diff = duration_cast<milliseconds>(now - slow_shader_start);
+        if (diff > seconds{1}) {
+            auto eta_mseconds =
+                static_cast<long>(static_cast<double>(total - slow_shader_first_value) /
+                                  (value - slow_shader_first_value) * diff.count());
+            estimate =
+                tr("Estimated Time %1")
+                    .arg(QTime(0, 0, 0, 0)
+                             .addMSecs(std::max<long>(eta_mseconds - diff.count() + 1000, 1000))
+                             .toString("mm:ss"));
+        }
+    }
+
+    // update labels and progress bar
+    ui->stage->setText(stage_translations[stage].arg(value).arg(total));
+    ui->value->setText(estimate);
     ui->progress_bar->setValue(value);
+    previous_time = now;
 }
 
 void LoadingScreen::paintEvent(QPaintEvent* event) {

--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -56,7 +56,7 @@ QProgressBar::chunk {
 
 constexpr const char* PROGRESSBAR_STYLE_COMPLETE = R"(
 QProgressBar {
-  background-color: black;
+  background-color: #0ab9e6;
   border: 2px solid white;
   border-radius: 4px;
   padding: 2px;

--- a/src/yuzu/loading_screen.h
+++ b/src/yuzu/loading_screen.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
+#include <QString>
 #include <QWidget>
 
 #if !QT_CONFIG(movie)
@@ -17,6 +19,10 @@ class AppLoader;
 
 namespace Ui {
 class LoadingScreen;
+}
+
+namespace VideoCore {
+enum class LoadCallbackStage;
 }
 
 class QBuffer;
@@ -39,11 +45,14 @@ public:
     /// used resources such as the logo and banner.
     void Clear();
 
+    void OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total);
+
     // In order to use a custom widget with a stylesheet, you need to override the paintEvent
     // See https://wiki.qt.io/How_to_Change_the_Background_Color_of_QWidget
     void paintEvent(QPaintEvent* event) override;
 
-    void OnLoadProgress(std::size_t value, std::size_t total);
+signals:
+    void LoadProgress(VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total);
 
 private:
 #ifndef YUZU_QT_MOVIE_MISSING
@@ -53,4 +62,19 @@ private:
 #endif
     std::unique_ptr<Ui::LoadingScreen> ui;
     std::size_t previous_total = 0;
+    VideoCore::LoadCallbackStage previous_stage;
+
+    // Definitions for the differences in text and styling for each stage
+    std::unordered_map<VideoCore::LoadCallbackStage, const char*> progressbar_style;
+    std::unordered_map<VideoCore::LoadCallbackStage, QString> stage_translations;
+
+    // newly generated shaders are added to the end of the file, so when loading and compiling
+    // shaders, it will start quickly but end slow if new shaders were added since previous launch.
+    // These variables are used to detect the change in speed so we can generate an ETA
+    bool slow_shader_compile_start = false;
+    std::chrono::high_resolution_clock::time_point slow_shader_start;
+    std::chrono::high_resolution_clock::time_point previous_time;
+    std::size_t slow_shader_first_value = 0;
 };
+
+Q_DECLARE_METATYPE(VideoCore::LoadCallbackStage);

--- a/src/yuzu/loading_screen.h
+++ b/src/yuzu/loading_screen.h
@@ -74,7 +74,7 @@ private:
     VideoCore::LoadCallbackStage previous_stage;
 
     QGraphicsOpacityEffect* opacity_effect = nullptr;
-    std::unique_ptr<QPropertyAnimation> fadeout_animation = nullptr;
+    std::unique_ptr<QPropertyAnimation> fadeout_animation;
 
     // Definitions for the differences in text and styling for each stage
     std::unordered_map<VideoCore::LoadCallbackStage, const char*> progressbar_style;

--- a/src/yuzu/loading_screen.h
+++ b/src/yuzu/loading_screen.h
@@ -27,7 +27,9 @@ enum class LoadCallbackStage;
 
 class QBuffer;
 class QByteArray;
+class QGraphicsOpacityEffect;
 class QMovie;
+class QPropertyAnimation;
 
 class LoadingScreen : public QWidget {
     Q_OBJECT
@@ -45,7 +47,11 @@ public:
     /// used resources such as the logo and banner.
     void Clear();
 
+    /// Slot used to update the status of the progress bar
     void OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total);
+
+    /// Hides the LoadingScreen with a fade out effect
+    void OnLoadComplete();
 
     // In order to use a custom widget with a stylesheet, you need to override the paintEvent
     // See https://wiki.qt.io/How_to_Change_the_Background_Color_of_QWidget
@@ -53,6 +59,9 @@ public:
 
 signals:
     void LoadProgress(VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total);
+    /// Signals that this widget is completely hidden now and should be replaced with the other
+    /// widget
+    void Hidden();
 
 private:
 #ifndef YUZU_QT_MOVIE_MISSING
@@ -63,6 +72,9 @@ private:
     std::unique_ptr<Ui::LoadingScreen> ui;
     std::size_t previous_total = 0;
     VideoCore::LoadCallbackStage previous_stage;
+
+    QGraphicsOpacityEffect* opacity_effect = nullptr;
+    std::unique_ptr<QPropertyAnimation> fadeout_animation = nullptr;
 
     // Definitions for the differences in text and styling for each stage
     std::unordered_map<VideoCore::LoadCallbackStage, const char*> progressbar_style;

--- a/src/yuzu/loading_screen.ui
+++ b/src/yuzu/loading_screen.ui
@@ -43,17 +43,78 @@
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QProgressBar" name="progress_bar">
+    <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,1">
+     <property name="spacing">
+      <number>15</number>
+     </property>
+     <property name="sizeConstraint">
+      <enum>QLayout::SetNoConstraint</enum>
+     </property>
+     <item alignment="Qt::AlignHCenter|Qt::AlignBottom">
+      <widget class="QLabel" name="stage">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="styleSheet">
-        <string notr="true">font-size: 26px;</string>
+        <string notr="true">background-color: black; color: white;
+font: 75 20pt &quot;Arial&quot;;</string>
+       </property>
+       <property name="text">
+        <string>Loading Shaders 387 / 1628</string>
+       </property>
+      </widget>
+     </item>
+     <item alignment="Qt::AlignHCenter|Qt::AlignTop">
+      <widget class="QProgressBar" name="progress_bar">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>500</width>
+         <height>40</height>
+        </size>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QProgressBar {
+color: white;
+border: 2px solid white;
+outline-color: black;
+border-radius: 20px;
+}
+QProgressBar::chunk {
+background-color: white;
+border-radius: 15px;
+}</string>
        </property>
        <property name="value">
-        <number>0</number>
+        <number>50</number>
+       </property>
+       <property name="textVisible">
+        <bool>false</bool>
        </property>
        <property name="format">
         <string>Loading Shaders %v out of %m</string>
+       </property>
+      </widget>
+     </item>
+     <item alignment="Qt::AlignHCenter|Qt::AlignTop">
+      <widget class="QLabel" name="value">
+       <property name="toolTip">
+        <string notr="true"/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: black; color: white;
+font: 75 15pt &quot;Arial&quot;;</string>
+       </property>
+       <property name="text">
+        <string>Stage 1 of 2. Estimate Time 5m 4s</string>
        </property>
       </widget>
      </item>

--- a/src/yuzu/loading_screen.ui
+++ b/src/yuzu/loading_screen.ui
@@ -30,59 +30,77 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QLabel" name="logo">
-     <property name="text">
-      <string/>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="margin">
-      <number>30</number>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,1">
-     <property name="spacing">
-      <number>15</number>
-     </property>
-     <property name="sizeConstraint">
-      <enum>QLayout::SetNoConstraint</enum>
-     </property>
-     <item alignment="Qt::AlignHCenter|Qt::AlignBottom">
-      <widget class="QLabel" name="stage">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">background-color: black; color: white;
+    <widget class="QWidget" name="fade_parent" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item alignment="Qt::AlignLeft|Qt::AlignTop">
+       <widget class="QLabel" name="logo">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+        </property>
+        <property name="margin">
+         <number>30</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,1">
+        <property name="spacing">
+         <number>15</number>
+        </property>
+        <property name="sizeConstraint">
+         <enum>QLayout::SetNoConstraint</enum>
+        </property>
+        <item alignment="Qt::AlignHCenter|Qt::AlignBottom">
+         <widget class="QLabel" name="stage">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">background-color: black; color: white;
 font: 75 20pt &quot;Arial&quot;;</string>
-       </property>
-       <property name="text">
-        <string>Loading Shaders 387 / 1628</string>
-       </property>
-      </widget>
-     </item>
-     <item alignment="Qt::AlignHCenter|Qt::AlignTop">
-      <widget class="QProgressBar" name="progress_bar">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>500</width>
-         <height>40</height>
-        </size>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">QProgressBar {
+          </property>
+          <property name="text">
+           <string>Loading Shaders 387 / 1628</string>
+          </property>
+         </widget>
+        </item>
+        <item alignment="Qt::AlignHCenter|Qt::AlignTop">
+         <widget class="QProgressBar" name="progress_bar">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>500</width>
+            <height>40</height>
+           </size>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">QProgressBar {
 color: white;
 border: 2px solid white;
 outline-color: black;
@@ -92,45 +110,48 @@ QProgressBar::chunk {
 background-color: white;
 border-radius: 15px;
 }</string>
-       </property>
-       <property name="value">
-        <number>50</number>
-       </property>
-       <property name="textVisible">
-        <bool>false</bool>
-       </property>
-       <property name="format">
-        <string>Loading Shaders %v out of %m</string>
-       </property>
-      </widget>
-     </item>
-     <item alignment="Qt::AlignHCenter|Qt::AlignTop">
-      <widget class="QLabel" name="value">
-       <property name="toolTip">
-        <string notr="true"/>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">background-color: black; color: white;
+          </property>
+          <property name="value">
+           <number>50</number>
+          </property>
+          <property name="textVisible">
+           <bool>false</bool>
+          </property>
+          <property name="format">
+           <string>Loading Shaders %v out of %m</string>
+          </property>
+         </widget>
+        </item>
+        <item alignment="Qt::AlignHCenter|Qt::AlignTop">
+         <widget class="QLabel" name="value">
+          <property name="toolTip">
+           <string notr="true"/>
+          </property>
+          <property name="styleSheet">
+           <string notr="true">background-color: black; color: white;
 font: 75 15pt &quot;Arial&quot;;</string>
-       </property>
-       <property name="text">
-        <string>Stage 1 of 2. Estimate Time 5m 4s</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item alignment="Qt::AlignRight|Qt::AlignBottom">
-    <widget class="QLabel" name="banner">
-     <property name="styleSheet">
-      <string notr="true">background-color: black;</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="margin">
-      <number>30</number>
-     </property>
+          </property>
+          <property name="text">
+           <string>Stage 1 of 2. Estimate Time 5m 4s</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item alignment="Qt::AlignRight|Qt::AlignBottom">
+       <widget class="QLabel" name="banner">
+        <property name="styleSheet">
+         <string notr="true">background-color: black;</string>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="margin">
+         <number>30</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -415,6 +415,13 @@ void GMainWindow::InitializeWidgets() {
     loading_screen = new LoadingScreen(this);
     loading_screen->hide();
     ui.horizontalLayout->addWidget(loading_screen);
+    connect(loading_screen, &LoadingScreen::Hidden, [&] {
+        loading_screen->Clear();
+        if (emulation_running) {
+            render_window->show();
+            render_window->setFocus();
+        }
+    });
 
     // Create status bar
     message_label = new QLabel();
@@ -1513,10 +1520,7 @@ void GMainWindow::OnStopGame() {
 }
 
 void GMainWindow::OnLoadComplete() {
-    loading_screen->hide();
-    loading_screen->Clear();
-    render_window->show();
-    render_window->setFocus();
+    loading_screen->OnLoadComplete();
 }
 
 void GMainWindow::OnMenuReportCompatibility() {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -904,7 +904,6 @@ void GMainWindow::BootGame(const QString& filename) {
 
     loading_screen->Prepare(Core::System::GetInstance().GetAppLoader());
     loading_screen->show();
-    loading_screen->setFocus();
 
     emulation_running = true;
     if (ui.action_Fullscreen->isChecked()) {


### PR DESCRIPTION
Part two for #2034, this adds more sparkle to the progress bar to make it more useful. Will rebase this pr after #2034 is merged.

**This image was taken with a loading simulator, and is not representative of actual shader loading times**

![obligatory ui image](https://user-images.githubusercontent.com/952515/51435336-5c0fe980-1c32-11e9-95b9-b540bdc607bd.gif)

There are two problems with the original single progressbar

1. The shader disk loading is actually broken into two parts: loading raw shaders and loading binary shaders.
2. Newly added shaders are appended to the caches, so on the next launch, loading progress goes quickly until it reaches new shaders at which point it'll dramatically slow down.

With these two problems in mind, I designed the progress bar to be minimal but informative. The progressbar is hidden until shader loading is started, and there are two distinct phases with different color progressbars (the colors used in the yuzu icon). If the progress slows down significantly, then we've reached a point where new shaders are either getting decompiled (step 1) or getting compiled (step 2) and we display an estimated time.

Reviewers:
The first 4 commits are from #2034 as this depends on it. Please just review the last commit.
