### PR TITLE
CMakeLists: Specify /volatile:iso for MSVC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ if (MSVC)
     # /Zo                 - Enhanced debug info for optimized builds
     # /permissive-        - Enables stricter C++ standards conformance checks
     # /EHsc               - C++-only exception handling semantics
+    # /volatile:iso       - Use strict standards-compliant volatile semantics.
     # /Zc:externConstexpr - Allow extern constexpr variables to have external linkage, like the standard mandates
     # /Zc:inline          - Let codegen omit inline functions in object files
     # /Zc:throwingNew     - Let codegen assume `operator new` (without std::nothrow) will never return null
@@ -38,6 +39,7 @@ if (MSVC)
         /permissive-
         /EHsc
         /std:c++latest
+        /volatile:iso
         /Zc:externConstexpr
         /Zc:inline
         /Zc:throwingNew


### PR DESCRIPTION
By default, MSVC doesn't use standards-compliant volatile semantics. This makes it behave in a standards-compliant manner, making expectations more uniform across compilers.

This is safe to apply, as we currently don't make direct use of the `volatile` cv-qualifier anywhere in our code, which is nice, because it won't potentially break existing code.

More documentation about the flag can be seen [here](https://docs.microsoft.com/en-us/cpp/build/reference/volatile-volatile-keyword-interpretation?view=vs-2019)