### PR TITLE
control_metadata: Resolve typo in Portuguese language name

### DIFF
--- a/src/core/file_sys/control_metadata.h
+++ b/src/core/file_sys/control_metadata.h
@@ -83,7 +83,7 @@ enum class Language : u8 {
     Italian = 7,
     Dutch = 8,
     CanadianFrench = 9,
-    Portugese = 10,
+    Portuguese = 10,
     Russian = 11,
     Korean = 12,
     Taiwanese = 13,


### PR DESCRIPTION
This isn't used anywhere, so this is a trivial fix.