### PR TITLE
input_common: unbreak -Werror with Clang

### DIFF
--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -56,8 +56,8 @@ else()
         -Werror=reorder
         -Werror=shadow
         -Werror=sign-compare
-        -Werror=unused-but-set-parameter
-        -Werror=unused-but-set-variable
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>
+        $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-variable>
         -Werror=unused-variable
     )
 endif()


### PR DESCRIPTION
Regressed by #4927. From [error log](https://github.com/yuzu-emu/yuzu/files/5599711/yuzu-qt5-s20201125.log):
```c++
error: unknown warning option '-Werror=unused-but-set-parameter'; did you mean '-Werror=unused-parameter'? [-Werror,-Wunknown-warning-option]
error: unknown warning option '-Werror=unused-but-set-variable'; did you mean '-Werror=unused-const-variable'? [-Werror,-Wunknown-warning-option]
```
