### PR TITLE
main/profile_select: Don't ask for profile when there's only one.

### DIFF
--- a/src/yuzu/applets/profile_select.cpp
+++ b/src/yuzu/applets/profile_select.cpp
@@ -114,6 +114,15 @@ QtProfileSelectionDialog::QtProfileSelectionDialog(QWidget* parent)
 
 QtProfileSelectionDialog::~QtProfileSelectionDialog() = default;
 
+int QtProfileSelectionDialog::exec() {
+    // Skip profile selection when there's only one.
+    if (profile_manager->GetUserCount() == 1) {
+        user_index = 0;
+        return QDialog::Accepted;
+    }
+    QDialog::exec();
+}
+
 void QtProfileSelectionDialog::accept() {
     QDialog::accept();
 }

--- a/src/yuzu/applets/profile_select.h
+++ b/src/yuzu/applets/profile_select.h
@@ -27,6 +27,7 @@ public:
     explicit QtProfileSelectionDialog(QWidget* parent);
     ~QtProfileSelectionDialog() override;
 
+    int exec() override;
     void accept() override;
     void reject() override;
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -303,24 +303,18 @@ void GMainWindow::ControllerSelectorReconfigureControllers(
 }
 
 void GMainWindow::ProfileSelectorSelectProfile() {
-    const Service::Account::ProfileManager manager;
-    int index = 0;
-    if (manager.GetUserCount() != 1) {
-        QtProfileSelectionDialog dialog(this);
-        dialog.setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowStaysOnTopHint |
-                              Qt::WindowTitleHint | Qt::WindowSystemMenuHint |
-                              Qt::WindowCloseButtonHint);
-        dialog.setWindowModality(Qt::WindowModal);
-
-        if (dialog.exec() == QDialog::Rejected) {
-            emit ProfileSelectorFinishedSelection(std::nullopt);
-            return;
-        }
-
-        index = dialog.GetIndex();
+    QtProfileSelectionDialog dialog(this);
+    dialog.setWindowFlags(Qt::Dialog | Qt::CustomizeWindowHint | Qt::WindowStaysOnTopHint |
+                          Qt::WindowTitleHint | Qt::WindowSystemMenuHint |
+                          Qt::WindowCloseButtonHint);
+    dialog.setWindowModality(Qt::WindowModal);
+    if (dialog.exec() == QDialog::Rejected) {
+        emit ProfileSelectorFinishedSelection(std::nullopt);
+        return;
     }
 
-    const auto uuid = manager.GetUser(static_cast<std::size_t>(index));
+    const Service::Account::ProfileManager manager;
+    const auto uuid = manager.GetUser(static_cast<std::size_t>(dialog.GetIndex()));
     if (!uuid.has_value()) {
         emit ProfileSelectorFinishedSelection(std::nullopt);
         return;


### PR DESCRIPTION
~Based on #4297.~

Reverts #4297 and moves the profile selection skip to QtProfileSelectionDialog. Now it skips in both 
`GMainWindow::ProfileSelectorSelectProfile` and `GMainWindow::OnGameListOpenFolder` when there's only one profile.