### PR TITLE
 threadsafe_queue: Remove NeedSize template parameter

### DIFF
--- a/src/common/threadsafe_queue.h
+++ b/src/common/threadsafe_queue.h
@@ -14,10 +14,10 @@
 #include "common/common_types.h"
 
 namespace Common {
-template <typename T, bool NeedSize = true>
+template <typename T>
 class SPSCQueue {
 public:
-    SPSCQueue() : size(0) {
+    SPSCQueue() {
         write_ptr = read_ptr = new ElementPtr();
     }
     ~SPSCQueue() {
@@ -26,12 +26,11 @@ public:
     }
 
     u32 Size() const {
-        static_assert(NeedSize, "using Size() on FifoQueue without NeedSize");
         return size.load();
     }
 
     bool Empty() const {
-        return !read_ptr->next.load();
+        return Size() == 0;
     }
 
     T& Front() const {
@@ -47,13 +46,13 @@ public:
         ElementPtr* new_ptr = new ElementPtr();
         write_ptr->next.store(new_ptr, std::memory_order_release);
         write_ptr = new_ptr;
-        if (NeedSize)
-            size++;
+
+        ++size;
     }
 
     void Pop() {
-        if (NeedSize)
-            size--;
+        --size;
+
         ElementPtr* tmpptr = read_ptr;
         // advance the read pointer
         read_ptr = tmpptr->next.load();
@@ -66,8 +65,7 @@ public:
         if (Empty())
             return false;
 
-        if (NeedSize)
-            size--;
+        --size;
 
         ElementPtr* tmpptr = read_ptr;
         read_ptr = tmpptr->next.load(std::memory_order_acquire);
@@ -103,13 +101,13 @@ private:
 
     ElementPtr* write_ptr;
     ElementPtr* read_ptr;
-    std::atomic<u32> size;
+    std::atomic<u32> size{0};
 };
 
 // a simple thread-safe,
 // single reader, multiple writer queue
 
-template <typename T, bool NeedSize = true>
+template <typename T>
 class MPSCQueue {
 public:
     u32 Size() const {
@@ -144,7 +142,7 @@ public:
     }
 
 private:
-    SPSCQueue<T, NeedSize> spsc_queue;
+    SPSCQueue<T> spsc_queue;
     std::mutex write_lock;
 };
 } // namespace Common

--- a/src/common/threadsafe_queue.h
+++ b/src/common/threadsafe_queue.h
@@ -7,11 +7,10 @@
 // a simple lockless thread-safe,
 // single reader, single writer queue
 
-#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <mutex>
-#include "common/common_types.h"
+#include <utility>
 
 namespace Common {
 template <typename T>
@@ -25,7 +24,7 @@ public:
         delete read_ptr;
     }
 
-    u32 Size() const {
+    std::size_t Size() const {
         return size.load();
     }
 
@@ -87,7 +86,7 @@ private:
     // and a pointer to the next ElementPtr
     class ElementPtr {
     public:
-        ElementPtr() : next(nullptr) {}
+        ElementPtr() {}
         ~ElementPtr() {
             ElementPtr* next_ptr = next.load();
 
@@ -96,12 +95,12 @@ private:
         }
 
         T current;
-        std::atomic<ElementPtr*> next;
+        std::atomic<ElementPtr*> next{nullptr};
     };
 
     ElementPtr* write_ptr;
     ElementPtr* read_ptr;
-    std::atomic<u32> size{0};
+    std::atomic_size_t size{0};
 };
 
 // a simple thread-safe,
@@ -110,7 +109,7 @@ private:
 template <typename T>
 class MPSCQueue {
 public:
-    u32 Size() const {
+    std::size_t Size() const {
         return spsc_queue.Size();
     }
 

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -54,10 +54,10 @@ static std::vector<Event> event_queue;
 static u64 event_fifo_id;
 // the queue for storing the events from other threads threadsafe until they will be added
 // to the event_queue by the emu thread
-static Common::MPSCQueue<Event, false> ts_queue;
+static Common::MPSCQueue<Event> ts_queue;
 
 // the queue for unscheduling the events from other threads threadsafe
-static Common::MPSCQueue<std::pair<const EventType*, u64>, false> unschedule_queue;
+static Common::MPSCQueue<std::pair<const EventType*, u64>> unschedule_queue;
 
 constexpr int MAX_SLICE_LENGTH = 20000;
 


### PR DESCRIPTION
The necessity of this parameter is dubious at best (even if enabled, it would still include the size data member as part of the class instead of removing it with template shenanigans), and in 2019 probably offers completely negligible savings as opposed to just leaving this enabled. This removes it and simplifies the overall interface.