### PR TITLE
 yuzu/debugger: Specify string conversions explicitly 

### DIFF
--- a/src/yuzu/debugger/graphics/graphics_breakpoints.cpp
+++ b/src/yuzu/debugger/graphics/graphics_breakpoints.cpp
@@ -135,7 +135,7 @@ GraphicsBreakPointsWidget::GraphicsBreakPointsWidget(
     std::shared_ptr<Tegra::DebugContext> debug_context, QWidget* parent)
     : QDockWidget(tr("Maxwell Breakpoints"), parent), Tegra::DebugContext::BreakPointObserver(
                                                           debug_context) {
-    setObjectName("TegraBreakPointsWidget");
+    setObjectName(QStringLiteral("TegraBreakPointsWidget"));
 
     status_text = new QLabel(tr("Emulation running"));
     resume_button = new QPushButton(tr("Resume"));

--- a/src/yuzu/debugger/profiler.cpp
+++ b/src/yuzu/debugger/profiler.cpp
@@ -47,7 +47,7 @@ private:
 #endif
 
 MicroProfileDialog::MicroProfileDialog(QWidget* parent) : QWidget(parent, Qt::Dialog) {
-    setObjectName("MicroProfile");
+    setObjectName(QStringLiteral("MicroProfile"));
     setWindowTitle(tr("MicroProfile"));
     resize(1000, 600);
     // Remove the "?" button from the titlebar and enable the maximize button
@@ -191,7 +191,7 @@ void MicroProfileDrawText(int x, int y, u32 hex_color, const char* text, u32 tex
     for (u32 i = 0; i < text_length; ++i) {
         // Position the text baseline 1 pixel above the bottom of the text cell, this gives nice
         // vertical alignment of text for a wide range of tested fonts.
-        mp_painter->drawText(x, y + MICROPROFILE_TEXT_HEIGHT - 2, QChar(text[i]));
+        mp_painter->drawText(x, y + MICROPROFILE_TEXT_HEIGHT - 2, QString{QLatin1Char{text[i]}});
         x += MICROPROFILE_TEXT_WIDTH + 1;
     }
 }

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -91,19 +91,19 @@ WaitTreeMutexInfo::WaitTreeMutexInfo(VAddr mutex_address, const Kernel::HandleTa
 WaitTreeMutexInfo::~WaitTreeMutexInfo() = default;
 
 QString WaitTreeMutexInfo::GetText() const {
-    return tr("waiting for mutex 0x%1").arg(mutex_address, 16, 16, QLatin1Char('0'));
+    return tr("waiting for mutex 0x%1").arg(mutex_address, 16, 16, QLatin1Char{'0'});
 }
 
 std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeMutexInfo::GetChildren() const {
+    const bool has_waiters = (mutex_value & Kernel::Mutex::MutexHasWaitersFlag) != 0;
+
     std::vector<std::unique_ptr<WaitTreeItem>> list;
-
-    bool has_waiters = (mutex_value & Kernel::Mutex::MutexHasWaitersFlag) != 0;
-
     list.push_back(std::make_unique<WaitTreeText>(tr("has waiters: %1").arg(has_waiters)));
     list.push_back(std::make_unique<WaitTreeText>(
-        tr("owner handle: 0x%1").arg(owner_handle, 8, 16, QLatin1Char('0'))));
-    if (owner != nullptr)
+        tr("owner handle: 0x%1").arg(owner_handle, 8, 16, QLatin1Char{'0'})));
+    if (owner != nullptr) {
         list.push_back(std::make_unique<WaitTreeThread>(*owner));
+    }
     return list;
 }
 
@@ -121,11 +121,14 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeCallstack::GetChildren() cons
     u64 base_pointer = thread.GetContext().cpu_registers[BaseRegister];
 
     while (base_pointer != 0) {
-        u64 lr = Memory::Read64(base_pointer + sizeof(u64));
-        if (lr == 0)
+        const u64 lr = Memory::Read64(base_pointer + sizeof(u64));
+        if (lr == 0) {
             break;
-        list.push_back(
-            std::make_unique<WaitTreeText>(tr("0x%1").arg(lr - sizeof(u32), 16, 16, QChar('0'))));
+        }
+
+        list.push_back(std::make_unique<WaitTreeText>(
+            tr("0x%1").arg(lr - sizeof(u32), 16, 16, QLatin1Char{'0'})));
+
         base_pointer = Memory::Read64(base_pointer);
     }
 
@@ -249,9 +252,9 @@ QString WaitTreeThread::GetText() const {
 
     const auto& context = thread.GetContext();
     const QString pc_info = tr(" PC = 0x%1 LR = 0x%2")
-                                .arg(context.pc, 8, 16, QLatin1Char('0'))
-                                .arg(context.cpu_registers[30], 8, 16, QLatin1Char('0'));
-    return WaitTreeWaitObject::GetText() + pc_info + " (" + status + ") ";
+                                .arg(context.pc, 8, 16, QLatin1Char{'0'})
+                                .arg(context.cpu_registers[30], 8, 16, QLatin1Char{'0'});
+    return QStringLiteral("%1%2 (%3) ").arg(WaitTreeWaitObject::GetText(), pc_info, status);
 }
 
 QColor WaitTreeThread::GetColor() const {
@@ -424,7 +427,7 @@ void WaitTreeModel::InitItems() {
 }
 
 WaitTreeWidget::WaitTreeWidget(QWidget* parent) : QDockWidget(tr("Wait Tree"), parent) {
-    setObjectName("WaitTreeWidget");
+    setObjectName(QStringLiteral("WaitTreeWidget"));
     view = new QTreeView(this);
     view->setHeaderHidden(true);
     setWidget(view);


### PR DESCRIPTION
Another set of changes that brings us slightly closer to disabling implicit string conversions in Qt code. This makes all of the string conversions explicit in the debugger, which is relatively lower traffic in terms of changes compared to the rest of the UI code.