### PR TITLE
Added missing include

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -12,6 +12,8 @@
 #include <utility>
 #include <vector>
 
+#include <boost/range/iterator_range_core.hpp>
+
 #include "common/alignment.h"
 #include "common/common_types.h"
 #include "core/core.h"


### PR DESCRIPTION
Building on Ubuntu, previously I was getting errors about `boost::make_iterator_range` being undefined in `buffer_cache.h`. This PR fixes this issue.