### PR TITLE
input_common/udp: Fix Linux build by using a backwards compatible way of error checking

### DIFF
--- a/src/input_common/udp/client.cpp
+++ b/src/input_common/udp/client.cpp
@@ -35,7 +35,7 @@ public:
           pad_index(pad_index) {
         boost::system::error_code ec{};
         auto ipv4 = boost::asio::ip::make_address_v4(host, ec);
-        if (ec.failed()) {
+        if (ec.value() != boost::system::errc::success) {
             LOG_ERROR(Input, "Invalid IPv4 address \"{}\" provided to socket", host);
             ipv4 = boost::asio::ip::address_v4{};
         }


### PR DESCRIPTION
Should fix https://github.com/yuzu-emu/yuzu/issues/3487.

error_code::failed is a function which has been introduced in Boost 1.69.
This version of boost hasn't landed in most major distros yet.