### PR TITLE
CMake: Update compiler paths for the current MinGW Docker image

### DIFF
--- a/CMakeModules/MinGWCross.cmake
+++ b/CMakeModules/MinGWCross.cmake
@@ -10,8 +10,8 @@ set(SDL2_PATH                       ${MINGW_PREFIX})
 set(MINGW_TOOL_PREFIX               ${CMAKE_SYSTEM_PROCESSOR}-w64-mingw32-)
 
 # Specify the cross compiler
-set(CMAKE_C_COMPILER            ${MINGW_TOOL_PREFIX}gcc-posix)
-set(CMAKE_CXX_COMPILER          ${MINGW_TOOL_PREFIX}g++-posix)
+set(CMAKE_C_COMPILER            ${MINGW_TOOL_PREFIX}gcc)
+set(CMAKE_CXX_COMPILER          ${MINGW_TOOL_PREFIX}g++)
 set(CMAKE_RC_COMPILER           ${MINGW_TOOL_PREFIX}windres)
 
 # Mingw tools


### PR DESCRIPTION
The Docker image was just updated to use Arch Linux instead of Ubuntu. This PR sets the compiler names to reflect how they are installed on the Arch Linux Docker image. Fixes `x86_64-w64-mingw32-g++-posix is not a full path and was not found in the PATH.` error and the likewise gcc error in CMake.