### PR TITLE
Corrected F2I None mode to RoundEven.

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -186,7 +186,7 @@ enum class SubOp : u64 {
 };
 
 enum class F2iRoundingOp : u64 {
-    None = 0,
+    RoundEven = 0,
     Floor = 1,
     Ceil = 2,
     Trunc = 3,

--- a/src/video_core/shader/decode/conversion.cpp
+++ b/src/video_core/shader/decode/conversion.cpp
@@ -118,8 +118,8 @@ u32 ShaderIR::DecodeConversion(NodeBlock& bb, u32 pc) {
 
         value = [&]() {
             switch (instr.conversion.f2i.rounding) {
-            case Tegra::Shader::F2iRoundingOp::None:
-                return value;
+            case Tegra::Shader::F2iRoundingOp::RoundEven:
+                return Operation(OperationCode::FRoundEven, PRECISE, value);
             case Tegra::Shader::F2iRoundingOp::Floor:
                 return Operation(OperationCode::FFloor, PRECISE, value);
             case Tegra::Shader::F2iRoundingOp::Ceil:


### PR DESCRIPTION
I noticed there was a trunc mode and a none mode which effectively did the same. After some hardware tests, it turns out that None mode was actualy RoundEven mode.