### PR TITLE
GUI: fix minor issues with dark themes + rename and reorder themes

### DIFF
--- a/dist/qt_themes/qdarkstyle/style.qss
+++ b/dist/qt_themes/qdarkstyle/style.qss
@@ -181,7 +181,7 @@ QMenu::icon {
 }
 
 QMenu::item {
-    padding: 5px 30px 5px 30px;
+    padding: 5px 16px 5px 40px;
     border: 1px solid transparent;
     /* reserve space for selection border */
 }
@@ -192,12 +192,13 @@ QMenu::item:selected {
 
 QMenu::separator {
     height: 2px;
-    background: lightblue;
+    background: #76797C;
     margin-left: 10px;
     margin-right: 5px;
 }
 
 QMenu::indicator {
+	margin: 0 -26px 0 8px;
     width: 18px;
     height: 18px;
 }
@@ -252,7 +253,7 @@ QWidget:disabled {
 }
 
 QAbstractItemView {
-    alternate-background-color: #31363b;
+    alternate-background-color: #2c2f32;
     color: #eff0f1;
     border: 1px solid #3A3939;
     border-radius: 2px;
@@ -577,8 +578,6 @@ QTreeView:hover {
 }
 
 QComboBox:on {
-    padding-top: 3px;
-    padding-left: 4px;
     selection-background-color: #4a4a4a;
 }
 
@@ -703,10 +702,10 @@ QTabBar::close-button:pressed {
 QTabBar::tab:top {
     color: #eff0f1;
     border: 1px solid #76797C;
-    border-bottom: 1px transparent black;
+    border-bottom: 2px transparent;
     background-color: #31363b;
-    padding: 5px;
-    min-width: 50px;
+    padding: 4px 16px 2px;
+    min-width: 38px;
     border-top-left-radius: 2px;
     border-top-right-radius: 2px;
 }
@@ -1078,7 +1077,7 @@ QListView::item:selected:active {
 }
 
 QHeaderView {
-    background-color: #31363b;
+    background-color: #403F3F;
     border: 1px transparent;
     border-radius: 0px;
     margin: 0px;
@@ -1086,30 +1085,32 @@ QHeaderView {
 }
 
 QHeaderView::section {
-    background-color: #31363b;
+    background-color: #232629;
     color: #eff0f1;
-    padding: 5px;
-    border: 1px solid #76797C;
+    padding: 0 5px;
+    border: 1px solid #403F3F;
+	border-bottom: 0;
     border-radius: 0px;
     text-align: center;
 }
 
 QHeaderView::section::vertical::first,
 QHeaderView::section::vertical::only-one {
-    border-top: 1px solid #76797C;
+    border-top: 1px solid #31363b;
 }
 
 QHeaderView::section::vertical {
     border-top: transparent;
 }
 
+QHeaderView::section::horizontal,
 QHeaderView::section::horizontal::first,
 QHeaderView::section::horizontal::only-one {
-    border-left: 1px solid #76797C;
+    border-left: transparent;
 }
 
-QHeaderView::section::horizontal {
-    border-left: transparent;
+QHeaderView::section::horizontal::last {
+	border-right: transparent;
 }
 
 QHeaderView::section:checked {

--- a/dist/qt_themes/qdarkstyle/style.qss
+++ b/dist/qt_themes/qdarkstyle/style.qss
@@ -198,7 +198,7 @@ QMenu::separator {
 }
 
 QMenu::indicator {
-	margin: 0 -26px 0 8px;
+    margin: 0 -26px 0 8px;
     width: 18px;
     height: 18px;
 }
@@ -1089,7 +1089,7 @@ QHeaderView::section {
     color: #eff0f1;
     padding: 0 5px;
     border: 1px solid #403F3F;
-	border-bottom: 0;
+    border-bottom: 0;
     border-radius: 0px;
     text-align: center;
 }
@@ -1110,7 +1110,7 @@ QHeaderView::section::horizontal::only-one {
 }
 
 QHeaderView::section::horizontal::last {
-	border-right: transparent;
+    border-right: transparent;
 }
 
 QHeaderView::section:checked {

--- a/src/yuzu/uisettings.cpp
+++ b/src/yuzu/uisettings.cpp
@@ -7,10 +7,10 @@
 namespace UISettings {
 
 const Themes themes{{
-    {"Default", "default"},
+    {"Light", "default"},
+    {"Light Colorful", "colorful"},
     {"Dark", "qdarkstyle"},
-    {"Colorful", "colorful"},
-    {"Colorful Dark", "colorful_dark"},
+    {"Dark Colorful", "colorful_dark"},
 }};
 
 Values values = {};


### PR DESCRIPTION
This PR fixes few minor UI issues with dark themes also trying to mimic more "Default" ("Light") mode styling and component sizes to avoid resize on theme change. The following changes has been made:

- mimic "Default" theme list headers styling - use list background color, border omission, no extra padding - **_Screenshot 1_**
- decrease contrast of even rows on the lists to mimic "Default"  theme styling and differentiate those rows more from Status Bar or Filter Bar - **_Screenshot 1_**
- update tabs minimal size and padding to roughly match "Default" theme styling - **_Screenshot 2_**
- fix Main Menu and Context Menu (ex. game row) checkbox position and items padding - **_Screenshot 3_**
- fix ComboBox currently selected value being repositioned on options list open (only "Dark" themes seems affected) - **_Preview 1_**

I have also changed the themes names and reordered them to make it even more obvious for user how the theme will be looking like. It's completely optional change, even rather proposition, which I can ditch if you don't like it. 

Currently themes list looks like:
- Default
- Dark
- Colorful
- Colorful Dark

Proposed names and order (also visible in _Preview 1_):
- Light
- Light Colorful
- Dark
- Dark Colorful

I'm open to any suggestions and I would like to try to fix some more themes issues if you have experienced any.


#### Screenshot 1
<img width="692" alt="y1" src="https://user-images.githubusercontent.com/719641/72930780-f8486100-3d5c-11ea-90f0-2dc604bacbfe.png">

#### Screenshot 2 
<img width="847" alt="y2" src="https://user-images.githubusercontent.com/719641/72930817-131ad580-3d5d-11ea-89d7-23cd58c84da9.png">

#### Screenshot 3 
<img width="692" alt="y3" src="https://user-images.githubusercontent.com/719641/72930829-1a41e380-3d5d-11ea-9f73-30868a1786f6.png">

#### Preview 1
![yuzucb](https://user-images.githubusercontent.com/719641/72932097-5e35e800-3d5f-11ea-9eaf-df6f5a40f48c.gif)


