### PR TITLE
shader: Split SSY and PBK stack

### DIFF
--- a/src/video_core/shader/node.h
+++ b/src/video_core/shader/node.h
@@ -174,6 +174,11 @@ enum class InternalFlag {
     Amount = 4,
 };
 
+enum class MetaStackClass {
+    Ssy,
+    Pbk,
+};
+
 class OperationNode;
 class ConditionalNode;
 class GprNode;
@@ -285,7 +290,7 @@ struct MetaTexture {
 };
 
 /// Parameters that modify an operation but are not part of any particular operand
-using Meta = std::variant<MetaArithmetic, MetaTexture, Tegra::Shader::HalfType>;
+using Meta = std::variant<MetaArithmetic, MetaTexture, MetaStackClass, Tegra::Shader::HalfType>;
 
 /// Holds any kind of operation that can be done in the IR
 class OperationNode final {


### PR DESCRIPTION
Hardware testing revealed that SSY and PBK push to a different stack, allowing code like this:
```        SSY label1;
        PBK label2;
        SYNC;
label1: PBK;
label2: EXIT;
```