### PR TITLE
capsrv: Stub 3 variants of SetShimLibraryVersion

### DIFF
--- a/src/core/hle/service/caps/caps_c.cpp
+++ b/src/core/hle/service/caps/caps_c.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/logging/log.h"
+#include "core/hle/ipc_helpers.h"
 #include "core/hle/service/caps/caps_c.h"
 
 namespace Service::Capture {
@@ -47,7 +49,7 @@ CAPS_C::CAPS_C() : ServiceFramework("caps:c") {
     static const FunctionInfo functions[] = {
         {1, nullptr, "CaptureRawImage"},
         {2, nullptr, "CaptureRawImageWithTimeout"},
-        {33, nullptr, "Unknown33"},
+        {33, &CAPS_C::SetShimLibraryVersion, "SetShimLibraryVersion"},
         {1001, nullptr, "RequestTakingScreenShot"},
         {1002, nullptr, "RequestTakingScreenShotWithTimeout"},
         {1011, nullptr, "NotifyTakingScreenShotRefused"},
@@ -71,5 +73,17 @@ CAPS_C::CAPS_C() : ServiceFramework("caps:c") {
 }
 
 CAPS_C::~CAPS_C() = default;
+
+void CAPS_C::SetShimLibraryVersion(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto library_version{rp.Pop<u64>()};
+    const auto applet_resource_user_id{rp.Pop<u64>()};
+
+    LOG_WARNING(Service_Capture, "(STUBBED) called. library_version={}, applet_resource_user_id={}",
+                library_version, applet_resource_user_id);
+
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(RESULT_SUCCESS);
+}
 
 } // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_c.h
+++ b/src/core/hle/service/caps/caps_c.h
@@ -16,6 +16,9 @@ class CAPS_C final : public ServiceFramework<CAPS_C> {
 public:
     explicit CAPS_C();
     ~CAPS_C() override;
+
+private:
+    void SetShimLibraryVersion(Kernel::HLERequestContext& ctx);
 };
 
 } // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_su.cpp
+++ b/src/core/hle/service/caps/caps_su.cpp
@@ -25,7 +25,12 @@ CAPS_SU::CAPS_SU() : ServiceFramework("caps:su") {
 CAPS_SU::~CAPS_SU() = default;
 
 void CAPS_SU::SetShimLibraryVersion(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_Capture, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    const auto library_version{rp.Pop<u64>()};
+    const auto applet_resource_user_id{rp.Pop<u64>()};
+
+    LOG_WARNING(Service_Capture, "(STUBBED) called. library_version={}, applet_resource_user_id={}",
+                library_version, applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/caps/caps_u.cpp
+++ b/src/core/hle/service/caps/caps_u.cpp
@@ -31,8 +31,7 @@ public:
 CAPS_U::CAPS_U() : ServiceFramework("caps:u") {
     // clang-format off
     static const FunctionInfo functions[] = {
-        {31, nullptr, "GetShimLibraryVersion"},
-        {32, nullptr, "SetShimLibraryVersion"},
+        {32, &CAPS_U::SetShimLibraryVersion, "SetShimLibraryVersion"},
         {102, &CAPS_U::GetAlbumContentsFileListForApplication, "GetAlbumContentsFileListForApplication"},
         {103, nullptr, "DeleteAlbumContentsFileForApplication"},
         {104, nullptr, "GetAlbumContentsFileSizeForApplication"},
@@ -52,6 +51,18 @@ CAPS_U::CAPS_U() : ServiceFramework("caps:u") {
 }
 
 CAPS_U::~CAPS_U() = default;
+
+void CAPS_U::SetShimLibraryVersion(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto library_version{rp.Pop<u64>()};
+    const auto applet_resource_user_id{rp.Pop<u64>()};
+
+    LOG_WARNING(Service_Capture, "(STUBBED) called. library_version={}, applet_resource_user_id={}",
+                library_version, applet_resource_user_id);
+
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(RESULT_SUCCESS);
+}
 
 void CAPS_U::GetAlbumContentsFileListForApplication(Kernel::HLERequestContext& ctx) {
     // Takes a type-0x6 output buffer containing an array of ApplicationAlbumFileEntry, a PID, an

--- a/src/core/hle/service/caps/caps_u.h
+++ b/src/core/hle/service/caps/caps_u.h
@@ -18,6 +18,7 @@ public:
     ~CAPS_U() override;
 
 private:
+    void SetShimLibraryVersion(Kernel::HLERequestContext& ctx);
     void GetAlbumContentsFileListForApplication(Kernel::HLERequestContext& ctx);
 };
 


### PR DESCRIPTION
caps_su/u's SetShimLibraryVersion - Used in Super Smash Bros. Ultimate
caps_c's SetShimLibraryVersion - Used by caps_su's SetShimLibraryVersion (according to switchbrew)