### PR TITLE
acc: Fix InitializeApplicationInfo

### DIFF
--- a/src/core/hle/service/acc/acc.h
+++ b/src/core/hle/service/acc/acc.h
@@ -35,7 +35,7 @@ public:
         void GetProfileEditor(Kernel::HLERequestContext& ctx);
 
     private:
-        ResultCode InitializeApplicationInfoBase(u64 process_id);
+        ResultCode InitializeApplicationInfoBase();
 
         enum class ApplicationType : u32_le {
             GameCard = 0,


### PR DESCRIPTION
Originally we were popping a u64 and assuming that was the process id. Upon further examination, only a pid is sent, not a u64. As we don't multiprocess support right now, we can ignore the pid and assume it's the current process we're targeting.

Secondly, we don't seem to set a storage ID for a game if we run it from a file. Since we have no way to work out if it's a gamecard or digital game, we can assume it's a digital game