### PR TITLE
vk_renderpass_cache: Pack renderpass cache key and unify keys

### DIFF
--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
@@ -140,6 +140,12 @@ void FixedPipelineState::BlendingAttachment::Fill(const Maxwell& regs, std::size
     enable.Assign(1);
 }
 
+void FixedPipelineState::Fill(const Maxwell& regs) {
+    rasterizer.Fill(regs);
+    depth_stencil.Fill(regs);
+    color_blending.Fill(regs);
+}
+
 std::size_t FixedPipelineState::Hash() const noexcept {
     const u64 hash = Common::CityHash64(reinterpret_cast<const char*>(this), sizeof *this);
     return static_cast<std::size_t>(hash);
@@ -147,15 +153,6 @@ std::size_t FixedPipelineState::Hash() const noexcept {
 
 bool FixedPipelineState::operator==(const FixedPipelineState& rhs) const noexcept {
     return std::memcmp(this, &rhs, sizeof *this) == 0;
-}
-
-FixedPipelineState GetFixedPipelineState(const Maxwell& regs) {
-    FixedPipelineState fixed_state;
-    fixed_state.rasterizer.Fill(regs);
-    fixed_state.depth_stencil.Fill(regs);
-    fixed_state.color_blending.Fill(regs);
-    fixed_state.padding = {};
-    return fixed_state;
 }
 
 u32 FixedPipelineState::PackComparisonOp(Maxwell::ComparisonOp op) noexcept {

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.h
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.h
@@ -17,7 +17,7 @@ namespace Vulkan {
 
 using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 
-struct alignas(32) FixedPipelineState {
+struct FixedPipelineState {
     static u32 PackComparisonOp(Maxwell::ComparisonOp op) noexcept;
     static Maxwell::ComparisonOp UnpackComparisonOp(u32 packed) noexcept;
 
@@ -237,7 +237,8 @@ struct alignas(32) FixedPipelineState {
     Rasterizer rasterizer;
     DepthStencil depth_stencil;
     ColorBlending color_blending;
-    std::array<u8, 20> padding;
+
+    void Fill(const Maxwell& regs);
 
     std::size_t Hash() const noexcept;
 
@@ -250,9 +251,6 @@ struct alignas(32) FixedPipelineState {
 static_assert(std::has_unique_object_representations_v<FixedPipelineState>);
 static_assert(std::is_trivially_copyable_v<FixedPipelineState>);
 static_assert(std::is_trivially_constructible_v<FixedPipelineState>);
-static_assert(sizeof(FixedPipelineState) % 32 == 0, "Size is not aligned");
-
-FixedPipelineState GetFixedPipelineState(const Maxwell& regs);
 
 } // namespace Vulkan
 

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -288,7 +288,7 @@ vk::Pipeline VKGraphicsPipeline::CreatePipeline(const RenderPassParams& renderpa
     depth_stencil_ci.maxDepthBounds = 0.0f;
 
     std::array<VkPipelineColorBlendAttachmentState, Maxwell::NumRenderTargets> cb_attachments;
-    const std::size_t num_attachments = renderpass_params.color_attachments.size();
+    const auto num_attachments = static_cast<std::size_t>(renderpass_params.num_color_attachments);
     for (std::size_t index = 0; index < num_attachments; ++index) {
         static constexpr std::array COMPONENT_TABLE = {
             VK_COLOR_COMPONENT_R_BIT, VK_COLOR_COMPONENT_G_BIT, VK_COLOR_COMPONENT_B_BIT,

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -161,6 +161,24 @@ u32 FillDescriptorLayout(const ShaderEntries& entries,
 
 } // Anonymous namespace
 
+std::size_t GraphicsPipelineCacheKey::Hash() const noexcept {
+    const u64 hash = Common::CityHash64(reinterpret_cast<const char*>(this), sizeof *this);
+    return static_cast<std::size_t>(hash);
+}
+
+bool GraphicsPipelineCacheKey::operator==(const GraphicsPipelineCacheKey& rhs) const noexcept {
+    return std::memcmp(&rhs, this, sizeof *this) == 0;
+}
+
+std::size_t ComputePipelineCacheKey::Hash() const noexcept {
+    const u64 hash = Common::CityHash64(reinterpret_cast<const char*>(this), sizeof *this);
+    return static_cast<std::size_t>(hash);
+}
+
+bool ComputePipelineCacheKey::operator==(const ComputePipelineCacheKey& rhs) const noexcept {
+    return std::memcmp(&rhs, this, sizeof *this) == 0;
+}
+
 CachedShader::CachedShader(Core::System& system, Tegra::Engines::ShaderType stage,
                            GPUVAddr gpu_addr, VAddr cpu_addr, ProgramCode program_code,
                            u32 main_offset)

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -7,7 +7,6 @@
 #include <array>
 #include <cstddef>
 #include <memory>
-#include <tuple>
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
@@ -51,42 +50,38 @@ using ProgramCode = std::vector<u64>;
 
 struct GraphicsPipelineCacheKey {
     FixedPipelineState fixed_state;
-    std::array<GPUVAddr, Maxwell::MaxShaderProgram> shaders;
     RenderPassParams renderpass_params;
+    std::array<GPUVAddr, Maxwell::MaxShaderProgram> shaders;
+    u64 padding; // This is necessary for unique object representations
 
-    std::size_t Hash() const noexcept {
-        std::size_t hash = fixed_state.Hash();
-        for (const auto& shader : shaders) {
-            boost::hash_combine(hash, shader);
-        }
-        boost::hash_combine(hash, renderpass_params.Hash());
-        return hash;
-    }
+    std::size_t Hash() const noexcept;
 
-    bool operator==(const GraphicsPipelineCacheKey& rhs) const noexcept {
-        return std::tie(fixed_state, shaders, renderpass_params) ==
-               std::tie(rhs.fixed_state, rhs.shaders, rhs.renderpass_params);
+    bool operator==(const GraphicsPipelineCacheKey& rhs) const noexcept;
+
+    bool operator!=(const GraphicsPipelineCacheKey& rhs) const noexcept {
+        return !operator==(rhs);
     }
 };
+static_assert(std::has_unique_object_representations_v<GraphicsPipelineCacheKey>);
+static_assert(std::is_trivially_copyable_v<GraphicsPipelineCacheKey>);
+static_assert(std::is_trivially_constructible_v<GraphicsPipelineCacheKey>);
 
 struct ComputePipelineCacheKey {
-    GPUVAddr shader{};
-    u32 shared_memory_size{};
-    std::array<u32, 3> workgroup_size{};
+    GPUVAddr shader;
+    u32 shared_memory_size;
+    std::array<u32, 3> workgroup_size;
 
-    std::size_t Hash() const noexcept {
-        return static_cast<std::size_t>(shader) ^
-               ((static_cast<std::size_t>(shared_memory_size) >> 7) << 40) ^
-               static_cast<std::size_t>(workgroup_size[0]) ^
-               (static_cast<std::size_t>(workgroup_size[1]) << 16) ^
-               (static_cast<std::size_t>(workgroup_size[2]) << 24);
-    }
+    std::size_t Hash() const noexcept;
 
-    bool operator==(const ComputePipelineCacheKey& rhs) const noexcept {
-        return std::tie(shader, shared_memory_size, workgroup_size) ==
-               std::tie(rhs.shader, rhs.shared_memory_size, rhs.workgroup_size);
+    bool operator==(const ComputePipelineCacheKey& rhs) const noexcept;
+
+    bool operator!=(const ComputePipelineCacheKey& rhs) const noexcept {
+        return !operator==(rhs);
     }
 };
+static_assert(std::has_unique_object_representations_v<ComputePipelineCacheKey>);
+static_assert(std::is_trivially_copyable_v<ComputePipelineCacheKey>);
+static_assert(std::is_trivially_constructible_v<ComputePipelineCacheKey>);
 
 } // namespace Vulkan
 

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -692,7 +692,7 @@ std::tuple<VkFramebuffer, VkExtent2D> RasterizerVulkan::ConfigureFramebuffers(
     FramebufferCacheKey key{renderpass, std::numeric_limits<u32>::max(),
                             std::numeric_limits<u32>::max(), std::numeric_limits<u32>::max()};
 
-    const auto try_push = [&](const View& view) {
+    const auto try_push = [&key](const View& view) {
         if (!view) {
             return false;
         }
@@ -703,7 +703,9 @@ std::tuple<VkFramebuffer, VkExtent2D> RasterizerVulkan::ConfigureFramebuffers(
         return true;
     };
 
-    for (std::size_t index = 0; index < std::size(color_attachments); ++index) {
+    const auto& regs = system.GPU().Maxwell3D().regs;
+    const std::size_t num_attachments = static_cast<std::size_t>(regs.rt_control.count);
+    for (std::size_t index = 0; index < num_attachments; ++index) {
         if (try_push(color_attachments[index])) {
             texture_cache.MarkColorBufferInUse(index);
         }

--- a/src/video_core/renderer_vulkan/vk_renderpass_cache.h
+++ b/src/video_core/renderer_vulkan/vk_renderpass_cache.h
@@ -19,8 +19,8 @@ namespace Vulkan {
 class VKDevice;
 
 struct RenderPassParams {
-    u8 num_color_attachments;
     std::array<u8, Tegra::Engines::Maxwell3D::Regs::NumRenderTargets> color_formats;
+    u8 num_color_attachments;
     u8 texceptions;
 
     u8 zeta_format;

--- a/src/video_core/renderer_vulkan/vk_renderpass_cache.h
+++ b/src/video_core/renderer_vulkan/vk_renderpass_cache.h
@@ -4,8 +4,7 @@
 
 #pragma once
 
-#include <memory>
-#include <tuple>
+#include <type_traits>
 #include <unordered_map>
 
 #include <boost/container/static_vector.hpp>
@@ -19,51 +18,25 @@ namespace Vulkan {
 
 class VKDevice;
 
-// TODO(Rodrigo): Optimize this structure for faster hashing
-
 struct RenderPassParams {
-    struct ColorAttachment {
-        u32 index = 0;
-        VideoCore::Surface::PixelFormat pixel_format = VideoCore::Surface::PixelFormat::Invalid;
-        bool is_texception = false;
+    u8 num_color_attachments;
+    std::array<u8, Tegra::Engines::Maxwell3D::Regs::NumRenderTargets> color_formats;
+    u8 texceptions;
 
-        std::size_t Hash() const noexcept {
-            return static_cast<std::size_t>(pixel_format) |
-                   static_cast<std::size_t>(is_texception) << 6 |
-                   static_cast<std::size_t>(index) << 7;
-        }
+    u8 zeta_format;
+    u8 zeta_texception;
 
-        bool operator==(const ColorAttachment& rhs) const noexcept {
-            return std::tie(index, pixel_format, is_texception) ==
-                   std::tie(rhs.index, rhs.pixel_format, rhs.is_texception);
-        }
-    };
+    std::size_t Hash() const noexcept;
 
-    boost::container::static_vector<ColorAttachment,
-                                    Tegra::Engines::Maxwell3D::Regs::NumRenderTargets>
-        color_attachments{};
-    // TODO(Rodrigo): Unify has_zeta into zeta_pixel_format and zeta_component_type.
-    VideoCore::Surface::PixelFormat zeta_pixel_format = VideoCore::Surface::PixelFormat::Invalid;
-    bool has_zeta = false;
-    bool zeta_texception = false;
+    bool operator==(const RenderPassParams& rhs) const noexcept;
 
-    std::size_t Hash() const noexcept {
-        std::size_t hash = 0;
-        for (const auto& rt : color_attachments) {
-            boost::hash_combine(hash, rt.Hash());
-        }
-        boost::hash_combine(hash, zeta_pixel_format);
-        boost::hash_combine(hash, has_zeta);
-        boost::hash_combine(hash, zeta_texception);
-        return hash;
-    }
-
-    bool operator==(const RenderPassParams& rhs) const {
-        return std::tie(color_attachments, zeta_pixel_format, has_zeta, zeta_texception) ==
-               std::tie(rhs.color_attachments, rhs.zeta_pixel_format, rhs.has_zeta,
-                        rhs.zeta_texception);
+    bool operator!=(const RenderPassParams& rhs) const noexcept {
+        return !operator==(rhs);
     }
 };
+static_assert(std::has_unique_object_representations_v<RenderPassParams>);
+static_assert(std::is_trivially_copyable_v<RenderPassParams>);
+static_assert(std::is_trivially_constructible_v<RenderPassParams>);
 
 } // namespace Vulkan
 


### PR DESCRIPTION
Continues what #3718 started for renderpasses. This allows us to call Common::CityHash and std::memcmp only once for GraphicsPipelineCacheKey.

Framebuffer creation was ignoring the number of color attachments, this caused validation errors. No known issues were caused by this.