### PR TITLE
audren: Only manage wave buffers with a size

### DIFF
--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -217,13 +217,15 @@ std::vector<s16> AudioRenderer::VoiceState::DequeueSamples(std::size_t sample_co
     if (offset == samples.size()) {
         offset = 0;
 
-        if (!wave_buffer.is_looping) {
+        if (!wave_buffer.is_looping && wave_buffer.buffer_sz) {
             SetWaveIndex(wave_index + 1);
         }
 
-        out_status.wave_buffer_consumed++;
+        if (wave_buffer.buffer_sz) {
+            out_status.wave_buffer_consumed++;
+        }
 
-        if (wave_buffer.end_of_stream) {
+        if (wave_buffer.end_of_stream || !wave_buffer.buffer_sz) {
             info.play_state = PlayState::Paused;
         }
     }

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -225,7 +225,7 @@ std::vector<s16> AudioRenderer::VoiceState::DequeueSamples(std::size_t sample_co
             out_status.wave_buffer_consumed++;
         }
 
-        if (wave_buffer.end_of_stream || !wave_buffer.buffer_sz) {
+        if (wave_buffer.end_of_stream || wave_buffer.buffer_sz == 0) {
             info.play_state = PlayState::Paused;
         }
     }


### PR DESCRIPTION
We shouldn't be incrementing if wave buffers are empty. They are considered invalid/unused wave buffers.

This fixes the issue of certain sounds looping when they shouldn't