### PR TITLE
fixed_pipeline_state: Pack structure, use memcmp and CityHash on it

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1149,7 +1149,7 @@ public:
 
                     /// Returns whether the vertex array specified by index is supposed to be
                     /// accessed per instance or not.
-                    bool IsInstancingEnabled(u32 index) const {
+                    bool IsInstancingEnabled(std::size_t index) const {
                         return is_instanced[index];
                     }
                 } instanced_arrays;

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
@@ -140,66 +140,13 @@ void FixedPipelineState::BlendingAttachment::Fill(const Maxwell& regs, std::size
     enable.Assign(1);
 }
 
-std::size_t FixedPipelineState::BlendingAttachment::Hash() const noexcept {
-    return raw;
-}
-
-bool FixedPipelineState::BlendingAttachment::operator==(const BlendingAttachment& rhs) const
-    noexcept {
-    return raw == rhs.raw;
-}
-
-std::size_t FixedPipelineState::VertexInput::Hash() const noexcept {
-    // TODO(Rodrigo): Replace this
-    return Common::CityHash64(reinterpret_cast<const char*>(this), sizeof *this);
-}
-
-bool FixedPipelineState::VertexInput::operator==(const VertexInput& rhs) const noexcept {
-    return std::memcmp(this, &rhs, sizeof *this) == 0;
-}
-
-std::size_t FixedPipelineState::Rasterizer::Hash() const noexcept {
-    u64 hash = static_cast<u64>(raw) << 32;
-    std::memcpy(&hash, &point_size, sizeof(u32));
+std::size_t FixedPipelineState::Hash() const noexcept {
+    const u64 hash = Common::CityHash64(reinterpret_cast<const char*>(this), sizeof *this);
     return static_cast<std::size_t>(hash);
 }
 
-bool FixedPipelineState::Rasterizer::operator==(const Rasterizer& rhs) const noexcept {
-    return raw == rhs.raw && point_size == rhs.point_size;
-}
-
-std::size_t FixedPipelineState::DepthStencil::Hash() const noexcept {
-    return raw;
-}
-
-bool FixedPipelineState::DepthStencil::operator==(const DepthStencil& rhs) const noexcept {
-    return raw == rhs.raw;
-}
-
-std::size_t FixedPipelineState::ColorBlending::Hash() const noexcept {
-    std::size_t hash = 0;
-    for (std::size_t rt = 0; rt < std::size(attachments); ++rt) {
-        boost::hash_combine(hash, attachments[rt].Hash());
-    }
-    return hash;
-}
-
-bool FixedPipelineState::ColorBlending::operator==(const ColorBlending& rhs) const noexcept {
-    return attachments == rhs.attachments;
-}
-
-std::size_t FixedPipelineState::Hash() const noexcept {
-    std::size_t hash = 0;
-    boost::hash_combine(hash, vertex_input.Hash());
-    boost::hash_combine(hash, rasterizer.Hash());
-    boost::hash_combine(hash, depth_stencil.Hash());
-    boost::hash_combine(hash, color_blending.Hash());
-    return hash;
-}
-
 bool FixedPipelineState::operator==(const FixedPipelineState& rhs) const noexcept {
-    return std::tie(vertex_input, rasterizer, depth_stencil, color_blending) ==
-           std::tie(rhs.vertex_input, rhs.rasterizer, rhs.depth_stencil, rhs.color_blending);
+    return std::memcmp(this, &rhs, sizeof *this) == 0;
 }
 
 FixedPipelineState GetFixedPipelineState(const Maxwell& regs) {
@@ -207,6 +154,7 @@ FixedPipelineState GetFixedPipelineState(const Maxwell& regs) {
     fixed_state.rasterizer.Fill(regs);
     fixed_state.depth_stencil.Fill(regs);
     fixed_state.color_blending.Fill(regs);
+    fixed_state.padding = {};
     return fixed_state;
 }
 

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -26,12 +26,13 @@ MICROPROFILE_DECLARE(Vulkan_PipelineCache);
 
 namespace {
 
-VkStencilOpState GetStencilFaceState(const FixedPipelineState::StencilFace& face) {
+template <class StencilFace>
+VkStencilOpState GetStencilFaceState(const StencilFace& face) {
     VkStencilOpState state;
-    state.failOp = MaxwellToVK::StencilOp(face.action_stencil_fail);
-    state.passOp = MaxwellToVK::StencilOp(face.action_depth_pass);
-    state.depthFailOp = MaxwellToVK::StencilOp(face.action_depth_fail);
-    state.compareOp = MaxwellToVK::ComparisonOp(face.test_func);
+    state.failOp = MaxwellToVK::StencilOp(face.ActionStencilFail());
+    state.passOp = MaxwellToVK::StencilOp(face.ActionDepthPass());
+    state.depthFailOp = MaxwellToVK::StencilOp(face.ActionDepthFail());
+    state.compareOp = MaxwellToVK::ComparisonOp(face.TestFunc());
     state.compareMask = 0;
     state.writeMask = 0;
     state.reference = 0;
@@ -277,13 +278,12 @@ vk::Pipeline VKGraphicsPipeline::CreatePipeline(const RenderPassParams& renderpa
     depth_stencil_ci.flags = 0;
     depth_stencil_ci.depthTestEnable = ds.depth_test_enable;
     depth_stencil_ci.depthWriteEnable = ds.depth_write_enable;
-    depth_stencil_ci.depthCompareOp = ds.depth_test_enable
-                                          ? MaxwellToVK::ComparisonOp(ds.depth_test_function)
-                                          : VK_COMPARE_OP_ALWAYS;
+    depth_stencil_ci.depthCompareOp =
+        ds.depth_test_enable ? MaxwellToVK::ComparisonOp(ds.DepthTestFunc()) : VK_COMPARE_OP_ALWAYS;
     depth_stencil_ci.depthBoundsTestEnable = ds.depth_bounds_enable;
     depth_stencil_ci.stencilTestEnable = ds.stencil_enable;
-    depth_stencil_ci.front = GetStencilFaceState(ds.front_stencil);
-    depth_stencil_ci.back = GetStencilFaceState(ds.back_stencil);
+    depth_stencil_ci.front = GetStencilFaceState(ds.front);
+    depth_stencil_ci.back = GetStencilFaceState(ds.back);
     depth_stencil_ci.minDepthBounds = 0.0f;
     depth_stencil_ci.maxDepthBounds = 0.0f;
 

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -286,29 +286,28 @@ vk::Pipeline VKGraphicsPipeline::CreatePipeline(const RenderPassParams& renderpa
     depth_stencil_ci.maxDepthBounds = 0.0f;
 
     std::array<VkPipelineColorBlendAttachmentState, Maxwell::NumRenderTargets> cb_attachments;
-    const std::size_t num_attachments =
-        std::min(cd.attachments_count, renderpass_params.color_attachments.size());
-    for (std::size_t i = 0; i < num_attachments; ++i) {
-        static constexpr std::array component_table = {
+    const std::size_t num_attachments = renderpass_params.color_attachments.size();
+    for (std::size_t index = 0; index < num_attachments; ++index) {
+        static constexpr std::array COMPONENT_TABLE = {
             VK_COLOR_COMPONENT_R_BIT, VK_COLOR_COMPONENT_G_BIT, VK_COLOR_COMPONENT_B_BIT,
             VK_COLOR_COMPONENT_A_BIT};
-        const auto& blend = cd.attachments[i];
+        const auto& blend = cd.attachments[index];
 
         VkColorComponentFlags color_components = 0;
-        for (std::size_t j = 0; j < component_table.size(); ++j) {
-            if (blend.components[j]) {
-                color_components |= component_table[j];
+        for (std::size_t i = 0; i < COMPONENT_TABLE.size(); ++i) {
+            if (blend.Mask()[i]) {
+                color_components |= COMPONENT_TABLE[i];
             }
         }
 
-        VkPipelineColorBlendAttachmentState& attachment = cb_attachments[i];
-        attachment.blendEnable = blend.enable;
-        attachment.srcColorBlendFactor = MaxwellToVK::BlendFactor(blend.src_rgb_func);
-        attachment.dstColorBlendFactor = MaxwellToVK::BlendFactor(blend.dst_rgb_func);
-        attachment.colorBlendOp = MaxwellToVK::BlendEquation(blend.rgb_equation);
-        attachment.srcAlphaBlendFactor = MaxwellToVK::BlendFactor(blend.src_a_func);
-        attachment.dstAlphaBlendFactor = MaxwellToVK::BlendFactor(blend.dst_a_func);
-        attachment.alphaBlendOp = MaxwellToVK::BlendEquation(blend.a_equation);
+        VkPipelineColorBlendAttachmentState& attachment = cb_attachments[index];
+        attachment.blendEnable = blend.enable != 0;
+        attachment.srcColorBlendFactor = MaxwellToVK::BlendFactor(blend.SourceRGBFactor());
+        attachment.dstColorBlendFactor = MaxwellToVK::BlendFactor(blend.DestRGBFactor());
+        attachment.colorBlendOp = MaxwellToVK::BlendEquation(blend.EquationRGB());
+        attachment.srcAlphaBlendFactor = MaxwellToVK::BlendFactor(blend.SourceAlphaFactor());
+        attachment.dstAlphaBlendFactor = MaxwellToVK::BlendFactor(blend.DestAlphaFactor());
+        attachment.alphaBlendOp = MaxwellToVK::BlendEquation(blend.EquationAlpha());
         attachment.colorWriteMask = color_components;
     }
 

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -334,7 +334,7 @@ VKPipelineCache::DecompileShaders(const GraphicsPipelineCacheKey& key) {
         specialization.point_size = fixed_state.input_assembly.point_size;
     }
     for (std::size_t i = 0; i < Maxwell::NumVertexAttributes; ++i) {
-        specialization.attribute_types[i] = fixed_state.vertex_input.attributes[i].type;
+        specialization.attribute_types[i] = fixed_state.vertex_input.attributes[i].Type();
     }
     specialization.ndc_minus_one_to_one = fixed_state.rasterizer.ndc_minus_one_to_one;
 

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -329,9 +329,9 @@ VKPipelineCache::DecompileShaders(const GraphicsPipelineCacheKey& key) {
     const auto& gpu = system.GPU().Maxwell3D();
 
     Specialization specialization;
-    if (fixed_state.input_assembly.topology == Maxwell::PrimitiveTopology::Points) {
-        ASSERT(fixed_state.input_assembly.point_size != 0.0f);
-        specialization.point_size = fixed_state.input_assembly.point_size;
+    if (fixed_state.rasterizer.Topology() == Maxwell::PrimitiveTopology::Points) {
+        ASSERT(fixed_state.rasterizer.point_size != 0);
+        std::memcpy(&specialization.point_size, &fixed_state.rasterizer.point_size, sizeof(u32));
     }
     for (std::size_t i = 0; i < Maxwell::NumVertexAttributes; ++i) {
         specialization.attribute_types[i] = fixed_state.vertex_input.attributes[i].Type();

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -806,25 +806,29 @@ void RasterizerVulkan::SetupVertexArrays(FixedPipelineState::VertexInput& vertex
                                          BufferBindings& buffer_bindings) {
     const auto& regs = system.GPU().Maxwell3D().regs;
 
-    for (u32 index = 0; index < static_cast<u32>(Maxwell::NumVertexAttributes); ++index) {
+    for (std::size_t index = 0; index < Maxwell::NumVertexAttributes; ++index) {
         const auto& attrib = regs.vertex_attrib_format[index];
         if (!attrib.IsValid()) {
+            vertex_input.SetAttribute(index, false, 0, 0, {}, {});
             continue;
         }
 
-        const auto& buffer = regs.vertex_array[attrib.buffer];
+        [[maybe_unused]] const auto& buffer = regs.vertex_array[attrib.buffer];
         ASSERT(buffer.IsEnabled());
 
-        vertex_input.attributes[vertex_input.num_attributes++] =
-            FixedPipelineState::VertexAttribute(index, attrib.buffer, attrib.type, attrib.size,
-                                                attrib.offset);
+        vertex_input.SetAttribute(index, true, attrib.buffer, attrib.offset, attrib.type.Value(),
+                                  attrib.size.Value());
     }
 
-    for (u32 index = 0; index < static_cast<u32>(Maxwell::NumVertexArrays); ++index) {
+    for (std::size_t index = 0; index < Maxwell::NumVertexArrays; ++index) {
         const auto& vertex_array = regs.vertex_array[index];
         if (!vertex_array.IsEnabled()) {
+            vertex_input.SetBinding(index, false, 0, 0);
             continue;
         }
+        vertex_input.SetBinding(
+            index, true, vertex_array.stride,
+            regs.instanced_arrays.IsInstancingEnabled(index) ? vertex_array.divisor : 0);
 
         const GPUVAddr start{vertex_array.StartAddress()};
         const GPUVAddr end{regs.vertex_array_limit[index].LimitAddress()};
@@ -832,10 +836,6 @@ void RasterizerVulkan::SetupVertexArrays(FixedPipelineState::VertexInput& vertex
         ASSERT(end > start);
         const std::size_t size{end - start + 1};
         const auto [buffer, offset] = buffer_cache.UploadMemory(start, size);
-
-        vertex_input.bindings[vertex_input.num_bindings++] = FixedPipelineState::VertexBinding(
-            index, vertex_array.stride,
-            regs.instanced_arrays.IsInstancingEnabled(index) ? vertex_array.divisor : 0);
         buffer_bindings.AddVertexBinding(buffer, offset);
     }
 }


### PR DESCRIPTION
Compare the whole struct with std::memcmp and hash with CityHash. Using CityHash instead of a naive hash should reduce the number of collisions. Improve used type traits to ensure this operation is safe.

With these changes the improvements to the hashable pipeline state are:
Optimized structure
```
Hash:            89 ns
Equal:          103 ns
Construction*:  164 ns
Struct size:    384 bytes
```
Original structure
```
Hash:           148 ns
Equal:          174 ns
Construction*:  281 ns
Size:          1384 bytes
```
* Attribute state initialization is not measured

These measures are averages taken with `std::chrono::high_resolution_clock` on MSVC shipped on Visual Studio 16.6.0 Preview 2.1.