### PR TITLE
fsp_srv: Resolve -Wmaybe_uninitialized warning in OpenSaveDataFileSystem()

### DIFF
--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -844,8 +844,7 @@ void FSP_SRV::OpenSaveDataFileSystem(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    FileSys::StorageId id;
-
+    FileSys::StorageId id{};
     switch (parameters.space_id) {
     case FileSys::SaveDataSpaceId::NandUser:
         id = FileSys::StorageId::NandUser;
@@ -857,6 +856,10 @@ void FSP_SRV::OpenSaveDataFileSystem(Kernel::HLERequestContext& ctx) {
     case FileSys::SaveDataSpaceId::NandSystem:
         id = FileSys::StorageId::NandSystem;
         break;
+    case FileSys::SaveDataSpaceId::TemporaryStorage:
+    case FileSys::SaveDataSpaceId::ProperSystem:
+    case FileSys::SaveDataSpaceId::SafeMode:
+        UNREACHABLE();
     }
 
     auto filesystem =

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -905,7 +905,14 @@ void FSP_SRV::ReadSaveDataFileSystemExtraDataWithMaskBySaveDataAttribute(
     // Stub this to None for now, backend needs an impl to read/write the SaveDataExtraData
     constexpr auto flags = static_cast<u32>(FileSys::SaveDataFlags::None);
 
-    LOG_WARNING(Service_FS, "(STUBBED) called, flags={}", flags);
+    LOG_WARNING(Service_FS,
+                "(STUBBED) called, flags={}, space_id={}, attribute.title_id={:016X}\n"
+                "attribute.user_id={:016X}{:016X}, attribute.save_id={:016X}\n"
+                "attribute.type={}, attribute.rank={}, attribute.index={}",
+                flags, static_cast<u32>(parameters.space_id), parameters.attribute.title_id,
+                parameters.attribute.user_id[1], parameters.attribute.user_id[0],
+                parameters.attribute.save_id, static_cast<u32>(parameters.attribute.type),
+                static_cast<u32>(parameters.attribute.rank), parameters.attribute.index);
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);


### PR DESCRIPTION
We can initialize `id` to a deterministic value and also mark the unreachable cases in the switch with `UNREACHABLE()`.