### PR TITLE
yuzu/{about_dialog, main}: Specify string conversions explicitly for SCM-related info

### DIFF
--- a/src/yuzu/about_dialog.cpp
+++ b/src/yuzu/about_dialog.cpp
@@ -9,10 +9,10 @@
 
 AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent), ui(new Ui::AboutDialog) {
     ui->setupUi(this);
-    ui->labelLogo->setPixmap(QIcon::fromTheme("yuzu").pixmap(200));
-    ui->labelBuildInfo->setText(
-        ui->labelBuildInfo->text().arg(Common::g_build_fullname, Common::g_scm_branch,
-                                       Common::g_scm_desc, QString(Common::g_build_date).left(10)));
+    ui->labelLogo->setPixmap(QIcon::fromTheme(QStringLiteral("yuzu")).pixmap(200));
+    ui->labelBuildInfo->setText(ui->labelBuildInfo->text().arg(
+        QString::fromUtf8(Common::g_build_fullname), QString::fromUtf8(Common::g_scm_branch),
+        QString::fromUtf8(Common::g_scm_desc), QString::fromUtf8(Common::g_build_date).left(10)));
 }
 
 AboutDialog::~AboutDialog() = default;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -198,11 +198,11 @@ GMainWindow::GMainWindow()
 
     ConnectMenuEvents();
     ConnectWidgetEvents();
+
     LOG_INFO(Frontend, "yuzu Version: {} | {}-{}", Common::g_build_fullname, Common::g_scm_branch,
              Common::g_scm_desc);
+    UpdateWindowTitle();
 
-    setWindowTitle(QString("yuzu %1| %2-%3")
-                       .arg(Common::g_build_fullname, Common::g_scm_branch, Common::g_scm_desc));
     show();
 
     Core::System::GetInstance().SetContentProvider(
@@ -936,9 +936,7 @@ void GMainWindow::BootGame(const QString& filename) {
             title_name = FileUtil::GetFilename(filename.toStdString());
     }
 
-    setWindowTitle(QString("yuzu %1| %4 | %2-%3")
-                       .arg(Common::g_build_fullname, Common::g_scm_branch, Common::g_scm_desc,
-                            QString::fromStdString(title_name)));
+    UpdateWindowTitle(QString::fromStdString(title_name));
 
     loading_screen->Prepare(Core::System::GetInstance().GetAppLoader());
     loading_screen->show();
@@ -979,8 +977,8 @@ void GMainWindow::ShutdownGame() {
     loading_screen->Clear();
     game_list->show();
     game_list->setFilterFocus();
-    setWindowTitle(QString("yuzu %1| %2-%3")
-                       .arg(Common::g_build_fullname, Common::g_scm_branch, Common::g_scm_desc));
+
+    UpdateWindowTitle();
 
     // Disable status bar updates
     status_bar_update_timer.stop();
@@ -1765,6 +1763,19 @@ void GMainWindow::OnCaptureScreenshot() {
         }
     }
     OnStartGame();
+}
+
+void GMainWindow::UpdateWindowTitle(const QString& title_name) {
+    const QString full_name = QString::fromUtf8(Common::g_build_fullname);
+    const QString branch_name = QString::fromUtf8(Common::g_scm_branch);
+    const QString description = QString::fromUtf8(Common::g_scm_desc);
+
+    if (title_name.isEmpty()) {
+        setWindowTitle(QStringLiteral("yuzu %1| %2-%3").arg(full_name, branch_name, description));
+    } else {
+        setWindowTitle(QStringLiteral("yuzu %1| %4 | %2-%3")
+                           .arg(full_name, branch_name, description, title_name));
+    }
 }
 
 void GMainWindow::UpdateStatusBar() {

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -209,6 +209,7 @@ private slots:
 
 private:
     std::optional<u64> SelectRomFSDumpTarget(const FileSys::ContentProvider&, u64 program_id);
+    void UpdateWindowTitle(const QString& title_name = {});
     void UpdateStatusBar();
 
     Ui::MainWindow ui;


### PR DESCRIPTION
Specifies the conversions explicitly to avoid implicit conversions from const char* to QString. This makes it easier to disable implicit QString conversions in the future.

In this case, the implicit conversion was technically wrong as well. The implicit conversion treats the input strings as ASCII characters. This would result in an incorrect conversion being performed in the rare case a branch name was created with a non-ASCII Unicode character, likely resulting in junk being displayed.