### PR TITLE
Add more information about the running game

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2055,7 +2055,7 @@ void GMainWindow::UpdateWindowTitle(const QString& title_name, const QString& ti
         const auto fmt = std::string(Common::g_title_bar_format_running);
         setWindowTitle(QString::fromStdString(
             fmt::format(fmt.empty() ? "yuzu {0}| {3} | {4} | {5} | {6} | {1}-{2}" : fmt, full_name,
-                        branch_name, description, title_name.toStdString(), title_id.toStdString(),
+                        branch_name, description, title_name.toStdString(), fmt::format("{:016X}", title_id),
                         title_version.toStdString(), dlc.toStdString(), date, build_id)));
     }
 }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2053,10 +2053,10 @@ void GMainWindow::UpdateWindowTitle(const QString& title_name, const QString& ti
                                                           std::string{}, date, build_id)));
     } else {
         const auto fmt = std::string(Common::g_title_bar_format_running);
-        setWindowTitle(QString::fromStdString(
-            fmt::format(fmt.empty() ? "yuzu {0}| {3} | {4} | {5} | {6} | {1}-{2}" : fmt, full_name,
-                        branch_name, description, title_name.toStdString(), fmt::format("{:016X}", title_id),
-                        title_version.toStdString(), dlc.toStdString(), date, build_id)));
+        setWindowTitle(QString::fromStdString(fmt::format(
+            fmt.empty() ? "yuzu {0}| {3} | {4} | {5} | {6} | {1}-{2}" : fmt, full_name, branch_name,
+            description, title_name.toStdString(), fmt::format("{:016X}", title_id),
+            title_version.toStdString(), dlc.toStdString(), date, build_id)));
     }
 }
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1087,8 +1087,7 @@ void GMainWindow::BootGame(const QString& filename) {
         }
     }
     LOG_INFO(Frontend, "Booting game: {:016X} | {}", title_id, title_name);
-    UpdateWindowTitle(QString::fromStdString(title_name),
-                      QString::fromStdString(std::to_string(title_id)), title_version, dlc);
+    UpdateWindowTitle(QString::fromStdString(title_name), title_id, title_version, dlc);
 
     loading_screen->Prepare(Core::System::GetInstance().GetAppLoader());
     loading_screen->show();
@@ -2036,7 +2035,7 @@ void GMainWindow::OnCaptureScreenshot() {
     OnStartGame();
 }
 
-void GMainWindow::UpdateWindowTitle(const QString& title_name, const QString& title_id,
+void GMainWindow::UpdateWindowTitle(const QString& title_name, u64 title_id,
                                     const QString& title_version, const QString& dlc) {
     const auto full_name = std::string(Common::g_build_fullname);
     const auto branch_name = std::string(Common::g_scm_branch);

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -216,7 +216,7 @@ private slots:
 
 private:
     std::optional<u64> SelectRomFSDumpTarget(const FileSys::ContentProvider&, u64 program_id);
-    void UpdateWindowTitle(const QString& title_name = {}, const QString& title_id = {},
+    void UpdateWindowTitle(const QString& title_name = {}, u64 title_id = {},
                            const QString& title_version = {}, const QString& dlc = {});
     void UpdateStatusBar();
     void HideMouseCursor();

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -215,7 +215,8 @@ private slots:
 
 private:
     std::optional<u64> SelectRomFSDumpTarget(const FileSys::ContentProvider&, u64 program_id);
-    void UpdateWindowTitle(const QString& title_name = {});
+    void UpdateWindowTitle(const QString& title_name = {}, const QString& title_id = {},
+                           const QString& title_version = {}, const QString& dlc = {});
     void UpdateStatusBar();
     void HideMouseCursor();
     void ShowMouseCursor();

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -135,6 +135,7 @@ private:
     void AllowOSSleep();
 
     bool LoadROM(const QString& filename);
+    QString LoadDLCsName(u64 title_id);
     void BootGame(const QString& filename);
     void ShutdownGame();
 


### PR DESCRIPTION
Implementes Feature Request #3997 

![image](https://user-images.githubusercontent.com/27208977/83976761-55a01180-a8fc-11ea-8ffa-92bd54a498b6.png)

DLC will be shown like this:
Case 1 (0 DLC): "_No DLC_"
Case 2 (1-5 DLCs):  "_DLC: 1, 5, 133_"
Case 3 (>5 DLCs, for example 35 DLCs): "_DLC: 1, 6, 7, 23, 30, ... (35)_"
