### PR TITLE
sm/controller: Increase PointerBufferSize

### DIFF
--- a/src/core/hle/service/sm/controller.cpp
+++ b/src/core/hle/service/sm/controller.cpp
@@ -44,7 +44,7 @@ void Controller::QueryPointerBufferSize(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u16>(0x500);
+    rb.Push<u16>(0x1000);
 }
 
 Controller::Controller() : ServiceFramework("IpcController") {


### PR DESCRIPTION
This increases the PointerBufferSize as a lager one is required by some services.
This change is still not hw-accurate, but it is proven to work in Ryujinx.

Instead of using a hardcoded size, we should figure out the specific values for each service in the future. Some of them can be taken from [Atmosphere](https://github.com/Atmosphere-NX/Atmosphere/search?q=PointerBufferSize). 

Thanks to @jduncanator for finding this issue in the first place.