### PR TITLE
Unicorn: Disable Unicorn Memory Mapping through a setting.

### DIFF
--- a/src/core/arm/unicorn/arm_unicorn.cpp
+++ b/src/core/arm/unicorn/arm_unicorn.cpp
@@ -10,6 +10,7 @@
 #include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/kernel/svc.h"
+#include "core/settings.h"
 
 namespace Core {
 
@@ -78,11 +79,15 @@ ARM_Unicorn::~ARM_Unicorn() {
 
 void ARM_Unicorn::MapBackingMemory(VAddr address, std::size_t size, u8* memory,
                                    Kernel::VMAPermission perms) {
-    CHECKED(uc_mem_map_ptr(uc, address, size, static_cast<u32>(perms), memory));
+    if (Settings::values.unicorn_mapping) {
+        CHECKED(uc_mem_map_ptr(uc, address, size, static_cast<u32>(perms), memory));
+    }
 }
 
 void ARM_Unicorn::UnmapMemory(VAddr address, std::size_t size) {
-    CHECKED(uc_mem_unmap(uc, address, size));
+    if (Settings::values.unicorn_mapping) {
+        CHECKED(uc_mem_unmap(uc, address, size));
+    }
 }
 
 void ARM_Unicorn::SetPC(u64 pc) {

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -103,6 +103,7 @@ void LogSettings() {
     LogSetting("Debugging_UseGdbstub", Settings::values.use_gdbstub);
     LogSetting("Debugging_GdbstubPort", Settings::values.gdbstub_port);
     LogSetting("Debugging_ProgramArgs", Settings::values.program_args);
+    LogSetting("Debugging_UnicornMapping", Settings::values.unicorn_mapping);
 }
 
 } // namespace Settings

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -417,6 +417,7 @@ struct Values {
     bool dump_nso;
     bool reporting_services;
     bool quest_flag;
+    bool unicorn_mapping;
 
     // WebService
     bool enable_telemetry;

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -38,6 +38,7 @@ void ConfigureDebug::SetConfiguration() {
     ui->dump_decompressed_nso->setChecked(Settings::values.dump_nso);
     ui->reporting_services->setChecked(Settings::values.reporting_services);
     ui->quest_flag->setChecked(Settings::values.quest_flag);
+    ui->unicorn_mapping->setChecked(Settings::values.unicorn_mapping);
 }
 
 void ConfigureDebug::ApplyConfiguration() {
@@ -50,6 +51,7 @@ void ConfigureDebug::ApplyConfiguration() {
     Settings::values.dump_nso = ui->dump_decompressed_nso->isChecked();
     Settings::values.reporting_services = ui->reporting_services->isChecked();
     Settings::values.quest_flag = ui->quest_flag->isChecked();
+    Settings::values.unicorn_mapping = ui->unicorn_mapping->isChecked();
     Debugger::ToggleConsole();
     Log::Filter filter;
     filter.ParseFilterString(Settings::values.log_filter);

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -193,6 +193,13 @@
         </property>
        </widget>
       </item>
+      <item>
+       <widget class="QCheckBox" name="unicorn_mapping">
+        <property name="text">
+         <string>Enable Unicorn Memory Mapping</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -384,6 +384,7 @@ void Config::ReadValues() {
     Settings::values.reporting_services =
         sdl2_config->GetBoolean("Debugging", "reporting_services", false);
     Settings::values.quest_flag = sdl2_config->GetBoolean("Debugging", "quest_flag", false);
+    Settings::values.unicorn_mapping = sdl2_config->GetBoolean("Debugging", "unicorn_mapping", false);
 
     const auto title_list = sdl2_config->Get("AddOns", "title_ids", "");
     std::stringstream ss(title_list);


### PR DESCRIPTION
Unicorn maps it's own memory for running. Unicorn's mapping is slow, 
buggy and produces memory leaks. However, dynarmic have implemented all 
the memory instructions in ARMv8. With this PR we disable it through a 
setting and kept in for developers to test ARMv7A if not all the 
instructions are implemented.