### PR TITLE
yuzu: Remove exit lock for game pausing

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1717,11 +1717,6 @@ void GMainWindow::OnStartGame() {
 }
 
 void GMainWindow::OnPauseGame() {
-    Core::System& system{Core::System::GetInstance()};
-    if (system.GetExitLock() && !ConfirmForceLockedExit()) {
-        return;
-    }
-
     emu_thread->SetRunning(false);
 
     ui.action_Start->setEnabled(true);


### PR DESCRIPTION
This removes the "exit lock" popup from yuzu when *pausing* a game.

**Motivation**
The exit lock feature is broken in many ways and doesn't work properly in a lot of games, causing it to appear every time you want to pause the game or stop it, even in places where it wouldn't on Switch.

Additionally, the feature of pausing a game doesn't exist like this on Switch and yuzu should be guaranteed to be deterministic anyway, so pausing the emulation shouldn't be able to interrupt any critical processes in any way.