### PR TITLE
nvdrv: Implement Ioctl2 command SubmitGPFIFOEx

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
@@ -164,17 +164,16 @@ u32 nvhost_gpu::SubmitGPFIFO(const std::vector<u8>& input, std::vector<u8>& outp
         ASSERT_MSG((input.size() + input2.size()) ==
                        sizeof(IoctlSubmitGpfifo) +
                            params.num_entries * sizeof(Tegra::CommandListHeader),
-                    "Incorrect input size");
-        std::memcpy(entries.data(), input2,
-                    params.num_entries * sizeof(Tegra::CommandListHeader));
+                   "Incorrect input size");
+        std::memcpy(entries.data(), input2, params.num_entries * sizeof(Tegra::CommandListHeader));
     } else {
         ASSERT_MSG(input.size() == sizeof(IoctlSubmitGpfifo) +
-                       params.num_entries * sizeof(Tegra::CommandListHeader),
+                                       params.num_entries * sizeof(Tegra::CommandListHeader),
                    "Incorrect input size");
         std::memcpy(entries.data(), &input[sizeof(IoctlSubmitGpfifo)],
                     params.num_entries * sizeof(Tegra::CommandListHeader));
     }
-    
+
     UNIMPLEMENTED_IF(params.flags.add_wait.Value() != 0);
     UNIMPLEMENTED_IF(params.flags.add_increment.Value() != 0);
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
@@ -165,7 +165,8 @@ u32 nvhost_gpu::SubmitGPFIFO(const std::vector<u8>& input, std::vector<u8>& outp
                        sizeof(IoctlSubmitGpfifo) +
                            params.num_entries * sizeof(Tegra::CommandListHeader),
                    "Incorrect input size");
-        std::memcpy(entries.data(), input2.data(), params.num_entries * sizeof(Tegra::CommandListHeader));
+        std::memcpy(entries.data(), input2.data(),
+                    params.num_entries * sizeof(Tegra::CommandListHeader));
     } else {
         ASSERT_MSG(input.size() == sizeof(IoctlSubmitGpfifo) +
                                        params.num_entries * sizeof(Tegra::CommandListHeader),

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
@@ -165,7 +165,7 @@ u32 nvhost_gpu::SubmitGPFIFO(const std::vector<u8>& input, std::vector<u8>& outp
                        sizeof(IoctlSubmitGpfifo) +
                            params.num_entries * sizeof(Tegra::CommandListHeader),
                    "Incorrect input size");
-        std::memcpy(entries.data(), input2, params.num_entries * sizeof(Tegra::CommandListHeader));
+        std::memcpy(entries.data(), input2.data(), params.num_entries * sizeof(Tegra::CommandListHeader));
     } else {
         ASSERT_MSG(input.size() == sizeof(IoctlSubmitGpfifo) +
                                        params.num_entries * sizeof(Tegra::CommandListHeader),

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
@@ -46,13 +46,15 @@ u32 nvhost_gpu::ioctl(Ioctl command, const std::vector<u8>& input, const std::ve
         return ChannelSetTimeout(input, output);
     case IoctlCommand::IocChannelSetTimeslice:
         return ChannelSetTimeslice(input, output);
+    case IoctlCommand::IocSubmitGPFIFOExCommand:
+        return SubmitGPFIFO(input, output, input2, version);
     default:
         break;
     }
 
     if (command.group == NVGPU_IOCTL_MAGIC) {
         if (command.cmd == NVGPU_IOCTL_CHANNEL_SUBMIT_GPFIFO) {
-            return SubmitGPFIFO(input, output);
+            return SubmitGPFIFO(input, output, input2, version);
         }
         if (command.cmd == NVGPU_IOCTL_CHANNEL_KICKOFF_PB) {
             return KickoffPB(input, output, input2, version);
@@ -145,23 +147,34 @@ u32 nvhost_gpu::AllocateObjectContext(const std::vector<u8>& input, std::vector<
     return 0;
 }
 
-u32 nvhost_gpu::SubmitGPFIFO(const std::vector<u8>& input, std::vector<u8>& output) {
+u32 nvhost_gpu::SubmitGPFIFO(const std::vector<u8>& input, std::vector<u8>& output,
+                             const std::vector<u8>& input2, IoctlVersion version) {
     if (input.size() < sizeof(IoctlSubmitGpfifo)) {
         UNIMPLEMENTED();
     }
     IoctlSubmitGpfifo params{};
+
     std::memcpy(&params, input.data(), sizeof(IoctlSubmitGpfifo));
     LOG_TRACE(Service_NVDRV, "called, gpfifo={:X}, num_entries={:X}, flags={:X}", params.address,
               params.num_entries, params.flags.raw);
 
-    ASSERT_MSG(input.size() == sizeof(IoctlSubmitGpfifo) +
-                                   params.num_entries * sizeof(Tegra::CommandListHeader),
-               "Incorrect input size");
-
     Tegra::CommandList entries(params.num_entries);
-    std::memcpy(entries.data(), &input[sizeof(IoctlSubmitGpfifo)],
-                params.num_entries * sizeof(Tegra::CommandListHeader));
 
+    if (version == IoctlVersion::Version2) {
+        ASSERT_MSG((input.size() + input2.size()) ==
+                       sizeof(IoctlSubmitGpfifo) +
+                           params.num_entries * sizeof(Tegra::CommandListHeader),
+                    "Incorrect input size");
+        std::memcpy(entries.data(), input2,
+                    params.num_entries * sizeof(Tegra::CommandListHeader));
+    } else {
+        ASSERT_MSG(input.size() == sizeof(IoctlSubmitGpfifo) +
+                       params.num_entries * sizeof(Tegra::CommandListHeader),
+                   "Incorrect input size");
+        std::memcpy(entries.data(), &input[sizeof(IoctlSubmitGpfifo)],
+                    params.num_entries * sizeof(Tegra::CommandListHeader));
+    }
+    
     UNIMPLEMENTED_IF(params.flags.add_wait.Value() != 0);
     UNIMPLEMENTED_IF(params.flags.add_increment.Value() != 0);
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
@@ -49,6 +49,7 @@ private:
         IocChannelGetWaitbaseCommand = 0xC0080003,
         IocChannelSetTimeoutCommand = 0x40044803,
         IocChannelSetTimeslice = 0xC004481D,
+        IocSubmitGPFIFOExCommand = 0xC018481B,
     };
 
     enum class CtxObjects : u32_le {
@@ -190,7 +191,8 @@ private:
     u32 SetChannelPriority(const std::vector<u8>& input, std::vector<u8>& output);
     u32 AllocGPFIFOEx2(const std::vector<u8>& input, std::vector<u8>& output);
     u32 AllocateObjectContext(const std::vector<u8>& input, std::vector<u8>& output);
-    u32 SubmitGPFIFO(const std::vector<u8>& input, std::vector<u8>& output);
+    u32 SubmitGPFIFO(const std::vector<u8>& input, std::vector<u8>& output,
+                     const std::vector<u8>& input2, IoctlVersion version);
     u32 KickoffPB(const std::vector<u8>& input, std::vector<u8>& output,
                   const std::vector<u8>& input2, IoctlVersion version);
     u32 GetWaitbase(const std::vector<u8>& input, std::vector<u8>& output);


### PR DESCRIPTION
Needed by:
- Super Mario 3D All-Stars
And possibly some other newer games.

Although this implements the command, this does not fully fix the issue for Super Mario 3D All-Stars, as the flag "add_increment" is unimplemented. Maybe someone with a better understanding of that can add to this PR.

I tried to streamline the code by having both SubmitGPFIFO and SubmitGPFIFOEx call the same function and differentiating between them inside it, since they are essentially the same command, just different ioctl versions. If you'd rather have two separate functions you're more than welcome to edit this.