### PR TITLE
tests/core_timing: Remove pragma optimize(off)

### DIFF
--- a/src/tests/core/core_timing.cpp
+++ b/src/tests/core/core_timing.cpp
@@ -46,19 +46,15 @@ struct ScopeInit final {
     Core::Timing::CoreTiming core_timing;
 };
 
-#pragma optimize("", off)
-
 u64 TestTimerSpeed(Core::Timing::CoreTiming& core_timing) {
-    u64 start = core_timing.GetGlobalTimeNs().count();
-    u64 placebo = 0;
+    const u64 start = core_timing.GetGlobalTimeNs().count();
+    volatile u64 placebo = 0;
     for (std::size_t i = 0; i < 1000; i++) {
-        placebo += core_timing.GetGlobalTimeNs().count();
+        placebo = placebo + core_timing.GetGlobalTimeNs().count();
     }
-    u64 end = core_timing.GetGlobalTimeNs().count();
-    return (end - start);
+    const u64 end = core_timing.GetGlobalTimeNs().count();
+    return end - start;
 }
-
-#pragma optimize("", on)
 
 } // Anonymous namespace
 


### PR DESCRIPTION
I made a review comment about this in the PR that this was introduced in (#3955, commit 71c4779211dc081a3b2dd4af52edad5748e7a7f5), but it seems to have been missed.

We shouldn't be using this pragma here because it's MSVC specific. This causes warnings on other compilers.

The test it's surrounding is *extremely* dubious, but for the sake of silencing warnings on other compilers, we can mark "placebo" as volatile and be on with it.