### PR TITLE
gl_rasterizer_cache: Get rid of variable shadowing

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -36,7 +36,6 @@ using PixelFormat = VideoCore::Surface::PixelFormat;
 using ComponentType = VideoCore::Surface::ComponentType;
 
 struct SurfaceParams {
-
     enum class SurfaceClass {
         Uploaded,
         RenderTarget,
@@ -185,7 +184,6 @@ struct SurfaceParams {
 
         if (bd == 32) {
             const u32 bh = MipBlockHeight(mip_level);
-
             if (bh >= 4) {
                 return 16;
             }

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -169,20 +169,28 @@ struct SurfaceParams {
     }
 
     u32 MipBlockDepth(u32 mip_level) const {
-        if (mip_level == 0)
+        if (mip_level == 0) {
             return block_depth;
-        if (is_layered)
+        }
+
+        if (is_layered) {
             return 1;
-        u32 depth = MipDepth(mip_level);
+        }
+
+        const u32 mip_depth = MipDepth(mip_level);
         u32 bd = 32;
-        while (bd > 1 && depth * 2 <= bd) {
+        while (bd > 1 && mip_depth * 2 <= bd) {
             bd >>= 1;
         }
+
         if (bd == 32) {
-            u32 bh = MipBlockHeight(mip_level);
-            if (bh >= 4)
+            const u32 bh = MipBlockHeight(mip_level);
+
+            if (bh >= 4) {
                 return 16;
+            }
         }
+
         return bd;
     }
 


### PR DESCRIPTION
Avoids shadowing the members of the struct itself, which results in a -Wshadow warning.