### PR TITLE
service/audio/audout_u: Only actually stop the audio stream in StopAudioOut if the stream is playing

### DIFF
--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -107,7 +107,9 @@ private:
     void StopAudioOut(Kernel::HLERequestContext& ctx) {
         LOG_DEBUG(Service_Audio, "called");
 
-        audio_core.StopStream(stream);
+        if (stream->IsPlaying()) {
+            audio_core.StopStream(stream);
+        }
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);


### PR DESCRIPTION
The service itself only does further actions if the stream is playing. If the stream is already stopped, then it just exits successfully.