### PR TITLE
Report out of range memory reads instead of crashing.

### DIFF
--- a/src/common/page_table.cpp
+++ b/src/common/page_table.cpp
@@ -6,7 +6,9 @@
 
 namespace Common {
 
-PageTable::PageTable(std::size_t page_size_in_bits) : page_size_in_bits{page_size_in_bits} {}
+PageTable::PageTable(std::size_t page_size_in_bits) : page_size_in_bits{page_size_in_bits} {
+    number_of_entries = 1ULL << page_size_in_bits;
+}
 
 PageTable::~PageTable() = default;
 
@@ -24,6 +26,7 @@ void PageTable::Resize(std::size_t address_space_width_in_bits) {
 
     pointers.shrink_to_fit();
     attributes.shrink_to_fit();
+    number_of_entries = num_page_table_entries;
 }
 
 } // namespace Common

--- a/src/common/page_table.h
+++ b/src/common/page_table.h
@@ -75,6 +75,12 @@ struct PageTable {
     std::vector<PageType> attributes;
 
     const std::size_t page_size_in_bits{};
+
+    /**
+     * Size variable that contains the number of entries to this page table's. Equivalent
+     * to page_table->pointers.size(). Used for micro-optimizations on reads.
+     */
+    std::size_t number_of_entries;
 };
 
 } // namespace Common

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -152,7 +152,12 @@ static u8* GetPointerFromVMA(VAddr vaddr) {
 
 template <typename T>
 T Read(const VAddr vaddr) {
-    const u8* page_pointer = current_page_table->pointers[vaddr >> PAGE_BITS];
+    auto entry = vaddr >> PAGE_BITS;
+    if (entry > current_page_table->number_of_entries) {
+        LOG_ERROR(HW_Memory, "Out of range Read{} @ 0x{:08X}", sizeof(T) * 8, vaddr);
+        return 0;
+    }
+    const u8* page_pointer = current_page_table->pointers[entry];
     if (page_pointer) {
         // NOTE: Avoid adding any extra logic to this fast-path block
         T value;


### PR DESCRIPTION
This PR reports out of range reads instead of letting yuzu crash. It should help with debugging and avoid certain crashes with Async on.