### PR TITLE
CMakeLists: disable -Winvalid-offsetof

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,7 @@ else()
         -Wextra
         -Wmissing-declarations
         -Wno-attributes
+        -Wno-invalid-offsetof
         -Wno-unused-parameter
     )
 


### PR DESCRIPTION
This Clang warning complains when offsetof is used on a
non-standard-layout type (i.e. any class using various C++ features),
even though it works fine (and is not undefined behavior as of C++17).