### PR TITLE
freezer: Make use of std::erase_if

### DIFF
--- a/src/core/tools/freezer.cpp
+++ b/src/core/tools/freezer.cpp
@@ -107,10 +107,7 @@ void Freezer::Unfreeze(VAddr address) {
 
     LOG_DEBUG(Common_Memory, "Unfreezing memory for address={:016X}", address);
 
-    entries.erase(
-        std::remove_if(entries.begin(), entries.end(),
-                       [&address](const Entry& entry) { return entry.address == address; }),
-        entries.end());
+    std::erase_if(entries, [address](const Entry& entry) { return entry.address == address; });
 }
 
 bool Freezer::IsFrozen(VAddr address) const {

--- a/src/core/tools/freezer.cpp
+++ b/src/core/tools/freezer.cpp
@@ -113,19 +113,15 @@ void Freezer::Unfreeze(VAddr address) {
 bool Freezer::IsFrozen(VAddr address) const {
     std::lock_guard lock{entries_mutex};
 
-    return std::find_if(entries.begin(), entries.end(), [address](const Entry& entry) {
-               return entry.address == address;
-           }) != entries.end();
+    return FindEntry(address) != entries.cend();
 }
 
 void Freezer::SetFrozenValue(VAddr address, u64 value) {
     std::lock_guard lock{entries_mutex};
 
-    const auto iter = std::find_if(entries.begin(), entries.end(), [address](const Entry& entry) {
-        return entry.address == address;
-    });
+    const auto iter = FindEntry(address);
 
-    if (iter == entries.end()) {
+    if (iter == entries.cend()) {
         LOG_ERROR(Common_Memory,
                   "Tried to set freeze value for address={:016X} that is not frozen!", address);
         return;
@@ -140,11 +136,9 @@ void Freezer::SetFrozenValue(VAddr address, u64 value) {
 std::optional<Freezer::Entry> Freezer::GetEntry(VAddr address) const {
     std::lock_guard lock{entries_mutex};
 
-    const auto iter = std::find_if(entries.begin(), entries.end(), [address](const Entry& entry) {
-        return entry.address == address;
-    });
+    const auto iter = FindEntry(address);
 
-    if (iter == entries.end()) {
+    if (iter == entries.cend()) {
         return std::nullopt;
     }
 
@@ -155,6 +149,16 @@ std::vector<Freezer::Entry> Freezer::GetEntries() const {
     std::lock_guard lock{entries_mutex};
 
     return entries;
+}
+
+Freezer::Entries::iterator Freezer::FindEntry(VAddr address) {
+    return std::find_if(entries.begin(), entries.end(),
+                        [address](const Entry& entry) { return entry.address == address; });
+}
+
+Freezer::Entries::const_iterator Freezer::FindEntry(VAddr address) const {
+    return std::find_if(entries.begin(), entries.end(),
+                        [address](const Entry& entry) { return entry.address == address; });
 }
 
 void Freezer::FrameCallback(std::uintptr_t, std::chrono::nanoseconds ns_late) {

--- a/src/core/tools/freezer.cpp
+++ b/src/core/tools/freezer.cpp
@@ -113,7 +113,7 @@ void Freezer::Unfreeze(VAddr address) {
 bool Freezer::IsFrozen(VAddr address) const {
     std::lock_guard lock{entries_mutex};
 
-    return std::find_if(entries.begin(), entries.end(), [&address](const Entry& entry) {
+    return std::find_if(entries.begin(), entries.end(), [address](const Entry& entry) {
                return entry.address == address;
            }) != entries.end();
 }
@@ -121,7 +121,7 @@ bool Freezer::IsFrozen(VAddr address) const {
 void Freezer::SetFrozenValue(VAddr address, u64 value) {
     std::lock_guard lock{entries_mutex};
 
-    const auto iter = std::find_if(entries.begin(), entries.end(), [&address](const Entry& entry) {
+    const auto iter = std::find_if(entries.begin(), entries.end(), [address](const Entry& entry) {
         return entry.address == address;
     });
 
@@ -140,7 +140,7 @@ void Freezer::SetFrozenValue(VAddr address, u64 value) {
 std::optional<Freezer::Entry> Freezer::GetEntry(VAddr address) const {
     std::lock_guard lock{entries_mutex};
 
-    const auto iter = std::find_if(entries.begin(), entries.end(), [&address](const Entry& entry) {
+    const auto iter = std::find_if(entries.begin(), entries.end(), [address](const Entry& entry) {
         return entry.address == address;
     });
 

--- a/src/core/tools/freezer.h
+++ b/src/core/tools/freezer.h
@@ -73,13 +73,18 @@ public:
     std::vector<Entry> GetEntries() const;
 
 private:
+    using Entries = std::vector<Entry>;
+
+    Entries::iterator FindEntry(VAddr address);
+    Entries::const_iterator FindEntry(VAddr address) const;
+
     void FrameCallback(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);
     void FillEntryReads();
 
     std::atomic_bool active{false};
 
     mutable std::mutex entries_mutex;
-    std::vector<Entry> entries;
+    Entries entries;
 
     std::shared_ptr<Core::Timing::EventType> event;
     Core::Timing::CoreTiming& core_timing;


### PR DESCRIPTION
With C++20 we can simplify the erasing idiom.

While we're at it, we can coalesce the repeated entry finding code into their own functions to make for nicer reading.