### PR TITLE
config: Organize config files into directories

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -5,6 +5,7 @@
 #include <array>
 #include <QKeySequence>
 #include <QSettings>
+#include "common/common_paths.h"
 #include "common/file_util.h"
 #include "configure_input_simple.h"
 #include "core/hle/service/acc/profile_manager.h"
@@ -13,10 +14,28 @@
 #include "input_common/udp/client.h"
 #include "yuzu/configuration/config.h"
 
-Config::Config(const std::string& config_file, bool is_global) {
+Config::Config() {
     // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
-    qt_config_loc = FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + config_file;
+    qt_config_loc = FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + "qt-config.ini";
     FileUtil::CreateFullPath(qt_config_loc);
+    qt_config =
+        std::make_unique<QSettings>(QString::fromStdString(qt_config_loc), QSettings::IniFormat);
+    Reload();
+}
+
+Config::Config(u64 title_id, bool is_global) {
+    // TODO: Ditto
+    std::string old_filename = fmt::format(
+        "{}{:016X}.ini", FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir), title_id);
+    qt_config_loc = fmt::format("{}custom" DIR_SEP "{:016X}" DIR_SEP "qt-config.ini",
+                                FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir), title_id);
+    FileUtil::CreateFullPath(qt_config_loc);
+    if (FileUtil::Exists(old_filename)) {
+        FileUtil::Copy(old_filename, qt_config_loc);
+        if (FileUtil::Exists(qt_config_loc)) {
+            FileUtil::Delete(old_filename);
+        }
+    }
     qt_config =
         std::make_unique<QSettings>(QString::fromStdString(qt_config_loc), QSettings::IniFormat);
     global = is_global;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -24,18 +24,21 @@ Config::Config() {
 }
 
 Config::Config(u64 title_id, bool is_global) {
-    // TODO: Ditto
-    std::string old_filename = fmt::format(
-        "{}{:016X}.ini", FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir), title_id);
+    // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
     qt_config_loc = fmt::format("{}custom" DIR_SEP "{:016X}" DIR_SEP "qt-config.ini",
                                 FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir), title_id);
     FileUtil::CreateFullPath(qt_config_loc);
+
+    // TODO: Remove migration code sometime mid-2021
+    std::string old_filename = fmt::format(
+        "{}{:016X}.ini", FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir), title_id);
     if (FileUtil::Exists(old_filename)) {
         FileUtil::Copy(old_filename, qt_config_loc);
         if (FileUtil::Exists(qt_config_loc)) {
             FileUtil::Delete(old_filename);
         }
     }
+
     qt_config =
         std::make_unique<QSettings>(QString::fromStdString(qt_config_loc), QSettings::IniFormat);
     global = is_global;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -28,17 +28,6 @@ Config::Config(u64 title_id, bool is_global) {
     qt_config_loc = fmt::format("{}custom" DIR_SEP "{:016X}.ini",
                                 FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir), title_id);
     FileUtil::CreateFullPath(qt_config_loc);
-
-    // TODO: Remove migration code sometime mid-2021
-    std::string old_filename = fmt::format(
-        "{}{:016X}.ini", FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir), title_id);
-    if (FileUtil::Exists(old_filename)) {
-        FileUtil::Copy(old_filename, qt_config_loc);
-        if (FileUtil::Exists(qt_config_loc)) {
-            FileUtil::Delete(old_filename);
-        }
-    }
-
     qt_config =
         std::make_unique<QSettings>(QString::fromStdString(qt_config_loc), QSettings::IniFormat);
     global = is_global;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -25,7 +25,7 @@ Config::Config() {
 
 Config::Config(u64 title_id, bool is_global) {
     // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
-    qt_config_loc = fmt::format("{}custom" DIR_SEP "{:016X}" DIR_SEP "qt-config.ini",
+    qt_config_loc = fmt::format("{}custom" DIR_SEP "{:016X}.ini",
                                 FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir), title_id);
     FileUtil::CreateFullPath(qt_config_loc);
 

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -16,7 +16,8 @@ class QSettings;
 
 class Config {
 public:
-    explicit Config(const std::string& config_loc = "qt-config.ini", bool is_global = true);
+    explicit Config();
+    explicit Config(u64 title_id, bool is_global);
     ~Config();
 
     void Reload();
@@ -109,7 +110,7 @@ private:
     std::unique_ptr<QSettings> qt_config;
     std::string qt_config_loc;
 
-    bool global;
+    bool global{true};
 };
 
 // These metatype declarations cannot be in core/settings.h because core is devoid of QT

--- a/src/yuzu/configuration/configure_per_game.cpp
+++ b/src/yuzu/configuration/configure_per_game.cpp
@@ -29,7 +29,7 @@
 
 ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id)
     : QDialog(parent), ui(std::make_unique<Ui::ConfigurePerGame>()), title_id(title_id) {
-    game_config = std::make_unique<Config>(fmt::format("{:016X}.ini", title_id), false);
+    game_config = std::make_unique<Config>(title_id, false);
 
     Settings::configuring_global = false;
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1063,7 +1063,7 @@ void GMainWindow::BootGame(const QString& filename) {
     const auto loader = Loader::GetLoader(v_file);
     if (!(loader == nullptr || loader->ReadProgramId(title_id) != Loader::ResultStatus::Success)) {
         // Load per game settings
-        Config per_game_config(fmt::format("{:016X}.ini", title_id), false);
+        Config per_game_config(title_id, false);
     }
 
     Settings::LogSettings();

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -232,6 +232,7 @@ private:
     std::optional<u64> SelectRomFSDumpTarget(const FileSys::ContentProvider&, u64 program_id);
     InstallResult InstallNSPXCI(const QString& filename);
     InstallResult InstallNCA(const QString& filename);
+    void MigrateConfigFiles();
     void UpdateWindowTitle(const std::string& title_name = {},
                            const std::string& title_version = {});
     void UpdateStatusBar();


### PR DESCRIPTION
Keeps the config folder a little neater by moving config files to `config/custom/[title id].ini`. Moves existing config files from the old location to the new one if able.