### PR TITLE
speed up memory page mapping

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -322,14 +322,15 @@ void ISelfController::SetScreenShotImageOrientation(Kernel::HLERequestContext& c
 
 void ISelfController::CreateManagedDisplayLayer(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_AM, "(STUBBED) called");
+
     // TODO(Subv): Find out how AM determines the display to use, for now just
     // create the layer in the Default display.
-    u64 display_id = nvflinger->OpenDisplay("Default");
-    u64 layer_id = nvflinger->CreateLayer(display_id);
+    const auto display_id = nvflinger->OpenDisplay("Default");
+    const auto layer_id = nvflinger->CreateLayer(*display_id);
 
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
-    rb.Push(layer_id);
+    rb.Push(*layer_id);
 }
 
 void ISelfController::SetHandlesRequestToDisplay(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -46,7 +46,7 @@ void NVFlinger::SetNVDrvInstance(std::shared_ptr<Nvidia::Module> instance) {
     nvdrv = std::move(instance);
 }
 
-u64 NVFlinger::OpenDisplay(std::string_view name) {
+std::optional<u64> NVFlinger::OpenDisplay(std::string_view name) {
     LOG_DEBUG(Service, "Opening \"{}\" display", name);
 
     // TODO(Subv): Currently we only support the Default display.
@@ -54,32 +54,48 @@ u64 NVFlinger::OpenDisplay(std::string_view name) {
 
     const auto itr = std::find_if(displays.begin(), displays.end(),
                                   [&](const Display& display) { return display.name == name; });
-
-    ASSERT(itr != displays.end());
+    if (itr == displays.end()) {
+        return {};
+    }
 
     return itr->id;
 }
 
-u64 NVFlinger::CreateLayer(u64 display_id) {
-    auto& display = FindDisplay(display_id);
+std::optional<u64> NVFlinger::CreateLayer(u64 display_id) {
+    auto* const display = FindDisplay(display_id);
 
-    ASSERT_MSG(display.layers.empty(), "Only one layer is supported per display at the moment");
+    if (display == nullptr) {
+        return {};
+    }
+
+    ASSERT_MSG(display->layers.empty(), "Only one layer is supported per display at the moment");
 
     const u64 layer_id = next_layer_id++;
     const u32 buffer_queue_id = next_buffer_queue_id++;
     auto buffer_queue = std::make_shared<BufferQueue>(buffer_queue_id, layer_id);
-    display.layers.emplace_back(layer_id, buffer_queue);
+    display->layers.emplace_back(layer_id, buffer_queue);
     buffer_queues.emplace_back(std::move(buffer_queue));
     return layer_id;
 }
 
-u32 NVFlinger::FindBufferQueueId(u64 display_id, u64 layer_id) const {
-    const auto& layer = FindLayer(display_id, layer_id);
-    return layer.buffer_queue->GetId();
+std::optional<u32> NVFlinger::FindBufferQueueId(u64 display_id, u64 layer_id) const {
+    const auto* const layer = FindLayer(display_id, layer_id);
+
+    if (layer == nullptr) {
+        return {};
+    }
+
+    return layer->buffer_queue->GetId();
 }
 
 Kernel::SharedPtr<Kernel::ReadableEvent> NVFlinger::FindVsyncEvent(u64 display_id) const {
-    return FindDisplay(display_id).vsync_event.readable;
+    auto* const display = FindDisplay(display_id);
+
+    if (display == nullptr) {
+        return nullptr;
+    }
+
+    return display->vsync_event.readable;
 }
 
 std::shared_ptr<BufferQueue> NVFlinger::FindBufferQueue(u32 id) const {
@@ -90,40 +106,60 @@ std::shared_ptr<BufferQueue> NVFlinger::FindBufferQueue(u32 id) const {
     return *itr;
 }
 
-Display& NVFlinger::FindDisplay(u64 display_id) {
+Display* NVFlinger::FindDisplay(u64 display_id) {
     const auto itr = std::find_if(displays.begin(), displays.end(),
                                   [&](const Display& display) { return display.id == display_id; });
 
-    ASSERT(itr != displays.end());
-    return *itr;
+    if (itr == displays.end()) {
+        return nullptr;
+    }
+
+    return &*itr;
 }
 
-const Display& NVFlinger::FindDisplay(u64 display_id) const {
+const Display* NVFlinger::FindDisplay(u64 display_id) const {
     const auto itr = std::find_if(displays.begin(), displays.end(),
                                   [&](const Display& display) { return display.id == display_id; });
 
-    ASSERT(itr != displays.end());
-    return *itr;
+    if (itr == displays.end()) {
+        return nullptr;
+    }
+
+    return &*itr;
 }
 
-Layer& NVFlinger::FindLayer(u64 display_id, u64 layer_id) {
-    auto& display = FindDisplay(display_id);
+Layer* NVFlinger::FindLayer(u64 display_id, u64 layer_id) {
+    auto* const display = FindDisplay(display_id);
 
-    const auto itr = std::find_if(display.layers.begin(), display.layers.end(),
+    if (display == nullptr) {
+        return nullptr;
+    }
+
+    const auto itr = std::find_if(display->layers.begin(), display->layers.end(),
                                   [&](const Layer& layer) { return layer.id == layer_id; });
 
-    ASSERT(itr != display.layers.end());
-    return *itr;
+    if (itr == display->layers.end()) {
+        return nullptr;
+    }
+
+    return &*itr;
 }
 
-const Layer& NVFlinger::FindLayer(u64 display_id, u64 layer_id) const {
-    const auto& display = FindDisplay(display_id);
+const Layer* NVFlinger::FindLayer(u64 display_id, u64 layer_id) const {
+    const auto* const display = FindDisplay(display_id);
 
-    const auto itr = std::find_if(display.layers.begin(), display.layers.end(),
+    if (display == nullptr) {
+        return nullptr;
+    }
+
+    const auto itr = std::find_if(display->layers.begin(), display->layers.end(),
                                   [&](const Layer& layer) { return layer.id == layer_id; });
 
-    ASSERT(itr != display.layers.end());
-    return *itr;
+    if (itr == display->layers.end()) {
+        return nullptr;
+    }
+
+    return &*itr;
 }
 
 void NVFlinger::Compose() {

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -78,7 +78,7 @@ u32 NVFlinger::FindBufferQueueId(u64 display_id, u64 layer_id) const {
     return layer.buffer_queue->GetId();
 }
 
-Kernel::SharedPtr<Kernel::ReadableEvent> NVFlinger::GetVsyncEvent(u64 display_id) {
+Kernel::SharedPtr<Kernel::ReadableEvent> NVFlinger::FindVsyncEvent(u64 display_id) {
     return FindDisplay(display_id).vsync_event.readable;
 }
 

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -78,7 +78,7 @@ u32 NVFlinger::FindBufferQueueId(u64 display_id, u64 layer_id) const {
     return layer.buffer_queue->GetId();
 }
 
-Kernel::SharedPtr<Kernel::ReadableEvent> NVFlinger::FindVsyncEvent(u64 display_id) {
+Kernel::SharedPtr<Kernel::ReadableEvent> NVFlinger::FindVsyncEvent(u64 display_id) const {
     return FindDisplay(display_id).vsync_event.readable;
 }
 

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -58,15 +59,23 @@ public:
     void SetNVDrvInstance(std::shared_ptr<Nvidia::Module> instance);
 
     /// Opens the specified display and returns the ID.
-    u64 OpenDisplay(std::string_view name);
+    ///
+    /// If an invalid display name is provided, then an empty optional is returned.
+    std::optional<u64> OpenDisplay(std::string_view name);
 
     /// Creates a layer on the specified display and returns the layer ID.
-    u64 CreateLayer(u64 display_id);
+    ///
+    /// If an invalid display ID is specified, then an empty optional is returned.
+    std::optional<u64> CreateLayer(u64 display_id);
 
     /// Finds the buffer queue ID of the specified layer in the specified display.
-    u32 FindBufferQueueId(u64 display_id, u64 layer_id) const;
+    ///
+    /// If an invalid display ID or layer ID is provided, then an empty optional is returned.
+    std::optional<u32> FindBufferQueueId(u64 display_id, u64 layer_id) const;
 
     /// Gets the vsync event for the specified display.
+    ///
+    /// If an invalid display ID is provided, then nullptr is returned.
     Kernel::SharedPtr<Kernel::ReadableEvent> FindVsyncEvent(u64 display_id) const;
 
     /// Obtains a buffer queue identified by the ID.
@@ -78,16 +87,16 @@ public:
 
 private:
     /// Finds the display identified by the specified ID.
-    Display& FindDisplay(u64 display_id);
+    Display* FindDisplay(u64 display_id);
 
     /// Finds the display identified by the specified ID.
-    const Display& FindDisplay(u64 display_id) const;
+    const Display* FindDisplay(u64 display_id) const;
 
     /// Finds the layer identified by the specified ID in the desired display.
-    Layer& FindLayer(u64 display_id, u64 layer_id);
+    Layer* FindLayer(u64 display_id, u64 layer_id);
 
     /// Finds the layer identified by the specified ID in the desired display.
-    const Layer& FindLayer(u64 display_id, u64 layer_id) const;
+    const Layer* FindLayer(u64 display_id, u64 layer_id) const;
 
     std::shared_ptr<Nvidia::Module> nvdrv;
 

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -67,7 +67,7 @@ public:
     u32 FindBufferQueueId(u64 display_id, u64 layer_id) const;
 
     /// Gets the vsync event for the specified display.
-    Kernel::SharedPtr<Kernel::ReadableEvent> GetVsyncEvent(u64 display_id);
+    Kernel::SharedPtr<Kernel::ReadableEvent> FindVsyncEvent(u64 display_id);
 
     /// Obtains a buffer queue identified by the ID.
     std::shared_ptr<BufferQueue> FindBufferQueue(u32 id) const;

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -67,7 +67,7 @@ public:
     u32 FindBufferQueueId(u64 display_id, u64 layer_id) const;
 
     /// Gets the vsync event for the specified display.
-    Kernel::SharedPtr<Kernel::ReadableEvent> FindVsyncEvent(u64 display_id);
+    Kernel::SharedPtr<Kernel::ReadableEvent> FindVsyncEvent(u64 display_id) const;
 
     /// Obtains a buffer queue identified by the ID.
     std::shared_ptr<BufferQueue> FindBufferQueue(u32 id) const;

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -34,6 +34,7 @@ namespace Service::VI {
 
 constexpr ResultCode ERR_OPERATION_FAILED{ErrorModule::VI, 1};
 constexpr ResultCode ERR_UNSUPPORTED{ErrorModule::VI, 6};
+constexpr ResultCode ERR_NOT_FOUND{ErrorModule::VI, 7};
 
 struct DisplayInfo {
     /// The name of this particular display.
@@ -838,11 +839,16 @@ private:
                     "(STUBBED) called. unknown=0x{:08X}, display=0x{:016X}, aruid=0x{:016X}",
                     unknown, display, aruid);
 
-        const u64 layer_id = nv_flinger->CreateLayer(display);
+        const auto layer_id = nv_flinger->CreateLayer(display);
+        if (!layer_id) {
+            IPC::ResponseBuilder rb{ctx, 2};
+            rb.Push(ERR_NOT_FOUND);
+            return;
+        }
 
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
-        rb.Push(layer_id);
+        rb.Push(*layer_id);
     }
 
     void AddToLayerStack(Kernel::HLERequestContext& ctx) {
@@ -950,9 +956,16 @@ private:
 
         ASSERT_MSG(name == "Default", "Non-default displays aren't supported yet");
 
+        const auto display_id = nv_flinger->OpenDisplay(name);
+        if (!display_id) {
+            IPC::ResponseBuilder rb{ctx, 2};
+            rb.Push(ERR_NOT_FOUND);
+            return;
+        }
+
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u64>(nv_flinger->OpenDisplay(name));
+        rb.Push<u64>(*display_id);
     }
 
     void CloseDisplay(Kernel::HLERequestContext& ctx) {
@@ -1043,10 +1056,21 @@ private:
 
         LOG_DEBUG(Service_VI, "called. layer_id=0x{:016X}, aruid=0x{:016X}", layer_id, aruid);
 
-        const u64 display_id = nv_flinger->OpenDisplay(display_name);
-        const u32 buffer_queue_id = nv_flinger->FindBufferQueueId(display_id, layer_id);
+        const auto display_id = nv_flinger->OpenDisplay(display_name);
+        if (!display_id) {
+            IPC::ResponseBuilder rb{ctx, 2};
+            rb.Push(ERR_NOT_FOUND);
+            return;
+        }
 
-        NativeWindow native_window{buffer_queue_id};
+        const auto buffer_queue_id = nv_flinger->FindBufferQueueId(*display_id, layer_id);
+        if (!buffer_queue_id) {
+            IPC::ResponseBuilder rb{ctx, 2};
+            rb.Push(ERR_NOT_FOUND);
+            return;
+        }
+
+        NativeWindow native_window{*buffer_queue_id};
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u64>(ctx.WriteBuffer(native_window.Serialize()));
@@ -1062,13 +1086,24 @@ private:
 
         // TODO(Subv): What's the difference between a Stray and a Managed layer?
 
-        const u64 layer_id = nv_flinger->CreateLayer(display_id);
-        const u32 buffer_queue_id = nv_flinger->FindBufferQueueId(display_id, layer_id);
+        const auto layer_id = nv_flinger->CreateLayer(display_id);
+        if (!layer_id) {
+            IPC::ResponseBuilder rb{ctx, 2};
+            rb.Push(ERR_NOT_FOUND);
+            return;
+        }
 
-        NativeWindow native_window{buffer_queue_id};
+        const auto buffer_queue_id = nv_flinger->FindBufferQueueId(display_id, *layer_id);
+        if (!buffer_queue_id) {
+            IPC::ResponseBuilder rb{ctx, 2};
+            rb.Push(ERR_NOT_FOUND);
+            return;
+        }
+
+        NativeWindow native_window{*buffer_queue_id};
         IPC::ResponseBuilder rb{ctx, 6};
         rb.Push(RESULT_SUCCESS);
-        rb.Push(layer_id);
+        rb.Push(*layer_id);
         rb.Push<u64>(ctx.WriteBuffer(native_window.Serialize()));
     }
 
@@ -1089,6 +1124,11 @@ private:
         LOG_WARNING(Service_VI, "(STUBBED) called. display_id=0x{:016X}", display_id);
 
         const auto vsync_event = nv_flinger->FindVsyncEvent(display_id);
+        if (!vsync_event) {
+            IPC::ResponseBuilder rb{ctx, 2};
+            rb.Push(ERR_NOT_FOUND);
+            return;
+        }
 
         IPC::ResponseBuilder rb{ctx, 2, 1};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -1088,7 +1088,7 @@ private:
 
         LOG_WARNING(Service_VI, "(STUBBED) called. display_id=0x{:016X}", display_id);
 
-        const auto vsync_event = nv_flinger->GetVsyncEvent(display_id);
+        const auto vsync_event = nv_flinger->FindVsyncEvent(display_id);
 
         IPC::ResponseBuilder rb{ctx, 2, 1};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -71,15 +71,20 @@ static void MapPages(PageTable& page_table, VAddr base, u64 size, u8* memory, Pa
                                  FlushMode::FlushAndInvalidate);
 
     VAddr end = base + size;
-    while (base != end) {
-        ASSERT_MSG(base < page_table.pointers.size(), "out of range mapping at {:016X}", base);
+    ASSERT_MSG(end <= page_table.pointers.size(), "out of range mapping at {:016X}",
+               base + page_table.pointers.size());
 
-        page_table.attributes[base] = type;
-        page_table.pointers[base] = memory;
+    std::fill(page_table.attributes.begin() + base, page_table.attributes.begin() + end, type);
 
-        base += 1;
-        if (memory != nullptr)
+    if (memory == nullptr) {
+        std::fill(page_table.pointers.begin() + base, page_table.pointers.begin() + end, memory);
+    } else {
+        while (base != end) {
+            page_table.pointers[base] = memory;
+
+            base += 1;
             memory += PAGE_SIZE;
+        }
     }
 }
 

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -981,6 +981,10 @@ union Instruction {
             }
             return false;
         }
+
+        bool IsComponentEnabled(std::size_t component) const {
+            return ((1ul << component) & component_mask) != 0;
+        }
     } txq;
 
     union {

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -983,7 +983,7 @@ union Instruction {
         }
 
         bool IsComponentEnabled(std::size_t component) const {
-            return ((1ul << component) & component_mask) != 0;
+            return ((1ULL << component) & component_mask) != 0;
         }
     } txq;
 

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -217,9 +217,9 @@ enum class StoreType : u64 {
     Signed8 = 1,
     Unsigned16 = 2,
     Signed16 = 3,
-    Bytes32 = 4,
-    Bytes64 = 5,
-    Bytes128 = 6,
+    Bits32 = 4,
+    Bits64 = 5,
+    Bits128 = 6,
 };
 
 enum class IMinMaxExchange : u64 {

--- a/src/video_core/shader/decode/memory.cpp
+++ b/src/video_core/shader/decode/memory.cpp
@@ -104,16 +104,27 @@ u32 ShaderIR::DecodeMemory(BasicBlock& bb, const BasicBlock& code, u32 pc) {
     }
     case OpCode::Id::LD_L: {
         UNIMPLEMENTED_IF_MSG(instr.ld_l.unknown == 1, "LD_L Unhandled mode: {}",
-                             static_cast<unsigned>(instr.ld_l.unknown.Value()));
+                             static_cast<u32>(instr.ld_l.unknown.Value()));
 
-        const Node index = Operation(OperationCode::IAdd, GetRegister(instr.gpr8),
-                                     Immediate(static_cast<s32>(instr.smem_imm)));
-        const Node lmem = GetLocalMemory(index);
+        const auto GetLmem = [&](s32 offset) {
+            ASSERT(offset % 4 == 0);
+            const Node immediate_offset = Immediate(static_cast<s32>(instr.smem_imm) + offset);
+            const Node address = Operation(OperationCode::IAdd, NO_PRECISE, GetRegister(instr.gpr8),
+                                           immediate_offset);
+            return GetLocalMemory(address);
+        };
 
         switch (instr.ldst_sl.type.Value()) {
         case Tegra::Shader::StoreType::Bytes32:
-            SetRegister(bb, instr.gpr0, lmem);
+            SetRegister(bb, instr.gpr0, GetLmem(0));
             break;
+        case Tegra::Shader::StoreType::Bytes64: {
+            SetTemporal(bb, 0, GetLmem(0));
+            SetTemporal(bb, 1, GetLmem(4));
+            SetRegister(bb, instr.gpr0, GetTemporal(0));
+            SetRegister(bb, instr.gpr0.Value() + 1, GetTemporal(1));
+            break;
+        }
         default:
             UNIMPLEMENTED_MSG("LD_L Unhandled type: {}",
                               static_cast<unsigned>(instr.ldst_sl.type.Value()));

--- a/src/video_core/shader/decode/memory.cpp
+++ b/src/video_core/shader/decode/memory.cpp
@@ -115,10 +115,10 @@ u32 ShaderIR::DecodeMemory(BasicBlock& bb, const BasicBlock& code, u32 pc) {
         };
 
         switch (instr.ldst_sl.type.Value()) {
-        case Tegra::Shader::StoreType::Bytes32:
+        case Tegra::Shader::StoreType::Bits32:
             SetRegister(bb, instr.gpr0, GetLmem(0));
             break;
-        case Tegra::Shader::StoreType::Bytes64: {
+        case Tegra::Shader::StoreType::Bits64: {
             SetTemporal(bb, 0, GetLmem(0));
             SetTemporal(bb, 1, GetLmem(4));
             SetRegister(bb, instr.gpr0, GetTemporal(0));
@@ -127,7 +127,7 @@ u32 ShaderIR::DecodeMemory(BasicBlock& bb, const BasicBlock& code, u32 pc) {
         }
         default:
             UNIMPLEMENTED_MSG("LD_L Unhandled type: {}",
-                              static_cast<unsigned>(instr.ldst_sl.type.Value()));
+                              static_cast<u32>(instr.ldst_sl.type.Value()));
         }
         break;
     }
@@ -217,7 +217,7 @@ u32 ShaderIR::DecodeMemory(BasicBlock& bb, const BasicBlock& code, u32 pc) {
                                      Immediate(static_cast<s32>(instr.smem_imm)));
 
         switch (instr.ldst_sl.type.Value()) {
-        case Tegra::Shader::StoreType::Bytes32:
+        case Tegra::Shader::StoreType::Bits32:
             SetLocalMemory(bb, index, GetRegister(instr.gpr0));
             break;
         default:

--- a/src/video_core/shader/decode/memory.cpp
+++ b/src/video_core/shader/decode/memory.cpp
@@ -355,15 +355,18 @@ u32 ShaderIR::DecodeMemory(BasicBlock& bb, const BasicBlock& code, u32 pc) {
         const auto& sampler =
             GetSampler(instr.sampler, Tegra::Shader::TextureType::Texture2D, false, false);
 
+        u32 indexer = 0;
         switch (instr.txq.query_type) {
         case Tegra::Shader::TextureQueryType::Dimension: {
             for (u32 element = 0; element < 4; ++element) {
-                MetaTexture meta{sampler, element};
-                const Node value = Operation(OperationCode::F4TextureQueryDimensions,
-                                             std::move(meta), GetRegister(instr.gpr8));
-                SetTemporal(bb, element, value);
+                if (instr.txq.IsComponentEnabled(element)) {
+                    MetaTexture meta{sampler, element};
+                    const Node value = Operation(OperationCode::F4TextureQueryDimensions,
+                                                 std::move(meta), GetRegister(instr.gpr8));
+                    SetTemporal(bb, indexer++, value);
+                }
             }
-            for (u32 i = 0; i < 4; ++i) {
+            for (u32 i = 0; i < indexer; ++i) {
                 SetRegister(bb, instr.gpr0.Value() + i, GetTemporal(i));
             }
             break;

--- a/src/video_core/textures/texture.h
+++ b/src/video_core/textures/texture.h
@@ -182,7 +182,7 @@ struct TICEntry {
     };
     union {
         BitField<0, 16, u32> height_minus_1;
-        BitField<16, 15, u32> depth_minus_1;
+        BitField<16, 14, u32> depth_minus_1;
     };
     union {
         BitField<6, 13, u32> mip_lod_bias;

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -62,9 +62,7 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
         const QColor new_bg_color = QColorDialog::getColor(bg_color);
         if (!new_bg_color.isValid())
             return;
-        bg_color = new_bg_color;
-        ui->bg_button->setStyleSheet(
-            QString("QPushButton { background-color: %1 }").arg(bg_color.name()));
+        UpdateBackgroundColorButton(new_bg_color);
     });
 }
 
@@ -76,10 +74,8 @@ void ConfigureGraphics::setConfiguration() {
     ui->toggle_frame_limit->setChecked(Settings::values.use_frame_limit);
     ui->frame_limit->setValue(Settings::values.frame_limit);
     ui->use_accurate_gpu_emulation->setChecked(Settings::values.use_accurate_gpu_emulation);
-    bg_color = QColor::fromRgbF(Settings::values.bg_red, Settings::values.bg_green,
-                                Settings::values.bg_blue);
-    ui->bg_button->setStyleSheet(
-        QString("QPushButton { background-color: %1 }").arg(bg_color.name()));
+    UpdateBackgroundColorButton(QColor::fromRgbF(Settings::values.bg_red, Settings::values.bg_green,
+                                                 Settings::values.bg_blue));
 }
 
 void ConfigureGraphics::applyConfiguration() {
@@ -91,4 +87,14 @@ void ConfigureGraphics::applyConfiguration() {
     Settings::values.bg_red = static_cast<float>(bg_color.redF());
     Settings::values.bg_green = static_cast<float>(bg_color.greenF());
     Settings::values.bg_blue = static_cast<float>(bg_color.blueF());
+}
+
+void ConfigureGraphics::UpdateBackgroundColorButton(QColor color) {
+    bg_color = color;
+
+    QPixmap pixmap(ui->bg_button->size());
+    pixmap.fill(bg_color);
+
+    const QIcon color_icon(pixmap);
+    ui->bg_button->setIcon(color_icon);
 }

--- a/src/yuzu/configuration/configure_graphics.h
+++ b/src/yuzu/configuration/configure_graphics.h
@@ -23,6 +23,8 @@ public:
 private:
     void setConfiguration();
 
+    void UpdateBackgroundColorButton(QColor color);
+
     std::unique_ptr<Ui::ConfigureGraphics> ui;
     QColor bg_color;
 };

--- a/src/yuzu/loading_screen.ui
+++ b/src/yuzu/loading_screen.ui
@@ -132,7 +132,7 @@ border-radius: 15px;
 font: 75 15pt &quot;Arial&quot;;</string>
           </property>
           <property name="text">
-           <string>Stage 1 of 2. Estimate Time 5m 4s</string>
+           <string>Estimated Time 5m 4s</string>
           </property>
          </widget>
         </item>
@@ -145,6 +145,9 @@ font: 75 15pt &quot;Arial&quot;;</string>
         </property>
         <property name="text">
          <string/>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
         </property>
         <property name="margin">
          <number>30</number>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1686,12 +1686,12 @@ void GMainWindow::OnCaptureScreenshot() {
                            tr("PNG Image (*.png)"));
     png_dialog.setAcceptMode(QFileDialog::AcceptSave);
     png_dialog.setDefaultSuffix("png");
-    png_dialog.exec();
-
-    const QString path = png_dialog.selectedFiles().first();
-    if (!path.isEmpty()) {
-        UISettings::values.screenshot_path = QFileInfo(path).path();
-        render_window->CaptureScreenshot(UISettings::values.screenshot_resolution_factor, path);
+    if (png_dialog.exec()) {
+        const QString path = png_dialog.selectedFiles().first();
+        if (!path.isEmpty()) {
+            UISettings::values.screenshot_path = QFileInfo(path).path();
+            render_window->CaptureScreenshot(UISettings::values.screenshot_resolution_factor, path);
+        }
     }
     OnStartGame();
 }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1682,9 +1682,13 @@ void GMainWindow::OnToggleFilterBar() {
 
 void GMainWindow::OnCaptureScreenshot() {
     OnPauseGame();
-    const QString path =
-        QFileDialog::getSaveFileName(this, tr("Capture Screenshot"),
-                                     UISettings::values.screenshot_path, tr("PNG Image (*.png)"));
+    QFileDialog png_dialog(this, tr("Capture Screenshot"), UISettings::values.screenshot_path,
+                           tr("PNG Image (*.png)"));
+    png_dialog.setAcceptMode(QFileDialog::AcceptSave);
+    png_dialog.setDefaultSuffix("png");
+    png_dialog.exec();
+
+    const QString path = png_dialog.selectedFiles().first();
     if (!path.isEmpty()) {
         UISettings::values.screenshot_path = QFileInfo(path).path();
         render_window->CaptureScreenshot(UISettings::values.screenshot_resolution_factor, path);


### PR DESCRIPTION
split up of type and mapping writes to have better cache optimizing
using std::fill which is much more efficient than doing it byte by byte