### PR TITLE
service: Remove two usages of the global system accessor

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -105,10 +105,9 @@ void ServiceFrameworkBase::InstallAsService(SM::ServiceManager& service_manager)
     port_installed = true;
 }
 
-void ServiceFrameworkBase::InstallAsNamedPort() {
+void ServiceFrameworkBase::InstallAsNamedPort(Kernel::KernelCore& kernel) {
     ASSERT(!port_installed);
 
-    auto& kernel = Core::System::GetInstance().Kernel();
     auto [server_port, client_port] =
         Kernel::ServerPort::CreatePortPair(kernel, max_sessions, service_name);
     server_port->SetHleHandler(shared_from_this());
@@ -116,10 +115,9 @@ void ServiceFrameworkBase::InstallAsNamedPort() {
     port_installed = true;
 }
 
-std::shared_ptr<Kernel::ClientPort> ServiceFrameworkBase::CreatePort() {
+std::shared_ptr<Kernel::ClientPort> ServiceFrameworkBase::CreatePort(Kernel::KernelCore& kernel) {
     ASSERT(!port_installed);
 
-    auto& kernel = Core::System::GetInstance().Kernel();
     auto [server_port, client_port] =
         Kernel::ServerPort::CreatePortPair(kernel, max_sessions, service_name);
     auto port = MakeResult(std::move(server_port)).Unwrap();

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -63,9 +63,9 @@ public:
     /// Creates a port pair and registers this service with the given ServiceManager.
     void InstallAsService(SM::ServiceManager& service_manager);
     /// Creates a port pair and registers it on the kernel's global port registry.
-    void InstallAsNamedPort();
+    void InstallAsNamedPort(Kernel::KernelCore& kernel);
     /// Creates and returns an unregistered port for the service.
-    std::shared_ptr<Kernel::ClientPort> CreatePort();
+    std::shared_ptr<Kernel::ClientPort> CreatePort(Kernel::KernelCore& kernel);
 
     void InvokeRequest(Kernel::HLERequestContext& ctx);
 

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -43,7 +43,7 @@ void ServiceManager::InstallInterfaces(std::shared_ptr<ServiceManager> self,
     ASSERT(self->sm_interface.expired());
 
     auto sm = std::make_shared<SM>(self, kernel);
-    sm->InstallAsNamedPort();
+    sm->InstallAsNamedPort(kernel);
     self->sm_interface = sm;
     self->controller_interface = std::make_unique<Controller>();
 }


### PR DESCRIPTION
Removes more instances of reliance on global state.