### PR TITLE
kernel/physical_core: Make use of std::unique_ptr instead of std::shared_ptr

### DIFF
--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -2,14 +2,12 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "common/assert.h"
 #include "core/arm/exclusive_monitor.h"
 #include "core/core.h"
 #include "core/core_manager.h"
 #include "core/core_timing.h"
 #include "core/cpu_manager.h"
 #include "core/gdbstub/gdbstub.h"
-#include "core/settings.h"
 
 namespace Core {
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -101,7 +101,7 @@ struct KernelCore::Impl {
     void Initialize(KernelCore& kernel) {
         Shutdown();
 
-        InitializePhysicalCores(kernel);
+        InitializePhysicalCores();
         InitializeSystemResourceLimit(kernel);
         InitializeThreads();
         InitializePreemption();
@@ -131,14 +131,14 @@ struct KernelCore::Impl {
         }
         cores.clear();
 
-        exclusive_monitor.reset(nullptr);
+        exclusive_monitor.reset();
     }
 
-    void InitializePhysicalCores(KernelCore& kernel) {
+    void InitializePhysicalCores() {
         exclusive_monitor =
             Core::MakeExclusiveMonitor(system.Memory(), global_scheduler.CpuCoresCount());
         for (std::size_t i = 0; i < global_scheduler.CpuCoresCount(); i++) {
-            cores.emplace_back(system, kernel, i, *exclusive_monitor);
+            cores.emplace_back(system, i, *exclusive_monitor);
         }
     }
 

--- a/src/core/hle/kernel/physical_core.cpp
+++ b/src/core/hle/kernel/physical_core.cpp
@@ -10,16 +10,15 @@
 #include "core/arm/exclusive_monitor.h"
 #include "core/arm/unicorn/arm_unicorn.h"
 #include "core/core.h"
-#include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/physical_core.h"
 #include "core/hle/kernel/scheduler.h"
 #include "core/hle/kernel/thread.h"
 
 namespace Kernel {
 
-PhysicalCore::PhysicalCore(Core::System& system, KernelCore& kernel, std::size_t id,
+PhysicalCore::PhysicalCore(Core::System& system, std::size_t id,
                            Core::ExclusiveMonitor& exclusive_monitor)
-    : core_index{id}, kernel{kernel} {
+    : core_index{id} {
 #ifdef ARCHITECTURE_x86_64
     arm_interface = std::make_shared<Core::ARM_Dynarmic>(system, exclusive_monitor, core_index);
 #else

--- a/src/core/hle/kernel/physical_core.cpp
+++ b/src/core/hle/kernel/physical_core.cpp
@@ -20,13 +20,13 @@ PhysicalCore::PhysicalCore(Core::System& system, std::size_t id,
                            Core::ExclusiveMonitor& exclusive_monitor)
     : core_index{id} {
 #ifdef ARCHITECTURE_x86_64
-    arm_interface = std::make_shared<Core::ARM_Dynarmic>(system, exclusive_monitor, core_index);
+    arm_interface = std::make_unique<Core::ARM_Dynarmic>(system, exclusive_monitor, core_index);
 #else
     arm_interface = std::make_shared<Core::ARM_Unicorn>(system);
     LOG_WARNING(Core, "CPU JIT requested, but Dynarmic not available");
 #endif
 
-    scheduler = std::make_shared<Kernel::Scheduler>(system, *arm_interface, core_index);
+    scheduler = std::make_unique<Kernel::Scheduler>(system, *arm_interface, core_index);
 }
 
 PhysicalCore::~PhysicalCore() = default;

--- a/src/core/hle/kernel/physical_core.h
+++ b/src/core/hle/kernel/physical_core.h
@@ -21,9 +21,7 @@ namespace Kernel {
 
 class PhysicalCore {
 public:
-    PhysicalCore(Core::System& system, KernelCore& kernel, std::size_t id,
-                 Core::ExclusiveMonitor& exclusive_monitor);
-
+    PhysicalCore(Core::System& system, std::size_t id, Core::ExclusiveMonitor& exclusive_monitor);
     ~PhysicalCore();
 
     /// Execute current jit state
@@ -66,7 +64,6 @@ public:
 
 private:
     std::size_t core_index;
-    KernelCore& kernel;
     std::shared_ptr<Core::ARM_Interface> arm_interface;
     std::shared_ptr<Kernel::Scheduler> scheduler;
 };

--- a/src/core/hle/kernel/physical_core.h
+++ b/src/core/hle/kernel/physical_core.h
@@ -24,6 +24,12 @@ public:
     PhysicalCore(Core::System& system, std::size_t id, Core::ExclusiveMonitor& exclusive_monitor);
     ~PhysicalCore();
 
+    PhysicalCore(const PhysicalCore&) = delete;
+    PhysicalCore& operator=(const PhysicalCore&) = delete;
+
+    PhysicalCore(PhysicalCore&&) = default;
+    PhysicalCore& operator=(PhysicalCore&&) = default;
+
     /// Execute current jit state
     void Run();
     /// Execute a single instruction in current jit.
@@ -64,8 +70,8 @@ public:
 
 private:
     std::size_t core_index;
-    std::shared_ptr<Core::ARM_Interface> arm_interface;
-    std::shared_ptr<Kernel::Scheduler> scheduler;
+    std::unique_ptr<Core::ARM_Interface> arm_interface;
+    std::unique_ptr<Kernel::Scheduler> scheduler;
 };
 
 } // namespace Kernel


### PR DESCRIPTION
shared_ptr was used in 2d1984c due to a misunderstanding of how the language generates move constructors and move assignment operators.

If a destructor is user-provided, then the compiler won't generate the move constructor and move assignment operators by default--they must be explicitly opted into.

The reason for the compilation errors is due to the fact that the language will fall back to attempting to use the copy constructor/copy assignment operators if the respective move constructor or move assignment operator is unavailable.

Given that we explicitly opt into them now, the the move constructor and move assignment operators will be generated as expected.

While we're at it, we can do a little bit of tidying up.