### PR TITLE
configure_input_player: Use the NpadStyleSet to limit the available controllers shown

### DIFF
--- a/src/yuzu/applets/controller.h
+++ b/src/yuzu/applets/controller.h
@@ -22,6 +22,10 @@ namespace InputCommon {
 class InputSubsystem;
 }
 
+namespace Settings {
+enum class ControllerType;
+}
+
 namespace Ui {
 class QtControllerSelectorDialog;
 }
@@ -56,6 +60,15 @@ private:
 
     // Sets the controller icons for "Supported Controller Types".
     void SetSupportedControllers();
+
+    // Sets the emulated controllers per player.
+    void SetEmulatedControllers(std::size_t player_index);
+
+    // Gets the Controller Type for a given controller combobox index per player.
+    Settings::ControllerType GetControllerTypeFromIndex(int index, std::size_t player_index) const;
+
+    // Gets the controller combobox index for a given Controller Type per player.
+    int GetIndexFromControllerType(Settings::ControllerType type, std::size_t player_index) const;
 
     // Updates the controller icons per player.
     void UpdateControllerIcon(std::size_t player_index);
@@ -113,6 +126,10 @@ private:
 
     // Comboboxes with a list of emulated controllers per player.
     std::array<QComboBox*, NUM_PLAYERS> emulated_controllers;
+
+    /// Pairs of emulated controller index and Controller Type enum per player.
+    std::array<std::vector<std::pair<int, Settings::ControllerType>>, NUM_PLAYERS>
+        index_controller_type_pairs;
 
     // Labels representing the number of connected controllers
     // above the "Connected Controllers" checkboxes.

--- a/src/yuzu/configuration/configure_input_player.h
+++ b/src/yuzu/configuration/configure_input_player.h
@@ -9,6 +9,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include <QWidget>
 
@@ -112,6 +113,15 @@ private:
     /// Update UI to reflect current configuration.
     void UpdateUI();
 
+    /// Sets the available controllers.
+    void SetConnectableControllers();
+
+    /// Gets the Controller Type for a given controller combobox index.
+    Settings::ControllerType GetControllerTypeFromIndex(int index) const;
+
+    /// Gets the controller combobox index for a given Controller Type.
+    int GetIndexFromControllerType(Settings::ControllerType type) const;
+
     /// Update the available input devices.
     void UpdateInputDevices();
 
@@ -150,6 +160,9 @@ private:
 
     std::unique_ptr<QTimer> timeout_timer;
     std::unique_ptr<QTimer> poll_timer;
+
+    /// Stores a pair of "Connected Controllers" combobox index and Controller Type enum.
+    std::vector<std::pair<int, Settings::ControllerType>> index_controller_type_pairs;
 
     static constexpr int PLAYER_COUNT = 8;
     std::array<QCheckBox*, PLAYER_COUNT> player_connected_checkbox;


### PR DESCRIPTION
Example:

Pokemon Let's Go, supports Handheld, Left and Right Joycons

![image](https://user-images.githubusercontent.com/39850852/99866001-c28e2780-2b7b-11eb-914a-4d39ab5a484e.png)

Invalid emulated controllers would show up as empty in the dropdown and utilize the Pro Controller image as a fallback

![image](https://user-images.githubusercontent.com/39850852/99866022-ee111200-2b7b-11eb-8004-31ee59fed767.png)


