### PR TITLE
vk_blit_screen: Make use of designated initializers where applicable

### DIFF
--- a/src/video_core/renderer_vulkan/vk_blit_screen.cpp
+++ b/src/video_core/renderer_vulkan/vk_blit_screen.cpp
@@ -141,24 +141,28 @@ struct ScreenRectVertex {
     std::array<f32, 2> tex_coord;
 
     static VkVertexInputBindingDescription GetDescription() {
-        VkVertexInputBindingDescription description;
-        description.binding = 0;
-        description.stride = sizeof(ScreenRectVertex);
-        description.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
-        return description;
+        return {
+            .binding = 0,
+            .stride = sizeof(ScreenRectVertex),
+            .inputRate = VK_VERTEX_INPUT_RATE_VERTEX,
+        };
     }
 
     static std::array<VkVertexInputAttributeDescription, 2> GetAttributes() {
-        std::array<VkVertexInputAttributeDescription, 2> attributes;
-        attributes[0].location = 0;
-        attributes[0].binding = 0;
-        attributes[0].format = VK_FORMAT_R32G32_SFLOAT;
-        attributes[0].offset = offsetof(ScreenRectVertex, position);
-        attributes[1].location = 1;
-        attributes[1].binding = 0;
-        attributes[1].format = VK_FORMAT_R32G32_SFLOAT;
-        attributes[1].offset = offsetof(ScreenRectVertex, tex_coord);
-        return attributes;
+        return {{
+            {
+                .location = 0,
+                .binding = 0,
+                .format = VK_FORMAT_R32G32_SFLOAT,
+                .offset = offsetof(ScreenRectVertex, position),
+            },
+            {
+                .location = 1,
+                .binding = 0,
+                .format = VK_FORMAT_R32G32_SFLOAT,
+                .offset = offsetof(ScreenRectVertex, tex_coord),
+            },
+        }};
     }
 };
 
@@ -267,20 +271,25 @@ std::tuple<VKFence&, VkSemaphore> VKBlitScreen::Draw(const Tegra::FramebufferCon
         blit_image->Transition(0, 1, 0, 1, VK_PIPELINE_STAGE_TRANSFER_BIT,
                                VK_ACCESS_TRANSFER_WRITE_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
-        VkBufferImageCopy copy;
-        copy.bufferOffset = image_offset;
-        copy.bufferRowLength = 0;
-        copy.bufferImageHeight = 0;
-        copy.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-        copy.imageSubresource.mipLevel = 0;
-        copy.imageSubresource.baseArrayLayer = 0;
-        copy.imageSubresource.layerCount = 1;
-        copy.imageOffset.x = 0;
-        copy.imageOffset.y = 0;
-        copy.imageOffset.z = 0;
-        copy.imageExtent.width = framebuffer.width;
-        copy.imageExtent.height = framebuffer.height;
-        copy.imageExtent.depth = 1;
+        const VkBufferImageCopy copy{
+            .bufferOffset = image_offset,
+            .bufferRowLength = 0,
+            .bufferImageHeight = 0,
+            .imageSubresource =
+                {
+                    .aspectMask = VK_IMAGE_ASPECT_COLOR_BIT,
+                    .mipLevel = 0,
+                    .baseArrayLayer = 0,
+                    .layerCount = 1,
+                },
+            .imageOffset = {.x = 0, .y = 0, .z = 0},
+            .imageExtent =
+                {
+                    .width = framebuffer.width,
+                    .height = framebuffer.height,
+                    .depth = 1,
+                },
+        };
         scheduler.Record(
             [buffer = *buffer, image = *blit_image->GetHandle(), copy](vk::CommandBuffer cmdbuf) {
                 cmdbuf.CopyBufferToImage(buffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, copy);
@@ -295,11 +304,9 @@ std::tuple<VKFence&, VkSemaphore> VKBlitScreen::Draw(const Tegra::FramebufferCon
                       descriptor_set = descriptor_sets[image_index], buffer = *buffer,
                       size = swapchain.GetSize(), pipeline = *pipeline,
                       layout = *pipeline_layout](vk::CommandBuffer cmdbuf) {
-        VkClearValue clear_color;
-        clear_color.color.float32[0] = 0.0f;
-        clear_color.color.float32[1] = 0.0f;
-        clear_color.color.float32[2] = 0.0f;
-        clear_color.color.float32[3] = 0.0f;
+        const VkClearValue clear_color{
+            .color = {.float32 = {0.0f, 0.0f, 0.0f, 0.0f}},
+        };
 
         VkRenderPassBeginInfo renderpass_bi;
         renderpass_bi.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
@@ -379,93 +386,109 @@ void VKBlitScreen::CreateSemaphores() {
 }
 
 void VKBlitScreen::CreateDescriptorPool() {
-    std::array<VkDescriptorPoolSize, 2> pool_sizes;
-    pool_sizes[0].type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    pool_sizes[0].descriptorCount = static_cast<u32>(image_count);
-    pool_sizes[1].type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    pool_sizes[1].descriptorCount = static_cast<u32>(image_count);
+    const std::array<VkDescriptorPoolSize, 2> pool_sizes{{
+        {
+            .type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+            .descriptorCount = static_cast<u32>(image_count),
+        },
+        {
+            .type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+            .descriptorCount = static_cast<u32>(image_count),
+        },
+    }};
 
-    VkDescriptorPoolCreateInfo ci;
-    ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
-    ci.pNext = nullptr;
-    ci.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
-    ci.maxSets = static_cast<u32>(image_count);
-    ci.poolSizeCount = static_cast<u32>(pool_sizes.size());
-    ci.pPoolSizes = pool_sizes.data();
+    const VkDescriptorPoolCreateInfo ci{
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT,
+        .maxSets = static_cast<u32>(image_count),
+        .poolSizeCount = static_cast<u32>(pool_sizes.size()),
+        .pPoolSizes = pool_sizes.data(),
+    };
     descriptor_pool = device.GetLogical().CreateDescriptorPool(ci);
 }
 
 void VKBlitScreen::CreateRenderPass() {
-    VkAttachmentDescription color_attachment;
-    color_attachment.flags = 0;
-    color_attachment.format = swapchain.GetImageFormat();
-    color_attachment.samples = VK_SAMPLE_COUNT_1_BIT;
-    color_attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-    color_attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-    color_attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    color_attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-    color_attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    color_attachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+    const VkAttachmentDescription color_attachment{
+        .flags = 0,
+        .format = swapchain.GetImageFormat(),
+        .samples = VK_SAMPLE_COUNT_1_BIT,
+        .loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR,
+        .storeOp = VK_ATTACHMENT_STORE_OP_STORE,
+        .stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+        .stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+        .finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR,
+    };
 
-    VkAttachmentReference color_attachment_ref;
-    color_attachment_ref.attachment = 0;
-    color_attachment_ref.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    const VkAttachmentReference color_attachment_ref{
+        .attachment = 0,
+        .layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
+    };
 
-    VkSubpassDescription subpass_description;
-    subpass_description.flags = 0;
-    subpass_description.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-    subpass_description.inputAttachmentCount = 0;
-    subpass_description.pInputAttachments = nullptr;
-    subpass_description.colorAttachmentCount = 1;
-    subpass_description.pColorAttachments = &color_attachment_ref;
-    subpass_description.pResolveAttachments = nullptr;
-    subpass_description.pDepthStencilAttachment = nullptr;
-    subpass_description.preserveAttachmentCount = 0;
-    subpass_description.pPreserveAttachments = nullptr;
+    const VkSubpassDescription subpass_description{
+        .flags = 0,
+        .pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS,
+        .inputAttachmentCount = 0,
+        .pInputAttachments = nullptr,
+        .colorAttachmentCount = 1,
+        .pColorAttachments = &color_attachment_ref,
+        .pResolveAttachments = nullptr,
+        .pDepthStencilAttachment = nullptr,
+        .preserveAttachmentCount = 0,
+        .pPreserveAttachments = nullptr,
+    };
 
-    VkSubpassDependency dependency;
-    dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
-    dependency.dstSubpass = 0;
-    dependency.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependency.dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependency.srcAccessMask = 0;
-    dependency.dstAccessMask =
-        VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
-    dependency.dependencyFlags = 0;
+    const VkSubpassDependency dependency{
+        .srcSubpass = VK_SUBPASS_EXTERNAL,
+        .dstSubpass = 0,
+        .srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+        .dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+        .srcAccessMask = 0,
+        .dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+        .dependencyFlags = 0,
+    };
 
-    VkRenderPassCreateInfo renderpass_ci;
-    renderpass_ci.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO;
-    renderpass_ci.pNext = nullptr;
-    renderpass_ci.flags = 0;
-    renderpass_ci.attachmentCount = 1;
-    renderpass_ci.pAttachments = &color_attachment;
-    renderpass_ci.subpassCount = 1;
-    renderpass_ci.pSubpasses = &subpass_description;
-    renderpass_ci.dependencyCount = 1;
-    renderpass_ci.pDependencies = &dependency;
+    const VkRenderPassCreateInfo renderpass_ci{
+        .sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .attachmentCount = 1,
+        .pAttachments = &color_attachment,
+        .subpassCount = 1,
+        .pSubpasses = &subpass_description,
+        .dependencyCount = 1,
+        .pDependencies = &dependency,
+    };
 
     renderpass = device.GetLogical().CreateRenderPass(renderpass_ci);
 }
 
 void VKBlitScreen::CreateDescriptorSetLayout() {
-    std::array<VkDescriptorSetLayoutBinding, 2> layout_bindings;
-    layout_bindings[0].binding = 0;
-    layout_bindings[0].descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    layout_bindings[0].descriptorCount = 1;
-    layout_bindings[0].stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
-    layout_bindings[0].pImmutableSamplers = nullptr;
-    layout_bindings[1].binding = 1;
-    layout_bindings[1].descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    layout_bindings[1].descriptorCount = 1;
-    layout_bindings[1].stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
-    layout_bindings[1].pImmutableSamplers = nullptr;
+    const std::array<VkDescriptorSetLayoutBinding, 2> layout_bindings{{
+        {
+            .binding = 0,
+            .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+            .descriptorCount = 1,
+            .stageFlags = VK_SHADER_STAGE_VERTEX_BIT,
+            .pImmutableSamplers = nullptr,
+        },
+        {
+            .binding = 1,
+            .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+            .descriptorCount = 1,
+            .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT,
+            .pImmutableSamplers = nullptr,
+        },
+    }};
 
-    VkDescriptorSetLayoutCreateInfo ci;
-    ci.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
-    ci.pNext = nullptr;
-    ci.flags = 0;
-    ci.bindingCount = static_cast<u32>(layout_bindings.size());
-    ci.pBindings = layout_bindings.data();
+    const VkDescriptorSetLayoutCreateInfo ci{
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .bindingCount = static_cast<u32>(layout_bindings.size()),
+        .pBindings = layout_bindings.data(),
+    };
 
     descriptor_set_layout = device.GetLogical().CreateDescriptorSetLayout(ci);
 }
@@ -473,175 +496,192 @@ void VKBlitScreen::CreateDescriptorSetLayout() {
 void VKBlitScreen::CreateDescriptorSets() {
     const std::vector layouts(image_count, *descriptor_set_layout);
 
-    VkDescriptorSetAllocateInfo ai;
-    ai.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-    ai.pNext = nullptr;
-    ai.descriptorPool = *descriptor_pool;
-    ai.descriptorSetCount = static_cast<u32>(image_count);
-    ai.pSetLayouts = layouts.data();
+    const VkDescriptorSetAllocateInfo ai{
+        .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO,
+        .pNext = nullptr,
+        .descriptorPool = *descriptor_pool,
+        .descriptorSetCount = static_cast<u32>(image_count),
+        .pSetLayouts = layouts.data(),
+    };
+
     descriptor_sets = descriptor_pool.Allocate(ai);
 }
 
 void VKBlitScreen::CreatePipelineLayout() {
-    VkPipelineLayoutCreateInfo ci;
-    ci.sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO;
-    ci.pNext = nullptr;
-    ci.flags = 0;
-    ci.setLayoutCount = 1;
-    ci.pSetLayouts = descriptor_set_layout.address();
-    ci.pushConstantRangeCount = 0;
-    ci.pPushConstantRanges = nullptr;
+    const VkPipelineLayoutCreateInfo ci{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .setLayoutCount = 1,
+        .pSetLayouts = descriptor_set_layout.address(),
+        .pushConstantRangeCount = 0,
+        .pPushConstantRanges = nullptr,
+    };
     pipeline_layout = device.GetLogical().CreatePipelineLayout(ci);
 }
 
 void VKBlitScreen::CreateGraphicsPipeline() {
-    std::array<VkPipelineShaderStageCreateInfo, 2> shader_stages;
-    shader_stages[0].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    shader_stages[0].pNext = nullptr;
-    shader_stages[0].flags = 0;
-    shader_stages[0].stage = VK_SHADER_STAGE_VERTEX_BIT;
-    shader_stages[0].module = *vertex_shader;
-    shader_stages[0].pName = "main";
-    shader_stages[0].pSpecializationInfo = nullptr;
-    shader_stages[1].sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO;
-    shader_stages[1].pNext = nullptr;
-    shader_stages[1].flags = 0;
-    shader_stages[1].stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    shader_stages[1].module = *fragment_shader;
-    shader_stages[1].pName = "main";
-    shader_stages[1].pSpecializationInfo = nullptr;
+    const std::array<VkPipelineShaderStageCreateInfo, 2> shader_stages{{
+        {
+            .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+            .pNext = nullptr,
+            .flags = 0,
+            .stage = VK_SHADER_STAGE_VERTEX_BIT,
+            .module = *vertex_shader,
+            .pName = "main",
+            .pSpecializationInfo = nullptr,
+        },
+        {
+            .sType = VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
+            .pNext = nullptr,
+            .flags = 0,
+            .stage = VK_SHADER_STAGE_FRAGMENT_BIT,
+            .module = *fragment_shader,
+            .pName = "main",
+            .pSpecializationInfo = nullptr,
+        },
+    }};
 
     const auto vertex_binding_description = ScreenRectVertex::GetDescription();
     const auto vertex_attrs_description = ScreenRectVertex::GetAttributes();
 
-    VkPipelineVertexInputStateCreateInfo vertex_input_ci;
-    vertex_input_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
-    vertex_input_ci.pNext = nullptr;
-    vertex_input_ci.flags = 0;
-    vertex_input_ci.vertexBindingDescriptionCount = 1;
-    vertex_input_ci.pVertexBindingDescriptions = &vertex_binding_description;
-    vertex_input_ci.vertexAttributeDescriptionCount = u32{vertex_attrs_description.size()};
-    vertex_input_ci.pVertexAttributeDescriptions = vertex_attrs_description.data();
+    const VkPipelineVertexInputStateCreateInfo vertex_input_ci{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .vertexBindingDescriptionCount = 1,
+        .pVertexBindingDescriptions = &vertex_binding_description,
+        .vertexAttributeDescriptionCount = u32{vertex_attrs_description.size()},
+        .pVertexAttributeDescriptions = vertex_attrs_description.data(),
+    };
 
-    VkPipelineInputAssemblyStateCreateInfo input_assembly_ci;
-    input_assembly_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO;
-    input_assembly_ci.pNext = nullptr;
-    input_assembly_ci.flags = 0;
-    input_assembly_ci.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
-    input_assembly_ci.primitiveRestartEnable = VK_FALSE;
+    const VkPipelineInputAssemblyStateCreateInfo input_assembly_ci{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP,
+        .primitiveRestartEnable = VK_FALSE,
+    };
 
-    VkPipelineViewportStateCreateInfo viewport_state_ci;
-    viewport_state_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO;
-    viewport_state_ci.pNext = nullptr;
-    viewport_state_ci.flags = 0;
-    viewport_state_ci.viewportCount = 1;
-    viewport_state_ci.pViewports = nullptr;
-    viewport_state_ci.scissorCount = 1;
-    viewport_state_ci.pScissors = nullptr;
+    const VkPipelineViewportStateCreateInfo viewport_state_ci{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .viewportCount = 1,
+        .pViewports = nullptr,
+        .scissorCount = 1,
+        .pScissors = nullptr,
+    };
 
-    VkPipelineRasterizationStateCreateInfo rasterization_ci;
-    rasterization_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO;
-    rasterization_ci.pNext = nullptr;
-    rasterization_ci.flags = 0;
-    rasterization_ci.depthClampEnable = VK_FALSE;
-    rasterization_ci.rasterizerDiscardEnable = VK_FALSE;
-    rasterization_ci.polygonMode = VK_POLYGON_MODE_FILL;
-    rasterization_ci.cullMode = VK_CULL_MODE_NONE;
-    rasterization_ci.frontFace = VK_FRONT_FACE_CLOCKWISE;
-    rasterization_ci.depthBiasEnable = VK_FALSE;
-    rasterization_ci.depthBiasConstantFactor = 0.0f;
-    rasterization_ci.depthBiasClamp = 0.0f;
-    rasterization_ci.depthBiasSlopeFactor = 0.0f;
-    rasterization_ci.lineWidth = 1.0f;
+    const VkPipelineRasterizationStateCreateInfo rasterization_ci{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .depthClampEnable = VK_FALSE,
+        .rasterizerDiscardEnable = VK_FALSE,
+        .polygonMode = VK_POLYGON_MODE_FILL,
+        .cullMode = VK_CULL_MODE_NONE,
+        .frontFace = VK_FRONT_FACE_CLOCKWISE,
+        .depthBiasEnable = VK_FALSE,
+        .depthBiasConstantFactor = 0.0f,
+        .depthBiasClamp = 0.0f,
+        .depthBiasSlopeFactor = 0.0f,
+        .lineWidth = 1.0f,
+    };
 
-    VkPipelineMultisampleStateCreateInfo multisampling_ci;
-    multisampling_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO;
-    multisampling_ci.pNext = nullptr;
-    multisampling_ci.flags = 0;
-    multisampling_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
-    multisampling_ci.sampleShadingEnable = VK_FALSE;
-    multisampling_ci.minSampleShading = 0.0f;
-    multisampling_ci.pSampleMask = nullptr;
-    multisampling_ci.alphaToCoverageEnable = VK_FALSE;
-    multisampling_ci.alphaToOneEnable = VK_FALSE;
+    const VkPipelineMultisampleStateCreateInfo multisampling_ci{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .rasterizationSamples = VK_SAMPLE_COUNT_1_BIT,
+        .sampleShadingEnable = VK_FALSE,
+        .minSampleShading = 0.0f,
+        .pSampleMask = nullptr,
+        .alphaToCoverageEnable = VK_FALSE,
+        .alphaToOneEnable = VK_FALSE,
+    };
 
-    VkPipelineColorBlendAttachmentState color_blend_attachment;
-    color_blend_attachment.blendEnable = VK_FALSE;
-    color_blend_attachment.srcColorBlendFactor = VK_BLEND_FACTOR_ZERO;
-    color_blend_attachment.dstColorBlendFactor = VK_BLEND_FACTOR_ZERO;
-    color_blend_attachment.colorBlendOp = VK_BLEND_OP_ADD;
-    color_blend_attachment.srcAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
-    color_blend_attachment.dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO;
-    color_blend_attachment.alphaBlendOp = VK_BLEND_OP_ADD;
-    color_blend_attachment.colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
-                                            VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
+    const VkPipelineColorBlendAttachmentState color_blend_attachment{
+        .blendEnable = VK_FALSE,
+        .srcColorBlendFactor = VK_BLEND_FACTOR_ZERO,
+        .dstColorBlendFactor = VK_BLEND_FACTOR_ZERO,
+        .colorBlendOp = VK_BLEND_OP_ADD,
+        .srcAlphaBlendFactor = VK_BLEND_FACTOR_ZERO,
+        .dstAlphaBlendFactor = VK_BLEND_FACTOR_ZERO,
+        .alphaBlendOp = VK_BLEND_OP_ADD,
+        .colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
+                          VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT,
+    };
 
-    VkPipelineColorBlendStateCreateInfo color_blend_ci;
-    color_blend_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO;
-    color_blend_ci.flags = 0;
-    color_blend_ci.pNext = nullptr;
-    color_blend_ci.logicOpEnable = VK_FALSE;
-    color_blend_ci.logicOp = VK_LOGIC_OP_COPY;
-    color_blend_ci.attachmentCount = 1;
-    color_blend_ci.pAttachments = &color_blend_attachment;
-    color_blend_ci.blendConstants[0] = 0.0f;
-    color_blend_ci.blendConstants[1] = 0.0f;
-    color_blend_ci.blendConstants[2] = 0.0f;
-    color_blend_ci.blendConstants[3] = 0.0f;
+    const VkPipelineColorBlendStateCreateInfo color_blend_ci{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .logicOpEnable = VK_FALSE,
+        .logicOp = VK_LOGIC_OP_COPY,
+        .attachmentCount = 1,
+        .pAttachments = &color_blend_attachment,
+        .blendConstants = {0.0f, 0.0f, 0.0f, 0.0f},
+    };
 
-    static constexpr std::array dynamic_states = {VK_DYNAMIC_STATE_VIEWPORT,
-                                                  VK_DYNAMIC_STATE_SCISSOR};
-    VkPipelineDynamicStateCreateInfo dynamic_state_ci;
-    dynamic_state_ci.sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO;
-    dynamic_state_ci.pNext = nullptr;
-    dynamic_state_ci.flags = 0;
-    dynamic_state_ci.dynamicStateCount = static_cast<u32>(dynamic_states.size());
-    dynamic_state_ci.pDynamicStates = dynamic_states.data();
+    static constexpr std::array dynamic_states{
+        VK_DYNAMIC_STATE_VIEWPORT,
+        VK_DYNAMIC_STATE_SCISSOR,
+    };
+    const VkPipelineDynamicStateCreateInfo dynamic_state_ci{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .dynamicStateCount = static_cast<u32>(dynamic_states.size()),
+        .pDynamicStates = dynamic_states.data(),
+    };
 
-    VkGraphicsPipelineCreateInfo pipeline_ci;
-    pipeline_ci.sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO;
-    pipeline_ci.pNext = nullptr;
-    pipeline_ci.flags = 0;
-    pipeline_ci.stageCount = static_cast<u32>(shader_stages.size());
-    pipeline_ci.pStages = shader_stages.data();
-    pipeline_ci.pVertexInputState = &vertex_input_ci;
-    pipeline_ci.pInputAssemblyState = &input_assembly_ci;
-    pipeline_ci.pTessellationState = nullptr;
-    pipeline_ci.pViewportState = &viewport_state_ci;
-    pipeline_ci.pRasterizationState = &rasterization_ci;
-    pipeline_ci.pMultisampleState = &multisampling_ci;
-    pipeline_ci.pDepthStencilState = nullptr;
-    pipeline_ci.pColorBlendState = &color_blend_ci;
-    pipeline_ci.pDynamicState = &dynamic_state_ci;
-    pipeline_ci.layout = *pipeline_layout;
-    pipeline_ci.renderPass = *renderpass;
-    pipeline_ci.subpass = 0;
-    pipeline_ci.basePipelineHandle = 0;
-    pipeline_ci.basePipelineIndex = 0;
+    const VkGraphicsPipelineCreateInfo pipeline_ci{
+        .sType = VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .stageCount = static_cast<u32>(shader_stages.size()),
+        .pStages = shader_stages.data(),
+        .pVertexInputState = &vertex_input_ci,
+        .pInputAssemblyState = &input_assembly_ci,
+        .pTessellationState = nullptr,
+        .pViewportState = &viewport_state_ci,
+        .pRasterizationState = &rasterization_ci,
+        .pMultisampleState = &multisampling_ci,
+        .pDepthStencilState = nullptr,
+        .pColorBlendState = &color_blend_ci,
+        .pDynamicState = &dynamic_state_ci,
+        .layout = *pipeline_layout,
+        .renderPass = *renderpass,
+        .subpass = 0,
+        .basePipelineHandle = 0,
+        .basePipelineIndex = 0,
+    };
 
     pipeline = device.GetLogical().CreateGraphicsPipeline(pipeline_ci);
 }
 
 void VKBlitScreen::CreateSampler() {
-    VkSamplerCreateInfo ci;
-    ci.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    ci.pNext = nullptr;
-    ci.flags = 0;
-    ci.magFilter = VK_FILTER_LINEAR;
-    ci.minFilter = VK_FILTER_NEAREST;
-    ci.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-    ci.addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
-    ci.addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
-    ci.addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
-    ci.mipLodBias = 0.0f;
-    ci.anisotropyEnable = VK_FALSE;
-    ci.maxAnisotropy = 0.0f;
-    ci.compareEnable = VK_FALSE;
-    ci.compareOp = VK_COMPARE_OP_NEVER;
-    ci.minLod = 0.0f;
-    ci.maxLod = 0.0f;
-    ci.borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK;
-    ci.unnormalizedCoordinates = VK_FALSE;
+    const VkSamplerCreateInfo ci{
+        .sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .magFilter = VK_FILTER_LINEAR,
+        .minFilter = VK_FILTER_NEAREST,
+        .mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR,
+        .addressModeU = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
+        .addressModeV = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
+        .addressModeW = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER,
+        .mipLodBias = 0.0f,
+        .anisotropyEnable = VK_FALSE,
+        .maxAnisotropy = 0.0f,
+        .compareEnable = VK_FALSE,
+        .compareOp = VK_COMPARE_OP_NEVER,
+        .minLod = 0.0f,
+        .maxLod = 0.0f,
+        .borderColor = VK_BORDER_COLOR_FLOAT_OPAQUE_BLACK,
+        .unnormalizedCoordinates = VK_FALSE,
+    };
 
     sampler = device.GetLogical().CreateSampler(ci);
 }
@@ -650,15 +690,16 @@ void VKBlitScreen::CreateFramebuffers() {
     const VkExtent2D size{swapchain.GetSize()};
     framebuffers.resize(image_count);
 
-    VkFramebufferCreateInfo ci;
-    ci.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-    ci.pNext = nullptr;
-    ci.flags = 0;
-    ci.renderPass = *renderpass;
-    ci.attachmentCount = 1;
-    ci.width = size.width;
-    ci.height = size.height;
-    ci.layers = 1;
+    VkFramebufferCreateInfo ci{
+        .sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .renderPass = *renderpass,
+        .attachmentCount = 1,
+        .width = size.width,
+        .height = size.height,
+        .layers = 1,
+    };
 
     for (std::size_t i = 0; i < image_count; ++i) {
         const VkImageView image_view{swapchain.GetImageViewIndex(i)};
@@ -678,16 +719,17 @@ void VKBlitScreen::ReleaseRawImages() {
 }
 
 void VKBlitScreen::CreateStagingBuffer(const Tegra::FramebufferConfig& framebuffer) {
-    VkBufferCreateInfo ci;
-    ci.sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO;
-    ci.pNext = nullptr;
-    ci.flags = 0;
-    ci.size = CalculateBufferSize(framebuffer);
-    ci.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT |
-               VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    ci.queueFamilyIndexCount = 0;
-    ci.pQueueFamilyIndices = nullptr;
+    const VkBufferCreateInfo ci{
+        .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .size = CalculateBufferSize(framebuffer),
+        .usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT |
+                 VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+    };
 
     buffer = device.GetLogical().CreateBuffer(ci);
     buffer_commit = memory_manager.Commit(buffer, true);
@@ -697,24 +739,28 @@ void VKBlitScreen::CreateRawImages(const Tegra::FramebufferConfig& framebuffer) 
     raw_images.resize(image_count);
     raw_buffer_commits.resize(image_count);
 
-    VkImageCreateInfo ci;
-    ci.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-    ci.pNext = nullptr;
-    ci.flags = 0;
-    ci.imageType = VK_IMAGE_TYPE_2D;
-    ci.format = GetFormat(framebuffer);
-    ci.extent.width = framebuffer.width;
-    ci.extent.height = framebuffer.height;
-    ci.extent.depth = 1;
-    ci.mipLevels = 1;
-    ci.arrayLayers = 1;
-    ci.samples = VK_SAMPLE_COUNT_1_BIT;
-    ci.tiling = VK_IMAGE_TILING_LINEAR;
-    ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
-    ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    ci.queueFamilyIndexCount = 0;
-    ci.pQueueFamilyIndices = nullptr;
-    ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+    const VkImageCreateInfo ci{
+        .sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
+        .pNext = nullptr,
+        .flags = 0,
+        .imageType = VK_IMAGE_TYPE_2D,
+        .format = GetFormat(framebuffer),
+        .extent =
+            {
+                .width = framebuffer.width,
+                .height = framebuffer.height,
+                .depth = 1,
+            },
+        .mipLevels = 1,
+        .arrayLayers = 1,
+        .samples = VK_SAMPLE_COUNT_1_BIT,
+        .tiling = VK_IMAGE_TILING_LINEAR,
+        .usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
+        .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+        .queueFamilyIndexCount = 0,
+        .pQueueFamilyIndices = nullptr,
+        .initialLayout = VK_IMAGE_LAYOUT_UNDEFINED,
+    };
 
     for (std::size_t i = 0; i < image_count; ++i) {
         raw_images[i] = std::make_unique<VKImage>(device, scheduler, ci, VK_IMAGE_ASPECT_COLOR_BIT);
@@ -723,39 +769,43 @@ void VKBlitScreen::CreateRawImages(const Tegra::FramebufferConfig& framebuffer) 
 }
 
 void VKBlitScreen::UpdateDescriptorSet(std::size_t image_index, VkImageView image_view) const {
-    VkDescriptorBufferInfo buffer_info;
-    buffer_info.buffer = *buffer;
-    buffer_info.offset = offsetof(BufferData, uniform);
-    buffer_info.range = sizeof(BufferData::uniform);
+    const VkDescriptorBufferInfo buffer_info{
+        .buffer = *buffer,
+        .offset = offsetof(BufferData, uniform),
+        .range = sizeof(BufferData::uniform),
+    };
 
-    VkWriteDescriptorSet ubo_write;
-    ubo_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    ubo_write.pNext = nullptr;
-    ubo_write.dstSet = descriptor_sets[image_index];
-    ubo_write.dstBinding = 0;
-    ubo_write.dstArrayElement = 0;
-    ubo_write.descriptorCount = 1;
-    ubo_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-    ubo_write.pImageInfo = nullptr;
-    ubo_write.pBufferInfo = &buffer_info;
-    ubo_write.pTexelBufferView = nullptr;
+    const VkWriteDescriptorSet ubo_write{
+        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+        .pNext = nullptr,
+        .dstSet = descriptor_sets[image_index],
+        .dstBinding = 0,
+        .dstArrayElement = 0,
+        .descriptorCount = 1,
+        .descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER,
+        .pImageInfo = nullptr,
+        .pBufferInfo = &buffer_info,
+        .pTexelBufferView = nullptr,
+    };
 
-    VkDescriptorImageInfo image_info;
-    image_info.sampler = *sampler;
-    image_info.imageView = image_view;
-    image_info.imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+    const VkDescriptorImageInfo image_info{
+        .sampler = *sampler,
+        .imageView = image_view,
+        .imageLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+    };
 
-    VkWriteDescriptorSet sampler_write;
-    sampler_write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-    sampler_write.pNext = nullptr;
-    sampler_write.dstSet = descriptor_sets[image_index];
-    sampler_write.dstBinding = 1;
-    sampler_write.dstArrayElement = 0;
-    sampler_write.descriptorCount = 1;
-    sampler_write.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    sampler_write.pImageInfo = &image_info;
-    sampler_write.pBufferInfo = nullptr;
-    sampler_write.pTexelBufferView = nullptr;
+    const VkWriteDescriptorSet sampler_write{
+        .sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET,
+        .pNext = nullptr,
+        .dstSet = descriptor_sets[image_index],
+        .dstBinding = 1,
+        .dstArrayElement = 0,
+        .descriptorCount = 1,
+        .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+        .pImageInfo = &image_info,
+        .pBufferInfo = nullptr,
+        .pTexelBufferView = nullptr,
+    };
 
     device.GetLogical().UpdateDescriptorSets(std::array{ubo_write, sampler_write}, {});
 }


### PR DESCRIPTION
Now that we make use of C++20, we can use designated initializers to make things a little nicer to read. Note that we can't use some initializers within VKBlitScreen's Draw function since it ICEs MSVC (lol).