### PR TITLE
General: Tidy up clang-format warnings part 2

### DIFF
--- a/.ci/scripts/format/script.sh
+++ b/.ci/scripts/format/script.sh
@@ -8,8 +8,6 @@ fi
 
 # Default clang-format points to default 3.5 version one
 CLANG_FORMAT=clang-format-10
-ls /usr/bin
-
 $CLANG_FORMAT --version
 
 if [ "$TRAVIS_EVENT_TYPE" = "pull_request" ]; then

--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -78,7 +78,7 @@ public:
                 const s16 surround_left{samples[i + 4]};
                 const s16 surround_right{samples[i + 5]};
                 // Not used in the ATSC reference implementation
-                [[maybe_unused]] const s16 low_frequency_effects { samples[i + 3] };
+                [[maybe_unused]] const s16 low_frequency_effects{samples[i + 3]};
 
                 constexpr s32 clev{707}; // center mixing level coefficient
                 constexpr s32 slev{707}; // surround mixing level coefficient

--- a/src/common/bit_field.h
+++ b/src/common/bit_field.h
@@ -161,7 +161,7 @@ public:
         }
     }
 
-    /// This constructor and assignment operator might be considered ambiguous:
+    // This constructor and assignment operator might be considered ambiguous:
     // Would they initialize the storage or just the bitfield?
     // Hence, delete them. Use the Assign method to set bitfield values!
     BitField(T val) = delete;

--- a/src/common/detached_tasks.cpp
+++ b/src/common/detached_tasks.cpp
@@ -34,8 +34,7 @@ void DetachedTasks::AddTask(std::function<void()> task) {
         std::unique_lock lock{instance->mutex};
         --instance->count;
         std::notify_all_at_thread_exit(instance->cv, std::move(lock));
-    })
-        .detach();
+    }).detach();
 }
 
 } // namespace Common

--- a/src/common/math_util.h
+++ b/src/common/math_util.h
@@ -54,6 +54,6 @@ struct Rectangle {
 };
 
 template <typename T>
-Rectangle(T, T, T, T)->Rectangle<T>;
+Rectangle(T, T, T, T) -> Rectangle<T>;
 
 } // namespace Common

--- a/src/core/file_sys/registered_cache.h
+++ b/src/core/file_sys/registered_cache.h
@@ -133,9 +133,9 @@ public:
     // Parsing function defines the conversion from raw file to NCA. If there are other steps
     // besides creating the NCA from the file (e.g. NAX0 on SD Card), that should go in a custom
     // parsing function.
-    explicit RegisteredCache(VirtualDir dir,
-                             ContentProviderParsingFunction parsing_function =
-                                 [](const VirtualFile& file, const NcaID& id) { return file; });
+    explicit RegisteredCache(
+        VirtualDir dir, ContentProviderParsingFunction parsing_function =
+                            [](const VirtualFile& file, const NcaID& id) { return file; });
     ~RegisteredCache() override;
 
     void Refresh() override;

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -293,13 +293,15 @@ std::vector<u8> HLERequestContext::ReadBuffer(std::size_t buffer_index) const {
                            BufferDescriptorA()[buffer_index].Size()};
 
     if (is_buffer_a) {
-        ASSERT_OR_EXECUTE_MSG(BufferDescriptorA().size() > buffer_index, { return buffer; },
-                              "BufferDescriptorA invalid buffer_index {}", buffer_index);
+        ASSERT_OR_EXECUTE_MSG(
+            BufferDescriptorA().size() > buffer_index, { return buffer; },
+            "BufferDescriptorA invalid buffer_index {}", buffer_index);
         buffer.resize(BufferDescriptorA()[buffer_index].Size());
         memory.ReadBlock(BufferDescriptorA()[buffer_index].Address(), buffer.data(), buffer.size());
     } else {
-        ASSERT_OR_EXECUTE_MSG(BufferDescriptorX().size() > buffer_index, { return buffer; },
-                              "BufferDescriptorX invalid buffer_index {}", buffer_index);
+        ASSERT_OR_EXECUTE_MSG(
+            BufferDescriptorX().size() > buffer_index, { return buffer; },
+            "BufferDescriptorX invalid buffer_index {}", buffer_index);
         buffer.resize(BufferDescriptorX()[buffer_index].Size());
         memory.ReadBlock(BufferDescriptorX()[buffer_index].Address(), buffer.data(), buffer.size());
     }
@@ -324,16 +326,16 @@ std::size_t HLERequestContext::WriteBuffer(const void* buffer, std::size_t size,
     }
 
     if (is_buffer_b) {
-        ASSERT_OR_EXECUTE_MSG(BufferDescriptorB().size() > buffer_index &&
-                                  BufferDescriptorB()[buffer_index].Size() >= size,
-                              { return 0; }, "BufferDescriptorB is invalid, index={}, size={}",
-                              buffer_index, size);
+        ASSERT_OR_EXECUTE_MSG(
+            BufferDescriptorB().size() > buffer_index &&
+                BufferDescriptorB()[buffer_index].Size() >= size,
+            { return 0; }, "BufferDescriptorB is invalid, index={}, size={}", buffer_index, size);
         memory.WriteBlock(BufferDescriptorB()[buffer_index].Address(), buffer, size);
     } else {
-        ASSERT_OR_EXECUTE_MSG(BufferDescriptorC().size() > buffer_index &&
-                                  BufferDescriptorC()[buffer_index].Size() >= size,
-                              { return 0; }, "BufferDescriptorC is invalid, index={}, size={}",
-                              buffer_index, size);
+        ASSERT_OR_EXECUTE_MSG(
+            BufferDescriptorC().size() > buffer_index &&
+                BufferDescriptorC()[buffer_index].Size() >= size,
+            { return 0; }, "BufferDescriptorC is invalid, index={}, size={}", buffer_index, size);
         memory.WriteBlock(BufferDescriptorC()[buffer_index].Address(), buffer, size);
     }
 
@@ -344,12 +346,14 @@ std::size_t HLERequestContext::GetReadBufferSize(std::size_t buffer_index) const
     const bool is_buffer_a{BufferDescriptorA().size() > buffer_index &&
                            BufferDescriptorA()[buffer_index].Size()};
     if (is_buffer_a) {
-        ASSERT_OR_EXECUTE_MSG(BufferDescriptorA().size() > buffer_index, { return 0; },
-                              "BufferDescriptorA invalid buffer_index {}", buffer_index);
+        ASSERT_OR_EXECUTE_MSG(
+            BufferDescriptorA().size() > buffer_index, { return 0; },
+            "BufferDescriptorA invalid buffer_index {}", buffer_index);
         return BufferDescriptorA()[buffer_index].Size();
     } else {
-        ASSERT_OR_EXECUTE_MSG(BufferDescriptorX().size() > buffer_index, { return 0; },
-                              "BufferDescriptorX invalid buffer_index {}", buffer_index);
+        ASSERT_OR_EXECUTE_MSG(
+            BufferDescriptorX().size() > buffer_index, { return 0; },
+            "BufferDescriptorX invalid buffer_index {}", buffer_index);
         return BufferDescriptorX()[buffer_index].Size();
     }
 }
@@ -358,12 +362,14 @@ std::size_t HLERequestContext::GetWriteBufferSize(std::size_t buffer_index) cons
     const bool is_buffer_b{BufferDescriptorB().size() > buffer_index &&
                            BufferDescriptorB()[buffer_index].Size()};
     if (is_buffer_b) {
-        ASSERT_OR_EXECUTE_MSG(BufferDescriptorB().size() > buffer_index, { return 0; },
-                              "BufferDescriptorB invalid buffer_index {}", buffer_index);
+        ASSERT_OR_EXECUTE_MSG(
+            BufferDescriptorB().size() > buffer_index, { return 0; },
+            "BufferDescriptorB invalid buffer_index {}", buffer_index);
         return BufferDescriptorB()[buffer_index].Size();
     } else {
-        ASSERT_OR_EXECUTE_MSG(BufferDescriptorC().size() > buffer_index, { return 0; },
-                              "BufferDescriptorC invalid buffer_index {}", buffer_index);
+        ASSERT_OR_EXECUTE_MSG(
+            BufferDescriptorC().size() > buffer_index, { return 0; },
+            "BufferDescriptorC invalid buffer_index {}", buffer_index);
         return BufferDescriptorC()[buffer_index].Size();
     }
     return 0;

--- a/src/core/hle/kernel/memory/page_table.cpp
+++ b/src/core/hle/kernel/memory/page_table.cpp
@@ -851,11 +851,12 @@ ResultCode PageTable::LockForDeviceAddressSpace(VAddr addr, std::size_t size) {
         return result;
     }
 
-    block_manager->UpdateLock(addr, size / PageSize,
-                              [](MemoryBlockManager::iterator block, MemoryPermission perm) {
-                                  block->ShareToDevice(perm);
-                              },
-                              perm);
+    block_manager->UpdateLock(
+        addr, size / PageSize,
+        [](MemoryBlockManager::iterator block, MemoryPermission perm) {
+            block->ShareToDevice(perm);
+        },
+        perm);
 
     return RESULT_SUCCESS;
 }
@@ -873,11 +874,12 @@ ResultCode PageTable::UnlockForDeviceAddressSpace(VAddr addr, std::size_t size) 
         return result;
     }
 
-    block_manager->UpdateLock(addr, size / PageSize,
-                              [](MemoryBlockManager::iterator block, MemoryPermission perm) {
-                                  block->UnshareToDevice(perm);
-                              },
-                              perm);
+    block_manager->UpdateLock(
+        addr, size / PageSize,
+        [](MemoryBlockManager::iterator block, MemoryPermission perm) {
+            block->UnshareToDevice(perm);
+        },
+        perm);
 
     return RESULT_SUCCESS;
 }

--- a/src/core/hle/service/am/applets/web_browser.cpp
+++ b/src/core/hle/service/am/applets/web_browser.cpp
@@ -551,7 +551,8 @@ void WebBrowser::ExecuteShop() {
 }
 
 void WebBrowser::ExecuteOffline() {
-    frontend.OpenPageLocal(filename, [this] { UnpackRomFS(); }, [this] { Finalize(); });
+    frontend.OpenPageLocal(
+        filename, [this] { UnpackRomFS(); }, [this] { Finalize(); });
 }
 
 } // namespace Service::AM::Applets

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -206,7 +206,7 @@ private:
     AudioCore::StreamPtr stream;
     std::string device_name;
 
-    [[maybe_unused]] AudoutParams audio_params {};
+    [[maybe_unused]] AudoutParams audio_params{};
 
     /// This is the event handle used to check if the audio buffer was released
     Kernel::EventPair buffer_event;

--- a/src/core/hle/service/bcat/backend/boxcat.cpp
+++ b/src/core/hle/service/bcat/backend/boxcat.cpp
@@ -365,8 +365,7 @@ bool Boxcat::Synchronize(TitleIDVersion title, ProgressServiceBackend& progress)
 
     std::thread([this, title, &progress] {
         SynchronizeInternal(applet_manager, dir_getter, title, progress);
-    })
-        .detach();
+    }).detach();
 
     return true;
 }
@@ -377,8 +376,7 @@ bool Boxcat::SynchronizeDirectory(TitleIDVersion title, std::string name,
 
     std::thread([this, title, name, &progress] {
         SynchronizeInternal(applet_manager, dir_getter, title, progress, name);
-    })
-        .detach();
+    }).detach();
 
     return true;
 }

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -86,11 +86,13 @@ public:
 
     [[nodiscard]] s64 GetNextTicks() const;
 
-    [[nodiscard]] std::unique_lock<std::mutex> Lock() const { return std::unique_lock{*guard}; }
+    [[nodiscard]] std::unique_lock<std::mutex> Lock() const {
+        return std::unique_lock{*guard};
+    }
 
-    private :
-        /// Finds the display identified by the specified ID.
-        [[nodiscard]] VI::Display* FindDisplay(u64 display_id);
+private:
+    /// Finds the display identified by the specified ID.
+    [[nodiscard]] VI::Display* FindDisplay(u64 display_id);
 
     /// Finds the display identified by the specified ID.
     [[nodiscard]] const VI::Display* FindDisplay(u64 display_id) const;

--- a/src/input_common/udp/client.cpp
+++ b/src/input_common/udp/client.cpp
@@ -224,8 +224,7 @@ void TestCommunication(const std::string& host, u16 port, u8 pad_index, u32 clie
         } else {
             failure_callback();
         }
-    })
-        .detach();
+    }).detach();
 }
 
 CalibrationConfigurationJob::CalibrationConfigurationJob(
@@ -279,8 +278,7 @@ CalibrationConfigurationJob::CalibrationConfigurationJob(
         complete_event.Wait();
         socket.Stop();
         worker_thread.join();
-    })
-        .detach();
+    }).detach();
 }
 
 CalibrationConfigurationJob::~CalibrationConfigurationJob() {

--- a/src/video_core/renderer_vulkan/wrapper.h
+++ b/src/video_core/renderer_vulkan/wrapper.h
@@ -756,8 +756,8 @@ public:
     }
 
     VkResult GetQueryResults(VkQueryPool query_pool, u32 first, u32 count, std::size_t data_size,
-                             void* data, VkDeviceSize stride, VkQueryResultFlags flags) const
-        noexcept {
+                             void* data, VkDeviceSize stride,
+                             VkQueryResultFlags flags) const noexcept {
         return dld->vkGetQueryPoolResults(handle, query_pool, first, count, data_size, data, stride,
                                           flags);
     }
@@ -849,8 +849,8 @@ public:
         dld->vkCmdBindPipeline(handle, bind_point, pipeline);
     }
 
-    void BindIndexBuffer(VkBuffer buffer, VkDeviceSize offset, VkIndexType index_type) const
-        noexcept {
+    void BindIndexBuffer(VkBuffer buffer, VkDeviceSize offset,
+                         VkIndexType index_type) const noexcept {
         dld->vkCmdBindIndexBuffer(handle, buffer, offset, index_type);
     }
 
@@ -863,8 +863,8 @@ public:
         BindVertexBuffers(binding, 1, &buffer, &offset);
     }
 
-    void Draw(u32 vertex_count, u32 instance_count, u32 first_vertex, u32 first_instance) const
-        noexcept {
+    void Draw(u32 vertex_count, u32 instance_count, u32 first_vertex,
+              u32 first_instance) const noexcept {
         dld->vkCmdDraw(handle, vertex_count, instance_count, first_vertex, first_instance);
     }
 
@@ -874,15 +874,15 @@ public:
                               first_instance);
     }
 
-    void ClearAttachments(Span<VkClearAttachment> attachments, Span<VkClearRect> rects) const
-        noexcept {
+    void ClearAttachments(Span<VkClearAttachment> attachments,
+                          Span<VkClearRect> rects) const noexcept {
         dld->vkCmdClearAttachments(handle, attachments.size(), attachments.data(), rects.size(),
                                    rects.data());
     }
 
     void BlitImage(VkImage src_image, VkImageLayout src_layout, VkImage dst_image,
-                   VkImageLayout dst_layout, Span<VkImageBlit> regions, VkFilter filter) const
-        noexcept {
+                   VkImageLayout dst_layout, Span<VkImageBlit> regions,
+                   VkFilter filter) const noexcept {
         dld->vkCmdBlitImage(handle, src_image, src_layout, dst_image, dst_layout, regions.size(),
                             regions.data(), filter);
     }
@@ -907,8 +907,8 @@ public:
                                     regions.data());
     }
 
-    void CopyBuffer(VkBuffer src_buffer, VkBuffer dst_buffer, Span<VkBufferCopy> regions) const
-        noexcept {
+    void CopyBuffer(VkBuffer src_buffer, VkBuffer dst_buffer,
+                    Span<VkBufferCopy> regions) const noexcept {
         dld->vkCmdCopyBuffer(handle, src_buffer, dst_buffer, regions.size(), regions.data());
     }
 
@@ -924,8 +924,8 @@ public:
                                     regions.data());
     }
 
-    void FillBuffer(VkBuffer dst_buffer, VkDeviceSize dst_offset, VkDeviceSize size, u32 data) const
-        noexcept {
+    void FillBuffer(VkBuffer dst_buffer, VkDeviceSize dst_offset, VkDeviceSize size,
+                    u32 data) const noexcept {
         dld->vkCmdFillBuffer(handle, dst_buffer, dst_offset, size, data);
     }
 

--- a/src/video_core/shader/control_flow.cpp
+++ b/src/video_core/shader/control_flow.cpp
@@ -187,24 +187,26 @@ std::optional<std::pair<BufferInfo, u64>> TrackLDC(const CFGRebuildState& state,
 
 std::optional<u64> TrackSHLRegister(const CFGRebuildState& state, u32& pos,
                                     u64 ldc_tracked_register) {
-    return TrackInstruction<u64>(state, pos,
-                                 [ldc_tracked_register](auto instr, const auto& opcode) {
-                                     return opcode.GetId() == OpCode::Id::SHL_IMM &&
-                                            instr.gpr0.Value() == ldc_tracked_register;
-                                 },
-                                 [](auto instr, const auto&) { return instr.gpr8.Value(); });
+    return TrackInstruction<u64>(
+        state, pos,
+        [ldc_tracked_register](auto instr, const auto& opcode) {
+            return opcode.GetId() == OpCode::Id::SHL_IMM &&
+                   instr.gpr0.Value() == ldc_tracked_register;
+        },
+        [](auto instr, const auto&) { return instr.gpr8.Value(); });
 }
 
 std::optional<u32> TrackIMNMXValue(const CFGRebuildState& state, u32& pos,
                                    u64 shl_tracked_register) {
-    return TrackInstruction<u32>(state, pos,
-                                 [shl_tracked_register](auto instr, const auto& opcode) {
-                                     return opcode.GetId() == OpCode::Id::IMNMX_IMM &&
-                                            instr.gpr0.Value() == shl_tracked_register;
-                                 },
-                                 [](auto instr, const auto&) {
-                                     return static_cast<u32>(instr.alu.GetSignedImm20_20() + 1);
-                                 });
+    return TrackInstruction<u32>(
+        state, pos,
+        [shl_tracked_register](auto instr, const auto& opcode) {
+            return opcode.GetId() == OpCode::Id::IMNMX_IMM &&
+                   instr.gpr0.Value() == shl_tracked_register;
+        },
+        [](auto instr, const auto&) {
+            return static_cast<u32>(instr.alu.GetSignedImm20_20() + 1);
+        });
 }
 
 std::optional<BranchIndirectInfo> TrackBranchIndirectInfo(const CFGRebuildState& state, u32 pos) {

--- a/src/video_core/shader/decode/memory.cpp
+++ b/src/video_core/shader/decode/memory.cpp
@@ -471,9 +471,9 @@ std::tuple<Node, Node, GlobalMemoryBase> ShaderIR::TrackGlobalMemory(NodeBlock& 
 
     const auto [base_address, index, offset] =
         TrackCbuf(addr_register, global_code, static_cast<s64>(global_code.size()));
-    ASSERT_OR_EXECUTE_MSG(base_address != nullptr,
-                          { return std::make_tuple(nullptr, nullptr, GlobalMemoryBase{}); },
-                          "Global memory tracking failed");
+    ASSERT_OR_EXECUTE_MSG(
+        base_address != nullptr, { return std::make_tuple(nullptr, nullptr, GlobalMemoryBase{}); },
+        "Global memory tracking failed");
 
     bb.push_back(Comment(fmt::format("Base address is c[0x{:x}][0x{:x}]", index, offset)));
 

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -281,24 +281,25 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
 
         button->setContextMenuPolicy(Qt::CustomContextMenu);
         connect(button, &QPushButton::clicked, [=, this] {
-            HandleClick(button_map[button_id],
-                        [=, this](Common::ParamPackage params) {
-                            // Workaround for ZL & ZR for analog triggers like on XBOX controllors.
-                            // Analog triggers (from controllers like the XBOX controller) would not
-                            // work due to a different range of their signals (from 0 to 255 on
-                            // analog triggers instead of -32768 to 32768 on analog joysticks). The
-                            // SDL driver misinterprets analog triggers as analog joysticks.
-                            // TODO: reinterpret the signal range for analog triggers to map the
-                            // values correctly. This is required for the correct emulation of the
-                            // analog triggers of the GameCube controller.
-                            if (button_id == Settings::NativeButton::ZL ||
-                                button_id == Settings::NativeButton::ZR) {
-                                params.Set("direction", "+");
-                                params.Set("threshold", "0.5");
-                            }
-                            buttons_param[button_id] = std::move(params);
-                        },
-                        InputCommon::Polling::DeviceType::Button);
+            HandleClick(
+                button_map[button_id],
+                [=, this](Common::ParamPackage params) {
+                    // Workaround for ZL & ZR for analog triggers like on XBOX controllors.
+                    // Analog triggers (from controllers like the XBOX controller) would not
+                    // work due to a different range of their signals (from 0 to 255 on
+                    // analog triggers instead of -32768 to 32768 on analog joysticks). The
+                    // SDL driver misinterprets analog triggers as analog joysticks.
+                    // TODO: reinterpret the signal range for analog triggers to map the
+                    // values correctly. This is required for the correct emulation of the
+                    // analog triggers of the GameCube controller.
+                    if (button_id == Settings::NativeButton::ZL ||
+                        button_id == Settings::NativeButton::ZR) {
+                        params.Set("direction", "+");
+                        params.Set("threshold", "0.5");
+                    }
+                    buttons_param[button_id] = std::move(params);
+                },
+                InputCommon::Polling::DeviceType::Button);
         });
         connect(button, &QPushButton::customContextMenuRequested,
                 [=, this](const QPoint& menu_location) {
@@ -325,12 +326,13 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
 
             analog_button->setContextMenuPolicy(Qt::CustomContextMenu);
             connect(analog_button, &QPushButton::clicked, [=, this] {
-                HandleClick(analog_map_buttons[analog_id][sub_button_id],
-                            [=, this](const Common::ParamPackage& params) {
-                                SetAnalogButton(params, analogs_param[analog_id],
-                                                analog_sub_buttons[sub_button_id]);
-                            },
-                            InputCommon::Polling::DeviceType::Button);
+                HandleClick(
+                    analog_map_buttons[analog_id][sub_button_id],
+                    [=, this](const Common::ParamPackage& params) {
+                        SetAnalogButton(params, analogs_param[analog_id],
+                                        analog_sub_buttons[sub_button_id]);
+                    },
+                    InputCommon::Polling::DeviceType::Button);
             });
             connect(analog_button, &QPushButton::customContextMenuRequested,
                     [=, this](const QPoint& menu_location) {
@@ -357,11 +359,12 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
                     tr("After pressing OK, first move your joystick horizontally, "
                        "and then vertically."),
                     QMessageBox::Ok | QMessageBox::Cancel) == QMessageBox::Ok) {
-                HandleClick(analog_map_stick[analog_id],
-                            [=, this](const Common::ParamPackage& params) {
-                                analogs_param[analog_id] = params;
-                            },
-                            InputCommon::Polling::DeviceType::Analog);
+                HandleClick(
+                    analog_map_stick[analog_id],
+                    [=, this](const Common::ParamPackage& params) {
+                        analogs_param[analog_id] = params;
+                    },
+                    InputCommon::Polling::DeviceType::Analog);
             }
         });
 

--- a/src/yuzu/configuration/configure_mouse_advanced.cpp
+++ b/src/yuzu/configuration/configure_mouse_advanced.cpp
@@ -84,11 +84,12 @@ ConfigureMouseAdvanced::ConfigureMouseAdvanced(QWidget* parent)
 
         button->setContextMenuPolicy(Qt::CustomContextMenu);
         connect(button, &QPushButton::clicked, [=, this] {
-            HandleClick(button_map[button_id],
-                        [=, this](const Common::ParamPackage& params) {
-                            buttons_param[button_id] = params;
-                        },
-                        InputCommon::Polling::DeviceType::Button);
+            HandleClick(
+                button_map[button_id],
+                [=, this](const Common::ParamPackage& params) {
+                    buttons_param[button_id] = params;
+                },
+                InputCommon::Polling::DeviceType::Button);
         });
         connect(button, &QPushButton::customContextMenuRequested,
                 [=, this](const QPoint& menu_location) {


### PR DESCRIPTION
General catch all for the clang-format migration changes. This shouldn't be merged until clang-format 10 issues are sorted out.

#4502 wasn't intended to be merged yet, but I forgot to mark the PR as a do not merge PR.