### PR TITLE
common: Silence two discarded result warnings

### DIFF
--- a/src/common/dynamic_library.cpp
+++ b/src/common/dynamic_library.cpp
@@ -21,7 +21,7 @@ namespace Common {
 DynamicLibrary::DynamicLibrary() = default;
 
 DynamicLibrary::DynamicLibrary(const char* filename) {
-    Open(filename);
+    void(Open(filename));
 }
 
 DynamicLibrary::DynamicLibrary(DynamicLibrary&& rhs) noexcept

--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -902,10 +902,10 @@ std::string SanitizePath(std::string_view path_, DirectorySeparator directory_se
     return std::string(RemoveTrailingSlash(path));
 }
 
-IOFile::IOFile() {}
+IOFile::IOFile() = default;
 
 IOFile::IOFile(const std::string& filename, const char openmode[], int flags) {
-    Open(filename, openmode, flags);
+    void(Open(filename, openmode, flags));
 }
 
 IOFile::~IOFile() {


### PR DESCRIPTION
These are intentionally discarded internally, since the rest of the public API allows querying success. We want all non-internal uses of
these functions to be explicitly checked, so we can signify that we intentionally want to discard the return values here.