### PR TITLE
 yuzu_cmd: Split emu_window OpenGL implementation into its own file 

### DIFF
--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -169,8 +169,7 @@ private:
      * For the request to be honored, EmuWindow implementations will usually reimplement this
      * function.
      */
-    virtual void OnMinimalClientAreaChangeRequest(
-        const std::pair<unsigned, unsigned>& minimal_size) {
+    virtual void OnMinimalClientAreaChangeRequest(std::pair<unsigned, unsigned>) {
         // By default, ignore this request and do nothing.
     }
 

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -440,8 +440,7 @@ void GRenderWindow::CaptureScreenshot(u16 res_scale, const QString& screenshot_p
                                layout);
 }
 
-void GRenderWindow::OnMinimalClientAreaChangeRequest(
-    const std::pair<unsigned, unsigned>& minimal_size) {
+void GRenderWindow::OnMinimalClientAreaChangeRequest(std::pair<unsigned, unsigned> minimal_size) {
     setMinimumSize(minimal_size.first, minimal_size.second);
 }
 

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -162,8 +162,7 @@ private:
     void TouchUpdateEvent(const QTouchEvent* event);
     void TouchEndEvent();
 
-    void OnMinimalClientAreaChangeRequest(
-        const std::pair<unsigned, unsigned>& minimal_size) override;
+    void OnMinimalClientAreaChangeRequest(std::pair<unsigned, unsigned> minimal_size) override;
 
     QWidget* container = nullptr;
     GGLWidgetInternal* child = nullptr;

--- a/src/yuzu_cmd/CMakeLists.txt
+++ b/src/yuzu_cmd/CMakeLists.txt
@@ -4,6 +4,8 @@ add_executable(yuzu-cmd
     config.cpp
     config.h
     default_ini.h
+    emu_window/emu_window_sdl2_gl.cpp
+    emu_window/emu_window_sdl2_gl.h
     emu_window/emu_window_sdl2.cpp
     emu_window/emu_window_sdl2.h
     resource.h

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
@@ -2,53 +2,27 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <algorithm>
-#include <cstdlib>
-#include <string>
-#define SDL_MAIN_HANDLED
 #include <SDL.h>
-#include <fmt/format.h>
-#include <glad/glad.h>
 #include "common/logging/log.h"
-#include "common/scm_rev.h"
-#include "common/string_util.h"
-#include "core/settings.h"
 #include "input_common/keyboard.h"
 #include "input_common/main.h"
 #include "input_common/motion_emu.h"
 #include "input_common/sdl/sdl.h"
 #include "yuzu_cmd/emu_window/emu_window_sdl2.h"
 
-class SDLGLContext : public Core::Frontend::GraphicsContext {
-public:
-    explicit SDLGLContext() {
-        // create a hidden window to make the shared context against
-        window = SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, // x position
-                                  SDL_WINDOWPOS_UNDEFINED,     // y position
-                                  Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height,
-                                  SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);
-        context = SDL_GL_CreateContext(window);
+EmuWindow_SDL2::EmuWindow_SDL2(bool fullscreen) {
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) < 0) {
+        LOG_CRITICAL(Frontend, "Failed to initialize SDL2! Exiting...");
+        exit(1);
     }
+    InputCommon::Init();
+    SDL_SetMainReady();
+}
 
-    ~SDLGLContext() {
-        SDL_GL_DeleteContext(context);
-        SDL_DestroyWindow(window);
-    }
-
-    void MakeCurrent() override {
-        SDL_GL_MakeCurrent(window, context);
-    }
-
-    void DoneCurrent() override {
-        SDL_GL_MakeCurrent(window, nullptr);
-    }
-
-    void SwapBuffers() override {}
-
-private:
-    SDL_Window* window;
-    SDL_GLContext context;
-};
+EmuWindow_SDL2::~EmuWindow_SDL2() {
+    InputCommon::Shutdown();
+    SDL_Quit();
+}
 
 void EmuWindow_SDL2::OnMouseMotion(s32 x, s32 y) {
     TouchMoved((unsigned)std::max(x, 0), (unsigned)std::max(y, 0));
@@ -139,112 +113,6 @@ void EmuWindow_SDL2::Fullscreen() {
     SDL_MaximizeWindow(render_window);
 }
 
-bool EmuWindow_SDL2::SupportsRequiredGLExtensions() {
-    std::vector<std::string> unsupported_ext;
-
-    if (!GLAD_GL_ARB_direct_state_access)
-        unsupported_ext.push_back("ARB_direct_state_access");
-    if (!GLAD_GL_ARB_vertex_type_10f_11f_11f_rev)
-        unsupported_ext.push_back("ARB_vertex_type_10f_11f_11f_rev");
-    if (!GLAD_GL_ARB_texture_mirror_clamp_to_edge)
-        unsupported_ext.push_back("ARB_texture_mirror_clamp_to_edge");
-    if (!GLAD_GL_ARB_multi_bind)
-        unsupported_ext.push_back("ARB_multi_bind");
-
-    // Extensions required to support some texture formats.
-    if (!GLAD_GL_EXT_texture_compression_s3tc)
-        unsupported_ext.push_back("EXT_texture_compression_s3tc");
-    if (!GLAD_GL_ARB_texture_compression_rgtc)
-        unsupported_ext.push_back("ARB_texture_compression_rgtc");
-    if (!GLAD_GL_ARB_depth_buffer_float)
-        unsupported_ext.push_back("ARB_depth_buffer_float");
-
-    for (const std::string& ext : unsupported_ext)
-        LOG_CRITICAL(Frontend, "Unsupported GL extension: {}", ext);
-
-    return unsupported_ext.empty();
-}
-
-EmuWindow_SDL2::EmuWindow_SDL2(bool fullscreen) {
-    // Initialize the window
-    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_JOYSTICK) < 0) {
-        LOG_CRITICAL(Frontend, "Failed to initialize SDL2! Exiting...");
-        exit(1);
-    }
-
-    InputCommon::Init();
-
-    SDL_SetMainReady();
-
-    const SDL_GLprofile profile = Settings::values.use_compatibility_profile
-                                      ? SDL_GL_CONTEXT_PROFILE_COMPATIBILITY
-                                      : SDL_GL_CONTEXT_PROFILE_CORE;
-
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, profile);
-    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
-    SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
-    SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
-    SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
-    SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 0);
-    SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
-
-    std::string window_title = fmt::format("yuzu {} | {}-{}", Common::g_build_fullname,
-                                           Common::g_scm_branch, Common::g_scm_desc);
-    render_window =
-        SDL_CreateWindow(window_title.c_str(),
-                         SDL_WINDOWPOS_UNDEFINED, // x position
-                         SDL_WINDOWPOS_UNDEFINED, // y position
-                         Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height,
-                         SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
-
-    if (render_window == nullptr) {
-        LOG_CRITICAL(Frontend, "Failed to create SDL2 window! {}", SDL_GetError());
-        exit(1);
-    }
-
-    if (fullscreen) {
-        Fullscreen();
-    }
-    gl_context = SDL_GL_CreateContext(render_window);
-
-    if (gl_context == nullptr) {
-        LOG_CRITICAL(Frontend, "Failed to create SDL2 GL context! {}", SDL_GetError());
-        exit(1);
-    }
-
-    if (!gladLoadGLLoader(static_cast<GLADloadproc>(SDL_GL_GetProcAddress))) {
-        LOG_CRITICAL(Frontend, "Failed to initialize GL functions! {}", SDL_GetError());
-        exit(1);
-    }
-
-    if (!SupportsRequiredGLExtensions()) {
-        LOG_CRITICAL(Frontend, "GPU does not support all required OpenGL extensions! Exiting...");
-        exit(1);
-    }
-
-    OnResize();
-    OnMinimalClientAreaChangeRequest(GetActiveConfig().min_client_area_size);
-    SDL_PumpEvents();
-    SDL_GL_SetSwapInterval(false);
-    LOG_INFO(Frontend, "yuzu Version: {} | {}-{}", Common::g_build_fullname, Common::g_scm_branch,
-             Common::g_scm_desc);
-    Settings::LogSettings();
-
-    DoneCurrent();
-}
-
-EmuWindow_SDL2::~EmuWindow_SDL2() {
-    InputCommon::Shutdown();
-    SDL_GL_DeleteContext(gl_context);
-    SDL_Quit();
-}
-
-void EmuWindow_SDL2::SwapBuffers() {
-    SDL_GL_SwapWindow(render_window);
-}
-
 void EmuWindow_SDL2::PollEvents() {
     SDL_Event event;
 
@@ -257,7 +125,11 @@ void EmuWindow_SDL2::PollEvents() {
             case SDL_WINDOWEVENT_RESIZED:
             case SDL_WINDOWEVENT_MAXIMIZED:
             case SDL_WINDOWEVENT_RESTORED:
+                OnResize();
+                break;
             case SDL_WINDOWEVENT_MINIMIZED:
+            case SDL_WINDOWEVENT_EXPOSED:
+                is_shown = event.window.event == SDL_WINDOWEVENT_EXPOSED;
                 OnResize();
                 break;
             case SDL_WINDOWEVENT_CLOSE:
@@ -300,20 +172,7 @@ void EmuWindow_SDL2::PollEvents() {
     }
 }
 
-void EmuWindow_SDL2::MakeCurrent() {
-    SDL_GL_MakeCurrent(render_window, gl_context);
-}
-
-void EmuWindow_SDL2::DoneCurrent() {
-    SDL_GL_MakeCurrent(render_window, nullptr);
-}
-
 void EmuWindow_SDL2::OnMinimalClientAreaChangeRequest(
     const std::pair<unsigned, unsigned>& minimal_size) {
-
     SDL_SetWindowMinimumSize(render_window, minimal_size.first, minimal_size.second);
-}
-
-std::unique_ptr<Core::Frontend::GraphicsContext> EmuWindow_SDL2::CreateSharedContext() const {
-    return std::make_unique<SDLGLContext>();
 }

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
@@ -172,7 +172,6 @@ void EmuWindow_SDL2::PollEvents() {
     }
 }
 
-void EmuWindow_SDL2::OnMinimalClientAreaChangeRequest(
-    const std::pair<unsigned, unsigned>& minimal_size) {
+void EmuWindow_SDL2::OnMinimalClientAreaChangeRequest(std::pair<unsigned, unsigned> minimal_size) {
     SDL_SetWindowMinimumSize(render_window, minimal_size.first, minimal_size.second);
 }

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.h
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.h
@@ -50,8 +50,7 @@ protected:
     void Fullscreen();
 
     /// Called when a configuration change affects the minimal size of the window
-    void OnMinimalClientAreaChangeRequest(
-        const std::pair<unsigned, unsigned>& minimal_size) override;
+    void OnMinimalClientAreaChangeRequest(std::pair<unsigned, unsigned> minimal_size) override;
 
     /// Is the window still open?
     bool is_open = true;

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.h
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.h
@@ -15,24 +15,13 @@ public:
     explicit EmuWindow_SDL2(bool fullscreen);
     ~EmuWindow_SDL2();
 
-    /// Swap buffers to display the next frame
-    void SwapBuffers() override;
-
     /// Polls window events
     void PollEvents() override;
-
-    /// Makes the graphics context current for the caller thread
-    void MakeCurrent() override;
-
-    /// Releases the GL context from the caller thread
-    void DoneCurrent() override;
-
-    std::unique_ptr<Core::Frontend::GraphicsContext> CreateSharedContext() const override;
 
     /// Whether the window is still open, and a close request hasn't yet been sent
     bool IsOpen() const;
 
-private:
+protected:
     /// Called by PollEvents when a key is pressed or released.
     void OnKeyEvent(int key, u8 state);
 
@@ -60,9 +49,6 @@ private:
     /// Called when user passes the fullscreen parameter flag
     void Fullscreen();
 
-    /// Whether the GPU and driver supports the OpenGL extension required
-    bool SupportsRequiredGLExtensions();
-
     /// Called when a configuration change affects the minimal size of the window
     void OnMinimalClientAreaChangeRequest(
         const std::pair<unsigned, unsigned>& minimal_size) override;
@@ -70,10 +56,9 @@ private:
     /// Is the window still open?
     bool is_open = true;
 
+    /// Is the window being shown?
+    bool is_shown = true;
+
     /// Internal SDL2 render window
     SDL_Window* render_window;
-
-    using SDL_GLContext = void*;
-    /// The OpenGL context associated with the window
-    SDL_GLContext gl_context;
 };

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.cpp
@@ -1,0 +1,154 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <cstdlib>
+#include <string>
+#define SDL_MAIN_HANDLED
+#include <SDL.h>
+#include <fmt/format.h>
+#include <glad/glad.h>
+#include "common/logging/log.h"
+#include "common/scm_rev.h"
+#include "common/string_util.h"
+#include "core/settings.h"
+#include "input_common/keyboard.h"
+#include "input_common/main.h"
+#include "input_common/motion_emu.h"
+#include "yuzu_cmd/emu_window/emu_window_sdl2_gl.h"
+
+class SDLGLContext : public Core::Frontend::GraphicsContext {
+public:
+    explicit SDLGLContext() {
+        // create a hidden window to make the shared context against
+        window = SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, // x position
+                                  SDL_WINDOWPOS_UNDEFINED,     // y position
+                                  Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height,
+                                  SDL_WINDOW_OPENGL | SDL_WINDOW_HIDDEN);
+        context = SDL_GL_CreateContext(window);
+    }
+
+    ~SDLGLContext() {
+        SDL_GL_DeleteContext(context);
+        SDL_DestroyWindow(window);
+    }
+
+    void MakeCurrent() override {
+        SDL_GL_MakeCurrent(window, context);
+    }
+
+    void DoneCurrent() override {
+        SDL_GL_MakeCurrent(window, nullptr);
+    }
+
+    void SwapBuffers() override {}
+
+private:
+    SDL_Window* window;
+    SDL_GLContext context;
+};
+
+bool EmuWindow_SDL2_GL::SupportsRequiredGLExtensions() {
+    std::vector<std::string> unsupported_ext;
+
+    if (!GLAD_GL_ARB_vertex_type_10f_11f_11f_rev)
+        unsupported_ext.push_back("ARB_vertex_type_10f_11f_11f_rev");
+    if (!GLAD_GL_ARB_texture_mirror_clamp_to_edge)
+        unsupported_ext.push_back("ARB_texture_mirror_clamp_to_edge");
+    if (!GLAD_GL_ARB_multi_bind)
+        unsupported_ext.push_back("ARB_multi_bind");
+
+    // Extensions required to support some texture formats.
+    if (!GLAD_GL_EXT_texture_compression_s3tc)
+        unsupported_ext.push_back("EXT_texture_compression_s3tc");
+    if (!GLAD_GL_ARB_texture_compression_rgtc)
+        unsupported_ext.push_back("ARB_texture_compression_rgtc");
+    if (!GLAD_GL_ARB_depth_buffer_float)
+        unsupported_ext.push_back("ARB_depth_buffer_float");
+
+    for (const std::string& ext : unsupported_ext)
+        LOG_CRITICAL(Frontend, "Unsupported GL extension: {}", ext);
+
+    return unsupported_ext.empty();
+}
+
+EmuWindow_SDL2_GL::EmuWindow_SDL2_GL(bool fullscreen) : EmuWindow_SDL2(fullscreen) {
+    const SDL_GLprofile profile = Settings::values.use_compatibility_profile
+                                      ? SDL_GL_CONTEXT_PROFILE_COMPATIBILITY
+                                      : SDL_GL_CONTEXT_PROFILE_CORE;
+
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, profile);
+    SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+    SDL_GL_SetAttribute(SDL_GL_RED_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 8);
+    SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 0);
+    SDL_GL_SetAttribute(SDL_GL_SHARE_WITH_CURRENT_CONTEXT, 1);
+
+    std::string window_title = fmt::format("yuzu {} | {}-{}", Common::g_build_fullname,
+                                           Common::g_scm_branch, Common::g_scm_desc);
+    render_window =
+        SDL_CreateWindow(window_title.c_str(),
+                         SDL_WINDOWPOS_UNDEFINED, // x position
+                         SDL_WINDOWPOS_UNDEFINED, // y position
+                         Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height,
+                         SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
+
+    if (render_window == nullptr) {
+        LOG_CRITICAL(Frontend, "Failed to create SDL2 window! {}", SDL_GetError());
+        exit(1);
+    }
+
+    if (fullscreen) {
+        Fullscreen();
+    }
+    gl_context = SDL_GL_CreateContext(render_window);
+
+    if (gl_context == nullptr) {
+        LOG_CRITICAL(Frontend, "Failed to create SDL2 GL context! {}", SDL_GetError());
+        exit(1);
+    }
+
+    if (!gladLoadGLLoader(static_cast<GLADloadproc>(SDL_GL_GetProcAddress))) {
+        LOG_CRITICAL(Frontend, "Failed to initialize GL functions! {}", SDL_GetError());
+        exit(1);
+    }
+
+    if (!SupportsRequiredGLExtensions()) {
+        LOG_CRITICAL(Frontend, "GPU does not support all required OpenGL extensions! Exiting...");
+        exit(1);
+    }
+
+    OnResize();
+    OnMinimalClientAreaChangeRequest(GetActiveConfig().min_client_area_size);
+    SDL_PumpEvents();
+    SDL_GL_SetSwapInterval(false);
+    LOG_INFO(Frontend, "yuzu Version: {} | {}-{}", Common::g_build_fullname, Common::g_scm_branch,
+             Common::g_scm_desc);
+    Settings::LogSettings();
+
+    DoneCurrent();
+}
+
+EmuWindow_SDL2_GL::~EmuWindow_SDL2_GL() {
+    SDL_GL_DeleteContext(gl_context);
+}
+
+void EmuWindow_SDL2_GL::SwapBuffers() {
+    SDL_GL_SwapWindow(render_window);
+}
+
+void EmuWindow_SDL2_GL::MakeCurrent() {
+    SDL_GL_MakeCurrent(render_window, gl_context);
+}
+
+void EmuWindow_SDL2_GL::DoneCurrent() {
+    SDL_GL_MakeCurrent(render_window, nullptr);
+}
+
+std::unique_ptr<Core::Frontend::GraphicsContext> EmuWindow_SDL2_GL::CreateSharedContext() const {
+    return std::make_unique<SDLGLContext>();
+}

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.h
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.h
@@ -1,0 +1,34 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include "core/frontend/emu_window.h"
+#include "yuzu_cmd/emu_window/emu_window_sdl2.h"
+
+class EmuWindow_SDL2_GL final : public EmuWindow_SDL2 {
+public:
+    explicit EmuWindow_SDL2_GL(bool fullscreen);
+    ~EmuWindow_SDL2_GL();
+
+    /// Swap buffers to display the next frame
+    void SwapBuffers() override;
+
+    /// Makes the graphics context current for the caller thread
+    void MakeCurrent() override;
+
+    /// Releases the GL context from the caller thread
+    void DoneCurrent() override;
+
+    std::unique_ptr<Core::Frontend::GraphicsContext> CreateSharedContext() const override;
+
+private:
+    /// Whether the GPU and driver supports the OpenGL extension required
+    bool SupportsRequiredGLExtensions();
+
+    using SDL_GLContext = void*;
+    /// The OpenGL context associated with the window
+    SDL_GLContext gl_context;
+};

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -31,6 +31,7 @@
 #include "video_core/renderer_base.h"
 #include "yuzu_cmd/config.h"
 #include "yuzu_cmd/emu_window/emu_window_sdl2.h"
+#include "yuzu_cmd/emu_window/emu_window_sdl2_gl.h"
 
 #include "core/file_sys/registered_cache.h"
 
@@ -173,7 +174,7 @@ int main(int argc, char** argv) {
     Settings::values.use_gdbstub = use_gdbstub;
     Settings::Apply();
 
-    std::unique_ptr<EmuWindow_SDL2> emu_window{std::make_unique<EmuWindow_SDL2>(fullscreen)};
+    std::unique_ptr<EmuWindow_SDL2> emu_window{std::make_unique<EmuWindow_SDL2_GL>(fullscreen)};
 
     if (!Settings::values.use_multi_core) {
         // Single core mode must acquire OpenGL context for entire emulation session


### PR DESCRIPTION
Moves OpenGL specific SDL2 window initialization to its own file.