### PR TITLE
macro_jit_x64: Use ecx for shift register

### DIFF
--- a/src/video_core/macro/macro_jit_x64.cpp
+++ b/src/video_core/macro/macro_jit_x64.cpp
@@ -239,7 +239,7 @@ void MacroJITx64Impl::Compile_ExtractInsert(Macro::Opcode opcode) {
 }
 
 void MacroJITx64Impl::Compile_ExtractShiftLeftImmediate(Macro::Opcode opcode) {
-    const auto dst = Compile_GetRegister(opcode.src_a, eax);
+    const auto dst = Compile_GetRegister(opcode.src_a, ecx);
     const auto src = Compile_GetRegister(opcode.src_b, RESULT);
 
     shr(src, dst.cvt8());
@@ -258,7 +258,7 @@ void MacroJITx64Impl::Compile_ExtractShiftLeftImmediate(Macro::Opcode opcode) {
 }
 
 void MacroJITx64Impl::Compile_ExtractShiftLeftRegister(Macro::Opcode opcode) {
-    const auto dst = Compile_GetRegister(opcode.src_a, eax);
+    const auto dst = Compile_GetRegister(opcode.src_a, ecx);
     const auto src = Compile_GetRegister(opcode.src_b, RESULT);
 
     if (opcode.bf_src_bit != 0) {


### PR DESCRIPTION
[SHL/SHR only accepts CL as their second argument](https://www.felixcloutier.com/x86/sal:sar:shl:shr).

Xbyak would detect this case, raise an assert, and crash at runtime.