### PR TITLE
alignment: Resolve allocator construction issues on debug

### DIFF
--- a/src/common/alignment.h
+++ b/src/common/alignment.h
@@ -51,6 +51,11 @@ public:
     using reference = T&;
     using const_reference = const T&;
 
+    using propagate_on_container_copy_assignment = std::true_type;
+    using propagate_on_container_move_assignment = std::true_type;
+    using propagate_on_container_swap = std::true_type;
+    using is_always_equal = std::true_type;
+
 public:
     pointer address(reference r) noexcept {
         return std::addressof(r);

--- a/src/common/alignment.h
+++ b/src/common/alignment.h
@@ -57,6 +57,11 @@ public:
     using is_always_equal = std::true_type;
 
 public:
+    constexpr AlignmentAllocator() noexcept = default;
+
+    template <typename T2>
+    constexpr AlignmentAllocator(const AlignmentAllocator<T2, Align>&) noexcept {}
+
     pointer address(reference r) noexcept {
         return std::addressof(r);
     }


### PR DESCRIPTION
This was related to the source allocator being passed into the constructor potentially having a different type than allocator being constructed.

We simply need to provide a constructor to handle this case.