### PR TITLE
Port citra-emu/citra#4601: "dsp_interface: fix sound being played while volume is 0"

### DIFF
--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -68,7 +68,7 @@ static void VolumeAdjustSamples(std::vector<s16>& samples) {
     }
 
     // Implementation of a volume slider with a dynamic range of 60 dB
-    const float volume_scale_factor{std::exp(6.90775f * volume) * 0.001f};
+    const float volume_scale_factor = volume == 0 ? 0 : std::exp(6.90775f * volume) * 0.001f;
     for (auto& sample : samples) {
         sample = static_cast<s16>(sample * volume_scale_factor);
     }


### PR DESCRIPTION
See citra-emu/citra#4601 for more details.

**Original description**:
According to documentation, if the argument of std::exp is zero, one is returned.
However we want the return value to be also zero in this case so no audio is played.