### PR TITLE
Correct Fermi Copy on Linear Textures.

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer_cache.cpp
@@ -265,6 +265,10 @@ std::size_t SurfaceParams::InnerMemorySize(bool force_gl, bool layer_only,
     params.component_type = ComponentTypeFromRenderTarget(config.format);
     params.type = GetFormatType(params.pixel_format);
     params.width = config.width;
+    if (!params.is_tiled) {
+        const u32 bpp = params.GetFormatBpp() / 8;
+        params.pitch = config.width * bpp;
+    }
     params.height = config.height;
     params.unaligned_height = config.height;
     params.target = SurfaceTarget::Texture2D;


### PR DESCRIPTION
A simple fix to fermi copies on linear textures.