### PR TITLE
Port citra-emu/citra#4911: "Add cancel option to analog stick configuration"

### DIFF
--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -301,13 +301,16 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
                     });
         }
         connect(analog_map_stick[analog_id], &QPushButton::clicked, [=] {
-            QMessageBox::information(this, tr("Information"),
-                                     tr("After pressing OK, first move your joystick horizontally, "
-                                        "and then vertically."));
-            HandleClick(
-                analog_map_stick[analog_id],
-                [=](const Common::ParamPackage& params) { analogs_param[analog_id] = params; },
-                InputCommon::Polling::DeviceType::Analog);
+            if (QMessageBox::information(
+                    this, tr("Information"),
+                    tr("After pressing OK, first move your joystick horizontally, "
+                       "and then vertically."),
+                    QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Ok) {
+                HandleClick(
+                    analog_map_stick[analog_id],
+                    [=](const Common::ParamPackage& params) { analogs_param[analog_id] = params; },
+                    InputCommon::Polling::DeviceType::Analog);
+            }
         });
     }
 


### PR DESCRIPTION
See citra-emu/citra#4911 for more details.

**Original description**:
When a user clicks the "Set Analog Stick" button, Citra will pop up an information window with instructions for setting it up.
The message reads "After pressing OK, first move your joystick horizontally, and then vertically."

There's a small incongruence between what the message says and the actual behavior, as Citra will try to accept an input even if the user closes the information window by pressing 'Esc' or by clicking the 'x' (not sure how to properly call it).

This PR proposes the addition of a 'Cancel' button and a check for the button clicked by the user.
According to the Qt documentation, this will also assign 'Cancel' as the Escape Button, triggering it when the user presses 'Esc'.