### PR TITLE
main: Log host system memory parameters

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -123,6 +123,8 @@ add_library(common STATIC
     lz4_compression.cpp
     lz4_compression.h
     math_util.h
+    memory_detect.cpp
+    memory_detect.h
     memory_hook.cpp
     memory_hook.h
     microprofile.cpp

--- a/src/common/memory_detect.cpp
+++ b/src/common/memory_detect.cpp
@@ -33,10 +33,13 @@ static MemoryInfo Detect() {
 #elif defined(__APPLE__)
     u64 ramsize;
     struct xsw_usage vmusage;
+    std::size_t sizeof_ramsize = sizeof(ramsize);
+    std::size_t sizeof_vmusage = sizeof(vmusage);
     // hw and vm are defined in sysctl.h
     // https://github.com/apple/darwin-xnu/blob/master/bsd/sys/sysctl.h#L471
-    sysctlbyname(hw.memsize, &ramsize, sizeof(ramsize), NULL, 0);
-    sysctlbyname(vm.swapusage, &vmusage, sizeof(vmusage), NULL, 0);
+    // sysctlbyname(const char *, void *, size_t *, void *, size_t);
+    sysctlbyname("hw.memsize", &ramsize, &sizeof_ramsize, NULL, 0);
+    sysctlbyname("vm.swapusage", &vmusage, &sizeof_vmusage, NULL, 0);
     mem_info.TotalPhysicalMemory = ramsize;
     mem_info.TotalSwapMemory = vmusage.xsu_total;
 #else

--- a/src/common/memory_detect.cpp
+++ b/src/common/memory_detect.cpp
@@ -1,0 +1,57 @@
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#ifdef _WIN32
+// clang-format off
+#include <windows.h>
+#include <sysinfoapi.h>
+// clang-format on
+#else
+#include <sys/types.h>
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#else
+#include <sys/sysinfo.h>
+#endif
+#endif
+
+#include "common/memory_detect.h"
+
+namespace Common {
+
+// Detects the RAM and Swapfile sizes
+static MemoryInfo Detect() {
+    MemoryInfo mem_info{};
+
+#ifdef _WIN32
+    MEMORYSTATUSEX memorystatus;
+    memorystatus.dwLength = sizeof(memorystatus);
+    GlobalMemoryStatusEx(&memorystatus);
+    mem_info.TotalPhysicalMemory = memorystatus.ullTotalPhys;
+    mem_info.TotalSwapMemory = memorystatus.ullTotalPageFile - mem_info.TotalPhysicalMemory;
+#elif defined(__APPLE__)
+    u64 ramsize;
+    struct xsw_usage vmusage;
+    // hw and vm are defined in sysctl.h
+    // https://github.com/apple/darwin-xnu/blob/master/bsd/sys/sysctl.h#L471
+    sysctlbyname(hw.memsize, &ramsize, sizeof(ramsize), NULL, 0);
+    sysctlbyname(vm.swapusage, &vmusage, sizeof(vmusage), NULL, 0);
+    mem_info.TotalPhysicalMemory = ramsize;
+    mem_info.TotalSwapMemory = vmusage.xsu_total;
+#else
+    struct sysinfo meminfo;
+    sysinfo(&meminfo);
+    mem_info.TotalPhysicalMemory = meminfo.totalram;
+    mem_info.TotalSwapMemory = meminfo.totalswap;
+#endif
+
+    return mem_info;
+}
+
+const MemoryInfo& GetMemInfo() {
+    static MemoryInfo mem_info = Detect();
+    return mem_info;
+}
+
+} // namespace Common

--- a/src/common/memory_detect.h
+++ b/src/common/memory_detect.h
@@ -1,0 +1,22 @@
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common/common_types.h"
+
+namespace Common {
+
+struct MemoryInfo {
+    u64 TotalPhysicalMemory{};
+    u64 TotalSwapMemory{};
+};
+
+/**
+ * Gets the memory info of the host system
+ * @return Reference to a MemoryInfo struct with the physical and swap memory sizes in bytes
+ */
+const MemoryInfo& GetMemInfo();
+
+} // namespace Common

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -65,6 +65,7 @@ static FileSys::VirtualFile VfsDirectoryCreateFileWrapper(const FileSys::Virtual
 #include "common/logging/backend.h"
 #include "common/logging/filter.h"
 #include "common/logging/log.h"
+#include "common/memory_detect.h"
 #include "common/microprofile.h"
 #include "common/scm_rev.h"
 #include "common/scope_exit.h"
@@ -219,6 +220,10 @@ GMainWindow::GMainWindow()
     LOG_INFO(Frontend, "Host CPU: {}", Common::GetCPUCaps().cpu_string);
 #endif
     LOG_INFO(Frontend, "Host OS: {}", QSysInfo::prettyProductName().toStdString());
+    LOG_INFO(Frontend, "Host RAM: {:.2f} GB",
+             Common::GetMemInfo().TotalPhysicalMemory / 1024.0f / 1024 / 1024);
+    LOG_INFO(Frontend, "Host Swapfile: {:.2f} GB",
+             Common::GetMemInfo().TotalSwapMemory / 1024.0f / 1024 / 1024);
     UpdateWindowTitle();
 
     show();

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -222,7 +222,7 @@ GMainWindow::GMainWindow()
     LOG_INFO(Frontend, "Host OS: {}", QSysInfo::prettyProductName().toStdString());
     LOG_INFO(Frontend, "Host RAM: {:.2f} GB",
              Common::GetMemInfo().TotalPhysicalMemory / 1024.0f / 1024 / 1024);
-    LOG_INFO(Frontend, "Host Swapfile: {:.2f} GB",
+    LOG_INFO(Frontend, "Host Swap: {:.2f} GB",
              Common::GetMemInfo().TotalSwapMemory / 1024.0f / 1024 / 1024);
     UpdateWindowTitle();
 


### PR DESCRIPTION
Logs both physical memory and swap(file) sizes. These values are useful when giving support as yuzu requires a large pagefile/swap(file) in cases of low physical memory (less than 8 GB) to prevent early crashes.

Tested on both Windows and Linux, ~~macOS is untested.~~

**Update**: macOS is unit tested and verified to work on macOS High Sierra 10.13.6

In the log, it will show these 2 lines:

```
Host RAM: 15.85 GB
Host Swap: 16.00 GB
```