### PR TITLE
lz4_compression/zstd_compression: Make use of std::span in interfaces

### DIFF
--- a/src/common/lz4_compression.cpp
+++ b/src/common/lz4_compression.cpp
@@ -10,14 +10,14 @@
 
 namespace Common::Compression {
 
-std::vector<u8> CompressDataLZ4(const u8* source, std::size_t source_size) {
-    ASSERT_MSG(source_size <= LZ4_MAX_INPUT_SIZE, "Source size exceeds LZ4 maximum input size");
+std::vector<u8> CompressDataLZ4(std::span<const u8> source) {
+    ASSERT_MSG(source.size() <= LZ4_MAX_INPUT_SIZE, "Source size exceeds LZ4 maximum input size");
 
-    const auto source_size_int = static_cast<int>(source_size);
+    const auto source_size_int = static_cast<int>(source.size());
     const int max_compressed_size = LZ4_compressBound(source_size_int);
     std::vector<u8> compressed(max_compressed_size);
 
-    const int compressed_size = LZ4_compress_default(reinterpret_cast<const char*>(source),
+    const int compressed_size = LZ4_compress_default(reinterpret_cast<const char*>(source.data()),
                                                      reinterpret_cast<char*>(compressed.data()),
                                                      source_size_int, max_compressed_size);
 
@@ -31,18 +31,17 @@ std::vector<u8> CompressDataLZ4(const u8* source, std::size_t source_size) {
     return compressed;
 }
 
-std::vector<u8> CompressDataLZ4HC(const u8* source, std::size_t source_size,
-                                  s32 compression_level) {
-    ASSERT_MSG(source_size <= LZ4_MAX_INPUT_SIZE, "Source size exceeds LZ4 maximum input size");
+std::vector<u8> CompressDataLZ4HC(std::span<const u8> source, s32 compression_level) {
+    ASSERT_MSG(source.size() <= LZ4_MAX_INPUT_SIZE, "Source size exceeds LZ4 maximum input size");
 
     compression_level = std::clamp(compression_level, LZ4HC_CLEVEL_MIN, LZ4HC_CLEVEL_MAX);
 
-    const auto source_size_int = static_cast<int>(source_size);
+    const auto source_size_int = static_cast<int>(source.size());
     const int max_compressed_size = LZ4_compressBound(source_size_int);
     std::vector<u8> compressed(max_compressed_size);
 
     const int compressed_size = LZ4_compress_HC(
-        reinterpret_cast<const char*>(source), reinterpret_cast<char*>(compressed.data()),
+        reinterpret_cast<const char*>(source.data()), reinterpret_cast<char*>(compressed.data()),
         source_size_int, max_compressed_size, compression_level);
 
     if (compressed_size <= 0) {
@@ -55,8 +54,8 @@ std::vector<u8> CompressDataLZ4HC(const u8* source, std::size_t source_size,
     return compressed;
 }
 
-std::vector<u8> CompressDataLZ4HCMax(const u8* source, std::size_t source_size) {
-    return CompressDataLZ4HC(source, source_size, LZ4HC_CLEVEL_MAX);
+std::vector<u8> CompressDataLZ4HCMax(std::span<const u8> source) {
+    return CompressDataLZ4HC(source, LZ4HC_CLEVEL_MAX);
 }
 
 std::vector<u8> DecompressDataLZ4(const std::vector<u8>& compressed,

--- a/src/common/lz4_compression.h
+++ b/src/common/lz4_compression.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <span>
 #include <vector>
 
 #include "common/common_types.h"
@@ -14,11 +15,10 @@ namespace Common::Compression {
  * Compresses a source memory region with LZ4 and returns the compressed data in a vector.
  *
  * @param source the uncompressed source memory region.
- * @param source_size the size in bytes of the uncompressed source memory region.
  *
  * @return the compressed data.
  */
-std::vector<u8> CompressDataLZ4(const u8* source, std::size_t source_size);
+std::vector<u8> CompressDataLZ4(std::span<const u8> source);
 
 /**
  * Utilizes the LZ4 subalgorithm LZ4HC with the specified compression level. Higher compression
@@ -27,22 +27,20 @@ std::vector<u8> CompressDataLZ4(const u8* source, std::size_t source_size);
  * also be decompressed with the default LZ4 decompression.
  *
  * @param source the uncompressed source memory region.
- * @param source_size the size in bytes of the uncompressed source memory region.
  * @param compression_level the used compression level. Should be between 3 and 12.
  *
  * @return the compressed data.
  */
-std::vector<u8> CompressDataLZ4HC(const u8* source, std::size_t source_size, s32 compression_level);
+std::vector<u8> CompressDataLZ4HC(std::span<const u8> source, s32 compression_level);
 
 /**
  * Utilizes the LZ4 subalgorithm LZ4HC with the highest possible compression level.
  *
  * @param source the uncompressed source memory region.
- * @param source_size the size in bytes of the uncompressed source memory region.
  *
  * @return the compressed data.
  */
-std::vector<u8> CompressDataLZ4HCMax(const u8* source, std::size_t source_size);
+std::vector<u8> CompressDataLZ4HCMax(std::span<const u8> source);
 
 /**
  * Decompresses a source memory region with LZ4 and returns the uncompressed data in a vector.

--- a/src/common/zstd_compression.cpp
+++ b/src/common/zstd_compression.cpp
@@ -5,19 +5,18 @@
 #include <algorithm>
 #include <zstd.h>
 
-#include "common/assert.h"
 #include "common/zstd_compression.h"
 
 namespace Common::Compression {
 
-std::vector<u8> CompressDataZSTD(const u8* source, std::size_t source_size, s32 compression_level) {
+std::vector<u8> CompressDataZSTD(std::span<const u8> source, s32 compression_level) {
     compression_level = std::clamp(compression_level, 1, ZSTD_maxCLevel());
 
-    const std::size_t max_compressed_size = ZSTD_compressBound(source_size);
+    const std::size_t max_compressed_size = ZSTD_compressBound(source.size());
     std::vector<u8> compressed(max_compressed_size);
 
-    const std::size_t compressed_size =
-        ZSTD_compress(compressed.data(), compressed.size(), source, source_size, compression_level);
+    const std::size_t compressed_size = ZSTD_compress(
+        compressed.data(), compressed.size(), source.data(), source.size(), compression_level);
 
     if (ZSTD_isError(compressed_size)) {
         // Compression failed
@@ -29,8 +28,8 @@ std::vector<u8> CompressDataZSTD(const u8* source, std::size_t source_size, s32 
     return compressed;
 }
 
-std::vector<u8> CompressDataZSTDDefault(const u8* source, std::size_t source_size) {
-    return CompressDataZSTD(source, source_size, ZSTD_CLEVEL_DEFAULT);
+std::vector<u8> CompressDataZSTDDefault(std::span<const u8> source) {
+    return CompressDataZSTD(source, ZSTD_CLEVEL_DEFAULT);
 }
 
 std::vector<u8> DecompressDataZSTD(const std::vector<u8>& compressed) {

--- a/src/common/zstd_compression.h
+++ b/src/common/zstd_compression.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <span>
 #include <vector>
 
 #include "common/common_types.h"
@@ -14,23 +15,21 @@ namespace Common::Compression {
  * Compresses a source memory region with Zstandard and returns the compressed data in a vector.
  *
  * @param source the uncompressed source memory region.
- * @param source_size the size in bytes of the uncompressed source memory region.
  * @param compression_level the used compression level. Should be between 1 and 22.
  *
  * @return the compressed data.
  */
-std::vector<u8> CompressDataZSTD(const u8* source, std::size_t source_size, s32 compression_level);
+std::vector<u8> CompressDataZSTD(std::span<const u8> source, s32 compression_level);
 
 /**
  * Compresses a source memory region with Zstandard with the default compression level and returns
  * the compressed data in a vector.
  *
  * @param source the uncompressed source memory region.
- * @param source_size the size in bytes of the uncompressed source memory region.
  *
  * @return the compressed data.
  */
-std::vector<u8> CompressDataZSTDDefault(const u8* source, std::size_t source_size);
+std::vector<u8> CompressDataZSTDDefault(std::span<const u8> source);
 
 /**
  * Decompresses a source memory region with Zstandard and returns the uncompressed data in a vector.

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -422,8 +422,7 @@ void ShaderDiskCacheOpenGL::SavePrecompiledHeaderToVirtualPrecompiledCache() {
 void ShaderDiskCacheOpenGL::SaveVirtualPrecompiledFile() {
     precompiled_cache_virtual_file_offset = 0;
     const std::vector<u8> uncompressed = precompiled_cache_virtual_file.ReadAllBytes();
-    const std::vector<u8> compressed =
-        Common::Compression::CompressDataZSTDDefault(uncompressed.data(), uncompressed.size());
+    const std::vector<u8> compressed = Common::Compression::CompressDataZSTDDefault(uncompressed);
 
     const auto precompiled_path{GetPrecompiledPath()};
     FileUtil::IOFile file(precompiled_path, "wb");


### PR DESCRIPTION
Allows condensing the data and data size parameters into a single argument.