### PR TITLE
audio_core/buffer: Make const and non-const getter for samples consistent

### DIFF
--- a/src/audio_core/buffer.h
+++ b/src/audio_core/buffer.h
@@ -21,7 +21,7 @@ public:
     Buffer(Tag tag, std::vector<s16>&& samples) : tag{tag}, samples{std::move(samples)} {}
 
     /// Returns the raw audio data for the buffer
-    std::vector<s16>& Samples() {
+    std::vector<s16>& GetSamples() {
         return samples;
     }
 

--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -95,7 +95,7 @@ void Stream::PlayNextBuffer() {
     active_buffer = queued_buffers.front();
     queued_buffers.pop();
 
-    VolumeAdjustSamples(active_buffer->Samples());
+    VolumeAdjustSamples(active_buffer->GetSamples());
 
     sink_stream.EnqueueSamples(GetNumChannels(), active_buffer->GetSamples());
 


### PR DESCRIPTION
This way proper const/non-const selection can occur if needed (as well as, y'know, keeping the interface consistent).