### PR TITLE
gl_texture_cache: Fix layered texture attachment base level

### DIFF
--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -417,7 +417,7 @@ void CachedSurfaceView::Attach(GLenum attachment, GLenum target) const {
 
         switch (params.target) {
         case SurfaceTarget::Texture2DArray:
-            glFramebufferTexture(target, attachment, GetTexture(), params.base_level);
+            glFramebufferTexture(target, attachment, GetTexture(), 0);
             break;
         default:
             UNIMPLEMENTED();


### PR DESCRIPTION
The base level is already included in the texture view. If we specify
the base level in the texture again, this will end up in the incorrect
level and potentially out of bounds.