### PR TITLE
fixed_pipeline_state,gl_rasterizer: Swap negative viewport checks for front faces

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1031,6 +1031,26 @@ void RasterizerOpenGL::SyncViewport() {
     const auto& regs = gpu.regs;
 
     const bool dirty_viewport = flags[Dirty::Viewports];
+    const bool dirty_clip_control = flags[Dirty::ClipControl];
+
+    if (dirty_clip_control || flags[Dirty::FrontFace]) {
+        flags[Dirty::FrontFace] = false;
+
+        GLenum mode = MaxwellToGL::FrontFace(regs.front_face);
+        if (regs.screen_y_control.triangle_rast_flip != 0 &&
+            regs.viewport_transform[0].scale_y < 0.0f) {
+            switch (mode) {
+            case GL_CW:
+                mode = GL_CCW;
+                break;
+            case GL_CCW:
+                mode = GL_CW;
+                break;
+            }
+        }
+        glFrontFace(mode);
+    }
+
     if (dirty_viewport || flags[Dirty::ClipControl]) {
         flags[Dirty::ClipControl] = false;
 
@@ -1127,11 +1147,6 @@ void RasterizerOpenGL::SyncCullMode() {
         } else {
             glDisable(GL_CULL_FACE);
         }
-    }
-
-    if (flags[Dirty::FrontFace]) {
-        flags[Dirty::FrontFace] = false;
-        glFrontFace(MaxwellToGL::FrontFace(regs.front_face));
     }
 }
 

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
@@ -71,8 +71,7 @@ void FixedPipelineState::Rasterizer::Fill(const Maxwell& regs) noexcept {
     const u32 topology_index = static_cast<u32>(regs.draw.topology.Value());
 
     u32 packed_front_face = PackFrontFace(regs.front_face);
-    if (regs.screen_y_control.triangle_rast_flip != 0 &&
-        regs.viewport_transform[0].scale_y > 0.0f) {
+    if (regs.screen_y_control.triangle_rast_flip != 0) {
         // Flip front face
         packed_front_face = 1 - packed_front_face;
     }


### PR DESCRIPTION
These fixes are based on gdkchan's explanation of the problem, found in [this](https://github.com/Ryujinx/Ryujinx/pull/1277) pull request from Ryujinx.

The implementation is different. On Vulkan I removed a leftover from OpenGL and everything works fine, on OpenGL I ported an the old Vulkan code back. As described in 606a62d, this is not a complete implementation because we only check for the first viewport.
The reason I didn't port gdkchan's solution is because I don't want to use viewport swizzles on games not using viewport swizzles and injecting shader code to flip `gl_Position` can introduce issues on transform feedbacks.

This fixes front face issues on Xenoblade Chronicles 2 and any other game doing bad things on NVN queues.

Credits to gdkchan from [Ryujinx](ryujinx.org/) for finding what causes this issue.