### PR TITLE
kernel/svc: Properly sanitize mutex address in WaitProcessWideKeyAtomic

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1339,6 +1339,20 @@ static ResultCode WaitProcessWideKeyAtomic(VAddr mutex_addr, VAddr condition_var
         "called mutex_addr={:X}, condition_variable_addr={:X}, thread_handle=0x{:08X}, timeout={}",
         mutex_addr, condition_variable_addr, thread_handle, nano_seconds);
 
+    if (Memory::IsKernelVirtualAddress(mutex_addr)) {
+        LOG_ERROR(
+            Kernel_SVC,
+            "Given mutex address must not be within the kernel address space. address=0x{:016X}",
+            mutex_addr);
+        return ERR_INVALID_ADDRESS_STATE;
+    }
+
+    if (!Common::IsWordAligned(mutex_addr)) {
+        LOG_ERROR(Kernel_SVC, "Given mutex address must be word-aligned. address=0x{:016X}",
+                  mutex_addr);
+        return ERR_INVALID_ADDRESS;
+    }
+
     auto* const current_process = Core::System::GetInstance().Kernel().CurrentProcess();
     const auto& handle_table = current_process->GetHandleTable();
     SharedPtr<Thread> thread = handle_table.Get<Thread>(thread_handle);


### PR DESCRIPTION
Just two overlooked checks that weren't added. We need to be checking whether or not the given address is within the kernel address space or if the given address isn't word-aligned and bail in these scenarios instead of trashing any kernel state.
