### PR TITLE
file_sys/fsmitm_romfsbuild: Utilize a string_view in romfs_calc_path_hash

### DIFF
--- a/src/core/file_sys/fsmitm_romfsbuild.cpp
+++ b/src/core/file_sys/fsmitm_romfsbuild.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <cstring>
+#include <string_view>
 #include "common/alignment.h"
 #include "common/assert.h"
 #include "core/file_sys/fsmitm_romfsbuild.h"
@@ -97,7 +98,8 @@ struct RomFSBuildFileContext {
     VirtualFile source;
 };
 
-static u32 romfs_calc_path_hash(u32 parent, std::string path, u32 start, std::size_t path_len) {
+static u32 romfs_calc_path_hash(u32 parent, std::string_view path, u32 start,
+                                std::size_t path_len) {
     u32 hash = parent ^ 123456789;
     for (u32 i = 0; i < path_len; i++) {
         hash = (hash >> 5) | (hash << 27);


### PR DESCRIPTION
The given string instance doesn't need to be copied entirely, we can just use a view instead.