### PR TITLE
maxwell_3d: Avoid moving macro_params

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -244,7 +244,7 @@ void Maxwell3D::InitDirtySettings() {
     dirty_pointers[MAXWELL3D_REG_INDEX(polygon_offset_clamp)] = polygon_offset_dirty_reg;
 }
 
-void Maxwell3D::CallMacroMethod(u32 method, std::vector<u32> parameters) {
+void Maxwell3D::CallMacroMethod(u32 method, std::size_t num_parameters, const u32* parameters) {
     // Reset the current macro.
     executing_macro = 0;
 
@@ -252,7 +252,7 @@ void Maxwell3D::CallMacroMethod(u32 method, std::vector<u32> parameters) {
     const u32 entry = ((method - MacroRegistersStart) >> 1) % macro_positions.size();
 
     // Execute the current macro.
-    macro_interpreter.Execute(macro_positions[entry], std::move(parameters));
+    macro_interpreter.Execute(macro_positions[entry], num_parameters, parameters);
 }
 
 void Maxwell3D::CallMethod(const GPU::MethodCall& method_call) {
@@ -289,7 +289,8 @@ void Maxwell3D::CallMethod(const GPU::MethodCall& method_call) {
 
         // Call the macro when there are no more parameters in the command buffer
         if (method_call.IsLastCall()) {
-            CallMacroMethod(executing_macro, std::move(macro_params));
+            CallMacroMethod(executing_macro, macro_params.size(), macro_params.data());
+            macro_params.clear();
         }
         return;
     }

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1307,9 +1307,10 @@ private:
     /**
      * Call a macro on this engine.
      * @param method Method to call
+     * @param num_parameters Number of arguments
      * @param parameters Arguments to the method call
      */
-    void CallMacroMethod(u32 method, std::vector<u32> parameters);
+    void CallMacroMethod(u32 method, std::size_t num_parameters, const u32* parameters);
 
     /// Handles writes to the macro uploading register.
     void ProcessMacroUpload(u32 data);

--- a/src/video_core/macro_interpreter.h
+++ b/src/video_core/macro_interpreter.h
@@ -25,7 +25,7 @@ public:
      * @param offset Offset to start execution at.
      * @param parameters The parameters of the macro.
      */
-    void Execute(u32 offset, std::vector<u32> parameters);
+    void Execute(u32 offset, std::size_t num_parameters, const u32* parameters);
 
 private:
     enum class Operation : u32 {
@@ -162,10 +162,12 @@ private:
     MethodAddress method_address = {};
 
     /// Input parameters of the current macro.
-    std::vector<u32> parameters;
+    std::unique_ptr<u32[]> parameters;
+    std::size_t num_parameters = 0;
+    std::size_t parameters_capacity = 0;
     /// Index of the next parameter that will be fetched by the 'parm' instruction.
     u32 next_parameter_index = 0;
 
-    bool carry_flag{};
+    bool carry_flag = false;
 };
 } // namespace Tegra


### PR DESCRIPTION
Instead of calling `std::move` on `macro_params` to the callee in `Maxwell3D::CallMethod`, pass a memory reference of it. This avoids constantly having `macro_params` without allocations, making its `std::vector<>::push_back` visible in the profiler (~5% from my testing).

Internally this memory reference is consumed with a `std::vector<u32>`-like `std::unique_ptr<u32[]>` but unlike `std::vector<>::resize` it won't zero newly allocated memory.

This turns constant allocation into a `std::memcpy`.

Thanks to @graphitemaster for pointing this out and suggesting a solution.