### PR TITLE
common/virtual_buffer: drop unused includes

### DIFF
--- a/src/common/virtual_buffer.cpp
+++ b/src/common/virtual_buffer.cpp
@@ -5,16 +5,7 @@
 #ifdef _WIN32
 #include <windows.h>
 #else
-#include <stdio.h>
 #include <sys/mman.h>
-#include <sys/types.h>
-#if defined __APPLE__ || defined __FreeBSD__ || defined __OpenBSD__
-#include <sys/sysctl.h>
-#elif defined __HAIKU__
-#include <OS.h>
-#else
-#include <sys/sysinfo.h>
-#endif
 #endif
 
 #include "common/assert.h"


### PR DESCRIPTION
Regressed by #3666. Similar to #4208. From [DragonFly build log](https://sting.dragonflybsd.org/dports/logs/emulators___yuzu-qt5.log):
```
src/common/virtual_buffer.cpp
src/common/virtual_buffer.cpp:16:10: fatal error: sys/sysinfo.h: No such file or directory
 #include <sys/sysinfo.h>
          ^~~~~~~~~~~~~~~
```
