### PR TITLE
input_common: fix build when SDL2 is disabled

### DIFF
--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -18,7 +18,9 @@ namespace InputCommon {
 
 static std::shared_ptr<Keyboard> keyboard;
 static std::shared_ptr<MotionEmu> motion_emu;
+#ifdef HAVE_SDL2
 static std::unique_ptr<SDL::State> sdl;
+#endif
 static std::unique_ptr<CemuhookUDP::State> udp;
 
 void Init() {
@@ -29,7 +31,9 @@ void Init() {
     motion_emu = std::make_shared<MotionEmu>();
     Input::RegisterFactory<Input::MotionDevice>("motion_emu", motion_emu);
 
+#ifdef HAVE_SDL2
     sdl = SDL::Init();
+#endif
 
     udp = CemuhookUDP::Init();
 }
@@ -40,7 +44,9 @@ void Shutdown() {
     Input::UnregisterFactory<Input::AnalogDevice>("analog_from_button");
     Input::UnregisterFactory<Input::MotionDevice>("motion_emu");
     motion_emu.reset();
+#ifdef HAVE_SDL2
     sdl.reset();
+#endif
     udp.reset();
 }
 


### PR DESCRIPTION
Just making the changes of https://github.com/yuzu-emu/yuzu/pull/3792, after it got mysteriously closed.