### PR TITLE
hle: services: Fix a crash with improper NVFlinger lifetime management.

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -187,7 +187,7 @@ struct System::Impl {
 
         service_manager = std::make_shared<Service::SM::ServiceManager>(kernel);
 
-        Service::Init(service_manager, system);
+        services = std::make_unique<Service::Services>(service_manager, system);
         GDBStub::DeferStart();
 
         interrupt_manager = std::make_unique<Core::Hardware::InterruptManager>(system);
@@ -296,7 +296,7 @@ struct System::Impl {
 
         // Shutdown emulation session
         GDBStub::Shutdown();
-        Service::Shutdown();
+        services.reset();
         service_manager.reset();
         cheat_engine.reset();
         telemetry_session.reset();
@@ -306,8 +306,8 @@ struct System::Impl {
         cpu_manager.Shutdown();
 
         // Shutdown kernel and core timing
-        kernel.Shutdown();
         core_timing.Shutdown();
+        kernel.Shutdown();
 
         // Close app loader
         app_loader.reset();
@@ -397,6 +397,9 @@ struct System::Impl {
 
     /// Service manager
     std::shared_ptr<Service::SM::ServiceManager> service_manager;
+
+    /// Services
+    std::unique_ptr<Service::Services> services;
 
     /// Telemetry session for this emulation session
     std::unique_ptr<Core::TelemetrySession> telemetry_session;

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -246,9 +246,8 @@ IDebugFunctions::IDebugFunctions() : ServiceFramework{"IDebugFunctions"} {
 
 IDebugFunctions::~IDebugFunctions() = default;
 
-ISelfController::ISelfController(Core::System& system,
-                                 std::shared_ptr<NVFlinger::NVFlinger> nvflinger)
-    : ServiceFramework("ISelfController"), system(system), nvflinger(std::move(nvflinger)) {
+ISelfController::ISelfController(Core::System& system, NVFlinger::NVFlinger& nvflinger)
+    : ServiceFramework("ISelfController"), system(system), nvflinger(nvflinger) {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &ISelfController::Exit, "Exit"},
@@ -458,8 +457,8 @@ void ISelfController::CreateManagedDisplayLayer(Kernel::HLERequestContext& ctx) 
 
     // TODO(Subv): Find out how AM determines the display to use, for now just
     // create the layer in the Default display.
-    const auto display_id = nvflinger->OpenDisplay("Default");
-    const auto layer_id = nvflinger->CreateLayer(*display_id);
+    const auto display_id = nvflinger.OpenDisplay("Default");
+    const auto layer_id = nvflinger.CreateLayer(*display_id);
 
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
@@ -476,8 +475,8 @@ void ISelfController::CreateManagedDisplaySeparableLayer(Kernel::HLERequestConte
     // Outputting 1 layer id instead of the expected 2 has not been observed to cause any adverse
     // side effects.
     // TODO: Support multiple layers
-    const auto display_id = nvflinger->OpenDisplay("Default");
-    const auto layer_id = nvflinger->CreateLayer(*display_id);
+    const auto display_id = nvflinger.OpenDisplay("Default");
+    const auto layer_id = nvflinger.CreateLayer(*display_id);
 
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
@@ -1586,8 +1585,8 @@ void IApplicationFunctions::GetFriendInvitationStorageChannelEvent(Kernel::HLERe
     rb.PushCopyObjects(friend_invitation_storage_channel_event.readable);
 }
 
-void InstallInterfaces(SM::ServiceManager& service_manager,
-                       std::shared_ptr<NVFlinger::NVFlinger> nvflinger, Core::System& system) {
+void InstallInterfaces(SM::ServiceManager& service_manager, NVFlinger::NVFlinger& nvflinger,
+                       Core::System& system) {
     auto message_queue = std::make_shared<AppletMessageQueue>(system.Kernel());
     // Needed on game boot
     message_queue->PushMessage(AppletMessageQueue::AppletMessage::FocusStateChanged);

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -121,8 +121,7 @@ public:
 
 class ISelfController final : public ServiceFramework<ISelfController> {
 public:
-    explicit ISelfController(Core::System& system_,
-                             std::shared_ptr<NVFlinger::NVFlinger> nvflinger_);
+    explicit ISelfController(Core::System& system_, NVFlinger::NVFlinger& nvflinger_);
     ~ISelfController() override;
 
 private:
@@ -156,7 +155,7 @@ private:
     };
 
     Core::System& system;
-    std::shared_ptr<NVFlinger::NVFlinger> nvflinger;
+    NVFlinger::NVFlinger& nvflinger;
     Kernel::EventPair launchable_event;
     Kernel::EventPair accumulated_suspended_tick_changed_event;
 
@@ -332,7 +331,7 @@ public:
 };
 
 /// Registers all AM services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager,
-                       std::shared_ptr<NVFlinger::NVFlinger> nvflinger, Core::System& system);
+void InstallInterfaces(SM::ServiceManager& service_manager, NVFlinger::NVFlinger& nvflinger,
+                       Core::System& system);
 
 } // namespace Service::AM

--- a/src/core/hle/service/am/applet_ae.cpp
+++ b/src/core/hle/service/am/applet_ae.cpp
@@ -13,10 +13,10 @@ namespace Service::AM {
 
 class ILibraryAppletProxy final : public ServiceFramework<ILibraryAppletProxy> {
 public:
-    explicit ILibraryAppletProxy(std::shared_ptr<NVFlinger::NVFlinger> nvflinger,
+    explicit ILibraryAppletProxy(NVFlinger::NVFlinger& nvflinger,
                                  std::shared_ptr<AppletMessageQueue> msg_queue,
                                  Core::System& system)
-        : ServiceFramework("ILibraryAppletProxy"), nvflinger(std::move(nvflinger)),
+        : ServiceFramework("ILibraryAppletProxy"), nvflinger(nvflinger),
           msg_queue(std::move(msg_queue)), system(system) {
         // clang-format off
         static const FunctionInfo functions[] = {
@@ -109,16 +109,16 @@ private:
         rb.PushIpcInterface<IApplicationFunctions>(system);
     }
 
-    std::shared_ptr<NVFlinger::NVFlinger> nvflinger;
+    NVFlinger::NVFlinger& nvflinger;
     std::shared_ptr<AppletMessageQueue> msg_queue;
     Core::System& system;
 };
 
 class ISystemAppletProxy final : public ServiceFramework<ISystemAppletProxy> {
 public:
-    explicit ISystemAppletProxy(std::shared_ptr<NVFlinger::NVFlinger> nvflinger,
+    explicit ISystemAppletProxy(NVFlinger::NVFlinger& nvflinger,
                                 std::shared_ptr<AppletMessageQueue> msg_queue, Core::System& system)
-        : ServiceFramework("ISystemAppletProxy"), nvflinger(std::move(nvflinger)),
+        : ServiceFramework("ISystemAppletProxy"), nvflinger(nvflinger),
           msg_queue(std::move(msg_queue)), system(system) {
         // clang-format off
         static const FunctionInfo functions[] = {
@@ -220,7 +220,8 @@ private:
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IApplicationCreator>();
     }
-    std::shared_ptr<NVFlinger::NVFlinger> nvflinger;
+
+    NVFlinger::NVFlinger& nvflinger;
     std::shared_ptr<AppletMessageQueue> msg_queue;
     Core::System& system;
 };
@@ -249,10 +250,10 @@ void AppletAE::OpenLibraryAppletProxyOld(Kernel::HLERequestContext& ctx) {
     rb.PushIpcInterface<ILibraryAppletProxy>(nvflinger, msg_queue, system);
 }
 
-AppletAE::AppletAE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger,
-                   std::shared_ptr<AppletMessageQueue> msg_queue, Core::System& system)
-    : ServiceFramework("appletAE"), nvflinger(std::move(nvflinger)),
-      msg_queue(std::move(msg_queue)), system(system) {
+AppletAE::AppletAE(NVFlinger::NVFlinger& nvflinger, std::shared_ptr<AppletMessageQueue> msg_queue,
+                   Core::System& system)
+    : ServiceFramework("appletAE"), nvflinger(nvflinger), msg_queue(std::move(msg_queue)),
+      system(system) {
     // clang-format off
     static const FunctionInfo functions[] = {
         {100, &AppletAE::OpenSystemAppletProxy, "OpenSystemAppletProxy"},

--- a/src/core/hle/service/am/applet_ae.h
+++ b/src/core/hle/service/am/applet_ae.h
@@ -23,7 +23,7 @@ class AppletMessageQueue;
 
 class AppletAE final : public ServiceFramework<AppletAE> {
 public:
-    explicit AppletAE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger,
+    explicit AppletAE(NVFlinger::NVFlinger& nvflinger,
                       std::shared_ptr<AppletMessageQueue> msg_queue, Core::System& system);
     ~AppletAE() override;
 
@@ -34,7 +34,7 @@ private:
     void OpenLibraryAppletProxy(Kernel::HLERequestContext& ctx);
     void OpenLibraryAppletProxyOld(Kernel::HLERequestContext& ctx);
 
-    std::shared_ptr<NVFlinger::NVFlinger> nvflinger;
+    NVFlinger::NVFlinger& nvflinger;
     std::shared_ptr<AppletMessageQueue> msg_queue;
     Core::System& system;
 };

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -12,9 +12,9 @@ namespace Service::AM {
 
 class IApplicationProxy final : public ServiceFramework<IApplicationProxy> {
 public:
-    explicit IApplicationProxy(std::shared_ptr<NVFlinger::NVFlinger> nvflinger,
+    explicit IApplicationProxy(NVFlinger::NVFlinger& nvflinger,
                                std::shared_ptr<AppletMessageQueue> msg_queue, Core::System& system)
-        : ServiceFramework("IApplicationProxy"), nvflinger(std::move(nvflinger)),
+        : ServiceFramework("IApplicationProxy"), nvflinger(nvflinger),
           msg_queue(std::move(msg_queue)), system(system) {
         // clang-format off
         static const FunctionInfo functions[] = {
@@ -98,7 +98,7 @@ private:
         rb.PushIpcInterface<IApplicationFunctions>(system);
     }
 
-    std::shared_ptr<NVFlinger::NVFlinger> nvflinger;
+    NVFlinger::NVFlinger& nvflinger;
     std::shared_ptr<AppletMessageQueue> msg_queue;
     Core::System& system;
 };
@@ -111,10 +111,10 @@ void AppletOE::OpenApplicationProxy(Kernel::HLERequestContext& ctx) {
     rb.PushIpcInterface<IApplicationProxy>(nvflinger, msg_queue, system);
 }
 
-AppletOE::AppletOE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger,
-                   std::shared_ptr<AppletMessageQueue> msg_queue, Core::System& system)
-    : ServiceFramework("appletOE"), nvflinger(std::move(nvflinger)),
-      msg_queue(std::move(msg_queue)), system(system) {
+AppletOE::AppletOE(NVFlinger::NVFlinger& nvflinger, std::shared_ptr<AppletMessageQueue> msg_queue,
+                   Core::System& system)
+    : ServiceFramework("appletOE"), nvflinger(nvflinger), msg_queue(std::move(msg_queue)),
+      system(system) {
     static const FunctionInfo functions[] = {
         {0, &AppletOE::OpenApplicationProxy, "OpenApplicationProxy"},
     };

--- a/src/core/hle/service/am/applet_oe.h
+++ b/src/core/hle/service/am/applet_oe.h
@@ -23,7 +23,7 @@ class AppletMessageQueue;
 
 class AppletOE final : public ServiceFramework<AppletOE> {
 public:
-    explicit AppletOE(std::shared_ptr<NVFlinger::NVFlinger> nvflinger,
+    explicit AppletOE(NVFlinger::NVFlinger& nvflinger,
                       std::shared_ptr<AppletMessageQueue> msg_queue, Core::System& system);
     ~AppletOE() override;
 
@@ -32,7 +32,7 @@ public:
 private:
     void OpenApplicationProxy(Kernel::HLERequestContext& ctx);
 
-    std::shared_ptr<NVFlinger::NVFlinger> nvflinger;
+    NVFlinger::NVFlinger& nvflinger;
     std::shared_ptr<AppletMessageQueue> msg_queue;
     Core::System& system;
 };

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -188,17 +188,19 @@ ResultCode ServiceFrameworkBase::HandleSyncRequest(Kernel::HLERequestContext& co
     return RESULT_SUCCESS;
 }
 
-/// Initialize ServiceManager
-void Init(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system) {
+/// Initialize Services
+Services::Services(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system)
+    : nv_flinger{std::make_unique<NVFlinger::NVFlinger>(system)} {
+
     // NVFlinger needs to be accessed by several services like Vi and AppletOE so we instantiate it
     // here and pass it into the respective InstallInterfaces functions.
-    auto nv_flinger = std::make_shared<NVFlinger::NVFlinger>(system);
+
     system.GetFileSystemController().CreateFactories(*system.GetFilesystem(), false);
 
     SM::ServiceManager::InstallInterfaces(sm, system.Kernel());
 
     Account::InstallInterfaces(system);
-    AM::InstallInterfaces(*sm, nv_flinger, system);
+    AM::InstallInterfaces(*sm, *nv_flinger, system);
     AOC::InstallInterfaces(*sm, system);
     APM::InstallInterfaces(system);
     Audio::InstallInterfaces(*sm, system);
@@ -246,14 +248,10 @@ void Init(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system) {
     SSL::InstallInterfaces(*sm);
     Time::InstallInterfaces(system);
     USB::InstallInterfaces(*sm);
-    VI::InstallInterfaces(*sm, nv_flinger);
+    VI::InstallInterfaces(*sm, *nv_flinger);
     WLAN::InstallInterfaces(*sm);
-
-    LOG_DEBUG(Service, "initialized OK");
 }
 
-/// Shutdown ServiceManager
-void Shutdown() {
-    LOG_DEBUG(Service, "shutdown OK");
-}
+Services::~Services() = default;
+
 } // namespace Service

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -191,7 +191,7 @@ private:
  */
 class Services final {
 public:
-    Services(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system);
+    explicit Services(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system);
     ~Services();
 
 private:

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -29,7 +29,11 @@ namespace Service {
 
 namespace FileSystem {
 class FileSystemController;
-} // namespace FileSystem
+}
+
+namespace NVFlinger {
+class NVFlinger;
+}
 
 namespace SM {
 class ServiceManager;
@@ -181,10 +185,17 @@ private:
     }
 };
 
-/// Initialize ServiceManager
-void Init(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system);
+/**
+ * The purpose of this class is to own any objects that need to be shared across the other service
+ * implementations. Will be torn down when the global system instance is shutdown.
+ */
+class Services final {
+public:
+    Services(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system);
+    ~Services();
 
-/// Shutdown ServiceManager
-void Shutdown();
+private:
+    std::unique_ptr<NVFlinger::NVFlinger> nv_flinger;
+};
 
 } // namespace Service

--- a/src/core/hle/service/vi/vi.h
+++ b/src/core/hle/service/vi/vi.h
@@ -43,12 +43,11 @@ enum class Policy {
 };
 
 namespace detail {
-void GetDisplayServiceImpl(Kernel::HLERequestContext& ctx,
-                           std::shared_ptr<NVFlinger::NVFlinger> nv_flinger, Permission permission);
+void GetDisplayServiceImpl(Kernel::HLERequestContext& ctx, NVFlinger::NVFlinger& nv_flinger,
+                           Permission permission);
 } // namespace detail
 
 /// Registers all VI services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager,
-                       std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+void InstallInterfaces(SM::ServiceManager& service_manager, NVFlinger::NVFlinger& nv_flinger);
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_m.cpp
+++ b/src/core/hle/service/vi/vi_m.cpp
@@ -8,8 +8,7 @@
 
 namespace Service::VI {
 
-VI_M::VI_M(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
-    : ServiceFramework{"vi:m"}, nv_flinger{std::move(nv_flinger)} {
+VI_M::VI_M(NVFlinger::NVFlinger& nv_flinger) : ServiceFramework{"vi:m"}, nv_flinger{nv_flinger} {
     static const FunctionInfo functions[] = {
         {2, &VI_M::GetDisplayService, "GetDisplayService"},
         {3, nullptr, "GetDisplayServiceWithProxyNameExchange"},

--- a/src/core/hle/service/vi/vi_m.h
+++ b/src/core/hle/service/vi/vi_m.h
@@ -18,13 +18,13 @@ namespace Service::VI {
 
 class VI_M final : public ServiceFramework<VI_M> {
 public:
-    explicit VI_M(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+    explicit VI_M(NVFlinger::NVFlinger& nv_flinger);
     ~VI_M() override;
 
 private:
     void GetDisplayService(Kernel::HLERequestContext& ctx);
 
-    std::shared_ptr<NVFlinger::NVFlinger> nv_flinger;
+    NVFlinger::NVFlinger& nv_flinger;
 };
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_s.cpp
+++ b/src/core/hle/service/vi/vi_s.cpp
@@ -8,8 +8,7 @@
 
 namespace Service::VI {
 
-VI_S::VI_S(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
-    : ServiceFramework{"vi:s"}, nv_flinger{std::move(nv_flinger)} {
+VI_S::VI_S(NVFlinger::NVFlinger& nv_flinger) : ServiceFramework{"vi:s"}, nv_flinger{nv_flinger} {
     static const FunctionInfo functions[] = {
         {1, &VI_S::GetDisplayService, "GetDisplayService"},
         {3, nullptr, "GetDisplayServiceWithProxyNameExchange"},

--- a/src/core/hle/service/vi/vi_s.h
+++ b/src/core/hle/service/vi/vi_s.h
@@ -18,13 +18,13 @@ namespace Service::VI {
 
 class VI_S final : public ServiceFramework<VI_S> {
 public:
-    explicit VI_S(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+    explicit VI_S(NVFlinger::NVFlinger& nv_flinger);
     ~VI_S() override;
 
 private:
     void GetDisplayService(Kernel::HLERequestContext& ctx);
 
-    std::shared_ptr<NVFlinger::NVFlinger> nv_flinger;
+    NVFlinger::NVFlinger& nv_flinger;
 };
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_u.cpp
+++ b/src/core/hle/service/vi/vi_u.cpp
@@ -8,8 +8,7 @@
 
 namespace Service::VI {
 
-VI_U::VI_U(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger)
-    : ServiceFramework{"vi:u"}, nv_flinger{std::move(nv_flinger)} {
+VI_U::VI_U(NVFlinger::NVFlinger& nv_flinger) : ServiceFramework{"vi:u"}, nv_flinger{nv_flinger} {
     static const FunctionInfo functions[] = {
         {0, &VI_U::GetDisplayService, "GetDisplayService"},
         {1, nullptr, "GetDisplayServiceWithProxyNameExchange"},

--- a/src/core/hle/service/vi/vi_u.h
+++ b/src/core/hle/service/vi/vi_u.h
@@ -18,13 +18,13 @@ namespace Service::VI {
 
 class VI_U final : public ServiceFramework<VI_U> {
 public:
-    explicit VI_U(std::shared_ptr<NVFlinger::NVFlinger> nv_flinger);
+    explicit VI_U(NVFlinger::NVFlinger& nv_flinger);
     ~VI_U() override;
 
 private:
     void GetDisplayService(Kernel::HLERequestContext& ctx);
 
-    std::shared_ptr<NVFlinger::NVFlinger> nv_flinger;
+    NVFlinger::NVFlinger& nv_flinger;
 };
 
 } // namespace Service::VI


### PR DESCRIPTION
- This crash would happen when attempting to shutdown yuzu early on in boot.