### PR TITLE
buffer_cache: Add missing include

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -12,6 +12,8 @@
 #include <utility>
 #include <vector>
 
+#include <boost/range/iterator_range.hpp>
+
 #include "common/alignment.h"
 #include "common/common_types.h"
 #include "core/core.h"

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -12,6 +12,8 @@
 #include <utility>
 #include <vector>
 
+#include <boost/icl/interval_map.hpp>
+#include <boost/icl/interval_set.hpp>
 #include <boost/range/iterator_range.hpp>
 
 #include "common/alignment.h"


### PR DESCRIPTION
`boost::make_iterator_range` is available when `boost/range/iterator_range.hpp` is included

Also, include `boost/icl/interval_map.hpp` and `boost/icl/interval_set.hpp`

`boost/range.hpp` is **not** present in the trimmed down version of boost yuzu uses.

Supersedes #3049 by using the correct include(s). Also, fixes #2821 