### PR TITLE
controller: Convert led_patterns integer literals to bool literals

### DIFF
--- a/src/yuzu/applets/controller.cpp
+++ b/src/yuzu/applets/controller.cpp
@@ -18,15 +18,15 @@
 
 namespace {
 
-constexpr std::array<std::array<bool, 4>, 8> led_patterns = {{
-    {1, 0, 0, 0},
-    {1, 1, 0, 0},
-    {1, 1, 1, 0},
-    {1, 1, 1, 1},
-    {1, 0, 0, 1},
-    {1, 0, 1, 0},
-    {1, 0, 1, 1},
-    {0, 1, 1, 0},
+constexpr std::array<std::array<bool, 4>, 8> led_patterns{{
+    {true, false, false, false},
+    {true, true, false, false},
+    {true, true, true, false},
+    {true, true, true, true},
+    {true, false, false, true},
+    {true, false, true, false},
+    {true, false, true, true},
+    {false, true, true, false},
 }};
 
 void UpdateController(Settings::ControllerType controller_type, std::size_t npad_index,


### PR DESCRIPTION
'bool' isn't always guaranteed to be the same size as an int, so this can technically cause truncation warnings if we support other platforms (e.g. AArch64) in the future.