### PR TITLE
applets/controller: Introduce additional checks for mode and caller

### DIFF
--- a/src/core/hle/service/am/applets/controller.cpp
+++ b/src/core/hle/service/am/applets/controller.cpp
@@ -62,7 +62,7 @@ void Controller::Initialize() {
               common_args.play_startup_sound, common_args.size, common_args.system_tick,
               common_args.theme_color);
 
-    library_applet_version = LibraryAppletVersion{common_args.library_version};
+    controller_applet_version = ControllerAppletVersion{common_args.library_version};
 
     const auto private_arg_storage = broker.PopNormalDataToApplet();
     ASSERT(private_arg_storage != nullptr);
@@ -73,7 +73,7 @@ void Controller::Initialize() {
     std::memcpy(&controller_private_arg, private_arg.data(), private_arg.size());
     ASSERT_MSG(controller_private_arg.arg_private_size == sizeof(ControllerSupportArgPrivate),
                "Unknown ControllerSupportArgPrivate revision={} with size={}",
-               library_applet_version, controller_private_arg.arg_private_size);
+               controller_applet_version, controller_private_arg.arg_private_size);
 
     // Some games such as Cave Story+ set invalid values for the ControllerSupportMode.
     // Defer to arg_size to set the ControllerSupportMode.
@@ -112,20 +112,20 @@ void Controller::Initialize() {
         ASSERT(user_arg_storage != nullptr);
 
         const auto& user_arg = user_arg_storage->GetData();
-        switch (library_applet_version) {
-        case LibraryAppletVersion::Version3:
-        case LibraryAppletVersion::Version4:
-        case LibraryAppletVersion::Version5:
+        switch (controller_applet_version) {
+        case ControllerAppletVersion::Version3:
+        case ControllerAppletVersion::Version4:
+        case ControllerAppletVersion::Version5:
             ASSERT(user_arg.size() == sizeof(ControllerSupportArgOld));
             std::memcpy(&controller_user_arg_old, user_arg.data(), user_arg.size());
             break;
-        case LibraryAppletVersion::Version7:
+        case ControllerAppletVersion::Version7:
             ASSERT(user_arg.size() == sizeof(ControllerSupportArgNew));
             std::memcpy(&controller_user_arg_new, user_arg.data(), user_arg.size());
             break;
         default:
             UNIMPLEMENTED_MSG("Unknown ControllerSupportArg revision={} with size={}",
-                              library_applet_version, controller_private_arg.arg_size);
+                              controller_applet_version, controller_private_arg.arg_size);
             ASSERT(user_arg.size() >= sizeof(ControllerSupportArgNew));
             std::memcpy(&controller_user_arg_new, user_arg.data(), sizeof(ControllerSupportArgNew));
             break;
@@ -165,10 +165,10 @@ void Controller::Execute() {
     switch (controller_private_arg.mode) {
     case ControllerSupportMode::ShowControllerSupport: {
         const auto parameters = [this] {
-            switch (library_applet_version) {
-            case LibraryAppletVersion::Version3:
-            case LibraryAppletVersion::Version4:
-            case LibraryAppletVersion::Version5:
+            switch (controller_applet_version) {
+            case ControllerAppletVersion::Version3:
+            case ControllerAppletVersion::Version4:
+            case ControllerAppletVersion::Version5:
                 return ConvertToFrontendParameters(
                     controller_private_arg, controller_user_arg_old.header,
                     controller_user_arg_old.enable_explain_text,
@@ -177,7 +177,7 @@ void Controller::Execute() {
                         controller_user_arg_old.identification_colors.end()),
                     std::vector<ExplainText>(controller_user_arg_old.explain_text.begin(),
                                              controller_user_arg_old.explain_text.end()));
-            case LibraryAppletVersion::Version7:
+            case ControllerAppletVersion::Version7:
             default:
                 return ConvertToFrontendParameters(
                     controller_private_arg, controller_user_arg_new.header,

--- a/src/core/hle/service/am/applets/controller.h
+++ b/src/core/hle/service/am/applets/controller.h
@@ -29,14 +29,18 @@ enum class LibraryAppletVersion : u32_le {
 };
 
 enum class ControllerSupportMode : u8 {
-    ShowControllerSupport = 0,
-    ShowControllerStrapGuide = 1,
-    ShowControllerFirmwareUpdate = 2,
+    ShowControllerSupport,
+    ShowControllerStrapGuide,
+    ShowControllerFirmwareUpdate,
+
+    MaxControllerSupportMode,
 };
 
 enum class ControllerSupportCaller : u8 {
-    Application = 0,
-    System = 1,
+    Application,
+    System,
+
+    MaxControllerSupportCaller,
 };
 
 struct ControllerSupportArgPrivate {

--- a/src/core/hle/service/am/applets/controller.h
+++ b/src/core/hle/service/am/applets/controller.h
@@ -125,6 +125,7 @@ private:
     ControllerSupportArgPrivate controller_private_arg;
     ControllerSupportArgOld controller_user_arg_old;
     ControllerSupportArgNew controller_user_arg_new;
+    ControllerUpdateFirmwareArg controller_update_arg;
     bool complete{false};
     ResultCode status{RESULT_SUCCESS};
     bool is_single_mode{false};

--- a/src/core/hle/service/am/applets/controller.h
+++ b/src/core/hle/service/am/applets/controller.h
@@ -21,7 +21,7 @@ namespace Service::AM::Applets {
 using IdentificationColor = std::array<u8, 4>;
 using ExplainText = std::array<char, 0x81>;
 
-enum class LibraryAppletVersion : u32_le {
+enum class ControllerAppletVersion : u32_le {
     Version3 = 0x3, // 1.0.0 - 2.3.0
     Version4 = 0x4, // 3.0.0 - 5.1.0
     Version5 = 0x5, // 6.0.0 - 7.0.1
@@ -121,7 +121,7 @@ public:
 private:
     const Core::Frontend::ControllerApplet& frontend;
 
-    LibraryAppletVersion library_applet_version;
+    ControllerAppletVersion controller_applet_version;
     ControllerSupportArgPrivate controller_private_arg;
     ControllerSupportArgOld controller_user_arg_old;
     ControllerSupportArgNew controller_user_arg_new;

--- a/src/core/hle/service/am/applets/controller.h
+++ b/src/core/hle/service/am/applets/controller.h
@@ -84,6 +84,13 @@ struct ControllerSupportArgNew {
 static_assert(sizeof(ControllerSupportArgNew) == 0x430,
               "ControllerSupportArgNew has incorrect size.");
 
+struct ControllerUpdateFirmwareArg {
+    bool enable_force_update{};
+    INSERT_PADDING_BYTES(3);
+};
+static_assert(sizeof(ControllerUpdateFirmwareArg) == 0x4,
+              "ControllerUpdateFirmwareArg has incorrect size.");
+
 struct ControllerSupportResultInfo {
     s8 player_count{};
     INSERT_PADDING_BYTES(3);


### PR DESCRIPTION
Some games like Cave Story+ set invalid values in the ControllerPrivateArg's mode and caller fields.
Use other fields to determine the appropriate mode and caller should either or both fields be invalid.

Fixes the issue reported by @german77 in https://github.com/yuzu-emu/yuzu/pull/4866#issuecomment-719059839