### PR TITLE
vk_sampler_cache: Implement a sampler cache

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -123,6 +123,8 @@ if (ENABLE_VULKAN)
         renderer_vulkan/vk_memory_manager.h
         renderer_vulkan/vk_resource_manager.cpp
         renderer_vulkan/vk_resource_manager.h
+        renderer_vulkan/vk_sampler_cache.cpp
+        renderer_vulkan/vk_sampler_cache.h
         renderer_vulkan/vk_scheduler.cpp
         renderer_vulkan/vk_scheduler.h
         renderer_vulkan/vk_stream_buffer.cpp

--- a/src/video_core/renderer_vulkan/vk_sampler_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_sampler_cache.cpp
@@ -35,7 +35,7 @@ std::size_t SamplerCacheKey::Hash() const {
 }
 
 bool SamplerCacheKey::operator==(const SamplerCacheKey& rhs) const {
-    return std::memcmp(raw.data(), rhs.raw.data(), sizeof(raw)) == 0;
+    return raw == rhs.raw;
 }
 
 VKSamplerCache::VKSamplerCache(const VKDevice& device) : device{device} {}

--- a/src/video_core/renderer_vulkan/vk_sampler_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_sampler_cache.cpp
@@ -1,0 +1,81 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <cstring>
+#include <optional>
+#include <unordered_map>
+
+#include "common/assert.h"
+#include "common/cityhash.h"
+#include "video_core/renderer_vulkan/declarations.h"
+#include "video_core/renderer_vulkan/maxwell_to_vk.h"
+#include "video_core/renderer_vulkan/vk_sampler_cache.h"
+#include "video_core/textures/texture.h"
+
+namespace Vulkan {
+
+static std::optional<vk::BorderColor> TryConvertBorderColor(std::array<float, 4> color) {
+    // TODO(Rodrigo): Manage integer border colors
+    if (color == std::array<float, 4>{0, 0, 0, 0}) {
+        return vk::BorderColor::eFloatTransparentBlack;
+    } else if (color == std::array<float, 4>{0, 0, 0, 1}) {
+        return vk::BorderColor::eFloatOpaqueBlack;
+    } else if (color == std::array<float, 4>{1, 1, 1, 1}) {
+        return vk::BorderColor::eFloatOpaqueWhite;
+    } else {
+        return {};
+    }
+}
+
+std::size_t SamplerCacheKey::Hash() const {
+    static_assert(sizeof(raw) % sizeof(u64) == 0);
+    return static_cast<std::size_t>(
+        Common::CityHash64(reinterpret_cast<const char*>(raw.data()), sizeof(raw) / sizeof(u64)));
+}
+
+bool SamplerCacheKey::operator==(const SamplerCacheKey& rhs) const {
+    return std::memcmp(raw.data(), rhs.raw.data(), sizeof(raw)) == 0;
+}
+
+VKSamplerCache::VKSamplerCache(const VKDevice& device) : device{device} {}
+
+VKSamplerCache::~VKSamplerCache() = default;
+
+vk::Sampler VKSamplerCache::GetSampler(const Tegra::Texture::TSCEntry& tsc) {
+    const auto [entry, is_cache_miss] = cache.try_emplace(SamplerCacheKey{tsc});
+    auto& sampler = entry->second;
+    if (is_cache_miss) {
+        sampler = CreateSampler(tsc);
+    }
+    return *sampler;
+}
+
+UniqueSampler VKSamplerCache::CreateSampler(const Tegra::Texture::TSCEntry& tsc) {
+    const float max_anisotropy = tsc.GetMaxAnisotropy();
+    const bool has_anisotropy = max_anisotropy > 1.0f;
+
+    const auto border_color = tsc.GetBorderColor();
+    const auto vk_border_color = TryConvertBorderColor(border_color);
+    UNIMPLEMENTED_IF_MSG(!vk_border_color, "Unimplemented border color {} {} {} {}",
+                         border_color[0], border_color[1], border_color[2], border_color[3]);
+
+    constexpr bool unnormalized_coords = false;
+
+    const vk::SamplerCreateInfo sampler_ci(
+        {}, MaxwellToVK::Sampler::Filter(tsc.mag_filter),
+        MaxwellToVK::Sampler::Filter(tsc.min_filter),
+        MaxwellToVK::Sampler::MipmapMode(tsc.mipmap_filter),
+        MaxwellToVK::Sampler::WrapMode(tsc.wrap_u), MaxwellToVK::Sampler::WrapMode(tsc.wrap_v),
+        MaxwellToVK::Sampler::WrapMode(tsc.wrap_p), tsc.GetLodBias(), has_anisotropy,
+        max_anisotropy, tsc.depth_compare_enabled,
+        MaxwellToVK::Sampler::DepthCompareFunction(tsc.depth_compare_func), tsc.GetMinLod(),
+        tsc.GetMaxLod(), vk_border_color.value_or(vk::BorderColor::eFloatTransparentBlack),
+        unnormalized_coords);
+
+    const auto& dld = device.GetDispatchLoader();
+    const auto dev = device.GetLogical();
+    return dev.createSamplerUnique(sampler_ci, nullptr, dld);
+}
+
+} // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_sampler_cache.h
+++ b/src/video_core/renderer_vulkan/vk_sampler_cache.h
@@ -1,0 +1,56 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <unordered_map>
+
+#include "common/common_types.h"
+#include "video_core/renderer_vulkan/declarations.h"
+#include "video_core/textures/texture.h"
+
+namespace Vulkan {
+
+class VKDevice;
+
+struct SamplerCacheKey final : public Tegra::Texture::TSCEntry {
+    std::size_t Hash() const;
+
+    bool operator==(const SamplerCacheKey& rhs) const;
+
+    bool operator!=(const SamplerCacheKey& rhs) const {
+        return !operator==(rhs);
+    }
+};
+
+} // namespace Vulkan
+
+namespace std {
+
+template <>
+struct hash<Vulkan::SamplerCacheKey> {
+    std::size_t operator()(const Vulkan::SamplerCacheKey& k) const noexcept {
+        return k.Hash();
+    }
+};
+
+} // namespace std
+
+namespace Vulkan {
+
+class VKSamplerCache {
+public:
+    explicit VKSamplerCache(const VKDevice& device);
+    ~VKSamplerCache();
+
+    vk::Sampler GetSampler(const Tegra::Texture::TSCEntry& tsc);
+
+private:
+    UniqueSampler CreateSampler(const Tegra::Texture::TSCEntry& tsc);
+
+    const VKDevice& device;
+    std::unordered_map<SamplerCacheKey, UniqueSampler> cache;
+};
+
+} // namespace Vulkan

--- a/src/video_core/textures/texture.h
+++ b/src/video_core/textures/texture.h
@@ -311,7 +311,7 @@ struct TSCEntry {
             };
             std::array<f32, 4> border_color;
         };
-        std::array<u32, 8> raw;
+        std::array<u8, 0x20> raw;
     };
 
     float GetMaxAnisotropy() const {

--- a/src/video_core/textures/texture.h
+++ b/src/video_core/textures/texture.h
@@ -283,31 +283,36 @@ enum class TextureMipmapFilter : u32 {
 
 struct TSCEntry {
     union {
-        BitField<0, 3, WrapMode> wrap_u;
-        BitField<3, 3, WrapMode> wrap_v;
-        BitField<6, 3, WrapMode> wrap_p;
-        BitField<9, 1, u32> depth_compare_enabled;
-        BitField<10, 3, DepthCompareFunc> depth_compare_func;
-        BitField<13, 1, u32> srgb_conversion;
-        BitField<20, 3, u32> max_anisotropy;
+        struct {
+            union {
+                BitField<0, 3, WrapMode> wrap_u;
+                BitField<3, 3, WrapMode> wrap_v;
+                BitField<6, 3, WrapMode> wrap_p;
+                BitField<9, 1, u32> depth_compare_enabled;
+                BitField<10, 3, DepthCompareFunc> depth_compare_func;
+                BitField<13, 1, u32> srgb_conversion;
+                BitField<20, 3, u32> max_anisotropy;
+            };
+            union {
+                BitField<0, 2, TextureFilter> mag_filter;
+                BitField<4, 2, TextureFilter> min_filter;
+                BitField<6, 2, TextureMipmapFilter> mipmap_filter;
+                BitField<9, 1, u32> cubemap_interface_filtering;
+                BitField<12, 13, u32> mip_lod_bias;
+            };
+            union {
+                BitField<0, 12, u32> min_lod_clamp;
+                BitField<12, 12, u32> max_lod_clamp;
+                BitField<24, 8, u32> srgb_border_color_r;
+            };
+            union {
+                BitField<12, 8, u32> srgb_border_color_g;
+                BitField<20, 8, u32> srgb_border_color_b;
+            };
+            std::array<f32, 4> border_color;
+        };
+        std::array<u32, 8> raw;
     };
-    union {
-        BitField<0, 2, TextureFilter> mag_filter;
-        BitField<4, 2, TextureFilter> min_filter;
-        BitField<6, 2, TextureMipmapFilter> mipmap_filter;
-        BitField<9, 1, u32> cubemap_interface_filtering;
-        BitField<12, 13, u32> mip_lod_bias;
-    };
-    union {
-        BitField<0, 12, u32> min_lod_clamp;
-        BitField<12, 12, u32> max_lod_clamp;
-        BitField<24, 8, u32> srgb_border_color_r;
-    };
-    union {
-        BitField<12, 8, u32> srgb_border_color_g;
-        BitField<20, 8, u32> srgb_border_color_b;
-    };
-    std::array<f32, 4> border_color;
 
     float GetMaxAnisotropy() const {
         return static_cast<float>(1U << max_anisotropy);


### PR DESCRIPTION
Implements a sampler cache that stores Vulkan sampler handles. As future improvement it could receive a fence on sampler queries and destroy samplers that are not being used and have not been used for some time, reducing memory overhead - that being said, samplers should be cheap on most implementations.