### PR TITLE
common: Add Common::DivCeil and Common::DivCeilLog2

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -112,6 +112,7 @@ add_library(common STATIC
     common_paths.h
     common_types.h
     concepts.h
+    div_ceil.h
     dynamic_library.cpp
     dynamic_library.h
     fiber.cpp

--- a/src/common/div_ceil.h
+++ b/src/common/div_ceil.h
@@ -1,0 +1,26 @@
+// Copyright 2020 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+namespace Common {
+
+/// Ceiled integer division.
+template <typename N, typename D>
+requires std::is_integral_v<N>&& std::is_unsigned_v<D>[[nodiscard]] constexpr auto DivCeil(
+    N number, D divisor) {
+    return (static_cast<D>(number) + divisor - 1) / divisor;
+}
+
+/// Ceiled integer division with logarithmic divisor in base 2
+template <typename N, typename D>
+requires std::is_integral_v<N>&& std::is_unsigned_v<D>[[nodiscard]] constexpr auto DivCeilLog2(
+    N value, D alignment_log2) {
+    return (static_cast<D>(value) + (D(1) << alignment_log2) - 1) >> alignment_log2;
+}
+
+} // namespace Common


### PR DESCRIPTION
Add an equivalent to 'Common::AlignUp(n, d) / d' and a log2 alternative.

Required by #4967