### PR TITLE
GUI: dark themes refinements and QSS cleanup

### DIFF
--- a/dist/qt_themes/qdarkstyle/style.qss
+++ b/dist/qt_themes/qdarkstyle/style.qss
@@ -2,7 +2,8 @@ QToolTip {
     border: 1px solid #76797C;
     background-color: #5A7566;
     color: white;
-    padding: 0px;                /*remove padding, for fix combobox tooltip.*/
+    /*remove padding, for fix combobox tooltip.*/
+    padding: 0;
     opacity: 200;
 }
 
@@ -13,7 +14,7 @@ QWidget {
     selection-color: #eff0f1;
     background-clip: border;
     border-image: none;
-    border: 0px transparent black;
+    border: 0;
     outline: 0;
 }
 
@@ -27,10 +28,10 @@ QWidget:item:selected {
 }
 
 QCheckBox {
-    spacing: 5px;
+    spacing: 6px;
     outline: none;
     color: #eff0f1;
-    margin-bottom: 2px;
+    margin: 0 2px 1px 0;
 }
 
 QCheckBox:disabled {
@@ -163,7 +164,7 @@ QMenuBar::item:selected {
 }
 
 QMenuBar::item:pressed {
-    border: 1px solid #76797C;
+    border: 1px solid #18465d;
     background-color: #3daee9;
     color: #eff0f1;
     margin-bottom: -1px;
@@ -171,9 +172,9 @@ QMenuBar::item:pressed {
 }
 
 QMenu {
-    border: 1px solid #76797C;
+    border: 1px solid #434242;
+    padding: 2px;
     color: #eff0f1;
-    margin: 2px;
 }
 
 QMenu::icon {
@@ -190,11 +191,21 @@ QMenu::item:selected {
     color: #eff0f1;
 }
 
-QMenu::separator {
-    height: 2px;
-    background: #76797C;
-    margin-left: 10px;
-    margin-right: 5px;
+QMenu::item:disabled {
+    color: #54575B;
+}
+
+QMenu::item:disabled:hover,
+QMenu::item:disabled:selected {
+    background-color: #393e43;
+    color: #666;
+}
+
+QMenu::separator,
+QMenuBar::separator {
+    height: 1px;
+    background-color: #54575B;
+    margin: 2px 4px 2px 40px;
 }
 
 QMenu::indicator {
@@ -203,10 +214,7 @@ QMenu::indicator {
     height: 18px;
 }
 
-
-/* non-exclusive indicator = check box style indicator
-   (see QActionGroup::setExclusive) */
-
+/* non-exclusive indicator = check box style indicator (see QActionGroup::setExclusive) */
 QMenu::indicator:non-exclusive:unchecked {
     image: url(:/qss_icons/rc/checkbox_unchecked.png);
 }
@@ -223,9 +231,7 @@ QMenu::indicator:non-exclusive:checked:selected {
     image: url(:/qss_icons/rc/checkbox_checked_disabled.png);
 }
 
-
 /* exclusive indicator = radio button style indicator (see QActionGroup::setExclusive) */
-
 QMenu::indicator:exclusive:unchecked {
     image: url(:/qss_icons/rc/radio_unchecked.png);
 }
@@ -243,12 +249,12 @@ QMenu::indicator:exclusive:checked:selected {
 }
 
 QMenu::right-arrow {
-    margin: 5px;
+    margin-right: 10px;
     image: url(:/qss_icons/rc/right_arrow.png)
 }
 
 QWidget:disabled {
-    color: #454545;
+    color: #4f515b;
     background-color: #31363b;
 }
 
@@ -259,23 +265,30 @@ QAbstractItemView {
     border-radius: 2px;
 }
 
-QWidget:focus,
-QMenuBar:focus {
+QAbstractItemView:disabled,
+QAbstractItemView:read-only {
+    alternate-background-color: #232629;
+}
+
+QWidget:focus {
     border: 1px solid #3daee9;
 }
 
 QTabWidget:focus,
 QCheckBox:focus,
 QRadioButton:focus,
-QSlider:focus {
+QSlider:focus,
+QTreeView:focus,
+QMenu:focus,
+QMenuBar:focus,
+QTabBar:focus {
     border: none;
 }
 
 QLineEdit {
     background-color: #232629;
     padding: 5px;
-    border-style: solid;
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
     border-radius: 2px;
     color: #eff0f1;
 }
@@ -285,9 +298,10 @@ QAbstractItemView QLineEdit {
 }
 
 QGroupBox {
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
     border-radius: 2px;
-    margin-top: 20px;
+    margin-top: 12px;
+    padding-top: 2px;
 }
 
 QGroupBox::title {
@@ -295,12 +309,12 @@ QGroupBox::title {
     subcontrol-position: top center;
     padding-left: 10px;
     padding-right: 10px;
-    padding-top: 10px;
+    padding-top: 2px;
 }
 
 QAbstractScrollArea {
     border-radius: 2px;
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
     background-color: transparent;
 }
 
@@ -319,7 +333,7 @@ QScrollBar::handle:horizontal {
 }
 
 QScrollBar::add-line:horizontal {
-    margin: 0px 3px 0px 3px;
+    margin: 0 3px;
     border-image: url(:/qss_icons/rc/right_arrow_disabled.png);
     width: 10px;
     height: 10px;
@@ -328,7 +342,7 @@ QScrollBar::add-line:horizontal {
 }
 
 QScrollBar::sub-line:horizontal {
-    margin: 0px 3px 0px 3px;
+    margin: 0 3px;
     border-image: url(:/qss_icons/rc/left_arrow_disabled.png);
     height: 10px;
     width: 10px;
@@ -379,7 +393,7 @@ QScrollBar::handle:vertical {
 }
 
 QScrollBar::sub-line:vertical {
-    margin: 3px 0px 3px 0px;
+    margin: 3px 0;
     border-image: url(:/qss_icons/rc/up_arrow_disabled.png);
     height: 10px;
     width: 10px;
@@ -388,7 +402,7 @@ QScrollBar::sub-line:vertical {
 }
 
 QScrollBar::add-line:vertical {
-    margin: 3px 0px 3px 0px;
+    margin: 3px 0;
     border-image: url(:/qss_icons/rc/down_arrow_disabled.png);
     height: 10px;
     width: 10px;
@@ -427,15 +441,14 @@ QScrollBar::sub-page:vertical {
 QTextEdit {
     background-color: #232629;
     color: #eff0f1;
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
 }
 
 QPlainTextEdit {
     background-color: #232629;
-    ;
     color: #eff0f1;
     border-radius: 2px;
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
 }
 
 QHeaderView::section {
@@ -465,15 +478,6 @@ QMainWindow::separator:hover {
     padding-left: 4px;
     border: 1px solid #76797C;
     spacing: 2px;
-}
-
-QMenu::separator {
-    height: 1px;
-    background-color: #76797C;
-    color: white;
-    padding-left: 4px;
-    margin-left: 10px;
-    margin-right: 5px;
 }
 
 QFrame {
@@ -518,25 +522,19 @@ QToolButton#qt_toolbar_ext_button {
 
 QPushButton {
     color: #eff0f1;
-    background-color: #31363b;
     border-width: 1px;
-    border-color: #76797C;
+    border-color: #54575B;
     border-style: solid;
-    padding: 5px;
+    padding: 6px 4px;
     border-radius: 2px;
     outline: none;
+    min-width: 100px;
+    background-color: #232629;
 }
 
 QPushButton:disabled {
     background-color: #31363b;
-    border-width: 1px;
     border-color: #454545;
-    border-style: solid;
-    padding-top: 5px;
-    padding-bottom: 5px;
-    padding-left: 10px;
-    padding-right: 10px;
-    border-radius: 2px;
     color: #454545;
 }
 
@@ -553,11 +551,11 @@ QPushButton:pressed {
 
 QComboBox {
     selection-background-color: #3daee9;
-    border-style: solid;
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
     border-radius: 2px;
-    padding: 5px;
+    padding: 4px 6px;
     min-width: 75px;
+    background-color: #232629;
 }
 
 QPushButton:checked {
@@ -571,8 +569,7 @@ QAbstractSpinBox:hover,
 QLineEdit:hover,
 QTextEdit:hover,
 QPlainTextEdit:hover,
-QAbstractView:hover,
-QTreeView:hover {
+QAbstractView:hover {
     border: 1px solid #3daee9;
     color: #eff0f1;
 }
@@ -591,6 +588,7 @@ QComboBox QAbstractItemView {
 QComboBox::drop-down {
     subcontrol-origin: padding;
     subcontrol-position: top right;
+    left: -6px;
     width: 15px;
     border-left-width: 0px;
     border-left-color: darkgray;
@@ -610,8 +608,8 @@ QComboBox::down-arrow:focus {
 }
 
 QAbstractSpinBox {
-    padding: 5px;
-    border: 1px solid #76797C;
+    padding: 4px 6px;
+    border: 1px solid #54575B;
     background-color: #232629;
     color: #eff0f1;
     border-radius: 2px;
@@ -622,12 +620,14 @@ QAbstractSpinBox:up-button {
     background-color: transparent;
     subcontrol-origin: border;
     subcontrol-position: center right;
+    left: -6px;
 }
 
 QAbstractSpinBox:down-button {
     background-color: transparent;
     subcontrol-origin: border;
     subcontrol-position: center left;
+    right: -6px;
 }
 
 QAbstractSpinBox::up-arrow,
@@ -654,31 +654,32 @@ QAbstractSpinBox::down-arrow:hover {
     image: url(:/qss_icons/rc/down_arrow.png);
 }
 
-QLabel {
-    border: 0px solid black;
+QLabel,
+QTabWidget {
+    border: 0;
 }
 
 QTabWidget {
-    border: 0px transparent black;
+    padding-top: 1px;
 }
 
 QTabWidget::pane {
     border: 1px solid #76797C;
     padding: 5px;
-    margin: 0px;
+    position: absolute;
+    top: -1px;
+    border-top-right-radius: 2px;
+    border-bottom-right-radius: 2px;
+    border-bottom-left-radius: 2px;
 }
 
 QTabWidget::tab-bar {
-    /* left: 5px; move to the right by 5px */
+    overflow: visible;
 }
 
 QTabBar {
     qproperty-drawBase: 0;
     border-radius: 3px;
-}
-
-QTabBar:focus {
-    border: 0px transparent black;
 }
 
 QTabBar::close-button {
@@ -696,36 +697,33 @@ QTabBar::close-button:pressed {
     background: transparent;
 }
 
-
 /* TOP TABS */
-
 QTabBar::tab:top {
     color: #eff0f1;
-    border: 1px solid #76797C;
-    border-bottom: 2px transparent;
-    background-color: #31363b;
-    padding: 4px 16px 2px;
-    min-width: 38px;
+    border: 1px solid #54575B;
+    background-color: #2a2f33;
+    padding: 4px 16px 5px;
+    min-width: 36px;
     border-top-left-radius: 2px;
     border-top-right-radius: 2px;
 }
 
 QTabBar::tab:top:selected {
-    color: #eff0f1;
-    background-color: #54575B;
-    border: 1px solid #76797C;
-    border-bottom: 2px solid #3daee9;
-    border-top-left-radius: 2px;
-    border-top-right-radius: 2px;
+    border-color: #76797C;
+    background-color: #31363b;
+    border-bottom-color: #31363b;
+}
+
+QTabBar::tab:top:!selected {
+    margin-top: 1px;
+    border-bottom-color: #76797C;
 }
 
 QTabBar::tab:top:!selected:hover {
     background-color: #3daee9;
 }
 
-
 /* BOTTOM TABS */
-
 QTabBar::tab:bottom {
     color: #eff0f1;
     border: 1px solid #76797C;
@@ -750,9 +748,7 @@ QTabBar::tab:bottom:!selected:hover {
     background-color: #3daee9;
 }
 
-
 /* LEFT TABS */
-
 QTabBar::tab:left {
     color: #eff0f1;
     border: 1px solid #76797C;
@@ -777,9 +773,7 @@ QTabBar::tab:left:!selected:hover {
     background-color: #3daee9;
 }
 
-
 /* RIGHT TABS */
-
 QTabBar::tab:right {
     color: #eff0f1;
     border: 1px solid #76797C;
@@ -847,7 +841,7 @@ QDockWidget::float-button:pressed {
 
 QTreeView,
 QListView {
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
     background-color: #232629;
 }
 
@@ -978,8 +972,8 @@ QSlider::handle:vertical {
 }
 
 QToolButton {
-    background-color: transparent;
-    border: 1px transparent #76797C;
+    background-color: #232629;
+    border: 1px solid #54575B;
     border-radius: 2px;
     margin: 3px;
     padding: 5px;
@@ -988,7 +982,6 @@ QToolButton {
 QToolButton[popupMode="1"] {
     /* only for MenuButtonPopup */
     padding-right: 20px;
-    /* make way for the popup button */
     border: 1px #76797C;
     border-radius: 5px;
 }
@@ -996,7 +989,6 @@ QToolButton[popupMode="1"] {
 QToolButton[popupMode="2"] {
     /* only for InstantPopup */
     padding-right: 10px;
-    /* make way for the popup button */
     border: 1px #76797C;
 }
 
@@ -1015,19 +1007,14 @@ QToolButton::menu-button:pressed {
     padding: 5px;
 }
 
-
 /* the subcontrol below is used only in the InstantPopup or DelayedPopup mode */
-
 QToolButton::menu-indicator {
     image: url(:/qss_icons/rc/down_arrow.png);
     top: -7px;
     left: -2px;
-    /* shift it a bit */
 }
 
-
 /* the subcontrols below are used only in the MenuButtonPopup mode */
-
 QToolButton::menu-button {
     border: 1px transparent #76797C;
     border-top-right-radius: 6px;
@@ -1052,14 +1039,22 @@ QPushButton::menu-indicator {
 }
 
 QTableView {
-    border: 1px solid #76797C;
+    border: 1px solid #54575B;
     gridline-color: #31363b;
     background-color: #232629;
 }
 
+QTreeView:disabled {
+    background-color: #1f2225;
+}
+
 QTableView,
 QHeaderView {
-    border-radius: 0px;
+    border-radius: 0;
+}
+
+QListView:focus {
+    border-color: #54575B;
 }
 
 QTableView::item:pressed,
@@ -1088,7 +1083,7 @@ QHeaderView::section {
     background-color: #232629;
     color: #eff0f1;
     padding: 0 5px;
-    border: 1px solid #403F3F;
+    border: 1px solid #434242;
     border-bottom: 0;
     border-radius: 0px;
     text-align: center;
@@ -1118,9 +1113,7 @@ QHeaderView::section:checked {
     background-color: #334e5e;
 }
 
-
-/* style the sort indicator */
-
+/* sort indicator */
 QHeaderView::down-arrow {
     image: url(:/qss_icons/rc/down_arrow.png);
 }
@@ -1150,14 +1143,13 @@ QToolBox::tab {
 }
 
 QToolBox::tab:selected {
-    /* italicize selected tabs */
     font: italic;
     background-color: #31363b;
     border-color: #3daee9;
 }
 
 QStatusBar::item {
-    border: 0px transparent dark;
+    border: 0;
 }
 
 QFrame[height="3"],
@@ -1194,7 +1186,6 @@ QProgressBar::chunk {
 
 QDateEdit {
     selection-background-color: #3daee9;
-    border-style: solid;
     border: 1px solid #3375A3;
     border-radius: 2px;
     padding: 1px;
@@ -1218,7 +1209,7 @@ QDateEdit::drop-down {
     subcontrol-origin: padding;
     subcontrol-position: top right;
     width: 15px;
-    border-left-width: 0px;
+    border-left-width: 0;
     border-left-color: darkgray;
     border-left-style: solid;
     border-top-right-radius: 3px;
@@ -1233,4 +1224,15 @@ QDateEdit::down-arrow:on,
 QDateEdit::down-arrow:hover,
 QDateEdit::down-arrow:focus {
     image: url(:/qss_icons/rc/down_arrow.png);
+}
+
+QComboBox:disabled,
+QPushButton:disabled,
+QAbstractSpinBox:disabled,
+QDateEdit:disabled,
+QLineEdit:disabled,
+QTextEdit:disabled,
+QToolButton:disabled,
+QPlainTextEdit:disabled {
+    background-color: #2b2e31;
 }


### PR DESCRIPTION
This PR introduce a lot of small changes and improvements for dark themes and supplement changes introduced in #3339. Most important things that has been updated:
* user control/interaction elements design has been standardized and proper disabled state for all of them has been added 
* tabs design has been based more on light theme and simplified
* Main Menu and Context Menu has been refined to mimic native menu better and disabled styling has been updated
* game list now dimms instead of being lighten up while loading

Other than that a lot of small tweaks and changes has been applied across whole dark themes stylesheet.

#### Config, Tabs and user interaction elements
<img width="935" alt="yc1" src="https://user-images.githubusercontent.com/719641/73134223-4fd41e80-4034-11ea-892f-fea4c0e54c7c.png">

#### Main Menu
<img width="467" alt="yc2" src="https://user-images.githubusercontent.com/719641/73134224-5a8eb380-4034-11ea-94f7-c3df76372132.png">

### Game List while loading
<img width="662" alt="yc3" src="https://user-images.githubusercontent.com/719641/73134228-64181b80-4034-11ea-8559-089f250e54fc.png">

