### PR TITLE
Revert "Merge pull request #5179 from ReinUsesLisp/fs-path"

### DIFF
--- a/src/common/file_util.cpp
+++ b/src/common/file_util.cpp
@@ -233,7 +233,7 @@ bool ForeachDirectoryEntry(u64* num_entries_out, const std::string& directory,
     }
     // windows loop
     do {
-        const std::string virtual_name = std::filesystem::path(ffd.cFileName).string();
+        const std::string virtual_name(Common::UTF16ToUTF8(ffd.cFileName));
 #else
     DIR* dirp = opendir(directory.c_str());
     if (!dirp)


### PR DESCRIPTION
This commit initially aimed to fix a bug where dumps containing utf-16 chars in their path could not have their file size read.

The commit resulted in errors and crashes later in execution due to the vfs' inability to properly interface with `std::filesystem`. Reverting such that a proper fix can be made.