### PR TITLE
MaxwellDMA: Fixes, corrections and relaxations.

### DIFF
--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -5,6 +5,7 @@
 #include "common/assert.h"
 #include "common/logging/log.h"
 #include "core/core.h"
+#include "core/settings.h"
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/engines/maxwell_dma.h"
 #include "video_core/memory_manager.h"
@@ -84,12 +85,16 @@ void MaxwellDMA::HandleCopy() {
     ASSERT(regs.exec.enable_2d == 1);
 
     if (regs.exec.is_dst_linear && !regs.exec.is_src_linear) {
-        ASSERT(regs.src_params.size_z == 1);
+        ASSERT(regs.src_params.BlockDepth() == 0);
         // If the input is tiled and the output is linear, deswizzle the input and copy it over.
-        const u32 src_bytes_per_pixel = regs.src_pitch / regs.src_params.size_x;
+        const u32 bytes_per_pixel = regs.dst_pitch / regs.x_count;
         const std::size_t src_size = Texture::CalculateSize(
-            true, src_bytes_per_pixel, regs.src_params.size_x, regs.src_params.size_y,
+            true, bytes_per_pixel, regs.src_params.size_x, regs.src_params.size_y,
             regs.src_params.size_z, regs.src_params.BlockHeight(), regs.src_params.BlockDepth());
+
+        const std::size_t src_layer_size = Texture::CalculateSize(
+            true, bytes_per_pixel, regs.src_params.size_x, regs.src_params.size_y, 1,
+            regs.src_params.BlockHeight(), regs.src_params.BlockDepth());
 
         const std::size_t dst_size = regs.dst_pitch * regs.y_count;
 
@@ -104,23 +109,23 @@ void MaxwellDMA::HandleCopy() {
         memory_manager.ReadBlock(source, read_buffer.data(), src_size);
         memory_manager.ReadBlock(dest, write_buffer.data(), dst_size);
 
-        Texture::UnswizzleSubrect(regs.x_count, regs.y_count, regs.dst_pitch,
-                                  regs.src_params.size_x, src_bytes_per_pixel, read_buffer.data(),
-                                  write_buffer.data(), regs.src_params.BlockHeight(),
-                                  regs.src_params.pos_x, regs.src_params.pos_y);
+        Texture::UnswizzleSubrect(
+            regs.x_count, regs.y_count, regs.dst_pitch, regs.src_params.size_x, bytes_per_pixel,
+            read_buffer.data() + src_layer_size * regs.src_params.pos_z, write_buffer.data(),
+            regs.src_params.BlockHeight(), regs.src_params.pos_x, regs.src_params.pos_y);
 
         memory_manager.WriteBlock(dest, write_buffer.data(), dst_size);
     } else {
         ASSERT(regs.dst_params.BlockDepth() == 0);
 
-        const u32 src_bytes_per_pixel = regs.src_pitch / regs.x_count;
+        const u32 bytes_per_pixel = regs.src_pitch / regs.x_count;
 
         const std::size_t dst_size = Texture::CalculateSize(
-            true, src_bytes_per_pixel, regs.dst_params.size_x, regs.dst_params.size_y,
+            true, bytes_per_pixel, regs.dst_params.size_x, regs.dst_params.size_y,
             regs.dst_params.size_z, regs.dst_params.BlockHeight(), regs.dst_params.BlockDepth());
 
         const std::size_t dst_layer_size = Texture::CalculateSize(
-            true, src_bytes_per_pixel, regs.dst_params.size_x, regs.dst_params.size_y, 1,
+            true, bytes_per_pixel, regs.dst_params.size_x, regs.dst_params.size_y, 1,
             regs.dst_params.BlockHeight(), regs.dst_params.BlockDepth());
 
         const std::size_t src_size = regs.src_pitch * regs.y_count;
@@ -133,14 +138,19 @@ void MaxwellDMA::HandleCopy() {
             write_buffer.resize(dst_size);
         }
 
-        memory_manager.ReadBlock(source, read_buffer.data(), src_size);
-        memory_manager.ReadBlock(dest, write_buffer.data(), dst_size);
+        if (Settings::values.use_accurate_gpu_emulation) {
+            memory_manager.ReadBlock(source, read_buffer.data(), src_size);
+            memory_manager.ReadBlock(dest, write_buffer.data(), dst_size);
+        } else {
+            memory_manager.ReadBlockUnsafe(source, read_buffer.data(), src_size);
+            memory_manager.ReadBlockUnsafe(dest, write_buffer.data(), dst_size);
+        }
 
         // If the input is linear and the output is tiled, swizzle the input and copy it over.
-        Texture::SwizzleSubrect(regs.x_count, regs.y_count, regs.src_pitch, regs.dst_params.size_x,
-                                src_bytes_per_pixel,
-                                write_buffer.data() + dst_layer_size * regs.dst_params.pos_z,
-                                read_buffer.data(), regs.dst_params.BlockHeight());
+        Texture::SwizzleSubrect(
+            regs.x_count, regs.y_count, regs.src_pitch, regs.dst_params.size_x, bytes_per_pixel,
+            write_buffer.data() + dst_layer_size * regs.dst_params.pos_z, read_buffer.data(),
+            regs.dst_params.BlockHeight(), regs.dst_params.pos_x, regs.dst_params.pos_y);
 
         memory_manager.WriteBlock(dest, write_buffer.data(), dst_size);
     }

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -257,19 +257,21 @@ std::vector<u8> UnswizzleTexture(u8* address, u32 tile_size_x, u32 tile_size_y, 
 
 void SwizzleSubrect(u32 subrect_width, u32 subrect_height, u32 source_pitch, u32 swizzled_width,
                     u32 bytes_per_pixel, u8* swizzled_data, u8* unswizzled_data,
-                    u32 block_height_bit) {
+                    u32 block_height_bit, u32 offset_x, u32 offset_y) {
     const u32 block_height = 1U << block_height_bit;
     const u32 image_width_in_gobs{(swizzled_width * bytes_per_pixel + (gob_size_x - 1)) /
                                   gob_size_x};
     for (u32 line = 0; line < subrect_height; ++line) {
+        const u32 dst_y = line + offset_y;
         const u32 gob_address_y =
-            (line / (gob_size_y * block_height)) * gob_size * block_height * image_width_in_gobs +
-            ((line % (gob_size_y * block_height)) / gob_size_y) * gob_size;
-        const auto& table = legacy_swizzle_table[line % gob_size_y];
+            (dst_y / (gob_size_y * block_height)) * gob_size * block_height * image_width_in_gobs +
+            ((dst_y % (gob_size_y * block_height)) / gob_size_y) * gob_size;
+        const auto& table = legacy_swizzle_table[dst_y % gob_size_y];
         for (u32 x = 0; x < subrect_width; ++x) {
+            const u32 dst_x = x + offset_x;
             const u32 gob_address =
-                gob_address_y + (x * bytes_per_pixel / gob_size_x) * gob_size * block_height;
-            const u32 swizzled_offset = gob_address + table[(x * bytes_per_pixel) % gob_size_x];
+                gob_address_y + (dst_x * bytes_per_pixel / gob_size_x) * gob_size * block_height;
+            const u32 swizzled_offset = gob_address + table[(dst_x * bytes_per_pixel) % gob_size_x];
             u8* source_line = unswizzled_data + line * source_pitch + x * bytes_per_pixel;
             u8* dest_addr = swizzled_data + swizzled_offset;
 

--- a/src/video_core/textures/decoders.h
+++ b/src/video_core/textures/decoders.h
@@ -44,7 +44,8 @@ std::size_t CalculateSize(bool tiled, u32 bytes_per_pixel, u32 width, u32 height
 
 /// Copies an untiled subrectangle into a tiled surface.
 void SwizzleSubrect(u32 subrect_width, u32 subrect_height, u32 source_pitch, u32 swizzled_width,
-                    u32 bytes_per_pixel, u8* swizzled_data, u8* unswizzled_data, u32 block_height);
+                    u32 bytes_per_pixel, u8* swizzled_data, u8* unswizzled_data, u32 block_height,
+                    u32 offset_x, u32 offset_y);
 
 /// Copies a tiled subrectangle into a linear surface.
 void UnswizzleSubrect(u32 subrect_width, u32 subrect_height, u32 dest_pitch, u32 swizzled_width,


### PR DESCRIPTION
This commit fixes offsets on Linear -> Tiled copies, corrects z pos for tiled->linear copies, corrects bytes_per_pixel calculation in tiled -> linear copies and relaxes some limitations set by latest dma fixes 
refactors.