### PR TITLE
filesys/romfs: Make ProcessFile and ProcessDirectory internally linked

### DIFF
--- a/src/core/file_sys/romfs.cpp
+++ b/src/core/file_sys/romfs.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <memory>
+
 #include "common/common_types.h"
 #include "common/swap.h"
 #include "core/file_sys/fsmitm_romfsbuild.h"

--- a/src/core/file_sys/romfs.cpp
+++ b/src/core/file_sys/romfs.cpp
@@ -12,7 +12,7 @@
 #include "core/file_sys/vfs_vector.h"
 
 namespace FileSys {
-
+namespace {
 constexpr u32 ROMFS_ENTRY_EMPTY = 0xFFFFFFFF;
 
 struct TableLocation {
@@ -51,7 +51,7 @@ struct FileEntry {
 static_assert(sizeof(FileEntry) == 0x20, "FileEntry has incorrect size.");
 
 template <typename Entry>
-static std::pair<Entry, std::string> GetEntry(const VirtualFile& file, std::size_t offset) {
+std::pair<Entry, std::string> GetEntry(const VirtualFile& file, std::size_t offset) {
     Entry entry{};
     if (file->ReadObject(&entry, offset) != sizeof(Entry))
         return {};
@@ -99,6 +99,7 @@ void ProcessDirectory(VirtualFile file, std::size_t dir_offset, std::size_t file
         this_dir_offset = entry.first.sibling;
     }
 }
+} // Anonymous namespace
 
 VirtualDir ExtractRomFS(VirtualFile file, RomFSExtractionType type) {
     RomFSHeader header{};

--- a/src/core/file_sys/romfs.h
+++ b/src/core/file_sys/romfs.h
@@ -5,10 +5,6 @@
 #pragma once
 
 #include <array>
-#include <map>
-#include "common/common_funcs.h"
-#include "common/common_types.h"
-#include "common/swap.h"
 #include "core/file_sys/vfs.h"
 
 namespace FileSys {


### PR DESCRIPTION
These functions aren't used outside of this file, so we can place them within an anonymous namespace. While we're at it, we can also remove some unused header inclusions.