### PR TITLE
video_core: dma_pusher: Remove integrity check on command lists.

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
@@ -214,7 +214,6 @@ u32 nvhost_gpu::SubmitGPFIFOImpl(IoctlSubmitGpfifo& params, std::vector<u8>& out
         params.fence_out.value = syncpoint_manager.GetSyncpointMax(params.fence_out.id);
     }
 
-    entries.RefreshIntegrityChecks(gpu);
     gpu.PushGPUEntries(std::move(entries));
 
     if (params.flags.add_increment.Value()) {

--- a/src/video_core/dma_pusher.h
+++ b/src/video_core/dma_pusher.h
@@ -90,10 +90,7 @@ struct CommandList final {
     explicit CommandList(std::vector<Tegra::CommandHeader>&& prefetch_command_list)
         : prefetch_command_list{std::move(prefetch_command_list)} {}
 
-    void RefreshIntegrityChecks(GPU& gpu);
-
     std::vector<Tegra::CommandListHeader> command_lists;
-    std::vector<u64> command_list_hashes;
     std::vector<Tegra::CommandHeader> prefetch_command_list;
 };
 


### PR DESCRIPTION
- This seems to cause softlocks in Breath of the Wild.