### PR TITLE
common_funcs: Remove semicolons from INSERT_PADDING_* macros

### DIFF
--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -19,13 +19,15 @@
 
 /// Helper macros to insert unused bytes or words to properly align structs. These values will be
 /// zero-initialized.
-#define INSERT_PADDING_BYTES(num_bytes) std::array<u8, num_bytes> CONCAT2(pad, __LINE__){};
-#define INSERT_PADDING_WORDS(num_words) std::array<u32, num_words> CONCAT2(pad, __LINE__){};
+#define INSERT_PADDING_BYTES(num_bytes)                                                            \
+    std::array<u8, num_bytes> CONCAT2(pad, __LINE__) {}
+#define INSERT_PADDING_WORDS(num_words)                                                            \
+    std::array<u32, num_words> CONCAT2(pad, __LINE__) {}
 
 /// These are similar to the INSERT_PADDING_* macros, but are needed for padding unions. This is
 /// because unions can only be initialized by one member.
-#define INSERT_UNION_PADDING_BYTES(num_bytes) std::array<u8, num_bytes> CONCAT2(pad, __LINE__);
-#define INSERT_UNION_PADDING_WORDS(num_words) std::array<u32, num_words> CONCAT2(pad, __LINE__);
+#define INSERT_UNION_PADDING_BYTES(num_bytes) std::array<u8, num_bytes> CONCAT2(pad, __LINE__)
+#define INSERT_UNION_PADDING_WORDS(num_words) std::array<u32, num_words> CONCAT2(pad, __LINE__)
 
 #ifndef _MSC_VER
 


### PR DESCRIPTION
Makes code that uses the macros consistent by requiring the lines to be terminated with a semicolon.