### PR TITLE
common/concepts: Move <type_traits> include out of the Common namespace

### DIFF
--- a/src/common/concepts.h
+++ b/src/common/concepts.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-namespace Common {
-
 #include <type_traits>
+
+namespace Common {
 
 // Check if type is like an STL container
 template <typename T>


### PR DESCRIPTION
This is a compiler/linker error waiting to happen.