### PR TITLE
perf_stats: Mark GetMeanFrametime() as const 

### DIFF
--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -95,12 +95,13 @@ PerfStatsResults PerfStats::GetAndResetStats(microseconds current_system_time_us
 
     const auto system_us_per_second = (current_system_time_us - reset_point_system_us) / interval;
 
-    PerfStatsResults results{};
-    results.system_fps = static_cast<double>(system_frames) / interval;
-    results.game_fps = static_cast<double>(game_frames) / interval;
-    results.frametime = duration_cast<DoubleSecs>(accumulated_frametime).count() /
-                        static_cast<double>(system_frames);
-    results.emulation_speed = system_us_per_second.count() / 1'000'000.0;
+    const PerfStatsResults results{
+        .system_fps = static_cast<double>(system_frames) / interval,
+        .game_fps = static_cast<double>(game_frames) / interval,
+        .frametime = duration_cast<DoubleSecs>(accumulated_frametime).count() /
+                     static_cast<double>(system_frames),
+        .emulation_speed = system_us_per_second.count() / 1'000'000.0,
+    };
 
     // Reset counters
     reset_point = now;

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -74,15 +74,16 @@ void PerfStats::EndGameFrame() {
     game_frames += 1;
 }
 
-double PerfStats::GetMeanFrametime() {
+double PerfStats::GetMeanFrametime() const {
     std::lock_guard lock{object_mutex};
 
     if (current_index <= IgnoreFrames) {
         return 0;
     }
+
     const double sum = std::accumulate(perf_history.begin() + IgnoreFrames,
                                        perf_history.begin() + current_index, 0.0);
-    return sum / (current_index - IgnoreFrames);
+    return sum / static_cast<double>(current_index - IgnoreFrames);
 }
 
 PerfStatsResults PerfStats::GetAndResetStats(microseconds current_system_time_us) {
@@ -111,7 +112,7 @@ PerfStatsResults PerfStats::GetAndResetStats(microseconds current_system_time_us
     return results;
 }
 
-double PerfStats::GetLastFrameTimeScale() {
+double PerfStats::GetLastFrameTimeScale() const {
     std::lock_guard lock{object_mutex};
 
     constexpr double FRAME_LENGTH = 1.0 / 60;

--- a/src/core/perf_stats.h
+++ b/src/core/perf_stats.h
@@ -30,7 +30,6 @@ struct PerfStatsResults {
 class PerfStats {
 public:
     explicit PerfStats(u64 title_id);
-
     ~PerfStats();
 
     using Clock = std::chrono::high_resolution_clock;
@@ -42,18 +41,18 @@ public:
     PerfStatsResults GetAndResetStats(std::chrono::microseconds current_system_time_us);
 
     /**
-     * Returns the Arthimetic Mean of all frametime values stored in the performance history.
+     * Returns the arithmetic mean of all frametime values stored in the performance history.
      */
-    double GetMeanFrametime();
+    double GetMeanFrametime() const;
 
     /**
      * Gets the ratio between walltime and the emulated time of the previous system frame. This is
      * useful for scaling inputs or outputs moving between the two time domains.
      */
-    double GetLastFrameTimeScale();
+    double GetLastFrameTimeScale() const;
 
 private:
-    std::mutex object_mutex{};
+    mutable std::mutex object_mutex;
 
     /// Title ID for the game that is running. 0 if there is no game running yet
     u64 title_id{0};
@@ -61,7 +60,7 @@ private:
     std::size_t current_index{0};
     /// Stores an hour of historical frametime data useful for processing and tracking performance
     /// regressions with code changes.
-    std::array<double, 216000> perf_history = {};
+    std::array<double, 216000> perf_history{};
 
     /// Point when the cumulative counters were reset
     Clock::time_point reset_point = Clock::now();


### PR DESCRIPTION
The general pattern is to mark mutexes as mutable when it comes to matters of constness, given the mutex acts as a transient member of a data structure: it's not a direct invariant of the data structure.

While we're at it, we can make use of designated initializers to directly initialize structs instead of zeroing them out beforehand.