### PR TITLE
core/loader: Remove dependencies on the global system instance

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -221,7 +221,7 @@ struct System::Impl {
         telemetry_session->AddInitialInfo(*app_loader);
         auto main_process =
             Kernel::Process::Create(system, "main", Kernel::Process::ProcessType::Userland);
-        const auto [load_result, load_parameters] = app_loader->Load(*main_process);
+        const auto [load_result, load_parameters] = app_loader->Load(*main_process, system);
         if (load_result != Loader::ResultStatus::Success) {
             LOG_CRITICAL(Core, "Failed to load ROM (Error {})!", static_cast<int>(load_result));
             Shutdown();

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -89,7 +89,7 @@ FileType AppLoader_DeconstructedRomDirectory::IdentifyType(const FileSys::Virtua
 }
 
 AppLoader_DeconstructedRomDirectory::LoadResult AppLoader_DeconstructedRomDirectory::Load(
-    Kernel::Process& process) {
+    Kernel::Process& process, Core::System& system) {
     if (is_loaded) {
         return {ResultStatus::ErrorAlreadyLoaded, {}};
     }
@@ -141,9 +141,9 @@ AppLoader_DeconstructedRomDirectory::LoadResult AppLoader_DeconstructedRomDirect
             continue;
         }
 
-        const bool should_pass_arguments{std::strcmp(module, "rtld") == 0};
-        const auto tentative_next_load_addr{AppLoader_NSO::LoadModule(
-            process, *module_file, code_size, should_pass_arguments, false)};
+        const bool should_pass_arguments = std::strcmp(module, "rtld") == 0;
+        const auto tentative_next_load_addr = AppLoader_NSO::LoadModule(
+            process, system, *module_file, code_size, should_pass_arguments, false);
         if (!tentative_next_load_addr) {
             return {ResultStatus::ErrorLoadingNSO, {}};
         }
@@ -168,9 +168,9 @@ AppLoader_DeconstructedRomDirectory::LoadResult AppLoader_DeconstructedRomDirect
         }
 
         const VAddr load_addr{next_load_addr};
-        const bool should_pass_arguments{std::strcmp(module, "rtld") == 0};
-        const auto tentative_next_load_addr{AppLoader_NSO::LoadModule(
-            process, *module_file, load_addr, should_pass_arguments, true, pm)};
+        const bool should_pass_arguments = std::strcmp(module, "rtld") == 0;
+        const auto tentative_next_load_addr = AppLoader_NSO::LoadModule(
+            process, system, *module_file, load_addr, should_pass_arguments, true, pm);
         if (!tentative_next_load_addr) {
             return {ResultStatus::ErrorLoadingNSO, {}};
         }
@@ -192,7 +192,7 @@ AppLoader_DeconstructedRomDirectory::LoadResult AppLoader_DeconstructedRomDirect
     // Register the RomFS if a ".romfs" file was found
     if (romfs_iter != files.end() && *romfs_iter != nullptr) {
         romfs = *romfs_iter;
-        Core::System::GetInstance().GetFileSystemController().RegisterRomFS(
+        system.GetFileSystemController().RegisterRomFS(
             std::make_unique<FileSys::RomFSFactory>(*this));
     }
 

--- a/src/core/loader/deconstructed_rom_directory.h
+++ b/src/core/loader/deconstructed_rom_directory.h
@@ -9,6 +9,10 @@
 #include "core/file_sys/program_metadata.h"
 #include "core/loader/loader.h"
 
+namespace Core {
+class System;
+}
+
 namespace Loader {
 
 /**
@@ -37,7 +41,7 @@ public:
         return IdentifyType(file);
     }
 
-    LoadResult Load(Kernel::Process& process) override;
+    LoadResult Load(Kernel::Process& process, Core::System& system) override;
 
     ResultStatus ReadRomFS(FileSys::VirtualFile& dir) override;
     ResultStatus ReadIcon(std::vector<u8>& buffer) override;

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -383,7 +383,8 @@ FileType AppLoader_ELF::IdentifyType(const FileSys::VirtualFile& file) {
     return FileType::Error;
 }
 
-AppLoader_ELF::LoadResult AppLoader_ELF::Load(Kernel::Process& process) {
+AppLoader_ELF::LoadResult AppLoader_ELF::Load(Kernel::Process& process,
+                                              [[maybe_unused]] Core::System& system) {
     if (is_loaded) {
         return {ResultStatus::ErrorAlreadyLoaded, {}};
     }

--- a/src/core/loader/elf.h
+++ b/src/core/loader/elf.h
@@ -8,6 +8,10 @@
 #include "common/common_types.h"
 #include "core/loader/loader.h"
 
+namespace Core {
+class System;
+}
+
 namespace Loader {
 
 /// Loads an ELF/AXF file
@@ -26,7 +30,7 @@ public:
         return IdentifyType(file);
     }
 
-    LoadResult Load(Kernel::Process& process) override;
+    LoadResult Load(Kernel::Process& process, Core::System& system) override;
 };
 
 } // namespace Loader

--- a/src/core/loader/kip.cpp
+++ b/src/core/loader/kip.cpp
@@ -43,7 +43,8 @@ FileType AppLoader_KIP::GetFileType() const {
                                                                          : FileType::Error;
 }
 
-AppLoader::LoadResult AppLoader_KIP::Load(Kernel::Process& process) {
+AppLoader::LoadResult AppLoader_KIP::Load(Kernel::Process& process,
+                                          [[maybe_unused]] Core::System& system) {
     if (is_loaded) {
         return {ResultStatus::ErrorAlreadyLoaded, {}};
     }

--- a/src/core/loader/kip.h
+++ b/src/core/loader/kip.h
@@ -6,6 +6,10 @@
 
 #include "core/loader/loader.h"
 
+namespace Core {
+class System;
+}
+
 namespace FileSys {
 class KIP;
 }
@@ -26,7 +30,7 @@ public:
 
     FileType GetFileType() const override;
 
-    LoadResult Load(Kernel::Process& process) override;
+    LoadResult Load(Kernel::Process& process, Core::System& system) override;
 
 private:
     std::unique_ptr<FileSys::KIP> kip;

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -15,6 +15,10 @@
 #include "core/file_sys/control_metadata.h"
 #include "core/file_sys/vfs.h"
 
+namespace Core {
+class System;
+}
+
 namespace FileSys {
 class NACP;
 } // namespace FileSys
@@ -154,9 +158,10 @@ public:
     /**
      * Load the application and return the created Process instance
      * @param process The newly created process.
+     * @param system  The system that this process is being loaded under.
      * @return The status result of the operation.
      */
-    virtual LoadResult Load(Kernel::Process& process) = 0;
+    virtual LoadResult Load(Kernel::Process& process, Core::System& system) = 0;
 
     /**
      * Get the code (typically .code section) of the application

--- a/src/core/loader/nax.cpp
+++ b/src/core/loader/nax.cpp
@@ -41,7 +41,8 @@ FileType AppLoader_NAX::GetFileType() const {
     return IdentifyTypeImpl(*nax);
 }
 
-AppLoader_NAX::LoadResult AppLoader_NAX::Load(Kernel::Process& process) {
+AppLoader_NAX::LoadResult AppLoader_NAX::Load(Kernel::Process& process,
+                                              [[maybe_unused]] Core::System& system) {
     if (is_loaded) {
         return {ResultStatus::ErrorAlreadyLoaded, {}};
     }
@@ -65,7 +66,7 @@ AppLoader_NAX::LoadResult AppLoader_NAX::Load(Kernel::Process& process) {
         return {nca_status, {}};
     }
 
-    const auto result = nca_loader->Load(process);
+    const auto result = nca_loader->Load(process, system);
     if (result.first != ResultStatus::Success) {
         return result;
     }

--- a/src/core/loader/nax.h
+++ b/src/core/loader/nax.h
@@ -8,10 +8,12 @@
 #include "common/common_types.h"
 #include "core/loader/loader.h"
 
+namespace Core {
+class System;
+}
+
 namespace FileSys {
-
 class NAX;
-
 } // namespace FileSys
 
 namespace Loader {
@@ -33,7 +35,7 @@ public:
 
     FileType GetFileType() const override;
 
-    LoadResult Load(Kernel::Process& process) override;
+    LoadResult Load(Kernel::Process& process, Core::System& system) override;
 
     ResultStatus ReadRomFS(FileSys::VirtualFile& dir) override;
     u64 ReadRomFSIVFCOffset() const override;

--- a/src/core/loader/nca.cpp
+++ b/src/core/loader/nca.cpp
@@ -31,7 +31,7 @@ FileType AppLoader_NCA::IdentifyType(const FileSys::VirtualFile& file) {
     return FileType::Error;
 }
 
-AppLoader_NCA::LoadResult AppLoader_NCA::Load(Kernel::Process& process) {
+AppLoader_NCA::LoadResult AppLoader_NCA::Load(Kernel::Process& process, Core::System& system) {
     if (is_loaded) {
         return {ResultStatus::ErrorAlreadyLoaded, {}};
     }
@@ -52,13 +52,13 @@ AppLoader_NCA::LoadResult AppLoader_NCA::Load(Kernel::Process& process) {
 
     directory_loader = std::make_unique<AppLoader_DeconstructedRomDirectory>(exefs, true);
 
-    const auto load_result = directory_loader->Load(process);
+    const auto load_result = directory_loader->Load(process, system);
     if (load_result.first != ResultStatus::Success) {
         return load_result;
     }
 
     if (nca->GetRomFS() != nullptr && nca->GetRomFS()->GetSize() > 0) {
-        Core::System::GetInstance().GetFileSystemController().RegisterRomFS(
+        system.GetFileSystemController().RegisterRomFS(
             std::make_unique<FileSys::RomFSFactory>(*this));
     }
 

--- a/src/core/loader/nca.h
+++ b/src/core/loader/nca.h
@@ -8,6 +8,10 @@
 #include "core/file_sys/vfs.h"
 #include "core/loader/loader.h"
 
+namespace Core {
+class System;
+}
+
 namespace FileSys {
 class NCA;
 }
@@ -33,7 +37,7 @@ public:
         return IdentifyType(file);
     }
 
-    LoadResult Load(Kernel::Process& process) override;
+    LoadResult Load(Kernel::Process& process, Core::System& system) override;
 
     ResultStatus ReadRomFS(FileSys::VirtualFile& dir) override;
     u64 ReadRomFSIVFCOffset() const override;

--- a/src/core/loader/nro.cpp
+++ b/src/core/loader/nro.cpp
@@ -208,7 +208,7 @@ bool AppLoader_NRO::LoadNro(Kernel::Process& process, const FileSys::VfsFile& fi
     return LoadNroImpl(process, file.ReadAllBytes(), file.GetName());
 }
 
-AppLoader_NRO::LoadResult AppLoader_NRO::Load(Kernel::Process& process) {
+AppLoader_NRO::LoadResult AppLoader_NRO::Load(Kernel::Process& process, Core::System& system) {
     if (is_loaded) {
         return {ResultStatus::ErrorAlreadyLoaded, {}};
     }
@@ -218,7 +218,7 @@ AppLoader_NRO::LoadResult AppLoader_NRO::Load(Kernel::Process& process) {
     }
 
     if (romfs != nullptr) {
-        Core::System::GetInstance().GetFileSystemController().RegisterRomFS(
+        system.GetFileSystemController().RegisterRomFS(
             std::make_unique<FileSys::RomFSFactory>(*this));
     }
 

--- a/src/core/loader/nro.h
+++ b/src/core/loader/nro.h
@@ -10,6 +10,10 @@
 #include "common/common_types.h"
 #include "core/loader/loader.h"
 
+namespace Core {
+class System;
+}
+
 namespace FileSys {
 class NACP;
 }
@@ -37,7 +41,7 @@ public:
         return IdentifyType(file);
     }
 
-    LoadResult Load(Kernel::Process& process) override;
+    LoadResult Load(Kernel::Process& process, Core::System& system) override;
 
     ResultStatus ReadIcon(std::vector<u8>& buffer) override;
     ResultStatus ReadProgramId(u64& out_program_id) override;

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -71,7 +71,7 @@ FileType AppLoader_NSO::IdentifyType(const FileSys::VirtualFile& file) {
     return FileType::NSO;
 }
 
-std::optional<VAddr> AppLoader_NSO::LoadModule(Kernel::Process& process,
+std::optional<VAddr> AppLoader_NSO::LoadModule(Kernel::Process& process, Core::System& system,
                                                const FileSys::VfsFile& file, VAddr load_base,
                                                bool should_pass_arguments, bool load_into_process,
                                                std::optional<FileSys::PatchManager> pm) {
@@ -148,7 +148,6 @@ std::optional<VAddr> AppLoader_NSO::LoadModule(Kernel::Process& process,
 
     // Apply cheats if they exist and the program has a valid title ID
     if (pm) {
-        auto& system = Core::System::GetInstance();
         system.SetCurrentProcessBuildID(nso_header.build_id);
         const auto cheats = pm->CreateCheatList(system, nso_header.build_id);
         if (!cheats.empty()) {
@@ -166,7 +165,8 @@ std::optional<VAddr> AppLoader_NSO::LoadModule(Kernel::Process& process,
     return load_base + image_size;
 }
 
-AppLoader_NSO::LoadResult AppLoader_NSO::Load(Kernel::Process& process) {
+AppLoader_NSO::LoadResult AppLoader_NSO::Load(Kernel::Process& process,
+                                              [[maybe_unused]] Core::System& system) {
     if (is_loaded) {
         return {ResultStatus::ErrorAlreadyLoaded, {}};
     }
@@ -175,7 +175,7 @@ AppLoader_NSO::LoadResult AppLoader_NSO::Load(Kernel::Process& process) {
 
     // Load module
     const VAddr base_address = process.PageTable().GetCodeRegionStart();
-    if (!LoadModule(process, *file, base_address, true, true)) {
+    if (!LoadModule(process, system, *file, base_address, true, true)) {
         return {ResultStatus::ErrorLoadingNSO, {}};
     }
 

--- a/src/core/loader/nso.h
+++ b/src/core/loader/nso.h
@@ -12,6 +12,10 @@
 #include "core/file_sys/patch_manager.h"
 #include "core/loader/loader.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 class Process;
 }
@@ -80,12 +84,12 @@ public:
         return IdentifyType(file);
     }
 
-    static std::optional<VAddr> LoadModule(Kernel::Process& process, const FileSys::VfsFile& file,
-                                           VAddr load_base, bool should_pass_arguments,
-                                           bool load_into_process,
+    static std::optional<VAddr> LoadModule(Kernel::Process& process, Core::System& system,
+                                           const FileSys::VfsFile& file, VAddr load_base,
+                                           bool should_pass_arguments, bool load_into_process,
                                            std::optional<FileSys::PatchManager> pm = {});
 
-    LoadResult Load(Kernel::Process& process) override;
+    LoadResult Load(Kernel::Process& process, Core::System& system) override;
 
     ResultStatus ReadNSOModules(Modules& modules) override;
 

--- a/src/core/loader/nsp.cpp
+++ b/src/core/loader/nsp.cpp
@@ -71,7 +71,7 @@ FileType AppLoader_NSP::IdentifyType(const FileSys::VirtualFile& file) {
     return FileType::Error;
 }
 
-AppLoader_NSP::LoadResult AppLoader_NSP::Load(Kernel::Process& process) {
+AppLoader_NSP::LoadResult AppLoader_NSP::Load(Kernel::Process& process, Core::System& system) {
     if (is_loaded) {
         return {ResultStatus::ErrorAlreadyLoaded, {}};
     }
@@ -99,15 +99,14 @@ AppLoader_NSP::LoadResult AppLoader_NSP::Load(Kernel::Process& process) {
         return {ResultStatus::ErrorNSPMissingProgramNCA, {}};
     }
 
-    const auto result = secondary_loader->Load(process);
+    const auto result = secondary_loader->Load(process, system);
     if (result.first != ResultStatus::Success) {
         return result;
     }
 
     FileSys::VirtualFile update_raw;
     if (ReadUpdateRaw(update_raw) == ResultStatus::Success && update_raw != nullptr) {
-        Core::System::GetInstance().GetFileSystemController().SetPackedUpdate(
-            std::move(update_raw));
+        system.GetFileSystemController().SetPackedUpdate(std::move(update_raw));
     }
 
     is_loaded = true;

--- a/src/core/loader/nsp.h
+++ b/src/core/loader/nsp.h
@@ -9,6 +9,10 @@
 #include "core/file_sys/vfs.h"
 #include "core/loader/loader.h"
 
+namespace Core {
+class System;
+}
+
 namespace FileSys {
 class NACP;
 class NSP;
@@ -35,7 +39,7 @@ public:
         return IdentifyType(file);
     }
 
-    LoadResult Load(Kernel::Process& process) override;
+    LoadResult Load(Kernel::Process& process, Core::System& system) override;
 
     ResultStatus ReadRomFS(FileSys::VirtualFile& file) override;
     u64 ReadRomFSIVFCOffset() const override;

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -49,7 +49,7 @@ FileType AppLoader_XCI::IdentifyType(const FileSys::VirtualFile& file) {
     return FileType::Error;
 }
 
-AppLoader_XCI::LoadResult AppLoader_XCI::Load(Kernel::Process& process) {
+AppLoader_XCI::LoadResult AppLoader_XCI::Load(Kernel::Process& process, Core::System& system) {
     if (is_loaded) {
         return {ResultStatus::ErrorAlreadyLoaded, {}};
     }
@@ -66,15 +66,14 @@ AppLoader_XCI::LoadResult AppLoader_XCI::Load(Kernel::Process& process) {
         return {ResultStatus::ErrorMissingProductionKeyFile, {}};
     }
 
-    const auto result = nca_loader->Load(process);
+    const auto result = nca_loader->Load(process, system);
     if (result.first != ResultStatus::Success) {
         return result;
     }
 
     FileSys::VirtualFile update_raw;
     if (ReadUpdateRaw(update_raw) == ResultStatus::Success && update_raw != nullptr) {
-        Core::System::GetInstance().GetFileSystemController().SetPackedUpdate(
-            std::move(update_raw));
+        system.GetFileSystemController().SetPackedUpdate(std::move(update_raw));
     }
 
     is_loaded = true;

--- a/src/core/loader/xci.h
+++ b/src/core/loader/xci.h
@@ -9,6 +9,10 @@
 #include "core/file_sys/vfs.h"
 #include "core/loader/loader.h"
 
+namespace Core {
+class System;
+}
+
 namespace FileSys {
 class NACP;
 class XCI;
@@ -35,7 +39,7 @@ public:
         return IdentifyType(file);
     }
 
-    LoadResult Load(Kernel::Process& process) override;
+    LoadResult Load(Kernel::Process& process, Core::System& system) override;
 
     ResultStatus ReadRomFS(FileSys::VirtualFile& file) override;
     u64 ReadRomFSIVFCOffset() const override;


### PR DESCRIPTION
Now all that remains is:

- 18 instances in file_sys code
- 14 instances in GDB stub code (this can be tossed wholesale)
- 4 instances in HLE code
- 2 instances in settings code.