### PR TITLE
video_core: Fix instances where msbuild always regenerated host shaders

### DIFF
--- a/src/video_core/host_shaders/CMakeLists.txt
+++ b/src/video_core/host_shaders/CMakeLists.txt
@@ -1,23 +1,16 @@
-set(SHADER_FILES
+set(SHADER_SOURCES
     opengl_present.frag
     opengl_present.vert
 )
 
 set(SHADER_INCLUDE ${CMAKE_CURRENT_BINARY_DIR}/include)
-set(HOST_SHADERS_INCLUDE ${SHADER_INCLUDE} PARENT_SCOPE)
-
 set(SHADER_DIR ${SHADER_INCLUDE}/video_core/host_shaders)
-add_custom_command(
-    OUTPUT
-        ${SHADER_DIR}
-    COMMAND
-        ${CMAKE_COMMAND} -E make_directory ${SHADER_DIR}
-)
+set(HOST_SHADERS_INCLUDE ${SHADER_INCLUDE} PARENT_SCOPE)
 
 set(INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/source_shader.h.in)
 set(HEADER_GENERATOR ${CMAKE_CURRENT_SOURCE_DIR}/StringShaderHeader.cmake)
 
-foreach(FILENAME IN ITEMS ${SHADER_FILES})
+foreach(FILENAME IN ITEMS ${SHADER_SOURCES})
     string(REPLACE "." "_" SHADER_NAME ${FILENAME})
     set(SOURCE_FILE ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME})
     set(HEADER_FILE ${SHADER_DIR}/${SHADER_NAME}.h)
@@ -29,8 +22,8 @@ foreach(FILENAME IN ITEMS ${SHADER_FILES})
         MAIN_DEPENDENCY
             ${SOURCE_FILE}
         DEPENDS
-            ${HEADER_GENERATOR}
             ${INPUT_FILE}
+            # HEADER_GENERATOR should be included here but msbuild seems to assume it's always modified
     )
     set(SHADER_HEADERS ${SHADER_HEADERS} ${HEADER_FILE})
 endforeach()
@@ -39,5 +32,5 @@ add_custom_target(host_shaders
     DEPENDS
         ${SHADER_HEADERS}
     SOURCES
-        ${SHADER_FILES}
+        ${SHADER_SOURCES}
 )

--- a/src/video_core/host_shaders/StringShaderHeader.cmake
+++ b/src/video_core/host_shaders/StringShaderHeader.cmake
@@ -8,4 +8,6 @@ string(TOUPPER ${CONTENTS_NAME} CONTENTS_NAME)
 
 file(READ ${SOURCE_FILE} CONTENTS)
 
+get_filename_component(OUTPUT_DIR ${HEADER_FILE} DIRECTORY)
+make_directory(${OUTPUT_DIR})
 configure_file(${INPUT_FILE} ${HEADER_FILE} @ONLY)


### PR DESCRIPTION
When HEADER_GENERATOR was included in the DEPENDS section of custom
commands, msbuild assumed this was always modified. Changing this file
is not common so we can remove it from there.