### PR TITLE
yuzu/configure_filesystem: Remove "Select Cache Directory" option

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -615,12 +615,6 @@ void Config::ReadDataStorageValues() {
                                 QString::fromStdString(FS::GetUserPath(FS::UserPath::DumpDir)))
                         .toString()
                         .toStdString());
-    FS::GetUserPath(FS::UserPath::CacheDir,
-                    qt_config
-                        ->value(QStringLiteral("cache_directory"),
-                                QString::fromStdString(FS::GetUserPath(FS::UserPath::CacheDir)))
-                        .toString()
-                        .toStdString());
     Settings::values.gamecard_inserted =
         ReadSetting(QStringLiteral("gamecard_inserted"), false).toBool();
     Settings::values.gamecard_current_game =
@@ -1219,9 +1213,6 @@ void Config::SaveDataStorageValues() {
     WriteSetting(QStringLiteral("dump_directory"),
                  QString::fromStdString(FS::GetUserPath(FS::UserPath::DumpDir)),
                  QString::fromStdString(FS::GetUserPath(FS::UserPath::DumpDir)));
-    WriteSetting(QStringLiteral("cache_directory"),
-                 QString::fromStdString(FS::GetUserPath(FS::UserPath::CacheDir)),
-                 QString::fromStdString(FS::GetUserPath(FS::UserPath::CacheDir)));
     WriteSetting(QStringLiteral("gamecard_inserted"), Settings::values.gamecard_inserted, false);
     WriteSetting(QStringLiteral("gamecard_current_game"), Settings::values.gamecard_current_game,
                  false);

--- a/src/yuzu/configuration/configure_filesystem.cpp
+++ b/src/yuzu/configuration/configure_filesystem.cpp
@@ -26,8 +26,6 @@ ConfigureFilesystem::ConfigureFilesystem(QWidget* parent)
             [this] { SetDirectory(DirectoryTarget::Dump, ui->dump_path_edit); });
     connect(ui->load_path_button, &QToolButton::pressed, this,
             [this] { SetDirectory(DirectoryTarget::Load, ui->load_path_edit); });
-    connect(ui->cache_directory_button, &QToolButton::pressed, this,
-            [this] { SetDirectory(DirectoryTarget::Cache, ui->cache_directory_edit); });
 
     connect(ui->reset_game_list_cache, &QPushButton::pressed, this,
             &ConfigureFilesystem::ResetMetadata);
@@ -50,8 +48,6 @@ void ConfigureFilesystem::setConfiguration() {
         QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::DumpDir)));
     ui->load_path_edit->setText(
         QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::LoadDir)));
-    ui->cache_directory_edit->setText(
-        QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::CacheDir)));
 
     ui->gamecard_inserted->setChecked(Settings::values.gamecard_inserted);
     ui->gamecard_current_game->setChecked(Settings::values.gamecard_current_game);
@@ -72,9 +68,6 @@ void ConfigureFilesystem::applyConfiguration() {
                             ui->dump_path_edit->text().toStdString());
     Common::FS::GetUserPath(Common::FS::UserPath::LoadDir,
                             ui->load_path_edit->text().toStdString());
-    Common::FS::GetUserPath(Common::FS::UserPath::CacheDir,
-                            ui->cache_directory_edit->text().toStdString());
-    Settings::values.gamecard_path = ui->gamecard_path_edit->text().toStdString();
 
     Settings::values.gamecard_inserted = ui->gamecard_inserted->isChecked();
     Settings::values.gamecard_current_game = ui->gamecard_current_game->isChecked();
@@ -102,9 +95,6 @@ void ConfigureFilesystem::SetDirectory(DirectoryTarget target, QLineEdit* edit) 
         break;
     case DirectoryTarget::Load:
         caption = tr("Select Mod Load Directory...");
-        break;
-    case DirectoryTarget::Cache:
-        caption = tr("Select Cache Directory...");
         break;
     }
 

--- a/src/yuzu/configuration/configure_filesystem.h
+++ b/src/yuzu/configuration/configure_filesystem.h
@@ -32,7 +32,6 @@ private:
         Gamecard,
         Dump,
         Load,
-        Cache,
     };
 
     void SetDirectory(DirectoryTarget target, QLineEdit* edit);

--- a/src/yuzu/configuration/configure_filesystem.ui
+++ b/src/yuzu/configuration/configure_filesystem.ui
@@ -198,40 +198,7 @@
         <string>Caching</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_5">
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_10">
-          <property name="text">
-           <string>Cache Directory</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <spacer name="horizontalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Fixed</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="0" column="2">
-         <widget class="QLineEdit" name="cache_directory_edit"/>
-        </item>
-        <item row="0" column="3">
-         <widget class="QToolButton" name="cache_directory_button">
-          <property name="text">
-           <string>...</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="0" colspan="4">
+        <item row="0" column="0" colspan="2">
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
            <widget class="QCheckBox" name="cache_game_list">

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -333,9 +333,6 @@ void Config::ReadValues() {
     FS::GetUserPath(
         FS::UserPath::DumpDir,
         sdl2_config->Get("Data Storage", "dump_directory", FS::GetUserPath(FS::UserPath::DumpDir)));
-    FS::GetUserPath(FS::UserPath::CacheDir,
-                    sdl2_config->Get("Data Storage", "cache_directory",
-                                     FS::GetUserPath(FS::UserPath::CacheDir)));
     Settings::values.gamecard_inserted =
         sdl2_config->GetBoolean("Data Storage", "gamecard_inserted", false);
     Settings::values.gamecard_current_game =


### PR DESCRIPTION
This tab of the settings is already extremely bloated and the setting itself is quite useless.
With a gamelist of almost 30 games, the cache directory is smaller than 1MB for me and therefore I don't see why it needs to be configurable.