### PR TITLE
gl_rasterizer/vk_memory_manager: Silence -Wreorder warnings

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -102,8 +102,8 @@ struct FramebufferCacheKey {
 
 RasterizerOpenGL::RasterizerOpenGL(Core::Frontend::EmuWindow& window, Core::System& system,
                                    ScreenInfo& info)
-    : res_cache{*this}, shader_cache{*this, system}, emu_window{window}, screen_info{info},
-      buffer_cache(*this, STREAM_BUFFER_SIZE), global_cache{*this} {
+    : res_cache{*this}, shader_cache{*this, system}, global_cache{*this}, emu_window{window},
+      screen_info{info}, buffer_cache(*this, STREAM_BUFFER_SIZE) {
     // Create sampler objects
     for (std::size_t i = 0; i < texture_samplers.size(); ++i) {
         texture_samplers[i].Create();

--- a/src/video_core/renderer_vulkan/vk_memory_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_memory_manager.cpp
@@ -238,7 +238,7 @@ bool VKMemoryManager::AllocMemory(vk::MemoryPropertyFlags wanted_properties, u32
 
 VKMemoryCommitImpl::VKMemoryCommitImpl(VKMemoryAllocation* allocation, vk::DeviceMemory memory,
                                        u8* data, u64 begin, u64 end)
-    : allocation{allocation}, memory{memory}, data{data}, interval(std::make_pair(begin, end)) {}
+    : interval(std::make_pair(begin, end)), memory{memory}, allocation{allocation}, data{data} {}
 
 VKMemoryCommitImpl::~VKMemoryCommitImpl() {
     allocation->Free(this);


### PR DESCRIPTION
Reorders two constructor initializer lists in terms of the class member variable's declaration order.

The warning mainly stems from:

```cpp
class Thing {
public:
    // Despite y being before x here, x will actually be initialized first
    // when the constructor runs, not y. Initialization occurs in terms
    // how the member variables are ordered.
    explicit Thing(int x, int y) : y{y}, x{x} {}

private:
    int x;
    int y;
};
```

which can be problematic in a scenario where one member variable's initialization depends on another one, and the order is mixed up. e.g. a somewhat minimal example:

```cpp
class OtherThing {
public:
    explicit OtherThing(int value) : value{value} {}

private:
    int value;
};

class Thing {
public:
    // Whoops, uninitialized value passed to ot's constructor.
    // Since 'ot' is declared first in the class body, it's constructor
    // will run before the assignment to the class member 'x' happens.
    explicit Thing(int x, int y) : x{x}, y{y}, ot{this->x} {}

private:
    OtherThing ot;
    int y;
    int x;
};
```

