### PR TITLE
file_sys: Ignore DeltaFragment NCAs during installation

### DIFF
--- a/src/core/file_sys/nca_metadata.h
+++ b/src/core/file_sys/nca_metadata.h
@@ -37,7 +37,7 @@ enum class ContentRecordType : u8 {
     Control = 3,
     Manual = 4,
     Legal = 5,
-    Patch = 6,
+    DeltaFragment = 6,
 };
 
 struct ContentRecord {

--- a/src/core/file_sys/nca_metadata.h
+++ b/src/core/file_sys/nca_metadata.h
@@ -35,8 +35,8 @@ enum class ContentRecordType : u8 {
     Program = 1,
     Data = 2,
     Control = 3,
-    Manual = 4,
-    Legal = 5,
+    HtmlDocument = 4,
+    LegalInformation = 5,
     DeltaFragment = 6,
 };
 

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -415,6 +415,9 @@ InstallResult RegisteredCache::InstallEntry(const NSP& nsp, bool overwrite_if_ex
     const auto cnmt_file = section0->GetFiles()[0];
     const CNMT cnmt(cnmt_file);
     for (const auto& record : cnmt.GetContentRecords()) {
+        // Ignore DeltaFragments, they are not useful to us
+        if (record.type == ContentRecordType::DeltaFragment)
+            continue;
         const auto nca = GetNCAFromNSPForID(nsp, record.nca_id);
         if (nca == nullptr)
             return InstallResult::ErrorCopyFailed;

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -99,7 +99,7 @@ ContentRecordType GetCRTypeFromNCAType(NCAContentType type) {
         return ContentRecordType::Data;
     case NCAContentType::Manual:
         // TODO(DarkLordZach): Peek at NCA contents to differentiate Manual and Legal.
-        return ContentRecordType::Manual;
+        return ContentRecordType::HtmlDocument;
     default:
         UNREACHABLE_MSG("Invalid NCAContentType={:02X}", static_cast<u8>(type));
     }

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -397,8 +397,8 @@ InstallResult RegisteredCache::InstallEntry(const NSP& nsp, bool overwrite_if_ex
     });
 
     if (meta_iter == ncas.end()) {
-        LOG_ERROR(Loader, "The XCI you are attempting to install does not have a metadata NCA and "
-                          "is therefore malformed. Double check your encryption keys.");
+        LOG_ERROR(Loader, "The file you are attempting to install does not have a metadata NCA and "
+                          "is therefore malformed. Check your encryption keys.");
         return InstallResult::ErrorMetaFailed;
     }
 

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -248,10 +248,13 @@ void NSP::ReadNCAs(const std::vector<VirtualFile>& files) {
                 auto next_file = pfs->GetFile(fmt::format("{}.nca", id_string));
 
                 if (next_file == nullptr) {
-                    LOG_WARNING(Service_FS,
-                                "NCA with ID {}.nca is listed in content metadata, but cannot "
-                                "be found in PFS. NSP appears to be corrupted.",
-                                id_string);
+                    if (rec.type != ContentRecordType::DeltaFragment) {
+                        LOG_WARNING(Service_FS,
+                                    "NCA with ID {}.nca is listed in content metadata, but cannot "
+                                    "be found in PFS. NSP appears to be corrupted.",
+                                    id_string);
+                    }
+
                     continue;
                 }
 

--- a/src/core/hle/service/am/applets/web_browser.cpp
+++ b/src/core/hle/service/am/applets/web_browser.cpp
@@ -459,10 +459,10 @@ void WebBrowser::InitializeOffline() {
     case OfflineWebSource::OfflineHtmlPage:
         // While there is an AppID TLV field, in official SW this is always ignored.
         title_id = 0;
-        type = FileSys::ContentRecordType::Manual;
+        type = FileSys::ContentRecordType::HtmlDocument;
         break;
     case OfflineWebSource::ApplicationLegalInformation:
-        type = FileSys::ContentRecordType::Legal;
+        type = FileSys::ContentRecordType::LegalInformation;
         break;
     case OfflineWebSource::SystemDataPage:
         type = FileSys::ContentRecordType::Data;

--- a/src/core/loader/nsp.cpp
+++ b/src/core/loader/nsp.cpp
@@ -168,7 +168,8 @@ ResultStatus AppLoader_NSP::ReadControlData(FileSys::NACP& nacp) {
 }
 
 ResultStatus AppLoader_NSP::ReadManualRomFS(FileSys::VirtualFile& file) {
-    const auto nca = nsp->GetNCA(nsp->GetProgramTitleID(), FileSys::ContentRecordType::Manual);
+    const auto nca =
+        nsp->GetNCA(nsp->GetProgramTitleID(), FileSys::ContentRecordType::HtmlDocument);
     if (nsp->GetStatus() != ResultStatus::Success || nca == nullptr)
         return ResultStatus::ErrorNoRomFS;
     file = nca->GetRomFS();

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -134,7 +134,7 @@ ResultStatus AppLoader_XCI::ReadControlData(FileSys::NACP& control) {
 
 ResultStatus AppLoader_XCI::ReadManualRomFS(FileSys::VirtualFile& file) {
     const auto nca = xci->GetSecurePartitionNSP()->GetNCA(xci->GetProgramTitleID(),
-                                                          FileSys::ContentRecordType::Manual);
+                                                          FileSys::ContentRecordType::HtmlDocument);
     if (xci->GetStatus() != ResultStatus::Success || nca == nullptr)
         return ResultStatus::ErrorXCIMissingPartition;
     file = nca->GetRomFS();


### PR DESCRIPTION
Fixes the installation error and warnings when installing a patch NSP without DeltaFragments. Many patch NSPs do not include these even if they're listed in the CNMT, since they are not useful outside of Nintendo's official patch installation process on real consoles, and there is no need to install them when they're present.

Also, I only renamed `ContentRecordType::Patch` since it has the most potential to cause confusion, but it may be a good idea to rename the rest of the values to their more common names as well (Manual -> HtmlDocument, Legal -> LegalInformation). I'm not 100% sure but I believe these names are official.