### PR TITLE
Implement a Host based GPU Clock.

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
@@ -9,6 +9,8 @@
 #include "core/core_timing.h"
 #include "core/core_timing_util.h"
 #include "core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.h"
+#include "video_core/gpu.h"
+#include "video_core/gpu_clock.h"
 
 namespace Service::Nvidia::Devices {
 
@@ -185,7 +187,7 @@ u32 nvhost_ctrl_gpu::GetGpuTime(const std::vector<u8>& input, std::vector<u8>& o
 
     IoctlGetGpuTime params{};
     std::memcpy(&params, input.data(), input.size());
-    const auto ns = Core::Timing::CyclesToNs(Core::System::GetInstance().CoreTiming().GetTicks());
+    const auto ns = Core::System::GetInstance().GPU().GetClock().GetNsTime();
     params.gpu_time = static_cast<u64_le>(ns.count());
     std::memcpy(output.data(), &params, output.size());
     return 0;

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
@@ -187,7 +187,7 @@ u32 nvhost_ctrl_gpu::GetGpuTime(const std::vector<u8>& input, std::vector<u8>& o
 
     IoctlGetGpuTime params{};
     std::memcpy(&params, input.data(), input.size());
-    const auto ns = Core::System::GetInstance().GPU().GetClock().GetNsTime();
+    const auto ns = Core::System::GetInstance().GPU().Clock().GetNsTime();
     params.gpu_time = static_cast<u64_le>(ns.count());
     std::memcpy(output.data(), &params, output.size());
     return 0;

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -22,6 +22,8 @@ add_library(video_core STATIC
     gpu.h
     gpu_asynch.cpp
     gpu_asynch.h
+    gpu_clock.cpp
+    gpu_clock.h
     gpu_synch.cpp
     gpu_synch.h
     gpu_thread.cpp

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -9,6 +9,7 @@
 #include "core/core_timing.h"
 #include "video_core/debug_utils/debug_utils.h"
 #include "video_core/engines/maxwell_3d.h"
+#include "video_core/gpu_clock.h"
 #include "video_core/memory_manager.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/textures/texture.h"
@@ -330,7 +331,7 @@ void Maxwell3D::ProcessQueryGet() {
             LongQueryResult query_result{};
             query_result.value = result;
             // TODO(Subv): Generate a real GPU timestamp and write it here instead of CoreTiming
-            query_result.timestamp = system.CoreTiming().GetTicks();
+            query_result.timestamp = system.GPU().GetClock().GetNsTime().count();
             memory_manager.WriteBlock(sequence_address, &query_result, sizeof(query_result));
         }
         dirty_flags.OnMemoryWrite();

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -330,8 +330,7 @@ void Maxwell3D::ProcessQueryGet() {
             // wait queues.
             LongQueryResult query_result{};
             query_result.value = result;
-            // TODO(Subv): Generate a real GPU timestamp and write it here instead of CoreTiming
-            query_result.timestamp = system.GPU().GetClock().GetNsTime().count();
+            query_result.timestamp = system.GPU().Clock().GetNsTime().count();
             memory_manager.WriteBlock(sequence_address, &query_result, sizeof(query_result));
         }
         dirty_flags.OnMemoryWrite();

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -296,7 +296,7 @@ void GPU::ProcessSemaphoreTriggerMethod() {
         block.sequence = regs.semaphore_sequence;
         // TODO(Kmather73): Generate a real GPU timestamp and write it here instead of
         // CoreTiming
-        block.timestamp = Core::System::GetInstance().CoreTiming().GetTicks();
+        block.timestamp = clock->GetNsTime().count();
         memory_manager->WriteBlock(regs.semaphore_address.SemaphoreAddress(), &block,
                                    sizeof(block));
     } else {

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -30,10 +30,9 @@ u32 FramebufferConfig::BytesPerPixel(PixelFormat format) {
     UNREACHABLE();
 }
 
-GPU::GPU(Core::System& system, VideoCore::RendererBase& renderer)
-    : renderer{renderer} {
-    clock = std::make_unique<Tegra::GPUClock>();
+GPU::GPU(Core::System& system, VideoCore::RendererBase& renderer) : renderer{renderer} {
     auto& rasterizer{renderer.Rasterizer()};
+    clock = std::make_unique<Tegra::GPUClock>();
     memory_manager = std::make_unique<Tegra::MemoryManager>(rasterizer);
     dma_pusher = std::make_unique<Tegra::DmaPusher>(*this);
     maxwell_3d = std::make_unique<Engines::Maxwell3D>(system, rasterizer, *memory_manager);
@@ -44,6 +43,14 @@ GPU::GPU(Core::System& system, VideoCore::RendererBase& renderer)
 }
 
 GPU::~GPU() = default;
+
+Tegra::GPUClock& GPU::Clock() {
+    return *clock;
+}
+
+const Tegra::GPUClock& GPU::Clock() const {
+    return *clock;
+}
 
 Engines::Maxwell3D& GPU::Maxwell3D() {
     return *maxwell_3d;
@@ -67,14 +74,6 @@ DmaPusher& GPU::DmaPusher() {
 
 const DmaPusher& GPU::DmaPusher() const {
     return *dma_pusher;
-}
-
-Tegra::GPUClock& GPU::GetClock() {
-    return *clock;
-}
-
-const Tegra::GPUClock& GPU::GetClock() const {
-    return *clock;
 }
 
 u32 RenderTargetBytesPerPixel(RenderTargetFormat format) {

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -12,6 +12,7 @@
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/engines/maxwell_dma.h"
 #include "video_core/gpu.h"
+#include "video_core/gpu_clock.h"
 #include "video_core/memory_manager.h"
 #include "video_core/renderer_base.h"
 
@@ -29,7 +30,9 @@ u32 FramebufferConfig::BytesPerPixel(PixelFormat format) {
     UNREACHABLE();
 }
 
-GPU::GPU(Core::System& system, VideoCore::RendererBase& renderer) : renderer{renderer} {
+GPU::GPU(Core::System& system, VideoCore::RendererBase& renderer)
+    : renderer{renderer} {
+    clock = std::make_unique<Tegra::GPUClock>();
     auto& rasterizer{renderer.Rasterizer()};
     memory_manager = std::make_unique<Tegra::MemoryManager>(rasterizer);
     dma_pusher = std::make_unique<Tegra::DmaPusher>(*this);
@@ -64,6 +67,14 @@ DmaPusher& GPU::DmaPusher() {
 
 const DmaPusher& GPU::DmaPusher() const {
     return *dma_pusher;
+}
+
+Tegra::GPUClock& GPU::GetClock() {
+    return *clock;
+}
+
+const Tegra::GPUClock& GPU::GetClock() const {
+    return *clock;
 }
 
 u32 RenderTargetBytesPerPixel(RenderTargetFormat format) {

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -80,6 +80,7 @@ u32 DepthFormatBytesPerPixel(DepthFormat format);
 
 struct CommandListHeader;
 class DebugContext;
+class GPUClock;
 
 /**
  * Struct describing framebuffer configuration
@@ -166,6 +167,12 @@ public:
 
     /// Returns a const reference to the GPU DMA pusher.
     const Tegra::DmaPusher& DmaPusher() const;
+
+    /// Returns a reference to the GPU's Clock.
+    Tegra::GPUClock& GetClock();
+
+    /// Returns a const reference to the GPU's Clock.
+    const Tegra::GPUClock& GetClock() const;
 
     struct Regs {
         static constexpr size_t NUM_REGS = 0x100;
@@ -262,6 +269,8 @@ private:
     std::unique_ptr<Engines::MaxwellDMA> maxwell_dma;
     /// Inline memory engine
     std::unique_ptr<Engines::KeplerMemory> kepler_memory;
+
+    std::unique_ptr<GPUClock> clock;
 };
 
 #define ASSERT_REG_POSITION(field_name, position)                                                  \

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -150,6 +150,12 @@ public:
     /// Calls a GPU method.
     void CallMethod(const MethodCall& method_call);
 
+    /// Returns a reference to the GPU's Clock.
+    Tegra::GPUClock& Clock();
+
+    /// Returns a const reference to the GPU's Clock.
+    const Tegra::GPUClock& Clock() const;
+
     /// Returns a reference to the Maxwell3D GPU engine.
     Engines::Maxwell3D& Maxwell3D();
 
@@ -167,12 +173,6 @@ public:
 
     /// Returns a const reference to the GPU DMA pusher.
     const Tegra::DmaPusher& DmaPusher() const;
-
-    /// Returns a reference to the GPU's Clock.
-    Tegra::GPUClock& GetClock();
-
-    /// Returns a const reference to the GPU's Clock.
-    const Tegra::GPUClock& GetClock() const;
 
     struct Regs {
         static constexpr size_t NUM_REGS = 0x100;
@@ -255,6 +255,7 @@ protected:
     VideoCore::RendererBase& renderer;
 
 private:
+    std::unique_ptr<GPUClock> clock;
     std::unique_ptr<Tegra::MemoryManager> memory_manager;
 
     /// Mapping of command subchannels to their bound engine ids
@@ -269,8 +270,6 @@ private:
     std::unique_ptr<Engines::MaxwellDMA> maxwell_dma;
     /// Inline memory engine
     std::unique_ptr<Engines::KeplerMemory> kepler_memory;
-
-    std::unique_ptr<GPUClock> clock;
 };
 
 #define ASSERT_REG_POSITION(field_name, position)                                                  \

--- a/src/video_core/gpu_clock.cpp
+++ b/src/video_core/gpu_clock.cpp
@@ -1,0 +1,19 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/uint128.h"
+#include "video_core/gpu_clock.h"
+
+namespace Tegra {
+
+GPUClock::GPUClock() = default;
+GPUClock::~GPUClock() = default;
+
+u64 GPUClock::GetTicks() const {
+    const u64 ns = GetNsTime().count();
+    const u128 middle = Common::Multiply64Into128(ns, gpu_clock);
+    return Common::Divide128On32(middle, 1000000000).first;
+}
+
+} // namespace Tegra

--- a/src/video_core/gpu_clock.cpp
+++ b/src/video_core/gpu_clock.cpp
@@ -11,9 +11,10 @@ GPUClock::GPUClock() = default;
 GPUClock::~GPUClock() = default;
 
 u64 GPUClock::GetTicks() const {
+    constexpr u32 ns_per_second = 1000000000U;
     const u64 ns = GetNsTime().count();
     const u128 middle = Common::Multiply64Into128(ns, gpu_clock);
-    return Common::Divide128On32(middle, 1000000000).first;
+    return Common::Divide128On32(middle, ns_per_second).first;
 }
 
 } // namespace Tegra

--- a/src/video_core/gpu_clock.h
+++ b/src/video_core/gpu_clock.h
@@ -1,0 +1,55 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <chrono>
+
+#include "common/common_types.h"
+
+namespace Tegra {
+
+enum GPUClockProfiles : u64 {
+    Profile1 = 384000000,
+    Profile2 = 768000000,
+    Profile3 = 691200000,
+    Profile4 = 230400000,
+    Profile5 = 307000000,
+    Profile6 = 460800000,
+};
+
+class GPUClock {
+public:
+    GPUClock();
+    ~GPUClock();
+
+    std::chrono::nanoseconds GetNsTime() const {
+        Clock::time_point now = Clock::now();
+        return std::chrono::duration_cast<std::chrono::nanoseconds>(now - start_walltime);
+    }
+
+    std::chrono::microseconds GetUsTime() const {
+        Clock::time_point now = Clock::now();
+        return std::chrono::duration_cast<std::chrono::microseconds>(now - start_walltime);
+    }
+
+    std::chrono::milliseconds GetMsTime() const {
+        Clock::time_point now = Clock::now();
+        return std::chrono::duration_cast<std::chrono::milliseconds>(now - start_walltime);
+    }
+
+    u64 GetTicks() const;
+
+    void SetGPUClock(const u64 new_clock) {
+        gpu_clock = new_clock;
+    }
+
+private:
+    using Clock = std::chrono::system_clock;
+    Clock::time_point start_walltime = Clock::now();
+
+    u64 gpu_clock{GPUClockProfiles::Profile1};
+};
+
+} // namespace Tegra

--- a/src/video_core/gpu_clock.h
+++ b/src/video_core/gpu_clock.h
@@ -2,6 +2,20 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+/**
+ * The GPU runs at different clockspeeds and paces than the CPU. It requires
+ * its own timer in order to keep it at check. Sadly a cycle timer is unfeasible
+ * for the GPU since it's pretty hard to accurately estimate the length of time
+ * actions like Draw, DispatchCompute and Clear can take (varying very unproportionally)
+ * Using the CPU's clock also has it's disadvantages:
+ * - If the CPU is idle while the GPU is running, the timer will advance unproportionally
+ * due to how CPU's idle timing works.
+ * - If the GPU is synced, the timer won't advance until control is given back to
+ * the CPU.
+ * For all these reasons, it has been decided to use a host timer for the GPU.
+ *
+ **/
+
 #pragma once
 
 #include <chrono>
@@ -24,22 +38,22 @@ public:
     GPUClock();
     ~GPUClock();
 
+    u64 GetTicks() const;
+
     std::chrono::nanoseconds GetNsTime() const {
-        Clock::time_point now = Clock::now();
+        const Clock::time_point now = Clock::now();
         return std::chrono::duration_cast<std::chrono::nanoseconds>(now - start_walltime);
     }
 
     std::chrono::microseconds GetUsTime() const {
-        Clock::time_point now = Clock::now();
+        const Clock::time_point now = Clock::now();
         return std::chrono::duration_cast<std::chrono::microseconds>(now - start_walltime);
     }
 
     std::chrono::milliseconds GetMsTime() const {
-        Clock::time_point now = Clock::now();
+        const Clock::time_point now = Clock::now();
         return std::chrono::duration_cast<std::chrono::milliseconds>(now - start_walltime);
     }
-
-    u64 GetTicks() const;
 
     void SetGPUClock(const u64 new_clock) {
         gpu_clock = new_clock;


### PR DESCRIPTION
The GPU runs at different clockspeeds and paces than the CPU. It requires its own timer in order to keep it at check. Sadly a cycle timer is unfeasible for the GPU since it's pretty hard to accurately estimate the length of time actions like Draw, DispatchCompute and Clear can take (varying very unproportionally)
Using the CPU's clock also has it's disadvantages:

- If the CPU is idle while the GPU is running, the timer will advance unproportionally due to how CPU's idle timing works.

- If the GPU is synced, the timer won't advance until control is given back to the CPU.

For all these reasons, it has been decided to use a host timer for the GPU.