### PR TITLE
CMakeLists: Define QT_USE_QSTRINGBUILDER for the Qt target

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -151,6 +151,12 @@ target_link_libraries(yuzu PRIVATE common core input_common video_core)
 target_link_libraries(yuzu PRIVATE Boost::boost glad Qt5::OpenGL Qt5::Widgets)
 target_link_libraries(yuzu PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
+target_compile_definitions(yuzu PRIVATE
+    # Use QStringBuilder for string concatenation to reduce
+    # the overall number of temporary strings created.
+    -DQT_USE_QSTRINGBUILDER
+)
+
 if (YUZU_ENABLE_COMPATIBILITY_REPORTING)
     target_compile_definitions(yuzu PRIVATE -DYUZU_ENABLE_COMPATIBILITY_REPORTING)
 endif()

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -95,7 +95,7 @@ public:
             if (row2.isEmpty())
                 return row1;
 
-            return row1 + "\n    " + row2;
+            return QString(row1 + "\n    " + row2);
         }
 
         return GameListItem::data(role);


### PR DESCRIPTION
This is a compile definition introduced in Qt 4.8 for reducing the total potential number of strings created when performing string concatenation. This allows for less memory churn.

This can be read about [here](https://blog.qt.io/blog/2011/06/13/string-concatenation-with-qstringbuilder/)

For a change that isn't source-compatible, we only had one occurrence that actually need to have its type clarified, which is pretty good, as far as transitioning goes.