### PR TITLE
core/core_timing_util: Use std::chrono types for specifying time units

### DIFF
--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -57,7 +57,9 @@ Stream::State Stream::GetState() const {
 
 s64 Stream::GetBufferReleaseCycles(const Buffer& buffer) const {
     const std::size_t num_samples{buffer.GetSamples().size() / GetNumChannels()};
-    return Core::Timing::usToCycles((static_cast<u64>(num_samples) * 1000000) / sample_rate);
+    const auto us =
+        std::chrono::microseconds((static_cast<u64>(num_samples) * 1000000) / sample_rate);
+    return Core::Timing::usToCycles(us);
 }
 
 static void VolumeAdjustSamples(std::vector<s16>& samples) {

--- a/src/core/core_timing_util.cpp
+++ b/src/core/core_timing_util.cpp
@@ -13,36 +13,40 @@ namespace Core::Timing {
 
 constexpr u64 MAX_VALUE_TO_MULTIPLY = std::numeric_limits<s64>::max() / BASE_CLOCK_RATE;
 
-s64 usToCycles(s64 us) {
-    if (static_cast<u64>(us / 1000000) > MAX_VALUE_TO_MULTIPLY) {
+s64 msToCycles(std::chrono::milliseconds ms) {
+    if (static_cast<u64>(ms.count() / 1000) > MAX_VALUE_TO_MULTIPLY) {
         LOG_ERROR(Core_Timing, "Integer overflow, use max value");
         return std::numeric_limits<s64>::max();
     }
-    if (static_cast<u64>(us) > MAX_VALUE_TO_MULTIPLY) {
+    if (static_cast<u64>(ms.count()) > MAX_VALUE_TO_MULTIPLY) {
         LOG_DEBUG(Core_Timing, "Time very big, do rounding");
-        return BASE_CLOCK_RATE * (us / 1000000);
+        return BASE_CLOCK_RATE * (ms.count() / 1000);
     }
-    return (BASE_CLOCK_RATE * us) / 1000000;
+    return (BASE_CLOCK_RATE * ms.count()) / 1000;
 }
 
-s64 usToCycles(u64 us) {
-    return usToCycles(static_cast<s64>(us));
-}
-
-s64 nsToCycles(s64 ns) {
-    if (static_cast<u64>(ns / 1000000000) > MAX_VALUE_TO_MULTIPLY) {
+s64 usToCycles(std::chrono::microseconds us) {
+    if (static_cast<u64>(us.count() / 1000000) > MAX_VALUE_TO_MULTIPLY) {
         LOG_ERROR(Core_Timing, "Integer overflow, use max value");
         return std::numeric_limits<s64>::max();
     }
-    if (static_cast<u64>(ns) > MAX_VALUE_TO_MULTIPLY) {
+    if (static_cast<u64>(us.count()) > MAX_VALUE_TO_MULTIPLY) {
         LOG_DEBUG(Core_Timing, "Time very big, do rounding");
-        return BASE_CLOCK_RATE * (ns / 1000000000);
+        return BASE_CLOCK_RATE * (us.count() / 1000000);
     }
-    return (BASE_CLOCK_RATE * ns) / 1000000000;
+    return (BASE_CLOCK_RATE * us.count()) / 1000000;
 }
 
-s64 nsToCycles(u64 ns) {
-    return nsToCycles(static_cast<s64>(ns));
+s64 nsToCycles(std::chrono::nanoseconds ns) {
+    if (static_cast<u64>(ns.count() / 1000000000) > MAX_VALUE_TO_MULTIPLY) {
+        LOG_ERROR(Core_Timing, "Integer overflow, use max value");
+        return std::numeric_limits<s64>::max();
+    }
+    if (static_cast<u64>(ns.count()) > MAX_VALUE_TO_MULTIPLY) {
+        LOG_DEBUG(Core_Timing, "Time very big, do rounding");
+        return BASE_CLOCK_RATE * (ns.count() / 1000000000);
+    }
+    return (BASE_CLOCK_RATE * ns.count()) / 1000000000;
 }
 
 u64 CpuCyclesToClockCycles(u64 ticks) {

--- a/src/core/core_timing_util.cpp
+++ b/src/core/core_timing_util.cpp
@@ -26,15 +26,7 @@ s64 usToCycles(s64 us) {
 }
 
 s64 usToCycles(u64 us) {
-    if (us / 1000000 > MAX_VALUE_TO_MULTIPLY) {
-        LOG_ERROR(Core_Timing, "Integer overflow, use max value");
-        return std::numeric_limits<s64>::max();
-    }
-    if (us > MAX_VALUE_TO_MULTIPLY) {
-        LOG_DEBUG(Core_Timing, "Time very big, do rounding");
-        return BASE_CLOCK_RATE * static_cast<s64>(us / 1000000);
-    }
-    return (BASE_CLOCK_RATE * static_cast<s64>(us)) / 1000000;
+    return usToCycles(static_cast<s64>(us));
 }
 
 s64 nsToCycles(s64 ns) {
@@ -50,15 +42,7 @@ s64 nsToCycles(s64 ns) {
 }
 
 s64 nsToCycles(u64 ns) {
-    if (ns / 1000000000 > MAX_VALUE_TO_MULTIPLY) {
-        LOG_ERROR(Core_Timing, "Integer overflow, use max value");
-        return std::numeric_limits<s64>::max();
-    }
-    if (ns > MAX_VALUE_TO_MULTIPLY) {
-        LOG_DEBUG(Core_Timing, "Time very big, do rounding");
-        return BASE_CLOCK_RATE * (static_cast<s64>(ns) / 1000000000);
-    }
-    return (BASE_CLOCK_RATE * static_cast<s64>(ns)) / 1000000000;
+    return nsToCycles(static_cast<s64>(ns));
 }
 
 u64 CpuCyclesToClockCycles(u64 ticks) {

--- a/src/core/core_timing_util.h
+++ b/src/core/core_timing_util.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <chrono>
 #include "common/common_types.h"
 
 namespace Core::Timing {
@@ -13,22 +14,20 @@ namespace Core::Timing {
 constexpr u64 BASE_CLOCK_RATE = 1019215872; // Switch clock speed is 1020MHz un/docked
 constexpr u64 CNTFREQ = 19200000;           // Value from fusee.
 
-s64 usToCycles(s64 us);
-s64 usToCycles(u64 us);
+s64 msToCycles(std::chrono::milliseconds ms);
+s64 usToCycles(std::chrono::microseconds us);
+s64 nsToCycles(std::chrono::nanoseconds ns);
 
-s64 nsToCycles(s64 ns);
-s64 nsToCycles(u64 ns);
-
-inline u64 cyclesToNs(s64 cycles) {
-    return cycles * 1000000000 / BASE_CLOCK_RATE;
+inline std::chrono::milliseconds cyclesToMs(s64 cycles) {
+    return std::chrono::milliseconds(cycles * 1000 / BASE_CLOCK_RATE);
 }
 
-inline s64 cyclesToUs(s64 cycles) {
-    return cycles * 1000000 / BASE_CLOCK_RATE;
+inline std::chrono::nanoseconds cyclesToNs(s64 cycles) {
+    return std::chrono::nanoseconds(cycles * 1000000000 / BASE_CLOCK_RATE);
 }
 
-inline u64 cyclesToMs(s64 cycles) {
-    return cycles * 1000 / BASE_CLOCK_RATE;
+inline std::chrono::microseconds cyclesToUs(s64 cycles) {
+    return std::chrono::microseconds(cycles * 1000000 / BASE_CLOCK_RATE);
 }
 
 u64 CpuCyclesToClockCycles(u64 ticks);

--- a/src/core/core_timing_util.h
+++ b/src/core/core_timing_util.h
@@ -13,41 +13,10 @@ namespace Core::Timing {
 constexpr u64 BASE_CLOCK_RATE = 1019215872; // Switch clock speed is 1020MHz un/docked
 constexpr u64 CNTFREQ = 19200000;           // Value from fusee.
 
-inline s64 msToCycles(int ms) {
-    // since ms is int there is no way to overflow
-    return BASE_CLOCK_RATE * static_cast<s64>(ms) / 1000;
-}
-
-inline s64 msToCycles(float ms) {
-    return static_cast<s64>(BASE_CLOCK_RATE * (0.001f) * ms);
-}
-
-inline s64 msToCycles(double ms) {
-    return static_cast<s64>(BASE_CLOCK_RATE * (0.001) * ms);
-}
-
-inline s64 usToCycles(float us) {
-    return static_cast<s64>(BASE_CLOCK_RATE * (0.000001f) * us);
-}
-
-inline s64 usToCycles(int us) {
-    return (BASE_CLOCK_RATE * static_cast<s64>(us) / 1000000);
-}
-
 s64 usToCycles(s64 us);
-
 s64 usToCycles(u64 us);
 
-inline s64 nsToCycles(float ns) {
-    return static_cast<s64>(BASE_CLOCK_RATE * (0.000000001f) * ns);
-}
-
-inline s64 nsToCycles(int ns) {
-    return BASE_CLOCK_RATE * static_cast<s64>(ns) / 1000000000;
-}
-
 s64 nsToCycles(s64 ns);
-
 s64 nsToCycles(u64 ns);
 
 inline u64 cyclesToNs(s64 cycles) {

--- a/src/core/core_timing_util.h
+++ b/src/core/core_timing_util.h
@@ -18,15 +18,15 @@ s64 msToCycles(std::chrono::milliseconds ms);
 s64 usToCycles(std::chrono::microseconds us);
 s64 nsToCycles(std::chrono::nanoseconds ns);
 
-inline std::chrono::milliseconds cyclesToMs(s64 cycles) {
+inline std::chrono::milliseconds CyclesToMs(s64 cycles) {
     return std::chrono::milliseconds(cycles * 1000 / BASE_CLOCK_RATE);
 }
 
-inline std::chrono::nanoseconds cyclesToNs(s64 cycles) {
+inline std::chrono::nanoseconds CyclesToNs(s64 cycles) {
     return std::chrono::nanoseconds(cycles * 1000000000 / BASE_CLOCK_RATE);
 }
 
-inline std::chrono::microseconds cyclesToUs(s64 cycles) {
+inline std::chrono::microseconds CyclesToUs(s64 cycles) {
     return std::chrono::microseconds(cycles * 1000000 / BASE_CLOCK_RATE);
 }
 

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -75,9 +75,9 @@ void Thread::WakeAfterDelay(s64 nanoseconds) {
 
     // This function might be called from any thread so we have to be cautious and use the
     // thread-safe version of ScheduleEvent.
+    const s64 cycles = Core::Timing::nsToCycles(std::chrono::nanoseconds{nanoseconds});
     Core::System::GetInstance().CoreTiming().ScheduleEventThreadsafe(
-        Core::Timing::nsToCycles(nanoseconds), kernel.ThreadWakeupCallbackEventType(),
-        callback_handle);
+        cycles, kernel.ThreadWakeupCallbackEventType(), callback_handle);
 }
 
 void Thread::CancelWakeupTimer() {

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
@@ -185,7 +185,7 @@ u32 nvhost_ctrl_gpu::GetGpuTime(const std::vector<u8>& input, std::vector<u8>& o
 
     IoctlGetGpuTime params{};
     std::memcpy(&params, input.data(), input.size());
-    const auto ns = Core::Timing::cyclesToNs(Core::System::GetInstance().CoreTiming().GetTicks());
+    const auto ns = Core::Timing::CyclesToNs(Core::System::GetInstance().CoreTiming().GetTicks());
     params.gpu_time = static_cast<u64_le>(ns.count());
     std::memcpy(output.data(), &params, output.size());
     return 0;

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
@@ -185,7 +185,8 @@ u32 nvhost_ctrl_gpu::GetGpuTime(const std::vector<u8>& input, std::vector<u8>& o
 
     IoctlGetGpuTime params{};
     std::memcpy(&params, input.data(), input.size());
-    params.gpu_time = Core::Timing::cyclesToNs(Core::System::GetInstance().CoreTiming().GetTicks());
+    const auto ns = Core::Timing::cyclesToNs(Core::System::GetInstance().CoreTiming().GetTicks());
+    params.gpu_time = static_cast<u64_le>(ns.count());
     std::memcpy(output.data(), &params, output.size());
     return 0;
 }

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -108,7 +108,7 @@ private:
         LOG_DEBUG(Service_Time, "called");
 
         const auto& core_timing = Core::System::GetInstance().CoreTiming();
-        const auto ms = Core::Timing::cyclesToMs(core_timing.GetTicks());
+        const auto ms = Core::Timing::CyclesToMs(core_timing.GetTicks());
         const SteadyClockTimePoint steady_clock_time_point{static_cast<u64_le>(ms.count() / 1000),
                                                            {}};
         IPC::ResponseBuilder rb{ctx, (sizeof(SteadyClockTimePoint) / 4) + 2};
@@ -285,7 +285,7 @@ void Module::Interface::GetClockSnapshot(Kernel::HLERequestContext& ctx) {
     }
 
     const auto& core_timing = Core::System::GetInstance().CoreTiming();
-    const auto ms = Core::Timing::cyclesToMs(core_timing.GetTicks());
+    const auto ms = Core::Timing::CyclesToMs(core_timing.GetTicks());
     const SteadyClockTimePoint steady_clock_time_point{static_cast<u64_le>(ms.count() / 1000), {}};
 
     CalendarTime calendar_time{};

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -108,8 +108,9 @@ private:
         LOG_DEBUG(Service_Time, "called");
 
         const auto& core_timing = Core::System::GetInstance().CoreTiming();
-        const SteadyClockTimePoint steady_clock_time_point{
-            Core::Timing::cyclesToMs(core_timing.GetTicks()) / 1000};
+        const auto ms = Core::Timing::cyclesToMs(core_timing.GetTicks());
+        const SteadyClockTimePoint steady_clock_time_point{static_cast<u64_le>(ms.count() / 1000),
+                                                           {}};
         IPC::ResponseBuilder rb{ctx, (sizeof(SteadyClockTimePoint) / 4) + 2};
         rb.Push(RESULT_SUCCESS);
         rb.PushRaw(steady_clock_time_point);
@@ -284,8 +285,8 @@ void Module::Interface::GetClockSnapshot(Kernel::HLERequestContext& ctx) {
     }
 
     const auto& core_timing = Core::System::GetInstance().CoreTiming();
-    const SteadyClockTimePoint steady_clock_time_point{
-        Core::Timing::cyclesToMs(core_timing.GetTicks()) / 1000, {}};
+    const auto ms = Core::Timing::cyclesToMs(core_timing.GetTicks());
+    const SteadyClockTimePoint steady_clock_time_point{static_cast<u64_le>(ms.count() / 1000), {}};
 
     CalendarTime calendar_time{};
     calendar_time.year = tm->tm_year + 1900;

--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -75,7 +75,7 @@ void ThreadManager::StartThread(VideoCore::RendererBase& renderer, Tegra::DmaPus
 
 void ThreadManager::SubmitList(Tegra::CommandList&& entries) {
     const u64 fence{PushCommand(SubmitListCommand(std::move(entries)))};
-    const s64 synchronization_ticks{Core::Timing::usToCycles(9000)};
+    const s64 synchronization_ticks{Core::Timing::usToCycles(std::chrono::microseconds{9000})};
     system.CoreTiming().ScheduleEvent(synchronization_ticks, synchronization_event, fence);
 }
 


### PR DESCRIPTION
Simplifies the interface and bases it off of the `std::chrono` time units. This way any other time unit can have their conversions handled by the standard library (either implicitly through regular cross-unit conversions, or explicitly with duration_cast, should it be necessary).