### PR TITLE
logging/settings: Increase maximum log size to 100 MB and add extended logging option

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -23,6 +23,7 @@
 #include "common/logging/text_formatter.h"
 #include "common/string_util.h"
 #include "common/threadsafe_queue.h"
+#include "core/settings.h"
 
 namespace Log {
 
@@ -152,10 +153,19 @@ FileBackend::FileBackend(const std::string& filename)
 void FileBackend::Write(const Entry& entry) {
     // prevent logs from going over the maximum size (in case its spamming and the user doesn't
     // know)
-    constexpr std::size_t MAX_BYTES_WRITTEN = 50 * 1024L * 1024L;
-    if (!file.IsOpen() || bytes_written > MAX_BYTES_WRITTEN) {
+    constexpr std::size_t MAX_BYTES_WRITTEN = 100 * 1024 * 1024;
+    constexpr std::size_t MAX_BYTES_WRITTEN_EXTENDED = 1024 * 1024 * 1024;
+
+    if (!file.IsOpen()) {
         return;
     }
+
+    if (Settings::values.extended_logging && bytes_written > MAX_BYTES_WRITTEN_EXTENDED) {
+        return;
+    } else if (!Settings::values.extended_logging && bytes_written > MAX_BYTES_WRITTEN) {
+        return;
+    }
+
     bytes_written += file.WriteString(FormatLogMessage(entry).append(1, '\n'));
     if (entry.log_level >= Level::Error) {
         file.Flush();

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -498,6 +498,7 @@ struct Values {
     bool reporting_services;
     bool quest_flag;
     bool disable_macro_jit;
+    bool extended_logging;
 
     // Misceallaneous
     std::string log_filter;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -523,6 +523,8 @@ void Config::ReadDebuggingValues() {
     Settings::values.quest_flag = ReadSetting(QStringLiteral("quest_flag"), false).toBool();
     Settings::values.disable_macro_jit =
         ReadSetting(QStringLiteral("disable_macro_jit"), false).toBool();
+    Settings::values.extended_logging =
+        ReadSetting(QStringLiteral("extended_logging"), false).toBool();
 
     qt_config->endGroup();
 }

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -41,6 +41,7 @@ void ConfigureDebug::SetConfiguration() {
     ui->enable_graphics_debugging->setChecked(Settings::values.renderer_debug);
     ui->disable_macro_jit->setEnabled(!Core::System::GetInstance().IsPoweredOn());
     ui->disable_macro_jit->setChecked(Settings::values.disable_macro_jit);
+    ui->extended_logging->setChecked(Settings::values.extended_logging);
 }
 
 void ConfigureDebug::ApplyConfiguration() {
@@ -53,6 +54,7 @@ void ConfigureDebug::ApplyConfiguration() {
     Settings::values.quest_flag = ui->quest_flag->isChecked();
     Settings::values.renderer_debug = ui->enable_graphics_debugging->isChecked();
     Settings::values.disable_macro_jit = ui->disable_macro_jit->isChecked();
+    Settings::values.extended_logging = ui->extended_logging->isChecked();
     Debugger::ToggleConsole();
     Log::Filter filter;
     filter.ParseFilterString(Settings::values.log_filter);

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -90,7 +90,7 @@
         <item>
          <widget class="QCheckBox" name="toggle_console">
           <property name="text">
-           <string>Show Log Console (Windows Only)</string>
+           <string>Show Log in Console</string>
           </property>
          </widget>
         </item>
@@ -102,6 +102,34 @@
          </widget>
         </item>
        </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="extended_logging">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>When checked, the max size of the log increases from 100 MB to 1 GB</string>
+        </property>
+        <property name="text">
+         <string>Enable Extended Logging</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_3">
+        <property name="font">
+         <font>
+          <italic>true</italic>
+         </font>
+        </property>
+        <property name="text">
+         <string>This will be reset automatically when yuzu closes.</string>
+        </property>
+        <property name="indent">
+         <number>20</number>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -115,7 +143,7 @@
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout_4">
         <item>
-         <widget class="QLabel" name="label_3">
+         <widget class="QLabel" name="label_4">
           <property name="text">
            <string>Arguments String</string>
           </property>
@@ -140,8 +168,8 @@
         <property name="enabled">
          <bool>true</bool>
         </property>
-        <property name="whatsThis">
-         <string>When checked, the graphics API enters in a slower debugging mode</string>
+        <property name="toolTip">
+         <string>When checked, the graphics API enters a slower debugging mode</string>
         </property>
         <property name="text">
          <string>Enable Graphics Debugging</string>
@@ -153,8 +181,8 @@
         <property name="enabled">
          <bool>true</bool>
         </property>
-        <property name="whatsThis">
-         <string>When checked, it disables the macro Just In Time compiler. Enabled this makes games run slower</string>
+        <property name="toolTip">
+         <string>When checked, it disables the macro Just In Time compiler. Enabling this makes games run slower</string>
         </property>
         <property name="text">
          <string>Disable Macro JIT</string>
@@ -169,7 +197,7 @@
      <property name="title">
       <string>Dump</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_6">
+     <layout class="QVBoxLayout" name="verticalLayout_7">
       <item>
        <widget class="QCheckBox" name="reporting_services">
         <property name="text">
@@ -178,7 +206,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="label">
+       <widget class="QLabel" name="label_5">
         <property name="font">
          <font>
           <italic>true</italic>
@@ -200,7 +228,7 @@
      <property name="title">
       <string>Advanced</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_7">
+     <layout class="QVBoxLayout" name="verticalLayout_8">
       <item>
        <widget class="QCheckBox" name="quest_flag">
         <property name="text">


### PR DESCRIPTION
This PR increases the maximum size the log can go up to from 50 MB to 100 MB.

The extended logging option is automatically disabled on boot but can be enabled afterwards, allowing the log file to go up to 1 GB during that session.

<img width="613" alt="2020-09-01_20-50-51" src="https://user-images.githubusercontent.com/15317421/91930133-e8024800-ec94-11ea-88a8-cc44989ece67.png">
<img width="613" alt="2020-09-01_20-50-54" src="https://user-images.githubusercontent.com/15317421/91930138-e9337500-ec94-11ea-9a9b-89736d9a408c.png">

This PR also fixes a few errors that are present in the general debug menu, such as tool tips not appearing.