### PR TITLE
frontend: Improve wait tree readability for dark themes

### DIFF
--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -2,9 +2,11 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <array>
 #include <fmt/format.h>
 
 #include "yuzu/debugger/wait_tree.h"
+#include "yuzu/uisettings.h"
 #include "yuzu/util/util.h"
 
 #include "common/assert.h"
@@ -19,11 +21,37 @@
 #include "core/hle/kernel/thread.h"
 #include "core/memory.h"
 
+namespace {
+
+constexpr std::array<std::array<Qt::GlobalColor, 2>, 10> WaitTreeColors{{
+    {Qt::GlobalColor::darkGreen, Qt::GlobalColor::green},
+    {Qt::GlobalColor::darkGreen, Qt::GlobalColor::green},
+    {Qt::GlobalColor::darkBlue, Qt::GlobalColor::cyan},
+    {Qt::GlobalColor::lightGray, Qt::GlobalColor::lightGray},
+    {Qt::GlobalColor::lightGray, Qt::GlobalColor::lightGray},
+    {Qt::GlobalColor::darkRed, Qt::GlobalColor::red},
+    {Qt::GlobalColor::darkYellow, Qt::GlobalColor::yellow},
+    {Qt::GlobalColor::red, Qt::GlobalColor::red},
+    {Qt::GlobalColor::darkCyan, Qt::GlobalColor::cyan},
+    {Qt::GlobalColor::gray, Qt::GlobalColor::gray},
+}};
+
+bool IsDarkTheme() {
+    const auto theme = UISettings::values.theme.toStdString();
+    return theme == "qdarkstyle" || theme == "colorful_dark";
+}
+
+} // namespace
+
 WaitTreeItem::WaitTreeItem() = default;
 WaitTreeItem::~WaitTreeItem() = default;
 
 QColor WaitTreeItem::GetColor() const {
-    return QColor(Qt::GlobalColor::black);
+    if (IsDarkTheme()) {
+        return QColor(Qt::GlobalColor::white);
+    } else {
+        return QColor(Qt::GlobalColor::black);
+    }
 }
 
 std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeItem::GetChildren() const {
@@ -263,36 +291,41 @@ QString WaitTreeThread::GetText() const {
 }
 
 QColor WaitTreeThread::GetColor() const {
+    std::size_t color_index = 0;
+    if (IsDarkTheme()) {
+        color_index = 1;
+    }
+
     const auto& thread = static_cast<const Kernel::Thread&>(object);
     switch (thread.GetStatus()) {
     case Kernel::ThreadStatus::Running:
-        return QColor(Qt::GlobalColor::darkGreen);
+        return QColor(WaitTreeColors[0][color_index]);
     case Kernel::ThreadStatus::Ready:
         if (!thread.IsPaused()) {
             if (thread.WasRunning()) {
-                return QColor(Qt::GlobalColor::darkGreen);
+                return QColor(WaitTreeColors[1][color_index]);
             } else {
-                return QColor(Qt::GlobalColor::darkBlue);
+                return QColor(WaitTreeColors[2][color_index]);
             }
         } else {
-            return QColor(Qt::GlobalColor::lightGray);
+            return QColor(WaitTreeColors[3][color_index]);
         }
     case Kernel::ThreadStatus::Paused:
-        return QColor(Qt::GlobalColor::lightGray);
+        return QColor(WaitTreeColors[4][color_index]);
     case Kernel::ThreadStatus::WaitHLEEvent:
     case Kernel::ThreadStatus::WaitIPC:
-        return QColor(Qt::GlobalColor::darkRed);
+        return QColor(WaitTreeColors[5][color_index]);
     case Kernel::ThreadStatus::WaitSleep:
-        return QColor(Qt::GlobalColor::darkYellow);
+        return QColor(WaitTreeColors[6][color_index]);
     case Kernel::ThreadStatus::WaitSynch:
     case Kernel::ThreadStatus::WaitMutex:
     case Kernel::ThreadStatus::WaitCondVar:
     case Kernel::ThreadStatus::WaitArb:
-        return QColor(Qt::GlobalColor::red);
+        return QColor(WaitTreeColors[7][color_index]);
     case Kernel::ThreadStatus::Dormant:
-        return QColor(Qt::GlobalColor::darkCyan);
+        return QColor(WaitTreeColors[8][color_index]);
     case Kernel::ThreadStatus::Dead:
-        return QColor(Qt::GlobalColor::gray);
+        return QColor(WaitTreeColors[9][color_index]);
     default:
         return WaitTreeItem::GetColor();
     }

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -37,8 +37,8 @@ constexpr std::array<std::array<Qt::GlobalColor, 2>, 10> WaitTreeColors{{
 }};
 
 bool IsDarkTheme() {
-    const auto theme = UISettings::values.theme.toStdString();
-    return theme == "qdarkstyle" || theme == "colorful_dark";
+    const auto& theme = UISettings::values.theme;
+    return theme == QStringLiteral("qdarkstyle") || theme == QStringLiteral("colorful_dark");
 }
 
 } // namespace
@@ -291,10 +291,7 @@ QString WaitTreeThread::GetText() const {
 }
 
 QColor WaitTreeThread::GetColor() const {
-    std::size_t color_index = 0;
-    if (IsDarkTheme()) {
-        color_index = 1;
-    }
+    const std::size_t color_index = IsDarkTheme() ? 1 : 0;
 
     const auto& thread = static_cast<const Kernel::Thread&>(object);
     switch (thread.GetStatus()) {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/25727384/87850577-a57aeb00-c934-11ea-8ea9-8d16605e426a.png)

After:
![image](https://user-images.githubusercontent.com/25727384/87850573-93994800-c934-11ea-8cea-7df686e3fd9c.png)

