### PR TITLE
"AudioRenderer" thread should have a unique name

### DIFF
--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -73,13 +73,14 @@ private:
     EffectInStatus info{};
 };
 AudioRenderer::AudioRenderer(Core::Timing::CoreTiming& core_timing, AudioRendererParameter params,
-                             Kernel::SharedPtr<Kernel::WritableEvent> buffer_event)
+                             Kernel::SharedPtr<Kernel::WritableEvent> buffer_event,
+                             const std::size_t instance_number)
     : worker_params{params}, buffer_event{buffer_event}, voices(params.voice_count),
       effects(params.effect_count) {
 
     audio_out = std::make_unique<AudioCore::AudioOut>();
     stream = audio_out->OpenStream(core_timing, STREAM_SAMPLE_RATE, STREAM_NUM_CHANNELS,
-                                   "AudioRenderer", [=]() { buffer_event->Signal(); });
+                                   fmt::format("AudioRenderer-Instance{}", instance_number), [=]() { buffer_event->Signal(); });
     audio_out->StartStream(stream);
 
     QueueMixedBuffer(0);

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -80,7 +80,8 @@ AudioRenderer::AudioRenderer(Core::Timing::CoreTiming& core_timing, AudioRendere
 
     audio_out = std::make_unique<AudioCore::AudioOut>();
     stream = audio_out->OpenStream(core_timing, STREAM_SAMPLE_RATE, STREAM_NUM_CHANNELS,
-                                   fmt::format("AudioRenderer-Instance{}", instance_number), [=]() { buffer_event->Signal(); });
+                                   fmt::format("AudioRenderer-Instance{}", instance_number),
+                                   [=]() { buffer_event->Signal(); });
     audio_out->StartStream(stream);
 
     QueueMixedBuffer(0);

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -74,7 +74,7 @@ private:
 };
 AudioRenderer::AudioRenderer(Core::Timing::CoreTiming& core_timing, AudioRendererParameter params,
                              Kernel::SharedPtr<Kernel::WritableEvent> buffer_event,
-                             const std::size_t instance_number)
+                             std::size_t instance_number)
     : worker_params{params}, buffer_event{buffer_event}, voices(params.voice_count),
       effects(params.effect_count) {
 

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -215,7 +215,7 @@ static_assert(sizeof(UpdateDataHeader) == 0x40, "UpdateDataHeader has wrong size
 class AudioRenderer {
 public:
     AudioRenderer(Core::Timing::CoreTiming& core_timing, AudioRendererParameter params,
-                  Kernel::SharedPtr<Kernel::WritableEvent> buffer_event, const std::size_t instance_number);
+                  Kernel::SharedPtr<Kernel::WritableEvent> buffer_event, std::size_t instance_number);
     ~AudioRenderer();
 
     std::vector<u8> UpdateAudioRenderer(const std::vector<u8>& input_params);

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -215,7 +215,7 @@ static_assert(sizeof(UpdateDataHeader) == 0x40, "UpdateDataHeader has wrong size
 class AudioRenderer {
 public:
     AudioRenderer(Core::Timing::CoreTiming& core_timing, AudioRendererParameter params,
-                  Kernel::SharedPtr<Kernel::WritableEvent> buffer_event);
+                  Kernel::SharedPtr<Kernel::WritableEvent> buffer_event, const std::size_t instance_number);
     ~AudioRenderer();
 
     std::vector<u8> UpdateAudioRenderer(const std::vector<u8>& input_params);

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -215,7 +215,8 @@ static_assert(sizeof(UpdateDataHeader) == 0x40, "UpdateDataHeader has wrong size
 class AudioRenderer {
 public:
     AudioRenderer(Core::Timing::CoreTiming& core_timing, AudioRendererParameter params,
-                  Kernel::SharedPtr<Kernel::WritableEvent> buffer_event, std::size_t instance_number);
+                  Kernel::SharedPtr<Kernel::WritableEvent> buffer_event,
+                  std::size_t instance_number);
     ~AudioRenderer();
 
     std::vector<u8> UpdateAudioRenderer(const std::vector<u8>& input_params);

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -25,7 +25,7 @@ namespace Service::Audio {
 
 class IAudioRenderer final : public ServiceFramework<IAudioRenderer> {
 public:
-    explicit IAudioRenderer(AudioCore::AudioRendererParameter audren_params)
+    explicit IAudioRenderer(AudioCore::AudioRendererParameter audren_params, const std::size_t instance_number)
         : ServiceFramework("IAudioRenderer") {
         // clang-format off
         static const FunctionInfo functions[] = {
@@ -48,8 +48,7 @@ public:
         auto& system = Core::System::GetInstance();
         system_event = Kernel::WritableEvent::CreateEventPair(
             system.Kernel(), Kernel::ResetType::Manual, "IAudioRenderer:SystemEvent");
-        renderer = std::make_unique<AudioCore::AudioRenderer>(system.CoreTiming(), audren_params,
-                                                              system_event.writable);
+        renderer = std::make_unique<AudioCore::AudioRenderer>(system.CoreTiming(), audren_params, system_event.writable, instance_number);
     }
 
 private:
@@ -607,7 +606,7 @@ void AudRenU::OpenAudioRendererImpl(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
 
     rb.Push(RESULT_SUCCESS);
-    rb.PushIpcInterface<IAudioRenderer>(params);
+    rb.PushIpcInterface<IAudioRenderer>(params, audren_instance_count++);
 }
 
 bool AudRenU::IsFeatureSupported(AudioFeatures feature, u32_le revision) const {

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -25,7 +25,8 @@ namespace Service::Audio {
 
 class IAudioRenderer final : public ServiceFramework<IAudioRenderer> {
 public:
-    explicit IAudioRenderer(AudioCore::AudioRendererParameter audren_params, const std::size_t instance_number)
+    explicit IAudioRenderer(AudioCore::AudioRendererParameter audren_params,
+                            const std::size_t instance_number)
         : ServiceFramework("IAudioRenderer") {
         // clang-format off
         static const FunctionInfo functions[] = {
@@ -48,7 +49,8 @@ public:
         auto& system = Core::System::GetInstance();
         system_event = Kernel::WritableEvent::CreateEventPair(
             system.Kernel(), Kernel::ResetType::Manual, "IAudioRenderer:SystemEvent");
-        renderer = std::make_unique<AudioCore::AudioRenderer>(system.CoreTiming(), audren_params, system_event.writable, instance_number);
+        renderer = std::make_unique<AudioCore::AudioRenderer>(
+            system.CoreTiming(), audren_params, system_event.writable, instance_number);
     }
 
 private:

--- a/src/core/hle/service/audio/audren_u.h
+++ b/src/core/hle/service/audio/audren_u.h
@@ -33,6 +33,7 @@ private:
     };
 
     bool IsFeatureSupported(AudioFeatures feature, u32_le revision) const;
+    std::size_t audren_instance_count = 0;
 };
 
 } // namespace Service::Audio


### PR DESCRIPTION
Creating multiple "AudioRenderer" threads cause the previous thread to be overwritten. The thread will name be renamed to AudioRenderer-InstanceX, where X is the current instance number.

The only game I'm able to test with this fix currently is CTR. This fixes the issue it has and goes in-game however it seems to have no samples playing. Currently unsure if it's related to this fix or if it's a separate issue. Hopefully having a larger sample of tests will conclude if we have an underlying problem with how we're handling these threads or if it's an audio renderer issue in general