### PR TITLE
kernel/codeset: Make CodeSet's memory data member a regular std::vector

### DIFF
--- a/src/core/hle/kernel/code_set.h
+++ b/src/core/hle/kernel/code_set.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <cstddef>
-#include <memory>
 #include <vector>
 
 #include "common/common_types.h"
@@ -78,7 +77,7 @@ struct CodeSet final {
     }
 
     /// The overall data that backs this code set.
-    std::shared_ptr<std::vector<u8>> memory;
+    std::vector<u8> memory;
 
     /// The segments that comprise this code set.
     std::array<Segment, 3> segments;

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -210,11 +210,13 @@ void Process::FreeTLSSlot(VAddr tls_address) {
 }
 
 void Process::LoadModule(CodeSet module_, VAddr base_addr) {
+    const auto memory = std::make_shared<std::vector<u8>>(std::move(module_.memory));
+
     const auto MapSegment = [&](const CodeSet::Segment& segment, VMAPermission permissions,
                                 MemoryState memory_state) {
         const auto vma = vm_manager
-                             .MapMemoryBlock(segment.addr + base_addr, module_.memory,
-                                             segment.offset, segment.size, memory_state)
+                             .MapMemoryBlock(segment.addr + base_addr, memory, segment.offset,
+                                             segment.size, memory_state)
                              .Unwrap();
         vm_manager.Reprotect(vma, permissions);
     };

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -341,7 +341,7 @@ Kernel::CodeSet ElfReader::LoadInto(VAddr vaddr) {
     }
 
     codeset.entrypoint = base_addr + header->e_entry;
-    codeset.memory = std::make_shared<std::vector<u8>>(std::move(program_image));
+    codeset.memory = std::move(program_image);
 
     LOG_DEBUG(Loader, "Done loading.");
 

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -187,7 +187,7 @@ static bool LoadNroImpl(Kernel::Process& process, const std::vector<u8>& data,
     program_image.resize(static_cast<u32>(program_image.size()) + bss_size);
 
     // Load codeset for current process
-    codeset.memory = std::make_shared<std::vector<u8>>(std::move(program_image));
+    codeset.memory = std::move(program_image);
     process.LoadModule(std::move(codeset), load_base);
 
     // Register module with GDBStub

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -178,7 +178,7 @@ std::optional<VAddr> AppLoader_NSO::LoadModule(Kernel::Process& process,
     }
 
     // Load codeset for current process
-    codeset.memory = std::make_shared<std::vector<u8>>(std::move(program_image));
+    codeset.memory = std::move(program_image);
     process.LoadModule(std::move(codeset), load_base);
 
     // Register module with GDBStub


### PR DESCRIPTION
The use of a shared_ptr is an implementation detail of the VMManager itself when mapping memory. Because of that, we shouldn't require all users of the CodeSet to have to allocate the shared_ptr ahead of time. It's intended that CodeSet simply pass in the required direct data, and that the memory manager takes care of it from that point on.

This means we just do the shared pointer allocation in a single place, when loading modules, as opposed to in each loader.