### PR TITLE
CI: Don't check clang format on early access builds

### DIFF
--- a/.ci/yuzu-patreon-step2.yml
+++ b/.ci/yuzu-patreon-step2.yml
@@ -5,18 +5,7 @@ variables:
   DisplayVersion: $[counter(variables['DisplayPrefix'], 1)]
 
 stages:
-- stage: format
-  displayName: 'format'
-  jobs:
-  - job: format
-    displayName: 'clang'
-    continueOnError: true
-    pool:
-      vmImage: ubuntu-latest
-    steps:
-    - template: ./templates/format-check.yml
 - stage: build
-  dependsOn: format
   displayName: 'build'
   jobs:
   - job: build


### PR DESCRIPTION
Apparently the core checks for errors before uploading new builds, and so if clang format fails, the website won't update the latest build.