### PR TITLE
kernel/server_session: Provide a GetName() override

### DIFF
--- a/src/core/hle/kernel/server_session.h
+++ b/src/core/hle/kernel/server_session.h
@@ -41,6 +41,10 @@ public:
         return "ServerSession";
     }
 
+    std::string GetName() const override {
+        return name;
+    }
+
     static const HandleType HANDLE_TYPE = HandleType::ServerSession;
     HandleType GetHandleType() const override {
         return HANDLE_TYPE;


### PR DESCRIPTION
Given server sessions can be given a name, we should allow retrieving it instead of using the default implementation of GetName(), which would just return `"[UNKNOWN KERNEL OBJECT]"`.