### PR TITLE
renderer_opengl: Fix sRGB blits

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -89,6 +89,9 @@ void Maxwell3D::InitializeRegisterDefaults() {
 
     // Commercial games seem to assume this value is enabled and nouveau sets this value manually.
     regs.rt_separate_frag_data = 1;
+
+    // Some games (like Super Mario Odyssey) assume that SRGB is enabled.
+    regs.framebuffer_srgb = 1;
 }
 
 #define DIRTY_REGS_POS(field_name) (offsetof(Maxwell3D::DirtyRegs, field_name))

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -485,6 +485,12 @@ std::pair<bool, bool> RasterizerOpenGL::ConfigureFramebuffers(
             View color_surface{
                 texture_cache.GetColorBufferSurface(*single_color_target, preserve_contents)};
 
+            if (color_surface) {
+                // Assume that a surface will be written to if it is used as a framebuffer, even if
+                // the shader doesn't actually write to it.
+                texture_cache.MarkColorBufferInUse(*single_color_target);
+            }
+
             fbkey.is_single_buffer = true;
             fbkey.color_attachments[0] =
                 GL_COLOR_ATTACHMENT0 + static_cast<GLenum>(*single_color_target);
@@ -498,6 +504,12 @@ std::pair<bool, bool> RasterizerOpenGL::ConfigureFramebuffers(
             // Multiple color attachments are enabled
             for (std::size_t index = 0; index < Maxwell::NumRenderTargets; ++index) {
                 View color_surface{texture_cache.GetColorBufferSurface(index, preserve_contents)};
+
+                if (color_surface) {
+                    // Assume that a surface will be written to if it is used as a framebuffer, even
+                    // if the shader doesn't actually write to it.
+                    texture_cache.MarkColorBufferInUse(index);
+                }
 
                 fbkey.color_attachments[index] =
                     GL_COLOR_ATTACHMENT0 + regs.rt_control.GetMap(index);

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -16,7 +16,6 @@ namespace OpenGL {
 using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 
 OpenGLState OpenGLState::cur_state;
-bool OpenGLState::s_rgb_used;
 
 namespace {
 
@@ -282,8 +281,6 @@ void OpenGLState::ApplySRgb() const {
         return;
     cur_state.framebuffer_srgb.enabled = framebuffer_srgb.enabled;
     if (framebuffer_srgb.enabled) {
-        // Track if sRGB is used
-        s_rgb_used = true;
         glEnable(GL_FRAMEBUFFER_SRGB);
     } else {
         glDisable(GL_FRAMEBUFFER_SRGB);

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -175,14 +175,6 @@ public:
         return cur_state;
     }
 
-    static bool GetsRGBUsed() {
-        return s_rgb_used;
-    }
-
-    static void ClearsRGBUsed() {
-        s_rgb_used = false;
-    }
-
     void SetDefaultViewports();
     /// Apply this state as the current OpenGL state
     void Apply();
@@ -253,8 +245,6 @@ public:
 private:
     static OpenGLState cur_state;
 
-    // Workaround for sRGB problems caused by QT not supporting srgb output
-    static bool s_rgb_used;
     struct {
         bool blend_state;
         bool stencil_state;

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -341,7 +341,7 @@ void RendererOpenGL::DrawScreenTriangles(const ScreenInfo& screen_info, float x,
         ScreenRectVertex(x + w, y + h, texcoords.bottom * scale_u, right * scale_v),
     }};
 
-    state.textures[0].texture = screen_info.display_texture;
+    state.textures[0] = screen_info.display_texture;
     state.framebuffer_srgb.enabled = screen_info.display_srgb;
     state.AllDirty();
     state.Apply();

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -38,7 +38,8 @@ struct TextureInfo {
 
 /// Structure used for storing information about the display target for the Switch screen
 struct ScreenInfo {
-    GLuint display_texture;
+    GLuint display_texture{};
+    bool display_srgb{};
     const Common::Rectangle<float> display_texcoords{0.0f, 0.0f, 1.0f, 1.0f};
     TextureInfo texture;
 };


### PR DESCRIPTION
Aims to fix #2101. Removes the sRGB hack of tracking if a frame used an sRGB rendertarget to apply at least once to blit the final texture as sRGB. Instead of doing this apply sRGB if the presented image has sRGB.

Also enable sRGB by default on Maxwell3D registers as some games seem to assume this.

Thanks to @FernandoS27 for fixing a regression introduced by this commit.