### PR TITLE
configure_input: Uncheck "Joycons Docked" when "Use Docked Mode" is checked

### DIFF
--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -182,6 +182,8 @@ void ConfigureInput::UpdateUIEnabled() {
         players_configure[i]->setEnabled(players_controller[i]->currentIndex() != 0);
     }
 
+    ui->handheld_connected->setChecked(ui->handheld_connected->isChecked() &&
+                                       !ui->use_docked_mode->isChecked());
     ui->handheld_connected->setEnabled(!ui->use_docked_mode->isChecked());
     ui->handheld_configure->setEnabled(ui->handheld_connected->isChecked() &&
                                        !ui->use_docked_mode->isChecked());


### PR DESCRIPTION
Previously, "Joycons Docked" and "Use Docked Mode" can both be checked. Even though the "Joycons Docked" checkbox is grayed out when "Use Docked Mode is checked, the value of this checkbox is still read and as a result causes unintended behaviors. This PR corrects this by unchecking "Joycons Docked"  when "Use Docked Mode" is checked.