### PR TITLE
Revert "ci: Add build name to archive root folder"

### DIFF
--- a/.ci/scripts/common/post-upload.sh
+++ b/.ci/scripts/common/post-upload.sh
@@ -1,12 +1,12 @@
 #!/bin/bash -ex
 
 # Copy documentation
-cp license.txt "$DIR_NAME"
-cp README.md "$DIR_NAME"
+cp license.txt "$REV_NAME"
+cp README.md "$REV_NAME"
 
-tar $COMPRESSION_FLAGS "$ARCHIVE_NAME" "$DIR_NAME"
+tar $COMPRESSION_FLAGS "$ARCHIVE_NAME" "$REV_NAME"
 
-mv "$DIR_NAME" $RELEASE_NAME
+mv "$REV_NAME" $RELEASE_NAME
 
 7z a "$REV_NAME.7z" $RELEASE_NAME
 

--- a/.ci/scripts/linux/upload.sh
+++ b/.ci/scripts/linux/upload.sh
@@ -5,11 +5,10 @@
 REV_NAME="yuzu-linux-${GITDATE}-${GITREV}"
 ARCHIVE_NAME="${REV_NAME}.tar.xz"
 COMPRESSION_FLAGS="-cJvf"
-DIR_NAME="${REV_NAME}_${RELEASE_NAME}"
 
-mkdir "$DIR_NAME"
+mkdir "$REV_NAME"
 
-cp build/bin/yuzu-cmd "$DIR_NAME"
-cp build/bin/yuzu "$DIR_NAME"
+cp build/bin/yuzu-cmd "$REV_NAME"
+cp build/bin/yuzu "$REV_NAME"
 
 . .ci/scripts/common/post-upload.sh

--- a/.ci/scripts/windows/upload.ps1
+++ b/.ci/scripts/windows/upload.ps1
@@ -1,8 +1,6 @@
-param($BUILD_NAME)
-
 $GITDATE = $(git show -s --date=short --format='%ad') -replace "-",""
 $GITREV = $(git show -s --format='%h')
-$RELEASE_DIST = "yuzu-windows-msvc-$BUILD_NAME"
+$RELEASE_DIST = "yuzu-windows-msvc"
 
 $MSVC_BUILD_ZIP = "yuzu-windows-msvc-$GITDATE-$GITREV.zip" -replace " ", ""
 $MSVC_BUILD_PDB = "yuzu-windows-msvc-$GITDATE-$GITREV-debugsymbols.zip" -replace " ", ""

--- a/.ci/scripts/windows/upload.sh
+++ b/.ci/scripts/windows/upload.sh
@@ -5,10 +5,9 @@
 REV_NAME="yuzu-windows-mingw-${GITDATE}-${GITREV}"
 ARCHIVE_NAME="${REV_NAME}.tar.gz"
 COMPRESSION_FLAGS="-czvf"
-DIR_NAME="${REV_NAME}_${RELEASE_NAME}"
 
-mkdir "$DIR_NAME"
+mkdir "$REV_NAME"
 # get around the permission issues
-cp -r package/* "$DIR_NAME"
+cp -r package/* "$REV_NAME"
 
 . .ci/scripts/common/post-upload.sh

--- a/.ci/templates/build-msvc.yml
+++ b/.ci/templates/build-msvc.yml
@@ -17,7 +17,6 @@ steps:
   inputs:
     targetType: 'filePath'
     filePath: './.ci/scripts/windows/upload.ps1'
-    arguments: '$(BuildName)'
 - publish: artifacts
   artifact: 'yuzu-$(BuildName)-windows-msvc'
   displayName: 'Upload Artifacts'


### PR DESCRIPTION
This reverts commit 5e553a6c267f4ab96a89833f1006ea27fd78b30a.

This commit introduced a regression (unintentional) by changing the folder that the build is deployed to (intentional). The installer creates a shortcut at install time which reads from the config at install time to point the shortcut to the folder path, so when this change went out, it caused the shortcut to point to the wrong launch path. Users would need to reinstall with a patched config to fix the issue, but for reasons we haven't figured out at the moment, the config update doesn't seem to be pushed out properly to some individuals, so we will just revert and hope for the best. 