### PR TITLE
pm: Implement various pm commands for finding process and title IDs

### DIFF
--- a/src/core/hle/service/pm/pm.h
+++ b/src/core/hle/service/pm/pm.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-namespace Service::SM {
-class ServiceManager;
+namespace Core {
+class System;
 }
 
 namespace Service::PM {
@@ -16,6 +16,6 @@ enum class SystemBootMode {
 };
 
 /// Registers all PM services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(Core::System& system);
 
 } // namespace Service::PM

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -242,7 +242,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system,
     PCTL::InstallInterfaces(*sm);
     PCV::InstallInterfaces(*sm);
     PlayReport::InstallInterfaces(*sm);
-    PM::InstallInterfaces(*sm);
+    PM::InstallInterfaces(system);
     PSC::InstallInterfaces(*sm);
     PSM::InstallInterfaces(*sm);
     Set::InstallInterfaces(*sm);


### PR DESCRIPTION
This implements various commands in `pm:shell`, `pm:dmnt`, and `pm:info` which map between process and title IDs.

- `pm:info GetTitleId(u64 process_id) -> u64 title_id` 
    This takes a process ID and returns the title ID it possesses, if the process ID doesn't correspond to a valid process returns an error code.
- `pm:dmnt GetTitlePid(u64 title_id) -> u64 process_id`
    The inverse of the preceding command, this takes a title ID and returns the process ID if there exists a process with that title ID, otherwise error.
- `pm:dmnt GetApplicationPid() -> u64 process_id` & `pm:shell GetApplicationPid() -> u64 process_id`
    These both return the process ID of the current application, and if no application is running they return 0, which is an invalid process ID.