### PR TITLE
Port citra-emu/citra#5106: "gdbstub: Ensure gdbstub doesn't drop packets crucial to initialization"

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -166,7 +166,7 @@ struct System::Impl {
         service_manager = std::make_shared<Service::SM::ServiceManager>();
 
         Service::Init(service_manager, system);
-        GDBStub::Init();
+        GDBStub::DeferStart();
 
         renderer = VideoCore::CreateRenderer(emu_window, system);
         if (!renderer->Init()) {

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -1166,8 +1166,10 @@ static void RemoveBreakpoint() {
 }
 
 void HandlePacket() {
-    if (!IsConnected() && defer_start) {
-        ToggleServer(true);
+    if (!IsConnected()) {
+        if (defer_start) {
+            ToggleServer(true);
+        }
         return;
     }
 

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -141,6 +141,7 @@ constexpr char target_xml[] =
 )";
 
 int gdbserver_socket = -1;
+bool defer_start = false;
 
 u8 command_buffer[GDB_BUFFER_SIZE];
 u32 command_length;
@@ -1165,7 +1166,8 @@ static void RemoveBreakpoint() {
 }
 
 void HandlePacket() {
-    if (!IsConnected()) {
+    if (!IsConnected() && defer_start) {
+        ToggleServer(true);
         return;
     }
 
@@ -1256,6 +1258,10 @@ void ToggleServer(bool status) {
     }
 }
 
+void DeferStart() {
+    defer_start = true;
+}
+
 static void Init(u16 port) {
     if (!server_enabled) {
         // Set the halt loop to false in case the user enabled the gdbstub mid-execution.
@@ -1341,6 +1347,7 @@ void Shutdown() {
     if (!server_enabled) {
         return;
     }
+    defer_start = false;
 
     LOG_INFO(Debug_GDBStub, "Stopping GDB ...");
     if (gdbserver_socket != -1) {

--- a/src/core/gdbstub/gdbstub.h
+++ b/src/core/gdbstub/gdbstub.h
@@ -43,6 +43,13 @@ void ToggleServer(bool status);
 /// Start the gdbstub server.
 void Init();
 
+/**
+ * Defer initialization of the gdbstub to the first packet processing functions.
+ * This avoids a case where the gdbstub thread is frozen after initialization
+ * and fails to respond in time to packets.
+ */
+void DeferStart();
+
 /// Stop gdbstub server.
 void Shutdown();
 


### PR DESCRIPTION
See citra-emu/citra#5106 for more details.

**Original description**:
This fixes https://github.com/yuzu-emu/yuzu/issues/1850, a common issue between citra and yuzu's gdbstub implementation.
Under the citra-qt codebase, during the VideoCore shader initialization, the EmuThread->RunLoop logic, used to emulate the game and, among other things, handle gdbstub packets, is frozen. This ends up making gdb send back its packet a second time and eventually sending the next packet in the list, in our case qSupported followed by vMustReplyEmpty. By this time gdb is expecting a reply to vMustReplyEmpty, qSupported having been dropped but citra just decided to unfreeze the gdbstub thread and process the packets, replying to the answer of qSupported.

To fix that, I introduced a way to defer the initialization of the gdb stub to the first handling of packets. This has two benefits: 
1. This allows the qt thread to not be frozen in place and still reactive along with its loading bar.
2. This allows us to not have to modify the per-UI code to ensure the gdbstub works.

This was the least hacky fix I could think of, anything else requiring to change the behaviour of EmuThread and/or VideoCore. Moreso the HandlePacket function of gdbstub actually already has to check each time if the server is started, so the cost of this check is negligible, which is definitely something to keep in mind as HandlePacket is part of the main running loop of the EmuThread.