### PR TITLE
decode/shift: Remove unused variable within Shift()

### DIFF
--- a/src/video_core/shader/decode/shift.cpp
+++ b/src/video_core/shader/decode/shift.cpp
@@ -23,7 +23,6 @@ Node IsFull(Node shift) {
 }
 
 Node Shift(OperationCode opcode, Node value, Node shift) {
-    Node is_full = Operation(OperationCode::LogicalIEqual, shift, Immediate(32));
     Node shifted = Operation(opcode, move(value), shift);
     return Operation(OperationCode::Select, IsFull(move(shift)), Immediate(0), move(shifted));
 }


### PR DESCRIPTION
Removes a redundant variable that is already satisfied by the IsFull() utility function.