### PR TITLE
gc_adapter: Make DeviceConnected() a const member function

### DIFF
--- a/src/input_common/gcadapter/gc_adapter.cpp
+++ b/src/input_common/gcadapter/gc_adapter.cpp
@@ -283,7 +283,7 @@ void Adapter::Reset() {
     }
 }
 
-bool Adapter::DeviceConnected(std::size_t port) {
+bool Adapter::DeviceConnected(std::size_t port) const {
     return adapter_controllers_status[port] != ControllerTypes::None;
 }
 

--- a/src/input_common/gcadapter/gc_adapter.h
+++ b/src/input_common/gcadapter/gc_adapter.h
@@ -76,7 +76,7 @@ public:
     void EndConfiguration();
 
     /// Returns true if there is a device connected to port
-    bool DeviceConnected(std::size_t port);
+    bool DeviceConnected(std::size_t port) const;
 
     std::array<Common::SPSCQueue<GCPadStatus>, 4>& GetPadQueue();
     const std::array<Common::SPSCQueue<GCPadStatus>, 4>& GetPadQueue() const;

--- a/src/input_common/gcadapter/gc_poller.cpp
+++ b/src/input_common/gcadapter/gc_poller.cpp
@@ -15,7 +15,7 @@ namespace InputCommon {
 
 class GCButton final : public Input::ButtonDevice {
 public:
-    explicit GCButton(int port_, int button_, GCAdapter::Adapter* adapter)
+    explicit GCButton(int port_, int button_, const GCAdapter::Adapter* adapter)
         : port(port_), button(button_), gcadapter(adapter) {}
 
     ~GCButton() override;
@@ -30,13 +30,13 @@ public:
 private:
     const int port;
     const int button;
-    GCAdapter::Adapter* gcadapter;
+    const GCAdapter::Adapter* gcadapter;
 };
 
 class GCAxisButton final : public Input::ButtonDevice {
 public:
     explicit GCAxisButton(int port_, int axis_, float threshold_, bool trigger_if_greater_,
-                          GCAdapter::Adapter* adapter)
+                          const GCAdapter::Adapter* adapter)
         : port(port_), axis(axis_), threshold(threshold_), trigger_if_greater(trigger_if_greater_),
           gcadapter(adapter),
           origin_value(static_cast<float>(adapter->GetOriginValue(port_, axis_))) {}
@@ -60,7 +60,7 @@ private:
     const int axis;
     float threshold;
     bool trigger_if_greater;
-    GCAdapter::Adapter* gcadapter;
+    const GCAdapter::Adapter* gcadapter;
     const float origin_value;
 };
 
@@ -149,8 +149,8 @@ void GCButtonFactory::EndConfiguration() {
 
 class GCAnalog final : public Input::AnalogDevice {
 public:
-    GCAnalog(int port_, int axis_x_, int axis_y_, float deadzone_, GCAdapter::Adapter* adapter,
-             float range_)
+    GCAnalog(int port_, int axis_x_, int axis_y_, float deadzone_,
+             const GCAdapter::Adapter* adapter, float range_)
         : port(port_), axis_x(axis_x_), axis_y(axis_y_), deadzone(deadzone_), gcadapter(adapter),
           origin_value_x(static_cast<float>(adapter->GetOriginValue(port_, axis_x_))),
           origin_value_y(static_cast<float>(adapter->GetOriginValue(port_, axis_y_))),
@@ -212,7 +212,7 @@ private:
     const int axis_x;
     const int axis_y;
     const float deadzone;
-    GCAdapter::Adapter* gcadapter;
+    const GCAdapter::Adapter* gcadapter;
     const float origin_value_x;
     const float origin_value_y;
     const float range;


### PR DESCRIPTION
This doesn't modify instance state, so it can be made const.

This allows several pointers to be made const, making their read-only nature explicit in our interfaces.