### PR TITLE
video_core: Enforce -Werror=type-limits

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -303,6 +303,7 @@ else()
         -Werror=conversion
         -Wno-error=sign-conversion
         -Werror=switch
+        -Werror=type-limits
         -Werror=unused-variable
 
         $<$<CXX_COMPILER_ID:GNU>:-Werror=class-memaccess>

--- a/src/video_core/command_classes/codecs/vp9.cpp
+++ b/src/video_core/command_classes/codecs/vp9.cpp
@@ -893,7 +893,7 @@ void VpxRangeEncoder::Write(bool bit, s32 probability) {
         if (((low_value << (offset - 1)) >> 31) != 0) {
             const s32 current_pos = static_cast<s32>(base_stream.GetPosition());
             base_stream.Seek(-1, Common::SeekOrigin::FromCurrentPos);
-            while (base_stream.GetPosition() >= 0 && PeekByte() == 0xff) {
+            while (PeekByte() == 0xff) {
                 base_stream.WriteByte(0);
 
                 base_stream.Seek(-2, Common::SeekOrigin::FromCurrentPos);


### PR DESCRIPTION
Silences one warning and avoids introducing more in the future.
`base_stream.GetPosition()` returns an unsigned type, so it will always be greater than or equal to zero.