### PR TITLE
common/hex_util: Combine HexVectorToString() and HexArrayToString()  

### DIFF
--- a/src/common/hex_util.cpp
+++ b/src/common/hex_util.cpp
@@ -30,13 +30,6 @@ std::vector<u8> HexStringToVector(std::string_view str, bool little_endian) {
     return out;
 }
 
-std::string HexVectorToString(const std::vector<u8>& vector, bool upper) {
-    std::string out;
-    for (u8 c : vector)
-        out += fmt::format(upper ? "{:02X}" : "{:02x}", c);
-    return out;
-}
-
 std::array<u8, 16> operator""_array16(const char* str, std::size_t len) {
     if (len != 32) {
         LOG_ERROR(Common,

--- a/src/common/hex_util.h
+++ b/src/common/hex_util.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <cstddef>
 #include <string>
+#include <type_traits>
 #include <vector>
 #include <fmt/format.h>
 #include "common/common_types.h"
@@ -30,13 +31,15 @@ std::array<u8, Size> HexStringToArray(std::string_view str) {
     return out;
 }
 
-std::string HexVectorToString(const std::vector<u8>& vector, bool upper = true);
+template <typename ContiguousContainer>
+std::string HexToString(const ContiguousContainer& data, bool upper = true) {
+    static_assert(std::is_same_v<typename ContiguousContainer::value_type, u8>,
+                  "Underlying type within the contiguous container must be u8.");
 
-template <std::size_t Size>
-std::string HexArrayToString(std::array<u8, Size> array, bool upper = true) {
     std::string out;
-    for (u8 c : array)
+    for (const u8 c : data) {
         out += fmt::format(upper ? "{:02X}" : "{:02x}", c);
+    }
     return out;
 }
 

--- a/src/common/hex_util.h
+++ b/src/common/hex_util.h
@@ -36,10 +36,15 @@ std::string HexToString(const ContiguousContainer& data, bool upper = true) {
     static_assert(std::is_same_v<typename ContiguousContainer::value_type, u8>,
                   "Underlying type within the contiguous container must be u8.");
 
+    constexpr std::size_t pad_width = 2;
+
     std::string out;
+    out.reserve(std::size(data) * pad_width);
+
     for (const u8 c : data) {
         out += fmt::format(upper ? "{:02X}" : "{:02x}", c);
     }
+
     return out;
 }
 

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -572,7 +572,7 @@ void KeyManager::WriteKeyToFile(KeyCategory category, std::string_view keyname,
             << "# If you are experiencing issues involving keys, it may help to delete this file\n";
     }
 
-    file << fmt::format("\n{} = {}", keyname, Common::HexArrayToString(key));
+    file << fmt::format("\n{} = {}", keyname, Common::HexToString(key));
     AttemptLoadKeyFile(yuzu_keys_dir, yuzu_keys_dir, filename, category == KeyCategory::Title);
 }
 
@@ -583,7 +583,7 @@ void KeyManager::SetKey(S128KeyType id, Key128 key, u64 field1, u64 field2) {
         Key128 rights_id;
         std::memcpy(rights_id.data(), &field2, sizeof(u64));
         std::memcpy(rights_id.data() + sizeof(u64), &field1, sizeof(u64));
-        WriteKeyToFile(KeyCategory::Title, Common::HexArrayToString(rights_id), key);
+        WriteKeyToFile(KeyCategory::Title, Common::HexToString(rights_id), key);
     }
 
     auto category = KeyCategory::Standard;

--- a/src/core/file_sys/ips_layer.cpp
+++ b/src/core/file_sys/ips_layer.cpp
@@ -295,7 +295,7 @@ void IPSwitchCompiler::Parse() {
                     LOG_INFO(Loader,
                              "[IPSwitchCompiler ('{}')]     - Patching value at offset 0x{:08X} "
                              "with byte string '{}'",
-                             patch_text->GetName(), offset, Common::HexVectorToString(replace));
+                             patch_text->GetName(), offset, Common::HexToString(replace));
                 }
 
                 patch.records.insert_or_assign(offset, std::move(replace));

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -142,7 +142,7 @@ std::vector<VirtualFile> PatchManager::CollectPatches(const std::vector<VirtualD
                     if (!compiler.IsValid())
                         continue;
 
-                    auto this_build_id = Common::HexArrayToString(compiler.GetBuildID());
+                    auto this_build_id = Common::HexToString(compiler.GetBuildID());
                     this_build_id =
                         this_build_id.substr(0, this_build_id.find_last_not_of('0') + 1);
 
@@ -168,7 +168,7 @@ std::vector<u8> PatchManager::PatchNSO(const std::vector<u8>& nso, const std::st
         return nso;
     }
 
-    const auto build_id_raw = Common::HexArrayToString(header.build_id);
+    const auto build_id_raw = Common::HexToString(header.build_id);
     const auto build_id = build_id_raw.substr(0, build_id_raw.find_last_not_of('0') + 1);
 
     if (Settings::values.dump_nso) {
@@ -219,7 +219,7 @@ std::vector<u8> PatchManager::PatchNSO(const std::vector<u8>& nso, const std::st
 }
 
 bool PatchManager::HasNSOPatch(const std::array<u8, 32>& build_id_) const {
-    const auto build_id_raw = Common::HexArrayToString(build_id_);
+    const auto build_id_raw = Common::HexToString(build_id_);
     const auto build_id = build_id_raw.substr(0, build_id_raw.find_last_not_of('0') + 1);
 
     LOG_INFO(Loader, "Querying NSO patch existence for build_id={}", build_id);
@@ -235,7 +235,7 @@ bool PatchManager::HasNSOPatch(const std::array<u8, 32>& build_id_) const {
 static std::optional<CheatList> ReadCheatFileFromFolder(const Core::System& system, u64 title_id,
                                                         const std::array<u8, 0x20>& build_id_,
                                                         const VirtualDir& base_path, bool upper) {
-    const auto build_id_raw = Common::HexArrayToString(build_id_, upper);
+    const auto build_id_raw = Common::HexToString(build_id_, upper);
     const auto build_id = build_id_raw.substr(0, sizeof(u64) * 2);
     const auto file = base_path->GetFile(fmt::format("{}.txt", build_id));
 

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -53,13 +53,14 @@ static bool FollowsNcaIdFormat(std::string_view name) {
 
 static std::string GetRelativePathFromNcaID(const std::array<u8, 16>& nca_id, bool second_hex_upper,
                                             bool within_two_digit) {
-    if (!within_two_digit)
-        return fmt::format("/{}.nca", Common::HexArrayToString(nca_id, second_hex_upper));
+    if (!within_two_digit) {
+        return fmt::format("/{}.nca", Common::HexToString(nca_id, second_hex_upper));
+    }
 
     Core::Crypto::SHA256Hash hash{};
     mbedtls_sha256(nca_id.data(), nca_id.size(), hash.data(), 0);
     return fmt::format("/000000{:02X}/{}.nca", hash[0],
-                       Common::HexArrayToString(nca_id, second_hex_upper));
+                       Common::HexToString(nca_id, second_hex_upper));
 }
 
 static std::string GetCNMTName(TitleType type, u64 title_id) {
@@ -376,10 +377,11 @@ std::vector<ContentProviderEntry> RegisteredCache::ListEntriesFilter(
 }
 
 static std::shared_ptr<NCA> GetNCAFromNSPForID(const NSP& nsp, const NcaID& id) {
-    const auto file = nsp.GetFile(fmt::format("{}.nca", Common::HexArrayToString(id, false)));
-    if (file == nullptr)
+    auto file = nsp.GetFile(fmt::format("{}.nca", Common::HexToString(id, false)));
+    if (file == nullptr) {
         return nullptr;
-    return std::make_shared<NCA>(file);
+    }
+    return std::make_shared<NCA>(std::move(file));
 }
 
 InstallResult RegisteredCache::InstallEntry(const XCI& xci, bool overwrite_if_exists,

--- a/src/core/file_sys/xts_archive.cpp
+++ b/src/core/file_sys/xts_archive.cpp
@@ -66,7 +66,7 @@ NAX::NAX(VirtualFile file_, std::array<u8, 0x10> nca_id)
     Core::Crypto::SHA256Hash hash{};
     mbedtls_sha256(nca_id.data(), nca_id.size(), hash.data(), 0);
     status = Parse(fmt::format("/registered/000000{:02X}/{}.nca", hash[0],
-                               Common::HexArrayToString(nca_id, false)));
+                               Common::HexToString(nca_id, false)));
 }
 
 NAX::~NAX() = default;

--- a/src/core/hle/service/am/applets/general_backend.cpp
+++ b/src/core/hle/service/am/applets/general_backend.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <string>
+#include <string_view>
 
 #include "common/assert.h"
 #include "common/hex_util.h"
@@ -16,21 +16,21 @@
 
 namespace Service::AM::Applets {
 
-static void LogCurrentStorage(AppletDataBroker& broker, std::string prefix) {
+static void LogCurrentStorage(AppletDataBroker& broker, std::string_view prefix) {
     std::unique_ptr<IStorage> storage = broker.PopNormalDataToApplet();
     for (; storage != nullptr; storage = broker.PopNormalDataToApplet()) {
         const auto data = storage->GetData();
         LOG_INFO(Service_AM,
-                 "called (STUBBED), during {} recieved normal data with size={:08X}, data={}",
-                 prefix, data.size(), Common::HexVectorToString(data));
+                 "called (STUBBED), during {} received normal data with size={:08X}, data={}",
+                 prefix, data.size(), Common::HexToString(data));
     }
 
     storage = broker.PopInteractiveDataToApplet();
     for (; storage != nullptr; storage = broker.PopInteractiveDataToApplet()) {
         const auto data = storage->GetData();
         LOG_INFO(Service_AM,
-                 "called (STUBBED), during {} recieved interactive data with size={:08X}, data={}",
-                 prefix, data.size(), Common::HexVectorToString(data));
+                 "called (STUBBED), during {} received interactive data with size={:08X}, data={}",
+                 prefix, data.size(), Common::HexToString(data));
     }
 }
 

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -310,7 +310,7 @@ public:
         if (!IsValidNROHash(hash)) {
             LOG_ERROR(Service_LDR,
                       "NRO hash is not present in any currently loaded NRRs (hash={})!",
-                      Common::HexArrayToString(hash));
+                      Common::HexToString(hash));
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ERROR_MISSING_NRR_HASH);
             return;

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -152,8 +152,8 @@ std::optional<VAddr> AppLoader_NSO::LoadModule(Kernel::Process& process,
         auto& system = Core::System::GetInstance();
         const auto cheats = pm->CreateCheatList(system, nso_header.build_id);
         if (!cheats.empty()) {
-            system.RegisterCheatList(cheats, Common::HexArrayToString(nso_header.build_id),
-                                     load_base, load_base + program_image.size());
+            system.RegisterCheatList(cheats, Common::HexToString(nso_header.build_id), load_base,
+                                     load_base + program_image.size());
         }
     }
 


### PR DESCRIPTION
Given the only difference is the input type, we can make this a little more generic and apply to any contiguous type. While we're at it, we can request the necessary memory ahead of time when building up the string to prevent unnecessary reallocations, given it's as trivial as calling `reserve()`.