### PR TITLE
file_sys: fix LayeredFS error when loading some games made with the Unity

### DIFF
--- a/src/core/file_sys/romfs.cpp
+++ b/src/core/file_sys/romfs.cpp
@@ -5,8 +5,8 @@
 #include <memory>
 
 #include "common/common_types.h"
-#include "common/swap.h"
 #include "common/string_util.h"
+#include "common/swap.h"
 #include "core/file_sys/fsmitm_romfsbuild.h"
 #include "core/file_sys/romfs.h"
 #include "core/file_sys/vfs.h"

--- a/src/core/file_sys/romfs.cpp
+++ b/src/core/file_sys/romfs.cpp
@@ -6,6 +6,7 @@
 
 #include "common/common_types.h"
 #include "common/swap.h"
+#include "common/string_util.h"
 #include "core/file_sys/fsmitm_romfsbuild.h"
 #include "core/file_sys/romfs.h"
 #include "core/file_sys/vfs.h"
@@ -126,7 +127,7 @@ VirtualDir ExtractRomFS(VirtualFile file, RomFSExtractionType type) {
         return out->GetSubdirectories().front();
 
     while (out->GetSubdirectories().size() == 1 && out->GetFiles().empty()) {
-        if (out->GetSubdirectories().front()->GetName() == "data" &&
+        if (Common::ToLower(out->GetSubdirectories().front()->GetName()) == "data" &&
             type == RomFSExtractionType::Truncated)
             break;
         out = out->GetSubdirectories().front();


### PR DESCRIPTION
Some Unity game, such like Pokemon Mystery Dungeon:DX,  using "Data" as the top directory.
Also see this issue more details -> https://github.com/yuzu-emu/yuzu/issues/3482