### PR TITLE
Fix CMake build errors for certain SDL2 installations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,8 +157,14 @@ if (ENABLE_SDL2)
         target_include_directories(SDL2 INTERFACE "${SDL2_INCLUDE_DIR}")
     else()
         find_package(SDL2 REQUIRED)
-        include_directories(${SDL2_INCLUDE_DIRS})
 
+        # Some installations don't set SDL2_LIBRARIES
+        if("${SDL2_LIBRARIES}" STREQUAL "")
+            message(WARNING "SDL2_LIBRARIES wasn't set, manually setting to SDL2::SDL2")
+            set(SDL2_LIBRARIES "SDL2::SDL2")
+        endif()
+
+        include_directories(${SDL2_INCLUDE_DIRS})
         add_library(SDL2 INTERFACE)
         target_link_libraries(SDL2 INTERFACE "${SDL2_LIBRARIES}")
     endif()


### PR DESCRIPTION
Previous commit led to a regression for Arch Linux users. This patch should fix that issue. See [here](https://discourse.libsdl.org/t/arch-linux-cmake-find-package-sdl2-required-passes-but-doesnt-find-anything/24226/2) and [here](https://github.com/tsoding/nothing/issues/923#issuecomment-506370650) for more information. Fixes #3426.