### PR TITLE
guest_driver: Take std::vector by reference in DeduceTextureHandlerSize()

### DIFF
--- a/src/video_core/guest_driver.cpp
+++ b/src/video_core/guest_driver.cpp
@@ -11,14 +11,16 @@
 
 namespace VideoCore {
 
-void GuestDriverProfile::DeduceTextureHandlerSize(std::vector<u32> bound_offsets) {
+void GuestDriverProfile::DeduceTextureHandlerSize(const std::vector<u32>& bound_offsets) {
     if (texture_handler_size) {
         return;
     }
+
     const std::size_t size = bound_offsets.size();
     if (size < 2) {
         return;
     }
+
     std::sort(bound_offsets.begin(), bound_offsets.end(), std::less{});
     u32 min_val = std::numeric_limits<u32>::max();
     for (std::size_t i = 1; i < size; ++i) {
@@ -28,9 +30,11 @@ void GuestDriverProfile::DeduceTextureHandlerSize(std::vector<u32> bound_offsets
         const u32 new_min = bound_offsets[i] - bound_offsets[i - 1];
         min_val = std::min(min_val, new_min);
     }
+
     if (min_val > 2) {
         return;
     }
+
     texture_handler_size = min_texture_handler_size * min_val;
 }
 

--- a/src/video_core/guest_driver.h
+++ b/src/video_core/guest_driver.h
@@ -22,7 +22,7 @@ public:
     explicit GuestDriverProfile(std::optional<u32> texture_handler_size)
         : texture_handler_size{texture_handler_size} {}
 
-    void DeduceTextureHandlerSize(std::vector<u32> bound_offsets);
+    void DeduceTextureHandlerSize(const std::vector<u32>& bound_offsets);
 
     u32 GetTextureHandlerSize() const {
         return texture_handler_size.value_or(default_texture_handler_size);

--- a/src/video_core/shader/decode.cpp
+++ b/src/video_core/shader/decode.cpp
@@ -49,7 +49,7 @@ void DeduceTextureHandlerSize(VideoCore::GuestDriverProfile& gpu_driver,
         bound_offsets.emplace_back(sampler.GetOffset());
     }
     if (count > 1) {
-        gpu_driver.DeduceTextureHandlerSize(std::move(bound_offsets));
+        gpu_driver.DeduceTextureHandlerSize(bound_offsets);
     }
 }
 


### PR DESCRIPTION
There's no need to take the whole vector by value, considering it only reads the data like a view. A constant reference is sufficient here.