### PR TITLE
input_common/main: Remove unimplemented prototype

### DIFF
--- a/src/input_common/main.h
+++ b/src/input_common/main.h
@@ -8,11 +8,17 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include "input_common/gcadapter/gc_poller.h"
-#include "input_common/settings.h"
 
 namespace Common {
 class ParamPackage;
+}
+
+namespace Settings::NativeAnalog {
+enum Values : int;
+}
+
+namespace Settings::NativeButton {
+enum Values : int;
 }
 
 namespace InputCommon {

--- a/src/input_common/main.h
+++ b/src/input_common/main.h
@@ -40,9 +40,6 @@ public:
      */
     virtual Common::ParamPackage GetNextInput() = 0;
 };
-
-// Get all DevicePoller from all backends for a specific device type
-std::vector<std::unique_ptr<DevicePoller>> GetPollers(DeviceType type);
 } // namespace Polling
 
 class GCAnalogFactory;

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -17,11 +17,11 @@
 #include <vector>
 #include <SDL.h>
 #include "common/logging/log.h"
-#include "common/math_util.h"
 #include "common/param_package.h"
 #include "common/threadsafe_queue.h"
 #include "core/frontend/input.h"
 #include "input_common/sdl/sdl_impl.h"
+#include "input_common/settings.h"
 
 namespace InputCommon::SDL {
 

--- a/src/input_common/settings.h
+++ b/src/input_common/settings.h
@@ -10,7 +10,7 @@
 
 namespace Settings {
 namespace NativeButton {
-enum Values {
+enum Values : int {
     A,
     B,
     X,
@@ -52,7 +52,7 @@ extern const std::array<const char*, NumButtons> mapping;
 } // namespace NativeButton
 
 namespace NativeAnalog {
-enum Values {
+enum Values : int {
     LStick,
     RStick,
 


### PR DESCRIPTION
I forgot to remove this in the rebase when removing most of the global variables within the input common codebase.