### PR TITLE
memory/slab_heap: Make use of static_cast over reinterpret_cast

### DIFF
--- a/src/core/hle/kernel/memory/slab_heap.h
+++ b/src/core/hle/kernel/memory/slab_heap.h
@@ -51,7 +51,7 @@ public:
     }
 
     void Free(void* obj) {
-        Node* node = reinterpret_cast<Node*>(obj);
+        Node* node = static_cast<Node*>(obj);
 
         Node* cur_head = head.load();
         do {
@@ -145,7 +145,7 @@ public:
     }
 
     T* Allocate() {
-        T* obj = reinterpret_cast<T*>(AllocateImpl());
+        T* obj = static_cast<T*>(AllocateImpl());
         if (obj != nullptr) {
             new (obj) T();
         }


### PR DESCRIPTION
Casting from void* with static_cast is permitted by the standard, so we can just make use of that instead.