### PR TITLE
Port citra-emu/citra#3928: "citra_qt: Log settings on launch"

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -74,4 +74,33 @@ void Apply() {
     Service::HID::ReloadInputDevices();
 }
 
+template <typename T>
+void LogSetting(const std::string& name, const T& value) {
+    LOG_INFO(Config, "{}: {}", name, value);
+}
+
+void LogSettings() {
+    LOG_INFO(Config, "yuzu Configuration:");
+    LogSetting("System_UseDockedMode", Settings::values.use_docked_mode);
+    LogSetting("System_EnableNfc", Settings::values.enable_nfc);
+    LogSetting("System_RngSeed", Settings::values.rng_seed.value_or(0));
+    LogSetting("System_CurrentUser", Settings::values.current_user);
+    LogSetting("System_LanguageIndex", Settings::values.language_index);
+    LogSetting("Core_UseCpuJit", Settings::values.use_cpu_jit);
+    LogSetting("Core_UseMultiCore", Settings::values.use_multi_core);
+    LogSetting("Renderer_UseResolutionFactor", Settings::values.resolution_factor);
+    LogSetting("Renderer_UseFrameLimit", Settings::values.use_frame_limit);
+    LogSetting("Renderer_FrameLimit", Settings::values.frame_limit);
+    LogSetting("Renderer_UseAccurateGpuEmulation", Settings::values.use_accurate_gpu_emulation);
+    LogSetting("Audio_OutputEngine", Settings::values.sink_id);
+    LogSetting("Audio_EnableAudioStretching", Settings::values.enable_audio_stretching);
+    LogSetting("Audio_OutputDevice", Settings::values.audio_device_id);
+    LogSetting("DataStorage_UseVirtualSd", Settings::values.use_virtual_sd);
+    LogSetting("DataStorage_NandDir", Settings::values.nand_dir);
+    LogSetting("DataStorage_SdmcDir", Settings::values.sdmc_dir);
+    LogSetting("Debugging_UseGdbstub", Settings::values.use_gdbstub);
+    LogSetting("Debugging_GdbstubPort", Settings::values.gdbstub_port);
+    LogSetting("Debugging_ProgramArgs", Settings::values.program_args);
+}
+
 } // namespace Settings

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -425,4 +425,5 @@ struct Values {
 } extern values;
 
 void Apply();
+void LogSettings();
 } // namespace Settings

--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -39,6 +39,7 @@ void ConfigureDialog::applyConfiguration() {
     ui->debugTab->applyConfiguration();
     ui->webTab->applyConfiguration();
     Settings::Apply();
+    Settings::LogSettings();
 }
 
 void ConfigureDialog::PopulateSelectionList() {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2042,6 +2042,9 @@ int main(int argc, char* argv[]) {
     GMainWindow main_window;
     // After settings have been loaded by GMainWindow, apply the filter
     main_window.show();
+
+    Settings::LogSettings();
+
     int result = app.exec();
     detached_tasks.WaitForAllTasks();
     return result;

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
@@ -195,6 +195,7 @@ EmuWindow_SDL2::EmuWindow_SDL2(bool fullscreen) {
     SDL_GL_SetSwapInterval(false);
     LOG_INFO(Frontend, "yuzu Version: {} | {}-{}", Common::g_build_fullname, Common::g_scm_branch,
              Common::g_scm_desc);
+    Settings::LogSettings();
 
     DoneCurrent();
 }


### PR DESCRIPTION
See citra-emu/citra#3928. cc @chris062689 

**Original description:**
Fix citra-emu/citra#3918

I chose some of the more diagnostic ones to be logged. Others like custom layout and multiplayer are not logged.