### PR TITLE
core_timing: Make usage of nanoseconds more consistent in the interface

### DIFF
--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -38,7 +38,7 @@ Stream::Stream(Core::Timing::CoreTiming& core_timing, u32 sample_rate, Format fo
       sink_stream{sink_stream}, core_timing{core_timing}, name{std::move(name_)} {
 
     release_event = Core::Timing::CreateEvent(
-        name, [this](u64 userdata, s64 cycles_late) { ReleaseActiveBuffer(cycles_late); });
+        name, [this](u64, std::chrono::nanoseconds ns_late) { ReleaseActiveBuffer(ns_late); });
 }
 
 void Stream::Play() {
@@ -78,7 +78,7 @@ static void VolumeAdjustSamples(std::vector<s16>& samples, float game_volume) {
     }
 }
 
-void Stream::PlayNextBuffer(s64 cycles_late) {
+void Stream::PlayNextBuffer(std::chrono::nanoseconds ns_late) {
     if (!IsPlaying()) {
         // Ensure we are in playing state before playing the next buffer
         sink_stream.Flush();
@@ -103,17 +103,18 @@ void Stream::PlayNextBuffer(s64 cycles_late) {
 
     sink_stream.EnqueueSamples(GetNumChannels(), active_buffer->GetSamples());
 
-    const auto time_stretch_delta = std::chrono::nanoseconds{
-        Settings::values.enable_audio_stretching.GetValue() ? 0 : cycles_late};
+    const auto time_stretch_delta = Settings::values.enable_audio_stretching.GetValue()
+                                        ? std::chrono::nanoseconds::zero()
+                                        : ns_late;
     const auto future_time = GetBufferReleaseNS(*active_buffer) - time_stretch_delta;
     core_timing.ScheduleEvent(future_time, release_event, {});
 }
 
-void Stream::ReleaseActiveBuffer(s64 cycles_late) {
+void Stream::ReleaseActiveBuffer(std::chrono::nanoseconds ns_late) {
     ASSERT(active_buffer);
     released_buffers.push(std::move(active_buffer));
     release_callback();
-    PlayNextBuffer(cycles_late);
+    PlayNextBuffer(ns_late);
 }
 
 bool Stream::QueueBuffer(BufferPtr&& buffer) {

--- a/src/audio_core/stream.h
+++ b/src/audio_core/stream.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <memory>
 #include <string>
@@ -96,10 +97,7 @@ private:
     void ReleaseActiveBuffer(s64 cycles_late = 0);
 
     /// Gets the number of core cycles when the specified buffer will be released
-    s64 GetBufferReleaseNS(const Buffer& buffer) const;
-
-    /// Gets the number of core cycles when the specified buffer will be released
-    s64 GetBufferReleaseNSHostTiming(const Buffer& buffer) const;
+    std::chrono::nanoseconds GetBufferReleaseNS(const Buffer& buffer) const;
 
     u32 sample_rate;                  ///< Sample rate of the stream
     Format format;                    ///< Format of the stream

--- a/src/audio_core/stream.h
+++ b/src/audio_core/stream.h
@@ -91,10 +91,10 @@ public:
 
 private:
     /// Plays the next queued buffer in the audio stream, starting playback if necessary
-    void PlayNextBuffer(s64 cycles_late = 0);
+    void PlayNextBuffer(std::chrono::nanoseconds ns_late = {});
 
     /// Releases the actively playing buffer, signalling that it has been completed
-    void ReleaseActiveBuffer(s64 cycles_late = 0);
+    void ReleaseActiveBuffer(std::chrono::nanoseconds ns_late = {});
 
     /// Gets the number of core cycles when the specified buffer will be released
     std::chrono::nanoseconds GetBufferReleaseNS(const Buffer& buffer) const;

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -53,7 +53,7 @@ void CoreTiming::ThreadEntry(CoreTiming& instance) {
     instance.ThreadLoop();
 }
 
-void CoreTiming::Initialize(std::function<void(void)>&& on_thread_init_) {
+void CoreTiming::Initialize(std::function<void()>&& on_thread_init_) {
     on_thread_init = std::move(on_thread_init_);
     event_fifo_id = 0;
     shutting_down = false;
@@ -106,11 +106,11 @@ bool CoreTiming::HasPendingEvents() const {
     return !(wait_set && event_queue.empty());
 }
 
-void CoreTiming::ScheduleEvent(s64 ns_into_future, const std::shared_ptr<EventType>& event_type,
-                               u64 userdata) {
+void CoreTiming::ScheduleEvent(std::chrono::nanoseconds ns_into_future,
+                               const std::shared_ptr<EventType>& event_type, u64 userdata) {
     {
         std::scoped_lock scope{basic_lock};
-        const u64 timeout = static_cast<u64>(GetGlobalTimeNs().count() + ns_into_future);
+        const u64 timeout = static_cast<u64>((GetGlobalTimeNs() + ns_into_future).count());
 
         event_queue.emplace_back(Event{timeout, event_fifo_id++, userdata, event_type});
 

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -17,14 +17,12 @@
 #include "common/common_types.h"
 #include "common/spin_lock.h"
 #include "common/thread.h"
-#include "common/threadsafe_queue.h"
 #include "common/wall_clock.h"
-#include "core/hardware_properties.h"
 
 namespace Core::Timing {
 
 /// A callback that may be scheduled for a particular core timing event.
-using TimedCallback = std::function<void(u64 userdata, s64 cycles_late)>;
+using TimedCallback = std::function<void(u64 userdata, std::chrono::nanoseconds ns_late)>;
 
 /// Contains the characteristics of a particular event.
 struct EventType {
@@ -42,12 +40,12 @@ struct EventType {
  * in main CPU clock cycles.
  *
  * To schedule an event, you first have to register its type. This is where you pass in the
- * callback. You then schedule events using the type id you get back.
+ * callback. You then schedule events using the type ID you get back.
  *
- * The int cyclesLate that the callbacks get is how many cycles late it was.
+ * The s64 ns_late that the callbacks get is how many ns late it was.
  * So to schedule a new event on a regular basis:
  * inside callback:
- *   ScheduleEvent(periodInCycles - cyclesLate, callback, "whatever")
+ *   ScheduleEvent(period_in_ns - ns_late, callback, "whatever")
  */
 class CoreTiming {
 public:

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -62,7 +62,7 @@ public:
 
     /// CoreTiming begins at the boundary of timing slice -1. An initial call to Advance() is
     /// required to end slice - 1 and start slice 0 before the first cycle of code is executed.
-    void Initialize(std::function<void(void)>&& on_thread_init_);
+    void Initialize(std::function<void()>&& on_thread_init_);
 
     /// Tears down all timing related functionality.
     void Shutdown();
@@ -95,8 +95,8 @@ public:
     bool HasPendingEvents() const;
 
     /// Schedules an event in core timing
-    void ScheduleEvent(s64 ns_into_future, const std::shared_ptr<EventType>& event_type,
-                       u64 userdata = 0);
+    void ScheduleEvent(std::chrono::nanoseconds ns_into_future,
+                       const std::shared_ptr<EventType>& event_type, u64 userdata = 0);
 
     void UnscheduleEvent(const std::shared_ptr<EventType>& event_type, u64 userdata);
 
@@ -161,7 +161,7 @@ private:
     std::atomic<bool> wait_set{};
     std::atomic<bool> shutting_down{};
     std::atomic<bool> has_started{};
-    std::function<void(void)> on_thread_init{};
+    std::function<void()> on_thread_init{};
 
     bool is_multicore{};
 

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -139,8 +139,6 @@ private:
 
     u64 global_timer = 0;
 
-    std::chrono::nanoseconds start_point;
-
     // The queue is a min-heap using std::make_heap/push_heap/pop_heap.
     // We don't use std::priority_queue because we need to be able to serialize, unserialize and
     // erase arbitrary events (RemoveEvent()) regardless of the queue order. These aren't

--- a/src/core/hardware_interrupt_manager.cpp
+++ b/src/core/hardware_interrupt_manager.cpp
@@ -23,7 +23,7 @@ InterruptManager::~InterruptManager() = default;
 
 void InterruptManager::GPUInterruptSyncpt(const u32 syncpoint_id, const u32 value) {
     const u64 msg = (static_cast<u64>(syncpoint_id) << 32ULL) | value;
-    system.CoreTiming().ScheduleEvent(10, gpu_interrupt_event, msg);
+    system.CoreTiming().ScheduleEvent(std::chrono::nanoseconds{10}, gpu_interrupt_event, msg);
 }
 
 } // namespace Core::Hardware

--- a/src/core/hardware_interrupt_manager.cpp
+++ b/src/core/hardware_interrupt_manager.cpp
@@ -11,12 +11,13 @@
 namespace Core::Hardware {
 
 InterruptManager::InterruptManager(Core::System& system_in) : system(system_in) {
-    gpu_interrupt_event = Core::Timing::CreateEvent("GPUInterrupt", [this](u64 message, s64) {
-        auto nvdrv = system.ServiceManager().GetService<Service::Nvidia::NVDRV>("nvdrv");
-        const u32 syncpt = static_cast<u32>(message >> 32);
-        const u32 value = static_cast<u32>(message);
-        nvdrv->SignalGPUInterruptSyncpt(syncpt, value);
-    });
+    gpu_interrupt_event =
+        Core::Timing::CreateEvent("GPUInterrupt", [this](u64 message, std::chrono::nanoseconds) {
+            auto nvdrv = system.ServiceManager().GetService<Service::Nvidia::NVDRV>("nvdrv");
+            const u32 syncpt = static_cast<u32>(message >> 32);
+            const u32 value = static_cast<u32>(message);
+            nvdrv->SignalGPUInterruptSyncpt(syncpt, value);
+        });
 }
 
 InterruptManager::~InterruptManager() = default;

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -149,11 +149,13 @@ struct KernelCore::Impl {
                     SchedulerLock lock(kernel);
                     global_scheduler.PreemptThreads();
                 }
-                s64 time_interval = Core::Timing::msToCycles(std::chrono::milliseconds(10));
+                const auto time_interval = std::chrono::nanoseconds{
+                    Core::Timing::msToCycles(std::chrono::milliseconds(10))};
                 system.CoreTiming().ScheduleEvent(time_interval, preemption_event);
             });
 
-        s64 time_interval = Core::Timing::msToCycles(std::chrono::milliseconds(10));
+        const auto time_interval =
+            std::chrono::nanoseconds{Core::Timing::msToCycles(std::chrono::milliseconds(10))};
         system.CoreTiming().ScheduleEvent(time_interval, preemption_event);
     }
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -144,7 +144,7 @@ struct KernelCore::Impl {
 
     void InitializePreemption(KernelCore& kernel) {
         preemption_event = Core::Timing::CreateEvent(
-            "PreemptionCallback", [this, &kernel](u64 userdata, s64 cycles_late) {
+            "PreemptionCallback", [this, &kernel](u64, std::chrono::nanoseconds) {
                 {
                     SchedulerLock lock(kernel);
                     global_scheduler.PreemptThreads();

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -34,7 +34,7 @@ ResultVal<std::shared_ptr<ServerSession>> ServerSession::Create(KernelCore& kern
     std::shared_ptr<ServerSession> session{std::make_shared<ServerSession>(kernel)};
 
     session->request_event = Core::Timing::CreateEvent(
-        name, [session](u64 userdata, s64 cycles_late) { session->CompleteSyncRequest(); });
+        name, [session](u64, std::chrono::nanoseconds) { session->CompleteSyncRequest(); });
     session->name = std::move(name);
     session->parent = std::move(parent);
 

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -184,8 +184,8 @@ ResultCode ServerSession::CompleteSyncRequest() {
 
 ResultCode ServerSession::HandleSyncRequest(std::shared_ptr<Thread> thread,
                                             Core::Memory::Memory& memory) {
-    ResultCode result = QueueSyncRequest(std::move(thread), memory);
-    const u64 delay = kernel.IsMulticore() ? 0U : 20000U;
+    const ResultCode result = QueueSyncRequest(std::move(thread), memory);
+    const auto delay = std::chrono::nanoseconds{kernel.IsMulticore() ? 0 : 20000};
     Core::System::GetInstance().CoreTiming().ScheduleEvent(delay, request_event, {});
     return result;
 }

--- a/src/core/hle/kernel/time_manager.cpp
+++ b/src/core/hle/kernel/time_manager.cpp
@@ -34,7 +34,8 @@ void TimeManager::ScheduleTimeEvent(Handle& event_handle, Thread* timetask, s64 
         ASSERT(timetask);
         ASSERT(timetask->GetStatus() != ThreadStatus::Ready);
         ASSERT(timetask->GetStatus() != ThreadStatus::WaitMutex);
-        system.CoreTiming().ScheduleEvent(nanoseconds, time_manager_event_type, event_handle);
+        system.CoreTiming().ScheduleEvent(std::chrono::nanoseconds{nanoseconds},
+                                          time_manager_event_type, event_handle);
     } else {
         event_handle = InvalidHandle;
     }

--- a/src/core/hle/kernel/time_manager.cpp
+++ b/src/core/hle/kernel/time_manager.cpp
@@ -16,7 +16,7 @@ namespace Kernel {
 
 TimeManager::TimeManager(Core::System& system_) : system{system_} {
     time_manager_event_type = Core::Timing::CreateEvent(
-        "Kernel::TimeManagerCallback", [this](u64 thread_handle, [[maybe_unused]] s64 cycles_late) {
+        "Kernel::TimeManagerCallback", [this](u64 thread_handle, std::chrono::nanoseconds) {
             SchedulerLock lock(system.Kernel());
             Handle proper_handle = static_cast<Handle>(thread_handle);
             if (cancelled_events[proper_handle]) {

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -4,10 +4,9 @@
 
 #pragma once
 
-#include "core/hle/service/hid/controllers/controller_base.h"
-#include "core/hle/service/service.h"
+#include <chrono>
 
-#include "controllers/controller_base.h"
+#include "core/hle/service/hid/controllers/controller_base.h"
 #include "core/hle/service/service.h"
 
 namespace Core::Timing {
@@ -65,7 +64,7 @@ private:
     }
 
     void GetSharedMemoryHandle(Kernel::HLERequestContext& ctx);
-    void UpdateControllers(u64 userdata, s64 cycles_late);
+    void UpdateControllers(u64 userdata, std::chrono::nanoseconds ns_late);
 
     std::shared_ptr<Kernel::SharedMemory> shared_mem;
 

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -28,8 +28,7 @@
 
 namespace Service::NVFlinger {
 
-constexpr s64 frame_ticks = static_cast<s64>(1000000000 / 60);
-constexpr s64 frame_ticks_30fps = static_cast<s64>(1000000000 / 30);
+constexpr auto frame_ns = std::chrono::nanoseconds{1000000000 / 60};
 
 void NVFlinger::VSyncThread(NVFlinger& nv_flinger) {
     nv_flinger.SplitVSync();
@@ -71,16 +70,20 @@ NVFlinger::NVFlinger(Core::System& system) : system(system) {
         Core::Timing::CreateEvent("ScreenComposition", [this](u64 userdata, s64 ns_late) {
             Lock();
             Compose();
-            const auto ticks = GetNextTicks();
-            this->system.CoreTiming().ScheduleEvent(std::max<s64>(0LL, ticks - ns_late),
-                                                    composition_event);
+
+            const auto ticks = std::chrono::nanoseconds{GetNextTicks()};
+            const auto ticks_delta = ticks - std::chrono::nanoseconds{ns_late};
+            const auto future_ns = std::max(std::chrono::nanoseconds::zero(), ticks_delta);
+
+            this->system.CoreTiming().ScheduleEvent(future_ns, composition_event);
         });
+
     if (system.IsMulticore()) {
         is_running = true;
         wait_event = std::make_unique<Common::Event>();
         vsync_thread = std::make_unique<std::thread>(VSyncThread, std::ref(*this));
     } else {
-        system.CoreTiming().ScheduleEvent(frame_ticks, composition_event);
+        system.CoreTiming().ScheduleEvent(frame_ns, composition_event);
     }
 }
 

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -66,13 +66,13 @@ NVFlinger::NVFlinger(Core::System& system) : system(system) {
     guard = std::make_shared<std::mutex>();
 
     // Schedule the screen composition events
-    composition_event =
-        Core::Timing::CreateEvent("ScreenComposition", [this](u64 userdata, s64 ns_late) {
+    composition_event = Core::Timing::CreateEvent(
+        "ScreenComposition", [this](u64, std::chrono::nanoseconds ns_late) {
             Lock();
             Compose();
 
             const auto ticks = std::chrono::nanoseconds{GetNextTicks()};
-            const auto ticks_delta = ticks - std::chrono::nanoseconds{ns_late};
+            const auto ticks_delta = ticks - ns_late;
             const auto future_ns = std::max(std::chrono::nanoseconds::zero(), ticks_delta);
 
             this->system.CoreTiming().ScheduleEvent(future_ns, composition_event);

--- a/src/core/memory/cheat_engine.cpp
+++ b/src/core/memory/cheat_engine.cpp
@@ -20,7 +20,7 @@
 
 namespace Core::Memory {
 
-constexpr s64 CHEAT_ENGINE_TICKS = static_cast<s64>(1000000000 / 12);
+constexpr auto CHEAT_ENGINE_NS = std::chrono::nanoseconds{1000000000 / 12};
 constexpr u32 KEYPAD_BITMASK = 0x3FFFFFF;
 
 StandardVmCallbacks::StandardVmCallbacks(Core::System& system, const CheatProcessMetadata& metadata)
@@ -191,7 +191,7 @@ void CheatEngine::Initialize() {
     event = Core::Timing::CreateEvent(
         "CheatEngine::FrameCallback::" + Common::HexToString(metadata.main_nso_build_id),
         [this](u64 userdata, s64 ns_late) { FrameCallback(userdata, ns_late); });
-    core_timing.ScheduleEvent(CHEAT_ENGINE_TICKS, event);
+    core_timing.ScheduleEvent(CHEAT_ENGINE_NS, event);
 
     metadata.process_id = system.CurrentProcess()->GetProcessID();
     metadata.title_id = system.CurrentProcess()->GetTitleID();
@@ -230,7 +230,8 @@ void CheatEngine::FrameCallback(u64 userdata, s64 ns_late) {
 
     vm.Execute(metadata);
 
-    core_timing.ScheduleEvent(CHEAT_ENGINE_TICKS - ns_late, event);
+    const auto future_ns = CHEAT_ENGINE_NS - std::chrono::nanoseconds{ns_late};
+    core_timing.ScheduleEvent(future_ns, event);
 }
 
 } // namespace Core::Memory

--- a/src/core/memory/cheat_engine.h
+++ b/src/core/memory/cheat_engine.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include <vector>
 #include "common/common_types.h"
@@ -71,7 +72,7 @@ public:
     void Reload(std::vector<CheatEntry> cheats);
 
 private:
-    void FrameCallback(u64 userdata, s64 cycles_late);
+    void FrameCallback(u64 userdata, std::chrono::nanoseconds ns_late);
 
     DmntCheatVm vm;
     CheatProcessMetadata metadata;

--- a/src/core/tools/freezer.h
+++ b/src/core/tools/freezer.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <atomic>
+#include <chrono>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -72,7 +73,7 @@ public:
     std::vector<Entry> GetEntries() const;
 
 private:
-    void FrameCallback(u64 userdata, s64 cycles_late);
+    void FrameCallback(u64 userdata, std::chrono::nanoseconds ns_late);
     void FillEntryReads();
 
     std::atomic_bool active{false};

--- a/src/tests/core/core_timing.cpp
+++ b/src/tests/core/core_timing.cpp
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <bitset>
+#include <chrono>
 #include <cstdlib>
 #include <memory>
 #include <string>
@@ -17,7 +18,6 @@
 namespace {
 // Numbers are chosen randomly to make sure the correct one is given.
 constexpr std::array<u64, 5> CB_IDS{{42, 144, 93, 1026, UINT64_C(0xFFFF7FFFF7FFFF)}};
-constexpr int MAX_SLICE_LENGTH = 10000; // Copied from CoreTiming internals
 constexpr std::array<u64, 5> calls_order{{2, 0, 1, 4, 3}};
 std::array<s64, 5> delays{};
 
@@ -25,12 +25,12 @@ std::bitset<CB_IDS.size()> callbacks_ran_flags;
 u64 expected_callback = 0;
 
 template <unsigned int IDX>
-void HostCallbackTemplate(u64 userdata, s64 nanoseconds_late) {
+void HostCallbackTemplate(u64 userdata, std::chrono::nanoseconds ns_late) {
     static_assert(IDX < CB_IDS.size(), "IDX out of range");
     callbacks_ran_flags.set(IDX);
     REQUIRE(CB_IDS[IDX] == userdata);
     REQUIRE(CB_IDS[IDX] == CB_IDS[calls_order[expected_callback]]);
-    delays[IDX] = nanoseconds_late;
+    delays[IDX] = ns_late.count();
     ++expected_callback;
 }
 
@@ -77,10 +77,12 @@ TEST_CASE("CoreTiming[BasicOrder]", "[core]") {
 
     core_timing.SyncPause(true);
 
-    u64 one_micro = 1000U;
+    const u64 one_micro = 1000U;
     for (std::size_t i = 0; i < events.size(); i++) {
-        u64 order = calls_order[i];
-        core_timing.ScheduleEvent(i * one_micro + 100U, events[order], CB_IDS[order]);
+        const u64 order = calls_order[i];
+        const auto future_ns = std::chrono::nanoseconds{static_cast<s64>(i * one_micro + 100)};
+
+        core_timing.ScheduleEvent(future_ns, events[order], CB_IDS[order]);
     }
     /// test pause
     REQUIRE(callbacks_ran_flags.none());

--- a/src/tests/core/core_timing.cpp
+++ b/src/tests/core/core_timing.cpp
@@ -116,13 +116,16 @@ TEST_CASE("CoreTiming[BasicOrderNoPausing]", "[core]") {
 
     expected_callback = 0;
 
-    u64 start = core_timing.GetGlobalTimeNs().count();
-    u64 one_micro = 1000U;
+    const u64 start = core_timing.GetGlobalTimeNs().count();
+    const u64 one_micro = 1000U;
+
     for (std::size_t i = 0; i < events.size(); i++) {
-        u64 order = calls_order[i];
-        core_timing.ScheduleEvent(i * one_micro + 100U, events[order], CB_IDS[order]);
+        const u64 order = calls_order[i];
+        const auto future_ns = std::chrono::nanoseconds{static_cast<s64>(i * one_micro + 100)};
+        core_timing.ScheduleEvent(future_ns, events[order], CB_IDS[order]);
     }
-    u64 end = core_timing.GetGlobalTimeNs().count();
+
+    const u64 end = core_timing.GetGlobalTimeNs().count();
     const double scheduling_time = static_cast<double>(end - start);
     const double timer_time = static_cast<double>(TestTimerSpeed(core_timing));
 


### PR DESCRIPTION
In a bunch of places we were using std::chrono types and in a bunch of other places, we were using raw primitive types. This aims to make it more consistent by using std::chrono::nanoseconds across the board, which makes for more consistent expectations when using the interface.