### PR TITLE
ci: install Vulkan SDK in MSVC build

### DIFF
--- a/.ci/templates/build-msvc.yml
+++ b/.ci/templates/build-msvc.yml
@@ -4,6 +4,8 @@ parameters:
   version: ''
 
 steps:
+- script: choco install vulkan-sdk && refreshenv
+  displayName: 'Install vulkan-sdk'
 - script: python -m pip install --upgrade pip conan
   displayName: 'Install conan'
 - script: mkdir build && cd build && cmake -G "Visual Studio 16 2019" -A x64 --config Release -DYUZU_USE_BUNDLED_QT=1 -DYUZU_USE_BUNDLED_UNICORN=1 -DYUZU_USE_QT_WEB_ENGINE=ON -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DYUZU_ENABLE_COMPATIBILITY_REPORTING=${COMPAT} -DUSE_DISCORD_PRESENCE=ON -DDISPLAY_VERSION=${{ parameters['version'] }} .. && cd ..


### PR DESCRIPTION
This PR will add an installation step for Vulkan SDK to the MSVC build.