### PR TITLE
cdma_pusher: Minor cleanup

### DIFF
--- a/src/video_core/cdma_pusher.cpp
+++ b/src/video_core/cdma_pusher.cpp
@@ -52,10 +52,9 @@ void CDmaPusher::Step() {
     const auto entries{cdma_queue.front()};
     cdma_queue.pop();
 
-    std::vector<u32> values(entries.size());
-    std::memcpy(values.data(), entries.data(), entries.size() * sizeof(u32));
+    for (const auto entry : entries) {
+        const u32 value = entry.raw;
 
-    for (const u32 value : values) {
         if (mask != 0) {
             const u32 lbs = Common::CountTrailingZeroes32(mask);
             mask &= ~(1U << lbs);
@@ -72,7 +71,7 @@ void CDmaPusher::Step() {
             continue;
         }
 
-        const auto mode = static_cast<ChSubmissionMode>((value >> 28) & 0xf);
+        const auto mode = entry.submission_mode.Value();
         switch (mode) {
         case ChSubmissionMode::SetClass: {
             mask = value & 0x3f;

--- a/src/video_core/cdma_pusher.cpp
+++ b/src/video_core/cdma_pusher.cpp
@@ -110,8 +110,8 @@ void CDmaPusher::ExecuteCommand(u32 offset, u32 data) {
         switch (static_cast<ThiMethod>(offset)) {
         case ThiMethod::IncSyncpt: {
             LOG_DEBUG(Service_NVDRV, "NVDEC Class IncSyncpt Method");
-            const auto syncpoint_id = static_cast<u32>(data & 0xFF);
-            const auto cond = static_cast<u32>((data >> 8) & 0xFF);
+            const auto syncpoint_id = data & 0xFF;
+            const auto cond = (data >> 8) & 0xFF;
             if (cond == 0) {
                 nvdec_sync->Increment(syncpoint_id);
             } else {
@@ -123,8 +123,8 @@ void CDmaPusher::ExecuteCommand(u32 offset, u32 data) {
         case ThiMethod::SetMethod1:
             LOG_DEBUG(Service_NVDRV, "NVDEC method 0x{:X}",
                       static_cast<u32>(nvdec_thi_state.method_0));
-            nvdec_processor->ProcessMethod(
-                static_cast<Tegra::Nvdec::Method>(nvdec_thi_state.method_0), {data});
+            nvdec_processor->ProcessMethod(static_cast<Nvdec::Method>(nvdec_thi_state.method_0),
+                                           {data});
             break;
         default:
             break;
@@ -135,8 +135,8 @@ void CDmaPusher::ExecuteCommand(u32 offset, u32 data) {
         switch (static_cast<ThiMethod>(offset)) {
         case ThiMethod::IncSyncpt: {
             LOG_DEBUG(Service_NVDRV, "VIC Class IncSyncpt Method");
-            const auto syncpoint_id = static_cast<u32>(data & 0xFF);
-            const auto cond = static_cast<u32>((data >> 8) & 0xFF);
+            const auto syncpoint_id = data & 0xFF;
+            const auto cond = (data >> 8) & 0xFF;
             if (cond == 0) {
                 vic_sync->Increment(syncpoint_id);
             } else {
@@ -148,8 +148,7 @@ void CDmaPusher::ExecuteCommand(u32 offset, u32 data) {
         case ThiMethod::SetMethod1:
             LOG_DEBUG(Service_NVDRV, "VIC method 0x{:X}, Args=({})",
                       static_cast<u32>(vic_thi_state.method_0), data);
-            vic_processor->ProcessMethod(static_cast<Tegra::Vic::Method>(vic_thi_state.method_0),
-                                         {data});
+            vic_processor->ProcessMethod(static_cast<Vic::Method>(vic_thi_state.method_0), {data});
             break;
         default:
             break;
@@ -158,7 +157,7 @@ void CDmaPusher::ExecuteCommand(u32 offset, u32 data) {
     case ChClassId::Host1x:
         // This device is mainly for syncpoint synchronization
         LOG_DEBUG(Service_NVDRV, "Host1X Class Method");
-        host1x_processor->ProcessMethod(static_cast<Tegra::Host1x::Method>(offset), {data});
+        host1x_processor->ProcessMethod(static_cast<Host1x::Method>(offset), {data});
         break;
     default:
         UNIMPLEMENTED_MSG("Current class not implemented {:X}", static_cast<u32>(current_class));

--- a/src/video_core/cdma_pusher.cpp
+++ b/src/video_core/cdma_pusher.cpp
@@ -59,9 +59,11 @@ void CDmaPusher::Step() {
         if (mask != 0) {
             const u32 lbs = Common::CountTrailingZeroes32(mask);
             mask &= ~(1U << lbs);
-            ExecuteCommand(static_cast<u32>(offset + lbs), value);
+            ExecuteCommand(static_cast<u32>(offset) + lbs, value);
             continue;
-        } else if (count != 0) {
+        }
+
+        if (count != 0) {
             --count;
             ExecuteCommand(static_cast<u32>(offset), value);
             if (incrementing) {
@@ -69,27 +71,28 @@ void CDmaPusher::Step() {
             }
             continue;
         }
+
         const auto mode = static_cast<ChSubmissionMode>((value >> 28) & 0xf);
         switch (mode) {
         case ChSubmissionMode::SetClass: {
             mask = value & 0x3f;
-            offset = (value >> 16) & 0xfff;
+            offset = static_cast<s32>((value >> 16) & 0xfff);
             current_class = static_cast<ChClassId>((value >> 6) & 0x3ff);
             break;
         }
         case ChSubmissionMode::Incrementing:
         case ChSubmissionMode::NonIncrementing:
             count = value & 0xffff;
-            offset = (value >> 16) & 0xfff;
+            offset = static_cast<s32>((value >> 16) & 0xfff);
             incrementing = mode == ChSubmissionMode::Incrementing;
             break;
         case ChSubmissionMode::Mask:
             mask = value & 0xffff;
-            offset = (value >> 16) & 0xfff;
+            offset = static_cast<s32>((value >> 16) & 0xfff);
             break;
         case ChSubmissionMode::Immediate: {
             const u32 data = value & 0xfff;
-            offset = (value >> 16) & 0xfff;
+            offset = static_cast<s32>((value >> 16) & 0xfff);
             ExecuteCommand(static_cast<u32>(offset), data);
             break;
         }

--- a/src/video_core/cdma_pusher.h
+++ b/src/video_core/cdma_pusher.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <memory>
-#include <unordered_map>
 #include <vector>
 #include <queue>
 

--- a/src/video_core/cdma_pusher.h
+++ b/src/video_core/cdma_pusher.h
@@ -128,7 +128,7 @@ private:
 
     s32 count{};
     s32 offset{};
-    s32 mask{};
+    u32 mask{};
     bool incrementing{};
 
     // Queue of command lists to be processed

--- a/src/video_core/cdma_pusher.h
+++ b/src/video_core/cdma_pusher.h
@@ -15,9 +15,9 @@
 namespace Tegra {
 
 class GPU;
+class Host1x;
 class Nvdec;
 class Vic;
-class Host1x;
 
 enum class ChSubmissionMode : u32 {
     SetClass = 0,
@@ -116,9 +116,9 @@ private:
 
     GPU& gpu;
 
-    std::shared_ptr<Tegra::Nvdec> nvdec_processor;
-    std::unique_ptr<Tegra::Vic> vic_processor;
-    std::unique_ptr<Tegra::Host1x> host1x_processor;
+    std::shared_ptr<Nvdec> nvdec_processor;
+    std::unique_ptr<Vic> vic_processor;
+    std::unique_ptr<Host1x> host1x_processor;
     std::unique_ptr<SyncptIncrManager> nvdec_sync;
     std::unique_ptr<SyncptIncrManager> vic_sync;
     ChClassId current_class{};

--- a/src/video_core/cdma_pusher.h
+++ b/src/video_core/cdma_pusher.h
@@ -67,8 +67,8 @@ struct ChCommand {
     std::vector<u32> arguments;
 };
 
-using ChCommandHeaderList = std::vector<Tegra::ChCommandHeader>;
-using ChCommandList = std::vector<Tegra::ChCommand>;
+using ChCommandHeaderList = std::vector<ChCommandHeader>;
+using ChCommandList = std::vector<ChCommand>;
 
 struct ThiRegisters {
     u32_le increment_syncpt{};


### PR DESCRIPTION
Tidies up the implementation of the CDMA pusher a little bit.

Makes some member variables unsigned, as they were entirely used within unsigned contexts, or were always being converted into unsigned contexts implicitly.

We can also remove an unnecessary intermediate `std::vector` in `Step()`. Instead, we can opt to use the popped vector directly. We can just access the raw value instead of `std::memcpy`-ing the data into the intermediate vector as a `u32`. 