### PR TITLE
yuzu: Resolve -Wextra-semi warnings

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -406,7 +406,7 @@ bool GameList::isEmpty() const {
              type == GameListItemType::SysNandDir)) {
             item_model->invisibleRootItem()->removeRow(child->row());
             i--;
-        };
+        }
     }
     return !item_model->invisibleRootItem()->hasChildren();
 }

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -374,7 +374,7 @@ void GameListWorker::run() {
             ScanFileSystem(ScanTarget::PopulateGameList, game_dir.path.toStdString(),
                            game_dir.deep_scan ? 256 : 0, game_list_dir);
         }
-    };
+    }
 
     emit Finished(watch_list);
 }

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -29,14 +29,14 @@ extern const Themes themes;
 
 struct GameDir {
     QString path;
-    bool deep_scan;
-    bool expanded;
+    bool deep_scan = false;
+    bool expanded = false;
     bool operator==(const GameDir& rhs) const {
         return path == rhs.path;
-    };
+    }
     bool operator!=(const GameDir& rhs) const {
         return !operator==(rhs);
-    };
+    }
 };
 
 struct Values {


### PR DESCRIPTION
While we're in the same area, we can ensure GameDir member variables are always initialized to consistent values.