### PR TITLE
video_core/macro_interpreter: Simplify GetRegister()

### DIFF
--- a/src/video_core/macro_interpreter.cpp
+++ b/src/video_core/macro_interpreter.cpp
@@ -223,8 +223,7 @@ void MacroInterpreter::ProcessResult(ResultOperation operation, u32 reg, u32 res
 }
 
 u32 MacroInterpreter::FetchParameter() {
-    ASSERT(next_parameter_index < parameters.size());
-    return parameters[next_parameter_index++];
+    return parameters.at(next_parameter_index++);
 }
 
 u32 MacroInterpreter::GetRegister(u32 register_id) const {

--- a/src/video_core/macro_interpreter.cpp
+++ b/src/video_core/macro_interpreter.cpp
@@ -228,22 +228,17 @@ u32 MacroInterpreter::FetchParameter() {
 }
 
 u32 MacroInterpreter::GetRegister(u32 register_id) const {
-    // Register 0 is supposed to always return 0.
-    if (register_id == 0)
-        return 0;
-
-    ASSERT(register_id < registers.size());
-    return registers[register_id];
+    return registers.at(register_id);
 }
 
 void MacroInterpreter::SetRegister(u32 register_id, u32 value) {
-    // Register 0 is supposed to always return 0. NOP is implemented as a store to the zero
-    // register.
-    if (register_id == 0)
+    // Register 0 is hardwired as the zero register.
+    // Ensure no writes to it actually occur.
+    if (register_id == 0) {
         return;
+    }
 
-    ASSERT(register_id < registers.size());
-    registers[register_id] = value;
+    registers.at(register_id) = value;
 }
 
 void MacroInterpreter::SetMethodAddress(u32 address) {


### PR DESCRIPTION
Given we already ensure nothing can set the zeroth register in SetRegister(), we don't need to check if the index is zero and special case it. We can just access the register normally, since it's already going to be zero.

We can also replace the assertion with `.at()` to perform the equivalent behavior inline as part of the API.