### PR TITLE
kernel/process: Decouple TLS handling from threads

### DIFF
--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <array>
-#include <bitset>
 #include <cstddef>
 #include <list>
 #include <string>
@@ -32,6 +31,7 @@ namespace Kernel {
 class KernelCore;
 class ResourceLimit;
 class Thread;
+class TLSPage;
 
 struct CodeSet;
 
@@ -260,10 +260,10 @@ public:
     // Thread-local storage management
 
     // Marks the next available region as used and returns the address of the slot.
-    VAddr MarkNextAvailableTLSSlotAsUsed(Thread& thread);
+    [[nodiscard]] VAddr CreateTLSRegion();
 
     // Frees a used TLS slot identified by the given address
-    void FreeTLSSlot(VAddr tls_address);
+    void FreeTLSRegion(VAddr tls_address);
 
 private:
     explicit Process(Core::System& system);
@@ -310,7 +310,7 @@ private:
     /// holds the TLS for a specific thread. This vector contains which parts are in use for each
     /// page as a bitmask.
     /// This vector will grow as more pages are allocated for new threads.
-    std::vector<std::bitset<8>> tls_slots;
+    std::vector<TLSPage> tls_pages;
 
     /// Contains the parsed process capability descriptors.
     ProcessCapabilities capabilities;

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -290,7 +290,7 @@ private:
     u64 code_memory_size = 0;
 
     /// Current status of the process
-    ProcessStatus status;
+    ProcessStatus status{};
 
     /// The ID of this process
     u64 process_id = 0;
@@ -339,7 +339,7 @@ private:
     Mutex mutex;
 
     /// Random values for svcGetInfo RandomEntropy
-    std::array<u64, RANDOM_ENTROPY_SIZE> random_entropy;
+    std::array<u64, RANDOM_ENTROPY_SIZE> random_entropy{};
 
     /// List of threads that are running with this process as their owner.
     std::list<const Thread*> thread_list;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -65,7 +65,7 @@ void Thread::Stop() {
     owner_process->UnregisterThread(this);
 
     // Mark the TLS slot in the thread's page as free.
-    owner_process->FreeTLSSlot(tls_address);
+    owner_process->FreeTLSRegion(tls_address);
 }
 
 void Thread::WakeAfterDelay(s64 nanoseconds) {
@@ -205,9 +205,9 @@ ResultVal<SharedPtr<Thread>> Thread::Create(KernelCore& kernel, std::string name
     thread->name = std::move(name);
     thread->callback_handle = kernel.ThreadWakeupCallbackHandleTable().Create(thread).Unwrap();
     thread->owner_process = &owner_process;
+    thread->tls_address = thread->owner_process->CreateTLSRegion();
     thread->scheduler = &system.Scheduler(processor_id);
     thread->scheduler->AddThread(thread);
-    thread->tls_address = thread->owner_process->MarkNextAvailableTLSSlotAsUsed(*thread);
 
     thread->owner_process->RegisterThread(thread.get());
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <functional>
-#include <memory>
 #include <string>
 #include <vector>
 
@@ -78,9 +77,6 @@ enum class ThreadActivity : u32 {
 
 class Thread final : public WaitObject {
 public:
-    using TLSMemory = std::vector<u8>;
-    using TLSMemoryPtr = std::shared_ptr<TLSMemory>;
-
     using MutexWaitingThreads = std::vector<SharedPtr<Thread>>;
 
     using ThreadContext = Core::ARM_Interface::ThreadContext;
@@ -167,14 +163,6 @@ public:
      */
     u64 GetThreadID() const {
         return thread_id;
-    }
-
-    TLSMemoryPtr& GetTLSMemory() {
-        return tls_memory;
-    }
-
-    const TLSMemoryPtr& GetTLSMemory() const {
-        return tls_memory;
     }
 
     /// Resumes a thread from waiting
@@ -463,11 +451,9 @@ private:
     u32 ideal_core{0xFFFFFFFF};
     u64 affinity_mask{0x1};
 
-    TLSMemoryPtr tls_memory = std::make_shared<TLSMemory>();
+    ThreadActivity activity = ThreadActivity::Normal;
 
     std::string name;
-
-    ThreadActivity activity = ThreadActivity::Normal;
 };
 
 /**

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -362,12 +362,37 @@ public:
     ResultVal<VMAHandle> MapBackingMemory(VAddr target, u8* memory, u64 size, MemoryState state);
 
     /**
-     * Finds the first free address that can hold a region of the desired size.
+     * Finds the first free memory region of the given size within
+     * the user-addressable ASLR memory region.
      *
-     * @param size Size of the desired region.
-     * @return The found free address.
+     * @param size The size of the desired region in bytes.
+     *
+     * @returns If successful, the base address of the free region with
+     *          the given size.
      */
     ResultVal<VAddr> FindFreeRegion(u64 size) const;
+
+    /**
+     * Finds the first free address range that can hold a region of the desired size
+     *
+     * @param begin The starting address of the range.
+     *              This is treated as an inclusive beginning address.
+     *
+     * @param end   The ending address of the range.
+     *              This is treated as an exclusive ending address.
+     *
+     * @param size  The size of the free region to attempt to locate,
+     *              in bytes.
+     *
+     * @returns If successful, the base address of the free region with
+     *          the given size.
+     *
+     * @returns If unsuccessful, a result containing an error code.
+     *
+     * @pre The starting address must be less than the ending address.
+     * @pre The size must not exceed the address range itself.
+     */
+    ResultVal<VAddr> FindFreeRegion(VAddr begin, VAddr end, u64 size) const;
 
     /**
      * Maps a memory-mapped IO region at a given address.


### PR DESCRIPTION
Previously each thread instance was holding a block of memory representing a TLS region. An issue with that is:

1. It's not necessary (it's mostly another carry-over from Citra).
2. It over-exposes info that shouldn't really be shared outside of a process instance.

This brings the TLS slot management more in line with how the kernel on the actual system handles it and makes way for handling other aspects related to TLS regions more correctly.

A thread instance is also no longer a requirement for retrieving a TLS region. This is important because a thread isn't the only thing that's assigned a TLS region. Process instances are also assigned one during creation. This will be handled in another PR, as it requires some changes outside of the kernel. This change preserves existing behavior while providing the necessary machinery to work off of.