### PR TITLE
Texture_Cache: Redo invalid Surfaces handling.

### DIFF
--- a/src/video_core/texture_cache/surface_params.cpp
+++ b/src/video_core/texture_cache/surface_params.cpp
@@ -246,6 +246,16 @@ SurfaceParams SurfaceParams::CreateForFermiCopySurface(
     return params;
 }
 
+VideoCore::Surface::SurfaceTarget SurfaceParams::ExpectedTarget(
+    const VideoCommon::Shader::Sampler& entry) {
+    return TextureTypeToSurfaceTarget(entry.GetType(), entry.IsArray());
+}
+
+VideoCore::Surface::SurfaceTarget SurfaceParams::ExpectedTarget(
+    const VideoCommon::Shader::Image& entry) {
+    return ImageTypeToSurfaceTarget(entry.GetType());
+}
+
 bool SurfaceParams::IsLayered() const {
     switch (target) {
     case SurfaceTarget::Texture1DArray:

--- a/src/video_core/texture_cache/surface_params.h
+++ b/src/video_core/texture_cache/surface_params.h
@@ -45,6 +45,14 @@ public:
     static SurfaceParams CreateForFermiCopySurface(
         const Tegra::Engines::Fermi2D::Regs::Surface& config);
 
+    /// Obtains the texture target from a shader's sampler entry.
+    static VideoCore::Surface::SurfaceTarget ExpectedTarget(
+        const VideoCommon::Shader::Sampler& entry);
+
+    /// Obtains the texture target from a shader's sampler entry.
+    static VideoCore::Surface::SurfaceTarget ExpectedTarget(
+        const VideoCommon::Shader::Image& entry);
+
     std::size_t Hash() const {
         return static_cast<std::size_t>(
             Common::CityHash64(reinterpret_cast<const char*>(this), sizeof(*this)));


### PR DESCRIPTION
This PR aims to redo the full setup of invalid textures in the texture cache. Invalid textures are when the information provided by such is invalid. According to RE, this is as possible as binding a nullptr in a texture bind in OpenGL. Sadly not all invalid textures may actually be invalid but bad fetches from the buffer or other synchronization misses. In general, this gives the texture cache the ability to track them and correct them with a dummy texture that acts as hardware acts when it finds an invalid texture.