### PR TITLE
Don't fail silently for vi, sm, set and ns services

### DIFF
--- a/src/core/hle/service/ns/ns.cpp
+++ b/src/core/hle/service/ns/ns.cpp
@@ -371,10 +371,15 @@ ResultVal<u8> IApplicationManagerInterface::GetApplicationDesiredLanguage(
     // Convert to application language, get priority list
     const auto application_language = ConvertToApplicationLanguage(language_code);
     if (application_language == std::nullopt) {
+        LOG_ERROR(Service_NS, "Could not convert application language! language_code={}",
+                  language_code);
         return ERR_APPLICATION_LANGUAGE_NOT_FOUND;
     }
     const auto priority_list = GetApplicationLanguagePriorityList(*application_language);
     if (!priority_list) {
+        LOG_ERROR(Service_NS,
+                  "Could not find application language priorities! application_language={}",
+                  *application_language);
         return ERR_APPLICATION_LANGUAGE_NOT_FOUND;
     }
 
@@ -386,6 +391,8 @@ ResultVal<u8> IApplicationManagerInterface::GetApplicationDesiredLanguage(
         }
     }
 
+    LOG_ERROR(Service_NS, "Could not find a valid language! supported_languages={:08X}",
+              supported_languages);
     return ERR_APPLICATION_LANGUAGE_NOT_FOUND;
 }
 
@@ -410,6 +417,7 @@ ResultVal<u64> IApplicationManagerInterface::ConvertApplicationLanguageToLanguag
     const auto language_code =
         ConvertToLanguageCode(static_cast<ApplicationLanguage>(application_language));
     if (language_code == std::nullopt) {
+        LOG_ERROR(Service_NS, "Language not found! application_language={}", application_language);
         return ERR_APPLICATION_LANGUAGE_NOT_FOUND;
     }
 

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -67,6 +67,7 @@ void SET::MakeLanguageCode(Kernel::HLERequestContext& ctx) {
     const auto index = rp.Pop<u32>();
 
     if (index >= available_language_codes.size()) {
+        LOG_ERROR(Service_SET, "Invalid language code index! index={}", index);
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(ERR_INVALID_LANGUAGE);
         return;

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -28,9 +28,11 @@ void ServiceManager::InvokeControlRequest(Kernel::HLERequestContext& context) {
 
 static ResultCode ValidateServiceName(const std::string& name) {
     if (name.size() <= 0 || name.size() > 8) {
+        LOG_ERROR(Service_SM, "Invalid service name! service={}", name);
         return ERR_INVALID_NAME;
     }
     if (name.find('\0') != std::string::npos) {
+        LOG_ERROR(Service_SM, "A non null terminated service was passed");
         return ERR_INVALID_NAME;
     }
     return RESULT_SUCCESS;
@@ -51,8 +53,10 @@ ResultVal<std::shared_ptr<Kernel::ServerPort>> ServiceManager::RegisterService(
 
     CASCADE_CODE(ValidateServiceName(name));
 
-    if (registered_services.find(name) != registered_services.end())
+    if (registered_services.find(name) != registered_services.end()) {
+        LOG_ERROR(Service_SM, "Service is already registered! service={}", name);
         return ERR_ALREADY_REGISTERED;
+    }
 
     auto& kernel = Core::System::GetInstance().Kernel();
     auto [server_port, client_port] =
@@ -66,9 +70,10 @@ ResultCode ServiceManager::UnregisterService(const std::string& name) {
     CASCADE_CODE(ValidateServiceName(name));
 
     const auto iter = registered_services.find(name);
-    if (iter == registered_services.end())
+    if (iter == registered_services.end()) {
+        LOG_ERROR(Service_SM, "Server is not registered! service={}", name);
         return ERR_SERVICE_NOT_REGISTERED;
-
+    }
     registered_services.erase(iter);
     return RESULT_SUCCESS;
 }
@@ -79,6 +84,7 @@ ResultVal<std::shared_ptr<Kernel::ClientPort>> ServiceManager::GetServicePort(
     CASCADE_CODE(ValidateServiceName(name));
     auto it = registered_services.find(name);
     if (it == registered_services.end()) {
+        LOG_ERROR(Service_SM, "Server is not registered! service={}", name);
         return ERR_SERVICE_NOT_REGISTERED;
     }
 

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -867,6 +867,7 @@ private:
 
         const auto layer_id = nv_flinger->CreateLayer(display);
         if (!layer_id) {
+            LOG_ERROR(Service_VI, "Layer not found! display=0x{:016X}", display);
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ERR_NOT_FOUND);
             return;
@@ -983,6 +984,7 @@ private:
 
         const auto display_id = nv_flinger->OpenDisplay(name);
         if (!display_id) {
+            LOG_ERROR(Service_VI, "Display not found! display_name={}", name);
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ERR_NOT_FOUND);
             return;
@@ -1082,6 +1084,7 @@ private:
 
         const auto display_id = nv_flinger->OpenDisplay(display_name);
         if (!display_id) {
+            LOG_ERROR(Service_VI, "Layer not found! layer_id={}", layer_id);
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ERR_NOT_FOUND);
             return;
@@ -1089,6 +1092,7 @@ private:
 
         const auto buffer_queue_id = nv_flinger->FindBufferQueueId(*display_id, layer_id);
         if (!buffer_queue_id) {
+            LOG_ERROR(Service_VI, "Buffer queue id not found! display_id={}", *display_id);
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ERR_NOT_FOUND);
             return;
@@ -1124,6 +1128,7 @@ private:
 
         const auto layer_id = nv_flinger->CreateLayer(display_id);
         if (!layer_id) {
+            LOG_ERROR(Service_VI, "Layer not found! layer_id={}", *layer_id);
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ERR_NOT_FOUND);
             return;
@@ -1131,6 +1136,7 @@ private:
 
         const auto buffer_queue_id = nv_flinger->FindBufferQueueId(display_id, *layer_id);
         if (!buffer_queue_id) {
+            LOG_ERROR(Service_VI, "Buffer queue id not found! display_id={}", display_id);
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ERR_NOT_FOUND);
             return;
@@ -1161,6 +1167,7 @@ private:
 
         const auto vsync_event = nv_flinger->FindVsyncEvent(display_id);
         if (!vsync_event) {
+            LOG_ERROR(Service_VI, "Vsync event was not found for display_id={}", display_id);
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ERR_NOT_FOUND);
             return;
@@ -1201,6 +1208,7 @@ private:
         case NintendoScaleMode::PreserveAspectRatio:
             return MakeResult(ConvertedScaleMode::PreserveAspectRatio);
         default:
+            LOG_ERROR(Service_VI, "Invalid scaling mode specified, mode={}", mode);
             return ERR_OPERATION_FAILED;
         }
     }
@@ -1257,6 +1265,7 @@ void detail::GetDisplayServiceImpl(Kernel::HLERequestContext& ctx,
     const auto policy = rp.PopEnum<Policy>();
 
     if (!IsValidServiceAccess(permission, policy)) {
+        LOG_ERROR(Service_VI, "Permission denied for policy {}", static_cast<u32>(policy));
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(ERR_PERMISSION_DENIED);
         return;


### PR DESCRIPTION
Retail games rarely throw error codes. Actually logging when calls fail helps with debugging/locating more issues in a users logs.
