### PR TITLE
cmake: fix fmt linking

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -191,5 +191,5 @@ endif()
 create_target_directory_groups(common)
 find_package(Boost 1.71 COMPONENTS context headers REQUIRED)
 
-target_link_libraries(common PUBLIC ${Boost_LIBRARIES} fmt::fmt microprofile)
+target_link_libraries(common PUBLIC ${Boost_LIBRARIES} fmt microprofile)
 target_link_libraries(common PRIVATE lz4::lz4 zstd::zstd xbyak)


### PR DESCRIPTION
On gcc/ld, and clang/lld, fmt::v6 symbols are excluded, so linking
fails. This fixes the issue.

Note: This was included in the FindBoost changes I shared with
BlinkHawk, however only they were merged. I'm not sure if it was missed,
or if there was an issue with this part of the change.