### PR TITLE
video_core/gpu_thread: Silence truncation warning in ThreadManager's constructor

### DIFF
--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -59,7 +59,7 @@ ThreadManager::ThreadManager(Core::System& system, VideoCore::RendererBase& rend
                              Tegra::DmaPusher& dma_pusher)
     : system{system}, thread{RunThread, std::ref(renderer), std::ref(dma_pusher), std::ref(state)} {
     synchronization_event = system.CoreTiming().RegisterEvent(
-        "GPUThreadSynch", [this](u64 fence, int) { state.WaitForSynchronization(fence); });
+        "GPUThreadSynch", [this](u64 fence, s64) { state.WaitForSynchronization(fence); });
 }
 
 ThreadManager::~ThreadManager() {


### PR DESCRIPTION
Since c5d41fd812d7eb1a04f36b76c08fe971cee0868c callback parameters were changed to use an s64 to represent late cycles instead of an int, so this was causing a truncation warning to occur here. Changing it to s64 is sufficient to silence the warning.