### PR TITLE
kernel/memory: Resolve several compiler warnings

### DIFF
--- a/src/core/hle/kernel/memory/address_space_info.cpp
+++ b/src/core/hle/kernel/memory/address_space_info.cpp
@@ -49,18 +49,18 @@ constexpr bool IsAllowedIndexForAddress(std::size_t index) {
     return index < std::size(AddressSpaceInfos) && AddressSpaceInfos[index].GetAddress() != Invalid;
 }
 
-constexpr std::size_t
-    AddressSpaceIndices32Bit[static_cast<std::size_t>(AddressSpaceInfo::Type::Count)]{
+constexpr std::array<std::size_t, static_cast<std::size_t>(AddressSpaceInfo::Type::Count)>
+    AddressSpaceIndices32Bit{
         0, 1, 0, 2, 0, 3,
     };
 
-constexpr std::size_t
-    AddressSpaceIndices36Bit[static_cast<std::size_t>(AddressSpaceInfo::Type::Count)]{
+constexpr std::array<std::size_t, static_cast<std::size_t>(AddressSpaceInfo::Type::Count)>
+    AddressSpaceIndices36Bit{
         4, 5, 4, 6, 4, 7,
     };
 
-constexpr std::size_t
-    AddressSpaceIndices39Bit[static_cast<std::size_t>(AddressSpaceInfo::Type::Count)]{
+constexpr std::array<std::size_t, static_cast<std::size_t>(AddressSpaceInfo::Type::Count)>
+    AddressSpaceIndices39Bit{
         9, 8, 8, 10, 12, 11,
     };
 

--- a/src/core/hle/kernel/memory/address_space_info.h
+++ b/src/core/hle/kernel/memory/address_space_info.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include "common/common_funcs.h"
 #include "common/common_types.h"
 
 namespace Kernel::Memory {

--- a/src/core/hle/kernel/memory/memory_block_manager.cpp
+++ b/src/core/hle/kernel/memory/memory_block_manager.cpp
@@ -67,7 +67,6 @@ void MemoryBlockManager::Update(VAddr addr, std::size_t num_pages, MemoryState p
                                 MemoryPermission prev_perm, MemoryAttribute prev_attribute,
                                 MemoryState state, MemoryPermission perm,
                                 MemoryAttribute attribute) {
-    const std::size_t prev_count{memory_block_tree.size()};
     const VAddr end_addr{addr + num_pages * PageSize};
     iterator node{memory_block_tree.begin()};
 
@@ -109,7 +108,6 @@ void MemoryBlockManager::Update(VAddr addr, std::size_t num_pages, MemoryState p
 
 void MemoryBlockManager::Update(VAddr addr, std::size_t num_pages, MemoryState state,
                                 MemoryPermission perm, MemoryAttribute attribute) {
-    const std::size_t prev_count{memory_block_tree.size()};
     const VAddr end_addr{addr + num_pages * PageSize};
     iterator node{memory_block_tree.begin()};
 
@@ -145,7 +143,6 @@ void MemoryBlockManager::Update(VAddr addr, std::size_t num_pages, MemoryState s
 
 void MemoryBlockManager::UpdateLock(VAddr addr, std::size_t num_pages, LockFunc&& lock_func,
                                     MemoryPermission perm) {
-    const std::size_t prev_count{memory_block_tree.size()};
     const VAddr end_addr{addr + num_pages * PageSize};
     iterator node{memory_block_tree.begin()};
 

--- a/src/core/hle/kernel/memory/memory_block_manager.h
+++ b/src/core/hle/kernel/memory/memory_block_manager.h
@@ -6,7 +6,6 @@
 
 #include <functional>
 #include <list>
-#include <memory>
 
 #include "common/common_types.h"
 #include "core/hle/kernel/memory/memory_block.h"

--- a/src/core/hle/kernel/memory/memory_manager.cpp
+++ b/src/core/hle/kernel/memory/memory_manager.cpp
@@ -104,9 +104,9 @@ ResultCode MemoryManager::Allocate(PageLinkedList& page_list, std::size_t num_pa
     // Ensure that we don't leave anything un-freed
     auto group_guard = detail::ScopeExit([&] {
         for (const auto& it : page_list.Nodes()) {
-            const auto num_pages{std::min(
+            const auto min_num_pages{std::min(
                 it.GetNumPages(), (chosen_manager.GetEndAddress() - it.GetAddress()) / PageSize)};
-            chosen_manager.Free(it.GetAddress(), num_pages);
+            chosen_manager.Free(it.GetAddress(), min_num_pages);
         }
     });
 
@@ -165,9 +165,9 @@ ResultCode MemoryManager::Free(PageLinkedList& page_list, std::size_t num_pages,
 
     // Free all of the pages
     for (const auto& it : page_list.Nodes()) {
-        const auto num_pages{std::min(
+        const auto min_num_pages{std::min(
             it.GetNumPages(), (chosen_manager.GetEndAddress() - it.GetAddress()) / PageSize)};
-        chosen_manager.Free(it.GetAddress(), num_pages);
+        chosen_manager.Free(it.GetAddress(), min_num_pages);
     }
 
     return RESULT_SUCCESS;

--- a/src/core/hle/kernel/memory/memory_manager.h
+++ b/src/core/hle/kernel/memory/memory_manager.h
@@ -7,7 +7,6 @@
 #include <array>
 #include <mutex>
 
-#include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "core/hle/kernel/memory/page_heap.h"
 #include "core/hle/result.h"

--- a/src/core/hle/kernel/memory/page_linked_list.h
+++ b/src/core/hle/kernel/memory/page_linked_list.h
@@ -7,7 +7,6 @@
 #include <list>
 
 #include "common/assert.h"
-#include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "core/hle/kernel/memory/memory_types.h"
 #include "core/hle/result.h"

--- a/src/core/hle/kernel/memory/page_table.cpp
+++ b/src/core/hle/kernel/memory/page_table.cpp
@@ -6,7 +6,6 @@
 #include "common/assert.h"
 #include "common/scope_exit.h"
 #include "core/core.h"
-#include "core/device_memory.h"
 #include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/memory/address_space_info.h"

--- a/src/core/hle/kernel/memory/page_table.h
+++ b/src/core/hle/kernel/memory/page_table.h
@@ -4,16 +4,15 @@
 
 #pragma once
 
-#include <list>
 #include <memory>
 #include <mutex>
 
-#include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/page_table.h"
 #include "core/file_sys/program_metadata.h"
 #include "core/hle/kernel/memory/memory_block.h"
 #include "core/hle/kernel/memory/memory_manager.h"
+#include "core/hle/result.h"
 
 namespace Core {
 class System;

--- a/src/core/hle/kernel/memory/slab_heap.h
+++ b/src/core/hle/kernel/memory/slab_heap.h
@@ -10,7 +10,6 @@
 #include <atomic>
 
 #include "common/assert.h"
-#include "common/common_funcs.h"
 #include "common/common_types.h"
 
 namespace Kernel::Memory {

--- a/src/core/hle/kernel/memory/system_control.cpp
+++ b/src/core/hle/kernel/memory/system_control.cpp
@@ -2,8 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#pragma once
-
 #include <random>
 
 #include "core/hle/kernel/memory/system_control.h"


### PR DESCRIPTION
Resolves a few compiler warnings like unused variables, variable shadowing, #pragma once within a cpp file, etc.

Each commit should be self-contained.