### PR TITLE
GUI: Add aspect ratio dropdown

### DIFF
--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -27,22 +27,9 @@ FramebufferLayout DefaultFrameLayout(u32 width, u32 height) {
     // so just calculate them both even if the other isn't showing.
     FramebufferLayout res{width, height};
 
-    const auto window_aspect_ratio = static_cast<float>(height) / width;
-    float emulation_aspect_ratio;
-
-    switch (static_cast<Aspect>(Settings::values.aspect_ratio)) {
-    case Aspect::AspectDefault:
-        emulation_aspect_ratio = static_cast<float>(ScreenUndocked::Height) / ScreenUndocked::Width;
-        break;
-    case Aspect::Aspect21by9:
-        emulation_aspect_ratio = 9.f / 21;
-        break;
-    case Aspect::AspectStretch:
-        emulation_aspect_ratio = window_aspect_ratio;
-        break;
-    default:
-        emulation_aspect_ratio = static_cast<float>(ScreenUndocked::Height) / ScreenUndocked::Width;
-    }
+    const float window_aspect_ratio = static_cast<float>(height) / width;
+    float emulation_aspect_ratio = EmulationAspectRatio(
+        static_cast<Aspect>(Settings::values.aspect_ratio), window_aspect_ratio);
 
     const Common::Rectangle<u32> screen_window_area{0, 0, width, height};
     Common::Rectangle<u32> screen = MaxRectangle(screen_window_area, emulation_aspect_ratio);
@@ -69,6 +56,19 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale) {
     }
 
     return DefaultFrameLayout(width, height);
+}
+
+float EmulationAspectRatio(Aspect aspect, float window_aspect_ratio) {
+    switch (aspect) {
+    case Aspect::Default:
+        return static_cast<float>(ScreenUndocked::Height) / ScreenUndocked::Width;
+    case Aspect::Aspect21by9:
+        return 9.0f / 21.0f;
+    case Aspect::StretchToWindow:
+        return window_aspect_ratio;
+    default:
+        return static_cast<float>(ScreenUndocked::Height) / ScreenUndocked::Width;
+    }
 }
 
 } // namespace Layout

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -30,17 +30,17 @@ FramebufferLayout DefaultFrameLayout(u32 width, u32 height) {
     const auto window_aspect_ratio = static_cast<float>(height) / width;
     float emulation_aspect_ratio;
 
-    switch (Settings::values.aspect_ratio) {
-    case 0: // 16:9 (Default)
+    switch (static_cast<Aspect>(Settings::values.aspect_ratio)) {
+    case Aspect::AspectDefault:
         emulation_aspect_ratio = static_cast<float>(ScreenUndocked::Height) / ScreenUndocked::Width;
         break;
-    case 1: // 21:9
+    case Aspect::Aspect21by9:
         emulation_aspect_ratio = 9.f / 21;
         break;
-    case 2: // Stretch to Window
+    case Aspect::AspectStretch:
         emulation_aspect_ratio = window_aspect_ratio;
         break;
-    default: // 16:9
+    default:
         emulation_aspect_ratio = static_cast<float>(ScreenUndocked::Height) / ScreenUndocked::Width;
     }
 

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -28,8 +28,8 @@ FramebufferLayout DefaultFrameLayout(u32 width, u32 height) {
     FramebufferLayout res{width, height};
 
     const float window_aspect_ratio = static_cast<float>(height) / width;
-    float emulation_aspect_ratio = EmulationAspectRatio(
-        static_cast<Aspect>(Settings::values.aspect_ratio), window_aspect_ratio);
+    const float emulation_aspect_ratio = EmulationAspectRatio(
+        static_cast<AspectRatio>(Settings::values.aspect_ratio), window_aspect_ratio);
 
     const Common::Rectangle<u32> screen_window_area{0, 0, width, height};
     Common::Rectangle<u32> screen = MaxRectangle(screen_window_area, emulation_aspect_ratio);
@@ -58,13 +58,15 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale) {
     return DefaultFrameLayout(width, height);
 }
 
-float EmulationAspectRatio(Aspect aspect, float window_aspect_ratio) {
+float EmulationAspectRatio(AspectRatio aspect, float window_aspect_ratio) {
     switch (aspect) {
-    case Aspect::Default:
+    case AspectRatio::Default:
         return static_cast<float>(ScreenUndocked::Height) / ScreenUndocked::Width;
-    case Aspect::Aspect21by9:
+    case AspectRatio::R4_3:
+        return 3.0f / 4.0f;
+    case AspectRatio::R21_9:
         return 9.0f / 21.0f;
-    case Aspect::StretchToWindow:
+    case AspectRatio::StretchToWindow:
         return window_aspect_ratio;
     default:
         return static_cast<float>(ScreenUndocked::Height) / ScreenUndocked::Width;

--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -27,9 +27,22 @@ FramebufferLayout DefaultFrameLayout(u32 width, u32 height) {
     // so just calculate them both even if the other isn't showing.
     FramebufferLayout res{width, height};
 
-    const float emulation_aspect_ratio{static_cast<float>(ScreenUndocked::Height) /
-                                       ScreenUndocked::Width};
     const auto window_aspect_ratio = static_cast<float>(height) / width;
+    float emulation_aspect_ratio;
+
+    switch (Settings::values.aspect_ratio) {
+    case 0: // 16:9 (Default)
+        emulation_aspect_ratio = static_cast<float>(ScreenUndocked::Height) / ScreenUndocked::Width;
+        break;
+    case 1: // 21:9
+        emulation_aspect_ratio = 9.f / 21;
+        break;
+    case 2: // Stretch to Window
+        emulation_aspect_ratio = window_aspect_ratio;
+        break;
+    default: // 16:9
+        emulation_aspect_ratio = static_cast<float>(ScreenUndocked::Height) / ScreenUndocked::Width;
+    }
 
     const Common::Rectangle<u32> screen_window_area{0, 0, width, height};
     Common::Rectangle<u32> screen = MaxRectangle(screen_window_area, emulation_aspect_ratio);

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -18,6 +18,12 @@ enum ScreenDocked : u32 {
     HeightDocked = 1080,
 };
 
+enum class Aspect {
+    AspectDefault,
+    Aspect21by9,
+    AspectStretch,
+};
+
 /// Describes the layout of the window framebuffer
 struct FramebufferLayout {
     u32 width{ScreenUndocked::Width};

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -19,9 +19,9 @@ enum ScreenDocked : u32 {
 };
 
 enum class Aspect {
-    AspectDefault,
+    Default,
     Aspect21by9,
-    AspectStretch,
+    StretchToWindow,
 };
 
 /// Describes the layout of the window framebuffer
@@ -53,5 +53,13 @@ FramebufferLayout DefaultFrameLayout(u32 width, u32 height);
  * @param res_scale resolution scale factor
  */
 FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale);
+
+/**
+ * Convenience method to determine emulation aspect ratio
+ * @param aspect Represents the index of aspect ratio in Settings::values.aspect_ratio
+ * @param window_aspect_ratio Current window aspect ratio
+ * @return Emulation render window aspect ratio
+ */
+float EmulationAspectRatio(Aspect aspect, float window_aspect_ratio);
 
 } // namespace Layout

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -18,9 +18,10 @@ enum ScreenDocked : u32 {
     HeightDocked = 1080,
 };
 
-enum class Aspect {
+enum class AspectRatio {
     Default,
-    Aspect21by9,
+    R4_3,
+    R21_9,
     StretchToWindow,
 };
 
@@ -56,10 +57,10 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale);
 
 /**
  * Convenience method to determine emulation aspect ratio
- * @param aspect Represents the index of aspect ratio in Settings::values.aspect_ratio
+ * @param aspect Represents the index of aspect ratio stored in Settings::values.aspect_ratio
  * @param window_aspect_ratio Current window aspect ratio
  * @return Emulation render window aspect ratio
  */
-float EmulationAspectRatio(Aspect aspect, float window_aspect_ratio);
+float EmulationAspectRatio(AspectRatio aspect, float window_aspect_ratio);
 
 } // namespace Layout

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -429,6 +429,7 @@ struct Values {
     int vulkan_device;
 
     float resolution_factor;
+    int aspect_ratio;
     bool use_frame_limit;
     u16 frame_limit;
     bool use_disk_shader_cache;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -630,6 +630,7 @@ void Config::ReadRendererValues() {
     Settings::values.vulkan_device = ReadSetting(QStringLiteral("vulkan_device"), 0).toInt();
     Settings::values.resolution_factor =
         ReadSetting(QStringLiteral("resolution_factor"), 1.0).toFloat();
+    Settings::values.aspect_ratio = ReadSetting(QStringLiteral("aspect_ratio"), 0).toInt();
     Settings::values.use_frame_limit =
         ReadSetting(QStringLiteral("use_frame_limit"), true).toBool();
     Settings::values.frame_limit = ReadSetting(QStringLiteral("frame_limit"), 100).toInt();
@@ -1064,6 +1065,7 @@ void Config::SaveRendererValues() {
     WriteSetting(QStringLiteral("vulkan_device"), Settings::values.vulkan_device, 0);
     WriteSetting(QStringLiteral("resolution_factor"),
                  static_cast<double>(Settings::values.resolution_factor), 1.0);
+    WriteSetting(QStringLiteral("aspect_ratio"), Settings::values.aspect_ratio, 0);
     WriteSetting(QStringLiteral("use_frame_limit"), Settings::values.use_frame_limit, true);
     WriteSetting(QStringLiteral("frame_limit"), Settings::values.frame_limit, 100);
     WriteSetting(QStringLiteral("use_disk_shader_cache"), Settings::values.use_disk_shader_cache,

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -97,6 +97,7 @@ void ConfigureGraphics::SetConfiguration() {
     ui->api->setCurrentIndex(static_cast<int>(Settings::values.renderer_backend));
     ui->resolution_factor_combobox->setCurrentIndex(
         static_cast<int>(FromResolutionFactor(Settings::values.resolution_factor)));
+    ui->aspect_ratio_combobox->setCurrentIndex(Settings::values.aspect_ratio);
     ui->use_disk_shader_cache->setEnabled(runtime_lock);
     ui->use_disk_shader_cache->setChecked(Settings::values.use_disk_shader_cache);
     ui->use_accurate_gpu_emulation->setChecked(Settings::values.use_accurate_gpu_emulation);
@@ -114,6 +115,7 @@ void ConfigureGraphics::ApplyConfiguration() {
     Settings::values.vulkan_device = vulkan_device;
     Settings::values.resolution_factor =
         ToResolutionFactor(static_cast<Resolution>(ui->resolution_factor_combobox->currentIndex()));
+    Settings::values.aspect_ratio = ui->aspect_ratio_combobox->currentIndex();
     Settings::values.use_disk_shader_cache = ui->use_disk_shader_cache->isChecked();
     Settings::values.use_accurate_gpu_emulation = ui->use_accurate_gpu_emulation->isChecked();
     Settings::values.use_asynchronous_gpu_emulation =

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -156,6 +156,11 @@
             </item>
             <item>
              <property name="text">
+              <string>Force 4:3</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
               <string>Force 21:9</string>
              </property>
             </item>

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -139,6 +139,36 @@
          </layout>
         </item>
         <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <widget class="QLabel" name="ar_label">
+            <property name="text">
+             <string>Aspect Ratio:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="aspect_ratio_combobox">
+            <item>
+             <property name="text">
+              <string>Default (16:9)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Force 21:9</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Stretch to Window</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_3">
           <item>
            <widget class="QLabel" name="bg_label">

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -379,6 +379,8 @@ void Config::ReadValues() {
 
     Settings::values.resolution_factor =
         static_cast<float>(sdl2_config->GetReal("Renderer", "resolution_factor", 1.0));
+    Settings::values.aspect_ratio =
+        static_cast<int>(sdl2_config->GetInteger("Renderer", "aspect_ratio", 0));
     Settings::values.use_frame_limit = sdl2_config->GetBoolean("Renderer", "use_frame_limit", true);
     Settings::values.frame_limit =
         static_cast<u16>(sdl2_config->GetInteger("Renderer", "frame_limit", 100));

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -123,7 +123,7 @@ use_shader_jit =
 resolution_factor =
 
 # Aspect ratio
-# 0: Default (16:9), 1: Force 21:9, 2: Stretch to Window
+# 0: Default (16:9), 1: Force 4:3, 2: Force 21:9, 3: Stretch to Window
 aspect_ratio =
 
 # Whether to enable V-Sync (caps the framerate at 60FPS) or not.

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -122,6 +122,10 @@ use_shader_jit =
 # factor for the Switch resolution
 resolution_factor =
 
+# Aspect ratio
+# 0: Default (16:9), 1: Force 21:9, 2: Stretch to Window
+aspect_ratio =
+
 # Whether to enable V-Sync (caps the framerate at 60FPS) or not.
 # 0 (default): Off, 1: On
 use_vsync =

--- a/src/yuzu_tester/config.cpp
+++ b/src/yuzu_tester/config.cpp
@@ -118,6 +118,8 @@ void Config::ReadValues() {
     // Renderer
     Settings::values.resolution_factor =
         static_cast<float>(sdl2_config->GetReal("Renderer", "resolution_factor", 1.0));
+    Settings::values.aspect_ratio =
+        static_cast<int>(sdl2_config->GetInteger("Renderer", "aspect_ratio", 0));
     Settings::values.use_frame_limit = false;
     Settings::values.frame_limit = 100;
     Settings::values.use_disk_shader_cache =

--- a/src/yuzu_tester/default_ini.h
+++ b/src/yuzu_tester/default_ini.h
@@ -26,6 +26,10 @@ use_shader_jit =
 # factor for the Switch resolution
 resolution_factor =
 
+# Aspect ratio
+# 0: Default (16:9), 1: Force 21:9, 2: Stretch to Window
+aspect_ratio =
+
 # Whether to enable V-Sync (caps the framerate at 60FPS) or not.
 # 0 (default): Off, 1: On
 use_vsync =

--- a/src/yuzu_tester/default_ini.h
+++ b/src/yuzu_tester/default_ini.h
@@ -27,7 +27,7 @@ use_shader_jit =
 resolution_factor =
 
 # Aspect ratio
-# 0: Default (16:9), 1: Force 21:9, 2: Stretch to Window
+# 0: Default (16:9), 1: Force 4:3, 2: Force 21:9, 3: Stretch to Window
 aspect_ratio =
 
 # Whether to enable V-Sync (caps the framerate at 60FPS) or not.


### PR DESCRIPTION
Supersedes #3404 and closes #2427, credit to @Margen67 for discovering the relevant line modification. Special thanks to @raven02 for the initial PR(s).

![image](https://user-images.githubusercontent.com/39850852/74562222-5cafa800-4f38-11ea-8528-144e987d2042.png)

16:9 (Default)
![yuzu_1uQtTbDNxB](https://user-images.githubusercontent.com/39850852/74499702-8faf5880-4eb2-11ea-98cb-8ca206a206de.png)

21:9
![M34DwDy5oL](https://user-images.githubusercontent.com/39850852/74499713-93db7600-4eb2-11ea-91c5-111166873d2f.png)

Stretch to Window
![Pkm5xQU1lo](https://user-images.githubusercontent.com/39850852/74499716-96d66680-4eb2-11ea-8381-a604898b1992.png)
