### PR TITLE
kernel: Replace usage of boost::intrusive_ptr with std::shared_ptr for kernel objects.

### DIFF
--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -73,7 +73,7 @@ private:
     EffectInStatus info{};
 };
 AudioRenderer::AudioRenderer(Core::Timing::CoreTiming& core_timing, AudioRendererParameter params,
-                             Kernel::SharedPtr<Kernel::WritableEvent> buffer_event,
+                             std::shared_ptr<Kernel::WritableEvent> buffer_event,
                              std::size_t instance_number)
     : worker_params{params}, buffer_event{buffer_event}, voices(params.voice_count),
       effects(params.effect_count) {

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -218,8 +218,7 @@ static_assert(sizeof(UpdateDataHeader) == 0x40, "UpdateDataHeader has wrong size
 class AudioRenderer {
 public:
     AudioRenderer(Core::Timing::CoreTiming& core_timing, AudioRendererParameter params,
-                  Kernel::SharedPtr<Kernel::WritableEvent> buffer_event,
-                  std::size_t instance_number);
+                  std::shared_ptr<Kernel::WritableEvent> buffer_event, std::size_t instance_number);
     ~AudioRenderer();
 
     std::vector<u8> UpdateAudioRenderer(const std::vector<u8>& input_params);
@@ -235,7 +234,7 @@ private:
     class VoiceState;
 
     AudioRendererParameter worker_params;
-    Kernel::SharedPtr<Kernel::WritableEvent> buffer_event;
+    std::shared_ptr<Kernel::WritableEvent> buffer_event;
     std::vector<VoiceState> voices;
     std::vector<EffectState> effects;
     std::unique_ptr<AudioOut> audio_out;

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -7,6 +7,7 @@
 #include <cstddef>
 #include <memory>
 #include <string>
+#include <vector>
 
 #include "common/common_types.h"
 #include "core/file_sys/vfs_types.h"

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -203,10 +203,10 @@ public:
     void PushRaw(const T& value);
 
     template <typename... O>
-    void PushMoveObjects(Kernel::SharedPtr<O>... pointers);
+    void PushMoveObjects(std::shared_ptr<O>... pointers);
 
     template <typename... O>
-    void PushCopyObjects(Kernel::SharedPtr<O>... pointers);
+    void PushCopyObjects(std::shared_ptr<O>... pointers);
 
 private:
     u32 normal_params_size{};
@@ -298,7 +298,7 @@ void ResponseBuilder::Push(const First& first_value, const Other&... other_value
 }
 
 template <typename... O>
-inline void ResponseBuilder::PushCopyObjects(Kernel::SharedPtr<O>... pointers) {
+inline void ResponseBuilder::PushCopyObjects(std::shared_ptr<O>... pointers) {
     auto objects = {pointers...};
     for (auto& object : objects) {
         context->AddCopyObject(std::move(object));
@@ -306,7 +306,7 @@ inline void ResponseBuilder::PushCopyObjects(Kernel::SharedPtr<O>... pointers) {
 }
 
 template <typename... O>
-inline void ResponseBuilder::PushMoveObjects(Kernel::SharedPtr<O>... pointers) {
+inline void ResponseBuilder::PushMoveObjects(std::shared_ptr<O>... pointers) {
     auto objects = {pointers...};
     for (auto& object : objects) {
         context->AddMoveObject(std::move(object));
@@ -357,10 +357,10 @@ public:
     T PopRaw();
 
     template <typename T>
-    Kernel::SharedPtr<T> GetMoveObject(std::size_t index);
+    std::shared_ptr<T> GetMoveObject(std::size_t index);
 
     template <typename T>
-    Kernel::SharedPtr<T> GetCopyObject(std::size_t index);
+    std::shared_ptr<T> GetCopyObject(std::size_t index);
 
     template <class T>
     std::shared_ptr<T> PopIpcInterface() {
@@ -465,12 +465,12 @@ void RequestParser::Pop(First& first_value, Other&... other_values) {
 }
 
 template <typename T>
-Kernel::SharedPtr<T> RequestParser::GetMoveObject(std::size_t index) {
+std::shared_ptr<T> RequestParser::GetMoveObject(std::size_t index) {
     return context->GetMoveObject<T>(index);
 }
 
 template <typename T>
-Kernel::SharedPtr<T> RequestParser::GetCopyObject(std::size_t index) {
+std::shared_ptr<T> RequestParser::GetCopyObject(std::size_t index) {
     return context->GetCopyObject<T>(index);
 }
 

--- a/src/core/hle/kernel/address_arbiter.h
+++ b/src/core/hle/kernel/address_arbiter.h
@@ -72,7 +72,7 @@ private:
     ResultCode WaitForAddressImpl(VAddr address, s64 timeout);
 
     // Gets the threads waiting on an address.
-    std::vector<SharedPtr<Thread>> GetThreadsWaitingOnAddress(VAddr address) const;
+    std::vector<std::shared_ptr<Thread>> GetThreadsWaitingOnAddress(VAddr address) const;
 
     Core::System& system;
 };

--- a/src/core/hle/kernel/client_port.cpp
+++ b/src/core/hle/kernel/client_port.cpp
@@ -15,11 +15,11 @@ namespace Kernel {
 ClientPort::ClientPort(KernelCore& kernel) : Object{kernel} {}
 ClientPort::~ClientPort() = default;
 
-SharedPtr<ServerPort> ClientPort::GetServerPort() const {
+std::shared_ptr<ServerPort> ClientPort::GetServerPort() const {
     return server_port;
 }
 
-ResultVal<SharedPtr<ClientSession>> ClientPort::Connect() {
+ResultVal<std::shared_ptr<ClientSession>> ClientPort::Connect() {
     // Note: Threads do not wait for the server endpoint to call
     // AcceptSession before returning from this call.
 
@@ -29,7 +29,8 @@ ResultVal<SharedPtr<ClientSession>> ClientPort::Connect() {
     active_sessions++;
 
     // Create a new session pair, let the created sessions inherit the parent port's HLE handler.
-    auto [server, client] = ServerSession::CreateSessionPair(kernel, server_port->GetName(), this);
+    auto [server, client] =
+        ServerSession::CreateSessionPair(kernel, server_port->GetName(), SharedFrom(this));
 
     if (server_port->HasHLEHandler()) {
         server_port->GetHLEHandler()->ClientConnected(server);

--- a/src/core/hle/kernel/client_port.h
+++ b/src/core/hle/kernel/client_port.h
@@ -17,6 +17,9 @@ class ServerPort;
 
 class ClientPort final : public Object {
 public:
+    explicit ClientPort(KernelCore& kernel);
+    ~ClientPort() override;
+
     friend class ServerPort;
     std::string GetTypeName() const override {
         return "ClientPort";
@@ -30,7 +33,7 @@ public:
         return HANDLE_TYPE;
     }
 
-    SharedPtr<ServerPort> GetServerPort() const;
+    std::shared_ptr<ServerPort> GetServerPort() const;
 
     /**
      * Creates a new Session pair, adds the created ServerSession to the associated ServerPort's
@@ -38,7 +41,7 @@ public:
      * waiting on it to awake.
      * @returns ClientSession The client endpoint of the created Session pair, or error code.
      */
-    ResultVal<SharedPtr<ClientSession>> Connect();
+    ResultVal<std::shared_ptr<ClientSession>> Connect();
 
     /**
      * Signifies that a previously active connection has been closed,
@@ -47,10 +50,7 @@ public:
     void ConnectionClosed();
 
 private:
-    explicit ClientPort(KernelCore& kernel);
-    ~ClientPort() override;
-
-    SharedPtr<ServerPort> server_port; ///< ServerPort associated with this client port.
+    std::shared_ptr<ServerPort> server_port; ///< ServerPort associated with this client port.
     u32 max_sessions = 0;    ///< Maximum number of simultaneous sessions the port can have
     u32 active_sessions = 0; ///< Number of currently open sessions to this port
     std::string name;        ///< Name of client port (optional)

--- a/src/core/hle/kernel/client_session.cpp
+++ b/src/core/hle/kernel/client_session.cpp
@@ -19,22 +19,20 @@ ClientSession::~ClientSession() {
 
     // A local reference to the ServerSession is necessary to guarantee it
     // will be kept alive until after ClientDisconnected() returns.
-    SharedPtr<ServerSession> server = parent->server;
-    if (server) {
-        server->ClientDisconnected();
+    if (parent->server) {
+        parent->server->ClientDisconnected();
     }
 
     parent->client = nullptr;
 }
 
-ResultCode ClientSession::SendSyncRequest(SharedPtr<Thread> thread) {
+ResultCode ClientSession::SendSyncRequest(Thread* thread) {
     // Keep ServerSession alive until we're done working with it.
-    SharedPtr<ServerSession> server = parent->server;
-    if (server == nullptr)
+    if (parent->server == nullptr)
         return ERR_SESSION_CLOSED_BY_REMOTE;
 
     // Signal the server session that new data is available
-    return server->HandleSyncRequest(std::move(thread));
+    return parent->server->HandleSyncRequest(SharedFrom(thread));
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/client_session.cpp
+++ b/src/core/hle/kernel/client_session.cpp
@@ -16,9 +16,6 @@ ClientSession::ClientSession(KernelCore& kernel) : Object{kernel} {}
 ClientSession::~ClientSession() {
     // This destructor will be called automatically when the last ClientSession handle is closed by
     // the emulated application.
-
-    // A local reference to the ServerSession is necessary to guarantee it
-    // will be kept alive until after ClientDisconnected() returns.
     if (parent->server) {
         parent->server->ClientDisconnected();
     }

--- a/src/core/hle/kernel/client_session.h
+++ b/src/core/hle/kernel/client_session.h
@@ -19,6 +19,9 @@ class Thread;
 
 class ClientSession final : public Object {
 public:
+    explicit ClientSession(KernelCore& kernel);
+    ~ClientSession() override;
+
     friend class ServerSession;
 
     std::string GetTypeName() const override {
@@ -34,12 +37,9 @@ public:
         return HANDLE_TYPE;
     }
 
-    ResultCode SendSyncRequest(SharedPtr<Thread> thread);
+    ResultCode SendSyncRequest(Thread* thread);
 
 private:
-    explicit ClientSession(KernelCore& kernel);
-    ~ClientSession() override;
-
     /// The parent session, which links to the server endpoint.
     std::shared_ptr<Session> parent;
 

--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -44,7 +44,7 @@ ResultCode HandleTable::SetSize(s32 handle_table_size) {
     return RESULT_SUCCESS;
 }
 
-ResultVal<Handle> HandleTable::Create(SharedPtr<Object> obj) {
+ResultVal<Handle> HandleTable::Create(std::shared_ptr<Object> obj) {
     DEBUG_ASSERT(obj != nullptr);
 
     const u16 slot = next_free_slot;
@@ -70,7 +70,7 @@ ResultVal<Handle> HandleTable::Create(SharedPtr<Object> obj) {
 }
 
 ResultVal<Handle> HandleTable::Duplicate(Handle handle) {
-    SharedPtr<Object> object = GetGeneric(handle);
+    std::shared_ptr<Object> object = GetGeneric(handle);
     if (object == nullptr) {
         LOG_ERROR(Kernel, "Tried to duplicate invalid handle: {:08X}", handle);
         return ERR_INVALID_HANDLE;
@@ -99,11 +99,11 @@ bool HandleTable::IsValid(Handle handle) const {
     return slot < table_size && objects[slot] != nullptr && generations[slot] == generation;
 }
 
-SharedPtr<Object> HandleTable::GetGeneric(Handle handle) const {
+std::shared_ptr<Object> HandleTable::GetGeneric(Handle handle) const {
     if (handle == CurrentThread) {
-        return GetCurrentThread();
+        return SharedFrom(GetCurrentThread());
     } else if (handle == CurrentProcess) {
-        return Core::System::GetInstance().CurrentProcess();
+        return SharedFrom(Core::System::GetInstance().CurrentProcess());
     }
 
     if (!IsValid(handle)) {

--- a/src/core/hle/kernel/handle_table.h
+++ b/src/core/hle/kernel/handle_table.h
@@ -68,7 +68,7 @@ public:
      * @return The created Handle or one of the following errors:
      *           - `ERR_HANDLE_TABLE_FULL`: the maximum number of handles has been exceeded.
      */
-    ResultVal<Handle> Create(SharedPtr<Object> obj);
+    ResultVal<Handle> Create(std::shared_ptr<Object> obj);
 
     /**
      * Returns a new handle that points to the same object as the passed in handle.
@@ -92,7 +92,7 @@ public:
      * Looks up a handle.
      * @return Pointer to the looked-up object, or `nullptr` if the handle is not valid.
      */
-    SharedPtr<Object> GetGeneric(Handle handle) const;
+    std::shared_ptr<Object> GetGeneric(Handle handle) const;
 
     /**
      * Looks up a handle while verifying its type.
@@ -100,7 +100,7 @@ public:
      *         type differs from the requested one.
      */
     template <class T>
-    SharedPtr<T> Get(Handle handle) const {
+    std::shared_ptr<T> Get(Handle handle) const {
         return DynamicObjectCast<T>(GetGeneric(handle));
     }
 
@@ -109,7 +109,7 @@ public:
 
 private:
     /// Stores the Object referenced by the handle or null if the slot is empty.
-    std::array<SharedPtr<Object>, MAX_COUNT> objects;
+    std::array<std::shared_ptr<Object>, MAX_COUNT> objects;
 
     /**
      * The value of `next_generation` when the handle was created, used to check for validity. For

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -32,23 +32,25 @@ SessionRequestHandler::SessionRequestHandler() = default;
 
 SessionRequestHandler::~SessionRequestHandler() = default;
 
-void SessionRequestHandler::ClientConnected(SharedPtr<ServerSession> server_session) {
+void SessionRequestHandler::ClientConnected(std::shared_ptr<ServerSession> server_session) {
     server_session->SetHleHandler(shared_from_this());
     connected_sessions.push_back(std::move(server_session));
 }
 
-void SessionRequestHandler::ClientDisconnected(const SharedPtr<ServerSession>& server_session) {
+void SessionRequestHandler::ClientDisconnected(
+    const std::shared_ptr<ServerSession>& server_session) {
     server_session->SetHleHandler(nullptr);
     boost::range::remove_erase(connected_sessions, server_session);
 }
 
-SharedPtr<WritableEvent> HLERequestContext::SleepClientThread(
+std::shared_ptr<WritableEvent> HLERequestContext::SleepClientThread(
     const std::string& reason, u64 timeout, WakeupCallback&& callback,
-    SharedPtr<WritableEvent> writable_event) {
+    std::shared_ptr<WritableEvent> writable_event) {
     // Put the client thread to sleep until the wait event is signaled or the timeout expires.
-    thread->SetWakeupCallback([context = *this, callback](
-                                  ThreadWakeupReason reason, SharedPtr<Thread> thread,
-                                  SharedPtr<WaitObject> object, std::size_t index) mutable -> bool {
+    thread->SetWakeupCallback([context = *this, callback](ThreadWakeupReason reason,
+                                                          std::shared_ptr<Thread> thread,
+                                                          std::shared_ptr<WaitObject> object,
+                                                          std::size_t index) mutable -> bool {
         ASSERT(thread->GetStatus() == ThreadStatus::WaitHLEEvent);
         callback(thread, context, reason);
         context.WriteToOutgoingCommandBuffer(*thread);
@@ -75,8 +77,8 @@ SharedPtr<WritableEvent> HLERequestContext::SleepClientThread(
     return writable_event;
 }
 
-HLERequestContext::HLERequestContext(SharedPtr<Kernel::ServerSession> server_session,
-                                     SharedPtr<Thread> thread)
+HLERequestContext::HLERequestContext(std::shared_ptr<Kernel::ServerSession> server_session,
+                                     std::shared_ptr<Thread> thread)
     : server_session(std::move(server_session)), thread(std::move(thread)) {
     cmd_buf[0] = 0;
 }

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
@@ -60,20 +61,20 @@ public:
      * associated ServerSession alive for the duration of the connection.
      * @param server_session Owning pointer to the ServerSession associated with the connection.
      */
-    void ClientConnected(SharedPtr<ServerSession> server_session);
+    void ClientConnected(std::shared_ptr<ServerSession> server_session);
 
     /**
      * Signals that a client has just disconnected from this HLE handler and releases the
      * associated ServerSession.
      * @param server_session ServerSession associated with the connection.
      */
-    void ClientDisconnected(const SharedPtr<ServerSession>& server_session);
+    void ClientDisconnected(const std::shared_ptr<ServerSession>& server_session);
 
 protected:
     /// List of sessions that are connected to this handler.
     /// A ServerSession whose server endpoint is an HLE implementation is kept alive by this list
     /// for the duration of the connection.
-    std::vector<SharedPtr<ServerSession>> connected_sessions;
+    std::vector<std::shared_ptr<ServerSession>> connected_sessions;
 };
 
 /**
@@ -97,7 +98,8 @@ protected:
  */
 class HLERequestContext {
 public:
-    explicit HLERequestContext(SharedPtr<ServerSession> session, SharedPtr<Thread> thread);
+    explicit HLERequestContext(std::shared_ptr<ServerSession> session,
+                               std::shared_ptr<Thread> thread);
     ~HLERequestContext();
 
     /// Returns a pointer to the IPC command buffer for this request.
@@ -109,12 +111,12 @@ public:
      * Returns the session through which this request was made. This can be used as a map key to
      * access per-client data on services.
      */
-    const SharedPtr<Kernel::ServerSession>& Session() const {
+    const std::shared_ptr<Kernel::ServerSession>& Session() const {
         return server_session;
     }
 
-    using WakeupCallback = std::function<void(SharedPtr<Thread> thread, HLERequestContext& context,
-                                              ThreadWakeupReason reason)>;
+    using WakeupCallback = std::function<void(
+        std::shared_ptr<Thread> thread, HLERequestContext& context, ThreadWakeupReason reason)>;
 
     /**
      * Puts the specified guest thread to sleep until the returned event is signaled or until the
@@ -129,9 +131,9 @@ public:
      * created.
      * @returns Event that when signaled will resume the thread and call the callback function.
      */
-    SharedPtr<WritableEvent> SleepClientThread(const std::string& reason, u64 timeout,
-                                               WakeupCallback&& callback,
-                                               SharedPtr<WritableEvent> writable_event = nullptr);
+    std::shared_ptr<WritableEvent> SleepClientThread(
+        const std::string& reason, u64 timeout, WakeupCallback&& callback,
+        std::shared_ptr<WritableEvent> writable_event = nullptr);
 
     /// Populates this context with data from the requesting process/thread.
     ResultCode PopulateFromIncomingCommandBuffer(const HandleTable& handle_table,
@@ -209,20 +211,20 @@ public:
     std::size_t GetWriteBufferSize(int buffer_index = 0) const;
 
     template <typename T>
-    SharedPtr<T> GetCopyObject(std::size_t index) {
+    std::shared_ptr<T> GetCopyObject(std::size_t index) {
         return DynamicObjectCast<T>(copy_objects.at(index));
     }
 
     template <typename T>
-    SharedPtr<T> GetMoveObject(std::size_t index) {
+    std::shared_ptr<T> GetMoveObject(std::size_t index) {
         return DynamicObjectCast<T>(move_objects.at(index));
     }
 
-    void AddMoveObject(SharedPtr<Object> object) {
+    void AddMoveObject(std::shared_ptr<Object> object) {
         move_objects.emplace_back(std::move(object));
     }
 
-    void AddCopyObject(SharedPtr<Object> object) {
+    void AddCopyObject(std::shared_ptr<Object> object) {
         copy_objects.emplace_back(std::move(object));
     }
 
@@ -266,11 +268,11 @@ private:
     void ParseCommandBuffer(const HandleTable& handle_table, u32_le* src_cmdbuf, bool incoming);
 
     std::array<u32, IPC::COMMAND_BUFFER_LENGTH> cmd_buf;
-    SharedPtr<Kernel::ServerSession> server_session;
-    SharedPtr<Thread> thread;
+    std::shared_ptr<Kernel::ServerSession> server_session;
+    std::shared_ptr<Thread> thread;
     // TODO(yuriks): Check common usage of this and optimize size accordingly
-    boost::container::small_vector<SharedPtr<Object>, 8> move_objects;
-    boost::container::small_vector<SharedPtr<Object>, 8> copy_objects;
+    boost::container::small_vector<std::shared_ptr<Object>, 8> move_objects;
+    boost::container::small_vector<std::shared_ptr<Object>, 8> copy_objects;
     boost::container::small_vector<std::shared_ptr<SessionRequestHandler>, 8> domain_objects;
 
     std::optional<IPC::CommandHeader> command_header;

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -6,6 +6,7 @@
 
 #include <string>
 #include <unordered_map>
+#include <vector>
 #include "core/hle/kernel/object.h"
 
 namespace Core {

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -30,7 +30,7 @@ class Thread;
 /// Represents a single instance of the kernel.
 class KernelCore {
 private:
-    using NamedPortTable = std::unordered_map<std::string, SharedPtr<ClientPort>>;
+    using NamedPortTable = std::unordered_map<std::string, std::shared_ptr<ClientPort>>;
 
 public:
     /// Constructs an instance of the kernel using the given System
@@ -56,13 +56,13 @@ public:
     void Shutdown();
 
     /// Retrieves a shared pointer to the system resource limit instance.
-    SharedPtr<ResourceLimit> GetSystemResourceLimit() const;
+    std::shared_ptr<ResourceLimit> GetSystemResourceLimit() const;
 
     /// Retrieves a shared pointer to a Thread instance within the thread wakeup handle table.
-    SharedPtr<Thread> RetrieveThreadFromWakeupCallbackHandleTable(Handle handle) const;
+    std::shared_ptr<Thread> RetrieveThreadFromWakeupCallbackHandleTable(Handle handle) const;
 
     /// Adds the given shared pointer to an internal list of active processes.
-    void AppendNewProcess(SharedPtr<Process> process);
+    void AppendNewProcess(std::shared_ptr<Process> process);
 
     /// Makes the given process the new current process.
     void MakeCurrentProcess(Process* process);
@@ -74,7 +74,7 @@ public:
     const Process* CurrentProcess() const;
 
     /// Retrieves the list of processes.
-    const std::vector<SharedPtr<Process>>& GetProcessList() const;
+    const std::vector<std::shared_ptr<Process>>& GetProcessList() const;
 
     /// Gets the sole instance of the global scheduler
     Kernel::GlobalScheduler& GlobalScheduler();
@@ -83,7 +83,7 @@ public:
     const Kernel::GlobalScheduler& GlobalScheduler() const;
 
     /// Adds a port to the named port table
-    void AddNamedPort(std::string name, SharedPtr<ClientPort> port);
+    void AddNamedPort(std::string name, std::shared_ptr<ClientPort> port);
 
     /// Finds a port within the named port table with the given name.
     NamedPortTable::iterator FindNamedPort(const std::string& name);

--- a/src/core/hle/kernel/object.h
+++ b/src/core/hle/kernel/object.h
@@ -5,9 +5,8 @@
 #pragma once
 
 #include <atomic>
+#include <memory>
 #include <string>
-
-#include <boost/smart_ptr/intrusive_ptr.hpp>
 
 #include "common/common_types.h"
 
@@ -32,7 +31,7 @@ enum class HandleType : u32 {
     ServerSession,
 };
 
-class Object : NonCopyable {
+class Object : NonCopyable, public std::enable_shared_from_this<Object> {
 public:
     explicit Object(KernelCore& kernel);
     virtual ~Object();
@@ -61,35 +60,24 @@ protected:
     KernelCore& kernel;
 
 private:
-    friend void intrusive_ptr_add_ref(Object*);
-    friend void intrusive_ptr_release(Object*);
-
-    std::atomic<u32> ref_count{0};
     std::atomic<u32> object_id{0};
 };
 
-// Special functions used by boost::instrusive_ptr to do automatic ref-counting
-inline void intrusive_ptr_add_ref(Object* object) {
-    object->ref_count.fetch_add(1, std::memory_order_relaxed);
-}
-
-inline void intrusive_ptr_release(Object* object) {
-    if (object->ref_count.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-        delete object;
-    }
-}
-
 template <typename T>
-using SharedPtr = boost::intrusive_ptr<T>;
+std::shared_ptr<T> SharedFrom(T* raw) {
+    if (raw == nullptr)
+        return nullptr;
+    return std::static_pointer_cast<T>(raw->shared_from_this());
+}
 
 /**
  * Attempts to downcast the given Object pointer to a pointer to T.
  * @return Derived pointer to the object, or `nullptr` if `object` isn't of type T.
  */
 template <typename T>
-inline SharedPtr<T> DynamicObjectCast(SharedPtr<Object> object) {
+inline std::shared_ptr<T> DynamicObjectCast(std::shared_ptr<Object> object) {
     if (object != nullptr && object->GetHandleType() == T::HANDLE_TYPE) {
-        return boost::static_pointer_cast<T>(object);
+        return std::static_pointer_cast<T>(object);
     }
     return nullptr;
 }

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -38,7 +38,7 @@ void SetupMainThread(Process& owner_process, KernelCore& kernel, u32 priority) {
     auto thread_res = Thread::Create(kernel, "main", entry_point, priority, 0,
                                      owner_process.GetIdealCore(), stack_top, owner_process);
 
-    SharedPtr<Thread> thread = std::move(thread_res).Unwrap();
+    std::shared_ptr<Thread> thread = std::move(thread_res).Unwrap();
 
     // Register 1 must be a handle to the main thread
     const Handle thread_handle = owner_process.GetHandleTable().Create(thread).Unwrap();
@@ -100,10 +100,10 @@ private:
     std::bitset<num_slot_entries> is_slot_used;
 };
 
-SharedPtr<Process> Process::Create(Core::System& system, std::string name, ProcessType type) {
+std::shared_ptr<Process> Process::Create(Core::System& system, std::string name, ProcessType type) {
     auto& kernel = system.Kernel();
 
-    SharedPtr<Process> process(new Process(system));
+    std::shared_ptr<Process> process = std::make_shared<Process>(system);
     process->name = std::move(name);
     process->resource_limit = kernel.GetSystemResourceLimit();
     process->status = ProcessStatus::Created;
@@ -121,7 +121,7 @@ SharedPtr<Process> Process::Create(Core::System& system, std::string name, Proce
     return process;
 }
 
-SharedPtr<ResourceLimit> Process::GetResourceLimit() const {
+std::shared_ptr<ResourceLimit> Process::GetResourceLimit() const {
     return resource_limit;
 }
 
@@ -142,12 +142,12 @@ u64 Process::GetTotalPhysicalMemoryUsedWithoutSystemResource() const {
     return GetTotalPhysicalMemoryUsed() - GetSystemResourceUsage();
 }
 
-void Process::InsertConditionVariableThread(SharedPtr<Thread> thread) {
+void Process::InsertConditionVariableThread(std::shared_ptr<Thread> thread) {
     VAddr cond_var_addr = thread->GetCondVarWaitAddress();
-    std::list<SharedPtr<Thread>>& thread_list = cond_var_threads[cond_var_addr];
+    std::list<std::shared_ptr<Thread>>& thread_list = cond_var_threads[cond_var_addr];
     auto it = thread_list.begin();
     while (it != thread_list.end()) {
-        const SharedPtr<Thread> current_thread = *it;
+        const std::shared_ptr<Thread> current_thread = *it;
         if (current_thread->GetPriority() > thread->GetPriority()) {
             thread_list.insert(it, thread);
             return;
@@ -157,12 +157,12 @@ void Process::InsertConditionVariableThread(SharedPtr<Thread> thread) {
     thread_list.push_back(thread);
 }
 
-void Process::RemoveConditionVariableThread(SharedPtr<Thread> thread) {
+void Process::RemoveConditionVariableThread(std::shared_ptr<Thread> thread) {
     VAddr cond_var_addr = thread->GetCondVarWaitAddress();
-    std::list<SharedPtr<Thread>>& thread_list = cond_var_threads[cond_var_addr];
+    std::list<std::shared_ptr<Thread>>& thread_list = cond_var_threads[cond_var_addr];
     auto it = thread_list.begin();
     while (it != thread_list.end()) {
-        const SharedPtr<Thread> current_thread = *it;
+        const std::shared_ptr<Thread> current_thread = *it;
         if (current_thread.get() == thread.get()) {
             thread_list.erase(it);
             return;
@@ -172,12 +172,13 @@ void Process::RemoveConditionVariableThread(SharedPtr<Thread> thread) {
     UNREACHABLE();
 }
 
-std::vector<SharedPtr<Thread>> Process::GetConditionVariableThreads(const VAddr cond_var_addr) {
-    std::vector<SharedPtr<Thread>> result{};
-    std::list<SharedPtr<Thread>>& thread_list = cond_var_threads[cond_var_addr];
+std::vector<std::shared_ptr<Thread>> Process::GetConditionVariableThreads(
+    const VAddr cond_var_addr) {
+    std::vector<std::shared_ptr<Thread>> result{};
+    std::list<std::shared_ptr<Thread>>& thread_list = cond_var_threads[cond_var_addr];
     auto it = thread_list.begin();
     while (it != thread_list.end()) {
-        SharedPtr<Thread> current_thread = *it;
+        std::shared_ptr<Thread> current_thread = *it;
         result.push_back(current_thread);
         ++it;
     }
@@ -239,12 +240,12 @@ void Process::Run(s32 main_thread_priority, u64 stack_size) {
 void Process::PrepareForTermination() {
     ChangeStatus(ProcessStatus::Exiting);
 
-    const auto stop_threads = [this](const std::vector<SharedPtr<Thread>>& thread_list) {
+    const auto stop_threads = [this](const std::vector<std::shared_ptr<Thread>>& thread_list) {
         for (auto& thread : thread_list) {
             if (thread->GetOwnerProcess() != this)
                 continue;
 
-            if (thread == system.CurrentScheduler().GetCurrentThread())
+            if (thread.get() == system.CurrentScheduler().GetCurrentThread())
                 continue;
 
             // TODO(Subv): When are the other running/ready threads terminated?

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -62,6 +62,9 @@ enum class ProcessStatus {
 
 class Process final : public WaitObject {
 public:
+    explicit Process(Core::System& system);
+    ~Process() override;
+
     enum : u64 {
         /// Lowest allowed process ID for a kernel initial process.
         InitialKIPIDMin = 1,
@@ -82,7 +85,8 @@ public:
 
     static constexpr std::size_t RANDOM_ENTROPY_SIZE = 4;
 
-    static SharedPtr<Process> Create(Core::System& system, std::string name, ProcessType type);
+    static std::shared_ptr<Process> Create(Core::System& system, std::string name,
+                                           ProcessType type);
 
     std::string GetTypeName() const override {
         return "Process";
@@ -157,7 +161,7 @@ public:
     }
 
     /// Gets the resource limit descriptor for this process
-    SharedPtr<ResourceLimit> GetResourceLimit() const;
+    std::shared_ptr<ResourceLimit> GetResourceLimit() const;
 
     /// Gets the ideal CPU core ID for this process
     u8 GetIdealCore() const {
@@ -234,13 +238,13 @@ public:
     }
 
     /// Insert a thread into the condition variable wait container
-    void InsertConditionVariableThread(SharedPtr<Thread> thread);
+    void InsertConditionVariableThread(std::shared_ptr<Thread> thread);
 
     /// Remove a thread from the condition variable wait container
-    void RemoveConditionVariableThread(SharedPtr<Thread> thread);
+    void RemoveConditionVariableThread(std::shared_ptr<Thread> thread);
 
     /// Obtain all condition variable threads waiting for some address
-    std::vector<SharedPtr<Thread>> GetConditionVariableThreads(VAddr cond_var_addr);
+    std::vector<std::shared_ptr<Thread>> GetConditionVariableThreads(VAddr cond_var_addr);
 
     /// Registers a thread as being created under this process,
     /// adding it to this process' thread list.
@@ -297,9 +301,6 @@ public:
     void FreeTLSRegion(VAddr tls_address);
 
 private:
-    explicit Process(Core::System& system);
-    ~Process() override;
-
     /// Checks if the specified thread should wait until this process is available.
     bool ShouldWait(const Thread* thread) const override;
 
@@ -338,7 +339,7 @@ private:
     u32 system_resource_size = 0;
 
     /// Resource limit descriptor for this process
-    SharedPtr<ResourceLimit> resource_limit;
+    std::shared_ptr<ResourceLimit> resource_limit;
 
     /// The ideal CPU core for this process, threads are scheduled on this core by default.
     u8 ideal_core = 0;
@@ -386,7 +387,7 @@ private:
     std::list<const Thread*> thread_list;
 
     /// List of threads waiting for a condition variable
-    std::unordered_map<VAddr, std::list<SharedPtr<Thread>>> cond_var_threads;
+    std::unordered_map<VAddr, std::list<std::shared_ptr<Thread>>> cond_var_threads;
 
     /// System context
     Core::System& system;

--- a/src/core/hle/kernel/resource_limit.cpp
+++ b/src/core/hle/kernel/resource_limit.cpp
@@ -16,8 +16,8 @@ constexpr std::size_t ResourceTypeToIndex(ResourceType type) {
 ResourceLimit::ResourceLimit(KernelCore& kernel) : Object{kernel} {}
 ResourceLimit::~ResourceLimit() = default;
 
-SharedPtr<ResourceLimit> ResourceLimit::Create(KernelCore& kernel) {
-    return new ResourceLimit(kernel);
+std::shared_ptr<ResourceLimit> ResourceLimit::Create(KernelCore& kernel) {
+    return std::make_shared<ResourceLimit>(kernel);
 }
 
 s64 ResourceLimit::GetCurrentResourceValue(ResourceType resource) const {

--- a/src/core/hle/kernel/resource_limit.h
+++ b/src/core/hle/kernel/resource_limit.h
@@ -31,8 +31,11 @@ constexpr bool IsValidResourceType(ResourceType type) {
 
 class ResourceLimit final : public Object {
 public:
+    explicit ResourceLimit(KernelCore& kernel);
+    ~ResourceLimit() override;
+
     /// Creates a resource limit object.
-    static SharedPtr<ResourceLimit> Create(KernelCore& kernel);
+    static std::shared_ptr<ResourceLimit> Create(KernelCore& kernel);
 
     std::string GetTypeName() const override {
         return "ResourceLimit";
@@ -76,9 +79,6 @@ public:
     ResultCode SetLimitValue(ResourceType resource, s64 value);
 
 private:
-    explicit ResourceLimit(KernelCore& kernel);
-    ~ResourceLimit() override;
-
     // TODO(Subv): Increment resource limit current values in their respective Kernel::T::Create
     // functions
     //

--- a/src/core/hle/kernel/scheduler.h
+++ b/src/core/hle/kernel/scheduler.h
@@ -28,13 +28,13 @@ public:
     ~GlobalScheduler();
 
     /// Adds a new thread to the scheduler
-    void AddThread(SharedPtr<Thread> thread);
+    void AddThread(std::shared_ptr<Thread> thread);
 
     /// Removes a thread from the scheduler
-    void RemoveThread(const Thread* thread);
+    void RemoveThread(std::shared_ptr<Thread> thread);
 
     /// Returns a list of all threads managed by the scheduler
-    const std::vector<SharedPtr<Thread>>& GetThreadList() const {
+    const std::vector<std::shared_ptr<Thread>>& GetThreadList() const {
         return thread_list;
     }
 
@@ -157,7 +157,7 @@ private:
     std::array<u32, NUM_CPU_CORES> preemption_priorities = {59, 59, 59, 62};
 
     /// Lists all thread ids that aren't deleted/etc.
-    std::vector<SharedPtr<Thread>> thread_list;
+    std::vector<std::shared_ptr<Thread>> thread_list;
     Core::System& system;
 };
 
@@ -213,8 +213,8 @@ private:
      */
     void UpdateLastContextSwitchTime(Thread* thread, Process* process);
 
-    SharedPtr<Thread> current_thread = nullptr;
-    SharedPtr<Thread> selected_thread = nullptr;
+    std::shared_ptr<Thread> current_thread = nullptr;
+    std::shared_ptr<Thread> selected_thread = nullptr;
 
     Core::System& system;
     Core::ARM_Interface& cpu_core;

--- a/src/core/hle/kernel/server_port.cpp
+++ b/src/core/hle/kernel/server_port.cpp
@@ -16,7 +16,7 @@ namespace Kernel {
 ServerPort::ServerPort(KernelCore& kernel) : WaitObject{kernel} {}
 ServerPort::~ServerPort() = default;
 
-ResultVal<SharedPtr<ServerSession>> ServerPort::Accept() {
+ResultVal<std::shared_ptr<ServerSession>> ServerPort::Accept() {
     if (pending_sessions.empty()) {
         return ERR_NOT_FOUND;
     }
@@ -26,7 +26,7 @@ ResultVal<SharedPtr<ServerSession>> ServerPort::Accept() {
     return MakeResult(std::move(session));
 }
 
-void ServerPort::AppendPendingSession(SharedPtr<ServerSession> pending_session) {
+void ServerPort::AppendPendingSession(std::shared_ptr<ServerSession> pending_session) {
     pending_sessions.push_back(std::move(pending_session));
 }
 
@@ -41,8 +41,8 @@ void ServerPort::Acquire(Thread* thread) {
 
 ServerPort::PortPair ServerPort::CreatePortPair(KernelCore& kernel, u32 max_sessions,
                                                 std::string name) {
-    SharedPtr<ServerPort> server_port(new ServerPort(kernel));
-    SharedPtr<ClientPort> client_port(new ClientPort(kernel));
+    std::shared_ptr<ServerPort> server_port = std::make_shared<ServerPort>(kernel);
+    std::shared_ptr<ClientPort> client_port = std::make_shared<ClientPort>(kernel);
 
     server_port->name = name + "_Server";
     client_port->name = name + "_Client";

--- a/src/core/hle/kernel/server_port.h
+++ b/src/core/hle/kernel/server_port.h
@@ -22,8 +22,11 @@ class SessionRequestHandler;
 
 class ServerPort final : public WaitObject {
 public:
+    explicit ServerPort(KernelCore& kernel);
+    ~ServerPort() override;
+
     using HLEHandler = std::shared_ptr<SessionRequestHandler>;
-    using PortPair = std::pair<SharedPtr<ServerPort>, SharedPtr<ClientPort>>;
+    using PortPair = std::pair<std::shared_ptr<ServerPort>, std::shared_ptr<ClientPort>>;
 
     /**
      * Creates a pair of ServerPort and an associated ClientPort.
@@ -52,7 +55,7 @@ public:
      * Accepts a pending incoming connection on this port. If there are no pending sessions, will
      * return ERR_NO_PENDING_SESSIONS.
      */
-    ResultVal<SharedPtr<ServerSession>> Accept();
+    ResultVal<std::shared_ptr<ServerSession>> Accept();
 
     /// Whether or not this server port has an HLE handler available.
     bool HasHLEHandler() const {
@@ -74,17 +77,14 @@ public:
 
     /// Appends a ServerSession to the collection of ServerSessions
     /// waiting to be accepted by this port.
-    void AppendPendingSession(SharedPtr<ServerSession> pending_session);
+    void AppendPendingSession(std::shared_ptr<ServerSession> pending_session);
 
     bool ShouldWait(const Thread* thread) const override;
     void Acquire(Thread* thread) override;
 
 private:
-    explicit ServerPort(KernelCore& kernel);
-    ~ServerPort() override;
-
     /// ServerSessions waiting to be accepted by the port
-    std::vector<SharedPtr<ServerSession>> pending_sessions;
+    std::vector<std::shared_ptr<ServerSession>> pending_sessions;
 
     /// This session's HLE request handler template (optional)
     /// ServerSessions created from this port inherit a reference to this handler.

--- a/src/core/hle/kernel/server_session.h
+++ b/src/core/hle/kernel/server_session.h
@@ -38,6 +38,9 @@ class Thread;
  */
 class ServerSession final : public WaitObject {
 public:
+    explicit ServerSession(KernelCore& kernel);
+    ~ServerSession() override;
+
     std::string GetTypeName() const override {
         return "ServerSession";
     }
@@ -59,7 +62,7 @@ public:
         return parent.get();
     }
 
-    using SessionPair = std::pair<SharedPtr<ServerSession>, SharedPtr<ClientSession>>;
+    using SessionPair = std::pair<std::shared_ptr<ServerSession>, std::shared_ptr<ClientSession>>;
 
     /**
      * Creates a pair of ServerSession and an associated ClientSession.
@@ -69,7 +72,7 @@ public:
      * @return The created session tuple
      */
     static SessionPair CreateSessionPair(KernelCore& kernel, const std::string& name = "Unknown",
-                                         SharedPtr<ClientPort> client_port = nullptr);
+                                         std::shared_ptr<ClientPort> client_port = nullptr);
 
     /**
      * Sets the HLE handler for the session. This handler will be called to service IPC requests
@@ -85,7 +88,7 @@ public:
      * @param thread Thread that initiated the request.
      * @returns ResultCode from the operation.
      */
-    ResultCode HandleSyncRequest(SharedPtr<Thread> thread);
+    ResultCode HandleSyncRequest(std::shared_ptr<Thread> thread);
 
     bool ShouldWait(const Thread* thread) const override;
 
@@ -118,9 +121,6 @@ public:
     }
 
 private:
-    explicit ServerSession(KernelCore& kernel);
-    ~ServerSession() override;
-
     /**
      * Creates a server session. The server session can have an optional HLE handler,
      * which will be invoked to handle the IPC requests that this session receives.
@@ -128,8 +128,8 @@ private:
      * @param name Optional name of the server session.
      * @return The created server session
      */
-    static ResultVal<SharedPtr<ServerSession>> Create(KernelCore& kernel,
-                                                      std::string name = "Unknown");
+    static ResultVal<std::shared_ptr<ServerSession>> Create(KernelCore& kernel,
+                                                            std::string name = "Unknown");
 
     /// Handles a SyncRequest to a domain, forwarding the request to the proper object or closing an
     /// object handle.
@@ -147,12 +147,12 @@ private:
     /// List of threads that are pending a response after a sync request. This list is processed in
     /// a LIFO manner, thus, the last request will be dispatched first.
     /// TODO(Subv): Verify if this is indeed processed in LIFO using a hardware test.
-    std::vector<SharedPtr<Thread>> pending_requesting_threads;
+    std::vector<std::shared_ptr<Thread>> pending_requesting_threads;
 
     /// Thread whose request is currently being handled. A request is considered "handled" when a
     /// response is sent via svcReplyAndReceive.
     /// TODO(Subv): Find a better name for this.
-    SharedPtr<Thread> currently_handling;
+    std::shared_ptr<Thread> currently_handling;
 
     /// When set to True, converts the session to a domain at the end of the command
     bool convert_to_domain{};

--- a/src/core/hle/kernel/session.h
+++ b/src/core/hle/kernel/session.h
@@ -20,8 +20,8 @@ class ServerSession;
  */
 class Session final {
 public:
-    ClientSession* client = nullptr; ///< The client endpoint of the session.
-    ServerSession* server = nullptr; ///< The server endpoint of the session.
-    SharedPtr<ClientPort> port;      ///< The port that this session is associated with (optional).
+    ClientSession* client = nullptr;  ///< The client endpoint of the session.
+    ServerSession* server = nullptr;  ///< The server endpoint of the session.
+    std::shared_ptr<ClientPort> port; ///< The port that this session is associated with (optional).
 };
 } // namespace Kernel

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -15,11 +15,12 @@ namespace Kernel {
 SharedMemory::SharedMemory(KernelCore& kernel) : Object{kernel} {}
 SharedMemory::~SharedMemory() = default;
 
-SharedPtr<SharedMemory> SharedMemory::Create(KernelCore& kernel, Process* owner_process, u64 size,
-                                             MemoryPermission permissions,
-                                             MemoryPermission other_permissions, VAddr address,
-                                             MemoryRegion region, std::string name) {
-    SharedPtr<SharedMemory> shared_memory(new SharedMemory(kernel));
+std::shared_ptr<SharedMemory> SharedMemory::Create(KernelCore& kernel, Process* owner_process,
+                                                   u64 size, MemoryPermission permissions,
+                                                   MemoryPermission other_permissions,
+                                                   VAddr address, MemoryRegion region,
+                                                   std::string name) {
+    std::shared_ptr<SharedMemory> shared_memory = std::make_shared<SharedMemory>(kernel);
 
     shared_memory->owner_process = owner_process;
     shared_memory->name = std::move(name);
@@ -58,10 +59,10 @@ SharedPtr<SharedMemory> SharedMemory::Create(KernelCore& kernel, Process* owner_
     return shared_memory;
 }
 
-SharedPtr<SharedMemory> SharedMemory::CreateForApplet(
+std::shared_ptr<SharedMemory> SharedMemory::CreateForApplet(
     KernelCore& kernel, std::shared_ptr<Kernel::PhysicalMemory> heap_block, std::size_t offset,
     u64 size, MemoryPermission permissions, MemoryPermission other_permissions, std::string name) {
-    SharedPtr<SharedMemory> shared_memory(new SharedMemory(kernel));
+    std::shared_ptr<SharedMemory> shared_memory = std::make_shared<SharedMemory>(kernel);
 
     shared_memory->owner_process = nullptr;
     shared_memory->name = std::move(name);

--- a/src/core/hle/kernel/shared_memory.h
+++ b/src/core/hle/kernel/shared_memory.h
@@ -33,6 +33,9 @@ enum class MemoryPermission : u32 {
 
 class SharedMemory final : public Object {
 public:
+    explicit SharedMemory(KernelCore& kernel);
+    ~SharedMemory() override;
+
     /**
      * Creates a shared memory object.
      * @param kernel The kernel instance to create a shared memory instance under.
@@ -46,11 +49,12 @@ public:
      * linear heap.
      * @param name Optional object name, used for debugging purposes.
      */
-    static SharedPtr<SharedMemory> Create(KernelCore& kernel, Process* owner_process, u64 size,
-                                          MemoryPermission permissions,
-                                          MemoryPermission other_permissions, VAddr address = 0,
-                                          MemoryRegion region = MemoryRegion::BASE,
-                                          std::string name = "Unknown");
+    static std::shared_ptr<SharedMemory> Create(KernelCore& kernel, Process* owner_process,
+                                                u64 size, MemoryPermission permissions,
+                                                MemoryPermission other_permissions,
+                                                VAddr address = 0,
+                                                MemoryRegion region = MemoryRegion::BASE,
+                                                std::string name = "Unknown");
 
     /**
      * Creates a shared memory object from a block of memory managed by an HLE applet.
@@ -63,7 +67,7 @@ public:
      * block.
      * @param name Optional object name, used for debugging purposes.
      */
-    static SharedPtr<SharedMemory> CreateForApplet(
+    static std::shared_ptr<SharedMemory> CreateForApplet(
         KernelCore& kernel, std::shared_ptr<Kernel::PhysicalMemory> heap_block, std::size_t offset,
         u64 size, MemoryPermission permissions, MemoryPermission other_permissions,
         std::string name = "Unknown Applet");
@@ -130,9 +134,6 @@ public:
     const u8* GetPointer(std::size_t offset = 0) const;
 
 private:
-    explicit SharedMemory(KernelCore& kernel);
-    ~SharedMemory() override;
-
     /// Backing memory for this shared memory block.
     std::shared_ptr<PhysicalMemory> backing_block;
     /// Offset into the backing block for this shared memory.

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -358,7 +358,7 @@ static ResultCode ConnectToNamedPort(Core::System& system, Handle* out_handle,
 
     auto client_port = it->second;
 
-    SharedPtr<ClientSession> client_session;
+    std::shared_ptr<ClientSession> client_session;
     CASCADE_RESULT(client_session, client_port->Connect());
 
     // Return the client session
@@ -370,7 +370,7 @@ static ResultCode ConnectToNamedPort(Core::System& system, Handle* out_handle,
 /// Makes a blocking IPC call to an OS service.
 static ResultCode SendSyncRequest(Core::System& system, Handle handle) {
     const auto& handle_table = system.Kernel().CurrentProcess()->GetHandleTable();
-    SharedPtr<ClientSession> session = handle_table.Get<ClientSession>(handle);
+    std::shared_ptr<ClientSession> session = handle_table.Get<ClientSession>(handle);
     if (!session) {
         LOG_ERROR(Kernel_SVC, "called with invalid handle=0x{:08X}", handle);
         return ERR_INVALID_HANDLE;
@@ -390,7 +390,7 @@ static ResultCode GetThreadId(Core::System& system, u64* thread_id, Handle threa
     LOG_TRACE(Kernel_SVC, "called thread=0x{:08X}", thread_handle);
 
     const auto& handle_table = system.Kernel().CurrentProcess()->GetHandleTable();
-    const SharedPtr<Thread> thread = handle_table.Get<Thread>(thread_handle);
+    const std::shared_ptr<Thread> thread = handle_table.Get<Thread>(thread_handle);
     if (!thread) {
         LOG_ERROR(Kernel_SVC, "Thread handle does not exist, handle=0x{:08X}", thread_handle);
         return ERR_INVALID_HANDLE;
@@ -405,13 +405,13 @@ static ResultCode GetProcessId(Core::System& system, u64* process_id, Handle han
     LOG_DEBUG(Kernel_SVC, "called handle=0x{:08X}", handle);
 
     const auto& handle_table = system.Kernel().CurrentProcess()->GetHandleTable();
-    const SharedPtr<Process> process = handle_table.Get<Process>(handle);
+    const std::shared_ptr<Process> process = handle_table.Get<Process>(handle);
     if (process) {
         *process_id = process->GetProcessID();
         return RESULT_SUCCESS;
     }
 
-    const SharedPtr<Thread> thread = handle_table.Get<Thread>(handle);
+    const std::shared_ptr<Thread> thread = handle_table.Get<Thread>(handle);
     if (thread) {
         const Process* const owner_process = thread->GetOwnerProcess();
         if (!owner_process) {
@@ -430,8 +430,8 @@ static ResultCode GetProcessId(Core::System& system, u64* process_id, Handle han
 }
 
 /// Default thread wakeup callback for WaitSynchronization
-static bool DefaultThreadWakeupCallback(ThreadWakeupReason reason, SharedPtr<Thread> thread,
-                                        SharedPtr<WaitObject> object, std::size_t index) {
+static bool DefaultThreadWakeupCallback(ThreadWakeupReason reason, std::shared_ptr<Thread> thread,
+                                        std::shared_ptr<WaitObject> object, std::size_t index) {
     ASSERT(thread->GetStatus() == ThreadStatus::WaitSynch);
 
     if (reason == ThreadWakeupReason::Timeout) {
@@ -511,7 +511,7 @@ static ResultCode WaitSynchronization(Core::System& system, Handle* index, VAddr
     }
 
     for (auto& object : objects) {
-        object->AddWaitingThread(thread);
+        object->AddWaitingThread(SharedFrom(thread));
     }
 
     thread->SetWaitObjects(std::move(objects));
@@ -531,7 +531,7 @@ static ResultCode CancelSynchronization(Core::System& system, Handle thread_hand
     LOG_TRACE(Kernel_SVC, "called thread=0x{:X}", thread_handle);
 
     const auto& handle_table = system.Kernel().CurrentProcess()->GetHandleTable();
-    SharedPtr<Thread> thread = handle_table.Get<Thread>(thread_handle);
+    std::shared_ptr<Thread> thread = handle_table.Get<Thread>(thread_handle);
     if (!thread) {
         LOG_ERROR(Kernel_SVC, "Thread handle does not exist, thread_handle=0x{:08X}",
                   thread_handle);
@@ -940,7 +940,7 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
         const auto& core_timing = system.CoreTiming();
         const auto& scheduler = system.CurrentScheduler();
         const auto* const current_thread = scheduler.GetCurrentThread();
-        const bool same_thread = current_thread == thread;
+        const bool same_thread = current_thread == thread.get();
 
         const u64 prev_ctx_ticks = scheduler.GetLastContextSwitchTicks();
         u64 out_ticks = 0;
@@ -1050,7 +1050,7 @@ static ResultCode SetThreadActivity(Core::System& system, Handle handle, u32 act
     }
 
     const auto* current_process = system.Kernel().CurrentProcess();
-    const SharedPtr<Thread> thread = current_process->GetHandleTable().Get<Thread>(handle);
+    const std::shared_ptr<Thread> thread = current_process->GetHandleTable().Get<Thread>(handle);
     if (!thread) {
         LOG_ERROR(Kernel_SVC, "Thread handle does not exist, handle=0x{:08X}", handle);
         return ERR_INVALID_HANDLE;
@@ -1066,7 +1066,7 @@ static ResultCode SetThreadActivity(Core::System& system, Handle handle, u32 act
         return ERR_INVALID_HANDLE;
     }
 
-    if (thread == system.CurrentScheduler().GetCurrentThread()) {
+    if (thread.get() == system.CurrentScheduler().GetCurrentThread()) {
         LOG_ERROR(Kernel_SVC, "The thread handle specified is the current running thread");
         return ERR_BUSY;
     }
@@ -1082,7 +1082,7 @@ static ResultCode GetThreadContext(Core::System& system, VAddr thread_context, H
     LOG_DEBUG(Kernel_SVC, "called, context=0x{:08X}, thread=0x{:X}", thread_context, handle);
 
     const auto* current_process = system.Kernel().CurrentProcess();
-    const SharedPtr<Thread> thread = current_process->GetHandleTable().Get<Thread>(handle);
+    const std::shared_ptr<Thread> thread = current_process->GetHandleTable().Get<Thread>(handle);
     if (!thread) {
         LOG_ERROR(Kernel_SVC, "Thread handle does not exist, handle=0x{:08X}", handle);
         return ERR_INVALID_HANDLE;
@@ -1098,7 +1098,7 @@ static ResultCode GetThreadContext(Core::System& system, VAddr thread_context, H
         return ERR_INVALID_HANDLE;
     }
 
-    if (thread == system.CurrentScheduler().GetCurrentThread()) {
+    if (thread.get() == system.CurrentScheduler().GetCurrentThread()) {
         LOG_ERROR(Kernel_SVC, "The thread handle specified is the current running thread");
         return ERR_BUSY;
     }
@@ -1123,7 +1123,7 @@ static ResultCode GetThreadPriority(Core::System& system, u32* priority, Handle 
     LOG_TRACE(Kernel_SVC, "called");
 
     const auto& handle_table = system.Kernel().CurrentProcess()->GetHandleTable();
-    const SharedPtr<Thread> thread = handle_table.Get<Thread>(handle);
+    const std::shared_ptr<Thread> thread = handle_table.Get<Thread>(handle);
     if (!thread) {
         LOG_ERROR(Kernel_SVC, "Thread handle does not exist, handle=0x{:08X}", handle);
         return ERR_INVALID_HANDLE;
@@ -1147,7 +1147,7 @@ static ResultCode SetThreadPriority(Core::System& system, Handle handle, u32 pri
 
     const auto* const current_process = system.Kernel().CurrentProcess();
 
-    SharedPtr<Thread> thread = current_process->GetHandleTable().Get<Thread>(handle);
+    std::shared_ptr<Thread> thread = current_process->GetHandleTable().Get<Thread>(handle);
     if (!thread) {
         LOG_ERROR(Kernel_SVC, "Thread handle does not exist, handle=0x{:08X}", handle);
         return ERR_INVALID_HANDLE;
@@ -1267,7 +1267,7 @@ static ResultCode QueryProcessMemory(Core::System& system, VAddr memory_info_add
                                      VAddr address) {
     LOG_TRACE(Kernel_SVC, "called process=0x{:08X} address={:X}", process_handle, address);
     const auto& handle_table = system.Kernel().CurrentProcess()->GetHandleTable();
-    SharedPtr<Process> process = handle_table.Get<Process>(process_handle);
+    std::shared_ptr<Process> process = handle_table.Get<Process>(process_handle);
     if (!process) {
         LOG_ERROR(Kernel_SVC, "Process handle does not exist, process_handle=0x{:08X}",
                   process_handle);
@@ -1495,7 +1495,7 @@ static ResultCode CreateThread(Core::System& system, Handle* out_handle, VAddr e
     }
 
     auto& kernel = system.Kernel();
-    CASCADE_RESULT(SharedPtr<Thread> thread,
+    CASCADE_RESULT(std::shared_ptr<Thread> thread,
                    Thread::Create(kernel, "", entry_point, priority, arg, processor_id, stack_top,
                                   *current_process));
 
@@ -1521,7 +1521,7 @@ static ResultCode StartThread(Core::System& system, Handle thread_handle) {
     LOG_DEBUG(Kernel_SVC, "called thread=0x{:08X}", thread_handle);
 
     const auto& handle_table = system.Kernel().CurrentProcess()->GetHandleTable();
-    const SharedPtr<Thread> thread = handle_table.Get<Thread>(thread_handle);
+    const std::shared_ptr<Thread> thread = handle_table.Get<Thread>(thread_handle);
     if (!thread) {
         LOG_ERROR(Kernel_SVC, "Thread handle does not exist, thread_handle=0x{:08X}",
                   thread_handle);
@@ -1545,7 +1545,7 @@ static void ExitThread(Core::System& system) {
 
     auto* const current_thread = system.CurrentScheduler().GetCurrentThread();
     current_thread->Stop();
-    system.GlobalScheduler().RemoveThread(current_thread);
+    system.GlobalScheduler().RemoveThread(SharedFrom(current_thread));
     system.PrepareReschedule();
 }
 
@@ -1617,7 +1617,7 @@ static ResultCode WaitProcessWideKeyAtomic(Core::System& system, VAddr mutex_add
 
     auto* const current_process = system.Kernel().CurrentProcess();
     const auto& handle_table = current_process->GetHandleTable();
-    SharedPtr<Thread> thread = handle_table.Get<Thread>(thread_handle);
+    std::shared_ptr<Thread> thread = handle_table.Get<Thread>(thread_handle);
     ASSERT(thread);
 
     const auto release_result = current_process->GetMutex().Release(mutex_addr);
@@ -1625,13 +1625,13 @@ static ResultCode WaitProcessWideKeyAtomic(Core::System& system, VAddr mutex_add
         return release_result;
     }
 
-    SharedPtr<Thread> current_thread = system.CurrentScheduler().GetCurrentThread();
+    Thread* current_thread = system.CurrentScheduler().GetCurrentThread();
     current_thread->SetCondVarWaitAddress(condition_variable_addr);
     current_thread->SetMutexWaitAddress(mutex_addr);
     current_thread->SetWaitHandle(thread_handle);
     current_thread->SetStatus(ThreadStatus::WaitCondVar);
     current_thread->InvalidateWakeupCallback();
-    current_process->InsertConditionVariableThread(current_thread);
+    current_process->InsertConditionVariableThread(SharedFrom(current_thread));
 
     current_thread->WakeAfterDelay(nano_seconds);
 
@@ -1651,7 +1651,7 @@ static ResultCode SignalProcessWideKey(Core::System& system, VAddr condition_var
 
     // Retrieve a list of all threads that are waiting for this condition variable.
     auto* const current_process = system.Kernel().CurrentProcess();
-    std::vector<SharedPtr<Thread>> waiting_threads =
+    std::vector<std::shared_ptr<Thread>> waiting_threads =
         current_process->GetConditionVariableThreads(condition_variable_addr);
 
     // Only process up to 'target' threads, unless 'target' is less equal 0, in which case process
@@ -1966,7 +1966,7 @@ static ResultCode GetThreadCoreMask(Core::System& system, Handle thread_handle, 
     LOG_TRACE(Kernel_SVC, "called, handle=0x{:08X}", thread_handle);
 
     const auto& handle_table = system.Kernel().CurrentProcess()->GetHandleTable();
-    const SharedPtr<Thread> thread = handle_table.Get<Thread>(thread_handle);
+    const std::shared_ptr<Thread> thread = handle_table.Get<Thread>(thread_handle);
     if (!thread) {
         LOG_ERROR(Kernel_SVC, "Thread handle does not exist, thread_handle=0x{:08X}",
                   thread_handle);
@@ -2025,7 +2025,7 @@ static ResultCode SetThreadCoreMask(Core::System& system, Handle thread_handle, 
     }
 
     const auto& handle_table = current_process->GetHandleTable();
-    const SharedPtr<Thread> thread = handle_table.Get<Thread>(thread_handle);
+    const std::shared_ptr<Thread> thread = handle_table.Get<Thread>(thread_handle);
     if (!thread) {
         LOG_ERROR(Kernel_SVC, "Thread handle does not exist, thread_handle=0x{:08X}",
                   thread_handle);

--- a/src/core/hle/kernel/transfer_memory.cpp
+++ b/src/core/hle/kernel/transfer_memory.cpp
@@ -14,9 +14,9 @@ namespace Kernel {
 TransferMemory::TransferMemory(KernelCore& kernel) : Object{kernel} {}
 TransferMemory::~TransferMemory() = default;
 
-SharedPtr<TransferMemory> TransferMemory::Create(KernelCore& kernel, VAddr base_address, u64 size,
-                                                 MemoryPermission permissions) {
-    SharedPtr<TransferMemory> transfer_memory{new TransferMemory(kernel)};
+std::shared_ptr<TransferMemory> TransferMemory::Create(KernelCore& kernel, VAddr base_address,
+                                                       u64 size, MemoryPermission permissions) {
+    std::shared_ptr<TransferMemory> transfer_memory{std::make_shared<TransferMemory>(kernel)};
 
     transfer_memory->base_address = base_address;
     transfer_memory->memory_size = size;

--- a/src/core/hle/kernel/transfer_memory.h
+++ b/src/core/hle/kernel/transfer_memory.h
@@ -27,10 +27,13 @@ enum class MemoryPermission : u32;
 ///
 class TransferMemory final : public Object {
 public:
+    explicit TransferMemory(KernelCore& kernel);
+    ~TransferMemory() override;
+
     static constexpr HandleType HANDLE_TYPE = HandleType::TransferMemory;
 
-    static SharedPtr<TransferMemory> Create(KernelCore& kernel, VAddr base_address, u64 size,
-                                            MemoryPermission permissions);
+    static std::shared_ptr<TransferMemory> Create(KernelCore& kernel, VAddr base_address, u64 size,
+                                                  MemoryPermission permissions);
 
     TransferMemory(const TransferMemory&) = delete;
     TransferMemory& operator=(const TransferMemory&) = delete;
@@ -79,9 +82,6 @@ public:
     ResultCode UnmapMemory(VAddr address, u64 size);
 
 private:
-    explicit TransferMemory(KernelCore& kernel);
-    ~TransferMemory() override;
-
     /// Memory block backing this instance.
     std::shared_ptr<PhysicalMemory> backing_block;
 

--- a/src/core/hle/kernel/wait_object.h
+++ b/src/core/hle/kernel/wait_object.h
@@ -33,13 +33,13 @@ public:
      * Add a thread to wait on this object
      * @param thread Pointer to thread to add
      */
-    void AddWaitingThread(SharedPtr<Thread> thread);
+    void AddWaitingThread(std::shared_ptr<Thread> thread);
 
     /**
      * Removes a thread from waiting on this object (e.g. if it was resumed already)
      * @param thread Pointer to thread to remove
      */
-    void RemoveWaitingThread(Thread* thread);
+    void RemoveWaitingThread(std::shared_ptr<Thread> thread);
 
     /**
      * Wake up all threads waiting on this object that can be awoken, in priority order,
@@ -51,24 +51,24 @@ public:
      * Wakes up a single thread waiting on this object.
      * @param thread Thread that is waiting on this object to wakeup.
      */
-    void WakeupWaitingThread(SharedPtr<Thread> thread);
+    void WakeupWaitingThread(std::shared_ptr<Thread> thread);
 
     /// Obtains the highest priority thread that is ready to run from this object's waiting list.
-    SharedPtr<Thread> GetHighestPriorityReadyThread() const;
+    std::shared_ptr<Thread> GetHighestPriorityReadyThread() const;
 
     /// Get a const reference to the waiting threads list for debug use
-    const std::vector<SharedPtr<Thread>>& GetWaitingThreads() const;
+    const std::vector<std::shared_ptr<Thread>>& GetWaitingThreads() const;
 
 private:
     /// Threads waiting for this object to become available
-    std::vector<SharedPtr<Thread>> waiting_threads;
+    std::vector<std::shared_ptr<Thread>> waiting_threads;
 };
 
 // Specialization of DynamicObjectCast for WaitObjects
 template <>
-inline SharedPtr<WaitObject> DynamicObjectCast<WaitObject>(SharedPtr<Object> object) {
+inline std::shared_ptr<WaitObject> DynamicObjectCast<WaitObject>(std::shared_ptr<Object> object) {
     if (object != nullptr && object->IsWaitable()) {
-        return boost::static_pointer_cast<WaitObject>(object);
+        return std::static_pointer_cast<WaitObject>(object);
     }
     return nullptr;
 }

--- a/src/core/hle/kernel/writable_event.cpp
+++ b/src/core/hle/kernel/writable_event.cpp
@@ -16,8 +16,8 @@ WritableEvent::WritableEvent(KernelCore& kernel) : Object{kernel} {}
 WritableEvent::~WritableEvent() = default;
 
 EventPair WritableEvent::CreateEventPair(KernelCore& kernel, std::string name) {
-    SharedPtr<WritableEvent> writable_event(new WritableEvent(kernel));
-    SharedPtr<ReadableEvent> readable_event(new ReadableEvent(kernel));
+    std::shared_ptr<WritableEvent> writable_event(new WritableEvent(kernel));
+    std::shared_ptr<ReadableEvent> readable_event(new ReadableEvent(kernel));
 
     writable_event->name = name + ":Writable";
     writable_event->readable = readable_event;
@@ -27,7 +27,7 @@ EventPair WritableEvent::CreateEventPair(KernelCore& kernel, std::string name) {
     return {std::move(readable_event), std::move(writable_event)};
 }
 
-SharedPtr<ReadableEvent> WritableEvent::GetReadableEvent() const {
+std::shared_ptr<ReadableEvent> WritableEvent::GetReadableEvent() const {
     return readable;
 }
 

--- a/src/core/hle/kernel/writable_event.h
+++ b/src/core/hle/kernel/writable_event.h
@@ -13,8 +13,8 @@ class ReadableEvent;
 class WritableEvent;
 
 struct EventPair {
-    SharedPtr<ReadableEvent> readable;
-    SharedPtr<WritableEvent> writable;
+    std::shared_ptr<ReadableEvent> readable;
+    std::shared_ptr<WritableEvent> writable;
 };
 
 class WritableEvent final : public Object {
@@ -40,7 +40,7 @@ public:
         return HANDLE_TYPE;
     }
 
-    SharedPtr<ReadableEvent> GetReadableEvent() const;
+    std::shared_ptr<ReadableEvent> GetReadableEvent() const;
 
     void Signal();
     void Clear();
@@ -49,7 +49,7 @@ public:
 private:
     explicit WritableEvent(KernelCore& kernel);
 
-    SharedPtr<ReadableEvent> readable;
+    std::shared_ptr<ReadableEvent> readable;
 
     std::string name; ///< Name of event (optional)
 };

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -531,12 +531,11 @@ AppletMessageQueue::AppletMessageQueue(Kernel::KernelCore& kernel) {
 
 AppletMessageQueue::~AppletMessageQueue() = default;
 
-const Kernel::SharedPtr<Kernel::ReadableEvent>& AppletMessageQueue::GetMesssageRecieveEvent()
-    const {
+const std::shared_ptr<Kernel::ReadableEvent>& AppletMessageQueue::GetMesssageRecieveEvent() const {
     return on_new_message.readable;
 }
 
-const Kernel::SharedPtr<Kernel::ReadableEvent>& AppletMessageQueue::GetOperationModeChangedEvent()
+const std::shared_ptr<Kernel::ReadableEvent>& AppletMessageQueue::GetOperationModeChangedEvent()
     const {
     return on_operation_mode_changed.readable;
 }

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -54,8 +54,8 @@ public:
     explicit AppletMessageQueue(Kernel::KernelCore& kernel);
     ~AppletMessageQueue();
 
-    const Kernel::SharedPtr<Kernel::ReadableEvent>& GetMesssageRecieveEvent() const;
-    const Kernel::SharedPtr<Kernel::ReadableEvent>& GetOperationModeChangedEvent() const;
+    const std::shared_ptr<Kernel::ReadableEvent>& GetMesssageRecieveEvent() const;
+    const std::shared_ptr<Kernel::ReadableEvent>& GetOperationModeChangedEvent() const;
     void PushMessage(AppletMessage msg);
     AppletMessage PopMessage();
     std::size_t GetMessageCount() const;

--- a/src/core/hle/service/am/applets/applets.cpp
+++ b/src/core/hle/service/am/applets/applets.cpp
@@ -108,15 +108,15 @@ void AppletDataBroker::SignalStateChanged() const {
     state_changed_event.writable->Signal();
 }
 
-Kernel::SharedPtr<Kernel::ReadableEvent> AppletDataBroker::GetNormalDataEvent() const {
+std::shared_ptr<Kernel::ReadableEvent> AppletDataBroker::GetNormalDataEvent() const {
     return pop_out_data_event.readable;
 }
 
-Kernel::SharedPtr<Kernel::ReadableEvent> AppletDataBroker::GetInteractiveDataEvent() const {
+std::shared_ptr<Kernel::ReadableEvent> AppletDataBroker::GetInteractiveDataEvent() const {
     return pop_interactive_out_data_event.readable;
 }
 
-Kernel::SharedPtr<Kernel::ReadableEvent> AppletDataBroker::GetStateChangedEvent() const {
+std::shared_ptr<Kernel::ReadableEvent> AppletDataBroker::GetStateChangedEvent() const {
     return state_changed_event.readable;
 }
 

--- a/src/core/hle/service/am/applets/applets.h
+++ b/src/core/hle/service/am/applets/applets.h
@@ -86,9 +86,9 @@ public:
 
     void SignalStateChanged() const;
 
-    Kernel::SharedPtr<Kernel::ReadableEvent> GetNormalDataEvent() const;
-    Kernel::SharedPtr<Kernel::ReadableEvent> GetInteractiveDataEvent() const;
-    Kernel::SharedPtr<Kernel::ReadableEvent> GetStateChangedEvent() const;
+    std::shared_ptr<Kernel::ReadableEvent> GetNormalDataEvent() const;
+    std::shared_ptr<Kernel::ReadableEvent> GetInteractiveDataEvent() const;
+    std::shared_ptr<Kernel::ReadableEvent> GetStateChangedEvent() const;
 
 private:
     // Queues are named from applet's perspective

--- a/src/core/hle/service/bcat/backend/backend.cpp
+++ b/src/core/hle/service/bcat/backend/backend.cpp
@@ -16,7 +16,7 @@ ProgressServiceBackend::ProgressServiceBackend(Kernel::KernelCore& kernel,
         kernel, std::string("ProgressServiceBackend:UpdateEvent:").append(event_name));
 }
 
-Kernel::SharedPtr<Kernel::ReadableEvent> ProgressServiceBackend::GetEvent() const {
+std::shared_ptr<Kernel::ReadableEvent> ProgressServiceBackend::GetEvent() const {
     return event.readable;
 }
 

--- a/src/core/hle/service/bcat/backend/backend.h
+++ b/src/core/hle/service/bcat/backend/backend.h
@@ -98,7 +98,7 @@ public:
 private:
     explicit ProgressServiceBackend(Kernel::KernelCore& kernel, std::string_view event_name);
 
-    Kernel::SharedPtr<Kernel::ReadableEvent> GetEvent() const;
+    std::shared_ptr<Kernel::ReadableEvent> GetEvent() const;
     DeliveryCacheProgressImpl& GetImpl();
 
     void SignalUpdate() const;

--- a/src/core/hle/service/bcat/module.cpp
+++ b/src/core/hle/service/bcat/module.cpp
@@ -87,7 +87,7 @@ struct DeliveryCacheDirectoryEntry {
 
 class IDeliveryCacheProgressService final : public ServiceFramework<IDeliveryCacheProgressService> {
 public:
-    IDeliveryCacheProgressService(Kernel::SharedPtr<Kernel::ReadableEvent> event,
+    IDeliveryCacheProgressService(std::shared_ptr<Kernel::ReadableEvent> event,
                                   const DeliveryCacheProgressImpl& impl)
         : ServiceFramework{"IDeliveryCacheProgressService"}, event(std::move(event)), impl(impl) {
         // clang-format off
@@ -118,7 +118,7 @@ private:
         rb.Push(RESULT_SUCCESS);
     }
 
-    Kernel::SharedPtr<Kernel::ReadableEvent> event;
+    std::shared_ptr<Kernel::ReadableEvent> event;
     const DeliveryCacheProgressImpl& impl;
 };
 

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -501,8 +501,7 @@ void Controller_NPad::VibrateController(const std::vector<u32>& controller_ids,
     last_processed_vibration = vibrations.back();
 }
 
-Kernel::SharedPtr<Kernel::ReadableEvent> Controller_NPad::GetStyleSetChangedEvent(
-    u32 npad_id) const {
+std::shared_ptr<Kernel::ReadableEvent> Controller_NPad::GetStyleSetChangedEvent(u32 npad_id) const {
     // TODO(ogniK): Figure out the best time to signal this event. This event seems that it should
     // be signalled at least once, and signaled after a new controller is connected?
     const auto& styleset_event = styleset_changed_events[NPadIdToIndex(npad_id)];

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -109,7 +109,7 @@ public:
     void VibrateController(const std::vector<u32>& controller_ids,
                            const std::vector<Vibration>& vibrations);
 
-    Kernel::SharedPtr<Kernel::ReadableEvent> GetStyleSetChangedEvent(u32 npad_id) const;
+    std::shared_ptr<Kernel::ReadableEvent> GetStyleSetChangedEvent(u32 npad_id) const;
     Vibration GetLastVibration() const;
 
     void AddNewController(NPadControllerType controller);

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -67,7 +67,7 @@ private:
     void GetSharedMemoryHandle(Kernel::HLERequestContext& ctx);
     void UpdateControllers(u64 userdata, s64 cycles_late);
 
-    Kernel::SharedPtr<Kernel::SharedMemory> shared_mem;
+    std::shared_ptr<Kernel::SharedMemory> shared_mem;
 
     Core::Timing::EventType* pad_update_event;
     Core::System& system;

--- a/src/core/hle/service/hid/irs.h
+++ b/src/core/hle/service/hid/irs.h
@@ -37,7 +37,7 @@ private:
     void RunIrLedProcessor(Kernel::HLERequestContext& ctx);
     void StopImageProcessorAsync(Kernel::HLERequestContext& ctx);
     void ActivateIrsensorWithFunctionLevel(Kernel::HLERequestContext& ctx);
-    Kernel::SharedPtr<Kernel::SharedMemory> shared_mem;
+    std::shared_ptr<Kernel::SharedMemory> shared_mem;
     const u32 device_handle{0xABCD};
     Core::System& system;
 };

--- a/src/core/hle/service/nfp/nfp.cpp
+++ b/src/core/hle/service/nfp/nfp.cpp
@@ -342,7 +342,7 @@ bool Module::Interface::LoadAmiibo(const std::vector<u8>& buffer) {
     return true;
 }
 
-const Kernel::SharedPtr<Kernel::ReadableEvent>& Module::Interface::GetNFCEvent() const {
+const std::shared_ptr<Kernel::ReadableEvent>& Module::Interface::GetNFCEvent() const {
     return nfc_tag_load.readable;
 }
 

--- a/src/core/hle/service/nfp/nfp.h
+++ b/src/core/hle/service/nfp/nfp.h
@@ -34,7 +34,7 @@ public:
 
         void CreateUserInterface(Kernel::HLERequestContext& ctx);
         bool LoadAmiibo(const std::vector<u8>& buffer);
-        const Kernel::SharedPtr<Kernel::ReadableEvent>& GetNFCEvent() const;
+        const std::shared_ptr<Kernel::ReadableEvent>& GetNFCEvent() const;
         const AmiiboFile& GetAmiiboBuffer() const;
 
     private:

--- a/src/core/hle/service/ns/pl_u.cpp
+++ b/src/core/hle/service/ns/pl_u.cpp
@@ -141,7 +141,7 @@ struct PL_U::Impl {
     }
 
     /// Handle to shared memory region designated for a shared font
-    Kernel::SharedPtr<Kernel::SharedMemory> shared_font_mem;
+    std::shared_ptr<Kernel::SharedMemory> shared_font_mem;
 
     /// Backing memory for the shared font data
     std::shared_ptr<Kernel::PhysicalMemory> shared_font;

--- a/src/core/hle/service/nvdrv/interface.cpp
+++ b/src/core/hle/service/nvdrv/interface.cpp
@@ -61,7 +61,7 @@ void NVDRV::IoctlBase(Kernel::HLERequestContext& ctx, IoctlVersion version) {
     if (ctrl.must_delay) {
         ctrl.fresh_call = false;
         ctx.SleepClientThread("NVServices::DelayedResponse", ctrl.timeout,
-                              [=](Kernel::SharedPtr<Kernel::Thread> thread,
+                              [=](std::shared_ptr<Kernel::Thread> thread,
                                   Kernel::HLERequestContext& ctx,
                                   Kernel::ThreadWakeupReason reason) {
                                   IoctlCtrl ctrl2{ctrl};

--- a/src/core/hle/service/nvdrv/nvdrv.cpp
+++ b/src/core/hle/service/nvdrv/nvdrv.cpp
@@ -100,11 +100,11 @@ void Module::SignalSyncpt(const u32 syncpoint_id, const u32 value) {
     }
 }
 
-Kernel::SharedPtr<Kernel::ReadableEvent> Module::GetEvent(const u32 event_id) const {
+std::shared_ptr<Kernel::ReadableEvent> Module::GetEvent(const u32 event_id) const {
     return events_interface.events[event_id].readable;
 }
 
-Kernel::SharedPtr<Kernel::WritableEvent> Module::GetEventWriteable(const u32 event_id) const {
+std::shared_ptr<Kernel::WritableEvent> Module::GetEventWriteable(const u32 event_id) const {
     return events_interface.events[event_id].writable;
 }
 

--- a/src/core/hle/service/nvdrv/nvdrv.h
+++ b/src/core/hle/service/nvdrv/nvdrv.h
@@ -114,9 +114,9 @@ public:
 
     void SignalSyncpt(const u32 syncpoint_id, const u32 value);
 
-    Kernel::SharedPtr<Kernel::ReadableEvent> GetEvent(u32 event_id) const;
+    std::shared_ptr<Kernel::ReadableEvent> GetEvent(u32 event_id) const;
 
-    Kernel::SharedPtr<Kernel::WritableEvent> GetEventWriteable(u32 event_id) const;
+    std::shared_ptr<Kernel::WritableEvent> GetEventWriteable(u32 event_id) const;
 
 private:
     /// Id to use for the next open file descriptor.

--- a/src/core/hle/service/nvflinger/buffer_queue.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue.cpp
@@ -117,11 +117,11 @@ u32 BufferQueue::Query(QueryType type) {
     return 0;
 }
 
-Kernel::SharedPtr<Kernel::WritableEvent> BufferQueue::GetWritableBufferWaitEvent() const {
+std::shared_ptr<Kernel::WritableEvent> BufferQueue::GetWritableBufferWaitEvent() const {
     return buffer_wait_event.writable;
 }
 
-Kernel::SharedPtr<Kernel::ReadableEvent> BufferQueue::GetBufferWaitEvent() const {
+std::shared_ptr<Kernel::ReadableEvent> BufferQueue::GetBufferWaitEvent() const {
     return buffer_wait_event.readable;
 }
 

--- a/src/core/hle/service/nvflinger/buffer_queue.h
+++ b/src/core/hle/service/nvflinger/buffer_queue.h
@@ -93,9 +93,9 @@ public:
         return id;
     }
 
-    Kernel::SharedPtr<Kernel::WritableEvent> GetWritableBufferWaitEvent() const;
+    std::shared_ptr<Kernel::WritableEvent> GetWritableBufferWaitEvent() const;
 
-    Kernel::SharedPtr<Kernel::ReadableEvent> GetBufferWaitEvent() const;
+    std::shared_ptr<Kernel::ReadableEvent> GetBufferWaitEvent() const;
 
 private:
     u32 id;

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -98,7 +98,7 @@ std::optional<u32> NVFlinger::FindBufferQueueId(u64 display_id, u64 layer_id) co
     return layer->GetBufferQueue().GetId();
 }
 
-Kernel::SharedPtr<Kernel::ReadableEvent> NVFlinger::FindVsyncEvent(u64 display_id) const {
+std::shared_ptr<Kernel::ReadableEvent> NVFlinger::FindVsyncEvent(u64 display_id) const {
     auto* const display = FindDisplay(display_id);
 
     if (display == nullptr) {

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -62,7 +62,7 @@ public:
     /// Gets the vsync event for the specified display.
     ///
     /// If an invalid display ID is provided, then nullptr is returned.
-    Kernel::SharedPtr<Kernel::ReadableEvent> FindVsyncEvent(u64 display_id) const;
+    std::shared_ptr<Kernel::ReadableEvent> FindVsyncEvent(u64 display_id) const;
 
     /// Obtains a buffer queue identified by the ID.
     BufferQueue& FindBufferQueue(u32 id);

--- a/src/core/hle/service/pm/pm.cpp
+++ b/src/core/hle/service/pm/pm.cpp
@@ -16,9 +16,9 @@ constexpr ResultCode ERROR_PROCESS_NOT_FOUND{ErrorModule::PM, 1};
 
 constexpr u64 NO_PROCESS_FOUND_PID{0};
 
-std::optional<Kernel::SharedPtr<Kernel::Process>> SearchProcessList(
-    const std::vector<Kernel::SharedPtr<Kernel::Process>>& process_list,
-    std::function<bool(const Kernel::SharedPtr<Kernel::Process>&)> predicate) {
+std::optional<std::shared_ptr<Kernel::Process>> SearchProcessList(
+    const std::vector<std::shared_ptr<Kernel::Process>>& process_list,
+    std::function<bool(const std::shared_ptr<Kernel::Process>&)> predicate) {
     const auto iter = std::find_if(process_list.begin(), process_list.end(), predicate);
 
     if (iter == process_list.end()) {
@@ -29,7 +29,7 @@ std::optional<Kernel::SharedPtr<Kernel::Process>> SearchProcessList(
 }
 
 void GetApplicationPidGeneric(Kernel::HLERequestContext& ctx,
-                              const std::vector<Kernel::SharedPtr<Kernel::Process>>& process_list) {
+                              const std::vector<std::shared_ptr<Kernel::Process>>& process_list) {
     const auto process = SearchProcessList(process_list, [](const auto& process) {
         return process->GetProcessID() == Kernel::Process::ProcessIDMin;
     });
@@ -124,7 +124,7 @@ private:
 
 class Info final : public ServiceFramework<Info> {
 public:
-    explicit Info(const std::vector<Kernel::SharedPtr<Kernel::Process>>& process_list)
+    explicit Info(const std::vector<std::shared_ptr<Kernel::Process>>& process_list)
         : ServiceFramework{"pm:info"}, process_list(process_list) {
         static const FunctionInfo functions[] = {
             {0, &Info::GetTitleId, "GetTitleId"},
@@ -154,7 +154,7 @@ private:
         rb.Push((*process)->GetTitleID());
     }
 
-    const std::vector<Kernel::SharedPtr<Kernel::Process>>& process_list;
+    const std::vector<std::shared_ptr<Kernel::Process>>& process_list;
 };
 
 class Shell final : public ServiceFramework<Shell> {

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -116,7 +116,7 @@ void ServiceFrameworkBase::InstallAsNamedPort() {
     port_installed = true;
 }
 
-Kernel::SharedPtr<Kernel::ClientPort> ServiceFrameworkBase::CreatePort() {
+std::shared_ptr<Kernel::ClientPort> ServiceFrameworkBase::CreatePort() {
     ASSERT(!port_installed);
 
     auto& kernel = Core::System::GetInstance().Kernel();

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -65,7 +65,7 @@ public:
     /// Creates a port pair and registers it on the kernel's global port registry.
     void InstallAsNamedPort();
     /// Creates and returns an unregistered port for the service.
-    Kernel::SharedPtr<Kernel::ClientPort> CreatePort();
+    std::shared_ptr<Kernel::ClientPort> CreatePort();
 
     void InvokeRequest(Kernel::HLERequestContext& ctx);
 

--- a/src/core/hle/service/sm/controller.cpp
+++ b/src/core/hle/service/sm/controller.cpp
@@ -30,7 +30,7 @@ void Controller::DuplicateSession(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1, IPC::ResponseBuilder::Flags::AlwaysMoveHandles};
     rb.Push(RESULT_SUCCESS);
-    Kernel::SharedPtr<Kernel::ClientSession> session{ctx.Session()->GetParent()->client};
+    std::shared_ptr<Kernel::ClientSession> session{ctx.Session()->GetParent()->client};
     rb.PushMoveObjects(session);
 
     LOG_DEBUG(Service, "session={}", session->GetObjectId());

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -45,7 +45,7 @@ void ServiceManager::InstallInterfaces(std::shared_ptr<ServiceManager> self) {
     self->controller_interface = std::make_unique<Controller>();
 }
 
-ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> ServiceManager::RegisterService(
+ResultVal<std::shared_ptr<Kernel::ServerPort>> ServiceManager::RegisterService(
     std::string name, unsigned int max_sessions) {
 
     CASCADE_CODE(ValidateServiceName(name));
@@ -72,7 +72,7 @@ ResultCode ServiceManager::UnregisterService(const std::string& name) {
     return RESULT_SUCCESS;
 }
 
-ResultVal<Kernel::SharedPtr<Kernel::ClientPort>> ServiceManager::GetServicePort(
+ResultVal<std::shared_ptr<Kernel::ClientPort>> ServiceManager::GetServicePort(
     const std::string& name) {
 
     CASCADE_CODE(ValidateServiceName(name));
@@ -84,7 +84,7 @@ ResultVal<Kernel::SharedPtr<Kernel::ClientPort>> ServiceManager::GetServicePort(
     return MakeResult(it->second);
 }
 
-ResultVal<Kernel::SharedPtr<Kernel::ClientSession>> ServiceManager::ConnectToService(
+ResultVal<std::shared_ptr<Kernel::ClientSession>> ServiceManager::ConnectToService(
     const std::string& name) {
 
     CASCADE_RESULT(auto client_port, GetServicePort(name));

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -48,11 +48,11 @@ public:
     ServiceManager();
     ~ServiceManager();
 
-    ResultVal<Kernel::SharedPtr<Kernel::ServerPort>> RegisterService(std::string name,
-                                                                     unsigned int max_sessions);
+    ResultVal<std::shared_ptr<Kernel::ServerPort>> RegisterService(std::string name,
+                                                                   unsigned int max_sessions);
     ResultCode UnregisterService(const std::string& name);
-    ResultVal<Kernel::SharedPtr<Kernel::ClientPort>> GetServicePort(const std::string& name);
-    ResultVal<Kernel::SharedPtr<Kernel::ClientSession>> ConnectToService(const std::string& name);
+    ResultVal<std::shared_ptr<Kernel::ClientPort>> GetServicePort(const std::string& name);
+    ResultVal<std::shared_ptr<Kernel::ClientSession>> ConnectToService(const std::string& name);
 
     template <typename T>
     std::shared_ptr<T> GetService(const std::string& service_name) const {
@@ -77,7 +77,7 @@ private:
     std::unique_ptr<Controller> controller_interface;
 
     /// Map of registered services, retrieved using GetServicePort or ConnectToService.
-    std::unordered_map<std::string, Kernel::SharedPtr<Kernel::ClientPort>> registered_services;
+    std::unordered_map<std::string, std::shared_ptr<Kernel::ClientPort>> registered_services;
 };
 
 } // namespace Service::SM

--- a/src/core/hle/service/time/time_sharedmemory.cpp
+++ b/src/core/hle/service/time/time_sharedmemory.cpp
@@ -21,7 +21,7 @@ SharedMemory::SharedMemory(Core::System& system) : system(system) {
 
 SharedMemory::~SharedMemory() = default;
 
-Kernel::SharedPtr<Kernel::SharedMemory> SharedMemory::GetSharedMemoryHolder() const {
+std::shared_ptr<Kernel::SharedMemory> SharedMemory::GetSharedMemoryHolder() const {
     return shared_memory_holder;
 }
 

--- a/src/core/hle/service/time/time_sharedmemory.h
+++ b/src/core/hle/service/time/time_sharedmemory.h
@@ -15,7 +15,7 @@ public:
     ~SharedMemory();
 
     // Return the shared memory handle
-    Kernel::SharedPtr<Kernel::SharedMemory> GetSharedMemoryHolder() const;
+    std::shared_ptr<Kernel::SharedMemory> GetSharedMemoryHolder() const;
 
     // Set memory barriers in shared memory and update them
     void SetStandardSteadyClockTimepoint(const SteadyClockTimePoint& timepoint);
@@ -66,7 +66,7 @@ public:
     static_assert(sizeof(Format) == 0xd8, "Format is an invalid size");
 
 private:
-    Kernel::SharedPtr<Kernel::SharedMemory> shared_memory_holder{};
+    std::shared_ptr<Kernel::SharedMemory> shared_memory_holder{};
     Core::System& system;
     Format shared_memory_format{};
 };

--- a/src/core/hle/service/vi/display/vi_display.cpp
+++ b/src/core/hle/service/vi/display/vi_display.cpp
@@ -31,7 +31,7 @@ const Layer& Display::GetLayer(std::size_t index) const {
     return layers.at(index);
 }
 
-Kernel::SharedPtr<Kernel::ReadableEvent> Display::GetVSyncEvent() const {
+std::shared_ptr<Kernel::ReadableEvent> Display::GetVSyncEvent() const {
     return vsync_event.readable;
 }
 

--- a/src/core/hle/service/vi/display/vi_display.h
+++ b/src/core/hle/service/vi/display/vi_display.h
@@ -57,7 +57,7 @@ public:
     const Layer& GetLayer(std::size_t index) const;
 
     /// Gets the readable vsync event.
-    Kernel::SharedPtr<Kernel::ReadableEvent> GetVSyncEvent() const;
+    std::shared_ptr<Kernel::ReadableEvent> GetVSyncEvent() const;
 
     /// Signals the internal vsync event.
     void SignalVSyncEvent();

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -542,7 +542,7 @@ private:
                 // Wait the current thread until a buffer becomes available
                 ctx.SleepClientThread(
                     "IHOSBinderDriver::DequeueBuffer", UINT64_MAX,
-                    [=](Kernel::SharedPtr<Kernel::Thread> thread, Kernel::HLERequestContext& ctx,
+                    [=](std::shared_ptr<Kernel::Thread> thread, Kernel::HLERequestContext& ctx,
                         Kernel::ThreadWakeupReason reason) {
                         // Repeat TransactParcel DequeueBuffer when a buffer is available
                         auto& buffer_queue = nv_flinger->FindBufferQueue(id);

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -57,7 +57,7 @@ std::size_t WaitTreeItem::Row() const {
 std::vector<std::unique_ptr<WaitTreeThread>> WaitTreeItem::MakeThreadItemList() {
     std::vector<std::unique_ptr<WaitTreeThread>> item_list;
     std::size_t row = 0;
-    auto add_threads = [&](const std::vector<Kernel::SharedPtr<Kernel::Thread>>& threads) {
+    auto add_threads = [&](const std::vector<std::shared_ptr<Kernel::Thread>>& threads) {
         for (std::size_t i = 0; i < threads.size(); ++i) {
             item_list.push_back(std::make_unique<WaitTreeThread>(*threads[i]));
             item_list.back()->row = row;
@@ -172,8 +172,8 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeWaitObject::GetChildren() con
     return list;
 }
 
-WaitTreeObjectList::WaitTreeObjectList(
-    const std::vector<Kernel::SharedPtr<Kernel::WaitObject>>& list, bool w_all)
+WaitTreeObjectList::WaitTreeObjectList(const std::vector<std::shared_ptr<Kernel::WaitObject>>& list,
+                                       bool w_all)
     : object_list(list), wait_all(w_all) {}
 
 WaitTreeObjectList::~WaitTreeObjectList() = default;
@@ -325,7 +325,7 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeThread::GetChildren() const {
 WaitTreeEvent::WaitTreeEvent(const Kernel::ReadableEvent& object) : WaitTreeWaitObject(object) {}
 WaitTreeEvent::~WaitTreeEvent() = default;
 
-WaitTreeThreadList::WaitTreeThreadList(const std::vector<Kernel::SharedPtr<Kernel::Thread>>& list)
+WaitTreeThreadList::WaitTreeThreadList(const std::vector<std::shared_ptr<Kernel::Thread>>& list)
     : thread_list(list) {}
 WaitTreeThreadList::~WaitTreeThreadList() = default;
 

--- a/src/yuzu/debugger/wait_tree.h
+++ b/src/yuzu/debugger/wait_tree.h
@@ -83,7 +83,7 @@ private:
     VAddr mutex_address;
     u32 mutex_value;
     Kernel::Handle owner_handle;
-    Kernel::SharedPtr<Kernel::Thread> owner;
+    std::shared_ptr<Kernel::Thread> owner;
 };
 
 class WaitTreeCallstack : public WaitTreeExpandableItem {
@@ -116,15 +116,14 @@ protected:
 class WaitTreeObjectList : public WaitTreeExpandableItem {
     Q_OBJECT
 public:
-    WaitTreeObjectList(const std::vector<Kernel::SharedPtr<Kernel::WaitObject>>& list,
-                       bool wait_all);
+    WaitTreeObjectList(const std::vector<std::shared_ptr<Kernel::WaitObject>>& list, bool wait_all);
     ~WaitTreeObjectList() override;
 
     QString GetText() const override;
     std::vector<std::unique_ptr<WaitTreeItem>> GetChildren() const override;
 
 private:
-    const std::vector<Kernel::SharedPtr<Kernel::WaitObject>>& object_list;
+    const std::vector<std::shared_ptr<Kernel::WaitObject>>& object_list;
     bool wait_all;
 };
 
@@ -149,14 +148,14 @@ public:
 class WaitTreeThreadList : public WaitTreeExpandableItem {
     Q_OBJECT
 public:
-    explicit WaitTreeThreadList(const std::vector<Kernel::SharedPtr<Kernel::Thread>>& list);
+    explicit WaitTreeThreadList(const std::vector<std::shared_ptr<Kernel::Thread>>& list);
     ~WaitTreeThreadList() override;
 
     QString GetText() const override;
     std::vector<std::unique_ptr<WaitTreeItem>> GetChildren() const override;
 
 private:
-    const std::vector<Kernel::SharedPtr<Kernel::Thread>>& thread_list;
+    const std::vector<std::shared_ptr<Kernel::Thread>>& thread_list;
 };
 
 class WaitTreeModel : public QAbstractItemModel {


### PR DESCRIPTION
We were using SharedPtr (boost::instrusive_ptr) from legacy Citra days -- without obvious advantage. We also had mixed usage of SharedPtr and std::shared_ptr -- which is messy and may even lead to ownership/ref counting bugs. Lastly, there are probably some good places where we want weak pointers, which std::shared_ptr supports.

See https://github.com/citra-emu/citra/pull/4710 for more details.

Should largely be a no-op as far as functionality... I suggest a quick merge so we can rebase other things.