### PR TITLE
common: unbreak build on BSDs

### DIFF
--- a/src/common/memory_detect.cpp
+++ b/src/common/memory_detect.cpp
@@ -40,16 +40,16 @@ static MemoryInfo Detect() {
     // hw and vm are defined in sysctl.h
     // https://github.com/apple/darwin-xnu/blob/master/bsd/sys/sysctl.h#L471
     // sysctlbyname(const char *, void *, size_t *, void *, size_t);
-    sysctlbyname("hw.memsize", &ramsize, &sizeof_ramsize, NULL, 0);
-    sysctlbyname("vm.swapusage", &vmusage, &sizeof_vmusage, NULL, 0);
+    sysctlbyname("hw.memsize", &ramsize, &sizeof_ramsize, nullptr, 0);
+    sysctlbyname("vm.swapusage", &vmusage, &sizeof_vmusage, nullptr, 0);
     mem_info.TotalPhysicalMemory = ramsize;
     mem_info.TotalSwapMemory = vmusage.xsu_total;
 #elif defined(__FreeBSD__)
     u_long physmem, swap_total;
     std::size_t sizeof_u_long = sizeof(u_long);
     // sysctlbyname(const char *, void *, size_t *, const void *, size_t);
-    sysctlbyname("hw.physmem", &physmem, &sizeof_u_long, NULL, 0);
-    sysctlbyname("vm.swap_total", &swap_total, &sizeof_u_long, NULL, 0);
+    sysctlbyname("hw.physmem", &physmem, &sizeof_u_long, nullptr, 0);
+    sysctlbyname("vm.swap_total", &swap_total, &sizeof_u_long, nullptr, 0);
     mem_info.TotalPhysicalMemory = physmem;
     mem_info.TotalSwapMemory = swap_total;
 #elif defined(__linux__)


### PR DESCRIPTION
Regressed by #3954. From [error log](https://github.com/yuzu-emu/yuzu/files/4848484/yuzu-s20200629.log):
```c++
src/common/memory_detect.cpp:15:10: fatal error: 'sys/sysinfo.h' file not found
#include <sys/sysinfo.h>
         ^~~~~~~~~~~~~~~
```

[sysinfo(2)](http://man7.org/linux/man-pages/man2/sysinfo.2.html) doesn't exist on any of BSDs. [libsysinfo](https://github.com/bsdimp/libsysinfo) relies on [kvm_getswapinfo(3)](https://man.freebsd.org/kvm_getswapinfo/3) which doesn't exist on NetBSD and OpenBSD. Also, installing libsysinfo [is dangerous](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=242236).
