### PR TITLE
[gpu, render_base, rasterizer_interface]: Make use of [[nodiscard]] where applicable

### DIFF
--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -32,7 +32,7 @@ using DiskResourceLoadCallback = std::function<void(LoadCallbackStage, std::size
 
 class RasterizerInterface {
 public:
-    virtual ~RasterizerInterface() {}
+    virtual ~RasterizerInterface() = default;
 
     /// Dispatches a draw invocation
     virtual void Draw(bool is_indexed, bool is_instanced) = 0;
@@ -90,15 +90,16 @@ public:
     virtual void TickFrame() = 0;
 
     /// Attempt to use a faster method to perform a surface copy
-    virtual bool AccelerateSurfaceCopy(const Tegra::Engines::Fermi2D::Regs::Surface& src,
-                                       const Tegra::Engines::Fermi2D::Regs::Surface& dst,
-                                       const Tegra::Engines::Fermi2D::Config& copy_config) {
+    [[nodiscard]] virtual bool AccelerateSurfaceCopy(
+        const Tegra::Engines::Fermi2D::Regs::Surface& src,
+        const Tegra::Engines::Fermi2D::Regs::Surface& dst,
+        const Tegra::Engines::Fermi2D::Config& copy_config) {
         return false;
     }
 
     /// Attempt to use a faster method to display the framebuffer to screen
-    virtual bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
-                                   u32 pixel_stride) {
+    [[nodiscard]] virtual bool AccelerateDisplay(const Tegra::FramebufferConfig& config,
+                                                 VAddr framebuffer_addr, u32 pixel_stride) {
         return false;
     }
 
@@ -110,12 +111,12 @@ public:
                                    const DiskResourceLoadCallback& callback) {}
 
     /// Grant access to the Guest Driver Profile for recording/obtaining info on the guest driver.
-    GuestDriverProfile& AccessGuestDriverProfile() {
+    [[nodiscard]] GuestDriverProfile& AccessGuestDriverProfile() {
         return guest_driver_profile;
     }
 
     /// Grant access to the Guest Driver Profile for recording/obtaining info on the guest driver.
-    const GuestDriverProfile& AccessGuestDriverProfile() const {
+    [[nodiscard]] const GuestDriverProfile& AccessGuestDriverProfile() const {
         return guest_driver_profile;
     }
 

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -38,7 +38,7 @@ public:
     virtual ~RendererBase();
 
     /// Initialize the renderer
-    virtual bool Init() = 0;
+    [[nodiscard]] virtual bool Init() = 0;
 
     /// Shutdown the renderer
     virtual void ShutDown() = 0;
@@ -49,43 +49,43 @@ public:
     // Getter/setter functions:
     // ------------------------
 
-    f32 GetCurrentFPS() const {
+    [[nodiscard]] f32 GetCurrentFPS() const {
         return m_current_fps;
     }
 
-    int GetCurrentFrame() const {
+    [[nodiscard]] int GetCurrentFrame() const {
         return m_current_frame;
     }
 
-    RasterizerInterface& Rasterizer() {
+    [[nodiscard]] RasterizerInterface& Rasterizer() {
         return *rasterizer;
     }
 
-    const RasterizerInterface& Rasterizer() const {
+    [[nodiscard]] const RasterizerInterface& Rasterizer() const {
         return *rasterizer;
     }
 
-    Core::Frontend::GraphicsContext& Context() {
+    [[nodiscard]] Core::Frontend::GraphicsContext& Context() {
         return *context;
     }
 
-    const Core::Frontend::GraphicsContext& Context() const {
+    [[nodiscard]] const Core::Frontend::GraphicsContext& Context() const {
         return *context;
     }
 
-    Core::Frontend::EmuWindow& GetRenderWindow() {
+    [[nodiscard]] Core::Frontend::EmuWindow& GetRenderWindow() {
         return render_window;
     }
 
-    const Core::Frontend::EmuWindow& GetRenderWindow() const {
+    [[nodiscard]] const Core::Frontend::EmuWindow& GetRenderWindow() const {
         return render_window;
     }
 
-    RendererSettings& Settings() {
+    [[nodiscard]] RendererSettings& Settings() {
         return renderer_settings;
     }
 
-    const RendererSettings& Settings() const {
+    [[nodiscard]] const RendererSettings& Settings() const {
         return renderer_settings;
     }
 


### PR DESCRIPTION
Makes use of `[[nodiscard]]` to allow the compiler to catch scenarios where not using the return value of a function is undeniably a bug.