### PR TITLE
kernel/vm_manager: Remove redundant Reset call in destructor

### DIFF
--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -68,9 +68,7 @@ VMManager::VMManager(Core::System& system) : system{system} {
     Reset(FileSys::ProgramAddressSpaceType::Is39Bit);
 }
 
-VMManager::~VMManager() {
-    Reset(FileSys::ProgramAddressSpaceType::Is39Bit);
-}
+VMManager::~VMManager() = default;
 
 void VMManager::Reset(FileSys::ProgramAddressSpaceType type) {
     Clear();


### PR DESCRIPTION
This is performing more work than would otherwise be necessary during VMManager's destruction. All we actually want to occur in this scenario is for any allocated memory to be freed, which will happen automatically as the VMManager instance goes out of scope. Anything else being done is unnecessary work.