### PR TITLE
 shader_ir/memory: Add LD_L 64 bits loads 

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -217,9 +217,9 @@ enum class StoreType : u64 {
     Signed8 = 1,
     Unsigned16 = 2,
     Signed16 = 3,
-    Bytes32 = 4,
-    Bytes64 = 5,
-    Bytes128 = 6,
+    Bits32 = 4,
+    Bits64 = 5,
+    Bits128 = 6,
 };
 
 enum class IMinMaxExchange : u64 {

--- a/src/video_core/shader/decode/memory.cpp
+++ b/src/video_core/shader/decode/memory.cpp
@@ -104,16 +104,27 @@ u32 ShaderIR::DecodeMemory(BasicBlock& bb, const BasicBlock& code, u32 pc) {
     }
     case OpCode::Id::LD_L: {
         UNIMPLEMENTED_IF_MSG(instr.ld_l.unknown == 1, "LD_L Unhandled mode: {}",
-                             static_cast<unsigned>(instr.ld_l.unknown.Value()));
+                             static_cast<u32>(instr.ld_l.unknown.Value()));
 
-        const Node index = Operation(OperationCode::IAdd, GetRegister(instr.gpr8),
-                                     Immediate(static_cast<s32>(instr.smem_imm)));
-        const Node lmem = GetLocalMemory(index);
+        const auto GetLmem = [&](s32 offset) {
+            ASSERT(offset % 4 == 0);
+            const Node immediate_offset = Immediate(static_cast<s32>(instr.smem_imm) + offset);
+            const Node address = Operation(OperationCode::IAdd, NO_PRECISE, GetRegister(instr.gpr8),
+                                           immediate_offset);
+            return GetLocalMemory(address);
+        };
 
         switch (instr.ldst_sl.type.Value()) {
         case Tegra::Shader::StoreType::Bytes32:
-            SetRegister(bb, instr.gpr0, lmem);
+            SetRegister(bb, instr.gpr0, GetLmem(0));
             break;
+        case Tegra::Shader::StoreType::Bytes64: {
+            SetTemporal(bb, 0, GetLmem(0));
+            SetTemporal(bb, 1, GetLmem(4));
+            SetRegister(bb, instr.gpr0, GetTemporal(0));
+            SetRegister(bb, instr.gpr0.Value() + 1, GetTemporal(1));
+            break;
+        }
         default:
             UNIMPLEMENTED_MSG("LD_L Unhandled type: {}",
                               static_cast<unsigned>(instr.ldst_sl.type.Value()));

--- a/src/video_core/shader/decode/memory.cpp
+++ b/src/video_core/shader/decode/memory.cpp
@@ -115,10 +115,10 @@ u32 ShaderIR::DecodeMemory(BasicBlock& bb, const BasicBlock& code, u32 pc) {
         };
 
         switch (instr.ldst_sl.type.Value()) {
-        case Tegra::Shader::StoreType::Bytes32:
+        case Tegra::Shader::StoreType::Bits32:
             SetRegister(bb, instr.gpr0, GetLmem(0));
             break;
-        case Tegra::Shader::StoreType::Bytes64: {
+        case Tegra::Shader::StoreType::Bits64: {
             SetTemporal(bb, 0, GetLmem(0));
             SetTemporal(bb, 1, GetLmem(4));
             SetRegister(bb, instr.gpr0, GetTemporal(0));
@@ -127,7 +127,7 @@ u32 ShaderIR::DecodeMemory(BasicBlock& bb, const BasicBlock& code, u32 pc) {
         }
         default:
             UNIMPLEMENTED_MSG("LD_L Unhandled type: {}",
-                              static_cast<unsigned>(instr.ldst_sl.type.Value()));
+                              static_cast<u32>(instr.ldst_sl.type.Value()));
         }
         break;
     }
@@ -217,7 +217,7 @@ u32 ShaderIR::DecodeMemory(BasicBlock& bb, const BasicBlock& code, u32 pc) {
                                      Immediate(static_cast<s32>(instr.smem_imm)));
 
         switch (instr.ldst_sl.type.Value()) {
-        case Tegra::Shader::StoreType::Bytes32:
+        case Tegra::Shader::StoreType::Bits32:
             SetLocalMemory(bb, index, GetRegister(instr.gpr0));
             break;
         default:


### PR DESCRIPTION
It also renames `BytesN` to `BitsN` since `Bytes32` is a misleading name.