### PR TITLE
alignment: unbreak build with Clang

### DIFF
--- a/src/common/alignment.h
+++ b/src/common/alignment.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include <cstddef>
+#include <new>
 #include <type_traits>
 
 namespace Common {


### PR DESCRIPTION
Regressed by #4373. `std::align_val_t` is defined in `<new>` (previously, bootlegged via `<new>`) but GCC 10 can use `std::align_val_t` without any headers.

https://en.cppreference.com/w/cpp/memory/new/align_val_t