### PR TITLE
core/arm: Remove obsolete Unicorn memory mapping

### DIFF
--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -44,13 +44,6 @@ public:
     /// Step CPU by one instruction
     virtual void Step() = 0;
 
-    /// Maps a backing memory region for the CPU
-    virtual void MapBackingMemory(VAddr address, std::size_t size, u8* memory,
-                                  Kernel::VMAPermission perms) = 0;
-
-    /// Unmaps a region of memory that was previously mapped using MapBackingMemory
-    virtual void UnmapMemory(VAddr address, std::size_t size) = 0;
-
     /// Clear all instruction cache
     virtual void ClearInstructionCache() = 0;
 

--- a/src/core/arm/dynarmic/arm_dynarmic.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic.cpp
@@ -177,15 +177,6 @@ ARM_Dynarmic::ARM_Dynarmic(System& system, ExclusiveMonitor& exclusive_monitor,
 
 ARM_Dynarmic::~ARM_Dynarmic() = default;
 
-void ARM_Dynarmic::MapBackingMemory(u64 address, std::size_t size, u8* memory,
-                                    Kernel::VMAPermission perms) {
-    inner_unicorn.MapBackingMemory(address, size, memory, perms);
-}
-
-void ARM_Dynarmic::UnmapMemory(u64 address, std::size_t size) {
-    inner_unicorn.UnmapMemory(address, size);
-}
-
 void ARM_Dynarmic::SetPC(u64 pc) {
     jit->SetPC(pc);
 }

--- a/src/core/arm/dynarmic/arm_dynarmic.h
+++ b/src/core/arm/dynarmic/arm_dynarmic.h
@@ -23,9 +23,6 @@ public:
     ARM_Dynarmic(System& system, ExclusiveMonitor& exclusive_monitor, std::size_t core_index);
     ~ARM_Dynarmic() override;
 
-    void MapBackingMemory(VAddr address, std::size_t size, u8* memory,
-                          Kernel::VMAPermission perms) override;
-    void UnmapMemory(u64 address, std::size_t size) override;
     void SetPC(u64 pc) override;
     u64 GetPC() const override;
     u64 GetReg(int index) const override;

--- a/src/core/arm/unicorn/arm_unicorn.cpp
+++ b/src/core/arm/unicorn/arm_unicorn.cpp
@@ -76,15 +76,6 @@ ARM_Unicorn::~ARM_Unicorn() {
     CHECKED(uc_close(uc));
 }
 
-void ARM_Unicorn::MapBackingMemory(VAddr address, std::size_t size, u8* memory,
-                                   Kernel::VMAPermission perms) {
-    CHECKED(uc_mem_map_ptr(uc, address, size, static_cast<u32>(perms), memory));
-}
-
-void ARM_Unicorn::UnmapMemory(VAddr address, std::size_t size) {
-    CHECKED(uc_mem_unmap(uc, address, size));
-}
-
 void ARM_Unicorn::SetPC(u64 pc) {
     CHECKED(uc_reg_write(uc, UC_ARM64_REG_PC, &pc));
 }

--- a/src/core/arm/unicorn/arm_unicorn.h
+++ b/src/core/arm/unicorn/arm_unicorn.h
@@ -18,9 +18,6 @@ public:
     explicit ARM_Unicorn(System& system);
     ~ARM_Unicorn() override;
 
-    void MapBackingMemory(VAddr address, std::size_t size, u8* memory,
-                          Kernel::VMAPermission perms) override;
-    void UnmapMemory(VAddr address, std::size_t size) override;
     void SetPC(u64 pc) override;
     u64 GetPC() const override;
     u64 GetReg(int index) const override;

--- a/src/core/core_cpu.cpp
+++ b/src/core/core_cpu.cpp
@@ -53,16 +53,12 @@ bool CpuBarrier::Rendezvous() {
 Cpu::Cpu(System& system, ExclusiveMonitor& exclusive_monitor, CpuBarrier& cpu_barrier,
          std::size_t core_index)
     : cpu_barrier{cpu_barrier}, core_timing{system.CoreTiming()}, core_index{core_index} {
-    if (Settings::values.cpu_jit_enabled) {
 #ifdef ARCHITECTURE_x86_64
-        arm_interface = std::make_unique<ARM_Dynarmic>(system, exclusive_monitor, core_index);
+    arm_interface = std::make_unique<ARM_Dynarmic>(system, exclusive_monitor, core_index);
 #else
-        arm_interface = std::make_unique<ARM_Unicorn>(system);
-        LOG_WARNING(Core, "CPU JIT requested, but Dynarmic not available");
+    arm_interface = std::make_unique<ARM_Unicorn>(system);
+    LOG_WARNING(Core, "CPU JIT requested, but Dynarmic not available");
 #endif
-    } else {
-        arm_interface = std::make_unique<ARM_Unicorn>(system);
-    }
 
     scheduler = std::make_unique<Kernel::Scheduler>(system, *arm_interface);
 }
@@ -70,15 +66,12 @@ Cpu::Cpu(System& system, ExclusiveMonitor& exclusive_monitor, CpuBarrier& cpu_ba
 Cpu::~Cpu() = default;
 
 std::unique_ptr<ExclusiveMonitor> Cpu::MakeExclusiveMonitor(std::size_t num_cores) {
-    if (Settings::values.cpu_jit_enabled) {
 #ifdef ARCHITECTURE_x86_64
-        return std::make_unique<DynarmicExclusiveMonitor>(num_cores);
+    return std::make_unique<DynarmicExclusiveMonitor>(num_cores);
 #else
-        return nullptr; // TODO(merry): Passthrough exclusive monitor
+    // TODO(merry): Passthrough exclusive monitor
+    return nullptr;
 #endif
-    } else {
-        return nullptr; // TODO(merry): Passthrough exclusive monitor
-    }
 }
 
 void Cpu::RunLoop(bool tight_loop) {

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -8,7 +8,6 @@
 #include "common/assert.h"
 #include "common/logging/log.h"
 #include "common/memory_hook.h"
-#include "core/arm/arm_interface.h"
 #include "core/core.h"
 #include "core/file_sys/program_metadata.h"
 #include "core/hle/kernel/errors.h"
@@ -109,15 +108,6 @@ ResultVal<VMManager::VMAHandle> VMManager::MapMemoryBlock(VAddr target,
     VirtualMemoryArea& final_vma = vma_handle->second;
     ASSERT(final_vma.size == size);
 
-    system.ArmInterface(0).MapBackingMemory(target, size, block->data() + offset,
-                                            VMAPermission::ReadWriteExecute);
-    system.ArmInterface(1).MapBackingMemory(target, size, block->data() + offset,
-                                            VMAPermission::ReadWriteExecute);
-    system.ArmInterface(2).MapBackingMemory(target, size, block->data() + offset,
-                                            VMAPermission::ReadWriteExecute);
-    system.ArmInterface(3).MapBackingMemory(target, size, block->data() + offset,
-                                            VMAPermission::ReadWriteExecute);
-
     final_vma.type = VMAType::AllocatedMemoryBlock;
     final_vma.permissions = VMAPermission::ReadWrite;
     final_vma.state = state;
@@ -136,11 +126,6 @@ ResultVal<VMManager::VMAHandle> VMManager::MapBackingMemory(VAddr target, u8* me
     CASCADE_RESULT(VMAIter vma_handle, CarveVMA(target, size));
     VirtualMemoryArea& final_vma = vma_handle->second;
     ASSERT(final_vma.size == size);
-
-    system.ArmInterface(0).MapBackingMemory(target, size, memory, VMAPermission::ReadWriteExecute);
-    system.ArmInterface(1).MapBackingMemory(target, size, memory, VMAPermission::ReadWriteExecute);
-    system.ArmInterface(2).MapBackingMemory(target, size, memory, VMAPermission::ReadWriteExecute);
-    system.ArmInterface(3).MapBackingMemory(target, size, memory, VMAPermission::ReadWriteExecute);
 
     final_vma.type = VMAType::BackingMemory;
     final_vma.permissions = VMAPermission::ReadWrite;
@@ -229,11 +214,6 @@ ResultCode VMManager::UnmapRange(VAddr target, u64 size) {
     }
 
     ASSERT(FindVMA(target)->second.size >= size);
-
-    system.ArmInterface(0).UnmapMemory(target, size);
-    system.ArmInterface(1).UnmapMemory(target, size);
-    system.ArmInterface(2).UnmapMemory(target, size);
-    system.ArmInterface(3).UnmapMemory(target, size);
 
     return RESULT_SUCCESS;
 }

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -85,7 +85,6 @@ void LogSettings() {
     LogSetting("System_RngSeed", Settings::values.rng_seed.value_or(0));
     LogSetting("System_CurrentUser", Settings::values.current_user);
     LogSetting("System_LanguageIndex", Settings::values.language_index);
-    LogSetting("Core_CpuJitEnabled", Settings::values.cpu_jit_enabled);
     LogSetting("Core_UseMultiCore", Settings::values.use_multi_core);
     LogSetting("Renderer_UseResolutionFactor", Settings::values.resolution_factor);
     LogSetting("Renderer_UseFrameLimit", Settings::values.use_frame_limit);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -378,7 +378,6 @@ struct Values {
     std::atomic_bool is_device_reload_pending{true};
 
     // Core
-    bool cpu_jit_enabled;
     bool use_multi_core;
 
     // Data Storage

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -168,7 +168,6 @@ void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader) {
     AddField(Telemetry::FieldType::UserConfig, "Audio_SinkId", Settings::values.sink_id);
     AddField(Telemetry::FieldType::UserConfig, "Audio_EnableAudioStretching",
              Settings::values.enable_audio_stretching);
-    AddField(Telemetry::FieldType::UserConfig, "Core_UseCpuJit", Settings::values.cpu_jit_enabled);
     AddField(Telemetry::FieldType::UserConfig, "Core_UseMultiCore",
              Settings::values.use_multi_core);
     AddField(Telemetry::FieldType::UserConfig, "Renderer_ResolutionFactor",

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -436,8 +436,6 @@ void Config::ReadControlValues() {
 void Config::ReadCoreValues() {
     qt_config->beginGroup(QStringLiteral("Core"));
 
-    Settings::values.cpu_jit_enabled =
-        ReadSetting(QStringLiteral("cpu_jit_enabled"), true).toBool();
     Settings::values.use_multi_core = ReadSetting(QStringLiteral("use_multi_core"), false).toBool();
 
     qt_config->endGroup();
@@ -831,7 +829,6 @@ void Config::SaveControlValues() {
 void Config::SaveCoreValues() {
     qt_config->beginGroup(QStringLiteral("Core"));
 
-    WriteSetting(QStringLiteral("cpu_jit_enabled"), Settings::values.cpu_jit_enabled, true);
     WriteSetting(QStringLiteral("use_multi_core"), Settings::values.use_multi_core, false);
 
     qt_config->endGroup();

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -340,7 +340,6 @@ void Config::ReadValues() {
     }
 
     // Core
-    Settings::values.cpu_jit_enabled = sdl2_config->GetBoolean("Core", "cpu_jit_enabled", true);
     Settings::values.use_multi_core = sdl2_config->GetBoolean("Core", "use_multi_core", false);
 
     // Renderer

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -76,10 +76,6 @@ motion_device=
 touch_device=
 
 [Core]
-# Whether to use the Just-In-Time (JIT) compiler for CPU emulation
-# 0: Interpreter (slow), 1 (default): JIT (fast)
-cpu_jit_enabled =
-
 # Whether to use multi-core for CPU emulation
 # 0 (default): Disabled, 1: Enabled
 use_multi_core=

--- a/src/yuzu_tester/config.cpp
+++ b/src/yuzu_tester/config.cpp
@@ -114,7 +114,6 @@ void Config::ReadValues() {
     }
 
     // Core
-    Settings::values.cpu_jit_enabled = sdl2_config->GetBoolean("Core", "cpu_jit_enabled", true);
     Settings::values.use_multi_core = sdl2_config->GetBoolean("Core", "use_multi_core", false);
 
     // Renderer

--- a/src/yuzu_tester/default_ini.h
+++ b/src/yuzu_tester/default_ini.h
@@ -8,10 +8,6 @@ namespace DefaultINI {
 
 const char* sdl2_config_file = R"(
 [Core]
-# Whether to use the Just-In-Time (JIT) compiler for CPU emulation
-# 0: Interpreter (slow), 1 (default): JIT (fast)
-cpu_jit_enabled =
-
 # Whether to use multi-core for CPU emulation
 # 0 (default): Disabled, 1: Enabled
 use_multi_core=


### PR DESCRIPTION
This was initially necessary when AArch64 JIT emulation was in its infancy and all memory-related instructions weren't implemented. Given the JIT now has all of these facilities implemented, we can remove these functions from the CPU interface.

Supersedes #2722 