### PR TITLE
GUI/configure: resize hotkeys action column to fit content

### DIFF
--- a/src/yuzu/configuration/configure_hotkeys.cpp
+++ b/src/yuzu/configuration/configure_hotkeys.cpp
@@ -48,6 +48,7 @@ void ConfigureHotkeys::Populate(const HotkeyRegistry& registry) {
     }
 
     ui->hotkey_list->expandAll();
+    ui->hotkey_list->resizeColumnToContents(0);
 }
 
 void ConfigureHotkeys::changeEvent(QEvent* event) {


### PR DESCRIPTION
Just a simple UX tweak. Resize hotkeys `Action` column to fit text after populate to avoid ellipsis trim.

<img width="825" alt="y1" src="https://user-images.githubusercontent.com/719641/72226421-4907cf00-3591-11ea-80c6-5e37e210a754.png">

Screenshot shows Configuration window with initial width.