### PR TITLE
submission_package: Fix updates integrated into cartridge images.

### DIFF
--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -286,12 +286,31 @@ void NSP::ReadNCAs(const std::vector<VirtualFile>& files) {
                 }
 
                 auto next_nca = std::make_shared<NCA>(std::move(next_file), nullptr, 0);
+
                 if (next_nca->GetType() == NCAContentType::Program) {
                     program_status[next_nca->GetTitleId()] = next_nca->GetStatus();
                 }
-                if (next_nca->GetStatus() == Loader::ResultStatus::Success ||
-                    (next_nca->GetStatus() == Loader::ResultStatus::ErrorMissingBKTRBaseRomFS &&
-                     (next_nca->GetTitleId() & 0x800) != 0)) {
+
+                if (next_nca->GetStatus() != Loader::ResultStatus::Success &&
+                    next_nca->GetStatus() != Loader::ResultStatus::ErrorMissingBKTRBaseRomFS) {
+                    continue;
+                }
+
+                // If the last 3 hexadecimal digits of the CNMT TitleID is 0x800 or is missing the
+                // BKTRBaseRomFS, this is an update NCA. Otherwise, this is a base NCA.
+                if ((cnmt.GetTitleID() & 0x800) != 0 ||
+                    next_nca->GetStatus() == Loader::ResultStatus::ErrorMissingBKTRBaseRomFS) {
+                    // If the last 3 hexadecimal digits of the NCA's TitleID is between 0x1 and
+                    // 0x7FF, this is a multi-program update NCA. Otherwise, this is a regular
+                    // update NCA.
+                    if ((next_nca->GetTitleId() & 0x7FF) != 0 &&
+                        (next_nca->GetTitleId() & 0x800) == 0) {
+                        ncas[next_nca->GetTitleId()][{cnmt.GetType(), rec.type}] =
+                            std::move(next_nca);
+                    } else {
+                        ncas[cnmt.GetTitleID()][{cnmt.GetType(), rec.type}] = std::move(next_nca);
+                    }
+                } else {
                     ncas[next_nca->GetTitleId()][{cnmt.GetType(), rec.type}] = std::move(next_nca);
                 }
             }


### PR DESCRIPTION
Fixes #4693

The previous PR #4675 had a flaw which did not account for updates integrated into cartridge images (XCIs). This PR aims to solve this by adding explicit checks for multi-content / multi-program data.