### PR TITLE
yuzu: Resolve C++20 deprecation warnings related to lambda captures

### DIFF
--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -71,7 +71,7 @@ public:
 
         stream = audio_core.OpenStream(system.CoreTiming(), audio_params.sample_rate,
                                        audio_params.channel_count, std::move(unique_name),
-                                       [=]() { buffer_event.writable->Signal(); });
+                                       [this] { buffer_event.writable->Signal(); });
     }
 
 private:

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -548,8 +548,8 @@ private:
                 // Wait the current thread until a buffer becomes available
                 ctx.SleepClientThread(
                     "IHOSBinderDriver::DequeueBuffer", UINT64_MAX,
-                    [=](std::shared_ptr<Kernel::Thread> thread, Kernel::HLERequestContext& ctx,
-                        Kernel::ThreadWakeupReason reason) {
+                    [=, this](std::shared_ptr<Kernel::Thread> thread,
+                              Kernel::HLERequestContext& ctx, Kernel::ThreadWakeupReason reason) {
                         // Repeat TransactParcel DequeueBuffer when a buffer is available
                         const auto guard = nv_flinger->Lock();
                         auto& buffer_queue = nv_flinger->FindBufferQueue(id);

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -81,7 +81,7 @@ void GPU::WaitFence(u32 syncpoint_id, u32 value) {
     }
     MICROPROFILE_SCOPE(GPU_wait);
     std::unique_lock lock{sync_mutex};
-    sync_cv.wait(lock, [=]() { return syncpoints[syncpoint_id].load() >= value; });
+    sync_cv.wait(lock, [=, this] { return syncpoints[syncpoint_id].load() >= value; });
 }
 
 void GPU::IncrementSyncPoint(const u32 syncpoint_id) {

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -567,7 +567,7 @@ void GRenderWindow::CaptureScreenshot(u32 res_scale, const QString& screenshot_p
     screenshot_image = QImage(QSize(layout.width, layout.height), QImage::Format_RGB32);
     renderer.RequestScreenshot(
         screenshot_image.bits(),
-        [=] {
+        [=, this] {
             const std::string std_screenshot_path = screenshot_path.toStdString();
             if (screenshot_image.mirrored(false, true).save(screenshot_path)) {
                 LOG_INFO(Frontend, "Screenshot saved to \"{}\"", std_screenshot_path);

--- a/src/yuzu/configuration/configure_mouse_advanced.cpp
+++ b/src/yuzu/configuration/configure_mouse_advanced.cpp
@@ -83,25 +83,28 @@ ConfigureMouseAdvanced::ConfigureMouseAdvanced(QWidget* parent)
         }
 
         button->setContextMenuPolicy(Qt::CustomContextMenu);
-        connect(button, &QPushButton::clicked, [=] {
-            HandleClick(
-                button_map[button_id],
-                [=](const Common::ParamPackage& params) { buttons_param[button_id] = params; },
-                InputCommon::Polling::DeviceType::Button);
+        connect(button, &QPushButton::clicked, [=, this] {
+            HandleClick(button_map[button_id],
+                        [=, this](const Common::ParamPackage& params) {
+                            buttons_param[button_id] = params;
+                        },
+                        InputCommon::Polling::DeviceType::Button);
         });
-        connect(button, &QPushButton::customContextMenuRequested, [=](const QPoint& menu_location) {
-            QMenu context_menu;
-            context_menu.addAction(tr("Clear"), [&] {
-                buttons_param[button_id].Clear();
-                button_map[button_id]->setText(tr("[not set]"));
-            });
-            context_menu.addAction(tr("Restore Default"), [&] {
-                buttons_param[button_id] = Common::ParamPackage{
-                    InputCommon::GenerateKeyboardParam(Config::default_mouse_buttons[button_id])};
-                button_map[button_id]->setText(ButtonToText(buttons_param[button_id]));
-            });
-            context_menu.exec(button_map[button_id]->mapToGlobal(menu_location));
-        });
+        connect(button, &QPushButton::customContextMenuRequested,
+                [=, this](const QPoint& menu_location) {
+                    QMenu context_menu;
+                    context_menu.addAction(tr("Clear"), [&] {
+                        buttons_param[button_id].Clear();
+                        button_map[button_id]->setText(tr("[not set]"));
+                    });
+                    context_menu.addAction(tr("Restore Default"), [&] {
+                        buttons_param[button_id] =
+                            Common::ParamPackage{InputCommon::GenerateKeyboardParam(
+                                Config::default_mouse_buttons[button_id])};
+                        button_map[button_id]->setText(ButtonToText(buttons_param[button_id]));
+                    });
+                    context_menu.exec(button_map[button_id]->mapToGlobal(menu_location));
+                });
     }
 
     connect(ui->buttonClearAll, &QPushButton::clicked, [this] { ClearAll(); });

--- a/src/yuzu/configuration/configure_ui.cpp
+++ b/src/yuzu/configuration/configure_ui.cpp
@@ -54,9 +54,9 @@ ConfigureUi::ConfigureUi(QWidget* parent) : QWidget(parent), ui(new Ui::Configur
 
     // Update text ComboBoxes after user interaction.
     connect(ui->row_1_text_combobox, QOverload<int>::of(&QComboBox::activated),
-            [=]() { ConfigureUi::UpdateSecondRowComboBox(); });
+            [this] { ConfigureUi::UpdateSecondRowComboBox(); });
     connect(ui->row_2_text_combobox, QOverload<int>::of(&QComboBox::activated),
-            [=]() { ConfigureUi::UpdateFirstRowComboBox(); });
+            [this] { ConfigureUi::UpdateFirstRowComboBox(); });
 
     // Set screenshot path to user specification.
     connect(ui->screenshot_path_button, &QToolButton::pressed, this, [this] {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -583,7 +583,7 @@ void GMainWindow::InitializeWidgets() {
     renderer_status_button->setObjectName(QStringLiteral("RendererStatusBarButton"));
     renderer_status_button->setCheckable(true);
     renderer_status_button->setFocusPolicy(Qt::NoFocus);
-    connect(renderer_status_button, &QPushButton::toggled, [=](bool checked) {
+    connect(renderer_status_button, &QPushButton::toggled, [this](bool checked) {
         renderer_status_button->setText(checked ? tr("VULKAN") : tr("OPENGL"));
     });
     renderer_status_button->toggle();
@@ -595,7 +595,7 @@ void GMainWindow::InitializeWidgets() {
 #else
     renderer_status_button->setChecked(Settings::values.renderer_backend.GetValue() ==
                                        Settings::RendererBackend::Vulkan);
-    connect(renderer_status_button, &QPushButton::clicked, [=] {
+    connect(renderer_status_button, &QPushButton::clicked, [this] {
         if (emulation_running) {
             return;
         }


### PR DESCRIPTION
C++20 deprecates capturing the this pointer via the '=' capture. Instead, we replace it or extend the capture specification.