### PR TITLE
externals: Cmake version checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ macro(yuzu_find_packages)
         #"libzip            1.5         libzip/1.5.2@bincrafters/stable"
         "lz4               1.8         lz4/1.9.2"
         "nlohmann_json     3.7         nlohmann_json/3.7.3"
+    # we need to be careful as the version check might be broken https://github.com/xiph/opus/issues/110
         "opus              1.3         opus/1.3.1"
         "ZLIB              1.2         zlib/1.2.11"
         "zstd              1.4         zstd/1.4.4"

--- a/externals/find-modules/FindCatch2.cmake
+++ b/externals/find-modules/FindCatch2.cmake
@@ -8,11 +8,25 @@ find_path(Catch2_INCLUDE_DIR
   PATH_SUFFIXES catch2
 )
 
+if(Catch2_INCLUDE_DIR)
+  file(STRINGS "${Catch2_INCLUDE_DIR}/catch.hpp" _Catch2_version_lines
+    REGEX "#define[ \t]+CATCH_VERSION_(MAJOR|MINOR|PATCH)")
+  string(REGEX REPLACE ".*CATCH_VERSION_MAJOR +\([0-9]+\).*" "\\1" _Catch2_version_major "${_Catch2_version_lines}")
+  string(REGEX REPLACE ".*CATCH_VERSION_MINOR +\([0-9]+\).*" "\\1" _Catch2_version_minor "${_Catch2_version_lines}")
+  string(REGEX REPLACE ".*CATCH_VERSION_PATCH +\([0-9]+\).*" "\\1" _Catch2_version_patch "${_Catch2_version_lines}")
+  set(Catch2_VERSION "${_Catch2_version_major}.${_Catch2_version_minor}.${_Catch2_version_patch}")
+  unset(_Catch2_version_major)
+  unset(_Catch2_version_minor)
+  unset(_Catch2_version_patch)
+  unset(_Catch2_version_lines)
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Catch2
   FOUND_VAR Catch2_FOUND
   REQUIRED_VARS
     Catch2_INCLUDE_DIR
+    Catch2_VERSION
   VERSION_VAR Catch2_VERSION
 )
 

--- a/externals/find-modules/FindLibzip.cmake
+++ b/externals/find-modules/FindLibzip.cmake
@@ -28,6 +28,16 @@ find_library(LIBZIP_LIBRARY
   "$ENV{LIB_DIR}/lib" "$ENV{LIB}" /usr/local/lib /usr/lib
 )
 
+if (LIBZIP_INCLUDE_DIR_ZIPCONF)
+  FILE(READ "${LIBZIP_INCLUDE_DIR_ZIPCONF}/zipconf.h" _LIBZIP_VERSION_CONTENTS)
+  if (_LIBZIP_VERSION_CONTENTS)
+    STRING(REGEX REPLACE ".*#define LIBZIP_VERSION \"([0-9.]+)\".*" "\\1" LIBZIP_VERSION "${_LIBZIP_VERSION_CONTENTS}")
+  endif()
+  unset(_LIBZIP_VERSION_CONTENTS)
+endif()
+
+set(LIBZIP_VERSION ${LIBZIP_VERSION} CACHE STRING "Version number of libzip")
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(Libzip
   FOUND_VAR LIBZIP_FOUND
@@ -35,18 +45,9 @@ find_package_handle_standard_args(Libzip
     LIBZIP_LIBRARY
     LIBZIP_INCLUDE_DIR
     LIBZIP_INCLUDE_DIR_ZIPCONF
+    LIBZIP_VERSION
+  VERSION_VAR LIBZIP_VERSION
 )
-
-set(LIBZIP_VERSION 0)
-
-if (LIBZIP_INCLUDE_DIR_ZIPCONF)
-  FILE(READ "${LIBZIP_INCLUDE_DIR_ZIPCONF}/zipconf.h" _LIBZIP_VERSION_CONTENTS)
-  if (_LIBZIP_VERSION_CONTENTS)
-    STRING(REGEX REPLACE ".*#define LIBZIP_VERSION \"([0-9.]+)\".*" "\\1" LIBZIP_VERSION "${_LIBZIP_VERSION_CONTENTS}")
-  endif()
-endif()
-
-set(LIBZIP_VERSION ${LIBZIP_VERSION} CACHE STRING "Version number of libzip")
 
 if(LIBZIP_FOUND)
   set(LIBZIP_LIBRARIES ${LIBZIP_LIBRARY})
@@ -65,5 +66,7 @@ endif()
 
 mark_as_advanced(
     LIBZIP_INCLUDE_DIR
+    LIBZIP_INCLUDE_DIR_ZIPCONF
     LIBZIP_LIBRARY
+    LIBZIP_VERSION
 )

--- a/externals/find-modules/Findfmt.cmake
+++ b/externals/find-modules/Findfmt.cmake
@@ -13,12 +13,38 @@ find_library(fmt_LIBRARY
   PATHS ${PC_fmt_LIBRARY_DIRS} ${CONAN_LIB_DIRS_fmt}
 )
 
+if(fmt_INCLUDE_DIR)
+  set(_fmt_version_file "${fmt_INCLUDE_DIR}/core.h")
+  if(NOT EXISTS "${_fmt_version_file}")
+    set(_fmt_version_file "${fmt_INCLUDE_DIR}/format.h")
+  endif()
+  if(EXISTS "${_fmt_version_file}")
+    # parse "#define FMT_VERSION 60200" to 6.2.0
+    file(STRINGS "${_fmt_version_file}" fmt_VERSION_LINE
+      REGEX "^#define[ \t]+FMT_VERSION[ \t]+[0-9]+$")
+    string(REGEX REPLACE "^#define[ \t]+FMT_VERSION[ \t]+([0-9]+)$"
+      "\\1" fmt_VERSION "${fmt_VERSION_LINE}")
+    foreach(ver "fmt_VERSION_PATCH" "fmt_VERSION_MINOR" "fmt_VERSION_MAJOR")
+      math(EXPR ${ver} "${fmt_VERSION} % 100")
+      math(EXPR fmt_VERSION "(${fmt_VERSION} - ${${ver}}) / 100")
+    endforeach()
+    set(fmt_VERSION
+      "${fmt_VERSION_MAJOR}.${fmt_VERSION_MINOR}.${fmt_VERSION_PATCH}")
+  endif()
+  unset(_fmt_version_file)
+  unset(fmt_VERSION_LINE)
+  unset(fmt_VERSION_MAJOR)
+  unset(fmt_VERSION_MINOR)
+  unset(fmt_VERSION_PATCH)
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(fmt
   FOUND_VAR fmt_FOUND
   REQUIRED_VARS
     fmt_LIBRARY
     fmt_INCLUDE_DIR
+    fmt_VERSION
   VERSION_VAR fmt_VERSION
 )
 

--- a/externals/find-modules/Findnlohmann_json.cmake
+++ b/externals/find-modules/Findnlohmann_json.cmake
@@ -8,11 +8,25 @@ find_path(nlohmann_json_INCLUDE_DIR
   PATH_SUFFIXES nlohmann
 )
 
+if(nlohmann_json_INCLUDE_DIR)
+  file(STRINGS "${nlohmann_json_INCLUDE_DIR}/json.hpp" _nlohmann_json_version_lines
+    REGEX "#define[ \t]+NLOHMANN_JSON_VERSION_(MAJOR|MINOR|PATCH)")
+  string(REGEX REPLACE ".*NLOHMANN_JSON_VERSION_MAJOR +\([0-9]+\).*" "\\1" _nlohmann_json_version_major "${_nlohmann_json_version_lines}")
+  string(REGEX REPLACE ".*NLOHMANN_JSON_VERSION_MINOR +\([0-9]+\).*" "\\1" _nlohmann_json_version_minor "${_nlohmann_json_version_lines}")
+  string(REGEX REPLACE ".*NLOHMANN_JSON_VERSION_PATCH +\([0-9]+\).*" "\\1" _nlohmann_json_version_patch "${_nlohmann_json_version_lines}")
+  set(nlohmann_json_VERSION "${_nlohmann_json_version_major}.${_nlohmann_json_version_minor}.${_nlohmann_json_version_patch}")
+  unset(_nlohmann_json_version_major)
+  unset(_nlohmann_json_version_minor)
+  unset(_nlohmann_json_version_patch)
+  unset(_nlohmann_json_version_lines)
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(nlohmann_json
   FOUND_VAR nlohmann_json_FOUND
   REQUIRED_VARS
     nlohmann_json_INCLUDE_DIR
+    nlohmann_json_VERSION
   VERSION_VAR nlohmann_json_VERSION
 )
 

--- a/externals/find-modules/Findzstd.cmake
+++ b/externals/find-modules/Findzstd.cmake
@@ -11,12 +11,26 @@ find_library(zstd_LIBRARY
   PATHS ${PC_zstd_LIBRARY_DIRS}
 )
 
+if(zstd_INCLUDE_DIR)
+  file(STRINGS "${zstd_INCLUDE_DIR}/zstd.h" _zstd_version_lines
+    REGEX "#define[ \t]+ZSTD_VERSION_(MAJOR|MINOR|RELEASE)")
+  string(REGEX REPLACE ".*ZSTD_VERSION_MAJOR *\([0-9]*\).*" "\\1" _zstd_version_major "${_zstd_version_lines}")
+  string(REGEX REPLACE ".*ZSTD_VERSION_MINOR *\([0-9]*\).*" "\\1" _zstd_version_minor "${_zstd_version_lines}")
+  string(REGEX REPLACE ".*ZSTD_VERSION_RELEASE *\([0-9]*\).*" "\\1" _zstd_version_release "${_zstd_version_lines}")
+  set(zstd_VERSION "${_zstd_version_major}.${_zstd_version_minor}.${_zstd_version_release}")
+  unset(_zstd_version_major)
+  unset(_zstd_version_minor)
+  unset(_zstd_version_release)
+  unset(_zstd_version_lines)
+endif()
+
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(zstd
   FOUND_VAR zstd_FOUND
   REQUIRED_VARS
     zstd_LIBRARY
     zstd_INCLUDE_DIR
+    zstd_VERSION
   VERSION_VAR zstd_VERSION
 )
 


### PR DESCRIPTION
This pull requests implements propper version checking for all modules (but opus). This will ensure that older versions of the system libraries will be rejected and conan will be used instead.

Fixes #3790