### PR TITLE
common/file_util: Make use of std::filesystem

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <array>
+#include <filesystem>
 #include <limits>
 #include <memory>
 #include <sstream>
@@ -75,62 +76,16 @@
 // The code still needs a ton of cleanup.
 // REMEMBER: strdup considered harmful!
 namespace Common::FS {
+namespace fs = std::filesystem;
 
-// Remove any ending forward slashes from directory paths
-// Modifies argument.
-static void StripTailDirSlashes(std::string& fname) {
-    if (fname.length() <= 1) {
-        return;
-    }
-
-    std::size_t i = fname.length();
-    while (i > 0 && fname[i - 1] == DIR_SEP_CHR) {
-        --i;
-    }
-    fname.resize(i);
+bool Exists(const fs::path& path) {
+    std::error_code ec;
+    return fs::exists(path, ec);
 }
 
-bool Exists(const std::string& filename) {
-    struct stat file_info;
-
-    std::string copy(filename);
-    StripTailDirSlashes(copy);
-
-#ifdef _WIN32
-    // Windows needs a slash to identify a driver root
-    if (copy.size() != 0 && copy.back() == ':')
-        copy += DIR_SEP_CHR;
-
-    int result = _wstat64(Common::UTF8ToUTF16W(copy).c_str(), &file_info);
-#else
-    int result = stat(copy.c_str(), &file_info);
-#endif
-
-    return (result == 0);
-}
-
-bool IsDirectory(const std::string& filename) {
-    struct stat file_info;
-
-    std::string copy(filename);
-    StripTailDirSlashes(copy);
-
-#ifdef _WIN32
-    // Windows needs a slash to identify a driver root
-    if (copy.size() != 0 && copy.back() == ':')
-        copy += DIR_SEP_CHR;
-
-    int result = _wstat64(Common::UTF8ToUTF16W(copy).c_str(), &file_info);
-#else
-    int result = stat(copy.c_str(), &file_info);
-#endif
-
-    if (result < 0) {
-        LOG_DEBUG(Common_Filesystem, "stat failed on {}: {}", filename, GetLastErrorMsg());
-        return false;
-    }
-
-    return S_ISDIR(file_info.st_mode);
+bool IsDirectory(const fs::path& path) {
+    std::error_code ec;
+    return fs::is_directory(path, ec);
 }
 
 bool Delete(const std::string& filename) {

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -39,48 +39,34 @@ enum class UserPath {
     UserDir,
 };
 
-// FileSystem tree node/
-struct FSTEntry {
-    bool isDirectory;
-    u64 size;                 // file length or number of entries from children
-    std::string physicalName; // name on disk
-    std::string virtualName;  // name in FST names table
-    std::vector<FSTEntry> children;
-};
-
-// Returns true if the exists
+// Returns true if the path exists
 [[nodiscard]] bool Exists(const std::filesystem::path& path);
 
 // Returns true if path is a directory
 [[nodiscard]] bool IsDirectory(const std::filesystem::path& path);
 
 // Returns the size of filename (64bit)
-[[nodiscard]] u64 GetSize(const std::string& filename);
-
-// Overloaded GetSize, accepts file descriptor
-[[nodiscard]] u64 GetSize(int fd);
+[[nodiscard]] u64 GetSize(const std::filesystem::path& path);
 
 // Overloaded GetSize, accepts FILE*
 [[nodiscard]] u64 GetSize(FILE* f);
 
 // Returns true if successful, or path already exists.
-bool CreateDir(const std::string& filename);
+bool CreateDir(const std::filesystem::path& path);
 
-// Creates the full path of fullPath returns true on success
-bool CreateFullPath(const std::string& fullPath);
+// Creates the full path of path. Returns true on success
+bool CreateFullPath(const std::filesystem::path& path);
 
-// Deletes a given filename, return true on success
-// Doesn't supports deleting a directory
-bool Delete(const std::string& filename);
+// Deletes a given file at the path.
+// This will also delete empty directories.
+// Return true on success
+bool Delete(const std::filesystem::path& path);
 
-// Deletes a directory filename, returns true on success
-bool DeleteDir(const std::string& filename);
+// Renames file src to dst, returns true on success
+bool Rename(const std::filesystem::path& src, const std::filesystem::path& dst);
 
-// renames file srcFilename to destFilename, returns true on success
-bool Rename(const std::string& srcFilename, const std::string& destFilename);
-
-// copies file srcFilename to destFilename, returns true on success
-bool Copy(const std::string& srcFilename, const std::string& destFilename);
+// copies file src to dst, returns true on success
+bool Copy(const std::filesystem::path& src, const std::filesystem::path& dst);
 
 // creates an empty file filename, returns true on success
 bool CreateEmptyFile(const std::string& filename);
@@ -107,27 +93,17 @@ using DirectoryEntryCallable = std::function<bool(
 bool ForeachDirectoryEntry(u64* num_entries_out, const std::string& directory,
                            DirectoryEntryCallable callback);
 
-/**
- * Scans the directory tree, storing the results.
- * @param directory the parent directory to start scanning from
- * @param parent_entry FSTEntry where the filesystem tree results will be stored.
- * @param recursion Number of children directories to read before giving up.
- * @return the total number of files/directories found
- */
-u64 ScanDirectoryTree(const std::string& directory, FSTEntry& parent_entry,
-                      unsigned int recursion = 0);
-
-// deletes the given directory and anything under it. Returns true on success.
-bool DeleteDirRecursively(const std::string& directory, unsigned int recursion = 256);
+// Deletes the given path and anything under it. Returns true on success.
+bool DeleteDirRecursively(const std::filesystem::path& path);
 
 // Returns the current directory
-[[nodiscard]] std::optional<std::string> GetCurrentDir();
+[[nodiscard]] std::optional<std::filesystem::path> GetCurrentDir();
 
 // Create directory and copy contents (does not overwrite existing files)
-void CopyDir(const std::string& source_path, const std::string& dest_path);
+void CopyDir(const std::filesystem::path& src, const std::filesystem::path& dst);
 
-// Set the current directory to given directory
-bool SetCurrentDir(const std::string& directory);
+// Set the current directory to given path
+bool SetCurrentDir(const std::filesystem::path& path);
 
 // Returns a pointer to a string with a yuzu data dir in the user's home
 // directory. To be used in "multi-user" mode (that is, installed).

--- a/src/common/file_util.h
+++ b/src/common/file_util.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <cstdio>
+#include <filesystem>
 #include <fstream>
 #include <functional>
 #include <limits>
@@ -47,11 +48,11 @@ struct FSTEntry {
     std::vector<FSTEntry> children;
 };
 
-// Returns true if file filename exists
-[[nodiscard]] bool Exists(const std::string& filename);
+// Returns true if the exists
+[[nodiscard]] bool Exists(const std::filesystem::path& path);
 
-// Returns true if filename is a directory
-[[nodiscard]] bool IsDirectory(const std::string& filename);
+// Returns true if path is a directory
+[[nodiscard]] bool IsDirectory(const std::filesystem::path& path);
 
 // Returns the size of filename (64bit)
 [[nodiscard]] u64 GetSize(const std::string& filename);


### PR DESCRIPTION
Migrates a bunch of our file handling code over to std::filesystem to simplify a bunch of our code and make it easier to maintain.

Notably with this, `CopyDir` will now function on Windows.