### PR TITLE
configure_input_player: Re-add "Clear" context menu option

### DIFF
--- a/src/yuzu/configuration/configure_input_player.h
+++ b/src/yuzu/configuration/configure_input_player.h
@@ -131,6 +131,7 @@ private:
 
     std::array<Common::ParamPackage, Settings::NativeButton::NumButtons> buttons_param;
     std::array<Common::ParamPackage, Settings::NativeAnalog::NumAnalogs> analogs_param;
+    std::array<Common::ParamPackage, Settings::NativeAnalog::NumAnalogs> stick_mod_param;
     std::array<Common::ParamPackage, Settings::NativeMotion::NumMotions> motions_param;
 
     static constexpr int ANALOG_SUB_BUTTONS_NUM = 4;
@@ -140,8 +141,7 @@ private:
     /// Each motion input is represented by a QPushButton.
     std::array<QPushButton*, Settings::NativeMotion::NumMotions> motion_map;
     /// Extra buttons for the modifiers.
-    Common::ParamPackage lstick_mod;
-    Common::ParamPackage rstick_mod;
+    std::array<QPushButton*, Settings::NativeAnalog::NumAnalogs> mod_buttons;
 
     /// A group of four QPushButtons represent one analog input. The buttons each represent up,
     /// down, left, right, respectively.


### PR DESCRIPTION
The context menu was removed in Mjölnir Part 1 as part of the input rewrite as we were unaware of it's usage statistics.
However, as this was the only way to clear the inputs of individual buttons, this PR will re-add it back in.

Closes #4646 