### PR TITLE
bcat/backend: Prevent fmt exception in debug log within NullBackend::Clear()

### DIFF
--- a/src/core/hle/service/bcat/backend/backend.cpp
+++ b/src/core/hle/service/bcat/backend/backend.cpp
@@ -117,7 +117,7 @@ bool NullBackend::SynchronizeDirectory(TitleIDVersion title, std::string name,
 }
 
 bool NullBackend::Clear(u64 title_id) {
-    LOG_DEBUG(Service_BCAT, "called, title_id={:016X}");
+    LOG_DEBUG(Service_BCAT, "called, title_id={:016X}", title_id);
 
     return true;
 }

--- a/src/core/hle/service/bcat/backend/backend.cpp
+++ b/src/core/hle/service/bcat/backend/backend.cpp
@@ -123,7 +123,7 @@ bool NullBackend::Clear(u64 title_id) {
 }
 
 void NullBackend::SetPassphrase(u64 title_id, const Passphrase& passphrase) {
-    LOG_DEBUG(Service_BCAT, "called, title_id={:016X}, passphrase = {}", title_id,
+    LOG_DEBUG(Service_BCAT, "called, title_id={:016X}, passphrase={}", title_id,
               Common::HexToString(passphrase));
 }
 


### PR DESCRIPTION
A formatting specifier within Clear wasn't being used, which will cause fmt to throw an exception. This fixes that.