### PR TITLE
yuzu/configure_hotkey: Minor changes

### DIFF
--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -12,7 +12,7 @@
 #include "yuzu/hotkeys.h"
 
 ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry)
-    : QDialog(parent), registry(registry), ui(new Ui::ConfigureDialog) {
+    : QDialog(parent), ui(new Ui::ConfigureDialog), registry(registry) {
     ui->setupUi(this);
     ui->hotkeysTab->Populate(registry);
     this->setConfiguration();

--- a/src/yuzu/configuration/configure_hotkeys.cpp
+++ b/src/yuzu/configuration/configure_hotkeys.cpp
@@ -90,7 +90,7 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
     }
 }
 
-bool ConfigureHotkeys::IsUsedKey(QKeySequence key_sequence) {
+bool ConfigureHotkeys::IsUsedKey(QKeySequence key_sequence) const {
     return GetUsedKeyList().contains(key_sequence);
 }
 

--- a/src/yuzu/configuration/configure_hotkeys.cpp
+++ b/src/yuzu/configuration/configure_hotkeys.cpp
@@ -71,16 +71,16 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
     }
 
     index = index.sibling(index.row(), 1);
-    auto* model = ui->hotkey_list->model();
-    auto previous_key = model->data(index);
+    auto* const model = ui->hotkey_list->model();
+    const auto previous_key = model->data(index);
 
-    auto* hotkey_dialog = new SequenceDialog;
-    int return_code = hotkey_dialog->exec();
+    auto* const hotkey_dialog = new SequenceDialog;
 
-    auto key_sequence = hotkey_dialog->GetSequence();
-
-    if (return_code == QDialog::Rejected || key_sequence.isEmpty())
+    const int return_code = hotkey_dialog->exec();
+    const auto key_sequence = hotkey_dialog->GetSequence();
+    if (return_code == QDialog::Rejected || key_sequence.isEmpty()) {
         return;
+    }
 
     if (IsUsedKey(key_sequence) && key_sequence != QKeySequence(previous_key.toString())) {
         QMessageBox::critical(this, tr("Error in inputted key"),

--- a/src/yuzu/configuration/configure_hotkeys.cpp
+++ b/src/yuzu/configuration/configure_hotkeys.cpp
@@ -66,8 +66,9 @@ void ConfigureHotkeys::Populate(const HotkeyRegistry& registry) {
 }
 
 void ConfigureHotkeys::Configure(QModelIndex index) {
-    if (index.parent() == QModelIndex())
+    if (!index.parent().isValid()) {
         return;
+    }
 
     index = index.sibling(index.row(), 1);
     auto* model = ui->hotkey_list->model();

--- a/src/yuzu/configuration/configure_hotkeys.cpp
+++ b/src/yuzu/configuration/configure_hotkeys.cpp
@@ -74,10 +74,10 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
     auto* const model = ui->hotkey_list->model();
     const auto previous_key = model->data(index);
 
-    auto* const hotkey_dialog = new SequenceDialog;
+    SequenceDialog hotkey_dialog;
 
-    const int return_code = hotkey_dialog->exec();
-    const auto key_sequence = hotkey_dialog->GetSequence();
+    const int return_code = hotkey_dialog.exec();
+    const auto key_sequence = hotkey_dialog.GetSequence();
     if (return_code == QDialog::Rejected || key_sequence.isEmpty()) {
         return;
     }

--- a/src/yuzu/configuration/configure_hotkeys.cpp
+++ b/src/yuzu/configuration/configure_hotkeys.cpp
@@ -74,7 +74,7 @@ void ConfigureHotkeys::Configure(QModelIndex index) {
     auto* const model = ui->hotkey_list->model();
     const auto previous_key = model->data(index);
 
-    SequenceDialog hotkey_dialog;
+    SequenceDialog hotkey_dialog{this};
 
     const int return_code = hotkey_dialog.exec();
     const auto key_sequence = hotkey_dialog.GetSequence();

--- a/src/yuzu/configuration/configure_hotkeys.h
+++ b/src/yuzu/configuration/configure_hotkeys.h
@@ -6,7 +6,6 @@
 
 #include <memory>
 #include <QWidget>
-#include "core/settings.h"
 
 namespace Ui {
 class ConfigureHotkeys;

--- a/src/yuzu/configuration/configure_hotkeys.h
+++ b/src/yuzu/configuration/configure_hotkeys.h
@@ -39,7 +39,7 @@ signals:
 
 private:
     void Configure(QModelIndex index);
-    bool IsUsedKey(QKeySequence key_sequence);
+    bool IsUsedKey(QKeySequence key_sequence) const;
     QList<QKeySequence> GetUsedKeyList() const;
 
     std::unique_ptr<Ui::ConfigureHotkeys> ui;


### PR DESCRIPTION
Minor clean-up related changes to the hotkey configuration dialog. This also notably prevents the logging window from stealing the initial focus of the hotkey dialog window.