### PR TITLE
video_core/const_buffer_locker: Remove #pragma once from cpp file

### DIFF
--- a/src/video_core/shader/const_buffer_locker.cpp
+++ b/src/video_core/shader/const_buffer_locker.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
+#include <tuple>
 
 #include "common/common_types.h"
 #include "video_core/engines/maxwell_3d.h"
@@ -101,8 +102,8 @@ bool ConstBufferLocker::IsConsistent() const {
 }
 
 bool ConstBufferLocker::HasEqualKeys(const ConstBufferLocker& rhs) const {
-    return keys == rhs.keys && bound_samplers == rhs.bound_samplers &&
-           bindless_samplers == rhs.bindless_samplers;
+    return std::tie(keys, bound_samplers, bindless_samplers) ==
+           std::tie(rhs.keys, rhs.bound_samplers, rhs.bindless_samplers);
 }
 
 } // namespace VideoCommon::Shader

--- a/src/video_core/shader/const_buffer_locker.cpp
+++ b/src/video_core/shader/const_buffer_locker.cpp
@@ -2,8 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#pragma once
-
 #include <algorithm>
 #include <memory>
 #include "common/assert.h"

--- a/src/video_core/shader/const_buffer_locker.cpp
+++ b/src/video_core/shader/const_buffer_locker.cpp
@@ -3,8 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
-#include <memory>
-#include "common/assert.h"
+
 #include "common/common_types.h"
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/engines/shader_type.h"

--- a/src/video_core/shader/const_buffer_locker.h
+++ b/src/video_core/shader/const_buffer_locker.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <unordered_map>
 #include "common/common_types.h"
 #include "common/hash.h"


### PR DESCRIPTION
Silences a compiler warning.

While we're in the same area we can do a little bit of tidying up.