### PR TITLE
core: Remove Core::CurrentProcess()

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -111,7 +111,8 @@ FileSys::VirtualFile GetGameFileFromPath(const FileSys::VirtualFilesystem& vfs,
 }
 struct System::Impl {
     explicit Impl(System& system)
-        : kernel{system}, cpu_core_manager{system}, applet_manager{system}, reporter{system} {}
+        : kernel{system}, fs_controller{system}, cpu_core_manager{system},
+          applet_manager{system}, reporter{system} {}
 
     Cpu& CurrentCpuCore() {
         return cpu_core_manager.GetCurrentCore();
@@ -641,11 +642,11 @@ bool System::GetExitLock() const {
     return impl->exit_lock;
 }
 
-void System::SetCurrentProcessBuildID(std::array<u8, 32> id) {
+void System::SetCurrentProcessBuildID(const CurrentBuildProcessID& id) {
     impl->build_id = id;
 }
 
-const std::array<u8, 32>& System::GetCurrentProcessBuildID() const {
+const System::CurrentBuildProcessID& System::GetCurrentProcessBuildID() const {
     return impl->build_id;
 }
 

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -359,8 +359,4 @@ private:
     static System s_instance;
 };
 
-inline Kernel::Process* CurrentProcess() {
-    return System::GetInstance().CurrentProcess();
-}
-
 } // namespace Core

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -8,7 +8,6 @@
 #include <memory>
 #include <string>
 
-#include <map>
 #include "common/common_types.h"
 #include "core/file_sys/vfs_types.h"
 #include "core/hle/kernel/object.h"

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -98,6 +98,8 @@ FileSys::VirtualFile GetGameFileFromPath(const FileSys::VirtualFilesystem& vfs,
 
 class System {
 public:
+    using CurrentBuildProcessID = std::array<u8, 0x20>;
+
     System(const System&) = delete;
     System& operator=(const System&) = delete;
 
@@ -330,9 +332,9 @@ public:
 
     bool GetExitLock() const;
 
-    void SetCurrentProcessBuildID(std::array<u8, 0x20> id);
+    void SetCurrentProcessBuildID(const CurrentBuildProcessID& id);
 
-    const std::array<u8, 0x20>& GetCurrentProcessBuildID() const;
+    const CurrentBuildProcessID& GetCurrentProcessBuildID() const;
 
 private:
     System();

--- a/src/core/file_sys/romfs_factory.cpp
+++ b/src/core/file_sys/romfs_factory.cpp
@@ -35,11 +35,11 @@ void RomFSFactory::SetPackedUpdate(VirtualFile update_raw) {
     this->update_raw = std::move(update_raw);
 }
 
-ResultVal<VirtualFile> RomFSFactory::OpenCurrentProcess() const {
+ResultVal<VirtualFile> RomFSFactory::OpenCurrentProcess(u64 current_process_title_id) const {
     if (!updatable)
         return MakeResult<VirtualFile>(file);
 
-    const PatchManager patch_manager(Core::CurrentProcess()->GetTitleID());
+    const PatchManager patch_manager(current_process_title_id);
     return MakeResult<VirtualFile>(
         patch_manager.PatchRomFS(file, ivfc_offset, ContentRecordType::Program, update_raw));
 }

--- a/src/core/file_sys/romfs_factory.h
+++ b/src/core/file_sys/romfs_factory.h
@@ -33,7 +33,7 @@ public:
     ~RomFSFactory();
 
     void SetPackedUpdate(VirtualFile update_raw);
-    ResultVal<VirtualFile> OpenCurrentProcess() const;
+    ResultVal<VirtualFile> OpenCurrentProcess(u64 current_process_title_id) const;
     ResultVal<VirtualFile> Open(u64 title_id, StorageId storage, ContentRecordType type) const;
 
 private:

--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -127,8 +127,9 @@ std::string SaveDataFactory::GetFullPath(SaveDataSpaceId space, SaveDataType typ
                                          u128 user_id, u64 save_id) {
     // According to switchbrew, if a save is of type SaveData and the title id field is 0, it should
     // be interpreted as the title id of the current process.
-    if (type == SaveDataType::SaveData && title_id == 0)
-        title_id = Core::CurrentProcess()->GetTitleID();
+    if (type == SaveDataType::SaveData && title_id == 0) {
+        title_id = Core::System::GetInstance().CurrentProcess()->GetTitleID();
+    }
 
     std::string out = GetSaveDataSpaceIdPath(space);
 

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -641,7 +641,8 @@ static void HandleQuery() {
                        strlen("Xfer:features:read:target.xml:")) == 0) {
         SendReply(target_xml);
     } else if (strncmp(query, "Offsets", strlen("Offsets")) == 0) {
-        const VAddr base_address = Core::CurrentProcess()->VMManager().GetCodeRegionBaseAddress();
+        const VAddr base_address =
+            Core::System::GetInstance().CurrentProcess()->VMManager().GetCodeRegionBaseAddress();
         std::string buffer = fmt::format("TextSeg={:0x}", base_address);
         SendReply(buffer.c_str());
     } else if (strncmp(query, "fThreadInfo", strlen("fThreadInfo")) == 0) {

--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -103,7 +103,7 @@ SharedPtr<Object> HandleTable::GetGeneric(Handle handle) const {
     if (handle == CurrentThread) {
         return GetCurrentThread();
     } else if (handle == CurrentProcess) {
-        return Core::CurrentProcess();
+        return Core::System::GetInstance().CurrentProcess();
     }
 
     if (!IsValid(handle)) {

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -1142,12 +1142,12 @@ void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
     if (kind == LaunchParameterKind::ApplicationSpecific && !launch_popped_application_specific) {
         const auto backend = BCAT::CreateBackendFromSettings(
             [this](u64 tid) { return system.GetFileSystemController().GetBCATDirectory(tid); });
-        const auto build_id_full = Core::System::GetInstance().GetCurrentProcessBuildID();
+        const auto build_id_full = system.GetCurrentProcessBuildID();
         u64 build_id{};
         std::memcpy(&build_id, build_id_full.data(), sizeof(u64));
 
         const auto data =
-            backend->GetLaunchParameter({Core::CurrentProcess()->GetTitleID(), build_id});
+            backend->GetLaunchParameter({system.CurrentProcess()->GetTitleID(), build_id});
 
         if (data.has_value()) {
             IPC::ResponseBuilder rb{ctx, 2, 0, 1};
@@ -1200,7 +1200,7 @@ void IApplicationFunctions::EnsureSaveData(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called, uid={:016X}{:016X}", user_id[1], user_id[0]);
 
     FileSys::SaveDataDescriptor descriptor{};
-    descriptor.title_id = Core::CurrentProcess()->GetTitleID();
+    descriptor.title_id = system.CurrentProcess()->GetTitleID();
     descriptor.user_id = user_id;
     descriptor.type = FileSys::SaveDataType::SaveData;
     const auto res = system.GetFileSystemController().CreateSaveData(

--- a/src/core/hle/service/bcat/bcat.cpp
+++ b/src/core/hle/service/bcat/bcat.cpp
@@ -6,8 +6,9 @@
 
 namespace Service::BCAT {
 
-BCAT::BCAT(std::shared_ptr<Module> module, FileSystem::FileSystemController& fsc, const char* name)
-    : Module::Interface(std::move(module), fsc, name) {
+BCAT::BCAT(Core::System& system, std::shared_ptr<Module> module,
+           FileSystem::FileSystemController& fsc, const char* name)
+    : Interface(system, std::move(module), fsc, name) {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &BCAT::CreateBcatService, "CreateBcatService"},

--- a/src/core/hle/service/bcat/bcat.h
+++ b/src/core/hle/service/bcat/bcat.h
@@ -6,12 +6,16 @@
 
 #include "core/hle/service/bcat/module.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::BCAT {
 
 class BCAT final : public Module::Interface {
 public:
-    explicit BCAT(std::shared_ptr<Module> module, FileSystem::FileSystemController& fsc,
-                  const char* name);
+    explicit BCAT(Core::System& system, std::shared_ptr<Module> module,
+                  FileSystem::FileSystemController& fsc, const char* name);
     ~BCAT() override;
 };
 

--- a/src/core/hle/service/bcat/module.h
+++ b/src/core/hle/service/bcat/module.h
@@ -6,6 +6,10 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service {
 
 namespace FileSystem {
@@ -20,8 +24,8 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        explicit Interface(std::shared_ptr<Module> module, FileSystem::FileSystemController& fsc,
-                           const char* name);
+        explicit Interface(Core::System& system_, std::shared_ptr<Module> module_,
+                           FileSystem::FileSystemController& fsc_, const char* name);
         ~Interface() override;
 
         void CreateBcatService(Kernel::HLERequestContext& ctx);
@@ -33,6 +37,9 @@ public:
 
         std::shared_ptr<Module> module;
         std::unique_ptr<Backend> backend;
+
+    private:
+        Core::System& system;
     };
 };
 

--- a/src/core/hle/service/fatal/fatal.cpp
+++ b/src/core/hle/service/fatal/fatal.cpp
@@ -66,7 +66,7 @@ enum class FatalType : u32 {
 
 static void GenerateErrorReport(Core::System& system, ResultCode error_code,
                                 const FatalInfo& info) {
-    const auto title_id = Core::CurrentProcess()->GetTitleID();
+    const auto title_id = system.CurrentProcess()->GetTitleID();
     std::string crash_report = fmt::format(
         "Yuzu {}-{} crash report\n"
         "Title ID:                        {:016x}\n"

--- a/src/core/hle/service/filesystem/filesystem.h
+++ b/src/core/hle/service/filesystem/filesystem.h
@@ -10,6 +10,10 @@
 #include "core/file_sys/vfs.h"
 #include "core/hle/result.h"
 
+namespace Core {
+class System;
+}
+
 namespace FileSys {
 class BISFactory;
 class RegisteredCache;
@@ -52,7 +56,7 @@ enum class ImageDirectoryId : u32 {
 
 class FileSystemController {
 public:
-    FileSystemController();
+    explicit FileSystemController(Core::System& system_);
     ~FileSystemController();
 
     ResultCode RegisterRomFS(std::unique_ptr<FileSys::RomFSFactory>&& factory);
@@ -125,6 +129,8 @@ private:
     std::unique_ptr<FileSys::XCI> gamecard;
     std::unique_ptr<FileSys::RegisteredCache> gamecard_registered;
     std::unique_ptr<FileSys::PlaceholderCache> gamecard_placeholder;
+
+    Core::System& system;
 };
 
 void InstallInterfaces(Core::System& system);

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -163,7 +163,7 @@ public:
             return;
         }
 
-        if (Core::CurrentProcess()->GetTitleID() != header.title_id) {
+        if (system.CurrentProcess()->GetTitleID() != header.title_id) {
             LOG_ERROR(Service_LDR,
                       "Attempting to load NRR with title ID other than current process. (actual "
                       "{:016X})!",
@@ -327,7 +327,7 @@ public:
         }
 
         // Load NRO as new executable module
-        auto* process = Core::CurrentProcess();
+        auto* process = system.CurrentProcess();
         auto& vm_manager = process->VMManager();
         auto map_address = vm_manager.FindFreeRegion(nro_size + bss_size);
 
@@ -411,7 +411,7 @@ public:
             return;
         }
 
-        auto& vm_manager = Core::CurrentProcess()->VMManager();
+        auto& vm_manager = system.CurrentProcess()->VMManager();
         const auto& nro_info = iter->second;
 
         // Unmap the mirrored memory

--- a/src/core/hle/service/ns/pl_u.cpp
+++ b/src/core/hle/service/ns/pl_u.cpp
@@ -324,14 +324,14 @@ void PL_U::GetSharedMemoryAddressOffset(Kernel::HLERequestContext& ctx) {
 void PL_U::GetSharedMemoryNativeHandle(Kernel::HLERequestContext& ctx) {
     // Map backing memory for the font data
     LOG_DEBUG(Service_NS, "called");
-    Core::CurrentProcess()->VMManager().MapMemoryBlock(SHARED_FONT_MEM_VADDR, impl->shared_font, 0,
-                                                       SHARED_FONT_MEM_SIZE,
-                                                       Kernel::MemoryState::Shared);
+    system.CurrentProcess()->VMManager().MapMemoryBlock(SHARED_FONT_MEM_VADDR, impl->shared_font, 0,
+                                                        SHARED_FONT_MEM_SIZE,
+                                                        Kernel::MemoryState::Shared);
 
     // Create shared font memory object
     auto& kernel = system.Kernel();
     impl->shared_font_mem = Kernel::SharedMemory::Create(
-        kernel, Core::CurrentProcess(), SHARED_FONT_MEM_SIZE, Kernel::MemoryPermission::ReadWrite,
+        kernel, system.CurrentProcess(), SHARED_FONT_MEM_SIZE, Kernel::MemoryPermission::ReadWrite,
         Kernel::MemoryPermission::Read, SHARED_FONT_MEM_VADDR, Kernel::MemoryRegion::BASE,
         "PL_U:shared_font_mem");
 

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -146,7 +146,7 @@ static u8* GetPointerFromVMA(const Kernel::Process& process, VAddr vaddr) {
  * using a VMA from the current process.
  */
 static u8* GetPointerFromVMA(VAddr vaddr) {
-    return GetPointerFromVMA(*Core::CurrentProcess(), vaddr);
+    return GetPointerFromVMA(*Core::System::GetInstance().CurrentProcess(), vaddr);
 }
 
 template <typename T>
@@ -226,7 +226,7 @@ bool IsValidVirtualAddress(const Kernel::Process& process, const VAddr vaddr) {
 }
 
 bool IsValidVirtualAddress(const VAddr vaddr) {
-    return IsValidVirtualAddress(*Core::CurrentProcess(), vaddr);
+    return IsValidVirtualAddress(*Core::System::GetInstance().CurrentProcess(), vaddr);
 }
 
 bool IsKernelVirtualAddress(const VAddr vaddr) {
@@ -387,7 +387,7 @@ void ReadBlock(const Kernel::Process& process, const VAddr src_addr, void* dest_
 }
 
 void ReadBlock(const VAddr src_addr, void* dest_buffer, const std::size_t size) {
-    ReadBlock(*Core::CurrentProcess(), src_addr, dest_buffer, size);
+    ReadBlock(*Core::System::GetInstance().CurrentProcess(), src_addr, dest_buffer, size);
 }
 
 void Write8(const VAddr addr, const u8 data) {
@@ -450,7 +450,7 @@ void WriteBlock(const Kernel::Process& process, const VAddr dest_addr, const voi
 }
 
 void WriteBlock(const VAddr dest_addr, const void* src_buffer, const std::size_t size) {
-    WriteBlock(*Core::CurrentProcess(), dest_addr, src_buffer, size);
+    WriteBlock(*Core::System::GetInstance().CurrentProcess(), dest_addr, src_buffer, size);
 }
 
 void ZeroBlock(const Kernel::Process& process, const VAddr dest_addr, const std::size_t size) {
@@ -539,7 +539,7 @@ void CopyBlock(const Kernel::Process& process, VAddr dest_addr, VAddr src_addr,
 }
 
 void CopyBlock(VAddr dest_addr, VAddr src_addr, std::size_t size) {
-    CopyBlock(*Core::CurrentProcess(), dest_addr, src_addr, size);
+    CopyBlock(*Core::System::GetInstance().CurrentProcess(), dest_addr, src_addr, size);
 }
 
 } // namespace Memory


### PR DESCRIPTION
Migrates the HLE service code off the use of directly accessing the global system instance where trivially able to do so. This removes all usages of Core::CurrentProcess from the service code, only 8 occurrences of this function exist elsewhere. There's still quite a bit of "System::GetInstance()" being used, however this was able to replace a few instances.

Keeping around `Core::CurrentProcess` only encourages the use of the global system instance (which will be phased out long-term). Instead, we use the direct system function call directly to remove the appealing but discouraged short-hand.