### PR TITLE
Complete the implementation of RGBA16UI

### DIFF
--- a/src/video_core/surface.cpp
+++ b/src/video_core/surface.cpp
@@ -249,6 +249,8 @@ PixelFormat PixelFormatFromTextureFormat(Tegra::Texture::TextureFormat format,
             return PixelFormat::RGBA16U;
         case Tegra::Texture::ComponentType::FLOAT:
             return PixelFormat::RGBA16F;
+        case Tegra::Texture::ComponentType::UINT:
+            return PixelFormat::RGBA16UI;
         default:
             break;
         }


### PR DESCRIPTION
Complete the RGBA16UI which has those 2 important lines missing and for information RGBA16UI is required by pokemon sword and shield