### PR TITLE
yuzu: delete macOS preprocessor directives and code

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -34,9 +34,6 @@
 #define fstat _fstat64
 
 #else
-#ifdef __APPLE__
-#include <sys/param.h>
-#endif
 #include <cctype>
 #include <cerrno>
 #include <cstdlib>
@@ -44,23 +41,6 @@
 #include <dirent.h>
 #include <pwd.h>
 #include <unistd.h>
-#endif
-
-#if defined(__APPLE__)
-// CFURL contains __attribute__ directives that gcc does not know how to parse, so we need to just
-// ignore them if we're not using clang. The macro is only used to prevent linking against
-// functions that don't exist on older versions of macOS, and the worst case scenario is a linker
-// error, so this is perfectly safe, just inconvenient.
-#ifndef __clang__
-#define availability(...)
-#endif
-#include <CoreFoundation/CFBundle.h>
-#include <CoreFoundation/CFString.h>
-#include <CoreFoundation/CFURL.h>
-#ifdef availability
-#undef availability
-#endif
-
 #endif
 
 #include <algorithm>
@@ -556,21 +536,6 @@ bool SetCurrentDir(const std::string& directory) {
 #endif
 }
 
-#if defined(__APPLE__)
-std::string GetBundleDirectory() {
-    CFURLRef BundleRef;
-    char AppBundlePath[MAXPATHLEN];
-    // Get the main bundle for the app
-    BundleRef = CFBundleCopyBundleURL(CFBundleGetMainBundle());
-    CFStringRef BundlePath = CFURLCopyFileSystemPath(BundleRef, kCFURLPOSIXPathStyle);
-    CFStringGetFileSystemRepresentation(BundlePath, AppBundlePath, sizeof(AppBundlePath));
-    CFRelease(BundleRef);
-    CFRelease(BundlePath);
-
-    return AppBundlePath;
-}
-#endif
-
 #ifdef _WIN32
 const std::string& GetExeDirectory() {
     static std::string exe_path;
@@ -644,15 +609,7 @@ static const std::string GetUserDirectory(const std::string& envvar) {
 #endif
 
 std::string GetSysDirectory() {
-    std::string sysDir;
-
-#if defined(__APPLE__)
-    sysDir = GetBundleDirectory();
-    sysDir += DIR_SEP;
-    sysDir += SYSDATA_DIR;
-#else
-    sysDir = SYSDATA_DIR;
-#endif
+    std::string sysDir = SYSDATA_DIR;
     sysDir += DIR_SEP;
 
     LOG_DEBUG(Common_Filesystem, "Setting to {}:", sysDir);

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -138,10 +138,6 @@ std::string GetNANDRegistrationDir(bool system = false);
 // Returns the path to where the sys file are
 std::string GetSysDirectory();
 
-#ifdef __APPLE__
-std::string GetBundleDirectory();
-#endif
-
 #ifdef _WIN32
 const std::string& GetExeDirectory();
 std::string AppDataRoamingDirectory();

--- a/src/common/telemetry.cpp
+++ b/src/common/telemetry.cpp
@@ -76,9 +76,7 @@ void AppendCPUInfo(FieldCollection& fc) {
 }
 
 void AppendOSInfo(FieldCollection& fc) {
-#ifdef __APPLE__
-    fc.AddField(FieldType::UserSystem, "OsPlatform", "Apple");
-#elif defined(_WIN32)
+#ifdef _WIN32
     fc.AddField(FieldType::UserSystem, "OsPlatform", "Windows");
 #elif defined(__linux__) || defined(linux) || defined(__linux)
     fc.AddField(FieldType::UserSystem, "OsPlatform", "Linux");

--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -3,9 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "common/thread.h"
-#ifdef __APPLE__
-#include <mach/mach.h>
-#elif defined(_WIN32)
+#ifdef _WIN32
 #include <windows.h>
 #else
 #if defined(__Bitrig__) || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__OpenBSD__)
@@ -61,9 +59,7 @@ void SetCurrentThreadName(const char* name) {
 // MinGW with the POSIX threading model does not support pthread_setname_np
 #if !defined(_WIN32) || defined(_MSC_VER)
 void SetCurrentThreadName(const char* name) {
-#ifdef __APPLE__
-    pthread_setname_np(name);
-#elif defined(__Bitrig__) || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#if defined(__Bitrig__) || defined(__DragonFly__) || defined(__FreeBSD__) || defined(__OpenBSD__)
     pthread_set_name_np(pthread_self(), name);
 #elif defined(__NetBSD__)
     pthread_setname_np(pthread_self(), "%s", (void*)name);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -6,9 +6,6 @@
 #include <clocale>
 #include <memory>
 #include <thread>
-#ifdef __APPLE__
-#include <unistd.h> // for chdir
-#endif
 
 // VFS includes must be before glad as they will conflict with Windows file api, which uses defines.
 #include "applets/error.h"
@@ -2338,14 +2335,6 @@ int main(int argc, char* argv[]) {
     // Init settings params
     QCoreApplication::setOrganizationName(QStringLiteral("yuzu team"));
     QCoreApplication::setApplicationName(QStringLiteral("yuzu"));
-
-#ifdef __APPLE__
-    // If you start a bundle (binary) on OSX without the Terminal, the working directory is "/".
-    // But since we require the working directory to be the executable path for the location of the
-    // user folder in the Qt Frontend, we need to cd into that working directory
-    const std::string bin_path = FileUtil::GetBundleDirectory() + DIR_SEP + "..";
-    chdir(bin_path.c_str());
-#endif
 
     // Enables the core to make the qt created contexts current on std::threads
     QCoreApplication::setAttribute(Qt::AA_DontCheckOpenGLContextThreadAffinity);


### PR DESCRIPTION
MacOS is no longer supported on Yuzu. This pr removes macOS specific code.