### PR TITLE
qt_themes: Set QLabel background color to transparent for Dark and Midnight Blue themes

### DIFF
--- a/dist/qt_themes/qdarkstyle/style.qss
+++ b/dist/qt_themes/qdarkstyle/style.qss
@@ -654,7 +654,11 @@ QAbstractSpinBox::down-arrow:hover {
     image: url(:/qss_icons/rc/down_arrow.png);
 }
 
-QLabel,
+QLabel {
+    border: 0;
+    background: transparent;
+}
+
 QTabWidget {
     border: 0;
 }

--- a/dist/qt_themes/qdarkstyle_midnight_blue/style.qss
+++ b/dist/qt_themes/qdarkstyle_midnight_blue/style.qss
@@ -875,7 +875,7 @@ https://doc.qt.io/qt-5/stylesheet-examples.html#customizing-qframe
 
 --------------------------------------------------------------------------- */
 QLabel {
-  background-color: #19232D;
+  background: transparent;
   border: 0px solid #32414B;
   padding: 2px;
   margin: 0px;
@@ -883,7 +883,6 @@ QLabel {
 }
 
 QLabel:disabled {
-  background-color: #19232D;
   border: 0px solid #32414B;
   color: #787878;
 }


### PR DESCRIPTION
Fixes certain override highlights in per-game settings from looking broken when viewed on the Dark or Midnight Blue themes by setting QLabels to have transparent backgrounds by default.

Also apparently adds a newline to the end of the Dark theme's qss file.