### PR TITLE
Filesystem: Implement OpenDataStorageWithProgramIndex

### DIFF
--- a/src/core/hle/service/filesystem/fsp_srv.h
+++ b/src/core/hle/service/filesystem/fsp_srv.h
@@ -49,6 +49,7 @@ private:
     void OpenDataStorageByCurrentProcess(Kernel::HLERequestContext& ctx);
     void OpenDataStorageByDataId(Kernel::HLERequestContext& ctx);
     void OpenPatchDataStorageByCurrentProcess(Kernel::HLERequestContext& ctx);
+    void OpenDataStorageWithProgramIndex(Kernel::HLERequestContext& ctx);
     void SetGlobalAccessLogMode(Kernel::HLERequestContext& ctx);
     void GetGlobalAccessLogMode(Kernel::HLERequestContext& ctx);
     void OutputAccessLogToSdCard(Kernel::HLERequestContext& ctx);


### PR DESCRIPTION
Program_index returned 0x00. Instead I used the current process to load the file contents. Updated the names of a few functions to match switchbrew.

used by RollerCoaster Tycoon 3: Complete Edition