### PR TITLE
Revert "gl_shader_decompiler: Implement merges with bitfieldInsert"

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1821,13 +1821,15 @@ private:
     Expression HMergeH0(Operation operation) {
         const std::string dest = VisitOperand(operation, 0).AsUint();
         const std::string src = VisitOperand(operation, 1).AsUint();
-        return {fmt::format("bitfieldInsert({}, {}, 0, 16)", dest, src), Type::Uint};
+        return {fmt::format("vec2(unpackHalf2x16({}).x, unpackHalf2x16({}).y)", src, dest),
+                Type::HalfFloat};
     }
 
     Expression HMergeH1(Operation operation) {
         const std::string dest = VisitOperand(operation, 0).AsUint();
         const std::string src = VisitOperand(operation, 1).AsUint();
-        return {fmt::format("bitfieldInsert({}, {}, 16, 16)", dest, src), Type::Uint};
+        return {fmt::format("vec2(unpackHalf2x16({}).x, unpackHalf2x16({}).y)", dest, src),
+                Type::HalfFloat};
     }
 
     Expression HPack2(Operation operation) {


### PR DESCRIPTION
This reverts commit 05cf27083608bebd3ee4c38f2f948c8f2030f881.

Apparently the first approach using floats instead of bitfieldInsert
worked better for Fire Emblem: Three Houses. Reverting to get that
behavior back.