### PR TITLE
cmake: Fix libusb builds breaking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,7 @@ elseif(SDL2_FOUND)
 endif()
 
 # Ensure libusb is properly configured (based on dolphin libusb include)
+INCLUDE(FindPkgConfig)
 find_package(LibUSB)
 if (NOT LIBUSB_FOUND)
     add_subdirectory(externals/libusb)


### PR DESCRIPTION
Fixes the `Unknown CMake command "pkg_check_modules".` error when building on windows