### PR TITLE
gl_framebuffer_cache: Optimize framebuffer cache management

### DIFF
--- a/src/video_core/renderer_opengl/gl_framebuffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_framebuffer_cache.h
@@ -18,20 +18,23 @@
 
 namespace OpenGL {
 
-struct alignas(sizeof(u64)) FramebufferCacheKey {
-    bool stencil_enable;
-    u16 colors_count;
+constexpr std::size_t BitsPerAttachment = 4;
 
-    std::array<GLenum, Tegra::Engines::Maxwell3D::Regs::NumRenderTargets> color_attachments{};
-    std::array<View, Tegra::Engines::Maxwell3D::Regs::NumRenderTargets> colors;
+struct FramebufferCacheKey {
     View zeta;
+    std::array<View, Tegra::Engines::Maxwell3D::Regs::NumRenderTargets> colors;
+    u32 color_attachments = 0;
 
-    std::size_t Hash() const;
+    std::size_t Hash() const noexcept;
 
-    bool operator==(const FramebufferCacheKey& rhs) const;
+    bool operator==(const FramebufferCacheKey& rhs) const noexcept;
 
-    bool operator!=(const FramebufferCacheKey& rhs) const {
+    bool operator!=(const FramebufferCacheKey& rhs) const noexcept {
         return !operator==(rhs);
+    }
+
+    void SetAttachment(std::size_t index, u32 attachment) {
+        color_attachments |= attachment << (BitsPerAttachment * index);
     }
 };
 

--- a/src/video_core/renderer_opengl/gl_framebuffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_framebuffer_cache.h
@@ -19,8 +19,8 @@
 namespace OpenGL {
 
 struct alignas(sizeof(u64)) FramebufferCacheKey {
-    bool stencil_enable = false;
-    u16 colors_count = 0;
+    bool stencil_enable;
+    u16 colors_count;
 
     std::array<GLenum, Tegra::Engines::Maxwell3D::Regs::NumRenderTargets> color_attachments{};
     std::array<View, Tegra::Engines::Maxwell3D::Regs::NumRenderTargets> colors;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -93,7 +93,6 @@ RasterizerOpenGL::RasterizerOpenGL(Core::System& system, Core::Frontend::EmuWind
     shader_program_manager = std::make_unique<GLShader::ProgramManager>();
     state.draw.shader_program = 0;
     state.Apply();
-    clear_framebuffer.Create();
 
     LOG_DEBUG(Render_OpenGL, "Sync fixed function OpenGL state here");
     CheckExtensions();
@@ -405,46 +404,32 @@ void RasterizerOpenGL::ConfigureFramebuffers() {
 
 void RasterizerOpenGL::ConfigureClearFramebuffer(OpenGLState& current_state, bool using_color_fb,
                                                  bool using_depth_fb, bool using_stencil_fb) {
+    using VideoCore::Surface::SurfaceType;
+
     auto& gpu = system.GPU().Maxwell3D();
     const auto& regs = gpu.regs;
 
     texture_cache.GuardRenderTargets(true);
-    View color_surface{};
+    View color_surface;
     if (using_color_fb) {
         color_surface = texture_cache.GetColorBufferSurface(regs.clear_buffers.RT, false);
     }
-    View depth_surface{};
+    View depth_surface;
     if (using_depth_fb || using_stencil_fb) {
         depth_surface = texture_cache.GetDepthBufferSurface(false);
     }
     texture_cache.GuardRenderTargets(false);
 
-    current_state.draw.draw_framebuffer = clear_framebuffer.handle;
+    FramebufferCacheKey key;
+    key.colors_count = color_surface ? 1 : 0;
+    key.colors[0] = color_surface;
+    key.color_attachments[0] = GL_COLOR_ATTACHMENT0;
+    key.zeta = depth_surface;
+    key.stencil_enable = depth_surface && depth_surface->GetSurfaceParams().type ==
+                                              VideoCore::Surface::SurfaceType::DepthStencil;
+
+    current_state.draw.draw_framebuffer = framebuffer_cache.GetFramebuffer(key);
     current_state.ApplyFramebufferState();
-
-    if (color_surface) {
-        color_surface->Attach(GL_COLOR_ATTACHMENT0, GL_DRAW_FRAMEBUFFER);
-    } else {
-        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, 0, 0);
-    }
-
-    if (depth_surface) {
-        const auto& params = depth_surface->GetSurfaceParams();
-        switch (params.type) {
-        case VideoCore::Surface::SurfaceType::Depth:
-            depth_surface->Attach(GL_DEPTH_ATTACHMENT, GL_DRAW_FRAMEBUFFER);
-            glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0, 0);
-            break;
-        case VideoCore::Surface::SurfaceType::DepthStencil:
-            depth_surface->Attach(GL_DEPTH_STENCIL_ATTACHMENT, GL_DRAW_FRAMEBUFFER);
-            break;
-        default:
-            UNIMPLEMENTED();
-        }
-    } else {
-        glFramebufferTexture2D(GL_DRAW_FRAMEBUFFER, GL_DEPTH_STENCIL_ATTACHMENT, GL_TEXTURE_2D, 0,
-                               0);
-    }
 }
 
 void RasterizerOpenGL::Clear() {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -223,8 +223,6 @@ private:
 
     enum class AccelDraw { Disabled, Arrays, Indexed };
     AccelDraw accelerate_draw = AccelDraw::Disabled;
-
-    OGLFramebuffer clear_framebuffer;
 };
 
 } // namespace OpenGL


### PR DESCRIPTION
First, reintroduce the framebuffer cache for clears.
After that, optimize framebuffer cache's key to use fewer bytes and to be more easily hashed. It is reduced to the color and zeta attachments and the color attachments map (`glDrawBuffers`) is reduced to a single u32.

After this is merged we can safely remove the render target count check in the texture cache found [here](https://github.com/yuzu-emu/yuzu/blob/e3ee017e91ef4d713f1af8cb60c5157e40d43f18/src/video_core/texture_cache/texture_cache.h#L170).

From my testing, Super Mario Maker 2 doesn't have regressions with these changes.