### PR TITLE
cmake: pass libusb include directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,6 +333,7 @@ endif()
 find_package(LibUSB)
 if (NOT LIBUSB_FOUND)
     add_subdirectory(externals/libusb)
+    set(LIBUSB_INCLUDE_DIR "")
     set(LIBUSB_LIBRARIES usb)
 endif()
 

--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -30,6 +30,7 @@ if(SDL2_FOUND)
     target_compile_definitions(input_common PRIVATE HAVE_SDL2)
 endif()
 
+target_include_directories(input_common SYSTEM PUBLIC ${LIBUSB_INCLUDE_DIR})
 target_link_libraries(input_common PUBLIC ${LIBUSB_LIBRARIES})
 
 create_target_directory_groups(input_common)

--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -30,8 +30,8 @@ if(SDL2_FOUND)
     target_compile_definitions(input_common PRIVATE HAVE_SDL2)
 endif()
 
-target_include_directories(input_common SYSTEM PUBLIC ${LIBUSB_INCLUDE_DIR})
-target_link_libraries(input_common PUBLIC ${LIBUSB_LIBRARIES})
+target_include_directories(input_common SYSTEM PRIVATE ${LIBUSB_INCLUDE_DIR})
+target_link_libraries(input_common PRIVATE ${LIBUSB_LIBRARIES})
 
 create_target_directory_groups(input_common)
 target_link_libraries(input_common PUBLIC core PRIVATE common Boost::boost)

--- a/src/input_common/gcadapter/gc_adapter.cpp
+++ b/src/input_common/gcadapter/gc_adapter.cpp
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <thread>
+#include <libusb.h>
 #include "common/logging/log.h"
 #include "input_common/gcadapter/gc_adapter.h"
 

--- a/src/input_common/gcadapter/gc_adapter.h
+++ b/src/input_common/gcadapter/gc_adapter.h
@@ -8,9 +8,12 @@
 #include <mutex>
 #include <thread>
 #include <unordered_map>
-#include <libusb.h>
 #include "common/common_types.h"
 #include "common/threadsafe_queue.h"
+
+struct libusb_context;
+struct libusb_device;
+struct libusb_device_handle;
 
 namespace GCAdapter {
 

--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -4,7 +4,6 @@
 
 #include <memory>
 #include <thread>
-#include <libusb.h>
 #include "common/param_package.h"
 #include "input_common/analog_from_button.h"
 #include "input_common/gcadapter/gc_adapter.h"


### PR DESCRIPTION
Regressed by #4266 
Fixes #4279

Reference libusb (unlike FreeBSD implementation) has `libusb-1.0/` directory prefix, so include directory from `pkg-config --cflags libusb-1.0` needs to be passed properly.
