### PR TITLE
bcat: Implement BCAT service and connect to yuzu Boxcat server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -46,3 +46,9 @@
 [submodule "sirit"]
     path = externals/sirit
     url = https://github.com/ReinUsesLisp/sirit
+[submodule "libzip"]
+	path = externals/libzip
+	url = https://github.com/DarkLordZach/libzip
+[submodule "zlib"]
+	path = externals/zlib
+	url = https://github.com/DarkLordZach/zlib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ option(YUZU_USE_BUNDLED_UNICORN "Build/Download bundled Unicorn" ON)
 
 option(YUZU_USE_QT_WEB_ENGINE "Use QtWebEngine for web applet implementation" OFF)
 
+option(YUZU_ENABLE_BOXCAT "Enable the Boxcat service, a yuzu high-level implementation of BCAT" ON)
+
 option(ENABLE_CUBEB "Enables the cubeb audio backend" ON)
 
 option(ENABLE_VULKAN "Enables Vulkan backend" ON)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -77,6 +77,12 @@ if (ENABLE_VULKAN)
     add_subdirectory(sirit)
 endif()
 
+# libzip
+add_subdirectory(libzip)
+
+# zlib
+add_subdirectory(zlib)
+
 if (ENABLE_WEB_SERVICE)
     # LibreSSL
     set(LIBRESSL_SKIP_INSTALL ON CACHE BOOL "")

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,3 +1,9 @@
+if (YUZU_ENABLE_BOXCAT)
+    set(BCAT_BOXCAT_ADDITIONAL_SOURCES hle/service/bcat/backend/boxcat.cpp hle/service/bcat/backend/boxcat.h)
+else()
+    set(BCAT_BOXCAT_ADDITIONAL_SOURCES)
+endif()
+
 add_library(core STATIC
     arm/arm_interface.h
     arm/arm_interface.cpp
@@ -82,6 +88,8 @@ add_library(core STATIC
     file_sys/vfs_concat.h
     file_sys/vfs_layered.cpp
     file_sys/vfs_layered.h
+    file_sys/vfs_libzip.cpp
+    file_sys/vfs_libzip.h
     file_sys/vfs_offset.cpp
     file_sys/vfs_offset.h
     file_sys/vfs_real.cpp
@@ -241,6 +249,9 @@ add_library(core STATIC
     hle/service/audio/errors.h
     hle/service/audio/hwopus.cpp
     hle/service/audio/hwopus.h
+    hle/service/bcat/backend/backend.cpp
+    hle/service/bcat/backend/backend.h
+    ${BCAT_BOXCAT_ADDITIONAL_SOURCES}
     hle/service/bcat/bcat.cpp
     hle/service/bcat/bcat.h
     hle/service/bcat/module.cpp
@@ -499,6 +510,15 @@ create_target_directory_groups(core)
 
 target_link_libraries(core PUBLIC common PRIVATE audio_core video_core)
 target_link_libraries(core PUBLIC Boost::boost PRIVATE fmt json-headers mbedtls opus unicorn open_source_archives)
+
+if (YUZU_ENABLE_BOXCAT)
+    get_directory_property(OPENSSL_LIBS
+        DIRECTORY ${PROJECT_SOURCE_DIR}/externals/libressl
+        DEFINITION OPENSSL_LIBS)
+    target_compile_definitions(core PRIVATE -DCPPHTTPLIB_OPENSSL_SUPPORT -DYUZU_ENABLE_BOXCAT)
+    target_link_libraries(core PRIVATE httplib json-headers ${OPENSSL_LIBS} zip)
+endif()
+
 if (ENABLE_WEB_SERVICE)
     target_compile_definitions(core PRIVATE -DENABLE_WEB_SERVICE)
     target_link_libraries(core PRIVATE web_service)

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -339,6 +339,7 @@ struct System::Impl {
 
     std::unique_ptr<Memory::CheatEngine> cheat_engine;
     std::unique_ptr<Tools::Freezer> memory_freezer;
+    std::array<u8, 0x20> build_id{};
 
     /// Frontend applets
     Service::AM::Applets::AppletManager applet_manager;
@@ -638,6 +639,14 @@ void System::SetExitLock(bool locked) {
 
 bool System::GetExitLock() const {
     return impl->exit_lock;
+}
+
+void System::SetCurrentProcessBuildID(std::array<u8, 32> id) {
+    impl->build_id = id;
+}
+
+const std::array<u8, 32>& System::GetCurrentProcessBuildID() const {
+    return impl->build_id;
 }
 
 System::ResultStatus System::Init(Frontend::EmuWindow& emu_window) {

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -330,6 +330,10 @@ public:
 
     bool GetExitLock() const;
 
+    void SetCurrentProcessBuildID(std::array<u8, 0x20> id);
+
+    const std::array<u8, 0x20>& GetCurrentProcessBuildID() const;
+
 private:
     System();
 

--- a/src/core/file_sys/bis_factory.cpp
+++ b/src/core/file_sys/bis_factory.cpp
@@ -136,4 +136,9 @@ u64 BISFactory::GetFullNANDTotalSpace() const {
     return static_cast<u64>(Settings::values.nand_total_size);
 }
 
+VirtualDir BISFactory::GetBCATDirectory(u64 title_id) const {
+    return GetOrCreateDirectoryRelative(nand_root,
+                                        fmt::format("/system/save/bcat/{:016X}", title_id));
+}
+
 } // namespace FileSys

--- a/src/core/file_sys/bis_factory.h
+++ b/src/core/file_sys/bis_factory.h
@@ -61,6 +61,8 @@ public:
     u64 GetUserNANDTotalSpace() const;
     u64 GetFullNANDTotalSpace() const;
 
+    VirtualDir GetBCATDirectory(u64 title_id) const;
+
 private:
     VirtualDir nand_root;
     VirtualDir load_root;

--- a/src/core/file_sys/vfs_libzip.cpp
+++ b/src/core/file_sys/vfs_libzip.cpp
@@ -15,13 +15,13 @@ VirtualDir ExtractZIP(VirtualFile file) {
     zip_error_t error{};
 
     const auto data = file->ReadAllBytes();
-    std::unique_ptr<zip_source_t, decltype(&zip_source_free)> src{
-        zip_source_buffer_create(data.data(), data.size(), 0, &error), zip_source_free};
+    std::unique_ptr<zip_source_t, decltype(&zip_source_close)> src{
+        zip_source_buffer_create(data.data(), data.size(), 0, &error), zip_source_close};
     if (src == nullptr)
         return nullptr;
 
-    std::unique_ptr<zip_t, decltype(&zip_discard)> zip{zip_open_from_source(src.get(), 0, &error),
-                                                       zip_discard};
+    std::unique_ptr<zip_t, decltype(&zip_close)> zip{zip_open_from_source(src.get(), 0, &error),
+                                                     zip_close};
     if (zip == nullptr)
         return nullptr;
 

--- a/src/core/file_sys/vfs_libzip.cpp
+++ b/src/core/file_sys/vfs_libzip.cpp
@@ -1,0 +1,83 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <string>
+#include <zip.h>
+#include "common/logging/backend.h"
+#include "core/file_sys/vfs.h"
+#include "core/file_sys/vfs_libzip.h"
+#include "core/file_sys/vfs_vector.h"
+
+namespace FileSys {
+
+VirtualDir ExtractZIP(VirtualFile file) {
+    zip_error_t error{};
+
+    const auto data = file->ReadAllBytes();
+    const auto src = zip_source_buffer_create(data.data(), data.size(), 0, &error);
+    if (src == nullptr)
+        return nullptr;
+
+    const auto zip = zip_open_from_source(src, 0, &error);
+    if (zip == nullptr)
+        return nullptr;
+
+    std::shared_ptr<VectorVfsDirectory> out = std::make_shared<VectorVfsDirectory>();
+
+    const auto num_entries = zip_get_num_entries(zip, 0);
+    if (num_entries == -1)
+        return nullptr;
+
+    zip_stat_t stat{};
+    zip_stat_init(&stat);
+
+    for (std::size_t i = 0; i < num_entries; ++i) {
+        const auto stat_res = zip_stat_index(zip, i, 0, &stat);
+        if (stat_res == -1)
+            return nullptr;
+
+        const std::string name(stat.name);
+        if (name.empty())
+            continue;
+
+        if (name[name.size() - 1] != '/') {
+            const auto file = zip_fopen_index(zip, i, 0);
+
+            std::vector<u8> buf(stat.size);
+            if (zip_fread(file, buf.data(), buf.size()) != buf.size())
+                return nullptr;
+
+            zip_fclose(file);
+
+            const auto parts = FileUtil::SplitPathComponents(stat.name);
+            const auto new_file = std::make_shared<VectorVfsFile>(buf, parts.back());
+
+            std::shared_ptr<VectorVfsDirectory> dtrv = out;
+            for (std::size_t j = 0; j < parts.size() - 1; ++j) {
+                if (dtrv == nullptr)
+                    return nullptr;
+                const auto subdir = dtrv->GetSubdirectory(parts[j]);
+                if (subdir == nullptr) {
+                    const auto temp = std::make_shared<VectorVfsDirectory>(
+                        std::vector<VirtualFile>{}, std::vector<VirtualDir>{}, parts[j]);
+                    dtrv->AddDirectory(temp);
+                    dtrv = temp;
+                } else {
+                    dtrv = std::dynamic_pointer_cast<VectorVfsDirectory>(subdir);
+                }
+            }
+
+            if (dtrv == nullptr)
+                return nullptr;
+            dtrv->AddFile(new_file);
+        }
+    }
+
+    zip_source_close(src);
+    zip_close(zip);
+
+    return out;
+}
+
+} // namespace FileSys

--- a/src/core/file_sys/vfs_libzip.h
+++ b/src/core/file_sys/vfs_libzip.h
@@ -1,0 +1,13 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/file_sys/vfs_types.h"
+
+namespace FileSys {
+
+VirtualDir ExtractZIP(VirtualFile zip);
+
+} // namespace FileSys

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -31,6 +31,7 @@
 #include "core/hle/service/am/tcap.h"
 #include "core/hle/service/apm/controller.h"
 #include "core/hle/service/apm/interface.h"
+#include "core/hle/service/bcat/backend/backend.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/hle/service/ns/ns.h"
 #include "core/hle/service/nvflinger/nvflinger.h"
@@ -46,15 +47,20 @@ constexpr ResultCode ERR_NO_DATA_IN_CHANNEL{ErrorModule::AM, 0x2};
 constexpr ResultCode ERR_NO_MESSAGES{ErrorModule::AM, 0x3};
 constexpr ResultCode ERR_SIZE_OUT_OF_BOUNDS{ErrorModule::AM, 0x1F7};
 
-constexpr u32 POP_LAUNCH_PARAMETER_MAGIC = 0xC79497CA;
+enum class LaunchParameterKind : u32 {
+    ApplicationSpecific = 1,
+    AccountPreselectedUser = 2,
+};
 
-struct LaunchParameters {
+constexpr u32 LAUNCH_PARAMETER_ACCOUNT_PRESELECTED_USER_MAGIC = 0xC79497CA;
+
+struct LaunchParameterAccountPreselectedUser {
     u32_le magic;
     u32_le is_account_selected;
     u128 current_user;
     INSERT_PADDING_BYTES(0x70);
 };
-static_assert(sizeof(LaunchParameters) == 0x88);
+static_assert(sizeof(LaunchParameterAccountPreselectedUser) == 0x88);
 
 IWindowController::IWindowController(Core::System& system_)
     : ServiceFramework("IWindowController"), system{system_} {
@@ -1128,26 +1134,54 @@ void IApplicationFunctions::EndBlockingHomeButton(Kernel::HLERequestContext& ctx
 }
 
 void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
-    LOG_DEBUG(Service_AM, "called");
+    IPC::RequestParser rp{ctx};
+    const auto kind = rp.PopEnum<LaunchParameterKind>();
 
-    LaunchParameters params{};
+    LOG_DEBUG(Service_AM, "called, kind={:08X}", static_cast<u8>(kind));
 
-    params.magic = POP_LAUNCH_PARAMETER_MAGIC;
-    params.is_account_selected = 1;
+    if (kind == LaunchParameterKind::ApplicationSpecific && !launch_popped_application_specific) {
+        const auto backend = BCAT::CreateBackendFromSettings(&FileSystem::GetBCATDirectory);
+        const auto build_id_full = Core::System::GetInstance().GetCurrentProcessBuildID();
+        u64 build_id{};
+        std::memcpy(&build_id, build_id_full.data(), sizeof(u64));
 
-    Account::ProfileManager profile_manager{};
-    const auto uuid = profile_manager.GetUser(Settings::values.current_user);
-    ASSERT(uuid);
-    params.current_user = uuid->uuid;
+        const auto data =
+            backend->GetLaunchParameter({Core::CurrentProcess()->GetTitleID(), build_id});
 
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+        if (data.has_value()) {
+            IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+            rb.Push(RESULT_SUCCESS);
+            rb.PushIpcInterface<AM::IStorage>(*data);
+            launch_popped_application_specific = true;
+            return;
+        }
+    } else if (kind == LaunchParameterKind::AccountPreselectedUser &&
+               !launch_popped_account_preselect) {
+        LaunchParameterAccountPreselectedUser params{};
 
-    rb.Push(RESULT_SUCCESS);
+        params.magic = LAUNCH_PARAMETER_ACCOUNT_PRESELECTED_USER_MAGIC;
+        params.is_account_selected = 1;
 
-    std::vector<u8> buffer(sizeof(LaunchParameters));
-    std::memcpy(buffer.data(), &params, buffer.size());
+        Account::ProfileManager profile_manager{};
+        const auto uuid = profile_manager.GetUser(Settings::values.current_user);
+        ASSERT(uuid);
+        params.current_user = uuid->uuid;
 
-    rb.PushIpcInterface<AM::IStorage>(buffer);
+        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+
+        rb.Push(RESULT_SUCCESS);
+
+        std::vector<u8> buffer(sizeof(LaunchParameterAccountPreselectedUser));
+        std::memcpy(buffer.data(), &params, buffer.size());
+
+        rb.PushIpcInterface<AM::IStorage>(buffer);
+        launch_popped_account_preselect = true;
+        return;
+    }
+
+    LOG_ERROR(Service_AM, "Attempted to load launch parameter but none was found!");
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(ERR_NO_DATA_IN_CHANNEL);
 }
 
 void IApplicationFunctions::CreateApplicationAndRequestToStartForQuest(

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -1140,7 +1140,8 @@ void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called, kind={:08X}", static_cast<u8>(kind));
 
     if (kind == LaunchParameterKind::ApplicationSpecific && !launch_popped_application_specific) {
-        const auto backend = BCAT::CreateBackendFromSettings(&FileSystem::GetBCATDirectory);
+        const auto backend = BCAT::CreateBackendFromSettings(
+            [this](u64 tid) { return system.GetFileSystemController().GetBCATDirectory(tid); });
         const auto build_id_full = Core::System::GetInstance().GetCurrentProcessBuildID();
         u64 build_id{};
         std::memcpy(&build_id, build_id_full.data(), sizeof(u64));

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -255,6 +255,8 @@ private:
     void EnableApplicationCrashReport(Kernel::HLERequestContext& ctx);
     void GetGpuErrorDetectedSystemEvent(Kernel::HLERequestContext& ctx);
 
+    bool launch_popped_application_specific = false;
+    bool launch_popped_account_preselect = false;
     Kernel::EventPair gpu_error_detected_event;
     Core::System& system;
 };

--- a/src/core/hle/service/am/applets/applets.cpp
+++ b/src/core/hle/service/am/applets/applets.cpp
@@ -157,6 +157,10 @@ AppletManager::AppletManager(Core::System& system_) : system{system_} {}
 
 AppletManager::~AppletManager() = default;
 
+const AppletFrontendSet& AppletManager::GetAppletFrontendSet() const {
+    return frontend;
+}
+
 void AppletManager::SetAppletFrontendSet(AppletFrontendSet set) {
     if (set.parental_controls != nullptr)
         frontend.parental_controls = std::move(set.parental_controls);

--- a/src/core/hle/service/am/applets/applets.h
+++ b/src/core/hle/service/am/applets/applets.h
@@ -190,6 +190,8 @@ public:
     explicit AppletManager(Core::System& system_);
     ~AppletManager();
 
+    const AppletFrontendSet& GetAppletFrontendSet() const;
+
     void SetAppletFrontendSet(AppletFrontendSet set);
     void SetDefaultAppletFrontendSet();
     void SetDefaultAppletsIfMissing();

--- a/src/core/hle/service/bcat/backend/backend.cpp
+++ b/src/core/hle/service/bcat/backend/backend.cpp
@@ -13,7 +13,7 @@ namespace Service::BCAT {
 ProgressServiceBackend::ProgressServiceBackend(std::string event_name) : impl{} {
     auto& kernel{Core::System::GetInstance().Kernel()};
     event = Kernel::WritableEvent::CreateEventPair(
-        kernel, Kernel::ResetType::OneShot, "ProgressServiceBackend:UpdateEvent:" + event_name);
+        kernel, Kernel::ResetType::Automatic, "ProgressServiceBackend:UpdateEvent:" + event_name);
 }
 
 Kernel::SharedPtr<Kernel::ReadableEvent> ProgressServiceBackend::GetEvent() {
@@ -48,8 +48,10 @@ void ProgressServiceBackend::StartDownloadingFile(std::string_view dir_name,
     impl.status = DeliveryCacheProgressImpl::Status::Downloading;
     impl.current_downloaded_bytes = 0;
     impl.current_total_bytes = file_size;
-    std::memcpy(impl.current_directory.data(), dir_name.data(), std::min(dir_name.size(), 0x31ull));
-    std::memcpy(impl.current_file.data(), file_name.data(), std::min(file_name.size(), 0x31ull));
+    std::memcpy(impl.current_directory.data(), dir_name.data(),
+                std::min<u64>(dir_name.size(), 0x31ull));
+    std::memcpy(impl.current_file.data(), file_name.data(),
+                std::min<u64>(file_name.size(), 0x31ull));
     SignalUpdate();
 }
 
@@ -68,7 +70,8 @@ void ProgressServiceBackend::CommitDirectory(std::string_view dir_name) {
     impl.current_file.fill(0);
     impl.current_downloaded_bytes = 0;
     impl.current_total_bytes = 0;
-    std::memcpy(impl.current_directory.data(), dir_name.data(), std::min(dir_name.size(), 0x31ull));
+    std::memcpy(impl.current_directory.data(), dir_name.data(),
+                std::min<u64>(dir_name.size(), 0x31ull));
     SignalUpdate();
 }
 
@@ -121,7 +124,7 @@ bool NullBackend::Clear(u64 title_id) {
 
 void NullBackend::SetPassphrase(u64 title_id, const Passphrase& passphrase) {
     LOG_DEBUG(Service_BCAT, "called, title_id={:016X}, passphrase = {}", title_id,
-              Common::HexArrayToString(passphrase));
+              Common::HexToString(passphrase));
 }
 
 std::optional<std::vector<u8>> NullBackend::GetLaunchParameter(TitleIDVersion title) {

--- a/src/core/hle/service/bcat/backend/backend.cpp
+++ b/src/core/hle/service/bcat/backend/backend.cpp
@@ -1,0 +1,47 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/hex_util.h"
+#include "common/logging/log.h"
+#include "core/hle/service/bcat/backend/backend.h"
+
+namespace Service::BCAT {
+
+Backend::Backend(DirectoryGetter getter) : dir_getter(std::move(getter)) {}
+
+Backend::~Backend() = default;
+
+NullBackend::NullBackend(const DirectoryGetter& getter) : Backend(std::move(getter)) {}
+
+NullBackend::~NullBackend() = default;
+
+bool NullBackend::Synchronize(TitleIDVersion title, CompletionCallback callback) {
+    LOG_DEBUG(Service_BCAT, "called, title_id={:016X}, build_id={:016X}", title.title_id,
+              title.build_id);
+
+    callback(true);
+    return true;
+}
+
+bool NullBackend::SynchronizeDirectory(TitleIDVersion title, std::string name,
+                                       CompletionCallback callback) {
+    LOG_DEBUG(Service_BCAT, "called, title_id={:016X}, build_id={:016X}, name={}", title.title_id,
+              title.build_id, name);
+
+    callback(true);
+    return true;
+}
+
+bool NullBackend::Clear(u64 title_id) {
+    LOG_DEBUG(Service_BCAT, "called, title_id={:016X}");
+
+    return true;
+}
+
+void NullBackend::SetPassphrase(u64 title_id, const Passphrase& passphrase) {
+    LOG_DEBUG(Service_BCAT, "called, title_id={:016X}, passphrase = {}", title_id,
+              Common::HexArrayToString(passphrase));
+}
+
+} // namespace Service::BCAT

--- a/src/core/hle/service/bcat/backend/backend.cpp
+++ b/src/core/hle/service/bcat/backend/backend.cpp
@@ -44,4 +44,10 @@ void NullBackend::SetPassphrase(u64 title_id, const Passphrase& passphrase) {
               Common::HexArrayToString(passphrase));
 }
 
+std::optional<std::vector<u8>> NullBackend::GetLaunchParameter(TitleIDVersion title) {
+    LOG_DEBUG(Service_BCAT, "called, title_id={:016X}, build_id={:016X}", title.title_id,
+              title.build_id);
+    return std::nullopt;
+}
+
 } // namespace Service::BCAT

--- a/src/core/hle/service/bcat/backend/backend.cpp
+++ b/src/core/hle/service/bcat/backend/backend.cpp
@@ -4,9 +4,89 @@
 
 #include "common/hex_util.h"
 #include "common/logging/log.h"
+#include "core/core.h"
+#include "core/hle/lock.h"
 #include "core/hle/service/bcat/backend/backend.h"
 
 namespace Service::BCAT {
+
+ProgressServiceBackend::ProgressServiceBackend(std::string event_name) : impl{} {
+    auto& kernel{Core::System::GetInstance().Kernel()};
+    event = Kernel::WritableEvent::CreateEventPair(
+        kernel, Kernel::ResetType::OneShot, "ProgressServiceBackend:UpdateEvent:" + event_name);
+}
+
+Kernel::SharedPtr<Kernel::ReadableEvent> ProgressServiceBackend::GetEvent() {
+    return event.readable;
+}
+
+DeliveryCacheProgressImpl& ProgressServiceBackend::GetImpl() {
+    return impl;
+}
+
+void ProgressServiceBackend::SetNeedHLELock(bool need) {
+    need_hle_lock = need;
+}
+
+void ProgressServiceBackend::SetTotalSize(u64 size) {
+    impl.total_bytes = size;
+    SignalUpdate();
+}
+
+void ProgressServiceBackend::StartConnecting() {
+    impl.status = DeliveryCacheProgressImpl::Status::Connecting;
+    SignalUpdate();
+}
+
+void ProgressServiceBackend::StartProcessingDataList() {
+    impl.status = DeliveryCacheProgressImpl::Status::ProcessingDataList;
+    SignalUpdate();
+}
+
+void ProgressServiceBackend::StartDownloadingFile(std::string_view dir_name,
+                                                  std::string_view file_name, u64 file_size) {
+    impl.status = DeliveryCacheProgressImpl::Status::Downloading;
+    impl.current_downloaded_bytes = 0;
+    impl.current_total_bytes = file_size;
+    std::memcpy(impl.current_directory.data(), dir_name.data(), std::min(dir_name.size(), 0x31ull));
+    std::memcpy(impl.current_file.data(), file_name.data(), std::min(file_name.size(), 0x31ull));
+    SignalUpdate();
+}
+
+void ProgressServiceBackend::UpdateFileProgress(u64 downloaded) {
+    impl.current_downloaded_bytes = downloaded;
+    SignalUpdate();
+}
+
+void ProgressServiceBackend::FinishDownloadingFile() {
+    impl.total_downloaded_bytes += impl.current_total_bytes;
+    SignalUpdate();
+}
+
+void ProgressServiceBackend::CommitDirectory(std::string_view dir_name) {
+    impl.status = DeliveryCacheProgressImpl::Status::Committing;
+    impl.current_file.fill(0);
+    impl.current_downloaded_bytes = 0;
+    impl.current_total_bytes = 0;
+    std::memcpy(impl.current_directory.data(), dir_name.data(), std::min(dir_name.size(), 0x31ull));
+    SignalUpdate();
+}
+
+void ProgressServiceBackend::FinishDownload(ResultCode result) {
+    impl.total_downloaded_bytes = impl.total_bytes;
+    impl.status = DeliveryCacheProgressImpl::Status::Done;
+    impl.result = result;
+    SignalUpdate();
+}
+
+void ProgressServiceBackend::SignalUpdate() const {
+    if (need_hle_lock) {
+        std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+        event.writable->Signal();
+    } else {
+        event.writable->Signal();
+    }
+}
 
 Backend::Backend(DirectoryGetter getter) : dir_getter(std::move(getter)) {}
 
@@ -16,20 +96,20 @@ NullBackend::NullBackend(const DirectoryGetter& getter) : Backend(std::move(gett
 
 NullBackend::~NullBackend() = default;
 
-bool NullBackend::Synchronize(TitleIDVersion title, CompletionCallback callback) {
+bool NullBackend::Synchronize(TitleIDVersion title, ProgressServiceBackend& progress) {
     LOG_DEBUG(Service_BCAT, "called, title_id={:016X}, build_id={:016X}", title.title_id,
               title.build_id);
 
-    callback(true);
+    progress.FinishDownload(RESULT_SUCCESS);
     return true;
 }
 
 bool NullBackend::SynchronizeDirectory(TitleIDVersion title, std::string name,
-                                       CompletionCallback callback) {
+                                       ProgressServiceBackend& progress) {
     LOG_DEBUG(Service_BCAT, "called, title_id={:016X}, build_id={:016X}, name={}", title.title_id,
               title.build_id, name);
 
-    callback(true);
+    progress.FinishDownload(RESULT_SUCCESS);
     return true;
 }
 

--- a/src/core/hle/service/bcat/backend/backend.h
+++ b/src/core/hle/service/bcat/backend/backend.h
@@ -57,11 +57,6 @@ static_assert(sizeof(DeliveryCacheProgressImpl) == 0x200,
 class ProgressServiceBackend {
     friend class IBcatService;
 
-    ProgressServiceBackend(std::string event_name);
-
-    Kernel::SharedPtr<Kernel::ReadableEvent> GetEvent();
-    DeliveryCacheProgressImpl& GetImpl();
-
 public:
     // Clients should call this with true if any of the functions are going to be called from a
     // non-HLE thread and this class need to lock the hle mutex. (default is false)
@@ -90,6 +85,11 @@ public:
     void FinishDownload(ResultCode result);
 
 private:
+    explicit ProgressServiceBackend(std::string event_name);
+
+    Kernel::SharedPtr<Kernel::ReadableEvent> GetEvent();
+    DeliveryCacheProgressImpl& GetImpl();
+
     void SignalUpdate() const;
 
     DeliveryCacheProgressImpl impl;

--- a/src/core/hle/service/bcat/backend/backend.h
+++ b/src/core/hle/service/bcat/backend/backend.h
@@ -1,0 +1,53 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <functional>
+#include "common/common_types.h"
+#include "core/file_sys/vfs_types.h"
+
+namespace Service::BCAT {
+
+using CompletionCallback = std::function<void(bool)>;
+using DirectoryGetter = std::function<FileSys::VirtualDir(u64)>;
+using Passphrase = std::array<u8, 0x20>;
+
+struct TitleIDVersion {
+    u64 title_id;
+    u64 build_id;
+};
+
+class Backend {
+public:
+    explicit Backend(DirectoryGetter getter);
+    virtual ~Backend();
+
+    virtual bool Synchronize(TitleIDVersion title, CompletionCallback callback) = 0;
+    virtual bool SynchronizeDirectory(TitleIDVersion title, std::string name,
+                                      CompletionCallback callback) = 0;
+
+    virtual bool Clear(u64 title_id) = 0;
+
+    virtual void SetPassphrase(u64 title_id, const Passphrase& passphrase) = 0;
+
+protected:
+    DirectoryGetter dir_getter;
+};
+
+class NullBackend : public Backend {
+public:
+    explicit NullBackend(const DirectoryGetter& getter);
+    ~NullBackend() override;
+
+    bool Synchronize(TitleIDVersion title, CompletionCallback callback) override;
+    bool SynchronizeDirectory(TitleIDVersion title, std::string name,
+                              CompletionCallback callback) override;
+
+    bool Clear(u64 title_id) override;
+
+    void SetPassphrase(u64 title_id, const Passphrase& passphrase) override;
+};
+
+} // namespace Service::BCAT

--- a/src/core/hle/service/bcat/backend/backend.h
+++ b/src/core/hle/service/bcat/backend/backend.h
@@ -50,4 +50,6 @@ public:
     void SetPassphrase(u64 title_id, const Passphrase& passphrase) override;
 };
 
+std::unique_ptr<Backend> CreateBackendFromSettings(DirectoryGetter getter);
+
 } // namespace Service::BCAT

--- a/src/core/hle/service/bcat/backend/backend.h
+++ b/src/core/hle/service/bcat/backend/backend.h
@@ -8,10 +8,14 @@
 #include <optional>
 #include "common/common_types.h"
 #include "core/file_sys/vfs_types.h"
+#include "core/hle/kernel/readable_event.h"
+#include "core/hle/kernel/writable_event.h"
+#include "core/hle/result.h"
 
 namespace Service::BCAT {
 
-using CompletionCallback = std::function<void(bool)>;
+struct DeliveryCacheProgressImpl;
+
 using DirectoryGetter = std::function<FileSys::VirtualDir(u64)>;
 using Passphrase = std::array<u8, 0x20>;
 
@@ -20,33 +24,116 @@ struct TitleIDVersion {
     u64 build_id;
 };
 
+using DirectoryName = std::array<char, 0x20>;
+using FileName = std::array<char, 0x20>;
+
+struct DeliveryCacheProgressImpl {
+    enum class Status : s32 {
+        None = 0x0,
+        Queued = 0x1,
+        Connecting = 0x2,
+        ProcessingDataList = 0x3,
+        Downloading = 0x4,
+        Committing = 0x5,
+        Done = 0x9,
+    };
+
+    Status status;
+    ResultCode result = RESULT_SUCCESS;
+    DirectoryName current_directory;
+    FileName current_file;
+    s64 current_downloaded_bytes; ///< Bytes downloaded on current file.
+    s64 current_total_bytes;      ///< Bytes total on current file.
+    s64 total_downloaded_bytes;   ///< Bytes downloaded on overall download.
+    s64 total_bytes;              ///< Bytes total on overall download.
+    INSERT_PADDING_BYTES(
+        0x198); ///< Appears to be unused in official code, possibly reserved for future use.
+};
+static_assert(sizeof(DeliveryCacheProgressImpl) == 0x200,
+              "DeliveryCacheProgressImpl has incorrect size.");
+
+// A class to manage the signalling to the game about BCAT download progress.
+// Some of this class is implemented in module.cpp to avoid exposing the implementation structure.
+class ProgressServiceBackend {
+    friend class IBcatService;
+
+    ProgressServiceBackend(std::string event_name);
+
+    Kernel::SharedPtr<Kernel::ReadableEvent> GetEvent();
+    DeliveryCacheProgressImpl& GetImpl();
+
+public:
+    // Clients should call this with true if any of the functions are going to be called from a
+    // non-HLE thread and this class need to lock the hle mutex. (default is false)
+    void SetNeedHLELock(bool need);
+
+    // Sets the number of bytes total in the entire download.
+    void SetTotalSize(u64 size);
+
+    // Notifies the application that the backend has started connecting to the server.
+    void StartConnecting();
+    // Notifies the application that the backend has begun accumulating and processing metadata.
+    void StartProcessingDataList();
+
+    // Notifies the application that a file is starting to be downloaded.
+    void StartDownloadingFile(std::string_view dir_name, std::string_view file_name, u64 file_size);
+    // Updates the progress of the current file to the size passed.
+    void UpdateFileProgress(u64 downloaded);
+    // Notifies the application that the current file has completed download.
+    void FinishDownloadingFile();
+
+    // Notifies the application that all files in this directory have completed and are being
+    // finalized.
+    void CommitDirectory(std::string_view dir_name);
+
+    // Notifies the application that the operation completed with result code result.
+    void FinishDownload(ResultCode result);
+
+private:
+    void SignalUpdate() const;
+
+    DeliveryCacheProgressImpl impl;
+    Kernel::EventPair event;
+    bool need_hle_lock = false;
+};
+
+// A class representing an abstract backend for BCAT functionality.
 class Backend {
 public:
     explicit Backend(DirectoryGetter getter);
     virtual ~Backend();
 
-    virtual bool Synchronize(TitleIDVersion title, CompletionCallback callback) = 0;
+    // Called when the backend is needed to synchronize the data for the game with title ID and
+    // version in title. A ProgressServiceBackend object is provided to alert the application of
+    // status.
+    virtual bool Synchronize(TitleIDVersion title, ProgressServiceBackend& progress) = 0;
+    // Very similar to Synchronize, but only for the directory provided. Backends should not alter
+    // the data for any other directories.
     virtual bool SynchronizeDirectory(TitleIDVersion title, std::string name,
-                                      CompletionCallback callback) = 0;
+                                      ProgressServiceBackend& progress) = 0;
 
+    // Removes all cached data associated with title id provided.
     virtual bool Clear(u64 title_id) = 0;
 
+    // Sets the BCAT Passphrase to be used with the associated title ID.
     virtual void SetPassphrase(u64 title_id, const Passphrase& passphrase) = 0;
 
+    // Gets the launch parameter used by AM associated with the title ID and version provided.
     virtual std::optional<std::vector<u8>> GetLaunchParameter(TitleIDVersion title) = 0;
 
 protected:
     DirectoryGetter dir_getter;
 };
 
+// A backend of BCAT that provides no operation.
 class NullBackend : public Backend {
 public:
     explicit NullBackend(const DirectoryGetter& getter);
     ~NullBackend() override;
 
-    bool Synchronize(TitleIDVersion title, CompletionCallback callback) override;
+    bool Synchronize(TitleIDVersion title, ProgressServiceBackend& progress) override;
     bool SynchronizeDirectory(TitleIDVersion title, std::string name,
-                              CompletionCallback callback) override;
+                              ProgressServiceBackend& progress) override;
 
     bool Clear(u64 title_id) override;
 

--- a/src/core/hle/service/bcat/backend/backend.h
+++ b/src/core/hle/service/bcat/backend/backend.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <functional>
+#include <optional>
 #include "common/common_types.h"
 #include "core/file_sys/vfs_types.h"
 
@@ -32,6 +33,8 @@ public:
 
     virtual void SetPassphrase(u64 title_id, const Passphrase& passphrase) = 0;
 
+    virtual std::optional<std::vector<u8>> GetLaunchParameter(TitleIDVersion title) = 0;
+
 protected:
     DirectoryGetter dir_getter;
 };
@@ -48,6 +51,8 @@ public:
     bool Clear(u64 title_id) override;
 
     void SetPassphrase(u64 title_id, const Passphrase& passphrase) override;
+
+    std::optional<std::vector<u8>> GetLaunchParameter(TitleIDVersion title) override;
 };
 
 std::unique_ptr<Backend> CreateBackendFromSettings(DirectoryGetter getter);

--- a/src/core/hle/service/bcat/backend/boxcat.cpp
+++ b/src/core/hle/service/bcat/backend/boxcat.cpp
@@ -1,0 +1,351 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <fmt/ostream.h>
+#include <httplib.h>
+#include <json.hpp>
+#include <mbedtls/sha256.h>
+#include "common/hex_util.h"
+#include "common/logging/backend.h"
+#include "common/logging/log.h"
+#include "core/core.h"
+#include "core/file_sys/vfs.h"
+#include "core/file_sys/vfs_libzip.h"
+#include "core/file_sys/vfs_vector.h"
+#include "core/frontend/applets/error.h"
+#include "core/hle/lock.h"
+#include "core/hle/service/am/applets/applets.h"
+#include "core/hle/service/bcat/backend/boxcat.h"
+#include "core/settings.h"
+
+namespace Service::BCAT {
+
+constexpr char BOXCAT_HOSTNAME[] = "api.yuzu-emu.org";
+
+// Formatted using fmt with arg[0] = hex title id
+constexpr char BOXCAT_PATHNAME_DATA[] = "/boxcat/titles/{:016X}/data";
+
+constexpr char BOXCAT_PATHNAME_EVENTS[] = "/boxcat/events";
+
+constexpr char BOXCAT_API_VERSION[] = "1";
+
+// HTTP status codes for Boxcat
+enum class ResponseStatus {
+    BadClientVersion = 301, ///< The Boxcat-Client-Version doesn't match the server.
+    NoUpdate = 304,         ///< The digest provided would match the new data, no need to update.
+    NoMatchTitleId = 404,   ///< The title ID provided doesn't have a boxcat implementation.
+    NoMatchBuildId = 406,   ///< The build ID provided is blacklisted (potentially because of format
+                            ///< issues or whatnot) and has no data.
+};
+
+enum class DownloadResult {
+    Success = 0,
+    NoResponse,
+    GeneralWebError,
+    NoMatchTitleId,
+    NoMatchBuildId,
+    InvalidContentType,
+    GeneralFSError,
+    BadClientVersion,
+};
+
+constexpr std::array<const char*, 8> DOWNLOAD_RESULT_LOG_MESSAGES{
+    "Success",
+    "There was no response from the server.",
+    "There was a general web error code returned from the server.",
+    "The title ID of the current game doesn't have a boxcat implementation. If you believe an "
+    "implementation should be added, contact yuzu support.",
+    "The build ID of the current version of the game is marked as incompatible with the current "
+    "BCAT distribution. Try upgrading or downgrading your game version or contacting yuzu support.",
+    "The content type of the web response was invalid.",
+    "There was a general filesystem error while saving the zip file.",
+    "The server is either too new or too old to serve the request. Try using the latest version of "
+    "an official release of yuzu.",
+};
+
+std::ostream& operator<<(std::ostream& os, DownloadResult result) {
+    return os << DOWNLOAD_RESULT_LOG_MESSAGES.at(static_cast<std::size_t>(result));
+}
+
+constexpr u32 PORT = 443;
+constexpr u32 TIMEOUT_SECONDS = 30;
+constexpr u64 VFS_COPY_BLOCK_SIZE = 1ull << 24; // 4MB
+
+namespace {
+
+std::string GetZIPFilePath(u64 title_id) {
+    return fmt::format("{}bcat/{:016X}/data.zip",
+                       FileUtil::GetUserPath(FileUtil::UserPath::CacheDir), title_id);
+}
+
+// If the error is something the user should know about (build ID mismatch, bad client version),
+// display an error.
+void HandleDownloadDisplayResult(DownloadResult res) {
+    if (res == DownloadResult::Success || res == DownloadResult::NoResponse ||
+        res == DownloadResult::GeneralWebError || res == DownloadResult::GeneralFSError ||
+        res == DownloadResult::NoMatchTitleId || res == DownloadResult::InvalidContentType) {
+        return;
+    }
+
+    const auto& frontend{Core::System::GetInstance().GetAppletManager().GetAppletFrontendSet()};
+    frontend.error->ShowCustomErrorText(
+        ResultCode(-1), "There was an error while attempting to use Boxcat.",
+        DOWNLOAD_RESULT_LOG_MESSAGES[static_cast<std::size_t>(res)], [] {});
+}
+
+} // namespace
+
+class Boxcat::Client {
+public:
+    Client(std::string zip_path, u64 title_id, u64 build_id)
+        : zip_path(std::move(zip_path)), title_id(title_id), build_id(build_id) {}
+
+    DownloadResult Download() {
+        const auto resolved_path = fmt::format(BOXCAT_PATHNAME_DATA, title_id);
+        if (client == nullptr) {
+            client = std::make_unique<httplib::SSLClient>(BOXCAT_HOSTNAME, PORT, TIMEOUT_SECONDS);
+        }
+
+        httplib::Headers headers{
+            {std::string("Boxcat-Client-Version"), std::string(BOXCAT_API_VERSION)},
+            {std::string("Boxcat-Build-Id"), fmt::format("{:016X}", build_id)},
+        };
+
+        if (FileUtil::Exists(zip_path)) {
+            FileUtil::IOFile file{zip_path, "rb"};
+            std::vector<u8> bytes(file.GetSize());
+            file.ReadBytes(bytes.data(), bytes.size());
+            const auto digest = DigestFile(bytes);
+            headers.insert({std::string("Boxcat-Current-Zip-Digest"),
+                            Common::HexArrayToString(digest, false)});
+        }
+
+        const auto response = client->Get(resolved_path.c_str(), headers);
+        if (response == nullptr)
+            return DownloadResult::NoResponse;
+
+        if (response->status == static_cast<int>(ResponseStatus::NoUpdate))
+            return DownloadResult::Success;
+        if (response->status == static_cast<int>(ResponseStatus::BadClientVersion))
+            return DownloadResult::BadClientVersion;
+        if (response->status == static_cast<int>(ResponseStatus::NoMatchTitleId))
+            return DownloadResult::NoMatchTitleId;
+        if (response->status == static_cast<int>(ResponseStatus::NoMatchBuildId))
+            return DownloadResult::NoMatchBuildId;
+        if (response->status >= 400)
+            return DownloadResult::GeneralWebError;
+
+        const auto content_type = response->headers.find("content-type");
+        if (content_type == response->headers.end() ||
+            content_type->second.find("application/zip") == std::string::npos) {
+            return DownloadResult::InvalidContentType;
+        }
+
+        FileUtil::CreateFullPath(zip_path);
+        FileUtil::IOFile file{zip_path, "wb"};
+        if (!file.IsOpen())
+            return DownloadResult::GeneralFSError;
+        if (!file.Resize(response->body.size()))
+            return DownloadResult::GeneralFSError;
+        if (file.WriteBytes(response->body.data(), response->body.size()) != response->body.size())
+            return DownloadResult::GeneralFSError;
+
+        return DownloadResult::Success;
+    }
+
+private:
+    using Digest = std::array<u8, 0x20>;
+    static Digest DigestFile(std::vector<u8> bytes) {
+        Digest out{};
+        mbedtls_sha256(bytes.data(), bytes.size(), out.data(), 0);
+        return out;
+    }
+
+    std::unique_ptr<httplib::Client> client;
+    std::string zip_path;
+    u64 title_id;
+    u64 build_id;
+};
+
+Boxcat::Boxcat(DirectoryGetter getter) : Backend(std::move(getter)) {}
+
+Boxcat::~Boxcat() = default;
+
+void SynchronizeInternal(DirectoryGetter dir_getter, TitleIDVersion title,
+                         CompletionCallback callback, std::optional<std::string> dir_name = {}) {
+    const auto failure = [&callback] {
+        // Acquire the HLE mutex
+        std::lock_guard lock{HLE::g_hle_lock};
+        callback(false);
+    };
+
+    if (Settings::values.bcat_boxcat_local) {
+        LOG_INFO(Service_BCAT, "Boxcat using local data by override, skipping download.");
+        // Acquire the HLE mutex
+        std::lock_guard lock{HLE::g_hle_lock};
+        callback(true);
+        return;
+    }
+
+    const auto zip_path{GetZIPFilePath(title.title_id)};
+    Boxcat::Client client{zip_path, title.title_id, title.build_id};
+
+    const auto res = client.Download();
+    if (res != DownloadResult::Success) {
+        LOG_ERROR(Service_BCAT, "Boxcat synchronization failed with error '{}'!", res);
+        HandleDownloadDisplayResult(res);
+        failure();
+        return;
+    }
+
+    FileUtil::IOFile zip{zip_path, "rb"};
+    const auto size = zip.GetSize();
+    std::vector<u8> bytes(size);
+    if (size == 0 || zip.ReadBytes(bytes.data(), bytes.size()) != bytes.size()) {
+        LOG_ERROR(Service_BCAT, "Boxcat failed to read ZIP file at path '{}'!", zip_path);
+        failure();
+        return;
+    }
+
+    const auto extracted = FileSys::ExtractZIP(std::make_shared<FileSys::VectorVfsFile>(bytes));
+    if (extracted == nullptr) {
+        LOG_ERROR(Service_BCAT, "Boxcat failed to extract ZIP file!");
+        failure();
+        return;
+    }
+
+    if (dir_name == std::nullopt) {
+        const auto target_dir = dir_getter(title.title_id);
+        if (target_dir == nullptr ||
+            !FileSys::VfsRawCopyD(extracted, target_dir, VFS_COPY_BLOCK_SIZE)) {
+            LOG_ERROR(Service_BCAT, "Boxcat failed to copy extracted ZIP to target directory!");
+            failure();
+            return;
+        }
+    } else {
+        const auto target_dir = dir_getter(title.title_id);
+        if (target_dir == nullptr) {
+            LOG_ERROR(Service_BCAT, "Boxcat failed to get directory for title ID!");
+            failure();
+            return;
+        }
+
+        const auto target_sub = target_dir->GetSubdirectory(*dir_name);
+        const auto source_sub = extracted->GetSubdirectory(*dir_name);
+
+        if (target_sub == nullptr || source_sub == nullptr ||
+            !FileSys::VfsRawCopyD(source_sub, target_sub, VFS_COPY_BLOCK_SIZE)) {
+            LOG_ERROR(Service_BCAT, "Boxcat failed to copy extracted ZIP to target directory!");
+            failure();
+            return;
+        }
+    }
+
+    // Acquire the HLE mutex
+    std::lock_guard lock{HLE::g_hle_lock};
+    callback(true);
+}
+
+bool Boxcat::Synchronize(TitleIDVersion title, CompletionCallback callback) {
+    is_syncing.exchange(true);
+    std::thread(&SynchronizeInternal, dir_getter, title, callback, std::nullopt).detach();
+    return true;
+}
+
+bool Boxcat::SynchronizeDirectory(TitleIDVersion title, std::string name,
+                                  CompletionCallback callback) {
+    is_syncing.exchange(true);
+    std::thread(&SynchronizeInternal, dir_getter, title, callback, name).detach();
+    return true;
+}
+
+bool Boxcat::Clear(u64 title_id) {
+    if (Settings::values.bcat_boxcat_local) {
+        LOG_INFO(Service_BCAT, "Boxcat using local data by override, skipping clear.");
+        return true;
+    }
+
+    const auto dir = dir_getter(title_id);
+
+    std::vector<std::string> dirnames;
+
+    for (const auto& subdir : dir->GetSubdirectories())
+        dirnames.push_back(subdir->GetName());
+
+    for (const auto& subdir : dirnames) {
+        if (!dir->DeleteSubdirectoryRecursive(subdir))
+            return false;
+    }
+
+    return true;
+}
+
+void Boxcat::SetPassphrase(u64 title_id, const Passphrase& passphrase) {
+    LOG_DEBUG(Service_BCAT, "called, title_id={:016X}, passphrase={}", title_id,
+              Common::HexArrayToString(passphrase));
+}
+
+Boxcat::StatusResult Boxcat::GetStatus(std::optional<std::string>& global,
+                                       std::map<std::string, EventStatus>& games) {
+    httplib::SSLClient client{BOXCAT_HOSTNAME, static_cast<int>(PORT),
+                              static_cast<int>(TIMEOUT_SECONDS)};
+
+    httplib::Headers headers{
+        {std::string("Boxcat-Client-Version"), std::string(BOXCAT_API_VERSION)},
+    };
+
+    const auto response = client.Get(BOXCAT_PATHNAME_EVENTS, headers);
+    if (response == nullptr)
+        return StatusResult::Offline;
+
+    if (response->status == static_cast<int>(ResponseStatus::BadClientVersion))
+        return StatusResult::BadClientVersion;
+
+    try {
+        nlohmann::json json = nlohmann::json::parse(response->body);
+
+        if (!json["online"].get<bool>())
+            return StatusResult::Offline;
+
+        if (json["global"].is_null())
+            global = std::nullopt;
+        else
+            global = json["global"].get<std::string>();
+
+        if (json["games"].is_array()) {
+            for (const auto object : json["games"]) {
+                if (object.is_object() && object.find("name") != object.end()) {
+                    EventStatus detail{};
+                    if (object["header"].is_string()) {
+                        detail.header = object["header"].get<std::string>();
+                    } else {
+                        detail.header = std::nullopt;
+                    }
+
+                    if (object["footer"].is_string()) {
+                        detail.footer = object["footer"].get<std::string>();
+                    } else {
+                        detail.footer = std::nullopt;
+                    }
+
+                    if (object["events"].is_array()) {
+                        for (const auto& event : object["events"]) {
+                            if (!event.is_string())
+                                continue;
+                            detail.events.push_back(event.get<std::string>());
+                        }
+                    }
+
+                    games.insert_or_assign(object["name"], std::move(detail));
+                }
+            }
+        }
+
+        return StatusResult::Success;
+    } catch (const nlohmann::json::parse_error& e) {
+        return StatusResult::ParseError;
+    }
+}
+
+} // namespace Service::BCAT

--- a/src/core/hle/service/bcat/backend/boxcat.cpp
+++ b/src/core/hle/service/bcat/backend/boxcat.cpp
@@ -364,17 +364,18 @@ void SynchronizeInternal(DirectoryGetter dir_getter, TitleIDVersion title,
 
 bool Boxcat::Synchronize(TitleIDVersion title, ProgressServiceBackend& progress) {
     is_syncing.exchange(true);
-    std::thread([this, title, &progress] { SynchronizeInternal(dir_getter, title, progress); })
-        .detach();
+    std::thread([this, title, &progress] {
+        SynchronizeInternal(dir_getter, title, progress);
+    }).detach();
     return true;
 }
 
 bool Boxcat::SynchronizeDirectory(TitleIDVersion title, std::string name,
                                   ProgressServiceBackend& progress) {
     is_syncing.exchange(true);
-    std::thread(
-        [this, title, name, &progress] { SynchronizeInternal(dir_getter, title, progress, name); })
-        .detach();
+    std::thread([this, title, name, &progress] {
+        SynchronizeInternal(dir_getter, title, progress, name);
+    }).detach();
     return true;
 }
 

--- a/src/core/hle/service/bcat/backend/boxcat.cpp
+++ b/src/core/hle/service/bcat/backend/boxcat.cpp
@@ -214,8 +214,7 @@ private:
                 std::vector<u8> bytes(file.GetSize());
                 file.ReadBytes(bytes.data(), bytes.size());
                 const auto digest = DigestFile(bytes);
-                headers.insert(
-                    {std::string("If-None-Match"), Common::HexArrayToString(digest, false)});
+                headers.insert({std::string("If-None-Match"), Common::HexToString(digest, false)});
             }
         }
 
@@ -402,7 +401,7 @@ bool Boxcat::Clear(u64 title_id) {
 
 void Boxcat::SetPassphrase(u64 title_id, const Passphrase& passphrase) {
     LOG_DEBUG(Service_BCAT, "called, title_id={:016X}, passphrase={}", title_id,
-              Common::HexArrayToString(passphrase));
+              Common::HexToString(passphrase));
 }
 
 std::optional<std::vector<u8>> Boxcat::GetLaunchParameter(TitleIDVersion title) {

--- a/src/core/hle/service/bcat/backend/boxcat.cpp
+++ b/src/core/hle/service/bcat/backend/boxcat.cpp
@@ -39,10 +39,10 @@ constexpr ResultCode ERROR_GENERAL_BCAT_FAILURE{ErrorModule::BCAT, 1};
 constexpr char BOXCAT_HOSTNAME[] = "api.yuzu-emu.org";
 
 // Formatted using fmt with arg[0] = hex title id
-constexpr char BOXCAT_PATHNAME_DATA[] = "/boxcat/titles/{:016X}/data";
-constexpr char BOXCAT_PATHNAME_LAUNCHPARAM[] = "/boxcat/titles/{:016X}/launchparam";
+constexpr char BOXCAT_PATHNAME_DATA[] = "/game-assets/{:016X}/boxcat";
+constexpr char BOXCAT_PATHNAME_LAUNCHPARAM[] = "/game-assets/{:016X}/launchparam";
 
-constexpr char BOXCAT_PATHNAME_EVENTS[] = "/boxcat/events";
+constexpr char BOXCAT_PATHNAME_EVENTS[] = "/game-assets/boxcat/events";
 
 constexpr char BOXCAT_API_VERSION[] = "1";
 constexpr char BOXCAT_CLIENT_TYPE[] = "yuzu";
@@ -203,9 +203,9 @@ private:
         }
 
         httplib::Headers headers{
-            {std::string("Boxcat-Client-Version"), std::string(BOXCAT_API_VERSION)},
+            {std::string("Game-Assets-API-Version"), std::string(BOXCAT_API_VERSION)},
             {std::string("Boxcat-Client-Type"), std::string(BOXCAT_CLIENT_TYPE)},
-            {std::string("Boxcat-Build-Id"), fmt::format("{:016X}", build_id)},
+            {std::string("Game-Build-Id"), fmt::format("{:016X}", build_id)},
         };
 
         if (FileUtil::Exists(path)) {
@@ -444,7 +444,7 @@ Boxcat::StatusResult Boxcat::GetStatus(std::optional<std::string>& global,
                               static_cast<int>(TIMEOUT_SECONDS)};
 
     httplib::Headers headers{
-        {std::string("Boxcat-Client-Version"), std::string(BOXCAT_API_VERSION)},
+        {std::string("Game-Assets-API-Version"), std::string(BOXCAT_API_VERSION)},
         {std::string("Boxcat-Client-Type"), std::string(BOXCAT_CLIENT_TYPE)},
     };
 

--- a/src/core/hle/service/bcat/backend/boxcat.cpp
+++ b/src/core/hle/service/bcat/backend/boxcat.cpp
@@ -364,18 +364,17 @@ void SynchronizeInternal(DirectoryGetter dir_getter, TitleIDVersion title,
 
 bool Boxcat::Synchronize(TitleIDVersion title, ProgressServiceBackend& progress) {
     is_syncing.exchange(true);
-    std::thread([this, title, &progress] {
-        SynchronizeInternal(dir_getter, title, progress);
-    }).detach();
+    std::thread([this, title, &progress] { SynchronizeInternal(dir_getter, title, progress); })
+        .detach();
     return true;
 }
 
 bool Boxcat::SynchronizeDirectory(TitleIDVersion title, std::string name,
                                   ProgressServiceBackend& progress) {
     is_syncing.exchange(true);
-    std::thread([this, title, name, &progress] {
-        SynchronizeInternal(dir_getter, title, progress, name);
-    }).detach();
+    std::thread(
+        [this, title, name, &progress] { SynchronizeInternal(dir_getter, title, progress, name); })
+        .detach();
     return true;
 }
 

--- a/src/core/hle/service/bcat/backend/boxcat.h
+++ b/src/core/hle/service/bcat/backend/boxcat.h
@@ -21,16 +21,16 @@ struct EventStatus {
 /// doesn't require a switch or nintendo account. The content is controlled by the yuzu team.
 class Boxcat final : public Backend {
     friend void SynchronizeInternal(DirectoryGetter dir_getter, TitleIDVersion title,
-                                    CompletionCallback callback,
+                                    ProgressServiceBackend& progress,
                                     std::optional<std::string> dir_name);
 
 public:
     explicit Boxcat(DirectoryGetter getter);
     ~Boxcat() override;
 
-    bool Synchronize(TitleIDVersion title, CompletionCallback callback) override;
+    bool Synchronize(TitleIDVersion title, ProgressServiceBackend& progress) override;
     bool SynchronizeDirectory(TitleIDVersion title, std::string name,
-                              CompletionCallback callback) override;
+                              ProgressServiceBackend& progress) override;
 
     bool Clear(u64 title_id) override;
 

--- a/src/core/hle/service/bcat/backend/boxcat.h
+++ b/src/core/hle/service/bcat/backend/boxcat.h
@@ -36,6 +36,8 @@ public:
 
     void SetPassphrase(u64 title_id, const Passphrase& passphrase) override;
 
+    std::optional<std::vector<u8>> GetLaunchParameter(TitleIDVersion title) override;
+
     enum class StatusResult {
         Success,
         Offline,

--- a/src/core/hle/service/bcat/backend/boxcat.h
+++ b/src/core/hle/service/bcat/backend/boxcat.h
@@ -1,0 +1,56 @@
+// Copyright 2019 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <atomic>
+#include <map>
+#include <optional>
+#include "core/hle/service/bcat/backend/backend.h"
+
+namespace Service::BCAT {
+
+struct EventStatus {
+    std::optional<std::string> header;
+    std::optional<std::string> footer;
+    std::vector<std::string> events;
+};
+
+/// Boxcat is yuzu's custom backend implementation of Nintendo's BCAT service. It is free to use and
+/// doesn't require a switch or nintendo account. The content is controlled by the yuzu team.
+class Boxcat final : public Backend {
+    friend void SynchronizeInternal(DirectoryGetter dir_getter, TitleIDVersion title,
+                                    CompletionCallback callback,
+                                    std::optional<std::string> dir_name);
+
+public:
+    explicit Boxcat(DirectoryGetter getter);
+    ~Boxcat() override;
+
+    bool Synchronize(TitleIDVersion title, CompletionCallback callback) override;
+    bool SynchronizeDirectory(TitleIDVersion title, std::string name,
+                              CompletionCallback callback) override;
+
+    bool Clear(u64 title_id) override;
+
+    void SetPassphrase(u64 title_id, const Passphrase& passphrase) override;
+
+    enum class StatusResult {
+        Success,
+        Offline,
+        ParseError,
+        BadClientVersion,
+    };
+
+    static StatusResult GetStatus(std::optional<std::string>& global,
+                                  std::map<std::string, EventStatus>& games);
+
+private:
+    std::atomic_bool is_syncing{false};
+
+    class Client;
+    std::unique_ptr<Client> client;
+};
+
+} // namespace Service::BCAT

--- a/src/core/hle/service/bcat/bcat.cpp
+++ b/src/core/hle/service/bcat/bcat.cpp
@@ -6,8 +6,8 @@
 
 namespace Service::BCAT {
 
-BCAT::BCAT(std::shared_ptr<Module> module, const char* name)
-    : Module::Interface(std::move(module), name) {
+BCAT::BCAT(std::shared_ptr<Module> module, FileSystem::FileSystemController& fsc, const char* name)
+    : Module::Interface(std::move(module), fsc, name) {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &BCAT::CreateBcatService, "CreateBcatService"},

--- a/src/core/hle/service/bcat/bcat.cpp
+++ b/src/core/hle/service/bcat/bcat.cpp
@@ -8,9 +8,13 @@ namespace Service::BCAT {
 
 BCAT::BCAT(std::shared_ptr<Module> module, const char* name)
     : Module::Interface(std::move(module), name) {
+    // clang-format off
     static const FunctionInfo functions[] = {
         {0, &BCAT::CreateBcatService, "CreateBcatService"},
+        {1, &BCAT::CreateDeliveryCacheStorageService, "CreateDeliveryCacheStorageService"},
+        {2, &BCAT::CreateDeliveryCacheStorageServiceWithApplicationId, "CreateDeliveryCacheStorageServiceWithApplicationId"},
     };
+    // clang-format on
     RegisterHandlers(functions);
 }
 

--- a/src/core/hle/service/bcat/bcat.h
+++ b/src/core/hle/service/bcat/bcat.h
@@ -10,7 +10,8 @@ namespace Service::BCAT {
 
 class BCAT final : public Module::Interface {
 public:
-    explicit BCAT(std::shared_ptr<Module> module, const char* name);
+    explicit BCAT(std::shared_ptr<Module> module, FileSystem::FileSystemController& fsc,
+                  const char* name);
     ~BCAT() override;
 };
 

--- a/src/core/hle/service/bcat/module.cpp
+++ b/src/core/hle/service/bcat/module.cpp
@@ -157,7 +157,7 @@ public:
             {30203, nullptr, "UnblockDeliveryTask"},
             {90100, nullptr, "EnumerateBackgroundDeliveryTask"},
             {90200, nullptr, "GetDeliveryList"},
-            {90201, nullptr, "ClearDeliveryCacheStorage"},
+            {90201, &IBcatService::ClearDeliveryCacheStorage, "ClearDeliveryCacheStorage"},
             {90300, nullptr, "GetPushNotificationLog"},
         };
         // clang-format on
@@ -252,6 +252,28 @@ private:
         rb.Push(RESULT_SUCCESS);
     }
 
+    void ClearDeliveryCacheStorage(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto title_id = rp.PopRaw<u64>();
+
+        LOG_DEBUG(Service_BCAT, "called, title_id={:016X}", title_id);
+
+        if (title_id == 0) {
+            LOG_ERROR(Service_BCAT, "Invalid title ID!");
+            IPC::ResponseBuilder rb{ctx, 2};
+            rb.Push(ERROR_INVALID_ARGUMENT);
+            return;
+        }
+
+        if (!backend.Clear(title_id)) {
+            LOG_ERROR(Service_BCAT, "Could not clear the directory successfully!");
+            IPC::ResponseBuilder rb{ctx, 2};
+            rb.Push(ERROR_FAILED_CLEAR_CACHE);
+            return;
+        }
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
     }
 
     Backend& backend;

--- a/src/core/hle/service/bcat/module.cpp
+++ b/src/core/hle/service/bcat/module.cpp
@@ -589,7 +589,6 @@ void Module::Interface::CreateDeliveryCacheStorageServiceWithApplicationId(
         Service::FileSystem::GetBCATDirectory(title_id));
 }
 
-namespace {
 std::unique_ptr<Backend> CreateBackendFromSettings(DirectoryGetter getter) {
     const auto backend = Settings::values.bcat_backend;
 
@@ -600,7 +599,6 @@ std::unique_ptr<Backend> CreateBackendFromSettings(DirectoryGetter getter) {
 
     return std::make_unique<NullBackend>(std::move(getter));
 }
-} // Anonymous namespace
 
 Module::Interface::Interface(std::shared_ptr<Module> module, const char* name)
     : ServiceFramework(name), module(std::move(module)),

--- a/src/core/hle/service/bcat/module.cpp
+++ b/src/core/hle/service/bcat/module.cpp
@@ -195,7 +195,7 @@ private:
         const auto passphrase_raw = ctx.ReadBuffer();
 
         LOG_DEBUG(Service_BCAT, "called, title_id={:016X}, passphrase={}", title_id,
-                  Common::HexVectorToString(passphrase_raw));
+                  Common::HexToString(passphrase_raw));
 
         if (title_id == 0) {
             LOG_ERROR(Service_BCAT, "Invalid title ID!");
@@ -335,7 +335,7 @@ private:
             rb.Push(ERROR_NO_OPEN_ENTITY);
         }
 
-        size = std::min(current_file->GetSize() - offset, size);
+        size = std::min<u64>(current_file->GetSize() - offset, size);
         const auto buffer = current_file->ReadBytes(size, offset);
         ctx.WriteBuffer(buffer);
 
@@ -437,7 +437,7 @@ private:
         }
 
         const auto files = current_dir->GetFiles();
-        write_size = std::min(write_size, files.size());
+        write_size = std::min<u64>(write_size, files.size());
         std::vector<DeliveryCacheDirectoryEntry> entries(write_size);
         std::transform(
             files.begin(), files.begin() + write_size, entries.begin(), [](const auto& file) {
@@ -519,7 +519,7 @@ private:
 
         LOG_DEBUG(Service_BCAT, "called, size={:016X}", size);
 
-        size = std::min(size, entries.size() - next_read_index);
+        size = std::min<u64>(size, entries.size() - next_read_index);
         ctx.WriteBuffer(entries.data() + next_read_index, size * sizeof(DirectoryName));
         next_read_index += size;
 

--- a/src/core/hle/service/bcat/module.h
+++ b/src/core/hle/service/bcat/module.h
@@ -18,6 +18,8 @@ public:
         ~Interface() override;
 
         void CreateBcatService(Kernel::HLERequestContext& ctx);
+        void CreateDeliveryCacheStorageService(Kernel::HLERequestContext& ctx);
+        void CreateDeliveryCacheStorageServiceWithApplicationId(Kernel::HLERequestContext& ctx);
 
     protected:
         std::shared_ptr<Module> module;

--- a/src/core/hle/service/bcat/module.h
+++ b/src/core/hle/service/bcat/module.h
@@ -8,6 +8,8 @@
 
 namespace Service::BCAT {
 
+class Backend;
+
 class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
@@ -19,6 +21,7 @@ public:
 
     protected:
         std::shared_ptr<Module> module;
+        std::unique_ptr<Backend> backend;
     };
 };
 

--- a/src/core/hle/service/bcat/module.h
+++ b/src/core/hle/service/bcat/module.h
@@ -6,7 +6,13 @@
 
 #include "core/hle/service/service.h"
 
-namespace Service::BCAT {
+namespace Service {
+
+namespace FileSystem {
+class FileSystemController;
+} // namespace FileSystem
+
+namespace BCAT {
 
 class Backend;
 
@@ -14,7 +20,8 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        explicit Interface(std::shared_ptr<Module> module, const char* name);
+        explicit Interface(std::shared_ptr<Module> module, FileSystem::FileSystemController& fsc,
+                           const char* name);
         ~Interface() override;
 
         void CreateBcatService(Kernel::HLERequestContext& ctx);
@@ -22,12 +29,16 @@ public:
         void CreateDeliveryCacheStorageServiceWithApplicationId(Kernel::HLERequestContext& ctx);
 
     protected:
+        FileSystem::FileSystemController& fsc;
+
         std::shared_ptr<Module> module;
         std::unique_ptr<Backend> backend;
     };
 };
 
 /// Registers all BCAT services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(Core::System& system);
 
-} // namespace Service::BCAT
+} // namespace BCAT
+
+} // namespace Service

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -674,7 +674,7 @@ FileSys::VirtualDir FileSystemController::GetModificationDumpRoot(u64 title_id) 
     return bis_factory->GetModificationDumpRoot(title_id);
 }
 
-FileSys::VirtualDir GetBCATDirectory(u64 title_id) {
+FileSys::VirtualDir FileSystemController::GetBCATDirectory(u64 title_id) const {
     LOG_TRACE(Service_FS, "Opening BCAT root for tid={:016X}", title_id);
 
     if (bis_factory == nullptr)

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -674,6 +674,15 @@ FileSys::VirtualDir FileSystemController::GetModificationDumpRoot(u64 title_id) 
     return bis_factory->GetModificationDumpRoot(title_id);
 }
 
+FileSys::VirtualDir GetBCATDirectory(u64 title_id) {
+    LOG_TRACE(Service_FS, "Opening BCAT root for tid={:016X}", title_id);
+
+    if (bis_factory == nullptr)
+        return nullptr;
+
+    return bis_factory->GetBCATDirectory(title_id);
+}
+
 void FileSystemController::CreateFactories(FileSys::VfsFilesystem& vfs, bool overwrite) {
     if (overwrite) {
         bis_factory = nullptr;

--- a/src/core/hle/service/filesystem/filesystem.h
+++ b/src/core/hle/service/filesystem/filesystem.h
@@ -110,6 +110,8 @@ public:
     FileSys::VirtualDir GetModificationLoadRoot(u64 title_id) const;
     FileSys::VirtualDir GetModificationDumpRoot(u64 title_id) const;
 
+    FileSys::VirtualDir GetBCATDirectory(u64 title_id) const;
+
     // Creates the SaveData, SDMC, and BIS Factories. Should be called once and before any function
     // above is called.
     void CreateFactories(FileSys::VfsFilesystem& vfs, bool overwrite = true);

--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -12,6 +12,13 @@
 
 namespace Service::NIFM {
 
+enum class RequestState : u32 {
+    NotSubmitted = 1,
+    Error = 1, ///< The duplicate 1 is intentional; it means both not submitted and error on HW.
+    Pending = 2,
+    Connected = 3,
+};
+
 class IScanRequest final : public ServiceFramework<IScanRequest> {
 public:
     explicit IScanRequest() : ServiceFramework("IScanRequest") {
@@ -81,7 +88,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u32>(0);
+        rb.PushEnum(RequestState::Connected);
     }
 
     void GetResult(Kernel::HLERequestContext& ctx) {
@@ -189,14 +196,14 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u8>(0);
+        rb.Push<u8>(1);
     }
     void IsAnyInternetRequestAccepted(Kernel::HLERequestContext& ctx) {
         LOG_WARNING(Service_NIFM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u8>(0);
+        rb.Push<u8>(1);
     }
     Core::System& system;
 };

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -208,7 +208,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system) {
     AOC::InstallInterfaces(*sm, system);
     APM::InstallInterfaces(system);
     Audio::InstallInterfaces(*sm, system);
-    BCAT::InstallInterfaces(*sm);
+    BCAT::InstallInterfaces(system);
     BPC::InstallInterfaces(*sm);
     BtDrv::InstallInterfaces(*sm, system);
     BTM::InstallInterfaces(*sm, system);

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -150,6 +150,7 @@ std::optional<VAddr> AppLoader_NSO::LoadModule(Kernel::Process& process,
     // Apply cheats if they exist and the program has a valid title ID
     if (pm) {
         auto& system = Core::System::GetInstance();
+        system.SetCurrentProcessBuildID(nso_header.build_id);
         const auto cheats = pm->CreateCheatList(system, nso_header.build_id);
         if (!cheats.empty()) {
             system.RegisterCheatList(cheats, nso_header.build_id, load_base, image_size);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -103,6 +103,8 @@ void LogSettings() {
     LogSetting("Debugging_UseGdbstub", Settings::values.use_gdbstub);
     LogSetting("Debugging_GdbstubPort", Settings::values.gdbstub_port);
     LogSetting("Debugging_ProgramArgs", Settings::values.program_args);
+    LogSetting("Services_BCATBackend", Settings::values.bcat_backend);
+    LogSetting("Services_BCATBoxcatLocal", Settings::values.bcat_boxcat_local);
 }
 
 } // namespace Settings

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -448,6 +448,10 @@ struct Values {
     bool reporting_services;
     bool quest_flag;
 
+    // BCAT
+    std::string bcat_backend;
+    bool bcat_boxcat_local;
+
     // WebService
     bool enable_telemetry;
     std::string web_api_url;

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -68,6 +68,7 @@ add_executable(yuzu
     configuration/configure_profile_manager.ui
     configuration/configure_service.cpp
     configuration/configure_service.h
+    configuration/configure_service.ui
     configuration/configure_system.cpp
     configuration/configure_system.h
     configuration/configure_system.ui

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -66,6 +66,8 @@ add_executable(yuzu
     configuration/configure_profile_manager.cpp
     configuration/configure_profile_manager.h
     configuration/configure_profile_manager.ui
+    configuration/configure_service.cpp
+    configuration/configure_service.h
     configuration/configure_system.cpp
     configuration/configure_system.h
     configuration/configure_system.ui
@@ -184,6 +186,10 @@ endif()
 if (YUZU_USE_QT_WEB_ENGINE)
     target_link_libraries(yuzu PRIVATE Qt5::WebEngineCore Qt5::WebEngineWidgets)
     target_compile_definitions(yuzu PRIVATE -DYUZU_USE_QT_WEB_ENGINE)
+endif ()
+
+if (YUZU_ENABLE_BOXCAT)
+    target_compile_definitions(yuzu PRIVATE -DYUZU_ENABLE_BOXCAT)
 endif ()
 
 if(UNIX AND NOT APPLE)

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -525,6 +525,13 @@ void Config::ReadDebuggingValues() {
     qt_config->endGroup();
 }
 
+void Config::ReadServiceValues() {
+    qt_config->beginGroup("Services");
+    Settings::values.bcat_backend = ReadSetting("bcat_backend", "boxcat").toString().toStdString();
+    Settings::values.bcat_boxcat_local = ReadSetting("bcat_boxcat_local", false).toBool();
+    qt_config->endGroup();
+}
+
 void Config::ReadDisabledAddOnValues() {
     const auto size = qt_config->beginReadArray(QStringLiteral("DisabledAddOns"));
 
@@ -769,6 +776,7 @@ void Config::ReadValues() {
     ReadMiscellaneousValues();
     ReadDebuggingValues();
     ReadWebServiceValues();
+    ReadServiceValues();
     ReadDisabledAddOnValues();
     ReadUIValues();
 }
@@ -866,6 +874,7 @@ void Config::SaveValues() {
     SaveMiscellaneousValues();
     SaveDebuggingValues();
     SaveWebServiceValues();
+    SaveServiceValues();
     SaveDisabledAddOnValues();
     SaveUIValues();
 }
@@ -960,6 +969,13 @@ void Config::SaveDebuggingValues() {
     WriteSetting(QStringLiteral("dump_nso"), Settings::values.dump_nso, false);
     WriteSetting(QStringLiteral("quest_flag"), Settings::values.quest_flag, false);
 
+    qt_config->endGroup();
+}
+
+void Config::SaveServiceValues() {
+    qt_config->beginGroup("Services");
+    WriteSetting("bcat_backend", QString::fromStdString(Settings::values.bcat_backend), "null");
+    WriteSetting("bcat_boxcat_local", Settings::values.bcat_boxcat_local, false);
     qt_config->endGroup();
 }
 

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -526,9 +526,13 @@ void Config::ReadDebuggingValues() {
 }
 
 void Config::ReadServiceValues() {
-    qt_config->beginGroup("Services");
-    Settings::values.bcat_backend = ReadSetting("bcat_backend", "boxcat").toString().toStdString();
-    Settings::values.bcat_boxcat_local = ReadSetting("bcat_boxcat_local", false).toBool();
+    qt_config->beginGroup(QStringLiteral("Services"));
+    Settings::values.bcat_backend =
+        ReadSetting(QStringLiteral("bcat_backend"), QStringLiteral("boxcat"))
+            .toString()
+            .toStdString();
+    Settings::values.bcat_boxcat_local =
+        ReadSetting(QStringLiteral("bcat_boxcat_local"), false).toBool();
     qt_config->endGroup();
 }
 
@@ -973,9 +977,10 @@ void Config::SaveDebuggingValues() {
 }
 
 void Config::SaveServiceValues() {
-    qt_config->beginGroup("Services");
-    WriteSetting("bcat_backend", QString::fromStdString(Settings::values.bcat_backend), "null");
-    WriteSetting("bcat_boxcat_local", Settings::values.bcat_boxcat_local, false);
+    qt_config->beginGroup(QStringLiteral("Services"));
+    WriteSetting(QStringLiteral("bcat_backend"),
+                 QString::fromStdString(Settings::values.bcat_backend), QStringLiteral("null"));
+    WriteSetting(QStringLiteral("bcat_boxcat_local"), Settings::values.bcat_boxcat_local, false);
     qt_config->endGroup();
 }
 

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -42,6 +42,7 @@ private:
     void ReadCoreValues();
     void ReadDataStorageValues();
     void ReadDebuggingValues();
+    void ReadServiceValues();
     void ReadDisabledAddOnValues();
     void ReadMiscellaneousValues();
     void ReadPathValues();
@@ -65,6 +66,7 @@ private:
     void SaveCoreValues();
     void SaveDataStorageValues();
     void SaveDebuggingValues();
+    void SaveServiceValues();
     void SaveDisabledAddOnValues();
     void SaveMiscellaneousValues();
     void SavePathValues();

--- a/src/yuzu/configuration/configure.ui
+++ b/src/yuzu/configuration/configure.ui
@@ -98,6 +98,11 @@
          <string>Web</string>
         </attribute>
        </widget>
+       <widget class="ConfigureService" name="serviceTab">
+        <attribute name="title">
+         <string>Services</string>
+        </attribute>
+       </widget>
       </widget>
      </item>
     </layout>
@@ -176,6 +181,12 @@
    <class>ConfigureHotkeys</class>
    <extends>QWidget</extends>
    <header>configuration/configure_hotkeys.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ConfigureService</class>
+   <extends>QWidget</extends>
+   <header>configuration/configure_service.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -44,6 +44,7 @@ void ConfigureDialog::ApplyConfiguration() {
     ui->audioTab->ApplyConfiguration();
     ui->debugTab->ApplyConfiguration();
     ui->webTab->ApplyConfiguration();
+    ui->serviceTab->ApplyConfiguration();
     Settings::Apply();
     Settings::LogSettings();
 }

--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -75,7 +75,8 @@ Q_DECLARE_METATYPE(QList<QWidget*>);
 void ConfigureDialog::PopulateSelectionList() {
     const std::array<std::pair<QString, QList<QWidget*>>, 4> items{
         {{tr("General"), {ui->generalTab, ui->webTab, ui->debugTab, ui->gameListTab}},
-         {tr("System"), {ui->systemTab, ui->profileManagerTab, ui->filesystemTab, ui->audioTab}},
+         {tr("System"),
+          {ui->systemTab, ui->profileManagerTab, ui->serviceTab, ui->filesystemTab, ui->audioTab}},
          {tr("Graphics"), {ui->graphicsTab}},
          {tr("Controls"), {ui->inputTab, ui->hotkeysTab}}},
     };
@@ -109,6 +110,7 @@ void ConfigureDialog::UpdateVisibleTabs() {
         {ui->webTab, tr("Web")},
         {ui->gameListTab, tr("Game List")},
         {ui->filesystemTab, tr("Filesystem")},
+        {ui->serviceTab, tr("Services")},
     };
 
     [[maybe_unused]] const QSignalBlocker blocker(ui->tabWidget);

--- a/src/yuzu/configuration/configure_service.cpp
+++ b/src/yuzu/configuration/configure_service.cpp
@@ -1,0 +1,129 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <QGraphicsItem>
+#include <QtConcurrent/QtConcurrent>
+#include "core/hle/service/bcat/backend/boxcat.h"
+#include "core/settings.h"
+#include "ui_configure_service.h"
+#include "yuzu/configuration/configure_service.h"
+
+namespace {
+QString FormatEventStatusString(const Service::BCAT::EventStatus& status) {
+    QString out;
+
+    if (status.header.has_value()) {
+        out += QStringLiteral("<i>%1</i><br>").arg(QString::fromStdString(*status.header));
+    }
+
+    if (status.events.size() == 1) {
+        out += QStringLiteral("%1<br>").arg(QString::fromStdString(status.events.front()));
+    } else {
+        for (const auto event : status.events) {
+            out += QStringLiteral("- %1<br>").arg(QString::fromStdString(event));
+        }
+    }
+
+    if (status.footer.has_value()) {
+        out += QStringLiteral("<i>%1</i><br>").arg(QString::fromStdString(*status.footer));
+    }
+
+    return out;
+}
+} // Anonymous namespace
+
+ConfigureService::ConfigureService(QWidget* parent)
+    : QWidget(parent), ui(std::make_unique<Ui::ConfigureService>()), watcher(this) {
+    ui->setupUi(this);
+
+    ui->bcat_source->addItem(QStringLiteral("None"));
+    ui->bcat_empty_label->setHidden(true);
+    ui->bcat_empty_header->setHidden(true);
+
+#ifdef YUZU_ENABLE_BOXCAT
+    ui->bcat_source->addItem(QStringLiteral("Boxcat"), QStringLiteral("boxcat"));
+#endif
+
+    connect(ui->bcat_source, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            &ConfigureService::OnBCATImplChanged);
+
+    this->setConfiguration();
+}
+
+ConfigureService::~ConfigureService() = default;
+
+void ConfigureService::applyConfiguration() {
+    Settings::values.bcat_backend = ui->bcat_source->currentText().toLower().toStdString();
+}
+
+void ConfigureService::retranslateUi() {
+    ui->retranslateUi(this);
+}
+
+void ConfigureService::setConfiguration() {
+    int index = ui->bcat_source->findData(QString::fromStdString(Settings::values.bcat_backend));
+    ui->bcat_source->setCurrentIndex(index == -1 ? 0 : index);
+}
+
+std::pair<QString, QString> ConfigureService::BCATDownloadEvents() {
+    std::optional<std::string> global;
+    std::map<std::string, Service::BCAT::EventStatus> map;
+    const auto res = Service::BCAT::Boxcat::GetStatus(global, map);
+
+    switch (res) {
+    case Service::BCAT::Boxcat::StatusResult::Offline:
+        return {"", tr("The boxcat service is offline or you are not connected to the internet.")};
+    case Service::BCAT::Boxcat::StatusResult::ParseError:
+        return {"",
+                tr("There was an error while processing the boxcat event data. Contact the yuzu "
+                   "developers.")};
+    case Service::BCAT::Boxcat::StatusResult::BadClientVersion:
+        return {"",
+                tr("The version of yuzu you are using is either too new or too old for the server. "
+                   "Try updating to the latest official release of yuzu.")};
+    }
+
+    if (map.empty()) {
+        return {QStringLiteral("Current Boxcat Events"),
+                tr("There are currently no events on boxcat.")};
+    }
+
+    QString out;
+    for (const auto& [key, value] : map) {
+        out += QStringLiteral("%1<b>%2</b><br>%3")
+                   .arg(out.isEmpty() ? "" : "<br>")
+                   .arg(QString::fromStdString(key))
+                   .arg(FormatEventStatusString(value));
+    }
+    return {QStringLiteral("Current Boxcat Events"), out};
+}
+
+void ConfigureService::OnBCATImplChanged() {
+#ifdef YUZU_ENABLE_BOXCAT
+    const auto boxcat = ui->bcat_source->currentText() == QStringLiteral("Boxcat");
+    ui->bcat_empty_header->setHidden(!boxcat);
+    ui->bcat_empty_label->setHidden(!boxcat);
+    ui->bcat_empty_header->setText("");
+    ui->bcat_empty_label->setText(tr("Yuzu is retrieving the latest boxcat status..."));
+
+    if (!boxcat)
+        return;
+
+    const auto future = QtConcurrent::run([this] { return BCATDownloadEvents(); });
+
+    watcher.setFuture(future);
+    connect(&watcher, &QFutureWatcher<std::pair<QString, QString>>::finished, this,
+            [this] { OnUpdateBCATEmptyLabel(watcher.result()); });
+#endif
+}
+
+void ConfigureService::OnUpdateBCATEmptyLabel(std::pair<QString, QString> string) {
+#ifdef YUZU_ENABLE_BOXCAT
+    const auto boxcat = ui->bcat_source->currentText() == QStringLiteral("Boxcat");
+    if (boxcat) {
+        ui->bcat_empty_header->setText(string.first);
+        ui->bcat_empty_label->setText(string.second);
+    }
+#endif
+}

--- a/src/yuzu/configuration/configure_service.cpp
+++ b/src/yuzu/configuration/configure_service.cpp
@@ -20,7 +20,7 @@ QString FormatEventStatusString(const Service::BCAT::EventStatus& status) {
     if (status.events.size() == 1) {
         out += QStringLiteral("%1<br>").arg(QString::fromStdString(status.events.front()));
     } else {
-        for (const auto event : status.events) {
+        for (const auto& event : status.events) {
             out += QStringLiteral("- %1<br>").arg(QString::fromStdString(event));
         }
     }
@@ -34,7 +34,7 @@ QString FormatEventStatusString(const Service::BCAT::EventStatus& status) {
 } // Anonymous namespace
 
 ConfigureService::ConfigureService(QWidget* parent)
-    : QWidget(parent), ui(std::make_unique<Ui::ConfigureService>()), watcher(this) {
+    : QWidget(parent), ui(std::make_unique<Ui::ConfigureService>()) {
     ui->setupUi(this);
 
     ui->bcat_source->addItem(QStringLiteral("None"));
@@ -62,7 +62,8 @@ void ConfigureService::RetranslateUi() {
 }
 
 void ConfigureService::SetConfiguration() {
-    int index = ui->bcat_source->findData(QString::fromStdString(Settings::values.bcat_backend));
+    const int index =
+        ui->bcat_source->findData(QString::fromStdString(Settings::values.bcat_backend));
     ui->bcat_source->setCurrentIndex(index == -1 ? 0 : index);
 }
 
@@ -73,14 +74,14 @@ std::pair<QString, QString> ConfigureService::BCATDownloadEvents() {
 
     switch (res) {
     case Service::BCAT::Boxcat::StatusResult::Offline:
-        return {QStringLiteral(""),
+        return {QString{},
                 tr("The boxcat service is offline or you are not connected to the internet.")};
     case Service::BCAT::Boxcat::StatusResult::ParseError:
-        return {QStringLiteral(""),
+        return {QString{},
                 tr("There was an error while processing the boxcat event data. Contact the yuzu "
                    "developers.")};
     case Service::BCAT::Boxcat::StatusResult::BadClientVersion:
-        return {QStringLiteral(""),
+        return {QString{},
                 tr("The version of yuzu you are using is either too new or too old for the server. "
                    "Try updating to the latest official release of yuzu.")};
     }
@@ -98,11 +99,11 @@ std::pair<QString, QString> ConfigureService::BCATDownloadEvents() {
 
     for (const auto& [key, value] : map) {
         out += QStringLiteral("%1<b>%2</b><br>%3")
-                   .arg(out.isEmpty() ? QStringLiteral("") : QStringLiteral("<br>"))
+                   .arg(out.isEmpty() ? QString{} : QStringLiteral("<br>"))
                    .arg(QString::fromStdString(key))
                    .arg(FormatEventStatusString(value));
     }
-    return {QStringLiteral("Current Boxcat Events"), out};
+    return {QStringLiteral("Current Boxcat Events"), std::move(out)};
 }
 
 void ConfigureService::OnBCATImplChanged() {
@@ -110,7 +111,7 @@ void ConfigureService::OnBCATImplChanged() {
     const auto boxcat = ui->bcat_source->currentText() == QStringLiteral("Boxcat");
     ui->bcat_empty_header->setHidden(!boxcat);
     ui->bcat_empty_label->setHidden(!boxcat);
-    ui->bcat_empty_header->setText(QStringLiteral(""));
+    ui->bcat_empty_header->setText(QString{});
     ui->bcat_empty_label->setText(tr("Yuzu is retrieving the latest boxcat status..."));
 
     if (!boxcat)

--- a/src/yuzu/configuration/configure_service.cpp
+++ b/src/yuzu/configuration/configure_service.cpp
@@ -48,20 +48,20 @@ ConfigureService::ConfigureService(QWidget* parent)
     connect(ui->bcat_source, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &ConfigureService::OnBCATImplChanged);
 
-    this->setConfiguration();
+    this->SetConfiguration();
 }
 
 ConfigureService::~ConfigureService() = default;
 
-void ConfigureService::applyConfiguration() {
+void ConfigureService::ApplyConfiguration() {
     Settings::values.bcat_backend = ui->bcat_source->currentText().toLower().toStdString();
 }
 
-void ConfigureService::retranslateUi() {
+void ConfigureService::RetranslateUi() {
     ui->retranslateUi(this);
 }
 
-void ConfigureService::setConfiguration() {
+void ConfigureService::SetConfiguration() {
     int index = ui->bcat_source->findData(QString::fromStdString(Settings::values.bcat_backend));
     ui->bcat_source->setCurrentIndex(index == -1 ? 0 : index);
 }
@@ -73,13 +73,14 @@ std::pair<QString, QString> ConfigureService::BCATDownloadEvents() {
 
     switch (res) {
     case Service::BCAT::Boxcat::StatusResult::Offline:
-        return {"", tr("The boxcat service is offline or you are not connected to the internet.")};
+        return {QStringLiteral(""),
+                tr("The boxcat service is offline or you are not connected to the internet.")};
     case Service::BCAT::Boxcat::StatusResult::ParseError:
-        return {"",
+        return {QStringLiteral(""),
                 tr("There was an error while processing the boxcat event data. Contact the yuzu "
                    "developers.")};
     case Service::BCAT::Boxcat::StatusResult::BadClientVersion:
-        return {"",
+        return {QStringLiteral(""),
                 tr("The version of yuzu you are using is either too new or too old for the server. "
                    "Try updating to the latest official release of yuzu.")};
     }
@@ -90,9 +91,14 @@ std::pair<QString, QString> ConfigureService::BCATDownloadEvents() {
     }
 
     QString out;
+
+    if (global.has_value()) {
+        out += QStringLiteral("%1<br>").arg(QString::fromStdString(*global));
+    }
+
     for (const auto& [key, value] : map) {
         out += QStringLiteral("%1<b>%2</b><br>%3")
-                   .arg(out.isEmpty() ? "" : "<br>")
+                   .arg(out.isEmpty() ? QStringLiteral("") : QStringLiteral("<br>"))
                    .arg(QString::fromStdString(key))
                    .arg(FormatEventStatusString(value));
     }
@@ -104,7 +110,7 @@ void ConfigureService::OnBCATImplChanged() {
     const auto boxcat = ui->bcat_source->currentText() == QStringLiteral("Boxcat");
     ui->bcat_empty_header->setHidden(!boxcat);
     ui->bcat_empty_label->setHidden(!boxcat);
-    ui->bcat_empty_header->setText("");
+    ui->bcat_empty_header->setText(QStringLiteral(""));
     ui->bcat_empty_label->setText(tr("Yuzu is retrieving the latest boxcat status..."));
 
     if (!boxcat)

--- a/src/yuzu/configuration/configure_service.h
+++ b/src/yuzu/configuration/configure_service.h
@@ -30,5 +30,5 @@ private:
     void OnUpdateBCATEmptyLabel(std::pair<QString, QString> string);
 
     std::unique_ptr<Ui::ConfigureService> ui;
-    QFutureWatcher<std::pair<QString, QString>> watcher;
+    QFutureWatcher<std::pair<QString, QString>> watcher{this};
 };

--- a/src/yuzu/configuration/configure_service.h
+++ b/src/yuzu/configuration/configure_service.h
@@ -1,0 +1,34 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <QFutureWatcher>
+#include <QWidget>
+
+namespace Ui {
+class ConfigureService;
+}
+
+class ConfigureService : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ConfigureService(QWidget* parent = nullptr);
+    ~ConfigureService() override;
+
+    void applyConfiguration();
+    void retranslateUi();
+
+private:
+    void setConfiguration();
+
+    std::pair<QString, QString> BCATDownloadEvents();
+    void OnBCATImplChanged();
+    void OnUpdateBCATEmptyLabel(std::pair<QString, QString> string);
+
+    std::unique_ptr<Ui::ConfigureService> ui;
+    QFutureWatcher<std::pair<QString, QString>> watcher;
+};

--- a/src/yuzu/configuration/configure_service.h
+++ b/src/yuzu/configuration/configure_service.h
@@ -19,11 +19,11 @@ public:
     explicit ConfigureService(QWidget* parent = nullptr);
     ~ConfigureService() override;
 
-    void applyConfiguration();
-    void retranslateUi();
+    void ApplyConfiguration();
+    void RetranslateUi();
 
 private:
-    void setConfiguration();
+    void SetConfiguration();
 
     std::pair<QString, QString> BCATDownloadEvents();
     void OnBCATImplChanged();

--- a/src/yuzu/configuration/configure_service.ui
+++ b/src/yuzu/configuration/configure_service.ui
@@ -78,6 +78,9 @@
           <property name="text">
            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://yuzu-emu.org/help/feature/boxcat&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Learn more about BCAT, Boxcat, and Current Events&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
+          <property name="openExternalLinks">
+           <bool>true</bool>
+          </property>
          </widget>
         </item>
         <item row="0" column="1" colspan="2">

--- a/src/yuzu/configuration/configure_service.ui
+++ b/src/yuzu/configuration/configure_service.ui
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureService</class>
+ <widget class="QWidget" name="ConfigureService">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>433</width>
+    <height>561</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_3">
+     <item>
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>BCAT</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="1" column="1" colspan="2">
+         <widget class="QLabel" name="label_2">
+          <property name="maximumSize">
+           <size>
+            <width>260</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>BCAT is Nintendo's way of sending data to games to engage its community and unlock additional content.</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string>BCAT Backend</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1" colspan="2">
+         <widget class="QLabel" name="bcat_empty_label">
+          <property name="enabled">
+           <bool>true</bool>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>260</width>
+            <height>16777215</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1" colspan="2">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://yuzu-emu.org/help/feature/boxcat&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;Learn more about BCAT, Boxcat, and Current Events&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1" colspan="2">
+         <widget class="QComboBox" name="bcat_source"/>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="bcat_empty_header">
+          <property name="text">
+           <string/>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -433,6 +433,11 @@ void Config::ReadValues() {
         sdl2_config->Get("WebService", "web_api_url", "https://api.yuzu-emu.org");
     Settings::values.yuzu_username = sdl2_config->Get("WebService", "yuzu_username", "");
     Settings::values.yuzu_token = sdl2_config->Get("WebService", "yuzu_token", "");
+
+    // Services
+    Settings::values.bcat_backend = sdl2_config->Get("Services", "bcat_backend", "boxcat");
+    Settings::values.bcat_boxcat_local =
+        sdl2_config->GetBoolean("Services", "bcat_boxcat_local", false);
 }
 
 void Config::Reload() {

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -251,6 +251,11 @@ web_api_url = https://api.yuzu-emu.org
 yuzu_username =
 yuzu_token =
 
+[Services]
+# The name of the backend to use for BCAT
+# If this is set to 'boxcat' boxcat will be used, otherwise a null implementation will be used
+bcat_backend =
+
 [AddOns]
 # Used to disable add-ons
 # List of title IDs of games that will have add-ons disabled (separated by '|'):


### PR DESCRIPTION
Do Not Merge Until:
- [x] Capability Flags Implemented
- [x] Task Backend Implemented
- [x] Let's Go Eevee/Pikachu BCAT Error Fixed (Causes error applet with code 0x27a)
(WILL BE ADDRESSED IN FUTURE PR)

This PR aims to implement a majority of the BCAT service. BCAT is a service Nintendo provides to games to host data that can be updated frequently, in order to update games without pushing a full eshop-style update. Normally, on the switch it just connects to Nintendo's servers, authenticates (meaning that if the device is banned it will be blocked), and then downloads data from the game's author.

Because of how the interface(es) of the BCAT service are laid out, it was possible to easily intercept this behavior and instead connect to yuzu servers and download yuzu content. I have worked extensively with @chris062689 to develop this web backend, which we are calling boxcat, so kudos to him!

The way I wrote the backend allows for, in the future, alternative sources of BCAT including but not limited to Nintendo, but because of the ban risk I didn't even consider adding it now.

Games are free to use any format desired for BCAT data, all the service does is synchronize the files/folders, thus each game had to be separately RE'd for its format.

This also implements a variant of PopLaunchParameter games can use to get launch arguments (not argc/argv) that were passed on application creation. This is called 'NXArgs' and is used by the news applet to give ingame bonuses in certain titles. Since news is through BCAT, but this isn't directly using the BCAT service, I have dubbed this 'indirect BCAT' in code. Coincidentally, the fact that we only returned the Account preselect data instead of 'no data' error code is what made BotW DLCs/Updates softlock, as it will attempt to read the application data over and over until the error is passed (NXArgs was added in 1.1.0)

Finally, I'd like to thank all of the people who helped me with research, testing, content creation, and general knowledge:
- Boxcat server system and teaching me what "web" is - @chris062689 
- BotW NXArgs Format Help - @leoetlino
- Splatoon 2 NXArgs Format Help, Error Investigation and Inspiration - @random0666
- Datamining BCAT and help parsing Byaml (SMO) - @OatmealDome 
- Help reversing structures and commands - @ogniK5377 
- Help dumping data from hardware - @Shadowninja108
- General knowledge and data - @SimonTime
- Content creation for SMO - @FearlessTobi, @Schplee, @MysticExile, @MelonSpeedruns, "Jon S#2728"
- Pokemon Let's Go format help - @SciresM 
- General RE help with structures and errors, review of code - @lioncash 

Special shoutout to @chris062689 again, without him this wouldn't have been possible!

Blog Post:
https://yuzu-emu.org/entry/yuzu-boxcat/

BotW DLC/Updates:
![dlc](https://user-images.githubusercontent.com/5064800/58774176-2854b100-858e-11e9-99ae-b7b68fed1df4.png)

UI:
![image](https://user-images.githubusercontent.com/5064800/58774212-4c17f700-858e-11e9-821a-6dbe3bd0e264.png)

