### PR TITLE
Port citra-emu/citra#4964: "Unfold UNREACHABLE implementation for dumb compilers"

### DIFF
--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -42,7 +42,8 @@ __declspec(noinline, noreturn)
     while (0)
 
 #define UNREACHABLE() assert_noinline_call([] { LOG_CRITICAL(Debug, "Unreachable code!"); })
-#define UNREACHABLE_MSG(...) assert_noinline_call([] { LOG_CRITICAL(Debug, "Unreachable code!\n" __VA_ARGS__); })
+#define UNREACHABLE_MSG(...)                                                                       \
+    assert_noinline_call([&] { LOG_CRITICAL(Debug, "Unreachable code!\n" __VA_ARGS__); })
 
 #ifdef _DEBUG
 #define DEBUG_ASSERT(_a_) ASSERT(_a_)

--- a/src/common/assert.h
+++ b/src/common/assert.h
@@ -41,8 +41,8 @@ __declspec(noinline, noreturn)
         }                                                                                          \
     while (0)
 
-#define UNREACHABLE() ASSERT_MSG(false, "Unreachable code!")
-#define UNREACHABLE_MSG(...) ASSERT_MSG(false, __VA_ARGS__)
+#define UNREACHABLE() assert_noinline_call([] { LOG_CRITICAL(Debug, "Unreachable code!"); })
+#define UNREACHABLE_MSG(...) assert_noinline_call([] { LOG_CRITICAL(Debug, "Unreachable code!\n" __VA_ARGS__); })
 
 #ifdef _DEBUG
 #define DEBUG_ASSERT(_a_) ASSERT(_a_)


### PR DESCRIPTION
See citra-emu/citra#4964 for more details.

**Original description**:
We rely on UNREACHABLE's noreturn attribute to eliminate parent's "no return value" warning. However, this was wrapped in a `if(!false)` block, which compilers may not unfold to recognize the noreturn nature.