### PR TITLE
core: cpu_manager: Add missing call to MicroProfileOnThreadExit().

### DIFF
--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -365,6 +365,8 @@ void CpuManager::RunThread(std::size_t core) {
     data.enter_barrier.reset();
     data.exit_barrier.reset();
     data.initialized = false;
+
+    MicroProfileOnThreadExit();
 }
 
 } // namespace Core


### PR DESCRIPTION
- Fixes an occasional crash when trying to launch subsequent games.