### PR TITLE
common/telemetry: Migrate namespace into the Common namespace

### DIFF
--- a/src/common/telemetry.cpp
+++ b/src/common/telemetry.cpp
@@ -12,7 +12,7 @@
 #include "common/x64/cpu_detect.h"
 #endif
 
-namespace Telemetry {
+namespace Common::Telemetry {
 
 void FieldCollection::Accept(VisitorInterface& visitor) const {
     for (const auto& field : fields) {
@@ -88,4 +88,4 @@ void AppendOSInfo(FieldCollection& fc) {
 #endif
 }
 
-} // namespace Telemetry
+} // namespace Common::Telemetry

--- a/src/common/telemetry.h
+++ b/src/common/telemetry.h
@@ -10,7 +10,7 @@
 #include <string>
 #include "common/common_types.h"
 
-namespace Telemetry {
+namespace Common::Telemetry {
 
 /// Field type, used for grouping fields together in the final submitted telemetry log
 enum class FieldType : u8 {
@@ -196,4 +196,4 @@ void AppendCPUInfo(FieldCollection& fc);
 /// such as platform name, etc.
 void AppendOSInfo(FieldCollection& fc);
 
-} // namespace Telemetry
+} // namespace Common::Telemetry

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -269,14 +269,14 @@ struct System::Impl {
         // Log last frame performance stats if game was loded
         if (perf_stats) {
             const auto perf_results = GetAndResetPerfStats();
-            telemetry_session->AddField(Telemetry::FieldType::Performance,
-                                        "Shutdown_EmulationSpeed",
+            constexpr auto performance = Common::Telemetry::FieldType::Performance;
+
+            telemetry_session->AddField(performance, "Shutdown_EmulationSpeed",
                                         perf_results.emulation_speed * 100.0);
-            telemetry_session->AddField(Telemetry::FieldType::Performance, "Shutdown_Framerate",
-                                        perf_results.game_fps);
-            telemetry_session->AddField(Telemetry::FieldType::Performance, "Shutdown_Frametime",
+            telemetry_session->AddField(performance, "Shutdown_Framerate", perf_results.game_fps);
+            telemetry_session->AddField(performance, "Shutdown_Frametime",
                                         perf_results.frametime * 1000.0);
-            telemetry_session->AddField(Telemetry::FieldType::Performance, "Mean_Frametime_MS",
+            telemetry_session->AddField(performance, "Mean_Frametime_MS",
                                         perf_stats->GetMeanFrametime());
         }
 

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -25,6 +25,8 @@
 
 namespace Core {
 
+namespace Telemetry = Common::Telemetry;
+
 static u64 GenerateTelemetryId() {
     u64 telemetry_id{};
 

--- a/src/core/telemetry_session.h
+++ b/src/core/telemetry_session.h
@@ -52,7 +52,7 @@ public:
      * @param value Value for the field to add.
      */
     template <typename T>
-    void AddField(Telemetry::FieldType type, const char* name, T value) {
+    void AddField(Common::Telemetry::FieldType type, const char* name, T value) {
         field_collection.AddField(type, name, std::move(value));
     }
 
@@ -63,7 +63,8 @@ public:
     bool SubmitTestcase();
 
 private:
-    Telemetry::FieldCollection field_collection; ///< Tracks all added fields for the session
+    /// Tracks all added fields for the session
+    Common::Telemetry::FieldCollection field_collection;
 };
 
 /**

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -509,9 +509,10 @@ void RendererOpenGL::AddTelemetryFields() {
     LOG_INFO(Render_OpenGL, "GL_RENDERER: {}", gpu_model);
 
     auto& telemetry_session = system.TelemetrySession();
-    telemetry_session.AddField(Telemetry::FieldType::UserSystem, "GPU_Vendor", gpu_vendor);
-    telemetry_session.AddField(Telemetry::FieldType::UserSystem, "GPU_Model", gpu_model);
-    telemetry_session.AddField(Telemetry::FieldType::UserSystem, "GPU_OpenGL_Version", gl_version);
+    constexpr auto user_system = Common::Telemetry::FieldType::UserSystem;
+    telemetry_session.AddField(user_system, "GPU_Vendor", gpu_vendor);
+    telemetry_session.AddField(user_system, "GPU_Model", gpu_model);
+    telemetry_session.AddField(user_system, "GPU_OpenGL_Version", gl_version);
 }
 
 void RendererOpenGL::CreateRasterizer() {

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -439,7 +439,7 @@ void RendererVulkan::Report() const {
     LOG_INFO(Render_Vulkan, "Vulkan: {}", api_version);
 
     auto& telemetry_session = system.TelemetrySession();
-    constexpr auto field = Telemetry::FieldType::UserSystem;
+    constexpr auto field = Common::Telemetry::FieldType::UserSystem;
     telemetry_session.AddField(field, "GPU_Vendor", vendor_name);
     telemetry_session.AddField(field, "GPU_Model", model_name);
     telemetry_session.AddField(field, "GPU_Vulkan_Driver", driver_name);

--- a/src/web_service/telemetry_json.cpp
+++ b/src/web_service/telemetry_json.cpp
@@ -10,6 +10,8 @@
 
 namespace WebService {
 
+namespace Telemetry = Common::Telemetry;
+
 struct TelemetryJson::Impl {
     Impl(std::string host, std::string username, std::string token)
         : host{std::move(host)}, username{std::move(username)}, token{std::move(token)} {}

--- a/src/web_service/telemetry_json.h
+++ b/src/web_service/telemetry_json.h
@@ -14,25 +14,25 @@ namespace WebService {
  * Implementation of VisitorInterface that serialized telemetry into JSON, and submits it to the
  * yuzu web service
  */
-class TelemetryJson : public Telemetry::VisitorInterface {
+class TelemetryJson : public Common::Telemetry::VisitorInterface {
 public:
     TelemetryJson(std::string host, std::string username, std::string token);
     ~TelemetryJson() override;
 
-    void Visit(const Telemetry::Field<bool>& field) override;
-    void Visit(const Telemetry::Field<double>& field) override;
-    void Visit(const Telemetry::Field<float>& field) override;
-    void Visit(const Telemetry::Field<u8>& field) override;
-    void Visit(const Telemetry::Field<u16>& field) override;
-    void Visit(const Telemetry::Field<u32>& field) override;
-    void Visit(const Telemetry::Field<u64>& field) override;
-    void Visit(const Telemetry::Field<s8>& field) override;
-    void Visit(const Telemetry::Field<s16>& field) override;
-    void Visit(const Telemetry::Field<s32>& field) override;
-    void Visit(const Telemetry::Field<s64>& field) override;
-    void Visit(const Telemetry::Field<std::string>& field) override;
-    void Visit(const Telemetry::Field<const char*>& field) override;
-    void Visit(const Telemetry::Field<std::chrono::microseconds>& field) override;
+    void Visit(const Common::Telemetry::Field<bool>& field) override;
+    void Visit(const Common::Telemetry::Field<double>& field) override;
+    void Visit(const Common::Telemetry::Field<float>& field) override;
+    void Visit(const Common::Telemetry::Field<u8>& field) override;
+    void Visit(const Common::Telemetry::Field<u16>& field) override;
+    void Visit(const Common::Telemetry::Field<u32>& field) override;
+    void Visit(const Common::Telemetry::Field<u64>& field) override;
+    void Visit(const Common::Telemetry::Field<s8>& field) override;
+    void Visit(const Common::Telemetry::Field<s16>& field) override;
+    void Visit(const Common::Telemetry::Field<s32>& field) override;
+    void Visit(const Common::Telemetry::Field<s64>& field) override;
+    void Visit(const Common::Telemetry::Field<std::string>& field) override;
+    void Visit(const Common::Telemetry::Field<const char*>& field) override;
+    void Visit(const Common::Telemetry::Field<std::chrono::microseconds>& field) override;
 
     void Complete() override;
     bool SubmitTestcase() override;

--- a/src/yuzu/compatdb.cpp
+++ b/src/yuzu/compatdb.cpp
@@ -54,7 +54,8 @@ void CompatDB::Submit() {
         back();
         LOG_DEBUG(Frontend, "Compatibility Rating: {}", compatibility->checkedId());
         Core::System::GetInstance().TelemetrySession().AddField(
-            Telemetry::FieldType::UserFeedback, "Compatibility", compatibility->checkedId());
+            Common::Telemetry::FieldType::UserFeedback, "Compatibility",
+            compatibility->checkedId());
 
         button(NextButton)->setEnabled(false);
         button(NextButton)->setText(tr("Submitting"));

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1041,7 +1041,7 @@ bool GMainWindow::LoadROM(const QString& filename) {
     }
     game_path = filename;
 
-    system.TelemetrySession().AddField(Telemetry::FieldType::App, "Frontend", "Qt");
+    system.TelemetrySession().AddField(Common::Telemetry::FieldType::App, "Frontend", "Qt");
     return true;
 }
 

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -229,7 +229,7 @@ int main(int argc, char** argv) {
         }
     }
 
-    system.TelemetrySession().AddField(Telemetry::FieldType::App, "Frontend", "SDL");
+    system.TelemetrySession().AddField(Common::Telemetry::FieldType::App, "Frontend", "SDL");
 
     // Core is loaded, start the GPU (makes the GPU contexts current to this thread)
     system.GPU().Start();

--- a/src/yuzu_tester/yuzu.cpp
+++ b/src/yuzu_tester/yuzu.cpp
@@ -251,7 +251,8 @@ int main(int argc, char** argv) {
 
     Service::Yuzu::InstallInterfaces(system.ServiceManager(), datastring, callback);
 
-    system.TelemetrySession().AddField(Telemetry::FieldType::App, "Frontend", "SDLHideTester");
+    system.TelemetrySession().AddField(Common::Telemetry::FieldType::App, "Frontend",
+                                       "SDLHideTester");
 
     system.GPU().Start();
     system.Renderer().Rasterizer().LoadDiskResources();


### PR DESCRIPTION
Migrates the Telemetry namespace into the Common namespace to make the code consistent with the rest of our common code.