### PR TITLE
time_zone_content_manager: Fix out of bounds read

### DIFF
--- a/src/core/hle/service/time/time_zone_content_manager.cpp
+++ b/src/core/hle/service/time/time_zone_content_manager.cpp
@@ -53,7 +53,7 @@ static std::vector<std::string> BuildLocationNameCache(Core::System& system) {
         return {};
     }
 
-    std::vector<char> raw_data(binary_list->GetSize());
+    std::vector<char> raw_data(binary_list->GetSize() + 1);
     binary_list->ReadBytes<char>(raw_data.data(), binary_list->GetSize());
 
     std::stringstream data_stream{raw_data.data()};


### PR DESCRIPTION
There were cases where raw_data didn't contain enough space to hold the zero terminator.

This was caught with -fsanitize=address.