### PR TITLE
frontend: Set minimum window size to 640x360 instead of 1280x720

### DIFF
--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -46,7 +46,7 @@ private:
 EmuWindow::EmuWindow() {
     // TODO: Find a better place to set this.
     config.min_client_area_size =
-        std::make_pair(Layout::ScreenUndocked::Width / 2, Layout::ScreenUndocked::Height / 2);
+        std::make_pair(Layout::MinimumSize::MinimumWidth, Layout::MinimumSize::MinimumHeight);
     active_config = config;
     touch_state = std::make_shared<TouchState>();
     Input::RegisterFactory<Input::TouchDevice>("emu_window", touch_state);

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -46,7 +46,7 @@ private:
 EmuWindow::EmuWindow() {
     // TODO: Find a better place to set this.
     config.min_client_area_size =
-        std::make_pair(Layout::MinimumSize::MinimumWidth, Layout::MinimumSize::MinimumHeight);
+        std::make_pair(Layout::MinimumSize::Width, Layout::MinimumSize::Height);
     active_config = config;
     touch_state = std::make_shared<TouchState>();
     Input::RegisterFactory<Input::TouchDevice>("emu_window", touch_state);

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -46,7 +46,7 @@ private:
 EmuWindow::EmuWindow() {
     // TODO: Find a better place to set this.
     config.min_client_area_size =
-        std::make_pair(Layout::ScreenUndocked::Width, Layout::ScreenUndocked::Height);
+        std::make_pair(Layout::ScreenUndocked::Width / 2, Layout::ScreenUndocked::Height / 2);
     active_config = config;
     touch_state = std::make_shared<TouchState>();
     Input::RegisterFactory<Input::TouchDevice>("emu_window", touch_state);

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -8,6 +8,11 @@
 
 namespace Layout {
 
+namespace MinimumSize {
+constexpr u32 MinimumWidth = 640;
+constexpr u32 MinimumHeight = 360;
+} // namespace MinimumSize
+
 namespace ScreenUndocked {
 constexpr u32 Width = 1280;
 constexpr u32 Height = 720;

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -9,8 +9,8 @@
 namespace Layout {
 
 namespace MinimumSize {
-constexpr u32 MinimumWidth = 640;
-constexpr u32 MinimumHeight = 360;
+constexpr u32 Width = 640;
+constexpr u32 Height = 360;
 } // namespace MinimumSize
 
 namespace ScreenUndocked {

--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -62,7 +62,7 @@ LoadingScreen::LoadingScreen(QWidget* parent)
     : QWidget(parent), ui(std::make_unique<Ui::LoadingScreen>()),
       previous_stage(VideoCore::LoadCallbackStage::Complete) {
     ui->setupUi(this);
-    setMinimumSize(Layout::MinimumSize::MinimumWidth, Layout::MinimumSize::MinimumHeight);
+    setMinimumSize(Layout::MinimumSize::Width, Layout::MinimumSize::Height);
 
     // Create a fade out effect to hide this loading screen widget.
     // When fading opacity, it will fade to the parent widgets background color, which is why we

--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -61,7 +61,7 @@ LoadingScreen::LoadingScreen(QWidget* parent)
     : QWidget(parent), ui(std::make_unique<Ui::LoadingScreen>()),
       previous_stage(VideoCore::LoadCallbackStage::Complete) {
     ui->setupUi(this);
-    setMinimumSize(1280, 720);
+    setMinimumSize(640, 360);
 
     // Create a fade out effect to hide this loading screen widget.
     // When fading opacity, it will fade to the parent widgets background color, which is why we

--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -19,6 +19,7 @@
 #include <QTime>
 #include <QtConcurrent/QtConcurrentRun>
 #include "common/logging/log.h"
+#include "core/frontend/framebuffer_layout.h"
 #include "core/loader/loader.h"
 #include "ui_loading_screen.h"
 #include "video_core/rasterizer_interface.h"
@@ -61,7 +62,7 @@ LoadingScreen::LoadingScreen(QWidget* parent)
     : QWidget(parent), ui(std::make_unique<Ui::LoadingScreen>()),
       previous_stage(VideoCore::LoadCallbackStage::Complete) {
     ui->setupUi(this);
-    setMinimumSize(640, 360);
+    setMinimumSize(Layout::MinimumSize::MinimumWidth, Layout::MinimumSize::MinimumHeight);
 
     // Create a fade out effect to hide this loading screen widget.
     // When fading opacity, it will fade to the parent widgets background color, which is why we

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -821,6 +821,7 @@ void GMainWindow::ConnectMenuEvents() {
             &GMainWindow::OnDisplayTitleBars);
     connect(ui.action_Show_Filter_Bar, &QAction::triggered, this, &GMainWindow::OnToggleFilterBar);
     connect(ui.action_Show_Status_Bar, &QAction::triggered, statusBar(), &QStatusBar::setVisible);
+    connect(ui.action_Reset_Window_Size, &QAction::triggered, this, &GMainWindow::ResetWindowSize);
 
     // Fullscreen
     ui.action_Fullscreen->setShortcut(
@@ -1805,6 +1806,20 @@ void GMainWindow::ToggleWindowMode() {
             render_window->RestoreGeometry();
             game_list->show();
         }
+    }
+}
+
+void GMainWindow::ResetWindowSize() {
+    const auto aspect_ratio = Layout::EmulationAspectRatio(
+        static_cast<Layout::AspectRatio>(Settings::values.aspect_ratio),
+        static_cast<float>(Layout::ScreenUndocked::Height) / Layout::ScreenUndocked::Width);
+    if (!ui.action_Single_Window_Mode->isChecked()) {
+        render_window->resize(Layout::ScreenUndocked::Height / aspect_ratio,
+                              Layout::ScreenUndocked::Height);
+    } else {
+        resize(Layout::ScreenUndocked::Height / aspect_ratio,
+               Layout::ScreenUndocked::Height + menuBar()->height() +
+                   (ui.action_Show_Status_Bar->isChecked() ? statusBar()->height() : 0));
     }
 }
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -714,13 +714,13 @@ void GMainWindow::InitializeHotkeys() {
 }
 
 void GMainWindow::SetDefaultUIGeometry() {
-    // geometry: 55% of the window contents are in the upper screen half, 45% in the lower half
+    // geometry: 53% of the window contents are in the upper screen half, 47% in the lower half
     const QRect screenRect = QApplication::desktop()->screenGeometry(this);
 
     const int w = screenRect.width() * 2 / 3;
-    const int h = screenRect.height() / 2;
+    const int h = screenRect.height() * 2 / 3;
     const int x = (screenRect.x() + screenRect.width()) / 2 - w / 2;
-    const int y = (screenRect.y() + screenRect.height()) / 2 - h * 55 / 100;
+    const int y = (screenRect.y() + screenRect.height()) / 2 - h * 53 / 100;
 
     setGeometry(x, y, w, h);
 }

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -208,6 +208,7 @@ private slots:
     void ShowFullscreen();
     void HideFullscreen();
     void ToggleWindowMode();
+    void ResetWindowSize();
     void OnCaptureScreenshot();
     void OnCoreError(Core::System::ResultStatus, std::string);
     void OnReinitializeKeys(ReinitializeKeyBehavior behavior);

--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1081</width>
-    <height>730</height>
+    <width>1280</width>
+    <height>720</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -44,7 +44,7 @@
     <rect>
      <x>0</x>
      <y>0</y>
-     <width>1081</width>
+     <width>1280</width>
      <height>21</height>
     </rect>
    </property>
@@ -96,6 +96,7 @@
     <addaction name="action_Display_Dock_Widget_Headers"/>
     <addaction name="action_Show_Filter_Bar"/>
     <addaction name="action_Show_Status_Bar"/>
+    <addaction name="action_Reset_Window_Size"/>
     <addaction name="separator"/>
     <addaction name="menu_View_Debugging"/>
    </widget>
@@ -213,6 +214,11 @@
    </property>
    <property name="text">
     <string>Show Status Bar</string>
+   </property>
+  </action>
+  <action name="action_Reset_Window_Size">
+   <property name="text">
+    <string>Reset Window Size</string>
    </property>
   </action>
   <action name="action_Fullscreen">


### PR DESCRIPTION
Previously the minimum window size was 1280x720, causing some users with monitors/screens with a height of less than 800 pixels (taskbar hidden) or 840 pixels (taskbar visible) have the status bar cut off **and not be able to resize the window below 720p**. This amends the issue by reducing the minimum window size to 640x360.

To those who are confused what this does, and does not do:

1. It **does not** cause the window to run at 360p by default
2. This is just allows users to resize the window below 720p to a minimum of 360p where previously you were not able to,


Before (1280x720):

![yuzu_jdIhxNuuO6](https://user-images.githubusercontent.com/39850852/74563560-10199c00-4f3b-11ea-8a61-7917cee1f99e.png)
![yuzu_CgCDWG6dlG](https://user-images.githubusercontent.com/39850852/74563593-2293d580-4f3b-11ea-8655-4b0ff78f9fee.png)

After (640x360):

![yuzu_lPRg3ZiXT7](https://user-images.githubusercontent.com/39850852/74563617-2d4e6a80-4f3b-11ea-85e3-6984daf8a018.png)
![yuzu_djYBOBkb4J](https://user-images.githubusercontent.com/39850852/74563631-350e0f00-4f3b-11ea-9333-160792fc395d.png)
