### PR TITLE
codec: Remove deprecated usage of AVCodecContext::refcounted_frames

### DIFF
--- a/src/video_core/command_classes/codecs/codec.cpp
+++ b/src/video_core/command_classes/codecs/codec.cpp
@@ -67,7 +67,6 @@ void Codec::Decode() {
         }
 
         av_codec_ctx = avcodec_alloc_context3(av_codec);
-        av_codec_ctx->refcounted_frames = 1;
         av_opt_set(av_codec_ctx->priv_data, "tune", "zerolatency", 0);
 
         // TODO(ameerj): libavcodec gpu hw acceleration


### PR DESCRIPTION
This was only necessary for use with the `avcodec_decode_video2`/`avcoded_decode_audio4` APIs which are also deprecated.

Given we use `avcodec_send_packet`/`avcodec_receive_frame`, this isn't necessary, this is even indicated directly within the FFmpeg API changes document [here](https://github.com/FFmpeg/FFmpeg/blob/master/doc/APIchanges#L410) on 2017-09-26.

This prevents our code from breaking whenever we update to a newer version of FFmpeg in the future if they ever decide to fully remove this API member.