### PR TITLE
Disable analog joystick from buttons by default

### DIFF
--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -178,6 +178,8 @@ struct Values {
     u16 udp_input_port;
     u8 udp_pad_index;
 
+    bool emulate_analog_keyboard;
+
     bool mouse_enabled;
     std::string mouse_device;
     MouseButtonsRaw mouse_buttons;

--- a/src/input_common/analog_from_button.cpp
+++ b/src/input_common/analog_from_button.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <thread>
 #include "common/math_util.h"
+#include "core/settings.h"
 #include "input_common/analog_from_button.h"
 
 namespace InputCommon {
@@ -112,7 +113,26 @@ public:
     }
 
     std::tuple<float, float> GetStatus() const override {
-        return std::make_tuple(std::cos(angle) * amplitude, std::sin(angle) * amplitude);
+        if (Settings::values.emulate_analog_keyboard) {
+            return std::make_tuple(std::cos(angle) * amplitude, std::sin(angle) * amplitude);
+        }
+        constexpr float SQRT_HALF = 0.707106781f;
+        int x = 0, y = 0;
+        if (right->GetStatus()) {
+            ++x;
+        }
+        if (left->GetStatus()) {
+            --x;
+        }
+        if (up->GetStatus()) {
+            ++y;
+        }
+        if (down->GetStatus()) {
+            --y;
+        }
+        const float coef = modifier->GetStatus() ? modifier_scale : 1.0f;
+        return std::make_tuple(static_cast<float>(x) * coef * (y == 0 ? 1.0f : SQRT_HALF),
+                               static_cast<float>(y) * coef * (x == 0 ? 1.0f : SQRT_HALF));
     }
 
     bool GetAnalogDirectionStatus(Input::AnalogDirection direction) const override {

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -510,6 +510,9 @@ void Config::ReadControlValues() {
     ReadTouchscreenValues();
     ReadMotionTouchValues();
 
+    Settings::values.emulate_analog_keyboard =
+        ReadSetting(QStringLiteral("emulate_analog_keyboard"), false).toBool();
+
     ReadSettingGlobal(Settings::values.use_docked_mode, QStringLiteral("use_docked_mode"), false);
     ReadSettingGlobal(Settings::values.vibration_enabled, QStringLiteral("vibration_enabled"),
                       true);
@@ -1193,6 +1196,8 @@ void Config::SaveControlValues() {
                  QString::fromStdString(Settings::values.touch_device),
                  QStringLiteral("engine:emu_window"));
     WriteSetting(QStringLiteral("keyboard_enabled"), Settings::values.keyboard_enabled, false);
+    WriteSetting(QStringLiteral("emulate_analog_keyboard"),
+                 Settings::values.emulate_analog_keyboard, false);
 
     qt_config->endGroup();
 }

--- a/src/yuzu/configuration/configure_input_advanced.cpp
+++ b/src/yuzu/configuration/configure_input_advanced.cpp
@@ -121,6 +121,7 @@ void ConfigureInputAdvanced::ApplyConfiguration() {
     Settings::values.debug_pad_enabled = ui->debug_enabled->isChecked();
     Settings::values.mouse_enabled = ui->mouse_enabled->isChecked();
     Settings::values.keyboard_enabled = ui->keyboard_enabled->isChecked();
+    Settings::values.emulate_analog_keyboard = ui->emulate_analog_keyboard->isChecked();
     Settings::values.touchscreen.enabled = ui->touchscreen_enabled->isChecked();
 }
 
@@ -147,6 +148,7 @@ void ConfigureInputAdvanced::LoadConfiguration() {
     ui->debug_enabled->setChecked(Settings::values.debug_pad_enabled);
     ui->mouse_enabled->setChecked(Settings::values.mouse_enabled);
     ui->keyboard_enabled->setChecked(Settings::values.keyboard_enabled);
+    ui->emulate_analog_keyboard->setChecked(Settings::values.emulate_analog_keyboard);
     ui->touchscreen_enabled->setChecked(Settings::values.touchscreen.enabled);
 
     UpdateUIEnabled();

--- a/src/yuzu/configuration/configure_input_advanced.ui
+++ b/src/yuzu/configuration/configure_input_advanced.ui
@@ -2546,14 +2546,27 @@
                  </property>
                 </widget>
                </item>
-               <item row="4" column="2">
+               <item row="1" column="0">
+                 <widget class="QCheckBox" name="emulate_analog_keyboard">
+                   <property name="minimumSize">
+                     <size>
+                       <width>0</width>
+                       <height>23</height>
+                     </size>
+                   </property>
+                   <property name="text">
+                     <string>Emulate Analog with Keyboard Input</string>
+                   </property>
+                 </widget>
+               </item>
+               <item row="5" column="2">
                 <widget class="QPushButton" name="touchscreen_advanced">
                  <property name="text">
                   <string>Advanced</string>
                  </property>
                 </widget>
                </item>
-               <item row="1" column="1">
+               <item row="2" column="1">
                 <spacer name="horizontalSpacer_8">
                  <property name="orientation">
                   <enum>Qt::Horizontal</enum>
@@ -2569,21 +2582,21 @@
                  </property>
                 </spacer>
                </item>
-               <item row="1" column="2">
+               <item row="2" column="2">
                 <widget class="QPushButton" name="mouse_advanced">
                  <property name="text">
                   <string>Advanced</string>
                  </property>
                 </widget>
                </item>
-               <item row="4" column="0">
+               <item row="5" column="0">
                 <widget class="QCheckBox" name="touchscreen_enabled">
                  <property name="text">
                   <string>Touchscreen</string>
                  </property>
                 </widget>
                </item>
-               <item row="1" column="0">
+               <item row="2" column="0">
                 <widget class="QCheckBox" name="mouse_enabled">
                  <property name="minimumSize">
                   <size>
@@ -2596,28 +2609,28 @@
                  </property>
                 </widget>
                </item>
-               <item row="6" column="0">
+               <item row="7" column="0">
                 <widget class="QLabel" name="motion_touch">
                  <property name="text">
                   <string>Motion / Touch</string>
                  </property>
                 </widget>
                </item>
-               <item row="6" column="2">
+               <item row="7" column="2">
                 <widget class="QPushButton" name="buttonMotionTouch">
                  <property name="text">
                   <string>Configure</string>
                  </property>
                 </widget>
                </item>
-               <item row="5" column="0">
+               <item row="6" column="0">
                 <widget class="QCheckBox" name="debug_enabled">
                  <property name="text">
                   <string>Debug Controller</string>
                  </property>
                 </widget>
                </item>
-               <item row="5" column="2">
+               <item row="6" column="2">
                 <widget class="QPushButton" name="debug_configure">
                  <property name="text">
                   <string>Configure</string>


### PR DESCRIPTION
Since this setting adds delay to the input, some games like SSBU don't work as intended. This will disable the setting by default and add a checkbox under advanced settings to enable it.