### PR TITLE
LOG: Implementation of Level Stubbed

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -289,6 +289,7 @@ const char* GetLevelName(Level log_level) {
         LVL(Warning);
         LVL(Error);
         LVL(Critical);
+        LVL(Stubbed);
     case Level::Count:
         break;
     }

--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -92,7 +92,18 @@ void Filter::ParseFilterString(std::string_view filter_view) {
     }
 }
 
+void Filter::ClearIgnoredLevels() {
+    ignored_levels.clear();
+}
+
+void Filter::AddIgnoredLevel(Level level) {
+    ignored_levels.push_back(level);
+}
+
 bool Filter::CheckMessage(Class log_class, Level level) const {
+    if (std::find(ignored_levels.begin(), ignored_levels.end(), level) != ignored_levels.end()) {
+        return false;
+    }
     return static_cast<u8>(level) >=
            static_cast<u8>(class_levels[static_cast<std::size_t>(log_class)]);
 }

--- a/src/common/logging/filter.h
+++ b/src/common/logging/filter.h
@@ -42,6 +42,10 @@ public:
      */
     void ParseFilterString(std::string_view filter_view);
 
+    void ClearIgnoredLevels();
+
+    void AddIgnoredLevel(Level level);
+
     /// Matches class/level combination against the filter, returning true if it passed.
     bool CheckMessage(Class log_class, Level level) const;
 
@@ -50,5 +54,6 @@ public:
 
 private:
     std::array<Level, static_cast<std::size_t>(Class::Count)> class_levels;
+    std::list<Level> ignored_levels;
 };
 } // namespace Log

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -29,8 +29,8 @@ enum class Level : u8 {
               ///< completed.
     Critical, ///< Major problems during execution that threaten the stability of the entire
               ///< application.
-
-    Count ///< Total number of logging levels
+    Stubbed,  ///< Debug information for stubbed services.
+    Count     ///< Total number of logging levels
 };
 
 typedef u8 ClassType;
@@ -170,4 +170,7 @@ void FmtLogMessage(Class log_class, Level log_level, const char* filename, unsig
                          ::Log::TrimSourcePath(__FILE__), __LINE__, __func__, __VA_ARGS__)
 #define LOG_CRITICAL(log_class, ...)                                                               \
     ::Log::FmtLogMessage(::Log::Class::log_class, ::Log::Level::Critical,                          \
+                         ::Log::TrimSourcePath(__FILE__), __LINE__, __func__, __VA_ARGS__)
+#define LOG_STUBBED(log_class, ...)                                                                \
+    ::Log::FmtLogMessage(::Log::Class::log_class, ::Log::Level::Stubbed,                           \
                          ::Log::TrimSourcePath(__FILE__), __LINE__, __func__, __VA_ARGS__)

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -65,6 +65,9 @@ void PrintColoredMessage(const Entry& entry) {
     case Level::Critical: // Bright magenta
         color = FOREGROUND_RED | FOREGROUND_BLUE | FOREGROUND_INTENSITY;
         break;
+    case Level::Stubbed: // Bright blue
+        color = FOREGROUND_BLUE | FOREGROUND_INTENSITY;
+        break;
     case Level::Count:
         UNREACHABLE();
     }

--- a/src/core/frontend/applets/software_keyboard.cpp
+++ b/src/core/frontend/applets/software_keyboard.cpp
@@ -20,7 +20,7 @@ void DefaultSoftwareKeyboardApplet::RequestText(
 
 void DefaultSoftwareKeyboardApplet::SendTextCheckDialog(
     std::u16string error_message, std::function<void()> finished_check) const {
-    LOG_WARNING(Service_AM,
+    LOG_STUBBED(Service_AM,
                 "(STUBBED) called - Default fallback software keyboard does not support text "
                 "check! (error_message={})",
                 Common::UTF16ToUTF8(error_message));

--- a/src/core/frontend/applets/web_browser.cpp
+++ b/src/core/frontend/applets/web_browser.cpp
@@ -14,10 +14,11 @@ DefaultWebBrowserApplet::~DefaultWebBrowserApplet() = default;
 void DefaultWebBrowserApplet::OpenPageLocal(std::string_view filename,
                                             std::function<void()> unpack_romfs_callback,
                                             std::function<void()> finished_callback) {
-    LOG_INFO(Service_AM,
-             "(STUBBED) called - No suitable web browser implementation found to open website page "
-             "at '{}'!",
-             filename);
+    LOG_STUBBED(
+        Service_AM,
+        "(STUBBED) called - No suitable web browser implementation found to open website page "
+        "at '{}'!",
+        filename);
     finished_callback();
 }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -847,7 +847,7 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
             return RESULT_SUCCESS;
 
         case GetInfoType::SystemResourceUsage:
-            LOG_WARNING(Kernel_SVC, "(STUBBED) Attempted to query system resource usage");
+            LOG_STUBBED(Kernel_SVC, "(STUBBED) Attempted to query system resource usage");
             *result = process->GetSystemResourceUsage();
             return RESULT_SUCCESS;
 
@@ -871,7 +871,7 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
             break;
         }
 
-        LOG_WARNING(Kernel_SVC, "(STUBBED) Unimplemented svcGetInfo id=0x{:016X}", info_id);
+        LOG_STUBBED(Kernel_SVC, "(STUBBED) Unimplemented svcGetInfo id=0x{:016X}", info_id);
         return ERR_INVALID_ENUM_VALUE;
     }
 
@@ -923,7 +923,7 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
         return RESULT_SUCCESS;
 
     case GetInfoType::PrivilegedProcessId:
-        LOG_WARNING(Kernel_SVC,
+        LOG_STUBBED(Kernel_SVC,
                     "(STUBBED) Attempted to query privileged process id bounds, returned 0");
         *result = 0;
         return RESULT_SUCCESS;
@@ -964,7 +964,7 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, u64 ha
     }
 
     default:
-        LOG_WARNING(Kernel_SVC, "(STUBBED) Unimplemented svcGetInfo id=0x{:016X}", info_id);
+        LOG_STUBBED(Kernel_SVC, "(STUBBED) Unimplemented svcGetInfo id=0x{:016X}", info_id);
         return ERR_INVALID_ENUM_VALUE;
     }
 }

--- a/src/core/hle/kernel/vm_manager.cpp
+++ b/src/core/hle/kernel/vm_manager.cpp
@@ -1026,7 +1026,7 @@ ResultVal<std::size_t> VMManager::SizeOfUnmappablePhysicalMemoryInRange(VAddr ad
 }
 
 u64 VMManager::GetTotalPhysicalMemoryAvailable() const {
-    LOG_WARNING(Kernel, "(STUBBED) called");
+    LOG_STUBBED(Kernel, "(STUBBED) called");
     return 0xF8000000;
 }
 

--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -247,14 +247,14 @@ public:
 
 private:
     void CheckAvailability(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
+        LOG_STUBBED(Service_ACC, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
         rb.Push(false); // TODO: Check when this is supposed to return true and when not
     }
 
     void GetAccountId(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
+        LOG_STUBBED(Service_ACC, "(STUBBED) called");
         // Should return a nintendo account ID
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
@@ -311,7 +311,7 @@ void Module::Interface::GetProfile(Kernel::HLERequestContext& ctx) {
 }
 
 void Module::Interface::IsUserRegistrationRequestPermitted(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_ACC, "(STUBBED) called");
+    LOG_STUBBED(Service_ACC, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.Push(profile_manager->CanSystemRegisterUser());

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -92,7 +92,7 @@ void IWindowController::GetAppletResourceUserId(Kernel::HLERequestContext& ctx) 
 }
 
 void IWindowController::AcquireForegroundRights(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
@@ -366,7 +366,7 @@ void ISelfController::LeaveFatalSection(Kernel::HLERequestContext& ctx) {
 }
 
 void ISelfController::GetLibraryAppletLaunchableEvent(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     launchable_event.writable->Signal();
 
@@ -376,7 +376,7 @@ void ISelfController::GetLibraryAppletLaunchableEvent(Kernel::HLERequestContext&
 }
 
 void ISelfController::SetScreenShotPermission(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
@@ -386,7 +386,7 @@ void ISelfController::SetOperationModeChangedNotification(Kernel::HLERequestCont
     IPC::RequestParser rp{ctx};
 
     bool flag = rp.Pop<bool>();
-    LOG_WARNING(Service_AM, "(STUBBED) called flag={}", flag);
+    LOG_STUBBED(Service_AM, "(STUBBED) called flag={}", flag);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
@@ -396,7 +396,7 @@ void ISelfController::SetPerformanceModeChangedNotification(Kernel::HLERequestCo
     IPC::RequestParser rp{ctx};
 
     bool flag = rp.Pop<bool>();
-    LOG_WARNING(Service_AM, "(STUBBED) called flag={}", flag);
+    LOG_STUBBED(Service_AM, "(STUBBED) called flag={}", flag);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
@@ -414,7 +414,7 @@ void ISelfController::SetFocusHandlingMode(Kernel::HLERequestContext& ctx) {
     };
     const auto flags = rp.PopRaw<FocusHandlingModeParams>();
 
-    LOG_WARNING(Service_AM, "(STUBBED) called. unknown0={}, unknown1={}, unknown2={}",
+    LOG_STUBBED(Service_AM, "(STUBBED) called. unknown0={}, unknown1={}, unknown2={}",
                 flags.unknown0, flags.unknown1, flags.unknown2);
 
     IPC::ResponseBuilder rb{ctx, 2};
@@ -422,7 +422,7 @@ void ISelfController::SetFocusHandlingMode(Kernel::HLERequestContext& ctx) {
 }
 
 void ISelfController::SetRestartMessageEnabled(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
@@ -434,21 +434,21 @@ void ISelfController::SetOutOfFocusSuspendingEnabled(Kernel::HLERequestContext& 
     IPC::RequestParser rp{ctx};
 
     bool enabled = rp.Pop<bool>();
-    LOG_WARNING(Service_AM, "(STUBBED) called enabled={}", enabled);
+    LOG_STUBBED(Service_AM, "(STUBBED) called enabled={}", enabled);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void ISelfController::SetScreenShotImageOrientation(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void ISelfController::CreateManagedDisplayLayer(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     // TODO(Subv): Find out how AM determines the display to use, for now just
     // create the layer in the Default display.
@@ -461,7 +461,7 @@ void ISelfController::CreateManagedDisplayLayer(Kernel::HLERequestContext& ctx) 
 }
 
 void ISelfController::SetHandlesRequestToDisplay(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
@@ -470,7 +470,7 @@ void ISelfController::SetHandlesRequestToDisplay(Kernel::HLERequestContext& ctx)
 void ISelfController::SetIdleTimeDetectionExtension(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     idle_time_detection_extension = rp.Pop<u32>();
-    LOG_WARNING(Service_AM, "(STUBBED) called idle_time_detection_extension={}",
+    LOG_STUBBED(Service_AM, "(STUBBED) called idle_time_detection_extension={}",
                 idle_time_detection_extension);
 
     IPC::ResponseBuilder rb{ctx, 2};
@@ -478,7 +478,7 @@ void ISelfController::SetIdleTimeDetectionExtension(Kernel::HLERequestContext& c
 }
 
 void ISelfController::GetIdleTimeDetectionExtension(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
@@ -665,7 +665,7 @@ void ICommonStateGetter::ReceiveMessage(Kernel::HLERequestContext& ctx) {
 }
 
 void ICommonStateGetter::GetCurrentFocusState(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
@@ -1114,7 +1114,7 @@ IApplicationFunctions::IApplicationFunctions(Core::System& system_)
 IApplicationFunctions::~IApplicationFunctions() = default;
 
 void IApplicationFunctions::EnableApplicationCrashReport(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
@@ -1122,14 +1122,14 @@ void IApplicationFunctions::EnableApplicationCrashReport(Kernel::HLERequestConte
 
 void IApplicationFunctions::InitializeApplicationCopyrightFrameBuffer(
     Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IApplicationFunctions::SetApplicationCopyrightImage(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
@@ -1139,7 +1139,7 @@ void IApplicationFunctions::SetApplicationCopyrightVisibility(Kernel::HLERequest
     IPC::RequestParser rp{ctx};
     const auto is_visible = rp.Pop<bool>();
 
-    LOG_WARNING(Service_AM, "(STUBBED) called, is_visible={}", is_visible);
+    LOG_STUBBED(Service_AM, "(STUBBED) called, is_visible={}", is_visible);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
@@ -1147,7 +1147,7 @@ void IApplicationFunctions::SetApplicationCopyrightVisibility(Kernel::HLERequest
 
 void IApplicationFunctions::BeginBlockingHomeButtonShortAndLongPressed(
     Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
@@ -1155,21 +1155,21 @@ void IApplicationFunctions::BeginBlockingHomeButtonShortAndLongPressed(
 
 void IApplicationFunctions::EndBlockingHomeButtonShortAndLongPressed(
     Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IApplicationFunctions::BeginBlockingHomeButton(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IApplicationFunctions::EndBlockingHomeButton(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
@@ -1230,7 +1230,7 @@ void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
 
 void IApplicationFunctions::CreateApplicationAndRequestToStartForQuest(
     Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
@@ -1261,14 +1261,14 @@ void IApplicationFunctions::SetTerminateResult(Kernel::HLERequestContext& ctx) {
 
     IPC::RequestParser rp{ctx};
     u32 result = rp.Pop<u32>();
-    LOG_WARNING(Service_AM, "(STUBBED) called, result=0x{:08X}", result);
+    LOG_STUBBED(Service_AM, "(STUBBED) called, result=0x{:08X}", result);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IApplicationFunctions::GetDisplayVersion(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 6};
     rb.Push(RESULT_SUCCESS);
@@ -1319,21 +1319,21 @@ void IApplicationFunctions::GetDesiredLanguage(Kernel::HLERequestContext& ctx) {
 }
 
 void IApplicationFunctions::InitializeGamePlayRecording(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IApplicationFunctions::SetGamePlayRecordingState(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IApplicationFunctions::NotifyRunning(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
@@ -1341,7 +1341,7 @@ void IApplicationFunctions::NotifyRunning(Kernel::HLERequestContext& ctx) {
 }
 
 void IApplicationFunctions::GetPseudoDeviceId(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 6};
     rb.Push(RESULT_SUCCESS);
@@ -1402,7 +1402,7 @@ void IApplicationFunctions::GetSaveDataSize(Kernel::HLERequestContext& ctx) {
 }
 
 void IApplicationFunctions::QueryApplicationPlayStatistics(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
@@ -1410,7 +1410,7 @@ void IApplicationFunctions::QueryApplicationPlayStatistics(Kernel::HLERequestCon
 }
 
 void IApplicationFunctions::QueryApplicationPlayStatisticsByUid(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
@@ -1418,7 +1418,7 @@ void IApplicationFunctions::QueryApplicationPlayStatisticsByUid(Kernel::HLEReque
 }
 
 void IApplicationFunctions::GetGpuErrorDetectedSystemEvent(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2, 1};
     rb.Push(RESULT_SUCCESS);
@@ -1461,7 +1461,7 @@ IHomeMenuFunctions::IHomeMenuFunctions() : ServiceFramework("IHomeMenuFunctions"
 IHomeMenuFunctions::~IHomeMenuFunctions() = default;
 
 void IHomeMenuFunctions::RequestToGetForeground(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AM, "(STUBBED) called");
+    LOG_STUBBED(Service_AM, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/am/applets/general_backend.cpp
+++ b/src/core/hle/service/am/applets/general_backend.cpp
@@ -23,17 +23,18 @@ static void LogCurrentStorage(AppletDataBroker& broker, std::string_view prefix)
     std::unique_ptr<IStorage> storage = broker.PopNormalDataToApplet();
     for (; storage != nullptr; storage = broker.PopNormalDataToApplet()) {
         const auto data = storage->GetData();
-        LOG_INFO(Service_AM,
-                 "called (STUBBED), during {} received normal data with size={:08X}, data={}",
-                 prefix, data.size(), Common::HexToString(data));
+        LOG_STUBBED(Service_AM,
+                    "called (STUBBED), during {} received normal data with size={:08X}, data={}",
+                    prefix, data.size(), Common::HexToString(data));
     }
 
     storage = broker.PopInteractiveDataToApplet();
     for (; storage != nullptr; storage = broker.PopInteractiveDataToApplet()) {
         const auto data = storage->GetData();
-        LOG_INFO(Service_AM,
-                 "called (STUBBED), during {} received interactive data with size={:08X}, data={}",
-                 prefix, data.size(), Common::HexToString(data));
+        LOG_STUBBED(
+            Service_AM,
+            "called (STUBBED), during {} received interactive data with size={:08X}, data={}",
+            prefix, data.size(), Common::HexToString(data));
     }
 }
 
@@ -208,7 +209,7 @@ StubApplet::StubApplet(Core::System& system_, AppletId id_)
 StubApplet::~StubApplet() = default;
 
 void StubApplet::Initialize() {
-    LOG_WARNING(Service_AM, "called (STUBBED)");
+    LOG_STUBBED(Service_AM, "called (STUBBED)");
     Applet::Initialize();
 
     const auto data = broker.PeekDataToAppletForDebug();
@@ -221,17 +222,17 @@ void StubApplet::Initialize() {
 }
 
 bool StubApplet::TransactionComplete() const {
-    LOG_WARNING(Service_AM, "called (STUBBED)");
+    LOG_STUBBED(Service_AM, "called (STUBBED)");
     return true;
 }
 
 ResultCode StubApplet::GetStatus() const {
-    LOG_WARNING(Service_AM, "called (STUBBED)");
+    LOG_STUBBED(Service_AM, "called (STUBBED)");
     return RESULT_SUCCESS;
 }
 
 void StubApplet::ExecuteInteractive() {
-    LOG_WARNING(Service_AM, "called (STUBBED)");
+    LOG_STUBBED(Service_AM, "called (STUBBED)");
     LogCurrentStorage(broker, "ExecuteInteractive");
 
     broker.PushNormalDataFromApplet(IStorage{std::vector<u8>(0x1000)});
@@ -240,7 +241,7 @@ void StubApplet::ExecuteInteractive() {
 }
 
 void StubApplet::Execute() {
-    LOG_WARNING(Service_AM, "called (STUBBED)");
+    LOG_STUBBED(Service_AM, "called (STUBBED)");
     LogCurrentStorage(broker, "Execute");
 
     broker.PushNormalDataFromApplet(IStorage{std::vector<u8>(0x1000)});

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -183,7 +183,7 @@ void AOC_U::PrepareAddOnContent(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto [addon_index, process_id] = rp.PopRaw<Parameters>();
 
-    LOG_WARNING(Service_AOC, "(STUBBED) called with addon_index={}, process_id={}", addon_index,
+    LOG_STUBBED(Service_AOC, "(STUBBED) called with addon_index={}, process_id={}", addon_index,
                 process_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
@@ -191,7 +191,7 @@ void AOC_U::PrepareAddOnContent(Kernel::HLERequestContext& ctx) {
 }
 
 void AOC_U::GetAddOnContentListChangedEvent(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_AOC, "(STUBBED) called");
+    LOG_STUBBED(Service_AOC, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2, 1};
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -127,7 +127,7 @@ private:
     }
 
     void AppendAudioOutBufferImpl(Kernel::HLERequestContext& ctx) {
-        LOG_DEBUG(Service_Audio, "(STUBBED) called {}", ctx.Description());
+        LOG_STUBBED(Service_Audio, "(STUBBED) called {}", ctx.Description());
         IPC::RequestParser rp{ctx};
 
         const auto& input_buffer{ctx.ReadBuffer()};

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -92,7 +92,7 @@ private:
     }
 
     void RequestUpdateImpl(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        LOG_STUBBED(Service_Audio, "(STUBBED) called");
 
         ctx.WriteBuffer(renderer->UpdateAudioRenderer(ctx.ReadBuffer()));
         IPC::ResponseBuilder rb{ctx, 2};
@@ -100,7 +100,7 @@ private:
     }
 
     void Start(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        LOG_STUBBED(Service_Audio, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
 
@@ -108,7 +108,7 @@ private:
     }
 
     void Stop(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        LOG_STUBBED(Service_Audio, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
 
@@ -116,7 +116,7 @@ private:
     }
 
     void QuerySystemEvent(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        LOG_STUBBED(Service_Audio, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 1};
         rb.Push(RESULT_SUCCESS);
@@ -245,7 +245,7 @@ private:
         const auto device_name_buffer = ctx.ReadBuffer();
         const std::string name = Common::StringFromBuffer(device_name_buffer);
 
-        LOG_WARNING(Service_Audio, "(STUBBED) called. name={}, volume={}", name, volume);
+        LOG_STUBBED(Service_Audio, "(STUBBED) called. name={}, volume={}", name, volume);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -257,7 +257,7 @@ private:
         const auto device_name_buffer = ctx.ReadBuffer();
         const std::string name = Common::StringFromBuffer(device_name_buffer);
 
-        LOG_WARNING(Service_Audio, "(STUBBED) called. name={}", name);
+        LOG_STUBBED(Service_Audio, "(STUBBED) called. name={}", name);
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
@@ -265,7 +265,7 @@ private:
     }
 
     void GetActiveAudioDeviceName(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        LOG_STUBBED(Service_Audio, "(STUBBED) called");
 
         // Currently set to always be TV audio output.
         const auto& device_name = audio_device_names[2];
@@ -280,7 +280,7 @@ private:
     }
 
     void QueryAudioDeviceSystemEvent(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        LOG_STUBBED(Service_Audio, "(STUBBED) called");
 
         buffer_event.writable->Signal();
 
@@ -290,7 +290,7 @@ private:
     }
 
     void GetActiveChannelCount(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        LOG_STUBBED(Service_Audio, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
@@ -299,7 +299,7 @@ private:
 
     // Should be similar to QueryAudioDeviceOutputEvent
     void QueryAudioDeviceInputEvent(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_Audio, "(STUBBED) called");
+        LOG_STUBBED(Service_Audio, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 1};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/btdrv/btdrv.cpp
+++ b/src/core/hle/service/btdrv/btdrv.cpp
@@ -39,7 +39,7 @@ public:
 
 private:
     void RegisterBleEvent(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_BTM, "(STUBBED) called");
+        LOG_STUBBED(Service_BTM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 1};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/btm/btm.cpp
+++ b/src/core/hle/service/btm/btm.cpp
@@ -67,7 +67,7 @@ public:
 
 private:
     void AcquireBleScanEvent(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_BTM, "(STUBBED) called");
+        LOG_STUBBED(Service_BTM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 1};
         rb.Push(RESULT_SUCCESS);
@@ -75,7 +75,7 @@ private:
     }
 
     void AcquireBleConnectionEvent(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_BTM, "(STUBBED) called");
+        LOG_STUBBED(Service_BTM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 1};
         rb.Push(RESULT_SUCCESS);
@@ -83,7 +83,7 @@ private:
     }
 
     void AcquireBleServiceDiscoveryEvent(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_BTM, "(STUBBED) called");
+        LOG_STUBBED(Service_BTM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 1};
         rb.Push(RESULT_SUCCESS);
@@ -91,7 +91,7 @@ private:
     }
 
     void AcquireBleMtuConfigEvent(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_BTM, "(STUBBED) called");
+        LOG_STUBBED(Service_BTM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 1};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -471,7 +471,7 @@ public:
     }
 
     void Commit(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_FS, "(STUBBED) called");
+        LOG_STUBBED(Service_FS, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -784,7 +784,7 @@ void FSP_SRV::OpenFileSystemWithPatch(Kernel::HLERequestContext& ctx) {
 
     const auto type = rp.PopRaw<FileSystemType>();
     const auto title_id = rp.PopRaw<u64>();
-    LOG_WARNING(Service_FS, "(STUBBED) called with type={}, title_id={:016X}",
+    LOG_STUBBED(Service_FS, "(STUBBED) called with type={}, title_id={:016X}",
                 static_cast<u8>(type), title_id);
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 0};
@@ -854,7 +854,7 @@ void FSP_SRV::OpenSaveDataFileSystem(Kernel::HLERequestContext& ctx) {
 }
 
 void FSP_SRV::OpenReadOnlySaveDataFileSystem(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_FS, "(STUBBED) called, delegating to 51 OpenSaveDataFilesystem");
+    LOG_STUBBED(Service_FS, "(STUBBED) called, delegating to 51 OpenSaveDataFilesystem");
     OpenSaveDataFileSystem(ctx);
 }
 

--- a/src/core/hle/service/friend/friend.cpp
+++ b/src/core/hle/service/friend/friend.cpp
@@ -123,14 +123,14 @@ private:
 
     void DeclareCloseOnlinePlaySession(Kernel::HLERequestContext& ctx) {
         // Stub used by Splatoon 2
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
+        LOG_STUBBED(Service_ACC, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
 
     void UpdateUserPresence(Kernel::HLERequestContext& ctx) {
         // Stub used by Retro City Rampage
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
+        LOG_STUBBED(Service_ACC, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
@@ -141,7 +141,7 @@ private:
         const auto uuid = rp.PopRaw<Common::UUID>();
         [[maybe_unused]] const auto filter = rp.PopRaw<SizedFriendFilter>();
         const auto pid = rp.Pop<u64>();
-        LOG_WARNING(Service_ACC, "(STUBBED) called, offset={}, uuid={}, pid={}", friend_offset,
+        LOG_STUBBED(Service_ACC, "(STUBBED) called, offset={}, uuid={}, pid={}", friend_offset,
                     uuid.Format(), pid);
 
         IPC::ResponseBuilder rb{ctx, 3};

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -487,7 +487,7 @@ void Controller_NPad::SetNpadMode(u32 npad_id, NPadAssignments assignment_mode) 
 
 void Controller_NPad::VibrateController(const std::vector<u32>& controller_ids,
                                         const std::vector<Vibration>& vibrations) {
-    LOG_WARNING(Service_HID, "(STUBBED) called");
+    LOG_STUBBED(Service_HID, "(STUBBED) called");
 
     if (!can_controllers_vibrate) {
         return;

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -134,7 +134,7 @@ public:
 
 private:
     void ActivateVibrationDevice(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_HID, "(STUBBED) called");
+        LOG_STUBBED(Service_HID, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -394,7 +394,7 @@ void Hid::StartSixAxisSensor(Kernel::HLERequestContext& ctx) {
     const auto handle{rp.Pop<u32>()};
     const auto applet_resource_user_id{rp.Pop<u64>()};
 
-    LOG_WARNING(Service_HID, "(STUBBED) called, handle={}, applet_resource_user_id={}", handle,
+    LOG_STUBBED(Service_HID, "(STUBBED) called, handle={}, applet_resource_user_id={}", handle,
                 applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
@@ -407,7 +407,7 @@ void Hid::SetGyroscopeZeroDriftMode(Kernel::HLERequestContext& ctx) {
     const auto drift_mode{rp.Pop<u32>()};
     const auto applet_resource_user_id{rp.Pop<u64>()};
 
-    LOG_WARNING(Service_HID,
+    LOG_STUBBED(Service_HID,
                 "(STUBBED) called, handle={}, drift_mode={}, applet_resource_user_id={}", handle,
                 drift_mode, applet_resource_user_id);
 
@@ -420,7 +420,7 @@ void Hid::IsSixAxisSensorAtRest(Kernel::HLERequestContext& ctx) {
     const auto handle{rp.Pop<u32>()};
     const auto applet_resource_user_id{rp.Pop<u64>()};
 
-    LOG_WARNING(Service_HID, "(STUBBED) called, handle={}, applet_resource_user_id={}", handle,
+    LOG_STUBBED(Service_HID, "(STUBBED) called, handle={}, applet_resource_user_id={}", handle,
                 applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 3};
@@ -562,7 +562,7 @@ void Hid::SetNpadJoyAssignmentModeSingleByDefault(Kernel::HLERequestContext& ctx
     const auto npad_id{rp.Pop<u32>()};
     const auto applet_resource_user_id{rp.Pop<u64>()};
 
-    LOG_WARNING(Service_HID, "(STUBBED) called, npad_id={}, applet_resource_user_id={}", npad_id,
+    LOG_STUBBED(Service_HID, "(STUBBED) called, npad_id={}, applet_resource_user_id={}", npad_id,
                 applet_resource_user_id);
 
     auto& controller = applet_resource->GetController<Controller_NPad>(HidController::NPad);
@@ -648,7 +648,7 @@ void Hid::SetNpadHandheldActivationMode(Kernel::HLERequestContext& ctx) {
     const auto applet_resource_user_id{rp.Pop<u64>()};
     const auto mode{rp.Pop<u64>()};
 
-    LOG_WARNING(Service_HID, "(STUBBED) called, applet_resource_user_id={}, mode={}",
+    LOG_STUBBED(Service_HID, "(STUBBED) called, applet_resource_user_id={}, mode={}",
                 applet_resource_user_id, mode);
 
     IPC::ResponseBuilder rb{ctx, 2};
@@ -659,7 +659,7 @@ void Hid::GetNpadHandheldActivationMode(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto applet_resource_user_id{rp.Pop<u64>()};
 
-    LOG_WARNING(Service_HID, "(STUBBED) called, applet_resource_user_id={}",
+    LOG_STUBBED(Service_HID, "(STUBBED) called, applet_resource_user_id={}",
                 applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
@@ -801,7 +801,7 @@ void Hid::ActivateConsoleSixAxisSensor(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto applet_resource_user_id{rp.Pop<u64>()};
 
-    LOG_WARNING(Service_HID, "(STUBBED) called, applet_resource_user_id={}",
+    LOG_STUBBED(Service_HID, "(STUBBED) called, applet_resource_user_id={}",
                 applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
@@ -813,7 +813,7 @@ void Hid::StartConsoleSixAxisSensor(Kernel::HLERequestContext& ctx) {
     const auto handle{rp.Pop<u32>()};
     const auto applet_resource_user_id{rp.Pop<u64>()};
 
-    LOG_WARNING(Service_HID, "(STUBBED) called, handle={}, applet_resource_user_id={}", handle,
+    LOG_STUBBED(Service_HID, "(STUBBED) called, handle={}, applet_resource_user_id={}", handle,
                 applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
@@ -824,7 +824,7 @@ void Hid::StopSixAxisSensor(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto handle{rp.Pop<u32>()};
 
-    LOG_WARNING(Service_HID, "(STUBBED) called, handle={}", handle);
+    LOG_STUBBED(Service_HID, "(STUBBED) called, handle={}", handle);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
@@ -835,7 +835,7 @@ void Hid::SetIsPalmaAllConnectable(Kernel::HLERequestContext& ctx) {
     const auto applet_resource_user_id{rp.Pop<u64>()};
     const auto unknown{rp.Pop<u32>()};
 
-    LOG_WARNING(Service_HID, "(STUBBED) called, applet_resource_user_id={}, unknown={}",
+    LOG_STUBBED(Service_HID, "(STUBBED) called, applet_resource_user_id={}, unknown={}",
                 applet_resource_user_id, unknown);
 
     IPC::ResponseBuilder rb{ctx, 2};
@@ -846,7 +846,7 @@ void Hid::SetPalmaBoostMode(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto unknown{rp.Pop<u32>()};
 
-    LOG_WARNING(Service_HID, "(STUBBED) called, unknown={}", unknown);
+    LOG_STUBBED(Service_HID, "(STUBBED) called, unknown={}", unknown);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/hid/irs.cpp
+++ b/src/core/hle/service/hid/irs.cpp
@@ -44,14 +44,14 @@ IRS::IRS(Core::System& system) : ServiceFramework{"irs"}, system(system) {
 }
 
 void IRS::ActivateIrsensor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IRS::DeactivateIrsensor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
@@ -66,35 +66,35 @@ void IRS::GetIrsensorSharedMemoryHandle(Kernel::HLERequestContext& ctx) {
 }
 
 void IRS::StopImageProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IRS::RunMomentProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IRS::RunClusteringProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IRS::RunImageTransferProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IRS::GetImageTransferProcessorState(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 5};
     rb.Push(RESULT_SUCCESS);
@@ -103,14 +103,14 @@ void IRS::GetImageTransferProcessorState(Kernel::HLERequestContext& ctx) {
 }
 
 void IRS::RunTeraPluginProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IRS::GetNpadIrCameraHandle(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
@@ -118,56 +118,56 @@ void IRS::GetNpadIrCameraHandle(Kernel::HLERequestContext& ctx) {
 }
 
 void IRS::RunPointingProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IRS::SuspendImageProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IRS::CheckFirmwareVersion(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IRS::SetFunctionLevel(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IRS::RunImageTransferExProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IRS::RunIrLedProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IRS::StopImageProcessorAsync(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void IRS::ActivateIrsensorWithFunctionLevel(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    LOG_STUBBED(Service_IRS, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -439,7 +439,7 @@ public:
     }
 
     void Initialize(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_LDR, "(STUBBED) called");
+        LOG_STUBBED(Service_LDR, "(STUBBED) called");
 
         initialized = true;
 

--- a/src/core/hle/service/mm/mm_u.cpp
+++ b/src/core/hle/service/mm/mm_u.cpp
@@ -30,14 +30,14 @@ public:
 
 private:
     void Initialize(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_MM, "(STUBBED) called");
+        LOG_STUBBED(Service_MM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
 
     void Finalize(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_MM, "(STUBBED) called");
+        LOG_STUBBED(Service_MM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -47,7 +47,7 @@ private:
         IPC::RequestParser rp{ctx};
         min = rp.Pop<u32>();
         max = rp.Pop<u32>();
-        LOG_WARNING(Service_MM, "(STUBBED) called, min=0x{:X}, max=0x{:X}", min, max);
+        LOG_STUBBED(Service_MM, "(STUBBED) called, min=0x{:X}, max=0x{:X}", min, max);
 
         current = min;
         IPC::ResponseBuilder rb{ctx, 2};
@@ -55,7 +55,7 @@ private:
     }
 
     void Get(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_MM, "(STUBBED) called");
+        LOG_STUBBED(Service_MM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
@@ -63,7 +63,7 @@ private:
     }
 
     void InitializeWithId(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_MM, "(STUBBED) called");
+        LOG_STUBBED(Service_MM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
@@ -71,7 +71,7 @@ private:
     }
 
     void FinalizeWithId(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_MM, "(STUBBED) called");
+        LOG_STUBBED(Service_MM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -82,7 +82,7 @@ private:
         u32 input_id = rp.Pop<u32>();
         min = rp.Pop<u32>();
         max = rp.Pop<u32>();
-        LOG_WARNING(Service_MM, "(STUBBED) called, input_id=0x{:X}, min=0x{:X}, max=0x{:X}",
+        LOG_STUBBED(Service_MM, "(STUBBED) called, input_id=0x{:X}, min=0x{:X}, max=0x{:X}",
                     input_id, min, max);
 
         current = min;
@@ -91,7 +91,7 @@ private:
     }
 
     void GetWithId(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_MM, "(STUBBED) called");
+        LOG_STUBBED(Service_MM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/nfc/nfc.cpp
+++ b/src/core/hle/service/nfc/nfc.cpp
@@ -154,7 +154,7 @@ private:
     }
 
     void GetStateOld(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NFC, "(STUBBED) called");
+        LOG_STUBBED(Service_NFC, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
@@ -162,7 +162,7 @@ private:
     }
 
     void FinalizeOld(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NFC, "(STUBBED) called");
+        LOG_STUBBED(Service_NFC, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/nfp/nfp.cpp
+++ b/src/core/hle/service/nfp/nfp.cpp
@@ -260,7 +260,7 @@ private:
     }
 
     void AttachAvailabilityChangeEvent(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NFP, "(STUBBED) called");
+        LOG_STUBBED(Service_NFP, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 1};
         rb.Push(RESULT_SUCCESS);
@@ -268,7 +268,7 @@ private:
     }
 
     void GetRegisterInfo(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NFP, "(STUBBED) called");
+        LOG_STUBBED(Service_NFP, "(STUBBED) called");
 
         // TODO(ogniK): Pull Mii and owner data from amiibo
 
@@ -277,7 +277,7 @@ private:
     }
 
     void GetCommonInfo(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NFP, "(STUBBED) called");
+        LOG_STUBBED(Service_NFP, "(STUBBED) called");
 
         // TODO(ogniK): Pull common information from amiibo
 
@@ -290,13 +290,13 @@ private:
     }
 
     void OpenApplicationArea(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NFP, "(STUBBED) called");
+        LOG_STUBBED(Service_NFP, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(ErrCodes::ERR_NO_APPLICATION_AREA);
     }
 
     void GetApplicationAreaSize(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NFP, "(STUBBED) called");
+        LOG_STUBBED(Service_NFP, "(STUBBED) called");
         // We don't need to worry about this since we can just open the file
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
@@ -304,7 +304,7 @@ private:
     }
 
     void GetApplicationArea(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NFP, "(STUBBED) called");
+        LOG_STUBBED(Service_NFP, "(STUBBED) called");
 
         // TODO(ogniK): Pull application area from amiibo
 

--- a/src/core/hle/service/nifm/nifm.cpp
+++ b/src/core/hle/service/nifm/nifm.cpp
@@ -76,14 +76,14 @@ public:
 
 private:
     void Submit(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        LOG_STUBBED(Service_NIFM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
 
     void GetRequestState(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        LOG_STUBBED(Service_NIFM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
@@ -96,14 +96,14 @@ private:
     }
 
     void GetResult(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        LOG_STUBBED(Service_NIFM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
 
     void GetSystemEventReadableHandles(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        LOG_STUBBED(Service_NIFM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 2};
         rb.Push(RESULT_SUCCESS);
@@ -111,14 +111,14 @@ private:
     }
 
     void Cancel(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        LOG_STUBBED(Service_NIFM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
 
     void SetConnectionConfirmationOption(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        LOG_STUBBED(Service_NIFM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -146,7 +146,7 @@ public:
 private:
     void GetClientId(Kernel::HLERequestContext& ctx) {
         static constexpr u32 client_id = 1;
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        LOG_STUBBED(Service_NIFM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
@@ -169,7 +169,7 @@ private:
         rb.PushIpcInterface<IRequest>(system);
     }
     void RemoveNetworkProfile(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        LOG_STUBBED(Service_NIFM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -189,14 +189,14 @@ private:
         rb.PushRaw<u128>(uuid);
     }
     void IsWirelessCommunicationEnabled(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        LOG_STUBBED(Service_NIFM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
         rb.Push<u8>(0);
     }
     void IsEthernetCommunicationEnabled(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        LOG_STUBBED(Service_NIFM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
@@ -207,7 +207,7 @@ private:
         }
     }
     void IsAnyInternetRequestAccepted(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIFM, "(STUBBED) called");
+        LOG_STUBBED(Service_NIFM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/nim/nim.cpp
+++ b/src/core/hle/service/nim/nim.cpp
@@ -224,14 +224,14 @@ private:
 
     // TODO(ogniK): Do we need these?
     void SuspendAutonomicTimeCorrection(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIM, "(STUBBED) called");
+        LOG_STUBBED(Service_NIM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
 
     void ResumeAutonomicTimeCorrection(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_NIM, "(STUBBED) called");
+        LOG_STUBBED(Service_NIM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
@@ -59,7 +59,7 @@ u32 nvhost_as_gpu::ioctl(Ioctl command, const std::vector<u8>& input, const std:
 u32 nvhost_as_gpu::InitalizeEx(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlInitalizeEx params{};
     std::memcpy(&params, input.data(), input.size());
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, big_page_size=0x{:X}", params.big_page_size);
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called, big_page_size=0x{:X}", params.big_page_size);
 
     return 0;
 }
@@ -85,7 +85,7 @@ u32 nvhost_as_gpu::AllocateSpace(const std::vector<u8>& input, std::vector<u8>& 
 u32 nvhost_as_gpu::Remap(const std::vector<u8>& input, std::vector<u8>& output) {
     std::size_t num_entries = input.size() / sizeof(IoctlRemapEntry);
 
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, num_entries=0x{:X}", num_entries);
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called, num_entries=0x{:X}", num_entries);
 
     std::vector<IoctlRemapEntry> entries(num_entries);
     std::memcpy(entries.data(), input.data(), input.size());
@@ -199,7 +199,7 @@ u32 nvhost_as_gpu::BindChannel(const std::vector<u8>& input, std::vector<u8>& ou
 u32 nvhost_as_gpu::GetVARegions(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlGetVaRegions params{};
     std::memcpy(&params, input.data(), input.size());
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, buf_addr={:X}, buf_size={:X}", params.buf_addr,
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called, buf_addr={:X}, buf_size={:X}", params.buf_addr,
                 params.buf_size);
 
     params.buf_size = 0x30;

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -160,7 +160,7 @@ u32 nvhost_ctrl::IocCtrlEventSignal(const std::vector<u8>& input, std::vector<u8
     // TODO(Blinkhawk): This is normally called when an NvEvents timeout on WaitSynchronization
     // It is believed from RE to cancel the GPU Event. However, better research is required
     u32 event_id = params.user_event_id & 0x00FF;
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, user_event_id: {:X}", event_id);
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called, user_event_id: {:X}", event_id);
     if (event_id >= MaxNvEvents) {
         return NvResult::BadParameter;
     }

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
@@ -161,7 +161,7 @@ u32 nvhost_ctrl_gpu::ZCullGetInfo(const std::vector<u8>& input, std::vector<u8>&
 }
 
 u32 nvhost_ctrl_gpu::ZBCSetTable(const std::vector<u8>& input, std::vector<u8>& output) {
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called");
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called");
 
     IoctlZbcSetTable params{};
     std::memcpy(&params, input.data(), input.size());
@@ -171,7 +171,7 @@ u32 nvhost_ctrl_gpu::ZBCSetTable(const std::vector<u8>& input, std::vector<u8>& 
 }
 
 u32 nvhost_ctrl_gpu::ZBCQueryTable(const std::vector<u8>& input, std::vector<u8>& output) {
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called");
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called");
 
     IoctlZbcQueryTable params{};
     std::memcpy(&params, input.data(), input.size());
@@ -181,7 +181,7 @@ u32 nvhost_ctrl_gpu::ZBCQueryTable(const std::vector<u8>& input, std::vector<u8>
 }
 
 u32 nvhost_ctrl_gpu::FlushL2(const std::vector<u8>& input, std::vector<u8>& output) {
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called");
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called");
 
     IoctlFlushL2 params{};
     std::memcpy(&params, input.data(), input.size());

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
@@ -101,7 +101,7 @@ u32 nvhost_gpu::ZCullBind(const std::vector<u8>& input, std::vector<u8>& output)
 u32 nvhost_gpu::SetErrorNotifier(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlSetErrorNotifier params{};
     std::memcpy(&params, input.data(), input.size());
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, offset={:X}, size={:X}, mem={:X}", params.offset,
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called, offset={:X}, size={:X}, mem={:X}", params.offset,
                 params.size, params.mem);
 
     std::memcpy(output.data(), &params, output.size());
@@ -110,7 +110,7 @@ u32 nvhost_gpu::SetErrorNotifier(const std::vector<u8>& input, std::vector<u8>& 
 
 u32 nvhost_gpu::SetChannelPriority(const std::vector<u8>& input, std::vector<u8>& output) {
     std::memcpy(&channel_priority, input.data(), input.size());
-    LOG_DEBUG(Service_NVDRV, "(STUBBED) called, priority={:X}", channel_priority);
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called, priority={:X}", channel_priority);
 
     return 0;
 }
@@ -135,7 +135,7 @@ u32 nvhost_gpu::AllocGPFIFOEx2(const std::vector<u8>& input, std::vector<u8>& ou
 u32 nvhost_gpu::AllocateObjectContext(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlAllocObjCtx params{};
     std::memcpy(&params, input.data(), input.size());
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, class_num={:X}, flags={:X}", params.class_num,
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called, class_num={:X}, flags={:X}", params.class_num,
                 params.flags);
 
     params.obj_id = 0x0;

--- a/src/core/hle/service/nvdrv/devices/nvmap.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvmap.cpp
@@ -143,7 +143,7 @@ u32 nvmap::IocFromId(const std::vector<u8>& input, std::vector<u8>& output) {
     IocFromIdParams params;
     std::memcpy(&params, input.data(), sizeof(params));
 
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called");
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called");
 
     auto itr = std::find_if(handles.begin(), handles.end(),
                             [&](const auto& entry) { return entry.second->id == params.id; });
@@ -173,7 +173,7 @@ u32 nvmap::IocParam(const std::vector<u8>& input, std::vector<u8>& output) {
     IocParamParams params;
     std::memcpy(&params, input.data(), sizeof(params));
 
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called type={}", params.param);
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called type={}", params.param);
 
     auto object = GetObject(params.handle);
     if (!object) {
@@ -218,7 +218,7 @@ u32 nvmap::IocFree(const std::vector<u8>& input, std::vector<u8>& output) {
     IocFreeParams params;
     std::memcpy(&params, input.data(), sizeof(params));
 
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called");
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called");
 
     auto itr = handles.find(params.handle);
     if (itr == handles.end()) {

--- a/src/core/hle/service/nvdrv/interface.cpp
+++ b/src/core/hle/service/nvdrv/interface.cpp
@@ -117,7 +117,7 @@ void NVDRV::Close(Kernel::HLERequestContext& ctx) {
 }
 
 void NVDRV::Initialize(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called");
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
@@ -129,7 +129,7 @@ void NVDRV::QueryEvent(Kernel::HLERequestContext& ctx) {
     u32 fd = rp.Pop<u32>();
     // TODO(Blinkhawk): Figure the meaning of the flag at bit 16
     u32 event_id = rp.Pop<u32>() & 0x000000FF;
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, fd={:X}, event_id={:X}", fd, event_id);
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called, fd={:X}, event_id={:X}", fd, event_id);
 
     IPC::ResponseBuilder rb{ctx, 3, 1};
     rb.Push(RESULT_SUCCESS);
@@ -147,7 +147,7 @@ void NVDRV::QueryEvent(Kernel::HLERequestContext& ctx) {
 void NVDRV::SetClientPID(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     pid = rp.Pop<u64>();
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, pid=0x{:X}", pid);
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called, pid=0x{:X}", pid);
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
@@ -155,14 +155,14 @@ void NVDRV::SetClientPID(Kernel::HLERequestContext& ctx) {
 }
 
 void NVDRV::FinishInitialize(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called");
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }
 
 void NVDRV::GetStatus(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called");
+    LOG_STUBBED(Service_NVDRV, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/nvflinger/buffer_queue.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue.cpp
@@ -104,7 +104,7 @@ void BufferQueue::ReleaseBuffer(u32 slot) {
 }
 
 u32 BufferQueue::Query(QueryType type) {
-    LOG_WARNING(Service, "(STUBBED) called type={}", static_cast<u32>(type));
+    LOG_STUBBED(Service, "(STUBBED) called type={}", static_cast<u32>(type));
 
     switch (type) {
     case QueryType::NativeWindowFormat:

--- a/src/core/hle/service/pctl/module.cpp
+++ b/src/core/hle/service/pctl/module.cpp
@@ -116,14 +116,14 @@ public:
 
 private:
     void Initialize(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_PCTL, "(STUBBED) called");
+        LOG_STUBBED(Service_PCTL, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 0};
         rb.Push(RESULT_SUCCESS);
     }
 
     void CheckFreeCommunicationPermission(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_PCTL, "(STUBBED) called");
+        LOG_STUBBED(Service_PCTL, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/ptm/psm.cpp
+++ b/src/core/hle/service/ptm/psm.cpp
@@ -48,7 +48,7 @@ public:
 
 private:
     void GetBatteryChargePercentage(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_PSM, "(STUBBED) called");
+        LOG_STUBBED(Service_PSM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
@@ -56,7 +56,7 @@ private:
     }
 
     void GetChargerType(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_PSM, "(STUBBED) called");
+        LOG_STUBBED(Service_PSM, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/sm/controller.cpp
+++ b/src/core/hle/service/sm/controller.cpp
@@ -34,13 +34,13 @@ void Controller::DuplicateSession(Kernel::HLERequestContext& ctx) {
 }
 
 void Controller::DuplicateSessionEx(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service, "(STUBBED) called, using DuplicateSession");
+    LOG_STUBBED(Service, "(STUBBED) called, using DuplicateSession");
 
     DuplicateSession(ctx);
 }
 
 void Controller::QueryPointerBufferSize(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service, "(STUBBED) called");
+    LOG_STUBBED(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -8,7 +8,7 @@
 namespace Service::Sockets {
 
 void BSD::RegisterClient(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service, "(STUBBED) called");
+    LOG_STUBBED(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 3};
 
@@ -17,7 +17,7 @@ void BSD::RegisterClient(Kernel::HLERequestContext& ctx) {
 }
 
 void BSD::StartMonitoring(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service, "(STUBBED) called");
+    LOG_STUBBED(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 2};
 
@@ -31,7 +31,7 @@ void BSD::Socket(Kernel::HLERequestContext& ctx) {
     u32 type = rp.Pop<u32>();
     u32 protocol = rp.Pop<u32>();
 
-    LOG_WARNING(Service, "(STUBBED) called domain={} type={} protocol={}", domain, type, protocol);
+    LOG_STUBBED(Service, "(STUBBED) called domain={} type={} protocol={}", domain, type, protocol);
 
     u32 fd = next_fd++;
 
@@ -43,7 +43,7 @@ void BSD::Socket(Kernel::HLERequestContext& ctx) {
 }
 
 void BSD::Connect(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service, "(STUBBED) called");
+    LOG_STUBBED(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 4};
 
@@ -53,7 +53,7 @@ void BSD::Connect(Kernel::HLERequestContext& ctx) {
 }
 
 void BSD::SendTo(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service, "(STUBBED) called");
+    LOG_STUBBED(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 4};
 
@@ -63,7 +63,7 @@ void BSD::SendTo(Kernel::HLERequestContext& ctx) {
 }
 
 void BSD::Close(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service, "(STUBBED) called");
+    LOG_STUBBED(Service, "(STUBBED) called");
 
     IPC::ResponseBuilder rb{ctx, 4};
 

--- a/src/core/hle/service/ssl/ssl.cpp
+++ b/src/core/hle/service/ssl/ssl.cpp
@@ -80,7 +80,7 @@ private:
         IPC::RequestParser rp{ctx};
         const auto parameters = rp.PopRaw<Parameters>();
 
-        LOG_WARNING(Service_SSL, "(STUBBED) called. enable={}, option={}", parameters.enable,
+        LOG_STUBBED(Service_SSL, "(STUBBED) called. enable={}, option={}", parameters.enable,
                     parameters.option);
 
         IPC::ResponseBuilder rb{ctx, 2};
@@ -88,7 +88,7 @@ private:
     }
 
     void CreateConnection(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_SSL, "(STUBBED) called");
+        LOG_STUBBED(Service_SSL, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
@@ -119,7 +119,7 @@ public:
 private:
     u32 ssl_version{};
     void CreateContext(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_SSL, "(STUBBED) called");
+        LOG_STUBBED(Service_SSL, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -581,7 +581,7 @@ private:
             IGBPQueryResponseParcel response{value};
             ctx.WriteBuffer(response.Serialize());
         } else if (transaction == TransactionId::CancelBuffer) {
-            LOG_CRITICAL(Service_VI, "(STUBBED) called, transaction=CancelBuffer");
+            LOG_STUBBED(Service_VI, "(STUBBED) called, transaction=CancelBuffer");
         } else if (transaction == TransactionId::Disconnect ||
                    transaction == TransactionId::DetachBuffer) {
             const auto buffer = ctx.ReadBuffer();
@@ -602,7 +602,7 @@ private:
         const s32 addval = rp.PopRaw<s32>();
         const u32 type = rp.Pop<u32>();
 
-        LOG_WARNING(Service_VI, "(STUBBED) called id={}, addval={:08X}, type={:08X}", id, addval,
+        LOG_STUBBED(Service_VI, "(STUBBED) called id={}, addval={:08X}, type={:08X}", id, addval,
                     type);
 
         IPC::ResponseBuilder rb{ctx, 2};
@@ -614,7 +614,7 @@ private:
         const u32 id = rp.Pop<u32>();
         const u32 unknown = rp.Pop<u32>();
 
-        LOG_WARNING(Service_VI, "(STUBBED) called id={}, unknown={:08X}", id, unknown);
+        LOG_STUBBED(Service_VI, "(STUBBED) called id={}, unknown={:08X}", id, unknown);
 
         const auto& buffer_queue = nv_flinger->FindBufferQueue(id);
 
@@ -684,7 +684,7 @@ private:
         const u64 layer_id = rp.Pop<u64>();
         const u64 z_value = rp.Pop<u64>();
 
-        LOG_WARNING(Service_VI, "(STUBBED) called. layer_id=0x{:016X}, z_value=0x{:016X}", layer_id,
+        LOG_STUBBED(Service_VI, "(STUBBED) called. layer_id=0x{:016X}, z_value=0x{:016X}", layer_id,
                     z_value);
 
         IPC::ResponseBuilder rb{ctx, 2};
@@ -705,7 +705,7 @@ private:
     }
 
     void GetDisplayMode(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        LOG_STUBBED(Service_VI, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 6};
         rb.Push(RESULT_SUCCESS);
@@ -814,7 +814,7 @@ private:
         IPC::RequestParser rp{ctx};
         const u64 display = rp.Pop<u64>();
 
-        LOG_WARNING(Service_VI, "(STUBBED) called. display=0x{:016X}", display);
+        LOG_STUBBED(Service_VI, "(STUBBED) called. display=0x{:016X}", display);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -848,7 +848,7 @@ private:
         const u32 stack = rp.Pop<u32>();
         const u64 layer_id = rp.Pop<u64>();
 
-        LOG_WARNING(Service_VI, "(STUBBED) called. stack=0x{:08X}, layer_id=0x{:016X}", stack,
+        LOG_STUBBED(Service_VI, "(STUBBED) called. stack=0x{:08X}, layer_id=0x{:016X}", stack,
                     layer_id);
 
         IPC::ResponseBuilder rb{ctx, 2};
@@ -860,7 +860,7 @@ private:
         const u64 layer_id = rp.Pop<u64>();
         const bool visibility = rp.Pop<bool>();
 
-        LOG_WARNING(Service_VI, "(STUBBED) called, layer_id=0x{:X}, visibility={}", layer_id,
+        LOG_STUBBED(Service_VI, "(STUBBED) called, layer_id=0x{:X}, visibility={}", layer_id,
                     visibility);
 
         IPC::ResponseBuilder rb{ctx, 2};
@@ -892,7 +892,7 @@ private:
     };
 
     void GetRelayService(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        LOG_STUBBED(Service_VI, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
@@ -900,7 +900,7 @@ private:
     }
 
     void GetSystemDisplayService(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        LOG_STUBBED(Service_VI, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
@@ -908,7 +908,7 @@ private:
     }
 
     void GetManagerDisplayService(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        LOG_STUBBED(Service_VI, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
@@ -916,7 +916,7 @@ private:
     }
 
     void GetIndirectDisplayTransactionService(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        LOG_STUBBED(Service_VI, "(STUBBED) called");
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
@@ -924,7 +924,7 @@ private:
     }
 
     void OpenDisplay(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        LOG_STUBBED(Service_VI, "(STUBBED) called");
 
         IPC::RequestParser rp{ctx};
         const auto name_buf = rp.PopRaw<std::array<char, 0x40>>();
@@ -963,7 +963,7 @@ private:
         IPC::RequestParser rp{ctx};
         const u64 display_id = rp.Pop<u64>();
 
-        LOG_WARNING(Service_VI, "(STUBBED) called. display_id=0x{:016X}", display_id);
+        LOG_STUBBED(Service_VI, "(STUBBED) called. display_id=0x{:016X}", display_id);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -1023,7 +1023,7 @@ private:
     }
 
     void ListDisplays(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_VI, "(STUBBED) called");
+        LOG_STUBBED(Service_VI, "(STUBBED) called");
 
         DisplayInfo display_info;
         display_info.width *= static_cast<u64>(Settings::values.resolution_factor);
@@ -1113,7 +1113,7 @@ private:
         IPC::RequestParser rp{ctx};
         const u64 layer_id = rp.Pop<u64>();
 
-        LOG_WARNING(Service_VI, "(STUBBED) called. layer_id=0x{:016X}", layer_id);
+        LOG_STUBBED(Service_VI, "(STUBBED) called. layer_id=0x{:016X}", layer_id);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -1123,7 +1123,7 @@ private:
         IPC::RequestParser rp{ctx};
         const u64 display_id = rp.Pop<u64>();
 
-        LOG_WARNING(Service_VI, "(STUBBED) called. display_id=0x{:016X}", display_id);
+        LOG_STUBBED(Service_VI, "(STUBBED) called. display_id=0x{:016X}", display_id);
 
         const auto vsync_event = nv_flinger->FindVsyncEvent(display_id);
         if (!vsync_event) {

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -431,7 +431,9 @@ struct Values {
     float bg_green;
     float bg_blue;
 
+    // Log
     std::string log_filter;
+    bool log_ignore_stubbed_services;
 
     bool use_dev_keys;
 

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -512,7 +512,7 @@ void Maxwell3D::ProcessMacroBind(u32 data) {
 }
 
 void Maxwell3D::ProcessFirmwareCall4() {
-    LOG_WARNING(HW_GPU, "(STUBBED) called");
+    LOG_STUBBED(HW_GPU, "(STUBBED) called");
 
     // Firmware call 4 is a blob that changes some registers depending on its parameters.
     // These registers don't affect emulation and so are stubbed by setting 0xd00 to 1.

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
@@ -1959,7 +1959,7 @@ private:
     }
 
     Expression YNegate(Operation) {
-        LOG_WARNING(Render_Vulkan, "(STUBBED)");
+        LOG_STUBBED(Render_Vulkan, "(STUBBED)");
         return {Constant(t_float, 1.0f), Type::Float};
     }
 

--- a/src/video_core/shader/decode/arithmetic.cpp
+++ b/src/video_core/shader/decode/arithmetic.cpp
@@ -144,7 +144,7 @@ u32 ShaderIR::DecodeArithmetic(NodeBlock& bb, u32 pc) {
     case OpCode::Id::RRO_C:
     case OpCode::Id::RRO_R:
     case OpCode::Id::RRO_IMM: {
-        LOG_DEBUG(HW_GPU, "(STUBBED) RRO used");
+        LOG_STUBBED(HW_GPU, "(STUBBED) RRO used");
 
         // Currently RRO is only implemented as a register move.
         op_b = GetOperandAbsNegFloat(op_b, instr.alu.abs_b, instr.alu.negate_b);

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -574,6 +574,8 @@ void Config::ReadMiscellaneousValues() {
         ReadSetting(QStringLiteral("log_filter"), QStringLiteral("*:Info"))
             .toString()
             .toStdString();
+    Settings::values.log_ignore_stubbed_services =
+        ReadSetting(QStringLiteral("log_ignore_stubbed_services"), false).toBool();
     Settings::values.use_dev_keys = ReadSetting(QStringLiteral("use_dev_keys"), false).toBool();
 
     qt_config->endGroup();
@@ -1028,6 +1030,9 @@ void Config::SaveMiscellaneousValues() {
 
     WriteSetting(QStringLiteral("log_filter"), QString::fromStdString(Settings::values.log_filter),
                  QStringLiteral("*:Info"));
+    WriteSetting(QStringLiteral("log_ignore_stubbed_services"),
+                 Settings::values.log_ignore_stubbed_services,
+                 false);
     WriteSetting(QStringLiteral("use_dev_keys"), Settings::values.use_dev_keys, false);
 
     qt_config->endGroup();

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -33,6 +33,7 @@ void ConfigureDebug::SetConfiguration() {
     ui->toggle_console->setEnabled(!Core::System::GetInstance().IsPoweredOn());
     ui->toggle_console->setChecked(UISettings::values.show_console);
     ui->log_filter_edit->setText(QString::fromStdString(Settings::values.log_filter));
+    ui->toggle_stubbed_logging->setChecked(Settings::values.log_ignore_stubbed_services);
     ui->homebrew_args_edit->setText(QString::fromStdString(Settings::values.program_args));
     ui->reporting_services->setChecked(Settings::values.reporting_services);
     ui->quest_flag->setChecked(Settings::values.quest_flag);
@@ -43,12 +44,18 @@ void ConfigureDebug::ApplyConfiguration() {
     Settings::values.gdbstub_port = ui->gdbport_spinbox->value();
     UISettings::values.show_console = ui->toggle_console->isChecked();
     Settings::values.log_filter = ui->log_filter_edit->text().toStdString();
+    Settings::values.log_ignore_stubbed_services = ui->toggle_stubbed_logging->isChecked();
     Settings::values.program_args = ui->homebrew_args_edit->text().toStdString();
     Settings::values.reporting_services = ui->reporting_services->isChecked();
     Settings::values.quest_flag = ui->quest_flag->isChecked();
     Debugger::ToggleConsole();
+
     Log::Filter filter;
     filter.ParseFilterString(Settings::values.log_filter);
+
+    if (Settings::values.log_ignore_stubbed_services)
+        filter.AddIgnoredLevel(Log::Level::Stubbed);
+
     Log::SetGlobalFilter(filter);
 }
 

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -104,6 +104,17 @@
        </layout>
       </item>
       <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_3">
+        <item>
+         <widget class="QCheckBox" name="toggle_stubbed_logging">
+          <property name="text">
+           <string>Ignore stubbed services</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
        <widget class="QCheckBox" name="reporting_services">
         <property name="text">
          <string>Enable Verbose Reporting Services</string>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -169,6 +169,8 @@ const int GMainWindow::max_recent_files_item;
 static void InitializeLogging() {
     Log::Filter log_filter;
     log_filter.ParseFilterString(Settings::values.log_filter);
+    if (Settings::values.log_ignore_stubbed_services)
+        log_filter.AddIgnoredLevel(Log::Level::Stubbed);
     Log::SetGlobalFilter(log_filter);
 
     const std::string& log_dir = FileUtil::GetUserPath(FileUtil::UserPath::LogDir);

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -74,6 +74,8 @@ static void PrintVersion() {
 static void InitializeLogging() {
     Log::Filter log_filter(Log::Level::Debug);
     log_filter.ParseFilterString(Settings::values.log_filter);
+    if (Settings::values.log_stubbed_services)
+        log_filter.AddIgnoredLevel(Log::Level::Stubbed);
     Log::SetGlobalFilter(log_filter);
 
     Log::AddBackend(std::make_unique<Log::ColorConsoleBackend>());

--- a/src/yuzu_tester/yuzu.cpp
+++ b/src/yuzu_tester/yuzu.cpp
@@ -73,6 +73,8 @@ static void PrintVersion() {
 static void InitializeLogging(bool console) {
     Log::Filter log_filter(Log::Level::Debug);
     log_filter.ParseFilterString(Settings::values.log_filter);
+    if (Settings::values.log_stubbed_services)
+        log_filter.AddIgnoredLevel(Log::Level::Stubbed);
     Log::SetGlobalFilter(log_filter);
 
     if (console)


### PR DESCRIPTION
- Stubbed is currently implement on a higher level than Critical.
- Added a filter list ignored_levels (Using a list in case of future expansions).
- Replaced all LOG_* call containing (STUBBED) to LOG_Stubbed.
- Added config setting "log_ignore_stubbed_services".
- Added GUI setting Debug -> Logging -> Ignore stubbed services.

![image](https://user-images.githubusercontent.com/3213428/73128672-2df67f80-3fd3-11ea-80ba-85c1dcdbd5ae.png)

Added 2 logs comparing Ignore stubbed services enabled and disabled.
[yuzu_log_ignore_stubbed.txt](https://github.com/yuzu-emu/yuzu/files/4113029/yuzu_log_ignore_stubbed.txt)
[yuzu_log_stubbed.txt](https://github.com/yuzu-emu/yuzu/files/4113030/yuzu_log_stubbed.txt)
