### PR TITLE
vk_memory_manager: Fixup commit interval allocation

### DIFF
--- a/src/video_core/renderer_vulkan/vk_memory_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_memory_manager.cpp
@@ -238,8 +238,7 @@ bool VKMemoryManager::AllocMemory(vk::MemoryPropertyFlags wanted_properties, u32
 
 VKMemoryCommitImpl::VKMemoryCommitImpl(VKMemoryAllocation* allocation, vk::DeviceMemory memory,
                                        u8* data, u64 begin, u64 end)
-    : allocation{allocation}, memory{memory}, data{data},
-      interval(std::make_pair(begin, begin + end)) {}
+    : allocation{allocation}, memory{memory}, data{data}, interval(std::make_pair(begin, end)) {}
 
 VKMemoryCommitImpl::~VKMemoryCommitImpl() {
     allocation->Free(this);


### PR DESCRIPTION
`VKMemoryCommitImpl` was using as the end of its interval `begin + end`. That ended up wasting memory.

Edit: Now that I look at it, this thing was exponential. No wonder why 8 textures were using 256 MiB of VRAM.