### PR TITLE
audio_core/CMakeLists: Make warnings consistent with core

### DIFF
--- a/src/audio_core/CMakeLists.txt
+++ b/src/audio_core/CMakeLists.txt
@@ -46,10 +46,13 @@ create_target_directory_groups(audio_core)
 
 if (NOT MSVC)
     target_compile_options(audio_core PRIVATE
+        -Werror=conversion
         -Werror=ignored-qualifiers
         -Werror=implicit-fallthrough
         -Werror=reorder
         -Werror=sign-compare
+        -Werror=unused-but-set-parameter
+        -Werror=unused-but-set-variable
         -Werror=unused-variable
     )
 endif()

--- a/src/audio_core/algorithm/filter.cpp
+++ b/src/audio_core/algorithm/filter.cpp
@@ -55,7 +55,8 @@ void Filter::Process(std::vector<s16>& signal) {
 /// @param total_count The total number of biquads to be cascaded.
 /// @param index 0-index of the biquad to calculate the Q value for.
 static double CascadingBiquadQ(std::size_t total_count, std::size_t index) {
-    const double pole = M_PI * (2 * index + 1) / (4.0 * total_count);
+    const auto pole =
+        M_PI * static_cast<double>(2 * index + 1) / (4.0 * static_cast<double>(total_count));
     return 1.0 / (2.0 * std::cos(pole));
 }
 

--- a/src/audio_core/algorithm/interpolate.cpp
+++ b/src/audio_core/algorithm/interpolate.cpp
@@ -146,7 +146,7 @@ std::vector<s16> Interpolate(InterpolationState& state, std::vector<s16> input, 
         return {};
 
     if (ratio <= 0) {
-        LOG_CRITICAL(Audio, "Nonsensical interpolation ratio {}", ratio);
+        LOG_ERROR(Audio, "Nonsensical interpolation ratio {}", ratio);
         return input;
     }
 
@@ -164,7 +164,8 @@ std::vector<s16> Interpolate(InterpolationState& state, std::vector<s16> input, 
     const std::size_t num_frames{input.size() / 2};
 
     std::vector<s16> output;
-    output.reserve(static_cast<std::size_t>(input.size() / ratio + InterpolationState::taps));
+    output.reserve(static_cast<std::size_t>(static_cast<double>(input.size()) / ratio +
+                                            InterpolationState::taps));
 
     for (std::size_t frame{}; frame < num_frames; ++frame) {
         const std::size_t lut_index{(state.fraction >> 8) * InterpolationState::taps};

--- a/src/audio_core/command_generator.cpp
+++ b/src/audio_core/command_generator.cpp
@@ -793,7 +793,6 @@ s32 CommandGenerator::DecodeAdpcm(ServerVoiceInfo& voice_info, VoiceState& dsp_s
             // Decode entire frame
             if (remaining_samples >= static_cast<int>(SAMPLES_PER_FRAME)) {
                 for (std::size_t i = 0; i < SAMPLES_PER_FRAME / 2; i++) {
-
                     // Sample 1
                     const s32 s0 = SIGNED_NIBBLES[buffer[buffer_offset] >> 4];
                     const s32 s1 = SIGNED_NIBBLES[buffer[buffer_offset++] & 0xf];
@@ -802,7 +801,7 @@ s32 CommandGenerator::DecodeAdpcm(ServerVoiceInfo& voice_info, VoiceState& dsp_s
                     sample_buffer[cur_mix_offset++] = sample_1;
                     sample_buffer[cur_mix_offset++] = sample_2;
                 }
-                remaining_samples -= SAMPLES_PER_FRAME;
+                remaining_samples -= static_cast<int>(SAMPLES_PER_FRAME);
                 position_in_frame += SAMPLES_PER_FRAME;
                 continue;
             }

--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -93,8 +93,10 @@ public:
                 constexpr s32 clev{707}; // center mixing level coefficient
                 constexpr s32 slev{707}; // surround mixing level coefficient
 
-                buf.push_back(left + (clev * center / 1000) + (slev * surround_left / 1000));
-                buf.push_back(right + (clev * center / 1000) + (slev * surround_right / 1000));
+                buf.push_back(static_cast<s16>(left + (clev * center / 1000) +
+                                               (slev * surround_left / 1000)));
+                buf.push_back(static_cast<s16>(right + (clev * center / 1000) +
+                                               (slev * surround_right / 1000)));
             }
             queue.Push(buf);
             return;

--- a/src/audio_core/voice_context.cpp
+++ b/src/audio_core/voice_context.cpp
@@ -128,7 +128,10 @@ void ServerVoiceInfo::UpdateParameters(const VoiceInfo::InParams& voice_in,
     in_params.wave_buffer_count = voice_in.wave_buffer_count;
     in_params.wave_bufffer_head = voice_in.wave_buffer_head;
     if (behavior_info.IsFlushVoiceWaveBuffersSupported()) {
-        in_params.wave_buffer_flush_request_count += voice_in.wave_buffer_flush_request_count;
+        const auto in_request_count = in_params.wave_buffer_flush_request_count;
+        const auto voice_request_count = voice_in.wave_buffer_flush_request_count;
+        in_params.wave_buffer_flush_request_count =
+            static_cast<u8>(in_request_count + voice_request_count);
     }
     in_params.mix_id = voice_in.mix_id;
     if (behavior_info.IsSplitterSupported()) {


### PR DESCRIPTION
Normalizes the warnings shared between audio_core and core.