### PR TITLE
Workaround to Mutex Corruption

### DIFF
--- a/src/core/hle/kernel/mutex.h
+++ b/src/core/hle/kernel/mutex.h
@@ -29,7 +29,7 @@ public:
                           Handle requesting_thread_handle);
 
     /// Releases the mutex at the specified address.
-    ResultCode Release(VAddr address);
+    ResultCode Release(VAddr address, Thread* holding_thread);
 
 private:
     Core::System& system;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -587,7 +587,8 @@ static ResultCode ArbitrateUnlock(Core::System& system, VAddr mutex_addr) {
     }
 
     auto* const current_process = system.Kernel().CurrentProcess();
-    return current_process->GetMutex().Release(mutex_addr);
+    return current_process->GetMutex().Release(mutex_addr,
+                                               system.CurrentScheduler().GetCurrentThread());
 }
 
 enum class BreakType : u32 {
@@ -1627,12 +1628,13 @@ static ResultCode WaitProcessWideKeyAtomic(Core::System& system, VAddr mutex_add
     std::shared_ptr<Thread> thread = handle_table.Get<Thread>(thread_handle);
     ASSERT(thread);
 
-    const auto release_result = current_process->GetMutex().Release(mutex_addr);
+    Thread* current_thread = system.CurrentScheduler().GetCurrentThread();
+
+    const auto release_result = current_process->GetMutex().Release(mutex_addr, current_thread);
     if (release_result.IsError()) {
         return release_result;
     }
 
-    Thread* current_thread = system.CurrentScheduler().GetCurrentThread();
     current_thread->SetCondVarWaitAddress(condition_variable_addr);
     current_thread->SetMutexWaitAddress(mutex_addr);
     current_thread->SetWaitHandle(thread_handle);


### PR DESCRIPTION
This a workaround to an unknown bug caused by mutex corruption within game code. The cause is unknown. It requires #2364 .

Here's the full research info:

> well I investigated the softlock issue through a game I thought softlocked derministically , here are the results:
> - First softlocking on condvar mutex is COMPLETELY random. Occurs on different occasions on the booting process of I am Setsuna by an small margin of difference. Logs differ on every run.
> - I have verified that it is the game indeed  the one who is granting mutex ownership to  a paused thread and that the bug is not in our HLE ystem.
> - The paused thread is set to be paused way before the softlock shows an invalid state.
> - The softlock does not occur instantly on an invalid state, the system keeps running for a while.
> 
> My current thoughts on what could be happening:
> - A bug in the Switch's SDK that does not happen  on real hardware.
> - Memory Corruption or bad page mirroring.
> - We were suppose to wake that thread earlier.
> deterministically*