### PR TITLE
main: Use three dots to complete the ellipsis

### DIFF
--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -293,7 +293,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Configure Current Game..</string>
+    <string>Configure Current Game...</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Fixes a typo in the UI file for "Configure Current Game...". An ellipsis has 3 dots.