### PR TITLE
Fix framebuffer size on fractional scaling display

### DIFF
--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -355,7 +355,7 @@ QByteArray GRenderWindow::saveGeometry() {
 }
 
 qreal GRenderWindow::windowPixelRatio() const {
-    return devicePixelRatio();
+    return devicePixelRatioF();
 }
 
 std::pair<u32, u32> GRenderWindow::ScaleTouch(const QPointF& pos) const {


### PR DESCRIPTION
Fix OpenGL renderer framebuffer size on fractional scaling display by using devicePixelRatioF()

Before:
![Screenshot_20200616_204427](https://user-images.githubusercontent.com/1533879/84853210-7e6a8a00-b013-11ea-9110-28bfcf58c230.png)
After:
![Screenshot_20200616_205301](https://user-images.githubusercontent.com/1533879/84853216-83c7d480-b013-11ea-9f74-c6f04488856c.png)

