### PR TITLE
Fix "explicitly defaulted but implicitly deleted" warning

### DIFF
--- a/src/core/hle/kernel/physical_core.h
+++ b/src/core/hle/kernel/physical_core.h
@@ -36,7 +36,7 @@ public:
     PhysicalCore& operator=(const PhysicalCore&) = delete;
 
     PhysicalCore(PhysicalCore&&) = default;
-    PhysicalCore& operator=(PhysicalCore&&) = default;
+    PhysicalCore& operator=(PhysicalCore&&) = delete;
 
     /// Initialize the core for the specified parameters.
     void Initialize(bool is_64_bit);


### PR DESCRIPTION
`PhysicalCore`'s move assignment operator was declared as `= default`,
but was implicitly deleted because `PhysicalCore` has fields
of reference type.  Switch to explicitly deleting it to avoid a Clang
warning.

The move *constructor* is still defaulted, and is required to exist due
to the use of `std::vector<PhysicalCore>`.