### PR TITLE
shader_ir/decode: Reduce the severity of common assertions

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -387,6 +387,13 @@ enum class IpaSampleMode : u64 {
     Offset = 2,
 };
 
+enum class LmemStoreCacheManagement : u64 {
+    Default = 0,
+    CG = 1,
+    CS = 2,
+    WT = 3,
+};
+
 struct IpaMode {
     IpaInterpMode interpolation_mode;
     IpaSampleMode sampling_mode;
@@ -782,7 +789,7 @@ union Instruction {
     } ld_l;
 
     union {
-        BitField<44, 2, u64> unknown;
+        BitField<44, 2, LmemStoreCacheManagement> cache_management;
     } st_l;
 
     union {

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -387,6 +387,13 @@ enum class IpaSampleMode : u64 {
     Offset = 2,
 };
 
+enum class LmemLoadCacheManagement : u64 {
+    Default = 0,
+    LU = 1,
+    CI = 2,
+    CV = 3,
+};
+
 enum class LmemStoreCacheManagement : u64 {
     Default = 0,
     CG = 1,

--- a/src/video_core/shader/decode/memory.cpp
+++ b/src/video_core/shader/decode/memory.cpp
@@ -86,8 +86,8 @@ u32 ShaderIR::DecodeMemory(NodeBlock& bb, u32 pc) {
         break;
     }
     case OpCode::Id::LD_L: {
-        UNIMPLEMENTED_IF_MSG(instr.ld_l.unknown == 1, "LD_L Unhandled mode: {}",
-                             static_cast<u32>(instr.ld_l.unknown.Value()));
+        LOG_DEBUG(HW_GPU, "LD_L cache management mode: {}",
+                  static_cast<u64>(instr.ld_l.unknown.Value()));
 
         const auto GetLmem = [&](s32 offset) {
             ASSERT(offset % 4 == 0);

--- a/src/video_core/shader/decode/memory.cpp
+++ b/src/video_core/shader/decode/memory.cpp
@@ -8,6 +8,7 @@
 
 #include "common/assert.h"
 #include "common/common_types.h"
+#include "common/logging/log.h"
 #include "video_core/engines/shader_bytecode.h"
 #include "video_core/shader/shader_ir.h"
 
@@ -205,8 +206,8 @@ u32 ShaderIR::DecodeMemory(NodeBlock& bb, u32 pc) {
         break;
     }
     case OpCode::Id::ST_L: {
-        UNIMPLEMENTED_IF_MSG(instr.st_l.unknown == 0, "ST_L Unhandled mode: {}",
-                             static_cast<u32>(instr.st_l.unknown.Value()));
+        LOG_DEBUG(HW_GPU, "ST_L cache management mode: {}",
+                  static_cast<u64>(instr.st_l.cache_management.Value()));
 
         const auto GetLmemAddr = [&](s32 offset) {
             ASSERT(offset % 4 == 0);


### PR DESCRIPTION
Reduce the severity of some checks from asserts to `LOG_DEBUG`, this is mostly because with the current state of shading languages (or shading representations) we can't manage them without a software implementation. Host shader compilers can choose whatever approach the want and OpenGL (and Vulkan) is fine with that.

[SPV_KHR_float_controls](https://github.com/KhronosGroup/SPIRV-Registry/blob/master/extensions/KHR/SPV_KHR_float_controls.html) might help in this regard, but it just exposes this functionality per-shader module instead of per-operation. SPIR-V is capable of exposing these per-operation but that functionality is reserved for kernels, not shaders.