### PR TITLE
kernel/thread: Remove unimplemented function prototype

### DIFF
--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -583,8 +583,6 @@ private:
 
     void SetCurrentPriority(u32 new_priority);
 
-    void AdjustSchedulingOnAffinity(u64 old_affinity_mask, s32 old_core);
-
     Common::SpinLock context_guard{};
     ThreadContext32 context_32{};
     ThreadContext64 context_64{};


### PR DESCRIPTION
This isn't used, so it can be removed.