### PR TITLE
shader/other: Reduce DEPBAR log severity

### DIFF
--- a/src/video_core/shader/decode/other.cpp
+++ b/src/video_core/shader/decode/other.cpp
@@ -256,7 +256,7 @@ u32 ShaderIR::DecodeOther(NodeBlock& bb, u32 pc) {
         break;
     }
     case OpCode::Id::DEPBAR: {
-        LOG_WARNING(HW_GPU, "DEPBAR instruction is stubbed");
+        LOG_DEBUG(HW_GPU, "DEPBAR instruction is stubbed");
         break;
     }
     default:


### PR DESCRIPTION
While DEPBAR is stubbed it doesn't change anything from our end. Shading languages handle what this instruction does implicitly. We are not getting anything out of this log except noise.