### PR TITLE
gl_shader_decompiler: Minor cleanup-related changes

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -2246,7 +2246,7 @@ private:
         code.AddLine("#ifdef SAMPLER_{}_IS_BUFFER", sampler.GetIndex());
     }
 
-    std::string GetDeclarationWithSuffix(u32 index, const std::string& name) const {
+    std::string GetDeclarationWithSuffix(u32 index, std::string_view name) const {
         return fmt::format("{}_{}_{}", name, index, suffix);
     }
 

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1235,7 +1235,7 @@ private:
 
     std::string BuildImageValues(Operation operation) {
         constexpr std::array constructors{"uint", "uvec2", "uvec3", "uvec4"};
-        const auto meta{std::get<MetaImage>(operation.GetMeta())};
+        const auto& meta{std::get<MetaImage>(operation.GetMeta())};
 
         const std::size_t values_count{meta.values.size()};
         std::string expr = fmt::format("{}(", constructors.at(values_count - 1));
@@ -1780,14 +1780,14 @@ private:
             return {"0", Type::Int};
         }
 
-        const auto meta{std::get<MetaImage>(operation.GetMeta())};
+        const auto& meta{std::get<MetaImage>(operation.GetMeta())};
         return {fmt::format("imageLoad({}, {}){}", GetImage(meta.image),
                             BuildIntegerCoordinates(operation), GetSwizzle(meta.element)),
                 Type::Uint};
     }
 
     Expression ImageStore(Operation operation) {
-        const auto meta{std::get<MetaImage>(operation.GetMeta())};
+        const auto& meta{std::get<MetaImage>(operation.GetMeta())};
         code.AddLine("imageStore({}, {}, {});", GetImage(meta.image),
                      BuildIntegerCoordinates(operation), BuildImageValues(operation));
         return {};
@@ -1795,7 +1795,7 @@ private:
 
     template <const std::string_view& opname>
     Expression AtomicImage(Operation operation) {
-        const auto meta{std::get<MetaImage>(operation.GetMeta())};
+        const auto& meta{std::get<MetaImage>(operation.GetMeta())};
         ASSERT(meta.values.size() == 1);
 
         return {fmt::format("imageAtomic{}({}, {}, {})", opname, GetImage(meta.image),

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1148,7 +1148,7 @@ private:
         for (const auto& variant : extras) {
             if (const auto argument = std::get_if<TextureArgument>(&variant)) {
                 expr += GenerateTextureArgument(*argument);
-            } else if (std::get_if<TextureAoffi>(&variant)) {
+            } else if (std::holds_alternative<TextureAoffi>(variant)) {
                 expr += GenerateTextureAoffi(meta->aoffi);
             } else {
                 UNREACHABLE();

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1158,8 +1158,8 @@ private:
         return expr + ')';
     }
 
-    std::string GenerateTextureArgument(TextureArgument argument) {
-        const auto [type, operand] = argument;
+    std::string GenerateTextureArgument(const TextureArgument& argument) {
+        const auto& [type, operand] = argument;
         if (operand == nullptr) {
             return {};
         }

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -2271,10 +2271,8 @@ private:
     ShaderWriter code;
 };
 
-static constexpr std::string_view flow_var = "flow_var_";
-
 std::string GetFlowVariable(u32 i) {
-    return fmt::format("{}{}", flow_var, i);
+    return fmt::format("flow_var_{}", i);
 }
 
 class ExprDecompiler {

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -2335,7 +2335,7 @@ public:
         inner += expr.value ? "true" : "false";
     }
 
-    std::string& GetResult() {
+    const std::string& GetResult() const {
         return inner;
     }
 

--- a/src/video_core/shader/node.h
+++ b/src/video_core/shader/node.h
@@ -410,7 +410,7 @@ public:
     explicit OperationNode(OperationCode code) : OperationNode(code, Meta{}) {}
 
     explicit OperationNode(OperationCode code, Meta meta)
-        : OperationNode(code, meta, std::vector<Node>{}) {}
+        : OperationNode(code, std::move(meta), std::vector<Node>{}) {}
 
     explicit OperationNode(OperationCode code, std::vector<Node> operands)
         : OperationNode(code, Meta{}, std::move(operands)) {}


### PR DESCRIPTION
Just applies a few minor changes that avoid redundant copies and heap allocations. Each commit itself should have extra context in its description to help clarify the changes.