### PR TITLE
gl_shader_cache: Use std::max() for determining num_workers

### DIFF
--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -403,7 +403,7 @@ void ShaderCacheOpenGL::LoadDiskCache(const std::atomic_bool& stop_loading,
         }
     };
 
-    const auto num_workers{static_cast<std::size_t>(std::thread::hardware_concurrency() + 1ULL)};
+    const std::size_t num_workers{std::max(1U, std::thread::hardware_concurrency())};
     const std::size_t bucket_size{transferable->size() / num_workers};
     std::vector<std::unique_ptr<Core::Frontend::GraphicsContext>> contexts(num_workers);
     std::vector<std::thread> threads(num_workers);


### PR DESCRIPTION
Does not allocate more threads than available in the host system for boot-time shader compilation and always allocates at least 1 thread if `std::thread::hardware_concurrency()` returns 0.