### PR TITLE
Set _FORTIFY_SOURCE=0 if building Opus with mingw-w64

### DIFF
--- a/externals/opus/CMakeLists.txt
+++ b/externals/opus/CMakeLists.txt
@@ -203,7 +203,11 @@ endif()
 target_compile_definitions(opus PRIVATE OPUS_BUILD ENABLE_HARDENING)
 
 if(NOT MSVC)
-    target_compile_definitions(opus PRIVATE _FORTIFY_SOURCE=2)
+    if(MINGW)
+        target_compile_definitions(opus PRIVATE _FORTIFY_SOURCE=0)
+    else()
+        target_compile_definitions(opus PRIVATE _FORTIFY_SOURCE=2)
+    endif()
 endif()
 
 # It is strongly recommended to uncomment one of these VAR_ARRAYS: Use C99


### PR DESCRIPTION
`_FORTIFY_SOURCE=0` must be set if building with `mingw-w64`, as described [here ](https://sourceforge.net/p/mingw-w64/mailman/message/36764708/). Resolves https://github.com/yuzu-emu/yuzu/issues/3726.