### PR TITLE
common/thread: Remove unused functions

### DIFF
--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -9,7 +9,6 @@
 #include <cstddef>
 #include <mutex>
 #include <thread>
-#include "common/common_types.h"
 
 namespace Common {
 
@@ -78,9 +77,6 @@ private:
     std::size_t generation = 0; // Incremented once each time the barrier is used
 };
 
-void SetThreadAffinity(std::thread::native_handle_type thread, u32 mask);
-void SetCurrentThreadAffinity(u32 mask);
-void SwitchCurrentThread(); // On Linux, this is equal to sleep 1ms
 void SetCurrentThreadName(const char* name);
 
 } // namespace Common


### PR DESCRIPTION
Many of these functions are carried over from Dolphin (where they aren't used anymore). Given these have no use (and we really shouldn't be screwing around with OS-specific thread scheduler handling from the emulator, these can be removed.

The function for setting the thread name is left, however, since it can have debugging utility usages.