### PR TITLE
externals: Track mainline zlib as a submodule

### DIFF
--- a/.ci/scripts/linux/docker.sh
+++ b/.ci/scripts/linux/docker.sh
@@ -11,4 +11,5 @@ ninja
 
 ccache -s
 
-ctest -VV -C Release
+# Ignore zlib's tests, since they aren't gated behind a CMake option.
+ctest -VV -E "(example|example64)" -C Release

--- a/.gitmodules
+++ b/.gitmodules
@@ -47,8 +47,8 @@
     path = externals/sirit
     url = https://github.com/ReinUsesLisp/sirit
 [submodule "libzip"]
-	path = externals/libzip
-	url = https://github.com/DarkLordZach/libzip
+    path = externals/libzip
+    url = https://github.com/DarkLordZach/libzip
 [submodule "zlib"]
-	path = externals/zlib
-	url = https://github.com/DarkLordZach/zlib
+    path = externals/zlib
+    url = https://github.com/madler/zlib

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -81,7 +81,7 @@ endif()
 add_subdirectory(zlib EXCLUDE_FROM_ALL)
 
 # libzip
-add_subdirectory(libzip)
+add_subdirectory(libzip EXCLUDE_FROM_ALL)
 
 if (ENABLE_WEB_SERVICE)
     # LibreSSL

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -77,11 +77,11 @@ if (ENABLE_VULKAN)
     add_subdirectory(sirit)
 endif()
 
+# zlib
+add_subdirectory(zlib EXCLUDE_FROM_ALL)
+
 # libzip
 add_subdirectory(libzip)
-
-# zlib
-add_subdirectory(zlib)
 
 if (ENABLE_WEB_SERVICE)
     # LibreSSL


### PR DESCRIPTION
We don't need to depend on a custom fork for this. We can add the library as is, and then make it excluded from the ALL target, so we only link in the libraries that we actually make use of.