### PR TITLE
install_dialog: Remove unused function prototype

### DIFF
--- a/src/yuzu/install_dialog.h
+++ b/src/yuzu/install_dialog.h
@@ -21,7 +21,6 @@ public:
     ~InstallDialog() override;
 
     QStringList GetFiles() const;
-    bool ShouldOverwriteFiles() const;
     int GetMinimumWidth() const;
 
 private:

--- a/src/yuzu/install_dialog.h
+++ b/src/yuzu/install_dialog.h
@@ -20,8 +20,8 @@ public:
     explicit InstallDialog(QWidget* parent, const QStringList& files);
     ~InstallDialog() override;
 
-    QStringList GetFiles() const;
-    int GetMinimumWidth() const;
+    [[nodiscard]] QStringList GetFiles() const;
+    [[nodiscard]] int GetMinimumWidth() const;
 
 private:
     QListWidget* file_list;


### PR DESCRIPTION
This function doesn't have an implementation, so it can be removed to prevent others from unintentionally using it.