### PR TITLE
Port Travis fixes from Citra (citra-emu/citra#5317 & citra-emu/citra#5332)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
     - os: osx
       env: NAME="macos build"
       sudo: false
-      osx_image: xcode10.2
+      osx_image: xcode10
       install: "./.travis/macos/deps.sh"
       script: "./.travis/macos/build.sh"
       after_success: "./.travis/macos/upload.sh"

--- a/.travis/linux/upload.sh
+++ b/.travis/linux/upload.sh
@@ -8,7 +8,7 @@ COMPRESSION_FLAGS="-cJvf"
 
 mkdir "$REV_NAME"
 
-cp build/bin/yuzu-cmd "$REV_NAME"
-cp build/bin/yuzu "$REV_NAME"
+cp build/bin/Release/yuzu-cmd "$REV_NAME"
+cp build/bin/Release/yuzu "$REV_NAME"
 
 . .travis/common/post-upload.sh

--- a/.travis/macos/build.sh
+++ b/.travis/macos/build.sh
@@ -5,7 +5,12 @@ set -o pipefail
 export MACOSX_DEPLOYMENT_TARGET=10.14
 export Qt5_DIR=$(brew --prefix)/opt/qt5
 export UNICORNDIR=$(pwd)/externals/unicorn
-export PATH="/usr/local/opt/ccache/libexec:$PATH"
+export PATH="/usr/local/opt/ccache/libexec:/usr/local/opt/llvm/bin:$PATH"
+
+export CC="clang"
+export CXX="clang++"
+export LDFLAGS="-L/usr/local/opt/llvm/lib"
+export CPPFLAGS="-I/usr/local/opt/llvm/include"
 
 # TODO: Build using ninja instead of make
 mkdir build && cd build

--- a/.travis/macos/deps.sh
+++ b/.travis/macos/deps.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -ex
 
 brew update
-brew install p7zip qt5 sdl2 ccache
+brew install p7zip qt5 sdl2 ccache llvm
 brew outdated cmake || brew upgrade cmake
 pip3 install macpack

--- a/.travis/macos/upload.sh
+++ b/.travis/macos/upload.sh
@@ -8,8 +8,8 @@ COMPRESSION_FLAGS="-czvf"
 
 mkdir "$REV_NAME"
 
-cp build/bin/yuzu-cmd "$REV_NAME"
-cp -r build/bin/yuzu.app "$REV_NAME"
+cp build/bin/Release/yuzu-cmd "$REV_NAME"
+cp -r build/bin/Release/yuzu.app "$REV_NAME"
 
 # move libs into folder for deployment
 macpack "${REV_NAME}/yuzu.app/Contents/MacOS/yuzu" -d "../Frameworks"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ else()
 endif()
 
 # Output binaries to bin/
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin/$<CONFIG>)
 
 # System imported libraries
 # If not found, download any missing through Conan


### PR DESCRIPTION
See https://github.com/citra-emu/citra/pull/5317 and https://github.com/citra-emu/citra/pull/5332 for more details.

Even though we don't use Travis anymore on yuzu, it makes sense to keep it and our CMake definitions up to date with Citra.