### PR TITLE
core/kernel: Migrate CodeSet to its own source files

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -107,6 +107,8 @@ add_library(core STATIC
     hle/kernel/client_port.h
     hle/kernel/client_session.cpp
     hle/kernel/client_session.h
+    hle/kernel/code_set.cpp
+    hle/kernel/code_set.h
     hle/kernel/errors.h
     hle/kernel/handle_table.cpp
     hle/kernel/handle_table.h

--- a/src/core/hle/kernel/code_set.cpp
+++ b/src/core/hle/kernel/code_set.cpp
@@ -1,0 +1,12 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/kernel/code_set.h"
+
+namespace Kernel {
+
+CodeSet::CodeSet() = default;
+CodeSet::~CodeSet() = default;
+
+} // namespace Kernel

--- a/src/core/hle/kernel/code_set.h
+++ b/src/core/hle/kernel/code_set.h
@@ -1,0 +1,90 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+#include "common/common_types.h"
+
+namespace Kernel {
+
+/**
+ * Represents executable data that may be loaded into a kernel process.
+ *
+ * A code set consists of three basic segments:
+ *   - A code (AKA text) segment,
+ *   - A read-only data segment (rodata)
+ *   - A data segment
+ *
+ * The code segment is the portion of the object file that contains
+ * executable instructions.
+ *
+ * The read-only data segment in the portion of the object file that
+ * contains (as one would expect) read-only data, such as fixed constant
+ * values and data structures.
+ *
+ * The data segment is similar to the read-only data segment -- it contains
+ * variables and data structures that have predefined values, however,
+ * entities within this segment can be modified.
+ */
+struct CodeSet final {
+    /// A single segment within a code set.
+    struct Segment final {
+        /// The byte offset that this segment is located at.
+        std::size_t offset = 0;
+
+        /// The address to map this segment to.
+        VAddr addr = 0;
+
+        /// The size of this segment in bytes.
+        u32 size = 0;
+    };
+
+    explicit CodeSet();
+    ~CodeSet();
+
+    CodeSet(const CodeSet&) = delete;
+    CodeSet& operator=(const CodeSet&) = delete;
+
+    CodeSet(CodeSet&&) = default;
+    CodeSet& operator=(CodeSet&&) = default;
+
+    Segment& CodeSegment() {
+        return segments[0];
+    }
+
+    const Segment& CodeSegment() const {
+        return segments[0];
+    }
+
+    Segment& RODataSegment() {
+        return segments[1];
+    }
+
+    const Segment& RODataSegment() const {
+        return segments[1];
+    }
+
+    Segment& DataSegment() {
+        return segments[2];
+    }
+
+    const Segment& DataSegment() const {
+        return segments[2];
+    }
+
+    /// The overall data that backs this code set.
+    std::shared_ptr<std::vector<u8>> memory;
+
+    /// The segments that comprise this code set.
+    std::array<Segment, 3> segments;
+
+    /// The entry point address for this code set.
+    VAddr entrypoint = 0;
+};
+
+} // namespace Kernel

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -9,6 +9,7 @@
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/file_sys/program_metadata.h"
+#include "core/hle/kernel/code_set.h"
 #include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
@@ -49,9 +50,6 @@ void SetupMainThread(Process& owner_process, KernelCore& kernel, VAddr entry_poi
     thread->ResumeFromWait();
 }
 } // Anonymous namespace
-
-CodeSet::CodeSet() = default;
-CodeSet::~CodeSet() = default;
 
 SharedPtr<Process> Process::Create(Core::System& system, std::string&& name) {
     auto& kernel = system.Kernel();

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -210,7 +210,7 @@ void Process::FreeTLSSlot(VAddr tls_address) {
 }
 
 void Process::LoadModule(CodeSet module_, VAddr base_addr) {
-    const auto MapSegment = [&](CodeSet::Segment& segment, VMAPermission permissions,
+    const auto MapSegment = [&](const CodeSet::Segment& segment, VMAPermission permissions,
                                 MemoryState memory_state) {
         const auto vma = vm_manager
                              .MapMemoryBlock(segment.addr + base_addr, module_.memory,

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -7,7 +7,6 @@
 #include <array>
 #include <bitset>
 #include <cstddef>
-#include <memory>
 #include <string>
 #include <vector>
 #include <boost/container/static_vector.hpp>
@@ -32,6 +31,8 @@ namespace Kernel {
 class KernelCore;
 class ResourceLimit;
 class Thread;
+
+struct CodeSet;
 
 struct AddressMapping {
     // Address and size must be page-aligned
@@ -63,46 +64,6 @@ enum class ProcessStatus {
     Exiting,
     Exited,
     DebugBreak,
-};
-
-struct CodeSet final {
-    struct Segment {
-        std::size_t offset = 0;
-        VAddr addr = 0;
-        u32 size = 0;
-    };
-
-    explicit CodeSet();
-    ~CodeSet();
-
-    Segment& CodeSegment() {
-        return segments[0];
-    }
-
-    const Segment& CodeSegment() const {
-        return segments[0];
-    }
-
-    Segment& RODataSegment() {
-        return segments[1];
-    }
-
-    const Segment& RODataSegment() const {
-        return segments[1];
-    }
-
-    Segment& DataSegment() {
-        return segments[2];
-    }
-
-    const Segment& DataSegment() const {
-        return segments[2];
-    }
-
-    std::shared_ptr<std::vector<u8>> memory;
-
-    std::array<Segment, 3> segments;
-    VAddr entrypoint = 0;
 };
 
 class Process final : public WaitObject {

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -9,6 +9,7 @@
 #include "common/common_types.h"
 #include "common/file_util.h"
 #include "common/logging/log.h"
+#include "core/hle/kernel/code_set.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/vm_manager.h"
 #include "core/loader/elf.h"

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -14,6 +14,7 @@
 #include "core/file_sys/romfs_factory.h"
 #include "core/file_sys/vfs_offset.h"
 #include "core/gdbstub/gdbstub.h"
+#include "core/hle/kernel/code_set.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/vm_manager.h"
 #include "core/hle/service/filesystem/filesystem.h"

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -11,6 +11,7 @@
 #include "common/swap.h"
 #include "core/file_sys/patch_manager.h"
 #include "core/gdbstub/gdbstub.h"
+#include "core/hle/kernel/code_set.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/vm_manager.h"
 #include "core/loader/nso.h"


### PR DESCRIPTION
Moves our class that holds the executable data to be mapped into memory into its own source file, to avoid the need to drag in other kernel objects when only its definition is needed. Also adds some basic documentation for the data structure as well.