### PR TITLE
shader/decode/other: Correct branch indirect argument within BRA handling

### DIFF
--- a/src/video_core/shader/decode/other.cpp
+++ b/src/video_core/shader/decode/other.cpp
@@ -102,7 +102,7 @@ u32 ShaderIR::DecodeOther(NodeBlock& bb, u32 pc) {
                                                  PRECISE, op_a, Immediate(3));
             const Node operand =
                 Operation(OperationCode::IAdd, PRECISE, convert, Immediate(target));
-            branch = Operation(OperationCode::BranchIndirect, convert);
+            branch = Operation(OperationCode::BranchIndirect, operand);
         }
 
         const Tegra::Shader::ConditionCode cc = instr.flow_condition_code;


### PR DESCRIPTION
This appears to have been a copy/paste error introduced within 8a6fc529a968e007f01464abadd32f9b5eb0a26c