### PR TITLE
input_common/sdl: Correct return values within GetPollers implementations

### DIFF
--- a/src/input_common/sdl/sdl.h
+++ b/src/input_common/sdl/sdl.h
@@ -24,17 +24,17 @@ namespace InputCommon::SDL {
 
 class State {
 public:
-    /// Unresisters SDL device factories and shut them down.
+    using Pollers = std::vector<std::unique_ptr<Polling::DevicePoller>>;
+
+    /// Unregisters SDL device factories and shut them down.
     virtual ~State() = default;
 
-    virtual std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> GetPollers(
-        InputCommon::Polling::DeviceType type) = 0;
+    virtual Pollers GetPollers(Polling::DeviceType type) = 0;
 };
 
 class NullState : public State {
 public:
-    std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> GetPollers(
-        InputCommon::Polling::DeviceType type) override {}
+    Pollers GetPollers(Polling::DeviceType type) override {}
 };
 
 std::unique_ptr<State> Init();

--- a/src/input_common/sdl/sdl.h
+++ b/src/input_common/sdl/sdl.h
@@ -34,7 +34,9 @@ public:
 
 class NullState : public State {
 public:
-    Pollers GetPollers(Polling::DeviceType type) override {}
+    Pollers GetPollers(Polling::DeviceType type) override {
+        return {};
+    }
 };
 
 std::unique_ptr<State> Init();

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -650,9 +650,8 @@ private:
 };
 } // namespace Polling
 
-std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> SDLState::GetPollers(
-    InputCommon::Polling::DeviceType type) {
-    std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> pollers;
+SDLState::Pollers SDLState::GetPollers(InputCommon::Polling::DeviceType type) {
+    Pollers pollers;
     switch (type) {
     case InputCommon::Polling::DeviceType::Analog:
         pollers.emplace_back(std::make_unique<Polling::SDLAnalogPoller>(*this));

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -652,6 +652,7 @@ private:
 
 SDLState::Pollers SDLState::GetPollers(InputCommon::Polling::DeviceType type) {
     Pollers pollers;
+
     switch (type) {
     case InputCommon::Polling::DeviceType::Analog:
         pollers.emplace_back(std::make_unique<Polling::SDLAnalogPoller>(*this));
@@ -659,8 +660,9 @@ SDLState::Pollers SDLState::GetPollers(InputCommon::Polling::DeviceType type) {
     case InputCommon::Polling::DeviceType::Button:
         pollers.emplace_back(std::make_unique<Polling::SDLButtonPoller>(*this));
         break;
-        return pollers;
     }
+
+    return pollers;
 }
 
 } // namespace SDL

--- a/src/input_common/sdl/sdl_impl.h
+++ b/src/input_common/sdl/sdl_impl.h
@@ -25,7 +25,7 @@ public:
     /// Initializes and registers SDL device factories
     SDLState();
 
-    /// Unresisters SDL device factories and shut them down.
+    /// Unregisters SDL device factories and shut them down.
     ~SDLState() override;
 
     /// Handle SDL_Events for joysticks from SDL_PollEvent
@@ -35,8 +35,7 @@ public:
     std::shared_ptr<SDLJoystick> GetSDLJoystickByGUID(const std::string& guid, int port);
 
     /// Get all DevicePoller that use the SDL backend for a specific device type
-    std::vector<std::unique_ptr<InputCommon::Polling::DevicePoller>> GetPollers(
-        InputCommon::Polling::DeviceType type) override;
+    Pollers GetPollers(Polling::DeviceType type) override;
 
     /// Used by the Pollers during config
     std::atomic<bool> polling = false;


### PR DESCRIPTION
Previously they weren't properly returning the containers at all. While we're at it, introduce a type alias to make relevant function declarations and definitions shorter.