### PR TITLE
kernel/shared_memory: Sanitize supplied size when unmapping

### DIFF
--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -119,7 +119,15 @@ ResultCode SharedMemory::Map(Process& target_process, VAddr address, MemoryPermi
                                                      ConvertPermissions(permissions));
 }
 
-ResultCode SharedMemory::Unmap(Process& target_process, VAddr address) {
+ResultCode SharedMemory::Unmap(Process& target_process, VAddr address, u64 unmap_size) {
+    if (unmap_size != size) {
+        LOG_ERROR(Kernel,
+                  "Invalid size passed to Unmap. Size must be equal to the size of the "
+                  "memory managed. Shared memory size=0x{:016X}, Unmap size=0x{:016X}",
+                  size, unmap_size);
+        return ERR_INVALID_SIZE;
+    }
+
     // TODO(Subv): Verify what happens if the application tries to unmap an address that is not
     // mapped to a SharedMemory.
     return target_process.VMManager().UnmapRange(address, size);

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -9,7 +9,6 @@
 #include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/shared_memory.h"
-#include "core/memory.h"
 
 namespace Kernel {
 

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -104,11 +104,17 @@ public:
 
     /**
      * Unmaps a shared memory block from the specified address in system memory
+     *
      * @param target_process Process from which to unmap the memory block.
-     * @param address Address in system memory where the shared memory block is mapped
+     * @param address        Address in system memory where the shared memory block is mapped.
+     * @param unmap_size     The amount of bytes to unmap from this shared memory instance.
+     *
      * @return Result code of the unmap operation
+     *
+     * @pre The given size to unmap must be the same size as the amount of memory managed by
+     *      the SharedMemory instance itself, otherwise ERR_INVALID_SIZE will be returned.
      */
-    ResultCode Unmap(Process& target_process, VAddr address);
+    ResultCode Unmap(Process& target_process, VAddr address, u64 unmap_size);
 
     /**
      * Gets a pointer to the shared memory block

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1140,7 +1140,7 @@ static ResultCode UnmapSharedMemory(Handle shared_memory_handle, VAddr addr, u64
         return ERR_INVALID_MEMORY_RANGE;
     }
 
-    return shared_memory->Unmap(*current_process, addr);
+    return shared_memory->Unmap(*current_process, addr, size);
 }
 
 static ResultCode QueryProcessMemory(VAddr memory_info_address, VAddr page_info_address,


### PR DESCRIPTION
The kernel makes sure that the given size to unmap is always the same size as the entire region managed by the shared memory instance, otherwise it returns an error code signifying an invalid size.

This is similarly done for transfer memory (which we already have checks in place for).