### PR TITLE
video_core/surface: Add function to detect sRGB surfaces

### DIFF
--- a/src/video_core/surface.cpp
+++ b/src/video_core/surface.cpp
@@ -513,6 +513,26 @@ bool IsPixelFormatASTC(PixelFormat format) {
     }
 }
 
+bool IsPixelFormatSRGB(PixelFormat format) {
+    switch (format) {
+    case PixelFormat::RGBA8_SRGB:
+    case PixelFormat::BGRA8_SRGB:
+    case PixelFormat::DXT1_SRGB:
+    case PixelFormat::DXT23_SRGB:
+    case PixelFormat::DXT45_SRGB:
+    case PixelFormat::BC7U_SRGB:
+    case PixelFormat::ASTC_2D_4X4_SRGB:
+    case PixelFormat::ASTC_2D_8X8_SRGB:
+    case PixelFormat::ASTC_2D_8X5_SRGB:
+    case PixelFormat::ASTC_2D_5X4_SRGB:
+    case PixelFormat::ASTC_2D_5X5_SRGB:
+    case PixelFormat::ASTC_2D_10X8_SRGB:
+        return true;
+    default:
+        return false;
+    }
+}
+
 std::pair<u32, u32> GetASTCBlockSize(PixelFormat format) {
     return {GetDefaultBlockWidth(format), GetDefaultBlockHeight(format)};
 }

--- a/src/video_core/surface.h
+++ b/src/video_core/surface.h
@@ -547,6 +547,8 @@ SurfaceType GetFormatType(PixelFormat pixel_format);
 
 bool IsPixelFormatASTC(PixelFormat format);
 
+bool IsPixelFormatSRGB(PixelFormat format);
+
 std::pair<u32, u32> GetASTCBlockSize(PixelFormat format);
 
 /// Returns true if the specified PixelFormat is a BCn format, e.g. DXT or DXN


### PR DESCRIPTION
This is required for proper conversion to RGBA8_UNORM or RGBA8_SRGB surfaces when a backend can target both native and converted ASTC.