### PR TITLE
common/bit_field: Silence sign-conversion warnings

### DIFF
--- a/src/common/bit_field.h
+++ b/src/common/bit_field.h
@@ -135,7 +135,8 @@ public:
     /// Constants to allow limited introspection of fields if needed
     static constexpr std::size_t position = Position;
     static constexpr std::size_t bits = Bits;
-    static constexpr StorageType mask = (((StorageType)~0) >> (8 * sizeof(T) - bits)) << position;
+    static constexpr StorageType mask = StorageType(
+        (std::numeric_limits<StorageType>::max() >> (8 * sizeof(T) - bits)) << position);
 
     /**
      * Formats a value by masking and shifting it according to the field parameters. A value
@@ -143,7 +144,7 @@ public:
      * the results together.
      */
     static constexpr FORCE_INLINE StorageType FormatValue(const T& value) {
-        return ((StorageType)value << position) & mask;
+        return (static_cast<StorageType>(value) << position) & mask;
     }
 
     /**


### PR DESCRIPTION
We can just use numeric_limits instead of relying on wraparound behavior here.