### PR TITLE
audio_core/cubeb_sink: Ensure COM is initialized on Windows prior to calling cubeb_init

### DIFF
--- a/src/audio_core/cubeb_sink.h
+++ b/src/audio_core/cubeb_sink.h
@@ -25,6 +25,10 @@ private:
     cubeb* ctx{};
     cubeb_devid output_device{};
     std::vector<SinkStreamPtr> sink_streams;
+
+#ifdef _MSC_VER
+    u32 com_init_result = 0;
+#endif
 };
 
 std::vector<std::string> ListCubebSinkDevices();


### PR DESCRIPTION
cubeb now requires that COM explicitly be initialized on the thread prior to calling cubeb_init for the WASAPI backend. This is documented [here](https://github.com/kinetiknz/cubeb/blob/master/include/cubeb/cubeb.h#L414). However, it wasn't actually enforced by the library until [this commit](https://github.com/kinetiknz/cubeb/commit/6f2420de8f155b10330cf973900ac7bdbfee589d), which added an assertion to check for it.