### PR TITLE
kernel/process: Make Create()'s name parameter be taken by value

### DIFF
--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -48,7 +48,7 @@ void SetupMainThread(Process& owner_process, KernelCore& kernel, u32 priority) {
 }
 } // Anonymous namespace
 
-SharedPtr<Process> Process::Create(Core::System& system, std::string&& name) {
+SharedPtr<Process> Process::Create(Core::System& system, std::string name) {
     auto& kernel = system.Kernel();
 
     SharedPtr<Process> process(new Process(system));

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -75,7 +75,7 @@ public:
 
     static constexpr std::size_t RANDOM_ENTROPY_SIZE = 4;
 
-    static SharedPtr<Process> Create(Core::System& system, std::string&& name);
+    static SharedPtr<Process> Create(Core::System& system, std::string name);
 
     std::string GetTypeName() const override {
         return "Process";


### PR DESCRIPTION
Makes the interface more flexible in terms of how Create() may be called, while still allowing the parameter itself to be moved into.