### PR TITLE
vk_state_tracker: Fix dirty flags for stencil_enable on VK_EXT_extended_dynamic_state

### DIFF
--- a/src/video_core/renderer_vulkan/vk_state_tracker.cpp
+++ b/src/video_core/renderer_vulkan/vk_state_tracker.cpp
@@ -158,6 +158,7 @@ void StateTracker::Initialize() {
     SetupDirtyFrontFace(tables);
     SetupDirtyPrimitiveTopology(tables);
     SetupDirtyStencilOp(tables);
+    SetupDirtyStencilTestEnable(tables);
 }
 
 void StateTracker::InvalidateCommandBufferState() {


### PR DESCRIPTION
Fixes a regression on any game using stencil on devices with VK_EXT_extended_dynamic_state.