### PR TITLE
video_core/shader/ast: Minor changes to ASTPrinter

### DIFF
--- a/src/video_core/shader/ast.cpp
+++ b/src/video_core/shader/ast.cpp
@@ -333,7 +333,7 @@ public:
         inner += fmt::format("{}({}) -> break;\n", Indent(), expr_parser.GetResult());
     }
 
-    void Visit(ASTNode& node) {
+    void Visit(const ASTNode& node) {
         std::visit(*this, *node->GetInnerData());
     }
 
@@ -364,7 +364,7 @@ private:
     static constexpr std::string_view spaces{"                                    "};
 };
 
-std::string ASTManager::Print() {
+std::string ASTManager::Print() const {
     ASTPrinter printer{};
     printer.Visit(main_node);
     return printer.GetResult();

--- a/src/video_core/shader/ast.cpp
+++ b/src/video_core/shader/ast.cpp
@@ -251,7 +251,7 @@ public:
     void operator()(const ASTIfThen& ast) {
         ExprPrinter expr_parser{};
         std::visit(expr_parser, *ast.condition);
-        inner += fmt::format("{}if ({}) {{\n", Ident(), expr_parser.GetResult());
+        inner += fmt::format("{}if ({}) {{\n", Indent(), expr_parser.GetResult());
         scope++;
         ASTNode current = ast.nodes.GetFirst();
         while (current) {
@@ -259,11 +259,11 @@ public:
             current = current->GetNext();
         }
         scope--;
-        inner += fmt::format("{}}}\n", Ident());
+        inner += fmt::format("{}}}\n", Indent());
     }
 
     void operator()(const ASTIfElse& ast) {
-        inner += Ident() + "else {\n";
+        inner += Indent() + "else {\n";
         scope++;
         ASTNode current = ast.nodes.GetFirst();
         while (current) {
@@ -271,21 +271,21 @@ public:
             current = current->GetNext();
         }
         scope--;
-        inner += Ident() + "}\n";
+        inner += Indent() + "}\n";
     }
 
     void operator()(const ASTBlockEncoded& ast) {
-        inner += fmt::format("{}Block({}, {});\n", Ident(), ast.start, ast.end);
+        inner += fmt::format("{}Block({}, {});\n", Indent(), ast.start, ast.end);
     }
 
     void operator()(const ASTBlockDecoded& ast) {
-        inner += Ident() + "Block;\n";
+        inner += Indent() + "Block;\n";
     }
 
     void operator()(const ASTVarSet& ast) {
         ExprPrinter expr_parser{};
         std::visit(expr_parser, *ast.condition);
-        inner += fmt::format("{}V{} := {};\n", Ident(), ast.index, expr_parser.GetResult());
+        inner += fmt::format("{}V{} := {};\n", Indent(), ast.index, expr_parser.GetResult());
     }
 
     void operator()(const ASTLabel& ast) {
@@ -296,13 +296,13 @@ public:
         ExprPrinter expr_parser{};
         std::visit(expr_parser, *ast.condition);
         inner +=
-            fmt::format("{}({}) -> goto Label_{};\n", Ident(), expr_parser.GetResult(), ast.label);
+            fmt::format("{}({}) -> goto Label_{};\n", Indent(), expr_parser.GetResult(), ast.label);
     }
 
     void operator()(const ASTDoWhile& ast) {
         ExprPrinter expr_parser{};
         std::visit(expr_parser, *ast.condition);
-        inner += fmt::format("{}do {{\n", Ident());
+        inner += fmt::format("{}do {{\n", Indent());
         scope++;
         ASTNode current = ast.nodes.GetFirst();
         while (current) {
@@ -310,23 +310,23 @@ public:
             current = current->GetNext();
         }
         scope--;
-        inner += fmt::format("{}}} while ({});\n", Ident(), expr_parser.GetResult());
+        inner += fmt::format("{}}} while ({});\n", Indent(), expr_parser.GetResult());
     }
 
     void operator()(const ASTReturn& ast) {
         ExprPrinter expr_parser{};
         std::visit(expr_parser, *ast.condition);
-        inner += fmt::format("{}({}) -> {};\n", Ident(), expr_parser.GetResult(),
+        inner += fmt::format("{}({}) -> {};\n", Indent(), expr_parser.GetResult(),
                              ast.kills ? "discard" : "exit");
     }
 
     void operator()(const ASTBreak& ast) {
         ExprPrinter expr_parser{};
         std::visit(expr_parser, *ast.condition);
-        inner += fmt::format("{}({}) -> break;\n", Ident(), expr_parser.GetResult());
+        inner += fmt::format("{}({}) -> break;\n", Indent(), expr_parser.GetResult());
     }
 
-    std::string& Ident() {
+    std::string& Indent() {
         if (memo_scope == scope) {
             return tabs_memo;
         }

--- a/src/video_core/shader/ast.cpp
+++ b/src/video_core/shader/ast.cpp
@@ -232,7 +232,8 @@ public:
         return inner;
     }
 
-    std::string inner{};
+private:
+    std::string inner;
 };
 
 class ASTPrinter {

--- a/src/video_core/shader/ast.cpp
+++ b/src/video_core/shader/ast.cpp
@@ -4,6 +4,8 @@
 
 #include <string>
 
+#include <fmt/format.h>
+
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "video_core/shader/ast.h"
@@ -249,7 +251,7 @@ public:
     void operator()(const ASTIfThen& ast) {
         ExprPrinter expr_parser{};
         std::visit(expr_parser, *ast.condition);
-        inner += Ident() + "if (" + expr_parser.GetResult() + ") {\n";
+        inner += fmt::format("{}if ({}) {{\n", Ident(), expr_parser.GetResult());
         scope++;
         ASTNode current = ast.nodes.GetFirst();
         while (current) {
@@ -257,7 +259,7 @@ public:
             current = current->GetNext();
         }
         scope--;
-        inner += Ident() + "}\n";
+        inner += fmt::format("{}}}\n", Ident());
     }
 
     void operator()(const ASTIfElse& ast) {
@@ -273,8 +275,7 @@ public:
     }
 
     void operator()(const ASTBlockEncoded& ast) {
-        inner += Ident() + "Block(" + std::to_string(ast.start) + ", " + std::to_string(ast.end) +
-                 ");\n";
+        inner += fmt::format("{}Block({}, {});\n", Ident(), ast.start, ast.end);
     }
 
     void operator()(const ASTBlockDecoded& ast) {
@@ -284,25 +285,24 @@ public:
     void operator()(const ASTVarSet& ast) {
         ExprPrinter expr_parser{};
         std::visit(expr_parser, *ast.condition);
-        inner +=
-            Ident() + "V" + std::to_string(ast.index) + " := " + expr_parser.GetResult() + ";\n";
+        inner += fmt::format("{}V{} := {};\n", Ident(), ast.index, expr_parser.GetResult());
     }
 
     void operator()(const ASTLabel& ast) {
-        inner += "Label_" + std::to_string(ast.index) + ":\n";
+        inner += fmt::format("Label_{}:\n", ast.index);
     }
 
     void operator()(const ASTGoto& ast) {
         ExprPrinter expr_parser{};
         std::visit(expr_parser, *ast.condition);
-        inner += Ident() + "(" + expr_parser.GetResult() + ") -> goto Label_" +
-                 std::to_string(ast.label) + ";\n";
+        inner +=
+            fmt::format("{}({}) -> goto Label_{};\n", Ident(), expr_parser.GetResult(), ast.label);
     }
 
     void operator()(const ASTDoWhile& ast) {
         ExprPrinter expr_parser{};
         std::visit(expr_parser, *ast.condition);
-        inner += Ident() + "do {\n";
+        inner += fmt::format("{}do {{\n", Ident());
         scope++;
         ASTNode current = ast.nodes.GetFirst();
         while (current) {
@@ -310,20 +310,20 @@ public:
             current = current->GetNext();
         }
         scope--;
-        inner += Ident() + "} while (" + expr_parser.GetResult() + ");\n";
+        inner += fmt::format("{}}} while ({});\n", Ident(), expr_parser.GetResult());
     }
 
     void operator()(const ASTReturn& ast) {
         ExprPrinter expr_parser{};
         std::visit(expr_parser, *ast.condition);
-        inner += Ident() + "(" + expr_parser.GetResult() + ") -> " +
-                 (ast.kills ? "discard" : "exit") + ";\n";
+        inner += fmt::format("{}({}) -> {};\n", Ident(), expr_parser.GetResult(),
+                             ast.kills ? "discard" : "exit");
     }
 
     void operator()(const ASTBreak& ast) {
         ExprPrinter expr_parser{};
         std::visit(expr_parser, *ast.condition);
-        inner += Ident() + "(" + expr_parser.GetResult() + ") -> break;\n";
+        inner += fmt::format("{}({}) -> break;\n", Ident(), expr_parser.GetResult());
     }
 
     std::string& Ident() {

--- a/src/video_core/shader/ast.cpp
+++ b/src/video_core/shader/ast.cpp
@@ -560,13 +560,13 @@ bool ASTManager::DirectlyRelated(const ASTNode& first, const ASTNode& second) co
     return min->GetParent() == max->GetParent();
 }
 
-void ASTManager::ShowCurrentState(std::string_view state) {
+void ASTManager::ShowCurrentState(std::string_view state) const {
     LOG_CRITICAL(HW_GPU, "\nState {}:\n\n{}\n", state, Print());
     SanityCheck();
 }
 
-void ASTManager::SanityCheck() {
-    for (auto& label : labels) {
+void ASTManager::SanityCheck() const {
+    for (const auto& label : labels) {
         if (!label->GetParent()) {
             LOG_CRITICAL(HW_GPU, "Sanity Check Failed");
         }

--- a/src/video_core/shader/ast.cpp
+++ b/src/video_core/shader/ast.cpp
@@ -326,15 +326,6 @@ public:
         inner += fmt::format("{}({}) -> break;\n", Indent(), expr_parser.GetResult());
     }
 
-    std::string& Indent() {
-        if (memo_scope == scope) {
-            return tabs_memo;
-        }
-        tabs_memo = tabs.substr(0, scope * 2);
-        memo_scope = scope;
-        return tabs_memo;
-    }
-
     void Visit(ASTNode& node) {
         std::visit(*this, *node->GetInnerData());
     }
@@ -344,6 +335,15 @@ public:
     }
 
 private:
+    std::string& Indent() {
+        if (memo_scope == scope) {
+            return tabs_memo;
+        }
+        tabs_memo = tabs.substr(0, scope * 2);
+        memo_scope = scope;
+        return tabs_memo;
+    }
+
     std::string inner{};
     u32 scope{};
 

--- a/src/video_core/shader/ast.h
+++ b/src/video_core/shader/ast.h
@@ -332,9 +332,9 @@ public:
 
     void Decompile();
 
-    void ShowCurrentState(std::string_view state);
+    void ShowCurrentState(std::string_view state) const;
 
-    void SanityCheck();
+    void SanityCheck() const;
 
     void Clear();
 

--- a/src/video_core/shader/ast.h
+++ b/src/video_core/shader/ast.h
@@ -328,7 +328,7 @@ public:
 
     void InsertReturn(Expr condition, bool kills);
 
-    std::string Print();
+    std::string Print() const;
 
     void Decompile();
 


### PR DESCRIPTION
- Makes use of fmt where applicable in order to make strings easier to read, as well as cut down on string churn.
- Makes Indent() non-allocating, given it only ever substrings a string_view that's always guaranteed to exist.