### PR TITLE
Core_Timing: Make core_timing threadsafe by default.

### DIFF
--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -101,7 +101,7 @@ void Stream::PlayNextBuffer() {
 
     sink_stream.EnqueueSamples(GetNumChannels(), active_buffer->GetSamples());
 
-    core_timing.ScheduleEventThreadsafe(GetBufferReleaseCycles(*active_buffer), release_event, {});
+    core_timing.ScheduleEvent(GetBufferReleaseCycles(*active_buffer), release_event, {});
 }
 
 void Stream::ReleaseActiveBuffer() {

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -76,13 +76,13 @@ void Thread::WakeAfterDelay(s64 nanoseconds) {
     // This function might be called from any thread so we have to be cautious and use the
     // thread-safe version of ScheduleEvent.
     const s64 cycles = Core::Timing::nsToCycles(std::chrono::nanoseconds{nanoseconds});
-    Core::System::GetInstance().CoreTiming().ScheduleEventThreadsafe(
+    Core::System::GetInstance().CoreTiming().ScheduleEvent(
         cycles, kernel.ThreadWakeupCallbackEventType(), callback_handle);
 }
 
 void Thread::CancelWakeupTimer() {
-    Core::System::GetInstance().CoreTiming().UnscheduleEventThreadsafe(
-        kernel.ThreadWakeupCallbackEventType(), callback_handle);
+    Core::System::GetInstance().CoreTiming().UnscheduleEvent(kernel.ThreadWakeupCallbackEventType(),
+                                                             callback_handle);
 }
 
 static std::optional<s32> GetNextProcessorId(u64 mask) {

--- a/src/tests/core/core_timing.cpp
+++ b/src/tests/core/core_timing.cpp
@@ -99,24 +99,24 @@ TEST_CASE("CoreTiming[Threadsave]", "[core]") {
     core_timing.Advance();
 
     // D -> B -> C -> A -> E
-    core_timing.ScheduleEventThreadsafe(1000, cb_a, CB_IDS[0]);
-    // Manually force since ScheduleEventThreadsafe doesn't call it
+    core_timing.ScheduleEvent(1000, cb_a, CB_IDS[0]);
+    // Manually force since ScheduleEvent doesn't call it
     core_timing.ForceExceptionCheck(1000);
     REQUIRE(1000 == core_timing.GetDowncount());
-    core_timing.ScheduleEventThreadsafe(500, cb_b, CB_IDS[1]);
-    // Manually force since ScheduleEventThreadsafe doesn't call it
+    core_timing.ScheduleEvent(500, cb_b, CB_IDS[1]);
+    // Manually force since ScheduleEvent doesn't call it
     core_timing.ForceExceptionCheck(500);
     REQUIRE(500 == core_timing.GetDowncount());
-    core_timing.ScheduleEventThreadsafe(800, cb_c, CB_IDS[2]);
-    // Manually force since ScheduleEventThreadsafe doesn't call it
+    core_timing.ScheduleEvent(800, cb_c, CB_IDS[2]);
+    // Manually force since ScheduleEvent doesn't call it
     core_timing.ForceExceptionCheck(800);
     REQUIRE(500 == core_timing.GetDowncount());
-    core_timing.ScheduleEventThreadsafe(100, cb_d, CB_IDS[3]);
-    // Manually force since ScheduleEventThreadsafe doesn't call it
+    core_timing.ScheduleEvent(100, cb_d, CB_IDS[3]);
+    // Manually force since ScheduleEvent doesn't call it
     core_timing.ForceExceptionCheck(100);
     REQUIRE(100 == core_timing.GetDowncount());
-    core_timing.ScheduleEventThreadsafe(1200, cb_e, CB_IDS[4]);
-    // Manually force since ScheduleEventThreadsafe doesn't call it
+    core_timing.ScheduleEvent(1200, cb_e, CB_IDS[4]);
+    // Manually force since ScheduleEvent doesn't call it
     core_timing.ForceExceptionCheck(1200);
     REQUIRE(100 == core_timing.GetDowncount());
 


### PR DESCRIPTION
The old implementation had faulty Threadsafe methods (they were threadsafe but it had other issues related to design causing bugs that made missing events possible under certain circunstances). In general, I see no regressions from using a mutex and speed is pretty much the same. If this becomes a concern, it can easily be replaced by a very simple spinlock and fast. This also simplifies everything and keeps event scheduling/unscheduling under one single method.