### PR TITLE
filesystem: Create subdirectories prior to creating a file

### DIFF
--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -55,6 +55,7 @@ std::string VfsDirectoryServiceWrapper::GetName() const {
 ResultCode VfsDirectoryServiceWrapper::CreateFile(const std::string& path_, u64 size) const {
     std::string path(FileUtil::SanitizePath(path_));
     auto dir = GetDirectoryRelativeWrapped(backing, FileUtil::GetParentPath(path));
+    // dir can be nullptr if path contains subdirectories, create those prior to creating the file.
     if (dir == nullptr) {
         dir = backing->CreateSubdirectory(FileUtil::GetParentPath(path));
     }

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -55,6 +55,9 @@ std::string VfsDirectoryServiceWrapper::GetName() const {
 ResultCode VfsDirectoryServiceWrapper::CreateFile(const std::string& path_, u64 size) const {
     std::string path(FileUtil::SanitizePath(path_));
     auto dir = GetDirectoryRelativeWrapped(backing, FileUtil::GetParentPath(path));
+    if (dir == nullptr) {
+        dir = backing->CreateSubdirectory(FileUtil::GetParentPath(path));
+    }
     auto file = dir->CreateFile(FileUtil::GetFilename(path));
     if (file == nullptr) {
         // TODO(DarkLordZach): Find a better error code for this


### PR DESCRIPTION
If subdirectories exist in the given path parameter and don't exist in the real filesystem create them prior to creating the files within.
This fixes the softlocks upon save creation in The Legend of Zelda: Breath of the Wild