### PR TITLE
 Add option to reset window size to 1080p

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -939,7 +939,10 @@ void GMainWindow::ConnectMenuEvents() {
             &GMainWindow::OnDisplayTitleBars);
     connect(ui.action_Show_Filter_Bar, &QAction::triggered, this, &GMainWindow::OnToggleFilterBar);
     connect(ui.action_Show_Status_Bar, &QAction::triggered, statusBar(), &QStatusBar::setVisible);
-    connect(ui.action_Reset_Window_Size, &QAction::triggered, this, &GMainWindow::ResetWindowSize);
+    connect(ui.action_Reset_Window_Size_720, &QAction::triggered, this,
+            &GMainWindow::ResetWindowSize720);
+    connect(ui.action_Reset_Window_Size_1080, &QAction::triggered, this,
+            &GMainWindow::ResetWindowSize1080);
 
     // Fullscreen
     connect(ui.action_Fullscreen, &QAction::triggered, this, &GMainWindow::ToggleFullscreen);
@@ -2258,7 +2261,7 @@ void GMainWindow::ToggleWindowMode() {
     }
 }
 
-void GMainWindow::ResetWindowSize() {
+void GMainWindow::ResetWindowSize720() {
     const auto aspect_ratio = Layout::EmulationAspectRatio(
         static_cast<Layout::AspectRatio>(Settings::values.aspect_ratio.GetValue()),
         static_cast<float>(Layout::ScreenUndocked::Height) / Layout::ScreenUndocked::Width);
@@ -2268,6 +2271,20 @@ void GMainWindow::ResetWindowSize() {
     } else {
         resize(Layout::ScreenUndocked::Height / aspect_ratio,
                Layout::ScreenUndocked::Height + menuBar()->height() +
+                   (ui.action_Show_Status_Bar->isChecked() ? statusBar()->height() : 0));
+    }
+}
+
+void GMainWindow::ResetWindowSize1080() {
+    const auto aspect_ratio = Layout::EmulationAspectRatio(
+        static_cast<Layout::AspectRatio>(Settings::values.aspect_ratio.GetValue()),
+        static_cast<float>(Layout::ScreenDocked::Height) / Layout::ScreenDocked::Width);
+    if (!ui.action_Single_Window_Mode->isChecked()) {
+        render_window->resize(Layout::ScreenDocked::Height / aspect_ratio,
+                              Layout::ScreenDocked::Height);
+    } else {
+        resize(Layout::ScreenDocked::Height / aspect_ratio,
+               Layout::ScreenDocked::Height + menuBar()->height() +
                    (ui.action_Show_Status_Bar->isChecked() ? statusBar()->height() : 0));
     }
 }

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -242,7 +242,8 @@ private slots:
     void ShowFullscreen();
     void HideFullscreen();
     void ToggleWindowMode();
-    void ResetWindowSize();
+    void ResetWindowSize720();
+    void ResetWindowSize1080();
     void OnCaptureScreenshot();
     void OnCoreError(Core::System::ResultStatus, std::string);
     void OnReinitializeKeys(ReinitializeKeyBehavior behavior);

--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -97,7 +97,8 @@
     <addaction name="action_Display_Dock_Widget_Headers"/>
     <addaction name="action_Show_Filter_Bar"/>
     <addaction name="action_Show_Status_Bar"/>
-    <addaction name="action_Reset_Window_Size"/>
+    <addaction name="action_Reset_Window_Size_720"/>
+    <addaction name="action_Reset_Window_Size_1080"/>
     <addaction name="separator"/>
     <addaction name="menu_View_Debugging"/>
    </widget>
@@ -220,9 +221,14 @@
     <string>Show Status Bar</string>
    </property>
   </action>
-  <action name="action_Reset_Window_Size">
+  <action name="action_Reset_Window_Size_720">
    <property name="text">
-    <string>Reset Window Size</string>
+    <string>Reset Window Size to 720p</string>
+   </property>
+  </action>
+  <action name="action_Reset_Window_Size_1080">
+   <property name="text">
+    <string>Reset Window Size to 1080p</string>
    </property>
   </action>
   <action name="action_Fullscreen">


### PR DESCRIPTION
Allows to resize between 720p and 1080p depending if undocked or docked mode is selected.

Fixes #5175 