### PR TITLE
patch_manager: Add support for case-sensitivity on Linux

### DIFF
--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -56,8 +56,7 @@ std::shared_ptr<VfsDirectory> FindSubdirectoryCaseless(const std::shared_ptr<Vfs
 #else
     const auto subdirs = dir->GetSubdirectories();
     for (const auto& subdir : subdirs) {
-        std::string dir_name = subdir->GetName();
-        dir_name = Common::ToLower(dir_name);
+        std::string dir_name = Common::ToLower(subdir->GetName());
         if (dir_name == name) {
             return subdir;
         }

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -6,6 +6,7 @@
 #include <array>
 #include <cstddef>
 #include <cstring>
+#include <boost/algorithm/string/case_conv.hpp>
 
 #include "common/file_util.h"
 #include "common/hex_util.h"
@@ -46,6 +47,24 @@ std::string FormatTitleVersion(u32 version, TitleVersionFormat format) {
     if (format == TitleVersionFormat::FourElements)
         return fmt::format("v{}.{}.{}.{}", bytes[3], bytes[2], bytes[1], bytes[0]);
     return fmt::format("v{}.{}.{}", bytes[3], bytes[2], bytes[1]);
+}
+
+std::shared_ptr<VfsDirectory> FindSubdirectoryCaseless(const std::shared_ptr<VfsDirectory> dir,
+                                                       const std::string& name) {
+#ifdef _WIN32
+    return dir->GetSubdirectory(name);
+#else
+    const auto subdirs = dir->GetSubdirectories();
+    for (const auto& subdir : subdirs) {
+        std::string dir_name = subdir->GetName();
+        boost::algorithm::to_lower(dir_name);
+        if (dir_name == name) {
+            return subdir;
+        }
+    }
+
+    return nullptr;
+#endif
 }
 
 PatchManager::PatchManager(u64 title_id) : title_id(title_id) {}
@@ -104,7 +123,7 @@ VirtualDir PatchManager::PatchExeFS(VirtualDir exefs) const {
             if (std::find(disabled.begin(), disabled.end(), subdir->GetName()) != disabled.end())
                 continue;
 
-            auto exefs_dir = subdir->GetSubdirectory("exefs");
+            auto exefs_dir = FindSubdirectoryCaseless(subdir, "exefs");
             if (exefs_dir != nullptr)
                 layers.push_back(std::move(exefs_dir));
         }
@@ -130,7 +149,7 @@ std::vector<VirtualFile> PatchManager::CollectPatches(const std::vector<VirtualD
         if (std::find(disabled.cbegin(), disabled.cend(), subdir->GetName()) != disabled.cend())
             continue;
 
-        auto exefs_dir = subdir->GetSubdirectory("exefs");
+        auto exefs_dir = FindSubdirectoryCaseless(subdir, "exefs");
         if (exefs_dir != nullptr) {
             for (const auto& file : exefs_dir->GetFiles()) {
                 if (file->GetExtension() == "ips") {
@@ -295,7 +314,7 @@ std::vector<Core::Memory::CheatEntry> PatchManager::CreateCheatList(
             continue;
         }
 
-        auto cheats_dir = subdir->GetSubdirectory("cheats");
+        auto cheats_dir = FindSubdirectoryCaseless(subdir, "cheats");
         if (cheats_dir != nullptr) {
             auto res = ReadCheatFileFromFolder(system, title_id, build_id_, cheats_dir, true);
             if (res.has_value()) {
@@ -340,11 +359,11 @@ static void ApplyLayeredFS(VirtualFile& romfs, u64 title_id, ContentRecordType t
             continue;
         }
 
-        auto romfs_dir = subdir->GetSubdirectory("romfs");
+        auto romfs_dir = FindSubdirectoryCaseless(subdir, "romfs");
         if (romfs_dir != nullptr)
             layers.push_back(std::move(romfs_dir));
 
-        auto ext_dir = subdir->GetSubdirectory("romfs_ext");
+        auto ext_dir = FindSubdirectoryCaseless(subdir, "romfs_ext");
         if (ext_dir != nullptr)
             layers_ext.push_back(std::move(ext_dir));
     }
@@ -470,7 +489,7 @@ std::map<std::string, std::string, std::less<>> PatchManager::GetPatchVersionNam
         for (const auto& mod : mod_dir->GetSubdirectories()) {
             std::string types;
 
-            const auto exefs_dir = mod->GetSubdirectory("exefs");
+            const auto exefs_dir = FindSubdirectoryCaseless(mod, "exefs");
             if (IsDirValidAndNonEmpty(exefs_dir)) {
                 bool ips = false;
                 bool ipswitch = false;
@@ -494,9 +513,9 @@ std::map<std::string, std::string, std::less<>> PatchManager::GetPatchVersionNam
                 if (layeredfs)
                     AppendCommaIfNotEmpty(types, "LayeredExeFS");
             }
-            if (IsDirValidAndNonEmpty(mod->GetSubdirectory("romfs")))
+            if (IsDirValidAndNonEmpty(FindSubdirectoryCaseless(mod, "romfs")))
                 AppendCommaIfNotEmpty(types, "LayeredFS");
-            if (IsDirValidAndNonEmpty(mod->GetSubdirectory("cheats")))
+            if (IsDirValidAndNonEmpty(FindSubdirectoryCaseless(mod, "cheats")))
                 AppendCommaIfNotEmpty(types, "Cheats");
 
             if (types.empty())

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -6,11 +6,11 @@
 #include <array>
 #include <cstddef>
 #include <cstring>
-#include <boost/algorithm/string/case_conv.hpp>
 
 #include "common/file_util.h"
 #include "common/hex_util.h"
 #include "common/logging/log.h"
+#include "common/string_util.h"
 #include "core/core.h"
 #include "core/file_sys/content_archive.h"
 #include "core/file_sys/control_metadata.h"
@@ -50,14 +50,14 @@ std::string FormatTitleVersion(u32 version, TitleVersionFormat format) {
 }
 
 std::shared_ptr<VfsDirectory> FindSubdirectoryCaseless(const std::shared_ptr<VfsDirectory> dir,
-                                                       const std::string& name) {
+                                                       std::string_view name) {
 #ifdef _WIN32
     return dir->GetSubdirectory(name);
 #else
     const auto subdirs = dir->GetSubdirectories();
     for (const auto& subdir : subdirs) {
         std::string dir_name = subdir->GetName();
-        boost::algorithm::to_lower(dir_name);
+        dir_name = Common::ToLower(dir_name);
         if (dir_name == name) {
             return subdir;
         }

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -32,7 +32,7 @@ std::string FormatTitleVersion(u32 version,
 // Returns a directory with name matching name case-insensitive. Returns nullptr if directory
 // doesn't have a directory with name.
 std::shared_ptr<VfsDirectory> FindSubdirectoryCaseless(const std::shared_ptr<VfsDirectory> dir,
-                                                       const std::string& name);
+                                                       std::string_view name);
 
 // A centralized class to manage patches to games.
 class PatchManager {

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -29,6 +29,11 @@ enum class TitleVersionFormat : u8 {
 std::string FormatTitleVersion(u32 version,
                                TitleVersionFormat format = TitleVersionFormat::ThreeElements);
 
+// Returns a directory with name matching name case-insensitive. Returns nullptr if directory
+// doesn't have a directory with name.
+std::shared_ptr<VfsDirectory> FindSubdirectoryCaseless(const std::shared_ptr<VfsDirectory> dir,
+                                                       const std::string& name);
+
 // A centralized class to manage patches to games.
 class PatchManager {
 public:


### PR DESCRIPTION
Some patch developers distribute their patches with odd-cased subdirectories. On Windows systems, this is fine: file names do not have case, so 'exefs' and 'exeFS' refer to the same directory. On most Linux systems however, case matters when naming files and directories. Thus, the current patch manager implementation in Linux does not recognize mods that use alternate-cases when naming specifically the `exefs`, `romfs`, `romfs_ext`, and `cheats` directories.

This changes patch_manager functions to use a case-insensitive variant of `GetSubdirectory`. With this change, patches now work on *nix systems even when patch directories are named with odd cases.

I am obviously open to changes, especially moving `FindSubdirectoryCaseless` to a different file. It is in patch_manager because I was afraid changing a more core VFS function would have other consequences, and as far as I know the rest of the file system interactions work fine on Linux without need for case handling.