### PR TITLE
gl_rasterizer: Limit OpenGL point size to a minimum of 1

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1135,7 +1135,9 @@ void RasterizerOpenGL::SyncTransformFeedback() {
 
 void RasterizerOpenGL::SyncPointState() {
     const auto& regs = system.GPU().Maxwell3D().regs;
-    state.point.size = regs.point_size;
+    // Limit the point size to 1 since nouveau sometimes sets a point size of 0 (and that's invalid
+    // in OpenGL).
+    state.point.size = std::max(1.0f, regs.point_size);
 }
 
 void RasterizerOpenGL::SyncPolygonOffset() {


### PR DESCRIPTION
nouveau sets the register to zero on some circumstances, this causes OpenGL errors. Bypass this by applying a minimum size for point size. The arbitrary number of one has been chosen since that's what a desktop Nvidia GPU reports as minimum + it doesn't make sense to have points smaller than 1 pixel. It may matter on multi-sampled environments, but Nvidia on OpenGL can't set this value anyways.