### PR TITLE
Rename to align with switchbrew and remove gpu function

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
@@ -31,7 +31,7 @@ private:
         IocSyncptWaitexCommand = 0xC0100019,
         IocSyncptReadMaxCommand = 0xC008001A,
         IocGetConfigCommand = 0xC183001B,
-        IocCtrlEventSignalCommand = 0xC004001C,
+        IocCtrlClearEventWaitCommand = 0xC004001C,
         IocCtrlEventWaitCommand = 0xC010001D,
         IocCtrlEventWaitAsyncCommand = 0xC010001E,
         IocCtrlEventRegisterCommand = 0xC004001F,
@@ -94,7 +94,7 @@ private:
     static_assert(sizeof(IocGetConfigParams) == 387, "IocGetConfigParams is incorrect size");
 
     struct IocCtrlEventSignalParams {
-        u32_le user_event_id;
+        u32_le event_id;
     };
     static_assert(sizeof(IocCtrlEventSignalParams) == 4,
                   "IocCtrlEventSignalParams is incorrect size");
@@ -142,7 +142,7 @@ private:
 
     u32 IocCtrlEventUnregister(const std::vector<u8>& input, std::vector<u8>& output);
 
-    u32 IocCtrlEventSignal(const std::vector<u8>& input, std::vector<u8>& output);
+    u32 IocCtrlClearEventWait(const std::vector<u8>& input, std::vector<u8>& output);
 
     EventInterface& events_interface;
 };


### PR DESCRIPTION
I renamed it to be the same as [switchbrews nvhost-ctrl](https://switchbrew.org/wiki/NV_services#NVHOST_IOCTL_CTRL_SYNCPT_CLEAR_EVENT_WAIT), and removed the gpu check as switchbrew says this function is exclusive to the switch, so it seamed unnecessary.