### PR TITLE
configure_per_game: Clearer per-game settings

### DIFF
--- a/src/yuzu/configuration/configuration_shared.cpp
+++ b/src/yuzu/configuration/configuration_shared.cpp
@@ -10,10 +10,6 @@
 #include "yuzu/configuration/configuration_shared.h"
 #include "yuzu/configuration/configure_per_game.h"
 
-namespace ConfigurationShared {
-Trackers trackers = {};
-}
-
 void ConfigurationShared::ApplyPerGameSetting(Settings::Setting<bool>* setting,
                                               const QCheckBox* checkbox) {
     if (checkbox->checkState() == Qt::PartiallyChecked) {

--- a/src/yuzu/configuration/configuration_shared.cpp
+++ b/src/yuzu/configuration/configuration_shared.cpp
@@ -89,11 +89,11 @@ void ConfigurationShared::SetPerGameSetting(
 void ConfigurationShared::SetHighlight(QWidget* widget, const std::string& name, bool highlighted) {
     if (highlighted) {
         widget->setStyleSheet(
-            QStringLiteral("QWidget#%1 { border:2px solid;border-color:rgba(0,203,255,0.5) }")
+            QStringLiteral("QWidget#%1 { background-color:rgba(0,203,255,0.5) }")
                 .arg(QString::fromStdString(name)));
     } else {
         widget->setStyleSheet(
-            QStringLiteral("QWidget#%1 { border:2px solid;border-color:rgba(0,0,0,0) }")
+            QStringLiteral("QWidget#%1 { background-color:rgba(0,0,0,0) }")
                 .arg(QString::fromStdString(name)));
     }
     widget->show();

--- a/src/yuzu/configuration/configuration_shared.cpp
+++ b/src/yuzu/configuration/configuration_shared.cpp
@@ -95,42 +95,42 @@ void ConfigurationShared::SetHighlight(QWidget* widget, const std::string& name,
 
 void ConfigurationShared::SetColoredTristate(QCheckBox* checkbox, const std::string& name,
                                              const Settings::Setting<bool>& setting,
-                                             ConfigurationShared::CheckState& tracker) {
+                                             CheckState& tracker) {
     if (setting.UsingGlobal()) {
         tracker = CheckState::Global;
     } else {
         tracker = (setting.GetValue() == setting.GetValue(true)) ? CheckState::On : CheckState::Off;
     }
     SetHighlight(checkbox, name, tracker != CheckState::Global);
-    QObject::connect(
-        checkbox, &QCheckBox::clicked, checkbox, [checkbox, name, setting, &tracker]() {
-            tracker =
-                static_cast<ConfigurationShared::CheckState>((tracker + 1) % CheckState::Count);
-            if (tracker == CheckState::Global) {
-                checkbox->setChecked(setting.GetValue(true));
-            }
-            SetHighlight(checkbox, name, tracker != CheckState::Global);
-        });
+    QObject::connect(checkbox, &QCheckBox::clicked, checkbox,
+                     [checkbox, name, setting, &tracker]() {
+                         tracker = static_cast<CheckState>((static_cast<int>(tracker) + 1) %
+                                                           static_cast<int>(CheckState::Count));
+                         if (tracker == CheckState::Global) {
+                             checkbox->setChecked(setting.GetValue(true));
+                         }
+                         SetHighlight(checkbox, name, tracker != CheckState::Global);
+                     });
 }
 
 void ConfigurationShared::SetColoredTristate(QCheckBox* checkbox, const std::string& name,
                                              bool global, bool state, bool global_state,
-                                             ConfigurationShared::CheckState& tracker) {
+                                             CheckState& tracker) {
     if (global) {
         tracker = CheckState::Global;
     } else {
         tracker = (state == global_state) ? CheckState::On : CheckState::Off;
     }
     SetHighlight(checkbox, name, tracker != CheckState::Global);
-    QObject::connect(
-        checkbox, &QCheckBox::clicked, checkbox, [checkbox, name, global_state, &tracker]() {
-            tracker =
-                static_cast<ConfigurationShared::CheckState>((tracker + 1) % CheckState::Count);
-            if (tracker == CheckState::Global) {
-                checkbox->setChecked(global_state);
-            }
-            SetHighlight(checkbox, name, tracker != CheckState::Global);
-        });
+    QObject::connect(checkbox, &QCheckBox::clicked, checkbox,
+                     [checkbox, name, global_state, &tracker]() {
+                         tracker = static_cast<CheckState>((static_cast<int>(tracker) + 1) %
+                                                           static_cast<int>(CheckState::Count));
+                         if (tracker == CheckState::Global) {
+                             checkbox->setChecked(global_state);
+                         }
+                         SetHighlight(checkbox, name, tracker != CheckState::Global);
+                     });
 }
 
 void ConfigurationShared::SetColoredComboBox(QComboBox* combobox, QWidget* target,

--- a/src/yuzu/configuration/configuration_shared.cpp
+++ b/src/yuzu/configuration/configuration_shared.cpp
@@ -124,3 +124,9 @@ void ConfigurationShared::InsertGlobalItem(QComboBox* combobox) {
     combobox->insertItem(ConfigurationShared::USE_GLOBAL_INDEX, use_global_text);
     combobox->insertSeparator(ConfigurationShared::USE_GLOBAL_SEPARATOR_INDEX);
 }
+
+void ConfigurationShared::InsertGlobalItem(QComboBox* combobox, const QString& global) {
+    const QString use_global_text = ConfigurePerGame::tr("Use global configuration (%1)").arg(global);
+    combobox->insertItem(ConfigurationShared::USE_GLOBAL_INDEX, use_global_text);
+    combobox->insertSeparator(ConfigurationShared::USE_GLOBAL_SEPARATOR_INDEX);
+}

--- a/src/yuzu/configuration/configuration_shared.cpp
+++ b/src/yuzu/configuration/configuration_shared.cpp
@@ -140,8 +140,8 @@ void ConfigurationShared::SetColoredTristate(QCheckBox* checkbox, const std::str
 void ConfigurationShared::SetColoredComboBox(QComboBox* combobox, QWidget* target,
                                              const std::string& target_name, int global) {
     InsertGlobalItem(combobox, global);
-    QObject::connect(combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated),
-                     target, [target, target_name](int index) {
+    QObject::connect(combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), target,
+                     [target, target_name](int index) {
                          ConfigurationShared::SetHighlight(target, target_name, index != 0);
                      });
 }

--- a/src/yuzu/configuration/configuration_shared.cpp
+++ b/src/yuzu/configuration/configuration_shared.cpp
@@ -125,8 +125,8 @@ void ConfigurationShared::InsertGlobalItem(QComboBox* combobox) {
     combobox->insertSeparator(ConfigurationShared::USE_GLOBAL_SEPARATOR_INDEX);
 }
 
-void ConfigurationShared::InsertGlobalItem(QComboBox* combobox, const QString& global) {
-    const QString use_global_text = ConfigurePerGame::tr("Use global configuration (%1)").arg(global);
+void ConfigurationShared::InsertGlobalItem(QComboBox* combobox, int global_index) {
+    const QString use_global_text = ConfigurePerGame::tr("Use global configuration (%1)").arg(combobox->itemText(global_index));
     combobox->insertItem(ConfigurationShared::USE_GLOBAL_INDEX, use_global_text);
     combobox->insertSeparator(ConfigurationShared::USE_GLOBAL_SEPARATOR_INDEX);
 }

--- a/src/yuzu/configuration/configuration_shared.cpp
+++ b/src/yuzu/configuration/configuration_shared.cpp
@@ -85,11 +85,11 @@ void ConfigurationShared::SetPerGameSetting(
                                                            ConfigurationShared::USE_GLOBAL_OFFSET);
 }
 
-void ConfigurationShared::SetBGColor(QWidget* widget, bool highlighted) {
+void ConfigurationShared::SetHighlight(QWidget* widget, bool highlighted) {
     if (highlighted) {
-        widget->setStyleSheet(QStringLiteral("background-color:rgba(0,203,255,0.5);"));
+        widget->setStyleSheet(QStringLiteral("border:2px solid;border-color:rgba(0,203,255,0.5);"));
     } else {
-        widget->setStyleSheet(QStringLiteral("background-color:rgba(0,0,0,0);"));
+        widget->setStyleSheet(QStringLiteral("border:2px solid;border-color:rgba(0,0,0,0);"));
     }
     widget->show();
 }
@@ -101,13 +101,13 @@ void ConfigurationShared::SetColoredTristate(QCheckBox* checkbox, Settings::Sett
     } else {
         tracker = (setting.GetValue() == setting.GetValue(true)) ? CheckState::On : CheckState::Off;
     }
-    SetBGColor(checkbox, tracker != CheckState::Global);
+    SetHighlight(checkbox, tracker != CheckState::Global);
     QObject::connect(checkbox, &QCheckBox::clicked, checkbox, [checkbox, setting, &tracker]() {
         tracker = static_cast<ConfigurationShared::CheckState>((tracker + 1) % CheckState::Count);
         if (tracker == CheckState::Global) {
             checkbox->setChecked(setting.GetValue(true));
         }
-        SetBGColor(checkbox, tracker != CheckState::Global);
+        SetHighlight(checkbox, tracker != CheckState::Global);
     });
 }
 

--- a/src/yuzu/configuration/configuration_shared.cpp
+++ b/src/yuzu/configuration/configuration_shared.cpp
@@ -11,16 +11,6 @@
 #include "yuzu/configuration/configure_per_game.h"
 
 void ConfigurationShared::ApplyPerGameSetting(Settings::Setting<bool>* setting,
-                                              const QCheckBox* checkbox) {
-    if (checkbox->checkState() == Qt::PartiallyChecked) {
-        setting->SetGlobal(true);
-    } else {
-        setting->SetGlobal(false);
-        setting->SetValue(checkbox->checkState() == Qt::Checked);
-    }
-}
-
-void ConfigurationShared::ApplyPerGameSetting(Settings::Setting<bool>* setting,
                                               const QCheckBox* checkbox,
                                               const CheckState& tracker) {
     if (tracker == CheckState::Global) {
@@ -140,12 +130,6 @@ void ConfigurationShared::SetColoredComboBox(QComboBox* combobox, QWidget* targe
                      [target, target_name](int index) {
                          ConfigurationShared::SetHighlight(target, target_name, index != 0);
                      });
-}
-
-void ConfigurationShared::InsertGlobalItem(QComboBox* combobox) {
-    const QString use_global_text = ConfigurePerGame::tr("Use global configuration");
-    combobox->insertItem(ConfigurationShared::USE_GLOBAL_INDEX, use_global_text);
-    combobox->insertSeparator(ConfigurationShared::USE_GLOBAL_SEPARATOR_INDEX);
 }
 
 void ConfigurationShared::InsertGlobalItem(QComboBox* combobox, int global_index) {

--- a/src/yuzu/configuration/configuration_shared.h
+++ b/src/yuzu/configuration/configuration_shared.h
@@ -15,8 +15,20 @@ constexpr int USE_GLOBAL_INDEX = 0;
 constexpr int USE_GLOBAL_SEPARATOR_INDEX = 1;
 constexpr int USE_GLOBAL_OFFSET = 2;
 
+enum CheckState {
+    Off,
+    On,
+    Global,
+    Count,
+};
+
+struct Trackers {
+} extern trackers;
+
 // Global-aware apply and set functions
 
+void ApplyPerGameSetting(Settings::Setting<bool>* setting, const QCheckBox* checkbox,
+                         const CheckState& tracker);
 void ApplyPerGameSetting(Settings::Setting<bool>* setting, const QCheckBox* checkbox);
 void ApplyPerGameSetting(Settings::Setting<int>* setting, const QComboBox* combobox);
 void ApplyPerGameSetting(Settings::Setting<Settings::RendererBackend>* setting,
@@ -30,6 +42,10 @@ void SetPerGameSetting(QComboBox* combobox,
                        const Settings::Setting<Settings::RendererBackend>* setting);
 void SetPerGameSetting(QComboBox* combobox,
                        const Settings::Setting<Settings::GPUAccuracy>* setting);
+
+void SetBGColor(QWidget* widget, bool highlighted);
+void SetColoredTristate(QCheckBox* checkbox, Settings::Setting<bool>& setting,
+                        ConfigurationShared::CheckState& tracker);
 
 void InsertGlobalItem(QComboBox* combobox);
 

--- a/src/yuzu/configuration/configuration_shared.h
+++ b/src/yuzu/configuration/configuration_shared.h
@@ -27,6 +27,14 @@ struct Trackers {
     CheckState use_multi_core;
 
     CheckState enable_audio_stretching;
+
+    CheckState use_disk_shader_cache;
+    CheckState use_asynchronous_gpu_emulation;
+
+    CheckState use_vsync;
+    CheckState use_assembly_shaders;
+    CheckState use_fast_gpu_time;
+    CheckState force_30fps_mode;
 } extern trackers;
 
 // Global-aware apply and set functions
@@ -52,5 +60,6 @@ void SetColoredTristate(QCheckBox* checkbox, const std::string& name, const Sett
                         ConfigurationShared::CheckState& tracker);
 
 void InsertGlobalItem(QComboBox* combobox);
+void InsertGlobalItem(QComboBox* combobox, const QString& global);
 
 } // namespace ConfigurationShared

--- a/src/yuzu/configuration/configuration_shared.h
+++ b/src/yuzu/configuration/configuration_shared.h
@@ -36,6 +36,9 @@ struct Trackers {
     CheckState use_asynchronous_shaders;
     CheckState use_fast_gpu_time;
     CheckState force_30fps_mode;
+
+    CheckState use_rng_seed;
+    CheckState use_custom_rtc;
 } extern trackers;
 
 // Global-aware apply and set functions

--- a/src/yuzu/configuration/configuration_shared.h
+++ b/src/yuzu/configuration/configuration_shared.h
@@ -25,6 +25,8 @@ enum CheckState {
 struct Trackers {
     CheckState use_frame_limit;
     CheckState use_multi_core;
+
+    CheckState enable_audio_stretching;
 } extern trackers;
 
 // Global-aware apply and set functions
@@ -45,8 +47,8 @@ void SetPerGameSetting(QComboBox* combobox,
 void SetPerGameSetting(QComboBox* combobox,
                        const Settings::Setting<Settings::GPUAccuracy>* setting);
 
-void SetHighlight(QWidget* widget, bool highlighted);
-void SetColoredTristate(QCheckBox* checkbox, Settings::Setting<bool>& setting,
+void SetHighlight(QWidget* widget, const std::string& name, bool highlighted);
+void SetColoredTristate(QCheckBox* checkbox, const std::string& name, const Settings::Setting<bool>& setting,
                         ConfigurationShared::CheckState& tracker);
 
 void InsertGlobalItem(QComboBox* combobox);

--- a/src/yuzu/configuration/configuration_shared.h
+++ b/src/yuzu/configuration/configuration_shared.h
@@ -15,7 +15,7 @@ constexpr int USE_GLOBAL_INDEX = 0;
 constexpr int USE_GLOBAL_SEPARATOR_INDEX = 1;
 constexpr int USE_GLOBAL_OFFSET = 2;
 
-enum CheckState {
+enum class CheckState {
     Off,
     On,
     Global,
@@ -42,10 +42,9 @@ void SetPerGameSetting(QComboBox* combobox,
 
 void SetHighlight(QWidget* widget, const std::string& name, bool highlighted);
 void SetColoredTristate(QCheckBox* checkbox, const std::string& name,
-                        const Settings::Setting<bool>& setting,
-                        ConfigurationShared::CheckState& tracker);
+                        const Settings::Setting<bool>& setting, CheckState& tracker);
 void SetColoredTristate(QCheckBox* checkbox, const std::string& name, bool global, bool state,
-                        bool global_state, ConfigurationShared::CheckState& tracker);
+                        bool global_state, CheckState& tracker);
 void SetColoredComboBox(QComboBox* combobox, QWidget* target, const std::string& target_name,
                         int global);
 

--- a/src/yuzu/configuration/configuration_shared.h
+++ b/src/yuzu/configuration/configuration_shared.h
@@ -45,7 +45,7 @@ void SetPerGameSetting(QComboBox* combobox,
 void SetPerGameSetting(QComboBox* combobox,
                        const Settings::Setting<Settings::GPUAccuracy>* setting);
 
-void SetBGColor(QWidget* widget, bool highlighted);
+void SetHighlight(QWidget* widget, bool highlighted);
 void SetColoredTristate(QCheckBox* checkbox, Settings::Setting<bool>& setting,
                         ConfigurationShared::CheckState& tracker);
 

--- a/src/yuzu/configuration/configuration_shared.h
+++ b/src/yuzu/configuration/configuration_shared.h
@@ -57,8 +57,13 @@ void SetPerGameSetting(QComboBox* combobox,
                        const Settings::Setting<Settings::GPUAccuracy>* setting);
 
 void SetHighlight(QWidget* widget, const std::string& name, bool highlighted);
-void SetColoredTristate(QCheckBox* checkbox, const std::string& name, const Settings::Setting<bool>& setting,
+void SetColoredTristate(QCheckBox* checkbox, const std::string& name,
+                        const Settings::Setting<bool>& setting,
                         ConfigurationShared::CheckState& tracker);
+void SetColoredTristate(QCheckBox* checkbox, const std::string& name, bool global, bool state,
+                        bool global_state, ConfigurationShared::CheckState& tracker);
+void SetColoredComboBox(QComboBox* combobox, QWidget* target, const std::string& target_name,
+                        int global);
 
 void InsertGlobalItem(QComboBox* combobox);
 void InsertGlobalItem(QComboBox* combobox, int global_index);

--- a/src/yuzu/configuration/configuration_shared.h
+++ b/src/yuzu/configuration/configuration_shared.h
@@ -33,6 +33,7 @@ struct Trackers {
 
     CheckState use_vsync;
     CheckState use_assembly_shaders;
+    CheckState use_asynchronous_shaders;
     CheckState use_fast_gpu_time;
     CheckState force_30fps_mode;
 } extern trackers;

--- a/src/yuzu/configuration/configuration_shared.h
+++ b/src/yuzu/configuration/configuration_shared.h
@@ -22,25 +22,6 @@ enum CheckState {
     Count,
 };
 
-struct Trackers {
-    CheckState use_frame_limit;
-    CheckState use_multi_core;
-
-    CheckState enable_audio_stretching;
-
-    CheckState use_disk_shader_cache;
-    CheckState use_asynchronous_gpu_emulation;
-
-    CheckState use_vsync;
-    CheckState use_assembly_shaders;
-    CheckState use_asynchronous_shaders;
-    CheckState use_fast_gpu_time;
-    CheckState force_30fps_mode;
-
-    CheckState use_rng_seed;
-    CheckState use_custom_rtc;
-} extern trackers;
-
 // Global-aware apply and set functions
 
 void ApplyPerGameSetting(Settings::Setting<bool>* setting, const QCheckBox* checkbox,

--- a/src/yuzu/configuration/configuration_shared.h
+++ b/src/yuzu/configuration/configuration_shared.h
@@ -23,6 +23,8 @@ enum CheckState {
 };
 
 struct Trackers {
+    CheckState use_frame_limit;
+    CheckState use_multi_core;
 } extern trackers;
 
 // Global-aware apply and set functions

--- a/src/yuzu/configuration/configuration_shared.h
+++ b/src/yuzu/configuration/configuration_shared.h
@@ -61,6 +61,6 @@ void SetColoredTristate(QCheckBox* checkbox, const std::string& name, const Sett
                         ConfigurationShared::CheckState& tracker);
 
 void InsertGlobalItem(QComboBox* combobox);
-void InsertGlobalItem(QComboBox* combobox, const QString& global);
+void InsertGlobalItem(QComboBox* combobox, int global_index);
 
 } // namespace ConfigurationShared

--- a/src/yuzu/configuration/configuration_shared.h
+++ b/src/yuzu/configuration/configuration_shared.h
@@ -26,7 +26,6 @@ enum class CheckState {
 
 void ApplyPerGameSetting(Settings::Setting<bool>* setting, const QCheckBox* checkbox,
                          const CheckState& tracker);
-void ApplyPerGameSetting(Settings::Setting<bool>* setting, const QCheckBox* checkbox);
 void ApplyPerGameSetting(Settings::Setting<int>* setting, const QComboBox* combobox);
 void ApplyPerGameSetting(Settings::Setting<Settings::RendererBackend>* setting,
                          const QComboBox* combobox);
@@ -48,7 +47,6 @@ void SetColoredTristate(QCheckBox* checkbox, const std::string& name, bool globa
 void SetColoredComboBox(QComboBox* combobox, QWidget* target, const std::string& target_name,
                         int global);
 
-void InsertGlobalItem(QComboBox* combobox);
 void InsertGlobalItem(QComboBox* combobox, int global_index);
 
 } // namespace ConfigurationShared

--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -49,12 +49,9 @@ void ConfigureAudio::SetConfiguration() {
 
     ui->volume_slider->setValue(Settings::values.volume.GetValue() * ui->volume_slider->maximum());
 
-    if (Settings::configuring_global) {
-        ui->toggle_audio_stretching->setChecked(
-            Settings::values.enable_audio_stretching.GetValue());
-    } else {
-        ConfigurationShared::SetPerGameSetting(ui->toggle_audio_stretching,
-                                               &Settings::values.enable_audio_stretching);
+    ui->toggle_audio_stretching->setChecked(Settings::values.enable_audio_stretching.GetValue());
+
+    if (!Settings::configuring_global) {
         if (Settings::values.volume.UsingGlobal()) {
             ui->volume_combo_box->setCurrentIndex(0);
             ui->volume_slider->setEnabled(false);
@@ -62,6 +59,8 @@ void ConfigureAudio::SetConfiguration() {
             ui->volume_combo_box->setCurrentIndex(1);
             ui->volume_slider->setEnabled(true);
         }
+        ConfigurationShared::SetHighlight(ui->volume_layout, "volume_layout",
+                                          !Settings::values.volume.UsingGlobal());
     }
     SetVolumeIndicatorText(ui->volume_slider->sliderPosition());
 }
@@ -119,8 +118,9 @@ void ConfigureAudio::ApplyConfiguration() {
                 ui->volume_slider->maximum());
         }
     } else {
-        ConfigurationShared::ApplyPerGameSetting(&Settings::values.enable_audio_stretching,
-                                                 ui->toggle_audio_stretching);
+        ConfigurationShared::ApplyPerGameSetting(
+            &Settings::values.enable_audio_stretching, ui->toggle_audio_stretching,
+            ConfigurationShared::trackers.enable_audio_stretching);
         if (ui->volume_combo_box->currentIndex() == 0) {
             Settings::values.volume.SetGlobal(true);
         } else {
@@ -173,9 +173,14 @@ void ConfigureAudio::SetupPerGameUI() {
         return;
     }
 
-    ui->toggle_audio_stretching->setTristate(true);
+    ConfigurationShared::SetColoredTristate(ui->toggle_audio_stretching, "toggle_audio_stretching",
+                                            Settings::values.enable_audio_stretching,
+                                            ConfigurationShared::trackers.enable_audio_stretching);
     connect(ui->volume_combo_box, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated),
-            this, [this](int index) { ui->volume_slider->setEnabled(index == 1); });
+            this, [this](int index) {
+                ui->volume_slider->setEnabled(index == 1);
+                ConfigurationShared::SetHighlight(ui->volume_layout, "volume_layout", index == 1);
+            });
 
     ui->output_sink_combo_box->setVisible(false);
     ui->output_sink_label->setVisible(false);

--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -120,7 +120,7 @@ void ConfigureAudio::ApplyConfiguration() {
     } else {
         ConfigurationShared::ApplyPerGameSetting(
             &Settings::values.enable_audio_stretching, ui->toggle_audio_stretching,
-            ConfigurationShared::trackers.enable_audio_stretching);
+            trackers.enable_audio_stretching);
         if (ui->volume_combo_box->currentIndex() == 0) {
             Settings::values.volume.SetGlobal(true);
         } else {
@@ -175,7 +175,7 @@ void ConfigureAudio::SetupPerGameUI() {
 
     ConfigurationShared::SetColoredTristate(ui->toggle_audio_stretching, "toggle_audio_stretching",
                                             Settings::values.enable_audio_stretching,
-                                            ConfigurationShared::trackers.enable_audio_stretching);
+                                            trackers.enable_audio_stretching);
     connect(ui->volume_combo_box, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated),
             this, [this](int index) {
                 ui->volume_slider->setEnabled(index == 1);

--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -120,7 +120,7 @@ void ConfigureAudio::ApplyConfiguration() {
     } else {
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.enable_audio_stretching,
                                                  ui->toggle_audio_stretching,
-                                                 trackers.enable_audio_stretching);
+                                                 enable_audio_stretching);
         if (ui->volume_combo_box->currentIndex() == 0) {
             Settings::values.volume.SetGlobal(true);
         } else {
@@ -175,7 +175,7 @@ void ConfigureAudio::SetupPerGameUI() {
 
     ConfigurationShared::SetColoredTristate(ui->toggle_audio_stretching, "toggle_audio_stretching",
                                             Settings::values.enable_audio_stretching,
-                                            trackers.enable_audio_stretching);
+                                            enable_audio_stretching);
     connect(ui->volume_combo_box, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated),
             this, [this](int index) {
                 ui->volume_slider->setEnabled(index == 1);

--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -118,9 +118,9 @@ void ConfigureAudio::ApplyConfiguration() {
                 ui->volume_slider->maximum());
         }
     } else {
-        ConfigurationShared::ApplyPerGameSetting(
-            &Settings::values.enable_audio_stretching, ui->toggle_audio_stretching,
-            trackers.enable_audio_stretching);
+        ConfigurationShared::ApplyPerGameSetting(&Settings::values.enable_audio_stretching,
+                                                 ui->toggle_audio_stretching,
+                                                 trackers.enable_audio_stretching);
         if (ui->volume_combo_box->currentIndex() == 0) {
             Settings::values.volume.SetGlobal(true);
         } else {

--- a/src/yuzu/configuration/configure_audio.h
+++ b/src/yuzu/configuration/configure_audio.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <QWidget>
+#include "yuzu/configuration/configuration_shared.h"
 
 namespace Ui {
 class ConfigureAudio;
@@ -37,4 +38,8 @@ private:
     void SetupPerGameUI();
 
     std::unique_ptr<Ui::ConfigureAudio> ui;
+
+    struct Trackers {
+        ConfigurationShared::CheckState enable_audio_stretching;
+    } trackers;
 };

--- a/src/yuzu/configuration/configure_audio.h
+++ b/src/yuzu/configuration/configure_audio.h
@@ -6,7 +6,10 @@
 
 #include <memory>
 #include <QWidget>
-#include "yuzu/configuration/configuration_shared.h"
+
+namespace ConfigurationShared {
+enum class CheckState;
+}
 
 namespace Ui {
 class ConfigureAudio;
@@ -39,7 +42,5 @@ private:
 
     std::unique_ptr<Ui::ConfigureAudio> ui;
 
-    struct Trackers {
-        ConfigurationShared::CheckState enable_audio_stretching;
-    } trackers;
+    ConfigurationShared::CheckState enable_audio_stretching;
 };

--- a/src/yuzu/configuration/configure_audio.ui
+++ b/src/yuzu/configuration/configure_audio.ui
@@ -58,8 +58,17 @@
       <item>
        <widget class="QWidget" name="volume_layout" native="true">
         <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
          <property name="topMargin">
-          <number>1</number>
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
          </property>
          <item>
           <widget class="QComboBox" name="volume_combo_box">

--- a/src/yuzu/configuration/configure_audio.ui
+++ b/src/yuzu/configuration/configure_audio.ui
@@ -56,80 +56,82 @@
        </layout>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <property name="topMargin">
-         <number>0</number>
-        </property>
-        <item>
-         <widget class="QComboBox" name="volume_combo_box">
-          <item>
+       <widget class="QWidget" name="volume_layout" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout_2">
+         <property name="topMargin">
+          <number>1</number>
+         </property>
+         <item>
+          <widget class="QComboBox" name="volume_combo_box">
+           <item>
+            <property name="text">
+             <string>Use global volume</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Set volume:</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="volume_label">
            <property name="text">
-            <string>Use global volume</string>
+            <string>Volume:</string>
            </property>
-          </item>
-          <item>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>30</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QSlider" name="volume_slider">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="maximum">
+            <number>100</number>
+           </property>
+           <property name="pageStep">
+            <number>10</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="volume_indicator">
+           <property name="minimumSize">
+            <size>
+             <width>32</width>
+             <height>0</height>
+            </size>
+           </property>
            <property name="text">
-            <string>Set volume:</string>
+            <string>0 %</string>
            </property>
-          </item>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="volume_label">
-          <property name="text">
-           <string>Volume:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>30</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QSlider" name="volume_slider">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="maximum">
-           <number>100</number>
-          </property>
-          <property name="pageStep">
-           <number>10</number>
-          </property>
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QLabel" name="volume_indicator">
-          <property name="minimumSize">
-           <size>
-            <width>32</width>
-            <height>0</height>
-           </size>
-          </property>
-          <property name="text">
-           <string>0 %</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-       </layout>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -19,9 +19,10 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
 
     SetConfiguration();
 
-    connect(ui->toggle_frame_limit, &QCheckBox::stateChanged, ui->frame_limit, [this]() {
-        ui->frame_limit->setEnabled(ui->toggle_frame_limit->checkState() == Qt::Checked);
-    });
+    if (Settings::configuring_global) {
+        connect(ui->toggle_frame_limit, &QCheckBox::clicked, ui->frame_limit,
+                [this]() { ui->frame_limit->setEnabled(ui->toggle_frame_limit->isChecked()); });
+    }
 }
 
 ConfigureGeneral::~ConfigureGeneral() = default;
@@ -40,17 +41,13 @@ void ConfigureGeneral::SetConfiguration() {
     ui->toggle_frame_limit->setChecked(Settings::values.use_frame_limit.GetValue());
     ui->frame_limit->setValue(Settings::values.frame_limit.GetValue());
 
-    if (!Settings::configuring_global) {
-        if (Settings::values.use_multi_core.UsingGlobal()) {
-            ui->use_multi_core->setCheckState(Qt::PartiallyChecked);
-        }
-        if (Settings::values.use_frame_limit.UsingGlobal()) {
-            ui->toggle_frame_limit->setCheckState(Qt::PartiallyChecked);
-        }
+    if (Settings::configuring_global) {
+        ui->frame_limit->setEnabled(Settings::values.use_frame_limit.GetValue());
+    } else {
+        ui->frame_limit->setEnabled(Settings::values.use_frame_limit.GetValue() &&
+                                    ConfigurationShared::trackers.use_frame_limit !=
+                                        ConfigurationShared::CheckState::Global);
     }
-
-    ui->frame_limit->setEnabled(ui->toggle_frame_limit->checkState() == Qt::Checked &&
-                                ui->toggle_frame_limit->isEnabled());
 }
 
 void ConfigureGeneral::ApplyConfiguration() {
@@ -71,9 +68,11 @@ void ConfigureGeneral::ApplyConfiguration() {
         }
     } else {
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_multi_core,
-                                                 ui->use_multi_core);
+                                                 ui->use_multi_core,
+                                                 ConfigurationShared::trackers.use_multi_core);
 
-        bool global_frame_limit = ui->toggle_frame_limit->checkState() == Qt::PartiallyChecked;
+        bool global_frame_limit = ConfigurationShared::trackers.use_frame_limit ==
+                                  ConfigurationShared::CheckState::Global;
         Settings::values.use_frame_limit.SetGlobal(global_frame_limit);
         Settings::values.frame_limit.SetGlobal(global_frame_limit);
         if (!global_frame_limit) {
@@ -109,6 +108,15 @@ void ConfigureGeneral::SetupPerGameUI() {
     ui->toggle_background_pause->setVisible(false);
     ui->toggle_hide_mouse->setVisible(false);
 
-    ui->toggle_frame_limit->setTristate(true);
-    ui->use_multi_core->setTristate(true);
+    ConfigurationShared::SetColoredTristate(ui->toggle_frame_limit,
+                                            Settings::values.use_frame_limit,
+                                            ConfigurationShared::trackers.use_frame_limit);
+    ConfigurationShared::SetColoredTristate(ui->use_multi_core, Settings::values.use_multi_core,
+                                            ConfigurationShared::trackers.use_multi_core);
+
+    connect(ui->toggle_frame_limit, &QCheckBox::clicked, ui->frame_limit, [this]() {
+        ui->frame_limit->setEnabled(ui->toggle_frame_limit->isChecked() &&
+                                    (ConfigurationShared::trackers.use_frame_limit !=
+                                     ConfigurationShared::CheckState::Global));
+    });
 }

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -45,7 +45,7 @@ void ConfigureGeneral::SetConfiguration() {
         ui->frame_limit->setEnabled(Settings::values.use_frame_limit.GetValue());
     } else {
         ui->frame_limit->setEnabled(Settings::values.use_frame_limit.GetValue() &&
-                                    ConfigurationShared::trackers.use_frame_limit !=
+                                    trackers.use_frame_limit !=
                                         ConfigurationShared::CheckState::Global);
     }
 }
@@ -69,9 +69,9 @@ void ConfigureGeneral::ApplyConfiguration() {
     } else {
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_multi_core,
                                                  ui->use_multi_core,
-                                                 ConfigurationShared::trackers.use_multi_core);
+                                                 trackers.use_multi_core);
 
-        bool global_frame_limit = ConfigurationShared::trackers.use_frame_limit ==
+        bool global_frame_limit = trackers.use_frame_limit ==
                                   ConfigurationShared::CheckState::Global;
         Settings::values.use_frame_limit.SetGlobal(global_frame_limit);
         Settings::values.frame_limit.SetGlobal(global_frame_limit);
@@ -110,14 +110,14 @@ void ConfigureGeneral::SetupPerGameUI() {
 
     ConfigurationShared::SetColoredTristate(ui->toggle_frame_limit, "toggle_frame_limit",
                                             Settings::values.use_frame_limit,
-                                            ConfigurationShared::trackers.use_frame_limit);
+                                            trackers.use_frame_limit);
     ConfigurationShared::SetColoredTristate(ui->use_multi_core, "use_multi_core",
                                             Settings::values.use_multi_core,
-                                            ConfigurationShared::trackers.use_multi_core);
+                                            trackers.use_multi_core);
 
     connect(ui->toggle_frame_limit, &QCheckBox::clicked, ui->frame_limit, [this]() {
         ui->frame_limit->setEnabled(ui->toggle_frame_limit->isChecked() &&
-                                    (ConfigurationShared::trackers.use_frame_limit !=
+                                    (trackers.use_frame_limit !=
                                      ConfigurationShared::CheckState::Global));
     });
 }

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -108,10 +108,11 @@ void ConfigureGeneral::SetupPerGameUI() {
     ui->toggle_background_pause->setVisible(false);
     ui->toggle_hide_mouse->setVisible(false);
 
-    ConfigurationShared::SetColoredTristate(ui->toggle_frame_limit,
+    ConfigurationShared::SetColoredTristate(ui->toggle_frame_limit, "toggle_frame_limit",
                                             Settings::values.use_frame_limit,
                                             ConfigurationShared::trackers.use_frame_limit);
-    ConfigurationShared::SetColoredTristate(ui->use_multi_core, Settings::values.use_multi_core,
+    ConfigurationShared::SetColoredTristate(ui->use_multi_core, "use_multi_core",
+                                            Settings::values.use_multi_core,
                                             ConfigurationShared::trackers.use_multi_core);
 
     connect(ui->toggle_frame_limit, &QCheckBox::clicked, ui->frame_limit, [this]() {

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -68,11 +68,10 @@ void ConfigureGeneral::ApplyConfiguration() {
         }
     } else {
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_multi_core,
-                                                 ui->use_multi_core,
-                                                 trackers.use_multi_core);
+                                                 ui->use_multi_core, trackers.use_multi_core);
 
-        bool global_frame_limit = trackers.use_frame_limit ==
-                                  ConfigurationShared::CheckState::Global;
+        bool global_frame_limit =
+            trackers.use_frame_limit == ConfigurationShared::CheckState::Global;
         Settings::values.use_frame_limit.SetGlobal(global_frame_limit);
         Settings::values.frame_limit.SetGlobal(global_frame_limit);
         if (!global_frame_limit) {
@@ -116,8 +115,8 @@ void ConfigureGeneral::SetupPerGameUI() {
                                             trackers.use_multi_core);
 
     connect(ui->toggle_frame_limit, &QCheckBox::clicked, ui->frame_limit, [this]() {
-        ui->frame_limit->setEnabled(ui->toggle_frame_limit->isChecked() &&
-                                    (trackers.use_frame_limit !=
-                                     ConfigurationShared::CheckState::Global));
+        ui->frame_limit->setEnabled(
+            ui->toggle_frame_limit->isChecked() &&
+            (trackers.use_frame_limit != ConfigurationShared::CheckState::Global));
     });
 }

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -45,8 +45,7 @@ void ConfigureGeneral::SetConfiguration() {
         ui->frame_limit->setEnabled(Settings::values.use_frame_limit.GetValue());
     } else {
         ui->frame_limit->setEnabled(Settings::values.use_frame_limit.GetValue() &&
-                                    trackers.use_frame_limit !=
-                                        ConfigurationShared::CheckState::Global);
+                                    use_frame_limit != ConfigurationShared::CheckState::Global);
     }
 }
 
@@ -68,10 +67,9 @@ void ConfigureGeneral::ApplyConfiguration() {
         }
     } else {
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_multi_core,
-                                                 ui->use_multi_core, trackers.use_multi_core);
+                                                 ui->use_multi_core, use_multi_core);
 
-        bool global_frame_limit =
-            trackers.use_frame_limit == ConfigurationShared::CheckState::Global;
+        bool global_frame_limit = use_frame_limit == ConfigurationShared::CheckState::Global;
         Settings::values.use_frame_limit.SetGlobal(global_frame_limit);
         Settings::values.frame_limit.SetGlobal(global_frame_limit);
         if (!global_frame_limit) {
@@ -108,15 +106,12 @@ void ConfigureGeneral::SetupPerGameUI() {
     ui->toggle_hide_mouse->setVisible(false);
 
     ConfigurationShared::SetColoredTristate(ui->toggle_frame_limit, "toggle_frame_limit",
-                                            Settings::values.use_frame_limit,
-                                            trackers.use_frame_limit);
+                                            Settings::values.use_frame_limit, use_frame_limit);
     ConfigurationShared::SetColoredTristate(ui->use_multi_core, "use_multi_core",
-                                            Settings::values.use_multi_core,
-                                            trackers.use_multi_core);
+                                            Settings::values.use_multi_core, use_multi_core);
 
     connect(ui->toggle_frame_limit, &QCheckBox::clicked, ui->frame_limit, [this]() {
-        ui->frame_limit->setEnabled(
-            ui->toggle_frame_limit->isChecked() &&
-            (trackers.use_frame_limit != ConfigurationShared::CheckState::Global));
+        ui->frame_limit->setEnabled(ui->toggle_frame_limit->isChecked() &&
+                                    (use_frame_limit != ConfigurationShared::CheckState::Global));
     });
 }

--- a/src/yuzu/configuration/configure_general.h
+++ b/src/yuzu/configuration/configure_general.h
@@ -6,7 +6,10 @@
 
 #include <memory>
 #include <QWidget>
-#include "yuzu/configuration/configuration_shared.h"
+
+namespace ConfigurationShared {
+enum class CheckState;
+}
 
 class HotkeyRegistry;
 
@@ -33,8 +36,6 @@ private:
 
     std::unique_ptr<Ui::ConfigureGeneral> ui;
 
-    struct Trackers {
-        ConfigurationShared::CheckState use_frame_limit;
-        ConfigurationShared::CheckState use_multi_core;
-    } trackers;
+    ConfigurationShared::CheckState use_frame_limit;
+    ConfigurationShared::CheckState use_multi_core;
 };

--- a/src/yuzu/configuration/configure_general.h
+++ b/src/yuzu/configuration/configure_general.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <QWidget>
+#include "yuzu/configuration/configuration_shared.h"
 
 class HotkeyRegistry;
 
@@ -31,4 +32,9 @@ private:
     void SetupPerGameUI();
 
     std::unique_ptr<Ui::ConfigureGeneral> ui;
+
+    struct Trackers {
+        ConfigurationShared::CheckState use_frame_limit;
+        ConfigurationShared::CheckState use_multi_core;
+    } trackers;
 };

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -143,10 +143,10 @@ void ConfigureGraphics::ApplyConfiguration() {
 
         ConfigurationShared::ApplyPerGameSetting(
             &Settings::values.use_disk_shader_cache, ui->use_disk_shader_cache,
-            ConfigurationShared::trackers.use_disk_shader_cache);
+            trackers.use_disk_shader_cache);
         ConfigurationShared::ApplyPerGameSetting(
             &Settings::values.use_asynchronous_gpu_emulation, ui->use_asynchronous_gpu_emulation,
-            ConfigurationShared::trackers.use_asynchronous_gpu_emulation);
+            trackers.use_asynchronous_gpu_emulation);
 
         if (ui->bg_combobox->currentIndex() == ConfigurationShared::USE_GLOBAL_INDEX) {
             Settings::values.bg_red.SetGlobal(true);
@@ -257,11 +257,11 @@ void ConfigureGraphics::SetupPerGameUI() {
 
     ConfigurationShared::SetColoredTristate(ui->use_disk_shader_cache, "use_disk_shader_cache",
                                             Settings::values.use_disk_shader_cache,
-                                            ConfigurationShared::trackers.use_disk_shader_cache);
+                                            trackers.use_disk_shader_cache);
     ConfigurationShared::SetColoredTristate(
         ui->use_asynchronous_gpu_emulation, "use_asynchronous_gpu_emulation",
         Settings::values.use_asynchronous_gpu_emulation,
-        ConfigurationShared::trackers.use_asynchronous_gpu_emulation);
+        trackers.use_asynchronous_gpu_emulation);
 
     ConfigurationShared::SetColoredComboBox(ui->aspect_ratio_combobox, ui->ar_label, "ar_label",
                                             Settings::values.aspect_ratio.GetValue(true));

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -31,13 +31,14 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
 
     SetConfiguration();
 
-    connect(ui->api, qOverload<int>(&QComboBox::currentIndexChanged), this,
-            [this] {
-                UpdateDeviceComboBox();
-                if (!Settings::configuring_global) {
-                    ConfigurationShared::SetHighlight(ui->api_layout, "api_layout", ui->api->currentIndex() != ConfigurationShared::USE_GLOBAL_INDEX);
-                }
-            });
+    connect(ui->api, qOverload<int>(&QComboBox::currentIndexChanged), this, [this] {
+        UpdateDeviceComboBox();
+        if (!Settings::configuring_global) {
+            ConfigurationShared::SetHighlight(ui->api_layout, "api_layout",
+                                              ui->api->currentIndex() !=
+                                                  ConfigurationShared::USE_GLOBAL_INDEX);
+        }
+    });
     connect(ui->device, qOverload<int>(&QComboBox::activated), this,
             [this](int device) { UpdateDeviceSelection(device); });
 
@@ -84,9 +85,12 @@ void ConfigureGraphics::SetConfiguration() {
 
         ui->bg_combobox->setCurrentIndex(Settings::values.bg_red.UsingGlobal() ? 0 : 1);
         ui->bg_button->setEnabled(!Settings::values.bg_red.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->aspect_ratio_layout, "aspect_ratio_layout", !Settings::values.aspect_ratio.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->bg_layout, "bg_layout", !Settings::values.bg_red.UsingGlobal());
-        // FIXME: ConfigurationShared::SetHighlight(ui->api_layout, "api_layout", !Settings::values.renderer_backend.UsingGlobal());
+        ConfigurationShared::SetHighlight(ui->aspect_ratio_layout, "aspect_ratio_layout",
+                                          !Settings::values.aspect_ratio.UsingGlobal());
+        ConfigurationShared::SetHighlight(ui->bg_layout, "bg_layout",
+                                          !Settings::values.bg_red.UsingGlobal());
+        // FIXME: ConfigurationShared::SetHighlight(ui->api_layout, "api_layout",
+        // !Settings::values.renderer_backend.UsingGlobal());
     }
 
     UpdateBackgroundColorButton(QColor::fromRgbF(Settings::values.bg_red.GetValue(),
@@ -243,9 +247,11 @@ void ConfigureGraphics::SetupPerGameUI() {
         return;
     }
 
-    connect(ui->aspect_ratio_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this, [this](int index) {
-        ConfigurationShared::SetHighlight(ui->aspect_ratio_layout, "aspect_ratio_layout", index != 0);
-    });
+    connect(ui->aspect_ratio_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated),
+            this, [this](int index) {
+                ConfigurationShared::SetHighlight(ui->aspect_ratio_layout, "aspect_ratio_layout",
+                                                  index != 0);
+            });
     connect(ui->bg_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this,
             [this](int index) {
                 ui->bg_button->setEnabled(index == 1);
@@ -260,6 +266,8 @@ void ConfigureGraphics::SetupPerGameUI() {
         Settings::values.use_asynchronous_gpu_emulation,
         ConfigurationShared::trackers.use_asynchronous_gpu_emulation);
 
-    ConfigurationShared::InsertGlobalItem(ui->aspect_ratio_combobox, ui->aspect_ratio_combobox->itemText(Settings::values.aspect_ratio.GetValue(true)));
-    ConfigurationShared::InsertGlobalItem(ui->api, ui->api->itemText(static_cast<int>(Settings::values.renderer_backend.GetValue(true))));
+    ConfigurationShared::InsertGlobalItem(ui->aspect_ratio_combobox,
+                                          Settings::values.aspect_ratio.GetValue(true));
+    ConfigurationShared::InsertGlobalItem(
+        ui->api, static_cast<int>(Settings::values.renderer_backend.GetValue(true)));
 }

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -141,12 +141,12 @@ void ConfigureGraphics::ApplyConfiguration() {
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.aspect_ratio,
                                                  ui->aspect_ratio_combobox);
 
-        ConfigurationShared::ApplyPerGameSetting(
-            &Settings::values.use_disk_shader_cache, ui->use_disk_shader_cache,
-            trackers.use_disk_shader_cache);
-        ConfigurationShared::ApplyPerGameSetting(
-            &Settings::values.use_asynchronous_gpu_emulation, ui->use_asynchronous_gpu_emulation,
-            trackers.use_asynchronous_gpu_emulation);
+        ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_disk_shader_cache,
+                                                 ui->use_disk_shader_cache,
+                                                 trackers.use_disk_shader_cache);
+        ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_asynchronous_gpu_emulation,
+                                                 ui->use_asynchronous_gpu_emulation,
+                                                 trackers.use_asynchronous_gpu_emulation);
 
         if (ui->bg_combobox->currentIndex() == ConfigurationShared::USE_GLOBAL_INDEX) {
             Settings::values.bg_red.SetGlobal(true);
@@ -260,8 +260,7 @@ void ConfigureGraphics::SetupPerGameUI() {
                                             trackers.use_disk_shader_cache);
     ConfigurationShared::SetColoredTristate(
         ui->use_asynchronous_gpu_emulation, "use_asynchronous_gpu_emulation",
-        Settings::values.use_asynchronous_gpu_emulation,
-        trackers.use_asynchronous_gpu_emulation);
+        Settings::values.use_asynchronous_gpu_emulation, trackers.use_asynchronous_gpu_emulation);
 
     ConfigurationShared::SetColoredComboBox(ui->aspect_ratio_combobox, ui->ar_label, "ar_label",
                                             Settings::values.aspect_ratio.GetValue(true));

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -87,7 +87,7 @@ void ConfigureGraphics::SetConfiguration() {
 
         ui->bg_combobox->setCurrentIndex(Settings::values.bg_red.UsingGlobal() ? 0 : 1);
         ui->bg_button->setEnabled(!Settings::values.bg_red.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->aspect_ratio_layout, "aspect_ratio_layout",
+        ConfigurationShared::SetHighlight(ui->ar_label, "ar_label",
                                           !Settings::values.aspect_ratio.UsingGlobal());
         ConfigurationShared::SetHighlight(ui->bg_layout, "bg_layout",
                                           !Settings::values.bg_red.UsingGlobal());
@@ -263,8 +263,8 @@ void ConfigureGraphics::SetupPerGameUI() {
         Settings::values.use_asynchronous_gpu_emulation,
         ConfigurationShared::trackers.use_asynchronous_gpu_emulation);
 
-    ConfigurationShared::SetColoredComboBox(ui->aspect_ratio_combobox, ui->aspect_ratio_layout,
-                                            "aspect_ratio_layout",
+    ConfigurationShared::SetColoredComboBox(ui->aspect_ratio_combobox, ui->ar_label,
+                                            "ar_label",
                                             Settings::values.aspect_ratio.GetValue(true));
     ConfigurationShared::InsertGlobalItem(
         ui->api, static_cast<int>(Settings::values.renderer_backend.GetValue(true)));

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -263,8 +263,7 @@ void ConfigureGraphics::SetupPerGameUI() {
         Settings::values.use_asynchronous_gpu_emulation,
         ConfigurationShared::trackers.use_asynchronous_gpu_emulation);
 
-    ConfigurationShared::SetColoredComboBox(ui->aspect_ratio_combobox, ui->ar_label,
-                                            "ar_label",
+    ConfigurationShared::SetColoredComboBox(ui->aspect_ratio_combobox, ui->ar_label, "ar_label",
                                             Settings::values.aspect_ratio.GetValue(true));
     ConfigurationShared::InsertGlobalItem(
         ui->api, static_cast<int>(Settings::values.renderer_backend.GetValue(true)));

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -142,11 +142,10 @@ void ConfigureGraphics::ApplyConfiguration() {
                                                  ui->aspect_ratio_combobox);
 
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_disk_shader_cache,
-                                                 ui->use_disk_shader_cache,
-                                                 trackers.use_disk_shader_cache);
+                                                 ui->use_disk_shader_cache, use_disk_shader_cache);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_asynchronous_gpu_emulation,
                                                  ui->use_asynchronous_gpu_emulation,
-                                                 trackers.use_asynchronous_gpu_emulation);
+                                                 use_asynchronous_gpu_emulation);
 
         if (ui->bg_combobox->currentIndex() == ConfigurationShared::USE_GLOBAL_INDEX) {
             Settings::values.bg_red.SetGlobal(true);
@@ -257,10 +256,10 @@ void ConfigureGraphics::SetupPerGameUI() {
 
     ConfigurationShared::SetColoredTristate(ui->use_disk_shader_cache, "use_disk_shader_cache",
                                             Settings::values.use_disk_shader_cache,
-                                            trackers.use_disk_shader_cache);
+                                            use_disk_shader_cache);
     ConfigurationShared::SetColoredTristate(
         ui->use_asynchronous_gpu_emulation, "use_asynchronous_gpu_emulation",
-        Settings::values.use_asynchronous_gpu_emulation, trackers.use_asynchronous_gpu_emulation);
+        Settings::values.use_asynchronous_gpu_emulation, use_asynchronous_gpu_emulation);
 
     ConfigurationShared::SetColoredComboBox(ui->aspect_ratio_combobox, ui->ar_label, "ar_label",
                                             Settings::values.aspect_ratio.GetValue(true));

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -80,6 +80,8 @@ void ConfigureGraphics::SetConfiguration() {
         ui->aspect_ratio_combobox->setCurrentIndex(Settings::values.aspect_ratio.GetValue());
     } else {
         ConfigurationShared::SetPerGameSetting(ui->api, &Settings::values.renderer_backend);
+        ConfigurationShared::SetHighlight(ui->api_layout, "api_layout",
+                                          !Settings::values.renderer_backend.UsingGlobal());
         ConfigurationShared::SetPerGameSetting(ui->aspect_ratio_combobox,
                                                &Settings::values.aspect_ratio);
 
@@ -89,8 +91,6 @@ void ConfigureGraphics::SetConfiguration() {
                                           !Settings::values.aspect_ratio.UsingGlobal());
         ConfigurationShared::SetHighlight(ui->bg_layout, "bg_layout",
                                           !Settings::values.bg_red.UsingGlobal());
-        // FIXME: ConfigurationShared::SetHighlight(ui->api_layout, "api_layout",
-        // !Settings::values.renderer_backend.UsingGlobal());
     }
 
     UpdateBackgroundColorButton(QColor::fromRgbF(Settings::values.bg_red.GetValue(),
@@ -141,10 +141,12 @@ void ConfigureGraphics::ApplyConfiguration() {
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.aspect_ratio,
                                                  ui->aspect_ratio_combobox);
 
-        ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_disk_shader_cache,
-                                                 ui->use_disk_shader_cache);
-        ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_asynchronous_gpu_emulation,
-                                                 ui->use_asynchronous_gpu_emulation);
+        ConfigurationShared::ApplyPerGameSetting(
+            &Settings::values.use_disk_shader_cache, ui->use_disk_shader_cache,
+            ConfigurationShared::trackers.use_disk_shader_cache);
+        ConfigurationShared::ApplyPerGameSetting(
+            &Settings::values.use_asynchronous_gpu_emulation, ui->use_asynchronous_gpu_emulation,
+            ConfigurationShared::trackers.use_asynchronous_gpu_emulation);
 
         if (ui->bg_combobox->currentIndex() == ConfigurationShared::USE_GLOBAL_INDEX) {
             Settings::values.bg_red.SetGlobal(true);
@@ -247,11 +249,6 @@ void ConfigureGraphics::SetupPerGameUI() {
         return;
     }
 
-    connect(ui->aspect_ratio_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated),
-            this, [this](int index) {
-                ConfigurationShared::SetHighlight(ui->aspect_ratio_layout, "aspect_ratio_layout",
-                                                  index != 0);
-            });
     connect(ui->bg_combobox, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this,
             [this](int index) {
                 ui->bg_button->setEnabled(index == 1);
@@ -266,8 +263,9 @@ void ConfigureGraphics::SetupPerGameUI() {
         Settings::values.use_asynchronous_gpu_emulation,
         ConfigurationShared::trackers.use_asynchronous_gpu_emulation);
 
-    ConfigurationShared::InsertGlobalItem(ui->aspect_ratio_combobox,
-                                          Settings::values.aspect_ratio.GetValue(true));
+    ConfigurationShared::SetColoredComboBox(ui->aspect_ratio_combobox, ui->aspect_ratio_layout,
+                                            "aspect_ratio_layout",
+                                            Settings::values.aspect_ratio.GetValue(true));
     ConfigurationShared::InsertGlobalItem(
         ui->api, static_cast<int>(Settings::values.renderer_backend.GetValue(true)));
 }

--- a/src/yuzu/configuration/configure_graphics.h
+++ b/src/yuzu/configuration/configure_graphics.h
@@ -9,7 +9,10 @@
 #include <QString>
 #include <QWidget>
 #include "core/settings.h"
-#include "yuzu/configuration/configuration_shared.h"
+
+namespace ConfigurationShared {
+enum class CheckState;
+}
 
 namespace Ui {
 class ConfigureGraphics;
@@ -43,10 +46,8 @@ private:
     std::unique_ptr<Ui::ConfigureGraphics> ui;
     QColor bg_color;
 
-    struct Trackers {
-        ConfigurationShared::CheckState use_disk_shader_cache;
-        ConfigurationShared::CheckState use_asynchronous_gpu_emulation;
-    } trackers;
+    ConfigurationShared::CheckState use_disk_shader_cache;
+    ConfigurationShared::CheckState use_asynchronous_gpu_emulation;
 
     std::vector<QString> vulkan_devices;
     u32 vulkan_device{};

--- a/src/yuzu/configuration/configure_graphics.h
+++ b/src/yuzu/configuration/configure_graphics.h
@@ -9,6 +9,7 @@
 #include <QString>
 #include <QWidget>
 #include "core/settings.h"
+#include "yuzu/configuration/configuration_shared.h"
 
 namespace Ui {
 class ConfigureGraphics;
@@ -41,6 +42,11 @@ private:
 
     std::unique_ptr<Ui::ConfigureGraphics> ui;
     QColor bg_color;
+
+    struct Trackers {
+        ConfigurationShared::CheckState use_disk_shader_cache;
+        ConfigurationShared::CheckState use_asynchronous_gpu_emulation;
+    } trackers;
 
     std::vector<QString> vulkan_devices;
     u32 vulkan_device{};

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>437</width>
     <height>321</height>
    </rect>
   </property>
@@ -24,7 +24,7 @@
        <layout class="QVBoxLayout" name="verticalLayout_3">
         <item>
          <widget class="QWidget" name="api_layout" native="true">
-          <layout class="QVBoxLayout" name="verticalLayout_5">
+          <layout class="QGridLayout" name="gridLayout">
            <property name="leftMargin">
             <number>0</number>
            </property>
@@ -37,40 +37,39 @@
            <property name="bottomMargin">
             <number>0</number>
            </property>
-           <item>
-            <layout class="QGridLayout" name="gridLayout">
-             <item row="0" column="1">
-              <widget class="QComboBox" name="api">
-               <item>
-                <property name="text">
-                 <string notr="true">OpenGL</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string notr="true">Vulkan</string>
-                </property>
-               </item>
-              </widget>
+           <property name="horizontalSpacing">
+            <number>6</number>
+           </property>
+           <item row="0" column="0">
+            <widget class="QLabel" name="api_label">
+             <property name="text">
+              <string>API:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QComboBox" name="api">
+             <item>
+              <property name="text">
+               <string notr="true">OpenGL</string>
+              </property>
              </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_2">
-               <property name="text">
-                <string>API:</string>
-               </property>
-              </widget>
+             <item>
+              <property name="text">
+               <string notr="true">Vulkan</string>
+              </property>
              </item>
-             <item row="1" column="1">
-              <widget class="QComboBox" name="device"/>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_3">
-               <property name="text">
-                <string>Device:</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QLabel" name="device_label">
+             <property name="text">
+              <string>Device:</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QComboBox" name="device"/>
            </item>
           </layout>
          </widget>

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -149,7 +149,7 @@
         <item>
          <widget class="QWidget" name="bg_layout" native="true">
           <property name="sizePolicy">
-           <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -23,43 +23,57 @@
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_3">
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_4">
-          <item>
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>API:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="api">
-            <item>
-             <property name="text">
-              <string notr="true">OpenGL</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true">Vulkan</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
-        </item>
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_5">
-          <item>
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Device:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="device"/>
-          </item>
-         </layout>
+         <widget class="QWidget" name="api_layout" native="true">
+          <layout class="QVBoxLayout" name="verticalLayout_5">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <layout class="QGridLayout" name="gridLayout">
+             <item row="0" column="1">
+              <widget class="QComboBox" name="api">
+               <item>
+                <property name="text">
+                 <string notr="true">OpenGL</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string notr="true">Vulkan</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_2">
+               <property name="text">
+                <string>API:</string>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QComboBox" name="device"/>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_3">
+               <property name="text">
+                <string>Device:</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
         </item>
        </layout>
       </widget>
@@ -85,96 +99,133 @@
          </widget>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_6">
-          <item>
-           <widget class="QLabel" name="ar_label">
-            <property name="text">
-             <string>Aspect Ratio:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="aspect_ratio_combobox">
-            <item>
+         <widget class="QWidget" name="aspect_ratio_layout" native="true">
+          <layout class="QHBoxLayout" name="horizontalLayout_6">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="ar_label">
              <property name="text">
-              <string>Default (16:9)</string>
+              <string>Aspect Ratio:</string>
              </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Force 4:3</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Force 21:9</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Stretch to Window</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="aspect_ratio_combobox">
+             <item>
+              <property name="text">
+               <string>Default (16:9)</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Force 4:3</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Force 21:9</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Stretch to Window</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <item>
-           <widget class="QComboBox" name="bg_combobox">
-            <property name="currentText">
-             <string>Use global background color</string>
-            </property>
-            <property name="currentIndex">
-             <number>0</number>
-            </property>
-            <property name="maxVisibleItems">
-             <number>10</number>
-            </property>
-            <item>
-             <property name="text">
+         <widget class="QWidget" name="bg_layout" native="true">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <property name="spacing">
+            <number>6</number>
+           </property>
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QComboBox" name="bg_combobox">
+             <property name="currentText">
               <string>Use global background color</string>
              </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Set background color:</string>
+             <property name="currentIndex">
+              <number>0</number>
              </property>
-            </item>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="bg_label">
-            <property name="text">
-             <string>Background Color:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QPushButton" name="bg_button">
-            <property name="maximumSize">
-             <size>
-              <width>40</width>
-              <height>16777215</height>
-             </size>
-            </property>
-           </widget>
-          </item>
-         </layout>
+             <property name="maxVisibleItems">
+              <number>10</number>
+             </property>
+             <item>
+              <property name="text">
+               <string>Use global background color</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Set background color:</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="bg_label">
+             <property name="text">
+              <string>Background Color:</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QPushButton" name="bg_button">
+             <property name="maximumSize">
+              <size>
+               <width>40</width>
+               <height>16777215</height>
+              </size>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </item>
        </layout>
       </widget>

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -90,18 +90,16 @@ void ConfigureGraphicsAdvanced::ApplyConfiguration() {
                                                  ui->anisotropic_filtering_combobox);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_vsync, ui->use_vsync,
                                                  trackers.use_vsync);
-        ConfigurationShared::ApplyPerGameSetting(
-            &Settings::values.use_assembly_shaders, ui->use_assembly_shaders,
-            trackers.use_assembly_shaders);
-        ConfigurationShared::ApplyPerGameSetting(
-            &Settings::values.use_asynchronous_shaders, ui->use_asynchronous_shaders,
-            trackers.use_asynchronous_shaders);
+        ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_assembly_shaders,
+                                                 ui->use_assembly_shaders,
+                                                 trackers.use_assembly_shaders);
+        ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_asynchronous_shaders,
+                                                 ui->use_asynchronous_shaders,
+                                                 trackers.use_asynchronous_shaders);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_fast_gpu_time,
-                                                 ui->use_fast_gpu_time,
-                                                 trackers.use_fast_gpu_time);
+                                                 ui->use_fast_gpu_time, trackers.use_fast_gpu_time);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.force_30fps_mode,
-                                                 ui->force_30fps_mode,
-                                                 trackers.force_30fps_mode);
+                                                 ui->force_30fps_mode, trackers.force_30fps_mode);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.max_anisotropy,
                                                  ui->anisotropic_filtering_combobox);
 

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -89,17 +89,16 @@ void ConfigureGraphicsAdvanced::ApplyConfiguration() {
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.max_anisotropy,
                                                  ui->anisotropic_filtering_combobox);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_vsync, ui->use_vsync,
-                                                 trackers.use_vsync);
+                                                 use_vsync);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_assembly_shaders,
-                                                 ui->use_assembly_shaders,
-                                                 trackers.use_assembly_shaders);
+                                                 ui->use_assembly_shaders, use_assembly_shaders);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_asynchronous_shaders,
                                                  ui->use_asynchronous_shaders,
-                                                 trackers.use_asynchronous_shaders);
+                                                 use_asynchronous_shaders);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_fast_gpu_time,
-                                                 ui->use_fast_gpu_time, trackers.use_fast_gpu_time);
+                                                 ui->use_fast_gpu_time, use_fast_gpu_time);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.force_30fps_mode,
-                                                 ui->force_30fps_mode, trackers.force_30fps_mode);
+                                                 ui->force_30fps_mode, force_30fps_mode);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.max_anisotropy,
                                                  ui->anisotropic_filtering_combobox);
 
@@ -141,19 +140,17 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     }
 
     ConfigurationShared::SetColoredTristate(ui->use_vsync, "use_vsync", Settings::values.use_vsync,
-                                            trackers.use_vsync);
+                                            use_vsync);
     ConfigurationShared::SetColoredTristate(ui->use_assembly_shaders, "use_assembly_shaders",
                                             Settings::values.use_assembly_shaders,
-                                            trackers.use_assembly_shaders);
+                                            use_assembly_shaders);
     ConfigurationShared::SetColoredTristate(ui->use_assembly_shaders, "use_asynchronous_shaders",
                                             Settings::values.use_asynchronous_shaders,
-                                            trackers.use_asynchronous_shaders);
+                                            use_asynchronous_shaders);
     ConfigurationShared::SetColoredTristate(ui->use_fast_gpu_time, "use_fast_gpu_time",
-                                            Settings::values.use_fast_gpu_time,
-                                            trackers.use_fast_gpu_time);
+                                            Settings::values.use_fast_gpu_time, use_fast_gpu_time);
     ConfigurationShared::SetColoredTristate(ui->force_30fps_mode, "force_30fps_mode",
-                                            Settings::values.force_30fps_mode,
-                                            trackers.force_30fps_mode);
+                                            Settings::values.force_30fps_mode, force_30fps_mode);
     ConfigurationShared::SetColoredComboBox(
         ui->gpu_accuracy, ui->label_gpu_accuracy, "label_gpu_accuracy",
         static_cast<int>(Settings::values.gpu_accuracy.GetValue(true)));

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -144,9 +144,9 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     ConfigurationShared::SetColoredTristate(ui->use_assembly_shaders, "use_assembly_shaders",
                                             Settings::values.use_assembly_shaders,
                                             use_assembly_shaders);
-    ConfigurationShared::SetColoredTristate(ui->use_asynchronous_shaders, "use_asynchronous_shaders",
-                                            Settings::values.use_asynchronous_shaders,
-                                            use_asynchronous_shaders);
+    ConfigurationShared::SetColoredTristate(
+        ui->use_asynchronous_shaders, "use_asynchronous_shaders",
+        Settings::values.use_asynchronous_shaders, use_asynchronous_shaders);
     ConfigurationShared::SetColoredTristate(ui->use_fast_gpu_time, "use_fast_gpu_time",
                                             Settings::values.use_fast_gpu_time, use_fast_gpu_time);
     ConfigurationShared::SetColoredTristate(ui->force_30fps_mode, "force_30fps_mode",

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -28,32 +28,25 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
     ui->force_30fps_mode->setEnabled(runtime_lock);
     ui->anisotropic_filtering_combobox->setEnabled(runtime_lock);
 
+    ui->use_vsync->setChecked(Settings::values.use_vsync.GetValue());
+    ui->use_assembly_shaders->setChecked(Settings::values.use_assembly_shaders.GetValue());
+    ui->use_asynchronous_shaders->setChecked(Settings::values.use_asynchronous_shaders.GetValue());
+    ui->use_fast_gpu_time->setChecked(Settings::values.use_fast_gpu_time.GetValue());
+    ui->force_30fps_mode->setChecked(Settings::values.force_30fps_mode.GetValue());
+
     if (Settings::configuring_global) {
         ui->gpu_accuracy->setCurrentIndex(
             static_cast<int>(Settings::values.gpu_accuracy.GetValue()));
-        ui->use_vsync->setChecked(Settings::values.use_vsync.GetValue());
-        ui->use_assembly_shaders->setChecked(Settings::values.use_assembly_shaders.GetValue());
-        ui->use_asynchronous_shaders->setChecked(
-            Settings::values.use_asynchronous_shaders.GetValue());
-        ui->use_fast_gpu_time->setChecked(Settings::values.use_fast_gpu_time.GetValue());
-        ui->force_30fps_mode->setChecked(Settings::values.force_30fps_mode.GetValue());
         ui->anisotropic_filtering_combobox->setCurrentIndex(
             Settings::values.max_anisotropy.GetValue());
     } else {
         ConfigurationShared::SetPerGameSetting(ui->gpu_accuracy, &Settings::values.gpu_accuracy);
-        ConfigurationShared::SetPerGameSetting(ui->use_vsync, &Settings::values.use_vsync);
-        ConfigurationShared::SetPerGameSetting(ui->use_assembly_shaders,
-                                               &Settings::values.use_assembly_shaders);
-        ConfigurationShared::SetPerGameSetting(ui->use_asynchronous_shaders,
-                                               &Settings::values.use_asynchronous_shaders);
-        ConfigurationShared::SetPerGameSetting(ui->use_asynchronous_shaders,
-                                               &Settings::values.use_asynchronous_shaders);
-        ConfigurationShared::SetPerGameSetting(ui->use_fast_gpu_time,
-                                               &Settings::values.use_fast_gpu_time);
-        ConfigurationShared::SetPerGameSetting(ui->force_30fps_mode,
-                                               &Settings::values.force_30fps_mode);
         ConfigurationShared::SetPerGameSetting(ui->anisotropic_filtering_combobox,
                                                &Settings::values.max_anisotropy);
+        ConfigurationShared::SetHighlight(ui->gpu_accuracy_layout, "gpu_accuracy_layout",
+                                          !Settings::values.gpu_accuracy.UsingGlobal());
+        ConfigurationShared::SetHighlight(ui->af_layout, "af_layout",
+                                          !Settings::values.max_anisotropy.UsingGlobal());
     }
 }
 
@@ -95,17 +88,20 @@ void ConfigureGraphicsAdvanced::ApplyConfiguration() {
     } else {
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.max_anisotropy,
                                                  ui->anisotropic_filtering_combobox);
-        ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_vsync, ui->use_vsync);
-        ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_assembly_shaders,
-                                                 ui->use_assembly_shaders);
-        ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_asynchronous_shaders,
-                                                 ui->use_asynchronous_shaders);
-        ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_asynchronous_shaders,
-                                                 ui->use_asynchronous_shaders);
+        ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_vsync, ui->use_vsync,
+                                                 ConfigurationShared::trackers.use_vsync);
+        ConfigurationShared::ApplyPerGameSetting(
+            &Settings::values.use_assembly_shaders, ui->use_assembly_shaders,
+            ConfigurationShared::trackers.use_assembly_shaders);
+        ConfigurationShared::ApplyPerGameSetting(
+            &Settings::values.use_asynchronous_shaders, ui->use_asynchronous_shaders,
+            ConfigurationShared::trackers.use_asynchronous_shaders);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_fast_gpu_time,
-                                                 ui->use_fast_gpu_time);
+                                                 ui->use_fast_gpu_time,
+                                                 ConfigurationShared::trackers.use_fast_gpu_time);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.force_30fps_mode,
-                                                 ui->force_30fps_mode);
+                                                 ui->force_30fps_mode,
+                                                 ConfigurationShared::trackers.force_30fps_mode);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.max_anisotropy,
                                                  ui->anisotropic_filtering_combobox);
 
@@ -146,11 +142,36 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
         return;
     }
 
-    ConfigurationShared::InsertGlobalItem(ui->gpu_accuracy);
-    ui->use_vsync->setTristate(true);
-    ui->use_assembly_shaders->setTristate(true);
-    ui->use_asynchronous_shaders->setTristate(true);
-    ui->use_fast_gpu_time->setTristate(true);
-    ui->force_30fps_mode->setTristate(true);
-    ConfigurationShared::InsertGlobalItem(ui->anisotropic_filtering_combobox);
+    ConfigurationShared::SetColoredTristate(ui->use_vsync, "use_vsync", Settings::values.use_vsync,
+                                            ConfigurationShared::trackers.use_vsync);
+    ConfigurationShared::SetColoredTristate(ui->use_assembly_shaders, "use_assembly_shaders",
+                                            Settings::values.use_assembly_shaders,
+                                            ConfigurationShared::trackers.use_assembly_shaders);
+    ConfigurationShared::SetColoredTristate(ui->use_assembly_shaders, "use_asynchronous_shaders",
+                                            Settings::values.use_asynchronous_shaders,
+                                            ConfigurationShared::trackers.use_asynchronous_shaders);
+    ConfigurationShared::SetColoredTristate(ui->use_fast_gpu_time, "use_fast_gpu_time",
+                                            Settings::values.use_fast_gpu_time,
+                                            ConfigurationShared::trackers.use_fast_gpu_time);
+    ConfigurationShared::SetColoredTristate(ui->force_30fps_mode, "force_30fps_mode",
+                                            Settings::values.force_30fps_mode,
+                                            ConfigurationShared::trackers.force_30fps_mode);
+    ConfigurationShared::InsertGlobalItem(
+        ui->gpu_accuracy,
+        ui->gpu_accuracy->itemText(static_cast<int>(Settings::values.gpu_accuracy.GetValue(true))));
+    ConfigurationShared::InsertGlobalItem(
+        ui->anisotropic_filtering_combobox,
+        ui->anisotropic_filtering_combobox->itemText(
+            static_cast<int>(Settings::values.max_anisotropy.GetValue(true))));
+
+    connect(ui->gpu_accuracy, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this,
+            [this](int index) {
+                ConfigurationShared::SetHighlight(ui->gpu_accuracy_layout, "gpu_accuracy_layout",
+                                                  index != 0);
+            });
+
+    connect(ui->anisotropic_filtering_combobox,
+            static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this, [this](int index) {
+                ConfigurationShared::SetHighlight(ui->af_layout, "af_layout", index != 0);
+            });
 }

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -43,9 +43,9 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
         ConfigurationShared::SetPerGameSetting(ui->gpu_accuracy, &Settings::values.gpu_accuracy);
         ConfigurationShared::SetPerGameSetting(ui->anisotropic_filtering_combobox,
                                                &Settings::values.max_anisotropy);
-        ConfigurationShared::SetHighlight(ui->gpu_accuracy_layout, "gpu_accuracy_layout",
+        ConfigurationShared::SetHighlight(ui->label_gpu_accuracy, "label_gpu_accuracy",
                                           !Settings::values.gpu_accuracy.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->af_layout, "af_layout",
+        ConfigurationShared::SetHighlight(ui->af_label, "af_label",
                                           !Settings::values.max_anisotropy.UsingGlobal());
     }
 }
@@ -156,20 +156,10 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     ConfigurationShared::SetColoredTristate(ui->force_30fps_mode, "force_30fps_mode",
                                             Settings::values.force_30fps_mode,
                                             ConfigurationShared::trackers.force_30fps_mode);
-    ConfigurationShared::InsertGlobalItem(
-        ui->gpu_accuracy, static_cast<int>(Settings::values.gpu_accuracy.GetValue(true)));
-    ConfigurationShared::InsertGlobalItem(
-        ui->anisotropic_filtering_combobox,
+    ConfigurationShared::SetColoredComboBox(
+        ui->gpu_accuracy, ui->label_gpu_accuracy, "label_gpu_accuracy",
+        static_cast<int>(Settings::values.gpu_accuracy.GetValue(true)));
+    ConfigurationShared::SetColoredComboBox(
+        ui->anisotropic_filtering_combobox, ui->af_label, "af_label",
         static_cast<int>(Settings::values.max_anisotropy.GetValue(true)));
-
-    connect(ui->gpu_accuracy, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this,
-            [this](int index) {
-                ConfigurationShared::SetHighlight(ui->gpu_accuracy_layout, "gpu_accuracy_layout",
-                                                  index != 0);
-            });
-
-    connect(ui->anisotropic_filtering_combobox,
-            static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this, [this](int index) {
-                ConfigurationShared::SetHighlight(ui->af_layout, "af_layout", index != 0);
-            });
 }

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -157,12 +157,10 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
                                             Settings::values.force_30fps_mode,
                                             ConfigurationShared::trackers.force_30fps_mode);
     ConfigurationShared::InsertGlobalItem(
-        ui->gpu_accuracy,
-        ui->gpu_accuracy->itemText(static_cast<int>(Settings::values.gpu_accuracy.GetValue(true))));
+        ui->gpu_accuracy, static_cast<int>(Settings::values.gpu_accuracy.GetValue(true)));
     ConfigurationShared::InsertGlobalItem(
         ui->anisotropic_filtering_combobox,
-        ui->anisotropic_filtering_combobox->itemText(
-            static_cast<int>(Settings::values.max_anisotropy.GetValue(true))));
+        static_cast<int>(Settings::values.max_anisotropy.GetValue(true)));
 
     connect(ui->gpu_accuracy, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this,
             [this](int index) {

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -144,7 +144,7 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     ConfigurationShared::SetColoredTristate(ui->use_assembly_shaders, "use_assembly_shaders",
                                             Settings::values.use_assembly_shaders,
                                             use_assembly_shaders);
-    ConfigurationShared::SetColoredTristate(ui->use_assembly_shaders, "use_asynchronous_shaders",
+    ConfigurationShared::SetColoredTristate(ui->use_asynchronous_shaders, "use_asynchronous_shaders",
                                             Settings::values.use_asynchronous_shaders,
                                             use_asynchronous_shaders);
     ConfigurationShared::SetColoredTristate(ui->use_fast_gpu_time, "use_fast_gpu_time",

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -89,19 +89,19 @@ void ConfigureGraphicsAdvanced::ApplyConfiguration() {
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.max_anisotropy,
                                                  ui->anisotropic_filtering_combobox);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_vsync, ui->use_vsync,
-                                                 ConfigurationShared::trackers.use_vsync);
+                                                 trackers.use_vsync);
         ConfigurationShared::ApplyPerGameSetting(
             &Settings::values.use_assembly_shaders, ui->use_assembly_shaders,
-            ConfigurationShared::trackers.use_assembly_shaders);
+            trackers.use_assembly_shaders);
         ConfigurationShared::ApplyPerGameSetting(
             &Settings::values.use_asynchronous_shaders, ui->use_asynchronous_shaders,
-            ConfigurationShared::trackers.use_asynchronous_shaders);
+            trackers.use_asynchronous_shaders);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_fast_gpu_time,
                                                  ui->use_fast_gpu_time,
-                                                 ConfigurationShared::trackers.use_fast_gpu_time);
+                                                 trackers.use_fast_gpu_time);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.force_30fps_mode,
                                                  ui->force_30fps_mode,
-                                                 ConfigurationShared::trackers.force_30fps_mode);
+                                                 trackers.force_30fps_mode);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.max_anisotropy,
                                                  ui->anisotropic_filtering_combobox);
 
@@ -143,19 +143,19 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     }
 
     ConfigurationShared::SetColoredTristate(ui->use_vsync, "use_vsync", Settings::values.use_vsync,
-                                            ConfigurationShared::trackers.use_vsync);
+                                            trackers.use_vsync);
     ConfigurationShared::SetColoredTristate(ui->use_assembly_shaders, "use_assembly_shaders",
                                             Settings::values.use_assembly_shaders,
-                                            ConfigurationShared::trackers.use_assembly_shaders);
+                                            trackers.use_assembly_shaders);
     ConfigurationShared::SetColoredTristate(ui->use_assembly_shaders, "use_asynchronous_shaders",
                                             Settings::values.use_asynchronous_shaders,
-                                            ConfigurationShared::trackers.use_asynchronous_shaders);
+                                            trackers.use_asynchronous_shaders);
     ConfigurationShared::SetColoredTristate(ui->use_fast_gpu_time, "use_fast_gpu_time",
                                             Settings::values.use_fast_gpu_time,
-                                            ConfigurationShared::trackers.use_fast_gpu_time);
+                                            trackers.use_fast_gpu_time);
     ConfigurationShared::SetColoredTristate(ui->force_30fps_mode, "force_30fps_mode",
                                             Settings::values.force_30fps_mode,
-                                            ConfigurationShared::trackers.force_30fps_mode);
+                                            trackers.force_30fps_mode);
     ConfigurationShared::SetColoredComboBox(
         ui->gpu_accuracy, ui->label_gpu_accuracy, "label_gpu_accuracy",
         static_cast<int>(Settings::values.gpu_accuracy.GetValue(true)));

--- a/src/yuzu/configuration/configure_graphics_advanced.h
+++ b/src/yuzu/configuration/configure_graphics_advanced.h
@@ -6,7 +6,10 @@
 
 #include <memory>
 #include <QWidget>
-#include "yuzu/configuration/configuration_shared.h"
+
+namespace ConfigurationShared {
+enum class CheckState;
+}
 
 namespace Ui {
 class ConfigureGraphicsAdvanced;
@@ -31,11 +34,9 @@ private:
 
     std::unique_ptr<Ui::ConfigureGraphicsAdvanced> ui;
 
-    struct Trackers {
-        ConfigurationShared::CheckState use_vsync;
-        ConfigurationShared::CheckState use_assembly_shaders;
-        ConfigurationShared::CheckState use_asynchronous_shaders;
-        ConfigurationShared::CheckState use_fast_gpu_time;
-        ConfigurationShared::CheckState force_30fps_mode;
-    } trackers;
+    ConfigurationShared::CheckState use_vsync;
+    ConfigurationShared::CheckState use_assembly_shaders;
+    ConfigurationShared::CheckState use_asynchronous_shaders;
+    ConfigurationShared::CheckState use_fast_gpu_time;
+    ConfigurationShared::CheckState force_30fps_mode;
 };

--- a/src/yuzu/configuration/configure_graphics_advanced.h
+++ b/src/yuzu/configuration/configure_graphics_advanced.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include <QWidget>
+#include "yuzu/configuration/configuration_shared.h"
 
 namespace Ui {
 class ConfigureGraphicsAdvanced;
@@ -29,4 +30,12 @@ private:
     void SetupPerGameUI();
 
     std::unique_ptr<Ui::ConfigureGraphicsAdvanced> ui;
+
+    struct Trackers {
+        ConfigurationShared::CheckState use_vsync;
+        ConfigurationShared::CheckState use_assembly_shaders;
+        ConfigurationShared::CheckState use_asynchronous_shaders;
+        ConfigurationShared::CheckState use_fast_gpu_time;
+        ConfigurationShared::CheckState force_30fps_mode;
+    } trackers;
 };

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>404</width>
     <height>321</height>
    </rect>
   </property>
@@ -23,34 +23,48 @@
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_3">
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
-          <item>
-           <widget class="QLabel" name="label_gpu_accuracy">
-            <property name="text">
-             <string>Accuracy Level:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="gpu_accuracy">
-            <item>
+         <widget class="QWidget" name="gpu_accuracy_layout" native="true">
+          <layout class="QHBoxLayout" name="horizontalLayout_2">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_gpu_accuracy">
              <property name="text">
-              <string notr="true">Normal</string>
+              <string>Accuracy Level:</string>
              </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true">High</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string notr="true">Extreme(very slow)</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="gpu_accuracy">
+             <item>
+              <property name="text">
+               <string notr="true">Normal</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string notr="true">High</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string notr="true">Extreme(very slow)</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </item>
         <item>
          <widget class="QCheckBox" name="use_vsync">
@@ -97,44 +111,58 @@
          </widget>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_1">
-          <item>
-           <widget class="QLabel" name="af_label">
-            <property name="text">
-             <string>Anisotropic Filtering:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QComboBox" name="anisotropic_filtering_combobox">
-            <item>
+         <widget class="QWidget" name="af_layout" native="true">
+          <layout class="QHBoxLayout" name="horizontalLayout_1">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="af_label">
              <property name="text">
-              <string>Default</string>
+              <string>Anisotropic Filtering:</string>
              </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>2x</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>4x</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>8x</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>16x</string>
-             </property>
-            </item>
-           </widget>
-          </item>
-         </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="anisotropic_filtering_combobox">
+             <item>
+              <property name="text">
+               <string>Default</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>2x</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>4x</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>8x</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>16x</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </item>
        </layout>
       </widget>

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -148,7 +148,7 @@ void ConfigureSystem::ApplyConfiguration() {
                                                  ui->combo_time_zone);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.sound_index, ui->combo_sound);
 
-        switch (ConfigurationShared::trackers.use_rng_seed) {
+        switch (trackers.use_rng_seed) {
         case ConfigurationShared::CheckState::On:
         case ConfigurationShared::CheckState::Off:
             Settings::values.rng_seed.SetGlobal(false);
@@ -168,7 +168,7 @@ void ConfigureSystem::ApplyConfiguration() {
             break;
         }
 
-        switch (ConfigurationShared::trackers.use_custom_rtc) {
+        switch (trackers.use_custom_rtc) {
         case ConfigurationShared::CheckState::On:
         case ConfigurationShared::CheckState::Off:
             Settings::values.custom_rtc.SetGlobal(false);
@@ -238,10 +238,10 @@ void ConfigureSystem::SetupPerGameUI() {
                                             Settings::values.rng_seed.UsingGlobal(),
                                             Settings::values.rng_seed.GetValue().has_value(),
                                             Settings::values.rng_seed.GetValue(true).has_value(),
-                                            ConfigurationShared::trackers.use_rng_seed);
+                                            trackers.use_rng_seed);
     ConfigurationShared::SetColoredTristate(ui->custom_rtc_checkbox, "custom_rtc_checkbox",
                                             Settings::values.custom_rtc.UsingGlobal(),
                                             Settings::values.custom_rtc.GetValue().has_value(),
                                             Settings::values.custom_rtc.GetValue(true).has_value(),
-                                            ConfigurationShared::trackers.use_custom_rtc);
+                                            trackers.use_custom_rtc);
 }

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -90,10 +90,14 @@ void ConfigureSystem::SetConfiguration() {
                                                &Settings::values.time_zone_index);
         ConfigurationShared::SetPerGameSetting(ui->combo_sound, &Settings::values.sound_index);
 
-        ConfigurationShared::SetHighlight(ui->label_language, "label_language", !Settings::values.language_index.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->label_region, "label_region", !Settings::values.region_index.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->label_timezone, "label_timezone", !Settings::values.time_zone_index.UsingGlobal());
-        ConfigurationShared::SetHighlight(ui->label_sound, "label_sound", !Settings::values.sound_index.UsingGlobal());
+        ConfigurationShared::SetHighlight(ui->label_language, "label_language",
+                                          !Settings::values.language_index.UsingGlobal());
+        ConfigurationShared::SetHighlight(ui->label_region, "label_region",
+                                          !Settings::values.region_index.UsingGlobal());
+        ConfigurationShared::SetHighlight(ui->label_timezone, "label_timezone",
+                                          !Settings::values.time_zone_index.UsingGlobal());
+        ConfigurationShared::SetHighlight(ui->label_sound, "label_sound",
+                                          !Settings::values.sound_index.UsingGlobal());
     }
 }
 

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -89,6 +89,11 @@ void ConfigureSystem::SetConfiguration() {
         ConfigurationShared::SetPerGameSetting(ui->combo_time_zone,
                                                &Settings::values.time_zone_index);
         ConfigurationShared::SetPerGameSetting(ui->combo_sound, &Settings::values.sound_index);
+
+        ConfigurationShared::SetHighlight(ui->label_language, "label_language", !Settings::values.language_index.UsingGlobal());
+        ConfigurationShared::SetHighlight(ui->label_region, "label_region", !Settings::values.region_index.UsingGlobal());
+        ConfigurationShared::SetHighlight(ui->label_timezone, "label_timezone", !Settings::values.time_zone_index.UsingGlobal());
+        ConfigurationShared::SetHighlight(ui->label_sound, "label_sound", !Settings::values.sound_index.UsingGlobal());
     }
 }
 

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -234,14 +234,12 @@ void ConfigureSystem::SetupPerGameUI() {
     ConfigurationShared::SetColoredComboBox(ui->combo_sound, ui->label_sound, "label_sound",
                                             Settings::values.sound_index.GetValue(true));
 
-    ConfigurationShared::SetColoredTristate(ui->rng_seed_checkbox, "rng_seed_checkbox",
-                                            Settings::values.rng_seed.UsingGlobal(),
-                                            Settings::values.rng_seed.GetValue().has_value(),
-                                            Settings::values.rng_seed.GetValue(true).has_value(),
-                                            trackers.use_rng_seed);
-    ConfigurationShared::SetColoredTristate(ui->custom_rtc_checkbox, "custom_rtc_checkbox",
-                                            Settings::values.custom_rtc.UsingGlobal(),
-                                            Settings::values.custom_rtc.GetValue().has_value(),
-                                            Settings::values.custom_rtc.GetValue(true).has_value(),
-                                            trackers.use_custom_rtc);
+    ConfigurationShared::SetColoredTristate(
+        ui->rng_seed_checkbox, "rng_seed_checkbox", Settings::values.rng_seed.UsingGlobal(),
+        Settings::values.rng_seed.GetValue().has_value(),
+        Settings::values.rng_seed.GetValue(true).has_value(), trackers.use_rng_seed);
+    ConfigurationShared::SetColoredTristate(
+        ui->custom_rtc_checkbox, "custom_rtc_checkbox", Settings::values.custom_rtc.UsingGlobal(),
+        Settings::values.custom_rtc.GetValue().has_value(),
+        Settings::values.custom_rtc.GetValue(true).has_value(), trackers.use_custom_rtc);
 }

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -67,21 +67,21 @@ void ConfigureSystem::SetConfiguration() {
     const auto rtc_time = Settings::values.custom_rtc.GetValue().value_or(
         std::chrono::seconds(QDateTime::currentSecsSinceEpoch()));
 
+    ui->rng_seed_checkbox->setChecked(Settings::values.rng_seed.GetValue().has_value());
+    ui->rng_seed_edit->setEnabled(Settings::values.rng_seed.GetValue().has_value() &&
+                                  Settings::values.rng_seed.UsingGlobal());
+    ui->rng_seed_edit->setText(rng_seed);
+
+    ui->custom_rtc_checkbox->setChecked(Settings::values.custom_rtc.GetValue().has_value());
+    ui->custom_rtc_edit->setEnabled(Settings::values.custom_rtc.GetValue().has_value() &&
+                                    Settings::values.rng_seed.UsingGlobal());
+    ui->custom_rtc_edit->setDateTime(QDateTime::fromSecsSinceEpoch(rtc_time.count()));
+
     if (Settings::configuring_global) {
         ui->combo_language->setCurrentIndex(Settings::values.language_index.GetValue());
         ui->combo_region->setCurrentIndex(Settings::values.region_index.GetValue());
         ui->combo_time_zone->setCurrentIndex(Settings::values.time_zone_index.GetValue());
         ui->combo_sound->setCurrentIndex(Settings::values.sound_index.GetValue());
-
-        ui->rng_seed_checkbox->setChecked(Settings::values.rng_seed.GetValue().has_value());
-        ui->rng_seed_edit->setEnabled(Settings::values.rng_seed.GetValue().has_value() &&
-                                      Settings::values.rng_seed.UsingGlobal());
-        ui->rng_seed_edit->setText(rng_seed);
-
-        ui->custom_rtc_checkbox->setChecked(Settings::values.custom_rtc.GetValue().has_value());
-        ui->custom_rtc_edit->setEnabled(Settings::values.custom_rtc.GetValue().has_value() &&
-                                        Settings::values.rng_seed.UsingGlobal());
-        ui->custom_rtc_edit->setDateTime(QDateTime::fromSecsSinceEpoch(rtc_time.count()));
     } else {
         ConfigurationShared::SetPerGameSetting(ui->combo_language,
                                                &Settings::values.language_index);
@@ -89,28 +89,6 @@ void ConfigureSystem::SetConfiguration() {
         ConfigurationShared::SetPerGameSetting(ui->combo_time_zone,
                                                &Settings::values.time_zone_index);
         ConfigurationShared::SetPerGameSetting(ui->combo_sound, &Settings::values.sound_index);
-
-        if (Settings::values.rng_seed.UsingGlobal()) {
-            ui->rng_seed_checkbox->setCheckState(Qt::PartiallyChecked);
-        } else {
-            ui->rng_seed_checkbox->setCheckState(
-                Settings::values.rng_seed.GetValue().has_value() ? Qt::Checked : Qt::Unchecked);
-            ui->rng_seed_edit->setEnabled(Settings::values.rng_seed.GetValue().has_value());
-            if (Settings::values.rng_seed.GetValue().has_value()) {
-                ui->rng_seed_edit->setText(rng_seed);
-            }
-        }
-
-        if (Settings::values.custom_rtc.UsingGlobal()) {
-            ui->custom_rtc_checkbox->setCheckState(Qt::PartiallyChecked);
-        } else {
-            ui->custom_rtc_checkbox->setCheckState(
-                Settings::values.custom_rtc.GetValue().has_value() ? Qt::Checked : Qt::Unchecked);
-            ui->custom_rtc_edit->setEnabled(Settings::values.custom_rtc.GetValue().has_value());
-            if (Settings::values.custom_rtc.GetValue().has_value()) {
-                ui->custom_rtc_edit->setDateTime(QDateTime::fromSecsSinceEpoch(rtc_time.count()));
-            }
-        }
     }
 }
 
@@ -161,37 +139,42 @@ void ConfigureSystem::ApplyConfiguration() {
                                                  ui->combo_time_zone);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.sound_index, ui->combo_sound);
 
-        switch (ui->rng_seed_checkbox->checkState()) {
-        case Qt::Checked:
+        switch (ConfigurationShared::trackers.use_rng_seed) {
+        case ConfigurationShared::CheckState::On:
+        case ConfigurationShared::CheckState::Off:
             Settings::values.rng_seed.SetGlobal(false);
-            Settings::values.rng_seed.SetValue(ui->rng_seed_edit->text().toULongLong(nullptr, 16));
+            if (ui->rng_seed_checkbox->isChecked()) {
+                Settings::values.rng_seed.SetValue(
+                    ui->rng_seed_edit->text().toULongLong(nullptr, 16));
+            } else {
+                Settings::values.rng_seed.SetValue(std::nullopt);
+            }
             break;
-        case Qt::Unchecked:
-            Settings::values.rng_seed.SetGlobal(false);
-            Settings::values.rng_seed.SetValue(std::nullopt);
-            break;
-        case Qt::PartiallyChecked:
+        case ConfigurationShared::CheckState::Global:
             Settings::values.rng_seed.SetGlobal(false);
             Settings::values.rng_seed.SetValue(std::nullopt);
             Settings::values.rng_seed.SetGlobal(true);
             break;
+        case ConfigurationShared::CheckState::Count:;
         }
 
-        switch (ui->custom_rtc_checkbox->checkState()) {
-        case Qt::Checked:
+        switch (ConfigurationShared::trackers.use_custom_rtc) {
+        case ConfigurationShared::CheckState::On:
+        case ConfigurationShared::CheckState::Off:
             Settings::values.custom_rtc.SetGlobal(false);
-            Settings::values.custom_rtc.SetValue(
-                std::chrono::seconds(ui->custom_rtc_edit->dateTime().toSecsSinceEpoch()));
+            if (ui->custom_rtc_checkbox->isChecked()) {
+                Settings::values.custom_rtc.SetValue(
+                    std::chrono::seconds(ui->custom_rtc_edit->dateTime().toSecsSinceEpoch()));
+            } else {
+                Settings::values.custom_rtc.SetValue(std::nullopt);
+            }
             break;
-        case Qt::Unchecked:
-            Settings::values.custom_rtc.SetGlobal(false);
-            Settings::values.custom_rtc.SetValue(std::nullopt);
-            break;
-        case Qt::PartiallyChecked:
+        case ConfigurationShared::CheckState::Global:
             Settings::values.custom_rtc.SetGlobal(false);
             Settings::values.custom_rtc.SetValue(std::nullopt);
             Settings::values.custom_rtc.SetGlobal(true);
             break;
+        case ConfigurationShared::CheckState::Count:;
         }
     }
 
@@ -229,10 +212,25 @@ void ConfigureSystem::SetupPerGameUI() {
         return;
     }
 
-    ConfigurationShared::InsertGlobalItem(ui->combo_language);
-    ConfigurationShared::InsertGlobalItem(ui->combo_region);
-    ConfigurationShared::InsertGlobalItem(ui->combo_time_zone);
-    ConfigurationShared::InsertGlobalItem(ui->combo_sound);
-    ui->rng_seed_checkbox->setTristate(true);
-    ui->custom_rtc_checkbox->setTristate(true);
+    ConfigurationShared::SetColoredComboBox(ui->combo_language, ui->label_language,
+                                            "label_language",
+                                            Settings::values.language_index.GetValue(true));
+    ConfigurationShared::SetColoredComboBox(ui->combo_region, ui->label_region, "label_region",
+                                            Settings::values.region_index.GetValue(true));
+    ConfigurationShared::SetColoredComboBox(ui->combo_time_zone, ui->label_timezone,
+                                            "label_timezone",
+                                            Settings::values.time_zone_index.GetValue(true));
+    ConfigurationShared::SetColoredComboBox(ui->combo_sound, ui->label_sound, "label_sound",
+                                            Settings::values.sound_index.GetValue(true));
+
+    ConfigurationShared::SetColoredTristate(ui->rng_seed_checkbox, "rng_seed_checkbox",
+                                            Settings::values.rng_seed.UsingGlobal(),
+                                            Settings::values.rng_seed.GetValue().has_value(),
+                                            Settings::values.rng_seed.GetValue(true).has_value(),
+                                            ConfigurationShared::trackers.use_rng_seed);
+    ConfigurationShared::SetColoredTristate(ui->custom_rtc_checkbox, "custom_rtc_checkbox",
+                                            Settings::values.custom_rtc.UsingGlobal(),
+                                            Settings::values.custom_rtc.GetValue().has_value(),
+                                            Settings::values.custom_rtc.GetValue(true).has_value(),
+                                            ConfigurationShared::trackers.use_custom_rtc);
 }

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -164,7 +164,8 @@ void ConfigureSystem::ApplyConfiguration() {
             Settings::values.rng_seed.SetValue(std::nullopt);
             Settings::values.rng_seed.SetGlobal(true);
             break;
-        case ConfigurationShared::CheckState::Count:;
+        case ConfigurationShared::CheckState::Count:
+            break;
         }
 
         switch (ConfigurationShared::trackers.use_custom_rtc) {
@@ -183,7 +184,8 @@ void ConfigureSystem::ApplyConfiguration() {
             Settings::values.custom_rtc.SetValue(std::nullopt);
             Settings::values.custom_rtc.SetGlobal(true);
             break;
-        case ConfigurationShared::CheckState::Count:;
+        case ConfigurationShared::CheckState::Count:
+            break;
         }
     }
 

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -148,7 +148,7 @@ void ConfigureSystem::ApplyConfiguration() {
                                                  ui->combo_time_zone);
         ConfigurationShared::ApplyPerGameSetting(&Settings::values.sound_index, ui->combo_sound);
 
-        switch (trackers.use_rng_seed) {
+        switch (use_rng_seed) {
         case ConfigurationShared::CheckState::On:
         case ConfigurationShared::CheckState::Off:
             Settings::values.rng_seed.SetGlobal(false);
@@ -168,7 +168,7 @@ void ConfigureSystem::ApplyConfiguration() {
             break;
         }
 
-        switch (trackers.use_custom_rtc) {
+        switch (use_custom_rtc) {
         case ConfigurationShared::CheckState::On:
         case ConfigurationShared::CheckState::Off:
             Settings::values.custom_rtc.SetGlobal(false);
@@ -237,9 +237,9 @@ void ConfigureSystem::SetupPerGameUI() {
     ConfigurationShared::SetColoredTristate(
         ui->rng_seed_checkbox, "rng_seed_checkbox", Settings::values.rng_seed.UsingGlobal(),
         Settings::values.rng_seed.GetValue().has_value(),
-        Settings::values.rng_seed.GetValue(true).has_value(), trackers.use_rng_seed);
+        Settings::values.rng_seed.GetValue(true).has_value(), use_rng_seed);
     ConfigurationShared::SetColoredTristate(
         ui->custom_rtc_checkbox, "custom_rtc_checkbox", Settings::values.custom_rtc.UsingGlobal(),
         Settings::values.custom_rtc.GetValue().has_value(),
-        Settings::values.custom_rtc.GetValue(true).has_value(), trackers.use_custom_rtc);
+        Settings::values.custom_rtc.GetValue(true).has_value(), use_custom_rtc);
 }

--- a/src/yuzu/configuration/configure_system.h
+++ b/src/yuzu/configuration/configure_system.h
@@ -8,7 +8,10 @@
 
 #include <QList>
 #include <QWidget>
-#include "yuzu/configuration/configuration_shared.h"
+
+namespace ConfigurationShared {
+enum class CheckState;
+}
 
 namespace Ui {
 class ConfigureSystem;
@@ -43,8 +46,6 @@ private:
     int time_zone_index = 0;
     int sound_index = 0;
 
-    struct Trackers {
-        ConfigurationShared::CheckState use_rng_seed;
-        ConfigurationShared::CheckState use_custom_rtc;
-    } trackers;
+    ConfigurationShared::CheckState use_rng_seed;
+    ConfigurationShared::CheckState use_custom_rtc;
 };

--- a/src/yuzu/configuration/configure_system.h
+++ b/src/yuzu/configuration/configure_system.h
@@ -8,6 +8,7 @@
 
 #include <QList>
 #include <QWidget>
+#include "yuzu/configuration/configuration_shared.h"
 
 namespace Ui {
 class ConfigureSystem;
@@ -41,4 +42,9 @@ private:
     int region_index = 0;
     int time_zone_index = 0;
     int sound_index = 0;
+
+    struct Trackers {
+        ConfigurationShared::CheckState use_rng_seed;
+        ConfigurationShared::CheckState use_custom_rtc;
+    } trackers;
 };

--- a/src/yuzu/configuration/configure_system.ui
+++ b/src/yuzu/configuration/configure_system.ui
@@ -21,490 +21,494 @@
        <property name="title">
         <string>System Settings</string>
        </property>
-       <layout class="QGridLayout" name="gridLayout">
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_sound">
-          <property name="text">
-           <string>Sound output mode</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_console_id">
-          <property name="text">
-           <string>Console ID:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QComboBox" name="combo_language">
-          <property name="toolTip">
-           <string>Note: this can be overridden when region setting is auto-select</string>
-          </property>
-          <item>
-           <property name="text">
-            <string>Japanese (日本語)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>English</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>French (français)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>German (Deutsch)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Italian (italiano)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Spanish (español)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Chinese</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Korean (한국어)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Dutch (Nederlands)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Portuguese (português)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Russian (Русский)</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Taiwanese</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>British English</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Canadian French</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Latin American Spanish</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Simplified Chinese</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Traditional Chinese (正體中文)</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_region">
-          <property name="text">
-           <string>Region:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QComboBox" name="combo_region">
-          <item>
-           <property name="text">
-            <string>Japan</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>USA</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Europe</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Australia</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>China</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Korea</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Taiwan</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_timezone">
-          <property name="text">
-           <string>Time Zone:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QComboBox" name="combo_time_zone">
-          <item>
-           <property name="text">
-            <string>Auto</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Default</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>CET</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>CST6CDT</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Cuba</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>EET</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Egypt</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Eire</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>EST</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>EST5EDT</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>GB</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>GB-Eire</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>GMT</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>GMT+0</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>GMT-0</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>GMT0</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Greenwich</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Hongkong</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>HST</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Iceland</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Iran</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Israel</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Jamaica</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Japan</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Kwajalein</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Libya</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>MET</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>MST</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>MST7MDT</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Navajo</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>NZ</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>NZ-CHAT</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Poland</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Portugal</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>PRC</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>PST8PDT</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>ROC</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>ROK</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Singapore</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Turkey</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>UCT</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Universal</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>UTC</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>W-SU</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>WET</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Zulu</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QCheckBox" name="rng_seed_checkbox">
-          <property name="text">
-           <string>RNG Seed</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QComboBox" name="combo_sound">
-          <item>
-           <property name="text">
-            <string>Mono</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Stereo</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Surround</string>
-           </property>
-          </item>
-         </widget>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_language">
-          <property name="text">
-           <string>Language</string>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QPushButton" name="button_regenerate_console_id">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="layoutDirection">
-           <enum>Qt::RightToLeft</enum>
-          </property>
-          <property name="text">
-           <string>Regenerate</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="0">
-         <widget class="QCheckBox" name="custom_rtc_checkbox">
-          <property name="text">
-           <string>Custom RTC</string>
-          </property>
-         </widget>
-        </item>
-        <item row="5" column="1">
-         <widget class="QDateTimeEdit" name="custom_rtc_edit">
-          <property name="minimumDate">
-           <date>
-            <year>1970</year>
-            <month>1</month>
-            <day>1</day>
-           </date>
-          </property>
-          <property name="displayFormat">
-           <string>d MMM yyyy h:mm:ss AP</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="1">
-         <widget class="QLineEdit" name="rng_seed_edit">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="font">
-           <font>
-            <family>Lucida Console</family>
-           </font>
-          </property>
-          <property name="inputMask">
-           <string notr="true">HHHHHHHH</string>
-          </property>
-          <property name="maxLength">
-           <number>8</number>
-          </property>
-         </widget>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_region">
+            <property name="text">
+             <string>Region:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QComboBox" name="combo_time_zone">
+            <item>
+             <property name="text">
+              <string>Auto</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Default</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>CET</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>CST6CDT</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Cuba</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>EET</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Egypt</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Eire</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>EST</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>EST5EDT</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>GB</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>GB-Eire</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>GMT</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>GMT+0</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>GMT-0</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>GMT0</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Greenwich</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Hongkong</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>HST</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Iceland</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Iran</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Israel</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Jamaica</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Japan</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Kwajalein</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Libya</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>MET</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>MST</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>MST7MDT</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Navajo</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>NZ</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>NZ-CHAT</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Poland</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Portugal</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>PRC</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>PST8PDT</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ROC</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>ROK</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Singapore</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Turkey</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>UCT</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Universal</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>UTC</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>W-SU</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>WET</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Zulu</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="combo_region">
+            <item>
+             <property name="text">
+              <string>Japan</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>USA</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Europe</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Australia</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>China</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Korea</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Taiwan</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_timezone">
+            <property name="text">
+             <string>Time Zone:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="combo_language">
+            <property name="toolTip">
+             <string>Note: this can be overridden when region setting is auto-select</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>Japanese (日本語)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>English</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>French (français)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>German (Deutsch)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Italian (italiano)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Spanish (español)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Chinese</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Korean (한국어)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Dutch (Nederlands)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Portuguese (português)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Russian (Русский)</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Taiwanese</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>British English</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Canadian French</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Latin American Spanish</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Simplified Chinese</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Traditional Chinese (正體中文)</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QCheckBox" name="custom_rtc_checkbox">
+            <property name="text">
+             <string>Custom RTC</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_language">
+            <property name="text">
+             <string>Language</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QCheckBox" name="rng_seed_checkbox">
+            <property name="text">
+             <string>RNG Seed</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="combo_sound">
+            <item>
+             <property name="text">
+              <string>Mono</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Stereo</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Surround</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_console_id">
+            <property name="text">
+             <string>Console ID:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_sound">
+            <property name="text">
+             <string>Sound output mode</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1">
+           <widget class="QDateTimeEdit" name="custom_rtc_edit">
+            <property name="minimumDate">
+             <date>
+              <year>1970</year>
+              <month>1</month>
+              <day>1</day>
+             </date>
+            </property>
+            <property name="displayFormat">
+             <string>d MMM yyyy h:mm:ss AP</string>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="1">
+           <widget class="QLineEdit" name="rng_seed_edit">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <family>Lucida Console</family>
+             </font>
+            </property>
+            <property name="inputMask">
+             <string notr="true">HHHHHHHH</string>
+            </property>
+            <property name="maxLength">
+             <number>8</number>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QPushButton" name="button_regenerate_console_id">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="layoutDirection">
+             <enum>Qt::RightToLeft</enum>
+            </property>
+            <property name="text">
+             <string>Regenerate</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </item>
        </layout>
       </widget>


### PR DESCRIPTION
In the original implementation of per-game configurations, the partially checked state of tristate check boxes were used to signal that a given setting would inherit its global configuration. In addition, many combo boxes stated "Use global configuration" to indicate the same behavior. Unfortunately it is not immediately clear to new users how tristate check boxes are supposed to work, and, assuming it is anyways, it is not convenient to go back-and-forth between the global config and the per-game config when the user forgets the global setting and wants to override it.

This PR aims to solve both of those problems. Check boxes still have three states, but they follow a different pattern:

1. they initially inherit the global state (can be on or off),
2. the first click negates the checkbox, and highlights it blue to indicate it will override the global config,
3. the second click negates it again, but it remains highlighted to still indicate an override,
4. a third click sets it back to the global state, without negating the checkbox since it will already be in that state.

In addition, combo boxes now say "Use global configuration ([global setting])" where [global setting] is replaced with the text corresponding to the selected global value. Their labels are also highlighted blue, with some exceptions, to indicate they will override the global setting.

This is purely a visual change to make per-game configs easier to understand and work with. Ideally nothing functional has changed.

Here's a screenshot of the roughest UI change, suggestions are welcome.
[![https://imgur.com/pEFSkst.png](https://imgur.com/pEFSkstl.png)](https://i.imgur.com/pEFSkst.png)
And [here's a video](https://cdn.discordapp.com/attachments/476077512984756254/732344258396422184/2020-07-13_17-09-52.mp4) of how checkboxes work.

Rei came up with this idea for this UI update, and BSoD also helped me sift through ideas to make the UI cleaner, so big thanks to them for this.