### PR TITLE
caps: Use strongly typed enums and add static assertions to struct sizes

### DIFF
--- a/src/core/hle/service/caps/caps.cpp
+++ b/src/core/hle/service/caps/caps.cpp
@@ -1,4 +1,4 @@
-// Copyright 2018 yuzu emulator team
+// Copyright 2018 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/hle/service/caps/caps.h
+++ b/src/core/hle/service/caps/caps.h
@@ -1,4 +1,4 @@
-// Copyright 2018 yuzu emulator team
+// Copyright 2018 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -12,73 +12,79 @@ class ServiceManager;
 
 namespace Service::Capture {
 
-enum AlbumImageOrientation {
+enum class AlbumImageOrientation {
     Orientation0 = 0,
     Orientation1 = 1,
     Orientation2 = 2,
     Orientation3 = 3,
 };
 
-enum AlbumReportOption {
+enum class AlbumReportOption {
     Disable = 0,
     Enable = 1,
 };
 
-enum ContentType : u8 {
+enum class ContentType : u8 {
     Screenshot = 0,
     Movie = 1,
     ExtraMovie = 3,
 };
 
-enum AlbumStorage : u8 {
+enum class AlbumStorage : u8 {
     NAND = 0,
     SD = 1,
 };
 
 struct AlbumFileDateTime {
-    u16 year;
-    u8 month;
-    u8 day;
-    u8 hour;
-    u8 minute;
-    u8 second;
-    u8 uid;
+    u16 year{};
+    u8 month{};
+    u8 day{};
+    u8 hour{};
+    u8 minute{};
+    u8 second{};
+    u8 uid{};
 };
+static_assert(sizeof(AlbumFileDateTime) == 0x8, "AlbumFileDateTime has incorrect size.");
 
 struct AlbumEntry {
-    u64 size;
-    u64 application_id;
-    AlbumFileDateTime datetime;
-    AlbumStorage storage;
-    ContentType content;
-    u8 padding[6];
+    u64 size{};
+    u64 application_id{};
+    AlbumFileDateTime datetime{};
+    AlbumStorage storage{};
+    ContentType content{};
+    INSERT_PADDING_BYTES(6);
 };
+static_assert(sizeof(AlbumEntry) == 0x20, "AlbumEntry has incorrect size.");
 
 struct AlbumFileEntry {
-    u64 size;
-    u64 hash;
-    AlbumFileDateTime datetime;
-    AlbumStorage storage;
-    ContentType content;
-    u8 padding[5];
-    u8 unknown;
+    u64 size{}; // Size of the entry
+    u64 hash{}; // AES256 with hardcoded key over AlbumEntry
+    AlbumFileDateTime datetime{};
+    AlbumStorage storage{};
+    ContentType content{};
+    INSERT_PADDING_BYTES(5);
+    u8 unknown{1}; // Set to 1 on official SW
 };
+static_assert(sizeof(AlbumFileEntry) == 0x20, "AlbumFileEntry has incorrect size.");
 
 struct ApplicationAlbumEntry {
-    u64 size;
-    u64 hash;
-    AlbumFileDateTime datetime;
-    AlbumStorage storage;
-    ContentType content;
-    u8 padding[5];
-    u8 unknown;
+    u64 size{}; // Size of the entry
+    u64 hash{}; // AES256 with hardcoded key over AlbumEntry
+    AlbumFileDateTime datetime{};
+    AlbumStorage storage{};
+    ContentType content{};
+    INSERT_PADDING_BYTES(5);
+    u8 unknown{1}; // Set to 1 on official SW
 };
+static_assert(sizeof(ApplicationAlbumEntry) == 0x20, "ApplicationAlbumEntry has incorrect size.");
 
 struct ApplicationAlbumFileEntry {
-    ApplicationAlbumEntry entry;
-    AlbumFileDateTime datetime;
-    u64 unknown;
+    ApplicationAlbumEntry entry{};
+    AlbumFileDateTime datetime{};
+    u64 unknown{};
 };
+static_assert(sizeof(ApplicationAlbumFileEntry) == 0x30,
+              "ApplicationAlbumFileEntry has incorrect size.");
 
 /// Registers all Capture services with the specified service manager.
 void InstallInterfaces(SM::ServiceManager& sm);

--- a/src/core/hle/service/caps/caps_a.cpp
+++ b/src/core/hle/service/caps/caps_a.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 yuzu emulator team
+// Copyright 2020 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/hle/service/caps/caps_a.h
+++ b/src/core/hle/service/caps/caps_a.h
@@ -1,4 +1,4 @@
-// Copyright 2020 yuzu emulator team
+// Copyright 2020 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/hle/service/caps/caps_c.cpp
+++ b/src/core/hle/service/caps/caps_c.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 yuzu emulator team
+// Copyright 2020 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/hle/service/caps/caps_c.h
+++ b/src/core/hle/service/caps/caps_c.h
@@ -1,4 +1,4 @@
-// Copyright 2020 yuzu emulator team
+// Copyright 2020 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/hle/service/caps/caps_sc.cpp
+++ b/src/core/hle/service/caps/caps_sc.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 yuzu emulator team
+// Copyright 2020 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/hle/service/caps/caps_sc.h
+++ b/src/core/hle/service/caps/caps_sc.h
@@ -1,4 +1,4 @@
-// Copyright 2020 yuzu emulator team
+// Copyright 2020 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/hle/service/caps/caps_ss.cpp
+++ b/src/core/hle/service/caps/caps_ss.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 yuzu emulator team
+// Copyright 2020 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/hle/service/caps/caps_ss.h
+++ b/src/core/hle/service/caps/caps_ss.h
@@ -1,4 +1,4 @@
-// Copyright 2020 yuzu emulator team
+// Copyright 2020 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/hle/service/caps/caps_su.cpp
+++ b/src/core/hle/service/caps/caps_su.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 yuzu emulator team
+// Copyright 2020 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/hle/service/caps/caps_su.h
+++ b/src/core/hle/service/caps/caps_su.h
@@ -1,4 +1,4 @@
-// Copyright 2020 yuzu emulator team
+// Copyright 2020 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/hle/service/caps/caps_u.cpp
+++ b/src/core/hle/service/caps/caps_u.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 yuzu emulator team
+// Copyright 2020 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -58,19 +58,23 @@ void CAPS_U::GetAlbumContentsFileListForApplication(Kernel::HLERequestContext& c
     // u8 ContentType, two s64s, and an u64 AppletResourceUserId. Returns an output u64 for total
     // output entries (which is copied to a s32 by official SW).
     IPC::RequestParser rp{ctx};
-    [[maybe_unused]] const auto application_album_file_entries = rp.PopRaw<std::array<u8, 0x30>>();
-    const auto pid = rp.Pop<s32>();
-    const auto content_type = rp.PopRaw<ContentType>();
-    [[maybe_unused]] const auto start_datetime = rp.PopRaw<AlbumFileDateTime>();
-    [[maybe_unused]] const auto end_datetime = rp.PopRaw<AlbumFileDateTime>();
-    const auto applet_resource_user_id = rp.Pop<u64>();
-    LOG_WARNING(Service_Capture,
-                "(STUBBED) called. pid={}, content_type={}, applet_resource_user_id={}", pid,
-                content_type, applet_resource_user_id);
+    const auto application_album_file_entries{ctx.ReadBuffer()};
+    const auto pid{rp.Pop<s32>()};
+    const auto content_type{rp.PopRaw<ContentType>()};
+    [[maybe_unused]] const auto start_datetime{rp.PopRaw<AlbumFileDateTime>()};
+    [[maybe_unused]] const auto end_datetime{rp.PopRaw<AlbumFileDateTime>()};
+    const auto applet_resource_user_id{rp.Pop<u64>()};
+
+    const auto total_entries = static_cast<s32>(application_album_file_entries.size());
+
+    LOG_WARNING(
+        Service_Capture,
+        "(STUBBED) called. total_entries={}, pid={}, content_type={}, applet_resource_user_id={}",
+        total_entries, pid, content_type, applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
-    rb.Push<s32>(0);
+    rb.Push<s32>(total_entries);
 }
 
 } // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_u.h
+++ b/src/core/hle/service/caps/caps_u.h
@@ -1,4 +1,4 @@
-// Copyright 2020 yuzu emulator team
+// Copyright 2020 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 


### PR DESCRIPTION
Also corrects ApplicationAlbumEntry to include pre-7.0.0 where #ShimLibraryVersion is 0, this was a plain AES256 with a random key generated at application launch.