### PR TITLE
common/wall_clock: Add virtual destructors

### DIFF
--- a/src/common/wall_clock.cpp
+++ b/src/common/wall_clock.cpp
@@ -15,7 +15,7 @@ namespace Common {
 using base_timer = std::chrono::steady_clock;
 using base_time_point = std::chrono::time_point<base_timer>;
 
-class StandardWallClock : public WallClock {
+class StandardWallClock final : public WallClock {
 public:
     StandardWallClock(u64 emulated_cpu_frequency, u64 emulated_clock_frequency)
         : WallClock(emulated_cpu_frequency, emulated_clock_frequency, false) {

--- a/src/common/wall_clock.h
+++ b/src/common/wall_clock.h
@@ -13,6 +13,8 @@ namespace Common {
 
 class WallClock {
 public:
+    virtual ~WallClock() = default;
+
     /// Returns current wall time in nanoseconds
     [[nodiscard]] virtual std::chrono::nanoseconds GetTimeNS() = 0;
 

--- a/src/common/x64/native_clock.h
+++ b/src/common/x64/native_clock.h
@@ -12,7 +12,7 @@
 namespace Common {
 
 namespace X64 {
-class NativeClock : public WallClock {
+class NativeClock final : public WallClock {
 public:
     NativeClock(u64 emulated_cpu_frequency, u64 emulated_clock_frequency, u64 rtsc_frequency);
 


### PR DESCRIPTION
From -fsanitize=address, this code wasn't calling the proper destructor.
Adding virtual destructors for each inherited class and the base class
fixes this bug.

While we are at it, mark the classes as final.