### PR TITLE
CMakeLists: Make use of /std:c++latest on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,8 +118,15 @@ message(STATUS "Target architecture: ${ARCHITECTURE}")
 # Configure C++ standard
 # ===========================
 
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
+if (MSVC)
+    add_compile_options(/std:c++latest)
+
+    # cubeb and boost still make use of deprecated result_of.
+    add_definitions(-D_HAS_DEPRECATED_RESULT_OF)
+else()
+    set(CMAKE_CXX_STANDARD 17)
+    set(CMAKE_CXX_STANDARD_REQUIRED ON)
+endif()
 
 # Output binaries to bin/
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -531,8 +531,8 @@ void GameList::AddPermDirPopup(QMenu& context_menu, QModelIndex selected) {
     UISettings::GameDir& game_dir =
         *selected.data(GameListDir::GameDirRole).value<UISettings::GameDir*>();
 
-    QAction* move_up = context_menu.addAction(tr(u8"\U000025b2 Move Up"));
-    QAction* move_down = context_menu.addAction(tr(u8"\U000025bc Move Down "));
+    QAction* move_up = context_menu.addAction(tr("\u25B2 Move Up"));
+    QAction* move_down = context_menu.addAction(tr("\u25bc Move Down"));
     QAction* open_directory_location = context_menu.addAction(tr("Open Directory Location"));
 
     const int row = selected.row();


### PR DESCRIPTION
Provides the buildbot with one builder that is always tracking the latest version of the C++ standard, allowing us to progressively rectify our code and amend any differences between standards over time instead of waiting for a complete standard change, potentially breaking a lot of code all at once.

For example, we already had some non-conformant code. `u8` prefixed on a string makes the string an array of `char8_t`, which is a distinct type in C++20.

GCC and clang have no concept of a "latest" switch unfortunately, so the same changes cannot be applied to them there.