### PR TITLE
shader_decode: Fix LD, LDG when track constant buffer

### DIFF
--- a/src/video_core/shader/track.cpp
+++ b/src/video_core/shader/track.cpp
@@ -159,11 +159,19 @@ std::tuple<Node, u32, u32> ShaderIR::TrackCbuf(Node tracked, const NodeBlock& co
         }
         // Reduce the cursor in one to avoid infinite loops when the instruction sets the same
         // register that it uses as operand
-        const auto [source, new_cursor] = TrackRegister(gpr, code, cursor - 1);
-        if (!source) {
-            return {};
+        s64 current_cursor = cursor;
+        while (current_cursor > 0) {
+            const auto [source, new_cursor] = TrackRegister(gpr, code, current_cursor - 1);
+            current_cursor = new_cursor;
+            if (!source) {
+                continue;
+            }
+            const auto [base_address, index, offset] = TrackCbuf(source, code, current_cursor);
+            if (base_address != nullptr) {
+                return {base_address, index, offset};
+            }
         }
-        return TrackCbuf(source, code, new_cursor);
+        return {};
     }
     if (const auto operation = std::get_if<OperationNode>(&*tracked)) {
         for (std::size_t i = operation->GetOperandsCount(); i > 0; --i) {

--- a/src/video_core/shader/track.cpp
+++ b/src/video_core/shader/track.cpp
@@ -157,10 +157,10 @@ std::tuple<Node, u32, u32> ShaderIR::TrackCbuf(Node tracked, const NodeBlock& co
         if (gpr->GetIndex() == Tegra::Shader::Register::ZeroIndex) {
             return {};
         }
-        // Reduce the cursor in one to avoid infinite loops when the instruction sets the same
-        // register that it uses as operand
         s64 current_cursor = cursor;
         while (current_cursor > 0) {
+            // Reduce the cursor in one to avoid infinite loops when the instruction sets the same
+            // register that it uses as operand
             const auto [source, new_cursor] = TrackRegister(gpr, code, current_cursor - 1);
             current_cursor = new_cursor;
             if (!source) {


### PR DESCRIPTION
It fixed opcode LD, LDG on Pokemon Sword that can't find the constant buffer. Not sure if it helps any on visual.