### PR TITLE
decode/image: Eliminate switch fallthrough in DecodeImage()

### DIFF
--- a/src/video_core/shader/decode/image.cpp
+++ b/src/video_core/shader/decode/image.cpp
@@ -470,6 +470,7 @@ u32 ShaderIR::DecodeImage(NodeBlock& bb, u32 pc) {
                 default:
                     break;
                 }
+                break;
             default:
                 break;
             }


### PR DESCRIPTION
Fortunately this didn't result in any issues, given the block that code was falling through to would immediately break.