### PR TITLE
vk_blit_screen: Initialize all members in VkPipelineViewportStateCreateInfo

### DIFF
--- a/src/video_core/renderer_vulkan/vk_blit_screen.cpp
+++ b/src/video_core/renderer_vulkan/vk_blit_screen.cpp
@@ -535,7 +535,9 @@ void VKBlitScreen::CreateGraphicsPipeline() {
     viewport_state_ci.pNext = nullptr;
     viewport_state_ci.flags = 0;
     viewport_state_ci.viewportCount = 1;
+    viewport_state_ci.pViewports = nullptr;
     viewport_state_ci.scissorCount = 1;
+    viewport_state_ci.pScissors = nullptr;
 
     VkPipelineRasterizationStateCreateInfo rasterization_ci;
     rasterization_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;


### PR DESCRIPTION
When the dynamic state is specified, pViewports and pScissors are
ignored, quoting the specification:

  pViewports is a pointer to an array of VkViewport structures, defining
  the viewport transforms. If the viewport state is dynamic, this member
  is ignored.

That said, AMD's proprietary driver itself seem to read it regardless of
what the specification says.