### PR TITLE
kernel/process: Remove use of global system accessors

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -133,7 +133,7 @@ void Process::PrepareForTermination() {
             if (thread->GetOwnerProcess() != this)
                 continue;
 
-            if (thread == GetCurrentThread())
+            if (thread == system.CurrentScheduler().GetCurrentThread())
                 continue;
 
             // TODO(Subv): When are the other running/ready threads terminated?
@@ -145,7 +145,6 @@ void Process::PrepareForTermination() {
         }
     };
 
-    const auto& system = Core::System::GetInstance();
     stop_threads(system.Scheduler(0).GetThreadList());
     stop_threads(system.Scheduler(1).GetThreadList());
     stop_threads(system.Scheduler(2).GetThreadList());
@@ -228,13 +227,11 @@ void Process::LoadModule(CodeSet module_, VAddr base_addr) {
     MapSegment(module_.DataSegment(), VMAPermission::ReadWrite, MemoryState::CodeMutable);
 
     // Clear instruction cache in CPU JIT
-    Core::System::GetInstance().ArmInterface(0).ClearInstructionCache();
-    Core::System::GetInstance().ArmInterface(1).ClearInstructionCache();
-    Core::System::GetInstance().ArmInterface(2).ClearInstructionCache();
-    Core::System::GetInstance().ArmInterface(3).ClearInstructionCache();
+    system.InvalidateCpuInstructionCaches();
 }
 
-Process::Process(Core::System& system) : WaitObject{system.Kernel()}, address_arbiter{system} {}
+Process::Process(Core::System& system)
+    : WaitObject{system.Kernel()}, address_arbiter{system}, system{system} {}
 Process::~Process() = default;
 
 void Process::Acquire(Thread* thread) {

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -266,7 +266,7 @@ public:
     void FreeTLSSlot(VAddr tls_address);
 
 private:
-    explicit Process(Core::System& kernel);
+    explicit Process(Core::System& system);
     ~Process() override;
 
     /// Checks if the specified thread should wait until this process is available.
@@ -330,6 +330,10 @@ private:
     /// Random values for svcGetInfo RandomEntropy
     std::array<u64, RANDOM_ENTROPY_SIZE> random_entropy;
 
+    /// System context
+    Core::System& system;
+
+    /// Name of this process
     std::string name;
 };
 


### PR DESCRIPTION
Now that we pass in a reference to the system instance, we can utilize it to eliminate the global accessors in Process-related code.