### PR TITLE
gl_rasterizer: Fix polygon offset units

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1340,7 +1340,9 @@ void RasterizerOpenGL::SyncPolygonOffset() {
     state.polygon_offset.fill_enable = regs.polygon_offset_fill_enable != 0;
     state.polygon_offset.line_enable = regs.polygon_offset_line_enable != 0;
     state.polygon_offset.point_enable = regs.polygon_offset_point_enable != 0;
-    state.polygon_offset.units = regs.polygon_offset_units;
+
+    // Hardware divides polygon offset units by two
+    state.polygon_offset.units = regs.polygon_offset_units / 2.0f;
     state.polygon_offset.factor = regs.polygon_offset_factor;
     state.polygon_offset.clamp = regs.polygon_offset_clamp;
 


### PR DESCRIPTION
For some reason hardware divides polygon offset units by two. This is visible since drivers multiply the application requested polygon offset by two.