### PR TITLE
Port citra-emu/citra#5617: "Fix telemetry-related exit crash from use-after-free"

### DIFF
--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -275,9 +275,9 @@ void RendererOpenGL::AddTelemetryFields() {
     LOG_INFO(Render_OpenGL, "GL_RENDERER: {}", gpu_model);
 
     constexpr auto user_system = Common::Telemetry::FieldType::UserSystem;
-    telemetry_session.AddField(user_system, "GPU_Vendor", gpu_vendor);
-    telemetry_session.AddField(user_system, "GPU_Model", gpu_model);
-    telemetry_session.AddField(user_system, "GPU_OpenGL_Version", gl_version);
+    telemetry_session.AddField(user_system, "GPU_Vendor", std::string(gpu_vendor));
+    telemetry_session.AddField(user_system, "GPU_Model", std::string(gpu_model));
+    telemetry_session.AddField(user_system, "GPU_OpenGL_Version", std::string(gl_version));
 }
 
 void RendererOpenGL::CreateRasterizer() {


### PR DESCRIPTION
See citra-emu/citra#5617 for more details.

**Original description**:
AddField is implemented using std::move.

However, the memory backing these three const char* fields are local in scope to this function. When Citra (SDL2 at least) attempts to use these fields on exit, the memory may already be unmapped/invalid. To fix this, just convert them to a string.

I couldn't find a good way to discriminate between const char[] and const char* in the AddField templating system, so for now we just need to be careful and keep this in mind. I did check and as far as I can tell, all of the other const char*-like fields passed to AddField are globals that won't be freed.