### PR TITLE
CMakeLists,network: Create YUZU_UNIX macro to replace __unix__

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,9 @@ if (NOT DEFINED ARCHITECTURE)
 endif()
 message(STATUS "Target architecture: ${ARCHITECTURE}")
 
+if (UNIX)
+    add_definitions(-DYUZU_UNIX=1)
+endif()
 
 # Configure C++ standard
 # ===========================

--- a/src/core/network/network.cpp
+++ b/src/core/network/network.cpp
@@ -11,7 +11,7 @@
 #ifdef _WIN32
 #define _WINSOCK_DEPRECATED_NO_WARNINGS // gethostname
 #include <winsock2.h>
-#elif __unix__
+#elif YUZU_UNIX
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
@@ -54,7 +54,7 @@ constexpr IPv4Address TranslateIPv4(in_addr addr) {
 sockaddr TranslateFromSockAddrIn(SockAddrIn input) {
     sockaddr_in result;
 
-#ifdef __unix__
+#if YUZU_UNIX
     result.sin_len = sizeof(result);
 #endif
 
@@ -99,7 +99,7 @@ bool EnableNonBlock(SOCKET fd, bool enable) {
     return ioctlsocket(fd, FIONBIO, &value) != SOCKET_ERROR;
 }
 
-#elif __unix__ // ^ _WIN32 v __unix__
+#elif YUZU_UNIX // ^ _WIN32 v YUZU_UNIX
 
 using SOCKET = int;
 using WSAPOLLFD = pollfd;

--- a/src/core/network/sockets.h
+++ b/src/core/network/sockets.h
@@ -9,7 +9,7 @@
 
 #if defined(_WIN32)
 #include <winsock.h>
-#elif !defined(__unix__)
+#elif !YUZU_UNIX
 #error "Platform not implemented"
 #endif
 
@@ -84,7 +84,7 @@ public:
 
 #if defined(_WIN32)
     SOCKET fd = INVALID_SOCKET;
-#elif defined(__unix__)
+#elif YUZU_UNIX
     int fd = -1;
 #endif
 };


### PR DESCRIPTION
`__unix__` is not predefined on Apple platforms even though they are Unix.