### PR TITLE
yuzu: Move CPU Jit setting to Debug tab

### DIFF
--- a/src/core/core_cpu.cpp
+++ b/src/core/core_cpu.cpp
@@ -53,7 +53,7 @@ bool CpuBarrier::Rendezvous() {
 Cpu::Cpu(System& system, ExclusiveMonitor& exclusive_monitor, CpuBarrier& cpu_barrier,
          std::size_t core_index)
     : cpu_barrier{cpu_barrier}, core_timing{system.CoreTiming()}, core_index{core_index} {
-    if (Settings::values.use_cpu_jit) {
+    if (Settings::values.cpu_jit_enabled) {
 #ifdef ARCHITECTURE_x86_64
         arm_interface = std::make_unique<ARM_Dynarmic>(system, exclusive_monitor, core_index);
 #else
@@ -70,7 +70,7 @@ Cpu::Cpu(System& system, ExclusiveMonitor& exclusive_monitor, CpuBarrier& cpu_ba
 Cpu::~Cpu() = default;
 
 std::unique_ptr<ExclusiveMonitor> Cpu::MakeExclusiveMonitor(std::size_t num_cores) {
-    if (Settings::values.use_cpu_jit) {
+    if (Settings::values.cpu_jit_enabled) {
 #ifdef ARCHITECTURE_x86_64
         return std::make_unique<DynarmicExclusiveMonitor>(num_cores);
 #else

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -85,7 +85,7 @@ void LogSettings() {
     LogSetting("System_RngSeed", Settings::values.rng_seed.value_or(0));
     LogSetting("System_CurrentUser", Settings::values.current_user);
     LogSetting("System_LanguageIndex", Settings::values.language_index);
-    LogSetting("Core_UseCpuJit", Settings::values.use_cpu_jit);
+    LogSetting("Core_CpuJitEnabled", Settings::values.cpu_jit_enabled);
     LogSetting("Core_UseMultiCore", Settings::values.use_multi_core);
     LogSetting("Renderer_UseResolutionFactor", Settings::values.resolution_factor);
     LogSetting("Renderer_UseFrameLimit", Settings::values.use_frame_limit);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -378,7 +378,7 @@ struct Values {
     std::atomic_bool is_device_reload_pending{true};
 
     // Core
-    bool use_cpu_jit;
+    bool cpu_jit_enabled;
     bool use_multi_core;
 
     // Data Storage

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -168,7 +168,7 @@ void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader) {
     AddField(Telemetry::FieldType::UserConfig, "Audio_SinkId", Settings::values.sink_id);
     AddField(Telemetry::FieldType::UserConfig, "Audio_EnableAudioStretching",
              Settings::values.enable_audio_stretching);
-    AddField(Telemetry::FieldType::UserConfig, "Core_UseCpuJit", Settings::values.use_cpu_jit);
+    AddField(Telemetry::FieldType::UserConfig, "Core_UseCpuJit", Settings::values.cpu_jit_enabled);
     AddField(Telemetry::FieldType::UserConfig, "Core_UseMultiCore",
              Settings::values.use_multi_core);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_ResolutionFactor",

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -436,7 +436,8 @@ void Config::ReadControlValues() {
 void Config::ReadCoreValues() {
     qt_config->beginGroup(QStringLiteral("Core"));
 
-    Settings::values.use_cpu_jit = ReadSetting(QStringLiteral("use_cpu_jit"), true).toBool();
+    Settings::values.cpu_jit_enabled =
+        ReadSetting(QStringLiteral("cpu_jit_enabled"), true).toBool();
     Settings::values.use_multi_core = ReadSetting(QStringLiteral("use_multi_core"), false).toBool();
 
     qt_config->endGroup();
@@ -829,7 +830,7 @@ void Config::SaveControlValues() {
 void Config::SaveCoreValues() {
     qt_config->beginGroup(QStringLiteral("Core"));
 
-    WriteSetting(QStringLiteral("use_cpu_jit"), Settings::values.use_cpu_jit, true);
+    WriteSetting(QStringLiteral("cpu_jit_enabled"), Settings::values.cpu_jit_enabled, true);
     WriteSetting(QStringLiteral("use_multi_core"), Settings::values.use_multi_core, false);
 
     qt_config->endGroup();

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -22,8 +22,6 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
 
     connect(ui->toggle_deepscan, &QCheckBox::stateChanged, this,
             [] { UISettings::values.is_game_list_reload_pending.exchange(true); });
-
-    ui->use_cpu_jit->setEnabled(!Core::System::GetInstance().IsPoweredOn());
 }
 
 ConfigureGeneral::~ConfigureGeneral() = default;
@@ -33,7 +31,6 @@ void ConfigureGeneral::SetConfiguration() {
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing);
     ui->toggle_user_on_boot->setChecked(UISettings::values.select_user_on_boot);
     ui->theme_combobox->setCurrentIndex(ui->theme_combobox->findData(UISettings::values.theme));
-    ui->use_cpu_jit->setChecked(Settings::values.use_cpu_jit);
 }
 
 void ConfigureGeneral::ApplyConfiguration() {
@@ -42,8 +39,6 @@ void ConfigureGeneral::ApplyConfiguration() {
     UISettings::values.select_user_on_boot = ui->toggle_user_on_boot->isChecked();
     UISettings::values.theme =
         ui->theme_combobox->itemData(ui->theme_combobox->currentIndex()).toString();
-
-    Settings::values.use_cpu_jit = ui->use_cpu_jit->isChecked();
 }
 
 void ConfigureGeneral::changeEvent(QEvent* event) {

--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -51,26 +51,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QGroupBox" name="PerformanceGroupBox">
-       <property name="title">
-        <string>Performance</string>
-       </property>
-       <layout class="QHBoxLayout" name="PerformanceHorizontalLayout">
-        <item>
-         <layout class="QVBoxLayout" name="PerformanceVerticalLayout">
-          <item>
-           <widget class="QCheckBox" name="use_cpu_jit">
-            <property name="text">
-             <string>Enable CPU JIT</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
       <widget class="QGroupBox" name="theme_group_box">
        <property name="title">
         <string>Theme</string>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -340,7 +340,7 @@ void Config::ReadValues() {
     }
 
     // Core
-    Settings::values.use_cpu_jit = sdl2_config->GetBoolean("Core", "use_cpu_jit", true);
+    Settings::values.cpu_jit_enabled = sdl2_config->GetBoolean("Core", "cpu_jit_enabled", true);
     Settings::values.use_multi_core = sdl2_config->GetBoolean("Core", "use_multi_core", false);
 
     // Renderer

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -78,7 +78,7 @@ touch_device=
 [Core]
 # Whether to use the Just-In-Time (JIT) compiler for CPU emulation
 # 0: Interpreter (slow), 1 (default): JIT (fast)
-use_cpu_jit =
+cpu_jit_enabled =
 
 # Whether to use multi-core for CPU emulation
 # 0 (default): Disabled, 1: Enabled

--- a/src/yuzu_tester/config.cpp
+++ b/src/yuzu_tester/config.cpp
@@ -114,7 +114,7 @@ void Config::ReadValues() {
     }
 
     // Core
-    Settings::values.use_cpu_jit = sdl2_config->GetBoolean("Core", "use_cpu_jit", true);
+    Settings::values.cpu_jit_enabled = sdl2_config->GetBoolean("Core", "cpu_jit_enabled", true);
     Settings::values.use_multi_core = sdl2_config->GetBoolean("Core", "use_multi_core", false);
 
     // Renderer

--- a/src/yuzu_tester/default_ini.h
+++ b/src/yuzu_tester/default_ini.h
@@ -10,7 +10,7 @@ const char* sdl2_config_file = R"(
 [Core]
 # Whether to use the Just-In-Time (JIT) compiler for CPU emulation
 # 0: Interpreter (slow), 1 (default): JIT (fast)
-use_cpu_jit =
+cpu_jit_enabled =
 
 # Whether to use multi-core for CPU emulation
 # 0 (default): Disabled, 1: Enabled


### PR DESCRIPTION
A normal user shouldn't change this, as it will slow down the emulation and can lead to bugs or crashes. So let's move the setting to Debug, like we do for Citra already.