### PR TITLE
CoreManager: Only run Reschedule() once

### DIFF
--- a/src/core/core_manager.cpp
+++ b/src/core/core_manager.cpp
@@ -28,6 +28,8 @@ CoreManager::CoreManager(System& system, std::size_t core_index)
 CoreManager::~CoreManager() = default;
 
 void CoreManager::RunLoop(bool tight_loop) {
+    Reschedule();
+
     // If we don't have a currently active thread then don't execute instructions,
     // instead advance to the next event and try to yield to the next thread
     if (Kernel::GetCurrentThread() == nullptr) {
@@ -41,7 +43,6 @@ void CoreManager::RunLoop(bool tight_loop) {
         }
     }
 
-    Reschedule();
     core_timing.Advance();
 }
 

--- a/src/core/core_manager.cpp
+++ b/src/core/core_manager.cpp
@@ -40,7 +40,7 @@ void CoreManager::RunLoop(bool tight_loop) {
             physical_core.Step();
         }
     }
-    
+
     Reschedule();
     core_timing.Advance();
 }

--- a/src/core/core_manager.cpp
+++ b/src/core/core_manager.cpp
@@ -28,8 +28,6 @@ CoreManager::CoreManager(System& system, std::size_t core_index)
 CoreManager::~CoreManager() = default;
 
 void CoreManager::RunLoop(bool tight_loop) {
-    Reschedule();
-
     // If we don't have a currently active thread then don't execute instructions,
     // instead advance to the next event and try to yield to the next thread
     if (Kernel::GetCurrentThread() == nullptr) {
@@ -42,9 +40,9 @@ void CoreManager::RunLoop(bool tight_loop) {
             physical_core.Step();
         }
     }
-    core_timing.Advance();
-
+    
     Reschedule();
+    core_timing.Advance();
 }
 
 void CoreManager::SingleStep() {


### PR DESCRIPTION
It doesn't seem to be necessary to call it 2 times. We verified it in 6 games (SMO, SSBU, Pokemon Sword, SMM2, Tetris 99, ACNH?) using a custom build including this change with no regressions. Feel free to test it on other games, though.

This should be essentially a slight free boost in FPS.