### PR TITLE
shader/image: Implement SULD and fix SUATOM

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -544,7 +544,7 @@ enum class VoteOperation : u64 {
     Eq = 2,  // allThreadsEqualNV
 };
 
-enum class ImageAtomicSize : u64 {
+enum class ImageAtomicOperationType : u64 {
     U32 = 0,
     S32 = 1,
     U64 = 2,
@@ -1431,7 +1431,7 @@ union Instruction {
 
     union {
         BitField<28, 1, u64> is_ba;
-        BitField<51, 3, ImageAtomicSize> size;
+        BitField<51, 3, ImageAtomicOperationType> operation_type;
         BitField<33, 3, ImageType> image_type;
         BitField<29, 4, ImageAtomicOperation> operation;
         BitField<49, 2, OutOfBoundsStore> out_of_bounds_store;

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -1427,7 +1427,7 @@ union Instruction {
             ASSERT(mode == SurfaceDataMode::D_BA);
             return store_data_layout;
         }
-    } sust;
+    } suldst;
 
     union {
         BitField<28, 1, u64> is_ba;

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -1590,6 +1590,7 @@ public:
         TMML_B, // Texture Mip Map Level
         TMML,   // Texture Mip Map Level
         SUST,   // Surface Store
+        SULD,   // Surface Load
         SUATOM, // Surface Atomic Operation
         EXIT,
         NOP,
@@ -1875,6 +1876,7 @@ private:
             INST("110111110110----", Id::TMML_B, Type::Texture, "TMML_B"),
             INST("1101111101011---", Id::TMML, Type::Texture, "TMML"),
             INST("11101011001-----", Id::SUST, Type::Image, "SUST"),
+            INST("11101011000-----", Id::SULD, Type::Image, "SULD"),
             INST("1110101000------", Id::SUATOM, Type::Image, "SUATOM_D"),
             INST("0101000010110---", Id::NOP, Type::Trivial, "NOP"),
             INST("11100000--------", Id::IPA, Type::Trivial, "IPA"),

--- a/src/video_core/renderer_opengl/gl_device.h
+++ b/src/video_core/renderer_opengl/gl_device.h
@@ -38,6 +38,10 @@ public:
         return has_vertex_viewport_layer;
     }
 
+    bool HasImageLoadFormatted() const {
+        return has_image_load_formatted;
+    }
+
     bool HasVariableAoffi() const {
         return has_variable_aoffi;
     }
@@ -61,6 +65,7 @@ private:
     u32 max_varyings{};
     bool has_warp_intrinsics{};
     bool has_vertex_viewport_layer{};
+    bool has_image_load_formatted{};
     bool has_variable_aoffi{};
     bool has_component_indexing_bug{};
     bool has_precise_bug{};

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -211,14 +211,14 @@ CachedProgram SpecializeShader(const std::string& code, const GLShader::ShaderEn
     const auto primitive_mode{variant.primitive_mode};
     const auto texture_buffer_usage{variant.texture_buffer_usage};
 
-    std::string source = "#version 430 core\n"
-                         "#extension GL_ARB_separate_shader_objects : enable\n"
-                         "#extension GL_NV_gpu_shader5 : enable\n"
-                         "#extension GL_NV_shader_thread_group : enable\n"
-                         "#extension GL_NV_shader_thread_shuffle : enable\n";
-    if (entries.shader_viewport_layer_array) {
-        source += "#extension GL_ARB_shader_viewport_layer_array : enable\n";
-    }
+    std::string source = R"(#version 430 core
+#extension GL_ARB_separate_shader_objects : enable
+#extension GL_ARB_shader_viewport_layer_array : enable
+#extension GL_EXT_shader_image_load_formatted : enable
+#extension GL_NV_gpu_shader5 : enable
+#extension GL_NV_shader_thread_group : enable
+#extension GL_NV_shader_thread_shuffle : enable
+)";
     if (program_type == ProgramType::Compute) {
         source += "#extension GL_ARB_compute_variable_group_size : require\n";
     }

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.h
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.h
@@ -90,7 +90,6 @@ struct ShaderEntries {
     std::vector<ImageEntry> images;
     std::vector<GlobalMemoryEntry> global_memory_entries;
     std::array<bool, Maxwell::NumClipDistances> clip_distances{};
-    bool shader_viewport_layer_array{};
     std::size_t shader_length{};
 };
 

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -343,20 +343,17 @@ std::optional<ShaderDiskCacheDecompiled> ShaderDiskCacheOpenGL::LoadDecompiledEn
         u8 is_bindless{};
         u8 is_written{};
         u8 is_read{};
-        u8 is_size_known{};
-        u32 size{};
+        u8 is_atomic{};
         if (!LoadObjectFromPrecompiled(offset) || !LoadObjectFromPrecompiled(index) ||
             !LoadObjectFromPrecompiled(type) || !LoadObjectFromPrecompiled(is_bindless) ||
             !LoadObjectFromPrecompiled(is_written) || !LoadObjectFromPrecompiled(is_read) ||
-            !LoadObjectFromPrecompiled(is_size_known) || !LoadObjectFromPrecompiled(size)) {
+            !LoadObjectFromPrecompiled(is_atomic)) {
             return {};
         }
         entry.entries.images.emplace_back(
             static_cast<std::size_t>(offset), static_cast<std::size_t>(index),
             static_cast<Tegra::Shader::ImageType>(type), is_bindless != 0, is_written != 0,
-            is_read != 0,
-            is_size_known ? std::make_optional(static_cast<Tegra::Shader::ImageAtomicSize>(size))
-                          : std::nullopt);
+            is_read != 0, is_atomic != 0);
     }
 
     u32 global_memory_count{};
@@ -429,14 +426,13 @@ bool ShaderDiskCacheOpenGL::SaveDecompiledFile(u64 unique_identifier, const std:
         return false;
     }
     for (const auto& image : entries.images) {
-        const u32 size = image.IsSizeKnown() ? static_cast<u32>(image.GetSize()) : 0U;
         if (!SaveObjectToPrecompiled(static_cast<u64>(image.GetOffset())) ||
             !SaveObjectToPrecompiled(static_cast<u64>(image.GetIndex())) ||
             !SaveObjectToPrecompiled(static_cast<u32>(image.GetType())) ||
             !SaveObjectToPrecompiled(static_cast<u8>(image.IsBindless() ? 1 : 0)) ||
             !SaveObjectToPrecompiled(static_cast<u8>(image.IsWritten() ? 1 : 0)) ||
             !SaveObjectToPrecompiled(static_cast<u8>(image.IsRead() ? 1 : 0)) ||
-            !SaveObjectToPrecompiled(image.IsSizeKnown()) || !SaveObjectToPrecompiled(size)) {
+            !SaveObjectToPrecompiled(static_cast<u8>(image.IsAtomic() ? 1 : 0))) {
             return false;
         }
     }

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -382,12 +382,6 @@ std::optional<ShaderDiskCacheDecompiled> ShaderDiskCacheOpenGL::LoadDecompiledEn
         }
     }
 
-    bool shader_viewport_layer_array{};
-    if (!LoadObjectFromPrecompiled(shader_viewport_layer_array)) {
-        return {};
-    }
-    entry.entries.shader_viewport_layer_array = shader_viewport_layer_array;
-
     u64 shader_length{};
     if (!LoadObjectFromPrecompiled(shader_length)) {
         return {};
@@ -462,10 +456,6 @@ bool ShaderDiskCacheOpenGL::SaveDecompiledFile(u64 unique_identifier, const std:
         if (!SaveObjectToPrecompiled(clip_distance)) {
             return false;
         }
-    }
-
-    if (!SaveObjectToPrecompiled(entries.shader_viewport_layer_array)) {
-        return false;
     }
 
     if (!SaveObjectToPrecompiled(static_cast<u64>(entries.shader_length))) {

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
@@ -955,16 +955,6 @@ private:
         return {};
     }
 
-    Id AtomicImageMin(Operation operation) {
-        UNIMPLEMENTED();
-        return {};
-    }
-
-    Id AtomicImageMax(Operation operation) {
-        UNIMPLEMENTED();
-        return {};
-    }
-
     Id AtomicImageAnd(Operation operation) {
         UNIMPLEMENTED();
         return {};
@@ -1449,8 +1439,6 @@ private:
         &SPIRVDecompiler::ImageLoad,
         &SPIRVDecompiler::ImageStore,
         &SPIRVDecompiler::AtomicImageAdd,
-        &SPIRVDecompiler::AtomicImageMin,
-        &SPIRVDecompiler::AtomicImageMax,
         &SPIRVDecompiler::AtomicImageAnd,
         &SPIRVDecompiler::AtomicImageOr,
         &SPIRVDecompiler::AtomicImageXor,

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
@@ -19,6 +19,7 @@
 #include "video_core/engines/shader_header.h"
 #include "video_core/renderer_vulkan/vk_device.h"
 #include "video_core/renderer_vulkan/vk_shader_decompiler.h"
+#include "video_core/shader/node.h"
 #include "video_core/shader/shader_ir.h"
 
 namespace Vulkan::VKShader {
@@ -939,6 +940,11 @@ private:
         return {};
     }
 
+    Id ImageLoad(Operation operation) {
+        UNIMPLEMENTED();
+        return {};
+    }
+
     Id ImageStore(Operation operation) {
         UNIMPLEMENTED();
         return {};
@@ -1440,6 +1446,7 @@ private:
         &SPIRVDecompiler::TextureQueryLod,
         &SPIRVDecompiler::TexelFetch,
 
+        &SPIRVDecompiler::ImageLoad,
         &SPIRVDecompiler::ImageStore,
         &SPIRVDecompiler::AtomicImageAdd,
         &SPIRVDecompiler::AtomicImageMin,

--- a/src/video_core/shader/node.h
+++ b/src/video_core/shader/node.h
@@ -149,11 +149,10 @@ enum class OperationCode {
     TextureQueryLod,        /// (MetaTexture, float[N] coords) -> float4
     TexelFetch,             /// (MetaTexture, int[N], int) -> float4
 
-    ImageLoad,           /// (MetaImage, int[N] coords) -> void
-    ImageStore,          /// (MetaImage, int[N] coords) -> void
+    ImageLoad,  /// (MetaImage, int[N] coords) -> void
+    ImageStore, /// (MetaImage, int[N] coords) -> void
+
     AtomicImageAdd,      /// (MetaImage, int[N] coords) -> void
-    AtomicImageMin,      /// (MetaImage, int[N] coords) -> void
-    AtomicImageMax,      /// (MetaImage, int[N] coords) -> void
     AtomicImageAnd,      /// (MetaImage, int[N] coords) -> void
     AtomicImageOr,       /// (MetaImage, int[N] coords) -> void
     AtomicImageXor,      /// (MetaImage, int[N] coords) -> void
@@ -295,21 +294,18 @@ private:
 
 class Image final {
 public:
-    constexpr explicit Image(std::size_t offset, std::size_t index, Tegra::Shader::ImageType type,
-                             std::optional<Tegra::Shader::ImageAtomicSize> size)
-        : offset{offset}, index{index}, type{type}, is_bindless{false}, size{size} {}
+    constexpr explicit Image(std::size_t offset, std::size_t index, Tegra::Shader::ImageType type)
+        : offset{offset}, index{index}, type{type}, is_bindless{false} {}
 
     constexpr explicit Image(u32 cbuf_index, u32 cbuf_offset, std::size_t index,
-                             Tegra::Shader::ImageType type,
-                             std::optional<Tegra::Shader::ImageAtomicSize> size)
+                             Tegra::Shader::ImageType type)
         : offset{(static_cast<u64>(cbuf_index) << 32) | cbuf_offset}, index{index}, type{type},
-          is_bindless{true}, size{size} {}
+          is_bindless{true} {}
 
     constexpr explicit Image(std::size_t offset, std::size_t index, Tegra::Shader::ImageType type,
-                             bool is_bindless, bool is_written, bool is_read,
-                             std::optional<Tegra::Shader::ImageAtomicSize> size)
+                             bool is_bindless, bool is_written, bool is_read, bool is_atomic)
         : offset{offset}, index{index}, type{type}, is_bindless{is_bindless},
-          is_written{is_written}, is_read{is_read}, size{size} {}
+          is_written{is_written}, is_read{is_read}, is_atomic{is_atomic} {}
 
     void MarkWrite() {
         is_written = true;
@@ -319,8 +315,10 @@ public:
         is_read = true;
     }
 
-    void SetSize(Tegra::Shader::ImageAtomicSize size_) {
-        size = size_;
+    void MarkAtomic() {
+        MarkWrite();
+        MarkRead();
+        is_atomic = true;
     }
 
     constexpr std::size_t GetOffset() const {
@@ -347,21 +345,17 @@ public:
         return is_read;
     }
 
+    constexpr bool IsAtomic() const {
+        return is_atomic;
+    }
+
     constexpr std::pair<u32, u32> GetBindlessCBuf() const {
         return {static_cast<u32>(offset >> 32), static_cast<u32>(offset)};
     }
 
-    constexpr bool IsSizeKnown() const {
-        return size.has_value();
-    }
-
-    constexpr Tegra::Shader::ImageAtomicSize GetSize() const {
-        return size.value();
-    }
-
     constexpr bool operator<(const Image& rhs) const {
-        return std::tie(offset, index, type, size, is_bindless) <
-               std::tie(rhs.offset, rhs.index, rhs.type, rhs.size, rhs.is_bindless);
+        return std::tie(offset, index, type, is_bindless) <
+               std::tie(rhs.offset, rhs.index, rhs.type, rhs.is_bindless);
     }
 
 private:
@@ -371,7 +365,7 @@ private:
     bool is_bindless{};
     bool is_written{};
     bool is_read{};
-    std::optional<Tegra::Shader::ImageAtomicSize> size{};
+    bool is_atomic{};
 };
 
 struct GlobalMemoryBase {

--- a/src/video_core/shader/node.h
+++ b/src/video_core/shader/node.h
@@ -149,7 +149,8 @@ enum class OperationCode {
     TextureQueryLod,        /// (MetaTexture, float[N] coords) -> float4
     TexelFetch,             /// (MetaTexture, int[N], int) -> float4
 
-    ImageStore,          /// (MetaImage, int[N] values) -> void
+    ImageLoad,           /// (MetaImage, int[N] coords) -> void
+    ImageStore,          /// (MetaImage, int[N] coords) -> void
     AtomicImageAdd,      /// (MetaImage, int[N] coords) -> void
     AtomicImageMin,      /// (MetaImage, int[N] coords) -> void
     AtomicImageMax,      /// (MetaImage, int[N] coords) -> void
@@ -402,6 +403,7 @@ struct MetaTexture {
 struct MetaImage {
     const Image& image;
     std::vector<Node> values;
+    u32 element{};
 };
 
 /// Parameters that modify an operation but are not part of any particular operand

--- a/src/video_core/shader/shader_ir.h
+++ b/src/video_core/shader/shader_ir.h
@@ -276,16 +276,13 @@ private:
                                       bool is_shadow);
 
     /// Accesses an image.
-    Image& GetImage(Tegra::Shader::Image image, Tegra::Shader::ImageType type,
-                    std::optional<Tegra::Shader::ImageAtomicSize> size = {});
+    Image& GetImage(Tegra::Shader::Image image, Tegra::Shader::ImageType type);
 
     /// Access a bindless image sampler.
-    Image& GetBindlessImage(Tegra::Shader::Register reg, Tegra::Shader::ImageType type,
-                            std::optional<Tegra::Shader::ImageAtomicSize> size = {});
+    Image& GetBindlessImage(Tegra::Shader::Register reg, Tegra::Shader::ImageType type);
 
     /// Tries to access an existing image, updating it's state as needed
-    Image* TryUseExistingImage(u64 offset, Tegra::Shader::ImageType type,
-                               std::optional<Tegra::Shader::ImageAtomicSize> size);
+    Image* TryUseExistingImage(u64 offset, Tegra::Shader::ImageType type);
 
     /// Extracts a sequence of bits from a node
     Node BitfieldExtract(Node value, u32 offset, u32 bits);


### PR DESCRIPTION
Implements SULD (`imageLoad`) using `GL_EXT_shader_image_load_formatted` when available. While we are at it, fix SUATOM related GLSL build issues.

This removes the image format guessing and always uses `r32ui` when atomic operations are present. Operations that will require signed/unsigned distinction (e.g. `MIN`) will have to use a compare-and-swap loop. The implementation for these has been removed until we find a game using it.