### PR TITLE
Kernel: Implement a New Thread Scheduler V2

### DIFF
--- a/src/common/multi_level_queue.h
+++ b/src/common/multi_level_queue.h
@@ -304,6 +304,13 @@ public:
         return levels[priority == Depth ? 63 : priority].back();
     }
 
+    void clear() {
+        used_priorities = 0;
+        for (std::size_t i = 0; i < Depth; i++) {
+            levels[i].clear();
+        }
+    }
+
 private:
     using const_list_iterator = typename std::list<T>::const_iterator;
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -444,6 +444,16 @@ const Kernel::Scheduler& System::Scheduler(std::size_t core_index) const {
     return CpuCore(core_index).Scheduler();
 }
 
+/// Gets the global scheduler
+Kernel::GlobalScheduler& System::GlobalScheduler() {
+    return impl->kernel.GlobalScheduler();
+}
+
+/// Gets the global scheduler
+const Kernel::GlobalScheduler& System::GlobalScheduler() const {
+    return impl->kernel.GlobalScheduler();
+}
+
 Kernel::Process* System::CurrentProcess() {
     return impl->kernel.CurrentProcess();
 }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -404,9 +404,10 @@ void System::PrepareReschedule() {
     CurrentCpuCore().PrepareReschedule();
 }
 
-void System::PrepareReschedule(s32 core_index) {
-    if (core_index >= 0)
+void System::PrepareReschedule(const u32 core_index) {
+    if (core_index < GlobalScheduler().CpuCoresCount()) {
         CpuCore(core_index).PrepareReschedule();
+    }
 }
 
 PerfStatsResults System::GetAndResetPerfStats() {

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -404,6 +404,11 @@ void System::PrepareReschedule() {
     CurrentCpuCore().PrepareReschedule();
 }
 
+void System::PrepareReschedule(s32 core_index) {
+    if (core_index >= 0)
+        CpuCore(core_index).PrepareReschedule();
+}
+
 PerfStatsResults System::GetAndResetPerfStats() {
     return impl->GetAndResetPerfStats();
 }

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -27,6 +27,7 @@ namespace Kernel {
 class KernelCore;
 class Process;
 class Scheduler;
+class GlobalScheduler;
 } // namespace Kernel
 
 namespace Loader {
@@ -237,6 +238,12 @@ public:
 
     /// Gets the scheduler for the CPU core with the specified index
     const Kernel::Scheduler& Scheduler(std::size_t core_index) const;
+
+    /// Gets the global scheduler
+    Kernel::GlobalScheduler& GlobalScheduler();
+
+    /// Gets the global scheduler
+    const Kernel::GlobalScheduler& GlobalScheduler() const;
 
     /// Provides a pointer to the current process
     Kernel::Process* CurrentProcess();

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -24,10 +24,10 @@ class VfsFilesystem;
 } // namespace FileSys
 
 namespace Kernel {
+class GlobalScheduler;
 class KernelCore;
 class Process;
 class Scheduler;
-class GlobalScheduler;
 } // namespace Kernel
 
 namespace Loader {
@@ -186,7 +186,7 @@ public:
     void PrepareReschedule();
 
     /// Prepare the core emulation for a reschedule
-    void PrepareReschedule(s32 core_index);
+    void PrepareReschedule(u32 core_index);
 
     /// Gets and resets core performance statistics
     PerfStatsResults GetAndResetPerfStats();

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -185,6 +185,9 @@ public:
     /// Prepare the core emulation for a reschedule
     void PrepareReschedule();
 
+    /// Prepare the core emulation for a reschedule
+    void PrepareReschedule(s32 core_index);
+
     /// Gets and resets core performance statistics
     PerfStatsResults GetAndResetPerfStats();
 

--- a/src/core/core_cpu.cpp
+++ b/src/core/core_cpu.cpp
@@ -117,4 +117,8 @@ void Cpu::Reschedule() {
     scheduler->TryDoContextSwitch();
 }
 
+void Cpu::Shutdown() {
+    scheduler->Shutdown();
+}
+
 } // namespace Core

--- a/src/core/core_cpu.cpp
+++ b/src/core/core_cpu.cpp
@@ -111,7 +111,7 @@ void Cpu::PrepareReschedule() {
 
 void Cpu::Reschedule() {
     // Lock the global kernel mutex when we manipulate the HLE state
-    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+    std::lock_guard lock(HLE::g_hle_lock);
 
     global_scheduler.SelectThread(core_index);
     scheduler->TryDoContextSwitch();

--- a/src/core/core_cpu.cpp
+++ b/src/core/core_cpu.cpp
@@ -52,7 +52,8 @@ bool CpuBarrier::Rendezvous() {
 
 Cpu::Cpu(System& system, ExclusiveMonitor& exclusive_monitor, CpuBarrier& cpu_barrier,
          std::size_t core_index)
-    : cpu_barrier{cpu_barrier}, core_timing{system.CoreTiming()}, core_index{core_index} {
+    : cpu_barrier{cpu_barrier}, global_scheduler{system.GlobalScheduler()},
+      core_timing{system.CoreTiming()}, core_index{core_index} {
 #ifdef ARCHITECTURE_x86_64
     arm_interface = std::make_unique<ARM_Dynarmic>(system, exclusive_monitor, core_index);
 #else
@@ -60,7 +61,7 @@ Cpu::Cpu(System& system, ExclusiveMonitor& exclusive_monitor, CpuBarrier& cpu_ba
     LOG_WARNING(Core, "CPU JIT requested, but Dynarmic not available");
 #endif
 
-    scheduler = std::make_unique<Kernel::Scheduler>(system, *arm_interface);
+    scheduler = std::make_unique<Kernel::Scheduler>(system, *arm_interface, core_index);
 }
 
 Cpu::~Cpu() = default;
@@ -81,21 +82,21 @@ void Cpu::RunLoop(bool tight_loop) {
         return;
     }
 
+    Reschedule();
+
     // If we don't have a currently active thread then don't execute instructions,
     // instead advance to the next event and try to yield to the next thread
     if (Kernel::GetCurrentThread() == nullptr) {
         LOG_TRACE(Core, "Core-{} idling", core_index);
         core_timing.Idle();
-        core_timing.Advance();
-        PrepareReschedule();
     } else {
         if (tight_loop) {
             arm_interface->Run();
         } else {
             arm_interface->Step();
         }
-        core_timing.Advance();
     }
+    core_timing.Advance();
 
     Reschedule();
 }
@@ -106,18 +107,14 @@ void Cpu::SingleStep() {
 
 void Cpu::PrepareReschedule() {
     arm_interface->PrepareReschedule();
-    reschedule_pending = true;
 }
 
 void Cpu::Reschedule() {
-    if (!reschedule_pending) {
-        return;
-    }
-
-    reschedule_pending = false;
     // Lock the global kernel mutex when we manipulate the HLE state
-    std::lock_guard lock{HLE::g_hle_lock};
-    scheduler->Reschedule();
+    std::lock_guard<std::recursive_mutex> lock(HLE::g_hle_lock);
+
+    global_scheduler.SelectThread(core_index);
+    scheduler->TryDoContextSwitch();
 }
 
 } // namespace Core

--- a/src/core/core_cpu.h
+++ b/src/core/core_cpu.h
@@ -13,6 +13,7 @@
 
 namespace Kernel {
 class Scheduler;
+class GlobalScheduler;
 }
 
 namespace Core {
@@ -90,6 +91,7 @@ private:
 
     std::unique_ptr<ARM_Interface> arm_interface;
     CpuBarrier& cpu_barrier;
+    Kernel::GlobalScheduler& global_scheduler;
     std::unique_ptr<Kernel::Scheduler> scheduler;
     Timing::CoreTiming& core_timing;
 

--- a/src/core/core_cpu.h
+++ b/src/core/core_cpu.h
@@ -12,8 +12,8 @@
 #include "common/common_types.h"
 
 namespace Kernel {
-class Scheduler;
 class GlobalScheduler;
+class Scheduler;
 } // namespace Kernel
 
 namespace Core {

--- a/src/core/core_cpu.h
+++ b/src/core/core_cpu.h
@@ -14,7 +14,7 @@
 namespace Kernel {
 class Scheduler;
 class GlobalScheduler;
-}
+} // namespace Kernel
 
 namespace Core {
 class System;

--- a/src/core/core_cpu.h
+++ b/src/core/core_cpu.h
@@ -84,6 +84,8 @@ public:
         return core_index;
     }
 
+    void Shutdown();
+
     static std::unique_ptr<ExclusiveMonitor> MakeExclusiveMonitor(std::size_t num_cores);
 
 private:

--- a/src/core/cpu_core_manager.cpp
+++ b/src/core/cpu_core_manager.cpp
@@ -58,6 +58,7 @@ void CpuCoreManager::Shutdown() {
 
     thread_to_cpu.clear();
     for (auto& cpu_core : cores) {
+        cpu_core->Shutdown();
         cpu_core.reset();
     }
 

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -22,7 +22,6 @@ namespace Kernel {
 namespace {
 // Wake up num_to_wake (or all) threads in a vector.
 void WakeThreads(const std::vector<SharedPtr<Thread>>& waiting_threads, s32 num_to_wake) {
-
     auto& system = Core::System::GetInstance();
     // Only process up to 'target' threads, unless 'target' is <= 0, in which case process
     // them all.

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -91,12 +91,20 @@ ResultCode AddressArbiter::ModifyByWaitingCountAndSignalToAddressIfEqual(VAddr a
 
     // Determine the modified value depending on the waiting count.
     s32 updated_value;
-    if (waiting_threads.empty()) {
-        updated_value = value + 1;
-    } else if (num_to_wake <= 0 || waiting_threads.size() <= static_cast<u32>(num_to_wake)) {
-        updated_value = value - 1;
+    if (num_to_wake <= 0) {
+        if (waiting_threads.empty()) {
+            updated_value = value + 1;
+        } else {
+            updated_value = value - 1;
+        }
     } else {
-        updated_value = value;
+        if (waiting_threads.empty()) {
+            updated_value = value + 1;
+        } else if (waiting_threads.size() <= static_cast<u32>(num_to_wake)) {
+            updated_value = value - 1;
+        } else {
+            updated_value = value;
+        }
     }
 
     if (static_cast<s32>(Memory::Read32(address)) != value) {

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -37,8 +37,7 @@ void WakeThreads(const std::vector<SharedPtr<Thread>>& waiting_threads, s32 num_
         waiting_threads[i]->SetWaitSynchronizationResult(RESULT_SUCCESS);
         waiting_threads[i]->SetArbiterWaitAddress(0);
         waiting_threads[i]->ResumeFromWait();
-        if (waiting_threads[i]->GetProcessorID() >= 0)
-            system.CpuCore(waiting_threads[i]->GetProcessorID()).PrepareReschedule();
+        system.PrepareReschedule(waiting_threads[i]->GetProcessorID());
     }
 }
 } // Anonymous namespace
@@ -173,7 +172,7 @@ ResultCode AddressArbiter::WaitForAddressImpl(VAddr address, s64 timeout) {
 
     current_thread->WakeAfterDelay(timeout);
 
-    system.CpuCore(current_thread->GetProcessorID()).PrepareReschedule();
+    system.PrepareReschedule(current_thread->GetProcessorID());
     return RESULT_TIMEOUT;
 }
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -116,6 +116,8 @@ struct KernelCore::Impl {
         thread_wakeup_event_type = nullptr;
         preemption_event = nullptr;
 
+        global_scheduler.Shutdown();
+
         named_ports.clear();
     }
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -229,6 +229,14 @@ const Kernel::GlobalScheduler& KernelCore::GlobalScheduler() const {
     return impl->global_scheduler;
 }
 
+Core::System& KernelCore::System() {
+    return impl->system;
+}
+
+const Core::System& KernelCore::System() const {
+    return impl->system;
+}
+
 void KernelCore::AddNamedPort(std::string name, SharedPtr<ClientPort> port) {
     impl->named_ports.emplace(std::move(name), std::move(port));
 }

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -18,6 +18,7 @@
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/resource_limit.h"
+#include "core/hle/kernel/scheduler.h"
 #include "core/hle/kernel/thread.h"
 #include "core/hle/lock.h"
 #include "core/hle/result.h"
@@ -140,6 +141,7 @@ struct KernelCore::Impl {
     // Lists all processes that exist in the current session.
     std::vector<SharedPtr<Process>> process_list;
     Process* current_process = nullptr;
+    Kernel::GlobalScheduler global_scheduler;
 
     SharedPtr<ResourceLimit> system_resource_limit;
 
@@ -201,6 +203,14 @@ const Process* KernelCore::CurrentProcess() const {
 
 const std::vector<SharedPtr<Process>>& KernelCore::GetProcessList() const {
     return impl->process_list;
+}
+
+Kernel::GlobalScheduler& KernelCore::GlobalScheduler() {
+    return impl->global_scheduler;
+}
+
+const Kernel::GlobalScheduler& KernelCore::GlobalScheduler() const {
+    return impl->global_scheduler;
 }
 
 void KernelCore::AddNamedPort(std::string name, SharedPtr<ClientPort> port) {

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -232,14 +232,6 @@ const Kernel::GlobalScheduler& KernelCore::GlobalScheduler() const {
     return impl->global_scheduler;
 }
 
-Core::System& KernelCore::System() {
-    return impl->system;
-}
-
-const Core::System& KernelCore::System() const {
-    return impl->system;
-}
-
 void KernelCore::AddNamedPort(std::string name, SharedPtr<ClientPort> port) {
     impl->named_ports.emplace(std::move(name), std::move(port));
 }

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -89,7 +89,7 @@ static void ThreadWakeupCallback(u64 thread_handle, [[maybe_unused]] s64 cycles_
 }
 
 struct KernelCore::Impl {
-    explicit Impl(Core::System& system) : system{system} {}
+    explicit Impl(Core::System& system) : system{system}, global_scheduler{system} {}
 
     void Initialize(KernelCore& kernel) {
         Shutdown();

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -25,6 +25,7 @@ class HandleTable;
 class Process;
 class ResourceLimit;
 class Thread;
+class GlobalScheduler;
 
 /// Represents a single instance of the kernel.
 class KernelCore {
@@ -74,6 +75,12 @@ public:
 
     /// Retrieves the list of processes.
     const std::vector<SharedPtr<Process>>& GetProcessList() const;
+
+    /// Gets the sole instance of the global scheduler
+    Kernel::GlobalScheduler& GlobalScheduler();
+
+    /// Gets the sole instance of the global scheduler
+    const Kernel::GlobalScheduler& GlobalScheduler() const;
 
     /// Adds a port to the named port table
     void AddNamedPort(std::string name, SharedPtr<ClientPort> port);

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -82,12 +82,6 @@ public:
     /// Gets the sole instance of the global scheduler
     const Kernel::GlobalScheduler& GlobalScheduler() const;
 
-    /// Gets the sole instance of the system
-    Core::System& System();
-
-    /// Gets the sole instance of the system
-    const Core::System& System() const;
-
     /// Adds a port to the named port table
     void AddNamedPort(std::string name, SharedPtr<ClientPort> port);
 

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -82,6 +82,12 @@ public:
     /// Gets the sole instance of the global scheduler
     const Kernel::GlobalScheduler& GlobalScheduler() const;
 
+    /// Gets the sole instance of the system
+    Core::System& System();
+
+    /// Gets the sole instance of the system
+    const Core::System& System() const;
+
     /// Adds a port to the named port table
     void AddNamedPort(std::string name, SharedPtr<ClientPort> port);
 

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -21,11 +21,11 @@ namespace Kernel {
 
 class AddressArbiter;
 class ClientPort;
+class GlobalScheduler;
 class HandleTable;
 class Process;
 class ResourceLimit;
 class Thread;
-class GlobalScheduler;
 
 /// Represents a single instance of the kernel.
 class KernelCore {

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -140,7 +140,7 @@ ResultCode Mutex::Release(VAddr address) {
     thread->SetMutexWaitAddress(0);
     thread->SetWaitHandle(0);
 
-    Core::System::GetInstance().PrepareReschedule();
+    system.PrepareReschedule();
 
     return RESULT_SUCCESS;
 }

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -139,6 +139,7 @@ ResultCode Mutex::Release(VAddr address) {
     thread->SetCondVarWaitAddress(0);
     thread->SetMutexWaitAddress(0);
     thread->SetWaitHandle(0);
+    thread->SetWaitSynchronizationResult(RESULT_SUCCESS);
 
     system.PrepareReschedule();
 

--- a/src/core/hle/kernel/mutex.cpp
+++ b/src/core/hle/kernel/mutex.cpp
@@ -140,6 +140,8 @@ ResultCode Mutex::Release(VAddr address) {
     thread->SetMutexWaitAddress(0);
     thread->SetWaitHandle(0);
 
+    Core::System::GetInstance().PrepareReschedule();
+
     return RESULT_SUCCESS;
 }
 } // namespace Kernel

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -213,10 +213,7 @@ void Process::PrepareForTermination() {
         }
     };
 
-    stop_threads(system.Scheduler(0).GetThreadList());
-    stop_threads(system.Scheduler(1).GetThreadList());
-    stop_threads(system.Scheduler(2).GetThreadList());
-    stop_threads(system.Scheduler(3).GetThreadList());
+    stop_threads(system.GlobalScheduler().GetThreadList());
 
     FreeTLSRegion(tls_region_address);
     tls_region_address = 0;

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -165,12 +165,12 @@ bool GlobalScheduler::YieldThreadAndBalanceLoad(Thread* yielding_thread) {
                     continue;
                 }
             }
-            if (next_thread->GetLastRunningTicks() >= thread->GetLastRunningTicks() ||
-                next_thread->GetPriority() < thread->GetPriority()) {
-                if (thread->GetPriority() <= priority) {
-                    winner = thread;
-                    break;
-                }
+        }
+        if (next_thread->GetLastRunningTicks() >= thread->GetLastRunningTicks() ||
+            next_thread->GetPriority() < thread->GetPriority()) {
+            if (thread->GetPriority() <= priority) {
+                winner = thread;
+                break;
             }
         }
     }
@@ -240,7 +240,7 @@ bool GlobalScheduler::YieldThreadAndWaitForLoadBalancing(Thread* yielding_thread
 
 void GlobalScheduler::PreemptThreads() {
     for (std::size_t core_id = 0; core_id < NUM_CPU_CORES; core_id++) {
-        const u64 priority = preemption_priorities[core_id];
+        const u32 priority = preemption_priorities[core_id];
         if (scheduled_queue[core_id].size(priority) > 1) {
             scheduled_queue[core_id].yield(priority);
             reselection_pending.store(true, std::memory_order_release);

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -3,6 +3,8 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <set>
+#include <unordered_set>
 #include <utility>
 
 #include "common/assert.h"
@@ -17,57 +19,286 @@
 
 namespace Kernel {
 
-std::mutex Scheduler::scheduler_mutex;
+void GlobalScheduler::AddThread(SharedPtr<Thread> thread) {
+    thread_list.push_back(std::move(thread));
+}
 
-Scheduler::Scheduler(Core::System& system, Core::ARM_Interface& cpu_core)
-    : cpu_core{cpu_core}, system{system} {}
+void GlobalScheduler::RemoveThread(Thread* thread) {
+    thread_list.erase(std::remove(thread_list.begin(), thread_list.end(), thread),
+                      thread_list.end());
+}
 
-Scheduler::~Scheduler() {
-    for (auto& thread : thread_list) {
-        thread->Stop();
+/*
+ * SelectThreads, Yield functions originally by TuxSH.
+ * licensed under GPLv2 or later under exception provided by the author.
+ */
+
+void GlobalScheduler::UnloadThread(s32 core) {
+    Scheduler& sched = Core::System::GetInstance().Scheduler(core);
+    sched.UnloadThread();
+}
+
+void GlobalScheduler::SelectThread(u32 core) {
+    auto update_thread = [](Thread* thread, Scheduler& sched) {
+        if (thread != sched.selected_thread) {
+            if (thread == nullptr) {
+                ++sched.idle_selection_count;
+            }
+            sched.selected_thread = thread;
+        }
+        sched.context_switch_pending = sched.selected_thread != sched.current_thread;
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+    };
+    Scheduler& sched = Core::System::GetInstance().Scheduler(core);
+    Thread* current_thread = nullptr;
+    current_thread = scheduled_queue[core].empty() ? nullptr : scheduled_queue[core].front();
+    if (!current_thread) {
+        Thread* winner = nullptr;
+        std::set<s32> sug_cores;
+        for (auto thread : suggested_queue[core]) {
+            s32 this_core = thread->GetProcessorID();
+            Thread* thread_on_core = nullptr;
+            if (this_core >= 0) {
+                thread_on_core = scheduled_queue[this_core].front();
+            }
+            if (this_core < 0 || thread != thread_on_core) {
+                winner = thread;
+                break;
+            }
+            sug_cores.insert(this_core);
+        }
+        if (winner && winner->GetPriority() > 2) {
+            if (winner->IsRunning()) {
+                UnloadThread(winner->GetProcessorID());
+            }
+            TransferToCore(winner->GetPriority(), core, winner);
+            current_thread = winner;
+        } else {
+            for (auto& src_core : sug_cores) {
+                auto it = scheduled_queue[src_core].begin();
+                it++;
+                if (it != scheduled_queue[src_core].end()) {
+                    Thread* thread_on_core = scheduled_queue[src_core].front();
+                    Thread* to_change = *it;
+                    if (thread_on_core->IsRunning() || to_change->IsRunning()) {
+                        UnloadThread(src_core);
+                    }
+                    TransferToCore(thread_on_core->GetPriority(), core, thread_on_core);
+                    current_thread = thread_on_core;
+                }
+            }
+        }
+    }
+    update_thread(current_thread, sched);
+}
+
+void GlobalScheduler::SelectThreads() {
+    auto update_thread = [](Thread* thread, Scheduler& sched) {
+        if (thread != sched.selected_thread) {
+            if (thread == nullptr) {
+                ++sched.idle_selection_count;
+            }
+            sched.selected_thread = thread;
+        }
+        sched.context_switch_pending = sched.selected_thread != sched.current_thread;
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+    };
+
+    auto& system = Core::System::GetInstance();
+
+    std::unordered_set<Thread*> picked_threads;
+    // This maintain the "current thread is on front of queue" invariant
+    std::array<Thread*, NUM_CPU_CORES> current_threads;
+    for (u32 i = 0; i < NUM_CPU_CORES; i++) {
+        Scheduler& sched = system.Scheduler(i);
+        current_threads[i] = scheduled_queue[i].empty() ? nullptr : scheduled_queue[i].front();
+        if (current_threads[i])
+            picked_threads.insert(current_threads[i]);
+        update_thread(current_threads[i], sched);
+    }
+
+    // Do some load-balancing. Allow second pass.
+    std::array<Thread*, NUM_CPU_CORES> current_threads_2 = current_threads;
+    for (u32 i = 0; i < NUM_CPU_CORES; i++) {
+        if (!scheduled_queue[i].empty()) {
+            continue;
+        }
+        Thread* winner = nullptr;
+        for (auto thread : suggested_queue[i]) {
+            if (thread->GetProcessorID() < 0 || thread != current_threads[i]) {
+                if (picked_threads.count(thread) == 0 && !thread->IsRunning()) {
+                    winner = thread;
+                    break;
+                }
+            }
+        }
+        if (winner) {
+            TransferToCore(winner->GetPriority(), i, winner);
+            current_threads_2[i] = winner;
+            picked_threads.insert(winner);
+        }
+    }
+
+    // See which to-be-current threads have changed & update accordingly
+    for (u32 i = 0; i < NUM_CPU_CORES; i++) {
+        Scheduler& sched = system.Scheduler(i);
+        if (current_threads_2[i] != current_threads[i]) {
+            update_thread(current_threads_2[i], sched);
+        }
+    }
+
+    reselection_pending.store(false, std::memory_order_release);
+}
+
+void GlobalScheduler::YieldThread(Thread* yielding_thread) {
+    // Note: caller should use critical section, etc.
+    u32 core_id = static_cast<u32>(yielding_thread->GetProcessorID());
+    u32 priority = yielding_thread->GetPriority();
+
+    // Yield the thread
+    ASSERT_MSG(yielding_thread == scheduled_queue[core_id].front(priority),
+               "Thread yielding without being in front");
+    scheduled_queue[core_id].yield(priority);
+
+    Thread* winner = scheduled_queue[core_id].front(priority);
+    AskForReselectionOrMarkRedundant(yielding_thread, winner);
+}
+
+void GlobalScheduler::YieldThreadAndBalanceLoad(Thread* yielding_thread) {
+    // Note: caller should check if !thread.IsSchedulerOperationRedundant and use critical section,
+    // etc.
+    u32 core_id = static_cast<u32>(yielding_thread->GetProcessorID());
+    u32 priority = yielding_thread->GetPriority();
+
+    // Yield the thread
+    ASSERT_MSG(yielding_thread == scheduled_queue[core_id].front(priority),
+               "Thread yielding without being in front");
+    scheduled_queue[core_id].yield(priority);
+
+    std::array<Thread*, NUM_CPU_CORES> current_threads;
+    for (u32 i = 0; i < NUM_CPU_CORES; i++) {
+        current_threads[i] = scheduled_queue[i].empty() ? nullptr : scheduled_queue[i].front();
+    }
+
+    Thread* next_thread = scheduled_queue[core_id].front(priority);
+    Thread* winner = nullptr;
+    for (auto& thread : suggested_queue[core_id]) {
+        s32 source_core = thread->GetProcessorID();
+        if (source_core >= 0) {
+            if (current_threads[source_core] != nullptr) {
+                if (thread == current_threads[source_core] ||
+                    current_threads[source_core]->GetPriority() < min_regular_priority)
+                    continue;
+            }
+            if (next_thread->GetLastRunningTicks() >= thread->GetLastRunningTicks() ||
+                next_thread->GetPriority() < thread->GetPriority()) {
+                if (thread->GetPriority() <= priority) {
+                    winner = thread;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (winner != nullptr) {
+        if (winner != yielding_thread) {
+            if (winner->IsRunning())
+                UnloadThread(winner->GetProcessorID());
+            TransferToCore(winner->GetPriority(), core_id, winner);
+        }
+    } else {
+        winner = next_thread;
+    }
+
+    AskForReselectionOrMarkRedundant(yielding_thread, winner);
+}
+
+void GlobalScheduler::YieldThreadAndWaitForLoadBalancing(Thread* yielding_thread) {
+    // Note: caller should check if !thread.IsSchedulerOperationRedundant and use critical section,
+    // etc.
+    Thread* winner = nullptr;
+    u32 core_id = static_cast<u32>(yielding_thread->GetProcessorID());
+
+    // Remove the thread from its scheduled mlq, put it on the corresponding "suggested" one instead
+    TransferToCore(yielding_thread->GetPriority(), -1, yielding_thread);
+
+    // If the core is idle, perform load balancing, excluding the threads that have just used this
+    // function...
+    if (scheduled_queue[core_id].empty()) {
+        // Here, "current_threads" is calculated after the ""yield"", unlike yield -1
+        std::array<Thread*, NUM_CPU_CORES> current_threads;
+        for (u32 i = 0; i < NUM_CPU_CORES; i++) {
+            current_threads[i] = scheduled_queue[i].empty() ? nullptr : scheduled_queue[i].front();
+        }
+        for (auto& thread : suggested_queue[core_id]) {
+            s32 source_core = thread->GetProcessorID();
+            if (source_core < 0 || thread == current_threads[source_core])
+                continue;
+            if (current_threads[source_core] == nullptr ||
+                current_threads[source_core]->GetPriority() >= min_regular_priority) {
+                winner = thread;
+            }
+            break;
+        }
+        if (winner != nullptr) {
+            if (winner != yielding_thread) {
+                if (winner->IsRunning())
+                    UnloadThread(winner->GetProcessorID());
+                TransferToCore(winner->GetPriority(), core_id, winner);
+            }
+        } else {
+            winner = yielding_thread;
+        }
+    }
+
+    AskForReselectionOrMarkRedundant(yielding_thread, winner);
+}
+
+void GlobalScheduler::AskForReselectionOrMarkRedundant(Thread* current_thread, Thread* winner) {
+    if (current_thread == winner) {
+        // Nintendo (not us) has a nullderef bug on current_thread->owner, but which is never
+        // triggered.
+        // current_thread->SetRedundantSchedulerOperation();
+    } else {
+        reselection_pending.store(true, std::memory_order_release);
     }
 }
 
+GlobalScheduler::~GlobalScheduler() = default;
+
+Scheduler::Scheduler(Core::System& system, Core::ARM_Interface& cpu_core, u32 id)
+    : system(system), cpu_core(cpu_core), id(id) {}
+
+Scheduler::~Scheduler() {}
+
 bool Scheduler::HaveReadyThreads() const {
-    std::lock_guard lock{scheduler_mutex};
-    return !ready_queue.empty();
+    return system.GlobalScheduler().HaveReadyThreads(id);
 }
 
 Thread* Scheduler::GetCurrentThread() const {
     return current_thread.get();
 }
 
+Thread* Scheduler::GetSelectedThread() const {
+    return selected_thread.get();
+}
+
+void Scheduler::SelectThreads() {
+    system.GlobalScheduler().SelectThread(id);
+}
+
 u64 Scheduler::GetLastContextSwitchTicks() const {
     return last_context_switch_time;
 }
 
-Thread* Scheduler::PopNextReadyThread() {
-    Thread* next = nullptr;
-    Thread* thread = GetCurrentThread();
-
-    if (thread && thread->GetStatus() == ThreadStatus::Running) {
-        if (ready_queue.empty()) {
-            return thread;
-        }
-        // We have to do better than the current thread.
-        // This call returns null when that's not possible.
-        next = ready_queue.front();
-        if (next == nullptr || next->GetPriority() >= thread->GetPriority()) {
-            next = thread;
-        }
-    } else {
-        if (ready_queue.empty()) {
-            return nullptr;
-        }
-        next = ready_queue.front();
-    }
-
-    return next;
+void Scheduler::TryDoContextSwitch() {
+    if (context_switch_pending)
+        SwitchContext();
 }
 
-void Scheduler::SwitchContext(Thread* new_thread) {
-    Thread* previous_thread = GetCurrentThread();
-    Process* const previous_process = system.Kernel().CurrentProcess();
+void Scheduler::UnloadThread() {
+    Thread* const previous_thread = GetCurrentThread();
+    Process* const previous_process = Core::CurrentProcess();
 
     UpdateLastContextSwitchTime(previous_thread, previous_process);
 
@@ -80,23 +311,51 @@ void Scheduler::SwitchContext(Thread* new_thread) {
         if (previous_thread->GetStatus() == ThreadStatus::Running) {
             // This is only the case when a reschedule is triggered without the current thread
             // yielding execution (i.e. an event triggered, system core time-sliced, etc)
-            ready_queue.add(previous_thread, previous_thread->GetPriority(), false);
             previous_thread->SetStatus(ThreadStatus::Ready);
         }
+        previous_thread->SetIsRunning(false);
+    }
+    current_thread = nullptr;
+}
+
+void Scheduler::SwitchContext() {
+    Thread* const previous_thread = GetCurrentThread();
+    Thread* const new_thread = GetSelectedThread();
+
+    context_switch_pending = false;
+    if (new_thread == previous_thread)
+        return;
+
+    Process* const previous_process = Core::CurrentProcess();
+
+    UpdateLastContextSwitchTime(previous_thread, previous_process);
+
+    // Save context for previous thread
+    if (previous_thread) {
+        cpu_core.SaveContext(previous_thread->GetContext());
+        // Save the TPIDR_EL0 system register in case it was modified.
+        previous_thread->SetTPIDR_EL0(cpu_core.GetTPIDR_EL0());
+
+        if (previous_thread->GetStatus() == ThreadStatus::Running) {
+            // This is only the case when a reschedule is triggered without the current thread
+            // yielding execution (i.e. an event triggered, system core time-sliced, etc)
+            previous_thread->SetStatus(ThreadStatus::Ready);
+        }
+        previous_thread->SetIsRunning(false);
     }
 
     // Load context of new thread
     if (new_thread) {
+        ASSERT_MSG(new_thread->GetProcessorID() == this->id,
+                   "Thread must be assigned to this core.");
         ASSERT_MSG(new_thread->GetStatus() == ThreadStatus::Ready,
                    "Thread must be ready to become running.");
 
         // Cancel any outstanding wakeup events for this thread
         new_thread->CancelWakeupTimer();
-
         current_thread = new_thread;
-
-        ready_queue.remove(new_thread, new_thread->GetPriority());
         new_thread->SetStatus(ThreadStatus::Running);
+        new_thread->SetIsRunning(true);
 
         auto* const thread_owner_process = current_thread->GetOwnerProcess();
         if (previous_process != thread_owner_process) {
@@ -116,7 +375,7 @@ void Scheduler::SwitchContext(Thread* new_thread) {
 
 void Scheduler::UpdateLastContextSwitchTime(Thread* thread, Process* process) {
     const u64 prev_switch_ticks = last_context_switch_time;
-    const u64 most_recent_switch_ticks = system.CoreTiming().GetTicks();
+    const u64 most_recent_switch_ticks = Core::System::GetInstance().CoreTiming().GetTicks();
     const u64 update_ticks = most_recent_switch_ticks - prev_switch_ticks;
 
     if (thread != nullptr) {
@@ -128,126 +387,6 @@ void Scheduler::UpdateLastContextSwitchTime(Thread* thread, Process* process) {
     }
 
     last_context_switch_time = most_recent_switch_ticks;
-}
-
-void Scheduler::Reschedule() {
-    std::lock_guard lock{scheduler_mutex};
-
-    Thread* cur = GetCurrentThread();
-    Thread* next = PopNextReadyThread();
-
-    if (cur && next) {
-        LOG_TRACE(Kernel, "context switch {} -> {}", cur->GetObjectId(), next->GetObjectId());
-    } else if (cur) {
-        LOG_TRACE(Kernel, "context switch {} -> idle", cur->GetObjectId());
-    } else if (next) {
-        LOG_TRACE(Kernel, "context switch idle -> {}", next->GetObjectId());
-    }
-
-    SwitchContext(next);
-}
-
-void Scheduler::AddThread(SharedPtr<Thread> thread) {
-    std::lock_guard lock{scheduler_mutex};
-
-    thread_list.push_back(std::move(thread));
-}
-
-void Scheduler::RemoveThread(Thread* thread) {
-    std::lock_guard lock{scheduler_mutex};
-
-    thread_list.erase(std::remove(thread_list.begin(), thread_list.end(), thread),
-                      thread_list.end());
-}
-
-void Scheduler::ScheduleThread(Thread* thread, u32 priority) {
-    std::lock_guard lock{scheduler_mutex};
-
-    ASSERT(thread->GetStatus() == ThreadStatus::Ready);
-    ready_queue.add(thread, priority);
-}
-
-void Scheduler::UnscheduleThread(Thread* thread, u32 priority) {
-    std::lock_guard lock{scheduler_mutex};
-
-    ASSERT(thread->GetStatus() == ThreadStatus::Ready);
-    ready_queue.remove(thread, priority);
-}
-
-void Scheduler::SetThreadPriority(Thread* thread, u32 priority) {
-    std::lock_guard lock{scheduler_mutex};
-    if (thread->GetPriority() == priority) {
-        return;
-    }
-
-    // If thread was ready, adjust queues
-    if (thread->GetStatus() == ThreadStatus::Ready)
-        ready_queue.adjust(thread, thread->GetPriority(), priority);
-}
-
-Thread* Scheduler::GetNextSuggestedThread(u32 core, u32 maximum_priority) const {
-    std::lock_guard lock{scheduler_mutex};
-
-    const u32 mask = 1U << core;
-    for (auto* thread : ready_queue) {
-        if ((thread->GetAffinityMask() & mask) != 0 && thread->GetPriority() < maximum_priority) {
-            return thread;
-        }
-    }
-    return nullptr;
-}
-
-void Scheduler::YieldWithoutLoadBalancing(Thread* thread) {
-    ASSERT(thread != nullptr);
-    // Avoid yielding if the thread isn't even running.
-    ASSERT(thread->GetStatus() == ThreadStatus::Running);
-
-    // Sanity check that the priority is valid
-    ASSERT(thread->GetPriority() < THREADPRIO_COUNT);
-
-    // Yield this thread -- sleep for zero time and force reschedule to different thread
-    GetCurrentThread()->Sleep(0);
-}
-
-void Scheduler::YieldWithLoadBalancing(Thread* thread) {
-    ASSERT(thread != nullptr);
-    const auto priority = thread->GetPriority();
-    const auto core = static_cast<u32>(thread->GetProcessorID());
-
-    // Avoid yielding if the thread isn't even running.
-    ASSERT(thread->GetStatus() == ThreadStatus::Running);
-
-    // Sanity check that the priority is valid
-    ASSERT(priority < THREADPRIO_COUNT);
-
-    // Sleep for zero time to be able to force reschedule to different thread
-    GetCurrentThread()->Sleep(0);
-
-    Thread* suggested_thread = nullptr;
-
-    // Search through all of the cpu cores (except this one) for a suggested thread.
-    // Take the first non-nullptr one
-    for (unsigned cur_core = 0; cur_core < Core::NUM_CPU_CORES; ++cur_core) {
-        const auto res =
-            system.CpuCore(cur_core).Scheduler().GetNextSuggestedThread(core, priority);
-
-        // If scheduler provides a suggested thread
-        if (res != nullptr) {
-            // And its better than the current suggested thread (or is the first valid one)
-            if (suggested_thread == nullptr ||
-                suggested_thread->GetPriority() > res->GetPriority()) {
-                suggested_thread = res;
-            }
-        }
-    }
-
-    // If a suggested thread was found, queue that for this core
-    if (suggested_thread != nullptr)
-        suggested_thread->ChangeCore(core, suggested_thread->GetAffinityMask());
-}
-
-void Scheduler::YieldAndWaitForLoadBalancing(Thread* thread) {
-    UNIMPLEMENTED_MSG("Wait for load balancing thread yield type is not implemented!");
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -342,6 +342,14 @@ bool GlobalScheduler::AskForReselectionOrMarkRedundant(Thread* current_thread, T
     }
 }
 
+void GlobalScheduler::Shutdown() {
+    for (std::size_t core = 0; core < NUM_CPU_CORES; core++) {
+        scheduled_queue[core].clear();
+        suggested_queue[core].clear();
+    }
+    thread_list.clear();
+}
+
 GlobalScheduler::~GlobalScheduler() = default;
 
 Scheduler::Scheduler(Core::System& system, Core::ARM_Interface& cpu_core, u32 core_id)

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -281,7 +281,8 @@ void GlobalScheduler::PreemptThreads() {
                 UnloadThread(winner->GetProcessorID());
             }
             TransferToCore(winner->GetPriority(), core_id, winner);
-            current_thread = winner->GetPriority() <= current_thread->GetPriority() ? winner : current_thread;
+            current_thread =
+                winner->GetPriority() <= current_thread->GetPriority() ? winner : current_thread;
         }
 
         if (current_thread != nullptr && current_thread->GetPriority() > priority) {

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -414,7 +414,7 @@ u64 Scheduler::GetLastContextSwitchTicks() const {
 }
 
 void Scheduler::TryDoContextSwitch() {
-    if (is_context_switch_pending ) {
+    if (is_context_switch_pending) {
         SwitchContext();
     }
 }

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -287,7 +287,7 @@ void GlobalScheduler::PreemptThreads() {
         if (current_thread != nullptr && current_thread->GetPriority() > priority) {
             for (auto& thread : suggested_queue[core_id]) {
                 const s32 source_core = thread->GetProcessorID();
-                if (thread->GetPriority() > priority) {
+                if (thread->GetPriority() < priority) {
                     continue;
                 }
                 if (source_core >= 0) {

--- a/src/core/hle/kernel/scheduler.h
+++ b/src/core/hle/kernel/scheduler.h
@@ -20,124 +20,141 @@ namespace Kernel {
 
 class Process;
 
-class Scheduler final {
+class GlobalScheduler final {
 public:
-    explicit Scheduler(Core::System& system, Core::ARM_Interface& cpu_core);
-    ~Scheduler();
+    static constexpr u32 NUM_CPU_CORES = 4;
 
-    /// Returns whether there are any threads that are ready to run.
-    bool HaveReadyThreads() const;
-
-    /// Reschedules to the next available thread (call after current thread is suspended)
-    void Reschedule();
-
-    /// Gets the current running thread
-    Thread* GetCurrentThread() const;
-
-    /// Gets the timestamp for the last context switch in ticks.
-    u64 GetLastContextSwitchTicks() const;
-
+    GlobalScheduler() {
+        reselection_pending = false;
+    }
+    ~GlobalScheduler();
     /// Adds a new thread to the scheduler
     void AddThread(SharedPtr<Thread> thread);
 
     /// Removes a thread from the scheduler
     void RemoveThread(Thread* thread);
 
-    /// Schedules a thread that has become "ready"
-    void ScheduleThread(Thread* thread, u32 priority);
-
-    /// Unschedules a thread that was already scheduled
-    void UnscheduleThread(Thread* thread, u32 priority);
-
-    /// Sets the priority of a thread in the scheduler
-    void SetThreadPriority(Thread* thread, u32 priority);
-
-    /// Gets the next suggested thread for load balancing
-    Thread* GetNextSuggestedThread(u32 core, u32 minimum_priority) const;
-
-    /**
-     * YieldWithoutLoadBalancing -- analogous to normal yield on a system
-     * Moves the thread to the end of the ready queue for its priority, and then reschedules the
-     * system to the new head of the queue.
-     *
-     * Example (Single Core -- but can be extrapolated to multi):
-     * ready_queue[prio=0]: ThreadA, ThreadB, ThreadC (->exec order->)
-     * Currently Running: ThreadR
-     *
-     * ThreadR calls YieldWithoutLoadBalancing
-     *
-     * ThreadR is moved to the end of ready_queue[prio=0]:
-     * ready_queue[prio=0]: ThreadA, ThreadB, ThreadC, ThreadR (->exec order->)
-     * Currently Running: Nothing
-     *
-     * System is rescheduled (ThreadA is popped off of queue):
-     * ready_queue[prio=0]: ThreadB, ThreadC, ThreadR (->exec order->)
-     * Currently Running: ThreadA
-     *
-     * If the queue is empty at time of call, no yielding occurs. This does not cross between cores
-     * or priorities at all.
-     */
-    void YieldWithoutLoadBalancing(Thread* thread);
-
-    /**
-     * YieldWithLoadBalancing -- yield but with better selection of the new running thread
-     * Moves the current thread to the end of the ready queue for its priority, then selects a
-     * 'suggested thread' (a thread on a different core that could run on this core) from the
-     * scheduler, changes its core, and reschedules the current core to that thread.
-     *
-     * Example (Dual Core -- can be extrapolated to Quad Core, this is just normal yield if it were
-     * single core):
-     * ready_queue[core=0][prio=0]: ThreadA, ThreadB (affinities not pictured as irrelevant
-     * ready_queue[core=1][prio=0]: ThreadC[affinity=both], ThreadD[affinity=core1only]
-     * Currently Running: ThreadQ on Core 0 || ThreadP on Core 1
-     *
-     * ThreadQ calls YieldWithLoadBalancing
-     *
-     * ThreadQ is moved to the end of ready_queue[core=0][prio=0]:
-     * ready_queue[core=0][prio=0]: ThreadA, ThreadB
-     * ready_queue[core=1][prio=0]: ThreadC[affinity=both], ThreadD[affinity=core1only]
-     * Currently Running: ThreadQ on Core 0 || ThreadP on Core 1
-     *
-     * A list of suggested threads for each core is compiled
-     * Suggested Threads: {ThreadC on Core 1}
-     * If this were quad core (as the switch is), there could be between 0 and 3 threads in this
-     * list. If there are more than one, the thread is selected by highest prio.
-     *
-     * ThreadC is core changed to Core 0:
-     * ready_queue[core=0][prio=0]: ThreadC, ThreadA, ThreadB, ThreadQ
-     * ready_queue[core=1][prio=0]: ThreadD
-     * Currently Running: None on Core 0 || ThreadP on Core 1
-     *
-     * System is rescheduled (ThreadC is popped off of queue):
-     * ready_queue[core=0][prio=0]: ThreadA, ThreadB, ThreadQ
-     * ready_queue[core=1][prio=0]: ThreadD
-     * Currently Running: ThreadC on Core 0 || ThreadP on Core 1
-     *
-     * If no suggested threads can be found this will behave just as normal yield. If there are
-     * multiple candidates for the suggested thread on a core, the highest prio is taken.
-     */
-    void YieldWithLoadBalancing(Thread* thread);
-
-    /// Currently unknown -- asserts as unimplemented on call
-    void YieldAndWaitForLoadBalancing(Thread* thread);
-
     /// Returns a list of all threads managed by the scheduler
     const std::vector<SharedPtr<Thread>>& GetThreadList() const {
         return thread_list;
     }
 
-private:
-    /**
-     * Pops and returns the next thread from the thread queue
-     * @return A pointer to the next ready thread
-     */
-    Thread* PopNextReadyThread();
+    void Suggest(u32 priority, u32 core, Thread* thread) {
+        suggested_queue[core].add(thread, priority);
+    }
 
+    void Unsuggest(u32 priority, u32 core, Thread* thread) {
+        suggested_queue[core].remove(thread, priority);
+    }
+
+    void Schedule(u32 priority, u32 core, Thread* thread) {
+        ASSERT_MSG(thread->GetProcessorID() == core,
+                   "Thread must be assigned to this core.");
+        scheduled_queue[core].add(thread, priority);
+    }
+
+    void SchedulePrepend(u32 priority, u32 core, Thread* thread) {
+        ASSERT_MSG(thread->GetProcessorID() == core,
+                   "Thread must be assigned to this core.");
+        scheduled_queue[core].add(thread, priority, false);
+    }
+
+    void Reschedule(u32 priority, u32 core, Thread* thread) {
+        scheduled_queue[core].remove(thread, priority);
+        scheduled_queue[core].add(thread, priority);
+    }
+
+    void Unschedule(u32 priority, u32 core, Thread* thread) {
+        scheduled_queue[core].remove(thread, priority);
+    }
+
+    void TransferToCore(u32 priority, s32 destination_core, Thread* thread) {
+        bool schedulable = thread->GetPriority() < THREADPRIO_COUNT;
+        s32 source_core = thread->GetProcessorID();
+        if (source_core == destination_core || !schedulable)
+            return;
+        thread->SetProcessorID(destination_core);
+        if (source_core >= 0)
+            Unschedule(priority, source_core, thread);
+        if (destination_core >= 0) {
+            Unsuggest(priority, destination_core, thread);
+            Schedule(priority, destination_core, thread);
+        }
+        if (source_core >= 0)
+            Suggest(priority, source_core, thread);
+    }
+
+    void UnloadThread(s32 core);
+
+    void SelectThreads();
+    void SelectThread(u32 core);
+
+    bool HaveReadyThreads(u32 core_id) {
+        return !scheduled_queue[core_id].empty();
+    }
+
+    void YieldThread(Thread* thread);
+    void YieldThreadAndBalanceLoad(Thread* thread);
+    void YieldThreadAndWaitForLoadBalancing(Thread* thread);
+
+    u32 CpuCoresCount() const {
+        return NUM_CPU_CORES;
+    }
+
+    void SetReselectionPending() {
+        reselection_pending.store(true, std::memory_order_release);
+    }
+
+    bool IsReselectionPending() {
+        return reselection_pending.load(std::memory_order_acquire);
+    }
+
+private:
+    void AskForReselectionOrMarkRedundant(Thread* current_thread, Thread* winner);
+
+    static constexpr u32 min_regular_priority = 2;
+    std::array<Common::MultiLevelQueue<Thread*, THREADPRIO_COUNT>, NUM_CPU_CORES> scheduled_queue;
+    std::array<Common::MultiLevelQueue<Thread*, THREADPRIO_COUNT>, NUM_CPU_CORES> suggested_queue;
+    std::atomic<bool> reselection_pending;
+
+    /// Lists all thread ids that aren't deleted/etc.
+    std::vector<SharedPtr<Thread>> thread_list;
+};
+
+class Scheduler final {
+public:
+    explicit Scheduler(Core::System& system, Core::ARM_Interface& cpu_core, const u32 id);
+    ~Scheduler();
+
+    /// Returns whether there are any threads that are ready to run.
+    bool HaveReadyThreads() const;
+
+    /// Reschedules to the next available thread (call after current thread is suspended)
+    void TryDoContextSwitch();
+
+    void UnloadThread();
+
+    void SelectThreads();
+
+    /// Gets the current running thread
+    Thread* GetCurrentThread() const;
+
+    Thread* GetSelectedThread() const;
+
+    /// Gets the timestamp for the last context switch in ticks.
+    u64 GetLastContextSwitchTicks() const;
+
+    bool ContextSwitchPending() const {
+        return context_switch_pending;
+    }
+
+private:
+    friend class GlobalScheduler;
     /**
      * Switches the CPU's active thread context to that of the specified thread
      * @param new_thread The thread to switch to
      */
-    void SwitchContext(Thread* new_thread);
+    void SwitchContext();
 
     /**
      * Called on every context switch to update the internal timestamp
@@ -152,19 +169,16 @@ private:
      */
     void UpdateLastContextSwitchTime(Thread* thread, Process* process);
 
-    /// Lists all thread ids that aren't deleted/etc.
-    std::vector<SharedPtr<Thread>> thread_list;
-
-    /// Lists only ready thread ids.
-    Common::MultiLevelQueue<Thread*, THREADPRIO_LOWEST + 1> ready_queue;
-
     SharedPtr<Thread> current_thread = nullptr;
-
-    Core::ARM_Interface& cpu_core;
-    u64 last_context_switch_time = 0;
+    SharedPtr<Thread> selected_thread = nullptr;
 
     Core::System& system;
-    static std::mutex scheduler_mutex;
+    Core::ARM_Interface& cpu_core;
+    u64 last_context_switch_time = 0;
+    u64 idle_selection_count = 0;
+    const u32 id;
+
+    bool context_switch_pending = false;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/scheduler.h
+++ b/src/core/hle/kernel/scheduler.h
@@ -155,7 +155,7 @@ private:
     std::array<Common::MultiLevelQueue<Thread*, THREADPRIO_COUNT>, NUM_CPU_CORES> suggested_queue;
     std::atomic<bool> reselection_pending;
 
-    std::array<u64, NUM_CPU_CORES> preemption_priorities = {59, 59, 59, 62};
+    std::array<u32, NUM_CPU_CORES> preemption_priorities = {59, 59, 59, 62};
 
     /// Lists all thread ids that aren't deleted/etc.
     std::vector<SharedPtr<Thread>> thread_list;

--- a/src/core/hle/kernel/scheduler.h
+++ b/src/core/hle/kernel/scheduler.h
@@ -133,6 +133,8 @@ public:
      */
     bool YieldThreadAndWaitForLoadBalancing(Thread* thread);
 
+    void PreemptThreads();
+
     u32 CpuCoresCount() const {
         return NUM_CPU_CORES;
     }
@@ -152,6 +154,8 @@ private:
     std::array<Common::MultiLevelQueue<Thread*, THREADPRIO_COUNT>, NUM_CPU_CORES> scheduled_queue;
     std::array<Common::MultiLevelQueue<Thread*, THREADPRIO_COUNT>, NUM_CPU_CORES> suggested_queue;
     std::atomic<bool> reselection_pending;
+
+    std::array<u64, NUM_CPU_CORES> preemption_priorities = {59, 59, 59, 62};
 
     /// Lists all thread ids that aren't deleted/etc.
     std::vector<SharedPtr<Thread>> thread_list;

--- a/src/core/hle/kernel/scheduler.h
+++ b/src/core/hle/kernel/scheduler.h
@@ -115,7 +115,7 @@ public:
      * YieldThread takes a thread and moves it to the back of the it's priority list
      * This operation can be redundant and no scheduling is changed if marked as so.
      */
-    void YieldThread(Thread* thread);
+    bool YieldThread(Thread* thread);
 
     /*
      * YieldThreadAndBalanceLoad takes a thread and moves it to the back of the it's priority list.
@@ -123,7 +123,7 @@ public:
      * a better priority than the next thread in the core.
      * This operation can be redundant and no scheduling is changed if marked as so.
      */
-    void YieldThreadAndBalanceLoad(Thread* thread);
+    bool YieldThreadAndBalanceLoad(Thread* thread);
 
     /*
      * YieldThreadAndWaitForLoadBalancing takes a thread and moves it out of the scheduling queue
@@ -131,7 +131,7 @@ public:
      * a suggested thread is obtained instead.
      * This operation can be redundant and no scheduling is changed if marked as so.
      */
-    void YieldThreadAndWaitForLoadBalancing(Thread* thread);
+    bool YieldThreadAndWaitForLoadBalancing(Thread* thread);
 
     u32 CpuCoresCount() const {
         return NUM_CPU_CORES;
@@ -146,7 +146,7 @@ public:
     }
 
 private:
-    void AskForReselectionOrMarkRedundant(Thread* current_thread, Thread* winner);
+    bool AskForReselectionOrMarkRedundant(Thread* current_thread, Thread* winner);
 
     static constexpr u32 min_regular_priority = 2;
     std::array<Common::MultiLevelQueue<Thread*, THREADPRIO_COUNT>, NUM_CPU_CORES> scheduled_queue;

--- a/src/core/hle/kernel/scheduler.h
+++ b/src/core/hle/kernel/scheduler.h
@@ -147,6 +147,8 @@ public:
         return reselection_pending.load();
     }
 
+    void Shutdown();
+
 private:
     bool AskForReselectionOrMarkRedundant(Thread* current_thread, Thread* winner);
 
@@ -187,6 +189,11 @@ public:
 
     bool ContextSwitchPending() const {
         return context_switch_pending;
+    }
+
+    void Shutdown() {
+        current_thread = nullptr;
+        selected_thread = nullptr;
     }
 
 private:

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -516,7 +516,7 @@ static ResultCode WaitSynchronization(Core::System& system, Handle* index, VAddr
     thread->WakeAfterDelay(nano_seconds);
     thread->SetWakeupCallback(DefaultThreadWakeupCallback);
 
-    system.CpuCore(thread->GetProcessorID()).PrepareReschedule();
+    system.PrepareReschedule(thread->GetProcessorID());
 
     return RESULT_TIMEOUT;
 }
@@ -534,8 +534,7 @@ static ResultCode CancelSynchronization(Core::System& system, Handle thread_hand
     }
 
     thread->CancelWait();
-    if (thread->GetProcessorID() >= 0)
-        Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
+    system.PrepareReschedule(thread->GetProcessorID());
     return RESULT_SUCCESS;
 }
 
@@ -1069,8 +1068,7 @@ static ResultCode SetThreadActivity(Core::System& system, Handle handle, u32 act
 
     thread->SetActivity(static_cast<ThreadActivity>(activity));
 
-    if (thread->GetProcessorID() >= 0)
-        Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
+    system.PrepareReschedule(thread->GetProcessorID());
     return RESULT_SUCCESS;
 }
 
@@ -1152,8 +1150,7 @@ static ResultCode SetThreadPriority(Core::System& system, Handle handle, u32 pri
 
     thread->SetPriority(priority);
 
-    if (thread->GetProcessorID() >= 0)
-        Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
+    system.PrepareReschedule(thread->GetProcessorID());
     return RESULT_SUCCESS;
 }
 
@@ -1509,8 +1506,7 @@ static ResultCode CreateThread(Core::System& system, Handle* out_handle, VAddr e
     thread->SetName(
         fmt::format("thread[entry_point={:X}, handle={:X}]", entry_point, *new_thread_handle));
 
-    if (thread->GetProcessorID() >= 0)
-        Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
+    system.PrepareReschedule(thread->GetProcessorID());
 
     return RESULT_SUCCESS;
 }
@@ -1532,10 +1528,7 @@ static ResultCode StartThread(Core::System& system, Handle thread_handle) {
     thread->ResumeFromWait();
 
     if (thread->GetStatus() == ThreadStatus::Ready) {
-        if (thread->GetProcessorID() >= 0)
-            Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
-        else
-            Core::System::GetInstance().GlobalScheduler().SetReselectionPending();
+        system.PrepareReschedule(thread->GetProcessorID());
     }
 
     return RESULT_SUCCESS;
@@ -1582,10 +1575,7 @@ static void SleepThread(Core::System& system, s64 nanoseconds) {
         current_thread->Sleep(nanoseconds);
     }
 
-    // Reschedule all CPU cores
-    for (std::size_t i = 0; i < Core::NUM_CPU_CORES; ++i) {
-        system.CpuCore(i).PrepareReschedule();
-    }
+    system.PrepareReschedule(current_thread->GetProcessorID());
 }
 
 /// Wait process wide key atomic
@@ -1632,7 +1622,7 @@ static ResultCode WaitProcessWideKeyAtomic(Core::System& system, VAddr mutex_add
 
     // Note: Deliberately don't attempt to inherit the lock owner's priority.
 
-    system.CpuCore(current_thread->GetProcessorID()).PrepareReschedule();
+    system.PrepareReschedule(current_thread->GetProcessorID());
     return RESULT_SUCCESS;
 }
 
@@ -1644,7 +1634,7 @@ static ResultCode SignalProcessWideKey(Core::System& system, VAddr condition_var
 
     // Retrieve a list of all threads that are waiting for this condition variable.
     std::vector<SharedPtr<Thread>> waiting_threads;
-    const auto& scheduler = Core::System::GetInstance().GlobalScheduler();
+    const auto& scheduler = system.GlobalScheduler();
     const auto& thread_list = scheduler.GetThreadList();
 
     for (const auto& thread : thread_list) {
@@ -1706,8 +1696,7 @@ static ResultCode SignalProcessWideKey(Core::System& system, VAddr condition_var
             thread->SetLockOwner(nullptr);
             thread->SetMutexWaitAddress(0);
             thread->SetWaitHandle(0);
-            if (thread->GetProcessorID() >= 0)
-                Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
+            system.PrepareReschedule(thread->GetProcessorID());
         } else {
             // Atomically signal that the mutex now has a waiting thread.
             do {
@@ -1731,8 +1720,7 @@ static ResultCode SignalProcessWideKey(Core::System& system, VAddr condition_var
             thread->SetStatus(ThreadStatus::WaitMutex);
 
             owner->AddMutexWaiter(thread);
-            if (thread->GetProcessorID() >= 0)
-                Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
+            system.PrepareReschedule(thread->GetProcessorID());
         }
     }
 
@@ -1758,13 +1746,10 @@ static ResultCode WaitForAddress(Core::System& system, VAddr address, u32 type, 
     }
 
     const auto arbitration_type = static_cast<AddressArbiter::ArbitrationType>(type);
-    auto& address_arbiter =
-        system.Kernel().CurrentProcess()->GetAddressArbiter();
+    auto& address_arbiter = system.Kernel().CurrentProcess()->GetAddressArbiter();
     ResultCode result = address_arbiter.WaitForAddress(address, arbitration_type, value, timeout);
     if (result == RESULT_SUCCESS)
-        Core::System::GetInstance()
-            .CpuCore(GetCurrentThread()->GetProcessorID())
-            .PrepareReschedule();
+        system.PrepareReschedule();
     return result;
 }
 
@@ -2051,10 +2036,10 @@ static ResultCode SetThreadCoreMask(Core::System& system, Handle thread_handle, 
         return ERR_INVALID_HANDLE;
     }
 
-    Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
+    system.PrepareReschedule(thread->GetProcessorID());
     thread->ChangeCore(core, affinity_mask);
-    if (thread->GetProcessorID() >= 0)
-        Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
+    system.PrepareReschedule(thread->GetProcessorID());
+
     return RESULT_SUCCESS;
 }
 
@@ -2165,7 +2150,7 @@ static ResultCode SignalEvent(Core::System& system, Handle handle) {
     }
 
     writable_event->Signal();
-    Core::System::GetInstance().PrepareReschedule();
+    system.PrepareReschedule();
     return RESULT_SUCCESS;
 }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -534,6 +534,8 @@ static ResultCode CancelSynchronization(Core::System& system, Handle thread_hand
     }
 
     thread->CancelWait();
+    if (thread->GetProcessorID() >= 0)
+        Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
     return RESULT_SUCCESS;
 }
 
@@ -1066,6 +1068,9 @@ static ResultCode SetThreadActivity(Core::System& system, Handle handle, u32 act
     }
 
     thread->SetActivity(static_cast<ThreadActivity>(activity));
+
+    if (thread->GetProcessorID() >= 0)
+        Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
     return RESULT_SUCCESS;
 }
 
@@ -1147,7 +1152,8 @@ static ResultCode SetThreadPriority(Core::System& system, Handle handle, u32 pri
 
     thread->SetPriority(priority);
 
-    system.CpuCore(thread->GetProcessorID()).PrepareReschedule();
+    if (thread->GetProcessorID() >= 0)
+        Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
     return RESULT_SUCCESS;
 }
 
@@ -1503,7 +1509,8 @@ static ResultCode CreateThread(Core::System& system, Handle* out_handle, VAddr e
     thread->SetName(
         fmt::format("thread[entry_point={:X}, handle={:X}]", entry_point, *new_thread_handle));
 
-    system.CpuCore(thread->GetProcessorID()).PrepareReschedule();
+    if (thread->GetProcessorID() >= 0)
+        Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
 
     return RESULT_SUCCESS;
 }
@@ -1525,7 +1532,10 @@ static ResultCode StartThread(Core::System& system, Handle thread_handle) {
     thread->ResumeFromWait();
 
     if (thread->GetStatus() == ThreadStatus::Ready) {
-        system.CpuCore(thread->GetProcessorID()).PrepareReschedule();
+        if (thread->GetProcessorID() >= 0)
+            Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
+        else
+            Core::System::GetInstance().GlobalScheduler().SetReselectionPending();
     }
 
     return RESULT_SUCCESS;
@@ -1537,7 +1547,7 @@ static void ExitThread(Core::System& system) {
 
     auto* const current_thread = system.CurrentScheduler().GetCurrentThread();
     current_thread->Stop();
-    system.CurrentScheduler().RemoveThread(current_thread);
+    system.GlobalScheduler().RemoveThread(current_thread);
     system.PrepareReschedule();
 }
 
@@ -1557,13 +1567,13 @@ static void SleepThread(Core::System& system, s64 nanoseconds) {
     if (nanoseconds <= 0) {
         switch (static_cast<SleepType>(nanoseconds)) {
         case SleepType::YieldWithoutLoadBalancing:
-            scheduler.YieldWithoutLoadBalancing(current_thread);
+            current_thread->YieldType0();
             break;
         case SleepType::YieldWithLoadBalancing:
-            scheduler.YieldWithLoadBalancing(current_thread);
+            current_thread->YieldType1();
             break;
         case SleepType::YieldAndWaitForLoadBalancing:
-            scheduler.YieldAndWaitForLoadBalancing(current_thread);
+            current_thread->YieldType2();
             break;
         default:
             UNREACHABLE_MSG("Unimplemented sleep yield type '{:016X}'!", nanoseconds);
@@ -1632,24 +1642,16 @@ static ResultCode SignalProcessWideKey(Core::System& system, VAddr condition_var
     LOG_TRACE(Kernel_SVC, "called, condition_variable_addr=0x{:X}, target=0x{:08X}",
               condition_variable_addr, target);
 
-    const auto RetrieveWaitingThreads = [&system](std::size_t core_index,
-                                                  std::vector<SharedPtr<Thread>>& waiting_threads,
-                                                  VAddr condvar_addr) {
-        const auto& scheduler = system.Scheduler(core_index);
-        const auto& thread_list = scheduler.GetThreadList();
-
-        for (const auto& thread : thread_list) {
-            if (thread->GetCondVarWaitAddress() == condvar_addr)
-                waiting_threads.push_back(thread);
-        }
-    };
-
     // Retrieve a list of all threads that are waiting for this condition variable.
     std::vector<SharedPtr<Thread>> waiting_threads;
-    RetrieveWaitingThreads(0, waiting_threads, condition_variable_addr);
-    RetrieveWaitingThreads(1, waiting_threads, condition_variable_addr);
-    RetrieveWaitingThreads(2, waiting_threads, condition_variable_addr);
-    RetrieveWaitingThreads(3, waiting_threads, condition_variable_addr);
+    const auto& scheduler = Core::System::GetInstance().GlobalScheduler();
+    const auto& thread_list = scheduler.GetThreadList();
+
+    for (const auto& thread : thread_list) {
+        if (thread->GetCondVarWaitAddress() == condition_variable_addr)
+            waiting_threads.push_back(thread);
+    }
+
     // Sort them by priority, such that the highest priority ones come first.
     std::sort(waiting_threads.begin(), waiting_threads.end(),
               [](const SharedPtr<Thread>& lhs, const SharedPtr<Thread>& rhs) {
@@ -1704,7 +1706,8 @@ static ResultCode SignalProcessWideKey(Core::System& system, VAddr condition_var
             thread->SetLockOwner(nullptr);
             thread->SetMutexWaitAddress(0);
             thread->SetWaitHandle(0);
-            system.CpuCore(thread->GetProcessorID()).PrepareReschedule();
+            if (thread->GetProcessorID() >= 0)
+                Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
         } else {
             // Atomically signal that the mutex now has a waiting thread.
             do {
@@ -1728,6 +1731,8 @@ static ResultCode SignalProcessWideKey(Core::System& system, VAddr condition_var
             thread->SetStatus(ThreadStatus::WaitMutex);
 
             owner->AddMutexWaiter(thread);
+            if (thread->GetProcessorID() >= 0)
+                Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
         }
     }
 
@@ -1753,8 +1758,14 @@ static ResultCode WaitForAddress(Core::System& system, VAddr address, u32 type, 
     }
 
     const auto arbitration_type = static_cast<AddressArbiter::ArbitrationType>(type);
-    auto& address_arbiter = system.Kernel().CurrentProcess()->GetAddressArbiter();
-    return address_arbiter.WaitForAddress(address, arbitration_type, value, timeout);
+    auto& address_arbiter =
+        system.Kernel().CurrentProcess()->GetAddressArbiter();
+    ResultCode result = address_arbiter.WaitForAddress(address, arbitration_type, value, timeout);
+    if (result == RESULT_SUCCESS)
+        Core::System::GetInstance()
+            .CpuCore(GetCurrentThread()->GetProcessorID())
+            .PrepareReschedule();
+    return result;
 }
 
 // Signals to an address (via Address Arbiter)
@@ -2040,7 +2051,10 @@ static ResultCode SetThreadCoreMask(Core::System& system, Handle thread_handle, 
         return ERR_INVALID_HANDLE;
     }
 
+    Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
     thread->ChangeCore(core, affinity_mask);
+    if (thread->GetProcessorID() >= 0)
+        Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
     return RESULT_SUCCESS;
 }
 
@@ -2151,6 +2165,7 @@ static ResultCode SignalEvent(Core::System& system, Handle handle) {
     }
 
     writable_event->Signal();
+    Core::System::GetInstance().PrepareReschedule();
     return RESULT_SUCCESS;
 }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1608,6 +1608,8 @@ static ResultCode WaitProcessWideKeyAtomic(Core::System& system, VAddr mutex_add
         return ERR_INVALID_ADDRESS;
     }
 
+    ASSERT(condition_variable_addr == Common::AlignDown(condition_variable_addr, 4));
+
     auto* const current_process = system.Kernel().CurrentProcess();
     const auto& handle_table = current_process->GetHandleTable();
     SharedPtr<Thread> thread = handle_table.Get<Thread>(thread_handle);
@@ -1638,6 +1640,8 @@ static ResultCode SignalProcessWideKey(Core::System& system, VAddr condition_var
                                        s32 target) {
     LOG_TRACE(Kernel_SVC, "called, condition_variable_addr=0x{:X}, target=0x{:08X}",
               condition_variable_addr, target);
+
+    ASSERT(condition_variable_addr == Common::AlignDown(condition_variable_addr, 4));
 
     // Retrieve a list of all threads that are waiting for this condition variable.
     std::vector<SharedPtr<Thread>> waiting_threads;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1556,18 +1556,18 @@ static void SleepThread(Core::System& system, s64 nanoseconds) {
 
     auto& scheduler = system.CurrentScheduler();
     auto* const current_thread = scheduler.GetCurrentThread();
-    bool redundant = false;
+    bool is_redundant = false;
 
     if (nanoseconds <= 0) {
         switch (static_cast<SleepType>(nanoseconds)) {
         case SleepType::YieldWithoutLoadBalancing:
-            redundant = current_thread->YieldSimple();
+            is_redundant = current_thread->YieldSimple();
             break;
         case SleepType::YieldWithLoadBalancing:
-            redundant = current_thread->YieldAndBalanceLoad();
+            is_redundant = current_thread->YieldAndBalanceLoad();
             break;
         case SleepType::YieldAndWaitForLoadBalancing:
-            redundant = current_thread->YieldAndWaitForLoadBalancing();
+            is_redundant = current_thread->YieldAndWaitForLoadBalancing();
             break;
         default:
             UNREACHABLE_MSG("Unimplemented sleep yield type '{:016X}'!", nanoseconds);
@@ -1576,9 +1576,9 @@ static void SleepThread(Core::System& system, s64 nanoseconds) {
         current_thread->Sleep(nanoseconds);
     }
 
-    if (redundant) {
+    if (is_redundant) {
         // If it's redundant, the core is pretty much idle. Some games keep idling
-        // a core while it's doing nothing, we advance timing to avoid costly continuos
+        // a core while it's doing nothing, we advance timing to avoid costly continuous
         // calls.
         system.CoreTiming().AddTicks(2000);
     }

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1577,10 +1577,12 @@ static void SleepThread(Core::System& system, s64 nanoseconds) {
     }
 
     if (redundant) {
-        system.CoreTiming().Idle();
-    } else {
-        system.PrepareReschedule(current_thread->GetProcessorID());
+        // If it's redundant, the core is pretty much idle. Some games keep idling
+        // a core while it's doing nothing, we advance timing to avoid costly continuos
+        // calls.
+        system.CoreTiming().AddTicks(2000);
     }
+    system.PrepareReschedule(current_thread->GetProcessorID());
 }
 
 /// Wait process wide key atomic

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -373,19 +373,19 @@ void Thread::Sleep(s64 nanoseconds) {
     WakeAfterDelay(nanoseconds);
 }
 
-void Thread::YieldSimple() {
+bool Thread::YieldSimple() {
     auto& scheduler = kernel.GlobalScheduler();
-    scheduler.YieldThread(this);
+    return scheduler.YieldThread(this);
 }
 
-void Thread::YieldAndBalanceLoad() {
+bool Thread::YieldAndBalanceLoad() {
     auto& scheduler = kernel.GlobalScheduler();
-    scheduler.YieldThreadAndBalanceLoad(this);
+    return scheduler.YieldThreadAndBalanceLoad(this);
 }
 
-void Thread::YieldAndWaitForLoadBalancing() {
+bool Thread::YieldAndWaitForLoadBalancing() {
     auto& scheduler = kernel.GlobalScheduler();
-    scheduler.YieldThreadAndWaitForLoadBalancing(this);
+    return scheduler.YieldThreadAndWaitForLoadBalancing(this);
 }
 
 void Thread::SetSchedulingStatus(ThreadSchedStatus new_status) {

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -410,7 +410,7 @@ ResultCode Thread::SetCoreAndAffinityMask(s32 new_core, u64 new_affinity_mask) {
     };
 
     const bool use_override = affinity_override_count != 0;
-    if (new_core == THREADDONTCHANGE_IDEAL) {
+    if (new_core == THREADPROCESSORID_DONT_UPDATE) {
         new_core = use_override ? ideal_core_override : ideal_core;
         if ((new_affinity_mask & (1ULL << new_core)) == 0) {
             return ERR_INVALID_COMBINATION;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -410,7 +410,7 @@ ResultCode Thread::SetCoreAndAffinityMask(s32 new_core, u64 new_affinity_mask) {
     };
 
     const bool use_override = affinity_override_count != 0;
-    if (new_core == static_cast<s32>(CoreFlags::DontChangeIdealCore)) {
+    if (new_core == THREADDONTCHANGE_IDEAL) {
         new_core = use_override ? ideal_core_override : ideal_core;
         if ((new_affinity_mask & (1ULL << new_core)) == 0) {
             return ERR_INVALID_COMBINATION;
@@ -452,7 +452,7 @@ void Thread::AdjustSchedulingOnStatus(u32 old_flags) {
 
         for (s32 core = 0; core < GlobalScheduler::NUM_CPU_CORES; core++) {
             if (core != processor_id && ((affinity_mask >> core) & 1) != 0) {
-                scheduler.Unsuggest(current_priority, core, this);
+                scheduler.Unsuggest(current_priority, static_cast<u32>(core), this);
             }
         }
     } else if (GetSchedulingStatus() == ThreadSchedStatus::Runnable) {
@@ -463,7 +463,7 @@ void Thread::AdjustSchedulingOnStatus(u32 old_flags) {
 
         for (s32 core = 0; core < GlobalScheduler::NUM_CPU_CORES; core++) {
             if (core != processor_id && ((affinity_mask >> core) & 1) != 0) {
-                scheduler.Suggest(current_priority, core, this);
+                scheduler.Suggest(current_priority, static_cast<u32>(core), this);
             }
         }
     }

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -42,7 +42,7 @@ Thread::~Thread() = default;
 void Thread::Stop() {
     // Cancel any outstanding wakeup events for this thread
     Core::System::GetInstance().CoreTiming().UnscheduleEvent(kernel.ThreadWakeupCallbackEventType(),
-                                                 callback_handle);
+                                                             callback_handle);
     kernel.ThreadWakeupCallbackHandleTable().Close(callback_handle);
     callback_handle = 0;
     SetStatus(ThreadStatus::Dead);
@@ -68,13 +68,13 @@ void Thread::WakeAfterDelay(s64 nanoseconds) {
     // This function might be called from any thread so we have to be cautious and use the
     // thread-safe version of ScheduleEvent.
     const s64 cycles = Core::Timing::nsToCycles(std::chrono::nanoseconds{nanoseconds});
-    Core::System::GetInstance().CoreTiming().ScheduleEvent(cycles, kernel.ThreadWakeupCallbackEventType(),
-                                               callback_handle);
+    Core::System::GetInstance().CoreTiming().ScheduleEvent(
+        cycles, kernel.ThreadWakeupCallbackEventType(), callback_handle);
 }
 
 void Thread::CancelWakeupTimer() {
     Core::System::GetInstance().CoreTiming().UnscheduleEvent(kernel.ThreadWakeupCallbackEventType(),
-                                                 callback_handle);
+                                                             callback_handle);
 }
 
 static std::optional<s32> GetNextProcessorId(u64 mask) {

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -41,8 +41,8 @@ Thread::~Thread() = default;
 
 void Thread::Stop() {
     // Cancel any outstanding wakeup events for this thread
-    Core::System::GetInstance().CoreTiming().UnscheduleEvent(kernel.ThreadWakeupCallbackEventType(),
-                                                             callback_handle);
+    kernel.System().CoreTiming().UnscheduleEvent(kernel.ThreadWakeupCallbackEventType(),
+                                                 callback_handle);
     kernel.ThreadWakeupCallbackHandleTable().Close(callback_handle);
     callback_handle = 0;
     SetStatus(ThreadStatus::Dead);
@@ -68,13 +68,13 @@ void Thread::WakeAfterDelay(s64 nanoseconds) {
     // This function might be called from any thread so we have to be cautious and use the
     // thread-safe version of ScheduleEvent.
     const s64 cycles = Core::Timing::nsToCycles(std::chrono::nanoseconds{nanoseconds});
-    Core::System::GetInstance().CoreTiming().ScheduleEvent(
-        cycles, kernel.ThreadWakeupCallbackEventType(), callback_handle);
+    kernel.System().CoreTiming().ScheduleEvent(cycles, kernel.ThreadWakeupCallbackEventType(),
+                                               callback_handle);
 }
 
 void Thread::CancelWakeupTimer() {
-    Core::System::GetInstance().CoreTiming().UnscheduleEvent(kernel.ThreadWakeupCallbackEventType(),
-                                                             callback_handle);
+    kernel.System().CoreTiming().UnscheduleEvent(kernel.ThreadWakeupCallbackEventType(),
+                                                 callback_handle);
 }
 
 static std::optional<s32> GetNextProcessorId(u64 mask) {
@@ -176,7 +176,7 @@ ResultVal<SharedPtr<Thread>> Thread::Create(KernelCore& kernel, std::string name
         return ResultCode(-1);
     }
 
-    auto& system = Core::System::GetInstance();
+    auto& system = kernel.System();
     SharedPtr<Thread> thread(new Thread(kernel));
 
     thread->thread_id = kernel.CreateNewThreadID();
@@ -258,7 +258,7 @@ void Thread::SetStatus(ThreadStatus new_status) {
     }
 
     if (status == ThreadStatus::Running) {
-        last_running_ticks = Core::System::GetInstance().CoreTiming().GetTicks();
+        last_running_ticks = kernel.System().CoreTiming().GetTicks();
     }
 
     status = new_status;
@@ -356,7 +356,7 @@ void Thread::SetActivity(ThreadActivity value) {
         // Set status if not waiting
         if (status == ThreadStatus::Ready || status == ThreadStatus::Running) {
             SetStatus(ThreadStatus::Paused);
-            Core::System::GetInstance().CpuCore(processor_id).PrepareReschedule();
+            kernel.System().CpuCore(processor_id).PrepareReschedule();
         }
     } else if (status == ThreadStatus::Paused) {
         // Ready to reschedule
@@ -476,7 +476,7 @@ void Thread::AdjustSchedulingOnPriority(u32 old_priority) {
     if (GetSchedulingStatus() != ThreadSchedStatus::Runnable) {
         return;
     }
-    auto& scheduler = Core::System::GetInstance().GlobalScheduler();
+    auto& scheduler = kernel.System().GlobalScheduler();
     if (processor_id >= 0) {
         scheduler.Unschedule(old_priority, processor_id, this);
     }
@@ -508,7 +508,7 @@ void Thread::AdjustSchedulingOnPriority(u32 old_priority) {
 }
 
 void Thread::AdjustSchedulingOnAffinity(u64 old_affinity_mask, s32 old_core) {
-    auto& scheduler = Core::System::GetInstance().GlobalScheduler();
+    auto& scheduler = kernel.System().GlobalScheduler();
     if (GetSchedulingStatus() != ThreadSchedStatus::Runnable ||
         current_priority >= THREADPRIO_COUNT) {
         return;

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -354,9 +354,7 @@ void Thread::SetActivity(ThreadActivity value) {
 
     if (value == ThreadActivity::Paused) {
         // Set status if not waiting
-        if (status == ThreadStatus::Ready) {
-            status = ThreadStatus::Paused;
-        } else if (status == ThreadStatus::Running) {
+        if (status == ThreadStatus::Ready || status == ThreadStatus::Running) {
             SetStatus(ThreadStatus::Paused);
             Core::System::GetInstance().CpuCore(processor_id).PrepareReschedule();
         }

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -133,6 +133,7 @@ void Thread::ResumeFromWait() {
 
 void Thread::CancelWait() {
     ASSERT(GetStatus() == ThreadStatus::WaitSynch);
+    ClearWaitObjects();
     SetWaitSynchronizationResult(ERR_SYNCHRONIZATION_CANCELED);
     ResumeFromWait();
 }

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -408,13 +408,13 @@ public:
     void Sleep(s64 nanoseconds);
 
     /// Yields this thread without rebalancing loads.
-    void YieldSimple();
+    bool YieldSimple();
 
     /// Yields this thread and does a load rebalancing.
-    void YieldAndBalanceLoad();
+    bool YieldAndBalanceLoad();
 
     /// Yields this thread and if the core is left idle, loads are rebalanced
-    void YieldAndWaitForLoadBalancing();
+    bool YieldAndWaitForLoadBalancing();
 
     ThreadSchedStatus GetSchedulingStatus() const {
         return static_cast<ThreadSchedStatus>(scheduling_state & ThreadSchedMasks::LowMask);

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -468,7 +468,7 @@ private:
 
     u64 total_cpu_time_ticks = 0; ///< Total CPU running ticks.
     u64 last_running_ticks = 0;   ///< CPU tick when thread was last running
-    u64 yield_count = 0; ///< Number of innecessaries yields occured.
+    u64 yield_count = 0;          ///< Number of innecessaries yields occured.
 
     s32 processor_id = 0;
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -416,6 +416,14 @@ public:
     /// Yields this thread and if the core is left idle, loads are rebalanced
     bool YieldAndWaitForLoadBalancing();
 
+    void IncrementYieldCount() {
+        yield_count++;
+    }
+
+    u64 GetYieldCount() const {
+        return yield_count;
+    }
+
     ThreadSchedStatus GetSchedulingStatus() const {
         return static_cast<ThreadSchedStatus>(scheduling_state & ThreadSchedMasks::LowMask);
     }
@@ -460,6 +468,7 @@ private:
 
     u64 total_cpu_time_ticks = 0; ///< Total CPU running ticks.
     u64 last_running_ticks = 0;   ///< CPU tick when thread was last running
+    u64 yield_count = 0; ///< Number of innecessaries yields occured.
 
     s32 processor_id = 0;
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -75,6 +75,21 @@ enum class ThreadActivity : u32 {
     Paused = 1,
 };
 
+enum class ThreadSchedStatus : u32 { None = 0, Paused = 1, Runnable = 2, Exited = 3 };
+
+enum ThreadSchedFlags : u32 {
+    ProcessPauseFlag = 1 << 4,
+    ThreadPauseFlag = 1 << 5,
+    ProcessDebugPauseFlag = 1 << 6,
+    KernelInitPauseFlag = 1 << 8,
+};
+
+enum ThreadSchedMasks : u32 {
+    LowMask = 0x000f,
+    HighMask = 0xfff0,
+    ForcePauseMask = 0x0070,
+};
+
 class Thread final : public WaitObject {
 public:
     using MutexWaitingThreads = std::vector<SharedPtr<Thread>>;
@@ -278,6 +293,10 @@ public:
         return processor_id;
     }
 
+    void SetProcessorID(s32 new_core) {
+        processor_id = new_core;
+    }
+
     Process* GetOwnerProcess() {
         return owner_process;
     }
@@ -383,11 +402,38 @@ public:
     /// Sleeps this thread for the given amount of nanoseconds.
     void Sleep(s64 nanoseconds);
 
+    /// Yields this thread without rebalancing loads.
+    void YieldType0();
+
+    /// Yields this thread and does a load rebalancing.
+    void YieldType1();
+
+    /// Yields this thread and if the core is left idle, loads are rebalanced
+    void YieldType2();
+
+    ThreadSchedStatus GetSchedulingStatus() {
+        return static_cast<ThreadSchedStatus>(scheduling_state & ThreadSchedMasks::LowMask);
+    }
+
+    bool IsRunning() const {
+        return is_running;
+    }
+
+    void SetIsRunning(bool value) {
+        is_running = value;
+    }
+
 private:
     explicit Thread(KernelCore& kernel);
     ~Thread() override;
 
-    void ChangeScheduler();
+    void SetSchedulingStatus(ThreadSchedStatus new_status);
+    void SetCurrentPriority(u32 new_priority);
+    ResultCode SetCoreAndAffinityMask(s32 new_core, u64 new_affinity_mask);
+
+    void AdjustSchedulingOnStatus(u32 old_flags);
+    void AdjustSchedulingOnPriority(u32 old_priority);
+    void AdjustSchedulingOnAffinity(u64 old_affinity_mask, s32 old_core);
 
     Core::ARM_Interface::ThreadContext context{};
 
@@ -452,6 +498,13 @@ private:
     u64 affinity_mask{0x1};
 
     ThreadActivity activity = ThreadActivity::Normal;
+
+    s32 ideal_core_override = -1;
+    u64 affinity_mask_override = 0x1;
+    u32 affinity_override_count = 0;
+
+    u32 scheduling_state = 0;
+    bool is_running = false;
 
     std::string name;
 };

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -35,6 +35,9 @@ enum ThreadProcessorId : s32 {
     /// Run thread on the ideal core specified by the process.
     THREADPROCESSORID_IDEAL = -2,
 
+    /// when setting Core and Affiny, keeps the ideal core intact
+    THREADDONTCHANGE_IDEAL = -3,
+
     /// Indicates that the preferred processor ID shouldn't be updated in
     /// a core mask setting operation.
     THREADPROCESSORID_DONT_UPDATE = -3,
@@ -93,12 +96,6 @@ enum class ThreadSchedMasks : u32 {
     LowMask = 0x000f,
     HighMask = 0xfff0,
     ForcePauseMask = 0x0070,
-};
-
-enum class CoreFlags : s32 {
-    IgnoreIdealCore = -1,
-    ProcessIdealCore = -2,
-    DontChangeIdealCore = -3,
 };
 
 class Thread final : public WaitObject {

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -35,9 +35,6 @@ enum ThreadProcessorId : s32 {
     /// Run thread on the ideal core specified by the process.
     THREADPROCESSORID_IDEAL = -2,
 
-    /// when setting Core and Affiny, keeps the ideal core intact
-    THREADDONTCHANGE_IDEAL = -3,
-
     /// Indicates that the preferred processor ID shouldn't be updated in
     /// a core mask setting operation.
     THREADPROCESSORID_DONT_UPDATE = -3,

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -82,17 +82,23 @@ enum class ThreadSchedStatus : u32 {
     Exited = 3,
 };
 
-enum ThreadSchedFlags : u32 {
+enum class ThreadSchedFlags : u32 {
     ProcessPauseFlag = 1 << 4,
     ThreadPauseFlag = 1 << 5,
     ProcessDebugPauseFlag = 1 << 6,
     KernelInitPauseFlag = 1 << 8,
 };
 
-enum ThreadSchedMasks : u32 {
+enum class ThreadSchedMasks : u32 {
     LowMask = 0x000f,
     HighMask = 0xfff0,
     ForcePauseMask = 0x0070,
+};
+
+enum class CoreFlags : s32 {
+    IgnoreIdealCore = -1,
+    ProcessIdealCore = -2,
+    DontChangeIdealCore = -3,
 };
 
 class Thread final : public WaitObject {
@@ -428,7 +434,8 @@ public:
     }
 
     ThreadSchedStatus GetSchedulingStatus() const {
-        return static_cast<ThreadSchedStatus>(scheduling_state & ThreadSchedMasks::LowMask);
+        return static_cast<ThreadSchedStatus>(scheduling_state &
+                                              static_cast<u32>(ThreadSchedMasks::LowMask));
     }
 
     bool IsRunning() const {
@@ -471,7 +478,8 @@ private:
 
     u64 total_cpu_time_ticks = 0; ///< Total CPU running ticks.
     u64 last_running_ticks = 0;   ///< CPU tick when thread was last running
-    u64 yield_count = 0;          ///< Number of innecessaries yields occured.
+    u64 yield_count = 0;          ///< Number of redundant yields carried by this thread.
+                                  ///< a redundant yield is one where no scheduling is changed
 
     s32 processor_id = 0;
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -319,6 +319,9 @@ public:
     }
 
     void ClearWaitObjects() {
+        for (const auto& waiting_object : wait_objects) {
+            waiting_object->RemoveWaitingThread(this);
+        }
         wait_objects.clear();
     }
 

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -75,7 +75,12 @@ enum class ThreadActivity : u32 {
     Paused = 1,
 };
 
-enum class ThreadSchedStatus : u32 { None = 0, Paused = 1, Runnable = 2, Exited = 3 };
+enum class ThreadSchedStatus : u32 {
+    None = 0,
+    Paused = 1,
+    Runnable = 2,
+    Exited = 3,
+};
 
 enum ThreadSchedFlags : u32 {
     ProcessPauseFlag = 1 << 4,
@@ -403,15 +408,15 @@ public:
     void Sleep(s64 nanoseconds);
 
     /// Yields this thread without rebalancing loads.
-    void YieldType0();
+    void YieldSimple();
 
     /// Yields this thread and does a load rebalancing.
-    void YieldType1();
+    void YieldAndBalanceLoad();
 
     /// Yields this thread and if the core is left idle, loads are rebalanced
-    void YieldType2();
+    void YieldAndWaitForLoadBalancing();
 
-    ThreadSchedStatus GetSchedulingStatus() {
+    ThreadSchedStatus GetSchedulingStatus() const {
         return static_cast<ThreadSchedStatus>(scheduling_state & ThreadSchedMasks::LowMask);
     }
 

--- a/src/core/hle/kernel/wait_object.cpp
+++ b/src/core/hle/kernel/wait_object.cpp
@@ -97,8 +97,7 @@ void WaitObject::WakeupWaitingThread(SharedPtr<Thread> thread) {
     }
     if (resume) {
         thread->ResumeFromWait();
-        if (thread->GetProcessorID() >= 0)
-            Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
+        Core::System::GetInstance().PrepareReschedule(thread->GetProcessorID());
     }
 }
 

--- a/src/core/hle/kernel/wait_object.cpp
+++ b/src/core/hle/kernel/wait_object.cpp
@@ -6,6 +6,8 @@
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "common/logging/log.h"
+#include "core/core.h"
+#include "core/core_cpu.h"
 #include "core/hle/kernel/object.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/thread.h"
@@ -95,6 +97,8 @@ void WaitObject::WakeupWaitingThread(SharedPtr<Thread> thread) {
     }
     if (resume) {
         thread->ResumeFromWait();
+        if (thread->GetProcessorID() >= 0)
+            Core::System::GetInstance().CpuCore(thread->GetProcessorID()).PrepareReschedule();
     }
 }
 

--- a/src/core/hle/kernel/wait_object.cpp
+++ b/src/core/hle/kernel/wait_object.cpp
@@ -95,7 +95,7 @@ void WaitObject::WakeupWaitingThread(SharedPtr<Thread> thread) {
     }
     if (resume) {
         thread->ResumeFromWait();
-        kernel.System().PrepareReschedule(thread->GetProcessorID());
+        Core::System::GetInstance().PrepareReschedule(thread->GetProcessorID());
     }
 }
 

--- a/src/core/hle/kernel/wait_object.cpp
+++ b/src/core/hle/kernel/wait_object.cpp
@@ -8,6 +8,7 @@
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/core_cpu.h"
+#include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/object.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/thread.h"
@@ -97,7 +98,7 @@ void WaitObject::WakeupWaitingThread(SharedPtr<Thread> thread) {
     }
     if (resume) {
         thread->ResumeFromWait();
-        Core::System::GetInstance().PrepareReschedule(thread->GetProcessorID());
+        kernel.System().PrepareReschedule(thread->GetProcessorID());
     }
 }
 

--- a/src/core/hle/kernel/wait_object.cpp
+++ b/src/core/hle/kernel/wait_object.cpp
@@ -85,9 +85,6 @@ void WaitObject::WakeupWaitingThread(SharedPtr<Thread> thread) {
 
     const std::size_t index = thread->GetWaitObjectIndex(this);
 
-    for (const auto& object : thread->GetWaitObjects()) {
-        object->RemoveWaitingThread(thread.get());
-    }
     thread->ClearWaitObjects();
 
     thread->CancelWakeupTimer();

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -66,10 +66,7 @@ std::vector<std::unique_ptr<WaitTreeThread>> WaitTreeItem::MakeThreadItemList() 
     };
 
     const auto& system = Core::System::GetInstance();
-    add_threads(system.Scheduler(0).GetThreadList());
-    add_threads(system.Scheduler(1).GetThreadList());
-    add_threads(system.Scheduler(2).GetThreadList());
-    add_threads(system.Scheduler(3).GetThreadList());
+    add_threads(system.GlobalScheduler().GetThreadList());
 
     return item_list;
 }


### PR DESCRIPTION
This PR is a continuation of the new scheduler (#2364) with significantly more fixes. The new scheduler is meant to be closer to the RE info we have and does a few things in a more appropriate manner. Core differences:

- The new scheduler does not automatically assign threads without an assigned cpu core. Instead it moves them to a suggested queue and resolves them when no scheduled thread can be assigned to the current core.
- All yield types are now implemented and can now be redundant accordingly (before the yielding thread went to sleep, leaving the possibility for a lower priority thread to be scheduled instead).
- Prepare reschedule has been revised and should now be triggered whenever a thread wakes up.
- Some corrections have been made to thread switching and picking threads on the go.

The new scheduler fixes some issues:
- Deadlocks that could occur with hle ipc wait and wait synchronization.
- Better handling of threads on some games, resulting in some less dynarmic usage.
- Unlike the old scheduler, no reads are reported to be running without being set to runs.

Additions, fixes and corrections in V2:
- New Scheduler V2 has been reworked to work with Fair Core Timing.
- All the comments signaled in #2364 have been addressed.
- The new scheduler has been fully checked against the RE twice now.
- Corrected a bug on Yields where candidate threads without assigned core where checked like if they were.
- Redundant yields will now add ticks to core timing in order to avoid yield bombing.
- Thread Preemption mechanism has been added.
- Mutexes and Condition Variable Threads will now have the correct result when waking up.
- Corrected some logic in address arbitering waiting count if equal signal.
- Wait objects correctly remove the thread from their list on timeout or cancel.
- Setting a Ready Thread as paused will correctly change that thread's scheduling.
- Shutting down the kernel will correctly clear the global scheduler.
- Most global accessors from thread.cpp have been removed.
- Added a few asserts to better picture possible kernel bugs.

Thanks to TuxSH and gdkchan for their work in reversing the switch's kernel.
Thanks to TuxSH' mesosphere and Ryujinx which served as reference to help validate this PR.

Depends on #2965