### PR TITLE
Port citra-emu/citra#5123: "SDL: Disable hidapi drivers due to compatibility problems with certain controllers"

### DIFF
--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -508,6 +508,13 @@ SDLState::SDLState() {
     if (SDL_SetHint(SDL_HINT_JOYSTICK_ALLOW_BACKGROUND_EVENTS, "1") == SDL_FALSE) {
         LOG_ERROR(Input, "Failed to set hint for background events with: {}", SDL_GetError());
     }
+// these hints are only defined on sdl2.0.9 or higher
+#if SDL_VERSION_ATLEAST(2, 0, 9)
+#if !SDL_VERSION_ATLEAST(2, 0, 12)
+    // There are also hints to toggle the individual drivers if needed.
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI, "0");
+#endif
+#endif
 
     SDL_AddEventWatch(&SDLEventWatcher, this);
 


### PR DESCRIPTION
See citra-emu/citra#5123 for more details.

**Original description**:
The change of SDL2 from 2.0.8 to 2.0.10 broke compatibility with some controllers that reported as Switch and Xbox One controllers.
Having SDL_HINT_JOYSTICK_HIDAPI set to "0" should get us the same behavior as before the change, as all of the reported problems stem from joysticks that have a hidapi driver implementation.

From some investigation, the current drivers try to write to the controller, for setting rumble, stick calibration, LED behavior and other similar tasks. 
Most or all of the users that had this problem and identified their controllers had non-official versions of the controllers. From the available information some of these controllers don't have some of the features the driver tries to use, and the driver fails to init the joystick in those cases.

Another reported issue caused by the hidapi drivers is #5118. In this case the driver works but always writes (0,0,80) to the lightbar, and there is no way to change the driver behavior.

Looking ahead at the proposed 2.0.12 source code, the compatibility problems should be solved by the changes to the driver to differentiate input-only controllers, but the PS4 lightbar behavior stays the same.
Closes citra-emu/citra#5118, but the issue might come back if the hidapi drivers are re-enabled.