### PR TITLE
yuzu/main: Remove redundant usages of QStringLiteral("")

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1655,7 +1655,7 @@ void GMainWindow::OnMenuInstallToNAND() {
 
     ui.action_Install_File_NAND->setEnabled(false);
 
-    install_progress = new QProgressDialog(QStringLiteral(""), tr("Cancel"), 0, total_size, this);
+    install_progress = new QProgressDialog(QString{}, tr("Cancel"), 0, total_size, this);
     install_progress->setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint &
                                      ~Qt::WindowMaximizeButtonHint);
     install_progress->setAttribute(Qt::WA_DeleteOnClose, true);
@@ -1705,12 +1705,12 @@ void GMainWindow::OnMenuInstallToNAND() {
     install_progress->close();
 
     const QString install_results =
-        (new_files.isEmpty() ? QStringLiteral("")
+        (new_files.isEmpty() ? QString{}
                              : tr("%n file(s) were newly installed\n", "", new_files.size())) +
         (overwritten_files.isEmpty()
-             ? QStringLiteral("")
+             ? QString{}
              : tr("%n file(s) were overwritten\n", "", overwritten_files.size())) +
-        (failed_files.isEmpty() ? QStringLiteral("")
+        (failed_files.isEmpty() ? QString{}
                                 : tr("%n file(s) failed to install\n", "", failed_files.size()));
 
     QMessageBox::information(this, tr("Install Results"), install_results);
@@ -2202,8 +2202,7 @@ void GMainWindow::UpdateStatusBar() {
 
     if (shaders_building != 0) {
         shader_building_label->setText(
-            tr("Building: %1 shader").arg(shaders_building) +
-            (shaders_building != 1 ? QString::fromStdString("s") : QString::fromStdString("")));
+            tr("Building: %n shader(s)", "", static_cast<int>(shaders_building)));
         shader_building_label->setVisible(true);
     } else {
         shader_building_label->setVisible(false);


### PR DESCRIPTION
An empty QStringLiteral can more efficiently be replaced with an empty QString. We can also simplify the localization of the shader building label, which also makes it easier for translators to translate the plural case (in which case, the string would be completely wrong for translation, given it would append an `s` to the end of the string).