### PR TITLE
shader/other: Fix hardcoded value in S2R INVOCATION_INFO

### DIFF
--- a/src/video_core/shader/decode/other.cpp
+++ b/src/video_core/shader/decode/other.cpp
@@ -83,7 +83,7 @@ u32 ShaderIR::DecodeOther(NodeBlock& bb, u32 pc) {
                 return Operation(OperationCode::YNegate);
             case SystemVariable::InvocationInfo:
                 LOG_WARNING(HW_GPU, "S2R instruction with InvocationInfo is incomplete");
-                return Immediate(0U);
+                return Immediate(0x00ff'0000U);
             case SystemVariable::WscaleFactorXY:
                 UNIMPLEMENTED_MSG("S2R WscaleFactorXY is not implemented");
                 return Immediate(0U);


### PR DESCRIPTION
Geometry shaders built from Nvidia's compiler check for bits[16:23] to
be less than or equal to 0 with VSETP to default to a "safe" value of
0x8000'0000 (safe from hardware's perspective). To avoid hitting this
path in the shader, return 0x0001'0000 from S2R INVOCATION_INFO.

What S2R INVOCATION_INFO returns from a geometry shader has yet to be
tested.

- Fixes the first layer of a 3D texture on UE4 games. Rainbow will still be there because there are 31 3D texture slices that contain trash.