### PR TITLE
configure_input_player: Use slider to edit modifier scale

### DIFF
--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -56,7 +56,6 @@ static void SetAnalogButton(const Common::ParamPackage& input_param,
     if (analog_param.Get("engine", "") != "analog_from_button") {
         analog_param = {
             {"engine", "analog_from_button"},
-            {"modifier_scale", "0.5"},
         };
     }
     analog_param.Set(button_name, input_param.Serialize());
@@ -236,8 +235,10 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
         widget->setVisible(false);
 
     analog_map_stick = {ui->buttonLStickAnalog, ui->buttonRStickAnalog};
-    analog_map_deadzone = {ui->sliderLStickDeadzone, ui->sliderRStickDeadzone};
-    analog_map_deadzone_label = {ui->labelLStickDeadzone, ui->labelRStickDeadzone};
+    analog_map_deadzone_and_modifier_slider = {ui->sliderLStickDeadzoneAndModifier,
+                                               ui->sliderRStickDeadzoneAndModifier};
+    analog_map_deadzone_and_modifier_slider_label = {ui->labelLStickDeadzoneAndModifier,
+                                                     ui->labelRStickDeadzoneAndModifier};
 
     for (int button_id = 0; button_id < Settings::NativeButton::NumButtons; button_id++) {
         auto* const button = button_map[button_id];
@@ -328,10 +329,18 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
                     InputCommon::Polling::DeviceType::Analog);
             }
         });
-        connect(analog_map_deadzone[analog_id], &QSlider::valueChanged, [=] {
-            const float deadzone = analog_map_deadzone[analog_id]->value() / 100.0f;
-            analog_map_deadzone_label[analog_id]->setText(tr("Deadzone: %1").arg(deadzone));
-            analogs_param[analog_id].Set("deadzone", deadzone);
+
+        connect(analog_map_deadzone_and_modifier_slider[analog_id], &QSlider::valueChanged, [=] {
+            const float slider_value = analog_map_deadzone_and_modifier_slider[analog_id]->value();
+            if (analogs_param[analog_id].Get("engine", "") == "sdl") {
+                analog_map_deadzone_and_modifier_slider_label[analog_id]->setText(
+                    tr("Deadzone: %1%").arg(slider_value));
+                analogs_param[analog_id].Set("deadzone", slider_value / 100.0f);
+            } else {
+                analog_map_deadzone_and_modifier_slider_label[analog_id]->setText(
+                    tr("Modifier Scale: %1%").arg(slider_value));
+                analogs_param[analog_id].Set("modifier_scale", slider_value / 100.0f);
+            }
         });
     }
 
@@ -517,20 +526,31 @@ void ConfigureInputPlayer::UpdateButtonLabels() {
         analog_map_stick[analog_id]->setText(tr("Set Analog Stick"));
 
         auto& param = analogs_param[analog_id];
-        auto* const analog_deadzone_slider = analog_map_deadzone[analog_id];
-        auto* const analog_deadzone_label = analog_map_deadzone_label[analog_id];
+        auto* const analog_stick_slider = analog_map_deadzone_and_modifier_slider[analog_id];
+        auto* const analog_stick_slider_label =
+            analog_map_deadzone_and_modifier_slider_label[analog_id];
 
-        if (param.Has("engine") && param.Get("engine", "") == "sdl") {
-            if (!param.Has("deadzone")) {
-                param.Set("deadzone", 0.1f);
+        if (param.Has("engine")) {
+            if (param.Get("engine", "") == "sdl") {
+                if (!param.Has("deadzone")) {
+                    param.Set("deadzone", 0.1f);
+                }
+
+                analog_stick_slider->setValue(static_cast<int>(param.Get("deadzone", 0.1f) * 100));
+                if (analog_stick_slider->value() == 0) {
+                    analog_stick_slider_label->setText(tr("Deadzone: 0%"));
+                }
+            } else {
+                if (!param.Has("modifier_scale")) {
+                    param.Set("modifier_scale", 0.5f);
+                }
+
+                analog_stick_slider->setValue(
+                    static_cast<int>(param.Get("modifier_scale", 0.5f) * 100));
+                if (analog_stick_slider->value() == 0) {
+                    analog_stick_slider_label->setText(tr("Modifier Scale: 0%"));
+                }
             }
-
-            analog_deadzone_slider->setValue(static_cast<int>(param.Get("deadzone", 0.1f) * 100));
-            analog_deadzone_slider->setVisible(true);
-            analog_deadzone_label->setVisible(true);
-        } else {
-            analog_deadzone_slider->setVisible(false);
-            analog_deadzone_label->setVisible(false);
         }
     }
 }

--- a/src/yuzu/configuration/configure_input_player.h
+++ b/src/yuzu/configuration/configure_input_player.h
@@ -97,8 +97,10 @@ private:
     /// Analog inputs are also represented each with a single button, used to configure with an
     /// actual analog stick
     std::array<QPushButton*, Settings::NativeAnalog::NumAnalogs> analog_map_stick;
-    std::array<QSlider*, Settings::NativeAnalog::NumAnalogs> analog_map_deadzone;
-    std::array<QLabel*, Settings::NativeAnalog::NumAnalogs> analog_map_deadzone_label;
+    std::array<QSlider*, Settings::NativeAnalog::NumAnalogs>
+        analog_map_deadzone_and_modifier_slider;
+    std::array<QLabel*, Settings::NativeAnalog::NumAnalogs>
+        analog_map_deadzone_and_modifier_slider_label;
 
     static const std::array<std::string, ANALOG_SUB_BUTTONS_NUM> analog_sub_buttons;
 

--- a/src/yuzu/configuration/configure_input_player.ui
+++ b/src/yuzu/configuration/configure_input_player.ui
@@ -171,11 +171,11 @@
          </layout>
         </item>
         <item row="4" column="0" colspan="2">
-         <layout class="QVBoxLayout" name="sliderRStickDeadzoneVerticalLayout">
+         <layout class="QVBoxLayout" name="sliderRStickDeadzoneAndModifierVerticalLayout">
           <item>
-           <layout class="QHBoxLayout" name="sliderRStickDeadzoneHorizontalLayout">
+           <layout class="QHBoxLayout" name="sliderRStickDeadzoneAndModifierHorizontalLayout">
             <item>
-             <widget class="QLabel" name="labelRStickDeadzone">
+             <widget class="QLabel" name="labelRStickDeadzoneAndModifier">
               <property name="text">
                <string>Deadzone: 0</string>
               </property>
@@ -187,7 +187,7 @@
            </layout>
           </item>
           <item>
-           <widget class="QSlider" name="sliderRStickDeadzone">
+           <widget class="QSlider" name="sliderRStickDeadzoneAndModifier">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -784,14 +784,14 @@
          </layout>
         </item>
         <item row="5" column="1" colspan="2">
-         <layout class="QVBoxLayout" name="sliderLStickDeadzoneVerticalLayout">
+         <layout class="QVBoxLayout" name="sliderLStickDeadzoneAndModifierVerticalLayout">
           <property name="sizeConstraint">
            <enum>QLayout::SetDefaultConstraint</enum>
           </property>
           <item>
-           <layout class="QHBoxLayout" name="sliderLStickDeadzoneHorizontalLayout">
+           <layout class="QHBoxLayout" name="sliderLStickDeadzoneAndModifierHorizontalLayout">
             <item>
-             <widget class="QLabel" name="labelLStickDeadzone">
+             <widget class="QLabel" name="labelLStickDeadzoneAndModifier">
               <property name="text">
                <string>Deadzone: 0</string>
               </property>
@@ -803,7 +803,7 @@
            </layout>
           </item>
           <item>
-           <widget class="QSlider" name="sliderLStickDeadzone">
+           <widget class="QSlider" name="sliderLStickDeadzoneAndModifier">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>


### PR DESCRIPTION
Use the existing deadzone slider to edit the modifier scale when keyboard is being used for stick controls. The slider is now always shown.

I also changed the shown value to show percent instead of decimals. I think that makes more sense to a regular user.

![image](https://user-images.githubusercontent.com/5352197/80096824-83a6dd80-856a-11ea-8990-ab8797fc040b.png)

The setText at line 543 and 552 are needed because QSlider::valueChanged isn't called when the sliders are set to 0 and the configure window is opened.