### PR TITLE
gl_shader_decompiler: Fix TXQ types

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1196,11 +1196,12 @@ private:
         switch (meta->element) {
         case 0:
         case 1:
-            return "textureSize(" + sampler + ", " + lod + ')' + GetSwizzle(meta->element);
+            return "itof(int(textureSize(" + sampler + ", " + lod + ')' +
+                   GetSwizzle(meta->element) + "))";
         case 2:
             return "0";
         case 3:
-            return "textureQueryLevels(" + sampler + ')';
+            return "itof(textureQueryLevels(" + sampler + "))";
         }
         UNREACHABLE();
         return "0";


### PR DESCRIPTION
TXQ returns integer types. Shaders usually do:
```
R0 = TXQ(); // => int
R0 = static_cast<float>(R0);
```
If we don't treat it as an integer, it will cast a binary float value from a theoretical integer to float - resulting in a corrupted number.