### PR TITLE
file_sys: Add code to access raw gamecard partitions and lazily load them

### DIFF
--- a/src/core/file_sys/card_image.cpp
+++ b/src/core/file_sys/card_image.cpp
@@ -139,6 +139,35 @@ VirtualDir XCI::GetLogoPartition() {
     return GetPartition(XCIPartition::Logo);
 }
 
+VirtualFile XCI::GetPartitionRaw(XCIPartition partition) const {
+    return partitions_raw[static_cast<std::size_t>(partition)];
+}
+
+VirtualFile XCI::GetSecurePartitionRaw() const {
+    return GetPartitionRaw(XCIPartition::Secure);
+}
+
+VirtualFile XCI::GetStoragePartition0() const {
+    return std::make_shared<OffsetVfsFile>(file, update_normal_partition_end, 0, "partition0");
+}
+
+VirtualFile XCI::GetStoragePartition1() const {
+    return std::make_shared<OffsetVfsFile>(file, file->GetSize() - update_normal_partition_end,
+                                           update_normal_partition_end, "partition1");
+}
+
+VirtualFile XCI::GetNormalPartitionRaw() const {
+    return GetPartitionRaw(XCIPartition::Normal);
+}
+
+VirtualFile XCI::GetUpdatePartitionRaw() const {
+    return GetPartitionRaw(XCIPartition::Update);
+}
+
+VirtualFile XCI::GetLogoPartitionRaw() const {
+    return GetPartitionRaw(XCIPartition::Logo);
+}
+
 u64 XCI::GetProgramTitleID() const {
     return secure_partition->GetProgramTitleID();
 }

--- a/src/core/file_sys/card_image.h
+++ b/src/core/file_sys/card_image.h
@@ -92,6 +92,13 @@ public:
     VirtualDir GetUpdatePartition();
     VirtualDir GetLogoPartition();
 
+    VirtualFile GetPartitionRaw(XCIPartition partition) const;
+    VirtualFile GetSecurePartitionRaw() const;
+    VirtualFile GetStoragePartition0() const;
+    VirtualFile GetStoragePartition1() const;
+    VirtualFile GetNormalPartitionRaw() const;
+    VirtualFile GetUpdatePartitionRaw() const;
+    VirtualFile GetLogoPartitionRaw() const;
 
     u64 GetProgramTitleID() const;
     u32 GetSystemUpdateVersion();

--- a/src/core/file_sys/card_image.h
+++ b/src/core/file_sys/card_image.h
@@ -81,14 +81,17 @@ public:
     Loader::ResultStatus GetStatus() const;
     Loader::ResultStatus GetProgramNCAStatus() const;
 
-    u8 GetFormatVersion() const;
+    u8 GetFormatVersion();
 
-    VirtualDir GetPartition(XCIPartition partition) const;
+    VirtualDir GetPartition(XCIPartition partition);
+    std::vector<VirtualDir> GetPartitions();
+
     std::shared_ptr<NSP> GetSecurePartitionNSP() const;
-    VirtualDir GetSecurePartition() const;
-    VirtualDir GetNormalPartition() const;
-    VirtualDir GetUpdatePartition() const;
-    VirtualDir GetLogoPartition() const;
+    VirtualDir GetSecurePartition();
+    VirtualDir GetNormalPartition();
+    VirtualDir GetUpdatePartition();
+    VirtualDir GetLogoPartition();
+
 
     u64 GetProgramTitleID() const;
     u32 GetSystemUpdateVersion();
@@ -123,6 +126,7 @@ private:
     Loader::ResultStatus program_nca_status;
 
     std::vector<VirtualDir> partitions;
+    std::vector<VirtualFile> partitions_raw;
     std::shared_ptr<NSP> secure_partition;
     std::shared_ptr<NCA> program;
     std::vector<std::shared_ptr<NCA>> ncas;

--- a/src/core/file_sys/partition_filesystem.cpp
+++ b/src/core/file_sys/partition_filesystem.cpp
@@ -65,6 +65,9 @@ PartitionFilesystem::PartitionFilesystem(std::shared_ptr<VfsFile> file) {
         std::string name(
             reinterpret_cast<const char*>(&file_data[strtab_offset + entry.strtab_offset]));
 
+        offsets[name] = content_offset + entry.offset;
+        sizes[name] = entry.size;
+
         pfs_files.emplace_back(std::make_shared<OffsetVfsFile>(
             file, entry.size, content_offset + entry.offset, std::move(name)));
     }
@@ -76,6 +79,14 @@ PartitionFilesystem::~PartitionFilesystem() = default;
 
 Loader::ResultStatus PartitionFilesystem::GetStatus() const {
     return status;
+}
+
+std::map<std::string, u64> PartitionFilesystem::GetFileOffsets() const {
+    return offsets;
+}
+
+std::map<std::string, u64> PartitionFilesystem::GetFileSizes() const {
+    return sizes;
 }
 
 std::vector<std::shared_ptr<VfsFile>> PartitionFilesystem::GetFiles() const {

--- a/src/core/file_sys/partition_filesystem.cpp
+++ b/src/core/file_sys/partition_filesystem.cpp
@@ -65,8 +65,8 @@ PartitionFilesystem::PartitionFilesystem(std::shared_ptr<VfsFile> file) {
         std::string name(
             reinterpret_cast<const char*>(&file_data[strtab_offset + entry.strtab_offset]));
 
-        offsets[name] = content_offset + entry.offset;
-        sizes[name] = entry.size;
+        offsets.insert_or_assign(name, content_offset + entry.offset);
+        sizes.insert_or_assign(name, entry.size);
 
         pfs_files.emplace_back(std::make_shared<OffsetVfsFile>(
             file, entry.size, content_offset + entry.offset, std::move(name)));

--- a/src/core/file_sys/partition_filesystem.h
+++ b/src/core/file_sys/partition_filesystem.h
@@ -29,6 +29,9 @@ public:
 
     Loader::ResultStatus GetStatus() const;
 
+    std::map<std::string, u64> GetFileOffsets() const;
+    std::map<std::string, u64> GetFileSizes() const;
+
     std::vector<std::shared_ptr<VfsFile>> GetFiles() const override;
     std::vector<std::shared_ptr<VfsDirectory>> GetSubdirectories() const override;
     std::string GetName() const override;
@@ -79,6 +82,9 @@ private:
     Header pfs_header{};
     bool is_hfs = false;
     std::size_t content_offset = 0;
+
+    std::map<std::string, u64> offsets;
+    std::map<std::string, u64> sizes;
 
     std::vector<VirtualFile> pfs_files;
 };


### PR DESCRIPTION
This adds:
- Optimization that lazily loads parts of the gamecard
- Bug fix that allows the update part to be loaded -- this is the reason for the previous bullet point.
- Accessors for the raw part0/1 of the gamecard
- Missing implementations for gamecard certificate and IDs
- Accessors for sizes/offset maps in PFS