### PR TITLE
software_keyboard: Resolve a pessimizing move warning

### DIFF
--- a/src/core/hle/service/am/applets/software_keyboard.cpp
+++ b/src/core/hle/service/am/applets/software_keyboard.cpp
@@ -122,8 +122,7 @@ void SoftwareKeyboard::ExecuteInteractive() {
 
         switch (request) {
         case Request::Calc: {
-            broker.PushNormalDataFromApplet(
-                std::make_shared<IStorage>(std::move(std::vector<u8>{1})));
+            broker.PushNormalDataFromApplet(std::make_shared<IStorage>(std::vector<u8>{1}));
             broker.SignalStateChanged();
             break;
         }


### PR DESCRIPTION
A std::vector created in place like this is already an rvalue and doesn't need to be moved.