### PR TITLE
frontend: Refactor ScopeAcquireWindowContext out of renderer_opengl.

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -95,6 +95,8 @@ add_library(core STATIC
     frontend/framebuffer_layout.cpp
     frontend/framebuffer_layout.h
     frontend/input.h
+    frontend/scope_acquire_window_context.cpp
+    frontend/scope_acquire_window_context.h
     gdbstub/gdbstub.cpp
     gdbstub/gdbstub.h
     hle/ipc.h

--- a/src/core/frontend/scope_acquire_window_context.cpp
+++ b/src/core/frontend/scope_acquire_window_context.cpp
@@ -1,0 +1,18 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/frontend/emu_window.h"
+#include "core/frontend/scope_acquire_window_context.h"
+
+namespace Core::Frontend {
+
+ScopeAcquireWindowContext::ScopeAcquireWindowContext(Core::Frontend::EmuWindow& emu_window_)
+    : emu_window{emu_window_} {
+    emu_window.MakeCurrent();
+}
+ScopeAcquireWindowContext::~ScopeAcquireWindowContext() {
+    emu_window.DoneCurrent();
+}
+
+} // namespace Core::Frontend

--- a/src/core/frontend/scope_acquire_window_context.h
+++ b/src/core/frontend/scope_acquire_window_context.h
@@ -1,0 +1,23 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common/common_types.h"
+
+namespace Core::Frontend {
+
+class EmuWindow;
+
+/// Helper class to acquire/release window context within a given scope
+class ScopeAcquireWindowContext : NonCopyable {
+public:
+    explicit ScopeAcquireWindowContext(Core::Frontend::EmuWindow& window);
+    ~ScopeAcquireWindowContext();
+
+private:
+    Core::Frontend::EmuWindow& emu_window;
+};
+
+} // namespace Core::Frontend

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -643,8 +643,6 @@ void RasterizerOpenGL::Clear() {
         return;
     }
 
-    ScopeAcquireGLContext acquire_context{emu_window};
-
     ConfigureFramebuffers(clear_state, use_color, use_depth || use_stencil, false,
                           regs.clear_buffers.RT.Value());
     if (regs.clear_flags.scissor) {
@@ -677,8 +675,6 @@ void RasterizerOpenGL::DrawArrays() {
     MICROPROFILE_SCOPE(OpenGL_Drawing);
     auto& gpu = Core::System::GetInstance().GPU().Maxwell3D();
     const auto& regs = gpu.regs;
-
-    ScopeAcquireGLContext acquire_context{emu_window};
 
     ConfigureFramebuffers(state);
     SyncColorMask();

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -39,16 +39,6 @@ struct ScreenInfo {
     TextureInfo texture;
 };
 
-/// Helper class to acquire/release OpenGL context within a given scope
-class ScopeAcquireGLContext : NonCopyable {
-public:
-    explicit ScopeAcquireGLContext(Core::Frontend::EmuWindow& window);
-    ~ScopeAcquireGLContext();
-
-private:
-    Core::Frontend::EmuWindow& emu_window;
-};
-
 class RendererOpenGL : public VideoCore::RendererBase {
 public:
     explicit RendererOpenGL(Core::Frontend::EmuWindow& window);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -14,6 +14,7 @@
 #include "configuration/configure_per_general.h"
 #include "core/file_sys/vfs.h"
 #include "core/file_sys/vfs_real.h"
+#include "core/frontend/scope_acquire_window_context.h"
 #include "core/hle/service/acc/profile_manager.h"
 #include "core/hle/service/am/applets/applets.h"
 #include "core/hle/service/hid/controllers/npad.h"
@@ -747,13 +748,15 @@ bool GMainWindow::LoadROM(const QString& filename) {
         ShutdownGame();
 
     render_window->InitRenderTarget();
-    render_window->MakeCurrent();
 
-    if (!gladLoadGL()) {
-        QMessageBox::critical(this, tr("Error while initializing OpenGL 4.3 Core!"),
-                              tr("Your GPU may not support OpenGL 4.3, or you do not "
-                                 "have the latest graphics driver."));
-        return false;
+    {
+        Core::Frontend::ScopeAcquireWindowContext acquire_context{*render_window};
+        if (!gladLoadGL()) {
+            QMessageBox::critical(this, tr("Error while initializing OpenGL 4.3 Core!"),
+                                  tr("Your GPU may not support OpenGL 4.3, or you do not "
+                                     "have the latest graphics driver."));
+            return false;
+        }
     }
 
     QStringList unsupported_gl_extensions = GetUnsupportedGLExtensions();
@@ -793,8 +796,6 @@ bool GMainWindow::LoadROM(const QString& filename) {
                "href='https://yuzu-emu.org/wiki/overview-of-switch-game-formats'>check out our "
                "wiki</a>. This message will not be shown again."));
     }
-
-    render_window->DoneCurrent();
 
     if (result != Core::System::ResultStatus::Success) {
         switch (result) {


### PR DESCRIPTION
This is a prerequisite for #2012 that needs to be merged first to fix canary conflicts.