### PR TITLE
ci: Rename build folder only on non-mainline builds

### DIFF
--- a/.ci/scripts/common/post-upload.sh
+++ b/.ci/scripts/common/post-upload.sh
@@ -1,12 +1,12 @@
 #!/bin/bash -ex
 
 # Copy documentation
-cp license.txt "$REV_NAME"
-cp README.md "$REV_NAME"
+cp license.txt "$DIR_NAME"
+cp README.md "$DIR_NAME"
 
-tar $COMPRESSION_FLAGS "$ARCHIVE_NAME" "$REV_NAME"
+tar $COMPRESSION_FLAGS "$ARCHIVE_NAME" "$DIR_NAME"
 
-mv "$REV_NAME" $RELEASE_NAME
+mv "$DIR_NAME" $RELEASE_NAME
 
 7z a "$REV_NAME.7z" $RELEASE_NAME
 

--- a/.ci/scripts/linux/upload.sh
+++ b/.ci/scripts/linux/upload.sh
@@ -6,9 +6,15 @@ REV_NAME="yuzu-linux-${GITDATE}-${GITREV}"
 ARCHIVE_NAME="${REV_NAME}.tar.xz"
 COMPRESSION_FLAGS="-cJvf"
 
-mkdir "$REV_NAME"
+if [ "${RELEASE_NAME}" = "mainline" ]; then
+    DIR_NAME="${REV_NAME}_${RELEASE_NAME}"
+else
+    DIR_NAME="${REV_NAME}"
+fi
 
-cp build/bin/yuzu-cmd "$REV_NAME"
-cp build/bin/yuzu "$REV_NAME"
+mkdir "$DIR_NAME"
+
+cp build/bin/yuzu-cmd "$DIR_NAME"
+cp build/bin/yuzu "$DIR_NAME"
 
 . .ci/scripts/common/post-upload.sh

--- a/.ci/scripts/windows/upload.ps1
+++ b/.ci/scripts/windows/upload.ps1
@@ -1,6 +1,13 @@
+param($BUILD_NAME)
+
 $GITDATE = $(git show -s --date=short --format='%ad') -replace "-",""
 $GITREV = $(git show -s --format='%h')
-$RELEASE_DIST = "yuzu-windows-msvc"
+
+if ("$BUILD_NAME" -eq "mainline") {
+    $RELEASE_DIST = "yuzu-windows-msvc-$BUILD_NAME"
+} else {
+    $RELEASE_DIST = "yuzu-windows-msvc"
+}
 
 $MSVC_BUILD_ZIP = "yuzu-windows-msvc-$GITDATE-$GITREV.zip" -replace " ", ""
 $MSVC_BUILD_PDB = "yuzu-windows-msvc-$GITDATE-$GITREV-debugsymbols.zip" -replace " ", ""

--- a/.ci/scripts/windows/upload.sh
+++ b/.ci/scripts/windows/upload.sh
@@ -6,8 +6,14 @@ REV_NAME="yuzu-windows-mingw-${GITDATE}-${GITREV}"
 ARCHIVE_NAME="${REV_NAME}.tar.gz"
 COMPRESSION_FLAGS="-czvf"
 
-mkdir "$REV_NAME"
+if [ "${RELEASE_NAME}" = "mainline" ]; then
+    DIR_NAME="${REV_NAME}_${RELEASE_NAME}"
+else
+    DIR_NAME="${REV_NAME}"
+fi
+
+mkdir "$DIR_NAME"
 # get around the permission issues
-cp -r package/* "$REV_NAME"
+cp -r package/* "$DIR_NAME"
 
 . .ci/scripts/common/post-upload.sh

--- a/.ci/templates/build-msvc.yml
+++ b/.ci/templates/build-msvc.yml
@@ -17,6 +17,7 @@ steps:
   inputs:
     targetType: 'filePath'
     filePath: './.ci/scripts/windows/upload.ps1'
+    arguments: '$(BuildName)'
 - publish: artifacts
   artifact: 'yuzu-$(BuildName)-windows-msvc'
   displayName: 'Upload Artifacts'


### PR DESCRIPTION
Adds a build name suffix to the archive folder name when the build name is *not* `mainline`.