### PR TITLE
applets/profile_select: Resolve a warning in exec()

### DIFF
--- a/src/yuzu/applets/profile_select.cpp
+++ b/src/yuzu/applets/profile_select.cpp
@@ -120,7 +120,7 @@ int QtProfileSelectionDialog::exec() {
         user_index = 0;
         return QDialog::Accepted;
     }
-    QDialog::exec();
+    return QDialog::exec();
 }
 
 void QtProfileSelectionDialog::accept() {


### PR DESCRIPTION
Resolves a warning where not all control paths return a value.