### PR TITLE
service/nvflinger: Relocate definitions of Layer and Display to the vi service

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -400,6 +400,10 @@ add_library(core STATIC
     hle/service/time/time.h
     hle/service/usb/usb.cpp
     hle/service/usb/usb.h
+    hle/service/vi/display/vi_display.cpp
+    hle/service/vi/display/vi_display.h
+    hle/service/vi/layer/vi_layer.cpp
+    hle/service/vi/layer/vi_layer.h
     hle/service/vi/vi.cpp
     hle/service/vi/vi.h
     hle/service/vi/vi_m.cpp

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <array>
 #include <memory>
 #include <optional>
 #include <string>
@@ -26,30 +25,16 @@ class WritableEvent;
 
 namespace Service::Nvidia {
 class Module;
-}
+} // namespace Service::Nvidia
+
+namespace Service::VI {
+struct Display;
+struct Layer;
+} // namespace Service::VI
 
 namespace Service::NVFlinger {
 
 class BufferQueue;
-
-struct Layer {
-    Layer(u64 id, std::shared_ptr<BufferQueue> queue);
-    ~Layer();
-
-    u64 id;
-    std::shared_ptr<BufferQueue> buffer_queue;
-};
-
-struct Display {
-    Display(u64 id, std::string name);
-    ~Display();
-
-    u64 id;
-    std::string name;
-
-    std::vector<Layer> layers;
-    Kernel::EventPair vsync_event;
-};
 
 class NVFlinger final {
 public:
@@ -88,26 +73,20 @@ public:
 
 private:
     /// Finds the display identified by the specified ID.
-    Display* FindDisplay(u64 display_id);
+    VI::Display* FindDisplay(u64 display_id);
 
     /// Finds the display identified by the specified ID.
-    const Display* FindDisplay(u64 display_id) const;
+    const VI::Display* FindDisplay(u64 display_id) const;
 
     /// Finds the layer identified by the specified ID in the desired display.
-    Layer* FindLayer(u64 display_id, u64 layer_id);
+    VI::Layer* FindLayer(u64 display_id, u64 layer_id);
 
     /// Finds the layer identified by the specified ID in the desired display.
-    const Layer* FindLayer(u64 display_id, u64 layer_id) const;
+    const VI::Layer* FindLayer(u64 display_id, u64 layer_id) const;
 
     std::shared_ptr<Nvidia::Module> nvdrv;
 
-    std::array<Display, 5> displays{{
-        {0, "Default"},
-        {1, "External"},
-        {2, "Edid"},
-        {3, "Internal"},
-        {4, "Null"},
-    }};
+    std::vector<VI::Display> displays;
     std::vector<std::shared_ptr<BufferQueue>> buffer_queues;
 
     /// Id to use for the next layer that is created, this counter is shared among all displays.

--- a/src/core/hle/service/vi/display/vi_display.cpp
+++ b/src/core/hle/service/vi/display/vi_display.cpp
@@ -1,0 +1,22 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <fmt/format.h>
+
+#include "core/core.h"
+#include "core/hle/kernel/readable_event.h"
+#include "core/hle/service/vi/display/vi_display.h"
+#include "core/hle/service/vi/layer/vi_layer.h"
+
+namespace Service::VI {
+
+Display::Display(u64 id, std::string name) : id{id}, name{std::move(name)} {
+    auto& kernel = Core::System::GetInstance().Kernel();
+    vsync_event = Kernel::WritableEvent::CreateEventPair(kernel, Kernel::ResetType::Sticky,
+                                                         fmt::format("Display VSync Event {}", id));
+}
+
+Display::~Display() = default;
+
+} // namespace Service::VI

--- a/src/core/hle/service/vi/display/vi_display.h
+++ b/src/core/hle/service/vi/display/vi_display.h
@@ -1,0 +1,28 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "common/common_types.h"
+#include "core/hle/kernel/writable_event.h"
+
+namespace Service::VI {
+
+struct Layer;
+
+struct Display {
+    Display(u64 id, std::string name);
+    ~Display();
+
+    u64 id;
+    std::string name;
+
+    std::vector<Layer> layers;
+    Kernel::EventPair vsync_event;
+};
+
+} // namespace Service::VI

--- a/src/core/hle/service/vi/layer/vi_layer.cpp
+++ b/src/core/hle/service/vi/layer/vi_layer.cpp
@@ -1,0 +1,14 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/vi/layer/vi_layer.h"
+
+namespace Service::VI {
+
+Layer::Layer(u64 id, std::shared_ptr<NVFlinger::BufferQueue> queue)
+    : id{id}, buffer_queue{std::move(queue)} {}
+
+Layer::~Layer() = default;
+
+} // namespace Service::VI

--- a/src/core/hle/service/vi/layer/vi_layer.h
+++ b/src/core/hle/service/vi/layer/vi_layer.h
@@ -1,0 +1,25 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+
+#include "common/common_types.h"
+
+namespace Service::NVFlinger {
+class BufferQueue;
+}
+
+namespace Service::VI {
+
+struct Layer {
+    Layer(u64 id, std::shared_ptr<NVFlinger::BufferQueue> queue);
+    ~Layer();
+
+    u64 id;
+    std::shared_ptr<NVFlinger::BufferQueue> buffer_queue;
+};
+
+} // namespace Service::VI


### PR DESCRIPTION
These are more closely related to the vi service as opposed to the intermediary NVFlinger class.

This also places them in their relevant subfolder, as future changes to these will result in subclassing to represent various displays and services, as they're done within the service itself on hardware.

The reasoning for prefixing the display and layer source files is to avoid potential clashing if two files with the same name are compiled in the same library (e.g. if 'display.cpp/.h' or 'layer.cpp/.h' is added to another service at any point), which MSVC will actually warn against, since it can result in ODR violations. This prevents that case from occurring.

This is a preliminary moving of data structures before expanding on how they function, so I've marked it as "style", even though it's preparation for non-style related changes in a follow-up PR.

This also presently coverts the std::array introduced within f45c25a back to a std::vector to allow
the forward declaration of the Display type (forward declaring a type within a std::vector is allowed since the introduction of [N4510](http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/n4510.html) to the standard by Zhihao Yuan)