### PR TITLE
yuzu/main: Add better popup texts and remove duplicated actions

### DIFF
--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -196,8 +196,6 @@ private slots:
     void OnMenuLoadFile();
     void OnMenuLoadFolder();
     void OnMenuInstallToNAND();
-    /// Called whenever a user select the "File->Select -- Directory" where -- is NAND or SD Card
-    void OnMenuSelectEmulatedDirectory(EmulatedDirectoryTarget target);
     void OnMenuRecentFile();
     void OnConfigure();
     void OnLoadAmiibo();

--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -64,8 +64,6 @@
     <addaction name="separator"/>
     <addaction name="menu_recent_files"/>
     <addaction name="separator"/>
-    <addaction name="action_Select_NAND_Directory"/>
-    <addaction name="action_Select_SDMC_Directory"/>
     <addaction name="separator"/>
     <addaction name="action_Load_Amiibo"/>
     <addaction name="separator"/>
@@ -215,22 +213,6 @@
    </property>
    <property name="text">
     <string>Show Status Bar</string>
-   </property>
-  </action>
-  <action name="action_Select_NAND_Directory">
-   <property name="text">
-    <string>Select NAND Directory...</string>
-   </property>
-   <property name="toolTip">
-    <string>Selects a folder to use as the root of the emulated NAND</string>
-   </property>
-  </action>
-  <action name="action_Select_SDMC_Directory">
-   <property name="text">
-    <string>Select SD Card Directory...</string>
-   </property>
-   <property name="toolTip">
-    <string>Selects a folder to use as the root of the emulated SD card</string>
    </property>
   </action>
   <action name="action_Fullscreen">


### PR DESCRIPTION
Inspired by https://github.com/citra-emu/citra/pull/4012 and [this blog post](https://www.joelonsoftware.com/2000/04/26/designing-for-people-who-have-better-things-to-do-with-their-lives/).

Makes popup texts more compact and clear and also links our quickstart guide now.
Also removes OnMenuSelectEmulatedDirectory from the File dropdown, as the action already exists in the Filesystem tab and provides better visual feedback there.

**Screenshots**:
Before
![old2](https://user-images.githubusercontent.com/20753089/79174709-cabf0100-7dfb-11ea-9533-eafe739ba7ba.png)
After
![Unbenannt2](https://user-images.githubusercontent.com/20753089/79174720-d0b4e200-7dfb-11ea-9f6a-cdebc5fece84.PNG)

Before
![old1](https://user-images.githubusercontent.com/20753089/79174737-d90d1d00-7dfb-11ea-828b-a391409c7a57.PNG)
After
![Unbenannt3](https://user-images.githubusercontent.com/20753089/79174739-dca0a400-7dfb-11ea-9d51-9391057ee479.PNG)

