### PR TITLE
CMakeLists: Use lower-case command names

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,7 +330,7 @@ elseif(SDL2_FOUND)
 endif()
 
 # Ensure libusb is properly configured (based on dolphin libusb include)
-INCLUDE(FindPkgConfig)
+include(FindPkgConfig)
 find_package(LibUSB)
 if (NOT LIBUSB_FOUND)
     add_subdirectory(externals/libusb)


### PR DESCRIPTION
Our convention uses lower-case command names, so this is just a consistency change.