### PR TITLE
gl_device: Deduce indexing bug from device instead of heuristic

### DIFF
--- a/src/video_core/renderer_opengl/gl_device.h
+++ b/src/video_core/renderer_opengl/gl_device.h
@@ -86,7 +86,6 @@ public:
 
 private:
     static bool TestVariableAoffi();
-    static bool TestComponentIndexingBug();
     static bool TestPreciseBug();
 
     std::array<BaseBindings, Tegra::Engines::MaxShaderTypes> base_bindings;


### PR DESCRIPTION
The heuristic to detect AMD's driver was not working properly since it also included Intel. Instead of using heuristics to detect it, compare the GL_VENDOR string.