### PR TITLE
core/settings: Move configuring_global behind an API

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -14,7 +14,7 @@
 namespace Settings {
 
 Values values = {};
-bool configuring_global = true;
+static bool configuring_global = true;
 
 std::string GetTimeZoneString() {
     static constexpr std::array timezones{
@@ -81,11 +81,12 @@ void LogSettings() {
     log_setting("Services_BCATBoxcatLocal", values.bcat_boxcat_local);
 }
 
-float Volume() {
-    if (values.audio_muted) {
-        return 0.0f;
-    }
-    return values.volume.GetValue();
+bool IsConfiguringGlobal() {
+    return configuring_global;
+}
+
+void SetConfiguringGlobal(bool is_global) {
+    configuring_global = is_global;
 }
 
 bool IsGPULevelExtreme() {
@@ -95,6 +96,13 @@ bool IsGPULevelExtreme() {
 bool IsGPULevelHigh() {
     return values.gpu_accuracy.GetValue() == GPUAccuracy::Extreme ||
            values.gpu_accuracy.GetValue() == GPUAccuracy::High;
+}
+
+float Volume() {
+    if (values.audio_muted) {
+        return 0.0f;
+    }
+    return values.volume.GetValue();
 }
 
 void RestoreGlobalState() {

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -33,8 +33,6 @@ enum class CPUAccuracy {
     DebugMode = 2,
 };
 
-extern bool configuring_global;
-
 template <typename Type>
 class Setting final {
 public:
@@ -198,12 +196,17 @@ struct Values {
 
     // Add-Ons
     std::map<u64, std::vector<std::string>> disabled_addons;
-} extern values;
+};
 
-float Volume();
+extern Values values;
+
+bool IsConfiguringGlobal();
+void SetConfiguringGlobal(bool is_global);
 
 bool IsGPULevelExtreme();
 bool IsGPULevelHigh();
+
+float Volume();
 
 std::string GetTimeZoneString();
 

--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -25,8 +25,8 @@ ConfigureAudio::ConfigureAudio(QWidget* parent)
     connect(ui->output_sink_combo_box, qOverload<int>(&QComboBox::currentIndexChanged), this,
             &ConfigureAudio::UpdateAudioDevices);
 
-    ui->volume_label->setVisible(Settings::configuring_global);
-    ui->volume_combo_box->setVisible(!Settings::configuring_global);
+    ui->volume_label->setVisible(Settings::IsConfiguringGlobal());
+    ui->volume_combo_box->setVisible(!Settings::IsConfiguringGlobal());
 
     SetupPerGameUI();
 
@@ -51,7 +51,7 @@ void ConfigureAudio::SetConfiguration() {
 
     ui->toggle_audio_stretching->setChecked(Settings::values.enable_audio_stretching.GetValue());
 
-    if (!Settings::configuring_global) {
+    if (!Settings::IsConfiguringGlobal()) {
         if (Settings::values.volume.UsingGlobal()) {
             ui->volume_combo_box->setCurrentIndex(0);
             ui->volume_slider->setEnabled(false);
@@ -99,7 +99,7 @@ void ConfigureAudio::SetVolumeIndicatorText(int percentage) {
 }
 
 void ConfigureAudio::ApplyConfiguration() {
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         Settings::values.sink_id =
             ui->output_sink_combo_box->itemText(ui->output_sink_combo_box->currentIndex())
                 .toStdString();
@@ -165,7 +165,7 @@ void ConfigureAudio::RetranslateUI() {
 }
 
 void ConfigureAudio::SetupPerGameUI() {
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         ui->volume_slider->setEnabled(Settings::values.volume.UsingGlobal());
         ui->toggle_audio_stretching->setEnabled(
             Settings::values.enable_audio_stretching.UsingGlobal());

--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -15,7 +15,7 @@
 ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry,
                                  InputCommon::InputSubsystem* input_subsystem)
     : QDialog(parent), ui(new Ui::ConfigureDialog), registry(registry) {
-    Settings::configuring_global = true;
+    Settings::SetConfiguringGlobal(true);
 
     ui->setupUi(this);
     ui->hotkeysTab->Populate(registry);

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -19,7 +19,7 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
 
     SetConfiguration();
 
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         connect(ui->toggle_frame_limit, &QCheckBox::clicked, ui->frame_limit,
                 [this]() { ui->frame_limit->setEnabled(ui->toggle_frame_limit->isChecked()); });
     }
@@ -41,7 +41,7 @@ void ConfigureGeneral::SetConfiguration() {
     ui->toggle_frame_limit->setChecked(Settings::values.use_frame_limit.GetValue());
     ui->frame_limit->setValue(Settings::values.frame_limit.GetValue());
 
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         ui->frame_limit->setEnabled(Settings::values.use_frame_limit.GetValue());
     } else {
         ui->frame_limit->setEnabled(Settings::values.use_frame_limit.GetValue() &&
@@ -50,7 +50,7 @@ void ConfigureGeneral::SetConfiguration() {
 }
 
 void ConfigureGeneral::ApplyConfiguration() {
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
         UISettings::values.select_user_on_boot = ui->toggle_user_on_boot->isChecked();
         UISettings::values.pause_when_in_background = ui->toggle_background_pause->isChecked();
@@ -93,7 +93,7 @@ void ConfigureGeneral::RetranslateUI() {
 }
 
 void ConfigureGeneral::SetupPerGameUI() {
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         ui->toggle_frame_limit->setEnabled(Settings::values.use_frame_limit.UsingGlobal());
         ui->frame_limit->setEnabled(Settings::values.frame_limit.UsingGlobal());
 

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -33,7 +33,7 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
 
     connect(ui->api, qOverload<int>(&QComboBox::currentIndexChanged), this, [this] {
         UpdateDeviceComboBox();
-        if (!Settings::configuring_global) {
+        if (!Settings::IsConfiguringGlobal()) {
             ConfigurationShared::SetHighlight(
                 ui->api_layout, ui->api->currentIndex() != ConfigurationShared::USE_GLOBAL_INDEX);
         }
@@ -49,8 +49,8 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
         UpdateBackgroundColorButton(new_bg_color);
     });
 
-    ui->bg_label->setVisible(Settings::configuring_global);
-    ui->bg_combobox->setVisible(!Settings::configuring_global);
+    ui->bg_label->setVisible(Settings::IsConfiguringGlobal());
+    ui->bg_combobox->setVisible(!Settings::IsConfiguringGlobal());
 }
 
 void ConfigureGraphics::UpdateDeviceSelection(int device) {
@@ -76,7 +76,7 @@ void ConfigureGraphics::SetConfiguration() {
         Settings::values.use_asynchronous_gpu_emulation.GetValue());
     ui->use_nvdec_emulation->setChecked(Settings::values.use_nvdec_emulation.GetValue());
 
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         ui->api->setCurrentIndex(static_cast<int>(Settings::values.renderer_backend.GetValue()));
         ui->aspect_ratio_combobox->setCurrentIndex(Settings::values.aspect_ratio.GetValue());
     } else {
@@ -100,7 +100,7 @@ void ConfigureGraphics::SetConfiguration() {
 }
 
 void ConfigureGraphics::ApplyConfiguration() {
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         // Guard if during game and set to game-specific value
         if (Settings::values.renderer_backend.UsingGlobal()) {
             Settings::values.renderer_backend.SetValue(GetCurrentGraphicsBackend());
@@ -194,7 +194,7 @@ void ConfigureGraphics::UpdateDeviceComboBox() {
 
     bool enabled = false;
 
-    if (!Settings::configuring_global &&
+    if (!Settings::IsConfiguringGlobal() &&
         ui->api->currentIndex() == ConfigurationShared::USE_GLOBAL_INDEX) {
         vulkan_device = Settings::values.vulkan_device.GetValue();
     }
@@ -212,7 +212,7 @@ void ConfigureGraphics::UpdateDeviceComboBox() {
         break;
     }
     // If in per-game config and use global is selected, don't enable.
-    enabled &= !(!Settings::configuring_global &&
+    enabled &= !(!Settings::IsConfiguringGlobal() &&
                  ui->api->currentIndex() == ConfigurationShared::USE_GLOBAL_INDEX);
     ui->device->setEnabled(enabled && !Core::System::GetInstance().IsPoweredOn());
 }
@@ -227,7 +227,7 @@ void ConfigureGraphics::RetrieveVulkanDevices() {
 }
 
 Settings::RendererBackend ConfigureGraphics::GetCurrentGraphicsBackend() const {
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         return static_cast<Settings::RendererBackend>(ui->api->currentIndex());
     }
 
@@ -241,7 +241,7 @@ Settings::RendererBackend ConfigureGraphics::GetCurrentGraphicsBackend() const {
 }
 
 void ConfigureGraphics::SetupPerGameUI() {
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         ui->api->setEnabled(Settings::values.renderer_backend.UsingGlobal());
         ui->device->setEnabled(Settings::values.renderer_backend.UsingGlobal());
         ui->aspect_ratio_combobox->setEnabled(Settings::values.aspect_ratio.UsingGlobal());

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -32,7 +32,7 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
     ui->use_asynchronous_shaders->setChecked(Settings::values.use_asynchronous_shaders.GetValue());
     ui->use_fast_gpu_time->setChecked(Settings::values.use_fast_gpu_time.GetValue());
 
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         ui->gpu_accuracy->setCurrentIndex(
             static_cast<int>(Settings::values.gpu_accuracy.GetValue()));
         ui->anisotropic_filtering_combobox->setCurrentIndex(
@@ -52,9 +52,9 @@ void ConfigureGraphicsAdvanced::ApplyConfiguration() {
     // Subtract 2 if configuring per-game (separator and "use global configuration" take 2 slots)
     const auto gpu_accuracy = static_cast<Settings::GPUAccuracy>(
         ui->gpu_accuracy->currentIndex() -
-        ((Settings::configuring_global) ? 0 : ConfigurationShared::USE_GLOBAL_OFFSET));
+        ((Settings::IsConfiguringGlobal()) ? 0 : ConfigurationShared::USE_GLOBAL_OFFSET));
 
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         // Must guard in case of a during-game configuration when set to be game-specific.
         if (Settings::values.gpu_accuracy.UsingGlobal()) {
             Settings::values.gpu_accuracy.SetValue(gpu_accuracy);
@@ -118,7 +118,7 @@ void ConfigureGraphicsAdvanced::RetranslateUI() {
 
 void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     // Disable if not global (only happens during game)
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         ui->gpu_accuracy->setEnabled(Settings::values.gpu_accuracy.UsingGlobal());
         ui->use_vsync->setEnabled(Settings::values.use_vsync.UsingGlobal());
         ui->use_assembly_shaders->setEnabled(Settings::values.use_assembly_shaders.UsingGlobal());

--- a/src/yuzu/configuration/configure_per_game.cpp
+++ b/src/yuzu/configuration/configure_per_game.cpp
@@ -31,7 +31,7 @@ ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id)
     : QDialog(parent), ui(std::make_unique<Ui::ConfigurePerGame>()), title_id(title_id) {
     game_config = std::make_unique<Config>(fmt::format("{:016X}.ini", title_id), false);
 
-    Settings::configuring_global = false;
+    Settings::SetConfiguringGlobal(false);
 
     ui->setupUi(this);
     setFocusPolicy(Qt::ClickFocus);

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -37,8 +37,8 @@ ConfigureSystem::ConfigureSystem(QWidget* parent) : QWidget(parent), ui(new Ui::
         }
     });
 
-    ui->label_console_id->setVisible(Settings::configuring_global);
-    ui->button_regenerate_console_id->setVisible(Settings::configuring_global);
+    ui->label_console_id->setVisible(Settings::IsConfiguringGlobal());
+    ui->button_regenerate_console_id->setVisible(Settings::IsConfiguringGlobal());
 
     SetupPerGameUI();
 
@@ -78,7 +78,7 @@ void ConfigureSystem::SetConfiguration() {
                                     Settings::values.rng_seed.UsingGlobal());
     ui->custom_rtc_edit->setDateTime(QDateTime::fromSecsSinceEpoch(rtc_time.count()));
 
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         ui->combo_language->setCurrentIndex(Settings::values.language_index.GetValue());
         ui->combo_region->setCurrentIndex(Settings::values.region_index.GetValue());
         ui->combo_time_zone->setCurrentIndex(Settings::values.time_zone_index.GetValue());
@@ -125,7 +125,7 @@ void ConfigureSystem::ApplyConfiguration() {
         return;
     }
 
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         // Guard if during game and set to game-specific value
         if (Settings::values.language_index.UsingGlobal()) {
             Settings::values.language_index.SetValue(ui->combo_language->currentIndex());
@@ -218,7 +218,7 @@ void ConfigureSystem::RefreshConsoleID() {
 }
 
 void ConfigureSystem::SetupPerGameUI() {
-    if (Settings::configuring_global) {
+    if (Settings::IsConfiguringGlobal()) {
         ui->combo_language->setEnabled(Settings::values.language_index.UsingGlobal());
         ui->combo_region->setEnabled(Settings::values.region_index.UsingGlobal());
         ui->combo_time_zone->setEnabled(Settings::values.time_zone_index.UsingGlobal());


### PR DESCRIPTION
Rather than have directly modified global state here, we can make it an implementation detail and have an interface that changes are queried through.