### PR TITLE
GCAdapter: only join worker thread if running & joinable

### DIFF
--- a/src/input_common/gcadapter/gc_adapter.cpp
+++ b/src/input_common/gcadapter/gc_adapter.cpp
@@ -265,7 +265,9 @@ void Adapter::Reset() {
     if (adapter_thread_running) {
         adapter_thread_running = false;
     }
-    adapter_input_thread.join();
+    if (adapter_input_thread.joinable()) {
+        adapter_input_thread.join();
+    }
 
     adapter_controllers_status.fill(ControllerTypes::None);
     get_origin.fill(true);


### PR DESCRIPTION
Without this, yuzu crashes with:
```
terminate called after throwing an instance of 'std::system_error'
  what():  Invalid argument
Aborted
```