### PR TITLE
yuzu_cmd: Use OpenGL compat when asked in the settings

### DIFF
--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
@@ -176,9 +176,13 @@ EmuWindow_SDL2::EmuWindow_SDL2(bool fullscreen) {
 
     SDL_SetMainReady();
 
+    const SDL_GLprofile profile = Settings::values.use_compatibility_profile
+                                      ? SDL_GL_CONTEXT_PROFILE_COMPATIBILITY
+                                      : SDL_GL_CONTEXT_PROFILE_CORE;
+
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, profile);
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
     SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
     SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);


### PR DESCRIPTION
Without this the SDL2 frontend would always use OpenGL core, ignoring the setting.