### PR TITLE
Remove option "Show files with type 'Unknown'"

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -738,7 +738,6 @@ void Config::ReadUIValues() {
 void Config::ReadUIGamelistValues() {
     qt_config->beginGroup(QStringLiteral("UIGameList"));
 
-    UISettings::values.show_unknown = ReadSetting(QStringLiteral("show_unknown"), true).toBool();
     UISettings::values.show_add_ons = ReadSetting(QStringLiteral("show_add_ons"), true).toBool();
     UISettings::values.icon_size = ReadSetting(QStringLiteral("icon_size"), 64).toUInt();
     UISettings::values.row_1_text_id = ReadSetting(QStringLiteral("row_1_text_id"), 3).toUInt();
@@ -1152,7 +1151,6 @@ void Config::SaveUIValues() {
 void Config::SaveUIGamelistValues() {
     qt_config->beginGroup(QStringLiteral("UIGameList"));
 
-    WriteSetting(QStringLiteral("show_unknown"), UISettings::values.show_unknown, true);
     WriteSetting(QStringLiteral("show_add_ons"), UISettings::values.show_add_ons, true);
     WriteSetting(QStringLiteral("icon_size"), UISettings::values.icon_size, 64);
     WriteSetting(QStringLiteral("row_1_text_id"), UISettings::values.row_1_text_id, 3);

--- a/src/yuzu/configuration/configure_ui.cpp
+++ b/src/yuzu/configuration/configure_ui.cpp
@@ -40,7 +40,6 @@ ConfigureUi::ConfigureUi(QWidget* parent) : QWidget(parent), ui(new Ui::Configur
     SetConfiguration();
 
     // Force game list reload if any of the relevant settings are changed.
-    connect(ui->show_unknown, &QCheckBox::stateChanged, this, &ConfigureUi::RequestGameListUpdate);
     connect(ui->icon_size_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &ConfigureUi::RequestGameListUpdate);
     connect(ui->row_1_text_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
@@ -60,7 +59,6 @@ ConfigureUi::~ConfigureUi() = default;
 void ConfigureUi::ApplyConfiguration() {
     UISettings::values.theme =
         ui->theme_combobox->itemData(ui->theme_combobox->currentIndex()).toString();
-    UISettings::values.show_unknown = ui->show_unknown->isChecked();
     UISettings::values.show_add_ons = ui->show_add_ons->isChecked();
     UISettings::values.icon_size = ui->icon_size_combobox->currentData().toUInt();
     UISettings::values.row_1_text_id = ui->row_1_text_combobox->currentData().toUInt();
@@ -74,7 +72,6 @@ void ConfigureUi::RequestGameListUpdate() {
 
 void ConfigureUi::SetConfiguration() {
     ui->theme_combobox->setCurrentIndex(ui->theme_combobox->findData(UISettings::values.theme));
-    ui->show_unknown->setChecked(UISettings::values.show_unknown);
     ui->show_add_ons->setChecked(UISettings::values.show_add_ons);
     ui->icon_size_combobox->setCurrentIndex(
         ui->icon_size_combobox->findData(UISettings::values.icon_size));

--- a/src/yuzu/configuration/configure_ui.ui
+++ b/src/yuzu/configuration/configure_ui.ui
@@ -52,13 +52,6 @@
         <item>
          <layout class="QVBoxLayout" name="GeneralVerticalLayout">
           <item>
-           <widget class="QCheckBox" name="show_unknown">
-            <property name="text">
-             <string>Show files with type 'Unknown'</string>
-            </property>
-           </widget>
-          </item>
-          <item>
            <widget class="QCheckBox" name="show_add_ons">
             <property name="text">
              <string>Show Add-Ons Column</string>

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -298,8 +298,7 @@ void GameListWorker::ScanFileSystem(ScanTarget target, const std::string& dir_pa
             }
 
             const auto file_type = loader->GetFileType();
-            if ((file_type == Loader::FileType::Unknown || file_type == Loader::FileType::Error) &&
-                !UISettings::values.show_unknown) {
+            if (file_type == Loader::FileType::Unknown || file_type == Loader::FileType::Error) {
                 return true;
             }
 

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -89,7 +89,6 @@ struct Values {
     int profile_index;
 
     // Game List
-    bool show_unknown;
     bool show_add_ons;
     uint32_t icon_size;
     uint8_t row_1_text_id;


### PR DESCRIPTION
Removes the option "Show files with type 'Unknown'" as this option serves no functional purpose other than clutter the games list and providing a bad UX. 