### PR TITLE
externals: Update dynarmic to master

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -7,16 +7,16 @@ include(DownloadExternals)
 add_library(catch-single-include INTERFACE)
 target_include_directories(catch-single-include INTERFACE catch/single_include)
 
+# libfmt
+add_subdirectory(fmt)
+add_library(fmt::fmt ALIAS fmt)
+
 # Dynarmic
 if (ARCHITECTURE_x86_64)
     set(DYNARMIC_TESTS OFF)
     set(DYNARMIC_NO_BUNDLED_FMT ON)
     add_subdirectory(dynarmic)
 endif()
-
-# libfmt
-add_subdirectory(fmt)
-add_library(fmt::fmt ALIAS fmt)
 
 # getopt
 if (MSVC)


### PR DESCRIPTION
Better instruction support has been added since the last update.

the (quite long) changelog:

```
f5233bfc constant_propagation_pass: Fold EOR operations
be3ba545 ir/value: Add member function to check whether or not all bits of a contained value are set
14297804 constant_propagation_pass: Fold AND operations
0d1f9841 constant_propagation_pass: Fold OR operations
7868411d constant_propagation_pass: Fold NOT operations
bcb947eb externals: Update fmt to 5.2.1
49041cb4 Squashed 'externals/fmt/' changes from 135ab5cf..3e75ad98
d3263fd6 ir/value: Add an IsZero() member function to Value's interface
01aa5096 ir/value: Add a GetImmediateAsS64() function
8f262d48 ir/value: Add IsSignedImmediate() and IsUnsignedImmediate() functions to Value's interface
e0eec323 constant_propagation_pass: Combine zero-extension folding code into its own function
f47c5e4e constant_propagation_pass: Fold ZeroExtend{Type}ToLong opcodes if possible
4f03ca65 constant_propagation_pass: Fold SignExtend{Type}ToWord opcodes if possible
f1d907c9 constant_propagation_pass: Fold SignExtend{Type}ToLong opcodes if possible
62a2ba79 a64: Add ARMv8.4+ instructions encodings to the encoding table
a0ea3a56 constant_propagation_pass: Fold Mul32 and Mul64 cases where applicable
a5d1d27c constant_propagation_pass: deduplicate common 32/64 bit checking for results in folding functions
b55b7a5c constant_propagation_pass: Fold division operations where applicable
2c8c83c2 constant_propagation_pass: Add 64-bit variants of shifts to the pass
1c0bed95 externals: Update catch to v2.4.1
05a2dbfc Switch boost::optional to std::optional
a695635e Add missing include guards
4295f727 Enable ninja and ccache on travis (#413)
af96812b Provide justification for always-true condition (#412)
333d3b73 IR: Implement FPVectorMulX
ea0c1919 A64: Implement FMULX, vector single-precision and double-precision variant
e9acec20 A64: Implement FMULX (by element), single and double precision variants
b7812371 emit_x64_vector_floating_point: AVX && DN implementation of EmitFPVectorMulX
d7af9903 fuzz_util: Simplify result return in InstructionGenerator's Generate() function
4763bb70 a64_emit_x64: Convert std::vector instances in GenFastmemFallbacks() to std::array
54aac805 a64_emit_x64: Make constness of loop elements explicit within GenFastmemFallbacks()
4e4e1d31 dynarmic_tests: Remove inconsistent spacing
75b8308c common: Move byte swapping functions to bit_utils.h
043cace4 constant_propagation_pass: Handle folding for Least/MostSignificant{Bit, Byte, Half, Word} opcodes
70a392af constant_propagation_pass: Fold byte reversal opcodes where applicable
91e82bb6 a32_unicorn: Silence a truncation warning within UnmappedMemoryHook()
6e54c8f8 tests/.../vfp_helper: Amend use of the comma operator
69eec299 externals: Update catch to v2.5.0
23eeb5eb Correct README (`jit` to `cpu`)
735e6c58 Reduce Inst::NumArgs calls / opcodes: Prefer std::vector to std::map (#425)
539fda53 frontend/A64/ir_emitter: Mark PC() and AlignPC() as const qualified member functions
67c39ec7 frontend/A32/ir_emitter: Mark PC() and AlignPC() as const-qualified member functions
7593eadc tests/A32/fuzz_arm: Remove unused Unix-specific include
18f5916e common: Remove address_range.h
cc67312f Squashed 'externals/xbyak/' changes from 42462ef9..f72646a7
ab4b8216 externals/xbyak: Update xbyak to 5.76
0be97f3e block_of_code: Replace cast with [[maybe_unused]] in DoesCpuSupport()
82be7280 backend/x64/a32_interface: Mark Context move constructor and move assignment as noexcept
22c946eb externals: Update Catch to 2.6.1
c63dfa74 tests/unicorn_emu: Add getters and setters for PC/SP
a71a2b3b translate_arm/branch: Invert conditionals where applicable
b613045b translate_arm/data_processing: Invert conditionals where applicable
ef37cebb translate_arm/exception_generating: Invert conditionals where applicable
3706f580 translate_arm/extension: Invert conditionals where applicable
83daf1c5 translate_arm/load_store: Invert conditionals where applicable
e71e5606 translate_arm/misc: Invert conditionals where applicable
3b1133ad translate_arm/multiply: Invert conditionals where applicable
b970daf9 translate_arm/packing: Invert conditionals where applicable
a6a9fbcc translate_arm/parallel: Invert conditionals where applicable
55fff7b2 translate_arm/reversal: Invert conditionals where applicable
18276e7c translate_arm/saturated: Invert conditionals where applicable
6a851dc4 translate_arm/status_register_access: Invert conditionals where applicable
797fca01 translate_arm/synchronization: Invert conditionals where applicable
c1f4241c translate_arm/vfp2: Invert conditionals where applicable
02a70f3b translate_arm/coprocessor: Minor tidying up
5c11851f tests/a32/testenv: Make A32TestEnv's code_mem member a std::vector
fc111fda A64: Implement LDNP/STNP
ccc3d525 A64: Implement scalar double/single precision FMULX (by element)
0d9cca04 A64: Implement FCADD
9f556b84 A64: Implement FCMLA
78742a6a common/fp/op: Add operations for floating-point reciprocal exponents
7b004e72 frontend/ir/ir_emitter: Add opcodes for floating point reciprocal exponents
dae46f01 A64: Implement FRECPX (single, double precision)
f01fca3b common/fp: Remove unnecessary includes
e042c63d common/bit_util: Make a few functions as constexpr
7ae37bcc frontend/ir/microinstruction: Add missing cases for FPRecipExponent{32,64} for ReadsFromAndWritesToFPSRCumulativeExceptionBits()
9426cc97 common/fp/op: Add FP conversion functions
36eba636 A64: Rearrange flag format/manipulation instructions
d365d408 A64: Fall back to interpreting for FCADD and FCMLA half-precision variants
3e5a52cc frontend/ir: Add opcodes for vector square roots
16e6a8f3 A64: Implement single and double-precision vector variant of FSQRT
a3eeb334 A64: Implement SQSHL (register)'s scalar variant
4429a0c8 A64: Implement UQSHL (register)'s scalar variant
f44cafe3 frontend/ir/ir_emitter: Alter parameters of FPDoubleToSingle() and FPSingleToDouble() to pass along desired rounding mode
e3ba0797 A64: Implement the scalar version of FCVTXN
cdfdd95e A64: Implement the vector version of FCVTXN
27af30d7 ir: Add A64-specific opcodes for getting and setting raw NZCV values
9cd84c51 A64: Implement CFINV
080d163d A64: Implement RMIF
5b66ae2a A64: Implement AXFlag and XAFlag
8d115ae8 ir_opt/a64_get_set_elimination_pass: Add handling for NZCV raw get and set operations
fb3847b0 A64: Amend prototypes of some SIMD scalar shift by immediate opcodes
203678bd A64: Implement SQSHRN, SQSHRUN, and UQSHRN's scalar variants
d1a1434a common/fp/info: Add specialization of FPInfo for half-precision floating point
deca5e5d common/fp/unpacked: Add FPUnpackCV
6dad7795 common/fp/unpacked: Add FPRoundCV
9c96c4c9 common/fp/unpacked: Adjust FPUnpack to operate like ARM pseudocode
74e230de common/fp/unpacked: Handle half-precision unpacking in FPUnpackBase
2f7f75ff common/fp/unpacked: Add half-precision instantiation of FPRoundBase
1b66e430 common/fp/process_nan: Add half-precision instantiations for NaN processing functions
5117997c common/fp/unpacked: Correct edge-cases within FPUnpack for half-precision floating point
1e093390 common/fp/op/FPRecipExponent: Add half-precision floating point specialization
8036a54a frontend/ir/value: Add U16U32U64 type to represent floating point types
db67a422 frontend/ir/ir_emitter: Amend FPRecipExponent to handle half-precision floating point
f8ad1819 A64: Implement FRECPX's half-precision floating point variant
b4ca6b67 A64: Implement SQRDMULH's by-index vector variant
328211b0 A64: Implement SQDMULL{2}'s by-element variant
996a6186 simd_vector_x_indexed_element: Deduplicate index and Vm operand construction
32388648 simd_scalar_x_indexed_element: Factor out index and Vm argument construction
2d78390d A64: Implement SQDMULL{2}'s scalar indexed element variant
5c6becc4 A64: Implement SQRDMULH's scalar indexed element variant
7627fa38 A64: Enable FMOV (general) for half-precision floating point
fd71df5e frontend/ir_emitter: Add half-precision variant of FPNeg
b772cb7c A64: Handle half-precision floating point in scalar FNEG
c75f7378 frontend/ir_emitter: Add half-precision variant of FPAbs
5196e947 A64: Handle half-precision floating point in scalar FABS
d59cff53 A64: Handle half-precision floating point in scalar FMOV
29e1a024 common/fp/op/FPConvert: Add half-precision instantiations to FPConvert
36e739ba common/fp/op/FPConvert: Amend off-by one in double NaN case in FPConvertNaN
f74c9dad common/fp/unpacked: Amend behavior of FPUnpackCV
eb09ae27 frontend/ir_emitter: Add half->{single, double} and {double, single}->half conversion opcodes
ede3d728 A64: Enable FCVT floating-point conversions for half-precision
d4d64219 A64: Handle half-precision floating point in FCVTN
f12b0f92 A64: Handle half-precision floating point in FCVTL
16a40b3b backend/x64: Expose FPCR in EmitContext instead of its subcomponents
59887e8b emit_x64_floating_point: Factor out ConvertRoundingModeToX64Immediate
2a5b4f49 emit_x64_floating_point: F16C implementation of FPHalfToSingle and FPHalfToDouble
a1f642f8 emit_x64_floating_point: F16C implementation of FPSingleToHalf
12b78391 externals: Update catch to 2.7.0
19571805 Squashed 'externals/xbyak/' changes from f72646a7..4a6fac8a
64bbe05f Squashed 'externals/fmt/' changes from 3e75ad98..9e554999
8f923106 externals/xbyak: Update xbyak to 5.77
89581c0c externals/fmt: Update fmt to 5.3.0
f4d63ff0 common/fp/op/FPRecipExponent: Prevent undefined behavior from shifting a negative value
06ac561e backend/x64/emit_x64_vector: Prevent undefined behavior within VectorSignedSaturatedShiftLeft
0bcc47a7 README: Update README
fc729bee A64: Implement scalar variant of SQSHL (immediate)
24479ecb simd_scalar_shift_by_immediate: Migrate SQSHL implementation to file-scope function
27695722 A64: Implement UQSHL (immediate)'s scalar variant
b7a76d69 simd_scalar_shift_by_immediate: Change UnallocatedEncoding()  path in SaturatingShiftLeft to ReservedValue()
fd4fa208 CMakeLists: Allow importing dynarmic build trees into other CMake projects
06e7e9fb A64: Implement FCMLA's indexed element variant
0dca81d2 A64: Handle reserved instruction cases more specifically where applicable
e299e926 ir_opt/a32_constant_memory_reads_pass: Apply const where applicable to locals
38977fac ir_opt/a32_get_set_elimination_pass: Mark local variables as const where applicable
d02eef2f ir_opt/a64_callback_config_pass: Mark locals as const where applicable
e244bf4f ir_opt/verification_pass: Mark locals as const where applicable
d75af9d0 A64/impl: Reorganize peculiar void use in V_scalar
a5ca8722 general: Replace unreachable-imitating assertions with UNREACHABLE()
f5840633 A64: Implement SQRDMULH's scalar vector variant
57629276 general: Mark hash functions as noexcept
31867874 frontend/ir_emitter: Add opcodes for signed saturated left shifts with unsigned saturation
508c77c3 A64: Implement SQSHLU's vector variant
be3fc0f9 A64: Implement SQSHLU's scalar variant
94ac9bec load_store_*: Make bracing consistent and variables const where applicable
2ae0c480 fp/op/FPMulAdd: Add half-precision floating-point specialization
13b41525 frontend/ir_emitter: Add half-precision opcode for FPMulAdd
0eb6412c A64: Enable half-precision floating point variants of FP data-processing three register instructions
278c7ae7 ir/frontend: Add half-precision opcode for FPVectorMulAdd
894169dc A64: Implement half-precision vector variants of FMLA/FMLS
caaa04cb A64: Implement FMLA/FMLS' half-precision scalar indexed variants
a935f355 A64: Implement FMLA/FMLS' half-precision vector indexed variants
22189122 A64/location_descriptor: Ensure FZ16 is included in the FPCR mask
590388b9 fp/op/FPRoundInt: Add half-precision specialization of FPRoundInt
82437051 frontend/ir_emitter: Add half-precision variant of FPRoundInt
722daae0 frontend/ir_emitter: Add half-precision variant of FPVectorRoundInt
95a96b32 frontend/microinstruction: Add FPVectorRoundInt types to ReadsFromAndWritesToFPSRCumulativeExceptionBits()
7c5cc15f A64: Enable half-precision variants of floating-point FRINT* variants
f8fb1028 A64: Enable half-precision vector FRINT* variants
9c9087ea common/fp/op/FPRSqrtEstimate: Add half-precision specialization for FPRSqrtEstimate
f1e55663 frontend/ir_emitter: Add half-precision opcode variant for FPRSqrtEstimate
5edbb415 frontend/ir_emitter: Add half-precision opcode variant for FPVectorRSqrtEstimate
0f677744 A64: Implement half-precision variant of FRSQRTE's scalar variant
e35352b6 A64: Implement half-precision variant of FRSQRTE's vector variant
408bbfb7 common/fp/op: Add half-precision specialization for FPRecipStepFused
065143b3 frontend/ir_emitter: Add half-precision opcode for FPRecipStepFused
4ae0a27e frontend/ir_emitter: Add half-precision opcode for FPVectorRecipStepFused
e93161e2 common/fp/op: Add half-precision specialization for FPRecipEstimate
1615ba0a frontend/ir_emitter: Add half-precision opcode for FPRecipEstimate
c55db968 frontend/ir_emitter: Add half-precision opcode for FPVectorRecipEstimate
abcf1a6e A64: Implement half-precision scalar variant of FRECPS
4519e464 A64: Implement half-precision vector variant of FRECPS
4b3f5b8a A64: Implement half-precision scalar variant of FRECPE
b67cc722 A64: Implement half-precision vector variant of FRECPE
cff43947 common/fp/op/FPRSqrtStepFused: Add half-precision specialization for FPRSqrtStepFused
db4d1347 frontend/ir_emitter: Add half-precision opcode variant of FPRSqrtStepFused
793b3b38 frontend/ir_emitter: Add half-precision opcode variant of FPVectorRSqrtStepFused
6f7a370c A64: Implement FRSQRTS' half-precision scalar variant
28e0f4fe A64: Implement FRSQRTS' half-precision vector variant
6c7de6c9 common/fp/op/FPToFixed: Add half-precision specialization of FPToFixed
1d3fc42b frontend/ir_emitter: Add half-precision->fixed-point opcodes
18969224 frontend/ir/microinstruction: Add missing fixed-point opcodes to ReadsFromAndWritesToFPSRCumulativeExceptionBits()
2c2fdb43 common/fp/info: Make half-precision info struct functions return correctly sized types
db78e2f3 ir/block: Default ctor and dtor in the cpp file
f4d0a09b ir/basic_block: Forward declare headers where applicable
105d4ed9 A64: Handle half-precision variants of FP->Fixed-point instructions
b0bc8106 Squashed 'externals/xbyak/' changes from 4a6fac8a..73ac5866
731aa2df externals: Update xbyak to 73ac586
732215d6 emit_x64_data_processing: Remove INVALID_REG
fe7c21b6 frontend/ir/cond: Remove unused invert() function
66e3b1c1 common/fp/op/FPConvert: Remove unnecessary casts in FPConvert()
127efc59 A32/translate_thumb: Clean up formatting
ad7d439e A32: Fuzz instructions using unicorn
bce91ff0 dynarmic_tests: Remove skyeye interpreter
0d376456 fuzz_arm: Tidy up existing tests
43422bc1 travis: Amend build parameters
79af6c11 a32_unicorn: Silence PC value assertions
9110e70b travis: Re-enable A32 tests
c62b8229 A32: Implement ARM-mode SDIV/UDIV
3b7b50b0 A32: Implement ARM-mode RBIT
20e499d8 A32: Implement ARM-mode BFC
745dfd50 A32: Implement ARM-mode BFI
42964964 A32: Implement ARM-mode UBFX
b4429e7f A32: Implement ARM-mode SBFX
adf04f6f A32: Implement ARM-mode MOVT
23571f99 A32: Implement ARM-mode MLS
c32a10ca a32/fuzz_arm: Use same fuzzing mechanism as AArch64
f3679e62 A32: Implement barrier instructions introduced in ARMv7
6201b0e3 A32/disassembler_arm: Mark utility functions as static where applicable
4ed37614 frontend: Move imm.h to the top-level directory of the frontends
f17bf4a3 A32/barrier: Correct PC assignment within ISB
f6a4aaef externals: Update Catch to 2.7.2
```