### PR TITLE
udp/client: Remove unused boost include

### DIFF
--- a/src/input_common/udp/client.cpp
+++ b/src/input_common/udp/client.cpp
@@ -9,7 +9,6 @@
 #include <functional>
 #include <thread>
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
 #include "common/logging/log.h"
 #include "input_common/udp/client.h"
 #include "input_common/udp/protocol.h"


### PR DESCRIPTION
Also silences a deprecation warning from boost on Clang/GCC.