### PR TITLE
vk_rasterizer: fix mistype on SetupGraphicsImages

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -848,7 +848,7 @@ void RasterizerVulkan::SetupGraphicsTextures(const ShaderEntries& entries, std::
 
 void RasterizerVulkan::SetupGraphicsImages(const ShaderEntries& entries, std::size_t stage) {
     MICROPROFILE_SCOPE(Vulkan_Images);
-    const auto& gpu = system.GPU().KeplerCompute();
+    const auto& gpu = system.GPU().Maxwell3D();
     for (const auto& entry : entries.images) {
         const auto tic = GetTextureInfo(gpu, entry, stage).tic;
         SetupImage(tic, entry);


### PR DESCRIPTION
This should use Maxwell3D engine. Fixed some GPU error on Kirby and maybe other games.