### PR TITLE
Introduce dummy context for yuzu-cmd VK support

### DIFF
--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.cpp
@@ -29,6 +29,7 @@ EmuWindow_SDL2_VK::EmuWindow_SDL2_VK(Core::System& system, bool fullscreen)
                          SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI);
 
     SDL_SysWMinfo wm;
+    SDL_VERSION(&wm.version);
     if (SDL_GetWindowWMInfo(render_window, &wm) == SDL_FALSE) {
         LOG_CRITICAL(Frontend, "Failed to get information from the window manager");
         std::exit(EXIT_FAILURE);
@@ -70,7 +71,7 @@ EmuWindow_SDL2_VK::EmuWindow_SDL2_VK(Core::System& system, bool fullscreen)
 EmuWindow_SDL2_VK::~EmuWindow_SDL2_VK() = default;
 
 std::unique_ptr<Core::Frontend::GraphicsContext> EmuWindow_SDL2_VK::CreateSharedContext() const {
-    return nullptr;
+    return std::make_unique<DummyContext>()
 }
 
 void EmuWindow_SDL2_VK::Present() {

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.h
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.h
@@ -22,3 +22,5 @@ public:
 
     std::unique_ptr<Core::Frontend::GraphicsContext> CreateSharedContext() const override;
 };
+
+class DummyContext : public Core::Frontend::GraphicsContext {};


### PR DESCRIPTION
This PR resolves https://github.com/yuzu-emu/yuzu/issues/3752 and adds the dummy context as used in `src/yuzu/bootmanager.cpp` to provide functioning VK support to yuzu-cmd.