### PR TITLE
yuzu/main: Minor adjustments to OnTransferableShaderCacheOpenFile()

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1096,7 +1096,7 @@ void GMainWindow::OnTransferableShaderCacheOpenFile(u64 program_id) {
         tranferable_shader_cache_folder_path + DIR_SEP +
         QString::fromStdString(fmt::format("{:016X}", program_id)) + ".bin";
 
-    if (!QFile(transferable_shader_cache_file_path).exists()) {
+    if (!QFile::exists(transferable_shader_cache_file_path)) {
         QMessageBox::warning(this,
                              tr("Error Opening %1 File").arg(QString::fromStdString(open_target)),
                              tr("File does not exist!"));

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1087,7 +1087,7 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
 void GMainWindow::OnTransferableShaderCacheOpenFile(u64 program_id) {
     ASSERT(program_id != 0);
 
-    constexpr char open_target[] = "Transferable Shader Cache";
+    const QString open_target = QStringLiteral("Transferable Shader Cache");
     const QString tranferable_shader_cache_folder_path =
         QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir)) + "opengl" +
         DIR_SEP + "transferable";
@@ -1097,12 +1097,10 @@ void GMainWindow::OnTransferableShaderCacheOpenFile(u64 program_id) {
         QString::fromStdString(fmt::format("{:016X}", program_id)) + ".bin";
 
     if (!QFile::exists(transferable_shader_cache_file_path)) {
-        QMessageBox::warning(this,
-                             tr("Error Opening %1 File").arg(QString::fromStdString(open_target)),
+        QMessageBox::warning(this, tr("Error Opening %1 File").arg(open_target),
                              tr("File does not exist!"));
         return;
     }
-    LOG_INFO(Frontend, "Opening {} path for program_id={:016x}", open_target, program_id);
 
     // Windows supports opening a folder with selecting a specified file in explorer. On every other
     // OS we just open the transferable shader cache folder without preselecting the transferable

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1105,10 +1105,10 @@ void GMainWindow::OnTransferableShaderCacheOpenFile(u64 program_id) {
     // OS we just open the transferable shader cache folder without preselecting the transferable
     // shader cache file for the selected game.
 #if defined(Q_OS_WIN)
-    const QString explorer = "explorer";
+    const QString explorer = QStringLiteral("explorer");
     QStringList param;
     if (!QFileInfo(transferable_shader_cache_file_path).isDir()) {
-        param << QLatin1String("/select,");
+        param << QStringLiteral("/select,");
     }
     param << QDir::toNativeSeparators(transferable_shader_cache_file_path);
     QProcess::startDetached(explorer, param);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1094,7 +1094,7 @@ void GMainWindow::OnTransferableShaderCacheOpenFile(u64 program_id) {
 
     const QString transferable_shader_cache_file_path =
         tranferable_shader_cache_folder_path + DIR_SEP +
-        QString::fromStdString(fmt::format("{:016X}", program_id)) + ".bin";
+        QString::fromStdString(fmt::format("{:016X}.bin", program_id));
 
     if (!QFile::exists(transferable_shader_cache_file_path)) {
         QMessageBox::warning(this, tr("Error Opening %1 File").arg(open_target),

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1087,7 +1087,6 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
 void GMainWindow::OnTransferableShaderCacheOpenFile(u64 program_id) {
     ASSERT(program_id != 0);
 
-    const QString open_target = QStringLiteral("Transferable Shader Cache");
     const QString tranferable_shader_cache_folder_path =
         QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir)) + "opengl" +
         DIR_SEP + "transferable";
@@ -1097,8 +1096,8 @@ void GMainWindow::OnTransferableShaderCacheOpenFile(u64 program_id) {
         QString::fromStdString(fmt::format("{:016X}.bin", program_id));
 
     if (!QFile::exists(transferable_shader_cache_file_path)) {
-        QMessageBox::warning(this, tr("Error Opening %1 File").arg(open_target),
-                             tr("File does not exist!"));
+        QMessageBox::warning(this, tr("Error Opening Transferable Shader Cache"),
+                             tr("A shader cache for this title does not exist."));
         return;
     }
 


### PR DESCRIPTION
Just a few minor changes. This also makes the error dialog slightly more unambiguous for those where English may not be their primary language (and disambiguates it in general).