### PR TITLE
gl_shader_decompiler: Re-implement TLDS lod

### DIFF
--- a/src/video_core/shader/decode/memory.cpp
+++ b/src/video_core/shader/decode/memory.cpp
@@ -429,7 +429,7 @@ u32 ShaderIR::DecodeMemory(NodeBlock& bb, u32 pc) {
         UNIMPLEMENTED_IF_MSG(instr.tlds.UsesMiscMode(TextureMiscMode::MZ), "MZ is not implemented");
 
         if (instr.tlds.UsesMiscMode(TextureMiscMode::NODEP)) {
-            LOG_WARNING(HW_GPU, "TMML.NODEP implementation is incomplete");
+            LOG_WARNING(HW_GPU, "TLDS.NODEP implementation is incomplete");
         }
 
         WriteTexsInstructionFloat(bb, instr, GetTldsCode(instr, texture_type, is_array));


### PR DESCRIPTION
Fixes a regression introduced in #2068. It also replaces `u32` iterations with `std::size_t`.