### PR TITLE
kernel/vm_manager: Amend flag value for code data

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -220,9 +220,9 @@ void Process::LoadModule(CodeSet module_, VAddr base_addr) {
     };
 
     // Map CodeSet segments
-    MapSegment(module_.CodeSegment(), VMAPermission::ReadExecute, MemoryState::CodeStatic);
-    MapSegment(module_.RODataSegment(), VMAPermission::Read, MemoryState::CodeMutable);
-    MapSegment(module_.DataSegment(), VMAPermission::ReadWrite, MemoryState::CodeMutable);
+    MapSegment(module_.CodeSegment(), VMAPermission::ReadExecute, MemoryState::Code);
+    MapSegment(module_.RODataSegment(), VMAPermission::Read, MemoryState::CodeData);
+    MapSegment(module_.DataSegment(), VMAPermission::ReadWrite, MemoryState::CodeData);
 
     // Clear instruction cache in CPU JIT
     system.InvalidateCpuInstructionCaches();

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -20,16 +20,16 @@ namespace Kernel {
 namespace {
 const char* GetMemoryStateName(MemoryState state) {
     static constexpr const char* names[] = {
-        "Unmapped",         "Io",
-        "Normal",           "CodeStatic",
-        "CodeMutable",      "Heap",
-        "Shared",           "Unknown1",
-        "ModuleCodeStatic", "ModuleCodeMutable",
-        "IpcBuffer0",       "Stack",
-        "ThreadLocal",      "TransferMemoryIsolated",
-        "TransferMemory",   "ProcessMemory",
-        "Inaccessible",     "IpcBuffer1",
-        "IpcBuffer3",       "KernelStack",
+        "Unmapped",       "Io",
+        "Normal",         "Code",
+        "CodeData",       "Heap",
+        "Shared",         "Unknown1",
+        "ModuleCode",     "ModuleCodeData",
+        "IpcBuffer0",     "Stack",
+        "ThreadLocal",    "TransferMemoryIsolated",
+        "TransferMemory", "ProcessMemory",
+        "Inaccessible",   "IpcBuffer1",
+        "IpcBuffer3",     "KernelStack",
     };
 
     return names[ToSvcMemoryState(state)];

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -166,7 +166,7 @@ enum class MemoryState : u32 {
     Io                     = 0x01 | FlagMapped,
     Normal                 = 0x02 | FlagMapped | FlagQueryPhysicalAddressAllowed,
     CodeStatic             = 0x03 | CodeFlags  | FlagMapProcess,
-    CodeMutable            = 0x04 | CodeFlags  | FlagMapProcess | FlagCodeMemory,
+    CodeMutable            = 0x04 | DataFlags  | FlagMapProcess | FlagCodeMemory,
     Heap                   = 0x05 | DataFlags  | FlagCodeMemory,
     Shared                 = 0x06 | FlagMapped | FlagMemoryPoolAllocated,
     ModuleCodeStatic       = 0x08 | CodeFlags  | FlagModule | FlagMapProcess,

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -165,12 +165,12 @@ enum class MemoryState : u32 {
     Unmapped               = 0x00,
     Io                     = 0x01 | FlagMapped,
     Normal                 = 0x02 | FlagMapped | FlagQueryPhysicalAddressAllowed,
-    CodeStatic             = 0x03 | CodeFlags  | FlagMapProcess,
-    CodeMutable            = 0x04 | DataFlags  | FlagMapProcess | FlagCodeMemory,
+    Code                   = 0x03 | CodeFlags  | FlagMapProcess,
+    CodeData               = 0x04 | DataFlags  | FlagMapProcess | FlagCodeMemory,
     Heap                   = 0x05 | DataFlags  | FlagCodeMemory,
     Shared                 = 0x06 | FlagMapped | FlagMemoryPoolAllocated,
-    ModuleCodeStatic       = 0x08 | CodeFlags  | FlagModule | FlagMapProcess,
-    ModuleCodeMutable      = 0x09 | DataFlags  | FlagModule | FlagMapProcess | FlagCodeMemory,
+    ModuleCode             = 0x08 | CodeFlags  | FlagModule | FlagMapProcess,
+    ModuleCodeData         = 0x09 | DataFlags  | FlagModule | FlagMapProcess | FlagCodeMemory,
 
     IpcBuffer0             = 0x0A | FlagMapped | FlagQueryPhysicalAddressAllowed | FlagMemoryPoolAllocated |
                                     IPCFlags | FlagSharedDevice | FlagSharedDeviceAligned,

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -319,15 +319,14 @@ public:
         }
 
         ASSERT(vm_manager
-                   .MirrorMemory(*map_address, nro_addr, nro_size,
-                                 Kernel::MemoryState::ModuleCodeStatic)
+                   .MirrorMemory(*map_address, nro_addr, nro_size, Kernel::MemoryState::ModuleCode)
                    .IsSuccess());
         ASSERT(vm_manager.UnmapRange(nro_addr, nro_size).IsSuccess());
 
         if (bss_size > 0) {
             ASSERT(vm_manager
                        .MirrorMemory(*map_address + nro_size, bss_addr, bss_size,
-                                     Kernel::MemoryState::ModuleCodeStatic)
+                                     Kernel::MemoryState::ModuleCode)
                        .IsSuccess());
             ASSERT(vm_manager.UnmapRange(bss_addr, bss_size).IsSuccess());
         }
@@ -388,8 +387,7 @@ public:
         const auto& nro_size = iter->second.size;
 
         ASSERT(vm_manager
-                   .MirrorMemory(heap_addr, mapped_addr, nro_size,
-                                 Kernel::MemoryState::ModuleCodeStatic)
+                   .MirrorMemory(heap_addr, mapped_addr, nro_size, Kernel::MemoryState::ModuleCode)
                    .IsSuccess());
         ASSERT(vm_manager.UnmapRange(mapped_addr, nro_size).IsSuccess());
 


### PR DESCRIPTION
The CodeData flags were using the CodeFlags flag superset, when it should be using the DataFlags flag superset. Fixes booting Shantae Half-Genie Hero (and probably a few other games). While we're at it, rename CodeStatic/CodeMutable to Code and CodeData where applicable to disambiguate this a little better.

(ROData is technically not mutable, so mutable/static wasn't the best choice of terminology anyways)

![BootScreen](https://user-images.githubusercontent.com/712067/54764958-0d99af80-4bcf-11e9-9646-33476da183f8.png)
