### PR TITLE
buffer_block: Remove unnecessary includes

### DIFF
--- a/src/video_core/buffer_cache/buffer_block.h
+++ b/src/video_core/buffer_cache/buffer_block.h
@@ -10,23 +10,23 @@ namespace VideoCommon {
 
 class BufferBlock {
 public:
-    bool Overlaps(VAddr start, VAddr end) const {
+    [[nodiscard]] bool Overlaps(VAddr start, VAddr end) const {
         return (cpu_addr < end) && (cpu_addr_end > start);
     }
 
-    bool IsInside(VAddr other_start, VAddr other_end) const {
+    [[nodiscard]] bool IsInside(VAddr other_start, VAddr other_end) const {
         return cpu_addr <= other_start && other_end <= cpu_addr_end;
     }
 
-    std::size_t Offset(VAddr in_addr) const {
+    [[nodiscard]] std::size_t Offset(VAddr in_addr) const {
         return static_cast<std::size_t>(in_addr - cpu_addr);
     }
 
-    VAddr CpuAddr() const {
+    [[nodiscard]] VAddr CpuAddr() const {
         return cpu_addr;
     }
 
-    VAddr CpuAddrEnd() const {
+    [[nodiscard]] VAddr CpuAddrEnd() const {
         return cpu_addr_end;
     }
 
@@ -35,11 +35,11 @@ public:
         cpu_addr_end = new_addr + size;
     }
 
-    std::size_t Size() const {
+    [[nodiscard]] std::size_t Size() const {
         return size;
     }
 
-    u64 Epoch() const {
+    [[nodiscard]] u64 Epoch() const {
         return epoch;
     }
 

--- a/src/video_core/buffer_cache/buffer_block.h
+++ b/src/video_core/buffer_cache/buffer_block.h
@@ -4,12 +4,7 @@
 
 #pragma once
 
-#include <unordered_set>
-#include <utility>
-
-#include "common/alignment.h"
 #include "common/common_types.h"
-#include "video_core/gpu.h"
 
 namespace VideoCommon {
 


### PR DESCRIPTION
Reduces the amount of dependencies the header pulls in. While we're at it, we can mark the interface as nodiscard where applicable.