### PR TITLE
Implement a MME Draw commands Inliner and correct host instance drawing

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -486,7 +486,7 @@ void Maxwell3D::FlushMMEInlineDraw() {
                "Illegal combination of instancing parameters");
 
     const bool is_indexed = mme_draw.current_mode == MMMEDrawMode::Indexed;
-    rasterizer.AccelerateDrawMultiBatch(is_indexed);
+    rasterizer.DrawMultiBatch(is_indexed);
 
     if (debug_context) {
         debug_context->OnEvent(Tegra::DebugContext::Event::FinishedPrimitiveBatch, nullptr);
@@ -657,7 +657,7 @@ void Maxwell3D::DrawArrays() {
     }
 
     const bool is_indexed{regs.index_array.count && !regs.vertex_buffer.count};
-    rasterizer.AccelerateDrawBatch(is_indexed);
+    rasterizer.DrawBatch(is_indexed);
 
     if (debug_context) {
         debug_context->OnEvent(Tegra::DebugContext::Event::FinishedPrimitiveBatch, nullptr);

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1269,14 +1269,14 @@ public:
         return execute_on;
     }
 
-    enum class MMMEDrawMode : u32 {
+    enum class MMEDrawMode : u32 {
         Undefined,
         Array,
         Indexed,
     };
 
     struct MMEDrawState {
-        MMMEDrawMode current_mode{MMMEDrawMode::Undefined};
+        MMEDrawMode current_mode{MMEDrawMode::Undefined};
         u32 current_count{};
         u32 instance_count{};
         bool instance_mode{};
@@ -1369,6 +1369,9 @@ private:
 
     /// Handles a write to the VERTEX_END_GL register, triggering a draw.
     void DrawArrays();
+
+    // Handles a instance drawcall from MME
+    void StepInstance(MMEDrawMode expected_mode, u32 count);
 };
 
 #define ASSERT_REG_POSITION(field_name, position)                                                  \

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1277,8 +1277,11 @@ public:
 
     struct MMEDrawState {
         MMMEDrawMode current_mode{MMMEDrawMode::Undefined};
-        u32 current_count;
-        u32 instance_count;
+        u32 current_count{};
+        u32 instance_count{};
+        bool instance_mode{};
+        bool gl_begin_consume{};
+        u32 gl_end_count{};
     } mme_draw;
 
 private:

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -811,8 +811,9 @@ public:
                 INSERT_PADDING_WORDS(0x21);
 
                 u32 vb_element_base;
+                u32 vb_base_instance;
 
-                INSERT_PADDING_WORDS(0x36);
+                INSERT_PADDING_WORDS(0x35);
 
                 union {
                     BitField<0, 1, u32> c0;
@@ -1238,6 +1239,11 @@ public:
     /// Write the value to the register identified by method.
     void CallMethod(const GPU::MethodCall& method_call);
 
+    /// Write the value to the register identified by method.
+    void CallMethodFromMME(const GPU::MethodCall& method_call);
+
+    void FlushMMEInlineDraw();
+
     /// Given a Texture Handle, returns the TSC and TIC entries.
     Texture::FullTextureInfo GetTextureInfo(const Texture::TextureHandle tex_handle,
                                             std::size_t offset) const;
@@ -1263,6 +1269,18 @@ public:
         return execute_on;
     }
 
+    enum class MMMEDrawMode : u32 {
+        Undefined,
+        Array,
+        Indexed,
+    };
+
+    struct MMEDrawState {
+        MMMEDrawMode current_mode{MMMEDrawMode::Undefined};
+        u32 current_count;
+        u32 instance_count;
+    } mme_draw;
+
 private:
     void InitializeRegisterDefaults();
 
@@ -1274,6 +1292,8 @@ private:
 
     /// Start offsets of each macro in macro_memory
     std::array<u32, 0x80> macro_positions = {};
+
+    std::array<bool, Regs::NUM_REGS> mme_inline{};
 
     /// Memory for macro code
     MacroMemory macro_memory;
@@ -1402,6 +1422,7 @@ ASSERT_REG_POSITION(stencil_front_mask, 0x4E7);
 ASSERT_REG_POSITION(frag_color_clamp, 0x4EA);
 ASSERT_REG_POSITION(screen_y_control, 0x4EB);
 ASSERT_REG_POSITION(vb_element_base, 0x50D);
+ASSERT_REG_POSITION(vb_base_instance, 0x50E);
 ASSERT_REG_POSITION(clip_distance_enabled, 0x544);
 ASSERT_REG_POSITION(point_size, 0x546);
 ASSERT_REG_POSITION(zeta_enable, 0x54E);

--- a/src/video_core/macro_interpreter.cpp
+++ b/src/video_core/macro_interpreter.cpp
@@ -257,7 +257,7 @@ void MacroInterpreter::SetMethodAddress(u32 address) {
 }
 
 void MacroInterpreter::Send(u32 value) {
-    maxwell3d.CallMethod({method_address.address, value});
+    maxwell3d.CallMethodFromMME({method_address.address, value});
     // Increment the method address by the method increment.
     method_address.address.Assign(method_address.address.Value() +
                                   method_address.increment.Value());

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -31,7 +31,7 @@ public:
     /// Draw the current batch of vertex arrays
     virtual bool DrawBatch(bool is_indexed) = 0;
 
-    /// Draw the current batch of multiple instasnces of vertex arrays
+    /// Draw the current batch of multiple instances of vertex arrays
     virtual bool DrawMultiBatch(bool is_indexed) = 0;
 
     /// Clear the current framebuffer

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -31,6 +31,9 @@ public:
     /// Draw the current batch of vertex arrays
     virtual void DrawArrays() = 0;
 
+    /// Draw the current batch of vertex arrays
+    virtual void DrawMultiArrays() = 0;
+
     /// Clear the current framebuffer
     virtual void Clear() = 0;
 
@@ -70,6 +73,10 @@ public:
     }
 
     virtual bool AccelerateDrawBatch(bool is_indexed) {
+        return false;
+    }
+
+    virtual bool AccelerateDrawMultiBatch(bool is_indexed) {
         return false;
     }
 

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -29,10 +29,10 @@ public:
     virtual ~RasterizerInterface() {}
 
     /// Draw the current batch of vertex arrays
-    virtual void DrawArrays() = 0;
+    virtual bool DrawBatch(bool is_indexed) = 0;
 
     /// Draw the current batch of multiple instasnces of vertex arrays
-    virtual void DrawMultiArrays() = 0;
+    virtual bool DrawMultiBatch(bool is_indexed) = 0;
 
     /// Clear the current framebuffer
     virtual void Clear() = 0;
@@ -69,14 +69,6 @@ public:
     /// Attempt to use a faster method to display the framebuffer to screen
     virtual bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
                                    u32 pixel_stride) {
-        return false;
-    }
-
-    virtual bool AccelerateDrawBatch(bool is_indexed) {
-        return false;
-    }
-
-    virtual bool AccelerateDrawMultiBatch(bool is_indexed) {
         return false;
     }
 

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -31,7 +31,7 @@ public:
     /// Draw the current batch of vertex arrays
     virtual void DrawArrays() = 0;
 
-    /// Draw the current batch of vertex arrays
+    /// Draw the current batch of multiple instasnces of vertex arrays
     virtual void DrawMultiArrays() = 0;
 
     /// Clear the current framebuffer

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -788,13 +788,13 @@ void RasterizerOpenGL::DrawArrays() {
     DrawPrelude();
 
     auto& maxwell3d = system.GPU().Maxwell3D();
-    auto& regs = maxwell3d.regs;
-    auto current_instance = maxwell3d.state.current_instance;
-    auto primitive_mode = MaxwellToGL::PrimitiveTopology(regs.draw.topology);
+    const auto& regs = maxwell3d.regs;
+    const auto current_instance = maxwell3d.state.current_instance;
+    const auto primitive_mode = MaxwellToGL::PrimitiveTopology(regs.draw.topology);
     if (accelerate_draw == AccelDraw::Indexed) {
-        auto index_format = MaxwellToGL::IndexFormat(regs.index_array.format);
-        auto count = regs.index_array.count;
-        auto base_vertex = static_cast<GLint>(regs.vb_element_base);
+        const auto index_format = MaxwellToGL::IndexFormat(regs.index_array.format);
+        const auto count = regs.index_array.count;
+        const auto base_vertex = static_cast<GLint>(regs.vb_element_base);
         const auto index_buffer_ptr = reinterpret_cast<const void*>(index_buffer_offset);
         if (current_instance > 0) {
             glDrawElementsInstancedBaseVertexBaseInstance(primitive_mode, count, index_format,
@@ -805,8 +805,8 @@ void RasterizerOpenGL::DrawArrays() {
                                      base_vertex);
         }
     } else {
-        auto count = regs.vertex_buffer.count;
-        auto vertex_first = regs.vertex_buffer.first;
+        const auto count = regs.vertex_buffer.count;
+        const auto vertex_first = regs.vertex_buffer.first;
         if (current_instance > 0) {
             glDrawArraysInstancedBaseInstance(primitive_mode, vertex_first, count, 1,
                                               current_instance);
@@ -819,21 +819,19 @@ void RasterizerOpenGL::DrawArrays() {
     maxwell3d.dirty.memory_general = false;
 }
 
-#pragma optimize("", off)
-
 void RasterizerOpenGL::DrawMultiArrays() {
     DrawPrelude();
 
     auto& maxwell3d = system.GPU().Maxwell3D();
-    auto& regs = maxwell3d.regs;
-    auto& draw_setup = maxwell3d.mme_draw;
-    auto num_instances = draw_setup.instance_count;
-    auto base_instance = static_cast<GLint>(regs.vb_base_instance);
-    auto primitive_mode = MaxwellToGL::PrimitiveTopology(regs.draw.topology);
+    const auto& regs = maxwell3d.regs;
+    const auto& draw_setup = maxwell3d.mme_draw;
+    const auto num_instances = draw_setup.instance_count;
+    const auto base_instance = static_cast<GLint>(regs.vb_base_instance);
+    const auto primitive_mode = MaxwellToGL::PrimitiveTopology(regs.draw.topology);
     if (draw_setup.current_mode == Tegra::Engines::Maxwell3D::MMMEDrawMode::Indexed) {
-        auto index_format = MaxwellToGL::IndexFormat(regs.index_array.format);
-        auto count = regs.index_array.count;
-        auto base_vertex = static_cast<GLint>(regs.vb_element_base);
+        const auto index_format = MaxwellToGL::IndexFormat(regs.index_array.format);
+        const auto count = regs.index_array.count;
+        const auto base_vertex = static_cast<GLint>(regs.vb_element_base);
         const auto index_buffer_ptr = reinterpret_cast<const void*>(index_buffer_offset);
         if (num_instances > 1) {
             glDrawElementsInstancedBaseVertexBaseInstance(primitive_mode, count, index_format,
@@ -844,8 +842,8 @@ void RasterizerOpenGL::DrawMultiArrays() {
                                      base_vertex);
         }
     } else {
-        auto count = regs.vertex_buffer.count;
-        auto vertex_first = regs.vertex_buffer.first;
+        const auto count = regs.vertex_buffer.count;
+        const auto vertex_first = regs.vertex_buffer.first;
         if (num_instances > 1) {
             glDrawArraysInstancedBaseInstance(primitive_mode, vertex_first, count, num_instances,
                                               base_instance);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -728,19 +728,19 @@ void RasterizerOpenGL::DrawPrelude() {
 }
 
 struct DrawParams {
-    bool is_indexed;
-    bool is_instanced;
-    GLenum primitive_mode;
-    GLint count;
-    GLint base_vertex;
+    bool is_indexed{};
+    bool is_instanced{};
+    GLenum primitive_mode{};
+    GLint count{};
+    GLint base_vertex{};
 
     // Indexed settings
-    GLenum index_format;
-    GLintptr index_buffer_offset;
+    GLenum index_format{};
+    GLintptr index_buffer_offset{};
 
     // Instanced setting
-    GLint num_instances;
-    GLint base_instance;
+    GLint num_instances{};
+    GLint base_instance{};
 
     void DispatchDraw() {
         if (is_indexed) {
@@ -770,7 +770,7 @@ void RasterizerOpenGL::DrawArrays() {
     auto& maxwell3d = system.GPU().Maxwell3D();
     const auto& regs = maxwell3d.regs;
     const auto current_instance = maxwell3d.state.current_instance;
-    DrawParams draw_call;
+    DrawParams draw_call{};
     draw_call.is_indexed = accelerate_draw == AccelDraw::Indexed;
     draw_call.num_instances = static_cast<GLint>(1);
     draw_call.base_instance = static_cast<GLint>(current_instance);
@@ -797,7 +797,7 @@ void RasterizerOpenGL::DrawMultiArrays() {
     auto& maxwell3d = system.GPU().Maxwell3D();
     const auto& regs = maxwell3d.regs;
     const auto& draw_setup = maxwell3d.mme_draw;
-    DrawParams draw_call;
+    DrawParams draw_call{};
     draw_call.is_indexed =
         draw_setup.current_mode == Tegra::Engines::Maxwell3D::MMMEDrawMode::Indexed;
     draw_call.num_instances = static_cast<GLint>(draw_setup.instance_count);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -749,13 +749,9 @@ bool RasterizerOpenGL::DrawBatch(bool is_indexed) {
 
     MICROPROFILE_SCOPE(OpenGL_Drawing);
 
-    auto& maxwell3d = system.GPU().Maxwell3D();
-    if (!maxwell3d.ShouldExecute()) {
-        return false;
-    }
-
     DrawPrelude();
 
+    auto& maxwell3d = system.GPU().Maxwell3D();
     const auto& regs = maxwell3d.regs;
     const auto current_instance = maxwell3d.state.current_instance;
     DrawParams draw_call{};
@@ -785,13 +781,9 @@ bool RasterizerOpenGL::DrawMultiBatch(bool is_indexed) {
 
     MICROPROFILE_SCOPE(OpenGL_Drawing);
 
-    auto& maxwell3d = system.GPU().Maxwell3D();
-    if (!maxwell3d.ShouldExecute()) {
-        return false;
-    }
-
     DrawPrelude();
 
+    auto& maxwell3d = system.GPU().Maxwell3D();
     const auto& regs = maxwell3d.regs;
     const auto& draw_setup = maxwell3d.mme_draw;
     DrawParams draw_call{};

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -626,15 +626,7 @@ void RasterizerOpenGL::Clear() {
 }
 
 void RasterizerOpenGL::DrawPrelude() {
-    if (accelerate_draw == AccelDraw::Disabled)
-        return;
-
-    MICROPROFILE_SCOPE(OpenGL_Drawing);
     auto& gpu = system.GPU().Maxwell3D();
-
-    if (!gpu.ShouldExecute()) {
-        return;
-    }
 
     SyncColorMask();
     SyncFragmentColorClampState();
@@ -754,9 +746,16 @@ struct DrawParams {
 
 bool RasterizerOpenGL::DrawBatch(bool is_indexed) {
     accelerate_draw = is_indexed ? AccelDraw::Indexed : AccelDraw::Arrays;
-    DrawPrelude();
+
+    MICROPROFILE_SCOPE(OpenGL_Drawing);
 
     auto& maxwell3d = system.GPU().Maxwell3D();
+    if (!maxwell3d.ShouldExecute()) {
+        return false;
+    }
+
+    DrawPrelude();
+
     const auto& regs = maxwell3d.regs;
     const auto current_instance = maxwell3d.state.current_instance;
     DrawParams draw_call{};
@@ -783,9 +782,16 @@ bool RasterizerOpenGL::DrawBatch(bool is_indexed) {
 
 bool RasterizerOpenGL::DrawMultiBatch(bool is_indexed) {
     accelerate_draw = is_indexed ? AccelDraw::Indexed : AccelDraw::Arrays;
-    DrawPrelude();
+
+    MICROPROFILE_SCOPE(OpenGL_Drawing);
 
     auto& maxwell3d = system.GPU().Maxwell3D();
+    if (!maxwell3d.ShouldExecute()) {
+        return false;
+    }
+
+    DrawPrelude();
+
     const auto& regs = maxwell3d.regs;
     const auto& draw_setup = maxwell3d.mme_draw;
     DrawParams draw_call{};

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -58,6 +58,7 @@ public:
     ~RasterizerOpenGL() override;
 
     void DrawArrays() override;
+    void DrawMultiArrays() override;
     void Clear() override;
     void DispatchCompute(GPUVAddr code_addr) override;
     void FlushAll() override;
@@ -72,6 +73,7 @@ public:
     bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
                            u32 pixel_stride) override;
     bool AccelerateDrawBatch(bool is_indexed) override;
+    bool AccelerateDrawMultiBatch(bool is_indexed) override;
     void UpdatePagesCachedCount(VAddr addr, u64 size, int delta) override;
     void LoadDiskResources(const std::atomic_bool& stop_loading,
                            const VideoCore::DiskResourceLoadCallback& callback) override;
@@ -135,6 +137,8 @@ private:
     /// Configures a constant buffer.
     void SetupGlobalMemory(const GLShader::GlobalMemoryEntry& entry, GPUVAddr gpu_addr,
                            std::size_t size);
+
+    void DrawPrelude();
 
     /// Configures the current textures to use for the draw command. Returns shaders texture buffer
     /// usage.
@@ -251,6 +255,8 @@ private:
     GLintptr SetupIndexBuffer();
 
     DrawParameters SetupDraw(GLintptr index_buffer_offset);
+
+    GLintptr index_buffer_offset;
 
     void SetupShaders(GLenum primitive_mode);
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -138,6 +138,7 @@ private:
     void SetupGlobalMemory(const GLShader::GlobalMemoryEntry& entry, GPUVAddr gpu_addr,
                            std::size_t size);
 
+    /// Syncs all the state, shaders, render targets and textures setting before a draw call.
     void DrawPrelude();
 
     /// Configures the current textures to use for the draw command. Returns shaders texture buffer
@@ -253,8 +254,6 @@ private:
     void SetupVertexInstances(GLuint vao);
 
     GLintptr SetupIndexBuffer();
-
-    DrawParameters SetupDraw(GLintptr index_buffer_offset);
 
     GLintptr index_buffer_offset;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -57,8 +57,8 @@ public:
                               ScreenInfo& info);
     ~RasterizerOpenGL() override;
 
-    void DrawArrays() override;
-    void DrawMultiArrays() override;
+    bool DrawBatch(bool is_indexed) override;
+    bool DrawMultiBatch(bool is_indexed) override;
     void Clear() override;
     void DispatchCompute(GPUVAddr code_addr) override;
     void FlushAll() override;
@@ -72,8 +72,6 @@ public:
                                const Tegra::Engines::Fermi2D::Config& copy_config) override;
     bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
                            u32 pixel_stride) override;
-    bool AccelerateDrawBatch(bool is_indexed) override;
-    bool AccelerateDrawMultiBatch(bool is_indexed) override;
     void UpdatePagesCachedCount(VAddr addr, u64 size, int delta) override;
     void LoadDiskResources(const std::atomic_bool& stop_loading,
                            const VideoCore::DiskResourceLoadCallback& callback) override;

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -964,7 +964,7 @@ private:
             switch (element) {
             case 2:
                 // Config pack's first value is instance_id.
-                return {"config_pack[0]", Type::Uint};
+                return {"gl_InstanceID", Type::Uint};
             case 3:
                 return {"gl_VertexID", Type::Int};
             }

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -462,6 +462,14 @@ private:
             code.AddLine("float gl_PointSize;");
         }
 
+        if (ir.UsesInstanceId()) {
+            code.AddLine("int gl_InstanceID;");
+        }
+
+        if (ir.UsesVertexId()) {
+            code.AddLine("int gl_VertexID;");
+        }
+
         --code.scope;
         code.AddLine("}};");
         code.AddNewLine();
@@ -964,7 +972,7 @@ private:
             switch (element) {
             case 2:
                 // Config pack's first value is instance_id.
-                return {"gl_InstanceID", Type::Uint};
+                return {"gl_InstanceID", Type::Int};
             case 3:
                 return {"gl_VertexID", Type::Int};
             }

--- a/src/video_core/shader/shader_ir.cpp
+++ b/src/video_core/shader/shader_ir.cpp
@@ -114,6 +114,18 @@ Node ShaderIR::GetOutputAttribute(Attribute::Index index, u64 element, Node buff
             break;
         }
     }
+    if (index == Attribute::Index::TessCoordInstanceIDVertexID) {
+        switch (element) {
+        case 2:
+            uses_instance_id = true;
+            break;
+        case 3:
+            uses_vertex_id = true;
+            break;
+        default:
+            break;
+        }
+    }
     if (index == Attribute::Index::ClipDistances0123 ||
         index == Attribute::Index::ClipDistances4567) {
         const auto clip_index =

--- a/src/video_core/shader/shader_ir.h
+++ b/src/video_core/shader/shader_ir.h
@@ -124,6 +124,14 @@ public:
         return uses_point_size;
     }
 
+    bool UsesInstanceId() const {
+        return uses_instance_id;
+    }
+
+    bool UsesVertexId() const {
+        return uses_vertex_id;
+    }
+
     bool HasPhysicalAttributes() const {
         return uses_physical_attributes;
     }
@@ -373,6 +381,8 @@ private:
     bool uses_viewport_index{};
     bool uses_point_size{};
     bool uses_physical_attributes{}; // Shader uses AL2P or physical attribute read/writes
+    bool uses_instance_id{};
+    bool uses_vertex_id{};
 
     Tegra::Shader::Header header;
 };


### PR DESCRIPTION
This PR aims to accumulate draw calls sent through MME(Macro Interpreter) and flush then once either a sync is required or the program has ended. This heavily increases performance in certain games like SMO, PLGE which use instance drawing heavily. In the pokemon mansion in PLGE performance went from 12fps all the way to 50fps. Some kingdoms in SMO got a significant 5fps boost(changes depending on your computer).

Special thanks to fincs, since he discovered how MME's worked to do instance drawing and suggested this method.