### PR TITLE
main: Add an option to modify the currrent game's configuration

### DIFF
--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -216,6 +216,7 @@ private slots:
     void OnMenuInstallToNAND();
     void OnMenuRecentFile();
     void OnConfigure();
+    void OnConfigurePerGame();
     void OnLoadAmiibo();
     void OnOpenYuzuFolder();
     void OnAbout();
@@ -249,6 +250,7 @@ private:
     void ShowMouseCursor();
     void OpenURL(const QUrl& url);
     void LoadTranslation();
+    void OpenPerGameConfiguration(u64 title_id, const std::string& file_name);
 
     Ui::MainWindow ui;
 

--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -81,6 +81,7 @@
     <addaction name="action_Restart"/>
     <addaction name="separator"/>
     <addaction name="action_Configure"/>
+    <addaction name="action_Configure_Current_Game"/>
    </widget>
    <widget class="QMenu" name="menu_View">
     <property name="title">
@@ -285,6 +286,14 @@
    </property>
    <property name="text">
     <string>Capture Screenshot</string>
+   </property>
+  </action>
+  <action name="action_Configure_Current_Game">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Configure Current Game..</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Creates a new entry in the Emulation menu labelled "Configure Current Game..." that is only enabled if a game is currently being run in yuzu. When selected, it opens the game properties dialog for the current game.

Thanks to BSoD for reminding me to do this.