### PR TITLE
prepo: Implement New, System, and Non-User variants of SaveReport

### DIFF
--- a/src/core/hle/service/prepo/prepo.cpp
+++ b/src/core/hle/service/prepo/prepo.cpp
@@ -2,18 +2,14 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <json.hpp>
-#include "common/file_util.h"
 #include "common/hex_util.h"
 #include "common/logging/log.h"
-#include "common/scm_rev.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/service/acc/profile_manager.h"
 #include "core/hle/service/prepo/prepo.h"
 #include "core/hle/service/service.h"
 #include "core/reporter.h"
-#include "core/settings.h"
 
 namespace Service::PlayReport {
 
@@ -22,14 +18,14 @@ public:
     explicit PlayReport(const char* name) : ServiceFramework{name} {
         // clang-format off
         static const FunctionInfo functions[] = {
-            {10100, nullptr, "SaveReportOld"},
-            {10101, &PlayReport::SaveReportWithUserOld, "SaveReportWithUserOld"},
-            {10102, nullptr, "SaveReport"},
-            {10103, nullptr, "SaveReportWithUser"},
+            {10100, &PlayReport::SaveReport<Core::Reporter::PlayReportType::Old>, "SaveReportOld"},
+            {10101, &PlayReport::SaveReportWithUser<Core::Reporter::PlayReportType::Old>, "SaveReportWithUserOld"},
+            {10102, &PlayReport::SaveReport<Core::Reporter::PlayReportType::New>, "SaveReport"},
+            {10103, &PlayReport::SaveReportWithUser<Core::Reporter::PlayReportType::New>, "SaveReportWithUser"},
             {10200, nullptr, "RequestImmediateTransmission"},
             {10300, nullptr, "GetTransmissionStatus"},
-            {20100, nullptr, "SaveSystemReport"},
-            {20101, nullptr, "SaveSystemReportWithUser"},
+            {20100, &PlayReport::SaveSystemReport, "SaveSystemReport"},
+            {20101, &PlayReport::SaveSystemReportWithUser, "SaveSystemReportWithUser"},
             {20200, nullptr, "SetOperationMode"},
             {30100, nullptr, "ClearStorage"},
             {30200, nullptr, "ClearStatistics"},
@@ -47,7 +43,28 @@ public:
     }
 
 private:
-    void SaveReportWithUserOld(Kernel::HLERequestContext& ctx) {
+    template <Core::Reporter::PlayReportType Type>
+    void SaveReport(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto process_id = rp.PopRaw<u64>();
+
+        const auto data1 = ctx.ReadBuffer(0);
+        const auto data2 = ctx.ReadBuffer(1);
+
+        LOG_DEBUG(Service_PREPO,
+                  "called, type={:02X}, process_id={:016X}, data1_size={:016X}, data2_size={:016X}",
+                  static_cast<u8>(Type), process_id, data1.size(), data2.size());
+
+        const auto& reporter{Core::System::GetInstance().GetReporter()};
+        reporter.SavePlayReport(Type, Core::CurrentProcess()->GetTitleID(), {data1, data2},
+                                process_id);
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+    }
+
+    template <Core::Reporter::PlayReportType Type>
+    void SaveReportWithUser(Kernel::HLERequestContext& ctx) {
         IPC::RequestParser rp{ctx};
         const auto user_id = rp.PopRaw<u128>();
         const auto process_id = rp.PopRaw<u64>();
@@ -57,12 +74,51 @@ private:
 
         LOG_DEBUG(
             Service_PREPO,
-            "called, user_id={:016X}{:016X}, unk1={:016X}, data1_size={:016X}, data2_size={:016X}",
-            user_id[1], user_id[0], process_id, data1.size(), data2.size());
+            "called, type={:02X}, user_id={:016X}{:016X}, process_id={:016X}, data1_size={:016X}, "
+            "data2_size={:016X}",
+            static_cast<u8>(Type), user_id[1], user_id[0], process_id, data1.size(), data2.size());
 
         const auto& reporter{Core::System::GetInstance().GetReporter()};
-        reporter.SavePlayReport(Core::CurrentProcess()->GetTitleID(), process_id, {data1, data2},
-                                user_id);
+        reporter.SavePlayReport(Type, Core::CurrentProcess()->GetTitleID(), {data1, data2},
+                                process_id, user_id);
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+    }
+
+    void SaveSystemReport(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto title_id = rp.PopRaw<u64>();
+
+        const auto data1 = ctx.ReadBuffer(0);
+        const auto data2 = ctx.ReadBuffer(1);
+
+        LOG_DEBUG(Service_PREPO, "called, title_id={:016X}, data1_size={:016X}, data2_size={:016X}",
+                  title_id, data1.size(), data2.size());
+
+        const auto& reporter{Core::System::GetInstance().GetReporter()};
+        reporter.SavePlayReport(Core::Reporter::PlayReportType::System, title_id, {data1, data2});
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+    }
+
+    void SaveSystemReportWithUser(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto user_id = rp.PopRaw<u128>();
+        const auto title_id = rp.PopRaw<u64>();
+
+        const auto data1 = ctx.ReadBuffer(0);
+        const auto data2 = ctx.ReadBuffer(1);
+
+        LOG_DEBUG(Service_PREPO,
+                  "called, user_id={:016X}{:016X}, title_id={:016X}, data1_size={:016X}, "
+                  "data2_size={:016X}",
+                  user_id[1], user_id[0], title_id, data1.size(), data2.size());
+
+        const auto& reporter{Core::System::GetInstance().GetReporter()};
+        reporter.SavePlayReport(Core::Reporter::PlayReportType::System, title_id, {data1, data2},
+                                std::nullopt, user_id);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/prepo/prepo.h
+++ b/src/core/hle/service/prepo/prepo.h
@@ -10,6 +10,6 @@ class ServiceManager;
 
 namespace Service::PlayReport {
 
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(Core::System& system);
 
 } // namespace Service::PlayReport

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -240,7 +240,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system) {
     PCIe::InstallInterfaces(*sm);
     PCTL::InstallInterfaces(*sm);
     PCV::InstallInterfaces(*sm);
-    PlayReport::InstallInterfaces(*sm);
+    PlayReport::InstallInterfaces(system);
     PM::InstallInterfaces(system);
     PSC::InstallInterfaces(*sm);
     PSM::InstallInterfaces(*sm);

--- a/src/core/reporter.cpp
+++ b/src/core/reporter.cpp
@@ -304,8 +304,8 @@ void Reporter::SaveUnimplementedAppletReport(
     SaveToFile(std::move(out), GetPath("unimpl_applet_report", title_id, timestamp));
 }
 
-void Reporter::SavePlayReport(u64 title_id, u64 process_id, std::vector<std::vector<u8>> data,
-                              std::optional<u128> user_id) const {
+void Reporter::SavePlayReport(PlayReportType type, u64 title_id, std::vector<std::vector<u8>> data,
+                              std::optional<u64> process_id, std::optional<u128> user_id) const {
     if (!IsReportingEnabled()) {
         return;
     }
@@ -321,7 +321,11 @@ void Reporter::SavePlayReport(u64 title_id, u64 process_id, std::vector<std::vec
         data_out.push_back(Common::HexToString(d));
     }
 
-    out["play_report_process_id"] = fmt::format("{:016X}", process_id);
+    if (process_id.has_value()) {
+        out["play_report_process_id"] = fmt::format("{:016X}", *process_id);
+    }
+
+    out["play_report_type"] = fmt::format("{:02}", static_cast<u8>(type));
     out["play_report_data"] = std::move(data_out);
 
     SaveToFile(std::move(out), GetPath("play_report", title_id, timestamp));

--- a/src/core/reporter.h
+++ b/src/core/reporter.h
@@ -46,8 +46,14 @@ public:
                                        std::vector<std::vector<u8>> normal_channel,
                                        std::vector<std::vector<u8>> interactive_channel) const;
 
-    void SavePlayReport(u64 title_id, u64 process_id, std::vector<std::vector<u8>> data,
-                        std::optional<u128> user_id = {}) const;
+    enum class PlayReportType {
+        Old,
+        New,
+        System,
+    };
+
+    void SavePlayReport(PlayReportType type, u64 title_id, std::vector<std::vector<u8>> data,
+                        std::optional<u64> process_id = {}, std::optional<u128> user_id = {}) const;
 
     void SaveErrorReport(u64 title_id, ResultCode result,
                          std::optional<std::string> custom_text_main = {},


### PR DESCRIPTION
We only had one variant of prepo's reporting functions implemented prior to this, SaveReportWithUserOld, simply because that was the only one we had seen called by games at the time of #2482.

This adds all of the versions of SaveReport*:
- `SaveReportOld` and `SaveReportWithUserOld` -- These were used prior to 6.0.0
- `SaveReport` and `SaveReportWithUser` -- Added in 6.0.0, have the same parameters.
- `SaveSystemReport` and `SaveSystemReportWithUser` -- Unlike the above two, which operate based on process_ids, these use title_ids.

The `WithUser` variants add an additional `u128` parameter at the front of the signature.

Since the framework to store/export this data was added with #2482, this was quite easy. The reports now include an additional JSON field for Old, New or System.