### PR TITLE
lr: Add command handler skeletons for Open*LocationResolver

### DIFF
--- a/src/core/hle/service/ncm/ncm.cpp
+++ b/src/core/hle/service/ncm/ncm.cpp
@@ -45,6 +45,25 @@ private:
     FileSys::StorageId storage;
 };
 
+class IRegisteredLocationResolver final : public ServiceFramework<IRegisteredLocationResolver> {
+public:
+    explicit IRegisteredLocationResolver() : ServiceFramework{"IRegisteredLocationResolver"} {
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "ResolveProgramPath"},
+            {1, nullptr, "RegisterProgramPath"},
+            {2, nullptr, "UnregisterProgramPath"},
+            {3, nullptr, "RedirectProgramPath"},
+            {4, nullptr, "ResolveHtmlDocumentPath"},
+            {5, nullptr, "RegisterHtmlDocumentPath"},
+            {6, nullptr, "UnregisterHtmlDocumentPath"},
+            {7, nullptr, "RedirectHtmlDocumentPath"},
+            {8, nullptr, ""},
+        };
+
+        RegisterHandlers(functions);
+    }
+};
+
 public:
     explicit LocationResolver() : ServiceFramework{"lr"} {
 class LR final : public ServiceFramework<LR> {
@@ -72,6 +91,14 @@ private:
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface(std::make_shared<ILocationResolver>(id));
+    }
+
+    void OpenRegisteredLocationResolver(Kernel::HLERequestContext& ctx) {
+        LOG_DEBUG(Service_NCM, "called");
+
+        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushIpcInterface(std::make_shared<IRegisteredLocationResolver>());
     }
 
 };

--- a/src/core/hle/service/ncm/ncm.cpp
+++ b/src/core/hle/service/ncm/ncm.cpp
@@ -11,8 +11,45 @@
 namespace Service::NCM {
 
 class LocationResolver final : public ServiceFramework<LocationResolver> {
+class ILocationResolver final : public ServiceFramework<ILocationResolver> {
+public:
+    explicit ILocationResolver(FileSys::StorageId id)
+        : ServiceFramework{"ILocationResolver"}, storage(id) {
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "ResolveProgramPath"},
+            {1, nullptr, "RedirectProgramPath"},
+            {2, nullptr, "ResolveApplicationControlPath"},
+            {3, nullptr, "ResolveApplicationHtmlDocumentPath"},
+            {4, nullptr, "ResolveDataPath"},
+            {5, nullptr, "RedirectApplicationControlPath"},
+            {6, nullptr, "RedirectApplicationHtmlDocumentPath"},
+            {7, nullptr, "ResolveApplicationLegalInformationPath"},
+            {8, nullptr, "RedirectApplicationLegalInformationPath"},
+            {9, nullptr, "Refresh"},
+            {10, nullptr, "RedirectProgramPath2"},
+            {11, nullptr, "Refresh2"},
+            {12, nullptr, "DeleteProgramPath"},
+            {13, nullptr, "DeleteApplicationControlPath"},
+            {14, nullptr, "DeleteApplicationHtmlDocumentPath"},
+            {15, nullptr, "DeleteApplicationLegalInformationPath"},
+            {16, nullptr, ""},
+            {17, nullptr, ""},
+            {18, nullptr, ""},
+            {19, nullptr, ""},
+        };
+
+        RegisterHandlers(functions);
+    }
+
+private:
+    FileSys::StorageId storage;
+};
+
 public:
     explicit LocationResolver() : ServiceFramework{"lr"} {
+class LR final : public ServiceFramework<LR> {
+public:
+    explicit LR() : ServiceFramework{"lr"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "OpenLocationResolver"},
@@ -24,6 +61,19 @@ public:
 
         RegisterHandlers(functions);
     }
+
+private:
+    void OpenLocationResolver(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto id = rp.PopRaw<FileSys::StorageId>();
+
+        LOG_DEBUG(Service_NCM, "called, id={:02X}", static_cast<u8>(id));
+
+        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushIpcInterface(std::make_shared<ILocationResolver>(id));
+    }
+
 };
 
 class NCM final : public ServiceFramework<NCM> {


### PR DESCRIPTION
- Implements LR service commands 0-2, which simply take no args and returns an object of the appropriate type.
- Rename LocationResolver to LR to prevent confusion with ILocationResolver.
- Add command names for ILocationResolver, IRegisteredLocationResolver, IAddOnContentLocationResolver.