### PR TITLE
audio_core: Make shadowing and unused parameters errors

### DIFF
--- a/src/audio_core/CMakeLists.txt
+++ b/src/audio_core/CMakeLists.txt
@@ -51,6 +51,8 @@ if (NOT MSVC)
         -Werror=implicit-fallthrough
         -Werror=reorder
         -Werror=sign-compare
+        -Werror=shadow
+        -Werror=unused-parameter
         -Werror=unused-variable
 
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>

--- a/src/audio_core/algorithm/filter.cpp
+++ b/src/audio_core/algorithm/filter.cpp
@@ -31,8 +31,8 @@ Filter Filter::LowPass(double cutoff, double Q) {
 
 Filter::Filter() : Filter(1.0, 0.0, 0.0, 1.0, 0.0, 0.0) {}
 
-Filter::Filter(double a0, double a1, double a2, double b0, double b1, double b2)
-    : a1(a1 / a0), a2(a2 / a0), b0(b0 / a0), b1(b1 / a0), b2(b2 / a0) {}
+Filter::Filter(double a0_, double a1_, double a2_, double b0_, double b1_, double b2_)
+    : a1(a1_ / a0_), a2(a2_ / a0_), b0(b0_ / a0_), b1(b1_ / a0_), b2(b2_ / a0_) {}
 
 void Filter::Process(std::vector<s16>& signal) {
     const std::size_t num_frames = signal.size() / 2;
@@ -69,7 +69,7 @@ CascadingFilter CascadingFilter::LowPass(double cutoff, std::size_t cascade_size
 }
 
 CascadingFilter::CascadingFilter() = default;
-CascadingFilter::CascadingFilter(std::vector<Filter> filters) : filters(std::move(filters)) {}
+CascadingFilter::CascadingFilter(std::vector<Filter> filters_) : filters(std::move(filters_)) {}
 
 void CascadingFilter::Process(std::vector<s16>& signal) {
     for (auto& filter : filters) {

--- a/src/audio_core/algorithm/filter.h
+++ b/src/audio_core/algorithm/filter.h
@@ -25,7 +25,7 @@ public:
     /// Passthrough filter.
     Filter();
 
-    Filter(double a0, double a1, double a2, double b0, double b1, double b2);
+    Filter(double a0_, double a1_, double a2_, double b0_, double b1_, double b2_);
 
     void Process(std::vector<s16>& signal);
 
@@ -51,7 +51,7 @@ public:
     /// Passthrough.
     CascadingFilter();
 
-    explicit CascadingFilter(std::vector<Filter> filters);
+    explicit CascadingFilter(std::vector<Filter> filters_);
 
     void Process(std::vector<s16>& signal);
 

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -71,9 +71,9 @@ namespace {
 namespace AudioCore {
 AudioRenderer::AudioRenderer(Core::Timing::CoreTiming& core_timing, Core::Memory::Memory& memory_,
                              AudioCommon::AudioRendererParameter params,
-                             std::shared_ptr<Kernel::WritableEvent> buffer_event,
+                             std::shared_ptr<Kernel::WritableEvent> buffer_event_,
                              std::size_t instance_number)
-    : worker_params{params}, buffer_event{buffer_event},
+    : worker_params{params}, buffer_event{buffer_event_},
       memory_pool_info(params.effect_count + params.voice_count * 4),
       voice_context(params.voice_count), effect_context(params.effect_count), mix_context(),
       sink_context(params.sink_count), splitter_context(),
@@ -89,7 +89,7 @@ AudioRenderer::AudioRenderer(Core::Timing::CoreTiming& core_timing, Core::Memory
     stream =
         audio_out->OpenStream(core_timing, params.sample_rate, AudioCommon::STREAM_NUM_CHANNELS,
                               fmt::format("AudioRenderer-Instance{}", instance_number),
-                              [=]() { buffer_event->Signal(); });
+                              [=]() { buffer_event_->Signal(); });
     audio_out->StartStream(stream);
 
     QueueMixedBuffer(0);

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -44,7 +44,8 @@ class AudioRenderer {
 public:
     AudioRenderer(Core::Timing::CoreTiming& core_timing, Core::Memory::Memory& memory_,
                   AudioCommon::AudioRendererParameter params,
-                  std::shared_ptr<Kernel::WritableEvent> buffer_event, std::size_t instance_number);
+                  std::shared_ptr<Kernel::WritableEvent> buffer_event_,
+                  std::size_t instance_number);
     ~AudioRenderer();
 
     [[nodiscard]] ResultCode UpdateAudioRenderer(const std::vector<u8>& input_params,

--- a/src/audio_core/buffer.h
+++ b/src/audio_core/buffer.h
@@ -18,7 +18,7 @@ class Buffer {
 public:
     using Tag = u64;
 
-    Buffer(Tag tag, std::vector<s16>&& samples) : tag{tag}, samples{std::move(samples)} {}
+    Buffer(Tag tag_, std::vector<s16>&& samples_) : tag{tag_}, samples{std::move(samples_)} {}
 
     /// Returns the raw audio data for the buffer
     std::vector<s16>& GetSamples() {

--- a/src/audio_core/command_generator.cpp
+++ b/src/audio_core/command_generator.cpp
@@ -67,12 +67,12 @@ s32 ApplyMixDepop(s32* output, s32 first_sample, s32 delta, s32 sample_count) {
 
 } // namespace
 
-CommandGenerator::CommandGenerator(AudioCommon::AudioRendererParameter& worker_params,
-                                   VoiceContext& voice_context, MixContext& mix_context,
-                                   SplitterContext& splitter_context, EffectContext& effect_context,
-                                   Core::Memory::Memory& memory)
-    : worker_params(worker_params), voice_context(voice_context), mix_context(mix_context),
-      splitter_context(splitter_context), effect_context(effect_context), memory(memory),
+CommandGenerator::CommandGenerator(AudioCommon::AudioRendererParameter& worker_params_,
+                                   VoiceContext& voice_context_, MixContext& mix_context_,
+                                   SplitterContext& splitter_context_,
+                                   EffectContext& effect_context_, Core::Memory::Memory& memory_)
+    : worker_params(worker_params_), voice_context(voice_context_), mix_context(mix_context_),
+      splitter_context(splitter_context_), effect_context(effect_context_), memory(memory_),
       mix_buffer((worker_params.mix_buffer_count + AudioCommon::MAX_CHANNEL_COUNT) *
                  worker_params.sample_count),
       sample_buffer(MIX_BUFFER_SIZE),
@@ -255,7 +255,8 @@ void CommandGenerator::GenerateDataSourceCommand(ServerVoiceInfo& voice_info, Vo
 
 void CommandGenerator::GenerateBiquadFilterCommandForVoice(ServerVoiceInfo& voice_info,
                                                            VoiceState& dsp_state,
-                                                           s32 mix_buffer_count, s32 channel) {
+                                                           [[maybe_unused]] s32 mix_buffer_count,
+                                                           [[maybe_unused]] s32 channel) {
     for (std::size_t i = 0; i < AudioCommon::MAX_BIQUAD_FILTERS; i++) {
         const auto& in_params = voice_info.GetInParams();
         auto& biquad_filter = in_params.biquad_filter[i];
@@ -278,9 +279,12 @@ void CommandGenerator::GenerateBiquadFilterCommandForVoice(ServerVoiceInfo& voic
     }
 }
 
-void AudioCore::CommandGenerator::GenerateBiquadFilterCommand(
-    s32 mix_buffer, const BiquadFilterParameter& params, std::array<s64, 2>& state,
-    std::size_t input_offset, std::size_t output_offset, s32 sample_count, s32 node_id) {
+void CommandGenerator::GenerateBiquadFilterCommand([[maybe_unused]] s32 mix_buffer_id,
+                                                   const BiquadFilterParameter& params,
+                                                   std::array<s64, 2>& state,
+                                                   std::size_t input_offset,
+                                                   std::size_t output_offset, s32 sample_count,
+                                                   s32 node_id) {
     if (dumping_frame) {
         LOG_DEBUG(Audio,
                   "(DSP_TRACE) GenerateBiquadFilterCommand node_id={}, "
@@ -714,7 +718,8 @@ s32 CommandGenerator::DecodePcm16(ServerVoiceInfo& voice_info, VoiceState& dsp_s
 }
 
 s32 CommandGenerator::DecodeAdpcm(ServerVoiceInfo& voice_info, VoiceState& dsp_state,
-                                  s32 sample_count, s32 channel, std::size_t mix_offset) {
+                                  s32 sample_count, [[maybe_unused]] s32 channel,
+                                  std::size_t mix_offset) {
     const auto& in_params = voice_info.GetInParams();
     const auto& wave_buffer = in_params.wave_buffer[dsp_state.wave_buffer_index];
     if (wave_buffer.buffer_address == 0) {

--- a/src/audio_core/command_generator.h
+++ b/src/audio_core/command_generator.h
@@ -25,10 +25,10 @@ using MixVolumeBuffer = std::array<float, AudioCommon::MAX_MIX_BUFFERS>;
 
 class CommandGenerator {
 public:
-    explicit CommandGenerator(AudioCommon::AudioRendererParameter& worker_params,
-                              VoiceContext& voice_context, MixContext& mix_context,
-                              SplitterContext& splitter_context, EffectContext& effect_context,
-                              Core::Memory::Memory& memory);
+    explicit CommandGenerator(AudioCommon::AudioRendererParameter& worker_params_,
+                              VoiceContext& voice_context_, MixContext& mix_context_,
+                              SplitterContext& splitter_context_, EffectContext& effect_context_,
+                              Core::Memory::Memory& memory_);
     ~CommandGenerator();
 
     void ClearMixBuffers();

--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -21,10 +21,10 @@ namespace AudioCore {
 
 class CubebSinkStream final : public SinkStream {
 public:
-    CubebSinkStream(cubeb* ctx, u32 sample_rate, u32 num_channels_, cubeb_devid output_device,
+    CubebSinkStream(cubeb* ctx_, u32 sample_rate, u32 num_channels_, cubeb_devid output_device,
                     const std::string& name)
-        : ctx{ctx}, num_channels{std::min(num_channels_, 6u)}, time_stretch{sample_rate,
-                                                                            num_channels} {
+        : ctx{ctx_}, num_channels{std::min(num_channels_, 6u)}, time_stretch{sample_rate,
+                                                                             num_channels} {
 
         cubeb_stream_params params{};
         params.rate = sample_rate;
@@ -192,8 +192,9 @@ SinkStream& CubebSink::AcquireSinkStream(u32 sample_rate, u32 num_channels,
     return *sink_streams.back();
 }
 
-long CubebSinkStream::DataCallback(cubeb_stream* stream, void* user_data, const void* input_buffer,
-                                   void* output_buffer, long num_frames) {
+long CubebSinkStream::DataCallback([[maybe_unused]] cubeb_stream* stream, void* user_data,
+                                   [[maybe_unused]] const void* input_buffer, void* output_buffer,
+                                   long num_frames) {
     auto* impl = static_cast<CubebSinkStream*>(user_data);
     auto* buffer = static_cast<u8*>(output_buffer);
 
@@ -236,7 +237,9 @@ long CubebSinkStream::DataCallback(cubeb_stream* stream, void* user_data, const 
     return num_frames;
 }
 
-void CubebSinkStream::StateCallback(cubeb_stream* stream, void* user_data, cubeb_state state) {}
+void CubebSinkStream::StateCallback([[maybe_unused]] cubeb_stream* stream,
+                                    [[maybe_unused]] void* user_data,
+                                    [[maybe_unused]] cubeb_state state) {}
 
 std::vector<std::string> ListCubebSinkDevices() {
     std::vector<std::string> device_list;

--- a/src/audio_core/effect_context.h
+++ b/src/audio_core/effect_context.h
@@ -184,7 +184,7 @@ struct AuxAddress {
 
 class EffectBase {
 public:
-    explicit EffectBase(EffectType effect_type);
+    explicit EffectBase(EffectType effect_type_);
     virtual ~EffectBase();
 
     virtual void Update(EffectInfo::InParams& in_params) = 0;
@@ -206,7 +206,7 @@ protected:
 template <typename T>
 class EffectGeneric : public EffectBase {
 public:
-    explicit EffectGeneric(EffectType effect_type) : EffectBase(effect_type) {}
+    explicit EffectGeneric(EffectType effect_type_) : EffectBase(effect_type_) {}
 
     T& GetParams() {
         return internal_params;
@@ -306,7 +306,7 @@ private:
 
 class EffectContext {
 public:
-    explicit EffectContext(std::size_t effect_count);
+    explicit EffectContext(std::size_t effect_count_);
     ~EffectContext();
 
     [[nodiscard]] std::size_t GetCount() const;

--- a/src/audio_core/info_updater.h
+++ b/src/audio_core/info_updater.h
@@ -21,8 +21,8 @@ class SplitterContext;
 class InfoUpdater {
 public:
     // TODO(ogniK): Pass process handle when we support it
-    InfoUpdater(const std::vector<u8>& in_params, std::vector<u8>& out_params,
-                BehaviorInfo& behavior_info);
+    InfoUpdater(const std::vector<u8>& in_params_, std::vector<u8>& out_params_,
+                BehaviorInfo& behavior_info_);
     ~InfoUpdater();
 
     bool UpdateBehaviorInfo(BehaviorInfo& in_behavior_info);

--- a/src/audio_core/memory_pool.cpp
+++ b/src/audio_core/memory_pool.cpp
@@ -10,11 +10,10 @@ namespace AudioCore {
 
 ServerMemoryPoolInfo::ServerMemoryPoolInfo() = default;
 ServerMemoryPoolInfo::~ServerMemoryPoolInfo() = default;
-bool ServerMemoryPoolInfo::Update(const ServerMemoryPoolInfo::InParams& in_params,
-                                  ServerMemoryPoolInfo::OutParams& out_params) {
+
+bool ServerMemoryPoolInfo::Update(const InParams& in_params, OutParams& out_params) {
     // Our state does not need to be changed
-    if (in_params.state != ServerMemoryPoolInfo::State::RequestAttach &&
-        in_params.state != ServerMemoryPoolInfo::State::RequestDetach) {
+    if (in_params.state != State::RequestAttach && in_params.state != State::RequestDetach) {
         return true;
     }
 
@@ -32,11 +31,11 @@ bool ServerMemoryPoolInfo::Update(const ServerMemoryPoolInfo::InParams& in_param
         return false;
     }
 
-    if (in_params.state == ServerMemoryPoolInfo::State::RequestAttach) {
+    if (in_params.state == State::RequestAttach) {
         cpu_address = in_params.address;
         size = in_params.size;
         used = true;
-        out_params.state = ServerMemoryPoolInfo::State::Attached;
+        out_params.state = State::Attached;
     } else {
         // Unexpected address
         if (cpu_address != in_params.address) {
@@ -54,7 +53,7 @@ bool ServerMemoryPoolInfo::Update(const ServerMemoryPoolInfo::InParams& in_param
         cpu_address = 0;
         size = 0;
         used = false;
-        out_params.state = ServerMemoryPoolInfo::State::Detached;
+        out_params.state = State::Detached;
     }
     return true;
 }

--- a/src/audio_core/memory_pool.h
+++ b/src/audio_core/memory_pool.h
@@ -28,19 +28,18 @@ public:
     struct InParams {
         u64_le address{};
         u64_le size{};
-        ServerMemoryPoolInfo::State state{};
+        State state{};
         INSERT_PADDING_WORDS(3);
     };
-    static_assert(sizeof(ServerMemoryPoolInfo::InParams) == 0x20, "InParams are an invalid size");
+    static_assert(sizeof(InParams) == 0x20, "InParams are an invalid size");
 
     struct OutParams {
-        ServerMemoryPoolInfo::State state{};
+        State state{};
         INSERT_PADDING_WORDS(3);
     };
-    static_assert(sizeof(ServerMemoryPoolInfo::OutParams) == 0x10, "OutParams are an invalid size");
+    static_assert(sizeof(OutParams) == 0x10, "OutParams are an invalid size");
 
-    bool Update(const ServerMemoryPoolInfo::InParams& in_params,
-                ServerMemoryPoolInfo::OutParams& out_params);
+    bool Update(const InParams& in_params, OutParams& out_params);
 
 private:
     // There's another entry here which is the DSP address, however since we're not talking to the

--- a/src/audio_core/sink_context.cpp
+++ b/src/audio_core/sink_context.cpp
@@ -5,7 +5,7 @@
 #include "audio_core/sink_context.h"
 
 namespace AudioCore {
-SinkContext::SinkContext(std::size_t sink_count) : sink_count(sink_count) {}
+SinkContext::SinkContext(std::size_t sink_count_) : sink_count{sink_count_} {}
 SinkContext::~SinkContext() = default;
 
 std::size_t SinkContext::GetCount() const {

--- a/src/audio_core/sink_context.h
+++ b/src/audio_core/sink_context.h
@@ -42,7 +42,7 @@ public:
         bool in_use;
         INSERT_UNION_PADDING_BYTES(5);
     };
-    static_assert(sizeof(SinkInfo::CircularBufferIn) == 0x28,
+    static_assert(sizeof(CircularBufferIn) == 0x28,
                   "SinkInfo::CircularBufferIn is in invalid size");
 
     struct DeviceIn {
@@ -54,7 +54,7 @@ public:
         bool down_matrix_enabled;
         DownmixCoefficients down_matrix_coef;
     };
-    static_assert(sizeof(SinkInfo::DeviceIn) == 0x11c, "SinkInfo::DeviceIn is an invalid size");
+    static_assert(sizeof(DeviceIn) == 0x11c, "SinkInfo::DeviceIn is an invalid size");
 
     struct InParams {
         SinkTypes type{};
@@ -64,16 +64,16 @@ public:
         INSERT_PADDING_WORDS(6);
         union {
             // std::array<u8, 0x120> raw{};
-            SinkInfo::DeviceIn device;
-            SinkInfo::CircularBufferIn circular_buffer;
+            DeviceIn device;
+            CircularBufferIn circular_buffer;
         };
     };
-    static_assert(sizeof(SinkInfo::InParams) == 0x140, "SinkInfo::InParams are an invalid size!");
+    static_assert(sizeof(InParams) == 0x140, "SinkInfo::InParams are an invalid size!");
 };
 
 class SinkContext {
 public:
-    explicit SinkContext(std::size_t sink_count);
+    explicit SinkContext(std::size_t sink_count_);
     ~SinkContext();
 
     [[nodiscard]] std::size_t GetCount() const;

--- a/src/audio_core/splitter_context.cpp
+++ b/src/audio_core/splitter_context.cpp
@@ -10,7 +10,7 @@
 
 namespace AudioCore {
 
-ServerSplitterDestinationData::ServerSplitterDestinationData(s32 id) : id(id) {}
+ServerSplitterDestinationData::ServerSplitterDestinationData(s32 id_) : id{id_} {}
 ServerSplitterDestinationData::~ServerSplitterDestinationData() = default;
 
 void ServerSplitterDestinationData::Update(SplitterInfo::InDestinationParams& header) {
@@ -87,7 +87,7 @@ void ServerSplitterDestinationData::UpdateInternalState() {
     needs_update = false;
 }
 
-ServerSplitterInfo::ServerSplitterInfo(s32 id) : id(id) {}
+ServerSplitterInfo::ServerSplitterInfo(s32 id_) : id(id_) {}
 ServerSplitterInfo::~ServerSplitterInfo() = default;
 
 void ServerSplitterInfo::InitializeInfos() {
@@ -121,7 +121,7 @@ const ServerSplitterDestinationData* ServerSplitterInfo::GetHead() const {
 }
 
 ServerSplitterDestinationData* ServerSplitterInfo::GetData(std::size_t depth) {
-    auto current_head = head;
+    auto* current_head = head;
     for (std::size_t i = 0; i < depth; i++) {
         if (current_head == nullptr) {
             return nullptr;
@@ -132,7 +132,7 @@ ServerSplitterDestinationData* ServerSplitterInfo::GetData(std::size_t depth) {
 }
 
 const ServerSplitterDestinationData* ServerSplitterInfo::GetData(std::size_t depth) const {
-    auto current_head = head;
+    auto* current_head = head;
     for (std::size_t i = 0; i < depth; i++) {
         if (current_head == nullptr) {
             return nullptr;
@@ -245,7 +245,7 @@ ServerSplitterDestinationData* SplitterContext::GetDestinationData(std::size_t i
 const ServerSplitterDestinationData* SplitterContext::GetDestinationData(std::size_t info,
                                                                          std::size_t data) const {
     ASSERT(info < info_count);
-    auto& cur_info = GetInfo(info);
+    const auto& cur_info = GetInfo(info);
     return cur_info.GetData(data);
 }
 
@@ -267,11 +267,11 @@ std::size_t SplitterContext::GetDataCount() const {
     return data_count;
 }
 
-void SplitterContext::Setup(std::size_t _info_count, std::size_t _data_count,
+void SplitterContext::Setup(std::size_t info_count_, std::size_t data_count_,
                             bool is_splitter_bug_fixed) {
 
-    info_count = _info_count;
-    data_count = _data_count;
+    info_count = info_count_;
+    data_count = data_count_;
 
     for (std::size_t i = 0; i < info_count; i++) {
         auto& splitter = infos.emplace_back(static_cast<s32>(i));
@@ -364,7 +364,7 @@ bool SplitterContext::RecomposeDestination(ServerSplitterInfo& info,
     // Clear our current destinations
     auto* current_head = info.GetHead();
     while (current_head != nullptr) {
-        auto next_head = current_head->GetNextDestination();
+        auto* next_head = current_head->GetNextDestination();
         current_head->SetNextDestination(nullptr);
         current_head = next_head;
     }
@@ -471,8 +471,8 @@ bool NodeStates::DepthFirstSearch(EdgeMatrix& edge_matrix) {
                 continue;
             }
 
-            const auto node_count = edge_matrix.GetNodeCount();
-            for (s32 j = 0; j < static_cast<s32>(node_count); j++) {
+            const auto edge_node_count = edge_matrix.GetNodeCount();
+            for (s32 j = 0; j < static_cast<s32>(edge_node_count); j++) {
                 // Check if our node is connected to our edge matrix
                 if (!edge_matrix.Connected(current_stack_index, j)) {
                     continue;

--- a/src/audio_core/splitter_context.h
+++ b/src/audio_core/splitter_context.h
@@ -63,7 +63,7 @@ public:
     NodeStates();
     ~NodeStates();
 
-    void Initialize(std::size_t _node_count);
+    void Initialize(std::size_t node_count_);
     bool Tsort(EdgeMatrix& edge_matrix);
     std::size_t GetIndexPos() const;
     const std::vector<s32>& GetIndexList() const;
@@ -72,15 +72,15 @@ private:
     void PushTsortResult(s32 index);
     bool DepthFirstSearch(EdgeMatrix& edge_matrix);
     void ResetState();
-    void UpdateState(NodeStates::State state, std::size_t i);
-    NodeStates::State GetState(std::size_t i);
+    void UpdateState(State state, std::size_t i);
+    State GetState(std::size_t i);
 
     std::size_t node_count{};
     std::vector<bool> was_node_found{};
     std::vector<bool> was_node_completed{};
     std::size_t index_pos{};
     std::vector<s32> index_list{};
-    NodeStates::Stack index_stack{};
+    Stack index_stack{};
 };
 
 enum class SplitterMagic : u32_le {
@@ -97,8 +97,7 @@ public:
         s32_le data_count{};
         INSERT_PADDING_WORDS(5);
     };
-    static_assert(sizeof(SplitterInfo::InHeader) == 0x20,
-                  "SplitterInfo::InHeader is an invalid size");
+    static_assert(sizeof(InHeader) == 0x20, "SplitterInfo::InHeader is an invalid size");
 
     struct InInfoPrams {
         SplitterMagic magic{};
@@ -107,8 +106,7 @@ public:
         s32_le length{};
         s32_le resource_id_base{};
     };
-    static_assert(sizeof(SplitterInfo::InInfoPrams) == 0x14,
-                  "SplitterInfo::InInfoPrams is an invalid size");
+    static_assert(sizeof(InInfoPrams) == 0x14, "SplitterInfo::InInfoPrams is an invalid size");
 
     struct InDestinationParams {
         SplitterMagic magic{};
@@ -118,13 +116,13 @@ public:
         bool in_use{};
         INSERT_PADDING_BYTES(3);
     };
-    static_assert(sizeof(SplitterInfo::InDestinationParams) == 0x70,
+    static_assert(sizeof(InDestinationParams) == 0x70,
                   "SplitterInfo::InDestinationParams is an invalid size");
 };
 
 class ServerSplitterDestinationData {
 public:
-    explicit ServerSplitterDestinationData(s32 id);
+    explicit ServerSplitterDestinationData(s32 id_);
     ~ServerSplitterDestinationData();
 
     void Update(SplitterInfo::InDestinationParams& header);
@@ -153,7 +151,7 @@ private:
 
 class ServerSplitterInfo {
 public:
-    explicit ServerSplitterInfo(s32 id);
+    explicit ServerSplitterInfo(s32 id_);
     ~ServerSplitterInfo();
 
     void InitializeInfos();

--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -31,10 +31,10 @@ u32 Stream::GetNumChannels() const {
     return {};
 }
 
-Stream::Stream(Core::Timing::CoreTiming& core_timing, u32 sample_rate, Format format,
-               ReleaseCallback&& release_callback, SinkStream& sink_stream, std::string&& name_)
-    : sample_rate{sample_rate}, format{format}, release_callback{std::move(release_callback)},
-      sink_stream{sink_stream}, core_timing{core_timing}, name{std::move(name_)} {
+Stream::Stream(Core::Timing::CoreTiming& core_timing_, u32 sample_rate_, Format format_,
+               ReleaseCallback&& release_callback_, SinkStream& sink_stream_, std::string&& name_)
+    : sample_rate{sample_rate_}, format{format_}, release_callback{std::move(release_callback_)},
+      sink_stream{sink_stream_}, core_timing{core_timing_}, name{std::move(name_)} {
     release_event =
         Core::Timing::CreateEvent(name, [this](std::uintptr_t, std::chrono::nanoseconds ns_late) {
             ReleaseActiveBuffer(ns_late);
@@ -122,7 +122,7 @@ bool Stream::QueueBuffer(BufferPtr&& buffer) {
     return false;
 }
 
-bool Stream::ContainsBuffer(Buffer::Tag tag) const {
+bool Stream::ContainsBuffer([[maybe_unused]] Buffer::Tag tag) const {
     UNIMPLEMENTED();
     return {};
 }

--- a/src/audio_core/stream.h
+++ b/src/audio_core/stream.h
@@ -44,8 +44,8 @@ public:
     /// Callback function type, used to change guest state on a buffer being released
     using ReleaseCallback = std::function<void()>;
 
-    Stream(Core::Timing::CoreTiming& core_timing, u32 sample_rate, Format format,
-           ReleaseCallback&& release_callback, SinkStream& sink_stream, std::string&& name_);
+    Stream(Core::Timing::CoreTiming& core_timing_, u32 sample_rate_, Format format_,
+           ReleaseCallback&& release_callback_, SinkStream& sink_stream_, std::string&& name_);
 
     /// Plays the audio stream
     void Play();

--- a/src/audio_core/voice_context.cpp
+++ b/src/audio_core/voice_context.cpp
@@ -8,7 +8,7 @@
 
 namespace AudioCore {
 
-ServerVoiceChannelResource::ServerVoiceChannelResource(s32 id) : id(id) {}
+ServerVoiceChannelResource::ServerVoiceChannelResource(s32 id_) : id(id_) {}
 ServerVoiceChannelResource::~ServerVoiceChannelResource() = default;
 
 bool ServerVoiceChannelResource::InUse() const {
@@ -209,7 +209,8 @@ void ServerVoiceInfo::UpdateWaveBuffers(
 
 void ServerVoiceInfo::UpdateWaveBuffer(ServerWaveBuffer& out_wavebuffer,
                                        const WaveBuffer& in_wave_buffer, SampleFormat sample_format,
-                                       bool is_buffer_valid, BehaviorInfo& behavior_info) {
+                                       bool is_buffer_valid,
+                                       [[maybe_unused]] BehaviorInfo& behavior_info) {
     if (!is_buffer_valid && out_wavebuffer.sent_to_dsp) {
         out_wavebuffer.buffer_address = 0;
         out_wavebuffer.buffer_size = 0;
@@ -400,7 +401,7 @@ bool ServerVoiceInfo::HasValidWaveBuffer(const VoiceState* state) const {
     return std::find(valid_wb.begin(), valid_wb.end(), true) != valid_wb.end();
 }
 
-VoiceContext::VoiceContext(std::size_t voice_count) : voice_count(voice_count) {
+VoiceContext::VoiceContext(std::size_t voice_count_) : voice_count{voice_count_} {
     for (std::size_t i = 0; i < voice_count; i++) {
         voice_channel_resources.emplace_back(static_cast<s32>(i));
         sorted_voice_info.push_back(&voice_info.emplace_back());

--- a/src/audio_core/voice_context.h
+++ b/src/audio_core/voice_context.h
@@ -118,12 +118,12 @@ public:
         bool in_use{};
         INSERT_PADDING_BYTES(11);
     };
-    static_assert(sizeof(VoiceChannelResource::InParams) == 0x70, "InParams is an invalid size");
+    static_assert(sizeof(InParams) == 0x70, "InParams is an invalid size");
 };
 
 class ServerVoiceChannelResource {
 public:
-    explicit ServerVoiceChannelResource(s32 id);
+    explicit ServerVoiceChannelResource(s32 id_);
     ~ServerVoiceChannelResource();
 
     bool InUse() const;
@@ -174,7 +174,7 @@ public:
         BehaviorFlags behavior_flags{};
         INSERT_PADDING_BYTES(16);
     };
-    static_assert(sizeof(VoiceInfo::InParams) == 0x170, "InParams is an invalid size");
+    static_assert(sizeof(InParams) == 0x170, "InParams is an invalid size");
 
     struct OutParams {
         u64_le played_sample_count{};
@@ -182,7 +182,7 @@ public:
         u8 voice_dropped{};
         INSERT_PADDING_BYTES(3);
     };
-    static_assert(sizeof(VoiceInfo::OutParams) == 0x10, "OutParams is an invalid size");
+    static_assert(sizeof(OutParams) == 0x10, "OutParams is an invalid size");
 };
 
 class ServerVoiceInfo {
@@ -263,7 +263,7 @@ private:
 
 class VoiceContext {
 public:
-    VoiceContext(std::size_t voice_count);
+    explicit VoiceContext(std::size_t voice_count_);
     ~VoiceContext();
 
     std::size_t GetVoiceCount() const;

--- a/src/common/wall_clock.cpp
+++ b/src/common/wall_clock.cpp
@@ -17,8 +17,8 @@ using base_time_point = std::chrono::time_point<base_timer>;
 
 class StandardWallClock final : public WallClock {
 public:
-    StandardWallClock(u64 emulated_cpu_frequency, u64 emulated_clock_frequency)
-        : WallClock(emulated_cpu_frequency, emulated_clock_frequency, false) {
+    explicit StandardWallClock(u64 emulated_cpu_frequency_, u64 emulated_clock_frequency_)
+        : WallClock(emulated_cpu_frequency_, emulated_clock_frequency_, false) {
         start_time = base_timer::now();
     }
 

--- a/src/common/wall_clock.h
+++ b/src/common/wall_clock.h
@@ -38,9 +38,9 @@ public:
     }
 
 protected:
-    WallClock(u64 emulated_cpu_frequency, u64 emulated_clock_frequency, bool is_native)
-        : emulated_cpu_frequency{emulated_cpu_frequency},
-          emulated_clock_frequency{emulated_clock_frequency}, is_native{is_native} {}
+    explicit WallClock(u64 emulated_cpu_frequency_, u64 emulated_clock_frequency_, bool is_native_)
+        : emulated_cpu_frequency{emulated_cpu_frequency_},
+          emulated_clock_frequency{emulated_clock_frequency_}, is_native{is_native_} {}
 
     u64 emulated_cpu_frequency;
     u64 emulated_clock_frequency;

--- a/src/common/x64/native_clock.cpp
+++ b/src/common/x64/native_clock.cpp
@@ -43,10 +43,10 @@ u64 EstimateRDTSCFrequency() {
 }
 
 namespace X64 {
-NativeClock::NativeClock(u64 emulated_cpu_frequency, u64 emulated_clock_frequency,
-                         u64 rtsc_frequency)
-    : WallClock(emulated_cpu_frequency, emulated_clock_frequency, true), rtsc_frequency{
-                                                                             rtsc_frequency} {
+NativeClock::NativeClock(u64 emulated_cpu_frequency_, u64 emulated_clock_frequency_,
+                         u64 rtsc_frequency_)
+    : WallClock(emulated_cpu_frequency_, emulated_clock_frequency_, true), rtsc_frequency{
+                                                                               rtsc_frequency_} {
     _mm_mfence();
     last_measure = __rdtsc();
     accumulated_ticks = 0U;

--- a/src/common/x64/native_clock.h
+++ b/src/common/x64/native_clock.h
@@ -14,7 +14,8 @@ namespace Common {
 namespace X64 {
 class NativeClock final : public WallClock {
 public:
-    NativeClock(u64 emulated_cpu_frequency, u64 emulated_clock_frequency, u64 rtsc_frequency);
+    explicit NativeClock(u64 emulated_cpu_frequency_, u64 emulated_clock_frequency_,
+                         u64 rtsc_frequency_);
 
     std::chrono::nanoseconds GetTimeNS() override;
 

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -27,8 +27,8 @@ using TimedCallback =
 
 /// Contains the characteristics of a particular event.
 struct EventType {
-    EventType(TimedCallback&& callback, std::string&& name)
-        : callback{std::move(callback)}, name{std::move(name)} {}
+    explicit EventType(TimedCallback&& callback_, std::string&& name_)
+        : callback{std::move(callback_)}, name{std::move(name_)} {}
 
     /// The event's callback function.
     TimedCallback callback;
@@ -67,8 +67,8 @@ public:
     void Shutdown();
 
     /// Sets if emulation is multicore or single core, must be set before Initialize
-    void SetMulticore(bool is_multicore) {
-        this->is_multicore = is_multicore;
+    void SetMulticore(bool is_multicore_) {
+        is_multicore = is_multicore_;
     }
 
     /// Check if it's using host timing.

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -119,7 +119,7 @@ union ResultCode {
     BitField<0, 9, ErrorModule> module;
     BitField<9, 13, u32> description;
 
-    constexpr explicit ResultCode(u32 raw) : raw(raw) {}
+    constexpr explicit ResultCode(u32 raw_) : raw(raw_) {}
 
     constexpr ResultCode(ErrorModule module_, u32 description_)
         : raw(module.FormatValue(module_) | description.FormatValue(description_)) {}


### PR DESCRIPTION
Moves the audio code closer to enabling warnings as errors in general.

Here's to another 5K PRs ✌️.