### PR TITLE
video_core: Remove usages of System::GetInstance() within the engines

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -128,7 +128,7 @@ struct System::Impl {
             return ResultStatus::ErrorVideoCore;
         }
 
-        gpu_core = std::make_unique<Tegra::GPU>(renderer->Rasterizer());
+        gpu_core = std::make_unique<Tegra::GPU>(system, renderer->Rasterizer());
 
         cpu_core_manager.Initialize(system);
         is_powered_on = true;

--- a/src/video_core/engines/kepler_memory.cpp
+++ b/src/video_core/engines/kepler_memory.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/assert.h"
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/memory.h"
@@ -11,9 +12,9 @@
 
 namespace Tegra::Engines {
 
-KeplerMemory::KeplerMemory(VideoCore::RasterizerInterface& rasterizer,
+KeplerMemory::KeplerMemory(Core::System& system, VideoCore::RasterizerInterface& rasterizer,
                            MemoryManager& memory_manager)
-    : memory_manager(memory_manager), rasterizer{rasterizer} {}
+    : system{system}, memory_manager(memory_manager), rasterizer{rasterizer} {}
 
 KeplerMemory::~KeplerMemory() = default;
 
@@ -50,7 +51,7 @@ void KeplerMemory::ProcessData(u32 data) {
     rasterizer.InvalidateRegion(*dest_address, sizeof(u32));
 
     Memory::Write32(*dest_address, data);
-    Core::System::GetInstance().GPU().Maxwell3D().dirty_flags.OnMemoryWrite();
+    system.GPU().Maxwell3D().dirty_flags.OnMemoryWrite();
 
     state.write_offset++;
 }

--- a/src/video_core/engines/kepler_memory.h
+++ b/src/video_core/engines/kepler_memory.h
@@ -5,12 +5,15 @@
 #pragma once
 
 #include <array>
-#include "common/assert.h"
 #include "common/bit_field.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "video_core/gpu.h"
 #include "video_core/memory_manager.h"
+
+namespace Core {
+class System;
+}
 
 namespace VideoCore {
 class RasterizerInterface;
@@ -23,7 +26,8 @@ namespace Tegra::Engines {
 
 class KeplerMemory final {
 public:
-    KeplerMemory(VideoCore::RasterizerInterface& rasterizer, MemoryManager& memory_manager);
+    KeplerMemory(Core::System& system, VideoCore::RasterizerInterface& rasterizer,
+                 MemoryManager& memory_manager);
     ~KeplerMemory();
 
     /// Write the value to the register identified by method.
@@ -76,6 +80,7 @@ public:
     } state{};
 
 private:
+    Core::System& system;
     MemoryManager& memory_manager;
     VideoCore::RasterizerInterface& rasterizer;
 

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -17,6 +17,10 @@
 #include "video_core/memory_manager.h"
 #include "video_core/textures/texture.h"
 
+namespace Core {
+class System;
+}
+
 namespace VideoCore {
 class RasterizerInterface;
 }
@@ -28,7 +32,8 @@ namespace Tegra::Engines {
 
 class Maxwell3D final {
 public:
-    explicit Maxwell3D(VideoCore::RasterizerInterface& rasterizer, MemoryManager& memory_manager);
+    explicit Maxwell3D(Core::System& system, VideoCore::RasterizerInterface& rasterizer,
+                       MemoryManager& memory_manager);
     ~Maxwell3D() = default;
 
     /// Register structure of the Maxwell3D engine.
@@ -1130,6 +1135,8 @@ public:
 
 private:
     void InitializeRegisterDefaults();
+
+    Core::System& system;
 
     VideoCore::RasterizerInterface& rasterizer;
 

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/assert.h"
 #include "core/core.h"
 #include "core/memory.h"
 #include "video_core/engines/maxwell_3d.h"
@@ -11,8 +12,9 @@
 
 namespace Tegra::Engines {
 
-MaxwellDMA::MaxwellDMA(VideoCore::RasterizerInterface& rasterizer, MemoryManager& memory_manager)
-    : memory_manager(memory_manager), rasterizer{rasterizer} {}
+MaxwellDMA::MaxwellDMA(Core::System& system, VideoCore::RasterizerInterface& rasterizer,
+                       MemoryManager& memory_manager)
+    : memory_manager(memory_manager), system{system}, rasterizer{rasterizer} {}
 
 void MaxwellDMA::CallMethod(const GPU::MethodCall& method_call) {
     ASSERT_MSG(method_call.method < Regs::NUM_REGS,
@@ -59,7 +61,7 @@ void MaxwellDMA::HandleCopy() {
     }
 
     // All copies here update the main memory, so mark all rasterizer states as invalid.
-    Core::System::GetInstance().GPU().Maxwell3D().dirty_flags.OnMemoryWrite();
+    system.GPU().Maxwell3D().dirty_flags.OnMemoryWrite();
 
     if (regs.exec.is_dst_linear && regs.exec.is_src_linear) {
         // When the enable_2d bit is disabled, the copy is performed as if we were copying a 1D

--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -5,12 +5,15 @@
 #pragma once
 
 #include <array>
-#include "common/assert.h"
 #include "common/bit_field.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "video_core/gpu.h"
 #include "video_core/memory_manager.h"
+
+namespace Core {
+class System;
+}
 
 namespace VideoCore {
 class RasterizerInterface;
@@ -20,7 +23,8 @@ namespace Tegra::Engines {
 
 class MaxwellDMA final {
 public:
-    explicit MaxwellDMA(VideoCore::RasterizerInterface& rasterizer, MemoryManager& memory_manager);
+    explicit MaxwellDMA(Core::System& system, VideoCore::RasterizerInterface& rasterizer,
+                        MemoryManager& memory_manager);
     ~MaxwellDMA() = default;
 
     /// Write the value to the register identified by method.
@@ -137,6 +141,8 @@ public:
     MemoryManager& memory_manager;
 
 private:
+    Core::System& system;
+
     VideoCore::RasterizerInterface& rasterizer;
 
     /// Performs the copy from the source buffer to the destination buffer as configured in the

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -28,14 +28,14 @@ u32 FramebufferConfig::BytesPerPixel(PixelFormat format) {
     UNREACHABLE();
 }
 
-GPU::GPU(VideoCore::RasterizerInterface& rasterizer) {
+GPU::GPU(Core::System& system, VideoCore::RasterizerInterface& rasterizer) {
     memory_manager = std::make_unique<Tegra::MemoryManager>();
     dma_pusher = std::make_unique<Tegra::DmaPusher>(*this);
-    maxwell_3d = std::make_unique<Engines::Maxwell3D>(rasterizer, *memory_manager);
+    maxwell_3d = std::make_unique<Engines::Maxwell3D>(system, rasterizer, *memory_manager);
     fermi_2d = std::make_unique<Engines::Fermi2D>(rasterizer, *memory_manager);
     kepler_compute = std::make_unique<Engines::KeplerCompute>(*memory_manager);
-    maxwell_dma = std::make_unique<Engines::MaxwellDMA>(rasterizer, *memory_manager);
-    kepler_memory = std::make_unique<Engines::KeplerMemory>(rasterizer, *memory_manager);
+    maxwell_dma = std::make_unique<Engines::MaxwellDMA>(system, rasterizer, *memory_manager);
+    kepler_memory = std::make_unique<Engines::KeplerMemory>(system, rasterizer, *memory_manager);
 }
 
 GPU::~GPU() = default;

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -6,11 +6,14 @@
 
 #include <array>
 #include <memory>
-#include <vector>
 #include "common/common_types.h"
 #include "core/hle/service/nvflinger/buffer_queue.h"
 #include "video_core/dma_pusher.h"
 #include "video_core/memory_manager.h"
+
+namespace Core {
+class System;
+}
 
 namespace VideoCore {
 class RasterizerInterface;
@@ -118,7 +121,7 @@ enum class EngineID {
 
 class GPU final {
 public:
-    explicit GPU(VideoCore::RasterizerInterface& rasterizer);
+    explicit GPU(Core::System& system, VideoCore::RasterizerInterface& rasterizer);
     ~GPU();
 
     struct MethodCall {


### PR DESCRIPTION
Avoids the use of the global accessor in favor of explicitly making the system a dependency within the interface.