### PR TITLE
common/concepts: Rename IsBaseOf to DerivedFrom

### DIFF
--- a/src/common/concepts.h
+++ b/src/common/concepts.h
@@ -23,10 +23,12 @@ concept IsSTLContainer = requires(T t) {
     t.size();
 };
 
-// Check if type T is derived from T2
-template <typename T, typename T2>
-concept IsBaseOf = requires {
-    std::is_base_of_v<T, T2>;
+// TODO: Replace with std::derived_from when the <concepts> header
+//       is available on all supported platforms.
+template <typename Derived, typename Base>
+concept DerivedFrom = requires {
+    std::is_base_of_v<Base, Derived>;
+    std::is_convertible_v<const volatile Derived*, const volatile Base*>;
 };
 
 } // namespace Common

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -57,7 +57,7 @@ public:
     ResultVal<std::shared_ptr<Kernel::ClientPort>> GetServicePort(const std::string& name);
     ResultVal<std::shared_ptr<Kernel::ClientSession>> ConnectToService(const std::string& name);
 
-    template <Common::IsBaseOf<Kernel::SessionRequestHandler> T>
+    template <Common::DerivedFrom<Kernel::SessionRequestHandler> T>
     std::shared_ptr<T> GetService(const std::string& service_name) const {
         auto service = registered_services.find(service_name);
         if (service == registered_services.end()) {

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -25,7 +25,7 @@ namespace Loader {
 
 namespace {
 
-template <Common::IsBaseOf<AppLoader> T>
+template <Common::DerivedFrom<AppLoader> T>
 std::optional<FileType> IdentifyFileLoader(FileSys::VirtualFile file) {
     const auto file_type = T::IdentifyType(file);
     if (file_type != FileType::Error) {


### PR DESCRIPTION
This makes it more inline with its currently unavailable standardized analogue [std::derived_from](https://en.cppreference.com/w/cpp/concepts/derived_from). While we're at it, we can also make the template match the requirements of the standardized variant as well.