### PR TITLE
common: Apply the nodiscard attribute where applicable

### DIFF
--- a/src/common/alignment.h
+++ b/src/common/alignment.h
@@ -8,25 +8,25 @@
 namespace Common {
 
 template <typename T>
-constexpr T AlignUp(T value, std::size_t size) {
+[[nodiscard]] constexpr T AlignUp(T value, std::size_t size) noexcept {
     static_assert(std::is_unsigned_v<T>, "T must be an unsigned value.");
     return static_cast<T>(value + (size - value % size) % size);
 }
 
 template <typename T>
-constexpr T AlignDown(T value, std::size_t size) {
+[[nodiscard]] constexpr T AlignDown(T value, std::size_t size) noexcept {
     static_assert(std::is_unsigned_v<T>, "T must be an unsigned value.");
     return static_cast<T>(value - value % size);
 }
 
 template <typename T>
-constexpr bool Is4KBAligned(T value) {
+[[nodiscard]] constexpr bool Is4KBAligned(T value) noexcept {
     static_assert(std::is_unsigned_v<T>, "T must be an unsigned value.");
     return (value & 0xFFF) == 0;
 }
 
 template <typename T>
-constexpr bool IsWordAligned(T value) {
+[[nodiscard]] constexpr bool IsWordAligned(T value) noexcept {
     static_assert(std::is_unsigned_v<T>, "T must be an unsigned value.");
     return (value & 0b11) == 0;
 }

--- a/src/common/bit_field.h
+++ b/src/common/bit_field.h
@@ -135,8 +135,8 @@ public:
      * containing several bitfields can be assembled by formatting each of their values and ORing
      * the results together.
      */
-    static constexpr FORCE_INLINE StorageType FormatValue(const T& value) {
-        return ((StorageType)value << position) & mask;
+    [[nodiscard]] static constexpr FORCE_INLINE StorageType FormatValue(const T& value) noexcept {
+        return (static_cast<StorageType>(value) << position) & mask;
     }
 
     /**
@@ -144,7 +144,8 @@ public:
      * (such as Value() or operator T), but this can be used to extract a value from a bitfield
      * union in a constexpr context.
      */
-    static constexpr FORCE_INLINE T ExtractValue(const StorageType& storage) {
+    [[nodiscard]] static constexpr FORCE_INLINE T
+    ExtractValue(const StorageType& storage) noexcept {
         if constexpr (std::numeric_limits<UnderlyingType>::is_signed) {
             std::size_t shift = 8 * sizeof(T) - bits;
             return static_cast<T>(static_cast<UnderlyingType>(storage << (shift - position)) >>
@@ -168,19 +169,19 @@ public:
     constexpr BitField(BitField&&) noexcept = default;
     constexpr BitField& operator=(BitField&&) noexcept = default;
 
-    constexpr FORCE_INLINE operator T() const {
+    [[nodiscard]] constexpr FORCE_INLINE operator T() const noexcept {
         return Value();
     }
 
-    constexpr FORCE_INLINE void Assign(const T& value) {
+    constexpr FORCE_INLINE void Assign(const T& value) noexcept {
         storage = (static_cast<StorageType>(storage) & ~mask) | FormatValue(value);
     }
 
-    constexpr T Value() const {
+    [[nodiscard]] constexpr T Value() const noexcept {
         return ExtractValue(storage);
     }
 
-    constexpr explicit operator bool() const {
+    [[nodiscard]] constexpr explicit operator bool() const noexcept {
         return Value() != 0;
     }
 

--- a/src/common/bit_util.h
+++ b/src/common/bit_util.h
@@ -17,12 +17,12 @@ namespace Common {
 
 /// Gets the size of a specified type T in bits.
 template <typename T>
-constexpr std::size_t BitSize() {
+[[nodiscard]] constexpr std::size_t BitSize() noexcept {
     return sizeof(T) * CHAR_BIT;
 }
 
 #ifdef _MSC_VER
-inline u32 CountLeadingZeroes32(u32 value) {
+[[nodiscard]] inline u32 CountLeadingZeroes32(u32 value) noexcept {
     unsigned long leading_zero = 0;
 
     if (_BitScanReverse(&leading_zero, value) != 0) {
@@ -32,7 +32,7 @@ inline u32 CountLeadingZeroes32(u32 value) {
     return 32;
 }
 
-inline u32 CountLeadingZeroes64(u64 value) {
+[[nodiscard]] inline u32 CountLeadingZeroes64(u64 value) noexcept {
     unsigned long leading_zero = 0;
 
     if (_BitScanReverse64(&leading_zero, value) != 0) {
@@ -42,7 +42,7 @@ inline u32 CountLeadingZeroes64(u64 value) {
     return 64;
 }
 #else
-inline u32 CountLeadingZeroes32(u32 value) {
+[[nodiscard]] inline u32 CountLeadingZeroes32(u32 value) noexcept {
     if (value == 0) {
         return 32;
     }
@@ -50,7 +50,7 @@ inline u32 CountLeadingZeroes32(u32 value) {
     return static_cast<u32>(__builtin_clz(value));
 }
 
-inline u32 CountLeadingZeroes64(u64 value) {
+[[nodiscard]] inline u32 CountLeadingZeroes64(u64 value) noexcept {
     if (value == 0) {
         return 64;
     }
@@ -60,7 +60,7 @@ inline u32 CountLeadingZeroes64(u64 value) {
 #endif
 
 #ifdef _MSC_VER
-inline u32 CountTrailingZeroes32(u32 value) {
+[[nodiscard]] inline u32 CountTrailingZeroes32(u32 value) noexcept {
     unsigned long trailing_zero = 0;
 
     if (_BitScanForward(&trailing_zero, value) != 0) {
@@ -70,7 +70,7 @@ inline u32 CountTrailingZeroes32(u32 value) {
     return 32;
 }
 
-inline u32 CountTrailingZeroes64(u64 value) {
+[[nodiscard]] inline u32 CountTrailingZeroes64(u64 value) noexcept {
     unsigned long trailing_zero = 0;
 
     if (_BitScanForward64(&trailing_zero, value) != 0) {
@@ -80,7 +80,7 @@ inline u32 CountTrailingZeroes64(u64 value) {
     return 64;
 }
 #else
-inline u32 CountTrailingZeroes32(u32 value) {
+[[nodiscard]] inline u32 CountTrailingZeroes32(u32 value) noexcept {
     if (value == 0) {
         return 32;
     }
@@ -88,7 +88,7 @@ inline u32 CountTrailingZeroes32(u32 value) {
     return static_cast<u32>(__builtin_ctz(value));
 }
 
-inline u32 CountTrailingZeroes64(u64 value) {
+[[nodiscard]] inline u32 CountTrailingZeroes64(u64 value) noexcept {
     if (value == 0) {
         return 64;
     }

--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -52,11 +52,11 @@ __declspec(dllimport) void __stdcall DebugBreak(void);
 // Call directly after the command or use the error num.
 // This function might change the error code.
 // Defined in Misc.cpp.
-std::string GetLastErrorMsg();
+[[nodiscard]] std::string GetLastErrorMsg();
 
 namespace Common {
 
-constexpr u32 MakeMagic(char a, char b, char c, char d) {
+[[nodiscard]] constexpr u32 MakeMagic(char a, char b, char c, char d) noexcept {
     return a | b << 8 | c << 16 | d << 24;
 }
 

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -46,19 +46,19 @@ struct FSTEntry {
 };
 
 // Returns true if file filename exists
-bool Exists(const std::string& filename);
+[[nodiscard]] bool Exists(const std::string& filename);
 
 // Returns true if filename is a directory
-bool IsDirectory(const std::string& filename);
+[[nodiscard]] bool IsDirectory(const std::string& filename);
 
 // Returns the size of filename (64bit)
-u64 GetSize(const std::string& filename);
+[[nodiscard]] u64 GetSize(const std::string& filename);
 
 // Overloaded GetSize, accepts file descriptor
-u64 GetSize(const int fd);
+[[nodiscard]] u64 GetSize(int fd);
 
 // Overloaded GetSize, accepts FILE*
-u64 GetSize(FILE* f);
+[[nodiscard]] u64 GetSize(FILE* f);
 
 // Returns true if successful, or path already exists.
 bool CreateDir(const std::string& filename);
@@ -118,7 +118,7 @@ u64 ScanDirectoryTree(const std::string& directory, FSTEntry& parent_entry,
 bool DeleteDirRecursively(const std::string& directory, unsigned int recursion = 256);
 
 // Returns the current directory
-std::string GetCurrentDir();
+[[nodiscard]] std::string GetCurrentDir();
 
 // Create directory and copy contents (does not overwrite existing files)
 void CopyDir(const std::string& source_path, const std::string& dest_path);
@@ -128,22 +128,22 @@ bool SetCurrentDir(const std::string& directory);
 
 // Returns a pointer to a string with a yuzu data dir in the user's home
 // directory. To be used in "multi-user" mode (that is, installed).
-const std::string& GetUserPath(UserPath path, const std::string& new_path = "");
+[[nodiscard]] const std::string& GetUserPath(UserPath path, const std::string& new_path = "");
 
-std::string GetHactoolConfigurationPath();
+[[nodiscard]] std::string GetHactoolConfigurationPath();
 
-std::string GetNANDRegistrationDir(bool system = false);
+[[nodiscard]] std::string GetNANDRegistrationDir(bool system = false);
 
 // Returns the path to where the sys file are
-std::string GetSysDirectory();
+[[nodiscard]] std::string GetSysDirectory();
 
 #ifdef __APPLE__
-std::string GetBundleDirectory();
+[[nodiscard]] std::string GetBundleDirectory();
 #endif
 
 #ifdef _WIN32
-const std::string& GetExeDirectory();
-std::string AppDataRoamingDirectory();
+[[nodiscard]] const std::string& GetExeDirectory();
+[[nodiscard]] std::string AppDataRoamingDirectory();
 #endif
 
 std::size_t WriteStringToFile(bool text_file, const std::string& str, const char* filename);
@@ -162,26 +162,27 @@ void SplitFilename83(const std::string& filename, std::array<char, 9>& short_nam
 
 // Splits the path on '/' or '\' and put the components into a vector
 // i.e. "C:\Users\Yuzu\Documents\save.bin" becomes {"C:", "Users", "Yuzu", "Documents", "save.bin" }
-std::vector<std::string> SplitPathComponents(std::string_view filename);
+[[nodiscard]] std::vector<std::string> SplitPathComponents(std::string_view filename);
 
 // Gets all of the text up to the last '/' or '\' in the path.
-std::string_view GetParentPath(std::string_view path);
+[[nodiscard]] std::string_view GetParentPath(std::string_view path);
 
 // Gets all of the text after the first '/' or '\' in the path.
-std::string_view GetPathWithoutTop(std::string_view path);
+[[nodiscard]] std::string_view GetPathWithoutTop(std::string_view path);
 
 // Gets the filename of the path
-std::string_view GetFilename(std::string_view path);
+[[nodiscard]] std::string_view GetFilename(std::string_view path);
 
 // Gets the extension of the filename
-std::string_view GetExtensionFromFilename(std::string_view name);
+[[nodiscard]] std::string_view GetExtensionFromFilename(std::string_view name);
 
 // Removes the final '/' or '\' if one exists
-std::string_view RemoveTrailingSlash(std::string_view path);
+[[nodiscard]] std::string_view RemoveTrailingSlash(std::string_view path);
 
 // Creates a new vector containing indices [first, last) from the original.
 template <typename T>
-std::vector<T> SliceVector(const std::vector<T>& vector, std::size_t first, std::size_t last) {
+[[nodiscard]] std::vector<T> SliceVector(const std::vector<T>& vector, std::size_t first,
+                                         std::size_t last) {
     if (first >= last)
         return {};
     last = std::min<std::size_t>(last, vector.size());
@@ -192,8 +193,9 @@ enum class DirectorySeparator { ForwardSlash, BackwardSlash, PlatformDefault };
 
 // Removes trailing slash, makes all '\\' into '/', and removes duplicate '/'. Makes '/' into '\\'
 // depending if directory_separator is BackwardSlash or PlatformDefault and running on windows
-std::string SanitizePath(std::string_view path,
-                         DirectorySeparator directory_separator = DirectorySeparator::ForwardSlash);
+[[nodiscard]] std::string SanitizePath(
+    std::string_view path,
+    DirectorySeparator directory_separator = DirectorySeparator::ForwardSlash);
 
 // simple wrapper for cstdlib file functions to
 // hopefully will make error checking easier
@@ -261,13 +263,13 @@ public:
         return WriteArray(str.c_str(), str.length());
     }
 
-    bool IsOpen() const {
+    [[nodiscard]] bool IsOpen() const {
         return nullptr != m_file;
     }
 
     bool Seek(s64 off, int origin) const;
-    u64 Tell() const;
-    u64 GetSize() const;
+    [[nodiscard]] u64 Tell() const;
+    [[nodiscard]] u64 GetSize() const;
     bool Resize(u64 size);
     bool Flush();
 

--- a/src/common/hex_util.h
+++ b/src/common/hex_util.h
@@ -13,12 +13,12 @@
 
 namespace Common {
 
-u8 ToHexNibble(char c1);
+[[nodiscard]] u8 ToHexNibble(char c1);
 
-std::vector<u8> HexStringToVector(std::string_view str, bool little_endian);
+[[nodiscard]] std::vector<u8> HexStringToVector(std::string_view str, bool little_endian);
 
 template <std::size_t Size, bool le = false>
-std::array<u8, Size> HexStringToArray(std::string_view str) {
+[[nodiscard]] std::array<u8, Size> HexStringToArray(std::string_view str) {
     std::array<u8, Size> out{};
     if constexpr (le) {
         for (std::size_t i = 2 * Size - 2; i <= 2 * Size; i -= 2)
@@ -30,17 +30,17 @@ std::array<u8, Size> HexStringToArray(std::string_view str) {
     return out;
 }
 
-std::string HexVectorToString(const std::vector<u8>& vector, bool upper = true);
+[[nodiscard]] std::string HexVectorToString(const std::vector<u8>& vector, bool upper = true);
 
 template <std::size_t Size>
-std::string HexArrayToString(std::array<u8, Size> array, bool upper = true) {
+[[nodiscard]] std::string HexArrayToString(std::array<u8, Size> array, bool upper = true) {
     std::string out;
     for (u8 c : array)
         out += fmt::format(upper ? "{:02X}" : "{:02x}", c);
     return out;
 }
 
-std::array<u8, 0x10> operator"" _array16(const char* str, std::size_t len);
-std::array<u8, 0x20> operator"" _array32(const char* str, std::size_t len);
+[[nodiscard]] std::array<u8, 0x10> operator"" _array16(const char* str, std::size_t len);
+[[nodiscard]] std::array<u8, 0x20> operator"" _array32(const char* str, std::size_t len);
 
 } // namespace Common

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -46,7 +46,7 @@ public:
     virtual void SetFilter(const Filter& new_filter) {
         filter = new_filter;
     }
-    virtual const char* GetName() const = 0;
+    [[nodiscard]] virtual const char* GetName() const = 0;
     virtual void Write(const Entry& entry) = 0;
 
 private:
@@ -58,12 +58,14 @@ private:
  */
 class ConsoleBackend : public Backend {
 public:
-    static const char* Name() {
+    [[nodiscard]] static const char* Name() {
         return "console";
     }
-    const char* GetName() const override {
+
+    [[nodiscard]] const char* GetName() const override {
         return Name();
     }
+
     void Write(const Entry& entry) override;
 };
 
@@ -72,13 +74,14 @@ public:
  */
 class ColorConsoleBackend : public Backend {
 public:
-    static const char* Name() {
+    [[nodiscard]] static const char* Name() {
         return "color_console";
     }
 
-    const char* GetName() const override {
+    [[nodiscard]] const char* GetName() const override {
         return Name();
     }
+
     void Write(const Entry& entry) override;
 };
 
@@ -89,11 +92,11 @@ class FileBackend : public Backend {
 public:
     explicit FileBackend(const std::string& filename);
 
-    static const char* Name() {
+    [[nodiscard]] static const char* Name() {
         return "file";
     }
 
-    const char* GetName() const override {
+    [[nodiscard]] const char* GetName() const override {
         return Name();
     }
 
@@ -109,12 +112,14 @@ private:
  */
 class DebuggerBackend : public Backend {
 public:
-    static const char* Name() {
+    [[nodiscard]] static const char* Name() {
         return "debugger";
     }
-    const char* GetName() const override {
+
+    [[nodiscard]] const char* GetName() const override {
         return Name();
     }
+
     void Write(const Entry& entry) override;
 };
 
@@ -122,18 +127,18 @@ void AddBackend(std::unique_ptr<Backend> backend);
 
 void RemoveBackend(std::string_view backend_name);
 
-Backend* GetBackend(std::string_view backend_name);
+[[nodiscard]] Backend* GetBackend(std::string_view backend_name);
 
 /**
  * Returns the name of the passed log class as a C-string. Subclasses are separated by periods
  * instead of underscores as in the enumeration.
  */
-const char* GetLogClassName(Class log_class);
+[[nodiscard]] const char* GetLogClassName(Class log_class);
 
 /**
  * Returns the name of the passed log level as a C-string.
  */
-const char* GetLevelName(Level log_level);
+[[nodiscard]] const char* GetLevelName(Level log_level);
 
 /**
  * The global filter will prevent any messages from even being processed if they are filtered. Each

--- a/src/common/logging/filter.h
+++ b/src/common/logging/filter.h
@@ -43,10 +43,10 @@ public:
     void ParseFilterString(std::string_view filter_view);
 
     /// Matches class/level combination against the filter, returning true if it passed.
-    bool CheckMessage(Class log_class, Level level) const;
+    [[nodiscard]] bool CheckMessage(Class log_class, Level level) const;
 
     /// Returns true if any logging classes are set to debug
-    bool IsDebug() const;
+    [[nodiscard]] bool IsDebug() const;
 
 private:
     std::array<Level, static_cast<std::size_t>(Class::Count)> class_levels;

--- a/src/common/logging/text_formatter.h
+++ b/src/common/logging/text_formatter.h
@@ -12,7 +12,7 @@ namespace Log {
 struct Entry;
 
 /// Formats a log entry into the provided text buffer.
-std::string FormatLogMessage(const Entry& entry);
+[[nodiscard]] std::string FormatLogMessage(const Entry& entry);
 /// Formats and prints a log entry to stderr.
 void PrintMessage(const Entry& entry);
 /// Prints the same message as `PrintMessage`, but colored according to the severity level.

--- a/src/common/lz4_compression.h
+++ b/src/common/lz4_compression.h
@@ -16,7 +16,7 @@ namespace Common::Compression {
  *
  * @return the compressed data.
  */
-std::vector<u8> CompressDataLZ4(const u8* source, std::size_t source_size);
+[[nodiscard]] std::vector<u8> CompressDataLZ4(const u8* source, std::size_t source_size);
 
 /**
  * Utilizes the LZ4 subalgorithm LZ4HC with the specified compression level. Higher compression
@@ -30,7 +30,8 @@ std::vector<u8> CompressDataLZ4(const u8* source, std::size_t source_size);
  *
  * @return the compressed data.
  */
-std::vector<u8> CompressDataLZ4HC(const u8* source, std::size_t source_size, s32 compression_level);
+[[nodiscard]] std::vector<u8> CompressDataLZ4HC(const u8* source, std::size_t source_size,
+                                                s32 compression_level);
 
 /**
  * Utilizes the LZ4 subalgorithm LZ4HC with the highest possible compression level.
@@ -40,7 +41,7 @@ std::vector<u8> CompressDataLZ4HC(const u8* source, std::size_t source_size, s32
  *
  * @return the compressed data.
  */
-std::vector<u8> CompressDataLZ4HCMax(const u8* source, std::size_t source_size);
+[[nodiscard]] std::vector<u8> CompressDataLZ4HCMax(const u8* source, std::size_t source_size);
 
 /**
  * Decompresses a source memory region with LZ4 and returns the uncompressed data in a vector.
@@ -50,6 +51,7 @@ std::vector<u8> CompressDataLZ4HCMax(const u8* source, std::size_t source_size);
  *
  * @return the decompressed data.
  */
-std::vector<u8> DecompressDataLZ4(const std::vector<u8>& compressed, std::size_t uncompressed_size);
+[[nodiscard]] std::vector<u8> DecompressDataLZ4(const std::vector<u8>& compressed,
+                                                std::size_t uncompressed_size);
 
 } // namespace Common::Compression

--- a/src/common/math_util.h
+++ b/src/common/math_util.h
@@ -18,24 +18,24 @@ struct Rectangle {
     T right{};
     T bottom{};
 
-    constexpr Rectangle() = default;
+    constexpr Rectangle() noexcept = default;
 
-    constexpr Rectangle(T left, T top, T right, T bottom)
+    constexpr Rectangle(T left, T top, T right, T bottom) noexcept
         : left(left), top(top), right(right), bottom(bottom) {}
 
-    T GetWidth() const {
+    [[nodiscard]] T GetWidth() const noexcept {
         return std::abs(static_cast<std::make_signed_t<T>>(right - left));
     }
-    T GetHeight() const {
+    [[nodiscard]] T GetHeight() const noexcept {
         return std::abs(static_cast<std::make_signed_t<T>>(bottom - top));
     }
-    Rectangle<T> TranslateX(const T x) const {
+    [[nodiscard]] Rectangle<T> TranslateX(const T x) const noexcept {
         return Rectangle{left + x, top, right + x, bottom};
     }
-    Rectangle<T> TranslateY(const T y) const {
+    [[nodiscard]] Rectangle<T> TranslateY(const T y) const noexcept {
         return Rectangle{left, top + y, right, bottom + y};
     }
-    Rectangle<T> Scale(const float s) const {
+    [[nodiscard]] Rectangle<T> Scale(const float s) const noexcept {
         return Rectangle{left, top, static_cast<T>(left + GetWidth() * s),
                          static_cast<T>(top + GetHeight() * s)};
     }

--- a/src/common/memory_hook.h
+++ b/src/common/memory_hook.h
@@ -26,21 +26,22 @@ class MemoryHook {
 public:
     virtual ~MemoryHook();
 
-    virtual std::optional<bool> IsValidAddress(VAddr addr) = 0;
+    [[nodiscard]] virtual std::optional<bool> IsValidAddress(VAddr addr) = 0;
 
-    virtual std::optional<u8> Read8(VAddr addr) = 0;
-    virtual std::optional<u16> Read16(VAddr addr) = 0;
-    virtual std::optional<u32> Read32(VAddr addr) = 0;
-    virtual std::optional<u64> Read64(VAddr addr) = 0;
+    [[nodiscard]] virtual std::optional<u8> Read8(VAddr addr) = 0;
+    [[nodiscard]] virtual std::optional<u16> Read16(VAddr addr) = 0;
+    [[nodiscard]] virtual std::optional<u32> Read32(VAddr addr) = 0;
+    [[nodiscard]] virtual std::optional<u64> Read64(VAddr addr) = 0;
 
-    virtual bool ReadBlock(VAddr src_addr, void* dest_buffer, std::size_t size) = 0;
+    [[nodiscard]] virtual bool ReadBlock(VAddr src_addr, void* dest_buffer, std::size_t size) = 0;
 
-    virtual bool Write8(VAddr addr, u8 data) = 0;
-    virtual bool Write16(VAddr addr, u16 data) = 0;
-    virtual bool Write32(VAddr addr, u32 data) = 0;
-    virtual bool Write64(VAddr addr, u64 data) = 0;
+    [[nodiscard]] virtual bool Write8(VAddr addr, u8 data) = 0;
+    [[nodiscard]] virtual bool Write16(VAddr addr, u16 data) = 0;
+    [[nodiscard]] virtual bool Write32(VAddr addr, u32 data) = 0;
+    [[nodiscard]] virtual bool Write64(VAddr addr, u64 data) = 0;
 
-    virtual bool WriteBlock(VAddr dest_addr, const void* src_buffer, std::size_t size) = 0;
+    [[nodiscard]] virtual bool WriteBlock(VAddr dest_addr, const void* src_buffer,
+                                          std::size_t size) = 0;
 };
 
 using MemoryHookPointer = std::shared_ptr<MemoryHook>;

--- a/src/common/multi_level_queue.h
+++ b/src/common/multi_level_queue.h
@@ -43,21 +43,21 @@ public:
         using reference = std::conditional_t<is_constant, const T&, T&>;
         using difference_type = typename std::pointer_traits<pointer>::difference_type;
 
-        friend bool operator==(const iterator_impl& lhs, const iterator_impl& rhs) {
+        [[nodiscard]] friend bool operator==(const iterator_impl& lhs, const iterator_impl& rhs) {
             if (lhs.IsEnd() && rhs.IsEnd())
                 return true;
             return std::tie(lhs.current_priority, lhs.it) == std::tie(rhs.current_priority, rhs.it);
         }
 
-        friend bool operator!=(const iterator_impl& lhs, const iterator_impl& rhs) {
+        [[nodiscard]] friend bool operator!=(const iterator_impl& lhs, const iterator_impl& rhs) {
             return !operator==(lhs, rhs);
         }
 
-        reference operator*() const {
+        [[nodiscard]] reference operator*() const {
             return *it;
         }
 
-        pointer operator->() const {
+        [[nodiscard]] pointer operator->() const {
             return it.operator->();
         }
 
@@ -143,15 +143,15 @@ public:
         explicit iterator_impl(container_ref mlq, u32 current_priority)
             : mlq(mlq), it(), current_priority(current_priority) {}
 
-        bool IsEnd() const {
+        [[nodiscard]] bool IsEnd() const {
             return current_priority == mlq.depth();
         }
 
-        list_iterator GetBeginItForPrio() const {
+        [[nodiscard]] list_iterator GetBeginItForPrio() const {
             return mlq.levels[current_priority].begin();
         }
 
-        list_iterator GetEndItForPrio() const {
+        [[nodiscard]] list_iterator GetEndItForPrio() const {
             return mlq.levels[current_priority].end();
         }
 
@@ -223,15 +223,15 @@ public:
         ListShiftForward(levels[priority], n);
     }
 
-    std::size_t depth() const {
+    [[nodiscard]] std::size_t depth() const {
         return Depth;
     }
 
-    std::size_t size(u32 priority) const {
+    [[nodiscard]] std::size_t size(u32 priority) const {
         return levels[priority].size();
     }
 
-    std::size_t size() const {
+    [[nodiscard]] std::size_t size() const {
         u64 priorities = used_priorities;
         std::size_t size = 0;
         while (priorities != 0) {
@@ -242,64 +242,64 @@ public:
         return size;
     }
 
-    bool empty() const {
+    [[nodiscard]] bool empty() const {
         return used_priorities == 0;
     }
 
-    bool empty(u32 priority) const {
+    [[nodiscard]] bool empty(u32 priority) const {
         return (used_priorities & (1ULL << priority)) == 0;
     }
 
-    u32 highest_priority_set(u32 max_priority = 0) const {
+    [[nodiscard]] u32 highest_priority_set(u32 max_priority = 0) const {
         const u64 priorities =
             max_priority == 0 ? used_priorities : (used_priorities & ~((1ULL << max_priority) - 1));
         return priorities == 0 ? Depth : static_cast<u32>(CountTrailingZeroes64(priorities));
     }
 
-    u32 lowest_priority_set(u32 min_priority = Depth - 1) const {
+    [[nodiscard]] u32 lowest_priority_set(u32 min_priority = Depth - 1) const {
         const u64 priorities = min_priority >= Depth - 1
                                    ? used_priorities
                                    : (used_priorities & ((1ULL << (min_priority + 1)) - 1));
         return priorities == 0 ? Depth : 63 - CountLeadingZeroes64(priorities);
     }
 
-    const_iterator cbegin(u32 max_prio = 0) const {
+    [[nodiscard]] const_iterator cbegin(u32 max_prio = 0) const {
         const u32 priority = highest_priority_set(max_prio);
         return priority == Depth ? cend()
                                  : const_iterator{*this, levels[priority].cbegin(), priority};
     }
-    const_iterator begin(u32 max_prio = 0) const {
+    [[nodiscard]] const_iterator begin(u32 max_prio = 0) const {
         return cbegin(max_prio);
     }
-    iterator begin(u32 max_prio = 0) {
+    [[nodiscard]] iterator begin(u32 max_prio = 0) {
         const u32 priority = highest_priority_set(max_prio);
         return priority == Depth ? end() : iterator{*this, levels[priority].begin(), priority};
     }
 
-    const_iterator cend(u32 min_prio = Depth - 1) const {
+    [[nodiscard]] const_iterator cend(u32 min_prio = Depth - 1) const {
         return min_prio == Depth - 1 ? const_iterator{*this, Depth} : cbegin(min_prio + 1);
     }
-    const_iterator end(u32 min_prio = Depth - 1) const {
+    [[nodiscard]] const_iterator end(u32 min_prio = Depth - 1) const {
         return cend(min_prio);
     }
-    iterator end(u32 min_prio = Depth - 1) {
+    [[nodiscard]] iterator end(u32 min_prio = Depth - 1) {
         return min_prio == Depth - 1 ? iterator{*this, Depth} : begin(min_prio + 1);
     }
 
-    T& front(u32 max_priority = 0) {
+    [[nodiscard]] T& front(u32 max_priority = 0) {
         const u32 priority = highest_priority_set(max_priority);
         return levels[priority == Depth ? 0 : priority].front();
     }
-    const T& front(u32 max_priority = 0) const {
+    [[nodiscard]] const T& front(u32 max_priority = 0) const {
         const u32 priority = highest_priority_set(max_priority);
         return levels[priority == Depth ? 0 : priority].front();
     }
 
-    T back(u32 min_priority = Depth - 1) {
+    [[nodiscard]] T back(u32 min_priority = Depth - 1) {
         const u32 priority = lowest_priority_set(min_priority); // intended
         return levels[priority == Depth ? 63 : priority].back();
     }
-    const T& back(u32 min_priority = Depth - 1) const {
+    [[nodiscard]] const T& back(u32 min_priority = Depth - 1) const {
         const u32 priority = lowest_priority_set(min_priority); // intended
         return levels[priority == Depth ? 63 : priority].back();
     }
@@ -322,7 +322,8 @@ private:
         in_list.splice(position, out_list, element);
     }
 
-    static const_list_iterator ListIterateTo(const std::list<T>& list, const T& element) {
+    [[nodiscard]] static const_list_iterator ListIterateTo(const std::list<T>& list,
+                                                           const T& element) {
         auto it = list.cbegin();
         while (it != list.cend() && *it != element) {
             ++it;

--- a/src/common/page_table.h
+++ b/src/common/page_table.h
@@ -33,11 +33,11 @@ struct SpecialRegion {
 
     MemoryHookPointer handler;
 
-    bool operator<(const SpecialRegion& other) const {
+    [[nodiscard]] bool operator<(const SpecialRegion& other) const {
         return std::tie(type, handler) < std::tie(other.type, other.handler);
     }
 
-    bool operator==(const SpecialRegion& other) const {
+    [[nodiscard]] bool operator==(const SpecialRegion& other) const {
         return std::tie(type, handler) == std::tie(other.type, other.handler);
     }
 };

--- a/src/common/param_package.h
+++ b/src/common/param_package.h
@@ -24,14 +24,14 @@ public:
     ParamPackage& operator=(const ParamPackage& other) = default;
     ParamPackage& operator=(ParamPackage&& other) = default;
 
-    std::string Serialize() const;
-    std::string Get(const std::string& key, const std::string& default_value) const;
-    int Get(const std::string& key, int default_value) const;
-    float Get(const std::string& key, float default_value) const;
+    [[nodiscard]] std::string Serialize() const;
+    [[nodiscard]] std::string Get(const std::string& key, const std::string& default_value) const;
+    [[nodiscard]] int Get(const std::string& key, int default_value) const;
+    [[nodiscard]] float Get(const std::string& key, float default_value) const;
     void Set(const std::string& key, std::string value);
     void Set(const std::string& key, int value);
     void Set(const std::string& key, float value);
-    bool Has(const std::string& key) const;
+    [[nodiscard]] bool Has(const std::string& key) const;
     void Erase(const std::string& key);
     void Clear();
 

--- a/src/common/quaternion.h
+++ b/src/common/quaternion.h
@@ -14,35 +14,39 @@ public:
     Vec3<T> xyz;
     T w{};
 
-    Quaternion<decltype(-T{})> Inverse() const {
+    [[nodiscard]] Quaternion<decltype(-T{})> Inverse() const noexcept {
         return {-xyz, w};
     }
 
-    Quaternion<decltype(T{} + T{})> operator+(const Quaternion& other) const {
+    [[nodiscard]] Quaternion<decltype(T{} + T{})> operator+(const Quaternion& other) const
+        noexcept {
         return {xyz + other.xyz, w + other.w};
     }
 
-    Quaternion<decltype(T{} - T{})> operator-(const Quaternion& other) const {
+    [[nodiscard]] Quaternion<decltype(T{} - T{})> operator-(const Quaternion& other) const
+        noexcept {
         return {xyz - other.xyz, w - other.w};
     }
 
-    Quaternion<decltype(T{} * T{} - T{} * T{})> operator*(const Quaternion& other) const {
+    [[nodiscard]] Quaternion<decltype(T{} * T{} - T{} * T{})> operator*(
+        const Quaternion& other) const noexcept {
         return {xyz * other.w + other.xyz * w + Cross(xyz, other.xyz),
                 w * other.w - Dot(xyz, other.xyz)};
     }
 
-    Quaternion<T> Normalized() const {
+    [[nodiscard]] Quaternion<T> Normalized() const noexcept {
         T length = std::sqrt(xyz.Length2() + w * w);
         return {xyz / length, w / length};
     }
 };
 
 template <typename T>
-auto QuaternionRotate(const Quaternion<T>& q, const Vec3<T>& v) {
+[[nodiscard]] auto QuaternionRotate(const Quaternion<T>& q, const Vec3<T>& v) noexcept {
     return v + 2 * Cross(q.xyz, Cross(q.xyz, v) + v * q.w);
 }
 
-inline Quaternion<float> MakeQuaternion(const Vec3<float>& axis, float angle) {
+[[nodiscard]] inline Quaternion<float> MakeQuaternion(const Vec3<float>& axis,
+                                                      float angle) noexcept {
     return {axis * std::sin(angle / 2), std::cos(angle / 2)};
 }
 

--- a/src/common/ring_buffer.h
+++ b/src/common/ring_buffer.h
@@ -64,7 +64,7 @@ public:
     /// @param output     Where to store the popped slots
     /// @param max_slots  Maximum number of slots to pop
     /// @returns The number of slots actually popped
-    std::size_t Pop(void* output, std::size_t max_slots = ~std::size_t(0)) {
+    [[nodiscard]] std::size_t Pop(void* output, std::size_t max_slots = ~std::size_t(0)) {
         const std::size_t read_index = m_read_index.load();
         const std::size_t slots_filled = m_write_index.load() - read_index;
         const std::size_t pop_count = std::min(slots_filled, max_slots);
@@ -83,7 +83,7 @@ public:
         return pop_count;
     }
 
-    std::vector<T> Pop(std::size_t max_slots = ~std::size_t(0)) {
+    [[nodiscard]] std::vector<T> Pop(std::size_t max_slots = ~std::size_t(0)) {
         std::vector<T> out(std::min(max_slots, capacity) * granularity);
         const std::size_t count = Pop(out.data(), out.size() / granularity);
         out.resize(count * granularity);
@@ -91,12 +91,12 @@ public:
     }
 
     /// @returns Number of slots used
-    std::size_t Size() const {
+    [[nodiscard]] std::size_t Size() const {
         return m_write_index.load() - m_read_index.load();
     }
 
     /// @returns Maximum size of ring buffer
-    constexpr std::size_t Capacity() const {
+    [[nodiscard]] constexpr std::size_t Capacity() const {
         return capacity;
     }
 

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -12,19 +12,19 @@
 namespace Common {
 
 /// Make a string lowercase
-std::string ToLower(std::string str);
+[[nodiscard]] std::string ToLower(std::string str);
 
 /// Make a string uppercase
-std::string ToUpper(std::string str);
+[[nodiscard]] std::string ToUpper(std::string str);
 
-std::string StringFromBuffer(const std::vector<u8>& data);
+[[nodiscard]] std::string StringFromBuffer(const std::vector<u8>& data);
 
-std::string StripSpaces(const std::string& s);
-std::string StripQuotes(const std::string& s);
+[[nodiscard]] std::string StripSpaces(const std::string& s);
+[[nodiscard]] std::string StripQuotes(const std::string& s);
 
-std::string StringFromBool(bool value);
+[[nodiscard]] std::string StringFromBool(bool value);
 
-std::string TabsToSpaces(int tab_size, std::string in);
+[[nodiscard]] std::string TabsToSpaces(int tab_size, std::string in);
 
 void SplitString(const std::string& str, char delim, std::vector<std::string>& output);
 
@@ -34,15 +34,15 @@ bool SplitPath(const std::string& full_path, std::string* _pPath, std::string* _
 
 void BuildCompleteFilename(std::string& _CompleteFilename, const std::string& _Path,
                            const std::string& _Filename);
-std::string ReplaceAll(std::string result, const std::string& src, const std::string& dest);
+[[nodiscard]] std::string ReplaceAll(std::string result, const std::string& src,
+                                     const std::string& dest);
 
-std::string UTF16ToUTF8(const std::u16string& input);
-std::u16string UTF8ToUTF16(const std::string& input);
+[[nodiscard]] std::string UTF16ToUTF8(const std::u16string& input);
+[[nodiscard]] std::u16string UTF8ToUTF16(const std::string& input);
 
 #ifdef _WIN32
-std::string UTF16ToUTF8(const std::wstring& input);
-std::wstring UTF8ToUTF16W(const std::string& str);
-
+[[nodiscard]] std::string UTF16ToUTF8(const std::wstring& input);
+[[nodiscard]] std::wstring UTF8ToUTF16W(const std::string& str);
 #endif
 
 /**
@@ -50,7 +50,7 @@ std::wstring UTF8ToUTF16W(const std::string& str);
  * `other` for equality.
  */
 template <typename InIt>
-bool ComparePartialString(InIt begin, InIt end, const char* other) {
+[[nodiscard]] bool ComparePartialString(InIt begin, InIt end, const char* other) {
     for (; begin != end && *other != '\0'; ++begin, ++other) {
         if (*begin != *other) {
             return false;
@@ -64,15 +64,16 @@ bool ComparePartialString(InIt begin, InIt end, const char* other) {
  * Creates a std::string from a fixed-size NUL-terminated char buffer. If the buffer isn't
  * NUL-terminated then the string ends at max_len characters.
  */
-std::string StringFromFixedZeroTerminatedBuffer(const char* buffer, std::size_t max_len);
+[[nodiscard]] std::string StringFromFixedZeroTerminatedBuffer(const char* buffer,
+                                                              std::size_t max_len);
 
 /**
  * Creates a UTF-16 std::u16string from a fixed-size NUL-terminated char buffer. If the buffer isn't
  * null-terminated, then the string ends at the greatest multiple of two less then or equal to
  * max_len_bytes.
  */
-std::u16string UTF16StringFromFixedZeroTerminatedBuffer(std::u16string_view buffer,
-                                                        std::size_t max_len);
+[[nodiscard]] std::u16string UTF16StringFromFixedZeroTerminatedBuffer(std::u16string_view buffer,
+                                                                      std::size_t max_len);
 
 /**
  * Attempts to trim an arbitrary prefix from `path`, leaving only the part starting at `root`. It's
@@ -84,6 +85,6 @@ std::u16string UTF16StringFromFixedZeroTerminatedBuffer(std::u16string_view buff
  *             including the last occurrence of this name will be stripped
  * @return A pointer to the same string passed as `path`, but starting at the trimmed portion
  */
-const char* TrimSourcePath(const char* path, const char* root = "src");
+[[nodiscard]] const char* TrimSourcePath(const char* path, const char* root = "src");
 
 } // namespace Common

--- a/src/common/telemetry.h
+++ b/src/common/telemetry.h
@@ -42,7 +42,7 @@ public:
      * Gets the name of this field.
      * @returns Name of this field as a string.
      */
-    virtual const std::string& GetName() const = 0;
+    [[nodiscard]] virtual const std::string& GetName() const = 0;
 };
 
 /**
@@ -63,29 +63,29 @@ public:
 
     void Accept(VisitorInterface& visitor) const override;
 
-    const std::string& GetName() const override {
+    [[nodiscard]] const std::string& GetName() const override {
         return name;
     }
 
     /**
      * Returns the type of the field.
      */
-    FieldType GetType() const {
+    [[nodiscard]] FieldType GetType() const {
         return type;
     }
 
     /**
      * Returns the value of the field.
      */
-    const T& GetValue() const {
+    [[nodiscard]] const T& GetValue() const {
         return value;
     }
 
-    bool operator==(const Field& other) const {
+    [[nodiscard]] bool operator==(const Field& other) const {
         return (type == other.type) && (name == other.name) && (value == other.value);
     }
 
-    bool operator!=(const Field& other) const {
+    [[nodiscard]] bool operator!=(const Field& other) const {
         return !(*this == other);
     }
 

--- a/src/common/thread.h
+++ b/src/common/thread.h
@@ -29,7 +29,7 @@ public:
     }
 
     template <class Clock, class Duration>
-    bool WaitUntil(const std::chrono::time_point<Clock, Duration>& time) {
+    [[nodiscard]] bool WaitUntil(const std::chrono::time_point<Clock, Duration>& time) {
         std::unique_lock lk{mutex};
         if (!condvar.wait_until(lk, time, [this] { return is_set; }))
             return false;

--- a/src/common/thread_queue_list.h
+++ b/src/common/thread_queue_list.h
@@ -25,7 +25,7 @@ struct ThreadQueueList {
     }
 
     // Only for debugging, returns priority level.
-    Priority contains(const T& uid) const {
+    [[nodiscard]] Priority contains(const T& uid) const {
         for (Priority i = 0; i < NUM_QUEUES; ++i) {
             const Queue& cur = queues[i];
             if (std::find(cur.data.cbegin(), cur.data.cend(), uid) != cur.data.cend()) {
@@ -36,7 +36,7 @@ struct ThreadQueueList {
         return -1;
     }
 
-    T get_first() const {
+    [[nodiscard]] T get_first() const {
         const Queue* cur = first;
         while (cur != nullptr) {
             if (!cur->data.empty()) {
@@ -49,7 +49,7 @@ struct ThreadQueueList {
     }
 
     template <typename UnaryPredicate>
-    T get_first_filter(UnaryPredicate filter) const {
+    [[nodiscard]] T get_first_filter(UnaryPredicate filter) const {
         const Queue* cur = first;
         while (cur != nullptr) {
             if (!cur->data.empty()) {
@@ -129,7 +129,7 @@ struct ThreadQueueList {
         first = nullptr;
     }
 
-    bool empty(Priority priority) const {
+    [[nodiscard]] bool empty(Priority priority) const {
         const Queue* cur = &queues[priority];
         return cur->data.empty();
     }

--- a/src/common/threadsafe_queue.h
+++ b/src/common/threadsafe_queue.h
@@ -25,15 +25,15 @@ public:
         delete read_ptr;
     }
 
-    std::size_t Size() const {
+    [[nodiscard]] std::size_t Size() const {
         return size.load();
     }
 
-    bool Empty() const {
+    [[nodiscard]] bool Empty() const {
         return Size() == 0;
     }
 
-    T& Front() const {
+    [[nodiscard]] T& Front() const {
         return read_ptr->current;
     }
 
@@ -123,15 +123,15 @@ private:
 template <typename T>
 class MPSCQueue {
 public:
-    std::size_t Size() const {
+    [[nodiscard]] std::size_t Size() const {
         return spsc_queue.Size();
     }
 
-    bool Empty() const {
+    [[nodiscard]] bool Empty() const {
         return spsc_queue.Empty();
     }
 
-    T& Front() const {
+    [[nodiscard]] T& Front() const {
         return spsc_queue.Front();
     }
 

--- a/src/common/timer.h
+++ b/src/common/timer.h
@@ -19,18 +19,18 @@ public:
 
     // The time difference is always returned in milliseconds, regardless of alternative internal
     // representation
-    std::chrono::milliseconds GetTimeDifference();
+    [[nodiscard]] std::chrono::milliseconds GetTimeDifference();
     void AddTimeDifference();
 
-    static std::chrono::seconds GetTimeSinceJan1970();
-    static std::chrono::seconds GetLocalTimeSinceJan1970();
-    static double GetDoubleTime();
+    [[nodiscard]] static std::chrono::seconds GetTimeSinceJan1970();
+    [[nodiscard]] static std::chrono::seconds GetLocalTimeSinceJan1970();
+    [[nodiscard]] static double GetDoubleTime();
 
-    static std::string GetTimeFormatted();
-    std::string GetTimeElapsedFormatted() const;
-    std::chrono::milliseconds GetTimeElapsed();
+    [[nodiscard]] static std::string GetTimeFormatted();
+    [[nodiscard]] std::string GetTimeElapsedFormatted() const;
+    [[nodiscard]] std::chrono::milliseconds GetTimeElapsed();
 
-    static std::chrono::milliseconds GetTimeMs();
+    [[nodiscard]] static std::chrono::milliseconds GetTimeMs();
 
 private:
     std::chrono::milliseconds m_LastTime;

--- a/src/common/uint128.cpp
+++ b/src/common/uint128.cpp
@@ -12,7 +12,7 @@
 
 namespace Common {
 
-u128 Multiply64Into128(u64 a, u64 b) {
+u128 Multiply64Into128(u64 a, u64 b) noexcept {
     u128 result;
 #ifdef _MSC_VER
     result[0] = _umul128(a, b, &result[1]);
@@ -24,7 +24,7 @@ u128 Multiply64Into128(u64 a, u64 b) {
     return result;
 }
 
-std::pair<u64, u64> Divide128On32(u128 dividend, u32 divisor) {
+std::pair<u64, u64> Divide128On32(u128 dividend, u32 divisor) noexcept {
     u64 remainder = dividend[0] % divisor;
     u64 accum = dividend[0] / divisor;
     if (dividend[1] == 0)

--- a/src/common/uint128.h
+++ b/src/common/uint128.h
@@ -10,10 +10,10 @@
 namespace Common {
 
 // This function multiplies 2 u64 values and produces a u128 value;
-u128 Multiply64Into128(u64 a, u64 b);
+[[nodiscard]] u128 Multiply64Into128(u64 a, u64 b) noexcept;
 
 // This function divides a u128 by a u32 value and produces two u64 values:
 // the result of division and the remainder
-std::pair<u64, u64> Divide128On32(u128 dividend, u32 divisor);
+[[nodiscard]] std::pair<u64, u64> Divide128On32(u128 dividend, u32 divisor) noexcept;
 
 } // namespace Common

--- a/src/common/zstd_compression.h
+++ b/src/common/zstd_compression.h
@@ -17,7 +17,8 @@ namespace Common::Compression {
  *
  * @return the compressed data.
  */
-std::vector<u8> CompressDataZSTD(const u8* source, std::size_t source_size, s32 compression_level);
+[[nodiscard]] std::vector<u8> CompressDataZSTD(const u8* source, std::size_t source_size,
+                                               s32 compression_level);
 
 /**
  * Compresses a source memory region with Zstandard with the default compression level and returns
@@ -28,7 +29,7 @@ std::vector<u8> CompressDataZSTD(const u8* source, std::size_t source_size, s32 
  *
  * @return the compressed data.
  */
-std::vector<u8> CompressDataZSTDDefault(const u8* source, std::size_t source_size);
+[[nodiscard]] std::vector<u8> CompressDataZSTDDefault(const u8* source, std::size_t source_size);
 
 /**
  * Decompresses a source memory region with Zstandard and returns the uncompressed data in a vector.
@@ -37,6 +38,6 @@ std::vector<u8> CompressDataZSTDDefault(const u8* source, std::size_t source_siz
  *
  * @return the decompressed data.
  */
-std::vector<u8> DecompressDataZSTD(const std::vector<u8>& compressed);
+[[nodiscard]] std::vector<u8> DecompressDataZSTD(const std::vector<u8>& compressed);
 
 } // namespace Common::Compression


### PR DESCRIPTION
Given the common library is supposed to be a general set of utilities, we can mark functions with the nodiscard attribute to allow the compiler to create warnings when functions have their return values discarded when they shouldn't be, identifying bugs quicker. This also takes the liberty of applying noexcept to some trivial cases as well (such as the bit arithmetic utilities, etc).

This is only done with the common library, given it's supposed to contain a multitude of functions that don't necessarily change quite frequently (e.g. applying it to other libraries would need to be done on a much more strict case-by-case basis).

I've kept the individual modifications within their own commits to make review slightly nicer, however I can squash these down at the end of review if that's preferable.