### PR TITLE
gl_device: Enable NV_vertex_buffer_unified_memory on Turing devices

### DIFF
--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -188,20 +188,6 @@ bool IsASTCSupported() {
     return true;
 }
 
-/// @brief Returns true when a GL_RENDERER is a Turing GPU
-/// @param renderer GL_RENDERER string
-bool IsTuring(std::string_view renderer) {
-    static constexpr std::array<std::string_view, 12> TURING_GPUS = {
-        "GTX 1650",        "GTX 1660",        "RTX 2060",        "RTX 2070",
-        "RTX 2080",        "TITAN RTX",       "Quadro RTX 3000", "Quadro RTX 4000",
-        "Quadro RTX 5000", "Quadro RTX 6000", "Quadro RTX 8000", "Tesla T4",
-    };
-    return std::any_of(TURING_GPUS.begin(), TURING_GPUS.end(),
-                       [renderer](std::string_view candidate) {
-                           return renderer.find(candidate) != std::string_view::npos;
-                       });
-}
-
 } // Anonymous namespace
 
 Device::Device()
@@ -213,7 +199,6 @@ Device::Device()
 
     const bool is_nvidia = vendor == "NVIDIA Corporation";
     const bool is_amd = vendor == "ATI Technologies Inc.";
-    const bool is_turing = is_nvidia && IsTuring(renderer);
 
     bool disable_fast_buffer_sub_data = false;
     if (is_nvidia && version == "4.6.0 NVIDIA 443.24") {
@@ -238,14 +223,11 @@ Device::Device()
     has_component_indexing_bug = is_amd;
     has_precise_bug = TestPreciseBug();
     has_nv_viewport_array2 = GLAD_GL_NV_viewport_array2;
+    has_vertex_buffer_unified_memory = GLAD_GL_NV_vertex_buffer_unified_memory;
 
     // At the moment of writing this, only Nvidia's driver optimizes BufferSubData on exclusive
     // uniform buffers as "push constants"
     has_fast_buffer_sub_data = is_nvidia && !disable_fast_buffer_sub_data;
-
-    // Nvidia's driver on Turing GPUs randomly crashes when the buffer is made resident, or on
-    // DeleteBuffers. Disable unified memory on these devices.
-    has_vertex_buffer_unified_memory = GLAD_GL_NV_vertex_buffer_unified_memory && !is_turing;
 
     use_assembly_shaders = Settings::values.use_assembly_shaders && GLAD_GL_NV_gpu_program5 &&
                            GLAD_GL_NV_compute_program5 && GLAD_GL_NV_transform_feedback &&


### PR DESCRIPTION
Once we make sure not to corrupt Nvidia's driver, we can safely use resident buffers on Turing devices.

See GitHub pull request #4156