### PR TITLE
video_core: Enforce -Wredundant-move and -Wpessimizing-move

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -302,6 +302,8 @@ else()
     target_compile_options(video_core PRIVATE
         -Werror=conversion
         -Wno-error=sign-conversion
+        -Werror=pessimizing-move
+        -Werror=redundant-move
         -Werror=switch
         -Werror=unused-variable
 

--- a/src/video_core/command_classes/codecs/vp9.cpp
+++ b/src/video_core/command_classes/codecs/vp9.cpp
@@ -366,7 +366,7 @@ Vp9PictureInfo VP9::GetVp9PictureInfo(const NvdecCommon::NvdecRegisters& state) 
     // to avoid buffering frame data needed for reference frame updating in the header composition.
     std::memcpy(vp9_info.frame_offsets.data(), state.surface_luma_offset.data(), 4 * sizeof(u64));
 
-    return std::move(vp9_info);
+    return vp9_info;
 }
 
 void VP9::InsertEntropy(u64 offset, Vp9EntropyProbs& dst) {

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -317,8 +317,7 @@ std::optional<std::vector<ShaderDiskCachePrecompiled>> ShaderDiskCacheOpenGL::Lo
             return std::nullopt;
         }
     }
-
-    return std::move(entries);
+    return entries;
 }
 
 void ShaderDiskCacheOpenGL::InvalidateTransferable() {

--- a/src/video_core/renderer_vulkan/wrapper.cpp
+++ b/src/video_core/renderer_vulkan/wrapper.cpp
@@ -844,7 +844,7 @@ std::optional<std::vector<VkExtensionProperties>> EnumerateInstanceExtensionProp
         VK_SUCCESS) {
         return std::nullopt;
     }
-    return std::move(properties);
+    return properties;
 }
 
 std::optional<std::vector<VkLayerProperties>> EnumerateInstanceLayerProperties(


### PR DESCRIPTION
Silence three warnings and make them errors to avoid introducing more in the future.