### PR TITLE
 logging/backend: Move CreateEntry into the Impl class. Relocate local static to a class variable

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -39,8 +39,10 @@ public:
     Impl(Impl const&) = delete;
     const Impl& operator=(Impl const&) = delete;
 
-    void PushEntry(Entry e) {
-        message_queue.Push(std::move(e));
+    void PushEntry(Class log_class, Level log_level, const char* filename, unsigned int line_num,
+                   const char* function, std::string message) {
+        message_queue.Push(
+            CreateEntry(log_class, log_level, filename, line_num, function, std::move(message)));
     }
 
     void AddBackend(std::unique_ptr<Backend> backend) {
@@ -106,6 +108,26 @@ private:
         entry.final_entry = true;
         message_queue.Push(entry);
         backend_thread.join();
+    }
+
+    Entry CreateEntry(Class log_class, Level log_level, const char* filename, unsigned int line_nr,
+                      const char* function, std::string message) const {
+        using std::chrono::duration_cast;
+        using std::chrono::steady_clock;
+
+        static steady_clock::time_point time_origin = steady_clock::now();
+
+        Entry entry;
+        entry.timestamp =
+            duration_cast<std::chrono::microseconds>(steady_clock::now() - time_origin);
+        entry.log_class = log_class;
+        entry.log_level = log_level;
+        entry.filename = Common::TrimSourcePath(filename);
+        entry.line_num = line_nr;
+        entry.function = function;
+        entry.message = std::move(message);
+
+        return entry;
     }
 
     std::mutex writing_mutex;
@@ -271,25 +293,6 @@ const char* GetLevelName(Level log_level) {
 #undef LVL
 }
 
-Entry CreateEntry(Class log_class, Level log_level, const char* filename, unsigned int line_nr,
-                  const char* function, std::string message) {
-    using std::chrono::duration_cast;
-    using std::chrono::steady_clock;
-
-    static steady_clock::time_point time_origin = steady_clock::now();
-
-    Entry entry;
-    entry.timestamp = duration_cast<std::chrono::microseconds>(steady_clock::now() - time_origin);
-    entry.log_class = log_class;
-    entry.log_level = log_level;
-    entry.filename = Common::TrimSourcePath(filename);
-    entry.line_num = line_nr;
-    entry.function = function;
-    entry.message = std::move(message);
-
-    return entry;
-}
-
 void SetGlobalFilter(const Filter& filter) {
     Impl::Instance().SetGlobalFilter(filter);
 }
@@ -314,9 +317,7 @@ void FmtLogMessageImpl(Class log_class, Level log_level, const char* filename,
     if (!filter.CheckMessage(log_class, log_level))
         return;
 
-    Entry entry =
-        CreateEntry(log_class, log_level, filename, line_num, function, fmt::vformat(format, args));
-
-    instance.PushEntry(std::move(entry));
+    instance.PushEntry(log_class, log_level, filename, line_num, function,
+                       fmt::vformat(format, args));
 }
 } // namespace Log

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -115,8 +115,6 @@ private:
         using std::chrono::duration_cast;
         using std::chrono::steady_clock;
 
-        static steady_clock::time_point time_origin = steady_clock::now();
-
         Entry entry;
         entry.timestamp =
             duration_cast<std::chrono::microseconds>(steady_clock::now() - time_origin);
@@ -135,6 +133,7 @@ private:
     std::vector<std::unique_ptr<Backend>> backends;
     Common::MPSCQueue<Log::Entry> message_queue;
     Filter filter;
+    std::chrono::steady_clock::time_point time_origin{std::chrono::steady_clock::now()};
 };
 
 void ConsoleBackend::Write(const Entry& entry) {

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -135,10 +135,6 @@ const char* GetLogClassName(Class log_class);
  */
 const char* GetLevelName(Level log_level);
 
-/// Creates a log entry by formatting the given source location, and message.
-Entry CreateEntry(Class log_class, Level log_level, const char* filename, unsigned int line_nr,
-                  const char* function, std::string message);
-
 /**
  * The global filter will prevent any messages from even being processed if they are filtered. Each
  * backend can have a filter, but if the level is lower than the global filter, the backend will


### PR DESCRIPTION
Keeps our logging related state all in one place, as opposed to having a local static within the function.

On weakly ordered systems (e.g. ARM/AArch64), this also gets rid of needing to do a second conditional atomic load within the logging functions, which is also nice as a side benefit to moving it into the class itself.