### PR TITLE
Link to Yuzu's wiki instead of Citra's

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-**The Contributor's Guide has moved to [the Citra wiki](https://github.com/citra-emu/citra/wiki/Contributing).**
+**The Contributor's Guide has moved to [the Yuzu wiki](https://github.com/yuzu-emu/yuzu/wiki/Contributing).**


### PR DESCRIPTION
The original Contributing.md had differences, such as some links, so I created a page on yuzu's wiki based on the original file.