### PR TITLE
common/math_util: Provide a template deduction guide for Common::Rectangle

### DIFF
--- a/src/common/math_util.h
+++ b/src/common/math_util.h
@@ -41,4 +41,7 @@ struct Rectangle {
     }
 };
 
+template <typename T>
+Rectangle(T, T, T, T)->Rectangle<T>;
+
 } // namespace Common


### PR DESCRIPTION
Allows for things such as:

```cpp
auto rect = Common::Rectangle{0, 0, 0, 0};
```

as opposed to being required to explicitly write out the underlying type, like:

```cpp
auto rect = Common::Rectangle<int>{0, 0, 0, 0};
```

The only requirement for the deduction is that all constructor arguments be the same type.