### PR TITLE
configuration/config: Move config loading and saving to functions based off groups

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -230,55 +230,64 @@ void Config::ReadPlayerValues() {
     for (std::size_t p = 0; p < Settings::values.players.size(); ++p) {
         auto& player = Settings::values.players[p];
 
-        player.connected = ReadSetting(QString("player_%1_connected").arg(p), false).toBool();
+        player.connected =
+            ReadSetting(QStringLiteral("player_%1_connected").arg(p), false).toBool();
 
         player.type = static_cast<Settings::ControllerType>(
             qt_config
-                ->value(QString("player_%1_type").arg(p),
+                ->value(QStringLiteral("player_%1_type").arg(p),
                         static_cast<u8>(Settings::ControllerType::DualJoycon))
                 .toUInt());
 
         player.body_color_left = qt_config
-                                     ->value(QString("player_%1_body_color_left").arg(p),
+                                     ->value(QStringLiteral("player_%1_body_color_left").arg(p),
                                              Settings::JOYCON_BODY_NEON_BLUE)
                                      .toUInt();
         player.body_color_right = qt_config
-                                      ->value(QString("player_%1_body_color_right").arg(p),
+                                      ->value(QStringLiteral("player_%1_body_color_right").arg(p),
                                               Settings::JOYCON_BODY_NEON_RED)
                                       .toUInt();
         player.button_color_left = qt_config
-                                       ->value(QString("player_%1_button_color_left").arg(p),
+                                       ->value(QStringLiteral("player_%1_button_color_left").arg(p),
                                                Settings::JOYCON_BUTTONS_NEON_BLUE)
                                        .toUInt();
-        player.button_color_right = qt_config
-                                        ->value(QString("player_%1_button_color_right").arg(p),
-                                                Settings::JOYCON_BUTTONS_NEON_RED)
-                                        .toUInt();
+        player.button_color_right =
+            qt_config
+                ->value(QStringLiteral("player_%1_button_color_right").arg(p),
+                        Settings::JOYCON_BUTTONS_NEON_RED)
+                .toUInt();
 
         for (int i = 0; i < Settings::NativeButton::NumButtons; ++i) {
-            std::string default_param = InputCommon::GenerateKeyboardParam(default_buttons[i]);
-            player.buttons[i] =
-                qt_config
-                    ->value(QString("player_%1_").arg(p) + Settings::NativeButton::mapping[i],
-                            QString::fromStdString(default_param))
-                    .toString()
-                    .toStdString();
-            if (player.buttons[i].empty())
-                player.buttons[i] = default_param;
+            const std::string default_param =
+                InputCommon::GenerateKeyboardParam(default_buttons[i]);
+            auto& player_buttons = player.buttons[i];
+
+            player_buttons = qt_config
+                                 ->value(QStringLiteral("player_%1_").arg(p) +
+                                             QString::fromUtf8(Settings::NativeButton::mapping[i]),
+                                         QString::fromStdString(default_param))
+                                 .toString()
+                                 .toStdString();
+            if (player_buttons.empty()) {
+                player_buttons = default_param;
+            }
         }
 
         for (int i = 0; i < Settings::NativeAnalog::NumAnalogs; ++i) {
-            std::string default_param = InputCommon::GenerateAnalogParamFromKeys(
+            const std::string default_param = InputCommon::GenerateAnalogParamFromKeys(
                 default_analogs[i][0], default_analogs[i][1], default_analogs[i][2],
                 default_analogs[i][3], default_analogs[i][4], 0.5f);
-            player.analogs[i] =
-                qt_config
-                    ->value(QString("player_%1_").arg(p) + Settings::NativeAnalog::mapping[i],
-                            QString::fromStdString(default_param))
-                    .toString()
-                    .toStdString();
-            if (player.analogs[i].empty())
-                player.analogs[i] = default_param;
+            auto& player_analogs = player.analogs[i];
+
+            player_analogs = qt_config
+                                 ->value(QStringLiteral("player_%1_").arg(p) +
+                                             QString::fromUtf8(Settings::NativeAnalog::mapping[i]),
+                                         QString::fromStdString(default_param))
+                                 .toString()
+                                 .toStdString();
+            if (player_analogs.empty()) {
+                player_analogs = default_param;
+            }
         }
     }
 
@@ -290,36 +299,45 @@ void Config::ReadPlayerValues() {
 }
 
 void Config::ReadDebugValues() {
-    Settings::values.debug_pad_enabled = ReadSetting("debug_pad_enabled", false).toBool();
+    Settings::values.debug_pad_enabled =
+        ReadSetting(QStringLiteral("debug_pad_enabled"), false).toBool();
+
     for (int i = 0; i < Settings::NativeButton::NumButtons; ++i) {
-        std::string default_param = InputCommon::GenerateKeyboardParam(default_buttons[i]);
-        Settings::values.debug_pad_buttons[i] =
-            qt_config
-                ->value(QString("debug_pad_") + Settings::NativeButton::mapping[i],
-                        QString::fromStdString(default_param))
-                .toString()
-                .toStdString();
-        if (Settings::values.debug_pad_buttons[i].empty())
-            Settings::values.debug_pad_buttons[i] = default_param;
+        const std::string default_param = InputCommon::GenerateKeyboardParam(default_buttons[i]);
+        auto& debug_pad_buttons = Settings::values.debug_pad_buttons[i];
+
+        debug_pad_buttons = qt_config
+                                ->value(QStringLiteral("debug_pad_") +
+                                            QString::fromUtf8(Settings::NativeButton::mapping[i]),
+                                        QString::fromStdString(default_param))
+                                .toString()
+                                .toStdString();
+        if (debug_pad_buttons.empty()) {
+            debug_pad_buttons = default_param;
+        }
     }
 
     for (int i = 0; i < Settings::NativeAnalog::NumAnalogs; ++i) {
-        std::string default_param = InputCommon::GenerateAnalogParamFromKeys(
+        const std::string default_param = InputCommon::GenerateAnalogParamFromKeys(
             default_analogs[i][0], default_analogs[i][1], default_analogs[i][2],
             default_analogs[i][3], default_analogs[i][4], 0.5f);
-        Settings::values.debug_pad_analogs[i] =
-            qt_config
-                ->value(QString("debug_pad_") + Settings::NativeAnalog::mapping[i],
-                        QString::fromStdString(default_param))
-                .toString()
-                .toStdString();
-        if (Settings::values.debug_pad_analogs[i].empty())
-            Settings::values.debug_pad_analogs[i] = default_param;
+        auto& debug_pad_analogs = Settings::values.debug_pad_analogs[i];
+
+        debug_pad_analogs = qt_config
+                                ->value(QStringLiteral("debug_pad_") +
+                                            QString::fromUtf8(Settings::NativeAnalog::mapping[i]),
+                                        QString::fromStdString(default_param))
+                                .toString()
+                                .toStdString();
+        if (debug_pad_analogs.empty()) {
+            debug_pad_analogs = default_param;
+        }
     }
 }
 
 void Config::ReadKeyboardValues() {
-    Settings::values.keyboard_enabled = ReadSetting("keyboard_enabled", false).toBool();
+    Settings::values.keyboard_enabled =
+        ReadSetting(QStringLiteral("keyboard_enabled"), false).toBool();
 
     std::transform(default_keyboard_keys.begin(), default_keyboard_keys.end(),
                    Settings::values.keyboard_keys.begin(), InputCommon::GenerateKeyboardParam);
@@ -332,18 +350,22 @@ void Config::ReadKeyboardValues() {
 }
 
 void Config::ReadMouseValues() {
-    Settings::values.mouse_enabled = ReadSetting("mouse_enabled", false).toBool();
+    Settings::values.mouse_enabled = ReadSetting(QStringLiteral("mouse_enabled"), false).toBool();
 
     for (int i = 0; i < Settings::NativeMouseButton::NumMouseButtons; ++i) {
-        std::string default_param = InputCommon::GenerateKeyboardParam(default_mouse_buttons[i]);
-        Settings::values.mouse_buttons[i] =
-            qt_config
-                ->value(QString("mouse_") + Settings::NativeMouseButton::mapping[i],
-                        QString::fromStdString(default_param))
-                .toString()
-                .toStdString();
-        if (Settings::values.mouse_buttons[i].empty())
-            Settings::values.mouse_buttons[i] = default_param;
+        const std::string default_param =
+            InputCommon::GenerateKeyboardParam(default_mouse_buttons[i]);
+        auto& mouse_buttons = Settings::values.mouse_buttons[i];
+
+        mouse_buttons = qt_config
+                            ->value(QStringLiteral("mouse_") +
+                                        QString::fromUtf8(Settings::NativeMouseButton::mapping[i]),
+                                    QString::fromStdString(default_param))
+                            .toString()
+                            .toStdString();
+        if (mouse_buttons.empty()) {
+            mouse_buttons = default_param;
+        }
     }
 }
 
@@ -356,7 +378,6 @@ void Config::ReadTouchscreenValues() {
     Settings::values.touchscreen.rotation_angle = ReadSetting("touchscreen_angle", 0).toUInt();
     Settings::values.touchscreen.diameter_x = ReadSetting("touchscreen_diameter_x", 15).toUInt();
     Settings::values.touchscreen.diameter_y = ReadSetting("touchscreen_diameter_y", 15).toUInt();
-    qt_config->endGroup();
 }
 
 void Config::ApplyDefaultProfileIfInputInvalid() {
@@ -366,8 +387,25 @@ void Config::ApplyDefaultProfileIfInputInvalid() {
     }
 }
 
-void Config::ReadValues() {
-    qt_config->beginGroup("Controls");
+void Config::ReadAudioValues() {
+    qt_config->beginGroup(QStringLiteral("Audio"));
+
+    Settings::values.sink_id = ReadSetting(QStringLiteral("output_engine"), QStringLiteral("auto"))
+                                   .toString()
+                                   .toStdString();
+    Settings::values.enable_audio_stretching =
+        ReadSetting(QStringLiteral("enable_audio_stretching"), true).toBool();
+    Settings::values.audio_device_id =
+        ReadSetting(QStringLiteral("output_device"), QStringLiteral("auto"))
+            .toString()
+            .toStdString();
+    Settings::values.volume = ReadSetting(QStringLiteral("volume"), 1).toFloat();
+
+    qt_config->endGroup();
+}
+
+void Config::ReadControlValues() {
+    qt_config->beginGroup(QStringLiteral("Controls"));
 
     ReadPlayerValues();
     ReadDebugValues();
@@ -376,162 +414,133 @@ void Config::ReadValues() {
     ReadTouchscreenValues();
 
     Settings::values.motion_device =
-        ReadSetting("motion_device", "engine:motion_emu,update_period:100,sensitivity:0.01")
+        ReadSetting(QStringLiteral("motion_device"),
+                    QStringLiteral("engine:motion_emu,update_period:100,sensitivity:0.01"))
             .toString()
             .toStdString();
 
-    qt_config->beginGroup("Core");
-    Settings::values.use_cpu_jit = ReadSetting("use_cpu_jit", true).toBool();
-    Settings::values.use_multi_core = ReadSetting("use_multi_core", false).toBool();
     qt_config->endGroup();
+}
 
-    qt_config->beginGroup("Renderer");
-    Settings::values.resolution_factor = ReadSetting("resolution_factor", 1.0).toFloat();
-    Settings::values.use_frame_limit = ReadSetting("use_frame_limit", true).toBool();
-    Settings::values.frame_limit = ReadSetting("frame_limit", 100).toInt();
-    Settings::values.use_compatibility_profile =
-        ReadSetting("use_compatibility_profile", true).toBool();
-    Settings::values.use_disk_shader_cache = ReadSetting("use_disk_shader_cache", true).toBool();
-    Settings::values.use_accurate_gpu_emulation =
-        ReadSetting("use_accurate_gpu_emulation", false).toBool();
-    Settings::values.use_asynchronous_gpu_emulation =
-        ReadSetting("use_asynchronous_gpu_emulation", false).toBool();
-    Settings::values.force_30fps_mode = ReadSetting("force_30fps_mode", false).toBool();
+void Config::ReadCoreValues() {
+    qt_config->beginGroup(QStringLiteral("Core"));
 
-    Settings::values.bg_red = ReadSetting("bg_red", 0.0).toFloat();
-    Settings::values.bg_green = ReadSetting("bg_green", 0.0).toFloat();
-    Settings::values.bg_blue = ReadSetting("bg_blue", 0.0).toFloat();
+    Settings::values.use_cpu_jit = ReadSetting(QStringLiteral("use_cpu_jit"), true).toBool();
+    Settings::values.use_multi_core = ReadSetting(QStringLiteral("use_multi_core"), false).toBool();
+
     qt_config->endGroup();
+}
 
-    qt_config->beginGroup("Audio");
-    Settings::values.sink_id = ReadSetting("output_engine", "auto").toString().toStdString();
-    Settings::values.enable_audio_stretching =
-        ReadSetting("enable_audio_stretching", true).toBool();
-    Settings::values.audio_device_id =
-        ReadSetting("output_device", "auto").toString().toStdString();
-    Settings::values.volume = ReadSetting("volume", 1).toFloat();
-    qt_config->endGroup();
+void Config::ReadDataStorageValues() {
+    qt_config->beginGroup(QStringLiteral("Data Storage"));
 
-    qt_config->beginGroup("Data Storage");
-    Settings::values.use_virtual_sd = ReadSetting("use_virtual_sd", true).toBool();
+    Settings::values.use_virtual_sd = ReadSetting(QStringLiteral("use_virtual_sd"), true).toBool();
     FileUtil::GetUserPath(
         FileUtil::UserPath::NANDDir,
         qt_config
-            ->value("nand_directory",
+            ->value(QStringLiteral("nand_directory"),
                     QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)))
             .toString()
             .toStdString());
     FileUtil::GetUserPath(
         FileUtil::UserPath::SDMCDir,
         qt_config
-            ->value("sdmc_directory",
+            ->value(QStringLiteral("sdmc_directory"),
                     QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)))
             .toString()
             .toStdString());
-    qt_config->endGroup();
-
-    qt_config->beginGroup("Core");
-    Settings::values.use_cpu_jit = ReadSetting("use_cpu_jit", true).toBool();
-    Settings::values.use_multi_core = ReadSetting("use_multi_core", false).toBool();
-    qt_config->endGroup();
-
-    qt_config->beginGroup("System");
-    Settings::values.use_docked_mode = ReadSetting("use_docked_mode", false).toBool();
-
-    Settings::values.current_user =
-        std::clamp<int>(ReadSetting("current_user", 0).toInt(), 0, Service::Account::MAX_USERS - 1);
-
-    Settings::values.language_index = ReadSetting("language_index", 1).toInt();
-
-    const auto rng_seed_enabled = ReadSetting("rng_seed_enabled", false).toBool();
-    if (rng_seed_enabled) {
-        Settings::values.rng_seed = ReadSetting("rng_seed", 0).toULongLong();
-    } else {
-        Settings::values.rng_seed = std::nullopt;
-    }
-
-    const auto custom_rtc_enabled = ReadSetting("custom_rtc_enabled", false).toBool();
-    if (custom_rtc_enabled) {
-        Settings::values.custom_rtc =
-            std::chrono::seconds(ReadSetting("custom_rtc", 0).toULongLong());
-    } else {
-        Settings::values.custom_rtc = std::nullopt;
-    }
 
     qt_config->endGroup();
+}
 
-    qt_config->beginGroup("Miscellaneous");
-    Settings::values.log_filter = ReadSetting("log_filter", "*:Info").toString().toStdString();
-    Settings::values.use_dev_keys = ReadSetting("use_dev_keys", false).toBool();
+void Config::ReadDebuggingValues() {
+    qt_config->beginGroup(QStringLiteral("Debugging"));
+
+    Settings::values.use_gdbstub = ReadSetting(QStringLiteral("use_gdbstub"), false).toBool();
+    Settings::values.gdbstub_port = ReadSetting(QStringLiteral("gdbstub_port"), 24689).toInt();
+    Settings::values.program_args =
+        ReadSetting(QStringLiteral("program_args"), QStringLiteral("")).toString().toStdString();
+    Settings::values.dump_exefs = ReadSetting(QStringLiteral("dump_exefs"), false).toBool();
+    Settings::values.dump_nso = ReadSetting(QStringLiteral("dump_nso"), false).toBool();
+
     qt_config->endGroup();
+}
 
-    qt_config->beginGroup("Debugging");
-    Settings::values.use_gdbstub = ReadSetting("use_gdbstub", false).toBool();
-    Settings::values.gdbstub_port = ReadSetting("gdbstub_port", 24689).toInt();
-    Settings::values.program_args = ReadSetting("program_args", "").toString().toStdString();
-    Settings::values.dump_exefs = ReadSetting("dump_exefs", false).toBool();
-    Settings::values.dump_nso = ReadSetting("dump_nso", false).toBool();
-    qt_config->endGroup();
+void Config::ReadDisabledAddOnValues() {
+    const auto size = qt_config->beginReadArray(QStringLiteral("DisabledAddOns"));
 
-    qt_config->beginGroup("WebService");
-    Settings::values.enable_telemetry = ReadSetting("enable_telemetry", true).toBool();
-    Settings::values.web_api_url =
-        ReadSetting("web_api_url", "https://api.yuzu-emu.org").toString().toStdString();
-    Settings::values.yuzu_username = ReadSetting("yuzu_username").toString().toStdString();
-    Settings::values.yuzu_token = ReadSetting("yuzu_token").toString().toStdString();
-    qt_config->endGroup();
-
-    const auto size = qt_config->beginReadArray("DisabledAddOns");
     for (int i = 0; i < size; ++i) {
         qt_config->setArrayIndex(i);
-        const auto title_id = ReadSetting("title_id", 0).toULongLong();
+        const auto title_id = ReadSetting(QStringLiteral("title_id"), 0).toULongLong();
         std::vector<std::string> out;
-        const auto d_size = qt_config->beginReadArray("disabled");
+        const auto d_size = qt_config->beginReadArray(QStringLiteral("disabled"));
         for (int j = 0; j < d_size; ++j) {
             qt_config->setArrayIndex(j);
-            out.push_back(ReadSetting("d", "").toString().toStdString());
+            out.push_back(
+                ReadSetting(QStringLiteral("d"), QStringLiteral("")).toString().toStdString());
         }
         qt_config->endArray();
         Settings::values.disabled_addons.insert_or_assign(title_id, out);
     }
+
     qt_config->endArray();
+}
 
-    qt_config->beginGroup("UI");
-    UISettings::values.theme = ReadSetting("theme", UISettings::themes[0].second).toString();
-    UISettings::values.enable_discord_presence =
-        ReadSetting("enable_discord_presence", true).toBool();
-    UISettings::values.screenshot_resolution_factor =
-        static_cast<u16>(ReadSetting("screenshot_resolution_factor", 0).toUInt());
-    UISettings::values.select_user_on_boot = ReadSetting("select_user_on_boot", false).toBool();
+void Config::ReadMiscellaneousValues() {
+    qt_config->beginGroup(QStringLiteral("Miscellaneous"));
 
-    qt_config->beginGroup("UIGameList");
-    UISettings::values.show_unknown = ReadSetting("show_unknown", true).toBool();
-    UISettings::values.show_add_ons = ReadSetting("show_add_ons", true).toBool();
-    UISettings::values.icon_size = ReadSetting("icon_size", 64).toUInt();
-    UISettings::values.row_1_text_id = ReadSetting("row_1_text_id", 3).toUInt();
-    UISettings::values.row_2_text_id = ReadSetting("row_2_text_id", 2).toUInt();
+    Settings::values.log_filter =
+        ReadSetting(QStringLiteral("log_filter"), QStringLiteral("*:Info"))
+            .toString()
+            .toStdString();
+    Settings::values.use_dev_keys = ReadSetting(QStringLiteral("use_dev_keys"), false).toBool();
+
     qt_config->endGroup();
+}
 
-    qt_config->beginGroup("UILayout");
-    UISettings::values.geometry = ReadSetting("geometry").toByteArray();
-    UISettings::values.state = ReadSetting("state").toByteArray();
-    UISettings::values.renderwindow_geometry = ReadSetting("geometryRenderWindow").toByteArray();
-    UISettings::values.gamelist_header_state = ReadSetting("gameListHeaderState").toByteArray();
-    UISettings::values.microprofile_geometry =
-        ReadSetting("microProfileDialogGeometry").toByteArray();
-    UISettings::values.microprofile_visible =
-        ReadSetting("microProfileDialogVisible", false).toBool();
+void Config::ReadPathValues() {
+    qt_config->beginGroup(QStringLiteral("Paths"));
+
+    UISettings::values.roms_path = ReadSetting(QStringLiteral("romsPath")).toString();
+    UISettings::values.symbols_path = ReadSetting(QStringLiteral("symbolsPath")).toString();
+    UISettings::values.game_directory_path =
+        ReadSetting(QStringLiteral("gameListRootDir"), QStringLiteral(".")).toString();
+    UISettings::values.game_directory_deepscan =
+        ReadSetting(QStringLiteral("gameListDeepScan"), false).toBool();
+    UISettings::values.recent_files = ReadSetting(QStringLiteral("recentFiles")).toStringList();
+
     qt_config->endGroup();
+}
 
-    qt_config->beginGroup("Paths");
-    UISettings::values.roms_path = ReadSetting("romsPath").toString();
-    UISettings::values.symbols_path = ReadSetting("symbolsPath").toString();
-    UISettings::values.game_directory_path = ReadSetting("gameListRootDir", ".").toString();
-    UISettings::values.game_directory_deepscan = ReadSetting("gameListDeepScan", false).toBool();
-    UISettings::values.recent_files = ReadSetting("recentFiles").toStringList();
+void Config::ReadRendererValues() {
+    qt_config->beginGroup(QStringLiteral("Renderer"));
+
+    Settings::values.resolution_factor =
+        ReadSetting(QStringLiteral("resolution_factor"), 1.0).toFloat();
+    Settings::values.use_frame_limit =
+        ReadSetting(QStringLiteral("use_frame_limit"), true).toBool();
+    Settings::values.frame_limit = ReadSetting(QStringLiteral("frame_limit"), 100).toInt();
+    Settings::values.use_compatibility_profile =
+        ReadSetting(QStringLiteral("use_compatibility_profile"), true).toBool();
+    Settings::values.use_disk_shader_cache =
+        ReadSetting(QStringLiteral("use_disk_shader_cache"), true).toBool();
+    Settings::values.use_accurate_gpu_emulation =
+        ReadSetting(QStringLiteral("use_accurate_gpu_emulation"), false).toBool();
+    Settings::values.use_asynchronous_gpu_emulation =
+        ReadSetting(QStringLiteral("use_asynchronous_gpu_emulation"), false).toBool();
+    Settings::values.force_30fps_mode =
+        ReadSetting(QStringLiteral("force_30fps_mode"), false).toBool();
+
+    Settings::values.bg_red = ReadSetting(QStringLiteral("bg_red"), 0.0).toFloat();
+    Settings::values.bg_green = ReadSetting(QStringLiteral("bg_green"), 0.0).toFloat();
+    Settings::values.bg_blue = ReadSetting(QStringLiteral("bg_blue"), 0.0).toFloat();
+
     qt_config->endGroup();
+}
 
-    qt_config->beginGroup("Shortcuts");
+void Config::ReadShortcutValues() {
+    qt_config->beginGroup(QStringLiteral("Shortcuts"));
+
     for (auto [name, group, shortcut] : default_hotkeys) {
         auto [keyseq, context] = shortcut;
         qt_config->beginGroup(group);
@@ -539,57 +548,173 @@ void Config::ReadValues() {
         UISettings::values.shortcuts.push_back(
             {name,
              group,
-             {ReadSetting("KeySeq", keyseq).toString(), ReadSetting("Context", context).toInt()}});
+             {ReadSetting(QStringLiteral("KeySeq"), keyseq).toString(),
+              ReadSetting(QStringLiteral("Context"), context).toInt()}});
         qt_config->endGroup();
         qt_config->endGroup();
     }
-    qt_config->endGroup();
 
-    UISettings::values.single_window_mode = ReadSetting("singleWindowMode", true).toBool();
-    UISettings::values.fullscreen = ReadSetting("fullscreen", false).toBool();
-    UISettings::values.display_titlebar = ReadSetting("displayTitleBars", true).toBool();
-    UISettings::values.show_filter_bar = ReadSetting("showFilterBar", true).toBool();
-    UISettings::values.show_status_bar = ReadSetting("showStatusBar", true).toBool();
-    UISettings::values.confirm_before_closing = ReadSetting("confirmClose", true).toBool();
-    UISettings::values.first_start = ReadSetting("firstStart", true).toBool();
-    UISettings::values.callout_flags = ReadSetting("calloutFlags", 0).toUInt();
-    UISettings::values.show_console = ReadSetting("showConsole", false).toBool();
-    UISettings::values.profile_index = ReadSetting("profileIndex", 0).toUInt();
+    qt_config->endGroup();
+}
+
+void Config::ReadSystemValues() {
+    qt_config->beginGroup(QStringLiteral("System"));
+
+    Settings::values.use_docked_mode =
+        ReadSetting(QStringLiteral("use_docked_mode"), false).toBool();
+
+    Settings::values.current_user = std::clamp<int>(
+        ReadSetting(QStringLiteral("current_user"), 0).toInt(), 0, Service::Account::MAX_USERS - 1);
+
+    Settings::values.language_index = ReadSetting(QStringLiteral("language_index"), 1).toInt();
+
+    const auto rng_seed_enabled = ReadSetting(QStringLiteral("rng_seed_enabled"), false).toBool();
+    if (rng_seed_enabled) {
+        Settings::values.rng_seed = ReadSetting(QStringLiteral("rng_seed"), 0).toULongLong();
+    } else {
+        Settings::values.rng_seed = std::nullopt;
+    }
+
+    const auto custom_rtc_enabled =
+        ReadSetting(QStringLiteral("custom_rtc_enabled"), false).toBool();
+    if (custom_rtc_enabled) {
+        Settings::values.custom_rtc =
+            std::chrono::seconds(ReadSetting(QStringLiteral("custom_rtc"), 0).toULongLong());
+    } else {
+        Settings::values.custom_rtc = std::nullopt;
+    }
+
+    qt_config->endGroup();
+}
+
+void Config::ReadUIValues() {
+    qt_config->beginGroup(QStringLiteral("UI"));
+
+    UISettings::values.theme =
+        ReadSetting(QStringLiteral("theme"), UISettings::themes[0].second).toString();
+    UISettings::values.enable_discord_presence =
+        ReadSetting(QStringLiteral("enable_discord_presence"), true).toBool();
+    UISettings::values.screenshot_resolution_factor =
+        static_cast<u16>(ReadSetting(QStringLiteral("screenshot_resolution_factor"), 0).toUInt());
+    UISettings::values.select_user_on_boot =
+        ReadSetting(QStringLiteral("select_user_on_boot"), false).toBool();
+
+    ReadUIGamelistValues();
+    ReadUILayoutValues();
+    ReadPathValues();
+    ReadShortcutValues();
+
+    UISettings::values.single_window_mode =
+        ReadSetting(QStringLiteral("singleWindowMode"), true).toBool();
+    UISettings::values.fullscreen = ReadSetting(QStringLiteral("fullscreen"), false).toBool();
+    UISettings::values.display_titlebar =
+        ReadSetting(QStringLiteral("displayTitleBars"), true).toBool();
+    UISettings::values.show_filter_bar =
+        ReadSetting(QStringLiteral("showFilterBar"), true).toBool();
+    UISettings::values.show_status_bar =
+        ReadSetting(QStringLiteral("showStatusBar"), true).toBool();
+    UISettings::values.confirm_before_closing =
+        ReadSetting(QStringLiteral("confirmClose"), true).toBool();
+    UISettings::values.first_start = ReadSetting(QStringLiteral("firstStart"), true).toBool();
+    UISettings::values.callout_flags = ReadSetting(QStringLiteral("calloutFlags"), 0).toUInt();
+    UISettings::values.show_console = ReadSetting(QStringLiteral("showConsole"), false).toBool();
+    UISettings::values.profile_index = ReadSetting(QStringLiteral("profileIndex"), 0).toUInt();
 
     ApplyDefaultProfileIfInputInvalid();
 
     qt_config->endGroup();
 }
 
+void Config::ReadUIGamelistValues() {
+    qt_config->beginGroup("UIGameList");
+
+    UISettings::values.show_unknown = ReadSetting(QStringLiteral("show_unknown"), true).toBool();
+    UISettings::values.show_add_ons = ReadSetting(QStringLiteral("show_add_ons"), true).toBool();
+    UISettings::values.icon_size = ReadSetting(QStringLiteral("icon_size"), 64).toUInt();
+    UISettings::values.row_1_text_id = ReadSetting(QStringLiteral("row_1_text_id"), 3).toUInt();
+    UISettings::values.row_2_text_id = ReadSetting(QStringLiteral("row_2_text_id"), 2).toUInt();
+
+    qt_config->endGroup();
+}
+
+void Config::ReadUILayoutValues() {
+    qt_config->beginGroup(QStringLiteral("UILayout"));
+
+    UISettings::values.geometry = ReadSetting(QStringLiteral("geometry")).toByteArray();
+    UISettings::values.state = ReadSetting(QStringLiteral("state")).toByteArray();
+    UISettings::values.renderwindow_geometry =
+        ReadSetting(QStringLiteral("geometryRenderWindow")).toByteArray();
+    UISettings::values.gamelist_header_state =
+        ReadSetting(QStringLiteral("gameListHeaderState")).toByteArray();
+    UISettings::values.microprofile_geometry =
+        ReadSetting(QStringLiteral("microProfileDialogGeometry")).toByteArray();
+    UISettings::values.microprofile_visible =
+        ReadSetting(QStringLiteral("microProfileDialogVisible"), false).toBool();
+
+    qt_config->endGroup();
+}
+
+void Config::ReadWebServiceValues() {
+    qt_config->beginGroup(QStringLiteral("WebService"));
+
+    Settings::values.enable_telemetry =
+        ReadSetting(QStringLiteral("enable_telemetry"), true).toBool();
+    Settings::values.web_api_url =
+        ReadSetting(QStringLiteral("web_api_url"), QStringLiteral("https://api.yuzu-emu.org"))
+            .toString()
+            .toStdString();
+    Settings::values.yuzu_username =
+        ReadSetting(QStringLiteral("yuzu_username")).toString().toStdString();
+    Settings::values.yuzu_token =
+        ReadSetting(QStringLiteral("yuzu_token")).toString().toStdString();
+
+    qt_config->endGroup();
+}
+
+void Config::ReadValues() {
+    ReadControlValues();
+    ReadCoreValues();
+    ReadRendererValues();
+    ReadAudioValues();
+    ReadDataStorageValues();
+    ReadSystemValues();
+    ReadMiscellaneousValues();
+    ReadDebugValues();
+    ReadWebServiceValues();
+    ReadDisabledAddOnValues();
+    ReadUIValues();
+}
+
 void Config::SavePlayerValues() {
     for (std::size_t p = 0; p < Settings::values.players.size(); ++p) {
         const auto& player = Settings::values.players[p];
 
-        WriteSetting(QString("player_%1_connected").arg(p), player.connected, false);
-        WriteSetting(QString("player_%1_type").arg(p), static_cast<u8>(player.type),
+        WriteSetting(QStringLiteral("player_%1_connected").arg(p), player.connected, false);
+        WriteSetting(QStringLiteral("player_%1_type").arg(p), static_cast<u8>(player.type),
                      static_cast<u8>(Settings::ControllerType::DualJoycon));
 
-        WriteSetting(QString("player_%1_body_color_left").arg(p), player.body_color_left,
+        WriteSetting(QStringLiteral("player_%1_body_color_left").arg(p), player.body_color_left,
                      Settings::JOYCON_BODY_NEON_BLUE);
-        WriteSetting(QString("player_%1_body_color_right").arg(p), player.body_color_right,
+        WriteSetting(QStringLiteral("player_%1_body_color_right").arg(p), player.body_color_right,
                      Settings::JOYCON_BODY_NEON_RED);
-        WriteSetting(QString("player_%1_button_color_left").arg(p), player.button_color_left,
+        WriteSetting(QStringLiteral("player_%1_button_color_left").arg(p), player.button_color_left,
                      Settings::JOYCON_BUTTONS_NEON_BLUE);
-        WriteSetting(QString("player_%1_button_color_right").arg(p), player.button_color_right,
-                     Settings::JOYCON_BUTTONS_NEON_RED);
+        WriteSetting(QStringLiteral("player_%1_button_color_right").arg(p),
+                     player.button_color_right, Settings::JOYCON_BUTTONS_NEON_RED);
 
         for (int i = 0; i < Settings::NativeButton::NumButtons; ++i) {
-            std::string default_param = InputCommon::GenerateKeyboardParam(default_buttons[i]);
-            WriteSetting(QString("player_%1_").arg(p) +
+            const std::string default_param =
+                InputCommon::GenerateKeyboardParam(default_buttons[i]);
+            WriteSetting(QStringLiteral("player_%1_").arg(p) +
                              QString::fromStdString(Settings::NativeButton::mapping[i]),
                          QString::fromStdString(player.buttons[i]),
                          QString::fromStdString(default_param));
         }
         for (int i = 0; i < Settings::NativeAnalog::NumAnalogs; ++i) {
-            std::string default_param = InputCommon::GenerateAnalogParamFromKeys(
+            const std::string default_param = InputCommon::GenerateAnalogParamFromKeys(
                 default_analogs[i][0], default_analogs[i][1], default_analogs[i][2],
                 default_analogs[i][3], default_analogs[i][4], 0.5f);
-            WriteSetting(QString("player_%1_").arg(p) +
+            WriteSetting(QStringLiteral("player_%1_").arg(p) +
                              QString::fromStdString(Settings::NativeAnalog::mapping[i]),
                          QString::fromStdString(player.analogs[i]),
                          QString::fromStdString(default_param));
@@ -600,17 +725,17 @@ void Config::SavePlayerValues() {
 void Config::SaveDebugValues() {
     WriteSetting("debug_pad_enabled", Settings::values.debug_pad_enabled, false);
     for (int i = 0; i < Settings::NativeButton::NumButtons; ++i) {
-        std::string default_param = InputCommon::GenerateKeyboardParam(default_buttons[i]);
-        WriteSetting(QString("debug_pad_") +
+        const std::string default_param = InputCommon::GenerateKeyboardParam(default_buttons[i]);
+        WriteSetting(QStringLiteral("debug_pad_") +
                          QString::fromStdString(Settings::NativeButton::mapping[i]),
                      QString::fromStdString(Settings::values.debug_pad_buttons[i]),
                      QString::fromStdString(default_param));
     }
     for (int i = 0; i < Settings::NativeAnalog::NumAnalogs; ++i) {
-        std::string default_param = InputCommon::GenerateAnalogParamFromKeys(
+        const std::string default_param = InputCommon::GenerateAnalogParamFromKeys(
             default_analogs[i][0], default_analogs[i][1], default_analogs[i][2],
             default_analogs[i][3], default_analogs[i][4], 0.5f);
-        WriteSetting(QString("debug_pad_") +
+        WriteSetting(QStringLiteral("debug_pad_") +
                          QString::fromStdString(Settings::NativeAnalog::mapping[i]),
                      QString::fromStdString(Settings::values.debug_pad_analogs[i]),
                      QString::fromStdString(default_param));
@@ -618,11 +743,12 @@ void Config::SaveDebugValues() {
 }
 
 void Config::SaveMouseValues() {
-    WriteSetting("mouse_enabled", Settings::values.mouse_enabled, false);
+    WriteSetting(QStringLiteral("mouse_enabled"), Settings::values.mouse_enabled, false);
 
     for (int i = 0; i < Settings::NativeMouseButton::NumMouseButtons; ++i) {
-        std::string default_param = InputCommon::GenerateKeyboardParam(default_mouse_buttons[i]);
-        WriteSetting(QString("mouse_") +
+        const std::string default_param =
+            InputCommon::GenerateKeyboardParam(default_mouse_buttons[i]);
+        WriteSetting(QStringLiteral("mouse_") +
                          QString::fromStdString(Settings::NativeMouseButton::mapping[i]),
                      QString::fromStdString(Settings::values.mouse_buttons[i]),
                      QString::fromStdString(default_param));
@@ -630,178 +756,276 @@ void Config::SaveMouseValues() {
 }
 
 void Config::SaveTouchscreenValues() {
-    WriteSetting("touchscreen_enabled", Settings::values.touchscreen.enabled, true);
-    WriteSetting("touchscreen_device", QString::fromStdString(Settings::values.touchscreen.device),
-                 "engine:emu_window");
+    const auto& touchscreen = Settings::values.touchscreen;
 
-    WriteSetting("touchscreen_finger", Settings::values.touchscreen.finger, 0);
-    WriteSetting("touchscreen_angle", Settings::values.touchscreen.rotation_angle, 0);
-    WriteSetting("touchscreen_diameter_x", Settings::values.touchscreen.diameter_x, 15);
-    WriteSetting("touchscreen_diameter_y", Settings::values.touchscreen.diameter_y, 15);
+    WriteSetting(QStringLiteral("touchscreen_enabled"), touchscreen.enabled, true);
+    WriteSetting(QStringLiteral("touchscreen_device"), QString::fromStdString(touchscreen.device),
+                 QStringLiteral("engine:emu_window"));
+
+    WriteSetting(QStringLiteral("touchscreen_finger"), touchscreen.finger, 0);
+    WriteSetting(QStringLiteral("touchscreen_angle"), touchscreen.rotation_angle, 0);
+    WriteSetting(QStringLiteral("touchscreen_diameter_x"), touchscreen.diameter_x, 15);
+    WriteSetting(QStringLiteral("touchscreen_diameter_y"), touchscreen.diameter_y, 15);
 }
 
 void Config::SaveValues() {
-    qt_config->beginGroup("Controls");
+    SaveControlValues();
+    SaveCoreValues();
+    SaveRendererValues();
+    SaveAudioValues();
+    SaveDataStorageValues();
+    SaveSystemValues();
+    SaveMiscellaneousValues();
+    SaveDebuggingValues();
+    SaveWebServiceValues();
+    SaveDisabledAddOnValues();
+    SaveUIValues();
+}
+
+void Config::SaveAudioValues() {
+    qt_config->beginGroup(QStringLiteral("Audio"));
+
+    WriteSetting(QStringLiteral("output_engine"), QString::fromStdString(Settings::values.sink_id),
+                 QStringLiteral("auto"));
+    WriteSetting(QStringLiteral("enable_audio_stretching"),
+                 Settings::values.enable_audio_stretching, true);
+    WriteSetting(QStringLiteral("output_device"),
+                 QString::fromStdString(Settings::values.audio_device_id), QStringLiteral("auto"));
+    WriteSetting(QStringLiteral("volume"), Settings::values.volume, 1.0f);
+
+    qt_config->endGroup();
+}
+
+void Config::SaveControlValues() {
+    qt_config->beginGroup(QStringLiteral("Controls"));
 
     SavePlayerValues();
     SaveDebugValues();
     SaveMouseValues();
     SaveTouchscreenValues();
 
-    WriteSetting("motion_device", QString::fromStdString(Settings::values.motion_device),
-                 "engine:motion_emu,update_period:100,sensitivity:0.01");
-    WriteSetting("keyboard_enabled", Settings::values.keyboard_enabled, false);
+    WriteSetting(QStringLiteral("motion_device"),
+                 QString::fromStdString(Settings::values.motion_device),
+                 QStringLiteral("engine:motion_emu,update_period:100,sensitivity:0.01"));
+    WriteSetting(QStringLiteral("keyboard_enabled"), Settings::values.keyboard_enabled, false);
 
     qt_config->endGroup();
+}
 
-    qt_config->beginGroup("Core");
-    WriteSetting("use_cpu_jit", Settings::values.use_cpu_jit, true);
-    WriteSetting("use_multi_core", Settings::values.use_multi_core, false);
+void Config::SaveCoreValues() {
+    qt_config->beginGroup(QStringLiteral("Core"));
+
+    WriteSetting(QStringLiteral("use_cpu_jit"), Settings::values.use_cpu_jit, true);
+    WriteSetting(QStringLiteral("use_multi_core"), Settings::values.use_multi_core, false);
+
     qt_config->endGroup();
+}
 
-    qt_config->beginGroup("Renderer");
-    WriteSetting("resolution_factor", (double)Settings::values.resolution_factor, 1.0);
-    WriteSetting("use_frame_limit", Settings::values.use_frame_limit, true);
-    WriteSetting("frame_limit", Settings::values.frame_limit, 100);
-    WriteSetting("use_compatibility_profile", Settings::values.use_compatibility_profile, true);
-    WriteSetting("use_disk_shader_cache", Settings::values.use_disk_shader_cache, true);
-    WriteSetting("use_accurate_gpu_emulation", Settings::values.use_accurate_gpu_emulation, false);
-    WriteSetting("use_asynchronous_gpu_emulation", Settings::values.use_asynchronous_gpu_emulation,
-                 false);
-    WriteSetting("force_30fps_mode", Settings::values.force_30fps_mode, false);
+void Config::SaveDataStorageValues() {
+    qt_config->beginGroup(QStringLiteral("Data Storage"));
 
-    // Cast to double because Qt's written float values are not human-readable
-    WriteSetting("bg_red", (double)Settings::values.bg_red, 0.0);
-    WriteSetting("bg_green", (double)Settings::values.bg_green, 0.0);
-    WriteSetting("bg_blue", (double)Settings::values.bg_blue, 0.0);
-    qt_config->endGroup();
-
-    qt_config->beginGroup("Audio");
-    WriteSetting("output_engine", QString::fromStdString(Settings::values.sink_id), "auto");
-    WriteSetting("enable_audio_stretching", Settings::values.enable_audio_stretching, true);
-    WriteSetting("output_device", QString::fromStdString(Settings::values.audio_device_id), "auto");
-    WriteSetting("volume", Settings::values.volume, 1.0f);
-    qt_config->endGroup();
-
-    qt_config->beginGroup("Data Storage");
-    WriteSetting("use_virtual_sd", Settings::values.use_virtual_sd, true);
-    WriteSetting("nand_directory",
+    WriteSetting(QStringLiteral("use_virtual_sd"), Settings::values.use_virtual_sd, true);
+    WriteSetting(QStringLiteral("nand_directory"),
                  QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)),
                  QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)));
-    WriteSetting("sdmc_directory",
+    WriteSetting(QStringLiteral("sdmc_directory"),
                  QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)),
                  QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)));
+
     qt_config->endGroup();
+}
 
-    qt_config->beginGroup("System");
-    WriteSetting("use_docked_mode", Settings::values.use_docked_mode, false);
-    WriteSetting("current_user", Settings::values.current_user, 0);
-    WriteSetting("language_index", Settings::values.language_index, 1);
+void Config::SaveDebuggingValues() {
+    qt_config->beginGroup(QStringLiteral("Debugging"));
 
-    WriteSetting("rng_seed_enabled", Settings::values.rng_seed.has_value(), false);
-    WriteSetting("rng_seed", Settings::values.rng_seed.value_or(0), 0);
+    WriteSetting(QStringLiteral("use_gdbstub"), Settings::values.use_gdbstub, false);
+    WriteSetting(QStringLiteral("gdbstub_port"), Settings::values.gdbstub_port, 24689);
+    WriteSetting(QStringLiteral("program_args"),
+                 QString::fromStdString(Settings::values.program_args), QStringLiteral(""));
+    WriteSetting(QStringLiteral("dump_exefs"), Settings::values.dump_exefs, false);
+    WriteSetting(QStringLiteral("dump_nso"), Settings::values.dump_nso, false);
 
-    WriteSetting("custom_rtc_enabled", Settings::values.custom_rtc.has_value(), false);
-    WriteSetting("custom_rtc",
+    qt_config->endGroup();
+}
+
+void Config::SaveDisabledAddOnValues() {
+    qt_config->beginWriteArray(QStringLiteral("DisabledAddOns"));
+
+    int i = 0;
+    for (const auto& elem : Settings::values.disabled_addons) {
+        qt_config->setArrayIndex(i);
+        WriteSetting(QStringLiteral("title_id"), QVariant::fromValue<u64>(elem.first), 0);
+        qt_config->beginWriteArray(QStringLiteral("disabled"));
+        for (std::size_t j = 0; j < elem.second.size(); ++j) {
+            qt_config->setArrayIndex(static_cast<int>(j));
+            WriteSetting(QStringLiteral("d"), QString::fromStdString(elem.second[j]),
+                         QStringLiteral(""));
+        }
+        qt_config->endArray();
+        ++i;
+    }
+
+    qt_config->endArray();
+}
+
+void Config::SaveMiscellaneousValues() {
+    qt_config->beginGroup(QStringLiteral("Miscellaneous"));
+
+    WriteSetting(QStringLiteral("log_filter"), QString::fromStdString(Settings::values.log_filter),
+                 QStringLiteral("*:Info"));
+    WriteSetting(QStringLiteral("use_dev_keys"), Settings::values.use_dev_keys, false);
+
+    qt_config->endGroup();
+}
+
+void Config::SavePathValues() {
+    qt_config->beginGroup(QStringLiteral("Paths"));
+
+    WriteSetting(QStringLiteral("romsPath"), UISettings::values.roms_path);
+    WriteSetting(QStringLiteral("symbolsPath"), UISettings::values.symbols_path);
+    WriteSetting(QStringLiteral("screenshotPath"), UISettings::values.screenshot_path);
+    WriteSetting(QStringLiteral("gameListRootDir"), UISettings::values.game_directory_path,
+                 QStringLiteral("."));
+    WriteSetting(QStringLiteral("gameListDeepScan"), UISettings::values.game_directory_deepscan,
+                 false);
+    WriteSetting(QStringLiteral("recentFiles"), UISettings::values.recent_files);
+
+    qt_config->endGroup();
+}
+
+void Config::SaveRendererValues() {
+    qt_config->beginGroup(QStringLiteral("Renderer"));
+
+    WriteSetting(QStringLiteral("resolution_factor"),
+                 static_cast<double>(Settings::values.resolution_factor), 1.0);
+    WriteSetting(QStringLiteral("use_frame_limit"), Settings::values.use_frame_limit, true);
+    WriteSetting(QStringLiteral("frame_limit"), Settings::values.frame_limit, 100);
+    WriteSetting(QStringLiteral("use_compatibility_profile"),
+                 Settings::values.use_compatibility_profile, true);
+    WriteSetting(QStringLiteral("use_disk_shader_cache"), Settings::values.use_disk_shader_cache,
+                 true);
+    WriteSetting(QStringLiteral("use_accurate_gpu_emulation"),
+                 Settings::values.use_accurate_gpu_emulation, false);
+    WriteSetting(QStringLiteral("use_asynchronous_gpu_emulation"),
+                 Settings::values.use_asynchronous_gpu_emulation, false);
+    WriteSetting(QStringLiteral("force_30fps_mode"), Settings::values.force_30fps_mode, false);
+
+    // Cast to double because Qt's written float values are not human-readable
+    WriteSetting(QStringLiteral("bg_red"), static_cast<double>(Settings::values.bg_red), 0.0);
+    WriteSetting(QStringLiteral("bg_green"), static_cast<double>(Settings::values.bg_green), 0.0);
+    WriteSetting(QStringLiteral("bg_blue"), static_cast<double>(Settings::values.bg_blue), 0.0);
+
+    qt_config->endGroup();
+}
+
+void Config::SaveShortcutValues() {
+    qt_config->beginGroup(QStringLiteral("Shortcuts"));
+
+    // Lengths of UISettings::values.shortcuts & default_hotkeys are same.
+    // However, their ordering must also be the same.
+    for (std::size_t i = 0; i < default_hotkeys.size(); i++) {
+        const auto [name, group, shortcut] = UISettings::values.shortcuts[i];
+        const auto& default_hotkey = default_hotkeys[i].shortcut;
+
+        qt_config->beginGroup(group);
+        qt_config->beginGroup(name);
+        WriteSetting(QStringLiteral("KeySeq"), shortcut.first, default_hotkey.first);
+        WriteSetting(QStringLiteral("Context"), shortcut.second, default_hotkey.second);
+        qt_config->endGroup();
+        qt_config->endGroup();
+    }
+
+    qt_config->endGroup();
+}
+
+void Config::SaveSystemValues() {
+    qt_config->beginGroup(QStringLiteral("System"));
+
+    WriteSetting(QStringLiteral("use_docked_mode"), Settings::values.use_docked_mode, false);
+    WriteSetting(QStringLiteral("current_user"), Settings::values.current_user, 0);
+    WriteSetting(QStringLiteral("language_index"), Settings::values.language_index, 1);
+
+    WriteSetting(QStringLiteral("rng_seed_enabled"), Settings::values.rng_seed.has_value(), false);
+    WriteSetting(QStringLiteral("rng_seed"), Settings::values.rng_seed.value_or(0), 0);
+
+    WriteSetting(QStringLiteral("custom_rtc_enabled"), Settings::values.custom_rtc.has_value(),
+                 false);
+    WriteSetting(QStringLiteral("custom_rtc"),
                  QVariant::fromValue<long long>(
                      Settings::values.custom_rtc.value_or(std::chrono::seconds{}).count()),
                  0);
 
     qt_config->endGroup();
+}
 
-    qt_config->beginGroup("Miscellaneous");
-    WriteSetting("log_filter", QString::fromStdString(Settings::values.log_filter), "*:Info");
-    WriteSetting("use_dev_keys", Settings::values.use_dev_keys, false);
+void Config::SaveUIValues() {
+    qt_config->beginGroup(QStringLiteral("UI"));
+
+    WriteSetting(QStringLiteral("theme"), UISettings::values.theme, UISettings::themes[0].second);
+    WriteSetting(QStringLiteral("enable_discord_presence"),
+                 UISettings::values.enable_discord_presence, true);
+    WriteSetting(QStringLiteral("screenshot_resolution_factor"),
+                 UISettings::values.screenshot_resolution_factor, 0);
+    WriteSetting(QStringLiteral("select_user_on_boot"), UISettings::values.select_user_on_boot,
+                 false);
+
+    SaveUIGamelistValues();
+    SaveUILayoutValues();
+    SavePathValues();
+    SaveShortcutValues();
+
+    WriteSetting(QStringLiteral("singleWindowMode"), UISettings::values.single_window_mode, true);
+    WriteSetting(QStringLiteral("fullscreen"), UISettings::values.fullscreen, false);
+    WriteSetting(QStringLiteral("displayTitleBars"), UISettings::values.display_titlebar, true);
+    WriteSetting(QStringLiteral("showFilterBar"), UISettings::values.show_filter_bar, true);
+    WriteSetting(QStringLiteral("showStatusBar"), UISettings::values.show_status_bar, true);
+    WriteSetting(QStringLiteral("confirmClose"), UISettings::values.confirm_before_closing, true);
+    WriteSetting(QStringLiteral("firstStart"), UISettings::values.first_start, true);
+    WriteSetting(QStringLiteral("calloutFlags"), UISettings::values.callout_flags, 0);
+    WriteSetting(QStringLiteral("showConsole"), UISettings::values.show_console, false);
+    WriteSetting(QStringLiteral("profileIndex"), UISettings::values.profile_index, 0);
+
     qt_config->endGroup();
+}
 
-    qt_config->beginGroup("Debugging");
-    WriteSetting("use_gdbstub", Settings::values.use_gdbstub, false);
-    WriteSetting("gdbstub_port", Settings::values.gdbstub_port, 24689);
-    WriteSetting("program_args", QString::fromStdString(Settings::values.program_args), "");
-    WriteSetting("dump_exefs", Settings::values.dump_exefs, false);
-    WriteSetting("dump_nso", Settings::values.dump_nso, false);
+void Config::SaveUIGamelistValues() {
+    qt_config->beginGroup(QStringLiteral("UIGameList"));
+
+    WriteSetting(QStringLiteral("show_unknown"), UISettings::values.show_unknown, true);
+    WriteSetting(QStringLiteral("show_add_ons"), UISettings::values.show_add_ons, true);
+    WriteSetting(QStringLiteral("icon_size"), UISettings::values.icon_size, 64);
+    WriteSetting(QStringLiteral("row_1_text_id"), UISettings::values.row_1_text_id, 3);
+    WriteSetting(QStringLiteral("row_2_text_id"), UISettings::values.row_2_text_id, 2);
+
     qt_config->endGroup();
+}
 
-    qt_config->beginGroup("WebService");
-    WriteSetting("enable_telemetry", Settings::values.enable_telemetry, true);
-    WriteSetting("web_api_url", QString::fromStdString(Settings::values.web_api_url),
-                 "https://api.yuzu-emu.org");
-    WriteSetting("yuzu_username", QString::fromStdString(Settings::values.yuzu_username));
-    WriteSetting("yuzu_token", QString::fromStdString(Settings::values.yuzu_token));
+void Config::SaveUILayoutValues() {
+    qt_config->beginGroup(QStringLiteral("UILayout"));
+
+    WriteSetting(QStringLiteral("geometry"), UISettings::values.geometry);
+    WriteSetting(QStringLiteral("state"), UISettings::values.state);
+    WriteSetting(QStringLiteral("geometryRenderWindow"), UISettings::values.renderwindow_geometry);
+    WriteSetting(QStringLiteral("gameListHeaderState"), UISettings::values.gamelist_header_state);
+    WriteSetting(QStringLiteral("microProfileDialogGeometry"),
+                 UISettings::values.microprofile_geometry);
+    WriteSetting(QStringLiteral("microProfileDialogVisible"),
+                 UISettings::values.microprofile_visible, false);
+
     qt_config->endGroup();
+}
 
-    qt_config->beginWriteArray("DisabledAddOns");
-    int i = 0;
-    for (const auto& elem : Settings::values.disabled_addons) {
-        qt_config->setArrayIndex(i);
-        WriteSetting("title_id", QVariant::fromValue<u64>(elem.first), 0);
-        qt_config->beginWriteArray("disabled");
-        for (std::size_t j = 0; j < elem.second.size(); ++j) {
-            qt_config->setArrayIndex(static_cast<int>(j));
-            WriteSetting("d", QString::fromStdString(elem.second[j]), "");
-        }
-        qt_config->endArray();
-        ++i;
-    }
-    qt_config->endArray();
+void Config::SaveWebServiceValues() {
+    qt_config->beginGroup(QStringLiteral("WebService"));
 
-    qt_config->beginGroup("UI");
-    WriteSetting("theme", UISettings::values.theme, UISettings::themes[0].second);
-    WriteSetting("enable_discord_presence", UISettings::values.enable_discord_presence, true);
-    WriteSetting("screenshot_resolution_factor", UISettings::values.screenshot_resolution_factor,
-                 0);
-    WriteSetting("select_user_on_boot", UISettings::values.select_user_on_boot, false);
+    WriteSetting(QStringLiteral("enable_telemetry"), Settings::values.enable_telemetry, true);
+    WriteSetting(QStringLiteral("web_api_url"),
+                 QString::fromStdString(Settings::values.web_api_url),
+                 QStringLiteral("https://api.yuzu-emu.org"));
+    WriteSetting(QStringLiteral("yuzu_username"),
+                 QString::fromStdString(Settings::values.yuzu_username));
+    WriteSetting(QStringLiteral("yuzu_token"), QString::fromStdString(Settings::values.yuzu_token));
 
-    qt_config->beginGroup("UIGameList");
-    WriteSetting("show_unknown", UISettings::values.show_unknown, true);
-    WriteSetting("show_add_ons", UISettings::values.show_add_ons, true);
-    WriteSetting("icon_size", UISettings::values.icon_size, 64);
-    WriteSetting("row_1_text_id", UISettings::values.row_1_text_id, 3);
-    WriteSetting("row_2_text_id", UISettings::values.row_2_text_id, 2);
-    qt_config->endGroup();
-
-    qt_config->beginGroup("UILayout");
-    WriteSetting("geometry", UISettings::values.geometry);
-    WriteSetting("state", UISettings::values.state);
-    WriteSetting("geometryRenderWindow", UISettings::values.renderwindow_geometry);
-    WriteSetting("gameListHeaderState", UISettings::values.gamelist_header_state);
-    WriteSetting("microProfileDialogGeometry", UISettings::values.microprofile_geometry);
-    WriteSetting("microProfileDialogVisible", UISettings::values.microprofile_visible, false);
-    qt_config->endGroup();
-
-    qt_config->beginGroup("Paths");
-    WriteSetting("romsPath", UISettings::values.roms_path);
-    WriteSetting("symbolsPath", UISettings::values.symbols_path);
-    WriteSetting("screenshotPath", UISettings::values.screenshot_path);
-    WriteSetting("gameListRootDir", UISettings::values.game_directory_path, ".");
-    WriteSetting("gameListDeepScan", UISettings::values.game_directory_deepscan, false);
-    WriteSetting("recentFiles", UISettings::values.recent_files);
-    qt_config->endGroup();
-
-    qt_config->beginGroup("Shortcuts");
-    // Lengths of UISettings::values.shortcuts & default_hotkeys are same.
-    // However, their ordering must also be the same.
-    for (std::size_t i = 0; i < default_hotkeys.size(); i++) {
-        auto [name, group, shortcut] = UISettings::values.shortcuts[i];
-        qt_config->beginGroup(group);
-        qt_config->beginGroup(name);
-        WriteSetting("KeySeq", shortcut.first, default_hotkeys[i].shortcut.first);
-        WriteSetting("Context", shortcut.second, default_hotkeys[i].shortcut.second);
-        qt_config->endGroup();
-        qt_config->endGroup();
-    }
-    qt_config->endGroup();
-
-    WriteSetting("singleWindowMode", UISettings::values.single_window_mode, true);
-    WriteSetting("fullscreen", UISettings::values.fullscreen, false);
-    WriteSetting("displayTitleBars", UISettings::values.display_titlebar, true);
-    WriteSetting("showFilterBar", UISettings::values.show_filter_bar, true);
-    WriteSetting("showStatusBar", UISettings::values.show_status_bar, true);
-    WriteSetting("confirmClose", UISettings::values.confirm_before_closing, true);
-    WriteSetting("firstStart", UISettings::values.first_start, true);
-    WriteSetting("calloutFlags", UISettings::values.callout_flags, 0);
-    WriteSetting("showConsole", UISettings::values.show_console, false);
-    WriteSetting("profileIndex", UISettings::values.profile_index, 0);
     qt_config->endGroup();
 }
 
@@ -811,7 +1035,7 @@ QVariant Config::ReadSetting(const QString& name) const {
 
 QVariant Config::ReadSetting(const QString& name, const QVariant& default_value) const {
     QVariant result;
-    if (qt_config->value(name + "/default", false).toBool()) {
+    if (qt_config->value(name + QStringLiteral("/default"), false).toBool()) {
         result = default_value;
     } else {
         result = qt_config->value(name, default_value);
@@ -825,7 +1049,7 @@ void Config::WriteSetting(const QString& name, const QVariant& value) {
 
 void Config::WriteSetting(const QString& name, const QVariant& value,
                           const QVariant& default_value) {
-    qt_config->setValue(name + "/default", value == default_value);
+    qt_config->setValue(name + QStringLiteral("/default"), value == default_value);
     qt_config->setValue(name, value);
 }
 

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -37,11 +37,45 @@ private:
     void ReadTouchscreenValues();
     void ApplyDefaultProfileIfInputInvalid();
 
+    // Read functions bases off the respective config section names.
+    void ReadAudioValues();
+    void ReadControlValues();
+    void ReadCoreValues();
+    void ReadDataStorageValues();
+    void ReadDebuggingValues();
+    void ReadDisabledAddOnValues();
+    void ReadMiscellaneousValues();
+    void ReadPathValues();
+    void ReadRendererValues();
+    void ReadShortcutValues();
+    void ReadSystemValues();
+    void ReadUIValues();
+    void ReadUIGamelistValues();
+    void ReadUILayoutValues();
+    void ReadWebServiceValues();
+
     void SaveValues();
     void SavePlayerValues();
     void SaveDebugValues();
     void SaveMouseValues();
     void SaveTouchscreenValues();
+
+    // Save functions based off the respective config section names.
+    void SaveAudioValues();
+    void SaveControlValues();
+    void SaveCoreValues();
+    void SaveDataStorageValues();
+    void SaveDebuggingValues();
+    void SaveDisabledAddOnValues();
+    void SaveMiscellaneousValues();
+    void SavePathValues();
+    void SaveRendererValues();
+    void SaveShortcutValues();
+    void SaveSystemValues();
+    void SaveUIValues();
+    void SaveUIGamelistValues();
+    void SaveUILayoutValues();
+    void SaveWebServiceValues();
 
     QVariant ReadSetting(const QString& name) const;
     QVariant ReadSetting(const QString& name, const QVariant& default_value) const;


### PR DESCRIPTION
Over time our config values have grown quite numerous in size. Unfortunately it also makes the single functions we have for loading and saving values more error prone.

For example, we were loading the core settings twice when they only should have been loaded once. In another section, a variable was shadowing another variable used to load settings from a completely different section.

Finally, in one other case, there was an extraneous endGroup() call used that didn't need to be done. This was essentially dead code and also a bug waiting to happen.

This separates the section loading code into its own separate functions. This keeps variables only visible to the code that actually needs it, and makes it much easier to visually see the end of each individual configuration group. It also makes it much easier to visually catch bugs during code review.

While we're at it, this also uses QStringLiteral instead of raw string literals, which both avoids constructing a lot of QString instances, but also makes it much easier to disable implicit ASCII to QString and vice-versa in the future via setting QT_NO_CAST_FROM_ASCII and QT_NO_CAST_TO_ASCII as compilation flags.