### PR TITLE
framebuffer_layout.h: drop the use of enum for screen dimensions

### DIFF
--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -48,8 +48,8 @@ FramebufferLayout FrameLayoutFromResolutionScale(u32 res_scale) {
     u32 width, height;
 
     if (Settings::values.use_docked_mode) {
-        width = ScreenDocked::WidthDocked * res_scale;
-        height = ScreenDocked::HeightDocked * res_scale;
+        width = ScreenDocked::Width * res_scale;
+        height = ScreenDocked::Height * res_scale;
     } else {
         width = ScreenUndocked::Width * res_scale;
         height = ScreenUndocked::Height * res_scale;

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -8,15 +8,15 @@
 
 namespace Layout {
 
-enum ScreenUndocked : u32 {
-    Width = 1280,
-    Height = 720,
-};
+namespace ScreenUndocked {
+constexpr u32 Width = 1280;
+constexpr u32 Height = 720;
+} // namespace ScreenUndocked
 
-enum ScreenDocked : u32 {
-    WidthDocked = 1920,
-    HeightDocked = 1080,
-};
+namespace ScreenDocked {
+constexpr u32 Width = 1920;
+constexpr u32 Height = 1080;
+} // namespace ScreenDocked
 
 enum class AspectRatio {
     Default,


### PR DESCRIPTION
There's no reason to use enum here.
May address #3493.