### PR TITLE
cmake: Look for newer boost library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,9 +118,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 # System imported libraries
 # ======================
 
-find_package(Boost 1.66.0 QUIET)
+find_package(Boost 1.71.0 QUIET)
 if (NOT Boost_FOUND)
-    message(STATUS "Boost 1.66.0 or newer not found, falling back to externals")
+    message(STATUS "Boost 1.71.0 or newer not found, falling back to externals")
 
     set(BOOST_ROOT "${PROJECT_SOURCE_DIR}/externals/boost")
     set(Boost_NO_SYSTEM_PATHS OFF)


### PR DESCRIPTION
`boost::container::static_vector_options` has found its way into the master branch.
From what I can tell it didn't become a thing in libboost until version [1.71](https://www.boost.org/doc/libs/1_71_0/doc/html/boost/container/static_vector_options.html).
Page does not exist in [version 1.70's documentation](https://www.boost.org/doc/libs/1_70_0/doc/html/boost/container/static_vector_options.html).

This new requirement should probably be reflected in CMakeLists.txt