### PR TITLE
common/scope_exit: Replace std::move with std::forward in ScopeExit()

### DIFF
--- a/src/common/scope_exit.h
+++ b/src/common/scope_exit.h
@@ -20,7 +20,7 @@ struct ScopeExitHelper {
 
 template <typename Func>
 ScopeExitHelper<Func> ScopeExit(Func&& func) {
-    return ScopeExitHelper<Func>(std::move(func));
+    return ScopeExitHelper<Func>(std::forward<Func>(func));
 }
 } // namespace detail
 


### PR DESCRIPTION
The template type here is actually a forwarding reference, not an rvalue reference in this case, so it's more appropriate to use std::forward to preserve the value category of the type being moved.