### PR TITLE
Use the correct directory for Qt Plugins

### DIFF
--- a/CMakeModules/CopyYuzuQt5Deps.cmake
+++ b/CMakeModules/CopyYuzuQt5Deps.cmake
@@ -6,9 +6,9 @@ function(copy_yuzu_Qt5_deps target_dir)
     set(Qt5_STYLES_DIR "${Qt5_DIR}/../../../plugins/styles/")
     set(Qt5_IMAGEFORMATS_DIR "${Qt5_DIR}/../../../plugins/imageformats/")
     set(Qt5_RESOURCES_DIR "${Qt5_DIR}/../../../resources/")
-    set(PLATFORMS ${DLL_DEST}platforms/)
-    set(STYLES ${DLL_DEST}styles/)
-    set(IMAGEFORMATS ${DLL_DEST}imageformats/)
+    set(PLATFORMS ${DLL_DEST}plugins/platforms/)
+    set(STYLES ${DLL_DEST}plugins/styles/)
+    set(IMAGEFORMATS ${DLL_DEST}plugins/imageformats/)
     windows_copy_files(${target_dir} ${Qt5_DLL_DIR} ${DLL_DEST}
         icudt*.dll
         icuin*.dll
@@ -42,11 +42,15 @@ function(copy_yuzu_Qt5_deps target_dir)
             icudtl.dat
         )
     endif ()
-
     windows_copy_files(yuzu ${Qt5_PLATFORMS_DIR} ${PLATFORMS} qwindows$<$<CONFIG:Debug>:d>.*)
     windows_copy_files(yuzu ${Qt5_STYLES_DIR} ${STYLES} qwindowsvistastyle$<$<CONFIG:Debug>:d>.*)
     windows_copy_files(yuzu ${Qt5_IMAGEFORMATS_DIR} ${IMAGEFORMATS}
         qjpeg$<$<CONFIG:Debug>:d>.*
         qgif$<$<CONFIG:Debug>:d>.*
         )
+    # Create an empty qt.conf file. Qt will detect that this file exists, and use the folder that its in as the root folder.
+    # This way it'll look for plugins in the root/plugins/ folder
+    add_custom_command(TARGET yuzu POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E touch ${DLL_DEST}qt.conf
+    )
 endfunction(copy_yuzu_Qt5_deps)


### PR DESCRIPTION
Qt does weird things when its missing a qt.conf file, causing me endless headaches when building locally. The "proper" fix is to add a qt.conf file (it can be blank) which sets that directory as the qt root folder for plugin loading, and from there, Qt will check the `plugins` folder for all the plugins. This means that we also need to move the rest of the plugin folders into that new folder.

Please test this before merging. If theres an issue with the build bots, it will cause the UI to fail to load entirely, so its important to test builds from the build bot before merging.