### PR TITLE
set: Implement GetQuestFlag with config option

### DIFF
--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -95,6 +95,14 @@ void SET::GetAvailableLanguageCodeCount2(Kernel::HLERequestContext& ctx) {
     PushResponseLanguageCode(ctx, post4_0_0_max_entries);
 }
 
+void SET::GetQuestFlag(Kernel::HLERequestContext& ctx) {
+    LOG_DEBUG(Service_SET, "called");
+
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(RESULT_SUCCESS);
+    rb.Push(static_cast<u32>(Settings::values.quest_flag));
+}
+
 void SET::GetLanguageCode(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_SET, "called {}", Settings::values.language_index);
 
@@ -114,7 +122,7 @@ SET::SET() : ServiceFramework("set") {
         {5, &SET::GetAvailableLanguageCodes2, "GetAvailableLanguageCodes2"},
         {6, &SET::GetAvailableLanguageCodeCount2, "GetAvailableLanguageCodeCount2"},
         {7, nullptr, "GetKeyCodeMap"},
-        {8, nullptr, "GetQuestFlag"},
+        {8, &SET::GetQuestFlag, "GetQuestFlag"},
         {9, nullptr, "GetKeyCodeMap2"},
     };
     // clang-format on

--- a/src/core/hle/service/set/set.h
+++ b/src/core/hle/service/set/set.h
@@ -42,6 +42,7 @@ private:
     void GetAvailableLanguageCodes2(Kernel::HLERequestContext& ctx);
     void GetAvailableLanguageCodeCount(Kernel::HLERequestContext& ctx);
     void GetAvailableLanguageCodeCount2(Kernel::HLERequestContext& ctx);
+    void GetQuestFlag(Kernel::HLERequestContext& ctx);
 };
 
 } // namespace Service::Set

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -416,6 +416,7 @@ struct Values {
     bool dump_exefs;
     bool dump_nso;
     bool reporting_services;
+    bool quest_flag;
 
     // WebService
     bool enable_telemetry;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -475,6 +475,7 @@ void Config::ReadDebuggingValues() {
     Settings::values.dump_nso = ReadSetting(QStringLiteral("dump_nso"), false).toBool();
     Settings::values.reporting_services =
         ReadSetting(QStringLiteral("reporting_services"), false).toBool();
+    Settings::values.quest_flag = ReadSetting(QStringLiteral("quest_flag"), false).toBool();
 
     qt_config->endGroup();
 }
@@ -858,6 +859,7 @@ void Config::SaveDebuggingValues() {
                  QString::fromStdString(Settings::values.program_args), QStringLiteral(""));
     WriteSetting(QStringLiteral("dump_exefs"), Settings::values.dump_exefs, false);
     WriteSetting(QStringLiteral("dump_nso"), Settings::values.dump_nso, false);
+    WriteSetting(QStringLiteral("quest_flag"), Settings::values.quest_flag, false);
 
     qt_config->endGroup();
 }

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -37,6 +37,7 @@ void ConfigureDebug::SetConfiguration() {
     ui->dump_exefs->setChecked(Settings::values.dump_exefs);
     ui->dump_decompressed_nso->setChecked(Settings::values.dump_nso);
     ui->reporting_services->setChecked(Settings::values.reporting_services);
+    ui->quest_flag->setChecked(Settings::values.quest_flag);
 }
 
 void ConfigureDebug::ApplyConfiguration() {
@@ -48,6 +49,7 @@ void ConfigureDebug::ApplyConfiguration() {
     Settings::values.dump_exefs = ui->dump_exefs->isChecked();
     Settings::values.dump_nso = ui->dump_decompressed_nso->isChecked();
     Settings::values.reporting_services = ui->reporting_services->isChecked();
+    Settings::values.quest_flag = ui->quest_flag->isChecked();
     Debugger::ToggleConsole();
     Log::Filter filter;
     filter.ParseFilterString(Settings::values.log_filter);

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>357</height>
+    <height>474</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -174,6 +174,22 @@
         </property>
         <property name="indent">
          <number>20</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox_5">
+     <property name="title">
+      <string>Advanced</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QCheckBox" name="quest_flag">
+        <property name="text">
+         <string>Kiosk (Quest) Mode</string>
         </property>
        </widget>
       </item>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -383,6 +383,7 @@ void Config::ReadValues() {
     Settings::values.dump_nso = sdl2_config->GetBoolean("Debugging", "dump_nso", false);
     Settings::values.reporting_services =
         sdl2_config->GetBoolean("Debugging", "reporting_services", false);
+    Settings::values.quest_flag = sdl2_config->GetBoolean("Debugging", "quest_flag", false);
 
     const auto title_list = sdl2_config->Get("AddOns", "title_ids", "");
     std::stringstream ss(title_list);

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -224,6 +224,9 @@ gdbstub_port=24689
 dump_exefs=false
 # Determines whether or not yuzu will dump all NSOs it attempts to load while loading them
 dump_nso=false
+# Determines whether or not yuzu will report to the game that the emulated console is in Kiosk Mode
+# false: Retail/Normal Mode (default), true: Kiosk Mode
+quest_flag =
 
 [WebService]
 # Whether or not to enable telemetry


### PR DESCRIPTION
This quite simply returns the current config value to the game to determine if the game is running under 'Retail' or 'Quest' (Kiosk) mode. Kiosk mode is commonly used in stores to display/show games to consumers.

It's unknown how this affects most games, but it's assumed they will show some sort of promotional/advertising material or a tutorial/minigame mode.

Closes #2615