### PR TITLE
query_cache: Implement a query cache and query 21 (samples passed)

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -180,6 +180,8 @@ if (ENABLE_VULKAN)
         renderer_vulkan/vk_memory_manager.h
         renderer_vulkan/vk_pipeline_cache.cpp
         renderer_vulkan/vk_pipeline_cache.h
+        renderer_vulkan/vk_query_cache.cpp
+        renderer_vulkan/vk_query_cache.h
         renderer_vulkan/vk_rasterizer.cpp
         renderer_vulkan/vk_rasterizer.h
         renderer_vulkan/vk_renderpass_cache.cpp

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -74,6 +74,8 @@ add_library(video_core STATIC
     renderer_opengl/gl_stream_buffer.h
     renderer_opengl/gl_texture_cache.cpp
     renderer_opengl/gl_texture_cache.h
+    renderer_opengl/gl_query_cache.cpp
+    renderer_opengl/gl_query_cache.h
     renderer_opengl/maxwell_to_gl.h
     renderer_opengl/renderer_opengl.cpp
     renderer_opengl/renderer_opengl.h

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(video_core STATIC
     memory_manager.h
     morton.cpp
     morton.h
+    query_cache.h
     rasterizer_accelerated.cpp
     rasterizer_accelerated.h
     rasterizer_cache.cpp

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <bitset>
+#include <optional>
 #include <type_traits>
 #include <unordered_map>
 #include <vector>
@@ -1462,6 +1463,9 @@ private:
 
     // Handles a instance drawcall from MME
     void StepInstance(MMEDrawMode expected_mode, u32 count);
+
+    /// Returns a query's value or an empty object if the value will be deferred through a cache.
+    std::optional<u64> GetQueryResult();
 };
 
 #define ASSERT_REG_POSITION(field_name, position)                                                  \

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -409,6 +409,27 @@ public:
             Linear = 1,
         };
 
+        enum class CounterReset : u32 {
+            SampleCnt = 0x01,
+            Unk02 = 0x02,
+            Unk03 = 0x03,
+            Unk04 = 0x04,
+            EmittedPrimitives = 0x10, // Not tested
+            Unk11 = 0x11,
+            Unk12 = 0x12,
+            Unk13 = 0x13,
+            Unk15 = 0x15,
+            Unk16 = 0x16,
+            Unk17 = 0x17,
+            Unk18 = 0x18,
+            Unk1A = 0x1A,
+            Unk1B = 0x1B,
+            Unk1C = 0x1C,
+            Unk1D = 0x1D,
+            Unk1E = 0x1E,
+            GeneratedPrimitives = 0x1F,
+        };
+
         struct Cull {
             enum class FrontFace : u32 {
                 ClockWise = 0x0900,
@@ -857,7 +878,7 @@ public:
                     BitField<7, 1, u32> c7;
                 } clip_distance_enabled;
 
-                INSERT_UNION_PADDING_WORDS(0x1);
+                u32 samplecnt_enable;
 
                 float point_size;
 
@@ -865,7 +886,11 @@ public:
 
                 u32 point_sprite_enable;
 
-                INSERT_UNION_PADDING_WORDS(0x5);
+                INSERT_UNION_PADDING_WORDS(0x3);
+
+                CounterReset counter_reset;
+
+                INSERT_UNION_PADDING_WORDS(0x1);
 
                 u32 zeta_enable;
 
@@ -1412,11 +1437,14 @@ private:
     /// Handles a write to the QUERY_GET register.
     void ProcessQueryGet();
 
-    // Writes the query result accordingly
+    /// Writes the query result accordingly.
     void StampQueryResult(u64 payload, bool long_query);
 
-    // Handles Conditional Rendering
+    /// Handles conditional rendering.
     void ProcessQueryCondition();
+
+    /// Handles counter resets.
+    void ProcessCounterReset();
 
     /// Handles writes to syncing register.
     void ProcessSyncPoint();
@@ -1499,8 +1527,10 @@ ASSERT_REG_POSITION(screen_y_control, 0x4EB);
 ASSERT_REG_POSITION(vb_element_base, 0x50D);
 ASSERT_REG_POSITION(vb_base_instance, 0x50E);
 ASSERT_REG_POSITION(clip_distance_enabled, 0x544);
+ASSERT_REG_POSITION(samplecnt_enable, 0x545);
 ASSERT_REG_POSITION(point_size, 0x546);
 ASSERT_REG_POSITION(point_sprite_enable, 0x548);
+ASSERT_REG_POSITION(counter_reset, 0x54C);
 ASSERT_REG_POSITION(zeta_enable, 0x54E);
 ASSERT_REG_POSITION(multisample_control, 0x54F);
 ASSERT_REG_POSITION(condition, 0x554);

--- a/src/video_core/query_cache.h
+++ b/src/video_core/query_cache.h
@@ -1,0 +1,323 @@
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <iterator>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+#include "common/assert.h"
+#include "core/core.h"
+#include "video_core/engines/maxwell_3d.h"
+#include "video_core/gpu.h"
+#include "video_core/memory_manager.h"
+#include "video_core/rasterizer_interface.h"
+
+namespace VideoCommon {
+
+template <class QueryCache, class HostCounter>
+class CounterStreamBase {
+public:
+    explicit CounterStreamBase(QueryCache& cache, VideoCore::QueryType type)
+        : cache{cache}, type{type} {}
+
+    /// Updates the state of the stream, enabling or disabling as needed.
+    void Update(bool enabled) {
+        if (enabled) {
+            Enable();
+        } else {
+            Disable();
+        }
+    }
+
+    /// Resets the stream to zero. It doesn't disable the query after resetting.
+    void Reset() {
+        if (current) {
+            current->EndQuery();
+
+            // Immediately start a new query to avoid disabling its state.
+            current = cache.Counter(nullptr, type);
+        }
+        last = nullptr;
+    }
+
+    /// Returns the current counter slicing as needed.
+    std::shared_ptr<HostCounter> Current() {
+        if (!current) {
+            return nullptr;
+        }
+        current->EndQuery();
+        last = std::move(current);
+        current = cache.Counter(last, type);
+        return last;
+    }
+
+    /// Returns true when the counter stream is enabled.
+    bool IsEnabled() const {
+        return static_cast<bool>(current);
+    }
+
+private:
+    /// Enables the stream.
+    void Enable() {
+        if (current) {
+            return;
+        }
+        current = cache.Counter(last, type);
+    }
+
+    // Disables the stream.
+    void Disable() {
+        if (current) {
+            current->EndQuery();
+        }
+        last = std::exchange(current, nullptr);
+    }
+
+    QueryCache& cache;
+    const VideoCore::QueryType type;
+
+    std::shared_ptr<HostCounter> current;
+    std::shared_ptr<HostCounter> last;
+};
+
+template <class QueryCache, class CachedQuery, class CounterStream, class HostCounter>
+class QueryCacheBase {
+public:
+    explicit QueryCacheBase(Core::System& system, VideoCore::RasterizerInterface& rasterizer)
+        : system{system}, rasterizer{rasterizer}, streams{{CounterStream{
+                                                      static_cast<QueryCache&>(*this),
+                                                      VideoCore::QueryType::SamplesPassed}}} {}
+
+    void InvalidateRegion(CacheAddr addr, std::size_t size) {
+        FlushAndRemoveRegion(addr, size);
+    }
+
+    void FlushRegion(CacheAddr addr, std::size_t size) {
+        FlushAndRemoveRegion(addr, size);
+    }
+
+    /**
+     * Records a query in GPU mapped memory, potentially marked with a timestamp.
+     * @param gpu_addr  GPU address to flush to when the mapped memory is read.
+     * @param type      Query type, e.g. SamplesPassed.
+     * @param timestamp Timestamp, when empty the flushed query is assumed to be short.
+     */
+    void Query(GPUVAddr gpu_addr, VideoCore::QueryType type, std::optional<u64> timestamp) {
+        auto& memory_manager = system.GPU().MemoryManager();
+        const auto host_ptr = memory_manager.GetPointer(gpu_addr);
+
+        CachedQuery* query = TryGet(ToCacheAddr(host_ptr));
+        if (!query) {
+            const auto cpu_addr = memory_manager.GpuToCpuAddress(gpu_addr);
+            ASSERT_OR_EXECUTE(cpu_addr, return;);
+
+            query = Register(type, *cpu_addr, host_ptr, timestamp.has_value());
+        }
+
+        query->BindCounter(Stream(type).Current(), timestamp);
+    }
+
+    /// Updates counters from GPU state. Expected to be called once per draw, clear or dispatch.
+    void UpdateCounters() {
+        const auto& regs = system.GPU().Maxwell3D().regs;
+        Stream(VideoCore::QueryType::SamplesPassed).Update(regs.samplecnt_enable);
+    }
+
+    /// Resets a counter to zero. It doesn't disable the query after resetting.
+    void ResetCounter(VideoCore::QueryType type) {
+        Stream(type).Reset();
+    }
+
+    /// Returns a new host counter.
+    std::shared_ptr<HostCounter> Counter(std::shared_ptr<HostCounter> dependency,
+                                         VideoCore::QueryType type) {
+        return std::make_shared<HostCounter>(static_cast<QueryCache&>(*this), std::move(dependency),
+                                             type);
+    }
+
+    /// Returns the counter stream of the specified type.
+    CounterStream& Stream(VideoCore::QueryType type) {
+        return streams[static_cast<std::size_t>(type)];
+    }
+
+private:
+    /// Flushes a memory range to guest memory and removes it from the cache.
+    void FlushAndRemoveRegion(CacheAddr addr, std::size_t size) {
+        const u64 addr_begin = static_cast<u64>(addr);
+        const u64 addr_end = addr_begin + static_cast<u64>(size);
+        const auto in_range = [addr_begin, addr_end](CachedQuery& query) {
+            const u64 cache_begin = query.CacheAddr();
+            const u64 cache_end = cache_begin + query.SizeInBytes();
+            return cache_begin < addr_end && addr_begin < cache_end;
+        };
+
+        const u64 page_end = addr_end >> PAGE_SHIFT;
+        for (u64 page = addr_begin >> PAGE_SHIFT; page <= page_end; ++page) {
+            const auto& it = cached_queries.find(page);
+            if (it == std::end(cached_queries)) {
+                continue;
+            }
+            auto& contents = it->second;
+            for (auto& query : contents) {
+                if (!in_range(query)) {
+                    continue;
+                }
+                rasterizer.UpdatePagesCachedCount(query.CpuAddr(), query.SizeInBytes(), -1);
+                query.Flush();
+            }
+            contents.erase(std::remove_if(std::begin(contents), std::end(contents), in_range),
+                           std::end(contents));
+        }
+    }
+
+    /// Registers the passed parameters as cached and returns a pointer to the stored cached query.
+    CachedQuery* Register(VideoCore::QueryType type, VAddr cpu_addr, u8* host_ptr, bool timestamp) {
+        rasterizer.UpdatePagesCachedCount(cpu_addr, CachedQuery::SizeInBytes(timestamp), 1);
+        const u64 page = static_cast<u64>(ToCacheAddr(host_ptr)) >> PAGE_SHIFT;
+        return &cached_queries[page].emplace_back(static_cast<QueryCache&>(*this), type, cpu_addr,
+                                                  host_ptr);
+    }
+
+    /// Tries to a get a cached query. Returns nullptr on failure.
+    CachedQuery* TryGet(CacheAddr addr) {
+        const u64 page = static_cast<u64>(addr) >> PAGE_SHIFT;
+        const auto it = cached_queries.find(page);
+        if (it == std::end(cached_queries)) {
+            return nullptr;
+        }
+        auto& contents = it->second;
+        const auto found = std::find_if(std::begin(contents), std::end(contents),
+                                        [addr](auto& query) { return query.CacheAddr() == addr; });
+        return found != std::end(contents) ? &*found : nullptr;
+    }
+
+    static constexpr std::uintptr_t PAGE_SIZE = 4096;
+    static constexpr int PAGE_SHIFT = 12;
+
+    Core::System& system;
+    VideoCore::RasterizerInterface& rasterizer;
+
+    std::unordered_map<u64, std::vector<CachedQuery>> cached_queries;
+
+    std::array<CounterStream, VideoCore::NumQueryTypes> streams;
+};
+
+template <class QueryCache, class HostCounter>
+class HostCounterBase {
+public:
+    explicit HostCounterBase(std::shared_ptr<HostCounter> dependency)
+        : dependency{std::move(dependency)} {}
+
+    /// Returns the current value of the query.
+    u64 Query() {
+        if (result) {
+            return *result;
+        }
+
+        u64 value = BlockingQuery();
+        if (dependency) {
+            value += dependency->Query();
+        }
+
+        return *(result = value);
+    }
+
+    /// Returns true when flushing this query will potentially wait.
+    bool WaitPending() const noexcept {
+        return result.has_value();
+    }
+
+protected:
+    /// Returns the value of query from the backend API blocking as needed.
+    virtual u64 BlockingQuery() const = 0;
+
+private:
+    std::shared_ptr<HostCounter> dependency; ///< Counter to add to this value.
+    std::optional<u64> result;               ///< Filled with the already returned value.
+};
+
+template <class HostCounter>
+class CachedQueryBase {
+public:
+    explicit CachedQueryBase(VAddr cpu_addr, u8* host_ptr)
+        : cpu_addr{cpu_addr}, host_ptr{host_ptr} {}
+
+    CachedQueryBase(CachedQueryBase&& rhs) noexcept
+        : cpu_addr{rhs.cpu_addr}, host_ptr{rhs.host_ptr}, counter{std::move(rhs.counter)},
+          timestamp{rhs.timestamp} {}
+
+    CachedQueryBase(const CachedQueryBase&) = delete;
+
+    CachedQueryBase& operator=(CachedQueryBase&& rhs) noexcept {
+        cpu_addr = rhs.cpu_addr;
+        host_ptr = rhs.host_ptr;
+        counter = std::move(rhs.counter);
+        timestamp = rhs.timestamp;
+        return *this;
+    }
+
+    /// Flushes the query to guest memory.
+    virtual void Flush() {
+        // When counter is nullptr it means that it's just been reseted. We are supposed to write a
+        // zero in these cases.
+        const u64 value = counter ? counter->Query() : 0;
+        std::memcpy(host_ptr, &value, sizeof(u64));
+
+        if (timestamp) {
+            std::memcpy(host_ptr + TIMESTAMP_OFFSET, &*timestamp, sizeof(u64));
+        }
+    }
+
+    /// Binds a counter to this query.
+    void BindCounter(std::shared_ptr<HostCounter> counter_, std::optional<u64> timestamp_) {
+        if (counter) {
+            // If there's an old counter set it means the query is being rewritten by the game.
+            // To avoid losing the data forever, flush here.
+            Flush();
+        }
+        counter = std::move(counter_);
+        timestamp = timestamp_;
+    }
+
+    VAddr CpuAddr() const noexcept {
+        return cpu_addr;
+    }
+
+    CacheAddr CacheAddr() const noexcept {
+        return ToCacheAddr(host_ptr);
+    }
+
+    u64 SizeInBytes() const noexcept {
+        return SizeInBytes(timestamp.has_value());
+    }
+
+    static u64 SizeInBytes(bool with_timestamp) {
+        return with_timestamp ? LARGE_QUERY_SIZE : SMALL_QUERY_SIZE;
+    }
+
+protected:
+    /// Returns true when querying the counter may potentially block.
+    bool WaitPending() const noexcept {
+        return counter && counter->WaitPending();
+    }
+
+private:
+    static constexpr std::size_t SMALL_QUERY_SIZE = 8;   // Query size without timestamp.
+    static constexpr std::size_t LARGE_QUERY_SIZE = 16;  // Query size with timestamp.
+    static constexpr std::intptr_t TIMESTAMP_OFFSET = 8; // Timestamp offset in a large query.
+
+    VAddr cpu_addr;                       ///< Guest CPU address.
+    u8* host_ptr;                         ///< Writable host pointer.
+    std::shared_ptr<HostCounter> counter; ///< Host counter to query, owns the dependency tree.
+    std::optional<u64> timestamp;         ///< Timestamp to flush to guest memory.
+};
+
+} // namespace VideoCommon

--- a/src/video_core/query_cache.h
+++ b/src/video_core/query_cache.h
@@ -172,7 +172,7 @@ private:
         const u64 addr_begin = static_cast<u64>(addr);
         const u64 addr_end = addr_begin + static_cast<u64>(size);
         const auto in_range = [addr_begin, addr_end](CachedQuery& query) {
-            const u64 cache_begin = query.CacheAddr();
+            const u64 cache_begin = query.GetCacheAddr();
             const u64 cache_end = cache_begin + query.SizeInBytes();
             return cache_begin < addr_end && addr_begin < cache_end;
         };
@@ -212,8 +212,9 @@ private:
             return nullptr;
         }
         auto& contents = it->second;
-        const auto found = std::find_if(std::begin(contents), std::end(contents),
-                                        [addr](auto& query) { return query.CacheAddr() == addr; });
+        const auto found =
+            std::find_if(std::begin(contents), std::end(contents),
+                         [addr](auto& query) { return query.GetCacheAddr() == addr; });
         return found != std::end(contents) ? &*found : nullptr;
     }
 
@@ -326,7 +327,7 @@ public:
         return cpu_addr;
     }
 
-    CacheAddr CacheAddr() const noexcept {
+    CacheAddr GetCacheAddr() const noexcept {
         return ToCacheAddr(host_ptr);
     }
 

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <functional>
+#include <optional>
 #include "common/common_types.h"
 #include "video_core/engines/fermi_2d.h"
 #include "video_core/gpu.h"
@@ -50,7 +51,7 @@ public:
     virtual void ResetCounter(QueryType type) = 0;
 
     /// Records a GPU query and caches it
-    virtual void Query(GPUVAddr gpu_addr, QueryType type) = 0;
+    virtual void Query(GPUVAddr gpu_addr, QueryType type, std::optional<u64> timestamp) = 0;
 
     /// Notify rasterizer that all caches should be flushed to Switch memory
     virtual void FlushAll() = 0;

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -20,6 +20,7 @@ namespace VideoCore {
 enum class QueryType {
     SamplesPassed,
 };
+constexpr std::size_t NumQueryTypes = 1;
 
 enum class LoadCallbackStage {
     Prepare,
@@ -48,8 +49,8 @@ public:
     /// Resets the counter of a query
     virtual void ResetCounter(QueryType type) = 0;
 
-    /// Returns the value of a GPU query
-    virtual u64 Query(QueryType type) = 0;
+    /// Records a GPU query and caches it
+    virtual void Query(GPUVAddr gpu_addr, QueryType type) = 0;
 
     /// Notify rasterizer that all caches should be flushed to Switch memory
     virtual void FlushAll() = 0;

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -17,6 +17,10 @@ class MemoryManager;
 
 namespace VideoCore {
 
+enum class QueryType {
+    SamplesPassed,
+};
+
 enum class LoadCallbackStage {
     Prepare,
     Decompile,
@@ -40,6 +44,12 @@ public:
 
     /// Dispatches a compute shader invocation
     virtual void DispatchCompute(GPUVAddr code_addr) = 0;
+
+    /// Resets the counter of a query
+    virtual void ResetCounter(QueryType type) = 0;
+
+    /// Returns the value of a GPU query
+    virtual u64 Query(QueryType type) = 0;
 
     /// Notify rasterizer that all caches should be flushed to Switch memory
     virtual void FlushAll() = 0;

--- a/src/video_core/renderer_opengl/gl_query_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_query_cache.cpp
@@ -2,58 +2,203 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cstring>
+#include <memory>
+#include <utility>
+#include <vector>
+
 #include <glad/glad.h>
 
+#include "common/assert.h"
+#include "core/core.h"
+#include "video_core/engines/maxwell_3d.h"
+#include "video_core/memory_manager.h"
 #include "video_core/renderer_opengl/gl_query_cache.h"
+#include "video_core/renderer_opengl/gl_rasterizer.h"
 
 namespace OpenGL {
 
-HostCounter::HostCounter(GLenum target) {
-    query.Create(target);
+using VideoCore::QueryType;
+
+namespace {
+
+constexpr std::array<GLenum, VideoCore::NumQueryTypes> QueryTargets = {GL_SAMPLES_PASSED};
+
+constexpr GLenum GetTarget(QueryType type) {
+    return QueryTargets[static_cast<std::size_t>(type)];
 }
 
-HostCounter::~HostCounter() = default;
+} // Anonymous namespace
 
-void HostCounter::UpdateState(bool enabled) {
+CounterStream::CounterStream(QueryCache& cache, QueryType type)
+    : cache{cache}, type{type}, target{GetTarget(type)} {}
+
+CounterStream::~CounterStream() = default;
+
+void CounterStream::Update(bool enabled, bool any_command_queued) {
     if (enabled) {
-        Enable();
-    } else {
-        Disable();
+        if (!current) {
+            current = cache.GetHostCounter(last, type);
+        }
+        return;
     }
+
+    if (current) {
+        EndQuery(any_command_queued);
+    }
+    last = std::exchange(current, nullptr);
 }
 
-void HostCounter::Reset() {
-    counter = 0;
-    Disable();
+void CounterStream::Reset(bool any_command_queued) {
+    if (current) {
+        EndQuery(any_command_queued);
+    }
+    current = nullptr;
+    last = nullptr;
 }
 
-u64 HostCounter::Query() {
-    if (!is_beginned) {
-        return counter;
+std::shared_ptr<HostCounter> CounterStream::GetCurrent(bool any_command_queued) {
+    if (!current) {
+        return nullptr;
     }
-    Disable();
-    u64 value;
-    glGetQueryObjectui64v(query.handle, GL_QUERY_RESULT, &value);
-    Enable();
+    EndQuery(any_command_queued);
+    last = std::move(current);
+    current = cache.GetHostCounter(last, type);
+    return last;
+}
 
-    counter += value;
+void CounterStream::EndQuery(bool any_command_queued) {
+    if (!any_command_queued) {
+        // There are chances a query waited on without commands (glDraw, glClear, glDispatch). Not
+        // having any of these causes a lock. glFlush is considered a command, so we can safely wait
+        // for this. Insert to the OpenGL command stream a flush.
+        glFlush();
+    }
+    glEndQuery(target);
+}
+
+QueryCache::QueryCache(Core::System& system, RasterizerOpenGL& rasterizer)
+    : RasterizerCache{rasterizer}, system{system},
+      rasterizer{rasterizer}, streams{{CounterStream{*this, QueryType::SamplesPassed}}} {}
+
+QueryCache::~QueryCache() = default;
+
+void QueryCache::Query(GPUVAddr gpu_addr, QueryType type) {
+    auto& memory_manager = system.GPU().MemoryManager();
+    const auto host_ptr = memory_manager.GetPointer(gpu_addr);
+
+    auto query = TryGet(host_ptr);
+    if (!query) {
+        const auto cpu_addr = memory_manager.GpuToCpuAddress(gpu_addr);
+        ASSERT_OR_EXECUTE(cpu_addr, return;);
+
+        query = std::make_shared<CachedQuery>(type, *cpu_addr, host_ptr);
+        Register(query);
+    }
+
+    query->SetCounter(GetStream(type).GetCurrent(rasterizer.AnyCommandQueued()));
+    query->MarkAsModified(true, *this);
+}
+
+void QueryCache::UpdateCounters() {
+    auto& samples_passed = GetStream(QueryType::SamplesPassed);
+
+    const auto& regs = system.GPU().Maxwell3D().regs;
+    samples_passed.Update(regs.samplecnt_enable, rasterizer.AnyCommandQueued());
+}
+
+void QueryCache::ResetCounter(QueryType type) {
+    GetStream(type).Reset(rasterizer.AnyCommandQueued());
+}
+
+void QueryCache::Reserve(QueryType type, OGLQuery&& query) {
+    reserved_queries[static_cast<std::size_t>(type)].push_back(std::move(query));
+}
+
+std::shared_ptr<HostCounter> QueryCache::GetHostCounter(std::shared_ptr<HostCounter> dependency,
+                                                        QueryType type) {
+    const auto type_index = static_cast<std::size_t>(type);
+    auto& reserve = reserved_queries[type_index];
+
+    if (reserve.empty()) {
+        return std::make_shared<HostCounter>(*this, std::move(dependency), type);
+    }
+
+    auto counter = std::make_shared<HostCounter>(*this, std::move(dependency), type,
+                                                 std::move(reserve.back()));
+    reserve.pop_back();
     return counter;
 }
 
-void HostCounter::Enable() {
-    if (is_beginned) {
-        return;
+void QueryCache::FlushObjectInner(const std::shared_ptr<CachedQuery>& counter_) {
+    auto& counter = *counter_;
+    auto& stream = GetStream(counter.GetType());
+
+    // Waiting for a query while another query of the same target is enabled locks Nvidia's driver.
+    // To avoid this disable and re-enable keeping the dependency stream.
+    const bool is_enabled = stream.IsEnabled();
+    if (is_enabled) {
+        stream.Update(false, false);
     }
-    is_beginned = true;
-    glBeginQuery(GL_SAMPLES_PASSED, query.handle);
+
+    counter.Flush();
+
+    if (is_enabled) {
+        stream.Update(true, false);
+    }
 }
 
-void HostCounter::Disable() {
-    if (!is_beginned) {
-        return;
+CounterStream& QueryCache::GetStream(QueryType type) {
+    return streams[static_cast<std::size_t>(type)];
+}
+
+HostCounter::HostCounter(QueryCache& cache, std::shared_ptr<HostCounter> dependency, QueryType type)
+    : cache{cache}, type{type}, dependency{std::move(dependency)} {
+    const GLenum target = GetTarget(type);
+    query.Create(target);
+    glBeginQuery(target, query.handle);
+}
+
+HostCounter::HostCounter(QueryCache& cache, std::shared_ptr<HostCounter> dependency, QueryType type,
+                         OGLQuery&& query_)
+    : cache{cache}, type{type}, dependency{std::move(dependency)}, query{std::move(query_)} {
+    glBeginQuery(GetTarget(type), query.handle);
+}
+
+HostCounter::~HostCounter() {
+    cache.Reserve(type, std::move(query));
+}
+
+u64 HostCounter::Query() {
+    if (query.handle == 0) {
+        return result;
     }
-    glEndQuery(GL_SAMPLES_PASSED);
-    is_beginned = false;
+
+    glGetQueryObjectui64v(query.handle, GL_QUERY_RESULT, &result);
+
+    if (dependency) {
+        result += dependency->Query();
+    }
+
+    return result;
+}
+
+CachedQuery::CachedQuery(QueryType type, VAddr cpu_addr, u8* host_ptr)
+    : RasterizerCacheObject{host_ptr}, type{type}, cpu_addr{cpu_addr}, host_ptr{host_ptr} {}
+
+CachedQuery::~CachedQuery() = default;
+
+void CachedQuery::Flush() {
+    const u64 value = counter->Query();
+    std::memcpy(host_ptr, &value, sizeof(value));
+}
+
+void CachedQuery::SetCounter(std::shared_ptr<HostCounter> counter_) {
+    counter = std::move(counter_);
+}
+
+QueryType CachedQuery::GetType() const {
+    return type;
 }
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_query_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_query_cache.cpp
@@ -1,0 +1,59 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <glad/glad.h>
+
+#include "video_core/renderer_opengl/gl_query_cache.h"
+
+namespace OpenGL {
+
+HostCounter::HostCounter(GLenum target) {
+    query.Create(target);
+}
+
+HostCounter::~HostCounter() = default;
+
+void HostCounter::UpdateState(bool enabled) {
+    if (enabled) {
+        Enable();
+    } else {
+        Disable();
+    }
+}
+
+void HostCounter::Reset() {
+    counter = 0;
+    Disable();
+}
+
+u64 HostCounter::Query() {
+    if (!is_beginned) {
+        return counter;
+    }
+    Disable();
+    u64 value;
+    glGetQueryObjectui64v(query.handle, GL_QUERY_RESULT, &value);
+    Enable();
+
+    counter += value;
+    return counter;
+}
+
+void HostCounter::Enable() {
+    if (is_beginned) {
+        return;
+    }
+    is_beginned = true;
+    glBeginQuery(GL_SAMPLES_PASSED, query.handle);
+}
+
+void HostCounter::Disable() {
+    if (!is_beginned) {
+        return;
+    }
+    glEndQuery(GL_SAMPLES_PASSED);
+    is_beginned = false;
+}
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_query_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_query_cache.cpp
@@ -2,8 +2,10 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <cstring>
 #include <memory>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -22,6 +24,13 @@ using VideoCore::QueryType;
 
 namespace {
 
+constexpr std::uintptr_t PAGE_SIZE = 4096;
+constexpr int PAGE_SHIFT = 12;
+
+constexpr std::size_t SMALL_QUERY_SIZE = 8;  // Query size without timestamp
+constexpr std::size_t LARGE_QUERY_SIZE = 16; // Query size with timestamp
+constexpr std::ptrdiff_t TIMESTAMP_OFFSET = 8;
+
 constexpr std::array<GLenum, VideoCore::NumQueryTypes> QueryTargets = {GL_SAMPLES_PASSED};
 
 constexpr GLenum GetTarget(QueryType type) {
@@ -37,23 +46,19 @@ CounterStream::~CounterStream() = default;
 
 void CounterStream::Update(bool enabled, bool any_command_queued) {
     if (enabled) {
-        if (!current) {
-            current = cache.GetHostCounter(last, type);
-        }
-        return;
+        Enable();
+    } else {
+        Disable(any_command_queued);
     }
-
-    if (current) {
-        EndQuery(any_command_queued);
-    }
-    last = std::exchange(current, nullptr);
 }
 
 void CounterStream::Reset(bool any_command_queued) {
     if (current) {
         EndQuery(any_command_queued);
+
+        // Immediately start a new query to avoid disabling its state.
+        current = cache.GetHostCounter(nullptr, type);
     }
-    current = nullptr;
     last = nullptr;
 }
 
@@ -67,6 +72,20 @@ std::shared_ptr<HostCounter> CounterStream::GetCurrent(bool any_command_queued) 
     return last;
 }
 
+void CounterStream::Enable() {
+    if (current) {
+        return;
+    }
+    current = cache.GetHostCounter(last, type);
+}
+
+void CounterStream::Disable(bool any_command_queued) {
+    if (current) {
+        EndQuery(any_command_queued);
+    }
+    last = std::exchange(current, nullptr);
+}
+
 void CounterStream::EndQuery(bool any_command_queued) {
     if (!any_command_queued) {
         // There are chances a query waited on without commands (glDraw, glClear, glDispatch). Not
@@ -78,26 +97,57 @@ void CounterStream::EndQuery(bool any_command_queued) {
 }
 
 QueryCache::QueryCache(Core::System& system, RasterizerOpenGL& rasterizer)
-    : RasterizerCache{rasterizer}, system{system},
-      rasterizer{rasterizer}, streams{{CounterStream{*this, QueryType::SamplesPassed}}} {}
+    : system{system}, rasterizer{rasterizer}, streams{{CounterStream{*this,
+                                                                     QueryType::SamplesPassed}}} {}
 
 QueryCache::~QueryCache() = default;
 
-void QueryCache::Query(GPUVAddr gpu_addr, QueryType type) {
+void QueryCache::InvalidateRegion(CacheAddr addr, std::size_t size) {
+    const u64 addr_begin = static_cast<u64>(addr);
+    const u64 addr_end = addr_begin + static_cast<u64>(size);
+    const auto in_range = [addr_begin, addr_end](CachedQuery& query) {
+        const u64 cache_begin = query.GetCacheAddr();
+        const u64 cache_end = cache_begin + query.GetSizeInBytes();
+        return cache_begin < addr_end && addr_begin < cache_end;
+    };
+
+    const u64 page_end = addr_end >> PAGE_SHIFT;
+    for (u64 page = addr_begin >> PAGE_SHIFT; page <= page_end; ++page) {
+        const auto& it = cached_queries.find(page);
+        if (it == std::end(cached_queries)) {
+            continue;
+        }
+        auto& contents = it->second;
+        for (auto& query : contents) {
+            if (!in_range(query)) {
+                continue;
+            }
+            rasterizer.UpdatePagesCachedCount(query.GetCpuAddr(), query.GetSizeInBytes(), -1);
+            Flush(query);
+        }
+        contents.erase(std::remove_if(std::begin(contents), std::end(contents), in_range),
+                       std::end(contents));
+    }
+}
+
+void QueryCache::FlushRegion(CacheAddr addr, std::size_t size) {
+    // We can handle flushes in the same way as invalidations.
+    InvalidateRegion(addr, size);
+}
+
+void QueryCache::Query(GPUVAddr gpu_addr, QueryType type, std::optional<u64> timestamp) {
     auto& memory_manager = system.GPU().MemoryManager();
     const auto host_ptr = memory_manager.GetPointer(gpu_addr);
 
-    auto query = TryGet(host_ptr);
+    CachedQuery* query = TryGet(ToCacheAddr(host_ptr));
     if (!query) {
         const auto cpu_addr = memory_manager.GpuToCpuAddress(gpu_addr);
         ASSERT_OR_EXECUTE(cpu_addr, return;);
 
-        query = std::make_shared<CachedQuery>(type, *cpu_addr, host_ptr);
-        Register(query);
+        query = &Register(CachedQuery(type, *cpu_addr, host_ptr));
     }
 
-    query->SetCounter(GetStream(type).GetCurrent(rasterizer.AnyCommandQueued()));
-    query->MarkAsModified(true, *this);
+    query->SetCounter(GetStream(type).GetCurrent(rasterizer.AnyCommandQueued()), timestamp);
 }
 
 void QueryCache::UpdateCounters() {
@@ -117,46 +167,59 @@ void QueryCache::Reserve(QueryType type, OGLQuery&& query) {
 
 std::shared_ptr<HostCounter> QueryCache::GetHostCounter(std::shared_ptr<HostCounter> dependency,
                                                         QueryType type) {
-    const auto type_index = static_cast<std::size_t>(type);
-    auto& reserve = reserved_queries[type_index];
-
+    auto& reserve = reserved_queries[static_cast<std::size_t>(type)];
+    OGLQuery query;
     if (reserve.empty()) {
-        return std::make_shared<HostCounter>(*this, std::move(dependency), type);
+        query.Create(GetTarget(type));
+    } else {
+        query = std::move(reserve.back());
+        reserve.pop_back();
     }
 
-    auto counter = std::make_shared<HostCounter>(*this, std::move(dependency), type,
-                                                 std::move(reserve.back()));
-    reserve.pop_back();
-    return counter;
+    return std::make_shared<HostCounter>(*this, std::move(dependency), type, std::move(query));
 }
 
-void QueryCache::FlushObjectInner(const std::shared_ptr<CachedQuery>& counter_) {
-    auto& counter = *counter_;
-    auto& stream = GetStream(counter.GetType());
+CachedQuery& QueryCache::Register(CachedQuery&& cached_query) {
+    const u64 page = static_cast<u64>(cached_query.GetCacheAddr()) >> PAGE_SHIFT;
+    auto& stored_ref = cached_queries[page].emplace_back(std::move(cached_query));
+    rasterizer.UpdatePagesCachedCount(stored_ref.GetCpuAddr(), stored_ref.GetSizeInBytes(), 1);
+    return stored_ref;
+}
+
+CachedQuery* QueryCache::TryGet(CacheAddr addr) {
+    const u64 page = static_cast<u64>(addr) >> PAGE_SHIFT;
+    const auto it = cached_queries.find(page);
+    if (it == std::end(cached_queries)) {
+        return nullptr;
+    }
+    auto& contents = it->second;
+    const auto found =
+        std::find_if(std::begin(contents), std::end(contents),
+                     [addr](const auto& query) { return query.GetCacheAddr() == addr; });
+    return found != std::end(contents) ? &*found : nullptr;
+}
+
+void QueryCache::Flush(CachedQuery& cached_query) {
+    auto& stream = GetStream(cached_query.GetType());
 
     // Waiting for a query while another query of the same target is enabled locks Nvidia's driver.
     // To avoid this disable and re-enable keeping the dependency stream.
-    const bool is_enabled = stream.IsEnabled();
-    if (is_enabled) {
-        stream.Update(false, false);
+    // But we only have to do this if we have pending waits to be done.
+    const bool slice_counter = stream.IsEnabled() && cached_query.WaitPending();
+    const bool any_command_queued = rasterizer.AnyCommandQueued();
+    if (slice_counter) {
+        stream.Update(false, any_command_queued);
     }
 
-    counter.Flush();
+    cached_query.Flush();
 
-    if (is_enabled) {
-        stream.Update(true, false);
+    if (slice_counter) {
+        stream.Update(true, any_command_queued);
     }
 }
 
 CounterStream& QueryCache::GetStream(QueryType type) {
     return streams[static_cast<std::size_t>(type)];
-}
-
-HostCounter::HostCounter(QueryCache& cache, std::shared_ptr<HostCounter> dependency, QueryType type)
-    : cache{cache}, type{type}, dependency{std::move(dependency)} {
-    const GLenum target = GetTarget(type);
-    query.Create(target);
-    glBeginQuery(target, query.handle);
 }
 
 HostCounter::HostCounter(QueryCache& cache, std::shared_ptr<HostCounter> dependency, QueryType type,
@@ -170,35 +233,80 @@ HostCounter::~HostCounter() {
 }
 
 u64 HostCounter::Query() {
-    if (query.handle == 0) {
-        return result;
+    if (result) {
+        return *result;
     }
 
-    glGetQueryObjectui64v(query.handle, GL_QUERY_RESULT, &result);
-
+    u64 value;
+    glGetQueryObjectui64v(query.handle, GL_QUERY_RESULT, &value);
     if (dependency) {
-        result += dependency->Query();
+        value += dependency->Query();
     }
 
-    return result;
+    return *(result = value);
+}
+
+bool HostCounter::WaitPending() const noexcept {
+    return result.has_value();
 }
 
 CachedQuery::CachedQuery(QueryType type, VAddr cpu_addr, u8* host_ptr)
-    : RasterizerCacheObject{host_ptr}, type{type}, cpu_addr{cpu_addr}, host_ptr{host_ptr} {}
+    : type{type}, cpu_addr{cpu_addr}, host_ptr{host_ptr} {}
+
+CachedQuery::CachedQuery(CachedQuery&& rhs) noexcept
+    : type{rhs.type}, cpu_addr{rhs.cpu_addr}, host_ptr{rhs.host_ptr},
+      counter{std::move(rhs.counter)}, timestamp{rhs.timestamp} {}
 
 CachedQuery::~CachedQuery() = default;
 
+CachedQuery& CachedQuery::operator=(CachedQuery&& rhs) noexcept {
+    type = rhs.type;
+    cpu_addr = rhs.cpu_addr;
+    host_ptr = rhs.host_ptr;
+    counter = std::move(rhs.counter);
+    timestamp = rhs.timestamp;
+    return *this;
+}
+
 void CachedQuery::Flush() {
-    const u64 value = counter->Query();
-    std::memcpy(host_ptr, &value, sizeof(value));
+    // When counter is nullptr it means that it's just been reseted. We are supposed to write a zero
+    // in these cases.
+    const u64 value = counter ? counter->Query() : 0;
+    std::memcpy(host_ptr, &value, sizeof(u64));
+
+    if (timestamp) {
+        std::memcpy(host_ptr + TIMESTAMP_OFFSET, &*timestamp, sizeof(u64));
+    }
 }
 
-void CachedQuery::SetCounter(std::shared_ptr<HostCounter> counter_) {
+void CachedQuery::SetCounter(std::shared_ptr<HostCounter> counter_, std::optional<u64> timestamp_) {
+    if (counter) {
+        // If there's an old counter set it means the query is being rewritten by the game.
+        // To avoid losing the data forever, flush here.
+        Flush();
+    }
     counter = std::move(counter_);
+    timestamp = timestamp_;
 }
 
-QueryType CachedQuery::GetType() const {
+bool CachedQuery::WaitPending() const noexcept {
+    return counter && counter->WaitPending();
+}
+
+QueryType CachedQuery::GetType() const noexcept {
     return type;
+}
+
+VAddr CachedQuery::GetCpuAddr() const noexcept {
+    return cpu_addr;
+}
+
+CacheAddr CachedQuery::GetCacheAddr() const noexcept {
+    return ToCacheAddr(host_ptr);
+}
+
+u64 CachedQuery::GetSizeInBytes() const noexcept {
+    return timestamp ? LARGE_QUERY_SIZE : SMALL_QUERY_SIZE;
 }
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_query_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_query_cache.cpp
@@ -20,211 +20,49 @@
 
 namespace OpenGL {
 
-using VideoCore::QueryType;
-
 namespace {
-
-constexpr std::uintptr_t PAGE_SIZE = 4096;
-constexpr int PAGE_SHIFT = 12;
-
-constexpr std::size_t SMALL_QUERY_SIZE = 8;  // Query size without timestamp
-constexpr std::size_t LARGE_QUERY_SIZE = 16; // Query size with timestamp
-constexpr std::ptrdiff_t TIMESTAMP_OFFSET = 8;
 
 constexpr std::array<GLenum, VideoCore::NumQueryTypes> QueryTargets = {GL_SAMPLES_PASSED};
 
-constexpr GLenum GetTarget(QueryType type) {
+constexpr GLenum GetTarget(VideoCore::QueryType type) {
     return QueryTargets[static_cast<std::size_t>(type)];
 }
 
 } // Anonymous namespace
 
-CounterStream::CounterStream(QueryCache& cache, QueryType type)
-    : cache{cache}, type{type}, target{GetTarget(type)} {}
-
-CounterStream::~CounterStream() = default;
-
-void CounterStream::Update(bool enabled, bool any_command_queued) {
-    if (enabled) {
-        Enable();
-    } else {
-        Disable(any_command_queued);
-    }
-}
-
-void CounterStream::Reset(bool any_command_queued) {
-    if (current) {
-        EndQuery(any_command_queued);
-
-        // Immediately start a new query to avoid disabling its state.
-        current = cache.GetHostCounter(nullptr, type);
-    }
-    last = nullptr;
-}
-
-std::shared_ptr<HostCounter> CounterStream::GetCurrent(bool any_command_queued) {
-    if (!current) {
-        return nullptr;
-    }
-    EndQuery(any_command_queued);
-    last = std::move(current);
-    current = cache.GetHostCounter(last, type);
-    return last;
-}
-
-void CounterStream::Enable() {
-    if (current) {
-        return;
-    }
-    current = cache.GetHostCounter(last, type);
-}
-
-void CounterStream::Disable(bool any_command_queued) {
-    if (current) {
-        EndQuery(any_command_queued);
-    }
-    last = std::exchange(current, nullptr);
-}
-
-void CounterStream::EndQuery(bool any_command_queued) {
-    if (!any_command_queued) {
-        // There are chances a query waited on without commands (glDraw, glClear, glDispatch). Not
-        // having any of these causes a lock. glFlush is considered a command, so we can safely wait
-        // for this. Insert to the OpenGL command stream a flush.
-        glFlush();
-    }
-    glEndQuery(target);
-}
-
-QueryCache::QueryCache(Core::System& system, RasterizerOpenGL& rasterizer)
-    : system{system}, rasterizer{rasterizer}, streams{{CounterStream{*this,
-                                                                     QueryType::SamplesPassed}}} {}
+QueryCache::QueryCache(Core::System& system, RasterizerOpenGL& gl_rasterizer)
+    : VideoCommon::QueryCacheBase<QueryCache, CachedQuery, CounterStream,
+                                  HostCounter>{system, static_cast<VideoCore::RasterizerInterface&>(
+                                                           gl_rasterizer)},
+      gl_rasterizer{gl_rasterizer} {}
 
 QueryCache::~QueryCache() = default;
 
-void QueryCache::InvalidateRegion(CacheAddr addr, std::size_t size) {
-    const u64 addr_begin = static_cast<u64>(addr);
-    const u64 addr_end = addr_begin + static_cast<u64>(size);
-    const auto in_range = [addr_begin, addr_end](CachedQuery& query) {
-        const u64 cache_begin = query.GetCacheAddr();
-        const u64 cache_end = cache_begin + query.GetSizeInBytes();
-        return cache_begin < addr_end && addr_begin < cache_end;
-    };
-
-    const u64 page_end = addr_end >> PAGE_SHIFT;
-    for (u64 page = addr_begin >> PAGE_SHIFT; page <= page_end; ++page) {
-        const auto& it = cached_queries.find(page);
-        if (it == std::end(cached_queries)) {
-            continue;
-        }
-        auto& contents = it->second;
-        for (auto& query : contents) {
-            if (!in_range(query)) {
-                continue;
-            }
-            rasterizer.UpdatePagesCachedCount(query.GetCpuAddr(), query.GetSizeInBytes(), -1);
-            Flush(query);
-        }
-        contents.erase(std::remove_if(std::begin(contents), std::end(contents), in_range),
-                       std::end(contents));
-    }
-}
-
-void QueryCache::FlushRegion(CacheAddr addr, std::size_t size) {
-    // We can handle flushes in the same way as invalidations.
-    InvalidateRegion(addr, size);
-}
-
-void QueryCache::Query(GPUVAddr gpu_addr, QueryType type, std::optional<u64> timestamp) {
-    auto& memory_manager = system.GPU().MemoryManager();
-    const auto host_ptr = memory_manager.GetPointer(gpu_addr);
-
-    CachedQuery* query = TryGet(ToCacheAddr(host_ptr));
-    if (!query) {
-        const auto cpu_addr = memory_manager.GpuToCpuAddress(gpu_addr);
-        ASSERT_OR_EXECUTE(cpu_addr, return;);
-
-        query = &Register(CachedQuery(type, *cpu_addr, host_ptr));
-    }
-
-    query->SetCounter(GetStream(type).GetCurrent(rasterizer.AnyCommandQueued()), timestamp);
-}
-
-void QueryCache::UpdateCounters() {
-    auto& samples_passed = GetStream(QueryType::SamplesPassed);
-
-    const auto& regs = system.GPU().Maxwell3D().regs;
-    samples_passed.Update(regs.samplecnt_enable, rasterizer.AnyCommandQueued());
-}
-
-void QueryCache::ResetCounter(QueryType type) {
-    GetStream(type).Reset(rasterizer.AnyCommandQueued());
-}
-
-void QueryCache::Reserve(QueryType type, OGLQuery&& query) {
-    reserved_queries[static_cast<std::size_t>(type)].push_back(std::move(query));
-}
-
-std::shared_ptr<HostCounter> QueryCache::GetHostCounter(std::shared_ptr<HostCounter> dependency,
-                                                        QueryType type) {
-    auto& reserve = reserved_queries[static_cast<std::size_t>(type)];
+OGLQuery QueryCache::AllocateQuery(VideoCore::QueryType type) {
+    auto& reserve = queries_reserve[static_cast<std::size_t>(type)];
     OGLQuery query;
     if (reserve.empty()) {
         query.Create(GetTarget(type));
-    } else {
-        query = std::move(reserve.back());
-        reserve.pop_back();
+        return query;
     }
 
-    return std::make_shared<HostCounter>(*this, std::move(dependency), type, std::move(query));
+    query = std::move(reserve.back());
+    reserve.pop_back();
+    return query;
 }
 
-CachedQuery& QueryCache::Register(CachedQuery&& cached_query) {
-    const u64 page = static_cast<u64>(cached_query.GetCacheAddr()) >> PAGE_SHIFT;
-    auto& stored_ref = cached_queries[page].emplace_back(std::move(cached_query));
-    rasterizer.UpdatePagesCachedCount(stored_ref.GetCpuAddr(), stored_ref.GetSizeInBytes(), 1);
-    return stored_ref;
+void QueryCache::Reserve(VideoCore::QueryType type, OGLQuery&& query) {
+    queries_reserve[static_cast<std::size_t>(type)].push_back(std::move(query));
 }
 
-CachedQuery* QueryCache::TryGet(CacheAddr addr) {
-    const u64 page = static_cast<u64>(addr) >> PAGE_SHIFT;
-    const auto it = cached_queries.find(page);
-    if (it == std::end(cached_queries)) {
-        return nullptr;
-    }
-    auto& contents = it->second;
-    const auto found =
-        std::find_if(std::begin(contents), std::end(contents),
-                     [addr](const auto& query) { return query.GetCacheAddr() == addr; });
-    return found != std::end(contents) ? &*found : nullptr;
+bool QueryCache::AnyCommandQueued() const noexcept {
+    return gl_rasterizer.AnyCommandQueued();
 }
 
-void QueryCache::Flush(CachedQuery& cached_query) {
-    auto& stream = GetStream(cached_query.GetType());
-
-    // Waiting for a query while another query of the same target is enabled locks Nvidia's driver.
-    // To avoid this disable and re-enable keeping the dependency stream.
-    // But we only have to do this if we have pending waits to be done.
-    const bool slice_counter = stream.IsEnabled() && cached_query.WaitPending();
-    const bool any_command_queued = rasterizer.AnyCommandQueued();
-    if (slice_counter) {
-        stream.Update(false, any_command_queued);
-    }
-
-    cached_query.Flush();
-
-    if (slice_counter) {
-        stream.Update(true, any_command_queued);
-    }
-}
-
-CounterStream& QueryCache::GetStream(QueryType type) {
-    return streams[static_cast<std::size_t>(type)];
-}
-
-HostCounter::HostCounter(QueryCache& cache, std::shared_ptr<HostCounter> dependency, QueryType type,
-                         OGLQuery&& query_)
-    : cache{cache}, type{type}, dependency{std::move(dependency)}, query{std::move(query_)} {
+HostCounter::HostCounter(QueryCache& cache, std::shared_ptr<HostCounter> dependency,
+                         VideoCore::QueryType type)
+    : VideoCommon::HostCounterBase<QueryCache, HostCounter>{std::move(dependency)}, cache{cache},
+      type{type}, query{cache.AllocateQuery(type)} {
     glBeginQuery(GetTarget(type), query.handle);
 }
 
@@ -232,81 +70,50 @@ HostCounter::~HostCounter() {
     cache.Reserve(type, std::move(query));
 }
 
-u64 HostCounter::Query() {
-    if (result) {
-        return *result;
+void HostCounter::EndQuery() {
+    if (!cache.AnyCommandQueued()) {
+        // There are chances a query waited on without commands (glDraw, glClear, glDispatch). Not
+        // having any of these causes a lock. glFlush is considered a command, so we can safely wait
+        // for this. Insert to the OpenGL command stream a flush.
+        glFlush();
     }
-
-    u64 value;
-    glGetQueryObjectui64v(query.handle, GL_QUERY_RESULT, &value);
-    if (dependency) {
-        value += dependency->Query();
-    }
-
-    return *(result = value);
+    glEndQuery(GetTarget(type));
 }
 
-bool HostCounter::WaitPending() const noexcept {
-    return result.has_value();
+u64 HostCounter::BlockingQuery() const {
+    GLint64 value;
+    glGetQueryObjecti64v(query.handle, GL_QUERY_RESULT, &value);
+    return static_cast<u64>(value);
 }
 
-CachedQuery::CachedQuery(QueryType type, VAddr cpu_addr, u8* host_ptr)
-    : type{type}, cpu_addr{cpu_addr}, host_ptr{host_ptr} {}
+CachedQuery::CachedQuery(QueryCache& cache, VideoCore::QueryType type, VAddr cpu_addr, u8* host_ptr)
+    : VideoCommon::CachedQueryBase<HostCounter>{cpu_addr, host_ptr}, cache{&cache}, type{type} {}
 
 CachedQuery::CachedQuery(CachedQuery&& rhs) noexcept
-    : type{rhs.type}, cpu_addr{rhs.cpu_addr}, host_ptr{rhs.host_ptr},
-      counter{std::move(rhs.counter)}, timestamp{rhs.timestamp} {}
-
-CachedQuery::~CachedQuery() = default;
+    : VideoCommon::CachedQueryBase<HostCounter>(std::move(rhs)), cache{rhs.cache}, type{rhs.type} {}
 
 CachedQuery& CachedQuery::operator=(CachedQuery&& rhs) noexcept {
+    VideoCommon::CachedQueryBase<HostCounter>::operator=(std::move(rhs));
+    cache = rhs.cache;
     type = rhs.type;
-    cpu_addr = rhs.cpu_addr;
-    host_ptr = rhs.host_ptr;
-    counter = std::move(rhs.counter);
-    timestamp = rhs.timestamp;
     return *this;
 }
 
 void CachedQuery::Flush() {
-    // When counter is nullptr it means that it's just been reseted. We are supposed to write a zero
-    // in these cases.
-    const u64 value = counter ? counter->Query() : 0;
-    std::memcpy(host_ptr, &value, sizeof(u64));
-
-    if (timestamp) {
-        std::memcpy(host_ptr + TIMESTAMP_OFFSET, &*timestamp, sizeof(u64));
+    // Waiting for a query while another query of the same target is enabled locks Nvidia's driver.
+    // To avoid this disable and re-enable keeping the dependency stream.
+    // But we only have to do this if we have pending waits to be done.
+    auto& stream = cache->Stream(type);
+    const bool slice_counter = WaitPending() && stream.IsEnabled();
+    if (slice_counter) {
+        stream.Update(false);
     }
-}
 
-void CachedQuery::SetCounter(std::shared_ptr<HostCounter> counter_, std::optional<u64> timestamp_) {
-    if (counter) {
-        // If there's an old counter set it means the query is being rewritten by the game.
-        // To avoid losing the data forever, flush here.
-        Flush();
+    VideoCommon::CachedQueryBase<HostCounter>::Flush();
+
+    if (slice_counter) {
+        stream.Update(true);
     }
-    counter = std::move(counter_);
-    timestamp = timestamp_;
-}
-
-bool CachedQuery::WaitPending() const noexcept {
-    return counter && counter->WaitPending();
-}
-
-QueryType CachedQuery::GetType() const noexcept {
-    return type;
-}
-
-VAddr CachedQuery::GetCpuAddr() const noexcept {
-    return cpu_addr;
-}
-
-CacheAddr CachedQuery::GetCacheAddr() const noexcept {
-    return ToCacheAddr(host_ptr);
-}
-
-u64 CachedQuery::GetSizeInBytes() const noexcept {
-    return timestamp ? LARGE_QUERY_SIZE : SMALL_QUERY_SIZE;
 }
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_query_cache.h
+++ b/src/video_core/renderer_opengl/gl_query_cache.h
@@ -4,38 +4,131 @@
 
 #pragma once
 
+#include <array>
+#include <memory>
+#include <optional>
+#include <vector>
+
 #include <glad/glad.h>
 
 #include "common/common_types.h"
+#include "video_core/rasterizer_cache.h"
+#include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
+
+namespace Core {
+class System;
+}
 
 namespace OpenGL {
 
+class CachedQuery;
+class HostCounter;
+class RasterizerOpenGL;
+class QueryCache;
+
+class CounterStream final {
+public:
+    explicit CounterStream(QueryCache& cache, VideoCore::QueryType type);
+    ~CounterStream();
+
+    void Update(bool enabled, bool any_command_queued);
+
+    void Reset(bool any_command_queued);
+
+    std::shared_ptr<HostCounter> GetCurrent(bool any_command_queued);
+
+    bool IsEnabled() const {
+        return current != nullptr;
+    }
+
+private:
+    void EndQuery(bool any_command_queued);
+
+    QueryCache& cache;
+
+    std::shared_ptr<HostCounter> current;
+    std::shared_ptr<HostCounter> last;
+    VideoCore::QueryType type;
+    GLenum target;
+};
+
+class QueryCache final : public RasterizerCache<std::shared_ptr<CachedQuery>> {
+public:
+    explicit QueryCache(Core::System& system, RasterizerOpenGL& rasterizer);
+    ~QueryCache();
+
+    void Query(GPUVAddr gpu_addr, VideoCore::QueryType type);
+
+    void UpdateCounters();
+
+    void ResetCounter(VideoCore::QueryType type);
+
+    void Reserve(VideoCore::QueryType type, OGLQuery&& query);
+
+    std::shared_ptr<HostCounter> GetHostCounter(std::shared_ptr<HostCounter> dependency,
+                                                VideoCore::QueryType type);
+
+protected:
+    void FlushObjectInner(const std::shared_ptr<CachedQuery>& counter) override;
+
+private:
+    CounterStream& GetStream(VideoCore::QueryType type);
+
+    Core::System& system;
+    RasterizerOpenGL& rasterizer;
+
+    std::array<CounterStream, VideoCore::NumQueryTypes> streams;
+    std::array<std::vector<OGLQuery>, VideoCore::NumQueryTypes> reserved_queries;
+};
+
 class HostCounter final {
 public:
-    explicit HostCounter(GLenum target);
+    explicit HostCounter(QueryCache& cache, std::shared_ptr<HostCounter> dependency,
+                         VideoCore::QueryType type);
+    explicit HostCounter(QueryCache& cache, std::shared_ptr<HostCounter> dependency,
+                         VideoCore::QueryType type, OGLQuery&& query);
     ~HostCounter();
 
-    /// Enables or disables the counter as required.
-    void UpdateState(bool enabled);
-
-    /// Resets the counter disabling it if needed.
-    void Reset();
-
     /// Returns the current value of the query.
-    /// @note It may harm precision of future queries if the counter is not disabled.
     u64 Query();
 
 private:
-    /// Enables the counter when disabled.
-    void Enable();
+    QueryCache& cache;
+    VideoCore::QueryType type;
 
-    /// Disables the counter when enabled.
-    void Disable();
+    std::shared_ptr<HostCounter> dependency; ///< Counter queued before this one.
+    OGLQuery query;                          ///< OpenGL query.
+    u64 result;                              ///< Added values of the counter.
+};
 
-    OGLQuery query;     ///< OpenGL query.
-    u64 counter{};      ///< Added values of the counter.
-    bool is_beginned{}; ///< True when the OpenGL query is beginned.
+class CachedQuery final : public RasterizerCacheObject {
+public:
+    explicit CachedQuery(VideoCore::QueryType type, VAddr cpu_addr, u8* host_ptr);
+    ~CachedQuery();
+
+    /// Writes the counter value to host memory.
+    void Flush();
+
+    /// Updates the counter this cached query registered in guest memory will write when requested.
+    void SetCounter(std::shared_ptr<HostCounter> counter);
+
+    /// Returns the query type.
+    VideoCore::QueryType GetType() const;
+
+    VAddr GetCpuAddr() const override {
+        return cpu_addr;
+    }
+
+    std::size_t GetSizeInBytes() const override {
+        return sizeof(u64);
+    }
+
+private:
+    VideoCore::QueryType type;
+    VAddr cpu_addr;                       ///< Guest CPU address.
+    u8* host_ptr;                         ///< Writable host pointer.
+    std::shared_ptr<HostCounter> counter; ///< Host counter to query, owns the dependency tree.
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_query_cache.h
+++ b/src/video_core/renderer_opengl/gl_query_cache.h
@@ -7,12 +7,12 @@
 #include <array>
 #include <memory>
 #include <optional>
+#include <unordered_map>
 #include <vector>
 
 #include <glad/glad.h>
 
 #include "common/common_types.h"
-#include "video_core/rasterizer_cache.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 
@@ -43,6 +43,10 @@ public:
     }
 
 private:
+    void Enable();
+
+    void Disable(bool any_command_queued);
+
     void EndQuery(bool any_command_queued);
 
     QueryCache& cache;
@@ -53,12 +57,16 @@ private:
     GLenum target;
 };
 
-class QueryCache final : public RasterizerCache<std::shared_ptr<CachedQuery>> {
+class QueryCache final {
 public:
     explicit QueryCache(Core::System& system, RasterizerOpenGL& rasterizer);
     ~QueryCache();
 
-    void Query(GPUVAddr gpu_addr, VideoCore::QueryType type);
+    void InvalidateRegion(CacheAddr addr, std::size_t size);
+
+    void FlushRegion(CacheAddr addr, std::size_t size);
+
+    void Query(GPUVAddr gpu_addr, VideoCore::QueryType type, std::optional<u64> timestamp);
 
     void UpdateCounters();
 
@@ -69,14 +77,19 @@ public:
     std::shared_ptr<HostCounter> GetHostCounter(std::shared_ptr<HostCounter> dependency,
                                                 VideoCore::QueryType type);
 
-protected:
-    void FlushObjectInner(const std::shared_ptr<CachedQuery>& counter) override;
-
 private:
+    CachedQuery& Register(CachedQuery&& cached_query);
+
+    CachedQuery* TryGet(CacheAddr addr);
+
+    void Flush(CachedQuery& cached_query);
+
     CounterStream& GetStream(VideoCore::QueryType type);
 
     Core::System& system;
     RasterizerOpenGL& rasterizer;
+
+    std::unordered_map<u64, std::vector<CachedQuery>> cached_queries;
 
     std::array<CounterStream, VideoCore::NumQueryTypes> streams;
     std::array<std::vector<OGLQuery>, VideoCore::NumQueryTypes> reserved_queries;
@@ -85,13 +98,14 @@ private:
 class HostCounter final {
 public:
     explicit HostCounter(QueryCache& cache, std::shared_ptr<HostCounter> dependency,
-                         VideoCore::QueryType type);
-    explicit HostCounter(QueryCache& cache, std::shared_ptr<HostCounter> dependency,
                          VideoCore::QueryType type, OGLQuery&& query);
     ~HostCounter();
 
     /// Returns the current value of the query.
     u64 Query();
+
+    /// Returns true when querying this counter will potentially wait for OpenGL.
+    bool WaitPending() const noexcept;
 
 private:
     QueryCache& cache;
@@ -99,36 +113,45 @@ private:
 
     std::shared_ptr<HostCounter> dependency; ///< Counter queued before this one.
     OGLQuery query;                          ///< OpenGL query.
-    u64 result;                              ///< Added values of the counter.
+    std::optional<u64> result;               ///< Added values of the counter.
 };
 
-class CachedQuery final : public RasterizerCacheObject {
+class CachedQuery final {
 public:
     explicit CachedQuery(VideoCore::QueryType type, VAddr cpu_addr, u8* host_ptr);
+    CachedQuery(CachedQuery&&) noexcept;
+    CachedQuery(const CachedQuery&) = delete;
     ~CachedQuery();
+
+    CachedQuery& operator=(CachedQuery&&) noexcept;
 
     /// Writes the counter value to host memory.
     void Flush();
 
     /// Updates the counter this cached query registered in guest memory will write when requested.
-    void SetCounter(std::shared_ptr<HostCounter> counter);
+    void SetCounter(std::shared_ptr<HostCounter> counter, std::optional<u64> timestamp);
+
+    /// Returns true when a flushing this query will potentially wait for OpenGL.
+    bool WaitPending() const noexcept;
 
     /// Returns the query type.
-    VideoCore::QueryType GetType() const;
+    VideoCore::QueryType GetType() const noexcept;
 
-    VAddr GetCpuAddr() const override {
-        return cpu_addr;
-    }
+    /// Returns the guest CPU address for this query.
+    VAddr GetCpuAddr() const noexcept;
 
-    std::size_t GetSizeInBytes() const override {
-        return sizeof(u64);
-    }
+    /// Returns the cache address for this query.
+    CacheAddr GetCacheAddr() const noexcept;
+
+    /// Returns the number of cached bytes.
+    u64 GetSizeInBytes() const noexcept;
 
 private:
-    VideoCore::QueryType type;
+    VideoCore::QueryType type;            ///< Abstracted query type (e.g. samples passed).
     VAddr cpu_addr;                       ///< Guest CPU address.
     u8* host_ptr;                         ///< Writable host pointer.
     std::shared_ptr<HostCounter> counter; ///< Host counter to query, owns the dependency tree.
+    std::optional<u64> timestamp;         ///< Timestamp to flush to guest memory.
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_query_cache.h
+++ b/src/video_core/renderer_opengl/gl_query_cache.h
@@ -1,0 +1,41 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <glad/glad.h>
+
+#include "common/common_types.h"
+#include "video_core/renderer_opengl/gl_resource_manager.h"
+
+namespace OpenGL {
+
+class HostCounter final {
+public:
+    explicit HostCounter(GLenum target);
+    ~HostCounter();
+
+    /// Enables or disables the counter as required.
+    void UpdateState(bool enabled);
+
+    /// Resets the counter disabling it if needed.
+    void Reset();
+
+    /// Returns the current value of the query.
+    /// @note It may harm precision of future queries if the counter is not disabled.
+    u64 Query();
+
+private:
+    /// Enables the counter when disabled.
+    void Enable();
+
+    /// Disables the counter when enabled.
+    void Disable();
+
+    OGLQuery query;     ///< OpenGL query.
+    u64 counter{};      ///< Added values of the counter.
+    bool is_beginned{}; ///< True when the OpenGL query is beginned.
+};
+
+} // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_query_cache.h
+++ b/src/video_core/renderer_opengl/gl_query_cache.h
@@ -6,11 +6,7 @@
 
 #include <array>
 #include <memory>
-#include <optional>
-#include <unordered_map>
 #include <vector>
-
-#include <glad/glad.h>
 
 #include "common/common_types.h"
 #include "video_core/query_cache.h"
@@ -30,8 +26,8 @@ class RasterizerOpenGL;
 
 using CounterStream = VideoCommon::CounterStreamBase<QueryCache, HostCounter>;
 
-class QueryCache final
-    : public VideoCommon::QueryCacheBase<QueryCache, CachedQuery, CounterStream, HostCounter> {
+class QueryCache final : public VideoCommon::QueryCacheBase<QueryCache, CachedQuery, CounterStream,
+                                                            HostCounter, std::vector<OGLQuery>> {
 public:
     explicit QueryCache(Core::System& system, RasterizerOpenGL& rasterizer);
     ~QueryCache();
@@ -44,7 +40,6 @@ public:
 
 private:
     RasterizerOpenGL& gl_rasterizer;
-    std::array<std::vector<OGLQuery>, VideoCore::NumQueryTypes> queries_reserve;
 };
 
 class HostCounter final : public VideoCommon::HostCounterBase<QueryCache, HostCounter> {
@@ -59,7 +54,7 @@ private:
     u64 BlockingQuery() const override;
 
     QueryCache& cache;
-    VideoCore::QueryType type;
+    const VideoCore::QueryType type;
     OGLQuery query;
 };
 

--- a/src/video_core/renderer_opengl/gl_query_cache.h
+++ b/src/video_core/renderer_opengl/gl_query_cache.h
@@ -63,8 +63,10 @@ public:
     explicit CachedQuery(QueryCache& cache, VideoCore::QueryType type, VAddr cpu_addr,
                          u8* host_ptr);
     CachedQuery(CachedQuery&& rhs) noexcept;
+    CachedQuery(const CachedQuery&) = delete;
 
     CachedQuery& operator=(CachedQuery&& rhs) noexcept;
+    CachedQuery& operator=(const CachedQuery&) = delete;
 
     void Flush() override;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -547,6 +547,9 @@ void RasterizerOpenGL::Draw(bool is_indexed, bool is_instanced) {
     MICROPROFILE_SCOPE(OpenGL_Drawing);
     auto& gpu = system.GPU().Maxwell3D();
 
+    const auto& regs = gpu.regs;
+    samples_passed.UpdateState(regs.samplecnt_enable);
+
     SyncRasterizeEnable(state);
     SyncColorMask();
     SyncFragmentColorClampState();
@@ -707,6 +710,27 @@ void RasterizerOpenGL::DispatchCompute(GPUVAddr code_addr) {
     state.ApplyProgramPipeline();
 
     glDispatchCompute(launch_desc.grid_dim_x, launch_desc.grid_dim_y, launch_desc.grid_dim_z);
+}
+
+void RasterizerOpenGL::ResetCounter(VideoCore::QueryType type) {
+    switch (type) {
+    case VideoCore::QueryType::SamplesPassed:
+        samples_passed.Reset();
+        break;
+    default:
+        UNIMPLEMENTED_MSG("type={}", static_cast<u32>(type));
+        break;
+    }
+}
+
+u64 RasterizerOpenGL::Query(VideoCore::QueryType type) {
+    switch (type) {
+    case VideoCore::QueryType::SamplesPassed:
+        return samples_passed.Query();
+    default:
+        UNIMPLEMENTED_MSG("type={}", static_cast<u32>(type));
+        return 1;
+    }
 }
 
 void RasterizerOpenGL::FlushAll() {}

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -722,8 +722,9 @@ void RasterizerOpenGL::ResetCounter(VideoCore::QueryType type) {
     query_cache.ResetCounter(type);
 }
 
-void RasterizerOpenGL::Query(GPUVAddr gpu_addr, VideoCore::QueryType type) {
-    query_cache.Query(gpu_addr, type);
+void RasterizerOpenGL::Query(GPUVAddr gpu_addr, VideoCore::QueryType type,
+                             std::optional<u64> timestamp) {
+    query_cache.Query(gpu_addr, type, timestamp);
 }
 
 void RasterizerOpenGL::FlushAll() {}

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -183,9 +183,22 @@ private:
     /// Syncs the alpha test state to match the guest state
     void SyncAlphaTest();
 
-    /// Check for extension that are not strictly required
-    /// but are needed for correct emulation
+    /// Check for extension that are not strictly required but are needed for correct emulation
     void CheckExtensions();
+
+    std::size_t CalculateVertexArraysSize() const;
+
+    std::size_t CalculateIndexBufferSize() const;
+
+    /// Updates and returns a vertex array object representing current vertex format
+    GLuint SetupVertexFormat();
+
+    void SetupVertexBuffer(GLuint vao);
+    void SetupVertexInstances(GLuint vao);
+
+    GLintptr SetupIndexBuffer();
+
+    void SetupShaders(GLenum primitive_mode);
 
     const Device device;
     OpenGLState state;
@@ -210,20 +223,6 @@ private:
     VertexArrayPushBuffer vertex_array_pushbuffer;
     BindBuffersRangePushBuffer bind_ubo_pushbuffer{GL_UNIFORM_BUFFER};
     BindBuffersRangePushBuffer bind_ssbo_pushbuffer{GL_SHADER_STORAGE_BUFFER};
-
-    std::size_t CalculateVertexArraysSize() const;
-
-    std::size_t CalculateIndexBufferSize() const;
-
-    /// Updates and returns a vertex array object representing current vertex format
-    GLuint SetupVertexFormat();
-
-    void SetupVertexBuffer(GLuint vao);
-    void SetupVertexInstances(GLuint vao);
-
-    GLintptr SetupIndexBuffer();
-
-    void SetupShaders(GLenum primitive_mode);
 
     HostCounter samples_passed{GL_SAMPLES_PASSED};
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -63,7 +63,7 @@ public:
     void Clear() override;
     void DispatchCompute(GPUVAddr code_addr) override;
     void ResetCounter(VideoCore::QueryType type) override;
-    u64 Query(VideoCore::QueryType type) override;
+    void Query(GPUVAddr gpu_addr, VideoCore::QueryType type) override;
     void FlushAll() override;
     void FlushRegion(CacheAddr addr, u64 size) override;
     void InvalidateRegion(CacheAddr addr, u64 size) override;
@@ -77,6 +77,11 @@ public:
                            u32 pixel_stride) override;
     void LoadDiskResources(const std::atomic_bool& stop_loading,
                            const VideoCore::DiskResourceLoadCallback& callback) override;
+
+    /// Returns true when there are commands queued to the OpenGL server.
+    bool AnyCommandQueued() const {
+        return num_queued_commands > 0;
+    }
 
 private:
     /// Configures the color and depth framebuffer states.
@@ -207,6 +212,7 @@ private:
     ShaderCacheOpenGL shader_cache;
     SamplerCacheOpenGL sampler_cache;
     FramebufferCacheOpenGL framebuffer_cache;
+    QueryCache query_cache;
 
     Core::System& system;
     ScreenInfo& screen_info;
@@ -223,8 +229,6 @@ private:
     VertexArrayPushBuffer vertex_array_pushbuffer;
     BindBuffersRangePushBuffer bind_ubo_pushbuffer{GL_UNIFORM_BUFFER};
     BindBuffersRangePushBuffer bind_ssbo_pushbuffer{GL_SHADER_STORAGE_BUFFER};
-
-    HostCounter samples_passed{GL_SAMPLES_PASSED};
 
     /// Number of commands queued to the OpenGL driver. Reseted on flush.
     std::size_t num_queued_commands = 0;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -226,6 +226,9 @@ private:
     void SetupShaders(GLenum primitive_mode);
 
     HostCounter samples_passed{GL_SAMPLES_PASSED};
+
+    /// Number of commands queued to the OpenGL driver. Reseted on flush.
+    std::size_t num_queued_commands = 0;
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -63,7 +63,7 @@ public:
     void Clear() override;
     void DispatchCompute(GPUVAddr code_addr) override;
     void ResetCounter(VideoCore::QueryType type) override;
-    void Query(GPUVAddr gpu_addr, VideoCore::QueryType type) override;
+    void Query(GPUVAddr gpu_addr, VideoCore::QueryType type, std::optional<u64> timestamp) override;
     void FlushAll() override;
     void FlushRegion(CacheAddr addr, u64 size) override;
     void InvalidateRegion(CacheAddr addr, u64 size) override;

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -24,6 +24,7 @@
 #include "video_core/renderer_opengl/gl_buffer_cache.h"
 #include "video_core/renderer_opengl/gl_device.h"
 #include "video_core/renderer_opengl/gl_framebuffer_cache.h"
+#include "video_core/renderer_opengl/gl_query_cache.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/renderer_opengl/gl_sampler_cache.h"
 #include "video_core/renderer_opengl/gl_shader_cache.h"
@@ -61,6 +62,8 @@ public:
     bool DrawMultiBatch(bool is_indexed) override;
     void Clear() override;
     void DispatchCompute(GPUVAddr code_addr) override;
+    void ResetCounter(VideoCore::QueryType type) override;
+    u64 Query(VideoCore::QueryType type) override;
     void FlushAll() override;
     void FlushRegion(CacheAddr addr, u64 size) override;
     void InvalidateRegion(CacheAddr addr, u64 size) override;
@@ -221,6 +224,8 @@ private:
     GLintptr SetupIndexBuffer();
 
     void SetupShaders(GLenum primitive_mode);
+
+    HostCounter samples_passed{GL_SAMPLES_PASSED};
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_resource_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_resource_manager.cpp
@@ -207,4 +207,21 @@ void OGLFramebuffer::Release() {
     handle = 0;
 }
 
+void OGLQuery::Create(GLenum target) {
+    if (handle != 0)
+        return;
+
+    MICROPROFILE_SCOPE(OpenGL_ResourceCreation);
+    glCreateQueries(target, 1, &handle);
+}
+
+void OGLQuery::Release() {
+    if (handle == 0)
+        return;
+
+    MICROPROFILE_SCOPE(OpenGL_ResourceDeletion);
+    glDeleteQueries(1, &handle);
+    handle = 0;
+}
+
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_resource_manager.h
+++ b/src/video_core/renderer_opengl/gl_resource_manager.h
@@ -266,4 +266,29 @@ public:
     GLuint handle = 0;
 };
 
+class OGLQuery : private NonCopyable {
+public:
+    OGLQuery() = default;
+
+    OGLQuery(OGLQuery&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
+
+    ~OGLQuery() {
+        Release();
+    }
+
+    OGLQuery& operator=(OGLQuery&& o) noexcept {
+        Release();
+        handle = std::exchange(o.handle, 0);
+        return *this;
+    }
+
+    /// Creates a new internal OpenGL resource and stores the handle
+    void Create(GLenum target);
+
+    /// Deletes the internal OpenGL resource
+    void Release();
+
+    GLuint handle = 0;
+};
+
 } // namespace OpenGL

--- a/src/video_core/renderer_vulkan/vk_device.cpp
+++ b/src/video_core/renderer_vulkan/vk_device.cpp
@@ -104,6 +104,7 @@ bool VKDevice::Create(const vk::DispatchLoaderDynamic& dldi, vk::Instance instan
     features.depthBiasClamp = true;
     features.geometryShader = true;
     features.tessellationShader = true;
+    features.occlusionQueryPrecise = true;
     features.fragmentStoresAndAtomics = true;
     features.shaderImageGatherExtended = true;
     features.shaderStorageImageWriteWithoutFormat = true;
@@ -116,6 +117,10 @@ bool VKDevice::Create(const vk::DispatchLoaderDynamic& dldi, vk::Instance instan
     vk::PhysicalDevice8BitStorageFeaturesKHR bit8_storage;
     bit8_storage.uniformAndStorageBuffer8BitAccess = true;
     SetNext(next, bit8_storage);
+
+    vk::PhysicalDeviceHostQueryResetFeaturesEXT host_query_reset;
+    host_query_reset.hostQueryReset = true;
+    SetNext(next, host_query_reset);
 
     vk::PhysicalDeviceFloat16Int8FeaturesKHR float16_int8;
     if (is_float16_supported) {
@@ -273,6 +278,7 @@ bool VKDevice::IsSuitable(const vk::DispatchLoaderDynamic& dldi, vk::PhysicalDev
         VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME,
         VK_EXT_SHADER_SUBGROUP_BALLOT_EXTENSION_NAME,
         VK_EXT_SHADER_SUBGROUP_VOTE_EXTENSION_NAME,
+        VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME,
     };
     std::bitset<required_extensions.size()> available_extensions{};
 
@@ -340,6 +346,7 @@ bool VKDevice::IsSuitable(const vk::DispatchLoaderDynamic& dldi, vk::PhysicalDev
         std::make_pair(features.depthBiasClamp, "depthBiasClamp"),
         std::make_pair(features.geometryShader, "geometryShader"),
         std::make_pair(features.tessellationShader, "tessellationShader"),
+        std::make_pair(features.occlusionQueryPrecise, "occlusionQueryPrecise"),
         std::make_pair(features.fragmentStoresAndAtomics, "fragmentStoresAndAtomics"),
         std::make_pair(features.shaderImageGatherExtended, "shaderImageGatherExtended"),
         std::make_pair(features.shaderStorageImageWriteWithoutFormat,
@@ -376,7 +383,7 @@ std::vector<const char*> VKDevice::LoadExtensions(const vk::DispatchLoaderDynami
         }
     };
 
-    extensions.reserve(13);
+    extensions.reserve(14);
     extensions.push_back(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
     extensions.push_back(VK_KHR_16BIT_STORAGE_EXTENSION_NAME);
     extensions.push_back(VK_KHR_8BIT_STORAGE_EXTENSION_NAME);
@@ -384,6 +391,7 @@ std::vector<const char*> VKDevice::LoadExtensions(const vk::DispatchLoaderDynami
     extensions.push_back(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME);
     extensions.push_back(VK_EXT_SHADER_SUBGROUP_BALLOT_EXTENSION_NAME);
     extensions.push_back(VK_EXT_SHADER_SUBGROUP_VOTE_EXTENSION_NAME);
+    extensions.push_back(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
 
     [[maybe_unused]] const bool nsight =
         std::getenv("NVTX_INJECTION64_PATH") || std::getenv("NSIGHT_LAUNCHED");

--- a/src/video_core/renderer_vulkan/vk_query_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_query_cache.cpp
@@ -1,0 +1,122 @@
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "video_core/renderer_vulkan/declarations.h"
+#include "video_core/renderer_vulkan/vk_device.h"
+#include "video_core/renderer_vulkan/vk_query_cache.h"
+#include "video_core/renderer_vulkan/vk_resource_manager.h"
+#include "video_core/renderer_vulkan/vk_scheduler.h"
+
+namespace Vulkan {
+
+namespace {
+
+constexpr std::array QUERY_TARGETS = {vk::QueryType::eOcclusion};
+
+constexpr vk::QueryType GetTarget(VideoCore::QueryType type) {
+    return QUERY_TARGETS[static_cast<std::size_t>(type)];
+}
+
+} // Anonymous namespace
+
+QueryPool::QueryPool() : VKFencedPool{GROW_STEP} {}
+
+QueryPool::~QueryPool() = default;
+
+void QueryPool::Initialize(const VKDevice& device_, VideoCore::QueryType type_) {
+    device = &device_;
+    type = type_;
+}
+
+std::pair<vk::QueryPool, std::uint32_t> QueryPool::Commit(VKFence& fence) {
+    std::size_t index;
+    do {
+        index = CommitResource(fence);
+    } while (usage[index]);
+    usage[index] = true;
+
+    return {*pools[index / GROW_STEP], static_cast<std::uint32_t>(index % GROW_STEP)};
+}
+
+void QueryPool::Allocate(std::size_t begin, std::size_t end) {
+    usage.resize(end);
+
+    const auto dev = device->GetLogical();
+    const u32 size = static_cast<u32>(end - begin);
+    const vk::QueryPoolCreateInfo query_pool_ci({}, GetTarget(type), size, {});
+    pools.push_back(dev.createQueryPoolUnique(query_pool_ci, nullptr, device->GetDispatchLoader()));
+}
+
+void QueryPool::Reserve(std::pair<vk::QueryPool, std::uint32_t> query) {
+    const auto it =
+        std::find_if(std::begin(pools), std::end(pools),
+                     [query_pool = query.first](auto& pool) { return query_pool == *pool; });
+    ASSERT(it != std::end(pools));
+
+    const std::ptrdiff_t pool_index = std::distance(std::begin(pools), it);
+    usage[pool_index * GROW_STEP + static_cast<std::ptrdiff_t>(query.second)] = false;
+}
+
+VKQueryCache::VKQueryCache(Core::System& system, VideoCore::RasterizerInterface& rasterizer,
+                           const VKDevice& device, VKScheduler& scheduler)
+    : VideoCommon::QueryCacheBase<VKQueryCache, CachedQuery, CounterStream, HostCounter,
+                                  QueryPool>{system, rasterizer},
+      device{device}, scheduler{scheduler} {
+    for (std::size_t i = 0; i < static_cast<std::size_t>(VideoCore::NumQueryTypes); ++i) {
+        query_pools[i].Initialize(device, static_cast<VideoCore::QueryType>(i));
+    }
+}
+
+VKQueryCache::~VKQueryCache() = default;
+
+std::pair<vk::QueryPool, std::uint32_t> VKQueryCache::AllocateQuery(VideoCore::QueryType type) {
+    return query_pools[static_cast<std::size_t>(type)].Commit(scheduler.GetFence());
+}
+
+void VKQueryCache::Reserve(VideoCore::QueryType type,
+                           std::pair<vk::QueryPool, std::uint32_t> query) {
+    query_pools[static_cast<std::size_t>(type)].Reserve(query);
+}
+
+HostCounter::HostCounter(VKQueryCache& cache, std::shared_ptr<HostCounter> dependency,
+                         VideoCore::QueryType type)
+    : VideoCommon::HostCounterBase<VKQueryCache, HostCounter>{std::move(dependency)}, cache{cache},
+      type{type}, query{cache.AllocateQuery(type)}, ticks{cache.Scheduler().Ticks()} {
+    const auto dev = cache.Device().GetLogical();
+    cache.Scheduler().Record([dev, query = query](vk::CommandBuffer cmdbuf, auto& dld) {
+        dev.resetQueryPoolEXT(query.first, query.second, 1, dld);
+        cmdbuf.beginQuery(query.first, query.second, vk::QueryControlFlagBits::ePrecise, dld);
+    });
+}
+
+HostCounter::~HostCounter() {
+    cache.Reserve(type, query);
+}
+
+void HostCounter::EndQuery() {
+    cache.Scheduler().Record([query = query](auto cmdbuf, auto& dld) {
+        cmdbuf.endQuery(query.first, query.second, dld);
+    });
+}
+
+u64 HostCounter::BlockingQuery() const {
+    if (ticks >= cache.Scheduler().Ticks()) {
+        cache.Scheduler().Flush();
+    }
+
+    const auto dev = cache.Device().GetLogical();
+    const auto& dld = cache.Device().GetDispatchLoader();
+    u64 value;
+    dev.getQueryPoolResults(query.first, query.second, 1, sizeof(value), &value, sizeof(value),
+                            vk::QueryResultFlagBits::e64 | vk::QueryResultFlagBits::eWait, dld);
+    return value;
+}
+
+} // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -24,6 +24,7 @@
 #include "video_core/renderer_vulkan/vk_descriptor_pool.h"
 #include "video_core/renderer_vulkan/vk_memory_manager.h"
 #include "video_core/renderer_vulkan/vk_pipeline_cache.h"
+#include "video_core/renderer_vulkan/vk_query_cache.h"
 #include "video_core/renderer_vulkan/vk_renderpass_cache.h"
 #include "video_core/renderer_vulkan/vk_resource_manager.h"
 #include "video_core/renderer_vulkan/vk_sampler_cache.h"
@@ -96,7 +97,7 @@ struct ImageView {
     vk::ImageLayout* layout = nullptr;
 };
 
-class RasterizerVulkan : public VideoCore::RasterizerAccelerated {
+class RasterizerVulkan final : public VideoCore::RasterizerAccelerated {
 public:
     explicit RasterizerVulkan(Core::System& system, Core::Frontend::EmuWindow& render_window,
                               VKScreenInfo& screen_info, const VKDevice& device,
@@ -108,6 +109,8 @@ public:
     bool DrawMultiBatch(bool is_indexed) override;
     void Clear() override;
     void DispatchCompute(GPUVAddr code_addr) override;
+    void ResetCounter(VideoCore::QueryType type) override;
+    void Query(GPUVAddr gpu_addr, VideoCore::QueryType type, std::optional<u64> timestamp) override;
     void FlushAll() override;
     void FlushRegion(CacheAddr addr, u64 size) override;
     void InvalidateRegion(CacheAddr addr, u64 size) override;
@@ -247,6 +250,7 @@ private:
     VKPipelineCache pipeline_cache;
     VKBufferCache buffer_cache;
     VKSamplerCache sampler_cache;
+    VKQueryCache query_cache;
 
     std::array<View, Maxwell::NumRenderTargets> color_attachments;
     View zeta_attachment;

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <condition_variable>
 #include <memory>
 #include <optional>
@@ -18,6 +19,7 @@ namespace Vulkan {
 
 class VKDevice;
 class VKFence;
+class VKQueryCache;
 class VKResourceManager;
 
 class VKFenceView {
@@ -67,6 +69,11 @@ public:
     /// Binds a pipeline to the current execution context.
     void BindGraphicsPipeline(vk::Pipeline pipeline);
 
+    /// Assigns the query cache.
+    void SetQueryCache(VKQueryCache& query_cache_) {
+        query_cache = &query_cache_;
+    }
+
     /// Returns true when viewports have been set in the current command buffer.
     bool TouchViewports() {
         return std::exchange(state.viewports, true);
@@ -110,6 +117,11 @@ public:
     /// Gets a reference to the current fence.
     VKFenceView GetFence() const {
         return current_fence;
+    }
+
+    /// Returns the current command buffer tick.
+    u64 Ticks() const {
+        return ticks;
     }
 
 private:
@@ -205,6 +217,8 @@ private:
 
     const VKDevice& device;
     VKResourceManager& resource_manager;
+    VKQueryCache* query_cache = nullptr;
+
     vk::CommandBuffer current_cmdbuf;
     VKFence* current_fence = nullptr;
     VKFence* next_fence = nullptr;
@@ -227,6 +241,7 @@ private:
     Common::SPSCQueue<std::unique_ptr<CommandChunk>> chunk_reserve;
     std::mutex mutex;
     std::condition_variable cv;
+    std::atomic<u64> ticks = 0;
     bool quit = false;
 };
 


### PR DESCRIPTION
Queries are a method to write information from the GPU to GPU and CPU visible memory. The most common types of queries are counters, timestamps and fences.

Khronos' APIs (OpenGL and Vulkan) use ranged queries with the following model:
```
BeginQuery();
Draw();
EndQuery();
value = AskValue();
```
Meanwhile NVN and hardware "queries" do this:
```
ResetCounter();
Draw();
value = AskValue();
```
To emulate this behaviour we add up previous queries to the current ones on request.

Asking for a query value is a costly operation, not because of the action of reading the value itself but because they are a blocking call. It doesn't have to wait for all GPU operations, only until the ranged query was ended. To minimize this cost this PR delays the query up it's read by the CPU.

This is done through a generic implementation in the `VideoCommon` namespace and then implemented on both Vulkan an OpenGL. Vulkan now requires `VK_EXT_host_query_reset`, this is widely available and now part of Vulkan 1.2.

Many games use `GL_SAMPLES_PASSED`, but I've only seen Splatoon 2 using it for visible effects.

- Allows to swim on ink on Splatoon 2 (only works with async off).
- Properly implements conditional rendering on Super Mario Odyssey (it shouldn't have visible effects).

This will be rebased after #3395 is merged.