### PR TITLE
shader_ir: Add separate instructions for ordered and unordered comparisons and fix NE on GLSL

### DIFF
--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -168,18 +168,22 @@ enum class Pred : u64 {
 };
 
 enum class PredCondition : u64 {
-    LessThan = 1,
-    Equal = 2,
-    LessEqual = 3,
-    GreaterThan = 4,
-    NotEqual = 5,
-    GreaterEqual = 6,
-    LessThanWithNan = 9,
-    LessEqualWithNan = 11,
-    GreaterThanWithNan = 12,
-    NotEqualWithNan = 13,
-    GreaterEqualWithNan = 14,
-    // TODO(Subv): Other condition types
+    F = 0,    // Always false
+    LT = 1,   // Ordered less than
+    EQ = 2,   // Ordered equal
+    LE = 3,   // Ordered less than or equal
+    GT = 4,   // Ordered greater than
+    NE = 5,   // Ordered not equal
+    GE = 6,   // Ordered greater than or equal
+    NUM = 7,  // Ordered
+    NAN_ = 8, // Unordered
+    LTU = 9,  // Unordered less than
+    EQU = 10, // Unordered equal
+    LEU = 11, // Unordered less than or equal
+    GTU = 12, // Unordered greater than
+    NEU = 13, // Unordered not equal
+    GEU = 14, // Unordered greater than or equal
+    T = 15,   // Always true
 };
 
 enum class PredOperation : u64 {

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1845,6 +1845,15 @@ private:
         static_assert(!unordered || type == Type::Float);
 
         const Expression expr = GenerateBinaryInfix(operation, op, Type::Bool, type, type);
+
+        if constexpr (op.compare("!=") == 0 && type == Type::Float && !unordered) {
+            // GLSL's operator!=(float, float) doesn't seem be ordered. This happens on both AMD's
+            // and Nvidia's proprietary stacks. Manually force an ordered comparison.
+            return {fmt::format("({} && !isnan({}) && !isnan({}))", expr.AsBool(),
+                                VisitOperand(operation, 0).AsFloat(),
+                                VisitOperand(operation, 1).AsFloat()),
+                    Type::Bool};
+        }
         if constexpr (!unordered) {
             return expr;
         }

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -1840,34 +1840,31 @@ private:
                 Type::HalfFloat};
     }
 
-    template <Type type>
-    Expression LogicalLessThan(Operation operation) {
-        return GenerateBinaryInfix(operation, "<", Type::Bool, type, type);
+    template <const std::string_view& op, Type type, bool unordered = false>
+    Expression Comparison(Operation operation) {
+        static_assert(!unordered || type == Type::Float);
+
+        const Expression expr = GenerateBinaryInfix(operation, op, Type::Bool, type, type);
+        if constexpr (!unordered) {
+            return expr;
+        }
+        // Unordered comparisons are always true for NaN operands.
+        return {fmt::format("({} || isnan({}) || isnan({}))", expr.AsBool(),
+                            VisitOperand(operation, 0).AsFloat(),
+                            VisitOperand(operation, 1).AsFloat()),
+                Type::Bool};
     }
 
-    template <Type type>
-    Expression LogicalEqual(Operation operation) {
-        return GenerateBinaryInfix(operation, "==", Type::Bool, type, type);
+    Expression FOrdered(Operation operation) {
+        return {fmt::format("(!isnan({}) && !isnan({}))", VisitOperand(operation, 0).AsFloat(),
+                            VisitOperand(operation, 1).AsFloat()),
+                Type::Bool};
     }
 
-    template <Type type>
-    Expression LogicalLessEqual(Operation operation) {
-        return GenerateBinaryInfix(operation, "<=", Type::Bool, type, type);
-    }
-
-    template <Type type>
-    Expression LogicalGreaterThan(Operation operation) {
-        return GenerateBinaryInfix(operation, ">", Type::Bool, type, type);
-    }
-
-    template <Type type>
-    Expression LogicalNotEqual(Operation operation) {
-        return GenerateBinaryInfix(operation, "!=", Type::Bool, type, type);
-    }
-
-    template <Type type>
-    Expression LogicalGreaterEqual(Operation operation) {
-        return GenerateBinaryInfix(operation, ">=", Type::Bool, type, type);
+    Expression FUnordered(Operation operation) {
+        return {fmt::format("(isnan({}) || isnan({}))", VisitOperand(operation, 0).AsFloat(),
+                            VisitOperand(operation, 1).AsFloat()),
+                Type::Bool};
     }
 
     Expression LogicalAddCarry(Operation operation) {
@@ -2324,6 +2321,13 @@ private:
         Func() = delete;
         ~Func() = delete;
 
+        static constexpr std::string_view LessThan = "<";
+        static constexpr std::string_view Equal = "==";
+        static constexpr std::string_view LessEqual = "<=";
+        static constexpr std::string_view GreaterThan = ">";
+        static constexpr std::string_view NotEqual = "!=";
+        static constexpr std::string_view GreaterEqual = ">=";
+
         static constexpr std::string_view Add = "Add";
         static constexpr std::string_view Min = "Min";
         static constexpr std::string_view Max = "Max";
@@ -2425,27 +2429,34 @@ private:
         &GLSLDecompiler::LogicalPick2,
         &GLSLDecompiler::LogicalAnd2,
 
-        &GLSLDecompiler::LogicalLessThan<Type::Float>,
-        &GLSLDecompiler::LogicalEqual<Type::Float>,
-        &GLSLDecompiler::LogicalLessEqual<Type::Float>,
-        &GLSLDecompiler::LogicalGreaterThan<Type::Float>,
-        &GLSLDecompiler::LogicalNotEqual<Type::Float>,
-        &GLSLDecompiler::LogicalGreaterEqual<Type::Float>,
-        &GLSLDecompiler::LogicalFIsNan,
+        &GLSLDecompiler::Comparison<Func::LessThan, Type::Float, false>,
+        &GLSLDecompiler::Comparison<Func::Equal, Type::Float, false>,
+        &GLSLDecompiler::Comparison<Func::LessEqual, Type::Float, false>,
+        &GLSLDecompiler::Comparison<Func::GreaterThan, Type::Float, false>,
+        &GLSLDecompiler::Comparison<Func::NotEqual, Type::Float, false>,
+        &GLSLDecompiler::Comparison<Func::GreaterEqual, Type::Float, false>,
+        &GLSLDecompiler::FOrdered,
+        &GLSLDecompiler::FUnordered,
+        &GLSLDecompiler::Comparison<Func::LessThan, Type::Float, true>,
+        &GLSLDecompiler::Comparison<Func::Equal, Type::Float, true>,
+        &GLSLDecompiler::Comparison<Func::LessEqual, Type::Float, true>,
+        &GLSLDecompiler::Comparison<Func::GreaterThan, Type::Float, true>,
+        &GLSLDecompiler::Comparison<Func::NotEqual, Type::Float, true>,
+        &GLSLDecompiler::Comparison<Func::GreaterEqual, Type::Float, true>,
 
-        &GLSLDecompiler::LogicalLessThan<Type::Int>,
-        &GLSLDecompiler::LogicalEqual<Type::Int>,
-        &GLSLDecompiler::LogicalLessEqual<Type::Int>,
-        &GLSLDecompiler::LogicalGreaterThan<Type::Int>,
-        &GLSLDecompiler::LogicalNotEqual<Type::Int>,
-        &GLSLDecompiler::LogicalGreaterEqual<Type::Int>,
+        &GLSLDecompiler::Comparison<Func::LessThan, Type::Int>,
+        &GLSLDecompiler::Comparison<Func::Equal, Type::Int>,
+        &GLSLDecompiler::Comparison<Func::LessEqual, Type::Int>,
+        &GLSLDecompiler::Comparison<Func::GreaterThan, Type::Int>,
+        &GLSLDecompiler::Comparison<Func::NotEqual, Type::Int>,
+        &GLSLDecompiler::Comparison<Func::GreaterEqual, Type::Int>,
 
-        &GLSLDecompiler::LogicalLessThan<Type::Uint>,
-        &GLSLDecompiler::LogicalEqual<Type::Uint>,
-        &GLSLDecompiler::LogicalLessEqual<Type::Uint>,
-        &GLSLDecompiler::LogicalGreaterThan<Type::Uint>,
-        &GLSLDecompiler::LogicalNotEqual<Type::Uint>,
-        &GLSLDecompiler::LogicalGreaterEqual<Type::Uint>,
+        &GLSLDecompiler::Comparison<Func::LessThan, Type::Uint>,
+        &GLSLDecompiler::Comparison<Func::Equal, Type::Uint>,
+        &GLSLDecompiler::Comparison<Func::LessEqual, Type::Uint>,
+        &GLSLDecompiler::Comparison<Func::GreaterThan, Type::Uint>,
+        &GLSLDecompiler::Comparison<Func::NotEqual, Type::Uint>,
+        &GLSLDecompiler::Comparison<Func::GreaterEqual, Type::Uint>,
 
         &GLSLDecompiler::LogicalAddCarry,
 

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
@@ -1618,6 +1618,24 @@ private:
         return {};
     }
 
+    Expression LogicalFOrdered(Operation operation) {
+        // Emulate SPIR-V's OpOrdered
+        const Id op_a = AsFloat(Visit(operation[0]));
+        const Id op_b = AsFloat(Visit(operation[1]));
+        const Id is_num_a = OpFOrdEqual(t_bool, op_a, op_a);
+        const Id is_num_b = OpFOrdEqual(t_bool, op_b, op_b);
+        return {OpLogicalAnd(t_bool, is_num_a, is_num_b), Type::Bool};
+    }
+
+    Expression LogicalFUnordered(Operation operation) {
+        // Emulate SPIR-V's OpUnordered
+        const Id op_a = AsFloat(Visit(operation[0]));
+        const Id op_b = AsFloat(Visit(operation[1]));
+        const Id is_nan_a = OpIsNan(t_bool, op_a);
+        const Id is_nan_b = OpIsNan(t_bool, op_b);
+        return {OpLogicalOr(t_bool, is_nan_a, is_nan_b), Type::Bool};
+    }
+
     Id GetTextureSampler(Operation operation) {
         const auto& meta = std::get<MetaTexture>(operation.GetMeta());
         ASSERT(!meta.sampler.is_buffer);
@@ -2511,7 +2529,14 @@ private:
         &SPIRVDecompiler::Binary<&Module::OpFOrdGreaterThan, Type::Bool, Type::Float>,
         &SPIRVDecompiler::Binary<&Module::OpFOrdNotEqual, Type::Bool, Type::Float>,
         &SPIRVDecompiler::Binary<&Module::OpFOrdGreaterThanEqual, Type::Bool, Type::Float>,
-        &SPIRVDecompiler::Unary<&Module::OpIsNan, Type::Bool, Type::Float>,
+        &SPIRVDecompiler::LogicalFOrdered,
+        &SPIRVDecompiler::LogicalFUnordered,
+        &SPIRVDecompiler::Binary<&Module::OpFUnordLessThan, Type::Bool, Type::Float>,
+        &SPIRVDecompiler::Binary<&Module::OpFUnordEqual, Type::Bool, Type::Float>,
+        &SPIRVDecompiler::Binary<&Module::OpFUnordLessThanEqual, Type::Bool, Type::Float>,
+        &SPIRVDecompiler::Binary<&Module::OpFUnordGreaterThan, Type::Bool, Type::Float>,
+        &SPIRVDecompiler::Binary<&Module::OpFUnordNotEqual, Type::Bool, Type::Float>,
+        &SPIRVDecompiler::Binary<&Module::OpFUnordGreaterThanEqual, Type::Bool, Type::Float>,
 
         &SPIRVDecompiler::Binary<&Module::OpSLessThan, Type::Bool, Type::Int>,
         &SPIRVDecompiler::Binary<&Module::OpIEqual, Type::Bool, Type::Int>,

--- a/src/video_core/shader/decode.cpp
+++ b/src/video_core/shader/decode.cpp
@@ -255,7 +255,7 @@ void ShaderIR::InsertControlFlow(NodeBlock& bb, const ShaderBlock& block) {
         Node n = Operation(OperationCode::Branch, Immediate(branch_case.address));
         Node op_b = Immediate(branch_case.cmp_value);
         Node condition =
-            GetPredicateComparisonInteger(Tegra::Shader::PredCondition::Equal, false, op_a, op_b);
+            GetPredicateComparisonInteger(Tegra::Shader::PredCondition::EQ, false, op_a, op_b);
         auto result = Conditional(condition, {n});
         bb.push_back(result);
         global_code.push_back(result);

--- a/src/video_core/shader/decode/xmad.cpp
+++ b/src/video_core/shader/decode/xmad.cpp
@@ -97,19 +97,19 @@ u32 ShaderIR::DecodeXmad(NodeBlock& bb, u32 pc) {
             return SignedOperation(OperationCode::IAdd, is_signed_c, original_c, shifted_b);
         }
         case Tegra::Shader::XmadMode::CSfu: {
-            const Node comp_a = GetPredicateComparisonInteger(PredCondition::Equal, is_signed_a,
-                                                              op_a, Immediate(0));
-            const Node comp_b = GetPredicateComparisonInteger(PredCondition::Equal, is_signed_b,
-                                                              op_b, Immediate(0));
+            const Node comp_a =
+                GetPredicateComparisonInteger(PredCondition::EQ, is_signed_a, op_a, Immediate(0));
+            const Node comp_b =
+                GetPredicateComparisonInteger(PredCondition::EQ, is_signed_b, op_b, Immediate(0));
             const Node comp = Operation(OperationCode::LogicalOr, comp_a, comp_b);
 
             const Node comp_minus_a = GetPredicateComparisonInteger(
-                PredCondition::NotEqual, is_signed_a,
+                PredCondition::NE, is_signed_a,
                 SignedOperation(OperationCode::IBitwiseAnd, is_signed_a, op_a,
                                 Immediate(0x80000000)),
                 Immediate(0));
             const Node comp_minus_b = GetPredicateComparisonInteger(
-                PredCondition::NotEqual, is_signed_b,
+                PredCondition::NE, is_signed_b,
                 SignedOperation(OperationCode::IBitwiseAnd, is_signed_b, op_b,
                                 Immediate(0x80000000)),
                 Immediate(0));

--- a/src/video_core/shader/node.h
+++ b/src/video_core/shader/node.h
@@ -110,13 +110,20 @@ enum class OperationCode {
     LogicalPick2,  /// (bool2 pair, uint index) -> bool
     LogicalAnd2,   /// (bool2 a) -> bool
 
-    LogicalFLessThan,     /// (float a, float b) -> bool
-    LogicalFEqual,        /// (float a, float b) -> bool
-    LogicalFLessEqual,    /// (float a, float b) -> bool
-    LogicalFGreaterThan,  /// (float a, float b) -> bool
-    LogicalFNotEqual,     /// (float a, float b) -> bool
-    LogicalFGreaterEqual, /// (float a, float b) -> bool
-    LogicalFIsNan,        /// (float a) -> bool
+    LogicalFOrdLessThan,       /// (float a, float b) -> bool
+    LogicalFOrdEqual,          /// (float a, float b) -> bool
+    LogicalFOrdLessEqual,      /// (float a, float b) -> bool
+    LogicalFOrdGreaterThan,    /// (float a, float b) -> bool
+    LogicalFOrdNotEqual,       /// (float a, float b) -> bool
+    LogicalFOrdGreaterEqual,   /// (float a, float b) -> bool
+    LogicalFOrdered,           /// (float a, float b) -> bool
+    LogicalFUnordered,         /// (float a, float b) -> bool
+    LogicalFUnordLessThan,     /// (float a, float b) -> bool
+    LogicalFUnordEqual,        /// (float a, float b) -> bool
+    LogicalFUnordLessEqual,    /// (float a, float b) -> bool
+    LogicalFUnordGreaterThan,  /// (float a, float b) -> bool
+    LogicalFUnordNotEqual,     /// (float a, float b) -> bool
+    LogicalFUnordGreaterEqual, /// (float a, float b) -> bool
 
     LogicalILessThan,     /// (int a, int b) -> bool
     LogicalIEqual,        /// (int a, int b) -> bool


### PR DESCRIPTION
This allows us to use native SPIR-V instructions without having to manually check for NAN.

"Not equal" operators on GLSL seem to behave as unordered when we expect an ordered comparison. Manually emulate this checking for LGE values (numbers, "not-NaNs").

For example, this would have returned true instead of false:
```glsl
float a = NAN;
float b = 5;
return a != b;
```

These are the unit tests used for this pull request: [nxgputests.zip](https://github.com/yuzu-emu/yuzu/files/4602975/nxgputests.zip)

Current master would crash or generate invalid GLSL, but the relevant part is that these kind of tests were failing:
```
        MOV R0, c[0x0][0x140];
        MOV R1, c[0x0][0x144];
        MOV32I R2, 0xffffffff;
        MOV32I R3, 0x3f800000;
        FSETP.NE.FTZ.AND P0, PT, R2, R3, PT;
@!P0    MOV32I R2, 0xdead;
 @P0    MOV32I R2, 0xcafe;
        STG.E [R0], R2;
        EXIT;
```

No known games were affected by this.