### PR TITLE
configuration: Toggle controller vibrations

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -504,7 +504,7 @@ void Controller_NPad::VibrateController(const std::vector<u32>& controller_ids,
                                         const std::vector<Vibration>& vibrations) {
     LOG_DEBUG(Service_HID, "(STUBBED) called");
 
-    if (!can_controllers_vibrate) {
+    if (!Settings::values.vibration_enabled || !can_controllers_vibrate) {
         return;
     }
     for (std::size_t i = 0; i < controller_ids.size(); i++) {

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -845,8 +845,7 @@ void Hid::CreateActiveVibrationDeviceList(Kernel::HLERequestContext& ctx) {
 void Hid::PermitVibration(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const auto can_vibrate{rp.Pop<bool>()};
-    applet_resource->GetController<Controller_NPad>(HidController::NPad)
-        .SetVibrationEnabled(can_vibrate);
+    Settings::values.vibration_enabled = can_vibrate;
 
     LOG_DEBUG(Service_HID, "called, can_vibrate={}", can_vibrate);
 
@@ -859,8 +858,7 @@ void Hid::IsVibrationPermitted(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
-    rb.Push(
-        applet_resource->GetController<Controller_NPad>(HidController::NPad).IsVibrationEnabled());
+    rb.Push(Settings::values.vibration_enabled);
 }
 
 void Hid::ActivateConsoleSixAxisSensor(Kernel::HLERequestContext& ctx) {

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -457,6 +457,8 @@ struct Values {
     // Controls
     std::array<PlayerInput, 10> players;
 
+    bool use_docked_mode;
+
     bool mouse_enabled;
     std::string mouse_device;
     MouseButtonsRaw mouse_buttons;
@@ -470,13 +472,14 @@ struct Values {
     AnalogsRaw debug_pad_analogs;
 
     std::string motion_device;
+
+    bool vibration_enabled;
+
     TouchscreenInput touchscreen;
     std::atomic_bool is_device_reload_pending{true};
     std::string udp_input_address;
     u16 udp_input_port;
     u8 udp_pad_index;
-
-    bool use_docked_mode;
 
     // Data Storage
     bool use_virtual_sd;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -431,6 +431,8 @@ void Config::ReadControlValues() {
     ReadMouseValues();
     ReadTouchscreenValues();
 
+    Settings::values.vibration_enabled =
+        ReadSetting(QStringLiteral("vibration_enabled"), true).toBool();
     Settings::values.motion_device =
         ReadSetting(QStringLiteral("motion_device"),
                     QStringLiteral("engine:motion_emu,update_period:100,sensitivity:0.01"))
@@ -988,6 +990,7 @@ void Config::SaveControlValues() {
     SaveMouseValues();
     SaveTouchscreenValues();
 
+    WriteSetting(QStringLiteral("vibration_enabled"), Settings::values.vibration_enabled, true);
     WriteSetting(QStringLiteral("motion_device"),
                  QString::fromStdString(Settings::values.motion_device),
                  QStringLiteral("engine:motion_emu,update_period:100,sensitivity:0.01"));

--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -92,6 +92,8 @@ ConfigureInput::ConfigureInput(QWidget* parent)
     connect(ui->mouse_enabled, &QCheckBox::stateChanged, this, &ConfigureInput::UpdateUIEnabled);
     connect(ui->keyboard_enabled, &QCheckBox::stateChanged, this, &ConfigureInput::UpdateUIEnabled);
     connect(ui->debug_enabled, &QCheckBox::stateChanged, this, &ConfigureInput::UpdateUIEnabled);
+    connect(ui->vibration_enabled, &QCheckBox::stateChanged, this,
+            &ConfigureInput::UpdateUIEnabled);
     connect(ui->touchscreen_enabled, &QCheckBox::stateChanged, this,
             &ConfigureInput::UpdateUIEnabled);
 
@@ -138,6 +140,7 @@ void ConfigureInput::ApplyConfiguration() {
     Settings::values.debug_pad_enabled = ui->debug_enabled->isChecked();
     Settings::values.mouse_enabled = ui->mouse_enabled->isChecked();
     Settings::values.keyboard_enabled = ui->keyboard_enabled->isChecked();
+    Settings::values.vibration_enabled = ui->vibration_enabled->isChecked();
     Settings::values.touchscreen.enabled = ui->touchscreen_enabled->isChecked();
 }
 
@@ -209,6 +212,7 @@ void ConfigureInput::LoadConfiguration() {
     ui->debug_enabled->setChecked(Settings::values.debug_pad_enabled);
     ui->mouse_enabled->setChecked(Settings::values.mouse_enabled);
     ui->keyboard_enabled->setChecked(Settings::values.keyboard_enabled);
+    ui->vibration_enabled->setChecked(Settings::values.vibration_enabled);
     ui->touchscreen_enabled->setChecked(Settings::values.touchscreen.enabled);
 
     UpdateUIEnabled();
@@ -234,6 +238,7 @@ void ConfigureInput::RestoreDefaults() {
     ui->mouse_enabled->setCheckState(Qt::Unchecked);
     ui->keyboard_enabled->setCheckState(Qt::Unchecked);
     ui->debug_enabled->setCheckState(Qt::Unchecked);
+    ui->vibration_enabled->setCheckState(Qt::Checked);
     ui->touchscreen_enabled->setCheckState(Qt::Checked);
     UpdateUIEnabled();
 }

--- a/src/yuzu/configuration/configure_input.ui
+++ b/src/yuzu/configuration/configure_input.ui
@@ -337,14 +337,15 @@
         <string>Other</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_3">
+       <item row="0" column="1">
+         <widget class="QCheckBox" name="mouse_enabled">
+          <property name="text">
+           <string>Mouse</string>
+          </property>
+         </widget>
+        </item>
         <item row="1" column="1">
          <widget class="QCheckBox" name="keyboard_enabled">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>23</height>
-           </size>
-          </property>
           <property name="text">
            <string>Keyboard</string>
           </property>
@@ -358,22 +359,16 @@
          </widget>
         </item>
         <item row="3" column="1">
-         <widget class="QCheckBox" name="touchscreen_enabled">
+         <widget class="QCheckBox" name="vibration_enabled">
           <property name="text">
-           <string>Touchscreen</string>
+           <string>Controller Vibration</string>
           </property>
          </widget>
         </item>
-        <item row="0" column="1">
-         <widget class="QCheckBox" name="mouse_enabled">
-          <property name="minimumSize">
-           <size>
-            <width>0</width>
-            <height>23</height>
-           </size>
-          </property>
+        <item row="4" column="1">
+         <widget class="QCheckBox" name="touchscreen_enabled">
           <property name="text">
-           <string>Mouse</string>
+           <string>Touchscreen</string>
           </property>
          </widget>
         </item>
@@ -419,7 +414,7 @@
           </property>
          </spacer>
         </item>
-        <item row="3" column="3">
+        <item row="4" column="3">
          <widget class="QPushButton" name="touchscreen_advanced">
           <property name="text">
            <string>Advanced</string>

--- a/src/yuzu/configuration/configure_input_simple.cpp
+++ b/src/yuzu/configuration/configure_input_simple.cpp
@@ -50,6 +50,7 @@ void HandheldOnProfileSelect() {
     Settings::values.keyboard_enabled = false;
     Settings::values.mouse_enabled = false;
     Settings::values.debug_pad_enabled = false;
+    Settings::values.vibration_enabled = true;
     Settings::values.touchscreen.enabled = true;
 }
 
@@ -65,6 +66,7 @@ void DualJoyconsDockedOnProfileSelect() {
     Settings::values.keyboard_enabled = false;
     Settings::values.mouse_enabled = false;
     Settings::values.debug_pad_enabled = false;
+    Settings::values.vibration_enabled = true;
     Settings::values.touchscreen.enabled = true;
 }
 

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -286,6 +286,8 @@ void Config::ReadValues() {
             Settings::values.debug_pad_analogs[i] = default_param;
     }
 
+    Settings::values.vibration_enabled =
+        sdl2_config->GetBoolean("ControlsGeneral", "vibration_enabled", true);
     Settings::values.touchscreen.enabled =
         sdl2_config->GetBoolean("ControlsGeneral", "touch_enabled", true);
     Settings::values.touchscreen.device =

--- a/src/yuzu_tester/config.cpp
+++ b/src/yuzu_tester/config.cpp
@@ -74,6 +74,7 @@ void Config::ReadValues() {
         Settings::values.debug_pad_analogs[i] = "";
     }
 
+    Settings::values.vibration_enabled = true;
     Settings::values.touchscreen.enabled = "";
     Settings::values.touchscreen.device = "";
     Settings::values.touchscreen.finger = 0;


### PR DESCRIPTION
Allow toggling controller vibrations on/off, this is exactly the same as the setting found in System Settings on hardware.

This setting is enabled by default

Does not conflict with #4291 

![image](https://user-images.githubusercontent.com/39850852/87690104-03ea7280-c757-11ea-9951-367a96100868.png)
