### PR TITLE
GPU: More optimizations to GPU Command List Processing and DMA Copy Optimizations

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(video_core STATIC
     dma_pusher.h
     engines/const_buffer_engine_interface.h
     engines/const_buffer_info.h
+    engines/engine_interface.h
     engines/engine_upload.cpp
     engines/engine_upload.h
     engines/fermi_2d.cpp

--- a/src/video_core/dma_pusher.h
+++ b/src/video_core/dma_pusher.h
@@ -4,11 +4,13 @@
 
 #pragma once
 
+#include <array>
 #include <vector>
 #include <queue>
 
 #include "common/bit_field.h"
 #include "common/common_types.h"
+#include "video_core/engines/engine_interface.h"
 
 namespace Core {
 class System;
@@ -69,7 +71,13 @@ public:
 
     void DispatchCalls();
 
+    void BindSubchannel(Tegra::Engines::EngineInterface* engine, u32 subchannel_id) {
+        subchannels[subchannel_id] = engine;
+    }
+
 private:
+    static constexpr u32 non_puller_methods = 0x40;
+    static constexpr u32 max_subchannels = 8;
     bool Step();
 
     void SetState(const CommandHeader& command_header);
@@ -88,6 +96,7 @@ private:
         u32 method_count;      ///< Current method count
         u32 length_pending;    ///< Large NI command length pending
         bool non_incrementing; ///< Current command's NI flag
+        bool is_last_call;
     };
 
     DmaState dma_state{};
@@ -95,6 +104,8 @@ private:
 
     GPUVAddr dma_mget{};  ///< main pushbuffer last read address
     bool ib_enable{true}; ///< IB mode enabled
+
+    std::array<Tegra::Engines::EngineInterface*, max_subchannels> subchannels{};
 
     GPU& gpu;
     Core::System& system;

--- a/src/video_core/engines/engine_interface.h
+++ b/src/video_core/engines/engine_interface.h
@@ -15,7 +15,8 @@ public:
     virtual void CallMethod(u32 method, u32 method_argument, bool is_last_call) = 0;
 
     /// Write multiple values to the register identified by method.
-    virtual void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending) = 0;
+    virtual void CallMultiMethod(u32 method, const u32* base_start, u32 amount,
+                                 u32 methods_pending) = 0;
 };
 
-}
+} // namespace Tegra::Engines

--- a/src/video_core/engines/engine_interface.h
+++ b/src/video_core/engines/engine_interface.h
@@ -1,0 +1,21 @@
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <type_traits>
+#include "common/common_types.h"
+
+namespace Tegra::Engines {
+
+class EngineInterface {
+public:
+    /// Write the value to the register identified by method.
+    virtual void CallMethod(u32 method, u32 method_argument, bool is_last_call) = 0;
+
+    /// Write multiple values to the register identified by method.
+    virtual void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending) = 0;
+};
+
+}

--- a/src/video_core/engines/fermi_2d.cpp
+++ b/src/video_core/engines/fermi_2d.cpp
@@ -12,13 +12,13 @@ namespace Tegra::Engines {
 
 Fermi2D::Fermi2D(VideoCore::RasterizerInterface& rasterizer) : rasterizer{rasterizer} {}
 
-void Fermi2D::CallMethod(const GPU::MethodCall& method_call) {
-    ASSERT_MSG(method_call.method < Regs::NUM_REGS,
+void Fermi2D::CallMethod(u32 method, u32 method_argument, bool is_last_call) {
+    ASSERT_MSG(method < Regs::NUM_REGS,
                "Invalid Fermi2D register, increase the size of the Regs structure");
 
-    regs.reg_array[method_call.method] = method_call.argument;
+    regs.reg_array[method] = method_argument;
 
-    switch (method_call.method) {
+    switch (method) {
     // Trigger the surface copy on the last register write. This is blit_src_y, but this is 64-bit,
     // so trigger on the second 32-bit write.
     case FERMI2D_REG_INDEX(blit_src_y) + 1: {
@@ -30,7 +30,7 @@ void Fermi2D::CallMethod(const GPU::MethodCall& method_call) {
 
 void Fermi2D::CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending) {
     for (std::size_t i = 0; i < amount; i++) {
-        CallMethod({method, base_start[i], 0, methods_pending - static_cast<u32>(i)});
+        CallMethod(method, base_start[i], methods_pending - static_cast<u32>(i) <= 1);
     }
 }
 

--- a/src/video_core/engines/fermi_2d.h
+++ b/src/video_core/engines/fermi_2d.h
@@ -41,7 +41,8 @@ public:
     void CallMethod(u32 method, u32 method_argument, bool is_last_call) override;
 
     /// Write multiple values to the register identified by method.
-    void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending) override;
+    void CallMultiMethod(u32 method, const u32* base_start, u32 amount,
+                         u32 methods_pending) override;
 
     enum class Origin : u32 {
         Center = 0,

--- a/src/video_core/engines/fermi_2d.h
+++ b/src/video_core/engines/fermi_2d.h
@@ -10,6 +10,7 @@
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/math_util.h"
+#include "video_core/engines/engine_interface.h"
 #include "video_core/gpu.h"
 
 namespace Tegra {
@@ -31,16 +32,16 @@ namespace Tegra::Engines {
 #define FERMI2D_REG_INDEX(field_name)                                                              \
     (offsetof(Tegra::Engines::Fermi2D::Regs, field_name) / sizeof(u32))
 
-class Fermi2D final {
+class Fermi2D final : public EngineInterface {
 public:
     explicit Fermi2D(VideoCore::RasterizerInterface& rasterizer);
     ~Fermi2D() = default;
 
     /// Write the value to the register identified by method.
-    void CallMethod(const GPU::MethodCall& method_call);
+    void CallMethod(u32 method, u32 method_argument, bool is_last_call) override;
 
     /// Write multiple values to the register identified by method.
-    void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending);
+    void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending) override;
 
     enum class Origin : u32 {
         Center = 0,

--- a/src/video_core/engines/kepler_compute.cpp
+++ b/src/video_core/engines/kepler_compute.cpp
@@ -24,7 +24,7 @@ KeplerCompute::KeplerCompute(Core::System& system, VideoCore::RasterizerInterfac
 
 KeplerCompute::~KeplerCompute() = default;
 
-void KeplerCompute::CallMethod(u32 method, u32 method_argument, bool is_last_call)  {
+void KeplerCompute::CallMethod(u32 method, u32 method_argument, bool is_last_call) {
     ASSERT_MSG(method < Regs::NUM_REGS,
                "Invalid KeplerCompute register, increase the size of the Regs structure");
 

--- a/src/video_core/engines/kepler_compute.cpp
+++ b/src/video_core/engines/kepler_compute.cpp
@@ -24,20 +24,19 @@ KeplerCompute::KeplerCompute(Core::System& system, VideoCore::RasterizerInterfac
 
 KeplerCompute::~KeplerCompute() = default;
 
-void KeplerCompute::CallMethod(const GPU::MethodCall& method_call) {
-    ASSERT_MSG(method_call.method < Regs::NUM_REGS,
+void KeplerCompute::CallMethod(u32 method, u32 method_argument, bool is_last_call)  {
+    ASSERT_MSG(method < Regs::NUM_REGS,
                "Invalid KeplerCompute register, increase the size of the Regs structure");
 
-    regs.reg_array[method_call.method] = method_call.argument;
+    regs.reg_array[method] = method_argument;
 
-    switch (method_call.method) {
+    switch (method) {
     case KEPLER_COMPUTE_REG_INDEX(exec_upload): {
         upload_state.ProcessExec(regs.exec_upload.linear != 0);
         break;
     }
     case KEPLER_COMPUTE_REG_INDEX(data_upload): {
-        const bool is_last_call = method_call.IsLastCall();
-        upload_state.ProcessData(method_call.argument, is_last_call);
+        upload_state.ProcessData(method_argument, is_last_call);
         if (is_last_call) {
             system.GPU().Maxwell3D().OnMemoryWrite();
         }
@@ -54,7 +53,7 @@ void KeplerCompute::CallMethod(const GPU::MethodCall& method_call) {
 void KeplerCompute::CallMultiMethod(u32 method, const u32* base_start, u32 amount,
                                     u32 methods_pending) {
     for (std::size_t i = 0; i < amount; i++) {
-        CallMethod({method, base_start[i], 0, methods_pending - static_cast<u32>(i)});
+        CallMethod(method, base_start[i], methods_pending - static_cast<u32>(i) <= 1);
     }
 }
 

--- a/src/video_core/engines/kepler_compute.h
+++ b/src/video_core/engines/kepler_compute.h
@@ -204,7 +204,8 @@ public:
     void CallMethod(u32 method, u32 method_argument, bool is_last_call) override;
 
     /// Write multiple values to the register identified by method.
-    void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending) override;
+    void CallMultiMethod(u32 method, const u32* base_start, u32 amount,
+                         u32 methods_pending) override;
 
     Texture::FullTextureInfo GetTexture(std::size_t offset) const;
 

--- a/src/video_core/engines/kepler_compute.h
+++ b/src/video_core/engines/kepler_compute.h
@@ -11,6 +11,7 @@
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "video_core/engines/const_buffer_engine_interface.h"
+#include "video_core/engines/engine_interface.h"
 #include "video_core/engines/engine_upload.h"
 #include "video_core/engines/shader_type.h"
 #include "video_core/gpu.h"
@@ -39,7 +40,7 @@ namespace Tegra::Engines {
 #define KEPLER_COMPUTE_REG_INDEX(field_name)                                                       \
     (offsetof(Tegra::Engines::KeplerCompute::Regs, field_name) / sizeof(u32))
 
-class KeplerCompute final : public ConstBufferEngineInterface {
+class KeplerCompute final : public ConstBufferEngineInterface, public EngineInterface {
 public:
     explicit KeplerCompute(Core::System& system, VideoCore::RasterizerInterface& rasterizer,
                            MemoryManager& memory_manager);
@@ -200,10 +201,10 @@ public:
                   "KeplerCompute LaunchParams has wrong size");
 
     /// Write the value to the register identified by method.
-    void CallMethod(const GPU::MethodCall& method_call);
+    void CallMethod(u32 method, u32 method_argument, bool is_last_call) override;
 
     /// Write multiple values to the register identified by method.
-    void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending);
+    void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending) override;
 
     Texture::FullTextureInfo GetTexture(std::size_t offset) const;
 

--- a/src/video_core/engines/kepler_memory.h
+++ b/src/video_core/engines/kepler_memory.h
@@ -42,7 +42,8 @@ public:
     void CallMethod(u32 method, u32 method_argument, bool is_last_call) override;
 
     /// Write multiple values to the register identified by method.
-    void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending) override;
+    void CallMultiMethod(u32 method, const u32* base_start, u32 amount,
+                         u32 methods_pending) override;
 
     struct Regs {
         static constexpr size_t NUM_REGS = 0x7F;

--- a/src/video_core/engines/kepler_memory.h
+++ b/src/video_core/engines/kepler_memory.h
@@ -10,6 +10,7 @@
 #include "common/bit_field.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
+#include "video_core/engines/engine_interface.h"
 #include "video_core/engines/engine_upload.h"
 #include "video_core/gpu.h"
 
@@ -32,16 +33,16 @@ namespace Tegra::Engines {
 #define KEPLERMEMORY_REG_INDEX(field_name)                                                         \
     (offsetof(Tegra::Engines::KeplerMemory::Regs, field_name) / sizeof(u32))
 
-class KeplerMemory final {
+class KeplerMemory final : public EngineInterface {
 public:
     KeplerMemory(Core::System& system, MemoryManager& memory_manager);
     ~KeplerMemory();
 
     /// Write the value to the register identified by method.
-    void CallMethod(const GPU::MethodCall& method_call);
+    void CallMethod(u32 method, u32 method_argument, bool is_last_call) override;
 
     /// Write multiple values to the register identified by method.
-    void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending);
+    void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending) override;
 
     struct Regs {
         static constexpr size_t NUM_REGS = 0x7F;

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -125,12 +125,10 @@ void Maxwell3D::CallMacroMethod(u32 method, std::size_t num_parameters, const u3
     }
 }
 
-void Maxwell3D::CallMethod(const GPU::MethodCall& method_call) {
-    const u32 method = method_call.method;
-
+void Maxwell3D::CallMethod(u32 method, u32 method_argument, bool is_last_call) {
     if (method == cb_data_state.current) {
-        regs.reg_array[method] = method_call.argument;
-        ProcessCBData(method_call.argument);
+        regs.reg_array[method] = method_argument;
+        ProcessCBData(method_argument);
         return;
     } else if (cb_data_state.current != null_cb_data) {
         FinishCBData();
@@ -153,10 +151,10 @@ void Maxwell3D::CallMethod(const GPU::MethodCall& method_call) {
             executing_macro = method;
         }
 
-        macro_params.push_back(method_call.argument);
+        macro_params.push_back(method_argument);
 
         // Call the macro when there are no more parameters in the command buffer
-        if (method_call.IsLastCall()) {
+        if (is_last_call) {
             CallMacroMethod(executing_macro, macro_params.size(), macro_params.data());
             macro_params.clear();
         }
@@ -166,7 +164,7 @@ void Maxwell3D::CallMethod(const GPU::MethodCall& method_call) {
     ASSERT_MSG(method < Regs::NUM_REGS,
                "Invalid Maxwell3D register, increase the size of the Regs structure");
 
-    u32 arg = method_call.argument;
+    u32 arg = method_argument;
     // Keep track of the register value in shadow_state when requested.
     if (shadow_state.shadow_ram_control == Regs::ShadowRamControl::Track ||
         shadow_state.shadow_ram_control == Regs::ShadowRamControl::TrackWithFilter) {
@@ -185,7 +183,7 @@ void Maxwell3D::CallMethod(const GPU::MethodCall& method_call) {
 
     switch (method) {
     case MAXWELL3D_REG_INDEX(shadow_ram_control): {
-        shadow_state.shadow_ram_control = static_cast<Regs::ShadowRamControl>(method_call.argument);
+        shadow_state.shadow_ram_control = static_cast<Regs::ShadowRamControl>(method_argument);
         break;
     }
     case MAXWELL3D_REG_INDEX(macros.data): {
@@ -268,7 +266,6 @@ void Maxwell3D::CallMethod(const GPU::MethodCall& method_call) {
         break;
     }
     case MAXWELL3D_REG_INDEX(data_upload): {
-        const bool is_last_call = method_call.IsLastCall();
         upload_state.ProcessData(arg, is_last_call);
         if (is_last_call) {
             OnMemoryWrite();
@@ -326,7 +323,7 @@ void Maxwell3D::CallMultiMethod(u32 method, const u32* base_start, u32 amount,
     }
     default: {
         for (std::size_t i = 0; i < amount; i++) {
-            CallMethod({method, base_start[i], 0, methods_pending - static_cast<u32>(i)});
+            CallMethod(method, base_start[i], methods_pending - static_cast<u32>(i) <= 1);
         }
     }
     }
@@ -356,16 +353,15 @@ void Maxwell3D::StepInstance(const MMEDrawMode expected_mode, const u32 count) {
     StepInstance(expected_mode, count);
 }
 
-void Maxwell3D::CallMethodFromMME(const GPU::MethodCall& method_call) {
-    const u32 method = method_call.method;
+void Maxwell3D::CallMethodFromMME(u32 method, u32 method_argument) {
     if (mme_inline[method]) {
-        regs.reg_array[method] = method_call.argument;
+        regs.reg_array[method] = method_argument;
         if (method == MAXWELL3D_REG_INDEX(vertex_buffer.count) ||
             method == MAXWELL3D_REG_INDEX(index_array.count)) {
             const MMEDrawMode expected_mode = method == MAXWELL3D_REG_INDEX(vertex_buffer.count)
                                                   ? MMEDrawMode::Array
                                                   : MMEDrawMode::Indexed;
-            StepInstance(expected_mode, method_call.argument);
+            StepInstance(expected_mode, method_argument);
         } else if (method == MAXWELL3D_REG_INDEX(draw.vertex_begin_gl)) {
             mme_draw.instance_mode =
                 (regs.draw.instance_next != 0) || (regs.draw.instance_cont != 0);
@@ -377,7 +373,7 @@ void Maxwell3D::CallMethodFromMME(const GPU::MethodCall& method_call) {
         if (mme_draw.current_mode != MMEDrawMode::Undefined) {
             FlushMMEInlineDraw();
         }
-        CallMethod(method_call);
+        CallMethod(method, method_argument, true);
     }
 }
 

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1361,7 +1361,8 @@ public:
     void CallMethod(u32 method, u32 method_argument, bool is_last_call) override;
 
     /// Write multiple values to the register identified by method.
-    void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending) override;
+    void CallMultiMethod(u32 method, const u32* base_start, u32 amount,
+                         u32 methods_pending) override;
 
     /// Write the value to the register identified by method.
     void CallMethodFromMME(u32 method, u32 method_argument);

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -19,6 +19,7 @@
 #include "common/math_util.h"
 #include "video_core/engines/const_buffer_engine_interface.h"
 #include "video_core/engines/const_buffer_info.h"
+#include "video_core/engines/engine_interface.h"
 #include "video_core/engines/engine_upload.h"
 #include "video_core/engines/shader_type.h"
 #include "video_core/gpu.h"
@@ -48,7 +49,7 @@ namespace Tegra::Engines {
 #define MAXWELL3D_REG_INDEX(field_name)                                                            \
     (offsetof(Tegra::Engines::Maxwell3D::Regs, field_name) / sizeof(u32))
 
-class Maxwell3D final : public ConstBufferEngineInterface {
+class Maxwell3D final : public ConstBufferEngineInterface, public EngineInterface {
 public:
     explicit Maxwell3D(Core::System& system, VideoCore::RasterizerInterface& rasterizer,
                        MemoryManager& memory_manager);
@@ -1357,13 +1358,13 @@ public:
     u32 GetRegisterValue(u32 method) const;
 
     /// Write the value to the register identified by method.
-    void CallMethod(const GPU::MethodCall& method_call);
+    void CallMethod(u32 method, u32 method_argument, bool is_last_call) override;
 
     /// Write multiple values to the register identified by method.
-    void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending);
+    void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending) override;
 
     /// Write the value to the register identified by method.
-    void CallMethodFromMME(const GPU::MethodCall& method_call);
+    void CallMethodFromMME(u32 method, u32 method_argument);
 
     void FlushMMEInlineDraw();
 

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -17,16 +17,16 @@ namespace Tegra::Engines {
 MaxwellDMA::MaxwellDMA(Core::System& system, MemoryManager& memory_manager)
     : system{system}, memory_manager{memory_manager} {}
 
-void MaxwellDMA::CallMethod(const GPU::MethodCall& method_call) {
-    ASSERT_MSG(method_call.method < Regs::NUM_REGS,
+void MaxwellDMA::CallMethod(u32 method, u32 method_argument, bool is_last_call) {
+    ASSERT_MSG(method < Regs::NUM_REGS,
                "Invalid MaxwellDMA register, increase the size of the Regs structure");
 
-    regs.reg_array[method_call.method] = method_call.argument;
+    regs.reg_array[method] = method_argument;
 
 #define MAXWELLDMA_REG_INDEX(field_name)                                                           \
     (offsetof(Tegra::Engines::MaxwellDMA::Regs, field_name) / sizeof(u32))
 
-    switch (method_call.method) {
+    switch (method) {
     case MAXWELLDMA_REG_INDEX(exec): {
         HandleCopy();
         break;
@@ -39,7 +39,7 @@ void MaxwellDMA::CallMethod(const GPU::MethodCall& method_call) {
 void MaxwellDMA::CallMultiMethod(u32 method, const u32* base_start, u32 amount,
                                  u32 methods_pending) {
     for (std::size_t i = 0; i < amount; i++) {
-        CallMethod({method, base_start[i], 0, methods_pending - static_cast<u32>(i)});
+        CallMethod(method, base_start[i], methods_pending - static_cast<u32>(i) <= 1);
     }
 }
 

--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -37,7 +37,8 @@ public:
     void CallMethod(u32 method, u32 method_argument, bool is_last_call) override;
 
     /// Write multiple values to the register identified by method.
-    void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending) override;
+    void CallMultiMethod(u32 method, const u32* base_start, u32 amount,
+                         u32 methods_pending) override;
 
     struct Regs {
         static constexpr std::size_t NUM_REGS = 0x1D6;

--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -10,6 +10,7 @@
 #include "common/bit_field.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
+#include "video_core/engines/engine_interface.h"
 #include "video_core/gpu.h"
 
 namespace Core {
@@ -27,16 +28,16 @@ namespace Tegra::Engines {
  * https://github.com/envytools/envytools/blob/master/rnndb/fifo/gk104_copy.xml
  */
 
-class MaxwellDMA final {
+class MaxwellDMA final : public EngineInterface {
 public:
     explicit MaxwellDMA(Core::System& system, MemoryManager& memory_manager);
     ~MaxwellDMA() = default;
 
     /// Write the value to the register identified by method.
-    void CallMethod(const GPU::MethodCall& method_call);
+    void CallMethod(u32 method, u32 method_argument, bool is_last_call) override;
 
     /// Write multiple values to the register identified by method.
-    void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending);
+    void CallMultiMethod(u32 method, const u32* base_start, u32 amount, u32 methods_pending) override;
 
     struct Regs {
         static constexpr std::size_t NUM_REGS = 0x1D6;

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -305,13 +305,15 @@ void GPU::CallEngineMethod(const MethodCall& method_call) {
         maxwell_3d->CallMethod(method_call.method, method_call.argument, method_call.IsLastCall());
         break;
     case EngineID::KEPLER_COMPUTE_B:
-        kepler_compute->CallMethod(method_call.method, method_call.argument, method_call.IsLastCall());
+        kepler_compute->CallMethod(method_call.method, method_call.argument,
+                                   method_call.IsLastCall());
         break;
     case EngineID::MAXWELL_DMA_COPY_A:
         maxwell_dma->CallMethod(method_call.method, method_call.argument, method_call.IsLastCall());
         break;
     case EngineID::KEPLER_INLINE_TO_MEMORY_B:
-        kepler_memory->CallMethod(method_call.method, method_call.argument, method_call.IsLastCall());
+        kepler_memory->CallMethod(method_call.method, method_call.argument,
+                                  method_call.IsLastCall());
         break;
     default:
         UNIMPLEMENTED_MSG("Unimplemented engine");

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -299,19 +299,19 @@ void GPU::CallEngineMethod(const MethodCall& method_call) {
 
     switch (engine) {
     case EngineID::FERMI_TWOD_A:
-        fermi_2d->CallMethod(method_call);
+        fermi_2d->CallMethod(method_call.method, method_call.argument, method_call.IsLastCall());
         break;
     case EngineID::MAXWELL_B:
-        maxwell_3d->CallMethod(method_call);
+        maxwell_3d->CallMethod(method_call.method, method_call.argument, method_call.IsLastCall());
         break;
     case EngineID::KEPLER_COMPUTE_B:
-        kepler_compute->CallMethod(method_call);
+        kepler_compute->CallMethod(method_call.method, method_call.argument, method_call.IsLastCall());
         break;
     case EngineID::MAXWELL_DMA_COPY_A:
-        maxwell_dma->CallMethod(method_call);
+        maxwell_dma->CallMethod(method_call.method, method_call.argument, method_call.IsLastCall());
         break;
     case EngineID::KEPLER_INLINE_TO_MEMORY_B:
-        kepler_memory->CallMethod(method_call);
+        kepler_memory->CallMethod(method_call.method, method_call.argument, method_call.IsLastCall());
         break;
     default:
         UNIMPLEMENTED_MSG("Unimplemented engine");

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -349,7 +349,7 @@ void GPU::ProcessBindMethod(const MethodCall& method_call) {
     // Bind the current subchannel to the desired engine id.
     LOG_DEBUG(HW_GPU, "Binding subchannel {} to engine {}", method_call.subchannel,
               method_call.argument);
-    auto engine_id = static_cast<EngineID>(method_call.argument);
+    const auto engine_id = static_cast<EngineID>(method_call.argument);
     bound_engines[method_call.subchannel] = static_cast<EngineID>(engine_id);
     switch (engine_id) {
     case EngineID::FERMI_TWOD_A:

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -368,7 +368,7 @@ void GPU::ProcessBindMethod(const MethodCall& method_call) {
         dma_pusher->BindSubchannel(kepler_memory.get(), method_call.subchannel);
         break;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented engine");
+        UNIMPLEMENTED_MSG("Unimplemented engine {:04X}", static_cast<u32>(engine_id));
     }
 }
 

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -347,7 +347,27 @@ void GPU::ProcessBindMethod(const MethodCall& method_call) {
     // Bind the current subchannel to the desired engine id.
     LOG_DEBUG(HW_GPU, "Binding subchannel {} to engine {}", method_call.subchannel,
               method_call.argument);
-    bound_engines[method_call.subchannel] = static_cast<EngineID>(method_call.argument);
+    auto engine_id = static_cast<EngineID>(method_call.argument);
+    bound_engines[method_call.subchannel] = static_cast<EngineID>(engine_id);
+    switch (engine_id) {
+    case EngineID::FERMI_TWOD_A:
+        dma_pusher->BindSubchannel(fermi_2d.get(), method_call.subchannel);
+        break;
+    case EngineID::MAXWELL_B:
+        dma_pusher->BindSubchannel(maxwell_3d.get(), method_call.subchannel);
+        break;
+    case EngineID::KEPLER_COMPUTE_B:
+        dma_pusher->BindSubchannel(kepler_compute.get(), method_call.subchannel);
+        break;
+    case EngineID::MAXWELL_DMA_COPY_A:
+        dma_pusher->BindSubchannel(maxwell_dma.get(), method_call.subchannel);
+        break;
+    case EngineID::KEPLER_INLINE_TO_MEMORY_B:
+        dma_pusher->BindSubchannel(kepler_memory.get(), method_call.subchannel);
+        break;
+    default:
+        UNIMPLEMENTED_MSG("Unimplemented engine");
+    }
 }
 
 void GPU::ProcessSemaphoreTriggerMethod() {

--- a/src/video_core/macro_interpreter.cpp
+++ b/src/video_core/macro_interpreter.cpp
@@ -328,7 +328,7 @@ void MacroInterpreter::SetMethodAddress(u32 address) {
 }
 
 void MacroInterpreter::Send(u32 value) {
-    maxwell3d.CallMethodFromMME({method_address.address, value});
+    maxwell3d.CallMethodFromMME(method_address.address, value);
     // Increment the method address by the method increment.
     method_address.address.Assign(method_address.address.Value() +
                                   method_address.increment.Value());

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -382,4 +382,18 @@ std::size_t CalculateSize(bool tiled, u32 bytes_per_pixel, u32 width, u32 height
     }
 }
 
+u64 GetGOBOffset(u32 width, u32 height, u32 dst_x, u32 dst_y, u32 block_height,
+                 u32 bytes_per_pixel) {
+    auto div_ceil = [](const u32 x, const u32 y) { return ((x + y - 1) / y); };
+    const u32 gobs_in_block = 1 << block_height;
+    const u32 y_blocks = gob_size_y << block_height;
+    const u32 x_per_gob = gob_size_x / bytes_per_pixel;
+    const u32 x_blocks = div_ceil(width, x_per_gob);
+    const u32 block_size = gob_size * gobs_in_block;
+    const u32 stride = block_size * x_blocks;
+    const u32 base = (dst_y / y_blocks) * stride + (dst_x / x_per_gob) * block_size;
+    const u32 relative_y = dst_y % y_blocks;
+    return base + (relative_y / gob_size_y) * gob_size;
+}
+
 } // namespace Tegra::Texture

--- a/src/video_core/textures/decoders.h
+++ b/src/video_core/textures/decoders.h
@@ -59,6 +59,7 @@ void UnswizzleSubrect(u32 subrect_width, u32 subrect_height, u32 dest_pitch, u32
 void SwizzleKepler(u32 width, u32 height, u32 dst_x, u32 dst_y, u32 block_height,
                    std::size_t copy_size, const u8* source_data, u8* swizzle_data);
 
+/// Obtains the offset of the gob for positions 'dst_x' & 'dst_y'
 u64 GetGOBOffset(u32 width, u32 height, u32 dst_x, u32 dst_y, u32 block_height,
                  u32 bytes_per_pixel);
 

--- a/src/video_core/textures/decoders.h
+++ b/src/video_core/textures/decoders.h
@@ -59,4 +59,7 @@ void UnswizzleSubrect(u32 subrect_width, u32 subrect_height, u32 dest_pitch, u32
 void SwizzleKepler(u32 width, u32 height, u32 dst_x, u32 dst_y, u32 block_height,
                    std::size_t copy_size, const u8* source_data, u8* swizzle_data);
 
+u64 GetGOBOffset(u32 width, u32 height, u32 dst_x, u32 dst_y, u32 block_height,
+                 u32 bytes_per_pixel);
+
 } // namespace Tegra::Texture


### PR DESCRIPTION
This PR aims to delegate engine calling to the DMA pusher, thus reducing spaghetti code. At the same time we are adding an optimized path for small DMA copies that avoid reading the whole texture but just tiny bits of it.

This optimizations greatly benefit Pokemon Sword & Shield on Cities and some routes.