### PR TITLE
aes_util: Make use of non-template variant of Transcode

### DIFF
--- a/src/core/crypto/aes_util.cpp
+++ b/src/core/crypto/aes_util.cpp
@@ -116,7 +116,7 @@ void AESCipher<Key, KeySize>::XTSTranscode(const u8* src, std::size_t size, u8* 
 
     for (std::size_t i = 0; i < size; i += sector_size) {
         SetIV(CalculateNintendoTweak(sector_id++));
-        Transcode<u8, u8>(src + i, sector_size, dest + i, op);
+        Transcode(src + i, sector_size, dest + i, op);
     }
 }
 

--- a/src/core/crypto/partition_data_manager.cpp
+++ b/src/core/crypto/partition_data_manager.cpp
@@ -349,8 +349,8 @@ static bool AttemptDecrypt(const std::array<u8, 16>& key, Package2Header& header
     Package2Header temp = header;
     AESCipher<Key128> cipher(key, Mode::CTR);
     cipher.SetIV(header.header_ctr);
-    cipher.Transcode(&temp.header_ctr, sizeof(Package2Header) - 0x100, &temp.header_ctr,
-                     Op::Decrypt);
+    cipher.Transcode(&temp.header_ctr, sizeof(Package2Header) - sizeof(Package2Header::signature),
+                     &temp.header_ctr, Op::Decrypt);
     if (temp.magic == Common::MakeMagic('P', 'K', '2', '1')) {
         header = temp;
         return true;


### PR DESCRIPTION
Same behavior, but minus a template instantiation. The input parameters are already typed correct to be able to be used with the non-template variant. While we're at it, we can get rid of a magic constant.