### PR TITLE
service/audio/hwopus: Move decoder state to its own class

### DIFF
--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -16,7 +16,7 @@
 #include "core/hle/service/audio/hwopus.h"
 
 namespace Service::Audio {
-
+namespace {
 struct OpusDeleter {
     void operator()(void* ptr) const {
         operator delete(ptr);
@@ -178,10 +178,11 @@ private:
     u32 channel_count;
 };
 
-static std::size_t WorkerBufferSize(u32 channel_count) {
+std::size_t WorkerBufferSize(u32 channel_count) {
     ASSERT_MSG(channel_count == 1 || channel_count == 2, "Invalid channel count");
     return opus_decoder_get_size(static_cast<int>(channel_count));
 }
+} // Anonymous namespace
 
 void HwOpus::GetWorkBufferSize(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};

--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -9,7 +9,7 @@
 
 #include <opus.h>
 
-#include "common/common_funcs.h"
+#include "common/assert.h"
 #include "common/logging/log.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/hle_ipc.h"
@@ -24,8 +24,10 @@ struct OpusDeleter {
 };
 
 struct OpusPacketHeader {
+    // Packet size in bytes.
     u32_be size;
-    INSERT_PADDING_WORDS(1);
+    // Indicates the final range of the codec's entropy coder.
+    u32_be final_range;
 };
 static_assert(sizeof(OpusPacketHeader) == 0x8, "OpusHeader is an invalid size");
 


### PR DESCRIPTION
Moves the non-multistream specific state to its own class. This will be necessary to support the multistream variants of opus decoding, given the overall decoder state parameters differ from the regular non-multistreamed version of the decoder.