### PR TITLE
core: Fix clang build

### DIFF
--- a/externals/microprofile/microprofile.h
+++ b/externals/microprofile/microprofile.h
@@ -857,7 +857,7 @@ inline int64_t MicroProfileLogTickDifference(MicroProfileLogEntry Start, MicroPr
 {
     uint64_t nStart = Start;
     uint64_t nEnd = End;
-    int64_t nDifference = ((nEnd<<16) - (nStart<<16));
+    auto nDifference = static_cast<int64_t>((nEnd << 16) - (nStart << 16));
     return nDifference >> 16;
 }
 
@@ -868,7 +868,7 @@ inline int64_t MicroProfileLogGetTick(MicroProfileLogEntry e)
 
 inline int64_t MicroProfileLogSetTick(MicroProfileLogEntry e, int64_t nTick)
 {
-    return (MP_LOG_TICK_MASK & nTick) | (e & ~MP_LOG_TICK_MASK);
+    return static_cast<int64_t>((MP_LOG_TICK_MASK & static_cast<uint64_t>(nTick)) | (e & static_cast<uint64_t>(~MP_LOG_TICK_MASK)));
 }
 
 template<typename T>

--- a/src/audio_core/CMakeLists.txt
+++ b/src/audio_core/CMakeLists.txt
@@ -51,8 +51,9 @@ if (NOT MSVC)
         -Werror=implicit-fallthrough
         -Werror=reorder
         -Werror=sign-compare
-        -Werror=unused-but-set-parameter
-        -Werror=unused-but-set-variable
+        -Werror=sign-conversion
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-variable>
         -Werror=unused-variable
     )
 endif()

--- a/src/audio_core/algorithm/interpolate.cpp
+++ b/src/audio_core/algorithm/interpolate.cpp
@@ -167,8 +167,8 @@ std::vector<s16> Interpolate(InterpolationState& state, std::vector<s16> input, 
     output.reserve(static_cast<std::size_t>(static_cast<double>(input.size()) / ratio +
                                             InterpolationState::taps));
 
-    for (std::size_t frame{}; frame < num_frames; ++frame) {
-        const std::size_t lut_index{(state.fraction >> 8) * InterpolationState::taps};
+    for (std::size_t frame = 0; frame < num_frames; ++frame) {
+        const auto lut_index{static_cast<size_t>(state.fraction >> 8) * InterpolationState::taps};
 
         std::rotate(state.history.begin(), state.history.end() - 1, state.history.end());
         state.history[0][0] = input[frame * 2 + 0];
@@ -225,7 +225,7 @@ void Resample(s32* output, const s32* input, s32 pitch, s32& fraction, std::size
 
         output[i] = (l0 * s0 + l1 * s1 + l2 * s2 + l3 * s3) >> 15;
         fraction += pitch;
-        index += (fraction >> 15);
+        index += static_cast<size_t>(fraction >> 15);
         fraction &= 0x7fff;
     }
 }

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -187,8 +187,8 @@ void AudioRenderer::QueueMixedBuffer(Buffer::Tag tag) {
         const auto& in_params = final_mix.GetInParams();
         std::vector<s32*> mix_buffers(channel_count);
         for (std::size_t i = 0; i < channel_count; i++) {
-            mix_buffers[i] =
-                command_generator.GetMixBuffer(in_params.buffer_offset + buffer_offsets[i]);
+            mix_buffers[i] = command_generator.GetMixBuffer(
+                static_cast<u32>(in_params.buffer_offset) + buffer_offsets[i]);
         }
 
         for (std::size_t i = 0; i < BUFFER_SIZE; i++) {

--- a/src/audio_core/codec.cpp
+++ b/src/audio_core/codec.cpp
@@ -32,7 +32,7 @@ std::vector<s16> DecodeADPCM(const u8* const data, std::size_t size, const ADPCM
     for (std::size_t framei = 0; framei < NUM_FRAMES; framei++) {
         const int frame_header = data[framei * FRAME_LEN];
         const int scale = 1 << (frame_header & 0xF);
-        const int idx = (frame_header >> 4) & 0x7;
+        const auto idx = static_cast<size_t>((frame_header >> 4) & 0x7);
 
         // Coefficients are fixed point with 11 bits fractional part.
         const int coef1 = coeff[idx * 2 + 0];
@@ -57,11 +57,11 @@ std::vector<s16> DecodeADPCM(const u8* const data, std::size_t size, const ADPCM
         std::size_t outputi = framei * SAMPLES_PER_FRAME;
         std::size_t datai = framei * FRAME_LEN + 1;
         for (std::size_t i = 0; i < SAMPLES_PER_FRAME && outputi < sample_count; i += 2) {
-            const s16 sample1 = decode_sample(SIGNED_NIBBLES[data[datai] >> 4]);
+            const s16 sample1 = decode_sample(SIGNED_NIBBLES[static_cast<u32>(data[datai] >> 4)]);
             ret[outputi] = sample1;
             outputi++;
 
-            const s16 sample2 = decode_sample(SIGNED_NIBBLES[data[datai] & 0xF]);
+            const s16 sample2 = decode_sample(SIGNED_NIBBLES[static_cast<u32>(data[datai] & 0xF)]);
             ret[outputi] = sample2;
             outputi++;
 

--- a/src/audio_core/command_generator.h
+++ b/src/audio_core/command_generator.h
@@ -50,12 +50,12 @@ public:
 private:
     void GenerateDataSourceCommand(ServerVoiceInfo& voice_info, VoiceState& dsp_state, s32 channel);
     void GenerateBiquadFilterCommandForVoice(ServerVoiceInfo& voice_info, VoiceState& dsp_state,
-                                             s32 mix_buffer_count, s32 channel);
+                                             u32 mix_buffer_count, s32 channel);
     void GenerateVolumeRampCommand(float last_volume, float current_volume, s32 channel,
                                    s32 node_id);
     void GenerateVoiceMixCommand(const MixVolumeBuffer& mix_volumes,
                                  const MixVolumeBuffer& last_mix_volumes, VoiceState& dsp_state,
-                                 s32 mix_buffer_offset, s32 mix_buffer_count, s32 voice_index,
+                                 u32 mix_buffer_offset, u32 mix_buffer_count, u32 voice_index,
                                  s32 node_id);
     void GenerateSubMixCommand(ServerMixInfo& mix_info);
     void GenerateMixCommands(ServerMixInfo& mix_info);

--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -202,7 +202,7 @@ long CubebSinkStream::DataCallback(cubeb_stream* stream, void* user_data, const 
     }
 
     const std::size_t num_channels = impl->GetNumChannels();
-    const std::size_t samples_to_write = num_channels * num_frames;
+    const std::size_t samples_to_write = num_channels * static_cast<u64>(num_frames);
     std::size_t samples_written;
 
     /*

--- a/src/audio_core/cubeb_sink.h
+++ b/src/audio_core/cubeb_sink.h
@@ -27,7 +27,7 @@ private:
     std::vector<SinkStreamPtr> sink_streams;
 
 #ifdef _WIN32
-    u32 com_init_result = 0;
+    s32 com_init_result = 0;
 #endif
 };
 

--- a/src/audio_core/info_updater.cpp
+++ b/src/audio_core/info_updater.cpp
@@ -350,7 +350,7 @@ ResultCode InfoUpdater::UpdateMixes(MixContext& mix_context, std::size_t mix_buf
         std::size_t total_buffer_count{};
         for (std::size_t i = 0; i < mix_count; i++) {
             const auto& in = mix_in_params[i];
-            total_buffer_count += in.buffer_count;
+            total_buffer_count += static_cast<size_t>(in.buffer_count);
             if (static_cast<std::size_t>(in.dest_mix_id) > mix_count &&
                 in.dest_mix_id != AudioCommon::NO_MIX && in.mix_id != AudioCommon::FINAL_MIX) {
                 LOG_ERROR(
@@ -379,7 +379,7 @@ ResultCode InfoUpdater::UpdateMixes(MixContext& mix_context, std::size_t mix_buf
         const auto& mix_in = mix_in_params[i];
         std::size_t target_mix{};
         if (behavior_info.IsMixInParameterDirtyOnlyUpdateSupported()) {
-            target_mix = mix_in.mix_id;
+            target_mix = static_cast<size_t>(mix_in.mix_id);
         } else {
             // Non dirty supported games just use i instead of the actual mix_id
             target_mix = i;

--- a/src/audio_core/mix_context.cpp
+++ b/src/audio_core/mix_context.cpp
@@ -62,7 +62,7 @@ void MixContext::UpdateDistancesFromFinalMix() {
                 distance_to_final_mix = AudioCommon::NO_FINAL_MIX;
                 break;
             } else {
-                const auto& dest_mix = GetInfo(mix_id);
+                const auto& dest_mix = GetInfo(static_cast<u32>(mix_id));
                 const auto dest_mix_distance = dest_mix.GetInParams().final_mix_distance;
 
                 if (dest_mix_distance == AudioCommon::NO_FINAL_MIX) {
@@ -129,7 +129,7 @@ bool MixContext::TsortInfo(SplitterContext& splitter_context) {
     std::size_t info_id{};
     for (auto itr = sorted_list.rbegin(); itr != sorted_list.rend(); ++itr) {
         // Set our sorted info
-        sorted_info[info_id++] = &GetInfo(*itr);
+        sorted_info[info_id++] = &GetInfo(static_cast<u32>(*itr));
     }
 
     // Calculate the mix buffer offset
@@ -218,7 +218,8 @@ bool ServerMixInfo::Update(EdgeMatrix& edge_matrix, const MixInfo::InParams& mix
     for (std::size_t i = 0; i < effect_count; i++) {
         auto* effect_info = effect_context.GetInfo(i);
         if (effect_info->GetMixID() == in_params.mix_id) {
-            effect_processing_order[effect_info->GetProcessingOrder()] = static_cast<s32>(i);
+            const auto processing_order = static_cast<u32>(effect_info->GetProcessingOrder());
+            effect_processing_order[processing_order] = static_cast<s32>(i);
         }
     }
 
@@ -265,7 +266,7 @@ bool ServerMixInfo::UpdateConnection(EdgeMatrix& edge_matrix, const MixInfo::InP
     if (in_params.dest_mix_id == mix_in.dest_mix_id &&
         in_params.splitter_id == mix_in.splitter_id &&
         ((in_params.splitter_id == AudioCommon::NO_SPLITTER) ||
-         !splitter_context.GetInfo(in_params.splitter_id).HasNewConnection())) {
+         !splitter_context.GetInfo(static_cast<u32>(in_params.splitter_id)).HasNewConnection())) {
         return false;
     }
     // Remove current edges for mix id
@@ -275,11 +276,11 @@ bool ServerMixInfo::UpdateConnection(EdgeMatrix& edge_matrix, const MixInfo::InP
         edge_matrix.Connect(in_params.mix_id, mix_in.dest_mix_id);
     } else if (mix_in.splitter_id != AudioCommon::NO_SPLITTER) {
         // Recurse our splitter linked and set our edges
-        auto& splitter_info = splitter_context.GetInfo(mix_in.splitter_id);
-        const auto length = splitter_info.GetLength();
-        for (s32 i = 0; i < length; i++) {
+        auto& splitter_info = splitter_context.GetInfo(static_cast<u32>(mix_in.splitter_id));
+        const auto length = static_cast<size_t>(splitter_info.GetLength());
+        for (size_t i = 0; i < length; i++) {
             const auto* splitter_destination =
-                splitter_context.GetDestinationData(mix_in.splitter_id, i);
+                splitter_context.GetDestinationData(static_cast<u32>(mix_in.splitter_id), i);
             if (splitter_destination == nullptr) {
                 continue;
             }

--- a/src/audio_core/sink_context.cpp
+++ b/src/audio_core/sink_context.cpp
@@ -23,8 +23,9 @@ bool SinkContext::InUse() const {
 }
 
 std::vector<u8> SinkContext::OutputBuffers() const {
-    std::vector<u8> buffer_ret(use_count);
-    std::memcpy(buffer_ret.data(), buffers.data(), use_count);
+    const auto output_use_count = static_cast<size_t>(use_count);
+    std::vector<u8> buffer_ret(output_use_count);
+    std::memcpy(buffer_ret.data(), buffers.data(), output_use_count);
     return buffer_ret;
 }
 

--- a/src/audio_core/time_stretch.h
+++ b/src/audio_core/time_stretch.h
@@ -5,8 +5,16 @@
 #pragma once
 
 #include <cstddef>
-#include <SoundTouch.h>
 #include "common/common_types.h"
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
+#include <SoundTouch.h>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 namespace AudioCore {
 

--- a/src/common/fiber.h
+++ b/src/common/fiber.h
@@ -41,8 +41,8 @@ public:
     Fiber(const Fiber&) = delete;
     Fiber& operator=(const Fiber&) = delete;
 
-    Fiber(Fiber&&) = default;
-    Fiber& operator=(Fiber&&) = default;
+    Fiber(Fiber&&) = delete;
+    Fiber& operator=(Fiber&&) = delete;
 
     /// Yields control from Fiber 'from' to Fiber 'to'
     /// Fiber 'from' must be the currently running fiber.

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -189,7 +189,8 @@ template <typename T>
         return {};
     }
     last = std::min<std::size_t>(last, vector.size());
-    return std::vector<T>(vector.begin() + first, vector.begin() + first + last);
+    return std::vector<T>(vector.begin() + static_cast<std::ptrdiff_t>(first),
+                          vector.begin() + static_cast<std::ptrdiff_t>(first + last));
 }
 
 enum class DirectorySeparator {

--- a/src/common/math_util.h
+++ b/src/common/math_util.h
@@ -27,7 +27,7 @@ struct Rectangle {
         if constexpr (std::is_floating_point_v<T>) {
             return std::abs(right - left);
         } else {
-            return std::abs(static_cast<std::make_signed_t<T>>(right - left));
+            return static_cast<T>(std::abs(static_cast<std::make_signed_t<T>>(right - left)));
         }
     }
 
@@ -35,7 +35,7 @@ struct Rectangle {
         if constexpr (std::is_floating_point_v<T>) {
             return std::abs(bottom - top);
         } else {
-            return std::abs(static_cast<std::make_signed_t<T>>(bottom - top));
+            return static_cast<T>(std::abs(static_cast<std::make_signed_t<T>>(bottom - top)));
         }
     }
 

--- a/src/common/multi_level_queue.h
+++ b/src/common/multi_level_queue.h
@@ -320,7 +320,7 @@ private:
         }
 
         const auto begin_range = list.begin();
-        const auto end_range = std::next(begin_range, shift);
+        const auto end_range = std::next(begin_range, static_cast<std::ptrdiff_t>(shift));
         list.splice(list.end(), list, begin_range, end_range);
     }
 

--- a/src/common/spin_lock.h
+++ b/src/common/spin_lock.h
@@ -15,6 +15,14 @@ namespace Common {
  */
 class SpinLock {
 public:
+    SpinLock() = default;
+
+    SpinLock(const SpinLock&) = delete;
+    SpinLock& operator=(const SpinLock&) = delete;
+
+    SpinLock(SpinLock&&) = delete;
+    SpinLock& operator=(SpinLock&&) = delete;
+
     void lock();
     void unlock();
     [[nodiscard]] bool try_lock();

--- a/src/common/swap.h
+++ b/src/common/swap.h
@@ -504,35 +504,35 @@ bool operator==(const S& p, const swap_struct_t<T, F> v) {
 template <typename T>
 struct swap_64_t {
     static T swap(T x) {
-        return static_cast<T>(Common::swap64(x));
+        return static_cast<T>(Common::swap64(static_cast<u64>(x)));
     }
 };
 
 template <typename T>
 struct swap_32_t {
     static T swap(T x) {
-        return static_cast<T>(Common::swap32(x));
+        return static_cast<T>(Common::swap32(static_cast<u32>(x)));
     }
 };
 
 template <typename T>
 struct swap_16_t {
     static T swap(T x) {
-        return static_cast<T>(Common::swap16(x));
+        return static_cast<T>(Common::swap16(static_cast<u16>(x)));
     }
 };
 
 template <typename T>
 struct swap_float_t {
     static T swap(T x) {
-        return static_cast<T>(Common::swapf(x));
+        return static_cast<T>(Common::swapf(static_cast<float>(x)));
     }
 };
 
 template <typename T>
 struct swap_double_t {
     static T swap(T x) {
-        return static_cast<T>(Common::swapd(x));
+        return static_cast<T>(Common::swapd(static_cast<double>(x)));
     }
 };
 

--- a/src/common/thread_queue_list.h
+++ b/src/common/thread_queue_list.h
@@ -33,7 +33,7 @@ struct ThreadQueueList {
             }
         }
 
-        return -1;
+        return static_cast<Priority>(-1);
     }
 
     [[nodiscard]] T get_first() const {
@@ -156,7 +156,7 @@ private:
     void link(Priority priority) {
         Queue* cur = &queues[priority];
 
-        for (int i = priority - 1; i >= 0; --i) {
+        for (auto i = static_cast<int>(priority - 1); i >= 0; --i) {
             if (queues[i].next_nonempty != UnlinkedTag()) {
                 cur->next_nonempty = queues[i].next_nonempty;
                 queues[i].next_nonempty = cur;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -630,8 +630,9 @@ else()
         -Werror=implicit-fallthrough
         -Werror=reorder
         -Werror=sign-compare
-        -Werror=unused-but-set-parameter
-        -Werror=unused-but-set-variable
+        -Werror=sign-conversion
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-variable>
         -Werror=unused-variable
     )
 endif()

--- a/src/core/arm/arm_interface.cpp
+++ b/src/core/arm/arm_interface.cpp
@@ -147,10 +147,18 @@ std::vector<ARM_Interface::BacktraceEntry> ARM_Interface::GetBacktraceFromContex
     auto fp = ctx.cpu_registers[29];
     auto lr = ctx.cpu_registers[30];
     while (true) {
-        out.push_back({"", 0, lr, 0});
-        if (!fp) {
+        out.push_back({
+            .module = "",
+            .address = 0,
+            .original_address = lr,
+            .offset = 0,
+            .name = "",
+        });
+
+        if (fp == 0) {
             break;
         }
+
         lr = memory.Read64(fp + 8) - 4;
         fp = memory.Read64(fp);
     }
@@ -203,10 +211,18 @@ std::vector<ARM_Interface::BacktraceEntry> ARM_Interface::GetBacktrace() const {
     auto fp = GetReg(29);
     auto lr = GetReg(30);
     while (true) {
-        out.push_back({"", 0, lr, 0, ""});
-        if (!fp) {
+        out.push_back({
+            .module = "",
+            .address = 0,
+            .original_address = lr,
+            .offset = 0,
+            .name = "",
+        });
+
+        if (fp == 0) {
             break;
         }
+
         lr = memory.Read64(fp + 8) - 4;
         fp = memory.Read64(fp);
     }

--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -93,14 +93,14 @@ public:
      * @param index Register index
      * @return Returns the value in the register
      */
-    virtual u64 GetReg(int index) const = 0;
+    virtual u64 GetReg(std::size_t index) const = 0;
 
     /**
      * Set an ARM register
      * @param index Register index
      * @param value Value to set register to
      */
-    virtual void SetReg(int index, u64 value) = 0;
+    virtual void SetReg(std::size_t index, u64 value) = 0;
 
     /**
      * Gets the value of a specified vector register.
@@ -108,7 +108,7 @@ public:
      * @param index The index of the vector register.
      * @return the value within the vector register.
      */
-    virtual u128 GetVectorReg(int index) const = 0;
+    virtual u128 GetVectorReg(std::size_t index) const = 0;
 
     /**
      * Sets a given value into a vector register.
@@ -116,7 +116,7 @@ public:
      * @param index The index of the vector register.
      * @param value The new value to place in the register.
      */
-    virtual void SetVectorReg(int index, u128 value) = 0;
+    virtual void SetVectorReg(std::size_t index, u128 value) = 0;
 
     /**
      * Get the current PSTATE register

--- a/src/core/arm/cpu_interrupt_handler.h
+++ b/src/core/arm/cpu_interrupt_handler.h
@@ -21,8 +21,8 @@ public:
     CPUInterruptHandler(const CPUInterruptHandler&) = delete;
     CPUInterruptHandler& operator=(const CPUInterruptHandler&) = delete;
 
-    CPUInterruptHandler(CPUInterruptHandler&&) = default;
-    CPUInterruptHandler& operator=(CPUInterruptHandler&&) = default;
+    CPUInterruptHandler(CPUInterruptHandler&&) = delete;
+    CPUInterruptHandler& operator=(CPUInterruptHandler&&) = delete;
 
     bool IsInterrupted() const {
         return is_interrupted;

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -111,7 +111,7 @@ public:
             }
             return 0U;
         }
-        return std::max<s64>(parent.system.CoreTiming().GetDowncount(), 0);
+        return static_cast<u64>(std::max<s64>(parent.system.CoreTiming().GetDowncount(), 0));
     }
 
     ARM_Dynarmic_32& parent;
@@ -210,19 +210,19 @@ u64 ARM_Dynarmic_32::GetPC() const {
     return jit->Regs()[15];
 }
 
-u64 ARM_Dynarmic_32::GetReg(int index) const {
+u64 ARM_Dynarmic_32::GetReg(std::size_t index) const {
     return jit->Regs()[index];
 }
 
-void ARM_Dynarmic_32::SetReg(int index, u64 value) {
+void ARM_Dynarmic_32::SetReg(std::size_t index, u64 value) {
     jit->Regs()[index] = static_cast<u32>(value);
 }
 
-u128 ARM_Dynarmic_32::GetVectorReg(int index) const {
+u128 ARM_Dynarmic_32::GetVectorReg(std::size_t index) const {
     return {};
 }
 
-void ARM_Dynarmic_32::SetVectorReg(int index, u128 value) {}
+void ARM_Dynarmic_32::SetVectorReg(std::size_t index, u128 value) {}
 
 u32 ARM_Dynarmic_32::GetPSTATE() const {
     return jit->Cpsr();

--- a/src/core/arm/dynarmic/arm_dynarmic_32.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.h
@@ -35,10 +35,10 @@ public:
 
     void SetPC(u64 pc) override;
     u64 GetPC() const override;
-    u64 GetReg(int index) const override;
-    void SetReg(int index, u64 value) override;
-    u128 GetVectorReg(int index) const override;
-    void SetVectorReg(int index, u128 value) override;
+    u64 GetReg(std::size_t index) const override;
+    void SetReg(std::size_t index, u64 value) override;
+    u128 GetVectorReg(std::size_t index) const override;
+    void SetVectorReg(std::size_t index, u128 value) override;
     u32 GetPSTATE() const override;
     void SetPSTATE(u32 pstate) override;
     void Run() override;

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -148,7 +148,7 @@ public:
             }
             return 0U;
         }
-        return std::max<s64>(parent.system.CoreTiming().GetDowncount(), 0);
+        return static_cast<u64>(std::max<s64>(parent.system.CoreTiming().GetDowncount(), 0));
     }
 
     u64 GetCNTPCT() override {
@@ -265,19 +265,19 @@ u64 ARM_Dynarmic_64::GetPC() const {
     return jit->GetPC();
 }
 
-u64 ARM_Dynarmic_64::GetReg(int index) const {
+u64 ARM_Dynarmic_64::GetReg(std::size_t index) const {
     return jit->GetRegister(index);
 }
 
-void ARM_Dynarmic_64::SetReg(int index, u64 value) {
+void ARM_Dynarmic_64::SetReg(std::size_t index, u64 value) {
     jit->SetRegister(index, value);
 }
 
-u128 ARM_Dynarmic_64::GetVectorReg(int index) const {
+u128 ARM_Dynarmic_64::GetVectorReg(std::size_t index) const {
     return jit->GetVector(index);
 }
 
-void ARM_Dynarmic_64::SetVectorReg(int index, u128 value) {
+void ARM_Dynarmic_64::SetVectorReg(std::size_t index, u128 value) {
     jit->SetVector(index, value);
 }
 

--- a/src/core/arm/dynarmic/arm_dynarmic_64.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.h
@@ -33,10 +33,10 @@ public:
 
     void SetPC(u64 pc) override;
     u64 GetPC() const override;
-    u64 GetReg(int index) const override;
-    void SetReg(int index, u64 value) override;
-    u128 GetVectorReg(int index) const override;
-    void SetVectorReg(int index, u128 value) override;
+    u64 GetReg(std::size_t index) const override;
+    void SetReg(std::size_t index, u64 value) override;
+    u128 GetVectorReg(std::size_t index) const override;
+    void SetVectorReg(std::size_t index, u128 value) override;
     u32 GetPSTATE() const override;
     void SetPSTATE(u32 pstate) override;
     void Run() override;

--- a/src/core/arm/unicorn/arm_unicorn.cpp
+++ b/src/core/arm/unicorn/arm_unicorn.cpp
@@ -96,35 +96,35 @@ u64 ARM_Unicorn::GetPC() const {
     return val;
 }
 
-u64 ARM_Unicorn::GetReg(int regn) const {
+u64 ARM_Unicorn::GetReg(std::size_t index) const {
     u64 val{};
     auto treg = UC_ARM64_REG_SP;
-    if (regn <= 28) {
-        treg = (uc_arm64_reg)(UC_ARM64_REG_X0 + regn);
-    } else if (regn < 31) {
-        treg = (uc_arm64_reg)(UC_ARM64_REG_X29 + regn - 29);
+    if (index <= 28) {
+        treg = static_cast<uc_arm64_reg>(UC_ARM64_REG_X0 + static_cast<int>(index));
+    } else if (index < 31) {
+        treg = static_cast<uc_arm64_reg>(UC_ARM64_REG_X29 + static_cast<int>(index) - 29);
     }
     CHECKED(uc_reg_read(uc, treg, &val));
     return val;
 }
 
-void ARM_Unicorn::SetReg(int regn, u64 val) {
+void ARM_Unicorn::SetReg(std::size_t index, u64 value) {
     auto treg = UC_ARM64_REG_SP;
-    if (regn <= 28) {
-        treg = (uc_arm64_reg)(UC_ARM64_REG_X0 + regn);
-    } else if (regn < 31) {
-        treg = (uc_arm64_reg)(UC_ARM64_REG_X29 + regn - 29);
+    if (index <= 28) {
+        treg = static_cast<uc_arm64_reg>(UC_ARM64_REG_X0 + static_cast<int>(index));
+    } else if (index < 31) {
+        treg = static_cast<uc_arm64_reg>(UC_ARM64_REG_X29 + static_cast<int>(index) - 29);
     }
-    CHECKED(uc_reg_write(uc, treg, &val));
+    CHECKED(uc_reg_write(uc, treg, &value));
 }
 
-u128 ARM_Unicorn::GetVectorReg(int /*index*/) const {
+u128 ARM_Unicorn::GetVectorReg(std::size_t /*index*/) const {
     UNIMPLEMENTED();
     static constexpr u128 res{};
     return res;
 }
 
-void ARM_Unicorn::SetVectorReg(int /*index*/, u128 /*value*/) {
+void ARM_Unicorn::SetVectorReg(std::size_t /*index*/, u128 /*value*/) {
     UNIMPLEMENTED();
 }
 
@@ -217,8 +217,8 @@ void ARM_Unicorn::SaveContext(ThreadContext64& ctx) {
     CHECKED(uc_reg_read(uc, UC_ARM64_REG_PC, &ctx.pc));
     CHECKED(uc_reg_read(uc, UC_ARM64_REG_NZCV, &ctx.pstate));
 
-    for (auto i = 0; i < 29; ++i) {
-        uregs[i] = UC_ARM64_REG_X0 + i;
+    for (std::size_t i = 0; i < 29; ++i) {
+        uregs[i] = UC_ARM64_REG_X0 + static_cast<int>(i);
         tregs[i] = &ctx.cpu_registers[i];
     }
     uregs[29] = UC_ARM64_REG_X29;
@@ -228,8 +228,8 @@ void ARM_Unicorn::SaveContext(ThreadContext64& ctx) {
 
     CHECKED(uc_reg_read_batch(uc, uregs, tregs, 31));
 
-    for (int i = 0; i < 32; ++i) {
-        uregs[i] = UC_ARM64_REG_Q0 + i;
+    for (std::size_t i = 0; i < 32; ++i) {
+        uregs[i] = UC_ARM64_REG_Q0 + static_cast<int>(i);
         tregs[i] = &ctx.vector_registers[i];
     }
 
@@ -244,8 +244,8 @@ void ARM_Unicorn::LoadContext(const ThreadContext64& ctx) {
     CHECKED(uc_reg_write(uc, UC_ARM64_REG_PC, &ctx.pc));
     CHECKED(uc_reg_write(uc, UC_ARM64_REG_NZCV, &ctx.pstate));
 
-    for (int i = 0; i < 29; ++i) {
-        uregs[i] = UC_ARM64_REG_X0 + i;
+    for (std::size_t i = 0; i < 29; ++i) {
+        uregs[i] = UC_ARM64_REG_X0 + static_cast<int>(i);
         tregs[i] = (void*)&ctx.cpu_registers[i];
     }
     uregs[29] = UC_ARM64_REG_X29;
@@ -255,8 +255,8 @@ void ARM_Unicorn::LoadContext(const ThreadContext64& ctx) {
 
     CHECKED(uc_reg_write_batch(uc, uregs, tregs, 31));
 
-    for (auto i = 0; i < 32; ++i) {
-        uregs[i] = UC_ARM64_REG_Q0 + i;
+    for (std::size_t i = 0; i < 32; ++i) {
+        uregs[i] = UC_ARM64_REG_Q0 + static_cast<int>(i);
         tregs[i] = (void*)&ctx.vector_registers[i];
     }
 

--- a/src/core/arm/unicorn/arm_unicorn.h
+++ b/src/core/arm/unicorn/arm_unicorn.h
@@ -26,10 +26,10 @@ public:
 
     void SetPC(u64 pc) override;
     u64 GetPC() const override;
-    u64 GetReg(int index) const override;
-    void SetReg(int index, u64 value) override;
-    u128 GetVectorReg(int index) const override;
-    void SetVectorReg(int index, u128 value) override;
+    u64 GetReg(std::size_t index) const override;
+    void SetReg(std::size_t index, u64 value) override;
+    u128 GetVectorReg(std::size_t index) const override;
+    void SetVectorReg(std::size_t index, u128 value) override;
     u32 GetPSTATE() const override;
     void SetPSTATE(u32 pstate) override;
     VAddr GetTlsAddress() const override;

--- a/src/core/core_timing_util.cpp
+++ b/src/core/core_timing_util.cpp
@@ -21,9 +21,9 @@ s64 msToCycles(std::chrono::milliseconds ms) {
     }
     if (static_cast<u64>(ms.count()) > MAX_VALUE_TO_MULTIPLY) {
         LOG_DEBUG(Core_Timing, "Time very big, do rounding");
-        return Hardware::BASE_CLOCK_RATE * (ms.count() / 1000);
+        return static_cast<s64>(Hardware::BASE_CLOCK_RATE * static_cast<u64>(ms.count() / 1000));
     }
-    return (Hardware::BASE_CLOCK_RATE * ms.count()) / 1000;
+    return static_cast<s64>((Hardware::BASE_CLOCK_RATE * static_cast<u64>(ms.count())) / 1000);
 }
 
 s64 usToCycles(std::chrono::microseconds us) {
@@ -33,51 +33,55 @@ s64 usToCycles(std::chrono::microseconds us) {
     }
     if (static_cast<u64>(us.count()) > MAX_VALUE_TO_MULTIPLY) {
         LOG_DEBUG(Core_Timing, "Time very big, do rounding");
-        return Hardware::BASE_CLOCK_RATE * (us.count() / 1000000);
+        return static_cast<s64>(Hardware::BASE_CLOCK_RATE * static_cast<u64>(us.count() / 1000000));
     }
-    return (Hardware::BASE_CLOCK_RATE * us.count()) / 1000000;
+    return static_cast<s64>((Hardware::BASE_CLOCK_RATE * static_cast<u64>(us.count())) / 1000000);
 }
 
 s64 nsToCycles(std::chrono::nanoseconds ns) {
-    const u128 temporal = Common::Multiply64Into128(ns.count(), Hardware::BASE_CLOCK_RATE);
-    return Common::Divide128On32(temporal, static_cast<u32>(1000000000)).first;
+    const u128 temp =
+        Common::Multiply64Into128(static_cast<u64>(ns.count()), Hardware::BASE_CLOCK_RATE);
+    return static_cast<s64>(Common::Divide128On32(temp, static_cast<u32>(1000000000)).first);
 }
 
-u64 msToClockCycles(std::chrono::milliseconds ns) {
-    const u128 temp = Common::Multiply64Into128(ns.count(), Hardware::CNTFREQ);
+u64 msToClockCycles(std::chrono::milliseconds ms) {
+    const auto count = static_cast<u64>(ms.count());
+    const u128 temp = Common::Multiply64Into128(count, Hardware::CNTFREQ);
     return Common::Divide128On32(temp, 1000).first;
 }
 
-u64 usToClockCycles(std::chrono::microseconds ns) {
-    const u128 temp = Common::Multiply64Into128(ns.count(), Hardware::CNTFREQ);
+u64 usToClockCycles(std::chrono::microseconds us) {
+    const auto count = static_cast<u64>(us.count());
+    const u128 temp = Common::Multiply64Into128(count, Hardware::CNTFREQ);
     return Common::Divide128On32(temp, 1000000).first;
 }
 
 u64 nsToClockCycles(std::chrono::nanoseconds ns) {
-    const u128 temp = Common::Multiply64Into128(ns.count(), Hardware::CNTFREQ);
+    const auto count = static_cast<u64>(ns.count());
+    const u128 temp = Common::Multiply64Into128(count, Hardware::CNTFREQ);
     return Common::Divide128On32(temp, 1000000000).first;
 }
 
 u64 CpuCyclesToClockCycles(u64 ticks) {
-    const u128 temporal = Common::Multiply64Into128(ticks, Hardware::CNTFREQ);
-    return Common::Divide128On32(temporal, static_cast<u32>(Hardware::BASE_CLOCK_RATE)).first;
+    const u128 temp = Common::Multiply64Into128(ticks, Hardware::CNTFREQ);
+    return Common::Divide128On32(temp, static_cast<u32>(Hardware::BASE_CLOCK_RATE)).first;
 }
 
 std::chrono::milliseconds CyclesToMs(s64 cycles) {
-    const u128 temporal = Common::Multiply64Into128(cycles, 1000);
-    u64 ms = Common::Divide128On32(temporal, static_cast<u32>(Hardware::BASE_CLOCK_RATE)).first;
+    const u128 temp = Common::Multiply64Into128(static_cast<u64>(cycles), 1000);
+    const u64 ms = Common::Divide128On32(temp, static_cast<u32>(Hardware::BASE_CLOCK_RATE)).first;
     return std::chrono::milliseconds(ms);
 }
 
 std::chrono::nanoseconds CyclesToNs(s64 cycles) {
-    const u128 temporal = Common::Multiply64Into128(cycles, 1000000000);
-    u64 ns = Common::Divide128On32(temporal, static_cast<u32>(Hardware::BASE_CLOCK_RATE)).first;
+    const u128 temp = Common::Multiply64Into128(static_cast<u64>(cycles), 1000000000);
+    const u64 ns = Common::Divide128On32(temp, static_cast<u32>(Hardware::BASE_CLOCK_RATE)).first;
     return std::chrono::nanoseconds(ns);
 }
 
 std::chrono::microseconds CyclesToUs(s64 cycles) {
-    const u128 temporal = Common::Multiply64Into128(cycles, 1000000);
-    u64 us = Common::Divide128On32(temporal, static_cast<u32>(Hardware::BASE_CLOCK_RATE)).first;
+    const u128 temp = Common::Multiply64Into128(static_cast<u64>(cycles), 1000000);
+    const u64 us = Common::Divide128On32(temp, static_cast<u32>(Hardware::BASE_CLOCK_RATE)).first;
     return std::chrono::microseconds(us);
 }
 

--- a/src/core/core_timing_util.h
+++ b/src/core/core_timing_util.h
@@ -12,8 +12,8 @@ namespace Core::Timing {
 s64 msToCycles(std::chrono::milliseconds ms);
 s64 usToCycles(std::chrono::microseconds us);
 s64 nsToCycles(std::chrono::nanoseconds ns);
-u64 msToClockCycles(std::chrono::milliseconds ns);
-u64 usToClockCycles(std::chrono::microseconds ns);
+u64 msToClockCycles(std::chrono::milliseconds ms);
+u64 usToClockCycles(std::chrono::microseconds us);
 u64 nsToClockCycles(std::chrono::nanoseconds ns);
 std::chrono::milliseconds CyclesToMs(s64 cycles);
 std::chrono::nanoseconds CyclesToNs(s64 cycles);

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -143,6 +143,7 @@ u64 GetSignatureTypeDataSize(SignatureType type) {
         return 0x3C;
     }
     UNREACHABLE();
+    return 0;
 }
 
 u64 GetSignatureTypePaddingSize(SignatureType type) {
@@ -157,6 +158,7 @@ u64 GetSignatureTypePaddingSize(SignatureType type) {
         return 0x40;
     }
     UNREACHABLE();
+    return 0;
 }
 
 SignatureType Ticket::GetSignatureType() const {
@@ -171,6 +173,7 @@ SignatureType Ticket::GetSignatureType() const {
     }
 
     UNREACHABLE();
+    return {};
 }
 
 TicketData& Ticket::GetData() {
@@ -348,7 +351,7 @@ std::optional<Key128> DeriveSDSeed() {
     std::array<u8, 0x10> buffer{};
     std::size_t offset = 0;
     for (; offset + 0x10 < save_43.GetSize(); ++offset) {
-        if (!save_43.Seek(offset, SEEK_SET)) {
+        if (!save_43.Seek(static_cast<s64>(offset), SEEK_SET)) {
             return std::nullopt;
         }
 
@@ -358,7 +361,7 @@ std::optional<Key128> DeriveSDSeed() {
         }
     }
 
-    if (!save_43.Seek(offset + 0x10, SEEK_SET)) {
+    if (!save_43.Seek(static_cast<s64>(offset + 0x10), SEEK_SET)) {
         return std::nullopt;
     }
 

--- a/src/core/crypto/partition_data_manager.cpp
+++ b/src/core/crypto/partition_data_manager.cpp
@@ -161,7 +161,7 @@ static constexpr u8 CalculateMaxKeyblobSourceHash() {
         return true;
     };
 
-    for (s8 i = 0x1F; i >= 0; --i) {
+    for (std::size_t i = 0x1F; i <= 0x1F; --i) {
         if (!is_zero(keyblob_source_hashes[i])) {
             return static_cast<u8>(i + 1);
         }

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -201,9 +201,9 @@ bool NCA::HandlePotentialHeaderDecryption() {
 }
 
 std::vector<NCASectionHeader> NCA::ReadSectionHeaders() const {
-    const std::ptrdiff_t number_sections =
+    const auto number_sections = static_cast<std::size_t>(
         std::count_if(std::begin(header.section_tables), std::end(header.section_tables),
-                      [](NCASectionTableEntry entry) { return entry.media_offset > 0; });
+                      [](NCASectionTableEntry entry) { return entry.media_offset > 0; }));
 
     std::vector<NCASectionHeader> sections(number_sections);
     const auto length_sections = SECTION_HEADER_SIZE * number_sections;

--- a/src/core/file_sys/fsmitm_romfsbuild.cpp
+++ b/src/core/file_sys/fsmitm_romfsbuild.cpp
@@ -103,7 +103,7 @@ static u32 romfs_calc_path_hash(u32 parent, std::string_view path, u32 start,
     u32 hash = parent ^ 123456789;
     for (u32 i = 0; i < path_len; i++) {
         hash = (hash >> 5) | (hash << 27);
-        hash ^= path[start + i];
+        hash ^= static_cast<u32>(path[start + i]);
     }
 
     return hash;

--- a/src/core/file_sys/kernel_executable.cpp
+++ b/src/core/file_sys/kernel_executable.cpp
@@ -36,14 +36,14 @@ bool DecompressBLZ(std::vector<u8>& data) {
     while (out_index > 0) {
         --index;
         auto control = data[index + start_offset];
-        for (size_t i = 0; i < 8; ++i) {
+        for (std::size_t i = 0; i < 8; ++i) {
             if (((control << i) & 0x80) > 0) {
                 if (index < 2) {
                     return false;
                 }
                 index -= 2;
-                std::size_t segment_offset =
-                    data[index + start_offset] | data[index + start_offset + 1] << 8;
+                std::size_t segment_offset = static_cast<u32>(data[index + start_offset]) |
+                                             static_cast<u32>(data[index + start_offset + 1] << 8);
                 std::size_t segment_size = ((segment_offset >> 12) & 0xF) + 3;
                 segment_offset &= 0xFFF;
                 segment_offset += 3;

--- a/src/core/file_sys/nca_patch.cpp
+++ b/src/core/file_sys/nca_patch.cpp
@@ -25,9 +25,9 @@ std::pair<std::size_t, std::size_t> SearchBucketEntry(u64 offset, const BlockTyp
         ASSERT_MSG(offset <= block.size, "Offset is out of bounds in BKTR relocation block.");
     }
 
-    std::size_t bucket_id = std::count_if(
+    const auto bucket_id = static_cast<std::size_t>(std::count_if(
         block.base_offsets.begin() + 1, block.base_offsets.begin() + block.number_buckets,
-        [&offset](u64 base_offset) { return base_offset <= offset; });
+        [&offset](u64 base_offset) { return base_offset <= offset; }));
 
     const auto& bucket = buckets[bucket_id];
 
@@ -53,6 +53,7 @@ std::pair<std::size_t, std::size_t> SearchBucketEntry(u64 offset, const BlockTyp
     }
 
     UNREACHABLE_MSG("Offset could not be found in BKTR block.");
+    return {};
 }
 } // Anonymous namespace
 
@@ -136,7 +137,7 @@ std::size_t BKTR::Read(u8* data, std::size_t length, std::size_t offset) const {
 
     const auto block_offset = section_offset & 0xF;
     if (block_offset != 0) {
-        auto block = bktr_romfs->ReadBytes(0x10, section_offset & ~0xF);
+        auto block = bktr_romfs->ReadBytes(0x10, section_offset & ~0xFU);
         cipher.Transcode(block.data(), block.size(), block.data(), Core::Crypto::Op::Decrypt);
         if (length + block_offset < 0x10) {
             std::memcpy(data, block.data() + block_offset, std::min(length, block.size()));

--- a/src/core/frontend/applets/controller.cpp
+++ b/src/core/frontend/applets/controller.cpp
@@ -30,7 +30,7 @@ void DefaultControllerApplet::ReconfigureControllers(std::function<void()> callb
     auto& players = Settings::values.players;
 
     const std::size_t min_supported_players =
-        parameters.enable_single_mode ? 1 : parameters.min_players;
+        parameters.enable_single_mode ? 1 : static_cast<std::size_t>(parameters.min_players);
 
     // Disconnect Handheld first.
     npad.DisconnectNPadAtIndex(8);

--- a/src/core/frontend/applets/profile_select.cpp
+++ b/src/core/frontend/applets/profile_select.cpp
@@ -12,8 +12,9 @@ ProfileSelectApplet::~ProfileSelectApplet() = default;
 
 void DefaultProfileSelectApplet::SelectProfile(
     std::function<void(std::optional<Common::UUID>)> callback) const {
+    const auto user_index = static_cast<std::size_t>(Settings::values.current_user);
     Service::Account::ProfileManager manager;
-    callback(manager.GetUser(Settings::values.current_user).value_or(Common::UUID{}));
+    callback(manager.GetUser(user_index).value_or(Common::UUID{}));
     LOG_INFO(Service_ACC, "called, selecting current user instead of prompting...");
 }
 

--- a/src/core/gdbstub/gdbstub.cpp
+++ b/src/core/gdbstub/gdbstub.cpp
@@ -205,7 +205,7 @@ static Kernel::Thread* FindThreadById(s64 id) {
     const auto& threads = Core::System::GetInstance().GlobalScheduler().GetThreadList();
     for (auto& thread : threads) {
         if (thread->GetThreadID() == static_cast<u64>(id)) {
-            current_core = thread->GetProcessorID();
+            current_core = static_cast<u32>(thread->GetProcessorID());
             return thread.get();
         }
     }
@@ -457,7 +457,14 @@ static u128 GdbHexToU128(const u8* src) {
 /// Read a byte from the gdb client.
 static u8 ReadByte() {
     u8 c;
-    std::size_t received_size = recv(gdbserver_socket, reinterpret_cast<char*>(&c), 1, MSG_WAITALL);
+
+#ifdef WIN32
+    const auto socket_id = static_cast<SOCKET>(gdbserver_socket);
+#else
+    const auto socket_id = gdbserver_socket;
+#endif
+
+    const auto received_size = recv(socket_id, reinterpret_cast<char*>(&c), 1, MSG_WAITALL);
     if (received_size != 1) {
         LOG_ERROR(Debug_GDBStub, "recv failed: {}", received_size);
         Shutdown();
@@ -574,7 +581,13 @@ bool CheckBreakpoint(VAddr addr, BreakpointType type) {
  * @param packet Packet to be sent to client.
  */
 static void SendPacket(const char packet) {
-    std::size_t sent_size = send(gdbserver_socket, &packet, 1, 0);
+#ifdef WIN32
+    const auto socket_id = static_cast<SOCKET>(gdbserver_socket);
+#else
+    const auto socket_id = gdbserver_socket;
+#endif
+
+    const auto sent_size = send(socket_id, &packet, 1, 0);
     if (sent_size != 1) {
         LOG_ERROR(Debug_GDBStub, "send failed");
     }
@@ -611,7 +624,13 @@ static void SendReply(const char* reply) {
     u8* ptr = command_buffer;
     u32 left = command_length + 4;
     while (left > 0) {
-        const auto sent_size = send(gdbserver_socket, reinterpret_cast<char*>(ptr), left, 0);
+#ifdef WIN32
+        const auto socket_id = static_cast<SOCKET>(gdbserver_socket);
+#else
+        const auto socket_id = gdbserver_socket;
+#endif
+        const auto sent_size =
+            send(socket_id, reinterpret_cast<char*>(ptr), static_cast<socklen_t>(left), 0);
         if (sent_size < 0) {
             LOG_ERROR(Debug_GDBStub, "gdb: send failed");
             return Shutdown();
@@ -1294,8 +1313,13 @@ static void Init(u16 port) {
     WSAStartup(MAKEWORD(2, 2), &InitData);
 #endif
 
-    int tmpsock = static_cast<int>(socket(PF_INET, SOCK_STREAM, 0));
-    if (tmpsock == -1) {
+#ifdef WIN32
+    using socket_type = SOCKET;
+#else
+    using socket_type = int;
+#endif
+    const auto tmpsock = static_cast<socket_type>(socket(PF_INET, SOCK_STREAM, 0));
+    if (tmpsock == static_cast<socket_type>(-1)) {
         LOG_ERROR(Debug_GDBStub, "Failed to create gdb socket");
     }
 
@@ -1335,7 +1359,7 @@ static void Init(u16 port) {
     }
 
     // Clean up temporary socket if it's still alive at this point.
-    if (tmpsock != -1) {
+    if (tmpsock != static_cast<socket_type>(-1)) {
         shutdown(tmpsock, SHUT_RDWR);
     }
 }
@@ -1352,7 +1376,12 @@ void Shutdown() {
 
     LOG_INFO(Debug_GDBStub, "Stopping GDB ...");
     if (gdbserver_socket != -1) {
-        shutdown(gdbserver_socket, SHUT_RDWR);
+#ifdef WIN32
+        const auto tmpsock = static_cast<SOCKET>(socket(PF_INET, SOCK_STREAM, 0));
+#else
+        const auto tmpsock = static_cast<int>(socket(PF_INET, SOCK_STREAM, 0));
+#endif
+        shutdown(tmpsock, SHUT_RDWR);
         gdbserver_socket = -1;
     }
 
@@ -1383,7 +1412,7 @@ void SetCpuStepFlag(bool is_step) {
     step_loop = is_step;
 }
 
-void SendTrap(Kernel::Thread* thread, int trap) {
+void SendTrap(Kernel::Thread* thread, u32 trap) {
     if (!send_trap) {
         return;
     }

--- a/src/core/gdbstub/gdbstub.h
+++ b/src/core/gdbstub/gdbstub.h
@@ -110,5 +110,5 @@ void SetCpuStepFlag(bool is_step);
  * @param thread Sending thread.
  * @param trap Trap no.
  */
-void SendTrap(Kernel::Thread* thread, int trap);
+void SendTrap(Kernel::Thread* thread, u32 trap);
 } // namespace GDBStub

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -233,7 +233,7 @@ void ResponseBuilder::PushRaw(const T& value) {
     static_assert(std::is_trivially_copyable_v<T>,
                   "It's undefined behavior to use memcpy with non-trivially copyable objects");
     std::memcpy(cmdbuf + index, &value, sizeof(T));
-    index += (sizeof(T) + 3) / 4; // round up to word length
+    index += static_cast<std::ptrdiff_t>((sizeof(T) + 3) / 4); // round up to word length
 }
 
 template <>
@@ -390,7 +390,7 @@ void RequestParser::PopRaw(T& value) {
     static_assert(std::is_trivially_copyable_v<T>,
                   "It's undefined behavior to use memcpy with non-trivially copyable objects");
     std::memcpy(&value, cmdbuf + index, sizeof(T));
-    index += (sizeof(T) + 3) / 4; // round up to word length
+    index += static_cast<std::ptrdiff_t>((sizeof(T) + 3) / 4); // round up to word length
 }
 
 template <typename T>

--- a/src/core/hle/kernel/address_arbiter.cpp
+++ b/src/core/hle/kernel/address_arbiter.cpp
@@ -108,7 +108,7 @@ ResultCode AddressArbiter::ModifyByWaitingCountAndSignalToAddressIfEqual(VAddr a
     auto& monitor = system.Monitor();
     s32 updated_value;
     do {
-        updated_value = monitor.ExclusiveRead32(current_core, address);
+        updated_value = static_cast<s32>(monitor.ExclusiveRead32(current_core, address));
 
         if (updated_value != value) {
             return ERR_INVALID_STATE;
@@ -129,7 +129,7 @@ ResultCode AddressArbiter::ModifyByWaitingCountAndSignalToAddressIfEqual(VAddr a
                 updated_value = value;
             }
         }
-    } while (!monitor.ExclusiveWrite32(current_core, address, updated_value));
+    } while (!monitor.ExclusiveWrite32(current_core, address, static_cast<u32>(updated_value)));
 
     WakeThreads(waiting_threads, num_to_wake);
     return RESULT_SUCCESS;

--- a/src/core/hle/kernel/handle_table.cpp
+++ b/src/core/hle/kernel/handle_table.cpp
@@ -68,7 +68,7 @@ ResultVal<Handle> HandleTable::Create(std::shared_ptr<Object> obj) {
     generations[slot] = generation;
     objects[slot] = std::move(obj);
 
-    Handle handle = generation | (slot << 15);
+    const auto handle = static_cast<Handle>(generation | static_cast<u16>(slot << 15));
     return MakeResult<Handle>(handle);
 }
 

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -58,7 +58,7 @@ std::shared_ptr<WritableEvent> HLERequestContext::SleepClientThread(
 
     {
         Handle event_handle = InvalidHandle;
-        SchedulerLockAndSleep lock(kernel, event_handle, thread.get(), timeout);
+        SchedulerLockAndSleep lock(kernel, event_handle, thread.get(), static_cast<s64>(timeout));
         thread->SetHLECallback(
             [context = *this, callback](std::shared_ptr<Thread> thread) mutable -> bool {
                 ThreadWakeupReason reason = thread->GetSignalingResult() == RESULT_TIMEOUT

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -168,7 +168,7 @@ struct KernelCore::Impl {
             const auto type =
                 static_cast<ThreadType>(THREADTYPE_KERNEL | THREADTYPE_HLE | THREADTYPE_SUSPEND);
             auto thread_res =
-                Thread::Create(system, type, std::move(name), 0, 0, 0, static_cast<u32>(i), 0,
+                Thread::Create(system, type, std::move(name), 0, 0, 0, static_cast<s32>(i), 0,
                                nullptr, std::move(init_func), init_func_parameter);
 
             suspend_threads[i] = std::move(thread_res).Unwrap();

--- a/src/core/hle/kernel/memory/address_space_info.cpp
+++ b/src/core/hle/kernel/memory/address_space_info.cpp
@@ -96,6 +96,7 @@ u64 AddressSpaceInfo::GetAddressSpaceStart(std::size_t width, Type type) {
         return AddressSpaceInfos[AddressSpaceIndices39Bit[index]].address;
     }
     UNREACHABLE();
+    return 0;
 }
 
 std::size_t AddressSpaceInfo::GetAddressSpaceSize(std::size_t width, Type type) {
@@ -112,6 +113,7 @@ std::size_t AddressSpaceInfo::GetAddressSpaceSize(std::size_t width, Type type) 
         return AddressSpaceInfos[AddressSpaceIndices39Bit[index]].size;
     }
     UNREACHABLE();
+    return 0;
 }
 
 } // namespace Kernel::Memory

--- a/src/core/hle/kernel/memory/memory_manager.cpp
+++ b/src/core/hle/kernel/memory/memory_manager.cpp
@@ -71,7 +71,7 @@ VAddr MemoryManager::AllocateContinuous(std::size_t num_pages, std::size_t align
     }
 
     // If we allocated more than we need, free some
-    const auto allocated_pages{PageHeap::GetBlockNumPages(heap_index)};
+    const auto allocated_pages{PageHeap::GetBlockNumPages(static_cast<u32>(heap_index))};
     if (allocated_pages > num_pages) {
         chosen_manager.Free(allocated_block + num_pages * PageSize, allocated_pages - num_pages);
     }
@@ -112,7 +112,7 @@ ResultCode MemoryManager::Allocate(PageLinkedList& page_list, std::size_t num_pa
 
     // Keep allocating until we've allocated all our pages
     for (s32 index{heap_index}; index >= 0 && num_pages > 0; index--) {
-        const auto pages_per_alloc{PageHeap::GetBlockNumPages(index)};
+        const auto pages_per_alloc{PageHeap::GetBlockNumPages(static_cast<u32>(index))};
 
         while (num_pages >= pages_per_alloc) {
             // Allocate a block

--- a/src/core/hle/kernel/memory/page_heap.h
+++ b/src/core/hle/kernel/memory/page_heap.h
@@ -34,7 +34,9 @@ public:
 
     static constexpr s32 GetBlockIndex(std::size_t num_pages) {
         for (s32 i{static_cast<s32>(NumMemoryBlockPageShifts) - 1}; i >= 0; i--) {
-            if (num_pages >= (static_cast<std::size_t>(1) << MemoryBlockPageShifts[i]) / PageSize) {
+            const auto shift_index = static_cast<std::size_t>(i);
+            if (num_pages >=
+                (static_cast<std::size_t>(1) << MemoryBlockPageShifts[shift_index]) / PageSize) {
                 return i;
             }
         }
@@ -86,7 +88,7 @@ private:
 
                 // Set the bitmap pointers
                 for (s32 depth{GetHighestDepthIndex()}; depth >= 0; depth--) {
-                    bit_storages[depth] = storage;
+                    bit_storages[static_cast<std::size_t>(depth)] = storage;
                     size = Common::AlignUp(size, 64) / 64;
                     storage += size;
                 }
@@ -99,7 +101,7 @@ private:
                 s32 depth{};
 
                 do {
-                    const u64 v{bit_storages[depth][offset]};
+                    const u64 v{bit_storages[static_cast<std::size_t>(depth)][offset]};
                     if (v == 0) {
                         // Non-zero depth indicates that a previous level had a free block
                         ASSERT(depth == 0);
@@ -125,7 +127,7 @@ private:
             constexpr bool ClearRange(std::size_t offset, std::size_t count) {
                 const s32 depth{GetHighestDepthIndex()};
                 const auto bit_ind{offset / 64};
-                u64* bits{bit_storages[depth]};
+                u64* bits{bit_storages[static_cast<std::size_t>(depth)]};
                 if (count < 64) {
                     const auto shift{offset % 64};
                     ASSERT(shift + count <= 64);
@@ -177,11 +179,11 @@ private:
                     const auto which{offset % 64};
                     const u64 mask{1ULL << which};
 
-                    u64* bit{std::addressof(bit_storages[depth][ind])};
+                    u64* bit{std::addressof(bit_storages[static_cast<std::size_t>(depth)][ind])};
                     const u64 v{*bit};
                     ASSERT((v & mask) == 0);
                     *bit = v | mask;
-                    if (v) {
+                    if (v != 0) {
                         break;
                     }
                     offset = ind;
@@ -195,12 +197,12 @@ private:
                     const auto which{offset % 64};
                     const u64 mask{1ULL << which};
 
-                    u64* bit{std::addressof(bit_storages[depth][ind])};
+                    u64* bit{std::addressof(bit_storages[static_cast<std::size_t>(depth)][ind])};
                     u64 v{*bit};
                     ASSERT((v & mask) != 0);
                     v &= ~mask;
                     *bit = v;
-                    if (v) {
+                    if (v != 0) {
                         break;
                     }
                     offset = ind;

--- a/src/core/hle/kernel/memory/page_table.cpp
+++ b/src/core/hle/kernel/memory/page_table.cpp
@@ -414,7 +414,8 @@ ResultCode PageTable::MapPhysicalMemory(VAddr addr, std::size_t size) {
     const std::size_t remaining_pages{remaining_size / PageSize};
 
     if (process->GetResourceLimit() &&
-        !process->GetResourceLimit()->Reserve(ResourceType::PhysicalMemory, remaining_size)) {
+        !process->GetResourceLimit()->Reserve(ResourceType::PhysicalMemory,
+                                              static_cast<s64>(remaining_size))) {
         return ERR_RESOURCE_LIMIT_EXCEEDED;
     }
 
@@ -778,7 +779,8 @@ ResultVal<VAddr> PageTable::SetHeapSize(std::size_t size) {
 
         auto process{system.Kernel().CurrentProcess()};
         if (process->GetResourceLimit() && delta != 0 &&
-            !process->GetResourceLimit()->Reserve(ResourceType::PhysicalMemory, delta)) {
+            !process->GetResourceLimit()->Reserve(ResourceType::PhysicalMemory,
+                                                  static_cast<s64>(delta))) {
             return ERR_RESOURCE_LIMIT_EXCEEDED;
         }
 

--- a/src/core/hle/kernel/physical_core.h
+++ b/src/core/hle/kernel/physical_core.h
@@ -34,7 +34,7 @@ public:
     PhysicalCore& operator=(const PhysicalCore&) = delete;
 
     PhysicalCore(PhysicalCore&&) = default;
-    PhysicalCore& operator=(PhysicalCore&&) = default;
+    PhysicalCore& operator=(PhysicalCore&&) = delete;
 
     void Idle();
     /// Interrupt this physical core.

--- a/src/core/hle/kernel/resource_limit.cpp
+++ b/src/core/hle/kernel/resource_limit.cpp
@@ -43,8 +43,8 @@ void ResourceLimit::Release(ResourceType resource, u64 amount) {
 void ResourceLimit::Release(ResourceType resource, u64 used_amount, u64 available_amount) {
     const std::size_t index{ResourceTypeToIndex(resource)};
 
-    current[index] -= used_amount;
-    available[index] -= available_amount;
+    current[index] -= static_cast<s64>(used_amount);
+    available[index] -= static_cast<s64>(available_amount);
 }
 
 std::shared_ptr<ResourceLimit> ResourceLimit::Create(KernelCore& kernel) {

--- a/src/core/hle/kernel/scheduler.cpp
+++ b/src/core/hle/kernel/scheduler.cpp
@@ -89,9 +89,11 @@ u32 GlobalScheduler::SelectThreads() {
             while (iter != suggested_queue[core_id].end()) {
                 suggested = *iter;
                 iter++;
-                s32 suggested_core_id = suggested->GetProcessorID();
-                Thread* top_thread =
-                    suggested_core_id >= 0 ? top_threads[suggested_core_id] : nullptr;
+                const s32 suggested_core_id = suggested->GetProcessorID();
+                Thread* top_thread = suggested_core_id >= 0
+                                         ? top_threads[static_cast<u32>(suggested_core_id)]
+                                         : nullptr;
+
                 if (top_thread != suggested) {
                     if (top_thread != nullptr &&
                         top_thread->GetPriority() < THREADPRIO_MAX_CORE_MIGRATION) {
@@ -102,16 +104,19 @@ u32 GlobalScheduler::SelectThreads() {
                     TransferToCore(suggested->GetPriority(), static_cast<s32>(core_id), suggested);
                     break;
                 }
+
                 suggested = nullptr;
                 migration_candidates[num_candidates++] = suggested_core_id;
             }
+
             // Step 3: Select a suggested thread from another core
             if (suggested == nullptr) {
                 for (std::size_t i = 0; i < num_candidates; i++) {
-                    s32 candidate_core = migration_candidates[i];
+                    const auto candidate_core = static_cast<u32>(migration_candidates[i]);
                     suggested = top_threads[candidate_core];
                     auto it = scheduled_queue[candidate_core].begin();
-                    it++;
+                    ++it;
+
                     Thread* next = it != scheduled_queue[candidate_core].end() ? *it : nullptr;
                     if (next != nullptr) {
                         TransferToCore(suggested->GetPriority(), static_cast<s32>(core_id),
@@ -128,7 +133,8 @@ u32 GlobalScheduler::SelectThreads() {
 
         idle_cores &= ~(1U << core_id);
     }
-    u32 cores_needing_context_switch{};
+
+    u32 cores_needing_context_switch = 0;
     for (u32 core = 0; core < Core::Hardware::NUM_CPU_CORES; core++) {
         Scheduler& sched = kernel.Scheduler(core);
         ASSERT(top_threads[core] == nullptr ||
@@ -186,13 +192,16 @@ bool GlobalScheduler::YieldThreadAndBalanceLoad(Thread* yielding_thread) {
     for (auto& thread : suggested_queue[core_id]) {
         const s32 source_core = thread->GetProcessorID();
         if (source_core >= 0) {
-            if (current_threads[source_core] != nullptr) {
-                if (thread == current_threads[source_core] ||
-                    current_threads[source_core]->GetPriority() < min_regular_priority) {
+            const auto sanitized_source_core = static_cast<u32>(source_core);
+
+            if (current_threads[sanitized_source_core] != nullptr) {
+                if (thread == current_threads[sanitized_source_core] ||
+                    current_threads[sanitized_source_core]->GetPriority() < min_regular_priority) {
                     continue;
                 }
             }
         }
+
         if (next_thread->GetLastRunningTicks() >= thread->GetLastRunningTicks() ||
             next_thread->GetPriority() < thread->GetPriority()) {
             if (thread->GetPriority() <= priority) {
@@ -240,17 +249,25 @@ bool GlobalScheduler::YieldThreadAndWaitForLoadBalancing(Thread* yielding_thread
         for (std::size_t i = 0; i < current_threads.size(); i++) {
             current_threads[i] = scheduled_queue[i].empty() ? nullptr : scheduled_queue[i].front();
         }
+
         for (auto& thread : suggested_queue[core_id]) {
             const s32 source_core = thread->GetProcessorID();
-            if (source_core < 0 || thread == current_threads[source_core]) {
+            if (source_core < 0) {
                 continue;
             }
-            if (current_threads[source_core] == nullptr ||
-                current_threads[source_core]->GetPriority() >= min_regular_priority) {
+
+            const auto sanitized_source_core = static_cast<u32>(source_core);
+            if (thread == current_threads[sanitized_source_core]) {
+                continue;
+            }
+
+            if (current_threads[sanitized_source_core] == nullptr ||
+                current_threads[sanitized_source_core]->GetPriority() >= min_regular_priority) {
                 winner = thread;
             }
             break;
         }
+
         if (winner != nullptr) {
             if (winner != yielding_thread) {
                 TransferToCore(winner->GetPriority(), static_cast<s32>(core_id), winner);
@@ -292,17 +309,22 @@ void GlobalScheduler::PreemptThreads() {
             if (thread->GetPriority() != priority) {
                 continue;
             }
+
             if (source_core >= 0) {
-                Thread* next_thread = scheduled_queue[source_core].empty()
+                const auto sanitized_source_core = static_cast<u32>(source_core);
+                Thread* next_thread = scheduled_queue[sanitized_source_core].empty()
                                           ? nullptr
-                                          : scheduled_queue[source_core].front();
+                                          : scheduled_queue[sanitized_source_core].front();
+
                 if (next_thread != nullptr && next_thread->GetPriority() < 2) {
                     break;
                 }
+
                 if (next_thread == thread) {
                     continue;
                 }
             }
+
             if (current_thread != nullptr &&
                 current_thread->GetLastRunningTicks() >= thread->GetLastRunningTicks()) {
                 winner = thread;
@@ -322,17 +344,22 @@ void GlobalScheduler::PreemptThreads() {
                 if (thread->GetPriority() < priority) {
                     continue;
                 }
+
                 if (source_core >= 0) {
-                    Thread* next_thread = scheduled_queue[source_core].empty()
+                    const auto sanitized_source_core = static_cast<u32>(source_core);
+                    Thread* next_thread = scheduled_queue[sanitized_source_core].empty()
                                               ? nullptr
-                                              : scheduled_queue[source_core].front();
+                                              : scheduled_queue[sanitized_source_core].front();
+
                     if (next_thread != nullptr && next_thread->GetPriority() < 2) {
                         break;
                     }
+
                     if (next_thread == thread) {
                         continue;
                     }
                 }
+
                 if (current_thread != nullptr &&
                     current_thread->GetLastRunningTicks() >= thread->GetLastRunningTicks()) {
                     winner = thread;
@@ -352,11 +379,11 @@ void GlobalScheduler::PreemptThreads() {
 
 void GlobalScheduler::EnableInterruptAndSchedule(u32 cores_pending_reschedule,
                                                  Core::EmuThreadHandle global_thread) {
-    u32 current_core = global_thread.host_handle;
+    const u32 current_core = global_thread.host_handle;
     bool must_context_switch = global_thread.guest_handle != InvalidHandle &&
                                (current_core < Core::Hardware::NUM_CPU_CORES);
     while (cores_pending_reschedule != 0) {
-        u32 core = Common::CountTrailingZeroes32(cores_pending_reschedule);
+        const u32 core = Common::CountTrailingZeroes32(cores_pending_reschedule);
         ASSERT(core < Core::Hardware::NUM_CPU_CORES);
         if (!must_context_switch || core != current_core) {
             auto& phys_core = kernel.PhysicalCore(core);
@@ -366,6 +393,7 @@ void GlobalScheduler::EnableInterruptAndSchedule(u32 cores_pending_reschedule,
         }
         cores_pending_reschedule &= ~(1U << core);
     }
+
     if (must_context_switch) {
         auto& core_scheduler = kernel.CurrentScheduler();
         kernel.ExitSVCProfile();
@@ -803,9 +831,11 @@ void Scheduler::Initialize() {
     std::string name = "Idle Thread Id:" + std::to_string(core_id);
     std::function<void(void*)> init_func = Core::CpuManager::GetIdleThreadStartFunc();
     void* init_func_parameter = system.GetCpuManager().GetStartFuncParamater();
-    ThreadType type = static_cast<ThreadType>(THREADTYPE_KERNEL | THREADTYPE_HLE | THREADTYPE_IDLE);
-    auto thread_res = Thread::Create(system, type, name, 0, 64, 0, static_cast<u32>(core_id), 0,
-                                     nullptr, std::move(init_func), init_func_parameter);
+    const auto type = static_cast<ThreadType>(THREADTYPE_KERNEL | THREADTYPE_HLE | THREADTYPE_IDLE);
+    auto thread_res =
+        Thread::Create(system, type, std::move(name), 0, 64, 0, static_cast<s32>(core_id), 0,
+                       nullptr, std::move(init_func), init_func_parameter);
+
     idle_thread = std::move(thread_res).Unwrap();
 }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -482,7 +482,8 @@ static ResultCode WaitSynchronization(Core::System& system, Handle* index, VAddr
 static ResultCode WaitSynchronization32(Core::System& system, u32 timeout_low, u32 handles_address,
                                         s32 handle_count, u32 timeout_high, Handle* index) {
     const s64 nano_seconds{(static_cast<s64>(timeout_high) << 32) | static_cast<s64>(timeout_low)};
-    return WaitSynchronization(system, index, handles_address, handle_count, nano_seconds);
+    return WaitSynchronization(system, index, handles_address, static_cast<u32>(handle_count),
+                               nano_seconds);
 }
 
 /// Resumes a thread waiting on WaitSynchronization
@@ -2002,7 +2003,7 @@ static ResultCode GetThreadCoreMask(Core::System& system, Handle thread_handle, 
         return ERR_INVALID_HANDLE;
     }
 
-    *core = thread->GetIdealCore();
+    *core = static_cast<u32>(thread->GetIdealCore());
     *mask = thread->GetAffinityMask();
 
     return RESULT_SUCCESS;
@@ -2070,7 +2071,7 @@ static ResultCode SetThreadCoreMask(Core::System& system, Handle thread_handle, 
         return ERR_INVALID_HANDLE;
     }
 
-    return thread->SetCoreAndAffinityMask(core, affinity_mask);
+    return thread->SetCoreAndAffinityMask(static_cast<s32>(core), affinity_mask);
 }
 
 static ResultCode SetThreadCoreMask32(Core::System& system, Handle thread_handle, u32 core,

--- a/src/core/hle/kernel/svc_wrap.h
+++ b/src/core/hle/kernel/svc_wrap.h
@@ -11,11 +11,11 @@
 
 namespace Kernel {
 
-static inline u64 Param(const Core::System& system, int n) {
+static inline u64 Param(const Core::System& system, std::size_t n) {
     return system.CurrentArmInterface().GetReg(n);
 }
 
-static inline u32 Param32(const Core::System& system, int n) {
+static inline u32 Param32(const Core::System& system, std::size_t n) {
     return static_cast<u32>(system.CurrentArmInterface().GetReg(n));
 }
 
@@ -29,7 +29,7 @@ static inline void FuncReturn(Core::System& system, u64 result) {
 }
 
 static inline void FuncReturn32(Core::System& system, u32 result) {
-    system.CurrentArmInterface().SetReg(0, (u64)result);
+    system.CurrentArmInterface().SetReg(0, static_cast<u64>(result));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -386,9 +386,10 @@ template <ResultCode func(Core::System&, Handle*, u32, u32, u32, u32, s32)>
 void SvcWrap32(Core::System& system) {
     Handle param_1 = 0;
 
-    const u32 retval = func(system, &param_1, Param32(system, 0), Param32(system, 1),
-                            Param32(system, 2), Param32(system, 3), Param32(system, 4))
-                           .raw;
+    const u32 retval =
+        func(system, &param_1, Param32(system, 0), Param32(system, 1), Param32(system, 2),
+             Param32(system, 3), static_cast<s32>(Param32(system, 4)))
+            .raw;
 
     system.CurrentArmInterface().SetReg(1, param_1);
     FuncReturn(system, retval);
@@ -542,8 +543,8 @@ void SvcWrap32(Core::System& system) {
 template <ResultCode func(Core::System&, u32, u32, s32, u32, Handle*)>
 void SvcWrap32(Core::System& system) {
     u32 param_1 = 0;
-    const u32 retval = func(system, Param32(system, 0), Param32(system, 1), Param32(system, 2),
-                            Param32(system, 3), &param_1)
+    const u32 retval = func(system, Param32(system, 0), Param32(system, 1),
+                            static_cast<s32>(Param32(system, 2)), Param32(system, 3), &param_1)
                            .raw;
     system.CurrentArmInterface().SetReg(1, param_1);
     FuncReturn(system, retval);

--- a/src/core/hle/kernel/synchronization.cpp
+++ b/src/core/hle/kernel/synchronization.cpp
@@ -51,7 +51,7 @@ std::pair<ResultCode, Handle> Synchronization::WaitFor(
             // We found a ready object, acquire it and set the result value
             SynchronizationObject* object = itr->get();
             object->Acquire(thread);
-            const u32 index = static_cast<s32>(std::distance(sync_objects.begin(), itr));
+            const auto index = static_cast<u32>(std::distance(sync_objects.begin(), itr));
             lock.CancelSleep();
             return {RESULT_SUCCESS, index};
         }
@@ -105,7 +105,7 @@ std::pair<ResultCode, Handle> Synchronization::WaitFor(
                 });
             ASSERT(itr != sync_objects.end());
             signaling_object->Acquire(thread);
-            const u32 index = static_cast<s32>(std::distance(sync_objects.begin(), itr));
+            const auto index = static_cast<u32>(std::distance(sync_objects.begin(), itr));
             return {signaling_result, index};
         }
         return {signaling_result, -1};

--- a/src/core/hle/kernel/thread.cpp
+++ b/src/core/hle/kernel/thread.cpp
@@ -525,7 +525,7 @@ ResultCode Thread::SetCoreAndAffinityMask(s32 new_core, u64 new_affinity_mask) {
         if (old_affinity_mask != new_affinity_mask) {
             const s32 old_core = processor_id;
             if (processor_id >= 0 && ((affinity_mask >> processor_id) & 1) == 0) {
-                if (static_cast<s32>(ideal_core) < 0) {
+                if (ideal_core < 0) {
                     processor_id = HighestSetCore(affinity_mask, Core::Hardware::NUM_CPU_CORES);
                 } else {
                     processor_id = ideal_core;

--- a/src/core/hle/kernel/thread.h
+++ b/src/core/hle/kernel/thread.h
@@ -470,7 +470,7 @@ public:
 
     bool InvokeHLECallback(std::shared_ptr<Thread> thread);
 
-    u32 GetIdealCore() const {
+    s32 GetIdealCore() const {
         return ideal_core;
     }
 
@@ -654,8 +654,8 @@ private:
 
     Scheduler* scheduler = nullptr;
 
-    u32 ideal_core{0xFFFFFFFF};
-    u64 affinity_mask{0x1};
+    s32 ideal_core = -1;
+    u64 affinity_mask = 1;
 
     s32 ideal_core_override = -1;
     u64 affinity_mask_override = 0x1;

--- a/src/core/hle/service/acc/profile_manager.cpp
+++ b/src/core/hle/service/acc/profile_manager.cpp
@@ -41,12 +41,15 @@ constexpr char ACC_SAVE_AVATORS_BASE_PATH[] = "/system/save/8000000000000010/su/
 ProfileManager::ProfileManager() {
     ParseUserSaveFile();
 
-    if (user_count == 0)
+    if (user_count == 0) {
         CreateNewUser(UUID::Generate(), "yuzu");
+    }
 
-    auto current = std::clamp<int>(Settings::values.current_user, 0, MAX_USERS - 1);
-    if (UserExistsIndex(current))
+    auto current = static_cast<size_t>(
+        std::clamp(Settings::values.current_user, 0, static_cast<s32>(MAX_USERS - 1)));
+    if (UserExistsIndex(current)) {
         current = 0;
+    }
 
     OpenUser(*GetUser(current));
 }
@@ -189,8 +192,8 @@ std::size_t ProfileManager::GetUserCount() const {
 /// booting
 
 std::size_t ProfileManager::GetOpenUserCount() const {
-    return std::count_if(profiles.begin(), profiles.end(),
-                         [](const ProfileInfo& p) { return p.is_open; });
+    return static_cast<std::size_t>(std::count_if(profiles.begin(), profiles.end(),
+                                                  [](const ProfileInfo& p) { return p.is_open; }));
 }
 
 /// Checks if a user id exists in our profile manager

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -1311,7 +1311,7 @@ void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
         params.is_account_selected = 1;
 
         Account::ProfileManager profile_manager{};
-        const auto uuid = profile_manager.GetUser(Settings::values.current_user);
+        const auto uuid = profile_manager.GetUser(static_cast<u32>(Settings::values.current_user));
         ASSERT(uuid);
         params.current_user = uuid->uuid;
 

--- a/src/core/hle/service/am/applets/controller.cpp
+++ b/src/core/hle/service/am/applets/controller.cpp
@@ -178,23 +178,23 @@ void Controller::Execute() {
 }
 
 void Controller::ConfigurationComplete() {
-    ControllerSupportResultInfo result_info{};
-
     const auto& players = Settings::values.players;
+
+    const s8 player_count =
+        is_single_mode
+            ? 1
+            : static_cast<s8>(std::count_if(players.begin(), players.end() - 2,
+                                            [](const auto& player) { return player.connected; }));
+
+    const auto index = static_cast<u32>(std::distance(
+        players.begin(), std::find_if(players.begin(), players.end(),
+                                      [](const auto& player) { return player.connected; })));
 
     // If enable_single_mode is enabled, player_count is 1 regardless of any other parameters.
     // Otherwise, only count connected players from P1-P8.
-    result_info.player_count =
-        is_single_mode ? 1
-                       : static_cast<s8>(std::count_if(
-                             players.begin(), players.end() - 2,
-                             [](Settings::PlayerInput player) { return player.connected; }));
-
-    result_info.selected_id = HID::Controller_NPad::IndexToNPad(
-        std::distance(players.begin(),
-                      std::find_if(players.begin(), players.end(),
-                                   [](Settings::PlayerInput player) { return player.connected; })));
-
+    ControllerSupportResultInfo result_info{};
+    result_info.player_count = player_count;
+    result_info.selected_id = HID::Controller_NPad::IndexToNPad(index);
     result_info.result = 0;
 
     LOG_DEBUG(Service_HID, "Result Info: player_count={}, selected_id={}, result={}",

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -69,9 +69,10 @@ public:
         buffer_event =
             Kernel::WritableEvent::CreateEventPair(system.Kernel(), "IAudioOutBufferReleased");
 
-        stream = audio_core.OpenStream(system.CoreTiming(), audio_params.sample_rate,
-                                       audio_params.channel_count, std::move(unique_name),
-                                       [this] { buffer_event.writable->Signal(); });
+        stream =
+            audio_core.OpenStream(system.CoreTiming(), static_cast<u32>(audio_params.sample_rate),
+                                  audio_params.channel_count, std::move(unique_name),
+                                  [this] { buffer_event.writable->Signal(); });
     }
 
 private:

--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -50,8 +50,8 @@ public:
         Enabled,
     };
 
-    explicit OpusDecoderState(OpusDecoderPtr decoder, u32 sample_rate, u32 channel_count)
-        : decoder{std::move(decoder)}, sample_rate{sample_rate}, channel_count{channel_count} {}
+    explicit OpusDecoderState(OpusDecoderPtr decoder_, s32 sample_rate_, u32 channel_count_)
+        : decoder{std::move(decoder_)}, sample_rate{sample_rate_}, channel_count{channel_count_} {}
 
     // Decodes interleaved Opus packets. Optionally allows reporting time taken to
     // perform the decoding, as well as any relevant extra behavior.
@@ -113,15 +113,16 @@ private:
             return false;
         }
 
-        const auto frame = input.data() + sizeof(OpusPacketHeader);
+        const auto* const frame = input.data() + sizeof(OpusPacketHeader);
         const auto decoded_sample_count = opus_packet_get_nb_samples(
-            frame, static_cast<opus_int32>(input.size() - sizeof(OpusPacketHeader)),
-            static_cast<opus_int32>(sample_rate));
-        if (decoded_sample_count * channel_count * sizeof(u16) > raw_output_sz) {
+            frame, static_cast<opus_int32>(input.size() - sizeof(OpusPacketHeader)), sample_rate);
+        const auto decoded_size =
+            static_cast<u32>(decoded_sample_count) * channel_count * sizeof(u16);
+        if (decoded_size > raw_output_sz) {
             LOG_ERROR(
                 Audio,
                 "Decoded data does not fit into the output data, decoded_sz={}, raw_output_sz={}",
-                decoded_sample_count * channel_count * sizeof(u16), raw_output_sz);
+                decoded_size, raw_output_sz);
             return false;
         }
 
@@ -137,11 +138,11 @@ private:
         }
 
         const auto end_time = std::chrono::high_resolution_clock::now() - start_time;
-        sample_count = out_sample_count;
+        sample_count = static_cast<u32>(out_sample_count);
         consumed = static_cast<u32>(sizeof(OpusPacketHeader) + hdr.size);
         if (out_performance_time != nullptr) {
-            *out_performance_time =
-                std::chrono::duration_cast<std::chrono::milliseconds>(end_time).count();
+            *out_performance_time = static_cast<u64>(
+                std::chrono::duration_cast<std::chrono::milliseconds>(end_time).count());
         }
 
         return true;
@@ -154,7 +155,7 @@ private:
     }
 
     OpusDecoderPtr decoder;
-    u32 sample_rate;
+    s32 sample_rate;
     u32 channel_count;
 };
 
@@ -212,7 +213,7 @@ std::size_t WorkerBufferSize(u32 channel_count) {
     ASSERT_MSG(channel_count == 1 || channel_count == 2, "Invalid channel count");
     constexpr int num_streams = 1;
     const int num_stereo_streams = channel_count == 2 ? 1 : 0;
-    return opus_multistream_decoder_get_size(num_streams, num_stereo_streams);
+    return static_cast<size_t>(opus_multistream_decoder_get_size(num_streams, num_stereo_streams));
 }
 
 // Creates the mapping table that maps the input channels to the particular
@@ -244,7 +245,7 @@ void HwOpus::GetWorkBufferSize(Kernel::HLERequestContext& ctx) {
                "Invalid sample rate");
     ASSERT_MSG(channel_count == 1 || channel_count == 2, "Invalid channel count");
 
-    const u32 worker_buffer_sz = static_cast<u32>(WorkerBufferSize(channel_count));
+    const auto worker_buffer_sz = static_cast<u32>(WorkerBufferSize(channel_count));
     LOG_DEBUG(Audio, "worker_buffer_sz={}", worker_buffer_sz);
 
     IPC::ResponseBuilder rb{ctx, 3};
@@ -254,7 +255,7 @@ void HwOpus::GetWorkBufferSize(Kernel::HLERequestContext& ctx) {
 
 void HwOpus::OpenOpusDecoder(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
-    const auto sample_rate = rp.Pop<u32>();
+    const auto sample_rate = rp.Pop<s32>();
     const auto channel_count = rp.Pop<u32>();
     const auto buffer_sz = rp.Pop<u32>();
 

--- a/src/core/hle/service/bcat/backend/backend.h
+++ b/src/core/hle/service/bcat/backend/backend.h
@@ -53,10 +53,10 @@ struct DeliveryCacheProgressImpl {
     ResultCode result = RESULT_SUCCESS;
     DirectoryName current_directory;
     FileName current_file;
-    s64 current_downloaded_bytes; ///< Bytes downloaded on current file.
-    s64 current_total_bytes;      ///< Bytes total on current file.
-    s64 total_downloaded_bytes;   ///< Bytes downloaded on overall download.
-    s64 total_bytes;              ///< Bytes total on overall download.
+    u64 current_downloaded_bytes; ///< Bytes downloaded on current file.
+    u64 current_total_bytes;      ///< Bytes total on current file.
+    u64 total_downloaded_bytes;   ///< Bytes downloaded on overall download.
+    u64 total_bytes;              ///< Bytes total on overall download.
     INSERT_PADDING_BYTES(
         0x198); ///< Appears to be unused in official code, possibly reserved for future use.
 };

--- a/src/core/hle/service/bcat/backend/boxcat.cpp
+++ b/src/core/hle/service/bcat/backend/boxcat.cpp
@@ -3,7 +3,16 @@
 // Refer to the license.txt file included.
 
 #include <fmt/ostream.h>
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#endif
 #include <httplib.h>
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+
 #include <mbedtls/sha256.h>
 #include <nlohmann/json.hpp>
 #include "common/hex_util.h"

--- a/src/core/hle/service/bcat/module.cpp
+++ b/src/core/hle/service/bcat/module.cpp
@@ -454,7 +454,8 @@ private:
         write_size = std::min<u64>(write_size, files.size());
         std::vector<DeliveryCacheDirectoryEntry> entries(write_size);
         std::transform(
-            files.begin(), files.begin() + write_size, entries.begin(), [](const auto& file) {
+            files.begin(), files.begin() + static_cast<s64>(write_size), entries.begin(),
+            [](const auto& file) {
                 FileName name{};
                 std::memcpy(name.data(), file->GetName().data(),
                             std::min(file->GetName().size(), name.size()));

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -94,7 +94,8 @@ private:
         }
 
         // Read the data from the Storage backend
-        std::vector<u8> output = backend->ReadBytes(length, offset);
+        const auto output = backend->ReadBytes(static_cast<u64>(length), static_cast<u64>(offset));
+
         // Write the data to memory
         ctx.WriteBuffer(output);
 
@@ -151,7 +152,7 @@ private:
         }
 
         // Read the data from the Storage backend
-        std::vector<u8> output = backend->ReadBytes(length, offset);
+        const auto output = backend->ReadBytes(static_cast<u64>(length), static_cast<u64>(offset));
 
         // Write the data to memory
         ctx.WriteBuffer(output);
@@ -194,7 +195,8 @@ private:
         // Write the data to the Storage backend
         const auto write_size =
             static_cast<std::size_t>(std::distance(data.begin(), data.begin() + length));
-        const std::size_t written = backend->Write(data.data(), write_size, offset);
+        const std::size_t written =
+            backend->Write(data.data(), write_size, static_cast<u64>(offset));
 
         ASSERT_MSG(static_cast<s64>(written) == length,
                    "Could not write all bytes to file (requested={:016X}, actual={:016X}).", length,

--- a/src/core/hle/service/hid/controllers/debug_pad.cpp
+++ b/src/core/hle/service/hid/controllers/debug_pad.cpp
@@ -23,7 +23,7 @@ void Controller_DebugPad::OnRelease() {}
 
 void Controller_DebugPad::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
                                    std::size_t size) {
-    shared_memory.header.timestamp = core_timing.GetCPUTicks();
+    shared_memory.header.timestamp = static_cast<s64>(core_timing.GetCPUTicks());
     shared_memory.header.total_entry_count = 17;
 
     if (!IsControllerActivated()) {
@@ -33,9 +33,11 @@ void Controller_DebugPad::OnUpdate(const Core::Timing::CoreTiming& core_timing, 
     }
     shared_memory.header.entry_count = 16;
 
-    const auto& last_entry = shared_memory.pad_states[shared_memory.header.last_entry_index];
+    const auto& last_entry =
+        shared_memory.pad_states[static_cast<u64>(shared_memory.header.last_entry_index)];
     shared_memory.header.last_entry_index = (shared_memory.header.last_entry_index + 1) % 17;
-    auto& cur_entry = shared_memory.pad_states[shared_memory.header.last_entry_index];
+    auto& cur_entry =
+        shared_memory.pad_states[static_cast<u64>(shared_memory.header.last_entry_index)];
 
     cur_entry.sampling_number = last_entry.sampling_number + 1;
     cur_entry.sampling_number2 = cur_entry.sampling_number;

--- a/src/core/hle/service/hid/controllers/gesture.cpp
+++ b/src/core/hle/service/hid/controllers/gesture.cpp
@@ -19,7 +19,7 @@ void Controller_Gesture::OnRelease() {}
 
 void Controller_Gesture::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
                                   std::size_t size) {
-    shared_memory.header.timestamp = core_timing.GetCPUTicks();
+    shared_memory.header.timestamp = static_cast<s64>(core_timing.GetCPUTicks());
     shared_memory.header.total_entry_count = 17;
 
     if (!IsControllerActivated()) {
@@ -29,9 +29,11 @@ void Controller_Gesture::OnUpdate(const Core::Timing::CoreTiming& core_timing, u
     }
     shared_memory.header.entry_count = 16;
 
-    const auto& last_entry = shared_memory.gesture_states[shared_memory.header.last_entry_index];
+    const auto& last_entry =
+        shared_memory.gesture_states[static_cast<u64>(shared_memory.header.last_entry_index)];
     shared_memory.header.last_entry_index = (shared_memory.header.last_entry_index + 1) % 17;
-    auto& cur_entry = shared_memory.gesture_states[shared_memory.header.last_entry_index];
+    auto& cur_entry =
+        shared_memory.gesture_states[static_cast<u64>(shared_memory.header.last_entry_index)];
 
     cur_entry.sampling_number = last_entry.sampling_number + 1;
     cur_entry.sampling_number2 = cur_entry.sampling_number;

--- a/src/core/hle/service/hid/controllers/keyboard.cpp
+++ b/src/core/hle/service/hid/controllers/keyboard.cpp
@@ -21,7 +21,7 @@ void Controller_Keyboard::OnRelease() {}
 
 void Controller_Keyboard::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
                                    std::size_t size) {
-    shared_memory.header.timestamp = core_timing.GetCPUTicks();
+    shared_memory.header.timestamp = static_cast<s64>(core_timing.GetCPUTicks());
     shared_memory.header.total_entry_count = 17;
 
     if (!IsControllerActivated()) {
@@ -31,9 +31,11 @@ void Controller_Keyboard::OnUpdate(const Core::Timing::CoreTiming& core_timing, 
     }
     shared_memory.header.entry_count = 16;
 
-    const auto& last_entry = shared_memory.pad_states[shared_memory.header.last_entry_index];
+    const auto& last_entry =
+        shared_memory.pad_states[static_cast<u64>(shared_memory.header.last_entry_index)];
     shared_memory.header.last_entry_index = (shared_memory.header.last_entry_index + 1) % 17;
-    auto& cur_entry = shared_memory.pad_states[shared_memory.header.last_entry_index];
+    auto& cur_entry =
+        shared_memory.pad_states[static_cast<u64>(shared_memory.header.last_entry_index)];
 
     cur_entry.sampling_number = last_entry.sampling_number + 1;
     cur_entry.sampling_number2 = cur_entry.sampling_number;

--- a/src/core/hle/service/hid/controllers/mouse.cpp
+++ b/src/core/hle/service/hid/controllers/mouse.cpp
@@ -19,7 +19,7 @@ void Controller_Mouse::OnRelease() {}
 
 void Controller_Mouse::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
                                 std::size_t size) {
-    shared_memory.header.timestamp = core_timing.GetCPUTicks();
+    shared_memory.header.timestamp = static_cast<s64>(core_timing.GetCPUTicks());
     shared_memory.header.total_entry_count = 17;
 
     if (!IsControllerActivated()) {
@@ -29,9 +29,11 @@ void Controller_Mouse::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8*
     }
     shared_memory.header.entry_count = 16;
 
-    auto& last_entry = shared_memory.mouse_states[shared_memory.header.last_entry_index];
+    auto& last_entry =
+        shared_memory.mouse_states[static_cast<u64>(shared_memory.header.last_entry_index)];
     shared_memory.header.last_entry_index = (shared_memory.header.last_entry_index + 1) % 17;
-    auto& cur_entry = shared_memory.mouse_states[shared_memory.header.last_entry_index];
+    auto& cur_entry =
+        shared_memory.mouse_states[static_cast<u64>(shared_memory.header.last_entry_index)];
 
     cur_entry.sampling_number = last_entry.sampling_number + 1;
     cur_entry.sampling_number2 = cur_entry.sampling_number;

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -341,26 +341,29 @@ void Controller_NPad::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* 
     }
     for (std::size_t i = 0; i < shared_memory_entries.size(); i++) {
         auto& npad = shared_memory_entries[i];
-        const std::array<NPadGeneric*, 7> controller_npads{&npad.main_controller_states,
-                                                           &npad.handheld_states,
-                                                           &npad.dual_states,
-                                                           &npad.left_joy_states,
-                                                           &npad.right_joy_states,
-                                                           &npad.pokeball_states,
-                                                           &npad.libnx};
+        const std::array controller_npads{
+            &npad.main_controller_states,
+            &npad.handheld_states,
+            &npad.dual_states,
+            &npad.left_joy_states,
+            &npad.right_joy_states,
+            &npad.pokeball_states,
+            &npad.libnx,
+        };
 
         for (auto* main_controller : controller_npads) {
             main_controller->common.entry_count = 16;
             main_controller->common.total_entry_count = 17;
 
             const auto& last_entry =
-                main_controller->npad[main_controller->common.last_entry_index];
+                main_controller->npad[static_cast<u64>(main_controller->common.last_entry_index)];
 
-            main_controller->common.timestamp = core_timing.GetCPUTicks();
+            main_controller->common.timestamp = static_cast<s64>(core_timing.GetCPUTicks());
             main_controller->common.last_entry_index =
                 (main_controller->common.last_entry_index + 1) % 17;
 
-            auto& cur_entry = main_controller->npad[main_controller->common.last_entry_index];
+            auto& cur_entry =
+                main_controller->npad[static_cast<u64>(main_controller->common.last_entry_index)];
 
             cur_entry.timestamp = last_entry.timestamp + 1;
             cur_entry.timestamp2 = cur_entry.timestamp;
@@ -371,22 +374,29 @@ void Controller_NPad::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* 
         if (controller_type == NPadControllerType::None || !connected_controllers[i].is_connected) {
             continue;
         }
-        const u32 npad_index = static_cast<u32>(i);
+        const auto npad_index = static_cast<u32>(i);
 
         RequestPadStateUpdate(npad_index);
         auto& pad_state = npad_pad_states[npad_index];
 
         auto& main_controller =
-            npad.main_controller_states.npad[npad.main_controller_states.common.last_entry_index];
+            npad.main_controller_states
+                .npad[static_cast<u64>(npad.main_controller_states.common.last_entry_index)];
         auto& handheld_entry =
-            npad.handheld_states.npad[npad.handheld_states.common.last_entry_index];
-        auto& dual_entry = npad.dual_states.npad[npad.dual_states.common.last_entry_index];
-        auto& left_entry = npad.left_joy_states.npad[npad.left_joy_states.common.last_entry_index];
+            npad.handheld_states
+                .npad[static_cast<u64>(npad.handheld_states.common.last_entry_index)];
+        auto& dual_entry =
+            npad.dual_states.npad[static_cast<u64>(npad.dual_states.common.last_entry_index)];
+        auto& left_entry =
+            npad.left_joy_states
+                .npad[static_cast<u64>(npad.left_joy_states.common.last_entry_index)];
         auto& right_entry =
-            npad.right_joy_states.npad[npad.right_joy_states.common.last_entry_index];
+            npad.right_joy_states
+                .npad[static_cast<u64>(npad.right_joy_states.common.last_entry_index)];
         auto& pokeball_entry =
-            npad.pokeball_states.npad[npad.pokeball_states.common.last_entry_index];
-        auto& libnx_entry = npad.libnx.npad[npad.libnx.common.last_entry_index];
+            npad.pokeball_states
+                .npad[static_cast<u64>(npad.pokeball_states.common.last_entry_index)];
+        auto& libnx_entry = npad.libnx.npad[static_cast<u64>(npad.libnx.common.last_entry_index)];
 
         libnx_entry.connection_status.raw = 0;
         libnx_entry.connection_status.IsConnected.Assign(1);
@@ -500,13 +510,14 @@ void Controller_NPad::OnMotionUpdate(const Core::Timing::CoreTiming& core_timing
             sixaxis_sensor->common.total_entry_count = 17;
 
             const auto& last_entry =
-                sixaxis_sensor->sixaxis[sixaxis_sensor->common.last_entry_index];
+                sixaxis_sensor->sixaxis[static_cast<u64>(sixaxis_sensor->common.last_entry_index)];
 
-            sixaxis_sensor->common.timestamp = core_timing.GetCPUTicks();
+            sixaxis_sensor->common.timestamp = static_cast<s64>(core_timing.GetCPUTicks());
             sixaxis_sensor->common.last_entry_index =
                 (sixaxis_sensor->common.last_entry_index + 1) % 17;
 
-            auto& cur_entry = sixaxis_sensor->sixaxis[sixaxis_sensor->common.last_entry_index];
+            auto& cur_entry =
+                sixaxis_sensor->sixaxis[static_cast<u64>(sixaxis_sensor->common.last_entry_index)];
 
             cur_entry.timestamp = last_entry.timestamp + 1;
             cur_entry.timestamp2 = cur_entry.timestamp;
@@ -529,17 +540,21 @@ void Controller_NPad::OnMotionUpdate(const Core::Timing::CoreTiming& core_timing
         }
 
         auto& full_sixaxis_entry =
-            npad.sixaxis_full.sixaxis[npad.sixaxis_full.common.last_entry_index];
+            npad.sixaxis_full.sixaxis[static_cast<u64>(npad.sixaxis_full.common.last_entry_index)];
         auto& handheld_sixaxis_entry =
-            npad.sixaxis_handheld.sixaxis[npad.sixaxis_handheld.common.last_entry_index];
+            npad.sixaxis_handheld
+                .sixaxis[static_cast<u64>(npad.sixaxis_handheld.common.last_entry_index)];
         auto& dual_left_sixaxis_entry =
-            npad.sixaxis_dual_left.sixaxis[npad.sixaxis_dual_left.common.last_entry_index];
+            npad.sixaxis_dual_left
+                .sixaxis[static_cast<u64>(npad.sixaxis_dual_left.common.last_entry_index)];
         auto& dual_right_sixaxis_entry =
-            npad.sixaxis_dual_right.sixaxis[npad.sixaxis_dual_right.common.last_entry_index];
+            npad.sixaxis_dual_right
+                .sixaxis[static_cast<u64>(npad.sixaxis_dual_right.common.last_entry_index)];
         auto& left_sixaxis_entry =
-            npad.sixaxis_left.sixaxis[npad.sixaxis_left.common.last_entry_index];
+            npad.sixaxis_left.sixaxis[static_cast<u64>(npad.sixaxis_left.common.last_entry_index)];
         auto& right_sixaxis_entry =
-            npad.sixaxis_right.sixaxis[npad.sixaxis_right.common.last_entry_index];
+            npad.sixaxis_right
+                .sixaxis[static_cast<u64>(npad.sixaxis_right.common.last_entry_index)];
 
         switch (controller_type) {
         case NPadControllerType::None:

--- a/src/core/hle/service/hid/controllers/stubbed.cpp
+++ b/src/core/hle/service/hid/controllers/stubbed.cpp
@@ -22,12 +22,12 @@ void Controller_Stubbed::OnUpdate(const Core::Timing::CoreTiming& core_timing, u
         return;
     }
 
-    CommonHeader header{};
-    header.timestamp = core_timing.GetCPUTicks();
-    header.total_entry_count = 17;
-    header.entry_count = 0;
-    header.last_entry_index = 0;
-
+    const CommonHeader header{
+        .timestamp = static_cast<s64>(core_timing.GetCPUTicks()),
+        .total_entry_count = 17,
+        .last_entry_index = 0,
+        .entry_count = 0,
+    };
     std::memcpy(data + common_offset, &header, sizeof(CommonHeader));
 }
 

--- a/src/core/hle/service/hid/controllers/touchscreen.cpp
+++ b/src/core/hle/service/hid/controllers/touchscreen.cpp
@@ -22,7 +22,7 @@ void Controller_Touchscreen::OnRelease() {}
 
 void Controller_Touchscreen::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
                                       std::size_t size) {
-    shared_memory.header.timestamp = core_timing.GetCPUTicks();
+    shared_memory.header.timestamp = static_cast<s64>(core_timing.GetCPUTicks());
     shared_memory.header.total_entry_count = 17;
 
     if (!IsControllerActivated()) {
@@ -33,9 +33,12 @@ void Controller_Touchscreen::OnUpdate(const Core::Timing::CoreTiming& core_timin
     shared_memory.header.entry_count = 16;
 
     const auto& last_entry =
-        shared_memory.shared_memory_entries[shared_memory.header.last_entry_index];
+        shared_memory
+            .shared_memory_entries[static_cast<u64>(shared_memory.header.last_entry_index)];
     shared_memory.header.last_entry_index = (shared_memory.header.last_entry_index + 1) % 17;
-    auto& cur_entry = shared_memory.shared_memory_entries[shared_memory.header.last_entry_index];
+    auto& cur_entry =
+        shared_memory
+            .shared_memory_entries[static_cast<u64>(shared_memory.header.last_entry_index)];
 
     cur_entry.sampling_number = last_entry.sampling_number + 1;
     cur_entry.sampling_number2 = cur_entry.sampling_number;

--- a/src/core/hle/service/hid/controllers/touchscreen.h
+++ b/src/core/hle/service/hid/controllers/touchscreen.h
@@ -69,6 +69,6 @@ private:
     TouchScreenSharedMemory shared_memory{};
     std::unique_ptr<Input::TouchDevice> touch_device;
     std::unique_ptr<Input::TouchDevice> touch_btn_device;
-    s64_le last_touch{};
+    u64_le last_touch{};
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/xpad.cpp
+++ b/src/core/hle/service/hid/controllers/xpad.cpp
@@ -20,7 +20,7 @@ void Controller_XPad::OnRelease() {}
 void Controller_XPad::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
                                std::size_t size) {
     for (auto& xpad_entry : shared_memory.shared_memory_entries) {
-        xpad_entry.header.timestamp = core_timing.GetCPUTicks();
+        xpad_entry.header.timestamp = static_cast<s64>(core_timing.GetCPUTicks());
         xpad_entry.header.total_entry_count = 17;
 
         if (!IsControllerActivated()) {
@@ -30,9 +30,11 @@ void Controller_XPad::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* 
         }
         xpad_entry.header.entry_count = 16;
 
-        const auto& last_entry = xpad_entry.pad_states[xpad_entry.header.last_entry_index];
+        const auto& last_entry =
+            xpad_entry.pad_states[static_cast<u64>(xpad_entry.header.last_entry_index)];
         xpad_entry.header.last_entry_index = (xpad_entry.header.last_entry_index + 1) % 17;
-        auto& cur_entry = xpad_entry.pad_states[xpad_entry.header.last_entry_index];
+        auto& cur_entry =
+            xpad_entry.pad_states[static_cast<u64>(xpad_entry.header.last_entry_index)];
 
         cur_entry.sampling_number = last_entry.sampling_number + 1;
         cur_entry.sampling_number2 = cur_entry.sampling_number;

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -23,7 +23,7 @@ namespace Service::LDR {
 
 constexpr ResultCode ERROR_INSUFFICIENT_ADDRESS_SPACE{ErrorModule::RO, 2};
 
-constexpr ResultCode ERROR_INVALID_MEMORY_STATE{ErrorModule::Loader, 51};
+[[maybe_unused]] constexpr ResultCode ERROR_INVALID_MEMORY_STATE{ErrorModule::Loader, 51};
 constexpr ResultCode ERROR_INVALID_NRO{ErrorModule::Loader, 52};
 constexpr ResultCode ERROR_INVALID_NRR{ErrorModule::Loader, 53};
 constexpr ResultCode ERROR_MISSING_NRR_HASH{ErrorModule::Loader, 54};
@@ -33,7 +33,7 @@ constexpr ResultCode ERROR_ALREADY_LOADED{ErrorModule::Loader, 57};
 constexpr ResultCode ERROR_INVALID_ALIGNMENT{ErrorModule::Loader, 81};
 constexpr ResultCode ERROR_INVALID_SIZE{ErrorModule::Loader, 82};
 constexpr ResultCode ERROR_INVALID_NRO_ADDRESS{ErrorModule::Loader, 84};
-constexpr ResultCode ERROR_INVALID_NRR_ADDRESS{ErrorModule::Loader, 85};
+[[maybe_unused]] constexpr ResultCode ERROR_INVALID_NRR_ADDRESS{ErrorModule::Loader, 85};
 constexpr ResultCode ERROR_NOT_INITIALIZED{ErrorModule::Loader, 87};
 
 constexpr std::size_t MAXIMUM_LOADED_RO{0x40};

--- a/src/core/hle/service/mii/manager.cpp
+++ b/src/core/hle/service/mii/manager.cpp
@@ -240,10 +240,10 @@ MiiStoreData BuildRandomStoreData(Age age, Gender gender, Race race, const Commo
     bf.eye_type.Assign(
         eye_type_info.values[GetRandomValue<std::size_t>(eye_type_info.values_count)]);
 
-    const auto eye_rotate_1{gender != Gender::Male ? 4 : 2};
-    const auto eye_rotate_2{gender != Gender::Male ? 3 : 4};
-    const auto eye_rotate_offset{32 - EyeRotateLookup[eye_rotate_1] + eye_rotate_2};
-    const auto eye_rotate{32 - EyeRotateLookup[bf.eye_type]};
+    const auto eye_rotate_1{gender != Gender::Male ? 4U : 2U};
+    const auto eye_rotate_2{gender != Gender::Male ? 3U : 4U};
+    const auto eye_rotate_offset{32U - EyeRotateLookup[eye_rotate_1] + eye_rotate_2};
+    const auto eye_rotate{32U - EyeRotateLookup[bf.eye_type]};
 
     bf.eye_color.Assign(
         EyeColorLookup[eye_color_info
@@ -257,11 +257,11 @@ MiiStoreData BuildRandomStoreData(Age age, Gender gender, Race race, const Commo
     bf.eyebrow_type.Assign(
         eyebrow_type_info.values[GetRandomValue<std::size_t>(eyebrow_type_info.values_count)]);
 
-    const auto eyebrow_rotate_1{race == Race::Asian ? 6 : 0};
-    const auto eyebrow_y{race == Race::Asian ? 9 : 10};
-    const auto eyebrow_rotate_offset{32 - EyebrowRotateLookup[eyebrow_rotate_1] + 6};
+    const auto eyebrow_rotate_1{race == Race::Asian ? 6U : 0U};
+    const auto eyebrow_y{race == Race::Asian ? 9U : 10U};
+    const auto eyebrow_rotate_offset{32U - EyebrowRotateLookup[eyebrow_rotate_1] + 6};
     const auto eyebrow_rotate{
-        32 - EyebrowRotateLookup[static_cast<std::size_t>(bf.eyebrow_type.Value())]};
+        32U - EyebrowRotateLookup[static_cast<std::size_t>(bf.eyebrow_type.Value())]};
 
     bf.eyebrow_color.Assign(bf.hair_color);
     bf.eyebrow_scale.Assign(4);
@@ -270,14 +270,14 @@ MiiStoreData BuildRandomStoreData(Age age, Gender gender, Race race, const Commo
     bf.eyebrow_x.Assign(2);
     bf.eyebrow_y.Assign(axis_y + eyebrow_y);
 
-    const auto nose_scale{gender == Gender::Female ? 3 : 4};
+    const auto nose_scale{gender == Gender::Female ? 3U : 4U};
 
     bf.nose_type.Assign(
         nose_type_info.values[GetRandomValue<std::size_t>(nose_type_info.values_count)]);
     bf.nose_scale.Assign(nose_scale);
     bf.nose_y.Assign(axis_y + 9);
 
-    const auto mouth_color{gender == Gender::Female ? GetRandomValue<int>(4) : 0};
+    const auto mouth_color{gender == Gender::Female ? GetRandomValue<u32>(4) : 0U};
 
     bf.mouth_type.Assign(
         mouth_type_info.values[GetRandomValue<std::size_t>(mouth_type_info.values_count)]);

--- a/src/core/hle/service/nfp/nfp.cpp
+++ b/src/core/hle/service/nfp/nfp.cpp
@@ -217,7 +217,7 @@ private:
         const auto& amiibo = nfp_interface.GetAmiiboBuffer();
         const TagInfo tag_info{
             .uuid = amiibo.uuid,
-            .uuid_length = static_cast<u8>(tag_info.uuid.size()),
+            .uuid_length = static_cast<u8>(amiibo.uuid.size()),
             .padding_1 = {},
             .protocol = 1, // TODO(ogniK): Figure out actual values
             .tag_type = 2,

--- a/src/core/hle/service/ns/ns.cpp
+++ b/src/core/hle/service/ns/ns.cpp
@@ -368,7 +368,7 @@ ResultVal<u8> IApplicationManagerInterface::GetApplicationDesiredLanguage(
 
     // Get language code from settings
     const auto language_code =
-        Set::GetLanguageCodeFromIndex(Settings::values.language_index.GetValue());
+        Set::GetLanguageCodeFromIndex(static_cast<u32>(Settings::values.language_index.GetValue()));
 
     // Convert to application language, get priority list
     const auto application_language = ConvertToApplicationLanguage(language_code);

--- a/src/core/hle/service/ns/pl_u.cpp
+++ b/src/core/hle/service/ns/pl_u.cpp
@@ -50,19 +50,9 @@ constexpr std::array<std::pair<FontArchives, const char*>, 7> SHARED_FONTS{
     std::make_pair(FontArchives::Extension, "nintendo_ext2_003.bfttf"),
 };
 
-constexpr std::array<const char*, 7> SHARED_FONTS_TTF{
-    "FontStandard.ttf",
-    "FontChineseSimplified.ttf",
-    "FontExtendedChineseSimplified.ttf",
-    "FontChineseTraditional.ttf",
-    "FontKorean.ttf",
-    "FontNintendoExtended.ttf",
-    "FontNintendoExtended2.ttf",
-};
-
 // The below data is specific to shared font data dumped from Switch on f/w 2.2
 // Virtual address and offsets/sizes likely will vary by dump
-constexpr VAddr SHARED_FONT_MEM_VADDR{0x00000009d3016000ULL};
+[[maybe_unused]] constexpr VAddr SHARED_FONT_MEM_VADDR{0x00000009d3016000ULL};
 constexpr u32 EXPECTED_RESULT{0x7f9a0218}; // What we expect the decrypted bfttf first 4 bytes to be
 constexpr u32 EXPECTED_MAGIC{0x36f81a1e};  // What we expect the encrypted bfttf first 4 bytes to be
 constexpr u64 SHARED_FONT_MEM_SIZE{0x1100000};

--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
@@ -139,7 +139,7 @@ u32 nvhost_as_gpu::MapBufferEx(const std::vector<u8>& input, std::vector<u8>& ou
 
     const auto object{nvmap_dev->GetObject(params.nvmap_handle)};
     if (!object) {
-        LOG_CRITICAL(Service_NVDRV, "invalid nvmap_handle={:X}", params.nvmap_handle);
+        LOG_ERROR(Service_NVDRV, "invalid nvmap_handle={:X}", params.nvmap_handle);
         std::memcpy(output.data(), &params, output.size());
         return NvErrCodes::InvalidInput;
     }
@@ -151,21 +151,24 @@ u32 nvhost_as_gpu::MapBufferEx(const std::vector<u8>& input, std::vector<u8>& ou
     auto& gpu = system.GPU();
 
     u64 page_size{params.page_size};
-    if (!page_size) {
+    if (page_size == 0) {
         page_size = object->align;
     }
 
     if ((params.flags & AddressSpaceFlags::Remap) != AddressSpaceFlags::None) {
-        if (const auto buffer_map{FindBufferMap(params.offset)}; buffer_map) {
-            const auto cpu_addr{static_cast<VAddr>(buffer_map->CpuAddr() + params.buffer_offset)};
+        const auto buffer_map = FindBufferMap(static_cast<GPUVAddr>(params.offset));
+
+        if (buffer_map) {
+            const auto cpu_addr{
+                static_cast<VAddr>(buffer_map->CpuAddr() + static_cast<u64>(params.buffer_offset))};
             const auto gpu_addr{static_cast<GPUVAddr>(params.offset + params.buffer_offset)};
 
             if (!gpu.MemoryManager().Map(cpu_addr, gpu_addr, params.mapping_size)) {
-                LOG_CRITICAL(Service_NVDRV,
-                             "remap failed, flags={:X}, nvmap_handle={:X}, buffer_offset={}, "
-                             "mapping_size = {}, offset={}",
-                             params.flags, params.nvmap_handle, params.buffer_offset,
-                             params.mapping_size, params.offset);
+                LOG_ERROR(Service_NVDRV,
+                          "Remap failed, flags={:X}, nvmap_handle={:X}, buffer_offset={}, "
+                          "mapping_size = {}, offset={}",
+                          params.flags, params.nvmap_handle, params.buffer_offset,
+                          params.mapping_size, params.offset);
 
                 std::memcpy(output.data(), &params, output.size());
                 return NvErrCodes::InvalidInput;
@@ -174,7 +177,7 @@ u32 nvhost_as_gpu::MapBufferEx(const std::vector<u8>& input, std::vector<u8>& ou
             std::memcpy(output.data(), &params, output.size());
             return NvErrCodes::Success;
         } else {
-            LOG_CRITICAL(Service_NVDRV, "address not mapped offset={}", params.offset);
+            LOG_ERROR(Service_NVDRV, "Address not mapped. offset={}", params.offset);
 
             std::memcpy(output.data(), &params, output.size());
             return NvErrCodes::InvalidInput;
@@ -184,25 +187,27 @@ u32 nvhost_as_gpu::MapBufferEx(const std::vector<u8>& input, std::vector<u8>& ou
     // We can only map objects that have already been assigned a CPU address.
     ASSERT(object->status == nvmap::Object::Status::Allocated);
 
-    const auto physical_address{object->addr + params.buffer_offset};
+    const auto physical_address{object->addr + static_cast<VAddr>(params.buffer_offset)};
     u64 size{params.mapping_size};
-    if (!size) {
+    if (size == 0) {
         size = object->size;
     }
 
     const bool is_alloc{(params.flags & AddressSpaceFlags::FixedOffset) == AddressSpaceFlags::None};
     if (is_alloc) {
-        params.offset = gpu.MemoryManager().MapAllocate(physical_address, size, page_size);
+        params.offset =
+            static_cast<s64>(gpu.MemoryManager().MapAllocate(physical_address, size, page_size));
     } else {
-        params.offset = gpu.MemoryManager().Map(physical_address, params.offset, size);
+        params.offset = static_cast<s64>(
+            gpu.MemoryManager().Map(physical_address, static_cast<GPUVAddr>(params.offset), size));
     }
 
     auto result{NvErrCodes::Success};
-    if (!params.offset) {
-        LOG_CRITICAL(Service_NVDRV, "failed to map size={}", size);
+    if (params.offset == 0) {
+        LOG_ERROR(Service_NVDRV, "Failed to map size={}", size);
         result = NvErrCodes::InvalidInput;
     } else {
-        AddBufferMap(params.offset, size, physical_address, is_alloc);
+        AddBufferMap(static_cast<GPUVAddr>(params.offset), size, physical_address, is_alloc);
     }
 
     std::memcpy(output.data(), &params, output.size());
@@ -213,12 +218,13 @@ u32 nvhost_as_gpu::UnmapBuffer(const std::vector<u8>& input, std::vector<u8>& ou
     IoctlUnmapBuffer params{};
     std::memcpy(&params, input.data(), input.size());
 
-    LOG_DEBUG(Service_NVDRV, "called, offset=0x{:X}", params.offset);
+    const auto offset = static_cast<GPUVAddr>(params.offset);
+    LOG_DEBUG(Service_NVDRV, "called, offset=0x{:X}", offset);
 
-    if (const auto size{RemoveBufferMap(params.offset)}; size) {
-        system.GPU().MemoryManager().Unmap(params.offset, *size);
+    if (const auto size{RemoveBufferMap(offset)}; size) {
+        system.GPU().MemoryManager().Unmap(offset, *size);
     } else {
-        LOG_ERROR(Service_NVDRV, "invalid offset=0x{:X}", params.offset);
+        LOG_ERROR(Service_NVDRV, "invalid offset=0x{:X}", offset);
     }
 
     std::memcpy(output.data(), &params, output.size());

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -63,8 +63,7 @@ u32 nvhost_ctrl::IocCtrlEventWait(const std::vector<u8>& input, std::vector<u8>&
         return NvResult::BadParameter;
     }
 
-    u32 event_id = params.value & 0x00FF;
-
+    const u32 event_id = params.value & 0x00FF;
     if (event_id >= MaxNvEvents) {
         std::memcpy(output.data(), &params, sizeof(params));
         return NvResult::BadParameter;
@@ -78,16 +77,17 @@ u32 nvhost_ctrl::IocCtrlEventWait(const std::vector<u8>& input, std::vector<u8>&
         event.writable->Signal();
         return NvResult::Success;
     }
+
     auto lock = gpu.LockSync();
     const u32 current_syncpoint_value = gpu.GetSyncpointValue(params.syncpt_id);
-    const s32 diff = current_syncpoint_value - params.threshold;
+    const s32 diff = static_cast<s32>(current_syncpoint_value - params.threshold);
     if (diff >= 0) {
         event.writable->Signal();
         params.value = current_syncpoint_value;
         std::memcpy(output.data(), &params, sizeof(params));
         return NvResult::Success;
     }
-    const u32 target_value = current_syncpoint_value - diff;
+    const u32 target_value = current_syncpoint_value - static_cast<u32>(diff);
 
     if (!is_async) {
         params.value = 0;
@@ -98,7 +98,7 @@ u32 nvhost_ctrl::IocCtrlEventWait(const std::vector<u8>& input, std::vector<u8>&
         return NvResult::Timeout;
     }
 
-    EventState status = events_interface.status[event_id];
+    const EventState status = events_interface.status[event_id];
     if (event_id < MaxNvEvents || status == EventState::Free || status == EventState::Registered) {
         events_interface.SetEventStatus(event_id, EventState::Waiting);
         events_interface.assigned_syncpt[event_id] = params.syncpt_id;
@@ -114,7 +114,7 @@ u32 nvhost_ctrl::IocCtrlEventWait(const std::vector<u8>& input, std::vector<u8>&
         if (!is_async && ctrl.fresh_call) {
             ctrl.must_delay = true;
             ctrl.timeout = params.timeout;
-            ctrl.event_id = event_id;
+            ctrl.event_id = static_cast<s32>(event_id);
             return NvResult::Timeout;
         }
         std::memcpy(output.data(), &params, sizeof(params));

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
@@ -127,7 +127,7 @@ u32 nvhost_gpu::AllocGPFIFOEx2(const std::vector<u8>& input, std::vector<u8>& ou
                 params.unk3);
 
     auto& gpu = system.GPU();
-    params.fence_out.id = assigned_syncpoints;
+    params.fence_out.id = static_cast<s32>(assigned_syncpoints);
     params.fence_out.value = gpu.GetSyncpointValue(assigned_syncpoints);
     assigned_syncpoints++;
     std::memcpy(output.data(), &params, output.size());
@@ -166,7 +166,8 @@ u32 nvhost_gpu::SubmitGPFIFO(const std::vector<u8>& input, std::vector<u8>& outp
     UNIMPLEMENTED_IF(params.flags.add_increment.Value() != 0);
 
     auto& gpu = system.GPU();
-    u32 current_syncpoint_value = gpu.GetSyncpointValue(params.fence_out.id);
+    const u32 current_syncpoint_value =
+        gpu.GetSyncpointValue(static_cast<u32>(params.fence_out.id));
     if (params.flags.increment.Value()) {
         params.fence_out.value += current_syncpoint_value;
     } else {
@@ -200,7 +201,8 @@ u32 nvhost_gpu::KickoffPB(const std::vector<u8>& input, std::vector<u8>& output,
     UNIMPLEMENTED_IF(params.flags.add_increment.Value() != 0);
 
     auto& gpu = system.GPU();
-    u32 current_syncpoint_value = gpu.GetSyncpointValue(params.fence_out.id);
+    const u32 current_syncpoint_value =
+        gpu.GetSyncpointValue(static_cast<u32>(params.fence_out.id));
     if (params.flags.increment.Value()) {
         params.fence_out.value += current_syncpoint_value;
     } else {

--- a/src/core/hle/service/nvdrv/interface.cpp
+++ b/src/core/hle/service/nvdrv/interface.cpp
@@ -61,9 +61,9 @@ void NVDRV::IoctlBase(Kernel::HLERequestContext& ctx, IoctlVersion version) {
     if (ctrl.must_delay) {
         ctrl.fresh_call = false;
         ctx.SleepClientThread(
-            "NVServices::DelayedResponse", ctrl.timeout,
-            [=, this](std::shared_ptr<Kernel::Thread> thread, Kernel::HLERequestContext& ctx_,
-                      Kernel::ThreadWakeupReason reason) {
+            "NVServices::DelayedResponse", static_cast<u64>(ctrl.timeout),
+            [=, this](std::shared_ptr<Kernel::Thread>, Kernel::HLERequestContext& ctx_,
+                      Kernel::ThreadWakeupReason) {
                 IoctlCtrl ctrl2{ctrl};
                 std::vector<u8> tmp_output = output;
                 std::vector<u8> tmp_output2 = output2;
@@ -77,7 +77,7 @@ void NVDRV::IoctlBase(Kernel::HLERequestContext& ctx, IoctlVersion version) {
                 rb.Push(RESULT_SUCCESS);
                 rb.Push(ioctl_result);
             },
-            nvdrv->GetEventWriteable(ctrl.event_id));
+            nvdrv->GetEventWriteable(static_cast<u32>(ctrl.event_id)));
     } else {
         ctx.WriteBuffer(output);
         if (version == IoctlVersion::Version3) {

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -247,7 +247,7 @@ void NVFlinger::Compose() {
         guard->unlock();
         for (u32 fence_id = 0; fence_id < multi_fence.num_fences; fence_id++) {
             const auto& fence = multi_fence.fences[fence_id];
-            gpu.WaitFence(fence.id, fence.value);
+            gpu.WaitFence(static_cast<u32>(fence.id), fence.value);
         }
         guard->lock();
 

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -80,10 +80,10 @@ namespace Service {
                                                        std::string_view port_name,
                                                        const u32* cmd_buff) {
     // Number of params == bits 0-5 + bits 6-11
-    int num_params = (cmd_buff[0] & 0x3F) + ((cmd_buff[0] >> 6) & 0x3F);
+    const u32 num_params = (cmd_buff[0] & 0x3F) + ((cmd_buff[0] >> 6) & 0x3F);
 
     std::string function_string = fmt::format("function '{}': port={}", name, port_name);
-    for (int i = 1; i <= num_params; ++i) {
+    for (u32 i = 1; i <= num_params; ++i) {
         function_string += fmt::format(", cmd_buff[{}]=0x{:X}", i, cmd_buff[i]);
     }
     return function_string;

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -91,7 +91,8 @@ void GetAvailableLanguageCodesImpl(Kernel::HLERequestContext& ctx, std::size_t m
 }
 
 void GetKeyCodeMapImpl(Kernel::HLERequestContext& ctx) {
-    const auto language_code = available_language_codes[Settings::values.language_index.GetValue()];
+    const auto language_code =
+        available_language_codes[static_cast<u32>(Settings::values.language_index.GetValue())];
     const auto key_code =
         std::find_if(language_to_layout.cbegin(), language_to_layout.cend(),
                      [=](const auto& element) { return element.first == language_code; });
@@ -167,7 +168,8 @@ void SET::GetLanguageCode(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
-    rb.PushEnum(available_language_codes[Settings::values.language_index.GetValue()]);
+    rb.PushEnum(
+        available_language_codes[static_cast<u32>(Settings::values.language_index.GetValue())]);
 }
 
 void SET::GetRegionCode(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -437,9 +437,9 @@ std::pair<s32, Errno> BSD::SocketImpl(Domain domain, Type type, Protocol protoco
         UNIMPLEMENTED_MSG("SOCK_RAW errno management");
     }
 
-    [[maybe_unused]] const bool unk_flag = (static_cast<u32>(type) & 0x20000000) != 0;
+    [[maybe_unused]] const bool unk_flag = (static_cast<u32>(type) & 0x20000000U) != 0;
     UNIMPLEMENTED_IF_MSG(unk_flag, "Unknown flag in type");
-    type = static_cast<Type>(static_cast<u32>(type) & ~0x20000000);
+    type = static_cast<Type>(static_cast<u32>(type) & ~0x20000000U);
 
     const s32 fd = FindFreeFileDescriptorHandle();
     if (fd < 0) {
@@ -447,7 +447,7 @@ std::pair<s32, Errno> BSD::SocketImpl(Domain domain, Type type, Protocol protoco
         return {-1, Errno::MFILE};
     }
 
-    FileDescriptor& descriptor = file_descriptors[fd].emplace();
+    FileDescriptor& descriptor = GetFileDescriptor(fd).emplace();
     // ENONMEM might be thrown here
 
     LOG_INFO(Service, "New socket fd={}", fd);
@@ -461,7 +461,7 @@ std::pair<s32, Errno> BSD::SocketImpl(Domain domain, Type type, Protocol protoco
 
 std::pair<s32, Errno> BSD::PollImpl(std::vector<u8>& write_buffer, std::vector<u8> read_buffer,
                                     s32 nfds, s32 timeout) {
-    if (write_buffer.size() < nfds * sizeof(PollFD)) {
+    if (write_buffer.size() < static_cast<size_t>(nfds) * sizeof(PollFD)) {
         return {-1, Errno::INVAL};
     }
 
@@ -471,7 +471,7 @@ std::pair<s32, Errno> BSD::PollImpl(std::vector<u8>& write_buffer, std::vector<u
     }
 
     const size_t length = std::min(read_buffer.size(), write_buffer.size());
-    std::vector<PollFD> fds(nfds);
+    std::vector<PollFD> fds(static_cast<size_t>(nfds));
     std::memcpy(fds.data(), read_buffer.data(), length);
 
     if (timeout >= 0) {
@@ -497,7 +497,7 @@ std::pair<s32, Errno> BSD::PollImpl(std::vector<u8>& write_buffer, std::vector<u
             return {0, Errno::SUCCESS};
         }
 
-        const std::optional<FileDescriptor>& descriptor = file_descriptors[pollfd.fd];
+        const std::optional<FileDescriptor>& descriptor = GetFileDescriptor(pollfd.fd);
         if (!descriptor) {
             LOG_ERROR(Service, "File descriptor handle={} is not allocated", pollfd.fd);
             pollfd.revents = POLL_NVAL;
@@ -508,7 +508,7 @@ std::pair<s32, Errno> BSD::PollImpl(std::vector<u8>& write_buffer, std::vector<u
     std::vector<Network::PollFD> host_pollfds(fds.size());
     std::transform(fds.begin(), fds.end(), host_pollfds.begin(), [this](PollFD pollfd) {
         Network::PollFD result;
-        result.socket = file_descriptors[pollfd.fd]->socket.get();
+        result.socket = GetFileDescriptor(pollfd.fd)->socket.get();
         result.events = TranslatePollEventsToHost(pollfd.events);
         result.revents = 0;
         return result;
@@ -536,13 +536,13 @@ std::pair<s32, Errno> BSD::AcceptImpl(s32 fd, std::vector<u8>& write_buffer) {
         return {-1, Errno::MFILE};
     }
 
-    FileDescriptor& descriptor = *file_descriptors[fd];
+    FileDescriptor& descriptor = *GetFileDescriptor(fd);
     auto [result, bsd_errno] = descriptor.socket->Accept();
     if (bsd_errno != Network::Errno::SUCCESS) {
         return {-1, Translate(bsd_errno)};
     }
 
-    FileDescriptor& new_descriptor = file_descriptors[new_fd].emplace();
+    FileDescriptor& new_descriptor = GetFileDescriptor(new_fd).emplace();
     new_descriptor.socket = std::move(result.socket);
     new_descriptor.is_connection_based = descriptor.is_connection_based;
 
@@ -561,7 +561,7 @@ Errno BSD::BindImpl(s32 fd, const std::vector<u8>& addr) {
     SockAddrIn addr_in;
     std::memcpy(&addr_in, addr.data(), sizeof(addr_in));
 
-    return Translate(file_descriptors[fd]->socket->Bind(Translate(addr_in)));
+    return Translate(GetFileDescriptor(fd)->socket->Bind(Translate(addr_in)));
 }
 
 Errno BSD::ConnectImpl(s32 fd, const std::vector<u8>& addr) {
@@ -573,7 +573,7 @@ Errno BSD::ConnectImpl(s32 fd, const std::vector<u8>& addr) {
     SockAddrIn addr_in;
     std::memcpy(&addr_in, addr.data(), sizeof(addr_in));
 
-    return Translate(file_descriptors[fd]->socket->Connect(Translate(addr_in)));
+    return Translate(GetFileDescriptor(fd)->socket->Connect(Translate(addr_in)));
 }
 
 Errno BSD::GetPeerNameImpl(s32 fd, std::vector<u8>& write_buffer) {
@@ -581,7 +581,7 @@ Errno BSD::GetPeerNameImpl(s32 fd, std::vector<u8>& write_buffer) {
         return Errno::BADF;
     }
 
-    const auto [addr_in, bsd_errno] = file_descriptors[fd]->socket->GetPeerName();
+    const auto [addr_in, bsd_errno] = GetFileDescriptor(fd)->socket->GetPeerName();
     if (bsd_errno != Network::Errno::SUCCESS) {
         return Translate(bsd_errno);
     }
@@ -597,7 +597,7 @@ Errno BSD::GetSockNameImpl(s32 fd, std::vector<u8>& write_buffer) {
         return Errno::BADF;
     }
 
-    const auto [addr_in, bsd_errno] = file_descriptors[fd]->socket->GetSockName();
+    const auto [addr_in, bsd_errno] = GetFileDescriptor(fd)->socket->GetSockName();
     if (bsd_errno != Network::Errno::SUCCESS) {
         return Translate(bsd_errno);
     }
@@ -612,7 +612,7 @@ Errno BSD::ListenImpl(s32 fd, s32 backlog) {
     if (!IsFileDescriptorValid(fd)) {
         return Errno::BADF;
     }
-    return Translate(file_descriptors[fd]->socket->Listen(backlog));
+    return Translate(GetFileDescriptor(fd)->socket->Listen(backlog));
 }
 
 std::pair<s32, Errno> BSD::FcntlImpl(s32 fd, FcntlCmd cmd, s32 arg) {
@@ -620,14 +620,14 @@ std::pair<s32, Errno> BSD::FcntlImpl(s32 fd, FcntlCmd cmd, s32 arg) {
         return {-1, Errno::BADF};
     }
 
-    FileDescriptor& descriptor = *file_descriptors[fd];
+    FileDescriptor& descriptor = *GetFileDescriptor(fd);
 
     switch (cmd) {
     case FcntlCmd::GETFL:
         ASSERT(arg == 0);
         return {descriptor.flags, Errno::SUCCESS};
     case FcntlCmd::SETFL: {
-        const bool enable = (arg & FLAG_O_NONBLOCK) != 0;
+        const bool enable = (static_cast<u32>(arg) & FLAG_O_NONBLOCK) != 0;
         const Errno bsd_errno = Translate(descriptor.socket->SetNonBlock(enable));
         if (bsd_errno != Errno::SUCCESS) {
             return {-1, bsd_errno};
@@ -648,7 +648,7 @@ Errno BSD::SetSockOptImpl(s32 fd, u32 level, OptName optname, size_t optlen, con
         return Errno::BADF;
     }
 
-    Network::Socket* const socket = file_descriptors[fd]->socket.get();
+    Network::Socket* const socket = GetFileDescriptor(fd)->socket.get();
 
     if (optname == OptName::LINGER) {
         ASSERT(optlen == sizeof(Linger));
@@ -689,14 +689,14 @@ Errno BSD::ShutdownImpl(s32 fd, s32 how) {
         return Errno::BADF;
     }
     const Network::ShutdownHow host_how = Translate(static_cast<ShutdownHow>(how));
-    return Translate(file_descriptors[fd]->socket->Shutdown(host_how));
+    return Translate(GetFileDescriptor(fd)->socket->Shutdown(host_how));
 }
 
 std::pair<s32, Errno> BSD::RecvImpl(s32 fd, u32 flags, std::vector<u8>& message) {
     if (!IsFileDescriptorValid(fd)) {
         return {-1, Errno::BADF};
     }
-    return Translate(file_descriptors[fd]->socket->Recv(flags, message));
+    return Translate(GetFileDescriptor(fd)->socket->Recv(flags, message));
 }
 
 std::pair<s32, Errno> BSD::RecvFromImpl(s32 fd, u32 flags, std::vector<u8>& message,
@@ -705,7 +705,7 @@ std::pair<s32, Errno> BSD::RecvFromImpl(s32 fd, u32 flags, std::vector<u8>& mess
         return {-1, Errno::BADF};
     }
 
-    FileDescriptor& descriptor = *file_descriptors[fd];
+    FileDescriptor& descriptor = *GetFileDescriptor(fd);
 
     Network::SockAddrIn addr_in{};
     Network::SockAddrIn* p_addr_in = nullptr;
@@ -719,7 +719,7 @@ std::pair<s32, Errno> BSD::RecvFromImpl(s32 fd, u32 flags, std::vector<u8>& mess
     // Apply flags
     if ((flags & FLAG_MSG_DONTWAIT) != 0) {
         flags &= ~FLAG_MSG_DONTWAIT;
-        if ((descriptor.flags & FLAG_O_NONBLOCK) == 0) {
+        if ((static_cast<u32>(descriptor.flags) & FLAG_O_NONBLOCK) == 0) {
             descriptor.socket->SetNonBlock(true);
         }
     }
@@ -727,7 +727,7 @@ std::pair<s32, Errno> BSD::RecvFromImpl(s32 fd, u32 flags, std::vector<u8>& mess
     const auto [ret, bsd_errno] = Translate(descriptor.socket->RecvFrom(flags, message, p_addr_in));
 
     // Restore original state
-    if ((descriptor.flags & FLAG_O_NONBLOCK) == 0) {
+    if ((static_cast<u32>(descriptor.flags) & FLAG_O_NONBLOCK) == 0) {
         descriptor.socket->SetNonBlock(false);
     }
 
@@ -748,7 +748,7 @@ std::pair<s32, Errno> BSD::SendImpl(s32 fd, u32 flags, const std::vector<u8>& me
     if (!IsFileDescriptorValid(fd)) {
         return {-1, Errno::BADF};
     }
-    return Translate(file_descriptors[fd]->socket->Send(message, flags));
+    return Translate(GetFileDescriptor(fd)->socket->Send(message, flags));
 }
 
 std::pair<s32, Errno> BSD::SendToImpl(s32 fd, u32 flags, const std::vector<u8>& message,
@@ -767,7 +767,8 @@ std::pair<s32, Errno> BSD::SendToImpl(s32 fd, u32 flags, const std::vector<u8>& 
         p_addr_in = &addr_in;
     }
 
-    return Translate(file_descriptors[fd]->socket->SendTo(flags, message, p_addr_in));
+    const auto& descriptor = GetFileDescriptor(fd);
+    return Translate(descriptor->socket->SendTo(flags, message, p_addr_in));
 }
 
 Errno BSD::CloseImpl(s32 fd) {
@@ -775,20 +776,21 @@ Errno BSD::CloseImpl(s32 fd) {
         return Errno::BADF;
     }
 
-    const Errno bsd_errno = Translate(file_descriptors[fd]->socket->Close());
+    auto& descriptor = GetFileDescriptor(fd);
+    const Errno bsd_errno = Translate(descriptor->socket->Close());
     if (bsd_errno != Errno::SUCCESS) {
         return bsd_errno;
     }
 
     LOG_INFO(Service, "Close socket fd={}", fd);
 
-    file_descriptors[fd].reset();
+    descriptor.reset();
     return bsd_errno;
 }
 
 s32 BSD::FindFreeFileDescriptorHandle() noexcept {
     for (s32 fd = 0; fd < static_cast<s32>(file_descriptors.size()); ++fd) {
-        if (!file_descriptors[fd]) {
+        if (!GetFileDescriptor(fd)) {
             return fd;
         }
     }
@@ -800,7 +802,7 @@ bool BSD::IsFileDescriptorValid(s32 fd) const noexcept {
         LOG_ERROR(Service, "Invalid file descriptor handle={}", fd);
         return false;
     }
-    if (!file_descriptors[fd]) {
+    if (!GetFileDescriptor(fd)) {
         LOG_ERROR(Service, "File descriptor handle={} is not allocated", fd);
         return false;
     }
@@ -813,10 +815,12 @@ bool BSD::IsBlockingSocket(s32 fd) const noexcept {
     if (fd > static_cast<s32>(MAX_FD) || fd < 0) {
         return false;
     }
-    if (!file_descriptors[fd]) {
+
+    const auto& descriptor = GetFileDescriptor(fd);
+    if (!descriptor) {
         return false;
     }
-    return (file_descriptors[fd]->flags & FLAG_O_NONBLOCK) != 0;
+    return (static_cast<u32>(descriptor->flags) & FLAG_O_NONBLOCK) != 0;
 }
 
 void BSD::BuildErrnoResponse(Kernel::HLERequestContext& ctx, Errno bsd_errno) const noexcept {
@@ -825,6 +829,14 @@ void BSD::BuildErrnoResponse(Kernel::HLERequestContext& ctx, Errno bsd_errno) co
     rb.Push(RESULT_SUCCESS);
     rb.Push<s32>(bsd_errno == Errno::SUCCESS ? 0 : -1);
     rb.PushEnum(bsd_errno);
+}
+
+std::optional<BSD::FileDescriptor>& BSD::GetFileDescriptor(s32 fd) {
+    return file_descriptors[static_cast<u32>(fd)];
+}
+
+const std::optional<BSD::FileDescriptor>& BSD::GetFileDescriptor(s32 fd) const {
+    return file_descriptors[static_cast<u32>(fd)];
 }
 
 BSD::BSD(Core::System& system, const char* name)

--- a/src/core/hle/service/sockets/bsd.h
+++ b/src/core/hle/service/sockets/bsd.h
@@ -167,6 +167,9 @@ private:
 
     void BuildErrnoResponse(Kernel::HLERequestContext& ctx, Errno bsd_errno) const noexcept;
 
+    std::optional<FileDescriptor>& GetFileDescriptor(s32 fd);
+    const std::optional<FileDescriptor>& GetFileDescriptor(s32 fd) const;
+
     std::array<std::optional<FileDescriptor>, MAX_FD> file_descriptors;
 
     BlockingWorkerPool<BSD, PollWork, AcceptWork, ConnectWork, RecvWork, RecvFromWork, SendWork,

--- a/src/core/hle/service/sockets/sockets_translate.cpp
+++ b/src/core/hle/service/sockets/sockets_translate.cpp
@@ -64,6 +64,7 @@ Network::Type Translate(Type type) {
         return Network::Type::DGRAM;
     default:
         UNIMPLEMENTED_MSG("Unimplemented type={}", static_cast<int>(type));
+        return {};
     }
 }
 

--- a/src/core/hle/service/time/time_zone_manager.cpp
+++ b/src/core/hle/service/time/time_zone_manager.cpp
@@ -117,7 +117,8 @@ static constexpr int GetMonthLength(bool is_leap_year, int month) {
     constexpr std::array<int, 12> month_lengths{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
     constexpr std::array<int, 12> month_lengths_leap{31, 29, 31, 30, 31, 30,
                                                      31, 31, 30, 31, 30, 31};
-    return is_leap_year ? month_lengths_leap[month] : month_lengths[month];
+    const auto month_index = static_cast<u32>(month);
+    return is_leap_year ? month_lengths_leap[month_index] : month_lengths[month_index];
 }
 
 static constexpr bool IsDigit(char value) {
@@ -320,7 +321,7 @@ static bool ParsePosixName(const char* name, TimeZoneRule& rule) {
     int dest_len{};
     int dest_offset{};
     const char* dest_name{name + offset};
-    if (rule.chars.size() < std::size_t(char_count)) {
+    if (rule.chars.size() < static_cast<std::size_t>(char_count)) {
         return {};
     }
 
@@ -343,7 +344,7 @@ static bool ParsePosixName(const char* name, TimeZoneRule& rule) {
             return {};
         }
         char_count += dest_len + 1;
-        if (rule.chars.size() < std::size_t(char_count)) {
+        if (rule.chars.size() < static_cast<std::size_t>(char_count)) {
             return {};
         }
         if (name[offset] != '\0' && name[offset] != ',' && name[offset] != ';') {
@@ -386,7 +387,7 @@ static bool ParsePosixName(const char* name, TimeZoneRule& rule) {
             rule.default_type = 0;
 
             s64 jan_first{};
-            int time_count{};
+            u32 time_count{};
             int jan_offset{};
             int year_beginning{epoch_year};
             do {
@@ -414,7 +415,7 @@ static bool ParsePosixName(const char* name, TimeZoneRule& rule) {
                 if (is_reversed ||
                     (start_time < end_time &&
                      (end_time - start_time < (year_seconds + (std_offset - dest_offset))))) {
-                    if (rule.ats.size() - 2 < std::size_t(time_count)) {
+                    if (rule.ats.size() - 2 < time_count) {
                         break;
                     }
 
@@ -438,7 +439,7 @@ static bool ParsePosixName(const char* name, TimeZoneRule& rule) {
                 }
                 jan_offset = 0;
             }
-            rule.time_count = time_count;
+            rule.time_count = static_cast<s32>(time_count);
             if (time_count == 0) {
                 rule.type_count = 1;
             } else if (years_per_repeat < year - year_beginning) {
@@ -451,26 +452,30 @@ static bool ParsePosixName(const char* name, TimeZoneRule& rule) {
             }
 
             s64 their_std_offset{};
-            for (int index{}; index < rule.time_count; ++index) {
+            for (u32 index = 0; index < static_cast<u32>(rule.time_count); ++index) {
                 const s8 type{rule.types[index]};
-                if (rule.ttis[type].is_standard_time_daylight) {
-                    their_std_offset = -rule.ttis[type].gmt_offset;
+                const auto& tti = rule.ttis[static_cast<u8>(type)];
+
+                if (tti.is_standard_time_daylight) {
+                    their_std_offset = -tti.gmt_offset;
                 }
             }
 
             s64 their_offset{their_std_offset};
-            for (int index{}; index < rule.time_count; ++index) {
+            for (u32 index = 0; index < static_cast<u32>(rule.time_count); ++index) {
                 const s8 type{rule.types[index]};
-                rule.types[index] = rule.ttis[type].is_dst ? 1 : 0;
-                if (!rule.ttis[type].is_gmt) {
-                    if (!rule.ttis[type].is_standard_time_daylight) {
+                const auto& tti = rule.ttis[static_cast<u8>(type)];
+
+                rule.types[index] = tti.is_dst ? 1 : 0;
+                if (!tti.is_gmt) {
+                    if (!tti.is_standard_time_daylight) {
                         rule.ats[index] += dest_offset - their_std_offset;
                     } else {
                         rule.ats[index] += std_offset - their_std_offset;
                     }
                 }
-                their_offset = -rule.ttis[type].gmt_offset;
-                if (!rule.ttis[type].is_dst) {
+                their_offset = -tti.gmt_offset;
+                if (!tti.is_dst) {
                     their_std_offset = their_offset;
                 }
             }
@@ -494,16 +499,16 @@ static bool ParsePosixName(const char* name, TimeZoneRule& rule) {
     }
 
     rule.char_count = char_count;
-    for (int index{}; index < std_len; ++index) {
+    for (std::size_t index = 0; index < static_cast<std::size_t>(std_len); ++index) {
         rule.chars[index] = std_name[index];
     }
 
-    rule.chars[std_len++] = '\0';
+    rule.chars[static_cast<size_t>(std_len++)] = '\0';
     if (dest_len != 0) {
-        for (int index{}; index < dest_len; ++index) {
-            rule.chars[std_len + index] = dest_name[index];
+        for (int index = 0; index < dest_len; ++index) {
+            rule.chars[static_cast<std::size_t>(std_len + index)] = dest_name[index];
         }
-        rule.chars[std_len + dest_len] = '\0';
+        rule.chars[static_cast<std::size_t>(std_len + dest_len)] = '\0';
     }
 
     return true;
@@ -531,33 +536,33 @@ static bool ParseTimeZoneBinary(TimeZoneRule& time_zone_rule, FileSys::VirtualFi
 
     int time_count{};
     u64 read_offset = sizeof(TzifHeader);
-    for (int index{}; index < time_zone_rule.time_count; ++index) {
+    for (size_t index = 0; index < static_cast<size_t>(time_zone_rule.time_count); ++index) {
         s64_be at{};
         vfs_file->ReadObject<s64_be>(&at, read_offset);
         time_zone_rule.types[index] = 1;
-        if (time_count != 0 && at <= time_zone_rule.ats[time_count - 1]) {
-            if (at < time_zone_rule.ats[time_count - 1]) {
+        if (time_count != 0 && at <= time_zone_rule.ats[static_cast<size_t>(time_count) - 1]) {
+            if (at < time_zone_rule.ats[static_cast<size_t>(time_count) - 1]) {
                 return {};
             }
             time_zone_rule.types[index - 1] = 0;
             time_count--;
         }
-        time_zone_rule.ats[time_count++] = at;
+        time_zone_rule.ats[static_cast<size_t>(time_count++)] = at;
         read_offset += sizeof(s64_be);
     }
     time_count = 0;
-    for (int index{}; index < time_zone_rule.time_count; ++index) {
-        const u8 type{*vfs_file->ReadByte(read_offset)};
-        read_offset += sizeof(u8);
+    for (size_t index = 0; index < static_cast<size_t>(time_zone_rule.time_count); ++index) {
+        const auto type{static_cast<s8>(*vfs_file->ReadByte(read_offset))};
+        read_offset += sizeof(s8);
         if (time_zone_rule.time_count <= type) {
             return {};
         }
         if (time_zone_rule.types[index] != 0) {
-            time_zone_rule.types[time_count++] = type;
+            time_zone_rule.types[static_cast<size_t>(time_count++)] = type;
         }
     }
     time_zone_rule.time_count = time_count;
-    for (int index{}; index < time_zone_rule.type_count; ++index) {
+    for (size_t index = 0; index < static_cast<size_t>(time_zone_rule.type_count); ++index) {
         TimeTypeInfo& ttis{time_zone_rule.ttis[index]};
         u32_be gmt_offset{};
         vfs_file->ReadObject<u32_be>(&gmt_offset, read_offset);
@@ -579,10 +584,11 @@ static bool ParseTimeZoneBinary(TimeZoneRule& time_zone_rule, FileSys::VirtualFi
         ttis.abbreviation_list_index = abbreviation_list_index;
     }
 
-    vfs_file->ReadArray(time_zone_rule.chars.data(), time_zone_rule.char_count, read_offset);
-    time_zone_rule.chars[time_zone_rule.char_count] = '\0';
-    read_offset += time_zone_rule.char_count;
-    for (int index{}; index < time_zone_rule.type_count; ++index) {
+    vfs_file->ReadArray(time_zone_rule.chars.data(), static_cast<u32>(time_zone_rule.char_count),
+                        read_offset);
+    time_zone_rule.chars[static_cast<u32>(time_zone_rule.char_count)] = '\0';
+    read_offset += static_cast<u64>(time_zone_rule.char_count);
+    for (size_t index = 0; index < static_cast<size_t>(time_zone_rule.type_count); ++index) {
         if (header.ttis_std_count == 0) {
             time_zone_rule.ttis[index].is_standard_time_daylight = false;
         } else {
@@ -595,7 +601,7 @@ static bool ParseTimeZoneBinary(TimeZoneRule& time_zone_rule, FileSys::VirtualFi
         }
     }
 
-    for (int index{}; index < time_zone_rule.type_count; ++index) {
+    for (size_t index = 0; index < static_cast<size_t>(time_zone_rule.type_count); ++index) {
         if (header.ttis_std_count == 0) {
             time_zone_rule.ttis[index].is_gmt = false;
         } else {
@@ -619,13 +625,14 @@ static bool ParseTimeZoneBinary(TimeZoneRule& time_zone_rule, FileSys::VirtualFi
     }
 
     std::array<char, time_zone_name_max + 1> temp_name{};
-    vfs_file->ReadArray(temp_name.data(), bytes_read, read_offset);
-    if (bytes_read > 2 && temp_name[0] == '\n' && temp_name[bytes_read - 1] == '\n' &&
-        std::size_t(time_zone_rule.type_count) + 2 <= time_zone_rule.ttis.size()) {
-        temp_name[bytes_read - 1] = '\0';
+    vfs_file->ReadArray(temp_name.data(), static_cast<size_t>(bytes_read), read_offset);
+    if (bytes_read > 2 && temp_name[0] == '\n' &&
+        temp_name[static_cast<u64>(bytes_read - 1)] == '\n' &&
+        static_cast<std::size_t>(time_zone_rule.type_count) + 2 <= time_zone_rule.ttis.size()) {
+        temp_name[static_cast<u64>(bytes_read - 1)] = '\0';
 
         std::array<char, time_zone_name_max> name{};
-        std::memcpy(name.data(), temp_name.data() + 1, std::size_t(bytes_read - 1));
+        std::memcpy(name.data(), temp_name.data() + 1, static_cast<std::size_t>(bytes_read - 1));
 
         TimeZoneRule temp_rule;
         if (ParsePosixName(name.data(), temp_rule)) {
@@ -642,24 +649,24 @@ static bool ParseTimeZoneBinary(TimeZoneRule& time_zone_rule, FileSys::VirtualFi
     s32 default_type{};
 
     for (default_type = 0; default_type < time_zone_rule.time_count; default_type++) {
-        if (time_zone_rule.types[default_type] == 0) {
+        if (time_zone_rule.types[static_cast<u32>(default_type)] == 0) {
             break;
         }
     }
 
     default_type = default_type < time_zone_rule.time_count ? -1 : 0;
     if (default_type < 0 && time_zone_rule.time_count > 0 &&
-        time_zone_rule.ttis[time_zone_rule.types[0]].is_dst) {
+        time_zone_rule.ttis[static_cast<u8>(time_zone_rule.types[0])].is_dst) {
         default_type = time_zone_rule.types[0];
         while (--default_type >= 0) {
-            if (!time_zone_rule.ttis[default_type].is_dst) {
+            if (!time_zone_rule.ttis[static_cast<u32>(default_type)].is_dst) {
                 break;
             }
         }
     }
     if (default_type < 0) {
         default_type = 0;
-        while (time_zone_rule.ttis[default_type].is_dst) {
+        while (time_zone_rule.ttis[static_cast<u32>(default_type)].is_dst) {
             if (++default_type >= time_zone_rule.type_count) {
                 default_type = 0;
                 break;
@@ -749,12 +756,12 @@ static ResultCode ToCalendarTimeInternal(const TimeZoneRule& rules, s64 time,
                                          CalendarTimeInternal& calendar_time,
                                          CalendarAdditionalInfo& calendar_additional_info) {
     if ((rules.go_ahead && time < rules.ats[0]) ||
-        (rules.go_back && time > rules.ats[rules.time_count - 1])) {
+        (rules.go_back && time > rules.ats[static_cast<size_t>(rules.time_count - 1)])) {
         s64 seconds{};
         if (time < rules.ats[0]) {
             seconds = rules.ats[0] - time;
         } else {
-            seconds = time - rules.ats[rules.time_count - 1];
+            seconds = time - rules.ats[static_cast<size_t>(rules.time_count - 1)];
         }
         seconds--;
 
@@ -767,7 +774,8 @@ static ResultCode ToCalendarTimeInternal(const TimeZoneRule& rules, s64 time,
         } else {
             new_time -= seconds;
         }
-        if (new_time < rules.ats[0] && new_time > rules.ats[rules.time_count - 1]) {
+        if (new_time < rules.ats[0] &&
+            new_time > rules.ats[static_cast<size_t>(rules.time_count - 1)]) {
             return ERROR_TIME_NOT_FOUND;
         }
         if (const ResultCode result{
@@ -791,25 +799,27 @@ static ResultCode ToCalendarTimeInternal(const TimeZoneRule& rules, s64 time,
         s32 low{1};
         s32 high{rules.time_count};
         while (low < high) {
-            s32 mid{(low + high) >> 1};
-            if (time < rules.ats[mid]) {
+            const s32 mid{(low + high) >> 1};
+            if (time < rules.ats[static_cast<size_t>(mid)]) {
                 high = mid;
             } else {
                 low = mid + 1;
             }
         }
-        tti_index = rules.types[low - 1];
+        tti_index = rules.types[static_cast<size_t>(low - 1)];
     }
 
-    if (const ResultCode result{CreateCalendarTime(time, rules.ttis[tti_index].gmt_offset,
-                                                   calendar_time, calendar_additional_info)};
+    if (const ResultCode result{
+            CreateCalendarTime(time, rules.ttis[static_cast<u32>(tti_index)].gmt_offset,
+                               calendar_time, calendar_additional_info)};
         result != RESULT_SUCCESS) {
         return result;
     }
 
-    calendar_additional_info.is_dst = rules.ttis[tti_index].is_dst;
-    const char* time_zone{&rules.chars[rules.ttis[tti_index].abbreviation_list_index]};
-    for (int index{}; time_zone[index] != '\0'; ++index) {
+    const auto& tti = rules.ttis[static_cast<size_t>(tti_index)];
+    calendar_additional_info.is_dst = tti.is_dst;
+    const char* time_zone{&rules.chars[static_cast<size_t>(tti.abbreviation_list_index)]};
+    for (size_t index = 0; time_zone[index] != '\0'; ++index) {
         calendar_additional_info.timezone_name[index] = time_zone[index];
     }
     return RESULT_SUCCESS;

--- a/src/core/hle/service/time/time_zone_service.cpp
+++ b/src/core/hle/service/time/time_zone_service.cpp
@@ -49,12 +49,12 @@ void ITimeZoneService::LoadTimeZoneRule(Kernel::HLERequestContext& ctx) {
     const auto raw_location_name{rp.PopRaw<std::array<u8, 0x24>>()};
 
     std::string location_name;
-    for (const auto& byte : raw_location_name) {
+    for (const auto byte : raw_location_name) {
         // Strip extra bytes
         if (byte == '\0') {
             break;
         }
-        location_name.push_back(byte);
+        location_name.push_back(static_cast<char>(byte));
     }
 
     LOG_DEBUG(Service_Time, "called, location_name={}", location_name);

--- a/src/core/loader/elf.cpp
+++ b/src/core/loader/elf.cpp
@@ -220,18 +220,19 @@ public:
     }
     const char* GetSectionName(int section) const;
     const u8* GetSectionDataPtr(int section) const {
-        if (section < 0 || section >= header->e_shnum)
+        if (section < 0 || section >= header->e_shnum) {
             return nullptr;
-        if (sections[section].sh_type != SHT_NOBITS)
-            return GetPtr(sections[section].sh_offset);
-        else
-            return nullptr;
+        }
+        if (sections[section].sh_type != SHT_NOBITS) {
+            return GetPtr(static_cast<int>(sections[section].sh_offset));
+        }
+        return nullptr;
     }
     bool IsCodeSection(int section) const {
         return sections[section].sh_type == SHT_PROGBITS;
     }
     const u8* GetSegmentPtr(int segment) {
-        return GetPtr(segments[segment].p_offset);
+        return GetPtr(static_cast<int>(segments[segment].p_offset));
     }
     u32 GetSectionAddr(SectionID section) const {
         return sectionAddrs[section];
@@ -258,14 +259,14 @@ ElfReader::ElfReader(void* ptr) {
 }
 
 const char* ElfReader::GetSectionName(int section) const {
-    if (sections[section].sh_type == SHT_NULL)
+    if (sections[section].sh_type == SHT_NULL) {
         return nullptr;
+    }
 
-    int name_offset = sections[section].sh_name;
-    const char* ptr = reinterpret_cast<const char*>(GetSectionDataPtr(header->e_shstrndx));
-
-    if (ptr)
+    const auto name_offset = sections[section].sh_name;
+    if (const auto* ptr = reinterpret_cast<const char*>(GetSectionDataPtr(header->e_shstrndx))) {
         return ptr + name_offset;
+    }
 
     return nullptr;
 }
@@ -291,7 +292,7 @@ Kernel::CodeSet ElfReader::LoadInto(VAddr vaddr) {
     for (unsigned int i = 0; i < header->e_phnum; ++i) {
         const Elf32_Phdr* p = &segments[i];
         if (p->p_type == PT_LOAD) {
-            total_image_size += (p->p_memsz + 0xFFF) & ~0xFFF;
+            total_image_size += (p->p_memsz + 0xFFF) & ~0xFFFU;
         }
     }
 
@@ -300,14 +301,14 @@ Kernel::CodeSet ElfReader::LoadInto(VAddr vaddr) {
 
     Kernel::CodeSet codeset;
 
-    for (unsigned int i = 0; i < header->e_phnum; ++i) {
+    for (u32 i = 0; i < header->e_phnum; ++i) {
         const Elf32_Phdr* p = &segments[i];
         LOG_DEBUG(Loader, "Type: {} Vaddr: {:08X} Filesz: {:08X} Memsz: {:08X} ", p->p_type,
                   p->p_vaddr, p->p_filesz, p->p_memsz);
 
         if (p->p_type == PT_LOAD) {
             Kernel::CodeSet::Segment* codeset_segment;
-            u32 permission_flags = p->p_flags & (PF_R | PF_W | PF_X);
+            const u32 permission_flags = p->p_flags & (PF_R | PF_W | PF_X);
             if (permission_flags == (PF_R | PF_X)) {
                 codeset_segment = &codeset.CodeSegment();
             } else if (permission_flags == (PF_R)) {
@@ -329,14 +330,14 @@ Kernel::CodeSet ElfReader::LoadInto(VAddr vaddr) {
             }
 
             const VAddr segment_addr = base_addr + p->p_vaddr;
-            const u32 aligned_size = (p->p_memsz + 0xFFF) & ~0xFFF;
+            const u32 aligned_size = (p->p_memsz + 0xFFF) & ~0xFFFU;
 
             codeset_segment->offset = current_image_position;
             codeset_segment->addr = segment_addr;
             codeset_segment->size = aligned_size;
 
-            std::memcpy(program_image.data() + current_image_position, GetSegmentPtr(i),
-                        p->p_filesz);
+            std::memcpy(program_image.data() + current_image_position,
+                        GetSegmentPtr(static_cast<int>(i)), p->p_filesz);
             current_image_position += aligned_size;
         }
     }

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -197,7 +197,7 @@ struct Memory::Impl {
         std::string string;
         string.reserve(max_length);
         for (std::size_t i = 0; i < max_length; ++i) {
-            const char c = Read8(vaddr);
+            const auto c = static_cast<char>(Read8(vaddr));
             if (c == '\0') {
                 break;
             }

--- a/src/core/network/network.cpp
+++ b/src/core/network/network.cpp
@@ -96,7 +96,7 @@ int LastError() {
 
 bool EnableNonBlock(SOCKET fd, bool enable) {
     u_long value = enable ? 1 : 0;
-    return ioctlsocket(fd, FIONBIO, &value) != SOCKET_ERROR;
+    return ioctlsocket(fd, static_cast<long>(FIONBIO), &value) != SOCKET_ERROR;
 }
 
 #elif __unix__ // ^ _WIN32 v __unix__
@@ -140,7 +140,9 @@ sockaddr TranslateFromSockAddrIn(SockAddrIn input) {
 
     result.sin_port = htons(input.portno);
 
-    result.sin_addr.s_addr = input.ip[0] | input.ip[1] << 8 | input.ip[2] << 16 | input.ip[3] << 24;
+    result.sin_addr.s_addr = static_cast<in_addr_t>(
+        input.ip[0] | static_cast<u32>(input.ip[1] << 8) | static_cast<u32>(input.ip[2] << 16) |
+        static_cast<u32>(input.ip[3] << 24));
 
     sockaddr addr;
     std::memcpy(&addr, &result, sizeof(addr));
@@ -148,7 +150,7 @@ sockaddr TranslateFromSockAddrIn(SockAddrIn input) {
 }
 
 int WSAPoll(WSAPOLLFD* fds, ULONG nfds, int timeout) {
-    return poll(fds, nfds, timeout);
+    return poll(fds, static_cast<nfds_t>(nfds), timeout);
 }
 
 int closesocket(SOCKET fd) {
@@ -158,7 +160,7 @@ int closesocket(SOCKET fd) {
 linger MakeLinger(bool enable, u32 linger_value) {
     linger value;
     value.l_onoff = enable ? 1 : 0;
-    value.l_linger = linger_value;
+    value.l_linger = static_cast<s32>(linger_value);
     return value;
 }
 
@@ -337,7 +339,7 @@ std::pair<s32, Errno> Poll(std::vector<PollFD>& pollfds, s32 timeout) {
     std::transform(pollfds.begin(), pollfds.end(), host_pollfds.begin(), [](PollFD fd) {
         WSAPOLLFD result;
         result.fd = fd.socket->fd;
-        result.events = TranslatePollEvents(fd.events);
+        result.events = static_cast<s16>(TranslatePollEvents(fd.events));
         result.revents = 0;
         return result;
     });
@@ -499,12 +501,12 @@ Errno Socket::Shutdown(ShutdownHow how) {
     }
 }
 
-std::pair<s32, Errno> Socket::Recv(int flags, std::vector<u8>& message) {
+std::pair<s32, Errno> Socket::Recv(u32 flags, std::vector<u8>& message) {
     ASSERT(flags == 0);
     ASSERT(message.size() < static_cast<size_t>(std::numeric_limits<int>::max()));
 
-    const auto result =
-        recv(fd, reinterpret_cast<char*>(message.data()), static_cast<int>(message.size()), 0);
+    const auto result = recv(fd, reinterpret_cast<char*>(message.data()),
+                             static_cast<socklen_t>(message.size()), 0);
     if (result != SOCKET_ERROR) {
         return {static_cast<s32>(result), Errno::SUCCESS};
     }
@@ -522,7 +524,7 @@ std::pair<s32, Errno> Socket::Recv(int flags, std::vector<u8>& message) {
     }
 }
 
-std::pair<s32, Errno> Socket::RecvFrom(int flags, std::vector<u8>& message, SockAddrIn* addr) {
+std::pair<s32, Errno> Socket::RecvFrom(u32 flags, std::vector<u8>& message, SockAddrIn* addr) {
     ASSERT(flags == 0);
     ASSERT(message.size() < static_cast<size_t>(std::numeric_limits<int>::max()));
 
@@ -532,7 +534,7 @@ std::pair<s32, Errno> Socket::RecvFrom(int flags, std::vector<u8>& message, Sock
     sockaddr* const p_addr_in = addr ? &addr_in : nullptr;
 
     const auto result = recvfrom(fd, reinterpret_cast<char*>(message.data()),
-                                 static_cast<int>(message.size()), 0, p_addr_in, p_addrlen);
+                                 static_cast<socklen_t>(message.size()), 0, p_addr_in, p_addrlen);
     if (result != SOCKET_ERROR) {
         if (addr) {
             ASSERT(addrlen == sizeof(addr_in));
@@ -554,12 +556,12 @@ std::pair<s32, Errno> Socket::RecvFrom(int flags, std::vector<u8>& message, Sock
     }
 }
 
-std::pair<s32, Errno> Socket::Send(const std::vector<u8>& message, int flags) {
+std::pair<s32, Errno> Socket::Send(const std::vector<u8>& message, u32 flags) {
     ASSERT(message.size() < static_cast<size_t>(std::numeric_limits<int>::max()));
     ASSERT(flags == 0);
 
     const auto result = send(fd, reinterpret_cast<const char*>(message.data()),
-                             static_cast<int>(message.size()), 0);
+                             static_cast<socklen_t>(message.size()), 0);
     if (result != SOCKET_ERROR) {
         return {static_cast<s32>(result), Errno::SUCCESS};
     }
@@ -591,8 +593,9 @@ std::pair<s32, Errno> Socket::SendTo(u32 flags, const std::vector<u8>& message,
         to = &host_addr_in;
     }
 
-    const auto result = sendto(fd, reinterpret_cast<const char*>(message.data()),
-                               static_cast<int>(message.size()), 0, to, tolen);
+    const auto result =
+        sendto(fd, reinterpret_cast<const char*>(message.data()),
+               static_cast<socklen_t>(message.size()), 0, to, static_cast<socklen_t>(tolen));
     if (result != SOCKET_ERROR) {
         return {static_cast<s32>(result), Errno::SUCCESS};
     }

--- a/src/core/network/network.h
+++ b/src/core/network/network.h
@@ -67,12 +67,12 @@ struct PollFD {
     u16 revents;
 };
 
-constexpr u16 POLL_IN = 1 << 0;
-constexpr u16 POLL_PRI = 1 << 1;
-constexpr u16 POLL_OUT = 1 << 2;
-constexpr u16 POLL_ERR = 1 << 3;
-constexpr u16 POLL_HUP = 1 << 4;
-constexpr u16 POLL_NVAL = 1 << 5;
+constexpr u32 POLL_IN = 1 << 0;
+constexpr u32 POLL_PRI = 1 << 1;
+constexpr u32 POLL_OUT = 1 << 2;
+constexpr u32 POLL_ERR = 1 << 3;
+constexpr u32 POLL_HUP = 1 << 4;
+constexpr u32 POLL_NVAL = 1 << 5;
 
 class NetworkInstance {
 public:

--- a/src/core/network/sockets.h
+++ b/src/core/network/sockets.h
@@ -56,11 +56,11 @@ public:
 
     Errno Shutdown(ShutdownHow how);
 
-    std::pair<s32, Errno> Recv(int flags, std::vector<u8>& message);
+    std::pair<s32, Errno> Recv(u32 flags, std::vector<u8>& message);
 
-    std::pair<s32, Errno> RecvFrom(int flags, std::vector<u8>& message, SockAddrIn* addr);
+    std::pair<s32, Errno> RecvFrom(u32 flags, std::vector<u8>& message, SockAddrIn* addr);
 
-    std::pair<s32, Errno> Send(const std::vector<u8>& message, int flags);
+    std::pair<s32, Errno> Send(const std::vector<u8>& message, u32 flags);
 
     std::pair<s32, Errno> SendTo(u32 flags, const std::vector<u8>& message, const SockAddrIn* addr);
 


### PR DESCRIPTION
Recent changes to the build system that made more warnings be flagged as errors caused building via clang to break.

This should fix #4795