### PR TITLE
ci: Fix Azure PR Builds

### DIFF
--- a/.ci/templates/build-single.yml
+++ b/.ci/templates/build-single.yml
@@ -7,7 +7,7 @@ steps:
   displayName: 'Prepare Environment'
   inputs:
     dockerVersion: '17.09.0-ce'
-- ${{ if eq(parameterscache, 'true') }}:
+- ${{ if eq(parameters.cache, 'true') }}:
   - task: CacheBeta@0
     displayName: 'Cache Build System'
     inputs:

--- a/.ci/templates/build-single.yml
+++ b/.ci/templates/build-single.yml
@@ -1,17 +1,19 @@
 parameters:
   artifactSource: 'true'
+  cache: 'false'
 
 steps:
 - task: DockerInstaller@0
   displayName: 'Prepare Environment'
   inputs:
     dockerVersion: '17.09.0-ce'
-- task: CacheBeta@0
-  displayName: 'Cache Build System'
-  inputs:
-    key: yuzu-v1-$(BuildName)-$(BuildSuffix)-$(CacheSuffix)
-    path: $(System.DefaultWorkingDirectory)/ccache
-    cacheHitVar: CACHE_RESTORED
+- ${{ if eq(parameterscache, 'true') }}:
+  - task: CacheBeta@0
+    displayName: 'Cache Build System'
+    inputs:
+      key: yuzu-v1-$(BuildName)-$(BuildSuffix)-$(CacheSuffix)
+      path: $(System.DefaultWorkingDirectory)/ccache
+      cacheHitVar: CACHE_RESTORED
 - script: chmod a+x ./.ci/scripts/$(ScriptFolder)/exec.sh && ./.ci/scripts/$(ScriptFolder)/exec.sh
   displayName: 'Build'
 - script: chmod a+x ./.ci/scripts/$(ScriptFolder)/upload.sh && RELEASE_NAME=$(BuildName) ./.ci/scripts/$(ScriptFolder)/upload.sh

--- a/.ci/templates/build-standard.yml
+++ b/.ci/templates/build-standard.yml
@@ -20,3 +20,4 @@ jobs:
   - template: ./build-single.yml
     parameters:
       artifactSource: 'false'
+      cache: $(parameters.cache)

--- a/.ci/templates/build-testing.yml
+++ b/.ci/templates/build-testing.yml
@@ -10,7 +10,7 @@ jobs:
         BuildSuffix: 'windows-testing'
         ScriptFolder: 'windows'
   steps:
-  - script: pip install --upgrade pip && pip install requests urllib3
+  - script: apt upgrade python3-pip && pip install requests urllib3
     displayName: 'Prepare Environment'
   - task: PythonScript@0
     condition: eq(variables['Build.Reason'], 'PullRequest')

--- a/.ci/templates/build-testing.yml
+++ b/.ci/templates/build-testing.yml
@@ -10,7 +10,7 @@ jobs:
         BuildSuffix: 'windows-testing'
         ScriptFolder: 'windows'
   steps:
-  - script: apt upgrade python3-pip && pip install requests urllib3
+  - script: sudo apt upgrade python3-pip && pip install requests urllib3
     displayName: 'Prepare Environment'
   - task: PythonScript@0
     condition: eq(variables['Build.Reason'], 'PullRequest')

--- a/.ci/templates/build-testing.yml
+++ b/.ci/templates/build-testing.yml
@@ -30,3 +30,4 @@ jobs:
     - template: ./build-single.yml
       parameters:
         artifactSource: 'false'
+        cache: 'false'

--- a/.ci/templates/build-testing.yml
+++ b/.ci/templates/build-testing.yml
@@ -10,7 +10,7 @@ jobs:
         BuildSuffix: 'windows-testing'
         ScriptFolder: 'windows'
   steps:
-  - script: pip install requests urllib3
+  - script: pip install --upgrade pip && pip install requests urllib3
     displayName: 'Prepare Environment'
   - task: PythonScript@0
     condition: eq(variables['Build.Reason'], 'PullRequest')

--- a/.ci/yuzu-mainline.yml
+++ b/.ci/yuzu-mainline.yml
@@ -21,3 +21,5 @@ stages:
   dependsOn: format
   jobs:
   - template: ./templates/build-standard.yml
+    parameters:
+      cache: 'true'

--- a/.ci/yuzu-verify.yml
+++ b/.ci/yuzu-verify.yml
@@ -15,4 +15,6 @@ stages:
   dependsOn: format
   jobs:
   - template: ./templates/build-standard.yml
+    parameters:
+      cache: 'false'
   - template: ./templates/build-testing.yml


### PR DESCRIPTION
- Removes caching from PR builds -- in its current form caches count as a build secret, which aren't accessible to forks

- Updates the version of pip used on the merge build agent -- the pip was too old and was having random errors.
