### PR TITLE
kernel/server_port: Make data members private

### DIFF
--- a/src/core/hle/kernel/client_port.cpp
+++ b/src/core/hle/kernel/client_port.cpp
@@ -33,10 +33,11 @@ ResultVal<SharedPtr<ClientSession>> ClientPort::Connect() {
     // Create a new session pair, let the created sessions inherit the parent port's HLE handler.
     auto sessions = ServerSession::CreateSessionPair(kernel, server_port->GetName(), this);
 
-    if (server_port->hle_handler)
-        server_port->hle_handler->ClientConnected(std::get<SharedPtr<ServerSession>>(sessions));
-    else
-        server_port->pending_sessions.push_back(std::get<SharedPtr<ServerSession>>(sessions));
+    if (server_port->HasHLEHandler()) {
+        server_port->GetHLEHandler()->ClientConnected(std::get<SharedPtr<ServerSession>>(sessions));
+    } else {
+        server_port->AppendPendingSession(std::get<SharedPtr<ServerSession>>(sessions));
+    }
 
     // Wake the threads waiting on the ServerPort
     server_port->WakeupAllWaitingThreads();

--- a/src/core/hle/kernel/server_port.cpp
+++ b/src/core/hle/kernel/server_port.cpp
@@ -26,6 +26,10 @@ ResultVal<SharedPtr<ServerSession>> ServerPort::Accept() {
     return MakeResult(std::move(session));
 }
 
+void ServerPort::AppendPendingSession(SharedPtr<ServerSession> pending_session) {
+    pending_sessions.push_back(std::move(pending_session));
+}
+
 bool ServerPort::ShouldWait(Thread* thread) const {
     // If there are no pending sessions, we wait until a new one is added.
     return pending_sessions.empty();

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -67,7 +67,7 @@ public:
         if (port == nullptr) {
             return nullptr;
         }
-        return std::static_pointer_cast<T>(port->hle_handler);
+        return std::static_pointer_cast<T>(port->GetHLEHandler());
     }
 
     void InvokeControlRequest(Kernel::HLERequestContext& context);


### PR DESCRIPTION
With this, all kernel objects finally have all of their data members behind an interface, making it nicer to reason about interactions with other code (as external code no longer has the freedom to totally alter internals and potentially messing up invariants).