### PR TITLE
Port citra-emu/citra#5495: "Add LGTM static analyzer config file"

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,13 @@
+path_classifiers:
+  library: "externals"
+extraction:
+  cpp:
+    prepare:
+      packages:
+      - "libsdl2-dev"
+      - "qtmultimedia5-dev"
+      - "clang-format-10"
+      - "libtbb-dev"
+      - "libjack-jackd2-dev"
+      - "doxygen"
+      - "graphviz"


### PR DESCRIPTION
See citra-emu/citra#5495 for more details.

**Original description**:
Refer to citra-emu/citra#5494 for some example issues found. LGTM analysis for this repo can be viewed [here](https://lgtm.com/projects/g/citra-emu/citra/alerts/?mode=tree). Note: this doesn't affect existing CI routines in any way.

Added config file makes static analysis results much easier to read and also speeds up analysis process by preinstalling used packages.

Potential addition:

```YAML
queries:
  include: "*"
```

This enables all warning types as opposed to default only. It might be a good idea to enable later on once default ones are addressed.

Additionally, it's worth taking a look at https://lgtm.com/projects/g/citra-emu/citra/ci/. Automatic check for new alerts introduced by PRs and alerts count/code quality badges are available.
