### PR TITLE
cheat_engine: Remove unnecessary system argument to CheatParser's Parse function

### DIFF
--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -76,8 +76,7 @@ VirtualDir FindSubdirectoryCaseless(const VirtualDir dir, std::string_view name)
 }
 
 std::optional<std::vector<Core::Memory::CheatEntry>> ReadCheatFileFromFolder(
-    const Core::System& system, u64 title_id, const PatchManager::BuildID& build_id_,
-    const VirtualDir& base_path, bool upper) {
+    u64 title_id, const PatchManager::BuildID& build_id_, const VirtualDir& base_path, bool upper) {
     const auto build_id_raw = Common::HexToString(build_id_, upper);
     const auto build_id = build_id_raw.substr(0, sizeof(u64) * 2);
     const auto file = base_path->GetFile(fmt::format("{}.txt", build_id));
@@ -95,9 +94,8 @@ std::optional<std::vector<Core::Memory::CheatEntry>> ReadCheatFileFromFolder(
         return std::nullopt;
     }
 
-    Core::Memory::TextCheatParser parser;
-    return parser.Parse(system,
-                        std::string_view(reinterpret_cast<const char*>(data.data()), data.size()));
+    const Core::Memory::TextCheatParser parser;
+    return parser.Parse(std::string_view(reinterpret_cast<const char*>(data.data()), data.size()));
 }
 
 void AppendCommaIfNotEmpty(std::string& to, std::string_view with) {
@@ -335,14 +333,12 @@ std::vector<Core::Memory::CheatEntry> PatchManager::CreateCheatList(
 
         auto cheats_dir = FindSubdirectoryCaseless(subdir, "cheats");
         if (cheats_dir != nullptr) {
-            auto res = ReadCheatFileFromFolder(system, title_id, build_id_, cheats_dir, true);
-            if (res.has_value()) {
+            if (const auto res = ReadCheatFileFromFolder(title_id, build_id_, cheats_dir, true)) {
                 std::copy(res->begin(), res->end(), std::back_inserter(out));
                 continue;
             }
 
-            res = ReadCheatFileFromFolder(system, title_id, build_id_, cheats_dir, false);
-            if (res.has_value()) {
+            if (const auto res = ReadCheatFileFromFolder(title_id, build_id_, cheats_dir, false)) {
                 std::copy(res->begin(), res->end(), std::back_inserter(out));
             }
         }

--- a/src/core/memory/cheat_engine.cpp
+++ b/src/core/memory/cheat_engine.cpp
@@ -98,10 +98,9 @@ std::string_view ExtractName(std::string_view data, std::size_t start_index) {
 }
 } // Anonymous namespace
 
-std::vector<CheatEntry> TextCheatParser::Parse(const Core::System& system,
-                                               std::string_view data) const {
+std::vector<CheatEntry> TextCheatParser::Parse(std::string_view data) const {
     std::vector<CheatEntry> out(1);
-    std::optional<u64> current_entry = std::nullopt;
+    std::optional<u64> current_entry;
 
     for (std::size_t i = 0; i < data.size(); ++i) {
         if (::isspace(data[i])) {

--- a/src/core/memory/cheat_engine.cpp
+++ b/src/core/memory/cheat_engine.cpp
@@ -19,9 +19,23 @@
 #include "core/memory/cheat_engine.h"
 
 namespace Core::Memory {
-
+namespace {
 constexpr auto CHEAT_ENGINE_NS = std::chrono::nanoseconds{1000000000 / 12};
 constexpr u32 KEYPAD_BITMASK = 0x3FFFFFF;
+
+std::string_view ExtractName(std::string_view data, std::size_t start_index, char match) {
+    auto end_index = start_index;
+    while (data[end_index] != match) {
+        ++end_index;
+        if (end_index > data.size() ||
+            (end_index - start_index - 1) > sizeof(CheatDefinition::readable_name)) {
+            return {};
+        }
+    }
+
+    return data.substr(start_index, end_index - start_index);
+}
+} // Anonymous namespace
 
 StandardVmCallbacks::StandardVmCallbacks(Core::System& system, const CheatProcessMetadata& metadata)
     : metadata(metadata), system(system) {}
@@ -82,22 +96,6 @@ CheatParser::~CheatParser() = default;
 
 TextCheatParser::~TextCheatParser() = default;
 
-namespace {
-template <char match>
-std::string_view ExtractName(std::string_view data, std::size_t start_index) {
-    auto end_index = start_index;
-    while (data[end_index] != match) {
-        ++end_index;
-        if (end_index > data.size() ||
-            (end_index - start_index - 1) > sizeof(CheatDefinition::readable_name)) {
-            return {};
-        }
-    }
-
-    return data.substr(start_index, end_index - start_index);
-}
-} // Anonymous namespace
-
 std::vector<CheatEntry> TextCheatParser::Parse(std::string_view data) const {
     std::vector<CheatEntry> out(1);
     std::optional<u64> current_entry;
@@ -114,7 +112,7 @@ std::vector<CheatEntry> TextCheatParser::Parse(std::string_view data) const {
                 return {};
             }
 
-            const auto name = ExtractName<'}'>(data, i + 1);
+            const auto name = ExtractName(data, i + 1, '}');
             if (name.empty()) {
                 return {};
             }
@@ -131,7 +129,7 @@ std::vector<CheatEntry> TextCheatParser::Parse(std::string_view data) const {
             current_entry = out.size();
             out.emplace_back();
 
-            const auto name = ExtractName<']'>(data, i + 1);
+            const auto name = ExtractName(data, i + 1, ']');
             if (name.empty()) {
                 return {};
             }

--- a/src/core/memory/cheat_engine.h
+++ b/src/core/memory/cheat_engine.h
@@ -47,8 +47,7 @@ class CheatParser {
 public:
     virtual ~CheatParser();
 
-    virtual std::vector<CheatEntry> Parse(const Core::System& system,
-                                          std::string_view data) const = 0;
+    [[nodiscard]] virtual std::vector<CheatEntry> Parse(std::string_view data) const = 0;
 };
 
 // CheatParser implementation that parses text files
@@ -56,7 +55,7 @@ class TextCheatParser final : public CheatParser {
 public:
     ~TextCheatParser() override;
 
-    std::vector<CheatEntry> Parse(const Core::System& system, std::string_view data) const override;
+    [[nodiscard]] std::vector<CheatEntry> Parse(std::string_view data) const override;
 };
 
 // Class that encapsulates a CheatList and manages its interaction with memory and CoreTiming


### PR DESCRIPTION
This isn't used within the function at all in any implementations, so we can remove it entirely.