### PR TITLE
service/vi: Partially implement BufferQueue disconnect

### DIFF
--- a/src/core/hle/service/nvflinger/buffer_queue.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue.cpp
@@ -103,6 +103,13 @@ void BufferQueue::ReleaseBuffer(u32 slot) {
     buffer_wait_event.writable->Signal();
 }
 
+void BufferQueue::Disconnect() {
+    queue.clear();
+    queue_sequence.clear();
+    id = 1;
+    layer_id = 1;
+}
+
 u32 BufferQueue::Query(QueryType type) {
     LOG_WARNING(Service, "(STUBBED) called type={}", static_cast<u32>(type));
 

--- a/src/core/hle/service/nvflinger/buffer_queue.h
+++ b/src/core/hle/service/nvflinger/buffer_queue.h
@@ -87,6 +87,7 @@ public:
                      Service::Nvidia::MultiFence& multi_fence);
     std::optional<std::reference_wrapper<const Buffer>> AcquireBuffer();
     void ReleaseBuffer(u32 slot);
+    void Disconnect();
     u32 Query(QueryType type);
 
     u32 GetId() const {


### PR DESCRIPTION
Thanks to fincs for guiding me in this.
This is not based on reverse engineering. It's purely based on making [deko_examples](https://github.com/switchbrew/switch-examples/tree/master/graphics/deko3d/deko_examples). I'm open for feedback on this, as I don't have experience doing HLE.

`Disconnect` and `DetachBuffer` were no-ops. This commit implements `Disconnect`.

While we are at it, change the code to use a `switch` case.