### PR TITLE
gl_shader_decompiler: Workaround textureLod when GL_EXT_texture_shadow_lod is not available

### DIFF
--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -216,6 +216,7 @@ Device::Device()
     has_shader_ballot = GLAD_GL_ARB_shader_ballot;
     has_vertex_viewport_layer = GLAD_GL_ARB_shader_viewport_layer_array;
     has_image_load_formatted = HasExtension(extensions, "GL_EXT_shader_image_load_formatted");
+    has_texture_shadow_lod = HasExtension(extensions, "GL_EXT_texture_shadow_lod");
     has_astc = IsASTCSupported();
     has_variable_aoffi = TestVariableAoffi();
     has_component_indexing_bug = is_amd;
@@ -245,6 +246,7 @@ Device::Device(std::nullptr_t) {
     has_shader_ballot = true;
     has_vertex_viewport_layer = true;
     has_image_load_formatted = true;
+    has_texture_shadow_lod = true;
     has_variable_aoffi = true;
 }
 

--- a/src/video_core/renderer_opengl/gl_device.h
+++ b/src/video_core/renderer_opengl/gl_device.h
@@ -68,6 +68,10 @@ public:
         return has_image_load_formatted;
     }
 
+    bool HasTextureShadowLod() const {
+        return has_texture_shadow_lod;
+    }
+
     bool HasASTC() const {
         return has_astc;
     }
@@ -110,6 +114,7 @@ private:
     bool has_shader_ballot{};
     bool has_vertex_viewport_layer{};
     bool has_image_load_formatted{};
+    bool has_texture_shadow_lod{};
     bool has_astc{};
     bool has_variable_aoffi{};
     bool has_component_indexing_bug{};


### PR DESCRIPTION
Fixes #3969 

Enable `GL_EXT_texture_shadow_lod` if exposed by the gpu driver.

Utilizes the workaround described [here](https://github.com/KhronosGroup/SPIRV-Cross/blob/master/spirv_glsl.cpp#L5872) and [here](https://github.com/KhronosGroup/SPIRV-Cross/blob/master/spirv_glsl.cpp#L5949) if `GL_EXT_texture_shadow_lod` isn't available, allowing the compute shaders in The Legend of Zelda: Breath of the Wild to compile on Intel/AMD's proprietary drivers.

In my short testing I have not noticed any visual changes.