### PR TITLE
ci: Correct azure tag and release names

### DIFF
--- a/.ci/templates/build-mock.yml
+++ b/.ci/templates/build-mock.yml
@@ -1,5 +1,5 @@
 steps:
   - script: mkdir artifacts || echo 'X' > artifacts/T1.txt
   - publish: artifacts
-    artifact: 'yuzu-$(BuildName)-$(BuildSuffix)'
+    artifact: 'yuzu-$(BuildName)-mock'
     displayName: 'Upload Artifacts'

--- a/.ci/templates/merge-private.yml
+++ b/.ci/templates/merge-private.yml
@@ -31,17 +31,7 @@ jobs:
       needSubmodules: 'true'
   - script: chmod a+x $(System.DefaultWorkingDirectory)/.ci/scripts/merge/yuzubot-git-config.sh && $(System.DefaultWorkingDirectory)/.ci/scripts/merge/yuzubot-git-config.sh
     displayName: 'Apply Git Configuration'
-  - script: git tag -a $(BuildName)-$(Build.BuildId) -m "yuzu $(BuildName) $(Build.BuildNumber) $(Build.DefinitionName)"
-    displayName: 'Tag Source'
   - script: git remote add other $(GitRepoPushChangesURL)
     displayName: 'Register Repository'
-  - script: git push --follow-tags --force other HEAD:$(GitPushBranch)
+  - script: git push --force other HEAD:$(GitPushBranch)
     displayName: 'Update Code'
-  - script: git rev-list -n 1 $(BuildName)-$(Build.BuildId) > $(Build.ArtifactStagingDirectory)/tag-commit.sha
-    displayName: 'Calculate Release Point'
-  - task: PublishPipelineArtifact@1
-    displayName: 'Upload Release Point'
-    inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)/tag-commit.sha'
-      artifact: 'yuzu-$(BuildName)-release-point'
-      replaceExistingArchive: true

--- a/.ci/templates/merge.yml
+++ b/.ci/templates/merge.yml
@@ -30,17 +30,7 @@ jobs:
       needSubmodules: 'true'
   - script: chmod a+x $(System.DefaultWorkingDirectory)/.ci/scripts/merge/yuzubot-git-config.sh && $(System.DefaultWorkingDirectory)/.ci/scripts/merge/yuzubot-git-config.sh
     displayName: 'Apply Git Configuration'
-  - script: git tag -a $(BuildName)-$(Build.BuildId) -m "yuzu $(BuildName) $(Build.BuildNumber) $(Build.DefinitionName)"
-    displayName: 'Tag Source'
   - script: git remote add other $(GitRepoPushChangesURL)
     displayName: 'Register Repository'
-  - script: git push --follow-tags --force other HEAD:$(GitPushBranch)
+  - script: git push --force other HEAD:$(GitPushBranch)
     displayName: 'Update Code'
-  - script: git rev-list -n 1 $(BuildName)-$(Build.BuildId) > $(Build.ArtifactStagingDirectory)/tag-commit.sha
-    displayName: 'Calculate Release Point'
-  - task: PublishPipelineArtifact@1
-    displayName: 'Upload Release Point'
-    inputs:
-      targetPath: '$(Build.ArtifactStagingDirectory)/tag-commit.sha'
-      artifact: 'yuzu-$(BuildName)-release-point'
-      replaceExistingArchive: true

--- a/.ci/templates/release-github.yml
+++ b/.ci/templates/release-github.yml
@@ -1,11 +1,13 @@
 steps:
   - template: ./release-download.yml
   - task: GitHubRelease@0
+    displayName: 'GitHub Release'
     inputs:
       action: 'create'
-      title: 'yuzu $(BuildName) #$(Build.BuildId)'
+      title: '$(ReleasePrefix) $(DisplayVersion)'
       assets: '$(Build.ArtifactStagingDirectory)/*'
       gitHubConnection: $(GitHubReleaseConnectionName)
       repositoryName: '$(Build.Repository.Name)'
       target: '$(Build.SourceVersion)'
-      tagSource: 'auto'
+      tagSource: manual
+      tag: $(BuildName)-$(DisplayPrefix)-$(DisplayVersion)

--- a/.ci/templates/release-private-tag.yml
+++ b/.ci/templates/release-private-tag.yml
@@ -1,0 +1,9 @@
+steps:
+  - script: chmod a+x $(System.DefaultWorkingDirectory)/.ci/scripts/merge/yuzubot-git-config.sh && $(System.DefaultWorkingDirectory)/.ci/scripts/merge/yuzubot-git-config.sh
+    displayName: 'Apply Git Configuration'
+  - script: git tag -a $(BuildName)-$(DisplayPrefix)-$(DisplayVersion) -m "yuzu $(BuildName) $(Build.BuildNumber) $(Build.DefinitionName) $(DisplayPrefix)-$(DisplayVersion)"
+    displayName: 'Tag Source'
+  - script: git remote add other $(GitRepoPushChangesURL)
+    displayName: 'Register Repository'
+  - script: git push other $(BuildName)-$(DisplayPrefix)-$(DisplayVersion)
+    displayName: 'Update Code'

--- a/.ci/yuzu-mainline-step2.yml
+++ b/.ci/yuzu-mainline-step2.yml
@@ -57,12 +57,12 @@ stages:
         cache: 'true'
         version: $(DisplayVersion)
 - stage: release
-  displayName: 'Release'
+  displayName: 'release'
   dependsOn:
   - build
   - build_win
   jobs:
   - job: github
-    displayName: 'GitHub Release'
+    displayName: 'github'
     steps:
     - template: ./templates/release-github.yml

--- a/.ci/yuzu-patreon-step2.yml
+++ b/.ci/yuzu-patreon-step2.yml
@@ -32,3 +32,11 @@ stages:
         artifactSource: 'false'
         cache: $(parameters.cache)
         version: $(DisplayVersion)
+- stage: release
+  displayName: 'release'
+  dependsOn: build
+  jobs:
+    - job: release
+      displayName: 'source'
+      steps:
+        - template: ./templates/release-private-tag.yml


### PR DESCRIPTION
Releases and tags now use the DisplayVersion instead of BuildId