### PR TITLE
HID: Only use inputs corresponding to controller type

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -260,7 +260,7 @@ void Controller_NPad::OnRelease() {}
 
 void Controller_NPad::RequestPadStateUpdate(u32 npad_id) {
     const auto controller_idx = NPadIdToIndex(npad_id);
-    [[maybe_unused]] const auto controller_type = connected_controllers[controller_idx].type;
+    const auto controller_type = connected_controllers[controller_idx].type;
     if (!connected_controllers[controller_idx].is_connected) {
         return;
     }
@@ -276,54 +276,63 @@ void Controller_NPad::RequestPadStateUpdate(u32 npad_id) {
         analog_state[static_cast<std::size_t>(JoystickId::Joystick_Right)]->GetStatus();
 
     using namespace Settings::NativeButton;
-    pad_state.a.Assign(button_state[A - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.b.Assign(button_state[B - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.x.Assign(button_state[X - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.y.Assign(button_state[Y - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.l_stick.Assign(button_state[LStick - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.r_stick.Assign(button_state[RStick - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.l.Assign(button_state[L - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.r.Assign(button_state[R - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.zl.Assign(button_state[ZL - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.zr.Assign(button_state[ZR - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.plus.Assign(button_state[Plus - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.minus.Assign(button_state[Minus - BUTTON_HID_BEGIN]->GetStatus());
+    if (controller_type != NPadControllerType::JoyLeft) {
+        pad_state.a.Assign(button_state[A - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.b.Assign(button_state[B - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.x.Assign(button_state[X - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.y.Assign(button_state[Y - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.r_stick.Assign(button_state[RStick - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.r.Assign(button_state[R - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.zr.Assign(button_state[ZR - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.plus.Assign(button_state[Plus - BUTTON_HID_BEGIN]->GetStatus());
 
-    pad_state.d_left.Assign(button_state[DLeft - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.d_up.Assign(button_state[DUp - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.d_right.Assign(button_state[DRight - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.d_down.Assign(button_state[DDown - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.r_stick_right.Assign(
+            analog_state[static_cast<std::size_t>(JoystickId::Joystick_Right)]
+                ->GetAnalogDirectionStatus(Input::AnalogDirection::RIGHT));
+        pad_state.r_stick_left.Assign(
+            analog_state[static_cast<std::size_t>(JoystickId::Joystick_Right)]
+                ->GetAnalogDirectionStatus(Input::AnalogDirection::LEFT));
+        pad_state.r_stick_up.Assign(
+            analog_state[static_cast<std::size_t>(JoystickId::Joystick_Right)]
+                ->GetAnalogDirectionStatus(Input::AnalogDirection::UP));
+        pad_state.r_stick_down.Assign(
+            analog_state[static_cast<std::size_t>(JoystickId::Joystick_Right)]
+                ->GetAnalogDirectionStatus(Input::AnalogDirection::DOWN));
+        rstick_entry.x = static_cast<s32>(stick_r_x_f * HID_JOYSTICK_MAX);
+        rstick_entry.y = static_cast<s32>(stick_r_y_f * HID_JOYSTICK_MAX);
+    }
 
-    pad_state.l_stick_right.Assign(
-        analog_state[static_cast<std::size_t>(JoystickId::Joystick_Left)]->GetAnalogDirectionStatus(
-            Input::AnalogDirection::RIGHT));
-    pad_state.l_stick_left.Assign(
-        analog_state[static_cast<std::size_t>(JoystickId::Joystick_Left)]->GetAnalogDirectionStatus(
-            Input::AnalogDirection::LEFT));
-    pad_state.l_stick_up.Assign(
-        analog_state[static_cast<std::size_t>(JoystickId::Joystick_Left)]->GetAnalogDirectionStatus(
-            Input::AnalogDirection::UP));
-    pad_state.l_stick_down.Assign(
-        analog_state[static_cast<std::size_t>(JoystickId::Joystick_Left)]->GetAnalogDirectionStatus(
-            Input::AnalogDirection::DOWN));
+    if (controller_type != NPadControllerType::JoyRight) {
+        pad_state.d_left.Assign(button_state[DLeft - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.d_up.Assign(button_state[DUp - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.d_right.Assign(button_state[DRight - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.d_down.Assign(button_state[DDown - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.l_stick.Assign(button_state[LStick - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.l.Assign(button_state[L - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.zl.Assign(button_state[ZL - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.minus.Assign(button_state[Minus - BUTTON_HID_BEGIN]->GetStatus());
 
-    pad_state.r_stick_right.Assign(
-        analog_state[static_cast<std::size_t>(JoystickId::Joystick_Right)]
-            ->GetAnalogDirectionStatus(Input::AnalogDirection::RIGHT));
-    pad_state.r_stick_left.Assign(analog_state[static_cast<std::size_t>(JoystickId::Joystick_Right)]
-                                      ->GetAnalogDirectionStatus(Input::AnalogDirection::LEFT));
-    pad_state.r_stick_up.Assign(analog_state[static_cast<std::size_t>(JoystickId::Joystick_Right)]
-                                    ->GetAnalogDirectionStatus(Input::AnalogDirection::UP));
-    pad_state.r_stick_down.Assign(analog_state[static_cast<std::size_t>(JoystickId::Joystick_Right)]
-                                      ->GetAnalogDirectionStatus(Input::AnalogDirection::DOWN));
+        pad_state.l_stick_right.Assign(
+            analog_state[static_cast<std::size_t>(JoystickId::Joystick_Left)]
+                ->GetAnalogDirectionStatus(Input::AnalogDirection::RIGHT));
+        pad_state.l_stick_left.Assign(
+            analog_state[static_cast<std::size_t>(JoystickId::Joystick_Left)]
+                ->GetAnalogDirectionStatus(Input::AnalogDirection::LEFT));
+        pad_state.l_stick_up.Assign(
+            analog_state[static_cast<std::size_t>(JoystickId::Joystick_Left)]
+                ->GetAnalogDirectionStatus(Input::AnalogDirection::UP));
+        pad_state.l_stick_down.Assign(
+            analog_state[static_cast<std::size_t>(JoystickId::Joystick_Left)]
+                ->GetAnalogDirectionStatus(Input::AnalogDirection::DOWN));
+        lstick_entry.x = static_cast<s32>(stick_l_x_f * HID_JOYSTICK_MAX);
+        lstick_entry.y = static_cast<s32>(stick_l_y_f * HID_JOYSTICK_MAX);
+    }
 
-    pad_state.left_sl.Assign(button_state[SL - BUTTON_HID_BEGIN]->GetStatus());
-    pad_state.left_sr.Assign(button_state[SR - BUTTON_HID_BEGIN]->GetStatus());
-
-    lstick_entry.x = static_cast<s32>(stick_l_x_f * HID_JOYSTICK_MAX);
-    lstick_entry.y = static_cast<s32>(stick_l_y_f * HID_JOYSTICK_MAX);
-    rstick_entry.x = static_cast<s32>(stick_r_x_f * HID_JOYSTICK_MAX);
-    rstick_entry.y = static_cast<s32>(stick_r_y_f * HID_JOYSTICK_MAX);
+    if (controller_type == NPadControllerType::JoyLeft ||
+        controller_type == NPadControllerType::JoyRight) {
+        pad_state.left_sl.Assign(button_state[SL - BUTTON_HID_BEGIN]->GetStatus());
+        pad_state.left_sr.Assign(button_state[SR - BUTTON_HID_BEGIN]->GetStatus());
+    }
 }
 
 void Controller_NPad::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,


### PR DESCRIPTION
This prevents using buttons that aren't supposed to exist in the controller.

Example:
You map all buttons xbox controller as a pro controller then change the controller type to left joycon. 
On SSBU you can still use A,X,Y,Z and right stick of the xbox controller.