### PR TITLE
patch_manager: Minor cleanup

### DIFF
--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -45,14 +45,15 @@ enum class TitleVersionFormat : u8 {
 std::string FormatTitleVersion(u32 version,
                                TitleVersionFormat format = TitleVersionFormat::ThreeElements) {
     std::array<u8, sizeof(u32)> bytes{};
-    bytes[0] = version % SINGLE_BYTE_MODULUS;
+    bytes[0] = static_cast<u8>(version % SINGLE_BYTE_MODULUS);
     for (std::size_t i = 1; i < bytes.size(); ++i) {
         version /= SINGLE_BYTE_MODULUS;
-        bytes[i] = version % SINGLE_BYTE_MODULUS;
+        bytes[i] = static_cast<u8>(version % SINGLE_BYTE_MODULUS);
     }
 
-    if (format == TitleVersionFormat::FourElements)
+    if (format == TitleVersionFormat::FourElements) {
         return fmt::format("v{}.{}.{}.{}", bytes[3], bytes[2], bytes[1], bytes[0]);
+    }
     return fmt::format("v{}.{}.{}", bytes[3], bytes[2], bytes[1]);
 }
 

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -25,55 +25,59 @@ class NACP;
 // A centralized class to manage patches to games.
 class PatchManager {
 public:
+    using BuildID = std::array<u8, 0x20>;
+    using Metadata = std::pair<std::unique_ptr<NACP>, VirtualFile>;
+    using PatchVersionNames = std::map<std::string, std::string, std::less<>>;
+
     explicit PatchManager(u64 title_id);
     ~PatchManager();
 
-    u64 GetTitleID() const;
+    [[nodiscard]] u64 GetTitleID() const;
 
     // Currently tracked ExeFS patches:
     // - Game Updates
-    VirtualDir PatchExeFS(VirtualDir exefs) const;
+    [[nodiscard]] VirtualDir PatchExeFS(VirtualDir exefs) const;
 
     // Currently tracked NSO patches:
     // - IPS
     // - IPSwitch
-    std::vector<u8> PatchNSO(const std::vector<u8>& nso, const std::string& name) const;
+    [[nodiscard]] std::vector<u8> PatchNSO(const std::vector<u8>& nso,
+                                           const std::string& name) const;
 
     // Checks to see if PatchNSO() will have any effect given the NSO's build ID.
     // Used to prevent expensive copies in NSO loader.
-    bool HasNSOPatch(const std::array<u8, 0x20>& build_id) const;
+    [[nodiscard]] bool HasNSOPatch(const BuildID& build_id) const;
 
     // Creates a CheatList object with all
-    std::vector<Core::Memory::CheatEntry> CreateCheatList(
-        const Core::System& system, const std::array<u8, 0x20>& build_id) const;
+    [[nodiscard]] std::vector<Core::Memory::CheatEntry> CreateCheatList(
+        const Core::System& system, const BuildID& build_id) const;
 
     // Currently tracked RomFS patches:
     // - Game Updates
     // - LayeredFS
-    VirtualFile PatchRomFS(VirtualFile base, u64 ivfc_offset,
-                           ContentRecordType type = ContentRecordType::Program,
-                           VirtualFile update_raw = nullptr) const;
+    [[nodiscard]] VirtualFile PatchRomFS(VirtualFile base, u64 ivfc_offset,
+                                         ContentRecordType type = ContentRecordType::Program,
+                                         VirtualFile update_raw = nullptr) const;
 
     // Returns a vector of pairs between patch names and patch versions.
     // i.e. Update 3.2.2 will return {"Update", "3.2.2"}
-    std::map<std::string, std::string, std::less<>> GetPatchVersionNames(
-        VirtualFile update_raw = nullptr) const;
+    [[nodiscard]] PatchVersionNames GetPatchVersionNames(VirtualFile update_raw = nullptr) const;
 
     // If the game update exists, returns the u32 version field in its Meta-type NCA. If that fails,
     // it will fallback to the Meta-type NCA of the base game. If that fails, the result will be
     // std::nullopt
-    std::optional<u32> GetGameVersion() const;
+    [[nodiscard]] std::optional<u32> GetGameVersion() const;
 
     // Given title_id of the program, attempts to get the control data of the update and parse
     // it, falling back to the base control data.
-    std::pair<std::unique_ptr<NACP>, VirtualFile> GetControlMetadata() const;
+    [[nodiscard]] Metadata GetControlMetadata() const;
 
     // Version of GetControlMetadata that takes an arbitrary NCA
-    std::pair<std::unique_ptr<NACP>, VirtualFile> ParseControlNCA(const NCA& nca) const;
+    [[nodiscard]] Metadata ParseControlNCA(const NCA& nca) const;
 
 private:
-    std::vector<VirtualFile> CollectPatches(const std::vector<VirtualDir>& patch_dirs,
-                                            const std::string& build_id) const;
+    [[nodiscard]] std::vector<VirtualFile> CollectPatches(const std::vector<VirtualDir>& patch_dirs,
+                                                          const std::string& build_id) const;
 
     u64 title_id;
 };

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -22,18 +22,6 @@ namespace FileSys {
 class NCA;
 class NACP;
 
-enum class TitleVersionFormat : u8 {
-    ThreeElements, ///< vX.Y.Z
-    FourElements,  ///< vX.Y.Z.W
-};
-
-std::string FormatTitleVersion(u32 version,
-                               TitleVersionFormat format = TitleVersionFormat::ThreeElements);
-
-// Returns a directory with name matching name case-insensitive. Returns nullptr if directory
-// doesn't have a directory with name.
-VirtualDir FindSubdirectoryCaseless(VirtualDir dir, std::string_view name);
-
 // A centralized class to manage patches to games.
 class PatchManager {
 public:


### PR DESCRIPTION
Tidies up the external interface of the patch manager a little bit. Figured I may as well get this out of the way before eliminating reliance on the global system instance.

Each commit should be fairly straightforward.