### PR TITLE
video_core: Make use of ordered container contains() where applicable

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -545,7 +545,7 @@ private:
     bool IsRegionWritten(VAddr start, VAddr end) const {
         const u64 page_end = end >> WRITE_PAGE_BIT;
         for (u64 page_start = start >> WRITE_PAGE_BIT; page_start <= page_end; ++page_start) {
-            if (written_pages.count(page_start) > 0) {
+            if (written_pages.contains(page_start)) {
                 return true;
             }
         }

--- a/src/video_core/renderer_opengl/gl_arb_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_arb_decompiler.cpp
@@ -1485,9 +1485,7 @@ void ARBDecompiler::Exit() {
     }
 
     const auto safe_get_register = [this](u32 reg) -> std::string {
-        // TODO(Rodrigo): Replace with contains once C++20 releases
-        const auto& used_registers = ir.GetRegisters();
-        if (used_registers.find(reg) != used_registers.end()) {
+        if (ir.GetRegisters().contains(reg)) {
             return fmt::format("R{}.x", reg);
         }
         return "{0, 0, 0, 0}.x";

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -459,7 +459,7 @@ void ShaderCacheOpenGL::LoadDiskCache(u64 title_id, const std::atomic_bool& stop
 ProgramSharedPtr ShaderCacheOpenGL::GeneratePrecompiledProgram(
     const ShaderDiskCacheEntry& entry, const ShaderDiskCachePrecompiled& precompiled_entry,
     const std::unordered_set<GLenum>& supported_formats) {
-    if (supported_formats.find(precompiled_entry.binary_format) == supported_formats.end()) {
+    if (!supported_formats.contains(precompiled_entry.binary_format)) {
         LOG_INFO(Render_OpenGL, "Precompiled cache entry with unsupported format, removing");
         return {};
     }

--- a/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_disk_cache.cpp
@@ -343,7 +343,7 @@ void ShaderDiskCacheOpenGL::SaveEntry(const ShaderDiskCacheEntry& entry) {
     }
 
     const u64 id = entry.unique_identifier;
-    if (stored_transferable.find(id) != stored_transferable.end()) {
+    if (stored_transferable.contains(id)) {
         // The shader already exists
         return;
     }

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -230,7 +230,7 @@ vk::Pipeline VKGraphicsPipeline::CreatePipeline(const RenderPassParams& renderpa
         if (!attribute.enabled) {
             continue;
         }
-        if (input_attributes.find(static_cast<u32>(index)) == input_attributes.end()) {
+        if (!input_attributes.contains(static_cast<u32>(index))) {
             // Skip attributes not used by the vertex shaders.
             continue;
         }

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
@@ -2125,8 +2125,7 @@ private:
             OpStore(z_pointer, depth);
         }
         if (stage == ShaderType::Fragment) {
-            const auto SafeGetRegister = [&](u32 reg) {
-                // TODO(Rodrigo): Replace with contains once C++20 releases
+            const auto SafeGetRegister = [this](u32 reg) {
                 if (const auto it = registers.find(reg); it != registers.end()) {
                     return OpLoad(t_float, it->second);
                 }

--- a/src/video_core/shader/control_flow.cpp
+++ b/src/video_core/shader/control_flow.cpp
@@ -257,7 +257,7 @@ std::pair<ParseResult, ParseInfo> ParseCode(CFGRebuildState& state, u32 address)
             single_branch.ignore = false;
             break;
         }
-        if (state.registered.count(offset) != 0) {
+        if (state.registered.contains(offset)) {
             single_branch.address = offset;
             single_branch.ignore = true;
             break;
@@ -632,12 +632,12 @@ void DecompileShader(CFGRebuildState& state) {
     for (auto label : state.labels) {
         state.manager->DeclareLabel(label);
     }
-    for (auto& block : state.block_info) {
-        if (state.labels.count(block.start) != 0) {
+    for (const auto& block : state.block_info) {
+        if (state.labels.contains(block.start)) {
             state.manager->InsertLabel(block.start);
         }
         const bool ignore = BlockBranchIsIgnored(block.branch);
-        u32 end = ignore ? block.end + 1 : block.end;
+        const u32 end = ignore ? block.end + 1 : block.end;
         state.manager->InsertBlock(block.start, end);
         if (!ignore) {
             InsertBranch(*state.manager, block.branch);
@@ -737,7 +737,7 @@ std::unique_ptr<ShaderCharacteristics> ScanFlow(const ProgramCode& program_code,
     auto back = result_out->blocks.begin();
     auto next = std::next(back);
     while (next != result_out->blocks.end()) {
-        if (state.labels.count(next->start) == 0 && next->start == back->end + 1) {
+        if (!state.labels.contains(next->start) && next->start == back->end + 1) {
             back->end = next->end;
             next = result_out->blocks.erase(next);
             continue;

--- a/src/video_core/shader/decode.cpp
+++ b/src/video_core/shader/decode.cpp
@@ -153,8 +153,8 @@ void ShaderIR::Decode() {
         const auto& blocks = shader_info.blocks;
         NodeBlock current_block;
         u32 current_label = static_cast<u32>(exit_branch);
-        for (auto& block : blocks) {
-            if (shader_info.labels.count(block.start) != 0) {
+        for (const auto& block : blocks) {
+            if (shader_info.labels.contains(block.start)) {
                 insert_block(current_block, current_label);
                 current_block.clear();
                 current_label = block.start;


### PR DESCRIPTION
With C++20, we can use the more concise `contains()` member function instead of comparing the result of the `find()` call with the end iterator.