### PR TITLE
externals: Use shared libraries if possible

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -86,7 +86,10 @@ if (ENABLE_WEB_SERVICE)
     set(LIBRESSL_SKIP_INSTALL ON CACHE BOOL "")
     add_subdirectory(libressl EXCLUDE_FROM_ALL)
     target_include_directories(ssl INTERFACE ./libressl/include)
-	target_compile_definitions(ssl PRIVATE -DHAVE_INET_NTOP)
+    target_compile_definitions(ssl PRIVATE -DHAVE_INET_NTOP)
+    get_directory_property(OPENSSL_LIBRARIES
+        DIRECTORY libressl
+        DEFINITION OPENSSL_LIBS)
 
     # lurlparser
     add_subdirectory(lurlparser EXCLUDE_FROM_ALL)
@@ -94,6 +97,8 @@ if (ENABLE_WEB_SERVICE)
     # httplib
     add_library(httplib INTERFACE)
     target_include_directories(httplib INTERFACE ./httplib)
+    target_compile_definitions(httplib INTERFACE -DCPPHTTPLIB_OPENSSL_SUPPORT)
+    target_link_libraries(httplib INTERFACE ${OPENSSL_LIBRARIES})
 
     # JSON
     add_library(json-headers INTERFACE)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -3,13 +3,27 @@
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMakeModules)
 include(DownloadExternals)
 
+# pkgconfig -- it is used to find shared libraries without cmake modules on linux systems
+find_package(PkgConfig)
+if (NOT PkgConfig_FOUND)
+    function(pkg_check_modules)
+        # STUB
+    endfunction()
+endif()
+
 # Catch
 add_library(catch-single-include INTERFACE)
 target_include_directories(catch-single-include INTERFACE catch/single_include)
 
 # libfmt
-add_subdirectory(fmt)
-add_library(fmt::fmt ALIAS fmt)
+pkg_check_modules(FMT IMPORTED_TARGET GLOBAL fmt>=6.1.0)
+if (FMT_FOUND)
+    add_library(fmt::fmt ALIAS PkgConfig::FMT)
+else()
+    message(STATUS "fmt 6.1.0 or newer not found, falling back to externals")
+    add_subdirectory(fmt)
+    add_library(fmt::fmt ALIAS fmt)
+endif()
 
 # Dynarmic
 if (ARCHITECTURE_x86_64)
@@ -30,9 +44,15 @@ add_subdirectory(glad)
 add_subdirectory(inih)
 
 # lz4
-set(LZ4_BUNDLED_MODE ON)
-add_subdirectory(lz4/contrib/cmake_unofficial EXCLUDE_FROM_ALL)
-target_include_directories(lz4_static INTERFACE ./lz4/lib)
+pkg_check_modules(LIBLZ4 IMPORTED_TARGET GLOBAL liblz4>=1.8.0)
+if (LIBLZ4_FOUND)
+    add_library(lz4_static ALIAS PkgConfig::LIBLZ4)
+else()
+    message(STATUS "liblz4 1.8.0 or newer not found, falling back to externals")
+    set(LZ4_BUNDLED_MODE ON)
+    add_subdirectory(lz4/contrib/cmake_unofficial EXCLUDE_FROM_ALL)
+    target_include_directories(lz4_static INTERFACE ./lz4/lib)
+endif()
 
 # mbedtls
 add_subdirectory(mbedtls EXCLUDE_FROM_ALL)
@@ -47,15 +67,27 @@ add_library(unicorn-headers INTERFACE)
 target_include_directories(unicorn-headers INTERFACE ./unicorn/include)
 
 # Zstandard
-add_subdirectory(zstd/build/cmake EXCLUDE_FROM_ALL)
-target_include_directories(libzstd_static INTERFACE ./zstd/lib)
+pkg_check_modules(LIBZSTD IMPORTED_TARGET GLOBAL libzstd>=1.3.8)
+if (LIBZSTD_FOUND)
+    add_library(libzstd_static ALIAS PkgConfig::LIBZSTD)
+else()
+    message(STATUS "libzstd 1.3.8 or newer not found, falling back to externals")
+    add_subdirectory(zstd/build/cmake EXCLUDE_FROM_ALL)
+    target_include_directories(libzstd_static INTERFACE ./zstd/lib)
+endif()
 
 # SoundTouch
 add_subdirectory(soundtouch)
 
 # Opus
-add_subdirectory(opus)
-target_include_directories(opus INTERFACE ./opus/include)
+pkg_check_modules(OPUS IMPORTED_TARGET GLOBAL opus>=1.3.1)
+if (OPUS_FOUND)
+    add_library(opus ALIAS PkgConfig::OPUS)
+else()
+    message(STATUS "opus 1.3.1 or newer not found, falling back to externals")
+    add_subdirectory(opus)
+    target_include_directories(opus INTERFACE ./opus/include)
+endif()
 
 # Cubeb
 if(ENABLE_CUBEB)
@@ -75,21 +107,35 @@ if (ENABLE_VULKAN)
 endif()
 
 # zlib
-add_subdirectory(zlib EXCLUDE_FROM_ALL)
-set(ZLIB_LIBRARIES z)
+find_package(ZLIB 1.2.11)
+if (NOT ZLIB_FOUND)
+    message(STATUS "zlib 1.2.11 or newer not found, falling back to externals")
+    add_subdirectory(zlib EXCLUDE_FROM_ALL)
+    set(ZLIB_LIBRARIES z)
+endif()
 
 # libzip
-add_subdirectory(libzip EXCLUDE_FROM_ALL)
+pkg_check_modules(LIBZIP IMPORTED_TARGET GLOBAL libzip>=1.5.3)
+if (LIBZIP_FOUND)
+    add_library(zip ALIAS PkgConfig::LIBZIP)
+else()
+    message(STATUS "libzip 1.5.3 or newer not found, falling back to externals")
+    add_subdirectory(libzip EXCLUDE_FROM_ALL)
+endif()
 
 if (ENABLE_WEB_SERVICE)
     # LibreSSL
-    set(LIBRESSL_SKIP_INSTALL ON CACHE BOOL "")
-    add_subdirectory(libressl EXCLUDE_FROM_ALL)
-    target_include_directories(ssl INTERFACE ./libressl/include)
-    target_compile_definitions(ssl PRIVATE -DHAVE_INET_NTOP)
-    get_directory_property(OPENSSL_LIBRARIES
-        DIRECTORY libressl
-        DEFINITION OPENSSL_LIBS)
+    find_package(OpenSSL COMPONENTS Crypto SSL)
+    if (NOT OpenSSL_FOUND)
+        message(STATUS "OpenSSL not found, falling back to externals")
+        set(LIBRESSL_SKIP_INSTALL ON CACHE BOOL "")
+        add_subdirectory(libressl EXCLUDE_FROM_ALL)
+        target_include_directories(ssl INTERFACE ./libressl/include)
+        target_compile_definitions(ssl PRIVATE -DHAVE_INET_NTOP)
+        get_directory_property(OPENSSL_LIBRARIES
+            DIRECTORY libressl
+            DEFINITION OPENSSL_LIBS)
+    endif()
 
     # lurlparser
     add_subdirectory(lurlparser EXCLUDE_FROM_ALL)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -591,11 +591,8 @@ target_link_libraries(core PUBLIC common PRIVATE audio_core video_core)
 target_link_libraries(core PUBLIC Boost::boost PRIVATE fmt json-headers mbedtls opus unicorn)
 
 if (YUZU_ENABLE_BOXCAT)
-    get_directory_property(OPENSSL_LIBS
-        DIRECTORY ${PROJECT_SOURCE_DIR}/externals/libressl
-        DEFINITION OPENSSL_LIBS)
-    target_compile_definitions(core PRIVATE -DCPPHTTPLIB_OPENSSL_SUPPORT -DYUZU_ENABLE_BOXCAT)
-    target_link_libraries(core PRIVATE httplib json-headers ${OPENSSL_LIBS} zip)
+    target_compile_definitions(core PRIVATE -DYUZU_ENABLE_BOXCAT)
+    target_link_libraries(core PRIVATE httplib json-headers zip)
 endif()
 
 if (ENABLE_WEB_SERVICE)

--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -27,4 +27,4 @@ if(SDL2_FOUND)
 endif()
 
 create_target_directory_groups(input_common)
-target_link_libraries(input_common PUBLIC core PRIVATE common ${Boost_LIBRARIES})
+target_link_libraries(input_common PUBLIC core PRIVATE common Boost::boost)

--- a/src/web_service/CMakeLists.txt
+++ b/src/web_service/CMakeLists.txt
@@ -8,9 +8,4 @@ add_library(web_service STATIC
 )
 
 create_target_directory_groups(web_service)
-
-get_directory_property(OPENSSL_LIBS
-        DIRECTORY ${PROJECT_SOURCE_DIR}/externals/libressl
-        DEFINITION OPENSSL_LIBS)
-target_compile_definitions(web_service PRIVATE -DCPPHTTPLIB_OPENSSL_SUPPORT)
-target_link_libraries(web_service PRIVATE common json-headers ${OPENSSL_LIBS} httplib lurlparser)
+target_link_libraries(web_service PRIVATE common json-headers httplib lurlparser)


### PR DESCRIPTION
This is mostly done by pkgconfig.
I've focused on the larger and more stable libraries.

Also the OpenSSL dependency is moved to httplib.