### PR TITLE
hle: nvdrv: Rewrite of GPU memory management.

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
@@ -16,11 +16,12 @@
 #include "video_core/renderer_base.h"
 
 namespace Service::Nvidia::Devices {
+
 namespace NvErrCodes {
-enum {
-    InvalidNmapHandle = -22,
-};
-}
+constexpr u32 Success{};
+constexpr u32 OutOfMemory{static_cast<u32>(-12)};
+constexpr u32 InvalidInput{static_cast<u32>(-22)};
+} // namespace NvErrCodes
 
 nvhost_as_gpu::nvhost_as_gpu(Core::System& system, std::shared_ptr<nvmap> nvmap_dev)
     : nvdevice(system), nvmap_dev(std::move(nvmap_dev)) {}
@@ -49,8 +50,9 @@ u32 nvhost_as_gpu::ioctl(Ioctl command, const std::vector<u8>& input, const std:
         break;
     }
 
-    if (static_cast<IoctlCommand>(command.cmd.Value()) == IoctlCommand::IocRemapCommand)
+    if (static_cast<IoctlCommand>(command.cmd.Value()) == IoctlCommand::IocRemapCommand) {
         return Remap(input, output);
+    }
 
     UNIMPLEMENTED_MSG("Unimplemented ioctl command");
     return 0;
@@ -59,6 +61,7 @@ u32 nvhost_as_gpu::ioctl(Ioctl command, const std::vector<u8>& input, const std:
 u32 nvhost_as_gpu::InitalizeEx(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlInitalizeEx params{};
     std::memcpy(&params, input.data(), input.size());
+
     LOG_WARNING(Service_NVDRV, "(STUBBED) called, big_page_size=0x{:X}", params.big_page_size);
 
     return 0;
@@ -67,53 +70,61 @@ u32 nvhost_as_gpu::InitalizeEx(const std::vector<u8>& input, std::vector<u8>& ou
 u32 nvhost_as_gpu::AllocateSpace(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlAllocSpace params{};
     std::memcpy(&params, input.data(), input.size());
+
     LOG_DEBUG(Service_NVDRV, "called, pages={:X}, page_size={:X}, flags={:X}", params.pages,
               params.page_size, params.flags);
 
-    auto& gpu = system.GPU();
-    const u64 size{static_cast<u64>(params.pages) * static_cast<u64>(params.page_size)};
-    if (params.flags & 1) {
-        params.offset = gpu.MemoryManager().AllocateSpace(params.offset, size, 1);
+    const auto size{static_cast<u64>(params.pages) * static_cast<u64>(params.page_size)};
+    if ((params.flags & AddressSpaceFlags::FixedOffset) != AddressSpaceFlags::None) {
+        params.offset = *system.GPU().MemoryManager().AllocateFixed(params.offset, size);
     } else {
-        params.offset = gpu.MemoryManager().AllocateSpace(size, params.align);
+        params.offset = system.GPU().MemoryManager().Allocate(size, params.align);
+    }
+
+    auto result{NvErrCodes::Success};
+    if (!params.offset) {
+        LOG_CRITICAL(Service_NVDRV, "allocation failed for size {}", size);
+        result = NvErrCodes::OutOfMemory;
     }
 
     std::memcpy(output.data(), &params, output.size());
-    return 0;
+    return result;
 }
 
 u32 nvhost_as_gpu::Remap(const std::vector<u8>& input, std::vector<u8>& output) {
-    std::size_t num_entries = input.size() / sizeof(IoctlRemapEntry);
+    const auto num_entries = input.size() / sizeof(IoctlRemapEntry);
 
-    LOG_WARNING(Service_NVDRV, "(STUBBED) called, num_entries=0x{:X}", num_entries);
+    LOG_DEBUG(Service_NVDRV, "called, num_entries=0x{:X}", num_entries);
 
+    auto result{NvErrCodes::Success};
     std::vector<IoctlRemapEntry> entries(num_entries);
     std::memcpy(entries.data(), input.data(), input.size());
 
-    auto& gpu = system.GPU();
     for (const auto& entry : entries) {
-        LOG_WARNING(Service_NVDRV, "remap entry, offset=0x{:X} handle=0x{:X} pages=0x{:X}",
-                    entry.offset, entry.nvmap_handle, entry.pages);
-        GPUVAddr offset = static_cast<GPUVAddr>(entry.offset) << 0x10;
-        auto object = nvmap_dev->GetObject(entry.nvmap_handle);
+        LOG_DEBUG(Service_NVDRV, "remap entry, offset=0x{:X} handle=0x{:X} pages=0x{:X}",
+                  entry.offset, entry.nvmap_handle, entry.pages);
+
+        const auto object{nvmap_dev->GetObject(entry.nvmap_handle)};
         if (!object) {
-            LOG_CRITICAL(Service_NVDRV, "nvmap {} is an invalid handle!", entry.nvmap_handle);
-            std::memcpy(output.data(), entries.data(), output.size());
-            return static_cast<u32>(NvErrCodes::InvalidNmapHandle);
+            LOG_CRITICAL(Service_NVDRV, "invalid nvmap_handle={:X}", entry.nvmap_handle);
+            result = NvErrCodes::InvalidInput;
+            break;
         }
 
-        ASSERT(object->status == nvmap::Object::Status::Allocated);
+        const auto offset{static_cast<GPUVAddr>(entry.offset) << 0x10};
+        const auto size{static_cast<u64>(entry.pages) << 0x10};
+        const auto map_offset{static_cast<u64>(entry.map_offset) << 0x10};
+        const auto addr{system.GPU().MemoryManager().Map(object->addr + map_offset, offset, size)};
 
-        const u64 size = static_cast<u64>(entry.pages) << 0x10;
-        ASSERT(size <= object->size);
-        const u64 map_offset = static_cast<u64>(entry.map_offset) << 0x10;
-
-        const GPUVAddr returned =
-            gpu.MemoryManager().MapBufferEx(object->addr + map_offset, offset, size);
-        ASSERT(returned == offset);
+        if (!addr) {
+            LOG_CRITICAL(Service_NVDRV, "map returned an invalid address!");
+            result = NvErrCodes::InvalidInput;
+            break;
+        }
     }
+
     std::memcpy(output.data(), entries.data(), output.size());
-    return 0;
+    return result;
 }
 
 u32 nvhost_as_gpu::MapBufferEx(const std::vector<u8>& input, std::vector<u8>& output) {
@@ -126,44 +137,76 @@ u32 nvhost_as_gpu::MapBufferEx(const std::vector<u8>& input, std::vector<u8>& ou
               params.flags, params.nvmap_handle, params.buffer_offset, params.mapping_size,
               params.offset);
 
-    if (!params.nvmap_handle) {
-        return 0;
+    const auto object{nvmap_dev->GetObject(params.nvmap_handle)};
+    if (!object) {
+        LOG_CRITICAL(Service_NVDRV, "invalid nvmap_handle={:X}", params.nvmap_handle);
+        std::memcpy(output.data(), &params, output.size());
+        return NvErrCodes::InvalidInput;
     }
-
-    auto object = nvmap_dev->GetObject(params.nvmap_handle);
-    ASSERT(object);
-
-    // We can only map objects that have already been assigned a CPU address.
-    ASSERT(object->status == nvmap::Object::Status::Allocated);
-
-    ASSERT(params.buffer_offset == 0);
 
     // The real nvservices doesn't make a distinction between handles and ids, and
     // object can only have one handle and it will be the same as its id. Assert that this is the
     // case to prevent unexpected behavior.
     ASSERT(object->id == params.nvmap_handle);
-
     auto& gpu = system.GPU();
 
-    if (params.flags & 1) {
-        params.offset = gpu.MemoryManager().MapBufferEx(object->addr, params.offset, object->size);
-    } else {
-        params.offset = gpu.MemoryManager().MapBufferEx(object->addr, object->size);
+    u64 page_size{params.page_size};
+    if (!page_size) {
+        page_size = object->align;
     }
 
-    // Create a new mapping entry for this operation.
-    ASSERT_MSG(buffer_mappings.find(params.offset) == buffer_mappings.end(),
-               "Offset is already mapped");
+    if ((params.flags & AddressSpaceFlags::Remap) != AddressSpaceFlags::None) {
+        if (const auto buffer_map{FindBufferMap(params.offset)}; buffer_map) {
+            const auto cpu_addr{static_cast<VAddr>(buffer_map->CpuAddr() + params.buffer_offset)};
+            const auto gpu_addr{static_cast<GPUVAddr>(params.offset + params.buffer_offset)};
 
-    BufferMapping mapping{};
-    mapping.nvmap_handle = params.nvmap_handle;
-    mapping.offset = params.offset;
-    mapping.size = object->size;
+            if (!gpu.MemoryManager().Map(cpu_addr, gpu_addr, params.mapping_size)) {
+                LOG_CRITICAL(Service_NVDRV,
+                             "remap failed, flags={:X}, nvmap_handle={:X}, buffer_offset={}, "
+                             "mapping_size = {}, offset={}",
+                             params.flags, params.nvmap_handle, params.buffer_offset,
+                             params.mapping_size, params.offset);
 
-    buffer_mappings[params.offset] = mapping;
+                std::memcpy(output.data(), &params, output.size());
+                return NvErrCodes::InvalidInput;
+            }
+
+            std::memcpy(output.data(), &params, output.size());
+            return NvErrCodes::Success;
+        } else {
+            LOG_CRITICAL(Service_NVDRV, "address not mapped offset={}", params.offset);
+
+            std::memcpy(output.data(), &params, output.size());
+            return NvErrCodes::InvalidInput;
+        }
+    }
+
+    // We can only map objects that have already been assigned a CPU address.
+    ASSERT(object->status == nvmap::Object::Status::Allocated);
+
+    const auto physical_address{object->addr + params.buffer_offset};
+    u64 size{params.mapping_size};
+    if (!size) {
+        size = object->size;
+    }
+
+    const bool is_alloc{(params.flags & AddressSpaceFlags::FixedOffset) == AddressSpaceFlags::None};
+    if (is_alloc) {
+        params.offset = gpu.MemoryManager().MapAllocate(physical_address, size, page_size);
+    } else {
+        params.offset = gpu.MemoryManager().Map(physical_address, params.offset, size);
+    }
+
+    auto result{NvErrCodes::Success};
+    if (!params.offset) {
+        LOG_CRITICAL(Service_NVDRV, "failed to map size={}", size);
+        result = NvErrCodes::InvalidInput;
+    } else {
+        AddBufferMap(params.offset, size, physical_address, is_alloc);
+    }
 
     std::memcpy(output.data(), &params, output.size());
-    return 0;
+    return result;
 }
 
 u32 nvhost_as_gpu::UnmapBuffer(const std::vector<u8>& input, std::vector<u8>& output) {
@@ -172,24 +215,20 @@ u32 nvhost_as_gpu::UnmapBuffer(const std::vector<u8>& input, std::vector<u8>& ou
 
     LOG_DEBUG(Service_NVDRV, "called, offset=0x{:X}", params.offset);
 
-    const auto itr = buffer_mappings.find(params.offset);
-    if (itr == buffer_mappings.end()) {
-        LOG_WARNING(Service_NVDRV, "Tried to unmap an invalid offset 0x{:X}", params.offset);
-        // Hardware tests shows that unmapping an already unmapped buffer always returns successful
-        // and doesn't fail.
-        return 0;
+    if (const auto size{RemoveBufferMap(params.offset)}; size) {
+        system.GPU().MemoryManager().Unmap(params.offset, *size);
+    } else {
+        LOG_ERROR(Service_NVDRV, "invalid offset=0x{:X}", params.offset);
     }
 
-    params.offset = system.GPU().MemoryManager().UnmapBuffer(params.offset, itr->second.size);
-    buffer_mappings.erase(itr->second.offset);
-
     std::memcpy(output.data(), &params, output.size());
-    return 0;
+    return NvErrCodes::Success;
 }
 
 u32 nvhost_as_gpu::BindChannel(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlBindChannel params{};
     std::memcpy(&params, input.data(), input.size());
+
     LOG_DEBUG(Service_NVDRV, "called, fd={:X}", params.fd);
 
     channel = params.fd;
@@ -199,6 +238,7 @@ u32 nvhost_as_gpu::BindChannel(const std::vector<u8>& input, std::vector<u8>& ou
 u32 nvhost_as_gpu::GetVARegions(const std::vector<u8>& input, std::vector<u8>& output) {
     IoctlGetVaRegions params{};
     std::memcpy(&params, input.data(), input.size());
+
     LOG_WARNING(Service_NVDRV, "(STUBBED) called, buf_addr={:X}, buf_size={:X}", params.buf_addr,
                 params.buf_size);
 
@@ -210,9 +250,43 @@ u32 nvhost_as_gpu::GetVARegions(const std::vector<u8>& input, std::vector<u8>& o
     params.regions[1].offset = 0x04000000;
     params.regions[1].page_size = 0x10000;
     params.regions[1].pages = 0x1bffff;
+
     // TODO(ogniK): This probably can stay stubbed but should add support way way later
+
     std::memcpy(output.data(), &params, output.size());
     return 0;
+}
+
+std::optional<nvhost_as_gpu::BufferMap> nvhost_as_gpu::FindBufferMap(GPUVAddr gpu_addr) const {
+    const auto end{buffer_mappings.upper_bound(gpu_addr)};
+    for (auto iter{buffer_mappings.begin()}; iter != end; ++iter) {
+        if (gpu_addr >= iter->second.StartAddr() && gpu_addr < iter->second.EndAddr()) {
+            return iter->second;
+        }
+    }
+
+    return {};
+}
+
+void nvhost_as_gpu::AddBufferMap(GPUVAddr gpu_addr, std::size_t size, VAddr cpu_addr,
+                                 bool is_allocated) {
+    buffer_mappings[gpu_addr] = {gpu_addr, size, cpu_addr, is_allocated};
+}
+
+std::optional<std::size_t> nvhost_as_gpu::RemoveBufferMap(GPUVAddr gpu_addr) {
+    if (const auto iter{buffer_mappings.find(gpu_addr)}; iter != buffer_mappings.end()) {
+        std::size_t size{};
+
+        if (iter->second.IsAllocated()) {
+            size = iter->second.Size();
+        }
+
+        buffer_mappings.erase(iter);
+
+        return size;
+    }
+
+    return {};
 }
 
 } // namespace Service::Nvidia::Devices

--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.h
@@ -4,9 +4,12 @@
 
 #pragma once
 
+#include <map>
 #include <memory>
-#include <unordered_map>
+#include <optional>
 #include <vector>
+
+#include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
 #include "core/hle/service/nvdrv/devices/nvdevice.h"
@@ -14,6 +17,13 @@
 namespace Service::Nvidia::Devices {
 
 class nvmap;
+
+enum class AddressSpaceFlags : u32 {
+    None = 0x0,
+    FixedOffset = 0x1,
+    Remap = 0x100,
+};
+DECLARE_ENUM_FLAG_OPERATORS(AddressSpaceFlags);
 
 class nvhost_as_gpu final : public nvdevice {
 public:
@@ -25,6 +35,45 @@ public:
               IoctlVersion version) override;
 
 private:
+    class BufferMap final {
+    public:
+        constexpr BufferMap() = default;
+
+        constexpr BufferMap(GPUVAddr start_addr, std::size_t size)
+            : start_addr{start_addr}, end_addr{start_addr + size} {}
+
+        constexpr BufferMap(GPUVAddr start_addr, std::size_t size, VAddr cpu_addr,
+                            bool is_allocated)
+            : start_addr{start_addr}, end_addr{start_addr + size}, cpu_addr{cpu_addr},
+              is_allocated{is_allocated} {}
+
+        constexpr VAddr StartAddr() const {
+            return start_addr;
+        }
+
+        constexpr VAddr EndAddr() const {
+            return end_addr;
+        }
+
+        constexpr std::size_t Size() const {
+            return end_addr - start_addr;
+        }
+
+        constexpr VAddr CpuAddr() const {
+            return cpu_addr;
+        }
+
+        constexpr bool IsAllocated() const {
+            return is_allocated;
+        }
+
+    private:
+        GPUVAddr start_addr{};
+        GPUVAddr end_addr{};
+        VAddr cpu_addr{};
+        bool is_allocated{};
+    };
+
     enum class IoctlCommand : u32_le {
         IocInitalizeExCommand = 0x40284109,
         IocAllocateSpaceCommand = 0xC0184102,
@@ -49,7 +98,7 @@ private:
     struct IoctlAllocSpace {
         u32_le pages;
         u32_le page_size;
-        u32_le flags;
+        AddressSpaceFlags flags;
         INSERT_PADDING_WORDS(1);
         union {
             u64_le offset;
@@ -69,18 +118,18 @@ private:
     static_assert(sizeof(IoctlRemapEntry) == 20, "IoctlRemapEntry is incorrect size");
 
     struct IoctlMapBufferEx {
-        u32_le flags; // bit0: fixed_offset, bit2: cacheable
-        u32_le kind;  // -1 is default
+        AddressSpaceFlags flags; // bit0: fixed_offset, bit2: cacheable
+        u32_le kind;             // -1 is default
         u32_le nvmap_handle;
         u32_le page_size; // 0 means don't care
-        u64_le buffer_offset;
+        s64_le buffer_offset;
         u64_le mapping_size;
-        u64_le offset;
+        s64_le offset;
     };
     static_assert(sizeof(IoctlMapBufferEx) == 40, "IoctlMapBufferEx is incorrect size");
 
     struct IoctlUnmapBuffer {
-        u64_le offset;
+        s64_le offset;
     };
     static_assert(sizeof(IoctlUnmapBuffer) == 8, "IoctlUnmapBuffer is incorrect size");
 
@@ -106,15 +155,6 @@ private:
     static_assert(sizeof(IoctlGetVaRegions) == 16 + sizeof(IoctlVaRegion) * 2,
                   "IoctlGetVaRegions is incorrect size");
 
-    struct BufferMapping {
-        u64 offset;
-        u64 size;
-        u32 nvmap_handle;
-    };
-
-    /// Map containing the nvmap object mappings in GPU memory.
-    std::unordered_map<u64, BufferMapping> buffer_mappings;
-
     u32 channel{};
 
     u32 InitalizeEx(const std::vector<u8>& input, std::vector<u8>& output);
@@ -125,7 +165,14 @@ private:
     u32 BindChannel(const std::vector<u8>& input, std::vector<u8>& output);
     u32 GetVARegions(const std::vector<u8>& input, std::vector<u8>& output);
 
+    std::optional<BufferMap> FindBufferMap(GPUVAddr gpu_addr) const;
+    void AddBufferMap(GPUVAddr gpu_addr, std::size_t size, VAddr cpu_addr, bool is_allocated);
+    std::optional<std::size_t> RemoveBufferMap(GPUVAddr gpu_addr);
+
     std::shared_ptr<nvmap> nvmap_dev;
+
+    // This is expected to be ordered, therefore we must use a map, not unordered_map
+    std::map<GPUVAddr, BufferMap> buffer_mappings;
 };
 
 } // namespace Service::Nvidia::Devices

--- a/src/core/hle/service/nvdrv/devices/nvmap.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvmap.cpp
@@ -18,7 +18,12 @@ enum {
 };
 }
 
-nvmap::nvmap(Core::System& system) : nvdevice(system) {}
+nvmap::nvmap(Core::System& system) : nvdevice(system) {
+    // Handle 0 appears to be used when remapping, so we create a placeholder empty nvmap object to
+    // represent this.
+    CreateObject(0);
+}
+
 nvmap::~nvmap() = default;
 
 VAddr nvmap::GetObjectAddress(u32 handle) const {
@@ -50,6 +55,21 @@ u32 nvmap::ioctl(Ioctl command, const std::vector<u8>& input, const std::vector<
     return 0;
 }
 
+u32 nvmap::CreateObject(u32 size) {
+    // Create a new nvmap object and obtain a handle to it.
+    auto object = std::make_shared<Object>();
+    object->id = next_id++;
+    object->size = size;
+    object->status = Object::Status::Created;
+    object->refcount = 1;
+
+    const u32 handle = next_handle++;
+
+    handles[handle] = std::move(object);
+
+    return handle;
+}
+
 u32 nvmap::IocCreate(const std::vector<u8>& input, std::vector<u8>& output) {
     IocCreateParams params;
     std::memcpy(&params, input.data(), sizeof(params));
@@ -59,17 +79,8 @@ u32 nvmap::IocCreate(const std::vector<u8>& input, std::vector<u8>& output) {
         LOG_ERROR(Service_NVDRV, "Size is 0");
         return static_cast<u32>(NvErrCodes::InvalidValue);
     }
-    // Create a new nvmap object and obtain a handle to it.
-    auto object = std::make_shared<Object>();
-    object->id = next_id++;
-    object->size = params.size;
-    object->status = Object::Status::Created;
-    object->refcount = 1;
 
-    u32 handle = next_handle++;
-    handles[handle] = std::move(object);
-
-    params.handle = handle;
+    params.handle = CreateObject(params.size);
 
     std::memcpy(output.data(), &params, sizeof(params));
     return 0;

--- a/src/core/hle/service/nvdrv/devices/nvmap.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvmap.cpp
@@ -65,7 +65,7 @@ u32 nvmap::CreateObject(u32 size) {
 
     const u32 handle = next_handle++;
 
-    handles[handle] = std::move(object);
+    handles.insert_or_assign(handle, std::move(object));
 
     return handle;
 }

--- a/src/core/hle/service/nvdrv/devices/nvmap.h
+++ b/src/core/hle/service/nvdrv/devices/nvmap.h
@@ -49,10 +49,10 @@ public:
 
 private:
     /// Id to use for the next handle that is created.
-    u32 next_handle = 1;
+    u32 next_handle = 0;
 
     /// Id to use for the next object that is created.
-    u32 next_id = 1;
+    u32 next_id = 0;
 
     /// Mapping of currently allocated handles to the objects they represent.
     std::unordered_map<u32, std::shared_ptr<Object>> handles;
@@ -118,6 +118,8 @@ private:
         u32_le handle;
     };
     static_assert(sizeof(IocGetIdParams) == 8, "IocGetIdParams has wrong size");
+
+    u32 CreateObject(u32 size);
 
     u32 IocCreate(const std::vector<u8>& input, std::vector<u8>& output);
     u32 IocAlloc(const std::vector<u8>& input, std::vector<u8>& output);

--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -4,7 +4,6 @@
 
 #include "common/alignment.h"
 #include "common/assert.h"
-#include "common/logging/log.h"
 #include "core/core.h"
 #include "core/hle/kernel/memory/page_table.h"
 #include "core/hle/kernel/process.h"
@@ -16,121 +15,137 @@
 namespace Tegra {
 
 MemoryManager::MemoryManager(Core::System& system, VideoCore::RasterizerInterface& rasterizer)
-    : rasterizer{rasterizer}, system{system} {
-    page_table.Resize(address_space_width, page_bits, false);
-
-    // Initialize the map with a single free region covering the entire managed space.
-    VirtualMemoryArea initial_vma;
-    initial_vma.size = address_space_end;
-    vma_map.emplace(initial_vma.base, initial_vma);
-
-    UpdatePageTableForVMA(initial_vma);
-}
+    : system{system}, rasterizer{rasterizer}, page_table(page_table_size) {}
 
 MemoryManager::~MemoryManager() = default;
 
-GPUVAddr MemoryManager::AllocateSpace(u64 size, u64 align) {
-    const u64 aligned_size{Common::AlignUp(size, page_size)};
-    const GPUVAddr gpu_addr{FindFreeRegion(address_space_base, aligned_size)};
-
-    AllocateMemory(gpu_addr, 0, aligned_size);
-
+GPUVAddr MemoryManager::UpdateRange(GPUVAddr gpu_addr, PageEntry page_entry, std::size_t size) {
+    u64 remaining_size{size};
+    for (u64 offset{}; offset < size; offset += page_size) {
+        if (remaining_size < page_size) {
+            SetPageEntry(gpu_addr + offset, page_entry + offset, remaining_size);
+        } else {
+            SetPageEntry(gpu_addr + offset, page_entry + offset);
+        }
+        remaining_size -= page_size;
+    }
     return gpu_addr;
 }
 
-GPUVAddr MemoryManager::AllocateSpace(GPUVAddr gpu_addr, u64 size, u64 align) {
-    const u64 aligned_size{Common::AlignUp(size, page_size)};
-
-    AllocateMemory(gpu_addr, 0, aligned_size);
-
-    return gpu_addr;
+GPUVAddr MemoryManager::Map(VAddr cpu_addr, GPUVAddr gpu_addr, std::size_t size) {
+    return UpdateRange(gpu_addr, cpu_addr, size);
 }
 
-GPUVAddr MemoryManager::MapBufferEx(VAddr cpu_addr, u64 size) {
-    const u64 aligned_size{Common::AlignUp(size, page_size)};
-    const GPUVAddr gpu_addr{FindFreeRegion(address_space_base, aligned_size)};
-
-    MapBackingMemory(gpu_addr, system.Memory().GetPointer(cpu_addr), aligned_size, cpu_addr);
-    ASSERT(
-        system.CurrentProcess()->PageTable().LockForDeviceAddressSpace(cpu_addr, size).IsSuccess());
-
-    return gpu_addr;
+GPUVAddr MemoryManager::MapAllocate(VAddr cpu_addr, std::size_t size, std::size_t align) {
+    return Map(cpu_addr, *FindFreeRange(size, align), size);
 }
 
-GPUVAddr MemoryManager::MapBufferEx(VAddr cpu_addr, GPUVAddr gpu_addr, u64 size) {
-    ASSERT((gpu_addr & page_mask) == 0);
-
-    const u64 aligned_size{Common::AlignUp(size, page_size)};
-
-    MapBackingMemory(gpu_addr, system.Memory().GetPointer(cpu_addr), aligned_size, cpu_addr);
-    ASSERT(
-        system.CurrentProcess()->PageTable().LockForDeviceAddressSpace(cpu_addr, size).IsSuccess());
-    return gpu_addr;
-}
-
-GPUVAddr MemoryManager::UnmapBuffer(GPUVAddr gpu_addr, u64 size) {
-    ASSERT((gpu_addr & page_mask) == 0);
-
-    const u64 aligned_size{Common::AlignUp(size, page_size)};
-    const auto cpu_addr = GpuToCpuAddress(gpu_addr);
-    ASSERT(cpu_addr);
+void MemoryManager::Unmap(GPUVAddr gpu_addr, std::size_t size) {
+    if (!size) {
+        return;
+    }
 
     // Flush and invalidate through the GPU interface, to be asynchronous if possible.
-    system.GPU().FlushAndInvalidateRegion(*cpu_addr, aligned_size);
+    system.GPU().FlushAndInvalidateRegion(*GpuToCpuAddress(gpu_addr), size);
 
-    UnmapRange(gpu_addr, aligned_size);
+    UpdateRange(gpu_addr, PageEntry::State::Unmapped, size);
+}
+
+std::optional<GPUVAddr> MemoryManager::AllocateFixed(GPUVAddr gpu_addr, std::size_t size) {
+    for (u64 offset{}; offset < size; offset += page_size) {
+        if (!GetPageEntry(gpu_addr + offset).IsUnmapped()) {
+            return {};
+        }
+    }
+
+    return UpdateRange(gpu_addr, PageEntry::State::Allocated, size);
+}
+
+GPUVAddr MemoryManager::Allocate(std::size_t size, std::size_t align) {
+    return *AllocateFixed(*FindFreeRange(size, align), size);
+}
+
+void MemoryManager::TryLockPage(PageEntry page_entry, std::size_t size) {
+    if (!page_entry.IsValid()) {
+        return;
+    }
+
     ASSERT(system.CurrentProcess()
                ->PageTable()
-               .UnlockForDeviceAddressSpace(cpu_addr.value(), size)
+               .LockForDeviceAddressSpace(page_entry.ToAddress(), size)
                .IsSuccess());
-
-    return gpu_addr;
 }
 
-GPUVAddr MemoryManager::FindFreeRegion(GPUVAddr region_start, u64 size) const {
-    // Find the first Free VMA.
-    const VMAHandle vma_handle{
-        std::find_if(vma_map.begin(), vma_map.end(), [region_start, size](const auto& vma) {
-            if (vma.second.type != VirtualMemoryArea::Type::Unmapped) {
-                return false;
+void MemoryManager::TryUnlockPage(PageEntry page_entry, std::size_t size) {
+    if (!page_entry.IsValid()) {
+        return;
+    }
+
+    ASSERT(system.CurrentProcess()
+               ->PageTable()
+               .UnlockForDeviceAddressSpace(page_entry.ToAddress(), size)
+               .IsSuccess());
+}
+
+PageEntry MemoryManager::GetPageEntry(GPUVAddr gpu_addr) const {
+    return page_table[PageEntryIndex(gpu_addr)];
+}
+
+void MemoryManager::SetPageEntry(GPUVAddr gpu_addr, PageEntry page_entry, std::size_t size) {
+    // TODO(bunnei): We should lock/unlock device regions. This currently causes issues due to
+    // improper tracking, but should be fixed in the future.
+
+    //// Unlock the old page
+    // TryUnlockPage(page_table[PageEntryIndex(gpu_addr)], size);
+
+    //// Lock the new page
+    // TryLockPage(page_entry, size);
+
+    page_table[PageEntryIndex(gpu_addr)] = page_entry;
+}
+
+std::optional<GPUVAddr> MemoryManager::FindFreeRange(std::size_t size, std::size_t align) const {
+    if (!align) {
+        align = page_size;
+    } else {
+        align = Common::AlignUp(align, page_size);
+    }
+
+    u64 available_size{};
+    GPUVAddr gpu_addr{address_space_start};
+    while (gpu_addr + available_size < address_space_size) {
+        if (GetPageEntry(gpu_addr + available_size).IsUnmapped()) {
+            available_size += page_size;
+
+            if (available_size >= size) {
+                return gpu_addr;
             }
+        } else {
+            gpu_addr += available_size + page_size;
+            available_size = 0;
 
-            const VAddr vma_end{vma.second.base + vma.second.size};
-            return vma_end > region_start && vma_end >= region_start + size;
-        })};
-
-    if (vma_handle == vma_map.end()) {
-        return {};
-    }
-
-    return std::max(region_start, vma_handle->second.base);
-}
-
-bool MemoryManager::IsAddressValid(GPUVAddr addr) const {
-    return (addr >> page_bits) < page_table.pointers.size();
-}
-
-std::optional<VAddr> MemoryManager::GpuToCpuAddress(GPUVAddr addr) const {
-    if (!IsAddressValid(addr)) {
-        return {};
-    }
-
-    const VAddr cpu_addr{page_table.backing_addr[addr >> page_bits]};
-    if (cpu_addr) {
-        return cpu_addr + (addr & page_mask);
+            const auto remainder{gpu_addr % align};
+            if (remainder) {
+                gpu_addr = (gpu_addr - remainder) + align;
+            }
+        }
     }
 
     return {};
 }
 
-template <typename T>
-T MemoryManager::Read(GPUVAddr addr) const {
-    if (!IsAddressValid(addr)) {
+std::optional<VAddr> MemoryManager::GpuToCpuAddress(GPUVAddr gpu_addr) const {
+    const auto page_entry{GetPageEntry(gpu_addr)};
+    if (!page_entry.IsValid()) {
         return {};
     }
 
-    const u8* page_pointer{GetPointer(addr)};
-    if (page_pointer) {
+    return page_entry.ToAddress() + (gpu_addr & page_mask);
+}
+
+template <typename T>
+T MemoryManager::Read(GPUVAddr addr) const {
+    if (auto page_pointer{GetPointer(addr)}; page_pointer) {
         // NOTE: Avoid adding any extra logic to this fast-path block
         T value;
         std::memcpy(&value, page_pointer, sizeof(T));
@@ -144,12 +159,7 @@ T MemoryManager::Read(GPUVAddr addr) const {
 
 template <typename T>
 void MemoryManager::Write(GPUVAddr addr, T data) {
-    if (!IsAddressValid(addr)) {
-        return;
-    }
-
-    u8* page_pointer{GetPointer(addr)};
-    if (page_pointer) {
+    if (auto page_pointer{GetPointer(addr)}; page_pointer) {
         // NOTE: Avoid adding any extra logic to this fast-path block
         std::memcpy(page_pointer, &data, sizeof(T));
         return;
@@ -167,66 +177,49 @@ template void MemoryManager::Write<u16>(GPUVAddr addr, u16 data);
 template void MemoryManager::Write<u32>(GPUVAddr addr, u32 data);
 template void MemoryManager::Write<u64>(GPUVAddr addr, u64 data);
 
-u8* MemoryManager::GetPointer(GPUVAddr addr) {
-    if (!IsAddressValid(addr)) {
+u8* MemoryManager::GetPointer(GPUVAddr gpu_addr) {
+    if (!GetPageEntry(gpu_addr).IsValid()) {
         return {};
     }
 
-    auto& memory = system.Memory();
-
-    const VAddr page_addr{page_table.backing_addr[addr >> page_bits]};
-
-    if (page_addr != 0) {
-        return memory.GetPointer(page_addr + (addr & page_mask));
-    }
-
-    LOG_ERROR(HW_GPU, "Unknown GetPointer @ 0x{:016X}", addr);
-    return {};
-}
-
-const u8* MemoryManager::GetPointer(GPUVAddr addr) const {
-    if (!IsAddressValid(addr)) {
+    const auto address{GpuToCpuAddress(gpu_addr)};
+    if (!address) {
         return {};
     }
 
-    const auto& memory = system.Memory();
+    return system.Memory().GetPointer(*address);
+}
 
-    const VAddr page_addr{page_table.backing_addr[addr >> page_bits]};
-
-    if (page_addr != 0) {
-        return memory.GetPointer(page_addr + (addr & page_mask));
+const u8* MemoryManager::GetPointer(GPUVAddr gpu_addr) const {
+    if (!GetPageEntry(gpu_addr).IsValid()) {
+        return {};
     }
 
-    LOG_ERROR(HW_GPU, "Unknown GetPointer @ 0x{:016X}", addr);
-    return {};
+    const auto address{GpuToCpuAddress(gpu_addr)};
+    if (!address) {
+        return {};
+    }
+
+    return system.Memory().GetPointer(*address);
 }
 
-bool MemoryManager::IsBlockContinuous(const GPUVAddr start, const std::size_t size) const {
-    const std::size_t inner_size = size - 1;
-    const GPUVAddr end = start + inner_size;
-    const auto host_ptr_start = reinterpret_cast<std::uintptr_t>(GetPointer(start));
-    const auto host_ptr_end = reinterpret_cast<std::uintptr_t>(GetPointer(end));
-    const auto range = static_cast<std::size_t>(host_ptr_end - host_ptr_start);
-    return range == inner_size;
-}
-
-void MemoryManager::ReadBlock(GPUVAddr gpu_src_addr, void* dest_buffer,
-                              const std::size_t size) const {
+void MemoryManager::ReadBlock(GPUVAddr gpu_src_addr, void* dest_buffer, std::size_t size) const {
     std::size_t remaining_size{size};
     std::size_t page_index{gpu_src_addr >> page_bits};
     std::size_t page_offset{gpu_src_addr & page_mask};
-
-    auto& memory = system.Memory();
 
     while (remaining_size > 0) {
         const std::size_t copy_amount{
             std::min(static_cast<std::size_t>(page_size) - page_offset, remaining_size)};
 
-        const VAddr src_addr{page_table.backing_addr[page_index] + page_offset};
-        // Flush must happen on the rasterizer interface, such that memory is always synchronous
-        // when it is read (even when in asynchronous GPU mode). Fixes Dead Cells title menu.
-        rasterizer.FlushRegion(src_addr, copy_amount);
-        memory.ReadBlockUnsafe(src_addr, dest_buffer, copy_amount);
+        if (const auto page_addr{GpuToCpuAddress(page_index << page_bits)}; page_addr) {
+            const auto src_addr{*page_addr + page_offset};
+
+            // Flush must happen on the rasterizer interface, such that memory is always synchronous
+            // when it is read (even when in asynchronous GPU mode). Fixes Dead Cells title menu.
+            rasterizer.FlushRegion(src_addr, copy_amount);
+            system.Memory().ReadBlockUnsafe(src_addr, dest_buffer, copy_amount);
+        }
 
         page_index++;
         page_offset = 0;
@@ -241,18 +234,17 @@ void MemoryManager::ReadBlockUnsafe(GPUVAddr gpu_src_addr, void* dest_buffer,
     std::size_t page_index{gpu_src_addr >> page_bits};
     std::size_t page_offset{gpu_src_addr & page_mask};
 
-    auto& memory = system.Memory();
-
     while (remaining_size > 0) {
         const std::size_t copy_amount{
             std::min(static_cast<std::size_t>(page_size) - page_offset, remaining_size)};
-        const u8* page_pointer = page_table.pointers[page_index];
-        if (page_pointer) {
-            const VAddr src_addr{page_table.backing_addr[page_index] + page_offset};
-            memory.ReadBlockUnsafe(src_addr, dest_buffer, copy_amount);
+
+        if (const auto page_addr{GpuToCpuAddress(page_index << page_bits)}; page_addr) {
+            const auto src_addr{*page_addr + page_offset};
+            system.Memory().ReadBlockUnsafe(src_addr, dest_buffer, copy_amount);
         } else {
             std::memset(dest_buffer, 0, copy_amount);
         }
+
         page_index++;
         page_offset = 0;
         dest_buffer = static_cast<u8*>(dest_buffer) + copy_amount;
@@ -260,23 +252,23 @@ void MemoryManager::ReadBlockUnsafe(GPUVAddr gpu_src_addr, void* dest_buffer,
     }
 }
 
-void MemoryManager::WriteBlock(GPUVAddr gpu_dest_addr, const void* src_buffer,
-                               const std::size_t size) {
+void MemoryManager::WriteBlock(GPUVAddr gpu_dest_addr, const void* src_buffer, std::size_t size) {
     std::size_t remaining_size{size};
     std::size_t page_index{gpu_dest_addr >> page_bits};
     std::size_t page_offset{gpu_dest_addr & page_mask};
-
-    auto& memory = system.Memory();
 
     while (remaining_size > 0) {
         const std::size_t copy_amount{
             std::min(static_cast<std::size_t>(page_size) - page_offset, remaining_size)};
 
-        const VAddr dest_addr{page_table.backing_addr[page_index] + page_offset};
-        // Invalidate must happen on the rasterizer interface, such that memory is always
-        // synchronous when it is written (even when in asynchronous GPU mode).
-        rasterizer.InvalidateRegion(dest_addr, copy_amount);
-        memory.WriteBlockUnsafe(dest_addr, src_buffer, copy_amount);
+        if (const auto page_addr{GpuToCpuAddress(page_index << page_bits)}; page_addr) {
+            const auto dest_addr{*page_addr + page_offset};
+
+            // Invalidate must happen on the rasterizer interface, such that memory is always
+            // synchronous when it is written (even when in asynchronous GPU mode).
+            rasterizer.InvalidateRegion(dest_addr, copy_amount);
+            system.Memory().WriteBlockUnsafe(dest_addr, src_buffer, copy_amount);
+        }
 
         page_index++;
         page_offset = 0;
@@ -286,21 +278,20 @@ void MemoryManager::WriteBlock(GPUVAddr gpu_dest_addr, const void* src_buffer,
 }
 
 void MemoryManager::WriteBlockUnsafe(GPUVAddr gpu_dest_addr, const void* src_buffer,
-                                     const std::size_t size) {
+                                     std::size_t size) {
     std::size_t remaining_size{size};
     std::size_t page_index{gpu_dest_addr >> page_bits};
     std::size_t page_offset{gpu_dest_addr & page_mask};
 
-    auto& memory = system.Memory();
-
     while (remaining_size > 0) {
         const std::size_t copy_amount{
             std::min(static_cast<std::size_t>(page_size) - page_offset, remaining_size)};
-        u8* page_pointer = page_table.pointers[page_index];
-        if (page_pointer) {
-            const VAddr dest_addr{page_table.backing_addr[page_index] + page_offset};
-            memory.WriteBlockUnsafe(dest_addr, src_buffer, copy_amount);
+
+        if (const auto page_addr{GpuToCpuAddress(page_index << page_bits)}; page_addr) {
+            const auto dest_addr{*page_addr + page_offset};
+            system.Memory().WriteBlockUnsafe(dest_addr, src_buffer, copy_amount);
         }
+
         page_index++;
         page_offset = 0;
         src_buffer = static_cast<const u8*>(src_buffer) + copy_amount;
@@ -308,273 +299,26 @@ void MemoryManager::WriteBlockUnsafe(GPUVAddr gpu_dest_addr, const void* src_buf
     }
 }
 
-void MemoryManager::CopyBlock(GPUVAddr gpu_dest_addr, GPUVAddr gpu_src_addr,
-                              const std::size_t size) {
+void MemoryManager::CopyBlock(GPUVAddr gpu_dest_addr, GPUVAddr gpu_src_addr, std::size_t size) {
     std::vector<u8> tmp_buffer(size);
     ReadBlock(gpu_src_addr, tmp_buffer.data(), size);
     WriteBlock(gpu_dest_addr, tmp_buffer.data(), size);
 }
 
 void MemoryManager::CopyBlockUnsafe(GPUVAddr gpu_dest_addr, GPUVAddr gpu_src_addr,
-                                    const std::size_t size) {
+                                    std::size_t size) {
     std::vector<u8> tmp_buffer(size);
     ReadBlockUnsafe(gpu_src_addr, tmp_buffer.data(), size);
     WriteBlockUnsafe(gpu_dest_addr, tmp_buffer.data(), size);
 }
 
 bool MemoryManager::IsGranularRange(GPUVAddr gpu_addr, std::size_t size) {
-    const VAddr addr = page_table.backing_addr[gpu_addr >> page_bits];
-    const std::size_t page = (addr & Core::Memory::PAGE_MASK) + size;
+    const auto cpu_addr{GpuToCpuAddress(gpu_addr)};
+    if (!cpu_addr) {
+        return {};
+    }
+    const std::size_t page{(*cpu_addr & Core::Memory::PAGE_MASK) + size};
     return page <= Core::Memory::PAGE_SIZE;
-}
-
-void MemoryManager::MapPages(GPUVAddr base, u64 size, u8* memory, Common::PageType type,
-                             VAddr backing_addr) {
-    LOG_DEBUG(HW_GPU, "Mapping {} onto {:016X}-{:016X}", fmt::ptr(memory), base * page_size,
-              (base + size) * page_size);
-
-    const VAddr end{base + size};
-    ASSERT_MSG(end <= page_table.pointers.size(), "out of range mapping at {:016X}",
-               base + page_table.pointers.size());
-
-    if (memory == nullptr) {
-        while (base != end) {
-            page_table.pointers[base] = nullptr;
-            page_table.backing_addr[base] = 0;
-
-            base += 1;
-        }
-    } else {
-        while (base != end) {
-            page_table.pointers[base] = memory;
-            page_table.backing_addr[base] = backing_addr;
-
-            base += 1;
-            memory += page_size;
-            backing_addr += page_size;
-        }
-    }
-}
-
-void MemoryManager::MapMemoryRegion(GPUVAddr base, u64 size, u8* target, VAddr backing_addr) {
-    ASSERT_MSG((size & page_mask) == 0, "non-page aligned size: {:016X}", size);
-    ASSERT_MSG((base & page_mask) == 0, "non-page aligned base: {:016X}", base);
-    MapPages(base / page_size, size / page_size, target, Common::PageType::Memory, backing_addr);
-}
-
-void MemoryManager::UnmapRegion(GPUVAddr base, u64 size) {
-    ASSERT_MSG((size & page_mask) == 0, "non-page aligned size: {:016X}", size);
-    ASSERT_MSG((base & page_mask) == 0, "non-page aligned base: {:016X}", base);
-    MapPages(base / page_size, size / page_size, nullptr, Common::PageType::Unmapped);
-}
-
-bool VirtualMemoryArea::CanBeMergedWith(const VirtualMemoryArea& next) const {
-    ASSERT(base + size == next.base);
-    if (type != next.type) {
-        return {};
-    }
-    if (type == VirtualMemoryArea::Type::Allocated && (offset + size != next.offset)) {
-        return {};
-    }
-    if (type == VirtualMemoryArea::Type::Mapped && backing_memory + size != next.backing_memory) {
-        return {};
-    }
-    return true;
-}
-
-MemoryManager::VMAHandle MemoryManager::FindVMA(GPUVAddr target) const {
-    if (target >= address_space_end) {
-        return vma_map.end();
-    } else {
-        return std::prev(vma_map.upper_bound(target));
-    }
-}
-
-MemoryManager::VMAIter MemoryManager::Allocate(VMAIter vma_handle) {
-    VirtualMemoryArea& vma{vma_handle->second};
-
-    vma.type = VirtualMemoryArea::Type::Allocated;
-    vma.backing_addr = 0;
-    vma.backing_memory = {};
-    UpdatePageTableForVMA(vma);
-
-    return MergeAdjacent(vma_handle);
-}
-
-MemoryManager::VMAHandle MemoryManager::AllocateMemory(GPUVAddr target, std::size_t offset,
-                                                       u64 size) {
-
-    // This is the appropriately sized VMA that will turn into our allocation.
-    VMAIter vma_handle{CarveVMA(target, size)};
-    VirtualMemoryArea& vma{vma_handle->second};
-
-    ASSERT(vma.size == size);
-
-    vma.offset = offset;
-
-    return Allocate(vma_handle);
-}
-
-MemoryManager::VMAHandle MemoryManager::MapBackingMemory(GPUVAddr target, u8* memory, u64 size,
-                                                         VAddr backing_addr) {
-    // This is the appropriately sized VMA that will turn into our allocation.
-    VMAIter vma_handle{CarveVMA(target, size)};
-    VirtualMemoryArea& vma{vma_handle->second};
-
-    ASSERT(vma.size == size);
-
-    vma.type = VirtualMemoryArea::Type::Mapped;
-    vma.backing_memory = memory;
-    vma.backing_addr = backing_addr;
-    UpdatePageTableForVMA(vma);
-
-    return MergeAdjacent(vma_handle);
-}
-
-void MemoryManager::UnmapRange(GPUVAddr target, u64 size) {
-    VMAIter vma{CarveVMARange(target, size)};
-    const VAddr target_end{target + size};
-    const VMAIter end{vma_map.end()};
-
-    // The comparison against the end of the range must be done using addresses since VMAs can be
-    // merged during this process, causing invalidation of the iterators.
-    while (vma != end && vma->second.base < target_end) {
-        // Unmapped ranges return to allocated state and can be reused
-        // This behavior is used by Super Mario Odyssey, Sonic Forces, and likely other games
-        vma = std::next(Allocate(vma));
-    }
-
-    ASSERT(FindVMA(target)->second.size >= size);
-}
-
-MemoryManager::VMAIter MemoryManager::StripIterConstness(const VMAHandle& iter) {
-    // This uses a neat C++ trick to convert a const_iterator to a regular iterator, given
-    // non-const access to its container.
-    return vma_map.erase(iter, iter); // Erases an empty range of elements
-}
-
-MemoryManager::VMAIter MemoryManager::CarveVMA(GPUVAddr base, u64 size) {
-    ASSERT_MSG((size & page_mask) == 0, "non-page aligned size: 0x{:016X}", size);
-    ASSERT_MSG((base & page_mask) == 0, "non-page aligned base: 0x{:016X}", base);
-
-    VMAIter vma_handle{StripIterConstness(FindVMA(base))};
-    if (vma_handle == vma_map.end()) {
-        // Target address is outside the managed range
-        return {};
-    }
-
-    const VirtualMemoryArea& vma{vma_handle->second};
-    if (vma.type == VirtualMemoryArea::Type::Mapped) {
-        // Region is already allocated
-        return vma_handle;
-    }
-
-    const VAddr start_in_vma{base - vma.base};
-    const VAddr end_in_vma{start_in_vma + size};
-
-    ASSERT_MSG(end_in_vma <= vma.size, "region size 0x{:016X} is less than required size 0x{:016X}",
-               vma.size, end_in_vma);
-
-    if (end_in_vma < vma.size) {
-        // Split VMA at the end of the allocated region
-        SplitVMA(vma_handle, end_in_vma);
-    }
-    if (start_in_vma != 0) {
-        // Split VMA at the start of the allocated region
-        vma_handle = SplitVMA(vma_handle, start_in_vma);
-    }
-
-    return vma_handle;
-}
-
-MemoryManager::VMAIter MemoryManager::CarveVMARange(GPUVAddr target, u64 size) {
-    ASSERT_MSG((size & page_mask) == 0, "non-page aligned size: 0x{:016X}", size);
-    ASSERT_MSG((target & page_mask) == 0, "non-page aligned base: 0x{:016X}", target);
-
-    const VAddr target_end{target + size};
-    ASSERT(target_end >= target);
-    ASSERT(size > 0);
-
-    VMAIter begin_vma{StripIterConstness(FindVMA(target))};
-    const VMAIter i_end{vma_map.lower_bound(target_end)};
-    if (std::any_of(begin_vma, i_end, [](const auto& entry) {
-            return entry.second.type == VirtualMemoryArea::Type::Unmapped;
-        })) {
-        return {};
-    }
-
-    if (target != begin_vma->second.base) {
-        begin_vma = SplitVMA(begin_vma, target - begin_vma->second.base);
-    }
-
-    VMAIter end_vma{StripIterConstness(FindVMA(target_end))};
-    if (end_vma != vma_map.end() && target_end != end_vma->second.base) {
-        end_vma = SplitVMA(end_vma, target_end - end_vma->second.base);
-    }
-
-    return begin_vma;
-}
-
-MemoryManager::VMAIter MemoryManager::SplitVMA(VMAIter vma_handle, u64 offset_in_vma) {
-    VirtualMemoryArea& old_vma{vma_handle->second};
-    VirtualMemoryArea new_vma{old_vma}; // Make a copy of the VMA
-
-    // For now, don't allow no-op VMA splits (trying to split at a boundary) because it's probably
-    // a bug. This restriction might be removed later.
-    ASSERT(offset_in_vma < old_vma.size);
-    ASSERT(offset_in_vma > 0);
-
-    old_vma.size = offset_in_vma;
-    new_vma.base += offset_in_vma;
-    new_vma.size -= offset_in_vma;
-
-    switch (new_vma.type) {
-    case VirtualMemoryArea::Type::Unmapped:
-        break;
-    case VirtualMemoryArea::Type::Allocated:
-        new_vma.offset += offset_in_vma;
-        break;
-    case VirtualMemoryArea::Type::Mapped:
-        new_vma.backing_memory += offset_in_vma;
-        break;
-    }
-
-    ASSERT(old_vma.CanBeMergedWith(new_vma));
-
-    return vma_map.emplace_hint(std::next(vma_handle), new_vma.base, new_vma);
-}
-
-MemoryManager::VMAIter MemoryManager::MergeAdjacent(VMAIter iter) {
-    const VMAIter next_vma{std::next(iter)};
-    if (next_vma != vma_map.end() && iter->second.CanBeMergedWith(next_vma->second)) {
-        iter->second.size += next_vma->second.size;
-        vma_map.erase(next_vma);
-    }
-
-    if (iter != vma_map.begin()) {
-        VMAIter prev_vma{std::prev(iter)};
-        if (prev_vma->second.CanBeMergedWith(iter->second)) {
-            prev_vma->second.size += iter->second.size;
-            vma_map.erase(iter);
-            iter = prev_vma;
-        }
-    }
-
-    return iter;
-}
-
-void MemoryManager::UpdatePageTableForVMA(const VirtualMemoryArea& vma) {
-    switch (vma.type) {
-    case VirtualMemoryArea::Type::Unmapped:
-        UnmapRegion(vma.base, vma.size);
-        break;
-    case VirtualMemoryArea::Type::Allocated:
-        MapMemoryRegion(vma.base, vma.size, nullptr, vma.backing_addr);
-        break;
-    case VirtualMemoryArea::Type::Mapped:
-        MapMemoryRegion(vma.base, vma.size, vma.backing_memory, vma.backing_addr);
-        break;
-    }
 }
 
 } // namespace Tegra

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -6,9 +6,9 @@
 
 #include <map>
 #include <optional>
+#include <vector>
 
 #include "common/common_types.h"
-#include "common/page_table.h"
 
 namespace VideoCore {
 class RasterizerInterface;
@@ -20,45 +20,57 @@ class System;
 
 namespace Tegra {
 
-/**
- * Represents a VMA in an address space. A VMA is a contiguous region of virtual addressing space
- * with homogeneous attributes across its extents. In this particular implementation each VMA is
- * also backed by a single host memory allocation.
- */
-struct VirtualMemoryArea {
-    enum class Type : u8 {
-        Unmapped,
-        Allocated,
-        Mapped,
+class PageEntry final {
+public:
+    enum class State : u32 {
+        Unmapped = static_cast<u32>(-1),
+        Allocated = static_cast<u32>(-2),
     };
 
-    /// Virtual base address of the region.
-    GPUVAddr base{};
-    /// Size of the region.
-    u64 size{};
-    /// Memory area mapping type.
-    Type type{Type::Unmapped};
-    /// CPU memory mapped address corresponding to this memory area.
-    VAddr backing_addr{};
-    /// Offset into the backing_memory the mapping starts from.
-    std::size_t offset{};
-    /// Pointer backing this VMA.
-    u8* backing_memory{};
+    constexpr PageEntry() = default;
+    constexpr PageEntry(State state) : state{state} {}
+    constexpr PageEntry(VAddr addr) : state{static_cast<State>(addr >> ShiftBits)} {}
 
-    /// Tests if this area can be merged to the right with `next`.
-    bool CanBeMergedWith(const VirtualMemoryArea& next) const;
+    constexpr bool IsUnmapped() const {
+        return state == State::Unmapped;
+    }
+
+    constexpr bool IsAllocated() const {
+        return state == State::Allocated;
+    }
+
+    constexpr bool IsValid() const {
+        return !IsUnmapped() && !IsAllocated();
+    }
+
+    constexpr VAddr ToAddress() const {
+        if (!IsValid()) {
+            return {};
+        }
+
+        return static_cast<VAddr>(state) << ShiftBits;
+    }
+
+    constexpr PageEntry operator+(u64 offset) {
+        // If this is a reserved value, offsets do not apply
+        if (!IsValid()) {
+            return *this;
+        }
+        return PageEntry{(static_cast<VAddr>(state) << ShiftBits) + offset};
+    }
+
+private:
+    static constexpr std::size_t ShiftBits{12};
+
+    State state{State::Unmapped};
 };
+static_assert(sizeof(PageEntry) == 4, "PageEntry is too large");
 
 class MemoryManager final {
 public:
     explicit MemoryManager(Core::System& system, VideoCore::RasterizerInterface& rasterizer);
     ~MemoryManager();
 
-    GPUVAddr AllocateSpace(u64 size, u64 align);
-    GPUVAddr AllocateSpace(GPUVAddr addr, u64 size, u64 align);
-    GPUVAddr MapBufferEx(VAddr cpu_addr, u64 size);
-    GPUVAddr MapBufferEx(VAddr cpu_addr, GPUVAddr addr, u64 size);
-    GPUVAddr UnmapBuffer(GPUVAddr addr, u64 size);
     std::optional<VAddr> GpuToCpuAddress(GPUVAddr addr) const;
 
     template <typename T>
@@ -69,9 +81,6 @@ public:
 
     u8* GetPointer(GPUVAddr addr);
     const u8* GetPointer(GPUVAddr addr) const;
-
-    /// Returns true if the block is continuous in host memory, false otherwise
-    bool IsBlockContinuous(GPUVAddr start, std::size_t size) const;
 
     /**
      * ReadBlock and WriteBlock are full read and write operations over virtual
@@ -98,92 +107,43 @@ public:
     void CopyBlockUnsafe(GPUVAddr gpu_dest_addr, GPUVAddr gpu_src_addr, std::size_t size);
 
     /**
-     * IsGranularRange checks if a gpu region can be simply read with a pointer
+     * IsGranularRange checks if a gpu region can be simply read with a pointer.
      */
     bool IsGranularRange(GPUVAddr gpu_addr, std::size_t size);
 
-private:
-    using VMAMap = std::map<GPUVAddr, VirtualMemoryArea>;
-    using VMAHandle = VMAMap::const_iterator;
-    using VMAIter = VMAMap::iterator;
-
-    bool IsAddressValid(GPUVAddr addr) const;
-    void MapPages(GPUVAddr base, u64 size, u8* memory, Common::PageType type,
-                  VAddr backing_addr = 0);
-    void MapMemoryRegion(GPUVAddr base, u64 size, u8* target, VAddr backing_addr);
-    void UnmapRegion(GPUVAddr base, u64 size);
-
-    /// Finds the VMA in which the given address is included in, or `vma_map.end()`.
-    VMAHandle FindVMA(GPUVAddr target) const;
-
-    VMAHandle AllocateMemory(GPUVAddr target, std::size_t offset, u64 size);
-
-    /**
-     * Maps an unmanaged host memory pointer at a given address.
-     *
-     * @param target       The guest address to start the mapping at.
-     * @param memory       The memory to be mapped.
-     * @param size         Size of the mapping in bytes.
-     * @param backing_addr The base address of the range to back this mapping.
-     */
-    VMAHandle MapBackingMemory(GPUVAddr target, u8* memory, u64 size, VAddr backing_addr);
-
-    /// Unmaps a range of addresses, splitting VMAs as necessary.
-    void UnmapRange(GPUVAddr target, u64 size);
-
-    /// Converts a VMAHandle to a mutable VMAIter.
-    VMAIter StripIterConstness(const VMAHandle& iter);
-
-    /// Marks as the specified VMA as allocated.
-    VMAIter Allocate(VMAIter vma);
-
-    /**
-     * Carves a VMA of a specific size at the specified address by splitting Free VMAs while doing
-     * the appropriate error checking.
-     */
-    VMAIter CarveVMA(GPUVAddr base, u64 size);
-
-    /**
-     * Splits the edges of the given range of non-Free VMAs so that there is a VMA split at each
-     * end of the range.
-     */
-    VMAIter CarveVMARange(GPUVAddr base, u64 size);
-
-    /**
-     * Splits a VMA in two, at the specified offset.
-     * @returns the right side of the split, with the original iterator becoming the left side.
-     */
-    VMAIter SplitVMA(VMAIter vma, u64 offset_in_vma);
-
-    /**
-     * Checks for and merges the specified VMA with adjacent ones if possible.
-     * @returns the merged VMA or the original if no merging was possible.
-     */
-    VMAIter MergeAdjacent(VMAIter vma);
-
-    /// Updates the pages corresponding to this VMA so they match the VMA's attributes.
-    void UpdatePageTableForVMA(const VirtualMemoryArea& vma);
-
-    /// Finds a free (unmapped region) of the specified size starting at the specified address.
-    GPUVAddr FindFreeRegion(GPUVAddr region_start, u64 size) const;
+    GPUVAddr Map(VAddr cpu_addr, GPUVAddr gpu_addr, std::size_t size);
+    GPUVAddr MapAllocate(VAddr cpu_addr, std::size_t size, std::size_t align);
+    std::optional<GPUVAddr> AllocateFixed(GPUVAddr gpu_addr, std::size_t size);
+    GPUVAddr Allocate(std::size_t size, std::size_t align);
+    void Unmap(GPUVAddr gpu_addr, std::size_t size);
 
 private:
+    PageEntry GetPageEntry(GPUVAddr gpu_addr) const;
+    void SetPageEntry(GPUVAddr gpu_addr, PageEntry page_entry, std::size_t size = page_size);
+    GPUVAddr UpdateRange(GPUVAddr gpu_addr, PageEntry page_entry, std::size_t size);
+    std::optional<GPUVAddr> FindFreeRange(std::size_t size, std::size_t align) const;
+
+    void TryLockPage(PageEntry page_entry, std::size_t size);
+    void TryUnlockPage(PageEntry page_entry, std::size_t size);
+
+    static constexpr std::size_t PageEntryIndex(GPUVAddr gpu_addr) {
+        return (gpu_addr >> page_bits) & page_table_mask;
+    }
+
+    static constexpr u64 address_space_size = 1ULL << 40;
+    static constexpr u64 address_space_start = 1ULL << 32;
     static constexpr u64 page_bits{16};
     static constexpr u64 page_size{1 << page_bits};
     static constexpr u64 page_mask{page_size - 1};
-
-    /// Address space in bits, according to Tegra X1 TRM
-    static constexpr u32 address_space_width{40};
-    /// Start address for mapping, this is fairly arbitrary but must be non-zero.
-    static constexpr GPUVAddr address_space_base{0x100000};
-    /// End of address space, based on address space in bits.
-    static constexpr GPUVAddr address_space_end{1ULL << address_space_width};
-
-    Common::PageTable page_table;
-    VMAMap vma_map;
-    VideoCore::RasterizerInterface& rasterizer;
+    static constexpr u64 page_table_bits{24};
+    static constexpr u64 page_table_size{1 << page_table_bits};
+    static constexpr u64 page_table_mask{page_table_size - 1};
 
     Core::System& system;
+
+    VideoCore::RasterizerInterface& rasterizer;
+
+    std::vector<PageEntry> page_table;
 };
 
 } // namespace Tegra


### PR DESCRIPTION
Rewrites our GPU Virtual Memory Manager. This greatly simplifies things, should reduce committed memory by the process, fixes many bugs, and allows us to implement a few new features. Among these, we implement the "remap" flag of the MapBufferEx ioctl. This fixes many of the graphical bugs with Mario Kart 8 Deluxe, as well as some of the softlock issues with Dragon Quest XI.