### PR TITLE
video_core/gpu_thread: Silence a -Wreorder warning

### DIFF
--- a/src/video_core/gpu_thread.h
+++ b/src/video_core/gpu_thread.h
@@ -113,9 +113,6 @@ public:
     /// Notify rasterizer that any caches of the specified region should be flushed and invalidated
     void FlushAndInvalidateRegion(VAddr addr, u64 size);
 
-    /// Waits the caller until the GPU thread is idle, used for synchronization
-    void WaitForIdle();
-
 private:
     /// Pushes a command to be executed by the GPU thread
     void PushCommand(CommandData&& command_data, bool wait_for_idle, bool allow_on_cpu);

--- a/src/video_core/gpu_thread.h
+++ b/src/video_core/gpu_thread.h
@@ -127,10 +127,10 @@ private:
 
 private:
     SynchState state;
-    std::thread thread;
-    std::thread::id thread_id;
     VideoCore::RendererBase& renderer;
     Tegra::DmaPusher& dma_pusher;
+    std::thread thread;
+    std::thread::id thread_id;
 };
 
 } // namespace VideoCommon::GPUThread


### PR DESCRIPTION
Moves the data members to satisfy the order they're declared as in the constructor initializer list. Silences a -Wreorder warning.

This also removes an unimplemented function prototype as well, to prevent accidental usage of it.