### PR TITLE
travis/linux: Use correct ccache directory

### DIFF
--- a/.travis/linux/build.sh
+++ b/.travis/linux/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash -ex
 
 mkdir -p "$HOME/.ccache"
-docker run -e ENABLE_COMPATIBILITY_REPORTING --env-file .travis/common/travis-ci.env -v $(pwd):/yuzu -v "$HOME/.ccache":/root/.ccache yuzuemu/build-environments:linux-fresh /bin/bash /yuzu/.travis/linux/docker.sh
+docker run -e ENABLE_COMPATIBILITY_REPORTING --env-file .travis/common/travis-ci.env -v $(pwd):/yuzu -v "$HOME/.ccache":/home/yuzu/.ccache yuzuemu/build-environments:linux-fresh /bin/bash /yuzu/.travis/linux/docker.sh


### PR DESCRIPTION
Changes the bound ccache directory to `/home/yuzu/.ccache` instead of `/root/.ccache`, since the `/root` directory is not accessible by the `yuzu` user in the guest container and is not the default ccache directory for this user.