### PR TITLE
nvdrv, video_core: Don't index out of bounds when given invalid syncpoint ID

### DIFF
--- a/src/core/hle/service/nvdrv/syncpoint_manager.h
+++ b/src/core/hle/service/nvdrv/syncpoint_manager.h
@@ -37,7 +37,7 @@ public:
      * @returns The lower bound for the specified syncpoint.
      */
     u32 GetSyncpointMin(u32 syncpoint_id) const {
-        return syncpoints[syncpoint_id].min.load(std::memory_order_relaxed);
+        return syncpoints.at(syncpoint_id).min.load(std::memory_order_relaxed);
     }
 
     /**
@@ -46,7 +46,7 @@ public:
      * @returns The upper bound for the specified syncpoint.
      */
     u32 GetSyncpointMax(u32 syncpoint_id) const {
-        return syncpoints[syncpoint_id].max.load(std::memory_order_relaxed);
+        return syncpoints.at(syncpoint_id).max.load(std::memory_order_relaxed);
     }
 
     /**


### PR DESCRIPTION
- Use .at() instead of raw indexing when dealing with untrusted indices.

- For the special case of WaitFence with syncpoint id -1, instead of crashing, log an error and ignore.  This is what I get when running Super Mario Maker 2.