### PR TITLE
Port citra-emu/citra#5280: "Small fixes to "Option to hide mouse on inactivity""

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1026,7 +1026,6 @@ void GMainWindow::BootGame(const QString& filename) {
         mouse_hide_timer.start();
         setMouseTracking(true);
         ui.centralwidget->setMouseTracking(true);
-        ui.menubar->setMouseTracking(true);
     }
 
     const u64 title_id = Core::System::GetInstance().CurrentProcess()->GetTitleID();
@@ -1099,7 +1098,6 @@ void GMainWindow::ShutdownGame() {
 
     setMouseTracking(false);
     ui.centralwidget->setMouseTracking(false);
-    ui.menubar->setMouseTracking(false);
 
     UpdateWindowTitle();
 
@@ -1861,12 +1859,10 @@ void GMainWindow::OnConfigure() {
     if (UISettings::values.hide_mouse && emulation_running) {
         setMouseTracking(true);
         ui.centralwidget->setMouseTracking(true);
-        ui.menubar->setMouseTracking(true);
         mouse_hide_timer.start();
     } else {
         setMouseTracking(false);
         ui.centralwidget->setMouseTracking(false);
-        ui.menubar->setMouseTracking(false);
     }
 
     dock_status_button->setChecked(Settings::values.use_docked_mode);


### PR DESCRIPTION
See citra-emu/citra#5280 for more details.

**Original description**:
Follow up to citra-emu/citra#5094.
Fixes a bug reported on discord by Dragois, and backports review comments from yuzu-emu/yuzu#3637.
The reported bug was that the menubar would lose sensitivity to the hover interactions. This happens because Qt menubars have mouse tracking true as default, therefore I had operated on false assumptions. 
There are no changes in behaviour besides the bug fix.