### PR TITLE
settings: Make use of std::string_view over std::string for logging

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -67,18 +67,18 @@ Values values = {};
 bool configuring_global = true;
 
 std::string GetTimeZoneString() {
-    static constexpr std::array<const char*, 46> timezones{{
+    static constexpr std::array timezones{
         "auto",      "default",   "CET", "CST6CDT", "Cuba",    "EET",    "Egypt",     "Eire",
         "EST",       "EST5EDT",   "GB",  "GB-Eire", "GMT",     "GMT+0",  "GMT-0",     "GMT0",
         "Greenwich", "Hongkong",  "HST", "Iceland", "Iran",    "Israel", "Jamaica",   "Japan",
         "Kwajalein", "Libya",     "MET", "MST",     "MST7MDT", "Navajo", "NZ",        "NZ-CHAT",
         "Poland",    "Portugal",  "PRC", "PST8PDT", "ROC",     "ROK",    "Singapore", "Turkey",
         "UCT",       "Universal", "UTC", "W-SU",    "WET",     "Zulu",
-    }};
+    };
 
-    ASSERT(Settings::values.time_zone_index.GetValue() < timezones.size());
-
-    return timezones[Settings::values.time_zone_index.GetValue()];
+    const auto time_zone_index = static_cast<std::size_t>(values.time_zone_index.GetValue());
+    ASSERT(time_zone_index < timezones.size());
+    return timezones[time_zone_index];
 }
 
 void Apply() {

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <string_view>
+
 #include "common/file_util.h"
 #include "core/core.h"
 #include "core/gdbstub/gdbstub.h"
@@ -91,41 +93,40 @@ void Apply() {
     Service::HID::ReloadInputDevices();
 }
 
-template <typename T>
-void LogSetting(const std::string& name, const T& value) {
-    LOG_INFO(Config, "{}: {}", name, value);
-}
-
 void LogSettings() {
+    const auto log_setting = [](std::string_view name, const auto& value) {
+        LOG_INFO(Config, "{}: {}", name, value);
+    };
+
     LOG_INFO(Config, "yuzu Configuration:");
-    LogSetting("Controls_UseDockedMode", Settings::values.use_docked_mode);
-    LogSetting("System_RngSeed", Settings::values.rng_seed.GetValue().value_or(0));
-    LogSetting("System_CurrentUser", Settings::values.current_user);
-    LogSetting("System_LanguageIndex", Settings::values.language_index.GetValue());
-    LogSetting("System_RegionIndex", Settings::values.region_index.GetValue());
-    LogSetting("System_TimeZoneIndex", Settings::values.time_zone_index.GetValue());
-    LogSetting("Core_UseMultiCore", Settings::values.use_multi_core.GetValue());
-    LogSetting("Renderer_UseResolutionFactor", Settings::values.resolution_factor.GetValue());
-    LogSetting("Renderer_UseFrameLimit", Settings::values.use_frame_limit.GetValue());
-    LogSetting("Renderer_FrameLimit", Settings::values.frame_limit.GetValue());
-    LogSetting("Renderer_UseDiskShaderCache", Settings::values.use_disk_shader_cache.GetValue());
-    LogSetting("Renderer_GPUAccuracyLevel", Settings::values.gpu_accuracy.GetValue());
-    LogSetting("Renderer_UseAsynchronousGpuEmulation",
-               Settings::values.use_asynchronous_gpu_emulation.GetValue());
-    LogSetting("Renderer_UseVsync", Settings::values.use_vsync.GetValue());
-    LogSetting("Renderer_UseAssemblyShaders", Settings::values.use_assembly_shaders.GetValue());
-    LogSetting("Renderer_AnisotropicFilteringLevel", Settings::values.max_anisotropy.GetValue());
-    LogSetting("Audio_OutputEngine", Settings::values.sink_id);
-    LogSetting("Audio_EnableAudioStretching", Settings::values.enable_audio_stretching.GetValue());
-    LogSetting("Audio_OutputDevice", Settings::values.audio_device_id);
-    LogSetting("DataStorage_UseVirtualSd", Settings::values.use_virtual_sd);
-    LogSetting("DataStorage_NandDir", FileUtil::GetUserPath(FileUtil::UserPath::NANDDir));
-    LogSetting("DataStorage_SdmcDir", FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir));
-    LogSetting("Debugging_UseGdbstub", Settings::values.use_gdbstub);
-    LogSetting("Debugging_GdbstubPort", Settings::values.gdbstub_port);
-    LogSetting("Debugging_ProgramArgs", Settings::values.program_args);
-    LogSetting("Services_BCATBackend", Settings::values.bcat_backend);
-    LogSetting("Services_BCATBoxcatLocal", Settings::values.bcat_boxcat_local);
+    log_setting("Controls_UseDockedMode", values.use_docked_mode);
+    log_setting("System_RngSeed", values.rng_seed.GetValue().value_or(0));
+    log_setting("System_CurrentUser", values.current_user);
+    log_setting("System_LanguageIndex", values.language_index.GetValue());
+    log_setting("System_RegionIndex", values.region_index.GetValue());
+    log_setting("System_TimeZoneIndex", values.time_zone_index.GetValue());
+    log_setting("Core_UseMultiCore", values.use_multi_core.GetValue());
+    log_setting("Renderer_UseResolutionFactor", values.resolution_factor.GetValue());
+    log_setting("Renderer_UseFrameLimit", values.use_frame_limit.GetValue());
+    log_setting("Renderer_FrameLimit", values.frame_limit.GetValue());
+    log_setting("Renderer_UseDiskShaderCache", values.use_disk_shader_cache.GetValue());
+    log_setting("Renderer_GPUAccuracyLevel", values.gpu_accuracy.GetValue());
+    log_setting("Renderer_UseAsynchronousGpuEmulation",
+                values.use_asynchronous_gpu_emulation.GetValue());
+    log_setting("Renderer_UseVsync", values.use_vsync.GetValue());
+    log_setting("Renderer_UseAssemblyShaders", values.use_assembly_shaders.GetValue());
+    log_setting("Renderer_AnisotropicFilteringLevel", values.max_anisotropy.GetValue());
+    log_setting("Audio_OutputEngine", values.sink_id);
+    log_setting("Audio_EnableAudioStretching", values.enable_audio_stretching.GetValue());
+    log_setting("Audio_OutputDevice", values.audio_device_id);
+    log_setting("DataStorage_UseVirtualSd", values.use_virtual_sd);
+    log_setting("DataStorage_NandDir", FileUtil::GetUserPath(FileUtil::UserPath::NANDDir));
+    log_setting("DataStorage_SdmcDir", FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir));
+    log_setting("Debugging_UseGdbstub", values.use_gdbstub);
+    log_setting("Debugging_GdbstubPort", values.gdbstub_port);
+    log_setting("Debugging_ProgramArgs", values.program_args);
+    log_setting("Services_BCATBackend", values.bcat_backend);
+    log_setting("Services_BCATBoxcatLocal", values.bcat_boxcat_local);
 }
 
 float Volume() {


### PR DESCRIPTION
In all usages of `LogSetting()`, string literals are provided. `std::string_view` is better suited here, as we won't churn a bunch of
string allocations every time the settings are logged out.

While we're at it, we can fold `LogSetting()` into `LogSettings()`, given it's only ever used there.