### PR TITLE
nro/ui: Show "Developer" field in Properties

### DIFF
--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -258,6 +258,15 @@ ResultStatus AppLoader_NRO::ReadTitle(std::string& title) {
     return ResultStatus::Success;
 }
 
+ResultStatus AppLoader_NRO::ReadControlData(FileSys::NACP& control) {
+    if (nacp == nullptr) {
+        return ResultStatus::ErrorNoControl;
+    }
+
+    control = *nacp;
+    return ResultStatus::Success;
+}
+
 bool AppLoader_NRO::IsRomFSUpdatable() const {
     return false;
 }

--- a/src/core/loader/nro.h
+++ b/src/core/loader/nro.h
@@ -43,6 +43,7 @@ public:
     ResultStatus ReadProgramId(u64& out_program_id) override;
     ResultStatus ReadRomFS(FileSys::VirtualFile& dir) override;
     ResultStatus ReadTitle(std::string& title) override;
+    ResultStatus ReadControlData(FileSys::NACP& control) override;
     bool IsRomFSUpdatable() const override;
 
 private:


### PR DESCRIPTION
With this, the "Developer" field in the Properties window for homebrew (all `.nro`s) is now populated.

<details>
  <summary>Example Screenshots</summary>

#### Before

![image](https://user-images.githubusercontent.com/6632271/64480548-6fc48c00-d1d2-11e9-8864-4fec8b27a788.png)


#### After
    
![image](https://user-images.githubusercontent.com/6632271/64480496-6a1a7680-d1d1-11e9-8dbf-8009a8aeebc5.png)

</details>
