### PR TITLE
Fix compilation when not building with boxcat

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -606,11 +606,11 @@ endif()
 create_target_directory_groups(core)
 
 target_link_libraries(core PUBLIC common PRIVATE audio_core video_core)
-target_link_libraries(core PUBLIC Boost::boost PRIVATE fmt::fmt nlohmann_json::nlohmann_json mbedtls Opus::Opus unicorn)
+target_link_libraries(core PUBLIC Boost::boost PRIVATE fmt::fmt nlohmann_json::nlohmann_json mbedtls Opus::Opus unicorn zip)
 
 if (YUZU_ENABLE_BOXCAT)
     target_compile_definitions(core PRIVATE -DYUZU_ENABLE_BOXCAT)
-    target_link_libraries(core PRIVATE httplib nlohmann_json::nlohmann_json zip)
+    target_link_libraries(core PRIVATE httplib nlohmann_json::nlohmann_json)
 endif()
 
 if (ENABLE_WEB_SERVICE)

--- a/src/yuzu/configuration/configure_service.cpp
+++ b/src/yuzu/configuration/configure_service.cpp
@@ -68,6 +68,7 @@ void ConfigureService::SetConfiguration() {
 }
 
 std::pair<QString, QString> ConfigureService::BCATDownloadEvents() {
+#ifdef YUZU_ENABLE_BOXCAT
     std::optional<std::string> global;
     std::map<std::string, Service::BCAT::EventStatus> map;
     const auto res = Service::BCAT::Boxcat::GetStatus(global, map);
@@ -106,6 +107,10 @@ std::pair<QString, QString> ConfigureService::BCATDownloadEvents() {
                    .arg(FormatEventStatusString(value));
     }
     return {QStringLiteral("Current Boxcat Events"), std::move(out)};
+#else
+    return {QStringLiteral("Current Boxcat Events"),
+            tr("There are currently no events on boxcat.")};
+#endif
 }
 
 void ConfigureService::OnBCATImplChanged() {

--- a/src/yuzu/configuration/configure_service.cpp
+++ b/src/yuzu/configuration/configure_service.cpp
@@ -106,10 +106,9 @@ std::pair<QString, QString> ConfigureService::BCATDownloadEvents() {
                    .arg(QString::fromStdString(key))
                    .arg(FormatEventStatusString(value));
     }
-    return {QStringLiteral("Current Boxcat Events"), std::move(out)};
+    return {tr("Current Boxcat Events"), std::move(out)};
 #else
-    return {QStringLiteral("Current Boxcat Events"),
-            tr("There are currently no events on boxcat.")};
+    return {tr("Current Boxcat Events"), tr("There are currently no events on boxcat.")};
 #endif
 }
 


### PR DESCRIPTION
Fixes compilation when trying to build without boxcat enabled.

Zip is also used by vfs and should not be exclusive to building with boxcat.