### PR TITLE
memory: add program counter in unmapped memory access log messages

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -224,8 +224,9 @@ struct Memory::Impl {
             switch (page_table.attributes[page_index]) {
             case Common::PageType::Unmapped: {
                 LOG_ERROR(HW_Memory,
-                          "Unmapped ReadBlock @ 0x{:016X} (start address = 0x{:016X}, size = {})",
-                          current_vaddr, src_addr, size);
+                          "Unmapped ReadBlock @ 0x{:016X} (start address = 0x{:016X}, size = {}) "
+                          "at PC 0x{:08X}",
+                          current_vaddr, src_addr, size, system.CurrentArmInterface().GetPC());
                 std::memset(dest_buffer, 0, copy_amount);
                 break;
             }
@@ -270,8 +271,9 @@ struct Memory::Impl {
             switch (page_table.attributes[page_index]) {
             case Common::PageType::Unmapped: {
                 LOG_ERROR(HW_Memory,
-                          "Unmapped ReadBlock @ 0x{:016X} (start address = 0x{:016X}, size = {})",
-                          current_vaddr, src_addr, size);
+                          "Unmapped ReadBlock @ 0x{:016X} (start address = 0x{:016X}, size = {}) "
+                          "at PC 0x{:08X}",
+                          current_vaddr, src_addr, size, system.CurrentArmInterface().GetPC());
                 std::memset(dest_buffer, 0, copy_amount);
                 break;
             }
@@ -322,8 +324,9 @@ struct Memory::Impl {
             switch (page_table.attributes[page_index]) {
             case Common::PageType::Unmapped: {
                 LOG_ERROR(HW_Memory,
-                          "Unmapped WriteBlock @ 0x{:016X} (start address = 0x{:016X}, size = {})",
-                          current_vaddr, dest_addr, size);
+                          "Unmapped WriteBlock @ 0x{:016X} (start address = 0x{:016X}, size = {}) "
+                          "at PC 0x{:08X}",
+                          current_vaddr, dest_addr, size, system.CurrentArmInterface().GetPC());
                 break;
             }
             case Common::PageType::Memory: {
@@ -366,8 +369,9 @@ struct Memory::Impl {
             switch (page_table.attributes[page_index]) {
             case Common::PageType::Unmapped: {
                 LOG_ERROR(HW_Memory,
-                          "Unmapped WriteBlock @ 0x{:016X} (start address = 0x{:016X}, size = {})",
-                          current_vaddr, dest_addr, size);
+                          "Unmapped WriteBlock @ 0x{:016X} (start address = 0x{:016X}, size = {}) "
+                          "at PC 0x{:08X}",
+                          current_vaddr, dest_addr, size, system.CurrentArmInterface().GetPC());
                 break;
             }
             case Common::PageType::Memory: {
@@ -416,8 +420,9 @@ struct Memory::Impl {
             switch (page_table.attributes[page_index]) {
             case Common::PageType::Unmapped: {
                 LOG_ERROR(HW_Memory,
-                          "Unmapped ZeroBlock @ 0x{:016X} (start address = 0x{:016X}, size = {})",
-                          current_vaddr, dest_addr, size);
+                          "Unmapped ZeroBlock @ 0x{:016X} (start address = 0x{:016X}, size = {}) "
+                          "at PC 0x{:08X}",
+                          current_vaddr, dest_addr, size, system.CurrentArmInterface().GetPC());
                 break;
             }
             case Common::PageType::Memory: {
@@ -463,8 +468,9 @@ struct Memory::Impl {
             switch (page_table.attributes[page_index]) {
             case Common::PageType::Unmapped: {
                 LOG_ERROR(HW_Memory,
-                          "Unmapped CopyBlock @ 0x{:016X} (start address = 0x{:016X}, size = {})",
-                          current_vaddr, src_addr, size);
+                          "Unmapped CopyBlock @ 0x{:016X} (start address = 0x{:016X}, size = {}) "
+                          "at PC 0x{:08X}",
+                          current_vaddr, src_addr, size, system.CurrentArmInterface().GetPC());
                 ZeroBlock(process, dest_addr, copy_amount);
                 break;
             }
@@ -641,7 +647,8 @@ struct Memory::Impl {
         const Common::PageType type = current_page_table->attributes[vaddr >> PAGE_BITS];
         switch (type) {
         case Common::PageType::Unmapped:
-            LOG_ERROR(HW_Memory, "Unmapped Read{} @ 0x{:08X}", sizeof(T) * 8, vaddr);
+            LOG_ERROR(HW_Memory, "Unmapped Read{} @ 0x{:08X} at PC 0x{:08X}", sizeof(T) * 8, vaddr,
+                      system.CurrentArmInterface().GetPC());
             return 0;
         case Common::PageType::Memory:
             ASSERT_MSG(false, "Mapped memory page without a pointer @ {:016X}", vaddr);
@@ -682,8 +689,9 @@ struct Memory::Impl {
         const Common::PageType type = current_page_table->attributes[vaddr >> PAGE_BITS];
         switch (type) {
         case Common::PageType::Unmapped:
-            LOG_ERROR(HW_Memory, "Unmapped Write{} 0x{:08X} @ 0x{:016X}", sizeof(data) * 8,
-                      static_cast<u32>(data), vaddr);
+            LOG_ERROR(HW_Memory, "Unmapped Write{} 0x{:08X} @ 0x{:016X} at PC 0x{:08X}",
+                      sizeof(data) * 8, static_cast<u32>(data), vaddr,
+                      system.CurrentArmInterface().GetPC());
             return;
         case Common::PageType::Memory:
             ASSERT_MSG(false, "Mapped memory page without a pointer @ {:016X}", vaddr);


### PR DESCRIPTION
See citra-emu/citra#5149 for more details.

Original description:
This will help developers track down the source for their unmapped memory read/writes. It did help me a lot already ...