### PR TITLE
core/CMakeLists: Add missing physical_memory.h header file

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -185,6 +185,7 @@ add_library(core STATIC
     hle/kernel/object.h
     hle/kernel/physical_core.cpp
     hle/kernel/physical_core.h
+    hle/kernel/physical_memory.h
     hle/kernel/process.cpp
     hle/kernel/process.h
     hle/kernel/process_capability.cpp


### PR DESCRIPTION
Allows this header file to show up in IDE CMake generators.