### PR TITLE
kernel/svc: Clean up wait synchronization related functionality

### DIFF
--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -46,8 +46,7 @@ static void ThreadWakeupCallback(u64 thread_handle, [[maybe_unused]] s64 cycles_
 
     bool resume = true;
 
-    if (thread->GetStatus() == ThreadStatus::WaitSynchAny ||
-        thread->GetStatus() == ThreadStatus::WaitSynchAll ||
+    if (thread->GetStatus() == ThreadStatus::WaitSynch ||
         thread->GetStatus() == ThreadStatus::WaitHLEEvent) {
         // Remove the thread from each of its waiting objects' waitlists
         for (const auto& object : thread->GetWaitObjects()) {

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -150,8 +150,7 @@ void Process::PrepareForTermination() {
                 continue;
 
             // TODO(Subv): When are the other running/ready threads terminated?
-            ASSERT_MSG(thread->GetStatus() == ThreadStatus::WaitSynchAny ||
-                           thread->GetStatus() == ThreadStatus::WaitSynchAll,
+            ASSERT_MSG(thread->GetStatus() == ThreadStatus::WaitSynch,
                        "Exiting processes with non-waiting threads is currently unimplemented");
 
             thread->Stop();

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -424,7 +424,7 @@ static ResultCode GetProcessId(Core::System& system, u64* process_id, Handle han
 /// Default thread wakeup callback for WaitSynchronization
 static bool DefaultThreadWakeupCallback(ThreadWakeupReason reason, SharedPtr<Thread> thread,
                                         SharedPtr<WaitObject> object, std::size_t index) {
-    ASSERT(thread->GetStatus() == ThreadStatus::WaitSynchAny);
+    ASSERT(thread->GetStatus() == ThreadStatus::WaitSynch);
 
     if (reason == ThreadWakeupReason::Timeout) {
         thread->SetWaitSynchronizationResult(RESULT_TIMEOUT);
@@ -502,7 +502,7 @@ static ResultCode WaitSynchronization(Core::System& system, Handle* index, VAddr
     }
 
     thread->SetWaitObjects(std::move(objects));
-    thread->SetStatus(ThreadStatus::WaitSynchAny);
+    thread->SetStatus(ThreadStatus::WaitSynch);
 
     // Create an event to wake the thread up after the specified nanosecond delay has passed
     thread->WakeAfterDelay(nano_seconds);

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -518,16 +518,14 @@ static ResultCode CancelSynchronization(Core::System& system, Handle thread_hand
     LOG_TRACE(Kernel_SVC, "called thread=0x{:X}", thread_handle);
 
     const auto& handle_table = system.Kernel().CurrentProcess()->GetHandleTable();
-    const SharedPtr<Thread> thread = handle_table.Get<Thread>(thread_handle);
+    SharedPtr<Thread> thread = handle_table.Get<Thread>(thread_handle);
     if (!thread) {
         LOG_ERROR(Kernel_SVC, "Thread handle does not exist, thread_handle=0x{:08X}",
                   thread_handle);
         return ERR_INVALID_HANDLE;
     }
 
-    ASSERT(thread->GetStatus() == ThreadStatus::WaitSynchAny);
-    thread->SetWaitSynchronizationResult(ERR_SYNCHRONIZATION_CANCELED);
-    thread->ResumeFromWait();
+    thread->CancelWait();
     return RESULT_SUCCESS;
 }
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -101,8 +101,7 @@ void Thread::ResumeFromWait() {
     ASSERT_MSG(wait_objects.empty(), "Thread is waking up while waiting for objects");
 
     switch (status) {
-    case ThreadStatus::WaitSynchAll:
-    case ThreadStatus::WaitSynchAny:
+    case ThreadStatus::WaitSynch:
     case ThreadStatus::WaitHLEEvent:
     case ThreadStatus::WaitSleep:
     case ThreadStatus::WaitIPC:
@@ -143,7 +142,7 @@ void Thread::ResumeFromWait() {
 }
 
 void Thread::CancelWait() {
-    ASSERT(GetStatus() == ThreadStatus::WaitSynchAny);
+    ASSERT(GetStatus() == ThreadStatus::WaitSynch);
     SetWaitSynchronizationResult(ERR_SYNCHRONIZATION_CANCELED);
     ResumeFromWait();
 }

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -142,6 +142,12 @@ void Thread::ResumeFromWait() {
     ChangeScheduler();
 }
 
+void Thread::CancelWait() {
+    ASSERT(GetStatus() == ThreadStatus::WaitSynchAny);
+    SetWaitSynchronizationResult(ERR_SYNCHRONIZATION_CANCELED);
+    ResumeFromWait();
+}
+
 /**
  * Resets a thread context, making it ready to be scheduled and run by the CPU
  * @param context Thread context to reset

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -164,10 +164,16 @@ public:
         return tls_memory;
     }
 
-    /**
-     * Resumes a thread from waiting
-     */
+    /// Resumes a thread from waiting
     void ResumeFromWait();
+
+    /// Cancels a waiting operation that this thread may or may not be within.
+    ///
+    /// When the thread is within a waiting state, this will set the thread's
+    /// waiting result to signal a canceled wait. The function will then resume
+    /// this thread.
+    ///
+    void CancelWait();
 
     /**
      * Schedules an event to wake up the specified thread after the specified delay

--- a/src/core/hle/kernel/wait_object.cpp
+++ b/src/core/hle/kernel/wait_object.cpp
@@ -38,8 +38,7 @@ SharedPtr<Thread> WaitObject::GetHighestPriorityReadyThread() {
         const ThreadStatus thread_status = thread->GetStatus();
 
         // The list of waiting threads must not contain threads that are not waiting to be awakened.
-        ASSERT_MSG(thread_status == ThreadStatus::WaitSynchAny ||
-                       thread_status == ThreadStatus::WaitSynchAll ||
+        ASSERT_MSG(thread_status == ThreadStatus::WaitSynch ||
                        thread_status == ThreadStatus::WaitHLEEvent,
                    "Inconsistent thread statuses in waiting_threads");
 
@@ -49,10 +48,10 @@ SharedPtr<Thread> WaitObject::GetHighestPriorityReadyThread() {
         if (ShouldWait(thread.get()))
             continue;
 
-        // A thread is ready to run if it's either in ThreadStatus::WaitSynchAny or
-        // in ThreadStatus::WaitSynchAll and the rest of the objects it is waiting on are ready.
+        // A thread is ready to run if it's either in ThreadStatus::WaitSynch
+        // and the rest of the objects it is waiting on are ready.
         bool ready_to_run = true;
-        if (thread_status == ThreadStatus::WaitSynchAll) {
+        if (thread_status == ThreadStatus::WaitSynch) {
             ready_to_run = thread->AllWaitObjectsReady();
         }
 
@@ -68,33 +67,35 @@ SharedPtr<Thread> WaitObject::GetHighestPriorityReadyThread() {
 void WaitObject::WakeupWaitingThread(SharedPtr<Thread> thread) {
     ASSERT(!ShouldWait(thread.get()));
 
-    if (!thread)
+    if (!thread) {
         return;
+    }
 
-    if (!thread->IsSleepingOnWaitAll()) {
-        Acquire(thread.get());
-    } else {
+    if (thread->IsSleepingOnWait()) {
         for (const auto& object : thread->GetWaitObjects()) {
             ASSERT(!object->ShouldWait(thread.get()));
             object->Acquire(thread.get());
         }
+    } else {
+        Acquire(thread.get());
     }
 
     const std::size_t index = thread->GetWaitObjectIndex(this);
 
-    for (const auto& object : thread->GetWaitObjects())
+    for (const auto& object : thread->GetWaitObjects()) {
         object->RemoveWaitingThread(thread.get());
+    }
     thread->ClearWaitObjects();
 
     thread->CancelWakeupTimer();
 
     bool resume = true;
-
-    if (thread->HasWakeupCallback())
+    if (thread->HasWakeupCallback()) {
         resume = thread->InvokeWakeupCallback(ThreadWakeupReason::Signal, thread, this, index);
-
-    if (resume)
+    }
+    if (resume) {
         thread->ResumeFromWait();
+    }
 }
 
 void WaitObject::WakeupAllWaitingThreads() {

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -227,8 +227,7 @@ QString WaitTreeThread::GetText() const {
     case Kernel::ThreadStatus::WaitIPC:
         status = tr("waiting for IPC reply");
         break;
-    case Kernel::ThreadStatus::WaitSynchAll:
-    case Kernel::ThreadStatus::WaitSynchAny:
+    case Kernel::ThreadStatus::WaitSynch:
         status = tr("waiting for objects");
         break;
     case Kernel::ThreadStatus::WaitMutex:
@@ -269,8 +268,7 @@ QColor WaitTreeThread::GetColor() const {
         return QColor(Qt::GlobalColor::darkRed);
     case Kernel::ThreadStatus::WaitSleep:
         return QColor(Qt::GlobalColor::darkYellow);
-    case Kernel::ThreadStatus::WaitSynchAll:
-    case Kernel::ThreadStatus::WaitSynchAny:
+    case Kernel::ThreadStatus::WaitSynch:
     case Kernel::ThreadStatus::WaitMutex:
     case Kernel::ThreadStatus::WaitCondVar:
     case Kernel::ThreadStatus::WaitArb:
@@ -325,10 +323,9 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeThread::GetChildren() const {
         list.push_back(std::make_unique<WaitTreeText>(tr("not waiting for mutex")));
     }
 
-    if (thread.GetStatus() == Kernel::ThreadStatus::WaitSynchAny ||
-        thread.GetStatus() == Kernel::ThreadStatus::WaitSynchAll) {
+    if (thread.GetStatus() == Kernel::ThreadStatus::WaitSynch) {
         list.push_back(std::make_unique<WaitTreeObjectList>(thread.GetWaitObjects(),
-                                                            thread.IsSleepingOnWaitAll()));
+                                                            thread.IsSleepingOnWait()));
     }
 
     list.push_back(std::make_unique<WaitTreeCallstack>(thread));


### PR DESCRIPTION
Previously we had a two wait synchronization thread status types (we should only have one wait type, but that's a separate issue altogether). This is \**big sigh*\* yet another holdover from Citra. In particular, this was necessary for `svcWaitSynchronization1` and `svcWaitSynchronizationN` supervisor calls. On the Switch, however, we only have one supervisor call–`svcWaitSynchronization`.

This removes the extra type and unifies code to use the one wait type. This also relocates the svcCancelSynchronization behavior to be a part of the thread interface, as future changes will alter this to be more correct (which requires access to thread internals).