### PR TITLE
video_core: Remove unnecessary enum class casting in logging messages

### DIFF
--- a/src/video_core/command_classes/codecs/codec.cpp
+++ b/src/video_core/command_classes/codecs/codec.cpp
@@ -44,7 +44,7 @@ Codec::~Codec() {
 }
 
 void Codec::SetTargetCodec(NvdecCommon::VideoCodec codec) {
-    LOG_INFO(Service_NVDRV, "NVDEC video codec initialized to {}", static_cast<u32>(codec));
+    LOG_INFO(Service_NVDRV, "NVDEC video codec initialized to {}", codec);
     current_codec = codec;
 }
 
@@ -62,7 +62,7 @@ void Codec::Decode() {
         } else if (current_codec == NvdecCommon::VideoCodec::Vp9) {
             av_codec = avcodec_find_decoder(AV_CODEC_ID_VP9);
         } else {
-            LOG_ERROR(Service_NVDRV, "Unknown video codec {}", static_cast<u32>(current_codec));
+            LOG_ERROR(Service_NVDRV, "Unknown video codec {}", current_codec);
             return;
         }
 

--- a/src/video_core/command_classes/vic.cpp
+++ b/src/video_core/command_classes/vic.cpp
@@ -27,7 +27,7 @@ void Vic::VicStateWrite(u32 offset, u32 arguments) {
 }
 
 void Vic::ProcessMethod(Method method, const std::vector<u32>& arguments) {
-    LOG_DEBUG(HW_GPU, "Vic method 0x{:X}", static_cast<u32>(method));
+    LOG_DEBUG(HW_GPU, "Vic method 0x{:X}", method);
     VicStateWrite(static_cast<u32>(method), arguments[0]);
     const u64 arg = static_cast<u64>(arguments[0]) << 8;
     switch (method) {

--- a/src/video_core/engines/fermi_2d.cpp
+++ b/src/video_core/engines/fermi_2d.cpp
@@ -48,8 +48,7 @@ static std::pair<u32, u32> DelimitLine(u32 src_1, u32 src_2, u32 dst_1, u32 dst_
 }
 
 void Fermi2D::HandleSurfaceCopy() {
-    LOG_DEBUG(HW_GPU, "Requested a surface copy with operation {}",
-              static_cast<u32>(regs.operation));
+    LOG_DEBUG(HW_GPU, "Requested a surface copy with operation {}", regs.operation);
 
     // TODO(Subv): Only raw copies are implemented.
     ASSERT(regs.operation == Operation::SrcCopy);

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -359,7 +359,7 @@ void Maxwell3D::CallMethodFromMME(u32 method, u32 method_argument) {
 }
 
 void Maxwell3D::FlushMMEInlineDraw() {
-    LOG_TRACE(HW_GPU, "called, topology={}, count={}", static_cast<u32>(regs.draw.topology.Value()),
+    LOG_TRACE(HW_GPU, "called, topology={}, count={}", regs.draw.topology.Value(),
               regs.vertex_buffer.count);
     ASSERT_MSG(!(regs.index_array.count && regs.vertex_buffer.count), "Both indexed and direct?");
     ASSERT(mme_draw.instance_count == mme_draw.gl_end_count);
@@ -504,8 +504,7 @@ void Maxwell3D::ProcessCounterReset() {
         rasterizer->ResetCounter(QueryType::SamplesPassed);
         break;
     default:
-        LOG_DEBUG(Render_OpenGL, "Unimplemented counter reset={}",
-                  static_cast<int>(regs.counter_reset));
+        LOG_DEBUG(Render_OpenGL, "Unimplemented counter reset={}", regs.counter_reset);
         break;
     }
 }
@@ -520,7 +519,7 @@ void Maxwell3D::ProcessSyncPoint() {
 }
 
 void Maxwell3D::DrawArrays() {
-    LOG_TRACE(HW_GPU, "called, topology={}, count={}", static_cast<u32>(regs.draw.topology.Value()),
+    LOG_TRACE(HW_GPU, "called, topology={}, count={}", regs.draw.topology.Value(),
               regs.vertex_buffer.count);
     ASSERT_MSG(!(regs.index_array.count && regs.vertex_buffer.count), "Both indexed and direct?");
 
@@ -558,12 +557,12 @@ std::optional<u64> Maxwell3D::GetQueryResult() {
         return 0;
     case Regs::QuerySelect::SamplesPassed:
         // Deferred.
-        rasterizer->Query(regs.query.QueryAddress(), VideoCore::QueryType::SamplesPassed,
+        rasterizer->Query(regs.query.QueryAddress(), QueryType::SamplesPassed,
                           system.GPU().GetTicks());
         return std::nullopt;
     default:
         LOG_DEBUG(HW_GPU, "Unimplemented query select type {}",
-                  static_cast<u32>(regs.query.query_get.select.Value()));
+                  regs.query.query_get.select.Value());
         return 1;
     }
 }

--- a/src/video_core/engines/shader_bytecode.h
+++ b/src/video_core/engines/shader_bytecode.h
@@ -1437,8 +1437,7 @@ union Instruction {
                 return TextureType::TextureCube;
             }
 
-            LOG_CRITICAL(HW_GPU, "Unhandled texture_info: {}",
-                         static_cast<u32>(texture_info.Value()));
+            LOG_CRITICAL(HW_GPU, "Unhandled texture_info: {}", texture_info.Value());
             UNREACHABLE();
             return TextureType::Texture1D;
         }
@@ -1533,8 +1532,7 @@ union Instruction {
                 return TextureType::Texture3D;
             }
 
-            LOG_CRITICAL(HW_GPU, "Unhandled texture_info: {}",
-                         static_cast<u32>(texture_info.Value()));
+            LOG_CRITICAL(HW_GPU, "Unhandled texture_info: {}", texture_info.Value());
             UNREACHABLE();
             return TextureType::Texture1D;
         }

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -299,8 +299,7 @@ void GPU::CallPullerMethod(const MethodCall& method_call) {
         break;
     }
     default:
-        LOG_ERROR(HW_GPU, "Special puller engine method {:X} not implemented",
-                  static_cast<u32>(method));
+        LOG_ERROR(HW_GPU, "Special puller engine method {:X} not implemented", method);
         break;
     }
 }
@@ -379,7 +378,7 @@ void GPU::ProcessBindMethod(const MethodCall& method_call) {
         dma_pusher->BindSubchannel(kepler_memory.get(), method_call.subchannel);
         break;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented engine {:04X}", static_cast<u32>(engine_id));
+        UNIMPLEMENTED_MSG("Unimplemented engine {:04X}", engine_id);
     }
 }
 
@@ -392,8 +391,7 @@ void GPU::ProcessFenceActionMethod() {
         IncrementSyncPoint(regs.fence_action.syncpoint_id);
         break;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented operation {}",
-                          static_cast<u32>(regs.fence_action.op.Value()));
+        UNIMPLEMENTED_MSG("Unimplemented operation {}", regs.fence_action.op.Value());
     }
 }
 

--- a/src/video_core/macro/macro_interpreter.cpp
+++ b/src/video_core/macro/macro_interpreter.cpp
@@ -133,8 +133,7 @@ bool MacroInterpreterImpl::Step(bool is_delay_slot) {
         break;
     }
     default:
-        UNIMPLEMENTED_MSG("Unimplemented macro operation {}",
-                          static_cast<u32>(opcode.operation.Value()));
+        UNIMPLEMENTED_MSG("Unimplemented macro operation {}", opcode.operation.Value());
     }
 
     // An instruction with the Exit flag will not actually
@@ -182,7 +181,7 @@ u32 MacroInterpreterImpl::GetALUResult(Macro::ALUOperation operation, u32 src_a,
         return ~(src_a & src_b);
 
     default:
-        UNIMPLEMENTED_MSG("Unimplemented ALU operation {}", static_cast<u32>(operation));
+        UNIMPLEMENTED_MSG("Unimplemented ALU operation {}", operation);
         return 0;
     }
 }
@@ -230,7 +229,7 @@ void MacroInterpreterImpl::ProcessResult(Macro::ResultOperation operation, u32 r
         Send((result >> 12) & 0b111111);
         break;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented result operation {}", static_cast<u32>(operation));
+        UNIMPLEMENTED_MSG("Unimplemented result operation {}", operation);
     }
 }
 

--- a/src/video_core/macro/macro_jit_x64.cpp
+++ b/src/video_core/macro/macro_jit_x64.cpp
@@ -165,8 +165,7 @@ void MacroJITx64Impl::Compile_ALU(Macro::Opcode opcode) {
         }
         break;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented ALU operation {}",
-                          static_cast<std::size_t>(opcode.alu_operation.Value()));
+        UNIMPLEMENTED_MSG("Unimplemented ALU operation {}", opcode.alu_operation.Value());
         break;
     }
     Compile_ProcessResult(opcode.result_operation, opcode.dst);
@@ -604,7 +603,7 @@ void MacroJITx64Impl::Compile_ProcessResult(Macro::ResultOperation operation, u3
         Compile_Send(RESULT);
         break;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented macro operation {}", static_cast<std::size_t>(operation));
+        UNIMPLEMENTED_MSG("Unimplemented macro operation {}", operation);
     }
 }
 

--- a/src/video_core/renderer_opengl/gl_arb_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_arb_decompiler.cpp
@@ -71,7 +71,7 @@ std::string_view GetInputFlags(PixelImap attribute) {
     case PixelImap::Unused:
         break;
     }
-    UNIMPLEMENTED_MSG("Unknown attribute usage index={}", static_cast<int>(attribute));
+    UNIMPLEMENTED_MSG("Unknown attribute usage index={}", attribute);
     return {};
 }
 
@@ -123,7 +123,7 @@ std::string_view PrimitiveDescription(Tegra::Engines::Maxwell3D::Regs::Primitive
     case Tegra::Engines::Maxwell3D::Regs::PrimitiveTopology::TriangleStripAdjacency:
         return "TRIANGLES_ADJACENCY";
     default:
-        UNIMPLEMENTED_MSG("topology={}", static_cast<int>(topology));
+        UNIMPLEMENTED_MSG("topology={}", topology);
         return "POINTS";
     }
 }
@@ -137,7 +137,7 @@ std::string_view TopologyName(Tegra::Shader::OutputTopology topology) {
     case Tegra::Shader::OutputTopology::TriangleStrip:
         return "TRIANGLE_STRIP";
     default:
-        UNIMPLEMENTED_MSG("Unknown output topology: {}", static_cast<u32>(topology));
+        UNIMPLEMENTED_MSG("Unknown output topology: {}", topology);
         return "points";
     }
 }
@@ -1351,7 +1351,7 @@ std::string ARBDecompiler::Visit(const Node& node) {
                                        GetGenericAttributeIndex(index), swizzle);
                 }
             }
-            UNIMPLEMENTED_MSG("Unimplemented input attribute={}", static_cast<int>(index));
+            UNIMPLEMENTED_MSG("Unimplemented input attribute={}", index);
             break;
         }
         return "{0, 0, 0, 0}.x";

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -131,7 +131,7 @@ std::pair<GLint, GLint> TransformFeedbackEnum(u8 location) {
     case 43:
         return {GL_BACK_SECONDARY_COLOR_NV, 0};
     }
-    UNIMPLEMENTED_MSG("index={}", static_cast<int>(index));
+    UNIMPLEMENTED_MSG("index={}", index);
     return {GL_POSITION, 0};
 }
 

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -316,7 +316,7 @@ std::pair<const char*, u32> GetPrimitiveDescription(Maxwell::PrimitiveTopology t
     case Maxwell::PrimitiveTopology::TriangleStripAdjacency:
         return {"triangles_adjacency", 6};
     default:
-        UNIMPLEMENTED_MSG("topology={}", static_cast<int>(topology));
+        UNIMPLEMENTED_MSG("topology={}", topology);
         return {"points", 1};
     }
 }
@@ -342,7 +342,7 @@ std::string GetTopologyName(Tegra::Shader::OutputTopology topology) {
     case Tegra::Shader::OutputTopology::TriangleStrip:
         return "triangle_strip";
     default:
-        UNIMPLEMENTED_MSG("Unknown output topology: {}", static_cast<u32>(topology));
+        UNIMPLEMENTED_MSG("Unknown output topology: {}", topology);
         return "points";
     }
 }
@@ -745,7 +745,7 @@ private:
         case PixelImap::Unused:
             break;
         }
-        UNIMPLEMENTED_MSG("Unknown attribute usage index={}", static_cast<int>(attribute));
+        UNIMPLEMENTED_MSG("Unknown attribute usage index={}", attribute);
         return {};
     }
 
@@ -1252,7 +1252,7 @@ private:
             }
             break;
         }
-        UNIMPLEMENTED_MSG("Unhandled input attribute: {}", static_cast<u32>(attribute));
+        UNIMPLEMENTED_MSG("Unhandled input attribute: {}", attribute);
         return {"0", Type::Int};
     }
 
@@ -1332,7 +1332,7 @@ private:
                                      GetSwizzle(element)),
                          Type::Float}};
             }
-            UNIMPLEMENTED_MSG("Unhandled output attribute: {}", static_cast<u32>(attribute));
+            UNIMPLEMENTED_MSG("Unhandled output attribute: {}", attribute);
             return std::nullopt;
         }
     }

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -689,8 +689,7 @@ void TextureCacheOpenGL::BufferCopy(Surface& src_surface, Surface& dst_surface) 
                                 dest_format.format, dest_format.type, nullptr);
             break;
         default:
-            LOG_CRITICAL(Render_OpenGL, "Unimplemented surface target={}",
-                         static_cast<u32>(dst_params.target));
+            LOG_CRITICAL(Render_OpenGL, "Unimplemented surface target={}", dst_params.target);
             UNREACHABLE();
         }
     }

--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -107,7 +107,7 @@ inline GLenum IndexFormat(Maxwell::IndexFormat index_format) {
     case Maxwell::IndexFormat::UnsignedInt:
         return GL_UNSIGNED_INT;
     }
-    UNREACHABLE_MSG("Invalid index_format={}", static_cast<u32>(index_format));
+    UNREACHABLE_MSG("Invalid index_format={}", index_format);
     return {};
 }
 
@@ -144,7 +144,7 @@ inline GLenum PrimitiveTopology(Maxwell::PrimitiveTopology topology) {
     case Maxwell::PrimitiveTopology::Patches:
         return GL_PATCHES;
     }
-    UNREACHABLE_MSG("Invalid topology={}", static_cast<int>(topology));
+    UNREACHABLE_MSG("Invalid topology={}", topology);
     return GL_POINTS;
 }
 
@@ -172,8 +172,8 @@ inline GLenum TextureFilterMode(Tegra::Texture::TextureFilter filter_mode,
         }
         break;
     }
-    UNREACHABLE_MSG("Invalid texture filter mode={} and mipmap filter mode={}",
-                    static_cast<u32>(filter_mode), static_cast<u32>(mipmap_filter_mode));
+    UNREACHABLE_MSG("Invalid texture filter mode={} and mipmap filter mode={}", filter_mode,
+                    mipmap_filter_mode);
     return GL_NEAREST;
 }
 
@@ -204,7 +204,7 @@ inline GLenum WrapMode(Tegra::Texture::WrapMode wrap_mode) {
             return GL_MIRROR_CLAMP_TO_EDGE;
         }
     }
-    UNIMPLEMENTED_MSG("Unimplemented texture wrap mode={}", static_cast<u32>(wrap_mode));
+    UNIMPLEMENTED_MSG("Unimplemented texture wrap mode={}", wrap_mode);
     return GL_REPEAT;
 }
 
@@ -227,7 +227,7 @@ inline GLenum DepthCompareFunc(Tegra::Texture::DepthCompareFunc func) {
     case Tegra::Texture::DepthCompareFunc::Always:
         return GL_ALWAYS;
     }
-    UNIMPLEMENTED_MSG("Unimplemented texture depth compare function={}", static_cast<u32>(func));
+    UNIMPLEMENTED_MSG("Unimplemented texture depth compare function={}", func);
     return GL_GREATER;
 }
 
@@ -249,7 +249,7 @@ inline GLenum BlendEquation(Maxwell::Blend::Equation equation) {
     case Maxwell::Blend::Equation::MaxGL:
         return GL_MAX;
     }
-    UNIMPLEMENTED_MSG("Unimplemented blend equation={}", static_cast<u32>(equation));
+    UNIMPLEMENTED_MSG("Unimplemented blend equation={}", equation);
     return GL_FUNC_ADD;
 }
 
@@ -313,7 +313,7 @@ inline GLenum BlendFunc(Maxwell::Blend::Factor factor) {
     case Maxwell::Blend::Factor::OneMinusConstantAlphaGL:
         return GL_ONE_MINUS_CONSTANT_ALPHA;
     }
-    UNIMPLEMENTED_MSG("Unimplemented blend factor={}", static_cast<u32>(factor));
+    UNIMPLEMENTED_MSG("Unimplemented blend factor={}", factor);
     return GL_ZERO;
 }
 
@@ -333,7 +333,7 @@ inline GLenum SwizzleSource(Tegra::Texture::SwizzleSource source) {
     case Tegra::Texture::SwizzleSource::OneFloat:
         return GL_ONE;
     }
-    UNIMPLEMENTED_MSG("Unimplemented swizzle source={}", static_cast<u32>(source));
+    UNIMPLEMENTED_MSG("Unimplemented swizzle source={}", source);
     return GL_ZERO;
 }
 
@@ -364,7 +364,7 @@ inline GLenum ComparisonOp(Maxwell::ComparisonOp comparison) {
     case Maxwell::ComparisonOp::AlwaysOld:
         return GL_ALWAYS;
     }
-    UNIMPLEMENTED_MSG("Unimplemented comparison op={}", static_cast<u32>(comparison));
+    UNIMPLEMENTED_MSG("Unimplemented comparison op={}", comparison);
     return GL_ALWAYS;
 }
 
@@ -395,7 +395,7 @@ inline GLenum StencilOp(Maxwell::StencilOp stencil) {
     case Maxwell::StencilOp::DecrWrapOGL:
         return GL_DECR_WRAP;
     }
-    UNIMPLEMENTED_MSG("Unimplemented stencil op={}", static_cast<u32>(stencil));
+    UNIMPLEMENTED_MSG("Unimplemented stencil op={}", stencil);
     return GL_KEEP;
 }
 
@@ -406,7 +406,7 @@ inline GLenum FrontFace(Maxwell::FrontFace front_face) {
     case Maxwell::FrontFace::CounterClockWise:
         return GL_CCW;
     }
-    UNIMPLEMENTED_MSG("Unimplemented front face cull={}", static_cast<u32>(front_face));
+    UNIMPLEMENTED_MSG("Unimplemented front face cull={}", front_face);
     return GL_CCW;
 }
 
@@ -419,7 +419,7 @@ inline GLenum CullFace(Maxwell::CullFace cull_face) {
     case Maxwell::CullFace::FrontAndBack:
         return GL_FRONT_AND_BACK;
     }
-    UNIMPLEMENTED_MSG("Unimplemented cull face={}", static_cast<u32>(cull_face));
+    UNIMPLEMENTED_MSG("Unimplemented cull face={}", cull_face);
     return GL_BACK;
 }
 
@@ -458,7 +458,7 @@ inline GLenum LogicOp(Maxwell::LogicOperation operation) {
     case Maxwell::LogicOperation::Set:
         return GL_SET;
     }
-    UNIMPLEMENTED_MSG("Unimplemented logic operation={}", static_cast<u32>(operation));
+    UNIMPLEMENTED_MSG("Unimplemented logic operation={}", operation);
     return GL_COPY;
 }
 
@@ -471,7 +471,7 @@ inline GLenum PolygonMode(Maxwell::PolygonMode polygon_mode) {
     case Maxwell::PolygonMode::Fill:
         return GL_FILL;
     }
-    UNREACHABLE_MSG("Invalid polygon mode={}", static_cast<int>(polygon_mode));
+    UNREACHABLE_MSG("Invalid polygon mode={}", polygon_mode);
     return GL_FILL;
 }
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -348,7 +348,7 @@ void RendererOpenGL::DrawScreen(const Layout::FramebufferLayout& layout) {
         } else {
             // Other transformations are unsupported
             LOG_CRITICAL(Render_OpenGL, "Unsupported framebuffer_transform_flags={}",
-                         static_cast<u32>(framebuffer_transform_flags));
+                         framebuffer_transform_flags);
             UNIMPLEMENTED();
         }
     }

--- a/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
@@ -26,7 +26,7 @@ VkFilter Filter(Tegra::Texture::TextureFilter filter) {
     case Tegra::Texture::TextureFilter::Linear:
         return VK_FILTER_LINEAR;
     }
-    UNREACHABLE_MSG("Invalid sampler filter={}", static_cast<u32>(filter));
+    UNREACHABLE_MSG("Invalid sampler filter={}", filter);
     return {};
 }
 
@@ -43,7 +43,7 @@ VkSamplerMipmapMode MipmapMode(Tegra::Texture::TextureMipmapFilter mipmap_filter
     case Tegra::Texture::TextureMipmapFilter::Linear:
         return VK_SAMPLER_MIPMAP_MODE_LINEAR;
     }
-    UNREACHABLE_MSG("Invalid sampler mipmap mode={}", static_cast<u32>(mipmap_filter));
+    UNREACHABLE_MSG("Invalid sampler mipmap mode={}", mipmap_filter);
     return {};
 }
 
@@ -79,7 +79,7 @@ VkSamplerAddressMode WrapMode(const VKDevice& device, Tegra::Texture::WrapMode w
         UNIMPLEMENTED();
         return VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented wrap mode={}", static_cast<u32>(wrap_mode));
+        UNIMPLEMENTED_MSG("Unimplemented wrap mode={}", wrap_mode);
         return {};
     }
 }
@@ -103,8 +103,7 @@ VkCompareOp DepthCompareFunction(Tegra::Texture::DepthCompareFunc depth_compare_
     case Tegra::Texture::DepthCompareFunc::Always:
         return VK_COMPARE_OP_ALWAYS;
     }
-    UNIMPLEMENTED_MSG("Unimplemented sampler depth compare function={}",
-                      static_cast<u32>(depth_compare_func));
+    UNIMPLEMENTED_MSG("Unimplemented sampler depth compare function={}", depth_compare_func);
     return {};
 }
 
@@ -228,8 +227,7 @@ FormatInfo SurfaceFormat(const VKDevice& device, FormatType format_type, PixelFo
 
     auto tuple = tex_format_tuples[static_cast<std::size_t>(pixel_format)];
     if (tuple.format == VK_FORMAT_UNDEFINED) {
-        UNIMPLEMENTED_MSG("Unimplemented texture format with pixel format={}",
-                          static_cast<u32>(pixel_format));
+        UNIMPLEMENTED_MSG("Unimplemented texture format with pixel format={}", pixel_format);
         return {VK_FORMAT_A8B8G8R8_UNORM_PACK32, true, true};
     }
 
@@ -275,7 +273,7 @@ VkShaderStageFlagBits ShaderStage(Tegra::Engines::ShaderType stage) {
     case Tegra::Engines::ShaderType::Compute:
         return VK_SHADER_STAGE_COMPUTE_BIT;
     }
-    UNIMPLEMENTED_MSG("Unimplemented shader stage={}", static_cast<u32>(stage));
+    UNIMPLEMENTED_MSG("Unimplemented shader stage={}", stage);
     return {};
 }
 
@@ -300,7 +298,7 @@ VkPrimitiveTopology PrimitiveTopology([[maybe_unused]] const VKDevice& device,
     case Maxwell::PrimitiveTopology::Patches:
         return VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented topology={}", static_cast<u32>(topology));
+        UNIMPLEMENTED_MSG("Unimplemented topology={}", topology);
         return {};
     }
 }
@@ -490,8 +488,7 @@ VkFormat VertexFormat(Maxwell::VertexAttribute::Type type, Maxwell::VertexAttrib
         }
         break;
     }
-    UNIMPLEMENTED_MSG("Unimplemented vertex format of type={} and size={}", static_cast<u32>(type),
-                      static_cast<u32>(size));
+    UNIMPLEMENTED_MSG("Unimplemented vertex format of type={} and size={}", type, size);
     return {};
 }
 
@@ -522,7 +519,7 @@ VkCompareOp ComparisonOp(Maxwell::ComparisonOp comparison) {
     case Maxwell::ComparisonOp::AlwaysOld:
         return VK_COMPARE_OP_ALWAYS;
     }
-    UNIMPLEMENTED_MSG("Unimplemented comparison op={}", static_cast<u32>(comparison));
+    UNIMPLEMENTED_MSG("Unimplemented comparison op={}", comparison);
     return {};
 }
 
@@ -539,7 +536,7 @@ VkIndexType IndexFormat(const VKDevice& device, Maxwell::IndexFormat index_forma
     case Maxwell::IndexFormat::UnsignedInt:
         return VK_INDEX_TYPE_UINT32;
     }
-    UNIMPLEMENTED_MSG("Unimplemented index_format={}", static_cast<u32>(index_format));
+    UNIMPLEMENTED_MSG("Unimplemented index_format={}", index_format);
     return {};
 }
 
@@ -570,7 +567,7 @@ VkStencilOp StencilOp(Maxwell::StencilOp stencil_op) {
     case Maxwell::StencilOp::DecrWrapOGL:
         return VK_STENCIL_OP_DECREMENT_AND_WRAP;
     }
-    UNIMPLEMENTED_MSG("Unimplemented stencil op={}", static_cast<u32>(stencil_op));
+    UNIMPLEMENTED_MSG("Unimplemented stencil op={}", stencil_op);
     return {};
 }
 
@@ -592,7 +589,7 @@ VkBlendOp BlendEquation(Maxwell::Blend::Equation equation) {
     case Maxwell::Blend::Equation::MaxGL:
         return VK_BLEND_OP_MAX;
     }
-    UNIMPLEMENTED_MSG("Unimplemented blend equation={}", static_cast<u32>(equation));
+    UNIMPLEMENTED_MSG("Unimplemented blend equation={}", equation);
     return {};
 }
 
@@ -656,7 +653,7 @@ VkBlendFactor BlendFactor(Maxwell::Blend::Factor factor) {
     case Maxwell::Blend::Factor::OneMinusConstantAlphaGL:
         return VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA;
     }
-    UNIMPLEMENTED_MSG("Unimplemented blend factor={}", static_cast<u32>(factor));
+    UNIMPLEMENTED_MSG("Unimplemented blend factor={}", factor);
     return {};
 }
 
@@ -667,7 +664,7 @@ VkFrontFace FrontFace(Maxwell::FrontFace front_face) {
     case Maxwell::FrontFace::CounterClockWise:
         return VK_FRONT_FACE_COUNTER_CLOCKWISE;
     }
-    UNIMPLEMENTED_MSG("Unimplemented front face={}", static_cast<u32>(front_face));
+    UNIMPLEMENTED_MSG("Unimplemented front face={}", front_face);
     return {};
 }
 
@@ -680,7 +677,7 @@ VkCullModeFlags CullFace(Maxwell::CullFace cull_face) {
     case Maxwell::CullFace::FrontAndBack:
         return VK_CULL_MODE_FRONT_AND_BACK;
     }
-    UNIMPLEMENTED_MSG("Unimplemented cull face={}", static_cast<u32>(cull_face));
+    UNIMPLEMENTED_MSG("Unimplemented cull face={}", cull_face);
     return {};
 }
 
@@ -700,7 +697,7 @@ VkComponentSwizzle SwizzleSource(Tegra::Texture::SwizzleSource swizzle) {
     case Tegra::Texture::SwizzleSource::OneFloat:
         return VK_COMPONENT_SWIZZLE_ONE;
     }
-    UNIMPLEMENTED_MSG("Unimplemented swizzle source={}", static_cast<u32>(swizzle));
+    UNIMPLEMENTED_MSG("Unimplemented swizzle source={}", swizzle);
     return {};
 }
 
@@ -723,7 +720,7 @@ VkViewportCoordinateSwizzleNV ViewportSwizzle(Maxwell::ViewportSwizzle swizzle) 
     case Maxwell::ViewportSwizzle::NegativeW:
         return VK_VIEWPORT_COORDINATE_SWIZZLE_NEGATIVE_W_NV;
     }
-    UNREACHABLE_MSG("Invalid swizzle={}", static_cast<int>(swizzle));
+    UNREACHABLE_MSG("Invalid swizzle={}", swizzle);
     return {};
 }
 

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -75,7 +75,7 @@ ShaderType GetShaderType(Maxwell::ShaderProgram program) {
     case Maxwell::ShaderProgram::Fragment:
         return ShaderType::Fragment;
     default:
-        UNIMPLEMENTED_MSG("program={}", static_cast<u32>(program));
+        UNIMPLEMENTED_MSG("program={}", program);
         return ShaderType::Vertex;
     }
 }

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
@@ -114,7 +114,7 @@ spv::Dim GetSamplerDim(const Sampler& sampler) {
     case Tegra::Shader::TextureType::TextureCube:
         return spv::Dim::Cube;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented sampler type={}", static_cast<int>(sampler.type));
+        UNIMPLEMENTED_MSG("Unimplemented sampler type={}", sampler.type);
         return spv::Dim::Dim2D;
     }
 }
@@ -134,7 +134,7 @@ std::pair<spv::Dim, bool> GetImageDim(const Image& image) {
     case Tegra::Shader::ImageType::Texture3D:
         return {spv::Dim::Dim3D, false};
     default:
-        UNIMPLEMENTED_MSG("Unimplemented image type={}", static_cast<int>(image.type));
+        UNIMPLEMENTED_MSG("Unimplemented image type={}", image.type);
         return {spv::Dim::Dim2D, false};
     }
 }
@@ -1254,7 +1254,7 @@ private:
                 const Id pointer = ArrayPass(type_descriptor.scalar, attribute_id, elements);
                 return {OpLoad(GetTypeDefinition(type), pointer), type};
             }
-            UNIMPLEMENTED_MSG("Unhandled input attribute: {}", static_cast<u32>(attribute));
+            UNIMPLEMENTED_MSG("Unhandled input attribute: {}", attribute);
             return {v_float_zero, Type::Float};
         }
 
@@ -1890,7 +1890,7 @@ private:
             case Tegra::Shader::TextureType::Texture3D:
                 return 3;
             default:
-                UNREACHABLE_MSG("Invalid texture type={}", static_cast<int>(type));
+                UNREACHABLE_MSG("Invalid texture type={}", type);
                 return 2;
             }
         }();

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -52,7 +52,7 @@ VkImageType SurfaceTargetToImage(SurfaceTarget target) {
         UNREACHABLE();
         return {};
     }
-    UNREACHABLE_MSG("Unknown texture target={}", static_cast<u32>(target));
+    UNREACHABLE_MSG("Unknown texture target={}", target);
     return {};
 }
 
@@ -64,7 +64,7 @@ VkImageAspectFlags PixelFormatToImageAspect(PixelFormat pixel_format) {
     } else if (pixel_format < PixelFormat::MaxDepthStencilFormat) {
         return VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
     } else {
-        UNREACHABLE_MSG("Invalid pixel format={}", static_cast<int>(pixel_format));
+        UNREACHABLE_MSG("Invalid pixel format={}", pixel_format);
         return VK_IMAGE_ASPECT_COLOR_BIT;
     }
 }

--- a/src/video_core/shader/decode/arithmetic.cpp
+++ b/src/video_core/shader/decode/arithmetic.cpp
@@ -110,8 +110,7 @@ u32 ShaderIR::DecodeArithmetic(NodeBlock& bb, u32 pc) {
             case SubOp::Sqrt:
                 return Operation(OperationCode::FSqrt, PRECISE, op_a);
             default:
-                UNIMPLEMENTED_MSG("Unhandled MUFU sub op={0:x}",
-                                  static_cast<unsigned>(instr.sub_op.Value()));
+                UNIMPLEMENTED_MSG("Unhandled MUFU sub op={0:x}", instr.sub_op.Value());
                 return Immediate(0);
             }
         }();

--- a/src/video_core/shader/decode/arithmetic_integer.cpp
+++ b/src/video_core/shader/decode/arithmetic_integer.cpp
@@ -83,7 +83,7 @@ u32 ShaderIR::DecodeArithmeticInteger(NodeBlock& bb, u32 pc) {
             case IAdd3Height::UpperHalfWord:
                 return BitfieldExtract(value, 16, 16);
             default:
-                UNIMPLEMENTED_MSG("Unhandled IADD3 height: {}", static_cast<u32>(height));
+                UNIMPLEMENTED_MSG("Unhandled IADD3 height: {}", height);
                 return Immediate(0);
             }
         };

--- a/src/video_core/shader/decode/arithmetic_integer_immediate.cpp
+++ b/src/video_core/shader/decode/arithmetic_integer_immediate.cpp
@@ -72,7 +72,7 @@ void ShaderIR::WriteLogicOperation(NodeBlock& bb, Register dest, LogicOperation 
         case LogicOperation::PassB:
             return op_b;
         default:
-            UNIMPLEMENTED_MSG("Unimplemented logic operation={}", static_cast<u32>(logic_op));
+            UNIMPLEMENTED_MSG("Unimplemented logic operation={}", logic_op);
             return Immediate(0);
         }
     }();
@@ -92,8 +92,7 @@ void ShaderIR::WriteLogicOperation(NodeBlock& bb, Register dest, LogicOperation 
         break;
     }
     default:
-        UNIMPLEMENTED_MSG("Unimplemented predicate result mode: {}",
-                          static_cast<u32>(predicate_mode));
+        UNIMPLEMENTED_MSG("Unimplemented predicate result mode: {}", predicate_mode);
     }
 }
 

--- a/src/video_core/shader/decode/conversion.cpp
+++ b/src/video_core/shader/decode/conversion.cpp
@@ -244,7 +244,7 @@ u32 ShaderIR::DecodeConversion(NodeBlock& bb, u32 pc) {
                 return Operation(OperationCode::FTrunc, value);
             default:
                 UNIMPLEMENTED_MSG("Unimplemented F2F rounding mode {}",
-                                  static_cast<u32>(instr.conversion.f2f.rounding.Value()));
+                                  instr.conversion.f2f.rounding.Value());
                 return value;
             }
         }();
@@ -300,7 +300,7 @@ u32 ShaderIR::DecodeConversion(NodeBlock& bb, u32 pc) {
                 return Operation(OperationCode::FTrunc, PRECISE, value);
             default:
                 UNIMPLEMENTED_MSG("Unimplemented F2I rounding mode {}",
-                                  static_cast<u32>(instr.conversion.f2i.rounding.Value()));
+                                  instr.conversion.f2i.rounding.Value());
                 return Immediate(0);
             }
         }();

--- a/src/video_core/shader/decode/memory.cpp
+++ b/src/video_core/shader/decode/memory.cpp
@@ -47,7 +47,7 @@ OperationCode GetAtomOperation(AtomicOp op) {
     case AtomicOp::Exch:
         return OperationCode::AtomicIExchange;
     default:
-        UNIMPLEMENTED_MSG("op={}", static_cast<int>(op));
+        UNIMPLEMENTED_MSG("op={}", op);
         return OperationCode::AtomicIAdd;
     }
 }
@@ -83,7 +83,7 @@ u32 GetMemorySize(Tegra::Shader::UniformType uniform_type) {
     case Tegra::Shader::UniformType::UnsignedQuad:
         return 128;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented size={}!", static_cast<u32>(uniform_type));
+        UNIMPLEMENTED_MSG("Unimplemented size={}!", uniform_type);
         return 32;
     }
 }
@@ -175,12 +175,12 @@ u32 ShaderIR::DecodeMemory(NodeBlock& bb, u32 pc) {
             break;
         }
         default:
-            UNIMPLEMENTED_MSG("Unhandled type: {}", static_cast<unsigned>(instr.ld_c.type.Value()));
+            UNIMPLEMENTED_MSG("Unhandled type: {}", instr.ld_c.type.Value());
         }
         break;
     }
     case OpCode::Id::LD_L:
-        LOG_DEBUG(HW_GPU, "LD_L cache management mode: {}", static_cast<u64>(instr.ld_l.unknown));
+        LOG_DEBUG(HW_GPU, "LD_L cache management mode: {}", instr.ld_l.unknown);
         [[fallthrough]];
     case OpCode::Id::LD_S: {
         const auto GetAddress = [&](s32 offset) {
@@ -224,7 +224,7 @@ u32 ShaderIR::DecodeMemory(NodeBlock& bb, u32 pc) {
         }
         default:
             UNIMPLEMENTED_MSG("{} Unhandled type: {}", opcode->get().GetName(),
-                              static_cast<u32>(instr.ldst_sl.type.Value()));
+                              instr.ldst_sl.type.Value());
         }
         break;
     }
@@ -306,8 +306,7 @@ u32 ShaderIR::DecodeMemory(NodeBlock& bb, u32 pc) {
         break;
     }
     case OpCode::Id::ST_L:
-        LOG_DEBUG(HW_GPU, "ST_L cache management mode: {}",
-                  static_cast<u64>(instr.st_l.cache_management.Value()));
+        LOG_DEBUG(HW_GPU, "ST_L cache management mode: {}", instr.st_l.cache_management.Value());
         [[fallthrough]];
     case OpCode::Id::ST_S: {
         const auto GetAddress = [&](s32 offset) {
@@ -340,7 +339,7 @@ u32 ShaderIR::DecodeMemory(NodeBlock& bb, u32 pc) {
         }
         default:
             UNIMPLEMENTED_MSG("{} unhandled type: {}", opcode->get().GetName(),
-                              static_cast<u32>(instr.ldst_sl.type.Value()));
+                              instr.ldst_sl.type.Value());
         }
         break;
     }
@@ -387,7 +386,7 @@ u32 ShaderIR::DecodeMemory(NodeBlock& bb, u32 pc) {
     }
     case OpCode::Id::RED: {
         UNIMPLEMENTED_IF_MSG(instr.red.type != GlobalAtomicType::U32, "type={}",
-                             static_cast<int>(instr.red.type.Value()));
+                             instr.red.type.Value());
         const auto [real_address, base_address, descriptor] =
             TrackGlobalMemory(bb, instr, true, true);
         if (!real_address || !base_address) {
@@ -403,12 +402,12 @@ u32 ShaderIR::DecodeMemory(NodeBlock& bb, u32 pc) {
         UNIMPLEMENTED_IF_MSG(instr.atom.operation == AtomicOp::Inc ||
                                  instr.atom.operation == AtomicOp::Dec ||
                                  instr.atom.operation == AtomicOp::SafeAdd,
-                             "operation={}", static_cast<int>(instr.atom.operation.Value()));
+                             "operation={}", instr.atom.operation.Value());
         UNIMPLEMENTED_IF_MSG(instr.atom.type == GlobalAtomicType::S64 ||
                                  instr.atom.type == GlobalAtomicType::U64 ||
                                  instr.atom.type == GlobalAtomicType::F16x2_FTZ_RN ||
                                  instr.atom.type == GlobalAtomicType::F32_FTZ_RN,
-                             "type={}", static_cast<int>(instr.atom.type.Value()));
+                             "type={}", instr.atom.type.Value());
 
         const auto [real_address, base_address, descriptor] =
             TrackGlobalMemory(bb, instr, true, true);
@@ -428,10 +427,10 @@ u32 ShaderIR::DecodeMemory(NodeBlock& bb, u32 pc) {
     case OpCode::Id::ATOMS: {
         UNIMPLEMENTED_IF_MSG(instr.atoms.operation == AtomicOp::Inc ||
                                  instr.atoms.operation == AtomicOp::Dec,
-                             "operation={}", static_cast<int>(instr.atoms.operation.Value()));
+                             "operation={}", instr.atoms.operation.Value());
         UNIMPLEMENTED_IF_MSG(instr.atoms.type == AtomicType::S64 ||
                                  instr.atoms.type == AtomicType::U64,
-                             "type={}", static_cast<int>(instr.atoms.type.Value()));
+                             "type={}", instr.atoms.type.Value());
         const bool is_signed =
             instr.atoms.type == AtomicType::S32 || instr.atoms.type == AtomicType::S64;
         const s32 offset = instr.atoms.GetImmediateOffset();

--- a/src/video_core/shader/decode/other.cpp
+++ b/src/video_core/shader/decode/other.cpp
@@ -34,14 +34,13 @@ u32 ShaderIR::DecodeOther(NodeBlock& bb, u32 pc) {
         break;
     }
     case OpCode::Id::EXIT: {
-        const Tegra::Shader::ConditionCode cc = instr.flow_condition_code;
-        UNIMPLEMENTED_IF_MSG(cc != Tegra::Shader::ConditionCode::T, "EXIT condition code used: {}",
-                             static_cast<u32>(cc));
+        const ConditionCode cc = instr.flow_condition_code;
+        UNIMPLEMENTED_IF_MSG(cc != ConditionCode::T, "EXIT condition code used: {}", cc);
 
         switch (instr.flow.cond) {
         case Tegra::Shader::FlowCondition::Always:
             bb.push_back(Operation(OperationCode::Exit));
-            if (instr.pred.pred_index == static_cast<u64>(Tegra::Shader::Pred::UnusedIndex)) {
+            if (instr.pred.pred_index == static_cast<u64>(Pred::UnusedIndex)) {
                 // If this is an unconditional exit then just end processing here,
                 // otherwise we have to account for the possibility of the condition
                 // not being met, so continue processing the next instruction.
@@ -56,17 +55,15 @@ u32 ShaderIR::DecodeOther(NodeBlock& bb, u32 pc) {
             break;
 
         default:
-            UNIMPLEMENTED_MSG("Unhandled flow condition: {}",
-                              static_cast<u32>(instr.flow.cond.Value()));
+            UNIMPLEMENTED_MSG("Unhandled flow condition: {}", instr.flow.cond.Value());
         }
         break;
     }
     case OpCode::Id::KIL: {
         UNIMPLEMENTED_IF(instr.flow.cond != Tegra::Shader::FlowCondition::Always);
 
-        const Tegra::Shader::ConditionCode cc = instr.flow_condition_code;
-        UNIMPLEMENTED_IF_MSG(cc != Tegra::Shader::ConditionCode::T, "KIL condition code used: {}",
-                             static_cast<u32>(cc));
+        const ConditionCode cc = instr.flow_condition_code;
+        UNIMPLEMENTED_IF_MSG(cc != ConditionCode::T, "KIL condition code used: {}", cc);
 
         bb.push_back(Operation(OperationCode::Discard));
         break;
@@ -130,8 +127,7 @@ u32 ShaderIR::DecodeOther(NodeBlock& bb, u32 pc) {
                     return Immediate(0u);
                 }
             default:
-                UNIMPLEMENTED_MSG("Unhandled system move: {}",
-                                  static_cast<u32>(instr.sys20.Value()));
+                UNIMPLEMENTED_MSG("Unhandled system move: {}", instr.sys20.Value());
                 return Immediate(0u);
             }
         }();
@@ -181,8 +177,8 @@ u32 ShaderIR::DecodeOther(NodeBlock& bb, u32 pc) {
         }
         const Node branch = Operation(OperationCode::BranchIndirect, operand);
 
-        const Tegra::Shader::ConditionCode cc = instr.flow_condition_code;
-        if (cc != Tegra::Shader::ConditionCode::T) {
+        const ConditionCode cc = instr.flow_condition_code;
+        if (cc != ConditionCode::T) {
             bb.push_back(Conditional(GetConditionCode(cc), {branch}));
         } else {
             bb.push_back(branch);
@@ -218,9 +214,8 @@ u32 ShaderIR::DecodeOther(NodeBlock& bb, u32 pc) {
         break;
     }
     case OpCode::Id::SYNC: {
-        const Tegra::Shader::ConditionCode cc = instr.flow_condition_code;
-        UNIMPLEMENTED_IF_MSG(cc != Tegra::Shader::ConditionCode::T, "SYNC condition code used: {}",
-                             static_cast<u32>(cc));
+        const ConditionCode cc = instr.flow_condition_code;
+        UNIMPLEMENTED_IF_MSG(cc != ConditionCode::T, "SYNC condition code used: {}", cc);
 
         if (decompiled) {
             break;
@@ -231,9 +226,8 @@ u32 ShaderIR::DecodeOther(NodeBlock& bb, u32 pc) {
         break;
     }
     case OpCode::Id::BRK: {
-        const Tegra::Shader::ConditionCode cc = instr.flow_condition_code;
-        UNIMPLEMENTED_IF_MSG(cc != Tegra::Shader::ConditionCode::T, "BRK condition code used: {}",
-                             static_cast<u32>(cc));
+        const ConditionCode cc = instr.flow_condition_code;
+        UNIMPLEMENTED_IF_MSG(cc != ConditionCode::T, "BRK condition code used: {}", cc);
         if (decompiled) {
             break;
         }
@@ -306,7 +300,7 @@ u32 ShaderIR::DecodeOther(NodeBlock& bb, u32 pc) {
             case Tegra::Shader::MembarType::GL:
                 return OperationCode::MemoryBarrierGlobal;
             default:
-                UNIMPLEMENTED_MSG("MEMBAR type={}", static_cast<int>(instr.membar.type.Value()));
+                UNIMPLEMENTED_MSG("MEMBAR type={}", instr.membar.type.Value());
                 return OperationCode::MemoryBarrierGlobal;
             }
         }();

--- a/src/video_core/shader/decode/shift.cpp
+++ b/src/video_core/shader/decode/shift.cpp
@@ -125,7 +125,7 @@ u32 ShaderIR::DecodeShift(NodeBlock& bb, u32 pc) {
     case OpCode::Id::SHF_LEFT_IMM: {
         UNIMPLEMENTED_IF(instr.generates_cc);
         UNIMPLEMENTED_IF_MSG(instr.shf.xmode != ShfXmode::None, "xmode={}",
-                             static_cast<int>(instr.shf.xmode.Value()));
+                             instr.shf.xmode.Value());
 
         if (instr.is_b_imm) {
             op_b = Immediate(static_cast<u32>(instr.shf.immediate));

--- a/src/video_core/shader/decode/texture.cpp
+++ b/src/video_core/shader/decode/texture.cpp
@@ -34,7 +34,7 @@ static std::size_t GetCoordCount(TextureType texture_type) {
     case TextureType::TextureCube:
         return 3;
     default:
-        UNIMPLEMENTED_MSG("Unhandled texture type: {}", static_cast<u32>(texture_type));
+        UNIMPLEMENTED_MSG("Unhandled texture type: {}", texture_type);
         return 0;
     }
 }
@@ -255,8 +255,7 @@ u32 ShaderIR::DecodeTexture(NodeBlock& bb, u32 pc) {
             break;
         }
         default:
-            UNIMPLEMENTED_MSG("Unhandled texture query type: {}",
-                              static_cast<u32>(instr.txq.query_type.Value()));
+            UNIMPLEMENTED_MSG("Unhandled texture query type: {}", instr.txq.query_type.Value());
         }
         break;
     }
@@ -302,7 +301,7 @@ u32 ShaderIR::DecodeTexture(NodeBlock& bb, u32 pc) {
             case TextureType::TextureCube:
                 return 3;
             default:
-                UNIMPLEMENTED_MSG("Unhandled texture type {}", static_cast<int>(texture_type));
+                UNIMPLEMENTED_MSG("Unhandled texture type {}", texture_type);
                 return 2;
             }
         }();
@@ -595,7 +594,7 @@ Node4 ShaderIR::GetTextureCode(Instruction instr, TextureType texture_type,
         lod = GetRegister(instr.gpr20.Value() + bias_offset);
         break;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented process mode={}", static_cast<u32>(process_mode));
+        UNIMPLEMENTED_MSG("Unimplemented process mode={}", process_mode);
         break;
     }
 

--- a/src/video_core/shader/decode/warp.cpp
+++ b/src/video_core/shader/decode/warp.cpp
@@ -27,7 +27,7 @@ OperationCode GetOperationCode(VoteOperation vote_op) {
     case VoteOperation::Eq:
         return OperationCode::VoteEqual;
     default:
-        UNREACHABLE_MSG("Invalid vote operation={}", static_cast<u64>(vote_op));
+        UNREACHABLE_MSG("Invalid vote operation={}", vote_op);
         return OperationCode::VoteAll;
     }
 }

--- a/src/video_core/shader/node_helper.cpp
+++ b/src/video_core/shader/node_helper.cpp
@@ -107,7 +107,7 @@ OperationCode SignedToUnsignedCode(OperationCode operation_code, bool is_signed)
         UNREACHABLE_MSG("Can't apply absolute to an unsigned integer");
         return {};
     default:
-        UNREACHABLE_MSG("Unknown signed operation with code={}", static_cast<u32>(operation_code));
+        UNREACHABLE_MSG("Unknown signed operation with code={}", operation_code);
         return {};
     }
 }

--- a/src/video_core/shader/shader_ir.cpp
+++ b/src/video_core/shader/shader_ir.cpp
@@ -171,7 +171,7 @@ Node ShaderIR::ConvertIntegerSize(Node value, Register::Size size, bool is_signe
         // Default - do nothing
         return value;
     default:
-        UNREACHABLE_MSG("Unimplemented conversion size: {}", static_cast<u32>(size));
+        UNREACHABLE_MSG("Unimplemented conversion size: {}", size);
         return value;
     }
 }
@@ -336,15 +336,15 @@ OperationCode ShaderIR::GetPredicateCombiner(PredOperation operation) {
     return operation_table[index];
 }
 
-Node ShaderIR::GetConditionCode(Tegra::Shader::ConditionCode cc) const {
+Node ShaderIR::GetConditionCode(ConditionCode cc) const {
     switch (cc) {
-    case Tegra::Shader::ConditionCode::NEU:
+    case ConditionCode::NEU:
         return GetInternalFlag(InternalFlag::Zero, true);
-    case Tegra::Shader::ConditionCode::FCSM_TR:
+    case ConditionCode::FCSM_TR:
         UNIMPLEMENTED_MSG("EXIT.FCSM_TR is not implemented");
         return MakeNode<PredicateNode>(Pred::NeverExecute, false);
     default:
-        UNIMPLEMENTED_MSG("Unimplemented condition code: {}", static_cast<u32>(cc));
+        UNIMPLEMENTED_MSG("Unimplemented condition code: {}", cc);
         return MakeNode<PredicateNode>(Pred::NeverExecute, false);
     }
 }

--- a/src/video_core/surface.cpp
+++ b/src/video_core/surface.cpp
@@ -28,7 +28,7 @@ SurfaceTarget SurfaceTargetFromTextureType(Tegra::Texture::TextureType texture_t
     case Tegra::Texture::TextureType::Texture2DArray:
         return SurfaceTarget::Texture2DArray;
     default:
-        LOG_CRITICAL(HW_GPU, "Unimplemented texture_type={}", static_cast<u32>(texture_type));
+        LOG_CRITICAL(HW_GPU, "Unimplemented texture_type={}", texture_type);
         UNREACHABLE();
         return SurfaceTarget::Texture2D;
     }
@@ -47,7 +47,7 @@ bool SurfaceTargetIsLayered(SurfaceTarget target) {
     case SurfaceTarget::TextureCubeArray:
         return true;
     default:
-        LOG_CRITICAL(HW_GPU, "Unimplemented surface_target={}", static_cast<u32>(target));
+        LOG_CRITICAL(HW_GPU, "Unimplemented surface_target={}", target);
         UNREACHABLE();
         return false;
     }
@@ -66,7 +66,7 @@ bool SurfaceTargetIsArray(SurfaceTarget target) {
     case SurfaceTarget::TextureCubeArray:
         return true;
     default:
-        LOG_CRITICAL(HW_GPU, "Unimplemented surface_target={}", static_cast<u32>(target));
+        LOG_CRITICAL(HW_GPU, "Unimplemented surface_target={}", target);
         UNREACHABLE();
         return false;
     }
@@ -85,7 +85,7 @@ PixelFormat PixelFormatFromDepthFormat(Tegra::DepthFormat format) {
     case Tegra::DepthFormat::D32_FLOAT_S8X24_UINT:
         return PixelFormat::D32_FLOAT_S8_UINT;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented format={}", static_cast<u32>(format));
+        UNIMPLEMENTED_MSG("Unimplemented format={}", format);
         return PixelFormat::S8_UINT_D24_UNORM;
     }
 }
@@ -183,7 +183,7 @@ PixelFormat PixelFormatFromRenderTargetFormat(Tegra::RenderTargetFormat format) 
     case Tegra::RenderTargetFormat::R8_UINT:
         return PixelFormat::R8_UINT;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented format={}", static_cast<int>(format));
+        UNIMPLEMENTED_MSG("Unimplemented format={}", format);
         return PixelFormat::A8B8G8R8_UNORM;
     }
 }
@@ -197,7 +197,7 @@ PixelFormat PixelFormatFromGPUPixelFormat(Tegra::FramebufferConfig::PixelFormat 
     case Tegra::FramebufferConfig::PixelFormat::B8G8R8A8_UNORM:
         return PixelFormat::B8G8R8A8_UNORM;
     default:
-        UNIMPLEMENTED_MSG("Unimplemented format={}", static_cast<u32>(format));
+        UNIMPLEMENTED_MSG("Unimplemented format={}", format);
         return PixelFormat::A8B8G8R8_UNORM;
     }
 }

--- a/src/video_core/texture_cache/surface_params.cpp
+++ b/src/video_core/texture_cache/surface_params.cpp
@@ -398,9 +398,9 @@ std::string SurfaceParams::TargetName() const {
     case SurfaceTarget::TextureCubeArray:
         return "CubeArray";
     default:
-        LOG_CRITICAL(HW_GPU, "Unimplemented surface_target={}", static_cast<u32>(target));
+        LOG_CRITICAL(HW_GPU, "Unimplemented surface_target={}", target);
         UNREACHABLE();
-        return fmt::format("TUK({})", static_cast<u32>(target));
+        return fmt::format("TUK({})", target);
     }
 }
 

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -1191,9 +1191,8 @@ private:
         const SurfaceParams& src_params = src->GetSurfaceParams();
         const SurfaceParams& dst_params = dst->GetSurfaceParams();
         if (!format_compatibility.TestCopy(src_params.pixel_format, dst_params.pixel_format)) {
-            LOG_ERROR(HW_GPU, "Illegal copy between formats={{{}, {}}}",
-                      static_cast<int>(dst_params.pixel_format),
-                      static_cast<int>(src_params.pixel_format));
+            LOG_ERROR(HW_GPU, "Illegal copy between formats={{{}, {}}}", dst_params.pixel_format,
+                      src_params.pixel_format);
             return;
         }
         ImageCopy(src, dst, copy);

--- a/src/video_core/textures/convert.cpp
+++ b/src/video_core/textures/convert.cpp
@@ -82,7 +82,7 @@ void ConvertFromHostToGuest(u8* data, PixelFormat pixel_format, u32 width, u32 h
                             bool convert_astc, bool convert_s8z24) {
     if (convert_astc && IsPixelFormatASTC(pixel_format)) {
         LOG_CRITICAL(HW_GPU, "Conversion of format {} after texture flushing is not implemented",
-                     static_cast<u32>(pixel_format));
+                     pixel_format);
         UNREACHABLE();
 
     } else if (convert_s8z24 && pixel_format == PixelFormat::S8_UINT_D24_UNORM) {


### PR DESCRIPTION
fmt now automatically prints the numeric value of an enum class member by default, so we don't need to use casts any more.

Reduces the line noise in our code a bit.