### PR TITLE
applets: Move from am to hle directory and rename namespace

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -111,6 +111,18 @@ add_library(core STATIC
     frontend/scope_acquire_window_context.h
     gdbstub/gdbstub.cpp
     gdbstub/gdbstub.h
+    hle/applet/applet.cpp
+    hle/applet/applet.h
+    hle/applet/error.cpp
+    hle/applet/error.h
+    hle/applet/general_backend.cpp
+    hle/applet/general_backend.h
+    hle/applet/profile_select.cpp
+    hle/applet/profile_select.h
+    hle/applet/software_keyboard.cpp
+    hle/applet/software_keyboard.h
+    hle/applet/web_browser.cpp
+    hle/applet/web_browser.h
     hle/ipc.h
     hle/ipc_helpers.h
     hle/kernel/address_arbiter.cpp
@@ -184,18 +196,6 @@ add_library(core STATIC
     hle/service/am/applet_ae.h
     hle/service/am/applet_oe.cpp
     hle/service/am/applet_oe.h
-    hle/service/am/applets/applets.cpp
-    hle/service/am/applets/applets.h
-    hle/service/am/applets/error.cpp
-    hle/service/am/applets/error.h
-    hle/service/am/applets/general_backend.cpp
-    hle/service/am/applets/general_backend.h
-    hle/service/am/applets/profile_select.cpp
-    hle/service/am/applets/profile_select.h
-    hle/service/am/applets/software_keyboard.cpp
-    hle/service/am/applets/software_keyboard.h
-    hle/service/am/applets/web_browser.cpp
-    hle/service/am/applets/web_browser.h
     hle/service/am/idle.cpp
     hle/service/am/idle.h
     hle/service/am/omm.cpp

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -19,12 +19,12 @@
 #include "core/file_sys/vfs_concat.h"
 #include "core/file_sys/vfs_real.h"
 #include "core/gdbstub/gdbstub.h"
+#include "core/hle/applet/applet.h"
 #include "core/hle/kernel/client_port.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/scheduler.h"
 #include "core/hle/kernel/thread.h"
-#include "core/hle/service/am/applets/applets.h"
 #include "core/hle/service/glue/manager.h"
 #include "core/hle/service/service.h"
 #include "core/hle/service/sm/sm.h"
@@ -304,7 +304,7 @@ struct System::Impl {
     std::unique_ptr<Tools::Freezer> memory_freezer;
 
     /// Frontend applets
-    Service::AM::Applets::AppletManager applet_manager;
+    HLE::Applet::AppletManager applet_manager;
 
     /// Glue services
     Service::Glue::ARPManager arp_manager;
@@ -519,7 +519,7 @@ std::shared_ptr<FileSys::VfsFilesystem> System::GetFilesystem() const {
     return impl->virtual_filesystem;
 }
 
-void System::SetAppletFrontendSet(Service::AM::Applets::AppletFrontendSet&& set) {
+void System::SetAppletFrontendSet(HLE::Applet::AppletFrontendSet&& set) {
     impl->applet_manager.SetAppletFrontendSet(std::move(set));
 }
 
@@ -527,11 +527,11 @@ void System::SetDefaultAppletFrontendSet() {
     impl->applet_manager.SetDefaultAppletFrontendSet();
 }
 
-Service::AM::Applets::AppletManager& System::GetAppletManager() {
+HLE::Applet::AppletManager& System::GetAppletManager() {
     return impl->applet_manager;
 }
 
-const Service::AM::Applets::AppletManager& System::GetAppletManager() const {
+const HLE::Applet::AppletManager& System::GetAppletManager() const {
     return impl->applet_manager;
 }
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -25,6 +25,11 @@ enum class ContentProviderUnionSlot;
 class VfsFilesystem;
 } // namespace FileSys
 
+namespace HLE::Applet {
+struct AppletFrontendSet;
+class AppletManager;
+} // namespace HLE::Applet
+
 namespace Kernel {
 class KernelCore;
 class Process;
@@ -37,11 +42,6 @@ enum class ResultStatus : u16;
 } // namespace Loader
 
 namespace Service {
-
-namespace AM::Applets {
-struct AppletFrontendSet;
-class AppletManager;
-} // namespace AM::Applets
 
 namespace Glue {
 class ARPManager;
@@ -271,13 +271,13 @@ public:
     void RegisterCheatList(const std::vector<FileSys::CheatList>& list, const std::string& build_id,
                            VAddr code_region_start, VAddr code_region_end);
 
-    void SetAppletFrontendSet(Service::AM::Applets::AppletFrontendSet&& set);
+    void SetAppletFrontendSet(HLE::Applet::AppletFrontendSet&& set);
 
     void SetDefaultAppletFrontendSet();
 
-    Service::AM::Applets::AppletManager& GetAppletManager();
+    HLE::Applet::AppletManager& GetAppletManager();
 
-    const Service::AM::Applets::AppletManager& GetAppletManager() const;
+    const HLE::Applet::AppletManager& GetAppletManager() const;
 
     void SetContentProvider(std::unique_ptr<FileSys::ContentProviderUnion> provider);
 

--- a/src/core/hle/applet/applet.cpp
+++ b/src/core/hle/applet/applet.cpp
@@ -10,18 +10,18 @@
 #include "core/frontend/applets/profile_select.h"
 #include "core/frontend/applets/software_keyboard.h"
 #include "core/frontend/applets/web_browser.h"
+#include "core/hle/applet/applet.h"
+#include "core/hle/applet/error.h"
+#include "core/hle/applet/general_backend.h"
+#include "core/hle/applet/profile_select.h"
+#include "core/hle/applet/software_keyboard.h"
+#include "core/hle/applet/web_browser.h"
 #include "core/hle/kernel/readable_event.h"
 #include "core/hle/kernel/server_session.h"
 #include "core/hle/kernel/writable_event.h"
 #include "core/hle/service/am/am.h"
-#include "core/hle/service/am/applets/applets.h"
-#include "core/hle/service/am/applets/error.h"
-#include "core/hle/service/am/applets/general_backend.h"
-#include "core/hle/service/am/applets/profile_select.h"
-#include "core/hle/service/am/applets/software_keyboard.h"
-#include "core/hle/service/am/applets/web_browser.h"
 
-namespace Service::AM::Applets {
+namespace HLE::Applet {
 
 AppletDataBroker::AppletDataBroker() {
     auto& kernel = Core::System::GetInstance().Kernel();
@@ -51,7 +51,7 @@ AppletDataBroker::RawChannelData AppletDataBroker::PeekDataToAppletForDebug() co
     return {std::move(out_normal), std::move(out_interactive)};
 }
 
-std::unique_ptr<IStorage> AppletDataBroker::PopNormalDataToGame() {
+std::unique_ptr<Service::AM::IStorage> AppletDataBroker::PopNormalDataToGame() {
     if (out_channel.empty())
         return nullptr;
 
@@ -60,7 +60,7 @@ std::unique_ptr<IStorage> AppletDataBroker::PopNormalDataToGame() {
     return out;
 }
 
-std::unique_ptr<IStorage> AppletDataBroker::PopNormalDataToApplet() {
+std::unique_ptr<Service::AM::IStorage> AppletDataBroker::PopNormalDataToApplet() {
     if (in_channel.empty())
         return nullptr;
 
@@ -69,7 +69,7 @@ std::unique_ptr<IStorage> AppletDataBroker::PopNormalDataToApplet() {
     return out;
 }
 
-std::unique_ptr<IStorage> AppletDataBroker::PopInteractiveDataToGame() {
+std::unique_ptr<Service::AM::IStorage> AppletDataBroker::PopInteractiveDataToGame() {
     if (out_interactive_channel.empty())
         return nullptr;
 
@@ -78,7 +78,7 @@ std::unique_ptr<IStorage> AppletDataBroker::PopInteractiveDataToGame() {
     return out;
 }
 
-std::unique_ptr<IStorage> AppletDataBroker::PopInteractiveDataToApplet() {
+std::unique_ptr<Service::AM::IStorage> AppletDataBroker::PopInteractiveDataToApplet() {
     if (in_interactive_channel.empty())
         return nullptr;
 
@@ -87,21 +87,21 @@ std::unique_ptr<IStorage> AppletDataBroker::PopInteractiveDataToApplet() {
     return out;
 }
 
-void AppletDataBroker::PushNormalDataFromGame(IStorage storage) {
-    in_channel.push_back(std::make_unique<IStorage>(storage));
+void AppletDataBroker::PushNormalDataFromGame(Service::AM::IStorage storage) {
+    in_channel.push_back(std::make_unique<Service::AM::IStorage>(storage));
 }
 
-void AppletDataBroker::PushNormalDataFromApplet(IStorage storage) {
-    out_channel.push_back(std::make_unique<IStorage>(storage));
+void AppletDataBroker::PushNormalDataFromApplet(Service::AM::IStorage storage) {
+    out_channel.push_back(std::make_unique<Service::AM::IStorage>(storage));
     pop_out_data_event.writable->Signal();
 }
 
-void AppletDataBroker::PushInteractiveDataFromGame(IStorage storage) {
-    in_interactive_channel.push_back(std::make_unique<IStorage>(storage));
+void AppletDataBroker::PushInteractiveDataFromGame(Service::AM::IStorage storage) {
+    in_interactive_channel.push_back(std::make_unique<Service::AM::IStorage>(storage));
 }
 
-void AppletDataBroker::PushInteractiveDataFromApplet(IStorage storage) {
-    out_interactive_channel.push_back(std::make_unique<IStorage>(storage));
+void AppletDataBroker::PushInteractiveDataFromApplet(Service::AM::IStorage storage) {
+    out_interactive_channel.push_back(std::make_unique<Service::AM::IStorage>(storage));
     pop_interactive_out_data_event.writable->Signal();
 }
 
@@ -241,4 +241,4 @@ std::shared_ptr<Applet> AppletManager::GetApplet(AppletId id, u64 current_proces
     }
 }
 
-} // namespace Service::AM::Applets
+} // namespace HLE::Applet

--- a/src/core/hle/applet/applet.h
+++ b/src/core/hle/applet/applet.h
@@ -25,8 +25,9 @@ class WebBrowserApplet;
 namespace Service::AM {
 
 class IStorage;
+}
 
-namespace Applets {
+namespace HLE::Applet {
 
 enum class AppletId : u32 {
     OverlayDisplay = 0x02,
@@ -64,17 +65,17 @@ public:
     // Retrieves but does not pop the data sent to applet.
     RawChannelData PeekDataToAppletForDebug() const;
 
-    std::unique_ptr<IStorage> PopNormalDataToGame();
-    std::unique_ptr<IStorage> PopNormalDataToApplet();
+    std::unique_ptr<Service::AM::IStorage> PopNormalDataToGame();
+    std::unique_ptr<Service::AM::IStorage> PopNormalDataToApplet();
 
-    std::unique_ptr<IStorage> PopInteractiveDataToGame();
-    std::unique_ptr<IStorage> PopInteractiveDataToApplet();
+    std::unique_ptr<Service::AM::IStorage> PopInteractiveDataToGame();
+    std::unique_ptr<Service::AM::IStorage> PopInteractiveDataToApplet();
 
-    void PushNormalDataFromGame(IStorage storage);
-    void PushNormalDataFromApplet(IStorage storage);
+    void PushNormalDataFromGame(Service::AM::IStorage storage);
+    void PushNormalDataFromApplet(Service::AM::IStorage storage);
 
-    void PushInteractiveDataFromGame(IStorage storage);
-    void PushInteractiveDataFromApplet(IStorage storage);
+    void PushInteractiveDataFromGame(Service::AM::IStorage storage);
+    void PushInteractiveDataFromApplet(Service::AM::IStorage storage);
 
     void SignalStateChanged() const;
 
@@ -86,16 +87,16 @@ private:
     // Queues are named from applet's perspective
 
     // PopNormalDataToApplet and PushNormalDataFromGame
-    std::deque<std::unique_ptr<IStorage>> in_channel;
+    std::deque<std::unique_ptr<Service::AM::IStorage>> in_channel;
 
     // PopNormalDataToGame and PushNormalDataFromApplet
-    std::deque<std::unique_ptr<IStorage>> out_channel;
+    std::deque<std::unique_ptr<Service::AM::IStorage>> out_channel;
 
     // PopInteractiveDataToApplet and PushInteractiveDataFromGame
-    std::deque<std::unique_ptr<IStorage>> in_interactive_channel;
+    std::deque<std::unique_ptr<Service::AM::IStorage>> in_interactive_channel;
 
     // PopInteractiveDataToGame and PushInteractiveDataFromApplet
-    std::deque<std::unique_ptr<IStorage>> out_interactive_channel;
+    std::deque<std::unique_ptr<Service::AM::IStorage>> out_interactive_channel;
 
     Kernel::EventPair state_changed_event;
 
@@ -193,5 +194,4 @@ private:
     AppletFrontendSet frontend;
 };
 
-} // namespace Applets
-} // namespace Service::AM
+} // namespace HLE::Applet

--- a/src/core/hle/applet/error.cpp
+++ b/src/core/hle/applet/error.cpp
@@ -9,12 +9,12 @@
 #include "common/string_util.h"
 #include "core/core.h"
 #include "core/frontend/applets/error.h"
+#include "core/hle/applet/error.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/service/am/am.h"
-#include "core/hle/service/am/applets/error.h"
 #include "core/reporter.h"
 
-namespace Service::AM::Applets {
+namespace HLE::Applet {
 
 #pragma pack(push, 4)
 struct ShowError {
@@ -184,8 +184,8 @@ void Error::Execute() {
 
 void Error::DisplayCompleted() {
     complete = true;
-    broker.PushNormalDataFromApplet(IStorage{{}});
+    broker.PushNormalDataFromApplet(Service::AM::IStorage{{}});
     broker.SignalStateChanged();
 }
 
-} // namespace Service::AM::Applets
+} // namespace HLE::Applet

--- a/src/core/hle/applet/error.h
+++ b/src/core/hle/applet/error.h
@@ -4,10 +4,10 @@
 
 #pragma once
 
+#include "core/hle/applet/applet.h"
 #include "core/hle/result.h"
-#include "core/hle/service/am/applets/applets.h"
 
-namespace Service::AM::Applets {
+namespace HLE::Applet {
 
 enum class ErrorAppletMode : u8 {
     ShowError = 0,
@@ -44,4 +44,4 @@ private:
     bool complete = false;
 };
 
-} // namespace Service::AM::Applets
+} // namespace HLE::Applet

--- a/src/core/hle/applet/general_backend.cpp
+++ b/src/core/hle/applet/general_backend.cpp
@@ -9,18 +9,18 @@
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/frontend/applets/general_frontend.h"
+#include "core/hle/applet/general_backend.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/result.h"
 #include "core/hle/service/am/am.h"
-#include "core/hle/service/am/applets/general_backend.h"
 #include "core/reporter.h"
 
-namespace Service::AM::Applets {
+namespace HLE::Applet {
 
 constexpr ResultCode ERROR_INVALID_PIN{ErrorModule::PCTL, 221};
 
 static void LogCurrentStorage(AppletDataBroker& broker, std::string_view prefix) {
-    std::unique_ptr<IStorage> storage = broker.PopNormalDataToApplet();
+    std::unique_ptr<Service::AM::IStorage> storage = broker.PopNormalDataToApplet();
     for (; storage != nullptr; storage = broker.PopNormalDataToApplet()) {
         const auto data = storage->GetData();
         LOG_INFO(Service_AM,
@@ -147,7 +147,7 @@ void Auth::AuthFinished(bool successful) {
     std::vector<u8> out(sizeof(Return));
     std::memcpy(out.data(), &return_, sizeof(Return));
 
-    broker.PushNormalDataFromApplet(IStorage{out});
+    broker.PushNormalDataFromApplet(Service::AM::IStorage{out});
     broker.SignalStateChanged();
 }
 
@@ -196,7 +196,7 @@ void PhotoViewer::Execute() {
 }
 
 void PhotoViewer::ViewFinished() {
-    broker.PushNormalDataFromApplet(IStorage{{}});
+    broker.PushNormalDataFromApplet(Service::AM::IStorage{{}});
     broker.SignalStateChanged();
 }
 
@@ -231,8 +231,8 @@ void StubApplet::ExecuteInteractive() {
     LOG_WARNING(Service_AM, "called (STUBBED)");
     LogCurrentStorage(broker, "ExecuteInteractive");
 
-    broker.PushNormalDataFromApplet(IStorage{std::vector<u8>(0x1000)});
-    broker.PushInteractiveDataFromApplet(IStorage{std::vector<u8>(0x1000)});
+    broker.PushNormalDataFromApplet(Service::AM::IStorage{std::vector<u8>(0x1000)});
+    broker.PushInteractiveDataFromApplet(Service::AM::IStorage{std::vector<u8>(0x1000)});
     broker.SignalStateChanged();
 }
 
@@ -240,9 +240,9 @@ void StubApplet::Execute() {
     LOG_WARNING(Service_AM, "called (STUBBED)");
     LogCurrentStorage(broker, "Execute");
 
-    broker.PushNormalDataFromApplet(IStorage{std::vector<u8>(0x1000)});
-    broker.PushInteractiveDataFromApplet(IStorage{std::vector<u8>(0x1000)});
+    broker.PushNormalDataFromApplet(Service::AM::IStorage{std::vector<u8>(0x1000)});
+    broker.PushInteractiveDataFromApplet(Service::AM::IStorage{std::vector<u8>(0x1000)});
     broker.SignalStateChanged();
 }
 
-} // namespace Service::AM::Applets
+} // namespace HLE::Applet

--- a/src/core/hle/applet/general_backend.h
+++ b/src/core/hle/applet/general_backend.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "core/hle/service/am/applets/applets.h"
+#include "core/hle/applet/applet.h"
 
-namespace Service::AM::Applets {
+namespace HLE::Applet {
 
 enum class AuthAppletType : u32 {
     ShowParentalAuthentication,
@@ -78,4 +78,4 @@ private:
     AppletId id;
 };
 
-} // namespace Service::AM::Applets
+} // namespace HLE::Applet

--- a/src/core/hle/applet/profile_select.cpp
+++ b/src/core/hle/applet/profile_select.cpp
@@ -8,10 +8,10 @@
 #include "common/string_util.h"
 #include "core/core.h"
 #include "core/frontend/applets/profile_select.h"
+#include "core/hle/applet/profile_select.h"
 #include "core/hle/service/am/am.h"
-#include "core/hle/service/am/applets/profile_select.h"
 
-namespace Service::AM::Applets {
+namespace HLE::Applet {
 
 constexpr ResultCode ERR_USER_CANCELLED_SELECTION{ErrorModule::Account, 1};
 
@@ -49,7 +49,7 @@ void ProfileSelect::ExecuteInteractive() {
 
 void ProfileSelect::Execute() {
     if (complete) {
-        broker.PushNormalDataFromApplet(IStorage{final_data});
+        broker.PushNormalDataFromApplet(Service::AM::IStorage{final_data});
         return;
     }
 
@@ -70,8 +70,8 @@ void ProfileSelect::SelectionComplete(std::optional<Common::UUID> uuid) {
 
     final_data = std::vector<u8>(sizeof(UserSelectionOutput));
     std::memcpy(final_data.data(), &output, final_data.size());
-    broker.PushNormalDataFromApplet(IStorage{final_data});
+    broker.PushNormalDataFromApplet(Service::AM::IStorage{final_data});
     broker.SignalStateChanged();
 }
 
-} // namespace Service::AM::Applets
+} // namespace HLE::Applet

--- a/src/core/hle/applet/profile_select.h
+++ b/src/core/hle/applet/profile_select.h
@@ -8,10 +8,10 @@
 
 #include "common/common_funcs.h"
 #include "common/uuid.h"
+#include "core/hle/applet/applet.h"
 #include "core/hle/result.h"
-#include "core/hle/service/am/applets/applets.h"
 
-namespace Service::AM::Applets {
+namespace HLE::Applet {
 
 struct UserSelectionConfig {
     // TODO(DarkLordZach): RE this structure
@@ -50,4 +50,4 @@ private:
     std::vector<u8> final_data;
 };
 
-} // namespace Service::AM::Applets
+} // namespace HLE::Applet

--- a/src/core/hle/applet/software_keyboard.cpp
+++ b/src/core/hle/applet/software_keyboard.cpp
@@ -7,11 +7,11 @@
 #include "common/string_util.h"
 #include "core/core.h"
 #include "core/frontend/applets/software_keyboard.h"
+#include "core/hle/applet/software_keyboard.h"
 #include "core/hle/result.h"
 #include "core/hle/service/am/am.h"
-#include "core/hle/service/am/applets/software_keyboard.h"
 
-namespace Service::AM::Applets {
+namespace HLE::Applet {
 
 constexpr std::size_t SWKBD_OUTPUT_BUFFER_SIZE = 0x7D8;
 constexpr std::size_t SWKBD_OUTPUT_INTERACTIVE_BUFFER_SIZE = 0x7D4;
@@ -101,7 +101,7 @@ void SoftwareKeyboard::ExecuteInteractive() {
 
 void SoftwareKeyboard::Execute() {
     if (complete) {
-        broker.PushNormalDataFromApplet(IStorage{final_data});
+        broker.PushNormalDataFromApplet(Service::AM::IStorage{final_data});
         return;
     }
 
@@ -143,16 +143,16 @@ void SoftwareKeyboard::WriteText(std::optional<std::u16string> text) {
         final_data = output_main;
 
         if (complete) {
-            broker.PushNormalDataFromApplet(IStorage{output_main});
+            broker.PushNormalDataFromApplet(Service::AM::IStorage{output_main});
             broker.SignalStateChanged();
         } else {
-            broker.PushInteractiveDataFromApplet(IStorage{output_sub});
+            broker.PushInteractiveDataFromApplet(Service::AM::IStorage{output_sub});
         }
     } else {
         output_main[0] = 1;
         complete = true;
-        broker.PushNormalDataFromApplet(IStorage{output_main});
+        broker.PushNormalDataFromApplet(Service::AM::IStorage{output_main});
         broker.SignalStateChanged();
     }
 }
-} // namespace Service::AM::Applets
+} // namespace HLE::Applet

--- a/src/core/hle/applet/software_keyboard.h
+++ b/src/core/hle/applet/software_keyboard.h
@@ -11,12 +11,12 @@
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
+#include "core/hle/applet/applet.h"
 #include "core/hle/service/am/am.h"
-#include "core/hle/service/am/applets/applets.h"
 
 union ResultCode;
 
-namespace Service::AM::Applets {
+namespace HLE::Applet {
 
 enum class KeysetDisable : u32 {
     Space = 0x02,
@@ -76,4 +76,4 @@ private:
     std::vector<u8> final_data;
 };
 
-} // namespace Service::AM::Applets
+} // namespace HLE::Applet

--- a/src/core/hle/applet/web_browser.cpp
+++ b/src/core/hle/applet/web_browser.cpp
@@ -23,12 +23,12 @@
 #include "core/file_sys/vfs_types.h"
 #include "core/frontend/applets/general_frontend.h"
 #include "core/frontend/applets/web_browser.h"
+#include "core/hle/applet/web_browser.h"
 #include "core/hle/kernel/process.h"
-#include "core/hle/service/am/applets/web_browser.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/loader/loader.h"
 
-namespace Service::AM::Applets {
+namespace HLE::Applet {
 
 enum class WebArgTLVType : u16 {
     InitialURL = 0x1,
@@ -283,7 +283,7 @@ void WebBrowser::Finalize() {
     std::vector<u8> data(sizeof(WebCommonReturnValue));
     std::memcpy(data.data(), &out, sizeof(WebCommonReturnValue));
 
-    broker.PushNormalDataFromApplet(IStorage{data});
+    broker.PushNormalDataFromApplet(Service::AM::IStorage{data});
     broker.SignalStateChanged();
 
     if (!temporary_dir.empty() && FileUtil::IsDirectory(temporary_dir)) {
@@ -547,4 +547,4 @@ void WebBrowser::ExecuteOffline() {
     frontend.OpenPageLocal(filename, [this] { UnpackRomFS(); }, [this] { Finalize(); });
 }
 
-} // namespace Service::AM::Applets
+} // namespace HLE::Applet

--- a/src/core/hle/applet/web_browser.h
+++ b/src/core/hle/applet/web_browser.h
@@ -6,10 +6,11 @@
 
 #include <map>
 #include "core/file_sys/vfs_types.h"
+#include "core/hle/applet/applet.h"
+#include "core/hle/result.h"
 #include "core/hle/service/am/am.h"
-#include "core/hle/service/am/applets/applets.h"
 
-namespace Service::AM::Applets {
+namespace HLE::Applet {
 
 enum class ShimKind : u32;
 enum class ShopWebTarget;
@@ -76,4 +77,4 @@ private:
     std::string shop_extra_parameter;
 };
 
-} // namespace Service::AM::Applets
+} // namespace HLE::Applet

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -11,6 +11,10 @@
 #include "core/file_sys/control_metadata.h"
 #include "core/file_sys/patch_manager.h"
 #include "core/file_sys/savedata_factory.h"
+#include "core/hle/applet/applet.h"
+#include "core/hle/applet/profile_select.h"
+#include "core/hle/applet/software_keyboard.h"
+#include "core/hle/applet/web_browser.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
@@ -21,10 +25,6 @@
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/am/applet_ae.h"
 #include "core/hle/service/am/applet_oe.h"
-#include "core/hle/service/am/applets/applets.h"
-#include "core/hle/service/am/applets/profile_select.h"
-#include "core/hle/service/am/applets/software_keyboard.h"
-#include "core/hle/service/am/applets/web_browser.h"
 #include "core/hle/service/am/idle.h"
 #include "core/hle/service/am/omm.h"
 #include "core/hle/service/am/spsm.h"
@@ -674,7 +674,7 @@ void ICommonStateGetter::GetPerformanceMode(Kernel::HLERequestContext& ctx) {
 
 class ILibraryAppletAccessor final : public ServiceFramework<ILibraryAppletAccessor> {
 public:
-    explicit ILibraryAppletAccessor(std::shared_ptr<Applets::Applet> applet)
+    explicit ILibraryAppletAccessor(std::shared_ptr<HLE::Applet::Applet> applet)
         : ServiceFramework("ILibraryAppletAccessor"), applet(std::move(applet)) {
         // clang-format off
         static const FunctionInfo functions[] = {
@@ -816,7 +816,7 @@ private:
         rb.PushCopyObjects(applet->GetBroker().GetInteractiveDataEvent());
     }
 
-    std::shared_ptr<Applets::Applet> applet;
+    std::shared_ptr<HLE::Applet::Applet> applet;
 };
 
 void IStorage::Open(Kernel::HLERequestContext& ctx) {
@@ -917,7 +917,7 @@ ILibraryAppletCreator::~ILibraryAppletCreator() = default;
 
 void ILibraryAppletCreator::CreateLibraryApplet(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
-    const auto applet_id = rp.PopRaw<Applets::AppletId>();
+    const auto applet_id = rp.PopRaw<HLE::Applet::AppletId>();
     const auto applet_mode = rp.PopRaw<u32>();
 
     LOG_DEBUG(Service_AM, "called with applet_id={:08X}, applet_mode={:08X}",

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -18,8 +18,8 @@
 #include "core/file_sys/vfs_real.h"
 #include "core/frontend/applets/general_frontend.h"
 #include "core/frontend/scope_acquire_window_context.h"
+#include "core/hle/applet/applet.h"
 #include "core/hle/service/acc/profile_manager.h"
-#include "core/hle/service/am/applets/applets.h"
 #include "core/hle/service/hid/controllers/npad.h"
 #include "core/hle/service/hid/hid.h"
 


### PR DESCRIPTION
Pretty self-explanatory. This is much more similar to citra's layout and makes sense as on hardware `am` and applets are in different binaries/title IDs.