### PR TITLE
maxwell_to_gl: Implement MirrorOnceClampOGL wrap mode using GL_MIRROR_CLAMP_EXT

### DIFF
--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -191,6 +191,12 @@ inline GLenum WrapMode(Tegra::Texture::WrapMode wrap_mode) {
         } else {
             return GL_MIRROR_CLAMP_TO_EDGE;
         }
+    case Tegra::Texture::WrapMode::MirrorOnceClampOGL:
+        if (GL_EXT_texture_mirror_clamp) {
+            return GL_MIRROR_CLAMP_EXT;
+        } else {
+            return GL_MIRROR_CLAMP_TO_EDGE;
+        }
     }
     UNIMPLEMENTED_MSG("Unimplemented texture wrap mode={}", static_cast<u32>(wrap_mode));
     return GL_REPEAT;


### PR DESCRIPTION
Like MirrorOnceBorder, this requires the `GL_EXT_texture_mirror_clamp` extension. This extension is unfortunately not available on Intel's drivers (both Windows proprietary and Linux Mesa). Use `GL_MIRROR_CLAMP_TO_EDGE` as a fallback if the extension is unavailable.

A Vulkan equivalent is not available so it will be left unimplemented.

Used in Kirby Star Allies. Thanks to gidoly from the yuzu discord for the log.