### PR TITLE
Port citra-emu/citra#4583: "citra_qt: Fix saving screenshot when no file extension is provided"

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1686,12 +1686,12 @@ void GMainWindow::OnCaptureScreenshot() {
                            tr("PNG Image (*.png)"));
     png_dialog.setAcceptMode(QFileDialog::AcceptSave);
     png_dialog.setDefaultSuffix("png");
-    png_dialog.exec();
-
-    const QString path = png_dialog.selectedFiles().first();
-    if (!path.isEmpty()) {
-        UISettings::values.screenshot_path = QFileInfo(path).path();
-        render_window->CaptureScreenshot(UISettings::values.screenshot_resolution_factor, path);
+    if (png_dialog.exec()) {
+        const QString path = png_dialog.selectedFiles().first();
+        if (!path.isEmpty()) {
+            UISettings::values.screenshot_path = QFileInfo(path).path();
+            render_window->CaptureScreenshot(UISettings::values.screenshot_resolution_factor, path);
+        }
     }
     OnStartGame();
 }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1682,9 +1682,13 @@ void GMainWindow::OnToggleFilterBar() {
 
 void GMainWindow::OnCaptureScreenshot() {
     OnPauseGame();
-    const QString path =
-        QFileDialog::getSaveFileName(this, tr("Capture Screenshot"),
-                                     UISettings::values.screenshot_path, tr("PNG Image (*.png)"));
+    QFileDialog png_dialog(this, tr("Capture Screenshot"), UISettings::values.screenshot_path,
+                           tr("PNG Image (*.png)"));
+    png_dialog.setAcceptMode(QFileDialog::AcceptSave);
+    png_dialog.setDefaultSuffix("png");
+    png_dialog.exec();
+
+    const QString path = png_dialog.selectedFiles().first();
     if (!path.isEmpty()) {
         UISettings::values.screenshot_path = QFileInfo(path).path();
         render_window->CaptureScreenshot(UISettings::values.screenshot_resolution_factor, path);


### PR DESCRIPTION
See citra-emu/citra#4583 for more details.

**Original description**:
By default, Qt doesn't add an extension to files if none is explicitly typed by the user.
As such, screenshots would silently fail to save if a user did not type an extension.

This fix creates a full QFileDialog instead of using the getSaveFileName shortcut so a default suffix can be added.
