### PR TITLE
ci: Make use of clang-format 10.0

### DIFF
--- a/.ci/scripts/format/script.sh
+++ b/.ci/scripts/format/script.sh
@@ -7,7 +7,7 @@ if grep -nrI '\s$' src *.yml *.txt *.md Doxyfile .gitignore .gitmodules .ci* dis
 fi
 
 # Default clang-format points to default 3.5 version one
-CLANG_FORMAT=clang-format-6.0
+CLANG_FORMAT=clang-format-10.0
 $CLANG_FORMAT --version
 
 if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then

--- a/.travis/clang-format/script.sh
+++ b/.travis/clang-format/script.sh
@@ -7,7 +7,7 @@ if grep -nrI '\s$' src *.yml *.txt *.md Doxyfile .gitignore .gitmodules .travis*
 fi
 
 # Default clang-format points to default 3.5 version one
-CLANG_FORMAT=clang-format-6.0
+CLANG_FORMAT=clang-format-10.0
 $CLANG_FORMAT --version
 
 if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then


### PR DESCRIPTION
10.0 plays nicer with C++ attributes compared to clang-format 6.0.

Depends on https://github.com/yuzu-emu/build-environments/pull/15