### PR TITLE
GUI/gamelist: add "None" as an option for second row and remove dynamically duplicate row options

### DIFF
--- a/src/yuzu/configuration/configure_gamelist.cpp
+++ b/src/yuzu/configuration/configure_gamelist.cpp
@@ -25,6 +25,7 @@ constexpr std::array row_text_names{
     QT_TR_NOOP("Filetype"),
     QT_TR_NOOP("Title ID"),
     QT_TR_NOOP("Title Name"),
+    QT_TR_NOOP("None"),
 };
 } // Anonymous namespace
 
@@ -46,6 +47,12 @@ ConfigureGameList::ConfigureGameList(QWidget* parent)
             &ConfigureGameList::RequestGameListUpdate);
     connect(ui->row_2_text_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &ConfigureGameList::RequestGameListUpdate);
+
+    // Update text ComboBoxes after user interaction.
+    connect(ui->row_1_text_combobox, QOverload<int>::of(&QComboBox::activated),
+            [=]() { ConfigureGameList::UpdateSecondRowComboBox(); });
+    connect(ui->row_2_text_combobox, QOverload<int>::of(&QComboBox::activated),
+            [=]() { ConfigureGameList::UpdateFirstRowComboBox(); });
 }
 
 ConfigureGameList::~ConfigureGameList() = default;
@@ -68,10 +75,6 @@ void ConfigureGameList::SetConfiguration() {
     ui->show_add_ons->setChecked(UISettings::values.show_add_ons);
     ui->icon_size_combobox->setCurrentIndex(
         ui->icon_size_combobox->findData(UISettings::values.icon_size));
-    ui->row_1_text_combobox->setCurrentIndex(
-        ui->row_1_text_combobox->findData(UISettings::values.row_1_text_id));
-    ui->row_2_text_combobox->setCurrentIndex(
-        ui->row_2_text_combobox->findData(UISettings::values.row_2_text_id));
 }
 
 void ConfigureGameList::changeEvent(QEvent* event) {
@@ -104,10 +107,41 @@ void ConfigureGameList::InitializeIconSizeComboBox() {
 }
 
 void ConfigureGameList::InitializeRowComboBoxes() {
+    UpdateFirstRowComboBox(true);
+    UpdateSecondRowComboBox(true);
+}
+
+void ConfigureGameList::UpdateFirstRowComboBox(bool init) {
+    const int currentIndex = init ? UISettings::values.row_1_text_id :
+        ui->row_1_text_combobox->findData(ui->row_1_text_combobox->currentData());
+
+    ui->row_1_text_combobox->clear();
+
+    for (std::size_t i = 0; i < row_text_names.size(); i++) {
+        const QString row_text_name = QString::fromUtf8(row_text_names[i]);
+        ui->row_1_text_combobox->addItem(row_text_name, QVariant::fromValue(i));
+    }
+
+    ui->row_1_text_combobox->setCurrentIndex(ui->row_1_text_combobox->findData(currentIndex));
+
+    ui->row_1_text_combobox->removeItem(4); // None
+    ui->row_1_text_combobox->removeItem(
+        ui->row_1_text_combobox->findData(ui->row_2_text_combobox->currentData()));
+}
+
+void ConfigureGameList::UpdateSecondRowComboBox(bool init) {
+    const int currentIndex = init ? UISettings::values.row_2_text_id :
+        ui->row_2_text_combobox->findData(ui->row_2_text_combobox->currentData());
+
+    ui->row_2_text_combobox->clear();
+
     for (std::size_t i = 0; i < row_text_names.size(); ++i) {
         const QString row_text_name = QString::fromUtf8(row_text_names[i]);
-
-        ui->row_1_text_combobox->addItem(row_text_name, QVariant::fromValue(i));
         ui->row_2_text_combobox->addItem(row_text_name, QVariant::fromValue(i));
     }
+
+    ui->row_2_text_combobox->setCurrentIndex(ui->row_2_text_combobox->findData(currentIndex));
+
+    ui->row_2_text_combobox->removeItem(
+        ui->row_2_text_combobox->findData(ui->row_1_text_combobox->currentData()));
 }

--- a/src/yuzu/configuration/configure_gamelist.cpp
+++ b/src/yuzu/configuration/configure_gamelist.cpp
@@ -21,11 +21,8 @@ constexpr std::array default_icon_sizes{
 };
 
 constexpr std::array row_text_names{
-    QT_TR_NOOP("Filename"),
-    QT_TR_NOOP("Filetype"),
-    QT_TR_NOOP("Title ID"),
-    QT_TR_NOOP("Title Name"),
-    QT_TR_NOOP("None"),
+    QT_TR_NOOP("Filename"),   QT_TR_NOOP("Filetype"), QT_TR_NOOP("Title ID"),
+    QT_TR_NOOP("Title Name"), QT_TR_NOOP("None"),
 };
 } // Anonymous namespace
 
@@ -112,8 +109,9 @@ void ConfigureGameList::InitializeRowComboBoxes() {
 }
 
 void ConfigureGameList::UpdateFirstRowComboBox(bool init) {
-    const int currentIndex = init ? UISettings::values.row_1_text_id :
-        ui->row_1_text_combobox->findData(ui->row_1_text_combobox->currentData());
+    const int currentIndex =
+        init ? UISettings::values.row_1_text_id
+             : ui->row_1_text_combobox->findData(ui->row_1_text_combobox->currentData());
 
     ui->row_1_text_combobox->clear();
 
@@ -130,8 +128,9 @@ void ConfigureGameList::UpdateFirstRowComboBox(bool init) {
 }
 
 void ConfigureGameList::UpdateSecondRowComboBox(bool init) {
-    const int currentIndex = init ? UISettings::values.row_2_text_id :
-        ui->row_2_text_combobox->findData(ui->row_2_text_combobox->currentData());
+    const int currentIndex =
+        init ? UISettings::values.row_2_text_id
+             : ui->row_2_text_combobox->findData(ui->row_2_text_combobox->currentData());
 
     ui->row_2_text_combobox->clear();
 

--- a/src/yuzu/configuration/configure_gamelist.h
+++ b/src/yuzu/configuration/configure_gamelist.h
@@ -31,5 +31,8 @@ private:
     void InitializeIconSizeComboBox();
     void InitializeRowComboBoxes();
 
+    void UpdateFirstRowComboBox(bool init = false);
+    void UpdateSecondRowComboBox(bool init = false);
+
     std::unique_ptr<Ui::ConfigureGameList> ui;
 };

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -108,7 +108,7 @@ public:
             }};
 
             const auto& row1 = row_data.at(UISettings::values.row_1_text_id);
-            int row2_id = UISettings::values.row_2_text_id;
+            const int row2_id = UISettings::values.row_2_text_id;
 
             if (row2_id == 4) // None
                 return row1;

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -108,11 +108,14 @@ public:
             }};
 
             const auto& row1 = row_data.at(UISettings::values.row_1_text_id);
-            const auto& row2 = row_data.at(UISettings::values.row_2_text_id);
+            int row2_id = UISettings::values.row_2_text_id;
 
-            if (row1.isEmpty() || row1 == row2)
-                return row2;
-            if (row2.isEmpty())
+            if (row2_id == 4) // None
+                return row1;
+
+            const auto& row2 = row_data.at(row2_id);
+
+            if (row1 == row2)
                 return row1;
 
             return QString(row1 + QStringLiteral("\n    ") + row2);


### PR DESCRIPTION
Currently user can achieve single row entries on the game list by selecting same option twice in configuration panel. Inspired by Citra I have implemented a bit user friendlier game list row configuration:
* second row has now "None" option
* duplicate options are dynamically removed on initial render and on user interaction

I'm not a QT nor C++ expert, I'm sure this could be written better so I'm awaiting reviews and comments ;) 

I have tried few simplifications  (using `curentIndex()` instead of  `currentData()`, avoiding "caching" current selection etc.) but I failed miserably due to some UI glitches or even crashes. Currently committed code, at least for me, working stable and as intended. 

I have left `row1 == row2` condition in `game_list_p.h` for the backward compatibility with older configs after update. It's also explanation why "None" need to be at the end of options array. I have also removed `.isEmpty()` checks because they seems no longer valid with current implementation, correct me please if I'm wrong.

Preview:
![yuzugl](https://user-images.githubusercontent.com/719641/72534543-4b12ac00-3877-11ea-9bb3-9f31dcce2daa.gif)
