### PR TITLE
web_service: Remove unnecessary inclusions

### DIFF
--- a/src/web_service/verify_login.h
+++ b/src/web_service/verify_login.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <functional>
-#include <future>
 #include <string>
 
 namespace WebService {

--- a/src/web_service/web_backend.cpp
+++ b/src/web_service/web_backend.cpp
@@ -10,7 +10,6 @@
 #include "common/common_types.h"
 #include "common/logging/log.h"
 #include "common/web_result.h"
-#include "core/settings.h"
 #include "web_service/web_backend.h"
 
 namespace WebService {


### PR DESCRIPTION
Reduces the potential amount of rebuilding necessary if any headers change. In particular, we were including a header from the core library when we don't even link the core library to the web_service library, so this also gets rid of an indirect dependency.