### PR TITLE
bsd: Stub several more functions.

### DIFF
--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -42,7 +42,47 @@ void BSD::Socket(Kernel::HLERequestContext& ctx) {
     rb.Push<u32>(0); // bsd errno
 }
 
+void BSD::Select(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service, "(STUBBED) called");
+
+    IPC::ResponseBuilder rb{ctx, 4};
+
+    rb.Push(RESULT_SUCCESS);
+    rb.Push<u32>(0); // ret
+    rb.Push<u32>(0); // bsd errno
+}
+
+void BSD::Bind(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service, "(STUBBED) called");
+
+    IPC::ResponseBuilder rb{ctx, 4};
+
+    rb.Push(RESULT_SUCCESS);
+    rb.Push<u32>(0); // ret
+    rb.Push<u32>(0); // bsd errno
+}
+
 void BSD::Connect(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service, "(STUBBED) called");
+
+    IPC::ResponseBuilder rb{ctx, 4};
+
+    rb.Push(RESULT_SUCCESS);
+    rb.Push<u32>(0); // ret
+    rb.Push<u32>(0); // bsd errno
+}
+
+void BSD::Listen(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service, "(STUBBED) called");
+
+    IPC::ResponseBuilder rb{ctx, 4};
+
+    rb.Push(RESULT_SUCCESS);
+    rb.Push<u32>(0); // ret
+    rb.Push<u32>(0); // bsd errno
+}
+
+void BSD::SetSockOpt(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 4};
@@ -80,7 +120,7 @@ BSD::BSD(const char* name) : ServiceFramework(name) {
         {2, &BSD::Socket, "Socket"},
         {3, nullptr, "SocketExempt"},
         {4, nullptr, "Open"},
-        {5, nullptr, "Select"},
+        {5, &BSD::Select, "Select"},
         {6, nullptr, "Poll"},
         {7, nullptr, "Sysctl"},
         {8, nullptr, "Recv"},
@@ -88,15 +128,15 @@ BSD::BSD(const char* name) : ServiceFramework(name) {
         {10, nullptr, "Send"},
         {11, &BSD::SendTo, "SendTo"},
         {12, nullptr, "Accept"},
-        {13, nullptr, "Bind"},
+        {13, &BSD::Bind, "Bind"},
         {14, &BSD::Connect, "Connect"},
         {15, nullptr, "GetPeerName"},
         {16, nullptr, "GetSockName"},
         {17, nullptr, "GetSockOpt"},
-        {18, nullptr, "Listen"},
+        {18, &BSD::Listen, "Listen"},
         {19, nullptr, "Ioctl"},
         {20, nullptr, "Fcntl"},
-        {21, nullptr, "SetSockOpt"},
+        {21, &BSD::SetSockOpt, "SetSockOpt"},
         {22, nullptr, "Shutdown"},
         {23, nullptr, "ShutdownAllSockets"},
         {24, nullptr, "Write"},

--- a/src/core/hle/service/sockets/bsd.h
+++ b/src/core/hle/service/sockets/bsd.h
@@ -18,7 +18,11 @@ private:
     void RegisterClient(Kernel::HLERequestContext& ctx);
     void StartMonitoring(Kernel::HLERequestContext& ctx);
     void Socket(Kernel::HLERequestContext& ctx);
+    void Select(Kernel::HLERequestContext& ctx);
+    void Bind(Kernel::HLERequestContext& ctx);
     void Connect(Kernel::HLERequestContext& ctx);
+    void Listen(Kernel::HLERequestContext& ctx);
+    void SetSockOpt(Kernel::HLERequestContext& ctx);
     void SendTo(Kernel::HLERequestContext& ctx);
     void Close(Kernel::HLERequestContext& ctx);
 


### PR DESCRIPTION
Required for Little Town Hero to boot further. These stubs should be OK, as BSD issues are fairly easy to track down. Furthermore, we are not planning on properly implementing BSD in the near term.