### PR TITLE
kernel/svc: Handle TotalPhysicalMemoryAvailableWithoutMmHeap and TotalPhysicalMemoryUsedWithoutMmHeap

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -72,8 +72,24 @@ SharedPtr<ResourceLimit> Process::GetResourceLimit() const {
     return resource_limit;
 }
 
+u64 Process::GetTotalPhysicalMemoryAvailable() const {
+    return vm_manager.GetTotalPhysicalMemoryAvailable();
+}
+
+u64 Process::GetTotalPhysicalMemoryAvailableWithoutMmHeap() const {
+    // TODO: Subtract the personal heap size from this when the
+    //       personal heap is implemented.
+    return GetTotalPhysicalMemoryAvailable();
+}
+
 u64 Process::GetTotalPhysicalMemoryUsed() const {
     return vm_manager.GetCurrentHeapSize() + main_thread_stack_size + code_memory_size;
+}
+
+u64 Process::GetTotalPhysicalMemoryUsedWithoutMmHeap() const {
+    // TODO: Subtract the personal heap size from this when the
+    //       personal heap is implemented.
+    return GetTotalPhysicalMemoryUsed();
 }
 
 void Process::RegisterThread(const Thread* thread) {

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -186,8 +186,19 @@ public:
         return random_entropy.at(index);
     }
 
+    /// Retrieves the total physical memory available to this process in bytes.
+    u64 GetTotalPhysicalMemoryAvailable() const;
+
+    /// Retrieves the total physical memory available to this process in bytes,
+    /// without the size of the personal heap added to it.
+    u64 GetTotalPhysicalMemoryAvailableWithoutMmHeap() const;
+
     /// Retrieves the total physical memory used by this process in bytes.
     u64 GetTotalPhysicalMemoryUsed() const;
+
+    /// Retrieves the total physical memory used by this process in bytes,
+    /// without the size of the personal heap added to it.
+    u64 GetTotalPhysicalMemoryUsedWithoutMmHeap() const;
 
     /// Gets the list of all threads created with this process as their owner.
     const std::list<const Thread*>& GetThreadList() const {

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -710,7 +710,7 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
         MapRegionSize = 3,
         HeapRegionBaseAddr = 4,
         HeapRegionSize = 5,
-        TotalMemoryUsage = 6,
+        TotalPhysicalMemoryAvailable = 6,
         TotalPhysicalMemoryUsed = 7,
         IsCurrentProcessBeingDebugged = 8,
         RegisterResourceLimit = 9,
@@ -745,7 +745,7 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
     case GetInfoType::ASLRRegionSize:
     case GetInfoType::NewMapRegionBaseAddr:
     case GetInfoType::NewMapRegionSize:
-    case GetInfoType::TotalMemoryUsage:
+    case GetInfoType::TotalPhysicalMemoryAvailable:
     case GetInfoType::TotalPhysicalMemoryUsed:
     case GetInfoType::IsVirtualAddressMemoryEnabled:
     case GetInfoType::PersonalMmHeapUsage:
@@ -803,8 +803,8 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
             *result = process->VMManager().GetNewMapRegionSize();
             return RESULT_SUCCESS;
 
-        case GetInfoType::TotalMemoryUsage:
-            *result = process->VMManager().GetTotalMemoryUsage();
+        case GetInfoType::TotalPhysicalMemoryAvailable:
+            *result = process->VMManager().GetTotalPhysicalMemoryAvailable();
             return RESULT_SUCCESS;
 
         case GetInfoType::TotalPhysicalMemoryUsed:

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -730,6 +730,9 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
         PrivilegedProcessId = 19,
         // 5.0.0+
         UserExceptionContextAddr = 20,
+        // 6.0.0+
+        TotalPhysicalMemoryAvailableWithoutMmHeap = 21,
+        TotalPhysicalMemoryUsedWithoutMmHeap = 22,
     };
 
     const auto info_id_type = static_cast<GetInfoType>(info_id);
@@ -750,7 +753,9 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
     case GetInfoType::IsVirtualAddressMemoryEnabled:
     case GetInfoType::PersonalMmHeapUsage:
     case GetInfoType::TitleId:
-    case GetInfoType::UserExceptionContextAddr: {
+    case GetInfoType::UserExceptionContextAddr:
+    case GetInfoType::TotalPhysicalMemoryAvailableWithoutMmHeap:
+    case GetInfoType::TotalPhysicalMemoryUsedWithoutMmHeap: {
         if (info_sub_id != 0) {
             return ERR_INVALID_ENUM_VALUE;
         }
@@ -804,7 +809,7 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
             return RESULT_SUCCESS;
 
         case GetInfoType::TotalPhysicalMemoryAvailable:
-            *result = process->VMManager().GetTotalPhysicalMemoryAvailable();
+            *result = process->GetTotalPhysicalMemoryAvailable();
             return RESULT_SUCCESS;
 
         case GetInfoType::TotalPhysicalMemoryUsed:
@@ -823,6 +828,14 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
             LOG_WARNING(Kernel_SVC,
                         "(STUBBED) Attempted to query user exception context address, returned 0");
             *result = 0;
+            return RESULT_SUCCESS;
+
+        case GetInfoType::TotalPhysicalMemoryAvailableWithoutMmHeap:
+            *result = process->GetTotalPhysicalMemoryAvailable();
+            return RESULT_SUCCESS;
+
+        case GetInfoType::TotalPhysicalMemoryUsedWithoutMmHeap:
+            *result = process->GetTotalPhysicalMemoryUsedWithoutMmHeap();
             return RESULT_SUCCESS;
 
         default:

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -716,7 +716,7 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
         RegisterResourceLimit = 9,
         IdleTickCount = 10,
         RandomEntropy = 11,
-        PerformanceCounter = 0xF0000002,
+        ThreadTickCount = 0xF0000002,
         // 2.0.0+
         ASLRRegionBaseAddr = 12,
         ASLRRegionSize = 13,
@@ -730,7 +730,6 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
         PrivilegedProcessId = 19,
         // 5.0.0+
         UserExceptionContextAddr = 20,
-        ThreadTickCount = 0xF0000002,
     };
 
     const auto info_id_type = static_cast<GetInfoType>(info_id);

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -758,7 +758,7 @@ VMManager::CheckResults VMManager::CheckRangeState(VAddr address, u64 size, Memo
         std::make_tuple(initial_state, initial_permissions, initial_attributes & ~ignore_mask));
 }
 
-u64 VMManager::GetTotalMemoryUsage() const {
+u64 VMManager::GetTotalPhysicalMemoryAvailable() const {
     LOG_WARNING(Kernel, "(STUBBED) called");
     return 0xF8000000;
 }

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -499,7 +499,7 @@ public:
     void LogLayout() const;
 
     /// Gets the total memory usage, used by svcGetInfo
-    u64 GetTotalMemoryUsage() const;
+    u64 GetTotalPhysicalMemoryAvailable() const;
 
     /// Gets the address space base address
     VAddr GetAddressSpaceBaseAddress() const;


### PR DESCRIPTION
Given we don't currently implement the personal heap yet, the existing memory querying functions are essentially doing what the memory querying types introduced in 6.0.0 do.

So, we can build the necessary machinery over the top of those and just use them as part of info types.