### PR TITLE
input_common: Treat warnings as errors

### DIFF
--- a/src/core/frontend/input.h
+++ b/src/core/frontend/input.h
@@ -30,7 +30,7 @@ public:
     virtual StatusType GetStatus() const {
         return {};
     }
-    virtual bool GetAnalogDirectionStatus(AnalogDirection direction) const {
+    virtual bool GetAnalogDirectionStatus([[maybe_unused]] AnalogDirection direction) const {
         return {};
     }
     virtual bool SetRumblePlay(f32 amp_low, f32 freq_low, f32 amp_high, f32 freq_high) const {

--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -31,6 +31,9 @@ add_library(input_common STATIC
 
 if (MSVC)
     target_compile_options(input_common PRIVATE
+        /W4
+        /WX
+
         # 'expression' : signed/unsigned mismatch
         /we4018
         # 'argument' : conversion from 'type1' to 'type2', possible loss of data (floating-point)
@@ -46,6 +49,7 @@ if (MSVC)
     )
 else()
     target_compile_options(input_common PRIVATE
+        -Werror
         -Werror=conversion
         -Werror=ignored-qualifiers
         -Werror=implicit-fallthrough

--- a/src/input_common/gcadapter/gc_poller.cpp
+++ b/src/input_common/gcadapter/gc_poller.cpp
@@ -96,7 +96,6 @@ std::unique_ptr<Input::ButtonDevice> GCButtonFactory::Create(const Common::Param
                                               adapter.get());
     }
 
-    UNREACHABLE();
     return nullptr;
 }
 

--- a/src/input_common/sdl/sdl.h
+++ b/src/input_common/sdl/sdl.h
@@ -23,7 +23,7 @@ public:
     /// Unregisters SDL device factories and shut them down.
     virtual ~State() = default;
 
-    virtual Pollers GetPollers(Polling::DeviceType type) {
+    virtual Pollers GetPollers(Polling::DeviceType) {
         return {};
     }
 

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -864,6 +864,8 @@ Common::ParamPackage SDLEventToMotionParamPackage(SDLState& state, const SDL_Eve
 Common::ParamPackage BuildParamPackageForBinding(int port, const std::string& guid,
                                                  const SDL_GameControllerButtonBind& binding) {
     switch (binding.bindType) {
+    case SDL_CONTROLLER_BINDTYPE_NONE:
+        break;
     case SDL_CONTROLLER_BINDTYPE_AXIS:
         return BuildAnalogParamPackageForButton(port, guid, binding.value.axis);
     case SDL_CONTROLLER_BINDTYPE_BUTTON:
@@ -984,7 +986,7 @@ class SDLPoller : public InputCommon::Polling::DevicePoller {
 public:
     explicit SDLPoller(SDLState& state_) : state(state_) {}
 
-    void Start(const std::string& device_id) override {
+    void Start([[maybe_unused]] const std::string& device_id) override {
         state.event_queue.Clear();
         state.polling = true;
     }

--- a/src/input_common/touch_from_button.cpp
+++ b/src/input_common/touch_from_button.cpp
@@ -44,8 +44,7 @@ private:
     std::vector<std::tuple<std::unique_ptr<Input::ButtonDevice>, int, int>> map;
 };
 
-std::unique_ptr<Input::TouchDevice> TouchFromButtonFactory::Create(
-    const Common::ParamPackage& params) {
+std::unique_ptr<Input::TouchDevice> TouchFromButtonFactory::Create(const Common::ParamPackage&) {
     return std::make_unique<TouchFromButtonDevice>();
 }
 

--- a/src/input_common/udp/client.cpp
+++ b/src/input_common/udp/client.cpp
@@ -63,7 +63,7 @@ public:
     }
 
 private:
-    void HandleReceive(const boost::system::error_code& error, std::size_t bytes_transferred) {
+    void HandleReceive(const boost::system::error_code&, std::size_t bytes_transferred) {
         if (auto type = Response::Validate(receive_buffer.data(), bytes_transferred)) {
             switch (*type) {
             case Type::Version: {
@@ -90,7 +90,7 @@ private:
         StartReceive();
     }
 
-    void HandleSend(const boost::system::error_code& error) {
+    void HandleSend(const boost::system::error_code&) {
         boost::system::error_code _ignored{};
         // Send a request for getting port info for the pad
         const Request::PortInfo port_info{1, {static_cast<u8>(pad_index), 0, 0, 0}};
@@ -369,7 +369,7 @@ CalibrationConfigurationJob::CalibrationConfigurationJob(
         u16 max_y{};
 
         Status current_status{Status::Initialized};
-        SocketCallback callback{[](Response::Version version) {}, [](Response::PortInfo info) {},
+        SocketCallback callback{[](Response::Version) {}, [](Response::PortInfo) {},
                                 [&](Response::PadData data) {
                                     if (current_status == Status::Initialized) {
                                         // Receiving data means the communication is ready now

--- a/src/input_common/udp/protocol.h
+++ b/src/input_common/udp/protocol.h
@@ -7,7 +7,16 @@
 #include <array>
 #include <optional>
 #include <type_traits>
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4701)
+#endif
 #include <boost/crc.hpp>
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 #include "common/bit_field.h"
 #include "common/swap.h"
 
@@ -93,7 +102,7 @@ static_assert(std::is_trivially_copyable_v<PadData>,
 
 /**
  * Creates a message with the proper header data that can be sent to the server.
- * @param T data Request body to send
+ * @param data Request body to send
  * @param client_id ID of the udp client (usually not checked on the server)
  */
 template <typename T>


### PR DESCRIPTION
Migrates over warnings as errors for input common to match how the common library treats warnings as errors.