### PR TITLE
settings: Add anisotropic filtering level to the yuzu configuration log

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -96,6 +96,7 @@ void LogSettings() {
     LogSetting("Renderer_UseAsynchronousGpuEmulation",
                Settings::values.use_asynchronous_gpu_emulation);
     LogSetting("Renderer_UseVsync", Settings::values.use_vsync);
+    LogSetting("Renderer_AnisotropicFilteringLevel", Settings::values.max_anisotropy);
     LogSetting("Audio_OutputEngine", Settings::values.sink_id);
     LogSetting("Audio_EnableAudioStretching", Settings::values.enable_audio_stretching);
     LogSetting("Audio_OutputDevice", Settings::values.audio_device_id);


### PR DESCRIPTION
```
Default = 0,
2x = 1,
4x = 2,
8x = 3,
16x = 4,
```