### PR TITLE
vk_memory_manager: Remove unified memory model flag

### DIFF
--- a/src/video_core/renderer_vulkan/vk_device.h
+++ b/src/video_core/renderer_vulkan/vk_device.h
@@ -78,11 +78,6 @@ public:
         return present_family;
     }
 
-    /// Returns true if the device is integrated with the host CPU.
-    bool IsIntegrated() const {
-        return properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
-    }
-
     /// Returns the current Vulkan API version provided in Vulkan-formatted version numbers.
     u32 GetApiVersion() const {
         return properties.apiVersion;

--- a/src/video_core/renderer_vulkan/vk_memory_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_memory_manager.cpp
@@ -118,8 +118,7 @@ private:
 };
 
 VKMemoryManager::VKMemoryManager(const VKDevice& device)
-    : device{device}, properties{device.GetPhysical().GetMemoryProperties()},
-      is_memory_unified{GetMemoryUnified(properties)} {}
+    : device{device}, properties{device.GetPhysical().GetMemoryProperties()} {}
 
 VKMemoryManager::~VKMemoryManager() = default;
 
@@ -207,16 +206,6 @@ VKMemoryCommit VKMemoryManager::TryAllocCommit(const VkMemoryRequirements& requi
         }
     }
     return {};
-}
-
-bool VKMemoryManager::GetMemoryUnified(const VkPhysicalDeviceMemoryProperties& properties) {
-    for (u32 heap_index = 0; heap_index < properties.memoryHeapCount; ++heap_index) {
-        if (!(properties.memoryHeaps[heap_index].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT)) {
-            // Memory is considered unified when heaps are device local only.
-            return false;
-        }
-    }
-    return true;
 }
 
 VKMemoryCommitImpl::VKMemoryCommitImpl(const VKDevice& device, VKMemoryAllocation* allocation,

--- a/src/video_core/renderer_vulkan/vk_memory_manager.h
+++ b/src/video_core/renderer_vulkan/vk_memory_manager.h
@@ -40,11 +40,6 @@ public:
     /// Commits memory required by the image and binds it.
     VKMemoryCommit Commit(const vk::Image& image, bool host_visible);
 
-    /// Returns true if the memory allocations are done always in host visible and coherent memory.
-    bool IsMemoryUnified() const {
-        return is_memory_unified;
-    }
-
 private:
     /// Allocates a chunk of memory.
     bool AllocMemory(VkMemoryPropertyFlags wanted_properties, u32 type_mask, u64 size);
@@ -53,12 +48,8 @@ private:
     VKMemoryCommit TryAllocCommit(const VkMemoryRequirements& requirements,
                                   VkMemoryPropertyFlags wanted_properties);
 
-    /// Returns true if the device uses an unified memory model.
-    static bool GetMemoryUnified(const VkPhysicalDeviceMemoryProperties& properties);
-
-    const VKDevice& device;                            ///< Device handler.
-    const VkPhysicalDeviceMemoryProperties properties; ///< Physical device properties.
-    const bool is_memory_unified;                      ///< True if memory model is unified.
+    const VKDevice& device;                                       ///< Device handler.
+    const VkPhysicalDeviceMemoryProperties properties;            ///< Physical device properties.
     std::vector<std::unique_ptr<VKMemoryAllocation>> allocations; ///< Current allocations.
 };
 

--- a/src/video_core/renderer_vulkan/vk_staging_buffer_pool.cpp
+++ b/src/video_core/renderer_vulkan/vk_staging_buffer_pool.cpp
@@ -39,8 +39,7 @@ VKStagingBufferPool::StagingBuffer& VKStagingBufferPool::StagingBuffer::operator
 
 VKStagingBufferPool::VKStagingBufferPool(const VKDevice& device, VKMemoryManager& memory_manager,
                                          VKScheduler& scheduler)
-    : device{device}, memory_manager{memory_manager}, scheduler{scheduler},
-      is_device_integrated{device.IsIntegrated()} {}
+    : device{device}, memory_manager{memory_manager}, scheduler{scheduler} {}
 
 VKStagingBufferPool::~VKStagingBufferPool() = default;
 
@@ -56,9 +55,7 @@ void VKStagingBufferPool::TickFrame() {
     current_delete_level = (current_delete_level + 1) % NumLevels;
 
     ReleaseCache(true);
-    if (!is_device_integrated) {
-        ReleaseCache(false);
-    }
+    ReleaseCache(false);
 }
 
 VKBuffer* VKStagingBufferPool::TryGetReservedBuffer(std::size_t size, bool host_visible) {
@@ -95,7 +92,7 @@ VKBuffer& VKStagingBufferPool::CreateStagingBuffer(std::size_t size, bool host_v
 }
 
 VKStagingBufferPool::StagingBuffersCache& VKStagingBufferPool::GetCache(bool host_visible) {
-    return is_device_integrated || host_visible ? host_staging_buffers : device_staging_buffers;
+    return host_visible ? host_staging_buffers : device_staging_buffers;
 }
 
 void VKStagingBufferPool::ReleaseCache(bool host_visible) {

--- a/src/video_core/renderer_vulkan/vk_staging_buffer_pool.h
+++ b/src/video_core/renderer_vulkan/vk_staging_buffer_pool.h
@@ -71,7 +71,6 @@ private:
     const VKDevice& device;
     VKMemoryManager& memory_manager;
     VKScheduler& scheduler;
-    const bool is_device_integrated;
 
     StagingBuffersCache host_staging_buffers;
     StagingBuffersCache device_staging_buffers;


### PR DESCRIPTION
All drivers (even Intel) seem to have a device local memory type that is
not host visible. Remove this flag so all devices follow the same path.

This fixes a crash when trying to map to host device local memory on
integrated devices.