### PR TITLE
service/am: Supply remaining missing IAudioController functions

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -99,7 +99,7 @@ IAudioController::IAudioController() : ServiceFramework("IAudioController") {
         {1, &IAudioController::GetMainAppletExpectedMasterVolume, "GetMainAppletExpectedMasterVolume"},
         {2, &IAudioController::GetLibraryAppletExpectedMasterVolume, "GetLibraryAppletExpectedMasterVolume"},
         {3, nullptr, "ChangeMainAppletMasterVolume"},
-        {4, nullptr, "SetTransparentVolumeRate"},
+        {4, &IAudioController::SetTransparentAudioRate, "SetTransparentVolumeRate"},
     };
     // clang-format on
 
@@ -137,6 +137,20 @@ void IAudioController::GetLibraryAppletExpectedMasterVolume(Kernel::HLERequestCo
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.Push(library_applet_volume);
+}
+
+void IAudioController::SetTransparentAudioRate(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const float transparent_volume_rate_tmp = rp.Pop<float>();
+
+    LOG_DEBUG(Service_AM, "called. transparent_volume_rate={}", transparent_volume_rate_tmp);
+
+    // Clamp volume range to 0-100%.
+    transparent_volume_rate =
+        std::clamp(transparent_volume_rate_tmp, min_allowed_volume, max_allowed_volume);
+
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(RESULT_SUCCESS);
 }
 
 IDisplayController::IDisplayController() : ServiceFramework("IDisplayController") {

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -81,12 +81,14 @@ private:
     void SetExpectedMasterVolume(Kernel::HLERequestContext& ctx);
     void GetMainAppletExpectedMasterVolume(Kernel::HLERequestContext& ctx);
     void GetLibraryAppletExpectedMasterVolume(Kernel::HLERequestContext& ctx);
+    void SetTransparentAudioRate(Kernel::HLERequestContext& ctx);
 
     static constexpr float min_allowed_volume = 0.0f;
     static constexpr float max_allowed_volume = 1.0f;
 
     float main_applet_volume{0.25f};
     float library_applet_volume{max_allowed_volume};
+    float transparent_volume_rate{min_allowed_volume};
 };
 
 class IDisplayController final : public ServiceFramework<IDisplayController> {

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <memory>
 #include <queue>
 #include "core/hle/kernel/writable_event.h"
@@ -81,6 +82,7 @@ private:
     void SetExpectedMasterVolume(Kernel::HLERequestContext& ctx);
     void GetMainAppletExpectedMasterVolume(Kernel::HLERequestContext& ctx);
     void GetLibraryAppletExpectedMasterVolume(Kernel::HLERequestContext& ctx);
+    void ChangeMainAppletMasterVolume(Kernel::HLERequestContext& ctx);
     void SetTransparentAudioRate(Kernel::HLERequestContext& ctx);
 
     static constexpr float min_allowed_volume = 0.0f;
@@ -89,6 +91,12 @@ private:
     float main_applet_volume{0.25f};
     float library_applet_volume{max_allowed_volume};
     float transparent_volume_rate{min_allowed_volume};
+
+    // Volume transition fade time in nanoseconds.
+    // e.g. If the main applet volume was 0% and was changed to 50%
+    //      with a fade of 50ns, then over the course of 50ns,
+    //      the volume will gradually fade up to 50%
+    std::chrono::nanoseconds fade_time_ns{0};
 };
 
 class IDisplayController final : public ServiceFramework<IDisplayController> {

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -82,7 +82,11 @@ private:
     void GetMainAppletExpectedMasterVolume(Kernel::HLERequestContext& ctx);
     void GetLibraryAppletExpectedMasterVolume(Kernel::HLERequestContext& ctx);
 
-    u32 volume{100};
+    static constexpr float min_allowed_volume = 0.0f;
+    static constexpr float max_allowed_volume = 1.0f;
+
+    float main_applet_volume{0.25f};
+    float library_applet_volume{max_allowed_volume};
 };
 
 class IDisplayController final : public ServiceFramework<IDisplayController> {


### PR DESCRIPTION
These are fairly basic HLE commands, that, for the most part, act as getters and setters. While we don't operate directly on the applets yet, for now, it's sufficient to just store the passed in data.