### PR TITLE
main: Set async gpu properly after loading per-game setting

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -184,4 +184,10 @@ void RestoreGlobalState() {
     values.sound_index.SetGlobal(true);
 }
 
+void Sanitize() {
+    values.use_asynchronous_gpu_emulation.SetValue(
+        values.use_asynchronous_gpu_emulation.GetValue() ||
+        values.use_multi_core.GetValue());
+}
+
 } // namespace Settings

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -186,8 +186,7 @@ void RestoreGlobalState() {
 
 void Sanitize() {
     values.use_asynchronous_gpu_emulation.SetValue(
-        values.use_asynchronous_gpu_emulation.GetValue() ||
-        values.use_multi_core.GetValue());
+        values.use_asynchronous_gpu_emulation.GetValue() || values.use_multi_core.GetValue());
 }
 
 } // namespace Settings

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -539,4 +539,7 @@ void LogSettings();
 // Restore the global state of all applicable settings in the Values struct
 void RestoreGlobalState();
 
+// Fixes settings that are known to cause issues with the emulator
+void Sanitize();
+
 } // namespace Settings

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -1342,11 +1342,13 @@ void Config::WriteSettingGlobal(const QString& name, const QVariant& value, bool
 
 void Config::Reload() {
     ReadValues();
+    Settings::Sanitize();
     // To apply default value changes
     SaveValues();
     Settings::Apply();
 }
 
 void Config::Save() {
+    Settings::Sanitize();
     SaveValues();
 }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1053,6 +1053,10 @@ void GMainWindow::BootGame(const QString& filename) {
     if (!(loader == nullptr || loader->ReadProgramId(title_id) != Loader::ResultStatus::Success)) {
         // Load per game settings
         Config per_game_config(fmt::format("{:016X}.ini", title_id), false);
+
+        Settings::values.use_asynchronous_gpu_emulation.SetValue(
+            Settings::values.use_asynchronous_gpu_emulation.GetValue() ||
+            Settings::values.use_multi_core.GetValue());
     }
 
     Settings::LogSettings();

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1053,10 +1053,6 @@ void GMainWindow::BootGame(const QString& filename) {
     if (!(loader == nullptr || loader->ReadProgramId(title_id) != Loader::ResultStatus::Success)) {
         // Load per game settings
         Config per_game_config(fmt::format("{:016X}.ini", title_id), false);
-
-        Settings::values.use_asynchronous_gpu_emulation.SetValue(
-            Settings::values.use_asynchronous_gpu_emulation.GetValue() ||
-            Settings::values.use_multi_core.GetValue());
     }
 
     Settings::LogSettings();


### PR DESCRIPTION
Another error that got pass me and only noticed when I was doing the per-game settings UI rework. This prevents asynchronous GPU emulation from being disabled while multi core is enabled as a result of a poorly put together per-game config.