### PR TITLE
async_shaders: std::move data within QueueVulkanShader()

### DIFF
--- a/src/video_core/shader/async_shaders.cpp
+++ b/src/video_core/shader/async_shaders.cpp
@@ -43,8 +43,8 @@ void AsyncShaders::AllocateWorkers() {
     // Create workers
     for (std::size_t i = 0; i < num_workers; i++) {
         context_list.push_back(emu_window.CreateSharedContext());
-        worker_threads.push_back(
-            std::thread(&AsyncShaders::ShaderCompilerThread, this, context_list[i].get()));
+        worker_threads.emplace_back(&AsyncShaders::ShaderCompilerThread, this,
+                                    context_list[i].get());
     }
 }
 

--- a/src/video_core/shader/async_shaders.cpp
+++ b/src/video_core/shader/async_shaders.cpp
@@ -153,8 +153,8 @@ void AsyncShaders::QueueVulkanShader(Vulkan::VKPipelineCache* pp_cache,
         .descriptor_pool = &descriptor_pool,
         .update_descriptor_queue = &update_descriptor_queue,
         .renderpass_cache = &renderpass_cache,
-        .bindings = bindings,
-        .program = program,
+        .bindings = std::move(bindings),
+        .program = std::move(program),
         .key = key,
     };
 

--- a/src/video_core/shader/async_shaders.cpp
+++ b/src/video_core/shader/async_shaders.cpp
@@ -106,8 +106,7 @@ std::vector<AsyncShaders::Result> AsyncShaders::GetCompletedWork() {
     std::vector<Result> results;
     {
         std::unique_lock lock{completed_mutex};
-        results.assign(std::make_move_iterator(finished_work.begin()),
-                       std::make_move_iterator(finished_work.end()));
+        results = std::move(finished_work);
         finished_work.clear();
     }
     return results;


### PR DESCRIPTION
Same behavior, but avoids redundant copies.

While we're at it, we can simplify the pushing of the parameters into the pending queue.