### PR TITLE
Port citra-emu/citra#5089: "Set render window's focus policy to Qt::StrongFocus"

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1798,7 +1798,7 @@ void GMainWindow::ToggleWindowMode() {
         // Render in the main window...
         render_window->BackupGeometry();
         ui.horizontalLayout->addWidget(render_window);
-        render_window->setFocusPolicy(Qt::ClickFocus);
+        render_window->setFocusPolicy(Qt::StrongFocus);
         if (emulation_running) {
             render_window->setVisible(true);
             render_window->setFocus();


### PR DESCRIPTION
See citra-emu/citra#5089 for more details.

**Original description**:
From my testing, possibly closes citra-emu/citra#5040. If it does, I'm not sure of the _exact_ reason for it. (Maybe the deprecated widget ignored the focus policy? Or some other bug? Or maybe something to do with how returning focus to the window works?)

I'm not happy with the lack of explanation for the change, but it's somewhat backed by [Qt docs](https://doc.qt.io/archives/qt-5.10/focus.html)
> Since pressing Tab is so common, most widgets that can have focus should support tab focus.
