### PR TITLE
yuzu/configuration: Make all widgets and dialogs aware of language changes

### DIFF
--- a/src/yuzu/configuration/configure_audio.h
+++ b/src/yuzu/configuration/configure_audio.h
@@ -19,9 +19,14 @@ public:
     ~ConfigureAudio() override;
 
     void ApplyConfiguration();
-    void RetranslateUI();
 
 private:
+    void changeEvent(QEvent* event) override;
+
+    void InitializeAudioOutputSinkComboBox();
+
+    void RetranslateUI();
+
     void UpdateAudioDevices(int sink_index);
 
     void SetConfiguration();

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -51,3 +51,15 @@ void ConfigureDebug::ApplyConfiguration() {
     filter.ParseFilterString(Settings::values.log_filter);
     Log::SetGlobalFilter(filter);
 }
+
+void ConfigureDebug::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
+void ConfigureDebug::RetranslateUI() {
+    ui->retranslateUi(this);
+}

--- a/src/yuzu/configuration/configure_debug.h
+++ b/src/yuzu/configuration/configure_debug.h
@@ -21,6 +21,9 @@ public:
     void ApplyConfiguration();
 
 private:
+    void changeEvent(QEvent* event) override;
+
+    void RetranslateUI();
     void SetConfiguration();
 
     std::unique_ptr<Ui::ConfigureDebug> ui;

--- a/src/yuzu/configuration/configure_dialog.h
+++ b/src/yuzu/configuration/configure_dialog.h
@@ -23,6 +23,10 @@ public:
     void ApplyConfiguration();
 
 private:
+    void changeEvent(QEvent* event) override;
+
+    void RetranslateUI();
+
     void SetConfiguration();
     void UpdateVisibleTabs();
     void PopulateSelectionList();

--- a/src/yuzu/configuration/configure_gamelist.cpp
+++ b/src/yuzu/configuration/configure_gamelist.cpp
@@ -77,7 +77,6 @@ void ConfigureGameList::SetConfiguration() {
 void ConfigureGameList::changeEvent(QEvent* event) {
     if (event->type() == QEvent::LanguageChange) {
         RetranslateUI();
-        return;
     }
 
     QWidget::changeEvent(event);

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -45,3 +45,15 @@ void ConfigureGeneral::ApplyConfiguration() {
 
     Settings::values.use_cpu_jit = ui->use_cpu_jit->isChecked();
 }
+
+void ConfigureGeneral::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
+void ConfigureGeneral::RetranslateUI() {
+    ui->retranslateUi(this);
+}

--- a/src/yuzu/configuration/configure_general.h
+++ b/src/yuzu/configuration/configure_general.h
@@ -23,6 +23,9 @@ public:
     void ApplyConfiguration();
 
 private:
+    void changeEvent(QEvent* event) override;
+    void RetranslateUI();
+
     void SetConfiguration();
 
     std::unique_ptr<Ui::ConfigureGeneral> ui;

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -104,6 +104,18 @@ void ConfigureGraphics::ApplyConfiguration() {
     Settings::values.bg_blue = static_cast<float>(bg_color.blueF());
 }
 
+void ConfigureGraphics::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
+void ConfigureGraphics::RetranslateUI() {
+    ui->retranslateUi(this);
+}
+
 void ConfigureGraphics::UpdateBackgroundColorButton(QColor color) {
     bg_color = color;
 

--- a/src/yuzu/configuration/configure_graphics.h
+++ b/src/yuzu/configuration/configure_graphics.h
@@ -21,6 +21,9 @@ public:
     void ApplyConfiguration();
 
 private:
+    void changeEvent(QEvent* event) override;
+    void RetranslateUI();
+
     void SetConfiguration();
 
     void UpdateBackgroundColorButton(QColor color);

--- a/src/yuzu/configuration/configure_hotkeys.cpp
+++ b/src/yuzu/configuration/configure_hotkeys.cpp
@@ -17,7 +17,6 @@ ConfigureHotkeys::ConfigureHotkeys(QWidget* parent)
 
     model = new QStandardItemModel(this);
     model->setColumnCount(3);
-    model->setHorizontalHeaderLabels({tr("Action"), tr("Hotkey"), tr("Context")});
 
     connect(ui->hotkey_list, &QTreeView::doubleClicked, this, &ConfigureHotkeys::Configure);
     ui->hotkey_list->setModel(model);
@@ -27,6 +26,8 @@ ConfigureHotkeys::ConfigureHotkeys(QWidget* parent)
 
     ui->hotkey_list->setColumnWidth(0, 200);
     ui->hotkey_list->resizeColumnToContents(1);
+
+    RetranslateUI();
 }
 
 ConfigureHotkeys::~ConfigureHotkeys() = default;
@@ -47,6 +48,20 @@ void ConfigureHotkeys::Populate(const HotkeyRegistry& registry) {
     }
 
     ui->hotkey_list->expandAll();
+}
+
+void ConfigureHotkeys::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
+void ConfigureHotkeys::RetranslateUI() {
+    ui->retranslateUi(this);
+
+    model->setHorizontalHeaderLabels({tr("Action"), tr("Hotkey"), tr("Context")});
 }
 
 void ConfigureHotkeys::Configure(QModelIndex index) {
@@ -111,8 +126,4 @@ void ConfigureHotkeys::ApplyConfiguration(HotkeyRegistry& registry) {
     }
 
     registry.SaveHotkeys();
-}
-
-void ConfigureHotkeys::RetranslateUI() {
-    ui->retranslateUi(this);
 }

--- a/src/yuzu/configuration/configure_hotkeys.h
+++ b/src/yuzu/configuration/configure_hotkeys.h
@@ -22,7 +22,6 @@ public:
     ~ConfigureHotkeys() override;
 
     void ApplyConfiguration(HotkeyRegistry& registry);
-    void RetranslateUI();
 
     /**
      * Populates the hotkey list widget using data from the provided registry.
@@ -32,6 +31,9 @@ public:
     void Populate(const HotkeyRegistry& registry);
 
 private:
+    void changeEvent(QEvent* event) override;
+    void RetranslateUI();
+
     void Configure(QModelIndex index);
     bool IsUsedKey(QKeySequence key_sequence) const;
 

--- a/src/yuzu/configuration/configure_input.h
+++ b/src/yuzu/configuration/configure_input.h
@@ -33,10 +33,16 @@ public:
     void ApplyConfiguration();
 
 private:
+    void changeEvent(QEvent* event) override;
+    void RetranslateUI();
+    void RetranslateControllerComboBoxes();
+
     void UpdateUIEnabled();
 
     /// Load configuration settings.
     void LoadConfiguration();
+    void LoadPlayerControllerIndices();
+
     /// Restore all buttons to their default values.
     void RestoreDefaults();
 

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -373,6 +373,19 @@ void ConfigureInputPlayer::ApplyConfiguration() {
     Settings::values.players[player_index].button_color_right = colors[3];
 }
 
+void ConfigureInputPlayer::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QDialog::changeEvent(event);
+}
+
+void ConfigureInputPlayer::RetranslateUI() {
+    ui->retranslateUi(this);
+    UpdateButtonLabels();
+}
+
 void ConfigureInputPlayer::OnControllerButtonClick(int i) {
     const QColor new_bg_color = QColorDialog::getColor(controller_colors[i]);
     if (!new_bg_color.isValid())

--- a/src/yuzu/configuration/configure_input_player.h
+++ b/src/yuzu/configuration/configure_input_player.h
@@ -41,6 +41,9 @@ public:
     void ApplyConfiguration();
 
 private:
+    void changeEvent(QEvent* event) override;
+    void RetranslateUI();
+
     void OnControllerButtonClick(int i);
 
     /// Load configuration settings.

--- a/src/yuzu/configuration/configure_input_simple.cpp
+++ b/src/yuzu/configuration/configure_input_simple.cpp
@@ -119,6 +119,18 @@ void ConfigureInputSimple::ApplyConfiguration() {
     UISettings::values.profile_index = index;
 }
 
+void ConfigureInputSimple::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
+void ConfigureInputSimple::RetranslateUI() {
+    ui->retranslateUi(this);
+}
+
 void ConfigureInputSimple::LoadConfiguration() {
     const auto index = UISettings::values.profile_index;
     if (index >= static_cast<int>(INPUT_PROFILES.size()) || index < 0) {

--- a/src/yuzu/configuration/configure_input_simple.h
+++ b/src/yuzu/configuration/configure_input_simple.h
@@ -30,6 +30,9 @@ public:
     void ApplyConfiguration();
 
 private:
+    void changeEvent(QEvent* event) override;
+    void RetranslateUI();
+
     /// Load configuration settings.
     void LoadConfiguration();
 

--- a/src/yuzu/configuration/configure_mouse_advanced.cpp
+++ b/src/yuzu/configuration/configure_mouse_advanced.cpp
@@ -140,6 +140,18 @@ void ConfigureMouseAdvanced::LoadConfiguration() {
     UpdateButtonLabels();
 }
 
+void ConfigureMouseAdvanced::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QDialog::changeEvent(event);
+}
+
+void ConfigureMouseAdvanced::RetranslateUI() {
+    ui->retranslateUi(this);
+}
+
 void ConfigureMouseAdvanced::RestoreDefaults() {
     for (int button_id = 0; button_id < Settings::NativeMouseButton::NumMouseButtons; button_id++) {
         buttons_param[button_id] = Common::ParamPackage{

--- a/src/yuzu/configuration/configure_mouse_advanced.h
+++ b/src/yuzu/configuration/configure_mouse_advanced.h
@@ -28,6 +28,9 @@ public:
     void ApplyConfiguration();
 
 private:
+    void changeEvent(QEvent* event) override;
+    void RetranslateUI();
+
     /// Load configuration settings.
     void LoadConfiguration();
     /// Restore all buttons to their default values.

--- a/src/yuzu/configuration/configure_per_general.cpp
+++ b/src/yuzu/configuration/configure_per_general.cpp
@@ -92,6 +92,18 @@ void ConfigurePerGameGeneral::ApplyConfiguration() {
     Settings::values.disabled_addons[title_id] = disabled_addons;
 }
 
+void ConfigurePerGameGeneral::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QDialog::changeEvent(event);
+}
+
+void ConfigurePerGameGeneral::RetranslateUI() {
+    ui->retranslateUi(this);
+}
+
 void ConfigurePerGameGeneral::LoadFromFile(FileSys::VirtualFile file) {
     this->file = std::move(file);
     LoadConfiguration();

--- a/src/yuzu/configuration/configure_per_general.h
+++ b/src/yuzu/configuration/configure_per_general.h
@@ -35,6 +35,9 @@ public:
     void LoadFromFile(FileSys::VirtualFile file);
 
 private:
+    void changeEvent(QEvent* event) override;
+    void RetranslateUI();
+
     void LoadConfiguration();
 
     std::unique_ptr<Ui::ConfigurePerGameGeneral> ui;

--- a/src/yuzu/configuration/configure_profile_manager.cpp
+++ b/src/yuzu/configuration/configure_profile_manager.cpp
@@ -80,11 +80,10 @@ ConfigureProfileManager ::ConfigureProfileManager(QWidget* parent)
       profile_manager(std::make_unique<Service::Account::ProfileManager>()) {
     ui->setupUi(this);
 
-    layout = new QVBoxLayout;
     tree_view = new QTreeView;
     item_model = new QStandardItemModel(tree_view);
+    item_model->insertColumns(0, 1);
     tree_view->setModel(item_model);
-
     tree_view->setAlternatingRowColors(true);
     tree_view->setSelectionMode(QHeaderView::SingleSelection);
     tree_view->setSelectionBehavior(QHeaderView::SelectRows);
@@ -96,13 +95,11 @@ ConfigureProfileManager ::ConfigureProfileManager(QWidget* parent)
     tree_view->setIconSize({64, 64});
     tree_view->setContextMenuPolicy(Qt::NoContextMenu);
 
-    item_model->insertColumns(0, 1);
-    item_model->setHeaderData(0, Qt::Horizontal, tr("Users"));
-
     // We must register all custom types with the Qt Automoc system so that we are able to use it
     // with signals/slots. In this case, QList falls under the umbrells of custom types.
     qRegisterMetaType<QList<QStandardItem*>>("QList<QStandardItem*>");
 
+    layout = new QVBoxLayout;
     layout->setContentsMargins(0, 0, 0, 0);
     layout->setSpacing(0);
     layout->addWidget(tree_view);
@@ -120,9 +117,23 @@ ConfigureProfileManager ::ConfigureProfileManager(QWidget* parent)
     ui->current_user_icon->setScene(scene);
 
     SetConfiguration();
+    RetranslateUI();
 }
 
 ConfigureProfileManager::~ConfigureProfileManager() = default;
+
+void ConfigureProfileManager::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
+void ConfigureProfileManager::RetranslateUI() {
+    ui->retranslateUi(this);
+    item_model->setHeaderData(0, Qt::Horizontal, tr("Users"));
+}
 
 void ConfigureProfileManager::SetConfiguration() {
     enabled = !Core::System::GetInstance().IsPoweredOn();

--- a/src/yuzu/configuration/configure_profile_manager.h
+++ b/src/yuzu/configuration/configure_profile_manager.h
@@ -33,6 +33,9 @@ public:
     void ApplyConfiguration();
 
 private:
+    void changeEvent(QEvent* event) override;
+    void RetranslateUI();
+
     void SetConfiguration();
 
     void PopulateUserList();

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -40,6 +40,18 @@ ConfigureSystem::ConfigureSystem(QWidget* parent) : QWidget(parent), ui(new Ui::
 
 ConfigureSystem::~ConfigureSystem() = default;
 
+void ConfigureSystem::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
+void ConfigureSystem::RetranslateUI() {
+    ui->retranslateUi(this);
+}
+
 void ConfigureSystem::SetConfiguration() {
     enabled = !Core::System::GetInstance().IsPoweredOn();
 

--- a/src/yuzu/configuration/configure_system.h
+++ b/src/yuzu/configuration/configure_system.h
@@ -23,6 +23,9 @@ public:
     void ApplyConfiguration();
 
 private:
+    void changeEvent(QEvent* event) override;
+    void RetranslateUI();
+
     void SetConfiguration();
 
     void ReadSystemSettings();

--- a/src/yuzu/configuration/configure_touchscreen_advanced.cpp
+++ b/src/yuzu/configuration/configure_touchscreen_advanced.cpp
@@ -20,6 +20,18 @@ ConfigureTouchscreenAdvanced::ConfigureTouchscreenAdvanced(QWidget* parent)
 
 ConfigureTouchscreenAdvanced::~ConfigureTouchscreenAdvanced() = default;
 
+void ConfigureTouchscreenAdvanced::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QDialog::changeEvent(event);
+}
+
+void ConfigureTouchscreenAdvanced::RetranslateUI() {
+    ui->retranslateUi(this);
+}
+
 void ConfigureTouchscreenAdvanced::ApplyConfiguration() {
     Settings::values.touchscreen.finger = ui->finger_box->value();
     Settings::values.touchscreen.diameter_x = ui->diameter_x_box->value();

--- a/src/yuzu/configuration/configure_touchscreen_advanced.h
+++ b/src/yuzu/configuration/configure_touchscreen_advanced.h
@@ -21,6 +21,9 @@ public:
     void ApplyConfiguration();
 
 private:
+    void changeEvent(QEvent* event) override;
+    void RetranslateUI();
+
     /// Load configuration settings.
     void LoadConfiguration();
     /// Restore all buttons to their default values.

--- a/src/yuzu/configuration/configure_web.cpp
+++ b/src/yuzu/configuration/configure_web.cpp
@@ -22,35 +22,55 @@ ConfigureWeb::ConfigureWeb(QWidget* parent)
 #ifndef USE_DISCORD_PRESENCE
     ui->discord_group->setVisible(false);
 #endif
+
     SetConfiguration();
+    RetranslateUI();
 }
 
 ConfigureWeb::~ConfigureWeb() = default;
 
-void ConfigureWeb::SetConfiguration() {
-    ui->web_credentials_disclaimer->setWordWrap(true);
-    ui->telemetry_learn_more->setOpenExternalLinks(true);
+void ConfigureWeb::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
+void ConfigureWeb::RetranslateUI() {
+    ui->retranslateUi(this);
+
     ui->telemetry_learn_more->setText(
         tr("<a href='https://yuzu-emu.org/help/feature/telemetry/'><span style=\"text-decoration: "
            "underline; color:#039be5;\">Learn more</span></a>"));
 
-    ui->web_signup_link->setOpenExternalLinks(true);
     ui->web_signup_link->setText(
         tr("<a href='https://profile.yuzu-emu.org/'><span style=\"text-decoration: underline; "
            "color:#039be5;\">Sign up</span></a>"));
-    ui->web_token_info_link->setOpenExternalLinks(true);
+
     ui->web_token_info_link->setText(
         tr("<a href='https://yuzu-emu.org/wiki/yuzu-web-service/'><span style=\"text-decoration: "
            "underline; color:#039be5;\">What is my token?</span></a>"));
 
+    ui->label_telemetry_id->setText(
+        tr("Telemetry ID: 0x%1").arg(QString::number(Core::GetTelemetryId(), 16).toUpper()));
+}
+
+void ConfigureWeb::SetConfiguration() {
+    ui->web_credentials_disclaimer->setWordWrap(true);
+
+    ui->telemetry_learn_more->setOpenExternalLinks(true);
+    ui->web_signup_link->setOpenExternalLinks(true);
+    ui->web_token_info_link->setOpenExternalLinks(true);
+
     ui->toggle_telemetry->setChecked(Settings::values.enable_telemetry);
     ui->edit_username->setText(QString::fromStdString(Settings::values.yuzu_username));
     ui->edit_token->setText(QString::fromStdString(Settings::values.yuzu_token));
+
     // Connect after setting the values, to avoid calling OnLoginChanged now
     connect(ui->edit_token, &QLineEdit::textChanged, this, &ConfigureWeb::OnLoginChanged);
     connect(ui->edit_username, &QLineEdit::textChanged, this, &ConfigureWeb::OnLoginChanged);
-    ui->label_telemetry_id->setText(
-        tr("Telemetry ID: 0x%1").arg(QString::number(Core::GetTelemetryId(), 16).toUpper()));
+
     user_verified = true;
 
     ui->toggle_discordrpc->setChecked(UISettings::values.enable_discord_presence);
@@ -119,8 +139,4 @@ void ConfigureWeb::OnLoginVerified() {
             tr("Verification failed. Check that you have entered your username and token "
                "correctly, and that your internet connection is working."));
     }
-}
-
-void ConfigureWeb::RetranslateUI() {
-    ui->retranslateUi(this);
 }

--- a/src/yuzu/configuration/configure_web.h
+++ b/src/yuzu/configuration/configure_web.h
@@ -20,9 +20,11 @@ public:
     ~ConfigureWeb() override;
 
     void ApplyConfiguration();
-    void RetranslateUI();
 
 private:
+    void changeEvent(QEvent* event) override;
+    void RetranslateUI();
+
     void RefreshTelemetryID();
     void OnLoginChanged();
     void VerifyLogin();


### PR DESCRIPTION
To prepare for translation support, this makes all of the widgets cognizant of the language change event that occurs whenever installTranslator() is called and automatically retranslates their text where necessary.

This is important as calling the backing UI's retranslateUi() is often not enough, particularly in cases where we add our own strings that aren't controlled by it. In that case we need to manually refresh the strings ourselves.