### PR TITLE
audio_core: Remove temp_mix_buffer

### DIFF
--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -79,8 +79,7 @@ AudioRenderer::AudioRenderer(Core::Timing::CoreTiming& core_timing, Core::Memory
       sink_context(params.sink_count), splitter_context(),
       voices(params.voice_count), memory{memory_},
       command_generator(worker_params, voice_context, mix_context, splitter_context, effect_context,
-                        memory),
-      temp_mix_buffer(AudioCommon::TOTAL_TEMP_MIX_SIZE) {
+                        memory) {
     behavior_info.SetUserRevision(params.revision);
     splitter_context.Initialize(behavior_info, params.splitter_count,
                                 params.num_splitter_send_channels);

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -73,7 +73,6 @@ private:
     Core::Memory::Memory& memory;
     CommandGenerator command_generator;
     std::size_t elapsed_frame_count{};
-    std::vector<s32> temp_mix_buffer{};
 };
 
 } // namespace AudioCore


### PR DESCRIPTION
It's unused and doesn't need to be initialized