### PR TITLE
core/frontend/emu_window: Make GraphicsContext's destructor virtual

### DIFF
--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -10,6 +10,8 @@
 
 namespace Core::Frontend {
 
+GraphicsContext::~GraphicsContext() = default;
+
 class EmuWindow::TouchState : public Input::Factory<Input::TouchDevice>,
                               public std::enable_shared_from_this<TouchState> {
 public:

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -19,6 +19,8 @@ namespace Core::Frontend {
  */
 class GraphicsContext {
 public:
+    virtual ~GraphicsContext();
+
     /// Makes the graphics context current for the caller thread
     virtual void MakeCurrent() = 0;
 


### PR DESCRIPTION
This class is used in a polymorphic context, so destruction of the context will lead to undefined behavior if the destructor isn't virtual.