### PR TITLE
Port citra-emu/citra#4953: "citra_qt/main.ui: remove unused actions "Load Symbol Map..." and "Select Game Directory...""

### DIFF
--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -140,11 +140,6 @@
     <string>Load Folder...</string>
    </property>
   </action>
-  <action name="action_Load_Symbol_Map">
-   <property name="text">
-    <string>Load Symbol Map...</string>
-   </property>
-  </action>
   <action name="action_Exit">
    <property name="text">
     <string>E&amp;xit</string>
@@ -219,14 +214,6 @@
    </property>
    <property name="text">
     <string>Show Status Bar</string>
-   </property>
-  </action>
-  <action name="action_Select_Game_List_Root">
-   <property name="text">
-    <string>Select Game Directory...</string>
-   </property>
-   <property name="toolTip">
-    <string>Selects a folder to display in the game list</string>
    </property>
   </action>
   <action name="action_Select_NAND_Directory">


### PR DESCRIPTION
See citra-emu/citra#4953 for more details.