### PR TITLE
physical_core: Make use of std::make_unique instead of std::make_shared in ctor

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -185,10 +185,9 @@ void ARM_Dynarmic_64::Step() {
 
 ARM_Dynarmic_64::ARM_Dynarmic_64(System& system, ExclusiveMonitor& exclusive_monitor,
                                  std::size_t core_index)
-    : ARM_Interface{system},
-      cb(std::make_unique<DynarmicCallbacks64>(*this)), inner_unicorn{system},
-      core_index{core_index}, exclusive_monitor{
-                                  dynamic_cast<DynarmicExclusiveMonitor&>(exclusive_monitor)} {}
+    : ARM_Interface{system}, cb(std::make_unique<DynarmicCallbacks64>(*this)),
+      inner_unicorn{system, ARM_Unicorn::Arch::AArch64}, core_index{core_index},
+      exclusive_monitor{dynamic_cast<DynarmicExclusiveMonitor&>(exclusive_monitor)} {}
 
 ARM_Dynarmic_64::~ARM_Dynarmic_64() = default;
 

--- a/src/core/arm/unicorn/arm_unicorn.cpp
+++ b/src/core/arm/unicorn/arm_unicorn.cpp
@@ -62,8 +62,9 @@ static bool UnmappedMemoryHook(uc_engine* uc, uc_mem_type type, u64 addr, int si
     return false;
 }
 
-ARM_Unicorn::ARM_Unicorn(System& system) : ARM_Interface{system} {
-    CHECKED(uc_open(UC_ARCH_ARM64, UC_MODE_ARM, &uc));
+ARM_Unicorn::ARM_Unicorn(System& system, Arch architecture) : ARM_Interface{system} {
+    const auto arch = architecture == Arch::AArch32 ? UC_ARCH_ARM : UC_ARCH_ARM64;
+    CHECKED(uc_open(arch, UC_MODE_ARM, &uc));
 
     auto fpv = 3 << 20;
     CHECKED(uc_reg_write(uc, UC_ARM64_REG_CPACR_EL1, &fpv));

--- a/src/core/arm/unicorn/arm_unicorn.h
+++ b/src/core/arm/unicorn/arm_unicorn.h
@@ -15,7 +15,12 @@ class System;
 
 class ARM_Unicorn final : public ARM_Interface {
 public:
-    explicit ARM_Unicorn(System& system);
+    enum class Arch {
+        AArch32, // 32-bit ARM
+        AArch64, // 64-bit ARM
+    };
+
+    explicit ARM_Unicorn(System& system, Arch architecture);
     ~ARM_Unicorn() override;
 
     void SetPC(u64 pc) override;

--- a/src/core/hle/kernel/physical_core.cpp
+++ b/src/core/hle/kernel/physical_core.cpp
@@ -27,7 +27,9 @@ PhysicalCore::PhysicalCore(Core::System& system, std::size_t id,
         std::make_unique<Core::ARM_Dynarmic_64>(system, exclusive_monitor, core_index);
 
 #else
-    arm_interface = std::make_shared<Core::ARM_Unicorn>(system);
+    using Core::ARM_Unicorn;
+    arm_interface_32 = std::make_unique<ARM_Unicorn>(system, ARM_Unicorn::Arch::AArch32);
+    arm_interface_64 = std::make_unique<ARM_Unicorn>(system, ARM_Unicorn::Arch::AArch64);
     LOG_WARNING(Core, "CPU JIT requested, but Dynarmic not available");
 #endif
 


### PR DESCRIPTION
Allows this code to compile successfully on non x86-64 architectures.

Fixes issue #3782 