### PR TITLE
video_core: unbreak -Werror in NVDEC with Clang

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.cpp
@@ -38,7 +38,7 @@ std::size_t WriteVectors(std::vector<u8>& dst, const std::vector<T>& src, std::s
 
 namespace NvErrCodes {
 constexpr u32 Success{};
-constexpr u32 OutOfMemory{static_cast<u32>(-12)};
+[[maybe_unused]] constexpr u32 OutOfMemory{static_cast<u32>(-12)};
 constexpr u32 InvalidInput{static_cast<u32>(-22)};
 } // namespace NvErrCodes
 


### PR DESCRIPTION
Regressed by #4729. From [error log](https://github.com/yuzu-emu/yuzu/files/5466456/yuzu-qt5-s20201030.log):
```c++
src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.cpp:41:15: error: unused variable 'OutOfMemory' [-Werror,-Wunused-const-variable]
constexpr u32 OutOfMemory{static_cast<u32>(-12)};
              ^
```
