### PR TITLE
src/CMakeLists: Add /Zc:externConstexpr to the MSVC build flags

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,15 +21,25 @@ if (MSVC)
     # Ensure that projects build with Unicode support.
     add_definitions(-DUNICODE -D_UNICODE)
 
-    # /W3 - Level 3 warnings
-    # /MP - Multi-threaded compilation
-    # /Zi - Output debugging information
-    # /Zo - enhanced debug info for optimized builds
-    # /permissive- - enables stricter C++ standards conformance checks
-    # /EHsc - C++-only exception handling semantics
-    # /Zc:throwingNew - let codegen assume `operator new` will never return null
-    # /Zc:inline - let codegen omit inline functions in object files
-    add_compile_options(/W3 /MP /Zi /Zo /permissive- /EHsc /std:c++latest /Zc:throwingNew,inline)
+    # /W3             - Level 3 warnings
+    # /MP             - Multi-threaded compilation
+    # /Zi             - Output debugging information
+    # /Zo             - Enhanced debug info for optimized builds
+    # /permissive-    - Enables stricter C++ standards conformance checks
+    # /EHsc           - C++-only exception handling semantics
+    # /Zc:inline      - Let codegen omit inline functions in object files
+    # /Zc:throwingNew - Let codegen assume `operator new` (without std::nothrow) will never return null
+    add_compile_options(
+        /W3
+        /MP
+        /Zi
+        /Zo
+        /permissive-
+        /EHsc
+        /std:c++latest
+        /Zc:inline
+        /Zc:throwingNew
+    )
 
     # /GS- - No stack buffer overflow checks
     add_compile_options("$<$<CONFIG:Release>:/GS->")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,14 +21,15 @@ if (MSVC)
     # Ensure that projects build with Unicode support.
     add_definitions(-DUNICODE -D_UNICODE)
 
-    # /W3             - Level 3 warnings
-    # /MP             - Multi-threaded compilation
-    # /Zi             - Output debugging information
-    # /Zo             - Enhanced debug info for optimized builds
-    # /permissive-    - Enables stricter C++ standards conformance checks
-    # /EHsc           - C++-only exception handling semantics
-    # /Zc:inline      - Let codegen omit inline functions in object files
-    # /Zc:throwingNew - Let codegen assume `operator new` (without std::nothrow) will never return null
+    # /W3                 - Level 3 warnings
+    # /MP                 - Multi-threaded compilation
+    # /Zi                 - Output debugging information
+    # /Zo                 - Enhanced debug info for optimized builds
+    # /permissive-        - Enables stricter C++ standards conformance checks
+    # /EHsc               - C++-only exception handling semantics
+    # /Zc:externConstexpr - Allow extern constexpr variables to have external linkage, like the standard mandates
+    # /Zc:inline          - Let codegen omit inline functions in object files
+    # /Zc:throwingNew     - Let codegen assume `operator new` (without std::nothrow) will never return null
     add_compile_options(
         /W3
         /MP
@@ -37,6 +38,7 @@ if (MSVC)
         /permissive-
         /EHsc
         /std:c++latest
+        /Zc:externConstexpr
         /Zc:inline
         /Zc:throwingNew
     )


### PR DESCRIPTION
The C++ standard allows constexpr variables declared with the extern keyword to have external linkage. Previously MSVC wasn't abiding by this. This just makes the compiler more standards compliant during builds. Unfortunately, MSVC doesn't enable this as part of `/permissive-`

More info on this flag can be seen [here](https://docs.microsoft.com/en-us/cpp/build/reference/zc-externconstexpr?view=vs-2019).