### PR TITLE
maxwell_3d: Remove unused entries

### DIFF
--- a/src/video_core/engines/kepler_compute.cpp
+++ b/src/video_core/engines/kepler_compute.cpp
@@ -50,7 +50,7 @@ void KeplerCompute::CallMethod(const GPU::MethodCall& method_call) {
     }
 }
 
-Tegra::Texture::FullTextureInfo KeplerCompute::GetTexture(std::size_t offset) const {
+Texture::FullTextureInfo KeplerCompute::GetTexture(std::size_t offset) const {
     const std::bitset<8> cbuf_mask = launch_description.const_buffer_enable_mask.Value();
     ASSERT(cbuf_mask[regs.tex_cb_index]);
 
@@ -61,13 +61,11 @@ Tegra::Texture::FullTextureInfo KeplerCompute::GetTexture(std::size_t offset) co
     ASSERT(address < texinfo.Address() + texinfo.size);
 
     const Texture::TextureHandle tex_handle{memory_manager.Read<u32>(address)};
-    return GetTextureInfo(tex_handle, offset);
+    return GetTextureInfo(tex_handle);
 }
 
-Texture::FullTextureInfo KeplerCompute::GetTextureInfo(const Texture::TextureHandle tex_handle,
-                                                       std::size_t offset) const {
-    return Texture::FullTextureInfo{static_cast<u32>(offset), GetTICEntry(tex_handle.tic_id),
-                                    GetTSCEntry(tex_handle.tsc_id)};
+Texture::FullTextureInfo KeplerCompute::GetTextureInfo(Texture::TextureHandle tex_handle) const {
+    return Texture::FullTextureInfo{GetTICEntry(tex_handle.tic_id), GetTSCEntry(tex_handle.tsc_id)};
 }
 
 u32 KeplerCompute::AccessConstBuffer32(ShaderType stage, u64 const_buffer, u64 offset) const {
@@ -89,7 +87,7 @@ SamplerDescriptor KeplerCompute::AccessBindlessSampler(ShaderType stage, u64 con
     const GPUVAddr tex_info_address = tex_info_buffer.Address() + offset;
 
     const Texture::TextureHandle tex_handle{memory_manager.Read<u32>(tex_info_address)};
-    const Texture::FullTextureInfo tex_info = GetTextureInfo(tex_handle, offset);
+    const Texture::FullTextureInfo tex_info = GetTextureInfo(tex_handle);
     SamplerDescriptor result = SamplerDescriptor::FromTicTexture(tex_info.tic.texture_type.Value());
     result.is_shadow.Assign(tex_info.tsc.depth_compare_enabled.Value());
     return result;

--- a/src/video_core/engines/kepler_compute.h
+++ b/src/video_core/engines/kepler_compute.h
@@ -196,11 +196,10 @@ public:
     /// Write the value to the register identified by method.
     void CallMethod(const GPU::MethodCall& method_call);
 
-    Tegra::Texture::FullTextureInfo GetTexture(std::size_t offset) const;
+    Texture::FullTextureInfo GetTexture(std::size_t offset) const;
 
-    /// Given a Texture Handle, returns the TSC and TIC entries.
-    Texture::FullTextureInfo GetTextureInfo(const Texture::TextureHandle tex_handle,
-                                            std::size_t offset) const;
+    /// Given a texture handle, returns the TSC and TIC entries.
+    Texture::FullTextureInfo GetTextureInfo(Texture::TextureHandle tex_handle) const;
 
     u32 AccessConstBuffer32(ShaderType stage, u64 const_buffer, u64 offset) const override;
 

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -760,21 +760,8 @@ Texture::TSCEntry Maxwell3D::GetTSCEntry(u32 tsc_index) const {
     return tsc_entry;
 }
 
-Texture::FullTextureInfo Maxwell3D::GetTextureInfo(const Texture::TextureHandle tex_handle,
-                                                   std::size_t offset) const {
-    Texture::FullTextureInfo tex_info{};
-
-    // Load the TIC data.
-    auto tic_entry = GetTICEntry(tex_handle.tic_id);
-    // TODO(Subv): Workaround for BitField's move constructor being deleted.
-    std::memcpy(&tex_info.tic, &tic_entry, sizeof(tic_entry));
-
-    // Load the TSC data
-    auto tsc_entry = GetTSCEntry(tex_handle.tsc_id);
-    // TODO(Subv): Workaround for BitField's move constructor being deleted.
-    std::memcpy(&tex_info.tsc, &tsc_entry, sizeof(tsc_entry));
-
-    return tex_info;
+Texture::FullTextureInfo Maxwell3D::GetTextureInfo(Texture::TextureHandle tex_handle) const {
+    return Texture::FullTextureInfo{GetTICEntry(tex_handle.tic_id), GetTSCEntry(tex_handle.tsc_id)};
 }
 
 Texture::FullTextureInfo Maxwell3D::GetStageTexture(Regs::ShaderStage stage,
@@ -790,7 +777,7 @@ Texture::FullTextureInfo Maxwell3D::GetStageTexture(Regs::ShaderStage stage,
 
     const Texture::TextureHandle tex_handle{memory_manager.Read<u32>(tex_info_address)};
 
-    return GetTextureInfo(tex_handle, offset);
+    return GetTextureInfo(tex_handle);
 }
 
 u32 Maxwell3D::GetRegisterValue(u32 method) const {
@@ -827,7 +814,7 @@ SamplerDescriptor Maxwell3D::AccessBindlessSampler(ShaderType stage, u64 const_b
     const GPUVAddr tex_info_address = tex_info_buffer.address + offset;
 
     const Texture::TextureHandle tex_handle{memory_manager.Read<u32>(tex_info_address)};
-    const Texture::FullTextureInfo tex_info = GetTextureInfo(tex_handle, offset);
+    const Texture::FullTextureInfo tex_info = GetTextureInfo(tex_handle);
     SamplerDescriptor result = SamplerDescriptor::FromTicTexture(tex_info.tic.texture_type.Value());
     result.is_shadow.Assign(tex_info.tsc.depth_compare_enabled.Value());
     return result;

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -763,7 +763,6 @@ Texture::TSCEntry Maxwell3D::GetTSCEntry(u32 tsc_index) const {
 Texture::FullTextureInfo Maxwell3D::GetTextureInfo(const Texture::TextureHandle tex_handle,
                                                    std::size_t offset) const {
     Texture::FullTextureInfo tex_info{};
-    tex_info.index = static_cast<u32>(offset);
 
     // Load the TIC data.
     auto tic_entry = GetTICEntry(tex_handle.tic_id);

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1254,9 +1254,6 @@ public:
     Texture::FullTextureInfo GetTextureInfo(const Texture::TextureHandle tex_handle,
                                             std::size_t offset) const;
 
-    /// Returns a list of enabled textures for the specified shader stage.
-    std::vector<Texture::FullTextureInfo> GetStageTextures(Regs::ShaderStage stage) const;
-
     /// Returns the texture information for a specific texture in a specific shader stage.
     Texture::FullTextureInfo GetStageTexture(Regs::ShaderStage stage, std::size_t offset) const;
 

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1250,9 +1250,8 @@ public:
 
     void FlushMMEInlineDraw();
 
-    /// Given a Texture Handle, returns the TSC and TIC entries.
-    Texture::FullTextureInfo GetTextureInfo(const Texture::TextureHandle tex_handle,
-                                            std::size_t offset) const;
+    /// Given a texture handle, returns the TSC and TIC entries.
+    Texture::FullTextureInfo GetTextureInfo(Texture::TextureHandle tex_handle) const;
 
     /// Returns the texture information for a specific texture in a specific shader stage.
     Texture::FullTextureInfo GetStageTexture(Regs::ShaderStage stage, std::size_t offset) const;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -969,7 +969,7 @@ TextureBufferUsage RasterizerOpenGL::SetupDrawTextures(Maxwell::ShaderStage stag
 
     for (u32 bindpoint = 0; bindpoint < entries.size(); ++bindpoint) {
         const auto& entry = entries[bindpoint];
-        const auto texture = [&]() {
+        const auto texture = [&] {
             if (!entry.IsBindless()) {
                 return maxwell3d.GetStageTexture(stage, entry.GetOffset());
             }
@@ -977,7 +977,7 @@ TextureBufferUsage RasterizerOpenGL::SetupDrawTextures(Maxwell::ShaderStage stag
             Tegra::Texture::TextureHandle tex_handle;
             Tegra::Engines::ShaderType shader_type = static_cast<Tegra::Engines::ShaderType>(stage);
             tex_handle.raw = maxwell3d.AccessConstBuffer32(shader_type, cbuf.first, cbuf.second);
-            return maxwell3d.GetTextureInfo(tex_handle, entry.GetOffset());
+            return maxwell3d.GetTextureInfo(tex_handle);
         }();
 
         if (SetupTexture(base_bindings.sampler + bindpoint, texture, entry)) {
@@ -1000,7 +1000,7 @@ TextureBufferUsage RasterizerOpenGL::SetupComputeTextures(const Shader& kernel) 
 
     for (u32 bindpoint = 0; bindpoint < entries.size(); ++bindpoint) {
         const auto& entry = entries[bindpoint];
-        const auto texture = [&]() {
+        const auto texture = [&] {
             if (!entry.IsBindless()) {
                 return compute.GetTexture(entry.GetOffset());
             }
@@ -1008,7 +1008,7 @@ TextureBufferUsage RasterizerOpenGL::SetupComputeTextures(const Shader& kernel) 
             Tegra::Texture::TextureHandle tex_handle;
             tex_handle.raw = compute.AccessConstBuffer32(Tegra::Engines::ShaderType::Compute,
                                                          cbuf.first, cbuf.second);
-            return compute.GetTextureInfo(tex_handle, entry.GetOffset());
+            return compute.GetTextureInfo(tex_handle);
         }();
 
         if (SetupTexture(bindpoint, texture, entry)) {
@@ -1046,7 +1046,7 @@ void RasterizerOpenGL::SetupComputeImages(const Shader& shader) {
     const auto& entries = shader->GetShaderEntries().images;
     for (u32 bindpoint = 0; bindpoint < entries.size(); ++bindpoint) {
         const auto& entry = entries[bindpoint];
-        const auto tic = [&]() {
+        const auto tic = [&] {
             if (!entry.IsBindless()) {
                 return compute.GetTexture(entry.GetOffset()).tic;
             }
@@ -1054,7 +1054,7 @@ void RasterizerOpenGL::SetupComputeImages(const Shader& shader) {
             Tegra::Texture::TextureHandle tex_handle;
             tex_handle.raw = compute.AccessConstBuffer32(Tegra::Engines::ShaderType::Compute,
                                                          cbuf.first, cbuf.second);
-            return compute.GetTextureInfo(tex_handle, entry.GetOffset()).tic;
+            return compute.GetTextureInfo(tex_handle).tic;
         }();
         SetupImage(bindpoint, tic, entry);
     }

--- a/src/video_core/textures/texture.h
+++ b/src/video_core/textures/texture.h
@@ -354,7 +354,6 @@ struct TSCEntry {
 static_assert(sizeof(TSCEntry) == 0x20, "TSCEntry has wrong size");
 
 struct FullTextureInfo {
-    u32 index;
     TICEntry tic;
     TSCEntry tsc;
 };


### PR DESCRIPTION
This removes unused parts of the API in maxwell_3d and kepler_compute, simplifying the code overall. There are other changes to be done but I'll wait for related changes to be merged first.