### PR TITLE
vulkan: Add requirements for supporting staging buffers at a generic buffer cache level

### DIFF
--- a/src/video_core/renderer_vulkan/vk_buffer_cache.h
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.h
@@ -19,21 +19,22 @@ class VKDevice;
 class VKMemoryManager;
 class VKScheduler;
 
-class Buffer final : public VideoCommon::BufferBlock {
+class CachedBuffer final : public VideoCommon::BufferBlock {
 public:
-    explicit Buffer(const VKDevice& device, VKMemoryManager& memory_manager, VKScheduler& scheduler,
-                    VKStagingBufferPool& staging_pool, VAddr cpu_addr, std::size_t size);
-    ~Buffer();
+    explicit CachedBuffer(const VKDevice& device, VKMemoryManager& memory_manager,
+                          VKScheduler& scheduler, VKStagingBufferPool& staging_pool, VAddr cpu_addr,
+                          std::size_t size);
+    ~CachedBuffer();
 
     void Upload(std::size_t offset, std::size_t size, const u8* data);
 
     void Download(std::size_t offset, std::size_t size, u8* data);
 
-    void CopyFrom(const Buffer& src, std::size_t src_offset, std::size_t dst_offset,
+    void CopyFrom(const CachedBuffer& src, std::size_t src_offset, std::size_t dst_offset,
                   std::size_t size);
 
     VkBuffer Handle() const {
-        return *buffer.handle;
+        return buffer.Handle();
     }
 
     u64 Address() const {
@@ -44,10 +45,11 @@ private:
     VKScheduler& scheduler;
     VKStagingBufferPool& staging_pool;
 
-    VKBuffer buffer;
+    Buffer buffer;
 };
 
-class VKBufferCache final : public VideoCommon::BufferCache<Buffer, VkBuffer, VKStreamBuffer> {
+class VKBufferCache final
+    : public VideoCommon::BufferCache<CachedBuffer, VkBuffer, VKStreamBuffer> {
 public:
     explicit VKBufferCache(VideoCore::RasterizerInterface& rasterizer,
                            Tegra::MemoryManager& gpu_memory, Core::Memory::Memory& cpu_memory,
@@ -58,7 +60,7 @@ public:
     BufferInfo GetEmptyBuffer(std::size_t size) override;
 
 protected:
-    std::shared_ptr<Buffer> CreateBlock(VAddr cpu_addr, std::size_t size) override;
+    std::shared_ptr<CachedBuffer> CreateBlock(VAddr cpu_addr, std::size_t size) override;
 
 private:
     const VKDevice& device;

--- a/src/video_core/renderer_vulkan/vk_memory_manager.h
+++ b/src/video_core/renderer_vulkan/vk_memory_manager.h
@@ -63,31 +63,33 @@ public:
     ~VKMemoryCommitImpl();
 
     /// Maps a memory region and returns a pointer to it.
-    /// It's illegal to have more than one memory map at the same time.
+    /// @note It's illegal to have more than one memory map at the same time.
     MemoryMap Map(u64 size, u64 offset = 0) const;
 
     /// Maps the whole commit and returns a pointer to it.
-    /// It's illegal to have more than one memory map at the same time.
+    /// @note It's illegal to have more than one memory map at the same time.
     MemoryMap Map() const;
 
     /// Returns the Vulkan memory handler.
-    VkDeviceMemory GetMemory() const {
+    VkDeviceMemory Memory() const {
         return *memory;
     }
 
     /// Returns the start position of the commit relative to the allocation.
-    VkDeviceSize GetOffset() const {
+    VkDeviceSize Offset() const {
         return static_cast<VkDeviceSize>(interval.first);
     }
 
 private:
     /// Unmaps memory.
-    void Unmap() const;
+    /// @note Currently a no-op because all memory maps are persistent
+    void Unmap() const {}
 
     const VKDevice& device;           ///< Vulkan device.
     const vk::DeviceMemory& memory;   ///< Vulkan device memory handler.
     std::pair<u64, u64> interval{};   ///< Interval where the commit exists.
     VKMemoryAllocation* allocation{}; ///< Pointer to the large memory allocation.
+    u8* persistent_map{};             ///< Pointer to a persistently mapped address.
 };
 
 /// Holds ownership of a memory map.

--- a/src/video_core/renderer_vulkan/vk_staging_buffer_pool.h
+++ b/src/video_core/renderer_vulkan/vk_staging_buffer_pool.h
@@ -17,9 +17,17 @@ namespace Vulkan {
 class VKDevice;
 class VKScheduler;
 
-struct VKBuffer final {
+struct Buffer {
     vk::Buffer handle;
     VKMemoryCommit commit;
+
+    VkBuffer Handle() const noexcept {
+        return *handle;
+    }
+
+    MemoryMap Map(u64 size, u64 offset = 0) const {
+        return commit->Map(size, offset);
+    }
 };
 
 class VKStagingBufferPool final {
@@ -28,19 +36,17 @@ public:
                                  VKScheduler& scheduler);
     ~VKStagingBufferPool();
 
-    VKBuffer& GetUnusedBuffer(std::size_t size, bool host_visible);
+    Buffer& GetUnusedBuffer(std::size_t size, bool host_visible);
 
     void TickFrame();
 
 private:
-    struct StagingBuffer final {
-        explicit StagingBuffer(std::unique_ptr<VKBuffer> buffer);
-
-        std::unique_ptr<VKBuffer> buffer;
-        u64 tick = 0;
+    struct StagingBuffer {
+        Buffer buffer;
+        u64 tick;
     };
 
-    struct StagingBuffers final {
+    struct StagingBuffers {
         std::vector<StagingBuffer> entries;
         std::size_t delete_index = 0;
     };
@@ -48,9 +54,9 @@ private:
     static constexpr std::size_t NumLevels = sizeof(std::size_t) * CHAR_BIT;
     using StagingBuffersCache = std::array<StagingBuffers, NumLevels>;
 
-    VKBuffer* TryGetReservedBuffer(std::size_t size, bool host_visible);
+    Buffer* TryGetReservedBuffer(std::size_t size, bool host_visible);
 
-    VKBuffer& CreateStagingBuffer(std::size_t size, bool host_visible);
+    Buffer& CreateStagingBuffer(std::size_t size, bool host_visible);
 
     StagingBuffersCache& GetCache(bool host_visible);
 

--- a/src/video_core/renderer_vulkan/vk_stream_buffer.h
+++ b/src/video_core/renderer_vulkan/vk_stream_buffer.h
@@ -63,8 +63,9 @@ private:
     vk::DeviceMemory memory;  ///< Memory allocation.
     u64 stream_buffer_size{}; ///< Stream buffer size.
 
-    u64 offset{};      ///< Buffer iterator.
-    u64 mapped_size{}; ///< Size reserved for the current copy.
+    u8* persistent_map{}; ///< Address of the persistently mapped pointer.
+    u64 offset{};         ///< Buffer iterator.
+    u64 mapped_size{};    ///< Size reserved for the current copy.
 
     std::vector<Watch> current_watches;           ///< Watches recorded in the current iteration.
     std::size_t current_watch_cursor{};           ///< Count of watches, reset on invalidation.


### PR DESCRIPTION
Description in the individual commits. This is intended to support staging buffers at a buffer cache level in the future. This also replaces our current map/unmap approach on Vulkan with persistent maps, fixing Nsight compatibility and probably increasing runtime performance a bit.