### PR TITLE
AM/ICommonStateGetter: Stub SetLcdBacklighOffEnabled

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -674,16 +674,10 @@ void ICommonStateGetter::GetCurrentFocusState(Kernel::HLERequestContext& ctx) {
 
 void ICommonStateGetter::SetLcdBacklighOffEnabled(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
-    auto is_lcd_backlight_off_enabled = rp.Pop<bool>();
+    const auto is_lcd_backlight_off_enabled = rp.Pop<bool>();
 
     LOG_WARNING(Service_AM, "(STUBBED) called. is_lcd_backlight_off_enabled={}",
                 is_lcd_backlight_off_enabled);
-
-    if (is_lcd_backlight_off_enabled) {
-        // Turn off the backlight
-    } else {
-        // Turn on the backlight
-    }
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -607,7 +607,7 @@ ICommonStateGetter::ICommonStateGetter(Core::System& system,
         {40, nullptr, "GetCradleFwVersion"},
         {50, nullptr, "IsVrModeEnabled"},
         {51, nullptr, "SetVrModeEnabled"},
-        {52, nullptr, "SwitchLcdBacklight"},
+        {52, &ICommonStateGetter::SetLcdBacklighOffEnabled, "SetLcdBacklighOffEnabled"},
         {53, nullptr, "BeginVrModeEx"},
         {54, nullptr, "EndVrModeEx"},
         {55, nullptr, "IsInControllerFirmwareUpdateSection"},
@@ -636,7 +636,6 @@ void ICommonStateGetter::GetBootMode(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
-
     rb.Push<u8>(static_cast<u8>(Service::PM::SystemBootMode::Normal)); // Normal boot mode
 }
 
@@ -660,6 +659,7 @@ void ICommonStateGetter::ReceiveMessage(Kernel::HLERequestContext& ctx) {
         rb.PushEnum<AppletMessageQueue::AppletMessage>(message);
         return;
     }
+
     rb.Push(RESULT_SUCCESS);
     rb.PushEnum<AppletMessageQueue::AppletMessage>(message);
 }
@@ -670,6 +670,23 @@ void ICommonStateGetter::GetCurrentFocusState(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
     rb.Push(static_cast<u8>(FocusState::InFocus));
+}
+
+void ICommonStateGetter::SetLcdBacklighOffEnabled(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    auto is_lcd_backlight_off_enabled = rp.Pop<bool>();
+
+    LOG_WARNING(Service_AM, "(STUBBED) called. is_lcd_backlight_off_enabled={}",
+                is_lcd_backlight_off_enabled);
+
+    if (is_lcd_backlight_off_enabled) {
+        // Turn off the backlight
+    } else {
+        // Turn on the backlight
+    }
+
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(RESULT_SUCCESS);
 }
 
 void ICommonStateGetter::GetDefaultDisplayResolutionChangeEvent(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -182,6 +182,7 @@ private:
     void GetOperationMode(Kernel::HLERequestContext& ctx);
     void GetPerformanceMode(Kernel::HLERequestContext& ctx);
     void GetBootMode(Kernel::HLERequestContext& ctx);
+    void SetLcdBacklighOffEnabled(Kernel::HLERequestContext& ctx);
     void GetDefaultDisplayResolution(Kernel::HLERequestContext& ctx);
     void SetCpuBoostMode(Kernel::HLERequestContext& ctx);
 


### PR DESCRIPTION
Closes #2719 

This command was mistakenly called SwitchLcdBacklight, according to sdk symbols and switchbrew it is actually called SetLcdBacklighOffEnabled. Note: The service command name is not a typo, it is missing the 't' in "Backlight".

This command sets whether the LCD backlight is turned on or off, however, this is stubbed for now since backlight services needs to be implemented #2542.

If the bool is true, the backlight turns off
If the bool is false, the backlight turns on