### PR TITLE
Add a stub for LoadOpenContext

### DIFF
--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -786,7 +786,7 @@ void Module::Interface::ListOpenContextStoredUsers(Kernel::HLERequestContext& ct
 void Module::Interface::LoadOpenContext(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_ACC, "(STUBBED) called");
 
-    //TODO(ZiggyDev): Research and implement function. This should do for now.
+    // TODO(ZiggyDev): Research and implement function. This should do for now.
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }

--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -783,6 +783,14 @@ void Module::Interface::ListOpenContextStoredUsers(Kernel::HLERequestContext& ct
     rb.Push(RESULT_SUCCESS);
 }
 
+void Module::Interface::LoadOpenContext(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service_ACC, "(STUBBED) called");
+
+    //TODO(ZiggyDev): Research and implement function. This should do for now.
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(RESULT_SUCCESS);
+}
+
 void Module::Interface::TrySelectUserWithoutInteraction(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_ACC, "called");
     // A u8 is passed into this function which we can safely ignore. It's to determine if we have

--- a/src/core/hle/service/acc/acc.h
+++ b/src/core/hle/service/acc/acc.h
@@ -35,6 +35,7 @@ public:
         void GetProfileEditor(Kernel::HLERequestContext& ctx);
         void ListQualifiedUsers(Kernel::HLERequestContext& ctx);
         void ListOpenContextStoredUsers(Kernel::HLERequestContext& ctx);
+        void LoadOpenContext(Kernel::HLERequestContext& ctx);
 
     private:
         ResultCode InitializeApplicationInfoBase();

--- a/src/core/hle/service/acc/acc_u0.cpp
+++ b/src/core/hle/service/acc/acc_u0.cpp
@@ -29,7 +29,7 @@ ACC_U0::ACC_U0(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> p
         {110, nullptr, "StoreSaveDataThumbnail"},
         {111, nullptr, "ClearSaveDataThumbnail"},
         {120, nullptr, "CreateGuestLoginRequest"},
-        {130, nullptr, "LoadOpenContext"}, // 5.0.0+
+        {130, &ACC_U0::LoadOpenContext, "LoadOpenContext"}, // 5.0.0+
         {131, &ACC_U0::ListOpenContextStoredUsers, "ListOpenContextStoredUsers"}, // 6.0.0+
         {140, &ACC_U0::InitializeApplicationInfoRestricted, "InitializeApplicationInfoRestricted"}, // 6.0.0+
         {141, &ACC_U0::ListQualifiedUsers, "ListQualifiedUsers"}, // 6.0.0+


### PR DESCRIPTION
There isn't any research done on this call, but building an empty response with a param size of 2 should work for now.