### PR TITLE
video_core/fence_manager: Remove unnecessary includes

### DIFF
--- a/src/video_core/fence_manager.h
+++ b/src/video_core/fence_manager.h
@@ -5,15 +5,10 @@
 #pragma once
 
 #include <algorithm>
-#include <array>
-#include <memory>
 #include <queue>
 
-#include "common/assert.h"
 #include "common/common_types.h"
 #include "core/core.h"
-#include "core/memory.h"
-#include "core/settings.h"
 #include "video_core/gpu.h"
 #include "video_core/memory_manager.h"
 #include "video_core/rasterizer_interface.h"

--- a/src/video_core/renderer_opengl/gl_fence_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_fence_manager.cpp
@@ -4,16 +4,17 @@
 
 #include "common/assert.h"
 
+#include <glad/glad.h>
+
 #include "video_core/renderer_opengl/gl_buffer_cache.h"
 #include "video_core/renderer_opengl/gl_fence_manager.h"
 
 namespace OpenGL {
 
-GLInnerFence::GLInnerFence(u32 payload, bool is_stubbed)
-    : VideoCommon::FenceBase(payload, is_stubbed), sync_object{} {}
+GLInnerFence::GLInnerFence(u32 payload, bool is_stubbed) : FenceBase(payload, is_stubbed) {}
 
 GLInnerFence::GLInnerFence(GPUVAddr address, u32 payload, bool is_stubbed)
-    : VideoCommon::FenceBase(address, payload, is_stubbed), sync_object{} {}
+    : FenceBase(address, payload, is_stubbed) {}
 
 GLInnerFence::~GLInnerFence() = default;
 

--- a/src/video_core/renderer_opengl/gl_fence_manager.h
+++ b/src/video_core/renderer_opengl/gl_fence_manager.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <memory>
-#include <glad/glad.h>
 
 #include "common/common_types.h"
 #include "video_core/fence_manager.h"


### PR DESCRIPTION
Avoids pulling in unnecessary things that can cause rebuilds when they aren't required.