### PR TITLE
bsd: Resolve a few warnings

### DIFF
--- a/src/core/hle/service/sockets/blocking_worker.h
+++ b/src/core/hle/service/sockets/blocking_worker.h
@@ -29,7 +29,7 @@ namespace Service::Sockets {
  * Worker abstraction to execute blocking calls on host without blocking the guest thread
  *
  * @tparam Service  Service where the work is executed
- * @tparam ...Types Types of work to execute
+ * @tparam Types Types of work to execute
  */
 template <class Service, class... Types>
 class BlockingWorker {

--- a/src/core/hle/service/sockets/blocking_worker.h
+++ b/src/core/hle/service/sockets/blocking_worker.h
@@ -109,9 +109,8 @@ private:
         while (keep_running) {
             work_event.Wait();
 
-            const auto visit_fn = [service, &keep_running](auto&& w) {
-                using T = std::decay_t<decltype(w)>;
-                if constexpr (std::is_same_v<T, std::monostate>) {
+            const auto visit_fn = [service, &keep_running]<typename T>(T&& w) {
+                if constexpr (std::is_same_v<std::decay_t<T>, std::monostate>) {
                     keep_running = false;
                 } else {
                     w.Execute(service);

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -491,7 +491,7 @@ std::pair<s32, Errno> BSD::PollImpl(std::vector<u8>& write_buffer, std::vector<u
     for (PollFD& pollfd : fds) {
         ASSERT(pollfd.revents == 0);
 
-        if (pollfd.fd > MAX_FD || pollfd.fd < 0) {
+        if (pollfd.fd > static_cast<s32>(MAX_FD) || pollfd.fd < 0) {
             LOG_ERROR(Service, "File descriptor handle={} is invalid", pollfd.fd);
             pollfd.revents = 0;
             return {0, Errno::SUCCESS};
@@ -795,7 +795,7 @@ s32 BSD::FindFreeFileDescriptorHandle() noexcept {
 }
 
 bool BSD::IsFileDescriptorValid(s32 fd) const noexcept {
-    if (fd > MAX_FD || fd < 0) {
+    if (fd > static_cast<s32>(MAX_FD) || fd < 0) {
         LOG_ERROR(Service, "Invalid file descriptor handle={}", fd);
         return false;
     }
@@ -809,7 +809,7 @@ bool BSD::IsFileDescriptorValid(s32 fd) const noexcept {
 bool BSD::IsBlockingSocket(s32 fd) const noexcept {
     // Inform invalid sockets as non-blocking
     // This way we avoid using a worker thread as it will fail without blocking host
-    if (fd > MAX_FD || fd < 0) {
+    if (fd > static_cast<s32>(MAX_FD) || fd < 0) {
         return false;
     }
     if (!file_descriptors[fd]) {

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -764,6 +764,7 @@ std::pair<s32, Errno> BSD::SendToImpl(s32 fd, u32 flags, const std::vector<u8>& 
         SockAddrIn guest_addr_in;
         std::memcpy(&guest_addr_in, addr.data(), sizeof(guest_addr_in));
         addr_in = Translate(guest_addr_in);
+        p_addr_in = &addr_in;
     }
 
     return Translate(file_descriptors[fd]->socket->SendTo(flags, message, p_addr_in));

--- a/src/core/hle/service/sockets/sockets_translate.cpp
+++ b/src/core/hle/service/sockets/sockets_translate.cpp
@@ -131,21 +131,21 @@ u16 TranslatePollEventsToGuest(u16 flags) {
 Network::SockAddrIn Translate(SockAddrIn value) {
     ASSERT(value.len == 0 || value.len == sizeof(value));
 
-    Network::SockAddrIn result;
-    result.family = Translate(static_cast<Domain>(value.family));
-    result.ip = value.ip;
-    result.portno = value.portno >> 8 | value.portno << 8;
-    return result;
+    return {
+        .family = Translate(static_cast<Domain>(value.family)),
+        .ip = value.ip,
+        .portno = static_cast<u16>(value.portno >> 8 | value.portno << 8),
+    };
 }
 
 SockAddrIn Translate(Network::SockAddrIn value) {
-    SockAddrIn result;
-    result.len = sizeof(result);
-    result.family = static_cast<u8>(Translate(value.family));
-    result.portno = value.portno >> 8 | value.portno << 8;
-    result.ip = value.ip;
-    result.zeroes = {};
-    return result;
+    return {
+        .len = sizeof(SockAddrIn),
+        .family = static_cast<u8>(Translate(value.family)),
+        .portno = static_cast<u16>(value.portno >> 8 | value.portno << 8),
+        .ip = value.ip,
+        .zeroes = {},
+    };
 }
 
 Network::ShutdownHow Translate(ShutdownHow how) {


### PR DESCRIPTION
Resolves a few warnings in our BSD code on Windows and Clang.

This also includes a bugfix for SendToImpl where the address would never be propagated down to SendTo.