### PR TITLE
Port citra-emu/citra#5037: "CMake: Create thin archives on Linux"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,15 @@ else()
             add_compile_options("-static")
         endif()
     endif()
+
+    if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR MINGW)
+        # GNU ar: Create thin archive files.
+        # Requires binutils-2.19 or later.
+        set(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> qcTP <TARGET> <LINK_FLAGS> <OBJECTS>")
+        set(CMAKE_C_ARCHIVE_APPEND   "<CMAKE_AR> qTP  <TARGET> <LINK_FLAGS> <OBJECTS>")
+        set(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> qcTP <TARGET> <LINK_FLAGS> <OBJECTS>")
+        set(CMAKE_CXX_ARCHIVE_APPEND "<CMAKE_AR> qTP  <TARGET> <LINK_FLAGS> <OBJECTS>")
+    endif()
 endif()
 
 add_subdirectory(common)


### PR DESCRIPTION
See citra-emu/citra#5037 for more details. As I don't have a Linux machine with a toolchain installed, I'm just gonna wait for CI to finish.

**Original description**:
This significantly reduces unnecessary disk writes and space usage
when building Citra.

libcore.a is now only ~1MB rather than several hundred megabytes.