### PR TITLE
frontend: Open transferable shader cache for a selected game in the gamelist

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -329,6 +329,8 @@ void GameList::PopupContextMenu(const QPoint& menu_location) {
     QMenu context_menu;
     QAction* open_save_location = context_menu.addAction(tr("Open Save Data Location"));
     QAction* open_lfs_location = context_menu.addAction(tr("Open Mod Data Location"));
+    QAction* open_transferable_shader_cache =
+        context_menu.addAction(tr("Open Transferable Shader Cache"));
     context_menu.addSeparator();
     QAction* dump_romfs = context_menu.addAction(tr("Dump RomFS"));
     QAction* copy_tid = context_menu.addAction(tr("Copy Title ID to Clipboard"));
@@ -344,6 +346,8 @@ void GameList::PopupContextMenu(const QPoint& menu_location) {
             [&]() { emit OpenFolderRequested(program_id, GameListOpenTarget::SaveData); });
     connect(open_lfs_location, &QAction::triggered,
             [&]() { emit OpenFolderRequested(program_id, GameListOpenTarget::ModData); });
+    connect(open_transferable_shader_cache, &QAction::triggered,
+            [&]() { emit OpenTransferableShaderCacheRequested(program_id); });
     connect(dump_romfs, &QAction::triggered, [&]() { emit DumpRomFSRequested(program_id, path); });
     connect(copy_tid, &QAction::triggered, [&]() { emit CopyTIDRequested(program_id); });
     connect(navigate_to_gamedb_entry, &QAction::triggered,

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -66,6 +66,7 @@ signals:
     void GameChosen(QString game_path);
     void ShouldCancelWorker();
     void OpenFolderRequested(u64 program_id, GameListOpenTarget target);
+    void OpenTransferableShaderCacheRequested(u64 program_id);
     void DumpRomFSRequested(u64 program_id, const std::string& game_path);
     void CopyTIDRequested(u64 program_id);
     void NavigateToGamedbEntryRequested(u64 program_id,

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1072,7 +1072,7 @@ void GMainWindow::OnTransferableShaderCacheOpenFile(u64 program_id) {
     ASSERT(program_id != 0);
 
     std::string transferable_shader_cache_file_path;
-    const std::string open_target = "Transferable Shader Cache";
+    constexpr char open_target[] = "Transferable Shader Cache";
     const std::string tranferable_shader_cache_folder =
         FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir) + "opengl" + DIR_SEP "transferable";
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1071,21 +1071,16 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
 void GMainWindow::OnTransferableShaderCacheOpenFile(u64 program_id) {
     ASSERT(program_id != 0);
 
-    std::string transferable_shader_cache_file_path;
     constexpr char open_target[] = "Transferable Shader Cache";
-    const std::string tranferable_shader_cache_folder =
-        FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir) + "opengl" + DIR_SEP "transferable";
+    const QString tranferable_shader_cache_folder_path =
+        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir)) + "opengl" +
+        DIR_SEP + "transferable";
 
-    transferable_shader_cache_file_path.append(tranferable_shader_cache_folder);
-    transferable_shader_cache_file_path.append(DIR_SEP);
-    transferable_shader_cache_file_path.append(fmt::format("{:016X}", program_id));
-    transferable_shader_cache_file_path.append(".bin");
+    const QString transferable_shader_cache_file_path =
+        tranferable_shader_cache_folder_path + DIR_SEP +
+        QString::fromStdString(fmt::format("{:016X}", program_id)) + ".bin";
 
-    const QString qpath_transferable_shader_cache_file =
-        QString::fromStdString(transferable_shader_cache_file_path);
-
-    const QFile qfile(qpath_transferable_shader_cache_file);
-    if (!qfile.exists()) {
+    if (!QFile(transferable_shader_cache_file_path).exists()) {
         QMessageBox::warning(this,
                              tr("Error Opening %1 File").arg(QString::fromStdString(open_target)),
                              tr("File does not exist!"));
@@ -1099,14 +1094,13 @@ void GMainWindow::OnTransferableShaderCacheOpenFile(u64 program_id) {
 #if defined(Q_OS_WIN)
     const QString explorer = "explorer";
     QStringList param;
-    if (!QFileInfo(qpath_transferable_shader_cache_file).isDir())
+    if (!QFileInfo(transferable_shader_cache_file_path).isDir()) {
         param << QLatin1String("/select,");
-    param << QDir::toNativeSeparators(qpath_transferable_shader_cache_file);
+    }
+    param << QDir::toNativeSeparators(transferable_shader_cache_file_path);
     QProcess::startDetached(explorer, param);
 #else
-    const QString qpath_transferable_shader_cache_folder =
-        QString::fromStdString(tranferable_shader_cache_folder);
-    QDesktopServices::openUrl(QUrl::fromLocalFile(qpath_transferable_shader_cache_folder));
+    QDesktopServices::openUrl(QUrl::fromLocalFile(tranferable_shader_cache_folder_path));
 #endif
 }
 

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -176,6 +176,7 @@ private slots:
     /// Called whenever a user selects a game in the game list widget.
     void OnGameListLoadFile(QString game_path);
     void OnGameListOpenFolder(u64 program_id, GameListOpenTarget target);
+    void OnTransferableShaderCacheOpenFile(u64 program_id);
     void OnGameListDumpRomFS(u64 program_id, const std::string& game_path);
     void OnGameListCopyTID(u64 program_id);
     void OnGameListNavigateToGamedbEntry(u64 program_id,


### PR DESCRIPTION
This PR adds option to open the transferable shader cache.
![image](https://user-images.githubusercontent.com/27208977/52466091-63674a80-2b81-11e9-947b-cf0ad01e4bb1.png)

On every OS the transferable shader cache folder opens. On Windows devices the transferable shader cache file for the selected game gets preselected as well.
![image](https://user-images.githubusercontent.com/27208977/52466173-bfca6a00-2b81-11e9-838c-42a3bb228e05.png)

If no transferable shader cache is present for the selected game, the following warning opens. No file explorer window opens in this case.
![image](https://user-images.githubusercontent.com/27208977/52466575-0a98b180-2b83-11e9-9f9d-f62bfe85e032.png)
