### PR TITLE
network: unbreak build on FreeBSD

### DIFF
--- a/src/core/network/network.cpp
+++ b/src/core/network/network.cpp
@@ -15,7 +15,9 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <poll.h>
+#include <sys/socket.h>
 #include <unistd.h>
 #else
 #error "Unimplemented platform"


### PR DESCRIPTION
Regressed by #4306. From [error log](https://github.com/yuzu-emu/yuzu/files/4962915/yuzu-qt5-s20200721.log):
```c++
src/core/network/network.cpp:112:28: error: use of undeclared identifier 'SHUT_RD'
constexpr int SD_RECEIVE = SHUT_RD;
                           ^
src/core/network/network.cpp:120:37: error: unknown type name 'in_addr'; did you mean 'in_addr_t'?
constexpr IPv4Address TranslateIPv4(in_addr addr) {
                                    ^~~~~~~
                                    in_addr_t
```