### PR TITLE
video_core/memory_manager: Mark a few member functions with the const qualifier

### DIFF
--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -180,8 +180,22 @@ u8* MemoryManager::GetPointer(GPUVAddr addr) {
         return {};
     }
 
-    u8* page_pointer{page_table.pointers[addr >> page_bits]};
-    if (page_pointer) {
+    u8* const page_pointer{page_table.pointers[addr >> page_bits]};
+    if (page_pointer != nullptr) {
+        return page_pointer + (addr & page_mask);
+    }
+
+    LOG_ERROR(HW_GPU, "Unknown GetPointer @ 0x{:016X}", addr);
+    return {};
+}
+
+const u8* MemoryManager::GetPointer(GPUVAddr addr) const {
+    if (!IsAddressValid(addr)) {
+        return {};
+    }
+
+    const u8* const page_pointer{page_table.pointers[addr >> page_bits]};
+    if (page_pointer != nullptr) {
         return page_pointer + (addr & page_mask);
     }
 

--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -99,12 +99,12 @@ bool MemoryManager::IsAddressValid(GPUVAddr addr) const {
     return (addr >> page_bits) < page_table.pointers.size();
 }
 
-std::optional<VAddr> MemoryManager::GpuToCpuAddress(GPUVAddr addr) {
+std::optional<VAddr> MemoryManager::GpuToCpuAddress(GPUVAddr addr) const {
     if (!IsAddressValid(addr)) {
         return {};
     }
 
-    VAddr cpu_addr{page_table.backing_addr[addr >> page_bits]};
+    const VAddr cpu_addr{page_table.backing_addr[addr >> page_bits]};
     if (cpu_addr) {
         return cpu_addr + (addr & page_mask);
     }

--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -114,7 +114,7 @@ std::optional<VAddr> MemoryManager::GpuToCpuAddress(GPUVAddr addr) const {
 }
 
 template <typename T>
-T MemoryManager::Read(GPUVAddr addr) {
+T MemoryManager::Read(GPUVAddr addr) const {
     if (!IsAddressValid(addr)) {
         return {};
     }
@@ -166,10 +166,10 @@ void MemoryManager::Write(GPUVAddr addr, T data) {
     }
 }
 
-template u8 MemoryManager::Read<u8>(GPUVAddr addr);
-template u16 MemoryManager::Read<u16>(GPUVAddr addr);
-template u32 MemoryManager::Read<u32>(GPUVAddr addr);
-template u64 MemoryManager::Read<u64>(GPUVAddr addr);
+template u8 MemoryManager::Read<u8>(GPUVAddr addr) const;
+template u16 MemoryManager::Read<u16>(GPUVAddr addr) const;
+template u32 MemoryManager::Read<u32>(GPUVAddr addr) const;
+template u64 MemoryManager::Read<u64>(GPUVAddr addr) const;
 template void MemoryManager::Write<u8>(GPUVAddr addr, u8 data);
 template void MemoryManager::Write<u16>(GPUVAddr addr, u16 data);
 template void MemoryManager::Write<u32>(GPUVAddr addr, u32 data);

--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -77,16 +77,17 @@ GPUVAddr MemoryManager::UnmapBuffer(GPUVAddr gpu_addr, u64 size) {
     return gpu_addr;
 }
 
-GPUVAddr MemoryManager::FindFreeRegion(GPUVAddr region_start, u64 size) {
+GPUVAddr MemoryManager::FindFreeRegion(GPUVAddr region_start, u64 size) const {
     // Find the first Free VMA.
-    const VMAHandle vma_handle{std::find_if(vma_map.begin(), vma_map.end(), [&](const auto& vma) {
-        if (vma.second.type != VirtualMemoryArea::Type::Unmapped) {
-            return false;
-        }
+    const VMAHandle vma_handle{
+        std::find_if(vma_map.begin(), vma_map.end(), [region_start, size](const auto& vma) {
+            if (vma.second.type != VirtualMemoryArea::Type::Unmapped) {
+                return false;
+            }
 
-        const VAddr vma_end{vma.second.base + vma.second.size};
-        return vma_end > region_start && vma_end >= region_start + size;
-    })};
+            const VAddr vma_end{vma.second.base + vma.second.size};
+            return vma_end > region_start && vma_end >= region_start + size;
+        })};
 
     if (vma_handle == vma_map.end()) {
         return {};

--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -203,7 +203,7 @@ const u8* MemoryManager::GetPointer(GPUVAddr addr) const {
     return {};
 }
 
-void MemoryManager::ReadBlock(GPUVAddr src_addr, void* dest_buffer, std::size_t size) {
+void MemoryManager::ReadBlock(GPUVAddr src_addr, void* dest_buffer, std::size_t size) const {
     std::memcpy(dest_buffer, GetPointer(src_addr), size);
 }
 void MemoryManager::WriteBlock(GPUVAddr dest_addr, const void* src_buffer, std::size_t size) {

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -53,7 +53,7 @@ public:
     std::optional<VAddr> GpuToCpuAddress(GPUVAddr addr) const;
 
     template <typename T>
-    T Read(GPUVAddr addr);
+    T Read(GPUVAddr addr) const;
 
     template <typename T>
     void Write(GPUVAddr addr, T data);

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -59,6 +59,7 @@ public:
     void Write(GPUVAddr addr, T data);
 
     u8* GetPointer(GPUVAddr addr);
+    const u8* GetPointer(GPUVAddr addr) const;
 
     void ReadBlock(GPUVAddr src_addr, void* dest_buffer, std::size_t size);
     void WriteBlock(GPUVAddr dest_addr, const void* src_buffer, std::size_t size);

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -50,7 +50,7 @@ public:
     GPUVAddr MapBufferEx(VAddr cpu_addr, u64 size);
     GPUVAddr MapBufferEx(VAddr cpu_addr, GPUVAddr addr, u64 size);
     GPUVAddr UnmapBuffer(GPUVAddr addr, u64 size);
-    std::optional<VAddr> GpuToCpuAddress(GPUVAddr addr);
+    std::optional<VAddr> GpuToCpuAddress(GPUVAddr addr) const;
 
     template <typename T>
     T Read(GPUVAddr addr);

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -127,7 +127,7 @@ private:
     void UpdatePageTableForVMA(const VirtualMemoryArea& vma);
 
     /// Finds a free (unmapped region) of the specified size starting at the specified address.
-    GPUVAddr FindFreeRegion(GPUVAddr region_start, u64 size);
+    GPUVAddr FindFreeRegion(GPUVAddr region_start, u64 size) const;
 
 private:
     static constexpr u64 page_bits{16};

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -61,7 +61,7 @@ public:
     u8* GetPointer(GPUVAddr addr);
     const u8* GetPointer(GPUVAddr addr) const;
 
-    void ReadBlock(GPUVAddr src_addr, void* dest_buffer, std::size_t size);
+    void ReadBlock(GPUVAddr src_addr, void* dest_buffer, std::size_t size) const;
     void WriteBlock(GPUVAddr dest_addr, const void* src_buffer, std::size_t size);
     void CopyBlock(GPUVAddr dest_addr, GPUVAddr src_addr, std::size_t size);
 


### PR DESCRIPTION
A few of these functions only really perform memory reads or searching for memory regions without actually modifying any internal state in the memory manager. This marks those member functions const to signify this (as well as allow their use in const contexts).