### PR TITLE
patch_manager: Remove usages of the global system instance

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -210,7 +210,7 @@ struct System::Impl {
 
     ResultStatus Load(System& system, Frontend::EmuWindow& emu_window,
                       const std::string& filepath) {
-        app_loader = Loader::GetLoader(GetGameFileFromPath(virtual_filesystem, filepath));
+        app_loader = Loader::GetLoader(system, GetGameFileFromPath(virtual_filesystem, filepath));
         if (!app_loader) {
             LOG_CRITICAL(Core, "Failed to obtain loader for {}!", filepath);
             return ResultStatus::ErrorGetLoader;
@@ -224,7 +224,7 @@ struct System::Impl {
             return init_result;
         }
 
-        telemetry_session->AddInitialInfo(*app_loader);
+        telemetry_session->AddInitialInfo(*app_loader, fs_controller, *content_provider);
         auto main_process =
             Kernel::Process::Create(system, "main", Kernel::Process::ProcessType::Userland);
         const auto [load_result, load_parameters] = app_loader->Load(*main_process, system);
@@ -338,7 +338,7 @@ struct System::Impl {
         Service::Glue::ApplicationLaunchProperty launch{};
         launch.title_id = process.GetTitleID();
 
-        FileSys::PatchManager pm{launch.title_id};
+        FileSys::PatchManager pm{launch.title_id, fs_controller, *content_provider};
         launch.version = pm.GetGameVersion().value_or(0);
 
         // TODO(DarkLordZach): When FSController/Game Card Support is added, if

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -17,8 +17,13 @@ namespace Core {
 class System;
 }
 
+namespace Service::FileSystem {
+class FileSystemController;
+}
+
 namespace FileSys {
 
+class ContentProvider;
 class NCA;
 class NACP;
 
@@ -29,7 +34,9 @@ public:
     using Metadata = std::pair<std::unique_ptr<NACP>, VirtualFile>;
     using PatchVersionNames = std::map<std::string, std::string, std::less<>>;
 
-    explicit PatchManager(u64 title_id);
+    explicit PatchManager(u64 title_id_,
+                          const Service::FileSystem::FileSystemController& fs_controller_,
+                          const ContentProvider& content_provider_);
     ~PatchManager();
 
     [[nodiscard]] u64 GetTitleID() const;
@@ -50,7 +57,7 @@ public:
 
     // Creates a CheatList object with all
     [[nodiscard]] std::vector<Core::Memory::CheatEntry> CreateCheatList(
-        const Core::System& system, const BuildID& build_id) const;
+        const BuildID& build_id) const;
 
     // Currently tracked RomFS patches:
     // - Game Updates
@@ -80,6 +87,8 @@ private:
                                                           const std::string& build_id) const;
 
     u64 title_id;
+    const Service::FileSystem::FileSystemController& fs_controller;
+    const ContentProvider& content_provider;
 };
 
 } // namespace FileSys

--- a/src/core/file_sys/romfs_factory.cpp
+++ b/src/core/file_sys/romfs_factory.cpp
@@ -37,10 +37,12 @@ void RomFSFactory::SetPackedUpdate(VirtualFile update_raw) {
 }
 
 ResultVal<VirtualFile> RomFSFactory::OpenCurrentProcess(u64 current_process_title_id) const {
-    if (!updatable)
+    if (!updatable) {
         return MakeResult<VirtualFile>(file);
+    }
 
-    const PatchManager patch_manager(current_process_title_id);
+    const PatchManager patch_manager{current_process_title_id, filesystem_controller,
+                                     content_provider};
     return MakeResult<VirtualFile>(
         patch_manager.PatchRomFS(file, ivfc_offset, ContentRecordType::Program, update_raw));
 }

--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -742,8 +742,10 @@ void Module::Interface::IsUserAccountSwitchLocked(Kernel::HLERequestContext& ctx
     bool is_locked = false;
 
     if (res != Loader::ResultStatus::Success) {
-        FileSys::PatchManager pm{system.CurrentProcess()->GetTitleID()};
-        auto nacp_unique = pm.GetControlMetadata().first;
+        const FileSys::PatchManager pm{system.CurrentProcess()->GetTitleID(),
+                                       system.GetFileSystemController(),
+                                       system.GetContentProvider()};
+        const auto nacp_unique = pm.GetControlMetadata().first;
 
         if (nacp_unique != nullptr) {
             is_locked = nacp_unique->GetUserAccountSwitchLock();

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -1381,13 +1381,16 @@ void IApplicationFunctions::GetDisplayVersion(Kernel::HLERequestContext& ctx) {
     const auto res = [this] {
         const auto title_id = system.CurrentProcess()->GetTitleID();
 
-        FileSys::PatchManager pm{title_id};
+        const FileSys::PatchManager pm{title_id, system.GetFileSystemController(),
+                                       system.GetContentProvider()};
         auto res = pm.GetControlMetadata();
         if (res.first != nullptr) {
             return res;
         }
 
-        FileSys::PatchManager pm_update{FileSys::GetUpdateTitleID(title_id)};
+        const FileSys::PatchManager pm_update{FileSys::GetUpdateTitleID(title_id),
+                                              system.GetFileSystemController(),
+                                              system.GetContentProvider()};
         return pm_update.GetControlMetadata();
     }();
 
@@ -1415,13 +1418,16 @@ void IApplicationFunctions::GetDesiredLanguage(Kernel::HLERequestContext& ctx) {
     const auto res = [this] {
         const auto title_id = system.CurrentProcess()->GetTitleID();
 
-        FileSys::PatchManager pm{title_id};
+        const FileSys::PatchManager pm{title_id, system.GetFileSystemController(),
+                                       system.GetContentProvider()};
         auto res = pm.GetControlMetadata();
         if (res.first != nullptr) {
             return res;
         }
 
-        FileSys::PatchManager pm_update{FileSys::GetUpdateTitleID(title_id)};
+        const FileSys::PatchManager pm_update{FileSys::GetUpdateTitleID(title_id),
+                                              system.GetFileSystemController(),
+                                              system.GetContentProvider()};
         return pm_update.GetControlMetadata();
     }();
 

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -164,7 +164,8 @@ void AOC_U::GetAddOnContentBaseId(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
 
     const auto title_id = system.CurrentProcess()->GetTitleID();
-    FileSys::PatchManager pm{title_id};
+    const FileSys::PatchManager pm{title_id, system.GetFileSystemController(),
+                                   system.GetContentProvider()};
 
     const auto res = pm.GetControlMetadata();
     if (res.first == nullptr) {

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -455,7 +455,9 @@ FileSys::SaveDataSize FileSystemController::ReadSaveDataSize(FileSys::SaveDataTy
         const auto res = system.GetAppLoader().ReadControlData(nacp);
 
         if (res != Loader::ResultStatus::Success) {
-            FileSys::PatchManager pm{system.CurrentProcess()->GetTitleID()};
+            const FileSys::PatchManager pm{system.CurrentProcess()->GetTitleID(),
+                                           system.GetFileSystemController(),
+                                           system.GetContentProvider()};
             const auto metadata = pm.GetControlMetadata();
             const auto& nacp_unique = metadata.first;
 
@@ -728,7 +730,8 @@ void FileSystemController::CreateFactories(FileSys::VfsFilesystem& vfs, bool ove
 void InstallInterfaces(Core::System& system) {
     std::make_shared<FSP_LDR>()->InstallAsService(system.ServiceManager());
     std::make_shared<FSP_PR>()->InstallAsService(system.ServiceManager());
-    std::make_shared<FSP_SRV>(system.GetFileSystemController(), system.GetReporter())
+    std::make_shared<FSP_SRV>(system.GetFileSystemController(), system.GetContentProvider(),
+                              system.GetReporter())
         ->InstallAsService(system.ServiceManager());
 }
 

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -650,8 +650,10 @@ private:
     u64 next_entry_index = 0;
 };
 
-FSP_SRV::FSP_SRV(FileSystemController& fsc, const Core::Reporter& reporter)
-    : ServiceFramework("fsp-srv"), fsc(fsc), reporter(reporter) {
+FSP_SRV::FSP_SRV(FileSystemController& fsc_, const FileSys::ContentProvider& content_provider_,
+                 const Core::Reporter& reporter_)
+    : ServiceFramework("fsp-srv"), fsc(fsc_), content_provider{content_provider_},
+      reporter(reporter_) {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "OpenFileSystem"},
@@ -968,7 +970,7 @@ void FSP_SRV::OpenDataStorageByDataId(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    FileSys::PatchManager pm{title_id};
+    const FileSys::PatchManager pm{title_id, fsc, content_provider};
 
     auto storage = std::make_shared<IStorage>(
         pm.PatchRomFS(std::move(data.Unwrap()), 0, FileSys::ContentRecordType::Data));

--- a/src/core/hle/service/filesystem/fsp_srv.h
+++ b/src/core/hle/service/filesystem/fsp_srv.h
@@ -12,8 +12,9 @@ class Reporter;
 }
 
 namespace FileSys {
+class ContentProvider;
 class FileSystemBackend;
-}
+} // namespace FileSys
 
 namespace Service::FileSystem {
 
@@ -32,7 +33,8 @@ enum class LogMode : u32 {
 
 class FSP_SRV final : public ServiceFramework<FSP_SRV> {
 public:
-    explicit FSP_SRV(FileSystemController& fsc, const Core::Reporter& reporter);
+    explicit FSP_SRV(FileSystemController& fsc_, const FileSys::ContentProvider& content_provider_,
+                     const Core::Reporter& reporter_);
     ~FSP_SRV() override;
 
 private:
@@ -55,6 +57,7 @@ private:
     void OpenMultiCommitManager(Kernel::HLERequestContext& ctx);
 
     FileSystemController& fsc;
+    const FileSys::ContentProvider& content_provider;
 
     FileSys::VirtualFile romfs;
     u64 current_process_id = 0;

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -114,7 +114,8 @@ AppLoader_DeconstructedRomDirectory::LoadResult AppLoader_DeconstructedRomDirect
     }
 
     if (override_update) {
-        const FileSys::PatchManager patch_manager(metadata.GetTitleID());
+        const FileSys::PatchManager patch_manager(
+            metadata.GetTitleID(), system.GetFileSystemController(), system.GetContentProvider());
         dir = patch_manager.PatchExeFS(dir);
     }
 
@@ -160,7 +161,8 @@ AppLoader_DeconstructedRomDirectory::LoadResult AppLoader_DeconstructedRomDirect
     modules.clear();
     const VAddr base_address{process.PageTable().GetCodeRegionStart()};
     VAddr next_load_addr{base_address};
-    const FileSys::PatchManager pm{metadata.GetTitleID()};
+    const FileSys::PatchManager pm{metadata.GetTitleID(), system.GetFileSystemController(),
+                                   system.GetContentProvider()};
     for (const auto& module : static_modules) {
         const FileSys::VirtualFile module_file{dir->GetFile(module)};
         if (!module_file) {

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -10,6 +10,7 @@
 #include "common/file_util.h"
 #include "common/logging/log.h"
 #include "common/string_util.h"
+#include "core/core.h"
 #include "core/hle/kernel/process.h"
 #include "core/loader/deconstructed_rom_directory.h"
 #include "core/loader/elf.h"
@@ -194,15 +195,14 @@ AppLoader::~AppLoader() = default;
 
 /**
  * Get a loader for a file with a specific type
- * @param file The file to load
- * @param type The type of the file
- * @param file the file to retrieve the loader for
- * @param type the file type
+ * @param system The system context to use.
+ * @param file   The file to retrieve the loader for
+ * @param type   The file type
  * @return std::unique_ptr<AppLoader> a pointer to a loader object;  nullptr for unsupported type
  */
-static std::unique_ptr<AppLoader> GetFileLoader(FileSys::VirtualFile file, FileType type) {
+static std::unique_ptr<AppLoader> GetFileLoader(Core::System& system, FileSys::VirtualFile file,
+                                                FileType type) {
     switch (type) {
-
     // Standard ELF file format.
     case FileType::ELF:
         return std::make_unique<AppLoader_ELF>(std::move(file));
@@ -221,7 +221,8 @@ static std::unique_ptr<AppLoader> GetFileLoader(FileSys::VirtualFile file, FileT
 
     // NX XCI (nX Card Image) file format.
     case FileType::XCI:
-        return std::make_unique<AppLoader_XCI>(std::move(file));
+        return std::make_unique<AppLoader_XCI>(std::move(file), system.GetFileSystemController(),
+                                               system.GetContentProvider());
 
     // NX NAX (NintendoAesXts) file format.
     case FileType::NAX:
@@ -229,7 +230,8 @@ static std::unique_ptr<AppLoader> GetFileLoader(FileSys::VirtualFile file, FileT
 
     // NX NSP (Nintendo Submission Package) file format
     case FileType::NSP:
-        return std::make_unique<AppLoader_NSP>(std::move(file));
+        return std::make_unique<AppLoader_NSP>(std::move(file), system.GetFileSystemController(),
+                                               system.GetContentProvider());
 
     // NX KIP (Kernel Internal Process) file format
     case FileType::KIP:
@@ -244,20 +246,21 @@ static std::unique_ptr<AppLoader> GetFileLoader(FileSys::VirtualFile file, FileT
     }
 }
 
-std::unique_ptr<AppLoader> GetLoader(FileSys::VirtualFile file) {
+std::unique_ptr<AppLoader> GetLoader(Core::System& system, FileSys::VirtualFile file) {
     FileType type = IdentifyFile(file);
-    FileType filename_type = GuessFromFilename(file->GetName());
+    const FileType filename_type = GuessFromFilename(file->GetName());
 
     // Special case: 00 is either a NCA or NAX.
     if (type != filename_type && !(file->GetName() == "00" && type == FileType::NAX)) {
         LOG_WARNING(Loader, "File {} has a different type than its extension.", file->GetName());
-        if (FileType::Unknown == type)
+        if (FileType::Unknown == type) {
             type = filename_type;
+        }
     }
 
     LOG_DEBUG(Loader, "Loading file {} as {}...", file->GetName(), GetFileTypeString(type));
 
-    return GetFileLoader(std::move(file), type);
+    return GetFileLoader(system, std::move(file), type);
 }
 
 } // namespace Loader

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -290,9 +290,12 @@ protected:
 
 /**
  * Identifies a bootable file and return a suitable loader
- * @param file The bootable file
- * @return the best loader for this file
+ *
+ * @param system The system context.
+ * @param file   The bootable file.
+ *
+ * @return the best loader for this file.
  */
-std::unique_ptr<AppLoader> GetLoader(FileSys::VirtualFile file);
+std::unique_ptr<AppLoader> GetLoader(Core::System& system, FileSys::VirtualFile file);
 
 } // namespace Loader

--- a/src/core/loader/nso.cpp
+++ b/src/core/loader/nso.cpp
@@ -149,7 +149,7 @@ std::optional<VAddr> AppLoader_NSO::LoadModule(Kernel::Process& process, Core::S
     // Apply cheats if they exist and the program has a valid title ID
     if (pm) {
         system.SetCurrentProcessBuildID(nso_header.build_id);
-        const auto cheats = pm->CreateCheatList(system, nso_header.build_id);
+        const auto cheats = pm->CreateCheatList(nso_header.build_id);
         if (!cheats.empty()) {
             system.RegisterCheatList(cheats, nso_header.build_id, load_base, image_size);
         }

--- a/src/core/loader/nsp.cpp
+++ b/src/core/loader/nsp.cpp
@@ -21,26 +21,33 @@
 
 namespace Loader {
 
-AppLoader_NSP::AppLoader_NSP(FileSys::VirtualFile file)
+AppLoader_NSP::AppLoader_NSP(FileSys::VirtualFile file,
+                             const Service::FileSystem::FileSystemController& fsc,
+                             const FileSys::ContentProvider& content_provider)
     : AppLoader(file), nsp(std::make_unique<FileSys::NSP>(file)),
       title_id(nsp->GetProgramTitleID()) {
 
-    if (nsp->GetStatus() != ResultStatus::Success)
+    if (nsp->GetStatus() != ResultStatus::Success) {
         return;
+    }
 
     if (nsp->IsExtractedType()) {
         secondary_loader = std::make_unique<AppLoader_DeconstructedRomDirectory>(nsp->GetExeFS());
     } else {
         const auto control_nca =
             nsp->GetNCA(nsp->GetProgramTitleID(), FileSys::ContentRecordType::Control);
-        if (control_nca == nullptr || control_nca->GetStatus() != ResultStatus::Success)
+        if (control_nca == nullptr || control_nca->GetStatus() != ResultStatus::Success) {
             return;
+        }
 
-        std::tie(nacp_file, icon_file) =
-            FileSys::PatchManager(nsp->GetProgramTitleID()).ParseControlNCA(*control_nca);
+        std::tie(nacp_file, icon_file) = [this, &content_provider, &control_nca, &fsc] {
+            const FileSys::PatchManager pm{nsp->GetProgramTitleID(), fsc, content_provider};
+            return pm.ParseControlNCA(*control_nca);
+        }();
 
-        if (title_id == 0)
+        if (title_id == 0) {
             return;
+        }
 
         secondary_loader = std::make_unique<AppLoader_NCA>(
             nsp->GetNCAFile(title_id, FileSys::ContentRecordType::Program));

--- a/src/core/loader/nsp.h
+++ b/src/core/loader/nsp.h
@@ -9,14 +9,15 @@
 #include "core/file_sys/vfs.h"
 #include "core/loader/loader.h"
 
-namespace Core {
-class System;
-}
-
 namespace FileSys {
+class ContentProvider;
 class NACP;
 class NSP;
 } // namespace FileSys
+
+namespace Service::FileSystem {
+class FileSystemController;
+}
 
 namespace Loader {
 
@@ -25,7 +26,9 @@ class AppLoader_NCA;
 /// Loads an XCI file
 class AppLoader_NSP final : public AppLoader {
 public:
-    explicit AppLoader_NSP(FileSys::VirtualFile file);
+    explicit AppLoader_NSP(FileSys::VirtualFile file,
+                           const Service::FileSystem::FileSystemController& fsc,
+                           const FileSys::ContentProvider& content_provider);
     ~AppLoader_NSP() override;
 
     /**

--- a/src/core/loader/xci.cpp
+++ b/src/core/loader/xci.cpp
@@ -20,18 +20,24 @@
 
 namespace Loader {
 
-AppLoader_XCI::AppLoader_XCI(FileSys::VirtualFile file)
+AppLoader_XCI::AppLoader_XCI(FileSys::VirtualFile file,
+                             const Service::FileSystem::FileSystemController& fsc,
+                             const FileSys::ContentProvider& content_provider)
     : AppLoader(file), xci(std::make_unique<FileSys::XCI>(file)),
       nca_loader(std::make_unique<AppLoader_NCA>(xci->GetProgramNCAFile())) {
-    if (xci->GetStatus() != ResultStatus::Success)
+    if (xci->GetStatus() != ResultStatus::Success) {
         return;
+    }
 
     const auto control_nca = xci->GetNCAByType(FileSys::NCAContentType::Control);
-    if (control_nca == nullptr || control_nca->GetStatus() != ResultStatus::Success)
+    if (control_nca == nullptr || control_nca->GetStatus() != ResultStatus::Success) {
         return;
+    }
 
-    std::tie(nacp_file, icon_file) =
-        FileSys::PatchManager(xci->GetProgramTitleID()).ParseControlNCA(*control_nca);
+    std::tie(nacp_file, icon_file) = [this, &content_provider, &control_nca, &fsc] {
+        const FileSys::PatchManager pm{xci->GetProgramTitleID(), fsc, content_provider};
+        return pm.ParseControlNCA(*control_nca);
+    }();
 }
 
 AppLoader_XCI::~AppLoader_XCI() = default;

--- a/src/core/loader/xci.h
+++ b/src/core/loader/xci.h
@@ -9,14 +9,15 @@
 #include "core/file_sys/vfs.h"
 #include "core/loader/loader.h"
 
-namespace Core {
-class System;
-}
-
 namespace FileSys {
+class ContentProvider;
 class NACP;
 class XCI;
 } // namespace FileSys
+
+namespace Service::FileSystem {
+class FileSystemController;
+}
 
 namespace Loader {
 
@@ -25,7 +26,9 @@ class AppLoader_NCA;
 /// Loads an XCI file
 class AppLoader_XCI final : public AppLoader {
 public:
-    explicit AppLoader_XCI(FileSys::VirtualFile file);
+    explicit AppLoader_XCI(FileSys::VirtualFile file,
+                           const Service::FileSystem::FileSystemController& fsc,
+                           const FileSys::ContentProvider& content_provider);
     ~AppLoader_XCI() override;
 
     /**

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -147,7 +147,9 @@ TelemetrySession::~TelemetrySession() {
     }
 }
 
-void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader) {
+void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader,
+                                      const Service::FileSystem::FileSystemController& fsc,
+                                      const FileSys::ContentProvider& content_provider) {
     // Log one-time top-level information
     AddField(Telemetry::FieldType::None, "TelemetryId", GetTelemetryId());
 
@@ -167,7 +169,10 @@ void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader) {
         app_loader.ReadTitle(name);
 
         if (name.empty()) {
-            const auto metadata = FileSys::PatchManager(program_id).GetControlMetadata();
+            const auto metadata = [&content_provider, &fsc, program_id] {
+                const FileSys::PatchManager pm{program_id, fsc, content_provider};
+                return pm.GetControlMetadata();
+            }();
             if (metadata.first != nullptr) {
                 name = metadata.first->GetApplicationName();
             }

--- a/src/core/telemetry_session.h
+++ b/src/core/telemetry_session.h
@@ -7,8 +7,16 @@
 #include <string>
 #include "common/telemetry.h"
 
+namespace FileSys {
+class ContentProvider;
+}
+
 namespace Loader {
 class AppLoader;
+}
+
+namespace Service::FileSystem {
+class FileSystemController;
 }
 
 namespace Core {
@@ -40,10 +48,14 @@ public:
      *   - Title file format
      *   - Miscellaneous settings values.
      *
-     * @param app_loader The application loader to use to retrieve
-     *                   title-specific information.
+     * @param app_loader       The application loader to use to retrieve
+     *                         title-specific information.
+     * @param fsc              Filesystem controller to use to retrieve info.
+     * @param content_provider Content provider to use to retrieve info.
      */
-    void AddInitialInfo(Loader::AppLoader& app_loader);
+    void AddInitialInfo(Loader::AppLoader& app_loader,
+                        const Service::FileSystem::FileSystemController& fsc,
+                        const FileSys::ContentProvider& content_provider);
 
     /**
      * Wrapper around the Telemetry::FieldCollection::AddField method.

--- a/src/yuzu/configuration/configure_per_game.cpp
+++ b/src/yuzu/configuration/configure_per_game.cpp
@@ -16,6 +16,7 @@
 
 #include "common/common_paths.h"
 #include "common/file_util.h"
+#include "core/core.h"
 #include "core/file_sys/control_metadata.h"
 #include "core/file_sys/patch_manager.h"
 #include "core/file_sys/xts_archive.h"
@@ -89,9 +90,11 @@ void ConfigurePerGame::LoadConfiguration() {
     ui->display_title_id->setText(
         QStringLiteral("%1").arg(title_id, 16, 16, QLatin1Char{'0'}).toUpper());
 
-    FileSys::PatchManager pm{title_id};
+    auto& system = Core::System::GetInstance();
+    const FileSys::PatchManager pm{title_id, system.GetFileSystemController(),
+                                   system.GetContentProvider()};
     const auto control = pm.GetControlMetadata();
-    const auto loader = Loader::GetLoader(file);
+    const auto loader = Loader::GetLoader(system, file);
 
     if (control.first != nullptr) {
         ui->display_version->setText(QString::fromStdString(control.first->GetVersionString()));

--- a/src/yuzu/configuration/configure_per_game_addons.cpp
+++ b/src/yuzu/configuration/configure_per_game_addons.cpp
@@ -112,8 +112,10 @@ void ConfigurePerGameAddons::LoadConfiguration() {
         return;
     }
 
-    FileSys::PatchManager pm{title_id};
-    const auto loader = Loader::GetLoader(file);
+    auto& system = Core::System::GetInstance();
+    const FileSys::PatchManager pm{title_id, system.GetFileSystemController(),
+                                   system.GetContentProvider()};
+    const auto loader = Loader::GetLoader(system, file);
 
     FileSys::VirtualFile update_raw;
     loader->ReadUpdateRaw(update_raw);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1090,9 +1090,9 @@ void GMainWindow::BootGame(const QString& filename) {
     StoreRecentFile(filename); // Put the filename on top of the list
 
     u64 title_id{0};
-
+    auto& system = Core::System::GetInstance();
     const auto v_file = Core::GetGameFileFromPath(vfs, filename.toUtf8().constData());
-    const auto loader = Loader::GetLoader(v_file);
+    const auto loader = Loader::GetLoader(system, v_file);
     if (!(loader == nullptr || loader->ReadProgramId(title_id) != Loader::ResultStatus::Success)) {
         // Load per game settings
         Config per_game_config(fmt::format("{:016X}", title_id), Config::ConfigType::PerGameConfig);
@@ -1144,9 +1144,13 @@ void GMainWindow::BootGame(const QString& filename) {
 
     std::string title_name;
     std::string title_version;
-    const auto res = Core::System::GetInstance().GetGameName(title_name);
+    const auto res = system.GetGameName(title_name);
 
-    const auto metadata = FileSys::PatchManager(title_id).GetControlMetadata();
+    const auto metadata = [&system, title_id] {
+        const FileSys::PatchManager pm(title_id, system.GetFileSystemController(),
+                                       system.GetContentProvider());
+        return pm.GetControlMetadata();
+    }();
     if (metadata.first != nullptr) {
         title_version = metadata.first->GetVersionString();
         title_name = metadata.first->GetApplicationName();
@@ -1157,7 +1161,7 @@ void GMainWindow::BootGame(const QString& filename) {
     LOG_INFO(Frontend, "Booting game: {:016X} | {} | {}", title_id, title_name, title_version);
     UpdateWindowTitle(title_name, title_version);
 
-    loading_screen->Prepare(Core::System::GetInstance().GetAppLoader());
+    loading_screen->Prepare(system.GetAppLoader());
     loading_screen->show();
 
     emulation_running = true;
@@ -1276,16 +1280,18 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
                                        const std::string& game_path) {
     std::string path;
     QString open_target;
+    auto& system = Core::System::GetInstance();
 
-    const auto [user_save_size, device_save_size] = [this, &program_id, &game_path] {
-        FileSys::PatchManager pm{program_id};
+    const auto [user_save_size, device_save_size] = [this, &game_path, &program_id, &system] {
+        const FileSys::PatchManager pm{program_id, system.GetFileSystemController(),
+                                       system.GetContentProvider()};
         const auto control = pm.GetControlMetadata().first;
         if (control != nullptr) {
             return std::make_pair(control->GetDefaultNormalSaveSize(),
                                   control->GetDeviceSaveDataSize());
         } else {
             const auto file = Core::GetGameFileFromPath(vfs, game_path);
-            const auto loader = Loader::GetLoader(file);
+            const auto loader = Loader::GetLoader(system, file);
 
             FileSys::NACP nacp{};
             loader->ReadControlData(nacp);
@@ -1612,7 +1618,8 @@ void GMainWindow::OnGameListDumpRomFS(u64 program_id, const std::string& game_pa
                                 "cancelled the operation."));
     };
 
-    const auto loader = Loader::GetLoader(vfs->OpenFile(game_path, FileSys::Mode::Read));
+    auto& system = Core::System::GetInstance();
+    const auto loader = Loader::GetLoader(system, vfs->OpenFile(game_path, FileSys::Mode::Read));
     if (loader == nullptr) {
         failed();
         return;
@@ -1624,7 +1631,7 @@ void GMainWindow::OnGameListDumpRomFS(u64 program_id, const std::string& game_pa
         return;
     }
 
-    const auto& installed = Core::System::GetInstance().GetContentProvider();
+    const auto& installed = system.GetContentProvider();
     const auto romfs_title_id = SelectRomFSDumpTarget(installed, program_id);
 
     if (!romfs_title_id) {
@@ -1639,7 +1646,7 @@ void GMainWindow::OnGameListDumpRomFS(u64 program_id, const std::string& game_pa
 
     if (*romfs_title_id == program_id) {
         const u64 ivfc_offset = loader->ReadRomFSIVFCOffset();
-        FileSys::PatchManager pm{program_id};
+        const FileSys::PatchManager pm{program_id, system.GetFileSystemController(), installed};
         romfs = pm.PatchRomFS(file, ivfc_offset, FileSys::ContentRecordType::Program);
     } else {
         romfs = installed.GetEntry(*romfs_title_id, FileSys::ContentRecordType::Data)->GetRomFS();
@@ -1756,7 +1763,8 @@ void GMainWindow::OnGameListShowList(bool show) {
 void GMainWindow::OnGameListOpenPerGameProperties(const std::string& file) {
     u64 title_id{};
     const auto v_file = Core::GetGameFileFromPath(vfs, file);
-    const auto loader = Loader::GetLoader(v_file);
+    const auto loader = Loader::GetLoader(Core::System::GetInstance(), v_file);
+
     if (loader == nullptr || loader->ReadProgramId(title_id) != Loader::ResultStatus::Success) {
         QMessageBox::information(this, tr("Properties"),
                                  tr("The game properties could not be loaded."));


### PR DESCRIPTION
With this, only 19 usages of the global system instance remain within the core library.

We're almost there.