### PR TITLE
shader/memory: Implement generic memory stores and loads (ST and LD)

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -1673,6 +1673,7 @@ private:
             INST("1110111111110---", Id::ST_A, Type::Memory, "ST_A"),
             INST("1110111101011---", Id::ST_S, Type::Memory, "ST_S"),
             INST("1110111101010---", Id::ST_L, Type::Memory, "ST_L"),
+            INST("101-------------", Id::ST, Type::Memory, "ST"),
             INST("1110111011011---", Id::STG, Type::Memory, "STG"),
             INST("1110111110100---", Id::AL2P, Type::Memory, "AL2P"),
             INST("110000----111---", Id::TEX, Type::Texture, "TEX"),

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -530,6 +530,11 @@ union Instruction {
     BitField<48, 16, u64> opcode;
 
     union {
+        BitField<8, 8, Register> gpr;
+        BitField<20, 24, s64> offset;
+    } gmem;
+
+    union {
         BitField<20, 16, u64> imm20_16;
         BitField<20, 19, u64> imm20_19;
         BitField<20, 32, s64> imm20_32;
@@ -812,13 +817,11 @@ union Instruction {
     union {
         BitField<48, 3, UniformType> type;
         BitField<46, 2, u64> cache_mode;
-        BitField<20, 24, s64> immediate_offset;
     } ldg;
 
     union {
         BitField<48, 3, UniformType> type;
         BitField<46, 2, u64> cache_mode;
-        BitField<20, 24, s64> immediate_offset;
     } stg;
 
     union {
@@ -826,6 +829,11 @@ union Instruction {
         BitField<47, 3, AttributeSize> size;
         BitField<20, 11, u64> address;
     } al2p;
+
+    union {
+        BitField<53, 3, UniformType> type;
+        BitField<52, 1, u64> extended;
+    } generic;
 
     union {
         BitField<0, 3, u64> pred0;
@@ -1387,10 +1395,12 @@ public:
         LD_L,
         LD_S,
         LD_C,
+        LD,  // Load from generic memory
+        LDG, // Load from global memory
         ST_A,
         ST_L,
         ST_S,
-        LDG,  // Load from global memory
+        ST,   // Store in generic memory
         STG,  // Store in global memory
         AL2P, // Transforms attribute memory into physical memory
         TEX,
@@ -1658,10 +1668,11 @@ private:
             INST("1110111101001---", Id::LD_S, Type::Memory, "LD_S"),
             INST("1110111101000---", Id::LD_L, Type::Memory, "LD_L"),
             INST("1110111110010---", Id::LD_C, Type::Memory, "LD_C"),
+            INST("100-------------", Id::LD, Type::Memory, "LD"),
+            INST("1110111011010---", Id::LDG, Type::Memory, "LDG"),
             INST("1110111111110---", Id::ST_A, Type::Memory, "ST_A"),
             INST("1110111101011---", Id::ST_S, Type::Memory, "ST_S"),
             INST("1110111101010---", Id::ST_L, Type::Memory, "ST_L"),
-            INST("1110111011010---", Id::LDG, Type::Memory, "LDG"),
             INST("1110111011011---", Id::STG, Type::Memory, "STG"),
             INST("1110111110100---", Id::AL2P, Type::Memory, "AL2P"),
             INST("110000----111---", Id::TEX, Type::Texture, "TEX"),

--- a/src/video_core/shader/decode/memory.cpp
+++ b/src/video_core/shader/decode/memory.cpp
@@ -148,12 +148,25 @@ u32 ShaderIR::DecodeMemory(NodeBlock& bb, u32 pc) {
         }
         break;
     }
+    case OpCode::Id::LD:
     case OpCode::Id::LDG: {
-        const auto [real_address_base, base_address, descriptor] =
-            TrackAndGetGlobalMemory(bb, GetRegister(instr.gpr8),
-                                    static_cast<u32>(instr.ldg.immediate_offset.Value()), false);
+        const auto type = [instr, &opcode]() -> Tegra::Shader::UniformType {
+            switch (opcode->get().GetId()) {
+            case OpCode::Id::LD:
+                UNIMPLEMENTED_IF_MSG(!instr.generic.extended, "Unextended LD is not implemented");
+                return instr.generic.type;
+            case OpCode::Id::LDG:
+                return instr.ldg.type;
+            default:
+                UNREACHABLE();
+                return {};
+            }
+        }();
 
-        const u32 count = GetUniformTypeElementsCount(instr.ldg.type);
+        const auto [real_address_base, base_address, descriptor] =
+            TrackAndGetGlobalMemory(bb, instr, false);
+
+        const u32 count = GetUniformTypeElementsCount(type);
         for (u32 i = 0; i < count; ++i) {
             const Node it_offset = Immediate(i * 4);
             const Node real_address =
@@ -169,8 +182,7 @@ u32 ShaderIR::DecodeMemory(NodeBlock& bb, u32 pc) {
     }
     case OpCode::Id::STG: {
         const auto [real_address_base, base_address, descriptor] =
-            TrackAndGetGlobalMemory(bb, GetRegister(instr.gpr8),
-                                    static_cast<u32>(instr.stg.immediate_offset.Value()), true);
+            TrackAndGetGlobalMemory(bb, instr, true);
 
         // Encode in temporary registers like this: real_base_address, {registers_to_be_written...}
         SetTemporal(bb, 0, real_address_base);
@@ -267,9 +279,11 @@ u32 ShaderIR::DecodeMemory(NodeBlock& bb, u32 pc) {
 }
 
 std::tuple<Node, Node, GlobalMemoryBase> ShaderIR::TrackAndGetGlobalMemory(NodeBlock& bb,
-                                                                           Node addr_register,
-                                                                           u32 immediate_offset,
+                                                                           Instruction instr,
                                                                            bool is_write) {
+    const auto addr_register{GetRegister(instr.gmem.gpr)};
+    const auto immediate_offset{static_cast<u32>(instr.gmem.offset)};
+
     const Node base_address{
         TrackCbuf(addr_register, global_code, static_cast<s64>(global_code.size()))};
     const auto cbuf = std::get_if<CbufNode>(base_address);

--- a/src/video_core/shader/shader_ir.h
+++ b/src/video_core/shader/shader_ir.h
@@ -818,10 +818,8 @@ private:
     std::pair<Node, s64> TrackRegister(const GprNode* tracked, const NodeBlock& code,
                                        s64 cursor) const;
 
-    std::tuple<Node, Node, GlobalMemoryBase> TrackAndGetGlobalMemory(NodeBlock& bb,
-                                                                     Node addr_register,
-                                                                     u32 immediate_offset,
-                                                                     bool is_write);
+    std::tuple<Node, Node, GlobalMemoryBase> TrackAndGetGlobalMemory(
+        NodeBlock& bb, Tegra::Shader::Instruction instr, bool is_write);
 
     template <typename... T>
     Node Operation(OperationCode code, const T*... operands) {


### PR DESCRIPTION
These instructions have a similar behaviour to STG and LDG, in fact at the moment of writing this I don't know what in particular makes them different since both write to and read to arbitrary memory addresses. Like STG's name suggests it might just allow writes to global memory meanwhile ST can write to local or other types of memory - that is a guess and it's very unlikely someone does that.

nouveau uses these to implement SSBOs.