### PR TITLE
Remove unused CPU Vendor string and telemtry field

### DIFF
--- a/src/common/telemetry.cpp
+++ b/src/common/telemetry.cpp
@@ -44,20 +44,6 @@ template class Field<std::string>;
 template class Field<const char*>;
 template class Field<std::chrono::microseconds>;
 
-#ifdef ARCHITECTURE_x86_64
-static const char* CpuVendorToStr(Common::CPUVendor vendor) {
-    switch (vendor) {
-    case Common::CPUVendor::INTEL:
-        return "Intel";
-    case Common::CPUVendor::AMD:
-        return "Amd";
-    case Common::CPUVendor::OTHER:
-        return "Other";
-    }
-    UNREACHABLE();
-}
-#endif
-
 void AppendBuildInfo(FieldCollection& fc) {
     const bool is_git_dirty{std::strstr(Common::g_scm_desc, "dirty") != nullptr};
     fc.AddField(FieldType::App, "Git_IsDirty", is_git_dirty);
@@ -71,7 +57,6 @@ void AppendCPUInfo(FieldCollection& fc) {
 #ifdef ARCHITECTURE_x86_64
     fc.AddField(FieldType::UserSystem, "CPU_Model", Common::GetCPUCaps().cpu_string);
     fc.AddField(FieldType::UserSystem, "CPU_BrandString", Common::GetCPUCaps().brand_string);
-    fc.AddField(FieldType::UserSystem, "CPU_Vendor", CpuVendorToStr(Common::GetCPUCaps().vendor));
     fc.AddField(FieldType::UserSystem, "CPU_Extension_x64_AES", Common::GetCPUCaps().aes);
     fc.AddField(FieldType::UserSystem, "CPU_Extension_x64_AVX", Common::GetCPUCaps().avx);
     fc.AddField(FieldType::UserSystem, "CPU_Extension_x64_AVX2", Common::GetCPUCaps().avx2);

--- a/src/common/x64/cpu_detect.cpp
+++ b/src/common/x64/cpu_detect.cpp
@@ -3,8 +3,6 @@
 // Refer to the license.txt file included.
 
 #include <cstring>
-#include <string>
-#include <thread>
 #include "common/common_types.h"
 #include "common/x64/cpu_detect.h"
 
@@ -51,8 +49,6 @@ namespace Common {
 static CPUCaps Detect() {
     CPUCaps caps = {};
 
-    caps.num_cores = std::thread::hardware_concurrency();
-
     // Assumes the CPU supports the CPUID instruction. Those that don't would likely not support
     // yuzu at all anyway
 
@@ -70,12 +66,6 @@ static CPUCaps Detect() {
     __cpuid(cpu_id, 0x80000000);
 
     u32 max_ex_fn = cpu_id[0];
-    if (!strcmp(caps.brand_string, "GenuineIntel"))
-        caps.vendor = CPUVendor::INTEL;
-    else if (!strcmp(caps.brand_string, "AuthenticAMD"))
-        caps.vendor = CPUVendor::AMD;
-    else
-        caps.vendor = CPUVendor::OTHER;
 
     // Set reasonable default brand string even if brand string not available
     strcpy(caps.cpu_string, caps.brand_string);
@@ -96,14 +86,8 @@ static CPUCaps Detect() {
             caps.sse4_1 = true;
         if ((cpu_id[2] >> 20) & 1)
             caps.sse4_2 = true;
-        if ((cpu_id[2] >> 22) & 1)
-            caps.movbe = true;
         if ((cpu_id[2] >> 25) & 1)
             caps.aes = true;
-
-        if ((cpu_id[3] >> 24) & 1) {
-            caps.fxsave_fxrstor = true;
-        }
 
         // AVX support requires 3 separate checks:
         //  - Is the AVX bit set in CPUID?
@@ -129,8 +113,6 @@ static CPUCaps Detect() {
         }
     }
 
-    caps.flush_to_zero = caps.sse;
-
     if (max_ex_fn >= 0x80000004) {
         // Extract CPU model string
         __cpuid(cpu_id, 0x80000002);
@@ -144,14 +126,8 @@ static CPUCaps Detect() {
     if (max_ex_fn >= 0x80000001) {
         // Check for more features
         __cpuid(cpu_id, 0x80000001);
-        if (cpu_id[2] & 1)
-            caps.lahf_sahf_64 = true;
-        if ((cpu_id[2] >> 5) & 1)
-            caps.lzcnt = true;
         if ((cpu_id[2] >> 16) & 1)
             caps.fma4 = true;
-        if ((cpu_id[3] >> 29) & 1)
-            caps.long_mode = true;
     }
 
     return caps;
@@ -160,50 +136,6 @@ static CPUCaps Detect() {
 const CPUCaps& GetCPUCaps() {
     static CPUCaps caps = Detect();
     return caps;
-}
-
-std::string GetCPUCapsString() {
-    auto caps = GetCPUCaps();
-
-    std::string sum(caps.cpu_string);
-    sum += " (";
-    sum += caps.brand_string;
-    sum += ")";
-
-    if (caps.sse)
-        sum += ", SSE";
-    if (caps.sse2) {
-        sum += ", SSE2";
-        if (!caps.flush_to_zero)
-            sum += " (without DAZ)";
-    }
-
-    if (caps.sse3)
-        sum += ", SSE3";
-    if (caps.ssse3)
-        sum += ", SSSE3";
-    if (caps.sse4_1)
-        sum += ", SSE4.1";
-    if (caps.sse4_2)
-        sum += ", SSE4.2";
-    if (caps.avx)
-        sum += ", AVX";
-    if (caps.avx2)
-        sum += ", AVX2";
-    if (caps.bmi1)
-        sum += ", BMI1";
-    if (caps.bmi2)
-        sum += ", BMI2";
-    if (caps.fma)
-        sum += ", FMA";
-    if (caps.aes)
-        sum += ", AES";
-    if (caps.movbe)
-        sum += ", MOVBE";
-    if (caps.long_mode)
-        sum += ", 64-bit support";
-
-    return sum;
 }
 
 } // namespace Common

--- a/src/common/x64/cpu_detect.h
+++ b/src/common/x64/cpu_detect.h
@@ -4,23 +4,12 @@
 
 #pragma once
 
-#include <string>
-
 namespace Common {
-
-/// x86/x64 CPU vendors that may be detected by this module
-enum class CPUVendor {
-    INTEL,
-    AMD,
-    OTHER,
-};
 
 /// x86/x64 CPU capabilities that may be detected by this module
 struct CPUCaps {
-    CPUVendor vendor;
     char cpu_string[0x21];
     char brand_string[0x41];
-    int num_cores;
     bool sse;
     bool sse2;
     bool sse3;
@@ -35,20 +24,6 @@ struct CPUCaps {
     bool fma;
     bool fma4;
     bool aes;
-
-    // Support for the FXSAVE and FXRSTOR instructions
-    bool fxsave_fxrstor;
-
-    bool movbe;
-
-    // This flag indicates that the hardware supports some mode in which denormal inputs and outputs
-    // are automatically set to (signed) zero.
-    bool flush_to_zero;
-
-    // Support for LAHF and SAHF instructions in 64-bit mode
-    bool lahf_sahf_64;
-
-    bool long_mode;
 };
 
 /**
@@ -56,11 +31,5 @@ struct CPUCaps {
  * @return Reference to a CPUCaps struct with the detected host CPU capabilities
  */
 const CPUCaps& GetCPUCaps();
-
-/**
- * Gets a string summary of the name and supported capabilities of the host CPU
- * @return String summary
- */
-std::string GetCPUCapsString();
 
 } // namespace Common


### PR DESCRIPTION
The information is duplicated in the brand string and the telemetry field is unused.

Already worked with flame sage to make this field optional as well.