### PR TITLE
configuration: Fix placement of SL and SR

### DIFF
--- a/src/yuzu/configuration/configure_input_player.ui
+++ b/src/yuzu/configuration/configure_input_player.ui
@@ -927,7 +927,7 @@
           </item>
          </layout>
         </item>
-        <item row="2" column="0">
+        <item row="0" column="2">
          <layout class="QVBoxLayout" name="buttonShoulderButtonsSLVerticalLayout">
           <item>
            <layout class="QHBoxLayout" name="buttonShoulderButtonsSLHorizontalLayout">
@@ -949,7 +949,7 @@
           </item>
          </layout>
         </item>
-        <item row="2" column="1">
+        <item row="1" column="2">
          <layout class="QVBoxLayout" name="buttonShoulderButtonsSRVerticalLayout">
           <item>
            <layout class="QHBoxLayout" name="buttonShoulderButtonsSRHorizontalLayout">


### PR DESCRIPTION
Thanks to @Morph1984 for pointing this out!
When I made #3579 I messed up the placement of SL and SR when you select a single joycon.

Current:
![image](https://user-images.githubusercontent.com/5352197/78769902-359cb200-798e-11ea-8993-34e0f497bf65.png)
![image](https://user-images.githubusercontent.com/5352197/78769971-4b11dc00-798e-11ea-9dd4-c3fb5c5c119c.png)

New:
![image](https://user-images.githubusercontent.com/5352197/78770052-667ce700-798e-11ea-82fa-a25b7736fa4b.png)
![image](https://user-images.githubusercontent.com/5352197/78770147-801e2e80-798e-11ea-8810-8396aaf7da9b.png)
