### PR TITLE
dmnt_cheat_vm: Correct register Restore and ClearRegs behavior

### DIFF
--- a/src/core/memory/dmnt_cheat_vm.cpp
+++ b/src/core/memory/dmnt_cheat_vm.cpp
@@ -1133,8 +1133,8 @@ void DmntCheatVm::Execute(const CheatProcessMetadata& metadata) {
             case SaveRestoreRegisterOpType::ClearRegs:
             case SaveRestoreRegisterOpType::Restore:
             default:
-                src = registers.data();
-                dst = saved_values.data();
+                src = saved_values.data();
+                dst = registers.data();
                 break;
             }
             for (std::size_t i = 0; i < NumRegisters; i++) {


### PR DESCRIPTION
Previously these were performing the same behavior as the Save and ClearSaved opcode types. I've also filed a PR upstream with Atmosphere [here](https://github.com/Atmosphere-NX/Atmosphere/pull/683) given it's derived from the same code.