### PR TITLE
Log the current title id and game name which is booting

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -964,11 +964,11 @@ void GMainWindow::BootGame(const QString& filename) {
     }
     status_bar_update_timer.start(2000);
 
+    const u64 title_id = Core::System::GetInstance().CurrentProcess()->GetTitleID();
+
     std::string title_name;
     const auto res = Core::System::GetInstance().GetGameName(title_name);
     if (res != Loader::ResultStatus::Success) {
-        const u64 title_id = Core::System::GetInstance().CurrentProcess()->GetTitleID();
-
         const auto [nacp, icon_file] = FileSys::PatchManager(title_id).GetControlMetadata();
         if (nacp != nullptr)
             title_name = nacp->GetApplicationName();
@@ -976,7 +976,7 @@ void GMainWindow::BootGame(const QString& filename) {
         if (title_name.empty())
             title_name = FileUtil::GetFilename(filename.toStdString());
     }
-
+    LOG_INFO(Frontend, "Booting game: \"{}\" | {:016X}", title_name, title_id);
     UpdateWindowTitle(QString::fromStdString(title_name));
 
     loading_screen->Prepare(Core::System::GetInstance().GetAppLoader());

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -976,7 +976,7 @@ void GMainWindow::BootGame(const QString& filename) {
         if (title_name.empty())
             title_name = FileUtil::GetFilename(filename.toStdString());
     }
-    LOG_INFO(Frontend, "Booting game: \"{}\" | {:016X}", title_name, title_id);
+    LOG_INFO(Frontend, "Booting game: {:016X} | {}", title_id, title_name);
     UpdateWindowTitle(QString::fromStdString(title_name));
 
     loading_screen->Prepare(Core::System::GetInstance().GetAppLoader());


### PR DESCRIPTION
Spit out a LOG_INFO of the current game name and it's title id in the log. This helps to read log files and figure out which games have which issues.

Log is as follows
`Frontend <Info> yuzu\main.cpp:BootGame:979: Booting game: 010003F003A34000 | Pokémon: Let's Go, Pikachu!`

The only other way we can get a TID in the current log is through the exefs patch notification or if the user is running debug logs, then the program metadata. By marking it as LOG_INFO, we should get this crucial info in all logs