### PR TITLE
kernel/kernel: Remove unnecessary forward declaration

### DIFF
--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -8,9 +8,6 @@
 #include <unordered_map>
 #include "core/hle/kernel/object.h"
 
-template <typename T>
-class ResultVal;
-
 namespace Core {
 class System;
 }


### PR DESCRIPTION
This is no longer necessary, as ResultVal isn't used anywhere in the header.