### PR TITLE
core: Resolve -Wreorder warnings

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -112,8 +112,8 @@ FileSys::VirtualFile GetGameFileFromPath(const FileSys::VirtualFilesystem& vfs,
 }
 struct System::Impl {
     explicit Impl(System& system)
-        : kernel{system}, fs_controller{system}, cpu_core_manager{system},
-          applet_manager{system}, reporter{system} {}
+        : kernel{system}, fs_controller{system}, cpu_core_manager{system}, reporter{system},
+          applet_manager{system} {}
 
     Cpu& CurrentCpuCore() {
         return cpu_core_manager.GetCurrentCore();

--- a/src/core/memory/cheat_engine.cpp
+++ b/src/core/memory/cheat_engine.cpp
@@ -22,7 +22,7 @@ constexpr u32 KEYPAD_BITMASK = 0x3FFFFFF;
 
 StandardVmCallbacks::StandardVmCallbacks(const Core::System& system,
                                          const CheatProcessMetadata& metadata)
-    : system(system), metadata(metadata) {}
+    : metadata(metadata), system(system) {}
 
 StandardVmCallbacks::~StandardVmCallbacks() = default;
 
@@ -176,9 +176,8 @@ std::vector<CheatEntry> TextCheatParser::Parse(const Core::System& system,
 
 CheatEngine::CheatEngine(Core::System& system, std::vector<CheatEntry> cheats,
                          const std::array<u8, 0x20>& build_id)
-    : system{system}, core_timing{system.CoreTiming()}, vm{std::make_unique<StandardVmCallbacks>(
-                                                            system, metadata)},
-      cheats(std::move(cheats)) {
+    : vm{std::make_unique<StandardVmCallbacks>(system, metadata)},
+      cheats(std::move(cheats)), core_timing{system.CoreTiming()}, system{system} {
     metadata.main_nso_build_id = build_id;
 }
 


### PR DESCRIPTION
Orders the members in constructor initializer lists to be formatted the same way as their declaration in the class itself.