### PR TITLE
Improve the Accuracy of the Rasterizer Cache through a Texception Pass

### DIFF
--- a/src/video_core/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache.h
@@ -104,7 +104,7 @@ protected:
     }
 
     /// Register an object into the cache
-    virtual void Register(const T& object) {
+    void Register(const T& object) {
         object->SetIsRegistered(true);
         interval_cache.add({GetInterval(object), ObjectSet{object}});
         map_cache.insert({object->GetAddr(), object});
@@ -112,7 +112,7 @@ protected:
     }
 
     /// Unregisters an object from the cache
-    virtual void Unregister(const T& object) {
+    void Unregister(const T& object) {
         object->SetIsRegistered(false);
         rasterizer.UpdatePagesCachedCount(object->GetAddr(), object->GetSizeInBytes(), -1);
         // Only flush if use_accurate_gpu_emulation is enabled, as it incurs a performance hit

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -575,8 +575,6 @@ std::pair<bool, bool> RasterizerOpenGL::ConfigureFramebuffers(
     SetupCachedFramebuffer(fbkey, current_state);
     SyncViewport(current_state);
 
-    res_cache.SignalPostFramebufferSetup();
-
     return current_depth_stencil_usage = {static_cast<bool>(depth_surface), fbkey.stencil_enable};
 }
 
@@ -1019,7 +1017,6 @@ void RasterizerOpenGL::SetupTextures(Maxwell::ShaderStage stage, const Shader& s
         texture_samplers[current_bindpoint].SyncWithConfig(texture.tsc);
 
         Surface surface = res_cache.GetTextureSurface(texture, entry);
-        res_cache.SignalSurfaceParameter(surface);
         if (surface != nullptr) {
             state.texture_units[current_bindpoint].texture =
                 entry.IsArray() ? surface->TextureLayer().handle : surface->Texture().handle;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1009,7 +1009,7 @@ Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params, bool pres
             // If surface parameters changed and we care about keeping the previous data, recreate
             // the surface from the old one
             Surface new_surface{RecreateSurface(surface, params)};
-            Unregister(surface);
+            UnregisterSurface(surface);
             Register(new_surface);
             if (new_surface->IsUploaded()) {
                 RegisterReinterpretSurface(new_surface);
@@ -1017,7 +1017,7 @@ Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params, bool pres
             return new_surface;
         } else {
             // Delete the old surface before creating a new one to prevent collisions.
-            Unregister(surface);
+            UnregisterSurface(surface);
         }
     }
 
@@ -1368,12 +1368,12 @@ static bool IsReinterpretInvalidSecond(const Surface render_surface,
 bool RasterizerCacheOpenGL::PartialReinterpretSurface(Surface triggering_surface,
                                                       Surface intersect) {
     if (IsReinterpretInvalid(triggering_surface, intersect)) {
-        Unregister(intersect);
+        UnregisterSurface(intersect);
         return false;
     }
     if (!LayerFitReinterpretSurface(*this, triggering_surface, intersect)) {
         if (IsReinterpretInvalidSecond(triggering_surface, intersect)) {
-            Unregister(intersect);
+            UnregisterSurface(intersect);
             return false;
         }
         FlushObject(intersect);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1394,7 +1394,6 @@ bool RasterizerCacheOpenGL::PartialReinterpretSurface(Surface triggering_surface
 void RasterizerCacheOpenGL::NotifyFrameBufferChange(Surface triggering_surface) {
     if (triggering_surface == nullptr)
         return;
-    run_texception_pass = false;
     if (texception) {
         return;
     }
@@ -1408,11 +1407,10 @@ void RasterizerCacheOpenGL::SignalPreDrawCall() {
     if (texception) {
         glTextureBarrier();
     }
+    texception = false;
 }
 
 void RasterizerCacheOpenGL::SignalPostDrawCall() {
-    if (!run_texception_pass)
-        return;
     for (u32 i = 0; i < Maxwell::NumRenderTargets; i++) {
         if (current_color_buffers[i] != nullptr) {
             Surface intersect = CollideOnReinterpretedSurface(current_color_buffers[i]->GetAddr());
@@ -1421,21 +1419,6 @@ void RasterizerCacheOpenGL::SignalPostDrawCall() {
                 texception = true;
             }
         }
-    }
-    if (!texception)
-        run_texception_pass = false;
-}
-
-void RasterizerCacheOpenGL::SignalPostFramebufferSetup() {
-    if (!run_texception_pass)
-        texception = false;
-}
-
-void RasterizerCacheOpenGL::SignalSurfaceParameter(Surface& surface) {
-    if (surface == nullptr)
-        return;
-    if (surface->IsReinterpreted()) {
-        run_texception_pass = true;
     }
 }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <optional>
 #include <glad/glad.h>
 
 #include "common/alignment.h"
@@ -1000,7 +1001,7 @@ Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params, bool pres
     Surface surface{TryGet(params.addr)};
     if (surface) {
         if (surface->GetSurfaceParams().IsCompatibleSurface(params)) {
-            // Use the cached surface as-is
+            // Use the cached surface as-is unless it's not synced with memory
             if (surface->MustReload())
                 LoadSurface(surface);
             return surface;
@@ -1298,44 +1299,47 @@ Surface RasterizerCacheOpenGL::TryGetReservedSurface(const SurfaceParams& params
     return {};
 }
 
-bool FindBestMipMap(std::size_t memory, const SurfaceParams params, u32 height, u32& mipmap) {
-    for (u32 i = 0; i < params.max_mip_level; i++)
+static std::optional<u32> TryFindBestMipMap(std::size_t memory, const SurfaceParams params,
+                                            u32 height) {
+    for (u32 i = 0; i < params.max_mip_level; i++) {
         if (memory == params.GetMipmapSingleSize(i) && params.MipHeight(i) == height) {
-            mipmap = i;
-            return true;
+            return {i};
         }
-    return false;
+    }
+    return {};
 }
 
-bool FindBestLayer(VAddr addr, const SurfaceParams params, u32 mipmap, u32& layer) {
-    std::size_t size = params.LayerMemorySize();
+static std::optional<u32> TryFindBestLayer(VAddr addr, const SurfaceParams params, u32 mipmap) {
+    const std::size_t size = params.LayerMemorySize();
     VAddr start = params.addr + params.GetMipmapLevelOffset(mipmap);
     for (u32 i = 0; i < params.depth; i++) {
         if (start == addr) {
-            layer = i;
-            return true;
+            return {i};
         }
         start += size;
     }
-    return false;
+    return {};
 }
 
-bool LayerFitReinterpretSurface(RasterizerCacheOpenGL& cache, const Surface render_surface,
-                                const Surface blitted_surface) {
-    const auto dst_params = blitted_surface->GetSurfaceParams();
-    const auto src_params = render_surface->GetSurfaceParams();
-    u32 level = 0;
-    std::size_t src_memory_size = src_params.size_in_bytes;
-    if (FindBestMipMap(src_memory_size, dst_params, src_params.height, level)) {
-        if (src_params.width == dst_params.MipWidthGobAligned(level) &&
-            src_params.height == dst_params.MipHeight(level) &&
-            src_params.block_height >= dst_params.MipBlockHeight(level)) {
-            u32 slot = 0;
-            if (FindBestLayer(render_surface->GetAddr(), dst_params, level, slot)) {
-                glCopyImageSubData(
-                    render_surface->Texture().handle, SurfaceTargetToGL(src_params.target), 0, 0, 0,
-                    0, blitted_surface->Texture().handle, SurfaceTargetToGL(dst_params.target),
-                    level, 0, 0, slot, dst_params.MipWidth(level), dst_params.MipHeight(level), 1);
+static bool LayerFitReinterpretSurface(RasterizerCacheOpenGL& cache, const Surface render_surface,
+                                       const Surface blitted_surface) {
+    const auto& dst_params = blitted_surface->GetSurfaceParams();
+    const auto& src_params = render_surface->GetSurfaceParams();
+    const std::size_t src_memory_size = src_params.size_in_bytes;
+    const std::optional<u32> level =
+        TryFindBestMipMap(src_memory_size, dst_params, src_params.height);
+    if (level.has_value()) {
+        if (src_params.width == dst_params.MipWidthGobAligned(*level) &&
+            src_params.height == dst_params.MipHeight(*level) &&
+            src_params.block_height >= dst_params.MipBlockHeight(*level)) {
+            const std::optional<u32> slot =
+                TryFindBestLayer(render_surface->GetAddr(), dst_params, *level);
+            if (slot.has_value()) {
+                glCopyImageSubData(render_surface->Texture().handle,
+                                   SurfaceTargetToGL(src_params.target), 0, 0, 0, 0,
+                                   blitted_surface->Texture().handle,
+                                   SurfaceTargetToGL(dst_params.target), *level, 0, 0, *slot,
+                                   dst_params.MipWidth(*level), dst_params.MipHeight(*level), 1);
                 blitted_surface->MarkAsModified(true, cache);
                 return true;
             }
@@ -1344,24 +1348,21 @@ bool LayerFitReinterpretSurface(RasterizerCacheOpenGL& cache, const Surface rend
     return false;
 }
 
-bool IsReinterpretInvalid(const Surface render_surface, const Surface blitted_surface) {
-    VAddr bound1 = blitted_surface->GetAddr() + blitted_surface->GetMemorySize();
-    VAddr bound2 = render_surface->GetAddr() + render_surface->GetMemorySize();
+static bool IsReinterpretInvalid(const Surface render_surface, const Surface blitted_surface) {
+    const VAddr bound1 = blitted_surface->GetAddr() + blitted_surface->GetMemorySize();
+    const VAddr bound2 = render_surface->GetAddr() + render_surface->GetMemorySize();
     if (bound2 > bound1)
         return true;
-    const auto dst_params = blitted_surface->GetSurfaceParams();
-    const auto src_params = render_surface->GetSurfaceParams();
-    if (dst_params.component_type != src_params.component_type)
-        return true;
-    return false;
+    const auto& dst_params = blitted_surface->GetSurfaceParams();
+    const auto& src_params = render_surface->GetSurfaceParams();
+    return (dst_params.component_type != src_params.component_type);
 }
 
-bool IsReinterpretInvalidSecond(const Surface render_surface, const Surface blitted_surface) {
-    const auto dst_params = blitted_surface->GetSurfaceParams();
-    const auto src_params = render_surface->GetSurfaceParams();
-    if (dst_params.height > src_params.height && dst_params.width > src_params.width)
-        return false;
-    return true;
+static bool IsReinterpretInvalidSecond(const Surface render_surface,
+                                       const Surface blitted_surface) {
+    const auto& dst_params = blitted_surface->GetSurfaceParams();
+    const auto& src_params = render_surface->GetSurfaceParams();
+    return (dst_params.height > src_params.height && dst_params.width > src_params.width);
 }
 
 bool RasterizerCacheOpenGL::PartialReinterpretSurface(Surface triggering_surface,
@@ -1383,7 +1384,7 @@ bool RasterizerCacheOpenGL::PartialReinterpretSurface(Surface triggering_surface
 }
 
 void RasterizerCacheOpenGL::SignalPreDrawCall() {
-    if (texception) {
+    if (texception && GLAD_GL_ARB_texture_barrier) {
         glTextureBarrier();
     }
     texception = false;

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -1007,6 +1007,8 @@ Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params, bool pres
     if (surface) {
         if (surface->GetSurfaceParams().IsCompatibleSurface(params)) {
             // Use the cached surface as-is
+            if (surface->MustReload())
+                LoadSurface(surface);
             return surface;
         } else if (preserve_contents) {
             // If surface parameters changed and we care about keeping the previous data, recreate
@@ -1014,6 +1016,9 @@ Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params, bool pres
             Surface new_surface{RecreateSurface(surface, params)};
             Unregister(surface);
             Register(new_surface);
+            if (new_surface->IsUploaded()) {
+                RegisterReinterpretSurface(new_surface);
+            }
             return new_surface;
         } else {
             // Delete the old surface before creating a new one to prevent collisions.

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -549,6 +549,8 @@ CachedSurface::CachedSurface(const SurfaceParams& params)
     // alternatives. This signals a bug on those functions.
     const auto width = static_cast<GLsizei>(params.MipWidth(0));
     const auto height = static_cast<GLsizei>(params.MipHeight(0));
+    memory_size = params.MemorySize();
+    reinterpreted = false;
 
     const auto& format_tuple = GetFormatTuple(params.pixel_format, params.component_type);
     gl_internal_format = format_tuple.internal_format;
@@ -995,6 +997,7 @@ void RasterizerCacheOpenGL::LoadSurface(const Surface& surface) {
     surface->LoadGLBuffer();
     surface->UploadGLTexture(read_framebuffer.handle, draw_framebuffer.handle);
     surface->MarkAsModified(false, *this);
+    surface->MarkForReload(false);
 }
 
 Surface RasterizerCacheOpenGL::GetSurface(const SurfaceParams& params, bool preserve_contents) {
@@ -1387,7 +1390,6 @@ bool RasterizerCacheOpenGL::PartialReinterpretSurface(Surface triggering_surface
     }
     return true;
 }
-
 
 void RasterizerCacheOpenGL::NotifyFrameBufferChange(Surface triggering_surface) {
     if (triggering_surface == nullptr)

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -469,6 +469,11 @@ public:
                           const Common::Rectangle<u32>& src_rect,
                           const Common::Rectangle<u32>& dst_rect);
 
+    void SignalPreDrawCall();
+    void SignalPostDrawCall();
+    void SignalSurfaceParameter(Surface& surface);
+    void SignalPostFramebufferSetup();
+
 private:
     void LoadSurface(const Surface& surface);
     Surface GetSurface(const SurfaceParams& params, bool preserve_contents = true);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -412,7 +412,7 @@ public:
         reinterpreted = true;
     }
 
-    bool IsReinterpreted() {
+    bool IsReinterpreted() const {
         return reinterpreted;
     }
 
@@ -420,11 +420,11 @@ public:
         must_reload = reload;
     }
 
-    bool MustReload() {
+    bool MustReload() const {
         return must_reload;
     }
 
-    bool IsUploaded() {
+    bool IsUploaded() const {
         return params.identity == SurfaceParams::SurfaceClass::Uploaded;
     }
 
@@ -489,6 +489,7 @@ private:
     Surface TryGetReservedSurface(const SurfaceParams& params);
 
     // Partialy reinterpret a surface based on a triggering_surface that collides with it.
+    // returns true if the reinterpret was successful, false in case it was not.
     bool PartialReinterpretSurface(Surface triggering_surface, Surface intersect);
 
     /// Performs a slow but accurate surface copy, flushing to RAM and reinterpreting the data
@@ -528,10 +529,10 @@ private:
     // Reinterpreted surfaces are very fragil as the game may keep rendering into them.
     SurfaceIntervalCache reinterpreted_surfaces;
 
-    void RegisterReinterpretSurface(Surface r_surface) {
-        auto interval = GetReinterpretInterval(r_surface);
-        reinterpreted_surfaces.insert({interval, r_surface});
-        r_surface->MarkReinterpreted();
+    void RegisterReinterpretSurface(Surface reinterpret_surface) {
+        auto interval = GetReinterpretInterval(reinterpret_surface);
+        reinterpreted_surfaces.insert({interval, reinterpret_surface});
+        reinterpret_surface->MarkReinterpreted();
     }
 
     Surface CollideOnReinterpretedSurface(VAddr addr) const {
@@ -543,14 +544,12 @@ private:
         return nullptr;
     }
 
-protected:
     void Register(const Surface& object) {
         RasterizerCache<Surface>::Register(object);
     }
 
     /// Unregisters an object from the cache
     void Unregister(const Surface& object) {
-        const auto& params = object->GetSurfaceParams();
         if (object->IsReinterpreted()) {
             auto interval = GetReinterpretInterval(object);
             reinterpreted_surfaces.erase(interval);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -34,6 +34,7 @@ using SurfaceTarget = VideoCore::Surface::SurfaceTarget;
 using SurfaceType = VideoCore::Surface::SurfaceType;
 using PixelFormat = VideoCore::Surface::PixelFormat;
 using ComponentType = VideoCore::Surface::ComponentType;
+using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 
 struct SurfaceParams {
     enum class SurfaceClass {
@@ -449,6 +450,9 @@ private:
     /// Tries to get a reserved surface for the specified parameters
     Surface TryGetReservedSurface(const SurfaceParams& params);
 
+    /// When a render target is changed, this method is called with the previous render target
+    void NotifyFrameBufferChange(Surface triggering_surface);
+
     /// Performs a slow but accurate surface copy, flushing to RAM and reinterpreting the data
     void AccurateCopySurface(const Surface& src_surface, const Surface& dst_surface);
     void FastLayeredCopySurface(const Surface& src_surface, const Surface& dst_surface);
@@ -469,7 +473,8 @@ private:
     /// using the new format.
     OGLBuffer copy_pbo;
 
-    std::array<Surface, Tegra::Engines::Maxwell3D::Regs::NumRenderTargets> last_color_buffers;
+    std::array<Surface, Maxwell::NumRenderTargets> last_color_buffers;
+    std::array<Surface, Maxwell::NumRenderTargets> current_color_buffers;
     Surface last_depth_buffer;
 };
 

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -488,9 +488,6 @@ private:
     /// Tries to get a reserved surface for the specified parameters
     Surface TryGetReservedSurface(const SurfaceParams& params);
 
-    /// When a render target is changed, this method is called with the previous render target
-    void NotifyFrameBufferChange(Surface triggering_surface);
-
     // Partialy reinterpret a surface based on a triggering_surface that collides with it.
     bool PartialReinterpretSurface(Surface triggering_surface, Surface intersect);
 
@@ -535,7 +532,6 @@ private:
         auto interval = GetReinterpretInterval(r_surface);
         reinterpreted_surfaces.insert({interval, r_surface});
         r_surface->MarkReinterpreted();
-        run_texception_pass = true;
     }
 
     Surface CollideOnReinterpretedSurface(VAddr addr) const {

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -150,7 +150,7 @@ struct SurfaceParams {
     }
 
     u32 MipWidthGobAligned(u32 mip_level) const {
-        return std::max(64U*8U / GetFormatBpp(), width >> mip_level);
+        return Common::AlignUp(std::max(1U, width >> mip_level), 64U * 8U / GetFormatBpp());
     }
 
     u32 MipHeight(u32 mip_level) const {
@@ -564,7 +564,6 @@ protected:
         }
         RasterizerCache<Surface>::Unregister(object);
     }
-
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -471,8 +471,6 @@ public:
 
     void SignalPreDrawCall();
     void SignalPostDrawCall();
-    void SignalSurfaceParameter(Surface& surface);
-    void SignalPostFramebufferSetup();
 
 private:
     void LoadSurface(const Surface& surface);
@@ -512,7 +510,6 @@ private:
     OGLFramebuffer read_framebuffer;
     OGLFramebuffer draw_framebuffer;
 
-    bool run_texception_pass = false;
     bool texception = false;
 
     /// Use a Pixel Buffer Object to download the previous texture and then upload it to the new one

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -518,7 +518,7 @@ private:
     Surface last_depth_buffer;
 
     using SurfaceIntervalCache = boost::icl::interval_map<VAddr, Surface>;
-    using SurfaceInterval = typename IntervalCache::interval_type;
+    using SurfaceInterval = typename SurfaceIntervalCache::interval_type;
 
     static auto GetReinterpretInterval(const Surface& object) {
         return SurfaceInterval::right_open(object->GetAddr() + 1,

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -141,8 +141,16 @@ struct SurfaceParams {
         return offset;
     }
 
+    std::size_t GetMipmapSingleSize(u32 mip_level) const {
+        return InnerMipmapMemorySize(mip_level, false, is_layered);
+    }
+
     u32 MipWidth(u32 mip_level) const {
         return std::max(1U, width >> mip_level);
+    }
+
+    u32 MipWidthGobAligned(u32 mip_level) const {
+        return std::max(64U*8U / GetFormatBpp(), width >> mip_level);
     }
 
     u32 MipHeight(u32 mip_level) const {
@@ -479,6 +487,9 @@ private:
 
     /// When a render target is changed, this method is called with the previous render target
     void NotifyFrameBufferChange(Surface triggering_surface);
+
+    // Partialy reinterpret a surface based on a triggering_surface that collides with it.
+    bool PartialReinterpretSurface(Surface triggering_surface, Surface intersect);
 
     /// Performs a slow but accurate surface copy, flushing to RAM and reinterpreting the data
     void AccurateCopySurface(const Surface& src_surface, const Surface& dst_surface);

--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -544,17 +544,13 @@ private:
         return nullptr;
     }
 
-    void Register(const Surface& object) {
-        RasterizerCache<Surface>::Register(object);
-    }
-
     /// Unregisters an object from the cache
-    void Unregister(const Surface& object) {
+    void UnregisterSurface(const Surface& object) {
         if (object->IsReinterpreted()) {
             auto interval = GetReinterpretInterval(object);
             reinterpreted_surfaces.erase(interval);
         }
-        RasterizerCache<Surface>::Unregister(object);
+        Unregister(object);
     }
 };
 


### PR DESCRIPTION
Some games create complex textures first and then render inside them, sometimes even using that same texture as parameter. This gives the name of this PR "Texception Pass" (texture + inception). This pass consists on detecting such behavior every draw call and copying and correcting the correct used texture.