### PR TITLE
ci: Add build name to archive root folder

### DIFF
--- a/.ci/scripts/common/post-upload.sh
+++ b/.ci/scripts/common/post-upload.sh
@@ -1,12 +1,12 @@
 #!/bin/bash -ex
 
 # Copy documentation
-cp license.txt "$REV_NAME"
-cp README.md "$REV_NAME"
+cp license.txt "$DIR_NAME"
+cp README.md "$DIR_NAME"
 
-tar $COMPRESSION_FLAGS "$ARCHIVE_NAME" "$REV_NAME"
+tar $COMPRESSION_FLAGS "$ARCHIVE_NAME" "$DIR_NAME"
 
-mv "$REV_NAME" $RELEASE_NAME
+mv "$DIR_NAME" $RELEASE_NAME
 
 7z a "$REV_NAME.7z" $RELEASE_NAME
 

--- a/.ci/scripts/linux/upload.sh
+++ b/.ci/scripts/linux/upload.sh
@@ -5,10 +5,11 @@
 REV_NAME="yuzu-linux-${GITDATE}-${GITREV}"
 ARCHIVE_NAME="${REV_NAME}.tar.xz"
 COMPRESSION_FLAGS="-cJvf"
+DIR_NAME="${REV_NAME}_${RELEASE_NAME}"
 
-mkdir "$REV_NAME"
+mkdir "$DIR_NAME"
 
-cp build/bin/yuzu-cmd "$REV_NAME"
-cp build/bin/yuzu "$REV_NAME"
+cp build/bin/yuzu-cmd "$DIR_NAME"
+cp build/bin/yuzu "$DIR_NAME"
 
 . .ci/scripts/common/post-upload.sh

--- a/.ci/scripts/windows/upload.ps1
+++ b/.ci/scripts/windows/upload.ps1
@@ -1,6 +1,8 @@
+param($BUILD_NAME)
+
 $GITDATE = $(git show -s --date=short --format='%ad') -replace "-",""
 $GITREV = $(git show -s --format='%h')
-$RELEASE_DIST = "yuzu-windows-msvc"
+$RELEASE_DIST = "yuzu-windows-msvc-$BUILD_NAME"
 
 $MSVC_BUILD_ZIP = "yuzu-windows-msvc-$GITDATE-$GITREV.zip" -replace " ", ""
 $MSVC_BUILD_PDB = "yuzu-windows-msvc-$GITDATE-$GITREV-debugsymbols.zip" -replace " ", ""

--- a/.ci/scripts/windows/upload.sh
+++ b/.ci/scripts/windows/upload.sh
@@ -5,9 +5,10 @@
 REV_NAME="yuzu-windows-mingw-${GITDATE}-${GITREV}"
 ARCHIVE_NAME="${REV_NAME}.tar.gz"
 COMPRESSION_FLAGS="-czvf"
+DIR_NAME="${REV_NAME}_${RELEASE_NAME}"
 
-mkdir "$REV_NAME"
+mkdir "$DIR_NAME"
 # get around the permission issues
-cp -r package/* "$REV_NAME"
+cp -r package/* "$DIR_NAME"
 
 . .ci/scripts/common/post-upload.sh

--- a/.ci/templates/build-msvc.yml
+++ b/.ci/templates/build-msvc.yml
@@ -17,6 +17,7 @@ steps:
   inputs:
     targetType: 'filePath'
     filePath: './.ci/scripts/windows/upload.ps1'
+    arguments: '$(BuildName)'
 - publish: artifacts
   artifact: 'yuzu-$(BuildName)-windows-msvc'
   displayName: 'Upload Artifacts'


### PR DESCRIPTION
Fixes a bug in the installer with multiple variants on the same platform.