### PR TITLE
yuzu/configure_debug: Remove duplicated checkboxes

### DIFF
--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -171,26 +171,6 @@
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_6">
       <item>
-       <widget class="QCheckBox" name="dump_decompressed_nso">
-        <property name="whatsThis">
-         <string>When checked, any NSO yuzu tries to load or patch will be copied decompressed to the yuzu/dump directory.</string>
-        </property>
-        <property name="text">
-         <string>Dump Decompressed NSOs</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QCheckBox" name="dump_exefs">
-        <property name="whatsThis">
-         <string>When checked, any game that yuzu loads will have its ExeFS dumped to the yuzu/dump directory.</string>
-        </property>
-        <property name="text">
-         <string>Dump ExeFS</string>
-        </property>
-       </widget>
-      </item>
-      <item>
        <widget class="QCheckBox" name="reporting_services">
         <property name="text">
          <string>Enable Verbose Reporting Services</string>
@@ -257,8 +237,6 @@
   <tabstop>open_log_button</tabstop>
   <tabstop>homebrew_args_edit</tabstop>
   <tabstop>enable_graphics_debugging</tabstop>
-  <tabstop>dump_decompressed_nso</tabstop>
-  <tabstop>dump_exefs</tabstop>
   <tabstop>reporting_services</tabstop>
   <tabstop>quest_flag</tabstop>
  </tabstops>


### PR DESCRIPTION
Those are already found in the Filesystem tab.
They were added back to the Debug tab by mistake in the Vulkan PR.
Fixes https://github.com/yuzu-emu/yuzu/issues/4427.