### PR TITLE
video_core/surface: Add R32_SINT render target format

### DIFF
--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -57,6 +57,7 @@ enum class RenderTargetFormat : u32 {
     RG16_UINT = 0xDD,
     RG16_FLOAT = 0xDE,
     R11G11B10_FLOAT = 0xE0,
+    R32_SINT = 0xE3,
     R32_UINT = 0xE4,
     R32_FLOAT = 0xE5,
     B5G6R5_UNORM = 0xE8,

--- a/src/video_core/surface.cpp
+++ b/src/video_core/surface.cpp
@@ -155,6 +155,8 @@ PixelFormat PixelFormatFromRenderTargetFormat(Tegra::RenderTargetFormat format) 
         return PixelFormat::R16I;
     case Tegra::RenderTargetFormat::R32_FLOAT:
         return PixelFormat::R32F;
+    case Tegra::RenderTargetFormat::R32_SINT:
+        return PixelFormat::R32I;
     case Tegra::RenderTargetFormat::R32_UINT:
         return PixelFormat::R32UI;
     case Tegra::RenderTargetFormat::RG32_UINT:


### PR DESCRIPTION
Thanks to @neico from pointing this out in #3417
- Used by Fire Emblem: Three Houses