### PR TITLE
Port citra-emu/citra#5577: "Update cubeb and request a persistent stream session"

### DIFF
--- a/src/audio_core/cubeb_sink.cpp
+++ b/src/audio_core/cubeb_sink.cpp
@@ -30,6 +30,7 @@ public:
         params.rate = sample_rate;
         params.channels = num_channels;
         params.format = CUBEB_SAMPLE_S16NE;
+        params.prefs = CUBEB_STREAM_PREF_PERSIST;
         switch (num_channels) {
         case 1:
             params.layout = CUBEB_LAYOUT_MONO;


### PR DESCRIPTION
See citra-emu/citra#5577 for more details.

**Original description**:
When using cubeb, the volume level assigned via windows wouldn't be remembered, annoying some users who controlled volume levels solely using the mixer volumes, instead of changing the master volume or the citra provided internal volume.
The issue happens on Citra as well as Yuzu (see yuzu-emu/yuzu#2935)

A recent cubeb change (kinetiknz/cubeb#599) introduced the CUBEB_STREAM_PREF_PERSIST flag which should fix the issue.

Fixes yuzu-emu/yuzu#2935.