### PR TITLE
CI Fix (Azure/Testing) - apt update before upgrade. Use apt-get.

### DIFF
--- a/.ci/templates/build-testing.yml
+++ b/.ci/templates/build-testing.yml
@@ -10,7 +10,7 @@ jobs:
         BuildSuffix: 'windows-testing'
         ScriptFolder: 'windows'
   steps:
-  - script: sudo apt-get update && sudo apt-get -y upgrade python3-pip && pip install requests urllib3
+  - script: sudo apt-get update && sudo apt-get --only-upgrade -y install python3-pip && pip install requests urllib3
     displayName: 'Prepare Environment'
   - task: PythonScript@0
     condition: eq(variables['Build.Reason'], 'PullRequest')

--- a/.ci/templates/build-testing.yml
+++ b/.ci/templates/build-testing.yml
@@ -10,7 +10,7 @@ jobs:
         BuildSuffix: 'windows-testing'
         ScriptFolder: 'windows'
   steps:
-  - script: sudo apt upgrade python3-pip && pip install requests urllib3
+  - script: sudo apt-get update && sudo apt-get -y upgrade python3-pip && pip install requests urllib3
     displayName: 'Prepare Environment'
   - task: PythonScript@0
     condition: eq(variables['Build.Reason'], 'PullRequest')


### PR DESCRIPTION
Identified a bug in the script which uses the azure image when attempting to upgrade python3-pip.
Package index was out of date because apt-get update was not ran before attempting the upgrade.