### PR TITLE
kernel/thread: Actually remove the definition of ExitCurrentThread()

### DIFF
--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -68,12 +68,6 @@ void Thread::Stop() {
     owner_process->FreeTLSSlot(tls_address);
 }
 
-void ExitCurrentThread() {
-    Thread* thread = GetCurrentThread();
-    thread->Stop();
-    Core::System::GetInstance().CurrentScheduler().RemoveThread(thread);
-}
-
 void Thread::WakeAfterDelay(s64 nanoseconds) {
     // Don't schedule a wakeup if the thread wants to wait forever
     if (nanoseconds == -1)


### PR DESCRIPTION
This was intended to be removed in 51d7f6bffcc0498a47abc7de27bf0906fc523dae, but I guess I forgot to actually save the file like a dingus.