### PR TITLE
vk_scheduler: Drop execution context in favor of views

### DIFF
--- a/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
@@ -109,8 +109,8 @@ void VKBufferCache::Reserve(std::size_t max_size) {
     }
 }
 
-VKExecutionContext VKBufferCache::Send(VKExecutionContext exctx) {
-    return stream_buffer->Send(exctx, buffer_offset - buffer_offset_base);
+void VKBufferCache::Send() {
+    stream_buffer->Send(buffer_offset - buffer_offset_base);
 }
 
 void VKBufferCache::AlignBuffer(std::size_t alignment) {

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.h
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.h
@@ -77,7 +77,7 @@ public:
     void Reserve(std::size_t max_size);
 
     /// Ensures that the set data is sent to the device.
-    [[nodiscard]] VKExecutionContext Send(VKExecutionContext exctx);
+    void Send();
 
     /// Returns the buffer cache handle.
     vk::Buffer GetBuffer() const {

--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -19,23 +19,19 @@ VKScheduler::VKScheduler(const VKDevice& device, VKResourceManager& resource_man
 
 VKScheduler::~VKScheduler() = default;
 
-VKExecutionContext VKScheduler::GetExecutionContext() const {
-    return VKExecutionContext(current_fence, current_cmdbuf);
-}
-
-VKExecutionContext VKScheduler::Flush(vk::Semaphore semaphore) {
+void VKScheduler::Flush(bool release_fence, vk::Semaphore semaphore) {
     SubmitExecution(semaphore);
-    current_fence->Release();
+    if (release_fence)
+        current_fence->Release();
     AllocateNewContext();
-    return GetExecutionContext();
 }
 
-VKExecutionContext VKScheduler::Finish(vk::Semaphore semaphore) {
+void VKScheduler::Finish(bool release_fence, vk::Semaphore semaphore) {
     SubmitExecution(semaphore);
     current_fence->Wait();
-    current_fence->Release();
+    if (release_fence)
+        current_fence->Release();
     AllocateNewContext();
-    return GetExecutionContext();
 }
 
 void VKScheduler::SubmitExecution(vk::Semaphore semaphore) {

--- a/src/video_core/renderer_vulkan/vk_stream_buffer.h
+++ b/src/video_core/renderer_vulkan/vk_stream_buffer.h
@@ -37,7 +37,7 @@ public:
     std::tuple<u8*, u64, bool> Reserve(u64 size);
 
     /// Ensures that "size" bytes of memory are available to the GPU, potentially recording a copy.
-    [[nodiscard]] VKExecutionContext Send(VKExecutionContext exctx, u64 size);
+    void Send(u64 size);
 
     vk::Buffer GetBuffer() const {
         return *buffer;


### PR DESCRIPTION
Instead of passing by copy an execution context through out the whole Vulkan call hierarchy, use a command buffer view and fence view approach.

This internally dereferences the command buffer or fence forcing the user to be unable to use an outdated version of it on normal usage. It is still possible to keep store an outdated if it is casted to `VKFence&` or `vk::CommandBuffer`.

While changing this file, add an extra parameter for Flush and Finish to allow releasing the fence from this calls.