### PR TITLE
frontend/controller: Eliminate dependency on the global system instance

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -120,7 +120,7 @@ public:
      * Gets the instance of the System singleton class.
      * @returns Reference to the instance of the System singleton class.
      */
-    static System& GetInstance() {
+    [[deprecated("Use of the global system instance is deprecated")]] static System& GetInstance() {
         return s_instance;
     }
 

--- a/src/core/frontend/applets/controller.cpp
+++ b/src/core/frontend/applets/controller.cpp
@@ -4,7 +4,6 @@
 
 #include "common/assert.h"
 #include "common/logging/log.h"
-#include "core/core.h"
 #include "core/frontend/applets/controller.h"
 #include "core/hle/service/hid/controllers/npad.h"
 #include "core/hle/service/hid/hid.h"
@@ -14,6 +13,9 @@ namespace Core::Frontend {
 
 ControllerApplet::~ControllerApplet() = default;
 
+DefaultControllerApplet::DefaultControllerApplet(Service::SM::ServiceManager& service_manager_)
+    : service_manager{service_manager_} {}
+
 DefaultControllerApplet::~DefaultControllerApplet() = default;
 
 void DefaultControllerApplet::ReconfigureControllers(std::function<void()> callback,
@@ -21,9 +23,7 @@ void DefaultControllerApplet::ReconfigureControllers(std::function<void()> callb
     LOG_INFO(Service_HID, "called, deducing the best configuration based on the given parameters!");
 
     auto& npad =
-        Core::System::GetInstance()
-            .ServiceManager()
-            .GetService<Service::HID::Hid>("hid")
+        service_manager.GetService<Service::HID::Hid>("hid")
             ->GetAppletResource()
             ->GetController<Service::HID::Controller_NPad>(Service::HID::HidController::NPad);
 

--- a/src/core/frontend/applets/controller.h
+++ b/src/core/frontend/applets/controller.h
@@ -8,6 +8,10 @@
 
 #include "common/common_types.h"
 
+namespace Service::SM {
+class ServiceManager;
+}
+
 namespace Core::Frontend {
 
 using BorderColor = std::array<u8, 4>;
@@ -39,10 +43,14 @@ public:
 
 class DefaultControllerApplet final : public ControllerApplet {
 public:
+    explicit DefaultControllerApplet(Service::SM::ServiceManager& service_manager_);
     ~DefaultControllerApplet() override;
 
     void ReconfigureControllers(std::function<void()> callback,
                                 ControllerParameters parameters) const override;
+
+private:
+    Service::SM::ServiceManager& service_manager;
 };
 
 } // namespace Core::Frontend

--- a/src/core/hle/service/am/applets/applets.cpp
+++ b/src/core/hle/service/am/applets/applets.cpp
@@ -206,7 +206,8 @@ void AppletManager::SetDefaultAppletFrontendSet() {
 
 void AppletManager::SetDefaultAppletsIfMissing() {
     if (frontend.controller == nullptr) {
-        frontend.controller = std::make_unique<Core::Frontend::DefaultControllerApplet>();
+        frontend.controller =
+            std::make_unique<Core::Frontend::DefaultControllerApplet>(system.ServiceManager());
     }
 
     if (frontend.e_commerce == nullptr) {


### PR DESCRIPTION
While we're at it, we can mark the global system instance function as deprecated.