### PR TITLE
yuzu/{profile_select, software_keyboard}: Tidy up interface

### DIFF
--- a/src/yuzu/applets/profile_select.cpp
+++ b/src/yuzu/applets/profile_select.cpp
@@ -122,18 +122,12 @@ QtProfileSelectionDialog::QtProfileSelectionDialog(QWidget* parent)
 QtProfileSelectionDialog::~QtProfileSelectionDialog() = default;
 
 void QtProfileSelectionDialog::accept() {
-    ok = true;
     QDialog::accept();
 }
 
 void QtProfileSelectionDialog::reject() {
-    ok = false;
     user_index = 0;
     QDialog::reject();
-}
-
-bool QtProfileSelectionDialog::GetStatus() const {
-    return ok;
 }
 
 int QtProfileSelectionDialog::GetIndex() const {

--- a/src/yuzu/applets/profile_select.cpp
+++ b/src/yuzu/applets/profile_select.cpp
@@ -136,7 +136,7 @@ bool QtProfileSelectionDialog::GetStatus() const {
     return ok;
 }
 
-u32 QtProfileSelectionDialog::GetIndex() const {
+int QtProfileSelectionDialog::GetIndex() const {
     return user_index;
 }
 

--- a/src/yuzu/applets/profile_select.h
+++ b/src/yuzu/applets/profile_select.h
@@ -29,14 +29,12 @@ public:
     void accept() override;
     void reject() override;
 
-    bool GetStatus() const;
     int GetIndex() const;
 
 private:
-    bool ok = false;
-    int user_index = 0;
-
     void SelectUser(const QModelIndex& index);
+
+    int user_index = 0;
 
     QVBoxLayout* layout;
     QTreeView* tree_view;

--- a/src/yuzu/applets/profile_select.h
+++ b/src/yuzu/applets/profile_select.h
@@ -30,11 +30,11 @@ public:
     void reject() override;
 
     bool GetStatus() const;
-    u32 GetIndex() const;
+    int GetIndex() const;
 
 private:
     bool ok = false;
-    u32 user_index = 0;
+    int user_index = 0;
 
     void SelectUser(const QModelIndex& index);
 

--- a/src/yuzu/applets/software_keyboard.cpp
+++ b/src/yuzu/applets/software_keyboard.cpp
@@ -104,23 +104,17 @@ QtSoftwareKeyboardDialog::QtSoftwareKeyboardDialog(
 QtSoftwareKeyboardDialog::~QtSoftwareKeyboardDialog() = default;
 
 void QtSoftwareKeyboardDialog::accept() {
-    ok = true;
     text = line_edit->text().toStdU16String();
     QDialog::accept();
 }
 
 void QtSoftwareKeyboardDialog::reject() {
-    ok = false;
     text.clear();
     QDialog::reject();
 }
 
 std::u16string QtSoftwareKeyboardDialog::GetText() const {
     return text;
-}
-
-bool QtSoftwareKeyboardDialog::GetStatus() const {
-    return ok;
 }
 
 QtSoftwareKeyboard::QtSoftwareKeyboard(GMainWindow& main_window) {

--- a/src/yuzu/applets/software_keyboard.h
+++ b/src/yuzu/applets/software_keyboard.h
@@ -36,10 +36,8 @@ public:
     void reject() override;
 
     std::u16string GetText() const;
-    bool GetStatus() const;
 
 private:
-    bool ok = false;
     std::u16string text;
 
     QDialogButtonBox* buttons;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -259,9 +259,8 @@ void GMainWindow::SoftwareKeyboardGetText(
     dialog.setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint |
                           Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint);
     dialog.setWindowModality(Qt::WindowModal);
-    dialog.exec();
 
-    if (!dialog.GetStatus()) {
+    if (dialog.exec() == QDialog::Rejected) {
         emit SoftwareKeyboardFinishedText(std::nullopt);
         return;
     }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -246,7 +246,7 @@ void GMainWindow::ProfileSelectorSelectProfile() {
     }
 
     Service::Account::ProfileManager manager;
-    const auto uuid = manager.GetUser(dialog.GetIndex());
+    const auto uuid = manager.GetUser(static_cast<std::size_t>(dialog.GetIndex()));
     if (!uuid.has_value()) {
         emit ProfileSelectorFinishedSelection(std::nullopt);
         return;
@@ -904,7 +904,7 @@ void GMainWindow::SelectAndSetCurrentUser() {
     dialog.exec();
 
     if (dialog.GetStatus()) {
-        Settings::values.current_user = static_cast<s32>(dialog.GetIndex());
+        Settings::values.current_user = dialog.GetIndex();
     }
 }
 
@@ -1055,7 +1055,7 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
         const std::string nand_dir = FileUtil::GetUserPath(FileUtil::UserPath::NANDDir);
         ASSERT(program_id != 0);
 
-        const auto select_profile = [this]() -> s32 {
+        const auto select_profile = [this] {
             QtProfileSelectionDialog dialog(this);
             dialog.setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint |
                                   Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint);
@@ -1070,11 +1070,12 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
         };
 
         const auto index = select_profile();
-        if (index == -1)
+        if (index == -1) {
             return;
+        }
 
         Service::Account::ProfileManager manager;
-        const auto user_id = manager.GetUser(index);
+        const auto user_id = manager.GetUser(static_cast<std::size_t>(index));
         ASSERT(user_id);
         path = nand_dir + FileSys::SaveDataFactory::GetFullPath(FileSys::SaveDataSpaceId::NandUser,
                                                                 FileSys::SaveDataType::SaveData,

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -238,9 +238,7 @@ void GMainWindow::ProfileSelectorSelectProfile() {
     dialog.setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint |
                           Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint);
     dialog.setWindowModality(Qt::WindowModal);
-    dialog.exec();
-
-    if (!dialog.GetStatus()) {
+    if (dialog.exec() == QDialog::Rejected) {
         emit ProfileSelectorFinishedSelection(std::nullopt);
         return;
     }
@@ -901,11 +899,12 @@ void GMainWindow::SelectAndSetCurrentUser() {
     dialog.setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint |
                           Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint);
     dialog.setWindowModality(Qt::WindowModal);
-    dialog.exec();
 
-    if (dialog.GetStatus()) {
-        Settings::values.current_user = dialog.GetIndex();
+    if (dialog.exec() == QDialog::Rejected) {
+        return;
     }
+
+    Settings::values.current_user = dialog.GetIndex();
 }
 
 void GMainWindow::BootGame(const QString& filename) {
@@ -1060,9 +1059,8 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
             dialog.setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowTitleHint |
                                   Qt::WindowSystemMenuHint | Qt::WindowCloseButtonHint);
             dialog.setWindowModality(Qt::WindowModal);
-            dialog.exec();
 
-            if (!dialog.GetStatus()) {
+            if (dialog.exec() == QDialog::Rejected) {
                 return -1;
             }
 


### PR DESCRIPTION
The index value returned by Qt is always going to be signed, so we shouldn't be returning it as an unsigned value; especially when we might be operating with other Qt objects that make use of it. Instead, we can convert it to the unsigned variant for functions that specifically need the index as an unsigned value.

We can also eliminate the GetStatus() function, as this behavior is already provided by the `QDialog::exec` function. We just need to check the return value of it.