### PR TITLE
service/vi: Convert Display and Layer structs into classes

### DIFF
--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -78,9 +78,8 @@ std::optional<u64> NVFlinger::CreateLayer(u64 display_id) {
 
     const u64 layer_id = next_layer_id++;
     const u32 buffer_queue_id = next_buffer_queue_id++;
-    auto buffer_queue = std::make_shared<BufferQueue>(buffer_queue_id, layer_id);
-    display->CreateLayer(layer_id, buffer_queue);
-    buffer_queues.emplace_back(std::move(buffer_queue));
+    buffer_queues.emplace_back(buffer_queue_id, layer_id);
+    display->CreateLayer(layer_id, buffer_queues.back());
     return layer_id;
 }
 
@@ -104,9 +103,17 @@ Kernel::SharedPtr<Kernel::ReadableEvent> NVFlinger::FindVsyncEvent(u64 display_i
     return display->GetVSyncEvent();
 }
 
-std::shared_ptr<BufferQueue> NVFlinger::FindBufferQueue(u32 id) const {
+BufferQueue& NVFlinger::FindBufferQueue(u32 id) {
     const auto itr = std::find_if(buffer_queues.begin(), buffer_queues.end(),
-                                  [&](const auto& queue) { return queue->GetId() == id; });
+                                  [id](const auto& queue) { return queue.GetId() == id; });
+
+    ASSERT(itr != buffer_queues.end());
+    return *itr;
+}
+
+const BufferQueue& NVFlinger::FindBufferQueue(u32 id) const {
+    const auto itr = std::find_if(buffer_queues.begin(), buffer_queues.end(),
+                                  [id](const auto& queue) { return queue.GetId() == id; });
 
     ASSERT(itr != buffer_queues.end());
     return *itr;

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -91,7 +91,7 @@ std::optional<u32> NVFlinger::FindBufferQueueId(u64 display_id, u64 layer_id) co
         return {};
     }
 
-    return layer->buffer_queue->GetId();
+    return layer->GetBufferQueue().GetId();
 }
 
 Kernel::SharedPtr<Kernel::ReadableEvent> NVFlinger::FindVsyncEvent(u64 display_id) const {
@@ -167,10 +167,10 @@ void NVFlinger::Compose() {
 
         // TODO(Subv): Support more than 1 layer.
         VI::Layer& layer = display.GetLayer(0);
-        auto& buffer_queue = layer.buffer_queue;
+        auto& buffer_queue = layer.GetBufferQueue();
 
         // Search for a queued buffer and acquire it
-        auto buffer = buffer_queue->AcquireBuffer();
+        auto buffer = buffer_queue.AcquireBuffer();
 
         MicroProfileFlip();
 
@@ -195,7 +195,7 @@ void NVFlinger::Compose() {
                      igbp_buffer.width, igbp_buffer.height, igbp_buffer.stride,
                      buffer->get().transform, buffer->get().crop_rect);
 
-        buffer_queue->ReleaseBuffer(buffer->get().slot);
+        buffer_queue.ReleaseBuffer(buffer->get().slot);
     }
 }
 

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -29,7 +29,7 @@ class Module;
 
 namespace Service::VI {
 class Display;
-struct Layer;
+class Layer;
 } // namespace Service::VI
 
 namespace Service::NVFlinger {

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -28,7 +28,7 @@ class Module;
 } // namespace Service::Nvidia
 
 namespace Service::VI {
-struct Display;
+class Display;
 struct Layer;
 } // namespace Service::VI
 

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -65,7 +65,10 @@ public:
     Kernel::SharedPtr<Kernel::ReadableEvent> FindVsyncEvent(u64 display_id) const;
 
     /// Obtains a buffer queue identified by the ID.
-    std::shared_ptr<BufferQueue> FindBufferQueue(u32 id) const;
+    BufferQueue& FindBufferQueue(u32 id);
+
+    /// Obtains a buffer queue identified by the ID.
+    const BufferQueue& FindBufferQueue(u32 id) const;
 
     /// Performs a composition request to the emulated nvidia GPU and triggers the vsync events when
     /// finished.
@@ -87,7 +90,7 @@ private:
     std::shared_ptr<Nvidia::Module> nvdrv;
 
     std::vector<VI::Display> displays;
-    std::vector<std::shared_ptr<BufferQueue>> buffer_queues;
+    std::vector<BufferQueue> buffer_queues;
 
     /// Id to use for the next layer that is created, this counter is shared among all displays.
     u64 next_layer_id = 1;

--- a/src/core/hle/service/vi/display/vi_display.cpp
+++ b/src/core/hle/service/vi/display/vi_display.cpp
@@ -48,7 +48,7 @@ void Display::CreateLayer(u64 id, std::shared_ptr<NVFlinger::BufferQueue> buffer
 
 Layer* Display::FindLayer(u64 id) {
     const auto itr = std::find_if(layers.begin(), layers.end(),
-                                  [id](const VI::Layer& layer) { return layer.id == id; });
+                                  [id](const VI::Layer& layer) { return layer.GetID() == id; });
 
     if (itr == layers.end()) {
         return nullptr;
@@ -59,7 +59,7 @@ Layer* Display::FindLayer(u64 id) {
 
 const Layer* Display::FindLayer(u64 id) const {
     const auto itr = std::find_if(layers.begin(), layers.end(),
-                                  [id](const VI::Layer& layer) { return layer.id == id; });
+                                  [id](const VI::Layer& layer) { return layer.GetID() == id; });
 
     if (itr == layers.end()) {
         return nullptr;

--- a/src/core/hle/service/vi/display/vi_display.cpp
+++ b/src/core/hle/service/vi/display/vi_display.cpp
@@ -39,11 +39,11 @@ void Display::SignalVSyncEvent() {
     vsync_event.writable->Signal();
 }
 
-void Display::CreateLayer(u64 id, std::shared_ptr<NVFlinger::BufferQueue> buffer_queue) {
+void Display::CreateLayer(u64 id, NVFlinger::BufferQueue& buffer_queue) {
     // TODO(Subv): Support more than 1 layer.
     ASSERT_MSG(layers.empty(), "Only one layer is supported per display at the moment");
 
-    layers.emplace_back(id, std::move(buffer_queue));
+    layers.emplace_back(id, buffer_queue);
 }
 
 Layer* Display::FindLayer(u64 id) {

--- a/src/core/hle/service/vi/display/vi_display.cpp
+++ b/src/core/hle/service/vi/display/vi_display.cpp
@@ -2,8 +2,12 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
+#include <utility>
+
 #include <fmt/format.h>
 
+#include "common/assert.h"
 #include "core/core.h"
 #include "core/hle/kernel/readable_event.h"
 #include "core/hle/service/vi/display/vi_display.h"
@@ -18,5 +22,50 @@ Display::Display(u64 id, std::string name) : id{id}, name{std::move(name)} {
 }
 
 Display::~Display() = default;
+
+Layer& Display::GetLayer(std::size_t index) {
+    return layers.at(index);
+}
+
+const Layer& Display::GetLayer(std::size_t index) const {
+    return layers.at(index);
+}
+
+Kernel::SharedPtr<Kernel::ReadableEvent> Display::GetVSyncEvent() const {
+    return vsync_event.readable;
+}
+
+void Display::SignalVSyncEvent() {
+    vsync_event.writable->Signal();
+}
+
+void Display::CreateLayer(u64 id, std::shared_ptr<NVFlinger::BufferQueue> buffer_queue) {
+    // TODO(Subv): Support more than 1 layer.
+    ASSERT_MSG(layers.empty(), "Only one layer is supported per display at the moment");
+
+    layers.emplace_back(id, std::move(buffer_queue));
+}
+
+Layer* Display::FindLayer(u64 id) {
+    const auto itr = std::find_if(layers.begin(), layers.end(),
+                                  [id](const VI::Layer& layer) { return layer.id == id; });
+
+    if (itr == layers.end()) {
+        return nullptr;
+    }
+
+    return &*itr;
+}
+
+const Layer* Display::FindLayer(u64 id) const {
+    const auto itr = std::find_if(layers.begin(), layers.end(),
+                                  [id](const VI::Layer& layer) { return layer.id == id; });
+
+    if (itr == layers.end()) {
+        return nullptr;
+    }
+
+    return &*itr;
+}
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/display/vi_display.h
+++ b/src/core/hle/service/vi/display/vi_display.h
@@ -16,7 +16,7 @@ class BufferQueue;
 
 namespace Service::VI {
 
-struct Layer;
+class Layer;
 
 /// Represents a single display type
 class Display {

--- a/src/core/hle/service/vi/display/vi_display.h
+++ b/src/core/hle/service/vi/display/vi_display.h
@@ -10,14 +10,84 @@
 #include "common/common_types.h"
 #include "core/hle/kernel/writable_event.h"
 
+namespace Service::NVFlinger {
+class BufferQueue;
+}
+
 namespace Service::VI {
 
 struct Layer;
 
-struct Display {
+/// Represents a single display type
+class Display {
+public:
+    /// Constructs a display with a given unique ID and name.
+    ///
+    /// @param id   The unique ID for this display.
+    /// @param name The name for this display.
+    ///
     Display(u64 id, std::string name);
     ~Display();
 
+    Display(const Display&) = delete;
+    Display& operator=(const Display&) = delete;
+
+    Display(Display&&) = default;
+    Display& operator=(Display&&) = default;
+
+    /// Gets the unique ID assigned to this display.
+    u64 GetID() const {
+        return id;
+    }
+
+    /// Gets the name of this display
+    const std::string& GetName() const {
+        return name;
+    }
+
+    /// Whether or not this display has any layers added to it.
+    bool HasLayers() const {
+        return !layers.empty();
+    }
+
+    /// Gets a layer for this display based off an index.
+    Layer& GetLayer(std::size_t index);
+
+    /// Gets a layer for this display based off an index.
+    const Layer& GetLayer(std::size_t index) const;
+
+    /// Gets the readable vsync event.
+    Kernel::SharedPtr<Kernel::ReadableEvent> GetVSyncEvent() const;
+
+    /// Signals the internal vsync event.
+    void SignalVSyncEvent();
+
+    /// Creates and adds a layer to this display with the given ID.
+    ///
+    /// @param id           The ID to assign to the created layer.
+    /// @param buffer_queue The buffer queue for the layer instance to use.
+    ///
+    void CreateLayer(u64 id, std::shared_ptr<NVFlinger::BufferQueue> buffer_queue);
+
+    /// Attempts to find a layer with the given ID.
+    ///
+    /// @param id The layer ID.
+    ///
+    /// @returns If found, the Layer instance with the given ID.
+    ///          If not found, then nullptr is returned.
+    ///
+    Layer* FindLayer(u64 id);
+
+    /// Attempts to find a layer with the given ID.
+    ///
+    /// @param id The layer ID.
+    ///
+    /// @returns If found, the Layer instance with the given ID.
+    ///          If not found, then nullptr is returned.
+    ///
+    const Layer* FindLayer(u64 id) const;
+
+private:
     u64 id;
     std::string name;
 

--- a/src/core/hle/service/vi/display/vi_display.h
+++ b/src/core/hle/service/vi/display/vi_display.h
@@ -67,7 +67,7 @@ public:
     /// @param id           The ID to assign to the created layer.
     /// @param buffer_queue The buffer queue for the layer instance to use.
     ///
-    void CreateLayer(u64 id, std::shared_ptr<NVFlinger::BufferQueue> buffer_queue);
+    void CreateLayer(u64 id, NVFlinger::BufferQueue& buffer_queue);
 
     /// Attempts to find a layer with the given ID.
     ///

--- a/src/core/hle/service/vi/layer/vi_layer.cpp
+++ b/src/core/hle/service/vi/layer/vi_layer.cpp
@@ -2,16 +2,11 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "common/assert.h"
 #include "core/hle/service/vi/layer/vi_layer.h"
 
 namespace Service::VI {
 
-Layer::Layer(u64 id, std::shared_ptr<NVFlinger::BufferQueue> queue)
-    : id{id}, buffer_queue{std::move(queue)}
-{
-    ASSERT_MSG(buffer_queue != nullptr, "buffer_queue may not be null.");
-}
+Layer::Layer(u64 id, NVFlinger::BufferQueue& queue) : id{id}, buffer_queue{queue} {}
 
 Layer::~Layer() = default;
 

--- a/src/core/hle/service/vi/layer/vi_layer.cpp
+++ b/src/core/hle/service/vi/layer/vi_layer.cpp
@@ -2,12 +2,16 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/assert.h"
 #include "core/hle/service/vi/layer/vi_layer.h"
 
 namespace Service::VI {
 
 Layer::Layer(u64 id, std::shared_ptr<NVFlinger::BufferQueue> queue)
-    : id{id}, buffer_queue{std::move(queue)} {}
+    : id{id}, buffer_queue{std::move(queue)}
+{
+    ASSERT_MSG(buffer_queue != nullptr, "buffer_queue may not be null.");
+}
 
 Layer::~Layer() = default;
 

--- a/src/core/hle/service/vi/layer/vi_layer.h
+++ b/src/core/hle/service/vi/layer/vi_layer.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "common/common_types.h"
 
 namespace Service::NVFlinger {
@@ -22,14 +20,14 @@ public:
     /// @param id    The ID to assign to this layer.
     /// @param queue The buffer queue for this layer to use.
     ///
-    Layer(u64 id, std::shared_ptr<NVFlinger::BufferQueue> queue);
+    Layer(u64 id, NVFlinger::BufferQueue& queue);
     ~Layer();
 
     Layer(const Layer&) = delete;
     Layer& operator=(const Layer&) = delete;
 
     Layer(Layer&&) = default;
-    Layer& operator=(Layer&&) = default;
+    Layer& operator=(Layer&&) = delete;
 
     /// Gets the ID for this layer.
     u64 GetID() const {
@@ -38,17 +36,17 @@ public:
 
     /// Gets a reference to the buffer queue this layer is using.
     NVFlinger::BufferQueue& GetBufferQueue() {
-        return *buffer_queue;
+        return buffer_queue;
     }
 
     /// Gets a const reference to the buffer queue this layer is using.
     const NVFlinger::BufferQueue& GetBufferQueue() const {
-        return *buffer_queue;
+        return buffer_queue;
     }
 
 private:
     u64 id;
-    std::shared_ptr<NVFlinger::BufferQueue> buffer_queue;
+    NVFlinger::BufferQueue& buffer_queue;
 };
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/layer/vi_layer.h
+++ b/src/core/hle/service/vi/layer/vi_layer.h
@@ -14,10 +14,39 @@ class BufferQueue;
 
 namespace Service::VI {
 
-struct Layer {
+/// Represents a single display layer.
+class Layer {
+public:
+    /// Constructs a layer with a given ID and buffer queue.
+    ///
+    /// @param id    The ID to assign to this layer.
+    /// @param queue The buffer queue for this layer to use.
+    ///
     Layer(u64 id, std::shared_ptr<NVFlinger::BufferQueue> queue);
     ~Layer();
 
+    Layer(const Layer&) = delete;
+    Layer& operator=(const Layer&) = delete;
+
+    Layer(Layer&&) = default;
+    Layer& operator=(Layer&&) = default;
+
+    /// Gets the ID for this layer.
+    u64 GetID() const {
+        return id;
+    }
+
+    /// Gets a reference to the buffer queue this layer is using.
+    NVFlinger::BufferQueue& GetBufferQueue() {
+        return *buffer_queue;
+    }
+
+    /// Gets a const reference to the buffer queue this layer is using.
+    const NVFlinger::BufferQueue& GetBufferQueue() const {
+        return *buffer_queue;
+    }
+
+private:
     u64 id;
     std::shared_ptr<NVFlinger::BufferQueue> buffer_queue;
 };


### PR DESCRIPTION
Continuing off of #2142, this converts the Display and Layer structs into classes and puts everything behind interface functions to cleanly isolate behavior for upcoming changes to these structs. #2142 was intended to be the last reorganization PR before functional changes start occurring, but I figured I'd separate this into its own PR beforehand to cut down on the amount of "churn" in later PRs.

This conversion into classes is because future changes will start placing invariants on both classes that need to hold, and so the interface prevents accidentally messing around with those. It also makes it a little more consistent, so we don't have cases where member variables are being directly accessed, and cases where they're not in the future.