### PR TITLE
maxwell_dma: Rename RenderEnable::Mode::FALSE and TRUE to avoid name conflict

### DIFF
--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -72,11 +72,13 @@ public:
 
     struct RenderEnable {
         enum class Mode : u32 {
-            FALSE = 0,
-            TRUE = 1,
-            CONDITIONAL = 2,
-            RENDER_IF_EQUAL = 3,
-            RENDER_IF_NOT_EQUAL = 4,
+            // Note: This uses Pascal case in order to avoid the identifiers
+            // FALSE and TRUE, which are reserved on Darwin.
+            False = 0,
+            True = 1,
+            Conditional = 2,
+            RenderIfEqual = 3,
+            RenderIfNotEqual = 4,
         };
 
         PackedGPUVAddr address;


### PR DESCRIPTION
On Apple platforms, `FALSE` and `TRUE` are defined as macros by <mach/boolean.h>, which is included by various system headers.

Note that there appear to be no actual users of the names to fix up.