### PR TITLE
yuzu/configuration: create UI tab and move gamelist settings there

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -36,9 +36,6 @@ add_executable(yuzu
     configuration/configure_filesystem.cpp
     configuration/configure_filesystem.h
     configuration/configure_filesystem.ui
-    configuration/configure_gamelist.cpp
-    configuration/configure_gamelist.h
-    configuration/configure_gamelist.ui
     configuration/configure_general.cpp
     configuration/configure_general.h
     configuration/configure_general.ui
@@ -75,6 +72,9 @@ add_executable(yuzu
     configuration/configure_touchscreen_advanced.cpp
     configuration/configure_touchscreen_advanced.h
     configuration/configure_touchscreen_advanced.ui
+    configuration/configure_ui.cpp
+    configuration/configure_ui.h
+    configuration/configure_ui.ui
     configuration/configure_web.cpp
     configuration/configure_web.h
     configuration/configure_web.ui

--- a/src/yuzu/configuration/configure.ui
+++ b/src/yuzu/configuration/configure.ui
@@ -48,7 +48,7 @@
          <string>General</string>
         </attribute>
        </widget>
-       <widget class="ConfigureGameList" name="gameListTab">
+       <widget class="ConfigureUi" name="uiTab">
         <attribute name="title">
          <string>Game List</string>
         </attribute>
@@ -166,9 +166,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ConfigureGameList</class>
+   <class>ConfigureUi</class>
    <extends>QWidget</extends>
-   <header>configuration/configure_gamelist.h</header>
+   <header>configuration/configure_ui.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -34,7 +34,7 @@ void ConfigureDialog::SetConfiguration() {}
 
 void ConfigureDialog::ApplyConfiguration() {
     ui->generalTab->ApplyConfiguration();
-    ui->gameListTab->ApplyConfiguration();
+    ui->uiTab->ApplyConfiguration();
     ui->systemTab->ApplyConfiguration();
     ui->profileManagerTab->ApplyConfiguration();
     ui->filesystemTab->applyConfiguration();
@@ -74,7 +74,7 @@ Q_DECLARE_METATYPE(QList<QWidget*>);
 
 void ConfigureDialog::PopulateSelectionList() {
     const std::array<std::pair<QString, QList<QWidget*>>, 5> items{
-        {{tr("General"), {ui->generalTab, ui->webTab, ui->debugTab, ui->gameListTab}},
+        {{tr("General"), {ui->generalTab, ui->webTab, ui->debugTab, ui->uiTab}},
          {tr("System"), {ui->systemTab, ui->profileManagerTab, ui->serviceTab, ui->filesystemTab}},
          {tr("Graphics"), {ui->graphicsTab}},
          {tr("Audio"), {ui->audioTab}},
@@ -108,7 +108,7 @@ void ConfigureDialog::UpdateVisibleTabs() {
         {ui->audioTab, tr("Audio")},
         {ui->debugTab, tr("Debug")},
         {ui->webTab, tr("Web")},
-        {ui->gameListTab, tr("Game List")},
+        {ui->uiTab, tr("UI")},
         {ui->filesystemTab, tr("Filesystem")},
         {ui->serviceTab, tr("Services")},
     };

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -15,11 +15,6 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
 
     ui->setupUi(this);
 
-    for (const auto& theme : UISettings::themes) {
-        ui->theme_combobox->addItem(QString::fromUtf8(theme.first),
-                                    QString::fromUtf8(theme.second));
-    }
-
     SetConfiguration();
 
     connect(ui->toggle_frame_limit, &QCheckBox::toggled, ui->frame_limit, &QSpinBox::setEnabled);
@@ -30,7 +25,6 @@ ConfigureGeneral::~ConfigureGeneral() = default;
 void ConfigureGeneral::SetConfiguration() {
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing);
     ui->toggle_user_on_boot->setChecked(UISettings::values.select_user_on_boot);
-    ui->theme_combobox->setCurrentIndex(ui->theme_combobox->findData(UISettings::values.theme));
     ui->toggle_background_pause->setChecked(UISettings::values.pause_when_in_background);
 
     ui->toggle_frame_limit->setChecked(Settings::values.use_frame_limit);
@@ -41,8 +35,6 @@ void ConfigureGeneral::SetConfiguration() {
 void ConfigureGeneral::ApplyConfiguration() {
     UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
     UISettings::values.select_user_on_boot = ui->toggle_user_on_boot->isChecked();
-    UISettings::values.theme =
-        ui->theme_combobox->itemData(ui->theme_combobox->currentIndex()).toString();
     UISettings::values.pause_when_in_background = ui->toggle_background_pause->isChecked();
 
     Settings::values.use_frame_limit = ui->toggle_frame_limit->isChecked();

--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -65,39 +65,12 @@
             </property>
            </widget>
           </item>
-           <item>
-             <widget class="QCheckBox" name="toggle_background_pause">
-               <property name="text">
-                 <string>Pause emulation when in background</string>
-               </property>
-             </widget>
-           </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="theme_group_box">
-       <property name="title">
-        <string>Theme</string>
-       </property>
-       <layout class="QHBoxLayout" name="theme_qhbox_layout">
-        <item>
-         <layout class="QVBoxLayout" name="theme_qvbox_layout">
           <item>
-           <layout class="QHBoxLayout" name="theme_qhbox_layout_2">
-            <item>
-             <widget class="QLabel" name="theme_label">
-              <property name="text">
-               <string>Theme:</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QComboBox" name="theme_combobox"/>
-            </item>
-           </layout>
+           <widget class="QCheckBox" name="toggle_background_pause">
+            <property name="text">
+             <string>Pause emulation when in background</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </item>

--- a/src/yuzu/configuration/configure_ui.h
+++ b/src/yuzu/configuration/configure_ui.h
@@ -8,15 +8,15 @@
 #include <QWidget>
 
 namespace Ui {
-class ConfigureGameList;
+class ConfigureUi;
 }
 
-class ConfigureGameList : public QWidget {
+class ConfigureUi : public QWidget {
     Q_OBJECT
 
 public:
-    explicit ConfigureGameList(QWidget* parent = nullptr);
-    ~ConfigureGameList() override;
+    explicit ConfigureUi(QWidget* parent = nullptr);
+    ~ConfigureUi() override;
 
     void ApplyConfiguration();
 
@@ -34,5 +34,5 @@ private:
     void UpdateFirstRowComboBox(bool init = false);
     void UpdateSecondRowComboBox(bool init = false);
 
-    std::unique_ptr<Ui::ConfigureGameList> ui;
+    std::unique_ptr<Ui::ConfigureUi> ui;
 };

--- a/src/yuzu/configuration/configure_ui.ui
+++ b/src/yuzu/configuration/configure_ui.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>ConfigureGameList</class>
- <widget class="QWidget" name="ConfigureGameList">
+ <class>ConfigureUi</class>
+ <widget class="QWidget" name="ConfigureUi">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -21,7 +21,34 @@
        <property name="title">
         <string>General</string>
        </property>
-       <layout class="QHBoxLayout" name="GeneralHorizontalLayout">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_3">
+            <item>
+             <widget class="QLabel" name="theme_label">
+              <property name="text">
+               <string>Theme:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="theme_combobox"/>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="GameListGroupBox">
+       <property name="title">
+        <string>Game List</string>
+       </property>
+       <layout class="QHBoxLayout" name="GameListHorizontalLayout">
         <item>
          <layout class="QVBoxLayout" name="GeneralVerticalLayout">
           <item>
@@ -38,19 +65,6 @@
             </property>
            </widget>
           </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="IconSizeGroupBox">
-       <property name="title">
-        <string>Icon Size</string>
-       </property>
-       <layout class="QHBoxLayout" name="icon_size_qhbox_layout">
-        <item>
-         <layout class="QVBoxLayout" name="icon_size_qvbox_layout">
           <item>
            <layout class="QHBoxLayout" name="icon_size_qhbox_layout_2">
             <item>
@@ -65,19 +79,6 @@
             </item>
            </layout>
           </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="RowGroupBox">
-       <property name="title">
-        <string>Row Text</string>
-       </property>
-       <layout class="QHBoxLayout" name="RowHorizontalLayout">
-        <item>
-         <layout class="QVBoxLayout" name="RowVerticalLayout">
           <item>
            <layout class="QHBoxLayout" name="row_1_qhbox_layout">
             <item>


### PR DESCRIPTION
Taken from https://github.com/yuzu-emu/yuzu/pull/1974.

Unifies the UI with Citra and makes it easier to port translation support.

![Unbenannt](https://user-images.githubusercontent.com/20753089/73032257-e50dc200-3e3e-11ea-9848-38ae90efc109.PNG)
