### PR TITLE
IUserLocalCommunicationService: stub function Initialize2

### DIFF
--- a/src/core/hle/service/ldn/ldn.cpp
+++ b/src/core/hle/service/ldn/ldn.cpp
@@ -129,7 +129,7 @@ public:
             {304, nullptr, "Disconnect"},
             {400, nullptr, "Initialize"},
             {401, nullptr, "Finalize"},
-            {402, nullptr, "SetOperationMode"},
+            {402, nullptr, "Initialize2"},
         };
         // clang-format on
 

--- a/src/core/hle/service/ldn/ldn.cpp
+++ b/src/core/hle/service/ldn/ldn.cpp
@@ -129,11 +129,19 @@ public:
             {304, nullptr, "Disconnect"},
             {400, nullptr, "Initialize"},
             {401, nullptr, "Finalize"},
-            {402, nullptr, "Initialize2"},
+            {402, &IUserLocalCommunicationService::Initialize2, "Initialize2"}, // 7.0.0+
         };
         // clang-format on
 
         RegisterHandlers(functions);
+    }
+
+    void Initialize2(Kernel::HLERequestContext& ctx) {
+        LOG_WARNING(Service_LDN, "(STUBBED) called");
+        // Result success seem make this services start network and continue.
+        // If we just pass result error then it will stop and maybe try again and again.
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_UNKNOWN);
     }
 };
 


### PR DESCRIPTION
Rename incorrect function `SetOperationMode` to `Initialize2` follow https://switchbrew.org/wiki/LDN_services#IUserLocalCommunicationService

Fix issue #3119 by stubbed Initialize2 function. Help Pokemon sword pass this crash.