### PR TITLE
vk_shader_decompiler: Use Visit instead of reimplementing it

### DIFF
--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
@@ -2552,29 +2552,7 @@ public:
     }
 
     Id operator()(const ExprCondCode& expr) {
-        const Node cc = decomp.ir.GetConditionCode(expr.cc);
-        Id target;
-
-        if (const auto pred = std::get_if<PredicateNode>(&*cc)) {
-            const auto index = pred->GetIndex();
-            switch (index) {
-            case Tegra::Shader::Pred::NeverExecute:
-                target = decomp.v_false;
-                break;
-            case Tegra::Shader::Pred::UnusedIndex:
-                target = decomp.v_true;
-                break;
-            default:
-                target = decomp.predicates.at(index);
-                break;
-            }
-        } else if (const auto flag = std::get_if<InternalFlagNode>(&*cc)) {
-            target = decomp.internal_flags.at(static_cast<u32>(flag->GetFlag()));
-        } else {
-            UNREACHABLE();
-        }
-
-        return decomp.OpLoad(decomp.t_bool, target);
+        return decomp.AsBool(decomp.Visit(decomp.ir.GetConditionCode(expr.cc)));
     }
 
     Id operator()(const ExprVar& expr) {


### PR DESCRIPTION
`ExprCondCode` visit implements the generic `Visit`. Use this instead one instead.

As an intended side effect this fixes unwritten memory usages in cases when a negation of a condition code is used.

- Fixes one of the crashes in Vulkan in Fire Emblem: Three Houses (the other crash is a device loss).