### PR TITLE
service: Remove unused RequestParser instances

### DIFF
--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -252,8 +252,6 @@ private:
     }
 
     void GetAudioDeviceOutputVolume(Kernel::HLERequestContext& ctx) {
-        IPC::RequestParser rp{ctx};
-
         const auto device_name_buffer = ctx.ReadBuffer();
         const std::string name = Common::StringFromBuffer(device_name_buffer);
 

--- a/src/core/hle/service/es/es.cpp
+++ b/src/core/hle/service/es/es.cpp
@@ -76,7 +76,6 @@ private:
     }
 
     void ImportTicket(Kernel::HLERequestContext& ctx) {
-        IPC::RequestParser rp{ctx};
         const auto ticket = ctx.ReadBuffer();
         const auto cert = ctx.ReadBuffer(1);
 


### PR DESCRIPTION
These aren't used, so they should be removed to reduce compilation warnings.