### PR TITLE
configure_dialog: Remove the Whats This? button from the dialog

### DIFF
--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -17,8 +17,12 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry)
     ui->hotkeysTab->Populate(registry);
     this->setConfiguration();
     this->PopulateSelectionList();
+
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
+
     connect(ui->selectorList, &QListWidget::itemSelectionChanged, this,
             &ConfigureDialog::UpdateVisibleTabs);
+
     adjustSize();
     ui->selectorList->setCurrentRow(0);
 


### PR DESCRIPTION
Removes the `?` button in the upper right of the dialog. The button is unused entirely, so there's no real reason to expose it in the UI at all.

Before:
![before](https://user-images.githubusercontent.com/712067/57434848-e6904f00-7209-11e9-8ab0-a5eb3a0c6f6d.png)

After:
![after](https://user-images.githubusercontent.com/712067/57434870-eee88a00-7209-11e9-82d7-e3b95c21a2e0.png)
