### PR TITLE
kernel/svc: Implement svcGetProcessList and svcGetThreadList

### DIFF
--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -191,6 +191,10 @@ const Process* KernelCore::CurrentProcess() const {
     return impl->current_process;
 }
 
+const std::vector<SharedPtr<Process>>& KernelCore::GetProcessList() const {
+    return impl->process_list;
+}
+
 void KernelCore::AddNamedPort(std::string name, SharedPtr<ClientPort> port) {
     impl->named_ports.emplace(std::move(name), std::move(port));
 }

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -72,6 +72,9 @@ public:
     /// Retrieves a const pointer to the current process.
     const Process* CurrentProcess() const;
 
+    /// Retrieves the list of processes.
+    const std::vector<SharedPtr<Process>>& GetProcessList() const;
+
     /// Adds a port to the named port table
     void AddNamedPort(std::string name, SharedPtr<ClientPort> port);
 

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -80,6 +80,14 @@ u64 Process::GetTotalPhysicalMemoryUsed() const {
     return vm_manager.GetCurrentHeapSize() + main_thread_stack_size + code_memory_size;
 }
 
+void Process::RegisterThread(const Thread* thread) {
+    thread_list.push_back(thread);
+}
+
+void Process::UnregisterThread(const Thread* thread) {
+    thread_list.remove(thread);
+}
+
 ResultCode Process::ClearSignalState() {
     if (status == ProcessStatus::Exited) {
         LOG_ERROR(Kernel, "called on a terminated process instance.");

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <bitset>
 #include <cstddef>
+#include <list>
 #include <string>
 #include <vector>
 #include <boost/container/static_vector.hpp>
@@ -189,6 +190,19 @@ public:
     /// Retrieves the total physical memory used by this process in bytes.
     u64 GetTotalPhysicalMemoryUsed() const;
 
+    /// Gets the list of all threads created with this process as their owner.
+    const std::list<const Thread*>& GetThreadList() const {
+        return thread_list;
+    }
+
+    /// Registers a thread as being created under this process,
+    /// adding it to this process' thread list.
+    void RegisterThread(const Thread* thread);
+
+    /// Unregisters a thread from this process, removing it
+    /// from this process' thread list.
+    void UnregisterThread(const Thread* thread);
+
     /// Clears the signaled state of the process if and only if it's signaled.
     ///
     /// @pre The process must not be already terminated. If this is called on a
@@ -307,6 +321,9 @@ private:
 
     /// Random values for svcGetInfo RandomEntropy
     std::array<u64, RANDOM_ENTROPY_SIZE> random_entropy;
+
+    /// List of threads that are running with this process as their owner.
+    std::list<const Thread*> thread_list;
 
     /// System context
     Core::System& system;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -2020,6 +2020,46 @@ static ResultCode GetProcessList(u32* out_num_processes, VAddr out_process_ids,
     return RESULT_SUCCESS;
 }
 
+ResultCode GetThreadList(u32* out_num_threads, VAddr out_thread_ids, u32 out_thread_ids_size,
+                         Handle debug_handle) {
+    // TODO: Handle this case when debug events are supported.
+    UNIMPLEMENTED_IF(debug_handle != InvalidHandle);
+
+    LOG_DEBUG(Kernel_SVC, "called. out_thread_ids=0x{:016X}, out_thread_ids_size={}",
+              out_thread_ids, out_thread_ids_size);
+
+    // If the size is negative or larger than INT32_MAX / sizeof(u64)
+    if ((out_thread_ids_size & 0xF0000000) != 0) {
+        LOG_ERROR(Kernel_SVC, "Supplied size outside [0, 0x0FFFFFFF] range. size={}",
+                  out_thread_ids_size);
+        return ERR_OUT_OF_RANGE;
+    }
+
+    const auto* const current_process = Core::System::GetInstance().Kernel().CurrentProcess();
+    const auto& vm_manager = current_process->VMManager();
+    const auto total_copy_size = out_thread_ids_size * sizeof(u64);
+
+    if (out_thread_ids_size > 0 &&
+        !vm_manager.IsWithinAddressSpace(out_thread_ids, total_copy_size)) {
+        LOG_ERROR(Kernel_SVC, "Address range outside address space. begin=0x{:016X}, end=0x{:016X}",
+                  out_thread_ids, out_thread_ids + total_copy_size);
+        return ERR_INVALID_ADDRESS_STATE;
+    }
+
+    const auto& thread_list = current_process->GetThreadList();
+    const auto num_threads = thread_list.size();
+    const auto copy_amount = std::min(std::size_t{out_thread_ids_size}, num_threads);
+
+    auto list_iter = thread_list.cbegin();
+    for (std::size_t i = 0; i < copy_amount; ++i, ++list_iter) {
+        Memory::Write64(out_thread_ids, (*list_iter)->GetThreadID());
+        out_thread_ids += sizeof(u64);
+    }
+
+    *out_num_threads = static_cast<u32>(num_threads);
+    return RESULT_SUCCESS;
+}
+
 namespace {
 struct FunctionDef {
     using Func = void();
@@ -2133,7 +2173,7 @@ static const FunctionDef SVC_Table[] = {
     {0x63, nullptr, "GetDebugEvent"},
     {0x64, nullptr, "ContinueDebugEvent"},
     {0x65, SvcWrap<GetProcessList>, "GetProcessList"},
-    {0x66, nullptr, "GetThreadList"},
+    {0x66, SvcWrap<GetThreadList>, "GetThreadList"},
     {0x67, nullptr, "GetDebugThreadContext"},
     {0x68, nullptr, "SetDebugThreadContext"},
     {0x69, nullptr, "QueryDebugProcessMemory"},

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -78,6 +78,14 @@ void SvcWrap() {
     FuncReturn(retval);
 }
 
+template <ResultCode func(u32*, u64, u32)>
+void SvcWrap() {
+    u32 param_1 = 0;
+    const u32 retval = func(&param_1, Param(1), static_cast<u32>(Param(2))).raw;
+    Core::CurrentArmInterface().SetReg(1, param_1);
+    FuncReturn(retval);
+}
+
 template <ResultCode func(u64*, u32)>
 void SvcWrap() {
     u64 param_1 = 0;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -62,6 +62,8 @@ void Thread::Stop() {
     }
     wait_objects.clear();
 
+    owner_process->UnregisterThread(this);
+
     // Mark the TLS slot in the thread's page as free.
     owner_process->FreeTLSSlot(tls_address);
 }
@@ -201,6 +203,8 @@ ResultVal<SharedPtr<Thread>> Thread::Create(KernelCore& kernel, std::string name
     thread->scheduler = &system.Scheduler(processor_id);
     thread->scheduler->AddThread(thread);
     thread->tls_address = thread->owner_process->MarkNextAvailableTLSSlotAsUsed(*thread);
+
+    thread->owner_process->RegisterThread(thread.get());
 
     // TODO(peachum): move to ScheduleThread() when scheduler is added so selected core is used
     // to initialize the context


### PR DESCRIPTION
Implements two basic info querying supervisor call functions. One retrieves the list of existing processes in general, while the other retrieves the list of threads under the current process. svcGetThreadList also allows passing in a handle to a kernel debug object, but we currently don't implement these events, so I've added an unimplemented assertion for that case.

Fairly simple as far as querying functions go.