### PR TITLE
filesystem: Re-introduces a workaround to create save data if it does not exist

### DIFF
--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -95,6 +95,16 @@ ResultVal<VirtualDir> SaveDataFactory::Open(SaveDataSpaceId space,
         GetFullPath(space, meta.type, meta.title_id, meta.user_id, meta.save_id);
 
     auto out = dir->GetDirectoryRelative(save_directory);
+    
+    if (out == nullptr) {
+        // TODO (bunnei): This is a work-around to always create a save data directory if it does
+        // not already exist. This is a hack, as we do not understand how this works on hardware.
+        // Without a save data directory, many games will assert on boot. This should not have any
+        // bad side-effects.
+        // TODO: It seems that some games do not use proper channels (EnsureSaveData,
+        // CreateSaveData) to create save data. Need to investigate how HW deals with this.
+        out = dir->CreateDirectoryRelative(save_directory);
+    }
 
     // Return an error if the save data doesn't actually exist.
     if (out == nullptr) {

--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -95,7 +95,7 @@ ResultVal<VirtualDir> SaveDataFactory::Open(SaveDataSpaceId space,
         GetFullPath(space, meta.type, meta.title_id, meta.user_id, meta.save_id);
 
     auto out = dir->GetDirectoryRelative(save_directory);
-    
+
     if (out == nullptr) {
         // TODO (bunnei): This is a work-around to always create a save data directory if it does
         // not already exist. This is a hack, as we do not understand how this works on hardware.


### PR DESCRIPTION
**Do not merge**

Reverts a change (highlighted in bold below) introduced in #2430

> Implementation of creation of save data, and **the removal of a hack where save data would be auto created upon open.** Applications must now use the proper channels (EnsureSaveData, CreateSaveData) to create it. The current impl in this PR for fsp-srv save data creation is quite sparse and will be improved in a separate PR.

Some games such as Breath of the Wild and Fire Emblem Warriors do not use proper channels (EnsureSaveData, CreateSaveData) to create save data. ref #2999 

Furthermore, other relevant directories were not created as a result (cache and temp directories for games like Super Mario Maker 2 and Bloons TD 5 respectively) ref #2963 

We need to investigate what hardware does when save data does not exist because some games do not ensure they exist or are created on boot,

@DarkLordZach This has to be investigated on hardware.