### PR TITLE
file_sys/program_metadata: Remove obsolete TODOs

### DIFF
--- a/src/core/file_sys/program_metadata.h
+++ b/src/core/file_sys/program_metadata.h
@@ -58,7 +58,6 @@ public:
     void Print() const;
 
 private:
-    // TODO(DarkLordZach): BitField is not trivially copyable.
     struct Header {
         std::array<char, 4> magic;
         std::array<u8, 8> reserved;
@@ -85,7 +84,6 @@ private:
 
     static_assert(sizeof(Header) == 0x80, "NPDM header structure size is wrong");
 
-    // TODO(DarkLordZach): BitField is not trivially copyable.
     struct AcidHeader {
         std::array<u8, 0x100> signature;
         std::array<u8, 0x100> nca_modulus;


### PR DESCRIPTION
BitField has been trivially copyable since e99a14862841841d74be8d0ea9426c2d23546b5e, so we can eliminate these TODO comments and use ReadObject() directly instead of memcpying the data.