### PR TITLE
vk_rasterizer: Support disabled uniform buffers

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -909,6 +909,13 @@ void RasterizerVulkan::SetupComputeImages(const ShaderEntries& entries) {
 
 void RasterizerVulkan::SetupConstBuffer(const ConstBufferEntry& entry,
                                         const Tegra::Engines::ConstBufferInfo& buffer) {
+    if (!buffer.enabled) {
+        // Set values to zero to unbind buffers
+        update_descriptor_queue.AddBuffer(buffer_cache.GetEmptyBuffer(sizeof(float)), 0,
+                                          sizeof(float));
+        return;
+    }
+
     // Align the size to avoid bad std140 interactions
     const std::size_t size =
         Common::AlignUp(CalculateConstBufferSize(entry, buffer), 4 * sizeof(float));

--- a/src/video_core/renderer_vulkan/vk_staging_buffer_pool.cpp
+++ b/src/video_core/renderer_vulkan/vk_staging_buffer_pool.cpp
@@ -73,7 +73,8 @@ VKBuffer* VKStagingBufferPool::TryGetReservedBuffer(std::size_t size, bool host_
 VKBuffer& VKStagingBufferPool::CreateStagingBuffer(std::size_t size, bool host_visible) {
     const auto usage =
         vk::BufferUsageFlagBits::eTransferSrc | vk::BufferUsageFlagBits::eTransferDst |
-        vk::BufferUsageFlagBits::eStorageBuffer | vk::BufferUsageFlagBits::eIndexBuffer;
+        vk::BufferUsageFlagBits::eUniformBuffer | vk::BufferUsageFlagBits::eStorageBuffer |
+        vk::BufferUsageFlagBits::eIndexBuffer;
     const u32 log2 = Common::Log2Ceil64(size);
     const vk::BufferCreateInfo buffer_ci({}, 1ULL << log2, usage, vk::SharingMode::eExclusive, 0,
                                          nullptr);


### PR DESCRIPTION
Adds support for "disabled" uniform buffers on Vulkan. This matches our current OpenGL behaviour of returning zeroes when these are read from a shader.