### PR TITLE
acc: Implement IProfileEditor interface and 'Store'/'StoreWithImage' commands

### DIFF
--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -350,6 +350,17 @@ void Module::Interface::IsUserAccountSwitchLocked(Kernel::HLERequestContext& ctx
     rb.Push(is_locked);
 }
 
+void Module::Interface::GetProfileEditor(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    Common::UUID user_id = rp.PopRaw<Common::UUID>();
+
+    LOG_DEBUG(Service_ACC, "called, user_id={}", user_id.Format());
+
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    rb.Push(RESULT_SUCCESS);
+    rb.PushIpcInterface<IProfileEditor>(user_id, *profile_manager);
+}
+
 void Module::Interface::TrySelectUserWithoutInteraction(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_ACC, "called");
     // A u8 is passed into this function which we can safely ignore. It's to determine if we have

--- a/src/core/hle/service/acc/acc.h
+++ b/src/core/hle/service/acc/acc.h
@@ -30,6 +30,7 @@ public:
         void IsUserRegistrationRequestPermitted(Kernel::HLERequestContext& ctx);
         void TrySelectUserWithoutInteraction(Kernel::HLERequestContext& ctx);
         void IsUserAccountSwitchLocked(Kernel::HLERequestContext& ctx);
+        void GetProfileEditor(Kernel::HLERequestContext& ctx);
 
     protected:
         std::shared_ptr<Module> module;

--- a/src/core/hle/service/acc/acc_su.cpp
+++ b/src/core/hle/service/acc/acc_su.cpp
@@ -41,7 +41,7 @@ ACC_SU::ACC_SU(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> p
         {202, nullptr, "CancelUserRegistration"},
         {203, nullptr, "DeleteUser"},
         {204, nullptr, "SetUserPosition"},
-        {205, nullptr, "GetProfileEditor"},
+        {205, &ACC_SU::GetProfileEditor, "GetProfileEditor"},
         {206, nullptr, "CompleteUserRegistrationForcibly"},
         {210, nullptr, "CreateFloatingRegistrationRequest"},
         {230, nullptr, "AuthenticateServiceAsync"},

--- a/src/core/hle/service/acc/profile_manager.cpp
+++ b/src/core/hle/service/acc/profile_manager.cpp
@@ -305,6 +305,17 @@ bool ProfileManager::SetProfileBase(UUID uuid, const ProfileBase& profile_new) {
     return true;
 }
 
+bool ProfileManager::SetProfileBaseAndData(Common::UUID uuid, const ProfileBase& profile_new,
+                                           const ProfileData& data_new) {
+    const auto index = GetUserIndex(uuid);
+    if (index.has_value() && SetProfileBase(uuid, profile_new)) {
+        profiles[*index].data = data_new;
+        return true;
+    }
+
+    return false;
+}
+
 void ProfileManager::ParseUserSaveFile() {
     FileUtil::IOFile save(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
                               ACC_SAVE_AVATORS_BASE_PATH + "profiles.dat",

--- a/src/core/hle/service/acc/profile_manager.h
+++ b/src/core/hle/service/acc/profile_manager.h
@@ -91,6 +91,8 @@ public:
 
     bool RemoveUser(Common::UUID uuid);
     bool SetProfileBase(Common::UUID uuid, const ProfileBase& profile_new);
+    bool SetProfileBaseAndData(Common::UUID uuid, const ProfileBase& profile_new,
+                               const ProfileData& data_new);
 
 private:
     void ParseUserSaveFile();


### PR DESCRIPTION
This is used by homebrew/libnx and allows easy editing of user name, timestamp, data and image.