### PR TITLE
CMakeLists: Disable concepts in boost asio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,8 @@ if (MSVC)
 
     # cubeb and boost still make use of deprecated result_of.
     add_definitions(-D_HAS_DEPRECATED_RESULT_OF)
+    # boost asio's concept usage doesn't play nicely with MSVC yet.
+    add_definitions(-DASIO_DISABLE_CONCEPTS)
 else()
     set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)


### PR DESCRIPTION
Testing to see if this resolves the recent issues with yuzu's early access pipeline