### PR TITLE
memory_manager: Mark IsGranularRange() as a const member function

### DIFF
--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -312,10 +312,10 @@ void MemoryManager::CopyBlockUnsafe(GPUVAddr gpu_dest_addr, GPUVAddr gpu_src_add
     WriteBlockUnsafe(gpu_dest_addr, tmp_buffer.data(), size);
 }
 
-bool MemoryManager::IsGranularRange(GPUVAddr gpu_addr, std::size_t size) {
+bool MemoryManager::IsGranularRange(GPUVAddr gpu_addr, std::size_t size) const {
     const auto cpu_addr{GpuToCpuAddress(gpu_addr)};
     if (!cpu_addr) {
-        return {};
+        return false;
     }
     const std::size_t page{(*cpu_addr & Core::Memory::PAGE_MASK) + size};
     return page <= Core::Memory::PAGE_SIZE;

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -109,7 +109,7 @@ public:
     /**
      * IsGranularRange checks if a gpu region can be simply read with a pointer.
      */
-    bool IsGranularRange(GPUVAddr gpu_addr, std::size_t size);
+    bool IsGranularRange(GPUVAddr gpu_addr, std::size_t size) const;
 
     GPUVAddr Map(VAddr cpu_addr, GPUVAddr gpu_addr, std::size_t size);
     GPUVAddr MapAllocate(VAddr cpu_addr, std::size_t size, std::size_t align);


### PR DESCRIPTION
This doesn't modify internal member state, so it can be marked as const.