### PR TITLE
buffer_cache: Replace boost::icl::interval_map with boost::intrusive::set

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(video_core STATIC
     buffer_cache/buffer_block.h
     buffer_cache/buffer_cache.h
+    buffer_cache/map_interval.cpp
     buffer_cache/map_interval.h
     dirty_flags.cpp
     dirty_flags.h

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -13,10 +13,8 @@
 #include <vector>
 
 #include <boost/container/small_vector.hpp>
-#include <boost/icl/interval_map.hpp>
 #include <boost/icl/interval_set.hpp>
 #include <boost/intrusive/set.hpp>
-#include <boost/range/iterator_range.hpp>
 
 #include "common/alignment.h"
 #include "common/assert.h"

--- a/src/video_core/buffer_cache/map_interval.cpp
+++ b/src/video_core/buffer_cache/map_interval.cpp
@@ -1,0 +1,33 @@
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <memory>
+
+#include "video_core/buffer_cache/map_interval.h"
+
+namespace VideoCommon {
+
+MapIntervalAllocator::MapIntervalAllocator() {
+    FillFreeList(first_chunk);
+}
+
+MapIntervalAllocator::~MapIntervalAllocator() = default;
+
+void MapIntervalAllocator::AllocateNewChunk() {
+    *new_chunk = std::make_unique<Chunk>();
+    FillFreeList(**new_chunk);
+    new_chunk = &(*new_chunk)->next;
+}
+
+void MapIntervalAllocator::FillFreeList(Chunk& chunk) {
+    const std::size_t old_size = free_list.size();
+    free_list.resize(old_size + chunk.data.size());
+    std::transform(chunk.data.rbegin(), chunk.data.rend(), free_list.begin() + old_size,
+                   [](MapInterval& interval) { return &interval; });
+}
+
+} // namespace VideoCommon

--- a/src/video_core/buffer_cache/map_interval.h
+++ b/src/video_core/buffer_cache/map_interval.h
@@ -9,12 +9,22 @@
 
 namespace VideoCommon {
 
-struct MapIntervalBase {
-    constexpr explicit MapIntervalBase(VAddr start, VAddr end, GPUVAddr gpu_addr) noexcept
+struct MapInterval {
+    constexpr explicit MapInterval() noexcept = default;
+
+    constexpr explicit MapInterval(VAddr start, VAddr end, GPUVAddr gpu_addr) noexcept
         : start{start}, end{end}, gpu_addr{gpu_addr} {}
 
-    constexpr bool IsInside(const VAddr other_start, const VAddr other_end) const noexcept {
+    constexpr bool IsInside(VAddr other_start, VAddr other_end) const noexcept {
         return (start <= other_start && other_end <= end);
+    }
+
+    constexpr bool operator==(const MapInterval& rhs) const noexcept {
+        return start == rhs.start && end == rhs.end;
+    }
+
+    constexpr bool operator!=(const MapInterval& rhs) const noexcept {
+        return !operator==(rhs);
     }
 
     constexpr void MarkAsModified(bool is_modified_, u64 ticks_) noexcept {
@@ -22,17 +32,9 @@ struct MapIntervalBase {
         ticks = ticks_;
     }
 
-    constexpr bool operator==(const MapIntervalBase& rhs) const noexcept {
-        return start == rhs.start && end == rhs.end;
-    }
-
-    constexpr bool operator!=(const MapIntervalBase& rhs) const noexcept {
-        return !operator==(rhs);
-    }
-
-    VAddr start;
-    VAddr end;
-    GPUVAddr gpu_addr;
+    VAddr start = 0;
+    VAddr end = 0;
+    GPUVAddr gpu_addr = 0;
     VAddr cpu_addr = 0;
     u64 ticks = 0;
     bool is_written = false;

--- a/src/video_core/buffer_cache/map_interval.h
+++ b/src/video_core/buffer_cache/map_interval.h
@@ -9,99 +9,37 @@
 
 namespace VideoCommon {
 
-class MapIntervalBase {
-public:
-    MapIntervalBase(const VAddr start, const VAddr end, const GPUVAddr gpu_addr)
+struct MapIntervalBase {
+    constexpr explicit MapIntervalBase(VAddr start, VAddr end, GPUVAddr gpu_addr) noexcept
         : start{start}, end{end}, gpu_addr{gpu_addr} {}
 
-    void SetCpuAddress(VAddr new_cpu_addr) {
-        cpu_addr = new_cpu_addr;
-    }
-
-    VAddr GetCpuAddress() const {
-        return cpu_addr;
-    }
-
-    GPUVAddr GetGpuAddress() const {
-        return gpu_addr;
-    }
-
-    bool IsInside(const VAddr other_start, const VAddr other_end) const {
+    constexpr bool IsInside(const VAddr other_start, const VAddr other_end) const noexcept {
         return (start <= other_start && other_end <= end);
     }
 
-    bool operator==(const MapIntervalBase& rhs) const {
-        return std::tie(start, end) == std::tie(rhs.start, rhs.end);
+    constexpr void MarkAsModified(bool is_modified_, u64 ticks_) noexcept {
+        is_modified = is_modified_;
+        ticks = ticks_;
     }
 
-    bool operator!=(const MapIntervalBase& rhs) const {
+    constexpr bool operator==(const MapIntervalBase& rhs) const noexcept {
+        return start == rhs.start && end == rhs.end;
+    }
+
+    constexpr bool operator!=(const MapIntervalBase& rhs) const noexcept {
         return !operator==(rhs);
     }
 
-    void MarkAsRegistered(const bool registered) {
-        is_registered = registered;
-    }
-
-    bool IsRegistered() const {
-        return is_registered;
-    }
-
-    void SetMemoryMarked(bool is_memory_marked_) {
-        is_memory_marked = is_memory_marked_;
-    }
-
-    bool IsMemoryMarked() const {
-        return is_memory_marked;
-    }
-
-    void SetSyncPending(bool is_sync_pending_) {
-        is_sync_pending = is_sync_pending_;
-    }
-
-    bool IsSyncPending() const {
-        return is_sync_pending;
-    }
-
-    VAddr GetStart() const {
-        return start;
-    }
-
-    VAddr GetEnd() const {
-        return end;
-    }
-
-    void MarkAsModified(const bool is_modified_, const u64 tick) {
-        is_modified = is_modified_;
-        ticks = tick;
-    }
-
-    bool IsModified() const {
-        return is_modified;
-    }
-
-    u64 GetModificationTick() const {
-        return ticks;
-    }
-
-    void MarkAsWritten(const bool is_written_) {
-        is_written = is_written_;
-    }
-
-    bool IsWritten() const {
-        return is_written;
-    }
-
-private:
     VAddr start;
     VAddr end;
     GPUVAddr gpu_addr;
-    VAddr cpu_addr{};
-    bool is_written{};
-    bool is_modified{};
-    bool is_registered{};
-    bool is_memory_marked{};
-    bool is_sync_pending{};
-    u64 ticks{};
+    VAddr cpu_addr = 0;
+    u64 ticks = 0;
+    bool is_written = false;
+    bool is_modified = false;
+    bool is_registered = false;
+    bool is_memory_marked = false;
+    bool is_sync_pending = false;
 };
 
 } // namespace VideoCommon

--- a/src/video_core/buffer_cache/map_interval.h
+++ b/src/video_core/buffer_cache/map_interval.h
@@ -4,44 +4,48 @@
 
 #pragma once
 
+#include <boost/intrusive/set_hook.hpp>
+
 #include "common/common_types.h"
 #include "video_core/gpu.h"
 
 namespace VideoCommon {
 
-struct MapInterval {
-    constexpr explicit MapInterval() noexcept = default;
+struct MapInterval : public boost::intrusive::set_base_hook<boost::intrusive::optimize_size<true>> {
+    /*implicit*/ MapInterval(VAddr start_) noexcept : start{start_} {}
 
-    constexpr explicit MapInterval(VAddr start, VAddr end, GPUVAddr gpu_addr) noexcept
-        : start{start}, end{end}, gpu_addr{gpu_addr} {}
+    explicit MapInterval(VAddr start_, VAddr end_, GPUVAddr gpu_addr_) noexcept
+        : start{start_}, end{end_}, gpu_addr{gpu_addr_} {}
 
-    constexpr bool IsInside(VAddr other_start, VAddr other_end) const noexcept {
-        return (start <= other_start && other_end <= end);
+    bool IsInside(VAddr other_start, VAddr other_end) const noexcept {
+        return start <= other_start && other_end <= end;
     }
 
-    constexpr bool operator==(const MapInterval& rhs) const noexcept {
-        return start == rhs.start && end == rhs.end;
+    bool Overlaps(VAddr other_start, VAddr other_end) const noexcept {
+        return start < other_end && other_start < end;
     }
 
-    constexpr bool operator!=(const MapInterval& rhs) const noexcept {
-        return !operator==(rhs);
-    }
-
-    constexpr void MarkAsModified(bool is_modified_, u64 ticks_) noexcept {
+    void MarkAsModified(bool is_modified_, u64 ticks_) noexcept {
         is_modified = is_modified_;
         ticks = ticks_;
     }
 
+    boost::intrusive::set_member_hook<> member_hook_;
     VAddr start = 0;
     VAddr end = 0;
     GPUVAddr gpu_addr = 0;
-    VAddr cpu_addr = 0;
     u64 ticks = 0;
     bool is_written = false;
     bool is_modified = false;
     bool is_registered = false;
     bool is_memory_marked = false;
     bool is_sync_pending = false;
+};
+
+struct MapIntervalCompare {
+    constexpr bool operator()(const MapInterval& lhs, const MapInterval& rhs) const noexcept {
+        return lhs.start < rhs.start;
+    }
 };
 
 } // namespace VideoCommon

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -8,6 +8,7 @@
 
 #include "common/assert.h"
 #include "common/microprofile.h"
+#include "video_core/buffer_cache/buffer_cache.h"
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_opengl/gl_buffer_cache.h"

--- a/src/video_core/renderer_opengl/gl_fence_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_fence_manager.cpp
@@ -4,6 +4,7 @@
 
 #include "common/assert.h"
 
+#include "video_core/renderer_opengl/gl_buffer_cache.h"
 #include "video_core/renderer_opengl/gl_fence_manager.h"
 
 namespace OpenGL {

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "core/core.h"
+#include "video_core/buffer_cache/buffer_cache.h"
 #include "video_core/renderer_vulkan/vk_buffer_cache.h"
 #include "video_core/renderer_vulkan/vk_device.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"

--- a/src/video_core/renderer_vulkan/vk_fence_manager.h
+++ b/src/video_core/renderer_vulkan/vk_fence_manager.h
@@ -7,6 +7,7 @@
 #include <memory>
 
 #include "video_core/fence_manager.h"
+#include "video_core/renderer_vulkan/vk_buffer_cache.h"
 #include "video_core/renderer_vulkan/wrapper.h"
 
 namespace Core {


### PR DESCRIPTION
Instead of using boost::icl::interval_map for caching, use
boost::intrusive::set. interval_map is intended as a container where the
keys can overlap with one another; we don't need this for caching
buffers and a std::set-like data structure that allows us to search with
lower_bound is enough.

This aims to keep mapped addresses close to one another in memory.