### PR TITLE
video_core/texture: Fix BitField size for depth_minus_one

### DIFF
--- a/src/video_core/textures/texture.h
+++ b/src/video_core/textures/texture.h
@@ -182,7 +182,7 @@ struct TICEntry {
     };
     union {
         BitField<0, 16, u32> height_minus_1;
-        BitField<16, 15, u32> depth_minus_1;
+        BitField<16, 14, u32> depth_minus_1;
     };
     union {
         BitField<6, 13, u32> mip_lod_bias;


### PR DESCRIPTION
Thanks to @ogniK5377 for finding an effect of this bug. If my maths don't fail me this should have a size of 14 instead of 15:
`29 - 16 + 1 = 14`

Sizes taken from: https://github.com/envytools/envytools/blob/c837aa9218b7dd7616a09ef4d5b3ad3cceabfaec/rnndb/graph/gm200_texture.xml#L367

This let's Octopath Traveler get in-game.