### PR TITLE
service/hid: Amend forward declaration of ServiceManager

### DIFF
--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -15,7 +15,7 @@ namespace Kernel {
 class SharedMemory;
 }
 
-namespace SM {
+namespace Service::SM {
 class ServiceManager;
 }
 


### PR DESCRIPTION
The SM namespace is within the Service namespace, so this was forward declaring a type that didn't exist. Silences a compiler warning.