### PR TITLE
aoc_u: Stub IPurchaseEventManager and its service commands

### DIFF
--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -54,8 +54,8 @@ public:
         : ServiceFramework{system_, "IPurchaseEventManager"} {
         // clang-format off
         static const FunctionInfo functions[] = {
-            {0, nullptr, "SetDefaultDeliveryTarget"},
-            {1, nullptr, "SetDeliveryTarget"},
+            {0, &IPurchaseEventManager::SetDefaultDeliveryTarget, "SetDefaultDeliveryTarget"},
+            {1, &IPurchaseEventManager::SetDeliveryTarget, "SetDeliveryTarget"},
             {2, nullptr, "GetPurchasedEventReadableHandle"},
             {3, nullptr, "PopPurchasedProductInfo"},
             {4, nullptr, "PopPurchasedProductInfoWithUid"},
@@ -63,6 +63,31 @@ public:
         // clang-format on
 
         RegisterHandlers(functions);
+    }
+
+private:
+    void SetDefaultDeliveryTarget(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+
+        const auto unknown_1 = rp.Pop<u64>();
+        [[maybe_unused]] const auto unknown_2 = ctx.ReadBuffer();
+
+        LOG_WARNING(Service_AOC, "(STUBBED) called, unknown_1={}", unknown_1);
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+    }
+
+    void SetDeliveryTarget(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+
+        const auto unknown_1 = rp.Pop<u64>();
+        [[maybe_unused]] const auto unknown_2 = ctx.ReadBuffer();
+
+        LOG_WARNING(Service_AOC, "(STUBBED) called, unknown_1={}", unknown_1);
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
     }
 };
 

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -48,6 +48,24 @@ static std::vector<u64> AccumulateAOCTitleIDs(Core::System& system) {
     return add_on_content;
 }
 
+class IPurchaseEventManager final : public ServiceFramework<IPurchaseEventManager> {
+public:
+    explicit IPurchaseEventManager(Core::System& system_)
+        : ServiceFramework{system_, "IPurchaseEventManager"} {
+        // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "SetDefaultDeliveryTarget"},
+            {1, nullptr, "SetDeliveryTarget"},
+            {2, nullptr, "GetPurchasedEventReadableHandle"},
+            {3, nullptr, "PopPurchasedProductInfo"},
+            {4, nullptr, "PopPurchasedProductInfoWithUid"},
+        };
+        // clang-format on
+
+        RegisterHandlers(functions);
+    }
+};
+
 AOC_U::AOC_U(Core::System& system_)
     : ServiceFramework{system_, "aoc:u"}, add_on_content{AccumulateAOCTitleIDs(system)} {
     // clang-format off
@@ -62,8 +80,8 @@ AOC_U::AOC_U(Core::System& system_)
         {7, &AOC_U::PrepareAddOnContent, "PrepareAddOnContent"},
         {8, &AOC_U::GetAddOnContentListChangedEvent, "GetAddOnContentListChangedEvent"},
         {9, nullptr, "GetAddOnContentLostErrorCode"},
-        {100, nullptr, "CreateEcPurchasedEventManager"},
-        {101, nullptr, "CreatePermanentEcPurchasedEventManager"},
+        {100, &AOC_U::CreateEcPurchasedEventManager, "CreateEcPurchasedEventManager"},
+        {101, &AOC_U::CreatePermanentEcPurchasedEventManager, "CreatePermanentEcPurchasedEventManager"},
     };
     // clang-format on
 
@@ -199,6 +217,22 @@ void AOC_U::GetAddOnContentListChangedEvent(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 2, 1};
     rb.Push(RESULT_SUCCESS);
     rb.PushCopyObjects(aoc_change_event.readable);
+}
+
+void AOC_U::CreateEcPurchasedEventManager(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service_AOC, "(STUBBED) called");
+
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    rb.Push(RESULT_SUCCESS);
+    rb.PushIpcInterface<IPurchaseEventManager>(system);
+}
+
+void AOC_U::CreatePermanentEcPurchasedEventManager(Kernel::HLERequestContext& ctx) {
+    LOG_WARNING(Service_AOC, "(STUBBED) called");
+
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1};
+    rb.Push(RESULT_SUCCESS);
+    rb.PushIpcInterface<IPurchaseEventManager>(system);
 }
 
 void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system) {

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -56,13 +56,16 @@ public:
         static const FunctionInfo functions[] = {
             {0, &IPurchaseEventManager::SetDefaultDeliveryTarget, "SetDefaultDeliveryTarget"},
             {1, &IPurchaseEventManager::SetDeliveryTarget, "SetDeliveryTarget"},
-            {2, nullptr, "GetPurchasedEventReadableHandle"},
+            {2, &IPurchaseEventManager::GetPurchasedEventReadableHandle, "GetPurchasedEventReadableHandle"},
             {3, nullptr, "PopPurchasedProductInfo"},
             {4, nullptr, "PopPurchasedProductInfoWithUid"},
         };
         // clang-format on
 
         RegisterHandlers(functions);
+
+        purchased_event = Kernel::WritableEvent::CreateEventPair(
+            system.Kernel(), "IPurchaseEventManager:PurchasedEvent");
     }
 
 private:
@@ -89,6 +92,16 @@ private:
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
     }
+
+    void GetPurchasedEventReadableHandle(Kernel::HLERequestContext& ctx) {
+        LOG_WARNING(Service_AOC, "called");
+
+        IPC::ResponseBuilder rb{ctx, 2, 1};
+        rb.Push(RESULT_SUCCESS);
+        rb.PushCopyObjects(purchased_event.readable);
+    }
+
+    Kernel::EventPair purchased_event;
 };
 
 AOC_U::AOC_U(Core::System& system_)

--- a/src/core/hle/service/aoc/aoc_u.h
+++ b/src/core/hle/service/aoc/aoc_u.h
@@ -27,6 +27,8 @@ private:
     void GetAddOnContentBaseId(Kernel::HLERequestContext& ctx);
     void PrepareAddOnContent(Kernel::HLERequestContext& ctx);
     void GetAddOnContentListChangedEvent(Kernel::HLERequestContext& ctx);
+    void CreateEcPurchasedEventManager(Kernel::HLERequestContext& ctx);
+    void CreatePermanentEcPurchasedEventManager(Kernel::HLERequestContext& ctx);
 
     std::vector<u64> add_on_content;
     Kernel::EventPair aoc_change_event;


### PR DESCRIPTION
Stubs the following commands:

**aoc:u**
CreateEcPurchasedEventManager
CreatePermanentEcPurchasedEventManager

**IPurchaseEventManager**
SetDefaultDeliveryTarget
SetDeliveryTarget

Implements
**IPurchaseEventManager**
GetPurchasedEventReadableHandle

- Used by Pokémon Café Mix
- Used by DOOM: Eternal