### PR TITLE
CMakeLists: Resolve #4478

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,8 +60,13 @@ else()
         -Wmissing-declarations
         -Wno-attributes
         -Wno-unused-parameter
-        -fconcepts
     )
+
+    # TODO: Remove when we update to a GCC compiler that enables this
+    #       by default (i.e. GCC 10 or newer).
+    if (CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+        add_compile_options(-fconcepts)
+    endif()
 
     if (ARCHITECTURE_x86_64)
         add_compile_options("-mcx16")


### PR DESCRIPTION
This switch is enabled by default in all recent versions of GCC and Clang.

Removing the flag just so I can see what the compiler error is if our GCC variant is too old. Otherwise it's basic enough to just check if clang is being used and not pass -fconcepts.

Fixes #4478