### PR TITLE
Dump RomFS command to include Updates

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1304,7 +1304,9 @@ void GMainWindow::OnGameListDumpRomFS(u64 program_id, const std::string& game_pa
     FileSys::VirtualFile romfs;
 
     if (*romfs_title_id == program_id) {
-        romfs = file;
+        u64 ivfc_offset = loader->ReadRomFSIVFCOffset();
+        FileSys::PatchManager pm{program_id};
+        romfs = pm.PatchRomFS(file, ivfc_offset, FileSys::ContentRecordType::Program);
     } else {
         romfs = installed.GetEntry(*romfs_title_id, FileSys::ContentRecordType::Data)->GetRomFS();
     }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1304,7 +1304,7 @@ void GMainWindow::OnGameListDumpRomFS(u64 program_id, const std::string& game_pa
     FileSys::VirtualFile romfs;
 
     if (*romfs_title_id == program_id) {
-        u64 ivfc_offset = loader->ReadRomFSIVFCOffset();
+        const u64 ivfc_offset = loader->ReadRomFSIVFCOffset();
         FileSys::PatchManager pm{program_id};
         romfs = pm.PatchRomFS(file, ivfc_offset, FileSys::ContentRecordType::Program);
     } else {


### PR DESCRIPTION
Patch the RomFS with the selected updates before dumping. Previously the resulting RomFS only contained data from the original title.

To dump the RomFS without updates the user can disable the update under Properties before choosing Dump RomFS.