### PR TITLE
arm_dynarmic: Minor logging changes

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -62,7 +62,7 @@ public:
         case Dynarmic::A32::Exception::Breakpoint:
             break;
         }
-        LOG_CRITICAL(HW_GPU, "ExceptionRaised(exception = {}, pc = {:08X}, code = {:08X})",
+        LOG_CRITICAL(Core_ARM, "ExceptionRaised(exception = {}, pc = {:08X}, code = {:08X})",
                      static_cast<std::size_t>(exception), pc, MemoryReadCode(pc));
         UNIMPLEMENTED();
     }

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -98,8 +98,8 @@ public:
             }
             [[fallthrough]];
         default:
-            ASSERT_MSG(false, "ExceptionRaised(exception = {}, pc = {:X})",
-                       static_cast<std::size_t>(exception), pc);
+            ASSERT_MSG(false, "ExceptionRaised(exception = {}, pc = {:08X}, code = {:08X})",
+                       static_cast<std::size_t>(exception), pc, MemoryReadCode(pc));
         }
     }
 


### PR DESCRIPTION
arm_dynarmic_32: Log under Core_ARM instead of HW_GPU
arm_dynarmic_64: Log the instruction when an exception is raised