### PR TITLE
Kernel: Correct behavior of Condition Variables to be more similar to real hardware.

### DIFF
--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -66,6 +66,9 @@ static void ThreadWakeupCallback(u64 thread_handle, [[maybe_unused]] s64 cycles_
         thread->SetMutexWaitAddress(0);
         thread->SetCondVarWaitAddress(0);
         thread->SetWaitHandle(0);
+        if (thread->GetStatus() == ThreadStatus::WaitCondVar) {
+            thread->GetOwnerProcess()->RemoveConditionVariableThread(thread);
+        }
 
         auto* const lock_owner = thread->GetLockOwner();
         // Threads waking up by timeout from WaitProcessWideKey do not perform priority inheritance

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -64,10 +64,10 @@ static void ThreadWakeupCallback(u64 thread_handle, [[maybe_unused]] s64 cycles_
     } else if (thread->GetStatus() == ThreadStatus::WaitMutex ||
                thread->GetStatus() == ThreadStatus::WaitCondVar) {
         thread->SetMutexWaitAddress(0);
-        thread->SetCondVarWaitAddress(0);
         thread->SetWaitHandle(0);
         if (thread->GetStatus() == ThreadStatus::WaitCondVar) {
             thread->GetOwnerProcess()->RemoveConditionVariableThread(thread);
+            thread->SetCondVarWaitAddress(0);
         }
 
         auto* const lock_owner = thread->GetLockOwner();

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -232,6 +232,15 @@ public:
         return thread_list;
     }
 
+    /// Insert a thread into the condition variable wait container
+    void InsertConditionVariableThread(SharedPtr<Thread> thread);
+
+    /// Remove a thread from the condition variable wait container
+    void RemoveConditionVariableThread(SharedPtr<Thread> thread);
+
+    /// Obtain all condition variable threads waiting for some address
+    std::vector<SharedPtr<Thread>> GetConditionVariableThreads(VAddr cond_var_addr);
+
     /// Registers a thread as being created under this process,
     /// adding it to this process' thread list.
     void RegisterThread(const Thread* thread);
@@ -374,6 +383,9 @@ private:
 
     /// List of threads that are running with this process as their owner.
     std::list<const Thread*> thread_list;
+
+    /// List of threads waiting for a condition variable
+    std::list<SharedPtr<Thread>> cond_var_threads;
 
     /// System context
     Core::System& system;

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <list>
 #include <string>
+#include <unordered_map>
 #include <vector>
 #include "common/common_types.h"
 #include "core/hle/kernel/address_arbiter.h"
@@ -385,7 +386,7 @@ private:
     std::list<const Thread*> thread_list;
 
     /// List of threads waiting for a condition variable
-    std::list<SharedPtr<Thread>> cond_var_threads;
+    std::unordered_map<VAddr, std::list<SharedPtr<Thread>>> cond_var_threads;
 
     /// System context
     Core::System& system;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1649,15 +1649,11 @@ static ResultCode SignalProcessWideKey(Core::System& system, VAddr condition_var
     std::vector<SharedPtr<Thread>> waiting_threads =
         current_process->GetConditionVariableThreads(condition_variable_addr);
 
-    // Only process up to 'target' threads, unless 'target' is -1, in which case process
+    // Only process up to 'target' threads, unless 'target' is less equal 0, in which case process
     // them all.
     std::size_t last = waiting_threads.size();
-    if (target != -1)
+    if (target > 0)
         last = std::min(waiting_threads.size(), static_cast<std::size_t>(target));
-
-    // If there are no threads waiting on this condition variable, just exit
-    if (last == 0)
-        return RESULT_SUCCESS;
 
     for (std::size_t index = 0; index < last; ++index) {
         auto& thread = waiting_threads[index];

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1661,8 +1661,8 @@ static ResultCode SignalProcessWideKey(Core::System& system, VAddr condition_var
         ASSERT(thread->GetCondVarWaitAddress() == condition_variable_addr);
 
         // liberate Cond Var Thread.
-        thread->SetCondVarWaitAddress(0);
         current_process->RemoveConditionVariableThread(thread);
+        thread->SetCondVarWaitAddress(0);
 
         const std::size_t current_core = system.CurrentCoreIndex();
         auto& monitor = system.Monitor();

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -306,7 +306,15 @@ void Thread::UpdatePriority() {
         return;
     }
 
+    if (GetStatus() == ThreadStatus::WaitCondVar) {
+        owner_process->RemoveConditionVariableThread(this);
+    }
+
     SetCurrentPriority(new_priority);
+
+    if (GetStatus() == ThreadStatus::WaitCondVar) {
+        owner_process->InsertConditionVariableThread(this);
+    }
 
     if (!lock_owner) {
         return;


### PR DESCRIPTION
This commit ensures cond var threads act exactly as they do in the real console. The original implementation uses an RBTree and the behavior of cond var threads is that at the same priority level they act like a FIFO.