### PR TITLE
audio_core: Remove unnecessary inclusions

### DIFF
--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -3,16 +3,13 @@
 // Refer to the license.txt file included.
 
 #include <vector>
-#include "audio_core/algorithm/interpolate.h"
+
 #include "audio_core/audio_out.h"
 #include "audio_core/audio_renderer.h"
-#include "audio_core/codec.h"
 #include "audio_core/common.h"
 #include "audio_core/info_updater.h"
 #include "audio_core/voice_context.h"
-#include "common/assert.h"
 #include "common/logging/log.h"
-#include "core/core.h"
 #include "core/hle/kernel/writable_event.h"
 #include "core/memory.h"
 #include "core/settings.h"

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -21,7 +21,6 @@
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
-#include "core/hle/kernel/object.h"
 #include "core/hle/result.h"
 
 namespace Core::Timing {

--- a/src/audio_core/command_generator.h
+++ b/src/audio_core/command_generator.h
@@ -7,7 +7,6 @@
 #include <array>
 #include "audio_core/common.h"
 #include "audio_core/voice_context.h"
-#include "common/common_funcs.h"
 #include "common/common_types.h"
 
 namespace Core::Memory {

--- a/src/audio_core/common.h
+++ b/src/audio_core/common.h
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #pragma once
+
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"

--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -12,7 +12,6 @@
 #include "common/assert.h"
 #include "common/logging/log.h"
 #include "core/core_timing.h"
-#include "core/core_timing_util.h"
 #include "core/settings.h"
 
 namespace AudioCore {


### PR DESCRIPTION
Same behavior, but removes header dependencies where they don't need to be.