### PR TITLE
common: Rename binary_find.h to algorithm.h

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -95,11 +95,11 @@ add_custom_command(OUTPUT scm_rev.cpp
 )
 
 add_library(common STATIC
+    algorithm.h
     alignment.h
     assert.h
     detached_tasks.cpp
     detached_tasks.h
-    binary_find.h
     bit_field.h
     bit_util.h
     cityhash.cpp

--- a/src/common/algorithm.h
+++ b/src/common/algorithm.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <algorithm>
+#include <functional>
 
 namespace Common {
 

--- a/src/common/algorithm.h
+++ b/src/common/algorithm.h
@@ -7,6 +7,11 @@
 #include <algorithm>
 #include <functional>
 
+// Algorithms that operate on iterators, much like the <algorithm> header.
+//
+// Note: If the algorithm is not general-purpose and/or doesn't operate on iterators,
+//       it should probably not be placed within this header.
+
 namespace Common {
 
 template <class ForwardIt, class T, class Compare = std::less<>>

--- a/src/video_core/texture_cache/surface_base.cpp
+++ b/src/video_core/texture_cache/surface_base.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/algorithm.h"
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "common/microprofile.h"

--- a/src/video_core/texture_cache/surface_base.h
+++ b/src/video_core/texture_cache/surface_base.h
@@ -4,12 +4,11 @@
 
 #pragma once
 
-#include <algorithm>
+#include <optional>
+#include <tuple>
 #include <unordered_map>
 #include <vector>
 
-#include "common/assert.h"
-#include "common/binary_find.h"
 #include "common/common_types.h"
 #include "video_core/gpu.h"
 #include "video_core/morton.h"


### PR DESCRIPTION
Makes the header a little bit more general-purpose and open for other iterator-based additions in the future. Having a single header for solely one 8 line algorithm is a little unnecessary.