### PR TITLE
gl_shader_decompiler: Return early when an operation is invalid

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -426,9 +426,14 @@ private:
     std::string Visit(Node node) {
         if (const auto operation = std::get_if<OperationNode>(node)) {
             const auto operation_index = static_cast<std::size_t>(operation->GetCode());
+            if (operation_index >= operation_decompilers.size()) {
+                UNREACHABLE_MSG("Out of bounds operation: {}", operation_index);
+                return {};
+            }
             const auto decompiler = operation_decompilers[operation_index];
             if (decompiler == nullptr) {
-                UNREACHABLE_MSG("Operation decompiler {} not defined", operation_index);
+                UNREACHABLE_MSG("Undefined operation: {}", operation_index);
+                return {};
             }
             return (this->*decompiler)(*operation);
 


### PR DESCRIPTION
This is a workaround for dumps of corrupted memory, it will report a valid message with asserts on and emit broken shaders with asserts off (instead of crashing). That being said, memory shouldn't be corrupted in the first place.