### PR TITLE
CpuCore: Clear exclusive state after doing a run in dynarmic.

### DIFF
--- a/src/core/core_cpu.cpp
+++ b/src/core/core_cpu.cpp
@@ -96,6 +96,8 @@ void Cpu::RunLoop(bool tight_loop) {
         } else {
             arm_interface->Step();
         }
+        // We are stopping a run, exclusive state must be cleared
+        arm_interface->ClearExclusiveState();
     }
     core_timing.Advance();
 

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -458,7 +458,6 @@ void Scheduler::SwitchContext() {
         cpu_core.LoadContext(new_thread->GetContext());
         cpu_core.SetTlsAddress(new_thread->GetTLSAddress());
         cpu_core.SetTPIDR_EL0(new_thread->GetTPIDR_EL0());
-        cpu_core.ClearExclusiveState();
     } else {
         current_thread = nullptr;
         // Note: We do not reset the current process and current page table when idling because


### PR DESCRIPTION
This commit corrects an error in which a Core could remain with an exclusive state after running, leaving space for possible race conditions between changing cores.

This finally fixes the Mutex Corruption problem worked around in: #2365