### PR TITLE
shader_decompiler: Remove FragCoord.w hack and change IPA implementation

### DIFF
--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
@@ -35,7 +35,7 @@ namespace {
 using Sirit::Id;
 using Tegra::Engines::ShaderType;
 using Tegra::Shader::Attribute;
-using Tegra::Shader::AttributeUse;
+using Tegra::Shader::PixelImap;
 using Tegra::Shader::Register;
 using namespace VideoCommon::Shader;
 
@@ -752,15 +752,15 @@ private:
             if (stage != ShaderType::Fragment) {
                 continue;
             }
-            switch (header.ps.GetAttributeUse(location)) {
-            case AttributeUse::Constant:
+            switch (header.ps.GetPixelImap(location)) {
+            case PixelImap::Constant:
                 Decorate(id, spv::Decoration::Flat);
                 break;
-            case AttributeUse::ScreenLinear:
-                Decorate(id, spv::Decoration::NoPerspective);
-                break;
-            case AttributeUse::Perspective:
+            case PixelImap::Perspective:
                 // Default
+                break;
+            case PixelImap::ScreenLinear:
+                Decorate(id, spv::Decoration::NoPerspective);
                 break;
             default:
                 UNREACHABLE_MSG("Unused attribute being fetched");
@@ -1145,9 +1145,6 @@ private:
             switch (attribute) {
             case Attribute::Index::Position: {
                 if (stage == ShaderType::Fragment) {
-                    if (element == 3) {
-                        return {Constant(t_float, 1.0f), Type::Float};
-                    }
                     return {OpLoad(t_float, AccessElement(t_in_float, frag_coord, element)),
                             Type::Float};
                 }


### PR DESCRIPTION
Credits go to gdkchan and [Ryujinx](https://github.com/Ryujinx/Ryujinx). The pull request used for this can
be found here: https://github.com/Ryujinx/Ryujinx/pull/1082

yuzu was already using the header for interpolation, but it was missing
the FragCoord.w multiplication described in the linked pull request.
This commit finally removes the FragCoord.w == 1.0f hack from the shader
decompiler.

While we are at it, this commit renames some enumerations to match
Nvidia's [documentation](https://github.com/NVIDIA/open-gpu-doc/blob/master/Shader-Program-Header/Shader-Program-Header.html) and fixes component declaration
order in the shader program header (z and w were swapped).

* Fixes Splatoon 2 shadows projection issues, they still look dark.