### PR TITLE
gl_texture_cache: Attach view instead of base texture for layered attchments

### DIFF
--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -411,14 +411,13 @@ CachedSurfaceView::~CachedSurfaceView() = default;
 void CachedSurfaceView::Attach(GLenum attachment, GLenum target) const {
     ASSERT(params.num_levels == 1);
 
-    const GLuint texture = surface.GetTexture();
     if (params.num_layers > 1) {
         // Layered framebuffer attachments
         UNIMPLEMENTED_IF(params.base_layer != 0);
 
         switch (params.target) {
         case SurfaceTarget::Texture2DArray:
-            glFramebufferTexture(target, attachment, texture, params.base_level);
+            glFramebufferTexture(target, attachment, GetTexture(), params.base_level);
             break;
         default:
             UNIMPLEMENTED();
@@ -427,6 +426,7 @@ void CachedSurfaceView::Attach(GLenum attachment, GLenum target) const {
     }
 
     const GLenum view_target = surface.GetTarget();
+    const GLuint texture = surface.GetTexture();
     switch (surface.GetSurfaceParams().target) {
     case SurfaceTarget::Texture1D:
         glFramebufferTexture1D(target, attachment, view_target, texture, params.base_level);


### PR DESCRIPTION
This way we are not ignoring the base layer of the current texture view.

- Tries to fix Astral Chain regression. Thanks to Rei for helping me bisect this.