### PR TITLE
fsp_srv: Implement GetFileTimeStampRaw

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -367,6 +367,35 @@ u64 GetSize(FILE* f) {
     return size;
 }
 
+FileTimeStampRaw GetTimeStamp(const std::string& filename) {
+
+    FileTimeStampRaw timestamp = FileTimeStampRaw();
+
+    if (!Exists(filename)) {
+        LOG_ERROR(Common_Filesystem, "failed {}: No such file", filename);
+        return timestamp;
+    }
+
+    struct stat buf;
+#ifdef _WIN32
+    if (_wstat64(Common::UTF8ToUTF16W(filename).c_str(), &buf) == 0)
+#else
+    if (stat(filename.c_str(), &buf) == 0)
+#endif
+    {
+        LOG_TRACE(Common_Filesystem, "{}: Created={}, Accessed={}, Modified={}", filename, buf.st_ctime, buf.st_atime, buf.st_mtime);
+
+        timestamp.Created = buf.st_ctime;
+        timestamp.Accessed = buf.st_atime;
+        timestamp.Modified = buf.st_mtime;
+        
+        return timestamp;
+    }
+
+    LOG_ERROR(Common_Filesystem, "Stat failed {}: {}", filename, GetLastErrorMsg());
+    return timestamp;
+}
+
 bool CreateEmptyFile(const std::string& filename) {
     LOG_TRACE(Common_Filesystem, "{}", filename);
 

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -383,12 +383,13 @@ FileTimeStampRaw GetTimeStamp(const std::string& filename) {
     if (stat(filename.c_str(), &buf) == 0)
 #endif
     {
-        LOG_TRACE(Common_Filesystem, "{}: Created={}, Accessed={}, Modified={}", filename, buf.st_ctime, buf.st_atime, buf.st_mtime);
+        LOG_TRACE(Common_Filesystem, "{}: Created={}, Accessed={}, Modified={}", filename,
+                  buf.st_ctime, buf.st_atime, buf.st_mtime);
 
         timestamp.Created = buf.st_ctime;
         timestamp.Accessed = buf.st_atime;
         timestamp.Modified = buf.st_mtime;
-        
+
         return timestamp;
     }
 

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -46,6 +46,13 @@ struct FSTEntry {
     std::vector<FSTEntry> children;
 };
 
+// Timestamps for GetFileTimeStampRaw
+struct FileTimeStampRaw {
+    u64 Created;
+    u64 Accessed;
+    u64 Modified;
+};
+
 // Returns true if file filename exists
 bool Exists(const std::string& filename);
 
@@ -60,6 +67,9 @@ u64 GetSize(const int fd);
 
 // Overloaded GetSize, accepts FILE*
 u64 GetSize(FILE* f);
+
+// Returns the timestamp of filename
+FileTimeStampRaw GetTimeStamp(const std::string& filename);
 
 // Returns true if successful, or path already exists.
 bool CreateDir(const std::string& filename);

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -241,6 +241,14 @@ ResultVal<FileSys::EntryType> VfsDirectoryServiceWrapper::GetEntryType(
     return FileSys::ERROR_PATH_NOT_FOUND;
 }
 
+ResultVal<FileUtil::FileTimeStampRaw> VfsDirectoryServiceWrapper::GetFileTimeStampRaw(const std::string& path_) const {
+    std::string path(FileUtil::SanitizePath(path_));
+    auto file = backing->GetFileRelative(path);
+    if (file == nullptr)
+        return FileSys::ERROR_PATH_NOT_FOUND;
+    return MakeResult(FileUtil::GetTimeStamp(path));
+}
+
 FileSystemController::FileSystemController() = default;
 
 FileSystemController::~FileSystemController() = default;

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -241,7 +241,8 @@ ResultVal<FileSys::EntryType> VfsDirectoryServiceWrapper::GetEntryType(
     return FileSys::ERROR_PATH_NOT_FOUND;
 }
 
-ResultVal<FileUtil::FileTimeStampRaw> VfsDirectoryServiceWrapper::GetFileTimeStampRaw(const std::string& path_) const {
+ResultVal<FileUtil::FileTimeStampRaw> VfsDirectoryServiceWrapper::GetFileTimeStampRaw(
+    const std::string& path_) const {
     std::string path(FileUtil::SanitizePath(path_));
     auto file = backing->GetFileRelative(path);
     if (file == nullptr)

--- a/src/core/hle/service/filesystem/filesystem.h
+++ b/src/core/hle/service/filesystem/filesystem.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include "common/common_types.h"
+#include "common/file_util.h"
 #include "core/file_sys/directory.h"
 #include "core/file_sys/vfs.h"
 #include "core/hle/result.h"
@@ -224,6 +225,13 @@ public:
      * @return The type of the specified path or error code
      */
     ResultVal<FileSys::EntryType> GetEntryType(const std::string& path) const;
+
+    /**
+     * Gets the creation, last accessed, and last modified timestamps of a File specified by its path
+     * @param path Path relative to the archive
+     * @return The timestamps of the File. They are expressed as a Unix timestamp
+     */
+    ResultVal<FileUtil::FileTimeStampRaw> GetFileTimeStampRaw(const std::string& path) const;
 
 private:
     FileSys::VirtualDir backing;

--- a/src/core/hle/service/filesystem/filesystem.h
+++ b/src/core/hle/service/filesystem/filesystem.h
@@ -227,7 +227,8 @@ public:
     ResultVal<FileSys::EntryType> GetEntryType(const std::string& path) const;
 
     /**
-     * Gets the creation, last accessed, and last modified timestamps of a File specified by its path
+     * Gets the creation, last accessed, and last modified timestamps of a File
+     * specified by its path
      * @param path Path relative to the archive
      * @return The timestamps of the File. They are expressed as a Unix timestamp
      */

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -319,7 +319,7 @@ public:
             {11, nullptr, "GetFreeSpaceSize"},
             {12, nullptr, "GetTotalSpaceSize"},
             {13, &IFileSystem::CleanDirectoryRecursively, "CleanDirectoryRecursively"},
-            {14, nullptr, "GetFileTimeStampRaw"},
+            {14, &IFileSystem::GetFileTimeStampRaw, "GetFileTimeStampRaw"},
             {15, nullptr, "QueryEntry"},
         };
         RegisterHandlers(functions);
@@ -494,6 +494,29 @@ public:
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
         rb.Push(size.get_total_size());
+    }
+
+    void GetFileTimeStampRaw(Kernel::HLERequestContext& ctx) {
+        const auto file_buffer = ctx.ReadBuffer();
+        const std::string name = Common::StringFromBuffer(file_buffer);
+
+        LOG_DEBUG(Service_FS, "() called. file={}", name);
+
+        auto result = backend.GetFileTimeStampRaw(name);
+
+        if (result.Failed()) {
+            IPC::ResponseBuilder rb{ctx, 2};
+            rb.Push(result.Code());
+            return;
+        }
+
+        auto timestamp = result.Unwrap();
+
+        IPC::ResponseBuilder rb{ctx, 5};
+        rb.Push(RESULT_SUCCESS);
+        rb.Push(timestamp.Created);
+        rb.Push(timestamp.Accessed);
+        rb.Push(timestamp.Modified);
     }
 
 private:

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -500,7 +500,7 @@ public:
         const auto file_buffer = ctx.ReadBuffer();
         const std::string name = Common::StringFromBuffer(file_buffer);
 
-        LOG_DEBUG(Service_FS, "() called. file={}", name);
+        LOG_DEBUG(Service_FS, "called. file={}", name);
 
         auto result = backend.GetFileTimeStampRaw(name);
 


### PR DESCRIPTION
This implements the GetFileTimeStampRaw command which returns the timestamp properties of a file (created, accessed, modified time).

Needed for some homebrew like Diablo-NX to boot.

Current issue with this implementation:
- Somehow it can't find the file in /sdmc (will investigate and fix soon)