### PR TITLE
crypto/key_manager: Remove dependency on the global system accessor

### DIFF
--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -23,7 +23,6 @@
 #include "common/hex_util.h"
 #include "common/logging/log.h"
 #include "common/string_util.h"
-#include "core/core.h"
 #include "core/crypto/aes_util.h"
 #include "core/crypto/key_manager.h"
 #include "core/crypto/partition_data_manager.h"
@@ -1022,10 +1021,10 @@ void KeyManager::DeriveBase() {
     }
 }
 
-void KeyManager::DeriveETicket(PartitionDataManager& data) {
+void KeyManager::DeriveETicket(PartitionDataManager& data,
+                               const FileSys::ContentProvider& provider) {
     // ETicket keys
-    const auto es = Core::System::GetInstance().GetContentProvider().GetEntry(
-        0x0100000000000033, FileSys::ContentRecordType::Program);
+    const auto es = provider.GetEntry(0x0100000000000033, FileSys::ContentRecordType::Program);
 
     if (es == nullptr) {
         return;

--- a/src/core/crypto/key_manager.h
+++ b/src/core/crypto/key_manager.h
@@ -20,6 +20,10 @@ namespace Common::FS {
 class IOFile;
 }
 
+namespace FileSys {
+class ContentProvider;
+}
+
 namespace Loader {
 enum class ResultStatus : u16;
 }
@@ -252,7 +256,7 @@ public:
 
     bool BaseDeriveNecessary() const;
     void DeriveBase();
-    void DeriveETicket(PartitionDataManager& data);
+    void DeriveETicket(PartitionDataManager& data, const FileSys::ContentProvider& provider);
     void PopulateTickets();
     void SynthesizeTickets();
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2592,8 +2592,10 @@ void GMainWindow::OnReinitializeKeys(ReinitializeKeyBehavior behavior) {
 
         const auto function = [this, &keys, &pdm] {
             keys.PopulateFromPartitionData(pdm);
-            Core::System::GetInstance().GetFileSystemController().CreateFactories(*vfs);
-            keys.DeriveETicket(pdm);
+
+            auto& system = Core::System::GetInstance();
+            system.GetFileSystemController().CreateFactories(*vfs);
+            keys.DeriveETicket(pdm, system.GetContentProvider());
         };
 
         QString errors;


### PR DESCRIPTION
We can supply the content provider as an argument instead of hardcoding a global accessor in the implementation.

Now the crypto code no longer has any dependencies on the global system instance.