### PR TITLE
Port citra-emu/citra#4906: "citra_qt: fix the stuck in fullscreen mode"

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1034,6 +1034,14 @@ void GMainWindow::BootGame(const QString& filename) {
 }
 
 void GMainWindow::ShutdownGame() {
+    if (!emulation_running) {
+        return;
+    }
+
+    if (ui.action_Fullscreen->isChecked()) {
+        HideFullscreen();
+    }
+
     AllowOSSleep();
 
     discord_rpc->Pause();


### PR DESCRIPTION
See citra-emu/citra#4906 for more details.

**Original description**:
The stuck in fullscreen mode bug happens if the emulated program exits, is fixed by adding [this](https://github.com/citra-emu/citra/compare/master...vvanelslande:hotkey-and-fullscreen-fixes?expand=1#diff-5e8bf22f5c3b3579c402308dd96b7563R888-R894), steps to reproduce:
- Start [FBI](https://github.com/Steveice10/FBI)
- Press START