### PR TITLE
hotkeys: Fix issues caused when changing the fullscreen hotkey

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -666,6 +666,11 @@ void GMainWindow::InitializeHotkeys() {
     ui.action_Capture_Screenshot->setShortcutContext(
         hotkey_registry.GetShortcutContext(main_window, capture_screenshot));
 
+    ui.action_Fullscreen->setShortcut(
+        hotkey_registry.GetHotkey(main_window, fullscreen, this)->key());
+    ui.action_Fullscreen->setShortcutContext(
+        hotkey_registry.GetShortcutContext(main_window, fullscreen));
+
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Load File"), this),
             &QShortcut::activated, this, &GMainWindow::OnMenuLoadFile);
     connect(
@@ -849,10 +854,6 @@ void GMainWindow::ConnectMenuEvents() {
     connect(ui.action_Reset_Window_Size, &QAction::triggered, this, &GMainWindow::ResetWindowSize);
 
     // Fullscreen
-    ui.action_Fullscreen->setShortcut(
-        hotkey_registry
-            .GetHotkey(QStringLiteral("Main Window"), QStringLiteral("Fullscreen"), this)
-            ->key());
     connect(ui.action_Fullscreen, &QAction::triggered, this, &GMainWindow::ToggleFullscreen);
 
     // Movie


### PR DESCRIPTION
Currently when changing the fullscreen hotkey the old hotkey still works for entering fullscreen, while the new hotkey can toggle between. The context menu will also show the old hotkey until yuzu is restarted. And if you switch back to the first hotkey you'll have to press it twice to enter the fullscreen.

This fixes that.

At first I tried with 
`ui.action_Fullscreen->setShortcut(hotkey_registry.GetKeySequence(main_window, fullscreen));`
to keep it in the same style as the others above, but that caused the double press issue.

I also added 
`ui.action_Fullscreen->setShortcutContext(hotkey_registry.GetShortcutContext(main_window, fullscreen));`
for the same reason (I don't know what it does) but this fix works without it, so I don't know if it should be removed.
