### PR TITLE
ci: Add windows MSVC builds to patreon and mainline pipelines

### DIFF
--- a/.ci/scripts/windows/upload.ps1
+++ b/.ci/scripts/windows/upload.ps1
@@ -1,0 +1,32 @@
+$GITDATE = $(git show -s --date=short --format='%ad') -replace "-",""
+$GITREV = $(git show -s --format='%h')
+$RELEASE_DIST = "yuzu-windows-msvc"
+
+$MSVC_BUILD_ZIP = "yuzu-windows-msvc-$GITDATE-$GITREV.zip" -replace " ", ""
+$MSVC_BUILD_PDB = "yuzu-windows-msvc-$GITDATE-$GITREV-debugsymbols.zip" -replace " ", ""
+$MSVC_SEVENZIP = "yuzu-windows-msvc-$GITDATE-$GITREV.7z" -replace " ", ""
+
+$env:BUILD_ZIP = $MSVC_BUILD_ZIP
+$env:BUILD_SYMBOLS = $MSVC_BUILD_PDB
+$env:BUILD_UPDATE = $MSVC_SEVENZIP
+
+$BUILD_DIR = ".\build\bin\Release"
+
+mkdir pdb
+Get-ChildItem "$BUILD_DIR\" -Recurse -Filter "*.pdb" | Copy-Item -destination .\pdb
+7z a -tzip $MSVC_BUILD_PDB .\pdb\*.pdb
+rm "$BUILD_DIR\*.pdb"
+mkdir $RELEASE_DIST
+mkdir "artifacts"
+
+Copy-Item "$BUILD_DIR\*" -Destination $RELEASE_DIST -Recurse
+rm "$RELEASE_DIST\*.exe"
+Get-ChildItem "$BUILD_DIR" -Recurse -Filter "yuzu*.exe" | Copy-Item -destination $RELEASE_DIST
+Get-ChildItem "$BUILD_DIR" -Recurse -Filter "QtWebEngineProcess*.exe" | Copy-Item -destination $RELEASE_DIST
+Copy-Item .\license.txt -Destination $RELEASE_DIST
+Copy-Item .\README.md -Destination $RELEASE_DIST
+7z a -tzip $MSVC_BUILD_ZIP $RELEASE_DIST\*
+7z a $MSVC_SEVENZIP $RELEASE_DIST
+
+Get-ChildItem . -Filter "*.zip" | Copy-Item -destination "artifacts"
+Get-ChildItem . -Filter "*.7z" | Copy-Item -destination "artifacts"

--- a/.ci/templates/build-msvc.yml
+++ b/.ci/templates/build-msvc.yml
@@ -1,0 +1,21 @@
+parameters:
+  artifactSource: 'true'
+  cache: 'false'
+
+steps:
+- script: mkdir build && cd build && set DATE=`date '+%Y.%m.%d'` && set CI=true && set AZURE_REPO_NAME=yuzu-emu/yuzu-$(BuildName) && set AZURE_REPO_TAG=$(BuildName)-$DATE && cmake -G "Visual Studio 15 2017 Win64" --config Release -DYUZU_USE_BUNDLED_QT=1 -DYUZU_USE_BUNDLED_SDL2=1 -DYUZU_USE_BUNDLED_UNICORN=1 -DYUZU_USE_QT_WEB_ENGINE=ON -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DYUZU_ENABLE_COMPATIBILITY_REPORTING=${COMPAT} -DUSE_DISCORD_PRESENCE=ON .. && cd ..
+  displayName: 'Configure CMake'
+- task: MSBuild@1
+  displayName: 'Build'
+  inputs:
+    solution: 'build/yuzu.sln'
+    maximumCpuCount: true
+    configuration: release
+- task: PowerShell@2
+  displayName: 'Package Artifacts'
+  inputs:
+    targetType: 'filePath'
+    filePath: './.ci/scripts/windows/upload.ps1'
+- publish: artifacts
+  artifact: 'yuzu-$(BuildName)-windows-msvc'
+  displayName: 'Upload Artifacts'

--- a/.ci/templates/build-single.yml
+++ b/.ci/templates/build-single.yml
@@ -3,8 +3,6 @@ parameters:
   cache: 'false'
 
 steps:
-- script: export DATE=`date '+%Y.%m.%d'` && export CI=true && AZURE_REPO_NAME=yuzu-emu/yuzu-$(BuildName) && AZURE_REPO_TAG=$(BuildName)-$DATE
-  displayName: 'Determine Build Name'
 - task: DockerInstaller@0
   displayName: 'Prepare Environment'
   inputs:
@@ -15,7 +13,7 @@ steps:
     key: yuzu-v1-$(BuildName)-$(BuildSuffix)-$(CacheSuffix)
     path: $(System.DefaultWorkingDirectory)/ccache
     cacheHitVar: CACHE_RESTORED
-- script: chmod a+x ./.ci/scripts/$(ScriptFolder)/exec.sh && ./.ci/scripts/$(ScriptFolder)/exec.sh
+- script: export DATE=`date '+%Y.%m.%d'` && export CI=true && export AZURE_REPO_NAME=yuzu-emu/yuzu-$(BuildName) && export AZURE_REPO_TAG=$(BuildName)-$DATE && chmod a+x ./.ci/scripts/$(ScriptFolder)/exec.sh && ./.ci/scripts/$(ScriptFolder)/exec.sh
   displayName: 'Build'
 - script: chmod a+x ./.ci/scripts/$(ScriptFolder)/upload.sh && RELEASE_NAME=$(BuildName) ./.ci/scripts/$(ScriptFolder)/upload.sh
   displayName: 'Package Artifacts'

--- a/.ci/templates/mergebot.yml
+++ b/.ci/templates/mergebot.yml
@@ -11,5 +11,5 @@ steps:
     inputs:
       scriptSource: 'filePath'
       scriptPath: '.ci/scripts/merge/apply-patches-by-label.py'
-      arguments: '${{ parameters.matchLabel }} patches'
+      arguments: '${{ parameters.matchLabel }} Tagged patches'
       workingDirectory: '$(System.DefaultWorkingDirectory)'

--- a/.ci/templates/release-download.yml
+++ b/.ci/templates/release-download.yml
@@ -2,7 +2,7 @@ steps:
   - task: DownloadPipelineArtifact@2
     displayName: 'Download Windows Release'
     inputs:
-      artifactName: 'yuzu-$(BuildName)-windows-mingw'
+      artifactName: 'yuzu-$(BuildName)-windows-msvc'
       buildType: 'current'
       targetPath: '$(Build.ArtifactStagingDirectory)'
   - task: DownloadPipelineArtifact@2

--- a/.ci/yuzu-mainline-step2.yml
+++ b/.ci/yuzu-mainline-step2.yml
@@ -53,7 +53,9 @@ stages:
         cache: 'true'
 - stage: release
   displayName: 'Release'
-  dependsOn: build
+  dependsOn:
+  - build
+  - build_win
   jobs:
   - job: github
     displayName: 'GitHub Release'

--- a/.ci/yuzu-mainline-step2.yml
+++ b/.ci/yuzu-mainline-step2.yml
@@ -34,7 +34,7 @@ stages:
       parameters:
         artifactSource: 'false'
         cache: 'true'
-- stage: build-win
+- stage: build_win
   dependsOn: format
   displayName: 'build-windows'
   jobs:

--- a/.ci/yuzu-mainline-step2.yml
+++ b/.ci/yuzu-mainline-step2.yml
@@ -15,9 +15,42 @@ stages:
   dependsOn: format
   displayName: 'build'
   jobs:
-  - template: ./templates/build-standard.yml
-    parameters:
-      cache: 'true'
+  - job: build
+    displayName: 'standard'
+    pool:
+      vmImage: ubuntu-latest
+    strategy:
+      maxParallel: 10
+      matrix:
+        linux:
+          BuildSuffix: 'linux'
+          ScriptFolder: 'linux'
+    steps:
+    - template: ./templates/sync-source.yml
+      parameters:
+        artifactSource: $(parameters.artifactSource)
+        needSubmodules: 'true'
+    - template: ./templates/build-single.yml
+      parameters:
+        artifactSource: 'false'
+        cache: 'true'
+- stage: build-win
+  dependsOn: format
+  displayName: 'build-windows'
+  jobs:
+  - job: build
+    displayName: 'msvc'
+    pool:
+      vmImage: vs2017-win2016
+    steps:
+    - template: ./templates/sync-source.yml
+      parameters:
+        artifactSource: $(parameters.artifactSource)
+        needSubmodules: 'true'
+    - template: ./templates/build-msvc.yml
+      parameters:
+        artifactSource: 'false'
+        cache: 'true'
 - stage: release
   displayName: 'Release'
   dependsOn: build

--- a/.ci/yuzu-patreon-step2.yml
+++ b/.ci/yuzu-patreon-step2.yml
@@ -15,14 +15,16 @@ stages:
   dependsOn: format
   displayName: 'build'
   jobs:
-  - template: ./templates/build-standard.yml
-    parameters:
-      cache: 'true'
-- stage: release
-  displayName: 'release'
-  dependsOn: build
-  jobs:
-  - job: azure
-    displayName: 'azure'
+  - job: build
+    displayName: 'windows-msvc'
+    pool:
+      vmImage: vs2017-win2016
     steps:
-    - template: ./templates/release-universal.yml
+    - template: ./templates/sync-source.yml
+      parameters:
+        artifactSource: $(parameters.artifactSource)
+        needSubmodules: 'true'
+    - template: ./templates/build-msvc.yml
+      parameters:
+        artifactSource: 'false'
+        cache: $(parameters.cache)


### PR DESCRIPTION
This:
- Adds the MSVC windows build template
- Fixes a mainline title bar bug
- Uses MSVC over MinGW in mainline and patreon