### PR TITLE
gcadapter: unbreak build on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,8 +331,10 @@ endif()
 
 # Ensure libusb is properly configured (based on dolphin libusb include)
 find_package(LibUSB)
-add_subdirectory(externals/libusb)
-set(LIBUSB_LIBRARIES usb)
+if (NOT LIBUSB_FOUND)
+    add_subdirectory(externals/libusb)
+    set(LIBUSB_LIBRARIES usb)
+endif()
 
 
 # Prefer the -pthread flag on Linux.

--- a/externals/find-modules/FindLibUSB.cmake
+++ b/externals/find-modules/FindLibUSB.cmake
@@ -1,0 +1,43 @@
+# - Find libusb-1.0 library
+# This module defines
+#  LIBUSB_INCLUDE_DIR, where to find bluetooth.h
+#  LIBUSB_LIBRARIES, the libraries needed to use libusb-1.0.
+#  LIBUSB_FOUND, If false, do not try to use libusb-1.0.
+#
+# Copyright (c) 2009, Michal Cihar, <michal@cihar.com>
+#
+# vim: expandtab sw=4 ts=4 sts=4:
+
+if(ANDROID)
+       set(LIBUSB_FOUND FALSE CACHE INTERNAL "libusb-1.0 found")
+       message(STATUS "libusb-1.0 not found.")
+elseif (NOT LIBUSB_FOUND)
+    pkg_check_modules (LIBUSB_PKG libusb-1.0)
+
+    find_path(LIBUSB_INCLUDE_DIR NAMES libusb.h
+       PATHS
+       ${LIBUSB_PKG_INCLUDE_DIRS}
+       /usr/include/libusb-1.0
+       /usr/include
+       /usr/local/include/libusb-1.0
+       /usr/local/include
+    )
+
+    find_library(LIBUSB_LIBRARIES NAMES usb-1.0 usb
+       PATHS
+       ${LIBUSB_PKG_LIBRARY_DIRS}
+       /usr/lib
+       /usr/local/lib
+    )
+
+    if(LIBUSB_INCLUDE_DIR AND LIBUSB_LIBRARIES)
+       set(LIBUSB_FOUND TRUE CACHE INTERNAL "libusb-1.0 found")
+       message(STATUS "Found libusb-1.0: ${LIBUSB_INCLUDE_DIR}, ${LIBUSB_LIBRARIES}")
+    else(LIBUSB_INCLUDE_DIR AND LIBUSB_LIBRARIES)
+       set(LIBUSB_FOUND FALSE CACHE INTERNAL "libusb-1.0 found")
+       message(STATUS "libusb-1.0 not found.")
+    endif(LIBUSB_INCLUDE_DIR AND LIBUSB_LIBRARIES)
+
+    mark_as_advanced(LIBUSB_INCLUDE_DIR LIBUSB_LIBRARIES)
+endif ()
+

--- a/src/input_common/gcadapter/gc_adapter.h
+++ b/src/input_common/gcadapter/gc_adapter.h
@@ -7,6 +7,7 @@
 #include <functional>
 #include <mutex>
 #include <thread>
+#include <unordered_map>
 #include <libusb.h>
 #include "common/common_types.h"
 #include "common/threadsafe_queue.h"


### PR DESCRIPTION
Regressed by #4137

- FreeBSD, OpenBSD, macOS use libc++ by default
- DragonFly, FreeBSD ship non-reference libusb
- 121af3646dad added `find_package(LibUSB)` but forgot to copy FindLibUSB.cmake from Dolphin
