### PR TITLE
gl_shader_decompiler: Improve generated code in HMergeH*

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1819,15 +1819,17 @@ private:
     }
 
     Expression HMergeH0(Operation operation) {
-        std::string dest = VisitOperand(operation, 0).AsUint();
-        std::string src = VisitOperand(operation, 1).AsUint();
-        return {fmt::format("(({} & 0x0000FFFFU) | ({} & 0xFFFF0000U))", src, dest), Type::Uint};
+        const std::string dest = VisitOperand(operation, 0).AsUint();
+        const std::string src = VisitOperand(operation, 1).AsUint();
+        return {fmt::format("vec2(unpackHalf2x16({}).x, unpackHalf2x16({}).y)", src, dest),
+                Type::HalfFloat};
     }
 
     Expression HMergeH1(Operation operation) {
-        std::string dest = VisitOperand(operation, 0).AsUint();
-        std::string src = VisitOperand(operation, 1).AsUint();
-        return {fmt::format("(({} & 0x0000FFFFU) | ({} & 0xFFFF0000U))", dest, src), Type::Uint};
+        const std::string dest = VisitOperand(operation, 0).AsUint();
+        const std::string src = VisitOperand(operation, 1).AsUint();
+        return {fmt::format("vec2(unpackHalf2x16({}).x, unpackHalf2x16({}).y)", dest, src),
+                Type::HalfFloat};
     }
 
     Expression HPack2(Operation operation) {

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1821,15 +1821,13 @@ private:
     Expression HMergeH0(Operation operation) {
         const std::string dest = VisitOperand(operation, 0).AsUint();
         const std::string src = VisitOperand(operation, 1).AsUint();
-        return {fmt::format("vec2(unpackHalf2x16({}).x, unpackHalf2x16({}).y)", src, dest),
-                Type::HalfFloat};
+        return {fmt::format("bitfieldInsert({}, {}, 0, 16)", dest, src), Type::Uint};
     }
 
     Expression HMergeH1(Operation operation) {
         const std::string dest = VisitOperand(operation, 0).AsUint();
         const std::string src = VisitOperand(operation, 1).AsUint();
-        return {fmt::format("vec2(unpackHalf2x16({}).x, unpackHalf2x16({}).y)", dest, src),
-                Type::HalfFloat};
+        return {fmt::format("bitfieldInsert({}, {}, 16, 16)", dest, src), Type::Uint};
     }
 
     Expression HPack2(Operation operation) {


### PR DESCRIPTION
Avoiding bitwise expressions, this fixes Turing issues in shaders using
half float merges that affected several games.