### PR TITLE
gl_rasterizer: Upload constant buffers with glNamedBufferSubData

### DIFF
--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -8,12 +8,16 @@
 
 #include "common/assert.h"
 #include "common/microprofile.h"
+#include "video_core/engines/maxwell_3d.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/gl_buffer_cache.h"
+#include "video_core/renderer_opengl/gl_device.h"
 #include "video_core/renderer_opengl/gl_rasterizer.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 
 namespace OpenGL {
+
+using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 
 MICROPROFILE_DEFINE(OpenGL_Buffer_Download, "OpenGL", "Buffer Download", MP_RGB(192, 192, 128));
 
@@ -26,11 +30,22 @@ CachedBufferBlock::CachedBufferBlock(CacheAddr cache_addr, const std::size_t siz
 CachedBufferBlock::~CachedBufferBlock() = default;
 
 OGLBufferCache::OGLBufferCache(RasterizerOpenGL& rasterizer, Core::System& system,
-                               std::size_t stream_size)
-    : VideoCommon::BufferCache<Buffer, GLuint, OGLStreamBuffer>{
-          rasterizer, system, std::make_unique<OGLStreamBuffer>(stream_size, true)} {}
+                               const Device& device, std::size_t stream_size)
+    : GenericBufferCache{rasterizer, system, std::make_unique<OGLStreamBuffer>(stream_size, true)} {
+    if (!device.HasFastBufferSubData()) {
+        return;
+    }
 
-OGLBufferCache::~OGLBufferCache() = default;
+    static constexpr auto size = static_cast<GLsizeiptr>(Maxwell::MaxConstBufferSize);
+    glCreateBuffers(static_cast<GLsizei>(std::size(cbufs)), std::data(cbufs));
+    for (const GLuint cbuf : cbufs) {
+        glNamedBufferData(cbuf, size, nullptr, GL_STREAM_DRAW);
+    }
+}
+
+OGLBufferCache::~OGLBufferCache() {
+    glDeleteBuffers(static_cast<GLsizei>(std::size(cbufs)), std::data(cbufs));
+}
 
 Buffer OGLBufferCache::CreateBlock(CacheAddr cache_addr, std::size_t size) {
     return std::make_shared<CachedBufferBlock>(cache_addr, size);
@@ -67,6 +82,14 @@ void OGLBufferCache::CopyBlock(const Buffer& src, const Buffer& dst, std::size_t
     glCopyNamedBufferSubData(*src->GetHandle(), *dst->GetHandle(),
                              static_cast<GLintptr>(src_offset), static_cast<GLintptr>(dst_offset),
                              static_cast<GLsizeiptr>(size));
+}
+
+OGLBufferCache::BufferInfo OGLBufferCache::ConstBufferUpload(const void* raw_pointer,
+                                                             std::size_t size) {
+    DEBUG_ASSERT(cbuf_cursor < std::size(cbufs));
+    const GLuint& cbuf = cbufs[cbuf_cursor++];
+    glNamedBufferSubData(cbuf, 0, static_cast<GLsizeiptr>(size), raw_pointer);
+    return {&cbuf, 0};
 }
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_buffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.h
@@ -4,10 +4,12 @@
 
 #pragma once
 
+#include <array>
 #include <memory>
 
 #include "common/common_types.h"
 #include "video_core/buffer_cache/buffer_cache.h"
+#include "video_core/engines/maxwell_3d.h"
 #include "video_core/rasterizer_cache.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/renderer_opengl/gl_stream_buffer.h"
@@ -18,12 +20,14 @@ class System;
 
 namespace OpenGL {
 
+class Device;
 class OGLStreamBuffer;
 class RasterizerOpenGL;
 
 class CachedBufferBlock;
 
 using Buffer = std::shared_ptr<CachedBufferBlock>;
+using GenericBufferCache = VideoCommon::BufferCache<Buffer, GLuint, OGLStreamBuffer>;
 
 class CachedBufferBlock : public VideoCommon::BufferBlock {
 public:
@@ -38,13 +42,17 @@ private:
     OGLBuffer gl_buffer{};
 };
 
-class OGLBufferCache final : public VideoCommon::BufferCache<Buffer, GLuint, OGLStreamBuffer> {
+class OGLBufferCache final : public GenericBufferCache {
 public:
     explicit OGLBufferCache(RasterizerOpenGL& rasterizer, Core::System& system,
-                            std::size_t stream_size);
+                            const Device& device, std::size_t stream_size);
     ~OGLBufferCache();
 
     const GLuint* GetEmptyBuffer(std::size_t) override;
+
+    void Acquire() noexcept {
+        cbuf_cursor = 0;
+    }
 
 protected:
     Buffer CreateBlock(CacheAddr cache_addr, std::size_t size) override;
@@ -61,6 +69,14 @@ protected:
 
     void CopyBlock(const Buffer& src, const Buffer& dst, std::size_t src_offset,
                    std::size_t dst_offset, std::size_t size) override;
+
+    BufferInfo ConstBufferUpload(const void* raw_pointer, std::size_t size) override;
+
+private:
+    std::size_t cbuf_cursor = 0;
+    std::array<GLuint, Tegra::Engines::Maxwell3D::Regs::MaxConstBuffers *
+                           Tegra::Engines::Maxwell3D::Regs::MaxShaderProgram>
+        cbufs;
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -51,7 +51,10 @@ bool HasExtension(const std::vector<std::string_view>& images, std::string_view 
 } // Anonymous namespace
 
 Device::Device() {
+    const std::string_view vendor = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
     const std::vector extensions = GetExtensions();
+
+    const bool is_nvidia = vendor == "NVIDIA Corporation";
 
     uniform_buffer_alignment = GetInteger<std::size_t>(GL_UNIFORM_BUFFER_OFFSET_ALIGNMENT);
     shader_storage_alignment = GetInteger<std::size_t>(GL_SHADER_STORAGE_BUFFER_OFFSET_ALIGNMENT);
@@ -64,6 +67,7 @@ Device::Device() {
     has_variable_aoffi = TestVariableAoffi();
     has_component_indexing_bug = TestComponentIndexingBug();
     has_precise_bug = TestPreciseBug();
+    has_fast_buffer_sub_data = is_nvidia;
 
     LOG_INFO(Render_OpenGL, "Renderer_VariableAOFFI: {}", has_variable_aoffi);
     LOG_INFO(Render_OpenGL, "Renderer_ComponentIndexingBug: {}", has_component_indexing_bug);

--- a/src/video_core/renderer_opengl/gl_device.h
+++ b/src/video_core/renderer_opengl/gl_device.h
@@ -54,6 +54,10 @@ public:
         return has_precise_bug;
     }
 
+    bool HasFastBufferSubData() const {
+        return has_fast_buffer_sub_data;
+    }
+
 private:
     static bool TestVariableAoffi();
     static bool TestComponentIndexingBug();
@@ -69,6 +73,7 @@ private:
     bool has_variable_aoffi{};
     bool has_component_indexing_bug{};
     bool has_precise_bug{};
+    bool has_fast_buffer_sub_data{};
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -575,11 +575,9 @@ void RasterizerOpenGL::DrawPrelude() {
                   (sizeof(GLShader::MaxwellUniformData) + device.GetUniformBufferAlignment()) *
                       Maxwell::MaxShaderStage;
 
-    if (!device.HasFastBufferSubData()) {
-        // Add space for at least 18 constant buffers
-        buffer_size += Maxwell::MaxConstBuffers *
-                       (Maxwell::MaxConstBufferSize + device.GetUniformBufferAlignment());
-    }
+    // Add space for at least 18 constant buffers
+    buffer_size += Maxwell::MaxConstBuffers *
+                   (Maxwell::MaxConstBufferSize + device.GetUniformBufferAlignment());
 
     // Prepare the vertex array.
     buffer_cache.Map(buffer_size);
@@ -743,12 +741,10 @@ void RasterizerOpenGL::DispatchCompute(GPUVAddr code_addr) {
     state.draw.shader_program = program;
     state.draw.program_pipeline = 0;
 
-    if (!device.HasFastBufferSubData()) {
-        const std::size_t buffer_size =
-            Tegra::Engines::KeplerCompute::NumConstBuffers *
-            (Maxwell::MaxConstBufferSize + device.GetUniformBufferAlignment());
-        buffer_cache.Map(buffer_size);
-    }
+    const std::size_t buffer_size =
+        Tegra::Engines::KeplerCompute::NumConstBuffers *
+        (Maxwell::MaxConstBufferSize + device.GetUniformBufferAlignment());
+    buffer_cache.Map(buffer_size);
 
     bind_ubo_pushbuffer.Setup(0);
     bind_ssbo_pushbuffer.Setup(0);
@@ -756,9 +752,7 @@ void RasterizerOpenGL::DispatchCompute(GPUVAddr code_addr) {
     SetupComputeConstBuffers(kernel);
     SetupComputeGlobalMemory(kernel);
 
-    if (!device.HasFastBufferSubData()) {
-        buffer_cache.Unmap();
-    }
+    buffer_cache.Unmap();
 
     bind_ubo_pushbuffer.Bind();
     bind_ssbo_pushbuffer.Bind();


### PR DESCRIPTION
Nvidia's OpenGL driver maps `gl(Named)BufferSubData` with some requirements to a fast. This path has an extra `memcpy` but updates the buffer without orphaning or waiting for previous calls. It can be seen as a better model for "push constants" that can upload a whole UBO instead of 256 bytes.

This path has some requirements established [here](http://on-demand.gputechconf.com/gtc/2014/presentations/S4379-opengl-44-scene-rendering-techniques.pdf#page=24).

Instead of using the stream buffer, this commits moves constant buffers uploads to calls of `glNamedBufferSubData` and from my testing it brings a performance improvement. This is disabled when the vendor is not Nvidia since it brings performance regressions.

Thanks to @graphitemaster for telling me about [this](http://on-demand.gputechconf.com/gtc/2014/presentations/S4379-opengl-44-scene-rendering-techniques.pdf) presentation from Nvidia. I recommend it to everyone interested in optimized OpenGL.