### PR TITLE
key_manager: Make data arrays constexpr

### DIFF
--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -10,7 +10,6 @@
 #include <string>
 
 #include <variant>
-#include <boost/container/flat_map.hpp>
 #include <fmt/format.h>
 #include "common/common_funcs.h"
 #include "common/common_types.h"
@@ -293,9 +292,6 @@ private:
 
     void SetKeyWrapped(S128KeyType id, Key128 key, u64 field1 = 0, u64 field2 = 0);
     void SetKeyWrapped(S256KeyType id, Key256 key, u64 field1 = 0, u64 field2 = 0);
-
-    static const boost::container::flat_map<std::string, KeyIndex<S128KeyType>> s128_file_id;
-    static const boost::container::flat_map<std::string, KeyIndex<S256KeyType>> s256_file_id;
 };
 
 Key128 GenerateKeyEncryptionKey(Key128 source, Key128 master, Key128 kek_seed, Key128 key_seed);


### PR DESCRIPTION
We can convert these maps into constexpr arrays to eliminate some runtime static constructors.