### PR TITLE
gl_shader_cache: Miscellaneous changes to shaders

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(video_core STATIC
     engines/maxwell_dma.h
     engines/shader_bytecode.h
     engines/shader_header.h
+    engines/shader_type.h
     gpu.cpp
     gpu.h
     gpu_asynch.cpp

--- a/src/video_core/engines/const_buffer_engine_interface.h
+++ b/src/video_core/engines/const_buffer_engine_interface.h
@@ -8,18 +8,10 @@
 #include "common/bit_field.h"
 #include "common/common_types.h"
 #include "video_core/engines/shader_bytecode.h"
+#include "video_core/engines/shader_type.h"
 #include "video_core/textures/texture.h"
 
 namespace Tegra::Engines {
-
-enum class ShaderType : u32 {
-    Vertex = 0,
-    TesselationControl = 1,
-    TesselationEval = 2,
-    Geometry = 3,
-    Fragment = 4,
-    Compute = 5,
-};
 
 struct SamplerDescriptor {
     union {

--- a/src/video_core/engines/kepler_compute.cpp
+++ b/src/video_core/engines/kepler_compute.cpp
@@ -8,6 +8,7 @@
 #include "core/core.h"
 #include "video_core/engines/kepler_compute.h"
 #include "video_core/engines/maxwell_3d.h"
+#include "video_core/engines/shader_type.h"
 #include "video_core/memory_manager.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_base.h"

--- a/src/video_core/engines/kepler_compute.h
+++ b/src/video_core/engines/kepler_compute.h
@@ -12,6 +12,7 @@
 #include "common/common_types.h"
 #include "video_core/engines/const_buffer_engine_interface.h"
 #include "video_core/engines/engine_upload.h"
+#include "video_core/engines/shader_type.h"
 #include "video_core/gpu.h"
 #include "video_core/textures/texture.h"
 

--- a/src/video_core/engines/kepler_compute.h
+++ b/src/video_core/engines/kepler_compute.h
@@ -140,7 +140,7 @@ public:
 
         INSERT_PADDING_WORDS(0x3);
 
-        BitField<0, 16, u32> shared_alloc;
+        BitField<0, 18, u32> shared_alloc;
 
         BitField<16, 16, u32> block_dim_x;
         union {

--- a/src/video_core/engines/kepler_compute.h
+++ b/src/video_core/engines/kepler_compute.h
@@ -178,7 +178,12 @@ public:
             BitField<24, 5, u32> gpr_alloc;
         };
 
-        INSERT_PADDING_WORDS(0x11);
+        union {
+            BitField<0, 20, u32> local_crs_alloc;
+            BitField<24, 5, u32> sass_version;
+        };
+
+        INSERT_PADDING_WORDS(0x10);
     } launch_description{};
 
     struct {

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -9,6 +9,7 @@
 #include "core/core_timing.h"
 #include "video_core/debug_utils/debug_utils.h"
 #include "video_core/engines/maxwell_3d.h"
+#include "video_core/engines/shader_type.h"
 #include "video_core/memory_manager.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/textures/texture.h"
@@ -368,24 +369,24 @@ void Maxwell3D::CallMethod(const GPU::MethodCall& method_call) {
         StartCBData(method);
         break;
     }
-    case MAXWELL3D_REG_INDEX(cb_bind[0].raw_config): {
-        ProcessCBBind(Regs::ShaderStage::Vertex);
+    case MAXWELL3D_REG_INDEX(cb_bind[0]): {
+        ProcessCBBind(0);
         break;
     }
-    case MAXWELL3D_REG_INDEX(cb_bind[1].raw_config): {
-        ProcessCBBind(Regs::ShaderStage::TesselationControl);
+    case MAXWELL3D_REG_INDEX(cb_bind[1]): {
+        ProcessCBBind(1);
         break;
     }
-    case MAXWELL3D_REG_INDEX(cb_bind[2].raw_config): {
-        ProcessCBBind(Regs::ShaderStage::TesselationEval);
+    case MAXWELL3D_REG_INDEX(cb_bind[2]): {
+        ProcessCBBind(2);
         break;
     }
-    case MAXWELL3D_REG_INDEX(cb_bind[3].raw_config): {
-        ProcessCBBind(Regs::ShaderStage::Geometry);
+    case MAXWELL3D_REG_INDEX(cb_bind[3]): {
+        ProcessCBBind(3);
         break;
     }
-    case MAXWELL3D_REG_INDEX(cb_bind[4].raw_config): {
-        ProcessCBBind(Regs::ShaderStage::Fragment);
+    case MAXWELL3D_REG_INDEX(cb_bind[4]): {
+        ProcessCBBind(4);
         break;
     }
     case MAXWELL3D_REG_INDEX(draw.vertex_end_gl): {
@@ -687,10 +688,10 @@ void Maxwell3D::DrawArrays() {
     }
 }
 
-void Maxwell3D::ProcessCBBind(Regs::ShaderStage stage) {
+void Maxwell3D::ProcessCBBind(std::size_t stage_index) {
     // Bind the buffer currently in CB_ADDRESS to the specified index in the desired shader stage.
-    auto& shader = state.shader_stages[static_cast<std::size_t>(stage)];
-    auto& bind_data = regs.cb_bind[static_cast<std::size_t>(stage)];
+    auto& shader = state.shader_stages[stage_index];
+    auto& bind_data = regs.cb_bind[stage_index];
 
     ASSERT(bind_data.index < Regs::MaxConstBuffers);
     auto& buffer = shader.const_buffers[bind_data.index];
@@ -757,9 +758,9 @@ Texture::FullTextureInfo Maxwell3D::GetTextureInfo(Texture::TextureHandle tex_ha
     return Texture::FullTextureInfo{GetTICEntry(tex_handle.tic_id), GetTSCEntry(tex_handle.tsc_id)};
 }
 
-Texture::FullTextureInfo Maxwell3D::GetStageTexture(Regs::ShaderStage stage,
-                                                    std::size_t offset) const {
-    const auto& shader = state.shader_stages[static_cast<std::size_t>(stage)];
+Texture::FullTextureInfo Maxwell3D::GetStageTexture(ShaderType stage, std::size_t offset) const {
+    const auto stage_index = static_cast<std::size_t>(stage);
+    const auto& shader = state.shader_stages[stage_index];
     const auto& tex_info_buffer = shader.const_buffers[regs.tex_cb_index];
     ASSERT(tex_info_buffer.enabled && tex_info_buffer.address != 0);
 

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -63,7 +63,6 @@ public:
         static constexpr std::size_t NumVertexArrays = 32;
         static constexpr std::size_t NumVertexAttributes = 32;
         static constexpr std::size_t NumVaryings = 31;
-        static constexpr std::size_t NumTextureSamplers = 32;
         static constexpr std::size_t NumImages = 8; // TODO(Rodrigo): Investigate this number
         static constexpr std::size_t NumClipDistances = 8;
         static constexpr std::size_t MaxShaderProgram = 6;

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -18,6 +18,7 @@
 #include "video_core/engines/const_buffer_engine_interface.h"
 #include "video_core/engines/const_buffer_info.h"
 #include "video_core/engines/engine_upload.h"
+#include "video_core/engines/shader_type.h"
 #include "video_core/gpu.h"
 #include "video_core/macro_interpreter.h"
 #include "video_core/textures/texture.h"
@@ -128,14 +129,6 @@ public:
             TesselationEval = 3,
             Geometry = 4,
             Fragment = 5,
-        };
-
-        enum class ShaderStage : u32 {
-            Vertex = 0,
-            TesselationControl = 1,
-            TesselationEval = 2,
-            Geometry = 3,
-            Fragment = 4,
         };
 
         struct VertexAttribute {
@@ -1254,7 +1247,7 @@ public:
     Texture::FullTextureInfo GetTextureInfo(Texture::TextureHandle tex_handle) const;
 
     /// Returns the texture information for a specific texture in a specific shader stage.
-    Texture::FullTextureInfo GetStageTexture(Regs::ShaderStage stage, std::size_t offset) const;
+    Texture::FullTextureInfo GetStageTexture(ShaderType stage, std::size_t offset) const;
 
     u32 AccessConstBuffer32(ShaderType stage, u64 const_buffer, u64 offset) const override;
 
@@ -1376,7 +1369,7 @@ private:
     void FinishCBData();
 
     /// Handles a write to the CB_BIND register.
-    void ProcessCBBind(Regs::ShaderStage stage);
+    void ProcessCBBind(std::size_t stage_index);
 
     /// Handles a write to the VERTEX_END_GL register, triggering a draw.
     void DrawArrays();

--- a/src/video_core/engines/shader_type.h
+++ b/src/video_core/engines/shader_type.h
@@ -1,0 +1,20 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common/common_types.h"
+
+namespace Tegra::Engines {
+
+enum class ShaderType : u32 {
+    Vertex = 0,
+    TesselationControl = 1,
+    TesselationEval = 2,
+    Geometry = 3,
+    Fragment = 4,
+    Compute = 5,
+};
+
+} // namespace Tegra::Engines

--- a/src/video_core/engines/shader_type.h
+++ b/src/video_core/engines/shader_type.h
@@ -16,5 +16,6 @@ enum class ShaderType : u32 {
     Fragment = 4,
     Compute = 5,
 };
+static constexpr std::size_t MaxShaderTypes = 6;
 
 } // namespace Tegra::Engines

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -74,6 +74,7 @@ Device::Device() {
     const std::vector extensions = GetExtensions();
 
     const bool is_nvidia = vendor == "NVIDIA Corporation";
+    const bool is_intel = vendor == "Intel";
 
     // Reserve the first UBO for emulation bindings
     base_bindings[0] = BaseBindings{ReservedUniformBlocks, 0, 0, 0};
@@ -110,6 +111,7 @@ Device::Device() {
     has_variable_aoffi = TestVariableAoffi();
     has_component_indexing_bug = TestComponentIndexingBug();
     has_precise_bug = TestPreciseBug();
+    has_broken_compute = is_intel;
     has_fast_buffer_sub_data = is_nvidia;
 
     LOG_INFO(Render_OpenGL, "Renderer_VariableAOFFI: {}", has_variable_aoffi);
@@ -127,6 +129,7 @@ Device::Device(std::nullptr_t) {
     has_image_load_formatted = true;
     has_variable_aoffi = true;
     has_component_indexing_bug = false;
+    has_broken_compute = false;
     has_precise_bug = false;
 }
 

--- a/src/video_core/renderer_opengl/gl_device.h
+++ b/src/video_core/renderer_opengl/gl_device.h
@@ -6,13 +6,31 @@
 
 #include <cstddef>
 #include "common/common_types.h"
+#include "video_core/engines/shader_type.h"
 
 namespace OpenGL {
 
-class Device {
+static constexpr u32 EmulationUniformBlockBinding = 0;
+
+class Device final {
 public:
+    struct BaseBindings final {
+        u32 uniform_buffer{};
+        u32 shader_storage_buffer{};
+        u32 sampler{};
+        u32 image{};
+    };
+
     explicit Device();
     explicit Device(std::nullptr_t);
+
+    const BaseBindings& GetBaseBindings(std::size_t stage_index) const noexcept {
+        return base_bindings[stage_index];
+    }
+
+    const BaseBindings& GetBaseBindings(Tegra::Engines::ShaderType shader_type) const noexcept {
+        return GetBaseBindings(static_cast<std::size_t>(shader_type));
+    }
 
     std::size_t GetUniformBufferAlignment() const {
         return uniform_buffer_alignment;
@@ -67,6 +85,7 @@ private:
     static bool TestComponentIndexingBug();
     static bool TestPreciseBug();
 
+    std::array<BaseBindings, Tegra::Engines::MaxShaderTypes> base_bindings;
     std::size_t uniform_buffer_alignment{};
     std::size_t shader_storage_alignment{};
     u32 max_vertex_attributes{};

--- a/src/video_core/renderer_opengl/gl_device.h
+++ b/src/video_core/renderer_opengl/gl_device.h
@@ -76,6 +76,10 @@ public:
         return has_precise_bug;
     }
 
+    bool HasBrokenCompute() const {
+        return has_broken_compute;
+    }
+
     bool HasFastBufferSubData() const {
         return has_fast_buffer_sub_data;
     }
@@ -97,6 +101,7 @@ private:
     bool has_variable_aoffi{};
     bool has_component_indexing_bug{};
     bool has_precise_bug{};
+    bool has_broken_compute{};
     bool has_fast_buffer_sub_data{};
 };
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -743,6 +743,8 @@ bool RasterizerOpenGL::DrawMultiBatch(bool is_indexed) {
 }
 
 void RasterizerOpenGL::DispatchCompute(GPUVAddr code_addr) {
+    buffer_cache.Acquire();
+
     auto kernel = shader_cache.GetComputeKernel(code_addr);
     SetupComputeTextures(kernel);
     SetupComputeImages(kernel);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -731,7 +731,8 @@ void RasterizerOpenGL::DispatchCompute(GPUVAddr code_addr) {
 
     const auto& launch_desc = system.GPU().KeplerCompute().launch_description;
     const ProgramVariant variant(launch_desc.block_dim_x, launch_desc.block_dim_y,
-                                 launch_desc.block_dim_z, launch_desc.shared_alloc);
+                                 launch_desc.block_dim_z, launch_desc.shared_alloc,
+                                 launch_desc.local_pos_alloc);
     std::tie(state.draw.shader_program, std::ignore) = kernel->GetHandle(variant);
     state.draw.program_pipeline = 0;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -940,12 +940,9 @@ void RasterizerOpenGL::SetupGlobalMemory(u32 binding, const GLShader::GlobalMemo
 
 void RasterizerOpenGL::SetupDrawTextures(std::size_t stage_index, const Shader& shader) {
     MICROPROFILE_SCOPE(OpenGL_Texture);
-    const auto& gpu = system.GPU();
-    const auto& maxwell3d = gpu.Maxwell3D();
-    const auto& entries = shader->GetShaderEntries().samplers;
-
+    const auto& maxwell3d = system.GPU().Maxwell3D();
     u32 binding = device.GetBaseBindings(stage_index).sampler;
-    for (const auto& entry : entries) {
+    for (const auto& entry : shader->GetShaderEntries().samplers) {
         const auto shader_type = static_cast<Tegra::Engines::ShaderType>(stage_index);
         const auto texture = GetTextureInfo(maxwell3d, entry, shader_type);
         SetupTexture(binding++, texture, entry);
@@ -955,10 +952,8 @@ void RasterizerOpenGL::SetupDrawTextures(std::size_t stage_index, const Shader& 
 void RasterizerOpenGL::SetupComputeTextures(const Shader& kernel) {
     MICROPROFILE_SCOPE(OpenGL_Texture);
     const auto& compute = system.GPU().KeplerCompute();
-    const auto& entries = kernel->GetShaderEntries().samplers;
-
     u32 binding = 0;
-    for (const auto& entry : entries) {
+    for (const auto& entry : kernel->GetShaderEntries().samplers) {
         const auto texture = GetTextureInfo(compute, entry, Tegra::Engines::ShaderType::Compute);
         SetupTexture(binding++, texture, entry);
     }
@@ -987,26 +982,20 @@ void RasterizerOpenGL::SetupTexture(u32 binding, const Tegra::Texture::FullTextu
 
 void RasterizerOpenGL::SetupDrawImages(std::size_t stage_index, const Shader& shader) {
     const auto& maxwell3d = system.GPU().Maxwell3D();
-    const auto& entries = shader->GetShaderEntries().images;
-
-    const auto num_entries = static_cast<u32>(entries.size());
-    for (u32 bindpoint = 0; bindpoint < num_entries; ++bindpoint) {
-        const auto& entry = entries[bindpoint];
+    u32 binding = device.GetBaseBindings(stage_index).image;
+    for (const auto& entry : shader->GetShaderEntries().images) {
         const auto shader_type = static_cast<Tegra::Engines::ShaderType>(stage_index);
         const auto tic = GetTextureInfo(maxwell3d, entry, shader_type).tic;
-        SetupImage(bindpoint, tic, entry);
+        SetupImage(binding++, tic, entry);
     }
 }
 
 void RasterizerOpenGL::SetupComputeImages(const Shader& shader) {
     const auto& compute = system.GPU().KeplerCompute();
-    const auto& entries = shader->GetShaderEntries().images;
-
-    const auto num_entries = static_cast<u32>(entries.size());
-    for (u32 bindpoint = 0; bindpoint < num_entries; ++bindpoint) {
-        const auto& entry = entries[bindpoint];
+    u32 binding = 0;
+    for (const auto& entry : shader->GetShaderEntries().images) {
         const auto tic = GetTextureInfo(compute, entry, Tegra::Engines::ShaderType::Compute).tic;
-        SetupImage(bindpoint, tic, entry);
+        SetupImage(binding++, tic, entry);
     }
 }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -743,6 +743,10 @@ bool RasterizerOpenGL::DrawMultiBatch(bool is_indexed) {
 }
 
 void RasterizerOpenGL::DispatchCompute(GPUVAddr code_addr) {
+    if (device.HasBrokenCompute()) {
+        return;
+    }
+
     buffer_cache.Acquire();
 
     auto kernel = shader_cache.GetComputeKernel(code_addr);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -857,13 +857,13 @@ bool RasterizerOpenGL::AccelerateDisplay(const Tegra::FramebufferConfig& config,
 
 void RasterizerOpenGL::SetupDrawConstBuffers(std::size_t stage_index, const Shader& shader) {
     MICROPROFILE_SCOPE(OpenGL_UBO);
-    const u32 base_binding = device.GetBaseBindings(stage_index).uniform_buffer;
     const auto& stages = system.GPU().Maxwell3D().state.shader_stages;
     const auto& shader_stage = stages[stage_index];
 
+    u32 binding = device.GetBaseBindings(stage_index).uniform_buffer;
     for (const auto& entry : shader->GetShaderEntries().const_buffers) {
         const auto& buffer = shader_stage.const_buffers[entry.GetIndex()];
-        SetupConstBuffer(base_binding + entry.GetIndex(), buffer, entry);
+        SetupConstBuffer(binding++, buffer, entry);
     }
 }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -731,7 +731,7 @@ void RasterizerOpenGL::DispatchCompute(GPUVAddr code_addr) {
 
     const auto& launch_desc = system.GPU().KeplerCompute().launch_description;
     const ProgramVariant variant(launch_desc.block_dim_x, launch_desc.block_dim_y,
-                                 launch_desc.block_dim_z);
+                                 launch_desc.block_dim_z, launch_desc.shared_alloc);
     std::tie(state.draw.shader_program, std::ignore) = kernel->GetHandle(variant);
     state.draw.program_pipeline = 0;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -89,7 +89,7 @@ private:
     void SetupComputeConstBuffers(const Shader& kernel);
 
     /// Configures a constant buffer.
-    void SetupConstBuffer(const Tegra::Engines::ConstBufferInfo& buffer,
+    void SetupConstBuffer(u32 binding, const Tegra::Engines::ConstBufferInfo& buffer,
                           const GLShader::ConstBufferEntry& entry);
 
     /// Configures the current global memory entries to use for the draw command.
@@ -99,15 +99,14 @@ private:
     void SetupComputeGlobalMemory(const Shader& kernel);
 
     /// Configures a constant buffer.
-    void SetupGlobalMemory(const GLShader::GlobalMemoryEntry& entry, GPUVAddr gpu_addr,
+    void SetupGlobalMemory(u32 binding, const GLShader::GlobalMemoryEntry& entry, GPUVAddr gpu_addr,
                            std::size_t size);
 
     /// Syncs all the state, shaders, render targets and textures setting before a draw call.
     void DrawPrelude();
 
     /// Configures the current textures to use for the draw command.
-    void SetupDrawTextures(std::size_t stage_index, const Shader& shader,
-                           BaseBindings base_bindings);
+    void SetupDrawTextures(std::size_t stage_index, const Shader& shader);
 
     /// Configures the textures used in a compute shader.
     void SetupComputeTextures(const Shader& kernel);
@@ -117,7 +116,7 @@ private:
                       const GLShader::SamplerEntry& entry);
 
     /// Configures images in a graphics shader.
-    void SetupDrawImages(std::size_t stage_index, const Shader& shader, BaseBindings base_bindings);
+    void SetupDrawImages(std::size_t stage_index, const Shader& shader);
 
     /// Configures images in a compute shader.
     void SetupComputeImages(const Shader& shader);

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -107,16 +107,15 @@ private:
     /// Syncs all the state, shaders, render targets and textures setting before a draw call.
     void DrawPrelude();
 
-    /// Configures the current textures to use for the draw command. Returns shaders texture buffer
-    /// usage.
-    TextureBufferUsage SetupDrawTextures(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage,
-                                         const Shader& shader, BaseBindings base_bindings);
+    /// Configures the current textures to use for the draw command.
+    void SetupDrawTextures(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage, const Shader& shader,
+                           BaseBindings base_bindings);
 
-    /// Configures the textures used in a compute shader. Returns texture buffer usage.
-    TextureBufferUsage SetupComputeTextures(const Shader& kernel);
+    /// Configures the textures used in a compute shader.
+    void SetupComputeTextures(const Shader& kernel);
 
-    /// Configures a texture. Returns true when the texture is a texture buffer.
-    bool SetupTexture(u32 binding, const Tegra::Texture::FullTextureInfo& texture,
+    /// Configures a texture.
+    void SetupTexture(u32 binding, const Tegra::Texture::FullTextureInfo& texture,
                       const GLShader::SamplerEntry& entry);
 
     /// Configures images in a compute shader.

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -83,8 +83,7 @@ private:
                                    bool using_depth_fb, bool using_stencil_fb);
 
     /// Configures the current constbuffers to use for the draw command.
-    void SetupDrawConstBuffers(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage,
-                               const Shader& shader);
+    void SetupDrawConstBuffers(std::size_t stage_index, const Shader& shader);
 
     /// Configures the current constbuffers to use for the kernel invocation.
     void SetupComputeConstBuffers(const Shader& kernel);
@@ -94,8 +93,7 @@ private:
                           const GLShader::ConstBufferEntry& entry);
 
     /// Configures the current global memory entries to use for the draw command.
-    void SetupDrawGlobalMemory(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage,
-                               const Shader& shader);
+    void SetupDrawGlobalMemory(std::size_t stage_index, const Shader& shader);
 
     /// Configures the current global memory entries to use for the kernel invocation.
     void SetupComputeGlobalMemory(const Shader& kernel);
@@ -108,7 +106,7 @@ private:
     void DrawPrelude();
 
     /// Configures the current textures to use for the draw command.
-    void SetupDrawTextures(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage, const Shader& shader,
+    void SetupDrawTextures(std::size_t stage_index, const Shader& shader,
                            BaseBindings base_bindings);
 
     /// Configures the textures used in a compute shader.
@@ -119,8 +117,7 @@ private:
                       const GLShader::SamplerEntry& entry);
 
     /// Configures images in a graphics shader.
-    void SetupDrawImages(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage, const Shader& shader,
-                         BaseBindings base_bindings);
+    void SetupDrawImages(std::size_t stage_index, const Shader& shader, BaseBindings base_bindings);
 
     /// Configures images in a compute shader.
     void SetupComputeImages(const Shader& shader);

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -118,6 +118,10 @@ private:
     void SetupTexture(u32 binding, const Tegra::Texture::FullTextureInfo& texture,
                       const GLShader::SamplerEntry& entry);
 
+    /// Configures images in a graphics shader.
+    void SetupDrawImages(Tegra::Engines::Maxwell3D::Regs::ShaderStage stage, const Shader& shader,
+                         BaseBindings base_bindings);
+
     /// Configures images in a compute shader.
     void SetupComputeImages(const Shader& shader);
 

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -449,6 +449,7 @@ std::tuple<GLuint, BaseBindings> CachedShader::GetHandle(const ProgramVariant& v
     base_bindings.cbuf += STAGE_RESERVED_UBOS;
     base_bindings.gmem += static_cast<u32>(entries.global_memory_entries.size());
     base_bindings.sampler += static_cast<u32>(entries.samplers.size());
+    base_bindings.image += static_cast<u32>(entries.images.size());
 
     return {program->handle, base_bindings};
 }

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -279,8 +279,9 @@ CachedProgram BuildShader(const Device& device, u64 unique_identifier, ShaderTyp
                         variant.block_x, variant.block_y, variant.block_z);
 
         if (variant.shared_memory_size > 0) {
-            source += fmt::format("shared uint smem[{}];",
-                                  Common::AlignUp(variant.shared_memory_size, 4) / 4);
+            // TODO(Rodrigo): We should divide by four here, but having a larger shared memory pool
+            // avoids out of bound stores. Find out why shared memory size is being invalid.
+            source += fmt::format("shared uint smem[{}];", variant.shared_memory_size);
         }
 
         if (variant.local_memory_size > 0) {

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -329,6 +329,11 @@ CachedProgram BuildShader(const Device& device, u64 unique_identifier, ProgramTy
             source += fmt::format("shared uint smem[{}];",
                                   Common::AlignUp(variant.shared_memory_size, 4) / 4);
         }
+
+        if (variant.local_memory_size > 0) {
+            source += fmt::format("#define LOCAL_MEMORY_SIZE {}",
+                                  Common::AlignUp(variant.local_memory_size, 4) / 4);
+        }
     }
 
     source += '\n';

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -16,6 +16,7 @@
 #include "core/frontend/emu_window.h"
 #include "video_core/engines/kepler_compute.h"
 #include "video_core/engines/maxwell_3d.h"
+#include "video_core/engines/shader_type.h"
 #include "video_core/memory_manager.h"
 #include "video_core/renderer_opengl/gl_rasterizer.h"
 #include "video_core/renderer_opengl/gl_shader_cache.h"
@@ -84,28 +85,26 @@ std::size_t CalculateProgramSize(const GLShader::ProgramCode& program) {
 /// Gets the shader program code from memory for the specified address
 ProgramCode GetShaderCode(Tegra::MemoryManager& memory_manager, const GPUVAddr gpu_addr,
                           const u8* host_ptr) {
-    ProgramCode program_code(VideoCommon::Shader::MAX_PROGRAM_LENGTH);
+    ProgramCode code(VideoCommon::Shader::MAX_PROGRAM_LENGTH);
     ASSERT_OR_EXECUTE(host_ptr != nullptr, {
-        std::fill(program_code.begin(), program_code.end(), 0);
-        return program_code;
+        std::fill(code.begin(), code.end(), 0);
+        return code;
     });
-    memory_manager.ReadBlockUnsafe(gpu_addr, program_code.data(),
-                                   program_code.size() * sizeof(u64));
-    program_code.resize(CalculateProgramSize(program_code));
-    return program_code;
+    memory_manager.ReadBlockUnsafe(gpu_addr, code.data(), code.size() * sizeof(u64));
+    code.resize(CalculateProgramSize(code));
+    return code;
 }
 
 /// Gets the shader type from a Maxwell program type
-constexpr GLenum GetShaderType(ProgramType program_type) {
-    switch (program_type) {
-    case ProgramType::VertexA:
-    case ProgramType::VertexB:
+constexpr GLenum GetGLShaderType(ShaderType shader_type) {
+    switch (shader_type) {
+    case ShaderType::Vertex:
         return GL_VERTEX_SHADER;
-    case ProgramType::Geometry:
+    case ShaderType::Geometry:
         return GL_GEOMETRY_SHADER;
-    case ProgramType::Fragment:
+    case ShaderType::Fragment:
         return GL_FRAGMENT_SHADER;
-    case ProgramType::Compute:
+    case ShaderType::Compute:
         return GL_COMPUTE_SHADER;
     default:
         return GL_NONE;
@@ -135,30 +134,11 @@ constexpr std::tuple<const char*, const char*, u32> GetPrimitiveDescription(GLen
     }
 }
 
-ProgramType GetProgramType(Maxwell::ShaderProgram program) {
-    switch (program) {
-    case Maxwell::ShaderProgram::VertexA:
-        return ProgramType::VertexA;
-    case Maxwell::ShaderProgram::VertexB:
-        return ProgramType::VertexB;
-    case Maxwell::ShaderProgram::TesselationControl:
-        return ProgramType::TessellationControl;
-    case Maxwell::ShaderProgram::TesselationEval:
-        return ProgramType::TessellationEval;
-    case Maxwell::ShaderProgram::Geometry:
-        return ProgramType::Geometry;
-    case Maxwell::ShaderProgram::Fragment:
-        return ProgramType::Fragment;
-    }
-    UNREACHABLE();
-    return {};
-}
-
 /// Hashes one (or two) program streams
-u64 GetUniqueIdentifier(ProgramType program_type, const ProgramCode& code,
+u64 GetUniqueIdentifier(ShaderType shader_type, bool is_a, const ProgramCode& code,
                         const ProgramCode& code_b) {
     u64 unique_identifier = boost::hash_value(code);
-    if (program_type == ProgramType::VertexA) {
+    if (is_a) {
         // VertexA programs include two programs
         boost::hash_combine(unique_identifier, boost::hash_value(code_b));
     }
@@ -166,79 +146,74 @@ u64 GetUniqueIdentifier(ProgramType program_type, const ProgramCode& code,
 }
 
 /// Creates an unspecialized program from code streams
-std::string GenerateGLSL(const Device& device, ProgramType program_type, const ShaderIR& ir,
+std::string GenerateGLSL(const Device& device, ShaderType shader_type, const ShaderIR& ir,
                          const std::optional<ShaderIR>& ir_b) {
-    switch (program_type) {
-    case ProgramType::VertexA:
-    case ProgramType::VertexB:
+    switch (shader_type) {
+    case ShaderType::Vertex:
         return GLShader::GenerateVertexShader(device, ir, ir_b ? &*ir_b : nullptr);
-    case ProgramType::Geometry:
+    case ShaderType::Geometry:
         return GLShader::GenerateGeometryShader(device, ir);
-    case ProgramType::Fragment:
+    case ShaderType::Fragment:
         return GLShader::GenerateFragmentShader(device, ir);
-    case ProgramType::Compute:
+    case ShaderType::Compute:
         return GLShader::GenerateComputeShader(device, ir);
     default:
-        UNIMPLEMENTED_MSG("Unimplemented program_type={}", static_cast<u32>(program_type));
+        UNIMPLEMENTED_MSG("Unimplemented shader_type={}", static_cast<u32>(shader_type));
         return {};
     }
 }
 
-constexpr const char* GetProgramTypeName(ProgramType program_type) {
-    switch (program_type) {
-    case ProgramType::VertexA:
-    case ProgramType::VertexB:
+constexpr const char* GetShaderTypeName(ShaderType shader_type) {
+    switch (shader_type) {
+    case ShaderType::Vertex:
         return "VS";
-    case ProgramType::TessellationControl:
-        return "TCS";
-    case ProgramType::TessellationEval:
-        return "TES";
-    case ProgramType::Geometry:
+    case ShaderType::TesselationControl:
+        return "HS";
+    case ShaderType::TesselationEval:
+        return "DS";
+    case ShaderType::Geometry:
         return "GS";
-    case ProgramType::Fragment:
+    case ShaderType::Fragment:
         return "FS";
-    case ProgramType::Compute:
+    case ShaderType::Compute:
         return "CS";
     }
     return "UNK";
 }
 
-Tegra::Engines::ShaderType GetEnginesShaderType(ProgramType program_type) {
+constexpr ShaderType GetShaderType(Maxwell::ShaderProgram program_type) {
     switch (program_type) {
-    case ProgramType::VertexA:
-    case ProgramType::VertexB:
-        return Tegra::Engines::ShaderType::Vertex;
-    case ProgramType::TessellationControl:
-        return Tegra::Engines::ShaderType::TesselationControl;
-    case ProgramType::TessellationEval:
-        return Tegra::Engines::ShaderType::TesselationEval;
-    case ProgramType::Geometry:
-        return Tegra::Engines::ShaderType::Geometry;
-    case ProgramType::Fragment:
-        return Tegra::Engines::ShaderType::Fragment;
-    case ProgramType::Compute:
-        return Tegra::Engines::ShaderType::Compute;
+    case Maxwell::ShaderProgram::VertexA:
+    case Maxwell::ShaderProgram::VertexB:
+        return ShaderType::Vertex;
+    case Maxwell::ShaderProgram::TesselationControl:
+        return ShaderType::TesselationControl;
+    case Maxwell::ShaderProgram::TesselationEval:
+        return ShaderType::TesselationEval;
+    case Maxwell::ShaderProgram::Geometry:
+        return ShaderType::Geometry;
+    case Maxwell::ShaderProgram::Fragment:
+        return ShaderType::Fragment;
     }
-    UNREACHABLE();
     return {};
 }
 
-std::string GetShaderId(u64 unique_identifier, ProgramType program_type) {
-    return fmt::format("{}{:016X}", GetProgramTypeName(program_type), unique_identifier);
+std::string GetShaderId(u64 unique_identifier, ShaderType shader_type) {
+    return fmt::format("{}{:016X}", GetShaderTypeName(shader_type), unique_identifier);
 }
 
-Tegra::Engines::ConstBufferEngineInterface& GetConstBufferEngineInterface(
-    Core::System& system, ProgramType program_type) {
-    if (program_type == ProgramType::Compute) {
+Tegra::Engines::ConstBufferEngineInterface& GetConstBufferEngineInterface(Core::System& system,
+                                                                          ShaderType shader_type) {
+    if (shader_type == ShaderType::Compute) {
         return system.GPU().KeplerCompute();
     } else {
         return system.GPU().Maxwell3D();
     }
 }
 
-std::unique_ptr<ConstBufferLocker> MakeLocker(Core::System& system, ProgramType program_type) {
-    return std::make_unique<ConstBufferLocker>(GetEnginesShaderType(program_type),
-                                               GetConstBufferEngineInterface(system, program_type));
+std::unique_ptr<ConstBufferLocker> MakeLocker(Core::System& system, ShaderType shader_type) {
+    return std::make_unique<ConstBufferLocker>(shader_type,
+                                               GetConstBufferEngineInterface(system, shader_type));
 }
 
 void FillLocker(ConstBufferLocker& locker, const ShaderDiskCacheUsage& usage) {
@@ -255,18 +230,18 @@ void FillLocker(ConstBufferLocker& locker, const ShaderDiskCacheUsage& usage) {
     }
 }
 
-CachedProgram BuildShader(const Device& device, u64 unique_identifier, ProgramType program_type,
-                          const ProgramCode& program_code, const ProgramCode& program_code_b,
+CachedProgram BuildShader(const Device& device, u64 unique_identifier, ShaderType shader_type,
+                          const ProgramCode& code, const ProgramCode& code_b,
                           ConstBufferLocker& locker, const ProgramVariant& variant,
                           bool hint_retrievable = false) {
-    LOG_INFO(Render_OpenGL, "called. {}", GetShaderId(unique_identifier, program_type));
+    LOG_INFO(Render_OpenGL, "called. {}", GetShaderId(unique_identifier, shader_type));
 
-    const bool is_compute = program_type == ProgramType::Compute;
+    const bool is_compute = shader_type == ShaderType::Compute;
     const u32 main_offset = is_compute ? KERNEL_MAIN_OFFSET : STAGE_MAIN_OFFSET;
-    const ShaderIR ir(program_code, main_offset, COMPILER_SETTINGS, locker);
+    const ShaderIR ir(code, main_offset, COMPILER_SETTINGS, locker);
     std::optional<ShaderIR> ir_b;
-    if (!program_code_b.empty()) {
-        ir_b.emplace(program_code_b, main_offset, COMPILER_SETTINGS, locker);
+    if (!code_b.empty()) {
+        ir_b.emplace(code_b, main_offset, COMPILER_SETTINGS, locker);
     }
     const auto entries = GLShader::GetEntries(ir);
 
@@ -274,7 +249,7 @@ CachedProgram BuildShader(const Device& device, u64 unique_identifier, ProgramTy
 #version 430 core
 #extension GL_ARB_separate_shader_objects : enable
 )",
-                                     GetShaderId(unique_identifier, program_type));
+                                     GetShaderId(unique_identifier, shader_type));
     if (device.HasShaderBallot()) {
         source += "#extension GL_ARB_shader_ballot : require\n";
     }
@@ -313,14 +288,14 @@ CachedProgram BuildShader(const Device& device, u64 unique_identifier, ProgramTy
             fmt::format("#define IMAGE_BINDING_{} {}\n", image.GetIndex(), base_bindings.image++);
     }
 
-    if (program_type == ProgramType::Geometry) {
+    if (shader_type == ShaderType::Geometry) {
         const auto [glsl_topology, debug_name, max_vertices] =
             GetPrimitiveDescription(variant.primitive_mode);
 
         source += fmt::format("layout ({}) in;\n\n", glsl_topology);
         source += fmt::format("#define MAX_VERTEX_INPUT {}\n", max_vertices);
     }
-    if (program_type == ProgramType::Compute) {
+    if (shader_type == ShaderType::Compute) {
         source +=
             fmt::format("layout (local_size_x = {}, local_size_y = {}, local_size_z = {}) in;\n",
                         variant.block_x, variant.block_y, variant.block_z);
@@ -337,10 +312,10 @@ CachedProgram BuildShader(const Device& device, u64 unique_identifier, ProgramTy
     }
 
     source += '\n';
-    source += GenerateGLSL(device, program_type, ir, ir_b);
+    source += GenerateGLSL(device, shader_type, ir, ir_b);
 
     OGLShader shader;
-    shader.Create(source.c_str(), GetShaderType(program_type));
+    shader.Create(source.c_str(), GetGLShaderType(shader_type));
 
     auto program = std::make_shared<OGLProgram>();
     program->Create(true, hint_retrievable, shader.handle);
@@ -363,18 +338,16 @@ std::unordered_set<GLenum> GetSupportedFormats() {
 
 } // Anonymous namespace
 
-CachedShader::CachedShader(const ShaderParameters& params, ProgramType program_type,
-                           GLShader::ShaderEntries entries, ProgramCode program_code,
-                           ProgramCode program_code_b)
-    : RasterizerCacheObject{params.host_ptr}, system{params.system},
-      disk_cache{params.disk_cache}, device{params.device}, cpu_addr{params.cpu_addr},
-      unique_identifier{params.unique_identifier}, program_type{program_type}, entries{entries},
-      program_code{std::move(program_code)}, program_code_b{std::move(program_code_b)} {
+CachedShader::CachedShader(const ShaderParameters& params, ShaderType shader_type,
+                           GLShader::ShaderEntries entries, ProgramCode code, ProgramCode code_b)
+    : RasterizerCacheObject{params.host_ptr}, system{params.system}, disk_cache{params.disk_cache},
+      device{params.device}, cpu_addr{params.cpu_addr}, unique_identifier{params.unique_identifier},
+      shader_type{shader_type}, entries{entries}, code{std::move(code)}, code_b{std::move(code_b)} {
     if (!params.precompiled_variants) {
         return;
     }
     for (const auto& pair : *params.precompiled_variants) {
-        auto locker = MakeLocker(system, program_type);
+        auto locker = MakeLocker(system, shader_type);
         const auto& usage = pair->first;
         FillLocker(*locker, usage);
 
@@ -395,38 +368,37 @@ CachedShader::CachedShader(const ShaderParameters& params, ProgramType program_t
 }
 
 Shader CachedShader::CreateStageFromMemory(const ShaderParameters& params,
-                                           Maxwell::ShaderProgram program_type,
-                                           ProgramCode program_code, ProgramCode program_code_b) {
-    params.disk_cache.SaveRaw(ShaderDiskCacheRaw(
-        params.unique_identifier, GetProgramType(program_type), program_code, program_code_b));
+                                           Maxwell::ShaderProgram program_type, ProgramCode code,
+                                           ProgramCode code_b) {
+    const auto shader_type = GetShaderType(program_type);
+    params.disk_cache.SaveRaw(
+        ShaderDiskCacheRaw(params.unique_identifier, shader_type, code, code_b));
 
-    ConstBufferLocker locker(GetEnginesShaderType(GetProgramType(program_type)),
-                             params.system.GPU().Maxwell3D());
-    const ShaderIR ir(program_code, STAGE_MAIN_OFFSET, COMPILER_SETTINGS, locker);
+    ConstBufferLocker locker(shader_type, params.system.GPU().Maxwell3D());
+    const ShaderIR ir(code, STAGE_MAIN_OFFSET, COMPILER_SETTINGS, locker);
     // TODO(Rodrigo): Handle VertexA shaders
     // std::optional<ShaderIR> ir_b;
-    // if (!program_code_b.empty()) {
-    //     ir_b.emplace(program_code_b, STAGE_MAIN_OFFSET);
+    // if (!code_b.empty()) {
+    //     ir_b.emplace(code_b, STAGE_MAIN_OFFSET);
     // }
-    return std::shared_ptr<CachedShader>(
-        new CachedShader(params, GetProgramType(program_type), GLShader::GetEntries(ir),
-                         std::move(program_code), std::move(program_code_b)));
+    return std::shared_ptr<CachedShader>(new CachedShader(
+        params, shader_type, GLShader::GetEntries(ir), std::move(code), std::move(code_b)));
 }
 
 Shader CachedShader::CreateKernelFromMemory(const ShaderParameters& params, ProgramCode code) {
     params.disk_cache.SaveRaw(
-        ShaderDiskCacheRaw(params.unique_identifier, ProgramType::Compute, code));
+        ShaderDiskCacheRaw(params.unique_identifier, ShaderType::Compute, code));
 
     ConstBufferLocker locker(Tegra::Engines::ShaderType::Compute,
                              params.system.GPU().KeplerCompute());
     const ShaderIR ir(code, KERNEL_MAIN_OFFSET, COMPILER_SETTINGS, locker);
     return std::shared_ptr<CachedShader>(new CachedShader(
-        params, ProgramType::Compute, GLShader::GetEntries(ir), std::move(code), {}));
+        params, ShaderType::Compute, GLShader::GetEntries(ir), std::move(code), {}));
 }
 
 Shader CachedShader::CreateFromCache(const ShaderParameters& params,
                                      const UnspecializedShader& unspecialized) {
-    return std::shared_ptr<CachedShader>(new CachedShader(params, unspecialized.program_type,
+    return std::shared_ptr<CachedShader>(new CachedShader(params, unspecialized.type,
                                                           unspecialized.entries, unspecialized.code,
                                                           unspecialized.code_b));
 }
@@ -437,7 +409,7 @@ std::tuple<GLuint, BaseBindings> CachedShader::GetHandle(const ProgramVariant& v
     const auto [entry, is_cache_miss] = curr_locker_variant->programs.try_emplace(variant);
     auto& program = entry->second;
     if (is_cache_miss) {
-        program = BuildShader(device, unique_identifier, program_type, program_code, program_code_b,
+        program = BuildShader(device, unique_identifier, shader_type, code, code_b,
                               *curr_locker_variant->locker, variant);
         disk_cache.SaveUsage(GetUsage(variant, *curr_locker_variant->locker));
 
@@ -469,7 +441,7 @@ bool CachedShader::EnsureValidLockerVariant() {
     if (!curr_locker_variant) {
         auto& new_variant = locker_variants.emplace_back();
         new_variant = std::make_unique<LockerVariant>();
-        new_variant->locker = MakeLocker(system, program_type);
+        new_variant->locker = MakeLocker(system, shader_type);
         curr_locker_variant = new_variant.get();
     }
     return previous_variant == curr_locker_variant;
@@ -537,10 +509,10 @@ void ShaderCacheOpenGL::LoadDiskCache(const std::atomic_bool& stop_loading,
                 }
             }
             if (!shader) {
-                auto locker{MakeLocker(system, unspecialized.program_type)};
+                auto locker{MakeLocker(system, unspecialized.type)};
                 FillLocker(*locker, usage);
 
-                shader = BuildShader(device, usage.unique_identifier, unspecialized.program_type,
+                shader = BuildShader(device, usage.unique_identifier, unspecialized.type,
                                      unspecialized.code, unspecialized.code_b, *locker,
                                      usage.variant, true);
             }
@@ -645,7 +617,7 @@ bool ShaderCacheOpenGL::GenerateUnspecializedShaders(
         const auto& raw{raws[i]};
         const u64 unique_identifier{raw.GetUniqueIdentifier()};
         const u64 calculated_hash{
-            GetUniqueIdentifier(raw.GetProgramType(), raw.GetProgramCode(), raw.GetProgramCodeB())};
+            GetUniqueIdentifier(raw.GetType(), raw.HasProgramA(), raw.GetCode(), raw.GetCodeB())};
         if (unique_identifier != calculated_hash) {
             LOG_ERROR(Render_OpenGL,
                       "Invalid hash in entry={:016x} (obtained hash={:016x}) - "
@@ -656,9 +628,9 @@ bool ShaderCacheOpenGL::GenerateUnspecializedShaders(
         }
 
         const u32 main_offset =
-            raw.GetProgramType() == ProgramType::Compute ? KERNEL_MAIN_OFFSET : STAGE_MAIN_OFFSET;
-        ConstBufferLocker locker(GetEnginesShaderType(raw.GetProgramType()));
-        const ShaderIR ir(raw.GetProgramCode(), main_offset, COMPILER_SETTINGS, locker);
+            raw.GetType() == ShaderType::Compute ? KERNEL_MAIN_OFFSET : STAGE_MAIN_OFFSET;
+        ConstBufferLocker locker(raw.GetType());
+        const ShaderIR ir(raw.GetCode(), main_offset, COMPILER_SETTINGS, locker);
         // TODO(Rodrigo): Handle VertexA shaders
         // std::optional<ShaderIR> ir_b;
         // if (raw.HasProgramA()) {
@@ -667,9 +639,9 @@ bool ShaderCacheOpenGL::GenerateUnspecializedShaders(
 
         UnspecializedShader unspecialized;
         unspecialized.entries = GLShader::GetEntries(ir);
-        unspecialized.program_type = raw.GetProgramType();
-        unspecialized.code = raw.GetProgramCode();
-        unspecialized.code_b = raw.GetProgramCodeB();
+        unspecialized.type = raw.GetType();
+        unspecialized.code = raw.GetCode();
+        unspecialized.code_b = raw.GetCodeB();
         unspecialized_shaders.emplace(raw.GetUniqueIdentifier(), unspecialized);
 
         if (callback) {
@@ -702,7 +674,8 @@ Shader ShaderCacheOpenGL::GetStageProgram(Maxwell::ShaderProgram program) {
         code_b = GetShaderCode(memory_manager, address_b, memory_manager.GetPointer(address_b));
     }
 
-    const auto unique_identifier = GetUniqueIdentifier(GetProgramType(program), code, code_b);
+    const auto unique_identifier = GetUniqueIdentifier(
+        GetShaderType(program), program == Maxwell::ShaderProgram::VertexA, code, code_b);
     const auto precompiled_variants = GetPrecompiledVariants(unique_identifier);
     const auto cpu_addr{*memory_manager.GpuToCpuAddress(address)};
     const ShaderParameters params{system,   disk_cache, precompiled_variants, device,
@@ -730,7 +703,7 @@ Shader ShaderCacheOpenGL::GetComputeKernel(GPUVAddr code_addr) {
 
     // No kernel found - create a new one
     auto code{GetShaderCode(memory_manager, code_addr, host_ptr)};
-    const auto unique_identifier{GetUniqueIdentifier(ProgramType::Compute, code, {})};
+    const auto unique_identifier{GetUniqueIdentifier(ShaderType::Compute, false, code, {})};
     const auto precompiled_variants = GetPrecompiledVariants(unique_identifier);
     const auto cpu_addr{*memory_manager.GpuToCpuAddress(code_addr)};
     const ShaderParameters params{system,   disk_cache, precompiled_variants, device,

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -270,7 +270,6 @@ CachedProgram BuildShader(const Device& device, u64 unique_identifier, ProgramTy
 
     auto base_bindings{variant.base_bindings};
     const auto primitive_mode{variant.primitive_mode};
-    const auto texture_buffer_usage{variant.texture_buffer_usage};
 
     std::string source = fmt::format(R"(// {}
 #version 430 core
@@ -315,17 +314,6 @@ CachedProgram BuildShader(const Device& device, u64 unique_identifier, ProgramTy
     for (const auto& image : entries.images) {
         source +=
             fmt::format("#define IMAGE_BINDING_{} {}\n", image.GetIndex(), base_bindings.image++);
-    }
-
-    // Transform 1D textures to texture samplers by declaring its preprocessor macros.
-    for (std::size_t i = 0; i < texture_buffer_usage.size(); ++i) {
-        if (!texture_buffer_usage.test(i)) {
-            continue;
-        }
-        source += fmt::format("#define SAMPLER_{}_IS_BUFFER\n", i);
-    }
-    if (texture_buffer_usage.any()) {
-        source += '\n';
     }
 
     if (program_type == ProgramType::Geometry) {

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -8,7 +8,9 @@
 #include <thread>
 #include <unordered_set>
 #include <boost/functional/hash.hpp>
+#include "common/alignment.h"
 #include "common/assert.h"
+#include "common/logging/log.h"
 #include "common/scope_exit.h"
 #include "core/core.h"
 #include "core/frontend/emu_window.h"
@@ -322,6 +324,11 @@ CachedProgram BuildShader(const Device& device, u64 unique_identifier, ProgramTy
         source +=
             fmt::format("layout (local_size_x = {}, local_size_y = {}, local_size_z = {}) in;\n",
                         variant.block_x, variant.block_y, variant.block_z);
+
+        if (variant.shared_memory_size > 0) {
+            source += fmt::format("shared uint smem[{}];",
+                                  Common::AlignUp(variant.shared_memory_size, 4) / 4);
+        }
     }
 
     source += '\n';

--- a/src/video_core/renderer_opengl/gl_shader_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_cache.h
@@ -17,6 +17,7 @@
 #include <glad/glad.h>
 
 #include "common/common_types.h"
+#include "video_core/engines/shader_type.h"
 #include "video_core/rasterizer_cache.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/renderer_opengl/gl_shader_decompiler.h"
@@ -47,7 +48,7 @@ using PrecompiledVariants = std::vector<PrecompiledPrograms::iterator>;
 
 struct UnspecializedShader {
     GLShader::ShaderEntries entries;
-    ProgramType program_type;
+    Tegra::Engines::ShaderType type;
     ProgramCode code;
     ProgramCode code_b;
 };
@@ -77,7 +78,7 @@ public:
     }
 
     std::size_t GetSizeInBytes() const override {
-        return program_code.size() * sizeof(u64);
+        return code.size() * sizeof(u64);
     }
 
     /// Gets the shader entries for the shader
@@ -94,7 +95,7 @@ private:
         std::unordered_map<ProgramVariant, CachedProgram> programs;
     };
 
-    explicit CachedShader(const ShaderParameters& params, ProgramType program_type,
+    explicit CachedShader(const ShaderParameters& params, Tegra::Engines::ShaderType shader_type,
                           GLShader::ShaderEntries entries, ProgramCode program_code,
                           ProgramCode program_code_b);
 
@@ -110,12 +111,12 @@ private:
     VAddr cpu_addr{};
 
     u64 unique_identifier{};
-    ProgramType program_type{};
+    Tegra::Engines::ShaderType shader_type{};
 
     GLShader::ShaderEntries entries;
 
-    ProgramCode program_code;
-    ProgramCode program_code_b;
+    ProgramCode code;
+    ProgramCode code_b;
 
     LockerVariant* curr_locker_variant = nullptr;
     std::vector<std::unique_ptr<LockerVariant>> locker_variants;

--- a/src/video_core/renderer_opengl/gl_shader_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_cache.h
@@ -87,7 +87,7 @@ public:
     }
 
     /// Gets the GL program handle for the shader
-    std::tuple<GLuint, BaseBindings> GetHandle(const ProgramVariant& variant);
+    GLuint GetHandle(const ProgramVariant& variant);
 
 private:
     struct LockerVariant {

--- a/src/video_core/renderer_opengl/gl_shader_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_cache.h
@@ -86,7 +86,7 @@ public:
     }
 
     /// Gets the GL program handle for the shader
-    std::tuple<GLuint, BaseBindings> GetProgramHandle(const ProgramVariant& variant);
+    std::tuple<GLuint, BaseBindings> GetHandle(const ProgramVariant& variant);
 
 private:
     struct LockerVariant {
@@ -98,7 +98,7 @@ private:
                           GLShader::ShaderEntries entries, ProgramCode program_code,
                           ProgramCode program_code_b);
 
-    void UpdateVariant();
+    bool EnsureValidLockerVariant();
 
     ShaderDiskCacheUsage GetUsage(const ProgramVariant& variant,
                                   const VideoCommon::Shader::ConstBufferLocker& locker) const;
@@ -117,7 +117,7 @@ private:
     ProgramCode program_code;
     ProgramCode program_code_b;
 
-    LockerVariant* curr_variant = nullptr;
+    LockerVariant* curr_locker_variant = nullptr;
     std::vector<std::unique_ptr<LockerVariant>> locker_variants;
 };
 

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -619,10 +619,9 @@ private:
     }
 
     void DeclareConstantBuffers() {
-        for (const auto& entry : ir.GetConstantBuffers()) {
-            const auto [index, size] = entry;
-            const u32 binding = device.GetBaseBindings(stage).uniform_buffer + index;
-            code.AddLine("layout (std140, binding = {}) uniform {} {{", binding,
+        u32 binding = device.GetBaseBindings(stage).uniform_buffer;
+        for (const auto& [index, cbuf] : ir.GetConstantBuffers()) {
+            code.AddLine("layout (std140, binding = {}) uniform {} {{", binding++,
                          GetConstBufferBlock(index));
             code.AddLine("    uvec4 {}[{}];", GetConstBuffer(index), MAX_CONSTBUFFER_ELEMENTS);
             code.AddLine("}};");
@@ -632,10 +631,7 @@ private:
 
     void DeclareGlobalMemory() {
         u32 binding = device.GetBaseBindings(stage).shader_storage_buffer;
-
-        for (const auto& gmem : ir.GetGlobalMemory()) {
-            const auto& [base, usage] = gmem;
-
+        for (const auto& [base, usage] : ir.GetGlobalMemory()) {
             // Since we don't know how the shader will use the shader, hint the driver to disable as
             // much optimizations as possible
             std::string qualifier = "coherent volatile";

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -650,12 +650,10 @@ private:
     }
 
     void DeclareSamplers() {
-        const auto& samplers = ir.GetSamplers();
-        for (const auto& sampler : samplers) {
+        u32 binding = device.GetBaseBindings(stage).sampler;
+        for (const auto& sampler : ir.GetSamplers()) {
             const std::string name = GetSampler(sampler);
-
-            const u32 binding = device.GetBaseBindings(stage).sampler + sampler.GetIndex();
-            const std::string description = fmt::format("layout (binding = {}) uniform", binding);
+            const std::string description = fmt::format("layout (binding = {}) uniform", binding++);
 
             std::string sampler_type = [&]() {
                 if (sampler.IsBuffer()) {
@@ -684,7 +682,7 @@ private:
 
             code.AddLine("{} {} {};", description, sampler_type, name);
         }
-        if (!samplers.empty()) {
+        if (!ir.GetSamplers().empty()) {
             code.AddNewLine();
         }
     }
@@ -724,8 +722,8 @@ private:
     }
 
     void DeclareImages() {
-        const auto& images{ir.GetImages()};
-        for (const auto& image : images) {
+        u32 binding = device.GetBaseBindings(stage).image;
+        for (const auto& image : ir.GetImages()) {
             std::string qualifier = "coherent volatile";
             if (image.IsRead() && !image.IsWritten()) {
                 qualifier += " readonly";
@@ -733,14 +731,12 @@ private:
                 qualifier += " writeonly";
             }
 
-            const u32 binding = device.GetBaseBindings(stage).image + image.GetIndex();
-
             const char* format = image.IsAtomic() ? "r32ui, " : "";
             const char* type_declaration = GetImageTypeDeclaration(image.GetType());
-            code.AddLine("layout ({}binding = {}) {} uniform uimage{} {};", format, binding,
+            code.AddLine("layout ({}binding = {}) {} uniform uimage{} {};", format, binding++,
                          qualifier, type_declaration, GetImage(image));
         }
-        if (!images.empty()) {
+        if (!ir.GetImages().empty()) {
             code.AddNewLine();
         }
     }

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.h
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.h
@@ -10,6 +10,7 @@
 #include <vector>
 #include "common/common_types.h"
 #include "video_core/engines/maxwell_3d.h"
+#include "video_core/engines/shader_type.h"
 #include "video_core/shader/shader_ir.h"
 
 namespace VideoCommon::Shader {
@@ -17,20 +18,8 @@ class ShaderIR;
 }
 
 namespace OpenGL {
-
 class Device;
-
-enum class ProgramType : u32 {
-    VertexA = 0,
-    VertexB = 1,
-    TessellationControl = 2,
-    TessellationEval = 3,
-    Geometry = 4,
-    Fragment = 5,
-    Compute = 6
-};
-
-} // namespace OpenGL
+}
 
 namespace OpenGL::GLShader {
 
@@ -94,6 +83,6 @@ ShaderEntries GetEntries(const VideoCommon::Shader::ShaderIR& ir);
 std::string GetCommonDeclarations();
 
 std::string Decompile(const Device& device, const VideoCommon::Shader::ShaderIR& ir,
-                      ProgramType stage, const std::string& suffix);
+                      Tegra::Engines::ShaderType stage, const std::string& suffix);
 
 } // namespace OpenGL::GLShader

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -53,11 +53,10 @@ struct BindlessSamplerKey {
     Tegra::Engines::SamplerDescriptor sampler{};
 };
 
-constexpr u32 NativeVersion = 10;
+constexpr u32 NativeVersion = 11;
 
 // Making sure sizes doesn't change by accident
-static_assert(sizeof(BaseBindings) == 16);
-static_assert(sizeof(ProgramVariant) == 36);
+static_assert(sizeof(ProgramVariant) == 20);
 
 ShaderCacheVersionHash GetShaderCacheVersionHash() {
     ShaderCacheVersionHash hash{};

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -52,11 +52,11 @@ struct BindlessSamplerKey {
     Tegra::Engines::SamplerDescriptor sampler{};
 };
 
-constexpr u32 NativeVersion = 7;
+constexpr u32 NativeVersion = 8;
 
 // Making sure sizes doesn't change by accident
 static_assert(sizeof(BaseBindings) == 16);
-static_assert(sizeof(ProgramVariant) == 28);
+static_assert(sizeof(ProgramVariant) == 32);
 
 ShaderCacheVersionHash GetShaderCacheVersionHash() {
     ShaderCacheVersionHash hash{};

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <cstring>
+
 #include <fmt/format.h>
 
 #include "common/assert.h"
@@ -12,16 +13,16 @@
 #include "common/logging/log.h"
 #include "common/scm_rev.h"
 #include "common/zstd_compression.h"
-
 #include "core/core.h"
 #include "core/hle/kernel/process.h"
 #include "core/settings.h"
-
+#include "video_core/engines/shader_type.h"
 #include "video_core/renderer_opengl/gl_shader_cache.h"
 #include "video_core/renderer_opengl/gl_shader_disk_cache.h"
 
 namespace OpenGL {
 
+using Tegra::Engines::ShaderType;
 using VideoCommon::Shader::BindlessSamplerMap;
 using VideoCommon::Shader::BoundSamplerMap;
 using VideoCommon::Shader::KeyMap;
@@ -67,10 +68,10 @@ ShaderCacheVersionHash GetShaderCacheVersionHash() {
 
 } // Anonymous namespace
 
-ShaderDiskCacheRaw::ShaderDiskCacheRaw(u64 unique_identifier, ProgramType program_type,
-                                       ProgramCode program_code, ProgramCode program_code_b)
-    : unique_identifier{unique_identifier}, program_type{program_type},
-      program_code{std::move(program_code)}, program_code_b{std::move(program_code_b)} {}
+ShaderDiskCacheRaw::ShaderDiskCacheRaw(u64 unique_identifier, ShaderType type, ProgramCode code,
+                                       ProgramCode code_b)
+    : unique_identifier{unique_identifier}, type{type}, code{std::move(code)}, code_b{std::move(
+                                                                                   code_b)} {}
 
 ShaderDiskCacheRaw::ShaderDiskCacheRaw() = default;
 
@@ -78,42 +79,39 @@ ShaderDiskCacheRaw::~ShaderDiskCacheRaw() = default;
 
 bool ShaderDiskCacheRaw::Load(FileUtil::IOFile& file) {
     if (file.ReadBytes(&unique_identifier, sizeof(u64)) != sizeof(u64) ||
-        file.ReadBytes(&program_type, sizeof(u32)) != sizeof(u32)) {
+        file.ReadBytes(&type, sizeof(u32)) != sizeof(u32)) {
         return false;
     }
-    u32 program_code_size{};
-    u32 program_code_size_b{};
-    if (file.ReadBytes(&program_code_size, sizeof(u32)) != sizeof(u32) ||
-        file.ReadBytes(&program_code_size_b, sizeof(u32)) != sizeof(u32)) {
+    u32 code_size{};
+    u32 code_size_b{};
+    if (file.ReadBytes(&code_size, sizeof(u32)) != sizeof(u32) ||
+        file.ReadBytes(&code_size_b, sizeof(u32)) != sizeof(u32)) {
         return false;
     }
 
-    program_code.resize(program_code_size);
-    program_code_b.resize(program_code_size_b);
+    code.resize(code_size);
+    code_b.resize(code_size_b);
 
-    if (file.ReadArray(program_code.data(), program_code_size) != program_code_size)
+    if (file.ReadArray(code.data(), code_size) != code_size)
         return false;
 
-    if (HasProgramA() &&
-        file.ReadArray(program_code_b.data(), program_code_size_b) != program_code_size_b) {
+    if (HasProgramA() && file.ReadArray(code_b.data(), code_size_b) != code_size_b) {
         return false;
     }
     return true;
 }
 
 bool ShaderDiskCacheRaw::Save(FileUtil::IOFile& file) const {
-    if (file.WriteObject(unique_identifier) != 1 ||
-        file.WriteObject(static_cast<u32>(program_type)) != 1 ||
-        file.WriteObject(static_cast<u32>(program_code.size())) != 1 ||
-        file.WriteObject(static_cast<u32>(program_code_b.size())) != 1) {
+    if (file.WriteObject(unique_identifier) != 1 || file.WriteObject(static_cast<u32>(type)) != 1 ||
+        file.WriteObject(static_cast<u32>(code.size())) != 1 ||
+        file.WriteObject(static_cast<u32>(code_b.size())) != 1) {
         return false;
     }
 
-    if (file.WriteArray(program_code.data(), program_code.size()) != program_code.size())
+    if (file.WriteArray(code.data(), code.size()) != code.size())
         return false;
 
-    if (HasProgramA() &&
-        file.WriteArray(program_code_b.data(), program_code_b.size()) != program_code_b.size()) {
+    if (HasProgramA() && file.WriteArray(code_b.data(), code_b.size()) != code_b.size()) {
         return false;
     }
     return true;

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -52,11 +52,11 @@ struct BindlessSamplerKey {
     Tegra::Engines::SamplerDescriptor sampler{};
 };
 
-constexpr u32 NativeVersion = 6;
+constexpr u32 NativeVersion = 7;
 
 // Making sure sizes doesn't change by accident
 static_assert(sizeof(BaseBindings) == 16);
-static_assert(sizeof(ProgramVariant) == 20);
+static_assert(sizeof(ProgramVariant) == 28);
 
 ShaderCacheVersionHash GetShaderCacheVersionHash() {
     ShaderCacheVersionHash hash{};

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -28,23 +28,6 @@ using VideoCommon::Shader::KeyMap;
 
 namespace {
 
-struct ConstBufferKey {
-    u32 cbuf;
-    u32 offset;
-    u32 value;
-};
-
-struct BoundSamplerKey {
-    u32 offset;
-    Tegra::Engines::SamplerDescriptor sampler;
-};
-
-struct BindlessSamplerKey {
-    u32 cbuf;
-    u32 offset;
-    Tegra::Engines::SamplerDescriptor sampler;
-};
-
 using ShaderCacheVersionHash = std::array<u8, 64>;
 
 enum class TransferableEntryKind : u32 {
@@ -52,10 +35,28 @@ enum class TransferableEntryKind : u32 {
     Usage,
 };
 
-constexpr u32 NativeVersion = 5;
+struct ConstBufferKey {
+    u32 cbuf{};
+    u32 offset{};
+    u32 value{};
+};
+
+struct BoundSamplerKey {
+    u32 offset{};
+    Tegra::Engines::SamplerDescriptor sampler{};
+};
+
+struct BindlessSamplerKey {
+    u32 cbuf{};
+    u32 offset{};
+    Tegra::Engines::SamplerDescriptor sampler{};
+};
+
+constexpr u32 NativeVersion = 6;
 
 // Making sure sizes doesn't change by accident
 static_assert(sizeof(BaseBindings) == 16);
+static_assert(sizeof(ProgramVariant) == 20);
 
 ShaderCacheVersionHash GetShaderCacheVersionHash() {
     ShaderCacheVersionHash hash{};

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -52,11 +52,11 @@ struct BindlessSamplerKey {
     Tegra::Engines::SamplerDescriptor sampler{};
 };
 
-constexpr u32 NativeVersion = 8;
+constexpr u32 NativeVersion = 9;
 
 // Making sure sizes doesn't change by accident
 static_assert(sizeof(BaseBindings) == 16);
-static_assert(sizeof(ProgramVariant) == 32);
+static_assert(sizeof(ProgramVariant) == 36);
 
 ShaderCacheVersionHash GetShaderCacheVersionHash() {
     ShaderCacheVersionHash hash{};

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -52,7 +52,7 @@ struct BindlessSamplerKey {
     Tegra::Engines::SamplerDescriptor sampler{};
 };
 
-constexpr u32 NativeVersion = 9;
+constexpr u32 NativeVersion = 10;
 
 // Making sure sizes doesn't change by accident
 static_assert(sizeof(BaseBindings) == 16);

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <bitset>
 #include <optional>
 #include <string>
 #include <tuple>
@@ -37,7 +36,6 @@ struct ShaderDiskCacheDump;
 
 using ProgramCode = std::vector<u64>;
 using ShaderDumpsMap = std::unordered_map<ShaderDiskCacheUsage, ShaderDiskCacheDump>;
-using TextureBufferUsage = std::bitset<64>;
 
 /// Allocated bindings used by an OpenGL shader program
 struct BaseBindings {
@@ -61,11 +59,10 @@ static_assert(std::is_trivially_copyable_v<BaseBindings>);
 struct ProgramVariant {
     BaseBindings base_bindings;
     GLenum primitive_mode{};
-    TextureBufferUsage texture_buffer_usage{};
 
     bool operator==(const ProgramVariant& rhs) const {
-        return std::tie(base_bindings, primitive_mode, texture_buffer_usage) ==
-               std::tie(rhs.base_bindings, rhs.primitive_mode, rhs.texture_buffer_usage);
+        return std::tie(base_bindings, primitive_mode) ==
+               std::tie(rhs.base_bindings, rhs.primitive_mode);
     }
 
     bool operator!=(const ProgramVariant& rhs) const {
@@ -112,7 +109,6 @@ template <>
 struct hash<OpenGL::ProgramVariant> {
     std::size_t operator()(const OpenGL::ProgramVariant& variant) const noexcept {
         return std::hash<OpenGL::BaseBindings>()(variant.base_bindings) ^
-               std::hash<OpenGL::TextureBufferUsage>()(variant.texture_buffer_usage) ^
                (static_cast<std::size_t>(variant.primitive_mode) << 6);
     }
 };

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.h
@@ -64,9 +64,10 @@ struct ProgramVariant final {
         : base_bindings{base_bindings}, primitive_mode{primitive_mode} {}
 
     /// Compute constructor.
-    explicit constexpr ProgramVariant(u32 block_x, u32 block_y, u32 block_z) noexcept
-        : block_x{block_x}, block_y{static_cast<u16>(block_y)}, block_z{static_cast<u16>(block_z)} {
-    }
+    explicit constexpr ProgramVariant(u32 block_x, u32 block_y, u32 block_z,
+                                      u32 shared_memory_size) noexcept
+        : block_x{block_x}, block_y{static_cast<u16>(block_y)}, block_z{static_cast<u16>(block_z)},
+          shared_memory_size{shared_memory_size} {}
 
     // Graphics specific parameters.
     BaseBindings base_bindings{};
@@ -76,11 +77,13 @@ struct ProgramVariant final {
     u32 block_x{};
     u16 block_y{};
     u16 block_z{};
+    u32 shared_memory_size{};
 
     bool operator==(const ProgramVariant& rhs) const noexcept {
-        return std::tie(base_bindings, primitive_mode, block_x, block_y, block_z) ==
-               std::tie(rhs.base_bindings, rhs.primitive_mode, rhs.block_x, rhs.block_y,
-                        rhs.block_z);
+        return std::tie(base_bindings, primitive_mode, block_x, block_y, block_z,
+                        shared_memory_size) == std::tie(rhs.base_bindings, rhs.primitive_mode,
+                                                        rhs.block_x, rhs.block_y, rhs.block_z,
+                                                        rhs.shared_memory_size);
     }
 
     bool operator!=(const ProgramVariant& rhs) const noexcept {
@@ -129,7 +132,8 @@ struct hash<OpenGL::ProgramVariant> {
                (static_cast<std::size_t>(variant.primitive_mode) << 6) ^
                static_cast<std::size_t>(variant.block_x) ^
                (static_cast<std::size_t>(variant.block_y) << 32) ^
-               (static_cast<std::size_t>(variant.block_z) << 48);
+               (static_cast<std::size_t>(variant.block_z) << 48) ^
+               (static_cast<std::size_t>(variant.shared_memory_size) << 16);
     }
 };
 

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.h
@@ -64,10 +64,10 @@ struct ProgramVariant final {
         : base_bindings{base_bindings}, primitive_mode{primitive_mode} {}
 
     /// Compute constructor.
-    explicit constexpr ProgramVariant(u32 block_x, u32 block_y, u32 block_z,
-                                      u32 shared_memory_size) noexcept
+    explicit constexpr ProgramVariant(u32 block_x, u32 block_y, u32 block_z, u32 shared_memory_size,
+                                      u32 local_memory_size) noexcept
         : block_x{block_x}, block_y{static_cast<u16>(block_y)}, block_z{static_cast<u16>(block_z)},
-          shared_memory_size{shared_memory_size} {}
+          shared_memory_size{shared_memory_size}, local_memory_size{local_memory_size} {}
 
     // Graphics specific parameters.
     BaseBindings base_bindings{};
@@ -78,12 +78,13 @@ struct ProgramVariant final {
     u16 block_y{};
     u16 block_z{};
     u32 shared_memory_size{};
+    u32 local_memory_size{};
 
     bool operator==(const ProgramVariant& rhs) const noexcept {
         return std::tie(base_bindings, primitive_mode, block_x, block_y, block_z,
-                        shared_memory_size) == std::tie(rhs.base_bindings, rhs.primitive_mode,
-                                                        rhs.block_x, rhs.block_y, rhs.block_z,
-                                                        rhs.shared_memory_size);
+                        shared_memory_size, local_memory_size) ==
+               std::tie(rhs.base_bindings, rhs.primitive_mode, rhs.block_x, rhs.block_y,
+                        rhs.block_z, rhs.shared_memory_size, rhs.local_memory_size);
     }
 
     bool operator!=(const ProgramVariant& rhs) const noexcept {
@@ -133,7 +134,8 @@ struct hash<OpenGL::ProgramVariant> {
                static_cast<std::size_t>(variant.block_x) ^
                (static_cast<std::size_t>(variant.block_y) << 32) ^
                (static_cast<std::size_t>(variant.block_z) << 48) ^
-               (static_cast<std::size_t>(variant.shared_memory_size) << 16);
+               (static_cast<std::size_t>(variant.shared_memory_size) << 16) ^
+               (static_cast<std::size_t>(variant.local_memory_size) << 36);
     }
 };
 

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.h
@@ -18,6 +18,7 @@
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "core/file_sys/vfs_vector.h"
+#include "video_core/engines/shader_type.h"
 #include "video_core/renderer_opengl/gl_shader_gen.h"
 #include "video_core/shader/const_buffer_locker.h"
 
@@ -154,8 +155,8 @@ namespace OpenGL {
 /// Describes a shader how it's used by the guest GPU
 class ShaderDiskCacheRaw {
 public:
-    explicit ShaderDiskCacheRaw(u64 unique_identifier, ProgramType program_type,
-                                ProgramCode program_code, ProgramCode program_code_b = {});
+    explicit ShaderDiskCacheRaw(u64 unique_identifier, Tegra::Engines::ShaderType type,
+                                ProgramCode code, ProgramCode code_b = {});
     ShaderDiskCacheRaw();
     ~ShaderDiskCacheRaw();
 
@@ -168,27 +169,26 @@ public:
     }
 
     bool HasProgramA() const {
-        return program_type == ProgramType::VertexA;
+        return !code.empty() && !code_b.empty();
     }
 
-    ProgramType GetProgramType() const {
-        return program_type;
+    Tegra::Engines::ShaderType GetType() const {
+        return type;
     }
 
-    const ProgramCode& GetProgramCode() const {
-        return program_code;
+    const ProgramCode& GetCode() const {
+        return code;
     }
 
-    const ProgramCode& GetProgramCodeB() const {
-        return program_code_b;
+    const ProgramCode& GetCodeB() const {
+        return code_b;
     }
 
 private:
     u64 unique_identifier{};
-    ProgramType program_type{};
-
-    ProgramCode program_code;
-    ProgramCode program_code_b;
+    Tegra::Engines::ShaderType type{};
+    ProgramCode code;
+    ProgramCode code_b;
 };
 
 /// Contains an OpenGL dumped binary program

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -4,6 +4,7 @@
 
 #include <fmt/format.h>
 #include "video_core/engines/maxwell_3d.h"
+#include "video_core/engines/shader_type.h"
 #include "video_core/renderer_opengl/gl_shader_decompiler.h"
 #include "video_core/renderer_opengl/gl_shader_gen.h"
 #include "video_core/shader/shader_ir.h"
@@ -11,6 +12,7 @@
 namespace OpenGL::GLShader {
 
 using Tegra::Engines::Maxwell3D;
+using Tegra::Engines::ShaderType;
 using VideoCommon::Shader::CompileDepth;
 using VideoCommon::Shader::CompilerSettings;
 using VideoCommon::Shader::ProgramCode;
@@ -24,10 +26,9 @@ layout (std140, binding = EMULATION_UBO_BINDING) uniform vs_config {
 };
 
 )";
-    const auto stage = ir_b ? ProgramType::VertexA : ProgramType::VertexB;
-    out += Decompile(device, ir, stage, "vertex");
+    out += Decompile(device, ir, ShaderType::Vertex, "vertex");
     if (ir_b) {
-        out += Decompile(device, *ir_b, ProgramType::VertexB, "vertex_b");
+        out += Decompile(device, *ir_b, ShaderType::Vertex, "vertex_b");
     }
 
     out += R"(
@@ -49,7 +50,7 @@ layout (std140, binding = EMULATION_UBO_BINDING) uniform gs_config {
 };
 
 )";
-    out += Decompile(device, ir, ProgramType::Geometry, "geometry");
+    out += Decompile(device, ir, ShaderType::Geometry, "geometry");
 
     out += R"(
 void main() {
@@ -76,7 +77,7 @@ layout (std140, binding = EMULATION_UBO_BINDING) uniform fs_config {
 };
 
 )";
-    out += Decompile(device, ir, ProgramType::Fragment, "fragment");
+    out += Decompile(device, ir, ShaderType::Fragment, "fragment");
 
     out += R"(
 void main() {
@@ -88,7 +89,7 @@ void main() {
 
 std::string GenerateComputeShader(const Device& device, const ShaderIR& ir) {
     std::string out = GetCommonDeclarations();
-    out += Decompile(device, ir, ProgramType::Compute, "compute");
+    out += Decompile(device, ir, ShaderType::Compute, "compute");
     out += R"(
 void main() {
     execute_compute();

--- a/src/video_core/renderer_opengl/gl_shader_gen.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_gen.cpp
@@ -2,9 +2,13 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <string>
+
 #include <fmt/format.h>
+
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/engines/shader_type.h"
+#include "video_core/renderer_opengl/gl_device.h"
 #include "video_core/renderer_opengl/gl_shader_decompiler.h"
 #include "video_core/renderer_opengl/gl_shader_gen.h"
 #include "video_core/shader/shader_ir.h"
@@ -20,12 +24,13 @@ using VideoCommon::Shader::ShaderIR;
 
 std::string GenerateVertexShader(const Device& device, const ShaderIR& ir, const ShaderIR* ir_b) {
     std::string out = GetCommonDeclarations();
-    out += R"(
-layout (std140, binding = EMULATION_UBO_BINDING) uniform vs_config {
+    out += fmt::format(R"(
+layout (std140, binding = {}) uniform vs_config {{
     float y_direction;
-};
+}};
 
-)";
+)",
+                       EmulationUniformBlockBinding);
     out += Decompile(device, ir, ShaderType::Vertex, "vertex");
     if (ir_b) {
         out += Decompile(device, *ir_b, ShaderType::Vertex, "vertex_b");
@@ -44,12 +49,13 @@ void main() {
 
 std::string GenerateGeometryShader(const Device& device, const ShaderIR& ir) {
     std::string out = GetCommonDeclarations();
-    out += R"(
-layout (std140, binding = EMULATION_UBO_BINDING) uniform gs_config {
+    out += fmt::format(R"(
+layout (std140, binding = {}) uniform gs_config {{
     float y_direction;
-};
+}};
 
-)";
+)",
+                       EmulationUniformBlockBinding);
     out += Decompile(device, ir, ShaderType::Geometry, "geometry");
 
     out += R"(
@@ -62,7 +68,7 @@ void main() {
 
 std::string GenerateFragmentShader(const Device& device, const ShaderIR& ir) {
     std::string out = GetCommonDeclarations();
-    out += R"(
+    out += fmt::format(R"(
 layout (location = 0) out vec4 FragColor0;
 layout (location = 1) out vec4 FragColor1;
 layout (location = 2) out vec4 FragColor2;
@@ -72,11 +78,12 @@ layout (location = 5) out vec4 FragColor5;
 layout (location = 6) out vec4 FragColor6;
 layout (location = 7) out vec4 FragColor7;
 
-layout (std140, binding = EMULATION_UBO_BINDING) uniform fs_config {
+layout (std140, binding = {}) uniform fs_config {{
     float y_direction;
-};
+}};
 
-)";
+)",
+                       EmulationUniformBlockBinding);
     out += Decompile(device, ir, ShaderType::Fragment, "fragment");
 
     out += R"(

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -417,14 +417,20 @@ void OpenGLState::ApplyClipControl() {
 }
 
 void OpenGLState::ApplyTextures() {
-    if (const auto update = UpdateArray(cur_state.textures, textures)) {
-        glBindTextures(update->first, update->second, textures.data() + update->first);
+    const std::size_t size = std::size(textures);
+    for (std::size_t i = 0; i < size; ++i) {
+        if (UpdateValue(cur_state.textures[i], textures[i])) {
+            glBindTextureUnit(static_cast<GLuint>(i), textures[i]);
+        }
     }
 }
 
 void OpenGLState::ApplySamplers() {
-    if (const auto update = UpdateArray(cur_state.samplers, samplers)) {
-        glBindSamplers(update->first, update->second, samplers.data() + update->first);
+    const std::size_t size = std::size(samplers);
+    for (std::size_t i = 0; i < size; ++i) {
+        if (UpdateValue(cur_state.samplers[i], samplers[i])) {
+            glBindSampler(static_cast<GLuint>(i), samplers[i]);
+        }
     }
 }
 

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -420,7 +420,11 @@ void OpenGLState::ApplyTextures() {
     const std::size_t size = std::size(textures);
     for (std::size_t i = 0; i < size; ++i) {
         if (UpdateValue(cur_state.textures[i], textures[i])) {
-            glBindTextureUnit(static_cast<GLuint>(i), textures[i]);
+            // BindTextureUnit doesn't support binding null textures, skip those binds.
+            // TODO(Rodrigo): Stop using null textures
+            if (textures[i] != 0) {
+                glBindTextureUnit(static_cast<GLuint>(i), textures[i]);
+            }
         }
     }
 }

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -96,8 +96,9 @@ public:
         GLenum operation = GL_COPY;
     } logic_op;
 
-    std::array<GLuint, Tegra::Engines::Maxwell3D::Regs::NumTextureSamplers> textures = {};
-    std::array<GLuint, Tegra::Engines::Maxwell3D::Regs::NumTextureSamplers> samplers = {};
+    static constexpr std::size_t NumSamplers = 32 * 5;
+    std::array<GLuint, NumSamplers> textures = {};
+    std::array<GLuint, NumSamplers> samplers = {};
     std::array<GLuint, Tegra::Engines::Maxwell3D::Regs::NumImages> images = {};
 
     struct {

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -97,9 +97,10 @@ public:
     } logic_op;
 
     static constexpr std::size_t NumSamplers = 32 * 5;
+    static constexpr std::size_t NumImages = 8 * 5;
     std::array<GLuint, NumSamplers> textures = {};
     std::array<GLuint, NumSamplers> samplers = {};
-    std::array<GLuint, Tegra::Engines::Maxwell3D::Regs::NumImages> images = {};
+    std::array<GLuint, NumImages> images = {};
 
     struct {
         GLuint read_framebuffer = 0; // GL_READ_FRAMEBUFFER_BINDING

--- a/src/video_core/renderer_opengl/utils.h
+++ b/src/video_core/renderer_opengl/utils.h
@@ -43,20 +43,22 @@ public:
     explicit BindBuffersRangePushBuffer(GLenum target);
     ~BindBuffersRangePushBuffer();
 
-    void Setup(GLuint first_);
+    void Setup();
 
-    void Push(const GLuint* buffer, GLintptr offset, GLsizeiptr size);
+    void Push(GLuint binding, const GLuint* buffer, GLintptr offset, GLsizeiptr size);
 
     void Bind();
 
 private:
-    GLenum target{};
-    GLuint first{};
-    std::vector<const GLuint*> buffer_pointers;
+    struct Entry {
+        GLuint binding;
+        const GLuint* buffer;
+        GLintptr offset;
+        GLsizeiptr size;
+    };
 
-    std::vector<GLuint> buffers;
-    std::vector<GLintptr> offsets;
-    std::vector<GLsizeiptr> sizes;
+    GLenum target;
+    std::vector<Entry> entries;
 };
 
 void LabelGLObject(GLenum identifier, GLuint handle, VAddr addr, std::string_view extra_info = {});

--- a/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
@@ -13,6 +13,8 @@
 
 namespace Vulkan::MaxwellToVK {
 
+using Maxwell = Tegra::Engines::Maxwell3D::Regs;
+
 namespace Sampler {
 
 vk::Filter Filter(Tegra::Texture::TextureFilter filter) {
@@ -196,17 +198,17 @@ std::pair<vk::Format, bool> SurfaceFormat(const VKDevice& device, FormatType for
     return {device.GetSupportedFormat(tuple.format, usage, format_type), tuple.attachable};
 }
 
-vk::ShaderStageFlagBits ShaderStage(Maxwell::ShaderStage stage) {
+vk::ShaderStageFlagBits ShaderStage(Tegra::Engines::ShaderType stage) {
     switch (stage) {
-    case Maxwell::ShaderStage::Vertex:
+    case Tegra::Engines::ShaderType::Vertex:
         return vk::ShaderStageFlagBits::eVertex;
-    case Maxwell::ShaderStage::TesselationControl:
+    case Tegra::Engines::ShaderType::TesselationControl:
         return vk::ShaderStageFlagBits::eTessellationControl;
-    case Maxwell::ShaderStage::TesselationEval:
+    case Tegra::Engines::ShaderType::TesselationEval:
         return vk::ShaderStageFlagBits::eTessellationEvaluation;
-    case Maxwell::ShaderStage::Geometry:
+    case Tegra::Engines::ShaderType::Geometry:
         return vk::ShaderStageFlagBits::eGeometry;
-    case Maxwell::ShaderStage::Fragment:
+    case Tegra::Engines::ShaderType::Fragment:
         return vk::ShaderStageFlagBits::eFragment;
     }
     UNIMPLEMENTED_MSG("Unimplemented shader stage={}", static_cast<u32>(stage));

--- a/src/video_core/renderer_vulkan/maxwell_to_vk.h
+++ b/src/video_core/renderer_vulkan/maxwell_to_vk.h
@@ -32,7 +32,7 @@ vk::CompareOp DepthCompareFunction(Tegra::Texture::DepthCompareFunc depth_compar
 std::pair<vk::Format, bool> SurfaceFormat(const VKDevice& device, FormatType format_type,
                                           PixelFormat pixel_format);
 
-vk::ShaderStageFlagBits ShaderStage(Maxwell::ShaderStage stage);
+vk::ShaderStageFlagBits ShaderStage(Tegra::Engines::ShaderType stage);
 
 vk::PrimitiveTopology PrimitiveTopology(Maxwell::PrimitiveTopology topology);
 

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.h
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.h
@@ -79,6 +79,6 @@ struct ShaderEntries {
 using DecompilerResult = std::pair<std::unique_ptr<Sirit::Module>, ShaderEntries>;
 
 DecompilerResult Decompile(const VKDevice& device, const VideoCommon::Shader::ShaderIR& ir,
-                           Maxwell::ShaderStage stage);
+                           Tegra::Engines::ShaderType stage);
 
 } // namespace Vulkan::VKShader

--- a/src/video_core/shader/const_buffer_locker.cpp
+++ b/src/video_core/shader/const_buffer_locker.cpp
@@ -9,6 +9,7 @@
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "video_core/engines/maxwell_3d.h"
+#include "video_core/engines/shader_type.h"
 #include "video_core/shader/const_buffer_locker.h"
 
 namespace VideoCommon::Shader {

--- a/src/video_core/shader/const_buffer_locker.h
+++ b/src/video_core/shader/const_buffer_locker.h
@@ -8,6 +8,7 @@
 #include "common/common_types.h"
 #include "common/hash.h"
 #include "video_core/engines/const_buffer_engine_interface.h"
+#include "video_core/engines/shader_type.h"
 
 namespace VideoCommon::Shader {
 
@@ -20,7 +21,7 @@ using BindlessSamplerMap =
  * The ConstBufferLocker is a class use to interface the 3D and compute engines with the shader
  * compiler. with it, the shader can obtain required data from GPU state and store it for disk
  * shader compilation.
- **/
+ */
 class ConstBufferLocker {
 public:
     explicit ConstBufferLocker(Tegra::Engines::ShaderType shader_stage);

--- a/src/video_core/shader/decode/texture.cpp
+++ b/src/video_core/shader/decode/texture.cpp
@@ -128,8 +128,8 @@ u32 ShaderIR::DecodeTexture(NodeBlock& bb, u32 pc) {
         }
         const Node component = Immediate(static_cast<u32>(instr.tld4s.component));
 
-        const auto& sampler =
-            GetSampler(instr.sampler, {{TextureType::Texture2D, false, depth_compare}});
+        const SamplerInfo info{TextureType::Texture2D, false, depth_compare};
+        const auto& sampler = GetSampler(instr.sampler, info);
 
         Node4 values;
         for (u32 element = 0; element < values.size(); ++element) {
@@ -149,7 +149,7 @@ u32 ShaderIR::DecodeTexture(NodeBlock& bb, u32 pc) {
         // Sadly, not all texture instructions specify the type of texture their sampler
         // uses. This must be fixed at a later instance.
         const auto& sampler =
-            is_bindless ? GetBindlessSampler(instr.gpr8, {}) : GetSampler(instr.sampler, {});
+            is_bindless ? GetBindlessSampler(instr.gpr8) : GetSampler(instr.sampler);
 
         u32 indexer = 0;
         switch (instr.txq.query_type) {
@@ -185,8 +185,7 @@ u32 ShaderIR::DecodeTexture(NodeBlock& bb, u32 pc) {
         auto texture_type = instr.tmml.texture_type.Value();
         const bool is_array = instr.tmml.array != 0;
         const auto& sampler =
-            is_bindless ? GetBindlessSampler(instr.gpr20, {{texture_type, is_array, false}})
-                        : GetSampler(instr.sampler, {{texture_type, is_array, false}});
+            is_bindless ? GetBindlessSampler(instr.gpr20) : GetSampler(instr.sampler);
 
         std::vector<Node> coords;
 
@@ -254,67 +253,50 @@ u32 ShaderIR::DecodeTexture(NodeBlock& bb, u32 pc) {
     return pc;
 }
 
+ShaderIR::SamplerInfo ShaderIR::GetSamplerInfo(std::optional<SamplerInfo> sampler_info, u32 offset,
+                                               std::optional<u32> buffer) {
+    if (sampler_info) {
+        return *sampler_info;
+    }
+    const auto sampler =
+        buffer ? locker.ObtainBindlessSampler(*buffer, offset) : locker.ObtainBoundSampler(offset);
+    if (!sampler) {
+        LOG_WARNING(HW_GPU, "Unknown sampler info");
+        return SamplerInfo{TextureType::Texture2D, false, false, false};
+    }
+    return SamplerInfo{sampler->texture_type, sampler->is_array != 0, sampler->is_shadow != 0,
+                       sampler->is_buffer != 0};
+}
+
 const Sampler& ShaderIR::GetSampler(const Tegra::Shader::Sampler& sampler,
                                     std::optional<SamplerInfo> sampler_info) {
     const auto offset = static_cast<u32>(sampler.index.Value());
-
-    TextureType type;
-    bool is_array;
-    bool is_shadow;
-    if (sampler_info) {
-        type = sampler_info->type;
-        is_array = sampler_info->is_array;
-        is_shadow = sampler_info->is_shadow;
-    } else if (const auto sampler = locker.ObtainBoundSampler(offset)) {
-        type = sampler->texture_type.Value();
-        is_array = sampler->is_array.Value() != 0;
-        is_shadow = sampler->is_shadow.Value() != 0;
-    } else {
-        LOG_WARNING(HW_GPU, "Unknown sampler info");
-        type = TextureType::Texture2D;
-        is_array = false;
-        is_shadow = false;
-    }
+    const auto info = GetSamplerInfo(sampler_info, offset);
 
     // If this sampler has already been used, return the existing mapping.
     const auto it =
         std::find_if(used_samplers.begin(), used_samplers.end(),
                      [offset](const Sampler& entry) { return entry.GetOffset() == offset; });
     if (it != used_samplers.end()) {
-        ASSERT(!it->IsBindless() && it->GetType() == type && it->IsArray() == is_array &&
-               it->IsShadow() == is_shadow);
+        ASSERT(!it->IsBindless() && it->GetType() == info.type && it->IsArray() == info.is_array &&
+               it->IsShadow() == info.is_shadow && it->IsBuffer() == info.is_buffer);
         return *it;
     }
 
     // Otherwise create a new mapping for this sampler
     const auto next_index = static_cast<u32>(used_samplers.size());
-    return used_samplers.emplace_back(Sampler(next_index, offset, type, is_array, is_shadow));
+    return used_samplers.emplace_back(next_index, offset, info.type, info.is_array, info.is_shadow,
+                                      info.is_buffer);
 }
 
-const Sampler& ShaderIR::GetBindlessSampler(const Tegra::Shader::Register& reg,
+const Sampler& ShaderIR::GetBindlessSampler(Tegra::Shader::Register reg,
                                             std::optional<SamplerInfo> sampler_info) {
     const Node sampler_register = GetRegister(reg);
     const auto [base_sampler, buffer, offset] =
         TrackCbuf(sampler_register, global_code, static_cast<s64>(global_code.size()));
     ASSERT(base_sampler != nullptr);
 
-    TextureType type;
-    bool is_array;
-    bool is_shadow;
-    if (sampler_info) {
-        type = sampler_info->type;
-        is_array = sampler_info->is_array;
-        is_shadow = sampler_info->is_shadow;
-    } else if (const auto sampler = locker.ObtainBindlessSampler(buffer, offset)) {
-        type = sampler->texture_type.Value();
-        is_array = sampler->is_array.Value() != 0;
-        is_shadow = sampler->is_shadow.Value() != 0;
-    } else {
-        LOG_WARNING(HW_GPU, "Unknown sampler info");
-        type = TextureType::Texture2D;
-        is_array = false;
-        is_shadow = false;
-    }
+    const auto info = GetSamplerInfo(sampler_info, offset, buffer);
 
     // If this sampler has already been used, return the existing mapping.
     const auto it =
@@ -323,15 +305,15 @@ const Sampler& ShaderIR::GetBindlessSampler(const Tegra::Shader::Register& reg,
                          return entry.GetBuffer() == buffer && entry.GetOffset() == offset;
                      });
     if (it != used_samplers.end()) {
-        ASSERT(it->IsBindless() && it->GetType() == type && it->IsArray() == is_array &&
-               it->IsShadow() == is_shadow);
+        ASSERT(it->IsBindless() && it->GetType() == info.type && it->IsArray() == info.is_array &&
+               it->IsShadow() == info.is_shadow);
         return *it;
     }
 
     // Otherwise create a new mapping for this sampler
     const auto next_index = static_cast<u32>(used_samplers.size());
-    return used_samplers.emplace_back(
-        Sampler(next_index, offset, buffer, type, is_array, is_shadow));
+    return used_samplers.emplace_back(next_index, offset, buffer, info.type, info.is_array,
+                                      info.is_shadow, info.is_buffer);
 }
 
 void ShaderIR::WriteTexInstructionFloat(NodeBlock& bb, Instruction instr, const Node4& components) {
@@ -416,17 +398,16 @@ Node4 ShaderIR::GetTextureCode(Instruction instr, TextureType texture_type,
                              (texture_type == TextureType::TextureCube && is_array && is_shadow),
                          "This method is not supported.");
 
+    const SamplerInfo info{texture_type, is_array, is_shadow, false};
     const auto& sampler =
-        is_bindless ? GetBindlessSampler(*bindless_reg, {{texture_type, is_array, is_shadow}})
-                    : GetSampler(instr.sampler, {{texture_type, is_array, is_shadow}});
+        is_bindless ? GetBindlessSampler(*bindless_reg, info) : GetSampler(instr.sampler, info);
 
     const bool lod_needed = process_mode == TextureProcessMode::LZ ||
                             process_mode == TextureProcessMode::LL ||
                             process_mode == TextureProcessMode::LLA;
 
-    // LOD selection (either via bias or explicit textureLod) not
-    // supported in GL for sampler2DArrayShadow and
-    // samplerCubeArrayShadow.
+    // LOD selection (either via bias or explicit textureLod) not supported in GL for
+    // sampler2DArrayShadow and samplerCubeArrayShadow.
     const bool gl_lod_supported =
         !((texture_type == Tegra::Shader::TextureType::Texture2D && is_array && is_shadow) ||
           (texture_type == Tegra::Shader::TextureType::TextureCube && is_array && is_shadow));
@@ -436,8 +417,8 @@ Node4 ShaderIR::GetTextureCode(Instruction instr, TextureType texture_type,
 
     UNIMPLEMENTED_IF(process_mode != TextureProcessMode::None && !gl_lod_supported);
 
-    Node bias = {};
-    Node lod = {};
+    Node bias;
+    Node lod;
     if (process_mode != TextureProcessMode::None && gl_lod_supported) {
         switch (process_mode) {
         case TextureProcessMode::LZ:
@@ -573,10 +554,9 @@ Node4 ShaderIR::GetTld4Code(Instruction instr, TextureType texture_type, bool de
 
     u64 parameter_register = instr.gpr20.Value();
 
-    const auto& sampler =
-        is_bindless
-            ? GetBindlessSampler(parameter_register++, {{texture_type, is_array, depth_compare}})
-            : GetSampler(instr.sampler, {{texture_type, is_array, depth_compare}});
+    const SamplerInfo info{texture_type, is_array, depth_compare, false};
+    const auto& sampler = is_bindless ? GetBindlessSampler(parameter_register++, info)
+                                      : GetSampler(instr.sampler, info);
 
     std::vector<Node> aoffi;
     if (is_aoffi) {
@@ -623,7 +603,7 @@ Node4 ShaderIR::GetTldCode(Tegra::Shader::Instruction instr) {
     // const Node aoffi_register{is_aoffi ? GetRegister(gpr20_cursor++) : nullptr};
     // const Node multisample{is_multisample ? GetRegister(gpr20_cursor++) : nullptr};
 
-    const auto& sampler = GetSampler(instr.sampler, {{texture_type, is_array, false}});
+    const auto& sampler = GetSampler(instr.sampler);
 
     Node4 values;
     for (u32 element = 0; element < values.size(); ++element) {
@@ -659,7 +639,7 @@ Node4 ShaderIR::GetTldsCode(Instruction instr, TextureType texture_type, bool is
     // When lod is used always is in gpr20
     const Node lod = lod_enabled ? GetRegister(instr.gpr20) : Immediate(0);
 
-    const auto& sampler = GetSampler(instr.sampler, {{texture_type, is_array, false}});
+    const auto& sampler = GetSampler(instr.sampler);
 
     Node4 values;
     for (u32 element = 0; element < values.size(); ++element) {

--- a/src/video_core/shader/node.h
+++ b/src/video_core/shader/node.h
@@ -225,14 +225,15 @@ class Sampler {
 public:
     /// This constructor is for bound samplers
     constexpr explicit Sampler(u32 index, u32 offset, Tegra::Shader::TextureType type,
-                               bool is_array, bool is_shadow)
-        : index{index}, offset{offset}, type{type}, is_array{is_array}, is_shadow{is_shadow} {}
+                               bool is_array, bool is_shadow, bool is_buffer)
+        : index{index}, offset{offset}, type{type}, is_array{is_array}, is_shadow{is_shadow},
+          is_buffer{is_buffer} {}
 
     /// This constructor is for bindless samplers
     constexpr explicit Sampler(u32 index, u32 offset, u32 buffer, Tegra::Shader::TextureType type,
-                               bool is_array, bool is_shadow)
+                               bool is_array, bool is_shadow, bool is_buffer)
         : index{index}, offset{offset}, buffer{buffer}, type{type}, is_array{is_array},
-          is_shadow{is_shadow}, is_bindless{true} {}
+          is_shadow{is_shadow}, is_buffer{is_buffer}, is_bindless{true} {}
 
     constexpr u32 GetIndex() const {
         return index;
@@ -258,6 +259,10 @@ public:
         return is_shadow;
     }
 
+    constexpr bool IsBuffer() const {
+        return is_buffer;
+    }
+
     constexpr bool IsBindless() const {
         return is_bindless;
     }
@@ -270,6 +275,7 @@ private:
     Tegra::Shader::TextureType type{}; ///< The type used to sample this texture (Texture2D, etc)
     bool is_array{};    ///< Whether the texture is being sampled as an array texture or not.
     bool is_shadow{};   ///< Whether the texture is being sampled as a depth texture or not.
+    bool is_buffer{};   ///< Whether the texture is a texture buffer without sampler.
     bool is_bindless{}; ///< Whether this sampler belongs to a bindless texture or not.
 };
 

--- a/src/video_core/shader/shader_ir.h
+++ b/src/video_core/shader/shader_ir.h
@@ -179,6 +179,7 @@ private:
         Tegra::Shader::TextureType type;
         bool is_array;
         bool is_shadow;
+        bool is_buffer;
     };
 
     void Decode();
@@ -303,13 +304,17 @@ private:
     /// Returns a predicate combiner operation
     OperationCode GetPredicateCombiner(Tegra::Shader::PredOperation operation);
 
+    /// Queries the missing sampler info from the execution context.
+    SamplerInfo GetSamplerInfo(std::optional<SamplerInfo> sampler_info, u32 offset,
+                               std::optional<u32> buffer = std::nullopt);
+
     /// Accesses a texture sampler
     const Sampler& GetSampler(const Tegra::Shader::Sampler& sampler,
-                              std::optional<SamplerInfo> sampler_info);
+                              std::optional<SamplerInfo> sampler_info = std::nullopt);
 
-    // Accesses a texture sampler for a bindless texture.
-    const Sampler& GetBindlessSampler(const Tegra::Shader::Register& reg,
-                                      std::optional<SamplerInfo> sampler_info);
+    /// Accesses a texture sampler for a bindless texture.
+    const Sampler& GetBindlessSampler(Tegra::Shader::Register reg,
+                                      std::optional<SamplerInfo> sampler_info = std::nullopt);
 
     /// Accesses an image.
     Image& GetImage(Tegra::Shader::Image image, Tegra::Shader::ImageType type);


### PR DESCRIPTION
This diff includes various changes that invalidate the shader cache. I opted to do all of this at once to avoid invalidating several times.

The description of each case is in its individual commit. As highlights this PR implements compute shaders for Intel free and proprietary and AMD proprietary drivers (nouveau and radeonsi were already covered) and it fixes build issues due to shared memory access in compute shaders.