### PR TITLE
cmake: Always enable Vulkan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,8 +26,6 @@ option(YUZU_ENABLE_BOXCAT "Enable the Boxcat service, a yuzu high-level implemen
 
 option(ENABLE_CUBEB "Enables the cubeb audio backend" ON)
 
-option(ENABLE_VULKAN "Enables Vulkan backend" ON)
-
 option(USE_DISCORD_PRESENCE "Enables Discord Rich Presence" OFF)
 
 # Default to a Release build

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -97,6 +97,66 @@ add_library(video_core STATIC
     renderer_opengl/renderer_opengl.h
     renderer_opengl/utils.cpp
     renderer_opengl/utils.h
+    renderer_vulkan/fixed_pipeline_state.cpp
+    renderer_vulkan/fixed_pipeline_state.h
+    renderer_vulkan/maxwell_to_vk.cpp
+    renderer_vulkan/maxwell_to_vk.h
+    renderer_vulkan/nsight_aftermath_tracker.cpp
+    renderer_vulkan/nsight_aftermath_tracker.h
+    renderer_vulkan/renderer_vulkan.h
+    renderer_vulkan/renderer_vulkan.cpp
+    renderer_vulkan/vk_blit_screen.cpp
+    renderer_vulkan/vk_blit_screen.h
+    renderer_vulkan/vk_buffer_cache.cpp
+    renderer_vulkan/vk_buffer_cache.h
+    renderer_vulkan/vk_compute_pass.cpp
+    renderer_vulkan/vk_compute_pass.h
+    renderer_vulkan/vk_compute_pipeline.cpp
+    renderer_vulkan/vk_compute_pipeline.h
+    renderer_vulkan/vk_descriptor_pool.cpp
+    renderer_vulkan/vk_descriptor_pool.h
+    renderer_vulkan/vk_device.cpp
+    renderer_vulkan/vk_device.h
+    renderer_vulkan/vk_fence_manager.cpp
+    renderer_vulkan/vk_fence_manager.h
+    renderer_vulkan/vk_graphics_pipeline.cpp
+    renderer_vulkan/vk_graphics_pipeline.h
+    renderer_vulkan/vk_image.cpp
+    renderer_vulkan/vk_image.h
+    renderer_vulkan/vk_memory_manager.cpp
+    renderer_vulkan/vk_memory_manager.h
+    renderer_vulkan/vk_pipeline_cache.cpp
+    renderer_vulkan/vk_pipeline_cache.h
+    renderer_vulkan/vk_query_cache.cpp
+    renderer_vulkan/vk_query_cache.h
+    renderer_vulkan/vk_rasterizer.cpp
+    renderer_vulkan/vk_rasterizer.h
+    renderer_vulkan/vk_renderpass_cache.cpp
+    renderer_vulkan/vk_renderpass_cache.h
+    renderer_vulkan/vk_resource_manager.cpp
+    renderer_vulkan/vk_resource_manager.h
+    renderer_vulkan/vk_sampler_cache.cpp
+    renderer_vulkan/vk_sampler_cache.h
+    renderer_vulkan/vk_scheduler.cpp
+    renderer_vulkan/vk_scheduler.h
+    renderer_vulkan/vk_shader_decompiler.cpp
+    renderer_vulkan/vk_shader_decompiler.h
+    renderer_vulkan/vk_shader_util.cpp
+    renderer_vulkan/vk_shader_util.h
+    renderer_vulkan/vk_staging_buffer_pool.cpp
+    renderer_vulkan/vk_staging_buffer_pool.h
+    renderer_vulkan/vk_state_tracker.cpp
+    renderer_vulkan/vk_state_tracker.h
+    renderer_vulkan/vk_stream_buffer.cpp
+    renderer_vulkan/vk_stream_buffer.h
+    renderer_vulkan/vk_swapchain.cpp
+    renderer_vulkan/vk_swapchain.h
+    renderer_vulkan/vk_texture_cache.cpp
+    renderer_vulkan/vk_texture_cache.h
+    renderer_vulkan/vk_update_descriptor.cpp
+    renderer_vulkan/vk_update_descriptor.h
+    renderer_vulkan/wrapper.cpp
+    renderer_vulkan/wrapper.h
     sampler_cache.cpp
     sampler_cache.h
     shader_cache.h
@@ -176,84 +236,13 @@ add_library(video_core STATIC
     video_core.h
 )
 
-if (ENABLE_VULKAN)
-    target_sources(video_core PRIVATE
-        renderer_vulkan/fixed_pipeline_state.cpp
-        renderer_vulkan/fixed_pipeline_state.h
-        renderer_vulkan/maxwell_to_vk.cpp
-        renderer_vulkan/maxwell_to_vk.h
-        renderer_vulkan/nsight_aftermath_tracker.cpp
-        renderer_vulkan/nsight_aftermath_tracker.h
-        renderer_vulkan/renderer_vulkan.h
-        renderer_vulkan/renderer_vulkan.cpp
-        renderer_vulkan/vk_blit_screen.cpp
-        renderer_vulkan/vk_blit_screen.h
-        renderer_vulkan/vk_buffer_cache.cpp
-        renderer_vulkan/vk_buffer_cache.h
-        renderer_vulkan/vk_compute_pass.cpp
-        renderer_vulkan/vk_compute_pass.h
-        renderer_vulkan/vk_compute_pipeline.cpp
-        renderer_vulkan/vk_compute_pipeline.h
-        renderer_vulkan/vk_descriptor_pool.cpp
-        renderer_vulkan/vk_descriptor_pool.h
-        renderer_vulkan/vk_device.cpp
-        renderer_vulkan/vk_device.h
-        renderer_vulkan/vk_fence_manager.cpp
-        renderer_vulkan/vk_fence_manager.h
-        renderer_vulkan/vk_graphics_pipeline.cpp
-        renderer_vulkan/vk_graphics_pipeline.h
-        renderer_vulkan/vk_image.cpp
-        renderer_vulkan/vk_image.h
-        renderer_vulkan/vk_memory_manager.cpp
-        renderer_vulkan/vk_memory_manager.h
-        renderer_vulkan/vk_pipeline_cache.cpp
-        renderer_vulkan/vk_pipeline_cache.h
-        renderer_vulkan/vk_query_cache.cpp
-        renderer_vulkan/vk_query_cache.h
-        renderer_vulkan/vk_rasterizer.cpp
-        renderer_vulkan/vk_rasterizer.h
-        renderer_vulkan/vk_renderpass_cache.cpp
-        renderer_vulkan/vk_renderpass_cache.h
-        renderer_vulkan/vk_resource_manager.cpp
-        renderer_vulkan/vk_resource_manager.h
-        renderer_vulkan/vk_sampler_cache.cpp
-        renderer_vulkan/vk_sampler_cache.h
-        renderer_vulkan/vk_scheduler.cpp
-        renderer_vulkan/vk_scheduler.h
-        renderer_vulkan/vk_shader_decompiler.cpp
-        renderer_vulkan/vk_shader_decompiler.h
-        renderer_vulkan/vk_shader_util.cpp
-        renderer_vulkan/vk_shader_util.h
-        renderer_vulkan/vk_staging_buffer_pool.cpp
-        renderer_vulkan/vk_staging_buffer_pool.h
-        renderer_vulkan/vk_state_tracker.cpp
-        renderer_vulkan/vk_state_tracker.h
-        renderer_vulkan/vk_stream_buffer.cpp
-        renderer_vulkan/vk_stream_buffer.h
-        renderer_vulkan/vk_swapchain.cpp
-        renderer_vulkan/vk_swapchain.h
-        renderer_vulkan/vk_texture_cache.cpp
-        renderer_vulkan/vk_texture_cache.h
-        renderer_vulkan/vk_update_descriptor.cpp
-        renderer_vulkan/vk_update_descriptor.h
-        renderer_vulkan/wrapper.cpp
-        renderer_vulkan/wrapper.h
-    )
-endif()
-
 create_target_directory_groups(video_core)
 
 target_link_libraries(video_core PUBLIC common core)
-target_link_libraries(video_core PRIVATE glad xbyak)
+target_link_libraries(video_core PRIVATE glad xbyak sirit)
 
 add_dependencies(video_core host_shaders)
-target_include_directories(video_core PRIVATE ${HOST_SHADERS_INCLUDE})
-
-if (ENABLE_VULKAN)
-    target_include_directories(video_core PRIVATE sirit ../../externals/Vulkan-Headers/include)
-    target_compile_definitions(video_core PRIVATE HAS_VULKAN)
-    target_link_libraries(video_core PRIVATE sirit)
-endif()
+target_include_directories(video_core PRIVATE sirit ../../externals/Vulkan-Headers/include ${HOST_SHADERS_INCLUDE})
 
 if (ENABLE_NSIGHT_AFTERMATH)
     if (NOT DEFINED ENV{NSIGHT_AFTERMATH_SDK})

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -11,9 +11,7 @@
 #include "video_core/gpu_synch.h"
 #include "video_core/renderer_base.h"
 #include "video_core/renderer_opengl/renderer_opengl.h"
-#ifdef HAS_VULKAN
 #include "video_core/renderer_vulkan/renderer_vulkan.h"
-#endif
 #include "video_core/video_core.h"
 
 namespace {
@@ -28,11 +26,9 @@ std::unique_ptr<VideoCore::RendererBase> CreateRenderer(
     case Settings::RendererBackend::OpenGL:
         return std::make_unique<OpenGL::RendererOpenGL>(telemetry_session, emu_window, cpu_memory,
                                                         gpu, std::move(context));
-#ifdef HAS_VULKAN
     case Settings::RendererBackend::Vulkan:
         return std::make_unique<Vulkan::RendererVulkan>(telemetry_session, emu_window, cpu_memory,
                                                         gpu, std::move(context));
-#endif
     default:
         return nullptr;
     }

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -212,7 +212,8 @@ target_link_libraries(yuzu PRIVATE common core input_common video_core)
 target_link_libraries(yuzu PRIVATE Boost::boost glad Qt5::Widgets)
 target_link_libraries(yuzu PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
-if (ENABLE_VULKAN AND NOT WIN32)
+target_include_directories(yuzu PRIVATE ../../externals/Vulkan-Headers/include)
+if (NOT WIN32)
     target_include_directories(yuzu PRIVATE ${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 endif()
 
@@ -272,9 +273,4 @@ endif()
 
 if (NOT APPLE)
     target_compile_definitions(yuzu PRIVATE HAS_OPENGL)
-endif()
-
-if (ENABLE_VULKAN)
-    target_include_directories(yuzu PRIVATE ../../externals/Vulkan-Headers/include)
-    target_compile_definitions(yuzu PRIVATE HAS_VULKAN)
 endif()

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -18,7 +18,7 @@
 #include <QOpenGLContext>
 #endif
 
-#if !defined(WIN32) && HAS_VULKAN
+#if !defined(WIN32)
 #include <qpa/qplatformnativeinterface.h>
 #endif
 
@@ -261,14 +261,12 @@ private:
     std::unique_ptr<Core::Frontend::GraphicsContext> context{};
 };
 
-#ifdef HAS_VULKAN
 class VulkanRenderWidget : public RenderWidget {
 public:
     explicit VulkanRenderWidget(GRenderWindow* parent) : RenderWidget(parent) {
         windowHandle()->setSurfaceType(QWindow::VulkanSurface);
     }
 };
-#endif
 
 static Core::Frontend::WindowSystemType GetWindowSystemType() {
     // Determine WSI type based on Qt platform.
@@ -288,7 +286,6 @@ static Core::Frontend::EmuWindow::WindowSystemInfo GetWindowSystemInfo(QWindow* 
     Core::Frontend::EmuWindow::WindowSystemInfo wsi;
     wsi.type = GetWindowSystemType();
 
-#ifdef HAS_VULKAN
     // Our Win32 Qt external doesn't have the private API.
 #if defined(WIN32) || defined(__APPLE__)
     wsi.render_surface = window ? reinterpret_cast<void*>(window->winId()) : nullptr;
@@ -301,7 +298,6 @@ static Core::Frontend::EmuWindow::WindowSystemInfo GetWindowSystemInfo(QWindow* 
         wsi.render_surface = window ? reinterpret_cast<void*>(window->winId()) : nullptr;
 #endif
     wsi.render_surface_scale = window ? static_cast<float>(window->devicePixelRatio()) : 1.0f;
-#endif
 
     return wsi;
 }
@@ -606,18 +602,12 @@ bool GRenderWindow::InitializeOpenGL() {
 }
 
 bool GRenderWindow::InitializeVulkan() {
-#ifdef HAS_VULKAN
     auto child = new VulkanRenderWidget(this);
     child_widget = child;
     child_widget->windowHandle()->create();
     main_context = std::make_unique<DummyContext>();
 
     return true;
-#else
-    QMessageBox::critical(this, tr("Vulkan not available!"),
-                          tr("yuzu has not been compiled with Vulkan support."));
-    return false;
-#endif
 }
 
 bool GRenderWindow::LoadOpenGL() {

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -4,21 +4,16 @@
 
 #include <QColorDialog>
 #include <QComboBox>
-#ifdef HAS_VULKAN
 #include <QVulkanInstance>
-#endif
 
 #include "common/common_types.h"
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/settings.h"
 #include "ui_configure_graphics.h"
+#include "video_core/renderer_vulkan/renderer_vulkan.h"
 #include "yuzu/configuration/configuration_shared.h"
 #include "yuzu/configuration/configure_graphics.h"
-
-#ifdef HAS_VULKAN
-#include "video_core/renderer_vulkan/renderer_vulkan.h"
-#endif
 
 ConfigureGraphics::ConfigureGraphics(QWidget* parent)
     : QWidget(parent), ui(new Ui::ConfigureGraphics) {
@@ -211,12 +206,10 @@ void ConfigureGraphics::UpdateDeviceComboBox() {
 }
 
 void ConfigureGraphics::RetrieveVulkanDevices() {
-#ifdef HAS_VULKAN
     vulkan_devices.clear();
     for (auto& name : Vulkan::RendererVulkan::EnumerateDevices()) {
         vulkan_devices.push_back(QString::fromStdString(name));
     }
-#endif
 }
 
 Settings::RendererBackend ConfigureGraphics::GetCurrentGraphicsBackend() const {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -610,11 +610,6 @@ void GMainWindow::InitializeWidgets() {
     });
     renderer_status_button->toggle();
 
-#ifndef HAS_VULKAN
-    renderer_status_button->setChecked(false);
-    renderer_status_button->setCheckable(false);
-    renderer_status_button->setDisabled(true);
-#else
     renderer_status_button->setChecked(Settings::values.renderer_backend.GetValue() ==
                                        Settings::RendererBackend::Vulkan);
     connect(renderer_status_button, &QPushButton::clicked, [this] {
@@ -629,7 +624,6 @@ void GMainWindow::InitializeWidgets() {
 
         Settings::Apply();
     });
-#endif // HAS_VULKAN
     statusBar()->insertPermanentWidget(0, renderer_status_button);
 
     statusBar()->setVisible(true);
@@ -1218,9 +1212,7 @@ void GMainWindow::ShutdownGame() {
     emu_frametime_label->setVisible(false);
     async_status_button->setEnabled(true);
     multicore_status_button->setEnabled(true);
-#ifdef HAS_VULKAN
     renderer_status_button->setEnabled(true);
-#endif
 
     emulation_running = false;
 
@@ -2459,10 +2451,8 @@ void GMainWindow::UpdateStatusButtons() {
         Settings::values.use_asynchronous_gpu_emulation.GetValue() ||
         Settings::values.use_multi_core.GetValue());
     async_status_button->setChecked(Settings::values.use_asynchronous_gpu_emulation.GetValue());
-#ifdef HAS_VULKAN
     renderer_status_button->setChecked(Settings::values.renderer_backend.GetValue() ==
                                        Settings::RendererBackend::Vulkan);
-#endif
 }
 
 void GMainWindow::HideMouseCursor() {

--- a/src/yuzu_cmd/CMakeLists.txt
+++ b/src/yuzu_cmd/CMakeLists.txt
@@ -4,25 +4,16 @@ add_executable(yuzu-cmd
     config.cpp
     config.h
     default_ini.h
-    emu_window/emu_window_sdl2_gl.cpp
-    emu_window/emu_window_sdl2_gl.h
     emu_window/emu_window_sdl2.cpp
     emu_window/emu_window_sdl2.h
     emu_window/emu_window_sdl2_gl.cpp
     emu_window/emu_window_sdl2_gl.h
+    emu_window/emu_window_sdl2_vk.cpp
+    emu_window/emu_window_sdl2_vk.h
     resource.h
     yuzu.cpp
     yuzu.rc
 )
-
-if (ENABLE_VULKAN)
-    target_sources(yuzu-cmd PRIVATE
-                   emu_window/emu_window_sdl2_vk.cpp
-                   emu_window/emu_window_sdl2_vk.h)
-
-    target_include_directories(yuzu-cmd PRIVATE ../../externals/Vulkan-Headers/include)
-    target_compile_definitions(yuzu-cmd PRIVATE HAS_VULKAN)
-endif()
 
 create_target_directory_groups(yuzu-cmd)
 
@@ -32,6 +23,8 @@ if (MSVC)
     target_link_libraries(yuzu-cmd PRIVATE getopt)
 endif()
 target_link_libraries(yuzu-cmd PRIVATE ${PLATFORM_LIBRARIES} SDL2 Threads::Threads)
+
+target_include_directories(yuzu-cmd PRIVATE ../../externals/Vulkan-Headers/include)
 
 if(UNIX AND NOT APPLE)
     install(TARGETS yuzu-cmd RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -36,9 +36,7 @@
 #include "yuzu_cmd/config.h"
 #include "yuzu_cmd/emu_window/emu_window_sdl2.h"
 #include "yuzu_cmd/emu_window/emu_window_sdl2_gl.h"
-#ifdef HAS_VULKAN
 #include "yuzu_cmd/emu_window/emu_window_sdl2_vk.h"
-#endif
 
 #ifdef _WIN32
 // windows.h needs to be included before shellapi.h
@@ -188,13 +186,8 @@ int main(int argc, char** argv) {
         emu_window = std::make_unique<EmuWindow_SDL2_GL>(system, fullscreen, &input_subsystem);
         break;
     case Settings::RendererBackend::Vulkan:
-#ifdef HAS_VULKAN
         emu_window = std::make_unique<EmuWindow_SDL2_VK>(system, fullscreen, &input_subsystem);
         break;
-#else
-        LOG_CRITICAL(Frontend, "Vulkan backend has not been compiled!");
-        return 1;
-#endif
     }
 
     system.SetContentProvider(std::make_unique<FileSys::ContentProviderUnion>());


### PR DESCRIPTION
This reduces the maintenance burden of having code hidden by
preprocessor macros. All Vulkan files are always included (aside from
Nsight Aftermath that is kept out-of-tree).

The original intention behind this setting was to keep Vulkan disabled while it was being developed and then it was used when Linux distros lacked an updated version of Qt. We don't have any reason to keep this cmake option.