### PR TITLE
main: Enable High DPI fixes for Qt >= 5.14

### DIFF
--- a/src/yuzu/applets/qt_software_keyboard.cpp
+++ b/src/yuzu/applets/qt_software_keyboard.cpp
@@ -575,7 +575,7 @@ void QtSoftwareKeyboardDialog::MoveAndResizeWindow(QPoint pos, QSize size) {
     QDialog::resize(size);
 
     // High DPI
-    const float dpi_scale = qApp->screenAt(pos)->logicalDotsPerInch() / 96.0f;
+    const float dpi_scale = screen()->logicalDotsPerInch() / 96.0f;
 
     RescaleKeyboardElements(size.width(), size.height(), dpi_scale);
 }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -680,8 +680,10 @@ void GMainWindow::SoftwareKeyboardShowNormal() {
     const auto y = layout.screen.top;
     const auto w = layout.screen.GetWidth();
     const auto h = layout.screen.GetHeight();
+    const auto scale_ratio = devicePixelRatioF();
 
-    software_keyboard->ShowNormalKeyboard(render_window->mapToGlobal(QPoint(x, y)), QSize(w, h));
+    software_keyboard->ShowNormalKeyboard(render_window->mapToGlobal(QPoint(x, y) / scale_ratio),
+                                          QSize(w, h) / scale_ratio);
 }
 
 void GMainWindow::SoftwareKeyboardShowTextCheck(
@@ -714,9 +716,11 @@ void GMainWindow::SoftwareKeyboardShowInline(
                                                (1.0f - appear_parameters.key_top_scale_y))));
     const auto w = static_cast<int>(layout.screen.GetWidth() * appear_parameters.key_top_scale_x);
     const auto h = static_cast<int>(layout.screen.GetHeight() * appear_parameters.key_top_scale_y);
+    const auto scale_ratio = devicePixelRatioF();
 
     software_keyboard->ShowInlineKeyboard(std::move(appear_parameters),
-                                          render_window->mapToGlobal(QPoint(x, y)), QSize(w, h));
+                                          render_window->mapToGlobal(QPoint(x, y) / scale_ratio),
+                                          QSize(w, h) / scale_ratio);
 }
 
 void GMainWindow::SoftwareKeyboardHideInline() {
@@ -796,10 +800,11 @@ void GMainWindow::WebBrowserOpenWebPage(const std::string& main_url,
         }
 
         const auto& layout = render_window->GetFramebufferLayout();
-        web_browser_view.resize(layout.screen.GetWidth(), layout.screen.GetHeight());
-        web_browser_view.move(layout.screen.left, layout.screen.top + menuBar()->height());
-        web_browser_view.setZoomFactor(static_cast<qreal>(layout.screen.GetWidth()) /
-                                       static_cast<qreal>(Layout::ScreenUndocked::Width));
+        const auto scale_ratio = devicePixelRatioF();
+        web_browser_view.resize(layout.screen.GetWidth() / scale_ratio,
+                                layout.screen.GetHeight() / scale_ratio);
+        web_browser_view.move(layout.screen.left / scale_ratio,
+                              (layout.screen.top / scale_ratio) + menuBar()->height());
 
         web_browser_view.setFocus();
         web_browser_view.show();

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -4401,6 +4401,10 @@ void GMainWindow::changeEvent(QEvent* event) {
 #endif
 
 static void SetHighDPIAttributes() {
+#ifdef _WIN32
+    // For Windows, we want to avoid scaling artifacts on fractional scaling ratios.
+    // This is done by setting the optimal scaling policy for the primary screen.
+
     // Create a temporary QApplication.
     int temp_argc = 0;
     char** temp_argv = nullptr;
@@ -4428,9 +4432,6 @@ static void SetHighDPIAttributes() {
     // Get the lower of the 2 ratios and truncate, this is the maximum integer scale.
     const float max_ratio = std::trunc(std::min(width_ratio, height_ratio));
 
-    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-
     if (max_ratio > real_ratio) {
         QApplication::setHighDpiScaleFactorRoundingPolicy(
             Qt::HighDpiScaleFactorRoundingPolicy::Round);
@@ -4438,6 +4439,14 @@ static void SetHighDPIAttributes() {
         QApplication::setHighDpiScaleFactorRoundingPolicy(
             Qt::HighDpiScaleFactorRoundingPolicy::Floor);
     }
+#else
+    // Other OSes should be better than Windows at fractional scaling.
+    QApplication::setHighDpiScaleFactorRoundingPolicy(
+        Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+#endif
+
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
 }
 
 int main(int argc, char* argv[]) {

--- a/src/yuzu/util/overlay_dialog.cpp
+++ b/src/yuzu/util/overlay_dialog.cpp
@@ -163,7 +163,7 @@ void OverlayDialog::MoveAndResizeWindow() {
     const auto height = static_cast<float>(parentWidget()->height());
 
     // High DPI
-    const float dpi_scale = parentWidget()->windowHandle()->screen()->logicalDotsPerInch() / 96.0f;
+    const float dpi_scale = screen()->logicalDotsPerInch() / 96.0f;
 
     const auto title_text_font_size = BASE_TITLE_FONT_SIZE * (height / BASE_HEIGHT) / dpi_scale;
     const auto body_text_font_size =


### PR DESCRIPTION
This uses Qt's new high DPI application attributes for scaling the current window.
However, these aren't perfect as scaling with non integer scales will cause artifacts in UI, icons and other elements.
Therefore, we use a heuristic to select an appropriate integer scale value depending on the current screen resolution and applies this to the application.

Fixes #4904
Fixes #7383
Fixes #8051