### PR TITLE
mii/manager: Make use of unused lower bound in GetRandomValue()

### DIFF
--- a/src/core/hle/service/mii/manager.cpp
+++ b/src/core/hle/service/mii/manager.cpp
@@ -131,7 +131,7 @@ template <typename T>
 T GetRandomValue(T min, T max) {
     std::random_device device;
     std::mt19937 gen(device());
-    std::uniform_int_distribution<u64> distribution(0, static_cast<u64>(max));
+    std::uniform_int_distribution<u64> distribution(static_cast<u64>(min), static_cast<u64>(max));
     return static_cast<T>(distribution(gen));
 }
 


### PR DESCRIPTION
Previously, the lower bound wasn't being used and zero was being used as the lower bound every time this function was called.

This affects the outcome of some of the randomized entries a little bit, for example, the lower-bound for beard and mustache flags was supposed to be 1, not 0.

Aside from these cases, the bug didn't affect anything else.

This was found while addressing cases in #4796 