### PR TITLE
loader: Implement various 'information' commands and add ro:1 service

### DIFF
--- a/src/core/file_sys/program_metadata.cpp
+++ b/src/core/file_sys/program_metadata.cpp
@@ -48,6 +48,15 @@ Loader::ResultStatus ProgramMetadata::Load(VirtualFile file) {
         return Loader::ResultStatus::ErrorBadKernelCapabilityDescriptors;
     }
 
+    acid_file_access_raw =
+        file->ReadBytes(acid_header.fac_size, npdm_header.acid_offset + acid_header.fac_offset);
+    aci0_file_access_raw =
+        file->ReadBytes(aci_header.fah_size, npdm_header.aci_offset + aci_header.fah_offset);
+    acid_service_access_raw =
+        file->ReadBytes(acid_header.sac_size, npdm_header.acid_offset + acid_header.sac_offset);
+    aci0_service_access_raw =
+        file->ReadBytes(aci_header.sac_size, npdm_header.aci_offset + aci_header.sac_offset);
+
     return Loader::ResultStatus::Success;
 }
 
@@ -64,6 +73,22 @@ void ProgramMetadata::LoadManual(bool is_64_bit, ProgramAddressSpaceType address
     aci_header.title_id = title_id;
     aci_file_access.permissions = filesystem_permissions;
     aci_kernel_capabilities = std ::move(capabilities);
+}
+
+std::vector<u8> ProgramMetadata::GetACIDFileAccessControl() const {
+    return acid_file_access_raw;
+}
+
+std::vector<u8> ProgramMetadata::GetACI0FileAccessControl() const {
+    return aci0_file_access_raw;
+}
+
+std::vector<u8> ProgramMetadata::GetACIDServiceAccessControl() const {
+    return acid_service_access_raw;
+}
+
+std::vector<u8> ProgramMetadata::GetACI0ServiceAccessControl() const {
+    return aci0_service_access_raw;
 }
 
 bool ProgramMetadata::Is64BitProgram() const {

--- a/src/core/file_sys/program_metadata.h
+++ b/src/core/file_sys/program_metadata.h
@@ -61,6 +61,11 @@ public:
     u32 GetSystemResourceSize() const;
     const KernelCapabilityDescriptors& GetKernelCapabilities() const;
 
+    std::vector<u8> GetACIDFileAccessControl() const;
+    std::vector<u8> GetACI0FileAccessControl() const;
+    std::vector<u8> GetACIDServiceAccessControl() const;
+    std::vector<u8> GetACI0ServiceAccessControl() const;
+
     void Print() const;
 
 private:
@@ -163,6 +168,11 @@ private:
 
     FileAccessControl acid_file_access;
     FileAccessHeader aci_file_access;
+
+    std::vector<u8> acid_file_access_raw;
+    std::vector<u8> aci0_file_access_raw;
+    std::vector<u8> acid_service_access_raw;
+    std::vector<u8> aci0_service_access_raw;
 
     KernelCapabilityDescriptors aci_kernel_capabilities;
 };

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -166,6 +166,8 @@ ResultCode Process::ClearSignalState() {
 }
 
 ResultCode Process::LoadFromMetadata(const FileSys::ProgramMetadata& metadata) {
+    program_metadata = std::make_unique<FileSys::ProgramMetadata>(metadata);
+
     program_id = metadata.GetTitleID();
     ideal_core = metadata.GetMainThreadCore();
     is_64bit_process = metadata.Is64BitProgram();
@@ -278,6 +280,8 @@ void Process::FreeTLSRegion(VAddr tls_address) {
 
 void Process::LoadModule(CodeSet module_, VAddr base_addr) {
     const auto memory = std::make_shared<PhysicalMemory>(std::move(module_.memory));
+
+    modules.insert_or_assign(base_addr, memory);
 
     const auto MapSegment = [&](const CodeSet::Segment& segment, VMAPermission permissions,
                                 MemoryState memory_state) {

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -277,6 +277,14 @@ public:
 
     void LoadModule(CodeSet module_, VAddr base_addr);
 
+    const std::map<VAddr, std::shared_ptr<std::vector<u8>>>& GetModules() const {
+        return modules;
+    }
+
+    const FileSys::ProgramMetadata& GetProgramMetadata() const {
+        return *program_metadata;
+    }
+
     ///////////////////////////////////////////////////////////////////////////////////////////////
     // Thread-local storage management
 
@@ -380,6 +388,12 @@ private:
 
     /// Name of this process
     std::string name;
+
+    /// List of loaded modules, keyed by base address
+    std::map<VAddr, std::shared_ptr<std::vector<u8>>> modules;
+
+    /// Program Metadata
+    std::unique_ptr<FileSys::ProgramMetadata> program_metadata;
 };
 
 } // namespace Kernel

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -167,7 +167,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
-        rb.Push(write_size);
+        rb.Push(static_cast<u32>(write_size));
     }
 
     const std::vector<Kernel::SharedPtr<Kernel::Process>>& process_list;
@@ -292,7 +292,7 @@ public:
 
 class RelocatableObject final : public ServiceFramework<RelocatableObject> {
 public:
-    explicit RelocatableObject() : ServiceFramework{"ldr:ro"} {
+    explicit RelocatableObject(const char* name) : ServiceFramework{name} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &RelocatableObject::LoadNro, "LoadNro"},

--- a/src/core/hle/service/ldr/ldr.h
+++ b/src/core/hle/service/ldr/ldr.h
@@ -11,6 +11,6 @@ class ServiceManager;
 namespace Service::LDR {
 
 /// Registers all LDR services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(Core::System& system);
 
 } // namespace Service::LDR

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -225,7 +225,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system) {
     HID::InstallInterfaces(*sm);
     LBL::InstallInterfaces(*sm);
     LDN::InstallInterfaces(*sm);
-    LDR::InstallInterfaces(*sm);
+    LDR::InstallInterfaces(system);
     LM::InstallInterfaces(*sm);
     Migration::InstallInterfaces(*sm);
     Mii::InstallInterfaces(*sm);


### PR DESCRIPTION
- Implement `DebugMonitor` `GetNsoInfos` -- returns an array of NSOInfo entries which contain the build ID, size, and mapped address of all NSOs for the current application.
- Implement `ProcessManager` `GetProgramInfo` -- Parses the current application's NPDM and copies select fields into a ProgramInfo struct and returns that.
- Implement `ProcessManager` `RegisterTitle` and `UnregisterTitle` -- Upon registry the title's ID and storage are added to an internal list and the index is returned. The index can later be passed to UnregisterTitle to remove the entry.
- Add service registration for `ro:1` service. This creates the same objects as the `ldr:ro` service and was added in 7.0.0.

Researched with IDA on 8.0.1.