### PR TITLE
input_common/udp: Minor changes

### DIFF
--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -41,6 +41,7 @@ void Shutdown() {
     Input::UnregisterFactory<Input::MotionDevice>("motion_emu");
     motion_emu.reset();
     sdl.reset();
+    udp.reset();
 }
 
 Keyboard* GetKeyboard() {

--- a/src/input_common/udp/client.cpp
+++ b/src/input_common/udp/client.cpp
@@ -125,7 +125,7 @@ static void SocketLoop(Socket* socket) {
 
 Client::Client(std::shared_ptr<DeviceStatus> status, const std::string& host, u16 port,
                u8 pad_index, u32 client_id)
-    : status(status) {
+    : status(std::move(status)) {
     StartCommunication(host, port, pad_index, client_id);
 }
 

--- a/src/input_common/udp/client.cpp
+++ b/src/input_common/udp/client.cpp
@@ -31,10 +31,9 @@ public:
 
     explicit Socket(const std::string& host, u16 port, u8 pad_index, u32 client_id,
                     SocketCallback callback)
-        : client_id(client_id), timer(io_service),
-          send_endpoint(udp::endpoint(address_v4::from_string(host), port)),
-          socket(io_service, udp::endpoint(udp::v4(), 0)), pad_index(pad_index),
-          callback(std::move(callback)) {}
+        : callback(std::move(callback)), timer(io_service),
+          socket(io_service, udp::endpoint(udp::v4(), 0)), client_id(client_id),
+          pad_index(pad_index), send_endpoint(udp::endpoint(address_v4::from_string(host), port)) {}
 
     void Stop() {
         io_service.stop();

--- a/src/input_common/udp/client.cpp
+++ b/src/input_common/udp/client.cpp
@@ -14,7 +14,6 @@
 #include "input_common/udp/client.h"
 #include "input_common/udp/protocol.h"
 
-using boost::asio::ip::address_v4;
 using boost::asio::ip::udp;
 
 namespace InputCommon::CemuhookUDP {
@@ -33,7 +32,8 @@ public:
                     SocketCallback callback)
         : callback(std::move(callback)), timer(io_service),
           socket(io_service, udp::endpoint(udp::v4(), 0)), client_id(client_id),
-          pad_index(pad_index), send_endpoint(udp::endpoint(address_v4::from_string(host), port)) {}
+          pad_index(pad_index),
+          send_endpoint(udp::endpoint(boost::asio::ip::make_address_v4(host), port)) {}
 
     void Stop() {
         io_service.stop();

--- a/src/input_common/udp/client.cpp
+++ b/src/input_common/udp/client.cpp
@@ -206,7 +206,7 @@ void TestCommunication(const std::string& host, u16 port, u8 pad_index, u32 clie
         Common::Event success_event;
         SocketCallback callback{[](Response::Version version) {}, [](Response::PortInfo info) {},
                                 [&](Response::PadData data) { success_event.Set(); }};
-        Socket socket{host, port, pad_index, client_id, callback};
+        Socket socket{host, port, pad_index, client_id, std::move(callback)};
         std::thread worker_thread{SocketLoop, &socket};
         bool result = success_event.WaitFor(std::chrono::seconds(8));
         socket.Stop();
@@ -266,7 +266,7 @@ CalibrationConfigurationJob::CalibrationConfigurationJob(
                                         complete_event.Set();
                                     }
                                 }};
-        Socket socket{host, port, pad_index, client_id, callback};
+        Socket socket{host, port, pad_index, client_id, std::move(callback)};
         std::thread worker_thread{SocketLoop, &socket};
         complete_event.Wait();
         socket.Stop();

--- a/src/input_common/udp/client.h
+++ b/src/input_common/udp/client.h
@@ -11,7 +11,6 @@
 #include <string>
 #include <thread>
 #include <tuple>
-#include <vector>
 #include "common/common_types.h"
 #include "common/thread.h"
 #include "common/vector_math.h"

--- a/src/input_common/udp/protocol.h
+++ b/src/input_common/udp/protocol.h
@@ -7,7 +7,6 @@
 #include <array>
 #include <optional>
 #include <type_traits>
-#include <vector>
 #include <boost/crc.hpp>
 #include "common/bit_field.h"
 #include "common/swap.h"

--- a/src/input_common/udp/udp.cpp
+++ b/src/input_common/udp/udp.cpp
@@ -16,7 +16,7 @@ namespace InputCommon::CemuhookUDP {
 class UDPTouchDevice final : public Input::TouchDevice {
 public:
     explicit UDPTouchDevice(std::shared_ptr<DeviceStatus> status_) : status(std::move(status_)) {}
-    std::tuple<float, float, bool> GetStatus() const {
+    std::tuple<float, float, bool> GetStatus() const override {
         std::lock_guard guard(status->update_mutex);
         return status->touch_status;
     }
@@ -28,7 +28,7 @@ private:
 class UDPMotionDevice final : public Input::MotionDevice {
 public:
     explicit UDPMotionDevice(std::shared_ptr<DeviceStatus> status_) : status(std::move(status_)) {}
-    std::tuple<Common::Vec3<float>, Common::Vec3<float>> GetStatus() const {
+    std::tuple<Common::Vec3<float>, Common::Vec3<float>> GetStatus() const override {
         std::lock_guard guard(status->update_mutex);
         return status->motion_status;
     }

--- a/src/input_common/udp/udp.cpp
+++ b/src/input_common/udp/udp.cpp
@@ -2,7 +2,9 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "common/logging/log.h"
+#include <mutex>
+#include <tuple>
+
 #include "common/param_package.h"
 #include "core/frontend/input.h"
 #include "core/settings.h"

--- a/src/input_common/udp/udp.h
+++ b/src/input_common/udp/udp.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <memory>
 #include <unordered_map>
 #include "input_common/main.h"

--- a/src/input_common/udp/udp.h
+++ b/src/input_common/udp/udp.h
@@ -5,14 +5,10 @@
 #pragma once
 
 #include <memory>
-#include <unordered_map>
-#include "input_common/main.h"
-#include "input_common/udp/client.h"
 
 namespace InputCommon::CemuhookUDP {
 
-class UDPTouchDevice;
-class UDPMotionDevice;
+class Client;
 
 class State {
 public:


### PR DESCRIPTION
Individual minor changes to the UDP backend that don't really warrant their own PRs by themselves.

Each commit should be fairly self-contained, so they can be reviewed individually. Notably, this corrects the fact that the UDP backend would never actually get shutdown whenever Shutdown() was called.