### PR TITLE
A setting for changing the sensitivity when using "WASD" keys 

### DIFF
--- a/.ci/templates/build-single.yml
+++ b/.ci/templates/build-single.yml
@@ -14,7 +14,7 @@ steps:
     cacheHitVar: CACHE_RESTORED
 - script: chmod a+x ./.ci/scripts/$(ScriptFolder)/exec.sh && ./.ci/scripts/$(ScriptFolder)/exec.sh
   displayName: 'Build'
-- script: chmod a+x ./.ci/scripts/$(ScriptFolder)/upload.sh && ./.ci/scripts/$(ScriptFolder)/upload.sh
+- script: chmod a+x ./.ci/scripts/$(ScriptFolder)/upload.sh && RELEASE_NAME=$(BuildName) ./.ci/scripts/$(ScriptFolder)/upload.sh
   displayName: 'Package Artifacts'
 - publish: artifacts
   artifact: 'yuzu-$(BuildName)-$(BuildSuffix)'

--- a/.ci/templates/build-testing.yml
+++ b/.ci/templates/build-testing.yml
@@ -10,6 +10,8 @@ jobs:
         BuildSuffix: 'windows-testing'
         ScriptFolder: 'windows'
   steps:
+  - script: pip install requests urllib3
+    displayName: 'Prepare Environment'
   - task: PythonScript@0
     condition: eq(variables['Build.Reason'], 'PullRequest')
     displayName: 'Determine Testing Status'

--- a/.ci/templates/build-testing.yml
+++ b/.ci/templates/build-testing.yml
@@ -4,7 +4,7 @@ jobs:
   pool:
     vmImage: ubuntu-latest
   strategy:
-    maxParallel: 10
+    maxParallel: 5
     matrix:
       windows:
         BuildSuffix: 'windows-testing'

--- a/.ci/templates/build-testing.yml
+++ b/.ci/templates/build-testing.yml
@@ -15,7 +15,7 @@ jobs:
     displayName: 'Determine Testing Status'
     inputs:
       scriptSource: 'filePath'
-      scriptPath: '../scripts/merge/check-label-presence.py'
+      scriptPath: '.ci/scripts/merge/check-label-presence.py'
       arguments: '$(System.PullRequest.PullRequestNumber) create-testing-build'
   - ${{ if eq(variables.enabletesting, 'true') }}:
     - template: ./sync-source.yml

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-yuzu  emulator
+yuzu emulator
 =============
 [![Travis CI Build Status](https://travis-ci.org/yuzu-emu/yuzu.svg?branch=master)](https://travis-ci.org/yuzu-emu/yuzu)
 [![AppVeyor CI Build Status](https://ci.appveyor.com/api/projects/status/77k97svb2usreu68?svg=true)](https://ci.appveyor.com/project/bunnei/yuzu)


### PR DESCRIPTION
This would be useful for those people who can't or don't have a controller, since for example, when playing diablo 3 can't move with the WASD keys as an analog would. 

There is an option for the RPCSX3 emulator where you can change the sensitivity from 0.5 to 0.1 for the WASD keys, maybe a similar solution could be found for this awesome emulator as well.


Thanks