### PR TITLE
gl_framebuffer_cache: Move to its own file and implement invalidation

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -36,6 +36,8 @@ add_library(video_core STATIC
     renderer_base.h
     renderer_opengl/gl_buffer_cache.cpp
     renderer_opengl/gl_buffer_cache.h
+    renderer_opengl/gl_framebuffer_cache.cpp
+    renderer_opengl/gl_framebuffer_cache.h
     renderer_opengl/gl_global_cache.cpp
     renderer_opengl/gl_global_cache.h
     renderer_opengl/gl_primitive_assembler.cpp

--- a/src/video_core/renderer_opengl/gl_framebuffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_framebuffer_cache.cpp
@@ -1,0 +1,76 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <tuple>
+
+#include "common/cityhash.h"
+#include "common/scope_exit.h"
+#include "video_core/engines/maxwell_3d.h"
+#include "video_core/renderer_opengl/gl_framebuffer_cache.h"
+#include "video_core/renderer_opengl/gl_state.h"
+
+namespace OpenGL {
+
+using Maxwell = Tegra::Engines::Maxwell3D::Regs;
+
+std::size_t FramebufferCacheKey::Hash() const {
+    static_assert(sizeof(*this) % sizeof(u64) == 0, "Unaligned struct");
+    return static_cast<std::size_t>(
+        Common::CityHash64(reinterpret_cast<const char*>(this), sizeof(*this)));
+}
+
+bool FramebufferCacheKey::operator==(const FramebufferCacheKey& rhs) const {
+    return std::tie(is_single_buffer, stencil_enable, color_attachments, colors, colors_count,
+                    zeta) == std::tie(rhs.is_single_buffer, rhs.stencil_enable,
+                                      rhs.color_attachments, rhs.colors, rhs.colors_count,
+                                      rhs.zeta);
+}
+
+FramebufferCacheOpenGL::FramebufferCacheOpenGL() = default;
+
+FramebufferCacheOpenGL::~FramebufferCacheOpenGL() = default;
+
+GLuint FramebufferCacheOpenGL::GetFramebuffer(const FramebufferCacheKey& key) {
+    const auto [entry, is_cache_miss] = cache.try_emplace(key);
+    auto& framebuffer{entry->second};
+    if (is_cache_miss) {
+        framebuffer = CreateFramebuffer(key);
+    }
+    return framebuffer.handle;
+}
+
+OGLFramebuffer FramebufferCacheOpenGL::CreateFramebuffer(const FramebufferCacheKey& key) {
+    OGLFramebuffer framebuffer;
+    framebuffer.Create();
+
+    // TODO(Rodrigo): Use DSA here after Nvidia fixes their framebuffer DSA bugs.
+    local_state.draw.draw_framebuffer = framebuffer.handle;
+    local_state.ApplyFramebufferState();
+
+    if (key.is_single_buffer) {
+        if (key.color_attachments[0] != GL_NONE) {
+            glFramebufferTexture(GL_DRAW_FRAMEBUFFER, key.color_attachments[0], key.colors[0], 0);
+        }
+        glDrawBuffer(key.color_attachments[0]);
+    } else {
+        for (std::size_t index = 0; index < Maxwell::NumRenderTargets; ++index) {
+            if (key.colors[index]) {
+                glFramebufferTexture(GL_DRAW_FRAMEBUFFER,
+                                     GL_COLOR_ATTACHMENT0 + static_cast<GLenum>(index),
+                                     key.colors[index], 0);
+            }
+        }
+        glDrawBuffers(key.colors_count, key.color_attachments.data());
+    }
+
+    if (key.zeta) {
+        const GLenum zeta_attachment =
+            key.stencil_enable ? GL_DEPTH_STENCIL_ATTACHMENT : GL_DEPTH_ATTACHMENT;
+        glFramebufferTexture(GL_DRAW_FRAMEBUFFER, zeta_attachment, key.zeta, 0);
+    }
+
+    return framebuffer;
+}
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_framebuffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_framebuffer_cache.h
@@ -1,0 +1,68 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <unordered_map>
+
+#include <glad/glad.h>
+
+#include "common/common_types.h"
+#include "video_core/engines/maxwell_3d.h"
+#include "video_core/renderer_opengl/gl_resource_manager.h"
+#include "video_core/renderer_opengl/gl_state.h"
+
+namespace OpenGL {
+
+struct alignas(sizeof(u64)) FramebufferCacheKey {
+    bool is_single_buffer = false;
+    bool stencil_enable = false;
+
+    std::array<GLenum, Tegra::Engines::Maxwell3D::Regs::NumRenderTargets> color_attachments{};
+    std::array<GLuint, Tegra::Engines::Maxwell3D::Regs::NumRenderTargets> colors{};
+    u32 colors_count = 0;
+
+    GLuint zeta = 0;
+
+    std::size_t Hash() const;
+
+    bool operator==(const FramebufferCacheKey& rhs) const;
+
+    bool operator!=(const FramebufferCacheKey& rhs) const {
+        return !operator==(rhs);
+    }
+};
+
+} // namespace OpenGL
+
+namespace std {
+
+template <>
+struct hash<OpenGL::FramebufferCacheKey> {
+    std::size_t operator()(const OpenGL::FramebufferCacheKey& k) const noexcept {
+        return k.Hash();
+    }
+};
+
+} // namespace std
+
+namespace OpenGL {
+
+class FramebufferCacheOpenGL {
+public:
+    FramebufferCacheOpenGL();
+    ~FramebufferCacheOpenGL();
+
+    GLuint GetFramebuffer(const FramebufferCacheKey& key);
+
+private:
+    OGLFramebuffer CreateFramebuffer(const FramebufferCacheKey& key);
+
+    OpenGLState local_state;
+    std::unordered_map<FramebufferCacheKey, OGLFramebuffer> cache;
+};
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -81,8 +81,10 @@ struct DrawParameters {
 };
 
 RasterizerOpenGL::RasterizerOpenGL(Core::System& system, ScreenInfo& info)
-    : res_cache{*this}, shader_cache{*this, system}, global_cache{*this}, system{system},
-      screen_info{info}, buffer_cache(*this, STREAM_BUFFER_SIZE) {
+    : framebuffer_cache{std::make_shared<FramebufferCacheOpenGLImpl>()},
+      res_cache{*this, framebuffer_cache}, shader_cache{*this, system},
+      global_cache{*this}, system{system}, screen_info{info},
+      buffer_cache(*this, STREAM_BUFFER_SIZE) {
     // Create sampler objects
     for (std::size_t i = 0; i < texture_samplers.size(); ++i) {
         texture_samplers[i].Create();
@@ -512,7 +514,7 @@ std::pair<bool, bool> RasterizerOpenGL::ConfigureFramebuffers(
                                depth_surface->GetSurfaceParams().type == SurfaceType::DepthStencil;
     }
 
-    current_state.draw.draw_framebuffer = framebuffer_cache.GetFramebuffer(fbkey);
+    current_state.draw.draw_framebuffer = framebuffer_cache->GetFramebuffer(fbkey);
     SyncViewport(current_state);
 
     return current_depth_stencil_usage = {static_cast<bool>(depth_surface), fbkey.stencil_enable};

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -209,10 +209,10 @@ private:
 
     OpenGLState state;
 
+    FramebufferCacheOpenGL framebuffer_cache;
     RasterizerCacheOpenGL res_cache;
     ShaderCacheOpenGL shader_cache;
     GlobalRegionCacheOpenGL global_cache;
-    FramebufferCacheOpenGL framebuffer_cache;
 
     Core::System& system;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -24,6 +24,7 @@
 #include "video_core/rasterizer_cache.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/gl_buffer_cache.h"
+#include "video_core/renderer_opengl/gl_framebuffer_cache.h"
 #include "video_core/renderer_opengl/gl_global_cache.h"
 #include "video_core/renderer_opengl/gl_primitive_assembler.h"
 #include "video_core/renderer_opengl/gl_rasterizer_cache.h"
@@ -46,7 +47,6 @@ namespace OpenGL {
 
 struct ScreenInfo;
 struct DrawParameters;
-struct FramebufferCacheKey;
 
 class RasterizerOpenGL : public VideoCore::RasterizerInterface {
 public:
@@ -212,6 +212,7 @@ private:
     RasterizerCacheOpenGL res_cache;
     ShaderCacheOpenGL shader_cache;
     GlobalRegionCacheOpenGL global_cache;
+    FramebufferCacheOpenGL framebuffer_cache;
 
     Core::System& system;
 
@@ -223,7 +224,6 @@ private:
              OGLVertexArray>
         vertex_array_cache;
 
-    std::map<FramebufferCacheKey, OGLFramebuffer> framebuffer_cache;
     FramebufferConfigState current_framebuffer_config_state;
     std::pair<bool, bool> current_depth_stencil_usage{};
 
@@ -246,8 +246,6 @@ private:
     DrawParameters SetupDraw();
 
     void SetupShaders(GLenum primitive_mode);
-
-    void SetupCachedFramebuffer(const FramebufferCacheKey& fbkey, OpenGLState& current_state);
 
     enum class AccelDraw { Disabled, Arrays, Indexed };
     AccelDraw accelerate_draw = AccelDraw::Disabled;

--- a/src/video_core/renderer_opengl/gl_resource_manager.h
+++ b/src/video_core/renderer_opengl/gl_resource_manager.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <utility>
 #include <glad/glad.h>
 #include "common/common_types.h"
@@ -11,15 +12,15 @@
 
 namespace OpenGL {
 
+class FramebufferCacheOpenGLImpl;
+using FramebufferCacheOpenGL = std::shared_ptr<FramebufferCacheOpenGLImpl>;
+
 class OGLTexture : private NonCopyable {
 public:
-    OGLTexture() = default;
+    explicit OGLTexture(FramebufferCacheOpenGL framebuffer_cache);
+    OGLTexture(OGLTexture&& o) noexcept;
 
-    OGLTexture(OGLTexture&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
-
-    ~OGLTexture() {
-        Release();
-    }
+    ~OGLTexture();
 
     OGLTexture& operator=(OGLTexture&& o) noexcept {
         Release();
@@ -34,6 +35,9 @@ public:
     void Release();
 
     GLuint handle = 0;
+
+private:
+    FramebufferCacheOpenGL framebuffer_cache;
 };
 
 class OGLSampler : private NonCopyable {

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -28,7 +28,7 @@ namespace OpenGL {
 
 /// Structure used for storing information about the textures for the Switch screen
 struct TextureInfo {
-    OGLTexture resource;
+    OGLTexture resource{nullptr};
     GLsizei width;
     GLsizei height;
     GLenum gl_format;


### PR DESCRIPTION
Moves framebuffer cache to its own files and replaces the ordered map with a hashed map.

Implement texture invalidation, on `OGLTexture` constructor it receives a `std::shared_ptr` to the framebuffer cache (or `nullptr`). When releasing `OGLTexture` the framebuffer cache gets signaled that a texture has been destroyed and it looks through the whole cache finding instances where this texture was used and deletes them.