### PR TITLE
core_timing: Rename CoreTiming namespace to Core::Timing

### DIFF
--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -37,7 +37,7 @@ Stream::Stream(u32 sample_rate, Format format, ReleaseCallback&& release_callbac
     : sample_rate{sample_rate}, format{format}, release_callback{std::move(release_callback)},
       sink_stream{sink_stream}, name{std::move(name_)} {
 
-    release_event = CoreTiming::RegisterEvent(
+    release_event = Core::Timing::RegisterEvent(
         name, [this](u64 userdata, int cycles_late) { ReleaseActiveBuffer(); });
 }
 
@@ -57,7 +57,7 @@ Stream::State Stream::GetState() const {
 
 s64 Stream::GetBufferReleaseCycles(const Buffer& buffer) const {
     const std::size_t num_samples{buffer.GetSamples().size() / GetNumChannels()};
-    return CoreTiming::usToCycles((static_cast<u64>(num_samples) * 1000000) / sample_rate);
+    return Core::Timing::usToCycles((static_cast<u64>(num_samples) * 1000000) / sample_rate);
 }
 
 static void VolumeAdjustSamples(std::vector<s16>& samples) {
@@ -99,7 +99,8 @@ void Stream::PlayNextBuffer() {
 
     sink_stream.EnqueueSamples(GetNumChannels(), active_buffer->GetSamples());
 
-    CoreTiming::ScheduleEventThreadsafe(GetBufferReleaseCycles(*active_buffer), release_event, {});
+    Core::Timing::ScheduleEventThreadsafe(GetBufferReleaseCycles(*active_buffer), release_event,
+                                          {});
 }
 
 void Stream::ReleaseActiveBuffer() {

--- a/src/audio_core/stream.h
+++ b/src/audio_core/stream.h
@@ -13,7 +13,7 @@
 #include "audio_core/buffer.h"
 #include "common/common_types.h"
 
-namespace CoreTiming {
+namespace Core::Timing {
 struct EventType;
 }
 
@@ -91,16 +91,16 @@ private:
     /// Gets the number of core cycles when the specified buffer will be released
     s64 GetBufferReleaseCycles(const Buffer& buffer) const;
 
-    u32 sample_rate;                        ///< Sample rate of the stream
-    Format format;                          ///< Format of the stream
-    ReleaseCallback release_callback;       ///< Buffer release callback for the stream
-    State state{State::Stopped};            ///< Playback state of the stream
-    CoreTiming::EventType* release_event{}; ///< Core timing release event for the stream
-    BufferPtr active_buffer;                ///< Actively playing buffer in the stream
-    std::queue<BufferPtr> queued_buffers;   ///< Buffers queued to be played in the stream
-    std::queue<BufferPtr> released_buffers; ///< Buffers recently released from the stream
-    SinkStream& sink_stream;                ///< Output sink for the stream
-    std::string name;                       ///< Name of the stream, must be unique
+    u32 sample_rate;                          ///< Sample rate of the stream
+    Format format;                            ///< Format of the stream
+    ReleaseCallback release_callback;         ///< Buffer release callback for the stream
+    State state{State::Stopped};              ///< Playback state of the stream
+    Core::Timing::EventType* release_event{}; ///< Core timing release event for the stream
+    BufferPtr active_buffer;                  ///< Actively playing buffer in the stream
+    std::queue<BufferPtr> queued_buffers;     ///< Buffers queued to be played in the stream
+    std::queue<BufferPtr> released_buffers;   ///< Buffers recently released from the stream
+    SinkStream& sink_stream;                  ///< Output sink for the stream
+    std::string name;                         ///< Name of the stream, must be unique
 };
 
 using StreamPtr = std::shared_ptr<Stream>;

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -112,14 +112,14 @@ public:
         // Always execute at least one tick.
         amortized_ticks = std::max<u64>(amortized_ticks, 1);
 
-        CoreTiming::AddTicks(amortized_ticks);
+        Timing::AddTicks(amortized_ticks);
         num_interpreted_instructions = 0;
     }
     u64 GetTicksRemaining() override {
-        return std::max(CoreTiming::GetDowncount(), 0);
+        return std::max(Timing::GetDowncount(), 0);
     }
     u64 GetCNTPCT() override {
-        return CoreTiming::GetTicks();
+        return Timing::GetTicks();
     }
 
     ARM_Dynarmic& parent;

--- a/src/core/arm/unicorn/arm_unicorn.cpp
+++ b/src/core/arm/unicorn/arm_unicorn.cpp
@@ -177,7 +177,7 @@ void ARM_Unicorn::Run() {
     if (GDBStub::IsServerEnabled()) {
         ExecuteInstructions(std::max(4000000, 0));
     } else {
-        ExecuteInstructions(std::max(CoreTiming::GetDowncount(), 0));
+        ExecuteInstructions(std::max(Timing::GetDowncount(), 0));
     }
 }
 
@@ -190,7 +190,7 @@ MICROPROFILE_DEFINE(ARM_Jit_Unicorn, "ARM JIT", "Unicorn", MP_RGB(255, 64, 64));
 void ARM_Unicorn::ExecuteInstructions(int num_instructions) {
     MICROPROFILE_SCOPE(ARM_Jit_Unicorn);
     CHECKED(uc_emu_start(uc, GetPC(), 1ULL << 63, 0, num_instructions));
-    CoreTiming::AddTicks(num_instructions);
+    Timing::AddTicks(num_instructions);
     if (GDBStub::IsServerEnabled()) {
         if (last_bkpt_hit) {
             uc_reg_write(uc, UC_ARM64_REG_PC, &last_bkpt.address);

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -94,7 +94,7 @@ struct System::Impl {
     ResultStatus Init(System& system, Frontend::EmuWindow& emu_window) {
         LOG_DEBUG(HW_Memory, "initialized OK");
 
-        CoreTiming::Init();
+        Timing::Init();
         kernel.Initialize();
 
         const auto current_time = std::chrono::duration_cast<std::chrono::seconds>(
@@ -205,7 +205,7 @@ struct System::Impl {
 
         // Shutdown kernel and core timing
         kernel.Shutdown();
-        CoreTiming::Shutdown();
+        Timing::Shutdown();
 
         // Close app loader
         app_loader.reset();
@@ -232,7 +232,7 @@ struct System::Impl {
     }
 
     PerfStatsResults GetAndResetPerfStats() {
-        return perf_stats.GetAndResetStats(CoreTiming::GetGlobalTimeUs());
+        return perf_stats.GetAndResetStats(Timing::GetGlobalTimeUs());
     }
 
     Kernel::KernelCore kernel;

--- a/src/core/core_cpu.cpp
+++ b/src/core/core_cpu.cpp
@@ -93,14 +93,14 @@ void Cpu::RunLoop(bool tight_loop) {
 
         if (IsMainCore()) {
             // TODO(Subv): Only let CoreTiming idle if all 4 cores are idling.
-            CoreTiming::Idle();
-            CoreTiming::Advance();
+            Timing::Idle();
+            Timing::Advance();
         }
 
         PrepareReschedule();
     } else {
         if (IsMainCore()) {
-            CoreTiming::Advance();
+            Timing::Advance();
         }
 
         if (tight_loop) {

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -15,7 +15,7 @@
 #include "common/threadsafe_queue.h"
 #include "core/core_timing_util.h"
 
-namespace CoreTiming {
+namespace Core::Timing {
 
 static s64 global_timer;
 static int slice_length;
@@ -242,4 +242,4 @@ int GetDowncount() {
     return downcount;
 }
 
-} // namespace CoreTiming
+} // namespace Core::Timing

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -22,7 +22,7 @@
 #include <string>
 #include "common/common_types.h"
 
-namespace CoreTiming {
+namespace Core::Timing {
 
 struct EventType;
 
@@ -92,4 +92,4 @@ std::chrono::microseconds GetGlobalTimeUs();
 
 int GetDowncount();
 
-} // namespace CoreTiming
+} // namespace Core::Timing

--- a/src/core/core_timing_util.cpp
+++ b/src/core/core_timing_util.cpp
@@ -8,7 +8,7 @@
 #include <limits>
 #include "common/logging/log.h"
 
-namespace CoreTiming {
+namespace Core::Timing {
 
 constexpr u64 MAX_VALUE_TO_MULTIPLY = std::numeric_limits<s64>::max() / BASE_CLOCK_RATE;
 
@@ -60,4 +60,4 @@ s64 nsToCycles(u64 ns) {
     return (BASE_CLOCK_RATE * static_cast<s64>(ns)) / 1000000000;
 }
 
-} // namespace CoreTiming
+} // namespace Core::Timing

--- a/src/core/core_timing_util.h
+++ b/src/core/core_timing_util.h
@@ -6,7 +6,7 @@
 
 #include "common/common_types.h"
 
-namespace CoreTiming {
+namespace Core::Timing {
 
 // The below clock rate is based on Switch's clockspeed being widely known as 1.020GHz
 // The exact value used is of course unverified.
@@ -61,4 +61,4 @@ inline u64 cyclesToMs(s64 cycles) {
     return cycles * 1000 / BASE_CLOCK_RATE;
 }
 
-} // namespace CoreTiming
+} // namespace Core::Timing

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -124,7 +124,7 @@ struct KernelCore::Impl {
 
     void InitializeThreads() {
         thread_wakeup_event_type =
-            CoreTiming::RegisterEvent("ThreadWakeupCallback", ThreadWakeupCallback);
+            Core::Timing::RegisterEvent("ThreadWakeupCallback", ThreadWakeupCallback);
     }
 
     std::atomic<u32> next_object_id{0};
@@ -137,7 +137,7 @@ struct KernelCore::Impl {
 
     SharedPtr<ResourceLimit> system_resource_limit;
 
-    CoreTiming::EventType* thread_wakeup_event_type = nullptr;
+    Core::Timing::EventType* thread_wakeup_event_type = nullptr;
     // TODO(yuriks): This can be removed if Thread objects are explicitly pooled in the future,
     // allowing us to simply use a pool index or similar.
     Kernel::HandleTable thread_wakeup_callback_handle_table;
@@ -213,7 +213,7 @@ u64 KernelCore::CreateNewProcessID() {
     return impl->next_process_id++;
 }
 
-CoreTiming::EventType* KernelCore::ThreadWakeupCallbackEventType() const {
+Core::Timing::EventType* KernelCore::ThreadWakeupCallbackEventType() const {
     return impl->thread_wakeup_event_type;
 }
 

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -11,7 +11,7 @@
 template <typename T>
 class ResultVal;
 
-namespace CoreTiming {
+namespace Core::Timing {
 struct EventType;
 }
 
@@ -89,7 +89,7 @@ private:
     u64 CreateNewThreadID();
 
     /// Retrieves the event type used for thread wakeup callbacks.
-    CoreTiming::EventType* ThreadWakeupCallbackEventType() const;
+    Core::Timing::EventType* ThreadWakeupCallbackEventType() const;
 
     /// Provides a reference to the thread wakeup callback handle table.
     Kernel::HandleTable& ThreadWakeupCallbackHandleTable();

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -111,7 +111,7 @@ void Scheduler::SwitchContext(Thread* new_thread) {
 
 void Scheduler::UpdateLastContextSwitchTime(Thread* thread, Process* process) {
     const u64 prev_switch_ticks = last_context_switch_time;
-    const u64 most_recent_switch_ticks = CoreTiming::GetTicks();
+    const u64 most_recent_switch_ticks = Core::Timing::GetTicks();
     const u64 update_ticks = most_recent_switch_ticks - prev_switch_ticks;
 
     if (thread != nullptr) {

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -927,9 +927,9 @@ static ResultCode GetInfo(u64* result, u64 info_id, u64 handle, u64 info_sub_id)
         if (same_thread && info_sub_id == 0xFFFFFFFFFFFFFFFF) {
             const u64 thread_ticks = current_thread->GetTotalCPUTimeTicks();
 
-            out_ticks = thread_ticks + (CoreTiming::GetTicks() - prev_ctx_ticks);
+            out_ticks = thread_ticks + (Core::Timing::GetTicks() - prev_ctx_ticks);
         } else if (same_thread && info_sub_id == system.CurrentCoreIndex()) {
-            out_ticks = CoreTiming::GetTicks() - prev_ctx_ticks;
+            out_ticks = Core::Timing::GetTicks() - prev_ctx_ticks;
         }
 
         *result = out_ticks;
@@ -1546,10 +1546,10 @@ static ResultCode SignalToAddress(VAddr address, u32 type, s32 value, s32 num_to
 static u64 GetSystemTick() {
     LOG_TRACE(Kernel_SVC, "called");
 
-    const u64 result{CoreTiming::GetTicks()};
+    const u64 result{Core::Timing::GetTicks()};
 
     // Advance time to defeat dumb games that busy-wait for the frame to end.
-    CoreTiming::AddTicks(400);
+    Core::Timing::AddTicks(400);
 
     return result;
 }

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -43,7 +43,7 @@ Thread::~Thread() = default;
 
 void Thread::Stop() {
     // Cancel any outstanding wakeup events for this thread
-    CoreTiming::UnscheduleEvent(kernel.ThreadWakeupCallbackEventType(), callback_handle);
+    Core::Timing::UnscheduleEvent(kernel.ThreadWakeupCallbackEventType(), callback_handle);
     kernel.ThreadWakeupCallbackHandleTable().Close(callback_handle);
     callback_handle = 0;
 
@@ -85,12 +85,13 @@ void Thread::WakeAfterDelay(s64 nanoseconds) {
 
     // This function might be called from any thread so we have to be cautious and use the
     // thread-safe version of ScheduleEvent.
-    CoreTiming::ScheduleEventThreadsafe(CoreTiming::nsToCycles(nanoseconds),
-                                        kernel.ThreadWakeupCallbackEventType(), callback_handle);
+    Core::Timing::ScheduleEventThreadsafe(Core::Timing::nsToCycles(nanoseconds),
+                                          kernel.ThreadWakeupCallbackEventType(), callback_handle);
 }
 
 void Thread::CancelWakeupTimer() {
-    CoreTiming::UnscheduleEventThreadsafe(kernel.ThreadWakeupCallbackEventType(), callback_handle);
+    Core::Timing::UnscheduleEventThreadsafe(kernel.ThreadWakeupCallbackEventType(),
+                                            callback_handle);
 }
 
 static std::optional<s32> GetNextProcessorId(u64 mask) {
@@ -197,7 +198,7 @@ ResultVal<SharedPtr<Thread>> Thread::Create(KernelCore& kernel, std::string name
     thread->stack_top = stack_top;
     thread->tpidr_el0 = 0;
     thread->nominal_priority = thread->current_priority = priority;
-    thread->last_running_ticks = CoreTiming::GetTicks();
+    thread->last_running_ticks = Core::Timing::GetTicks();
     thread->processor_id = processor_id;
     thread->ideal_core = processor_id;
     thread->affinity_mask = 1ULL << processor_id;
@@ -257,7 +258,7 @@ void Thread::SetStatus(ThreadStatus new_status) {
     }
 
     if (status == ThreadStatus::Running) {
-        last_running_ticks = CoreTiming::GetTicks();
+        last_running_ticks = Core::Timing::GetTicks();
     }
 
     status = new_status;

--- a/src/core/hle/service/hid/controllers/debug_pad.cpp
+++ b/src/core/hle/service/hid/controllers/debug_pad.cpp
@@ -22,7 +22,7 @@ void Controller_DebugPad::OnInit() {}
 void Controller_DebugPad::OnRelease() {}
 
 void Controller_DebugPad::OnUpdate(u8* data, std::size_t size) {
-    shared_memory.header.timestamp = CoreTiming::GetTicks();
+    shared_memory.header.timestamp = Core::Timing::GetTicks();
     shared_memory.header.total_entry_count = 17;
 
     if (!IsControllerActivated()) {

--- a/src/core/hle/service/hid/controllers/gesture.cpp
+++ b/src/core/hle/service/hid/controllers/gesture.cpp
@@ -18,7 +18,7 @@ void Controller_Gesture::OnInit() {}
 void Controller_Gesture::OnRelease() {}
 
 void Controller_Gesture::OnUpdate(u8* data, std::size_t size) {
-    shared_memory.header.timestamp = CoreTiming::GetTicks();
+    shared_memory.header.timestamp = Core::Timing::GetTicks();
     shared_memory.header.total_entry_count = 17;
 
     if (!IsControllerActivated()) {

--- a/src/core/hle/service/hid/controllers/keyboard.cpp
+++ b/src/core/hle/service/hid/controllers/keyboard.cpp
@@ -20,7 +20,7 @@ void Controller_Keyboard::OnInit() {}
 void Controller_Keyboard::OnRelease() {}
 
 void Controller_Keyboard::OnUpdate(u8* data, std::size_t size) {
-    shared_memory.header.timestamp = CoreTiming::GetTicks();
+    shared_memory.header.timestamp = Core::Timing::GetTicks();
     shared_memory.header.total_entry_count = 17;
 
     if (!IsControllerActivated()) {

--- a/src/core/hle/service/hid/controllers/mouse.cpp
+++ b/src/core/hle/service/hid/controllers/mouse.cpp
@@ -18,7 +18,7 @@ void Controller_Mouse::OnInit() {}
 void Controller_Mouse::OnRelease() {}
 
 void Controller_Mouse::OnUpdate(u8* data, std::size_t size) {
-    shared_memory.header.timestamp = CoreTiming::GetTicks();
+    shared_memory.header.timestamp = Core::Timing::GetTicks();
     shared_memory.header.total_entry_count = 17;
 
     if (!IsControllerActivated()) {

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -308,7 +308,7 @@ void Controller_NPad::OnUpdate(u8* data, std::size_t data_len) {
             const auto& last_entry =
                 main_controller->npad[main_controller->common.last_entry_index];
 
-            main_controller->common.timestamp = CoreTiming::GetTicks();
+            main_controller->common.timestamp = Core::Timing::GetTicks();
             main_controller->common.last_entry_index =
                 (main_controller->common.last_entry_index + 1) % 17;
 

--- a/src/core/hle/service/hid/controllers/stubbed.cpp
+++ b/src/core/hle/service/hid/controllers/stubbed.cpp
@@ -22,7 +22,7 @@ void Controller_Stubbed::OnUpdate(u8* data, std::size_t size) {
     }
 
     CommonHeader header{};
-    header.timestamp = CoreTiming::GetTicks();
+    header.timestamp = Core::Timing::GetTicks();
     header.total_entry_count = 17;
     header.entry_count = 0;
     header.last_entry_index = 0;

--- a/src/core/hle/service/hid/controllers/touchscreen.cpp
+++ b/src/core/hle/service/hid/controllers/touchscreen.cpp
@@ -21,7 +21,7 @@ void Controller_Touchscreen::OnInit() {}
 void Controller_Touchscreen::OnRelease() {}
 
 void Controller_Touchscreen::OnUpdate(u8* data, std::size_t size) {
-    shared_memory.header.timestamp = CoreTiming::GetTicks();
+    shared_memory.header.timestamp = Core::Timing::GetTicks();
     shared_memory.header.total_entry_count = 17;
 
     if (!IsControllerActivated()) {
@@ -48,7 +48,7 @@ void Controller_Touchscreen::OnUpdate(u8* data, std::size_t size) {
         touch_entry.diameter_x = Settings::values.touchscreen.diameter_x;
         touch_entry.diameter_y = Settings::values.touchscreen.diameter_y;
         touch_entry.rotation_angle = Settings::values.touchscreen.rotation_angle;
-        const u64 tick = CoreTiming::GetTicks();
+        const u64 tick = Core::Timing::GetTicks();
         touch_entry.delta_time = tick - last_touch;
         last_touch = tick;
         touch_entry.finger = Settings::values.touchscreen.finger;

--- a/src/core/hle/service/hid/controllers/xpad.cpp
+++ b/src/core/hle/service/hid/controllers/xpad.cpp
@@ -19,7 +19,7 @@ void Controller_XPad::OnRelease() {}
 
 void Controller_XPad::OnUpdate(u8* data, std::size_t size) {
     for (auto& xpad_entry : shared_memory.shared_memory_entries) {
-        xpad_entry.header.timestamp = CoreTiming::GetTicks();
+        xpad_entry.header.timestamp = Core::Timing::GetTicks();
         xpad_entry.header.total_entry_count = 17;
 
         if (!IsControllerActivated()) {

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -36,9 +36,9 @@ namespace Service::HID {
 
 // Updating period for each HID device.
 // TODO(ogniK): Find actual polling rate of hid
-constexpr u64 pad_update_ticks = CoreTiming::BASE_CLOCK_RATE / 66;
-constexpr u64 accelerometer_update_ticks = CoreTiming::BASE_CLOCK_RATE / 100;
-constexpr u64 gyroscope_update_ticks = CoreTiming::BASE_CLOCK_RATE / 100;
+constexpr u64 pad_update_ticks = Core::Timing::BASE_CLOCK_RATE / 66;
+constexpr u64 accelerometer_update_ticks = Core::Timing::BASE_CLOCK_RATE / 100;
+constexpr u64 gyroscope_update_ticks = Core::Timing::BASE_CLOCK_RATE / 100;
 constexpr std::size_t SHARED_MEMORY_SIZE = 0x40000;
 
 IAppletResource::IAppletResource() : ServiceFramework("IAppletResource") {
@@ -73,14 +73,13 @@ IAppletResource::IAppletResource() : ServiceFramework("IAppletResource") {
     GetController<Controller_Stubbed>(HidController::Unknown3).SetCommonHeaderOffset(0x5000);
 
     // Register update callbacks
-    pad_update_event =
-        CoreTiming::RegisterEvent("HID::UpdatePadCallback", [this](u64 userdata, int cycles_late) {
-            UpdateControllers(userdata, cycles_late);
-        });
+    pad_update_event = Core::Timing::RegisterEvent(
+        "HID::UpdatePadCallback",
+        [this](u64 userdata, int cycles_late) { UpdateControllers(userdata, cycles_late); });
 
     // TODO(shinyquagsire23): Other update callbacks? (accel, gyro?)
 
-    CoreTiming::ScheduleEvent(pad_update_ticks, pad_update_event);
+    Core::Timing::ScheduleEvent(pad_update_ticks, pad_update_event);
 
     ReloadInputDevices();
 }
@@ -94,7 +93,7 @@ void IAppletResource::DeactivateController(HidController controller) {
 }
 
 IAppletResource ::~IAppletResource() {
-    CoreTiming::UnscheduleEvent(pad_update_event, 0);
+    Core::Timing::UnscheduleEvent(pad_update_event, 0);
 }
 
 void IAppletResource::GetSharedMemoryHandle(Kernel::HLERequestContext& ctx) {
@@ -114,7 +113,7 @@ void IAppletResource::UpdateControllers(u64 userdata, int cycles_late) {
         controller->OnUpdate(shared_mem->GetPointer(), SHARED_MEMORY_SIZE);
     }
 
-    CoreTiming::ScheduleEvent(pad_update_ticks - cycles_late, pad_update_event);
+    Core::Timing::ScheduleEvent(pad_update_ticks - cycles_late, pad_update_event);
 }
 
 class IActiveVibrationDeviceList final : public ServiceFramework<IActiveVibrationDeviceList> {

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -7,7 +7,7 @@
 #include "controllers/controller_base.h"
 #include "core/hle/service/service.h"
 
-namespace CoreTiming {
+namespace Core::Timing {
 struct EventType;
 }
 
@@ -66,7 +66,7 @@ private:
 
     Kernel::SharedPtr<Kernel::SharedMemory> shared_mem;
 
-    CoreTiming::EventType* pad_update_event;
+    Core::Timing::EventType* pad_update_event;
 
     std::array<std::unique_ptr<ControllerBase>, static_cast<size_t>(HidController::MaxControllers)>
         controllers{};

--- a/src/core/hle/service/hid/irs.cpp
+++ b/src/core/hle/service/hid/irs.cpp
@@ -98,7 +98,7 @@ void IRS::GetImageTransferProcessorState(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 5};
     rb.Push(RESULT_SUCCESS);
-    rb.PushRaw<u64>(CoreTiming::GetTicks());
+    rb.PushRaw<u64>(Core::Timing::GetTicks());
     rb.PushRaw<u32>(0);
 }
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
@@ -184,7 +184,7 @@ u32 nvhost_ctrl_gpu::GetGpuTime(const std::vector<u8>& input, std::vector<u8>& o
 
     IoctlGetGpuTime params{};
     std::memcpy(&params, input.data(), input.size());
-    params.gpu_time = CoreTiming::cyclesToNs(CoreTiming::GetTicks());
+    params.gpu_time = Core::Timing::cyclesToNs(Core::Timing::GetTicks());
     std::memcpy(output.data(), &params, output.size());
     return 0;
 }

--- a/src/core/hle/service/nvflinger/buffer_queue.h
+++ b/src/core/hle/service/nvflinger/buffer_queue.h
@@ -13,10 +13,6 @@
 #include "core/hle/kernel/object.h"
 #include "core/hle/kernel/writable_event.h"
 
-namespace CoreTiming {
-struct EventType;
-}
-
 namespace Service::NVFlinger {
 
 struct IGBPBuffer {

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -25,21 +25,21 @@
 namespace Service::NVFlinger {
 
 constexpr std::size_t SCREEN_REFRESH_RATE = 60;
-constexpr u64 frame_ticks = static_cast<u64>(CoreTiming::BASE_CLOCK_RATE / SCREEN_REFRESH_RATE);
+constexpr u64 frame_ticks = static_cast<u64>(Core::Timing::BASE_CLOCK_RATE / SCREEN_REFRESH_RATE);
 
 NVFlinger::NVFlinger() {
     // Schedule the screen composition events
     composition_event =
-        CoreTiming::RegisterEvent("ScreenComposition", [this](u64 userdata, int cycles_late) {
+        Core::Timing::RegisterEvent("ScreenComposition", [this](u64 userdata, int cycles_late) {
             Compose();
-            CoreTiming::ScheduleEvent(frame_ticks - cycles_late, composition_event);
+            Core::Timing::ScheduleEvent(frame_ticks - cycles_late, composition_event);
         });
 
-    CoreTiming::ScheduleEvent(frame_ticks, composition_event);
+    Core::Timing::ScheduleEvent(frame_ticks, composition_event);
 }
 
 NVFlinger::~NVFlinger() {
-    CoreTiming::UnscheduleEvent(composition_event, 0);
+    Core::Timing::UnscheduleEvent(composition_event, 0);
 }
 
 void NVFlinger::SetNVDrvInstance(std::shared_ptr<Nvidia::Module> instance) {

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -14,7 +14,7 @@
 #include "common/common_types.h"
 #include "core/hle/kernel/object.h"
 
-namespace CoreTiming {
+namespace Core::Timing {
 struct EventType;
 }
 
@@ -115,8 +115,8 @@ private:
     /// layers.
     u32 next_buffer_queue_id = 1;
 
-    /// CoreTiming event that handles screen composition.
-    CoreTiming::EventType* composition_event;
+    /// Event that handles screen composition.
+    Core::Timing::EventType* composition_event;
 };
 
 } // namespace Service::NVFlinger

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -106,8 +106,8 @@ private:
     void GetCurrentTimePoint(Kernel::HLERequestContext& ctx) {
         LOG_DEBUG(Service_Time, "called");
 
-        SteadyClockTimePoint steady_clock_time_point{
-            CoreTiming::cyclesToMs(CoreTiming::GetTicks()) / 1000};
+        const SteadyClockTimePoint steady_clock_time_point{
+            Core::Timing::cyclesToMs(Core::Timing::GetTicks()) / 1000};
         IPC::ResponseBuilder rb{ctx, (sizeof(SteadyClockTimePoint) / 4) + 2};
         rb.Push(RESULT_SUCCESS);
         rb.PushRaw(steady_clock_time_point);
@@ -282,7 +282,7 @@ void Module::Interface::GetClockSnapshot(Kernel::HLERequestContext& ctx) {
     }
 
     const SteadyClockTimePoint steady_clock_time_point{
-        CoreTiming::cyclesToMs(CoreTiming::GetTicks()) / 1000, {}};
+        Core::Timing::cyclesToMs(Core::Timing::GetTicks()) / 1000, {}};
 
     CalendarTime calendar_time{};
     calendar_time.year = tm->tm_year + 1900;

--- a/src/tests/core/core_timing.cpp
+++ b/src/tests/core/core_timing.cpp
@@ -31,10 +31,10 @@ void CallbackTemplate(u64 userdata, s64 cycles_late) {
 class ScopeInit final {
 public:
     ScopeInit() {
-        CoreTiming::Init();
+        Core::Timing::Init();
     }
     ~ScopeInit() {
-        CoreTiming::Shutdown();
+        Core::Timing::Shutdown();
     }
 };
 
@@ -44,37 +44,37 @@ static void AdvanceAndCheck(u32 idx, int downcount, int expected_lateness = 0,
     expected_callback = CB_IDS[idx];
     lateness = expected_lateness;
 
-    CoreTiming::AddTicks(CoreTiming::GetDowncount() -
-                         cpu_downcount); // Pretend we executed X cycles of instructions.
-    CoreTiming::Advance();
+    // Pretend we executed X cycles of instructions.
+    Core::Timing::AddTicks(Core::Timing::GetDowncount() - cpu_downcount);
+    Core::Timing::Advance();
 
     REQUIRE(decltype(callbacks_ran_flags)().set(idx) == callbacks_ran_flags);
-    REQUIRE(downcount == CoreTiming::GetDowncount());
+    REQUIRE(downcount == Core::Timing::GetDowncount());
 }
 
 TEST_CASE("CoreTiming[BasicOrder]", "[core]") {
     ScopeInit guard;
 
-    CoreTiming::EventType* cb_a = CoreTiming::RegisterEvent("callbackA", CallbackTemplate<0>);
-    CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", CallbackTemplate<1>);
-    CoreTiming::EventType* cb_c = CoreTiming::RegisterEvent("callbackC", CallbackTemplate<2>);
-    CoreTiming::EventType* cb_d = CoreTiming::RegisterEvent("callbackD", CallbackTemplate<3>);
-    CoreTiming::EventType* cb_e = CoreTiming::RegisterEvent("callbackE", CallbackTemplate<4>);
+    Core::Timing::EventType* cb_a = Core::Timing::RegisterEvent("callbackA", CallbackTemplate<0>);
+    Core::Timing::EventType* cb_b = Core::Timing::RegisterEvent("callbackB", CallbackTemplate<1>);
+    Core::Timing::EventType* cb_c = Core::Timing::RegisterEvent("callbackC", CallbackTemplate<2>);
+    Core::Timing::EventType* cb_d = Core::Timing::RegisterEvent("callbackD", CallbackTemplate<3>);
+    Core::Timing::EventType* cb_e = Core::Timing::RegisterEvent("callbackE", CallbackTemplate<4>);
 
     // Enter slice 0
-    CoreTiming::Advance();
+    Core::Timing::Advance();
 
     // D -> B -> C -> A -> E
-    CoreTiming::ScheduleEvent(1000, cb_a, CB_IDS[0]);
-    REQUIRE(1000 == CoreTiming::GetDowncount());
-    CoreTiming::ScheduleEvent(500, cb_b, CB_IDS[1]);
-    REQUIRE(500 == CoreTiming::GetDowncount());
-    CoreTiming::ScheduleEvent(800, cb_c, CB_IDS[2]);
-    REQUIRE(500 == CoreTiming::GetDowncount());
-    CoreTiming::ScheduleEvent(100, cb_d, CB_IDS[3]);
-    REQUIRE(100 == CoreTiming::GetDowncount());
-    CoreTiming::ScheduleEvent(1200, cb_e, CB_IDS[4]);
-    REQUIRE(100 == CoreTiming::GetDowncount());
+    Core::Timing::ScheduleEvent(1000, cb_a, CB_IDS[0]);
+    REQUIRE(1000 == Core::Timing::GetDowncount());
+    Core::Timing::ScheduleEvent(500, cb_b, CB_IDS[1]);
+    REQUIRE(500 == Core::Timing::GetDowncount());
+    Core::Timing::ScheduleEvent(800, cb_c, CB_IDS[2]);
+    REQUIRE(500 == Core::Timing::GetDowncount());
+    Core::Timing::ScheduleEvent(100, cb_d, CB_IDS[3]);
+    REQUIRE(100 == Core::Timing::GetDowncount());
+    Core::Timing::ScheduleEvent(1200, cb_e, CB_IDS[4]);
+    REQUIRE(100 == Core::Timing::GetDowncount());
 
     AdvanceAndCheck(3, 400);
     AdvanceAndCheck(1, 300);
@@ -86,36 +86,36 @@ TEST_CASE("CoreTiming[BasicOrder]", "[core]") {
 TEST_CASE("CoreTiming[Threadsave]", "[core]") {
     ScopeInit guard;
 
-    CoreTiming::EventType* cb_a = CoreTiming::RegisterEvent("callbackA", CallbackTemplate<0>);
-    CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", CallbackTemplate<1>);
-    CoreTiming::EventType* cb_c = CoreTiming::RegisterEvent("callbackC", CallbackTemplate<2>);
-    CoreTiming::EventType* cb_d = CoreTiming::RegisterEvent("callbackD", CallbackTemplate<3>);
-    CoreTiming::EventType* cb_e = CoreTiming::RegisterEvent("callbackE", CallbackTemplate<4>);
+    Core::Timing::EventType* cb_a = Core::Timing::RegisterEvent("callbackA", CallbackTemplate<0>);
+    Core::Timing::EventType* cb_b = Core::Timing::RegisterEvent("callbackB", CallbackTemplate<1>);
+    Core::Timing::EventType* cb_c = Core::Timing::RegisterEvent("callbackC", CallbackTemplate<2>);
+    Core::Timing::EventType* cb_d = Core::Timing::RegisterEvent("callbackD", CallbackTemplate<3>);
+    Core::Timing::EventType* cb_e = Core::Timing::RegisterEvent("callbackE", CallbackTemplate<4>);
 
     // Enter slice 0
-    CoreTiming::Advance();
+    Core::Timing::Advance();
 
     // D -> B -> C -> A -> E
-    CoreTiming::ScheduleEventThreadsafe(1000, cb_a, CB_IDS[0]);
+    Core::Timing::ScheduleEventThreadsafe(1000, cb_a, CB_IDS[0]);
     // Manually force since ScheduleEventThreadsafe doesn't call it
-    CoreTiming::ForceExceptionCheck(1000);
-    REQUIRE(1000 == CoreTiming::GetDowncount());
-    CoreTiming::ScheduleEventThreadsafe(500, cb_b, CB_IDS[1]);
+    Core::Timing::ForceExceptionCheck(1000);
+    REQUIRE(1000 == Core::Timing::GetDowncount());
+    Core::Timing::ScheduleEventThreadsafe(500, cb_b, CB_IDS[1]);
     // Manually force since ScheduleEventThreadsafe doesn't call it
-    CoreTiming::ForceExceptionCheck(500);
-    REQUIRE(500 == CoreTiming::GetDowncount());
-    CoreTiming::ScheduleEventThreadsafe(800, cb_c, CB_IDS[2]);
+    Core::Timing::ForceExceptionCheck(500);
+    REQUIRE(500 == Core::Timing::GetDowncount());
+    Core::Timing::ScheduleEventThreadsafe(800, cb_c, CB_IDS[2]);
     // Manually force since ScheduleEventThreadsafe doesn't call it
-    CoreTiming::ForceExceptionCheck(800);
-    REQUIRE(500 == CoreTiming::GetDowncount());
-    CoreTiming::ScheduleEventThreadsafe(100, cb_d, CB_IDS[3]);
+    Core::Timing::ForceExceptionCheck(800);
+    REQUIRE(500 == Core::Timing::GetDowncount());
+    Core::Timing::ScheduleEventThreadsafe(100, cb_d, CB_IDS[3]);
     // Manually force since ScheduleEventThreadsafe doesn't call it
-    CoreTiming::ForceExceptionCheck(100);
-    REQUIRE(100 == CoreTiming::GetDowncount());
-    CoreTiming::ScheduleEventThreadsafe(1200, cb_e, CB_IDS[4]);
+    Core::Timing::ForceExceptionCheck(100);
+    REQUIRE(100 == Core::Timing::GetDowncount());
+    Core::Timing::ScheduleEventThreadsafe(1200, cb_e, CB_IDS[4]);
     // Manually force since ScheduleEventThreadsafe doesn't call it
-    CoreTiming::ForceExceptionCheck(1200);
-    REQUIRE(100 == CoreTiming::GetDowncount());
+    Core::Timing::ForceExceptionCheck(1200);
+    REQUIRE(100 == Core::Timing::GetDowncount());
 
     AdvanceAndCheck(3, 400);
     AdvanceAndCheck(1, 300);
@@ -143,42 +143,42 @@ TEST_CASE("CoreTiming[SharedSlot]", "[core]") {
 
     ScopeInit guard;
 
-    CoreTiming::EventType* cb_a = CoreTiming::RegisterEvent("callbackA", FifoCallback<0>);
-    CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", FifoCallback<1>);
-    CoreTiming::EventType* cb_c = CoreTiming::RegisterEvent("callbackC", FifoCallback<2>);
-    CoreTiming::EventType* cb_d = CoreTiming::RegisterEvent("callbackD", FifoCallback<3>);
-    CoreTiming::EventType* cb_e = CoreTiming::RegisterEvent("callbackE", FifoCallback<4>);
+    Core::Timing::EventType* cb_a = Core::Timing::RegisterEvent("callbackA", FifoCallback<0>);
+    Core::Timing::EventType* cb_b = Core::Timing::RegisterEvent("callbackB", FifoCallback<1>);
+    Core::Timing::EventType* cb_c = Core::Timing::RegisterEvent("callbackC", FifoCallback<2>);
+    Core::Timing::EventType* cb_d = Core::Timing::RegisterEvent("callbackD", FifoCallback<3>);
+    Core::Timing::EventType* cb_e = Core::Timing::RegisterEvent("callbackE", FifoCallback<4>);
 
-    CoreTiming::ScheduleEvent(1000, cb_a, CB_IDS[0]);
-    CoreTiming::ScheduleEvent(1000, cb_b, CB_IDS[1]);
-    CoreTiming::ScheduleEvent(1000, cb_c, CB_IDS[2]);
-    CoreTiming::ScheduleEvent(1000, cb_d, CB_IDS[3]);
-    CoreTiming::ScheduleEvent(1000, cb_e, CB_IDS[4]);
+    Core::Timing::ScheduleEvent(1000, cb_a, CB_IDS[0]);
+    Core::Timing::ScheduleEvent(1000, cb_b, CB_IDS[1]);
+    Core::Timing::ScheduleEvent(1000, cb_c, CB_IDS[2]);
+    Core::Timing::ScheduleEvent(1000, cb_d, CB_IDS[3]);
+    Core::Timing::ScheduleEvent(1000, cb_e, CB_IDS[4]);
 
     // Enter slice 0
-    CoreTiming::Advance();
-    REQUIRE(1000 == CoreTiming::GetDowncount());
+    Core::Timing::Advance();
+    REQUIRE(1000 == Core::Timing::GetDowncount());
 
     callbacks_ran_flags = 0;
     counter = 0;
     lateness = 0;
-    CoreTiming::AddTicks(CoreTiming::GetDowncount());
-    CoreTiming::Advance();
-    REQUIRE(MAX_SLICE_LENGTH == CoreTiming::GetDowncount());
+    Core::Timing::AddTicks(Core::Timing::GetDowncount());
+    Core::Timing::Advance();
+    REQUIRE(MAX_SLICE_LENGTH == Core::Timing::GetDowncount());
     REQUIRE(0x1FULL == callbacks_ran_flags.to_ullong());
 }
 
-TEST_CASE("CoreTiming[PredictableLateness]", "[core]") {
+TEST_CASE("Core::Timing[PredictableLateness]", "[core]") {
     ScopeInit guard;
 
-    CoreTiming::EventType* cb_a = CoreTiming::RegisterEvent("callbackA", CallbackTemplate<0>);
-    CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", CallbackTemplate<1>);
+    Core::Timing::EventType* cb_a = Core::Timing::RegisterEvent("callbackA", CallbackTemplate<0>);
+    Core::Timing::EventType* cb_b = Core::Timing::RegisterEvent("callbackB", CallbackTemplate<1>);
 
     // Enter slice 0
-    CoreTiming::Advance();
+    Core::Timing::Advance();
 
-    CoreTiming::ScheduleEvent(100, cb_a, CB_IDS[0]);
-    CoreTiming::ScheduleEvent(200, cb_b, CB_IDS[1]);
+    Core::Timing::ScheduleEvent(100, cb_a, CB_IDS[0]);
+    Core::Timing::ScheduleEvent(200, cb_b, CB_IDS[1]);
 
     AdvanceAndCheck(0, 90, 10, -10); // (100 - 10)
     AdvanceAndCheck(1, MAX_SLICE_LENGTH, 50, -50);
@@ -192,9 +192,10 @@ static void RescheduleCallback(u64 userdata, s64 cycles_late) {
     REQUIRE(reschedules >= 0);
     REQUIRE(lateness == cycles_late);
 
-    if (reschedules > 0)
-        CoreTiming::ScheduleEvent(1000, reinterpret_cast<CoreTiming::EventType*>(userdata),
-                                  userdata);
+    if (reschedules > 0) {
+        Core::Timing::ScheduleEvent(1000, reinterpret_cast<Core::Timing::EventType*>(userdata),
+                                    userdata);
+    }
 }
 } // namespace ChainSchedulingTest
 
@@ -203,35 +204,35 @@ TEST_CASE("CoreTiming[ChainScheduling]", "[core]") {
 
     ScopeInit guard;
 
-    CoreTiming::EventType* cb_a = CoreTiming::RegisterEvent("callbackA", CallbackTemplate<0>);
-    CoreTiming::EventType* cb_b = CoreTiming::RegisterEvent("callbackB", CallbackTemplate<1>);
-    CoreTiming::EventType* cb_c = CoreTiming::RegisterEvent("callbackC", CallbackTemplate<2>);
-    CoreTiming::EventType* cb_rs =
-        CoreTiming::RegisterEvent("callbackReschedule", RescheduleCallback);
+    Core::Timing::EventType* cb_a = Core::Timing::RegisterEvent("callbackA", CallbackTemplate<0>);
+    Core::Timing::EventType* cb_b = Core::Timing::RegisterEvent("callbackB", CallbackTemplate<1>);
+    Core::Timing::EventType* cb_c = Core::Timing::RegisterEvent("callbackC", CallbackTemplate<2>);
+    Core::Timing::EventType* cb_rs =
+        Core::Timing::RegisterEvent("callbackReschedule", RescheduleCallback);
 
     // Enter slice 0
-    CoreTiming::Advance();
+    Core::Timing::Advance();
 
-    CoreTiming::ScheduleEvent(800, cb_a, CB_IDS[0]);
-    CoreTiming::ScheduleEvent(1000, cb_b, CB_IDS[1]);
-    CoreTiming::ScheduleEvent(2200, cb_c, CB_IDS[2]);
-    CoreTiming::ScheduleEvent(1000, cb_rs, reinterpret_cast<u64>(cb_rs));
-    REQUIRE(800 == CoreTiming::GetDowncount());
+    Core::Timing::ScheduleEvent(800, cb_a, CB_IDS[0]);
+    Core::Timing::ScheduleEvent(1000, cb_b, CB_IDS[1]);
+    Core::Timing::ScheduleEvent(2200, cb_c, CB_IDS[2]);
+    Core::Timing::ScheduleEvent(1000, cb_rs, reinterpret_cast<u64>(cb_rs));
+    REQUIRE(800 == Core::Timing::GetDowncount());
 
     reschedules = 3;
     AdvanceAndCheck(0, 200);  // cb_a
     AdvanceAndCheck(1, 1000); // cb_b, cb_rs
     REQUIRE(2 == reschedules);
 
-    CoreTiming::AddTicks(CoreTiming::GetDowncount());
-    CoreTiming::Advance(); // cb_rs
+    Core::Timing::AddTicks(Core::Timing::GetDowncount());
+    Core::Timing::Advance(); // cb_rs
     REQUIRE(1 == reschedules);
-    REQUIRE(200 == CoreTiming::GetDowncount());
+    REQUIRE(200 == Core::Timing::GetDowncount());
 
     AdvanceAndCheck(2, 800); // cb_c
 
-    CoreTiming::AddTicks(CoreTiming::GetDowncount());
-    CoreTiming::Advance(); // cb_rs
+    Core::Timing::AddTicks(Core::Timing::GetDowncount());
+    Core::Timing::Advance(); // cb_rs
     REQUIRE(0 == reschedules);
-    REQUIRE(MAX_SLICE_LENGTH == CoreTiming::GetDowncount());
+    REQUIRE(MAX_SLICE_LENGTH == Core::Timing::GetDowncount());
 }

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -317,7 +317,7 @@ void Maxwell3D::ProcessQueryGet() {
             LongQueryResult query_result{};
             query_result.value = result;
             // TODO(Subv): Generate a real GPU timestamp and write it here instead of CoreTiming
-            query_result.timestamp = CoreTiming::GetTicks();
+            query_result.timestamp = Core::Timing::GetTicks();
             Memory::WriteBlock(*address, &query_result, sizeof(query_result));
         }
         dirty_flags.OnMemoryWrite();

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -282,7 +282,7 @@ void GPU::ProcessSemaphoreTriggerMethod() {
         block.sequence = regs.semaphore_sequence;
         // TODO(Kmather73): Generate a real GPU timestamp and write it here instead of
         // CoreTiming
-        block.timestamp = CoreTiming::GetTicks();
+        block.timestamp = Core::Timing::GetTicks();
         Memory::WriteBlock(*address, &block, sizeof(block));
     } else {
         const auto address =

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -137,7 +137,7 @@ void RendererOpenGL::SwapBuffers(
 
     render_window.PollEvents();
 
-    Core::System::GetInstance().FrameLimiter().DoFrameLimiting(CoreTiming::GetGlobalTimeUs());
+    Core::System::GetInstance().FrameLimiter().DoFrameLimiting(Core::Timing::GetGlobalTimeUs());
     Core::System::GetInstance().GetPerfStats().BeginSystemFrame();
 
     // Restore the rasterizer state


### PR DESCRIPTION
Places all of the timing-related functionality under the existing Core namespace to keep things consistent, rather than having the timing utilities sitting in its own completely separate top-level namespace.

No functional changes made.