### PR TITLE
externals: Track upstream inih

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "inih"]
     path = externals/inih/inih
-    url = https://github.com/svn2github/inih
+    url = https://github.com/benhoyt/inih.git
 [submodule "cubeb"]
     path = externals/cubeb
     url = https://github.com/kinetiknz/cubeb.git


### PR DESCRIPTION
Tracks the upstream inih project and updates to the latest release.

Previously, we were tracking the svn2github release of the project back when google code was closing. However, the author of the library continued development on the library on Github, so we can change the URL to track that one.

See the [changelogs](https://github.com/benhoyt/inih/releases) for fixed issues (some of which are memory safety issues).