### PR TITLE
hle/service: Resolve unused variable warnings

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -363,8 +363,6 @@ void ISelfController::SetPerformanceModeChangedNotification(Kernel::HLERequestCo
 void ISelfController::SetFocusHandlingMode(Kernel::HLERequestContext& ctx) {
     // Takes 3 input u8s with each field located immediately after the previous
     // u8, these are bool flags. No output.
-    LOG_WARNING(Service_AM, "(STUBBED) called");
-
     IPC::RequestParser rp{ctx};
 
     struct FocusHandlingModeParams {
@@ -372,7 +370,10 @@ void ISelfController::SetFocusHandlingMode(Kernel::HLERequestContext& ctx) {
         u8 unknown1;
         u8 unknown2;
     };
-    auto flags = rp.PopRaw<FocusHandlingModeParams>();
+    const auto flags = rp.PopRaw<FocusHandlingModeParams>();
+
+    LOG_WARNING(Service_AM, "(STUBBED) called. unknown0={}, unknown1={}, unknown2={}",
+                flags.unknown0, flags.unknown1, flags.unknown2);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -150,7 +150,6 @@ private:
     void GetReleasedAudioOutBufferImpl(Kernel::HLERequestContext& ctx) {
         LOG_DEBUG(Service_Audio, "called {}", ctx.Description());
 
-        IPC::RequestParser rp{ctx};
         const u64 max_count{ctx.GetWriteBufferSize() / sizeof(u64)};
         const auto released_buffers{audio_core.GetTagsAndReleaseBuffers(stream, max_count)};
 
@@ -194,12 +193,9 @@ private:
 void AudOutU::ListAudioOutsImpl(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_Audio, "called");
 
-    IPC::RequestParser rp{ctx};
-
     ctx.WriteBuffer(DefaultDevice);
 
     IPC::ResponseBuilder rb{ctx, 3};
-
     rb.Push(RESULT_SUCCESS);
     rb.Push<u32>(1); // Amount of audio devices
 }

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -10,6 +10,7 @@
 #include "common/alignment.h"
 #include "common/common_funcs.h"
 #include "common/logging/log.h"
+#include "common/string_util.h"
 #include "core/core.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/hle_ipc.h"
@@ -184,7 +185,6 @@ public:
 private:
     void ListAudioDeviceName(Kernel::HLERequestContext& ctx) {
         LOG_WARNING(Service_Audio, "(STUBBED) called");
-        IPC::RequestParser rp{ctx};
 
         constexpr std::array<char, 15> audio_interface{{"AudioInterface"}};
         ctx.WriteBuffer(audio_interface);
@@ -195,13 +195,13 @@ private:
     }
 
     void SetAudioDeviceOutputVolume(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
-
         IPC::RequestParser rp{ctx};
-        f32 volume = static_cast<f32>(rp.Pop<u32>());
+        const f32 volume = rp.Pop<f32>();
 
-        auto file_buffer = ctx.ReadBuffer();
-        auto end = std::find(file_buffer.begin(), file_buffer.end(), '\0');
+        const auto device_name_buffer = ctx.ReadBuffer();
+        const std::string name = Common::StringFromBuffer(device_name_buffer);
+
+        LOG_WARNING(Service_Audio, "(STUBBED) called. name={}, volume={}", name, volume);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -209,7 +209,6 @@ private:
 
     void GetActiveAudioDeviceName(Kernel::HLERequestContext& ctx) {
         LOG_WARNING(Service_Audio, "(STUBBED) called");
-        IPC::RequestParser rp{ctx};
 
         constexpr std::array<char, 12> audio_interface{{"AudioDevice"}};
         ctx.WriteBuffer(audio_interface);

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -315,61 +315,53 @@ public:
     void CreateFile(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
 
-        auto file_buffer = ctx.ReadBuffer();
-        std::string name = Common::StringFromBuffer(file_buffer);
+        const auto file_buffer = ctx.ReadBuffer();
+        const std::string name = Common::StringFromBuffer(file_buffer);
 
-        u64 mode = rp.Pop<u64>();
-        u32 size = rp.Pop<u32>();
+        const u64 mode = rp.Pop<u64>();
+        const u32 size = rp.Pop<u32>();
 
-        LOG_DEBUG(Service_FS, "called file {} mode 0x{:X} size 0x{:08X}", name, mode, size);
+        LOG_DEBUG(Service_FS, "called. file={}, mode=0x{:X}, size=0x{:08X}", name, mode, size);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(backend.CreateFile(name, size));
     }
 
     void DeleteFile(Kernel::HLERequestContext& ctx) {
-        IPC::RequestParser rp{ctx};
+        const auto file_buffer = ctx.ReadBuffer();
+        const std::string name = Common::StringFromBuffer(file_buffer);
 
-        auto file_buffer = ctx.ReadBuffer();
-        std::string name = Common::StringFromBuffer(file_buffer);
-
-        LOG_DEBUG(Service_FS, "called file {}", name);
+        LOG_DEBUG(Service_FS, "called. file={}", name);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(backend.DeleteFile(name));
     }
 
     void CreateDirectory(Kernel::HLERequestContext& ctx) {
-        IPC::RequestParser rp{ctx};
+        const auto file_buffer = ctx.ReadBuffer();
+        const std::string name = Common::StringFromBuffer(file_buffer);
 
-        auto file_buffer = ctx.ReadBuffer();
-        std::string name = Common::StringFromBuffer(file_buffer);
-
-        LOG_DEBUG(Service_FS, "called directory {}", name);
+        LOG_DEBUG(Service_FS, "called. directory={}", name);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(backend.CreateDirectory(name));
     }
 
     void DeleteDirectory(Kernel::HLERequestContext& ctx) {
-        const IPC::RequestParser rp{ctx};
-
         const auto file_buffer = ctx.ReadBuffer();
-        std::string name = Common::StringFromBuffer(file_buffer);
+        const std::string name = Common::StringFromBuffer(file_buffer);
 
-        LOG_DEBUG(Service_FS, "called directory {}", name);
+        LOG_DEBUG(Service_FS, "called. directory={}", name);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(backend.DeleteDirectory(name));
     }
 
     void DeleteDirectoryRecursively(Kernel::HLERequestContext& ctx) {
-        const IPC::RequestParser rp{ctx};
-
         const auto file_buffer = ctx.ReadBuffer();
-        std::string name = Common::StringFromBuffer(file_buffer);
+        const std::string name = Common::StringFromBuffer(file_buffer);
 
-        LOG_DEBUG(Service_FS, "called directory {}", name);
+        LOG_DEBUG(Service_FS, "called. directory={}", name);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(backend.DeleteDirectoryRecursively(name));
@@ -386,18 +378,16 @@ public:
     }
 
     void RenameFile(Kernel::HLERequestContext& ctx) {
-        IPC::RequestParser rp{ctx};
-
         std::vector<u8> buffer;
         buffer.resize(ctx.BufferDescriptorX()[0].Size());
         Memory::ReadBlock(ctx.BufferDescriptorX()[0].Address(), buffer.data(), buffer.size());
-        std::string src_name = Common::StringFromBuffer(buffer);
+        const std::string src_name = Common::StringFromBuffer(buffer);
 
         buffer.resize(ctx.BufferDescriptorX()[1].Size());
         Memory::ReadBlock(ctx.BufferDescriptorX()[1].Address(), buffer.data(), buffer.size());
-        std::string dst_name = Common::StringFromBuffer(buffer);
+        const std::string dst_name = Common::StringFromBuffer(buffer);
 
-        LOG_DEBUG(Service_FS, "called file '{}' to file '{}'", src_name, dst_name);
+        LOG_DEBUG(Service_FS, "called. file '{}' to file '{}'", src_name, dst_name);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(backend.RenameFile(src_name, dst_name));
@@ -406,12 +396,12 @@ public:
     void OpenFile(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
 
-        auto file_buffer = ctx.ReadBuffer();
-        std::string name = Common::StringFromBuffer(file_buffer);
+        const auto file_buffer = ctx.ReadBuffer();
+        const std::string name = Common::StringFromBuffer(file_buffer);
 
-        auto mode = static_cast<FileSys::Mode>(rp.Pop<u32>());
+        const auto mode = static_cast<FileSys::Mode>(rp.Pop<u32>());
 
-        LOG_DEBUG(Service_FS, "called file {} mode {}", name, static_cast<u32>(mode));
+        LOG_DEBUG(Service_FS, "called. file={}, mode={}", name, static_cast<u32>(mode));
 
         auto result = backend.OpenFile(name, mode);
         if (result.Failed()) {
@@ -430,13 +420,13 @@ public:
     void OpenDirectory(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
 
-        auto file_buffer = ctx.ReadBuffer();
-        std::string name = Common::StringFromBuffer(file_buffer);
+        const auto file_buffer = ctx.ReadBuffer();
+        const std::string name = Common::StringFromBuffer(file_buffer);
 
         // TODO(Subv): Implement this filter.
-        u32 filter_flags = rp.Pop<u32>();
+        const u32 filter_flags = rp.Pop<u32>();
 
-        LOG_DEBUG(Service_FS, "called directory {} filter {}", name, filter_flags);
+        LOG_DEBUG(Service_FS, "called. directory={}, filter={}", name, filter_flags);
 
         auto result = backend.OpenDirectory(name);
         if (result.Failed()) {
@@ -453,12 +443,10 @@ public:
     }
 
     void GetEntryType(Kernel::HLERequestContext& ctx) {
-        IPC::RequestParser rp{ctx};
+        const auto file_buffer = ctx.ReadBuffer();
+        const std::string name = Common::StringFromBuffer(file_buffer);
 
-        auto file_buffer = ctx.ReadBuffer();
-        std::string name = Common::StringFromBuffer(file_buffer);
-
-        LOG_DEBUG(Service_FS, "called file {}", name);
+        LOG_DEBUG(Service_FS, "called. file={}", name);
 
         auto result = backend.GetEntryType(name);
         if (result.Failed()) {

--- a/src/core/hle/service/sockets/sfdnsres.cpp
+++ b/src/core/hle/service/sockets/sfdnsres.cpp
@@ -8,12 +8,20 @@
 namespace Service::Sockets {
 
 void SFDNSRES::GetAddrInfo(Kernel::HLERequestContext& ctx) {
-    IPC::RequestParser rp{ctx};
+    struct Parameters {
+        u8 use_nsd_resolve;
+        u32 unknown;
+        u64 process_id;
+    };
 
-    LOG_WARNING(Service, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    const auto parameters = rp.PopRaw<Parameters>();
+
+    LOG_WARNING(Service,
+                "(STUBBED) called. use_nsd_resolve={}, unknown=0x{:08X}, process_id=0x{:016X}",
+                parameters.use_nsd_resolve, parameters.unknown, parameters.process_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
-
     rb.Push(RESULT_SUCCESS);
 }
 

--- a/src/core/hle/service/spl/module.cpp
+++ b/src/core/hle/service/spl/module.cpp
@@ -26,9 +26,7 @@ Module::Interface::~Interface() = default;
 void Module::Interface::GetRandomBytes(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_SPL, "called");
 
-    IPC::RequestParser rp{ctx};
-
-    std::size_t size = ctx.GetWriteBufferSize();
+    const std::size_t size = ctx.GetWriteBufferSize();
 
     std::uniform_int_distribution<u16> distribution(0, std::numeric_limits<u8>::max());
     std::vector<u8> data(size);

--- a/src/core/hle/service/ssl/ssl.cpp
+++ b/src/core/hle/service/ssl/ssl.cpp
@@ -68,9 +68,16 @@ public:
 
 private:
     void SetOption(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_SSL, "(STUBBED) called");
+        struct Parameters {
+            u8 enable;
+            u32 option;
+        };
 
         IPC::RequestParser rp{ctx};
+        const auto parameters = rp.PopRaw<Parameters>();
+
+        LOG_WARNING(Service_SSL, "(STUBBED) called. enable={}, option={}", parameters.enable,
+                    parameters.option);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -1037,7 +1037,6 @@ private:
     void ListDisplays(Kernel::HLERequestContext& ctx) {
         LOG_WARNING(Service_VI, "(STUBBED) called");
 
-        IPC::RequestParser rp{ctx};
         DisplayInfo display_info;
         display_info.width *= static_cast<u64>(Settings::values.resolution_factor);
         display_info.height *= static_cast<u64>(Settings::values.resolution_factor);


### PR DESCRIPTION
In several places, we have request parsers where there's nothing to really parse, simply because the HLE function in question operates on buffers. In these cases we can just remove these instances altogether.

In the other cases, we can retrieve the relevant members from the parser and at least log them out, giving them some use.