### PR TITLE
configure/system: Only allow changing system settings if the game is not running

### DIFF
--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -71,6 +71,9 @@ void ConfigureSystem::SetConfiguration() {
     const auto rtc_time = Settings::values.custom_rtc.value_or(
         std::chrono::seconds(QDateTime::currentSecsSinceEpoch()));
     ui->custom_rtc_edit->setDateTime(QDateTime::fromSecsSinceEpoch(rtc_time.count()));
+
+    if (!enabled)
+        ui->group_system_settings->setEnabled(false);
 }
 
 void ConfigureSystem::ReadSystemSettings() {}


### PR DESCRIPTION
As requested by @Hexagon12 on Discord.