### PR TITLE
Remove bad and useless packages from LGTM build

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -6,8 +6,5 @@ extraction:
       packages:
       - "libsdl2-dev"
       - "qtmultimedia5-dev"
-      - "clang-format-10"
       - "libtbb-dev"
       - "libjack-jackd2-dev"
-      - "doxygen"
-      - "graphviz"


### PR DESCRIPTION
Follow-up to #4596, which was originally authored by me. Currently, build fails when searching for `clang-format-10` as it is missing for whatever reason.

Even with this patch analysis still fails due to CMake version being 3.13.4 and Yuzu needing at least 3.15, but at least we are not ones to blame now. Once they upgrade their distro used for build, it will likely start working.

P.S.: when it does, I'm going to look into this once more and specify all packages it will pull into this file to speed build up.