### PR TITLE
vk_graphics_pipeline: Resolve narrowing warnings

### DIFF
--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -307,8 +307,10 @@ vk::Pipeline VKGraphicsPipeline::CreatePipeline(const RenderPassParams& renderpa
         .sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
         .pNext = nullptr,
         .flags = 0,
-        .depthClampEnable = state.depth_clamp_disabled == 0 ? VK_TRUE : VK_FALSE,
-        .rasterizerDiscardEnable = state.rasterize_enable == 0 ? VK_TRUE : VK_FALSE,
+        .depthClampEnable =
+            static_cast<VkBool32>(state.depth_clamp_disabled == 0 ? VK_TRUE : VK_FALSE),
+        .rasterizerDiscardEnable =
+            static_cast<VkBool32>(state.rasterize_enable == 0 ? VK_TRUE : VK_FALSE),
         .polygonMode = VK_POLYGON_MODE_FILL,
         .cullMode =
             dynamic.cull_enable ? MaxwellToVK::CullFace(dynamic.CullFace()) : VK_CULL_MODE_NONE,


### PR DESCRIPTION
For whatever reason, VK_TRUE and VK_FALSE aren't defined as having a VkBool32 type, so we need to cast to it explicitly.