### PR TITLE
ci: Add TAR-XZ compression to MSVC builds

### DIFF
--- a/.ci/scripts/windows/upload.ps1
+++ b/.ci/scripts/windows/upload.ps1
@@ -5,6 +5,8 @@ $RELEASE_DIST = "yuzu-windows-msvc"
 $MSVC_BUILD_ZIP = "yuzu-windows-msvc-$GITDATE-$GITREV.zip" -replace " ", ""
 $MSVC_BUILD_PDB = "yuzu-windows-msvc-$GITDATE-$GITREV-debugsymbols.zip" -replace " ", ""
 $MSVC_SEVENZIP = "yuzu-windows-msvc-$GITDATE-$GITREV.7z" -replace " ", ""
+$MSVC_TAR = "yuzu-windows-msvc-$GITDATE-$GITREV.tar" -replace " ", ""
+$MSVC_TARXZ = "yuzu-windows-msvc-$GITDATE-$GITREV.tar.xz" -replace " ", ""
 
 $env:BUILD_ZIP = $MSVC_BUILD_ZIP
 $env:BUILD_SYMBOLS = $MSVC_BUILD_PDB
@@ -28,5 +30,9 @@ Copy-Item .\README.md -Destination $RELEASE_DIST
 7z a -tzip $MSVC_BUILD_ZIP $RELEASE_DIST\*
 7z a $MSVC_SEVENZIP $RELEASE_DIST
 
+7z a -r -ttar $MSVC_TAR $RELEASE_DIST
+7z a -r -txz $MSVC_TARXZ $MSVC_TAR
+
 Get-ChildItem . -Filter "*.zip" | Copy-Item -destination "artifacts"
 Get-ChildItem . -Filter "*.7z" | Copy-Item -destination "artifacts"
+Get-ChildItem . -Filter "*.tar.xz" | Copy-Item -destination "artifacts"


### PR DESCRIPTION
This makes the builds smaller in a low-dependency format.