### PR TITLE
GLSLDecompiler: Correct Texture Gather Offset.

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1670,7 +1670,7 @@ private:
 
         const auto type = meta->sampler.IsShadow() ? Type::Float : Type::Int;
         return {GenerateTexture(operation, "Gather",
-                                {TextureArgument{type, meta->component}, TextureAoffi{}}) +
+                                {TextureAoffi{}, TextureArgument{type, meta->component}}) +
                     GetSwizzle(meta->element),
                 Type::Float};
     }


### PR DESCRIPTION
This commit corrects the argument ordering in textureGatherOffset.