### PR TITLE
controller: Pass ControllerParameters by reference in ReconfigureControllers()

### DIFF
--- a/src/core/frontend/applets/controller.cpp
+++ b/src/core/frontend/applets/controller.cpp
@@ -19,7 +19,7 @@ DefaultControllerApplet::DefaultControllerApplet(Service::SM::ServiceManager& se
 DefaultControllerApplet::~DefaultControllerApplet() = default;
 
 void DefaultControllerApplet::ReconfigureControllers(std::function<void()> callback,
-                                                     ControllerParameters parameters) const {
+                                                     const ControllerParameters& parameters) const {
     LOG_INFO(Service_HID, "called, deducing the best configuration based on the given parameters!");
 
     auto& npad =

--- a/src/core/frontend/applets/controller.h
+++ b/src/core/frontend/applets/controller.h
@@ -38,7 +38,7 @@ public:
     virtual ~ControllerApplet();
 
     virtual void ReconfigureControllers(std::function<void()> callback,
-                                        ControllerParameters parameters) const = 0;
+                                        const ControllerParameters& parameters) const = 0;
 };
 
 class DefaultControllerApplet final : public ControllerApplet {
@@ -47,7 +47,7 @@ public:
     ~DefaultControllerApplet() override;
 
     void ReconfigureControllers(std::function<void()> callback,
-                                ControllerParameters parameters) const override;
+                                const ControllerParameters& parameters) const override;
 
 private:
     Service::SM::ServiceManager& service_manager;

--- a/src/yuzu/applets/controller.cpp
+++ b/src/yuzu/applets/controller.cpp
@@ -589,7 +589,7 @@ QtControllerSelector::QtControllerSelector(GMainWindow& parent) {
 QtControllerSelector::~QtControllerSelector() = default;
 
 void QtControllerSelector::ReconfigureControllers(
-    std::function<void()> callback, Core::Frontend::ControllerParameters parameters) const {
+    std::function<void()> callback, const Core::Frontend::ControllerParameters& parameters) const {
     this->callback = std::move(callback);
     emit MainWindowReconfigureControllers(parameters);
 }

--- a/src/yuzu/applets/controller.h
+++ b/src/yuzu/applets/controller.h
@@ -120,11 +120,13 @@ public:
     explicit QtControllerSelector(GMainWindow& parent);
     ~QtControllerSelector() override;
 
-    void ReconfigureControllers(std::function<void()> callback,
-                                Core::Frontend::ControllerParameters parameters) const override;
+    void ReconfigureControllers(
+        std::function<void()> callback,
+        const Core::Frontend::ControllerParameters& parameters) const override;
 
 signals:
-    void MainWindowReconfigureControllers(Core::Frontend::ControllerParameters parameters) const;
+    void MainWindowReconfigureControllers(
+        const Core::Frontend::ControllerParameters& parameters) const;
 
 private:
     void MainWindowReconfigureFinished();


### PR DESCRIPTION
Prevents unnecessary copies and heap reallocations from occurring.

