### PR TITLE
video_core: Silent implicit conversion warning

### DIFF
--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -16,9 +16,10 @@ std::unique_ptr<RendererBase> CreateRenderer(Core::Frontend::EmuWindow& emu_wind
 }
 
 u16 GetResolutionScaleFactor(const RendererBase& renderer) {
-    return !Settings::values.resolution_factor
-               ? renderer.GetRenderWindow().GetFramebufferLayout().GetScalingRatio()
-               : Settings::values.resolution_factor;
+    return static_cast<u16>(
+        Settings::values.resolution_factor
+            ? Settings::values.resolution_factor
+            : renderer.GetRenderWindow().GetFramebufferLayout().GetScalingRatio());
 }
 
 } // namespace VideoCore


### PR DESCRIPTION
Also sort the predicate order to have the semantically positive value first.