### PR TITLE
common/CMakeLists: Amend boost dependency

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -134,4 +134,4 @@ endif()
 
 create_target_directory_groups(common)
 
-target_link_libraries(common PUBLIC fmt microprofile)
+target_link_libraries(common PUBLIC Boost::boost fmt microprofile)


### PR DESCRIPTION
When #2247 was created, thread_queue_list.h was the only user of boost-related code, however #2252 moved the page table struct into common, which makes use of Boost.ICL, so we need to add the dependency to it again.