### PR TITLE
rasterizer_cache: Protect inherited caches from submission level

### DIFF
--- a/src/video_core/rasterizer_cache.h
+++ b/src/video_core/rasterizer_cache.h
@@ -169,6 +169,8 @@ protected:
         object->MarkAsModified(false, *this);
     }
 
+    std::recursive_mutex mutex;
+
 private:
     /// Returns a list of cached objects from the specified memory region, ordered by access time
     std::vector<T> GetSortedObjectsFromRegion(CacheAddr addr, u64 size) {
@@ -208,5 +210,4 @@ private:
     IntervalCache interval_cache; ///< Cache of objects
     u64 modified_ticks{};         ///< Counter of cache state ticks, used for in-order flushing
     VideoCore::RasterizerInterface& rasterizer;
-    std::recursive_mutex mutex;
 };

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -23,6 +23,7 @@ OGLBufferCache::OGLBufferCache(RasterizerOpenGL& rasterizer, std::size_t size)
 
 GLintptr OGLBufferCache::UploadMemory(GPUVAddr gpu_addr, std::size_t size, std::size_t alignment,
                                       bool cache) {
+    std::lock_guard lock{mutex};
     auto& memory_manager = Core::System::GetInstance().GPU().MemoryManager();
 
     // Cache management is a big overhead, so only cache entries with a given size.
@@ -62,6 +63,7 @@ GLintptr OGLBufferCache::UploadMemory(GPUVAddr gpu_addr, std::size_t size, std::
 
 GLintptr OGLBufferCache::UploadHostMemory(const void* raw_pointer, std::size_t size,
                                           std::size_t alignment) {
+    std::lock_guard lock{mutex};
     AlignBuffer(alignment);
     std::memcpy(buffer_ptr, raw_pointer, size);
     const GLintptr uploaded_offset = buffer_offset;

--- a/src/video_core/renderer_opengl/gl_global_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_global_cache.cpp
@@ -76,6 +76,7 @@ GlobalRegionCacheOpenGL::GlobalRegionCacheOpenGL(RasterizerOpenGL& rasterizer)
 GlobalRegion GlobalRegionCacheOpenGL::GetGlobalRegion(
     const GLShader::GlobalMemoryEntry& global_region,
     Tegra::Engines::Maxwell3D::Regs::ShaderStage stage) {
+    std::lock_guard lock{mutex};
 
     auto& gpu{Core::System::GetInstance().GPU()};
     auto& memory_manager{gpu.MemoryManager()};


### PR DESCRIPTION
This PR just adds the mutex protection to the highest level as race conditions could still happen.