### PR TITLE
NvFlinger: Split Buffer Wait from VSync on Async VSync.

### DIFF
--- a/src/core/hle/service/nvflinger/buffer_queue.h
+++ b/src/core/hle/service/nvflinger/buffer_queue.h
@@ -77,7 +77,7 @@ public:
     };
 
     struct Buffer {
-        enum class Status { Free = 0, Queued = 1, Dequeued = 2, Acquired = 3 };
+        enum class Status { Free = 0, Queued = 1, Dequeued = 2, Acquired = 3, Presenting = 4 };
 
         u32 slot;
         Status status = Status::Free;
@@ -96,6 +96,8 @@ public:
                      const Common::Rectangle<int>& crop_rect, u32 swap_interval,
                      Service::Nvidia::MultiFence& multi_fence);
     std::optional<std::reference_wrapper<const Buffer>> AcquireBuffer();
+    std::optional<std::reference_wrapper<const Buffer>> ObtainPresentBuffer();
+    void SetToPresentBuffer(u32 slot);
     void ReleaseBuffer(u32 slot);
     void Disconnect();
     u32 Query(QueryType type);
@@ -115,6 +117,7 @@ private:
     std::list<u32> free_buffers;
     std::vector<Buffer> queue;
     std::list<u32> queue_sequence;
+    std::list<u32> presenting_sequence;
     Kernel::EventPair buffer_wait_event;
 };
 

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -80,6 +80,9 @@ public:
     /// Obtains a buffer queue identified by the ID.
     const BufferQueue& FindBufferQueue(u32 id) const;
 
+    /// On queueing buffer for rendering
+    void NotifyQueue();
+
     /// Performs a composition request to the emulated nvidia GPU and triggers the vsync events when
     /// finished.
     void Compose();
@@ -104,8 +107,10 @@ private:
     const VI::Layer* FindLayer(u64 display_id, u64 layer_id) const;
 
     static void VSyncThread(NVFlinger& nv_flinger);
+    static void WaitForBuffersThread(NVFlinger& nv_flinger);
 
     void SplitVSync();
+    void WaitForBuffers();
 
     std::shared_ptr<Nvidia::Module> nvdrv;
 
@@ -128,7 +133,9 @@ private:
     Core::System& system;
 
     std::unique_ptr<std::thread> vsync_thread;
+    std::unique_ptr<std::thread> buffer_thread;
     std::unique_ptr<Common::Event> wait_event;
+    std::unique_ptr<Common::Event> queue_event;
     std::atomic<bool> is_running{};
 };
 

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -580,6 +580,7 @@ private:
             buffer_queue.QueueBuffer(request.data.slot, request.data.transform,
                                      request.data.GetCropRect(), request.data.swap_interval,
                                      request.data.multi_fence);
+            nv_flinger->NotifyQueue();
 
             IGBPQueueBufferResponseParcel response{1280, 720};
             ctx.WriteBuffer(response.Serialize());


### PR DESCRIPTION
This PR splits presentation from waiting. Now buffers will be waited for in a different thread and presented on a separate thread. It should improve smoothness in games like D3 or that rely on accurate timing of vsync events.

This only affects Multicore + Async.