### PR TITLE
video_core: Make use of defaulted three-way comparison where applicable

### DIFF
--- a/src/video_core/engines/const_buffer_engine_interface.h
+++ b/src/video_core/engines/const_buffer_engine_interface.h
@@ -28,12 +28,8 @@ struct SamplerDescriptor {
         BitField<17, 7, Tegra::Texture::TextureFormat> format;
     };
 
-    bool operator==(const SamplerDescriptor& rhs) const noexcept {
-        return raw == rhs.raw;
-    }
-
-    bool operator!=(const SamplerDescriptor& rhs) const noexcept {
-        return !operator==(rhs);
+    auto operator<=>(const SamplerDescriptor& rhs) const noexcept {
+        return raw <=> rhs.raw;
     }
 
     static SamplerDescriptor FromTIC(const Tegra::Texture::TICEntry& tic) {

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -505,17 +505,7 @@ struct IpaMode {
     IpaInterpMode interpolation_mode;
     IpaSampleMode sampling_mode;
 
-    bool operator==(const IpaMode& a) const {
-        return std::tie(interpolation_mode, sampling_mode) ==
-               std::tie(a.interpolation_mode, a.sampling_mode);
-    }
-    bool operator!=(const IpaMode& a) const {
-        return !operator==(a);
-    }
-    bool operator<(const IpaMode& a) const {
-        return std::tie(interpolation_mode, sampling_mode) <
-               std::tie(a.interpolation_mode, a.sampling_mode);
-    }
+    auto operator<=>(const IpaMode&) const = default;
 };
 
 enum class SystemVariable : u64 {

--- a/src/video_core/renderer_opengl/gl_framebuffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_framebuffer_cache.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <tuple>
 #include <unordered_map>
 #include <utility>
 
@@ -75,11 +74,6 @@ std::size_t FramebufferCacheKey::Hash() const noexcept {
     }
     hash ^= static_cast<std::size_t>(color_attachments) << 16;
     return hash;
-}
-
-bool FramebufferCacheKey::operator==(const FramebufferCacheKey& rhs) const noexcept {
-    return std::tie(colors, zeta, color_attachments) ==
-           std::tie(rhs.colors, rhs.zeta, rhs.color_attachments);
 }
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_framebuffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_framebuffer_cache.h
@@ -26,11 +26,7 @@ struct FramebufferCacheKey {
 
     std::size_t Hash() const noexcept;
 
-    bool operator==(const FramebufferCacheKey& rhs) const noexcept;
-
-    bool operator!=(const FramebufferCacheKey& rhs) const noexcept {
-        return !operator==(rhs);
-    }
+    auto operator<=>(const FramebufferCacheKey&) const noexcept = default;
 
     void SetAttachment(std::size_t index, u32 attachment) {
         color_attachments |= attachment << (BitsPerAttachment * index);

--- a/src/video_core/shader/control_flow.h
+++ b/src/video_core/shader/control_flow.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <list>
-#include <optional>
 #include <set>
 #include <variant>
 
@@ -30,13 +29,7 @@ struct Condition {
         return predicate == Pred::UnusedIndex && cc == ConditionCode::T;
     }
 
-    bool operator==(const Condition& other) const {
-        return std::tie(predicate, cc) == std::tie(other.predicate, other.cc);
-    }
-
-    bool operator!=(const Condition& other) const {
-        return !operator==(other);
-    }
+    auto operator<=>(const Condition&) const = default;
 };
 
 class SingleBranch {
@@ -47,14 +40,7 @@ public:
         : condition{condition}, address{address}, kill{kill}, is_sync{is_sync}, is_brk{is_brk},
           ignore{ignore} {}
 
-    bool operator==(const SingleBranch& b) const {
-        return std::tie(condition, address, kill, is_sync, is_brk, ignore) ==
-               std::tie(b.condition, b.address, b.kill, b.is_sync, b.is_brk, b.ignore);
-    }
-
-    bool operator!=(const SingleBranch& b) const {
-        return !operator==(b);
-    }
+    auto operator<=>(const SingleBranch&) const = default;
 
     Condition condition{};
     s32 address{exit_branch};

--- a/src/video_core/shader/node.h
+++ b/src/video_core/shader/node.h
@@ -253,20 +253,20 @@ enum class MetaStackClass {
     Pbk,
 };
 
-class OperationNode;
-class ConditionalNode;
-class GprNode;
-class CustomVarNode;
-class ImmediateNode;
-class InternalFlagNode;
-class PredicateNode;
 class AbufNode;
 class CbufNode;
-class LmemNode;
-class PatchNode;
-class SmemNode;
-class GmemNode;
 class CommentNode;
+class ConditionalNode;
+class CustomVarNode;
+class GmemNode;
+class GprNode;
+class ImmediateNode;
+class InternalFlagNode;
+class LmemNode;
+class OperationNode;
+class PatchNode;
+class PredicateNode;
+class SmemNode;
 
 using NodeData = std::variant<OperationNode, ConditionalNode, GprNode, CustomVarNode, ImmediateNode,
                               InternalFlagNode, PredicateNode, AbufNode, PatchNode, CbufNode,

--- a/src/video_core/shader/node.h
+++ b/src/video_core/shader/node.h
@@ -377,9 +377,7 @@ struct GlobalMemoryBase {
     u32 cbuf_index = 0;
     u32 cbuf_offset = 0;
 
-    bool operator<(const GlobalMemoryBase& rhs) const {
-        return std::tie(cbuf_index, cbuf_offset) < std::tie(rhs.cbuf_index, rhs.cbuf_offset);
-    }
+    auto operator<=>(const GlobalMemoryBase& rhs) const = default;
 };
 
 /// Parameters describing an arithmetic operation

--- a/src/video_core/texture_cache/surface_view.cpp
+++ b/src/video_core/texture_cache/surface_view.cpp
@@ -15,13 +15,4 @@ std::size_t ViewParams::Hash() const {
            (static_cast<std::size_t>(num_levels) << 32) ^ (static_cast<std::size_t>(target) << 36);
 }
 
-bool ViewParams::operator==(const ViewParams& rhs) const {
-    return std::tie(base_layer, num_layers, base_level, num_levels, target) ==
-           std::tie(rhs.base_layer, rhs.num_layers, rhs.base_level, rhs.num_levels, rhs.target);
-}
-
-bool ViewParams::operator!=(const ViewParams& rhs) const {
-    return !operator==(rhs);
-}
-
 } // namespace VideoCommon

--- a/src/video_core/texture_cache/surface_view.h
+++ b/src/video_core/texture_cache/surface_view.h
@@ -20,8 +20,7 @@ struct ViewParams {
 
     std::size_t Hash() const;
 
-    bool operator==(const ViewParams& rhs) const;
-    bool operator!=(const ViewParams& rhs) const;
+    auto operator<=>(const ViewParams& rhs) const = default;
 
     bool IsLayered() const {
         switch (target) {


### PR DESCRIPTION
Allows the compiler to generate the comparison operators in a much more succinct manner.