### PR TITLE
Make the ExeFS dumper take applied updates into account

### DIFF
--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -80,16 +80,6 @@ VirtualDir PatchManager::PatchExeFS(VirtualDir exefs) const {
     if (exefs == nullptr)
         return exefs;
 
-    if (Settings::values.dump_exefs) {
-        LOG_INFO(Loader, "Dumping ExeFS for title_id={:016X}", title_id);
-        const auto dump_dir =
-            Core::System::GetInstance().GetFileSystemController().GetModificationDumpRoot(title_id);
-        if (dump_dir != nullptr) {
-            const auto exefs_dir = GetOrCreateDirectoryRelative(dump_dir, "/exefs");
-            VfsRawCopyD(exefs, exefs_dir);
-        }
-    }
-
     const auto& installed = Core::System::GetInstance().GetContentProvider();
 
     const auto& disabled = Settings::values.disabled_addons[title_id];
@@ -132,6 +122,16 @@ VirtualDir PatchManager::PatchExeFS(VirtualDir exefs) const {
         if (layered != nullptr) {
             LOG_INFO(Loader, "    ExeFS: LayeredExeFS patches applied successfully");
             exefs = std::move(layered);
+        }
+    }
+
+    if (Settings::values.dump_exefs) {
+        LOG_INFO(Loader, "Dumping ExeFS for title_id={:016X}", title_id);
+        const auto dump_dir =
+                Core::System::GetInstance().GetFileSystemController().GetModificationDumpRoot(title_id);
+        if (dump_dir != nullptr) {
+            const auto exefs_dir = GetOrCreateDirectoryRelative(dump_dir, "/exefs");
+            VfsRawCopyD(exefs, exefs_dir);
         }
     }
 


### PR DESCRIPTION
Currently the "Dump ExeFS" option always dumps the base ExeFS files regardless of whether you have updates enabled. This happens because the code responsible for dumping is placed above the code that checks for and applies updates. Simply swapping these around fixes the issue.

I am somewhat inexperienced when it comes to git and pull requests, so if I make any mistakes I can only apologize.