### PR TITLE
core: Mark unused fields as [[maybe_unused]]

### DIFF
--- a/src/core/hle/kernel/memory/memory_block_manager.h
+++ b/src/core/hle/kernel/memory/memory_block_manager.h
@@ -57,8 +57,8 @@ public:
 private:
     void MergeAdjacent(iterator it, iterator& next_it);
 
-    const VAddr start_addr;
-    const VAddr end_addr;
+    [[maybe_unused]] const VAddr start_addr;
+    [[maybe_unused]] const VAddr end_addr;
 
     MemoryBlockTree memory_block_tree;
 };

--- a/src/core/hle/service/ncm/ncm.cpp
+++ b/src/core/hle/service/ncm/ncm.cpp
@@ -45,7 +45,7 @@ public:
     }
 
 private:
-    FileSys::StorageId storage;
+    [[maybe_unused]] FileSys::StorageId storage;
 };
 
 class IRegisteredLocationResolver final : public ServiceFramework<IRegisteredLocationResolver> {


### PR DESCRIPTION
These fields look like they might be useful in the future (especially in ncm where the methods are all unimplemented), so I didn't remove them entirely.