### PR TITLE
Log version and about section version fix

### DIFF
--- a/CMakeModules/GenerateSCMRev.cmake
+++ b/CMakeModules/GenerateSCMRev.cmake
@@ -48,6 +48,25 @@ if (BUILD_REPOSITORY)
   endif()
 endif()
 
+# "Hack": Generate BUILD_FULLNAME from the Git desc
+if (GIT_DESC)
+  # regex capture the characters before the first "-" into CMAKE_MATCH_1
+  string(REGEX MATCH "^([a-z]*)-.*" OUTVAR ${GIT_DESC})
+  if ("${CMAKE_MATCH_COUNT}" GREATER 0)
+    # capitalize the first letter of the repo name.
+    string(SUBSTRING ${CMAKE_MATCH_1} 0 1 FIRST_LETTER)
+    string(SUBSTRING ${CMAKE_MATCH_1} 1 -1 REMAINDER)
+    string(TOUPPER ${FIRST_LETTER} FIRST_LETTER)
+    set(REPO_NAME "${FIRST_LETTER}${REMAINDER}")
+
+    # If GIT_DESC has been parsed correctly, build the BUILD_FULLNAME from the repo name and the
+    # build version
+    if(REPO_NAME)
+        set(BUILD_FULLNAME "${REPO_NAME} ${BUILD_ID} ")
+    endif()
+  endif()
+endif()
+
 # The variable SRC_DIR must be passed into the script (since it uses the current build directory for all values of CMAKE_*_DIR)
 set(VIDEO_CORE "${SRC_DIR}/src/video_core")
 set(HASH_FILES

--- a/CMakeModules/GenerateSCMRev.cmake
+++ b/CMakeModules/GenerateSCMRev.cmake
@@ -20,6 +20,8 @@ get_timestamp(BUILD_DATE)
 # Also if this is a CI build, add the build name (ie: Nightly, Canary) to the scm_rev file as well
 set(REPO_NAME "")
 set(BUILD_VERSION "0")
+set(TITLE_BAR_FORMAT_IDLE "yuzu {5} ")
+set(BUILD_ID "420")
 if (BUILD_REPOSITORY)
   # regex capture the string nightly or canary into CMAKE_MATCH_1
   string(REGEX MATCH "yuzu-emu/yuzu-?(.*)" OUTVAR ${BUILD_REPOSITORY})
@@ -44,25 +46,6 @@ if (BUILD_REPOSITORY)
       else()
         set(BUILD_FULLNAME "")
       endif()
-    endif()
-  endif()
-endif()
-
-# "Hack": Generate BUILD_FULLNAME from the Git desc
-if (GIT_DESC)
-  # regex capture the characters before the first "-" into CMAKE_MATCH_1
-  string(REGEX MATCH "^([a-z]*)-.*" OUTVAR ${GIT_DESC})
-  if ("${CMAKE_MATCH_COUNT}" GREATER 0)
-    # capitalize the first letter of the repo name.
-    string(SUBSTRING ${CMAKE_MATCH_1} 0 1 FIRST_LETTER)
-    string(SUBSTRING ${CMAKE_MATCH_1} 1 -1 REMAINDER)
-    string(TOUPPER ${FIRST_LETTER} FIRST_LETTER)
-    set(REPO_NAME "${FIRST_LETTER}${REMAINDER}")
-
-    # If GIT_DESC has been parsed correctly, build the BUILD_FULLNAME from the repo name and the
-    # build version
-    if(REPO_NAME)
-        set(BUILD_FULLNAME "${REPO_NAME} ${BUILD_ID} ")
     endif()
   endif()
 endif()

--- a/CMakeModules/GenerateSCMRev.cmake
+++ b/CMakeModules/GenerateSCMRev.cmake
@@ -20,8 +20,6 @@ get_timestamp(BUILD_DATE)
 # Also if this is a CI build, add the build name (ie: Nightly, Canary) to the scm_rev file as well
 set(REPO_NAME "")
 set(BUILD_VERSION "0")
-set(TITLE_BAR_FORMAT_IDLE "yuzu {5} ")
-set(BUILD_ID "420")
 if (BUILD_REPOSITORY)
   # regex capture the string nightly or canary into CMAKE_MATCH_1
   string(REGEX MATCH "yuzu-emu/yuzu-?(.*)" OUTVAR ${BUILD_REPOSITORY})

--- a/src/yuzu/about_dialog.cpp
+++ b/src/yuzu/about_dialog.cpp
@@ -11,13 +11,14 @@
 AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent), ui(new Ui::AboutDialog) {
     const auto build_id = std::string(Common::g_build_id);
     const auto fmt = std::string(Common::g_title_bar_format_idle);
-    const auto yuzuBuildVersion = fmt::format(fmt.empty() ? "yuzu Development Build" : fmt, std::string{}, std::string{},
-                                              std::string{}, std::string{}, std::string{}, build_id);
+    const auto yuzu_build_version =
+        fmt::format(fmt.empty() ? "yuzu Development Build" : fmt, std::string{}, std::string{},
+                    std::string{}, std::string{}, std::string{}, build_id);
 
     ui->setupUi(this);
     ui->labelLogo->setPixmap(QIcon::fromTheme(QStringLiteral("yuzu")).pixmap(200));
     ui->labelBuildInfo->setText(ui->labelBuildInfo->text().arg(
-        QString::fromStdString(yuzuBuildVersion), QString::fromUtf8(Common::g_scm_branch),
+        QString::fromStdString(yuzu_build_version), QString::fromUtf8(Common::g_scm_branch),
         QString::fromUtf8(Common::g_scm_desc), QString::fromUtf8(Common::g_build_date).left(10)));
 }
 

--- a/src/yuzu/about_dialog.cpp
+++ b/src/yuzu/about_dialog.cpp
@@ -3,15 +3,21 @@
 // Refer to the license.txt file included.
 
 #include <QIcon>
+#include <fmt/format.h>
 #include "common/scm_rev.h"
 #include "ui_aboutdialog.h"
 #include "yuzu/about_dialog.h"
 
 AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent), ui(new Ui::AboutDialog) {
+    const auto build_id = std::string(Common::g_build_id);
+    const auto fmt = std::string(Common::g_title_bar_format_idle);
+    const auto yuzuBuildVersion = fmt::format(fmt.empty() ? "yuzu Development Build" : fmt, std::string{}, std::string{},
+                                              std::string{}, std::string{}, std::string{}, build_id);
+
     ui->setupUi(this);
     ui->labelLogo->setPixmap(QIcon::fromTheme(QStringLiteral("yuzu")).pixmap(200));
     ui->labelBuildInfo->setText(ui->labelBuildInfo->text().arg(
-        QString::fromUtf8(Common::g_build_fullname), QString::fromUtf8(Common::g_scm_branch),
+        QString::fromStdString(yuzuBuildVersion), QString::fromUtf8(Common::g_scm_branch),
         QString::fromUtf8(Common::g_scm_desc), QString::fromUtf8(Common::g_build_date).left(10)));
 }
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -207,11 +207,11 @@ GMainWindow::GMainWindow()
 
     const auto build_id = std::string(Common::g_build_id);
     const auto fmt = std::string(Common::g_title_bar_format_idle);
-    const auto yuzuBuildVersion =
+    const auto yuzu_build_version =
         fmt::format(fmt.empty() ? "yuzu Development Build" : fmt, std::string{}, std::string{},
                     std::string{}, std::string{}, std::string{}, build_id);
 
-    LOG_INFO(Frontend, "yuzu Version: {} | {}-{}", yuzuBuildVersion, Common::g_scm_branch,
+    LOG_INFO(Frontend, "yuzu Version: {} | {}-{}", yuzu_build_version, Common::g_scm_branch,
              Common::g_scm_desc);
 #ifdef ARCHITECTURE_x86_64
     LOG_INFO(Frontend, "Host CPU: {}", Common::GetCPUCaps().cpu_string);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -205,7 +205,13 @@ GMainWindow::GMainWindow()
     ConnectMenuEvents();
     ConnectWidgetEvents();
 
-    LOG_INFO(Frontend, "yuzu Version: {} | {}-{}", Common::g_build_fullname, Common::g_scm_branch,
+    const auto build_id = std::string(Common::g_build_id);
+    const auto fmt = std::string(Common::g_title_bar_format_idle);
+    const auto yuzuBuildVersion =
+        fmt::format(fmt.empty() ? "yuzu Development Build" : fmt, std::string{}, std::string{},
+                    std::string{}, std::string{}, std::string{}, build_id);
+
+    LOG_INFO(Frontend, "yuzu Version: {} | {}-{}", yuzuBuildVersion, Common::g_scm_branch,
              Common::g_scm_desc);
 #ifdef ARCHITECTURE_x86_64
     LOG_INFO(Frontend, "Host CPU: {}", Common::GetCPUCaps().cpu_string);


### PR DESCRIPTION
I noticed some time ago that the "human-readable" yuzu version was missing from the log and about section. This PR aims to fix that by "hacking together" the required parameter directly into GenerateSCMRev.cmake instead of modifying every single CI to pass the correct argument to cmake.
I tested this against Mainline, i hope it works in the Patreon repo too, as i couldn't test it being that it isn't public.