### PR TITLE
thread: FPCR.FZ is likely not 1 (and FPCR.RMode = TieAway and FPCR.DN = 0)

### DIFF
--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -148,8 +148,7 @@ static void ResetThreadContext64(Core::ARM_Interface::ThreadContext64& context, 
     context.pc = entry_point;
     context.sp = stack_top;
     // TODO(merry): Perform a hardware test to determine the below value.
-    // AHP = 0, DN = 1, FTZ = 1, RMode = Round towards zero
-    context.fpcr = 0x03C00000;
+    context.fpcr = 0;
 }
 
 ResultVal<std::shared_ptr<Thread>> Thread::Create(KernelCore& kernel, std::string name,


### PR DESCRIPTION
Technical Summary:

bunnei narrowed down certain game issues to a rounding issue. This was hack-fixed by stepping back to unicorn for these instructions. Unicorn however, was broken, and did not pick up the fpcr set by the rest of the system, so ran with fpcr = 0. This turns out to fix things.

**Edit:** [fpcr value confirmed in Atmosphere](https://github.com/Atmosphere-NX/Atmosphere/blob/fa4a96d021a7b5b8b18d76490e598264da81e682/libraries/libmesosphere/source/arch/arm64/kern_k_thread_context.cpp#L134).