### PR TITLE
gl_shader_decompiler: Fix casts from fp32 to fp16

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1469,7 +1469,8 @@ private:
     }
 
     Expression HCastFloat(Operation operation) {
-        return {fmt::format("vec2({})", VisitOperand(operation, 0).AsFloat()), Type::HalfFloat};
+        return {fmt::format("vec2({}, 0.0f)", VisitOperand(operation, 0).AsFloat()),
+                Type::HalfFloat};
     }
 
     Expression HUnpack(Operation operation) {


### PR DESCRIPTION
Casts from f32 to f16 zeroes the higher half of the target register.