### PR TITLE
ips_layer: Eliminate a redundant copy in Parse()

### DIFF
--- a/src/core/file_sys/ips_layer.cpp
+++ b/src/core/file_sys/ips_layer.cpp
@@ -245,9 +245,11 @@ void IPSwitchCompiler::Parse() {
 
             // Read rest of patch
             while (true) {
-                if (i + 1 >= lines.size())
+                if (i + 1 >= lines.size()) {
                     break;
-                const auto patch_line = lines[++i];
+                }
+
+                const auto& patch_line = lines[++i];
 
                 // Start of new patch
                 if (StartsWith(patch_line, "@enabled") || StartsWith(patch_line, "@disabled")) {


### PR DESCRIPTION
Prevents unnecessary copying of the line being parsed.