### PR TITLE
texture_cache: Always load textures on Recycle

### DIFF
--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -542,7 +542,7 @@ private:
                                               const SurfaceParams& params, const GPUVAddr gpu_addr,
                                               const bool preserve_contents,
                                               const MatchTopologyResult untopological) {
-        const bool do_load = preserve_contents && Settings::IsGPULevelExtreme();
+        const bool do_load = preserve_contents;
         for (auto& surface : overlaps) {
             Unregister(surface);
         }


### PR DESCRIPTION
This is a temporary fix. We should handle textures that have the
candidate as a super texture and they are an inner mipmap with copies.