### PR TITLE
Revert PR 2590.

### DIFF
--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -47,7 +47,7 @@ public:
 
         auto& system = Core::System::GetInstance();
         system_event = Kernel::WritableEvent::CreateEventPair(
-            system.Kernel(), Kernel::ResetType::Automatic, "IAudioRenderer:SystemEvent");
+            system.Kernel(), Kernel::ResetType::Manual, "IAudioRenderer:SystemEvent");
         renderer = std::make_unique<AudioCore::AudioRenderer>(system.CoreTiming(), audren_params,
                                                               system_event.writable);
     }


### PR DESCRIPTION
Even though it has been proven that IAudioRenderer:SystemEvent is 
actually an automatic event. The current implementation of such event is 
all thought to be manual. Thus it's implementation needs to be corrected 
when doing such change. As it is right now this PR introduced a series 
of regressions on softlocks on multiple games. Therefore, this pr 
reverts such change until a correct implementation is made.