### PR TITLE
memory: Race-condition in pagetables.

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -548,9 +548,9 @@ struct Memory::Impl {
                         // longer exist, and we should just leave the pagetable entry blank.
                         page_type = Common::PageType::Unmapped;
                     } else {
-                        page_type = Common::PageType::Memory;
                         current_page_table->pointers[vaddr >> PAGE_BITS] =
                             pointer - (vaddr & ~PAGE_MASK);
+                        page_type = Common::PageType::Memory;
                     }
                     break;
                 }
@@ -591,9 +591,12 @@ struct Memory::Impl {
                    base + page_table.pointers.size());
 
         if (!target) {
+            ASSERT_MSG(type != Common::PageType::Memory,
+                       "Mapping memory page without a pointer @ {:016x}", base * PAGE_SIZE);
+
             while (base != end) {
-                page_table.pointers[base] = nullptr;
                 page_table.attributes[base] = type;
+                page_table.pointers[base] = nullptr;
                 page_table.backing_addr[base] = 0;
 
                 base += 1;


### PR DESCRIPTION
Users have been reporting the `Mapped memory page without a pointer` assertion being triggered, which should never happen.

The most likely way this is triggered is due to a race condition while modifying page tables. i.e.: An entry is accessed with an out-of-date attribute.

This PR attempts to 1. set `pointers` before `attribute = Memory`, and 2. set `attribute` before `pointers = nullptr` to avoid this race. Please not however that this is not a guaranteed fix because the compiler may reorder this operation during optimization.

Ideally one would audit the codebase for race-conditions and use appropriate synchronisation primitives as required.