### PR TITLE
gl_texture_cache: Implement asynchronous flushing

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -64,6 +64,8 @@ add_library(video_core STATIC
     renderer_opengl/gl_shader_manager.h
     renderer_opengl/gl_shader_util.cpp
     renderer_opengl/gl_shader_util.h
+    renderer_opengl/gl_staging_buffer.cpp
+    renderer_opengl/gl_staging_buffer.h
     renderer_opengl/gl_state.cpp
     renderer_opengl/gl_state.h
     renderer_opengl/gl_stream_buffer.cpp

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -114,6 +114,7 @@ add_library(video_core STATIC
     shader/shader_ir.cpp
     shader/shader_ir.h
     shader/track.cpp
+    staging_buffer_cache.h
     surface.cpp
     surface.h
     texture_cache/surface_base.cpp

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -4,6 +4,8 @@
 
 #include <array>
 #include <cstddef>
+#include <string_view>
+
 #include <glad/glad.h>
 
 #include "common/logging/log.h"
@@ -23,6 +25,9 @@ T GetInteger(GLenum pname) {
 } // Anonymous namespace
 
 Device::Device() {
+    const std::string_view vendor = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
+    const bool intel_proprietary = vendor == "Intel";
+
     uniform_buffer_alignment = GetInteger<std::size_t>(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT);
     shader_storage_alignment = GetInteger<std::size_t>(GL_SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT);
     max_vertex_attributes = GetInteger<u32>(GL_MAX_VERTEX_ATTRIBS);
@@ -32,6 +37,7 @@ Device::Device() {
     has_vertex_viewport_layer = GLAD_GL_ARB_shader_viewport_layer_array;
     has_variable_aoffi = TestVariableAoffi();
     has_component_indexing_bug = TestComponentIndexingBug();
+    has_broken_pbo_streaming = intel_proprietary;
 }
 
 Device::Device(std::nullptr_t) {
@@ -42,6 +48,7 @@ Device::Device(std::nullptr_t) {
     has_vertex_viewport_layer = true;
     has_variable_aoffi = true;
     has_component_indexing_bug = false;
+    has_broken_pbo_streaming = false;
 }
 
 bool Device::TestVariableAoffi() {

--- a/src/video_core/renderer_opengl/gl_device.h
+++ b/src/video_core/renderer_opengl/gl_device.h
@@ -46,6 +46,10 @@ public:
         return has_component_indexing_bug;
     }
 
+    bool HasBrokenPBOStreaming() const {
+        return has_broken_pbo_streaming;
+    }
+
 private:
     static bool TestVariableAoffi();
     static bool TestComponentIndexingBug();
@@ -58,6 +62,7 @@ private:
     bool has_vertex_viewport_layer{};
     bool has_variable_aoffi{};
     bool has_component_indexing_bug{};
+    bool has_broken_pbo_streaming{};
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_staging_buffer.cpp
+++ b/src/video_core/renderer_opengl/gl_staging_buffer.cpp
@@ -11,6 +11,154 @@
 
 namespace OpenGL {
 
+class PersistentStagingBuffer final : public StagingBuffer {
+public:
+    explicit PersistentStagingBuffer(std::size_t size, bool is_read_buffer)
+        : is_read_buffer{is_read_buffer} {
+        constexpr GLenum storage_read = GL_MAP_PERSISTENT_BIT | GL_MAP_READ_BIT;
+        constexpr GLenum storage_write = GL_MAP_PERSISTENT_BIT | GL_MAP_WRITE_BIT;
+        constexpr GLenum map_read = GL_MAP_PERSISTENT_BIT | GL_MAP_READ_BIT;
+        constexpr GLenum map_write = GL_MAP_PERSISTENT_BIT | GL_MAP_WRITE_BIT |
+                                     GL_MAP_FLUSH_EXPLICIT_BIT | GL_MAP_UNSYNCHRONIZED_BIT;
+        const GLenum storage = is_read_buffer ? storage_read : storage_write;
+        const GLenum map = is_read_buffer ? map_read : map_write;
+
+        buffer.Create();
+        glNamedBufferStorage(buffer.handle, static_cast<GLsizeiptr>(size), nullptr, storage);
+        pointer = reinterpret_cast<u8*>(
+            glMapNamedBufferRange(buffer.handle, 0, static_cast<GLsizeiptr>(size), map));
+    }
+
+    ~PersistentStagingBuffer() override {
+        if (sync) {
+            glDeleteSync(sync);
+        }
+    }
+
+    u8* GetOpenGLPointer() const override {
+        // Operations with a bound OpenGL buffer start with an offset of 0.
+        return nullptr;
+    }
+
+    u8* Map([[maybe_unused]] std::size_t size) const override {
+        return pointer;
+    }
+
+    void Unmap(std::size_t size) const override {
+        if (!is_read_buffer) {
+            // We flush the buffer on write operations
+            glFlushMappedNamedBufferRange(buffer.handle, 0, size);
+        }
+    }
+
+    void QueueFence(bool own) override {
+        DEBUG_ASSERT(!sync);
+        owned = own;
+        sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+    }
+
+    void WaitFence() override {
+        DEBUG_ASSERT(sync);
+        switch (glClientWaitSync(sync, 0, GL_TIMEOUT_IGNORED)) {
+        case GL_ALREADY_SIGNALED:
+        case GL_CONDITION_SATISFIED:
+            break;
+        case GL_TIMEOUT_EXPIRED:
+        case GL_WAIT_FAILED:
+            UNREACHABLE_MSG("Fence wait failed");
+            break;
+        }
+        Discard();
+    }
+
+    void Discard() override {
+        DEBUG_ASSERT(sync);
+        glDeleteSync(sync);
+        sync = nullptr;
+        owned = false;
+    }
+
+    bool IsAvailable() override {
+        if (owned) {
+            return false;
+        }
+        if (!sync) {
+            return true;
+        }
+        switch (glClientWaitSync(sync, 0, 0)) {
+        case GL_TIMEOUT_EXPIRED:
+            // The fence is unavailable
+            return false;
+        case GL_ALREADY_SIGNALED:
+        case GL_CONDITION_SATISFIED:
+            break;
+        case GL_WAIT_FAILED:
+            UNREACHABLE_MSG("Fence wait failed");
+            break;
+        default:
+            UNREACHABLE_MSG("Unknown glClientWaitSync result");
+            break;
+        }
+        // The fence has been signaled, we can destroy it
+        glDeleteSync(sync);
+        sync = nullptr;
+        return true;
+    }
+
+    void Bind(GLenum target) const override {
+        glBindBuffer(target, buffer.handle);
+    }
+
+private:
+    OGLBuffer buffer;
+    GLsync sync{};
+    u8* pointer{};
+    bool is_read_buffer{};
+    bool owned{};
+};
+
+class CpuStagingBuffer final : public StagingBuffer {
+public:
+    explicit CpuStagingBuffer(std::size_t size) : pointer{std::make_unique<u8[]>(size)} {}
+
+    ~CpuStagingBuffer() override = default;
+
+    u8* Map([[maybe_unused]] std::size_t size) const override {
+        return pointer.get();
+    }
+
+    u8* GetOpenGLPointer() const override {
+        return pointer.get();
+    }
+
+    void Unmap([[maybe_unused]] std::size_t size) const override {}
+
+    void QueueFence(bool own) override {
+        // We don't queue anything here
+    }
+
+    void WaitFence() override {
+        // CPU operations are immediate, we don't wait for anything
+    }
+
+    void Discard() override {
+        UNREACHABLE_MSG("CpuStagingBuffer doesn't support deferred operations");
+    }
+
+    bool IsAvailable() override {
+        // A CPU buffer is always available, operations are immediate
+        return true;
+    }
+
+    void Bind(GLenum target) const override {
+        // OpenGL operations that use CPU buffers need that the target is zero
+        glBindBuffer(target, 0);
+    }
+
+private:
+    std::unique_ptr<u8[]> pointer;
+};
+
 StagingBufferCache::StagingBufferCache(const Device& device)
     : VideoCommon::StagingBufferCache<StagingBuffer>{!device.HasBrokenPBOStreaming()},
       device{device} {}
@@ -19,130 +167,10 @@ StagingBufferCache::~StagingBufferCache() = default;
 
 std::unique_ptr<StagingBuffer> StagingBufferCache::CreateBuffer(std::size_t size, bool is_flush) {
     if (device.HasBrokenPBOStreaming()) {
-        return std::unique_ptr<StagingBuffer>(new CpuStagingBuffer(size, is_flush));
+        return std::unique_ptr<StagingBuffer>(new CpuStagingBuffer(size));
     } else {
         return std::unique_ptr<StagingBuffer>(new PersistentStagingBuffer(size, is_flush));
     }
-}
-
-PersistentStagingBuffer::PersistentStagingBuffer(std::size_t size, bool is_readable)
-    : is_readable{is_readable} {
-    buffer.Create();
-    glNamedBufferStorage(buffer.handle, static_cast<GLsizeiptr>(size), nullptr,
-                         GL_MAP_PERSISTENT_BIT |
-                             (is_readable ? GL_MAP_READ_BIT : GL_MAP_WRITE_BIT));
-    pointer = reinterpret_cast<u8*>(glMapNamedBufferRange(
-        buffer.handle, 0, static_cast<GLsizeiptr>(size),
-        GL_MAP_PERSISTENT_BIT | (is_readable ? GL_MAP_READ_BIT
-                                             : (GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT |
-                                                GL_MAP_UNSYNCHRONIZED_BIT))));
-}
-
-PersistentStagingBuffer::~PersistentStagingBuffer() {
-    if (sync) {
-        glDeleteSync(sync);
-    }
-}
-
-u8* PersistentStagingBuffer::GetOpenGLPointer() const {
-    return nullptr;
-}
-
-u8* PersistentStagingBuffer::Map([[maybe_unused]] std::size_t size) const {
-    return pointer;
-}
-
-void PersistentStagingBuffer::Unmap(std::size_t size) const {
-    if (!is_readable) {
-        glFlushMappedNamedBufferRange(buffer.handle, 0, size);
-    }
-}
-
-void PersistentStagingBuffer::QueueFence(bool own) {
-    DEBUG_ASSERT(!sync);
-    owned = own;
-    sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
-}
-
-void PersistentStagingBuffer::WaitFence() {
-    DEBUG_ASSERT(sync);
-    switch (glClientWaitSync(sync, 0, GL_TIMEOUT_IGNORED)) {
-    case GL_ALREADY_SIGNALED:
-    case GL_CONDITION_SATISFIED:
-        break;
-    case GL_TIMEOUT_EXPIRED:
-    case GL_WAIT_FAILED:
-        UNREACHABLE_MSG("Fence wait failed");
-        break;
-    }
-    Discard();
-}
-
-void PersistentStagingBuffer::Discard() {
-    DEBUG_ASSERT(sync);
-    glDeleteSync(sync);
-    sync = nullptr;
-    owned = false;
-}
-
-bool PersistentStagingBuffer::IsAvailable() {
-    if (owned) {
-        return false;
-    }
-    if (!sync) {
-        return true;
-    }
-    switch (glClientWaitSync(sync, 0, 0)) {
-    case GL_TIMEOUT_EXPIRED:
-        return false;
-    case GL_ALREADY_SIGNALED:
-    case GL_CONDITION_SATISFIED:
-        break;
-    case GL_WAIT_FAILED:
-        UNREACHABLE_MSG("Fence wait failed");
-        break;
-    default:
-        UNREACHABLE_MSG("Unknown glClientWaitSync result");
-        break;
-    }
-    glDeleteSync(sync);
-    sync = nullptr;
-    return true;
-}
-
-void PersistentStagingBuffer::Bind(GLenum target) const {
-    glBindBuffer(target, buffer.handle);
-}
-
-CpuStagingBuffer::CpuStagingBuffer(std::size_t size, bool is_readable)
-    : pointer{std::make_unique<u8[]>(size)} {}
-
-CpuStagingBuffer::~CpuStagingBuffer() = default;
-
-u8* CpuStagingBuffer::Map(std::size_t size) const {
-    return pointer.get();
-}
-
-u8* CpuStagingBuffer::GetOpenGLPointer() const {
-    return pointer.get();
-}
-
-void CpuStagingBuffer::Unmap(std::size_t size) const {}
-
-void CpuStagingBuffer::QueueFence(bool own) {}
-
-void CpuStagingBuffer::WaitFence() {}
-
-void CpuStagingBuffer::Discard() {
-    UNREACHABLE();
-}
-
-bool CpuStagingBuffer::IsAvailable() {
-    return true;
-}
-
-void CpuStagingBuffer::Bind(GLenum target) const {
-    glBindBuffer(target, 0);
 }
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_staging_buffer.cpp
+++ b/src/video_core/renderer_opengl/gl_staging_buffer.cpp
@@ -1,0 +1,148 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <memory>
+#include <glad/glad.h>
+#include "common/assert.h"
+#include "video_core/renderer_opengl/gl_device.h"
+#include "video_core/renderer_opengl/gl_resource_manager.h"
+#include "video_core/renderer_opengl/gl_staging_buffer.h"
+
+namespace OpenGL {
+
+StagingBufferCache::StagingBufferCache(const Device& device)
+    : VideoCommon::StagingBufferCache<StagingBuffer>{!device.HasBrokenPBOStreaming()},
+      device{device} {}
+
+StagingBufferCache::~StagingBufferCache() = default;
+
+std::unique_ptr<StagingBuffer> StagingBufferCache::CreateBuffer(std::size_t size, bool is_flush) {
+    if (device.HasBrokenPBOStreaming()) {
+        return std::unique_ptr<StagingBuffer>(new CpuStagingBuffer(size, is_flush));
+    } else {
+        return std::unique_ptr<StagingBuffer>(new PersistentStagingBuffer(size, is_flush));
+    }
+}
+
+PersistentStagingBuffer::PersistentStagingBuffer(std::size_t size, bool is_readable)
+    : is_readable{is_readable} {
+    buffer.Create();
+    glNamedBufferStorage(buffer.handle, static_cast<GLsizeiptr>(size), nullptr,
+                         GL_MAP_PERSISTENT_BIT |
+                             (is_readable ? GL_MAP_READ_BIT : GL_MAP_WRITE_BIT));
+    pointer = reinterpret_cast<u8*>(glMapNamedBufferRange(
+        buffer.handle, 0, static_cast<GLsizeiptr>(size),
+        GL_MAP_PERSISTENT_BIT | (is_readable ? GL_MAP_READ_BIT
+                                             : (GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT |
+                                                GL_MAP_UNSYNCHRONIZED_BIT))));
+}
+
+PersistentStagingBuffer::~PersistentStagingBuffer() {
+    if (sync) {
+        glDeleteSync(sync);
+    }
+}
+
+u8* PersistentStagingBuffer::GetOpenGLPointer() const {
+    return nullptr;
+}
+
+u8* PersistentStagingBuffer::Map([[maybe_unused]] std::size_t size) const {
+    return pointer;
+}
+
+void PersistentStagingBuffer::Unmap(std::size_t size) const {
+    if (!is_readable) {
+        glFlushMappedNamedBufferRange(buffer.handle, 0, size);
+    }
+}
+
+void PersistentStagingBuffer::QueueFence(bool own) {
+    DEBUG_ASSERT(!sync);
+    owned = own;
+    sync = glFenceSync(GL_SYNC_GPU_COMMANDS_COMPLETE, 0);
+}
+
+void PersistentStagingBuffer::WaitFence() {
+    DEBUG_ASSERT(sync);
+    switch (glClientWaitSync(sync, 0, GL_TIMEOUT_IGNORED)) {
+    case GL_ALREADY_SIGNALED:
+    case GL_CONDITION_SATISFIED:
+        break;
+    case GL_TIMEOUT_EXPIRED:
+    case GL_WAIT_FAILED:
+        UNREACHABLE_MSG("Fence wait failed");
+        break;
+    }
+    Discard();
+}
+
+void PersistentStagingBuffer::Discard() {
+    DEBUG_ASSERT(sync);
+    glDeleteSync(sync);
+    sync = nullptr;
+    owned = false;
+}
+
+bool PersistentStagingBuffer::IsAvailable() {
+    if (owned) {
+        return false;
+    }
+    if (!sync) {
+        return true;
+    }
+    switch (glClientWaitSync(sync, 0, 0)) {
+    case GL_TIMEOUT_EXPIRED:
+        return false;
+    case GL_ALREADY_SIGNALED:
+    case GL_CONDITION_SATISFIED:
+        break;
+    case GL_WAIT_FAILED:
+        UNREACHABLE_MSG("Fence wait failed");
+        break;
+    default:
+        UNREACHABLE_MSG("Unknown glClientWaitSync result");
+        break;
+    }
+    glDeleteSync(sync);
+    sync = nullptr;
+    return true;
+}
+
+void PersistentStagingBuffer::Bind(GLenum target) const {
+    glBindBuffer(target, buffer.handle);
+}
+
+CpuStagingBuffer::CpuStagingBuffer(std::size_t size, bool is_readable)
+    : pointer{std::make_unique<u8[]>(size)} {}
+
+CpuStagingBuffer::~CpuStagingBuffer() = default;
+
+u8* CpuStagingBuffer::Map(std::size_t size) const {
+    return pointer.get();
+}
+
+u8* CpuStagingBuffer::GetOpenGLPointer() const {
+    return pointer.get();
+}
+
+void CpuStagingBuffer::Unmap(std::size_t size) const {}
+
+void CpuStagingBuffer::QueueFence(bool own) {}
+
+void CpuStagingBuffer::WaitFence() {}
+
+void CpuStagingBuffer::Discard() {
+    UNREACHABLE();
+}
+
+bool CpuStagingBuffer::IsAvailable() {
+    return true;
+}
+
+void CpuStagingBuffer::Bind(GLenum target) const {
+    glBindBuffer(target, 0);
+}
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_staging_buffer.cpp
+++ b/src/video_core/renderer_opengl/gl_staging_buffer.cpp
@@ -87,19 +87,10 @@ public:
         if (!sync) {
             return true;
         }
-        switch (glClientWaitSync(sync, 0, 0)) {
-        case GL_TIMEOUT_EXPIRED:
-            // The fence is unavailable
+        GLint status;
+        glGetSynciv(sync, GL_SYNC_STATUS, sizeof(GLint), nullptr, &status);
+        if (status == GL_UNSIGNALED) {
             return false;
-        case GL_ALREADY_SIGNALED:
-        case GL_CONDITION_SATISFIED:
-            break;
-        case GL_WAIT_FAILED:
-            UNREACHABLE_MSG("Fence wait failed");
-            break;
-        default:
-            UNREACHABLE_MSG("Unknown glClientWaitSync result");
-            break;
         }
         // The fence has been signaled, we can destroy it
         glDeleteSync(sync);

--- a/src/video_core/renderer_opengl/gl_staging_buffer.cpp
+++ b/src/video_core/renderer_opengl/gl_staging_buffer.cpp
@@ -15,8 +15,10 @@ class PersistentStagingBuffer final : public StagingBuffer {
 public:
     explicit PersistentStagingBuffer(std::size_t size, bool is_read_buffer)
         : is_read_buffer{is_read_buffer} {
-        constexpr GLenum storage_read = GL_MAP_PERSISTENT_BIT | GL_MAP_READ_BIT;
-        constexpr GLenum storage_write = GL_MAP_PERSISTENT_BIT | GL_MAP_WRITE_BIT;
+        constexpr GLenum storage_read =
+            GL_CLIENT_STORAGE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_READ_BIT;
+        constexpr GLenum storage_write =
+            GL_CLIENT_STORAGE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_WRITE_BIT;
         constexpr GLenum map_read = GL_MAP_PERSISTENT_BIT | GL_MAP_READ_BIT;
         constexpr GLenum map_write = GL_MAP_PERSISTENT_BIT | GL_MAP_WRITE_BIT |
                                      GL_MAP_FLUSH_EXPLICIT_BIT | GL_MAP_UNSYNCHRONIZED_BIT;

--- a/src/video_core/renderer_opengl/gl_staging_buffer.h
+++ b/src/video_core/renderer_opengl/gl_staging_buffer.h
@@ -31,75 +31,30 @@ class StagingBuffer : public NonCopyable {
 public:
     virtual ~StagingBuffer() = default;
 
+    /// Returns the base pointer passed to an OpenGL function.
     [[nodiscard]] virtual u8* GetOpenGLPointer() const = 0;
 
+    /// Maps the staging buffer.
     [[nodiscard]] virtual u8* Map(std::size_t size) const = 0;
 
+    /// Unmaps the staging buffer
     virtual void Unmap(std::size_t size) const = 0;
 
+    /// Inserts a fence in the OpenGL pipeline.
+    /// @param own Protects the fence from being used before it's waited, intended for flushes.
     virtual void QueueFence(bool own) = 0;
 
+    /// Waits for a fence and releases the ownership.
     virtual void WaitFence() = 0;
 
+    /// Discards the deferred operation and its bound fence. A fence must be queued.
     virtual void Discard() = 0;
 
+    /// Returns true when the fence is available.
     [[nodiscard]] virtual bool IsAvailable() = 0;
 
+    /// Binds the staging buffer handle to an OpenGL target.
     virtual void Bind(GLenum target) const = 0;
-};
-
-class PersistentStagingBuffer final : public StagingBuffer {
-public:
-    explicit PersistentStagingBuffer(std::size_t size, bool is_readable);
-    ~PersistentStagingBuffer() override;
-
-    u8* GetOpenGLPointer() const override;
-
-    u8* Map(std::size_t size) const override;
-
-    void Unmap(std::size_t size) const override;
-
-    void QueueFence(bool own) override;
-
-    void WaitFence() override;
-
-    void Discard() override;
-
-    bool IsAvailable() override;
-
-    void Bind(GLenum target) const override;
-
-private:
-    OGLBuffer buffer;
-    GLsync sync{};
-    u8* pointer{};
-    bool is_readable{};
-    bool owned{};
-};
-
-class CpuStagingBuffer final : public StagingBuffer {
-public:
-    explicit CpuStagingBuffer(std::size_t size, bool is_readable);
-    ~CpuStagingBuffer() override;
-
-    u8* GetOpenGLPointer() const override;
-
-    u8* Map(std::size_t size) const override;
-
-    void Unmap(std::size_t size) const override;
-
-    void QueueFence(bool own) override;
-
-    void WaitFence() override;
-
-    void Discard() override;
-
-    bool IsAvailable() override;
-
-    void Bind(GLenum target) const override;
-
-private:
-    std::unique_ptr<u8[]> pointer;
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_staging_buffer.h
+++ b/src/video_core/renderer_opengl/gl_staging_buffer.h
@@ -1,0 +1,105 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <glad/glad.h>
+#include "common/common_types.h"
+#include "video_core/renderer_opengl/gl_resource_manager.h"
+#include "video_core/staging_buffer_cache.h"
+
+namespace OpenGL {
+
+class Device;
+class StagingBuffer;
+
+class StagingBufferCache final : public VideoCommon::StagingBufferCache<StagingBuffer> {
+public:
+    explicit StagingBufferCache(const Device& device);
+    ~StagingBufferCache() override;
+
+protected:
+    std::unique_ptr<StagingBuffer> CreateBuffer(std::size_t size, bool is_flush) override;
+
+private:
+    const Device& device;
+};
+
+class StagingBuffer : public NonCopyable {
+public:
+    virtual ~StagingBuffer() = default;
+
+    [[nodiscard]] virtual u8* GetOpenGLPointer() const = 0;
+
+    [[nodiscard]] virtual u8* Map(std::size_t size) const = 0;
+
+    virtual void Unmap(std::size_t size) const = 0;
+
+    virtual void QueueFence(bool own) = 0;
+
+    virtual void WaitFence() = 0;
+
+    virtual void Discard() = 0;
+
+    [[nodiscard]] virtual bool IsAvailable() = 0;
+
+    virtual void Bind(GLenum target) const = 0;
+};
+
+class PersistentStagingBuffer final : public StagingBuffer {
+public:
+    explicit PersistentStagingBuffer(std::size_t size, bool is_readable);
+    ~PersistentStagingBuffer() override;
+
+    u8* GetOpenGLPointer() const override;
+
+    u8* Map(std::size_t size) const override;
+
+    void Unmap(std::size_t size) const override;
+
+    void QueueFence(bool own) override;
+
+    void WaitFence() override;
+
+    void Discard() override;
+
+    bool IsAvailable() override;
+
+    void Bind(GLenum target) const override;
+
+private:
+    OGLBuffer buffer;
+    GLsync sync{};
+    u8* pointer{};
+    bool is_readable{};
+    bool owned{};
+};
+
+class CpuStagingBuffer final : public StagingBuffer {
+public:
+    explicit CpuStagingBuffer(std::size_t size, bool is_readable);
+    ~CpuStagingBuffer() override;
+
+    u8* GetOpenGLPointer() const override;
+
+    u8* Map(std::size_t size) const override;
+
+    void Unmap(std::size_t size) const override;
+
+    void QueueFence(bool own) override;
+
+    void WaitFence() override;
+
+    void Discard() override;
+
+    bool IsAvailable() override;
+
+    void Bind(GLenum target) const override;
+
+private:
+    std::unique_ptr<u8[]> pointer;
+};
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -122,9 +122,13 @@ public:
     explicit StagingBuffer(std::size_t size);
     ~StagingBuffer();
 
-    void QueueFence();
+    void QueueFence(bool own);
 
-    [[nodiscard]] bool IsAvailable() const;
+    void WaitFence();
+
+    void Discard();
+
+    [[nodiscard]] bool IsAvailable();
 
     [[nodiscard]] GLuint GetHandle() const {
         return buffer.handle;
@@ -136,8 +140,9 @@ public:
 
 private:
     OGLBuffer buffer;
-    OGLSync sync;
+    GLsync sync{};
     u8* pointer{};
+    bool owned{};
 };
 
 class TextureCacheOpenGL final : public TextureCacheBase {

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -17,8 +17,8 @@
 #include "video_core/engines/shader_bytecode.h"
 #include "video_core/renderer_opengl/gl_device.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
-#include "video_core/texture_cache/texture_cache.h"
 #include "video_core/renderer_opengl/gl_staging_buffer.h"
+#include "video_core/texture_cache/texture_cache.h"
 
 namespace OpenGL {
 

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -18,6 +18,7 @@
 #include "video_core/renderer_opengl/gl_device.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/texture_cache/texture_cache.h"
+#include "video_core/renderer_opengl/gl_staging_buffer.h"
 
 namespace OpenGL {
 
@@ -59,7 +60,7 @@ protected:
     View CreateViewInner(const ViewParams& view_key, bool is_proxy);
 
 private:
-    void UploadTextureMipmap(u32 level, const StagingBuffer& staging_buffer);
+    void UploadTextureMipmap(u32 level, const u8* opengl_pointer);
 
     GLenum internal_format{};
     GLenum format{};
@@ -115,34 +116,6 @@ private:
     OGLTextureView texture_view;
     u32 swizzle;
     bool is_proxy;
-};
-
-class StagingBuffer final {
-public:
-    explicit StagingBuffer(std::size_t size);
-    ~StagingBuffer();
-
-    void QueueFence(bool own);
-
-    void WaitFence();
-
-    void Discard();
-
-    [[nodiscard]] bool IsAvailable();
-
-    [[nodiscard]] GLuint GetHandle() const {
-        return buffer.handle;
-    }
-
-    [[nodiscard]] u8* GetPointer() const {
-        return pointer;
-    }
-
-private:
-    OGLBuffer buffer;
-    GLsync sync{};
-    u8* pointer{};
-    bool owned{};
 };
 
 class TextureCacheOpenGL final : public TextureCacheBase {

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -172,6 +172,7 @@ void RendererOpenGL::LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuf
                              framebuffer.stride, block_height_log2, framebuffer.height, 0, 1, 1,
                              gl_framebuffer_data.data(), host_ptr);
 
+    glBindBuffer(GL_PIXEL_UNPACK_BUFFER, 0);
     glPixelStorei(GL_UNPACK_ROW_LENGTH, static_cast<GLint>(framebuffer.stride));
 
     // Update existing texture

--- a/src/video_core/staging_buffer_cache.h
+++ b/src/video_core/staging_buffer_cache.h
@@ -23,15 +23,15 @@ public:
     explicit StagingBufferCache(bool can_flush_aot) : can_flush_aot{can_flush_aot} {}
     virtual ~StagingBufferCache() = default;
 
-    [[nodiscard]] StagingBufferType& GetWriteBuffer(std::size_t size) {
+    StagingBufferType& GetWriteBuffer(std::size_t size) {
         return GetBuffer(size, false);
     }
 
-    [[nodiscard]] StagingBufferType& GetReadBuffer(std::size_t size) {
+    StagingBufferType& GetReadBuffer(std::size_t size) {
         return GetBuffer(size, true);
     }
 
-    [[nodiscard]] bool CanFlushAheadOfTime() const {
+    bool CanFlushAheadOfTime() const {
         return can_flush_aot;
     }
 

--- a/src/video_core/staging_buffer_cache.h
+++ b/src/video_core/staging_buffer_cache.h
@@ -17,24 +17,42 @@ namespace VideoCommon {
 
 template <typename StagingBufferType>
 class StagingBufferCache {
-public:
-    explicit StagingBufferCache() = default;
-    ~StagingBufferCache() = default;
+    using Cache = std::unordered_map<u32, std::vector<std::unique_ptr<StagingBufferType>>>;
 
-    StagingBufferType& GetBuffer(std::size_t size) {
+public:
+    explicit StagingBufferCache(bool can_flush_aot) : can_flush_aot{can_flush_aot} {}
+    virtual ~StagingBufferCache() = default;
+
+    [[nodiscard]] StagingBufferType& GetWriteBuffer(std::size_t size) {
+        return GetBuffer(size, false);
+    }
+
+    [[nodiscard]] StagingBufferType& GetReadBuffer(std::size_t size) {
+        return GetBuffer(size, true);
+    }
+
+    [[nodiscard]] bool CanFlushAheadOfTime() const {
+        return can_flush_aot;
+    }
+
+protected:
+    virtual std::unique_ptr<StagingBufferType> CreateBuffer(std::size_t size, bool is_flush) = 0;
+
+private:
+    StagingBufferType& GetBuffer(std::size_t size, bool is_flush) {
         const u32 ceil = Common::Log2Ceil64(size);
-        auto& buffers = cache[ceil];
+        auto& buffers = (is_flush ? flush_cache : upload_cache)[ceil];
         const auto it = std::find_if(buffers.begin(), buffers.end(),
                                      [](auto& buffer) { return buffer->IsAvailable(); });
         if (it != buffers.end()) {
             return **it;
         }
-        const std::size_t buf_size = 1ULL << ceil;
-        return *buffers.emplace_back(std::make_unique<StagingBufferType>(buf_size));
+        return *buffers.emplace_back(CreateBuffer(1ULL << ceil, is_flush));
     }
 
-private:
-    std::unordered_map<u32, std::vector<std::unique_ptr<StagingBufferType>>> cache;
+    bool can_flush_aot{};
+    Cache upload_cache;
+    Cache flush_cache;
 };
 
 } // namespace VideoCommon

--- a/src/video_core/staging_buffer_cache.h
+++ b/src/video_core/staging_buffer_cache.h
@@ -25,7 +25,7 @@ public:
         const u32 ceil = Common::Log2Ceil64(size);
         auto& buffers = cache[ceil];
         const auto it = std::find_if(buffers.begin(), buffers.end(),
-                                     [](const auto& buffer) { return buffer->IsAvailable(); });
+                                     [](auto& buffer) { return buffer->IsAvailable(); });
         if (it != buffers.end()) {
             return **it;
         }

--- a/src/video_core/staging_buffer_cache.h
+++ b/src/video_core/staging_buffer_cache.h
@@ -1,0 +1,40 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <unordered_map>
+#include <vector>
+
+#include "common/bit_util.h"
+#include "common/common_types.h"
+
+namespace VideoCommon {
+
+template <typename StagingBufferType>
+class StagingBufferCache {
+public:
+    explicit StagingBufferCache() = default;
+    ~StagingBufferCache() = default;
+
+    StagingBufferType& GetBuffer(std::size_t size) {
+        const u32 ceil = Common::Log2Ceil64(size);
+        auto& buffers = cache[ceil];
+        const auto it = std::find_if(buffers.begin(), buffers.end(),
+                                     [](const auto& buffer) { return buffer->IsAvailable(); });
+        if (it != buffers.end()) {
+            return **it;
+        }
+        const std::size_t buf_size = 1ULL << ceil;
+        return *buffers.emplace_back(std::make_unique<StagingBufferType>(buf_size));
+    }
+
+private:
+    std::unordered_map<u32, std::vector<std::unique_ptr<StagingBufferType>>> cache;
+};
+
+} // namespace VideoCommon

--- a/src/video_core/texture_cache/surface_base.h
+++ b/src/video_core/texture_cache/surface_base.h
@@ -197,13 +197,13 @@ public:
         }
     }
 
-    void MarkAsRenderTarget(const bool is_target, const u32 index) {
-        this->is_target = is_target;
-        this->index = index;
+    void MarkAsRenderTarget(const bool is_target_, const u32 index_) {
+        is_target = is_target_;
+        index = index_;
     }
 
-    void MarkAsPicked(const bool is_picked) {
-        this->is_picked = is_picked;
+    void MarkAsPicked(const bool is_picked_) {
+        is_picked = is_picked_;
     }
 
     bool IsModified() const {
@@ -211,7 +211,7 @@ public:
     }
 
     bool IsProtected() const {
-        // Only 3D Slices are to be protected
+        // Only 3D slices are to be protected
         return is_target && params.block_depth > 0;
     }
 

--- a/src/video_core/texture_cache/surface_base.h
+++ b/src/video_core/texture_cache/surface_base.h
@@ -177,9 +177,24 @@ public:
 
     virtual void DownloadTexture(StagingBufferType& buffer) = 0;
 
+    void SetFlushBuffer(StagingBufferType* buffer) {
+        flush_buffer = buffer;
+    }
+
+    StagingBufferType* GetFlushBuffer() const {
+        return flush_buffer;
+    }
+
     void MarkAsModified(const bool is_modified_, const u64 tick) {
         is_modified = is_modified_ || is_target;
         modification_tick = tick;
+
+        if (is_modified && flush_buffer) {
+            // The buffer has been modified while we thought it was no longer being to be used and
+            // we queued a flush.
+            flush_buffer->Discard();
+            flush_buffer = nullptr;
+        }
     }
 
     void MarkAsRenderTarget(const bool is_target, const u32 index) {
@@ -303,6 +318,8 @@ private:
     bool is_picked{};
     u32 index{NO_RT};
     u64 modification_tick{};
+
+    StagingBufferType* flush_buffer{};
 };
 
 } // namespace VideoCommon


### PR DESCRIPTION
Instead of flushing textures when "the guest wants them" we flush ahead of time when a linear render target is detached. For most cases this means that when the guest requests for texture memory we wait for a fence and swizzle the texture instead of halting the whole OpenGL pipeline and waiting for the GPU to finish. This heuristic might harm performance on games that render to linear textures but never read them from the CPU, I haven't found a case where this is true.

This also moves texture uploads/downloads to OpenGL buffers potentially avoiding a memcpy in the driver.

The whole fast path is disabled on Intel's proprietary driver since it was throwing `GL_OUT_OF_MEMORY` errors with it. It falls back to classic client side buffers for uploads and downloads, with ahead of time flushing disabled. From my testing, it improves performance on Nvidia and AMD GPUs.

Thanks to exzap for explaining me why `glFlush` is required after `glGetTextureImage` calls, the explanation is in the code.