### PR TITLE
CMakeLists: Ensure we specify Unicode as the codepage on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,9 @@ if (MSVC)
     # Avoid windows.h from including some usually unused libs like winsocks.h, since this might cause some redefinition errors.
     add_definitions(-DWIN32_LEAN_AND_MEAN)
 
+    # Ensure that projects build with Unicode support.
+    add_definitions(-DUNICODE -D_UNICODE)
+
     # /W3 - Level 3 warnings
     # /MP - Multi-threaded compilation
     # /Zi - Output debugging information

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -32,17 +32,19 @@
 #include "yuzu_cmd/config.h"
 #include "yuzu_cmd/emu_window/emu_window_sdl2.h"
 
-#include <getopt.h>
 #include "core/file_sys/registered_cache.h"
-#ifndef _MSC_VER
-#include <unistd.h>
-#endif
 
 #ifdef _WIN32
 // windows.h needs to be included before shellapi.h
 #include <windows.h>
 
 #include <shellapi.h>
+#endif
+
+#undef _UNICODE
+#include <getopt.h>
+#ifndef _MSC_VER
+#include <unistd.h>
 #endif
 
 #ifdef _WIN32


### PR DESCRIPTION
Previously we were building with MBCS, which is pretty undesirable. We want the application to be Unicode-aware in general.