### PR TITLE
main: Fix Open Save/Mod Locations for installed titles

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -502,10 +502,10 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, std::string pat
     navigate_to_gamedb_entry->setVisible(it != compatibility_list.end() && program_id != 0);
 
     connect(open_save_location, &QAction::triggered, [this, program_id, path]() {
-        emit OpenFolderRequested(GameListOpenTarget::SaveData, path);
+        emit OpenFolderRequested(program_id, GameListOpenTarget::SaveData, path);
     });
     connect(open_mod_location, &QAction::triggered, [this, program_id, path]() {
-        emit OpenFolderRequested(GameListOpenTarget::ModData, path);
+        emit OpenFolderRequested(program_id, GameListOpenTarget::ModData, path);
     });
     connect(open_transferable_shader_cache, &QAction::triggered,
             [this, program_id]() { emit OpenTransferableShaderCacheRequested(program_id); });

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -84,7 +84,8 @@ public:
 signals:
     void GameChosen(QString game_path);
     void ShouldCancelWorker();
-    void OpenFolderRequested(GameListOpenTarget target, const std::string& game_path);
+    void OpenFolderRequested(u64 program_id, GameListOpenTarget target,
+                             const std::string& game_path);
     void OpenTransferableShaderCacheRequested(u64 program_id);
     void RemoveInstalledEntryRequested(u64 program_id, InstalledEntryType type);
     void RemoveFileRequested(u64 program_id, GameListRemoveTarget target);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1239,20 +1239,18 @@ void GMainWindow::OnGameListLoadFile(QString game_path) {
     BootGame(game_path);
 }
 
-void GMainWindow::OnGameListOpenFolder(GameListOpenTarget target, const std::string& game_path) {
+void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target,
+                                       const std::string& game_path) {
     std::string path;
     QString open_target;
 
+    FileSys::PatchManager pm{program_id};
+    const auto control = pm.GetControlMetadata();
     const auto v_file = Core::GetGameFileFromPath(vfs, game_path);
     const auto loader = Loader::GetLoader(v_file);
-    FileSys::NACP control{};
-    u64 program_id{};
 
-    loader->ReadControlData(control);
-    loader->ReadProgramId(program_id);
-
-    const bool has_user_save{control.GetDefaultNormalSaveSize() > 0};
-    const bool has_device_save{control.GetDeviceSaveDataSize() > 0};
+    const bool has_user_save{control.first->GetDefaultNormalSaveSize() > 0};
+    const bool has_device_save{control.first->GetDeviceSaveDataSize() > 0};
 
     ASSERT_MSG(has_user_save != has_device_save, "Game uses both user and device savedata?");
 

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -198,7 +198,8 @@ private slots:
     void OnOpenFAQ();
     /// Called whenever a user selects a game in the game list widget.
     void OnGameListLoadFile(QString game_path);
-    void OnGameListOpenFolder(GameListOpenTarget target, const std::string& game_path);
+    void OnGameListOpenFolder(u64 program_id, GameListOpenTarget target,
+                              const std::string& game_path);
     void OnTransferableShaderCacheOpenFile(u64 program_id);
     void OnGameListRemoveInstalledEntry(u64 program_id, InstalledEntryType type);
     void OnGameListRemoveFile(u64 program_id, GameListRemoveTarget target);


### PR DESCRIPTION
Previously NAND/SDMC installed titles would open device saves when they are supposed to be user saves. This is due to the control nca not being read and thus returns 0 for both GetDefaultNormalSaveSize() and GetDeviceSaveDataSize(). Fix this by utilizing the patch manager to read the control nca.