### PR TITLE
yuzu: Save sound output mode and set it to Stereo by default

### DIFF
--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -387,6 +387,7 @@ struct Values {
 
     s32 current_user;
     s32 language_index;
+    s32 sound_index;
 
     // Controls
     std::array<PlayerInput, 10> players;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -698,6 +698,8 @@ void Config::ReadSystemValues() {
         Settings::values.custom_rtc = std::nullopt;
     }
 
+    Settings::values.sound_index = ReadSetting(QStringLiteral("sound_index"), 1).toInt();
+
     qt_config->endGroup();
 }
 
@@ -1124,6 +1126,8 @@ void Config::SaveSystemValues() {
                  QVariant::fromValue<long long>(
                      Settings::values.custom_rtc.value_or(std::chrono::seconds{}).count()),
                  0);
+
+    WriteSetting(QStringLiteral("sound_index"), Settings::values.sound_index, 1);
 
     qt_config->endGroup();
 }

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -56,6 +56,7 @@ void ConfigureSystem::SetConfiguration() {
     enabled = !Core::System::GetInstance().IsPoweredOn();
 
     ui->combo_language->setCurrentIndex(Settings::values.language_index);
+    ui->combo_sound->setCurrentIndex(Settings::values.sound_index);
 
     ui->rng_seed_checkbox->setChecked(Settings::values.rng_seed.has_value());
     ui->rng_seed_edit->setEnabled(Settings::values.rng_seed.has_value());
@@ -81,6 +82,7 @@ void ConfigureSystem::ApplyConfiguration() {
     }
 
     Settings::values.language_index = ui->combo_language->currentIndex();
+    Settings::values.sound_index = ui->combo_sound->currentIndex();
 
     if (ui->rng_seed_checkbox->isChecked()) {
         Settings::values.rng_seed = ui->rng_seed_edit->text().toULongLong(nullptr, 16);


### PR DESCRIPTION
This was requested bei Rei and BsoD Gaming on Discord. 
Previously, the setting would always go back to Mono after reopening the configuration tab. This is fixed with this PR and the default value is set to Stereo.

This setting still has no use so I'm not really against removing it altogether either.
For now I've chosen to keep it as it exists on the real Switch as well and can be hooked up to our backends sometime in the future.