### PR TITLE
{bcat, gpu, nvflinger}: Remove trivial usages of the global system accessor

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -1140,8 +1140,9 @@ void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called, kind={:08X}", static_cast<u8>(kind));
 
     if (kind == LaunchParameterKind::ApplicationSpecific && !launch_popped_application_specific) {
-        const auto backend = BCAT::CreateBackendFromSettings(
-            [this](u64 tid) { return system.GetFileSystemController().GetBCATDirectory(tid); });
+        const auto backend = BCAT::CreateBackendFromSettings(system, [this](u64 tid) {
+            return system.GetFileSystemController().GetBCATDirectory(tid);
+        });
         const auto build_id_full = system.GetCurrentProcessBuildID();
         u64 build_id{};
         std::memcpy(&build_id, build_id_full.data(), sizeof(u64));

--- a/src/core/hle/service/bcat/backend/backend.cpp
+++ b/src/core/hle/service/bcat/backend/backend.cpp
@@ -10,8 +10,8 @@
 
 namespace Service::BCAT {
 
-ProgressServiceBackend::ProgressServiceBackend(std::string_view event_name) {
-    auto& kernel{Core::System::GetInstance().Kernel()};
+ProgressServiceBackend::ProgressServiceBackend(Kernel::KernelCore& kernel,
+                                               std::string_view event_name) {
     event = Kernel::WritableEvent::CreateEventPair(
         kernel, Kernel::ResetType::Automatic,
         std::string("ProgressServiceBackend:UpdateEvent:").append(event_name));

--- a/src/core/hle/service/bcat/backend/backend.h
+++ b/src/core/hle/service/bcat/backend/backend.h
@@ -15,6 +15,14 @@
 #include "core/hle/kernel/writable_event.h"
 #include "core/hle/result.h"
 
+namespace Core {
+class System;
+}
+
+namespace Kernel {
+class KernelCore;
+}
+
 namespace Service::BCAT {
 
 struct DeliveryCacheProgressImpl;
@@ -88,7 +96,7 @@ public:
     void FinishDownload(ResultCode result);
 
 private:
-    explicit ProgressServiceBackend(std::string_view event_name);
+    explicit ProgressServiceBackend(Kernel::KernelCore& kernel, std::string_view event_name);
 
     Kernel::SharedPtr<Kernel::ReadableEvent> GetEvent() const;
     DeliveryCacheProgressImpl& GetImpl();
@@ -145,6 +153,6 @@ public:
     std::optional<std::vector<u8>> GetLaunchParameter(TitleIDVersion title) override;
 };
 
-std::unique_ptr<Backend> CreateBackendFromSettings(DirectoryGetter getter);
+std::unique_ptr<Backend> CreateBackendFromSettings(Core::System& system, DirectoryGetter getter);
 
 } // namespace Service::BCAT

--- a/src/core/hle/service/bcat/backend/boxcat.h
+++ b/src/core/hle/service/bcat/backend/boxcat.h
@@ -9,6 +9,10 @@
 #include <optional>
 #include "core/hle/service/bcat/backend/backend.h"
 
+namespace Service::AM::Applets {
+class AppletManager;
+}
+
 namespace Service::BCAT {
 
 struct EventStatus {
@@ -20,12 +24,13 @@ struct EventStatus {
 /// Boxcat is yuzu's custom backend implementation of Nintendo's BCAT service. It is free to use and
 /// doesn't require a switch or nintendo account. The content is controlled by the yuzu team.
 class Boxcat final : public Backend {
-    friend void SynchronizeInternal(DirectoryGetter dir_getter, TitleIDVersion title,
+    friend void SynchronizeInternal(AM::Applets::AppletManager& applet_manager,
+                                    DirectoryGetter dir_getter, TitleIDVersion title,
                                     ProgressServiceBackend& progress,
                                     std::optional<std::string> dir_name);
 
 public:
-    explicit Boxcat(DirectoryGetter getter);
+    explicit Boxcat(AM::Applets::AppletManager& applet_manager_, DirectoryGetter getter);
     ~Boxcat() override;
 
     bool Synchronize(TitleIDVersion title, ProgressServiceBackend& progress) override;
@@ -53,6 +58,7 @@ private:
 
     class Client;
     std::unique_ptr<Client> client;
+    AM::Applets::AppletManager& applet_manager;
 };
 
 } // namespace Service::BCAT

--- a/src/core/hle/service/nvflinger/buffer_queue.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue.cpp
@@ -14,8 +14,8 @@
 
 namespace Service::NVFlinger {
 
-BufferQueue::BufferQueue(u32 id, u64 layer_id) : id(id), layer_id(layer_id) {
-    auto& kernel = Core::System::GetInstance().Kernel();
+BufferQueue::BufferQueue(Kernel::KernelCore& kernel, u32 id, u64 layer_id)
+    : id(id), layer_id(layer_id) {
     buffer_wait_event = Kernel::WritableEvent::CreateEventPair(kernel, Kernel::ResetType::Manual,
                                                                "BufferQueue NativeHandle");
 }

--- a/src/core/hle/service/nvflinger/buffer_queue.h
+++ b/src/core/hle/service/nvflinger/buffer_queue.h
@@ -15,6 +15,10 @@
 #include "core/hle/kernel/writable_event.h"
 #include "core/hle/service/nvdrv/nvdata.h"
 
+namespace Kernel {
+class KernelCore;
+}
+
 namespace Service::NVFlinger {
 
 struct IGBPBuffer {
@@ -44,7 +48,7 @@ public:
         NativeWindowFormat = 2,
     };
 
-    BufferQueue(u32 id, u64 layer_id);
+    explicit BufferQueue(Kernel::KernelCore& kernel, u32 id, u64 layer_id);
     ~BufferQueue();
 
     enum class BufferTransformFlags : u32 {

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -83,7 +83,7 @@ std::optional<u64> NVFlinger::CreateLayer(u64 display_id) {
 
     const u64 layer_id = next_layer_id++;
     const u32 buffer_queue_id = next_buffer_queue_id++;
-    buffer_queues.emplace_back(buffer_queue_id, layer_id);
+    buffer_queues.emplace_back(system.Kernel(), buffer_queue_id, layer_id);
     display->CreateLayer(layer_id, buffer_queues.back());
     return layer_id;
 }

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -326,7 +326,7 @@ void GPU::ProcessSemaphoreTriggerMethod() {
         block.sequence = regs.semaphore_sequence;
         // TODO(Kmather73): Generate a real GPU timestamp and write it here instead of
         // CoreTiming
-        block.timestamp = Core::System::GetInstance().CoreTiming().GetTicks();
+        block.timestamp = system.CoreTiming().GetTicks();
         memory_manager->WriteBlock(regs.semaphore_address.SemaphoreAddress(), &block,
                                    sizeof(block));
     } else {


### PR DESCRIPTION
Eliminates the reliance on global state in a few areas. These are relatively trivial usages that are able to be replaced via passing along the system instance as part of function interfaces. In some cases, it's as simple as just using a member variable instead of the accessor.

Brings us a little close to dropping the global singleton.