### PR TITLE
service/aoc_u: Minor cleanup

### DIFF
--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -116,15 +116,15 @@ void AOC_U::ListAddOnContent(Kernel::HLERequestContext& ctx) {
     const auto current = Core::System::GetInstance().CurrentProcess()->GetTitleID();
 
     std::vector<u32> out;
-    for (size_t i = 0; i < add_on_content.size(); ++i) {
-        if ((add_on_content[i] & DLC_BASE_TITLE_ID_MASK) == current) {
-            out.push_back(static_cast<u32>(add_on_content[i] & 0x7FF));
-        }
-    }
-
     const auto& disabled = Settings::values.disabled_addons[current];
-    if (std::find(disabled.begin(), disabled.end(), "DLC") != disabled.end()) {
-        out = {};
+    if (std::find(disabled.begin(), disabled.end(), "DLC") == disabled.end()) {
+        for (u64 content_id : add_on_content) {
+            if ((content_id & DLC_BASE_TITLE_ID_MASK) != current) {
+                continue;
+            }
+
+            out.push_back(static_cast<u32>(content_id & 0x7FF));
+        }
     }
 
     if (out.size() < offset) {

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -75,7 +75,15 @@ AOC_U::AOC_U() : ServiceFramework("aoc:u"), add_on_content(AccumulateAOCTitleIDs
 AOC_U::~AOC_U() = default;
 
 void AOC_U::CountAddOnContent(Kernel::HLERequestContext& ctx) {
-    LOG_DEBUG(Service_AOC, "called");
+    struct Parameters {
+        u64 process_id;
+    };
+    static_assert(sizeof(Parameters) == 8);
+
+    IPC::RequestParser rp{ctx};
+    const auto params = rp.PopRaw<Parameters>();
+
+    LOG_DEBUG(Service_AOC, "called. process_id={}", params.process_id);
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
@@ -94,23 +102,32 @@ void AOC_U::CountAddOnContent(Kernel::HLERequestContext& ctx) {
 }
 
 void AOC_U::ListAddOnContent(Kernel::HLERequestContext& ctx) {
-    IPC::RequestParser rp{ctx};
+    struct Parameters {
+        u32 offset;
+        u32 count;
+        u64 process_id;
+    };
+    static_assert(sizeof(Parameters) == 16);
 
-    const auto offset = rp.PopRaw<u32>();
-    auto count = rp.PopRaw<u32>();
-    LOG_DEBUG(Service_AOC, "called with offset={}, count={}", offset, count);
+    IPC::RequestParser rp{ctx};
+    const auto [offset, count, process_id] = rp.PopRaw<Parameters>();
+
+    LOG_DEBUG(Service_AOC, "called with offset={}, count={}, process_id={}", offset, count,
+              process_id);
 
     const auto current = Core::System::GetInstance().CurrentProcess()->GetTitleID();
 
     std::vector<u32> out;
     for (size_t i = 0; i < add_on_content.size(); ++i) {
-        if ((add_on_content[i] & DLC_BASE_TITLE_ID_MASK) == current)
+        if ((add_on_content[i] & DLC_BASE_TITLE_ID_MASK) == current) {
             out.push_back(static_cast<u32>(add_on_content[i] & 0x7FF));
+        }
     }
 
     const auto& disabled = Settings::values.disabled_addons[current];
-    if (std::find(disabled.begin(), disabled.end(), "DLC") != disabled.end())
+    if (std::find(disabled.begin(), disabled.end(), "DLC") != disabled.end()) {
         out = {};
+    }
 
     if (out.size() < offset) {
         IPC::ResponseBuilder rb{ctx, 2};
@@ -119,22 +136,31 @@ void AOC_U::ListAddOnContent(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    count = static_cast<u32>(std::min<size_t>(out.size() - offset, count));
+    const auto out_count = static_cast<u32>(std::min<size_t>(out.size() - offset, count));
     std::rotate(out.begin(), out.begin() + offset, out.end());
-    out.resize(count);
+    out.resize(out_count);
 
     ctx.WriteBuffer(out);
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
-    rb.Push(count);
+    rb.Push(out_count);
 }
 
 void AOC_U::GetAddOnContentBaseId(Kernel::HLERequestContext& ctx) {
-    LOG_DEBUG(Service_AOC, "called");
+    struct Parameters {
+        u64 process_id;
+    };
+    static_assert(sizeof(Parameters) == 8);
+
+    IPC::RequestParser rp{ctx};
+    const auto params = rp.PopRaw<Parameters>();
+
+    LOG_DEBUG(Service_AOC, "called. process_id={}", params.process_id);
 
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
+
     const auto title_id = Core::System::GetInstance().CurrentProcess()->GetTitleID();
     FileSys::PatchManager pm{title_id};
 
@@ -148,10 +174,17 @@ void AOC_U::GetAddOnContentBaseId(Kernel::HLERequestContext& ctx) {
 }
 
 void AOC_U::PrepareAddOnContent(Kernel::HLERequestContext& ctx) {
-    IPC::RequestParser rp{ctx};
+    struct Parameters {
+        s32 addon_index;
+        u64 process_id;
+    };
+    static_assert(sizeof(Parameters) == 16);
 
-    const auto aoc_id = rp.PopRaw<u32>();
-    LOG_WARNING(Service_AOC, "(STUBBED) called with aoc_id={:08X}", aoc_id);
+    IPC::RequestParser rp{ctx};
+    const auto [addon_index, process_id] = rp.PopRaw<Parameters>();
+
+    LOG_WARNING(Service_AOC, "(STUBBED) called with addon_index={}, process_id={}", addon_index,
+                process_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -9,7 +9,6 @@
 #include "core/file_sys/content_archive.h"
 #include "core/file_sys/control_metadata.h"
 #include "core/file_sys/nca_metadata.h"
-#include "core/file_sys/partition_filesystem.h"
 #include "core/file_sys/patch_manager.h"
 #include "core/file_sys/registered_cache.h"
 #include "core/hle/ipc_helpers.h"
@@ -18,7 +17,6 @@
 #include "core/hle/kernel/readable_event.h"
 #include "core/hle/kernel/writable_event.h"
 #include "core/hle/service/aoc/aoc_u.h"
-#include "core/hle/service/filesystem/filesystem.h"
 #include "core/loader/loader.h"
 #include "core/settings.h"
 


### PR DESCRIPTION
Cleanup a bit of the interface and fills in some parameters (we weren't actually popping the process ID parameter) and logs it out along with the rest of the entries. The rest of the changes are relatively minor, like not allocating when we don't need to, etc.