### PR TITLE
shader_decode: Reimplement BFE instructions

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -911,14 +911,9 @@ union Instruction {
     } fadd32i;
 
     union {
-        BitField<20, 8, u64> shift_position;
-        BitField<28, 8, u64> shift_length;
-        BitField<48, 1, u64> negate_b;
-        BitField<49, 1, u64> negate_a;
-
-        u64 GetLeftShiftValue() const {
-            return 32 - (shift_position + shift_length);
-        }
+        BitField<40, 1, u64> brev;
+        BitField<47, 1, u64> rd_cc;
+        BitField<48, 1, u64> is_signed;
     } bfe;
 
     union {

--- a/src/video_core/shader/decode/bfe.cpp
+++ b/src/video_core/shader/decode/bfe.cpp
@@ -44,14 +44,18 @@ u32 ShaderIR::DecodeBfe(NodeBlock& bb, u32 pc) {
             Node v1 =
                 SignedOperation(OperationCode::ILogicalShiftRight, is_signed, op_a, Immediate(s));
             if (mask != 0) {
-                v1 = SignedOperation(OperationCode::IBitwiseAnd, is_signed, std::move(v1), Immediate(mask));
+                v1 = SignedOperation(OperationCode::IBitwiseAnd, is_signed, std::move(v1),
+                                     Immediate(mask));
             }
             Node v2 = op_a;
             if (mask != 0) {
-                v2 = SignedOperation(OperationCode::IBitwiseAnd, is_signed, std::move(v2), Immediate(mask));
+                v2 = SignedOperation(OperationCode::IBitwiseAnd, is_signed, std::move(v2),
+                                     Immediate(mask));
             }
-            v2 = SignedOperation(OperationCode::ILogicalShiftLeft, is_signed, std::move(v2), Immediate(s));
-            return SignedOperation(OperationCode::IBitwiseOr, is_signed, std::move(v1), std::move(v2));
+            v2 = SignedOperation(OperationCode::ILogicalShiftLeft, is_signed, std::move(v2),
+                                 Immediate(s));
+            return SignedOperation(OperationCode::IBitwiseOr, is_signed, std::move(v1),
+                                   std::move(v2));
         };
         op_a = swap(1, 0x55555555U);
         op_a = swap(2, 0x33333333U);

--- a/src/video_core/shader/decode/bfe.cpp
+++ b/src/video_core/shader/decode/bfe.cpp
@@ -44,14 +44,14 @@ u32 ShaderIR::DecodeBfe(NodeBlock& bb, u32 pc) {
             Node v1 =
                 SignedOperation(OperationCode::ILogicalShiftRight, is_signed, op_a, Immediate(s));
             if (mask != 0) {
-                v1 = SignedOperation(OperationCode::IBitwiseAnd, is_signed, v1, Immediate(mask));
+                v1 = SignedOperation(OperationCode::IBitwiseAnd, is_signed, std::move(v1), Immediate(mask));
             }
             Node v2 = op_a;
             if (mask != 0) {
-                v2 = SignedOperation(OperationCode::IBitwiseAnd, is_signed, op_a, Immediate(mask));
+                v2 = SignedOperation(OperationCode::IBitwiseAnd, is_signed, std::move(v2), Immediate(mask));
             }
-            v2 = SignedOperation(OperationCode::ILogicalShiftLeft, is_signed, v2, Immediate(s));
-            return SignedOperation(OperationCode::IBitwiseOr, is_signed, v1, v2);
+            v2 = SignedOperation(OperationCode::ILogicalShiftLeft, is_signed, std::move(v2), Immediate(s));
+            return SignedOperation(OperationCode::IBitwiseOr, is_signed, std::move(v1), std::move(v2));
         };
         op_a = swap(1, 0x55555555U);
         op_a = swap(2, 0x33333333U);
@@ -66,7 +66,7 @@ u32 ShaderIR::DecodeBfe(NodeBlock& bb, u32 pc) {
                                       Immediate(8), Immediate(8));
     const auto result =
         SignedOperation(OperationCode::IBitfieldExtract, is_signed, op_a, offset, bits);
-    SetRegister(bb, instr.gpr0, result);
+    SetRegister(bb, instr.gpr0, std::move(result));
 
     return pc;
 }

--- a/src/video_core/shader/decode/bfe.cpp
+++ b/src/video_core/shader/decode/bfe.cpp
@@ -36,6 +36,9 @@ u32 ShaderIR::DecodeBfe(NodeBlock& bb, u32 pc) {
 
     const bool is_signed = instr.bfe.is_signed;
 
+    // using reverse parallel method in
+    // https://graphics.stanford.edu/~seander/bithacks.html#ReverseParallel
+    // note for later if possible to implement faster method.
     if (instr.bfe.brev) {
         const auto swap = [&](u32 s, u32 mask) {
             Node v1 =

--- a/src/video_core/shader/decode/bfe.cpp
+++ b/src/video_core/shader/decode/bfe.cpp
@@ -68,7 +68,7 @@ u32 ShaderIR::DecodeBfe(NodeBlock& bb, u32 pc) {
                                         Immediate(0), Immediate(8));
     const auto bits = SignedOperation(OperationCode::IBitfieldExtract, is_signed, op_b,
                                       Immediate(8), Immediate(8));
-    const auto result =
+    auto result =
         SignedOperation(OperationCode::IBitfieldExtract, is_signed, op_a, offset, bits);
     SetRegister(bb, instr.gpr0, std::move(result));
 

--- a/src/video_core/shader/decode/bfe.cpp
+++ b/src/video_core/shader/decode/bfe.cpp
@@ -68,8 +68,7 @@ u32 ShaderIR::DecodeBfe(NodeBlock& bb, u32 pc) {
                                         Immediate(0), Immediate(8));
     const auto bits = SignedOperation(OperationCode::IBitfieldExtract, is_signed, op_b,
                                       Immediate(8), Immediate(8));
-    auto result =
-        SignedOperation(OperationCode::IBitfieldExtract, is_signed, op_a, offset, bits);
+    auto result = SignedOperation(OperationCode::IBitfieldExtract, is_signed, op_a, offset, bits);
     SetRegister(bb, instr.gpr0, std::move(result));
 
     return pc;

--- a/src/video_core/shader/node_helper.cpp
+++ b/src/video_core/shader/node_helper.cpp
@@ -68,6 +68,8 @@ OperationCode SignedToUnsignedCode(OperationCode operation_code, bool is_signed)
         return OperationCode::UBitwiseXor;
     case OperationCode::IBitwiseNot:
         return OperationCode::UBitwiseNot;
+    case OperationCode::IBitfieldExtract:
+        return OperationCode::UBitfieldExtract;
     case OperationCode::IBitfieldInsert:
         return OperationCode::UBitfieldInsert;
     case OperationCode::IBitCount:


### PR DESCRIPTION
This PR reimplement BFE instruction set. Still missing ~~BREV and~~ Rd.CC tho.
As always thank to @ReinUsesLisp 