### PR TITLE
kernel: Remove all dependencies on the global system instance

### DIFF
--- a/src/core/hle/kernel/client_session.cpp
+++ b/src/core/hle/kernel/client_session.cpp
@@ -48,14 +48,15 @@ ResultVal<std::shared_ptr<ClientSession>> ClientSession::Create(KernelCore& kern
 }
 
 ResultCode ClientSession::SendSyncRequest(std::shared_ptr<Thread> thread,
-                                          Core::Memory::Memory& memory) {
+                                          Core::Memory::Memory& memory,
+                                          Core::Timing::CoreTiming& core_timing) {
     // Keep ServerSession alive until we're done working with it.
     if (!parent->Server()) {
         return ERR_SESSION_CLOSED_BY_REMOTE;
     }
 
     // Signal the server session that new data is available
-    return parent->Server()->HandleSyncRequest(std::move(thread), memory);
+    return parent->Server()->HandleSyncRequest(std::move(thread), memory, core_timing);
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/client_session.h
+++ b/src/core/hle/kernel/client_session.h
@@ -16,6 +16,10 @@ namespace Core::Memory {
 class Memory;
 }
 
+namespace Core::Timing {
+class CoreTiming;
+}
+
 namespace Kernel {
 
 class KernelCore;
@@ -42,7 +46,8 @@ public:
         return HANDLE_TYPE;
     }
 
-    ResultCode SendSyncRequest(std::shared_ptr<Thread> thread, Core::Memory::Memory& memory);
+    ResultCode SendSyncRequest(std::shared_ptr<Thread> thread, Core::Memory::Memory& memory,
+                               Core::Timing::CoreTiming& core_timing);
 
     bool ShouldWait(const Thread* thread) const override;
 

--- a/src/core/hle/kernel/server_session.cpp
+++ b/src/core/hle/kernel/server_session.cpp
@@ -8,7 +8,6 @@
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "common/logging/log.h"
-#include "core/core.h"
 #include "core/core_timing.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/client_port.h"
@@ -185,10 +184,11 @@ ResultCode ServerSession::CompleteSyncRequest() {
 }
 
 ResultCode ServerSession::HandleSyncRequest(std::shared_ptr<Thread> thread,
-                                            Core::Memory::Memory& memory) {
+                                            Core::Memory::Memory& memory,
+                                            Core::Timing::CoreTiming& core_timing) {
     const ResultCode result = QueueSyncRequest(std::move(thread), memory);
     const auto delay = std::chrono::nanoseconds{kernel.IsMulticore() ? 0 : 20000};
-    Core::System::GetInstance().CoreTiming().ScheduleEvent(delay, request_event, {});
+    core_timing.ScheduleEvent(delay, request_event, {});
     return result;
 }
 

--- a/src/core/hle/kernel/server_session.h
+++ b/src/core/hle/kernel/server_session.h
@@ -18,8 +18,9 @@ class Memory;
 }
 
 namespace Core::Timing {
+class CoreTiming;
 struct EventType;
-}
+} // namespace Core::Timing
 
 namespace Kernel {
 
@@ -87,12 +88,14 @@ public:
     /**
      * Handle a sync request from the emulated application.
      *
-     * @param thread Thread that initiated the request.
-     * @param memory Memory context to handle the sync request under.
+     * @param thread      Thread that initiated the request.
+     * @param memory      Memory context to handle the sync request under.
+     * @param core_timing Core timing context to schedule the request event under.
      *
      * @returns ResultCode from the operation.
      */
-    ResultCode HandleSyncRequest(std::shared_ptr<Thread> thread, Core::Memory::Memory& memory);
+    ResultCode HandleSyncRequest(std::shared_ptr<Thread> thread, Core::Memory::Memory& memory,
+                                 Core::Timing::CoreTiming& core_timing);
 
     bool ShouldWait(const Thread* thread) const override;
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -346,7 +346,7 @@ static ResultCode SendSyncRequest(Core::System& system, Handle handle) {
         SchedulerLock lock(system.Kernel());
         thread->InvalidateHLECallback();
         thread->SetStatus(ThreadStatus::WaitIPC);
-        session->SendSyncRequest(SharedFrom(thread), system.Memory());
+        session->SendSyncRequest(SharedFrom(thread), system.Memory(), system.CoreTiming());
     }
 
     if (thread->HasHLECallback()) {


### PR DESCRIPTION
With this, the kernel finally doesn't depend directly on the global system instance anymore.

All that remains to have their dependency on the global instance removed is:

- 18 instances in the file_sys code
- 14 instances in the GDB stub (this is broken anyways, so this can be tossed if it really comes down to it)
- 6 instances in the loader code.
- 4 instances in the services
- 2 instances in the settings code
- 1 instance in the crypto code

After all these are removed in the future, our frontends will be able to have full control over the lifecycle of the entire emulated system (and will likely make start up a little faster, given less static constructors).