### PR TITLE
kernel/vm_manager: Minor cleanup

### DIFF
--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -765,11 +765,14 @@ void VMManager::MergeAdjacentVMA(VirtualMemoryArea& left, const VirtualMemoryAre
             // Fast case: left is an entire backing block.
             left.backing_block->insert(left.backing_block->end(), right_begin, right_end);
         } else {
+            // Slow case: make a new memory block for left and right.
             const auto left_begin = left.backing_block->begin() + left.offset;
             const auto left_end = left_begin + left.size;
+            const auto left_size = static_cast<std::size_t>(std::distance(left_begin, left_end));
+            const auto right_size = static_cast<std::size_t>(std::distance(right_begin, right_end));
 
-            // Slow case: make a new memory block for left and right.
             auto new_memory = std::make_shared<PhysicalMemory>();
+            new_memory->reserve(left_size + right_size);
             new_memory->insert(new_memory->end(), left_begin, left_end);
             new_memory->insert(new_memory->end(), right_begin, right_end);
 

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -773,7 +773,7 @@ void VMManager::MergeAdjacentVMA(VirtualMemoryArea& left, const VirtualMemoryAre
             new_memory->insert(new_memory->end(), left_begin, left_end);
             new_memory->insert(new_memory->end(), right_begin, right_end);
 
-            left.backing_block = new_memory;
+            left.backing_block = std::move(new_memory);
             left.offset = 0;
         }
 

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -342,7 +342,7 @@ ResultCode VMManager::MapPhysicalMemory(VAddr target, u64 size) {
             const auto map_size = std::min(end_addr - cur_addr, vma_end - cur_addr);
             if (vma.state == MemoryState::Unmapped) {
                 const auto map_res =
-                    MapMemoryBlock(cur_addr, std::make_shared<PhysicalMemory>(map_size, 0), 0,
+                    MapMemoryBlock(cur_addr, std::make_shared<PhysicalMemory>(map_size), 0,
                                    map_size, MemoryState::Heap, VMAPermission::ReadWrite);
                 result = map_res.Code();
                 if (result.IsError()) {
@@ -443,7 +443,7 @@ ResultCode VMManager::UnmapPhysicalMemory(VAddr target, u64 size) {
     if (result.IsError()) {
         for (const auto [map_address, map_size] : unmapped_regions) {
             const auto remap_res =
-                MapMemoryBlock(map_address, std::make_shared<PhysicalMemory>(map_size, 0), 0,
+                MapMemoryBlock(map_address, std::make_shared<PhysicalMemory>(map_size), 0,
                                map_size, MemoryState::Heap, VMAPermission::None);
             ASSERT_MSG(remap_res.Succeeded(), "Failed to remap a memory block.");
         }

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -330,7 +330,7 @@ ResultCode VMManager::MapPhysicalMemory(VAddr target, u64 size) {
         cur_addr = target;
 
         auto iter = FindVMA(target);
-        ASSERT_MSG(iter != vma_map.end(), "MapPhysicalMemory iter != end");
+        ASSERT(iter != vma_map.end());
 
         while (true) {
             const auto& vma = iter->second;
@@ -360,7 +360,7 @@ ResultCode VMManager::MapPhysicalMemory(VAddr target, u64 size) {
             // Advance to the next block.
             cur_addr = vma_end;
             iter = FindVMA(cur_addr);
-            ASSERT_MSG(iter != vma_map.end(), "MapPhysicalMemory iter != end");
+            ASSERT(iter != vma_map.end());
         }
     }
 
@@ -368,7 +368,7 @@ ResultCode VMManager::MapPhysicalMemory(VAddr target, u64 size) {
     if (result.IsError()) {
         for (const auto [unmap_address, unmap_size] : mapped_regions) {
             ASSERT_MSG(UnmapRange(unmap_address, unmap_size).IsSuccess(),
-                       "MapPhysicalMemory un-map on error");
+                       "Failed to unmap memory range.");
         }
 
         return result;
@@ -407,7 +407,7 @@ ResultCode VMManager::UnmapPhysicalMemory(VAddr target, u64 size) {
         cur_addr = target;
 
         auto iter = FindVMA(target);
-        ASSERT_MSG(iter != vma_map.end(), "UnmapPhysicalMemory iter != end");
+        ASSERT(iter != vma_map.end());
 
         while (true) {
             const auto& vma = iter->second;
@@ -434,7 +434,7 @@ ResultCode VMManager::UnmapPhysicalMemory(VAddr target, u64 size) {
             // Advance to the next block.
             cur_addr = vma_end;
             iter = FindVMA(cur_addr);
-            ASSERT_MSG(iter != vma_map.end(), "UnmapPhysicalMemory iter != end");
+            ASSERT(iter != vma_map.end());
         }
     }
 
@@ -445,7 +445,7 @@ ResultCode VMManager::UnmapPhysicalMemory(VAddr target, u64 size) {
             const auto remap_res =
                 MapMemoryBlock(map_address, std::make_shared<PhysicalMemory>(map_size, 0), 0,
                                map_size, MemoryState::Heap, VMAPermission::None);
-            ASSERT_MSG(remap_res.Succeeded(), "UnmapPhysicalMemory re-map on error");
+            ASSERT_MSG(remap_res.Succeeded(), "Failed to remap a memory block.");
         }
     }
 
@@ -965,7 +965,7 @@ ResultVal<std::size_t> VMManager::SizeOfAllocatedVMAsInRange(VAddr address,
 
     VAddr cur_addr = address;
     auto iter = FindVMA(cur_addr);
-    ASSERT_MSG(iter != vma_map.end(), "SizeOfAllocatedVMAsInRange iter != end");
+    ASSERT(iter != vma_map.end());
 
     while (true) {
         const auto& vma = iter->second;
@@ -986,7 +986,7 @@ ResultVal<std::size_t> VMManager::SizeOfAllocatedVMAsInRange(VAddr address,
         // Advance to the next block.
         cur_addr = vma_end;
         iter = std::next(iter);
-        ASSERT_MSG(iter != vma_map.end(), "SizeOfAllocatedVMAsInRange iter != end");
+        ASSERT(iter != vma_map.end());
     }
 
     return MakeResult(mapped_size);
@@ -1000,7 +1000,7 @@ ResultVal<std::size_t> VMManager::SizeOfUnmappablePhysicalMemoryInRange(VAddr ad
 
     VAddr cur_addr = address;
     auto iter = FindVMA(cur_addr);
-    ASSERT_MSG(iter != vma_map.end(), "SizeOfUnmappablePhysicalMemoryInRange iter != end");
+    ASSERT(iter != vma_map.end());
 
     while (true) {
         const auto& vma = iter->second;
@@ -1029,7 +1029,7 @@ ResultVal<std::size_t> VMManager::SizeOfUnmappablePhysicalMemoryInRange(VAddr ad
         // Advance to the next block.
         cur_addr = vma_end;
         iter = std::next(iter);
-        ASSERT_MSG(iter != vma_map.end(), "SizeOfUnmappablePhysicalMemoryInRange iter != end");
+        ASSERT(iter != vma_map.end());
     }
 
     return MakeResult(mapped_size);

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -447,6 +447,8 @@ ResultCode VMManager::UnmapPhysicalMemory(VAddr target, u64 size) {
                                map_size, MemoryState::Heap, VMAPermission::None);
             ASSERT_MSG(remap_res.Succeeded(), "Failed to remap a memory block.");
         }
+
+        return result;
     }
 
     // Update mapped amount

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -296,12 +296,6 @@ ResultVal<VAddr> VMManager::SetHeapSize(u64 size) {
 }
 
 ResultCode VMManager::MapPhysicalMemory(VAddr target, u64 size) {
-    const auto end_addr = target + size;
-    const auto last_addr = end_addr - 1;
-    VAddr cur_addr = target;
-
-    ResultCode result = RESULT_SUCCESS;
-
     // Check how much memory we've already mapped.
     const auto mapped_size_result = SizeOfAllocatedVMAsInRange(target, size);
     if (mapped_size_result.Failed()) {
@@ -324,10 +318,13 @@ ResultCode VMManager::MapPhysicalMemory(VAddr target, u64 size) {
 
     // Keep track of the memory regions we unmap.
     std::vector<std::pair<u64, u64>> mapped_regions;
+    ResultCode result = RESULT_SUCCESS;
 
     // Iterate, trying to map memory.
     {
-        cur_addr = target;
+        const auto end_addr = target + size;
+        const auto last_addr = end_addr - 1;
+        VAddr cur_addr = target;
 
         auto iter = FindVMA(target);
         ASSERT(iter != vma_map.end());
@@ -381,12 +378,6 @@ ResultCode VMManager::MapPhysicalMemory(VAddr target, u64 size) {
 }
 
 ResultCode VMManager::UnmapPhysicalMemory(VAddr target, u64 size) {
-    const auto end_addr = target + size;
-    const auto last_addr = end_addr - 1;
-    VAddr cur_addr = target;
-
-    ResultCode result = RESULT_SUCCESS;
-
     // Check how much memory is currently mapped.
     const auto mapped_size_result = SizeOfUnmappablePhysicalMemoryInRange(target, size);
     if (mapped_size_result.Failed()) {
@@ -401,10 +392,13 @@ ResultCode VMManager::UnmapPhysicalMemory(VAddr target, u64 size) {
 
     // Keep track of the memory regions we unmap.
     std::vector<std::pair<u64, u64>> unmapped_regions;
+    ResultCode result = RESULT_SUCCESS;
 
     // Try to unmap regions.
     {
-        cur_addr = target;
+        const auto end_addr = target + size;
+        const auto last_addr = end_addr - 1;
+        VAddr cur_addr = target;
 
         auto iter = FindVMA(target);
         ASSERT(iter != vma_map.end());
@@ -443,8 +437,8 @@ ResultCode VMManager::UnmapPhysicalMemory(VAddr target, u64 size) {
     if (result.IsError()) {
         for (const auto [map_address, map_size] : unmapped_regions) {
             const auto remap_res =
-                MapMemoryBlock(map_address, std::make_shared<PhysicalMemory>(map_size), 0,
-                               map_size, MemoryState::Heap, VMAPermission::None);
+                MapMemoryBlock(map_address, std::make_shared<PhysicalMemory>(map_size), 0, map_size,
+                               MemoryState::Heap, VMAPermission::None);
             ASSERT_MSG(remap_res.Succeeded(), "Failed to remap a memory block.");
         }
 

--- a/src/core/hle/kernel/vm_manager.h
+++ b/src/core/hle/kernel/vm_manager.h
@@ -454,8 +454,8 @@ public:
 
     /// Maps memory at a given address.
     ///
-    /// @param addr The virtual address to map memory at.
-    /// @param size The amount of memory to map.
+    /// @param target The virtual address to map memory at.
+    /// @param size   The amount of memory to map.
     ///
     /// @note The destination address must lie within the Map region.
     ///
@@ -468,8 +468,8 @@ public:
 
     /// Unmaps memory at a given address.
     ///
-    /// @param addr The virtual address to unmap memory at.
-    /// @param size The amount of memory to unmap.
+    /// @param target The virtual address to unmap memory at.
+    /// @param size   The amount of memory to unmap.
     ///
     /// @note The destination address must lie within the Map region.
     ///


### PR DESCRIPTION
Performs some minor cleanup related to the memory manager. Mostly just performs simplifications and very small performance improvements in the slow path of `MergeAdjacentVMA`. One commit fixes a trivial bug within a failure case for `UnmapPhysicalMemory` as well. This case shouldn't be hit within normal (stable) software emulation, so that's likely why it has gone unnoticed until now.