### PR TITLE
virtual_buffer: Mark size parameter of FreeMemoryPages() as [[maybe_unused]]

### DIFF
--- a/src/common/virtual_buffer.cpp
+++ b/src/common/virtual_buffer.cpp
@@ -38,7 +38,7 @@ void* AllocateMemoryPages(std::size_t size) {
     return base;
 }
 
-void FreeMemoryPages(void* base, std::size_t size) {
+void FreeMemoryPages(void* base, [[maybe_unused]] std::size_t size) {
     if (!base) {
         return;
     }


### PR DESCRIPTION
This isn't used on Windows, but is used on non-Windows operating systems.