### PR TITLE
yuzu/bootmanager: Minor interface tidying

### DIFF
--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -20,7 +20,7 @@ static Common::Rectangle<T> MaxRectangle(Common::Rectangle<T> window_area,
                                 static_cast<T>(std::round(scale * screen_aspect_ratio))};
 }
 
-FramebufferLayout DefaultFrameLayout(unsigned width, unsigned height) {
+FramebufferLayout DefaultFrameLayout(u32 width, u32 height) {
     ASSERT(width > 0);
     ASSERT(height > 0);
     // The drawing code needs at least somewhat valid values for both screens
@@ -29,22 +29,23 @@ FramebufferLayout DefaultFrameLayout(unsigned width, unsigned height) {
 
     const float emulation_aspect_ratio{static_cast<float>(ScreenUndocked::Height) /
                                        ScreenUndocked::Width};
-    Common::Rectangle<unsigned> screen_window_area{0, 0, width, height};
-    Common::Rectangle<unsigned> screen = MaxRectangle(screen_window_area, emulation_aspect_ratio);
+    const auto window_aspect_ratio = static_cast<float>(height) / width;
 
-    float window_aspect_ratio = static_cast<float>(height) / width;
+    const Common::Rectangle<u32> screen_window_area{0, 0, width, height};
+    Common::Rectangle<u32> screen = MaxRectangle(screen_window_area, emulation_aspect_ratio);
 
     if (window_aspect_ratio < emulation_aspect_ratio) {
         screen = screen.TranslateX((screen_window_area.GetWidth() - screen.GetWidth()) / 2);
     } else {
         screen = screen.TranslateY((height - screen.GetHeight()) / 2);
     }
+
     res.screen = screen;
     return res;
 }
 
-FramebufferLayout FrameLayoutFromResolutionScale(u16 res_scale) {
-    int width, height;
+FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale) {
+    u32 width, height;
 
     if (Settings::values.use_docked_mode) {
         width = ScreenDocked::WidthDocked * res_scale;

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -8,15 +8,22 @@
 
 namespace Layout {
 
-enum ScreenUndocked : unsigned { Width = 1280, Height = 720 };
-enum ScreenDocked : unsigned { WidthDocked = 1920, HeightDocked = 1080 };
+enum ScreenUndocked : u32 {
+    Width = 1280,
+    Height = 720,
+};
+
+enum ScreenDocked : u32 {
+    WidthDocked = 1920,
+    HeightDocked = 1080,
+};
 
 /// Describes the layout of the window framebuffer
 struct FramebufferLayout {
-    unsigned width{ScreenUndocked::Width};
-    unsigned height{ScreenUndocked::Height};
+    u32 width{ScreenUndocked::Width};
+    u32 height{ScreenUndocked::Height};
 
-    Common::Rectangle<unsigned> screen;
+    Common::Rectangle<u32> screen;
 
     /**
      * Returns the ration of pixel size of the screen, compared to the native size of the undocked
@@ -33,12 +40,12 @@ struct FramebufferLayout {
  * @param height Window framebuffer height in pixels
  * @return Newly created FramebufferLayout object with default screen regions initialized
  */
-FramebufferLayout DefaultFrameLayout(unsigned width, unsigned height);
+FramebufferLayout DefaultFrameLayout(u32 width, u32 height);
 
 /**
  * Convenience method to get frame layout by resolution scale
  * @param res_scale resolution scale factor
  */
-FramebufferLayout FrameLayoutFromResolutionScale(u16 res_scale);
+FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale);
 
 } // namespace Layout

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -185,7 +185,7 @@ private:
     bool do_painting;
 };
 
-GRenderWindow::GRenderWindow(QWidget* parent, EmuThread* emu_thread)
+GRenderWindow::GRenderWindow(GMainWindow* parent, EmuThread* emu_thread)
     : QWidget(parent), emu_thread(emu_thread) {
     setWindowTitle(QStringLiteral("yuzu %1 | %2-%3")
                        .arg(QString::fromUtf8(Common::g_build_name),
@@ -194,8 +194,7 @@ GRenderWindow::GRenderWindow(QWidget* parent, EmuThread* emu_thread)
     setAttribute(Qt::WA_AcceptTouchEvents);
 
     InputCommon::Init();
-    connect(this, &GRenderWindow::FirstFrameDisplayed, static_cast<GMainWindow*>(parent),
-            &GMainWindow::OnLoadComplete);
+    connect(this, &GRenderWindow::FirstFrameDisplayed, parent, &GMainWindow::OnLoadComplete);
 }
 
 GRenderWindow::~GRenderWindow() {

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -394,7 +394,7 @@ void GRenderWindow::InitRenderTarget() {
     context->setShareContext(shared_context.get());
     context->setFormat(fmt);
     context->create();
-    fmt.setSwapInterval(false);
+    fmt.setSwapInterval(0);
 
     child = new GGLWidgetInternal(this, shared_context.get());
     container = QWidget::createWindowContainer(child, this);

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -246,9 +246,9 @@ void GRenderWindow::PollEvents() {}
 void GRenderWindow::OnFramebufferSizeChanged() {
     // Screen changes potentially incur a change in screen DPI, hence we should update the
     // framebuffer size
-    qreal pixelRatio = GetWindowPixelRatio();
-    unsigned width = child->QPaintDevice::width() * pixelRatio;
-    unsigned height = child->QPaintDevice::height() * pixelRatio;
+    const qreal pixel_ratio = GetWindowPixelRatio();
+    const u32 width = child->QPaintDevice::width() * pixel_ratio;
+    const u32 height = child->QPaintDevice::height() * pixel_ratio;
     UpdateCurrentFramebufferLayout(width, height);
 }
 
@@ -294,10 +294,10 @@ qreal GRenderWindow::GetWindowPixelRatio() const {
     return windowHandle() ? windowHandle()->screen()->devicePixelRatio() : 1.0f;
 }
 
-std::pair<unsigned, unsigned> GRenderWindow::ScaleTouch(const QPointF pos) const {
+std::pair<u32, u32> GRenderWindow::ScaleTouch(const QPointF pos) const {
     const qreal pixel_ratio = GetWindowPixelRatio();
-    return {static_cast<unsigned>(std::max(std::round(pos.x() * pixel_ratio), qreal{0.0})),
-            static_cast<unsigned>(std::max(std::round(pos.y() * pixel_ratio), qreal{0.0}))};
+    return {static_cast<u32>(std::max(std::round(pos.x() * pixel_ratio), qreal{0.0})),
+            static_cast<u32>(std::max(std::round(pos.y() * pixel_ratio), qreal{0.0}))};
 }
 
 void GRenderWindow::closeEvent(QCloseEvent* event) {
@@ -353,7 +353,7 @@ void GRenderWindow::focusOutEvent(QFocusEvent* event) {
     InputCommon::GetKeyboard()->ReleaseAllKeys();
 }
 
-void GRenderWindow::OnClientAreaResized(unsigned width, unsigned height) {
+void GRenderWindow::OnClientAreaResized(u32 width, u32 height) {
     NotifyClientAreaSizeChanged(std::make_pair(width, height));
 }
 
@@ -440,7 +440,7 @@ void GRenderWindow::CaptureScreenshot(u16 res_scale, const QString& screenshot_p
                                layout);
 }
 
-void GRenderWindow::OnMinimalClientAreaChangeRequest(std::pair<unsigned, unsigned> minimal_size) {
+void GRenderWindow::OnMinimalClientAreaChangeRequest(std::pair<u32, u32> minimal_size) {
     setMinimumSize(minimal_size.first, minimal_size.second);
 }
 

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -426,11 +426,12 @@ void GRenderWindow::InitRenderTarget() {
     BackupGeometry();
 }
 
-void GRenderWindow::CaptureScreenshot(u16 res_scale, const QString& screenshot_path) {
+void GRenderWindow::CaptureScreenshot(u32 res_scale, const QString& screenshot_path) {
     auto& renderer = Core::System::GetInstance().Renderer();
 
-    if (!res_scale)
+    if (res_scale == 0) {
         res_scale = VideoCore::GetResolutionScaleFactor(renderer);
+    }
 
     const Layout::FramebufferLayout layout{Layout::FrameLayoutFromResolutionScale(res_scale)};
     screenshot_image = QImage(QSize(layout.width, layout.height), QImage::Format_RGB32);

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -435,12 +435,17 @@ void GRenderWindow::CaptureScreenshot(u32 res_scale, const QString& screenshot_p
 
     const Layout::FramebufferLayout layout{Layout::FrameLayoutFromResolutionScale(res_scale)};
     screenshot_image = QImage(QSize(layout.width, layout.height), QImage::Format_RGB32);
-    renderer.RequestScreenshot(screenshot_image.bits(),
-                               [=] {
-                                   screenshot_image.mirrored(false, true).save(screenshot_path);
-                                   LOG_INFO(Frontend, "The screenshot is saved.");
-                               },
-                               layout);
+    renderer.RequestScreenshot(
+        screenshot_image.bits(),
+        [=] {
+            const std::string std_screenshot_path = screenshot_path.toStdString();
+            if (screenshot_image.mirrored(false, true).save(screenshot_path)) {
+                LOG_INFO(Frontend, "Screenshot saved to \"{}\"", std_screenshot_path);
+            } else {
+                LOG_ERROR(Frontend, "Failed to save screenshot to \"{}\"", std_screenshot_path);
+            }
+        },
+        layout);
 }
 
 void GRenderWindow::OnMinimalClientAreaChangeRequest(std::pair<u32, u32> minimal_size) {

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -26,6 +26,8 @@
 
 EmuThread::EmuThread(GRenderWindow* render_window) : render_window(render_window) {}
 
+EmuThread::~EmuThread() = default;
+
 void EmuThread::run() {
     render_window->MakeCurrent();
 

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -266,7 +266,7 @@ void GRenderWindow::ForwardKeyReleaseEvent(QKeyEvent* event) {
 }
 
 void GRenderWindow::BackupGeometry() {
-    geometry = ((QWidget*)this)->saveGeometry();
+    geometry = QWidget::saveGeometry();
 }
 
 void GRenderWindow::RestoreGeometry() {
@@ -283,10 +283,11 @@ void GRenderWindow::restoreGeometry(const QByteArray& geometry) {
 QByteArray GRenderWindow::saveGeometry() {
     // If we are a top-level widget, store the current geometry
     // otherwise, store the last backup
-    if (parent() == nullptr)
-        return ((QWidget*)this)->saveGeometry();
-    else
-        return geometry;
+    if (parent() == nullptr) {
+        return QWidget::saveGeometry();
+    }
+
+    return geometry;
 }
 
 qreal GRenderWindow::GetWindowPixelRatio() const {

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -144,7 +144,7 @@ public:
 
     void InitRenderTarget();
 
-    void CaptureScreenshot(u16 res_scale, const QString& screenshot_path);
+    void CaptureScreenshot(u32 res_scale, const QString& screenshot_path);
 
 public slots:
     void moveContext(); // overridden

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -133,13 +133,13 @@ public:
     QByteArray saveGeometry();                        // overridden
 
     qreal GetWindowPixelRatio() const;
-    std::pair<unsigned, unsigned> ScaleTouch(const QPointF pos) const;
+    std::pair<u32, u32> ScaleTouch(QPointF pos) const;
 
     void closeEvent(QCloseEvent* event) override;
     bool event(QEvent* event) override;
     void focusOutEvent(QFocusEvent* event) override;
 
-    void OnClientAreaResized(unsigned width, unsigned height);
+    void OnClientAreaResized(u32 width, u32 height);
 
     void InitRenderTarget();
 
@@ -162,7 +162,7 @@ private:
     void TouchUpdateEvent(const QTouchEvent* event);
     void TouchEndEvent();
 
-    void OnMinimalClientAreaChangeRequest(std::pair<unsigned, unsigned> minimal_size) override;
+    void OnMinimalClientAreaChangeRequest(std::pair<u32, u32> minimal_size) override;
 
     QWidget* container = nullptr;
     GGLWidgetInternal* child = nullptr;

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -114,7 +114,7 @@ class GRenderWindow : public QWidget, public Core::Frontend::EmuWindow {
     Q_OBJECT
 
 public:
-    GRenderWindow(QWidget* parent, EmuThread* emu_thread);
+    GRenderWindow(GMainWindow* parent, EmuThread* emu_thread);
     ~GRenderWindow() override;
 
     // EmuWindow implementation

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -27,11 +27,12 @@ namespace VideoCore {
 enum class LoadCallbackStage;
 }
 
-class EmuThread : public QThread {
+class EmuThread final : public QThread {
     Q_OBJECT
 
 public:
     explicit EmuThread(GRenderWindow* render_window);
+    ~EmuThread() override;
 
     /**
      * Start emulation (on new thread)


### PR DESCRIPTION
Tidies up a bit of the bootmanager code and makes it safer. Particularly, we now enforce that the parent of GRenderWindow is GMainWindow, and get rid of the downcast within the constructor, which makes the interface more type-safe.

We also now log out the destination of a screenshot rather than just saying it was saved. We also check if it actually successfully saved to disk before printing said logging message out. If we were unable to save the screenshot to disk, we now display an error message in the log.

The rest of the changes are primarily cosmetic changes made to make reading it nicer.