### PR TITLE
submission_package: Account for multi-content NSPs

### DIFF
--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -267,9 +267,9 @@ void NSP::ReadNCAs(const std::vector<VirtualFile>& files) {
             }
 
             const CNMT cnmt(inner_file);
-            auto& ncas_title = ncas[cnmt.GetTitleID()];
 
-            ncas_title[{cnmt.GetType(), ContentRecordType::Meta}] = nca;
+            ncas[cnmt.GetTitleID()][{cnmt.GetType(), ContentRecordType::Meta}] = nca;
+
             for (const auto& rec : cnmt.GetContentRecords()) {
                 const auto id_string = Common::HexToString(rec.nca_id, false);
                 auto next_file = pfs->GetFile(fmt::format("{}.nca", id_string));
@@ -287,12 +287,12 @@ void NSP::ReadNCAs(const std::vector<VirtualFile>& files) {
 
                 auto next_nca = std::make_shared<NCA>(std::move(next_file), nullptr, 0);
                 if (next_nca->GetType() == NCAContentType::Program) {
-                    program_status[cnmt.GetTitleID()] = next_nca->GetStatus();
+                    program_status[next_nca->GetTitleId()] = next_nca->GetStatus();
                 }
                 if (next_nca->GetStatus() == Loader::ResultStatus::Success ||
                     (next_nca->GetStatus() == Loader::ResultStatus::ErrorMissingBKTRBaseRomFS &&
-                     (cnmt.GetTitleID() & 0x800) != 0)) {
-                    ncas_title[{cnmt.GetType(), rec.type}] = std::move(next_nca);
+                     (next_nca->GetTitleId() & 0x800) != 0)) {
+                    ncas[next_nca->GetTitleId()][{cnmt.GetType(), rec.type}] = std::move(next_nca);
                 }
             }
 


### PR DESCRIPTION
Previously we assumed a submission package can only contain one Program NCA with a single TitleID.
However, Super Mario 3D All-Stars contains four Program NCAs, each with their unique TitleIDs.
This accounts for the existence of multi-content games such as this one.
- Fixes booting Super Mario 3D All-Stars from the games list.

Closes #3906 