### PR TITLE
kernel/object: Remove unused handle type entry

### DIFF
--- a/src/core/hle/kernel/object.cpp
+++ b/src/core/hle/kernel/object.cpp
@@ -24,7 +24,6 @@ bool Object::IsWaitable() const {
     case HandleType::WritableEvent:
     case HandleType::SharedMemory:
     case HandleType::TransferMemory:
-    case HandleType::AddressArbiter:
     case HandleType::ResourceLimit:
     case HandleType::ClientPort:
     case HandleType::ClientSession:

--- a/src/core/hle/kernel/object.h
+++ b/src/core/hle/kernel/object.h
@@ -25,7 +25,6 @@ enum class HandleType : u32 {
     TransferMemory,
     Thread,
     Process,
-    AddressArbiter,
     ResourceLimit,
     ClientPort,
     ServerPort,


### PR DESCRIPTION
The AddressArbiter type isn't actually used, given the arbiter itself isn't a direct kernel object (or object that implements the wait object facilities). The arbiter class itself also doesn't need to make use of this.

Given this, we can remove the enum entry entirely.