### PR TITLE
Port citra-emu/citra#5364: ".github: add a new issue template"

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report-feature-request.md
+++ b/.github/ISSUE_TEMPLATE/bug-report-feature-request.md
@@ -1,4 +1,13 @@
-<!--
+---
+name: Bug Report / Feature Request
+about: Tech support does not belong here. You should only file an issue here if you think you have experienced an actual bug with yuzu or you are requesting a feature you believe would make yuzu better.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!---
 Please keep in mind yuzu is EXPERIMENTAL SOFTWARE.
 
 Please read the FAQ:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: yuzu Discord
+    url: https://discord.com/invite/u77vRWY
+    about: If you are experiencing an issue with yuzu, and you need tech support, or if you have a general question, try asking in the official yuzu Discord linked here. Piracy is not allowed.
+  - name: Community forums
+    url: https://community.citra-emu.org
+    about: This is an alternative place for tech support, however helpers there are not as active.


### PR DESCRIPTION
See citra-emu/citra#5364 for more details.

**Original description**:
Hopefully this will decrease the number of users using GitHub issues for tech support requests.

Adds links to the discord, forums, and android repo for users reporting android bugs. There is a hyperlink at the bottom of the template page for those who want to create an actual issue.

<img src="https://i.imgur.com/o28DHHR.png">
