### PR TITLE
Implement Native Resolution Rescaling

### DIFF
--- a/src/common/common_paths.h
+++ b/src/common/common_paths.h
@@ -36,6 +36,7 @@
 #define LOAD_DIR "load"
 #define DUMP_DIR "dump"
 #define SHADER_DIR "shader"
+#define RESCALING_DIR "rescaling"
 #define LOG_DIR "log"
 
 // Filenames

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -695,6 +695,7 @@ const std::string& GetUserPath(UserPath path, const std::string& new_path) {
         paths.emplace(UserPath::LoadDir, user_path + LOAD_DIR DIR_SEP);
         paths.emplace(UserPath::DumpDir, user_path + DUMP_DIR DIR_SEP);
         paths.emplace(UserPath::ShaderDir, user_path + SHADER_DIR DIR_SEP);
+        paths.emplace(UserPath::RescalingDir, user_path + RESCALING_DIR DIR_SEP);
         paths.emplace(UserPath::SysDataDir, user_path + SYSDATA_DIR DIR_SEP);
         paths.emplace(UserPath::KeysDir, user_path + KEYS_DIR DIR_SEP);
         // TODO: Put the logs in a better location for each OS

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -33,6 +33,7 @@ enum class UserPath {
     LoadDir,
     DumpDir,
     ShaderDir,
+    RescalingDir,
     SysDataDir,
     UserDir,
 };

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -94,8 +94,7 @@ void LogSettings() {
     LogSetting("Renderer_UseAccurateGpuEmulation", Settings::values.use_accurate_gpu_emulation);
     LogSetting("Renderer_UseAsynchronousGpuEmulation",
                Settings::values.use_asynchronous_gpu_emulation);
-    LogSetting("Renderer_UseResolutionScanner",
-               Settings::values.use_resolution_scanner);
+    LogSetting("Renderer_UseResolutionScanner", Settings::values.use_resolution_scanner);
     LogSetting("Audio_OutputEngine", Settings::values.sink_id);
     LogSetting("Audio_EnableAudioStretching", Settings::values.enable_audio_stretching);
     LogSetting("Audio_OutputDevice", Settings::values.audio_device_id);

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -94,6 +94,8 @@ void LogSettings() {
     LogSetting("Renderer_UseAccurateGpuEmulation", Settings::values.use_accurate_gpu_emulation);
     LogSetting("Renderer_UseAsynchronousGpuEmulation",
                Settings::values.use_asynchronous_gpu_emulation);
+    LogSetting("Renderer_UseResolutionScanner",
+               Settings::values.use_resolution_scanner);
     LogSetting("Audio_OutputEngine", Settings::values.sink_id);
     LogSetting("Audio_EnableAudioStretching", Settings::values.enable_audio_stretching);
     LogSetting("Audio_OutputDevice", Settings::values.audio_device_id);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -423,6 +423,7 @@ struct Values {
     bool use_accurate_gpu_emulation;
     bool use_asynchronous_gpu_emulation;
     bool force_30fps_mode;
+    bool use_resolution_scanner;
 
     float bg_red;
     float bg_green;

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -122,6 +122,8 @@ add_library(video_core STATIC
     shader/track.cpp
     surface.cpp
     surface.h
+    texture_cache/resolution_scaling/database.cpp
+    texture_cache/resolution_scaling/database.h
     texture_cache/surface_base.cpp
     texture_cache/surface_base.h
     texture_cache/surface_params.cpp
@@ -171,7 +173,7 @@ endif()
 create_target_directory_groups(video_core)
 
 target_link_libraries(video_core PUBLIC common core)
-target_link_libraries(video_core PRIVATE glad)
+target_link_libraries(video_core PRIVATE glad json-headers)
 if (ENABLE_VULKAN)
     target_link_libraries(video_core PRIVATE sirit)
 endif()

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1084,10 +1084,10 @@ void RasterizerOpenGL::SyncViewport(OpenGLState& current_state, bool rescaling) 
         auto& viewport = current_state.viewports[i];
         const auto& src = regs.viewports[i];
         const Common::Rectangle<s32> viewport_rect{regs.viewport_transform[i].GetRect()};
-        viewport.x = viewport_rect.left * factor;
-        viewport.y = viewport_rect.bottom * factor;
-        viewport.width = viewport_rect.GetWidth() * factor;
-        viewport.height = viewport_rect.GetHeight() * factor;
+        viewport.x = static_cast<GLint>(viewport_rect.left * factor);
+        viewport.y = static_cast<GLint>(viewport_rect.bottom * factor);
+        viewport.width = static_cast<GLint>(viewport_rect.GetWidth() * factor);
+        viewport.height = static_cast<GLint>(viewport_rect.GetHeight() * factor);
         viewport.depth_range_far = src.depth_range_far;
         viewport.depth_range_near = src.depth_range_near;
     }

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -251,7 +251,10 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
         if (!gpu.regs.IsShaderConfigEnabled(index)) {
             switch (program) {
             case Maxwell::ShaderProgram::Geometry:
-                shader_program_manager->UseTrivialGeometryShader();
+                shader_program_manager->BindGeometryShader(nullptr);
+                break;
+            case Maxwell::ShaderProgram::Fragment:
+                shader_program_manager->BindFragmentShader(nullptr);
                 break;
             default:
                 break;
@@ -260,14 +263,6 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
         }
 
         const std::size_t stage{index == 0 ? 0 : index - 1}; // Stage indices are 0 - 5
-
-        GLShader::MaxwellUniformData ubo{};
-        ubo.SetFromRegs(gpu, stage);
-        const auto [buffer, offset] =
-            buffer_cache.UploadHostMemory(&ubo, sizeof(ubo), device.GetUniformBufferAlignment());
-
-        // Bind the emulation info buffer
-        bind_ubo_pushbuffer.Push(buffer, offset, static_cast<GLsizeiptr>(sizeof(ubo)));
 
         Shader shader{shader_cache.GetStageProgram(program)};
 
@@ -282,13 +277,13 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
         switch (program) {
         case Maxwell::ShaderProgram::VertexA:
         case Maxwell::ShaderProgram::VertexB:
-            shader_program_manager->UseProgrammableVertexShader(program_handle);
+            shader_program_manager->BindVertexShader(&program_handle);
             break;
         case Maxwell::ShaderProgram::Geometry:
-            shader_program_manager->UseProgrammableGeometryShader(program_handle);
+            shader_program_manager->BindGeometryShader(&program_handle);
             break;
         case Maxwell::ShaderProgram::Fragment:
-            shader_program_manager->UseProgrammableFragmentShader(program_handle);
+            shader_program_manager->BindFragmentShader(&program_handle);
             break;
         default:
             UNIMPLEMENTED_MSG("Unimplemented shader index={}, enable={}, offset=0x{:08X}", index,
@@ -605,11 +600,6 @@ void RasterizerOpenGL::DrawPrelude() {
         buffer_size = Common::AlignUp(buffer_size, 4) + CalculateIndexBufferSize();
     }
 
-    // Uniform space for the 5 shader stages
-    buffer_size = Common::AlignUp<std::size_t>(buffer_size, 4) +
-                  (sizeof(GLShader::MaxwellUniformData) + device.GetUniformBufferAlignment()) *
-                      Maxwell::MaxShaderStage;
-
     // Add space for at least 18 constant buffers
     buffer_size += Maxwell::MaxConstBuffers *
                    (Maxwell::MaxConstBufferSize + device.GetUniformBufferAlignment());
@@ -651,6 +641,7 @@ void RasterizerOpenGL::DrawPrelude() {
         gpu.dirty.ResetVertexArrays();
     }
 
+    shader_program_manager->SetConstants(gpu);
     shader_program_manager->ApplyTo(state);
     state.Apply();
 
@@ -773,7 +764,7 @@ void RasterizerOpenGL::DispatchCompute(GPUVAddr code_addr) {
     SetupComputeImages(kernel);
 
     const auto [program, next_bindings] = kernel->GetProgramHandle(variant);
-    state.draw.shader_program = program;
+    state.draw.shader_program = program.handle;
     state.draw.program_pipeline = 0;
 
     const std::size_t buffer_size =

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -647,7 +647,7 @@ void RasterizerOpenGL::DrawPrelude() {
         gpu.dirty.ResetVertexArrays();
     }
 
-    bool res_scaling = texture_cache.IsResolutionScalingEnabled();
+    const bool res_scaling = texture_cache.IsResolutionScalingEnabled();
     SyncViewport(state, res_scaling);
     SyncScissorTest(state, res_scaling);
 
@@ -1079,7 +1079,7 @@ void RasterizerOpenGL::SyncViewport(OpenGLState& current_state, bool rescaling) 
         regs.IsShaderConfigEnabled(static_cast<size_t>(Maxwell::ShaderProgram::Geometry));
     const std::size_t viewport_count =
         geometry_shaders_enabled ? Tegra::Engines::Maxwell3D::Regs::NumViewports : 1;
-    float factor = rescaling ? Settings::values.resolution_factor : 1.0;
+    const float factor = rescaling ? Settings::values.resolution_factor : 1.0f;
     for (std::size_t i = 0; i < viewport_count; i++) {
         auto& viewport = current_state.viewports[i];
         const auto& src = regs.viewports[i];
@@ -1304,7 +1304,7 @@ void RasterizerOpenGL::SyncScissorTest(OpenGLState& current_state, bool rescalin
         regs.IsShaderConfigEnabled(static_cast<size_t>(Maxwell::ShaderProgram::Geometry));
     const std::size_t viewport_count =
         geometry_shaders_enabled ? Tegra::Engines::Maxwell3D::Regs::NumViewports : 1;
-    float factor = rescaling ? Settings::values.resolution_factor : 1.0;
+    const float factor = rescaling ? Settings::values.resolution_factor : 1.0f;
     for (std::size_t i = 0; i < viewport_count; i++) {
         const auto& src = regs.scissor_test[i];
         auto& dst = current_state.viewports[i].scissor;
@@ -1314,10 +1314,10 @@ void RasterizerOpenGL::SyncScissorTest(OpenGLState& current_state, bool rescalin
         }
         const u32 width = src.max_x - src.min_x;
         const u32 height = src.max_y - src.min_y;
-        dst.x = src.min_x * factor;
-        dst.y = src.min_y * factor;
-        dst.width = width * factor;
-        dst.height = height * factor;
+        dst.x = static_cast<u32>(src.min_x * factor);
+        dst.y = static_cast<u32>(src.min_y * factor);
+        dst.width = static_cast<u32>(width * factor);
+        dst.height = static_cast<u32>(height * factor);
     }
 }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -651,7 +651,7 @@ void RasterizerOpenGL::DrawPrelude() {
     SyncViewport(state, res_scaling);
     SyncScissorTest(state, res_scaling);
 
-    shader_program_manager->SetConstants(gpu);
+    shader_program_manager->SetConstants(gpu, res_scaling);
     shader_program_manager->ApplyTo(state);
     state.Apply();
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -375,6 +375,7 @@ void RasterizerOpenGL::UpdatePagesCachedCount(VAddr addr, u64 size, int delta) {
 void RasterizerOpenGL::LoadDiskResources(const std::atomic_bool& stop_loading,
                                          const VideoCore::DiskResourceLoadCallback& callback) {
     shader_cache.LoadDiskCache(stop_loading, callback);
+    texture_cache.LoadResources();
 }
 
 void RasterizerOpenGL::ConfigureFramebuffers() {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -547,7 +547,12 @@ void RasterizerOpenGL::Clear() {
 
     ConfigureClearFramebuffer(clear_state, use_color, use_depth, use_stencil);
 
-    bool res_scaling = texture_cache.IsResolutionScalingEnabled();
+    bool res_scaling;
+    if (use_color) {
+        res_scaling = texture_cache.IsResolutionScalingEnabledRT(regs.clear_buffers.RT);
+    } else {
+        res_scaling = texture_cache.IsResolutionScalingEnabledDB();
+    }
 
     SyncViewport(clear_state, res_scaling);
     if (regs.clear_flags.scissor) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -128,7 +128,7 @@ private:
                     const GLShader::ImageEntry& entry);
 
     /// Syncs the viewport and depth range to match the guest state
-    void SyncViewport(OpenGLState& current_state);
+    void SyncViewport(OpenGLState& current_state, bool rescaling = false);
 
     /// Syncs the clip enabled status to match the guest state
     void SyncClipEnabled(
@@ -162,7 +162,7 @@ private:
     void SyncMultiSampleState();
 
     /// Syncs the scissor test state to match the guest state
-    void SyncScissorTest(OpenGLState& current_state);
+    void SyncScissorTest(OpenGLState& current_state, bool rescaling = false);
 
     /// Syncs the transform feedback state to match the guest state
     void SyncTransformFeedback();

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -128,7 +128,7 @@ private:
                     const GLShader::ImageEntry& entry);
 
     /// Syncs the viewport and depth range to match the guest state
-    void SyncViewport(OpenGLState& current_state, bool rescaling = false);
+    void SyncViewport(OpenGLState& current_state, bool rescaling);
 
     /// Syncs the clip enabled status to match the guest state
     void SyncClipEnabled(
@@ -162,7 +162,7 @@ private:
     void SyncMultiSampleState();
 
     /// Syncs the scissor test state to match the guest state
-    void SyncScissorTest(OpenGLState& current_state, bool rescaling = false);
+    void SyncScissorTest(OpenGLState& current_state, bool rescaling);
 
     /// Syncs the transform feedback state to match the guest state
     void SyncTransformFeedback();

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -268,6 +268,7 @@ CachedProgram SpecializeShader(const std::string& code, const GLShader::ShaderEn
 
     auto program = std::make_shared<GLShader::StageProgram>();
     program->Create(true, hint_retrievable, shader.handle);
+    program->SetUniformLocations();
     return program;
 }
 

--- a/src/video_core/renderer_opengl/gl_shader_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_cache.h
@@ -20,6 +20,7 @@
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/renderer_opengl/gl_shader_decompiler.h"
 #include "video_core/renderer_opengl/gl_shader_disk_cache.h"
+#include "video_core/renderer_opengl/gl_shader_manager.h"
 
 namespace Core {
 class System;
@@ -37,7 +38,7 @@ class RasterizerOpenGL;
 struct UnspecializedShader;
 
 using Shader = std::shared_ptr<CachedShader>;
-using CachedProgram = std::shared_ptr<OGLProgram>;
+using CachedProgram = std::shared_ptr<GLShader::StageProgram>;
 using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 using PrecompiledPrograms = std::unordered_map<ShaderDiskCacheUsage, CachedProgram>;
 using PrecompiledShaders = std::unordered_map<u64, GLShader::ProgramResult>;
@@ -80,7 +81,8 @@ public:
     }
 
     /// Gets the GL program handle for the shader
-    std::tuple<GLuint, BaseBindings> GetProgramHandle(const ProgramVariant& variant);
+    std::tuple<GLShader::StageProgram&, BaseBindings> GetProgramHandle(
+        const ProgramVariant& variant);
 
 private:
     explicit CachedShader(const ShaderParameters& params, ProgramType program_type,

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -2496,9 +2496,8 @@ std::string GetCommonDeclarations() {
         "    return bvec2(comparison.x || is_nan1.x || is_nan2.x, comparison.y || is_nan1.y || "
         "is_nan2.y);\n"
         "}}\n\n"
-        "layout(location = 0) uniform uvec4 config_pack; // instance_id, flip_stage, y_direction, "
-        "padding\n"
-        "layout(location = 1) uniform vec2 viewport_flip;\n\n");
+        "uniform uvec4 config_pack; // instance_id, flip_stage, y_direction, padding\n"
+        "uniform vec2 viewport_flip;\n\n");
 }
 
 ProgramResult Decompile(const Device& device, const ShaderIR& ir, ProgramType stage,

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -2486,7 +2486,10 @@ std::string GetCommonDeclarations() {
         "    bvec2 is_nan2 = isnan(pair2);\n"
         "    return bvec2(comparison.x || is_nan1.x || is_nan2.x, comparison.y || is_nan1.y || "
         "is_nan2.y);\n"
-        "}}\n\n");
+        "}}\n\n"
+        "layout(location = 0) uniform uvec4 config_pack; // instance_id, flip_stage, y_direction, "
+        "padding\n"
+        "layout(location = 1) uniform vec2 viewport_flip;\n\n");
 }
 
 ProgramResult Decompile(const Device& device, const ShaderIR& ir, ProgramType stage,

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -943,18 +943,19 @@ private:
         case Attribute::Index::Position:
             switch (stage) {
             case ProgramType::Geometry:
-                return fmt::format("gl_in[{}].gl_Position{}", Visit(buffer).AsUint(),
-                                   GetSwizzle(element));
+                return {fmt::format("gl_in[{}].gl_Position{}", Visit(buffer).AsUint(),
+                                    GetSwizzle(element)),
+                        Type::Float};
             case ProgramType::Fragment: {
                 switch (element) {
                 case 0:
-                    return "(gl_FragCoord.x / utof(config_pack[3]))";
+                    return {"(gl_FragCoord.x / utof(config_pack[3]))", Type::Float};
                 case 1:
-                    return "(gl_FragCoord.y / utof(config_pack[3]))";
+                    return {"(gl_FragCoord.y / utof(config_pack[3]))", Type::Float};
                 case 2:
-                    return "gl_FragCoord.z";
+                    return {"gl_FragCoord.z", Type::Float};
                 case 3:
-                    return "1.0f";
+                    return {"1.0f", Type::Float};
                 }
             }
             default:

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -943,12 +943,20 @@ private:
         case Attribute::Index::Position:
             switch (stage) {
             case ProgramType::Geometry:
-                return {fmt::format("gl_in[{}].gl_Position{}", Visit(buffer).AsUint(),
-                                    GetSwizzle(element)),
-                        Type::Float};
-            case ProgramType::Fragment:
-                return {element == 3 ? "1.0f" : ("gl_FragCoord"s + GetSwizzle(element)),
-                        Type::Float};
+                return fmt::format("gl_in[{}].gl_Position{}", Visit(buffer).AsUint(),
+                                   GetSwizzle(element));
+            case ProgramType::Fragment: {
+                switch (element) {
+                case 0:
+                    return "(gl_FragCoord.x / utof(config_pack[3]))";
+                case 1:
+                    return "(gl_FragCoord.y / utof(config_pack[3]))";
+                case 2:
+                    return "gl_FragCoord.z";
+                case 3:
+                    return "1.0f";
+                }
+            }
             default:
                 UNREACHABLE();
             }

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -27,14 +27,6 @@ ProgramResult GenerateVertexShader(const Device& device, const ShaderSetup& setu
     std::string out = "// Shader Unique Id: VS" + id + "\n\n";
     out += GetCommonDeclarations();
 
-    out += R"(
-layout (std140, binding = EMULATION_UBO_BINDING) uniform vs_config {
-    vec4 viewport_flip;
-    uvec4 config_pack; // instance_id, flip_stage, y_direction, padding
-};
-
-)";
-
     const ShaderIR program_ir(setup.program.code, PROGRAM_OFFSET, setup.program.size_a, settings);
     const auto stage = setup.IsDualProgram() ? ProgramType::VertexA : ProgramType::VertexB;
     ProgramResult program = Decompile(device, program_ir, stage, "vertex");
@@ -77,14 +69,6 @@ ProgramResult GenerateGeometryShader(const Device& device, const ShaderSetup& se
     std::string out = "// Shader Unique Id: GS" + id + "\n\n";
     out += GetCommonDeclarations();
 
-    out += R"(
-layout (std140, binding = EMULATION_UBO_BINDING) uniform gs_config {
-    vec4 viewport_flip;
-    uvec4 config_pack; // instance_id, flip_stage, y_direction, padding
-};
-
-)";
-
     const ShaderIR program_ir(setup.program.code, PROGRAM_OFFSET, setup.program.size_a, settings);
     ProgramResult program = Decompile(device, program_ir, ProgramType::Geometry, "geometry");
     out += program.first;
@@ -92,7 +76,7 @@ layout (std140, binding = EMULATION_UBO_BINDING) uniform gs_config {
     out += R"(
 void main() {
     execute_geometry();
-};)";
+})";
 
     return {std::move(out), std::move(program.second)};
 }
@@ -112,11 +96,6 @@ layout (location = 4) out vec4 FragColor4;
 layout (location = 5) out vec4 FragColor5;
 layout (location = 6) out vec4 FragColor6;
 layout (location = 7) out vec4 FragColor7;
-
-layout (std140, binding = EMULATION_UBO_BINDING) uniform fs_config {
-    vec4 viewport_flip;
-    uvec4 config_pack; // instance_id, flip_stage, y_direction, padding
-};
 
 )";
 

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -2,13 +2,34 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <array>
 #include "common/common_types.h"
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/renderer_opengl/gl_shader_manager.h"
 
 namespace OpenGL::GLShader {
 
-using Tegra::Engines::Maxwell3D;
+using Maxwell = Tegra::Engines::Maxwell3D::Regs;
+
+enum ProgramLocations : u32 {
+    CONFIG_PACK = 0,
+    VIEWPORT_SCALE = 1,
+};
+
+StageProgram::StageProgram() = default;
+
+StageProgram::~StageProgram() = default;
+
+void StageProgram::UpdateConstants() {
+    if (state.config_pack != old_state.config_pack) {
+        glProgramUniform4uiv(handle, CONFIG_PACK, 1, state.config_pack.data());
+        old_state.config_pack = state.config_pack;
+    }
+    if (state.viewport_scale != old_state.viewport_scale) {
+        glProgramUniform2fv(handle, VIEWPORT_SCALE, 1, state.viewport_scale.data());
+        old_state.viewport_scale = state.viewport_scale;
+    }
+}
 
 ProgramManager::ProgramManager() {
     pipeline.Create();
@@ -16,10 +37,54 @@ ProgramManager::ProgramManager() {
 
 ProgramManager::~ProgramManager() = default;
 
+void ProgramManager::SetConstants(Tegra::Engines::Maxwell3D& maxwell_3d) {
+    const auto& regs = maxwell_3d.regs;
+    const auto& state = maxwell_3d.state;
+
+    // TODO(bunnei): Support more than one viewport
+    const GLfloat flip_x = regs.viewport_transform[0].scale_x < 0.0 ? -1.0f : 1.0f;
+    const GLfloat flip_y = regs.viewport_transform[0].scale_y < 0.0 ? -1.0f : 1.0f;
+
+    const GLuint instance_id = state.current_instance;
+
+    // Assign in which stage the position has to be flipped (the last stage before the fragment
+    // shader).
+    const GLuint flip_stage = [&]() {
+        constexpr u32 geometry_index = static_cast<u32>(Maxwell::ShaderProgram::Geometry);
+        if (regs.shader_config[geometry_index].enable) {
+            return geometry_index;
+        } else {
+            return static_cast<u32>(Maxwell::ShaderProgram::VertexB);
+        }
+    }();
+
+    // Y_NEGATE controls what value S2R returns for the Y_DIRECTION system value.
+    const GLfloat y_direction = regs.screen_y_control.y_negate == 0 ? 1.0f : -1.0f;
+
+    for (const auto stage :
+         std::array{current_state.vertex, current_state.geometry, current_state.fragment}) {
+        if (!stage) {
+            continue;
+        }
+        stage->SetInstanceID(instance_id);
+        stage->SetFlipStage(flip_stage);
+        stage->SetYDirection(y_direction);
+        stage->SetViewportScale(flip_x, flip_y);
+        stage->UpdateConstants();
+    }
+}
+
 void ProgramManager::ApplyTo(OpenGLState& state) {
     UpdatePipeline();
     state.draw.shader_program = 0;
     state.draw.program_pipeline = pipeline.handle;
+}
+
+GLuint GetHandle(StageProgram* program) {
+    if (!program) {
+        return 0;
+    }
+    return program->handle;
 }
 
 void ProgramManager::UpdatePipeline() {
@@ -33,34 +98,11 @@ void ProgramManager::UpdatePipeline() {
                                      GL_FRAGMENT_SHADER_BIT};
     glUseProgramStages(pipeline.handle, all_used_stages, 0);
 
-    glUseProgramStages(pipeline.handle, GL_VERTEX_SHADER_BIT, current_state.vertex_shader);
-    glUseProgramStages(pipeline.handle, GL_GEOMETRY_SHADER_BIT, current_state.geometry_shader);
-    glUseProgramStages(pipeline.handle, GL_FRAGMENT_SHADER_BIT, current_state.fragment_shader);
+    glUseProgramStages(pipeline.handle, GL_VERTEX_SHADER_BIT, GetHandle(current_state.vertex));
+    glUseProgramStages(pipeline.handle, GL_GEOMETRY_SHADER_BIT, GetHandle(current_state.geometry));
+    glUseProgramStages(pipeline.handle, GL_FRAGMENT_SHADER_BIT, GetHandle(current_state.fragment));
 
     old_state = current_state;
-}
-
-void MaxwellUniformData::SetFromRegs(const Maxwell3D& maxwell, std::size_t shader_stage) {
-    const auto& regs = maxwell.regs;
-    const auto& state = maxwell.state;
-
-    // TODO(bunnei): Support more than one viewport
-    viewport_flip[0] = regs.viewport_transform[0].scale_x < 0.0 ? -1.0f : 1.0f;
-    viewport_flip[1] = regs.viewport_transform[0].scale_y < 0.0 ? -1.0f : 1.0f;
-
-    instance_id = state.current_instance;
-
-    // Assign in which stage the position has to be flipped
-    // (the last stage before the fragment shader).
-    constexpr u32 geometry_index = static_cast<u32>(Maxwell3D::Regs::ShaderProgram::Geometry);
-    if (maxwell.regs.shader_config[geometry_index].enable) {
-        flip_stage = geometry_index;
-    } else {
-        flip_stage = static_cast<u32>(Maxwell3D::Regs::ShaderProgram::VertexB);
-    }
-
-    // Y_NEGATE controls what value S2R returns for the Y_DIRECTION system value.
-    y_direction = regs.screen_y_control.y_negate == 0 ? 1.f : -1.f;
 }
 
 } // namespace OpenGL::GLShader

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -12,16 +12,15 @@ namespace OpenGL::GLShader {
 
 using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 
-enum ProgramLocations : u32 {
-    CONFIG_PACK = 0,
-    VIEWPORT_SCALE = 1,
-};
-
 StageProgram::StageProgram() = default;
 
 StageProgram::~StageProgram() = default;
 
 void StageProgram::UpdateConstants() {
+    enum ProgramLocations : u32 {
+        CONFIG_PACK = 0,
+        VIEWPORT_SCALE = 1,
+    };
     if (state.config_pack != old_state.config_pack) {
         glProgramUniform4uiv(handle, CONFIG_PACK, 1, state.config_pack.data());
         old_state.config_pack = state.config_pack;
@@ -65,7 +64,7 @@ void ProgramManager::SetConstants(Tegra::Engines::Maxwell3D& maxwell_3d, bool re
     const GLfloat rescale_factor = rescaling ? Settings::values.resolution_factor : 1.0f;
 
     for (const auto stage :
-         std::array{current_state.vertex, current_state.geometry, current_state.fragment}) {
+         {current_state.vertex, current_state.geometry, current_state.fragment}) {
         if (!stage) {
             continue;
         }

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -16,17 +16,18 @@ StageProgram::StageProgram() = default;
 
 StageProgram::~StageProgram() = default;
 
+void StageProgram::SetUniformLocations() {
+    config_pack_location = glGetUniformLocation(handle, "config_pack");
+    viewport_flip_location = glGetUniformLocation(handle, "viewport_flip");
+}
+
 void StageProgram::UpdateConstants() {
-    enum ProgramLocations : u32 {
-        CONFIG_PACK = 0,
-        VIEWPORT_SCALE = 1,
-    };
     if (state.config_pack != old_state.config_pack) {
-        glProgramUniform4uiv(handle, CONFIG_PACK, 1, state.config_pack.data());
+        glProgramUniform4uiv(handle, config_pack_location, 1, state.config_pack.data());
         old_state.config_pack = state.config_pack;
     }
     if (state.viewport_scale != old_state.viewport_scale) {
-        glProgramUniform2fv(handle, VIEWPORT_SCALE, 1, state.viewport_scale.data());
+        glProgramUniform2fv(handle, viewport_flip_location, 1, state.viewport_scale.data());
         old_state.viewport_scale = state.viewport_scale;
     }
 }

--- a/src/video_core/renderer_opengl/gl_shader_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_manager.cpp
@@ -4,6 +4,7 @@
 
 #include <array>
 #include "common/common_types.h"
+#include "core/settings.h"
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/renderer_opengl/gl_shader_manager.h"
 
@@ -37,7 +38,7 @@ ProgramManager::ProgramManager() {
 
 ProgramManager::~ProgramManager() = default;
 
-void ProgramManager::SetConstants(Tegra::Engines::Maxwell3D& maxwell_3d) {
+void ProgramManager::SetConstants(Tegra::Engines::Maxwell3D& maxwell_3d, bool rescaling) {
     const auto& regs = maxwell_3d.regs;
     const auto& state = maxwell_3d.state;
 
@@ -61,6 +62,8 @@ void ProgramManager::SetConstants(Tegra::Engines::Maxwell3D& maxwell_3d) {
     // Y_NEGATE controls what value S2R returns for the Y_DIRECTION system value.
     const GLfloat y_direction = regs.screen_y_control.y_negate == 0 ? 1.0f : -1.0f;
 
+    const GLfloat rescale_factor = rescaling ? Settings::values.resolution_factor : 1.0f;
+
     for (const auto stage :
          std::array{current_state.vertex, current_state.geometry, current_state.fragment}) {
         if (!stage) {
@@ -70,6 +73,7 @@ void ProgramManager::SetConstants(Tegra::Engines::Maxwell3D& maxwell_3d) {
         stage->SetFlipStage(flip_stage);
         stage->SetYDirection(y_direction);
         stage->SetViewportScale(flip_x, flip_y);
+        stage->SetRescalingFactor(rescale_factor);
         stage->UpdateConstants();
     }
 }

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -4,71 +4,98 @@
 
 #pragma once
 
+#include <array>
 #include <cstddef>
+#include <tuple>
 
 #include <glad/glad.h>
 
+#include "common/common_types.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/renderer_opengl/gl_state.h"
 #include "video_core/renderer_opengl/maxwell_to_gl.h"
 
+namespace Tegra::Engines {
+class Maxwell3D;
+}
+
 namespace OpenGL::GLShader {
 
-/// Uniform structure for the Uniform Buffer Object, all vectors must be 16-byte aligned
-/// @note Always keep a vec4 at the end. The GL spec is not clear whether the alignment at
-///       the end of a uniform block is included in UNIFORM_BLOCK_DATA_SIZE or not.
-///       Not following that rule will cause problems on some AMD drivers.
-struct MaxwellUniformData {
-    void SetFromRegs(const Tegra::Engines::Maxwell3D& maxwell, std::size_t shader_stage);
+class StageProgram final : public OGLProgram {
+public:
+    explicit StageProgram();
+    ~StageProgram();
 
-    alignas(16) GLvec4 viewport_flip;
-    struct alignas(16) {
-        GLuint instance_id;
-        GLuint flip_stage;
-        GLfloat y_direction;
+    void UpdateConstants();
+
+    void SetInstanceID(GLuint instance_id) {
+        state.instance_id = instance_id;
+    }
+
+    void SetFlipStage(GLuint flip_stage) {
+        state.flip_stage = flip_stage;
+    }
+
+    void SetYDirection(GLfloat y_direction) {
+        state.y_direction = y_direction;
+    }
+
+    void SetViewportScale(GLfloat x, GLfloat y) {
+        state.viewport_scale = {x, y};
+    }
+
+private:
+    struct State {
+        union {
+            std::array<GLuint, 4> config_pack{};
+            struct {
+                GLuint instance_id;
+                GLuint flip_stage;
+                GLfloat y_direction;
+            };
+        };
+
+        std::array<GLfloat, 2> viewport_scale{};
     };
-};
-static_assert(sizeof(MaxwellUniformData) == 32, "MaxwellUniformData structure size is incorrect");
-static_assert(sizeof(MaxwellUniformData) < 16384,
-              "MaxwellUniformData structure must be less than 16kb as per the OpenGL spec");
 
-class ProgramManager {
+    State state;
+    State old_state;
+};
+
+class ProgramManager final {
 public:
     explicit ProgramManager();
     ~ProgramManager();
 
+    void SetConstants(Tegra::Engines::Maxwell3D& maxwell_3d);
+
     void ApplyTo(OpenGLState& state);
 
-    void UseProgrammableVertexShader(GLuint program) {
-        current_state.vertex_shader = program;
+    void BindVertexShader(StageProgram* program) {
+        current_state.vertex = program;
     }
 
-    void UseProgrammableGeometryShader(GLuint program) {
-        current_state.geometry_shader = program;
+    void BindGeometryShader(StageProgram* program) {
+        current_state.geometry = program;
     }
 
-    void UseProgrammableFragmentShader(GLuint program) {
-        current_state.fragment_shader = program;
-    }
-
-    void UseTrivialGeometryShader() {
-        current_state.geometry_shader = 0;
+    void BindFragmentShader(StageProgram* program) {
+        current_state.fragment = program;
     }
 
 private:
     struct PipelineState {
         bool operator==(const PipelineState& rhs) const {
-            return vertex_shader == rhs.vertex_shader && fragment_shader == rhs.fragment_shader &&
-                   geometry_shader == rhs.geometry_shader;
+            return vertex == rhs.vertex && fragment == rhs.fragment && geometry == rhs.geometry;
         }
 
         bool operator!=(const PipelineState& rhs) const {
             return !operator==(rhs);
         }
 
-        GLuint vertex_shader{};
-        GLuint fragment_shader{};
-        GLuint geometry_shader{};
+        StageProgram* vertex{};
+        StageProgram* fragment{};
+        StageProgram* geometry{};
     };
 
     void UpdatePipeline();

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -40,6 +40,10 @@ public:
         state.y_direction = y_direction;
     }
 
+    void SetRescalingFactor(GLfloat rescaling_factor) {
+        state.rescaling_factor = rescaling_factor;
+    }
+
     void SetViewportScale(GLfloat x, GLfloat y) {
         state.viewport_scale = {x, y};
     }
@@ -52,6 +56,7 @@ private:
                 GLuint instance_id;
                 GLuint flip_stage;
                 GLfloat y_direction;
+                GLfloat rescaling_factor;
             };
         };
 
@@ -67,7 +72,7 @@ public:
     explicit ProgramManager();
     ~ProgramManager();
 
-    void SetConstants(Tegra::Engines::Maxwell3D& maxwell_3d);
+    void SetConstants(Tegra::Engines::Maxwell3D& maxwell_3d, bool rescaling);
 
     void ApplyTo(OpenGLState& state);
 

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -26,6 +26,8 @@ public:
     explicit StageProgram();
     ~StageProgram();
 
+    void SetUniformLocations();
+
     void UpdateConstants();
 
     void SetInstanceID(GLuint instance_id) {
@@ -62,6 +64,9 @@ private:
 
         std::array<GLfloat, 2> viewport_scale{};
     };
+
+    GLint config_pack_location = -1;
+    GLint viewport_flip_location = -1;
 
     State state;
     State old_state;

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -249,7 +249,8 @@ CachedSurface::CachedSurface(const GPUVAddr gpu_addr, const SurfaceParams& param
 
 void CachedSurface::Init() {
     target = GetTextureTarget(params.target);
-    u32 resolution_factor = IsRescaled() ? static_cast<u32>(Settings::values.resolution_factor) : 1;
+    const u32 resolution_factor =
+        IsRescaled() ? static_cast<u32>(Settings::values.resolution_factor) : 1;
     texture = CreateTexture(params, target, internal_format, texture_buffer, resolution_factor);
     DecorateSurfaceName();
     main_view = CreateViewInner(
@@ -482,8 +483,8 @@ void TextureCacheOpenGL::ImageCopy(Surface& src_surface, Surface& dst_surface,
         // A fallback is needed
         return;
     }
-    bool src_rescaled = src_surface->IsRescaled();
-    bool dst_rescaled = dst_surface->IsRescaled();
+    const bool src_rescaled = src_surface->IsRescaled();
+    const bool dst_rescaled = dst_surface->IsRescaled();
     if (src_rescaled != dst_rescaled) {
         LOG_CRITICAL(HW_GPU, "Rescaling Database is incorrectly set! Rescan the database!.");
     }
@@ -555,8 +556,8 @@ void TextureCacheOpenGL::ImageBlit(View& src_view, View& dst_view,
     const Common::Rectangle<u32>& dst_rect = copy_config.dst_rect;
     const bool is_linear = copy_config.filter == Tegra::Engines::Fermi2D::Filter::Linear;
 
-    bool src_rescaled = src_view->GetParent().IsRescaled();
-    bool dst_rescaled = dst_view->GetParent().IsRescaled();
+    const bool src_rescaled = src_view->GetParent().IsRescaled();
+    const bool dst_rescaled = dst_view->GetParent().IsRescaled();
     const u32 factor1 = src_rescaled ? static_cast<u32>(Settings::values.resolution_factor) : 1U;
     const u32 factor2 = dst_rescaled ? static_cast<u32>(Settings::values.resolution_factor) : 1U;
 
@@ -575,8 +576,8 @@ void TextureCacheOpenGL::BufferCopy(Surface& src_surface, Surface& dst_surface) 
     const auto source_format = GetFormatTuple(src_params.pixel_format, src_params.component_type);
     const auto dest_format = GetFormatTuple(dst_params.pixel_format, dst_params.component_type);
 
-    bool src_rescaled = src_surface->IsRescaled();
-    bool dst_rescaled = dst_surface->IsRescaled();
+    const bool src_rescaled = src_surface->IsRescaled();
+    const bool dst_rescaled = dst_surface->IsRescaled();
     if (src_rescaled != dst_rescaled) {
         LOG_CRITICAL(HW_GPU, "Rescaling Database is incorrectly set! Rescan the database!.");
     }

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -199,7 +199,7 @@ void ApplyTextureDefaults(const SurfaceParams& params, GLuint texture) {
 }
 
 OGLTexture CreateTexture(const SurfaceParams& params, GLenum target, GLenum internal_format,
-                         OGLBuffer& texture_buffer, float resolution_factor) {
+                         OGLBuffer& texture_buffer, u32 resolution_factor) {
     OGLTexture texture;
     texture.Create(target);
 
@@ -249,7 +249,7 @@ CachedSurface::CachedSurface(const GPUVAddr gpu_addr, const SurfaceParams& param
 
 void CachedSurface::Init() {
     target = GetTextureTarget(params.target);
-    float resolution_factor = IsRescaled() ? Settings::values.resolution_factor : 1.0;
+    u32 resolution_factor = IsRescaled() ? static_cast<u32>(Settings::values.resolution_factor) : 1;
     texture = CreateTexture(params, target, internal_format, texture_buffer, resolution_factor);
     DecorateSurfaceName();
     main_view = CreateViewInner(
@@ -332,7 +332,6 @@ void CachedSurface::UploadTextureMipmap(u32 level, const std::vector<u8>& stagin
             UNREACHABLE();
         }
     } else {
-        float resolution_factor = IsRescaled() ? Settings::values.resolution_factor : 1.0;
         switch (params.target) {
         case SurfaceTarget::Texture1D:
             glTextureSubImage1D(texture.handle, level, 0, params.GetMipWidth(level), format, type,
@@ -345,9 +344,8 @@ void CachedSurface::UploadTextureMipmap(u32 level, const std::vector<u8>& stagin
             break;
         case SurfaceTarget::Texture1DArray:
         case SurfaceTarget::Texture2D:
-            glTextureSubImage2D(
-                texture.handle, level, 0, 0, params.GetMipWidth(level) * resolution_factor,
-                params.GetMipHeight(level) * resolution_factor, format, type, buffer);
+            glTextureSubImage2D(texture.handle, level, 0, 0, params.GetMipWidth(level),
+                                params.GetMipHeight(level), format, type, buffer);
             break;
         case SurfaceTarget::Texture3D:
         case SurfaceTarget::Texture2DArray:
@@ -489,7 +487,7 @@ void TextureCacheOpenGL::ImageCopy(Surface& src_surface, Surface& dst_surface,
     if (src_rescaled != dst_rescaled) {
         LOG_CRITICAL(HW_GPU, "Rescaling Database is incorrectly set! Rescan the database!.");
     }
-    u32 factor = static_cast<u32>(src_rescaled ? Settings::values.resolution_factor : 1.0);
+    const u32 factor = src_rescaled ? static_cast<u32>(Settings::values.resolution_factor) : 1U;
     const auto src_handle = src_surface->GetTexture();
     const auto src_target = src_surface->GetTarget();
     const auto dst_handle = dst_surface->GetTexture();
@@ -559,8 +557,8 @@ void TextureCacheOpenGL::ImageBlit(View& src_view, View& dst_view,
 
     bool src_rescaled = src_view->GetParent().IsRescaled();
     bool dst_rescaled = dst_view->GetParent().IsRescaled();
-    u32 factor1 = static_cast<u32>(src_rescaled ? Settings::values.resolution_factor : 1);
-    u32 factor2 = static_cast<u32>(dst_rescaled ? Settings::values.resolution_factor : 1);
+    const u32 factor1 = src_rescaled ? static_cast<u32>(Settings::values.resolution_factor) : 1U;
+    const u32 factor2 = dst_rescaled ? static_cast<u32>(Settings::values.resolution_factor) : 1U;
 
     glBlitFramebuffer(src_rect.left * factor1, src_rect.top * factor1, src_rect.right * factor1,
                       src_rect.bottom * factor1, dst_rect.left * factor2, dst_rect.top * factor2,
@@ -582,7 +580,7 @@ void TextureCacheOpenGL::BufferCopy(Surface& src_surface, Surface& dst_surface) 
     if (src_rescaled != dst_rescaled) {
         LOG_CRITICAL(HW_GPU, "Rescaling Database is incorrectly set! Rescan the database!.");
     }
-    u32 factor = static_cast<u32>(src_rescaled ? Settings::values.resolution_factor : 1.0);
+    const u32 factor = src_rescaled ? static_cast<u32>(Settings::values.resolution_factor) : 1U;
 
     const std::size_t source_size = src_surface->GetHostSizeInBytes() * factor * factor;
     const std::size_t dest_size = dst_surface->GetHostSizeInBytes() * factor * factor;

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -39,6 +39,8 @@ public:
     explicit CachedSurface(GPUVAddr gpu_addr, const SurfaceParams& params);
     ~CachedSurface();
 
+    void Init();
+
     void UploadTexture(const std::vector<u8>& staging_buffer) override;
     void DownloadTexture(std::vector<u8>& staging_buffer) override;
 

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -98,6 +98,10 @@ public:
         return texture_view.handle;
     }
 
+    const CachedSurface& GetParent() const {
+        return surface;
+    }
+
     const SurfaceParams& GetSurfaceParams() const {
         return surface.GetSurfaceParams();
     }

--- a/src/video_core/texture_cache/resolution_scaling/database.cpp
+++ b/src/video_core/texture_cache/resolution_scaling/database.cpp
@@ -19,6 +19,10 @@ namespace VideoCommon::Resolution {
 
 using namespace nlohmann;
 
+std::string GetBaseDir() {
+    return FileUtil::GetUserPath(FileUtil::UserPath::RescalingDir);
+}
+
 ScalingDatabase::ScalingDatabase(Core::System& system) : database{}, blacklist{}, system{system} {
     title_id = 0;
 }
@@ -63,6 +67,11 @@ void ScalingDatabase::LoadDatabase() {
 }
 
 void ScalingDatabase::SaveDatabase() {
+    std::string dir = GetBaseDir();
+    if (!FileUtil::CreateDir(dir)) {
+        LOG_ERROR(HW_GPU, "Failed to create directory={}", dir);
+        return;
+    }
     json out;
     out["version"] = DBVersion;
     auto entries = json::array();
@@ -100,10 +109,6 @@ void ScalingDatabase::Unregister(const PixelFormat format, const u32 width, cons
     ResolutionKey key{format, width, height};
     database.erase(key);
     blacklist.insert(key);
-}
-
-std::string GetBaseDir() {
-    return FileUtil::GetUserPath(FileUtil::UserPath::RescalingDir);
 }
 
 std::string ScalingDatabase::GetTitleID() const {

--- a/src/video_core/texture_cache/resolution_scaling/database.cpp
+++ b/src/video_core/texture_cache/resolution_scaling/database.cpp
@@ -1,0 +1,74 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <fstream>
+#include <json.hpp>
+
+#include "core/core.h"
+#include "core/hle/kernel/process.h"
+#include "video_core/texture_cache/resolution_scaling/database.h"
+
+namespace VideoCommon::Resolution {
+
+explicit ScalingDatabase::ScalingDatabase(Core::System& system) : database{}, blacklist{}, system{system} {
+    title_id = system.CurrentProcess()->GetTitleID();
+}
+
+ScalingDatabase::~ScalingDatabase() {
+    SaveDatabase();
+}
+
+void ScalingDatabase::SaveDatabase() {
+    json out;
+    out["version"] = DBVersion;
+    auto entries = json::array();
+    for (const auto& pair : database) {
+        const auto [key, value] = pair;
+        if (value) {
+            entries.push_back({
+                {"format", static_cast<u32>(key.format)},
+                {"width", key.width},
+                {"height", key.height},
+            });
+        }
+    }
+    out["entries"] = std::move(entries);
+    std::ofstream file(GetProfilePath());
+    file << std::setw(4) << out << std::endl;
+}
+
+void ScalingDatabase::Register(const PixelFormat format, const u32 width, const u32 height) {
+    if (blacklist.count(key) == 0) {
+        ResolutionKey key{format, width, height};
+        database.emplace(key, false);
+    }
+}
+
+void MarkRendered(const PixelFormat format, const u32 width, const u32 height) {
+    ResolutionKey key{format, width, height};
+    auto search = database.find(key);
+    if (search != database.end()) {
+        search->second = true;
+    }
+}
+
+void ScalingDatabase::Unregister(const PixelFormat format, const u32 width, const u32 height) {
+    ResolutionKey key{format, width, height};
+    database.erase(key);
+    blacklist.insert(key);
+}
+
+std::string GetBaseDir() const {
+    return FileUtil::GetUserPath(FileUtil::UserPath::RescalingDir);
+}
+
+std::string ScalingDatabase::GetTitleID() const {
+    return fmt::format("{:016X}", title_id);
+}
+
+std::string ScalingDatabase::GetProfilePath() const {
+    return FileUtil::SanitizePath(GetBaseDir() + DIR_SEP_CHR + GetTitleID() + ".json");
+}
+
+} // namespace VideoCommon::Resolution

--- a/src/video_core/texture_cache/resolution_scaling/database.cpp
+++ b/src/video_core/texture_cache/resolution_scaling/database.cpp
@@ -23,9 +23,7 @@ std::string GetBaseDir() {
     return FileUtil::GetUserPath(FileUtil::UserPath::RescalingDir);
 }
 
-ScalingDatabase::ScalingDatabase(Core::System& system) : database{}, blacklist{}, system{system} {
-    title_id = 0;
-}
+ScalingDatabase::ScalingDatabase(Core::System& system) : system{system} {}
 
 ScalingDatabase::~ScalingDatabase() {
     SaveDatabase();
@@ -43,7 +41,8 @@ void ScalingDatabase::LoadDatabase() {
     if (!exists) {
         return;
     }
-    std::ifstream file(path);
+    std::ifstream file;
+    OpenFStream(file, path, std::ios_base::in);
     json in;
     file >> in;
     u32 version = in["version"].get<u32>();
@@ -73,7 +72,7 @@ void ScalingDatabase::SaveDatabase() {
         return;
     }
     json out;
-    out["version"] = DBVersion;
+    out.emplace("version", DBVersion);
     auto entries = json::array();
     for (const auto& key : database) {
         entries.push_back({
@@ -82,7 +81,7 @@ void ScalingDatabase::SaveDatabase() {
             {"height", key.height},
         });
     }
-    out["entries"] = std::move(entries);
+    out.emplace("entries", std::move(entries));
     auto blacklist_entries = json::array();
     for (const auto& key : blacklist) {
         blacklist_entries.push_back({
@@ -91,22 +90,22 @@ void ScalingDatabase::SaveDatabase() {
             {"height", key.height},
         });
     }
-    out["blacklist"] = blacklist_entries;
+    out.emplace("blacklist", std::move(blacklist_entries));
     const std::string path = GetProfilePath();
-    std::ofstream file(path);
+    std::ofstream file;
+    OpenFStream(file, path, std::ios_base::out);
     file << std::setw(4) << out << std::endl;
 }
 
 void ScalingDatabase::Register(PixelFormat format, u32 width, u32 height) {
-    ResolutionKey key{format, width, height};
+    const ResolutionKey key{format, width, height};
     if (blacklist.count(key) == 0) {
-        ResolutionKey key{format, width, height};
         database.insert(key);
     }
 }
 
 void ScalingDatabase::Unregister(PixelFormat format, u32 width, u32 height) {
-    ResolutionKey key{format, width, height};
+    const ResolutionKey key{format, width, height};
     database.erase(key);
     blacklist.insert(key);
 }

--- a/src/video_core/texture_cache/resolution_scaling/database.cpp
+++ b/src/video_core/texture_cache/resolution_scaling/database.cpp
@@ -39,7 +39,7 @@ void ScalingDatabase::Init() {
 
 void ScalingDatabase::LoadDatabase() {
     const std::string path = GetProfilePath();
-    bool exists = FileUtil::Exists(path);
+    const bool exists = FileUtil::Exists(path);
     if (!exists) {
         return;
     }
@@ -67,7 +67,7 @@ void ScalingDatabase::LoadDatabase() {
 }
 
 void ScalingDatabase::SaveDatabase() {
-    std::string dir = GetBaseDir();
+    const std::string dir = GetBaseDir();
     if (!FileUtil::CreateDir(dir)) {
         LOG_ERROR(HW_GPU, "Failed to create directory={}", dir);
         return;
@@ -97,7 +97,7 @@ void ScalingDatabase::SaveDatabase() {
     file << std::setw(4) << out << std::endl;
 }
 
-void ScalingDatabase::Register(const PixelFormat format, const u32 width, const u32 height) {
+void ScalingDatabase::Register(PixelFormat format, u32 width, u32 height) {
     ResolutionKey key{format, width, height};
     if (blacklist.count(key) == 0) {
         ResolutionKey key{format, width, height};
@@ -105,7 +105,7 @@ void ScalingDatabase::Register(const PixelFormat format, const u32 width, const 
     }
 }
 
-void ScalingDatabase::Unregister(const PixelFormat format, const u32 width, const u32 height) {
+void ScalingDatabase::Unregister(PixelFormat format, u32 width, u32 height) {
     ResolutionKey key{format, width, height};
     database.erase(key);
     blacklist.insert(key);

--- a/src/video_core/texture_cache/resolution_scaling/database.cpp
+++ b/src/video_core/texture_cache/resolution_scaling/database.cpp
@@ -51,7 +51,7 @@ void ScalingDatabase::LoadDatabase() {
         key.format = static_cast<PixelFormat>(entry["format"].get<u32>());
         key.width = entry["width"].get<u32>();
         key.height = entry["height"].get<u32>();
-        database.emplace(key, true);
+        database.insert(key);
     }
     for (const auto& entry : in["blacklist"]) {
         ResolutionKey key{};
@@ -66,15 +66,12 @@ void ScalingDatabase::SaveDatabase() {
     json out;
     out["version"] = DBVersion;
     auto entries = json::array();
-    for (const auto& pair : database) {
-        const auto [key, value] = pair;
-        if (value) {
-            entries.push_back({
-                {"format", static_cast<u32>(key.format)},
-                {"width", key.width},
-                {"height", key.height},
-            });
-        }
+    for (const auto& key : database) {
+        entries.push_back({
+            {"format", static_cast<u32>(key.format)},
+            {"width", key.width},
+            {"height", key.height},
+        });
     }
     out["entries"] = std::move(entries);
     auto blacklist_entries = json::array();
@@ -95,15 +92,7 @@ void ScalingDatabase::Register(const PixelFormat format, const u32 width, const 
     ResolutionKey key{format, width, height};
     if (blacklist.count(key) == 0) {
         ResolutionKey key{format, width, height};
-        database.emplace(key, false);
-    }
-}
-
-void ScalingDatabase::MarkRendered(const PixelFormat format, const u32 width, const u32 height) {
-    ResolutionKey key{format, width, height};
-    auto search = database.find(key);
-    if (search != database.end()) {
-        search->second = true;
+        database.insert(key);
     }
 }
 

--- a/src/video_core/texture_cache/resolution_scaling/database.h
+++ b/src/video_core/texture_cache/resolution_scaling/database.h
@@ -7,6 +7,10 @@
 #include <unordered_set>
 #include "video_core/surface.h"
 
+namespace Core {
+class System;
+}
+
 namespace VideoCommon::Resolution {
 
 using VideoCore::Surface::PixelFormat;
@@ -44,25 +48,30 @@ namespace VideoCommon::Resolution {
 
 class ScalingDatabase {
 public:
-    explicit ScalingDatabase() : database{} {}
+    explicit ScalingDatabase(Core::System& system);
+    ~ScalingDatabase();
+
+    void SaveDatabase();
 
     bool IsInDatabase(const PixelFormat format, const u32 width, const u32 height) {
         ResolutionKey key{format, width, height};
         return database.count(key) > 0;
     }
 
-    void Register(const PixelFormat format, const u32 width, const u32 height) {
-        ResolutionKey key{format, width, height};
-        database.insert(key);
-    }
+    void MarkRendered(const PixelFormat format, const u32 width, const u32 height);
+    void Register(const PixelFormat format, const u32 width, const u32 height);
+    void Unregister(const PixelFormat format, const u32 width, const u32 height);
 
-    void Unregister(const PixelFormat format, const u32 width, const u32 height) {
-        ResolutionKey key{format, width, height};
-        database.erase(key);
-    }
+    std::string GetTitleID() const;
+    std::string GetProfilePath() const;
 
 private:
-    std::unordered_set<ResolutionKey> database;
+    std::unordered_map<ResolutionKey, bool> database;
+    std::unordered_set<ResolutionKey> blacklist;
+    u64 title_id;
+    Core::System& system;
+
+    static constexpr u32 DBVersion = 1;
 };
 
 } // namespace VideoCommon::Resolution

--- a/src/video_core/texture_cache/resolution_scaling/database.h
+++ b/src/video_core/texture_cache/resolution_scaling/database.h
@@ -29,6 +29,10 @@ struct ResolutionKey {
     bool operator==(const ResolutionKey& ks) const {
         return std::tie(format, width, height) == std::tie(ks.format, ks.width, ks.height);
     }
+
+    bool operator!=(const ResolutionKey& ks) const {
+        return !(*this == ks);
+    }
 };
 
 } // namespace VideoCommon::Resolution
@@ -55,13 +59,13 @@ public:
     void LoadDatabase();
     void Init();
 
-    bool IsInDatabase(const PixelFormat format, const u32 width, const u32 height) {
-        ResolutionKey key{format, width, height};
+    bool IsInDatabase(const PixelFormat format, const u32 width, const u32 height) const {
+        const ResolutionKey key{format, width, height};
         return database.count(key) > 0;
     }
 
-    bool IsBlacklisted(const PixelFormat format, const u32 width, const u32 height) {
-        ResolutionKey key{format, width, height};
+    bool IsBlacklisted(const PixelFormat format, const u32 width, const u32 height) const {
+        const ResolutionKey key{format, width, height};
         return blacklist.count(key) > 0;
     }
 

--- a/src/video_core/texture_cache/resolution_scaling/database.h
+++ b/src/video_core/texture_cache/resolution_scaling/database.h
@@ -52,10 +52,17 @@ public:
     ~ScalingDatabase();
 
     void SaveDatabase();
+    void LoadDatabase();
+    void Init();
 
     bool IsInDatabase(const PixelFormat format, const u32 width, const u32 height) {
         ResolutionKey key{format, width, height};
         return database.count(key) > 0;
+    }
+
+    bool IsBlacklisted(const PixelFormat format, const u32 width, const u32 height) {
+        ResolutionKey key{format, width, height};
+        return blacklist.count(key) > 0;
     }
 
     void MarkRendered(const PixelFormat format, const u32 width, const u32 height);
@@ -68,6 +75,7 @@ public:
 private:
     std::unordered_map<ResolutionKey, bool> database;
     std::unordered_set<ResolutionKey> blacklist;
+    bool initialized{};
     u64 title_id;
     Core::System& system;
 

--- a/src/video_core/texture_cache/resolution_scaling/database.h
+++ b/src/video_core/texture_cache/resolution_scaling/database.h
@@ -65,7 +65,6 @@ public:
         return blacklist.count(key) > 0;
     }
 
-    void MarkRendered(const PixelFormat format, const u32 width, const u32 height);
     void Register(const PixelFormat format, const u32 width, const u32 height);
     void Unregister(const PixelFormat format, const u32 width, const u32 height);
 
@@ -73,7 +72,7 @@ public:
     std::string GetProfilePath() const;
 
 private:
-    std::unordered_map<ResolutionKey, bool> database;
+    std::unordered_set<ResolutionKey> database;
     std::unordered_set<ResolutionKey> blacklist;
     bool initialized{};
     u64 title_id;

--- a/src/video_core/texture_cache/resolution_scaling/database.h
+++ b/src/video_core/texture_cache/resolution_scaling/database.h
@@ -1,0 +1,68 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <unordered_set>
+#include "video_core/surface.h"
+
+namespace VideoCommon::Resolution {
+
+using VideoCore::Surface::PixelFormat;
+
+struct ResolutionKey {
+    PixelFormat format;
+    u32 width;
+    u32 height;
+    std::size_t Hash() const {
+        const std::size_t comp1 = static_cast<std::size_t>(format) << 44;
+        const std::size_t comp2 = static_cast<std::size_t>(height) << 24;
+        const std::size_t comp3 = static_cast<std::size_t>(width);
+        return comp1 | comp2 | comp3;
+    }
+
+    bool operator==(const ResolutionKey& ks) const {
+        return std::tie(format, width, height) == std::tie(ks.format, ks.width, ks.height);
+    }
+};
+
+} // namespace VideoCommon::Resolution
+
+namespace std {
+
+template <>
+struct hash<VideoCommon::Resolution::ResolutionKey> {
+    std::size_t operator()(const VideoCommon::Resolution::ResolutionKey& k) const {
+        return k.Hash();
+    }
+};
+
+} // namespace std
+
+namespace VideoCommon::Resolution {
+
+class ScalingDatabase {
+public:
+    explicit ScalingDatabase() : database{} {}
+
+    bool IsInDatabase(const PixelFormat format, const u32 width, const u32 height) {
+        ResolutionKey key{format, width, height};
+        return database.count(key) > 0;
+    }
+
+    void Register(const PixelFormat format, const u32 width, const u32 height) {
+        ResolutionKey key{format, width, height};
+        database.insert(key);
+    }
+
+    void Unregister(const PixelFormat format, const u32 width, const u32 height) {
+        ResolutionKey key{format, width, height};
+        database.erase(key);
+    }
+
+private:
+    std::unordered_set<ResolutionKey> database;
+};
+
+} // namespace VideoCommon::Resolution

--- a/src/video_core/texture_cache/resolution_scaling/database.h
+++ b/src/video_core/texture_cache/resolution_scaling/database.h
@@ -72,10 +72,10 @@ public:
     std::string GetProfilePath() const;
 
 private:
-    std::unordered_set<ResolutionKey> database;
-    std::unordered_set<ResolutionKey> blacklist;
+    std::unordered_set<ResolutionKey> database{};
+    std::unordered_set<ResolutionKey> blacklist{};
     bool initialized{};
-    u64 title_id;
+    u64 title_id{};
     Core::System& system;
 
     static constexpr u32 DBVersion = 1;

--- a/src/video_core/texture_cache/surface_base.h
+++ b/src/video_core/texture_cache/surface_base.h
@@ -205,6 +205,10 @@ public:
         index = index_;
     }
 
+    void MarkAsRescaled(const bool is_rescaled) {
+        this->is_rescaled = is_rescaled;
+    }
+
     void MarkAsPicked(bool is_picked_) {
         is_picked = is_picked_;
     }
@@ -224,6 +228,10 @@ public:
 
     u32 GetRenderTarget() const {
         return index;
+    }
+
+    bool IsRescaled() const {
+        return is_rescaled;
     }
 
     bool IsRegistered() const {
@@ -318,6 +326,7 @@ private:
     bool is_target{};
     bool is_registered{};
     bool is_picked{};
+    bool is_rescaled{};
     u32 index{NO_RT};
     u64 modification_tick{};
 };

--- a/src/video_core/texture_cache/surface_base.h
+++ b/src/video_core/texture_cache/surface_base.h
@@ -207,6 +207,11 @@ public:
 
     void MarkAsRescaled(const bool is_rescaled) {
         this->is_rescaled = is_rescaled;
+        this->is_rescale_candidate = is_rescaled;
+    }
+
+    void MarkAsRescaleCandidate(const bool is_rescale_candidate) {
+        this->is_rescale_candidate = is_rescale_candidate;
     }
 
     void MarkAsPicked(bool is_picked_) {
@@ -232,6 +237,10 @@ public:
 
     bool IsRescaled() const {
         return is_rescaled;
+    }
+
+    bool IsRescaleCandidate() const {
+        return is_rescale_candidate;
     }
 
     bool IsRegistered() const {
@@ -327,6 +336,7 @@ private:
     bool is_registered{};
     bool is_picked{};
     bool is_rescaled{};
+    bool is_rescale_candidate{};
     u32 index{NO_RT};
     u64 modification_tick{};
 };

--- a/src/video_core/texture_cache/surface_base.h
+++ b/src/video_core/texture_cache/surface_base.h
@@ -207,11 +207,6 @@ public:
 
     void MarkAsRescaled(const bool is_rescaled) {
         this->is_rescaled = is_rescaled;
-        this->is_rescale_candidate = is_rescaled;
-    }
-
-    void MarkAsRescaleCandidate(const bool is_rescale_candidate) {
-        this->is_rescale_candidate = is_rescale_candidate;
     }
 
     void MarkAsPicked(bool is_picked_) {
@@ -237,10 +232,6 @@ public:
 
     bool IsRescaled() const {
         return is_rescaled;
-    }
-
-    bool IsRescaleCandidate() const {
-        return is_rescale_candidate;
     }
 
     bool IsRegistered() const {
@@ -336,7 +327,6 @@ private:
     bool is_registered{};
     bool is_picked{};
     bool is_rescaled{};
-    bool is_rescale_candidate{};
     u32 index{NO_RT};
     u64 modification_tick{};
 };

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -160,8 +160,12 @@ public:
             depth_buffer.target->MarkAsRenderTarget(false, NO_RT);
         depth_buffer.target = surface_view.first;
         depth_buffer.view = surface_view.second;
-        if (depth_buffer.target)
+        if (depth_buffer.target) {
             depth_buffer.target->MarkAsRenderTarget(true, DEPTH_RT);
+            if (IsResScannerEnabled()) {
+                MarkScannerRender(depth_buffer.target);
+            }
+        }
         return surface_view.second;
     }
 
@@ -194,8 +198,12 @@ public:
             render_targets[index].target->MarkAsRenderTarget(false, NO_RT);
         render_targets[index].target = surface_view.first;
         render_targets[index].view = surface_view.second;
-        if (render_targets[index].target)
+        if (render_targets[index].target) {
             render_targets[index].target->MarkAsRenderTarget(true, static_cast<u32>(index));
+            if (IsResScannerEnabled()) {
+                MarkScannerRender(render_targets[index].target);
+            }
+        }
         return surface_view.second;
     }
 
@@ -1020,7 +1028,12 @@ private:
             params.num_levels > 1 || params.IsCompressed() || params.block_depth > 1) {
             return;
         }
-        scaling_database.Unregister(params.pixel_format, params.width, params.height);
+        scaling_database.Register(params.pixel_format, params.width, params.height);
+    }
+
+    void MarkScannerRender(const TSurface& surface) {
+        const auto params = surface->GetSurfaceParams();
+        scaling_database.MarkRendered(params.pixel_format, params.width, params.height);
     }
 
     constexpr PixelFormat GetSiblingFormat(PixelFormat format) const {

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -167,7 +167,7 @@ public:
         depth_buffer.view = surface_view.second;
         if (depth_buffer.target) {
             depth_buffer.target->MarkAsRenderTarget(true, DEPTH_RT);
-            if (IsResScannerEnabled()) {
+            if (IsResolutionScannerEnabled()) {
                 MarkScanner(depth_buffer.target);
             }
         }
@@ -205,7 +205,7 @@ public:
         render_targets[index].view = surface_view.second;
         if (render_targets[index].target) {
             render_targets[index].target->MarkAsRenderTarget(true, static_cast<u32>(index));
-            if (IsResScannerEnabled()) {
+            if (IsResolutionScannerEnabled()) {
                 MarkScanner(render_targets[index].target);
             }
         }
@@ -253,7 +253,7 @@ public:
         DeduceBestBlit(src_params, dst_params, src_gpu_addr, dst_gpu_addr);
         std::pair<TSurface, TView> dst_surface = GetSurface(dst_gpu_addr, dst_params, true, false);
         std::pair<TSurface, TView> src_surface = GetSurface(src_gpu_addr, src_params, true, false);
-        if (IsResScannerEnabled()) {
+        if (IsResolutionScannerEnabled()) {
             bool is_candidate = IsInRSDatabase(src_surface.first);
             if (is_candidate) {
                 MarkScanner(dst_surface.first);
@@ -283,7 +283,7 @@ public:
     }
 
     bool IsResolutionScalingEnabled() {
-        if (IsResScannerEnabled()) {
+        if (IsResolutionScannerEnabled()) {
             return CheckBlackListMatch();
         }
         if (!EnabledRescaling()) {
@@ -390,7 +390,7 @@ protected:
             ManageRenderTargetUnregister(surface);
         }
 
-        if (IsResScannerEnabled()) {
+        if (IsResolutionScannerEnabled()) {
             if (reason == UnregisterReason::Restructured) {
                 UnmarkScanner(surface);
             }
@@ -569,7 +569,7 @@ private:
                 ImageCopy(current_surface, new_surface, brick);
             }
         }
-        if (IsResScannerEnabled()) {
+        if (IsResolutionScannerEnabled()) {
             if (IsInRSDatabase(current_surface)) {
                 if (IsRSBlacklisted(new_surface)) {
                     UnmarkScanner(current_surface);
@@ -966,7 +966,7 @@ private:
         if (!surface->IsModified()) {
             return;
         }
-        if (IsResScannerEnabled()) {
+        if (IsResolutionScannerEnabled()) {
             UnmarkScanner(surface);
         }
         staging_cache.GetBuffer(0).resize(surface->GetHostSizeInBytes());
@@ -1043,7 +1043,7 @@ private:
         return enable_resolution_scaling;
     }
 
-    bool IsResScannerEnabled() const {
+    bool IsResolutionScannerEnabled() const {
         return Settings::values.use_resolution_scanner;
     }
 
@@ -1061,12 +1061,12 @@ private:
         scaling_database.Register(params.pixel_format, params.width, params.height);
     }
 
-    bool IsRSBlacklisted(const TSurface& surface) {
+    bool IsRSBlacklisted(const TSurface& surface) const {
         const auto params = surface->GetSurfaceParams();
         return scaling_database.IsBlacklisted(params.pixel_format, params.width, params.height);
     }
 
-    bool IsInRSDatabase(const TSurface& surface) {
+    bool IsInRSDatabase(const TSurface& surface) const {
         const auto& params = surface->GetSurfaceParams();
         return scaling_database.IsInDatabase(params.pixel_format, params.width, params.height);
     }

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -320,7 +320,7 @@ protected:
         }
 
         enable_resolution_scaling =
-            Settings::values.resolution_factor != 1.0 && !Settings::values.use_resolution_scanner;
+            Settings::values.resolution_factor != 1.0f && !Settings::values.use_resolution_scanner;
 
         SetEmptyDepthBuffer();
         staging_cache.SetSize(2);
@@ -422,10 +422,8 @@ protected:
 
     // Must be called by child's create surface
     void SignalCreatedSurface(TSurface& new_surface) {
-        if (EnabledRescaling()) {
-            if (IsInRSDatabase(new_surface)) {
-                new_surface->MarkAsRescaled(true);
-            }
+        if (EnabledRescaling() && IsInRSDatabase(new_surface)) {
+            new_surface->MarkAsRescaled(true);
         }
     }
 

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -168,7 +168,6 @@ public:
             depth_buffer.target->MarkAsRenderTarget(true, DEPTH_RT);
             if (IsResScannerEnabled()) {
                 MarkScanner(depth_buffer.target);
-                MarkScannerRender(depth_buffer.target);
             }
         }
         return surface_view.second;
@@ -207,7 +206,6 @@ public:
             render_targets[index].target->MarkAsRenderTarget(true, static_cast<u32>(index));
             if (IsResScannerEnabled()) {
                 MarkScanner(render_targets[index].target);
-                MarkScannerRender(render_targets[index].target);
             }
         }
         return surface_view.second;
@@ -1064,11 +1062,6 @@ private:
     bool IsBlackListed(const TSurface& surface) {
         const auto params = surface->GetSurfaceParams();
         return scaling_database.IsBlacklisted(params.pixel_format, params.width, params.height);
-    }
-
-    void MarkScannerRender(const TSurface& surface) {
-        const auto params = surface->GetSurfaceParams();
-        scaling_database.MarkRendered(params.pixel_format, params.width, params.height);
     }
 
     constexpr PixelFormat GetSiblingFormat(PixelFormat format) const {

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -626,8 +626,6 @@ void Config::ReadRendererValues() {
         ReadSetting(QStringLiteral("use_asynchronous_gpu_emulation"), false).toBool();
     Settings::values.use_resolution_scanner =
         ReadSetting(QStringLiteral("use_resolution_scanner"), false).toBool();
-    Settings::values.use_resolution_scanner =
-        ReadSetting(QStringLiteral("use_resolution_scanner"), false).toBool();
     Settings::values.force_30fps_mode =
         ReadSetting(QStringLiteral("force_30fps_mode"), false).toBool();
 

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -1051,8 +1051,8 @@ void Config::SaveRendererValues() {
                  Settings::values.use_accurate_gpu_emulation, false);
     WriteSetting(QStringLiteral("use_asynchronous_gpu_emulation"),
                  Settings::values.use_asynchronous_gpu_emulation, false);
-    WriteSetting(QStringLiteral("use_resolution_scanner"),
-                 Settings::values.use_resolution_scanner, false);
+    WriteSetting(QStringLiteral("use_resolution_scanner"), Settings::values.use_resolution_scanner,
+                 false);
     WriteSetting(QStringLiteral("force_30fps_mode"), Settings::values.force_30fps_mode, false);
 
     // Cast to double because Qt's written float values are not human-readable

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -624,6 +624,10 @@ void Config::ReadRendererValues() {
         ReadSetting(QStringLiteral("use_accurate_gpu_emulation"), false).toBool();
     Settings::values.use_asynchronous_gpu_emulation =
         ReadSetting(QStringLiteral("use_asynchronous_gpu_emulation"), false).toBool();
+    Settings::values.use_resolution_scanner =
+        ReadSetting(QStringLiteral("use_resolution_scanner"), false).toBool();
+    Settings::values.use_resolution_scanner =
+        ReadSetting(QStringLiteral("use_resolution_scanner"), false).toBool();
     Settings::values.force_30fps_mode =
         ReadSetting(QStringLiteral("force_30fps_mode"), false).toBool();
 
@@ -1047,6 +1051,8 @@ void Config::SaveRendererValues() {
                  Settings::values.use_accurate_gpu_emulation, false);
     WriteSetting(QStringLiteral("use_asynchronous_gpu_emulation"),
                  Settings::values.use_asynchronous_gpu_emulation, false);
+    WriteSetting(QStringLiteral("use_resolution_scanner"),
+                 Settings::values.use_resolution_scanner, false);
     WriteSetting(QStringLiteral("force_30fps_mode"), Settings::values.force_30fps_mode, false);
 
     // Cast to double because Qt's written float values are not human-readable

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -10,7 +10,7 @@
 
 namespace {
 enum class Resolution : int {
-    Auto,
+    Scanner,
     Scale1x,
     Scale2x,
     Scale3x,
@@ -19,7 +19,7 @@ enum class Resolution : int {
 
 float ToResolutionFactor(Resolution option) {
     switch (option) {
-    case Resolution::Auto:
+    case Resolution::Scanner:
         return 1.f;
     case Resolution::Scale1x:
         return 1.f;
@@ -30,12 +30,12 @@ float ToResolutionFactor(Resolution option) {
     case Resolution::Scale4x:
         return 4.f;
     }
-    return 0.f;
+    return 1.f;
 }
 
-Resolution FromResolutionFactor(float factor) {
-    if (factor == 0.f) {
-        return Resolution::Auto;
+Resolution FromResolutionFactor(float factor, bool scanner_on) {
+    if (scanner_on) {
+        return Resolution::Scanner;
     } else if (factor == 1.f) {
         return Resolution::Scale1x;
     } else if (factor == 2.f) {
@@ -45,7 +45,7 @@ Resolution FromResolutionFactor(float factor) {
     } else if (factor == 4.f) {
         return Resolution::Scale4x;
     }
-    return Resolution::Auto;
+    return Resolution::Scale1x;
 }
 } // Anonymous namespace
 
@@ -69,15 +69,14 @@ ConfigureGraphics::~ConfigureGraphics() = default;
 void ConfigureGraphics::SetConfiguration() {
     const bool runtime_lock = !Core::System::GetInstance().IsPoweredOn();
 
-    ui->resolution_factor_combobox->setCurrentIndex(
-        static_cast<int>(FromResolutionFactor(Settings::values.resolution_factor)));
+    ui->resolution_factor_combobox->setEnabled(runtime_lock);
+    ui->resolution_factor_combobox->setCurrentIndex(static_cast<int>(FromResolutionFactor(
+        Settings::values.resolution_factor, Settings::values.use_resolution_scanner)));
     ui->use_disk_shader_cache->setEnabled(runtime_lock);
     ui->use_disk_shader_cache->setChecked(Settings::values.use_disk_shader_cache);
     ui->use_accurate_gpu_emulation->setChecked(Settings::values.use_accurate_gpu_emulation);
     ui->use_asynchronous_gpu_emulation->setEnabled(runtime_lock);
     ui->use_asynchronous_gpu_emulation->setChecked(Settings::values.use_asynchronous_gpu_emulation);
-    ui->use_resolution_scanner->setEnabled(runtime_lock);
-    ui->use_resolution_scanner->setChecked(Settings::values.use_resolution_scanner);
     ui->force_30fps_mode->setEnabled(runtime_lock);
     ui->force_30fps_mode->setChecked(Settings::values.force_30fps_mode);
     UpdateBackgroundColorButton(QColor::fromRgbF(Settings::values.bg_red, Settings::values.bg_green,
@@ -85,14 +84,13 @@ void ConfigureGraphics::SetConfiguration() {
 }
 
 void ConfigureGraphics::ApplyConfiguration() {
-    Settings::values.resolution_factor =
-        ToResolutionFactor(static_cast<Resolution>(ui->resolution_factor_combobox->currentIndex()));
+    const auto resolution = static_cast<Resolution>(ui->resolution_factor_combobox->currentIndex());
+    Settings::values.resolution_factor = ToResolutionFactor(resolution);
     Settings::values.use_disk_shader_cache = ui->use_disk_shader_cache->isChecked();
     Settings::values.use_accurate_gpu_emulation = ui->use_accurate_gpu_emulation->isChecked();
     Settings::values.use_asynchronous_gpu_emulation =
         ui->use_asynchronous_gpu_emulation->isChecked();
-    Settings::values.use_resolution_scanner =
-        ui->use_resolution_scanner->isChecked();
+    Settings::values.use_resolution_scanner = resolution == Resolution::Scanner;
     Settings::values.force_30fps_mode = ui->force_30fps_mode->isChecked();
     Settings::values.bg_red = static_cast<float>(bg_color.redF());
     Settings::values.bg_green = static_cast<float>(bg_color.greenF());

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -76,6 +76,8 @@ void ConfigureGraphics::SetConfiguration() {
     ui->use_accurate_gpu_emulation->setChecked(Settings::values.use_accurate_gpu_emulation);
     ui->use_asynchronous_gpu_emulation->setEnabled(runtime_lock);
     ui->use_asynchronous_gpu_emulation->setChecked(Settings::values.use_asynchronous_gpu_emulation);
+    ui->use_resolution_scanner->setEnabled(runtime_lock);
+    ui->use_resolution_scanner->setChecked(Settings::values.use_resolution_scanner);
     ui->force_30fps_mode->setEnabled(runtime_lock);
     ui->force_30fps_mode->setChecked(Settings::values.force_30fps_mode);
     UpdateBackgroundColorButton(QColor::fromRgbF(Settings::values.bg_red, Settings::values.bg_green,
@@ -89,6 +91,8 @@ void ConfigureGraphics::ApplyConfiguration() {
     Settings::values.use_accurate_gpu_emulation = ui->use_accurate_gpu_emulation->isChecked();
     Settings::values.use_asynchronous_gpu_emulation =
         ui->use_asynchronous_gpu_emulation->isChecked();
+    Settings::values.use_resolution_scanner =
+        ui->use_resolution_scanner->isChecked();
     Settings::values.force_30fps_mode = ui->force_30fps_mode->isChecked();
     Settings::values.bg_red = static_cast<float>(bg_color.redF());
     Settings::values.bg_green = static_cast<float>(bg_color.greenF());

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -20,7 +20,7 @@ enum class Resolution : int {
 float ToResolutionFactor(Resolution option) {
     switch (option) {
     case Resolution::Auto:
-        return 0.f;
+        return 1.f;
     case Resolution::Scale1x:
         return 1.f;
     case Resolution::Scale2x:

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -51,13 +51,6 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="use_resolution_scanner">
-          <property name="text">
-           <string>Enable Resolution Scanner</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>
            <widget class="QLabel" name="label">
@@ -70,7 +63,7 @@
            <widget class="QComboBox" name="resolution_factor_combobox">
             <item>
              <property name="text">
-              <string>Auto (Window Size)</string>
+              <string>Profile Scanner (Native)</string>
              </property>
             </item>
             <item>

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -75,22 +75,22 @@
             </item>
             <item>
              <property name="text">
-              <string>Native (1280x720)</string>
+              <string>Native (1280x720/1920x1080)</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>2x Native (2560x1440)</string>
+              <string>2x Native (2560x1440/3840x2160)</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>3x Native (3840x2160)</string>
+              <string>3x Native (3840x2160/5760x3240)</string>
              </property>
             </item>
             <item>
              <property name="text">
-              <string>4x Native (5120x2880)</string>
+              <string>4x Native (5120x2880/7680x4320)</string>
              </property>
             </item>
            </widget>

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -51,6 +51,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="use_resolution_scanner">
+          <property name="text">
+           <string>Enable Resolution Scanner</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <layout class="QHBoxLayout" name="horizontalLayout">
           <item>
            <widget class="QLabel" name="label">

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -471,6 +471,7 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, std::string pat
     QAction* open_lfs_location = context_menu.addAction(tr("Open Mod Data Location"));
     QAction* open_transferable_shader_cache =
         context_menu.addAction(tr("Open Transferable Shader Cache"));
+    QAction* open_rescaling_profile_cache = context_menu.addAction(tr("Open Rescaling Profile"));
     context_menu.addSeparator();
     QAction* dump_romfs = context_menu.addAction(tr("Dump RomFS"));
     QAction* copy_tid = context_menu.addAction(tr("Copy Title ID to Clipboard"));
@@ -490,6 +491,8 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, std::string pat
     });
     connect(open_transferable_shader_cache, &QAction::triggered,
             [this, program_id]() { emit OpenTransferableShaderCacheRequested(program_id); });
+    connect(open_rescaling_profile_cache, &QAction::triggered,
+            [&]() { emit OpenResolutionProfileRequested(program_id); });
     connect(dump_romfs, &QAction::triggered,
             [this, program_id, path]() { emit DumpRomFSRequested(program_id, path); });
     connect(copy_tid, &QAction::triggered,

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -492,7 +492,7 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, std::string pat
     connect(open_transferable_shader_cache, &QAction::triggered,
             [this, program_id]() { emit OpenTransferableShaderCacheRequested(program_id); });
     connect(open_rescaling_profile_cache, &QAction::triggered,
-            [&]() { emit OpenResolutionProfileRequested(program_id); });
+            [this, program_id]() { emit OpenResolutionProfileRequested(program_id); });
     connect(dump_romfs, &QAction::triggered,
             [this, program_id, path]() { emit DumpRomFSRequested(program_id, path); });
     connect(copy_tid, &QAction::triggered,

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -75,6 +75,7 @@ signals:
     void ShouldCancelWorker();
     void OpenFolderRequested(u64 program_id, GameListOpenTarget target);
     void OpenTransferableShaderCacheRequested(u64 program_id);
+    void OpenResolutionProfileRequested(u64 program_id);
     void DumpRomFSRequested(u64 program_id, const std::string& game_path);
     void CopyTIDRequested(u64 program_id);
     void NavigateToGamedbEntryRequested(u64 program_id,

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1149,6 +1149,23 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
     QDesktopServices::openUrl(QUrl::fromLocalFile(qpath));
 }
 
+void DisplayOrSelect(const QString& folder_path, const QString& file_path) {
+// Windows supports opening a folder with selecting a specified file in explorer. On every other
+// OS we just open the transferable shader cache folder without preselecting the transferable
+// shader cache file for the selected game.
+#if defined(Q_OS_WIN)
+    const QString explorer = QStringLiteral("explorer");
+    QStringList param;
+    if (!QFileInfo(file_path).isDir()) {
+        param << QStringLiteral("/select,");
+    }
+    param << QDir::toNativeSeparators(file_path);
+    QProcess::startDetached(explorer, param);
+#else
+    QDesktopServices::openUrl(QUrl::fromLocalFile(folder_path));
+#endif
+}
+
 void GMainWindow::OnTransferableShaderCacheOpenFile(u64 program_id) {
     ASSERT(program_id != 0);
 
@@ -1166,20 +1183,7 @@ void GMainWindow::OnTransferableShaderCacheOpenFile(u64 program_id) {
         return;
     }
 
-    // Windows supports opening a folder with selecting a specified file in explorer. On every other
-    // OS we just open the transferable shader cache folder without preselecting the transferable
-    // shader cache file for the selected game.
-#if defined(Q_OS_WIN)
-    const QString explorer = QStringLiteral("explorer");
-    QStringList param;
-    if (!QFileInfo(transferable_shader_cache_file_path).isDir()) {
-        param << QStringLiteral("/select,");
-    }
-    param << QDir::toNativeSeparators(transferable_shader_cache_file_path);
-    QProcess::startDetached(explorer, param);
-#else
-    QDesktopServices::openUrl(QUrl::fromLocalFile(tranferable_shader_cache_folder_path));
-#endif
+    DisplayOrSelect(tranferable_shader_cache_folder_path, transferable_shader_cache_file_path);
 }
 
 void GMainWindow::OnResolutionProfileOpenFile(u64 program_id) {
@@ -1196,20 +1200,7 @@ void GMainWindow::OnResolutionProfileOpenFile(u64 program_id) {
         return;
     }
 
-    // Windows supports opening a folder with selecting a specified file in explorer. On every other
-    // OS we just open the transferable shader cache folder without preselecting the transferable
-    // shader cache file for the selected game.
-#if defined(Q_OS_WIN)
-    const QString explorer = QStringLiteral("explorer");
-    QStringList param;
-    if (!QFileInfo(rescaling_profile_file_path).isDir()) {
-        param << QStringLiteral("/select,");
-    }
-    param << QDir::toNativeSeparators(rescaling_profile_file_path);
-    QProcess::startDetached(explorer, param);
-#else
-    QDesktopServices::openUrl(QUrl::fromLocalFile(rescaling_dir));
-#endif
+    DisplayOrSelect(rescaling_dir, rescaling_profile_file_path);
 }
 
 static std::size_t CalculateRomFSEntrySize(const FileSys::VirtualDir& dir, bool full) {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -681,6 +681,8 @@ void GMainWindow::ConnectWidgetEvents() {
     connect(game_list, &GameList::OpenFolderRequested, this, &GMainWindow::OnGameListOpenFolder);
     connect(game_list, &GameList::OpenTransferableShaderCacheRequested, this,
             &GMainWindow::OnTransferableShaderCacheOpenFile);
+    connect(game_list, &GameList::OpenResolutionProfileRequested, this,
+            &GMainWindow::OnResolutionProfileOpenFile);
     connect(game_list, &GameList::DumpRomFSRequested, this, &GMainWindow::OnGameListDumpRomFS);
     connect(game_list, &GameList::CopyTIDRequested, this, &GMainWindow::OnGameListCopyTID);
     connect(game_list, &GameList::NavigateToGamedbEntryRequested, this,
@@ -1177,6 +1179,36 @@ void GMainWindow::OnTransferableShaderCacheOpenFile(u64 program_id) {
     QProcess::startDetached(explorer, param);
 #else
     QDesktopServices::openUrl(QUrl::fromLocalFile(tranferable_shader_cache_folder_path));
+#endif
+}
+
+void GMainWindow::OnResolutionProfileOpenFile(u64 program_id) {
+    ASSERT(program_id != 0);
+
+    const QString rescaling_dir =
+        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::RescalingDir));
+    const QString rescaling_profile_file_path =
+        rescaling_dir + QString::fromStdString(fmt::format("{:016X}.json", program_id));
+
+    if (!QFile::exists(rescaling_profile_file_path)) {
+        QMessageBox::warning(this, tr("Error Opening Rescaling Profile"),
+                             tr("A rescaling profile for this title does not exist."));
+        return;
+    }
+
+    // Windows supports opening a folder with selecting a specified file in explorer. On every other
+    // OS we just open the transferable shader cache folder without preselecting the transferable
+    // shader cache file for the selected game.
+#if defined(Q_OS_WIN)
+    const QString explorer = QStringLiteral("explorer");
+    QStringList param;
+    if (!QFileInfo(rescaling_profile_file_path).isDir()) {
+        param << QStringLiteral("/select,");
+    }
+    param << QDir::toNativeSeparators(rescaling_profile_file_path);
+    QProcess::startDetached(explorer, param);
+#else
+    QDesktopServices::openUrl(QUrl::fromLocalFile(rescaling_dir));
 #endif
 }
 

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -185,6 +185,7 @@ private slots:
     void OnGameListLoadFile(QString game_path);
     void OnGameListOpenFolder(u64 program_id, GameListOpenTarget target);
     void OnTransferableShaderCacheOpenFile(u64 program_id);
+    void OnResolutionProfileOpenFile(u64 program_id);
     void OnGameListDumpRomFS(u64 program_id, const std::string& game_path);
     void OnGameListCopyTID(u64 program_id);
     void OnGameListNavigateToGamedbEntry(u64 program_id,


### PR DESCRIPTION
Native Resolution Rescaling in Emulators used to be an almost trivial process for old console GPUs where only 1 render target existed, memory wasn't unified (in the GPU sense, not on SoC sense) and textures weren't anywhere as complex as they are now. Native Resolution Rescaling for a modern GPU as Maxwell 2nd Gen is quite a challenge due to many factors: More complex texture types can be partially or entirely rendered onto: Cube textures, Array Textures, 3d Textures, etc; 8 different render targets with shared viewports and scissor tests, unified memories with uncalled readbacks and hardcoded shaders created for fixed resolutions (glFragCoord & TexelFetch). This PR introduces a set of heuristics and mechanisms to detect possible candidate render targets for rescaling based on a simple evolutive AI algorithm and performs render target rescaling based on a generated database of rescalable rendertargets (rescale profile) plus its corrections on state and shader code.
