### PR TITLE
address_space_info: Make use of designated initializers

### DIFF
--- a/src/core/hle/kernel/memory/address_space_info.cpp
+++ b/src/core/hle/kernel/memory/address_space_info.cpp
@@ -49,20 +49,19 @@ constexpr bool IsAllowedIndexForAddress(std::size_t index) {
     return index < AddressSpaceInfos.size() && AddressSpaceInfos[index].address != Invalid;
 }
 
-constexpr std::array<std::size_t, static_cast<std::size_t>(AddressSpaceInfo::Type::Count)>
-    AddressSpaceIndices32Bit{
-        0, 1, 0, 2, 0, 3,
-    };
+using IndexArray = std::array<std::size_t, static_cast<std::size_t>(AddressSpaceInfo::Type::Count)>;
 
-constexpr std::array<std::size_t, static_cast<std::size_t>(AddressSpaceInfo::Type::Count)>
-    AddressSpaceIndices36Bit{
-        4, 5, 4, 6, 4, 7,
-    };
+constexpr IndexArray AddressSpaceIndices32Bit{
+    0, 1, 0, 2, 0, 3,
+};
 
-constexpr std::array<std::size_t, static_cast<std::size_t>(AddressSpaceInfo::Type::Count)>
-    AddressSpaceIndices39Bit{
-        9, 8, 8, 10, 12, 11,
-    };
+constexpr IndexArray AddressSpaceIndices36Bit{
+    4, 5, 4, 6, 4, 7,
+};
+
+constexpr IndexArray AddressSpaceIndices39Bit{
+    9, 8, 8, 10, 12, 11,
+};
 
 constexpr bool IsAllowed32BitType(AddressSpaceInfo::Type type) {
     return type < AddressSpaceInfo::Type::Count && type != AddressSpaceInfo::Type::Large64Bit &&

--- a/src/core/hle/kernel/memory/address_space_info.cpp
+++ b/src/core/hle/kernel/memory/address_space_info.cpp
@@ -29,24 +29,24 @@ enum : u64 {
 
 // clang-format off
 constexpr std::array<AddressSpaceInfo, 13> AddressSpaceInfos{{
-   { 32 /*bit_width*/, Size_2_MB   /*addr*/, Size_1_GB   - Size_2_MB   /*size*/, AddressSpaceInfo::Type::Is32Bit,    },
-   { 32 /*bit_width*/, Size_1_GB   /*addr*/, Size_4_GB   - Size_1_GB   /*size*/, AddressSpaceInfo::Type::Small64Bit, },
-   { 32 /*bit_width*/, Invalid     /*addr*/, Size_1_GB                 /*size*/, AddressSpaceInfo::Type::Heap,       },
-   { 32 /*bit_width*/, Invalid     /*addr*/, Size_1_GB                 /*size*/, AddressSpaceInfo::Type::Alias,      },
-   { 36 /*bit_width*/, Size_128_MB /*addr*/, Size_2_GB   - Size_128_MB /*size*/, AddressSpaceInfo::Type::Is32Bit,    },
-   { 36 /*bit_width*/, Size_2_GB   /*addr*/, Size_64_GB  - Size_2_GB   /*size*/, AddressSpaceInfo::Type::Small64Bit, },
-   { 36 /*bit_width*/, Invalid     /*addr*/, Size_6_GB                 /*size*/, AddressSpaceInfo::Type::Heap,       },
-   { 36 /*bit_width*/, Invalid     /*addr*/, Size_6_GB                 /*size*/, AddressSpaceInfo::Type::Alias,      },
-   { 39 /*bit_width*/, Size_128_MB /*addr*/, Size_512_GB - Size_128_MB /*size*/, AddressSpaceInfo::Type::Large64Bit, },
-   { 39 /*bit_width*/, Invalid     /*addr*/, Size_64_GB                /*size*/, AddressSpaceInfo::Type::Is32Bit     },
-   { 39 /*bit_width*/, Invalid     /*addr*/, Size_6_GB                 /*size*/, AddressSpaceInfo::Type::Heap,       },
-   { 39 /*bit_width*/, Invalid     /*addr*/, Size_64_GB                /*size*/, AddressSpaceInfo::Type::Alias,      },
-   { 39 /*bit_width*/, Invalid     /*addr*/, Size_2_GB                 /*size*/, AddressSpaceInfo::Type::Stack,      },
+   { .bit_width = 32, .address = Size_2_MB  , .size = Size_1_GB   - Size_2_MB  , .type = AddressSpaceInfo::Type::Is32Bit,    },
+   { .bit_width = 32, .address = Size_1_GB  , .size = Size_4_GB   - Size_1_GB  , .type = AddressSpaceInfo::Type::Small64Bit, },
+   { .bit_width = 32, .address = Invalid    , .size = Size_1_GB                , .type = AddressSpaceInfo::Type::Heap,       },
+   { .bit_width = 32, .address = Invalid    , .size = Size_1_GB                , .type = AddressSpaceInfo::Type::Alias,      },
+   { .bit_width = 36, .address = Size_128_MB, .size = Size_2_GB   - Size_128_MB, .type = AddressSpaceInfo::Type::Is32Bit,    },
+   { .bit_width = 36, .address = Size_2_GB  , .size = Size_64_GB  - Size_2_GB  , .type = AddressSpaceInfo::Type::Small64Bit, },
+   { .bit_width = 36, .address = Invalid    , .size = Size_6_GB                , .type = AddressSpaceInfo::Type::Heap,       },
+   { .bit_width = 36, .address = Invalid    , .size = Size_6_GB                , .type = AddressSpaceInfo::Type::Alias,      },
+   { .bit_width = 39, .address = Size_128_MB, .size = Size_512_GB - Size_128_MB, .type = AddressSpaceInfo::Type::Large64Bit, },
+   { .bit_width = 39, .address = Invalid    , .size = Size_64_GB               , .type = AddressSpaceInfo::Type::Is32Bit     },
+   { .bit_width = 39, .address = Invalid    , .size = Size_6_GB                , .type = AddressSpaceInfo::Type::Heap,       },
+   { .bit_width = 39, .address = Invalid    , .size = Size_64_GB               , .type = AddressSpaceInfo::Type::Alias,      },
+   { .bit_width = 39, .address = Invalid    , .size = Size_2_GB                , .type = AddressSpaceInfo::Type::Stack,      },
 }};
 // clang-format on
 
 constexpr bool IsAllowedIndexForAddress(std::size_t index) {
-    return index < std::size(AddressSpaceInfos) && AddressSpaceInfos[index].GetAddress() != Invalid;
+    return index < AddressSpaceInfos.size() && AddressSpaceInfos[index].address != Invalid;
 }
 
 constexpr std::array<std::size_t, static_cast<std::size_t>(AddressSpaceInfo::Type::Count)>
@@ -80,37 +80,37 @@ constexpr bool IsAllowed39BitType(AddressSpaceInfo::Type type) {
 
 } // namespace
 
-u64 AddressSpaceInfo::GetAddressSpaceStart(std::size_t width, AddressSpaceInfo::Type type) {
+u64 AddressSpaceInfo::GetAddressSpaceStart(std::size_t width, Type type) {
     const std::size_t index{static_cast<std::size_t>(type)};
     switch (width) {
     case 32:
         ASSERT(IsAllowed32BitType(type));
         ASSERT(IsAllowedIndexForAddress(AddressSpaceIndices32Bit[index]));
-        return AddressSpaceInfos[AddressSpaceIndices32Bit[index]].GetAddress();
+        return AddressSpaceInfos[AddressSpaceIndices32Bit[index]].address;
     case 36:
         ASSERT(IsAllowed36BitType(type));
         ASSERT(IsAllowedIndexForAddress(AddressSpaceIndices36Bit[index]));
-        return AddressSpaceInfos[AddressSpaceIndices36Bit[index]].GetAddress();
+        return AddressSpaceInfos[AddressSpaceIndices36Bit[index]].address;
     case 39:
         ASSERT(IsAllowed39BitType(type));
         ASSERT(IsAllowedIndexForAddress(AddressSpaceIndices39Bit[index]));
-        return AddressSpaceInfos[AddressSpaceIndices39Bit[index]].GetAddress();
+        return AddressSpaceInfos[AddressSpaceIndices39Bit[index]].address;
     }
     UNREACHABLE();
 }
 
-std::size_t AddressSpaceInfo::GetAddressSpaceSize(std::size_t width, AddressSpaceInfo::Type type) {
+std::size_t AddressSpaceInfo::GetAddressSpaceSize(std::size_t width, Type type) {
     const std::size_t index{static_cast<std::size_t>(type)};
     switch (width) {
     case 32:
         ASSERT(IsAllowed32BitType(type));
-        return AddressSpaceInfos[AddressSpaceIndices32Bit[index]].GetSize();
+        return AddressSpaceInfos[AddressSpaceIndices32Bit[index]].size;
     case 36:
         ASSERT(IsAllowed36BitType(type));
-        return AddressSpaceInfos[AddressSpaceIndices36Bit[index]].GetSize();
+        return AddressSpaceInfos[AddressSpaceIndices36Bit[index]].size;
     case 39:
         ASSERT(IsAllowed39BitType(type));
-        return AddressSpaceInfos[AddressSpaceIndices39Bit[index]].GetSize();
+        return AddressSpaceInfos[AddressSpaceIndices39Bit[index]].size;
     }
     UNREACHABLE();
 }

--- a/src/core/hle/kernel/memory/address_space_info.h
+++ b/src/core/hle/kernel/memory/address_space_info.h
@@ -11,8 +11,7 @@
 
 namespace Kernel::Memory {
 
-class AddressSpaceInfo final : NonCopyable {
-public:
+struct AddressSpaceInfo final {
     enum class Type : u32 {
         Is32Bit = 0,
         Small64Bit = 1,
@@ -23,31 +22,13 @@ public:
         Count,
     };
 
-private:
-    std::size_t bit_width{};
-    std::size_t addr{};
-    std::size_t size{};
-    Type type{};
-
-public:
     static u64 GetAddressSpaceStart(std::size_t width, Type type);
     static std::size_t GetAddressSpaceSize(std::size_t width, Type type);
 
-    constexpr AddressSpaceInfo(std::size_t bit_width, std::size_t addr, std::size_t size, Type type)
-        : bit_width{bit_width}, addr{addr}, size{size}, type{type} {}
-
-    constexpr std::size_t GetWidth() const {
-        return bit_width;
-    }
-    constexpr std::size_t GetAddress() const {
-        return addr;
-    }
-    constexpr std::size_t GetSize() const {
-        return size;
-    }
-    constexpr Type GetType() const {
-        return type;
-    }
+    const std::size_t bit_width{};
+    const std::size_t address{};
+    const std::size_t size{};
+    const Type type{};
 };
 
 } // namespace Kernel::Memory


### PR DESCRIPTION
We can alter the structure so that we can use designated initializers in the array, eliminating the comments that indicate their field names. Also has the benefit of preventing bugs from reordering in the future, though this is unlikely to happen.