### PR TITLE
video_core: Implement viewport swizzles with NV_viewport_swizzle

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -44,6 +44,12 @@ void Maxwell3D::InitializeRegisterDefaults() {
         viewport.depth_range_near = 0.0f;
         viewport.depth_range_far = 1.0f;
     }
+    for (auto& viewport : regs.viewport_transform) {
+        viewport.swizzle.x.Assign(Regs::ViewportSwizzle::PositiveX);
+        viewport.swizzle.y.Assign(Regs::ViewportSwizzle::PositiveY);
+        viewport.swizzle.z.Assign(Regs::ViewportSwizzle::PositiveZ);
+        viewport.swizzle.w.Assign(Regs::ViewportSwizzle::PositiveW);
+    }
 
     // Doom and Bomberman seems to use the uninitialized registers and just enable blend
     // so initialize blend registers with sane values

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -630,6 +630,7 @@ public:
             f32 translate_y;
             f32 translate_z;
             union {
+                u32 raw;
                 BitField<0, 3, ViewportSwizzle> x;
                 BitField<4, 3, ViewportSwizzle> y;
                 BitField<8, 3, ViewportSwizzle> z;

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -575,6 +575,17 @@ public:
             Replay = 3,
         };
 
+        enum class ViewportSwizzle : u32 {
+            PositiveX = 0,
+            NegativeX = 1,
+            PositiveY = 2,
+            NegativeY = 3,
+            PositiveZ = 4,
+            NegativeZ = 5,
+            PositiveW = 6,
+            NegativeW = 7,
+        };
+
         struct RenderTargetConfig {
             u32 address_high;
             u32 address_low;
@@ -618,7 +629,13 @@ public:
             f32 translate_x;
             f32 translate_y;
             f32 translate_z;
-            INSERT_UNION_PADDING_WORDS(2);
+            union {
+                BitField<0, 3, ViewportSwizzle> x;
+                BitField<4, 3, ViewportSwizzle> y;
+                BitField<8, 3, ViewportSwizzle> z;
+                BitField<12, 3, ViewportSwizzle> w;
+            } swizzle;
+            INSERT_UNION_PADDING_WORDS(1);
 
             Common::Rectangle<f32> GetRect() const {
                 return {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1019,6 +1019,14 @@ void RasterizerOpenGL::SyncViewport() {
             const GLdouble near_depth = src.translate_z - src.scale_z * reduce_z;
             const GLdouble far_depth = src.translate_z + src.scale_z;
             glDepthRangeIndexed(static_cast<GLuint>(i), near_depth, far_depth);
+
+            if (!GLAD_GL_NV_viewport_swizzle) {
+                continue;
+            }
+            glViewportSwizzleNV(static_cast<GLuint>(i), MaxwellToGL::ViewportSwizzle(src.swizzle.x),
+                                MaxwellToGL::ViewportSwizzle(src.swizzle.y),
+                                MaxwellToGL::ViewportSwizzle(src.swizzle.z),
+                                MaxwellToGL::ViewportSwizzle(src.swizzle.w));
         }
     }
 }

--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -503,5 +503,10 @@ inline GLenum PolygonMode(Maxwell::PolygonMode polygon_mode) {
     return GL_FILL;
 }
 
+inline GLenum ViewportSwizzle(Maxwell::ViewportSwizzle swizzle) {
+    // Enumeration order matches register order. We can convert it arithmetically.
+    return GL_VIEWPORT_SWIZZLE_POSITIVE_X_NV + static_cast<GLenum>(swizzle);
+}
+
 } // namespace MaxwellToGL
 } // namespace OpenGL

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <cstring>
 #include <tuple>
 
@@ -101,6 +102,12 @@ void FixedPipelineState::ColorBlending::Fill(const Maxwell& regs) noexcept {
     }
 }
 
+void FixedPipelineState::ViewportSwizzles::Fill(const Maxwell& regs) noexcept {
+    const auto& transform = regs.viewport_transform;
+    std::transform(transform.begin(), transform.end(), swizzles.begin(),
+                   [](const auto& viewport) { return static_cast<u16>(viewport.swizzle.raw); });
+}
+
 void FixedPipelineState::BlendingAttachment::Fill(const Maxwell& regs, std::size_t index) {
     const auto& mask = regs.color_mask[regs.color_mask_common ? 0 : index];
 
@@ -144,6 +151,7 @@ void FixedPipelineState::Fill(const Maxwell& regs) {
     rasterizer.Fill(regs);
     depth_stencil.Fill(regs);
     color_blending.Fill(regs);
+    viewport_swizzles.Fill(regs);
 }
 
 std::size_t FixedPipelineState::Hash() const noexcept {

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.h
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.h
@@ -233,10 +233,17 @@ struct FixedPipelineState {
         void Fill(const Maxwell& regs) noexcept;
     };
 
+    struct ViewportSwizzles {
+        std::array<u16, Maxwell::NumViewports> swizzles;
+
+        void Fill(const Maxwell& regs) noexcept;
+    };
+
     VertexInput vertex_input;
     Rasterizer rasterizer;
     DepthStencil depth_stencil;
     ColorBlending color_blending;
+    ViewportSwizzles viewport_swizzles;
 
     void Fill(const Maxwell& regs);
 

--- a/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
@@ -672,4 +672,27 @@ VkComponentSwizzle SwizzleSource(Tegra::Texture::SwizzleSource swizzle) {
     return {};
 }
 
+VkViewportCoordinateSwizzleNV ViewportSwizzle(Maxwell::ViewportSwizzle swizzle) {
+    switch (swizzle) {
+    case Maxwell::ViewportSwizzle::PositiveX:
+        return VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_X_NV;
+    case Maxwell::ViewportSwizzle::NegativeX:
+        return VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_X_NV;
+    case Maxwell::ViewportSwizzle::PositiveY:
+        return VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_Y_NV;
+    case Maxwell::ViewportSwizzle::NegativeY:
+        return VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_Y_NV;
+    case Maxwell::ViewportSwizzle::PositiveZ:
+        return VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_Z_NV;
+    case Maxwell::ViewportSwizzle::NegativeZ:
+        return VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_Z_NV;
+    case Maxwell::ViewportSwizzle::PositiveW:
+        return VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_W_NV;
+    case Maxwell::ViewportSwizzle::NegativeW:
+        return VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_W_NV;
+    }
+    UNREACHABLE_MSG("Invalid swizzle={}", static_cast<int>(swizzle));
+    return {};
+}
+
 } // namespace Vulkan::MaxwellToVK

--- a/src/video_core/renderer_vulkan/maxwell_to_vk.h
+++ b/src/video_core/renderer_vulkan/maxwell_to_vk.h
@@ -59,4 +59,6 @@ VkCullModeFlags CullFace(Maxwell::CullFace cull_face);
 
 VkComponentSwizzle SwizzleSource(Tegra::Texture::SwizzleSource swizzle);
 
+VkViewportCoordinateSwizzleNV ViewportSwizzle(Maxwell::ViewportSwizzle swizzle);
+
 } // namespace Vulkan::MaxwellToVK

--- a/src/video_core/renderer_vulkan/vk_device.cpp
+++ b/src/video_core/renderer_vulkan/vk_device.cpp
@@ -260,6 +260,10 @@ bool VKDevice::Create() {
         LOG_INFO(Render_Vulkan, "Device doesn't support float16 natively");
     }
 
+    if (!nv_viewport_swizzle) {
+        LOG_INFO(Render_Vulkan, "Device doesn't support viewport swizzles");
+    }
+
     VkPhysicalDeviceUniformBufferStandardLayoutFeaturesKHR std430_layout;
     if (khr_uniform_buffer_standard_layout) {
         std430_layout.sType =
@@ -521,6 +525,7 @@ std::vector<const char*> VKDevice::LoadExtensions() {
     bool has_ext_subgroup_size_control{};
     bool has_ext_transform_feedback{};
     for (const auto& extension : physical.EnumerateDeviceExtensionProperties()) {
+        Test(extension, nv_viewport_swizzle, VK_NV_VIEWPORT_SWIZZLE_EXTENSION_NAME, true);
         Test(extension, khr_uniform_buffer_standard_layout,
              VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_EXTENSION_NAME, true);
         Test(extension, has_khr_shader_float16_int8, VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME,

--- a/src/video_core/renderer_vulkan/vk_device.h
+++ b/src/video_core/renderer_vulkan/vk_device.h
@@ -147,6 +147,11 @@ public:
         return is_formatless_image_load_supported;
     }
 
+    /// Returns true if the device supports VK_NV_viewport_swizzle.
+    bool IsNvViewportSwizzleSupported() const {
+        return nv_viewport_swizzle;
+    }
+
     /// Returns true if the device supports VK_EXT_scalar_block_layout.
     bool IsKhrUniformBufferStandardLayoutSupported() const {
         return khr_uniform_buffer_standard_layout;
@@ -222,6 +227,7 @@ private:
     bool is_float16_supported{};            ///< Support for float16 arithmetics.
     bool is_warp_potentially_bigger{};      ///< Host warp size can be bigger than guest.
     bool is_formatless_image_load_supported{}; ///< Support for shader image read without format.
+    bool nv_viewport_swizzle{};                ///< Support for VK_NV_viewport_swizzle.
     bool khr_uniform_buffer_standard_layout{}; ///< Support for std430 on UBOs.
     bool ext_index_type_uint8{};               ///< Support for VK_EXT_index_type_uint8.
     bool ext_depth_range_unrestricted{};       ///< Support for VK_EXT_depth_range_unrestricted.


### PR DESCRIPTION
It is currently implemented only on devices with GL_NV_viewport_swizzle or VK_NV_viewport_swizzle.

- Fixes flipping issues in several games (#2703).