### PR TITLE
input_common: First implementation of controller rumble

### DIFF
--- a/src/core/frontend/input.h
+++ b/src/core/frontend/input.h
@@ -33,6 +33,9 @@ public:
     virtual bool GetAnalogDirectionStatus(AnalogDirection direction) const {
         return {};
     }
+    virtual bool SetRumblePlay(f32 amp_high, f32 amp_low, f32 freq_high, f32 freq_low) const {
+        return {};
+    }
 };
 
 /// An abstract class template for a factory that can create input devices.

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -121,7 +121,7 @@ public:
 
     void SetNpadMode(u32 npad_id, NPadAssignments assignment_mode);
 
-    void VibrateController(const std::vector<u32>& controller_ids,
+    void VibrateController(const std::vector<u32>& controllers,
                            const std::vector<Vibration>& vibrations);
 
     Vibration GetLastVibration() const;

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -802,18 +802,18 @@ void Hid::EndPermitVibrationSession(Kernel::HLERequestContext& ctx) {
 
 void Hid::SendVibrationValue(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
-    const auto controller_id{rp.Pop<u32>()};
+    const auto controller{rp.Pop<u32>()};
     const auto vibration_values{rp.PopRaw<Controller_NPad::Vibration>()};
     const auto applet_resource_user_id{rp.Pop<u64>()};
 
-    LOG_DEBUG(Service_HID, "called, controller_id={}, applet_resource_user_id={}", controller_id,
+    LOG_DEBUG(Service_HID, "called, controller={}, applet_resource_user_id={}", controller,
               applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 
     applet_resource->GetController<Controller_NPad>(HidController::NPad)
-        .VibrateController({controller_id}, {vibration_values});
+        .VibrateController({controller}, {vibration_values});
 }
 
 void Hid::SendVibrationValues(Kernel::HLERequestContext& ctx) {
@@ -831,8 +831,6 @@ void Hid::SendVibrationValues(Kernel::HLERequestContext& ctx) {
 
     std::memcpy(controller_list.data(), controllers.data(), controllers.size());
     std::memcpy(vibration_list.data(), vibrations.data(), vibrations.size());
-    std::transform(controller_list.begin(), controller_list.end(), controller_list.begin(),
-                   [](u32 controller_id) { return controller_id - 3; });
 
     applet_resource->GetController<Controller_NPad>(HidController::NPad)
         .VibrateController(controller_list, vibration_list);


### PR DESCRIPTION
This is an approach to implement a basic controller rumble. It enables vibrations on Pro Controllers that can use sdl_haptics. 
The first button of player settings is used as a reference to know which controller corresponds to which player.

From testing and debugging I found that controller_ids should be splitted into 4 bytes. The second rightmost byte always contains the player number.

Most of the code added should be changed with a better method. I'm looking to fix it until everyone it's happy with the code.

Closes #3894 