### PR TITLE
input_common/motion_input: Make use of Common::PI constant

### DIFF
--- a/src/common/math_util.h
+++ b/src/common/math_util.h
@@ -9,7 +9,7 @@
 
 namespace Common {
 
-constexpr float PI = 3.14159265f;
+constexpr float PI = 3.1415926535f;
 
 template <class T>
 struct Rectangle {

--- a/src/input_common/motion_input.cpp
+++ b/src/input_common/motion_input.cpp
@@ -1,3 +1,8 @@
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included
+
+#include "common/math_util.h"
 #include "input_common/motion_input.h"
 
 namespace InputCommon {
@@ -69,7 +74,7 @@ void MotionInput::UpdateOrientation(u64 elapsed_time) {
     }
 
     const auto normal_accel = accel.Normalized();
-    auto rad_gyro = gyro * 3.1415926535f * 2;
+    auto rad_gyro = gyro * Common::PI * 2;
     const f32 swap = rad_gyro.x;
     rad_gyro.x = rad_gyro.y;
     rad_gyro.y = -swap;

--- a/src/input_common/motion_input.h
+++ b/src/input_common/motion_input.h
@@ -1,6 +1,6 @@
-// Copyright 2014 Dolphin Emulator Project
-// Licensed under GPLv2+
-// Refer to the license.txt file included.
+// Copyright 2020 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included
 
 #pragma once
 


### PR DESCRIPTION
Also amend the copyright notice to yuzu's instead of Dolphin's, which was mistakenly copy-pasted from another file.