### PR TITLE
qt/bootmanager: Remove unnecessary glBindFramebuffer

### DIFF
--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -224,7 +224,6 @@ public:
         }
 
         context->MakeCurrent();
-        glBindFramebuffer(GL_DRAW_FRAMEBUFFER, 0);
         if (Core::System::GetInstance().Renderer().TryPresent(100)) {
             context->SwapBuffers();
             glFinish();


### PR DESCRIPTION
Presentation context always has GL_DRAW_FRAMEBUFFER_BINDING as zero.
There is no need to bind the default framebuffer constantly.

According to Nsight this was using ~0.7ms per frame and it broke
renderdoc captures.