### PR TITLE
vk_pipeline_cache: Fix unintentional memcpy into optional

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -330,8 +330,10 @@ VKPipelineCache::DecompileShaders(const GraphicsPipelineCacheKey& key) {
 
     Specialization specialization;
     if (fixed_state.rasterizer.Topology() == Maxwell::PrimitiveTopology::Points) {
-        ASSERT(fixed_state.rasterizer.point_size != 0);
-        std::memcpy(&specialization.point_size, &fixed_state.rasterizer.point_size, sizeof(u32));
+        float point_size;
+        std::memcpy(&point_size, &fixed_state.rasterizer.point_size, sizeof(float));
+        specialization.point_size = point_size;
+        ASSERT(point_size != 0.0f);
     }
     for (std::size_t i = 0; i < Maxwell::NumVertexAttributes; ++i) {
         specialization.attribute_types[i] = fixed_state.vertex_input.attributes[i].Type();


### PR DESCRIPTION
The intention behind this was to assign a float to from an uint32_t, but
it was unintentionally being copied directly into the std::optional.

Copy to a temporary and assign that temporary to std::optional. This can
be replaced with std::bit_cast<float> once we are in C++20.

- Silences a validation issue and bug (dynamic state point size not being set) on Super Mario Odyssey.