### PR TITLE
service: Auto stub fallback

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -152,6 +152,10 @@ void ServiceFrameworkBase::ReportUnimplementedFunction(Kernel::HLERequestContext
     Core::System::GetInstance().GetReporter().SaveUnimplementedFunctionReport(
         ctx, ctx.GetCommand(), function_name, service_name);
     UNIMPLEMENTED_MSG("Unknown / unimplemented {}", fmt::to_string(buf));
+
+    LOG_WARNING(Service, "Using auto stub fallback!");
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(RESULT_SUCCESS);
 }
 
 void ServiceFrameworkBase::InvokeRequest(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
For simple services, we can implement an automatic stub fallback to help with compatibility until a proper implementation is done.

This should not be merged as it's a hack, however, it's to improve compatibility until we have an actual implementation of HLE functions.