### PR TITLE
shader/shift: Implement SHR wrapped and clamped variants

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -675,6 +675,10 @@ union Instruction {
     } shift;
 
     union {
+        BitField<39, 1, u64> wrap;
+    } shr;
+
+    union {
         BitField<39, 5, u64> shift_amount;
         BitField<48, 1, u64> negate_b;
         BitField<49, 1, u64> negate_a;


### PR DESCRIPTION
Nvidia defaults to wrapped shifts, but this is undefined behaviour in GLSL. Explicitly mask/clamp according to what the guest shader requires.