### PR TITLE
Port citra-emu/citra#5185: "gdbstub: Fix some gdbstub jankiness"

### DIFF
--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -1389,10 +1389,9 @@ void SendTrap(Kernel::Thread* thread, int trap) {
         return;
     }
 
-    if (!halt_loop || current_thread == thread) {
-        current_thread = thread;
-        SendSignal(thread, trap);
-    }
+    current_thread = thread;
+    SendSignal(thread, trap);
+
     halt_loop = true;
     send_trap = false;
 }


### PR DESCRIPTION
See citra-emu/citra#5185 for more details.

**Original description**:
1. Ensure that register information available to gdbstub is most up-to-date.
2. There's no reason to check for `current_thread == thread` when emitting a trap packet.
   Doing this results in random hangs whenever a step happens upon a thread switch.

Not sure whether (1) is actually necessary. I'm planning on a refactoring of the JIT which will eventually make it a moot point anyway (using contexts directly instead of needing to Load/Store them).