### PR TITLE
address_arbiter/scheduler: Resolve sign conversion warnings

### DIFF
--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -81,7 +81,7 @@ ResultCode AddressArbiter::IncrementAndSignalToAddressIfEqual(VAddr address, s32
     do {
         current_value = monitor.ExclusiveRead32(current_core, address);
 
-        if (current_value != value) {
+        if (current_value != static_cast<u32>(value)) {
             return ERR_INVALID_STATE;
         }
         current_value++;

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -131,7 +131,8 @@ u32 GlobalScheduler::SelectThreads() {
     u32 cores_needing_context_switch{};
     for (u32 core = 0; core < Core::Hardware::NUM_CPU_CORES; core++) {
         Scheduler& sched = kernel.Scheduler(core);
-        ASSERT(top_threads[core] == nullptr || top_threads[core]->GetProcessorID() == core);
+        ASSERT(top_threads[core] == nullptr ||
+               static_cast<u32>(top_threads[core]->GetProcessorID()) == core);
         if (update_thread(top_threads[core], sched)) {
             cores_needing_context_switch |= (1ul << core);
         }


### PR DESCRIPTION
Makes the type conversion explicit.