### PR TITLE
kernel/scheduler: Mark SchedulerLock constructor as nodiscard 

### DIFF
--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -39,7 +39,7 @@ public:
 
     class Scoped {
     public:
-        explicit Scoped(GraphicsContext& context_) : context(context_) {
+        [[nodiscard]] explicit Scoped(GraphicsContext& context_) : context(context_) {
             context.MakeCurrent();
         }
         ~Scoped() {
@@ -52,7 +52,7 @@ public:
 
     /// Calls MakeCurrent on the context and calls DoneCurrent when the scope for the returned value
     /// ends
-    Scoped Acquire() {
+    [[nodiscard]] Scoped Acquire() {
         return Scoped{*this};
     }
 };

--- a/src/core/hle/kernel/scheduler.h
+++ b/src/core/hle/kernel/scheduler.h
@@ -289,7 +289,7 @@ private:
 
 class SchedulerLock {
 public:
-    explicit SchedulerLock(KernelCore& kernel);
+    [[nodiscard]] explicit SchedulerLock(KernelCore& kernel);
     ~SchedulerLock();
 
 protected:


### PR DESCRIPTION
Allows the compiler to warn about cases where the constructor is used but then immediately discarded, which is a potential cause of locking/unlocking bugs. Similar to thread locks, where the following is accidentally done:

```cpp
std::lock_guard{mutex}
```
instead of
```cpp
std::lock_guard guard{mutex};
```