### PR TITLE
gl_rasterizer: Use transformed viewport for depth ranges

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -933,13 +933,15 @@ void RasterizerOpenGL::SyncViewport() {
             }
             flags[Dirty::Viewport0 + i] = false;
 
-            const Common::Rectangle<f32> rect{regs.viewport_transform[i].GetRect()};
+            const auto& src = regs.viewport_transform[i];
+            const Common::Rectangle<f32> rect{src.GetRect()};
             glViewportIndexedf(static_cast<GLuint>(i), rect.left, rect.bottom, rect.GetWidth(),
                                rect.GetHeight());
 
-            const auto& src = regs.viewports[i];
-            glDepthRangeIndexed(static_cast<GLuint>(i), static_cast<GLdouble>(src.depth_range_near),
-                                static_cast<GLdouble>(src.depth_range_far));
+            const GLdouble reduce_z = regs.depth_mode == Maxwell::DepthMode::MinusOneToOne;
+            const GLdouble near_depth = src.translate_z - src.scale_z * reduce_z;
+            const GLdouble far_depth = src.translate_z + src.scale_z;
+            glDepthRangeIndexed(static_cast<GLuint>(i), near_depth, far_depth);
         }
     }
 }


### PR DESCRIPTION
Implement depth ranges using the transformed viewport instead of the
generic one. This matches the current Vulkan implementation but doesn't
support negative depth ranges. An update to glad is required for this.

Partially fixes a regression caused by #3529 and #3542 on OpenGL. The other fix required to address the regressions on Super Mario Odyssey are described in #3542.