### PR TITLE
frontend/Graphics: Add "Advanced" graphics tab and experimental Anisotropic Filtering support

### DIFF
--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -430,6 +430,7 @@ struct Values {
 
     float resolution_factor;
     int aspect_ratio;
+    int max_anisotropy;
     bool use_frame_limit;
     u16 frame_limit;
     bool use_disk_shader_cache;

--- a/src/video_core/renderer_opengl/gl_sampler_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_sampler_cache.cpp
@@ -38,7 +38,7 @@ OGLSampler SamplerCacheOpenGL::CreateSampler(const Tegra::Texture::TSCEntry& tsc
         glSamplerParameterf(sampler_id, GL_TEXTURE_MAX_ANISOTROPY, tsc.GetMaxAnisotropy());
     } else if (GLAD_GL_EXT_texture_filter_anisotropic) {
         glSamplerParameterf(sampler_id, GL_TEXTURE_MAX_ANISOTROPY_EXT, tsc.GetMaxAnisotropy());
-    } else if (tsc.GetMaxAnisotropy() != 1) {
+    } else {
         LOG_WARNING(Render_OpenGL, "Anisotropy not supported by host GPU driver");
     }
 

--- a/src/video_core/textures/texture.h
+++ b/src/video_core/textures/texture.h
@@ -8,6 +8,7 @@
 #include "common/assert.h"
 #include "common/bit_field.h"
 #include "common/common_types.h"
+#include "core/settings.h"
 
 namespace Tegra::Texture {
 
@@ -294,6 +295,14 @@ enum class TextureMipmapFilter : u32 {
     Linear = 3,
 };
 
+enum class Anisotropy {
+    Default,
+    Filter2x,
+    Filter4x,
+    Filter8x,
+    Filter16x,
+};
+
 struct TSCEntry {
     union {
         struct {
@@ -328,7 +337,20 @@ struct TSCEntry {
     };
 
     float GetMaxAnisotropy() const {
-        return static_cast<float>(1U << max_anisotropy);
+        switch (static_cast<Anisotropy>(Settings::values.max_anisotropy)) {
+        case Anisotropy::Default:
+            return static_cast<float>(1U << max_anisotropy);
+        case Anisotropy::Filter2x:
+            return static_cast<float>(2U << max_anisotropy);
+        case Anisotropy::Filter4x:
+            return static_cast<float>(4U << max_anisotropy);
+        case Anisotropy::Filter8x:
+            return static_cast<float>(8U << max_anisotropy);
+        case Anisotropy::Filter16x:
+            return static_cast<float>(16U << max_anisotropy);
+        default:
+            return static_cast<float>(1U << max_anisotropy);
+        }
     }
 
     float GetMinLod() const {

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -42,6 +42,9 @@ add_executable(yuzu
     configuration/configure_graphics.cpp
     configuration/configure_graphics.h
     configuration/configure_graphics.ui
+    configuration/configure_graphics_advanced.cpp
+    configuration/configure_graphics_advanced.h
+    configuration/configure_graphics_advanced.ui
     configuration/configure_hotkeys.cpp
     configuration/configure_hotkeys.h
     configuration/configure_hotkeys.ui

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -631,6 +631,7 @@ void Config::ReadRendererValues() {
     Settings::values.resolution_factor =
         ReadSetting(QStringLiteral("resolution_factor"), 1.0).toFloat();
     Settings::values.aspect_ratio = ReadSetting(QStringLiteral("aspect_ratio"), 0).toInt();
+    Settings::values.max_anisotropy = ReadSetting(QStringLiteral("max_anisotropy"), 0).toInt();
     Settings::values.use_frame_limit =
         ReadSetting(QStringLiteral("use_frame_limit"), true).toBool();
     Settings::values.frame_limit = ReadSetting(QStringLiteral("frame_limit"), 100).toInt();
@@ -1067,6 +1068,7 @@ void Config::SaveRendererValues() {
     WriteSetting(QStringLiteral("resolution_factor"),
                  static_cast<double>(Settings::values.resolution_factor), 1.0);
     WriteSetting(QStringLiteral("aspect_ratio"), Settings::values.aspect_ratio, 0);
+    WriteSetting(QStringLiteral("max_anisotropy"), Settings::values.max_anisotropy, 0);
     WriteSetting(QStringLiteral("use_frame_limit"), Settings::values.use_frame_limit, true);
     WriteSetting(QStringLiteral("frame_limit"), Settings::values.frame_limit, 100);
     WriteSetting(QStringLiteral("use_disk_shader_cache"), Settings::values.use_disk_shader_cache,

--- a/src/yuzu/configuration/configure.ui
+++ b/src/yuzu/configuration/configure.ui
@@ -83,6 +83,11 @@
          <string>Graphics</string>
         </attribute>
        </widget>
+       <widget class="ConfigureGraphicsAdvanced" name="graphicsAdvancedTab">
+        <attribute name="title">
+         <string>GraphicsAdvanced</string>
+        </attribute>
+       </widget>
        <widget class="ConfigureAudio" name="audioTab">
         <attribute name="title">
          <string>Audio</string>
@@ -157,6 +162,12 @@
    <class>ConfigureGraphics</class>
    <extends>QWidget</extends>
    <header>configuration/configure_graphics.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ConfigureGraphicsAdvanced</class>
+   <extends>QWidget</extends>
+   <header>configuration/configure_graphics_advanced.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -41,6 +41,7 @@ void ConfigureDialog::ApplyConfiguration() {
     ui->inputTab->ApplyConfiguration();
     ui->hotkeysTab->ApplyConfiguration(registry);
     ui->graphicsTab->ApplyConfiguration();
+    ui->graphicsAdvancedTab->ApplyConfiguration();
     ui->audioTab->ApplyConfiguration();
     ui->debugTab->ApplyConfiguration();
     ui->webTab->ApplyConfiguration();
@@ -76,7 +77,7 @@ void ConfigureDialog::PopulateSelectionList() {
     const std::array<std::pair<QString, QList<QWidget*>>, 5> items{
         {{tr("General"), {ui->generalTab, ui->webTab, ui->debugTab, ui->uiTab}},
          {tr("System"), {ui->systemTab, ui->profileManagerTab, ui->serviceTab, ui->filesystemTab}},
-         {tr("Graphics"), {ui->graphicsTab}},
+         {tr("Graphics"), {ui->graphicsTab, ui->graphicsAdvancedTab}},
          {tr("Audio"), {ui->audioTab}},
          {tr("Controls"), {ui->inputTab, ui->hotkeysTab}}},
     };
@@ -105,6 +106,7 @@ void ConfigureDialog::UpdateVisibleTabs() {
         {ui->inputTab, tr("Input")},
         {ui->hotkeysTab, tr("Hotkeys")},
         {ui->graphicsTab, tr("Graphics")},
+        {ui->graphicsAdvancedTab, tr("Advanced")},
         {ui->audioTab, tr("Audio")},
         {ui->debugTab, tr("Debug")},
         {ui->webTab, tr("Web")},

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -100,13 +100,8 @@ void ConfigureGraphics::SetConfiguration() {
     ui->aspect_ratio_combobox->setCurrentIndex(Settings::values.aspect_ratio);
     ui->use_disk_shader_cache->setEnabled(runtime_lock);
     ui->use_disk_shader_cache->setChecked(Settings::values.use_disk_shader_cache);
-    ui->use_accurate_gpu_emulation->setChecked(Settings::values.use_accurate_gpu_emulation);
     ui->use_asynchronous_gpu_emulation->setEnabled(runtime_lock);
     ui->use_asynchronous_gpu_emulation->setChecked(Settings::values.use_asynchronous_gpu_emulation);
-    ui->use_vsync->setEnabled(runtime_lock);
-    ui->use_vsync->setChecked(Settings::values.use_vsync);
-    ui->force_30fps_mode->setEnabled(runtime_lock);
-    ui->force_30fps_mode->setChecked(Settings::values.force_30fps_mode);
     UpdateBackgroundColorButton(QColor::fromRgbF(Settings::values.bg_red, Settings::values.bg_green,
                                                  Settings::values.bg_blue));
     UpdateDeviceComboBox();
@@ -119,11 +114,8 @@ void ConfigureGraphics::ApplyConfiguration() {
         ToResolutionFactor(static_cast<Resolution>(ui->resolution_factor_combobox->currentIndex()));
     Settings::values.aspect_ratio = ui->aspect_ratio_combobox->currentIndex();
     Settings::values.use_disk_shader_cache = ui->use_disk_shader_cache->isChecked();
-    Settings::values.use_accurate_gpu_emulation = ui->use_accurate_gpu_emulation->isChecked();
     Settings::values.use_asynchronous_gpu_emulation =
         ui->use_asynchronous_gpu_emulation->isChecked();
-    Settings::values.use_vsync = ui->use_vsync->isChecked();
-    Settings::values.force_30fps_mode = ui->force_30fps_mode->isChecked();
     Settings::values.bg_red = static_cast<float>(bg_color.redF());
     Settings::values.bg_green = static_cast<float>(bg_color.greenF());
     Settings::values.bg_blue = static_cast<float>(bg_color.blueF());

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -85,30 +85,6 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="use_vsync">
-          <property name="toolTip">
-           <string>VSync prevents the screen from tearing, but some graphics cards have lower performance with VSync enabled. Keep it enabled if you don't notice a performance difference.</string>
-          </property>
-          <property name="text">
-           <string>Use VSync (OpenGL only)</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="use_accurate_gpu_emulation">
-          <property name="text">
-           <string>Use accurate GPU emulation (slow)</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="force_30fps_mode">
-          <property name="text">
-           <string>Force 30 FPS mode</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
            <widget class="QLabel" name="label">

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -1,0 +1,48 @@
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/core.h"
+#include "core/settings.h"
+#include "ui_configure_graphics_advanced.h"
+#include "yuzu/configuration/configure_graphics_advanced.h"
+
+ConfigureGraphicsAdvanced::ConfigureGraphicsAdvanced(QWidget* parent)
+    : QWidget(parent), ui(new Ui::ConfigureGraphicsAdvanced) {
+
+    ui->setupUi(this);
+
+    SetConfiguration();
+}
+
+ConfigureGraphicsAdvanced::~ConfigureGraphicsAdvanced() = default;
+
+void ConfigureGraphicsAdvanced::SetConfiguration() {
+    const bool runtime_lock = !Core::System::GetInstance().IsPoweredOn();
+    ui->use_accurate_gpu_emulation->setChecked(Settings::values.use_accurate_gpu_emulation);
+    ui->use_vsync->setEnabled(runtime_lock);
+    ui->use_vsync->setChecked(Settings::values.use_vsync);
+    ui->force_30fps_mode->setEnabled(runtime_lock);
+    ui->force_30fps_mode->setChecked(Settings::values.force_30fps_mode);
+    ui->anisotropic_filtering_combobox->setEnabled(runtime_lock);
+    ui->anisotropic_filtering_combobox->setCurrentIndex(Settings::values.max_anisotropy);
+}
+
+void ConfigureGraphicsAdvanced::ApplyConfiguration() {
+    Settings::values.use_accurate_gpu_emulation = ui->use_accurate_gpu_emulation->isChecked();
+    Settings::values.use_vsync = ui->use_vsync->isChecked();
+    Settings::values.force_30fps_mode = ui->force_30fps_mode->isChecked();
+    Settings::values.max_anisotropy = ui->anisotropic_filtering_combobox->currentIndex();
+}
+
+void ConfigureGraphicsAdvanced::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
+void ConfigureGraphicsAdvanced::RetranslateUI() {
+    ui->retranslateUi(this);
+}

--- a/src/yuzu/configuration/configure_graphics_advanced.h
+++ b/src/yuzu/configuration/configure_graphics_advanced.h
@@ -1,0 +1,30 @@
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <QWidget>
+
+namespace Ui {
+class ConfigureGraphicsAdvanced;
+}
+
+class ConfigureGraphicsAdvanced : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit ConfigureGraphicsAdvanced(QWidget* parent = nullptr);
+    ~ConfigureGraphicsAdvanced() override;
+
+    void ApplyConfiguration();
+
+private:
+    void changeEvent(QEvent* event) override;
+    void RetranslateUI();
+
+    void SetConfiguration();
+
+    std::unique_ptr<Ui::ConfigureGraphicsAdvanced> ui;
+};

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureGraphicsAdvanced</class>
+ <widget class="QWidget" name="ConfigureGraphicsAdvanced">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>321</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_1">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QGroupBox" name="groupBox_1">
+       <property name="title">
+        <string>Advanced Graphics Settings</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <widget class="QCheckBox" name="use_accurate_gpu_emulation">
+          <property name="text">
+           <string>Use accurate GPU emulation (slow)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="use_vsync">
+          <property name="toolTip">
+           <string>VSync prevents the screen from tearing, but some graphics cards have lower performance with VSync enabled. Keep it enabled if you don't notice a performance difference.</string>
+          </property>
+          <property name="text">
+           <string>Use VSync (OpenGL only)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="force_30fps_mode">
+          <property name="text">
+           <string>Force 30 FPS mode</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_1">
+          <item>
+           <widget class="QLabel" name="af_label">
+            <property name="text">
+             <string>Anisotropic Filtering:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="anisotropic_filtering_combobox">
+            <item>
+             <property name="text">
+              <string>Default</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>2x</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>4x</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>8x</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>16x</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -381,6 +381,8 @@ void Config::ReadValues() {
         static_cast<float>(sdl2_config->GetReal("Renderer", "resolution_factor", 1.0));
     Settings::values.aspect_ratio =
         static_cast<int>(sdl2_config->GetInteger("Renderer", "aspect_ratio", 0));
+    Settings::values.max_anisotropy =
+        static_cast<int>(sdl2_config->GetInteger("Renderer", "max_anisotropy", 0));
     Settings::values.use_frame_limit = sdl2_config->GetBoolean("Renderer", "use_frame_limit", true);
     Settings::values.frame_limit =
         static_cast<u16>(sdl2_config->GetInteger("Renderer", "frame_limit", 100));

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -126,6 +126,10 @@ resolution_factor =
 # 0: Default (16:9), 1: Force 4:3, 2: Force 21:9, 3: Stretch to Window
 aspect_ratio =
 
+# Anisotropic filtering
+# 0: Default, 1: 2x, 2: 4x, 3: 8x, 4: 16x
+max_anisotropy =
+
 # Whether to enable V-Sync (caps the framerate at 60FPS) or not.
 # 0 (default): Off, 1: On
 use_vsync =

--- a/src/yuzu_tester/config.cpp
+++ b/src/yuzu_tester/config.cpp
@@ -120,6 +120,8 @@ void Config::ReadValues() {
         static_cast<float>(sdl2_config->GetReal("Renderer", "resolution_factor", 1.0));
     Settings::values.aspect_ratio =
         static_cast<int>(sdl2_config->GetInteger("Renderer", "aspect_ratio", 0));
+    Settings::values.max_anisotropy =
+        static_cast<int>(sdl2_config->GetInteger("Renderer", "max_anisotropy", 0));
     Settings::values.use_frame_limit = false;
     Settings::values.frame_limit = 100;
     Settings::values.use_disk_shader_cache =

--- a/src/yuzu_tester/default_ini.h
+++ b/src/yuzu_tester/default_ini.h
@@ -30,6 +30,10 @@ resolution_factor =
 # 0: Default (16:9), 1: Force 4:3, 2: Force 21:9, 3: Stretch to Window
 aspect_ratio =
 
+# Anisotropic filtering
+# 0: Default, 1: 2x, 2: 4x, 3: 8x, 4: 16x
+max_anisotropy =
+
 # Whether to enable V-Sync (caps the framerate at 60FPS) or not.
 # 0 (default): Off, 1: On
 use_vsync =


### PR DESCRIPTION
Closes #3447, credit to @Margen67 for finding out the appropriate value.

1. This PR adds a new `Advanced` tab in the `Graphics` section of the `Configure` menu

![image](https://user-images.githubusercontent.com/39850852/75122825-9b97d900-566f-11ea-833a-04a75ae0b6d4.png)

![image](https://user-images.githubusercontent.com/39850852/75122828-a8b4c800-566f-11ea-8109-416228158c44.png)

This moves both the `Use Accurate GPU emulation` and `Force 30 FPS mode` options to the advanced tab.

2. This PR adds an experimental `Anisotropic Filtering` dropdown under the `Advanced Graphics Settings` allowing you to select between the Default, 2x, 4x, 8x, and 16x options. However, this setting cannot be changed when in game. (The dropdown will be grayed out when a game is running)

![image](https://user-images.githubusercontent.com/39850852/75122877-3a243a00-5670-11ea-989d-034698457c26.png)

Please note that this setting **may break rendering in some games**, so it is recommended to leave it at the default setting.


Comparisons courtesy of @BSoDGamingYT

Fire Emblem Three Houses
https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html?uid=a52cc034-55d9-11ea-b9b8-0edaf8f81e27
https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html?uid=7f92d2e8-55dc-11ea-b9b8-0edaf8f81e27

Pokemon Sword/Shield
https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html?uid=7a1031d0-55d2-11ea-b9b8-0edaf8f81e27
https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html?uid=4710396a-55d7-11ea-b9b8-0edaf8f81e27

The Legend of Zelda Breath of the Wild
https://cdn.knightlab.com/libs/juxtapose/latest/embed/index.html?uid=761f9550-55de-11ea-b9b8-0edaf8f81e27


