### PR TITLE
Unbreak -Werror=implicit-fallthrough with Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,7 @@ if (ENABLE_SDL2)
             set(SDL2_LIBRARIES "SDL2::SDL2")
         endif()
 
-        include_directories(${SDL2_INCLUDE_DIRS})
+        include_directories(SYSTEM ${SDL2_INCLUDE_DIRS})
         add_library(SDL2 INTERFACE)
         target_link_libraries(SDL2 INTERFACE "${SDL2_LIBRARIES}")
     endif()


### PR DESCRIPTION
Regressed by 1c340c6efad9. See [error log](https://github.com/yuzu-emu/yuzu/files/4498032/yuzu-qt5-s20200417.log).
