### PR TITLE
shader_ir/memory: Ignore global memory when tracking fails

### DIFF
--- a/src/video_core/shader/shader_ir.h
+++ b/src/video_core/shader/shader_ir.h
@@ -371,8 +371,9 @@ private:
     std::pair<Node, s64> TrackRegister(const GprNode* tracked, const NodeBlock& code,
                                        s64 cursor) const;
 
-    std::tuple<Node, Node, GlobalMemoryBase> TrackAndGetGlobalMemory(
-        NodeBlock& bb, Tegra::Shader::Instruction instr, bool is_write);
+    std::tuple<Node, Node, GlobalMemoryBase> TrackGlobalMemory(NodeBlock& bb,
+                                                               Tegra::Shader::Instruction instr,
+                                                               bool is_write);
 
     const ProgramCode& program_code;
     const u32 main_offset;


### PR DESCRIPTION
Ignore global memory operations instead of invoking undefined behaviour when constant buffer tracking fails and we are blasting through asserts, ignore the operation.

In the case of LDG this means filling the destination registers with zeroes; for STG this means ignore the instruction as a whole.

The default behaviour is still to abort execution on failure.

While we are at it, remove the usage of unnecessary temporaries for STG.