### PR TITLE
page_table: Allow page tables to be moved

### DIFF
--- a/src/common/page_table.cpp
+++ b/src/common/page_table.cpp
@@ -8,7 +8,7 @@ namespace Common {
 
 PageTable::PageTable() = default;
 
-PageTable::~PageTable() = default;
+PageTable::~PageTable() noexcept = default;
 
 void PageTable::Resize(std::size_t address_space_width_in_bits, std::size_t page_size_in_bits,
                        bool has_attribute) {

--- a/src/common/page_table.h
+++ b/src/common/page_table.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tuple>
+
 #include "common/common_types.h"
 #include "common/memory_hook.h"
 #include "common/virtual_buffer.h"
@@ -47,7 +49,13 @@ struct SpecialRegion {
  */
 struct PageTable {
     PageTable();
-    ~PageTable();
+    ~PageTable() noexcept;
+
+    PageTable(const PageTable&) = delete;
+    PageTable& operator=(const PageTable&) = delete;
+
+    PageTable(PageTable&&) noexcept = default;
+    PageTable& operator=(PageTable&&) noexcept = default;
 
     /**
      * Resizes the page table to be able to accomodate enough pages within

--- a/src/common/page_table.h
+++ b/src/common/page_table.h
@@ -4,10 +4,6 @@
 
 #pragma once
 
-#include <vector>
-
-#include <boost/icl/interval_map.hpp>
-
 #include "common/common_types.h"
 #include "common/memory_hook.h"
 #include "common/virtual_buffer.h"

--- a/src/common/page_table.h
+++ b/src/common/page_table.h
@@ -54,6 +54,8 @@ struct PageTable {
      * a given address space.
      *
      * @param address_space_width_in_bits The address size width in bits.
+     * @param page_size_in_bits           The page size in bits.
+     * @param has_attribute               Whether or not this page has any backing attributes.
      */
     void Resize(std::size_t address_space_width_in_bits, std::size_t page_size_in_bits,
                 bool has_attribute);

--- a/src/common/virtual_buffer.cpp
+++ b/src/common/virtual_buffer.cpp
@@ -13,7 +13,7 @@
 
 namespace Common {
 
-void* AllocateMemoryPages(std::size_t size) {
+void* AllocateMemoryPages(std::size_t size) noexcept {
 #ifdef _WIN32
     void* base{VirtualAlloc(nullptr, size, MEM_COMMIT, PAGE_READWRITE)};
 #else
@@ -29,7 +29,7 @@ void* AllocateMemoryPages(std::size_t size) {
     return base;
 }
 
-void FreeMemoryPages(void* base, [[maybe_unused]] std::size_t size) {
+void FreeMemoryPages(void* base, [[maybe_unused]] std::size_t size) noexcept {
     if (!base) {
         return;
     }

--- a/src/common/virtual_buffer.h
+++ b/src/common/virtual_buffer.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <type_traits>
 #include <utility>
 
 namespace Common {
@@ -14,6 +15,11 @@ void FreeMemoryPages(void* base, std::size_t size) noexcept;
 template <typename T>
 class VirtualBuffer final {
 public:
+    static_assert(
+        std::is_trivially_constructible_v<T>,
+        "T must be trivially constructible, as non-trivial constructors will not be executed "
+        "with the current allocator");
+
     constexpr VirtualBuffer() = default;
     explicit VirtualBuffer(std::size_t count) : alloc_size{count * sizeof(T)} {
         base_ptr = reinterpret_cast<T*>(AllocateMemoryPages(alloc_size));

--- a/src/common/virtual_buffer.h
+++ b/src/common/virtual_buffer.h
@@ -4,23 +4,36 @@
 
 #pragma once
 
-#include "common/common_funcs.h"
+#include <utility>
 
 namespace Common {
 
-void* AllocateMemoryPages(std::size_t size);
-void FreeMemoryPages(void* base, std::size_t size);
+void* AllocateMemoryPages(std::size_t size) noexcept;
+void FreeMemoryPages(void* base, std::size_t size) noexcept;
 
 template <typename T>
-class VirtualBuffer final : NonCopyable {
+class VirtualBuffer final {
 public:
     constexpr VirtualBuffer() = default;
     explicit VirtualBuffer(std::size_t count) : alloc_size{count * sizeof(T)} {
         base_ptr = reinterpret_cast<T*>(AllocateMemoryPages(alloc_size));
     }
 
-    ~VirtualBuffer() {
+    ~VirtualBuffer() noexcept {
         FreeMemoryPages(base_ptr, alloc_size);
+    }
+
+    VirtualBuffer(const VirtualBuffer&) = delete;
+    VirtualBuffer& operator=(const VirtualBuffer&) = delete;
+
+    VirtualBuffer(VirtualBuffer&& other) noexcept
+        : alloc_size{std::exchange(other.alloc_size, 0)}, base_ptr{std::exchange(other.base_ptr),
+                                                                   nullptr} {}
+
+    VirtualBuffer& operator=(VirtualBuffer&& other) noexcept {
+        alloc_size = std::exchange(other.alloc_size, 0);
+        base_ptr = std::exchange(other.base_ptr, nullptr);
+        return *this;
     }
 
     void resize(std::size_t count) {


### PR DESCRIPTION
Makes the API a little more flexible by allowing them to be moved if they ever need to be. Previously, with the destructor specified, but no move assignment or move constructor specified, they wouldn't be implicitly generated.

While we're at it, we can also make VirtualBuffer a little more type-safe at compile-time so we don't ever unintentionally hit undefined behavior.