### PR TITLE
Revert #2466

### DIFF
--- a/src/video_core/macro_interpreter.cpp
+++ b/src/video_core/macro_interpreter.cpp
@@ -120,7 +120,9 @@ bool MacroInterpreter::Step(u32 offset, bool is_delay_slot) {
 
     // An instruction with the Exit flag will not actually
     // cause an exit if it's executed inside a delay slot.
-    if (opcode.is_exit && !is_delay_slot) {
+    // TODO(Blinkhawk): Reversed to always exit. The behavior explained above requires further
+    // testing on the MME code.
+    if (opcode.is_exit) {
         // Exit has a delay slot, execute the next instruction
         Step(offset, true);
         return false;


### PR DESCRIPTION
This reverts a tested behavior on delay slots not exiting if the exit 
flag is set. Currently new tests are required in order to ensure this 
behavior and figure if we are missing something else in our code.