### PR TITLE
CMakeLists: Raise minimum Boost requirement to 1.66.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,9 +179,9 @@ set_property(DIRECTORY APPEND PROPERTY
 # System imported libraries
 # ======================
 
-find_package(Boost 1.64.0 QUIET)
+find_package(Boost 1.66.0 QUIET)
 if (NOT Boost_FOUND)
-    message(STATUS "Boost 1.64.0 or newer not found, falling back to externals")
+    message(STATUS "Boost 1.66.0 or newer not found, falling back to externals")
 
     set(BOOST_ROOT "${PROJECT_SOURCE_DIR}/externals/boost")
     set(Boost_NO_SYSTEM_PATHS OFF)


### PR DESCRIPTION
Required due to bugfix in boost for [changed template resolving rules in GCC 7.3.0 in C++17 mode](https://bugzilla.redhat.com/show_bug.cgi?id=1485641).

Closes #2255.