### PR TITLE
screenshots: Option to save screenshots immediately in a specified directory + Linux workaround

### DIFF
--- a/src/common/common_paths.h
+++ b/src/common/common_paths.h
@@ -35,6 +35,7 @@
 #define KEYS_DIR "keys"
 #define LOAD_DIR "load"
 #define DUMP_DIR "dump"
+#define SCREENSHOTS_DIR "screenshots"
 #define SHADER_DIR "shader"
 #define LOG_DIR "log"
 

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -695,6 +695,7 @@ const std::string& GetUserPath(UserPath path, const std::string& new_path) {
         paths.emplace(UserPath::NANDDir, user_path + NAND_DIR DIR_SEP);
         paths.emplace(UserPath::LoadDir, user_path + LOAD_DIR DIR_SEP);
         paths.emplace(UserPath::DumpDir, user_path + DUMP_DIR DIR_SEP);
+        paths.emplace(UserPath::ScreenshotsDir, user_path + SCREENSHOTS_DIR DIR_SEP);
         paths.emplace(UserPath::ShaderDir, user_path + SHADER_DIR DIR_SEP);
         paths.emplace(UserPath::SysDataDir, user_path + SYSDATA_DIR DIR_SEP);
         paths.emplace(UserPath::KeysDir, user_path + KEYS_DIR DIR_SEP);

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -32,6 +32,7 @@ enum class UserPath {
     SDMCDir,
     LoadDir,
     DumpDir,
+    ScreenshotsDir,
     ShaderDir,
     SysDataDir,
     UserDir,

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -578,7 +578,6 @@ void Config::ReadPathValues() {
 
     UISettings::values.roms_path = ReadSetting(QStringLiteral("romsPath")).toString();
     UISettings::values.symbols_path = ReadSetting(QStringLiteral("symbolsPath")).toString();
-    UISettings::values.screenshot_path = ReadSetting(QStringLiteral("screenshotPath")).toString();
     UISettings::values.game_dir_deprecated =
         ReadSetting(QStringLiteral("gameListRootDir"), QStringLiteral(".")).toString();
     UISettings::values.game_dir_deprecated_deepscan =
@@ -675,6 +674,22 @@ void Config::ReadRendererValues() {
     qt_config->endGroup();
 }
 
+void Config::ReadScreenshotValues() {
+    qt_config->beginGroup(QStringLiteral("Screenshots"));
+
+    UISettings::values.enable_screenshot_save_as =
+        ReadSetting(QStringLiteral("enable_screenshot_save_as"), true).toBool();
+    FileUtil::GetUserPath(
+        FileUtil::UserPath::ScreenshotsDir,
+        qt_config
+            ->value(QStringLiteral("screenshot_path"), QString::fromStdString(FileUtil::GetUserPath(
+                                                           FileUtil::UserPath::ScreenshotsDir)))
+            .toString()
+            .toStdString());
+
+    qt_config->endGroup();
+}
+
 void Config::ReadShortcutValues() {
     qt_config->beginGroup(QStringLiteral("Shortcuts"));
 
@@ -756,6 +771,7 @@ void Config::ReadUIValues() {
     ReadUIGamelistValues();
     ReadUILayoutValues();
     ReadPathValues();
+    ReadScreenshotValues();
     ReadShortcutValues();
 
     UISettings::values.single_window_mode =
@@ -1085,7 +1101,6 @@ void Config::SavePathValues() {
 
     WriteSetting(QStringLiteral("romsPath"), UISettings::values.roms_path);
     WriteSetting(QStringLiteral("symbolsPath"), UISettings::values.symbols_path);
-    WriteSetting(QStringLiteral("screenshotPath"), UISettings::values.screenshot_path);
     qt_config->beginWriteArray(QStringLiteral("gamedirs"));
     for (int i = 0; i < UISettings::values.game_dirs.size(); ++i) {
         qt_config->setArrayIndex(i);
@@ -1164,6 +1179,17 @@ void Config::SaveRendererValues() {
     qt_config->endGroup();
 }
 
+void Config::SaveScreenshotValues() {
+    qt_config->beginGroup(QStringLiteral("Screenshots"));
+
+    WriteSetting(QStringLiteral("enableScreenshotSaveAs"),
+                 UISettings::values.enable_screenshot_save_as);
+    WriteSetting(QStringLiteral("screenshotPath"),
+                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ScreenshotsDir)));
+
+    qt_config->endGroup();
+}
+
 void Config::SaveShortcutValues() {
     qt_config->beginGroup(QStringLiteral("Shortcuts"));
 
@@ -1226,6 +1252,7 @@ void Config::SaveUIValues() {
     SaveUIGamelistValues();
     SaveUILayoutValues();
     SavePathValues();
+    SaveScreenshotValues();
     SaveShortcutValues();
 
     WriteSetting(QStringLiteral("singleWindowMode"), UISettings::values.single_window_mode, true);

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -1182,9 +1182,9 @@ void Config::SaveRendererValues() {
 void Config::SaveScreenshotValues() {
     qt_config->beginGroup(QStringLiteral("Screenshots"));
 
-    WriteSetting(QStringLiteral("enableScreenshotSaveAs"),
+    WriteSetting(QStringLiteral("enable_screenshot_save_as"),
                  UISettings::values.enable_screenshot_save_as);
-    WriteSetting(QStringLiteral("screenshotPath"),
+    WriteSetting(QStringLiteral("screenshot_path"),
                  QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ScreenshotsDir)));
 
     qt_config->endGroup();

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -51,6 +51,7 @@ private:
     void ReadPathValues();
     void ReadCpuValues();
     void ReadRendererValues();
+    void ReadScreenshotValues();
     void ReadShortcutValues();
     void ReadSystemValues();
     void ReadUIValues();
@@ -76,6 +77,7 @@ private:
     void SavePathValues();
     void SaveCpuValues();
     void SaveRendererValues();
+    void SaveScreenshotValues();
     void SaveShortcutValues();
     void SaveSystemValues();
     void SaveUIValues();

--- a/src/yuzu/configuration/configure_ui.cpp
+++ b/src/yuzu/configuration/configure_ui.cpp
@@ -4,9 +4,11 @@
 
 #include <array>
 #include <utility>
+#include <QFileDialog>
 
 #include <QDirIterator>
 #include "common/common_types.h"
+#include "common/file_util.h"
 #include "core/settings.h"
 #include "ui_configure_ui.h"
 #include "yuzu/configuration/configure_ui.h"
@@ -55,6 +57,14 @@ ConfigureUi::ConfigureUi(QWidget* parent) : QWidget(parent), ui(new Ui::Configur
             [=]() { ConfigureUi::UpdateSecondRowComboBox(); });
     connect(ui->row_2_text_combobox, QOverload<int>::of(&QComboBox::activated),
             [=]() { ConfigureUi::UpdateFirstRowComboBox(); });
+
+    // Set screenshot path to user specification.
+    connect(ui->screenshot_path_button, &QToolButton::pressed, this, [this] {
+        const QString& filename = QFileDialog::getExistingDirectory(
+            this, tr("Select Screenshots Path..."),
+            QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ScreenshotsDir)));
+        ui->screenshot_path_edit->setText(filename);
+    });
 }
 
 ConfigureUi::~ConfigureUi() = default;
@@ -66,6 +76,10 @@ void ConfigureUi::ApplyConfiguration() {
     UISettings::values.icon_size = ui->icon_size_combobox->currentData().toUInt();
     UISettings::values.row_1_text_id = ui->row_1_text_combobox->currentData().toUInt();
     UISettings::values.row_2_text_id = ui->row_2_text_combobox->currentData().toUInt();
+
+    UISettings::values.enable_screenshot_save_as = ui->enable_screenshot_save_as->isChecked();
+    FileUtil::GetUserPath(FileUtil::UserPath::ScreenshotsDir,
+                          ui->screenshot_path_edit->text().toStdString());
     Settings::Apply();
 }
 
@@ -80,6 +94,10 @@ void ConfigureUi::SetConfiguration() {
     ui->show_add_ons->setChecked(UISettings::values.show_add_ons);
     ui->icon_size_combobox->setCurrentIndex(
         ui->icon_size_combobox->findData(UISettings::values.icon_size));
+
+    ui->enable_screenshot_save_as->setChecked(UISettings::values.enable_screenshot_save_as);
+    ui->screenshot_path_edit->setText(
+        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ScreenshotsDir)));
 }
 
 void ConfigureUi::changeEvent(QEvent* event) {

--- a/src/yuzu/configuration/configure_ui.cpp
+++ b/src/yuzu/configuration/configure_ui.cpp
@@ -60,9 +60,11 @@ ConfigureUi::ConfigureUi(QWidget* parent) : QWidget(parent), ui(new Ui::Configur
 
     // Set screenshot path to user specification.
     connect(ui->screenshot_path_button, &QToolButton::pressed, this, [this] {
-        const QString& filename = QFileDialog::getExistingDirectory(
-            this, tr("Select Screenshots Path..."),
-            QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ScreenshotsDir)));
+        const QString& filename =
+            QFileDialog::getExistingDirectory(
+                this, tr("Select Screenshots Path..."),
+                QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ScreenshotsDir))) +
+            QDir::separator();
         if (!filename.isEmpty()) {
             ui->screenshot_path_edit->setText(filename);
         }

--- a/src/yuzu/configuration/configure_ui.cpp
+++ b/src/yuzu/configuration/configure_ui.cpp
@@ -63,7 +63,9 @@ ConfigureUi::ConfigureUi(QWidget* parent) : QWidget(parent), ui(new Ui::Configur
         const QString& filename = QFileDialog::getExistingDirectory(
             this, tr("Select Screenshots Path..."),
             QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ScreenshotsDir)));
-        ui->screenshot_path_edit->setText(filename);
+        if (!filename.isEmpty()) {
+            ui->screenshot_path_edit->setText(filename);
+        }
     });
 }
 

--- a/src/yuzu/configuration/configure_ui.ui
+++ b/src/yuzu/configuration/configure_ui.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>300</width>
-    <height>377</height>
+    <width>363</width>
+    <height>391</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -119,6 +119,47 @@
           </item>
           <item>
            <widget class="QComboBox" name="row_2_text_combobox"/>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="screenshots_GroupBox">
+     <property name="title">
+      <string>Screenshots</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout_3">
+        <item>
+         <widget class="QCheckBox" name="enable_screenshot_save_as">
+          <property name="text">
+           <string>Ask Where To Save Screenshots (Windows Only)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_4">
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Screenshots Path: </string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLineEdit" name="screenshot_path_edit"/>
+          </item>
+          <item>
+           <widget class="QToolButton" name="screenshot_path_button">
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </item>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2155,12 +2155,14 @@ void GMainWindow::OnCaptureScreenshot() {
     OnPauseGame();
 
     const u64 title_id = Core::System::GetInstance().CurrentProcess()->GetTitleID();
-    const auto screenshot_path = FileUtil::GetUserPath(FileUtil::UserPath::ScreenshotsDir);
-    const auto date = QDateTime::currentDateTime()
-                          .toString(QStringLiteral("yyyy-MM-dd_hh-mm-ss-zzz"))
-                          .toStdString();
-    QString filename = QString::fromStdString(screenshot_path + fmt::format("{:016X}", title_id) +
-                                              "_" + date + ".png");
+    const auto screenshot_path =
+        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ScreenshotsDir));
+    const auto date =
+        QDateTime::currentDateTime().toString(QStringLiteral("yyyy-MM-dd_hh-mm-ss-zzz"));
+    QString filename = QStringLiteral("%1%2_%3.png")
+                           .arg(screenshot_path)
+                           .arg(title_id, 16, 16, QLatin1Char{'0'})
+                           .arg(date);
 
 #ifdef _WIN32
     if (UISettings::values.enable_screenshot_save_as) {

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -66,11 +66,11 @@ struct Values {
     // Discord RPC
     bool enable_discord_presence;
 
+    bool enable_screenshot_save_as;
     u16 screenshot_resolution_factor;
 
     QString roms_path;
     QString symbols_path;
-    QString screenshot_path;
     QString game_dir_deprecated;
     bool game_dir_deprecated_deepscan;
     QVector<UISettings::GameDir> game_dirs;


### PR DESCRIPTION
Currently, to save a screenshot, there is no option but to choose a path and filename each time the user wanted to take a screenshot. In Linux, the Capture Screenshot QFileDialog is blank **if** it is visible, thus it is completely unusable.

This PR allows the user to save a screenshot immediately, shortcutting the process in Windows, and provides a workaround for the dialog issue in Linux until an actual solution is found. To control this behavior, in Emulation -> Configure... -> General -> UI there are two new options. The first lets the user choose whether yuzu prompts where to store the screenshot (marked as Windows only). The second is a text box that allows the user to specify a default path to save screenshots. Beside that is a button that opens a QFileDialog letting the user choose the default screenshots path. The default path is `[yuzu directory]/screenshots`.

This PR was intended to make use of `UISettings::values.screenshot_path`, but ended up removing it altogether in favor of adding an entry to `FileUtil`. IMO it is debatable whether it belongs there, and I am open to changing how the default directory is determined.

This will hopefully be a welcome change to Windows users, but this was originally written as a workaround for the Linux issue. It seems all QFileDialogs have issues when a game is running in Linux, but the Capture Screenshot dialog is the most visible when a game is running, given its utility. Thus we have the motivation for this PR.

It is worth noting that building yuzu with MinGW and running it in Wine under Linux does not produce the same result as running it natively in Linux. The QFileDialog and saving screenshots with the prompt works well in Wine.