### PR TITLE
common/thread_queue_list: Remove unnecessary dependency on boost

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -128,4 +128,4 @@ endif()
 
 create_target_directory_groups(common)
 
-target_link_libraries(common PUBLIC Boost::boost fmt microprofile)
+target_link_libraries(common PUBLIC fmt microprofile)

--- a/src/common/thread_queue_list.h
+++ b/src/common/thread_queue_list.h
@@ -6,7 +6,6 @@
 
 #include <array>
 #include <deque>
-#include <boost/range/algorithm_ext/erase.hpp>
 
 namespace Common {
 
@@ -111,8 +110,9 @@ struct ThreadQueueList {
     }
 
     void remove(Priority priority, const T& thread_id) {
-        Queue* cur = &queues[priority];
-        boost::remove_erase(cur->data, thread_id);
+        Queue* const cur = &queues[priority];
+        const auto iter = std::remove(cur->data.begin(), cur->data.end(), thread_id);
+        cur->data.erase(iter, cur->data.end());
     }
 
     void rotate(Priority priority) {


### PR DESCRIPTION
We really don't need to pull in several headers of boost related machinery just to perform the erase-remove idiom (particularly with C++20 around the corner, which adds universal container std::erase and std::erase_if, which we can just use instead).