### PR TITLE
kernel/thread: Remove BoostPriority()

### DIFF
--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -220,11 +220,6 @@ void Thread::SetPriority(u32 priority) {
     UpdatePriority();
 }
 
-void Thread::BoostPriority(u32 priority) {
-    scheduler->SetThreadPriority(this, priority);
-    current_priority = priority;
-}
-
 void Thread::SetWaitSynchronizationResult(ResultCode result) {
     context.cpu_registers[0] = result.raw;
 }

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -136,12 +136,6 @@ public:
      */
     void SetPriority(u32 priority);
 
-    /**
-     * Temporarily boosts the thread's priority until the next time it is scheduled
-     * @param priority The new priority
-     */
-    void BoostPriority(u32 priority);
-
     /// Adds a thread to the list of threads that are waiting for a lock held by this thread.
     void AddMutexWaiter(SharedPtr<Thread> thread);
 


### PR DESCRIPTION
This is a holdover from Citra that currently remains unused, so it can be removed from the Thread interface.