### PR TITLE
Kernel: Refactors and Implement a TimeManager and SchedulerLocks

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -187,6 +187,8 @@ add_library(core STATIC
     hle/kernel/synchronization.h
     hle/kernel/thread.cpp
     hle/kernel/thread.h
+    hle/kernel/time_manager.cpp
+    hle/kernel/time_manager.h
     hle/kernel/transfer_memory.cpp
     hle/kernel/transfer_memory.h
     hle/kernel/vm_manager.cpp

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -707,4 +707,12 @@ const Service::SM::ServiceManager& System::ServiceManager() const {
     return *impl->service_manager;
 }
 
+void System::RegisterCoreThread(std::size_t id) {
+    impl->kernel.RegisterCoreThread(id);
+}
+
+void System::RegisterHostThread() {
+    impl->kernel.RegisterHostThread();
+}
+
 } // namespace Core

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -360,6 +360,12 @@ public:
 
     const CurrentBuildProcessID& GetCurrentProcessBuildID() const;
 
+    /// Register a host thread as an emulated CPU Core.
+    void RegisterCoreThread(std::size_t id);
+
+    /// Register a host thread as an auxiliary thread.
+    void RegisterHostThread();
+
 private:
     System();
 

--- a/src/core/hardware_properties.h
+++ b/src/core/hardware_properties.h
@@ -20,6 +20,8 @@ constexpr u32 NUM_CPU_CORES = 4;            // Number of CPU Cores
 
 } // namespace Hardware
 
+constexpr u32 INVALID_HOST_THREAD_ID = 0xFFFFFFFF;
+
 struct EmuThreadHandle {
     u32 host_handle;
     u32 guest_handle;

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -97,8 +97,8 @@ static void ThreadWakeupCallback(u64 thread_handle, [[maybe_unused]] s64 cycles_
 }
 
 struct KernelCore::Impl {
-    explicit Impl(Core::System& system)
-        : system{system}, global_scheduler{system}, synchronization{system} {}
+    explicit Impl(Core::System& system, KernelCore& kernel)
+        : system{system}, global_scheduler{kernel}, synchronization{system} {}
 
     void Initialize(KernelCore& kernel) {
         Shutdown();
@@ -215,7 +215,7 @@ struct KernelCore::Impl {
     Core::System& system;
 };
 
-KernelCore::KernelCore(Core::System& system) : impl{std::make_unique<Impl>(system)} {}
+KernelCore::KernelCore(Core::System& system) : impl{std::make_unique<Impl>(system, *this)} {}
 KernelCore::~KernelCore() {
     Shutdown();
 }
@@ -263,6 +263,14 @@ Kernel::GlobalScheduler& KernelCore::GlobalScheduler() {
 
 const Kernel::GlobalScheduler& KernelCore::GlobalScheduler() const {
     return impl->global_scheduler;
+}
+
+Kernel::Scheduler& KernelCore::Scheduler(std::size_t id) {
+    return impl->cores[id].Scheduler();
+}
+
+const Kernel::Scheduler& KernelCore::Scheduler(std::size_t id) const {
+    return impl->cores[id].Scheduler();
 }
 
 Kernel::PhysicalCore& KernelCore::PhysicalCore(std::size_t id) {

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -27,6 +27,7 @@
 #include "core/hle/kernel/scheduler.h"
 #include "core/hle/kernel/synchronization.h"
 #include "core/hle/kernel/thread.h"
+#include "core/hle/kernel/time_manager.h"
 #include "core/hle/lock.h"
 #include "core/hle/result.h"
 #include "core/memory.h"
@@ -100,7 +101,7 @@ static void ThreadWakeupCallback(u64 thread_handle, [[maybe_unused]] s64 cycles_
 
 struct KernelCore::Impl {
     explicit Impl(Core::System& system, KernelCore& kernel)
-        : system{system}, global_scheduler{kernel}, synchronization{system} {}
+        : system{system}, global_scheduler{kernel}, synchronization{system}, time_manager{system} {}
 
     void Initialize(KernelCore& kernel) {
         Shutdown();
@@ -238,6 +239,7 @@ struct KernelCore::Impl {
     Process* current_process = nullptr;
     Kernel::GlobalScheduler global_scheduler;
     Kernel::Synchronization synchronization;
+    Kernel::TimeManager time_manager;
 
     std::shared_ptr<ResourceLimit> system_resource_limit;
 
@@ -335,6 +337,14 @@ Kernel::Synchronization& KernelCore::Synchronization() {
 
 const Kernel::Synchronization& KernelCore::Synchronization() const {
     return impl->synchronization;
+}
+
+Kernel::TimeManager& KernelCore::TimeManager() {
+    return impl->time_manager;
+}
+
+const Kernel::TimeManager& KernelCore::TimeManager() const {
+    return impl->time_manager;
 }
 
 Core::ExclusiveMonitor& KernelCore::GetExclusiveMonitor() {

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "core/hardware_properties.h"
 #include "core/hle/kernel/object.h"
 
 namespace Core {
@@ -65,7 +66,7 @@ public:
     std::shared_ptr<ResourceLimit> GetSystemResourceLimit() const;
 
     /// Retrieves a shared pointer to a Thread instance within the thread wakeup handle table.
-    std::shared_ptr<Thread> RetrieveThreadFromWakeupCallbackHandleTable(Handle handle) const;
+    std::shared_ptr<Thread> RetrieveThreadFromGlobalHandleTable(Handle handle) const;
 
     /// Adds the given shared pointer to an internal list of active processes.
     void AppendNewProcess(std::shared_ptr<Process> process);
@@ -127,6 +128,18 @@ public:
     /// Determines whether or not the given port is a valid named port.
     bool IsValidNamedPort(NamedPortTable::const_iterator port) const;
 
+    /// Gets the current host_thread/guest_thread handle.
+    Core::EmuThreadHandle GetCurrentEmuThreadId() const;
+
+    /// Gets the current host_thread handle.
+    u32 GetCurrentHostThreadId() const;
+
+    /// Register the current thread as a CPU Core Thread.
+    void RegisterCoreThread(std::size_t core_id);
+
+    /// Register the current thread as a non CPU core thread.
+    void RegisterHostThread();
+
 private:
     friend class Object;
     friend class Process;
@@ -147,11 +160,11 @@ private:
     /// Retrieves the event type used for thread wakeup callbacks.
     const std::shared_ptr<Core::Timing::EventType>& ThreadWakeupCallbackEventType() const;
 
-    /// Provides a reference to the thread wakeup callback handle table.
-    Kernel::HandleTable& ThreadWakeupCallbackHandleTable();
+    /// Provides a reference to the global handle table.
+    Kernel::HandleTable& GlobalHandleTable();
 
-    /// Provides a const reference to the thread wakeup callback handle table.
-    const Kernel::HandleTable& ThreadWakeupCallbackHandleTable() const;
+    /// Provides a const reference to the global handle table.
+    const Kernel::HandleTable& GlobalHandleTable() const;
 
     struct Impl;
     std::unique_ptr<Impl> impl;

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -29,6 +29,7 @@ class HandleTable;
 class PhysicalCore;
 class Process;
 class ResourceLimit;
+class Scheduler;
 class Synchronization;
 class Thread;
 
@@ -86,6 +87,12 @@ public:
 
     /// Gets the sole instance of the global scheduler
     const Kernel::GlobalScheduler& GlobalScheduler() const;
+
+    /// Gets the sole instance of the Scheduler assoviated with cpu core 'id'
+    Kernel::Scheduler& Scheduler(std::size_t id);
+
+    /// Gets the sole instance of the Scheduler assoviated with cpu core 'id'
+    const Kernel::Scheduler& Scheduler(std::size_t id) const;
 
     /// Gets the an instance of the respective physical CPU core.
     Kernel::PhysicalCore& PhysicalCore(std::size_t id);

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -33,6 +33,7 @@ class ResourceLimit;
 class Scheduler;
 class Synchronization;
 class Thread;
+class TimeManager;
 
 /// Represents a single instance of the kernel.
 class KernelCore {
@@ -106,6 +107,12 @@ public:
 
     /// Gets the an instance of the Synchronization Interface.
     const Kernel::Synchronization& Synchronization() const;
+
+    /// Gets the an instance of the TimeManager Interface.
+    Kernel::TimeManager& TimeManager();
+
+    /// Gets the an instance of the TimeManager Interface.
+    const Kernel::TimeManager& TimeManager() const;
 
     /// Stops execution of 'id' core, in order to reschedule a new thread.
     void PrepareReschedule(std::size_t id);

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -8,10 +8,10 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include "core/hardware_properties.h"
 #include "core/hle/kernel/object.h"
 
 namespace Core {
+struct EmuThreadHandle;
 class ExclusiveMonitor;
 class System;
 } // namespace Core
@@ -136,10 +136,10 @@ public:
     bool IsValidNamedPort(NamedPortTable::const_iterator port) const;
 
     /// Gets the current host_thread/guest_thread handle.
-    Core::EmuThreadHandle GetCurrentEmuThreadId() const;
+    Core::EmuThreadHandle GetCurrentEmuThreadID() const;
 
     /// Gets the current host_thread handle.
-    u32 GetCurrentHostThreadId() const;
+    u32 GetCurrentHostThreadID() const;
 
     /// Register the current thread as a CPU Core Thread.
     void RegisterCoreThread(std::size_t core_id);

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -21,7 +21,7 @@
 
 namespace Kernel {
 
-GlobalScheduler::GlobalScheduler(Core::System& system) : system{system} {}
+GlobalScheduler::GlobalScheduler(KernelCore& kernel) : kernel{kernel} {}
 
 GlobalScheduler::~GlobalScheduler() = default;
 
@@ -35,7 +35,7 @@ void GlobalScheduler::RemoveThread(std::shared_ptr<Thread> thread) {
 }
 
 void GlobalScheduler::UnloadThread(std::size_t core) {
-    Scheduler& sched = system.Scheduler(core);
+    Scheduler& sched = kernel.Scheduler(core);
     sched.UnloadThread();
 }
 
@@ -50,7 +50,7 @@ void GlobalScheduler::SelectThread(std::size_t core) {
         sched.is_context_switch_pending = sched.selected_thread != sched.current_thread;
         std::atomic_thread_fence(std::memory_order_seq_cst);
     };
-    Scheduler& sched = system.Scheduler(core);
+    Scheduler& sched = kernel.Scheduler(core);
     Thread* current_thread = nullptr;
     // Step 1: Get top thread in schedule queue.
     current_thread = scheduled_queue[core].empty() ? nullptr : scheduled_queue[core].front();

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -18,6 +18,7 @@
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/scheduler.h"
+#include "core/hle/kernel/time_manager.h"
 
 namespace Kernel {
 
@@ -356,6 +357,29 @@ void GlobalScheduler::Shutdown() {
     thread_list.clear();
 }
 
+void GlobalScheduler::Lock() {
+    Core::EmuThreadHandle current_thread = kernel.GetCurrentEmuThreadId();
+    if (current_thread == current_owner) {
+        ++scope_lock;
+    } else {
+        inner_lock.lock();
+        current_owner = current_thread;
+        scope_lock = 1;
+    }
+}
+
+void GlobalScheduler::Unlock() {
+    if (--scope_lock == 0) {
+        for (std::size_t i = 0; i < Core::Hardware::NUM_CPU_CORES; i++) {
+            SelectThread(i);
+        }
+        current_owner = Core::EmuThreadHandle::InvalidHandle();
+        scope_lock = 1;
+        inner_lock.unlock();
+        // TODO(Blinkhawk): Setup the interrupts and change context on current core.
+    }
+}
+
 Scheduler::Scheduler(Core::System& system, Core::ARM_Interface& cpu_core, std::size_t core_id)
     : system(system), cpu_core(cpu_core), core_id(core_id) {}
 
@@ -483,6 +507,30 @@ void Scheduler::UpdateLastContextSwitchTime(Thread* thread, Process* process) {
 void Scheduler::Shutdown() {
     current_thread = nullptr;
     selected_thread = nullptr;
+}
+
+SchedulerLock::SchedulerLock(KernelCore& kernel) : kernel{kernel} {
+    auto& global_scheduler = kernel.GlobalScheduler();
+    global_scheduler.Lock();
+}
+
+SchedulerLock::~SchedulerLock() {
+    auto& global_scheduler = kernel.GlobalScheduler();
+    global_scheduler.Unlock();
+}
+
+SchedulerLockAndSleep::SchedulerLockAndSleep(KernelCore& kernel, Handle& event_handle,
+                                             Thread* time_task, s64 nanoseconds)
+    : SchedulerLock{kernel}, event_handle{event_handle}, time_task{time_task}, nanoseconds{
+                                                                                   nanoseconds} {
+    event_handle = InvalidHandle;
+}
+
+SchedulerLockAndSleep::~SchedulerLockAndSleep() {
+    if (!sleep_cancelled) {
+        auto& time_manager = kernel.TimeManager();
+        time_manager.ScheduleTimeEvent(event_handle, time_task, nanoseconds);
+    }
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -530,10 +530,11 @@ SchedulerLockAndSleep::SchedulerLockAndSleep(KernelCore& kernel, Handle& event_h
 }
 
 SchedulerLockAndSleep::~SchedulerLockAndSleep() {
-    if (!sleep_cancelled) {
-        auto& time_manager = kernel.TimeManager();
-        time_manager.ScheduleTimeEvent(event_handle, time_task, nanoseconds);
+    if (sleep_cancelled) {
+        return;
     }
+    auto& time_manager = kernel.TimeManager();
+    time_manager.ScheduleTimeEvent(event_handle, time_task, nanoseconds);
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -513,13 +513,11 @@ void Scheduler::Shutdown() {
 }
 
 SchedulerLock::SchedulerLock(KernelCore& kernel) : kernel{kernel} {
-    auto& global_scheduler = kernel.GlobalScheduler();
-    global_scheduler.Lock();
+    kernel.GlobalScheduler().Lock();
 }
 
 SchedulerLock::~SchedulerLock() {
-    auto& global_scheduler = kernel.GlobalScheduler();
-    global_scheduler.Unlock();
+    kernel.GlobalScheduler().Unlock();
 }
 
 SchedulerLockAndSleep::SchedulerLockAndSleep(KernelCore& kernel, Handle& event_handle,

--- a/src/core/hle/kernel/scheduler.h
+++ b/src/core/hle/kernel/scheduler.h
@@ -20,11 +20,12 @@ class System;
 
 namespace Kernel {
 
+class KernelCore;
 class Process;
 
 class GlobalScheduler final {
 public:
-    explicit GlobalScheduler(Core::System& system);
+    explicit GlobalScheduler(KernelCore& kernel);
     ~GlobalScheduler();
 
     /// Adds a new thread to the scheduler
@@ -160,7 +161,7 @@ private:
 
     /// Lists all thread ids that aren't deleted/etc.
     std::vector<std::shared_ptr<Thread>> thread_list;
-    Core::System& system;
+    KernelCore& kernel;
 };
 
 class Scheduler final {

--- a/src/core/hle/kernel/scheduler.h
+++ b/src/core/hle/kernel/scheduler.h
@@ -171,7 +171,7 @@ private:
 
     /// Scheduler lock mechanisms.
     std::mutex inner_lock{}; // TODO(Blinkhawk): Replace for a SpinLock
-    std::atomic<std::size_t> scope_lock{};
+    std::atomic<s64> scope_lock{};
     Core::EmuThreadHandle current_owner{Core::EmuThreadHandle::InvalidHandle()};
 
     /// Lists all thread ids that aren't deleted/etc.
@@ -245,7 +245,7 @@ private:
 
 class SchedulerLock {
 public:
-    SchedulerLock(KernelCore& kernel);
+    explicit SchedulerLock(KernelCore& kernel);
     ~SchedulerLock();
 
 protected:
@@ -254,8 +254,8 @@ protected:
 
 class SchedulerLockAndSleep : public SchedulerLock {
 public:
-    SchedulerLockAndSleep(KernelCore& kernel, Handle& event_handle, Thread* time_task,
-                          s64 nanoseconds);
+    explicit SchedulerLockAndSleep(KernelCore& kernel, Handle& event_handle, Thread* time_task,
+                                   s64 nanoseconds);
     ~SchedulerLockAndSleep();
 
     void CancelSleep() {

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -453,6 +453,10 @@ public:
         is_sync_cancelled = value;
     }
 
+    Handle GetGlobalHandle() const {
+        return global_handle;
+    }
+
 private:
     void SetSchedulingStatus(ThreadSchedStatus new_status);
     void SetCurrentPriority(u32 new_priority);
@@ -514,7 +518,7 @@ private:
     VAddr arb_wait_address{0};
 
     /// Handle used as userdata to reference this object when inserting into the CoreTiming queue.
-    Handle callback_handle = 0;
+    Handle global_handle = 0;
 
     /// Callback that will be invoked when the thread is resumed from a waiting state. If the thread
     /// was waiting via WaitSynchronization then the object will be the last object that became

--- a/src/core/hle/kernel/time_manager.cpp
+++ b/src/core/hle/kernel/time_manager.cpp
@@ -1,0 +1,42 @@
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/core.h"
+#include "core/core_timing.h"
+#include "core/core_timing_util.h"
+#include "core/hle/kernel/handle_table.h"
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/kernel/thread.h"
+#include "core/hle/kernel/time_manager.h"
+
+namespace Kernel {
+
+TimeManager::TimeManager(Core::System& system) : system{system} {
+    time_manager_event_type = Core::Timing::CreateEvent(
+        "Kernel::TimeManagerCallback", [this](u64 thread_handle, [[maybe_unused]] s64 cycles_late) {
+            Handle proper_handle = static_cast<Handle>(thread_handle);
+            std::shared_ptr<Thread> thread =
+                this->system.Kernel().RetrieveThreadFromGlobalHandleTable(proper_handle);
+            thread->ResumeFromWait();
+        });
+}
+
+void TimeManager::ScheduleTimeEvent(Handle& event_handle, Thread* timetask, s64 nanoseconds) {
+    if (nanoseconds > 0) {
+        ASSERT(timetask);
+        event_handle = timetask->GetGlobalHandle();
+        const s64 cycles = Core::Timing::nsToCycles(std::chrono::nanoseconds{nanoseconds});
+        system.CoreTiming().ScheduleEvent(cycles, time_manager_event_type, event_handle);
+    } else {
+        event_handle = InvalidHandle;
+    }
+}
+
+void TimeManager::UnscheduleTimeEvent(Handle event_handle) {
+    if (event_handle != InvalidHandle) {
+        system.CoreTiming().UnscheduleEvent(time_manager_event_type, event_handle);
+    }
+}
+
+} // namespace Kernel

--- a/src/core/hle/kernel/time_manager.cpp
+++ b/src/core/hle/kernel/time_manager.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/assert.h"
 #include "core/core.h"
 #include "core/core_timing.h"
 #include "core/core_timing_util.h"
@@ -34,9 +35,10 @@ void TimeManager::ScheduleTimeEvent(Handle& event_handle, Thread* timetask, s64 
 }
 
 void TimeManager::UnscheduleTimeEvent(Handle event_handle) {
-    if (event_handle != InvalidHandle) {
-        system.CoreTiming().UnscheduleEvent(time_manager_event_type, event_handle);
+    if (event_handle == InvalidHandle) {
+        return;
     }
+    system.CoreTiming().UnscheduleEvent(time_manager_event_type, event_handle);
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/time_manager.h
+++ b/src/core/hle/kernel/time_manager.h
@@ -1,0 +1,36 @@
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+
+#include "core/hle/kernel/object.h"
+
+namespace Core {
+class System;
+} // namespace Core
+
+namespace Core::Timing {
+struct EventType;
+} // namespace Core::Timing
+
+namespace Kernel {
+
+class Thread;
+
+class TimeManager {
+public:
+    TimeManager(Core::System& system);
+
+    void ScheduleTimeEvent(Handle& event_handle, Thread* timetask, s64 nanoseconds);
+
+    void UnscheduleTimeEvent(Handle event_handle);
+
+private:
+    Core::System& system;
+    std::shared_ptr<Core::Timing::EventType> time_manager_event_type;
+};
+
+} // namespace Kernel

--- a/src/core/hle/kernel/time_manager.h
+++ b/src/core/hle/kernel/time_manager.h
@@ -20,12 +20,19 @@ namespace Kernel {
 
 class Thread;
 
+/**
+ * The `TimeManager` takes care of scheduling time events on threads and executes their TimeUp
+ * method when the event is triggered.
+ */
 class TimeManager {
 public:
-    TimeManager(Core::System& system);
+    explicit TimeManager(Core::System& system);
 
+    /// Schedule a time event on `timetask` thread that will expire in 'nanoseconds'
+    /// returns a non-invalid handle in `event_handle` if correctly scheduled
     void ScheduleTimeEvent(Handle& event_handle, Thread* timetask, s64 nanoseconds);
 
+    /// Unschedule an existing time event
     void UnscheduleTimeEvent(Handle event_handle);
 
 private:


### PR DESCRIPTION
This PR introduces TimeManager and SchedulerLocks to the kernel, also known as Critical Sections (This are private within the global scheduler)