### PR TITLE
acc: Return a unique value per account for GetAccountId

### DIFF
--- a/src/common/uuid.h
+++ b/src/common/uuid.h
@@ -40,6 +40,11 @@ struct UUID {
         uuid = INVALID_UUID;
     }
 
+    // TODO(ogniK): Properly generate a Nintendo ID
+    constexpr u64 GetNintendoID() const {
+        return uuid[0];
+    }
+
     std::string Format() const;
     std::string FormatSwitch() const;
 };

--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -228,7 +228,8 @@ public:
 
 class IManagerForApplication final : public ServiceFramework<IManagerForApplication> {
 public:
-    IManagerForApplication() : ServiceFramework("IManagerForApplication") {
+    explicit IManagerForApplication(Common::UUID user_id)
+        : ServiceFramework("IManagerForApplication"), user_id(user_id) {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IManagerForApplication::CheckAvailability, "CheckAvailability"},
@@ -254,12 +255,14 @@ private:
     }
 
     void GetAccountId(Kernel::HLERequestContext& ctx) {
-        LOG_WARNING(Service_ACC, "(STUBBED) called");
-        // Should return a nintendo account ID
+        LOG_DEBUG(Service_ACC, "called");
+
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(RESULT_SUCCESS);
-        rb.PushRaw<u64>(1);
+        rb.PushRaw<u64>(user_id.GetNintendoID());
     }
+
+    Common::UUID user_id;
 };
 
 void Module::Interface::GetUserCount(Kernel::HLERequestContext& ctx) {
@@ -389,7 +392,7 @@ void Module::Interface::GetBaasAccountManagerForApplication(Kernel::HLERequestCo
     LOG_DEBUG(Service_ACC, "called");
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
-    rb.PushIpcInterface<IManagerForApplication>();
+    rb.PushIpcInterface<IManagerForApplication>(profile_manager->GetLastOpenedUser());
 }
 
 void Module::Interface::IsUserAccountSwitchLocked(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
Currently we return 1 for a users Nintendo ID. By returning just the lower part of the users UUID, we can have a unique account for each user