### PR TITLE
surface_view: Add missing operator!= to ViewParams

### DIFF
--- a/src/video_core/texture_cache/surface_view.cpp
+++ b/src/video_core/texture_cache/surface_view.cpp
@@ -20,4 +20,8 @@ bool ViewParams::operator==(const ViewParams& rhs) const {
            std::tie(rhs.base_layer, rhs.num_layers, rhs.base_level, rhs.num_levels, rhs.target);
 }
 
+bool ViewParams::operator!=(const ViewParams& rhs) const {
+    return !operator==(rhs);
+}
+
 } // namespace VideoCommon

--- a/src/video_core/texture_cache/surface_view.h
+++ b/src/video_core/texture_cache/surface_view.h
@@ -21,6 +21,7 @@ struct ViewParams {
     std::size_t Hash() const;
 
     bool operator==(const ViewParams& rhs) const;
+    bool operator!=(const ViewParams& rhs) const;
 
     bool IsLayered() const {
         switch (target) {


### PR DESCRIPTION
Provides logical symmetry to the interface.