### PR TITLE
core: Add missing override specifiers where applicable

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -26,7 +26,6 @@ using Vector = Dynarmic::A64::Vector;
 class ARM_Dynarmic_Callbacks : public Dynarmic::A64::UserCallbacks {
 public:
     explicit ARM_Dynarmic_Callbacks(ARM_Dynarmic& parent) : parent(parent) {}
-    ~ARM_Dynarmic_Callbacks() = default;
 
     u8 MemoryRead8(u64 vaddr) override {
         return Memory::Read8(vaddr);

--- a/src/core/arm/dynarmic/arm_dynarmic.h
+++ b/src/core/arm/dynarmic/arm_dynarmic.h
@@ -29,7 +29,7 @@ class ARM_Dynarmic final : public ARM_Interface {
 public:
     ARM_Dynarmic(Timing::CoreTiming& core_timing, ExclusiveMonitor& exclusive_monitor,
                  std::size_t core_index);
-    ~ARM_Dynarmic();
+    ~ARM_Dynarmic() override;
 
     void MapBackingMemory(VAddr address, std::size_t size, u8* memory,
                           Kernel::VMAPermission perms) override;
@@ -76,7 +76,7 @@ private:
 class DynarmicExclusiveMonitor final : public ExclusiveMonitor {
 public:
     explicit DynarmicExclusiveMonitor(std::size_t core_count);
-    ~DynarmicExclusiveMonitor();
+    ~DynarmicExclusiveMonitor() override;
 
     void SetExclusive(std::size_t core_index, VAddr addr) override;
     void ClearExclusive() override;

--- a/src/core/arm/unicorn/arm_unicorn.h
+++ b/src/core/arm/unicorn/arm_unicorn.h
@@ -18,7 +18,7 @@ namespace Core {
 class ARM_Unicorn final : public ARM_Interface {
 public:
     explicit ARM_Unicorn(Timing::CoreTiming& core_timing);
-    ~ARM_Unicorn();
+    ~ARM_Unicorn() override;
 
     void MapBackingMemory(VAddr address, std::size_t size, u8* memory,
                           Kernel::VMAPermission perms) override;

--- a/src/core/hle/service/audio/audin_u.cpp
+++ b/src/core/hle/service/audio/audin_u.cpp
@@ -2,9 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "common/logging/log.h"
-#include "core/hle/ipc_helpers.h"
-#include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/service/audio/audin_u.h"
 
 namespace Service::Audio {
@@ -33,7 +30,6 @@ public:
 
         RegisterHandlers(functions);
     }
-    ~IAudioIn() = default;
 };
 
 AudInU::AudInU() : ServiceFramework("audin:u") {

--- a/src/core/hle/service/audio/audrec_u.cpp
+++ b/src/core/hle/service/audio/audrec_u.cpp
@@ -2,9 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "common/logging/log.h"
-#include "core/hle/ipc_helpers.h"
-#include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/service/audio/audrec_u.h"
 
 namespace Service::Audio {
@@ -30,7 +27,6 @@ public:
 
         RegisterHandlers(functions);
     }
-    ~IFinalOutputRecorder() = default;
 };
 
 AudRecU::AudRecU() : ServiceFramework("audrec:u") {

--- a/src/core/hle/service/nvdrv/devices/nvdisp_disp0.h
+++ b/src/core/hle/service/nvdrv/devices/nvdisp_disp0.h
@@ -18,7 +18,7 @@ class nvmap;
 class nvdisp_disp0 final : public nvdevice {
 public:
     explicit nvdisp_disp0(std::shared_ptr<nvmap> nvmap_dev);
-    ~nvdisp_disp0();
+    ~nvdisp_disp0() override;
 
     u32 ioctl(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output) override;
 

--- a/src/core/hle/service/nvdrv/interface.h
+++ b/src/core/hle/service/nvdrv/interface.h
@@ -17,7 +17,7 @@ namespace Service::Nvidia {
 class NVDRV final : public ServiceFramework<NVDRV> {
 public:
     NVDRV(std::shared_ptr<Module> nvdrv, const char* name);
-    ~NVDRV();
+    ~NVDRV() override;
 
 private:
     void Open(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/nvdrv/nvmemp.h
+++ b/src/core/hle/service/nvdrv/nvmemp.h
@@ -11,7 +11,7 @@ namespace Service::Nvidia {
 class NVMEMP final : public ServiceFramework<NVMEMP> {
 public:
     NVMEMP();
-    ~NVMEMP();
+    ~NVMEMP() override;
 
 private:
     void Cmd0(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -90,7 +90,7 @@ private:
                            Kernel::HLERequestContext& ctx);
 
     ServiceFrameworkBase(const char* service_name, u32 max_sessions, InvokerFn* handler_invoker);
-    ~ServiceFrameworkBase();
+    ~ServiceFrameworkBase() override;
 
     void RegisterHandlersBase(const FunctionInfoBase* functions, std::size_t n);
     void ReportUnimplementedFunction(Kernel::HLERequestContext& ctx, const FunctionInfoBase* info);

--- a/src/core/hle/service/set/set_cal.h
+++ b/src/core/hle/service/set/set_cal.h
@@ -11,7 +11,7 @@ namespace Service::Set {
 class SET_CAL final : public ServiceFramework<SET_CAL> {
 public:
     explicit SET_CAL();
-    ~SET_CAL();
+    ~SET_CAL() override;
 };
 
 } // namespace Service::Set

--- a/src/core/hle/service/ssl/ssl.cpp
+++ b/src/core/hle/service/ssl/ssl.cpp
@@ -64,7 +64,6 @@ public:
         };
         RegisterHandlers(functions);
     }
-    ~ISslContext() = default;
 
 private:
     void SetOption(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -498,7 +498,6 @@ public:
         };
         RegisterHandlers(functions);
     }
-    ~IHOSBinderDriver() = default;
 
 private:
     enum class TransactionId {
@@ -692,7 +691,6 @@ public:
         };
         RegisterHandlers(functions);
     }
-    ~ISystemDisplayService() = default;
 
 private:
     void SetLayerZ(Kernel::HLERequestContext& ctx) {
@@ -818,7 +816,6 @@ public:
         };
         RegisterHandlers(functions);
     }
-    ~IManagerDisplayService() = default;
 
 private:
     void CloseDisplay(Kernel::HLERequestContext& ctx) {
@@ -884,7 +881,6 @@ private:
 class IApplicationDisplayService final : public ServiceFramework<IApplicationDisplayService> {
 public:
     explicit IApplicationDisplayService(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
-    ~IApplicationDisplayService() = default;
 
 private:
     enum class ConvertedScaleMode : u64 {

--- a/src/core/loader/xci.h
+++ b/src/core/loader/xci.h
@@ -22,7 +22,7 @@ class AppLoader_NCA;
 class AppLoader_XCI final : public AppLoader {
 public:
     explicit AppLoader_XCI(FileSys::VirtualFile file);
-    ~AppLoader_XCI();
+    ~AppLoader_XCI() override;
 
     /**
      * Returns the type of the file


### PR DESCRIPTION
Applies the override specifier where applicable. In the case of destructors that are defaulted in their class definition, they can just simply be removed.

This also removes the unnecessary inclusions being done in audin_u and audrec_u, given their close proximity.