### PR TITLE
video_core/dma_pusher: Silence C4828 warnings

### DIFF
--- a/src/video_core/dma_pusher.h
+++ b/src/video_core/dma_pusher.h
@@ -83,7 +83,7 @@ private:
         u32 subchannel;        ///< Current subchannel
         u32 method_count;      ///< Current method count
         u32 length_pending;    ///< Large NI command length pending
-        bool non_incrementing; ///< Current command’s NI flag
+        bool non_incrementing; ///< Current command's NI flag
     };
 
     DmaState dma_state{};


### PR DESCRIPTION
This was previously causing:

> warning C4828: The file contains a character starting at offset 0xa33
that is illegal in the current source character set (codepage 65001).

warnings on Windows when compiling yuzu.