### PR TITLE
Remove usage of System::CurrentInterface() from most services

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -1066,7 +1066,7 @@ IApplicationFunctions::IApplicationFunctions(Core::System& system_)
 
     RegisterHandlers(functions);
 
-    auto& kernel = Core::System::GetInstance().Kernel();
+    auto& kernel = system.Kernel();
     gpu_error_detected_event = Kernel::WritableEvent::CreateEventPair(
         kernel, Kernel::ResetType::Manual, "IApplicationFunctions:GpuErrorDetectedSystemEvent");
 }

--- a/src/core/hle/service/aoc/aoc_u.h
+++ b/src/core/hle/service/aoc/aoc_u.h
@@ -14,7 +14,7 @@ namespace Service::AOC {
 
 class AOC_U final : public ServiceFramework<AOC_U> {
 public:
-    AOC_U();
+    AOC_U(Core::System& system);
     ~AOC_U() override;
 
 private:
@@ -26,9 +26,10 @@ private:
 
     std::vector<u64> add_on_content;
     Kernel::EventPair aoc_change_event;
+    Core::System& system;
 };
 
 /// Registers all AOC services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace Service::AOC

--- a/src/core/hle/service/aoc/aoc_u.h
+++ b/src/core/hle/service/aoc/aoc_u.h
@@ -14,7 +14,7 @@ namespace Service::AOC {
 
 class AOC_U final : public ServiceFramework<AOC_U> {
 public:
-    AOC_U(Core::System& system);
+    explicit AOC_U(Core::System& system);
     ~AOC_U() override;
 
 private:

--- a/src/core/hle/service/btdrv/btdrv.cpp
+++ b/src/core/hle/service/btdrv/btdrv.cpp
@@ -16,7 +16,7 @@ namespace Service::BtDrv {
 
 class Bt final : public ServiceFramework<Bt> {
 public:
-    explicit Bt() : ServiceFramework{"bt"} {
+    explicit Bt(Core::System& system) : ServiceFramework{"bt"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "LeClientReadCharacteristic"},
@@ -33,7 +33,7 @@ public:
         // clang-format on
         RegisterHandlers(functions);
 
-        auto& kernel = Core::System::GetInstance().Kernel();
+        auto& kernel = system.Kernel();
         register_event = Kernel::WritableEvent::CreateEventPair(
             kernel, Kernel::ResetType::Automatic, "BT:RegisterEvent");
     }
@@ -163,9 +163,9 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
     std::make_shared<BtDrv>()->InstallAsService(sm);
-    std::make_shared<Bt>()->InstallAsService(sm);
+    std::make_shared<Bt>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::BtDrv

--- a/src/core/hle/service/btdrv/btdrv.h
+++ b/src/core/hle/service/btdrv/btdrv.h
@@ -8,9 +8,13 @@ namespace Service::SM {
 class ServiceManager;
 }
 
+namespace Core {
+class System;
+}
+
 namespace Service::BtDrv {
 
 /// Registers all BtDrv services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::BtDrv

--- a/src/core/hle/service/btm/btm.h
+++ b/src/core/hle/service/btm/btm.h
@@ -8,8 +8,12 @@ namespace Service::SM {
 class ServiceManager;
 }
 
+namespace Core {
+class System;
+};
+
 namespace Service::BTM {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::BTM

--- a/src/core/hle/service/fatal/fatal.h
+++ b/src/core/hle/service/fatal/fatal.h
@@ -6,13 +6,17 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Fatal {
 
 class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        explicit Interface(std::shared_ptr<Module> module, const char* name);
+        explicit Interface(std::shared_ptr<Module> module, Core::System& system, const char* name);
         ~Interface() override;
 
         void ThrowFatal(Kernel::HLERequestContext& ctx);
@@ -21,9 +25,10 @@ public:
 
     protected:
         std::shared_ptr<Module> module;
+        Core::System& system;
     };
 };
 
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace Service::Fatal

--- a/src/core/hle/service/fatal/fatal_p.cpp
+++ b/src/core/hle/service/fatal/fatal_p.cpp
@@ -6,8 +6,8 @@
 
 namespace Service::Fatal {
 
-Fatal_P::Fatal_P(std::shared_ptr<Module> module)
-    : Module::Interface(std::move(module), "fatal:p") {}
+Fatal_P::Fatal_P(std::shared_ptr<Module> module, Core::System& system)
+    : Module::Interface(std::move(module), system, "fatal:p") {}
 
 Fatal_P::~Fatal_P() = default;
 

--- a/src/core/hle/service/fatal/fatal_p.h
+++ b/src/core/hle/service/fatal/fatal_p.h
@@ -10,7 +10,7 @@ namespace Service::Fatal {
 
 class Fatal_P final : public Module::Interface {
 public:
-    explicit Fatal_P(std::shared_ptr<Module> module);
+    explicit Fatal_P(std::shared_ptr<Module> module, Core::System& system);
     ~Fatal_P() override;
 };
 

--- a/src/core/hle/service/fatal/fatal_u.cpp
+++ b/src/core/hle/service/fatal/fatal_u.cpp
@@ -6,7 +6,8 @@
 
 namespace Service::Fatal {
 
-Fatal_U::Fatal_U(std::shared_ptr<Module> module) : Module::Interface(std::move(module), "fatal:u") {
+Fatal_U::Fatal_U(std::shared_ptr<Module> module, Core::System& system)
+    : Module::Interface(std::move(module), system, "fatal:u") {
     static const FunctionInfo functions[] = {
         {0, &Fatal_U::ThrowFatal, "ThrowFatal"},
         {1, &Fatal_U::ThrowFatalWithPolicy, "ThrowFatalWithPolicy"},

--- a/src/core/hle/service/fatal/fatal_u.h
+++ b/src/core/hle/service/fatal/fatal_u.h
@@ -10,7 +10,7 @@ namespace Service::Fatal {
 
 class Fatal_U final : public Module::Interface {
 public:
-    explicit Fatal_U(std::shared_ptr<Module> module);
+    explicit Fatal_U(std::shared_ptr<Module> module, Core::System& system);
     ~Fatal_U() override;
 };
 

--- a/src/core/hle/service/friend/friend.h
+++ b/src/core/hle/service/friend/friend.h
@@ -6,13 +6,17 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Friend {
 
 class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        explicit Interface(std::shared_ptr<Module> module, const char* name);
+        explicit Interface(std::shared_ptr<Module> module, Core::System& system, const char* name);
         ~Interface() override;
 
         void CreateFriendService(Kernel::HLERequestContext& ctx);
@@ -20,10 +24,11 @@ public:
 
     protected:
         std::shared_ptr<Module> module;
+        Core::System& system;
     };
 };
 
 /// Registers all Friend services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace Service::Friend

--- a/src/core/hle/service/friend/interface.cpp
+++ b/src/core/hle/service/friend/interface.cpp
@@ -6,8 +6,8 @@
 
 namespace Service::Friend {
 
-Friend::Friend(std::shared_ptr<Module> module, const char* name)
-    : Interface(std::move(module), name) {
+Friend::Friend(std::shared_ptr<Module> module, Core::System& system, const char* name)
+    : Interface(std::move(module), system, name) {
     static const FunctionInfo functions[] = {
         {0, &Friend::CreateFriendService, "CreateFriendService"},
         {1, &Friend::CreateNotificationService, "CreateNotificationService"},

--- a/src/core/hle/service/friend/interface.h
+++ b/src/core/hle/service/friend/interface.h
@@ -10,7 +10,7 @@ namespace Service::Friend {
 
 class Friend final : public Module::Interface {
 public:
-    explicit Friend(std::shared_ptr<Module> module, const char* name);
+    explicit Friend(std::shared_ptr<Module> module, Core::System& system, const char* name);
     ~Friend() override;
 };
 

--- a/src/core/hle/service/hid/controllers/controller_base.cpp
+++ b/src/core/hle/service/hid/controllers/controller_base.cpp
@@ -9,12 +9,12 @@ namespace Service::HID {
 ControllerBase::ControllerBase() = default;
 ControllerBase::~ControllerBase() = default;
 
-void ControllerBase::ActivateController() {
+void ControllerBase::ActivateController(Core::System& system) {
     if (is_activated) {
         OnRelease();
     }
     is_activated = true;
-    OnInit();
+    OnInit(system);
 }
 
 void ControllerBase::DeactivateController() {

--- a/src/core/hle/service/hid/controllers/controller_base.cpp
+++ b/src/core/hle/service/hid/controllers/controller_base.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::HID {
 
-ControllerBase::ControllerBase(Core::System& system) : system(system){};
+ControllerBase::ControllerBase(Core::System& system) : system(system) {}
 ControllerBase::~ControllerBase() = default;
 
 void ControllerBase::ActivateController() {

--- a/src/core/hle/service/hid/controllers/controller_base.cpp
+++ b/src/core/hle/service/hid/controllers/controller_base.cpp
@@ -6,15 +6,15 @@
 
 namespace Service::HID {
 
-ControllerBase::ControllerBase() = default;
+ControllerBase::ControllerBase(Core::System& system) : system(system){};
 ControllerBase::~ControllerBase() = default;
 
-void ControllerBase::ActivateController(Core::System& system) {
+void ControllerBase::ActivateController() {
     if (is_activated) {
         OnRelease();
     }
     is_activated = true;
-    OnInit(system);
+    OnInit();
 }
 
 void ControllerBase::DeactivateController() {

--- a/src/core/hle/service/hid/controllers/controller_base.h
+++ b/src/core/hle/service/hid/controllers/controller_base.h
@@ -11,6 +11,10 @@ namespace Core::Timing {
 class CoreTiming;
 }
 
+namespace Core {
+class System;
+}
+
 namespace Service::HID {
 class ControllerBase {
 public:
@@ -18,7 +22,7 @@ public:
     virtual ~ControllerBase();
 
     // Called when the controller is initialized
-    virtual void OnInit() = 0;
+    virtual void OnInit(Core::System& system) = 0;
 
     // When the controller is released
     virtual void OnRelease() = 0;
@@ -30,7 +34,7 @@ public:
     // Called when input devices should be loaded
     virtual void OnLoadInputDevices() = 0;
 
-    void ActivateController();
+    void ActivateController(Core::System& system);
 
     void DeactivateController();
 

--- a/src/core/hle/service/hid/controllers/controller_base.h
+++ b/src/core/hle/service/hid/controllers/controller_base.h
@@ -18,11 +18,11 @@ class System;
 namespace Service::HID {
 class ControllerBase {
 public:
-    ControllerBase();
+    ControllerBase(Core::System& system);
     virtual ~ControllerBase();
 
     // Called when the controller is initialized
-    virtual void OnInit(Core::System& system) = 0;
+    virtual void OnInit() = 0;
 
     // When the controller is released
     virtual void OnRelease() = 0;
@@ -34,7 +34,7 @@ public:
     // Called when input devices should be loaded
     virtual void OnLoadInputDevices() = 0;
 
-    void ActivateController(Core::System& system);
+    void ActivateController();
 
     void DeactivateController();
 
@@ -50,5 +50,7 @@ protected:
         s64_le entry_count;
     };
     static_assert(sizeof(CommonHeader) == 0x20, "CommonHeader is an invalid size");
+
+    Core::System& system;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/controller_base.h
+++ b/src/core/hle/service/hid/controllers/controller_base.h
@@ -18,7 +18,7 @@ class System;
 namespace Service::HID {
 class ControllerBase {
 public:
-    ControllerBase(Core::System& system);
+    explicit ControllerBase(Core::System& system);
     virtual ~ControllerBase();
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/debug_pad.cpp
+++ b/src/core/hle/service/hid/controllers/debug_pad.cpp
@@ -17,7 +17,7 @@ enum class JoystickId : std::size_t { Joystick_Left, Joystick_Right };
 Controller_DebugPad::Controller_DebugPad() = default;
 Controller_DebugPad::~Controller_DebugPad() = default;
 
-void Controller_DebugPad::OnInit() {}
+void Controller_DebugPad::OnInit(Core::System& system) {}
 
 void Controller_DebugPad::OnRelease() {}
 

--- a/src/core/hle/service/hid/controllers/debug_pad.cpp
+++ b/src/core/hle/service/hid/controllers/debug_pad.cpp
@@ -14,10 +14,11 @@ constexpr s32 HID_JOYSTICK_MAX = 0x7fff;
 constexpr s32 HID_JOYSTICK_MIN = -0x7fff;
 enum class JoystickId : std::size_t { Joystick_Left, Joystick_Right };
 
-Controller_DebugPad::Controller_DebugPad() = default;
+Controller_DebugPad::Controller_DebugPad(Core::System& system)
+    : ControllerBase(system), system(system) {}
 Controller_DebugPad::~Controller_DebugPad() = default;
 
-void Controller_DebugPad::OnInit(Core::System& system) {}
+void Controller_DebugPad::OnInit() {}
 
 void Controller_DebugPad::OnRelease() {}
 

--- a/src/core/hle/service/hid/controllers/debug_pad.h
+++ b/src/core/hle/service/hid/controllers/debug_pad.h
@@ -20,7 +20,7 @@ public:
     ~Controller_DebugPad() override;
 
     // Called when the controller is initialized
-    void OnInit() override;
+    void OnInit(Core::System& system) override;
 
     // When the controller is released
     void OnRelease() override;

--- a/src/core/hle/service/hid/controllers/debug_pad.h
+++ b/src/core/hle/service/hid/controllers/debug_pad.h
@@ -16,11 +16,11 @@
 namespace Service::HID {
 class Controller_DebugPad final : public ControllerBase {
 public:
-    Controller_DebugPad();
+    explicit Controller_DebugPad(Core::System& system);
     ~Controller_DebugPad() override;
 
     // Called when the controller is initialized
-    void OnInit(Core::System& system) override;
+    void OnInit() override;
 
     // When the controller is released
     void OnRelease() override;
@@ -89,5 +89,6 @@ private:
         buttons;
     std::array<std::unique_ptr<Input::AnalogDevice>, Settings::NativeAnalog::NUM_STICKS_HID>
         analogs;
+    Core::System& system;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/gesture.cpp
+++ b/src/core/hle/service/hid/controllers/gesture.cpp
@@ -13,7 +13,7 @@ constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3BA00;
 Controller_Gesture::Controller_Gesture() = default;
 Controller_Gesture::~Controller_Gesture() = default;
 
-void Controller_Gesture::OnInit() {}
+void Controller_Gesture::OnInit(Core::System& system) {}
 
 void Controller_Gesture::OnRelease() {}
 

--- a/src/core/hle/service/hid/controllers/gesture.cpp
+++ b/src/core/hle/service/hid/controllers/gesture.cpp
@@ -10,10 +10,11 @@
 namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3BA00;
 
-Controller_Gesture::Controller_Gesture() = default;
+Controller_Gesture::Controller_Gesture(Core::System& system)
+    : ControllerBase(system), system(system) {}
 Controller_Gesture::~Controller_Gesture() = default;
 
-void Controller_Gesture::OnInit(Core::System& system) {}
+void Controller_Gesture::OnInit() {}
 
 void Controller_Gesture::OnRelease() {}
 

--- a/src/core/hle/service/hid/controllers/gesture.h
+++ b/src/core/hle/service/hid/controllers/gesture.h
@@ -12,11 +12,11 @@
 namespace Service::HID {
 class Controller_Gesture final : public ControllerBase {
 public:
-    Controller_Gesture();
+    Controller_Gesture(Core::System& system);
     ~Controller_Gesture() override;
 
     // Called when the controller is initialized
-    void OnInit(Core::System& system) override;
+    void OnInit() override;
 
     // When the controller is released
     void OnRelease() override;
@@ -59,5 +59,6 @@ private:
         std::array<GestureState, 17> gesture_states;
     };
     SharedMemory shared_memory{};
+    Core::System& system;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/gesture.h
+++ b/src/core/hle/service/hid/controllers/gesture.h
@@ -16,7 +16,7 @@ public:
     ~Controller_Gesture() override;
 
     // Called when the controller is initialized
-    void OnInit() override;
+    void OnInit(Core::System& system) override;
 
     // When the controller is released
     void OnRelease() override;

--- a/src/core/hle/service/hid/controllers/gesture.h
+++ b/src/core/hle/service/hid/controllers/gesture.h
@@ -12,7 +12,7 @@
 namespace Service::HID {
 class Controller_Gesture final : public ControllerBase {
 public:
-    Controller_Gesture(Core::System& system);
+    explicit Controller_Gesture(Core::System& system);
     ~Controller_Gesture() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/keyboard.cpp
+++ b/src/core/hle/service/hid/controllers/keyboard.cpp
@@ -12,10 +12,11 @@ namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3800;
 constexpr u8 KEYS_PER_BYTE = 8;
 
-Controller_Keyboard::Controller_Keyboard() = default;
+Controller_Keyboard::Controller_Keyboard(Core::System& system)
+    : ControllerBase(system), system(system) {}
 Controller_Keyboard::~Controller_Keyboard() = default;
 
-void Controller_Keyboard::OnInit(Core::System& system) {}
+void Controller_Keyboard::OnInit() {}
 
 void Controller_Keyboard::OnRelease() {}
 

--- a/src/core/hle/service/hid/controllers/keyboard.cpp
+++ b/src/core/hle/service/hid/controllers/keyboard.cpp
@@ -15,7 +15,7 @@ constexpr u8 KEYS_PER_BYTE = 8;
 Controller_Keyboard::Controller_Keyboard() = default;
 Controller_Keyboard::~Controller_Keyboard() = default;
 
-void Controller_Keyboard::OnInit() {}
+void Controller_Keyboard::OnInit(Core::System& system) {}
 
 void Controller_Keyboard::OnRelease() {}
 

--- a/src/core/hle/service/hid/controllers/keyboard.h
+++ b/src/core/hle/service/hid/controllers/keyboard.h
@@ -19,7 +19,7 @@ public:
     ~Controller_Keyboard() override;
 
     // Called when the controller is initialized
-    void OnInit() override;
+    void OnInit(Core::System& system) override;
 
     // When the controller is released
     void OnRelease() override;

--- a/src/core/hle/service/hid/controllers/keyboard.h
+++ b/src/core/hle/service/hid/controllers/keyboard.h
@@ -15,11 +15,11 @@
 namespace Service::HID {
 class Controller_Keyboard final : public ControllerBase {
 public:
-    Controller_Keyboard();
+    Controller_Keyboard(Core::System& system);
     ~Controller_Keyboard() override;
 
     // Called when the controller is initialized
-    void OnInit(Core::System& system) override;
+    void OnInit() override;
 
     // When the controller is released
     void OnRelease() override;
@@ -53,5 +53,6 @@ private:
         keyboard_keys;
     std::array<std::unique_ptr<Input::ButtonDevice>, Settings::NativeKeyboard::NumKeyboardMods>
         keyboard_mods;
+    Core::System& system;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/keyboard.h
+++ b/src/core/hle/service/hid/controllers/keyboard.h
@@ -15,7 +15,7 @@
 namespace Service::HID {
 class Controller_Keyboard final : public ControllerBase {
 public:
-    Controller_Keyboard(Core::System& system);
+    explicit Controller_Keyboard(Core::System& system);
     ~Controller_Keyboard() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/mouse.cpp
+++ b/src/core/hle/service/hid/controllers/mouse.cpp
@@ -11,10 +11,10 @@
 namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3400;
 
-Controller_Mouse::Controller_Mouse() = default;
+Controller_Mouse::Controller_Mouse(Core::System& system) : ControllerBase(system), system(system) {}
 Controller_Mouse::~Controller_Mouse() = default;
 
-void Controller_Mouse::OnInit(Core::System& system) {}
+void Controller_Mouse::OnInit() {}
 void Controller_Mouse::OnRelease() {}
 
 void Controller_Mouse::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,

--- a/src/core/hle/service/hid/controllers/mouse.cpp
+++ b/src/core/hle/service/hid/controllers/mouse.cpp
@@ -14,7 +14,7 @@ constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3400;
 Controller_Mouse::Controller_Mouse() = default;
 Controller_Mouse::~Controller_Mouse() = default;
 
-void Controller_Mouse::OnInit() {}
+void Controller_Mouse::OnInit(Core::System& system) {}
 void Controller_Mouse::OnRelease() {}
 
 void Controller_Mouse::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,

--- a/src/core/hle/service/hid/controllers/mouse.h
+++ b/src/core/hle/service/hid/controllers/mouse.h
@@ -14,11 +14,11 @@
 namespace Service::HID {
 class Controller_Mouse final : public ControllerBase {
 public:
-    Controller_Mouse();
+    Controller_Mouse(Core::System& system);
     ~Controller_Mouse() override;
 
     // Called when the controller is initialized
-    void OnInit(Core::System& system) override;
+    void OnInit() override;
 
     // When the controller is released
     void OnRelease() override;
@@ -53,5 +53,6 @@ private:
     std::unique_ptr<Input::MouseDevice> mouse_device;
     std::array<std::unique_ptr<Input::ButtonDevice>, Settings::NativeMouseButton::NumMouseButtons>
         mouse_button_devices;
+    Core::System& system;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/mouse.h
+++ b/src/core/hle/service/hid/controllers/mouse.h
@@ -18,7 +18,7 @@ public:
     ~Controller_Mouse() override;
 
     // Called when the controller is initialized
-    void OnInit() override;
+    void OnInit(Core::System& system) override;
 
     // When the controller is released
     void OnRelease() override;

--- a/src/core/hle/service/hid/controllers/mouse.h
+++ b/src/core/hle/service/hid/controllers/mouse.h
@@ -14,7 +14,7 @@
 namespace Service::HID {
 class Controller_Mouse final : public ControllerBase {
 public:
-    Controller_Mouse(Core::System& system);
+    explicit Controller_Mouse(Core::System& system);
     ~Controller_Mouse() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -167,8 +167,8 @@ void Controller_NPad::InitNewlyAddedControler(std::size_t controller_idx) {
     controller.battery_level[2] = BATTERY_FULL;
 }
 
-void Controller_NPad::OnInit() {
-    auto& kernel = Core::System::GetInstance().Kernel();
+void Controller_NPad::OnInit(Core::System& system) {
+    auto& kernel = system.Kernel();
     styleset_changed_event = Kernel::WritableEvent::CreateEventPair(
         kernel, Kernel::ResetType::Automatic, "npad:NpadStyleSetChanged");
 

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -93,7 +93,7 @@ u32 Controller_NPad::IndexToNPad(std::size_t index) {
     };
 }
 
-Controller_NPad::Controller_NPad() = default;
+Controller_NPad::Controller_NPad(Core::System& system) : ControllerBase(system), system(system) {}
 Controller_NPad::~Controller_NPad() = default;
 
 void Controller_NPad::InitNewlyAddedControler(std::size_t controller_idx) {
@@ -167,7 +167,7 @@ void Controller_NPad::InitNewlyAddedControler(std::size_t controller_idx) {
     controller.battery_level[2] = BATTERY_FULL;
 }
 
-void Controller_NPad::OnInit(Core::System& system) {
+void Controller_NPad::OnInit() {
     auto& kernel = system.Kernel();
     styleset_changed_event = Kernel::WritableEvent::CreateEventPair(
         kernel, Kernel::ResetType::Automatic, "npad:NpadStyleSetChanged");

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -20,11 +20,11 @@ constexpr u32 NPAD_UNKNOWN = 16; // TODO(ogniK): What is this?
 
 class Controller_NPad final : public ControllerBase {
 public:
-    Controller_NPad();
+    Controller_NPad(Core::System& system);
     ~Controller_NPad() override;
 
     // Called when the controller is initialized
-    void OnInit(Core::System& system) override;
+    void OnInit() override;
 
     // When the controller is released
     void OnRelease() override;
@@ -327,5 +327,6 @@ private:
     std::array<ControllerPad, 10> npad_pad_states{};
     bool IsControllerSupported(NPadControllerType controller);
     bool is_in_lr_assignment_mode{false};
+    Core::System& system;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -24,7 +24,7 @@ public:
     ~Controller_NPad() override;
 
     // Called when the controller is initialized
-    void OnInit() override;
+    void OnInit(Core::System& system) override;
 
     // When the controller is released
     void OnRelease() override;

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -20,7 +20,7 @@ constexpr u32 NPAD_UNKNOWN = 16; // TODO(ogniK): What is this?
 
 class Controller_NPad final : public ControllerBase {
 public:
-    Controller_NPad(Core::System& system);
+    explicit Controller_NPad(Core::System& system);
     ~Controller_NPad() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/stubbed.cpp
+++ b/src/core/hle/service/hid/controllers/stubbed.cpp
@@ -9,10 +9,11 @@
 
 namespace Service::HID {
 
-Controller_Stubbed::Controller_Stubbed() = default;
+Controller_Stubbed::Controller_Stubbed(Core::System& system)
+    : ControllerBase(system), system(system) {}
 Controller_Stubbed::~Controller_Stubbed() = default;
 
-void Controller_Stubbed::OnInit(Core::System& system) {}
+void Controller_Stubbed::OnInit() {}
 
 void Controller_Stubbed::OnRelease() {}
 

--- a/src/core/hle/service/hid/controllers/stubbed.cpp
+++ b/src/core/hle/service/hid/controllers/stubbed.cpp
@@ -12,7 +12,7 @@ namespace Service::HID {
 Controller_Stubbed::Controller_Stubbed() = default;
 Controller_Stubbed::~Controller_Stubbed() = default;
 
-void Controller_Stubbed::OnInit() {}
+void Controller_Stubbed::OnInit(Core::System& system) {}
 
 void Controller_Stubbed::OnRelease() {}
 

--- a/src/core/hle/service/hid/controllers/stubbed.h
+++ b/src/core/hle/service/hid/controllers/stubbed.h
@@ -10,11 +10,11 @@
 namespace Service::HID {
 class Controller_Stubbed final : public ControllerBase {
 public:
-    Controller_Stubbed();
+    Controller_Stubbed(Core::System& system);
     ~Controller_Stubbed() override;
 
     // Called when the controller is initialized
-    void OnInit(Core::System& system) override;
+    void OnInit() override;
 
     // When the controller is released
     void OnRelease() override;
@@ -30,5 +30,6 @@ public:
 private:
     bool smart_update{};
     std::size_t common_offset{};
+    Core::System& system;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/stubbed.h
+++ b/src/core/hle/service/hid/controllers/stubbed.h
@@ -10,7 +10,7 @@
 namespace Service::HID {
 class Controller_Stubbed final : public ControllerBase {
 public:
-    Controller_Stubbed(Core::System& system);
+    explicit Controller_Stubbed(Core::System& system);
     ~Controller_Stubbed() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/stubbed.h
+++ b/src/core/hle/service/hid/controllers/stubbed.h
@@ -14,7 +14,7 @@ public:
     ~Controller_Stubbed() override;
 
     // Called when the controller is initialized
-    void OnInit() override;
+    void OnInit(Core::System& system) override;
 
     // When the controller is released
     void OnRelease() override;

--- a/src/core/hle/service/hid/controllers/touchscreen.cpp
+++ b/src/core/hle/service/hid/controllers/touchscreen.cpp
@@ -13,10 +13,11 @@
 namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x400;
 
-Controller_Touchscreen::Controller_Touchscreen() = default;
+Controller_Touchscreen::Controller_Touchscreen(Core::System& system)
+    : ControllerBase(system), system(system) {}
 Controller_Touchscreen::~Controller_Touchscreen() = default;
 
-void Controller_Touchscreen::OnInit(Core::System& system) {}
+void Controller_Touchscreen::OnInit() {}
 
 void Controller_Touchscreen::OnRelease() {}
 

--- a/src/core/hle/service/hid/controllers/touchscreen.cpp
+++ b/src/core/hle/service/hid/controllers/touchscreen.cpp
@@ -16,7 +16,7 @@ constexpr std::size_t SHARED_MEMORY_OFFSET = 0x400;
 Controller_Touchscreen::Controller_Touchscreen() = default;
 Controller_Touchscreen::~Controller_Touchscreen() = default;
 
-void Controller_Touchscreen::OnInit() {}
+void Controller_Touchscreen::OnInit(Core::System& system) {}
 
 void Controller_Touchscreen::OnRelease() {}
 

--- a/src/core/hle/service/hid/controllers/touchscreen.h
+++ b/src/core/hle/service/hid/controllers/touchscreen.h
@@ -14,7 +14,7 @@
 namespace Service::HID {
 class Controller_Touchscreen final : public ControllerBase {
 public:
-    Controller_Touchscreen(Core::System& system);
+    explicit Controller_Touchscreen(Core::System& system);
     ~Controller_Touchscreen() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/touchscreen.h
+++ b/src/core/hle/service/hid/controllers/touchscreen.h
@@ -18,7 +18,7 @@ public:
     ~Controller_Touchscreen() override;
 
     // Called when the controller is initialized
-    void OnInit() override;
+    void OnInit(Core::System& system) override;
 
     // When the controller is released
     void OnRelease() override;

--- a/src/core/hle/service/hid/controllers/touchscreen.h
+++ b/src/core/hle/service/hid/controllers/touchscreen.h
@@ -14,11 +14,11 @@
 namespace Service::HID {
 class Controller_Touchscreen final : public ControllerBase {
 public:
-    Controller_Touchscreen();
+    Controller_Touchscreen(Core::System& system);
     ~Controller_Touchscreen() override;
 
     // Called when the controller is initialized
-    void OnInit(Core::System& system) override;
+    void OnInit() override;
 
     // When the controller is released
     void OnRelease() override;
@@ -69,5 +69,6 @@ private:
     TouchScreenSharedMemory shared_memory{};
     std::unique_ptr<Input::TouchDevice> touch_device;
     s64_le last_touch{};
+    Core::System& system;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/xpad.cpp
+++ b/src/core/hle/service/hid/controllers/xpad.cpp
@@ -10,10 +10,10 @@
 namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3C00;
 
-Controller_XPad::Controller_XPad() = default;
+Controller_XPad::Controller_XPad(Core::System& system) : ControllerBase(system), system(system) {}
 Controller_XPad::~Controller_XPad() = default;
 
-void Controller_XPad::OnInit(Core::System& system) {}
+void Controller_XPad::OnInit() {}
 
 void Controller_XPad::OnRelease() {}
 

--- a/src/core/hle/service/hid/controllers/xpad.cpp
+++ b/src/core/hle/service/hid/controllers/xpad.cpp
@@ -13,7 +13,7 @@ constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3C00;
 Controller_XPad::Controller_XPad() = default;
 Controller_XPad::~Controller_XPad() = default;
 
-void Controller_XPad::OnInit() {}
+void Controller_XPad::OnInit(Core::System& system) {}
 
 void Controller_XPad::OnRelease() {}
 

--- a/src/core/hle/service/hid/controllers/xpad.h
+++ b/src/core/hle/service/hid/controllers/xpad.h
@@ -16,7 +16,7 @@ public:
     ~Controller_XPad() override;
 
     // Called when the controller is initialized
-    void OnInit() override;
+    void OnInit(Core::System& system) override;
 
     // When the controller is released
     void OnRelease() override;

--- a/src/core/hle/service/hid/controllers/xpad.h
+++ b/src/core/hle/service/hid/controllers/xpad.h
@@ -12,11 +12,11 @@
 namespace Service::HID {
 class Controller_XPad final : public ControllerBase {
 public:
-    Controller_XPad();
+    Controller_XPad(Core::System& system);
     ~Controller_XPad() override;
 
     // Called when the controller is initialized
-    void OnInit(Core::System& system) override;
+    void OnInit() override;
 
     // When the controller is released
     void OnRelease() override;
@@ -56,5 +56,6 @@ private:
     };
     static_assert(sizeof(SharedMemory) == 0x1000, "SharedMemory is an invalid size");
     SharedMemory shared_memory{};
+    Core::System& system;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/xpad.h
+++ b/src/core/hle/service/hid/controllers/xpad.h
@@ -12,7 +12,7 @@
 namespace Service::HID {
 class Controller_XPad final : public ControllerBase {
 public:
-    Controller_XPad(Core::System& system);
+    explicit Controller_XPad(Core::System& system);
     ~Controller_XPad() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -1061,7 +1061,7 @@ void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system
     std::make_shared<HidSys>()->InstallAsService(service_manager);
     std::make_shared<HidTmp>()->InstallAsService(service_manager);
 
-    std::make_shared<IRS>()->InstallAsService(service_manager);
+    std::make_shared<IRS>(system)->InstallAsService(service_manager);
     std::make_shared<IRS_SYS>()->InstallAsService(service_manager);
 
     std::make_shared<XCD_SYS>()->InstallAsService(service_manager);

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -67,8 +67,8 @@ IAppletResource::IAppletResource(Core::System& system)
     MakeController<Controller_Gesture>(HidController::Gesture);
 
     // Homebrew doesn't try to activate some controllers, so we activate them by default
-    GetController<Controller_NPad>(HidController::NPad).ActivateController(system);
-    GetController<Controller_Touchscreen>(HidController::Touchscreen).ActivateController(system);
+    GetController<Controller_NPad>(HidController::NPad).ActivateController();
+    GetController<Controller_Touchscreen>(HidController::Touchscreen).ActivateController();
 
     GetController<Controller_Stubbed>(HidController::Unknown1).SetCommonHeaderOffset(0x4c00);
     GetController<Controller_Stubbed>(HidController::Unknown2).SetCommonHeaderOffset(0x4e00);
@@ -89,7 +89,7 @@ IAppletResource::IAppletResource(Core::System& system)
 }
 
 void IAppletResource::ActivateController(HidController controller) {
-    controllers[static_cast<size_t>(controller)]->ActivateController(system);
+    controllers[static_cast<size_t>(controller)]->ActivateController();
 }
 
 void IAppletResource::DeactivateController(HidController controller) {

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -42,7 +42,7 @@ enum class HidController : std::size_t {
 
 class IAppletResource final : public ServiceFramework<IAppletResource> {
 public:
-    IAppletResource();
+    IAppletResource(Core::System& system);
     ~IAppletResource() override;
 
     void ActivateController(HidController controller);
@@ -70,6 +70,7 @@ private:
     Kernel::SharedPtr<Kernel::SharedMemory> shared_mem;
 
     Core::Timing::EventType* pad_update_event;
+    Core::System& system;
 
     std::array<std::unique_ptr<ControllerBase>, static_cast<size_t>(HidController::MaxControllers)>
         controllers{};
@@ -77,7 +78,7 @@ private:
 
 class Hid final : public ServiceFramework<Hid> {
 public:
-    Hid();
+    Hid(Core::System& system);
     ~Hid() override;
 
     std::shared_ptr<IAppletResource> GetAppletResource();
@@ -126,12 +127,13 @@ private:
     void SwapNpadAssignment(Kernel::HLERequestContext& ctx);
 
     std::shared_ptr<IAppletResource> applet_resource;
+    Core::System& system;
 };
 
 /// Reload input devices. Used when input configuration changed
 void ReloadInputDevices();
 
 /// Registers all HID services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace Service::HID

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -42,7 +42,7 @@ enum class HidController : std::size_t {
 
 class IAppletResource final : public ServiceFramework<IAppletResource> {
 public:
-    IAppletResource(Core::System& system);
+    explicit IAppletResource(Core::System& system);
     ~IAppletResource() override;
 
     void ActivateController(HidController controller);
@@ -61,7 +61,7 @@ public:
 private:
     template <typename T>
     void MakeController(HidController controller) {
-        controllers[static_cast<std::size_t>(controller)] = std::make_unique<T>();
+        controllers[static_cast<std::size_t>(controller)] = std::make_unique<T>(system);
     }
 
     void GetSharedMemoryHandle(Kernel::HLERequestContext& ctx);
@@ -78,7 +78,7 @@ private:
 
 class Hid final : public ServiceFramework<Hid> {
 public:
-    Hid(Core::System& system);
+    explicit Hid(Core::System& system);
     ~Hid() override;
 
     std::shared_ptr<IAppletResource> GetAppletResource();

--- a/src/core/hle/service/hid/irs.cpp
+++ b/src/core/hle/service/hid/irs.cpp
@@ -11,7 +11,7 @@
 
 namespace Service::HID {
 
-IRS::IRS() : ServiceFramework{"irs"} {
+IRS::IRS(Core::System& system) : ServiceFramework{"irs"}, system(system) {
     // clang-format off
     static const FunctionInfo functions[] = {
         {302, &IRS::ActivateIrsensor, "ActivateIrsensor"},
@@ -37,7 +37,7 @@ IRS::IRS() : ServiceFramework{"irs"} {
 
     RegisterHandlers(functions);
 
-    auto& kernel = Core::System::GetInstance().Kernel();
+    auto& kernel = system.Kernel();
     shared_mem = Kernel::SharedMemory::Create(
         kernel, nullptr, 0x8000, Kernel::MemoryPermission::ReadWrite,
         Kernel::MemoryPermission::Read, 0, Kernel::MemoryRegion::BASE, "IRS:SharedMemory");
@@ -98,7 +98,7 @@ void IRS::GetImageTransferProcessorState(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 5};
     rb.Push(RESULT_SUCCESS);
-    rb.PushRaw<u64>(Core::System::GetInstance().CoreTiming().GetTicks());
+    rb.PushRaw<u64>(system.CoreTiming().GetTicks());
     rb.PushRaw<u32>(0);
 }
 

--- a/src/core/hle/service/hid/irs.h
+++ b/src/core/hle/service/hid/irs.h
@@ -15,7 +15,7 @@ namespace Service::HID {
 
 class IRS final : public ServiceFramework<IRS> {
 public:
-    explicit IRS();
+    explicit IRS(Core::System& system);
     ~IRS() override;
 
 private:
@@ -39,6 +39,7 @@ private:
     void ActivateIrsensorWithFunctionLevel(Kernel::HLERequestContext& ctx);
     Kernel::SharedPtr<Kernel::SharedMemory> shared_mem;
     const u32 device_handle{0xABCD};
+    Core::System& system;
 };
 
 class IRS_SYS final : public ServiceFramework<IRS_SYS> {

--- a/src/core/hle/service/ldr/ldr.h
+++ b/src/core/hle/service/ldr/ldr.h
@@ -11,6 +11,6 @@ class ServiceManager;
 namespace Service::LDR {
 
 /// Registers all LDR services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::LDR

--- a/src/core/hle/service/nfp/nfp.h
+++ b/src/core/hle/service/nfp/nfp.h
@@ -16,7 +16,7 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        explicit Interface(std::shared_ptr<Module> module, const char* name);
+        explicit Interface(std::shared_ptr<Module> module, Core::System& system, const char* name);
         ~Interface() override;
 
         struct ModelInfo {
@@ -43,9 +43,10 @@ public:
 
     protected:
         std::shared_ptr<Module> module;
+        Core::System& system;
     };
 };
 
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace Service::NFP

--- a/src/core/hle/service/nfp/nfp_user.cpp
+++ b/src/core/hle/service/nfp/nfp_user.cpp
@@ -6,8 +6,8 @@
 
 namespace Service::NFP {
 
-NFP_User::NFP_User(std::shared_ptr<Module> module)
-    : Module::Interface(std::move(module), "nfp:user") {
+NFP_User::NFP_User(std::shared_ptr<Module> module, Core::System& system)
+    : Module::Interface(std::move(module), system, "nfp:user") {
     static const FunctionInfo functions[] = {
         {0, &NFP_User::CreateUserInterface, "CreateUserInterface"},
     };

--- a/src/core/hle/service/nfp/nfp_user.h
+++ b/src/core/hle/service/nfp/nfp_user.h
@@ -10,7 +10,7 @@ namespace Service::NFP {
 
 class NFP_User final : public Module::Interface {
 public:
-    explicit NFP_User(std::shared_ptr<Module> module);
+    explicit NFP_User(std::shared_ptr<Module> module, Core::System& system);
     ~NFP_User() override;
 };
 

--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -31,7 +31,7 @@ public:
 
 class IRequest final : public ServiceFramework<IRequest> {
 public:
-    explicit IRequest() : ServiceFramework("IRequest") {
+    explicit IRequest(Core::System& system) : ServiceFramework("IRequest") {
         static const FunctionInfo functions[] = {
             {0, &IRequest::GetRequestState, "GetRequestState"},
             {1, &IRequest::GetResult, "GetResult"},
@@ -61,7 +61,7 @@ public:
         };
         RegisterHandlers(functions);
 
-        auto& kernel = Core::System::GetInstance().Kernel();
+        auto& kernel = system.Kernel();
         event1 = Kernel::WritableEvent::CreateEventPair(kernel, Kernel::ResetType::Automatic,
                                                         "IRequest:Event1");
         event2 = Kernel::WritableEvent::CreateEventPair(kernel, Kernel::ResetType::Automatic,
@@ -130,7 +130,7 @@ public:
 
 class IGeneralService final : public ServiceFramework<IGeneralService> {
 public:
-    IGeneralService();
+    IGeneralService(Core::System& system);
 
 private:
     void GetClientId(Kernel::HLERequestContext& ctx) {
@@ -155,7 +155,7 @@ private:
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
 
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IRequest>();
+        rb.PushIpcInterface<IRequest>(system);
     }
     void RemoveNetworkProfile(Kernel::HLERequestContext& ctx) {
         LOG_WARNING(Service_NIFM, "(STUBBED) called");
@@ -198,9 +198,11 @@ private:
         rb.Push(RESULT_SUCCESS);
         rb.Push<u8>(0);
     }
+    Core::System& system;
 };
 
-IGeneralService::IGeneralService() : ServiceFramework("IGeneralService") {
+IGeneralService::IGeneralService(Core::System& system)
+    : ServiceFramework("IGeneralService"), system(system) {
     static const FunctionInfo functions[] = {
         {1, &IGeneralService::GetClientId, "GetClientId"},
         {2, &IGeneralService::CreateScanRequest, "CreateScanRequest"},
@@ -245,7 +247,8 @@ IGeneralService::IGeneralService() : ServiceFramework("IGeneralService") {
 
 class NetworkInterface final : public ServiceFramework<NetworkInterface> {
 public:
-    explicit NetworkInterface(const char* name) : ServiceFramework{name} {
+    explicit NetworkInterface(const char* name, Core::System& system)
+        : ServiceFramework{name}, system(system) {
         static const FunctionInfo functions[] = {
             {4, &NetworkInterface::CreateGeneralServiceOld, "CreateGeneralServiceOld"},
             {5, &NetworkInterface::CreateGeneralService, "CreateGeneralService"},
@@ -258,7 +261,7 @@ public:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IGeneralService>();
+        rb.PushIpcInterface<IGeneralService>(system);
     }
 
     void CreateGeneralService(Kernel::HLERequestContext& ctx) {
@@ -266,14 +269,17 @@ public:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IGeneralService>();
+        rb.PushIpcInterface<IGeneralService>(system);
     }
+
+private:
+    Core::System& system;
 };
 
-void InstallInterfaces(SM::ServiceManager& service_manager) {
-    std::make_shared<NetworkInterface>("nifm:a")->InstallAsService(service_manager);
-    std::make_shared<NetworkInterface>("nifm:s")->InstallAsService(service_manager);
-    std::make_shared<NetworkInterface>("nifm:u")->InstallAsService(service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {
+    std::make_shared<NetworkInterface>("nifm:a", system)->InstallAsService(service_manager);
+    std::make_shared<NetworkInterface>("nifm:s", system)->InstallAsService(service_manager);
+    std::make_shared<NetworkInterface>("nifm:u", system)->InstallAsService(service_manager);
 }
 
 } // namespace Service::NIFM

--- a/src/core/hle/service/nifm/nifm.h
+++ b/src/core/hle/service/nifm/nifm.h
@@ -8,9 +8,13 @@ namespace Service::SM {
 class ServiceManager;
 }
 
+namespace Core {
+class System;
+}
+
 namespace Service::NIFM {
 
 /// Registers all NIFM services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace Service::NIFM

--- a/src/core/hle/service/nim/nim.cpp
+++ b/src/core/hle/service/nim/nim.cpp
@@ -126,7 +126,7 @@ public:
 class IEnsureNetworkClockAvailabilityService final
     : public ServiceFramework<IEnsureNetworkClockAvailabilityService> {
 public:
-    IEnsureNetworkClockAvailabilityService()
+    IEnsureNetworkClockAvailabilityService(Core::System& system)
         : ServiceFramework("IEnsureNetworkClockAvailabilityService") {
         static const FunctionInfo functions[] = {
             {0, &IEnsureNetworkClockAvailabilityService::StartTask, "StartTask"},
@@ -139,7 +139,7 @@ public:
         };
         RegisterHandlers(functions);
 
-        auto& kernel = Core::System::GetInstance().Kernel();
+        auto& kernel = system.Kernel();
         finished_event = Kernel::WritableEvent::CreateEventPair(
             kernel, Kernel::ResetType::Automatic,
             "IEnsureNetworkClockAvailabilityService:FinishEvent");
@@ -200,7 +200,7 @@ private:
 
 class NTC final : public ServiceFramework<NTC> {
 public:
-    explicit NTC() : ServiceFramework{"ntc"} {
+    explicit NTC(Core::System& system) : ServiceFramework{"ntc"}, system(system) {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &NTC::OpenEnsureNetworkClockAvailabilityService, "OpenEnsureNetworkClockAvailabilityService"},
@@ -218,7 +218,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IEnsureNetworkClockAvailabilityService>();
+        rb.PushIpcInterface<IEnsureNetworkClockAvailabilityService>(system);
     }
 
     // TODO(ogniK): Do we need these?
@@ -235,13 +235,14 @@ private:
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
+    Core::System& system;
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
     std::make_shared<NIM>()->InstallAsService(sm);
     std::make_shared<NIM_ECA>()->InstallAsService(sm);
     std::make_shared<NIM_SHP>()->InstallAsService(sm);
-    std::make_shared<NTC>()->InstallAsService(sm);
+    std::make_shared<NTC>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::NIM

--- a/src/core/hle/service/nim/nim.cpp
+++ b/src/core/hle/service/nim/nim.cpp
@@ -126,7 +126,7 @@ public:
 class IEnsureNetworkClockAvailabilityService final
     : public ServiceFramework<IEnsureNetworkClockAvailabilityService> {
 public:
-    IEnsureNetworkClockAvailabilityService(Core::System& system)
+    explicit IEnsureNetworkClockAvailabilityService(Core::System& system)
         : ServiceFramework("IEnsureNetworkClockAvailabilityService") {
         static const FunctionInfo functions[] = {
             {0, &IEnsureNetworkClockAvailabilityService::StartTask, "StartTask"},

--- a/src/core/hle/service/nim/nim.h
+++ b/src/core/hle/service/nim/nim.h
@@ -8,8 +8,12 @@ namespace Service::SM {
 class ServiceManager;
 }
 
+namespace Core {
+class System;
+}
+
 namespace Service::NIM {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::NIM

--- a/src/core/hle/service/ns/ns.cpp
+++ b/src/core/hle/service/ns/ns.cpp
@@ -617,7 +617,9 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& service_manager, FileSystem::FileSystemController& fsc) {
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system,
+                       FileSystem::FileSystemController& fsc) {
+
     std::make_shared<NS>("ns:am2")->InstallAsService(service_manager);
     std::make_shared<NS>("ns:ec")->InstallAsService(service_manager);
     std::make_shared<NS>("ns:rid")->InstallAsService(service_manager);
@@ -628,7 +630,7 @@ void InstallInterfaces(SM::ServiceManager& service_manager, FileSystem::FileSyst
     std::make_shared<NS_SU>()->InstallAsService(service_manager);
     std::make_shared<NS_VM>()->InstallAsService(service_manager);
 
-    std::make_shared<PL_U>(fsc)->InstallAsService(service_manager);
+    std::make_shared<PL_U>(system, fsc)->InstallAsService(service_manager);
 }
 
 } // namespace Service::NS

--- a/src/core/hle/service/ns/ns.cpp
+++ b/src/core/hle/service/ns/ns.cpp
@@ -617,8 +617,7 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system,
-                       FileSystem::FileSystemController& fsc) {
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {
 
     std::make_shared<NS>("ns:am2")->InstallAsService(service_manager);
     std::make_shared<NS>("ns:ec")->InstallAsService(service_manager);
@@ -630,7 +629,7 @@ void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system
     std::make_shared<NS_SU>()->InstallAsService(service_manager);
     std::make_shared<NS_VM>()->InstallAsService(service_manager);
 
-    std::make_shared<PL_U>(system, fsc)->InstallAsService(service_manager);
+    std::make_shared<PL_U>(system)->InstallAsService(service_manager);
 }
 
 } // namespace Service::NS

--- a/src/core/hle/service/ns/ns.h
+++ b/src/core/hle/service/ns/ns.h
@@ -97,8 +97,8 @@ private:
 };
 
 /// Registers all NS services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager, FileSystem::FileSystemController& fsc);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system,
+                       FileSystem::FileSystemController& fsc);
 
 } // namespace NS
-
 } // namespace Service

--- a/src/core/hle/service/ns/ns.h
+++ b/src/core/hle/service/ns/ns.h
@@ -97,8 +97,7 @@ private:
 };
 
 /// Registers all NS services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system,
-                       FileSystem::FileSystemController& fsc);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace NS
 } // namespace Service

--- a/src/core/hle/service/ns/pl_u.cpp
+++ b/src/core/hle/service/ns/pl_u.cpp
@@ -145,8 +145,9 @@ struct PL_U::Impl {
     std::vector<FontRegion> shared_font_regions;
 };
 
-PL_U::PL_U(FileSystem::FileSystemController& fsc)
-    : ServiceFramework("pl:u"), impl{std::make_unique<Impl>()} {
+PL_U::PL_U(Core::System& system, FileSystem::FileSystemController& fsc)
+    : ServiceFramework("pl:u"), impl{std::make_unique<Impl>()}, system(system) {
+
     static const FunctionInfo functions[] = {
         {0, &PL_U::RequestLoad, "RequestLoad"},
         {1, &PL_U::GetLoadState, "GetLoadState"},
@@ -255,7 +256,7 @@ void PL_U::GetSharedMemoryNativeHandle(Kernel::HLERequestContext& ctx) {
                                                        Kernel::MemoryState::Shared);
 
     // Create shared font memory object
-    auto& kernel = Core::System::GetInstance().Kernel();
+    auto& kernel = system.Kernel();
     impl->shared_font_mem = Kernel::SharedMemory::Create(
         kernel, Core::CurrentProcess(), SHARED_FONT_MEM_SIZE, Kernel::MemoryPermission::ReadWrite,
         Kernel::MemoryPermission::Read, SHARED_FONT_MEM_VADDR, Kernel::MemoryRegion::BASE,

--- a/src/core/hle/service/ns/pl_u.cpp
+++ b/src/core/hle/service/ns/pl_u.cpp
@@ -145,7 +145,7 @@ struct PL_U::Impl {
     std::vector<FontRegion> shared_font_regions;
 };
 
-PL_U::PL_U(Core::System& system, FileSystem::FileSystemController& fsc)
+PL_U::PL_U(Core::System& system)
     : ServiceFramework("pl:u"), impl{std::make_unique<Impl>()}, system(system) {
 
     static const FunctionInfo functions[] = {
@@ -157,6 +157,9 @@ PL_U::PL_U(Core::System& system, FileSystem::FileSystemController& fsc)
         {5, &PL_U::GetSharedFontInOrderOfPriority, "GetSharedFontInOrderOfPriority"},
     };
     RegisterHandlers(functions);
+
+    auto& fsc = system.GetFileSystemController();
+
     // Attempt to load shared font data from disk
     const auto* nand = fsc.GetSystemNANDContents();
     std::size_t offset = 0;

--- a/src/core/hle/service/ns/pl_u.h
+++ b/src/core/hle/service/ns/pl_u.h
@@ -20,7 +20,7 @@ void EncryptSharedFont(const std::vector<u8>& input, Kernel::PhysicalMemory& out
 
 class PL_U final : public ServiceFramework<PL_U> {
 public:
-    PL_U(FileSystem::FileSystemController& fsc);
+    PL_U(Core::System& system, FileSystem::FileSystemController& fsc);
     ~PL_U() override;
 
 private:
@@ -33,6 +33,7 @@ private:
 
     struct Impl;
     std::unique_ptr<Impl> impl;
+    Core::System& system;
 };
 
 } // namespace NS

--- a/src/core/hle/service/ns/pl_u.h
+++ b/src/core/hle/service/ns/pl_u.h
@@ -20,7 +20,7 @@ void EncryptSharedFont(const std::vector<u8>& input, Kernel::PhysicalMemory& out
 
 class PL_U final : public ServiceFramework<PL_U> {
 public:
-    PL_U(Core::System& system);
+    explicit PL_U(Core::System& system);
     ~PL_U() override;
 
 private:

--- a/src/core/hle/service/ns/pl_u.h
+++ b/src/core/hle/service/ns/pl_u.h
@@ -20,7 +20,7 @@ void EncryptSharedFont(const std::vector<u8>& input, Kernel::PhysicalMemory& out
 
 class PL_U final : public ServiceFramework<PL_U> {
 public:
-    PL_U(Core::System& system, FileSystem::FileSystemController& fsc);
+    PL_U(Core::System& system);
     ~PL_U() override;
 
 private:

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -31,11 +31,11 @@ constexpr s64 frame_ticks_30fps = static_cast<s64>(Core::Timing::BASE_CLOCK_RATE
 
 NVFlinger::NVFlinger(Core::Timing::CoreTiming& core_timing, Core::System& system)
     : core_timing{core_timing}, system(system) {
-    displays.emplace_back(0, "Default");
-    displays.emplace_back(1, "External");
-    displays.emplace_back(2, "Edid");
-    displays.emplace_back(3, "Internal");
-    displays.emplace_back(4, "Null");
+    displays.emplace_back(0, "Default", system);
+    displays.emplace_back(1, "External", system);
+    displays.emplace_back(2, "Edid", system);
+    displays.emplace_back(3, "Internal", system);
+    displays.emplace_back(4, "Null", system);
 
     // Schedule the screen composition events
     composition_event = core_timing.RegisterEvent("ScreenComposition", [this](u64 userdata,

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -29,8 +29,7 @@ namespace Service::NVFlinger {
 constexpr s64 frame_ticks = static_cast<s64>(Core::Timing::BASE_CLOCK_RATE / 60);
 constexpr s64 frame_ticks_30fps = static_cast<s64>(Core::Timing::BASE_CLOCK_RATE / 30);
 
-NVFlinger::NVFlinger(Core::Timing::CoreTiming& core_timing, Core::System& system)
-    : core_timing{core_timing}, system(system) {
+NVFlinger::NVFlinger(Core::System& system) : system(system) {
     displays.emplace_back(0, "Default", system);
     displays.emplace_back(1, "External", system);
     displays.emplace_back(2, "Edid", system);
@@ -38,18 +37,20 @@ NVFlinger::NVFlinger(Core::Timing::CoreTiming& core_timing, Core::System& system
     displays.emplace_back(4, "Null", system);
 
     // Schedule the screen composition events
-    composition_event = core_timing.RegisterEvent("ScreenComposition", [this](u64 userdata,
-                                                                              s64 cycles_late) {
-        Compose();
-        const auto ticks = Settings::values.force_30fps_mode ? frame_ticks_30fps : GetNextTicks();
-        this->core_timing.ScheduleEvent(std::max<s64>(0LL, ticks - cycles_late), composition_event);
-    });
+    composition_event = system.CoreTiming().RegisterEvent(
+        "ScreenComposition", [this](u64 userdata, s64 cycles_late) {
+            Compose();
+            const auto ticks =
+                Settings::values.force_30fps_mode ? frame_ticks_30fps : GetNextTicks();
+            this->system.CoreTiming().ScheduleEvent(std::max<s64>(0LL, ticks - cycles_late),
+                                                    composition_event);
+        });
 
-    core_timing.ScheduleEvent(frame_ticks, composition_event);
+    system.CoreTiming().ScheduleEvent(frame_ticks, composition_event);
 }
 
 NVFlinger::~NVFlinger() {
-    core_timing.UnscheduleEvent(composition_event, 0);
+    system.CoreTiming().UnscheduleEvent(composition_event, 0);
 }
 
 void NVFlinger::SetNVDrvInstance(std::shared_ptr<Nvidia::Module> instance) {

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -29,7 +29,8 @@ namespace Service::NVFlinger {
 constexpr s64 frame_ticks = static_cast<s64>(Core::Timing::BASE_CLOCK_RATE / 60);
 constexpr s64 frame_ticks_30fps = static_cast<s64>(Core::Timing::BASE_CLOCK_RATE / 30);
 
-NVFlinger::NVFlinger(Core::Timing::CoreTiming& core_timing) : core_timing{core_timing} {
+NVFlinger::NVFlinger(Core::Timing::CoreTiming& core_timing, Core::System& system)
+    : core_timing{core_timing}, system(system) {
     displays.emplace_back(0, "Default");
     displays.emplace_back(1, "External");
     displays.emplace_back(2, "Edid");
@@ -185,11 +186,9 @@ void NVFlinger::Compose() {
         MicroProfileFlip();
 
         if (!buffer) {
-            auto& system_instance = Core::System::GetInstance();
-
             // There was no queued buffer to draw, render previous frame
-            system_instance.GetPerfStats().EndGameFrame();
-            system_instance.GPU().SwapBuffers({});
+            system.GetPerfStats().EndGameFrame();
+            system.GPU().SwapBuffers({});
             continue;
         }
 

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -38,7 +38,7 @@ class BufferQueue;
 
 class NVFlinger final {
 public:
-    explicit NVFlinger(Core::Timing::CoreTiming& core_timing);
+    explicit NVFlinger(Core::Timing::CoreTiming& core_timing, Core::System& system);
     ~NVFlinger();
 
     /// Sets the NVDrv module instance to use to send buffers to the GPU.
@@ -107,6 +107,8 @@ private:
 
     /// Core timing instance for registering/unregistering the composition event.
     Core::Timing::CoreTiming& core_timing;
+
+    Core::System& system;
 };
 
 } // namespace Service::NVFlinger

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -38,7 +38,7 @@ class BufferQueue;
 
 class NVFlinger final {
 public:
-    explicit NVFlinger(Core::Timing::CoreTiming& core_timing, Core::System& system);
+    explicit NVFlinger(Core::System& system);
     ~NVFlinger();
 
     /// Sets the NVDrv module instance to use to send buffers to the GPU.
@@ -104,9 +104,6 @@ private:
 
     /// Event that handles screen composition.
     Core::Timing::EventType* composition_event;
-
-    /// Core timing instance for registering/unregistering the composition event.
-    Core::Timing::CoreTiming& core_timing;
 
     Core::System& system;
 };

--- a/src/core/hle/service/prepo/prepo.cpp
+++ b/src/core/hle/service/prepo/prepo.cpp
@@ -15,7 +15,7 @@ namespace Service::PlayReport {
 
 class PlayReport final : public ServiceFramework<PlayReport> {
 public:
-    explicit PlayReport(Core::System& system, const char* name)
+    explicit PlayReport(const char* name, Core::System& system)
         : ServiceFramework{name}, system(system) {
         // clang-format off
         static const FunctionInfo functions[] = {
@@ -128,12 +128,12 @@ private:
     Core::System& system;
 };
 
-void InstallInterfaces(Core::System& system) {
-    std::make_shared<PlayReport>(system, "prepo:a")->InstallAsService(system.ServiceManager());
-    std::make_shared<PlayReport>(system, "prepo:a2")->InstallAsService(system.ServiceManager());
-    std::make_shared<PlayReport>(system, "prepo:m")->InstallAsService(system.ServiceManager());
-    std::make_shared<PlayReport>(system, "prepo:s")->InstallAsService(system.ServiceManager());
-    std::make_shared<PlayReport>(system, "prepo:u")->InstallAsService(system.ServiceManager());
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {
+    std::make_shared<PlayReport>("prepo:a", system)->InstallAsService(service_manager);
+    std::make_shared<PlayReport>("prepo:a2", system)->InstallAsService(service_manager);
+    std::make_shared<PlayReport>("prepo:m", system)->InstallAsService(service_manager);
+    std::make_shared<PlayReport>("prepo:s", system)->InstallAsService(service_manager);
+    std::make_shared<PlayReport>("prepo:u", system)->InstallAsService(service_manager);
 }
 
 } // namespace Service::PlayReport

--- a/src/core/hle/service/prepo/prepo.h
+++ b/src/core/hle/service/prepo/prepo.h
@@ -8,8 +8,12 @@ namespace Service::SM {
 class ServiceManager;
 }
 
+namespace Core {
+class System;
+}
+
 namespace Service::PlayReport {
 
-void InstallInterfaces(Core::System& system);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace Service::PlayReport

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -198,7 +198,7 @@ ResultCode ServiceFrameworkBase::HandleSyncRequest(Kernel::HLERequestContext& co
 void Init(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system) {
     // NVFlinger needs to be accessed by several services like Vi and AppletOE so we instantiate it
     // here and pass it into the respective InstallInterfaces functions.
-    auto nv_flinger = std::make_shared<NVFlinger::NVFlinger>(system.CoreTiming(), system);
+    auto nv_flinger = std::make_shared<NVFlinger::NVFlinger>(system);
     system.GetFileSystemController().CreateFactories(*system.GetFilesystem(), false);
 
     SM::ServiceManager::InstallInterfaces(sm);

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -198,50 +198,50 @@ ResultCode ServiceFrameworkBase::HandleSyncRequest(Kernel::HLERequestContext& co
 void Init(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system) {
     // NVFlinger needs to be accessed by several services like Vi and AppletOE so we instantiate it
     // here and pass it into the respective InstallInterfaces functions.
-    auto nv_flinger = std::make_shared<NVFlinger::NVFlinger>(system.CoreTiming());
+    auto nv_flinger = std::make_shared<NVFlinger::NVFlinger>(system.CoreTiming(), system);
     system.GetFileSystemController().CreateFactories(*system.GetFilesystem(), false);
 
     SM::ServiceManager::InstallInterfaces(sm);
 
     Account::InstallInterfaces(system);
     AM::InstallInterfaces(*sm, nv_flinger, system);
-    AOC::InstallInterfaces(*sm);
+    AOC::InstallInterfaces(*sm, system);
     APM::InstallInterfaces(system);
     Audio::InstallInterfaces(*sm, system);
     BCAT::InstallInterfaces(*sm);
     BPC::InstallInterfaces(*sm);
-    BtDrv::InstallInterfaces(*sm);
-    BTM::InstallInterfaces(*sm);
+    BtDrv::InstallInterfaces(*sm, system);
+    BTM::InstallInterfaces(*sm, system);
     Capture::InstallInterfaces(*sm);
     ERPT::InstallInterfaces(*sm);
     ES::InstallInterfaces(*sm);
     EUPLD::InstallInterfaces(*sm);
-    Fatal::InstallInterfaces(*sm);
+    Fatal::InstallInterfaces(*sm, system);
     FGM::InstallInterfaces(*sm);
     FileSystem::InstallInterfaces(system);
-    Friend::InstallInterfaces(*sm);
+    Friend::InstallInterfaces(*sm, system);
     Glue::InstallInterfaces(system);
     GRC::InstallInterfaces(*sm);
-    HID::InstallInterfaces(*sm);
+    HID::InstallInterfaces(*sm, system);
     LBL::InstallInterfaces(*sm);
     LDN::InstallInterfaces(*sm);
-    LDR::InstallInterfaces(*sm);
+    LDR::InstallInterfaces(*sm, system);
     LM::InstallInterfaces(*sm);
     Migration::InstallInterfaces(*sm);
     Mii::InstallInterfaces(*sm);
     MM::InstallInterfaces(*sm);
     NCM::InstallInterfaces(*sm);
     NFC::InstallInterfaces(*sm);
-    NFP::InstallInterfaces(*sm);
-    NIFM::InstallInterfaces(*sm);
-    NIM::InstallInterfaces(*sm);
+    NFP::InstallInterfaces(*sm, system);
+    NIFM::InstallInterfaces(*sm, system);
+    NIM::InstallInterfaces(*sm, system);
     NPNS::InstallInterfaces(*sm);
-    NS::InstallInterfaces(*sm, system.GetFileSystemController());
+    NS::InstallInterfaces(*sm, system);
     Nvidia::InstallInterfaces(*sm, *nv_flinger, system);
     PCIe::InstallInterfaces(*sm);
     PCTL::InstallInterfaces(*sm);
     PCV::InstallInterfaces(*sm);
-    PlayReport::InstallInterfaces(system);
+    PlayReport::InstallInterfaces(*sm, system);
     PM::InstallInterfaces(system);
     PSC::InstallInterfaces(*sm);
     PSM::InstallInterfaces(*sm);

--- a/src/core/hle/service/time/interface.cpp
+++ b/src/core/hle/service/time/interface.cpp
@@ -7,8 +7,8 @@
 namespace Service::Time {
 
 Time::Time(std::shared_ptr<Module> time, std::shared_ptr<SharedMemory> shared_memory,
-           const char* name)
-    : Module::Interface(std::move(time), std::move(shared_memory), name) {
+           Core::System& system, const char* name)
+    : Module::Interface(std::move(time), std::move(shared_memory), system, name) {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &Time::GetStandardUserSystemClock, "GetStandardUserSystemClock"},

--- a/src/core/hle/service/time/interface.h
+++ b/src/core/hle/service/time/interface.h
@@ -13,7 +13,7 @@ class SharedMemory;
 class Time final : public Module::Interface {
 public:
     explicit Time(std::shared_ptr<Module> time, std::shared_ptr<SharedMemory> shared_memory,
-                  const char* name);
+                  Core::System& system, const char* name);
     ~Time() override;
 };
 

--- a/src/core/hle/service/time/time.h
+++ b/src/core/hle/service/time/time.h
@@ -80,7 +80,8 @@ public:
     class Interface : public ServiceFramework<Interface> {
     public:
         explicit Interface(std::shared_ptr<Module> time,
-                           std::shared_ptr<SharedMemory> shared_memory, const char* name);
+                           std::shared_ptr<SharedMemory> shared_memory, Core::System& system,
+                           const char* name);
         ~Interface() override;
 
         void GetStandardUserSystemClock(Kernel::HLERequestContext& ctx);
@@ -97,6 +98,7 @@ public:
     protected:
         std::shared_ptr<Module> time;
         std::shared_ptr<SharedMemory> shared_memory;
+        Core::System& system;
     };
 };
 

--- a/src/core/hle/service/vi/display/vi_display.cpp
+++ b/src/core/hle/service/vi/display/vi_display.cpp
@@ -15,8 +15,8 @@
 
 namespace Service::VI {
 
-Display::Display(u64 id, std::string name) : id{id}, name{std::move(name)} {
-    auto& kernel = Core::System::GetInstance().Kernel();
+Display::Display(u64 id, std::string name, Core::System& system) : id{id}, name{std::move(name)} {
+    auto& kernel = system.Kernel();
     vsync_event = Kernel::WritableEvent::CreateEventPair(kernel, Kernel::ResetType::Manual,
                                                          fmt::format("Display VSync Event {}", id));
 }

--- a/src/core/hle/service/vi/display/vi_display.h
+++ b/src/core/hle/service/vi/display/vi_display.h
@@ -26,7 +26,7 @@ public:
     /// @param id   The unique ID for this display.
     /// @param name The name for this display.
     ///
-    Display(u64 id, std::string name);
+    Display(u64 id, std::string name, Core::System& system);
     ~Display();
 
     Display(const Display&) = delete;


### PR DESCRIPTION
Removes use of this global accessor from most of the services. The filesystem, SM and the nvflinger BufferQueue still use this. Removal will be done in the future as they're used throughout the codebase