### PR TITLE
compatible_formats: Add missing header guard

### DIFF
--- a/src/video_core/compatible_formats.h
+++ b/src/video_core/compatible_formats.h
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#pragma once
+
 #include <array>
 #include <bitset>
 #include <cstddef>


### PR DESCRIPTION
Prevents potential inclusion issues from occurring.