### PR TITLE
core: Resolve several -Wextra-semi warnings

### DIFF
--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -342,8 +342,9 @@ ResultVal<std::remove_reference_t<Arg>> MakeResult(Arg&& arg) {
  */
 #define CASCADE_RESULT(target, source)                                                             \
     auto CONCAT2(check_result_L, __LINE__) = source;                                               \
-    if (CONCAT2(check_result_L, __LINE__).Failed())                                                \
+    if (CONCAT2(check_result_L, __LINE__).Failed()) {                                              \
         return CONCAT2(check_result_L, __LINE__).Code();                                           \
+    }                                                                                              \
     target = std::move(*CONCAT2(check_result_L, __LINE__))
 
 /**
@@ -351,6 +352,9 @@ ResultVal<std::remove_reference_t<Arg>> MakeResult(Arg&& arg) {
  * non-success, or discarded otherwise.
  */
 #define CASCADE_CODE(source)                                                                       \
-    auto CONCAT2(check_result_L, __LINE__) = source;                                               \
-    if (CONCAT2(check_result_L, __LINE__).IsError())                                               \
-        return CONCAT2(check_result_L, __LINE__);
+    do {                                                                                           \
+        auto CONCAT2(check_result_L, __LINE__) = source;                                           \
+        if (CONCAT2(check_result_L, __LINE__).IsError()) {                                         \
+            return CONCAT2(check_result_L, __LINE__);                                              \
+        }                                                                                          \
+    } while (false)

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -90,7 +90,7 @@ u32 Controller_NPad::IndexToNPad(std::size_t index) {
     default:
         UNIMPLEMENTED_MSG("Unknown npad index {}", index);
         return 0;
-    };
+    }
 }
 
 Controller_NPad::Controller_NPad(Core::System& system) : ControllerBase(system), system(system) {}
@@ -630,7 +630,7 @@ Controller_NPad::LedPattern Controller_NPad::GetLedPattern(u32 npad_id) {
     default:
         UNIMPLEMENTED_MSG("Unhandled npad_id {}", npad_id);
         return LedPattern{0, 0, 0, 0};
-    };
+    }
 }
 
 void Controller_NPad::SetVibrationEnabled(bool can_vibrate) {

--- a/src/core/hle/service/nvdrv/devices/nvdevice.h
+++ b/src/core/hle/service/nvdrv/devices/nvdevice.h
@@ -21,8 +21,9 @@ namespace Service::Nvidia::Devices {
 /// implement the ioctl interface.
 class nvdevice {
 public:
-    explicit nvdevice(Core::System& system) : system{system} {};
+    explicit nvdevice(Core::System& system) : system{system} {}
     virtual ~nvdevice() = default;
+
     union Ioctl {
         u32_le raw;
         BitField<0, 8, u32> cmd;


### PR DESCRIPTION
We can amend one of the cascade macros to require semicolons in order to compile. In other cases, we can just remove the superfluous semicolons. Silences around 30+ warnings.