### PR TITLE
hle/service/audio/audout_u: Correct lack of return in failure case of AppendAudioOutBufferImpl()

### DIFF
--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -138,6 +138,7 @@ private:
         if (!audio_core.QueueBuffer(stream, tag, std::move(samples))) {
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ERR_BUFFER_COUNT_EXCEEDED);
+            return;
         }
 
         IPC::ResponseBuilder rb{ctx, 2};


### PR DESCRIPTION
Previously we were overwriting the error case with a success code further down (which is definitely not what we should be doing here).