### PR TITLE
Fix process memory initialization for ELF and NRO

### DIFF
--- a/src/core/file_sys/program_metadata.cpp
+++ b/src/core/file_sys/program_metadata.cpp
@@ -51,6 +51,17 @@ Loader::ResultStatus ProgramMetadata::Load(VirtualFile file) {
     return Loader::ResultStatus::Success;
 }
 
+/*static*/ ProgramMetadata ProgramMetadata::GetDefault() {
+    ProgramMetadata result;
+
+    result.LoadManual(
+        true /*is_64_bit*/, FileSys::ProgramAddressSpaceType::Is39Bit /*address_space*/,
+        0x2c /*main_thread_prio*/, 0 /*main_thread_core*/, 0x00100000 /*main_thread_stack_size*/,
+        {}, 0xFFFFFFFFFFFFFFFF /*filesystem_permissions*/, {} /*capabilities*/);
+
+    return result;
+}
+
 void ProgramMetadata::LoadManual(bool is_64_bit, ProgramAddressSpaceType address_space,
                                  s32 main_thread_prio, u32 main_thread_core,
                                  u32 main_thread_stack_size, u64 title_id,

--- a/src/core/file_sys/program_metadata.h
+++ b/src/core/file_sys/program_metadata.h
@@ -44,9 +44,13 @@ public:
     ProgramMetadata();
     ~ProgramMetadata();
 
+    /// Gets a default ProgramMetadata configuration, should only be used for homebrew formats where
+    /// we do not have an NPDM file
+    static ProgramMetadata GetDefault();
+
     Loader::ResultStatus Load(VirtualFile file);
 
-    // Load from parameters instead of NPDM file, used for KIP
+    /// Load from parameters instead of NPDM file, used for KIP
     void LoadManual(bool is_64_bit, ProgramAddressSpaceType address_space, s32 main_thread_prio,
                     u32 main_thread_core, u32 main_thread_stack_size, u64 title_id,
                     u64 filesystem_permissions, KernelCapabilityDescriptors capabilities);

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -398,6 +398,11 @@ AppLoader_ELF::LoadResult AppLoader_ELF::Load(Kernel::Process& process) {
     Kernel::CodeSet codeset = elf_reader.LoadInto(base_address);
     const VAddr entry_point = codeset.entrypoint;
 
+    // Setup the process code layout
+    if (process.LoadFromMetadata(FileSys::ProgramMetadata::GetDefault(), buffer.size()).IsError()) {
+        return {ResultStatus::ErrorNotInitialized, {}};
+    }
+
     process.LoadModule(std::move(codeset), entry_point);
 
     is_loaded = true;

--- a/src/core/loader/nro.h
+++ b/src/core/loader/nro.h
@@ -47,7 +47,7 @@ public:
     bool IsRomFSUpdatable() const override;
 
 private:
-    bool LoadNro(Kernel::Process& process, const FileSys::VfsFile& file, VAddr load_base);
+    bool LoadNro(Kernel::Process& process, const FileSys::VfsFile& file);
 
     std::vector<u8> icon_data;
     std::unique_ptr<FileSys::NACP> nacp;


### PR DESCRIPTION
With the old VMM, we relied on the memory layout being initialized at ctor time. Homebrew apps relied on this behavior. This change restores similar functionality. 