### PR TITLE
am/kernel: Fix various bugs related to applet signalling and software keyboard

### DIFF
--- a/src/core/hle/kernel/transfer_memory.cpp
+++ b/src/core/hle/kernel/transfer_memory.cpp
@@ -23,6 +23,8 @@ SharedPtr<TransferMemory> TransferMemory::Create(KernelCore& kernel, VAddr base_
     transfer_memory->owner_permissions = permissions;
     transfer_memory->owner_process = kernel.CurrentProcess();
 
+    transfer_memory->MapMemory(base_address, size, permissions);
+
     return transfer_memory;
 }
 

--- a/src/core/hle/kernel/wait_object.cpp
+++ b/src/core/hle/kernel/wait_object.cpp
@@ -51,17 +51,8 @@ SharedPtr<Thread> WaitObject::GetHighestPriorityReadyThread() const {
         if (ShouldWait(thread.get()))
             continue;
 
-        // A thread is ready to run if it's either in ThreadStatus::WaitSynch
-        // and the rest of the objects it is waiting on are ready.
-        bool ready_to_run = true;
-        if (thread_status == ThreadStatus::WaitSynch) {
-            ready_to_run = thread->AllWaitObjectsReady();
-        }
-
-        if (ready_to_run) {
-            candidate = thread.get();
-            candidate_priority = thread->GetPriority();
-        }
+        candidate = thread.get();
+        candidate_priority = thread->GetPriority();
     }
 
     return candidate;

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -847,17 +847,16 @@ private:
     void PopInteractiveOutData(Kernel::HLERequestContext& ctx) {
         LOG_DEBUG(Service_AM, "called");
 
-        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
-
         const auto storage = applet->GetBroker().PopInteractiveDataToGame();
         if (storage == nullptr) {
             LOG_ERROR(Service_AM,
                       "storage is a nullptr. There is no data in the current interactive channel");
-
+            IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ERR_NO_DATA_IN_CHANNEL);
             return;
         }
 
+        IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IStorage>(std::move(*storage));
     }

--- a/src/core/hle/service/am/applets/applets.cpp
+++ b/src/core/hle/service/am/applets/applets.cpp
@@ -88,6 +88,7 @@ std::unique_ptr<IStorage> AppletDataBroker::PopInteractiveDataToApplet() {
 
 void AppletDataBroker::PushNormalDataFromGame(IStorage storage) {
     in_channel.push_back(std::make_unique<IStorage>(storage));
+    pop_out_data_event.writable->Clear();
 }
 
 void AppletDataBroker::PushNormalDataFromApplet(IStorage storage) {
@@ -97,6 +98,7 @@ void AppletDataBroker::PushNormalDataFromApplet(IStorage storage) {
 
 void AppletDataBroker::PushInteractiveDataFromGame(IStorage storage) {
     in_interactive_channel.push_back(std::make_unique<IStorage>(storage));
+    pop_interactive_out_data_event.writable->Clear();
 }
 
 void AppletDataBroker::PushInteractiveDataFromApplet(IStorage storage) {

--- a/src/core/hle/service/am/applets/software_keyboard.cpp
+++ b/src/core/hle/service/am/applets/software_keyboard.cpp
@@ -91,6 +91,7 @@ void SoftwareKeyboard::ExecuteInteractive() {
 
     if (status == INTERACTIVE_STATUS_OK) {
         complete = true;
+        broker.SignalStateChanged();
     } else {
         std::array<char16_t, SWKBD_OUTPUT_INTERACTIVE_BUFFER_SIZE / 2 - 2> string;
         std::memcpy(string.data(), data.data() + 4, string.size() * 2);


### PR DESCRIPTION
Fixes:
- Missing call to MapMemory when creating a TransferMemory -- this would lead to a hard crash when trying to read the transfer memory.
- Using `Automatic` event types for applet data channels -- this fixes softlocks/infinite loops with applet data channels
- Correct a miscounted IPC header in `am`
- Add a missing state changed event signal in interactive applet -- fixes a softlock for some games
- Make wait object wake on any signalled thread, not all -- fixes softlock with applet as sdk code waits on two events that are mutually exculsive. This fixes a bug introduced by #2416 

![pkdx](https://user-images.githubusercontent.com/5064800/60966462-48426780-a2e6-11e9-8b4d-fc0e9317e8e5.png)
![pkmn](https://user-images.githubusercontent.com/5064800/60966464-48dafe00-a2e6-11e9-8183-645e8dec5968.png)
![smm2](https://user-images.githubusercontent.com/5064800/60966465-48dafe00-a2e6-11e9-92ea-5bc885e160e7.png)
![stardew](https://user-images.githubusercontent.com/5064800/60966466-48dafe00-a2e6-11e9-95c1-042c5aa33689.png)
![mc](https://user-images.githubusercontent.com/5064800/60966469-49739480-a2e6-11e9-9268-df34078ba3e6.png)
