### PR TITLE
Port citra-emu/citra#3839: "travis: use prebuilt image"

### DIFF
--- a/.travis/linux-mingw/build.sh
+++ b/.travis/linux-mingw/build.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 mkdir "$HOME/.ccache" || true
-docker run --env-file .travis/common/travis-ci.env -v $(pwd):/yuzu -v "$HOME/.ccache":/root/.ccache ubuntu:18.04 /bin/bash -ex /yuzu/.travis/linux-mingw/docker.sh
+docker run --env-file .travis/common/travis-ci.env -v $(pwd):/yuzu -v "$HOME/.ccache":/root/.ccache yuzuemu/build-environments:linux-mingw /bin/bash -ex /yuzu/.travis/linux-mingw/docker.sh

--- a/.travis/linux-mingw/deps.sh
+++ b/.travis/linux-mingw/deps.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -ex
 
-docker pull ubuntu:18.04
+docker pull yuzuemu/build-environments:linux-mingw

--- a/.travis/linux-mingw/docker.sh
+++ b/.travis/linux-mingw/docker.sh
@@ -1,16 +1,6 @@
 #!/bin/bash -ex
 
 cd /yuzu
-MINGW_PACKAGES="sdl2-mingw-w64 qt5base-mingw-w64 qt5tools-mingw-w64 libsamplerate-mingw-w64 qt5multimedia-mingw-w64"
-apt-get update
-apt-get install -y gpg wget git python3-pip python ccache g++-mingw-w64-x86-64 gcc-mingw-w64-x86-64 mingw-w64-tools cmake
-echo 'deb http://ppa.launchpad.net/tobydox/mingw-w64/ubuntu bionic main ' > /etc/apt/sources.list.d/extras.list
-apt-key adv --keyserver keyserver.ubuntu.com --recv '72931B477E22FEFD47F8DECE02FE5F12ADDE29B2'
-apt-get update
-apt-get install -y ${MINGW_PACKAGES}
-
-# fix a problem in current MinGW headers
-wget -q https://raw.githubusercontent.com/Alexpux/mingw-w64/d0d7f784833bbb0b2d279310ddc6afb52fe47a46/mingw-w64-headers/crt/errno.h -O /usr/x86_64-w64-mingw32/include/errno.h
 # override Travis CI unreasonable ccache size
 echo 'max_size = 3.0G' > "$HOME/.ccache/ccache.conf"
 

--- a/.travis/linux/build.sh
+++ b/.travis/linux/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -ex
 
 mkdir -p "$HOME/.ccache"
-docker run -e ENABLE_COMPATIBILITY_REPORTING --env-file .travis/common/travis-ci.env -v $(pwd):/yuzu -v "$HOME/.ccache":/root/.ccache ubuntu:18.04 /bin/bash /yuzu/.travis/linux/docker.sh
+docker run -e ENABLE_COMPATIBILITY_REPORTING --env-file .travis/common/travis-ci.env -v $(pwd):/yuzu -v "$HOME/.ccache":/root/.ccache yuzuemu/build-environments:linux-fresh /bin/bash /yuzu/.travis/linux/docker.sh

--- a/.travis/linux/deps.sh
+++ b/.travis/linux/deps.sh
@@ -1,3 +1,3 @@
 #!/bin/sh -ex
 
-docker pull ubuntu:18.04
+docker pull yuzuemu/build-environments:linux-fresh

--- a/.travis/linux/docker.sh
+++ b/.travis/linux/docker.sh
@@ -1,8 +1,5 @@
 #!/bin/bash -ex
 
-apt-get update
-apt-get install --no-install-recommends -y build-essential git libqt5opengl5-dev libsdl2-dev libssl-dev python qtbase5-dev qtwebengine5-dev wget cmake ninja-build ccache
-
 cd /yuzu
 
 mkdir build && cd build

--- a/CMakeModules/GenerateSCMRev.cmake
+++ b/CMakeModules/GenerateSCMRev.cmake
@@ -19,7 +19,7 @@ set(BUILD_VERSION "0")
 if (BUILD_REPOSITORY)
   # regex capture the string nightly or canary into CMAKE_MATCH_1
   string(REGEX MATCH "yuzu-emu/yuzu-?(.*)" OUTVAR ${BUILD_REPOSITORY})
-  if (${CMAKE_MATCH_COUNT} GREATER 0)
+  if ("${CMAKE_MATCH_COUNT}" GREATER 0)
     # capitalize the first letter of each word in the repo name.
     string(REPLACE "-" ";" REPO_NAME_LIST ${CMAKE_MATCH_1})
     foreach(WORD ${REPO_NAME_LIST})


### PR DESCRIPTION
See citra-emu/citra#3839 for more details.
The Dockerfiles can be found at [yuzu-emu/build-environments](https://github.com/yuzu-emu/build-environments).

**Original description**:
This is a WIP change to the current CI workflow.

In this PR, the builder no longer install packages during the building process, instead, the prebuilt Docker images from hub.docker.com/r/citraemu/build-environments are used.

This can ensure the consistency across the builds and frozen builds are absolutely frozen to the exact version required.

There are several problems in this PR. They will be ironed out very soon. In the mean time, you can stlll comment about your concerns against the change.

MinGW builds will have seperate commits to address the changes. (b/c it's unsure if we will use cross-compile to produce Windows (R) binaries)