### PR TITLE
dma_pusher: Remove reliance on the global system instance

### DIFF
--- a/src/video_core/dma_pusher.cpp
+++ b/src/video_core/dma_pusher.cpp
@@ -12,7 +12,7 @@
 
 namespace Tegra {
 
-DmaPusher::DmaPusher(GPU& gpu) : gpu(gpu) {}
+DmaPusher::DmaPusher(Core::System& system, GPU& gpu) : gpu{gpu}, system{system} {}
 
 DmaPusher::~DmaPusher() = default;
 
@@ -26,7 +26,7 @@ void DmaPusher::DispatchCalls() {
 
     dma_pushbuffer_subindex = 0;
 
-    while (Core::System::GetInstance().IsPoweredOn()) {
+    while (system.IsPoweredOn()) {
         if (!Step()) {
             break;
         }

--- a/src/video_core/dma_pusher.h
+++ b/src/video_core/dma_pusher.h
@@ -10,6 +10,10 @@
 #include "common/bit_field.h"
 #include "common/common_types.h"
 
+namespace Core {
+class System;
+}
+
 namespace Tegra {
 
 enum class SubmissionMode : u32 {
@@ -56,7 +60,7 @@ using CommandList = std::vector<Tegra::CommandListHeader>;
  */
 class DmaPusher {
 public:
-    explicit DmaPusher(GPU& gpu);
+    explicit DmaPusher(Core::System& system, GPU& gpu);
     ~DmaPusher();
 
     void Push(CommandList&& entries) {
@@ -71,8 +75,6 @@ private:
     void SetState(const CommandHeader& command_header);
 
     void CallMethod(u32 argument) const;
-
-    GPU& gpu;
 
     std::vector<CommandHeader> command_headers; ///< Buffer for list of commands fetched at once
 
@@ -92,6 +94,9 @@ private:
 
     GPUVAddr dma_mget{};  ///< main pushbuffer last read address
     bool ib_enable{true}; ///< IB mode enabled
+
+    GPU& gpu;
+    Core::System& system;
 };
 
 } // namespace Tegra

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -27,7 +27,7 @@ GPU::GPU(Core::System& system, std::unique_ptr<VideoCore::RendererBase>&& render
     : system{system}, renderer{std::move(renderer_)}, is_async{is_async} {
     auto& rasterizer{renderer->Rasterizer()};
     memory_manager = std::make_unique<Tegra::MemoryManager>(system, rasterizer);
-    dma_pusher = std::make_unique<Tegra::DmaPusher>(*this);
+    dma_pusher = std::make_unique<Tegra::DmaPusher>(system, *this);
     maxwell_3d = std::make_unique<Engines::Maxwell3D>(system, rasterizer, *memory_manager);
     fermi_2d = std::make_unique<Engines::Fermi2D>(rasterizer);
     kepler_compute = std::make_unique<Engines::KeplerCompute>(system, rasterizer, *memory_manager);


### PR DESCRIPTION
With this, the video core no longer has calls to the global system instance at all; woo!