### PR TITLE
gl_rasterizer: Implement RASTERIZE_ENABLE

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -88,11 +88,11 @@ void Maxwell3D::InitializeRegisterDefaults() {
         color_mask.A.Assign(1);
     }
 
-    // Commercial games seem to assume this value is enabled and nouveau sets this value manually.
+    // NVN games expect these values to be enabled at boot
+    regs.rasterize_enable = 1;
     regs.rt_separate_frag_data = 1;
-
-    // Some games (like Super Mario Odyssey) assume that SRGB is enabled.
     regs.framebuffer_srgb = 1;
+
     mme_inline[MAXWELL3D_REG_INDEX(draw.vertex_end_gl)] = true;
     mme_inline[MAXWELL3D_REG_INDEX(draw.vertex_begin_gl)] = true;
     mme_inline[MAXWELL3D_REG_INDEX(vertex_buffer.count)] = true;

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -657,7 +657,11 @@ public:
                 std::array<f32, 4> tess_level_outer;
                 std::array<f32, 2> tess_level_inner;
 
-                INSERT_UNION_PADDING_WORDS(0x102);
+                INSERT_UNION_PADDING_WORDS(0x10);
+
+                u32 rasterize_enable;
+
+                INSERT_UNION_PADDING_WORDS(0xF1);
 
                 u32 tfb_enabled;
 
@@ -1420,6 +1424,7 @@ ASSERT_REG_POSITION(sync_info, 0xB2);
 ASSERT_REG_POSITION(tess_mode, 0xC8);
 ASSERT_REG_POSITION(tess_level_outer, 0xC9);
 ASSERT_REG_POSITION(tess_level_inner, 0xCD);
+ASSERT_REG_POSITION(rasterize_enable, 0xDF);
 ASSERT_REG_POSITION(tfb_enabled, 0x1D1);
 ASSERT_REG_POSITION(rt, 0x200);
 ASSERT_REG_POSITION(viewport_transform, 0x280);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -514,6 +514,7 @@ void RasterizerOpenGL::Clear() {
     ConfigureClearFramebuffer(clear_state, use_color, use_depth, use_stencil);
 
     SyncViewport(clear_state);
+    SyncRasterizeEnable(clear_state);
     if (regs.clear_flags.scissor) {
         SyncScissorTest(clear_state);
     }
@@ -541,6 +542,7 @@ void RasterizerOpenGL::Clear() {
 void RasterizerOpenGL::DrawPrelude() {
     auto& gpu = system.GPU().Maxwell3D();
 
+    SyncRasterizeEnable(state);
     SyncColorMask();
     SyncFragmentColorClampState();
     SyncMultiSampleState();
@@ -1131,6 +1133,11 @@ void RasterizerOpenGL::SyncStencilTestState() {
         state.stencil.back.action_depth_fail = GL_KEEP;
         state.stencil.back.action_depth_pass = GL_KEEP;
     }
+}
+
+void RasterizerOpenGL::SyncRasterizeEnable(OpenGLState& current_state) {
+    const auto& regs = system.GPU().Maxwell3D().regs;
+    current_state.rasterizer_discard = regs.rasterize_enable == 0;
 }
 
 void RasterizerOpenGL::SyncColorMask() {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -168,6 +168,9 @@ private:
     /// Syncs the point state to match the guest state
     void SyncPointState();
 
+    /// Syncs the rasterizer enable state to match the guest state
+    void SyncRasterizeEnable(OpenGLState& current_state);
+
     /// Syncs Color Mask
     void SyncColorMask();
 

--- a/src/video_core/renderer_opengl/gl_state.cpp
+++ b/src/video_core/renderer_opengl/gl_state.cpp
@@ -182,6 +182,10 @@ void OpenGLState::ApplyCulling() {
     }
 }
 
+void OpenGLState::ApplyRasterizerDiscard() {
+    Enable(GL_RASTERIZER_DISCARD, cur_state.rasterizer_discard, rasterizer_discard);
+}
+
 void OpenGLState::ApplyColorMask() {
     if (!dirty.color_mask) {
         return;
@@ -455,6 +459,7 @@ void OpenGLState::Apply() {
     ApplyPointSize();
     ApplyFragmentColorClamp();
     ApplyMultisample();
+    ApplyRasterizerDiscard();
     ApplyColorMask();
     ApplyDepthClamp();
     ApplyViewport();

--- a/src/video_core/renderer_opengl/gl_state.h
+++ b/src/video_core/renderer_opengl/gl_state.h
@@ -48,6 +48,8 @@ public:
         GLuint index = 0;
     } primitive_restart; // GL_PRIMITIVE_RESTART
 
+    bool rasterizer_discard = false; // GL_RASTERIZER_DISCARD
+
     struct ColorMask {
         GLboolean red_enabled = GL_TRUE;
         GLboolean green_enabled = GL_TRUE;
@@ -56,6 +58,7 @@ public:
     };
     std::array<ColorMask, Tegra::Engines::Maxwell3D::Regs::NumRenderTargets>
         color_mask; // GL_COLOR_WRITEMASK
+
     struct {
         bool test_enabled = false; // GL_STENCIL_TEST
         struct {
@@ -174,6 +177,7 @@ public:
     void ApplyMultisample();
     void ApplySRgb();
     void ApplyCulling();
+    void ApplyRasterizerDiscard();
     void ApplyColorMask();
     void ApplyDepth();
     void ApplyPrimitiveRestart();


### PR DESCRIPTION
`RASTERIZE_ENABLE` is the opposite of `GL_RASTERIZER_DISCARD`. Implement it naturally using this. NVN games expect rasterize to be enabled by default, reflect that in our initial GPU state.

This removes the horrible point in the middle of the screen in Xenoblade Chronicles 2. It looks like this point is used as if it were a compute shader invocation.
![xc2](https://user-images.githubusercontent.com/26564870/71128807-d7747500-21cc-11ea-8d33-03986e278d69.png)
