### PR TITLE
macro_jit_x64: Amend readability of Compile_ExtractShiftLeftRegister()

### DIFF
--- a/src/video_core/macro/macro_jit_x64.cpp
+++ b/src/video_core/macro/macro_jit_x64.cpp
@@ -240,10 +240,10 @@ void MacroJITx64Impl::Compile_ExtractInsert(Macro::Opcode opcode) {
 }
 
 void MacroJITx64Impl::Compile_ExtractShiftLeftImmediate(Macro::Opcode opcode) {
-    auto dst = Compile_GetRegister(opcode.src_a, eax);
-    auto src = Compile_GetRegister(opcode.src_b, RESULT);
+    const auto dst = Compile_GetRegister(opcode.src_a, eax);
+    const auto src = Compile_GetRegister(opcode.src_b, RESULT);
 
-    shr(src, al);
+    shr(src, dst.cvt8());
     if (opcode.bf_size != 0 && opcode.bf_size != 31) {
         and_(src, opcode.GetBitfieldMask());
     } else if (opcode.bf_size == 0) {

--- a/src/video_core/macro/macro_jit_x64.cpp
+++ b/src/video_core/macro/macro_jit_x64.cpp
@@ -259,8 +259,8 @@ void MacroJITx64Impl::Compile_ExtractShiftLeftImmediate(Macro::Opcode opcode) {
 }
 
 void MacroJITx64Impl::Compile_ExtractShiftLeftRegister(Macro::Opcode opcode) {
-    auto dst = Compile_GetRegister(opcode.src_a, eax);
-    auto src = Compile_GetRegister(opcode.src_b, RESULT);
+    const auto dst = Compile_GetRegister(opcode.src_a, eax);
+    const auto src = Compile_GetRegister(opcode.src_b, RESULT);
 
     if (opcode.bf_src_bit != 0) {
         shr(src, opcode.bf_src_bit);
@@ -269,7 +269,8 @@ void MacroJITx64Impl::Compile_ExtractShiftLeftRegister(Macro::Opcode opcode) {
     if (opcode.bf_size != 31) {
         and_(src, opcode.GetBitfieldMask());
     }
-    shl(src, al);
+    shl(src, dst.cvt8());
+
     Compile_ProcessResult(opcode.result_operation, opcode.dst);
 }
 


### PR DESCRIPTION
Previously the dst variables weren't being used, but the code managed to function normally anyways, since the register being used directly, is the same register as the one being loaded (only it's the 8-bit view of it being used in the shifts).

We can make use of the destination directly to prevent compiler warnings.