### PR TITLE
Port citra-emu/citra#5097: "Update README.md"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 yuzu emulator
 =============
-[![Travis CI Build Status](https://travis-ci.org/yuzu-emu/yuzu.svg?branch=master)](https://travis-ci.org/yuzu-emu/yuzu)
+[![Travis CI Build Status](https://travis-ci.com/yuzu-emu/yuzu.svg?branch=master)](https://travis-ci.com/yuzu-emu/yuzu)
 [![Azure Mainline CI Build Status](https://dev.azure.com/yuzu-emu/yuzu/_apis/build/status/yuzu%20mainline?branchName=master)](https://dev.azure.com/yuzu-emu/yuzu/)
 
 yuzu is an experimental open-source emulator for the Nintendo Switch from the creators of [Citra](https://citra-emu.org/).
@@ -21,7 +21,7 @@ For development discussion, please join us on [Discord](https://discord.gg/XQV6d
 
 Most of the development happens on GitHub. It's also where [our central repository](https://github.com/yuzu-emu/yuzu) is hosted.
 
-If you want to contribute please take a look at the [Contributor's Guide](CONTRIBUTING.md) and [Developer Information](https://github.com/yuzu-emu/yuzu/wiki/Developer-Information). You should as well contact any of the developers on Discord in order to know about the current state of the emulator.
+If you want to contribute please take a look at the [Contributor's Guide](CONTRIBUTING.md) and [Developer Information](https://github.com/yuzu-emu/yuzu/wiki/Developer-Information). You should also contact any of the developers on Discord in order to know about the current state of the emulator.
 
 ### Building
 


### PR DESCRIPTION
See citra-emu/citra#5097 for more details.

**Original description**:
- Discord is generally the preferred method for developer communication now
- fixed a typo in contributor info
- 3D output is working, but not very popular. if we want to keep that part, VR headsets would probably be more relevant.
- neobrain is no longer active in the project and probably shouldn't be contacted for donations
- firmware version is no longer relevant for homebrew purposes
pinging @bunnei because I'm not sure whether he is still the one to contact for console donations (not that we ever get any)