### PR TITLE
Port citra-emu/citra#5047: "Fix c++ standard flag for msvc"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -38,7 +38,6 @@ if (MSVC)
         /Zo
         /permissive-
         /EHsc
-        /std:c++latest
         /volatile:iso
         /Zc:externConstexpr
         /Zc:inline


### PR DESCRIPTION
See citra-emu/citra#5047 for more details.

**Original description**:
~~C++17 is already specified through cmake~~
apparently this doesn't work before CMake 10, but the below warning is still fixed by specifying /std:c++17
fixes MSVC spamming the following:
> \source\repos\citra\out\build\x64-Debug\cl : Command line warning D9025: overriding '/std:c++latest' with '/std:c++17'