### PR TITLE
kernel/svc: Deglobalize the supervisor call handlers

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic.h
+++ b/src/core/arm/dynarmic/arm_dynarmic.h
@@ -12,19 +12,15 @@
 #include "core/arm/exclusive_monitor.h"
 #include "core/arm/unicorn/arm_unicorn.h"
 
-namespace Core::Timing {
-class CoreTiming;
-}
-
 namespace Core {
 
 class ARM_Dynarmic_Callbacks;
 class DynarmicExclusiveMonitor;
+class System;
 
 class ARM_Dynarmic final : public ARM_Interface {
 public:
-    ARM_Dynarmic(Timing::CoreTiming& core_timing, ExclusiveMonitor& exclusive_monitor,
-                 std::size_t core_index);
+    ARM_Dynarmic(System& system, ExclusiveMonitor& exclusive_monitor, std::size_t core_index);
     ~ARM_Dynarmic() override;
 
     void MapBackingMemory(VAddr address, std::size_t size, u8* memory,
@@ -63,7 +59,7 @@ private:
     ARM_Unicorn inner_unicorn;
 
     std::size_t core_index;
-    Timing::CoreTiming& core_timing;
+    System& system;
     DynarmicExclusiveMonitor& exclusive_monitor;
 };
 

--- a/src/core/arm/unicorn/arm_unicorn.h
+++ b/src/core/arm/unicorn/arm_unicorn.h
@@ -9,15 +9,13 @@
 #include "core/arm/arm_interface.h"
 #include "core/gdbstub/gdbstub.h"
 
-namespace Core::Timing {
-class CoreTiming;
-}
-
 namespace Core {
+
+class System;
 
 class ARM_Unicorn final : public ARM_Interface {
 public:
-    explicit ARM_Unicorn(Timing::CoreTiming& core_timing);
+    explicit ARM_Unicorn(System& system);
     ~ARM_Unicorn() override;
 
     void MapBackingMemory(VAddr address, std::size_t size, u8* memory,
@@ -47,8 +45,10 @@ public:
     void RecordBreak(GDBStub::BreakpointAddress bkpt);
 
 private:
+    static void InterruptHook(uc_engine* uc, u32 int_no, void* user_data);
+
     uc_engine* uc{};
-    Timing::CoreTiming& core_timing;
+    System& system;
     GDBStub::BreakpointAddress last_bkpt{};
     bool last_bkpt_hit = false;
 };

--- a/src/core/core_cpu.cpp
+++ b/src/core/core_cpu.cpp
@@ -55,13 +55,13 @@ Cpu::Cpu(System& system, ExclusiveMonitor& exclusive_monitor, CpuBarrier& cpu_ba
     : cpu_barrier{cpu_barrier}, core_timing{system.CoreTiming()}, core_index{core_index} {
     if (Settings::values.use_cpu_jit) {
 #ifdef ARCHITECTURE_x86_64
-        arm_interface = std::make_unique<ARM_Dynarmic>(core_timing, exclusive_monitor, core_index);
+        arm_interface = std::make_unique<ARM_Dynarmic>(system, exclusive_monitor, core_index);
 #else
-        arm_interface = std::make_unique<ARM_Unicorn>();
+        arm_interface = std::make_unique<ARM_Unicorn>(system);
         LOG_WARNING(Core, "CPU JIT requested, but Dynarmic not available");
 #endif
     } else {
-        arm_interface = std::make_unique<ARM_Unicorn>(core_timing);
+        arm_interface = std::make_unique<ARM_Unicorn>(system);
     }
 
     scheduler = std::make_unique<Kernel::Scheduler>(system, *arm_interface);

--- a/src/core/hle/kernel/svc.h
+++ b/src/core/hle/kernel/svc.h
@@ -6,8 +6,12 @@
 
 #include "common/common_types.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 
-void CallSVC(u32 immediate);
+void CallSVC(Core::System& system, u32 immediate);
 
 } // namespace Kernel

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -11,278 +11,312 @@
 
 namespace Kernel {
 
-static inline u64 Param(int n) {
-    return Core::CurrentArmInterface().GetReg(n);
+static inline u64 Param(const Core::System& system, int n) {
+    return system.CurrentArmInterface().GetReg(n);
 }
 
 /**
  * HLE a function return from the current ARM userland process
- * @param res Result to return
+ * @param system System context
+ * @param result Result to return
  */
-static inline void FuncReturn(u64 res) {
-    Core::CurrentArmInterface().SetReg(0, res);
+static inline void FuncReturn(Core::System& system, u64 result) {
+    system.CurrentArmInterface().SetReg(0, result);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Function wrappers that return type ResultCode
 
-template <ResultCode func(u64)>
-void SvcWrap() {
-    FuncReturn(func(Param(0)).raw);
+template <ResultCode func(Core::System&, u64)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system, Param(system, 0)).raw);
 }
 
-template <ResultCode func(u32)>
-void SvcWrap() {
-    FuncReturn(func(static_cast<u32>(Param(0))).raw);
+template <ResultCode func(Core::System&, u32)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system, static_cast<u32>(Param(system, 0))).raw);
 }
 
-template <ResultCode func(u32, u32)>
-void SvcWrap() {
-    FuncReturn(func(static_cast<u32>(Param(0)), static_cast<u32>(Param(1))).raw);
+template <ResultCode func(Core::System&, u32, u32)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(
+        system,
+        func(system, static_cast<u32>(Param(system, 0)), static_cast<u32>(Param(system, 1))).raw);
 }
 
-template <ResultCode func(u32*)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, u32*)>
+void SvcWrap(Core::System& system) {
     u32 param = 0;
-    const u32 retval = func(&param).raw;
-    Core::CurrentArmInterface().SetReg(1, param);
-    FuncReturn(retval);
+    const u32 retval = func(system, &param).raw;
+    system.CurrentArmInterface().SetReg(1, param);
+    FuncReturn(system, retval);
 }
 
-template <ResultCode func(u32*, u32)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, u32*, u32)>
+void SvcWrap(Core::System& system) {
     u32 param_1 = 0;
-    u32 retval = func(&param_1, static_cast<u32>(Param(1))).raw;
-    Core::CurrentArmInterface().SetReg(1, param_1);
-    FuncReturn(retval);
+    const u32 retval = func(system, &param_1, static_cast<u32>(Param(system, 1))).raw;
+    system.CurrentArmInterface().SetReg(1, param_1);
+    FuncReturn(system, retval);
 }
 
-template <ResultCode func(u32*, u32*)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, u32*, u32*)>
+void SvcWrap(Core::System& system) {
     u32 param_1 = 0;
     u32 param_2 = 0;
-    const u32 retval = func(&param_1, &param_2).raw;
+    const u32 retval = func(system, &param_1, &param_2).raw;
 
-    auto& arm_interface = Core::CurrentArmInterface();
+    auto& arm_interface = system.CurrentArmInterface();
     arm_interface.SetReg(1, param_1);
     arm_interface.SetReg(2, param_2);
 
-    FuncReturn(retval);
+    FuncReturn(system, retval);
 }
 
-template <ResultCode func(u32*, u64)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, u32*, u64)>
+void SvcWrap(Core::System& system) {
     u32 param_1 = 0;
-    const u32 retval = func(&param_1, Param(1)).raw;
-    Core::CurrentArmInterface().SetReg(1, param_1);
-    FuncReturn(retval);
+    const u32 retval = func(system, &param_1, Param(system, 1)).raw;
+    system.CurrentArmInterface().SetReg(1, param_1);
+    FuncReturn(system, retval);
 }
 
-template <ResultCode func(u32*, u64, u32)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, u32*, u64, u32)>
+void SvcWrap(Core::System& system) {
     u32 param_1 = 0;
-    const u32 retval = func(&param_1, Param(1), static_cast<u32>(Param(2))).raw;
-    Core::CurrentArmInterface().SetReg(1, param_1);
-    FuncReturn(retval);
+    const u32 retval =
+        func(system, &param_1, Param(system, 1), static_cast<u32>(Param(system, 2))).raw;
+
+    system.CurrentArmInterface().SetReg(1, param_1);
+    FuncReturn(system, retval);
 }
 
-template <ResultCode func(u64*, u32)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, u64*, u32)>
+void SvcWrap(Core::System& system) {
     u64 param_1 = 0;
-    const u32 retval = func(&param_1, static_cast<u32>(Param(1))).raw;
-    Core::CurrentArmInterface().SetReg(1, param_1);
-    FuncReturn(retval);
+    const u32 retval = func(system, &param_1, static_cast<u32>(Param(system, 1))).raw;
+
+    system.CurrentArmInterface().SetReg(1, param_1);
+    FuncReturn(system, retval);
 }
 
-template <ResultCode func(u64, s32)>
-void SvcWrap() {
-    FuncReturn(func(Param(0), static_cast<s32>(Param(1))).raw);
+template <ResultCode func(Core::System&, u64, s32)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system, Param(system, 0), static_cast<s32>(Param(system, 1))).raw);
 }
 
-template <ResultCode func(u64, u32)>
-void SvcWrap() {
-    FuncReturn(func(Param(0), static_cast<u32>(Param(1))).raw);
+template <ResultCode func(Core::System&, u64, u32)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system, Param(system, 0), static_cast<u32>(Param(system, 1))).raw);
 }
 
-template <ResultCode func(u64*, u64)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, u64*, u64)>
+void SvcWrap(Core::System& system) {
     u64 param_1 = 0;
-    u32 retval = func(&param_1, Param(1)).raw;
-    Core::CurrentArmInterface().SetReg(1, param_1);
-    FuncReturn(retval);
+    const u32 retval = func(system, &param_1, Param(system, 1)).raw;
+
+    system.CurrentArmInterface().SetReg(1, param_1);
+    FuncReturn(system, retval);
 }
 
-template <ResultCode func(u64*, u32, u32)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, u64*, u32, u32)>
+void SvcWrap(Core::System& system) {
     u64 param_1 = 0;
-    u32 retval = func(&param_1, static_cast<u32>(Param(1)), static_cast<u32>(Param(2))).raw;
-    Core::CurrentArmInterface().SetReg(1, param_1);
-    FuncReturn(retval);
+    const u32 retval = func(system, &param_1, static_cast<u32>(Param(system, 1)),
+                            static_cast<u32>(Param(system, 2)))
+                           .raw;
+
+    system.CurrentArmInterface().SetReg(1, param_1);
+    FuncReturn(system, retval);
 }
 
-template <ResultCode func(u32, u64)>
-void SvcWrap() {
-    FuncReturn(func(static_cast<u32>(Param(0)), Param(1)).raw);
+template <ResultCode func(Core::System&, u32, u64)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system, static_cast<u32>(Param(system, 0)), Param(system, 1)).raw);
 }
 
-template <ResultCode func(u32, u32, u64)>
-void SvcWrap() {
-    FuncReturn(func(static_cast<u32>(Param(0)), static_cast<u32>(Param(1)), Param(2)).raw);
+template <ResultCode func(Core::System&, u32, u32, u64)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system, static_cast<u32>(Param(system, 0)),
+                            static_cast<u32>(Param(system, 1)), Param(system, 2))
+                           .raw);
 }
 
-template <ResultCode func(u32, u32*, u64*)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, u32, u32*, u64*)>
+void SvcWrap(Core::System& system) {
     u32 param_1 = 0;
     u64 param_2 = 0;
-    ResultCode retval = func(static_cast<u32>(Param(2)), &param_1, &param_2);
-    Core::CurrentArmInterface().SetReg(1, param_1);
-    Core::CurrentArmInterface().SetReg(2, param_2);
-    FuncReturn(retval.raw);
+    const ResultCode retval = func(system, static_cast<u32>(Param(system, 2)), &param_1, &param_2);
+
+    system.CurrentArmInterface().SetReg(1, param_1);
+    system.CurrentArmInterface().SetReg(2, param_2);
+    FuncReturn(system, retval.raw);
 }
 
-template <ResultCode func(u64, u64, u32, u32)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, u64, u64, u32, u32)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system, Param(system, 0), Param(system, 1),
+                            static_cast<u32>(Param(system, 2)), static_cast<u32>(Param(system, 3)))
+                           .raw);
+}
+
+template <ResultCode func(Core::System&, u64, u64, u32, u64)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system, Param(system, 0), Param(system, 1),
+                            static_cast<u32>(Param(system, 2)), Param(system, 3))
+                           .raw);
+}
+
+template <ResultCode func(Core::System&, u32, u64, u32)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system, static_cast<u32>(Param(system, 0)), Param(system, 1),
+                            static_cast<u32>(Param(system, 2)))
+                           .raw);
+}
+
+template <ResultCode func(Core::System&, u64, u64, u64)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system, Param(system, 0), Param(system, 1), Param(system, 2)).raw);
+}
+
+template <ResultCode func(Core::System&, u64, u64, u32)>
+void SvcWrap(Core::System& system) {
     FuncReturn(
-        func(Param(0), Param(1), static_cast<u32>(Param(2)), static_cast<u32>(Param(3))).raw);
+        system,
+        func(system, Param(system, 0), Param(system, 1), static_cast<u32>(Param(system, 2))).raw);
 }
 
-template <ResultCode func(u64, u64, u32, u64)>
-void SvcWrap() {
-    FuncReturn(func(Param(0), Param(1), static_cast<u32>(Param(2)), Param(3)).raw);
+template <ResultCode func(Core::System&, u32, u64, u64, u32)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system, static_cast<u32>(Param(system, 0)), Param(system, 1),
+                            Param(system, 2), static_cast<u32>(Param(system, 3)))
+                           .raw);
 }
 
-template <ResultCode func(u32, u64, u32)>
-void SvcWrap() {
-    FuncReturn(func(static_cast<u32>(Param(0)), Param(1), static_cast<u32>(Param(2))).raw);
-}
-
-template <ResultCode func(u64, u64, u64)>
-void SvcWrap() {
-    FuncReturn(func(Param(0), Param(1), Param(2)).raw);
-}
-
-template <ResultCode func(u64, u64, u32)>
-void SvcWrap() {
-    FuncReturn(func(Param(0), Param(1), static_cast<u32>(Param(2))).raw);
-}
-
-template <ResultCode func(u32, u64, u64, u32)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, u32, u64, u64)>
+void SvcWrap(Core::System& system) {
     FuncReturn(
-        func(static_cast<u32>(Param(0)), Param(1), Param(2), static_cast<u32>(Param(3))).raw);
+        system,
+        func(system, static_cast<u32>(Param(system, 0)), Param(system, 1), Param(system, 2)).raw);
 }
 
-template <ResultCode func(u32, u64, u64)>
-void SvcWrap() {
-    FuncReturn(func(static_cast<u32>(Param(0)), Param(1), Param(2)).raw);
-}
-
-template <ResultCode func(u32*, u64, u64, s64)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, u32*, u64, u64, s64)>
+void SvcWrap(Core::System& system) {
     u32 param_1 = 0;
-    ResultCode retval =
-        func(&param_1, Param(1), static_cast<u32>(Param(2)), static_cast<s64>(Param(3)));
-    Core::CurrentArmInterface().SetReg(1, param_1);
-    FuncReturn(retval.raw);
+    const u32 retval = func(system, &param_1, Param(system, 1), static_cast<u32>(Param(system, 2)),
+                            static_cast<s64>(Param(system, 3)))
+                           .raw;
+
+    system.CurrentArmInterface().SetReg(1, param_1);
+    FuncReturn(system, retval);
 }
 
-template <ResultCode func(u64, u64, u32, s64)>
-void SvcWrap() {
-    FuncReturn(
-        func(Param(0), Param(1), static_cast<u32>(Param(2)), static_cast<s64>(Param(3))).raw);
+template <ResultCode func(Core::System&, u64, u64, u32, s64)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system, Param(system, 0), Param(system, 1),
+                            static_cast<u32>(Param(system, 2)), static_cast<s64>(Param(system, 3)))
+                           .raw);
 }
 
-template <ResultCode func(u64*, u64, u64, u64)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, u64*, u64, u64, u64)>
+void SvcWrap(Core::System& system) {
     u64 param_1 = 0;
-    u32 retval = func(&param_1, Param(1), Param(2), Param(3)).raw;
-    Core::CurrentArmInterface().SetReg(1, param_1);
-    FuncReturn(retval);
+    const u32 retval =
+        func(system, &param_1, Param(system, 1), Param(system, 2), Param(system, 3)).raw;
+
+    system.CurrentArmInterface().SetReg(1, param_1);
+    FuncReturn(system, retval);
 }
 
-template <ResultCode func(u32*, u64, u64, u64, u32, s32)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, u32*, u64, u64, u64, u32, s32)>
+void SvcWrap(Core::System& system) {
     u32 param_1 = 0;
-    u32 retval = func(&param_1, Param(1), Param(2), Param(3), static_cast<u32>(Param(4)),
-                      static_cast<s32>(Param(5)))
-                     .raw;
-    Core::CurrentArmInterface().SetReg(1, param_1);
-    FuncReturn(retval);
+    const u32 retval = func(system, &param_1, Param(system, 1), Param(system, 2), Param(system, 3),
+                            static_cast<u32>(Param(system, 4)), static_cast<s32>(Param(system, 5)))
+                           .raw;
+
+    system.CurrentArmInterface().SetReg(1, param_1);
+    FuncReturn(system, retval);
 }
 
-template <ResultCode func(u32*, u64, u64, u32)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, u32*, u64, u64, u32)>
+void SvcWrap(Core::System& system) {
     u32 param_1 = 0;
-    u32 retval = func(&param_1, Param(1), Param(2), static_cast<u32>(Param(3))).raw;
-    Core::CurrentArmInterface().SetReg(1, param_1);
-    FuncReturn(retval);
+    const u32 retval = func(system, &param_1, Param(system, 1), Param(system, 2),
+                            static_cast<u32>(Param(system, 3)))
+                           .raw;
+
+    system.CurrentArmInterface().SetReg(1, param_1);
+    FuncReturn(system, retval);
 }
 
-template <ResultCode func(Handle*, u64, u32, u32)>
-void SvcWrap() {
+template <ResultCode func(Core::System&, Handle*, u64, u32, u32)>
+void SvcWrap(Core::System& system) {
     u32 param_1 = 0;
-    u32 retval =
-        func(&param_1, Param(1), static_cast<u32>(Param(2)), static_cast<u32>(Param(3))).raw;
-    Core::CurrentArmInterface().SetReg(1, param_1);
-    FuncReturn(retval);
+    const u32 retval = func(system, &param_1, Param(system, 1), static_cast<u32>(Param(system, 2)),
+                            static_cast<u32>(Param(system, 3)))
+                           .raw;
+
+    system.CurrentArmInterface().SetReg(1, param_1);
+    FuncReturn(system, retval);
 }
 
-template <ResultCode func(u64, u32, s32, s64)>
-void SvcWrap() {
-    FuncReturn(func(Param(0), static_cast<u32>(Param(1)), static_cast<s32>(Param(2)),
-                    static_cast<s64>(Param(3)))
-                   .raw);
+template <ResultCode func(Core::System&, u64, u32, s32, s64)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system, Param(system, 0), static_cast<u32>(Param(system, 1)),
+                            static_cast<s32>(Param(system, 2)), static_cast<s64>(Param(system, 3)))
+                           .raw);
 }
 
-template <ResultCode func(u64, u32, s32, s32)>
-void SvcWrap() {
-    FuncReturn(func(Param(0), static_cast<u32>(Param(1)), static_cast<s32>(Param(2)),
-                    static_cast<s32>(Param(3)))
-                   .raw);
+template <ResultCode func(Core::System&, u64, u32, s32, s32)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system, Param(system, 0), static_cast<u32>(Param(system, 1)),
+                            static_cast<s32>(Param(system, 2)), static_cast<s32>(Param(system, 3)))
+                           .raw);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Function wrappers that return type u32
 
-template <u32 func()>
-void SvcWrap() {
-    FuncReturn(func());
+template <u32 func(Core::System&)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Function wrappers that return type u64
 
-template <u64 func()>
-void SvcWrap() {
-    FuncReturn(func());
+template <u64 func(Core::System&)>
+void SvcWrap(Core::System& system) {
+    FuncReturn(system, func(system));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /// Function wrappers that return type void
 
-template <void func()>
-void SvcWrap() {
-    func();
+template <void func(Core::System&)>
+void SvcWrap(Core::System& system) {
+    func(system);
 }
 
-template <void func(s64)>
-void SvcWrap() {
-    func(static_cast<s64>(Param(0)));
+template <void func(Core::System&, s64)>
+void SvcWrap(Core::System& system) {
+    func(system, static_cast<s64>(Param(system, 0)));
 }
 
-template <void func(u64, u64 len)>
-void SvcWrap() {
-    func(Param(0), Param(1));
+template <void func(Core::System&, u64, u64)>
+void SvcWrap(Core::System& system) {
+    func(system, Param(system, 0), Param(system, 1));
 }
 
-template <void func(u64, u64, u64)>
-void SvcWrap() {
-    func(Param(0), Param(1), Param(2));
+template <void func(Core::System&, u64, u64, u64)>
+void SvcWrap(Core::System& system) {
+    func(system, Param(system, 0), Param(system, 1), Param(system, 2));
 }
 
-template <void func(u32, u64, u64)>
-void SvcWrap() {
-    func(static_cast<u32>(Param(0)), Param(1), Param(2));
+template <void func(Core::System&, u32, u64, u64)>
+void SvcWrap(Core::System& system) {
+    func(system, static_cast<u32>(Param(system, 0)), Param(system, 1), Param(system, 2));
 }
 
 } // namespace Kernel


### PR DESCRIPTION
Adjusts the interface of the wrappers to take a system reference, which allows accessing a system instance without using the global accessors.

This also allows getting rid of all global accessors within the supervisor call handling code. While this does make the wrappers themselves slightly more noisy, this will be further cleaned up in following changes. This eliminates the global system accessors in the current code while preserving the existing interface, making any replacement changes much less noisy.

This will also make deglobalizing the memory subsystem a little nicer, since the system instance will already be available for utilizing said deglobalized subsystem.