### PR TITLE
web_service: Move web_result.h into web_service

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -172,7 +172,6 @@ add_library(common STATIC
     virtual_buffer.h
     wall_clock.cpp
     wall_clock.h
-    web_result.h
     zstd_compression.cpp
     zstd_compression.h
 )

--- a/src/web_service/CMakeLists.txt
+++ b/src/web_service/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(web_service STATIC
     verify_login.h
     web_backend.cpp
     web_backend.h
+    web_result.h
 )
 
 create_target_directory_groups(web_service)

--- a/src/web_service/telemetry_json.cpp
+++ b/src/web_service/telemetry_json.cpp
@@ -4,9 +4,9 @@
 
 #include <nlohmann/json.hpp>
 #include "common/detached_tasks.h"
-#include "common/web_result.h"
 #include "web_service/telemetry_json.h"
 #include "web_service/web_backend.h"
+#include "web_service/web_result.h"
 
 namespace WebService {
 
@@ -125,7 +125,7 @@ bool TelemetryJson::SubmitTestcase() {
     Client client(impl->host, impl->username, impl->token);
     auto value = client.PostJson("/gamedb/testcase", content, false);
 
-    return value.result_code == Common::WebResult::Code::Success;
+    return value.result_code == WebResult::Code::Success;
 }
 
 } // namespace WebService

--- a/src/web_service/verify_login.cpp
+++ b/src/web_service/verify_login.cpp
@@ -3,9 +3,9 @@
 // Refer to the license.txt file included.
 
 #include <nlohmann/json.hpp>
-#include "common/web_result.h"
 #include "web_service/verify_login.h"
 #include "web_service/web_backend.h"
+#include "web_service/web_result.h"
 
 namespace WebService {
 

--- a/src/web_service/web_backend.h
+++ b/src/web_service/web_backend.h
@@ -7,11 +7,9 @@
 #include <memory>
 #include <string>
 
-namespace Common {
-struct WebResult;
-}
-
 namespace WebService {
+
+struct WebResult;
 
 class Client {
 public:
@@ -25,8 +23,7 @@ public:
      * @param allow_anonymous If true, allow anonymous unauthenticated requests.
      * @return the result of the request.
      */
-    Common::WebResult PostJson(const std::string& path, const std::string& data,
-                               bool allow_anonymous);
+    WebResult PostJson(const std::string& path, const std::string& data, bool allow_anonymous);
 
     /**
      * Gets JSON from the specified path.
@@ -34,7 +31,7 @@ public:
      * @param allow_anonymous If true, allow anonymous unauthenticated requests.
      * @return the result of the request.
      */
-    Common::WebResult GetJson(const std::string& path, bool allow_anonymous);
+    WebResult GetJson(const std::string& path, bool allow_anonymous);
 
     /**
      * Deletes JSON to the specified path.
@@ -43,8 +40,7 @@ public:
      * @param allow_anonymous If true, allow anonymous unauthenticated requests.
      * @return the result of the request.
      */
-    Common::WebResult DeleteJson(const std::string& path, const std::string& data,
-                                 bool allow_anonymous);
+    WebResult DeleteJson(const std::string& path, const std::string& data, bool allow_anonymous);
 
     /**
      * Gets a plain string from the specified path.
@@ -52,7 +48,7 @@ public:
      * @param allow_anonymous If true, allow anonymous unauthenticated requests.
      * @return the result of the request.
      */
-    Common::WebResult GetPlain(const std::string& path, bool allow_anonymous);
+    WebResult GetPlain(const std::string& path, bool allow_anonymous);
 
     /**
      * Gets an PNG image from the specified path.
@@ -60,14 +56,14 @@ public:
      * @param allow_anonymous If true, allow anonymous unauthenticated requests.
      * @return the result of the request.
      */
-    Common::WebResult GetImage(const std::string& path, bool allow_anonymous);
+    WebResult GetImage(const std::string& path, bool allow_anonymous);
 
     /**
      * Requests an external JWT for the specific audience provided.
      * @param audience the audience of the JWT requested.
      * @return the result of the request.
      */
-    Common::WebResult GetExternalJWT(const std::string& audience);
+    WebResult GetExternalJWT(const std::string& audience);
 
 private:
     struct Impl;

--- a/src/web_service/web_result.h
+++ b/src/web_service/web_result.h
@@ -7,7 +7,7 @@
 #include <string>
 #include "common/common_types.h"
 
-namespace Common {
+namespace WebService {
 struct WebResult {
     enum class Code : u32 {
         Success,
@@ -22,4 +22,4 @@ struct WebResult {
     std::string result_string;
     std::string returned_data;
 };
-} // namespace Common
+} // namespace WebService


### PR DESCRIPTION
This is the only place it's actively used. It's also more appropriate for web-related structures to be within the web service target. Especially given this one doesn't rely on anything in the common library.