### PR TITLE
Fix thread naming on Linux, which limits names to 15 bytes.

### DIFF
--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/common_funcs.h"
+#include "common/logging/log.h"
 #include "common/thread.h"
 #ifdef __APPLE__
 #include <mach/mach.h>
@@ -18,6 +20,8 @@
 #ifndef _WIN32
 #include <unistd.h>
 #endif
+
+#include <string>
 
 #ifdef __FreeBSD__
 #define cpu_set_t cpuset_t
@@ -110,6 +114,14 @@ void SetCurrentThreadName(const char* name) {
     pthread_set_name_np(pthread_self(), name);
 #elif defined(__NetBSD__)
     pthread_setname_np(pthread_self(), "%s", (void*)name);
+#elif defined(__linux__)
+    // Linux limits thread names to 15 characters and will outright reject any
+    // attempt to set a longer name with ERANGE.
+    std::string truncated(name, std::min(strlen(name), static_cast<size_t>(15)));
+    if (int e = pthread_setname_np(pthread_self(), truncated.c_str())) {
+        errno = e;
+        LOG_ERROR(Common, "Failed to set thread name to '{}': {}", truncated, GetLastErrorMsg());
+    }
 #else
     pthread_setname_np(pthread_self(), name);
 #endif

--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -331,7 +331,7 @@ void CpuManager::RunThread(std::size_t core) {
     system.RegisterCoreThread(core);
     std::string name;
     if (is_multicore) {
-        name = "yuzu:CoreCPUThread_" + std::to_string(core);
+        name = "yuzu:CPUCore_" + std::to_string(core);
     } else {
         name = "yuzu:CPUThread";
     }


### PR DESCRIPTION
- In `SetCurrentThreadName`, when on Linux, truncate to 15 bytes, as (at least on glibc) `pthread_set_name_np` will otherwise return `ERANGE` and do nothing.
- Also, add logging in case `pthread_set_name_np` returns an error anyway.  This is Linux-specific, as the Apple and BSD versions of `pthread_set_name_np` return `void`.
- To make things slightly more succinct, change `SetCurrentThreadName` to take `const std::string&` rather than `const char *`.
- Change the name for CPU threads in multi-core mode from "yuzu:CoreCPUThread_N" (19 bytes) to "yuzu:CPUCore_N" (14 bytes) so it fits into the Linux limit.  Some other thread names are also cut off, but I didn't bother addressing them as you can guess them from the truncated versions.  For a CPU thread, truncation means you can't see which core it is!
