### PR TITLE
configure_general: Explicitly guard use_multi_core when applying setting

### DIFF
--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -65,6 +65,8 @@ void ConfigureGeneral::ApplyConfiguration() {
             Settings::values.use_frame_limit.SetValue(ui->toggle_frame_limit->checkState() ==
                                                       Qt::Checked);
             Settings::values.frame_limit.SetValue(ui->frame_limit->value());
+        }
+        if (Settings::values.use_multi_core.UsingGlobal()) {
             Settings::values.use_multi_core.SetValue(ui->use_multi_core->isChecked());
         }
     } else {


### PR DESCRIPTION
This is likely an oversight during a rebase. This guards use_multi_core to only be set when the global value is in use. It should not make a difference given the current code base, but makes the code sensible and makes less assumptions.