### PR TITLE
Port citra-emu/citra#5376: "Actually save the input when clearing/resetting to default"

### DIFF
--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -480,7 +480,9 @@ void ConfigureInputPlayer::RestoreDefaults() {
             SetAnalogButton(params, analogs_param[analog_id], analog_sub_buttons[sub_button_id]);
         }
     }
+
     UpdateButtonLabels();
+    ApplyConfiguration();
 }
 
 void ConfigureInputPlayer::ClearAll() {
@@ -505,6 +507,7 @@ void ConfigureInputPlayer::ClearAll() {
     }
 
     UpdateButtonLabels();
+    ApplyConfiguration();
 }
 
 void ConfigureInputPlayer::UpdateButtonLabels() {


### PR DESCRIPTION
See citra-emu/citra#5376 for more details.

**Original description**:
Previously I would have to reset the input to default every single time I opened Citra if I just wanted the default keyboard binds.