### PR TITLE
kernel/handle_table: Remove usages of the global system instance

### DIFF
--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -8,6 +8,7 @@
 #include "core/core.h"
 #include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/handle_table.h"
+#include "core/hle/kernel/scheduler.h"
 #include "core/hle/kernel/process.h"
 #include "core/hle/kernel/thread.h"
 
@@ -103,7 +104,7 @@ bool HandleTable::IsValid(Handle handle) const {
 
 std::shared_ptr<Object> HandleTable::GetGeneric(Handle handle) const {
     if (handle == CurrentThread) {
-        return SharedFrom(GetCurrentThread());
+        return SharedFrom(Core::System::GetInstance().CurrentScheduler().GetCurrentThread());
     } else if (handle == CurrentProcess) {
         return SharedFrom(Core::System::GetInstance().CurrentProcess());
     }

--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -8,8 +8,9 @@
 #include "core/core.h"
 #include "core/hle/kernel/errors.h"
 #include "core/hle/kernel/handle_table.h"
-#include "core/hle/kernel/scheduler.h"
+#include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/process.h"
+#include "core/hle/kernel/scheduler.h"
 #include "core/hle/kernel/thread.h"
 
 namespace Kernel {
@@ -23,7 +24,7 @@ constexpr u16 GetGeneration(Handle handle) {
 }
 } // Anonymous namespace
 
-HandleTable::HandleTable() {
+HandleTable::HandleTable(KernelCore& kernel) : kernel{kernel} {
     Clear();
 }
 
@@ -104,9 +105,9 @@ bool HandleTable::IsValid(Handle handle) const {
 
 std::shared_ptr<Object> HandleTable::GetGeneric(Handle handle) const {
     if (handle == CurrentThread) {
-        return SharedFrom(Core::System::GetInstance().CurrentScheduler().GetCurrentThread());
+        return SharedFrom(kernel.CurrentScheduler().GetCurrentThread());
     } else if (handle == CurrentProcess) {
-        return SharedFrom(Core::System::GetInstance().CurrentProcess());
+        return SharedFrom(kernel.CurrentProcess());
     }
 
     if (!IsValid(handle)) {

--- a/src/core/hle/kernel/handle_table.h
+++ b/src/core/hle/kernel/handle_table.h
@@ -14,6 +14,8 @@
 
 namespace Kernel {
 
+class KernelCore;
+
 enum KernelHandle : Handle {
     InvalidHandle = 0,
     CurrentThread = 0xFFFF8000,
@@ -48,7 +50,7 @@ public:
     /// This is the maximum limit of handles allowed per process in Horizon
     static constexpr std::size_t MAX_COUNT = 1024;
 
-    HandleTable();
+    explicit HandleTable(KernelCore& kernel);
     ~HandleTable();
 
     /**
@@ -134,6 +136,9 @@ private:
 
     /// Head of the free slots linked list.
     u16 next_free_slot = 0;
+
+    /// Underlying kernel instance that this handle table operates under.
+    KernelCore& kernel;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -50,7 +50,8 @@ namespace Kernel {
 
 struct KernelCore::Impl {
     explicit Impl(Core::System& system, KernelCore& kernel)
-        : global_scheduler{kernel}, synchronization{system}, time_manager{system}, system{system} {}
+        : global_scheduler{kernel}, synchronization{system}, time_manager{system},
+          global_handle_table{kernel}, system{system} {}
 
     void SetMulticore(bool is_multicore) {
         this->is_multicore = is_multicore;
@@ -307,7 +308,7 @@ struct KernelCore::Impl {
 
     // This is the kernel's handle table or supervisor handle table which
     // stores all the objects in place.
-    Kernel::HandleTable global_handle_table;
+    HandleTable global_handle_table;
 
     /// Map of named ports managed by the kernel, which can be retrieved using
     /// the ConnectToPort SVC.

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -408,7 +408,7 @@ void Process::LoadModule(CodeSet code_set, VAddr base_addr) {
 Process::Process(Core::System& system)
     : SynchronizationObject{system.Kernel()}, page_table{std::make_unique<Memory::PageTable>(
                                                   system)},
-      address_arbiter{system}, mutex{system}, system{system} {}
+      handle_table{system.Kernel()}, address_arbiter{system}, mutex{system}, system{system} {}
 
 Process::~Process() = default;
 

--- a/src/core/hle/kernel/process.h
+++ b/src/core/hle/kernel/process.h
@@ -382,12 +382,6 @@ private:
     /// List of threads waiting for a condition variable
     std::unordered_map<VAddr, std::list<std::shared_ptr<Thread>>> cond_var_threads;
 
-    /// System context
-    Core::System& system;
-
-    /// Name of this process
-    std::string name;
-
     /// Address of the top of the main thread's stack
     VAddr main_thread_stack_top{};
 
@@ -399,6 +393,12 @@ private:
 
     /// Process total image size
     std::size_t image_size{};
+
+    /// Name of this process
+    std::string name;
+
+    /// System context
+    Core::System& system;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -13,16 +13,8 @@
 #include "common/logging/log.h"
 #include "common/thread_queue_list.h"
 #include "core/arm/arm_interface.h"
-#ifdef ARCHITECTURE_x86_64
-#include "core/arm/dynarmic/arm_dynarmic_32.h"
-#include "core/arm/dynarmic/arm_dynarmic_64.h"
-#endif
-#include "core/arm/cpu_interrupt_handler.h"
-#include "core/arm/exclusive_monitor.h"
 #include "core/arm/unicorn/arm_unicorn.h"
 #include "core/core.h"
-#include "core/core_timing.h"
-#include "core/core_timing_util.h"
 #include "core/cpu_manager.h"
 #include "core/hardware_properties.h"
 #include "core/hle/kernel/errors.h"
@@ -35,6 +27,11 @@
 #include "core/hle/kernel/time_manager.h"
 #include "core/hle/result.h"
 #include "core/memory.h"
+
+#ifdef ARCHITECTURE_x86_64
+#include "core/arm/dynarmic/arm_dynarmic_32.h"
+#include "core/arm/dynarmic/arm_dynarmic_64.h"
+#endif
 
 namespace Kernel {
 
@@ -538,15 +535,6 @@ ResultCode Thread::SetCoreAndAffinityMask(s32 new_core, u64 new_affinity_mask) {
         }
     }
     return RESULT_SUCCESS;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////
-
-/**
- * Gets the current thread
- */
-Thread* GetCurrentThread() {
-    return Core::System::GetInstance().CurrentScheduler().GetCurrentThread();
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -680,9 +680,4 @@ private:
     std::string name;
 };
 
-/**
- * Gets the current thread
- */
-Thread* GetCurrentThread();
-
 } // namespace Kernel


### PR DESCRIPTION
Removes even more usages of the global system instance, trimming away more dependencies on global variables and making them explicit in the interface.

With this, the kernel has only one more remaining place that depends on the global system instance.