### PR TITLE
savedata_factory: Eliminate usage of the global system instance

### DIFF
--- a/src/core/file_sys/savedata_factory.h
+++ b/src/core/file_sys/savedata_factory.h
@@ -12,6 +12,10 @@
 #include "core/file_sys/vfs.h"
 #include "core/hle/result.h"
 
+namespace Core {
+class System;
+}
+
 namespace FileSys {
 
 enum class SaveDataSpaceId : u8 {
@@ -84,7 +88,7 @@ struct SaveDataSize {
 /// File system interface to the SaveData archive
 class SaveDataFactory {
 public:
-    explicit SaveDataFactory(VirtualDir dir);
+    explicit SaveDataFactory(Core::System& system_, VirtualDir save_directory_);
     ~SaveDataFactory();
 
     ResultVal<VirtualDir> Create(SaveDataSpaceId space, const SaveDataAttribute& meta) const;
@@ -93,8 +97,8 @@ public:
     VirtualDir GetSaveDataSpaceDirectory(SaveDataSpaceId space) const;
 
     static std::string GetSaveDataSpaceIdPath(SaveDataSpaceId space);
-    static std::string GetFullPath(SaveDataSpaceId space, SaveDataType type, u64 title_id,
-                                   u128 user_id, u64 save_id);
+    static std::string GetFullPath(Core::System& system, SaveDataSpaceId space, SaveDataType type,
+                                   u64 title_id, u128 user_id, u64 save_id);
 
     SaveDataSize ReadSaveDataSize(SaveDataType type, u64 title_id, u128 user_id) const;
     void WriteSaveDataSize(SaveDataType type, u64 title_id, u128 user_id,
@@ -102,6 +106,7 @@ public:
 
 private:
     VirtualDir dir;
+    Core::System& system;
 };
 
 } // namespace FileSys

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -717,7 +717,8 @@ void FileSystemController::CreateFactories(FileSys::VfsFilesystem& vfs, bool ove
     }
 
     if (save_data_factory == nullptr) {
-        save_data_factory = std::make_unique<FileSys::SaveDataFactory>(std::move(nand_directory));
+        save_data_factory =
+            std::make_unique<FileSys::SaveDataFactory>(system, std::move(nand_directory));
     }
 
     if (sdmc_factory == nullptr) {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1342,12 +1342,12 @@ void GMainWindow::OnGameListOpenFolder(u64 program_id, GameListOpenTarget target
             const auto user_id = manager.GetUser(static_cast<std::size_t>(index));
             ASSERT(user_id);
             path = nand_dir + FileSys::SaveDataFactory::GetFullPath(
-                                  FileSys::SaveDataSpaceId::NandUser,
+                                  system, FileSys::SaveDataSpaceId::NandUser,
                                   FileSys::SaveDataType::SaveData, program_id, user_id->uuid, 0);
         } else {
             // Device save data
             path = nand_dir + FileSys::SaveDataFactory::GetFullPath(
-                                  FileSys::SaveDataSpaceId::NandUser,
+                                  system, FileSys::SaveDataSpaceId::NandUser,
                                   FileSys::SaveDataType::SaveData, program_id, {}, 0);
         }
 


### PR DESCRIPTION
Now there's only two meaningful instances left in core.