### PR TITLE
gl_rasterizer: Implement line widths and smooth lines

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -966,7 +966,10 @@ public:
                     BitField<4, 1, u32> triangle_rast_flip;
                 } screen_y_control;
 
-                INSERT_UNION_PADDING_WORDS(0x21);
+                float line_width_smooth;
+                float line_width_aliased;
+
+                INSERT_UNION_PADDING_WORDS(0x1F);
 
                 u32 vb_element_base;
                 u32 vb_base_instance;
@@ -1024,7 +1027,7 @@ public:
 
                 float polygon_offset_factor;
 
-                INSERT_UNION_PADDING_WORDS(0x1);
+                u32 line_smooth_enable;
 
                 struct {
                     u32 tic_address_high;
@@ -1591,6 +1594,8 @@ ASSERT_REG_POSITION(stencil_front_func_mask, 0x4E6);
 ASSERT_REG_POSITION(stencil_front_mask, 0x4E7);
 ASSERT_REG_POSITION(frag_color_clamp, 0x4EA);
 ASSERT_REG_POSITION(screen_y_control, 0x4EB);
+ASSERT_REG_POSITION(line_width_smooth, 0x4EC);
+ASSERT_REG_POSITION(line_width_aliased, 0x4ED);
 ASSERT_REG_POSITION(vb_element_base, 0x50D);
 ASSERT_REG_POSITION(vb_base_instance, 0x50E);
 ASSERT_REG_POSITION(clip_distance_enabled, 0x544);
@@ -1604,6 +1609,7 @@ ASSERT_REG_POSITION(multisample_control, 0x54F);
 ASSERT_REG_POSITION(condition, 0x554);
 ASSERT_REG_POSITION(tsc, 0x557);
 ASSERT_REG_POSITION(polygon_offset_factor, 0x55B);
+ASSERT_REG_POSITION(line_smooth_enable, 0x55C);
 ASSERT_REG_POSITION(tic, 0x55D);
 ASSERT_REG_POSITION(stencil_two_side_enable, 0x565);
 ASSERT_REG_POSITION(stencil_back_op_fail, 0x566);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -496,6 +496,7 @@ void RasterizerOpenGL::Draw(bool is_indexed, bool is_instanced) {
     SyncPrimitiveRestart();
     SyncScissorTest();
     SyncPointState();
+    SyncLineState();
     SyncPolygonOffset();
     SyncAlphaTest();
     SyncFramebufferSRGB();
@@ -1309,6 +1310,19 @@ void RasterizerOpenGL::SyncPointState() {
     // in OpenGL).
     glPointSize(std::max(1.0f, gpu.regs.point_size));
     glDisable(GL_PROGRAM_POINT_SIZE);
+}
+
+void RasterizerOpenGL::SyncLineState() {
+    auto& gpu = system.GPU().Maxwell3D();
+    auto& flags = gpu.dirty.flags;
+    if (!flags[Dirty::LineWidth]) {
+        return;
+    }
+    flags[Dirty::LineWidth] = false;
+
+    const auto& regs = gpu.regs;
+    oglEnable(GL_LINE_SMOOTH, regs.line_smooth_enable);
+    glLineWidth(regs.line_smooth_enable ? regs.line_width_smooth : regs.line_width_aliased);
 }
 
 void RasterizerOpenGL::SyncPolygonOffset() {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -171,6 +171,9 @@ private:
     /// Syncs the point state to match the guest state
     void SyncPointState();
 
+    /// Syncs the line state to match the guest state
+    void SyncLineState();
+
     /// Syncs the rasterizer enable state to match the guest state
     void SyncRasterizeEnable();
 

--- a/src/video_core/renderer_opengl/gl_state_tracker.cpp
+++ b/src/video_core/renderer_opengl/gl_state_tracker.cpp
@@ -185,6 +185,12 @@ void SetupDirtyPointSize(Tables& tables) {
     tables[0][OFF(point_sprite_enable)] = PointSize;
 }
 
+void SetupDirtyLineWidth(Tables& tables) {
+    tables[0][OFF(line_width_smooth)] = LineWidth;
+    tables[0][OFF(line_width_aliased)] = LineWidth;
+    tables[0][OFF(line_smooth_enable)] = LineWidth;
+}
+
 void SetupDirtyClipControl(Tables& tables) {
     auto& table = tables[0];
     table[OFF(screen_y_control)] = ClipControl;
@@ -233,6 +239,7 @@ void StateTracker::Initialize() {
     SetupDirtyLogicOp(tables);
     SetupDirtyFragmentClampColor(tables);
     SetupDirtyPointSize(tables);
+    SetupDirtyLineWidth(tables);
     SetupDirtyClipControl(tables);
     SetupDirtyDepthClampEnabled(tables);
     SetupDirtyMisc(tables);

--- a/src/video_core/renderer_opengl/gl_state_tracker.h
+++ b/src/video_core/renderer_opengl/gl_state_tracker.h
@@ -78,6 +78,7 @@ enum : u8 {
     LogicOp,
     FragmentClampColor,
     PointSize,
+    LineWidth,
     ClipControl,
     DepthClampEnabled,
 


### PR DESCRIPTION
Implements "legacy" features from OpenGL present on hardware such as
smooth lines and line width.

- Used by [deko3d-examples](https://github.com/switchbrew/switch-examples/blob/master/graphics/deko3d/deko_examples/source/Example09_SimpleCompute.cpp#L254).