### PR TITLE
video_core: Add missing override specifiers

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.h
@@ -538,12 +538,12 @@ private:
         return nullptr;
     }
 
-    void Register(const Surface& object) {
+    void Register(const Surface& object) override {
         RasterizerCache<Surface>::Register(object);
     }
 
     /// Unregisters an object from the cache
-    void Unregister(const Surface& object) {
+    void Unregister(const Surface& object) override {
         if (object->IsReinterpreted()) {
             auto interval = GetReinterpretInterval(object);
             reinterpreted_surfaces.erase(interval);

--- a/src/video_core/renderer_vulkan/vk_resource_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_resource_manager.cpp
@@ -21,7 +21,7 @@ public:
     CommandBufferPool(const VKDevice& device)
         : VKFencedPool(COMMAND_BUFFER_POOL_SIZE), device{device} {}
 
-    void Allocate(std::size_t begin, std::size_t end) {
+    void Allocate(std::size_t begin, std::size_t end) override {
         const auto dev = device.GetLogical();
         const auto& dld = device.GetDispatchLoader();
         const u32 graphics_family = device.GetGraphicsFamily();

--- a/src/video_core/renderer_vulkan/vk_resource_manager.h
+++ b/src/video_core/renderer_vulkan/vk_resource_manager.h
@@ -97,7 +97,7 @@ private:
 class VKFenceWatch final : public VKResource {
 public:
     explicit VKFenceWatch();
-    ~VKFenceWatch();
+    ~VKFenceWatch() override;
 
     /// Waits for the fence to be released.
     void Wait();


### PR DESCRIPTION
Ensures that the signatures will always match with the base class.

Also silences a few compilation warnings.