### PR TITLE
gl_rasterizer: Allow rendering without fragment shader

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -271,6 +271,9 @@ void RasterizerOpenGL::SetupShaders(GLenum primitive_mode) {
             case Maxwell::ShaderProgram::Geometry:
                 shader_program_manager->UseTrivialGeometryShader();
                 break;
+            case Maxwell::ShaderProgram::Fragment:
+                shader_program_manager->UseTrivialFragmentShader();
+                break;
             default:
                 break;
             }

--- a/src/video_core/renderer_opengl/gl_shader_manager.h
+++ b/src/video_core/renderer_opengl/gl_shader_manager.h
@@ -50,6 +50,10 @@ public:
         current_state.geometry_shader = 0;
     }
 
+    void UseTrivialFragmentShader() {
+        current_state.fragment_shader = 0;
+    }
+
 private:
     struct PipelineState {
         bool operator==(const PipelineState& rhs) const {


### PR DESCRIPTION
Rendering without a fragment shader is usually used in depth-only passes.

Fixes shadows artifacts in some instances on PLGE:
![imagen](https://user-images.githubusercontent.com/26564870/71488737-ee384e80-2800-11ea-87ae-cfe56dd8da7c.png)

And removes some of the artifacts in LM3 (this previously something like a button drawn in the floor):
![imagen](https://user-images.githubusercontent.com/26564870/71488771-0f993a80-2801-11ea-87f9-cf0e58e0255f.png)
