### PR TITLE
NvServices: Correct Ioctl Remap.

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
@@ -104,10 +104,12 @@ u32 nvhost_as_gpu::Remap(const std::vector<u8>& input, std::vector<u8>& output) 
 
         ASSERT(object->status == nvmap::Object::Status::Allocated);
 
-        u64 size = static_cast<u64>(entry.pages) << 0x10;
+        const u64 size = static_cast<u64>(entry.pages) << 0x10;
         ASSERT(size <= object->size);
+        const u64 map_offset = static_cast<u64>(entry.map_offset) << 0x10;
 
-        GPUVAddr returned = gpu.MemoryManager().MapBufferEx(object->addr, offset, size);
+        const GPUVAddr returned =
+            gpu.MemoryManager().MapBufferEx(object->addr + map_offset, offset, size);
         ASSERT(returned == offset);
     }
     std::memcpy(output.data(), entries.data(), output.size());

--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.h
@@ -62,7 +62,7 @@ private:
         u16_le flags;
         u16_le kind;
         u32_le nvmap_handle;
-        INSERT_PADDING_WORDS(1);
+        u32_le map_offset;
         u32_le offset;
         u32_le pages;
     };


### PR DESCRIPTION
This commit corrects a padding value in Ioctl Remap that was actually an offset to the mapping address.

**Thanks to Gdkchan for finding the issue.**