### PR TITLE
renderer_opengl: Keep frames synchronized when using a GPU debugger.

### DIFF
--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -157,6 +157,7 @@ Device::Device() : base_bindings{BuildBaseBindings()} {
     has_precise_bug = TestPreciseBug();
     has_broken_compute = is_intel_proprietary;
     has_fast_buffer_sub_data = is_nvidia;
+    has_debug_tool = HasExtension(extensions, "GL_EXT_debug_tool");
 
     LOG_INFO(Render_OpenGL, "Renderer_VariableAOFFI: {}", has_variable_aoffi);
     LOG_INFO(Render_OpenGL, "Renderer_ComponentIndexingBug: {}", has_component_indexing_bug);

--- a/src/video_core/renderer_opengl/gl_device.h
+++ b/src/video_core/renderer_opengl/gl_device.h
@@ -84,6 +84,10 @@ public:
         return has_fast_buffer_sub_data;
     }
 
+    bool HasDebugTool() const {
+        return has_debug_tool;
+    }
+
 private:
     static bool TestVariableAoffi();
     static bool TestPreciseBug();
@@ -102,6 +106,7 @@ private:
     bool has_precise_bug{};
     bool has_broken_compute{};
     bool has_fast_buffer_sub_data{};
+    bool has_debug_tool{};
 };
 
 } // namespace OpenGL


### PR DESCRIPTION
This change adds a GPU debug mode where output frames are kept synchronized with the GPU thread. This is needed to fix GPU debuggers such as RenderDoc, which was broken due to how #3430 works. This mode is automatically activated by checking `GL_EXT_debug_tool`.