### PR TITLE
shader/memory: Silence no return value warning

### DIFF
--- a/src/video_core/shader/decode/memory.cpp
+++ b/src/video_core/shader/decode/memory.cpp
@@ -44,6 +44,9 @@ Node GetAtomOperation(AtomicOp op, bool is_signed, Node memory, Node data) {
             return OperationCode::AtomicIXor;
         case AtomicOp::Exch:
             return OperationCode::AtomicIExchange;
+        default:
+            UNIMPLEMENTED_MSG("op={}", static_cast<int>(op));
+            return OperationCode::AtomicIAdd;
         }
     }();
     return SignedOperation(operation_code, is_signed, std::move(memory), std::move(data));


### PR DESCRIPTION
Silences a warning about not all control paths returning a value.