### PR TITLE
macro: Add support for "middle methods" on the code cache

### DIFF
--- a/src/video_core/macro/macro.cpp
+++ b/src/video_core/macro/macro.cpp
@@ -35,10 +35,19 @@ void MacroEngine::Execute(Engines::Maxwell3D& maxwell3d, u32 method,
         }
     } else {
         // Macro not compiled, check if it's uploaded and if so, compile it
+        std::pair<bool, u32> mid_method;
         auto macro_code = uploaded_macro_code.find(method);
         if (macro_code == uploaded_macro_code.end()) {
-            UNREACHABLE_MSG("Macro 0x{0:x} was not uploaded", method);
-            return;
+            for (const auto& [method_base, code] : uploaded_macro_code) {
+                if (method >= method_base && (method - method_base) < code.size()) {
+                    mid_method = {true, method_base};
+                    break;
+                }
+            }
+            if (!mid_method.first) {
+                UNREACHABLE_MSG("Macro 0x{0:x} was not uploaded", method);
+                return;
+            }
         }
         auto& cache_info = macro_cache[method];
         cache_info.hash = boost::hash_value(macro_code->second);

--- a/src/video_core/macro/macro.cpp
+++ b/src/video_core/macro/macro.cpp
@@ -57,7 +57,7 @@ void MacroEngine::Execute(Engines::Maxwell3D& maxwell3d, u32 method,
             cache_info.hash = boost::hash_value(macro_code->second);
         } else {
             const auto& macro_cached = uploaded_macro_code[mid_method.value()];
-            const auto rebased_method = method - macro_code->first;
+            const auto rebased_method = method - mid_method.value();
             auto& code = uploaded_macro_code[method];
             code.resize(macro_cached.size() - rebased_method);
             std::memcpy(code.data(), macro_cached.data() + rebased_method,


### PR DESCRIPTION
Macro code is just uploaded sequentially from a starting address, however that does not mean the entry point for the macro is at that address. This PR adds preliminary support for executing macros in the middle of our cached code.