### PR TITLE
fsp_srv: Minor cleanup related changes

### DIFF
--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -115,11 +115,12 @@ private:
 
     void Read(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
-        const u64 unk = rp.Pop<u64>();
+        const u64 option = rp.Pop<u64>();
         const s64 offset = rp.Pop<s64>();
         const s64 length = rp.Pop<s64>();
 
-        LOG_DEBUG(Service_FS, "called, offset=0x{:X}, length={}", offset, length);
+        LOG_DEBUG(Service_FS, "called, option={}, offset=0x{:X}, length={}", option, offset,
+                  length);
 
         // Error checking
         if (length < 0) {
@@ -148,11 +149,12 @@ private:
 
     void Write(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
-        const u64 unk = rp.Pop<u64>();
+        const u64 option = rp.Pop<u64>();
         const s64 offset = rp.Pop<s64>();
         const s64 length = rp.Pop<s64>();
 
-        LOG_DEBUG(Service_FS, "called, offset=0x{:X}, length={}", offset, length);
+        LOG_DEBUG(Service_FS, "called, option={}, offset=0x{:X}, length={}", option, offset,
+                  length);
 
         // Error checking
         if (length < 0) {

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -252,10 +252,7 @@ private:
     u64 next_entry_index = 0;
 
     void Read(Kernel::HLERequestContext& ctx) {
-        IPC::RequestParser rp{ctx};
-        const u64 unk = rp.Pop<u64>();
-
-        LOG_DEBUG(Service_FS, "called, unk=0x{:X}", unk);
+        LOG_DEBUG(Service_FS, "called.");
 
         // Calculate how many entries we can fit in the output buffer
         const u64 count_entries = ctx.GetWriteBufferSize() / sizeof(FileSys::Entry);


### PR DESCRIPTION
Logs two unused variables (also getting rid of unused variable warnings). This also gets rid of unnecessary parameter popping in IDirectory's Read() function. This doesn't actually take any input parameters--it only has output parameters.