### PR TITLE
file_sys/nca_metadata: Remove unnecessary comparison operators for TitleType

### DIFF
--- a/src/core/file_sys/nca_metadata.cpp
+++ b/src/core/file_sys/nca_metadata.cpp
@@ -10,14 +10,6 @@
 
 namespace FileSys {
 
-bool operator>=(TitleType lhs, TitleType rhs) {
-    return static_cast<std::size_t>(lhs) >= static_cast<std::size_t>(rhs);
-}
-
-bool operator<=(TitleType lhs, TitleType rhs) {
-    return static_cast<std::size_t>(lhs) <= static_cast<std::size_t>(rhs);
-}
-
 CNMT::CNMT(VirtualFile file) {
     if (file->ReadObject(&header) != sizeof(CNMTHeader))
         return;

--- a/src/core/file_sys/nca_metadata.h
+++ b/src/core/file_sys/nca_metadata.h
@@ -29,9 +29,6 @@ enum class TitleType : u8 {
     DeltaTitle = 0x83,
 };
 
-bool operator>=(TitleType lhs, TitleType rhs);
-bool operator<=(TitleType lhs, TitleType rhs);
-
 enum class ContentRecordType : u8 {
     Meta = 0,
     Program = 1,


### PR DESCRIPTION
enum class elements from the same enum can already be compared against one another without the need for explicitly defined comparison operators.