### PR TITLE
common/fileutil: Convert namespace to Common::FS

### DIFF
--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -19,7 +19,7 @@
 #include "common/string_util.h"
 #endif
 
-namespace FileUtil {
+namespace Common::FS {
 
 // User paths for GetUserPath
 enum class UserPath {
@@ -204,6 +204,16 @@ enum class DirectorySeparator {
     std::string_view path,
     DirectorySeparator directory_separator = DirectorySeparator::ForwardSlash);
 
+// To deal with Windows being dumb at Unicode
+template <typename T>
+void OpenFStream(T& fstream, const std::string& filename, std::ios_base::openmode openmode) {
+#ifdef _MSC_VER
+    fstream.open(Common::UTF8ToUTF16W(filename), openmode);
+#else
+    fstream.open(filename, openmode);
+#endif
+}
+
 // simple wrapper for cstdlib file functions to
 // hopefully will make error checking easier
 // and make forgetting an fclose() harder
@@ -285,14 +295,4 @@ private:
     std::FILE* m_file = nullptr;
 };
 
-} // namespace FileUtil
-
-// To deal with Windows being dumb at unicode:
-template <typename T>
-void OpenFStream(T& fstream, const std::string& filename, std::ios_base::openmode openmode) {
-#ifdef _MSC_VER
-    fstream.open(Common::UTF8ToUTF16W(filename), openmode);
-#else
-    fstream.open(filename, openmode);
-#endif
-}
+} // namespace Common::FS

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -94,7 +94,7 @@ public:
     void Write(const Entry& entry) override;
 
 private:
-    FileUtil::IOFile file;
+    Common::FS::IOFile file;
     std::size_t bytes_written;
 };
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -113,7 +113,7 @@ FileSys::VirtualFile GetGameFileFromPath(const FileSys::VirtualFilesystem& vfs,
         return FileSys::ConcatenatedVfsFile::MakeConcatenatedFile(concat, dir->GetName());
     }
 
-    if (FileUtil::IsDirectory(path))
+    if (Common::FS::IsDirectory(path))
         return vfs->OpenFile(path + "/" + "main", FileSys::Mode::Read);
 
     return vfs->OpenFile(path, FileSys::Mode::Read);

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -96,13 +96,13 @@ u64 GetSignatureTypePaddingSize(SignatureType type) {
 }
 
 SignatureType Ticket::GetSignatureType() const {
-    if (auto ticket = std::get_if<RSA4096Ticket>(&data)) {
+    if (const auto* ticket = std::get_if<RSA4096Ticket>(&data)) {
         return ticket->sig_type;
     }
-    if (auto ticket = std::get_if<RSA2048Ticket>(&data)) {
+    if (const auto* ticket = std::get_if<RSA2048Ticket>(&data)) {
         return ticket->sig_type;
     }
-    if (auto ticket = std::get_if<ECDSATicket>(&data)) {
+    if (const auto* ticket = std::get_if<ECDSATicket>(&data)) {
         return ticket->sig_type;
     }
 
@@ -110,13 +110,13 @@ SignatureType Ticket::GetSignatureType() const {
 }
 
 TicketData& Ticket::GetData() {
-    if (auto ticket = std::get_if<RSA4096Ticket>(&data)) {
+    if (auto* ticket = std::get_if<RSA4096Ticket>(&data)) {
         return ticket->data;
     }
-    if (auto ticket = std::get_if<RSA2048Ticket>(&data)) {
+    if (auto* ticket = std::get_if<RSA2048Ticket>(&data)) {
         return ticket->data;
     }
-    if (auto ticket = std::get_if<ECDSATicket>(&data)) {
+    if (auto* ticket = std::get_if<ECDSATicket>(&data)) {
         return ticket->data;
     }
 
@@ -124,13 +124,13 @@ TicketData& Ticket::GetData() {
 }
 
 const TicketData& Ticket::GetData() const {
-    if (auto ticket = std::get_if<RSA4096Ticket>(&data)) {
+    if (const auto* ticket = std::get_if<RSA4096Ticket>(&data)) {
         return ticket->data;
     }
-    if (auto ticket = std::get_if<RSA2048Ticket>(&data)) {
+    if (const auto* ticket = std::get_if<RSA2048Ticket>(&data)) {
         return ticket->data;
     }
-    if (auto ticket = std::get_if<ECDSATicket>(&data)) {
+    if (const auto* ticket = std::get_if<ECDSATicket>(&data)) {
         return ticket->data;
     }
 
@@ -233,8 +233,9 @@ void KeyManager::DeriveGeneralPurposeKeys(std::size_t crypto_revision) {
 }
 
 RSAKeyPair<2048> KeyManager::GetETicketRSAKey() const {
-    if (IsAllZeroArray(eticket_extended_kek) || !HasKey(S128KeyType::ETicketRSAKek))
+    if (IsAllZeroArray(eticket_extended_kek) || !HasKey(S128KeyType::ETicketRSAKek)) {
         return {};
+    }
 
     const auto eticket_final = GetKey(S128KeyType::ETicketRSAKek);
 
@@ -261,27 +262,30 @@ Key128 DeriveKeyblobMACKey(const Key128& keyblob_key, const Key128& mac_source) 
 }
 
 std::optional<Key128> DeriveSDSeed() {
-    const FileUtil::IOFile save_43(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
-                                       "/system/save/8000000000000043",
-                                   "rb+");
-    if (!save_43.IsOpen())
-        return {};
+    const Common::FS::IOFile save_43(Common::FS::GetUserPath(Common::FS::UserPath::NANDDir) +
+                                         "/system/save/8000000000000043",
+                                     "rb+");
+    if (!save_43.IsOpen()) {
+        return std::nullopt;
+    }
 
-    const FileUtil::IOFile sd_private(
-        FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir) + "/Nintendo/Contents/private", "rb+");
-    if (!sd_private.IsOpen())
-        return {};
+    const Common::FS::IOFile sd_private(Common::FS::GetUserPath(Common::FS::UserPath::SDMCDir) +
+                                            "/Nintendo/Contents/private",
+                                        "rb+");
+    if (!sd_private.IsOpen()) {
+        return std::nullopt;
+    }
 
     std::array<u8, 0x10> private_seed{};
     if (sd_private.ReadBytes(private_seed.data(), private_seed.size()) != private_seed.size()) {
-        return {};
+        return std::nullopt;
     }
 
     std::array<u8, 0x10> buffer{};
     std::size_t offset = 0;
     for (; offset + 0x10 < save_43.GetSize(); ++offset) {
         if (!save_43.Seek(offset, SEEK_SET)) {
-            return {};
+            return std::nullopt;
         }
 
         save_43.ReadBytes(buffer.data(), buffer.size());
@@ -291,23 +295,26 @@ std::optional<Key128> DeriveSDSeed() {
     }
 
     if (!save_43.Seek(offset + 0x10, SEEK_SET)) {
-        return {};
+        return std::nullopt;
     }
 
     Key128 seed{};
     if (save_43.ReadBytes(seed.data(), seed.size()) != seed.size()) {
-        return {};
+        return std::nullopt;
     }
     return seed;
 }
 
 Loader::ResultStatus DeriveSDKeys(std::array<Key256, 2>& sd_keys, KeyManager& keys) {
-    if (!keys.HasKey(S128KeyType::Source, static_cast<u64>(SourceKeyType::SDKek)))
+    if (!keys.HasKey(S128KeyType::Source, static_cast<u64>(SourceKeyType::SDKek))) {
         return Loader::ResultStatus::ErrorMissingSDKEKSource;
-    if (!keys.HasKey(S128KeyType::Source, static_cast<u64>(SourceKeyType::AESKekGeneration)))
+    }
+    if (!keys.HasKey(S128KeyType::Source, static_cast<u64>(SourceKeyType::AESKekGeneration))) {
         return Loader::ResultStatus::ErrorMissingAESKEKGenerationSource;
-    if (!keys.HasKey(S128KeyType::Source, static_cast<u64>(SourceKeyType::AESKeyGeneration)))
+    }
+    if (!keys.HasKey(S128KeyType::Source, static_cast<u64>(SourceKeyType::AESKeyGeneration))) {
         return Loader::ResultStatus::ErrorMissingAESKeyGenerationSource;
+    }
 
     const auto sd_kek_source =
         keys.GetKey(S128KeyType::Source, static_cast<u64>(SourceKeyType::SDKek));
@@ -320,14 +327,17 @@ Loader::ResultStatus DeriveSDKeys(std::array<Key256, 2>& sd_keys, KeyManager& ke
         GenerateKeyEncryptionKey(sd_kek_source, master_00, aes_kek_gen, aes_key_gen);
     keys.SetKey(S128KeyType::SDKek, sd_kek);
 
-    if (!keys.HasKey(S128KeyType::SDSeed))
+    if (!keys.HasKey(S128KeyType::SDSeed)) {
         return Loader::ResultStatus::ErrorMissingSDSeed;
+    }
     const auto sd_seed = keys.GetKey(S128KeyType::SDSeed);
 
-    if (!keys.HasKey(S256KeyType::SDKeySource, static_cast<u64>(SDKeyType::Save)))
+    if (!keys.HasKey(S256KeyType::SDKeySource, static_cast<u64>(SDKeyType::Save))) {
         return Loader::ResultStatus::ErrorMissingSDSaveKeySource;
-    if (!keys.HasKey(S256KeyType::SDKeySource, static_cast<u64>(SDKeyType::NCA)))
+    }
+    if (!keys.HasKey(S256KeyType::SDKeySource, static_cast<u64>(SDKeyType::NCA))) {
         return Loader::ResultStatus::ErrorMissingSDNCAKeySource;
+    }
 
     std::array<Key256, 2> sd_key_sources{
         keys.GetKey(S256KeyType::SDKeySource, static_cast<u64>(SDKeyType::Save)),
@@ -336,8 +346,9 @@ Loader::ResultStatus DeriveSDKeys(std::array<Key256, 2>& sd_keys, KeyManager& ke
 
     // Combine sources and seed
     for (auto& source : sd_key_sources) {
-        for (std::size_t i = 0; i < source.size(); ++i)
+        for (std::size_t i = 0; i < source.size(); ++i) {
             source[i] ^= sd_seed[i & 0xF];
+        }
     }
 
     AESCipher<Key128> cipher(sd_kek, Mode::ECB);
@@ -355,9 +366,10 @@ Loader::ResultStatus DeriveSDKeys(std::array<Key256, 2>& sd_keys, KeyManager& ke
     return Loader::ResultStatus::Success;
 }
 
-std::vector<Ticket> GetTicketblob(const FileUtil::IOFile& ticket_save) {
-    if (!ticket_save.IsOpen())
+std::vector<Ticket> GetTicketblob(const Common::FS::IOFile& ticket_save) {
+    if (!ticket_save.IsOpen()) {
         return {};
+    }
 
     std::vector<u8> buffer(ticket_save.GetSize());
     if (ticket_save.ReadBytes(buffer.data(), buffer.size()) != buffer.size()) {
@@ -417,7 +429,7 @@ static std::optional<u64> FindTicketOffset(const std::array<u8, size>& data) {
             offset = i + 1;
             break;
         } else if (data[i] != 0x0) {
-            return {};
+            return std::nullopt;
         }
     }
 
@@ -427,16 +439,18 @@ static std::optional<u64> FindTicketOffset(const std::array<u8, size>& data) {
 std::optional<std::pair<Key128, Key128>> ParseTicket(const Ticket& ticket,
                                                      const RSAKeyPair<2048>& key) {
     const auto issuer = ticket.GetData().issuer;
-    if (IsAllZeroArray(issuer))
-        return {};
+    if (IsAllZeroArray(issuer)) {
+        return std::nullopt;
+    }
     if (issuer[0] != 'R' || issuer[1] != 'o' || issuer[2] != 'o' || issuer[3] != 't') {
         LOG_INFO(Crypto, "Attempting to parse ticket with non-standard certificate authority.");
     }
 
     Key128 rights_id = ticket.GetData().rights_id;
 
-    if (rights_id == Key128{})
-        return {};
+    if (rights_id == Key128{}) {
+        return std::nullopt;
+    }
 
     if (!std::any_of(ticket.GetData().title_key_common_pad.begin(),
                      ticket.GetData().title_key_common_pad.end(), [](u8 b) { return b != 0; })) {
@@ -468,15 +482,17 @@ std::optional<std::pair<Key128, Key128>> ParseTicket(const Ticket& ticket,
     std::array<u8, 0xDF> m_2;
     std::memcpy(m_2.data(), rsa_step.data() + 0x21, m_2.size());
 
-    if (m_0 != 0)
-        return {};
+    if (m_0 != 0) {
+        return std::nullopt;
+    }
 
     m_1 = m_1 ^ MGF1<0x20>(m_2);
     m_2 = m_2 ^ MGF1<0xDF>(m_1);
 
     const auto offset = FindTicketOffset(m_2);
-    if (!offset)
-        return {};
+    if (!offset) {
+        return std::nullopt;
+    }
     ASSERT(*offset > 0);
 
     Key128 key_temp{};
@@ -487,8 +503,8 @@ std::optional<std::pair<Key128, Key128>> ParseTicket(const Ticket& ticket,
 
 KeyManager::KeyManager() {
     // Initialize keys
-    const std::string hactool_keys_dir = FileUtil::GetHactoolConfigurationPath();
-    const std::string yuzu_keys_dir = FileUtil::GetUserPath(FileUtil::UserPath::KeysDir);
+    const std::string hactool_keys_dir = Common::FS::GetHactoolConfigurationPath();
+    const std::string yuzu_keys_dir = Common::FS::GetUserPath(Common::FS::UserPath::KeysDir);
     if (Settings::values.use_dev_keys) {
         dev_mode = true;
         AttemptLoadKeyFile(yuzu_keys_dir, hactool_keys_dir, "dev.keys", false);
@@ -506,34 +522,39 @@ KeyManager::KeyManager() {
 }
 
 static bool ValidCryptoRevisionString(std::string_view base, size_t begin, size_t length) {
-    if (base.size() < begin + length)
+    if (base.size() < begin + length) {
         return false;
+    }
     return std::all_of(base.begin() + begin, base.begin() + begin + length,
                        [](u8 c) { return std::isxdigit(c); });
 }
 
 void KeyManager::LoadFromFile(const std::string& filename, bool is_title_keys) {
     std::ifstream file;
-    OpenFStream(file, filename, std::ios_base::in);
-    if (!file.is_open())
+    Common::FS::OpenFStream(file, filename, std::ios_base::in);
+    if (!file.is_open()) {
         return;
+    }
 
     std::string line;
     while (std::getline(file, line)) {
         std::vector<std::string> out;
         std::stringstream stream(line);
         std::string item;
-        while (std::getline(stream, item, '='))
+        while (std::getline(stream, item, '=')) {
             out.push_back(std::move(item));
+        }
 
-        if (out.size() != 2)
+        if (out.size() != 2) {
             continue;
+        }
 
         out[0].erase(std::remove(out[0].begin(), out[0].end(), ' '), out[0].end());
         out[1].erase(std::remove(out[1].begin(), out[1].end(), ' '), out[1].end());
 
-        if (out[0].compare(0, 1, "#") == 0)
+        if (out[0].compare(0, 1, "#") == 0) {
             continue;
+        }
 
         if (is_title_keys) {
             auto rights_id_raw = Common::HexStringToArray<16>(out[0]);
@@ -553,14 +574,16 @@ void KeyManager::LoadFromFile(const std::string& filename, bool is_title_keys) {
                 s256_keys[{index.type, index.field1, index.field2}] = key;
             } else if (out[0].compare(0, 8, "keyblob_") == 0 &&
                        out[0].compare(0, 9, "keyblob_k") != 0) {
-                if (!ValidCryptoRevisionString(out[0], 8, 2))
+                if (!ValidCryptoRevisionString(out[0], 8, 2)) {
                     continue;
+                }
 
                 const auto index = std::stoul(out[0].substr(8, 2), nullptr, 16);
                 keyblobs[index] = Common::HexStringToArray<0x90>(out[1]);
             } else if (out[0].compare(0, 18, "encrypted_keyblob_") == 0) {
-                if (!ValidCryptoRevisionString(out[0], 18, 2))
+                if (!ValidCryptoRevisionString(out[0], 18, 2)) {
                     continue;
+                }
 
                 const auto index = std::stoul(out[0].substr(18, 2), nullptr, 16);
                 encrypted_keyblobs[index] = Common::HexStringToArray<0xB0>(out[1]);
@@ -568,8 +591,9 @@ void KeyManager::LoadFromFile(const std::string& filename, bool is_title_keys) {
                 eticket_extended_kek = Common::HexStringToArray<576>(out[1]);
             } else {
                 for (const auto& kv : KEYS_VARIABLE_LENGTH) {
-                    if (!ValidCryptoRevisionString(out[0], kv.second.size(), 2))
+                    if (!ValidCryptoRevisionString(out[0], kv.second.size(), 2)) {
                         continue;
+                    }
                     if (out[0].compare(0, kv.second.size(), kv.second) == 0) {
                         const auto index =
                             std::stoul(out[0].substr(kv.second.size(), 2), nullptr, 16);
@@ -604,10 +628,11 @@ void KeyManager::LoadFromFile(const std::string& filename, bool is_title_keys) {
 
 void KeyManager::AttemptLoadKeyFile(const std::string& dir1, const std::string& dir2,
                                     const std::string& filename, bool title) {
-    if (FileUtil::Exists(dir1 + DIR_SEP + filename))
+    if (Common::FS::Exists(dir1 + DIR_SEP + filename)) {
         LoadFromFile(dir1 + DIR_SEP + filename, title);
-    else if (FileUtil::Exists(dir2 + DIR_SEP + filename))
+    } else if (Common::FS::Exists(dir2 + DIR_SEP + filename)) {
         LoadFromFile(dir2 + DIR_SEP + filename, title);
+    }
 }
 
 bool KeyManager::BaseDeriveNecessary() const {
@@ -615,8 +640,9 @@ bool KeyManager::BaseDeriveNecessary() const {
         return !HasKey(key_type, index1, index2);
     };
 
-    if (check_key_existence(S256KeyType::Header))
+    if (check_key_existence(S256KeyType::Header)) {
         return true;
+    }
 
     for (size_t i = 0; i < CURRENT_CRYPTO_REVISION; ++i) {
         if (check_key_existence(S128KeyType::Master, i) ||
@@ -641,14 +667,16 @@ bool KeyManager::HasKey(S256KeyType id, u64 field1, u64 field2) const {
 }
 
 Key128 KeyManager::GetKey(S128KeyType id, u64 field1, u64 field2) const {
-    if (!HasKey(id, field1, field2))
+    if (!HasKey(id, field1, field2)) {
         return {};
+    }
     return s128_keys.at({id, field1, field2});
 }
 
 Key256 KeyManager::GetKey(S256KeyType id, u64 field1, u64 field2) const {
-    if (!HasKey(id, field1, field2))
+    if (!HasKey(id, field1, field2)) {
         return {};
+    }
     return s256_keys.at({id, field1, field2});
 }
 
@@ -670,7 +698,7 @@ Key256 KeyManager::GetBISKey(u8 partition_id) const {
 template <size_t Size>
 void KeyManager::WriteKeyToFile(KeyCategory category, std::string_view keyname,
                                 const std::array<u8, Size>& key) {
-    const std::string yuzu_keys_dir = FileUtil::GetUserPath(FileUtil::UserPath::KeysDir);
+    const std::string yuzu_keys_dir = Common::FS::GetUserPath(Common::FS::UserPath::KeysDir);
     std::string filename = "title.keys_autogenerated";
     if (category == KeyCategory::Standard) {
         filename = dev_mode ? "dev.keys_autogenerated" : "prod.keys_autogenerated";
@@ -679,9 +707,9 @@ void KeyManager::WriteKeyToFile(KeyCategory category, std::string_view keyname,
     }
 
     const auto path = yuzu_keys_dir + DIR_SEP + filename;
-    const auto add_info_text = !FileUtil::Exists(path);
-    FileUtil::CreateFullPath(path);
-    FileUtil::IOFile file{path, "a"};
+    const auto add_info_text = !Common::FS::Exists(path);
+    Common::FS::CreateFullPath(path);
+    Common::FS::IOFile file{path, "a"};
     if (!file.IsOpen()) {
         return;
     }
@@ -765,29 +793,31 @@ void KeyManager::SetKey(S256KeyType id, Key256 key, u64 field1, u64 field2) {
 }
 
 bool KeyManager::KeyFileExists(bool title) {
-    const std::string hactool_keys_dir = FileUtil::GetHactoolConfigurationPath();
-    const std::string yuzu_keys_dir = FileUtil::GetUserPath(FileUtil::UserPath::KeysDir);
+    const std::string hactool_keys_dir = Common::FS::GetHactoolConfigurationPath();
+    const std::string yuzu_keys_dir = Common::FS::GetUserPath(Common::FS::UserPath::KeysDir);
     if (title) {
-        return FileUtil::Exists(hactool_keys_dir + DIR_SEP + "title.keys") ||
-               FileUtil::Exists(yuzu_keys_dir + DIR_SEP + "title.keys");
+        return Common::FS::Exists(hactool_keys_dir + DIR_SEP + "title.keys") ||
+               Common::FS::Exists(yuzu_keys_dir + DIR_SEP + "title.keys");
     }
 
     if (Settings::values.use_dev_keys) {
-        return FileUtil::Exists(hactool_keys_dir + DIR_SEP + "dev.keys") ||
-               FileUtil::Exists(yuzu_keys_dir + DIR_SEP + "dev.keys");
+        return Common::FS::Exists(hactool_keys_dir + DIR_SEP + "dev.keys") ||
+               Common::FS::Exists(yuzu_keys_dir + DIR_SEP + "dev.keys");
     }
 
-    return FileUtil::Exists(hactool_keys_dir + DIR_SEP + "prod.keys") ||
-           FileUtil::Exists(yuzu_keys_dir + DIR_SEP + "prod.keys");
+    return Common::FS::Exists(hactool_keys_dir + DIR_SEP + "prod.keys") ||
+           Common::FS::Exists(yuzu_keys_dir + DIR_SEP + "prod.keys");
 }
 
 void KeyManager::DeriveSDSeedLazy() {
-    if (HasKey(S128KeyType::SDSeed))
+    if (HasKey(S128KeyType::SDSeed)) {
         return;
+    }
 
     const auto res = DeriveSDSeed();
-    if (res)
+    if (res) {
         SetKey(S128KeyType::SDSeed, *res);
+    }
 }
 
 static Key128 CalculateCMAC(const u8* source, size_t size, const Key128& key) {
@@ -799,11 +829,13 @@ static Key128 CalculateCMAC(const u8* source, size_t size, const Key128& key) {
 }
 
 void KeyManager::DeriveBase() {
-    if (!BaseDeriveNecessary())
+    if (!BaseDeriveNecessary()) {
         return;
+    }
 
-    if (!HasKey(S128KeyType::SecureBoot) || !HasKey(S128KeyType::TSEC))
+    if (!HasKey(S128KeyType::SecureBoot) || !HasKey(S128KeyType::TSEC)) {
         return;
+    }
 
     const auto has_bis = [this](u64 id) {
         return HasKey(S128KeyType::BIS, id, static_cast<u64>(BISKeyType::Crypto)) &&
@@ -820,10 +852,11 @@ void KeyManager::DeriveBase() {
                static_cast<u64>(BISKeyType::Tweak));
     };
 
-    if (has_bis(2) && !has_bis(3))
+    if (has_bis(2) && !has_bis(3)) {
         copy_bis(2, 3);
-    else if (has_bis(3) && !has_bis(2))
+    } else if (has_bis(3) && !has_bis(2)) {
         copy_bis(3, 2);
+    }
 
     std::bitset<32> revisions(0xFFFFFFFF);
     for (size_t i = 0; i < revisions.size(); ++i) {
@@ -833,15 +866,17 @@ void KeyManager::DeriveBase() {
         }
     }
 
-    if (!revisions.any())
+    if (!revisions.any()) {
         return;
+    }
 
     const auto sbk = GetKey(S128KeyType::SecureBoot);
     const auto tsec = GetKey(S128KeyType::TSEC);
 
     for (size_t i = 0; i < revisions.size(); ++i) {
-        if (!revisions[i])
+        if (!revisions[i]) {
             continue;
+        }
 
         // Derive keyblob key
         const auto key = DeriveKeyblobKey(
@@ -850,16 +885,18 @@ void KeyManager::DeriveBase() {
         SetKey(S128KeyType::Keyblob, key, i);
 
         // Derive keyblob MAC key
-        if (!HasKey(S128KeyType::Source, static_cast<u64>(SourceKeyType::KeyblobMAC)))
+        if (!HasKey(S128KeyType::Source, static_cast<u64>(SourceKeyType::KeyblobMAC))) {
             continue;
+        }
 
         const auto mac_key = DeriveKeyblobMACKey(
             key, GetKey(S128KeyType::Source, static_cast<u64>(SourceKeyType::KeyblobMAC)));
         SetKey(S128KeyType::KeyblobMAC, mac_key, i);
 
         Key128 cmac = CalculateCMAC(encrypted_keyblobs[i].data() + 0x10, 0xA0, mac_key);
-        if (std::memcmp(cmac.data(), encrypted_keyblobs[i].data(), cmac.size()) != 0)
+        if (std::memcmp(cmac.data(), encrypted_keyblobs[i].data(), cmac.size()) != 0) {
             continue;
+        }
 
         // Decrypt keyblob
         if (keyblobs[i] == std::array<u8, 0x90>{}) {
@@ -883,16 +920,19 @@ void KeyManager::DeriveBase() {
 
     revisions.set();
     for (size_t i = 0; i < revisions.size(); ++i) {
-        if (!HasKey(S128KeyType::Master, i))
+        if (!HasKey(S128KeyType::Master, i)) {
             revisions.reset(i);
+        }
     }
 
-    if (!revisions.any())
+    if (!revisions.any()) {
         return;
+    }
 
     for (size_t i = 0; i < revisions.size(); ++i) {
-        if (!revisions[i])
+        if (!revisions[i]) {
             continue;
+        }
 
         // Derive general purpose keys
         DeriveGeneralPurposeKeys(i);
@@ -922,16 +962,19 @@ void KeyManager::DeriveETicket(PartitionDataManager& data) {
     const auto es = Core::System::GetInstance().GetContentProvider().GetEntry(
         0x0100000000000033, FileSys::ContentRecordType::Program);
 
-    if (es == nullptr)
+    if (es == nullptr) {
         return;
+    }
 
     const auto exefs = es->GetExeFS();
-    if (exefs == nullptr)
+    if (exefs == nullptr) {
         return;
+    }
 
     const auto main = exefs->GetFile("main");
-    if (main == nullptr)
+    if (main == nullptr) {
         return;
+    }
 
     const auto bytes = main->ReadAllBytes();
 
@@ -941,16 +984,19 @@ void KeyManager::DeriveETicket(PartitionDataManager& data) {
     const auto seed3 = data.GetRSAKekSeed3();
     const auto mask0 = data.GetRSAKekMask0();
 
-    if (eticket_kek != Key128{})
+    if (eticket_kek != Key128{}) {
         SetKey(S128KeyType::Source, eticket_kek, static_cast<size_t>(SourceKeyType::ETicketKek));
+    }
     if (eticket_kekek != Key128{}) {
         SetKey(S128KeyType::Source, eticket_kekek,
                static_cast<size_t>(SourceKeyType::ETicketKekek));
     }
-    if (seed3 != Key128{})
+    if (seed3 != Key128{}) {
         SetKey(S128KeyType::RSAKek, seed3, static_cast<size_t>(RSAKekType::Seed3));
-    if (mask0 != Key128{})
+    }
+    if (mask0 != Key128{}) {
         SetKey(S128KeyType::RSAKek, mask0, static_cast<size_t>(RSAKekType::Mask0));
+    }
     if (eticket_kek == Key128{} || eticket_kekek == Key128{} || seed3 == Key128{} ||
         mask0 == Key128{}) {
         return;
@@ -976,8 +1022,9 @@ void KeyManager::DeriveETicket(PartitionDataManager& data) {
     AESCipher<Key128> es_kek(temp_kekek, Mode::ECB);
     es_kek.Transcode(eticket_kek.data(), eticket_kek.size(), eticket_final.data(), Op::Decrypt);
 
-    if (eticket_final == Key128{})
+    if (eticket_final == Key128{}) {
         return;
+    }
 
     SetKey(S128KeyType::ETicketRSAKek, eticket_final);
 
@@ -992,18 +1039,20 @@ void KeyManager::DeriveETicket(PartitionDataManager& data) {
 void KeyManager::PopulateTickets() {
     const auto rsa_key = GetETicketRSAKey();
 
-    if (rsa_key == RSAKeyPair<2048>{})
+    if (rsa_key == RSAKeyPair<2048>{}) {
         return;
+    }
 
-    if (!common_tickets.empty() && !personal_tickets.empty())
+    if (!common_tickets.empty() && !personal_tickets.empty()) {
         return;
+    }
 
-    const FileUtil::IOFile save1(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
-                                     "/system/save/80000000000000e1",
-                                 "rb+");
-    const FileUtil::IOFile save2(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
-                                     "/system/save/80000000000000e2",
-                                 "rb+");
+    const Common::FS::IOFile save1(Common::FS::GetUserPath(Common::FS::UserPath::NANDDir) +
+                                       "/system/save/80000000000000e1",
+                                   "rb+");
+    const Common::FS::IOFile save2(Common::FS::GetUserPath(Common::FS::UserPath::NANDDir) +
+                                       "/system/save/80000000000000e2",
+                                   "rb+");
 
     const auto blob2 = GetTicketblob(save2);
     auto res = GetTicketblob(save1);
@@ -1013,8 +1062,10 @@ void KeyManager::PopulateTickets() {
     for (std::size_t i = 0; i < res.size(); ++i) {
         const auto common = i < idx;
         const auto pair = ParseTicket(res[i], rsa_key);
-        if (!pair)
+        if (!pair) {
             continue;
+        }
+
         const auto& [rid, key] = *pair;
         u128 rights_id;
         std::memcpy(rights_id.data(), rid.data(), rid.size());
@@ -1043,27 +1094,33 @@ void KeyManager::SynthesizeTickets() {
 }
 
 void KeyManager::SetKeyWrapped(S128KeyType id, Key128 key, u64 field1, u64 field2) {
-    if (key == Key128{})
+    if (key == Key128{}) {
         return;
+    }
     SetKey(id, key, field1, field2);
 }
 
 void KeyManager::SetKeyWrapped(S256KeyType id, Key256 key, u64 field1, u64 field2) {
-    if (key == Key256{})
+    if (key == Key256{}) {
         return;
+    }
+
     SetKey(id, key, field1, field2);
 }
 
 void KeyManager::PopulateFromPartitionData(PartitionDataManager& data) {
-    if (!BaseDeriveNecessary())
+    if (!BaseDeriveNecessary()) {
         return;
+    }
 
-    if (!data.HasBoot0())
+    if (!data.HasBoot0()) {
         return;
+    }
 
     for (size_t i = 0; i < encrypted_keyblobs.size(); ++i) {
-        if (encrypted_keyblobs[i] != std::array<u8, 0xB0>{})
+        if (encrypted_keyblobs[i] != std::array<u8, 0xB0>{}) {
             continue;
+        }
         encrypted_keyblobs[i] = data.GetEncryptedKeyblob(i);
         WriteKeyToFile<0xB0>(KeyCategory::Console, fmt::format("encrypted_keyblob_{:02X}", i),
                              encrypted_keyblobs[i]);
@@ -1085,8 +1142,9 @@ void KeyManager::PopulateFromPartitionData(PartitionDataManager& data) {
                       static_cast<u64>(SourceKeyType::Keyblob), i);
     }
 
-    if (data.HasFuses())
+    if (data.HasFuses()) {
         SetKeyWrapped(S128KeyType::SecureBoot, data.GetSecureBootKey());
+    }
 
     DeriveBase();
 
@@ -1100,8 +1158,9 @@ void KeyManager::PopulateFromPartitionData(PartitionDataManager& data) {
 
     const auto masters = data.GetTZMasterKeys(latest_master);
     for (size_t i = 0; i < masters.size(); ++i) {
-        if (masters[i] != Key128{} && !HasKey(S128KeyType::Master, i))
+        if (masters[i] != Key128{} && !HasKey(S128KeyType::Master, i)) {
             SetKey(S128KeyType::Master, masters[i], i);
+        }
     }
 
     DeriveBase();
@@ -1111,8 +1170,9 @@ void KeyManager::PopulateFromPartitionData(PartitionDataManager& data) {
 
     std::array<Key128, 0x20> package2_keys{};
     for (size_t i = 0; i < package2_keys.size(); ++i) {
-        if (HasKey(S128KeyType::Package2, i))
+        if (HasKey(S128KeyType::Package2, i)) {
             package2_keys[i] = GetKey(S128KeyType::Package2, i);
+        }
     }
     data.DecryptPackage2(package2_keys, Package2Type::NormalMain);
 
@@ -1150,12 +1210,15 @@ const std::map<u128, Ticket>& KeyManager::GetPersonalizedTickets() const {
 
 bool KeyManager::AddTicketCommon(Ticket raw) {
     const auto rsa_key = GetETicketRSAKey();
-    if (rsa_key == RSAKeyPair<2048>{})
+    if (rsa_key == RSAKeyPair<2048>{}) {
         return false;
+    }
 
     const auto pair = ParseTicket(raw, rsa_key);
-    if (!pair)
+    if (!pair) {
         return false;
+    }
+
     const auto& [rid, key] = *pair;
     u128 rights_id;
     std::memcpy(rights_id.data(), rid.data(), rid.size());
@@ -1166,12 +1229,15 @@ bool KeyManager::AddTicketCommon(Ticket raw) {
 
 bool KeyManager::AddTicketPersonalized(Ticket raw) {
     const auto rsa_key = GetETicketRSAKey();
-    if (rsa_key == RSAKeyPair<2048>{})
+    if (rsa_key == RSAKeyPair<2048>{}) {
         return false;
+    }
 
     const auto pair = ParseTicket(raw, rsa_key);
-    if (!pair)
+    if (!pair) {
         return false;
+    }
+
     const auto& [rid, key] = *pair;
     u128 rights_id;
     std::memcpy(rights_id.data(), rid.data(), rid.size());

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -17,7 +17,7 @@
 #include "core/crypto/partition_data_manager.h"
 #include "core/file_sys/vfs_types.h"
 
-namespace FileUtil {
+namespace Common::FS {
 class IOFile;
 }
 
@@ -308,7 +308,7 @@ std::array<u8, 0x90> DecryptKeyblob(const std::array<u8, 0xB0>& encrypted_keyblo
 std::optional<Key128> DeriveSDSeed();
 Loader::ResultStatus DeriveSDKeys(std::array<Key256, 2>& sd_keys, KeyManager& keys);
 
-std::vector<Ticket> GetTicketblob(const FileUtil::IOFile& ticket_save);
+std::vector<Ticket> GetTicketblob(const Common::FS::IOFile& ticket_save);
 
 // Returns a pair of {rights_id, titlekey}. Fails if the ticket has no certificate authority
 // (offset 0x140-0x144 is zero)

--- a/src/core/file_sys/bis_factory.cpp
+++ b/src/core/file_sys/bis_factory.cpp
@@ -86,7 +86,7 @@ VirtualFile BISFactory::OpenPartitionStorage(BisPartitionId id) const {
     auto& keys = Core::Crypto::KeyManager::Instance();
     Core::Crypto::PartitionDataManager pdm{
         Core::System::GetInstance().GetFilesystem()->OpenDirectory(
-            FileUtil::GetUserPath(FileUtil::UserPath::SysDataDir), Mode::Read)};
+            Common::FS::GetUserPath(Common::FS::UserPath::SysDataDir), Mode::Read)};
     keys.PopulateFromPartitionData(pdm);
 
     switch (id) {

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -728,7 +728,7 @@ InstallResult RegisteredCache::RawInstallNCA(const NCA& nca, const VfsCopyFuncti
         LOG_WARNING(Loader, "Overwriting existing NCA...");
         VirtualDir c_dir;
         { c_dir = dir->GetFileRelative(path)->GetContainingDirectory(); }
-        c_dir->DeleteFile(FileUtil::GetFilename(path));
+        c_dir->DeleteFile(Common::FS::GetFilename(path));
     }
 
     auto out = dir->CreateFileRelative(path);

--- a/src/core/file_sys/vfs.cpp
+++ b/src/core/file_sys/vfs.cpp
@@ -30,7 +30,7 @@ bool VfsFilesystem::IsWritable() const {
 }
 
 VfsEntryType VfsFilesystem::GetEntryType(std::string_view path_) const {
-    const auto path = FileUtil::SanitizePath(path_);
+    const auto path = Common::FS::SanitizePath(path_);
     if (root->GetFileRelative(path) != nullptr)
         return VfsEntryType::File;
     if (root->GetDirectoryRelative(path) != nullptr)
@@ -40,22 +40,22 @@ VfsEntryType VfsFilesystem::GetEntryType(std::string_view path_) const {
 }
 
 VirtualFile VfsFilesystem::OpenFile(std::string_view path_, Mode perms) {
-    const auto path = FileUtil::SanitizePath(path_);
+    const auto path = Common::FS::SanitizePath(path_);
     return root->GetFileRelative(path);
 }
 
 VirtualFile VfsFilesystem::CreateFile(std::string_view path_, Mode perms) {
-    const auto path = FileUtil::SanitizePath(path_);
+    const auto path = Common::FS::SanitizePath(path_);
     return root->CreateFileRelative(path);
 }
 
 VirtualFile VfsFilesystem::CopyFile(std::string_view old_path_, std::string_view new_path_) {
-    const auto old_path = FileUtil::SanitizePath(old_path_);
-    const auto new_path = FileUtil::SanitizePath(new_path_);
+    const auto old_path = Common::FS::SanitizePath(old_path_);
+    const auto new_path = Common::FS::SanitizePath(new_path_);
 
     // VfsDirectory impls are only required to implement copy across the current directory.
-    if (FileUtil::GetParentPath(old_path) == FileUtil::GetParentPath(new_path)) {
-        if (!root->Copy(FileUtil::GetFilename(old_path), FileUtil::GetFilename(new_path)))
+    if (Common::FS::GetParentPath(old_path) == Common::FS::GetParentPath(new_path)) {
+        if (!root->Copy(Common::FS::GetFilename(old_path), Common::FS::GetFilename(new_path)))
             return nullptr;
         return OpenFile(new_path, Mode::ReadWrite);
     }
@@ -76,8 +76,8 @@ VirtualFile VfsFilesystem::CopyFile(std::string_view old_path_, std::string_view
 }
 
 VirtualFile VfsFilesystem::MoveFile(std::string_view old_path, std::string_view new_path) {
-    const auto sanitized_old_path = FileUtil::SanitizePath(old_path);
-    const auto sanitized_new_path = FileUtil::SanitizePath(new_path);
+    const auto sanitized_old_path = Common::FS::SanitizePath(old_path);
+    const auto sanitized_new_path = Common::FS::SanitizePath(new_path);
 
     // Again, non-default impls are highly encouraged to provide a more optimized version of this.
     auto out = CopyFile(sanitized_old_path, sanitized_new_path);
@@ -89,26 +89,26 @@ VirtualFile VfsFilesystem::MoveFile(std::string_view old_path, std::string_view 
 }
 
 bool VfsFilesystem::DeleteFile(std::string_view path_) {
-    const auto path = FileUtil::SanitizePath(path_);
-    auto parent = OpenDirectory(FileUtil::GetParentPath(path), Mode::Write);
+    const auto path = Common::FS::SanitizePath(path_);
+    auto parent = OpenDirectory(Common::FS::GetParentPath(path), Mode::Write);
     if (parent == nullptr)
         return false;
-    return parent->DeleteFile(FileUtil::GetFilename(path));
+    return parent->DeleteFile(Common::FS::GetFilename(path));
 }
 
 VirtualDir VfsFilesystem::OpenDirectory(std::string_view path_, Mode perms) {
-    const auto path = FileUtil::SanitizePath(path_);
+    const auto path = Common::FS::SanitizePath(path_);
     return root->GetDirectoryRelative(path);
 }
 
 VirtualDir VfsFilesystem::CreateDirectory(std::string_view path_, Mode perms) {
-    const auto path = FileUtil::SanitizePath(path_);
+    const auto path = Common::FS::SanitizePath(path_);
     return root->CreateDirectoryRelative(path);
 }
 
 VirtualDir VfsFilesystem::CopyDirectory(std::string_view old_path_, std::string_view new_path_) {
-    const auto old_path = FileUtil::SanitizePath(old_path_);
-    const auto new_path = FileUtil::SanitizePath(new_path_);
+    const auto old_path = Common::FS::SanitizePath(old_path_);
+    const auto new_path = Common::FS::SanitizePath(new_path_);
 
     // Non-default impls are highly encouraged to provide a more optimized version of this.
     auto old_dir = OpenDirectory(old_path, Mode::Read);
@@ -139,8 +139,8 @@ VirtualDir VfsFilesystem::CopyDirectory(std::string_view old_path_, std::string_
 }
 
 VirtualDir VfsFilesystem::MoveDirectory(std::string_view old_path, std::string_view new_path) {
-    const auto sanitized_old_path = FileUtil::SanitizePath(old_path);
-    const auto sanitized_new_path = FileUtil::SanitizePath(new_path);
+    const auto sanitized_old_path = Common::FS::SanitizePath(old_path);
+    const auto sanitized_new_path = Common::FS::SanitizePath(new_path);
 
     // Non-default impls are highly encouraged to provide a more optimized version of this.
     auto out = CopyDirectory(sanitized_old_path, sanitized_new_path);
@@ -152,17 +152,17 @@ VirtualDir VfsFilesystem::MoveDirectory(std::string_view old_path, std::string_v
 }
 
 bool VfsFilesystem::DeleteDirectory(std::string_view path_) {
-    const auto path = FileUtil::SanitizePath(path_);
-    auto parent = OpenDirectory(FileUtil::GetParentPath(path), Mode::Write);
+    const auto path = Common::FS::SanitizePath(path_);
+    auto parent = OpenDirectory(Common::FS::GetParentPath(path), Mode::Write);
     if (parent == nullptr)
         return false;
-    return parent->DeleteSubdirectoryRecursive(FileUtil::GetFilename(path));
+    return parent->DeleteSubdirectoryRecursive(Common::FS::GetFilename(path));
 }
 
 VfsFile::~VfsFile() = default;
 
 std::string VfsFile::GetExtension() const {
-    return std::string(FileUtil::GetExtensionFromFilename(GetName()));
+    return std::string(Common::FS::GetExtensionFromFilename(GetName()));
 }
 
 VfsDirectory::~VfsDirectory() = default;
@@ -203,7 +203,7 @@ std::string VfsFile::GetFullPath() const {
 }
 
 std::shared_ptr<VfsFile> VfsDirectory::GetFileRelative(std::string_view path) const {
-    auto vec = FileUtil::SplitPathComponents(path);
+    auto vec = Common::FS::SplitPathComponents(path);
     vec.erase(std::remove_if(vec.begin(), vec.end(), [](const auto& str) { return str.empty(); }),
               vec.end());
     if (vec.empty()) {
@@ -239,7 +239,7 @@ std::shared_ptr<VfsFile> VfsDirectory::GetFileAbsolute(std::string_view path) co
 }
 
 std::shared_ptr<VfsDirectory> VfsDirectory::GetDirectoryRelative(std::string_view path) const {
-    auto vec = FileUtil::SplitPathComponents(path);
+    auto vec = Common::FS::SplitPathComponents(path);
     vec.erase(std::remove_if(vec.begin(), vec.end(), [](const auto& str) { return str.empty(); }),
               vec.end());
     if (vec.empty()) {
@@ -301,7 +301,7 @@ std::size_t VfsDirectory::GetSize() const {
 }
 
 std::shared_ptr<VfsFile> VfsDirectory::CreateFileRelative(std::string_view path) {
-    auto vec = FileUtil::SplitPathComponents(path);
+    auto vec = Common::FS::SplitPathComponents(path);
     vec.erase(std::remove_if(vec.begin(), vec.end(), [](const auto& str) { return str.empty(); }),
               vec.end());
     if (vec.empty()) {
@@ -320,7 +320,7 @@ std::shared_ptr<VfsFile> VfsDirectory::CreateFileRelative(std::string_view path)
         }
     }
 
-    return dir->CreateFileRelative(FileUtil::GetPathWithoutTop(path));
+    return dir->CreateFileRelative(Common::FS::GetPathWithoutTop(path));
 }
 
 std::shared_ptr<VfsFile> VfsDirectory::CreateFileAbsolute(std::string_view path) {
@@ -332,7 +332,7 @@ std::shared_ptr<VfsFile> VfsDirectory::CreateFileAbsolute(std::string_view path)
 }
 
 std::shared_ptr<VfsDirectory> VfsDirectory::CreateDirectoryRelative(std::string_view path) {
-    auto vec = FileUtil::SplitPathComponents(path);
+    auto vec = Common::FS::SplitPathComponents(path);
     vec.erase(std::remove_if(vec.begin(), vec.end(), [](const auto& str) { return str.empty(); }),
               vec.end());
     if (vec.empty()) {
@@ -351,7 +351,7 @@ std::shared_ptr<VfsDirectory> VfsDirectory::CreateDirectoryRelative(std::string_
         }
     }
 
-    return dir->CreateDirectoryRelative(FileUtil::GetPathWithoutTop(path));
+    return dir->CreateDirectoryRelative(Common::FS::GetPathWithoutTop(path));
 }
 
 std::shared_ptr<VfsDirectory> VfsDirectory::CreateDirectoryAbsolute(std::string_view path) {

--- a/src/core/file_sys/vfs_libzip.cpp
+++ b/src/core/file_sys/vfs_libzip.cpp
@@ -49,7 +49,7 @@ VirtualDir ExtractZIP(VirtualFile file) {
             if (zip_fread(file2.get(), buf.data(), buf.size()) != s64(buf.size()))
                 return nullptr;
 
-            const auto parts = FileUtil::SplitPathComponents(stat.name);
+            const auto parts = Common::FS::SplitPathComponents(stat.name);
             const auto new_file = std::make_shared<VectorVfsFile>(buf, parts.back());
 
             std::shared_ptr<VectorVfsDirectory> dtrv = out;

--- a/src/core/file_sys/vfs_real.h
+++ b/src/core/file_sys/vfs_real.h
@@ -9,7 +9,7 @@
 #include "core/file_sys/mode.h"
 #include "core/file_sys/vfs.h"
 
-namespace FileUtil {
+namespace Common::FS {
 class IOFile;
 }
 
@@ -36,7 +36,7 @@ public:
     bool DeleteDirectory(std::string_view path) override;
 
 private:
-    boost::container::flat_map<std::string, std::weak_ptr<FileUtil::IOFile>> cache;
+    boost::container::flat_map<std::string, std::weak_ptr<Common::FS::IOFile>> cache;
 };
 
 // An implmentation of VfsFile that represents a file on the user's computer.
@@ -58,13 +58,13 @@ public:
     bool Rename(std::string_view name) override;
 
 private:
-    RealVfsFile(RealVfsFilesystem& base, std::shared_ptr<FileUtil::IOFile> backing,
+    RealVfsFile(RealVfsFilesystem& base, std::shared_ptr<Common::FS::IOFile> backing,
                 const std::string& path, Mode perms = Mode::Read);
 
     bool Close();
 
     RealVfsFilesystem& base;
-    std::shared_ptr<FileUtil::IOFile> backing;
+    std::shared_ptr<Common::FS::IOFile> backing;
     std::string path;
     std::string parent_path;
     std::vector<std::string> path_components;

--- a/src/core/file_sys/xts_archive.cpp
+++ b/src/core/file_sys/xts_archive.cpp
@@ -44,7 +44,7 @@ static bool CalculateHMAC256(Destination* out, const SourceKey* key, std::size_t
 }
 
 NAX::NAX(VirtualFile file_) : header(std::make_unique<NAXHeader>()), file(std::move(file_)) {
-    std::string path = FileUtil::SanitizePath(file->GetFullPath());
+    std::string path = Common::FS::SanitizePath(file->GetFullPath());
     static const std::regex nax_path_regex("/registered/(000000[0-9A-F]{2})/([0-9A-F]{32})\\.nca",
                                            std::regex_constants::ECMAScript |
                                                std::regex_constants::icase);

--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -35,7 +35,7 @@ constexpr ResultCode ERR_INVALID_BUFFER_SIZE{ErrorModule::Account, 30};
 constexpr ResultCode ERR_FAILED_SAVE_DATA{ErrorModule::Account, 100};
 
 static std::string GetImagePath(Common::UUID uuid) {
-    return FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
+    return Common::FS::GetUserPath(Common::FS::UserPath::NANDDir) +
            "/system/save/8000000000000010/su/avators/" + uuid.FormatSwitch() + ".jpg";
 }
 
@@ -318,7 +318,7 @@ protected:
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
 
-        const FileUtil::IOFile image(GetImagePath(user_id), "rb");
+        const Common::FS::IOFile image(GetImagePath(user_id), "rb");
         if (!image.IsOpen()) {
             LOG_WARNING(Service_ACC,
                         "Failed to load user provided image! Falling back to built-in backup...");
@@ -340,7 +340,7 @@ protected:
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(RESULT_SUCCESS);
 
-        const FileUtil::IOFile image(GetImagePath(user_id), "rb");
+        const Common::FS::IOFile image(GetImagePath(user_id), "rb");
 
         if (!image.IsOpen()) {
             LOG_WARNING(Service_ACC,
@@ -405,7 +405,7 @@ protected:
         ProfileData data;
         std::memcpy(&data, user_data.data(), sizeof(ProfileData));
 
-        FileUtil::IOFile image(GetImagePath(user_id), "wb");
+        Common::FS::IOFile image(GetImagePath(user_id), "wb");
 
         if (!image.IsOpen() || !image.Resize(image_data.size()) ||
             image.WriteBytes(image_data.data(), image_data.size()) != image_data.size() ||

--- a/src/core/hle/service/acc/profile_manager.cpp
+++ b/src/core/hle/service/acc/profile_manager.cpp
@@ -13,6 +13,7 @@
 
 namespace Service::Account {
 
+namespace FS = Common::FS;
 using Common::UUID;
 
 struct UserRaw {
@@ -318,9 +319,8 @@ bool ProfileManager::SetProfileBaseAndData(Common::UUID uuid, const ProfileBase&
 }
 
 void ProfileManager::ParseUserSaveFile() {
-    FileUtil::IOFile save(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
-                              ACC_SAVE_AVATORS_BASE_PATH + "profiles.dat",
-                          "rb");
+    const FS::IOFile save(
+        FS::GetUserPath(FS::UserPath::NANDDir) + ACC_SAVE_AVATORS_BASE_PATH + "profiles.dat", "rb");
 
     if (!save.IsOpen()) {
         LOG_WARNING(Service_ACC, "Failed to load profile data from save data... Generating new "
@@ -366,22 +366,22 @@ void ProfileManager::WriteUserSaveFile() {
         };
     }
 
-    const auto raw_path =
-        FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) + "/system/save/8000000000000010";
-    if (FileUtil::Exists(raw_path) && !FileUtil::IsDirectory(raw_path))
-        FileUtil::Delete(raw_path);
+    const auto raw_path = FS::GetUserPath(FS::UserPath::NANDDir) + "/system/save/8000000000000010";
+    if (FS::Exists(raw_path) && !FS::IsDirectory(raw_path)) {
+        FS::Delete(raw_path);
+    }
 
-    const auto path = FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
-                      ACC_SAVE_AVATORS_BASE_PATH + "profiles.dat";
+    const auto path =
+        FS::GetUserPath(FS::UserPath::NANDDir) + ACC_SAVE_AVATORS_BASE_PATH + "profiles.dat";
 
-    if (!FileUtil::CreateFullPath(path)) {
+    if (!FS::CreateFullPath(path)) {
         LOG_WARNING(Service_ACC, "Failed to create full path of profiles.dat. Create the directory "
                                  "nand/system/save/8000000000000010/su/avators to mitigate this "
                                  "issue.");
         return;
     }
 
-    FileUtil::IOFile save(path, "wb");
+    FS::IOFile save(path, "wb");
 
     if (!save.IsOpen()) {
         LOG_WARNING(Service_ACC, "Failed to write save data to file... No changes to user data "

--- a/src/core/hle/service/am/applets/web_browser.cpp
+++ b/src/core/hle/service/am/applets/web_browser.cpp
@@ -293,8 +293,8 @@ void WebBrowser::Finalize() {
     broker.PushNormalDataFromApplet(std::make_shared<IStorage>(std::move(data)));
     broker.SignalStateChanged();
 
-    if (!temporary_dir.empty() && FileUtil::IsDirectory(temporary_dir)) {
-        FileUtil::DeleteDirRecursively(temporary_dir);
+    if (!temporary_dir.empty() && Common::FS::IsDirectory(temporary_dir)) {
+        Common::FS::DeleteDirRecursively(temporary_dir);
     }
 }
 
@@ -452,10 +452,10 @@ void WebBrowser::InitializeOffline() {
     };
 
     temporary_dir =
-        FileUtil::SanitizePath(FileUtil::GetUserPath(FileUtil::UserPath::CacheDir) + "web_applet_" +
-                                   WEB_SOURCE_NAMES[static_cast<u32>(source) - 1],
-                               FileUtil::DirectorySeparator::PlatformDefault);
-    FileUtil::DeleteDirRecursively(temporary_dir);
+        Common::FS::SanitizePath(Common::FS::GetUserPath(Common::FS::UserPath::CacheDir) +
+                                     "web_applet_" + WEB_SOURCE_NAMES[static_cast<u32>(source) - 1],
+                                 Common::FS::DirectorySeparator::PlatformDefault);
+    Common::FS::DeleteDirRecursively(temporary_dir);
 
     u64 title_id = 0; // 0 corresponds to current process
     ASSERT(args[WebArgTLVType::ApplicationID].size() >= 0x8);
@@ -492,8 +492,8 @@ void WebBrowser::InitializeOffline() {
     }
 
     filename =
-        FileUtil::SanitizePath(temporary_dir + path_additional_directory + DIR_SEP + filename,
-                               FileUtil::DirectorySeparator::PlatformDefault);
+        Common::FS::SanitizePath(temporary_dir + path_additional_directory + DIR_SEP + filename,
+                                 Common::FS::DirectorySeparator::PlatformDefault);
 }
 
 void WebBrowser::ExecuteShop() {

--- a/src/core/hle/service/bcat/backend/boxcat.cpp
+++ b/src/core/hle/service/bcat/backend/boxcat.cpp
@@ -89,12 +89,12 @@ constexpr u32 TIMEOUT_SECONDS = 30;
 
 std::string GetBINFilePath(u64 title_id) {
     return fmt::format("{}bcat/{:016X}/launchparam.bin",
-                       FileUtil::GetUserPath(FileUtil::UserPath::CacheDir), title_id);
+                       Common::FS::GetUserPath(Common::FS::UserPath::CacheDir), title_id);
 }
 
 std::string GetZIPFilePath(u64 title_id) {
     return fmt::format("{}bcat/{:016X}/data.zip",
-                       FileUtil::GetUserPath(FileUtil::UserPath::CacheDir), title_id);
+                       Common::FS::GetUserPath(Common::FS::UserPath::CacheDir), title_id);
 }
 
 // If the error is something the user should know about (build ID mismatch, bad client version),
@@ -205,8 +205,8 @@ private:
             {std::string("Game-Build-Id"), fmt::format("{:016X}", build_id)},
         };
 
-        if (FileUtil::Exists(path)) {
-            FileUtil::IOFile file{path, "rb"};
+        if (Common::FS::Exists(path)) {
+            Common::FS::IOFile file{path, "rb"};
             if (file.IsOpen()) {
                 std::vector<u8> bytes(file.GetSize());
                 file.ReadBytes(bytes.data(), bytes.size());
@@ -236,8 +236,8 @@ private:
             return DownloadResult::InvalidContentType;
         }
 
-        FileUtil::CreateFullPath(path);
-        FileUtil::IOFile file{path, "wb"};
+        Common::FS::CreateFullPath(path);
+        Common::FS::IOFile file{path, "wb"};
         if (!file.IsOpen())
             return DownloadResult::GeneralFSError;
         if (!file.Resize(response->body.size()))
@@ -290,7 +290,7 @@ void SynchronizeInternal(AM::Applets::AppletManager& applet_manager, DirectoryGe
         LOG_ERROR(Service_BCAT, "Boxcat synchronization failed with error '{}'!", res);
 
         if (res == DownloadResult::NoMatchBuildId || res == DownloadResult::NoMatchTitleId) {
-            FileUtil::Delete(zip_path);
+            Common::FS::Delete(zip_path);
         }
 
         HandleDownloadDisplayResult(applet_manager, res);
@@ -300,7 +300,7 @@ void SynchronizeInternal(AM::Applets::AppletManager& applet_manager, DirectoryGe
 
     progress.StartProcessingDataList();
 
-    FileUtil::IOFile zip{zip_path, "rb"};
+    Common::FS::IOFile zip{zip_path, "rb"};
     const auto size = zip.GetSize();
     std::vector<u8> bytes(size);
     if (!zip.IsOpen() || size == 0 || zip.ReadBytes(bytes.data(), bytes.size()) != bytes.size()) {
@@ -420,7 +420,7 @@ std::optional<std::vector<u8>> Boxcat::GetLaunchParameter(TitleIDVersion title) 
             LOG_ERROR(Service_BCAT, "Boxcat synchronization failed with error '{}'!", res);
 
             if (res == DownloadResult::NoMatchBuildId || res == DownloadResult::NoMatchTitleId) {
-                FileUtil::Delete(path);
+                Common::FS::Delete(path);
             }
 
             HandleDownloadDisplayResult(applet_manager, res);
@@ -428,7 +428,7 @@ std::optional<std::vector<u8>> Boxcat::GetLaunchParameter(TitleIDVersion title) 
         }
     }
 
-    FileUtil::IOFile bin{path, "rb"};
+    Common::FS::IOFile bin{path, "rb"};
     const auto size = bin.GetSize();
     std::vector<u8> bytes(size);
     if (!bin.IsOpen() || size == 0 || bin.ReadBytes(bytes.data(), bytes.size()) != bytes.size()) {

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -67,7 +67,7 @@ FileType GuessFromFilename(const std::string& name) {
         return FileType::NCA;
 
     const std::string extension =
-        Common::ToLower(std::string(FileUtil::GetExtensionFromFilename(name)));
+        Common::ToLower(std::string(Common::FS::GetExtensionFromFilename(name)));
 
     if (extension == "elf")
         return FileType::ELF;

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -38,11 +38,11 @@ PerfStats::~PerfStats() {
     std::ostringstream stream;
     std::copy(perf_history.begin() + IgnoreFrames, perf_history.begin() + current_index,
               std::ostream_iterator<double>(stream, "\n"));
-    const std::string& path = FileUtil::GetUserPath(FileUtil::UserPath::LogDir);
+    const std::string& path = Common::FS::GetUserPath(Common::FS::UserPath::LogDir);
     // %F Date format expanded is "%Y-%m-%d"
     const std::string filename =
         fmt::format("{}/{:%F-%H-%M}_{:016X}.csv", path, *std::localtime(&t), title_id);
-    FileUtil::IOFile file(filename, "w");
+    Common::FS::IOFile file(filename, "w");
     file.WriteString(stream.str());
 }
 

--- a/src/core/reporter.cpp
+++ b/src/core/reporter.cpp
@@ -28,8 +28,9 @@
 namespace {
 
 std::string GetPath(std::string_view type, u64 title_id, std::string_view timestamp) {
-    return fmt::format("{}{}/{:016X}_{}.json", FileUtil::GetUserPath(FileUtil::UserPath::LogDir),
-                       type, title_id, timestamp);
+    return fmt::format("{}{}/{:016X}_{}.json",
+                       Common::FS::GetUserPath(Common::FS::UserPath::LogDir), type, title_id,
+                       timestamp);
 }
 
 std::string GetTimestamp() {
@@ -40,13 +41,13 @@ std::string GetTimestamp() {
 using namespace nlohmann;
 
 void SaveToFile(json json, const std::string& filename) {
-    if (!FileUtil::CreateFullPath(filename)) {
+    if (!Common::FS::CreateFullPath(filename)) {
         LOG_ERROR(Core, "Failed to create path for '{}' to save report!", filename);
         return;
     }
 
     std::ofstream file(
-        FileUtil::SanitizePath(filename, FileUtil::DirectorySeparator::PlatformDefault));
+        Common::FS::SanitizePath(filename, Common::FS::DirectorySeparator::PlatformDefault));
     file << std::setw(4) << json << std::endl;
 }
 

--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -121,8 +121,8 @@ void LogSettings() {
     log_setting("Audio_EnableAudioStretching", values.enable_audio_stretching.GetValue());
     log_setting("Audio_OutputDevice", values.audio_device_id);
     log_setting("DataStorage_UseVirtualSd", values.use_virtual_sd);
-    log_setting("DataStorage_NandDir", FileUtil::GetUserPath(FileUtil::UserPath::NANDDir));
-    log_setting("DataStorage_SdmcDir", FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir));
+    log_setting("DataStorage_NandDir", Common::FS::GetUserPath(Common::FS::UserPath::NANDDir));
+    log_setting("DataStorage_SdmcDir", Common::FS::GetUserPath(Common::FS::UserPath::SDMCDir));
     log_setting("Debugging_UseGdbstub", values.use_gdbstub);
     log_setting("Debugging_GdbstubPort", values.gdbstub_port);
     log_setting("Debugging_ProgramArgs", values.program_args);

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -70,12 +70,12 @@ static const char* TranslateGPUAccuracyLevel(Settings::GPUAccuracy backend) {
 
 u64 GetTelemetryId() {
     u64 telemetry_id{};
-    const std::string filename{FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) +
+    const std::string filename{Common::FS::GetUserPath(Common::FS::UserPath::ConfigDir) +
                                "telemetry_id"};
 
-    bool generate_new_id = !FileUtil::Exists(filename);
+    bool generate_new_id = !Common::FS::Exists(filename);
     if (!generate_new_id) {
-        FileUtil::IOFile file(filename, "rb");
+        Common::FS::IOFile file(filename, "rb");
         if (!file.IsOpen()) {
             LOG_ERROR(Core, "failed to open telemetry_id: {}", filename);
             return {};
@@ -88,7 +88,7 @@ u64 GetTelemetryId() {
     }
 
     if (generate_new_id) {
-        FileUtil::IOFile file(filename, "wb");
+        Common::FS::IOFile file(filename, "wb");
         if (!file.IsOpen()) {
             LOG_ERROR(Core, "failed to open telemetry_id: {}", filename);
             return {};
@@ -102,10 +102,10 @@ u64 GetTelemetryId() {
 
 u64 RegenerateTelemetryId() {
     const u64 new_telemetry_id{GenerateTelemetryId()};
-    const std::string filename{FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) +
+    const std::string filename{Common::FS::GetUserPath(Common::FS::UserPath::ConfigDir) +
                                "telemetry_id"};
 
-    FileUtil::IOFile file(filename, "wb");
+    Common::FS::IOFile file(filename, "wb");
     if (!file.IsOpen()) {
         LOG_ERROR(Core, "failed to open telemetry_id: {}", filename);
         return {};

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.h
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.h
@@ -25,7 +25,7 @@ namespace Core {
 class System;
 }
 
-namespace FileUtil {
+namespace Common::FS {
 class IOFile;
 }
 
@@ -38,9 +38,9 @@ struct ShaderDiskCacheEntry {
     ShaderDiskCacheEntry();
     ~ShaderDiskCacheEntry();
 
-    bool Load(FileUtil::IOFile& file);
+    bool Load(Common::FS::IOFile& file);
 
-    bool Save(FileUtil::IOFile& file) const;
+    bool Save(Common::FS::IOFile& file) const;
 
     bool HasProgramA() const {
         return !code.empty() && !code_b.empty();
@@ -97,10 +97,10 @@ public:
 private:
     /// Loads the transferable cache. Returns empty on failure.
     std::optional<std::vector<ShaderDiskCachePrecompiled>> LoadPrecompiledFile(
-        FileUtil::IOFile& file);
+        Common::FS::IOFile& file);
 
     /// Opens current game's transferable file and write it's header if it doesn't exist
-    FileUtil::IOFile AppendTransferableFile() const;
+    Common::FS::IOFile AppendTransferableFile() const;
 
     /// Save precompiled header to precompiled_cache_in_memory
     void SavePrecompiledHeaderToVirtualPrecompiledCache();

--- a/src/video_core/renderer_vulkan/nsight_aftermath_tracker.cpp
+++ b/src/video_core/renderer_vulkan/nsight_aftermath_tracker.cpp
@@ -65,10 +65,10 @@ bool NsightAftermathTracker::Initialize() {
         return false;
     }
 
-    dump_dir = FileUtil::GetUserPath(FileUtil::UserPath::LogDir) + "gpucrash";
+    dump_dir = Common::FS::GetUserPath(Common::FS::UserPath::LogDir) + "gpucrash";
 
-    (void)FileUtil::DeleteDirRecursively(dump_dir);
-    if (!FileUtil::CreateDir(dump_dir)) {
+    (void)Common::FS::DeleteDirRecursively(dump_dir);
+    if (!Common::FS::CreateDir(dump_dir)) {
         LOG_ERROR(Render_Vulkan, "Failed to create Nsight Aftermath dump directory");
         return false;
     }
@@ -106,7 +106,7 @@ void NsightAftermathTracker::SaveShader(const std::vector<u32>& spirv) const {
         return;
     }
 
-    FileUtil::IOFile file(fmt::format("{}/source_{:016x}.spv", dump_dir, hash.hash), "wb");
+    Common::FS::IOFile file(fmt::format("{}/source_{:016x}.spv", dump_dir, hash.hash), "wb");
     if (!file.IsOpen()) {
         LOG_ERROR(Render_Vulkan, "Failed to dump SPIR-V module with hash={:016x}", hash.hash);
         return;
@@ -156,12 +156,12 @@ void NsightAftermathTracker::OnGpuCrashDumpCallback(const void* gpu_crash_dump,
     }();
 
     std::string_view dump_view(static_cast<const char*>(gpu_crash_dump), gpu_crash_dump_size);
-    if (FileUtil::WriteStringToFile(false, base_name, dump_view) != gpu_crash_dump_size) {
+    if (Common::FS::WriteStringToFile(false, base_name, dump_view) != gpu_crash_dump_size) {
         LOG_ERROR(Render_Vulkan, "Failed to write dump file");
         return;
     }
     const std::string_view json_view(json.data(), json.size());
-    if (FileUtil::WriteStringToFile(true, base_name + ".json", json_view) != json.size()) {
+    if (Common::FS::WriteStringToFile(true, base_name + ".json", json_view) != json.size()) {
         LOG_ERROR(Render_Vulkan, "Failed to write JSON");
         return;
     }
@@ -180,7 +180,7 @@ void NsightAftermathTracker::OnShaderDebugInfoCallback(const void* shader_debug_
 
     const std::string path =
         fmt::format("{}/shader_{:016x}{:016x}.nvdbg", dump_dir, identifier.id[0], identifier.id[1]);
-    FileUtil::IOFile file(path, "wb");
+    Common::FS::IOFile file(path, "wb");
     if (!file.IsOpen()) {
         LOG_ERROR(Render_Vulkan, "Failed to create file {}", path);
         return;

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -78,7 +78,7 @@ Common::DynamicLibrary OpenVulkanLibrary() {
     if (!libvulkan_env || !library.Open(libvulkan_env)) {
         // Use the libvulkan.dylib from the application bundle.
         const std::string filename =
-            FileUtil::GetBundleDirectory() + "/Contents/Frameworks/libvulkan.dylib";
+            Common::FS::GetBundleDirectory() + "/Contents/Frameworks/libvulkan.dylib";
         library.Open(filename.c_str());
     }
 #else

--- a/src/yuzu/applets/profile_select.cpp
+++ b/src/yuzu/applets/profile_select.cpp
@@ -26,7 +26,7 @@ QString FormatUserEntryText(const QString& username, Common::UUID uuid) {
 }
 
 QString GetImagePath(Common::UUID uuid) {
-    const auto path = FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
+    const auto path = Common::FS::GetUserPath(Common::FS::UserPath::NANDDir) +
                       "/system/save/8000000000000010/su/avators/" + uuid.FormatSwitch() + ".jpg";
     return QString::fromStdString(path);
 }

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -13,10 +13,12 @@
 #include "input_common/udp/client.h"
 #include "yuzu/configuration/config.h"
 
+namespace FS = Common::FS;
+
 Config::Config(const std::string& config_file, bool is_global) {
     // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
-    qt_config_loc = FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + config_file;
-    FileUtil::CreateFullPath(qt_config_loc);
+    qt_config_loc = FS::GetUserPath(FS::UserPath::ConfigDir) + config_file;
+    FS::CreateFullPath(qt_config_loc);
     qt_config =
         std::make_unique<QSettings>(QString::fromStdString(qt_config_loc), QSettings::IniFormat);
     global = is_global;
@@ -464,41 +466,36 @@ void Config::ReadDataStorageValues() {
     qt_config->beginGroup(QStringLiteral("Data Storage"));
 
     Settings::values.use_virtual_sd = ReadSetting(QStringLiteral("use_virtual_sd"), true).toBool();
-    FileUtil::GetUserPath(
-        FileUtil::UserPath::NANDDir,
-        qt_config
-            ->value(QStringLiteral("nand_directory"),
-                    QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)))
-            .toString()
-            .toStdString());
-    FileUtil::GetUserPath(
-        FileUtil::UserPath::SDMCDir,
-        qt_config
-            ->value(QStringLiteral("sdmc_directory"),
-                    QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)))
-            .toString()
-            .toStdString());
-    FileUtil::GetUserPath(
-        FileUtil::UserPath::LoadDir,
-        qt_config
-            ->value(QStringLiteral("load_directory"),
-                    QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::LoadDir)))
-            .toString()
-            .toStdString());
-    FileUtil::GetUserPath(
-        FileUtil::UserPath::DumpDir,
-        qt_config
-            ->value(QStringLiteral("dump_directory"),
-                    QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::DumpDir)))
-            .toString()
-            .toStdString());
-    FileUtil::GetUserPath(
-        FileUtil::UserPath::CacheDir,
-        qt_config
-            ->value(QStringLiteral("cache_directory"),
-                    QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::CacheDir)))
-            .toString()
-            .toStdString());
+    FS::GetUserPath(FS::UserPath::NANDDir,
+                    qt_config
+                        ->value(QStringLiteral("nand_directory"),
+                                QString::fromStdString(FS::GetUserPath(FS::UserPath::NANDDir)))
+                        .toString()
+                        .toStdString());
+    FS::GetUserPath(FS::UserPath::SDMCDir,
+                    qt_config
+                        ->value(QStringLiteral("sdmc_directory"),
+                                QString::fromStdString(FS::GetUserPath(FS::UserPath::SDMCDir)))
+                        .toString()
+                        .toStdString());
+    FS::GetUserPath(FS::UserPath::LoadDir,
+                    qt_config
+                        ->value(QStringLiteral("load_directory"),
+                                QString::fromStdString(FS::GetUserPath(FS::UserPath::LoadDir)))
+                        .toString()
+                        .toStdString());
+    FS::GetUserPath(FS::UserPath::DumpDir,
+                    qt_config
+                        ->value(QStringLiteral("dump_directory"),
+                                QString::fromStdString(FS::GetUserPath(FS::UserPath::DumpDir)))
+                        .toString()
+                        .toStdString());
+    FS::GetUserPath(FS::UserPath::CacheDir,
+                    qt_config
+                        ->value(QStringLiteral("cache_directory"),
+                                QString::fromStdString(FS::GetUserPath(FS::UserPath::CacheDir)))
+                        .toString()
+                        .toStdString());
     Settings::values.gamecard_inserted =
         ReadSetting(QStringLiteral("gamecard_inserted"), false).toBool();
     Settings::values.gamecard_current_game =
@@ -677,11 +674,11 @@ void Config::ReadScreenshotValues() {
 
     UISettings::values.enable_screenshot_save_as =
         ReadSetting(QStringLiteral("enable_screenshot_save_as"), true).toBool();
-    FileUtil::GetUserPath(
-        FileUtil::UserPath::ScreenshotsDir,
+    FS::GetUserPath(
+        FS::UserPath::ScreenshotsDir,
         qt_config
-            ->value(QStringLiteral("screenshot_path"), QString::fromStdString(FileUtil::GetUserPath(
-                                                           FileUtil::UserPath::ScreenshotsDir)))
+            ->value(QStringLiteral("screenshot_path"),
+                    QString::fromStdString(FS::GetUserPath(FS::UserPath::ScreenshotsDir)))
             .toString()
             .toStdString());
 
@@ -1016,20 +1013,20 @@ void Config::SaveDataStorageValues() {
 
     WriteSetting(QStringLiteral("use_virtual_sd"), Settings::values.use_virtual_sd, true);
     WriteSetting(QStringLiteral("nand_directory"),
-                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)),
-                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)));
+                 QString::fromStdString(FS::GetUserPath(FS::UserPath::NANDDir)),
+                 QString::fromStdString(FS::GetUserPath(FS::UserPath::NANDDir)));
     WriteSetting(QStringLiteral("sdmc_directory"),
-                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)),
-                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)));
+                 QString::fromStdString(FS::GetUserPath(FS::UserPath::SDMCDir)),
+                 QString::fromStdString(FS::GetUserPath(FS::UserPath::SDMCDir)));
     WriteSetting(QStringLiteral("load_directory"),
-                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::LoadDir)),
-                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::LoadDir)));
+                 QString::fromStdString(FS::GetUserPath(FS::UserPath::LoadDir)),
+                 QString::fromStdString(FS::GetUserPath(FS::UserPath::LoadDir)));
     WriteSetting(QStringLiteral("dump_directory"),
-                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::DumpDir)),
-                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::DumpDir)));
+                 QString::fromStdString(FS::GetUserPath(FS::UserPath::DumpDir)),
+                 QString::fromStdString(FS::GetUserPath(FS::UserPath::DumpDir)));
     WriteSetting(QStringLiteral("cache_directory"),
-                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::CacheDir)),
-                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::CacheDir)));
+                 QString::fromStdString(FS::GetUserPath(FS::UserPath::CacheDir)),
+                 QString::fromStdString(FS::GetUserPath(FS::UserPath::CacheDir)));
     WriteSetting(QStringLiteral("gamecard_inserted"), Settings::values.gamecard_inserted, false);
     WriteSetting(QStringLiteral("gamecard_current_game"), Settings::values.gamecard_current_game,
                  false);
@@ -1180,7 +1177,7 @@ void Config::SaveScreenshotValues() {
     WriteSetting(QStringLiteral("enable_screenshot_save_as"),
                  UISettings::values.enable_screenshot_save_as);
     WriteSetting(QStringLiteral("screenshot_path"),
-                 QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ScreenshotsDir)));
+                 QString::fromStdString(FS::GetUserPath(FS::UserPath::ScreenshotsDir)));
 
     qt_config->endGroup();
 }

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -19,7 +19,8 @@ ConfigureDebug::ConfigureDebug(QWidget* parent) : QWidget(parent), ui(new Ui::Co
     SetConfiguration();
 
     connect(ui->open_log_button, &QPushButton::clicked, []() {
-        QString path = QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::LogDir));
+        const auto path =
+            QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::LogDir));
         QDesktopServices::openUrl(QUrl::fromLocalFile(path));
     });
 }

--- a/src/yuzu/configuration/configure_filesystem.cpp
+++ b/src/yuzu/configuration/configure_filesystem.cpp
@@ -42,16 +42,16 @@ ConfigureFilesystem::~ConfigureFilesystem() = default;
 
 void ConfigureFilesystem::setConfiguration() {
     ui->nand_directory_edit->setText(
-        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)));
+        QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::NANDDir)));
     ui->sdmc_directory_edit->setText(
-        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)));
+        QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::SDMCDir)));
     ui->gamecard_path_edit->setText(QString::fromStdString(Settings::values.gamecard_path));
     ui->dump_path_edit->setText(
-        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::DumpDir)));
+        QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::DumpDir)));
     ui->load_path_edit->setText(
-        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::LoadDir)));
+        QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::LoadDir)));
     ui->cache_directory_edit->setText(
-        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::CacheDir)));
+        QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::CacheDir)));
 
     ui->gamecard_inserted->setChecked(Settings::values.gamecard_inserted);
     ui->gamecard_current_game->setChecked(Settings::values.gamecard_current_game);
@@ -64,14 +64,16 @@ void ConfigureFilesystem::setConfiguration() {
 }
 
 void ConfigureFilesystem::applyConfiguration() {
-    FileUtil::GetUserPath(FileUtil::UserPath::NANDDir,
-                          ui->nand_directory_edit->text().toStdString());
-    FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir,
-                          ui->sdmc_directory_edit->text().toStdString());
-    FileUtil::GetUserPath(FileUtil::UserPath::DumpDir, ui->dump_path_edit->text().toStdString());
-    FileUtil::GetUserPath(FileUtil::UserPath::LoadDir, ui->load_path_edit->text().toStdString());
-    FileUtil::GetUserPath(FileUtil::UserPath::CacheDir,
-                          ui->cache_directory_edit->text().toStdString());
+    Common::FS::GetUserPath(Common::FS::UserPath::NANDDir,
+                            ui->nand_directory_edit->text().toStdString());
+    Common::FS::GetUserPath(Common::FS::UserPath::SDMCDir,
+                            ui->sdmc_directory_edit->text().toStdString());
+    Common::FS::GetUserPath(Common::FS::UserPath::DumpDir,
+                            ui->dump_path_edit->text().toStdString());
+    Common::FS::GetUserPath(Common::FS::UserPath::LoadDir,
+                            ui->load_path_edit->text().toStdString());
+    Common::FS::GetUserPath(Common::FS::UserPath::CacheDir,
+                            ui->cache_directory_edit->text().toStdString());
     Settings::values.gamecard_path = ui->gamecard_path_edit->text().toStdString();
 
     Settings::values.gamecard_inserted = ui->gamecard_inserted->isChecked();
@@ -121,12 +123,13 @@ void ConfigureFilesystem::SetDirectory(DirectoryTarget target, QLineEdit* edit) 
 }
 
 void ConfigureFilesystem::ResetMetadata() {
-    if (!FileUtil::Exists(FileUtil::GetUserPath(FileUtil::UserPath::CacheDir) + DIR_SEP +
-                          "game_list")) {
+    if (!Common::FS::Exists(Common::FS::GetUserPath(Common::FS::UserPath::CacheDir) + DIR_SEP +
+                            "game_list")) {
         QMessageBox::information(this, tr("Reset Metadata Cache"),
                                  tr("The metadata cache is already empty."));
-    } else if (FileUtil::DeleteDirRecursively(FileUtil::GetUserPath(FileUtil::UserPath::CacheDir) +
-                                              DIR_SEP + "game_list")) {
+    } else if (Common::FS::DeleteDirRecursively(
+                   Common::FS::GetUserPath(Common::FS::UserPath::CacheDir) + DIR_SEP +
+                   "game_list")) {
         QMessageBox::information(this, tr("Reset Metadata Cache"),
                                  tr("The operation completed successfully."));
         UISettings::values.is_game_list_reload_pending.exchange(true);

--- a/src/yuzu/configuration/configure_per_game_addons.cpp
+++ b/src/yuzu/configuration/configure_per_game_addons.cpp
@@ -79,8 +79,8 @@ void ConfigurePerGameAddons::ApplyConfiguration() {
     std::sort(disabled_addons.begin(), disabled_addons.end());
     std::sort(current.begin(), current.end());
     if (disabled_addons != current) {
-        FileUtil::Delete(FileUtil::GetUserPath(FileUtil::UserPath::CacheDir) + DIR_SEP +
-                         "game_list" + DIR_SEP + fmt::format("{:016X}.pv.txt", title_id));
+        Common::FS::Delete(Common::FS::GetUserPath(Common::FS::UserPath::CacheDir) + DIR_SEP +
+                           "game_list" + DIR_SEP + fmt::format("{:016X}.pv.txt", title_id));
     }
 
     Settings::values.disabled_addons[title_id] = disabled_addons;

--- a/src/yuzu/configuration/configure_profile_manager.cpp
+++ b/src/yuzu/configuration/configure_profile_manager.cpp
@@ -34,7 +34,7 @@ constexpr std::array<u8, 107> backup_jpeg{
 };
 
 QString GetImagePath(Common::UUID uuid) {
-    const auto path = FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
+    const auto path = Common::FS::GetUserPath(Common::FS::UserPath::NANDDir) +
                       "/system/save/8000000000000010/su/avators/" + uuid.FormatSwitch() + ".jpg";
     return QString::fromStdString(path);
 }
@@ -282,7 +282,7 @@ void ConfigureProfileManager::SetUserImage() {
     }
 
     const auto raw_path = QString::fromStdString(
-        FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) + "/system/save/8000000000000010");
+        Common::FS::GetUserPath(Common::FS::UserPath::NANDDir) + "/system/save/8000000000000010");
     const QFileInfo raw_info{raw_path};
     if (raw_info.exists() && !raw_info.isDir() && !QFile::remove(raw_path)) {
         QMessageBox::warning(this, tr("Error deleting file"),

--- a/src/yuzu/configuration/configure_ui.cpp
+++ b/src/yuzu/configuration/configure_ui.cpp
@@ -61,9 +61,9 @@ ConfigureUi::ConfigureUi(QWidget* parent) : QWidget(parent), ui(new Ui::Configur
     // Set screenshot path to user specification.
     connect(ui->screenshot_path_button, &QToolButton::pressed, this, [this] {
         const QString& filename =
-            QFileDialog::getExistingDirectory(
-                this, tr("Select Screenshots Path..."),
-                QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ScreenshotsDir))) +
+            QFileDialog::getExistingDirectory(this, tr("Select Screenshots Path..."),
+                                              QString::fromStdString(Common::FS::GetUserPath(
+                                                  Common::FS::UserPath::ScreenshotsDir))) +
             QDir::separator();
         if (!filename.isEmpty()) {
             ui->screenshot_path_edit->setText(filename);
@@ -82,8 +82,8 @@ void ConfigureUi::ApplyConfiguration() {
     UISettings::values.row_2_text_id = ui->row_2_text_combobox->currentData().toUInt();
 
     UISettings::values.enable_screenshot_save_as = ui->enable_screenshot_save_as->isChecked();
-    FileUtil::GetUserPath(FileUtil::UserPath::ScreenshotsDir,
-                          ui->screenshot_path_edit->text().toStdString());
+    Common::FS::GetUserPath(Common::FS::UserPath::ScreenshotsDir,
+                            ui->screenshot_path_edit->text().toStdString());
     Settings::Apply();
 }
 
@@ -101,7 +101,7 @@ void ConfigureUi::SetConfiguration() {
 
     ui->enable_screenshot_save_as->setChecked(UISettings::values.enable_screenshot_save_as);
     ui->screenshot_path_edit->setText(
-        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ScreenshotsDir)));
+        QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::ScreenshotsDir)));
 }
 
 void ConfigureUi::changeEvent(QEvent* event) {

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -39,12 +39,12 @@ QString GetGameListCachedObject(const std::string& filename, const std::string& 
         return generator();
     }
 
-    const auto path = FileUtil::GetUserPath(FileUtil::UserPath::CacheDir) + DIR_SEP + "game_list" +
-                      DIR_SEP + filename + '.' + ext;
+    const auto path = Common::FS::GetUserPath(Common::FS::UserPath::CacheDir) + DIR_SEP +
+                      "game_list" + DIR_SEP + filename + '.' + ext;
 
-    FileUtil::CreateFullPath(path);
+    Common::FS::CreateFullPath(path);
 
-    if (!FileUtil::Exists(path)) {
+    if (!Common::FS::Exists(path)) {
         const auto str = generator();
 
         QFile file{QString::fromStdString(path)};
@@ -70,14 +70,14 @@ std::pair<std::vector<u8>, std::string> GetGameListCachedObject(
         return generator();
     }
 
-    const auto path1 = FileUtil::GetUserPath(FileUtil::UserPath::CacheDir) + DIR_SEP + "game_list" +
-                       DIR_SEP + filename + ".jpeg";
-    const auto path2 = FileUtil::GetUserPath(FileUtil::UserPath::CacheDir) + DIR_SEP + "game_list" +
-                       DIR_SEP + filename + ".appname.txt";
+    const auto path1 = Common::FS::GetUserPath(Common::FS::UserPath::CacheDir) + DIR_SEP +
+                       "game_list" + DIR_SEP + filename + ".jpeg";
+    const auto path2 = Common::FS::GetUserPath(Common::FS::UserPath::CacheDir) + DIR_SEP +
+                       "game_list" + DIR_SEP + filename + ".appname.txt";
 
-    FileUtil::CreateFullPath(path1);
+    Common::FS::CreateFullPath(path1);
 
-    if (!FileUtil::Exists(path1) || !FileUtil::Exists(path2)) {
+    if (!Common::FS::Exists(path1) || !Common::FS::Exists(path2)) {
         const auto [icon, nacp] = generator();
 
         QFile file1{QString::fromStdString(path1)};
@@ -208,7 +208,7 @@ QList<QStandardItem*> MakeGameListEntry(const std::string& path, const std::stri
                              file_type_string, program_id),
         new GameListItemCompat(compatibility),
         new GameListItem(file_type_string),
-        new GameListItemSize(FileUtil::GetSize(path)),
+        new GameListItemSize(Common::FS::GetSize(path)),
     };
 
     if (UISettings::values.show_add_ons) {
@@ -289,7 +289,7 @@ void GameListWorker::ScanFileSystem(ScanTarget target, const std::string& dir_pa
         }
 
         const std::string physical_name = directory + DIR_SEP + virtual_name;
-        const bool is_dir = FileUtil::IsDirectory(physical_name);
+        const bool is_dir = Common::FS::IsDirectory(physical_name);
         if (!is_dir &&
             (HasSupportedFileExtension(physical_name) || IsExtractedNCAMain(physical_name))) {
             const auto file = vfs->OpenFile(physical_name, FileSys::Mode::Read);
@@ -345,7 +345,7 @@ void GameListWorker::ScanFileSystem(ScanTarget target, const std::string& dir_pa
         return true;
     };
 
-    FileUtil::ForeachDirectoryEntry(nullptr, dir_path, callback);
+    Common::FS::ForeachDirectoryEntry(nullptr, dir_path, callback);
 }
 
 void GameListWorker::run() {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -177,8 +177,8 @@ static void InitializeLogging() {
     log_filter.ParseFilterString(Settings::values.log_filter);
     Log::SetGlobalFilter(log_filter);
 
-    const std::string& log_dir = FileUtil::GetUserPath(FileUtil::UserPath::LogDir);
-    FileUtil::CreateFullPath(log_dir);
+    const std::string& log_dir = Common::FS::GetUserPath(Common::FS::UserPath::LogDir);
+    Common::FS::CreateFullPath(log_dir);
     Log::AddBackend(std::make_unique<Log::FileBackend>(log_dir + LOG_FILE));
 #ifdef _WIN32
     Log::AddBackend(std::make_unique<Log::DebuggerBackend>());
@@ -1121,7 +1121,7 @@ void GMainWindow::BootGame(const QString& filename) {
         title_name = metadata.first->GetApplicationName();
     }
     if (res != Loader::ResultStatus::Success || title_name.empty()) {
-        title_name = FileUtil::GetFilename(filename.toStdString());
+        title_name = Common::FS::GetFilename(filename.toStdString());
     }
     LOG_INFO(Frontend, "Booting game: {:016X} | {} | {}", title_id, title_name, title_version);
     UpdateWindowTitle(title_name, title_version);
@@ -1259,7 +1259,7 @@ void GMainWindow::OnGameListOpenFolder(GameListOpenTarget target, const std::str
     switch (target) {
     case GameListOpenTarget::SaveData: {
         open_target = tr("Save Data");
-        const std::string nand_dir = FileUtil::GetUserPath(FileUtil::UserPath::NANDDir);
+        const std::string nand_dir = Common::FS::GetUserPath(Common::FS::UserPath::NANDDir);
 
         if (has_user_save) {
             // User save data
@@ -1294,16 +1294,16 @@ void GMainWindow::OnGameListOpenFolder(GameListOpenTarget target, const std::str
                                   FileSys::SaveDataType::SaveData, program_id, {}, 0);
         }
 
-        if (!FileUtil::Exists(path)) {
-            FileUtil::CreateFullPath(path);
-            FileUtil::CreateDir(path);
+        if (!Common::FS::Exists(path)) {
+            Common::FS::CreateFullPath(path);
+            Common::FS::CreateDir(path);
         }
 
         break;
     }
     case GameListOpenTarget::ModData: {
         open_target = tr("Mod Data");
-        const auto load_dir = FileUtil::GetUserPath(FileUtil::UserPath::LoadDir);
+        const auto load_dir = Common::FS::GetUserPath(Common::FS::UserPath::LoadDir);
         path = fmt::format("{}{:016X}", load_dir, program_id);
         break;
     }
@@ -1325,7 +1325,7 @@ void GMainWindow::OnGameListOpenFolder(GameListOpenTarget target, const std::str
 
 void GMainWindow::OnTransferableShaderCacheOpenFile(u64 program_id) {
     const QString shader_dir =
-        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir));
+        QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::ShaderDir));
     const QString transferable_shader_cache_folder_path =
         shader_dir + QStringLiteral("opengl") + QDir::separator() + QStringLiteral("transferable");
     const QString transferable_shader_cache_file_path =
@@ -1428,8 +1428,8 @@ void GMainWindow::OnGameListRemoveInstalledEntry(u64 program_id, InstalledEntryT
         RemoveAddOnContent(program_id, entry_type);
         break;
     }
-    FileUtil::DeleteDirRecursively(FileUtil::GetUserPath(FileUtil::UserPath::CacheDir) + DIR_SEP +
-                                   "game_list");
+    Common::FS::DeleteDirRecursively(Common::FS::GetUserPath(Common::FS::UserPath::CacheDir) +
+                                     DIR_SEP + "game_list");
     game_list->PopulateAsync(UISettings::values.game_dirs);
 }
 
@@ -1519,7 +1519,7 @@ void GMainWindow::OnGameListRemoveFile(u64 program_id, GameListRemoveTarget targ
 
 void GMainWindow::RemoveTransferableShaderCache(u64 program_id) {
     const QString shader_dir =
-        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ShaderDir));
+        QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::ShaderDir));
     const QString transferable_shader_cache_folder_path =
         shader_dir + QStringLiteral("opengl") + QDir::separator() + QStringLiteral("transferable");
     const QString transferable_shader_cache_file_path =
@@ -1543,7 +1543,7 @@ void GMainWindow::RemoveTransferableShaderCache(u64 program_id) {
 
 void GMainWindow::RemoveCustomConfiguration(u64 program_id) {
     const QString config_dir =
-        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir));
+        QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::ConfigDir));
     const QString custom_config_file_path =
         config_dir + QString::fromStdString(fmt::format("{:016X}.ini", program_id));
 
@@ -1590,7 +1590,7 @@ void GMainWindow::OnGameListDumpRomFS(u64 program_id, const std::string& game_pa
     }
 
     const auto path = fmt::format(
-        "{}{:016X}/romfs", FileUtil::GetUserPath(FileUtil::UserPath::DumpDir), *romfs_title_id);
+        "{}{:016X}/romfs", Common::FS::GetUserPath(Common::FS::UserPath::DumpDir), *romfs_title_id);
 
     FileSys::VirtualFile romfs;
 
@@ -1670,13 +1670,13 @@ void GMainWindow::OnGameListNavigateToGamedbEntry(u64 program_id,
 void GMainWindow::OnGameListOpenDirectory(const QString& directory) {
     QString path;
     if (directory == QStringLiteral("SDMC")) {
-        path = QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir) +
+        path = QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::SDMCDir) +
                                       "Nintendo/Contents/registered");
     } else if (directory == QStringLiteral("UserNAND")) {
-        path = QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
+        path = QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::NANDDir) +
                                       "user/Contents/registered");
     } else if (directory == QStringLiteral("SysNAND")) {
-        path = QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::NANDDir) +
+        path = QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::NANDDir) +
                                       "system/Contents/registered");
     } else {
         path = directory;
@@ -1690,8 +1690,10 @@ void GMainWindow::OnGameListOpenDirectory(const QString& directory) {
 
 void GMainWindow::OnGameListAddDirectory() {
     const QString dir_path = QFileDialog::getExistingDirectory(this, tr("Select Directory"));
-    if (dir_path.isEmpty())
+    if (dir_path.isEmpty()) {
         return;
+    }
+
     UISettings::GameDir game_dir{dir_path, false, true};
     if (!UISettings::values.game_dirs.contains(game_dir)) {
         UISettings::values.game_dirs.append(game_dir);
@@ -1882,8 +1884,8 @@ void GMainWindow::OnMenuInstallToNAND() {
                                 : tr("%n file(s) failed to install\n", "", failed_files.size()));
 
     QMessageBox::information(this, tr("Install Results"), install_results);
-    FileUtil::DeleteDirRecursively(FileUtil::GetUserPath(FileUtil::UserPath::CacheDir) + DIR_SEP +
-                                   "game_list");
+    Common::FS::DeleteDirRecursively(Common::FS::GetUserPath(Common::FS::UserPath::CacheDir) +
+                                     DIR_SEP + "game_list");
     game_list->PopulateAsync(UISettings::values.game_dirs);
     ui.action_Install_File_NAND->setEnabled(true);
 }
@@ -2302,7 +2304,7 @@ void GMainWindow::LoadAmiibo(const QString& filename) {
 
 void GMainWindow::OnOpenYuzuFolder() {
     QDesktopServices::openUrl(QUrl::fromLocalFile(
-        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::UserDir))));
+        QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::UserDir))));
 }
 
 void GMainWindow::OnAbout() {
@@ -2324,7 +2326,7 @@ void GMainWindow::OnCaptureScreenshot() {
 
     const u64 title_id = Core::System::GetInstance().CurrentProcess()->GetTitleID();
     const auto screenshot_path =
-        QString::fromStdString(FileUtil::GetUserPath(FileUtil::UserPath::ScreenshotsDir));
+        QString::fromStdString(Common::FS::GetUserPath(Common::FS::UserPath::ScreenshotsDir));
     const auto date =
         QDateTime::currentDateTime().toString(QStringLiteral("yyyy-MM-dd_hh-mm-ss-zzz"));
     QString filename = QStringLiteral("%1%2_%3.png")
@@ -2527,18 +2529,18 @@ void GMainWindow::OnReinitializeKeys(ReinitializeKeyBehavior behavior) {
         if (res == QMessageBox::Cancel)
             return;
 
-        FileUtil::Delete(FileUtil::GetUserPath(FileUtil::UserPath::KeysDir) +
-                         "prod.keys_autogenerated");
-        FileUtil::Delete(FileUtil::GetUserPath(FileUtil::UserPath::KeysDir) +
-                         "console.keys_autogenerated");
-        FileUtil::Delete(FileUtil::GetUserPath(FileUtil::UserPath::KeysDir) +
-                         "title.keys_autogenerated");
+        Common::FS::Delete(Common::FS::GetUserPath(Common::FS::UserPath::KeysDir) +
+                           "prod.keys_autogenerated");
+        Common::FS::Delete(Common::FS::GetUserPath(Common::FS::UserPath::KeysDir) +
+                           "console.keys_autogenerated");
+        Common::FS::Delete(Common::FS::GetUserPath(Common::FS::UserPath::KeysDir) +
+                           "title.keys_autogenerated");
     }
 
     Core::Crypto::KeyManager& keys = Core::Crypto::KeyManager::Instance();
     if (keys.BaseDeriveNecessary()) {
         Core::Crypto::PartitionDataManager pdm{vfs->OpenDirectory(
-            FileUtil::GetUserPath(FileUtil::UserPath::SysDataDir), FileSys::Mode::Read)};
+            Common::FS::GetUserPath(Common::FS::UserPath::SysDataDir), FileSys::Mode::Read)};
 
         const auto function = [this, &keys, &pdm] {
             keys.PopulateFromPartitionData(pdm);
@@ -2870,7 +2872,7 @@ int main(int argc, char* argv[]) {
     // If you start a bundle (binary) on OSX without the Terminal, the working directory is "/".
     // But since we require the working directory to be the executable path for the location of
     // the user folder in the Qt Frontend, we need to cd into that working directory
-    const std::string bin_path = FileUtil::GetBundleDirectory() + DIR_SEP + "..";
+    const std::string bin_path = Common::FS::GetBundleDirectory() + DIR_SEP + "..";
     chdir(bin_path.c_str());
 #endif
 

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -16,9 +16,11 @@
 #include "yuzu_cmd/config.h"
 #include "yuzu_cmd/default_ini.h"
 
+namespace FS = Common::FS;
+
 Config::Config() {
     // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
-    sdl2_config_loc = FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + "sdl2-config.ini";
+    sdl2_config_loc = FS::GetUserPath(FS::UserPath::ConfigDir) + "sdl2-config.ini";
     sdl2_config = std::make_unique<INIReader>(sdl2_config_loc);
 
     Reload();
@@ -31,8 +33,8 @@ bool Config::LoadINI(const std::string& default_contents, bool retry) {
     if (sdl2_config->ParseError() < 0) {
         if (retry) {
             LOG_WARNING(Config, "Failed to load {}. Creating file from defaults...", location);
-            FileUtil::CreateFullPath(location);
-            FileUtil::WriteStringToFile(true, location, default_contents);
+            FS::CreateFullPath(location);
+            FS::WriteStringToFile(true, location, default_contents);
             sdl2_config = std::make_unique<INIReader>(location); // Reopen file
 
             return LoadINI(default_contents, false);
@@ -315,21 +317,21 @@ void Config::ReadValues() {
     // Data Storage
     Settings::values.use_virtual_sd =
         sdl2_config->GetBoolean("Data Storage", "use_virtual_sd", true);
-    FileUtil::GetUserPath(FileUtil::UserPath::NANDDir,
-                          sdl2_config->Get("Data Storage", "nand_directory",
-                                           FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)));
-    FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir,
-                          sdl2_config->Get("Data Storage", "sdmc_directory",
-                                           FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)));
-    FileUtil::GetUserPath(FileUtil::UserPath::LoadDir,
-                          sdl2_config->Get("Data Storage", "load_directory",
-                                           FileUtil::GetUserPath(FileUtil::UserPath::LoadDir)));
-    FileUtil::GetUserPath(FileUtil::UserPath::DumpDir,
-                          sdl2_config->Get("Data Storage", "dump_directory",
-                                           FileUtil::GetUserPath(FileUtil::UserPath::DumpDir)));
-    FileUtil::GetUserPath(FileUtil::UserPath::CacheDir,
-                          sdl2_config->Get("Data Storage", "cache_directory",
-                                           FileUtil::GetUserPath(FileUtil::UserPath::CacheDir)));
+    FS::GetUserPath(
+        FS::UserPath::NANDDir,
+        sdl2_config->Get("Data Storage", "nand_directory", FS::GetUserPath(FS::UserPath::NANDDir)));
+    FS::GetUserPath(
+        FS::UserPath::SDMCDir,
+        sdl2_config->Get("Data Storage", "sdmc_directory", FS::GetUserPath(FS::UserPath::SDMCDir)));
+    FS::GetUserPath(
+        FS::UserPath::LoadDir,
+        sdl2_config->Get("Data Storage", "load_directory", FS::GetUserPath(FS::UserPath::LoadDir)));
+    FS::GetUserPath(
+        FS::UserPath::DumpDir,
+        sdl2_config->Get("Data Storage", "dump_directory", FS::GetUserPath(FS::UserPath::DumpDir)));
+    FS::GetUserPath(FS::UserPath::CacheDir,
+                    sdl2_config->Get("Data Storage", "cache_directory",
+                                     FS::GetUserPath(FS::UserPath::CacheDir)));
     Settings::values.gamecard_inserted =
         sdl2_config->GetBoolean("Data Storage", "gamecard_inserted", false);
     Settings::values.gamecard_current_game =

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -82,8 +82,8 @@ static void InitializeLogging() {
 
     Log::AddBackend(std::make_unique<Log::ColorConsoleBackend>());
 
-    const std::string& log_dir = FileUtil::GetUserPath(FileUtil::UserPath::LogDir);
-    FileUtil::CreateFullPath(log_dir);
+    const std::string& log_dir = Common::FS::GetUserPath(Common::FS::UserPath::LogDir);
+    Common::FS::CreateFullPath(log_dir);
     Log::AddBackend(std::make_unique<Log::FileBackend>(log_dir + LOG_FILE));
 #ifdef _WIN32
     Log::AddBackend(std::make_unique<Log::DebuggerBackend>());

--- a/src/yuzu_tester/config.cpp
+++ b/src/yuzu_tester/config.cpp
@@ -15,10 +15,11 @@
 #include "yuzu_tester/config.h"
 #include "yuzu_tester/default_ini.h"
 
+namespace FS = Common::FS;
+
 Config::Config() {
     // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
-    sdl2_config_loc =
-        FileUtil::GetUserPath(FileUtil::UserPath::ConfigDir) + "sdl2-tester-config.ini";
+    sdl2_config_loc = FS::GetUserPath(FS::UserPath::ConfigDir) + "sdl2-tester-config.ini";
     sdl2_config = std::make_unique<INIReader>(sdl2_config_loc);
 
     Reload();
@@ -31,8 +32,8 @@ bool Config::LoadINI(const std::string& default_contents, bool retry) {
     if (sdl2_config->ParseError() < 0) {
         if (retry) {
             LOG_WARNING(Config, "Failed to load {}. Creating file from defaults...", location);
-            FileUtil::CreateFullPath(location);
-            FileUtil::WriteStringToFile(true, default_contents, location);
+            FS::CreateFullPath(location);
+            FS::WriteStringToFile(true, default_contents, location);
             sdl2_config = std::make_unique<INIReader>(location); // Reopen file
 
             return LoadINI(default_contents, false);
@@ -87,12 +88,12 @@ void Config::ReadValues() {
     // Data Storage
     Settings::values.use_virtual_sd =
         sdl2_config->GetBoolean("Data Storage", "use_virtual_sd", true);
-    FileUtil::GetUserPath(FileUtil::UserPath::NANDDir,
-                          sdl2_config->Get("Data Storage", "nand_directory",
-                                           FileUtil::GetUserPath(FileUtil::UserPath::NANDDir)));
-    FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir,
-                          sdl2_config->Get("Data Storage", "sdmc_directory",
-                                           FileUtil::GetUserPath(FileUtil::UserPath::SDMCDir)));
+    FS::GetUserPath(Common::FS::UserPath::NANDDir,
+                    sdl2_config->Get("Data Storage", "nand_directory",
+                                     Common::FS::GetUserPath(Common::FS::UserPath::NANDDir)));
+    FS::GetUserPath(Common::FS::UserPath::SDMCDir,
+                    sdl2_config->Get("Data Storage", "sdmc_directory",
+                                     Common::FS::GetUserPath(Common::FS::UserPath::SDMCDir)));
 
     // System
     Settings::values.current_user = std::clamp<int>(

--- a/src/yuzu_tester/yuzu.cpp
+++ b/src/yuzu_tester/yuzu.cpp
@@ -79,8 +79,8 @@ static void InitializeLogging(bool console) {
     if (console)
         Log::AddBackend(std::make_unique<Log::ColorConsoleBackend>());
 
-    const std::string& log_dir = FileUtil::GetUserPath(FileUtil::UserPath::LogDir);
-    FileUtil::CreateFullPath(log_dir);
+    const std::string& log_dir = Common::FS::GetUserPath(Common::FS::UserPath::LogDir);
+    Common::FS::CreateFullPath(log_dir);
     Log::AddBackend(std::make_unique<Log::FileBackend>(log_dir + LOG_FILE));
 #ifdef _WIN32
     Log::AddBackend(std::make_unique<Log::DebuggerBackend>());


### PR DESCRIPTION
Migrates a remaining common file over to the Common namespace, making it consistent with the rest of the common files.

This also allows for high-traffic FS related code to alias the filesystem function namespace as

```cpp
namespace FS = Common::FS;
```

for more concise typing.