### PR TITLE
web_browser: Add shortcut to Enter key to exit applet

### DIFF
--- a/src/yuzu/applets/web_browser.cpp
+++ b/src/yuzu/applets/web_browser.cpp
@@ -56,6 +56,8 @@ constexpr char NX_SHIM_INJECT_SCRIPT[] = R"(
     window.nx.endApplet = function() {
         applet_done = true;
     };
+
+    window.onkeypress = function(e) { if (e.keyCode === 13) { applet_done = true; } };
 )";
 
 QString GetNXShimInjectionScript() {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -339,6 +339,11 @@ void GMainWindow::WebBrowserOpenPage(std::string_view filename, std::string_view
                 .arg(QString::fromStdString(std::to_string(key_code))));
     };
 
+    QMessageBox::information(
+        this, tr("Exit"),
+        tr("To exit the web application, use the game provided controls to select exit, select the "
+           "'Exit Web Applet' option in the menu bar, or press the 'Enter' key."));
+
     bool running_exit_check = false;
     while (!finished) {
         QApplication::processEvents();


### PR DESCRIPTION
Addresses issues where a user in fullscreen could not exit some web applets without leaving fullscreen. (Specifically #2157)