### PR TITLE
yuzu/applets/{profile_select, software_keyboard}: Use QDialogButtonBox standard buttons instead of custom ones where applicable

### DIFF
--- a/src/yuzu/applets/profile_select.cpp
+++ b/src/yuzu/applets/profile_select.cpp
@@ -58,10 +58,7 @@ QtProfileSelectionDialog::QtProfileSelectionDialog(QWidget* parent)
 
     scroll_area = new QScrollArea;
 
-    buttons = new QDialogButtonBox;
-    buttons->addButton(tr("Cancel"), QDialogButtonBox::RejectRole);
-    buttons->addButton(tr("OK"), QDialogButtonBox::AcceptRole);
-
+    buttons = new QDialogButtonBox(QDialogButtonBox::Cancel | QDialogButtonBox::Ok);
     connect(buttons, &QDialogButtonBox::accepted, this, &QtProfileSelectionDialog::accept);
     connect(buttons, &QDialogButtonBox::rejected, this, &QtProfileSelectionDialog::reject);
 

--- a/src/yuzu/applets/software_keyboard.cpp
+++ b/src/yuzu/applets/software_keyboard.cpp
@@ -75,13 +75,13 @@ QtSoftwareKeyboardDialog::QtSoftwareKeyboardDialog(
         length_label->setText(QStringLiteral("%1/%2").arg(text.size()).arg(parameters.max_length));
     });
 
-    buttons = new QDialogButtonBox;
-    buttons->addButton(tr("Cancel"), QDialogButtonBox::RejectRole);
-    buttons->addButton(parameters.submit_text.empty()
-                           ? tr("OK")
-                           : QString::fromStdU16String(parameters.submit_text),
-                       QDialogButtonBox::AcceptRole);
-
+    buttons = new QDialogButtonBox(QDialogButtonBox::Cancel);
+    if (parameters.submit_text.empty()) {
+        buttons->addButton(QDialogButtonBox::Ok);
+    } else {
+        buttons->addButton(QString::fromStdU16String(parameters.submit_text),
+                           QDialogButtonBox::AcceptRole);
+    }
     connect(buttons, &QDialogButtonBox::accepted, this, &QtSoftwareKeyboardDialog::accept);
     connect(buttons, &QDialogButtonBox::rejected, this, &QtSoftwareKeyboardDialog::reject);
     layout->addWidget(header_label);


### PR DESCRIPTION
Makes for less reading, and also makes Qt handle the translation of the buttons, rather than us needing to do so.