### PR TITLE
common/lz4_compression: Remove #pragma once directive from the cpp file

### DIFF
--- a/src/common/lz4_compression.cpp
+++ b/src/common/lz4_compression.cpp
@@ -2,8 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#pragma once
-
 #include <algorithm>
 #include <lz4hc.h>
 


### PR DESCRIPTION
Introduced within 798d76f4c7018174e58702fb06a042dc8c84f0be, this only really has an effect within header files.

Silences a `-Wpragma-once-outside-header` warning with clang.