### PR TITLE
yuzu/loading_screen: Resolve runtime Qt string formatting warnings

### DIFF
--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -192,7 +192,12 @@ void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size
     }
 
     // update labels and progress bar
-    ui->stage->setText(stage_translations[stage].arg(value).arg(total));
+    if (stage == VideoCore::LoadCallbackStage::Decompile ||
+        stage == VideoCore::LoadCallbackStage::Build) {
+        ui->stage->setText(stage_translations[stage].arg(value).arg(total));
+    } else {
+        ui->stage->setText(stage_translations[stage]);
+    }
     ui->value->setText(estimate);
     ui->progress_bar->setValue(static_cast<int>(value));
     previous_time = now;


### PR DESCRIPTION
In our error console, when loading a game, the strings:

```
QString::arg: Argument missing: "Loading...", 0
QString::arg: Argument missing: "Launching...", 0
```

would occasionally pop up when the loading screen was running. This was due to the strings being assumed to have formatting indicators in them, however only two out of the four strings actually have them. This only applies the arguments to the strings that have formatting specifiers provided, which avoids these warnings from occurring.

Example of the warnings that would occur:

![Warnings](https://user-images.githubusercontent.com/712067/55810103-fefb3580-5ab4-11e9-959a-f7b0f81d9d11.png)
