### PR TITLE
fs: Fix RomFS building when zero byte files are present

### DIFF
--- a/src/core/file_sys/fsmitm_romfsbuild.cpp
+++ b/src/core/file_sys/fsmitm_romfsbuild.cpp
@@ -240,7 +240,7 @@ RomFSBuildContext::RomFSBuildContext(VirtualDir base_, VirtualDir ext_)
 
 RomFSBuildContext::~RomFSBuildContext() = default;
 
-std::map<u64, VirtualFile> RomFSBuildContext::Build() {
+std::multimap<u64, VirtualFile> RomFSBuildContext::Build() {
     const u64 dir_hash_table_entry_count = romfs_get_hash_table_count(num_dirs);
     const u64 file_hash_table_entry_count = romfs_get_hash_table_count(num_files);
     dir_hash_table_size = 4 * dir_hash_table_entry_count;
@@ -294,7 +294,7 @@ std::map<u64, VirtualFile> RomFSBuildContext::Build() {
         cur_dir->parent->child = cur_dir;
     }
 
-    std::map<u64, VirtualFile> out;
+    std::multimap<u64, VirtualFile> out;
 
     // Populate file tables.
     for (const auto& it : files) {

--- a/src/core/file_sys/fsmitm_romfsbuild.h
+++ b/src/core/file_sys/fsmitm_romfsbuild.h
@@ -43,7 +43,7 @@ public:
     ~RomFSBuildContext();
 
     // This finalizes the context.
-    std::map<u64, VirtualFile> Build();
+    std::multimap<u64, VirtualFile> Build();
 
 private:
     VirtualDir base;

--- a/src/core/file_sys/vfs_concat.cpp
+++ b/src/core/file_sys/vfs_concat.cpp
@@ -11,7 +11,7 @@
 
 namespace FileSys {
 
-static bool VerifyConcatenationMapContinuity(const std::map<u64, VirtualFile>& map) {
+static bool VerifyConcatenationMapContinuity(const std::multimap<u64, VirtualFile>& map) {
     const auto last_valid = --map.end();
     for (auto iter = map.begin(); iter != last_valid;) {
         const auto old = iter++;
@@ -27,12 +27,12 @@ ConcatenatedVfsFile::ConcatenatedVfsFile(std::vector<VirtualFile> files_, std::s
     : name(std::move(name)) {
     std::size_t next_offset = 0;
     for (const auto& file : files_) {
-        files[next_offset] = file;
+        files.emplace(next_offset, file);
         next_offset += file->GetSize();
     }
 }
 
-ConcatenatedVfsFile::ConcatenatedVfsFile(std::map<u64, VirtualFile> files_, std::string name)
+ConcatenatedVfsFile::ConcatenatedVfsFile(std::multimap<u64, VirtualFile> files_, std::string name)
     : files(std::move(files_)), name(std::move(name)) {
     ASSERT(VerifyConcatenationMapContinuity(files));
 }
@@ -50,7 +50,7 @@ VirtualFile ConcatenatedVfsFile::MakeConcatenatedFile(std::vector<VirtualFile> f
 }
 
 VirtualFile ConcatenatedVfsFile::MakeConcatenatedFile(u8 filler_byte,
-                                                      std::map<u64, VirtualFile> files,
+                                                      std::multimap<u64, VirtualFile> files,
                                                       std::string name) {
     if (files.empty())
         return nullptr;

--- a/src/core/file_sys/vfs_concat.h
+++ b/src/core/file_sys/vfs_concat.h
@@ -15,7 +15,7 @@ namespace FileSys {
 // read-only.
 class ConcatenatedVfsFile : public VfsFile {
     ConcatenatedVfsFile(std::vector<VirtualFile> files, std::string name);
-    ConcatenatedVfsFile(std::map<u64, VirtualFile> files, std::string name);
+    ConcatenatedVfsFile(std::multimap<u64, VirtualFile> files, std::string name);
 
 public:
     ~ConcatenatedVfsFile() override;
@@ -25,7 +25,7 @@ public:
 
     /// Convenience function that turns a map of offsets to files into a concatenated file, filling
     /// gaps with a given filler byte.
-    static VirtualFile MakeConcatenatedFile(u8 filler_byte, std::map<u64, VirtualFile> files,
+    static VirtualFile MakeConcatenatedFile(u8 filler_byte, std::multimap<u64, VirtualFile> files,
                                             std::string name);
 
     std::string GetName() const override;
@@ -40,7 +40,7 @@ public:
 
 private:
     // Maps starting offset to file -- more efficient.
-    std::map<u64, VirtualFile> files;
+    std::multimap<u64, VirtualFile> files;
     std::string name;
 };
 


### PR DESCRIPTION
When zero byte files are present, the key (offset) for that file is identical to the file right after. A `std::map` isn't able to fit key-value pairs with identical keys (offsets). Therefore, the solution is to use `std::multimap` which permits multiple entries with the same key.

This most prominently fixes Pokemon Sword and Shield weather with any RomFS mod applied.

![image](https://user-images.githubusercontent.com/39850852/87242218-9ce85900-c3f8-11ea-8f7b-708a4460797f.png)

![image](https://user-images.githubusercontent.com/39850852/87242222-a5409400-c3f8-11ea-99fb-bdc94dd2db45.png)

![image](https://user-images.githubusercontent.com/39850852/87242225-ad98cf00-c3f8-11ea-8c15-6f5f20074b1a.png)

![image](https://user-images.githubusercontent.com/39850852/87242228-b5587380-c3f8-11ea-8326-49aa01224d2c.png)
