### PR TITLE
Improve time zone support

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -148,6 +148,8 @@ add_library(common STATIC
     thread.h
     thread_queue_list.h
     threadsafe_queue.h
+    time_zone.cpp
+    time_zone.h
     timer.cpp
     timer.h
     uint128.cpp

--- a/src/common/time_zone.cpp
+++ b/src/common/time_zone.cpp
@@ -37,13 +37,13 @@ static int ConvertOsTimeZoneOffsetToInt(const std::string& timezone) {
     }
 }
 
-int GetCurrentOffsetSeconds() {
+std::chrono::seconds GetCurrentOffsetSeconds() {
     const int offset{ConvertOsTimeZoneOffsetToInt(GetOsTimeZoneOffset())};
 
     int seconds{(offset / 100) * 60 * 60}; // Convert hour component to seconds
     seconds += (offset % 100) * 60;        // Convert minute component to seconds
 
-    return seconds;
+    return std::chrono::seconds{seconds};
 }
 
 } // namespace Common::TimeZone

--- a/src/common/time_zone.cpp
+++ b/src/common/time_zone.cpp
@@ -1,0 +1,49 @@
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <chrono>
+#include <iomanip>
+#include <sstream>
+
+#include "common/logging/log.h"
+#include "common/time_zone.h"
+
+namespace Common::TimeZone {
+
+std::string GetDefaultTimeZone() {
+    return "GMT";
+}
+
+static std::string GetOsTimeZoneOffset() {
+    const std::time_t t{std::time(nullptr)};
+    const std::tm tm{*std::localtime(&t)};
+
+    std::stringstream ss;
+    ss << std::put_time(&tm, "%z"); // Get the current timezone offset, e.g. "-400", as a string
+
+    return ss.str();
+}
+
+static int ConvertOsTimeZoneOffsetToInt(const std::string& timezone) {
+    try {
+        return std::stoi(timezone);
+    } catch (const std::invalid_argument&) {
+        LOG_CRITICAL(Common, "invalid_argument with {}!", timezone);
+        return 0;
+    } catch (const std::out_of_range&) {
+        LOG_CRITICAL(Common, "out_of_range with {}!", timezone);
+        return 0;
+    }
+}
+
+int GetCurrentOffsetSeconds() {
+    const int offset{ConvertOsTimeZoneOffsetToInt(GetOsTimeZoneOffset())};
+
+    int seconds{(offset / 100) * 60 * 60}; // Convert hour component to seconds
+    seconds += (offset % 100) * 60;        // Convert minute component to seconds
+
+    return seconds;
+}
+
+} // namespace Common::TimeZone

--- a/src/common/time_zone.h
+++ b/src/common/time_zone.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <string>
 
 namespace Common::TimeZone {
@@ -12,6 +13,6 @@ namespace Common::TimeZone {
 std::string GetDefaultTimeZone();
 
 /// Gets the offset of the current timezone (from the default), in seconds
-int GetCurrentOffsetSeconds();
+std::chrono::seconds GetCurrentOffsetSeconds();
 
 } // namespace Common::TimeZone

--- a/src/common/time_zone.h
+++ b/src/common/time_zone.h
@@ -1,0 +1,17 @@
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+
+namespace Common::TimeZone {
+
+/// Gets the default timezone, i.e. "GMT"
+std::string GetDefaultTimeZone();
+
+/// Gets the offset of the current timezone (from the default), in seconds
+int GetCurrentOffsetSeconds();
+
+} // namespace Common::TimeZone

--- a/src/core/hle/service/time/time_manager.cpp
+++ b/src/core/hle/service/time/time_manager.cpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <ctime>
 
+#include "common/time_zone.h"
 #include "core/hle/service/time/ephemeral_network_system_clock_context_writer.h"
 #include "core/hle/service/time/local_system_clock_context_writer.h"
 #include "core/hle/service/time/network_system_clock_context_writer.h"
@@ -21,8 +22,16 @@ static std::chrono::seconds GetSecondsSinceEpoch() {
            Settings::values.custom_rtc_differential;
 }
 
+static s64 GetExternalTimeZoneOffset() {
+    // With "auto" timezone setting, we use the external system's timezone offset
+    if (Settings::GetTimeZoneString() == "auto") {
+        return Common::TimeZone::GetCurrentOffsetSeconds();
+    }
+    return 0;
+}
+
 static s64 GetExternalRtcValue() {
-    return GetSecondsSinceEpoch().count();
+    return GetSecondsSinceEpoch().count() + GetExternalTimeZoneOffset();
 }
 
 TimeManager::TimeManager(Core::System& system)

--- a/src/core/hle/service/time/time_manager.cpp
+++ b/src/core/hle/service/time/time_manager.cpp
@@ -25,7 +25,7 @@ static std::chrono::seconds GetSecondsSinceEpoch() {
 static s64 GetExternalTimeZoneOffset() {
     // With "auto" timezone setting, we use the external system's timezone offset
     if (Settings::GetTimeZoneString() == "auto") {
-        return Common::TimeZone::GetCurrentOffsetSeconds();
+        return Common::TimeZone::GetCurrentOffsetSeconds().count();
     }
     return 0;
 }

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -63,6 +63,21 @@ const std::array<const char*, NumMouseButtons> mapping = {{
 
 Values values = {};
 
+std::string GetTimeZoneString() {
+    static constexpr std::array<const char*, 46> timezones{{
+        "auto",      "default",   "CET", "CST6CDT", "Cuba",    "EET",    "Egypt",     "Eire",
+        "EST",       "EST5EDT",   "GB",  "GB-Eire", "GMT",     "GMT+0",  "GMT-0",     "GMT0",
+        "Greenwich", "Hongkong",  "HST", "Iceland", "Iran",    "Israel", "Jamaica",   "Japan",
+        "Kwajalein", "Libya",     "MET", "MST",     "MST7MDT", "Navajo", "NZ",        "NZ-CHAT",
+        "Poland",    "Portugal",  "PRC", "PST8PDT", "ROC",     "ROK",    "Singapore", "Turkey",
+        "UCT",       "Universal", "UTC", "W-SU",    "WET",     "Zulu",
+    }};
+
+    ASSERT(Settings::values.time_zone_index < timezones.size());
+
+    return timezones[Settings::values.time_zone_index];
+}
+
 void Apply() {
     GDBStub::SetServerPort(values.gdbstub_port);
     GDBStub::ToggleServer(values.use_gdbstub);
@@ -87,6 +102,7 @@ void LogSettings() {
     LogSetting("System_CurrentUser", Settings::values.current_user);
     LogSetting("System_LanguageIndex", Settings::values.language_index);
     LogSetting("System_RegionIndex", Settings::values.region_index);
+    LogSetting("System_TimeZoneIndex", Settings::values.time_zone_index);
     LogSetting("Core_UseMultiCore", Settings::values.use_multi_core);
     LogSetting("Renderer_UseResolutionFactor", Settings::values.resolution_factor);
     LogSetting("Renderer_UseFrameLimit", Settings::values.use_frame_limit);

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -394,6 +394,7 @@ struct Values {
     s32 current_user;
     s32 language_index;
     s32 region_index;
+    s32 time_zone_index;
     s32 sound_index;
 
     // Controls
@@ -490,6 +491,9 @@ struct Values {
 bool IsGPULevelExtreme();
 bool IsGPULevelHigh();
 
+std::string GetTimeZoneString();
+
 void Apply();
 void LogSettings();
+
 } // namespace Settings

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -687,6 +687,8 @@ void Config::ReadSystemValues() {
 
     Settings::values.region_index = ReadSetting(QStringLiteral("region_index"), 1).toInt();
 
+    Settings::values.time_zone_index = ReadSetting(QStringLiteral("time_zone_index"), 0).toInt();
+
     const auto rng_seed_enabled = ReadSetting(QStringLiteral("rng_seed_enabled"), false).toBool();
     if (rng_seed_enabled) {
         Settings::values.rng_seed = ReadSetting(QStringLiteral("rng_seed"), 0).toULongLong();
@@ -1126,6 +1128,7 @@ void Config::SaveSystemValues() {
     WriteSetting(QStringLiteral("current_user"), Settings::values.current_user, 0);
     WriteSetting(QStringLiteral("language_index"), Settings::values.language_index, 1);
     WriteSetting(QStringLiteral("region_index"), Settings::values.region_index, 1);
+    WriteSetting(QStringLiteral("time_zone_index"), Settings::values.time_zone_index, 0);
 
     WriteSetting(QStringLiteral("rng_seed_enabled"), Settings::values.rng_seed.has_value(), false);
     WriteSetting(QStringLiteral("rng_seed"), Settings::values.rng_seed.value_or(0), 0);

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -57,6 +57,7 @@ void ConfigureSystem::SetConfiguration() {
 
     ui->combo_language->setCurrentIndex(Settings::values.language_index);
     ui->combo_region->setCurrentIndex(Settings::values.region_index);
+    ui->combo_time_zone->setCurrentIndex(Settings::values.time_zone_index);
     ui->combo_sound->setCurrentIndex(Settings::values.sound_index);
 
     ui->rng_seed_checkbox->setChecked(Settings::values.rng_seed.has_value());
@@ -84,6 +85,7 @@ void ConfigureSystem::ApplyConfiguration() {
 
     Settings::values.language_index = ui->combo_language->currentIndex();
     Settings::values.region_index = ui->combo_region->currentIndex();
+    Settings::values.time_zone_index = ui->combo_time_zone->currentIndex();
     Settings::values.sound_index = ui->combo_sound->currentIndex();
 
     if (ui->rng_seed_checkbox->isChecked()) {

--- a/src/yuzu/configuration/configure_system.h
+++ b/src/yuzu/configuration/configure_system.h
@@ -37,5 +37,6 @@ private:
 
     int language_index = 0;
     int region_index = 0;
+    int time_zone_index = 0;
     int sound_index = 0;
 };

--- a/src/yuzu/configuration/configure_system.ui
+++ b/src/yuzu/configuration/configure_system.ui
@@ -22,14 +22,14 @@
         <string>System Settings</string>
        </property>
        <layout class="QGridLayout" name="gridLayout">
-        <item row="2" column="0">
+        <item row="3" column="0">
          <widget class="QLabel" name="label_sound">
           <property name="text">
            <string>Sound output mode</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
+        <item row="4" column="0">
          <widget class="QLabel" name="label_console_id">
           <property name="text">
            <string>Console ID:</string>
@@ -174,14 +174,255 @@
           </item>
          </widget>
         </item>
-        <item row="5" column="0">
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_timezone">
+          <property name="text">
+           <string>Time Zone:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QComboBox" name="combo_time_zone">
+          <item>
+           <property name="text">
+            <string>Auto</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Default</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>CET</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>CST6CDT</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Cuba</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>EET</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Egypt</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Eire</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>EST</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>EST5EDT</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>GB</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>GB-Eire</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>GMT</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>GMT+0</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>GMT-0</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>GMT0</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Greenwich</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Hongkong</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>HST</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Iceland</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Iran</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Israel</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Jamaica</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Japan</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Kwajalein</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Libya</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>MET</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>MST</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>MST7MDT</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Navajo</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>NZ</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>NZ-CHAT</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Poland</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Portugal</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>PRC</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>PST8PDT</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ROC</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>ROK</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Singapore</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Turkey</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>UCT</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Universal</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>UTC</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>W-SU</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>WET</string>
+           </property>
+          </item>
+          <item>
+           <property name="text">
+            <string>Zulu</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item row="6" column="0">
          <widget class="QCheckBox" name="rng_seed_checkbox">
           <property name="text">
            <string>RNG Seed</string>
           </property>
          </widget>
         </item>
-        <item row="2" column="1">
+        <item row="3" column="1">
          <widget class="QComboBox" name="combo_sound">
           <item>
            <property name="text">
@@ -207,7 +448,7 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="4" column="1">
          <widget class="QPushButton" name="button_regenerate_console_id">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -223,14 +464,14 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
+        <item row="5" column="0">
          <widget class="QCheckBox" name="custom_rtc_checkbox">
           <property name="text">
            <string>Custom RTC</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
+        <item row="5" column="1">
          <widget class="QDateTimeEdit" name="custom_rtc_edit">
           <property name="minimumDate">
            <date>
@@ -244,7 +485,7 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="1">
+        <item row="6" column="1">
          <widget class="QLineEdit" name="rng_seed_edit">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -367,6 +367,9 @@ void Config::ReadValues() {
         Settings::values.custom_rtc = std::nullopt;
     }
 
+    Settings::values.language_index = sdl2_config->GetInteger("System", "language_index", 1);
+    Settings::values.time_zone_index = sdl2_config->GetInteger("System", "time_zone_index", 0);
+
     // Core
     Settings::values.use_multi_core = sdl2_config->GetBoolean("Core", "use_multi_core", false);
 
@@ -408,8 +411,6 @@ void Config::ReadValues() {
         sdl2_config->GetBoolean("Audio", "enable_audio_stretching", true);
     Settings::values.audio_device_id = sdl2_config->Get("Audio", "output_device", "auto");
     Settings::values.volume = static_cast<float>(sdl2_config->GetReal("Audio", "volume", 1));
-
-    Settings::values.language_index = sdl2_config->GetInteger("System", "language_index", 1);
 
     // Miscellaneous
     Settings::values.log_filter = sdl2_config->Get("Miscellaneous", "log_filter", "*:Trace");

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -262,6 +262,10 @@ language_index =
 # -1: Auto-select (default), 0: Japan, 1: USA, 2: Europe, 3: Australia, 4: China, 5: Korea, 6: Taiwan
 region_value =
 
+# The system time zone that yuzu will use during emulation
+# 0: Auto-select (default), 1: Default (system archive value), Others: Index for specified time zone
+time_zone_index =
+
 [Miscellaneous]
 # A filter which removes logs below a certain logging level.
 # Examples: *:Debug Kernel.SVC:Trace Service.*:Critical


### PR DESCRIPTION
Various improvements to time zone support. Tested against ACNH. 

* Tries to detect current time zone and use that. Windows only for now, and fairly incomplete.
* Adds a setting to manually change the time zone.