### PR TITLE
gcadapter: Tidy up compiler warnings

### DIFF
--- a/src/input_common/gcadapter/gc_adapter.cpp
+++ b/src/input_common/gcadapter/gc_adapter.cpp
@@ -33,7 +33,7 @@ Adapter::Adapter() {
     }
 }
 
-GCPadStatus Adapter::GetPadStatus(int port, const std::array<u8, 37>& adapter_payload) {
+GCPadStatus Adapter::GetPadStatus(std::size_t port, const std::array<u8, 37>& adapter_payload) {
     GCPadStatus pad = {};
     bool get_origin = false;
 
@@ -227,7 +227,7 @@ void Adapter::Setup() {
     }
 
     if (devices != nullptr) {
-        for (std::size_t index = 0; index < device_count; ++index) {
+        for (std::size_t index = 0; index < static_cast<std::size_t>(device_count); ++index) {
             if (CheckDeviceAccess(devices[index])) {
                 // GC Adapter found and accessible, registering it
                 GetGCEndpoint(devices[index]);
@@ -357,11 +357,11 @@ void Adapter::Reset() {
     }
 }
 
-bool Adapter::DeviceConnected(int port) {
+bool Adapter::DeviceConnected(std::size_t port) {
     return adapter_controllers_status[port] != ControllerTypes::None;
 }
 
-void Adapter::ResetDeviceType(int port) {
+void Adapter::ResetDeviceType(std::size_t port) {
     adapter_controllers_status[port] = ControllerTypes::None;
 }
 

--- a/src/input_common/gcadapter/gc_adapter.cpp
+++ b/src/input_common/gcadapter/gc_adapter.cpp
@@ -198,7 +198,7 @@ void Adapter::StartScanThread() {
     }
 
     detect_thread_running = true;
-    detect_thread = std::thread([=] { ScanThreadFunc(); });
+    detect_thread = std::thread(&Adapter::ScanThreadFunc, this);
 }
 
 void Adapter::StopScanThread() {

--- a/src/input_common/gcadapter/gc_adapter.h
+++ b/src/input_common/gcadapter/gc_adapter.h
@@ -104,7 +104,7 @@ public:
     const std::array<GCState, 4>& GetPadState() const;
 
 private:
-    GCPadStatus GetPadStatus(int port, const std::array<u8, 37>& adapter_payload);
+    GCPadStatus GetPadStatus(std::size_t port, const std::array<u8, 37>& adapter_payload);
 
     void PadToState(const GCPadStatus& pad, GCState& state);
 
@@ -117,10 +117,10 @@ private:
     void StopScanThread();
 
     /// Returns true if there is a device connected to port
-    bool DeviceConnected(int port);
+    bool DeviceConnected(std::size_t port);
 
     /// Resets status of device connected to port
-    void ResetDeviceType(int port);
+    void ResetDeviceType(std::size_t port);
 
     /// Returns true if we successfully gain access to GC Adapter
     bool CheckDeviceAccess(libusb_device* device);

--- a/src/input_common/gcadapter/gc_poller.cpp
+++ b/src/input_common/gcadapter/gc_poller.cpp
@@ -249,7 +249,7 @@ Common::ParamPackage GCAnalogFactory::GetNextInput() {
             const u8 axis = static_cast<u8>(pad.axis);
             if (analog_x_axis == -1) {
                 analog_x_axis = axis;
-                controller_number = port;
+                controller_number = static_cast<int>(port);
             } else if (analog_y_axis == -1 && analog_x_axis != axis && controller_number == port) {
                 analog_y_axis = axis;
             }

--- a/src/input_common/gcadapter/gc_poller.cpp
+++ b/src/input_common/gcadapter/gc_poller.cpp
@@ -6,6 +6,7 @@
 #include <list>
 #include <mutex>
 #include <utility>
+#include "common/assert.h"
 #include "common/threadsafe_queue.h"
 #include "input_common/gcadapter/gc_adapter.h"
 #include "input_common/gcadapter/gc_poller.h"
@@ -94,6 +95,9 @@ std::unique_ptr<Input::ButtonDevice> GCButtonFactory::Create(const Common::Param
         return std::make_unique<GCAxisButton>(port, axis, threshold, trigger_if_greater,
                                               adapter.get());
     }
+
+    UNREACHABLE();
+    return nullptr;
 }
 
 Common::ParamPackage GCButtonFactory::GetNextInput() {

--- a/src/input_common/gcadapter/gc_poller.cpp
+++ b/src/input_common/gcadapter/gc_poller.cpp
@@ -100,7 +100,7 @@ std::unique_ptr<Input::ButtonDevice> GCButtonFactory::Create(const Common::Param
     return nullptr;
 }
 
-Common::ParamPackage GCButtonFactory::GetNextInput() {
+Common::ParamPackage GCButtonFactory::GetNextInput() const {
     Common::ParamPackage params;
     GCAdapter::GCPadStatus pad;
     auto& queue = adapter->GetPadQueue();

--- a/src/input_common/gcadapter/gc_poller.h
+++ b/src/input_common/gcadapter/gc_poller.h
@@ -25,7 +25,7 @@ public:
      */
     std::unique_ptr<Input::ButtonDevice> Create(const Common::ParamPackage& params) override;
 
-    Common::ParamPackage GetNextInput();
+    Common::ParamPackage GetNextInput() const;
 
     /// For device input configuration/polling
     void BeginConfiguration();


### PR DESCRIPTION
Tidies up some compiler warnings and also removes some deprecated usages of lambda captures in C++20.