### PR TITLE
gl_shader_decompiler: Fix geometry shader outputs on Intel drivers

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -619,6 +619,21 @@ private:
             }
         }
 
+        if (stage != ShaderType::Geometry &&
+            (stage != ShaderType::Vertex || device.HasVertexViewportLayer())) {
+            if (ir.UsesLayer()) {
+                code.AddLine("int gl_Layer;");
+            }
+            if (ir.UsesViewportIndex()) {
+                code.AddLine("int gl_ViewportIndex;");
+            }
+        } else if ((ir.UsesLayer() || ir.UsesViewportIndex()) && stage == ShaderType::Vertex &&
+                   !device.HasVertexViewportLayer()) {
+            LOG_ERROR(
+                Render_OpenGL,
+                "GL_ARB_shader_viewport_layer_array is not available and its required by a shader");
+        }
+
         if (ir.UsesPointSize()) {
             code.AddLine("float gl_PointSize;");
         }
@@ -635,18 +650,13 @@ private:
         code.AddLine("}};");
         code.AddNewLine();
 
-        if (stage != ShaderType::Vertex || device.HasVertexViewportLayer()) {
+        if (stage == ShaderType::Geometry) {
             if (ir.UsesLayer()) {
                 code.AddLine("out int gl_Layer;");
             }
             if (ir.UsesViewportIndex()) {
                 code.AddLine("out int gl_ViewportIndex;");
             }
-        } else if ((ir.UsesLayer() || ir.UsesViewportIndex()) && stage == ShaderType::Vertex &&
-                   !device.HasVertexViewportLayer()) {
-            LOG_ERROR(
-                Render_OpenGL,
-                "GL_ARB_shader_viewport_layer_array is not available and its required by a shader");
         }
         code.AddNewLine();
     }

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -618,19 +618,6 @@ private:
                 break;
             }
         }
-        if (stage != ShaderType::Vertex || device.HasVertexViewportLayer()) {
-            if (ir.UsesLayer()) {
-                code.AddLine("int gl_Layer;");
-            }
-            if (ir.UsesViewportIndex()) {
-                code.AddLine("int gl_ViewportIndex;");
-            }
-        } else if ((ir.UsesLayer() || ir.UsesViewportIndex()) && stage == ShaderType::Vertex &&
-                   !device.HasVertexViewportLayer()) {
-            LOG_ERROR(
-                Render_OpenGL,
-                "GL_ARB_shader_viewport_layer_array is not available and its required by a shader");
-        }
 
         if (ir.UsesPointSize()) {
             code.AddLine("float gl_PointSize;");
@@ -646,6 +633,21 @@ private:
 
         --code.scope;
         code.AddLine("}};");
+        code.AddNewLine();
+
+        if (stage != ShaderType::Vertex || device.HasVertexViewportLayer()) {
+            if (ir.UsesLayer()) {
+                code.AddLine("out int gl_Layer;");
+            }
+            if (ir.UsesViewportIndex()) {
+                code.AddLine("out int gl_ViewportIndex;");
+            }
+        } else if ((ir.UsesLayer() || ir.UsesViewportIndex()) && stage == ShaderType::Vertex &&
+                   !device.HasVertexViewportLayer()) {
+            LOG_ERROR(
+                Render_OpenGL,
+                "GL_ARB_shader_viewport_layer_array is not available and its required by a shader");
+        }
         code.AddNewLine();
     }
 


### PR DESCRIPTION
On Intel's proprietary drivers, gl_Layer and gl_ViewportIndex are not allowed members of gl_PerVertex block, causing the shader to fail to compile. Fix this by declaring these variables outside of gl_PerVertex.