### PR TITLE
vulkan_renderer: Alpha Test Culling Implementation

### DIFF
--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
@@ -8,6 +8,7 @@
 
 #include <boost/functional/hash.hpp>
 
+#include "common/bit_cast.h"
 #include "common/cityhash.h"
 #include "common/common_types.h"
 #include "video_core/renderer_vulkan/fixed_pipeline_state.h"
@@ -64,9 +65,9 @@ void FixedPipelineState::Fill(const Maxwell& regs, bool has_extended_dynamic_sta
     const auto test_func =
         regs.alpha_test_enabled == 1 ? regs.alpha_test_func : Maxwell::ComparisonOp::Always;
     alpha_test_func.Assign(PackComparisonOp(test_func));
-    std::memcpy(&alpha_test_ref, &regs.alpha_test_ref, sizeof(u32)); // TODO: C++20 std::bit_cast
+    alpha_test_ref = Common::BitCast<u32>(regs.alpha_test_ref);
 
-    std::memcpy(&point_size, &regs.point_size, sizeof(point_size)); // TODO: C++20 std::bit_cast
+    point_size = Common::BitCast<u32>(regs.point_size);
 
     for (std::size_t index = 0; index < Maxwell::NumVertexArrays; ++index) {
         binding_divisors[index] =

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
@@ -60,6 +60,11 @@ void FixedPipelineState::Fill(const Maxwell& regs, bool has_extended_dynamic_sta
     rasterize_enable.Assign(regs.rasterize_enable != 0 ? 1 : 0);
     topology.Assign(regs.draw.topology);
 
+    alpha_raw = 0;
+    alpha_test_enabled.Assign(regs.alpha_test_enabled);
+    alpha_test_func.Assign(PackComparisonOp(regs.alpha_test_func));
+    std::memcpy(&alpha_test_ref, &regs.alpha_test_ref, sizeof(u32)); // TODO: C++20 std::bit_cast
+
     std::memcpy(&point_size, &regs.point_size, sizeof(point_size)); // TODO: C++20 std::bit_cast
 
     for (std::size_t index = 0; index < Maxwell::NumVertexArrays; ++index) {

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.cpp
@@ -61,8 +61,9 @@ void FixedPipelineState::Fill(const Maxwell& regs, bool has_extended_dynamic_sta
     topology.Assign(regs.draw.topology);
 
     alpha_raw = 0;
-    alpha_test_enabled.Assign(regs.alpha_test_enabled);
-    alpha_test_func.Assign(PackComparisonOp(regs.alpha_test_func));
+    const auto test_func =
+        regs.alpha_test_enabled == 1 ? regs.alpha_test_func : Maxwell::ComparisonOp::Always;
+    alpha_test_func.Assign(PackComparisonOp(test_func));
     std::memcpy(&alpha_test_ref, &regs.alpha_test_ref, sizeof(u32)); // TODO: C++20 std::bit_cast
 
     std::memcpy(&point_size, &regs.point_size, sizeof(point_size)); // TODO: C++20 std::bit_cast

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.h
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.h
@@ -188,11 +188,10 @@ struct FixedPipelineState {
         BitField<24, 4, Maxwell::PrimitiveTopology> topology;
     };
 
-    u32 alpha_test_ref; /// < Alpha test reference
+    u32 alpha_test_ref; ///< Alpha test reference value
     union {
         u32 alpha_raw;
         BitField<0, 3, u32> alpha_test_func;
-        BitField<3, 1, u32> alpha_test_enabled;
     };
 
     u32 point_size;

--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.h
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.h
@@ -187,6 +187,14 @@ struct FixedPipelineState {
         BitField<23, 1, u32> rasterize_enable;
         BitField<24, 4, Maxwell::PrimitiveTopology> topology;
     };
+
+    u32 alpha_test_ref; /// < Alpha test reference
+    union {
+        u32 alpha_raw;
+        BitField<0, 3, u32> alpha_test_func;
+        BitField<3, 1, u32> alpha_test_enabled;
+    };
+
     u32 point_size;
     std::array<u32, Maxwell::NumVertexArrays> binding_divisors;
     std::array<VertexAttribute, Maxwell::NumVertexAttributes> attributes;

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -345,12 +345,10 @@ VKPipelineCache::DecompileShaders(const FixedPipelineState& fixed_state) {
     specialization.ndc_minus_one_to_one = fixed_state.ndc_minus_one_to_one;
 
     // Alpha test
-    if (fixed_state.alpha_test_enabled == 1) {
-        specialization.alpha_test_enabled = true;
-        specialization.alpha_test_func = static_cast<u8>(fixed_state.alpha_test_func);
-        // memcpy from u32 to float TODO: C++20 std::bit_cast
-        std::memcpy(&specialization.alpha_test_ref, &fixed_state.alpha_test_ref, sizeof(float));
-    }
+    specialization.alpha_test_func =
+        FixedPipelineState::UnpackComparisonOp(fixed_state.alpha_test_func.Value());
+    // memcpy from u32 to float TODO: C++20 std::bit_cast
+    std::memcpy(&specialization.alpha_test_ref, &fixed_state.alpha_test_ref, sizeof(float));
 
     SPIRVProgram program;
     std::vector<VkDescriptorSetLayoutBinding> bindings;

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -344,6 +344,14 @@ VKPipelineCache::DecompileShaders(const FixedPipelineState& fixed_state) {
     }
     specialization.ndc_minus_one_to_one = fixed_state.ndc_minus_one_to_one;
 
+    // Alpha test
+    if (fixed_state.alpha_test_enabled == 1) {
+        specialization.alpha_test_enabled = true;
+        specialization.alpha_test_func = static_cast<u8>(fixed_state.alpha_test_func);
+        // memcpy from u32 to float TODO: C++20 std::bit_cast
+        std::memcpy(&specialization.alpha_test_ref, &fixed_state.alpha_test_ref, sizeof(float));
+    }
+
     SPIRVProgram program;
     std::vector<VkDescriptorSetLayoutBinding> bindings;
 

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <vector>
 
+#include "common/bit_cast.h"
 #include "common/microprofile.h"
 #include "core/core.h"
 #include "core/memory.h"
@@ -347,8 +348,7 @@ VKPipelineCache::DecompileShaders(const FixedPipelineState& fixed_state) {
     // Alpha test
     specialization.alpha_test_func =
         FixedPipelineState::UnpackComparisonOp(fixed_state.alpha_test_func.Value());
-    // memcpy from u32 to float TODO: C++20 std::bit_cast
-    std::memcpy(&specialization.alpha_test_ref, &fixed_state.alpha_test_ref, sizeof(float));
+    specialization.alpha_test_ref = Common::BitCast<float>(fixed_state.alpha_test_ref);
 
     SPIRVProgram program;
     std::vector<VkDescriptorSetLayoutBinding> bindings;

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
@@ -2083,16 +2083,12 @@ private:
         case Compare::LessOld:
             return OpFOrdLessThan(t_bool, operand_1, operand_2);
         case Compare::EqualOld:
-            // Note: not accurate when tested against a unit test
-            // TODO: confirm if used by games
             return OpFOrdEqual(t_bool, operand_1, operand_2);
         case Compare::LessEqualOld:
             return OpFOrdLessThanEqual(t_bool, operand_1, operand_2);
         case Compare::GreaterOld:
             return OpFOrdGreaterThan(t_bool, operand_1, operand_2);
         case Compare::NotEqualOld:
-            // Note: not accurate when tested against a unit test
-            // TODO: confirm if used by games
             return OpFOrdNotEqual(t_bool, operand_1, operand_2);
         case Compare::GreaterEqualOld:
             return OpFOrdGreaterThanEqual(t_bool, operand_1, operand_2);
@@ -2105,12 +2101,10 @@ private:
         if (specialization.alpha_test_func == Maxwell::ComparisonOp::AlwaysOld) {
             return;
         }
-
         const Id true_label = OpLabel();
         const Id discard_label = OpLabel();
         const Id alpha_reference = Constant(t_float, specialization.alpha_test_ref);
         const Id alpha_value = OpLoad(t_float, pointer);
-
         const Id condition =
             MaxwellToSpirvComparison(specialization.alpha_test_func, alpha_value, alpha_reference);
 

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.h
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.h
@@ -95,9 +95,8 @@ struct Specialization final {
     std::bitset<Maxwell::NumVertexAttributes> enabled_attributes;
     std::array<Maxwell::VertexAttribute::Type, Maxwell::NumVertexAttributes> attribute_types{};
     bool ndc_minus_one_to_one{};
-    bool alpha_test_enabled{};
     float alpha_test_ref{};
-    u8 alpha_test_func{};
+    Maxwell::ComparisonOp alpha_test_func{};
 };
 // Old gcc versions don't consider this trivially copyable.
 // static_assert(std::is_trivially_copyable_v<Specialization>);

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.h
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.h
@@ -95,6 +95,9 @@ struct Specialization final {
     std::bitset<Maxwell::NumVertexAttributes> enabled_attributes;
     std::array<Maxwell::VertexAttribute::Type, Maxwell::NumVertexAttributes> attribute_types{};
     bool ndc_minus_one_to_one{};
+    bool alpha_test_enabled{};
+    float alpha_test_ref{};
+    u8 alpha_test_func{};
 };
 // Old gcc versions don't consider this trivially copyable.
 // static_assert(std::is_trivially_copyable_v<Specialization>);


### PR DESCRIPTION
This PR aims to implement the alpha test culling for the Vulkan renderer, culling the render if its `alpha` value does not satisfy a comparison operation against a particular reference alpha value, both of which are provided by Maxwell 3D. 

This is used on different textures in various titles. One of the most noticeable being SSBU's menus:

Before
![before](https://user-images.githubusercontent.com/52414509/99609371-c1bf8f00-29dd-11eb-871e-aac68f3445af.png)

After
![after](https://user-images.githubusercontent.com/52414509/99609374-c4ba7f80-29dd-11eb-852d-e8c3336f83af.png)
