### PR TITLE
web_service: web_backend: Handle socket errors with GenericRequest.

### DIFF
--- a/src/web_service/web_backend.cpp
+++ b/src/web_service/web_backend.cpp
@@ -65,6 +65,17 @@ struct Client::Impl {
         if (cli == nullptr) {
             cli = std::make_unique<httplib::Client>(host.c_str());
         }
+
+        if (!cli->is_valid()) {
+            LOG_ERROR(WebService, "Client is invalid, skipping request!");
+            return {};
+        }
+
+        if (!cli->is_socket_open()) {
+            LOG_ERROR(WebService, "Failed to open socket, skipping request!");
+            return {};
+        }
+
         cli->set_connection_timeout(TIMEOUT_SECONDS);
         cli->set_read_timeout(TIMEOUT_SECONDS);
         cli->set_write_timeout(TIMEOUT_SECONDS);


### PR DESCRIPTION
- Fixes a shutdown crash when we try to submit telemetry if there is a service issue.

Similar fix to #4797 