### PR TITLE
HID: Make all input shared memory the same

### DIFF
--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -115,7 +115,10 @@ void IAppletResource::UpdateControllers(u64 userdata, s64 ns_late) {
         if (should_reload) {
             controller->OnLoadInputDevices();
         }
-        controller->OnUpdate(core_timing, shared_mem->GetPointer(), SHARED_MEMORY_SIZE);
+        // TODO(german77): Sync this function with the emulator to remove 'loop'
+        for (std::size_t loop = 0; loop < 17; ++loop) {
+            controller->OnUpdate(core_timing, shared_mem->GetPointer(), SHARED_MEMORY_SIZE);
+        }
     }
 
     core_timing.ScheduleEvent(pad_update_ticks - ns_late, pad_update_event);


### PR DESCRIPTION
As explained by #4132, yuzu had minor problems with input lag. From my testing I had 1 to 4 frames of lag. After changing the sleep period to 5ms now I have 0 to 2 frames of lag. 
5ms is the period that the acelerometer and gyroscope are polled from a joycon.
After more testing I found that this does not solve the problem. Just make it less likely to be delayed by many frames.

Solution:
The input memory consist of an array of 17 values. An unsync input poller is equivalent of reading an input value before or after the actual updated value. That means you read a random value of that input array. In the worst case scenario you lag 17 frames.

A game with 1200fps has near 0ms of input lag because it reads the whole input array in one screen refresh.

By making the full input array contain only the latest value. It will ensure that in the next frame the correct data will be read. This will fix problems with input lag while I found a way to sync the function with the emulator.

Needs to be tested as it has potential to break some games.