### PR TITLE
gl_shader_disk_cache: Remove #pragma once from cpp file

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -2,8 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#pragma once
-
 #include <cstring>
 #include <fmt/format.h>
 #include <lz4.h>


### PR DESCRIPTION
This is only necessary in headers. Silences a warning with clang.