### PR TITLE
Implement a New Shader Scanner, Decompile Flow Stack and implement BRX BRA.CC

### DIFF
--- a/CMakeModules/GenerateSCMRev.cmake
+++ b/CMakeModules/GenerateSCMRev.cmake
@@ -82,6 +82,8 @@ set(HASH_FILES
     "${VIDEO_CORE}/shader/decode/shift.cpp"
     "${VIDEO_CORE}/shader/decode/video.cpp"
     "${VIDEO_CORE}/shader/decode/xmad.cpp"
+    "${VIDEO_CORE}/shader/control_flow.cpp"
+    "${VIDEO_CORE}/shader/control_flow.h"
     "${VIDEO_CORE}/shader/decode.cpp"
     "${VIDEO_CORE}/shader/node.h"
     "${VIDEO_CORE}/shader/node_helper.cpp"

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -56,6 +56,8 @@ add_custom_command(OUTPUT scm_rev.cpp
       "${VIDEO_CORE}/shader/decode/shift.cpp"
       "${VIDEO_CORE}/shader/decode/video.cpp"
       "${VIDEO_CORE}/shader/decode/xmad.cpp"
+      "${VIDEO_CORE}/shader/control_flow.cpp"
+      "${VIDEO_CORE}/shader/control_flow.h"
       "${VIDEO_CORE}/shader/decode.cpp"
       "${VIDEO_CORE}/shader/node.h"
       "${VIDEO_CORE}/shader/node_helper.cpp"

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -103,6 +103,8 @@ add_library(video_core STATIC
     shader/decode/video.cpp
     shader/decode/xmad.cpp
     shader/decode/other.cpp
+    shader/control_flow.cpp
+    shader/control_flow.h
     shader/decode.cpp
     shader/node_helper.cpp
     shader/node_helper.h

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -1368,6 +1368,20 @@ union Instruction {
     } bra;
 
     union {
+        BitField<20, 24, u64> target;
+        BitField<5, 1, u64> constant_buffer;
+
+        s32 GetBranchExtend() const {
+            // Sign extend the branch target offset
+            u32 mask = 1U << (24 - 1);
+            u32 value = static_cast<u32>(target);
+            // The branch offset is relative to the next instruction and is stored in bytes, so
+            // divide it by the size of an instruction and add 1 to it.
+            return static_cast<s32>((value ^ mask) - mask) / sizeof(Instruction) + 1;
+        }
+    } brx;
+
+    union {
         BitField<39, 1, u64> emit; // EmitVertex
         BitField<40, 1, u64> cut;  // EndPrimitive
     } out;
@@ -1464,6 +1478,7 @@ public:
         BFE_IMM,
         BFI_IMM_R,
         BRA,
+        BRX,
         PBK,
         LD_A,
         LD_L,
@@ -1738,6 +1753,7 @@ private:
             INST("111000101001----", Id::SSY, Type::Flow, "SSY"),
             INST("111000101010----", Id::PBK, Type::Flow, "PBK"),
             INST("111000100100----", Id::BRA, Type::Flow, "BRA"),
+            INST("111000100101----", Id::BRX, Type::Flow, "BRX"),
             INST("1111000011111---", Id::SYNC, Type::Flow, "SYNC"),
             INST("111000110100---", Id::BRK, Type::Flow, "BRK"),
             INST("111000110000----", Id::EXIT, Type::Flow, "EXIT"),

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -191,10 +191,12 @@ public:
 
         // TODO(Subv): Figure out the actual depth of the flow stack, for now it seems
         // unlikely that shaders will use 20 nested SSYs and PBKs.
-        constexpr u32 FLOW_STACK_SIZE = 20;
-        for (const auto stack : std::array{MetaStackClass::Ssy, MetaStackClass::Pbk}) {
-            code.AddLine("uint {}[{}];", FlowStackName(stack), FLOW_STACK_SIZE);
-            code.AddLine("uint {} = 0u;", FlowStackTopName(stack));
+        if (!ir.IsFlowStackDisabled()) {
+            constexpr u32 FLOW_STACK_SIZE = 20;
+            for (const auto stack : std::array{MetaStackClass::Ssy, MetaStackClass::Pbk}) {
+                code.AddLine("uint {}[{}];", FlowStackName(stack), FLOW_STACK_SIZE);
+                code.AddLine("uint {} = 0u;", FlowStackTopName(stack));
+            }
         }
 
         code.AddLine("while (true) {{");

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1555,6 +1555,14 @@ private:
         return {};
     }
 
+    std::string BranchIndirect(Operation operation) {
+        const std::string op_a = VisitOperand(operation, 0, Type::Uint);
+
+        code.AddLine("jmp_to = {};", op_a);
+        code.AddLine("break;");
+        return {};
+    }
+
     std::string PushFlowStack(Operation operation) {
         const auto stack = std::get<MetaStackClass>(operation.GetMeta());
         const auto target = std::get_if<ImmediateNode>(&*operation[0]);
@@ -1789,6 +1797,7 @@ private:
         &GLSLDecompiler::ImageStore,
 
         &GLSLDecompiler::Branch,
+        &GLSLDecompiler::BranchIndirect,
         &GLSLDecompiler::PushFlowStack,
         &GLSLDecompiler::PopFlowStack,
         &GLSLDecompiler::Exit,

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -29,14 +29,14 @@ layout (std140, binding = EMULATION_UBO_BINDING) uniform vs_config {
 };
 
 )";
-    const ShaderIR program_ir(setup.program.code, PROGRAM_OFFSET);
+    const ShaderIR program_ir(setup.program.code, PROGRAM_OFFSET, setup.program.size_a);
     ProgramResult program =
         Decompile(device, program_ir, Maxwell3D::Regs::ShaderStage::Vertex, "vertex");
 
     out += program.first;
 
     if (setup.IsDualProgram()) {
-        const ShaderIR program_ir_b(setup.program.code_b, PROGRAM_OFFSET);
+        const ShaderIR program_ir_b(setup.program.code_b, PROGRAM_OFFSET, setup.program.size_b);
         ProgramResult program_b =
             Decompile(device, program_ir_b, Maxwell3D::Regs::ShaderStage::Vertex, "vertex_b");
 
@@ -80,7 +80,7 @@ layout (std140, binding = EMULATION_UBO_BINDING) uniform gs_config {
 };
 
 )";
-    const ShaderIR program_ir(setup.program.code, PROGRAM_OFFSET);
+    const ShaderIR program_ir(setup.program.code, PROGRAM_OFFSET, setup.program.size_a);
     ProgramResult program =
         Decompile(device, program_ir, Maxwell3D::Regs::ShaderStage::Geometry, "geometry");
     out += program.first;
@@ -115,7 +115,7 @@ layout (std140, binding = EMULATION_UBO_BINDING) uniform fs_config {
 };
 
 )";
-    const ShaderIR program_ir(setup.program.code, PROGRAM_OFFSET);
+    const ShaderIR program_ir(setup.program.code, PROGRAM_OFFSET, setup.program.size_a);
     ProgramResult program =
         Decompile(device, program_ir, Maxwell3D::Regs::ShaderStage::Fragment, "fragment");
 

--- a/src/video_core/renderer_opengl/gl_shader_gen.h
+++ b/src/video_core/renderer_opengl/gl_shader_gen.h
@@ -27,6 +27,8 @@ struct ShaderSetup {
         ProgramCode code;
         ProgramCode code_b; // Used for dual vertex shaders
         u64 unique_identifier;
+        std::size_t size_a;
+        std::size_t size_b;
     } program;
 
     /// Used in scenarios where we have a dual vertex shaders

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
@@ -949,6 +949,14 @@ private:
         return {};
     }
 
+    Id BranchIndirect(Operation operation) {
+        const Id op_a = VisitOperand<Type::Uint>(operation, 0);
+
+        Emit(OpStore(jmp_to, op_a));
+        BranchingOp([&]() { Emit(OpBranch(continue_label)); });
+        return {};
+    }
+
     Id PushFlowStack(Operation operation) {
         const auto target = std::get_if<ImmediateNode>(&*operation[0]);
         ASSERT(target);
@@ -1334,6 +1342,7 @@ private:
         &SPIRVDecompiler::ImageStore,
 
         &SPIRVDecompiler::Branch,
+        &SPIRVDecompiler::BranchIndirect,
         &SPIRVDecompiler::PushFlowStack,
         &SPIRVDecompiler::PopFlowStack,
         &SPIRVDecompiler::Exit,

--- a/src/video_core/shader/control_flow.cpp
+++ b/src/video_core/shader/control_flow.cpp
@@ -1,0 +1,393 @@
+
+#include <list>
+#include <map>
+#include <unordered_set>
+#include <vector>
+
+#include "common/assert.h"
+#include "common/common_types.h"
+#include "video_core/shader/control_flow.h"
+#include "video_core/shader/shader_ir.h"
+
+namespace VideoCommon::Shader {
+
+using Tegra::Shader::Instruction;
+using Tegra::Shader::OpCode;
+
+constexpr s32 unassigned_branch = -2;
+
+struct BlockBranchInfo {
+    Condition condition{};
+    s32 address{exit_branch};
+    bool kill{};
+    bool is_sync{};
+    bool is_brk{};
+};
+
+struct BlockInfo {
+    BlockInfo() {}
+    u32 start{};
+    u32 end{};
+    bool visited{};
+    BlockBranchInfo branch{};
+
+    bool IsInside(const u32 address) const {
+        return start <= address && address <= end;
+    }
+};
+
+struct Stamp {
+    Stamp() = default;
+    Stamp(u32 address, u32 target) : address{address}, target{target} {}
+    u32 address{};
+    u32 target{};
+    bool operator==(const Stamp& sb) const {
+        return std::tie(address, target) == std::tie(sb.address, sb.target);
+    }
+    bool operator<(const Stamp& sb) const {
+        return address < sb.address;
+    }
+    bool operator>(const Stamp& sb) const {
+        return address > sb.address;
+    }
+    bool operator<=(const Stamp& sb) const {
+        return address <= sb.address;
+    }
+    bool operator>=(const Stamp& sb) const {
+        return address >= sb.address;
+    }
+};
+
+struct CFGRebuildState {
+    explicit CFGRebuildState(const ProgramCode& program_code, const std::size_t program_size)
+        : program_code{program_code}, program_size{program_size} {
+        // queries.clear();
+        block_info.clear();
+        labels.clear();
+        visited_address.clear();
+        ssy_labels.clear();
+        pbk_labels.clear();
+        inspect_queries.clear();
+    }
+
+    std::vector<BlockInfo> block_info{};
+    std::list<u32> inspect_queries{};
+    // std::list<Query> queries{};
+    std::unordered_set<u32> visited_address{};
+    std::unordered_set<u32> labels{};
+    std::set<Stamp> ssy_labels;
+    std::set<Stamp> pbk_labels;
+    const ProgramCode& program_code;
+    const std::size_t program_size;
+};
+
+enum class BlockCollision : u32 { None = 0, Found = 1, Inside = 2 };
+
+std::pair<BlockCollision, std::vector<BlockInfo>::iterator> TryGetBlock(CFGRebuildState& state,
+                                                                        u32 address) {
+    auto it = state.block_info.begin();
+    while (it != state.block_info.end()) {
+        if (it->start == address) {
+            return {BlockCollision::Found, it};
+        }
+        if (it->IsInside(address)) {
+            return {BlockCollision::Inside, it};
+        }
+        it++;
+    }
+    return {BlockCollision::None, it};
+}
+
+struct ParseInfo {
+    BlockBranchInfo branch_info{};
+    u32 end_address{};
+};
+
+BlockInfo* CreateBlockInfo(CFGRebuildState& state, u32 start, u32 end) {
+    auto& it = state.block_info.emplace_back();
+    it.start = start;
+    it.end = end;
+    state.visited_address.insert(start);
+    return &it;
+}
+
+Pred GetPredicate(u32 index, bool negated) {
+    return static_cast<Pred>(index + (negated ? 8 : 0));
+}
+
+enum class ParseResult : u32 {
+    ControlCaught = 0,
+    BlockEnd = 1,
+    AbnormalFlow = 2,
+};
+
+ParseResult ParseCode(CFGRebuildState& state, u32 address, ParseInfo& parse_info) {
+
+    u32 offset = static_cast<u32>(address);
+    u32 end_address = static_cast<u32>(state.program_size - 10U) * 8U;
+
+    auto insert_label = ([](CFGRebuildState& state, u32 address) {
+        auto pair = state.labels.emplace(address);
+        if (pair.second) {
+            state.inspect_queries.push_back(address);
+        }
+    });
+
+    while (true) {
+        if (offset >= end_address) {
+            parse_info.branch_info.address = exit_branch;
+            break;
+        }
+        if (state.visited_address.count(offset) != 0) {
+            parse_info.branch_info.address = offset;
+            break;
+        }
+        const Instruction instr = {state.program_code[offset]};
+        const auto opcode = OpCode::Decode(instr);
+        if (!opcode || opcode->get().GetType() != OpCode::Type::Flow) {
+            offset++;
+            continue;
+        }
+
+        switch (opcode->get().GetId()) {
+        case OpCode::Id::EXIT: {
+            const auto pred_index = static_cast<u32>(instr.pred.pred_index);
+            parse_info.branch_info.condition.predicate =
+                GetPredicate(pred_index, instr.negate_pred != 0);
+            if (parse_info.branch_info.condition.predicate == Pred::NeverExecute) {
+                offset++;
+                continue;
+            }
+            const ConditionCode cc = instr.flow_condition_code;
+            parse_info.branch_info.condition.cc = cc;
+            if (cc == ConditionCode::F) {
+                offset++;
+                continue;
+            }
+            parse_info.branch_info.address = exit_branch;
+            parse_info.branch_info.kill = false;
+            parse_info.branch_info.is_sync = false;
+            parse_info.branch_info.is_brk = false;
+            parse_info.end_address = offset;
+
+            return ParseResult::ControlCaught;
+        }
+        case OpCode::Id::BRA: {
+            if (instr.bra.constant_buffer != 0) {
+                return ParseResult::AbnormalFlow;
+            }
+            const auto pred_index = static_cast<u32>(instr.pred.pred_index);
+            parse_info.branch_info.condition.predicate =
+                GetPredicate(pred_index, instr.negate_pred != 0);
+            if (parse_info.branch_info.condition.predicate == Pred::NeverExecute) {
+                offset++;
+                continue;
+            }
+            const ConditionCode cc = instr.flow_condition_code;
+            parse_info.branch_info.condition.cc = cc;
+            if (cc == ConditionCode::F) {
+                offset++;
+                continue;
+            }
+            u32 branch_offset = offset + instr.bra.GetBranchTarget();
+            if (branch_offset == 0) {
+                parse_info.branch_info.address = exit_branch;
+            } else {
+                parse_info.branch_info.address = branch_offset;
+            }
+            insert_label(state, branch_offset);
+            parse_info.branch_info.kill = false;
+            parse_info.branch_info.is_sync = false;
+            parse_info.branch_info.is_brk = false;
+            parse_info.end_address = offset;
+
+            return ParseResult::ControlCaught;
+        }
+        case OpCode::Id::SYNC: {
+            parse_info.branch_info.condition;
+            const auto pred_index = static_cast<u32>(instr.pred.pred_index);
+            parse_info.branch_info.condition.predicate =
+                GetPredicate(pred_index, instr.negate_pred != 0);
+            if (parse_info.branch_info.condition.predicate == Pred::NeverExecute) {
+                offset++;
+                continue;
+            }
+            const ConditionCode cc = instr.flow_condition_code;
+            parse_info.branch_info.condition.cc = cc;
+            if (cc == ConditionCode::F) {
+                offset++;
+                continue;
+            }
+            parse_info.branch_info.address = unassigned_branch;
+            parse_info.branch_info.kill = false;
+            parse_info.branch_info.is_sync = true;
+            parse_info.branch_info.is_brk = false;
+            parse_info.end_address = offset;
+
+            return ParseResult::ControlCaught;
+        }
+        case OpCode::Id::BRK: {
+            parse_info.branch_info.condition;
+            const auto pred_index = static_cast<u32>(instr.pred.pred_index);
+            parse_info.branch_info.condition.predicate =
+                GetPredicate(pred_index, instr.negate_pred != 0);
+            if (parse_info.branch_info.condition.predicate == Pred::NeverExecute) {
+                offset++;
+                continue;
+            }
+            const ConditionCode cc = instr.flow_condition_code;
+            parse_info.branch_info.condition.cc = cc;
+            if (cc == ConditionCode::F) {
+                offset++;
+                continue;
+            }
+            parse_info.branch_info.address = unassigned_branch;
+            parse_info.branch_info.kill = false;
+            parse_info.branch_info.is_sync = false;
+            parse_info.branch_info.is_brk = true;
+            parse_info.end_address = offset;
+
+            return ParseResult::ControlCaught;
+        }
+        case OpCode::Id::KIL: {
+            parse_info.branch_info.condition;
+            const auto pred_index = static_cast<u32>(instr.pred.pred_index);
+            parse_info.branch_info.condition.predicate =
+                GetPredicate(pred_index, instr.negate_pred != 0);
+            if (parse_info.branch_info.condition.predicate == Pred::NeverExecute) {
+                offset++;
+                continue;
+            }
+            const ConditionCode cc = instr.flow_condition_code;
+            parse_info.branch_info.condition.cc = cc;
+            if (cc == ConditionCode::F) {
+                offset++;
+                continue;
+            }
+            parse_info.branch_info.address = exit_branch;
+            parse_info.branch_info.kill = true;
+            parse_info.branch_info.is_sync = false;
+            parse_info.branch_info.is_brk = false;
+            parse_info.end_address = offset;
+
+            return ParseResult::ControlCaught;
+        }
+        case OpCode::Id::SSY: {
+            const u32 target = offset + instr.bra.GetBranchTarget();
+            insert_label(state, target);
+            state.ssy_labels.emplace(offset, target);
+            break;
+        }
+        case OpCode::Id::PBK: {
+            const u32 target = offset + instr.bra.GetBranchTarget();
+            insert_label(state, target);
+            state.pbk_labels.emplace(offset, target);
+            break;
+        }
+        default:
+            break;
+        }
+
+        offset++;
+    }
+    parse_info.branch_info.kill = false;
+    parse_info.branch_info.is_sync = false;
+    parse_info.branch_info.is_brk = false;
+    parse_info.end_address = offset - 1;
+    return ParseResult::BlockEnd;
+}
+
+bool TryInspectAddress(CFGRebuildState& state) {
+    if (state.inspect_queries.empty()) {
+        return false;
+    }
+    u32 address = state.inspect_queries.front();
+    state.inspect_queries.pop_front();
+    auto search_result = TryGetBlock(state, address);
+    BlockInfo* block_info;
+    switch (search_result.first) {
+    case BlockCollision::Found: {
+        return true;
+        break;
+    }
+    case BlockCollision::Inside: {
+        // This case is the tricky one:
+        // We need to Split the block in 2 sepprate blocks
+        auto it = search_result.second;
+        block_info = CreateBlockInfo(state, address, it->end);
+        it->end = address - 1;
+        block_info->branch = it->branch;
+        BlockBranchInfo forward_branch{};
+        forward_branch.address = address;
+        it->branch = forward_branch;
+        return true;
+        break;
+    }
+    default:
+        break;
+    }
+    ParseInfo parse_info;
+    ParseResult parse_result = ParseCode(state, address, parse_info);
+    if (parse_result == ParseResult::AbnormalFlow) {
+        // if it's the end of the program, end it safely
+        // if it's AbnormalFlow, we end it as false, ending the CFG reconstruction
+        return false;
+    }
+
+    block_info = CreateBlockInfo(state, address, parse_info.end_address);
+    block_info->branch = parse_info.branch_info;
+    if (parse_info.branch_info.condition.IsUnconditional()) {
+        return true;
+    }
+
+    u32 fallthrough_address = parse_info.end_address + 1;
+    state.inspect_queries.push_front(fallthrough_address);
+    return true;
+}
+
+bool ScanFlow(const ProgramCode& program_code, u32 program_size, u32 start_address,
+              ShaderCharacteristics& result_out) {
+    CFGRebuildState state{program_code, program_size};
+    // Inspect Code and generate blocks
+    state.labels.clear();
+    state.labels.emplace(start_address);
+    state.inspect_queries.push_back(start_address);
+    while (!state.inspect_queries.empty()) {
+        if (!TryInspectAddress(state)) {
+            return false;
+        }
+    }
+    std::sort(state.block_info.begin(), state.block_info.end(),
+              [](const BlockInfo& a, const BlockInfo& b) -> bool { return a.start < b.start; });
+    // Remove unvisited blocks
+    result_out.blocks.clear();
+    result_out.decompilable = false;
+    result_out.start = start_address;
+    result_out.end = start_address;
+    for (auto& block : state.block_info) {
+        ShaderBlock new_block{};
+        new_block.start = block.start;
+        new_block.end = block.end;
+        new_block.branch.cond = block.branch.condition;
+        new_block.branch.kills = block.branch.kill;
+        new_block.branch.address = block.branch.address;
+        result_out.end = std::max(result_out.end, block.end);
+        result_out.blocks.push_back(new_block);
+    }
+    if (result_out.decompilable) {
+        return true;
+    }
+    auto back = result_out.blocks.begin();
+    auto next = std::next(back);
+    while (next != result_out.blocks.end()) {
+        if (state.labels.count(next->start) == 0 && next->start == back->end + 1) {
+            back->end = next->end;
+            next = result_out.blocks.erase(next);
+            continue;
+        }
+        back = next;
+        next++;
+    }
+    return true;
+}
+} // namespace VideoCommon::Shader

--- a/src/video_core/shader/control_flow.cpp
+++ b/src/video_core/shader/control_flow.cpp
@@ -163,7 +163,7 @@ enum class ParseResult : u32 {
 
 ParseResult ParseCode(CFGRebuildState& state, u32 address, ParseInfo& parse_info) {
     u32 offset = static_cast<u32>(address);
-    const u32 end_address = static_cast<u32>(state.program_size - 10U) * 8U;
+    const u32 end_address = static_cast<u32>(state.program_size / 8U);
 
     const auto insert_label = ([](CFGRebuildState& state, u32 address) {
         auto pair = state.labels.emplace(address);

--- a/src/video_core/shader/control_flow.cpp
+++ b/src/video_core/shader/control_flow.cpp
@@ -284,6 +284,9 @@ ParseResult ParseCode(CFGRebuildState& state, u32 address, ParseInfo& parse_info
             state.pbk_labels.emplace(offset, target);
             break;
         }
+        case OpCode::Id::BRX: {
+            return ParseResult::AbnormalFlow;
+        }
         default:
             break;
         }

--- a/src/video_core/shader/control_flow.cpp
+++ b/src/video_core/shader/control_flow.cpp
@@ -139,6 +139,8 @@ std::pair<ParseResult, ParseInfo> ParseCode(CFGRebuildState& state, u32 address)
 
     while (true) {
         if (offset >= end_address) {
+            // ASSERT_OR_EXECUTE can't be used, as it ignores the break
+            ASSERT_MSG(false, "Shader passed the current limit!");
             parse_info.branch_info.address = exit_branch;
             parse_info.branch_info.ignore = false;
             break;

--- a/src/video_core/shader/control_flow.cpp
+++ b/src/video_core/shader/control_flow.cpp
@@ -4,6 +4,7 @@
 
 #include <list>
 #include <map>
+#include <stack>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -20,68 +21,18 @@ using Tegra::Shader::OpCode;
 
 constexpr s32 unassigned_branch = -2;
 
-/**
- * 'ControlStack' represents a static stack of control jumps such as SSY and PBK
- * stacks in Maxwell.
- **/
-struct ControlStack {
-    static constexpr std::size_t stack_fixed_size = 20;
-    std::array<u32, stack_fixed_size> stack{};
-    u32 index{};
-
-    bool Compare(const ControlStack& cs) const {
-        if (index != cs.index) {
-            return false;
-        }
-        return std::memcmp(stack.data(), cs.stack.data(), index * sizeof(u32)) == 0;
-    }
-
-    /// This compare just compares the top of the stack against one another
-    bool SoftCompare(const ControlStack& cs) const {
-        if (index == 0 || cs.index == 0) {
-            return index == cs.index;
-        }
-        return Top() == cs.Top();
-    }
-
-    u32 Size() const {
-        return index;
-    }
-
-    u32 Top() const {
-        return stack[index - 1];
-    }
-
-    bool Push(u32 address) {
-        if (index >= stack.size()) {
-            return false;
-        }
-        stack[index] = address;
-        index++;
-        return true;
-    }
-
-    bool Pop() {
-        if (index == 0) {
-            return false;
-        }
-        index--;
-        return true;
-    }
-};
-
 struct Query {
     u32 address{};
-    ControlStack ssy_stack{};
-    ControlStack pbk_stack{};
+    std::stack<u32> ssy_stack{};
+    std::stack<u32> pbk_stack{};
 };
 
 struct BlockStack {
     BlockStack() = default;
     BlockStack(const BlockStack& b) = default;
     BlockStack(const Query& q) : ssy_stack{q.ssy_stack}, pbk_stack{q.pbk_stack} {}
-    ControlStack ssy_stack{};
-    ControlStack pbk_stack{};
+    std::stack<u32> ssy_stack{};
+    std::stack<u32> pbk_stack{};
 };
 
 struct BlockBranchInfo {
@@ -144,13 +95,13 @@ struct ParseInfo {
     u32 end_address{};
 };
 
-BlockInfo* CreateBlockInfo(CFGRebuildState& state, u32 start, u32 end) {
+BlockInfo& CreateBlockInfo(CFGRebuildState& state, u32 start, u32 end) {
     auto& it = state.block_info.emplace_back();
     it.start = start;
     it.end = end;
     const u32 index = static_cast<u32>(state.block_info.size() - 1);
     state.registered.insert({start, index});
-    return &it;
+    return it;
 }
 
 Pred GetPredicate(u32 index, bool negated) {
@@ -174,16 +125,17 @@ enum class ParseResult : u32 {
     AbnormalFlow,
 };
 
-ParseResult ParseCode(CFGRebuildState& state, u32 address, ParseInfo& parse_info) {
+std::pair<ParseResult, ParseInfo> ParseCode(CFGRebuildState& state, u32 address) {
     u32 offset = static_cast<u32>(address);
     const u32 end_address = static_cast<u32>(state.program_size / sizeof(Instruction));
+    ParseInfo parse_info{};
 
-    const auto insert_label = ([](CFGRebuildState& state, u32 address) {
-        auto pair = state.labels.emplace(address);
+    const auto insert_label = [](CFGRebuildState& state, u32 address) {
+        const auto pair = state.labels.emplace(address);
         if (pair.second) {
             state.inspect_queries.push_back(address);
         }
-    });
+    };
 
     while (true) {
         if (offset >= end_address) {
@@ -229,11 +181,11 @@ ParseResult ParseCode(CFGRebuildState& state, u32 address, ParseInfo& parse_info
             parse_info.branch_info.ignore = false;
             parse_info.end_address = offset;
 
-            return ParseResult::ControlCaught;
+            return {ParseResult::ControlCaught, parse_info};
         }
         case OpCode::Id::BRA: {
             if (instr.bra.constant_buffer != 0) {
-                return ParseResult::AbnormalFlow;
+                return {ParseResult::AbnormalFlow, parse_info};
             }
             const auto pred_index = static_cast<u32>(instr.pred.pred_index);
             parse_info.branch_info.condition.predicate =
@@ -248,7 +200,7 @@ ParseResult ParseCode(CFGRebuildState& state, u32 address, ParseInfo& parse_info
                 offset++;
                 continue;
             }
-            u32 branch_offset = offset + instr.bra.GetBranchTarget();
+            const u32 branch_offset = offset + instr.bra.GetBranchTarget();
             if (branch_offset == 0) {
                 parse_info.branch_info.address = exit_branch;
             } else {
@@ -261,10 +213,9 @@ ParseResult ParseCode(CFGRebuildState& state, u32 address, ParseInfo& parse_info
             parse_info.branch_info.ignore = false;
             parse_info.end_address = offset;
 
-            return ParseResult::ControlCaught;
+            return {ParseResult::ControlCaught, parse_info};
         }
         case OpCode::Id::SYNC: {
-            parse_info.branch_info.condition;
             const auto pred_index = static_cast<u32>(instr.pred.pred_index);
             parse_info.branch_info.condition.predicate =
                 GetPredicate(pred_index, instr.negate_pred != 0);
@@ -285,10 +236,9 @@ ParseResult ParseCode(CFGRebuildState& state, u32 address, ParseInfo& parse_info
             parse_info.branch_info.ignore = false;
             parse_info.end_address = offset;
 
-            return ParseResult::ControlCaught;
+            return {ParseResult::ControlCaught, parse_info};
         }
         case OpCode::Id::BRK: {
-            parse_info.branch_info.condition;
             const auto pred_index = static_cast<u32>(instr.pred.pred_index);
             parse_info.branch_info.condition.predicate =
                 GetPredicate(pred_index, instr.negate_pred != 0);
@@ -309,10 +259,9 @@ ParseResult ParseCode(CFGRebuildState& state, u32 address, ParseInfo& parse_info
             parse_info.branch_info.ignore = false;
             parse_info.end_address = offset;
 
-            return ParseResult::ControlCaught;
+            return {ParseResult::ControlCaught, parse_info};
         }
         case OpCode::Id::KIL: {
-            parse_info.branch_info.condition;
             const auto pred_index = static_cast<u32>(instr.pred.pred_index);
             parse_info.branch_info.condition.predicate =
                 GetPredicate(pred_index, instr.negate_pred != 0);
@@ -333,7 +282,7 @@ ParseResult ParseCode(CFGRebuildState& state, u32 address, ParseInfo& parse_info
             parse_info.branch_info.ignore = false;
             parse_info.end_address = offset;
 
-            return ParseResult::ControlCaught;
+            return {ParseResult::ControlCaught, parse_info};
         }
         case OpCode::Id::SSY: {
             const u32 target = offset + instr.bra.GetBranchTarget();
@@ -348,7 +297,7 @@ ParseResult ParseCode(CFGRebuildState& state, u32 address, ParseInfo& parse_info
             break;
         }
         case OpCode::Id::BRX: {
-            return ParseResult::AbnormalFlow;
+            return {ParseResult::AbnormalFlow, parse_info};
         }
         default:
             break;
@@ -360,7 +309,7 @@ ParseResult ParseCode(CFGRebuildState& state, u32 address, ParseInfo& parse_info
     parse_info.branch_info.is_sync = false;
     parse_info.branch_info.is_brk = false;
     parse_info.end_address = offset - 1;
-    return ParseResult::BlockEnd;
+    return {ParseResult::BlockEnd, parse_info};
 }
 
 bool TryInspectAddress(CFGRebuildState& state) {
@@ -377,10 +326,10 @@ bool TryInspectAddress(CFGRebuildState& state) {
     case BlockCollision::Inside: {
         // This case is the tricky one:
         // We need to Split the block in 2 sepparate blocks
-        auto it = search_result.second;
-        BlockInfo* block_info = CreateBlockInfo(state, address, it->end);
+        const auto it = search_result.second;
+        BlockInfo& block_info = CreateBlockInfo(state, address, it->end);
         it->end = address - 1;
-        block_info->branch = it->branch;
+        block_info.branch = it->branch;
         BlockBranchInfo forward_branch{};
         forward_branch.address = address;
         forward_branch.ignore = true;
@@ -390,15 +339,14 @@ bool TryInspectAddress(CFGRebuildState& state) {
     default:
         break;
     }
-    ParseInfo parse_info;
-    const ParseResult parse_result = ParseCode(state, address, parse_info);
+    const auto [parse_result, parse_info] = ParseCode(state, address);
     if (parse_result == ParseResult::AbnormalFlow) {
         // if it's AbnormalFlow, we end it as false, ending the CFG reconstruction
         return false;
     }
 
-    BlockInfo* block_info = CreateBlockInfo(state, address, parse_info.end_address);
-    block_info->branch = parse_info.branch_info;
+    BlockInfo& block_info = CreateBlockInfo(state, address, parse_info.end_address);
+    block_info.branch = parse_info.branch_info;
     if (parse_info.branch_info.condition.IsUnconditional()) {
         return true;
     }
@@ -409,14 +357,15 @@ bool TryInspectAddress(CFGRebuildState& state) {
 }
 
 bool TryQuery(CFGRebuildState& state) {
-    const auto gather_labels = ([](ControlStack& cc, std::map<u32, u32>& labels, BlockInfo& block) {
+    const auto gather_labels = [](std::stack<u32>& cc, std::map<u32, u32>& labels,
+                                  BlockInfo& block) {
         auto gather_start = labels.lower_bound(block.start);
         const auto gather_end = labels.upper_bound(block.end);
         while (gather_start != gather_end) {
-            cc.Push(gather_start->second);
+            cc.push(gather_start->second);
             gather_start++;
         }
-    });
+    };
     if (state.queries.empty()) {
         return false;
     }
@@ -428,9 +377,8 @@ bool TryQuery(CFGRebuildState& state) {
     // consumes a label. Schedule new queries accordingly
     if (block.visited) {
         BlockStack& stack = state.stacks[q.address];
-        const bool all_okay =
-            (stack.ssy_stack.Size() == 0 || q.ssy_stack.Compare(stack.ssy_stack)) &&
-            (stack.pbk_stack.Size() == 0 || q.pbk_stack.Compare(stack.pbk_stack));
+        const bool all_okay = (stack.ssy_stack.size() == 0 || q.ssy_stack == stack.ssy_stack) &&
+                              (stack.pbk_stack.size() == 0 || q.pbk_stack == stack.pbk_stack);
         state.queries.pop_front();
         return all_okay;
     }
@@ -447,15 +395,15 @@ bool TryQuery(CFGRebuildState& state) {
     Query conditional_query{q2};
     if (block.branch.is_sync) {
         if (block.branch.address == unassigned_branch) {
-            block.branch.address = conditional_query.ssy_stack.Top();
+            block.branch.address = conditional_query.ssy_stack.top();
         }
-        conditional_query.ssy_stack.Pop();
+        conditional_query.ssy_stack.pop();
     }
     if (block.branch.is_brk) {
         if (block.branch.address == unassigned_branch) {
-            block.branch.address = conditional_query.pbk_stack.Top();
+            block.branch.address = conditional_query.pbk_stack.top();
         }
-        conditional_query.pbk_stack.Pop();
+        conditional_query.pbk_stack.pop();
     }
     conditional_query.address = block.branch.address;
     state.queries.push_back(conditional_query);

--- a/src/video_core/shader/control_flow.h
+++ b/src/video_core/shader/control_flow.h
@@ -3,7 +3,7 @@
 #include <cstring>
 #include <list>
 #include <optional>
-#include <vector>
+#include <unordered_set>
 
 #include "video_core/engines/shader_bytecode.h"
 #include "video_core/shader/shader_ir.h"
@@ -48,6 +48,7 @@ struct ShaderCharacteristics {
     bool decompilable{};
     u32 start;
     u32 end;
+    std::unordered_set<u32> labels{};
 };
 
 bool ScanFlow(const ProgramCode& program_code, u32 program_size, u32 start_address,

--- a/src/video_core/shader/control_flow.h
+++ b/src/video_core/shader/control_flow.h
@@ -32,8 +32,6 @@ struct Condition {
 };
 
 struct ShaderBlock {
-    ShaderBlock() = default;
-    ShaderBlock(const ShaderBlock& sb) = default;
     u32 start{};
     u32 end{};
     bool ignore_branch{};
@@ -44,7 +42,7 @@ struct ShaderBlock {
         bool operator==(const Branch& b) const {
             return std::tie(cond, kills, address) == std::tie(b.cond, b.kills, b.address);
         }
-    } branch;
+    } branch{};
     bool operator==(const ShaderBlock& sb) const {
         return std::tie(start, end, ignore_branch, branch) ==
                std::tie(sb.start, sb.end, sb.ignore_branch, sb.branch);
@@ -52,14 +50,14 @@ struct ShaderBlock {
 };
 
 struct ShaderCharacteristics {
-    std::list<ShaderBlock> blocks;
+    std::list<ShaderBlock> blocks{};
     bool decompilable{};
-    u32 start;
-    u32 end;
+    u32 start{};
+    u32 end{};
     std::unordered_set<u32> labels{};
 };
 
-bool ScanFlow(const ProgramCode& program_code, u32 program_size, u32 start_address,
-              ShaderCharacteristics& result_out);
+std::optional<ShaderCharacteristics> ScanFlow(const ProgramCode& program_code, u32 program_size,
+                                              u32 start_address);
 
 } // namespace VideoCommon::Shader

--- a/src/video_core/shader/control_flow.h
+++ b/src/video_core/shader/control_flow.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cstring>
+#include <list>
+#include <optional>
+#include <vector>
+
+#include "video_core/engines/shader_bytecode.h"
+#include "video_core/shader/shader_ir.h"
+
+namespace VideoCommon::Shader {
+
+using Tegra::Shader::ConditionCode;
+using Tegra::Shader::Pred;
+
+constexpr s32 exit_branch = -1;
+
+struct Condition {
+    Pred predicate{Pred::UnusedIndex};
+    ConditionCode cc{ConditionCode::T};
+
+    bool IsUnconditional() const {
+        return (predicate == Pred::UnusedIndex) && (cc == ConditionCode::T);
+    }
+};
+
+struct ShaderBlock {
+    ShaderBlock() {}
+    ShaderBlock(const ShaderBlock& sb) = default;
+    u32 start{};
+    u32 end{};
+    struct Branch {
+        Condition cond{};
+        bool kills{};
+        s32 address{};
+        bool operator==(const Branch& b) const {
+            return std::memcmp(this, &b, sizeof(Branch)) == 0;
+        }
+    } branch;
+    bool operator==(const ShaderBlock& sb) const {
+        return std::memcmp(this, &sb, sizeof(ShaderBlock)) == 0;
+    }
+};
+
+struct ShaderCharacteristics {
+    std::list<ShaderBlock> blocks;
+    bool decompilable{};
+    u32 start;
+    u32 end;
+};
+
+bool ScanFlow(const ProgramCode& program_code, u32 program_size, u32 start_address,
+              ShaderCharacteristics& result_out);
+
+} // namespace VideoCommon::Shader

--- a/src/video_core/shader/control_flow.h
+++ b/src/video_core/shader/control_flow.h
@@ -1,3 +1,7 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 #pragma once
 
 #include <cstring>
@@ -20,12 +24,15 @@ struct Condition {
     ConditionCode cc{ConditionCode::T};
 
     bool IsUnconditional() const {
-        return (predicate == Pred::UnusedIndex) && (cc == ConditionCode::T);
+        return predicate == Pred::UnusedIndex && cc == ConditionCode::T;
+    }
+    bool operator==(const Condition& other) const {
+        return std::tie(predicate, cc) == std::tie(other.predicate, other.cc);
     }
 };
 
 struct ShaderBlock {
-    ShaderBlock() {}
+    ShaderBlock() = default;
     ShaderBlock(const ShaderBlock& sb) = default;
     u32 start{};
     u32 end{};
@@ -35,11 +42,12 @@ struct ShaderBlock {
         bool kills{};
         s32 address{};
         bool operator==(const Branch& b) const {
-            return std::memcmp(this, &b, sizeof(Branch)) == 0;
+            return std::tie(cond, kills, address) == std::tie(b.cond, b.kills, b.address);
         }
     } branch;
     bool operator==(const ShaderBlock& sb) const {
-        return std::memcmp(this, &sb, sizeof(ShaderBlock)) == 0;
+        return std::tie(start, end, ignore_branch, branch) ==
+               std::tie(sb.start, sb.end, sb.ignore_branch, sb.branch);
     }
 };
 

--- a/src/video_core/shader/control_flow.h
+++ b/src/video_core/shader/control_flow.h
@@ -29,6 +29,7 @@ struct ShaderBlock {
     ShaderBlock(const ShaderBlock& sb) = default;
     u32 start{};
     u32 end{};
+    bool ignore_branch{};
     struct Branch {
         Condition cond{};
         bool kills{};

--- a/src/video_core/shader/decode.cpp
+++ b/src/video_core/shader/decode.cpp
@@ -39,7 +39,7 @@ void ShaderIR::Decode() {
     std::memcpy(&header, program_code.data(), sizeof(Tegra::Shader::Header));
 
     disable_flow_stack = false;
-    const auto info = ScanFlow(program_code, program_size, main_offset);
+    const auto info = ScanFlow(program_code, MAX_PROGRAM_LENGTH * sizeof(u64), main_offset);
     if (info) {
         const auto& shader_info = *info;
         coverage_begin = shader_info.start;

--- a/src/video_core/shader/decode.cpp
+++ b/src/video_core/shader/decode.cpp
@@ -46,7 +46,7 @@ void ShaderIR::Decode() {
         coverage_end = shader_info.end;
         if (shader_info.decompilable) {
             disable_flow_stack = true;
-            auto insert_block = ([this](NodeBlock& nodes, u32 label) {
+            const auto insert_block = ([this](NodeBlock& nodes, u32 label) {
                 if (label == exit_branch) {
                     return;
                 }
@@ -88,7 +88,6 @@ void ShaderIR::Decode() {
     for (u32 label = main_offset; label < shader_end; label++) {
         basic_blocks.insert({label, DecodeRange(label, label + 1)});
     }
-    return;
 }
 
 NodeBlock ShaderIR::DecodeRange(u32 begin, u32 end) {
@@ -104,16 +103,17 @@ void ShaderIR::DecodeRangeInner(NodeBlock& bb, u32 begin, u32 end) {
 }
 
 void ShaderIR::InsertControlFlow(NodeBlock& bb, const ShaderBlock& block) {
-    auto apply_conditions = ([&](const Condition& cond, Node n) -> Node {
+    const auto apply_conditions = ([&](const Condition& cond, Node n) -> Node {
         Node result = n;
         if (cond.cc != ConditionCode::T) {
             result = Conditional(GetConditionCode(cond.cc), {result});
         }
         if (cond.predicate != Pred::UnusedIndex) {
             u32 pred = static_cast<u32>(cond.predicate);
-            bool is_neg = pred > 7;
-            if (is_neg)
+            const bool is_neg = pred > 7;
+            if (is_neg) {
                 pred -= 8;
+            }
             result = Conditional(GetPredicate(pred, is_neg), {result});
         }
         return result;

--- a/src/video_core/shader/decode.cpp
+++ b/src/video_core/shader/decode.cpp
@@ -39,7 +39,7 @@ void ShaderIR::Decode() {
     std::memcpy(&header, program_code.data(), sizeof(Tegra::Shader::Header));
 
     disable_flow_stack = false;
-    const auto info = ScanFlow(program_code, program_code.size(), main_offset);
+    const auto info = ScanFlow(program_code, program_size, main_offset);
     if (info) {
         const auto& shader_info = *info;
         coverage_begin = shader_info.start;

--- a/src/video_core/shader/decode.cpp
+++ b/src/video_core/shader/decode.cpp
@@ -39,7 +39,7 @@ void ShaderIR::Decode() {
     std::memcpy(&header, program_code.data(), sizeof(Tegra::Shader::Header));
 
     ShaderCharacteristics shader_info{};
-    bool can_proceed = ScanFlow(program_code, MAX_PROGRAM_LENGTH, main_offset, shader_info);
+    bool can_proceed = ScanFlow(program_code, program_code.size(), main_offset, shader_info);
     if (can_proceed) {
         coverage_begin = shader_info.start;
         coverage_end = shader_info.end;
@@ -52,12 +52,12 @@ void ShaderIR::Decode() {
         }
         return;
     }
-    LOG_CRITICAL(HW_GPU, "Flow Analysis failed, falling back to brute force compiling");
+    LOG_WARNING(HW_GPU, "Flow Analysis failed, falling back to brute force compiling");
 
     // Now we need to deal with an undecompilable shader. We need to brute force
     // a shader that captures every position.
     coverage_begin = shader_info.start;
-    const u32 shader_end = static_cast<u32>(MAX_PROGRAM_LENGTH);
+    const u32 shader_end = static_cast<u32>(program_size / sizeof(u64));
     coverage_end = shader_end;
     for (u32 label = main_offset; label < shader_end; label++) {
         basic_blocks.insert({label, DecodeRange(label, label + 1)});

--- a/src/video_core/shader/decode.cpp
+++ b/src/video_core/shader/decode.cpp
@@ -39,7 +39,7 @@ void ShaderIR::Decode() {
     std::memcpy(&header, program_code.data(), sizeof(Tegra::Shader::Header));
 
     disable_flow_stack = false;
-    const auto info = ScanFlow(program_code, MAX_PROGRAM_LENGTH * sizeof(u64), main_offset);
+    const auto info = ScanFlow(program_code, program_size, main_offset);
     if (info) {
         const auto& shader_info = *info;
         coverage_begin = shader_info.start;

--- a/src/video_core/shader/decode.cpp
+++ b/src/video_core/shader/decode.cpp
@@ -146,15 +146,18 @@ u32 ShaderIR::DecodeInstr(NodeBlock& bb, u32 pc) {
 
     const Instruction instr = {program_code[pc]};
     const auto opcode = OpCode::Decode(instr);
+    const u32 nv_address = ConvertAddressToNvidiaSpace(pc);
 
     // Decoding failure
     if (!opcode) {
         UNIMPLEMENTED_MSG("Unhandled instruction: {0:x}", instr.value);
+        bb.push_back(Comment(fmt::format("{:05x} Unimplemented Shader instruction (0x{:016x})",
+                                         nv_address, instr.value)));
         return pc + 1;
     }
 
-    bb.push_back(
-        Comment(fmt::format("{}: {} (0x{:016x})", pc, opcode->get().GetName(), instr.value)));
+    bb.push_back(Comment(
+        fmt::format("{:05x} {} (0x{:016x})", nv_address, opcode->get().GetName(), instr.value)));
 
     using Tegra::Shader::Pred;
     UNIMPLEMENTED_IF_MSG(instr.pred.full_pred == Pred::NeverExecute,

--- a/src/video_core/shader/decode.cpp
+++ b/src/video_core/shader/decode.cpp
@@ -39,9 +39,9 @@ void ShaderIR::Decode() {
     std::memcpy(&header, program_code.data(), sizeof(Tegra::Shader::Header));
 
     disable_flow_stack = false;
-    ShaderCharacteristics shader_info{};
-    bool can_proceed = ScanFlow(program_code, program_code.size(), main_offset, shader_info);
-    if (can_proceed) {
+    const auto info = ScanFlow(program_code, program_code.size(), main_offset);
+    if (info) {
+        const auto& shader_info = *info;
         coverage_begin = shader_info.start;
         coverage_end = shader_info.end;
         if (shader_info.decompilable) {
@@ -52,7 +52,7 @@ void ShaderIR::Decode() {
                 }
                 basic_blocks.insert({label, nodes});
             });
-            std::list<ShaderBlock>& blocks = shader_info.blocks;
+            const auto& blocks = shader_info.blocks;
             NodeBlock current_block;
             u32 current_label = exit_branch;
             for (auto& block : blocks) {
@@ -82,7 +82,7 @@ void ShaderIR::Decode() {
 
     // Now we need to deal with an undecompilable shader. We need to brute force
     // a shader that captures every position.
-    coverage_begin = shader_info.start;
+    coverage_begin = main_offset;
     const u32 shader_end = static_cast<u32>(program_size / sizeof(u64));
     coverage_end = shader_end;
     for (u32 label = main_offset; label < shader_end; label++) {

--- a/src/video_core/shader/node.h
+++ b/src/video_core/shader/node.h
@@ -148,12 +148,12 @@ enum class OperationCode {
 
     ImageStore, /// (MetaImage, float[N] coords) -> void
 
-    Branch,        /// (uint branch_target) -> void
-    BranchIndirect,/// (uint branch_target) -> void
-    PushFlowStack, /// (uint branch_target) -> void
-    PopFlowStack,  /// () -> void
-    Exit,          /// () -> void
-    Discard,       /// () -> void
+    Branch,         /// (uint branch_target) -> void
+    BranchIndirect, /// (uint branch_target) -> void
+    PushFlowStack,  /// (uint branch_target) -> void
+    PopFlowStack,   /// () -> void
+    Exit,           /// () -> void
+    Discard,        /// () -> void
 
     EmitVertex,   /// () -> void
     EndPrimitive, /// () -> void

--- a/src/video_core/shader/node.h
+++ b/src/video_core/shader/node.h
@@ -149,6 +149,7 @@ enum class OperationCode {
     ImageStore, /// (MetaImage, float[N] coords) -> void
 
     Branch,        /// (uint branch_target) -> void
+    BranchIndirect,/// (uint branch_target) -> void
     PushFlowStack, /// (uint branch_target) -> void
     PopFlowStack,  /// () -> void
     Exit,          /// () -> void

--- a/src/video_core/shader/shader_ir.cpp
+++ b/src/video_core/shader/shader_ir.cpp
@@ -22,8 +22,8 @@ using Tegra::Shader::PredCondition;
 using Tegra::Shader::PredOperation;
 using Tegra::Shader::Register;
 
-ShaderIR::ShaderIR(const ProgramCode& program_code, u32 main_offset)
-    : program_code{program_code}, main_offset{main_offset} {
+ShaderIR::ShaderIR(const ProgramCode& program_code, u32 main_offset, const std::size_t size)
+    : program_code{program_code}, main_offset{main_offset}, program_size{size} {
     Decode();
 }
 

--- a/src/video_core/shader/shader_ir.h
+++ b/src/video_core/shader/shader_ir.h
@@ -123,10 +123,15 @@ public:
         return header;
     }
 
+    bool IsFlowStackDisabled() const {
+        return disable_flow_stack;
+    }
+
 private:
     void Decode();
 
     NodeBlock DecodeRange(u32 begin, u32 end);
+    void DecodeRangeInner(NodeBlock& bb, u32 begin, u32 end);
     void InsertControlFlow(NodeBlock& bb, const ShaderBlock& block);
 
     /**
@@ -320,6 +325,7 @@ private:
     const ProgramCode& program_code;
     const u32 main_offset;
     const std::size_t program_size;
+    bool disable_flow_stack{};
 
     u32 coverage_begin{};
     u32 coverage_end{};

--- a/src/video_core/shader/shader_ir.h
+++ b/src/video_core/shader/shader_ir.h
@@ -26,14 +26,6 @@ using ProgramCode = std::vector<u64>;
 
 constexpr u32 MAX_PROGRAM_LENGTH = 0x1000;
 
-/// Describes the behaviour of code path of a given entry point and a return point.
-enum class ExitMethod {
-    Undetermined, ///< Internal value. Only occur when analyzing JMP loop.
-    AlwaysReturn, ///< All code paths reach the return point.
-    Conditional,  ///< Code path reaches the return point or an END instruction conditionally.
-    AlwaysEnd,    ///< All code paths reach a END instruction.
-};
-
 class ConstBuffer {
 public:
     explicit ConstBuffer(u32 max_offset, bool is_indirect)
@@ -131,8 +123,6 @@ public:
 
 private:
     void Decode();
-
-    ExitMethod Scan(u32 begin, u32 end, std::set<u32>& labels);
 
     NodeBlock DecodeRange(u32 begin, u32 end);
 
@@ -329,7 +319,6 @@ private:
 
     u32 coverage_begin{};
     u32 coverage_end{};
-    std::map<std::pair<u32, u32>, ExitMethod> exit_method_map;
 
     std::map<u32, NodeBlock> basic_blocks;
     NodeBlock global_code;

--- a/src/video_core/shader/shader_ir.h
+++ b/src/video_core/shader/shader_ir.h
@@ -65,7 +65,7 @@ struct GlobalMemoryUsage {
 
 class ShaderIR final {
 public:
-    explicit ShaderIR(const ProgramCode& program_code, u32 main_offset);
+    explicit ShaderIR(const ProgramCode& program_code, u32 main_offset, std::size_t size);
     ~ShaderIR();
 
     const std::map<u32, NodeBlock>& GetBasicBlocks() const {
@@ -316,6 +316,7 @@ private:
 
     const ProgramCode& program_code;
     const u32 main_offset;
+    const std::size_t program_size;
 
     u32 coverage_begin{};
     u32 coverage_end{};

--- a/src/video_core/shader/shader_ir.h
+++ b/src/video_core/shader/shader_ir.h
@@ -22,6 +22,8 @@
 
 namespace VideoCommon::Shader {
 
+struct ShaderBlock;
+
 using ProgramCode = std::vector<u64>;
 
 constexpr u32 MAX_PROGRAM_LENGTH = 0x1000;
@@ -125,6 +127,7 @@ private:
     void Decode();
 
     NodeBlock DecodeRange(u32 begin, u32 end);
+    void InsertControlFlow(NodeBlock& bb, const ShaderBlock& block);
 
     /**
      * Decodes a single instruction from Tegra to IR.

--- a/src/video_core/shader/shader_ir.h
+++ b/src/video_core/shader/shader_ir.h
@@ -127,6 +127,10 @@ public:
         return disable_flow_stack;
     }
 
+    u32 ConvertAddressToNvidiaSpace(const u32 address) const {
+        return (address - main_offset) * sizeof(Tegra::Shader::Instruction);
+    }
+
 private:
     void Decode();
 


### PR DESCRIPTION
This PR does an overhaul to our old shader scanner by introducing a new one that it's more accurate, safer and predictable. It also decompiles SYNC/BRK into direct branches when possible. Furthermore, it introduces shader instructions BRX and BRA.CC and decompiles into brute force when they exist as they are indirect branches.

This PR should:
* Improve performance in low-end GPUs
* Produce more readibale code.
* Avoid reading out-of-bounds shaders (aka corrupted shaders).