### PR TITLE
audio: Synchronize event time with framerate.

### DIFF
--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -11,8 +11,10 @@
 #include "audio_core/stream.h"
 #include "common/assert.h"
 #include "common/logging/log.h"
+#include "core/core.h"
 #include "core/core_timing.h"
 #include "core/core_timing_util.h"
+#include "core/perf_stats.h"
 #include "core/settings.h"
 
 namespace AudioCore {
@@ -61,8 +63,11 @@ Stream::State Stream::GetState() const {
 
 s64 Stream::GetBufferReleaseCycles(const Buffer& buffer) const {
     const std::size_t num_samples{buffer.GetSamples().size() / GetNumChannels()};
-    const auto us =
-        std::chrono::microseconds((static_cast<u64>(num_samples) * 1000000) / sample_rate);
+    const double time_scale{Settings::values.enable_realtime_audio
+                                ? Core::System::GetInstance().GetPerfStats().GetLastFrameTimeScale()
+                                : 1.0f};
+    const auto us{std::chrono::microseconds(
+        (static_cast<u64>(num_samples) * static_cast<u64>(1000000 / time_scale)) / sample_rate)};
     return Core::Timing::usToCycles(us);
 }
 

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -108,13 +108,15 @@ PerfStatsResults PerfStats::GetAndResetStats(microseconds current_system_time_us
     system_frames = 0;
     game_frames = 0;
 
+    target_fps = static_cast<u32>(results.game_fps / results.emulation_speed);
+
     return results;
 }
 
 double PerfStats::GetLastFrameTimeScale() {
     std::lock_guard lock{object_mutex};
 
-    constexpr double FRAME_LENGTH = 1.0 / 60;
+    double FRAME_LENGTH = 1.0 / target_fps;
     return duration_cast<DoubleSecs>(previous_frame_length).count() / FRAME_LENGTH;
 }
 

--- a/src/core/perf_stats.h
+++ b/src/core/perf_stats.h
@@ -81,6 +81,8 @@ private:
     Clock::time_point frame_begin = reset_point;
     /// Total visible duration (including frame-limiting, etc.) of the previous system frame
     Clock::duration previous_frame_length = Clock::duration::zero();
+
+    u32 target_fps{60};
 };
 
 class FrameLimiter {

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -98,6 +98,7 @@ void LogSettings() {
     LogSetting("Renderer_UseVsync", Settings::values.use_vsync);
     LogSetting("Audio_OutputEngine", Settings::values.sink_id);
     LogSetting("Audio_EnableAudioStretching", Settings::values.enable_audio_stretching);
+    LogSetting("Audio_EnableRealTime", Settings::values.enable_realtime_audio);
     LogSetting("Audio_OutputDevice", Settings::values.audio_device_id);
     LogSetting("DataStorage_UseVirtualSd", Settings::values.use_virtual_sd);
     LogSetting("DataStorage_NandDir", FileUtil::GetUserPath(FileUtil::UserPath::NANDDir));

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -452,6 +452,7 @@ struct Values {
     // Audio
     std::string sink_id;
     bool enable_audio_stretching;
+    bool enable_realtime_audio;
     std::string audio_device_id;
     float volume;
 

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -178,6 +178,7 @@ void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader) {
     constexpr auto field_type = Telemetry::FieldType::UserConfig;
     AddField(field_type, "Audio_SinkId", Settings::values.sink_id);
     AddField(field_type, "Audio_EnableAudioStretching", Settings::values.enable_audio_stretching);
+    AddField(field_type, "Audio_EnableRealTime", Settings::values.enable_realtime_audio);
     AddField(field_type, "Core_UseMultiCore", Settings::values.use_multi_core);
     AddField(field_type, "Renderer_Backend", TranslateRenderer(Settings::values.renderer_backend));
     AddField(field_type, "Renderer_ResolutionFactor", Settings::values.resolution_factor);

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -408,7 +408,7 @@ void Config::ReadAudioValues() {
     Settings::values.enable_audio_stretching =
         ReadSetting(QStringLiteral("enable_audio_stretching"), true).toBool();
     Settings::values.enable_realtime_audio =
-        ReadSetting(QStringLiteral("enable_realtime_audio"), true).toBool();
+        ReadSetting(QStringLiteral("enable_realtime_audio"), false).toBool();
     Settings::values.audio_device_id =
         ReadSetting(QStringLiteral("output_device"), QStringLiteral("auto"))
             .toString()
@@ -918,7 +918,7 @@ void Config::SaveAudioValues() {
     WriteSetting(QStringLiteral("enable_audio_stretching"),
                  Settings::values.enable_audio_stretching, true);
     WriteSetting(QStringLiteral("enable_realtime_audio"), Settings::values.enable_realtime_audio,
-                 true);
+                 false);
     WriteSetting(QStringLiteral("output_device"),
                  QString::fromStdString(Settings::values.audio_device_id), QStringLiteral("auto"));
     WriteSetting(QStringLiteral("volume"), Settings::values.volume, 1.0f);

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -407,6 +407,8 @@ void Config::ReadAudioValues() {
                                    .toStdString();
     Settings::values.enable_audio_stretching =
         ReadSetting(QStringLiteral("enable_audio_stretching"), true).toBool();
+    Settings::values.enable_realtime_audio =
+        ReadSetting(QStringLiteral("enable_realtime_audio"), true).toBool();
     Settings::values.audio_device_id =
         ReadSetting(QStringLiteral("output_device"), QStringLiteral("auto"))
             .toString()
@@ -915,6 +917,8 @@ void Config::SaveAudioValues() {
                  QStringLiteral("auto"));
     WriteSetting(QStringLiteral("enable_audio_stretching"),
                  Settings::values.enable_audio_stretching, true);
+    WriteSetting(QStringLiteral("enable_realtime_audio"), Settings::values.enable_realtime_audio,
+                 true);
     WriteSetting(QStringLiteral("output_device"),
                  QString::fromStdString(Settings::values.audio_device_id), QStringLiteral("auto"));
     WriteSetting(QStringLiteral("volume"), Settings::values.volume, 1.0f);

--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -42,6 +42,7 @@ void ConfigureAudio::SetConfiguration() {
     SetAudioDeviceFromDeviceID();
 
     ui->toggle_audio_stretching->setChecked(Settings::values.enable_audio_stretching);
+    ui->toggle_realtime_audio->setChecked(Settings::values.enable_realtime_audio);
     ui->volume_slider->setValue(Settings::values.volume * ui->volume_slider->maximum());
     SetVolumeIndicatorText(ui->volume_slider->sliderPosition());
 }
@@ -84,6 +85,7 @@ void ConfigureAudio::ApplyConfiguration() {
         ui->output_sink_combo_box->itemText(ui->output_sink_combo_box->currentIndex())
             .toStdString();
     Settings::values.enable_audio_stretching = ui->toggle_audio_stretching->isChecked();
+    Settings::values.enable_realtime_audio = ui->toggle_realtime_audio->isChecked();
     Settings::values.audio_device_id =
         ui->audio_device_combo_box->itemText(ui->audio_device_combo_box->currentIndex())
             .toStdString();

--- a/src/yuzu/configuration/configure_audio.ui
+++ b/src/yuzu/configuration/configure_audio.ui
@@ -31,16 +31,26 @@
         </item>
        </layout>
       </item>
-       <item>
-         <widget class="QCheckBox" name="toggle_audio_stretching">
-           <property name="toolTip">
-             <string>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</string>
-           </property>
-           <property name="text">
-             <string>Enable audio stretching</string>
-           </property>
-         </widget>
-       </item>
+      <item>
+        <widget class="QCheckBox" name="toggle_audio_stretching">
+          <property name="toolTip">
+            <string>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</string>
+          </property>
+          <property name="text">
+            <string>Enable audio stretching</string>
+          </property>
+        </widget>
+      </item>
+      <item>
+        <widget class="QCheckBox" name="toggle_realtime_audio">
+          <property name="toolTip">
+            <string>This adjusts audio timing to match real-time speed and helps prevent audio stutter.</string>
+          </property>
+          <property name="text">
+            <string>Enable real-time audio</string>
+          </property>
+        </widget>
+      </item>
       <item>
        <layout class="QHBoxLayout">
         <item>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -404,6 +404,8 @@ void Config::ReadValues() {
     Settings::values.sink_id = sdl2_config->Get("Audio", "output_engine", "auto");
     Settings::values.enable_audio_stretching =
         sdl2_config->GetBoolean("Audio", "enable_audio_stretching", true);
+    Settings::values.enable_realtime_audio =
+        sdl2_config->GetBoolean("Audio", "enable_realtime_audio", true);
     Settings::values.audio_device_id = sdl2_config->Get("Audio", "output_device", "auto");
     Settings::values.volume = static_cast<float>(sdl2_config->GetReal("Audio", "volume", 1));
 

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -405,7 +405,7 @@ void Config::ReadValues() {
     Settings::values.enable_audio_stretching =
         sdl2_config->GetBoolean("Audio", "enable_audio_stretching", true);
     Settings::values.enable_realtime_audio =
-        sdl2_config->GetBoolean("Audio", "enable_realtime_audio", true);
+        sdl2_config->GetBoolean("Audio", "enable_realtime_audio", false);
     Settings::values.audio_device_id = sdl2_config->Get("Audio", "output_device", "auto");
     Settings::values.volume = static_cast<float>(sdl2_config->GetReal("Audio", "volume", 1));
 

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -201,6 +201,11 @@ output_engine =
 # 0: No, 1 (default): Yes
 enable_audio_stretching =
 
+# Whether or not to enable the real-time audio processing.
+# This effect adjusts audio speed to match real-time speed and helps prevent audio stutter.
+# 0: No, 1 (default): Yes
+enable_realtime_audio =
+
 # Which audio device to use.
 # auto (default): Auto-select
 output_device =


### PR DESCRIPTION
This is a pretty simple change that continually re-adjusts audio event time to try to compensate for the current framerate. This should result in real-time audio, even when the game is running slower (or faster) than normal.

This is behind a setting on the Audio tab. For now, this is default on (as internal testing has been very positive), even though this is not necessarily accurate. If we find this causes regressions, we can revisit that decision.

I'm also merging existing audio PRs, so that we can EA test this without conflict. Please ignore those in review.

