### PR TITLE
Modify rumble amplification

### DIFF
--- a/src/input_common/gcadapter/gc_poller.cpp
+++ b/src/input_common/gcadapter/gc_poller.cpp
@@ -302,8 +302,8 @@ public:
 
     bool SetRumblePlay(f32 amp_low, f32 freq_low, f32 amp_high, f32 freq_high) const override {
         const auto mean_amplitude = (amp_low + amp_high) * 0.5f;
-        const auto processed_amplitude = static_cast<u8>(
-            pow(mean_amplitude, 0.5f) * (3.0f - 2.0f * pow(mean_amplitude, 0.15f)) * 0x8);
+        const auto processed_amplitude =
+            static_cast<u8>((mean_amplitude + std::pow(mean_amplitude, 0.3f)) * 0.5f * 0x8);
 
         return gcadapter->RumblePlay(port, processed_amplitude);
     }

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -402,8 +402,7 @@ public:
 
     bool SetRumblePlay(f32 amp_low, f32 freq_low, f32 amp_high, f32 freq_high) const override {
         const auto process_amplitude = [](f32 amplitude) {
-            return static_cast<u16>(std::pow(amplitude, 0.5f) *
-                                    (3.0f - 2.0f * std::pow(amplitude, 0.15f)) * 0xFFFF);
+            return static_cast<u16>((amplitude + std::pow(amplitude, 0.3f)) * 0.5f * 0xFFFF);
         };
 
         const auto processed_amp_low = process_amplitude(amp_low);


### PR DESCRIPTION
Changes the current amplification method for a more linear and less aggressive one. Since vibration strength can be fine tuned now.

This should amend problems where 1% of rumble strength still was too strong 