### PR TITLE
HID: Fixes rumble only in one controller

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -675,12 +675,12 @@ void Controller_NPad::VibrateController(const std::vector<u32>& controllers,
     bool success = true;
     if (vibrations.size() == 1) {
         for (std::size_t i = 0; i < controllers.size(); ++i) {
-            std::size_t controller = (controllers[i] >> 8) & 0x7;
+            const std::size_t controller = (controllers[i] >> 8) & 0x7;
             success = success && VibratePhysicalController(controller, vibrations[0]);
         }
     } else {
         for (std::size_t i = 0; i < vibrations.size(); ++i) {
-            std::size_t controller = i >> 1;
+            const std::size_t controller = i / 2;
             success = success && VibratePhysicalController(controller, vibrations[i]);
         }
     }
@@ -696,11 +696,7 @@ bool Controller_NPad::VibratePhysicalController(std::size_t controller, Vibratio
     using namespace Settings::NativeButton;
     const auto& button_state = buttons[controller];
     const auto controller_type = connected_controllers[controller].type;
-    auto use_button = A;
-    switch (controller_type) {
-    case NPadControllerType::JoyLeft:
-        use_button = DDown;
-    }
+    const auto use_button = controller_type == NPadControllerType::JoyLeft ? DDown : A;
     if (button_state[use_button - BUTTON_HID_BEGIN]) {
         return !button_state[use_button - BUTTON_HID_BEGIN]->SetRumblePlay(
             vibration.amp_high, vibration.amp_low, vibration.freq_high, vibration.freq_low);

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -128,7 +128,7 @@ public:
     void VibrateController(const std::vector<u32>& controllers,
                            const std::vector<Vibration>& vibrations);
 
-    // Called from VibrateController and Vibrates a specific controller
+    // Vibrates a specific controller
     bool VibratePhysicalController(std::size_t controllers, Vibration vibrations);
 
     Vibration GetLastVibration() const;

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -128,6 +128,9 @@ public:
     void VibrateController(const std::vector<u32>& controllers,
                            const std::vector<Vibration>& vibrations);
 
+    // Called from VibrateController and Vibrates a specific controller
+    bool VibratePhysicalController(std::size_t controllers, Vibration vibrations);
+
     Vibration GetLastVibration() const;
 
     std::shared_ptr<Kernel::ReadableEvent> GetStyleSetChangedEvent(u32 npad_id) const;

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -129,7 +129,7 @@ public:
                            const std::vector<Vibration>& vibrations);
 
     // Vibrates a specific controller
-    bool VibratePhysicalController(std::size_t controllers, Vibration vibrations);
+    bool VibratePhysicalController(std::size_t controller, Vibration vibration);
 
     Vibration GetLastVibration() const;
 


### PR DESCRIPTION
Fixed regression by one of the last stages of #4291.
Handles multiple vibrations in one command fixing vibration on 1-2 switch.
If a controller is mapped as a left joycon it will switch the button to DDown. 