### PR TITLE
yuzu_tester: Add and implement testing utility for homebrew

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -88,6 +88,7 @@ add_subdirectory(tests)
 
 if (ENABLE_SDL2)
     add_subdirectory(yuzu_cmd)
+    add_subdirectory(yuzu_tester)
 endif()
 
 if (ENABLE_QT)

--- a/src/yuzu_tester/CMakeLists.txt
+++ b/src/yuzu_tester/CMakeLists.txt
@@ -1,0 +1,34 @@
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMakeModules)
+
+add_executable(yuzu-tester
+    config.cpp
+    config.h
+    default_ini.h
+    emu_window/emu_window_sdl2_hide.cpp
+    emu_window/emu_window_sdl2_hide.h
+    resource.h
+    service/yuzutest.cpp
+    service/yuzutest.h
+    yuzu.cpp
+    yuzu.rc
+)
+
+create_target_directory_groups(yuzu-tester)
+
+target_link_libraries(yuzu-tester PRIVATE common core input_common)
+target_link_libraries(yuzu-tester PRIVATE inih glad)
+if (MSVC)
+    target_link_libraries(yuzu-tester PRIVATE getopt)
+endif()
+target_link_libraries(yuzu-tester PRIVATE ${PLATFORM_LIBRARIES} SDL2 Threads::Threads)
+
+if(UNIX AND NOT APPLE)
+    install(TARGETS yuzu-tester RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+endif()
+
+if (MSVC)
+    include(CopyYuzuSDLDeps)
+    include(CopyYuzuUnicornDeps)
+    copy_yuzu_SDL_deps(yuzu-tester)
+    copy_yuzu_unicorn_deps(yuzu-tester)
+endif()

--- a/src/yuzu_tester/config.cpp
+++ b/src/yuzu_tester/config.cpp
@@ -93,7 +93,6 @@ void Config::ReadValues() {
 
     // System
     Settings::values.use_docked_mode = sdl2_config->GetBoolean("System", "use_docked_mode", false);
-    Settings::values.enable_nfc = sdl2_config->GetBoolean("System", "enable_nfc", true);
     const auto size = sdl2_config->GetInteger("System", "users_size", 0);
 
     Settings::values.current_user = std::clamp<int>(

--- a/src/yuzu_tester/config.cpp
+++ b/src/yuzu_tester/config.cpp
@@ -1,0 +1,185 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+#include <sstream>
+#include <SDL.h>
+#include <inih/cpp/INIReader.h>
+#include "common/file_util.h"
+#include "common/logging/log.h"
+#include "common/param_package.h"
+#include "core/hle/service/acc/profile_manager.h"
+#include "core/settings.h"
+#include "input_common/main.h"
+#include "yuzu_tester/config.h"
+#include "yuzu_tester/default_ini.h"
+
+Config::Config() {
+    // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
+    sdl2_config_loc =
+        FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + "sdl2-tester-config.ini";
+    sdl2_config = std::make_unique<INIReader>(sdl2_config_loc);
+
+    Reload();
+}
+
+Config::~Config() = default;
+
+bool Config::LoadINI(const std::string& default_contents, bool retry) {
+    const char* location = this->sdl2_config_loc.c_str();
+    if (sdl2_config->ParseError() < 0) {
+        if (retry) {
+            LOG_WARNING(Config, "Failed to load {}. Creating file from defaults...", location);
+            FileUtil::CreateFullPath(location);
+            FileUtil::WriteStringToFile(true, default_contents, location);
+            sdl2_config = std::make_unique<INIReader>(location); // Reopen file
+
+            return LoadINI(default_contents, false);
+        }
+        LOG_ERROR(Config, "Failed.");
+        return false;
+    }
+    LOG_INFO(Config, "Successfully loaded {}", location);
+    return true;
+}
+
+void Config::ReadValues() {
+    // Controls
+    for (std::size_t p = 0; p < Settings::values.players.size(); ++p) {
+        for (int i = 0; i < Settings::NativeButton::NumButtons; ++i) {
+            Settings::values.players[p].buttons[i] = "";
+        }
+
+        for (int i = 0; i < Settings::NativeAnalog::NumAnalogs; ++i) {
+            Settings::values.players[p].analogs[i] = "";
+        }
+    }
+
+    Settings::values.mouse_enabled = false;
+    for (int i = 0; i < Settings::NativeMouseButton::NumMouseButtons; ++i) {
+        Settings::values.mouse_buttons[i] = "";
+    }
+
+    Settings::values.motion_device = "";
+
+    Settings::values.keyboard_enabled = false;
+
+    Settings::values.debug_pad_enabled = false;
+    for (int i = 0; i < Settings::NativeButton::NumButtons; ++i) {
+        Settings::values.debug_pad_buttons[i] = "";
+    }
+
+    for (int i = 0; i < Settings::NativeAnalog::NumAnalogs; ++i) {
+        Settings::values.debug_pad_analogs[i] = "";
+    }
+
+    Settings::values.touchscreen.enabled = "";
+    Settings::values.touchscreen.device = "";
+    Settings::values.touchscreen.finger = 0;
+    Settings::values.touchscreen.rotation_angle = 0;
+    Settings::values.touchscreen.diameter_x = 15;
+    Settings::values.touchscreen.diameter_y = 15;
+
+    // Data Storage
+    Settings::values.use_virtual_sd =
+        sdl2_config->GetBoolean("Data Storage", "use_virtual_sd", true);
+    FileUtil::GetUserPath(FileUtil::UserPath::NANDDir,
+                          sdl2_config->Get("Data Storage", "nand_directory",
+                                           FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)));
+    FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir,
+                          sdl2_config->Get("Data Storage", "sdmc_directory",
+                                           FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)));
+
+    // System
+    Settings::values.use_docked_mode = sdl2_config->GetBoolean("System", "use_docked_mode", false);
+    Settings::values.enable_nfc = sdl2_config->GetBoolean("System", "enable_nfc", true);
+    const auto size = sdl2_config->GetInteger("System", "users_size", 0);
+
+    Settings::values.current_user = std::clamp<int>(
+        sdl2_config->GetInteger("System", "current_user", 0), 0, Service::Account::MAX_USERS - 1);
+
+    const auto rng_seed_enabled = sdl2_config->GetBoolean("System", "rng_seed_enabled", false);
+    if (rng_seed_enabled) {
+        Settings::values.rng_seed = sdl2_config->GetInteger("System", "rng_seed", 0);
+    } else {
+        Settings::values.rng_seed = std::nullopt;
+    }
+
+    const auto custom_rtc_enabled = sdl2_config->GetBoolean("System", "custom_rtc_enabled", false);
+    if (custom_rtc_enabled) {
+        Settings::values.custom_rtc =
+            std::chrono::seconds(sdl2_config->GetInteger("System", "custom_rtc", 0));
+    } else {
+        Settings::values.custom_rtc = std::nullopt;
+    }
+
+    // Core
+    Settings::values.use_cpu_jit = sdl2_config->GetBoolean("Core", "use_cpu_jit", true);
+    Settings::values.use_multi_core = sdl2_config->GetBoolean("Core", "use_multi_core", false);
+
+    // Renderer
+    Settings::values.resolution_factor =
+        static_cast<float>(sdl2_config->GetReal("Renderer", "resolution_factor", 1.0));
+    Settings::values.use_frame_limit = false;
+    Settings::values.frame_limit = 100;
+    Settings::values.use_disk_shader_cache =
+        sdl2_config->GetBoolean("Renderer", "use_disk_shader_cache", false);
+    Settings::values.use_accurate_gpu_emulation =
+        sdl2_config->GetBoolean("Renderer", "use_accurate_gpu_emulation", false);
+    Settings::values.use_asynchronous_gpu_emulation =
+        sdl2_config->GetBoolean("Renderer", "use_asynchronous_gpu_emulation", false);
+
+    Settings::values.bg_red = static_cast<float>(sdl2_config->GetReal("Renderer", "bg_red", 0.0));
+    Settings::values.bg_green =
+        static_cast<float>(sdl2_config->GetReal("Renderer", "bg_green", 0.0));
+    Settings::values.bg_blue = static_cast<float>(sdl2_config->GetReal("Renderer", "bg_blue", 0.0));
+
+    // Audio
+    Settings::values.sink_id = "null";
+    Settings::values.enable_audio_stretching = false;
+    Settings::values.audio_device_id = "auto";
+    Settings::values.volume = 0;
+
+    Settings::values.language_index = sdl2_config->GetInteger("System", "language_index", 1);
+
+    // Miscellaneous
+    Settings::values.log_filter = sdl2_config->Get("Miscellaneous", "log_filter", "*:Trace");
+    Settings::values.use_dev_keys = sdl2_config->GetBoolean("Miscellaneous", "use_dev_keys", false);
+
+    // Debugging
+    Settings::values.use_gdbstub = false;
+    Settings::values.program_args = "";
+    Settings::values.dump_exefs = sdl2_config->GetBoolean("Debugging", "dump_exefs", false);
+    Settings::values.dump_nso = sdl2_config->GetBoolean("Debugging", "dump_nso", false);
+
+    const auto title_list = sdl2_config->Get("AddOns", "title_ids", "");
+    std::stringstream ss(title_list);
+    std::string line;
+    while (std::getline(ss, line, '|')) {
+        const auto title_id = std::stoul(line, nullptr, 16);
+        const auto disabled_list = sdl2_config->Get("AddOns", "disabled_" + line, "");
+
+        std::stringstream inner_ss(disabled_list);
+        std::string inner_line;
+        std::vector<std::string> out;
+        while (std::getline(inner_ss, inner_line, '|')) {
+            out.push_back(inner_line);
+        }
+
+        Settings::values.disabled_addons.insert_or_assign(title_id, out);
+    }
+
+    // Web Service
+    Settings::values.enable_telemetry =
+        sdl2_config->GetBoolean("WebService", "enable_telemetry", true);
+    Settings::values.web_api_url =
+        sdl2_config->Get("WebService", "web_api_url", "https://api.yuzu-emu.org");
+    Settings::values.yuzu_username = sdl2_config->Get("WebService", "yuzu_username", "");
+    Settings::values.yuzu_token = sdl2_config->Get("WebService", "yuzu_token", "");
+}
+
+void Config::Reload() {
+    LoadINI(DefaultINI::sdl2_config_file);
+    ReadValues();
+}

--- a/src/yuzu_tester/config.h
+++ b/src/yuzu_tester/config.h
@@ -1,0 +1,24 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+class INIReader;
+
+class Config {
+    std::unique_ptr<INIReader> sdl2_config;
+    std::string sdl2_config_loc;
+
+    bool LoadINI(const std::string& default_contents = "", bool retry = true);
+    void ReadValues();
+
+public:
+    Config();
+    ~Config();
+
+    void Reload();
+};

--- a/src/yuzu_tester/default_ini.h
+++ b/src/yuzu_tester/default_ini.h
@@ -1,0 +1,150 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+namespace DefaultINI {
+
+const char* sdl2_config_file = R"(
+[Core]
+# Whether to use the Just-In-Time (JIT) compiler for CPU emulation
+# 0: Interpreter (slow), 1 (default): JIT (fast)
+use_cpu_jit =
+
+# Whether to use multi-core for CPU emulation
+# 0 (default): Disabled, 1: Enabled
+use_multi_core=
+
+[Renderer]
+# Whether to use software or hardware rendering.
+# 0: Software, 1 (default): Hardware
+use_hw_renderer =
+
+# Whether to use the Just-In-Time (JIT) compiler for shader emulation
+# 0: Interpreter (slow), 1 (default): JIT (fast)
+use_shader_jit =
+
+# Resolution scale factor
+# 0: Auto (scales resolution to window size), 1: Native Switch screen resolution, Otherwise a scale
+# factor for the Switch resolution
+resolution_factor =
+
+# Whether to enable V-Sync (caps the framerate at 60FPS) or not.
+# 0 (default): Off, 1: On
+use_vsync =
+
+# Whether to use disk based shader cache
+# 0 (default): Off, 1 : On
+use_disk_shader_cache =
+
+# Whether to use accurate GPU emulation
+# 0 (default): Off (fast), 1 : On (slow)
+use_accurate_gpu_emulation =
+
+# Whether to use asynchronous GPU emulation
+# 0 : Off (slow), 1 (default): On (fast)
+use_asynchronous_gpu_emulation =
+
+# The clear color for the renderer. What shows up on the sides of the bottom screen.
+# Must be in range of 0.0-1.0. Defaults to 1.0 for all.
+bg_red =
+bg_blue =
+bg_green =
+
+[Layout]
+# Layout for the screen inside the render window.
+# 0 (default): Default Top Bottom Screen, 1: Single Screen Only, 2: Large Screen Small Screen
+layout_option =
+
+# Toggle custom layout (using the settings below) on or off.
+# 0 (default): Off, 1: On
+custom_layout =
+
+# Screen placement when using Custom layout option
+# 0x, 0y is the top left corner of the render window.
+custom_top_left =
+custom_top_top =
+custom_top_right =
+custom_top_bottom =
+custom_bottom_left =
+custom_bottom_top =
+custom_bottom_right =
+custom_bottom_bottom =
+
+# Swaps the prominent screen with the other screen.
+# For example, if Single Screen is chosen, setting this to 1 will display the bottom screen instead of the top screen.
+# 0 (default): Top Screen is prominent, 1: Bottom Screen is prominent
+swap_screen =
+
+[Data Storage]
+# Whether to create a virtual SD card.
+# 1 (default): Yes, 0: No
+use_virtual_sd =
+
+[System]
+# Whether the system is docked
+# 1: Yes, 0 (default): No
+use_docked_mode =
+
+# Allow the use of NFC in games
+# 1 (default): Yes, 0 : No
+enable_nfc =
+
+# Sets the seed for the RNG generator built into the switch
+# rng_seed will be ignored and randomly generated if rng_seed_enabled is false
+rng_seed_enabled =
+rng_seed =
+
+# Sets the current time (in seconds since 12:00 AM Jan 1, 1970) that will be used by the time service
+# This will auto-increment, with the time set being the time the game is started
+# This override will only occur if custom_rtc_enabled is true, otherwise the current time is used
+custom_rtc_enabled =
+custom_rtc =
+
+# Sets the account username, max length is 32 characters
+# yuzu (default)
+username = yuzu
+
+# Sets the systems language index
+# 0: Japanese, 1: English (default), 2: French, 3: German, 4: Italian, 5: Spanish, 6: Chinese,
+# 7: Korean, 8: Dutch, 9: Portuguese, 10: Russian, 11: Taiwanese, 12: British English, 13: Canadian French,
+# 14: Latin American Spanish, 15: Simplified Chinese, 16: Traditional Chinese
+language_index =
+
+# The system region that yuzu will use during emulation
+# -1: Auto-select (default), 0: Japan, 1: USA, 2: Europe, 3: Australia, 4: China, 5: Korea, 6: Taiwan
+region_value =
+
+[Miscellaneous]
+# A filter which removes logs below a certain logging level.
+# Examples: *:Debug Kernel.SVC:Trace Service.*:Critical
+log_filter = *:Trace
+
+[Debugging]
+# Arguments to be passed to argv/argc in the emulated program. It is preferable to use the testing service datastring
+program_args=
+# Determines whether or not yuzu will dump the ExeFS of all games it attempts to load while loading them
+dump_exefs=false
+# Determines whether or not yuzu will dump all NSOs it attempts to load while loading them
+dump_nso=false
+
+[WebService]
+# Whether or not to enable telemetry
+# 0: No, 1 (default): Yes
+enable_telemetry =
+# URL for Web API
+web_api_url = https://api.yuzu-emu.org
+# Username and token for yuzu Web Service
+# See https://profile.yuzu-emu.org/ for more info
+yuzu_username =
+yuzu_token =
+
+[AddOns]
+# Used to disable add-ons
+# List of title IDs of games that will have add-ons disabled (separated by '|'):
+title_ids =
+# For each title ID, have a key/value pair called `disabled_<title_id>` equal to the names of the add-ons to disable (sep. by '|')
+# e.x. disabled_0100000000010000 = Update|DLC <- disables Updates and DLC on Super Mario Odyssey
+)";
+}

--- a/src/yuzu_tester/emu_window/emu_window_sdl2_hide.cpp
+++ b/src/yuzu_tester/emu_window/emu_window_sdl2_hide.cpp
@@ -1,0 +1,123 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <cstdlib>
+#include <string>
+#define SDL_MAIN_HANDLED
+#include <SDL.h>
+#include <fmt/format.h>
+#include <glad/glad.h>
+#include "common/logging/log.h"
+#include "common/scm_rev.h"
+#include "core/settings.h"
+#include "input_common/main.h"
+#include "yuzu_tester/emu_window/emu_window_sdl2_hide.h"
+
+bool EmuWindow_SDL2_Hide::SupportsRequiredGLExtensions() {
+    std::vector<std::string> unsupported_ext;
+
+    if (!GLAD_GL_ARB_direct_state_access)
+        unsupported_ext.push_back("ARB_direct_state_access");
+    if (!GLAD_GL_ARB_vertex_type_10f_11f_11f_rev)
+        unsupported_ext.push_back("ARB_vertex_type_10f_11f_11f_rev");
+    if (!GLAD_GL_ARB_texture_mirror_clamp_to_edge)
+        unsupported_ext.push_back("ARB_texture_mirror_clamp_to_edge");
+    if (!GLAD_GL_ARB_multi_bind)
+        unsupported_ext.push_back("ARB_multi_bind");
+
+    // Extensions required to support some texture formats.
+    if (!GLAD_GL_EXT_texture_compression_s3tc)
+        unsupported_ext.push_back("EXT_texture_compression_s3tc");
+    if (!GLAD_GL_ARB_texture_compression_rgtc)
+        unsupported_ext.push_back("ARB_texture_compression_rgtc");
+    if (!GLAD_GL_ARB_depth_buffer_float)
+        unsupported_ext.push_back("ARB_depth_buffer_float");
+
+    for (const std::string& ext : unsupported_ext)
+        LOG_CRITICAL(Frontend, "Unsupported GL extension: {}", ext);
+
+    return unsupported_ext.empty();
+}
+
+EmuWindow_SDL2_Hide::EmuWindow_SDL2_Hide() {
+    // Initialize the window
+    if (SDL_Init(SDL_INIT_VIDEO) < 0) {
+        LOG_CRITICAL(Frontend, "Failed to initialize SDL2! Exiting...");
+        exit(1);
+    }
+
+    InputCommon::Init();
+
+    SDL_SetMainReady();
+
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+    SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 0);
+
+    std::string window_title = fmt::format("yuzu-tester {} | {}-{}", Common::g_build_fullname,
+                                           Common::g_scm_branch, Common::g_scm_desc);
+    render_window =
+        SDL_CreateWindow(window_title.c_str(),
+                         SDL_WINDOWPOS_UNDEFINED, // x position
+                         SDL_WINDOWPOS_UNDEFINED, // y position
+                         Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height,
+                         SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+    SDL_HideWindow(render_window);
+
+    if (render_window == nullptr) {
+        LOG_CRITICAL(Frontend, "Failed to create SDL2 window! {}", SDL_GetError());
+        exit(1);
+    }
+
+    gl_context = SDL_GL_CreateContext(render_window);
+
+    if (gl_context == nullptr) {
+        LOG_CRITICAL(Frontend, "Failed to create SDL2 GL context! {}", SDL_GetError());
+        exit(1);
+    }
+
+    if (!gladLoadGLLoader(static_cast<GLADloadproc>(SDL_GL_GetProcAddress))) {
+        LOG_CRITICAL(Frontend, "Failed to initialize GL functions! {}", SDL_GetError());
+        exit(1);
+    }
+
+    if (!SupportsRequiredGLExtensions()) {
+        LOG_CRITICAL(Frontend, "GPU does not support all required OpenGL extensions! Exiting...");
+        exit(1);
+    }
+
+    SDL_PumpEvents();
+    SDL_GL_SetSwapInterval(false);
+    LOG_INFO(Frontend, "yuzu-tester Version: {} | {}-{}", Common::g_build_fullname,
+             Common::g_scm_branch, Common::g_scm_desc);
+    Settings::LogSettings();
+
+    DoneCurrent();
+}
+
+EmuWindow_SDL2_Hide::~EmuWindow_SDL2_Hide() {
+    InputCommon::Shutdown();
+    SDL_GL_DeleteContext(gl_context);
+    SDL_Quit();
+}
+
+void EmuWindow_SDL2_Hide::SwapBuffers() {
+    SDL_GL_SwapWindow(render_window);
+}
+
+void EmuWindow_SDL2_Hide::PollEvents() {}
+
+void EmuWindow_SDL2_Hide::MakeCurrent() {
+    SDL_GL_MakeCurrent(render_window, gl_context);
+}
+
+void EmuWindow_SDL2_Hide::DoneCurrent() {
+    SDL_GL_MakeCurrent(render_window, nullptr);
+}

--- a/src/yuzu_tester/emu_window/emu_window_sdl2_hide.cpp
+++ b/src/yuzu_tester/emu_window/emu_window_sdl2_hide.cpp
@@ -63,13 +63,12 @@ EmuWindow_SDL2_Hide::EmuWindow_SDL2_Hide() {
 
     std::string window_title = fmt::format("yuzu-tester {} | {}-{}", Common::g_build_fullname,
                                            Common::g_scm_branch, Common::g_scm_desc);
-    render_window =
-        SDL_CreateWindow(window_title.c_str(),
-                         SDL_WINDOWPOS_UNDEFINED, // x position
-                         SDL_WINDOWPOS_UNDEFINED, // y position
-                         Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height,
-                         SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
-    SDL_HideWindow(render_window);
+    render_window = SDL_CreateWindow(window_title.c_str(),
+                                     SDL_WINDOWPOS_UNDEFINED, // x position
+                                     SDL_WINDOWPOS_UNDEFINED, // y position
+                                     Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height,
+                                     SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE |
+                                         SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_HIDDEN);
 
     if (render_window == nullptr) {
         LOG_CRITICAL(Frontend, "Failed to create SDL2 window! {}", SDL_GetError());

--- a/src/yuzu_tester/emu_window/emu_window_sdl2_hide.h
+++ b/src/yuzu_tester/emu_window/emu_window_sdl2_hide.h
@@ -1,0 +1,41 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/frontend/emu_window.h"
+
+struct SDL_Window;
+
+class EmuWindow_SDL2_Hide : public Core::Frontend::EmuWindow {
+public:
+    explicit EmuWindow_SDL2_Hide();
+    ~EmuWindow_SDL2_Hide();
+
+    /// Swap buffers to display the next frame
+    void SwapBuffers() override;
+
+    /// Polls window events
+    void PollEvents() override;
+
+    /// Makes the graphics context current for the caller thread
+    void MakeCurrent() override;
+
+    /// Releases the GL context from the caller thread
+    void DoneCurrent() override;
+
+    /// Whether the window is still open, and a close request hasn't yet been sent
+    bool IsOpen() const;
+
+private:
+    /// Whether the GPU and driver supports the OpenGL extension required
+    bool SupportsRequiredGLExtensions();
+
+    /// Internal SDL2 render window
+    SDL_Window* render_window;
+
+    using SDL_GLContext = void*;
+    /// The OpenGL context associated with the window
+    SDL_GLContext gl_context;
+};

--- a/src/yuzu_tester/resource.h
+++ b/src/yuzu_tester/resource.h
@@ -1,0 +1,16 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Visual C++ generated include file.
+// Used by pcafe.rc
+//
+#define IDI_ICON3 103
+
+// Next default values for new objects
+//
+#ifdef APSTUDIO_INVOKED
+#ifndef APSTUDIO_READONLY_SYMBOLS
+#define _APS_NEXT_RESOURCE_VALUE 105
+#define _APS_NEXT_COMMAND_VALUE 40001
+#define _APS_NEXT_CONTROL_VALUE 1001
+#define _APS_NEXT_SYMED_VALUE 101
+#endif
+#endif

--- a/src/yuzu_tester/service/yuzutest.cpp
+++ b/src/yuzu_tester/service/yuzutest.cpp
@@ -1,0 +1,104 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+#include "common/string_util.h"
+#include "core/hle/ipc_helpers.h"
+#include "core/hle/service/service.h"
+#include "core/hle/service/sm/sm.h"
+#include "yuzu_tester/service/yuzutest.h"
+
+namespace Service::Yuzu {
+
+constexpr u64 SERVICE_VERSION = 1;
+
+class YuzuTest final : public ServiceFramework<YuzuTest> {
+public:
+    explicit YuzuTest(std::string data, std::function<void(u32, std::string)> finish_callback)
+        : ServiceFramework{"yuzutest"}, data(std::move(data)),
+          finish_callback(std::move(finish_callback)) {
+        static const FunctionInfo functions[] = {
+            {0, &YuzuTest::Initialize, "Initialize"},
+            {1, &YuzuTest::GetServiceVersion, "GetServiceVersion"},
+            {2, &YuzuTest::GetData, "GetData"},
+            {3, &YuzuTest::SetResultCode, "SetResultCode"},
+            {4, &YuzuTest::SetResultData, "SetResultData"},
+            {5, &YuzuTest::Finish, "Finish"},
+        };
+
+        RegisterHandlers(functions);
+    }
+
+private:
+    void Initialize(Kernel::HLERequestContext& ctx) {
+        LOG_DEBUG(Frontend, "called");
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+    }
+
+    void GetServiceVersion(Kernel::HLERequestContext& ctx) {
+        LOG_DEBUG(Frontend, "called");
+        IPC::ResponseBuilder rb{ctx, 4};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push(SERVICE_VERSION);
+    }
+
+    void GetData(Kernel::HLERequestContext& ctx) {
+        LOG_DEBUG(Frontend, "called");
+        const auto size = ctx.GetWriteBufferSize();
+        const auto write_size = std::min(size, data.size());
+        ctx.WriteBuffer(data.data(), write_size);
+
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push<u32>(write_size);
+    }
+
+    void SetResultCode(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto code = rp.PopRaw<u32>();
+
+        LOG_INFO(Frontend, "called with result_code={:08X}", code);
+        result_code = code;
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+    }
+
+    void SetResultData(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto buffer = ctx.ReadBuffer();
+        std::string data = Common::StringFromFixedZeroTerminatedBuffer(
+            reinterpret_cast<const char*>(buffer.data()), buffer.size());
+
+        LOG_INFO(Frontend, "called with string={}", data);
+        result_string = data;
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+    }
+
+    void Finish(Kernel::HLERequestContext& ctx) {
+        LOG_DEBUG(Frontend, "called");
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+
+        finish_callback(result_code, result_string);
+    }
+
+    std::string data;
+
+    u32 result_code = 0;
+    std::string result_string;
+
+    std::function<void(u64, std::string)> finish_callback;
+};
+
+void InstallInterfaces(SM::ServiceManager& sm, std::string data,
+                       std::function<void(u32, std::string)> finish_callback) {
+    std::make_shared<YuzuTest>(data, finish_callback)->InstallAsService(sm);
+}
+
+} // namespace Service::Yuzu

--- a/src/yuzu_tester/service/yuzutest.cpp
+++ b/src/yuzu_tester/service/yuzutest.cpp
@@ -95,7 +95,7 @@ private:
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
 
-        finish_callback(results);
+        finish_callback(std::move(results));
     }
 
     std::string data;

--- a/src/yuzu_tester/service/yuzutest.cpp
+++ b/src/yuzu_tester/service/yuzutest.cpp
@@ -57,7 +57,12 @@ private:
     }
 
     void StartIndividual(Kernel::HLERequestContext& ctx) {
-        LOG_DEBUG(Frontend, "called");
+        const auto name_raw = ctx.ReadBuffer();
+
+        const auto name = Common::StringFromFixedZeroTerminatedBuffer(
+            reinterpret_cast<const char*>(name_raw.data()), name_raw.size());
+
+        LOG_DEBUG(Frontend, "called, name={}", name);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);

--- a/src/yuzu_tester/service/yuzutest.h
+++ b/src/yuzu_tester/service/yuzutest.h
@@ -1,0 +1,19 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <functional>
+#include <string>
+
+namespace Service::SM {
+class ServiceManager;
+}
+
+namespace Service::Yuzu {
+
+void InstallInterfaces(SM::ServiceManager& sm, std::string data,
+                       std::function<void(u32, std::string)> finish_callback);
+
+} // namespace Service::Yuzu

--- a/src/yuzu_tester/service/yuzutest.h
+++ b/src/yuzu_tester/service/yuzutest.h
@@ -13,7 +13,13 @@ class ServiceManager;
 
 namespace Service::Yuzu {
 
+struct TestResult {
+    u32 code;
+    std::string data;
+    std::string name;
+};
+
 void InstallInterfaces(SM::ServiceManager& sm, std::string data,
-                       std::function<void(u32, std::string)> finish_callback);
+                       std::function<void(std::vector<TestResult>)> finish_callback);
 
 } // namespace Service::Yuzu

--- a/src/yuzu_tester/yuzu.cpp
+++ b/src/yuzu_tester/yuzu.cpp
@@ -170,7 +170,7 @@ int main(int argc, char** argv) {
 
     bool finished = false;
     int return_value = 0;
-    const auto callback = [&finished, &return_value](u32 code, std::string string) {
+    const auto callback = [&finished, &return_value](std::vector<Service::Yuzu::TestResult>) {
         finished = true;
         return_value = code & 0xFF;
         const auto text = fmt::format("Test Finished [Result Code: {:08X}]\n{}", code, string);

--- a/src/yuzu_tester/yuzu.cpp
+++ b/src/yuzu_tester/yuzu.cpp
@@ -176,7 +176,10 @@ int main(int argc, char** argv) {
         finished = true;
         return_value = 0;
 
-        const auto len =
+        // Find the minimum length needed to fully enclose all test names (and the header field) in
+        // the fmt::format column by first finding the maximum size of any test name and comparing
+        // that to 9, the string length of 'Test Name'
+        const auto needed_length_name =
             std::max<u64>(std::max_element(results.begin(), results.end(),
                                            [](const auto& lhs, const auto& rhs) {
                                                return lhs.name.size() < rhs.name.size();
@@ -187,7 +190,8 @@ int main(int argc, char** argv) {
         std::size_t passed = 0;
         std::size_t failed = 0;
 
-        std::cout << fmt::format("Result [Res Code] | {:<{}} | Extra Data", "Test Name", len)
+        std::cout << fmt::format("Result [Res Code] | {:<{}} | Extra Data", "Test Name",
+                                 needed_length_name)
                   << std::endl;
 
         for (const auto& res : results) {
@@ -196,8 +200,8 @@ int main(int argc, char** argv) {
                 ++passed;
             else
                 ++failed;
-            std::cout << fmt::format("{} [{:08X}] | {:<{}} | {}", main_res, res.code, res.name, len,
-                                     res.data)
+            std::cout << fmt::format("{} [{:08X}] | {:<{}} | {}", main_res, res.code, res.name,
+                                     needed_length_name, res.data)
                       << std::endl;
         }
 
@@ -229,9 +233,6 @@ int main(int argc, char** argv) {
         return -1;
     case Core::System::ResultStatus::ErrorNotInitialized:
         LOG_CRITICAL(Frontend, "CPUCore not initialized");
-        return -1;
-    case Core::System::ResultStatus::ErrorSystemMode:
-        LOG_CRITICAL(Frontend, "Failed to determine system mode!");
         return -1;
     case Core::System::ResultStatus::ErrorVideoCore:
         LOG_CRITICAL(Frontend, "Failed to initialize VideoCore!");

--- a/src/yuzu_tester/yuzu.cpp
+++ b/src/yuzu_tester/yuzu.cpp
@@ -1,0 +1,232 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include <fmt/ostream.h>
+
+#include "common/common_paths.h"
+#include "common/detached_tasks.h"
+#include "common/file_util.h"
+#include "common/logging/backend.h"
+#include "common/logging/filter.h"
+#include "common/logging/log.h"
+#include "common/microprofile.h"
+#include "common/scm_rev.h"
+#include "common/scope_exit.h"
+#include "common/string_util.h"
+#include "common/telemetry.h"
+#include "core/core.h"
+#include "core/crypto/key_manager.h"
+#include "core/file_sys/vfs_real.h"
+#include "core/hle/service/filesystem/filesystem.h"
+#include "core/loader/loader.h"
+#include "core/settings.h"
+#include "core/telemetry_session.h"
+#include "video_core/renderer_base.h"
+#include "yuzu_tester/config.h"
+#include "yuzu_tester/emu_window/emu_window_sdl2_hide.h"
+#include "yuzu_tester/service/yuzutest.h"
+
+#include <getopt.h>
+#ifndef _MSC_VER
+#include <unistd.h>
+#endif
+
+#ifdef _WIN32
+// windows.h needs to be included before shellapi.h
+#include <windows.h>
+
+#include <shellapi.h>
+#endif
+
+#ifdef _WIN32
+extern "C" {
+// tells Nvidia and AMD drivers to use the dedicated GPU by default on laptops with switchable
+// graphics
+__declspec(dllexport) unsigned long NvOptimusEnablement = 0x00000001;
+__declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
+}
+#endif
+
+static void PrintHelp(const char* argv0) {
+    std::cout << "Usage: " << argv0
+              << " [options] <filename>\n"
+                 "-h, --help            Display this help and exit\n"
+                 "-v, --version         Output version information and exit\n"
+                 "-d, --datastring      Pass following string as data to test service command #2\n"
+                 "-l, --log             Log to console in addition to file (will log to file only "
+                 "by default)\n";
+}
+
+static void PrintVersion() {
+    std::cout << "yuzu [Test Utility] " << Common::g_scm_branch << " " << Common::g_scm_desc
+              << std::endl;
+}
+
+static void InitializeLogging(bool console) {
+    Log::Filter log_filter(Log::Level::Debug);
+    log_filter.ParseFilterString(Settings::values.log_filter);
+    Log::SetGlobalFilter(log_filter);
+
+    if (console)
+        Log::AddBackend(std::make_unique<Log::ColorConsoleBackend>());
+
+    const std::string& log_dir = FileUtil::GetUserPath(FileUtil::UserPath::LogDir);
+    FileUtil::CreateFullPath(log_dir);
+    Log::AddBackend(std::make_unique<Log::FileBackend>(log_dir + LOG_FILE));
+#ifdef _WIN32
+    Log::AddBackend(std::make_unique<Log::DebuggerBackend>());
+#endif
+}
+
+/// Application entry point
+int main(int argc, char** argv) {
+    Common::DetachedTasks detached_tasks;
+    Config config;
+
+    int option_index = 0;
+
+    char* endarg;
+#ifdef _WIN32
+    int argc_w;
+    auto argv_w = CommandLineToArgvW(GetCommandLineW(), &argc_w);
+
+    if (argv_w == nullptr) {
+        std::cout << "Failed to get command line arguments" << std::endl;
+        return -1;
+    }
+#endif
+    std::string filepath;
+
+    static struct option long_options[] = {
+        {"help", no_argument, 0, 'h'},
+        {"version", no_argument, 0, 'v'},
+        {"datastring", optional_argument, 0, 'd'},
+        {"log", no_argument, 0, 'l'},
+        {0, 0, 0, 0},
+    };
+
+    bool console_log = false;
+    std::string datastring;
+
+    while (optind < argc) {
+        int arg = getopt_long(argc, argv, "hvdl::", long_options, &option_index);
+        if (arg != -1) {
+            switch (static_cast<char>(arg)) {
+            case 'h':
+                PrintHelp(argv[0]);
+                return 0;
+            case 'v':
+                PrintVersion();
+                return 0;
+            case 'd':
+                datastring = argv[optind];
+                ++optind;
+                break;
+            case 'l':
+                console_log = true;
+                break;
+            }
+        } else {
+#ifdef _WIN32
+            filepath = Common::UTF16ToUTF8(argv_w[optind]);
+#else
+            filepath = argv[optind];
+#endif
+            optind++;
+        }
+    }
+
+    InitializeLogging(console_log);
+
+#ifdef _WIN32
+    LocalFree(argv_w);
+#endif
+
+    MicroProfileOnThreadCreate("EmuThread");
+    SCOPE_EXIT({ MicroProfileShutdown(); });
+
+    if (filepath.empty()) {
+        LOG_CRITICAL(Frontend, "Failed to load application: No application specified");
+        std::cout << "Failed to load application: No application specified" << std::endl;
+        PrintHelp(argv[0]);
+        return -1;
+    }
+
+    Settings::values.use_gdbstub = false;
+    Settings::Apply();
+
+    std::unique_ptr<EmuWindow_SDL2_Hide> emu_window{std::make_unique<EmuWindow_SDL2_Hide>()};
+
+    if (!Settings::values.use_multi_core) {
+        // Single core mode must acquire OpenGL context for entire emulation session
+        emu_window->MakeCurrent();
+    }
+
+    bool finished = false;
+    int return_value = 0;
+    const auto callback = [&finished, &return_value](u32 code, std::string string) {
+        finished = true;
+        return_value = code & 0xFF;
+        const auto text = fmt::format("Test Finished [Result Code: {:08X}]\n{}", code, string);
+        LOG_INFO(Frontend, text.c_str());
+        std::cout << text << std::endl;
+    };
+
+    Core::System& system{Core::System::GetInstance()};
+    system.SetFilesystem(std::make_shared<FileSys::RealVfsFilesystem>());
+    Service::FileSystem::CreateFactories(*system.GetFilesystem());
+
+    SCOPE_EXIT({ system.Shutdown(); });
+
+    const Core::System::ResultStatus load_result{system.Load(*emu_window, filepath)};
+
+    switch (load_result) {
+    case Core::System::ResultStatus::ErrorGetLoader:
+        LOG_CRITICAL(Frontend, "Failed to obtain loader for %s!", filepath.c_str());
+        return -1;
+    case Core::System::ResultStatus::ErrorLoader:
+        LOG_CRITICAL(Frontend, "Failed to load ROM!");
+        return -1;
+    case Core::System::ResultStatus::ErrorNotInitialized:
+        LOG_CRITICAL(Frontend, "CPUCore not initialized");
+        return -1;
+    case Core::System::ResultStatus::ErrorSystemMode:
+        LOG_CRITICAL(Frontend, "Failed to determine system mode!");
+        return -1;
+    case Core::System::ResultStatus::ErrorVideoCore:
+        LOG_CRITICAL(Frontend, "Failed to initialize VideoCore!");
+        return -1;
+    case Core::System::ResultStatus::Success:
+        break; // Expected case
+    default:
+        if (static_cast<u32>(load_result) >
+            static_cast<u32>(Core::System::ResultStatus::ErrorLoader)) {
+            const u16 loader_id = static_cast<u16>(Core::System::ResultStatus::ErrorLoader);
+            const u16 error_id = static_cast<u16>(load_result) - loader_id;
+            LOG_CRITICAL(Frontend,
+                         "While attempting to load the ROM requested, an error occured. Please "
+                         "refer to the yuzu wiki for more information or the yuzu discord for "
+                         "additional help.\n\nError Code: {:04X}-{:04X}\nError Description: {}",
+                         loader_id, error_id, static_cast<Loader::ResultStatus>(error_id));
+        }
+    }
+
+    Service::Yuzu::InstallInterfaces(system.ServiceManager(), datastring, callback);
+
+    system.TelemetrySession().AddField(Telemetry::FieldType::App, "Frontend", "SDLHideTester");
+
+    system.Renderer().Rasterizer().LoadDiskResources();
+
+    while (!finished) {
+        system.RunLoop();
+    }
+
+    detached_tasks.WaitForAllTasks();
+    return return_value;
+}

--- a/src/yuzu_tester/yuzu.rc
+++ b/src/yuzu_tester/yuzu.rc
@@ -1,0 +1,17 @@
+#include "winresrc.h"
+/////////////////////////////////////////////////////////////////////////////
+//
+// Icon
+//
+
+// Icon with lowest ID value placed first to ensure application icon
+// remains consistent on all systems.
+YUZU_ICON               ICON                    "../../dist/yuzu.ico"
+
+
+/////////////////////////////////////////////////////////////////////////////
+//
+// RT_MANIFEST
+//
+
+1                       RT_MANIFEST             "../../dist/yuzu.manifest"


### PR DESCRIPTION
This is designed to make unit testing of switch homebrew easier and automatable.

Adds:
- A new frontend (`yuzu_tester`) that will not show a window or emulate input (but otherwise is basically `yuzu_cmd`).
- A service that is only installed for that frontend called `yuzutest` -- this is so the homebrew can communicate with yuzu the results of the test, (NOTE: this is not present in yuzu-qt or yuzu-cmd and can't be used to determine if the app is running on an emulator unless it is running on the test utility.)

When a NRO/NSO that uses the testing service is run on `yuzu-tester`, it will be executed headlessely and when complete the result code from the service will display on screen.

The service also supports passing in a string (for example, to parameterize the test) and string output (for more detailed results/debugging).

In addition to this change, I wrote a library and example for libnx on how to use this system effectively. (https://github.com/DarkLordZach/libyuzutest)

Example of console window when running a test:
![image](https://user-images.githubusercontent.com/5064800/54967245-4af29a00-4f4d-11e9-9dc2-729edb125643.png)

I eventually want to replace the SDL2-render-to-nowhere with a true null graphics backend, but this works for now.