### PR TITLE
hle: Type check ResponseBuilder::Push arguments, and fix use in vi.cpp

### DIFF
--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -166,8 +166,23 @@ public:
         ValidateHeader();
     }
 
+    void PushImpl(s8 value);
+    void PushImpl(s16 value);
+    void PushImpl(s32 value);
+    void PushImpl(s64 value);
+    void PushImpl(u8 value);
+    void PushImpl(u16 value);
+    void PushImpl(u32 value);
+    void PushImpl(u64 value);
+    void PushImpl(float value);
+    void PushImpl(double value);
+    void PushImpl(bool value);
+    void PushImpl(ResultCode value);
+
     template <typename T>
-    void Push(T value);
+    void Push(T value) {
+        return PushImpl(value);
+    }
 
     template <typename First, typename... Other>
     void Push(const First& first_value, const Other&... other_values);
@@ -215,13 +230,11 @@ private:
 
 /// Push ///
 
-template <>
-inline void ResponseBuilder::Push(s32 value) {
+inline void ResponseBuilder::PushImpl(s32 value) {
     cmdbuf[index++] = static_cast<u32>(value);
 }
 
-template <>
-inline void ResponseBuilder::Push(u32 value) {
+inline void ResponseBuilder::PushImpl(u32 value) {
     cmdbuf[index++] = value;
 }
 
@@ -233,62 +246,52 @@ void ResponseBuilder::PushRaw(const T& value) {
     index += (sizeof(T) + 3) / 4; // round up to word length
 }
 
-template <>
-inline void ResponseBuilder::Push(ResultCode value) {
+inline void ResponseBuilder::PushImpl(ResultCode value) {
     // Result codes are actually 64-bit in the IPC buffer, but only the high part is discarded.
     Push(value.raw);
     Push<u32>(0);
 }
 
-template <>
-inline void ResponseBuilder::Push(s8 value) {
+inline void ResponseBuilder::PushImpl(s8 value) {
     PushRaw(value);
 }
 
-template <>
-inline void ResponseBuilder::Push(s16 value) {
+inline void ResponseBuilder::PushImpl(s16 value) {
     PushRaw(value);
 }
 
-template <>
-inline void ResponseBuilder::Push(s64 value) {
-    Push(static_cast<u32>(value));
-    Push(static_cast<u32>(value >> 32));
+inline void ResponseBuilder::PushImpl(s64 value) {
+    PushImpl(static_cast<u32>(value));
+    PushImpl(static_cast<u32>(value >> 32));
 }
 
-template <>
-inline void ResponseBuilder::Push(u8 value) {
+inline void ResponseBuilder::PushImpl(u8 value) {
     PushRaw(value);
 }
 
-template <>
-inline void ResponseBuilder::Push(u16 value) {
+inline void ResponseBuilder::PushImpl(u16 value) {
     PushRaw(value);
 }
 
-template <>
-inline void ResponseBuilder::Push(u64 value) {
-    Push(static_cast<u32>(value));
-    Push(static_cast<u32>(value >> 32));
+inline void ResponseBuilder::PushImpl(u64 value) {
+    PushImpl(static_cast<u32>(value));
+    PushImpl(static_cast<u32>(value >> 32));
 }
 
-template <>
-inline void ResponseBuilder::Push(float value) {
+inline void ResponseBuilder::PushImpl(float value) {
     u32 integral;
     std::memcpy(&integral, &value, sizeof(u32));
-    Push(integral);
+    PushImpl(integral);
 }
 
-template <>
-inline void ResponseBuilder::Push(double value) {
+inline void ResponseBuilder::PushImpl(double value) {
     u64 integral;
     std::memcpy(&integral, &value, sizeof(u64));
-    Push(integral);
+    PushImpl(integral);
 }
 
-template <>
-inline void ResponseBuilder::Push(bool value) {
-    Push(static_cast<u8>(value));
+inline void ResponseBuilder::PushImpl(bool value) {
+    PushImpl(static_cast<u8>(value));
 }
 
 template <typename First, typename... Other>

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -1230,8 +1230,8 @@ private:
         const auto height = rp.Pop<u64>();
         LOG_DEBUG(Service_VI, "called width={}, height={}", width, height);
 
-        constexpr std::size_t base_size = 0x20000;
-        constexpr std::size_t alignment = 0x1000;
+        constexpr u64 base_size = 0x20000;
+        constexpr u64 alignment = 0x1000;
         const auto texture_size = width * height * 4;
         const auto out_size = (texture_size + base_size - 1) / base_size * base_size;
 


### PR DESCRIPTION
- Add a type check so that calling Push with an invalid type produces a compile error rather than a linker error.

- vi.cpp was calling Push with a variable of type `std::size_t`.  There's no explicit overload for `size_t`, but there is one for `u64`, which on most platforms is the same type as `size_t`.  On macOS, however, it isn't: both types are 64 bits, but `size_t` is `unsigned long` and `u64` is `unsigned long long`.  Regardless, it makes more sense to explicitly use `u64` here instead of `size_t`.
