### PR TITLE
renderer_opengl/utils: Use a std::string_view with LabelGLObject()

### DIFF
--- a/src/video_core/renderer_opengl/utils.cpp
+++ b/src/video_core/renderer_opengl/utils.cpp
@@ -38,27 +38,27 @@ void BindBuffersRangePushBuffer::Bind() const {
                        sizes.data());
 }
 
-void LabelGLObject(GLenum identifier, GLuint handle, VAddr addr, std::string extra_info) {
+void LabelGLObject(GLenum identifier, GLuint handle, VAddr addr, std::string_view extra_info) {
     if (!GLAD_GL_KHR_debug) {
-        return; // We don't need to throw an error as this is just for debugging
+        // We don't need to throw an error as this is just for debugging
+        return;
     }
-    const std::string nice_addr = fmt::format("0x{:016x}", addr);
-    std::string object_label;
 
+    std::string object_label;
     if (extra_info.empty()) {
         switch (identifier) {
         case GL_TEXTURE:
-            object_label = "Texture@" + nice_addr;
+            object_label = fmt::format("Texture@0x{:016X}", addr);
             break;
         case GL_PROGRAM:
-            object_label = "Shader@" + nice_addr;
+            object_label = fmt::format("Shader@0x{:016X}", addr);
             break;
         default:
-            object_label = fmt::format("Object(0x{:x})@{}", identifier, nice_addr);
+            object_label = fmt::format("Object(0x{:X})@0x{:016X}", identifier, addr);
             break;
         }
     } else {
-        object_label = extra_info + '@' + nice_addr;
+        object_label = fmt::format("{}@0x{:016X}", extra_info, addr);
     }
     glObjectLabel(identifier, handle, -1, static_cast<const GLchar*>(object_label.c_str()));
 }

--- a/src/video_core/renderer_opengl/utils.h
+++ b/src/video_core/renderer_opengl/utils.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <string>
+#include <string_view>
 #include <vector>
 #include <glad/glad.h>
 #include "common/common_types.h"
@@ -30,6 +30,6 @@ private:
     std::vector<GLsizeiptr> sizes;
 };
 
-void LabelGLObject(GLenum identifier, GLuint handle, VAddr addr, std::string extra_info = "");
+void LabelGLObject(GLenum identifier, GLuint handle, VAddr addr, std::string_view extra_info = {});
 
 } // namespace OpenGL


### PR DESCRIPTION
Uses a std::string_view instead of a std::string, given the pointed to string isn't modified and is only used in a formatting operation. This is nice because a few usages directly supply a string literal to the function, allowing these usages to otherwise not heap allocate, unlike with std::string*. It's also nice for the early-return case, as no resources will be unnecessarily created and destroyed within the function. 

While we're at it, we can combine the address formatting into a single formatting call. 

\* - Unless the std::string implementation does small-string optimization and the string fits in the string buffer.