### PR TITLE
renderer_opengl/gl_global_cache: Add missing override specifiers

### DIFF
--- a/src/video_core/renderer_opengl/gl_global_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_global_cache.cpp
@@ -57,8 +57,8 @@ GlobalRegion GlobalRegionCacheOpenGL::GetUncachedGlobalRegion(VAddr addr, u32 si
     return region;
 }
 
-void GlobalRegionCacheOpenGL::ReserveGlobalRegion(const GlobalRegion& region) {
-    reserve[region->GetAddr()] = region;
+void GlobalRegionCacheOpenGL::ReserveGlobalRegion(GlobalRegion region) {
+    reserve.insert_or_assign(region->GetAddr(), std::move(region));
 }
 
 GlobalRegionCacheOpenGL::GlobalRegionCacheOpenGL(RasterizerOpenGL& rasterizer)

--- a/src/video_core/renderer_opengl/gl_global_cache.h
+++ b/src/video_core/renderer_opengl/gl_global_cache.h
@@ -70,7 +70,7 @@ public:
 private:
     GlobalRegion TryGetReservedGlobalRegion(VAddr addr, u32 size) const;
     GlobalRegion GetUncachedGlobalRegion(VAddr addr, u32 size);
-    void ReserveGlobalRegion(const GlobalRegion& region);
+    void ReserveGlobalRegion(GlobalRegion region);
 
     std::unordered_map<VAddr, GlobalRegion> reserve;
 };

--- a/src/video_core/renderer_opengl/gl_global_cache.h
+++ b/src/video_core/renderer_opengl/gl_global_cache.h
@@ -30,12 +30,12 @@ public:
     explicit CachedGlobalRegion(VAddr addr, u32 size);
 
     /// Gets the address of the shader in guest memory, required for cache management
-    VAddr GetAddr() const {
+    VAddr GetAddr() const override {
         return addr;
     }
 
     /// Gets the size of the shader in guest memory, required for cache management
-    std::size_t GetSizeInBytes() const {
+    std::size_t GetSizeInBytes() const override {
         return size;
     }
 


### PR DESCRIPTION
Silences compiler warnings. While we're in the area, also convert `ReserveGlobalRegion()` over to using `insert_or_assign()`, since it's a fairly trivial change.