### PR TITLE
video_core/gpu_thread: Tidy up SwapBuffers()

### DIFF
--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -71,8 +71,7 @@ void ThreadManager::SubmitList(Tegra::CommandList&& entries) {
 }
 
 void ThreadManager::SwapBuffers(const Tegra::FramebufferConfig* framebuffer) {
-    PushCommand(SwapBuffersCommand(framebuffer ? *framebuffer
-                                               : std::optional<const Tegra::FramebufferConfig>{}));
+    PushCommand(SwapBuffersCommand(framebuffer ? std::make_optional(*framebuffer) : std::nullopt));
 }
 
 void ThreadManager::FlushRegion(CacheAddr addr, u64 size) {


### PR DESCRIPTION
We can just use std::nullopt and std::make_optional to make this a little bit less noisy.