### PR TITLE
codec: Make lookup table static constexpr

### DIFF
--- a/src/audio_core/codec.cpp
+++ b/src/audio_core/codec.cpp
@@ -16,8 +16,9 @@ std::vector<s16> DecodeADPCM(const u8* const data, std::size_t size, const ADPCM
 
     constexpr std::size_t FRAME_LEN = 8;
     constexpr std::size_t SAMPLES_PER_FRAME = 14;
-    constexpr std::array<int, 16> SIGNED_NIBBLES = {
-        {0, 1, 2, 3, 4, 5, 6, 7, -8, -7, -6, -5, -4, -3, -2, -1}};
+    static constexpr std::array<int, 16> SIGNED_NIBBLES{
+        0, 1, 2, 3, 4, 5, 6, 7, -8, -7, -6, -5, -4, -3, -2, -1,
+    };
 
     const std::size_t sample_count = (size / FRAME_LEN) * SAMPLES_PER_FRAME;
     const std::size_t ret_size =

--- a/src/audio_core/codec.h
+++ b/src/audio_core/codec.h
@@ -38,7 +38,7 @@ using ADPCM_Coeff = std::array<s16, 16>;
  * @param state ADPCM state, this is updated with new state
  * @return Decoded stereo signed PCM16 data, sample_count in length
  */
-std::vector<s16> DecodeADPCM(const u8* const data, std::size_t size, const ADPCM_Coeff& coeff,
+std::vector<s16> DecodeADPCM(const u8* data, std::size_t size, const ADPCM_Coeff& coeff,
                              ADPCMState& state);
 
 }; // namespace AudioCore::Codec

--- a/src/audio_core/command_generator.cpp
+++ b/src/audio_core/command_generator.cpp
@@ -726,8 +726,9 @@ s32 CommandGenerator::DecodeAdpcm(ServerVoiceInfo& voice_info, VoiceState& dsp_s
         return 0;
     }
 
-    constexpr std::array<int, 16> SIGNED_NIBBLES = {
-        {0, 1, 2, 3, 4, 5, 6, 7, -8, -7, -6, -5, -4, -3, -2, -1}};
+    static constexpr std::array<int, 16> SIGNED_NIBBLES{
+        0, 1, 2, 3, 4, 5, 6, 7, -8, -7, -6, -5, -4, -3, -2, -1,
+    };
 
     constexpr std::size_t FRAME_LEN = 8;
     constexpr std::size_t NIBBLES_PER_SAMPLE = 16;


### PR DESCRIPTION
Allows compilers to elide needing to push these values on the stack every time the function is called.