### PR TITLE
Port citra-emu/citra#4877: "citra_qt: on osx chdir to bundle dir to allow detection of user folder"

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2172,7 +2172,10 @@ int main(int argc, char* argv[]) {
     QCoreApplication::setApplicationName(QStringLiteral("yuzu"));
 
 #ifdef __APPLE__
-    std::string bin_path = FileUtil::GetBundleDirectory() + DIR_SEP + "..";
+    // If you start a bundle (binary) on OSX without the Terminal, the working directory is "/".
+    // But since we require the working directory to be the executable path for the location of the
+    // user folder in the Qt Frontend, we need to cd into that working directory
+    const std::string bin_path = FileUtil::GetBundleDirectory() + DIR_SEP + "..";
     chdir(bin_path.c_str());
 #endif
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -6,6 +6,7 @@
 #include <clocale>
 #include <memory>
 #include <thread>
+#include <unistd.h>
 
 // VFS includes must be before glad as they will conflict with Windows file api, which uses defines.
 #include "applets/error.h"
@@ -2167,6 +2168,11 @@ int main(int argc, char* argv[]) {
     // Init settings params
     QCoreApplication::setOrganizationName(QStringLiteral("yuzu team"));
     QCoreApplication::setApplicationName(QStringLiteral("yuzu"));
+
+#ifdef __APPLE__
+    std::string bin_path = FileUtil::GetBundleDirectory() + DIR_SEP + "..";
+    chdir(bin_path.c_str());
+#endif
 
     // Enables the core to make the qt created contexts current on std::threads
     QCoreApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -6,7 +6,9 @@
 #include <clocale>
 #include <memory>
 #include <thread>
-#include <unistd.h>
+#ifdef __APPLE__
+#include <unistd.h> // for chdir
+#endif
 
 // VFS includes must be before glad as they will conflict with Windows file api, which uses defines.
 #include "applets/error.h"


### PR DESCRIPTION
See citra-emu/citra#4877 for more details.

Yes, we don't currently have an OSX build but the plan was to add it back when there's Vulkan support and compatibility layers support all the features we need. 
As we don't have any negative effects from it, it makes sense porting all MacOS features or workaround from Citra.