### PR TITLE
video_core: Replace most unordered hash tables with tsl-robin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,6 +165,7 @@ macro(yuzu_find_packages)
         #"libzip            1.5         libzip/1.5.2@bincrafters/stable"
         "lz4               1.8         lz4/1.9.2"
         "nlohmann_json     3.7         nlohmann_json/3.7.3"
+        "tsl-robin-map     0.6.2       tsl-robin-map/0.6.2@tessil/stable"
         "ZLIB              1.2         zlib/1.2.11"
         "zstd              1.4         zstd/1.4.4"
     )

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -239,6 +239,7 @@ create_target_directory_groups(video_core)
 
 target_link_libraries(video_core PUBLIC common core)
 target_link_libraries(video_core PRIVATE glad xbyak)
+target_include_directories(video_core PRIVATE tsl-robin-map::tsl-robin-map)
 
 if (ENABLE_VULKAN)
     target_include_directories(video_core PRIVATE sirit ../../externals/Vulkan-Headers/include)

--- a/src/video_core/buffer_cache/buffer_block.h
+++ b/src/video_core/buffer_cache/buffer_block.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <unordered_set>
 #include <utility>
 
 #include "common/alignment.h"

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -9,7 +9,6 @@
 #include <limits>
 #include <optional>
 #include <type_traits>
-#include <unordered_map>
 #include <vector>
 
 #include "common/assert.h"

--- a/src/video_core/query_cache.h
+++ b/src/video_core/query_cache.h
@@ -11,9 +11,10 @@
 #include <memory>
 #include <mutex>
 #include <optional>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
+
+#include <tsl/robin_map.h>
+#include <tsl/robin_set.h>
 
 #include "common/assert.h"
 #include "core/core.h"
@@ -222,11 +223,11 @@ private:
 
         const u64 page_end = addr_end >> PAGE_BITS;
         for (u64 page = addr_begin >> PAGE_BITS; page <= page_end; ++page) {
-            const auto& it = cached_queries.find(page);
+            auto it = cached_queries.find(page);
             if (it == std::end(cached_queries)) {
                 continue;
             }
-            auto& contents = it->second;
+            auto& contents = it.value();
             for (auto& query : contents) {
                 if (!in_range(query)) {
                     continue;
@@ -250,11 +251,11 @@ private:
     /// Tries to a get a cached query. Returns nullptr on failure.
     CachedQuery* TryGet(VAddr addr) {
         const u64 page = static_cast<u64>(addr) >> PAGE_BITS;
-        const auto it = cached_queries.find(page);
+        auto it = cached_queries.find(page);
         if (it == std::end(cached_queries)) {
             return nullptr;
         }
-        auto& contents = it->second;
+        auto& contents = it.value();
         const auto found = std::find_if(std::begin(contents), std::end(contents),
                                         [addr](auto& query) { return query.GetCpuAddr() == addr; });
         return found != std::end(contents) ? &*found : nullptr;
@@ -262,7 +263,7 @@ private:
 
     void AsyncFlushQuery(VAddr addr) {
         if (!uncommitted_flushes) {
-            uncommitted_flushes = std::make_shared<std::unordered_set<VAddr>>();
+            uncommitted_flushes = std::make_shared<tsl::robin_set<VAddr>>();
         }
         uncommitted_flushes->insert(addr);
     }
@@ -275,12 +276,12 @@ private:
 
     std::recursive_mutex mutex;
 
-    std::unordered_map<u64, std::vector<CachedQuery>> cached_queries;
+    tsl::robin_map<u64, std::vector<CachedQuery>> cached_queries;
 
     std::array<CounterStream, VideoCore::NumQueryTypes> streams;
 
-    std::shared_ptr<std::unordered_set<VAddr>> uncommitted_flushes{};
-    std::list<std::shared_ptr<std::unordered_set<VAddr>>> committed_flushes;
+    std::shared_ptr<tsl::robin_set<VAddr>> uncommitted_flushes{};
+    std::list<std::shared_ptr<tsl::robin_set<VAddr>>> committed_flushes;
 };
 
 template <class QueryCache, class HostCounter>

--- a/src/video_core/renderer_opengl/gl_framebuffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_framebuffer_cache.cpp
@@ -3,8 +3,9 @@
 // Refer to the license.txt file included.
 
 #include <tuple>
-#include <unordered_map>
 #include <utility>
+
+#include <tsl/robin_map.h>
 
 #include <glad/glad.h>
 
@@ -22,8 +23,8 @@ FramebufferCacheOpenGL::FramebufferCacheOpenGL() = default;
 FramebufferCacheOpenGL::~FramebufferCacheOpenGL() = default;
 
 GLuint FramebufferCacheOpenGL::GetFramebuffer(const FramebufferCacheKey& key) {
-    const auto [entry, is_cache_miss] = cache.try_emplace(key);
-    auto& framebuffer{entry->second};
+    auto [entry, is_cache_miss] = cache.try_emplace(key);
+    auto& framebuffer = entry.value();
     if (is_cache_miss) {
         framebuffer = CreateFramebuffer(key);
     }

--- a/src/video_core/renderer_opengl/gl_framebuffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_framebuffer_cache.h
@@ -6,7 +6,8 @@
 
 #include <array>
 #include <cstddef>
-#include <unordered_map>
+
+#include <tsl/robin_map.h>
 
 #include <glad/glad.h>
 
@@ -62,7 +63,10 @@ public:
 private:
     OGLFramebuffer CreateFramebuffer(const FramebufferCacheKey& key);
 
-    std::unordered_map<FramebufferCacheKey, OGLFramebuffer> cache;
+    tsl::robin_map<FramebufferCacheKey, OGLFramebuffer, std::hash<FramebufferCacheKey>,
+                   std::equal_to<FramebufferCacheKey>,
+                   std::allocator<std::pair<FramebufferCacheKey, OGLFramebuffer>>, true>
+        cache;
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_query_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_query_cache.cpp
@@ -5,9 +5,10 @@
 #include <algorithm>
 #include <cstring>
 #include <memory>
-#include <unordered_map>
 #include <utility>
 #include <vector>
+
+#include <tsl/robin_map.h>
 
 #include <glad/glad.h>
 

--- a/src/video_core/renderer_opengl/gl_shader_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_cache.h
@@ -10,9 +10,9 @@
 #include <memory>
 #include <string>
 #include <tuple>
-#include <unordered_map>
-#include <unordered_set>
 #include <vector>
+
+#include <tsl/robin_map.h>
 
 #include <glad/glad.h>
 
@@ -110,15 +110,15 @@ public:
     Shader* GetComputeKernel(GPUVAddr code_addr);
 
 private:
-    ProgramSharedPtr GeneratePrecompiledProgram(
-        const ShaderDiskCacheEntry& entry, const ShaderDiskCachePrecompiled& precompiled_entry,
-        const std::unordered_set<GLenum>& supported_formats);
+    ProgramSharedPtr GeneratePrecompiledProgram(const ShaderDiskCacheEntry& entry,
+                                                const ShaderDiskCachePrecompiled& precompiled_entry,
+                                                const std::vector<GLint>& supported_formats);
 
     Core::System& system;
     Core::Frontend::EmuWindow& emu_window;
     const Device& device;
     ShaderDiskCacheOpenGL disk_cache;
-    std::unordered_map<u64, PrecompiledShader> runtime_cache;
+    tsl::robin_map<u64, PrecompiledShader> runtime_cache;
 
     std::unique_ptr<Shader> null_shader;
     std::unique_ptr<Shader> null_kernel;

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -2694,7 +2694,7 @@ private:
         return AppendSuffix(GetGenericAttributeIndex(attribute), INPUT_ATTRIBUTE_NAME);
     }
 
-    std::unordered_map<u8, GenericVaryingDescription> varying_description;
+    tsl::robin_map<u8, GenericVaryingDescription> varying_description;
 
     std::string GetGenericOutputAttribute(Attribute::Index attribute, std::size_t element) const {
         const u8 offset = static_cast<u8>(GetGenericAttributeIndex(attribute) * 4 + element);
@@ -2788,7 +2788,7 @@ private:
     const std::string_view suffix;
     const Header header;
     const bool use_unified_uniforms;
-    std::unordered_map<u8, VaryingTFB> transform_feedback;
+    tsl::robin_map<u8, VaryingTFB> transform_feedback;
 
     ShaderWriter code;
 

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.h
@@ -8,10 +8,11 @@
 #include <string>
 #include <tuple>
 #include <type_traits>
-#include <unordered_map>
-#include <unordered_set>
 #include <utility>
 #include <vector>
+
+#include <tsl/robin_map.h>
+#include <tsl/robin_set.h>
 
 #include <glad/glad.h>
 
@@ -166,7 +167,7 @@ private:
     std::size_t precompiled_cache_virtual_file_offset = 0;
 
     // Stored transferable shaders
-    std::unordered_set<u64> stored_transferable;
+    tsl::robin_set<u64> stored_transferable;
 
     // The cache has been loaded at boot
     bool is_usable{};

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -7,9 +7,10 @@
 #include <array>
 #include <functional>
 #include <memory>
-#include <unordered_map>
 #include <utility>
 #include <vector>
+
+#include <tsl/robin_map.h>
 
 #include <glad/glad.h>
 
@@ -151,7 +152,7 @@ private:
 
     OGLFramebuffer src_framebuffer;
     OGLFramebuffer dst_framebuffer;
-    std::unordered_map<u32, OGLBuffer> copy_pbo_cache;
+    tsl::robin_map<u32, OGLBuffer> copy_pbo_cache;
 };
 
 } // namespace OpenGL

--- a/src/video_core/renderer_vulkan/vk_device.h
+++ b/src/video_core/renderer_vulkan/vk_device.h
@@ -6,8 +6,9 @@
 
 #include <string>
 #include <string_view>
-#include <unordered_map>
 #include <vector>
+
+#include <tsl/robin_map.h>
 
 #include "common/common_types.h"
 #include "video_core/renderer_vulkan/nsight_aftermath_tracker.h"
@@ -252,7 +253,7 @@ private:
     std::vector<std::string> reported_extensions; ///< Reported Vulkan extensions.
 
     /// Format properties dictionary.
-    std::unordered_map<VkFormat, VkFormatProperties> format_properties;
+    tsl::robin_map<VkFormat, VkFormatProperties> format_properties;
 
     /// Nsight Aftermath GPU crash tracker
     NsightAftermathTracker nsight_aftermath_tracker;

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -212,8 +212,8 @@ VKGraphicsPipeline& VKPipelineCache::GetGraphicsPipeline(const GraphicsPipelineC
     }
     last_graphics_key = key;
 
-    const auto [pair, is_cache_miss] = graphics_cache.try_emplace(key);
-    auto& entry = pair->second;
+    auto [pair, is_cache_miss] = graphics_cache.try_emplace(key);
+    auto& entry = pair.value();
     if (is_cache_miss) {
         LOG_INFO(Render_Vulkan, "Compile 0x{:016X}", key.Hash());
         const auto [program, bindings] = DecompileShaders(key);
@@ -227,8 +227,8 @@ VKGraphicsPipeline& VKPipelineCache::GetGraphicsPipeline(const GraphicsPipelineC
 VKComputePipeline& VKPipelineCache::GetComputePipeline(const ComputePipelineCacheKey& key) {
     MICROPROFILE_SCOPE(Vulkan_PipelineCache);
 
-    const auto [pair, is_cache_miss] = compute_cache.try_emplace(key);
-    auto& entry = pair->second;
+    auto [pair, is_cache_miss] = compute_cache.try_emplace(key);
+    auto& entry = pair.value();
     if (!is_cache_miss) {
         return *entry;
     }

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -8,11 +8,12 @@
 #include <cstddef>
 #include <memory>
 #include <type_traits>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include <boost/functional/hash.hpp>
+
+#include <tsl/robin_map.h>
 
 #include "common/common_types.h"
 #include "video_core/engines/const_buffer_engine_interface.h"
@@ -178,9 +179,18 @@ private:
     GraphicsPipelineCacheKey last_graphics_key;
     VKGraphicsPipeline* last_graphics_pipeline = nullptr;
 
-    std::unordered_map<GraphicsPipelineCacheKey, std::unique_ptr<VKGraphicsPipeline>>
+    tsl::robin_map<
+        GraphicsPipelineCacheKey, std::unique_ptr<VKGraphicsPipeline>,
+        std::hash<GraphicsPipelineCacheKey>, std::equal_to<GraphicsPipelineCacheKey>,
+        std::allocator<std::pair<GraphicsPipelineCacheKey, std::unique_ptr<VKGraphicsPipeline>>>,
+        true>
         graphics_cache;
-    std::unordered_map<ComputePipelineCacheKey, std::unique_ptr<VKComputePipeline>> compute_cache;
+    tsl::robin_map<
+        ComputePipelineCacheKey, std::unique_ptr<VKComputePipeline>,
+        std::hash<ComputePipelineCacheKey>, std::equal_to<ComputePipelineCacheKey>,
+        std::allocator<std::pair<ComputePipelineCacheKey, std::unique_ptr<VKComputePipeline>>>,
+        true>
+        compute_cache;
 };
 
 void FillDescriptorUpdateTemplateEntries(

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -838,8 +838,8 @@ std::tuple<VkFramebuffer, VkExtent2D> RasterizerVulkan::ConfigureFramebuffers(
         texture_cache.MarkDepthBufferInUse();
     }
 
-    const auto [fbentry, is_cache_miss] = framebuffer_cache.try_emplace(key);
-    auto& framebuffer = fbentry->second;
+    auto [entry, is_cache_miss] = framebuffer_cache.try_emplace(key);
+    auto& framebuffer = entry.value();
     if (is_cache_miss) {
         VkFramebufferCreateInfo framebuffer_ci;
         framebuffer_ci.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -307,7 +307,10 @@ private:
     u32 draw_counter = 0;
 
     // TODO(Rodrigo): Invalidate on image destruction
-    std::unordered_map<FramebufferCacheKey, vk::Framebuffer> framebuffer_cache;
+    tsl::robin_map<FramebufferCacheKey, vk::Framebuffer, std::hash<FramebufferCacheKey>,
+                   std::equal_to<FramebufferCacheKey>,
+                   std::allocator<std::pair<FramebufferCacheKey, vk::Framebuffer>>, true>
+        framebuffer_cache;
 };
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_renderpass_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_renderpass_cache.cpp
@@ -29,12 +29,12 @@ VKRenderPassCache::VKRenderPassCache(const VKDevice& device) : device{device} {}
 VKRenderPassCache::~VKRenderPassCache() = default;
 
 VkRenderPass VKRenderPassCache::GetRenderPass(const RenderPassParams& params) {
-    const auto [pair, is_cache_miss] = cache.try_emplace(params);
-    auto& entry = pair->second;
+    auto [entry, is_cache_miss] = cache.try_emplace(params);
+    auto& renderpass = entry.value();
     if (is_cache_miss) {
-        entry = CreateRenderPass(params);
+        renderpass = CreateRenderPass(params);
     }
-    return *entry;
+    return *renderpass;
 }
 
 vk::RenderPass VKRenderPassCache::CreateRenderPass(const RenderPassParams& params) const {

--- a/src/video_core/renderer_vulkan/vk_renderpass_cache.h
+++ b/src/video_core/renderer_vulkan/vk_renderpass_cache.h
@@ -5,10 +5,11 @@
 #pragma once
 
 #include <type_traits>
-#include <unordered_map>
 
 #include <boost/container/static_vector.hpp>
 #include <boost/functional/hash.hpp>
+
+#include <tsl/robin_map.h>
 
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/renderer_vulkan/wrapper.h"
@@ -64,7 +65,10 @@ private:
     vk::RenderPass CreateRenderPass(const RenderPassParams& params) const;
 
     const VKDevice& device;
-    std::unordered_map<RenderPassParams, vk::RenderPass> cache;
+    tsl::robin_map<RenderPassParams, vk::RenderPass, std::hash<RenderPassParams>,
+                   std::equal_to<RenderPassParams>,
+                   std::allocator<std::pair<RenderPassParams, vk::RenderPass>>, true>
+        cache;
 };
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_sampler_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_sampler_cache.cpp
@@ -2,7 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <unordered_map>
+#include <tsl/robin_map.h>
 
 #include "video_core/renderer_vulkan/maxwell_to_vk.h"
 #include "video_core/renderer_vulkan/vk_sampler_cache.h"

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
@@ -7,10 +7,11 @@
 #include <map>
 #include <optional>
 #include <type_traits>
-#include <unordered_map>
 #include <utility>
 
 #include <fmt/format.h>
+
+#include <tsl/robin_map.h>
 
 #include <sirit/sirit.h>
 
@@ -2701,7 +2702,7 @@ private:
     const Tegra::Shader::Header header;
     const Registry& registry;
     const Specialization& specialization;
-    std::unordered_map<u8, VaryingTFB> transform_feedback;
+    tsl::robin_map<u8, VaryingTFB> transform_feedback;
 
     const Id t_void = Name(TypeVoid(), "void");
 
@@ -2793,7 +2794,7 @@ private:
     Id shared_memory{};
     std::array<Id, INTERNAL_FLAGS_COUNT> internal_flags{};
     std::map<Attribute::Index, Id> input_attributes;
-    std::unordered_map<u8, GenericVaryingDescription> output_attributes;
+    tsl::robin_map<u8, GenericVaryingDescription> output_attributes;
     std::map<u32, Id> constant_buffers;
     std::map<GlobalMemoryBase, Id> global_buffers;
     std::map<u32, TexelBuffer> uniform_texels;

--- a/src/video_core/renderer_vulkan/vk_staging_buffer_pool.cpp
+++ b/src/video_core/renderer_vulkan/vk_staging_buffer_pool.cpp
@@ -3,9 +3,10 @@
 // Refer to the license.txt file included.
 
 #include <algorithm>
-#include <unordered_map>
 #include <utility>
 #include <vector>
+
+#include <tsl/robin_map.h>
 
 #include "common/bit_util.h"
 #include "common/common_types.h"

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -372,8 +372,8 @@ VkImageView CachedSurfaceView::GetImageView(SwizzleSource x_source, SwizzleSourc
     }
     last_swizzle = new_swizzle;
 
-    const auto [entry, is_cache_miss] = view_cache.try_emplace(new_swizzle);
-    auto& image_view = entry->second;
+    auto [entry, is_cache_miss] = view_cache.try_emplace(new_swizzle);
+    auto& image_view = entry.value();
     if (!is_cache_miss) {
         return last_image_view = *image_view;
     }

--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -5,7 +5,8 @@
 #pragma once
 
 #include <memory>
-#include <unordered_map>
+
+#include <tsl/robin_map.h>
 
 #include "common/common_types.h"
 #include "video_core/renderer_vulkan/vk_image.h"
@@ -196,7 +197,7 @@ private:
     u32 last_swizzle = 0;
 
     vk::ImageView render_target;
-    std::unordered_map<u32, vk::ImageView> view_cache;
+    tsl::robin_map<u32, vk::ImageView> view_cache;
 };
 
 class VKTextureCache final : public TextureCacheBase {

--- a/src/video_core/shader/control_flow.cpp
+++ b/src/video_core/shader/control_flow.cpp
@@ -6,8 +6,9 @@
 #include <map>
 #include <set>
 #include <stack>
-#include <unordered_map>
 #include <vector>
+
+#include <tsl/robin_map.h>
 
 #include "common/assert.h"
 #include "common/common_types.h"
@@ -75,11 +76,11 @@ struct CFGRebuildState {
     std::vector<BlockInfo> block_info;
     std::list<u32> inspect_queries;
     std::list<Query> queries;
-    std::unordered_map<u32, u32> registered;
+    tsl::robin_map<u32, u32> registered;
     std::set<u32> labels;
     std::map<u32, u32> ssy_labels;
     std::map<u32, u32> pbk_labels;
-    std::unordered_map<u32, BlockStack> stacks;
+    tsl::robin_map<u32, BlockStack> stacks;
     ASTManager* manager{};
 };
 

--- a/src/video_core/shader/registry.h
+++ b/src/video_core/shader/registry.h
@@ -7,8 +7,9 @@
 #include <array>
 #include <optional>
 #include <type_traits>
-#include <unordered_map>
 #include <utility>
+
+#include <tsl/robin_map.h>
 
 #include "common/common_types.h"
 #include "common/hash.h"
@@ -48,12 +49,11 @@ struct equal_to<VideoCommon::Shader::SeparateSamplerKey> {
 
 namespace VideoCommon::Shader {
 
-using KeyMap = std::unordered_map<std::pair<u32, u32>, u32, Common::PairHash>;
-using BoundSamplerMap = std::unordered_map<u32, Tegra::Engines::SamplerDescriptor>;
-using SeparateSamplerMap =
-    std::unordered_map<SeparateSamplerKey, Tegra::Engines::SamplerDescriptor>;
+using KeyMap = tsl::robin_map<std::pair<u32, u32>, u32, Common::PairHash>;
+using BoundSamplerMap = tsl::robin_map<u32, Tegra::Engines::SamplerDescriptor>;
+using SeparateSamplerMap = tsl::robin_map<SeparateSamplerKey, Tegra::Engines::SamplerDescriptor>;
 using BindlessSamplerMap =
-    std::unordered_map<std::pair<u32, u32>, Tegra::Engines::SamplerDescriptor, Common::PairHash>;
+    tsl::robin_map<std::pair<u32, u32>, Tegra::Engines::SamplerDescriptor, Common::PairHash>;
 
 struct GraphicsInfo {
     using Maxwell = Tegra::Engines::Maxwell3D::Regs;

--- a/src/video_core/shader/transform_feedback.cpp
+++ b/src/video_core/shader/transform_feedback.cpp
@@ -4,7 +4,8 @@
 
 #include <algorithm>
 #include <array>
-#include <unordered_map>
+
+#include <tsl/robin_map.h>
 
 #include "common/assert.h"
 #include "common/common_types.h"
@@ -70,9 +71,8 @@ constexpr std::array VECTORS = {
 };
 } // namespace
 
-std::unordered_map<u8, VaryingTFB> BuildTransformFeedback(const GraphicsInfo& info) {
-
-    std::unordered_map<u8, VaryingTFB> tfb;
+tsl::robin_map<u8, VaryingTFB> BuildTransformFeedback(const GraphicsInfo& info) {
+    tsl::robin_map<u8, VaryingTFB> tfb;
 
     for (std::size_t buffer = 0; buffer < Maxwell::NumTransformFeedbackBuffers; ++buffer) {
         const auto& locations = info.tfb_varying_locs[buffer];

--- a/src/video_core/shader/transform_feedback.h
+++ b/src/video_core/shader/transform_feedback.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <unordered_map>
+#include <tsl/robin_map.h>
 
 #include "common/common_types.h"
 #include "video_core/shader/registry.h"
@@ -18,6 +18,6 @@ struct VaryingTFB {
     std::size_t components;
 };
 
-std::unordered_map<u8, VaryingTFB> BuildTransformFeedback(const GraphicsInfo& info);
+tsl::robin_map<u8, VaryingTFB> BuildTransformFeedback(const GraphicsInfo& info);
 
 } // namespace VideoCommon::Shader

--- a/src/video_core/shader_cache.h
+++ b/src/video_core/shader_cache.h
@@ -115,7 +115,7 @@ private:
             if (it == invalidation_cache.end()) {
                 continue;
             }
-            InvalidatePageEntries(it->second, addr, addr_end);
+            InvalidatePageEntries(it.value(), addr, addr_end);
         }
     }
 
@@ -175,9 +175,9 @@ private:
     void RemoveEntryFromInvalidationCache(const Entry* entry) {
         const u64 page_end = (entry->addr_end + PAGE_SIZE - 1) >> PAGE_BITS;
         for (u64 page = entry->addr_start >> PAGE_BITS; page < page_end; ++page) {
-            const auto entries_it = invalidation_cache.find(page);
+            auto entries_it = invalidation_cache.find(page);
             ASSERT(entries_it != invalidation_cache.end());
-            std::vector<Entry*>& entries = entries_it->second;
+            std::vector<Entry*>& entries = entries_it.value();
 
             const auto entry_it = std::find(entries.begin(), entries.end(), entry);
             ASSERT(entry_it != entries.end());
@@ -231,8 +231,8 @@ private:
     mutable std::mutex lookup_mutex;
     std::mutex invalidation_mutex;
 
-    std::unordered_map<u64, std::unique_ptr<Entry>> lookup_cache;
-    std::unordered_map<u64, std::vector<Entry*>> invalidation_cache;
+    tsl::robin_map<u64, std::unique_ptr<Entry>> lookup_cache;
+    tsl::robin_map<u64, std::vector<Entry*>> invalidation_cache;
     std::vector<std::unique_ptr<T>> storage;
     std::vector<Entry*> marked_for_removal;
 };

--- a/src/video_core/texture_cache/surface_base.h
+++ b/src/video_core/texture_cache/surface_base.h
@@ -6,8 +6,9 @@
 
 #include <optional>
 #include <tuple>
-#include <unordered_map>
 #include <vector>
+
+#include <tsl/robin_map.h>
 
 #include "common/common_types.h"
 #include "video_core/gpu.h"
@@ -306,12 +307,12 @@ protected:
     virtual TView CreateView(const ViewParams& view_key) = 0;
 
     TView main_view;
-    std::unordered_map<ViewParams, TView> views;
+    tsl::robin_map<ViewParams, TView> views;
 
 private:
     TView GetView(const ViewParams& key) {
-        const auto [entry, is_cache_miss] = views.try_emplace(key);
-        auto& view{entry->second};
+        auto [entry, is_cache_miss] = views.try_emplace(key);
+        auto& view = entry.value();
         if (is_cache_miss) {
             view = CreateView(key);
         }


### PR DESCRIPTION
Add `robin-map` as a conan dependency. More information about these hash tables can be found [here](https://github.com/Tessil/robin-map).

Trivially replace most `std::unordered_map` usages with `tsl::robin_map` and `std::unordered_set` with `tsl::robin_set`.

None `std::unordered_*` usage in `video_core` stores pointers or iterators beyond their immediate scope. This allows us to swap to `tsl::robin_*` tables without issues.