### PR TITLE
video_core/macro_jit_x64: Remove initializer in member variable

### DIFF
--- a/src/video_core/macro/macro_jit_x64.h
+++ b/src/video_core/macro/macro_jit_x64.h
@@ -85,8 +85,8 @@ private:
     std::optional<Macro::Opcode> next_opcode{};
     ProgramType program{nullptr};
 
-    std::array<Xbyak::Label, MAX_CODE_SIZE> labels{};
-    std::array<Xbyak::Label, MAX_CODE_SIZE> delay_skip{};
+    std::array<Xbyak::Label, MAX_CODE_SIZE> labels;
+    std::array<Xbyak::Label, MAX_CODE_SIZE> delay_skip;
     Xbyak::Label end_of_code{};
 
     bool is_delay_slot{};


### PR DESCRIPTION
Fix build time issues on gcc. Confirmed through asan that avoiding this
initialization is safe (this was not intentional, as I was debugging something else).

Closes #4051.