### PR TITLE
Port citra-emu/citra#4197: "threadsafe_queue: Add PopWait and use it where possible "

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -40,9 +40,7 @@ public:
     const Impl& operator=(Impl const&) = delete;
 
     void PushEntry(Entry e) {
-        std::lock_guard<std::mutex> lock(message_mutex);
         message_queue.Push(std::move(e));
-        message_cv.notify_one();
     }
 
     void AddBackend(std::unique_ptr<Backend> backend) {
@@ -85,16 +83,13 @@ private:
                     backend->Write(e);
                 }
             };
-            while (true) {
-                {
-                    std::unique_lock<std::mutex> lock(message_mutex);
-                    message_cv.wait(lock, [&] { return !running || message_queue.Pop(entry); });
-                }
-                if (!running) {
+            while (message_queue.PopWait(entry)) {
+                if (entry.final_entry) {
                     break;
                 }
                 write_logs(entry);
             }
+
             // Drain the logging queue. Only writes out up to MAX_LOGS_TO_WRITE to prevent a case
             // where a system is repeatedly spamming logs even on close.
             const int MAX_LOGS_TO_WRITE = filter.IsDebug() ? INT_MAX : 100;
@@ -106,14 +101,13 @@ private:
     }
 
     ~Impl() {
-        running = false;
-        message_cv.notify_one();
+        Entry entry;
+        entry.final_entry = true;
+        message_queue.Push(entry);
         backend_thread.join();
     }
 
-    std::atomic_bool running{true};
-    std::mutex message_mutex, writing_mutex;
-    std::condition_variable message_cv;
+    std::mutex writing_mutex;
     std::thread backend_thread;
     std::vector<std::unique_ptr<Backend>> backends;
     Common::MPSCQueue<Log::Entry> message_queue;

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -83,7 +83,8 @@ private:
                     backend->Write(e);
                 }
             };
-            while (message_queue.PopWait(entry)) {
+            while (true) {
+                entry = message_queue.PopWait();
                 if (entry.final_entry) {
                     break;
                 }

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -27,6 +27,7 @@ struct Entry {
     unsigned int line_num;
     std::string function;
     std::string message;
+    bool final_entry = false;
 
     Entry() = default;
     Entry(Entry&& o) = default;


### PR DESCRIPTION
See citra-emu/citra#4197 for more details.

**Original description**:
This adds a way to wait until the SPSCQueue / MPSCQueue isn't empty anymore. I didn't add a WaitFor and WaitUntil yet, but this can be easily added if necessary.

For now there is only one instance where this gets used (logging) but scripting (citra-emu/citra#4016) should also use it. This also assures that Wait isn't ended spuriously.