### PR TITLE
service: Restore "unused" function

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -72,6 +72,23 @@
 
 namespace Service {
 
+/**
+ * Creates a function string for logging, complete with the name (or header code, depending
+ * on what's passed in) the port name, and all the cmd_buff arguments.
+ */
+[[maybe_unused]] static std::string MakeFunctionString(std::string_view name,
+                                                       std::string_view port_name,
+                                                       const u32* cmd_buff) {
+    // Number of params == bits 0-5 + bits 6-11
+    int num_params = (cmd_buff[0] & 0x3F) + ((cmd_buff[0] >> 6) & 0x3F);
+
+    std::string function_string = fmt::format("function '{}': port={}", name, port_name);
+    for (int i = 1; i <= num_params; ++i) {
+        function_string += fmt::format(", cmd_buff[{}]=0x{:X}", i, cmd_buff[i]);
+    }
+    return function_string;
+}
+
 ServiceFrameworkBase::ServiceFrameworkBase(const char* service_name, u32 max_sessions,
                                            InvokerFn* handler_invoker)
     : service_name(service_name), max_sessions(max_sessions), handler_invoker(handler_invoker) {}


### PR DESCRIPTION
Turns out this function is actually used, but within a trace log.