### PR TITLE
nvdrv: Remove useless re-declaration of pure virtual methods that were already declared in the superclass

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.h
@@ -18,39 +18,6 @@ public:
     explicit nvhost_nvdec_common(Core::System& system, std::shared_ptr<nvmap> nvmap_dev);
     ~nvhost_nvdec_common() override;
 
-    /**
-     * Handles an ioctl1 request.
-     * @param command The ioctl command id.
-     * @param input A buffer containing the input data for the ioctl.
-     * @param output A buffer where the output data will be written to.
-     * @returns The result code of the ioctl.
-     */
-    virtual NvResult Ioctl1(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output,
-                            IoctlCtrl& ctrl) = 0;
-
-    /**
-     * Handles an ioctl2 request.
-     * @param command The ioctl command id.
-     * @param input A buffer containing the input data for the ioctl.
-     * @param inline_input A buffer containing the input data for the ioctl which has been inlined.
-     * @param output A buffer where the output data will be written to.
-     * @returns The result code of the ioctl.
-     */
-    virtual NvResult Ioctl2(Ioctl command, const std::vector<u8>& input,
-                            const std::vector<u8>& inline_input, std::vector<u8>& output,
-                            IoctlCtrl& ctrl) = 0;
-
-    /**
-     * Handles an ioctl3 request.
-     * @param command The ioctl command id.
-     * @param input A buffer containing the input data for the ioctl.
-     * @param output A buffer where the output data will be written to.
-     * @param inline_output A buffer where the inlined output data will be written to.
-     * @returns The result code of the ioctl.
-     */
-    virtual NvResult Ioctl3(Ioctl command, const std::vector<u8>& input, std::vector<u8>& output,
-                            std::vector<u8>& inline_output, IoctlCtrl& ctrl) = 0;
-
 protected:
     class BufferMap final {
     public:


### PR DESCRIPTION
Clang warning.