### PR TITLE
video_core: Resolve more variable shadowing scenarios pt.2

### DIFF
--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -243,8 +243,8 @@ std::string BuildCommaSeparatedExtensions(std::vector<std::string> available_ext
 RendererVulkan::RendererVulkan(Core::TelemetrySession& telemetry_session_,
                                Core::Frontend::EmuWindow& emu_window,
                                Core::Memory::Memory& cpu_memory_, Tegra::GPU& gpu_,
-                               std::unique_ptr<Core::Frontend::GraphicsContext> context)
-    : RendererBase{emu_window, std::move(context)}, telemetry_session{telemetry_session_},
+                               std::unique_ptr<Core::Frontend::GraphicsContext> context_)
+    : RendererBase{emu_window, std::move(context_)}, telemetry_session{telemetry_session_},
       cpu_memory{cpu_memory_}, gpu{gpu_} {}
 
 RendererVulkan::~RendererVulkan() {

--- a/src/video_core/renderer_vulkan/renderer_vulkan.h
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.h
@@ -45,9 +45,9 @@ struct VKScreenInfo {
 class RendererVulkan final : public VideoCore::RendererBase {
 public:
     explicit RendererVulkan(Core::TelemetrySession& telemtry_session,
-                            Core::Frontend::EmuWindow& emu_window, Core::Memory::Memory& cpu_memory,
-                            Tegra::GPU& gpu,
-                            std::unique_ptr<Core::Frontend::GraphicsContext> context);
+                            Core::Frontend::EmuWindow& emu_window,
+                            Core::Memory::Memory& cpu_memory_, Tegra::GPU& gpu_,
+                            std::unique_ptr<Core::Frontend::GraphicsContext> context_);
     ~RendererVulkan() override;
 
     bool Init() override;

--- a/src/video_core/renderer_vulkan/vk_compute_pass.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pass.cpp
@@ -461,15 +461,15 @@ VkDescriptorSet VKComputePass::CommitDescriptorSet(
     return set;
 }
 
-QuadArrayPass::QuadArrayPass(const VKDevice& device, VKScheduler& scheduler,
-                             VKDescriptorPool& descriptor_pool,
-                             VKStagingBufferPool& staging_buffer_pool,
-                             VKUpdateDescriptorQueue& update_descriptor_queue)
-    : VKComputePass(device, descriptor_pool, BuildQuadArrayPassDescriptorSetLayoutBinding(),
+QuadArrayPass::QuadArrayPass(const VKDevice& device_, VKScheduler& scheduler_,
+                             VKDescriptorPool& descriptor_pool_,
+                             VKStagingBufferPool& staging_buffer_pool_,
+                             VKUpdateDescriptorQueue& update_descriptor_queue_)
+    : VKComputePass(device_, descriptor_pool_, BuildQuadArrayPassDescriptorSetLayoutBinding(),
                     BuildQuadArrayPassDescriptorUpdateTemplateEntry(),
                     BuildComputePushConstantRange(sizeof(u32)), std::size(quad_array), quad_array),
-      scheduler{scheduler}, staging_buffer_pool{staging_buffer_pool},
-      update_descriptor_queue{update_descriptor_queue} {}
+      scheduler{scheduler_}, staging_buffer_pool{staging_buffer_pool_},
+      update_descriptor_queue{update_descriptor_queue_} {}
 
 QuadArrayPass::~QuadArrayPass() = default;
 
@@ -510,14 +510,14 @@ std::pair<VkBuffer, VkDeviceSize> QuadArrayPass::Assemble(u32 num_vertices, u32 
     return {*buffer.handle, 0};
 }
 
-Uint8Pass::Uint8Pass(const VKDevice& device, VKScheduler& scheduler,
-                     VKDescriptorPool& descriptor_pool, VKStagingBufferPool& staging_buffer_pool,
-                     VKUpdateDescriptorQueue& update_descriptor_queue)
-    : VKComputePass(device, descriptor_pool, BuildInputOutputDescriptorSetBindings(),
+Uint8Pass::Uint8Pass(const VKDevice& device_, VKScheduler& scheduler_,
+                     VKDescriptorPool& descriptor_pool_, VKStagingBufferPool& staging_buffer_pool_,
+                     VKUpdateDescriptorQueue& update_descriptor_queue_)
+    : VKComputePass(device_, descriptor_pool_, BuildInputOutputDescriptorSetBindings(),
                     BuildInputOutputDescriptorUpdateTemplate(), {}, std::size(uint8_pass),
                     uint8_pass),
-      scheduler{scheduler}, staging_buffer_pool{staging_buffer_pool},
-      update_descriptor_queue{update_descriptor_queue} {}
+      scheduler{scheduler_}, staging_buffer_pool{staging_buffer_pool_},
+      update_descriptor_queue{update_descriptor_queue_} {}
 
 Uint8Pass::~Uint8Pass() = default;
 
@@ -555,16 +555,16 @@ std::pair<VkBuffer, u64> Uint8Pass::Assemble(u32 num_vertices, VkBuffer src_buff
     return {*buffer.handle, 0};
 }
 
-QuadIndexedPass::QuadIndexedPass(const VKDevice& device, VKScheduler& scheduler,
-                                 VKDescriptorPool& descriptor_pool,
-                                 VKStagingBufferPool& staging_buffer_pool,
-                                 VKUpdateDescriptorQueue& update_descriptor_queue)
-    : VKComputePass(device, descriptor_pool, BuildInputOutputDescriptorSetBindings(),
+QuadIndexedPass::QuadIndexedPass(const VKDevice& device_, VKScheduler& scheduler_,
+                                 VKDescriptorPool& descriptor_pool_,
+                                 VKStagingBufferPool& staging_buffer_pool_,
+                                 VKUpdateDescriptorQueue& update_descriptor_queue_)
+    : VKComputePass(device_, descriptor_pool_, BuildInputOutputDescriptorSetBindings(),
                     BuildInputOutputDescriptorUpdateTemplate(),
                     BuildComputePushConstantRange(sizeof(u32) * 2), std::size(QUAD_INDEXED_SPV),
                     QUAD_INDEXED_SPV),
-      scheduler{scheduler}, staging_buffer_pool{staging_buffer_pool},
-      update_descriptor_queue{update_descriptor_queue} {}
+      scheduler{scheduler_}, staging_buffer_pool{staging_buffer_pool_},
+      update_descriptor_queue{update_descriptor_queue_} {}
 
 QuadIndexedPass::~QuadIndexedPass() = default;
 

--- a/src/video_core/renderer_vulkan/vk_compute_pass.h
+++ b/src/video_core/renderer_vulkan/vk_compute_pass.h
@@ -43,10 +43,10 @@ private:
 
 class QuadArrayPass final : public VKComputePass {
 public:
-    explicit QuadArrayPass(const VKDevice& device, VKScheduler& scheduler,
-                           VKDescriptorPool& descriptor_pool,
-                           VKStagingBufferPool& staging_buffer_pool,
-                           VKUpdateDescriptorQueue& update_descriptor_queue);
+    explicit QuadArrayPass(const VKDevice& device_, VKScheduler& scheduler_,
+                           VKDescriptorPool& descriptor_pool_,
+                           VKStagingBufferPool& staging_buffer_pool_,
+                           VKUpdateDescriptorQueue& update_descriptor_queue_);
     ~QuadArrayPass();
 
     std::pair<VkBuffer, VkDeviceSize> Assemble(u32 num_vertices, u32 first);
@@ -59,9 +59,10 @@ private:
 
 class Uint8Pass final : public VKComputePass {
 public:
-    explicit Uint8Pass(const VKDevice& device, VKScheduler& scheduler,
-                       VKDescriptorPool& descriptor_pool, VKStagingBufferPool& staging_buffer_pool,
-                       VKUpdateDescriptorQueue& update_descriptor_queue);
+    explicit Uint8Pass(const VKDevice& device_, VKScheduler& scheduler_,
+                       VKDescriptorPool& descriptor_pool_,
+                       VKStagingBufferPool& staging_buffer_pool_,
+                       VKUpdateDescriptorQueue& update_descriptor_queue_);
     ~Uint8Pass();
 
     std::pair<VkBuffer, u64> Assemble(u32 num_vertices, VkBuffer src_buffer, u64 src_offset);
@@ -74,10 +75,10 @@ private:
 
 class QuadIndexedPass final : public VKComputePass {
 public:
-    explicit QuadIndexedPass(const VKDevice& device, VKScheduler& scheduler,
-                             VKDescriptorPool& descriptor_pool,
-                             VKStagingBufferPool& staging_buffer_pool,
-                             VKUpdateDescriptorQueue& update_descriptor_queue);
+    explicit QuadIndexedPass(const VKDevice& device_, VKScheduler& scheduler_,
+                             VKDescriptorPool& descriptor_pool_,
+                             VKStagingBufferPool& staging_buffer_pool_,
+                             VKUpdateDescriptorQueue& update_descriptor_queue_);
     ~QuadIndexedPass();
 
     std::pair<VkBuffer, u64> Assemble(Tegra::Engines::Maxwell3D::Regs::IndexFormat index_format,

--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
@@ -15,16 +15,16 @@
 
 namespace Vulkan {
 
-VKComputePipeline::VKComputePipeline(const VKDevice& device, VKScheduler& scheduler,
-                                     VKDescriptorPool& descriptor_pool,
-                                     VKUpdateDescriptorQueue& update_descriptor_queue,
-                                     const SPIRVShader& shader)
-    : device{device}, scheduler{scheduler}, entries{shader.entries},
+VKComputePipeline::VKComputePipeline(const VKDevice& device_, VKScheduler& scheduler_,
+                                     VKDescriptorPool& descriptor_pool_,
+                                     VKUpdateDescriptorQueue& update_descriptor_queue_,
+                                     const SPIRVShader& shader_)
+    : device{device_}, scheduler{scheduler_}, entries{shader_.entries},
       descriptor_set_layout{CreateDescriptorSetLayout()},
-      descriptor_allocator{descriptor_pool, *descriptor_set_layout},
-      update_descriptor_queue{update_descriptor_queue}, layout{CreatePipelineLayout()},
+      descriptor_allocator{descriptor_pool_, *descriptor_set_layout},
+      update_descriptor_queue{update_descriptor_queue_}, layout{CreatePipelineLayout()},
       descriptor_template{CreateDescriptorUpdateTemplate()},
-      shader_module{CreateShaderModule(shader.code)}, pipeline{CreatePipeline()} {}
+      shader_module{CreateShaderModule(shader_.code)}, pipeline{CreatePipeline()} {}
 
 VKComputePipeline::~VKComputePipeline() = default;
 

--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.h
@@ -17,10 +17,10 @@ class VKUpdateDescriptorQueue;
 
 class VKComputePipeline final {
 public:
-    explicit VKComputePipeline(const VKDevice& device, VKScheduler& scheduler,
-                               VKDescriptorPool& descriptor_pool,
-                               VKUpdateDescriptorQueue& update_descriptor_queue,
-                               const SPIRVShader& shader);
+    explicit VKComputePipeline(const VKDevice& device_, VKScheduler& scheduler_,
+                               VKDescriptorPool& descriptor_pool_,
+                               VKUpdateDescriptorQueue& update_descriptor_queue_,
+                               const SPIRVShader& shader_);
     ~VKComputePipeline();
 
     VkDescriptorSet CommitDescriptorSet();

--- a/src/video_core/renderer_vulkan/vk_device.cpp
+++ b/src/video_core/renderer_vulkan/vk_device.cpp
@@ -491,8 +491,8 @@ bool VKDevice::IsOptimalAstcSupported(const VkPhysicalDeviceFeatures& features) 
         VK_FORMAT_FEATURE_BLIT_DST_BIT | VK_FORMAT_FEATURE_TRANSFER_SRC_BIT |
         VK_FORMAT_FEATURE_TRANSFER_DST_BIT};
     for (const auto format : astc_formats) {
-        const auto format_properties{physical.GetFormatProperties(format)};
-        if (!(format_properties.optimalTilingFeatures & format_feature_usage)) {
+        const auto physical_format_properties{physical.GetFormatProperties(format)};
+        if ((physical_format_properties.optimalTilingFeatures & format_feature_usage) == 0) {
             return false;
         }
     }
@@ -644,8 +644,8 @@ std::vector<const char*> VKDevice::LoadExtensions() {
     VkPhysicalDeviceFeatures2KHR features;
     features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2_KHR;
 
-    VkPhysicalDeviceProperties2KHR properties;
-    properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
+    VkPhysicalDeviceProperties2KHR physical_properties;
+    physical_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2_KHR;
 
     if (has_khr_shader_float16_int8) {
         VkPhysicalDeviceFloat16Int8FeaturesKHR float16_int8_features;
@@ -670,8 +670,8 @@ std::vector<const char*> VKDevice::LoadExtensions() {
         subgroup_properties.sType =
             VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES_EXT;
         subgroup_properties.pNext = nullptr;
-        properties.pNext = &subgroup_properties;
-        physical.GetProperties2KHR(properties);
+        physical_properties.pNext = &subgroup_properties;
+        physical.GetProperties2KHR(physical_properties);
 
         is_warp_potentially_bigger = subgroup_properties.maxSubgroupSize > GuestWarpSize;
 
@@ -695,8 +695,8 @@ std::vector<const char*> VKDevice::LoadExtensions() {
         VkPhysicalDeviceTransformFeedbackPropertiesEXT tfb_properties;
         tfb_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT;
         tfb_properties.pNext = nullptr;
-        properties.pNext = &tfb_properties;
-        physical.GetProperties2KHR(properties);
+        physical_properties.pNext = &tfb_properties;
+        physical.GetProperties2KHR(physical_properties);
 
         if (tfb_features.transformFeedback && tfb_features.geometryStreams &&
             tfb_properties.maxTransformFeedbackStreams >= 4 &&

--- a/src/video_core/renderer_vulkan/vk_fence_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_fence_manager.cpp
@@ -14,12 +14,13 @@
 
 namespace Vulkan {
 
-InnerFence::InnerFence(const VKDevice& device, VKScheduler& scheduler, u32 payload, bool is_stubbed)
-    : VideoCommon::FenceBase(payload, is_stubbed), device{device}, scheduler{scheduler} {}
+InnerFence::InnerFence(const VKDevice& device_, VKScheduler& scheduler_, u32 payload_,
+                       bool is_stubbed_)
+    : FenceBase{payload_, is_stubbed_}, device{device_}, scheduler{scheduler_} {}
 
-InnerFence::InnerFence(const VKDevice& device, VKScheduler& scheduler, GPUVAddr address,
-                       u32 payload, bool is_stubbed)
-    : VideoCommon::FenceBase(address, payload, is_stubbed), device{device}, scheduler{scheduler} {}
+InnerFence::InnerFence(const VKDevice& device_, VKScheduler& scheduler_, GPUVAddr address_,
+                       u32 payload_, bool is_stubbed_)
+    : FenceBase{address_, payload_, is_stubbed_}, device{device_}, scheduler{scheduler_} {}
 
 InnerFence::~InnerFence() = default;
 
@@ -71,11 +72,12 @@ bool InnerFence::IsEventSignalled() const {
     }
 }
 
-VKFenceManager::VKFenceManager(VideoCore::RasterizerInterface& rasterizer, Tegra::GPU& gpu,
-                               Tegra::MemoryManager& memory_manager, VKTextureCache& texture_cache,
-                               VKBufferCache& buffer_cache, VKQueryCache& query_cache,
-                               const VKDevice& device_, VKScheduler& scheduler_)
-    : GenericFenceManager(rasterizer, gpu, texture_cache, buffer_cache, query_cache),
+VKFenceManager::VKFenceManager(VideoCore::RasterizerInterface& rasterizer_, Tegra::GPU& gpu_,
+                               Tegra::MemoryManager& memory_manager_,
+                               VKTextureCache& texture_cache_, VKBufferCache& buffer_cache_,
+                               VKQueryCache& query_cache_, const VKDevice& device_,
+                               VKScheduler& scheduler_)
+    : GenericFenceManager{rasterizer_, gpu_, texture_cache_, buffer_cache_, query_cache_},
       device{device_}, scheduler{scheduler_} {}
 
 Fence VKFenceManager::CreateFence(u32 value, bool is_stubbed) {

--- a/src/video_core/renderer_vulkan/vk_fence_manager.h
+++ b/src/video_core/renderer_vulkan/vk_fence_manager.h
@@ -28,10 +28,10 @@ class VKTextureCache;
 
 class InnerFence : public VideoCommon::FenceBase {
 public:
-    explicit InnerFence(const VKDevice& device, VKScheduler& scheduler, u32 payload,
-                        bool is_stubbed);
-    explicit InnerFence(const VKDevice& device, VKScheduler& scheduler, GPUVAddr address,
-                        u32 payload, bool is_stubbed);
+    explicit InnerFence(const VKDevice& device_, VKScheduler& scheduler_, u32 payload_,
+                        bool is_stubbed_);
+    explicit InnerFence(const VKDevice& device_, VKScheduler& scheduler_, GPUVAddr address_,
+                        u32 payload_, bool is_stubbed_);
     ~InnerFence();
 
     void Queue();
@@ -55,10 +55,10 @@ using GenericFenceManager =
 
 class VKFenceManager final : public GenericFenceManager {
 public:
-    explicit VKFenceManager(VideoCore::RasterizerInterface& rasterizer, Tegra::GPU& gpu,
-                            Tegra::MemoryManager& memory_manager, VKTextureCache& texture_cache,
-                            VKBufferCache& buffer_cache, VKQueryCache& query_cache,
-                            const VKDevice& device, VKScheduler& scheduler);
+    explicit VKFenceManager(VideoCore::RasterizerInterface& rasterizer_, Tegra::GPU& gpu_,
+                            Tegra::MemoryManager& memory_manager_, VKTextureCache& texture_cache_,
+                            VKBufferCache& buffer_cache_, VKQueryCache& query_cache_,
+                            const VKDevice& device_, VKScheduler& scheduler_);
 
 protected:
     Fence CreateFence(u32 value, bool is_stubbed) override;

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -71,21 +71,21 @@ VkViewportSwizzleNV UnpackViewportSwizzle(u16 swizzle) {
 
 } // Anonymous namespace
 
-VKGraphicsPipeline::VKGraphicsPipeline(const VKDevice& device, VKScheduler& scheduler,
-                                       VKDescriptorPool& descriptor_pool,
-                                       VKUpdateDescriptorQueue& update_descriptor_queue,
-                                       VKRenderPassCache& renderpass_cache,
-                                       const GraphicsPipelineCacheKey& key,
-                                       vk::Span<VkDescriptorSetLayoutBinding> bindings,
-                                       const SPIRVProgram& program)
-    : device{device}, scheduler{scheduler}, cache_key{key}, hash{cache_key.Hash()},
-      descriptor_set_layout{CreateDescriptorSetLayout(bindings)},
-      descriptor_allocator{descriptor_pool, *descriptor_set_layout},
-      update_descriptor_queue{update_descriptor_queue}, layout{CreatePipelineLayout()},
-      descriptor_template{CreateDescriptorUpdateTemplate(program)}, modules{CreateShaderModules(
-                                                                        program)},
-      renderpass{renderpass_cache.GetRenderPass(cache_key.renderpass_params)},
-      pipeline{CreatePipeline(cache_key.renderpass_params, program)} {}
+VKGraphicsPipeline::VKGraphicsPipeline(const VKDevice& device_, VKScheduler& scheduler_,
+                                       VKDescriptorPool& descriptor_pool_,
+                                       VKUpdateDescriptorQueue& update_descriptor_queue_,
+                                       VKRenderPassCache& renderpass_cache_,
+                                       const GraphicsPipelineCacheKey& key_,
+                                       vk::Span<VkDescriptorSetLayoutBinding> bindings_,
+                                       const SPIRVProgram& program_)
+    : device{device_}, scheduler{scheduler_}, cache_key{key_}, hash{cache_key.Hash()},
+      descriptor_set_layout{CreateDescriptorSetLayout(bindings_)},
+      descriptor_allocator{descriptor_pool_, *descriptor_set_layout},
+      update_descriptor_queue{update_descriptor_queue_}, layout{CreatePipelineLayout()},
+      descriptor_template{CreateDescriptorUpdateTemplate(program_)}, modules{CreateShaderModules(
+                                                                         program_)},
+      renderpass{renderpass_cache_.GetRenderPass(cache_key.renderpass_params)},
+      pipeline{CreatePipeline(cache_key.renderpass_params, program_)} {}
 
 VKGraphicsPipeline::~VKGraphicsPipeline() = default;
 
@@ -162,8 +162,8 @@ std::vector<vk::ShaderModule> VKGraphicsPipeline::CreateShaderModules(
         .codeSize = 0,
     };
 
-    std::vector<vk::ShaderModule> modules;
-    modules.reserve(Maxwell::MaxShaderStage);
+    std::vector<vk::ShaderModule> shader_modules;
+    shader_modules.reserve(Maxwell::MaxShaderStage);
     for (std::size_t i = 0; i < Maxwell::MaxShaderStage; ++i) {
         const auto& stage = program[i];
         if (!stage) {
@@ -174,9 +174,9 @@ std::vector<vk::ShaderModule> VKGraphicsPipeline::CreateShaderModules(
 
         ci.codeSize = stage->code.size() * sizeof(u32);
         ci.pCode = stage->code.data();
-        modules.push_back(device.GetLogical().CreateShaderModule(ci));
+        shader_modules.push_back(device.GetLogical().CreateShaderModule(ci));
     }
-    return modules;
+    return shader_modules;
 }
 
 vk::Pipeline VKGraphicsPipeline::CreatePipeline(const RenderPassParams& renderpass_params,

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -51,13 +51,13 @@ using SPIRVProgram = std::array<std::optional<SPIRVShader>, Maxwell::MaxShaderSt
 
 class VKGraphicsPipeline final {
 public:
-    explicit VKGraphicsPipeline(const VKDevice& device, VKScheduler& scheduler,
-                                VKDescriptorPool& descriptor_pool,
-                                VKUpdateDescriptorQueue& update_descriptor_queue,
-                                VKRenderPassCache& renderpass_cache,
-                                const GraphicsPipelineCacheKey& key,
-                                vk::Span<VkDescriptorSetLayoutBinding> bindings,
-                                const SPIRVProgram& program);
+    explicit VKGraphicsPipeline(const VKDevice& device_, VKScheduler& scheduler_,
+                                VKDescriptorPool& descriptor_pool_,
+                                VKUpdateDescriptorQueue& update_descriptor_queue_,
+                                VKRenderPassCache& renderpass_cache_,
+                                const GraphicsPipelineCacheKey& key_,
+                                vk::Span<VkDescriptorSetLayoutBinding> bindings_,
+                                const SPIRVProgram& program_);
     ~VKGraphicsPipeline();
 
     VkDescriptorSet CommitDescriptorSet();

--- a/src/video_core/renderer_vulkan/vk_image.cpp
+++ b/src/video_core/renderer_vulkan/vk_image.cpp
@@ -13,18 +13,18 @@
 
 namespace Vulkan {
 
-VKImage::VKImage(const VKDevice& device, VKScheduler& scheduler, const VkImageCreateInfo& image_ci,
-                 VkImageAspectFlags aspect_mask)
-    : device{device}, scheduler{scheduler}, format{image_ci.format}, aspect_mask{aspect_mask},
-      image_num_layers{image_ci.arrayLayers}, image_num_levels{image_ci.mipLevels} {
-    UNIMPLEMENTED_IF_MSG(image_ci.queueFamilyIndexCount != 0,
+VKImage::VKImage(const VKDevice& device_, VKScheduler& scheduler_,
+                 const VkImageCreateInfo& image_ci_, VkImageAspectFlags aspect_mask_)
+    : device{device_}, scheduler{scheduler_}, format{image_ci_.format}, aspect_mask{aspect_mask_},
+      image_num_layers{image_ci_.arrayLayers}, image_num_levels{image_ci_.mipLevels} {
+    UNIMPLEMENTED_IF_MSG(image_ci_.queueFamilyIndexCount != 0,
                          "Queue family tracking is not implemented");
 
-    image = device.GetLogical().CreateImage(image_ci);
+    image = device_.GetLogical().CreateImage(image_ci_);
 
     const u32 num_ranges = image_num_layers * image_num_levels;
     barriers.resize(num_ranges);
-    subrange_states.resize(num_ranges, {{}, image_ci.initialLayout});
+    subrange_states.resize(num_ranges, {{}, image_ci_.initialLayout});
 }
 
 VKImage::~VKImage() = default;

--- a/src/video_core/renderer_vulkan/vk_image.h
+++ b/src/video_core/renderer_vulkan/vk_image.h
@@ -17,8 +17,8 @@ class VKScheduler;
 
 class VKImage {
 public:
-    explicit VKImage(const VKDevice& device, VKScheduler& scheduler,
-                     const VkImageCreateInfo& image_ci, VkImageAspectFlags aspect_mask);
+    explicit VKImage(const VKDevice& device_, VKScheduler& scheduler_,
+                     const VkImageCreateInfo& image_ci_, VkImageAspectFlags aspect_mask_);
     ~VKImage();
 
     /// Records in the passed command buffer an image transition and updates the state of the image.

--- a/src/video_core/renderer_vulkan/vk_memory_manager.cpp
+++ b/src/video_core/renderer_vulkan/vk_memory_manager.cpp
@@ -29,10 +29,10 @@ u64 GetAllocationChunkSize(u64 required_size) {
 
 class VKMemoryAllocation final {
 public:
-    explicit VKMemoryAllocation(const VKDevice& device, vk::DeviceMemory memory,
-                                VkMemoryPropertyFlags properties, u64 allocation_size, u32 type)
-        : device{device}, memory{std::move(memory)}, properties{properties},
-          allocation_size{allocation_size}, shifted_type{ShiftType(type)} {}
+    explicit VKMemoryAllocation(const VKDevice& device_, vk::DeviceMemory memory_,
+                                VkMemoryPropertyFlags properties_, u64 allocation_size_, u32 type_)
+        : device{device_}, memory{std::move(memory_)}, properties{properties_},
+          allocation_size{allocation_size_}, shifted_type{ShiftType(type_)} {}
 
     VKMemoryCommit Commit(VkDeviceSize commit_size, VkDeviceSize alignment) {
         auto found = TryFindFreeSection(free_iterator, allocation_size,
@@ -117,8 +117,8 @@ private:
     std::vector<const VKMemoryCommitImpl*> commits;
 };
 
-VKMemoryManager::VKMemoryManager(const VKDevice& device)
-    : device{device}, properties{device.GetPhysical().GetMemoryProperties()} {}
+VKMemoryManager::VKMemoryManager(const VKDevice& device_)
+    : device{device_}, properties{device_.GetPhysical().GetMemoryProperties()} {}
 
 VKMemoryManager::~VKMemoryManager() = default;
 
@@ -207,9 +207,9 @@ VKMemoryCommit VKMemoryManager::TryAllocCommit(const VkMemoryRequirements& requi
     return {};
 }
 
-VKMemoryCommitImpl::VKMemoryCommitImpl(const VKDevice& device, VKMemoryAllocation* allocation,
-                                       const vk::DeviceMemory& memory, u64 begin, u64 end)
-    : device{device}, memory{memory}, interval{begin, end}, allocation{allocation} {}
+VKMemoryCommitImpl::VKMemoryCommitImpl(const VKDevice& device_, VKMemoryAllocation* allocation_,
+                                       const vk::DeviceMemory& memory_, u64 begin_, u64 end_)
+    : device{device_}, memory{memory_}, interval{begin_, end_}, allocation{allocation_} {}
 
 VKMemoryCommitImpl::~VKMemoryCommitImpl() {
     allocation->Free(this);

--- a/src/video_core/renderer_vulkan/vk_memory_manager.h
+++ b/src/video_core/renderer_vulkan/vk_memory_manager.h
@@ -21,7 +21,7 @@ using VKMemoryCommit = std::unique_ptr<VKMemoryCommitImpl>;
 
 class VKMemoryManager final {
 public:
-    explicit VKMemoryManager(const VKDevice& device);
+    explicit VKMemoryManager(const VKDevice& device_);
     VKMemoryManager(const VKMemoryManager&) = delete;
     ~VKMemoryManager();
 
@@ -58,8 +58,8 @@ class VKMemoryCommitImpl final {
     friend MemoryMap;
 
 public:
-    explicit VKMemoryCommitImpl(const VKDevice& device, VKMemoryAllocation* allocation,
-                                const vk::DeviceMemory& memory, u64 begin, u64 end);
+    explicit VKMemoryCommitImpl(const VKDevice& device_, VKMemoryAllocation* allocation_,
+                                const vk::DeviceMemory& memory_, u64 begin_, u64 end_);
     ~VKMemoryCommitImpl();
 
     /// Maps a memory region and returns a pointer to it.
@@ -93,8 +93,8 @@ private:
 /// Holds ownership of a memory map.
 class MemoryMap final {
 public:
-    explicit MemoryMap(const VKMemoryCommitImpl* commit, u8* address)
-        : commit{commit}, address{address} {}
+    explicit MemoryMap(const VKMemoryCommitImpl* commit_, u8* address_)
+        : commit{commit_}, address{address_} {}
 
     ~MemoryMap() {
         if (commit) {

--- a/src/video_core/renderer_vulkan/vk_query_cache.h
+++ b/src/video_core/renderer_vulkan/vk_query_cache.h
@@ -53,9 +53,9 @@ private:
 class VKQueryCache final
     : public VideoCommon::QueryCacheBase<VKQueryCache, CachedQuery, CounterStream, HostCounter> {
 public:
-    explicit VKQueryCache(VideoCore::RasterizerInterface& rasterizer,
-                          Tegra::Engines::Maxwell3D& maxwell3d, Tegra::MemoryManager& gpu_memory,
-                          const VKDevice& device, VKScheduler& scheduler);
+    explicit VKQueryCache(VideoCore::RasterizerInterface& rasterizer_,
+                          Tegra::Engines::Maxwell3D& maxwell3d_, Tegra::MemoryManager& gpu_memory_,
+                          const VKDevice& device_, VKScheduler& scheduler_);
     ~VKQueryCache();
 
     std::pair<VkQueryPool, u32> AllocateQuery(VideoCore::QueryType type);
@@ -78,8 +78,8 @@ private:
 
 class HostCounter final : public VideoCommon::HostCounterBase<VKQueryCache, HostCounter> {
 public:
-    explicit HostCounter(VKQueryCache& cache, std::shared_ptr<HostCounter> dependency,
-                         VideoCore::QueryType type);
+    explicit HostCounter(VKQueryCache& cache_, std::shared_ptr<HostCounter> dependency_,
+                         VideoCore::QueryType type_);
     ~HostCounter();
 
     void EndQuery();

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -904,15 +904,14 @@ void RasterizerVulkan::SetupShaderDescriptors(
     texture_cache.GuardSamplers(false);
 }
 
-void RasterizerVulkan::SetupImageTransitions(
-    Texceptions texceptions, const std::array<View, Maxwell::NumRenderTargets>& color_attachments,
-    const View& zeta_attachment) {
+void RasterizerVulkan::SetupImageTransitions(Texceptions texceptions, const ColorAttachments& color,
+                                             const ZetaAttachment& zeta) {
     TransitionImages(sampled_views, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_ACCESS_SHADER_READ_BIT);
     TransitionImages(image_views, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
                      VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT);
 
-    for (std::size_t rt = 0; rt < std::size(color_attachments); ++rt) {
-        const auto color_attachment = color_attachments[rt];
+    for (std::size_t rt = 0; rt < color.size(); ++rt) {
+        const auto color_attachment = color[rt];
         if (color_attachment == nullptr) {
             continue;
         }
@@ -923,13 +922,13 @@ void RasterizerVulkan::SetupImageTransitions(
                                          VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
     }
 
-    if (zeta_attachment != nullptr) {
+    if (zeta != nullptr) {
         const auto image_layout = texceptions[ZETA_TEXCEPTION_INDEX]
                                       ? VK_IMAGE_LAYOUT_GENERAL
                                       : VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
-        zeta_attachment->Transition(image_layout, VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
-                                    VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
-                                        VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
+        zeta->Transition(image_layout, VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
+                         VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT |
+                             VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT);
     }
 }
 

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -160,6 +160,9 @@ private:
         bool is_indexed = 0;
     };
 
+    using ColorAttachments = std::array<View, Maxwell::NumRenderTargets>;
+    using ZetaAttachment = View;
+
     using Texceptions = std::bitset<Maxwell::NumRenderTargets + 1>;
 
     static constexpr std::size_t ZETA_TEXCEPTION_INDEX = 8;
@@ -181,9 +184,8 @@ private:
     /// Setup descriptors in the graphics pipeline.
     void SetupShaderDescriptors(const std::array<Shader*, Maxwell::MaxShaderProgram>& shaders);
 
-    void SetupImageTransitions(Texceptions texceptions,
-                               const std::array<View, Maxwell::NumRenderTargets>& color_attachments,
-                               const View& zeta_attachment);
+    void SetupImageTransitions(Texceptions texceptions, const ColorAttachments& color,
+                               const ZetaAttachment& zeta);
 
     void UpdateDynamicStates();
 
@@ -308,8 +310,8 @@ private:
     vk::Event wfi_event;
     VideoCommon::Shader::AsyncShaders async_shaders;
 
-    std::array<View, Maxwell::NumRenderTargets> color_attachments;
-    View zeta_attachment;
+    ColorAttachments color_attachments;
+    ZetaAttachment zeta_attachment;
 
     std::vector<ImageView> sampled_views;
     std::vector<ImageView> image_views;

--- a/src/video_core/renderer_vulkan/vk_renderpass_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_renderpass_cache.cpp
@@ -24,7 +24,7 @@ bool RenderPassParams::operator==(const RenderPassParams& rhs) const noexcept {
     return std::memcmp(&rhs, this, sizeof *this) == 0;
 }
 
-VKRenderPassCache::VKRenderPassCache(const VKDevice& device) : device{device} {}
+VKRenderPassCache::VKRenderPassCache(const VKDevice& device_) : device{device_} {}
 
 VKRenderPassCache::~VKRenderPassCache() = default;
 

--- a/src/video_core/renderer_vulkan/vk_renderpass_cache.h
+++ b/src/video_core/renderer_vulkan/vk_renderpass_cache.h
@@ -55,7 +55,7 @@ namespace Vulkan {
 
 class VKRenderPassCache final {
 public:
-    explicit VKRenderPassCache(const VKDevice& device);
+    explicit VKRenderPassCache(const VKDevice& device_);
     ~VKRenderPassCache();
 
     VkRenderPass GetRenderPass(const RenderPassParams& params);

--- a/src/video_core/renderer_vulkan/vk_sampler_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_sampler_cache.cpp
@@ -36,7 +36,7 @@ VkBorderColor ConvertBorderColor(std::array<float, 4> color) {
 
 } // Anonymous namespace
 
-VKSamplerCache::VKSamplerCache(const VKDevice& device) : device{device} {}
+VKSamplerCache::VKSamplerCache(const VKDevice& device_) : device{device_} {}
 
 VKSamplerCache::~VKSamplerCache() = default;
 

--- a/src/video_core/renderer_vulkan/vk_sampler_cache.h
+++ b/src/video_core/renderer_vulkan/vk_sampler_cache.h
@@ -14,7 +14,7 @@ class VKDevice;
 
 class VKSamplerCache final : public VideoCommon::SamplerCache<VkSampler, vk::Sampler> {
 public:
-    explicit VKSamplerCache(const VKDevice& device);
+    explicit VKSamplerCache(const VKDevice& device_);
     ~VKSamplerCache();
 
 protected:

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -104,7 +104,7 @@ private:
     template <typename T>
     class TypedCommand final : public Command {
     public:
-        explicit TypedCommand(T&& command) : command{std::move(command)} {}
+        explicit TypedCommand(T&& command_) : command{std::move(command_)} {}
         ~TypedCommand() override = default;
 
         TypedCommand(TypedCommand&&) = delete;

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.h
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.h
@@ -30,8 +30,8 @@ constexpr u32 DESCRIPTOR_SET = 0;
 
 class ConstBufferEntry : public VideoCommon::Shader::ConstBuffer {
 public:
-    explicit constexpr ConstBufferEntry(const VideoCommon::Shader::ConstBuffer& entry, u32 index)
-        : VideoCommon::Shader::ConstBuffer{entry}, index{index} {}
+    explicit constexpr ConstBufferEntry(const ConstBuffer& entry_, u32 index_)
+        : ConstBuffer{entry_}, index{index_} {}
 
     constexpr u32 GetIndex() const {
         return index;
@@ -43,8 +43,8 @@ private:
 
 class GlobalBufferEntry {
 public:
-    constexpr explicit GlobalBufferEntry(u32 cbuf_index, u32 cbuf_offset, bool is_written)
-        : cbuf_index{cbuf_index}, cbuf_offset{cbuf_offset}, is_written{is_written} {}
+    constexpr explicit GlobalBufferEntry(u32 cbuf_index_, u32 cbuf_offset_, bool is_written_)
+        : cbuf_index{cbuf_index_}, cbuf_offset{cbuf_offset_}, is_written{is_written_} {}
 
     constexpr u32 GetCbufIndex() const {
         return cbuf_index;

--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -40,9 +40,9 @@ class CachedSurface final : public VideoCommon::SurfaceBase<View> {
     friend CachedSurfaceView;
 
 public:
-    explicit CachedSurface(const VKDevice& device, VKMemoryManager& memory_manager,
-                           VKScheduler& scheduler, VKStagingBufferPool& staging_pool,
-                           GPUVAddr gpu_addr, const SurfaceParams& params);
+    explicit CachedSurface(const VKDevice& device_, VKMemoryManager& memory_manager_,
+                           VKScheduler& scheduler_, VKStagingBufferPool& staging_pool_,
+                           GPUVAddr gpu_addr_, const SurfaceParams& params_);
     ~CachedSurface();
 
     void UploadTexture(const std::vector<u8>& staging_buffer) override;
@@ -84,7 +84,7 @@ public:
 protected:
     void DecorateSurfaceName();
 
-    View CreateView(const ViewParams& params) override;
+    View CreateView(const ViewParams& view_params) override;
 
 private:
     void UploadBuffer(const std::vector<u8>& staging_buffer);
@@ -110,8 +110,8 @@ private:
 
 class CachedSurfaceView final : public VideoCommon::ViewBase {
 public:
-    explicit CachedSurfaceView(const VKDevice& device, CachedSurface& surface,
-                               const ViewParams& params);
+    explicit CachedSurfaceView(const VKDevice& device_, CachedSurface& surface_,
+                               const ViewParams& view_params_);
     ~CachedSurfaceView();
 
     VkImageView GetImageView(Tegra::Texture::SwizzleSource x_source,
@@ -126,11 +126,11 @@ public:
     }
 
     u32 GetWidth() const {
-        return params.GetMipWidth(base_level);
+        return surface_params.GetMipWidth(base_level);
     }
 
     u32 GetHeight() const {
-        return params.GetMipHeight(base_level);
+        return surface_params.GetMipHeight(base_level);
     }
 
     u32 GetNumLayers() const {
@@ -169,7 +169,7 @@ public:
 
 private:
     // Store a copy of these values to avoid double dereference when reading them
-    const SurfaceParams params;
+    const SurfaceParams surface_params;
     const VkImage image;
     const VkBufferView buffer_view;
     const VkImageAspectFlags aspect_mask;

--- a/src/video_core/renderer_vulkan/vk_update_descriptor.cpp
+++ b/src/video_core/renderer_vulkan/vk_update_descriptor.cpp
@@ -14,8 +14,8 @@
 
 namespace Vulkan {
 
-VKUpdateDescriptorQueue::VKUpdateDescriptorQueue(const VKDevice& device, VKScheduler& scheduler)
-    : device{device}, scheduler{scheduler} {}
+VKUpdateDescriptorQueue::VKUpdateDescriptorQueue(const VKDevice& device_, VKScheduler& scheduler_)
+    : device{device_}, scheduler{scheduler_} {}
 
 VKUpdateDescriptorQueue::~VKUpdateDescriptorQueue() = default;
 

--- a/src/video_core/renderer_vulkan/vk_update_descriptor.h
+++ b/src/video_core/renderer_vulkan/vk_update_descriptor.h
@@ -31,7 +31,7 @@ struct DescriptorUpdateEntry {
 
 class VKUpdateDescriptorQueue final {
 public:
-    explicit VKUpdateDescriptorQueue(const VKDevice& device, VKScheduler& scheduler);
+    explicit VKUpdateDescriptorQueue(const VKDevice& device_, VKScheduler& scheduler_);
     ~VKUpdateDescriptorQueue();
 
     void TickFrame();

--- a/src/video_core/renderer_vulkan/wrapper.cpp
+++ b/src/video_core/renderer_vulkan/wrapper.cpp
@@ -417,7 +417,7 @@ VkResult Free(VkDevice device, VkCommandPool handle, Span<VkCommandBuffer> buffe
 }
 
 Instance Instance::Create(u32 version, Span<const char*> layers, Span<const char*> extensions,
-                          InstanceDispatch& dld) noexcept {
+                          InstanceDispatch& dispatch) noexcept {
     const VkApplicationInfo application_info{
         .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO,
         .pNext = nullptr,
@@ -439,17 +439,17 @@ Instance Instance::Create(u32 version, Span<const char*> layers, Span<const char
     };
 
     VkInstance instance;
-    if (dld.vkCreateInstance(&ci, nullptr, &instance) != VK_SUCCESS) {
+    if (dispatch.vkCreateInstance(&ci, nullptr, &instance) != VK_SUCCESS) {
         // Failed to create the instance.
         return {};
     }
-    if (!Proc(dld.vkDestroyInstance, dld, "vkDestroyInstance", instance)) {
+    if (!Proc(dispatch.vkDestroyInstance, dispatch, "vkDestroyInstance", instance)) {
         // We successfully created an instance but the destroy function couldn't be loaded.
         // This is a good moment to panic.
         return {};
     }
 
-    return Instance(instance, dld);
+    return Instance(instance, dispatch);
 }
 
 std::optional<std::vector<VkPhysicalDevice>> Instance::EnumeratePhysicalDevices() {
@@ -540,7 +540,7 @@ std::vector<VkImage> SwapchainKHR::GetImages() const {
 
 Device Device::Create(VkPhysicalDevice physical_device, Span<VkDeviceQueueCreateInfo> queues_ci,
                       Span<const char*> enabled_extensions, const void* next,
-                      DeviceDispatch& dld) noexcept {
+                      DeviceDispatch& dispatch) noexcept {
     const VkDeviceCreateInfo ci{
         .sType = VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO,
         .pNext = next,
@@ -555,11 +555,11 @@ Device Device::Create(VkPhysicalDevice physical_device, Span<VkDeviceQueueCreate
     };
 
     VkDevice device;
-    if (dld.vkCreateDevice(physical_device, &ci, nullptr, &device) != VK_SUCCESS) {
+    if (dispatch.vkCreateDevice(physical_device, &ci, nullptr, &device) != VK_SUCCESS) {
         return {};
     }
-    Load(device, dld);
-    return Device(device, dld);
+    Load(device, dispatch);
+    return Device(device, dispatch);
 }
 
 Queue Device::GetQueue(u32 family_index) const noexcept {

--- a/src/video_core/renderer_vulkan/wrapper.h
+++ b/src/video_core/renderer_vulkan/wrapper.h
@@ -52,7 +52,7 @@ public:
 
     /// Construct a span from a pointer and a size.
     /// This is inteded for subranges.
-    constexpr Span(const T* ptr, std::size_t num) noexcept : ptr{ptr}, num{num} {}
+    constexpr Span(const T* ptr_, std::size_t num_) noexcept : ptr{ptr_}, num{num_} {}
 
     /// Returns the data pointer by the span.
     constexpr const T* data() const noexcept {
@@ -469,9 +469,10 @@ public:
     PoolAllocations() = default;
 
     /// Construct an allocation. Errors are reported through IsOutOfPoolMemory().
-    explicit PoolAllocations(std::unique_ptr<AllocationType[]> allocations, std::size_t num,
-                             VkDevice device, PoolType pool, const DeviceDispatch& dld) noexcept
-        : allocations{std::move(allocations)}, num{num}, device{device}, pool{pool}, dld{&dld} {}
+    explicit PoolAllocations(std::unique_ptr<AllocationType[]> allocations_, std::size_t num_,
+                             VkDevice device_, PoolType pool_, const DeviceDispatch& dld_) noexcept
+        : allocations{std::move(allocations_)}, num{num_}, device{device_}, pool{pool_},
+          dld{&dld_} {}
 
     /// Copying Vulkan allocations is not supported and will never be.
     PoolAllocations(const PoolAllocations&) = delete;
@@ -565,7 +566,7 @@ class Instance : public Handle<VkInstance, NoOwner, InstanceDispatch> {
 public:
     /// Creates a Vulkan instance. Use "operator bool" for error handling.
     static Instance Create(u32 version, Span<const char*> layers, Span<const char*> extensions,
-                           InstanceDispatch& dld) noexcept;
+                           InstanceDispatch& dispatch) noexcept;
 
     /// Enumerates physical devices.
     /// @return Physical devices and an empty handle on failure.
@@ -581,7 +582,8 @@ public:
     constexpr Queue() noexcept = default;
 
     /// Construct a queue handle.
-    constexpr Queue(VkQueue queue, const DeviceDispatch& dld) noexcept : queue{queue}, dld{&dld} {}
+    constexpr Queue(VkQueue queue_, const DeviceDispatch& dld_) noexcept
+        : queue{queue_}, dld{&dld_} {}
 
     VkResult Submit(Span<VkSubmitInfo> submit_infos,
                     VkFence fence = VK_NULL_HANDLE) const noexcept {
@@ -720,7 +722,7 @@ class Device : public Handle<VkDevice, NoOwner, DeviceDispatch> {
 public:
     static Device Create(VkPhysicalDevice physical_device, Span<VkDeviceQueueCreateInfo> queues_ci,
                          Span<const char*> enabled_extensions, const void* next,
-                         DeviceDispatch& dld) noexcept;
+                         DeviceDispatch& dispatch) noexcept;
 
     Queue GetQueue(u32 family_index) const noexcept;
 
@@ -809,8 +811,9 @@ class PhysicalDevice {
 public:
     constexpr PhysicalDevice() noexcept = default;
 
-    constexpr PhysicalDevice(VkPhysicalDevice physical_device, const InstanceDispatch& dld) noexcept
-        : physical_device{physical_device}, dld{&dld} {}
+    constexpr PhysicalDevice(VkPhysicalDevice physical_device_,
+                             const InstanceDispatch& dld_) noexcept
+        : physical_device{physical_device_}, dld{&dld_} {}
 
     constexpr operator VkPhysicalDevice() const noexcept {
         return physical_device;
@@ -849,8 +852,8 @@ class CommandBuffer {
 public:
     CommandBuffer() noexcept = default;
 
-    explicit CommandBuffer(VkCommandBuffer handle, const DeviceDispatch& dld) noexcept
-        : handle{handle}, dld{&dld} {}
+    explicit CommandBuffer(VkCommandBuffer handle_, const DeviceDispatch& dld_) noexcept
+        : handle{handle_}, dld{&dld_} {}
 
     const VkCommandBuffer* address() const noexcept {
         return &handle;

--- a/src/video_core/shader/control_flow.cpp
+++ b/src/video_core/shader/control_flow.cpp
@@ -241,10 +241,10 @@ std::pair<ParseResult, ParseInfo> ParseCode(CFGRebuildState& state, u32 address)
     ParseInfo parse_info{};
     SingleBranch single_branch{};
 
-    const auto insert_label = [](CFGRebuildState& state, u32 address) {
-        const auto pair = state.labels.emplace(address);
+    const auto insert_label = [](CFGRebuildState& rebuild_state, u32 label_address) {
+        const auto pair = rebuild_state.labels.emplace(label_address);
         if (pair.second) {
-            state.inspect_queries.push_back(address);
+            rebuild_state.inspect_queries.push_back(label_address);
         }
     };
 

--- a/src/video_core/shader/decode/image.cpp
+++ b/src/video_core/shader/decode/image.cpp
@@ -358,9 +358,9 @@ u32 ShaderIR::DecodeImage(NodeBlock& bb, u32 pc) {
                              instr.suldst.GetStoreDataLayout() != StoreType::Bits64);
 
             auto descriptor = [this, instr] {
-                std::optional<Tegra::Engines::SamplerDescriptor> descriptor;
+                std::optional<Tegra::Engines::SamplerDescriptor> sampler_descriptor;
                 if (instr.suldst.is_immediate) {
-                    descriptor =
+                    sampler_descriptor =
                         registry.ObtainBoundSampler(static_cast<u32>(instr.image.index.Value()));
                 } else {
                     const Node image_register = GetRegister(instr.gpr39);
@@ -368,12 +368,12 @@ u32 ShaderIR::DecodeImage(NodeBlock& bb, u32 pc) {
                                                   static_cast<s64>(global_code.size()));
                     const auto buffer = std::get<1>(result);
                     const auto offset = std::get<2>(result);
-                    descriptor = registry.ObtainBindlessSampler(buffer, offset);
+                    sampler_descriptor = registry.ObtainBindlessSampler(buffer, offset);
                 }
-                if (!descriptor) {
+                if (!sampler_descriptor) {
                     UNREACHABLE_MSG("Failed to obtain image descriptor");
                 }
-                return *descriptor;
+                return *sampler_descriptor;
             }();
 
             const auto comp_mask = GetImageComponentMask(descriptor.format);

--- a/src/video_core/shader/decode/other.cpp
+++ b/src/video_core/shader/decode/other.cpp
@@ -90,11 +90,11 @@ u32 ShaderIR::DecodeOther(NodeBlock& bb, u32 pc) {
                 UNIMPLEMENTED_MSG("S2R WscaleFactorZ is not implemented");
                 return Immediate(0U);
             case SystemVariable::Tid: {
-                Node value = Immediate(0);
-                value = BitfieldInsert(value, Operation(OperationCode::LocalInvocationIdX), 0, 9);
-                value = BitfieldInsert(value, Operation(OperationCode::LocalInvocationIdY), 16, 9);
-                value = BitfieldInsert(value, Operation(OperationCode::LocalInvocationIdZ), 26, 5);
-                return value;
+                Node val = Immediate(0);
+                val = BitfieldInsert(val, Operation(OperationCode::LocalInvocationIdX), 0, 9);
+                val = BitfieldInsert(val, Operation(OperationCode::LocalInvocationIdY), 16, 9);
+                val = BitfieldInsert(val, Operation(OperationCode::LocalInvocationIdZ), 26, 5);
+                return val;
             }
             case SystemVariable::TidX:
                 return Operation(OperationCode::LocalInvocationIdX);

--- a/src/video_core/texture_cache/surface_base.cpp
+++ b/src/video_core/texture_cache/surface_base.cpp
@@ -167,27 +167,28 @@ std::vector<CopyParams> SurfaceBaseImpl::BreakDownNonLayered(const SurfaceParams
     return result;
 }
 
-void SurfaceBaseImpl::SwizzleFunc(MortonSwizzleMode mode, u8* memory, const SurfaceParams& params,
-                                  u8* buffer, u32 level) {
-    const u32 width{params.GetMipWidth(level)};
-    const u32 height{params.GetMipHeight(level)};
-    const u32 block_height{params.GetMipBlockHeight(level)};
-    const u32 block_depth{params.GetMipBlockDepth(level)};
+void SurfaceBaseImpl::SwizzleFunc(MortonSwizzleMode mode, u8* memory,
+                                  const SurfaceParams& surface_params, u8* buffer, u32 level) {
+    const u32 width{surface_params.GetMipWidth(level)};
+    const u32 height{surface_params.GetMipHeight(level)};
+    const u32 block_height{surface_params.GetMipBlockHeight(level)};
+    const u32 block_depth{surface_params.GetMipBlockDepth(level)};
 
     std::size_t guest_offset{mipmap_offsets[level]};
-    if (params.is_layered) {
+    if (surface_params.is_layered) {
         std::size_t host_offset = 0;
         const std::size_t guest_stride = layer_size;
-        const std::size_t host_stride = params.GetHostLayerSize(level);
-        for (u32 layer = 0; layer < params.depth; ++layer) {
-            MortonSwizzle(mode, params.pixel_format, width, block_height, height, block_depth, 1,
-                          params.tile_width_spacing, buffer + host_offset, memory + guest_offset);
+        const std::size_t host_stride = surface_params.GetHostLayerSize(level);
+        for (u32 layer = 0; layer < surface_params.depth; ++layer) {
+            MortonSwizzle(mode, surface_params.pixel_format, width, block_height, height,
+                          block_depth, 1, surface_params.tile_width_spacing, buffer + host_offset,
+                          memory + guest_offset);
             guest_offset += guest_stride;
             host_offset += host_stride;
         }
     } else {
-        MortonSwizzle(mode, params.pixel_format, width, block_height, height, block_depth,
-                      params.GetMipDepth(level), params.tile_width_spacing, buffer,
+        MortonSwizzle(mode, surface_params.pixel_format, width, block_height, height, block_depth,
+                      surface_params.GetMipDepth(level), surface_params.tile_width_spacing, buffer,
                       memory + guest_offset);
     }
 }

--- a/src/video_core/texture_cache/surface_base.h
+++ b/src/video_core/texture_cache/surface_base.h
@@ -167,8 +167,8 @@ protected:
     std::vector<std::size_t> mipmap_offsets;
 
 private:
-    void SwizzleFunc(MortonSwizzleMode mode, u8* memory, const SurfaceParams& params, u8* buffer,
-                     u32 level);
+    void SwizzleFunc(MortonSwizzleMode mode, u8* memory, const SurfaceParams& surface_params,
+                     u8* buffer, u32 level);
 
     std::vector<CopyParams> BreakDownLayered(const SurfaceParams& in_params) const;
 

--- a/src/video_core/texture_cache/surface_params.cpp
+++ b/src/video_core/texture_cache/surface_params.cpp
@@ -356,18 +356,18 @@ std::size_t SurfaceParams::GetLayerSize(bool as_host_size, bool uncompressed) co
 
 std::size_t SurfaceParams::GetInnerMipmapMemorySize(u32 level, bool as_host_size,
                                                     bool uncompressed) const {
-    const u32 width{GetMipmapSize(uncompressed, GetMipWidth(level), GetDefaultBlockWidth())};
-    const u32 height{GetMipmapSize(uncompressed, GetMipHeight(level), GetDefaultBlockHeight())};
-    const u32 depth{is_layered ? 1U : GetMipDepth(level)};
+    const u32 mip_width{GetMipmapSize(uncompressed, GetMipWidth(level), GetDefaultBlockWidth())};
+    const u32 mip_height{GetMipmapSize(uncompressed, GetMipHeight(level), GetDefaultBlockHeight())};
+    const u32 mip_depth{is_layered ? 1U : GetMipDepth(level)};
     if (is_tiled) {
-        return Tegra::Texture::CalculateSize(!as_host_size, GetBytesPerPixel(), width, height,
-                                             depth, GetMipBlockHeight(level),
+        return Tegra::Texture::CalculateSize(!as_host_size, GetBytesPerPixel(), mip_width,
+                                             mip_height, mip_depth, GetMipBlockHeight(level),
                                              GetMipBlockDepth(level));
     } else if (as_host_size || IsBuffer()) {
-        return GetBytesPerPixel() * width * height * depth;
+        return GetBytesPerPixel() * mip_width * mip_height * mip_depth;
     } else {
         // Linear Texture Case
-        return pitch * height * depth;
+        return pitch * mip_height * mip_depth;
     }
 }
 


### PR DESCRIPTION
Migrates the video core code closer to enabling variable shadowing warnings as errors.

This primarily sorts out shadowing occurrences within the Vulkan code. The follow-up to this will resolve the remaining shadowing instances and turn shadowing warnings into errors.