### PR TITLE
service/audren_u: Unstub ListAudioDeviceName

### DIFF
--- a/src/core/hle/service/audio/audio.cpp
+++ b/src/core/hle/service/audio/audio.cpp
@@ -19,16 +19,16 @@
 
 namespace Service::Audio {
 
-void InstallInterfaces(SM::ServiceManager& service_manager) {
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {
     std::make_shared<AudCtl>()->InstallAsService(service_manager);
     std::make_shared<AudOutA>()->InstallAsService(service_manager);
-    std::make_shared<AudOutU>()->InstallAsService(service_manager);
+    std::make_shared<AudOutU>(system)->InstallAsService(service_manager);
     std::make_shared<AudInA>()->InstallAsService(service_manager);
     std::make_shared<AudInU>()->InstallAsService(service_manager);
     std::make_shared<AudRecA>()->InstallAsService(service_manager);
     std::make_shared<AudRecU>()->InstallAsService(service_manager);
     std::make_shared<AudRenA>()->InstallAsService(service_manager);
-    std::make_shared<AudRenU>()->InstallAsService(service_manager);
+    std::make_shared<AudRenU>(system)->InstallAsService(service_manager);
     std::make_shared<CodecCtl>()->InstallAsService(service_manager);
     std::make_shared<HwOpus>()->InstallAsService(service_manager);
 

--- a/src/core/hle/service/audio/audio.h
+++ b/src/core/hle/service/audio/audio.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
@@ -11,6 +15,6 @@ class ServiceManager;
 namespace Service::Audio {
 
 /// Registers all Audio services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audout_u.h
+++ b/src/core/hle/service/audio/audout_u.h
@@ -11,6 +11,10 @@ namespace AudioCore {
 class AudioOut;
 }
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 class HLERequestContext;
 }
@@ -21,15 +25,17 @@ class IAudioOut;
 
 class AudOutU final : public ServiceFramework<AudOutU> {
 public:
-    AudOutU();
+    explicit AudOutU(Core::System& system_);
     ~AudOutU() override;
 
 private:
+    void ListAudioOutsImpl(Kernel::HLERequestContext& ctx);
+    void OpenAudioOutImpl(Kernel::HLERequestContext& ctx);
+
     std::vector<std::shared_ptr<IAudioOut>> audio_out_interfaces;
     std::unique_ptr<AudioCore::AudioOut> audio_core;
 
-    void ListAudioOutsImpl(Kernel::HLERequestContext& ctx);
-    void OpenAudioOutImpl(Kernel::HLERequestContext& ctx);
+    Core::System& system;
 };
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -242,9 +242,8 @@ private:
 
         ctx.WriteBuffer(out_device_name);
 
-        IPC::ResponseBuilder rb{ctx, 3};
+        IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
-        rb.Push<u32>(1);
     }
 
     void QueryAudioDeviceSystemEvent(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/audio/audren_u.h
+++ b/src/core/hle/service/audio/audren_u.h
@@ -30,16 +30,18 @@ private:
 
     void OpenAudioRendererImpl(Kernel::HLERequestContext& ctx);
 
-    enum class AudioFeatures : u32 {
-        Splitter,
-        PerformanceMetricsVersion2,
-        VariadicCommandBuffer,
-    };
-
-    bool IsFeatureSupported(AudioFeatures feature, u32_le revision) const;
-
     std::size_t audren_instance_count = 0;
     Core::System& system;
 };
+
+// Describes a particular audio feature that may be supported in a particular revision.
+enum class AudioFeatures : u32 {
+    Splitter,
+    PerformanceMetricsVersion2,
+    VariadicCommandBuffer,
+};
+
+// Tests if a particular audio feature is supported with a given audio revision.
+bool IsFeatureSupported(AudioFeatures feature, u32_le revision);
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audren_u.h
+++ b/src/core/hle/service/audio/audren_u.h
@@ -6,6 +6,10 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 class HLERequestContext;
 }
@@ -14,7 +18,7 @@ namespace Service::Audio {
 
 class AudRenU final : public ServiceFramework<AudRenU> {
 public:
-    explicit AudRenU();
+    explicit AudRenU(Core::System& system_);
     ~AudRenU() override;
 
 private:
@@ -33,7 +37,9 @@ private:
     };
 
     bool IsFeatureSupported(AudioFeatures feature, u32_le revision) const;
+
     std::size_t audren_instance_count = 0;
+    Core::System& system;
 };
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audren_u.h
+++ b/src/core/hle/service/audio/audren_u.h
@@ -36,6 +36,7 @@ private:
 
 // Describes a particular audio feature that may be supported in a particular revision.
 enum class AudioFeatures : u32 {
+    AudioUSBDeviceOutput,
     Splitter,
     PerformanceMetricsVersion2,
     VariadicCommandBuffer,

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -206,7 +206,7 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system) {
     AM::InstallInterfaces(*sm, nv_flinger, system);
     AOC::InstallInterfaces(*sm);
     APM::InstallInterfaces(system);
-    Audio::InstallInterfaces(*sm);
+    Audio::InstallInterfaces(*sm, system);
     BCAT::InstallInterfaces(*sm);
     BPC::InstallInterfaces(*sm);
     BtDrv::InstallInterfaces(*sm);


### PR DESCRIPTION
Unstubs ListAudioDeviceName and properly lists the device names, along with placing revision handling in place for the function as well. In the process this also unstubs GetAudioDeviceServiceWithRevisionInfo() due to said revision handling.

This also makes our reported active device name consistent with the actual names available. Previously it was returning a completely different name from the ones that would have otherwise been listed through ListAudioDeviceName(), which is incorrect.