### PR TITLE
capsrv: Split Capture services into individual files and stub GetAlbumContentsFileListForApplication

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -287,6 +287,18 @@ add_library(core STATIC
     hle/service/btm/btm.h
     hle/service/caps/caps.cpp
     hle/service/caps/caps.h
+    hle/service/caps/caps_a.cpp
+    hle/service/caps/caps_a.h
+    hle/service/caps/caps_c.cpp
+    hle/service/caps/caps_c.h
+    hle/service/caps/caps_u.cpp
+    hle/service/caps/caps_u.h
+    hle/service/caps/caps_sc.cpp
+    hle/service/caps/caps_sc.h
+    hle/service/caps/caps_ss.cpp
+    hle/service/caps/caps_ss.h
+    hle/service/caps/caps_su.cpp
+    hle/service/caps/caps_su.h
     hle/service/erpt/erpt.cpp
     hle/service/erpt/erpt.h
     hle/service/es/es.cpp

--- a/src/core/hle/service/caps/caps.cpp
+++ b/src/core/hle/service/caps/caps.cpp
@@ -2,168 +2,24 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <memory>
-
 #include "core/hle/service/caps/caps.h"
+#include "core/hle/service/caps/caps_a.h"
+#include "core/hle/service/caps/caps_c.h"
+#include "core/hle/service/caps/caps_sc.h"
+#include "core/hle/service/caps/caps_ss.h"
+#include "core/hle/service/caps/caps_su.h"
+#include "core/hle/service/caps/caps_u.h"
 #include "core/hle/service/service.h"
-#include "core/hle/service/sm/sm.h"
 
 namespace Service::Capture {
-
-class CAPS_A final : public ServiceFramework<CAPS_A> {
-public:
-    explicit CAPS_A() : ServiceFramework{"caps:a"} {
-        // clang-format off
-        static const FunctionInfo functions[] = {
-            {0, nullptr, "GetAlbumFileCount"},
-            {1, nullptr, "GetAlbumFileList"},
-            {2, nullptr, "LoadAlbumFile"},
-            {3, nullptr, "DeleteAlbumFile"},
-            {4, nullptr, "StorageCopyAlbumFile"},
-            {5, nullptr, "IsAlbumMounted"},
-            {6, nullptr, "GetAlbumUsage"},
-            {7, nullptr, "GetAlbumFileSize"},
-            {8, nullptr, "LoadAlbumFileThumbnail"},
-            {9, nullptr, "LoadAlbumScreenShotImage"},
-            {10, nullptr, "LoadAlbumScreenShotThumbnailImage"},
-            {11, nullptr, "GetAlbumEntryFromApplicationAlbumEntry"},
-            {12, nullptr, "Unknown12"},
-            {13, nullptr, "Unknown13"},
-            {14, nullptr, "Unknown14"},
-            {15, nullptr, "Unknown15"},
-            {16, nullptr, "Unknown16"},
-            {17, nullptr, "Unknown17"},
-            {18, nullptr, "Unknown18"},
-            {202, nullptr, "SaveEditedScreenShot"},
-            {301, nullptr, "GetLastThumbnail"},
-            {401, nullptr, "GetAutoSavingStorage"},
-            {501, nullptr, "GetRequiredStorageSpaceSizeToCopyAll"},
-            {1001, nullptr, "Unknown1001"},
-            {1002, nullptr, "Unknown1002"},
-            {1003, nullptr, "Unknown1003"},
-            {8001, nullptr, "ForceAlbumUnmounted"},
-            {8002, nullptr, "ResetAlbumMountStatus"},
-            {8011, nullptr, "RefreshAlbumCache"},
-            {8012, nullptr, "GetAlbumCache"},
-            {8013, nullptr, "Unknown8013"},
-            {8021, nullptr, "GetAlbumEntryFromApplicationAlbumEntryAruid"},
-            {10011, nullptr, "SetInternalErrorConversionEnabled"},
-            {50000, nullptr, "Unknown50000"},
-            {60002, nullptr, "Unknown60002"},
-        };
-        // clang-format on
-
-        RegisterHandlers(functions);
-    }
-};
-
-class CAPS_C final : public ServiceFramework<CAPS_C> {
-public:
-    explicit CAPS_C() : ServiceFramework{"caps:c"} {
-        // clang-format off
-        static const FunctionInfo functions[] = {
-            {33, nullptr, "Unknown33"},
-            {2001, nullptr, "Unknown2001"},
-            {2002, nullptr, "Unknown2002"},
-            {2011, nullptr, "Unknown2011"},
-            {2012, nullptr, "Unknown2012"},
-            {2013, nullptr, "Unknown2013"},
-            {2014, nullptr, "Unknown2014"},
-            {2101, nullptr, "Unknown2101"},
-            {2102, nullptr, "Unknown2102"},
-            {2201, nullptr, "Unknown2201"},
-            {2301, nullptr, "Unknown2301"},
-        };
-        // clang-format on
-
-        RegisterHandlers(functions);
-    }
-};
-
-class CAPS_SC final : public ServiceFramework<CAPS_SC> {
-public:
-    explicit CAPS_SC() : ServiceFramework{"caps:sc"} {
-        // clang-format off
-        static const FunctionInfo functions[] = {
-            {1, nullptr, "Unknown1"},
-            {2, nullptr, "Unknown2"},
-            {1001, nullptr, "Unknown3"},
-            {1002, nullptr, "Unknown4"},
-            {1003, nullptr, "Unknown5"},
-            {1011, nullptr, "Unknown6"},
-            {1012, nullptr, "Unknown7"},
-            {1201, nullptr, "Unknown8"},
-            {1202, nullptr, "Unknown9"},
-            {1203, nullptr, "Unknown10"},
-        };
-        // clang-format on
-
-        RegisterHandlers(functions);
-    }
-};
-
-class CAPS_SS final : public ServiceFramework<CAPS_SS> {
-public:
-    explicit CAPS_SS() : ServiceFramework{"caps:ss"} {
-        // clang-format off
-        static const FunctionInfo functions[] = {
-            {201, nullptr, "Unknown1"},
-            {202, nullptr, "Unknown2"},
-            {203, nullptr, "Unknown3"},
-            {204, nullptr, "Unknown4"},
-        };
-        // clang-format on
-
-        RegisterHandlers(functions);
-    }
-};
-
-class CAPS_SU final : public ServiceFramework<CAPS_SU> {
-public:
-    explicit CAPS_SU() : ServiceFramework{"caps:su"} {
-        // clang-format off
-        static const FunctionInfo functions[] = {
-            {201, nullptr, "SaveScreenShot"},
-            {203, nullptr, "SaveScreenShotEx0"},
-        };
-        // clang-format on
-
-        RegisterHandlers(functions);
-    }
-};
-
-class CAPS_U final : public ServiceFramework<CAPS_U> {
-public:
-    explicit CAPS_U() : ServiceFramework{"caps:u"} {
-        // clang-format off
-        static const FunctionInfo functions[] = {
-            {32, nullptr, "SetShimLibraryVersion"},
-            {102, nullptr, "GetAlbumFileListByAruid"},
-            {103, nullptr, "DeleteAlbumFileByAruid"},
-            {104, nullptr, "GetAlbumFileSizeByAruid"},
-            {105, nullptr, "DeleteAlbumFileByAruidForDebug"},
-            {110, nullptr, "LoadAlbumScreenShotImageByAruid"},
-            {120, nullptr, "LoadAlbumScreenShotThumbnailImageByAruid"},
-            {130, nullptr, "PrecheckToCreateContentsByAruid"},
-            {140, nullptr, "GetAlbumFileList1AafeAruidDeprecated"},
-            {141, nullptr, "GetAlbumFileList2AafeUidAruidDeprecated"},
-            {142, nullptr, "GetAlbumFileList3AaeAruid"},
-            {143, nullptr, "GetAlbumFileList4AaeUidAruid"},
-            {60002, nullptr, "OpenAccessorSessionForApplication"},
-        };
-        // clang-format on
-
-        RegisterHandlers(functions);
-    }
-};
 
 void InstallInterfaces(SM::ServiceManager& sm) {
     std::make_shared<CAPS_A>()->InstallAsService(sm);
     std::make_shared<CAPS_C>()->InstallAsService(sm);
+    std::make_shared<CAPS_U>()->InstallAsService(sm);
     std::make_shared<CAPS_SC>()->InstallAsService(sm);
     std::make_shared<CAPS_SS>()->InstallAsService(sm);
     std::make_shared<CAPS_SU>()->InstallAsService(sm);
-    std::make_shared<CAPS_U>()->InstallAsService(sm);
 }
 
 } // namespace Service::Capture

--- a/src/core/hle/service/caps/caps.h
+++ b/src/core/hle/service/caps/caps.h
@@ -4,11 +4,81 @@
 
 #pragma once
 
+#include "core/hle/service/service.h"
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::Capture {
+
+enum AlbumImageOrientation {
+    Orientation0 = 0,
+    Orientation1 = 1,
+    Orientation2 = 2,
+    Orientation3 = 3,
+};
+
+enum AlbumReportOption {
+    Disable = 0,
+    Enable = 1,
+};
+
+enum ContentType : u8 {
+    Screenshot = 0,
+    Movie = 1,
+    ExtraMovie = 3,
+};
+
+enum AlbumStorage : u8 {
+    NAND = 0,
+    SD = 1,
+};
+
+struct AlbumFileDateTime {
+    u16 year;
+    u8 month;
+    u8 day;
+    u8 hour;
+    u8 minute;
+    u8 second;
+    u8 uid;
+};
+
+struct AlbumEntry {
+    u64 size;
+    u64 application_id;
+    AlbumFileDateTime datetime;
+    AlbumStorage storage;
+    ContentType content;
+    u8 padding[6];
+};
+
+struct AlbumFileEntry {
+    u64 size;
+    u64 hash;
+    AlbumFileDateTime datetime;
+    AlbumStorage storage;
+    ContentType content;
+    u8 padding[5];
+    u8 unknown;
+};
+
+struct ApplicationAlbumEntry {
+    u64 size;
+    u64 hash;
+    AlbumFileDateTime datetime;
+    AlbumStorage storage;
+    ContentType content;
+    u8 padding[5];
+    u8 unknown;
+};
+
+struct ApplicationAlbumFileEntry {
+    ApplicationAlbumEntry entry;
+    AlbumFileDateTime datetime;
+    u64 unknown;
+};
 
 /// Registers all Capture services with the specified service manager.
 void InstallInterfaces(SM::ServiceManager& sm);

--- a/src/core/hle/service/caps/caps.h
+++ b/src/core/hle/service/caps/caps.h
@@ -10,6 +10,7 @@ class ServiceManager;
 
 namespace Service::Capture {
 
+/// Registers all Capture services with the specified service manager.
 void InstallInterfaces(SM::ServiceManager& sm);
 
 } // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_a.cpp
+++ b/src/core/hle/service/caps/caps_a.cpp
@@ -1,0 +1,78 @@
+// Copyright 2020 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/caps/caps_a.h"
+
+namespace Service::Capture {
+
+class IAlbumAccessorSession final : public ServiceFramework<IAlbumAccessorSession> {
+public:
+    explicit IAlbumAccessorSession() : ServiceFramework{"IAlbumAccessorSession"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {2001, nullptr, "OpenAlbumMovieReadStream"},
+            {2002, nullptr, "CloseAlbumMovieReadStream"},
+            {2003, nullptr, "GetAlbumMovieReadStreamMovieDataSize"},
+            {2004, nullptr, "ReadMovieDataFromAlbumMovieReadStream"},
+            {2005, nullptr, "GetAlbumMovieReadStreamBrokenReason"},
+            {2006, nullptr, "GetAlbumMovieReadStreamImageDataSize"},
+            {2007, nullptr, "ReadImageDataFromAlbumMovieReadStream"},
+            {2008, nullptr, "ReadFileAttributeFromAlbumMovieReadStream"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+CAPS_A::CAPS_A() : ServiceFramework("caps:a") {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "GetAlbumFileCount"},
+        {1, nullptr, "GetAlbumFileList"},
+        {2, nullptr, "LoadAlbumFile"},
+        {3, nullptr, "DeleteAlbumFile"},
+        {4, nullptr, "StorageCopyAlbumFile"},
+        {5, nullptr, "IsAlbumMounted"},
+        {6, nullptr, "GetAlbumUsage"},
+        {7, nullptr, "GetAlbumFileSize"},
+        {8, nullptr, "LoadAlbumFileThumbnail"},
+        {9, nullptr, "LoadAlbumScreenShotImage"},
+        {10, nullptr, "LoadAlbumScreenShotThumbnailImage"},
+        {11, nullptr, "GetAlbumEntryFromApplicationAlbumEntry"},
+        {12, nullptr, "LoadAlbumScreenShotImageEx"},
+        {13, nullptr, "LoadAlbumScreenShotThumbnailImageEx"},
+        {14, nullptr, "LoadAlbumScreenShotImageEx0"},
+        {15, nullptr, "GetAlbumUsage3"},
+        {16, nullptr, "GetAlbumMountResult"},
+        {17, nullptr, "GetAlbumUsage16"},
+        {18, nullptr, "Unknown18"},
+        {100, nullptr, "GetAlbumFileCountEx0"},
+        {101, nullptr, "GetAlbumFileListEx0"},
+        {202, nullptr, "SaveEditedScreenShot"},
+        {301, nullptr, "GetLastThumbnail"},
+        {302, nullptr, "GetLastOverlayMovieThumbnail"},
+        {401, nullptr, "GetAutoSavingStorage"},
+        {501, nullptr, "GetRequiredStorageSpaceSizeToCopyAll"},
+        {1001, nullptr, "LoadAlbumScreenShotThumbnailImageEx0"},
+        {1002, nullptr, "LoadAlbumScreenShotImageEx1"},
+        {1003, nullptr, "LoadAlbumScreenShotThumbnailImageEx1"},
+        {8001, nullptr, "ForceAlbumUnmounted"},
+        {8002, nullptr, "ResetAlbumMountStatus"},
+        {8011, nullptr, "RefreshAlbumCache"},
+        {8012, nullptr, "GetAlbumCache"},
+        {8013, nullptr, "GetAlbumCacheEx"},
+        {8021, nullptr, "GetAlbumEntryFromApplicationAlbumEntryAruid"},
+        {10011, nullptr, "SetInternalErrorConversionEnabled"},
+        {50000, nullptr, "LoadMakerNoteInfoForDebug"},
+        {60002, nullptr, "OpenAccessorSession"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+CAPS_A::~CAPS_A() = default;
+
+} // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_a.h
+++ b/src/core/hle/service/caps/caps_a.h
@@ -1,0 +1,21 @@
+// Copyright 2020 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Kernel {
+class HLERequestContext;
+}
+
+namespace Service::Capture {
+
+class CAPS_A final : public ServiceFramework<CAPS_A> {
+public:
+    explicit CAPS_A();
+    ~CAPS_A() override;
+};
+
+} // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_c.cpp
+++ b/src/core/hle/service/caps/caps_c.cpp
@@ -1,0 +1,75 @@
+// Copyright 2020 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/caps/caps_c.h"
+
+namespace Service::Capture {
+
+class IAlbumControlSession final : public ServiceFramework<IAlbumControlSession> {
+public:
+    explicit IAlbumControlSession() : ServiceFramework{"IAlbumControlSession"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {2001, nullptr, "OpenAlbumMovieReadStream"},
+            {2002, nullptr, "CloseAlbumMovieReadStream"},
+            {2003, nullptr, "GetAlbumMovieReadStreamMovieDataSize"},
+            {2004, nullptr, "ReadMovieDataFromAlbumMovieReadStream"},
+            {2005, nullptr, "GetAlbumMovieReadStreamBrokenReason"},
+            {2006, nullptr, "GetAlbumMovieReadStreamImageDataSize"},
+            {2007, nullptr, "ReadImageDataFromAlbumMovieReadStream"},
+            {2008, nullptr, "ReadFileAttributeFromAlbumMovieReadStream"},
+            {2401, nullptr, "OpenAlbumMovieWriteStream"},
+            {2402, nullptr, "FinishAlbumMovieWriteStream"},
+            {2403, nullptr, "CommitAlbumMovieWriteStream"},
+            {2404, nullptr, "DiscardAlbumMovieWriteStream"},
+            {2405, nullptr, "DiscardAlbumMovieWriteStreamNoDelete"},
+            {2406, nullptr, "CommitAlbumMovieWriteStreamEx"},
+            {2411, nullptr, "StartAlbumMovieWriteStreamDataSection"},
+            {2412, nullptr, "EndAlbumMovieWriteStreamDataSection"},
+            {2413, nullptr, "StartAlbumMovieWriteStreamMetaSection"},
+            {2414, nullptr, "EndAlbumMovieWriteStreamMetaSection"},
+            {2421, nullptr, "ReadDataFromAlbumMovieWriteStream"},
+            {2422, nullptr, "WriteDataToAlbumMovieWriteStream"},
+            {2424, nullptr, "WriteMetaToAlbumMovieWriteStream"},
+            {2431, nullptr, "GetAlbumMovieWriteStreamBrokenReason"},
+            {2433, nullptr, "GetAlbumMovieWriteStreamDataSize"},
+            {2434, nullptr, "SetAlbumMovieWriteStreamDataSize"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+CAPS_C::CAPS_C() : ServiceFramework("caps:c") {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {1, nullptr, "CaptureRawImage"},
+        {2, nullptr, "CaptureRawImageWithTimeout"},
+        {33, nullptr, "Unknown33"},
+        {1001, nullptr, "RequestTakingScreenShot"},
+        {1002, nullptr, "RequestTakingScreenShotWithTimeout"},
+        {1011, nullptr, "NotifyTakingScreenShotRefused"},
+        {2001, nullptr, "NotifyAlbumStorageIsAvailable"},
+        {2002, nullptr, "NotifyAlbumStorageIsUnavailable"},
+        {2011, nullptr, "RegisterAppletResourceUserId"},
+        {2012, nullptr, "UnregisterAppletResourceUserId"},
+        {2013, nullptr, "GetApplicationIdFromAruid"},
+        {2014, nullptr, "CheckApplicationIdRegistered"},
+        {2101, nullptr, "GenerateCurrentAlbumFileId"},
+        {2102, nullptr, "GenerateApplicationAlbumEntry"},
+        {2201, nullptr, "SaveAlbumScreenShotFile"},
+        {2202, nullptr, "SaveAlbumScreenShotFileEx"},
+        {2301, nullptr, "SetOverlayScreenShotThumbnailData"},
+        {2302, nullptr, "SetOverlayMovieThumbnailData"},
+        {60001, nullptr, "OpenControlSession"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+CAPS_C::~CAPS_C() = default;
+
+} // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_c.h
+++ b/src/core/hle/service/caps/caps_c.h
@@ -1,0 +1,21 @@
+// Copyright 2020 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Kernel {
+class HLERequestContext;
+}
+
+namespace Service::Capture {
+
+class CAPS_C final : public ServiceFramework<CAPS_C> {
+public:
+    explicit CAPS_C();
+    ~CAPS_C() override;
+};
+
+} // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_sc.cpp
+++ b/src/core/hle/service/caps/caps_sc.cpp
@@ -1,0 +1,40 @@
+// Copyright 2020 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/caps/caps_sc.h"
+
+namespace Service::Capture {
+
+CAPS_SC::CAPS_SC() : ServiceFramework("caps:sc") {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {1, nullptr, "CaptureRawImage"},
+        {2, nullptr, "CaptureRawImageWithTimeout"},
+        {3, nullptr, "AttachSharedBuffer"},
+        {5, nullptr, "CaptureRawImageToAttachedSharedBuffer"},
+        {210, nullptr, "Unknown210"},
+        {1001, nullptr, "RequestTakingScreenShot"},
+        {1002, nullptr, "RequestTakingScreenShotWithTimeout"},
+        {1003, nullptr, "RequestTakingScreenShotEx"},
+        {1004, nullptr, "RequestTakingScreenShotEx1"},
+        {1009, nullptr, "CancelTakingScreenShot"},
+        {1010, nullptr, "SetTakingScreenShotCancelState"},
+        {1011, nullptr, "NotifyTakingScreenShotRefused"},
+        {1012, nullptr, "NotifyTakingScreenShotFailed"},
+        {1101, nullptr, "SetupOverlayMovieThumbnail"},
+        {1106, nullptr, "Unknown1106"},
+        {1107, nullptr, "Unknown1107"},
+        {1201, nullptr, "OpenRawScreenShotReadStream"},
+        {1202, nullptr, "CloseRawScreenShotReadStream"},
+        {1203, nullptr, "ReadRawScreenShotReadStream"},
+        {1204, nullptr, "Unknown1204"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+CAPS_SC::~CAPS_SC() = default;
+
+} // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_sc.h
+++ b/src/core/hle/service/caps/caps_sc.h
@@ -1,0 +1,21 @@
+// Copyright 2020 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Kernel {
+class HLERequestContext;
+}
+
+namespace Service::Capture {
+
+class CAPS_SC final : public ServiceFramework<CAPS_SC> {
+public:
+    explicit CAPS_SC();
+    ~CAPS_SC() override;
+};
+
+} // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_ss.cpp
+++ b/src/core/hle/service/caps/caps_ss.cpp
@@ -1,0 +1,26 @@
+// Copyright 2020 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/caps/caps_ss.h"
+
+namespace Service::Capture {
+
+CAPS_SS::CAPS_SS() : ServiceFramework("caps:ss") {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {201, nullptr, "SaveScreenShot"},
+        {202, nullptr, "SaveEditedScreenShot"},
+        {203, nullptr, "SaveScreenShotEx0"},
+        {204, nullptr, "SaveEditedScreenShotEx0"},
+        {206, nullptr, "Unknown206"},
+        {208, nullptr, "SaveScreenShotOfMovieEx1"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+CAPS_SS::~CAPS_SS() = default;
+
+} // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_ss.h
+++ b/src/core/hle/service/caps/caps_ss.h
@@ -1,0 +1,21 @@
+// Copyright 2020 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Kernel {
+class HLERequestContext;
+}
+
+namespace Service::Capture {
+
+class CAPS_SS final : public ServiceFramework<CAPS_SS> {
+public:
+    explicit CAPS_SS();
+    ~CAPS_SS() override;
+};
+
+} // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_su.cpp
+++ b/src/core/hle/service/caps/caps_su.cpp
@@ -1,0 +1,22 @@
+// Copyright 2020 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/caps/caps_su.h"
+
+namespace Service::Capture {
+
+CAPS_SU::CAPS_SU() : ServiceFramework("caps:su") {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {201, nullptr, "SaveScreenShot"},
+        {203, nullptr, "SaveScreenShotEx0"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+CAPS_SU::~CAPS_SU() = default;
+
+} // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_su.h
+++ b/src/core/hle/service/caps/caps_su.h
@@ -1,0 +1,21 @@
+// Copyright 2020 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Kernel {
+class HLERequestContext;
+}
+
+namespace Service::Capture {
+
+class CAPS_SU final : public ServiceFramework<CAPS_SU> {
+public:
+    explicit CAPS_SU();
+    ~CAPS_SU() override;
+};
+
+} // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_u.cpp
+++ b/src/core/hle/service/caps/caps_u.cpp
@@ -1,0 +1,53 @@
+// Copyright 2020 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/caps/caps_u.h"
+
+namespace Service::Capture {
+
+class IAlbumAccessorApplicationSession final
+    : public ServiceFramework<IAlbumAccessorApplicationSession> {
+public:
+    explicit IAlbumAccessorApplicationSession()
+        : ServiceFramework{"IAlbumAccessorApplicationSession"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {2001, nullptr, "OpenAlbumMovieReadStream"},
+            {2002, nullptr, "CloseAlbumMovieReadStream"},
+            {2003, nullptr, "GetAlbumMovieReadStreamMovieDataSize"},
+            {2004, nullptr, "ReadMovieDataFromAlbumMovieReadStream"},
+            {2005, nullptr, "GetAlbumMovieReadStreamBrokenReason"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
+CAPS_U::CAPS_U() : ServiceFramework("caps:u") {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {31, nullptr, "GetShimLibraryVersion"},
+        {32, nullptr, "SetShimLibraryVersion"},
+        {102, nullptr, "GetAlbumContentsFileListForApplication"},
+        {103, nullptr, "DeleteAlbumContentsFileForApplication"},
+        {104, nullptr, "GetAlbumContentsFileSizeForApplication"},
+        {105, nullptr, "DeleteAlbumFileByAruidForDebug"},
+        {110, nullptr, "LoadAlbumContentsFileScreenShotImageForApplication"},
+        {120, nullptr, "LoadAlbumContentsFileThumbnailImageForApplication"},
+        {130, nullptr, "PrecheckToCreateContentsForApplication"},
+        {140, nullptr, "GetAlbumFileList1AafeAruidDeprecated"},
+        {141, nullptr, "GetAlbumFileList2AafeUidAruidDeprecated"},
+        {142, nullptr, "GetAlbumFileList3AaeAruid"},
+        {143, nullptr, "GetAlbumFileList4AaeUidAruid"},
+        {60002, nullptr, "OpenAccessorSessionForApplication"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+CAPS_U::~CAPS_U() = default;
+
+} // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_u.cpp
+++ b/src/core/hle/service/caps/caps_u.cpp
@@ -2,6 +2,9 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/logging/log.h"
+#include "core/hle/ipc_helpers.h"
+#include "core/hle/service/caps/caps.h"
 #include "core/hle/service/caps/caps_u.h"
 
 namespace Service::Capture {
@@ -30,7 +33,7 @@ CAPS_U::CAPS_U() : ServiceFramework("caps:u") {
     static const FunctionInfo functions[] = {
         {31, nullptr, "GetShimLibraryVersion"},
         {32, nullptr, "SetShimLibraryVersion"},
-        {102, nullptr, "GetAlbumContentsFileListForApplication"},
+        {102, &CAPS_U::GetAlbumContentsFileListForApplication, "GetAlbumContentsFileListForApplication"},
         {103, nullptr, "DeleteAlbumContentsFileForApplication"},
         {104, nullptr, "GetAlbumContentsFileSizeForApplication"},
         {105, nullptr, "DeleteAlbumFileByAruidForDebug"},
@@ -49,5 +52,25 @@ CAPS_U::CAPS_U() : ServiceFramework("caps:u") {
 }
 
 CAPS_U::~CAPS_U() = default;
+
+void CAPS_U::GetAlbumContentsFileListForApplication(Kernel::HLERequestContext& ctx) {
+    // Takes a type-0x6 output buffer containing an array of ApplicationAlbumFileEntry, a PID, an
+    // u8 ContentType, two s64s, and an u64 AppletResourceUserId. Returns an output u64 for total
+    // output entries (which is copied to a s32 by official SW).
+    IPC::RequestParser rp{ctx};
+    auto application_album_entries = rp.PopRaw<std::array<u8, 0x30>>();
+    auto pid = rp.Pop<s32>();
+    auto content_type = rp.PopRaw<ContentType>();
+    auto start_datetime = rp.PopRaw<AlbumFileDateTime>();
+    auto end_datetime = rp.PopRaw<AlbumFileDateTime>();
+    auto applet_resource_user_id = rp.Pop<u64>();
+    LOG_WARNING(Service_Capture,
+                "(STUBBED) called. pid={}, content_type={}, applet_resource_user_id={}", pid,
+                content_type, applet_resource_user_id);
+
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(RESULT_SUCCESS);
+    rb.Push<s32>(0);
+}
 
 } // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_u.cpp
+++ b/src/core/hle/service/caps/caps_u.cpp
@@ -58,12 +58,12 @@ void CAPS_U::GetAlbumContentsFileListForApplication(Kernel::HLERequestContext& c
     // u8 ContentType, two s64s, and an u64 AppletResourceUserId. Returns an output u64 for total
     // output entries (which is copied to a s32 by official SW).
     IPC::RequestParser rp{ctx};
-    auto application_album_entries = rp.PopRaw<std::array<u8, 0x30>>();
-    auto pid = rp.Pop<s32>();
-    auto content_type = rp.PopRaw<ContentType>();
-    auto start_datetime = rp.PopRaw<AlbumFileDateTime>();
-    auto end_datetime = rp.PopRaw<AlbumFileDateTime>();
-    auto applet_resource_user_id = rp.Pop<u64>();
+    [[maybe_unused]] const auto application_album_file_entries = rp.PopRaw<std::array<u8, 0x30>>();
+    const auto pid = rp.Pop<s32>();
+    const auto content_type = rp.PopRaw<ContentType>();
+    [[maybe_unused]] const auto start_datetime = rp.PopRaw<AlbumFileDateTime>();
+    [[maybe_unused]] const auto end_datetime = rp.PopRaw<AlbumFileDateTime>();
+    const auto applet_resource_user_id = rp.Pop<u64>();
     LOG_WARNING(Service_Capture,
                 "(STUBBED) called. pid={}, content_type={}, applet_resource_user_id={}", pid,
                 content_type, applet_resource_user_id);

--- a/src/core/hle/service/caps/caps_u.h
+++ b/src/core/hle/service/caps/caps_u.h
@@ -1,0 +1,21 @@
+// Copyright 2020 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Kernel {
+class HLERequestContext;
+}
+
+namespace Service::Capture {
+
+class CAPS_U final : public ServiceFramework<CAPS_U> {
+public:
+    explicit CAPS_U();
+    ~CAPS_U() override;
+};
+
+} // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_u.h
+++ b/src/core/hle/service/caps/caps_u.h
@@ -16,6 +16,9 @@ class CAPS_U final : public ServiceFramework<CAPS_U> {
 public:
     explicit CAPS_U();
     ~CAPS_U() override;
+
+private:
+    void GetAlbumContentsFileListForApplication(Kernel::HLERequestContext& ctx);
 };
 
 } // namespace Service::Capture


### PR DESCRIPTION
Splits caps into caps_a, caps_c, caps_u, caps_sc, caps_ss, and caps_su.

Stubs GetAlbumContentsFileListForApplication (#2720) as it is used in Super Smash Bros. Ultimate World of Light. The crash following this is unrelated. This command is also used when taking a snapshot. However, it calls SaveScreenShotEx0 in caps:su next and crashes due to it also being unimplemented.