### PR TITLE
Fix format error in performance statistics

### DIFF
--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
@@ -181,9 +181,10 @@ void EmuWindow_SDL2::PollEvents() {
     const u32 current_time = SDL_GetTicks();
     if (current_time > last_time + 2000) {
         const auto results = Core::System::GetInstance().GetAndResetPerfStats();
-        const auto title = fmt::format(
-            "yuzu {} | {}-{} | FPS: {:.0f} ({:.0%})", Common::g_build_fullname,
-            Common::g_scm_branch, Common::g_scm_desc, results.game_fps, results.emulation_speed);
+        const auto title =
+            fmt::format("yuzu {} | {}-{} | FPS: {:.0f} ({:.0f}%)", Common::g_build_fullname,
+                        Common::g_scm_branch, Common::g_scm_desc, results.game_fps,
+                        results.emulation_speed * 100.0);
         SDL_SetWindowTitle(render_window, title.c_str());
         last_time = current_time;
     }


### PR DESCRIPTION
Resubmission: this fixes a format error (that otherwise causes `yuzu-cmd` to fail) to allow the reporting of emulation speed statistic in the window title of `yuzu-cmd`. Resolves https://github.com/yuzu-emu/yuzu/issues/3746.