### PR TITLE
CMakeLists: Update fmt to 7.0.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,7 +161,7 @@ macro(yuzu_find_packages)
     #    Cmake Pkg Prefix  Version     Conan Pkg
         "Boost             1.73        boost/1.73.0"
         "Catch2            2.13        catch2/2.13.0"
-        "fmt               7.0         fmt/7.0.1"
+        "fmt               7.0         fmt/7.0.3"
     # can't use until https://github.com/bincrafters/community/issues/1173
         #"libzip            1.5         libzip/1.5.2@bincrafters/stable"
         "lz4               1.8         lz4/1.9.2"


### PR DESCRIPTION
Keeps the library up to date and fixes a few bugs

See changelogs for:

- [7.0.2](https://github.com/fmtlib/fmt/releases/tag/7.0.2)
- [7.0.3](https://github.com/fmtlib/fmt/releases/tag/7.0.3)

respectively to see addressed issues.