### PR TITLE
General: Tidy up clang-format warnings

### DIFF
--- a/.ci/scripts/format/script.sh
+++ b/.ci/scripts/format/script.sh
@@ -7,7 +7,9 @@ if grep -nrI '\s$' src *.yml *.txt *.md Doxyfile .gitignore .gitmodules .ci* dis
 fi
 
 # Default clang-format points to default 3.5 version one
-CLANG_FORMAT=clang-format-10.0
+CLANG_FORMAT=clang-format-10
+ls /usr/bin
+
 $CLANG_FORMAT --version
 
 if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -456,7 +456,7 @@ endif()
 # against all the src files. This should be used before making a pull request.
 # =======================================================================
 
-set(CLANG_FORMAT_POSTFIX "-6.0")
+set(CLANG_FORMAT_POSTFIX "-10")
 find_program(CLANG_FORMAT
     NAMES clang-format${CLANG_FORMAT_POSTFIX}
           clang-format

--- a/src/common/bit_field.h
+++ b/src/common/bit_field.h
@@ -161,7 +161,7 @@ public:
         }
     }
 
-    // This constructor and assignment operator might be considered ambiguous:
+    /// This constructor and assignment operator might be considered ambiguous:
     // Would they initialize the storage or just the bitfield?
     // Hence, delete them. Use the Assign method to set bitfield values!
     BitField(T val) = delete;


### PR DESCRIPTION
Now that we updates to clang-format 10. This PR serves to catch anything that is now unconforming to the updated clang-format.

This just changes a piece of code in order to run the pass.