### PR TITLE
kernel/thread: Remove unused guest_handle member variable

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -40,9 +40,8 @@ void SetupMainThread(Process& owner_process, KernelCore& kernel, VAddr entry_poi
     SharedPtr<Thread> thread = std::move(thread_res).Unwrap();
 
     // Register 1 must be a handle to the main thread
-    const Handle guest_handle = owner_process.GetHandleTable().Create(thread).Unwrap();
-    thread->SetGuestHandle(guest_handle);
-    thread->GetContext().cpu_registers[1] = guest_handle;
+    const Handle thread_handle = owner_process.GetHandleTable().Create(thread).Unwrap();
+    thread->GetContext().cpu_registers[1] = thread_handle;
 
     // Threads by default are dormant, wake up the main thread so it runs when the scheduler fires
     thread->ResumeFromWait();

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1244,10 +1244,9 @@ static ResultCode CreateThread(Core::System& system, Handle* out_handle, VAddr e
         return ERR_INVALID_THREAD_PRIORITY;
     }
 
-    const std::string name = fmt::format("thread-{:X}", entry_point);
     auto& kernel = system.Kernel();
     CASCADE_RESULT(SharedPtr<Thread> thread,
-                   Thread::Create(kernel, name, entry_point, priority, arg, processor_id, stack_top,
+                   Thread::Create(kernel, "", entry_point, priority, arg, processor_id, stack_top,
                                   *current_process));
 
     const auto new_thread_handle = current_process->GetHandleTable().Create(thread);
@@ -1257,6 +1256,10 @@ static ResultCode CreateThread(Core::System& system, Handle* out_handle, VAddr e
         return new_thread_handle.Code();
     }
     *out_handle = *new_thread_handle;
+
+    // Set the thread name for debugging purposes.
+    thread->SetName(
+        fmt::format("thread[entry_point={:X}, handle={:X}]", entry_point, *new_thread_handle));
 
     system.CpuCore(thread->GetProcessorID()).PrepareReschedule();
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1250,14 +1250,13 @@ static ResultCode CreateThread(Core::System& system, Handle* out_handle, VAddr e
                    Thread::Create(kernel, name, entry_point, priority, arg, processor_id, stack_top,
                                   *current_process));
 
-    const auto new_guest_handle = current_process->GetHandleTable().Create(thread);
-    if (new_guest_handle.Failed()) {
+    const auto new_thread_handle = current_process->GetHandleTable().Create(thread);
+    if (new_thread_handle.Failed()) {
         LOG_ERROR(Kernel_SVC, "Failed to create handle with error=0x{:X}",
-                  new_guest_handle.Code().raw);
-        return new_guest_handle.Code();
+                  new_thread_handle.Code().raw);
+        return new_thread_handle.Code();
     }
-    thread->SetGuestHandle(*new_guest_handle);
-    *out_handle = *new_guest_handle;
+    *out_handle = *new_thread_handle;
 
     system.CpuCore(thread->GetProcessorID()).PrepareReschedule();
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -102,6 +102,11 @@ public:
     std::string GetName() const override {
         return name;
     }
+
+    void SetName(std::string new_name) {
+        name = std::move(new_name);
+    }
+
     std::string GetTypeName() const override {
         return "Thread";
     }

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -345,10 +345,6 @@ public:
         arb_wait_address = address;
     }
 
-    void SetGuestHandle(Handle handle) {
-        guest_handle = handle;
-    }
-
     bool HasWakeupCallback() const {
         return wakeup_callback != nullptr;
     }
@@ -441,9 +437,6 @@ private:
 
     /// If waiting for an AddressArbiter, this is the address being waited on.
     VAddr arb_wait_address{0};
-
-    /// Handle used by guest emulated application to access this thread
-    Handle guest_handle = 0;
 
     /// Handle used as userdata to reference this object when inserting into the CoreTiming queue.
     Handle callback_handle = 0;


### PR DESCRIPTION
This member variable is entirely unused. It was only set but never actually utilized. Given that, we can remove it to get rid of noise in the thread interface.