### PR TITLE
hotkeys: (HACK) don't set a shortcut for the screenshot hotkey

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -684,8 +684,12 @@ void GMainWindow::InitializeHotkeys() {
     ui.action_Show_Status_Bar->setShortcutContext(
         hotkey_registry.GetShortcutContext(main_window, toggle_status_bar));
 
+    // This is a hack which should be removed if and when a
+    // proper solution is found
+    /*
     ui.action_Capture_Screenshot->setShortcut(
         hotkey_registry.GetKeySequence(main_window, capture_screenshot));
+    */
     ui.action_Capture_Screenshot->setShortcutContext(
         hotkey_registry.GetShortcutContext(main_window, capture_screenshot));
 


### PR DESCRIPTION
This *should* make it work again as intended, at least with the "default" settings (I have no idea why, but it worked for me)
I wasn't able to find the root of the problem unfortunately, but the bug was most probably caused by hotkey_registry
The screenshot hotkey didn't work as intended while in-game, and this PR attempts to fix that problem (in a "hacky" way, though)

This has only been tested by me, so it should be considered "untested"