### PR TITLE
Add missing types to NpadCommunicationMode

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -89,6 +89,8 @@ public:
     enum class NpadCommunicationMode : u64 {
         Unknown0 = 0,
         Unknown1 = 1,
+        Unknown2 = 2,
+        Unknown3 = 3,
     };
 
     struct DeviceHandle {


### PR DESCRIPTION
In latest research I found NpadCommunicationMode actually has 4 different types 