### PR TITLE
controllers/npad: Validate device handles before use

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -56,12 +56,14 @@ public:
         JoyconLeft = 6,
         JoyconRight = 7,
         Pokeball = 9,
+        MaxNpadType = 10,
     };
 
     enum class DeviceIndex : u8 {
         Left = 0,
         Right = 1,
         None = 2,
+        MaxDeviceIndex = 3,
     };
 
     enum class GyroscopeZeroDriftMode : u32 {
@@ -213,6 +215,8 @@ public:
     static Settings::ControllerType MapNPadToSettingsType(Controller_NPad::NPadControllerType type);
     static std::size_t NPadIdToIndex(u32 npad_id);
     static u32 IndexToNPad(std::size_t index);
+    static bool IsNpadIdValid(u32 npad_id);
+    static bool IsDeviceHandleValid(const DeviceHandle& device_handle);
 
 private:
     struct CommonHeader {


### PR DESCRIPTION
Some games such as NEKOPARA Vol. 3 send invalid device handles when calling InitializeVibrationDevice. Introduce a check to validate the device handle before use.

Fixes #5188 