### PR TITLE
service/am: Remove usages of global system accessors

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -104,7 +104,8 @@ FileSys::VirtualFile GetGameFileFromPath(const FileSys::VirtualFilesystem& vfs,
     return vfs->OpenFile(path, FileSys::Mode::Read);
 }
 struct System::Impl {
-    explicit Impl(System& system) : kernel{system}, cpu_core_manager{system}, reporter{system} {}
+    explicit Impl(System& system)
+        : kernel{system}, cpu_core_manager{system}, applet_manager{system}, reporter{system} {}
 
     Cpu& CurrentCpuCore() {
         return cpu_core_manager.GetCurrentCore();

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -10,12 +10,15 @@
 #include "core/hle/kernel/writable_event.h"
 #include "core/hle/service/service.h"
 
-namespace Service {
-namespace NVFlinger {
+namespace Kernel {
+class KernelCore;
+}
+
+namespace Service::NVFlinger {
 class NVFlinger;
 }
 
-namespace AM {
+namespace Service::AM {
 
 enum SystemLanguage {
     Japanese = 0,
@@ -47,7 +50,7 @@ public:
         PerformanceModeChanged = 31,
     };
 
-    AppletMessageQueue();
+    explicit AppletMessageQueue(Kernel::KernelCore& kernel);
     ~AppletMessageQueue();
 
     const Kernel::SharedPtr<Kernel::ReadableEvent>& GetMesssageRecieveEvent() const;
@@ -65,12 +68,14 @@ private:
 
 class IWindowController final : public ServiceFramework<IWindowController> {
 public:
-    IWindowController();
+    explicit IWindowController(Core::System& system_);
     ~IWindowController() override;
 
 private:
     void GetAppletResourceUserId(Kernel::HLERequestContext& ctx);
     void AcquireForegroundRights(Kernel::HLERequestContext& ctx);
+
+    Core::System& system;
 };
 
 class IAudioController final : public ServiceFramework<IAudioController> {
@@ -113,7 +118,8 @@ public:
 
 class ISelfController final : public ServiceFramework<ISelfController> {
 public:
-    explicit ISelfController(std::shared_ptr<NVFlinger::NVFlinger> nvflinger);
+    explicit ISelfController(Core::System& system_,
+                             std::shared_ptr<NVFlinger::NVFlinger> nvflinger_);
     ~ISelfController() override;
 
 private:
@@ -208,7 +214,7 @@ private:
 
 class ILibraryAppletCreator final : public ServiceFramework<ILibraryAppletCreator> {
 public:
-    ILibraryAppletCreator(u64 current_process_title_id);
+    explicit ILibraryAppletCreator(Core::System& system_);
     ~ILibraryAppletCreator() override;
 
 private:
@@ -216,12 +222,12 @@ private:
     void CreateStorage(Kernel::HLERequestContext& ctx);
     void CreateTransferMemoryStorage(Kernel::HLERequestContext& ctx);
 
-    u64 current_process_title_id;
+    Core::System& system;
 };
 
 class IApplicationFunctions final : public ServiceFramework<IApplicationFunctions> {
 public:
-    IApplicationFunctions();
+    explicit IApplicationFunctions(Core::System& system_);
     ~IApplicationFunctions() override;
 
 private:
@@ -245,6 +251,7 @@ private:
     void GetGpuErrorDetectedSystemEvent(Kernel::HLERequestContext& ctx);
 
     Kernel::EventPair gpu_error_detected_event;
+    Core::System& system;
 };
 
 class IHomeMenuFunctions final : public ServiceFramework<IHomeMenuFunctions> {
@@ -278,5 +285,4 @@ public:
 void InstallInterfaces(SM::ServiceManager& service_manager,
                        std::shared_ptr<NVFlinger::NVFlinger> nvflinger, Core::System& system);
 
-} // namespace AM
-} // namespace Service
+} // namespace Service::AM

--- a/src/core/hle/service/am/applet_ae.cpp
+++ b/src/core/hle/service/am/applet_ae.cpp
@@ -50,7 +50,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<ISelfController>(nvflinger);
+        rb.PushIpcInterface<ISelfController>(system, nvflinger);
     }
 
     void GetWindowController(Kernel::HLERequestContext& ctx) {
@@ -58,7 +58,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IWindowController>();
+        rb.PushIpcInterface<IWindowController>(system);
     }
 
     void GetAudioController(Kernel::HLERequestContext& ctx) {
@@ -98,7 +98,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<ILibraryAppletCreator>(system.CurrentProcess()->GetTitleID());
+        rb.PushIpcInterface<ILibraryAppletCreator>(system);
     }
 
     void GetApplicationFunctions(Kernel::HLERequestContext& ctx) {
@@ -106,7 +106,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IApplicationFunctions>();
+        rb.PushIpcInterface<IApplicationFunctions>(system);
     }
 
     std::shared_ptr<NVFlinger::NVFlinger> nvflinger;
@@ -154,7 +154,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<ISelfController>(nvflinger);
+        rb.PushIpcInterface<ISelfController>(system, nvflinger);
     }
 
     void GetWindowController(Kernel::HLERequestContext& ctx) {
@@ -162,7 +162,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IWindowController>();
+        rb.PushIpcInterface<IWindowController>(system);
     }
 
     void GetAudioController(Kernel::HLERequestContext& ctx) {
@@ -194,7 +194,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<ILibraryAppletCreator>(system.CurrentProcess()->GetTitleID());
+        rb.PushIpcInterface<ILibraryAppletCreator>(system);
     }
 
     void GetHomeMenuFunctions(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -4,7 +4,6 @@
 
 #include "common/logging/log.h"
 #include "core/hle/ipc_helpers.h"
-#include "core/hle/kernel/process.h"
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/am/applet_oe.h"
 #include "core/hle/service/nvflinger/nvflinger.h"
@@ -64,7 +63,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IWindowController>();
+        rb.PushIpcInterface<IWindowController>(system);
     }
 
     void GetSelfController(Kernel::HLERequestContext& ctx) {
@@ -72,7 +71,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<ISelfController>(nvflinger);
+        rb.PushIpcInterface<ISelfController>(system, nvflinger);
     }
 
     void GetCommonStateGetter(Kernel::HLERequestContext& ctx) {
@@ -88,7 +87,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<ILibraryAppletCreator>(system.CurrentProcess()->GetTitleID());
+        rb.PushIpcInterface<ILibraryAppletCreator>(system);
     }
 
     void GetApplicationFunctions(Kernel::HLERequestContext& ctx) {
@@ -96,7 +95,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IApplicationFunctions>();
+        rb.PushIpcInterface<IApplicationFunctions>(system);
     }
 
     std::shared_ptr<NVFlinger::NVFlinger> nvflinger;

--- a/src/core/hle/service/am/applets/applets.h
+++ b/src/core/hle/service/am/applets/applets.h
@@ -12,6 +12,10 @@
 
 union ResultCode;
 
+namespace Core {
+class System;
+}
+
 namespace Core::Frontend {
 class ECommerceApplet;
 class ErrorApplet;
@@ -21,6 +25,10 @@ class ProfileSelectApplet;
 class SoftwareKeyboardApplet;
 class WebBrowserApplet;
 } // namespace Core::Frontend
+
+namespace Kernel {
+class KernelCore;
+}
 
 namespace Service::AM {
 
@@ -53,7 +61,7 @@ enum class AppletId : u32 {
 
 class AppletDataBroker final {
 public:
-    AppletDataBroker();
+    explicit AppletDataBroker(Kernel::KernelCore& kernel_);
     ~AppletDataBroker();
 
     struct RawChannelData {
@@ -108,7 +116,7 @@ private:
 
 class Applet {
 public:
-    Applet();
+    explicit Applet(Kernel::KernelCore& kernel_);
     virtual ~Applet();
 
     virtual void Initialize();
@@ -179,7 +187,7 @@ struct AppletFrontendSet {
 
 class AppletManager {
 public:
-    AppletManager();
+    explicit AppletManager(Core::System& system_);
     ~AppletManager();
 
     void SetAppletFrontendSet(AppletFrontendSet set);
@@ -187,10 +195,11 @@ public:
     void SetDefaultAppletsIfMissing();
     void ClearAll();
 
-    std::shared_ptr<Applet> GetApplet(AppletId id, u64 current_process_title_id) const;
+    std::shared_ptr<Applet> GetApplet(AppletId id) const;
 
 private:
     AppletFrontendSet frontend;
+    Core::System& system;
 };
 
 } // namespace Applets

--- a/src/core/hle/service/am/applets/error.cpp
+++ b/src/core/hle/service/am/applets/error.cpp
@@ -85,7 +85,8 @@ ResultCode Decode64BitError(u64 error) {
 
 } // Anonymous namespace
 
-Error::Error(const Core::Frontend::ErrorApplet& frontend) : frontend(frontend) {}
+Error::Error(Core::System& system_, const Core::Frontend::ErrorApplet& frontend_)
+    : Applet{system_.Kernel()}, frontend(frontend_), system{system_} {}
 
 Error::~Error() = default;
 
@@ -145,8 +146,8 @@ void Error::Execute() {
     }
 
     const auto callback = [this] { DisplayCompleted(); };
-    const auto title_id = Core::CurrentProcess()->GetTitleID();
-    const auto& reporter{Core::System::GetInstance().GetReporter()};
+    const auto title_id = system.CurrentProcess()->GetTitleID();
+    const auto& reporter{system.GetReporter()};
 
     switch (mode) {
     case ErrorAppletMode::ShowError:

--- a/src/core/hle/service/am/applets/error.h
+++ b/src/core/hle/service/am/applets/error.h
@@ -7,6 +7,10 @@
 #include "core/hle/result.h"
 #include "core/hle/service/am/applets/applets.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::AM::Applets {
 
 enum class ErrorAppletMode : u8 {
@@ -21,7 +25,7 @@ enum class ErrorAppletMode : u8 {
 
 class Error final : public Applet {
 public:
-    explicit Error(const Core::Frontend::ErrorApplet& frontend);
+    explicit Error(Core::System& system_, const Core::Frontend::ErrorApplet& frontend_);
     ~Error() override;
 
     void Initialize() override;
@@ -42,6 +46,7 @@ private:
     std::unique_ptr<ErrorArguments> args;
 
     bool complete = false;
+    Core::System& system;
 };
 
 } // namespace Service::AM::Applets

--- a/src/core/hle/service/am/applets/general_backend.cpp
+++ b/src/core/hle/service/am/applets/general_backend.cpp
@@ -37,7 +37,8 @@ static void LogCurrentStorage(AppletDataBroker& broker, std::string_view prefix)
     }
 }
 
-Auth::Auth(Core::Frontend::ParentalControlsApplet& frontend) : frontend(frontend) {}
+Auth::Auth(Core::System& system_, Core::Frontend::ParentalControlsApplet& frontend_)
+    : Applet{system_.Kernel()}, frontend(frontend_) {}
 
 Auth::~Auth() = default;
 
@@ -151,7 +152,8 @@ void Auth::AuthFinished(bool successful) {
     broker.SignalStateChanged();
 }
 
-PhotoViewer::PhotoViewer(const Core::Frontend::PhotoViewerApplet& frontend) : frontend(frontend) {}
+PhotoViewer::PhotoViewer(Core::System& system_, const Core::Frontend::PhotoViewerApplet& frontend_)
+    : Applet{system_.Kernel()}, frontend(frontend_), system{system_} {}
 
 PhotoViewer::~PhotoViewer() = default;
 
@@ -185,7 +187,7 @@ void PhotoViewer::Execute() {
     const auto callback = [this] { ViewFinished(); };
     switch (mode) {
     case PhotoViewerAppletMode::CurrentApp:
-        frontend.ShowPhotosForApplication(Core::CurrentProcess()->GetTitleID(), callback);
+        frontend.ShowPhotosForApplication(system.CurrentProcess()->GetTitleID(), callback);
         break;
     case PhotoViewerAppletMode::AllApps:
         frontend.ShowAllPhotos(callback);
@@ -200,7 +202,8 @@ void PhotoViewer::ViewFinished() {
     broker.SignalStateChanged();
 }
 
-StubApplet::StubApplet(AppletId id) : id(id) {}
+StubApplet::StubApplet(Core::System& system_, AppletId id_)
+    : Applet{system_.Kernel()}, id(id_), system{system_} {}
 
 StubApplet::~StubApplet() = default;
 
@@ -209,7 +212,7 @@ void StubApplet::Initialize() {
     Applet::Initialize();
 
     const auto data = broker.PeekDataToAppletForDebug();
-    Core::System::GetInstance().GetReporter().SaveUnimplementedAppletReport(
+    system.GetReporter().SaveUnimplementedAppletReport(
         static_cast<u32>(id), common_args.arguments_version, common_args.library_version,
         common_args.theme_color, common_args.play_startup_sound, common_args.system_tick,
         data.normal, data.interactive);

--- a/src/core/hle/service/am/applets/general_backend.h
+++ b/src/core/hle/service/am/applets/general_backend.h
@@ -6,6 +6,10 @@
 
 #include "core/hle/service/am/applets/applets.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::AM::Applets {
 
 enum class AuthAppletType : u32 {
@@ -16,7 +20,7 @@ enum class AuthAppletType : u32 {
 
 class Auth final : public Applet {
 public:
-    explicit Auth(Core::Frontend::ParentalControlsApplet& frontend);
+    explicit Auth(Core::System& system_, Core::Frontend::ParentalControlsApplet& frontend_);
     ~Auth() override;
 
     void Initialize() override;
@@ -45,7 +49,7 @@ enum class PhotoViewerAppletMode : u8 {
 
 class PhotoViewer final : public Applet {
 public:
-    explicit PhotoViewer(const Core::Frontend::PhotoViewerApplet& frontend);
+    explicit PhotoViewer(Core::System& system_, const Core::Frontend::PhotoViewerApplet& frontend_);
     ~PhotoViewer() override;
 
     void Initialize() override;
@@ -60,11 +64,12 @@ private:
     const Core::Frontend::PhotoViewerApplet& frontend;
     bool complete = false;
     PhotoViewerAppletMode mode = PhotoViewerAppletMode::CurrentApp;
+    Core::System& system;
 };
 
 class StubApplet final : public Applet {
 public:
-    explicit StubApplet(AppletId id);
+    explicit StubApplet(Core::System& system_, AppletId id_);
     ~StubApplet() override;
 
     void Initialize() override;
@@ -76,6 +81,7 @@ public:
 
 private:
     AppletId id;
+    Core::System& system;
 };
 
 } // namespace Service::AM::Applets

--- a/src/core/hle/service/am/applets/profile_select.cpp
+++ b/src/core/hle/service/am/applets/profile_select.cpp
@@ -15,8 +15,9 @@ namespace Service::AM::Applets {
 
 constexpr ResultCode ERR_USER_CANCELLED_SELECTION{ErrorModule::Account, 1};
 
-ProfileSelect::ProfileSelect(const Core::Frontend::ProfileSelectApplet& frontend)
-    : frontend(frontend) {}
+ProfileSelect::ProfileSelect(Core::System& system_,
+                             const Core::Frontend::ProfileSelectApplet& frontend_)
+    : Applet{system_.Kernel()}, frontend(frontend_) {}
 
 ProfileSelect::~ProfileSelect() = default;
 

--- a/src/core/hle/service/am/applets/profile_select.h
+++ b/src/core/hle/service/am/applets/profile_select.h
@@ -11,6 +11,10 @@
 #include "core/hle/result.h"
 #include "core/hle/service/am/applets/applets.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::AM::Applets {
 
 struct UserSelectionConfig {
@@ -29,7 +33,8 @@ static_assert(sizeof(UserSelectionOutput) == 0x18, "UserSelectionOutput has inco
 
 class ProfileSelect final : public Applet {
 public:
-    explicit ProfileSelect(const Core::Frontend::ProfileSelectApplet& frontend);
+    explicit ProfileSelect(Core::System& system_,
+                           const Core::Frontend::ProfileSelectApplet& frontend_);
     ~ProfileSelect() override;
 
     void Initialize() override;

--- a/src/core/hle/service/am/applets/software_keyboard.cpp
+++ b/src/core/hle/service/am/applets/software_keyboard.cpp
@@ -39,8 +39,9 @@ static Core::Frontend::SoftwareKeyboardParameters ConvertToFrontendParameters(
     return params;
 }
 
-SoftwareKeyboard::SoftwareKeyboard(const Core::Frontend::SoftwareKeyboardApplet& frontend)
-    : frontend(frontend) {}
+SoftwareKeyboard::SoftwareKeyboard(Core::System& system_,
+                                   const Core::Frontend::SoftwareKeyboardApplet& frontend_)
+    : Applet{system_.Kernel()}, frontend(frontend_) {}
 
 SoftwareKeyboard::~SoftwareKeyboard() = default;
 

--- a/src/core/hle/service/am/applets/software_keyboard.h
+++ b/src/core/hle/service/am/applets/software_keyboard.h
@@ -16,6 +16,10 @@
 
 union ResultCode;
 
+namespace Core {
+class System;
+}
+
 namespace Service::AM::Applets {
 
 enum class KeysetDisable : u32 {
@@ -55,7 +59,8 @@ static_assert(sizeof(KeyboardConfig) == 0x3E0, "KeyboardConfig has incorrect siz
 
 class SoftwareKeyboard final : public Applet {
 public:
-    explicit SoftwareKeyboard(const Core::Frontend::SoftwareKeyboardApplet& frontend);
+    explicit SoftwareKeyboard(Core::System& system_,
+                              const Core::Frontend::SoftwareKeyboardApplet& frontend_);
     ~SoftwareKeyboard() override;
 
     void Initialize() override;

--- a/src/core/hle/service/am/applets/web_browser.h
+++ b/src/core/hle/service/am/applets/web_browser.h
@@ -9,6 +9,10 @@
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/am/applets/applets.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::AM::Applets {
 
 enum class ShimKind : u32;
@@ -17,8 +21,8 @@ enum class WebArgTLVType : u16;
 
 class WebBrowser final : public Applet {
 public:
-    WebBrowser(Core::Frontend::WebBrowserApplet& frontend, u64 current_process_title_id,
-               Core::Frontend::ECommerceApplet* frontend_e_commerce = nullptr);
+    WebBrowser(Core::System& system_, Core::Frontend::WebBrowserApplet& frontend_,
+               Core::Frontend::ECommerceApplet* frontend_e_commerce_ = nullptr);
 
     ~WebBrowser() override;
 
@@ -59,8 +63,6 @@ private:
     bool unpacked = false;
     ResultCode status = RESULT_SUCCESS;
 
-    u64 current_process_title_id;
-
     ShimKind kind;
     std::map<WebArgTLVType, std::vector<u8>> args;
 
@@ -74,6 +76,8 @@ private:
     std::optional<u128> user_id;
     std::optional<bool> shop_full_display;
     std::string shop_extra_parameter;
+
+    Core::System& system;
 };
 
 } // namespace Service::AM::Applets


### PR DESCRIPTION
Avoids the use of global accessors, removing the reliance on global state. This also makes dependencies explicit in the interface, as opposed to being hidden.

With this we're much closer to removing the `Core::CurrentProcess` global accessor.

