### PR TITLE
gl_rasterizer: Remove unused code paths from ConfigureFramebuffers

### DIFF
--- a/src/video_core/renderer_opengl/gl_framebuffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_framebuffer_cache.h
@@ -19,7 +19,6 @@
 namespace OpenGL {
 
 struct alignas(sizeof(u64)) FramebufferCacheKey {
-    bool is_single_buffer = false;
     bool stencil_enable = false;
     u16 colors_count = 0;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -77,39 +77,8 @@ public:
                            const VideoCore::DiskResourceLoadCallback& callback) override;
 
 private:
-    struct FramebufferConfigState {
-        bool using_color_fb{};
-        bool using_depth_fb{};
-        bool preserve_contents{};
-        std::optional<std::size_t> single_color_target;
-
-        bool operator==(const FramebufferConfigState& rhs) const {
-            return std::tie(using_color_fb, using_depth_fb, preserve_contents,
-                            single_color_target) == std::tie(rhs.using_color_fb, rhs.using_depth_fb,
-                                                             rhs.preserve_contents,
-                                                             rhs.single_color_target);
-        }
-        bool operator!=(const FramebufferConfigState& rhs) const {
-            return !operator==(rhs);
-        }
-    };
-
-    /**
-     * Configures the color and depth framebuffer states.
-     *
-     * @param current_state       The current OpenGL state.
-     * @param using_color_fb      If true, configure color framebuffers.
-     * @param using_depth_fb      If true, configure the depth/stencil framebuffer.
-     * @param preserve_contents   If true, tries to preserve data from a previously used
-     *                            framebuffer.
-     * @param single_color_target Specifies if a single color buffer target should be used.
-     *
-     * @returns If depth (first) or stencil (second) are being stored in the bound zeta texture
-     *          (requires using_depth_fb to be true)
-     */
-    std::pair<bool, bool> ConfigureFramebuffers(
-        OpenGLState& current_state, bool using_color_fb = true, bool using_depth_fb = true,
-        bool preserve_contents = true, std::optional<std::size_t> single_color_target = {});
+    /// Configures the color and depth framebuffer states.
+    void ConfigureFramebuffers();
 
     void ConfigureClearFramebuffer(OpenGLState& current_state, bool using_color_fb,
                                    bool using_depth_fb, bool using_stencil_fb);
@@ -227,9 +196,6 @@ private:
                         Tegra::Engines::Maxwell3D::Regs::NumVertexAttributes>,
              OGLVertexArray>
         vertex_array_cache;
-
-    FramebufferConfigState current_framebuffer_config_state;
-    std::pair<bool, bool> current_depth_stencil_usage{};
 
     static constexpr std::size_t STREAM_BUFFER_SIZE = 128 * 1024 * 1024;
     OGLBufferCache buffer_cache;


### PR DESCRIPTION
`ConfigureFramebuffers` no longer handles clears. Remove unused code from it.