### PR TITLE
shader/shader_ir: Make Comment() take a std::string by value

### DIFF
--- a/src/video_core/shader/shader_ir.cpp
+++ b/src/video_core/shader/shader_ir.cpp
@@ -39,8 +39,8 @@ Node ShaderIR::Conditional(Node condition, std::vector<Node>&& code) {
     return StoreNode(ConditionalNode(condition, std::move(code)));
 }
 
-Node ShaderIR::Comment(const std::string& text) {
-    return StoreNode(CommentNode(text));
+Node ShaderIR::Comment(std::string text) {
+    return StoreNode(CommentNode(std::move(text)));
 }
 
 Node ShaderIR::Immediate(u32 value) {

--- a/src/video_core/shader/shader_ir.h
+++ b/src/video_core/shader/shader_ir.h
@@ -663,7 +663,7 @@ private:
     /// Creates a conditional node
     Node Conditional(Node condition, std::vector<Node>&& code);
     /// Creates a commentary
-    Node Comment(const std::string& text);
+    Node Comment(std::string text);
     /// Creates an u32 immediate
     Node Immediate(u32 value);
     /// Creates a s32 immediate


### PR DESCRIPTION
This allows for forming comment nodes without making unnecessary copies of the std::string instance.

e.g. previously:

```cpp
Comment(fmt::format("Base address is c[0x{:x}][0x{:x}]",
        cbuf->GetIndex(), cbuf_offset));
```

Would result in a copy of the string being created, as CommentNode() takes a std::string by value (a const ref passed to a value parameter results in a copy). Now, only one instance of the string is ever moved around. 