### PR TITLE
gcadapter: Fix crash if gc configured but adapter not connected

### DIFF
--- a/src/input_common/gcadapter/gc_adapter.h
+++ b/src/input_common/gcadapter/gc_adapter.h
@@ -100,6 +100,9 @@ public:
     void BeginConfiguration();
     void EndConfiguration();
 
+    /// Returns true if there is a device connected to port
+    bool DeviceConnected(std::size_t port);
+
     std::array<Common::SPSCQueue<GCPadStatus>, 4>& GetPadQueue();
     const std::array<Common::SPSCQueue<GCPadStatus>, 4>& GetPadQueue() const;
 
@@ -118,9 +121,6 @@ private:
 
     /// Stop scanning for the adapter
     void StopScanThread();
-
-    /// Returns true if there is a device connected to port
-    bool DeviceConnected(std::size_t port);
 
     /// Resets status of device connected to port
     void ResetDeviceType(std::size_t port);


### PR DESCRIPTION
Previously, a crash would occur if the user has one of their inputs configured to be a GC adapter, but then attempts to launch a game if the adapter is unplugged. The state of the adapter would be queried, but there is no state, throwing an exception.

This checks first that a device is connected at the port, which is updated only if the adapter in properly plugged in and instantiated, before attempting to query its actual state.