### PR TITLE
Kernel: Correct Cancel Synchronization.

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -505,6 +505,11 @@ static ResultCode WaitSynchronization(Core::System& system, Handle* index, VAddr
         return RESULT_TIMEOUT;
     }
 
+    if (thread->IsSyncCancelled()) {
+        thread->SetSyncCancelled(false);
+        return ERR_SYNCHRONIZATION_CANCELED;
+    }
+
     for (auto& object : objects) {
         object->AddWaitingThread(thread);
     }

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -132,8 +132,11 @@ void Thread::ResumeFromWait() {
 }
 
 void Thread::CancelWait() {
-    ASSERT(GetStatus() == ThreadStatus::WaitSynch);
-    ClearWaitObjects();
+    if (GetSchedulingStatus() != ThreadSchedStatus::Paused) {
+        is_sync_cancelled = true;
+        return;
+    }
+    is_sync_cancelled = false;
     SetWaitSynchronizationResult(ERR_SYNCHRONIZATION_CANCELED);
     ResumeFromWait();
 }

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -440,6 +440,14 @@ public:
         is_running = value;
     }
 
+    bool IsSyncCancelled() const {
+        return is_sync_cancelled;
+    }
+
+    void SetSyncCancelled(bool value) {
+        is_sync_cancelled = value;
+    }
+
 private:
     explicit Thread(KernelCore& kernel);
     ~Thread() override;
@@ -524,6 +532,7 @@ private:
 
     u32 scheduling_state = 0;
     bool is_running = false;
+    bool is_sync_cancelled = false;
 
     std::string name;
 };


### PR DESCRIPTION
This commit corrects the behavior of cancel synchronization when the thread is running/ready and ensures the next wait is cancelled as it's suppose to.