### PR TITLE
General: Make ignoring a discarded return value an error

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,10 @@ if (MSVC)
 
         # Warnings
         /W3
+        /we4547 # 'operator' : operator before comma has no effect; expected operator with side-effect
+        /we4548 # Expression before comma has no effect; expected expression with side-effect
+        /we4549 # 'operator1': operator before comma has no effect; did you intend 'operator2'?
+        /we4555 # Expression has no effect; expected expression with side-effect
         /we4834 # Discarding return value of function with 'nodiscard' attribute
     )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,7 +32,6 @@ if (MSVC)
     # /Zc:inline          - Let codegen omit inline functions in object files
     # /Zc:throwingNew     - Let codegen assume `operator new` (without std::nothrow) will never return null
     add_compile_options(
-        /W3
         /MP
         /Zi
         /Zo
@@ -43,6 +42,10 @@ if (MSVC)
         /Zc:externConstexpr
         /Zc:inline
         /Zc:throwingNew
+
+        # Warnings
+        /W3
+        /we4834 # Discarding return value of function with 'nodiscard' attribute
     )
 
     # /GS- - No stack buffer overflow checks
@@ -56,6 +59,7 @@ else()
         -Werror=implicit-fallthrough
         -Werror=missing-declarations
         -Werror=reorder
+        -Werror=unused-result
         -Wextra
         -Wmissing-declarations
         -Wno-attributes

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -232,7 +232,7 @@ public:
 
     void Swap(IOFile& other) noexcept;
 
-    [[nodiscard]] bool Open(const std::string& filename, const char openmode[], int flags = 0);
+    bool Open(const std::string& filename, const char openmode[], int flags = 0);
     bool Close();
 
     template <typename T>

--- a/src/common/misc.cpp
+++ b/src/common/misc.cpp
@@ -16,16 +16,23 @@
 // Call directly after the command or use the error num.
 // This function might change the error code.
 std::string GetLastErrorMsg() {
-    static const std::size_t buff_size = 255;
+    static constexpr std::size_t buff_size = 255;
     char err_str[buff_size];
 
 #ifdef _WIN32
     FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, GetLastError(),
                    MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), err_str, buff_size, nullptr);
+    return std::string(err_str, buff_size);
+#elif defined(__GLIBC__) && (_GNU_SOURCE || (_POSIX_C_SOURCE < 200112L && _XOPEN_SOURCE < 600))
+    // Thread safe (GNU-specific)
+    const char* str = strerror_r(errno, err_str, buff_size);
+    return std::string(str);
 #else
     // Thread safe (XSI-compliant)
-    strerror_r(errno, err_str, buff_size);
+    const int success = strerror_r(errno, err_str, buff_size);
+    if (success != 0) {
+        return {};
+    }
+    return std::string(err_str);
 #endif
-
-    return std::string(err_str, buff_size);
 }


### PR DESCRIPTION
Allows our CI to catch more potential bugs.

This also removes the [[nodiscard]] attribute of `IOFile`'s `Open()` member function. There are cases where a file may want to be opened, but have the status of it checked at a later time. This was something I missed when initially adding all of the [[nodiscard]] specifiers to the common library.

It is still possible to ignore discarded return values, however they must now be explicit. e.g.

```cpp
[[nodiscard]] Fart* MakeFarts();

// ...

void fn() {
    // Lotta hot air here.
    // Necessary to work around [insert extremely esoteric reason here]
    static_cast<void>(MakeFarts(10));
}
```