### PR TITLE
kernel/resource_limit: Remove the name member from resource limits

### DIFF
--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -115,7 +115,7 @@ struct KernelCore::Impl {
 
     // Creates the default system resource limit
     void InitializeSystemResourceLimit(KernelCore& kernel) {
-        system_resource_limit = ResourceLimit::Create(kernel, "System");
+        system_resource_limit = ResourceLimit::Create(kernel);
 
         // If setting the default system values fails, then something seriously wrong has occurred.
         ASSERT(system_resource_limit->SetLimitValue(ResourceType::PhysicalMemory, 0x200000000)

--- a/src/core/hle/kernel/resource_limit.cpp
+++ b/src/core/hle/kernel/resource_limit.cpp
@@ -16,11 +16,8 @@ constexpr std::size_t ResourceTypeToIndex(ResourceType type) {
 ResourceLimit::ResourceLimit(KernelCore& kernel) : Object{kernel} {}
 ResourceLimit::~ResourceLimit() = default;
 
-SharedPtr<ResourceLimit> ResourceLimit::Create(KernelCore& kernel, std::string name) {
-    SharedPtr<ResourceLimit> resource_limit(new ResourceLimit(kernel));
-
-    resource_limit->name = std::move(name);
-    return resource_limit;
+SharedPtr<ResourceLimit> ResourceLimit::Create(KernelCore& kernel) {
+    return new ResourceLimit(kernel);
 }
 
 s64 ResourceLimit::GetCurrentResourceValue(ResourceType resource) const {

--- a/src/core/hle/kernel/resource_limit.h
+++ b/src/core/hle/kernel/resource_limit.h
@@ -31,16 +31,14 @@ constexpr bool IsValidResourceType(ResourceType type) {
 
 class ResourceLimit final : public Object {
 public:
-    /**
-     * Creates a resource limit object.
-     */
-    static SharedPtr<ResourceLimit> Create(KernelCore& kernel, std::string name = "Unknown");
+    /// Creates a resource limit object.
+    static SharedPtr<ResourceLimit> Create(KernelCore& kernel);
 
     std::string GetTypeName() const override {
         return "ResourceLimit";
     }
     std::string GetName() const override {
-        return name;
+        return GetTypeName();
     }
 
     static const HandleType HANDLE_TYPE = HandleType::ResourceLimit;
@@ -95,9 +93,6 @@ private:
     ResourceArray limits{};
     /// Current resource limit values.
     ResourceArray values{};
-
-    /// Name of resource limit object.
-    std::string name;
 };
 
 } // namespace Kernel


### PR DESCRIPTION
This doesn't really provide any benefit to the resource limit interface. There's no way for callers to any of the service functions for resource limits to provide a custom name, so all created instances of resource limits other than the system resource limit would have a name of "Unknown".

The system resource limit itself is already trivially identifiable from its limit values, so there's no real need to take up space in the object to identify one object meaningfully out of N total objects.