### PR TITLE
yuzu/main: Amend lifetime issues with InputSubsystem

### DIFF
--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -305,8 +305,8 @@ static Core::Frontend::EmuWindow::WindowSystemInfo GetWindowSystemInfo(QWindow* 
 }
 
 GRenderWindow::GRenderWindow(GMainWindow* parent, EmuThread* emu_thread_,
-                             InputCommon::InputSubsystem* input_subsystem_)
-    : QWidget(parent), emu_thread(emu_thread_), input_subsystem{input_subsystem_} {
+                             std::shared_ptr<InputCommon::InputSubsystem> input_subsystem_)
+    : QWidget(parent), emu_thread(emu_thread_), input_subsystem{std::move(input_subsystem_)} {
     setWindowTitle(QStringLiteral("yuzu %1 | %2-%3")
                        .arg(QString::fromUtf8(Common::g_build_name),
                             QString::fromUtf8(Common::g_scm_branch),

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 
 #include <QImage>
@@ -126,7 +127,7 @@ class GRenderWindow : public QWidget, public Core::Frontend::EmuWindow {
 
 public:
     explicit GRenderWindow(GMainWindow* parent, EmuThread* emu_thread_,
-                           InputCommon::InputSubsystem* input_subsystem_);
+                           std::shared_ptr<InputCommon::InputSubsystem> input_subsystem_);
     ~GRenderWindow() override;
 
     // EmuWindow implementation.
@@ -188,7 +189,7 @@ private:
     QStringList GetUnsupportedGLExtensions() const;
 
     EmuThread* emu_thread;
-    InputCommon::InputSubsystem* input_subsystem;
+    std::shared_ptr<InputCommon::InputSubsystem> input_subsystem;
 
     // Main context that will be shared with all other contexts that are requested.
     // If this is used in a shared context setting, then this should not be used directly, but

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -187,7 +187,7 @@ static void InitializeLogging() {
 }
 
 GMainWindow::GMainWindow()
-    : input_subsystem{std::make_unique<InputCommon::InputSubsystem>()},
+    : input_subsystem{std::make_shared<InputCommon::InputSubsystem>()},
       config{std::make_unique<Config>()}, vfs{std::make_shared<FileSys::RealVfsFilesystem>()},
       provider{std::make_unique<FileSys::ManualContentProvider>()} {
     InitializeLogging();
@@ -474,7 +474,7 @@ void GMainWindow::InitializeWidgets() {
 #ifdef YUZU_ENABLE_COMPATIBILITY_REPORTING
     ui.action_Report_Compatibility->setVisible(true);
 #endif
-    render_window = new GRenderWindow(this, emu_thread.get(), input_subsystem.get());
+    render_window = new GRenderWindow(this, emu_thread.get(), input_subsystem);
     render_window->hide();
 
     game_list = new GameList(vfs, provider.get(), this);

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -258,7 +258,7 @@ private:
     Ui::MainWindow ui;
 
     std::unique_ptr<DiscordRPC::DiscordInterface> discord_rpc;
-    std::unique_ptr<InputCommon::InputSubsystem> input_subsystem;
+    std::shared_ptr<InputCommon::InputSubsystem> input_subsystem;
 
     GRenderWindow* render_window;
     GameList* game_list;


### PR DESCRIPTION
Due to the way Qt performs destruction of parent/child widgets, we need to make the lifetime of the input subsystem shared across the main window and the render window.