### PR TITLE
audio_renderer: Add a voice mixing system

### DIFF
--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -73,6 +73,20 @@ private:
     EffectInStatus info{};
 };
 
+class AudioRenderer::ChannelState {
+public:
+    const ChannelInfoIn& GetInfo() const {
+        return info;
+    }
+
+    ChannelInfoIn& GetInfo() {
+        return info;
+    }
+
+private:
+    ChannelInfoIn info{};
+};
+
 AudioRenderer::AudioRenderer(Core::Timing::CoreTiming& core_timing, Core::Memory::Memory& memory_,
                              AudioRendererParameter params,
                              std::shared_ptr<Kernel::WritableEvent> buffer_event,
@@ -132,6 +146,15 @@ std::vector<u8> AudioRenderer::UpdateAudioRenderer(const std::vector<u8>& input_
     for (auto& voice : voices) {
         std::memcpy(&voice.GetInfo(), input_params.data() + voice_offset, sizeof(VoiceInfo));
         voice_offset += sizeof(VoiceInfo);
+    }
+
+    std::size_t channel_offset{sizeof(UpdateDataHeader) + config.behavior_size +
+                               config.memory_pools_size};
+    channels.resize((voice_offset - channel_offset) / sizeof(ChannelInfoIn));
+    for (auto& channel : channels) {
+        std::memcpy(&channel.GetInfo(), input_params.data() + channel_offset,
+                    sizeof(ChannelInfoIn));
+        channel_offset += sizeof(ChannelInfoIn);
     }
 
     std::size_t effect_offset{sizeof(UpdateDataHeader) + config.behavior_size +
@@ -352,10 +375,16 @@ void AudioRenderer::QueueMixedBuffer(Buffer::Tag tag) {
 
             samples_remaining -= samples.size() / stream->GetNumChannels();
 
+            // TODO(FearlessTobi): Implement Surround mixing
+            const auto& mix = channels[voice.GetInfo().id].GetInfo().mix;
             for (const auto& sample : samples) {
                 const s32 buffer_sample{buffer[offset]};
-                buffer[offset++] =
-                    ClampToS16(buffer_sample + static_cast<s32>(sample * voice.GetInfo().volume));
+
+                // index 0 is for the left ear, 1 is for the right
+                const float submix = mix[offset % 2];
+
+                buffer[offset++] = ClampToS16(
+                    buffer_sample + static_cast<s32>(sample * voice.GetInfo().volume * submix));
             }
         }
     }

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -360,9 +360,11 @@ static std::size_t GetMixVolumeIndex(const VoiceInfo& voice_info, std::size_t of
     case 1:
         return 0;
     case 2:
+    case 6:
         return offset % 2;
     default:
         UNIMPLEMENTED_MSG("Unimplemented channel_count={}", voice_info.channel_count);
+        return 0;
     }
 }
 

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -148,6 +148,14 @@ struct VoiceOutStatus {
 };
 static_assert(sizeof(VoiceOutStatus) == 0x10, "VoiceOutStatus has wrong size");
 
+struct ChannelInfoIn {
+    u32_le id;
+    std::array<float_le, 24> mix;
+    bool is_used;
+    INSERT_PADDING_BYTES(11);
+};
+static_assert(sizeof(ChannelInfoIn) == 0x70, "ChannelInfoIn has wrong size");
+
 struct AuxInfo {
     std::array<u8, 24> input_mix_buffers;
     std::array<u8, 24> output_mix_buffers;
@@ -235,11 +243,13 @@ public:
     Stream::State GetStreamState() const;
 
 private:
+    class ChannelState;
     class EffectState;
     class VoiceState;
 
     AudioRendererParameter worker_params;
     std::shared_ptr<Kernel::WritableEvent> buffer_event;
+    std::vector<ChannelState> channels;
     std::vector<VoiceState> voices;
     std::vector<EffectState> effects;
     std::unique_ptr<AudioOut> audio_out;

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -150,7 +150,7 @@ static_assert(sizeof(VoiceOutStatus) == 0x10, "VoiceOutStatus has wrong size");
 
 struct ChannelInfoIn {
     u32_le id;
-    std::array<float_le, 24> mix;
+    std::array<float_le, 24> mix_volume;
     bool is_used;
     INSERT_PADDING_BYTES(11);
 };


### PR DESCRIPTION
This implements a rudimentary mixing system for voices in audren. 
So far it only supports Stereo mixing, but Sorround isn't implemented anywhere anyway.

Improvements by this can be seen in quite a few games, including Super Mario Odyssey.
[Before](https://streamable.com/6uk6v) and [After](https://streamable.com/dzp39) (thanks to BsoD Gaming).

This has been extensively hw-tested with a modified version of the `audren-simple` program.
[Version 1](https://cdn.discordapp.com/attachments/576428479726223370/668132374667722782/audren-simple-volumeTobiHex.nro) / [Version 2](https://cdn.discordapp.com/attachments/576428479726223370/668132377360596992/audren-simpleSide.nro)

The only new issue known with this is the menu music in Disgaea 5 not playing anymore, but I think I just uncovered a deeper lying bug here as there are many other audren issues there.