### PR TITLE
vk_stream_buffer: Prevent Vulkan crash in Linux on recent NVIDIA driver

### DIFF
--- a/src/video_core/renderer_vulkan/vk_stream_buffer.cpp
+++ b/src/video_core/renderer_vulkan/vk_stream_buffer.cpp
@@ -121,7 +121,7 @@ void VKStreamBuffer::CreateBuffers(VkBufferUsageFlags usage) {
 
     // Substract from the preferred heap size some bytes to avoid getting out of memory.
     const VkDeviceSize heap_size = memory_properties.memoryHeaps[preferred_heap].size;
-    const VkDeviceSize allocable_size = heap_size - 4 * 1024 * 1024;
+    const VkDeviceSize allocable_size = heap_size - 9 * 1024 * 1024;
 
     VkBufferCreateInfo buffer_ci;
     buffer_ci.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;


### PR DESCRIPTION
Fixes #3794 
This prevents the crash on Linux systems running the current Linux Long Lived branch NVIDIA driver (450.57). Sets allocable_size to 9 MiB, an experimentally determined value such that anything less than 9 MiB reproduces the crash. Many thanks to @ReinUsesLisp who helped me debug the error.