### PR TITLE
Remove ext_extended_dynamic_state blacklist

### DIFF
--- a/src/video_core/renderer_vulkan/vk_device.cpp
+++ b/src/video_core/renderer_vulkan/vk_device.cpp
@@ -388,14 +388,6 @@ bool VKDevice::Create() {
 
     CollectTelemetryParameters();
 
-    if (ext_extended_dynamic_state && driver_id == VK_DRIVER_ID_AMD_PROPRIETARY_KHR) {
-        // AMD's proprietary driver supports VK_EXT_extended_dynamic_state but the <stride> field
-        // seems to be bugged. Blacklisting it for now.
-        LOG_WARNING(Render_Vulkan,
-                    "Blacklisting AMD proprietary from VK_EXT_extended_dynamic_state");
-        ext_extended_dynamic_state = false;
-    }
-
     graphics_queue = logical.GetQueue(graphics_family);
     present_queue = logical.GetQueue(present_family);
 


### PR DESCRIPTION
Latest AMD 20.9.2 driver fixed this, there's no reason to keep it blocked, as the previous stable signed driver release doesn't include the extension.