### PR TITLE
gl_shader_decompiler: Add missing DeclareImages

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -399,6 +399,7 @@ public:
         DeclareConstantBuffers();
         DeclareGlobalMemory();
         DeclareSamplers();
+        DeclareImages();
         DeclarePhysicalAttributeReader();
 
         code.AddLine("void execute_{}() {{", suffix);


### PR DESCRIPTION
`gl_shader_decompiler` was missing a `DeclareImages`. Images were not being declared.