### PR TITLE
cpu_interrupt_handler: Mark move contructor/assignment as deleted

### DIFF
--- a/src/core/arm/cpu_interrupt_handler.h
+++ b/src/core/arm/cpu_interrupt_handler.h
@@ -21,8 +21,8 @@ public:
     CPUInterruptHandler(const CPUInterruptHandler&) = delete;
     CPUInterruptHandler& operator=(const CPUInterruptHandler&) = delete;
 
-    CPUInterruptHandler(CPUInterruptHandler&&) = default;
-    CPUInterruptHandler& operator=(CPUInterruptHandler&&) = default;
+    CPUInterruptHandler(CPUInterruptHandler&&) = delete;
+    CPUInterruptHandler& operator=(CPUInterruptHandler&&) = delete;
 
     bool IsInterrupted() const {
         return is_interrupted;


### PR DESCRIPTION
The interrupt handler contains a std::atomic_bool, which isn't copyable or movable, so the special move member functions will always be deleted, despite being defaulted.

This resolves warnings on Clang and GCC.