### PR TITLE
vk_state_tracker: Fix primitive topology

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -1443,10 +1443,10 @@ void RasterizerVulkan::UpdateFrontFace(Tegra::Engines::Maxwell3D::Regs& regs) {
 }
 
 void RasterizerVulkan::UpdatePrimitiveTopology(Tegra::Engines::Maxwell3D::Regs& regs) {
-    if (!state_tracker.TouchPrimitiveTopology()) {
+    const Maxwell::PrimitiveTopology primitive_topology = regs.draw.topology.Value();
+    if (!state_tracker.ChangePrimitiveTopology(primitive_topology)) {
         return;
     }
-    const Maxwell::PrimitiveTopology primitive_topology = regs.draw.topology.Value();
     scheduler.Record([this, primitive_topology](vk::CommandBuffer cmdbuf) {
         cmdbuf.SetPrimitiveTopologyEXT(MaxwellToVK::PrimitiveTopology(device, primitive_topology));
     });

--- a/src/video_core/renderer_vulkan/vk_state_tracker.cpp
+++ b/src/video_core/renderer_vulkan/vk_state_tracker.cpp
@@ -42,7 +42,6 @@ Flags MakeInvalidationFlags() {
     flags[DepthWriteEnable] = true;
     flags[DepthCompareOp] = true;
     flags[FrontFace] = true;
-    flags[PrimitiveTopology] = true;
     flags[StencilOp] = true;
     flags[StencilTestEnable] = true;
     return flags;
@@ -112,10 +111,6 @@ void SetupDirtyFrontFace(Tables& tables) {
     table[OFF(screen_y_control)] = FrontFace;
 }
 
-void SetupDirtyPrimitiveTopology(Tables& tables) {
-    tables[0][OFF(draw.topology)] = PrimitiveTopology;
-}
-
 void SetupDirtyStencilOp(Tables& tables) {
     auto& table = tables[0];
     table[OFF(stencil_front_op_fail)] = StencilOp;
@@ -156,13 +151,13 @@ void StateTracker::Initialize() {
     SetupDirtyDepthWriteEnable(tables);
     SetupDirtyDepthCompareOp(tables);
     SetupDirtyFrontFace(tables);
-    SetupDirtyPrimitiveTopology(tables);
     SetupDirtyStencilOp(tables);
     SetupDirtyStencilTestEnable(tables);
 }
 
 void StateTracker::InvalidateCommandBufferState() {
     system.GPU().Maxwell3D().dirty.flags |= invalidation_flags;
+    current_topology = INVALID_TOPOLOGY;
 }
 
 } // namespace Vulkan


### PR DESCRIPTION
State track the current primitive topology with a regular comparison instead of using dirty flags.

This fixes a bug in dirty flags for this particular state and it also avoids unnecessary state changes as this property is stored in a frequently changed bit field.

- Fixes a regression on drivers with `VK_EXT_extended_dynamic_state` on Smash Ultimate.