### PR TITLE
general: Use deducation guides for std::lock_guard and std::unique_lock

### DIFF
--- a/src/common/detached_tasks.cpp
+++ b/src/common/detached_tasks.cpp
@@ -16,22 +16,22 @@ DetachedTasks::DetachedTasks() {
 }
 
 void DetachedTasks::WaitForAllTasks() {
-    std::unique_lock<std::mutex> lock(mutex);
+    std::unique_lock lock{mutex};
     cv.wait(lock, [this]() { return count == 0; });
 }
 
 DetachedTasks::~DetachedTasks() {
-    std::unique_lock<std::mutex> lock(mutex);
+    std::unique_lock lock{mutex};
     ASSERT(count == 0);
     instance = nullptr;
 }
 
 void DetachedTasks::AddTask(std::function<void()> task) {
-    std::unique_lock<std::mutex> lock(instance->mutex);
+    std::unique_lock lock{instance->mutex};
     ++instance->count;
     std::thread([task{std::move(task)}]() {
         task();
-        std::unique_lock<std::mutex> lock(instance->mutex);
+        std::unique_lock lock{instance->mutex};
         --instance->count;
         std::notify_all_at_thread_exit(instance->cv, std::move(lock));
     })

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -46,12 +46,12 @@ public:
     }
 
     void AddBackend(std::unique_ptr<Backend> backend) {
-        std::lock_guard<std::mutex> lock(writing_mutex);
+        std::lock_guard lock{writing_mutex};
         backends.push_back(std::move(backend));
     }
 
     void RemoveBackend(std::string_view backend_name) {
-        std::lock_guard<std::mutex> lock(writing_mutex);
+        std::lock_guard lock{writing_mutex};
         const auto it =
             std::remove_if(backends.begin(), backends.end(),
                            [&backend_name](const auto& i) { return backend_name == i->GetName(); });
@@ -80,7 +80,7 @@ private:
         backend_thread = std::thread([&] {
             Entry entry;
             auto write_logs = [&](Entry& e) {
-                std::lock_guard<std::mutex> lock(writing_mutex);
+                std::lock_guard lock{writing_mutex};
                 for (const auto& backend : backends) {
                     backend->Write(e);
                 }

--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -15,7 +15,7 @@ namespace Common {
 class Event {
 public:
     void Set() {
-        std::lock_guard<std::mutex> lk(mutex);
+        std::lock_guard lk{mutex};
         if (!is_set) {
             is_set = true;
             condvar.notify_one();
@@ -23,14 +23,14 @@ public:
     }
 
     void Wait() {
-        std::unique_lock<std::mutex> lk(mutex);
+        std::unique_lock lk{mutex};
         condvar.wait(lk, [&] { return is_set; });
         is_set = false;
     }
 
     template <class Clock, class Duration>
     bool WaitUntil(const std::chrono::time_point<Clock, Duration>& time) {
-        std::unique_lock<std::mutex> lk(mutex);
+        std::unique_lock lk{mutex};
         if (!condvar.wait_until(lk, time, [this] { return is_set; }))
             return false;
         is_set = false;
@@ -38,7 +38,7 @@ public:
     }
 
     void Reset() {
-        std::unique_lock<std::mutex> lk(mutex);
+        std::unique_lock lk{mutex};
         // no other action required, since wait loops on the predicate and any lingering signal will
         // get cleared on the first iteration
         is_set = false;
@@ -56,7 +56,7 @@ public:
 
     /// Blocks until all "count" threads have called Sync()
     void Sync() {
-        std::unique_lock<std::mutex> lk(mutex);
+        std::unique_lock lk{mutex};
         const std::size_t current_generation = generation;
 
         if (++waiting == count) {

--- a/src/common/threadsafe_queue.h
+++ b/src/common/threadsafe_queue.h
@@ -78,7 +78,7 @@ public:
 
     T PopWait() {
         if (Empty()) {
-            std::unique_lock<std::mutex> lock(cv_mutex);
+            std::unique_lock lock{cv_mutex};
             cv.wait(lock, [this]() { return !Empty(); });
         }
         T t;
@@ -137,7 +137,7 @@ public:
 
     template <typename Arg>
     void Push(Arg&& t) {
-        std::lock_guard<std::mutex> lock(write_lock);
+        std::lock_guard lock{write_lock};
         spsc_queue.Push(t);
     }
 

--- a/src/core/core_cpu.cpp
+++ b/src/core/core_cpu.cpp
@@ -22,7 +22,7 @@
 namespace Core {
 
 void CpuBarrier::NotifyEnd() {
-    std::unique_lock<std::mutex> lock(mutex);
+    std::unique_lock lock{mutex};
     end = true;
     condition.notify_all();
 }
@@ -34,7 +34,7 @@ bool CpuBarrier::Rendezvous() {
     }
 
     if (!end) {
-        std::unique_lock<std::mutex> lock(mutex);
+        std::unique_lock lock{mutex};
 
         --cores_waiting;
         if (!cores_waiting) {
@@ -131,7 +131,7 @@ void Cpu::Reschedule() {
 
     reschedule_pending = false;
     // Lock the global kernel mutex when we manipulate the HLE state
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+    std::lock_guard lock{HLE::g_hle_lock};
     scheduler->Reschedule();
 }
 

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -30,7 +30,7 @@ private:
         explicit Device(std::weak_ptr<TouchState>&& touch_state) : touch_state(touch_state) {}
         std::tuple<float, float, bool> GetStatus() const override {
             if (auto state = touch_state.lock()) {
-                std::lock_guard<std::mutex> guard(state->mutex);
+                std::lock_guard guard{state->mutex};
                 return std::make_tuple(state->touch_x, state->touch_y, state->touch_pressed);
             }
             return std::make_tuple(0.0f, 0.0f, false);
@@ -81,7 +81,7 @@ void EmuWindow::TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y) {
     if (!IsWithinTouchscreen(framebuffer_layout, framebuffer_x, framebuffer_y))
         return;
 
-    std::lock_guard<std::mutex> guard(touch_state->mutex);
+    std::lock_guard guard{touch_state->mutex};
     touch_state->touch_x = static_cast<float>(framebuffer_x - framebuffer_layout.screen.left) /
                            (framebuffer_layout.screen.right - framebuffer_layout.screen.left);
     touch_state->touch_y = static_cast<float>(framebuffer_y - framebuffer_layout.screen.top) /
@@ -91,7 +91,7 @@ void EmuWindow::TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y) {
 }
 
 void EmuWindow::TouchReleased() {
-    std::lock_guard<std::mutex> guard(touch_state->mutex);
+    std::lock_guard guard{touch_state->mutex};
     touch_state->touch_pressed = false;
     touch_state->touch_x = 0;
     touch_state->touch_y = 0;

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -34,7 +34,7 @@ static void ThreadWakeupCallback(u64 thread_handle, [[maybe_unused]] s64 cycles_
     const auto& system = Core::System::GetInstance();
 
     // Lock the global kernel mutex when we enter the kernel HLE.
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+    std::lock_guard lock{HLE::g_hle_lock};
 
     SharedPtr<Thread> thread =
         system.Kernel().RetrieveThreadFromWakeupCallbackHandleTable(proper_handle);

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -2138,7 +2138,7 @@ void CallSVC(u32 immediate) {
     MICROPROFILE_SCOPE(Kernel_SVC);
 
     // Lock the global kernel mutex when we enter the kernel HLE.
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+    std::lock_guard lock{HLE::g_hle_lock};
 
     const FunctionDef* info = GetSVCInfo(immediate);
     if (info) {

--- a/src/core/hle/service/nfp/nfp.cpp
+++ b/src/core/hle/service/nfp/nfp.cpp
@@ -335,7 +335,7 @@ void Module::Interface::CreateUserInterface(Kernel::HLERequestContext& ctx) {
 }
 
 bool Module::Interface::LoadAmiibo(const std::vector<u8>& buffer) {
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+    std::lock_guard lock{HLE::g_hle_lock};
     if (buffer.size() < sizeof(AmiiboFile)) {
         return false;
     }

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -18,13 +18,13 @@ using std::chrono::microseconds;
 namespace Core {
 
 void PerfStats::BeginSystemFrame() {
-    std::lock_guard<std::mutex> lock(object_mutex);
+    std::lock_guard lock{object_mutex};
 
     frame_begin = Clock::now();
 }
 
 void PerfStats::EndSystemFrame() {
-    std::lock_guard<std::mutex> lock(object_mutex);
+    std::lock_guard lock{object_mutex};
 
     auto frame_end = Clock::now();
     accumulated_frametime += frame_end - frame_begin;
@@ -35,13 +35,13 @@ void PerfStats::EndSystemFrame() {
 }
 
 void PerfStats::EndGameFrame() {
-    std::lock_guard<std::mutex> lock(object_mutex);
+    std::lock_guard lock{object_mutex};
 
     game_frames += 1;
 }
 
 PerfStatsResults PerfStats::GetAndResetStats(microseconds current_system_time_us) {
-    std::lock_guard<std::mutex> lock(object_mutex);
+    std::lock_guard lock{object_mutex};
 
     const auto now = Clock::now();
     // Walltime elapsed since stats were reset
@@ -67,7 +67,7 @@ PerfStatsResults PerfStats::GetAndResetStats(microseconds current_system_time_us
 }
 
 double PerfStats::GetLastFrameTimeScale() {
-    std::lock_guard<std::mutex> lock(object_mutex);
+    std::lock_guard lock{object_mutex};
 
     constexpr double FRAME_LENGTH = 1.0 / 60;
     return duration_cast<DoubleSecs>(previous_frame_length).count() / FRAME_LENGTH;

--- a/src/input_common/keyboard.cpp
+++ b/src/input_common/keyboard.cpp
@@ -36,18 +36,18 @@ struct KeyButtonPair {
 class KeyButtonList {
 public:
     void AddKeyButton(int key_code, KeyButton* key_button) {
-        std::lock_guard<std::mutex> guard(mutex);
+        std::lock_guard guard{mutex};
         list.push_back(KeyButtonPair{key_code, key_button});
     }
 
     void RemoveKeyButton(const KeyButton* key_button) {
-        std::lock_guard<std::mutex> guard(mutex);
+        std::lock_guard guard{mutex};
         list.remove_if(
             [key_button](const KeyButtonPair& pair) { return pair.key_button == key_button; });
     }
 
     void ChangeKeyStatus(int key_code, bool pressed) {
-        std::lock_guard<std::mutex> guard(mutex);
+        std::lock_guard guard{mutex};
         for (const KeyButtonPair& pair : list) {
             if (pair.key_code == key_code)
                 pair.key_button->status.store(pressed);
@@ -55,7 +55,7 @@ public:
     }
 
     void ChangeAllKeyStatus(bool pressed) {
-        std::lock_guard<std::mutex> guard(mutex);
+        std::lock_guard guard{mutex};
         for (const KeyButtonPair& pair : list) {
             pair.key_button->status.store(pressed);
         }

--- a/src/input_common/motion_emu.cpp
+++ b/src/input_common/motion_emu.cpp
@@ -39,7 +39,7 @@ public:
     void Tilt(int x, int y) {
         auto mouse_move = Common::MakeVec(x, y) - mouse_origin;
         if (is_tilting) {
-            std::lock_guard<std::mutex> guard(tilt_mutex);
+            std::lock_guard guard{tilt_mutex};
             if (mouse_move.x == 0 && mouse_move.y == 0) {
                 tilt_angle = 0;
             } else {
@@ -51,13 +51,13 @@ public:
     }
 
     void EndTilt() {
-        std::lock_guard<std::mutex> guard(tilt_mutex);
+        std::lock_guard guard{tilt_mutex};
         tilt_angle = 0;
         is_tilting = false;
     }
 
     std::tuple<Common::Vec3<float>, Common::Vec3<float>> GetStatus() {
-        std::lock_guard<std::mutex> guard(status_mutex);
+        std::lock_guard guard{status_mutex};
         return status;
     }
 
@@ -93,7 +93,7 @@ private:
             old_q = q;
 
             {
-                std::lock_guard<std::mutex> guard(tilt_mutex);
+                std::lock_guard guard{tilt_mutex};
 
                 // Find the quaternion describing current 3DS tilting
                 q = Common::MakeQuaternion(
@@ -115,7 +115,7 @@ private:
 
             // Update the sensor state
             {
-                std::lock_guard<std::mutex> guard(status_mutex);
+                std::lock_guard guard{status_mutex};
                 status = std::make_tuple(gravity, angular_rate);
             }
         }

--- a/src/video_core/debug_utils/debug_utils.cpp
+++ b/src/video_core/debug_utils/debug_utils.cpp
@@ -10,7 +10,7 @@ namespace Tegra {
 
 void DebugContext::DoOnEvent(Event event, void* data) {
     {
-        std::unique_lock<std::mutex> lock(breakpoint_mutex);
+        std::unique_lock lock{breakpoint_mutex};
 
         // TODO(Subv): Commit the rasterizer's caches so framebuffers, render targets, etc. will
         // show on debug widgets
@@ -32,7 +32,7 @@ void DebugContext::DoOnEvent(Event event, void* data) {
 
 void DebugContext::Resume() {
     {
-        std::lock_guard<std::mutex> lock(breakpoint_mutex);
+        std::lock_guard lock{breakpoint_mutex};
 
         // Tell all observers that we are about to resume
         for (auto& breakpoint_observer : breakpoint_observers) {

--- a/src/video_core/debug_utils/debug_utils.h
+++ b/src/video_core/debug_utils/debug_utils.h
@@ -40,7 +40,7 @@ public:
         /// Constructs the object such that it observes events of the given DebugContext.
         explicit BreakPointObserver(std::shared_ptr<DebugContext> debug_context)
             : context_weak(debug_context) {
-            std::unique_lock<std::mutex> lock(debug_context->breakpoint_mutex);
+            std::unique_lock lock{debug_context->breakpoint_mutex};
             debug_context->breakpoint_observers.push_back(this);
         }
 
@@ -48,7 +48,7 @@ public:
             auto context = context_weak.lock();
             if (context) {
                 {
-                    std::unique_lock<std::mutex> lock(context->breakpoint_mutex);
+                    std::unique_lock lock{context->breakpoint_mutex};
                     context->breakpoint_observers.remove(this);
                 }
 

--- a/src/video_core/gpu_thread.h
+++ b/src/video_core/gpu_thread.h
@@ -95,13 +95,13 @@ struct SynchState final {
     std::condition_variable frames_condition;
 
     void IncrementFramesCounter() {
-        std::lock_guard<std::mutex> lock{frames_mutex};
+        std::lock_guard lock{frames_mutex};
         ++queued_frame_count;
     }
 
     void DecrementFramesCounter() {
         {
-            std::lock_guard<std::mutex> lock{frames_mutex};
+            std::lock_guard lock{frames_mutex};
             --queued_frame_count;
 
             if (queued_frame_count) {
@@ -113,7 +113,7 @@ struct SynchState final {
 
     void WaitForFrames() {
         {
-            std::lock_guard<std::mutex> lock{frames_mutex};
+            std::lock_guard lock{frames_mutex};
             if (!queued_frame_count) {
                 return;
             }
@@ -121,14 +121,14 @@ struct SynchState final {
 
         // Wait for the GPU to be idle (all commands to be executed)
         {
-            std::unique_lock<std::mutex> lock{frames_mutex};
+            std::unique_lock lock{frames_mutex};
             frames_condition.wait(lock, [this] { return !queued_frame_count; });
         }
     }
 
     void SignalCommands() {
         {
-            std::unique_lock<std::mutex> lock{commands_mutex};
+            std::unique_lock lock{commands_mutex};
             if (queue.Empty()) {
                 return;
             }
@@ -138,7 +138,7 @@ struct SynchState final {
     }
 
     void WaitForCommands() {
-        std::unique_lock<std::mutex> lock{commands_mutex};
+        std::unique_lock lock{commands_mutex};
         commands_condition.wait(lock, [this] { return !queue.Empty(); });
     }
 

--- a/src/video_core/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache.h
@@ -84,7 +84,7 @@ public:
 
     /// Write any cached resources overlapping the specified region back to memory
     void FlushRegion(CacheAddr addr, std::size_t size) {
-        std::lock_guard<std::recursive_mutex> lock{mutex};
+        std::lock_guard lock{mutex};
 
         const auto& objects{GetSortedObjectsFromRegion(addr, size)};
         for (auto& object : objects) {
@@ -94,7 +94,7 @@ public:
 
     /// Mark the specified region as being invalidated
     void InvalidateRegion(CacheAddr addr, u64 size) {
-        std::lock_guard<std::recursive_mutex> lock{mutex};
+        std::lock_guard lock{mutex};
 
         const auto& objects{GetSortedObjectsFromRegion(addr, size)};
         for (auto& object : objects) {
@@ -108,7 +108,7 @@ public:
 
     /// Invalidates everything in the cache
     void InvalidateAll() {
-        std::lock_guard<std::recursive_mutex> lock{mutex};
+        std::lock_guard lock{mutex};
 
         while (interval_cache.begin() != interval_cache.end()) {
             Unregister(*interval_cache.begin()->second.begin());
@@ -133,7 +133,7 @@ protected:
 
     /// Register an object into the cache
     virtual void Register(const T& object) {
-        std::lock_guard<std::recursive_mutex> lock{mutex};
+        std::lock_guard lock{mutex};
 
         object->SetIsRegistered(true);
         interval_cache.add({GetInterval(object), ObjectSet{object}});
@@ -143,7 +143,7 @@ protected:
 
     /// Unregisters an object from the cache
     virtual void Unregister(const T& object) {
-        std::lock_guard<std::recursive_mutex> lock{mutex};
+        std::lock_guard lock{mutex};
 
         object->SetIsRegistered(false);
         rasterizer.UpdatePagesCachedCount(object->GetCpuAddr(), object->GetSizeInBytes(), -1);
@@ -153,14 +153,14 @@ protected:
 
     /// Returns a ticks counter used for tracking when cached objects were last modified
     u64 GetModifiedTicks() {
-        std::lock_guard<std::recursive_mutex> lock{mutex};
+        std::lock_guard lock{mutex};
 
         return ++modified_ticks;
     }
 
     /// Flushes the specified object, updating appropriate cache state as needed
     void FlushObject(const T& object) {
-        std::lock_guard<std::recursive_mutex> lock{mutex};
+        std::lock_guard lock{mutex};
 
         if (!object->IsDirty()) {
             return;

--- a/src/web_service/web_backend.cpp
+++ b/src/web_service/web_backend.cpp
@@ -24,7 +24,7 @@ constexpr u32 TIMEOUT_SECONDS = 30;
 struct Client::Impl {
     Impl(std::string host, std::string username, std::string token)
         : host{std::move(host)}, username{std::move(username)}, token{std::move(token)} {
-        std::lock_guard<std::mutex> lock(jwt_cache.mutex);
+        std::lock_guard lock{jwt_cache.mutex};
         if (this->username == jwt_cache.username && this->token == jwt_cache.token) {
             jwt = jwt_cache.jwt;
         }
@@ -151,7 +151,7 @@ struct Client::Impl {
         if (result.result_code != Common::WebResult::Code::Success) {
             LOG_ERROR(WebService, "UpdateJWT failed");
         } else {
-            std::lock_guard<std::mutex> lock(jwt_cache.mutex);
+            std::lock_guard lock{jwt_cache.mutex};
             jwt_cache.username = username;
             jwt_cache.token = token;
             jwt_cache.jwt = jwt = result.returned_data;

--- a/src/yuzu/applets/profile_select.cpp
+++ b/src/yuzu/applets/profile_select.cpp
@@ -163,6 +163,6 @@ void QtProfileSelector::SelectProfile(
 
 void QtProfileSelector::MainWindowFinishedSelection(std::optional<Service::Account::UUID> uuid) {
     // Acquire the HLE mutex
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+    std::lock_guard lock{HLE::g_hle_lock};
     callback(uuid);
 }

--- a/src/yuzu/applets/software_keyboard.cpp
+++ b/src/yuzu/applets/software_keyboard.cpp
@@ -141,12 +141,12 @@ void QtSoftwareKeyboard::SendTextCheckDialog(std::u16string error_message,
 
 void QtSoftwareKeyboard::MainWindowFinishedText(std::optional<std::u16string> text) {
     // Acquire the HLE mutex
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+    std::lock_guard lock{HLE::g_hle_lock};
     text_output(text);
 }
 
 void QtSoftwareKeyboard::MainWindowFinishedCheckDialog() {
     // Acquire the HLE mutex
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+    std::lock_guard lock{HLE::g_hle_lock};
     finished_check();
 }

--- a/src/yuzu/applets/web_browser.cpp
+++ b/src/yuzu/applets/web_browser.cpp
@@ -104,12 +104,12 @@ void QtWebBrowser::OpenPage(std::string_view url, std::function<void()> unpack_r
 
 void QtWebBrowser::MainWindowUnpackRomFS() {
     // Acquire the HLE mutex
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+    std::lock_guard lock{HLE::g_hle_lock};
     unpack_romfs_callback();
 }
 
 void QtWebBrowser::MainWindowFinishedBrowsing() {
     // Acquire the HLE mutex
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+    std::lock_guard lock{HLE::g_hle_lock};
     finished_callback();
 }

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -67,7 +67,7 @@ void EmuThread::run() {
 
             was_active = false;
         } else {
-            std::unique_lock<std::mutex> lock(running_mutex);
+            std::unique_lock lock{running_mutex};
             running_cv.wait(lock, [this] { return IsRunning() || exec_step || stop_run; });
         }
     }

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -53,7 +53,7 @@ public:
      * @note This function is thread-safe
      */
     void SetRunning(bool running) {
-        std::unique_lock<std::mutex> lock(running_mutex);
+        std::unique_lock lock{running_mutex};
         this->running = running;
         lock.unlock();
         running_cv.notify_all();


### PR DESCRIPTION
Since C++17, the introduction of deduction guides for locking facilities means that we no longer need to hardcode the mutex type into the locks and guards themselves, making it easier to switch mutex types, should it ever be necessary in the future (and also makes for less reading).