### PR TITLE
Fix OpenGL compatibility profile for mesa/Linux

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2129,6 +2129,11 @@ int main(int argc, char* argv[]) {
     // generating shaders
     setlocale(LC_ALL, "C");
 
+    // Environment variables
+#ifdef __linux__
+    setenv("MESA_GL_VERSION_OVERRIDE", "4.5COMPAT", 0);
+#endif
+
     GMainWindow main_window;
     // After settings have been loaded by GMainWindow, apply the filter
     main_window.show();


### PR DESCRIPTION
The  `Use OpenGL compatibility profile` checkbox currently does not work on Linux/mesa, probably due to `QSurfaceFormat::CompatibilityProfile` in upstream Qt not working properly.

So this PR does actually make PLG render correctly on Linux/mesa using AMD, without a user manually setting the environment variable.

Obviously I'm joking by putting this in main(), but I tried putting this in bootmanager.cpp where you actually check the setting from Yuzu, but it doesn't work.

```
    if (Settings::values.use_compatibility_profile) {
        fmt.setProfile(QSurfaceFormat::CompatibilityProfile);
#ifdef __linux__
        setenv("MESA_GL_VERSION_OVERRIDE", "4.5COMPAT", 0);
#endif
    } else {
        fmt.setProfile(QSurfaceFormat::CoreProfile);
    }
```

Your discord's development channel is locked so it's not like I could talk about this there.

Can someone figure out where is best to put this environment variable, and under whatever `#ifdef __linux__` and other conditional stuff you'd like?

Should upstream Qt be fixed? Sure I agree. waitingskeleton.jpg