### PR TITLE
kernel/process: Set page table when page table resizes occur.

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -106,6 +106,8 @@ ResultCode Process::LoadFromMetadata(const FileSys::ProgramMetadata& metadata) {
     is_64bit_process = metadata.Is64BitProgram();
 
     vm_manager.Reset(metadata.GetAddressSpaceType());
+    // Ensure that the potentially resized page table is seen by CPU backends.
+    Memory::SetCurrentPageTable(&vm_manager.page_table);
 
     const auto& caps = metadata.GetKernelCapabilities();
     const auto capability_init_result =


### PR DESCRIPTION
We need to ensure dynarmic gets a valid pointer if the page table is resized (the relevant pointers would be invalidated in this scenario). In this scenario, the page table can be resized depending on what kind of address space is specified within the NPDM metadata (if it's present).

Fixes BotW/ARMS/anything that doesn't specify a 39-bit address space.

While this isn't a preferable approach to the problem, I'd rather refactor our initialization process with everything in working order first, before changing it, potentially causing more regressions. So this will have a follow-up to it.