### PR TITLE
maxwell_3d: Fix macro binding cursor

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -249,16 +249,10 @@ void Maxwell3D::CallMacroMethod(u32 method, std::vector<u32> parameters) {
     executing_macro = 0;
 
     // Lookup the macro offset
-    const u32 entry{(method - MacroRegistersStart) >> 1};
-    const auto& search{macro_offsets.find(entry)};
-    if (search == macro_offsets.end()) {
-        LOG_CRITICAL(HW_GPU, "macro not found for method 0x{:X}!", method);
-        UNREACHABLE();
-        return;
-    }
+    const u32 entry = ((method - MacroRegistersStart) >> 1) % macro_positions.size();
 
     // Execute the current macro.
-    macro_interpreter.Execute(search->second, std::move(parameters));
+    macro_interpreter.Execute(macro_positions[entry], std::move(parameters));
 }
 
 void Maxwell3D::CallMethod(const GPU::MethodCall& method_call) {
@@ -421,7 +415,7 @@ void Maxwell3D::ProcessMacroUpload(u32 data) {
 }
 
 void Maxwell3D::ProcessMacroBind(u32 data) {
-    macro_offsets[regs.macros.entry] = data;
+    macro_positions[regs.macros.entry++] = data;
 }
 
 void Maxwell3D::ProcessQueryGet() {

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1270,7 +1270,7 @@ private:
     MemoryManager& memory_manager;
 
     /// Start offsets of each macro in macro_memory
-    std::unordered_map<u32, u32> macro_offsets;
+    std::array<u32, 0x80> macro_positions = {};
 
     /// Memory for macro code
     MacroMemory macro_memory;


### PR DESCRIPTION
This is based on Ryujinx' implementation and it can be found here: https://github.com/Ryujinx/Ryujinx/blob/master/Ryujinx.Graphics/Graphics3d/NvGpuFifo.cs

`macros.entry` (just like the data uploading register) increments on every bind. We weren't emulating this properly.

Thanks to @fincs for pointing out this bug.