### PR TITLE
video_core: Conditially activate relevant compiler warnings

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -278,7 +278,9 @@ else()
         -Wno-error=sign-conversion
         -Werror=switch
         -Werror=unused-variable
-        -Werror=unused-but-set-variable
-        -Werror=class-memaccess
+
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=class-memaccess>
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-variable>
     )
 endif()


### PR DESCRIPTION
These compiler flags aren't shared with Clang, so specifying these flags unconditionally when building with it can lead to a bit of warning spam. So we can wrap these to only activate when compiling with GCC.

While we're in the area, we can also enable -Wunused-but-set-parameter given this is almost always a bug.