### PR TITLE
service: Eliminate usages of the global system instance

### DIFF
--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -47,8 +47,8 @@ static constexpr u32 SanitizeJPEGSize(std::size_t size) {
 
 class IManagerForSystemService final : public ServiceFramework<IManagerForSystemService> {
 public:
-    explicit IManagerForSystemService(Common::UUID user_id)
-        : ServiceFramework("IManagerForSystemService") {
+    explicit IManagerForSystemService(Core::System& system_, Common::UUID)
+        : ServiceFramework{system_, "IManagerForSystemService"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "CheckAvailability"},
@@ -83,8 +83,8 @@ public:
 // 3.0.0+
 class IFloatingRegistrationRequest final : public ServiceFramework<IFloatingRegistrationRequest> {
 public:
-    explicit IFloatingRegistrationRequest(Common::UUID user_id)
-        : ServiceFramework("IFloatingRegistrationRequest") {
+    explicit IFloatingRegistrationRequest(Core::System& system_, Common::UUID)
+        : ServiceFramework{system_, "IFloatingRegistrationRequest"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetSessionId"},
@@ -108,7 +108,8 @@ public:
 
 class IAdministrator final : public ServiceFramework<IAdministrator> {
 public:
-    explicit IAdministrator(Common::UUID user_id) : ServiceFramework("IAdministrator") {
+    explicit IAdministrator(Core::System& system_, Common::UUID)
+        : ServiceFramework{system_, "IAdministrator"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "CheckAvailability"},
@@ -165,8 +166,8 @@ public:
 
 class IAuthorizationRequest final : public ServiceFramework<IAuthorizationRequest> {
 public:
-    explicit IAuthorizationRequest(Common::UUID user_id)
-        : ServiceFramework("IAuthorizationRequest") {
+    explicit IAuthorizationRequest(Core::System& system_, Common::UUID)
+        : ServiceFramework{system_, "IAuthorizationRequest"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetSessionId"},
@@ -184,7 +185,8 @@ public:
 
 class IOAuthProcedure final : public ServiceFramework<IOAuthProcedure> {
 public:
-    explicit IOAuthProcedure(Common::UUID user_id) : ServiceFramework("IOAuthProcedure") {
+    explicit IOAuthProcedure(Core::System& system_, Common::UUID)
+        : ServiceFramework{system_, "IOAuthProcedure"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "PrepareAsync"},
@@ -202,8 +204,8 @@ public:
 // 3.0.0+
 class IOAuthProcedureForExternalNsa final : public ServiceFramework<IOAuthProcedureForExternalNsa> {
 public:
-    explicit IOAuthProcedureForExternalNsa(Common::UUID user_id)
-        : ServiceFramework("IOAuthProcedureForExternalNsa") {
+    explicit IOAuthProcedureForExternalNsa(Core::System& system_, Common::UUID)
+        : ServiceFramework{system_, "IOAuthProcedureForExternalNsa"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "PrepareAsync"},
@@ -225,8 +227,8 @@ public:
 class IOAuthProcedureForNintendoAccountLinkage final
     : public ServiceFramework<IOAuthProcedureForNintendoAccountLinkage> {
 public:
-    explicit IOAuthProcedureForNintendoAccountLinkage(Common::UUID user_id)
-        : ServiceFramework("IOAuthProcedureForNintendoAccountLinkage") {
+    explicit IOAuthProcedureForNintendoAccountLinkage(Core::System& system_, Common::UUID)
+        : ServiceFramework{system_, "IOAuthProcedureForNintendoAccountLinkage"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "PrepareAsync"},
@@ -246,7 +248,8 @@ public:
 
 class INotifier final : public ServiceFramework<INotifier> {
 public:
-    explicit INotifier(Common::UUID user_id) : ServiceFramework("INotifier") {
+    explicit INotifier(Core::System& system_, Common::UUID)
+        : ServiceFramework{system_, "INotifier"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetSystemEvent"},
@@ -259,9 +262,9 @@ public:
 
 class IProfileCommon : public ServiceFramework<IProfileCommon> {
 public:
-    explicit IProfileCommon(const char* name, bool editor_commands, Common::UUID user_id,
-                            ProfileManager& profile_manager)
-        : ServiceFramework(name), profile_manager(profile_manager), user_id(user_id) {
+    explicit IProfileCommon(Core::System& system_, const char* name, bool editor_commands,
+                            Common::UUID user_id_, ProfileManager& profile_manager_)
+        : ServiceFramework{system_, name}, profile_manager{profile_manager_}, user_id{user_id_} {
         static const FunctionInfo functions[] = {
             {0, &IProfileCommon::Get, "Get"},
             {1, &IProfileCommon::GetBase, "GetBase"},
@@ -427,19 +430,21 @@ protected:
 
 class IProfile final : public IProfileCommon {
 public:
-    IProfile(Common::UUID user_id, ProfileManager& profile_manager)
-        : IProfileCommon("IProfile", false, user_id, profile_manager) {}
+    explicit IProfile(Core::System& system_, Common::UUID user_id_,
+                      ProfileManager& profile_manager_)
+        : IProfileCommon{system_, "IProfile", false, user_id_, profile_manager_} {}
 };
 
 class IProfileEditor final : public IProfileCommon {
 public:
-    IProfileEditor(Common::UUID user_id, ProfileManager& profile_manager)
-        : IProfileCommon("IProfileEditor", true, user_id, profile_manager) {}
+    explicit IProfileEditor(Core::System& system_, Common::UUID user_id_,
+                            ProfileManager& profile_manager_)
+        : IProfileCommon{system_, "IProfileEditor", true, user_id_, profile_manager_} {}
 };
 
 class IAsyncContext final : public ServiceFramework<IAsyncContext> {
 public:
-    explicit IAsyncContext(Common::UUID user_id) : ServiceFramework("IAsyncContext") {
+    explicit IAsyncContext(Core::System& system_) : ServiceFramework{system_, "IAsyncContext"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetSystemEvent"},
@@ -455,7 +460,8 @@ public:
 
 class ISessionObject final : public ServiceFramework<ISessionObject> {
 public:
-    explicit ISessionObject(Common::UUID user_id) : ServiceFramework("ISessionObject") {
+    explicit ISessionObject(Core::System& system_, Common::UUID)
+        : ServiceFramework{system_, "ISessionObject"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {999, nullptr, "Dummy"},
@@ -468,7 +474,8 @@ public:
 
 class IGuestLoginRequest final : public ServiceFramework<IGuestLoginRequest> {
 public:
-    explicit IGuestLoginRequest(Common::UUID) : ServiceFramework("IGuestLoginRequest") {
+    explicit IGuestLoginRequest(Core::System& system_, Common::UUID)
+        : ServiceFramework{system_, "IGuestLoginRequest"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetSessionId"},
@@ -487,8 +494,8 @@ public:
 
 class IManagerForApplication final : public ServiceFramework<IManagerForApplication> {
 public:
-    explicit IManagerForApplication(Common::UUID user_id)
-        : ServiceFramework("IManagerForApplication"), user_id(user_id) {
+    explicit IManagerForApplication(Core::System& system_, Common::UUID user_id_)
+        : ServiceFramework{system_, "IManagerForApplication"}, user_id{user_id_} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IManagerForApplication::CheckAvailability, "CheckAvailability"},
@@ -534,8 +541,8 @@ private:
 class IAsyncNetworkServiceLicenseKindContext final
     : public ServiceFramework<IAsyncNetworkServiceLicenseKindContext> {
 public:
-    explicit IAsyncNetworkServiceLicenseKindContext(Common::UUID user_id)
-        : ServiceFramework("IAsyncNetworkServiceLicenseKindContext") {
+    explicit IAsyncNetworkServiceLicenseKindContext(Core::System& system_, Common::UUID)
+        : ServiceFramework{system_, "IAsyncNetworkServiceLicenseKindContext"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetSystemEvent"},
@@ -554,8 +561,8 @@ public:
 class IOAuthProcedureForUserRegistration final
     : public ServiceFramework<IOAuthProcedureForUserRegistration> {
 public:
-    explicit IOAuthProcedureForUserRegistration(Common::UUID user_id)
-        : ServiceFramework("IOAuthProcedureForUserRegistration") {
+    explicit IOAuthProcedureForUserRegistration(Core::System& system_, Common::UUID)
+        : ServiceFramework{system_, "IOAuthProcedureForUserRegistration"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "PrepareAsync"},
@@ -578,7 +585,7 @@ public:
 
 class DAUTH_O final : public ServiceFramework<DAUTH_O> {
 public:
-    explicit DAUTH_O(Common::UUID) : ServiceFramework("dauth:o") {
+    explicit DAUTH_O(Core::System& system_, Common::UUID) : ServiceFramework{system_, "dauth:o"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "EnsureAuthenticationTokenCacheAsync"}, // [5.0.0-5.1.0] GeneratePostData
@@ -597,7 +604,8 @@ public:
 // 6.0.0+
 class IAsyncResult final : public ServiceFramework<IAsyncResult> {
 public:
-    explicit IAsyncResult(Common::UUID user_id) : ServiceFramework("IAsyncResult") {
+    explicit IAsyncResult(Core::System& system_, Common::UUID)
+        : ServiceFramework{system_, "IAsyncResult"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetResult"},
@@ -656,7 +664,7 @@ void Module::Interface::GetProfile(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
-    rb.PushIpcInterface<IProfile>(user_id, *profile_manager);
+    rb.PushIpcInterface<IProfile>(system, user_id, *profile_manager);
 }
 
 void Module::Interface::IsUserRegistrationRequestPermitted(Kernel::HLERequestContext& ctx) {
@@ -731,7 +739,7 @@ void Module::Interface::GetBaasAccountManagerForApplication(Kernel::HLERequestCo
     LOG_DEBUG(Service_ACC, "called");
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
-    rb.PushIpcInterface<IManagerForApplication>(profile_manager->GetLastOpenedUser());
+    rb.PushIpcInterface<IManagerForApplication>(system, profile_manager->GetLastOpenedUser());
 }
 
 void Module::Interface::IsUserAccountSwitchLocked(Kernel::HLERequestContext& ctx) {
@@ -769,7 +777,7 @@ void Module::Interface::GetProfileEditor(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
-    rb.PushIpcInterface<IProfileEditor>(user_id, *profile_manager);
+    rb.PushIpcInterface<IProfileEditor>(system, user_id, *profile_manager);
 }
 
 void Module::Interface::ListQualifiedUsers(Kernel::HLERequestContext& ctx) {
@@ -791,7 +799,7 @@ void Module::Interface::LoadOpenContext(Kernel::HLERequestContext& ctx) {
     // TODO: Find the differences between this and GetBaasAccountManagerForApplication
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
-    rb.PushIpcInterface<IManagerForApplication>(profile_manager->GetLastOpenedUser());
+    rb.PushIpcInterface<IManagerForApplication>(system, profile_manager->GetLastOpenedUser());
 }
 
 void Module::Interface::ListOpenContextStoredUsers(Kernel::HLERequestContext& ctx) {
@@ -827,11 +835,11 @@ void Module::Interface::TrySelectUserWithoutInteraction(Kernel::HLERequestContex
     rb.PushRaw<u128>(profile_manager->GetUser(0)->uuid);
 }
 
-Module::Interface::Interface(std::shared_ptr<Module> module,
-                             std::shared_ptr<ProfileManager> profile_manager, Core::System& system,
-                             const char* name)
-    : ServiceFramework(name), module(std::move(module)),
-      profile_manager(std::move(profile_manager)), system(system) {}
+Module::Interface::Interface(std::shared_ptr<Module> module_,
+                             std::shared_ptr<ProfileManager> profile_manager_,
+                             Core::System& system_, const char* name)
+    : ServiceFramework{system_, name}, module{std::move(module_)}, profile_manager{std::move(
+                                                                       profile_manager_)} {}
 
 Module::Interface::~Interface() = default;
 

--- a/src/core/hle/service/acc/acc.h
+++ b/src/core/hle/service/acc/acc.h
@@ -15,8 +15,8 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        explicit Interface(std::shared_ptr<Module> module,
-                           std::shared_ptr<ProfileManager> profile_manager, Core::System& system,
+        explicit Interface(std::shared_ptr<Module> module_,
+                           std::shared_ptr<ProfileManager> profile_manager_, Core::System& system_,
                            const char* name);
         ~Interface() override;
 
@@ -60,7 +60,6 @@ public:
     protected:
         std::shared_ptr<Module> module;
         std::shared_ptr<ProfileManager> profile_manager;
-        Core::System& system;
     };
 };
 

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -77,13 +77,11 @@ public:
 private:
     void GetAppletResourceUserId(Kernel::HLERequestContext& ctx);
     void AcquireForegroundRights(Kernel::HLERequestContext& ctx);
-
-    Core::System& system;
 };
 
 class IAudioController final : public ServiceFramework<IAudioController> {
 public:
-    IAudioController();
+    explicit IAudioController(Core::System& system_);
     ~IAudioController() override;
 
 private:
@@ -109,13 +107,13 @@ private:
 
 class IDisplayController final : public ServiceFramework<IDisplayController> {
 public:
-    IDisplayController();
+    explicit IDisplayController(Core::System& system_);
     ~IDisplayController() override;
 };
 
 class IDebugFunctions final : public ServiceFramework<IDebugFunctions> {
 public:
-    IDebugFunctions();
+    explicit IDebugFunctions(Core::System& system_);
     ~IDebugFunctions() override;
 };
 
@@ -154,7 +152,6 @@ private:
         Disable = 2,
     };
 
-    Core::System& system;
     NVFlinger::NVFlinger& nvflinger;
     Kernel::EventPair launchable_event;
     Kernel::EventPair accumulated_suspended_tick_changed_event;
@@ -167,8 +164,8 @@ private:
 
 class ICommonStateGetter final : public ServiceFramework<ICommonStateGetter> {
 public:
-    explicit ICommonStateGetter(Core::System& system,
-                                std::shared_ptr<AppletMessageQueue> msg_queue);
+    explicit ICommonStateGetter(Core::System& system_,
+                                std::shared_ptr<AppletMessageQueue> msg_queue_);
     ~ICommonStateGetter() override;
 
 private:
@@ -196,7 +193,6 @@ private:
     void GetDefaultDisplayResolution(Kernel::HLERequestContext& ctx);
     void SetCpuBoostMode(Kernel::HLERequestContext& ctx);
 
-    Core::System& system;
     std::shared_ptr<AppletMessageQueue> msg_queue;
     bool vr_mode_state{};
 };
@@ -211,7 +207,7 @@ public:
 
 class IStorage final : public ServiceFramework<IStorage> {
 public:
-    explicit IStorage(std::vector<u8>&& buffer);
+    explicit IStorage(Core::System& system_, std::vector<u8>&& buffer);
     ~IStorage() override;
 
     std::vector<u8>& GetData() {
@@ -235,7 +231,7 @@ private:
 
 class IStorageAccessor final : public ServiceFramework<IStorageAccessor> {
 public:
-    explicit IStorageAccessor(IStorage& backing);
+    explicit IStorageAccessor(Core::System& system_, IStorage& backing_);
     ~IStorageAccessor() override;
 
 private:
@@ -255,8 +251,6 @@ private:
     void CreateLibraryApplet(Kernel::HLERequestContext& ctx);
     void CreateStorage(Kernel::HLERequestContext& ctx);
     void CreateTransferMemoryStorage(Kernel::HLERequestContext& ctx);
-
-    Core::System& system;
 };
 
 class IApplicationFunctions final : public ServiceFramework<IApplicationFunctions> {
@@ -299,12 +293,11 @@ private:
     s32 previous_program_index{-1};
     Kernel::EventPair gpu_error_detected_event;
     Kernel::EventPair friend_invitation_storage_channel_event;
-    Core::System& system;
 };
 
 class IHomeMenuFunctions final : public ServiceFramework<IHomeMenuFunctions> {
 public:
-    explicit IHomeMenuFunctions(Kernel::KernelCore& kernel);
+    explicit IHomeMenuFunctions(Core::System& system_);
     ~IHomeMenuFunctions() override;
 
 private:
@@ -312,24 +305,23 @@ private:
     void GetPopFromGeneralChannelEvent(Kernel::HLERequestContext& ctx);
 
     Kernel::EventPair pop_from_general_channel_event;
-    Kernel::KernelCore& kernel;
 };
 
 class IGlobalStateController final : public ServiceFramework<IGlobalStateController> {
 public:
-    IGlobalStateController();
+    explicit IGlobalStateController(Core::System& system_);
     ~IGlobalStateController() override;
 };
 
 class IApplicationCreator final : public ServiceFramework<IApplicationCreator> {
 public:
-    IApplicationCreator();
+    explicit IApplicationCreator(Core::System& system_);
     ~IApplicationCreator() override;
 };
 
 class IProcessWindingController final : public ServiceFramework<IProcessWindingController> {
 public:
-    IProcessWindingController();
+    explicit IProcessWindingController(Core::System& system_);
     ~IProcessWindingController() override;
 };
 

--- a/src/core/hle/service/am/applet_ae.cpp
+++ b/src/core/hle/service/am/applet_ae.cpp
@@ -13,11 +13,11 @@ namespace Service::AM {
 
 class ILibraryAppletProxy final : public ServiceFramework<ILibraryAppletProxy> {
 public:
-    explicit ILibraryAppletProxy(NVFlinger::NVFlinger& nvflinger,
-                                 std::shared_ptr<AppletMessageQueue> msg_queue,
-                                 Core::System& system)
-        : ServiceFramework("ILibraryAppletProxy"), nvflinger(nvflinger),
-          msg_queue(std::move(msg_queue)), system(system) {
+    explicit ILibraryAppletProxy(NVFlinger::NVFlinger& nvflinger_,
+                                 std::shared_ptr<AppletMessageQueue> msg_queue_,
+                                 Core::System& system_)
+        : ServiceFramework{system_, "ILibraryAppletProxy"}, nvflinger{nvflinger_},
+          msg_queue{std::move(msg_queue_)} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &ILibraryAppletProxy::GetCommonStateGetter, "GetCommonStateGetter"},
@@ -66,7 +66,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IAudioController>();
+        rb.PushIpcInterface<IAudioController>(system);
     }
 
     void GetDisplayController(Kernel::HLERequestContext& ctx) {
@@ -74,7 +74,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IDisplayController>();
+        rb.PushIpcInterface<IDisplayController>(system);
     }
 
     void GetProcessWindingController(Kernel::HLERequestContext& ctx) {
@@ -82,7 +82,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IProcessWindingController>();
+        rb.PushIpcInterface<IProcessWindingController>(system);
     }
 
     void GetDebugFunctions(Kernel::HLERequestContext& ctx) {
@@ -90,7 +90,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IDebugFunctions>();
+        rb.PushIpcInterface<IDebugFunctions>(system);
     }
 
     void GetLibraryAppletCreator(Kernel::HLERequestContext& ctx) {
@@ -111,15 +111,15 @@ private:
 
     NVFlinger::NVFlinger& nvflinger;
     std::shared_ptr<AppletMessageQueue> msg_queue;
-    Core::System& system;
 };
 
 class ISystemAppletProxy final : public ServiceFramework<ISystemAppletProxy> {
 public:
-    explicit ISystemAppletProxy(NVFlinger::NVFlinger& nvflinger,
-                                std::shared_ptr<AppletMessageQueue> msg_queue, Core::System& system)
-        : ServiceFramework("ISystemAppletProxy"), nvflinger(nvflinger),
-          msg_queue(std::move(msg_queue)), system(system) {
+    explicit ISystemAppletProxy(NVFlinger::NVFlinger& nvflinger_,
+                                std::shared_ptr<AppletMessageQueue> msg_queue_,
+                                Core::System& system_)
+        : ServiceFramework{system_, "ISystemAppletProxy"}, nvflinger{nvflinger_},
+          msg_queue{std::move(msg_queue_)} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &ISystemAppletProxy::GetCommonStateGetter, "GetCommonStateGetter"},
@@ -170,7 +170,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IAudioController>();
+        rb.PushIpcInterface<IAudioController>(system);
     }
 
     void GetDisplayController(Kernel::HLERequestContext& ctx) {
@@ -178,7 +178,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IDisplayController>();
+        rb.PushIpcInterface<IDisplayController>(system);
     }
 
     void GetDebugFunctions(Kernel::HLERequestContext& ctx) {
@@ -186,7 +186,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IDebugFunctions>();
+        rb.PushIpcInterface<IDebugFunctions>(system);
     }
 
     void GetLibraryAppletCreator(Kernel::HLERequestContext& ctx) {
@@ -202,7 +202,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IHomeMenuFunctions>(system.Kernel());
+        rb.PushIpcInterface<IHomeMenuFunctions>(system);
     }
 
     void GetGlobalStateController(Kernel::HLERequestContext& ctx) {
@@ -210,7 +210,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IGlobalStateController>();
+        rb.PushIpcInterface<IGlobalStateController>(system);
     }
 
     void GetApplicationCreator(Kernel::HLERequestContext& ctx) {
@@ -218,12 +218,11 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IApplicationCreator>();
+        rb.PushIpcInterface<IApplicationCreator>(system);
     }
 
     NVFlinger::NVFlinger& nvflinger;
     std::shared_ptr<AppletMessageQueue> msg_queue;
-    Core::System& system;
 };
 
 void AppletAE::OpenSystemAppletProxy(Kernel::HLERequestContext& ctx) {
@@ -250,10 +249,10 @@ void AppletAE::OpenLibraryAppletProxyOld(Kernel::HLERequestContext& ctx) {
     rb.PushIpcInterface<ILibraryAppletProxy>(nvflinger, msg_queue, system);
 }
 
-AppletAE::AppletAE(NVFlinger::NVFlinger& nvflinger, std::shared_ptr<AppletMessageQueue> msg_queue,
-                   Core::System& system)
-    : ServiceFramework("appletAE"), nvflinger(nvflinger), msg_queue(std::move(msg_queue)),
-      system(system) {
+AppletAE::AppletAE(NVFlinger::NVFlinger& nvflinger_, std::shared_ptr<AppletMessageQueue> msg_queue_,
+                   Core::System& system_)
+    : ServiceFramework{system_, "appletAE"}, nvflinger{nvflinger_}, msg_queue{
+                                                                        std::move(msg_queue_)} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {100, &AppletAE::OpenSystemAppletProxy, "OpenSystemAppletProxy"},

--- a/src/core/hle/service/am/applet_ae.h
+++ b/src/core/hle/service/am/applet_ae.h
@@ -23,8 +23,8 @@ class AppletMessageQueue;
 
 class AppletAE final : public ServiceFramework<AppletAE> {
 public:
-    explicit AppletAE(NVFlinger::NVFlinger& nvflinger,
-                      std::shared_ptr<AppletMessageQueue> msg_queue, Core::System& system);
+    explicit AppletAE(NVFlinger::NVFlinger& nvflinger_,
+                      std::shared_ptr<AppletMessageQueue> msg_queue_, Core::System& system_);
     ~AppletAE() override;
 
     const std::shared_ptr<AppletMessageQueue>& GetMessageQueue() const;
@@ -36,7 +36,6 @@ private:
 
     NVFlinger::NVFlinger& nvflinger;
     std::shared_ptr<AppletMessageQueue> msg_queue;
-    Core::System& system;
 };
 
 } // namespace AM

--- a/src/core/hle/service/am/applet_oe.cpp
+++ b/src/core/hle/service/am/applet_oe.cpp
@@ -12,10 +12,11 @@ namespace Service::AM {
 
 class IApplicationProxy final : public ServiceFramework<IApplicationProxy> {
 public:
-    explicit IApplicationProxy(NVFlinger::NVFlinger& nvflinger,
-                               std::shared_ptr<AppletMessageQueue> msg_queue, Core::System& system)
-        : ServiceFramework("IApplicationProxy"), nvflinger(nvflinger),
-          msg_queue(std::move(msg_queue)), system(system) {
+    explicit IApplicationProxy(NVFlinger::NVFlinger& nvflinger_,
+                               std::shared_ptr<AppletMessageQueue> msg_queue_,
+                               Core::System& system_)
+        : ServiceFramework{system_, "IApplicationProxy"}, nvflinger{nvflinger_},
+          msg_queue{std::move(msg_queue_)} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IApplicationProxy::GetCommonStateGetter, "GetCommonStateGetter"},
@@ -39,7 +40,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IAudioController>();
+        rb.PushIpcInterface<IAudioController>(system);
     }
 
     void GetDisplayController(Kernel::HLERequestContext& ctx) {
@@ -47,7 +48,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IDisplayController>();
+        rb.PushIpcInterface<IDisplayController>(system);
     }
 
     void GetDebugFunctions(Kernel::HLERequestContext& ctx) {
@@ -55,7 +56,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IDebugFunctions>();
+        rb.PushIpcInterface<IDebugFunctions>(system);
     }
 
     void GetWindowController(Kernel::HLERequestContext& ctx) {
@@ -100,7 +101,6 @@ private:
 
     NVFlinger::NVFlinger& nvflinger;
     std::shared_ptr<AppletMessageQueue> msg_queue;
-    Core::System& system;
 };
 
 void AppletOE::OpenApplicationProxy(Kernel::HLERequestContext& ctx) {
@@ -111,10 +111,10 @@ void AppletOE::OpenApplicationProxy(Kernel::HLERequestContext& ctx) {
     rb.PushIpcInterface<IApplicationProxy>(nvflinger, msg_queue, system);
 }
 
-AppletOE::AppletOE(NVFlinger::NVFlinger& nvflinger, std::shared_ptr<AppletMessageQueue> msg_queue,
-                   Core::System& system)
-    : ServiceFramework("appletOE"), nvflinger(nvflinger), msg_queue(std::move(msg_queue)),
-      system(system) {
+AppletOE::AppletOE(NVFlinger::NVFlinger& nvflinger_, std::shared_ptr<AppletMessageQueue> msg_queue_,
+                   Core::System& system_)
+    : ServiceFramework{system_, "appletOE"}, nvflinger{nvflinger_}, msg_queue{
+                                                                        std::move(msg_queue_)} {
     static const FunctionInfo functions[] = {
         {0, &AppletOE::OpenApplicationProxy, "OpenApplicationProxy"},
     };

--- a/src/core/hle/service/am/applet_oe.h
+++ b/src/core/hle/service/am/applet_oe.h
@@ -23,8 +23,8 @@ class AppletMessageQueue;
 
 class AppletOE final : public ServiceFramework<AppletOE> {
 public:
-    explicit AppletOE(NVFlinger::NVFlinger& nvflinger,
-                      std::shared_ptr<AppletMessageQueue> msg_queue, Core::System& system);
+    explicit AppletOE(NVFlinger::NVFlinger& nvflinger_,
+                      std::shared_ptr<AppletMessageQueue> msg_queue_, Core::System& system_);
     ~AppletOE() override;
 
     const std::shared_ptr<AppletMessageQueue>& GetMessageQueue() const;
@@ -34,7 +34,6 @@ private:
 
     NVFlinger::NVFlinger& nvflinger;
     std::shared_ptr<AppletMessageQueue> msg_queue;
-    Core::System& system;
 };
 
 } // namespace AM

--- a/src/core/hle/service/am/applets/controller.cpp
+++ b/src/core/hle/service/am/applets/controller.cpp
@@ -46,7 +46,7 @@ static Core::Frontend::ControllerParameters ConvertToFrontendParameters(
 }
 
 Controller::Controller(Core::System& system_, const Core::Frontend::ControllerApplet& frontend_)
-    : Applet{system_.Kernel()}, frontend(frontend_) {}
+    : Applet{system_.Kernel()}, frontend{frontend_}, system{system_} {}
 
 Controller::~Controller() = default;
 
@@ -245,7 +245,7 @@ void Controller::ConfigurationComplete() {
     complete = true;
     out_data = std::vector<u8>(sizeof(ControllerSupportResultInfo));
     std::memcpy(out_data.data(), &result_info, out_data.size());
-    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(std::move(out_data)));
+    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(system, std::move(out_data)));
     broker.SignalStateChanged();
 }
 

--- a/src/core/hle/service/am/applets/controller.h
+++ b/src/core/hle/service/am/applets/controller.h
@@ -120,6 +120,7 @@ public:
 
 private:
     const Core::Frontend::ControllerApplet& frontend;
+    Core::System& system;
 
     ControllerAppletVersion controller_applet_version;
     ControllerSupportArgPrivate controller_private_arg;

--- a/src/core/hle/service/am/applets/error.cpp
+++ b/src/core/hle/service/am/applets/error.cpp
@@ -87,7 +87,7 @@ ResultCode Decode64BitError(u64 error) {
 } // Anonymous namespace
 
 Error::Error(Core::System& system_, const Core::Frontend::ErrorApplet& frontend_)
-    : Applet{system_.Kernel()}, frontend(frontend_), system{system_} {}
+    : Applet{system_.Kernel()}, frontend{frontend_}, system{system_} {}
 
 Error::~Error() = default;
 
@@ -186,7 +186,7 @@ void Error::Execute() {
 
 void Error::DisplayCompleted() {
     complete = true;
-    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(std::vector<u8>{}));
+    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(system, std::vector<u8>{}));
     broker.SignalStateChanged();
 }
 

--- a/src/core/hle/service/am/applets/general_backend.cpp
+++ b/src/core/hle/service/am/applets/general_backend.cpp
@@ -38,7 +38,7 @@ static void LogCurrentStorage(AppletDataBroker& broker, std::string_view prefix)
 }
 
 Auth::Auth(Core::System& system_, Core::Frontend::ParentalControlsApplet& frontend_)
-    : Applet{system_.Kernel()}, frontend(frontend_) {}
+    : Applet{system_.Kernel()}, frontend{frontend_}, system{system_} {}
 
 Auth::~Auth() = default;
 
@@ -135,8 +135,8 @@ void Auth::Execute() {
     }
 }
 
-void Auth::AuthFinished(bool successful) {
-    this->successful = successful;
+void Auth::AuthFinished(bool is_successful) {
+    this->successful = is_successful;
 
     struct Return {
         ResultCode result_code;
@@ -148,12 +148,12 @@ void Auth::AuthFinished(bool successful) {
     std::vector<u8> out(sizeof(Return));
     std::memcpy(out.data(), &return_, sizeof(Return));
 
-    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(std::move(out)));
+    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(system, std::move(out)));
     broker.SignalStateChanged();
 }
 
 PhotoViewer::PhotoViewer(Core::System& system_, const Core::Frontend::PhotoViewerApplet& frontend_)
-    : Applet{system_.Kernel()}, frontend(frontend_), system{system_} {}
+    : Applet{system_.Kernel()}, frontend{frontend_}, system{system_} {}
 
 PhotoViewer::~PhotoViewer() = default;
 
@@ -198,12 +198,12 @@ void PhotoViewer::Execute() {
 }
 
 void PhotoViewer::ViewFinished() {
-    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(std::vector<u8>{}));
+    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(system, std::vector<u8>{}));
     broker.SignalStateChanged();
 }
 
 StubApplet::StubApplet(Core::System& system_, AppletId id_)
-    : Applet{system_.Kernel()}, id(id_), system{system_} {}
+    : Applet{system_.Kernel()}, id{id_}, system{system_} {}
 
 StubApplet::~StubApplet() = default;
 
@@ -234,8 +234,9 @@ void StubApplet::ExecuteInteractive() {
     LOG_WARNING(Service_AM, "called (STUBBED)");
     LogCurrentStorage(broker, "ExecuteInteractive");
 
-    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(std::vector<u8>(0x1000)));
-    broker.PushInteractiveDataFromApplet(std::make_shared<IStorage>(std::vector<u8>(0x1000)));
+    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(system, std::vector<u8>(0x1000)));
+    broker.PushInteractiveDataFromApplet(
+        std::make_shared<IStorage>(system, std::vector<u8>(0x1000)));
     broker.SignalStateChanged();
 }
 
@@ -243,8 +244,9 @@ void StubApplet::Execute() {
     LOG_WARNING(Service_AM, "called (STUBBED)");
     LogCurrentStorage(broker, "Execute");
 
-    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(std::vector<u8>(0x1000)));
-    broker.PushInteractiveDataFromApplet(std::make_shared<IStorage>(std::vector<u8>(0x1000)));
+    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(system, std::vector<u8>(0x1000)));
+    broker.PushInteractiveDataFromApplet(
+        std::make_shared<IStorage>(system, std::vector<u8>(0x1000)));
     broker.SignalStateChanged();
 }
 

--- a/src/core/hle/service/am/applets/general_backend.h
+++ b/src/core/hle/service/am/applets/general_backend.h
@@ -29,10 +29,11 @@ public:
     void ExecuteInteractive() override;
     void Execute() override;
 
-    void AuthFinished(bool successful = true);
+    void AuthFinished(bool is_successful = true);
 
 private:
     Core::Frontend::ParentalControlsApplet& frontend;
+    Core::System& system;
     bool complete = false;
     bool successful = false;
 

--- a/src/core/hle/service/am/applets/profile_select.cpp
+++ b/src/core/hle/service/am/applets/profile_select.cpp
@@ -17,7 +17,7 @@ constexpr ResultCode ERR_USER_CANCELLED_SELECTION{ErrorModule::Account, 1};
 
 ProfileSelect::ProfileSelect(Core::System& system_,
                              const Core::Frontend::ProfileSelectApplet& frontend_)
-    : Applet{system_.Kernel()}, frontend(frontend_) {}
+    : Applet{system_.Kernel()}, frontend{frontend_}, system{system_} {}
 
 ProfileSelect::~ProfileSelect() = default;
 
@@ -50,7 +50,7 @@ void ProfileSelect::ExecuteInteractive() {
 
 void ProfileSelect::Execute() {
     if (complete) {
-        broker.PushNormalDataFromApplet(std::make_shared<IStorage>(std::move(final_data)));
+        broker.PushNormalDataFromApplet(std::make_shared<IStorage>(system, std::move(final_data)));
         return;
     }
 
@@ -71,7 +71,7 @@ void ProfileSelect::SelectionComplete(std::optional<Common::UUID> uuid) {
 
     final_data = std::vector<u8>(sizeof(UserSelectionOutput));
     std::memcpy(final_data.data(), &output, final_data.size());
-    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(std::move(final_data)));
+    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(system, std::move(final_data)));
     broker.SignalStateChanged();
 }
 

--- a/src/core/hle/service/am/applets/profile_select.h
+++ b/src/core/hle/service/am/applets/profile_select.h
@@ -53,6 +53,7 @@ private:
     bool complete = false;
     ResultCode status = RESULT_SUCCESS;
     std::vector<u8> final_data;
+    Core::System& system;
 };
 
 } // namespace Service::AM::Applets

--- a/src/core/hle/service/am/applets/software_keyboard.cpp
+++ b/src/core/hle/service/am/applets/software_keyboard.cpp
@@ -53,7 +53,7 @@ static Core::Frontend::SoftwareKeyboardParameters ConvertToFrontendParameters(
 
 SoftwareKeyboard::SoftwareKeyboard(Core::System& system_,
                                    const Core::Frontend::SoftwareKeyboardApplet& frontend_)
-    : Applet{system_.Kernel()}, frontend(frontend_) {}
+    : Applet{system_.Kernel()}, frontend{frontend_}, system{system_} {}
 
 SoftwareKeyboard::~SoftwareKeyboard() = default;
 
@@ -122,7 +122,7 @@ void SoftwareKeyboard::ExecuteInteractive() {
 
         switch (request) {
         case Request::Calc: {
-            broker.PushNormalDataFromApplet(std::make_shared<IStorage>(std::vector<u8>{1}));
+            broker.PushNormalDataFromApplet(std::make_shared<IStorage>(system, std::vector<u8>{1}));
             broker.SignalStateChanged();
             break;
         }
@@ -135,7 +135,7 @@ void SoftwareKeyboard::ExecuteInteractive() {
 
 void SoftwareKeyboard::Execute() {
     if (complete) {
-        broker.PushNormalDataFromApplet(std::make_shared<IStorage>(std::move(final_data)));
+        broker.PushNormalDataFromApplet(std::make_shared<IStorage>(system, std::move(final_data)));
         broker.SignalStateChanged();
         return;
     }
@@ -179,15 +179,17 @@ void SoftwareKeyboard::WriteText(std::optional<std::u16string> text) {
         final_data = output_main;
 
         if (complete) {
-            broker.PushNormalDataFromApplet(std::make_shared<IStorage>(std::move(output_main)));
+            broker.PushNormalDataFromApplet(
+                std::make_shared<IStorage>(system, std::move(output_main)));
             broker.SignalStateChanged();
         } else {
-            broker.PushInteractiveDataFromApplet(std::make_shared<IStorage>(std::move(output_sub)));
+            broker.PushInteractiveDataFromApplet(
+                std::make_shared<IStorage>(system, std::move(output_sub)));
         }
     } else {
         output_main[0] = 1;
         complete = true;
-        broker.PushNormalDataFromApplet(std::make_shared<IStorage>(std::move(output_main)));
+        broker.PushNormalDataFromApplet(std::make_shared<IStorage>(system, std::move(output_main)));
         broker.SignalStateChanged();
     }
 }

--- a/src/core/hle/service/am/applets/software_keyboard.h
+++ b/src/core/hle/service/am/applets/software_keyboard.h
@@ -80,6 +80,7 @@ private:
     bool complete = false;
     bool is_inline = false;
     std::vector<u8> final_data;
+    Core::System& system;
 };
 
 } // namespace Service::AM::Applets

--- a/src/core/hle/service/am/applets/web_browser.cpp
+++ b/src/core/hle/service/am/applets/web_browser.cpp
@@ -290,7 +290,7 @@ void WebBrowser::Finalize() {
     std::vector<u8> data(sizeof(WebCommonReturnValue));
     std::memcpy(data.data(), &out, sizeof(WebCommonReturnValue));
 
-    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(std::move(data)));
+    broker.PushNormalDataFromApplet(std::make_shared<IStorage>(system, std::move(data)));
     broker.SignalStateChanged();
 
     if (!temporary_dir.empty() && Common::FS::IsDirectory(temporary_dir)) {

--- a/src/core/hle/service/am/idle.cpp
+++ b/src/core/hle/service/am/idle.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::AM {
 
-IdleSys::IdleSys() : ServiceFramework{"idle:sys"} {
+IdleSys::IdleSys(Core::System& system_) : ServiceFramework{system_, "idle:sys"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "GetAutoPowerDownEvent"},

--- a/src/core/hle/service/am/idle.h
+++ b/src/core/hle/service/am/idle.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::AM {
 
 class IdleSys final : public ServiceFramework<IdleSys> {
 public:
-    explicit IdleSys();
+    explicit IdleSys(Core::System& system_);
     ~IdleSys() override;
 };
 

--- a/src/core/hle/service/am/omm.cpp
+++ b/src/core/hle/service/am/omm.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::AM {
 
-OMM::OMM() : ServiceFramework{"omm"} {
+OMM::OMM(Core::System& system_) : ServiceFramework{system_, "omm"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "GetOperationMode"},

--- a/src/core/hle/service/am/omm.h
+++ b/src/core/hle/service/am/omm.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::AM {
 
 class OMM final : public ServiceFramework<OMM> {
 public:
-    explicit OMM();
+    explicit OMM(Core::System& system_);
     ~OMM() override;
 };
 

--- a/src/core/hle/service/am/spsm.cpp
+++ b/src/core/hle/service/am/spsm.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::AM {
 
-SPSM::SPSM() : ServiceFramework{"spsm"} {
+SPSM::SPSM(Core::System& system_) : ServiceFramework{system_, "spsm"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "GetState"},

--- a/src/core/hle/service/am/spsm.h
+++ b/src/core/hle/service/am/spsm.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::AM {
 
 class SPSM final : public ServiceFramework<SPSM> {
 public:
-    explicit SPSM();
+    explicit SPSM(Core::System& system_);
     ~SPSM() override;
 };
 

--- a/src/core/hle/service/am/tcap.cpp
+++ b/src/core/hle/service/am/tcap.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::AM {
 
-TCAP::TCAP() : ServiceFramework{"tcap"} {
+TCAP::TCAP(Core::System& system_) : ServiceFramework{system_, "tcap"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "GetContinuousHighSkinTemperatureEvent"},

--- a/src/core/hle/service/am/tcap.h
+++ b/src/core/hle/service/am/tcap.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::AM {
 
 class TCAP final : public ServiceFramework<TCAP> {
 public:
-    explicit TCAP();
+    explicit TCAP(Core::System& system_);
     ~TCAP() override;
 };
 

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -48,8 +48,8 @@ static std::vector<u64> AccumulateAOCTitleIDs(Core::System& system) {
     return add_on_content;
 }
 
-AOC_U::AOC_U(Core::System& system)
-    : ServiceFramework("aoc:u"), add_on_content(AccumulateAOCTitleIDs(system)), system(system) {
+AOC_U::AOC_U(Core::System& system_)
+    : ServiceFramework{system_, "aoc:u"}, add_on_content{AccumulateAOCTitleIDs(system)} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "CountAddOnContentByApplicationId"},

--- a/src/core/hle/service/aoc/aoc_u.h
+++ b/src/core/hle/service/aoc/aoc_u.h
@@ -6,6 +6,10 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 class WritableEvent;
 }
@@ -26,7 +30,6 @@ private:
 
     std::vector<u64> add_on_content;
     Kernel::EventPair aoc_change_event;
-    Core::System& system;
 };
 
 /// Registers all AOC services with the specified service manager.

--- a/src/core/hle/service/apm/apm.cpp
+++ b/src/core/hle/service/apm/apm.cpp
@@ -14,13 +14,14 @@ Module::~Module() = default;
 
 void InstallInterfaces(Core::System& system) {
     auto module_ = std::make_shared<Module>();
-    std::make_shared<APM>(module_, system.GetAPMController(), "apm")
+    std::make_shared<APM>(system, module_, system.GetAPMController(), "apm")
         ->InstallAsService(system.ServiceManager());
-    std::make_shared<APM>(module_, system.GetAPMController(), "apm:p")
+    std::make_shared<APM>(system, module_, system.GetAPMController(), "apm:p")
         ->InstallAsService(system.ServiceManager());
-    std::make_shared<APM>(module_, system.GetAPMController(), "apm:am")
+    std::make_shared<APM>(system, module_, system.GetAPMController(), "apm:am")
         ->InstallAsService(system.ServiceManager());
-    std::make_shared<APM_Sys>(system.GetAPMController())->InstallAsService(system.ServiceManager());
+    std::make_shared<APM_Sys>(system, system.GetAPMController())
+        ->InstallAsService(system.ServiceManager());
 }
 
 } // namespace Service::APM

--- a/src/core/hle/service/apm/apm.h
+++ b/src/core/hle/service/apm/apm.h
@@ -4,7 +4,9 @@
 
 #pragma once
 
-#include "core/hle/service/service.h"
+namespace Core {
+class System;
+}
 
 namespace Service::APM {
 

--- a/src/core/hle/service/apm/interface.h
+++ b/src/core/hle/service/apm/interface.h
@@ -13,7 +13,8 @@ class Module;
 
 class APM final : public ServiceFramework<APM> {
 public:
-    explicit APM(std::shared_ptr<Module> apm, Controller& controller, const char* name);
+    explicit APM(Core::System& system_, std::shared_ptr<Module> apm_, Controller& controller_,
+                 const char* name);
     ~APM() override;
 
 private:
@@ -26,7 +27,7 @@ private:
 
 class APM_Sys final : public ServiceFramework<APM_Sys> {
 public:
-    explicit APM_Sys(Controller& controller);
+    explicit APM_Sys(Core::System& system_, Controller& controller);
     ~APM_Sys() override;
 
     void SetCpuBoostMode(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/audio/audctl.cpp
+++ b/src/core/hle/service/audio/audctl.cpp
@@ -8,7 +8,7 @@
 
 namespace Service::Audio {
 
-AudCtl::AudCtl() : ServiceFramework{"audctl"} {
+AudCtl::AudCtl(Core::System& system_) : ServiceFramework{system_, "audctl"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "GetTargetVolume"},

--- a/src/core/hle/service/audio/audctl.h
+++ b/src/core/hle/service/audio/audctl.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Audio {
 
 class AudCtl final : public ServiceFramework<AudCtl> {
 public:
-    explicit AudCtl();
+    explicit AudCtl(Core::System& system_);
     ~AudCtl() override;
 
 private:

--- a/src/core/hle/service/audio/auddbg.cpp
+++ b/src/core/hle/service/audio/auddbg.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::Audio {
 
-AudDbg::AudDbg(const char* name) : ServiceFramework{name} {
+AudDbg::AudDbg(Core::System& system_, const char* name) : ServiceFramework{system_, name} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "RequestSuspendForDebug"},

--- a/src/core/hle/service/audio/auddbg.h
+++ b/src/core/hle/service/audio/auddbg.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Audio {
 
 class AudDbg final : public ServiceFramework<AudDbg> {
 public:
-    explicit AudDbg(const char* name);
+    explicit AudDbg(Core::System& system_, const char* name);
     ~AudDbg() override;
 };
 

--- a/src/core/hle/service/audio/audin_a.cpp
+++ b/src/core/hle/service/audio/audin_a.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::Audio {
 
-AudInA::AudInA() : ServiceFramework{"audin:a"} {
+AudInA::AudInA(Core::System& system_) : ServiceFramework{system_, "audin:a"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "RequestSuspendAudioIns"},

--- a/src/core/hle/service/audio/audin_a.h
+++ b/src/core/hle/service/audio/audin_a.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Audio {
 
 class AudInA final : public ServiceFramework<AudInA> {
 public:
-    explicit AudInA();
+    explicit AudInA(Core::System& system_);
     ~AudInA() override;
 };
 

--- a/src/core/hle/service/audio/audin_u.cpp
+++ b/src/core/hle/service/audio/audin_u.cpp
@@ -11,7 +11,7 @@ namespace Service::Audio {
 
 class IAudioIn final : public ServiceFramework<IAudioIn> {
 public:
-    IAudioIn() : ServiceFramework("IAudioIn") {
+    explicit IAudioIn(Core::System& system_) : ServiceFramework{system_, "IAudioIn"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetAudioInState"},
@@ -36,7 +36,7 @@ public:
     }
 };
 
-AudInU::AudInU() : ServiceFramework("audin:u") {
+AudInU::AudInU(Core::System& system_) : ServiceFramework{system_, "audin:u"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &AudInU::ListAudioIns, "ListAudioIns"},
@@ -96,7 +96,7 @@ void AudInU::OpenInOutImpl(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 6, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushRaw<AudInOutParams>(params);
-    rb.PushIpcInterface<IAudioIn>();
+    rb.PushIpcInterface<IAudioIn>(system);
 }
 
 void AudInU::OpenAudioIn(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/audio/audin_u.h
+++ b/src/core/hle/service/audio/audin_u.h
@@ -6,6 +6,10 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 class HLERequestContext;
 }
@@ -14,7 +18,7 @@ namespace Service::Audio {
 
 class AudInU final : public ServiceFramework<AudInU> {
 public:
-    explicit AudInU();
+    explicit AudInU(Core::System& system_);
     ~AudInU() override;
 
 private:

--- a/src/core/hle/service/audio/audio.cpp
+++ b/src/core/hle/service/audio/audio.cpp
@@ -20,22 +20,22 @@
 namespace Service::Audio {
 
 void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {
-    std::make_shared<AudCtl>()->InstallAsService(service_manager);
-    std::make_shared<AudOutA>()->InstallAsService(service_manager);
+    std::make_shared<AudCtl>(system)->InstallAsService(service_manager);
+    std::make_shared<AudOutA>(system)->InstallAsService(service_manager);
     std::make_shared<AudOutU>(system)->InstallAsService(service_manager);
-    std::make_shared<AudInA>()->InstallAsService(service_manager);
-    std::make_shared<AudInU>()->InstallAsService(service_manager);
-    std::make_shared<AudRecA>()->InstallAsService(service_manager);
-    std::make_shared<AudRecU>()->InstallAsService(service_manager);
-    std::make_shared<AudRenA>()->InstallAsService(service_manager);
+    std::make_shared<AudInA>(system)->InstallAsService(service_manager);
+    std::make_shared<AudInU>(system)->InstallAsService(service_manager);
+    std::make_shared<AudRecA>(system)->InstallAsService(service_manager);
+    std::make_shared<AudRecU>(system)->InstallAsService(service_manager);
+    std::make_shared<AudRenA>(system)->InstallAsService(service_manager);
     std::make_shared<AudRenU>(system)->InstallAsService(service_manager);
-    std::make_shared<CodecCtl>()->InstallAsService(service_manager);
-    std::make_shared<HwOpus>()->InstallAsService(service_manager);
+    std::make_shared<CodecCtl>(system)->InstallAsService(service_manager);
+    std::make_shared<HwOpus>(system)->InstallAsService(service_manager);
 
-    std::make_shared<AudDbg>("audin:d")->InstallAsService(service_manager);
-    std::make_shared<AudDbg>("audout:d")->InstallAsService(service_manager);
-    std::make_shared<AudDbg>("audrec:d")->InstallAsService(service_manager);
-    std::make_shared<AudDbg>("audren:d")->InstallAsService(service_manager);
+    std::make_shared<AudDbg>(system, "audin:d")->InstallAsService(service_manager);
+    std::make_shared<AudDbg>(system, "audout:d")->InstallAsService(service_manager);
+    std::make_shared<AudDbg>(system, "audrec:d")->InstallAsService(service_manager);
+    std::make_shared<AudDbg>(system, "audren:d")->InstallAsService(service_manager);
 }
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audout_a.cpp
+++ b/src/core/hle/service/audio/audout_a.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::Audio {
 
-AudOutA::AudOutA() : ServiceFramework{"audout:a"} {
+AudOutA::AudOutA(Core::System& system_) : ServiceFramework{system_, "audout:a"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "RequestSuspendAudioOuts"},

--- a/src/core/hle/service/audio/audout_a.h
+++ b/src/core/hle/service/audio/audout_a.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Audio {
 
 class AudOutA final : public ServiceFramework<AudOutA> {
 public:
-    explicit AudOutA();
+    explicit AudOutA(Core::System& system_);
     ~AudOutA() override;
 };
 

--- a/src/core/hle/service/audio/audout_u.cpp
+++ b/src/core/hle/service/audio/audout_u.cpp
@@ -40,11 +40,11 @@ enum class AudioState : u32 {
 
 class IAudioOut final : public ServiceFramework<IAudioOut> {
 public:
-    IAudioOut(Core::System& system, AudoutParams audio_params, AudioCore::AudioOut& audio_core,
-              std::string&& device_name, std::string&& unique_name)
-        : ServiceFramework("IAudioOut"), audio_core(audio_core),
-          device_name(std::move(device_name)),
-          audio_params(audio_params), main_memory{system.Memory()} {
+    IAudioOut(Core::System& system_, AudoutParams audio_params_, AudioCore::AudioOut& audio_core_,
+              std::string&& device_name_, std::string&& unique_name)
+        : ServiceFramework{system_, "IAudioOut"}, audio_core{audio_core_},
+          device_name{std::move(device_name_)}, audio_params{audio_params_}, main_memory{
+                                                                                 system.Memory()} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IAudioOut::GetAudioOutState, "GetAudioOutState"},
@@ -213,7 +213,7 @@ private:
     Core::Memory::Memory& main_memory;
 };
 
-AudOutU::AudOutU(Core::System& system_) : ServiceFramework("audout:u"), system{system_} {
+AudOutU::AudOutU(Core::System& system_) : ServiceFramework{system_, "audout:u"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &AudOutU::ListAudioOutsImpl, "ListAudioOuts"},

--- a/src/core/hle/service/audio/audout_u.h
+++ b/src/core/hle/service/audio/audout_u.h
@@ -34,8 +34,6 @@ private:
 
     std::vector<std::shared_ptr<IAudioOut>> audio_out_interfaces;
     std::unique_ptr<AudioCore::AudioOut> audio_core;
-
-    Core::System& system;
 };
 
 } // namespace Service::Audio

--- a/src/core/hle/service/audio/audrec_a.cpp
+++ b/src/core/hle/service/audio/audrec_a.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::Audio {
 
-AudRecA::AudRecA() : ServiceFramework{"audrec:a"} {
+AudRecA::AudRecA(Core::System& system_) : ServiceFramework{system_, "audrec:a"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "RequestSuspendFinalOutputRecorders"},

--- a/src/core/hle/service/audio/audrec_a.h
+++ b/src/core/hle/service/audio/audrec_a.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Audio {
 
 class AudRecA final : public ServiceFramework<AudRecA> {
 public:
-    explicit AudRecA();
+    explicit AudRecA(Core::System& system_);
     ~AudRecA() override;
 };
 

--- a/src/core/hle/service/audio/audrec_u.cpp
+++ b/src/core/hle/service/audio/audrec_u.cpp
@@ -8,7 +8,8 @@ namespace Service::Audio {
 
 class IFinalOutputRecorder final : public ServiceFramework<IFinalOutputRecorder> {
 public:
-    IFinalOutputRecorder() : ServiceFramework("IFinalOutputRecorder") {
+    explicit IFinalOutputRecorder(Core::System& system_)
+        : ServiceFramework{system_, "IFinalOutputRecorder"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetFinalOutputRecorderState"},
@@ -29,7 +30,7 @@ public:
     }
 };
 
-AudRecU::AudRecU() : ServiceFramework("audrec:u") {
+AudRecU::AudRecU(Core::System& system_) : ServiceFramework{system_, "audrec:u"} {
     static const FunctionInfo functions[] = {
         {0, nullptr, "OpenFinalOutputRecorder"},
     };

--- a/src/core/hle/service/audio/audrec_u.h
+++ b/src/core/hle/service/audio/audrec_u.h
@@ -6,15 +6,15 @@
 
 #include "core/hle/service/service.h"
 
-namespace Kernel {
-class HLERequestContext;
+namespace Core {
+class System;
 }
 
 namespace Service::Audio {
 
 class AudRecU final : public ServiceFramework<AudRecU> {
 public:
-    explicit AudRecU();
+    explicit AudRecU(Core::System& system_);
     ~AudRecU() override;
 };
 

--- a/src/core/hle/service/audio/audren_a.cpp
+++ b/src/core/hle/service/audio/audren_a.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::Audio {
 
-AudRenA::AudRenA() : ServiceFramework{"audren:a"} {
+AudRenA::AudRenA(Core::System& system_) : ServiceFramework{system_, "audren:a"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "RequestSuspendAudioRenderers"},

--- a/src/core/hle/service/audio/audren_a.h
+++ b/src/core/hle/service/audio/audren_a.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Audio {
 
 class AudRenA final : public ServiceFramework<AudRenA> {
 public:
-    explicit AudRenA();
+    explicit AudRenA(Core::System& system_);
     ~AudRenA() override;
 };
 

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -28,7 +28,7 @@ class IAudioRenderer final : public ServiceFramework<IAudioRenderer> {
 public:
     explicit IAudioRenderer(Core::System& system, AudioCommon::AudioRendererParameter audren_params,
                             const std::size_t instance_number)
-        : ServiceFramework("IAudioRenderer") {
+        : ServiceFramework{system, "IAudioRenderer"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IAudioRenderer::GetSampleRate, "GetSampleRate"},
@@ -167,8 +167,8 @@ private:
 
 class IAudioDevice final : public ServiceFramework<IAudioDevice> {
 public:
-    explicit IAudioDevice(Core::System& system, u32_le revision_num)
-        : ServiceFramework("IAudioDevice"), revision{revision_num} {
+    explicit IAudioDevice(Core::System& system_, u32_le revision_num)
+        : ServiceFramework{system_, "IAudioDevice"}, revision{revision_num} {
         static const FunctionInfo functions[] = {
             {0, &IAudioDevice::ListAudioDeviceName, "ListAudioDeviceName"},
             {1, &IAudioDevice::SetAudioDeviceOutputVolume, "SetAudioDeviceOutputVolume"},
@@ -325,7 +325,7 @@ private:
 
 }; // namespace Audio
 
-AudRenU::AudRenU(Core::System& system_) : ServiceFramework("audren:u"), system{system_} {
+AudRenU::AudRenU(Core::System& system_) : ServiceFramework{system_, "audren:u"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &AudRenU::OpenAudioRenderer, "OpenAudioRenderer"},

--- a/src/core/hle/service/audio/audren_u.h
+++ b/src/core/hle/service/audio/audren_u.h
@@ -31,7 +31,6 @@ private:
     void OpenAudioRendererImpl(Kernel::HLERequestContext& ctx);
 
     std::size_t audren_instance_count = 0;
-    Core::System& system;
 };
 
 // Describes a particular audio feature that may be supported in a particular revision.

--- a/src/core/hle/service/audio/codecctl.cpp
+++ b/src/core/hle/service/audio/codecctl.cpp
@@ -2,14 +2,11 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "common/logging/log.h"
-#include "core/hle/ipc_helpers.h"
-#include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/service/audio/codecctl.h"
 
 namespace Service::Audio {
 
-CodecCtl::CodecCtl() : ServiceFramework("codecctl") {
+CodecCtl::CodecCtl(Core::System& system_) : ServiceFramework{system_, "codecctl"} {
     static const FunctionInfo functions[] = {
         {0, nullptr, "InitializeCodecController"},
         {1, nullptr, "FinalizeCodecController"},

--- a/src/core/hle/service/audio/codecctl.h
+++ b/src/core/hle/service/audio/codecctl.h
@@ -6,15 +6,15 @@
 
 #include "core/hle/service/service.h"
 
-namespace Kernel {
-class HLERequestContext;
+namespace Core {
+class System;
 }
 
 namespace Service::Audio {
 
 class CodecCtl final : public ServiceFramework<CodecCtl> {
 public:
-    explicit CodecCtl();
+    explicit CodecCtl(Core::System& system_);
     ~CodecCtl() override;
 };
 

--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -160,8 +160,9 @@ private:
 
 class IHardwareOpusDecoderManager final : public ServiceFramework<IHardwareOpusDecoderManager> {
 public:
-    explicit IHardwareOpusDecoderManager(OpusDecoderState decoder_state)
-        : ServiceFramework("IHardwareOpusDecoderManager"), decoder_state{std::move(decoder_state)} {
+    explicit IHardwareOpusDecoderManager(Core::System& system_, OpusDecoderState decoder_state)
+        : ServiceFramework{system_, "IHardwareOpusDecoderManager"}, decoder_state{
+                                                                        std::move(decoder_state)} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IHardwareOpusDecoderManager::DecodeInterleavedOld, "DecodeInterleavedOld"},
@@ -287,10 +288,10 @@ void HwOpus::OpenOpusDecoder(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushIpcInterface<IHardwareOpusDecoderManager>(
-        OpusDecoderState{std::move(decoder), sample_rate, channel_count});
+        system, OpusDecoderState{std::move(decoder), sample_rate, channel_count});
 }
 
-HwOpus::HwOpus() : ServiceFramework("hwopus") {
+HwOpus::HwOpus(Core::System& system_) : ServiceFramework{system_, "hwopus"} {
     static const FunctionInfo functions[] = {
         {0, &HwOpus::OpenOpusDecoder, "OpenOpusDecoder"},
         {1, &HwOpus::GetWorkBufferSize, "GetWorkBufferSize"},

--- a/src/core/hle/service/audio/hwopus.h
+++ b/src/core/hle/service/audio/hwopus.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Audio {
 
 class HwOpus final : public ServiceFramework<HwOpus> {
 public:
-    explicit HwOpus();
+    explicit HwOpus(Core::System& system_);
     ~HwOpus() override;
 
 private:

--- a/src/core/hle/service/bcat/module.h
+++ b/src/core/hle/service/bcat/module.h
@@ -37,9 +37,6 @@ public:
 
         std::shared_ptr<Module> module;
         std::unique_ptr<Backend> backend;
-
-    private:
-        Core::System& system;
     };
 };
 

--- a/src/core/hle/service/bpc/bpc.cpp
+++ b/src/core/hle/service/bpc/bpc.cpp
@@ -12,7 +12,7 @@ namespace Service::BPC {
 
 class BPC final : public ServiceFramework<BPC> {
 public:
-    explicit BPC() : ServiceFramework{"bpc"} {
+    explicit BPC(Core::System& system_) : ServiceFramework{system_, "bpc"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "ShutdownSystem"},
@@ -40,7 +40,7 @@ public:
 
 class BPC_R final : public ServiceFramework<BPC_R> {
 public:
-    explicit BPC_R() : ServiceFramework{"bpc:r"} {
+    explicit BPC_R(Core::System& system_) : ServiceFramework{system_, "bpc:r"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetRtcTime"},
@@ -55,9 +55,9 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<BPC>()->InstallAsService(sm);
-    std::make_shared<BPC_R>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<BPC>(system)->InstallAsService(sm);
+    std::make_shared<BPC_R>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::BPC

--- a/src/core/hle/service/bpc/bpc.h
+++ b/src/core/hle/service/bpc/bpc.h
@@ -4,12 +4,16 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::BPC {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::BPC

--- a/src/core/hle/service/btdrv/btdrv.cpp
+++ b/src/core/hle/service/btdrv/btdrv.cpp
@@ -17,7 +17,7 @@ namespace Service::BtDrv {
 
 class Bt final : public ServiceFramework<Bt> {
 public:
-    explicit Bt(Core::System& system) : ServiceFramework{"bt"} {
+    explicit Bt(Core::System& system_) : ServiceFramework{system_, "bt"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "LeClientReadCharacteristic"},
@@ -52,7 +52,7 @@ private:
 
 class BtDrv final : public ServiceFramework<BtDrv> {
 public:
-    explicit BtDrv() : ServiceFramework{"btdrv"} {
+    explicit BtDrv(Core::System& system_) : ServiceFramework{system_, "btdrv"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "InitializeBluetoothDriver"},
@@ -166,7 +166,7 @@ public:
 };
 
 void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
-    std::make_shared<BtDrv>()->InstallAsService(sm);
+    std::make_shared<BtDrv>(system)->InstallAsService(sm);
     std::make_shared<Bt>(system)->InstallAsService(sm);
 }
 

--- a/src/core/hle/service/btm/btm.cpp
+++ b/src/core/hle/service/btm/btm.cpp
@@ -18,7 +18,7 @@ namespace Service::BTM {
 
 class IBtmUserCore final : public ServiceFramework<IBtmUserCore> {
 public:
-    explicit IBtmUserCore(Core::System& system) : ServiceFramework{"IBtmUserCore"} {
+    explicit IBtmUserCore(Core::System& system_) : ServiceFramework{system_, "IBtmUserCore"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IBtmUserCore::AcquireBleScanEvent, "AcquireBleScanEvent"},
@@ -107,7 +107,7 @@ private:
 
 class BTM_USR final : public ServiceFramework<BTM_USR> {
 public:
-    explicit BTM_USR(Core::System& system) : ServiceFramework{"btm:u"}, system(system) {
+    explicit BTM_USR(Core::System& system_) : ServiceFramework{system_, "btm:u"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &BTM_USR::GetCore, "GetCore"},
@@ -124,13 +124,11 @@ private:
         rb.Push(RESULT_SUCCESS);
         rb.PushIpcInterface<IBtmUserCore>(system);
     }
-
-    Core::System& system;
 };
 
 class BTM final : public ServiceFramework<BTM> {
 public:
-    explicit BTM() : ServiceFramework{"btm"} {
+    explicit BTM(Core::System& system_) : ServiceFramework{system_, "btm"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetState"},
@@ -207,7 +205,7 @@ public:
 
 class BTM_DBG final : public ServiceFramework<BTM_DBG> {
 public:
-    explicit BTM_DBG() : ServiceFramework{"btm:dbg"} {
+    explicit BTM_DBG(Core::System& system_) : ServiceFramework{system_, "btm:dbg"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "AcquireDiscoveryEvent"},
@@ -232,7 +230,7 @@ public:
 
 class IBtmSystemCore final : public ServiceFramework<IBtmSystemCore> {
 public:
-    explicit IBtmSystemCore() : ServiceFramework{"IBtmSystemCore"} {
+    explicit IBtmSystemCore(Core::System& system_) : ServiceFramework{system_, "IBtmSystemCore"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "StartGamepadPairing"},
@@ -254,7 +252,7 @@ public:
 
 class BTM_SYS final : public ServiceFramework<BTM_SYS> {
 public:
-    explicit BTM_SYS() : ServiceFramework{"btm:sys"} {
+    explicit BTM_SYS(Core::System& system_) : ServiceFramework{system_, "btm:sys"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &BTM_SYS::GetCore, "GetCore"},
@@ -270,14 +268,14 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IBtmSystemCore>();
+        rb.PushIpcInterface<IBtmSystemCore>(system);
     }
 };
 
 void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
-    std::make_shared<BTM>()->InstallAsService(sm);
-    std::make_shared<BTM_DBG>()->InstallAsService(sm);
-    std::make_shared<BTM_SYS>()->InstallAsService(sm);
+    std::make_shared<BTM>(system)->InstallAsService(sm);
+    std::make_shared<BTM_DBG>(system)->InstallAsService(sm);
+    std::make_shared<BTM_SYS>(system)->InstallAsService(sm);
     std::make_shared<BTM_USR>(system)->InstallAsService(sm);
 }
 

--- a/src/core/hle/service/caps/caps.cpp
+++ b/src/core/hle/service/caps/caps.cpp
@@ -13,13 +13,13 @@
 
 namespace Service::Capture {
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<CAPS_A>()->InstallAsService(sm);
-    std::make_shared<CAPS_C>()->InstallAsService(sm);
-    std::make_shared<CAPS_U>()->InstallAsService(sm);
-    std::make_shared<CAPS_SC>()->InstallAsService(sm);
-    std::make_shared<CAPS_SS>()->InstallAsService(sm);
-    std::make_shared<CAPS_SU>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<CAPS_A>(system)->InstallAsService(sm);
+    std::make_shared<CAPS_C>(system)->InstallAsService(sm);
+    std::make_shared<CAPS_U>(system)->InstallAsService(sm);
+    std::make_shared<CAPS_SC>(system)->InstallAsService(sm);
+    std::make_shared<CAPS_SS>(system)->InstallAsService(sm);
+    std::make_shared<CAPS_SU>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::Capture

--- a/src/core/hle/service/caps/caps.h
+++ b/src/core/hle/service/caps/caps.h
@@ -6,6 +6,10 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
@@ -87,6 +91,6 @@ static_assert(sizeof(ApplicationAlbumFileEntry) == 0x30,
               "ApplicationAlbumFileEntry has incorrect size.");
 
 /// Registers all Capture services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::Capture

--- a/src/core/hle/service/caps/caps_a.cpp
+++ b/src/core/hle/service/caps/caps_a.cpp
@@ -8,7 +8,8 @@ namespace Service::Capture {
 
 class IAlbumAccessorSession final : public ServiceFramework<IAlbumAccessorSession> {
 public:
-    explicit IAlbumAccessorSession() : ServiceFramework{"IAlbumAccessorSession"} {
+    explicit IAlbumAccessorSession(Core::System& system_)
+        : ServiceFramework{system_, "IAlbumAccessorSession"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {2001, nullptr, "OpenAlbumMovieReadStream"},
@@ -26,7 +27,7 @@ public:
     }
 };
 
-CAPS_A::CAPS_A() : ServiceFramework("caps:a") {
+CAPS_A::CAPS_A(Core::System& system_) : ServiceFramework{system_, "caps:a"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "GetAlbumFileCount"},

--- a/src/core/hle/service/caps/caps_a.h
+++ b/src/core/hle/service/caps/caps_a.h
@@ -6,6 +6,10 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 class HLERequestContext;
 }
@@ -14,7 +18,7 @@ namespace Service::Capture {
 
 class CAPS_A final : public ServiceFramework<CAPS_A> {
 public:
-    explicit CAPS_A();
+    explicit CAPS_A(Core::System& system_);
     ~CAPS_A() override;
 };
 

--- a/src/core/hle/service/caps/caps_c.cpp
+++ b/src/core/hle/service/caps/caps_c.cpp
@@ -10,7 +10,8 @@ namespace Service::Capture {
 
 class IAlbumControlSession final : public ServiceFramework<IAlbumControlSession> {
 public:
-    explicit IAlbumControlSession() : ServiceFramework{"IAlbumControlSession"} {
+    explicit IAlbumControlSession(Core::System& system_)
+        : ServiceFramework{system_, "IAlbumControlSession"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {2001, nullptr, "OpenAlbumMovieReadStream"},
@@ -44,7 +45,7 @@ public:
     }
 };
 
-CAPS_C::CAPS_C() : ServiceFramework("caps:c") {
+CAPS_C::CAPS_C(Core::System& system_) : ServiceFramework{system_, "caps:c"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {1, nullptr, "CaptureRawImage"},

--- a/src/core/hle/service/caps/caps_c.h
+++ b/src/core/hle/service/caps/caps_c.h
@@ -6,6 +6,10 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 class HLERequestContext;
 }
@@ -14,7 +18,7 @@ namespace Service::Capture {
 
 class CAPS_C final : public ServiceFramework<CAPS_C> {
 public:
-    explicit CAPS_C();
+    explicit CAPS_C(Core::System& system_);
     ~CAPS_C() override;
 
 private:

--- a/src/core/hle/service/caps/caps_sc.cpp
+++ b/src/core/hle/service/caps/caps_sc.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::Capture {
 
-CAPS_SC::CAPS_SC() : ServiceFramework("caps:sc") {
+CAPS_SC::CAPS_SC(Core::System& system_) : ServiceFramework{system_, "caps:sc"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {1, nullptr, "CaptureRawImage"},

--- a/src/core/hle/service/caps/caps_sc.h
+++ b/src/core/hle/service/caps/caps_sc.h
@@ -6,15 +6,15 @@
 
 #include "core/hle/service/service.h"
 
-namespace Kernel {
-class HLERequestContext;
+namespace Core {
+class System;
 }
 
 namespace Service::Capture {
 
 class CAPS_SC final : public ServiceFramework<CAPS_SC> {
 public:
-    explicit CAPS_SC();
+    explicit CAPS_SC(Core::System& system_);
     ~CAPS_SC() override;
 };
 

--- a/src/core/hle/service/caps/caps_ss.cpp
+++ b/src/core/hle/service/caps/caps_ss.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::Capture {
 
-CAPS_SS::CAPS_SS() : ServiceFramework("caps:ss") {
+CAPS_SS::CAPS_SS(Core::System& system_) : ServiceFramework{system_, "caps:ss"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {201, nullptr, "SaveScreenShot"},

--- a/src/core/hle/service/caps/caps_ss.h
+++ b/src/core/hle/service/caps/caps_ss.h
@@ -6,15 +6,15 @@
 
 #include "core/hle/service/service.h"
 
-namespace Kernel {
-class HLERequestContext;
+namespace Core {
+class System;
 }
 
 namespace Service::Capture {
 
 class CAPS_SS final : public ServiceFramework<CAPS_SS> {
 public:
-    explicit CAPS_SS();
+    explicit CAPS_SS(Core::System& system_);
     ~CAPS_SS() override;
 };
 

--- a/src/core/hle/service/caps/caps_su.cpp
+++ b/src/core/hle/service/caps/caps_su.cpp
@@ -8,7 +8,7 @@
 
 namespace Service::Capture {
 
-CAPS_SU::CAPS_SU() : ServiceFramework("caps:su") {
+CAPS_SU::CAPS_SU(Core::System& system_) : ServiceFramework{system_, "caps:su"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {32, &CAPS_SU::SetShimLibraryVersion, "SetShimLibraryVersion"},

--- a/src/core/hle/service/caps/caps_su.h
+++ b/src/core/hle/service/caps/caps_su.h
@@ -6,6 +6,10 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 class HLERequestContext;
 }
@@ -14,7 +18,7 @@ namespace Service::Capture {
 
 class CAPS_SU final : public ServiceFramework<CAPS_SU> {
 public:
-    explicit CAPS_SU();
+    explicit CAPS_SU(Core::System& system_);
     ~CAPS_SU() override;
 
 private:

--- a/src/core/hle/service/caps/caps_u.cpp
+++ b/src/core/hle/service/caps/caps_u.cpp
@@ -12,8 +12,8 @@ namespace Service::Capture {
 class IAlbumAccessorApplicationSession final
     : public ServiceFramework<IAlbumAccessorApplicationSession> {
 public:
-    explicit IAlbumAccessorApplicationSession()
-        : ServiceFramework{"IAlbumAccessorApplicationSession"} {
+    explicit IAlbumAccessorApplicationSession(Core::System& system_)
+        : ServiceFramework{system_, "IAlbumAccessorApplicationSession"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {2001, nullptr, "OpenAlbumMovieReadStream"},
@@ -28,7 +28,7 @@ public:
     }
 };
 
-CAPS_U::CAPS_U() : ServiceFramework("caps:u") {
+CAPS_U::CAPS_U(Core::System& system_) : ServiceFramework{system_, "caps:u"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {32, &CAPS_U::SetShimLibraryVersion, "SetShimLibraryVersion"},

--- a/src/core/hle/service/caps/caps_u.h
+++ b/src/core/hle/service/caps/caps_u.h
@@ -6,6 +6,10 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 class HLERequestContext;
 }
@@ -14,7 +18,7 @@ namespace Service::Capture {
 
 class CAPS_U final : public ServiceFramework<CAPS_U> {
 public:
-    explicit CAPS_U();
+    explicit CAPS_U(Core::System& system_);
     ~CAPS_U() override;
 
 private:

--- a/src/core/hle/service/erpt/erpt.cpp
+++ b/src/core/hle/service/erpt/erpt.cpp
@@ -12,7 +12,7 @@ namespace Service::ERPT {
 
 class ErrorReportContext final : public ServiceFramework<ErrorReportContext> {
 public:
-    explicit ErrorReportContext() : ServiceFramework{"erpt:c"} {
+    explicit ErrorReportContext(Core::System& system_) : ServiceFramework{system_, "erpt:c"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "SubmitContext"},
@@ -35,7 +35,7 @@ public:
 
 class ErrorReportSession final : public ServiceFramework<ErrorReportSession> {
 public:
-    explicit ErrorReportSession() : ServiceFramework{"erpt:r"} {
+    explicit ErrorReportSession(Core::System& system_) : ServiceFramework{system_, "erpt:r"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "OpenReport"},
@@ -48,9 +48,9 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<ErrorReportContext>()->InstallAsService(sm);
-    std::make_shared<ErrorReportSession>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<ErrorReportContext>(system)->InstallAsService(sm);
+    std::make_shared<ErrorReportSession>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::ERPT

--- a/src/core/hle/service/erpt/erpt.h
+++ b/src/core/hle/service/erpt/erpt.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
@@ -11,6 +15,6 @@ class ServiceManager;
 namespace Service::ERPT {
 
 /// Registers all ERPT services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::ERPT

--- a/src/core/hle/service/es/es.cpp
+++ b/src/core/hle/service/es/es.cpp
@@ -14,7 +14,7 @@ constexpr ResultCode ERROR_INVALID_RIGHTS_ID{ErrorModule::ETicket, 3};
 
 class ETicket final : public ServiceFramework<ETicket> {
 public:
-    explicit ETicket() : ServiceFramework{"es"} {
+    explicit ETicket(Core::System& system_) : ServiceFramework{system_, "es"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {1, &ETicket::ImportTicket, "ImportTicket"},
@@ -305,8 +305,8 @@ private:
     Core::Crypto::KeyManager& keys = Core::Crypto::KeyManager::Instance();
 };
 
-void InstallInterfaces(SM::ServiceManager& service_manager) {
-    std::make_shared<ETicket>()->InstallAsService(service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {
+    std::make_shared<ETicket>(system)->InstallAsService(service_manager);
 }
 
 } // namespace Service::ES

--- a/src/core/hle/service/es/es.h
+++ b/src/core/hle/service/es/es.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
@@ -11,6 +15,6 @@ class ServiceManager;
 namespace Service::ES {
 
 /// Registers all ES services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace Service::ES

--- a/src/core/hle/service/eupld/eupld.cpp
+++ b/src/core/hle/service/eupld/eupld.cpp
@@ -12,7 +12,7 @@ namespace Service::EUPLD {
 
 class ErrorUploadContext final : public ServiceFramework<ErrorUploadContext> {
 public:
-    explicit ErrorUploadContext() : ServiceFramework{"eupld:c"} {
+    explicit ErrorUploadContext(Core::System& system_) : ServiceFramework{system_, "eupld:c"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "SetUrl"},
@@ -29,7 +29,7 @@ public:
 
 class ErrorUploadRequest final : public ServiceFramework<ErrorUploadRequest> {
 public:
-    explicit ErrorUploadRequest() : ServiceFramework{"eupld:r"} {
+    explicit ErrorUploadRequest(Core::System& system_) : ServiceFramework{system_, "eupld:r"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
@@ -45,9 +45,9 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<ErrorUploadContext>()->InstallAsService(sm);
-    std::make_shared<ErrorUploadRequest>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<ErrorUploadContext>(system)->InstallAsService(sm);
+    std::make_shared<ErrorUploadRequest>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::EUPLD

--- a/src/core/hle/service/eupld/eupld.h
+++ b/src/core/hle/service/eupld/eupld.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
@@ -11,6 +15,6 @@ class ServiceManager;
 namespace Service::EUPLD {
 
 /// Registers all EUPLD services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::EUPLD

--- a/src/core/hle/service/fatal/fatal.cpp
+++ b/src/core/hle/service/fatal/fatal.cpp
@@ -20,8 +20,9 @@
 
 namespace Service::Fatal {
 
-Module::Interface::Interface(std::shared_ptr<Module> module, Core::System& system, const char* name)
-    : ServiceFramework(name), module(std::move(module)), system(system) {}
+Module::Interface::Interface(std::shared_ptr<Module> module_, Core::System& system_,
+                             const char* name)
+    : ServiceFramework{system_, name}, module{std::move(module_)} {}
 
 Module::Interface::~Interface() = default;
 

--- a/src/core/hle/service/fatal/fatal.h
+++ b/src/core/hle/service/fatal/fatal.h
@@ -16,7 +16,8 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        explicit Interface(std::shared_ptr<Module> module, Core::System& system, const char* name);
+        explicit Interface(std::shared_ptr<Module> module_, Core::System& system_,
+                           const char* name);
         ~Interface() override;
 
         void ThrowFatal(Kernel::HLERequestContext& ctx);
@@ -25,7 +26,6 @@ public:
 
     protected:
         std::shared_ptr<Module> module;
-        Core::System& system;
     };
 };
 

--- a/src/core/hle/service/fatal/fatal_p.cpp
+++ b/src/core/hle/service/fatal/fatal_p.cpp
@@ -6,8 +6,8 @@
 
 namespace Service::Fatal {
 
-Fatal_P::Fatal_P(std::shared_ptr<Module> module, Core::System& system)
-    : Module::Interface(std::move(module), system, "fatal:p") {}
+Fatal_P::Fatal_P(std::shared_ptr<Module> module_, Core::System& system_)
+    : Interface(std::move(module_), system_, "fatal:p") {}
 
 Fatal_P::~Fatal_P() = default;
 

--- a/src/core/hle/service/fatal/fatal_p.h
+++ b/src/core/hle/service/fatal/fatal_p.h
@@ -10,7 +10,7 @@ namespace Service::Fatal {
 
 class Fatal_P final : public Module::Interface {
 public:
-    explicit Fatal_P(std::shared_ptr<Module> module, Core::System& system);
+    explicit Fatal_P(std::shared_ptr<Module> module_, Core::System& system_);
     ~Fatal_P() override;
 };
 

--- a/src/core/hle/service/fatal/fatal_u.cpp
+++ b/src/core/hle/service/fatal/fatal_u.cpp
@@ -6,8 +6,8 @@
 
 namespace Service::Fatal {
 
-Fatal_U::Fatal_U(std::shared_ptr<Module> module, Core::System& system)
-    : Module::Interface(std::move(module), system, "fatal:u") {
+Fatal_U::Fatal_U(std::shared_ptr<Module> module_, Core::System& system_)
+    : Interface(std::move(module_), system_, "fatal:u") {
     static const FunctionInfo functions[] = {
         {0, &Fatal_U::ThrowFatal, "ThrowFatal"},
         {1, &Fatal_U::ThrowFatalWithPolicy, "ThrowFatalWithPolicy"},

--- a/src/core/hle/service/fatal/fatal_u.h
+++ b/src/core/hle/service/fatal/fatal_u.h
@@ -10,7 +10,7 @@ namespace Service::Fatal {
 
 class Fatal_U final : public Module::Interface {
 public:
-    explicit Fatal_U(std::shared_ptr<Module> module, Core::System& system);
+    explicit Fatal_U(std::shared_ptr<Module> module_, Core::System& system_);
     ~Fatal_U() override;
 };
 

--- a/src/core/hle/service/fgm/fgm.cpp
+++ b/src/core/hle/service/fgm/fgm.cpp
@@ -14,7 +14,7 @@ namespace Service::FGM {
 
 class IRequest final : public ServiceFramework<IRequest> {
 public:
-    explicit IRequest() : ServiceFramework{"IRequest"} {
+    explicit IRequest(Core::System& system_) : ServiceFramework{system_, "IRequest"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
@@ -30,7 +30,7 @@ public:
 
 class FGM final : public ServiceFramework<FGM> {
 public:
-    explicit FGM(const char* name) : ServiceFramework{name} {
+    explicit FGM(Core::System& system_, const char* name) : ServiceFramework{system_, name} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &FGM::Initialize, "Initialize"},
@@ -46,13 +46,13 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IRequest>();
+        rb.PushIpcInterface<IRequest>(system);
     }
 };
 
 class FGM_DBG final : public ServiceFramework<FGM_DBG> {
 public:
-    explicit FGM_DBG() : ServiceFramework{"fgm:dbg"} {
+    explicit FGM_DBG(Core::System& system_) : ServiceFramework{system_, "fgm:dbg"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
@@ -65,11 +65,11 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<FGM>("fgm")->InstallAsService(sm);
-    std::make_shared<FGM>("fgm:0")->InstallAsService(sm);
-    std::make_shared<FGM>("fgm:9")->InstallAsService(sm);
-    std::make_shared<FGM_DBG>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<FGM>(system, "fgm")->InstallAsService(sm);
+    std::make_shared<FGM>(system, "fgm:0")->InstallAsService(sm);
+    std::make_shared<FGM>(system, "fgm:9")->InstallAsService(sm);
+    std::make_shared<FGM_DBG>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::FGM

--- a/src/core/hle/service/fgm/fgm.h
+++ b/src/core/hle/service/fgm/fgm.h
@@ -4,12 +4,16 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::FGM {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::FGM

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -728,11 +728,9 @@ void FileSystemController::CreateFactories(FileSys::VfsFilesystem& vfs, bool ove
 }
 
 void InstallInterfaces(Core::System& system) {
-    std::make_shared<FSP_LDR>()->InstallAsService(system.ServiceManager());
-    std::make_shared<FSP_PR>()->InstallAsService(system.ServiceManager());
-    std::make_shared<FSP_SRV>(system.GetFileSystemController(), system.GetContentProvider(),
-                              system.GetReporter())
-        ->InstallAsService(system.ServiceManager());
+    std::make_shared<FSP_LDR>(system)->InstallAsService(system.ServiceManager());
+    std::make_shared<FSP_PR>(system)->InstallAsService(system.ServiceManager());
+    std::make_shared<FSP_SRV>(system)->InstallAsService(system.ServiceManager());
 }
 
 } // namespace Service::FileSystem

--- a/src/core/hle/service/filesystem/fsp_ldr.cpp
+++ b/src/core/hle/service/filesystem/fsp_ldr.cpp
@@ -7,7 +7,7 @@
 
 namespace Service::FileSystem {
 
-FSP_LDR::FSP_LDR() : ServiceFramework{"fsp:ldr"} {
+FSP_LDR::FSP_LDR(Core::System& system_) : ServiceFramework{system_, "fsp:ldr"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "OpenCodeFileSystem"},

--- a/src/core/hle/service/filesystem/fsp_ldr.h
+++ b/src/core/hle/service/filesystem/fsp_ldr.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::FileSystem {
 
 class FSP_LDR final : public ServiceFramework<FSP_LDR> {
 public:
-    explicit FSP_LDR();
+    explicit FSP_LDR(Core::System& system_);
     ~FSP_LDR() override;
 };
 

--- a/src/core/hle/service/filesystem/fsp_pr.cpp
+++ b/src/core/hle/service/filesystem/fsp_pr.cpp
@@ -7,7 +7,7 @@
 
 namespace Service::FileSystem {
 
-FSP_PR::FSP_PR() : ServiceFramework{"fsp:pr"} {
+FSP_PR::FSP_PR(Core::System& system_) : ServiceFramework{system_, "fsp:pr"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "RegisterProgram"},

--- a/src/core/hle/service/filesystem/fsp_pr.h
+++ b/src/core/hle/service/filesystem/fsp_pr.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::FileSystem {
 
 class FSP_PR final : public ServiceFramework<FSP_PR> {
 public:
-    explicit FSP_PR();
+    explicit FSP_PR(Core::System& system_);
     ~FSP_PR() override;
 };
 

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -14,6 +14,7 @@
 #include "common/hex_util.h"
 #include "common/logging/log.h"
 #include "common/string_util.h"
+#include "core/core.h"
 #include "core/file_sys/directory.h"
 #include "core/file_sys/errors.h"
 #include "core/file_sys/mode.h"
@@ -56,8 +57,8 @@ enum class FileSystemType : u8 {
 
 class IStorage final : public ServiceFramework<IStorage> {
 public:
-    explicit IStorage(FileSys::VirtualFile backend_)
-        : ServiceFramework("IStorage"), backend(std::move(backend_)) {
+    explicit IStorage(Core::System& system_, FileSys::VirtualFile backend_)
+        : ServiceFramework{system_, "IStorage"}, backend(std::move(backend_)) {
         static const FunctionInfo functions[] = {
             {0, &IStorage::Read, "Read"},
             {1, nullptr, "Write"},
@@ -114,8 +115,8 @@ private:
 
 class IFile final : public ServiceFramework<IFile> {
 public:
-    explicit IFile(FileSys::VirtualFile backend_)
-        : ServiceFramework("IFile"), backend(std::move(backend_)) {
+    explicit IFile(Core::System& system_, FileSys::VirtualFile backend_)
+        : ServiceFramework{system_, "IFile"}, backend(std::move(backend_)) {
         static const FunctionInfo functions[] = {
             {0, &IFile::Read, "Read"},       {1, &IFile::Write, "Write"},
             {2, &IFile::Flush, "Flush"},     {3, &IFile::SetSize, "SetSize"},
@@ -246,8 +247,8 @@ static void BuildEntryIndex(std::vector<FileSys::Entry>& entries, const std::vec
 
 class IDirectory final : public ServiceFramework<IDirectory> {
 public:
-    explicit IDirectory(FileSys::VirtualDir backend_)
-        : ServiceFramework("IDirectory"), backend(std::move(backend_)) {
+    explicit IDirectory(Core::System& system_, FileSys::VirtualDir backend_)
+        : ServiceFramework{system_, "IDirectory"}, backend(std::move(backend_)) {
         static const FunctionInfo functions[] = {
             {0, &IDirectory::Read, "Read"},
             {1, &IDirectory::GetEntryCount, "GetEntryCount"},
@@ -302,8 +303,9 @@ private:
 
 class IFileSystem final : public ServiceFramework<IFileSystem> {
 public:
-    explicit IFileSystem(FileSys::VirtualDir backend, SizeGetter size)
-        : ServiceFramework("IFileSystem"), backend(std::move(backend)), size(std::move(size)) {
+    explicit IFileSystem(Core::System& system_, FileSys::VirtualDir backend_, SizeGetter size_)
+        : ServiceFramework{system_, "IFileSystem"}, backend{std::move(backend_)}, size{std::move(
+                                                                                      size_)} {
         static const FunctionInfo functions[] = {
             {0, &IFileSystem::CreateFile, "CreateFile"},
             {1, &IFileSystem::DeleteFile, "DeleteFile"},
@@ -420,7 +422,7 @@ public:
             return;
         }
 
-        auto file = std::make_shared<IFile>(result.Unwrap());
+        auto file = std::make_shared<IFile>(system, result.Unwrap());
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
@@ -445,7 +447,7 @@ public:
             return;
         }
 
-        auto directory = std::make_shared<IDirectory>(result.Unwrap());
+        auto directory = std::make_shared<IDirectory>(system, result.Unwrap());
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
@@ -500,8 +502,9 @@ private:
 
 class ISaveDataInfoReader final : public ServiceFramework<ISaveDataInfoReader> {
 public:
-    explicit ISaveDataInfoReader(FileSys::SaveDataSpaceId space, FileSystemController& fsc)
-        : ServiceFramework("ISaveDataInfoReader"), fsc(fsc) {
+    explicit ISaveDataInfoReader(Core::System& system_, FileSys::SaveDataSpaceId space,
+                                 FileSystemController& fsc_)
+        : ServiceFramework{system_, "ISaveDataInfoReader"}, fsc{fsc_} {
         static const FunctionInfo functions[] = {
             {0, &ISaveDataInfoReader::ReadSaveDataInfo, "ReadSaveDataInfo"},
         };
@@ -650,10 +653,9 @@ private:
     u64 next_entry_index = 0;
 };
 
-FSP_SRV::FSP_SRV(FileSystemController& fsc_, const FileSys::ContentProvider& content_provider_,
-                 const Core::Reporter& reporter_)
-    : ServiceFramework("fsp-srv"), fsc(fsc_), content_provider{content_provider_},
-      reporter(reporter_) {
+FSP_SRV::FSP_SRV(Core::System& system_)
+    : ServiceFramework{system_, "fsp-srv"}, fsc{system.GetFileSystemController()},
+      content_provider{system.GetContentProvider()}, reporter{system.GetReporter()} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "OpenFileSystem"},
@@ -803,8 +805,9 @@ void FSP_SRV::OpenFileSystemWithPatch(Kernel::HLERequestContext& ctx) {
 void FSP_SRV::OpenSdCardFileSystem(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_FS, "called");
 
-    auto filesystem = std::make_shared<IFileSystem>(
-        fsc.OpenSDMC().Unwrap(), SizeGetter::FromStorageId(fsc, FileSys::StorageId::SdCard));
+    auto filesystem =
+        std::make_shared<IFileSystem>(system, fsc.OpenSDMC().Unwrap(),
+                                      SizeGetter::FromStorageId(fsc, FileSys::StorageId::SdCard));
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
@@ -864,8 +867,8 @@ void FSP_SRV::OpenSaveDataFileSystem(Kernel::HLERequestContext& ctx) {
         UNREACHABLE();
     }
 
-    auto filesystem =
-        std::make_shared<IFileSystem>(std::move(dir.Unwrap()), SizeGetter::FromStorageId(fsc, id));
+    auto filesystem = std::make_shared<IFileSystem>(system, std::move(dir.Unwrap()),
+                                                    SizeGetter::FromStorageId(fsc, id));
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
@@ -884,7 +887,8 @@ void FSP_SRV::OpenSaveDataInfoReaderBySaveDataSpaceId(Kernel::HLERequestContext&
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
-    rb.PushIpcInterface<ISaveDataInfoReader>(std::make_shared<ISaveDataInfoReader>(space, fsc));
+    rb.PushIpcInterface<ISaveDataInfoReader>(
+        std::make_shared<ISaveDataInfoReader>(system, space, fsc));
 }
 
 void FSP_SRV::WriteSaveDataFileSystemExtraDataBySaveDataAttribute(Kernel::HLERequestContext& ctx) {
@@ -933,7 +937,7 @@ void FSP_SRV::OpenDataStorageByCurrentProcess(Kernel::HLERequestContext& ctx) {
         return;
     }
 
-    auto storage = std::make_shared<IStorage>(std::move(romfs.Unwrap()));
+    auto storage = std::make_shared<IStorage>(system, std::move(romfs.Unwrap()));
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
@@ -957,7 +961,7 @@ void FSP_SRV::OpenDataStorageByDataId(Kernel::HLERequestContext& ctx) {
         if (archive != nullptr) {
             IPC::ResponseBuilder rb{ctx, 2, 0, 1};
             rb.Push(RESULT_SUCCESS);
-            rb.PushIpcInterface(std::make_shared<IStorage>(archive));
+            rb.PushIpcInterface(std::make_shared<IStorage>(system, archive));
             return;
         }
 
@@ -973,7 +977,7 @@ void FSP_SRV::OpenDataStorageByDataId(Kernel::HLERequestContext& ctx) {
     const FileSys::PatchManager pm{title_id, fsc, content_provider};
 
     auto storage = std::make_shared<IStorage>(
-        pm.PatchRomFS(std::move(data.Unwrap()), 0, FileSys::ContentRecordType::Data));
+        system, pm.PatchRomFS(std::move(data.Unwrap()), 0, FileSys::ContentRecordType::Data));
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
@@ -1035,7 +1039,8 @@ void FSP_SRV::GetAccessLogVersionInfo(Kernel::HLERequestContext& ctx) {
 
 class IMultiCommitManager final : public ServiceFramework<IMultiCommitManager> {
 public:
-    explicit IMultiCommitManager() : ServiceFramework("IMultiCommitManager") {
+    explicit IMultiCommitManager(Core::System& system_)
+        : ServiceFramework{system_, "IMultiCommitManager"} {
         static const FunctionInfo functions[] = {
             {1, &IMultiCommitManager::Add, "Add"},
             {2, &IMultiCommitManager::Commit, "Commit"},
@@ -1066,7 +1071,7 @@ void FSP_SRV::OpenMultiCommitManager(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
-    rb.PushIpcInterface<IMultiCommitManager>(std::make_shared<IMultiCommitManager>());
+    rb.PushIpcInterface<IMultiCommitManager>(std::make_shared<IMultiCommitManager>(system));
 }
 
 } // namespace Service::FileSystem

--- a/src/core/hle/service/filesystem/fsp_srv.h
+++ b/src/core/hle/service/filesystem/fsp_srv.h
@@ -33,8 +33,7 @@ enum class LogMode : u32 {
 
 class FSP_SRV final : public ServiceFramework<FSP_SRV> {
 public:
-    explicit FSP_SRV(FileSystemController& fsc_, const FileSys::ContentProvider& content_provider_,
-                     const Core::Reporter& reporter_);
+    explicit FSP_SRV(Core::System& system_);
     ~FSP_SRV() override;
 
 private:

--- a/src/core/hle/service/friend/friend.cpp
+++ b/src/core/hle/service/friend/friend.cpp
@@ -17,7 +17,7 @@ namespace Service::Friend {
 
 class IFriendService final : public ServiceFramework<IFriendService> {
 public:
-    IFriendService() : ServiceFramework("IFriendService") {
+    explicit IFriendService(Core::System& system_) : ServiceFramework{system_, "IFriendService"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetCompletionEvent"},
@@ -171,8 +171,8 @@ private:
 
 class INotificationService final : public ServiceFramework<INotificationService> {
 public:
-    INotificationService(Common::UUID uuid, Core::System& system)
-        : ServiceFramework("INotificationService"), uuid(uuid) {
+    explicit INotificationService(Common::UUID uuid_, Core::System& system_)
+        : ServiceFramework{system_, "INotificationService"}, uuid{uuid_} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &INotificationService::GetEvent, "GetEvent"},
@@ -267,7 +267,7 @@ private:
 void Module::Interface::CreateFriendService(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
-    rb.PushIpcInterface<IFriendService>();
+    rb.PushIpcInterface<IFriendService>(system);
     LOG_DEBUG(Service_ACC, "called");
 }
 
@@ -282,8 +282,9 @@ void Module::Interface::CreateNotificationService(Kernel::HLERequestContext& ctx
     rb.PushIpcInterface<INotificationService>(uuid, system);
 }
 
-Module::Interface::Interface(std::shared_ptr<Module> module, Core::System& system, const char* name)
-    : ServiceFramework(name), module(std::move(module)), system(system) {}
+Module::Interface::Interface(std::shared_ptr<Module> module_, Core::System& system_,
+                             const char* name)
+    : ServiceFramework{system_, name}, module{std::move(module_)} {}
 
 Module::Interface::~Interface() = default;
 

--- a/src/core/hle/service/friend/friend.h
+++ b/src/core/hle/service/friend/friend.h
@@ -16,7 +16,8 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        explicit Interface(std::shared_ptr<Module> module, Core::System& system, const char* name);
+        explicit Interface(std::shared_ptr<Module> module_, Core::System& system_,
+                           const char* name);
         ~Interface() override;
 
         void CreateFriendService(Kernel::HLERequestContext& ctx);
@@ -24,7 +25,6 @@ public:
 
     protected:
         std::shared_ptr<Module> module;
-        Core::System& system;
     };
 };
 

--- a/src/core/hle/service/friend/interface.cpp
+++ b/src/core/hle/service/friend/interface.cpp
@@ -6,8 +6,8 @@
 
 namespace Service::Friend {
 
-Friend::Friend(std::shared_ptr<Module> module, Core::System& system, const char* name)
-    : Interface(std::move(module), system, name) {
+Friend::Friend(std::shared_ptr<Module> module_, Core::System& system_, const char* name)
+    : Interface(std::move(module_), system_, name) {
     static const FunctionInfo functions[] = {
         {0, &Friend::CreateFriendService, "CreateFriendService"},
         {1, &Friend::CreateNotificationService, "CreateNotificationService"},

--- a/src/core/hle/service/friend/interface.h
+++ b/src/core/hle/service/friend/interface.h
@@ -10,7 +10,7 @@ namespace Service::Friend {
 
 class Friend final : public Module::Interface {
 public:
-    explicit Friend(std::shared_ptr<Module> module, Core::System& system, const char* name);
+    explicit Friend(std::shared_ptr<Module> module_, Core::System& system_, const char* name);
     ~Friend() override;
 };
 

--- a/src/core/hle/service/glue/arp.cpp
+++ b/src/core/hle/service/glue/arp.cpp
@@ -33,8 +33,8 @@ std::optional<u64> GetTitleIDForProcessID(const Core::System& system, u64 proces
 }
 } // Anonymous namespace
 
-ARP_R::ARP_R(const Core::System& system, const ARPManager& manager)
-    : ServiceFramework{"arp:r"}, system(system), manager(manager) {
+ARP_R::ARP_R(Core::System& system_, const ARPManager& manager_)
+    : ServiceFramework{system_, "arp:r"}, manager{manager_} {
     // clang-format off
         static const FunctionInfo functions[] = {
             {0, &ARP_R::GetApplicationLaunchProperty, "GetApplicationLaunchProperty"},
@@ -152,8 +152,9 @@ class IRegistrar final : public ServiceFramework<IRegistrar> {
 
 public:
     explicit IRegistrar(
+        Core::System& system_,
         std::function<ResultCode(u64, ApplicationLaunchProperty, std::vector<u8>)> issuer)
-        : ServiceFramework{"IRegistrar"}, issue_process_id(std::move(issuer)) {
+        : ServiceFramework{system_, "IRegistrar"}, issue_process_id{std::move(issuer)} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IRegistrar::Issue, "Issue"},
@@ -237,8 +238,8 @@ private:
     std::vector<u8> control;
 };
 
-ARP_W::ARP_W(const Core::System& system, ARPManager& manager)
-    : ServiceFramework{"arp:w"}, system(system), manager(manager) {
+ARP_W::ARP_W(Core::System& system_, ARPManager& manager_)
+    : ServiceFramework{system_, "arp:w"}, manager{manager_} {
     // clang-format off
         static const FunctionInfo functions[] = {
             {0, &ARP_W::AcquireRegistrar, "AcquireRegistrar"},
@@ -255,7 +256,7 @@ void ARP_W::AcquireRegistrar(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_ARP, "called");
 
     registrar = std::make_shared<IRegistrar>(
-        [this](u64 process_id, ApplicationLaunchProperty launch, std::vector<u8> control) {
+        system, [this](u64 process_id, ApplicationLaunchProperty launch, std::vector<u8> control) {
             const auto res = GetTitleIDForProcessID(system, process_id);
             if (!res.has_value()) {
                 return ERR_NOT_REGISTERED;

--- a/src/core/hle/service/glue/arp.h
+++ b/src/core/hle/service/glue/arp.h
@@ -13,7 +13,7 @@ class IRegistrar;
 
 class ARP_R final : public ServiceFramework<ARP_R> {
 public:
-    explicit ARP_R(const Core::System& system, const ARPManager& manager);
+    explicit ARP_R(Core::System& system_, const ARPManager& manager_);
     ~ARP_R() override;
 
 private:
@@ -22,20 +22,18 @@ private:
     void GetApplicationControlProperty(Kernel::HLERequestContext& ctx);
     void GetApplicationControlPropertyWithApplicationId(Kernel::HLERequestContext& ctx);
 
-    const Core::System& system;
     const ARPManager& manager;
 };
 
 class ARP_W final : public ServiceFramework<ARP_W> {
 public:
-    explicit ARP_W(const Core::System& system, ARPManager& manager);
+    explicit ARP_W(Core::System& system_, ARPManager& manager_);
     ~ARP_W() override;
 
 private:
     void AcquireRegistrar(Kernel::HLERequestContext& ctx);
     void DeleteProperties(Kernel::HLERequestContext& ctx);
 
-    const Core::System& system;
     ARPManager& manager;
     std::shared_ptr<IRegistrar> registrar;
 };

--- a/src/core/hle/service/glue/bgtc.cpp
+++ b/src/core/hle/service/glue/bgtc.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::Glue {
 
-BGTC_T::BGTC_T() : ServiceFramework{"bgtc:t"} {
+BGTC_T::BGTC_T(Core::System& system_) : ServiceFramework{system_, "bgtc:t"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {1, nullptr, "NotifyTaskStarting"},
@@ -31,7 +31,7 @@ BGTC_T::BGTC_T() : ServiceFramework{"bgtc:t"} {
 
 BGTC_T::~BGTC_T() = default;
 
-BGTC_SC::BGTC_SC() : ServiceFramework{"bgtc:sc"} {
+BGTC_SC::BGTC_SC(Core::System& system_) : ServiceFramework{system_, "bgtc:sc"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {1, nullptr, "GetState"},

--- a/src/core/hle/service/glue/bgtc.h
+++ b/src/core/hle/service/glue/bgtc.h
@@ -6,17 +6,21 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Glue {
 
 class BGTC_T final : public ServiceFramework<BGTC_T> {
 public:
-    BGTC_T();
+    explicit BGTC_T(Core::System& system_);
     ~BGTC_T() override;
 };
 
 class BGTC_SC final : public ServiceFramework<BGTC_SC> {
 public:
-    BGTC_SC();
+    explicit BGTC_SC(Core::System& system_);
     ~BGTC_SC() override;
 };
 

--- a/src/core/hle/service/glue/glue.cpp
+++ b/src/core/hle/service/glue/glue.cpp
@@ -18,8 +18,8 @@ void InstallInterfaces(Core::System& system) {
         ->InstallAsService(system.ServiceManager());
 
     // BackGround Task Controller
-    std::make_shared<BGTC_T>()->InstallAsService(system.ServiceManager());
-    std::make_shared<BGTC_SC>()->InstallAsService(system.ServiceManager());
+    std::make_shared<BGTC_T>(system)->InstallAsService(system.ServiceManager());
+    std::make_shared<BGTC_SC>(system)->InstallAsService(system.ServiceManager());
 }
 
 } // namespace Service::Glue

--- a/src/core/hle/service/grc/grc.cpp
+++ b/src/core/hle/service/grc/grc.cpp
@@ -12,7 +12,7 @@ namespace Service::GRC {
 
 class GRC final : public ServiceFramework<GRC> {
 public:
-    explicit GRC() : ServiceFramework{"grc:c"} {
+    explicit GRC(Core::System& system) : ServiceFramework{system, "grc:c"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {1, nullptr, "OpenContinuousRecorder"},
@@ -27,8 +27,8 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<GRC>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<GRC>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::GRC

--- a/src/core/hle/service/grc/grc.h
+++ b/src/core/hle/service/grc/grc.h
@@ -4,12 +4,16 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::GRC {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::GRC

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -41,7 +41,7 @@ enum class HidController : std::size_t {
 
 class IAppletResource final : public ServiceFramework<IAppletResource> {
 public:
-    explicit IAppletResource(Core::System& system);
+    explicit IAppletResource(Core::System& system_);
     ~IAppletResource() override;
 
     void ActivateController(HidController controller);
@@ -71,7 +71,6 @@ private:
 
     std::shared_ptr<Core::Timing::EventType> pad_update_event;
     std::shared_ptr<Core::Timing::EventType> motion_update_event;
-    Core::System& system;
 
     std::array<std::unique_ptr<ControllerBase>, static_cast<size_t>(HidController::MaxControllers)>
         controllers{};
@@ -79,7 +78,7 @@ private:
 
 class Hid final : public ServiceFramework<Hid> {
 public:
-    explicit Hid(Core::System& system);
+    explicit Hid(Core::System& system_);
     ~Hid() override;
 
     std::shared_ptr<IAppletResource> GetAppletResource();
@@ -164,7 +163,6 @@ private:
     static_assert(sizeof(VibrationDeviceInfo) == 0x8, "VibrationDeviceInfo has incorrect size.");
 
     std::shared_ptr<IAppletResource> applet_resource;
-    Core::System& system;
 };
 
 /// Reload input devices. Used when input configuration changed

--- a/src/core/hle/service/hid/irs.cpp
+++ b/src/core/hle/service/hid/irs.cpp
@@ -12,7 +12,7 @@
 
 namespace Service::HID {
 
-IRS::IRS(Core::System& system) : ServiceFramework{"irs"}, system(system) {
+IRS::IRS(Core::System& system_) : ServiceFramework{system_, "irs"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {302, &IRS::ActivateIrsensor, "ActivateIrsensor"},
@@ -175,7 +175,7 @@ void IRS::ActivateIrsensorWithFunctionLevel(Kernel::HLERequestContext& ctx) {
 
 IRS::~IRS() = default;
 
-IRS_SYS::IRS_SYS() : ServiceFramework{"irs:sys"} {
+IRS_SYS::IRS_SYS(Core::System& system_) : ServiceFramework{system_, "irs:sys"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {500, nullptr, "SetAppletResourceUserId"},

--- a/src/core/hle/service/hid/irs.h
+++ b/src/core/hle/service/hid/irs.h
@@ -7,6 +7,10 @@
 #include "core/hle/kernel/object.h"
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 class SharedMemory;
 }
@@ -15,7 +19,7 @@ namespace Service::HID {
 
 class IRS final : public ServiceFramework<IRS> {
 public:
-    explicit IRS(Core::System& system);
+    explicit IRS(Core::System& system_);
     ~IRS() override;
 
 private:
@@ -37,14 +41,14 @@ private:
     void RunIrLedProcessor(Kernel::HLERequestContext& ctx);
     void StopImageProcessorAsync(Kernel::HLERequestContext& ctx);
     void ActivateIrsensorWithFunctionLevel(Kernel::HLERequestContext& ctx);
+
     std::shared_ptr<Kernel::SharedMemory> shared_mem;
     const u32 device_handle{0xABCD};
-    Core::System& system;
 };
 
 class IRS_SYS final : public ServiceFramework<IRS_SYS> {
 public:
-    explicit IRS_SYS();
+    explicit IRS_SYS(Core::System& system);
     ~IRS_SYS() override;
 };
 

--- a/src/core/hle/service/hid/xcd.cpp
+++ b/src/core/hle/service/hid/xcd.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::HID {
 
-XCD_SYS::XCD_SYS() : ServiceFramework{"xcd:sys"} {
+XCD_SYS::XCD_SYS(Core::System& system_) : ServiceFramework{system_, "xcd:sys"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "GetDataFormat"},

--- a/src/core/hle/service/hid/xcd.h
+++ b/src/core/hle/service/hid/xcd.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::HID {
 
 class XCD_SYS final : public ServiceFramework<XCD_SYS> {
 public:
-    explicit XCD_SYS();
+    explicit XCD_SYS(Core::System& system_);
     ~XCD_SYS() override;
 };
 

--- a/src/core/hle/service/lbl/lbl.cpp
+++ b/src/core/hle/service/lbl/lbl.cpp
@@ -15,7 +15,7 @@ namespace Service::LBL {
 
 class LBL final : public ServiceFramework<LBL> {
 public:
-    explicit LBL() : ServiceFramework{"lbl"} {
+    explicit LBL(Core::System& system_) : ServiceFramework{system_, "lbl"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "SaveCurrentSetting"},
@@ -84,8 +84,8 @@ private:
     bool vr_mode_enabled = false;
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<LBL>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<LBL>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::LBL

--- a/src/core/hle/service/lbl/lbl.h
+++ b/src/core/hle/service/lbl/lbl.h
@@ -4,12 +4,16 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::LBL {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::LBL

--- a/src/core/hle/service/ldn/ldn.cpp
+++ b/src/core/hle/service/ldn/ldn.cpp
@@ -13,7 +13,7 @@ namespace Service::LDN {
 
 class IMonitorService final : public ServiceFramework<IMonitorService> {
 public:
-    explicit IMonitorService() : ServiceFramework{"IMonitorService"} {
+    explicit IMonitorService(Core::System& system_) : ServiceFramework{system_, "IMonitorService"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetStateForMonitor"},
@@ -33,7 +33,7 @@ public:
 
 class LDNM final : public ServiceFramework<LDNM> {
 public:
-    explicit LDNM() : ServiceFramework{"ldn:m"} {
+    explicit LDNM(Core::System& system_) : ServiceFramework{system_, "ldn:m"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &LDNM::CreateMonitorService, "CreateMonitorService"}
@@ -48,15 +48,15 @@ public:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IMonitorService>();
+        rb.PushIpcInterface<IMonitorService>(system);
     }
 };
 
 class ISystemLocalCommunicationService final
     : public ServiceFramework<ISystemLocalCommunicationService> {
 public:
-    explicit ISystemLocalCommunicationService()
-        : ServiceFramework{"ISystemLocalCommunicationService"} {
+    explicit ISystemLocalCommunicationService(Core::System& system_)
+        : ServiceFramework{system_, "ISystemLocalCommunicationService"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetState"},
@@ -99,7 +99,8 @@ public:
 class IUserLocalCommunicationService final
     : public ServiceFramework<IUserLocalCommunicationService> {
 public:
-    explicit IUserLocalCommunicationService() : ServiceFramework{"IUserLocalCommunicationService"} {
+    explicit IUserLocalCommunicationService(Core::System& system_)
+        : ServiceFramework{system_, "IUserLocalCommunicationService"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetState"},
@@ -148,7 +149,7 @@ public:
 
 class LDNS final : public ServiceFramework<LDNS> {
 public:
-    explicit LDNS() : ServiceFramework{"ldn:s"} {
+    explicit LDNS(Core::System& system_) : ServiceFramework{system_, "ldn:s"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &LDNS::CreateSystemLocalCommunicationService, "CreateSystemLocalCommunicationService"},
@@ -163,13 +164,13 @@ public:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<ISystemLocalCommunicationService>();
+        rb.PushIpcInterface<ISystemLocalCommunicationService>(system);
     }
 };
 
 class LDNU final : public ServiceFramework<LDNU> {
 public:
-    explicit LDNU() : ServiceFramework{"ldn:u"} {
+    explicit LDNU(Core::System& system_) : ServiceFramework{system_, "ldn:u"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &LDNU::CreateUserLocalCommunicationService, "CreateUserLocalCommunicationService"},
@@ -184,14 +185,14 @@ public:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IUserLocalCommunicationService>();
+        rb.PushIpcInterface<IUserLocalCommunicationService>(system);
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<LDNM>()->InstallAsService(sm);
-    std::make_shared<LDNS>()->InstallAsService(sm);
-    std::make_shared<LDNU>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<LDNM>(system)->InstallAsService(sm);
+    std::make_shared<LDNS>(system)->InstallAsService(sm);
+    std::make_shared<LDNU>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::LDN

--- a/src/core/hle/service/ldn/ldn.h
+++ b/src/core/hle/service/ldn/ldn.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
@@ -11,6 +15,6 @@ class ServiceManager;
 namespace Service::LDN {
 
 /// Registers all LDN services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::LDN

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -115,7 +115,7 @@ static_assert(sizeof(NROInfo) == 0x60, "NROInfo has invalid size.");
 
 class DebugMonitor final : public ServiceFramework<DebugMonitor> {
 public:
-    explicit DebugMonitor() : ServiceFramework{"ldr:dmnt"} {
+    explicit DebugMonitor(Core::System& system_) : ServiceFramework{system_, "ldr:dmnt"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "AddProcessToDebugLaunchQueue"},
@@ -130,7 +130,7 @@ public:
 
 class ProcessManager final : public ServiceFramework<ProcessManager> {
 public:
-    explicit ProcessManager() : ServiceFramework{"ldr:pm"} {
+    explicit ProcessManager(Core::System& system_) : ServiceFramework{system_, "ldr:pm"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "CreateProcess"},
@@ -147,7 +147,7 @@ public:
 
 class Shell final : public ServiceFramework<Shell> {
 public:
-    explicit Shell() : ServiceFramework{"ldr:shel"} {
+    explicit Shell(Core::System& system_) : ServiceFramework{system_, "ldr:shel"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "AddProcessToLaunchQueue"},
@@ -161,7 +161,7 @@ public:
 
 class RelocatableObject final : public ServiceFramework<RelocatableObject> {
 public:
-    explicit RelocatableObject(Core::System& system) : ServiceFramework{"ldr:ro"}, system(system) {
+    explicit RelocatableObject(Core::System& system_) : ServiceFramework{system_, "ldr:ro"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &RelocatableObject::LoadNro, "LoadNro"},
@@ -639,13 +639,12 @@ private:
                Common::Is4KBAligned(header.segment_headers[RO_INDEX].memory_size) &&
                Common::Is4KBAligned(header.segment_headers[DATA_INDEX].memory_size);
     }
-    Core::System& system;
 };
 
 void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
-    std::make_shared<DebugMonitor>()->InstallAsService(sm);
-    std::make_shared<ProcessManager>()->InstallAsService(sm);
-    std::make_shared<Shell>()->InstallAsService(sm);
+    std::make_shared<DebugMonitor>(system)->InstallAsService(sm);
+    std::make_shared<ProcessManager>(system)->InstallAsService(sm);
+    std::make_shared<Shell>(system)->InstallAsService(sm);
     std::make_shared<RelocatableObject>(system)->InstallAsService(sm);
 }
 

--- a/src/core/hle/service/ldr/ldr.h
+++ b/src/core/hle/service/ldr/ldr.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }

--- a/src/core/hle/service/mig/mig.cpp
+++ b/src/core/hle/service/mig/mig.cpp
@@ -12,7 +12,7 @@ namespace Service::Migration {
 
 class MIG_USR final : public ServiceFramework<MIG_USR> {
 public:
-    explicit MIG_USR() : ServiceFramework{"mig:usr"} {
+    explicit MIG_USR(Core::System& system_) : ServiceFramework{system_, "mig:usr"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {10, nullptr, "TryGetLastMigrationInfo"},
@@ -33,8 +33,8 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<MIG_USR>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<MIG_USR>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::Migration

--- a/src/core/hle/service/mig/mig.h
+++ b/src/core/hle/service/mig/mig.h
@@ -4,12 +4,16 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::Migration {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::Migration

--- a/src/core/hle/service/mii/mii.cpp
+++ b/src/core/hle/service/mii/mii.cpp
@@ -18,7 +18,8 @@ constexpr ResultCode ERROR_INVALID_ARGUMENT{ErrorModule::Mii, 1};
 
 class IDatabaseService final : public ServiceFramework<IDatabaseService> {
 public:
-    explicit IDatabaseService() : ServiceFramework{"IDatabaseService"} {
+    explicit IDatabaseService(Core::System& system_)
+        : ServiceFramework{system_, "IDatabaseService"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IDatabaseService::IsUpdated, "IsUpdated"},
@@ -252,7 +253,8 @@ private:
 
 class MiiDBModule final : public ServiceFramework<MiiDBModule> {
 public:
-    explicit MiiDBModule(const char* name) : ServiceFramework{name} {
+    explicit MiiDBModule(Core::System& system_, const char* name)
+        : ServiceFramework{system_, name} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &MiiDBModule::GetDatabaseService, "GetDatabaseService"},
@@ -266,7 +268,7 @@ private:
     void GetDatabaseService(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IDatabaseService>();
+        rb.PushIpcInterface<IDatabaseService>(system);
 
         LOG_DEBUG(Service_Mii, "called");
     }
@@ -274,7 +276,7 @@ private:
 
 class MiiImg final : public ServiceFramework<MiiImg> {
 public:
-    explicit MiiImg() : ServiceFramework{"miiimg"} {
+    explicit MiiImg(Core::System& system_) : ServiceFramework{system_, "miiimg"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
@@ -298,11 +300,11 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<MiiDBModule>("mii:e")->InstallAsService(sm);
-    std::make_shared<MiiDBModule>("mii:u")->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<MiiDBModule>(system, "mii:e")->InstallAsService(sm);
+    std::make_shared<MiiDBModule>(system, "mii:u")->InstallAsService(sm);
 
-    std::make_shared<MiiImg>()->InstallAsService(sm);
+    std::make_shared<MiiImg>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::Mii

--- a/src/core/hle/service/mii/mii.h
+++ b/src/core/hle/service/mii/mii.h
@@ -4,12 +4,16 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::Mii {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::Mii

--- a/src/core/hle/service/mm/mm_u.cpp
+++ b/src/core/hle/service/mm/mm_u.cpp
@@ -6,12 +6,13 @@
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/client_session.h"
 #include "core/hle/service/mm/mm_u.h"
+#include "core/hle/service/sm/sm.h"
 
 namespace Service::MM {
 
 class MM_U final : public ServiceFramework<MM_U> {
 public:
-    explicit MM_U() : ServiceFramework{"mm:u"} {
+    explicit MM_U(Core::System& system_) : ServiceFramework{system_, "mm:u"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &MM_U::InitializeOld, "InitializeOld"},
@@ -104,8 +105,8 @@ private:
     u32 id{1};
 };
 
-void InstallInterfaces(SM::ServiceManager& service_manager) {
-    std::make_shared<MM_U>()->InstallAsService(service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {
+    std::make_shared<MM_U>(system)->InstallAsService(service_manager);
 }
 
 } // namespace Service::MM

--- a/src/core/hle/service/mm/mm_u.h
+++ b/src/core/hle/service/mm/mm_u.h
@@ -4,11 +4,17 @@
 
 #pragma once
 
-#include "core/hle/service/service.h"
+namespace Core {
+class System;
+}
+
+namespace Service::SM {
+class ServiceManager;
+}
 
 namespace Service::MM {
 
 /// Registers all MM services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace Service::MM

--- a/src/core/hle/service/ncm/ncm.cpp
+++ b/src/core/hle/service/ncm/ncm.cpp
@@ -14,8 +14,8 @@ namespace Service::NCM {
 
 class ILocationResolver final : public ServiceFramework<ILocationResolver> {
 public:
-    explicit ILocationResolver(FileSys::StorageId id)
-        : ServiceFramework{"ILocationResolver"}, storage(id) {
+    explicit ILocationResolver(Core::System& system_, FileSys::StorageId id)
+        : ServiceFramework{system_, "ILocationResolver"}, storage{id} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "ResolveProgramPath"},
@@ -50,7 +50,8 @@ private:
 
 class IRegisteredLocationResolver final : public ServiceFramework<IRegisteredLocationResolver> {
 public:
-    explicit IRegisteredLocationResolver() : ServiceFramework{"IRegisteredLocationResolver"} {
+    explicit IRegisteredLocationResolver(Core::System& system_)
+        : ServiceFramework{system_, "IRegisteredLocationResolver"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "ResolveProgramPath"},
@@ -72,7 +73,8 @@ public:
 
 class IAddOnContentLocationResolver final : public ServiceFramework<IAddOnContentLocationResolver> {
 public:
-    explicit IAddOnContentLocationResolver() : ServiceFramework{"IAddOnContentLocationResolver"} {
+    explicit IAddOnContentLocationResolver(Core::System& system_)
+        : ServiceFramework{system_, "IAddOnContentLocationResolver"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "ResolveAddOnContentPath"},
@@ -89,7 +91,7 @@ public:
 
 class LR final : public ServiceFramework<LR> {
 public:
-    explicit LR() : ServiceFramework{"lr"} {
+    explicit LR(Core::System& system_) : ServiceFramework{system_, "lr"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "OpenLocationResolver"},
@@ -105,7 +107,7 @@ public:
 
 class NCM final : public ServiceFramework<NCM> {
 public:
-    explicit NCM() : ServiceFramework{"ncm"} {
+    explicit NCM(Core::System& system_) : ServiceFramework{system_, "ncm"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "CreateContentStorage"},
@@ -130,9 +132,9 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<LR>()->InstallAsService(sm);
-    std::make_shared<NCM>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<LR>(system)->InstallAsService(sm);
+    std::make_shared<NCM>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::NCM

--- a/src/core/hle/service/ncm/ncm.h
+++ b/src/core/hle/service/ncm/ncm.h
@@ -4,12 +4,16 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::NCM {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::NCM

--- a/src/core/hle/service/nfc/nfc.cpp
+++ b/src/core/hle/service/nfc/nfc.cpp
@@ -16,7 +16,7 @@ namespace Service::NFC {
 
 class IAm final : public ServiceFramework<IAm> {
 public:
-    explicit IAm() : ServiceFramework{"NFC::IAm"} {
+    explicit IAm(Core::System& system_) : ServiceFramework{system_, "NFC::IAm"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
@@ -31,7 +31,7 @@ public:
 
 class NFC_AM final : public ServiceFramework<NFC_AM> {
 public:
-    explicit NFC_AM() : ServiceFramework{"nfc:am"} {
+    explicit NFC_AM(Core::System& system_) : ServiceFramework{system_, "nfc:am"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &NFC_AM::CreateAmInterface, "CreateAmInterface"},
@@ -47,13 +47,13 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IAm>();
+        rb.PushIpcInterface<IAm>(system);
     }
 };
 
 class MFIUser final : public ServiceFramework<MFIUser> {
 public:
-    explicit MFIUser() : ServiceFramework{"NFC::MFIUser"} {
+    explicit MFIUser(Core::System& system_) : ServiceFramework{system_, "NFC::MFIUser"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
@@ -79,7 +79,7 @@ public:
 
 class NFC_MF_U final : public ServiceFramework<NFC_MF_U> {
 public:
-    explicit NFC_MF_U() : ServiceFramework{"nfc:mf:u"} {
+    explicit NFC_MF_U(Core::System& system_) : ServiceFramework{system_, "nfc:mf:u"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &NFC_MF_U::CreateUserInterface, "CreateUserInterface"},
@@ -95,13 +95,13 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<MFIUser>();
+        rb.PushIpcInterface<MFIUser>(system);
     }
 };
 
 class IUser final : public ServiceFramework<IUser> {
 public:
-    explicit IUser() : ServiceFramework{"NFC::IUser"} {
+    explicit IUser(Core::System& system_) : ServiceFramework{system_, "NFC::IUser"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IUser::InitializeOld, "InitializeOld"},
@@ -171,7 +171,7 @@ private:
 
 class NFC_U final : public ServiceFramework<NFC_U> {
 public:
-    explicit NFC_U() : ServiceFramework{"nfc:user"} {
+    explicit NFC_U(Core::System& system_) : ServiceFramework{system_, "nfc:user"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &NFC_U::CreateUserInterface, "CreateUserInterface"},
@@ -187,13 +187,13 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IUser>();
+        rb.PushIpcInterface<IUser>(system);
     }
 };
 
 class ISystem final : public ServiceFramework<ISystem> {
 public:
-    explicit ISystem() : ServiceFramework{"ISystem"} {
+    explicit ISystem(Core::System& system_) : ServiceFramework{system_, "ISystem"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
@@ -230,7 +230,7 @@ public:
 
 class NFC_SYS final : public ServiceFramework<NFC_SYS> {
 public:
-    explicit NFC_SYS() : ServiceFramework{"nfc:sys"} {
+    explicit NFC_SYS(Core::System& system_) : ServiceFramework{system_, "nfc:sys"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &NFC_SYS::CreateSystemInterface, "CreateSystemInterface"},
@@ -246,15 +246,15 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<ISystem>();
+        rb.PushIpcInterface<ISystem>(system);
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<NFC_AM>()->InstallAsService(sm);
-    std::make_shared<NFC_MF_U>()->InstallAsService(sm);
-    std::make_shared<NFC_U>()->InstallAsService(sm);
-    std::make_shared<NFC_SYS>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<NFC_AM>(system)->InstallAsService(sm);
+    std::make_shared<NFC_MF_U>(system)->InstallAsService(sm);
+    std::make_shared<NFC_U>(system)->InstallAsService(sm);
+    std::make_shared<NFC_SYS>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::NFC

--- a/src/core/hle/service/nfc/nfc.h
+++ b/src/core/hle/service/nfc/nfc.h
@@ -4,12 +4,16 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::NFC {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::NFC

--- a/src/core/hle/service/nfp/nfp.cpp
+++ b/src/core/hle/service/nfp/nfp.cpp
@@ -21,8 +21,9 @@ namespace ErrCodes {
 constexpr ResultCode ERR_NO_APPLICATION_AREA(ErrorModule::NFP, 152);
 } // namespace ErrCodes
 
-Module::Interface::Interface(std::shared_ptr<Module> module, Core::System& system, const char* name)
-    : ServiceFramework(name), module(std::move(module)), system(system) {
+Module::Interface::Interface(std::shared_ptr<Module> module_, Core::System& system_,
+                             const char* name)
+    : ServiceFramework{system_, name}, module{std::move(module_)} {
     auto& kernel = system.Kernel();
     nfc_tag_load = Kernel::WritableEvent::CreateEventPair(kernel, "IUser:NFCTagDetected");
 }
@@ -31,8 +32,8 @@ Module::Interface::~Interface() = default;
 
 class IUser final : public ServiceFramework<IUser> {
 public:
-    IUser(Module::Interface& nfp_interface, Core::System& system)
-        : ServiceFramework("NFP::IUser"), nfp_interface(nfp_interface) {
+    explicit IUser(Module::Interface& nfp_interface_, Core::System& system_)
+        : ServiceFramework{system_, "NFP::IUser"}, nfp_interface{nfp_interface_} {
         static const FunctionInfo functions[] = {
             {0, &IUser::Initialize, "Initialize"},
             {1, &IUser::Finalize, "Finalize"},

--- a/src/core/hle/service/nfp/nfp.h
+++ b/src/core/hle/service/nfp/nfp.h
@@ -16,7 +16,8 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        explicit Interface(std::shared_ptr<Module> module, Core::System& system, const char* name);
+        explicit Interface(std::shared_ptr<Module> module_, Core::System& system_,
+                           const char* name);
         ~Interface() override;
 
         struct ModelInfo {
@@ -43,7 +44,6 @@ public:
 
     protected:
         std::shared_ptr<Module> module;
-        Core::System& system;
     };
 };
 

--- a/src/core/hle/service/nfp/nfp_user.cpp
+++ b/src/core/hle/service/nfp/nfp_user.cpp
@@ -6,8 +6,8 @@
 
 namespace Service::NFP {
 
-NFP_User::NFP_User(std::shared_ptr<Module> module, Core::System& system)
-    : Module::Interface(std::move(module), system, "nfp:user") {
+NFP_User::NFP_User(std::shared_ptr<Module> module_, Core::System& system_)
+    : Interface(std::move(module_), system_, "nfp:user") {
     static const FunctionInfo functions[] = {
         {0, &NFP_User::CreateUserInterface, "CreateUserInterface"},
     };

--- a/src/core/hle/service/nfp/nfp_user.h
+++ b/src/core/hle/service/nfp/nfp_user.h
@@ -10,7 +10,7 @@ namespace Service::NFP {
 
 class NFP_User final : public Module::Interface {
 public:
-    explicit NFP_User(std::shared_ptr<Module> module, Core::System& system);
+    explicit NFP_User(std::shared_ptr<Module> module_, Core::System& system_);
     ~NFP_User() override;
 };
 

--- a/src/core/hle/service/nifm/nifm.h
+++ b/src/core/hle/service/nifm/nifm.h
@@ -4,12 +4,12 @@
 
 #pragma once
 
-namespace Service::SM {
-class ServiceManager;
-}
-
 namespace Core {
 class System;
+}
+
+namespace Service::SM {
+class ServiceManager;
 }
 
 namespace Service::NIFM {

--- a/src/core/hle/service/nim/nim.cpp
+++ b/src/core/hle/service/nim/nim.cpp
@@ -17,7 +17,8 @@ namespace Service::NIM {
 
 class IShopServiceAsync final : public ServiceFramework<IShopServiceAsync> {
 public:
-    IShopServiceAsync() : ServiceFramework("IShopServiceAsync") {
+    explicit IShopServiceAsync(Core::System& system_)
+        : ServiceFramework{system_, "IShopServiceAsync"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Cancel"},
@@ -35,7 +36,8 @@ public:
 
 class IShopServiceAccessor final : public ServiceFramework<IShopServiceAccessor> {
 public:
-    IShopServiceAccessor() : ServiceFramework("IShopServiceAccessor") {
+    explicit IShopServiceAccessor(Core::System& system_)
+        : ServiceFramework{system_, "IShopServiceAccessor"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IShopServiceAccessor::CreateAsyncInterface, "CreateAsyncInterface"},
@@ -50,13 +52,14 @@ private:
         LOG_WARNING(Service_NIM, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IShopServiceAsync>();
+        rb.PushIpcInterface<IShopServiceAsync>(system);
     }
 };
 
 class IShopServiceAccessServer final : public ServiceFramework<IShopServiceAccessServer> {
 public:
-    IShopServiceAccessServer() : ServiceFramework("IShopServiceAccessServer") {
+    explicit IShopServiceAccessServer(Core::System& system_)
+        : ServiceFramework{system_, "IShopServiceAccessServer"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IShopServiceAccessServer::CreateAccessorInterface, "CreateAccessorInterface"},
@@ -71,13 +74,13 @@ private:
         LOG_WARNING(Service_NIM, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IShopServiceAccessor>();
+        rb.PushIpcInterface<IShopServiceAccessor>(system);
     }
 };
 
 class NIM final : public ServiceFramework<NIM> {
 public:
-    explicit NIM() : ServiceFramework{"nim"} {
+    explicit NIM(Core::System& system_) : ServiceFramework{system_, "nim"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "CreateSystemUpdateTask"},
@@ -207,7 +210,7 @@ public:
 
 class NIM_ECA final : public ServiceFramework<NIM_ECA> {
 public:
-    explicit NIM_ECA() : ServiceFramework{"nim:eca"} {
+    explicit NIM_ECA(Core::System& system_) : ServiceFramework{system_, "nim:eca"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &NIM_ECA::CreateServerInterface, "CreateServerInterface"},
@@ -226,13 +229,13 @@ private:
         LOG_WARNING(Service_NIM, "(STUBBED) called");
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IShopServiceAccessServer>();
+        rb.PushIpcInterface<IShopServiceAccessServer>(system);
     }
 };
 
 class NIM_SHP final : public ServiceFramework<NIM_SHP> {
 public:
-    explicit NIM_SHP() : ServiceFramework{"nim:shp"} {
+    explicit NIM_SHP(Core::System& system_) : ServiceFramework{system_, "nim:shp"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "RequestDeviceAuthenticationToken"},
@@ -272,8 +275,8 @@ public:
 class IEnsureNetworkClockAvailabilityService final
     : public ServiceFramework<IEnsureNetworkClockAvailabilityService> {
 public:
-    explicit IEnsureNetworkClockAvailabilityService(Core::System& system)
-        : ServiceFramework("IEnsureNetworkClockAvailabilityService") {
+    explicit IEnsureNetworkClockAvailabilityService(Core::System& system_)
+        : ServiceFramework{system_, "IEnsureNetworkClockAvailabilityService"} {
         static const FunctionInfo functions[] = {
             {0, &IEnsureNetworkClockAvailabilityService::StartTask, "StartTask"},
             {1, &IEnsureNetworkClockAvailabilityService::GetFinishNotificationEvent,
@@ -345,7 +348,7 @@ private:
 
 class NTC final : public ServiceFramework<NTC> {
 public:
-    explicit NTC(Core::System& system) : ServiceFramework{"ntc"}, system(system) {
+    explicit NTC(Core::System& system_) : ServiceFramework{system_, "ntc"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &NTC::OpenEnsureNetworkClockAvailabilityService, "OpenEnsureNetworkClockAvailabilityService"},
@@ -380,13 +383,12 @@ private:
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
-    Core::System& system;
 };
 
 void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
-    std::make_shared<NIM>()->InstallAsService(sm);
-    std::make_shared<NIM_ECA>()->InstallAsService(sm);
-    std::make_shared<NIM_SHP>()->InstallAsService(sm);
+    std::make_shared<NIM>(system)->InstallAsService(sm);
+    std::make_shared<NIM_ECA>(system)->InstallAsService(sm);
+    std::make_shared<NIM_SHP>(system)->InstallAsService(sm);
     std::make_shared<NTC>(system)->InstallAsService(sm);
 }
 

--- a/src/core/hle/service/nim/nim.h
+++ b/src/core/hle/service/nim/nim.h
@@ -4,12 +4,12 @@
 
 #pragma once
 
-namespace Service::SM {
-class ServiceManager;
-}
-
 namespace Core {
 class System;
+}
+
+namespace Service::SM {
+class ServiceManager;
 }
 
 namespace Service::NIM {

--- a/src/core/hle/service/npns/npns.cpp
+++ b/src/core/hle/service/npns/npns.cpp
@@ -12,7 +12,7 @@ namespace Service::NPNS {
 
 class NPNS_S final : public ServiceFramework<NPNS_S> {
 public:
-    explicit NPNS_S() : ServiceFramework{"npns:s"} {
+    explicit NPNS_S(Core::System& system_) : ServiceFramework{system_, "npns:s"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {1, nullptr, "ListenAll"},
@@ -62,7 +62,7 @@ public:
 
 class NPNS_U final : public ServiceFramework<NPNS_U> {
 public:
-    explicit NPNS_U() : ServiceFramework{"npns:u"} {
+    explicit NPNS_U(Core::System& system_) : ServiceFramework{system_, "npns:u"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {1, nullptr, "ListenAll"},
@@ -91,9 +91,9 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<NPNS_S>()->InstallAsService(sm);
-    std::make_shared<NPNS_U>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<NPNS_S>(system)->InstallAsService(sm);
+    std::make_shared<NPNS_U>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::NPNS

--- a/src/core/hle/service/npns/npns.h
+++ b/src/core/hle/service/npns/npns.h
@@ -4,12 +4,16 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::NPNS {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::NPNS

--- a/src/core/hle/service/ns/ns.cpp
+++ b/src/core/hle/service/ns/ns.cpp
@@ -18,7 +18,8 @@
 
 namespace Service::NS {
 
-IAccountProxyInterface::IAccountProxyInterface() : ServiceFramework{"IAccountProxyInterface"} {
+IAccountProxyInterface::IAccountProxyInterface(Core::System& system_)
+    : ServiceFramework{system_, "IAccountProxyInterface"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "CreateUserAccount"},
@@ -31,7 +32,7 @@ IAccountProxyInterface::IAccountProxyInterface() : ServiceFramework{"IAccountPro
 IAccountProxyInterface::~IAccountProxyInterface() = default;
 
 IApplicationManagerInterface::IApplicationManagerInterface(Core::System& system_)
-    : ServiceFramework{"IApplicationManagerInterface"}, system{system_} {
+    : ServiceFramework{system_, "IApplicationManagerInterface"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "ListApplicationRecord"},
@@ -428,8 +429,8 @@ ResultVal<u64> IApplicationManagerInterface::ConvertApplicationLanguageToLanguag
     return MakeResult(static_cast<u64>(*language_code));
 }
 
-IApplicationVersionInterface::IApplicationVersionInterface()
-    : ServiceFramework{"IApplicationVersionInterface"} {
+IApplicationVersionInterface::IApplicationVersionInterface(Core::System& system_)
+    : ServiceFramework{system_, "IApplicationVersionInterface"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "GetLaunchRequiredVersion"},
@@ -449,8 +450,8 @@ IApplicationVersionInterface::IApplicationVersionInterface()
 
 IApplicationVersionInterface::~IApplicationVersionInterface() = default;
 
-IContentManagementInterface::IContentManagementInterface()
-    : ServiceFramework{"IContentManagementInterface"} {
+IContentManagementInterface::IContentManagementInterface(Core::System& system_)
+    : ServiceFramework{system_, "IContentManagementInterface"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {11, nullptr, "CalculateApplicationOccupiedSize"},
@@ -469,7 +470,8 @@ IContentManagementInterface::IContentManagementInterface()
 
 IContentManagementInterface::~IContentManagementInterface() = default;
 
-IDocumentInterface::IDocumentInterface() : ServiceFramework{"IDocumentInterface"} {
+IDocumentInterface::IDocumentInterface(Core::System& system_)
+    : ServiceFramework{system_, "IDocumentInterface"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {21, nullptr, "GetApplicationContentPath"},
@@ -483,7 +485,8 @@ IDocumentInterface::IDocumentInterface() : ServiceFramework{"IDocumentInterface"
 
 IDocumentInterface::~IDocumentInterface() = default;
 
-IDownloadTaskInterface::IDownloadTaskInterface() : ServiceFramework{"IDownloadTaskInterface"} {
+IDownloadTaskInterface::IDownloadTaskInterface(Core::System& system_)
+    : ServiceFramework{system_, "IDownloadTaskInterface"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {701, nullptr, "ClearTaskStatusList"},
@@ -503,7 +506,8 @@ IDownloadTaskInterface::IDownloadTaskInterface() : ServiceFramework{"IDownloadTa
 
 IDownloadTaskInterface::~IDownloadTaskInterface() = default;
 
-IECommerceInterface::IECommerceInterface() : ServiceFramework{"IECommerceInterface"} {
+IECommerceInterface::IECommerceInterface(Core::System& system_)
+    : ServiceFramework{system_, "IECommerceInterface"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "RequestLinkDevice"},
@@ -521,8 +525,8 @@ IECommerceInterface::IECommerceInterface() : ServiceFramework{"IECommerceInterfa
 
 IECommerceInterface::~IECommerceInterface() = default;
 
-IFactoryResetInterface::IFactoryResetInterface::IFactoryResetInterface()
-    : ServiceFramework{"IFactoryResetInterface"} {
+IFactoryResetInterface::IFactoryResetInterface(Core::System& system_)
+    : ServiceFramework{system_, "IFactoryResetInterface"} {
     // clang-format off
         static const FunctionInfo functions[] = {
             {100, nullptr, "ResetToFactorySettings"},
@@ -540,7 +544,7 @@ IFactoryResetInterface::IFactoryResetInterface::IFactoryResetInterface()
 
 IFactoryResetInterface::~IFactoryResetInterface() = default;
 
-NS::NS(const char* name, Core::System& system_) : ServiceFramework{name}, system{system_} {
+NS::NS(const char* name, Core::System& system_) : ServiceFramework{system_, name} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {7992, &NS::PushInterface<IECommerceInterface>, "GetECommerceInterface"},
@@ -565,7 +569,7 @@ std::shared_ptr<IApplicationManagerInterface> NS::GetApplicationManagerInterface
 
 class NS_DEV final : public ServiceFramework<NS_DEV> {
 public:
-    explicit NS_DEV() : ServiceFramework{"ns:dev"} {
+    explicit NS_DEV(Core::System& system_) : ServiceFramework{system_, "ns:dev"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "LaunchProgram"},
@@ -592,7 +596,8 @@ public:
 
 class ISystemUpdateControl final : public ServiceFramework<ISystemUpdateControl> {
 public:
-    explicit ISystemUpdateControl() : ServiceFramework{"ISystemUpdateControl"} {
+    explicit ISystemUpdateControl(Core::System& system_)
+        : ServiceFramework{system_, "ISystemUpdateControl"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "HasDownloaded"},
@@ -627,7 +632,7 @@ public:
 
 class NS_SU final : public ServiceFramework<NS_SU> {
 public:
-    explicit NS_SU() : ServiceFramework{"ns:su"} {
+    explicit NS_SU(Core::System& system_) : ServiceFramework{system_, "ns:su"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetBackgroundNetworkUpdateState"},
@@ -659,13 +664,13 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<ISystemUpdateControl>();
+        rb.PushIpcInterface<ISystemUpdateControl>(system);
     }
 };
 
 class NS_VM final : public ServiceFramework<NS_VM> {
 public:
-    explicit NS_VM() : ServiceFramework{"ns:vm"} {
+    explicit NS_VM(Core::System& system_) : ServiceFramework{system_, "ns:vm"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {1200, nullptr, "NeedsUpdateVulnerability"},
@@ -686,9 +691,9 @@ void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system
     std::make_shared<NS>("ns:rt", system)->InstallAsService(service_manager);
     std::make_shared<NS>("ns:web", system)->InstallAsService(service_manager);
 
-    std::make_shared<NS_DEV>()->InstallAsService(service_manager);
-    std::make_shared<NS_SU>()->InstallAsService(service_manager);
-    std::make_shared<NS_VM>()->InstallAsService(service_manager);
+    std::make_shared<NS_DEV>(system)->InstallAsService(service_manager);
+    std::make_shared<NS_SU>(system)->InstallAsService(service_manager);
+    std::make_shared<NS_VM>(system)->InstallAsService(service_manager);
 
     std::make_shared<PL_U>(system)->InstallAsService(service_manager);
 }

--- a/src/core/hle/service/ns/ns.h
+++ b/src/core/hle/service/ns/ns.h
@@ -20,7 +20,7 @@ namespace NS {
 
 class IAccountProxyInterface final : public ServiceFramework<IAccountProxyInterface> {
 public:
-    explicit IAccountProxyInterface();
+    explicit IAccountProxyInterface(Core::System& system_);
     ~IAccountProxyInterface() override;
 };
 
@@ -36,43 +36,41 @@ private:
     void GetApplicationControlData(Kernel::HLERequestContext& ctx);
     void GetApplicationDesiredLanguage(Kernel::HLERequestContext& ctx);
     void ConvertApplicationLanguageToLanguageCode(Kernel::HLERequestContext& ctx);
-
-    Core::System& system;
 };
 
 class IApplicationVersionInterface final : public ServiceFramework<IApplicationVersionInterface> {
 public:
-    explicit IApplicationVersionInterface();
+    explicit IApplicationVersionInterface(Core::System& system_);
     ~IApplicationVersionInterface() override;
 };
 
 class IContentManagementInterface final : public ServiceFramework<IContentManagementInterface> {
 public:
-    explicit IContentManagementInterface();
+    explicit IContentManagementInterface(Core::System& system_);
     ~IContentManagementInterface() override;
 };
 
 class IDocumentInterface final : public ServiceFramework<IDocumentInterface> {
 public:
-    explicit IDocumentInterface();
+    explicit IDocumentInterface(Core::System& system_);
     ~IDocumentInterface() override;
 };
 
 class IDownloadTaskInterface final : public ServiceFramework<IDownloadTaskInterface> {
 public:
-    explicit IDownloadTaskInterface();
+    explicit IDownloadTaskInterface(Core::System& system_);
     ~IDownloadTaskInterface() override;
 };
 
 class IECommerceInterface final : public ServiceFramework<IECommerceInterface> {
 public:
-    explicit IECommerceInterface();
+    explicit IECommerceInterface(Core::System& system_);
     ~IECommerceInterface() override;
 };
 
 class IFactoryResetInterface final : public ServiceFramework<IFactoryResetInterface> {
 public:
-    explicit IFactoryResetInterface();
+    explicit IFactoryResetInterface(Core::System& system_);
     ~IFactoryResetInterface() override;
 };
 
@@ -90,7 +88,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<T>();
+        rb.PushIpcInterface<T>(system);
     }
 
     void PushIApplicationManagerInterface(Kernel::HLERequestContext& ctx) {
@@ -108,8 +106,6 @@ private:
 
         return std::make_shared<T>(std::forward<Args>(args)...);
     }
-
-    Core::System& system;
 };
 
 /// Registers all NS services with the specified service manager.

--- a/src/core/hle/service/ns/pl_u.cpp
+++ b/src/core/hle/service/ns/pl_u.cpp
@@ -141,8 +141,8 @@ struct PL_U::Impl {
     std::vector<FontRegion> shared_font_regions;
 };
 
-PL_U::PL_U(Core::System& system)
-    : ServiceFramework("pl:u"), impl{std::make_unique<Impl>()}, system(system) {
+PL_U::PL_U(Core::System& system_)
+    : ServiceFramework{system_, "pl:u"}, impl{std::make_unique<Impl>()} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &PL_U::RequestLoad, "RequestLoad"},

--- a/src/core/hle/service/ns/pl_u.h
+++ b/src/core/hle/service/ns/pl_u.h
@@ -20,7 +20,7 @@ void EncryptSharedFont(const std::vector<u32>& input, std::vector<u8>& output, s
 
 class PL_U final : public ServiceFramework<PL_U> {
 public:
-    explicit PL_U(Core::System& system);
+    explicit PL_U(Core::System& system_);
     ~PL_U() override;
 
 private:
@@ -33,7 +33,6 @@ private:
 
     struct Impl;
     std::unique_ptr<Impl> impl;
-    Core::System& system;
 };
 
 } // namespace NS

--- a/src/core/hle/service/nvdrv/interface.cpp
+++ b/src/core/hle/service/nvdrv/interface.cpp
@@ -297,8 +297,8 @@ void NVDRV::DumpGraphicsMemoryInfo(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
 }
 
-NVDRV::NVDRV(std::shared_ptr<Module> nvdrv, const char* name)
-    : ServiceFramework(name), nvdrv(std::move(nvdrv)) {
+NVDRV::NVDRV(Core::System& system_, std::shared_ptr<Module> nvdrv_, const char* name)
+    : ServiceFramework{system_, name}, nvdrv{std::move(nvdrv_)} {
     static const FunctionInfo functions[] = {
         {0, &NVDRV::Open, "Open"},
         {1, &NVDRV::Ioctl1, "Ioctl"},

--- a/src/core/hle/service/nvdrv/interface.h
+++ b/src/core/hle/service/nvdrv/interface.h
@@ -16,10 +16,10 @@ namespace Service::Nvidia {
 
 class NVDRV final : public ServiceFramework<NVDRV> {
 public:
-    NVDRV(std::shared_ptr<Module> nvdrv, const char* name);
+    explicit NVDRV(Core::System& system_, std::shared_ptr<Module> nvdrv_, const char* name);
     ~NVDRV() override;
 
-    void SignalGPUInterruptSyncpt(const u32 syncpoint_id, const u32 value);
+    void SignalGPUInterruptSyncpt(u32 syncpoint_id, u32 value);
 
 private:
     void Open(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/nvdrv/nvdrv.cpp
+++ b/src/core/hle/service/nvdrv/nvdrv.cpp
@@ -30,11 +30,11 @@ namespace Service::Nvidia {
 void InstallInterfaces(SM::ServiceManager& service_manager, NVFlinger::NVFlinger& nvflinger,
                        Core::System& system) {
     auto module_ = std::make_shared<Module>(system);
-    std::make_shared<NVDRV>(module_, "nvdrv")->InstallAsService(service_manager);
-    std::make_shared<NVDRV>(module_, "nvdrv:a")->InstallAsService(service_manager);
-    std::make_shared<NVDRV>(module_, "nvdrv:s")->InstallAsService(service_manager);
-    std::make_shared<NVDRV>(module_, "nvdrv:t")->InstallAsService(service_manager);
-    std::make_shared<NVMEMP>()->InstallAsService(service_manager);
+    std::make_shared<NVDRV>(system, module_, "nvdrv")->InstallAsService(service_manager);
+    std::make_shared<NVDRV>(system, module_, "nvdrv:a")->InstallAsService(service_manager);
+    std::make_shared<NVDRV>(system, module_, "nvdrv:s")->InstallAsService(service_manager);
+    std::make_shared<NVDRV>(system, module_, "nvdrv:t")->InstallAsService(service_manager);
+    std::make_shared<NVMEMP>(system)->InstallAsService(service_manager);
     nvflinger.SetNVDrvInstance(module_);
 }
 

--- a/src/core/hle/service/nvdrv/nvdrv.h
+++ b/src/core/hle/service/nvdrv/nvdrv.h
@@ -100,7 +100,7 @@ struct EventInterface {
 
 class Module final {
 public:
-    Module(Core::System& system);
+    explicit Module(Core::System& system_);
     ~Module();
 
     /// Returns a pointer to one of the available devices, identified by its name.

--- a/src/core/hle/service/nvdrv/nvmemp.cpp
+++ b/src/core/hle/service/nvdrv/nvmemp.cpp
@@ -8,7 +8,7 @@
 
 namespace Service::Nvidia {
 
-NVMEMP::NVMEMP() : ServiceFramework("nvmemp") {
+NVMEMP::NVMEMP(Core::System& system_) : ServiceFramework{system_, "nvmemp"} {
     static const FunctionInfo functions[] = {
         {0, &NVMEMP::Open, "Open"},
         {1, &NVMEMP::GetAruid, "GetAruid"},

--- a/src/core/hle/service/nvdrv/nvmemp.h
+++ b/src/core/hle/service/nvdrv/nvmemp.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Nvidia {
 
 class NVMEMP final : public ServiceFramework<NVMEMP> {
 public:
-    NVMEMP();
+    explicit NVMEMP(Core::System& system_);
     ~NVMEMP() override;
 
 private:

--- a/src/core/hle/service/olsc/olsc.cpp
+++ b/src/core/hle/service/olsc/olsc.cpp
@@ -12,7 +12,7 @@ namespace Service::OLSC {
 
 class OLSC final : public ServiceFramework<OLSC> {
 public:
-    explicit OLSC() : ServiceFramework{"olsc:u"} {
+    explicit OLSC(Core::System& system_) : ServiceFramework{system_, "olsc:u"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &OLSC::Initialize, "Initialize"},
@@ -62,8 +62,8 @@ private:
     bool initialized{};
 };
 
-void InstallInterfaces(SM::ServiceManager& service_manager) {
-    std::make_shared<OLSC>()->InstallAsService(service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {
+    std::make_shared<OLSC>(system)->InstallAsService(service_manager);
 }
 
 } // namespace Service::OLSC

--- a/src/core/hle/service/olsc/olsc.h
+++ b/src/core/hle/service/olsc/olsc.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
@@ -11,6 +15,6 @@ class ServiceManager;
 namespace Service::OLSC {
 
 /// Registers all SSL services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace Service::OLSC

--- a/src/core/hle/service/pcie/pcie.cpp
+++ b/src/core/hle/service/pcie/pcie.cpp
@@ -12,7 +12,7 @@ namespace Service::PCIe {
 
 class ISession final : public ServiceFramework<ISession> {
 public:
-    explicit ISession() : ServiceFramework{"ISession"} {
+    explicit ISession(Core::System& system_) : ServiceFramework{system_, "ISession"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "QueryFunctions"},
@@ -48,7 +48,7 @@ public:
 
 class PCIe final : public ServiceFramework<PCIe> {
 public:
-    explicit PCIe() : ServiceFramework{"pcie"} {
+    explicit PCIe(Core::System& system_) : ServiceFramework{system, "pcie"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "RegisterClassDriver"},
@@ -60,8 +60,8 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<PCIe>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<PCIe>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::PCIe

--- a/src/core/hle/service/pcie/pcie.h
+++ b/src/core/hle/service/pcie/pcie.h
@@ -4,12 +4,16 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::PCIe {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::PCIe

--- a/src/core/hle/service/pctl/module.cpp
+++ b/src/core/hle/service/pctl/module.cpp
@@ -11,7 +11,8 @@ namespace Service::PCTL {
 
 class IParentalControlService final : public ServiceFramework<IParentalControlService> {
 public:
-    IParentalControlService() : ServiceFramework("IParentalControlService") {
+    explicit IParentalControlService(Core::System& system_)
+        : ServiceFramework{system_, "IParentalControlService"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {1, &IParentalControlService::Initialize, "Initialize"},
@@ -137,7 +138,7 @@ void Module::Interface::CreateService(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
-    rb.PushIpcInterface<IParentalControlService>();
+    rb.PushIpcInterface<IParentalControlService>(system);
 }
 
 void Module::Interface::CreateServiceWithoutInitialize(Kernel::HLERequestContext& ctx) {
@@ -145,20 +146,20 @@ void Module::Interface::CreateServiceWithoutInitialize(Kernel::HLERequestContext
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
-    rb.PushIpcInterface<IParentalControlService>();
+    rb.PushIpcInterface<IParentalControlService>(system);
 }
 
-Module::Interface::Interface(std::shared_ptr<Module> module, const char* name)
-    : ServiceFramework(name), module(std::move(module)) {}
+Module::Interface::Interface(Core::System& system_, std::shared_ptr<Module> module_, const char* name)
+    : ServiceFramework{system_, name}, module{std::move(module_)} {}
 
 Module::Interface::~Interface() = default;
 
-void InstallInterfaces(SM::ServiceManager& service_manager) {
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {
     auto module = std::make_shared<Module>();
-    std::make_shared<PCTL>(module, "pctl")->InstallAsService(service_manager);
-    std::make_shared<PCTL>(module, "pctl:a")->InstallAsService(service_manager);
-    std::make_shared<PCTL>(module, "pctl:r")->InstallAsService(service_manager);
-    std::make_shared<PCTL>(module, "pctl:s")->InstallAsService(service_manager);
+    std::make_shared<PCTL>(system, module, "pctl")->InstallAsService(service_manager);
+    std::make_shared<PCTL>(system, module, "pctl:a")->InstallAsService(service_manager);
+    std::make_shared<PCTL>(system, module, "pctl:r")->InstallAsService(service_manager);
+    std::make_shared<PCTL>(system, module, "pctl:s")->InstallAsService(service_manager);
 }
 
 } // namespace Service::PCTL

--- a/src/core/hle/service/pctl/module.h
+++ b/src/core/hle/service/pctl/module.h
@@ -6,13 +6,18 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::PCTL {
 
 class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        explicit Interface(std::shared_ptr<Module> module, const char* name);
+        explicit Interface(Core::System& system_, std::shared_ptr<Module> module_,
+                           const char* name);
         ~Interface() override;
 
         void CreateService(Kernel::HLERequestContext& ctx);
@@ -24,6 +29,6 @@ public:
 };
 
 /// Registers all PCTL services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace Service::PCTL

--- a/src/core/hle/service/pctl/pctl.cpp
+++ b/src/core/hle/service/pctl/pctl.cpp
@@ -6,8 +6,8 @@
 
 namespace Service::PCTL {
 
-PCTL::PCTL(std::shared_ptr<Module> module, const char* name)
-    : Module::Interface(std::move(module), name) {
+PCTL::PCTL(Core::System& system_, std::shared_ptr<Module> module_, const char* name)
+    : Interface{system_, std::move(module_), name} {
     static const FunctionInfo functions[] = {
         {0, &PCTL::CreateService, "CreateService"},
         {1, &PCTL::CreateServiceWithoutInitialize, "CreateServiceWithoutInitialize"},

--- a/src/core/hle/service/pctl/pctl.h
+++ b/src/core/hle/service/pctl/pctl.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/pctl/module.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::PCTL {
 
 class PCTL final : public Module::Interface {
 public:
-    explicit PCTL(std::shared_ptr<Module> module, const char* name);
+    explicit PCTL(Core::System& system_, std::shared_ptr<Module> module_, const char* name);
     ~PCTL() override;
 };
 

--- a/src/core/hle/service/pcv/pcv.cpp
+++ b/src/core/hle/service/pcv/pcv.cpp
@@ -12,7 +12,7 @@ namespace Service::PCV {
 
 class PCV final : public ServiceFramework<PCV> {
 public:
-    explicit PCV() : ServiceFramework{"pcv"} {
+    explicit PCV(Core::System& system_) : ServiceFramework{system_, "pcv"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "SetPowerEnabled"},
@@ -54,7 +54,7 @@ public:
 
 class PCV_ARB final : public ServiceFramework<PCV_ARB> {
 public:
-    explicit PCV_ARB() : ServiceFramework{"pcv:arb"} {
+    explicit PCV_ARB(Core::System& system_) : ServiceFramework{system_, "pcv:arb"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "ReleaseControl"},
@@ -67,7 +67,7 @@ public:
 
 class PCV_IMM final : public ServiceFramework<PCV_IMM> {
 public:
-    explicit PCV_IMM() : ServiceFramework{"pcv:imm"} {
+    explicit PCV_IMM(Core::System& system_) : ServiceFramework{system_, "pcv:imm"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "SetClockRate"},
@@ -78,10 +78,10 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<PCV>()->InstallAsService(sm);
-    std::make_shared<PCV_ARB>()->InstallAsService(sm);
-    std::make_shared<PCV_IMM>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<PCV>(system)->InstallAsService(sm);
+    std::make_shared<PCV_ARB>(system)->InstallAsService(sm);
+    std::make_shared<PCV_IMM>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::PCV

--- a/src/core/hle/service/pcv/pcv.h
+++ b/src/core/hle/service/pcv/pcv.h
@@ -4,12 +4,16 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::PCV {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::PCV

--- a/src/core/hle/service/pm/pm.cpp
+++ b/src/core/hle/service/pm/pm.cpp
@@ -44,7 +44,7 @@ void GetApplicationPidGeneric(Kernel::HLERequestContext& ctx,
 
 class BootMode final : public ServiceFramework<BootMode> {
 public:
-    explicit BootMode() : ServiceFramework{"pm:bm"} {
+    explicit BootMode(Core::System& system_) : ServiceFramework{system_, "pm:bm"} {
         static const FunctionInfo functions[] = {
             {0, &BootMode::GetBootMode, "GetBootMode"},
             {1, &BootMode::SetMaintenanceBoot, "SetMaintenanceBoot"},
@@ -75,8 +75,8 @@ private:
 
 class DebugMonitor final : public ServiceFramework<DebugMonitor> {
 public:
-    explicit DebugMonitor(const Kernel::KernelCore& kernel)
-        : ServiceFramework{"pm:dmnt"}, kernel(kernel) {
+    explicit DebugMonitor(Core::System& system_)
+        : ServiceFramework{system_, "pm:dmnt"}, kernel{system_.Kernel()} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetJitDebugProcessIdList"},
@@ -125,8 +125,9 @@ private:
 
 class Info final : public ServiceFramework<Info> {
 public:
-    explicit Info(const std::vector<std::shared_ptr<Kernel::Process>>& process_list)
-        : ServiceFramework{"pm:info"}, process_list(process_list) {
+    explicit Info(Core::System& system_,
+                  const std::vector<std::shared_ptr<Kernel::Process>>& process_list_)
+        : ServiceFramework{system_, "pm:info"}, process_list{process_list_} {
         static const FunctionInfo functions[] = {
             {0, &Info::GetTitleId, "GetTitleId"},
         };
@@ -160,8 +161,8 @@ private:
 
 class Shell final : public ServiceFramework<Shell> {
 public:
-    explicit Shell(const Kernel::KernelCore& kernel)
-        : ServiceFramework{"pm:shell"}, kernel(kernel) {
+    explicit Shell(Core::System& system_)
+        : ServiceFramework{system_, "pm:shell"}, kernel{system_.Kernel()} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "LaunchProgram"},
@@ -190,11 +191,11 @@ private:
 };
 
 void InstallInterfaces(Core::System& system) {
-    std::make_shared<BootMode>()->InstallAsService(system.ServiceManager());
-    std::make_shared<DebugMonitor>(system.Kernel())->InstallAsService(system.ServiceManager());
-    std::make_shared<Info>(system.Kernel().GetProcessList())
+    std::make_shared<BootMode>(system)->InstallAsService(system.ServiceManager());
+    std::make_shared<DebugMonitor>(system)->InstallAsService(system.ServiceManager());
+    std::make_shared<Info>(system, system.Kernel().GetProcessList())
         ->InstallAsService(system.ServiceManager());
-    std::make_shared<Shell>(system.Kernel())->InstallAsService(system.ServiceManager());
+    std::make_shared<Shell>(system)->InstallAsService(system.ServiceManager());
 }
 
 } // namespace Service::PM

--- a/src/core/hle/service/prepo/prepo.cpp
+++ b/src/core/hle/service/prepo/prepo.cpp
@@ -16,8 +16,7 @@ namespace Service::PlayReport {
 
 class PlayReport final : public ServiceFramework<PlayReport> {
 public:
-    explicit PlayReport(const char* name, Core::System& system)
-        : ServiceFramework{name}, system(system) {
+    explicit PlayReport(const char* name, Core::System& system_) : ServiceFramework{system_, name} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {10100, &PlayReport::SaveReport<Core::Reporter::PlayReportType::Old>, "SaveReportOld"},
@@ -140,8 +139,6 @@ private:
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
-
-    Core::System& system;
 };
 
 void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {

--- a/src/core/hle/service/prepo/prepo.h
+++ b/src/core/hle/service/prepo/prepo.h
@@ -4,12 +4,12 @@
 
 #pragma once
 
-namespace Service::SM {
-class ServiceManager;
-}
-
 namespace Core {
 class System;
+}
+
+namespace Service::SM {
+class ServiceManager;
 }
 
 namespace Service::PlayReport {

--- a/src/core/hle/service/psc/psc.cpp
+++ b/src/core/hle/service/psc/psc.cpp
@@ -14,7 +14,7 @@ namespace Service::PSC {
 
 class PSC_C final : public ServiceFramework<PSC_C> {
 public:
-    explicit PSC_C() : ServiceFramework{"psc:c"} {
+    explicit PSC_C(Core::System& system_) : ServiceFramework{system_, "psc:c"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
@@ -35,7 +35,7 @@ public:
 
 class IPmModule final : public ServiceFramework<IPmModule> {
 public:
-    explicit IPmModule() : ServiceFramework{"IPmModule"} {
+    explicit IPmModule(Core::System& system_) : ServiceFramework{system_, "IPmModule"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Initialize"},
@@ -52,7 +52,7 @@ public:
 
 class PSC_M final : public ServiceFramework<PSC_M> {
 public:
-    explicit PSC_M() : ServiceFramework{"psc:m"} {
+    explicit PSC_M(Core::System& system_) : ServiceFramework{system_, "psc:m"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &PSC_M::GetPmModule, "GetPmModule"},
@@ -68,13 +68,13 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IPmModule>();
+        rb.PushIpcInterface<IPmModule>(system);
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<PSC_C>()->InstallAsService(sm);
-    std::make_shared<PSC_M>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<PSC_C>(system)->InstallAsService(sm);
+    std::make_shared<PSC_M>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::PSC

--- a/src/core/hle/service/psc/psc.h
+++ b/src/core/hle/service/psc/psc.h
@@ -4,12 +4,16 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::PSC {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::PSC

--- a/src/core/hle/service/ptm/psm.cpp
+++ b/src/core/hle/service/ptm/psm.cpp
@@ -14,7 +14,7 @@ namespace Service::PSM {
 
 class PSM final : public ServiceFramework<PSM> {
 public:
-    explicit PSM() : ServiceFramework{"psm"} {
+    explicit PSM(Core::System& system_) : ServiceFramework{system_, "psm"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &PSM::GetBatteryChargePercentage, "GetBatteryChargePercentage"},
@@ -72,8 +72,8 @@ private:
     ChargerType charger_type{ChargerType::RegularCharger};
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<PSM>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<PSM>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::PSM

--- a/src/core/hle/service/ptm/psm.h
+++ b/src/core/hle/service/ptm/psm.h
@@ -4,12 +4,16 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::PSM {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::PSM

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -90,9 +90,10 @@ namespace Service {
     return function_string;
 }
 
-ServiceFrameworkBase::ServiceFrameworkBase(const char* service_name, u32 max_sessions,
-                                           InvokerFn* handler_invoker)
-    : service_name(service_name), max_sessions(max_sessions), handler_invoker(handler_invoker) {}
+ServiceFrameworkBase::ServiceFrameworkBase(Core::System& system_, const char* service_name_,
+                                           u32 max_sessions_, InvokerFn* handler_invoker_)
+    : system{system_}, service_name{service_name_}, max_sessions{max_sessions_},
+      handler_invoker{handler_invoker_} {}
 
 ServiceFrameworkBase::~ServiceFrameworkBase() = default;
 
@@ -146,8 +147,8 @@ void ServiceFrameworkBase::ReportUnimplementedFunction(Kernel::HLERequestContext
     }
     buf.push_back('}');
 
-    Core::System::GetInstance().GetReporter().SaveUnimplementedFunctionReport(
-        ctx, ctx.GetCommand(), function_name, service_name);
+    system.GetReporter().SaveUnimplementedFunctionReport(ctx, ctx.GetCommand(), function_name,
+                                                         service_name);
     UNIMPLEMENTED_MSG("Unknown / unimplemented {}", fmt::to_string(buf));
 }
 
@@ -171,7 +172,7 @@ ResultCode ServiceFrameworkBase::HandleSyncRequest(Kernel::HLERequestContext& co
     }
     case IPC::CommandType::ControlWithContext:
     case IPC::CommandType::Control: {
-        Core::System::GetInstance().ServiceManager().InvokeControlRequest(context);
+        system.ServiceManager().InvokeControlRequest(context);
         break;
     }
     case IPC::CommandType::RequestWithContext:
@@ -197,7 +198,7 @@ Services::Services(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system
 
     system.GetFileSystemController().CreateFactories(*system.GetFilesystem(), false);
 
-    SM::ServiceManager::InstallInterfaces(sm, system.Kernel());
+    SM::ServiceManager::InstallInterfaces(sm, system);
 
     Account::InstallInterfaces(system);
     AM::InstallInterfaces(*sm, *nv_flinger, system);
@@ -205,51 +206,51 @@ Services::Services(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system
     APM::InstallInterfaces(system);
     Audio::InstallInterfaces(*sm, system);
     BCAT::InstallInterfaces(system);
-    BPC::InstallInterfaces(*sm);
+    BPC::InstallInterfaces(*sm, system);
     BtDrv::InstallInterfaces(*sm, system);
     BTM::InstallInterfaces(*sm, system);
-    Capture::InstallInterfaces(*sm);
-    ERPT::InstallInterfaces(*sm);
-    ES::InstallInterfaces(*sm);
-    EUPLD::InstallInterfaces(*sm);
+    Capture::InstallInterfaces(*sm, system);
+    ERPT::InstallInterfaces(*sm, system);
+    ES::InstallInterfaces(*sm, system);
+    EUPLD::InstallInterfaces(*sm, system);
     Fatal::InstallInterfaces(*sm, system);
-    FGM::InstallInterfaces(*sm);
+    FGM::InstallInterfaces(*sm, system);
     FileSystem::InstallInterfaces(system);
     Friend::InstallInterfaces(*sm, system);
     Glue::InstallInterfaces(system);
-    GRC::InstallInterfaces(*sm);
+    GRC::InstallInterfaces(*sm, system);
     HID::InstallInterfaces(*sm, system);
-    LBL::InstallInterfaces(*sm);
-    LDN::InstallInterfaces(*sm);
+    LBL::InstallInterfaces(*sm, system);
+    LDN::InstallInterfaces(*sm, system);
     LDR::InstallInterfaces(*sm, system);
     LM::InstallInterfaces(system);
-    Migration::InstallInterfaces(*sm);
-    Mii::InstallInterfaces(*sm);
-    MM::InstallInterfaces(*sm);
-    NCM::InstallInterfaces(*sm);
-    NFC::InstallInterfaces(*sm);
+    Migration::InstallInterfaces(*sm, system);
+    Mii::InstallInterfaces(*sm, system);
+    MM::InstallInterfaces(*sm, system);
+    NCM::InstallInterfaces(*sm, system);
+    NFC::InstallInterfaces(*sm, system);
     NFP::InstallInterfaces(*sm, system);
     NIFM::InstallInterfaces(*sm, system);
     NIM::InstallInterfaces(*sm, system);
-    NPNS::InstallInterfaces(*sm);
+    NPNS::InstallInterfaces(*sm, system);
     NS::InstallInterfaces(*sm, system);
     Nvidia::InstallInterfaces(*sm, *nv_flinger, system);
-    OLSC::InstallInterfaces(*sm);
-    PCIe::InstallInterfaces(*sm);
-    PCTL::InstallInterfaces(*sm);
-    PCV::InstallInterfaces(*sm);
+    OLSC::InstallInterfaces(*sm, system);
+    PCIe::InstallInterfaces(*sm, system);
+    PCTL::InstallInterfaces(*sm, system);
+    PCV::InstallInterfaces(*sm, system);
     PlayReport::InstallInterfaces(*sm, system);
     PM::InstallInterfaces(system);
-    PSC::InstallInterfaces(*sm);
-    PSM::InstallInterfaces(*sm);
-    Set::InstallInterfaces(*sm);
+    PSC::InstallInterfaces(*sm, system);
+    PSM::InstallInterfaces(*sm, system);
+    Set::InstallInterfaces(*sm, system);
     Sockets::InstallInterfaces(*sm, system);
-    SPL::InstallInterfaces(*sm);
-    SSL::InstallInterfaces(*sm);
+    SPL::InstallInterfaces(*sm, system);
+    SSL::InstallInterfaces(*sm, system);
     Time::InstallInterfaces(system);
-    USB::InstallInterfaces(*sm);
-    VI::InstallInterfaces(*sm, *nv_flinger);
-    WLAN::InstallInterfaces(*sm);
+    USB::InstallInterfaces(*sm, system);
+    VI::InstallInterfaces(*sm, system, *nv_flinger);
+    WLAN::InstallInterfaces(*sm, system);
 }
 
 Services::~Services() = default;

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -80,6 +80,9 @@ protected:
     template <typename Self>
     using HandlerFnP = void (Self::*)(Kernel::HLERequestContext&);
 
+    /// System context that the service operates under.
+    Core::System& system;
+
 private:
     template <typename T>
     friend class ServiceFramework;
@@ -93,7 +96,8 @@ private:
     using InvokerFn = void(ServiceFrameworkBase* object, HandlerFnP<ServiceFrameworkBase> member,
                            Kernel::HLERequestContext& ctx);
 
-    ServiceFrameworkBase(const char* service_name, u32 max_sessions, InvokerFn* handler_invoker);
+    explicit ServiceFrameworkBase(Core::System& system_, const char* service_name_,
+                                  u32 max_sessions_, InvokerFn* handler_invoker_);
     ~ServiceFrameworkBase() override;
 
     void RegisterHandlersBase(const FunctionInfoBase* functions, std::size_t n);
@@ -151,11 +155,15 @@ protected:
 
     /**
      * Initializes the handler with no functions installed.
-     * @param max_sessions Maximum number of sessions that can be
-     * connected to this service at the same time.
+     *
+     * @param system_       The system context to construct this service under.
+     * @param service_name_ Name of the service.
+     * @param max_sessions_ Maximum number of sessions that can be
+     *                      connected to this service at the same time.
      */
-    explicit ServiceFramework(const char* service_name, u32 max_sessions = DefaultMaxSessions)
-        : ServiceFrameworkBase(service_name, max_sessions, Invoker) {}
+    explicit ServiceFramework(Core::System& system_, const char* service_name_,
+                              u32 max_sessions_ = DefaultMaxSessions)
+        : ServiceFrameworkBase(system_, service_name_, max_sessions_, Invoker) {}
 
     /// Registers handlers in the service.
     template <std::size_t N>

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -188,7 +188,7 @@ void SET::GetKeyCodeMap2(Kernel::HLERequestContext& ctx) {
     GetKeyCodeMapImpl(ctx);
 }
 
-SET::SET() : ServiceFramework("set") {
+SET::SET(Core::System& system_) : ServiceFramework{system_, "set"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &SET::GetLanguageCode, "GetLanguageCode"},

--- a/src/core/hle/service/set/set.h
+++ b/src/core/hle/service/set/set.h
@@ -6,6 +6,10 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Set {
 
 /// This is "nn::settings::LanguageCode", which is a NUL-terminated string stored in a u64.
@@ -32,7 +36,7 @@ LanguageCode GetLanguageCodeFromIndex(std::size_t idx);
 
 class SET final : public ServiceFramework<SET> {
 public:
-    explicit SET();
+    explicit SET(Core::System& system_);
     ~SET() override;
 
 private:

--- a/src/core/hle/service/set/set_cal.cpp
+++ b/src/core/hle/service/set/set_cal.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::Set {
 
-SET_CAL::SET_CAL() : ServiceFramework("set:cal") {
+SET_CAL::SET_CAL(Core::System& system_) : ServiceFramework{system_, "set:cal"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "GetBluetoothBdAddress"},

--- a/src/core/hle/service/set/set_cal.h
+++ b/src/core/hle/service/set/set_cal.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Set {
 
 class SET_CAL final : public ServiceFramework<SET_CAL> {
 public:
-    explicit SET_CAL();
+    explicit SET_CAL(Core::System& system_);
     ~SET_CAL() override;
 };
 

--- a/src/core/hle/service/set/set_fd.cpp
+++ b/src/core/hle/service/set/set_fd.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::Set {
 
-SET_FD::SET_FD() : ServiceFramework("set:fd") {
+SET_FD::SET_FD(Core::System& system_) : ServiceFramework{system_, "set:fd"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {2, nullptr, "SetSettingsItemValue"},

--- a/src/core/hle/service/set/set_fd.h
+++ b/src/core/hle/service/set/set_fd.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Set {
 
 class SET_FD final : public ServiceFramework<SET_FD> {
 public:
-    explicit SET_FD();
+    explicit SET_FD(Core::System& system_);
     ~SET_FD() override;
 };
 

--- a/src/core/hle/service/set/set_sys.cpp
+++ b/src/core/hle/service/set/set_sys.cpp
@@ -103,7 +103,7 @@ void SET_SYS::SetColorSetId(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
 }
 
-SET_SYS::SET_SYS() : ServiceFramework("set:sys") {
+SET_SYS::SET_SYS(Core::System& system_) : ServiceFramework{system_, "set:sys"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "SetLanguageCode"},

--- a/src/core/hle/service/set/set_sys.h
+++ b/src/core/hle/service/set/set_sys.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Set {
 
 class SET_SYS final : public ServiceFramework<SET_SYS> {
 public:
-    explicit SET_SYS();
+    explicit SET_SYS(Core::System& system_);
     ~SET_SYS() override;
 
 private:

--- a/src/core/hle/service/set/settings.cpp
+++ b/src/core/hle/service/set/settings.cpp
@@ -7,14 +7,15 @@
 #include "core/hle/service/set/set_fd.h"
 #include "core/hle/service/set/set_sys.h"
 #include "core/hle/service/set/settings.h"
+#include "core/hle/service/sm/sm.h"
 
 namespace Service::Set {
 
-void InstallInterfaces(SM::ServiceManager& service_manager) {
-    std::make_shared<SET>()->InstallAsService(service_manager);
-    std::make_shared<SET_CAL>()->InstallAsService(service_manager);
-    std::make_shared<SET_FD>()->InstallAsService(service_manager);
-    std::make_shared<SET_SYS>()->InstallAsService(service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {
+    std::make_shared<SET>(system)->InstallAsService(service_manager);
+    std::make_shared<SET_CAL>(system)->InstallAsService(service_manager);
+    std::make_shared<SET_FD>(system)->InstallAsService(service_manager);
+    std::make_shared<SET_SYS>(system)->InstallAsService(service_manager);
 }
 
 } // namespace Service::Set

--- a/src/core/hle/service/set/settings.h
+++ b/src/core/hle/service/set/settings.h
@@ -4,11 +4,17 @@
 
 #pragma once
 
-#include "core/hle/service/service.h"
+namespace Core {
+class System;
+}
+
+namespace Service::SM {
+class ServiceManager;
+}
 
 namespace Service::Set {
 
 /// Registers all Settings services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace Service::Set

--- a/src/core/hle/service/sm/controller.cpp
+++ b/src/core/hle/service/sm/controller.cpp
@@ -48,7 +48,7 @@ void Controller::QueryPointerBufferSize(Kernel::HLERequestContext& ctx) {
 }
 
 // https://switchbrew.org/wiki/IPC_Marshalling
-Controller::Controller() : ServiceFramework("IpcController") {
+Controller::Controller(Core::System& system_) : ServiceFramework{system_, "IpcController"} {
     static const FunctionInfo functions[] = {
         {0, &Controller::ConvertCurrentObjectToDomain, "ConvertCurrentObjectToDomain"},
         {1, nullptr, "CopyFromCurrentDomain"},

--- a/src/core/hle/service/sm/controller.h
+++ b/src/core/hle/service/sm/controller.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 
 class Controller final : public ServiceFramework<Controller> {
 public:
-    Controller();
+    explicit Controller(Core::System& system_);
     ~Controller() override;
 
 private:

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -16,6 +16,10 @@
 #include "core/hle/result.h"
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 class ClientPort;
 class ClientSession;
@@ -31,7 +35,7 @@ class Controller;
 /// Interface to "sm:" service
 class SM final : public ServiceFramework<SM> {
 public:
-    explicit SM(std::shared_ptr<ServiceManager> service_manager, Kernel::KernelCore& kernel);
+    explicit SM(std::shared_ptr<ServiceManager> service_manager_, Core::System& system_);
     ~SM() override;
 
 private:
@@ -46,7 +50,7 @@ private:
 
 class ServiceManager {
 public:
-    static void InstallInterfaces(std::shared_ptr<ServiceManager> self, Kernel::KernelCore& kernel);
+    static void InstallInterfaces(std::shared_ptr<ServiceManager> self, Core::System& system);
 
     explicit ServiceManager(Kernel::KernelCore& kernel_);
     ~ServiceManager();

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -827,8 +827,8 @@ void BSD::BuildErrnoResponse(Kernel::HLERequestContext& ctx, Errno bsd_errno) co
     rb.PushEnum(bsd_errno);
 }
 
-BSD::BSD(Core::System& system, const char* name)
-    : ServiceFramework(name), worker_pool{system, this} {
+BSD::BSD(Core::System& system_, const char* name)
+    : ServiceFramework{system_, name}, worker_pool{system_, this} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &BSD::RegisterClient, "RegisterClient"},
@@ -873,7 +873,7 @@ BSD::BSD(Core::System& system, const char* name)
 
 BSD::~BSD() = default;
 
-BSDCFG::BSDCFG() : ServiceFramework{"bsdcfg"} {
+BSDCFG::BSDCFG(Core::System& system_) : ServiceFramework{system_, "bsdcfg"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "SetIfUp"},

--- a/src/core/hle/service/sockets/bsd.h
+++ b/src/core/hle/service/sockets/bsd.h
@@ -26,7 +26,7 @@ namespace Service::Sockets {
 
 class BSD final : public ServiceFramework<BSD> {
 public:
-    explicit BSD(Core::System& system, const char* name);
+    explicit BSD(Core::System& system_, const char* name);
     ~BSD() override;
 
 private:
@@ -176,7 +176,7 @@ private:
 
 class BSDCFG final : public ServiceFramework<BSDCFG> {
 public:
-    explicit BSDCFG();
+    explicit BSDCFG(Core::System& system_);
     ~BSDCFG() override;
 };
 

--- a/src/core/hle/service/sockets/ethc.cpp
+++ b/src/core/hle/service/sockets/ethc.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::Sockets {
 
-ETHC_C::ETHC_C() : ServiceFramework{"ethc:c"} {
+ETHC_C::ETHC_C(Core::System& system_) : ServiceFramework{system_, "ethc:c"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "Initialize"},
@@ -23,7 +23,7 @@ ETHC_C::ETHC_C() : ServiceFramework{"ethc:c"} {
 
 ETHC_C::~ETHC_C() = default;
 
-ETHC_I::ETHC_I() : ServiceFramework{"ethc:i"} {
+ETHC_I::ETHC_I(Core::System& system_) : ServiceFramework{system_, "ethc:i"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "GetReadableHandle"},

--- a/src/core/hle/service/sockets/ethc.h
+++ b/src/core/hle/service/sockets/ethc.h
@@ -6,17 +6,21 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Sockets {
 
 class ETHC_C final : public ServiceFramework<ETHC_C> {
 public:
-    explicit ETHC_C();
+    explicit ETHC_C(Core::System& system_);
     ~ETHC_C() override;
 };
 
 class ETHC_I final : public ServiceFramework<ETHC_I> {
 public:
-    explicit ETHC_I();
+    explicit ETHC_I(Core::System& system_);
     ~ETHC_I() override;
 };
 

--- a/src/core/hle/service/sockets/nsd.cpp
+++ b/src/core/hle/service/sockets/nsd.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::Sockets {
 
-NSD::NSD(const char* name) : ServiceFramework(name) {
+NSD::NSD(Core::System& system_, const char* name) : ServiceFramework{system_, name} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {10, nullptr, "GetSettingName"},

--- a/src/core/hle/service/sockets/nsd.h
+++ b/src/core/hle/service/sockets/nsd.h
@@ -4,14 +4,17 @@
 
 #pragma once
 
-#include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/service/service.h"
+
+namespace Core {
+class System;
+}
 
 namespace Service::Sockets {
 
 class NSD final : public ServiceFramework<NSD> {
 public:
-    explicit NSD(const char* name);
+    explicit NSD(Core::System& system_, const char* name);
     ~NSD() override;
 };
 

--- a/src/core/hle/service/sockets/sfdnsres.cpp
+++ b/src/core/hle/service/sockets/sfdnsres.cpp
@@ -7,25 +7,7 @@
 
 namespace Service::Sockets {
 
-void SFDNSRES::GetAddrInfoRequest(Kernel::HLERequestContext& ctx) {
-    struct Parameters {
-        u8 use_nsd_resolve;
-        u32 unknown;
-        u64 process_id;
-    };
-
-    IPC::RequestParser rp{ctx};
-    const auto parameters = rp.PopRaw<Parameters>();
-
-    LOG_WARNING(Service,
-                "(STUBBED) called. use_nsd_resolve={}, unknown=0x{:08X}, process_id=0x{:016X}",
-                parameters.use_nsd_resolve, parameters.unknown, parameters.process_id);
-
-    IPC::ResponseBuilder rb{ctx, 2};
-    rb.Push(RESULT_SUCCESS);
-}
-
-SFDNSRES::SFDNSRES() : ServiceFramework("sfdnsres") {
+SFDNSRES::SFDNSRES(Core::System& system_) : ServiceFramework{system_, "sfdnsres"} {
     static const FunctionInfo functions[] = {
         {0, nullptr, "SetDnsAddressesPrivate"},
         {1, nullptr, "GetDnsAddressPrivate"},
@@ -48,5 +30,23 @@ SFDNSRES::SFDNSRES() : ServiceFramework("sfdnsres") {
 }
 
 SFDNSRES::~SFDNSRES() = default;
+
+void SFDNSRES::GetAddrInfoRequest(Kernel::HLERequestContext& ctx) {
+    struct Parameters {
+        u8 use_nsd_resolve;
+        u32 unknown;
+        u64 process_id;
+    };
+
+    IPC::RequestParser rp{ctx};
+    const auto parameters = rp.PopRaw<Parameters>();
+
+    LOG_WARNING(Service,
+                "(STUBBED) called. use_nsd_resolve={}, unknown=0x{:08X}, process_id=0x{:016X}",
+                parameters.use_nsd_resolve, parameters.unknown, parameters.process_id);
+
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(RESULT_SUCCESS);
+}
 
 } // namespace Service::Sockets

--- a/src/core/hle/service/sockets/sfdnsres.h
+++ b/src/core/hle/service/sockets/sfdnsres.h
@@ -7,11 +7,15 @@
 #include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Sockets {
 
 class SFDNSRES final : public ServiceFramework<SFDNSRES> {
 public:
-    explicit SFDNSRES();
+    explicit SFDNSRES(Core::System& system_);
     ~SFDNSRES() override;
 
 private:

--- a/src/core/hle/service/sockets/sockets.cpp
+++ b/src/core/hle/service/sockets/sockets.cpp
@@ -13,15 +13,15 @@ namespace Service::Sockets {
 void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {
     std::make_shared<BSD>(system, "bsd:s")->InstallAsService(service_manager);
     std::make_shared<BSD>(system, "bsd:u")->InstallAsService(service_manager);
-    std::make_shared<BSDCFG>()->InstallAsService(service_manager);
+    std::make_shared<BSDCFG>(system)->InstallAsService(service_manager);
 
-    std::make_shared<ETHC_C>()->InstallAsService(service_manager);
-    std::make_shared<ETHC_I>()->InstallAsService(service_manager);
+    std::make_shared<ETHC_C>(system)->InstallAsService(service_manager);
+    std::make_shared<ETHC_I>(system)->InstallAsService(service_manager);
 
-    std::make_shared<NSD>("nsd:a")->InstallAsService(service_manager);
-    std::make_shared<NSD>("nsd:u")->InstallAsService(service_manager);
+    std::make_shared<NSD>(system, "nsd:a")->InstallAsService(service_manager);
+    std::make_shared<NSD>(system, "nsd:u")->InstallAsService(service_manager);
 
-    std::make_shared<SFDNSRES>()->InstallAsService(service_manager);
+    std::make_shared<SFDNSRES>(system)->InstallAsService(service_manager);
 }
 
 } // namespace Service::Sockets

--- a/src/core/hle/service/spl/csrng.cpp
+++ b/src/core/hle/service/spl/csrng.cpp
@@ -6,7 +6,8 @@
 
 namespace Service::SPL {
 
-CSRNG::CSRNG(std::shared_ptr<Module> module) : Module::Interface(std::move(module), "csrng") {
+CSRNG::CSRNG(Core::System& system_, std::shared_ptr<Module> module_)
+    : Interface(system_, std::move(module_), "csrng") {
     static const FunctionInfo functions[] = {
         {0, &CSRNG::GetRandomBytes, "GetRandomBytes"},
     };

--- a/src/core/hle/service/spl/csrng.h
+++ b/src/core/hle/service/spl/csrng.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/spl/module.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::SPL {
 
 class CSRNG final : public Module::Interface {
 public:
-    explicit CSRNG(std::shared_ptr<Module> module);
+    explicit CSRNG(Core::System& system_, std::shared_ptr<Module> module_);
     ~CSRNG() override;
 };
 

--- a/src/core/hle/service/spl/module.cpp
+++ b/src/core/hle/service/spl/module.cpp
@@ -17,8 +17,9 @@
 
 namespace Service::SPL {
 
-Module::Interface::Interface(std::shared_ptr<Module> module, const char* name)
-    : ServiceFramework(name), module(std::move(module)),
+Module::Interface::Interface(Core::System& system_, std::shared_ptr<Module> module_,
+                             const char* name)
+    : ServiceFramework{system_, name}, module{std::move(module_)},
       rng(Settings::values.rng_seed.GetValue().value_or(std::time(nullptr))) {}
 
 Module::Interface::~Interface() = default;
@@ -38,10 +39,10 @@ void Module::Interface::GetRandomBytes(Kernel::HLERequestContext& ctx) {
     rb.Push(RESULT_SUCCESS);
 }
 
-void InstallInterfaces(SM::ServiceManager& service_manager) {
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {
     auto module = std::make_shared<Module>();
-    std::make_shared<CSRNG>(module)->InstallAsService(service_manager);
-    std::make_shared<SPL>(module)->InstallAsService(service_manager);
+    std::make_shared<CSRNG>(system, module)->InstallAsService(service_manager);
+    std::make_shared<SPL>(system, module)->InstallAsService(service_manager);
 }
 
 } // namespace Service::SPL

--- a/src/core/hle/service/spl/module.h
+++ b/src/core/hle/service/spl/module.h
@@ -7,13 +7,18 @@
 #include <random>
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::SPL {
 
 class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        explicit Interface(std::shared_ptr<Module> module, const char* name);
+        explicit Interface(Core::System& system_, std::shared_ptr<Module> module_,
+                           const char* name);
         ~Interface() override;
 
         void GetRandomBytes(Kernel::HLERequestContext& ctx);
@@ -27,6 +32,6 @@ public:
 };
 
 /// Registers all SPL services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace Service::SPL

--- a/src/core/hle/service/spl/spl.cpp
+++ b/src/core/hle/service/spl/spl.cpp
@@ -6,7 +6,8 @@
 
 namespace Service::SPL {
 
-SPL::SPL(std::shared_ptr<Module> module) : Module::Interface(std::move(module), "spl:") {
+SPL::SPL(Core::System& system_, std::shared_ptr<Module> module_)
+    : Interface(system_, std::move(module_), "spl:") {
     static const FunctionInfo functions[] = {
         {0, nullptr, "GetConfig"},
         {1, nullptr, "ModularExponentiate"},

--- a/src/core/hle/service/spl/spl.h
+++ b/src/core/hle/service/spl/spl.h
@@ -6,11 +6,15 @@
 
 #include "core/hle/service/spl/module.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::SPL {
 
 class SPL final : public Module::Interface {
 public:
-    explicit SPL(std::shared_ptr<Module> module);
+    explicit SPL(Core::System& system_, std::shared_ptr<Module> module_);
     ~SPL() override;
 };
 

--- a/src/core/hle/service/ssl/ssl.cpp
+++ b/src/core/hle/service/ssl/ssl.cpp
@@ -12,7 +12,7 @@ namespace Service::SSL {
 
 class ISslConnection final : public ServiceFramework<ISslConnection> {
 public:
-    ISslConnection() : ServiceFramework("ISslConnection") {
+    explicit ISslConnection(Core::System& system_) : ServiceFramework{system_, "ISslConnection"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "SetSocketDescriptor"},
@@ -52,7 +52,7 @@ public:
 
 class ISslContext final : public ServiceFramework<ISslContext> {
 public:
-    ISslContext() : ServiceFramework("ISslContext") {
+    explicit ISslContext(Core::System& system_) : ServiceFramework{system_, "ISslContext"} {
         static const FunctionInfo functions[] = {
             {0, &ISslContext::SetOption, "SetOption"},
             {1, nullptr, "GetOption"},
@@ -92,13 +92,13 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<ISslConnection>();
+        rb.PushIpcInterface<ISslConnection>(system);
     }
 };
 
 class SSL final : public ServiceFramework<SSL> {
 public:
-    explicit SSL() : ServiceFramework{"ssl"} {
+    explicit SSL(Core::System& system_) : ServiceFramework{system_, "ssl"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &SSL::CreateContext, "CreateContext"},
@@ -123,7 +123,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<ISslContext>();
+        rb.PushIpcInterface<ISslContext>(system);
     }
 
     void SetInterfaceVersion(Kernel::HLERequestContext& ctx) {
@@ -137,8 +137,8 @@ private:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& service_manager) {
-    std::make_shared<SSL>()->InstallAsService(service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {
+    std::make_shared<SSL>(system)->InstallAsService(service_manager);
 }
 
 } // namespace Service::SSL

--- a/src/core/hle/service/ssl/ssl.h
+++ b/src/core/hle/service/ssl/ssl.h
@@ -4,6 +4,10 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
@@ -11,6 +15,6 @@ class ServiceManager;
 namespace Service::SSL {
 
 /// Registers all SSL services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system);
 
 } // namespace Service::SSL

--- a/src/core/hle/service/time/interface.cpp
+++ b/src/core/hle/service/time/interface.cpp
@@ -7,7 +7,7 @@
 namespace Service::Time {
 
 Time::Time(std::shared_ptr<Module> module, Core::System& system, const char* name)
-    : Module::Interface(std::move(module), system, name) {
+    : Interface(std::move(module), system, name) {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &Time::GetStandardUserSystemClock, "GetStandardUserSystemClock"},

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -21,8 +21,8 @@ namespace Service::Time {
 
 class ISystemClock final : public ServiceFramework<ISystemClock> {
 public:
-    explicit ISystemClock(Clock::SystemClockCore& clock_core, Core::System& system)
-        : ServiceFramework("ISystemClock"), clock_core{clock_core}, system{system} {
+    explicit ISystemClock(Clock::SystemClockCore& clock_core_, Core::System& system_)
+        : ServiceFramework{system_, "ISystemClock"}, clock_core{clock_core_} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &ISystemClock::GetCurrentTime, "GetCurrentTime"},
@@ -82,13 +82,12 @@ private:
     }
 
     Clock::SystemClockCore& clock_core;
-    Core::System& system;
 };
 
 class ISteadyClock final : public ServiceFramework<ISteadyClock> {
 public:
-    explicit ISteadyClock(Clock::SteadyClockCore& clock_core, Core::System& system)
-        : ServiceFramework("ISteadyClock"), clock_core{clock_core}, system{system} {
+    explicit ISteadyClock(Clock::SteadyClockCore& clock_core_, Core::System& system_)
+        : ServiceFramework{system_, "ISteadyClock"}, clock_core{clock_core_} {
         static const FunctionInfo functions[] = {
             {0, &ISteadyClock::GetCurrentTimePoint, "GetCurrentTimePoint"},
             {2, nullptr, "GetTestOffset"},
@@ -119,7 +118,6 @@ private:
     }
 
     Clock::SteadyClockCore& clock_core;
-    Core::System& system;
 };
 
 ResultCode Module::Interface::GetClockSnapshotFromSystemClockContextInternal(
@@ -206,7 +204,8 @@ void Module::Interface::GetTimeZoneService(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_Time, "called");
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
-    rb.PushIpcInterface<ITimeZoneService>(system.GetTimeManager().GetTimeZoneContentManager());
+    rb.PushIpcInterface<ITimeZoneService>(system,
+                                          system.GetTimeManager().GetTimeZoneContentManager());
 }
 
 void Module::Interface::GetStandardLocalSystemClock(Kernel::HLERequestContext& ctx) {
@@ -375,8 +374,9 @@ void Module::Interface::GetSharedMemoryNativeHandle(Kernel::HLERequestContext& c
     rb.PushCopyObjects(SharedFrom(&system.Kernel().GetTimeSharedMem()));
 }
 
-Module::Interface::Interface(std::shared_ptr<Module> module, Core::System& system, const char* name)
-    : ServiceFramework(name), module{std::move(module)}, system{system} {}
+Module::Interface::Interface(std::shared_ptr<Module> module_, Core::System& system_,
+                             const char* name)
+    : ServiceFramework{system_, name}, module{std::move(module_)} {}
 
 Module::Interface::~Interface() = default;
 

--- a/src/core/hle/service/time/time.h
+++ b/src/core/hle/service/time/time.h
@@ -20,7 +20,8 @@ public:
 
     class Interface : public ServiceFramework<Interface> {
     public:
-        explicit Interface(std::shared_ptr<Module> module, Core::System& system, const char* name);
+        explicit Interface(std::shared_ptr<Module> module_, Core::System& system_,
+                           const char* name);
         ~Interface() override;
 
         void GetStandardUserSystemClock(Kernel::HLERequestContext& ctx);
@@ -44,7 +45,6 @@ public:
 
     protected:
         std::shared_ptr<Module> module;
-        Core::System& system;
     };
 };
 

--- a/src/core/hle/service/time/time_zone_service.cpp
+++ b/src/core/hle/service/time/time_zone_service.cpp
@@ -10,8 +10,9 @@
 
 namespace Service::Time {
 
-ITimeZoneService ::ITimeZoneService(TimeZone::TimeZoneContentManager& time_zone_content_manager)
-    : ServiceFramework("ITimeZoneService"), time_zone_content_manager{time_zone_content_manager} {
+ITimeZoneService ::ITimeZoneService(Core::System& system_,
+                                    TimeZone::TimeZoneContentManager& time_zone_manager_)
+    : ServiceFramework{system_, "ITimeZoneService"}, time_zone_content_manager{time_zone_manager_} {
     static const FunctionInfo functions[] = {
         {0, &ITimeZoneService::GetDeviceLocationName, "GetDeviceLocationName"},
         {1, nullptr, "SetDeviceLocationName"},

--- a/src/core/hle/service/time/time_zone_service.h
+++ b/src/core/hle/service/time/time_zone_service.h
@@ -6,6 +6,10 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Service::Time {
 
 namespace TimeZone {
@@ -14,7 +18,8 @@ class TimeZoneContentManager;
 
 class ITimeZoneService final : public ServiceFramework<ITimeZoneService> {
 public:
-    explicit ITimeZoneService(TimeZone::TimeZoneContentManager& time_zone_manager);
+    explicit ITimeZoneService(Core::System& system_,
+                              TimeZone::TimeZoneContentManager& time_zone_manager_);
 
 private:
     void GetDeviceLocationName(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/usb/usb.cpp
+++ b/src/core/hle/service/usb/usb.cpp
@@ -15,7 +15,7 @@ namespace Service::USB {
 
 class IDsInterface final : public ServiceFramework<IDsInterface> {
 public:
-    explicit IDsInterface() : ServiceFramework{"IDsInterface"} {
+    explicit IDsInterface(Core::System& system_) : ServiceFramework{system_, "IDsInterface"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "GetDsEndpoint"},
@@ -40,7 +40,7 @@ public:
 
 class USB_DS final : public ServiceFramework<USB_DS> {
 public:
-    explicit USB_DS() : ServiceFramework{"usb:ds"} {
+    explicit USB_DS(Core::System& system_) : ServiceFramework{system_, "usb:ds"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "BindDevice"},
@@ -65,7 +65,8 @@ public:
 
 class IClientEpSession final : public ServiceFramework<IClientEpSession> {
 public:
-    explicit IClientEpSession() : ServiceFramework{"IClientEpSession"} {
+    explicit IClientEpSession(Core::System& system_)
+        : ServiceFramework{system_, "IClientEpSession"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Open"},
@@ -86,7 +87,8 @@ public:
 
 class IClientIfSession final : public ServiceFramework<IClientIfSession> {
 public:
-    explicit IClientIfSession() : ServiceFramework{"IClientIfSession"} {
+    explicit IClientIfSession(Core::System& system_)
+        : ServiceFramework{system_, "IClientIfSession"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Unknown0"},
@@ -108,7 +110,7 @@ public:
 
 class USB_HS final : public ServiceFramework<USB_HS> {
 public:
-    explicit USB_HS() : ServiceFramework{"usb:hs"} {
+    explicit USB_HS(Core::System& system_) : ServiceFramework{system_, "usb:hs"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "BindClientProcess"},
@@ -129,7 +131,7 @@ public:
 
 class IPdSession final : public ServiceFramework<IPdSession> {
 public:
-    explicit IPdSession() : ServiceFramework{"IPdSession"} {
+    explicit IPdSession(Core::System& system_) : ServiceFramework{system_, "IPdSession"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "BindNoticeEvent"},
@@ -148,7 +150,7 @@ public:
 
 class USB_PD final : public ServiceFramework<USB_PD> {
 public:
-    explicit USB_PD() : ServiceFramework{"usb:pd"} {
+    explicit USB_PD(Core::System& system_) : ServiceFramework{system_, "usb:pd"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &USB_PD::GetPdSession, "GetPdSession"},
@@ -164,13 +166,14 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IPdSession>();
+        rb.PushIpcInterface<IPdSession>(system);
     }
 };
 
 class IPdCradleSession final : public ServiceFramework<IPdCradleSession> {
 public:
-    explicit IPdCradleSession() : ServiceFramework{"IPdCradleSession"} {
+    explicit IPdCradleSession(Core::System& system_)
+        : ServiceFramework{system_, "IPdCradleSession"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "VdmUserWrite"},
@@ -191,7 +194,7 @@ public:
 
 class USB_PD_C final : public ServiceFramework<USB_PD_C> {
 public:
-    explicit USB_PD_C() : ServiceFramework{"usb:pd:c"} {
+    explicit USB_PD_C(Core::System& system_) : ServiceFramework{system_, "usb:pd:c"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &USB_PD_C::GetPdCradleSession, "GetPdCradleSession"},
@@ -205,7 +208,7 @@ private:
     void GetPdCradleSession(Kernel::HLERequestContext& ctx) {
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IPdCradleSession>();
+        rb.PushIpcInterface<IPdCradleSession>(system);
 
         LOG_DEBUG(Service_USB, "called");
     }
@@ -213,7 +216,7 @@ private:
 
 class USB_PM final : public ServiceFramework<USB_PM> {
 public:
-    explicit USB_PM() : ServiceFramework{"usb:pm"} {
+    explicit USB_PM(Core::System& system_) : ServiceFramework{system_, "usb:pm"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Unknown0"},
@@ -229,12 +232,12 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<USB_DS>()->InstallAsService(sm);
-    std::make_shared<USB_HS>()->InstallAsService(sm);
-    std::make_shared<USB_PD>()->InstallAsService(sm);
-    std::make_shared<USB_PD_C>()->InstallAsService(sm);
-    std::make_shared<USB_PM>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<USB_DS>(system)->InstallAsService(sm);
+    std::make_shared<USB_HS>(system)->InstallAsService(sm);
+    std::make_shared<USB_PD>(system)->InstallAsService(sm);
+    std::make_shared<USB_PD_C>(system)->InstallAsService(sm);
+    std::make_shared<USB_PM>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::USB

--- a/src/core/hle/service/usb/usb.h
+++ b/src/core/hle/service/usb/usb.h
@@ -4,12 +4,16 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::USB {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::USB

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -492,8 +492,8 @@ private:
 
 class IHOSBinderDriver final : public ServiceFramework<IHOSBinderDriver> {
 public:
-    explicit IHOSBinderDriver(NVFlinger::NVFlinger& nv_flinger)
-        : ServiceFramework("IHOSBinderDriver"), nv_flinger(nv_flinger) {
+    explicit IHOSBinderDriver(Core::System& system_, NVFlinger::NVFlinger& nv_flinger_)
+        : ServiceFramework{system_, "IHOSBinderDriver"}, nv_flinger(nv_flinger_) {
         static const FunctionInfo functions[] = {
             {0, &IHOSBinderDriver::TransactParcel, "TransactParcel"},
             {1, &IHOSBinderDriver::AdjustRefcount, "AdjustRefcount"},
@@ -689,7 +689,8 @@ private:
 
 class ISystemDisplayService final : public ServiceFramework<ISystemDisplayService> {
 public:
-    explicit ISystemDisplayService() : ServiceFramework("ISystemDisplayService") {
+    explicit ISystemDisplayService(Core::System& system_)
+        : ServiceFramework{system_, "ISystemDisplayService"} {
         static const FunctionInfo functions[] = {
             {1200, nullptr, "GetZOrderCountMin"},
             {1202, nullptr, "GetZOrderCountMax"},
@@ -790,8 +791,8 @@ private:
 
 class IManagerDisplayService final : public ServiceFramework<IManagerDisplayService> {
 public:
-    explicit IManagerDisplayService(NVFlinger::NVFlinger& nv_flinger)
-        : ServiceFramework("IManagerDisplayService"), nv_flinger(nv_flinger) {
+    explicit IManagerDisplayService(Core::System& system_, NVFlinger::NVFlinger& nv_flinger_)
+        : ServiceFramework{system_, "IManagerDisplayService"}, nv_flinger{nv_flinger_} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {200, nullptr, "AllocateProcessHeapBlock"},
@@ -935,7 +936,7 @@ private:
 
 class IApplicationDisplayService final : public ServiceFramework<IApplicationDisplayService> {
 public:
-    explicit IApplicationDisplayService(NVFlinger::NVFlinger& nv_flinger);
+    explicit IApplicationDisplayService(Core::System& system_, NVFlinger::NVFlinger& nv_flinger_);
 
 private:
     enum class ConvertedScaleMode : u64 {
@@ -959,7 +960,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IHOSBinderDriver>(nv_flinger);
+        rb.PushIpcInterface<IHOSBinderDriver>(system, nv_flinger);
     }
 
     void GetSystemDisplayService(Kernel::HLERequestContext& ctx) {
@@ -967,7 +968,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<ISystemDisplayService>();
+        rb.PushIpcInterface<ISystemDisplayService>(system);
     }
 
     void GetManagerDisplayService(Kernel::HLERequestContext& ctx) {
@@ -975,7 +976,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IManagerDisplayService>(nv_flinger);
+        rb.PushIpcInterface<IManagerDisplayService>(system, nv_flinger);
     }
 
     void GetIndirectDisplayTransactionService(Kernel::HLERequestContext& ctx) {
@@ -983,7 +984,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2, 0, 1};
         rb.Push(RESULT_SUCCESS);
-        rb.PushIpcInterface<IHOSBinderDriver>(nv_flinger);
+        rb.PushIpcInterface<IHOSBinderDriver>(system, nv_flinger);
     }
 
     void OpenDisplay(Kernel::HLERequestContext& ctx) {
@@ -1261,8 +1262,9 @@ private:
     NVFlinger::NVFlinger& nv_flinger;
 };
 
-IApplicationDisplayService::IApplicationDisplayService(NVFlinger::NVFlinger& nv_flinger)
-    : ServiceFramework("IApplicationDisplayService"), nv_flinger(nv_flinger) {
+IApplicationDisplayService::IApplicationDisplayService(Core::System& system_,
+                                                       NVFlinger::NVFlinger& nv_flinger_)
+    : ServiceFramework{system_, "IApplicationDisplayService"}, nv_flinger{nv_flinger_} {
     static const FunctionInfo functions[] = {
         {100, &IApplicationDisplayService::GetRelayService, "GetRelayService"},
         {101, &IApplicationDisplayService::GetSystemDisplayService, "GetSystemDisplayService"},
@@ -1303,8 +1305,8 @@ static bool IsValidServiceAccess(Permission permission, Policy policy) {
     return false;
 }
 
-void detail::GetDisplayServiceImpl(Kernel::HLERequestContext& ctx, NVFlinger::NVFlinger& nv_flinger,
-                                   Permission permission) {
+void detail::GetDisplayServiceImpl(Kernel::HLERequestContext& ctx, Core::System& system,
+                                   NVFlinger::NVFlinger& nv_flinger, Permission permission) {
     IPC::RequestParser rp{ctx};
     const auto policy = rp.PopEnum<Policy>();
 
@@ -1317,13 +1319,14 @@ void detail::GetDisplayServiceImpl(Kernel::HLERequestContext& ctx, NVFlinger::NV
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(RESULT_SUCCESS);
-    rb.PushIpcInterface<IApplicationDisplayService>(nv_flinger);
+    rb.PushIpcInterface<IApplicationDisplayService>(system, nv_flinger);
 }
 
-void InstallInterfaces(SM::ServiceManager& service_manager, NVFlinger::NVFlinger& nv_flinger) {
-    std::make_shared<VI_M>(nv_flinger)->InstallAsService(service_manager);
-    std::make_shared<VI_S>(nv_flinger)->InstallAsService(service_manager);
-    std::make_shared<VI_U>(nv_flinger)->InstallAsService(service_manager);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system,
+                       NVFlinger::NVFlinger& nv_flinger) {
+    std::make_shared<VI_M>(system, nv_flinger)->InstallAsService(service_manager);
+    std::make_shared<VI_S>(system, nv_flinger)->InstallAsService(service_manager);
+    std::make_shared<VI_U>(system, nv_flinger)->InstallAsService(service_manager);
 }
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi.h
+++ b/src/core/hle/service/vi/vi.h
@@ -7,6 +7,10 @@
 #include <memory>
 #include "common/common_types.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 class HLERequestContext;
 }
@@ -43,11 +47,12 @@ enum class Policy {
 };
 
 namespace detail {
-void GetDisplayServiceImpl(Kernel::HLERequestContext& ctx, NVFlinger::NVFlinger& nv_flinger,
-                           Permission permission);
+void GetDisplayServiceImpl(Kernel::HLERequestContext& ctx, Core::System& system,
+                           NVFlinger::NVFlinger& nv_flinger, Permission permission);
 } // namespace detail
 
 /// Registers all VI services with the specified service manager.
-void InstallInterfaces(SM::ServiceManager& service_manager, NVFlinger::NVFlinger& nv_flinger);
+void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system,
+                       NVFlinger::NVFlinger& nv_flinger);
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_m.cpp
+++ b/src/core/hle/service/vi/vi_m.cpp
@@ -8,7 +8,8 @@
 
 namespace Service::VI {
 
-VI_M::VI_M(NVFlinger::NVFlinger& nv_flinger) : ServiceFramework{"vi:m"}, nv_flinger{nv_flinger} {
+VI_M::VI_M(Core::System& system_, NVFlinger::NVFlinger& nv_flinger_)
+    : ServiceFramework{system_, "vi:m"}, nv_flinger{nv_flinger_} {
     static const FunctionInfo functions[] = {
         {2, &VI_M::GetDisplayService, "GetDisplayService"},
         {3, nullptr, "GetDisplayServiceWithProxyNameExchange"},
@@ -21,7 +22,7 @@ VI_M::~VI_M() = default;
 void VI_M::GetDisplayService(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_VI, "called");
 
-    detail::GetDisplayServiceImpl(ctx, nv_flinger, Permission::Manager);
+    detail::GetDisplayServiceImpl(ctx, system, nv_flinger, Permission::Manager);
 }
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_m.h
+++ b/src/core/hle/service/vi/vi_m.h
@@ -6,6 +6,10 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 class HLERequestContext;
 }
@@ -18,7 +22,7 @@ namespace Service::VI {
 
 class VI_M final : public ServiceFramework<VI_M> {
 public:
-    explicit VI_M(NVFlinger::NVFlinger& nv_flinger);
+    explicit VI_M(Core::System& system_, NVFlinger::NVFlinger& nv_flinger_);
     ~VI_M() override;
 
 private:

--- a/src/core/hle/service/vi/vi_s.cpp
+++ b/src/core/hle/service/vi/vi_s.cpp
@@ -8,7 +8,8 @@
 
 namespace Service::VI {
 
-VI_S::VI_S(NVFlinger::NVFlinger& nv_flinger) : ServiceFramework{"vi:s"}, nv_flinger{nv_flinger} {
+VI_S::VI_S(Core::System& system_, NVFlinger::NVFlinger& nv_flinger_)
+    : ServiceFramework{system_, "vi:s"}, nv_flinger{nv_flinger_} {
     static const FunctionInfo functions[] = {
         {1, &VI_S::GetDisplayService, "GetDisplayService"},
         {3, nullptr, "GetDisplayServiceWithProxyNameExchange"},
@@ -21,7 +22,7 @@ VI_S::~VI_S() = default;
 void VI_S::GetDisplayService(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_VI, "called");
 
-    detail::GetDisplayServiceImpl(ctx, nv_flinger, Permission::System);
+    detail::GetDisplayServiceImpl(ctx, system, nv_flinger, Permission::System);
 }
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_s.h
+++ b/src/core/hle/service/vi/vi_s.h
@@ -6,6 +6,10 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 class HLERequestContext;
 }
@@ -18,7 +22,7 @@ namespace Service::VI {
 
 class VI_S final : public ServiceFramework<VI_S> {
 public:
-    explicit VI_S(NVFlinger::NVFlinger& nv_flinger);
+    explicit VI_S(Core::System& system_, NVFlinger::NVFlinger& nv_flinger_);
     ~VI_S() override;
 
 private:

--- a/src/core/hle/service/vi/vi_u.cpp
+++ b/src/core/hle/service/vi/vi_u.cpp
@@ -8,7 +8,8 @@
 
 namespace Service::VI {
 
-VI_U::VI_U(NVFlinger::NVFlinger& nv_flinger) : ServiceFramework{"vi:u"}, nv_flinger{nv_flinger} {
+VI_U::VI_U(Core::System& system_, NVFlinger::NVFlinger& nv_flinger_)
+    : ServiceFramework{system_, "vi:u"}, nv_flinger{nv_flinger_} {
     static const FunctionInfo functions[] = {
         {0, &VI_U::GetDisplayService, "GetDisplayService"},
         {1, nullptr, "GetDisplayServiceWithProxyNameExchange"},
@@ -21,7 +22,7 @@ VI_U::~VI_U() = default;
 void VI_U::GetDisplayService(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_VI, "called");
 
-    detail::GetDisplayServiceImpl(ctx, nv_flinger, Permission::User);
+    detail::GetDisplayServiceImpl(ctx, system, nv_flinger, Permission::User);
 }
 
 } // namespace Service::VI

--- a/src/core/hle/service/vi/vi_u.h
+++ b/src/core/hle/service/vi/vi_u.h
@@ -6,6 +6,10 @@
 
 #include "core/hle/service/service.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 class HLERequestContext;
 }
@@ -18,7 +22,7 @@ namespace Service::VI {
 
 class VI_U final : public ServiceFramework<VI_U> {
 public:
-    explicit VI_U(NVFlinger::NVFlinger& nv_flinger);
+    explicit VI_U(Core::System& system_, NVFlinger::NVFlinger& nv_flinger_);
     ~VI_U() override;
 
 private:

--- a/src/core/hle/service/wlan/wlan.cpp
+++ b/src/core/hle/service/wlan/wlan.cpp
@@ -12,7 +12,7 @@ namespace Service::WLAN {
 
 class WLANInfra final : public ServiceFramework<WLANInfra> {
 public:
-    explicit WLANInfra() : ServiceFramework{"wlan:inf"} {
+    explicit WLANInfra(Core::System& system_) : ServiceFramework{system_, "wlan:inf"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "OpenMode"},
@@ -55,7 +55,7 @@ public:
 
 class WLANLocal final : public ServiceFramework<WLANLocal> {
 public:
-    explicit WLANLocal() : ServiceFramework{"wlan:lcl"} {
+    explicit WLANLocal(Core::System& system_) : ServiceFramework{system_, "wlan:lcl"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Unknown0"},
@@ -120,7 +120,7 @@ public:
 
 class WLANLocalGetFrame final : public ServiceFramework<WLANLocalGetFrame> {
 public:
-    explicit WLANLocalGetFrame() : ServiceFramework{"wlan:lg"} {
+    explicit WLANLocalGetFrame(Core::System& system_) : ServiceFramework{system_, "wlan:lg"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Unknown"},
@@ -133,7 +133,7 @@ public:
 
 class WLANSocketGetFrame final : public ServiceFramework<WLANSocketGetFrame> {
 public:
-    explicit WLANSocketGetFrame() : ServiceFramework{"wlan:sg"} {
+    explicit WLANSocketGetFrame(Core::System& system_) : ServiceFramework{system_, "wlan:sg"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Unknown"},
@@ -146,7 +146,7 @@ public:
 
 class WLANSocketManager final : public ServiceFramework<WLANSocketManager> {
 public:
-    explicit WLANSocketManager() : ServiceFramework{"wlan:soc"} {
+    explicit WLANSocketManager(Core::System& system_) : ServiceFramework{system_, "wlan:soc"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "Unknown0"},
@@ -169,12 +169,12 @@ public:
     }
 };
 
-void InstallInterfaces(SM::ServiceManager& sm) {
-    std::make_shared<WLANInfra>()->InstallAsService(sm);
-    std::make_shared<WLANLocal>()->InstallAsService(sm);
-    std::make_shared<WLANLocalGetFrame>()->InstallAsService(sm);
-    std::make_shared<WLANSocketGetFrame>()->InstallAsService(sm);
-    std::make_shared<WLANSocketManager>()->InstallAsService(sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system) {
+    std::make_shared<WLANInfra>(system)->InstallAsService(sm);
+    std::make_shared<WLANLocal>(system)->InstallAsService(sm);
+    std::make_shared<WLANLocalGetFrame>(system)->InstallAsService(sm);
+    std::make_shared<WLANSocketGetFrame>(system)->InstallAsService(sm);
+    std::make_shared<WLANSocketManager>(system)->InstallAsService(sm);
 }
 
 } // namespace Service::WLAN

--- a/src/core/hle/service/wlan/wlan.h
+++ b/src/core/hle/service/wlan/wlan.h
@@ -4,12 +4,16 @@
 
 #pragma once
 
+namespace Core {
+class System;
+}
+
 namespace Service::SM {
 class ServiceManager;
 }
 
 namespace Service::WLAN {
 
-void InstallInterfaces(SM::ServiceManager& sm);
+void InstallInterfaces(SM::ServiceManager& sm, Core::System& system);
 
 } // namespace Service::WLAN

--- a/src/yuzu_tester/service/yuzutest.cpp
+++ b/src/yuzu_tester/service/yuzutest.cpp
@@ -4,6 +4,7 @@
 
 #include <memory>
 #include "common/string_util.h"
+#include "core/core.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/service/service.h"
 #include "core/hle/service/sm/sm.h"
@@ -15,10 +16,10 @@ constexpr u64 SERVICE_VERSION = 0x00000002;
 
 class YuzuTest final : public ServiceFramework<YuzuTest> {
 public:
-    explicit YuzuTest(std::string data,
-                      std::function<void(std::vector<TestResult>)> finish_callback)
-        : ServiceFramework{"yuzutest"}, data(std::move(data)),
-          finish_callback(std::move(finish_callback)) {
+    explicit YuzuTest(Core::System& system_, std::string data_,
+                      std::function<void(std::vector<TestResult>)> finish_callback_)
+        : ServiceFramework{system_, "yuzutest"}, data{std::move(data_)}, finish_callback{std::move(
+                                                                             finish_callback_)} {
         static const FunctionInfo functions[] = {
             {0, &YuzuTest::Initialize, "Initialize"},
             {1, &YuzuTest::GetServiceVersion, "GetServiceVersion"},
@@ -104,9 +105,11 @@ private:
     std::function<void(std::vector<TestResult>)> finish_callback;
 };
 
-void InstallInterfaces(SM::ServiceManager& sm, std::string data,
+void InstallInterfaces(Core::System& system, std::string data,
                        std::function<void(std::vector<TestResult>)> finish_callback) {
-    std::make_shared<YuzuTest>(data, finish_callback)->InstallAsService(sm);
+    auto& sm = system.ServiceManager();
+    std::make_shared<YuzuTest>(system, std::move(data), std::move(finish_callback))
+        ->InstallAsService(sm);
 }
 
 } // namespace Service::Yuzu

--- a/src/yuzu_tester/service/yuzutest.h
+++ b/src/yuzu_tester/service/yuzutest.h
@@ -7,8 +7,8 @@
 #include <functional>
 #include <string>
 
-namespace Service::SM {
-class ServiceManager;
+namespace Core {
+class System;
 }
 
 namespace Service::Yuzu {
@@ -19,7 +19,7 @@ struct TestResult {
     std::string name;
 };
 
-void InstallInterfaces(SM::ServiceManager& sm, std::string data,
+void InstallInterfaces(Core::System& system, std::string data,
                        std::function<void(std::vector<TestResult>)> finish_callback);
 
 } // namespace Service::Yuzu

--- a/src/yuzu_tester/yuzu.cpp
+++ b/src/yuzu_tester/yuzu.cpp
@@ -247,9 +247,10 @@ int main(int argc, char** argv) {
                          "additional help.\n\nError Code: {:04X}-{:04X}\nError Description: {}",
                          loader_id, error_id, static_cast<Loader::ResultStatus>(error_id));
         }
+        break;
     }
 
-    Service::Yuzu::InstallInterfaces(system.ServiceManager(), datastring, callback);
+    Service::Yuzu::InstallInterfaces(system, datastring, callback);
 
     system.TelemetrySession().AddField(Common::Telemetry::FieldType::App, "Frontend",
                                        "SDLHideTester");


### PR DESCRIPTION
Completely removes all usages of the global system instance within the services code by passing in the using system instance to the services.