### PR TITLE
cmake: Fix generating CMake configs and linking with Boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,6 @@ macro(yuzu_find_packages)
     # Capitalization matters here. We need the naming to match the generated paths from Conan
     set(REQUIRED_LIBS
     #    Cmake Pkg Prefix  Version     Conan Pkg
-        "Boost             1.73        boost/1.73.0"
         "Catch2            2.13        catch2/2.13.0"
         "fmt               7.1         fmt/7.1.2"
     # can't use until https://github.com/bincrafters/community/issues/1173
@@ -194,6 +193,17 @@ macro(yuzu_find_packages)
     endforeach()
     unset(FN_FORCE_REQUIRED)
 endmacro()
+
+if (NOT Boost_FOUND)
+    find_package(Boost 1.73.0 COMPONENTS context headers QUIET)
+    if (Boost_FOUND)
+        set(Boost_LIBRARIES Boost::boost Boost::context)
+    endif()
+endif()
+if (NOT Boost_FOUND)
+    message(STATUS "Boost 1.73.0 or newer not found, falling back to Conan")
+    list(APPEND CONAN_REQUIRED_LIBS "boost/1.73.0")
+endif()
 
 # Attempt to locate any packages that are required and report the missing ones in CONAN_REQUIRED_LIBS
 yuzu_find_packages()
@@ -299,6 +309,11 @@ if (CONAN_REQUIRED_LIBS)
     # this time with required, so we bail if its not found.
     yuzu_find_packages(FORCE_REQUIRED)
 
+    if (NOT Boost_FOUND)
+        find_package(Boost 1.73.0 REQUIRED COMPONENTS context headers)
+        set(Boost_LIBRARIES Boost::boost)
+    endif()
+    
     # Due to issues with variable scopes in functions, we need to also find_package(qt5) outside of the function
     if(ENABLE_QT)
         list(APPEND CMAKE_MODULE_PATH "${CONAN_QT_ROOT_RELEASE}")

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -210,7 +210,7 @@ endif()
 
 create_target_directory_groups(common)
 
-target_link_libraries(common PUBLIC Boost::boost fmt::fmt microprofile)
+target_link_libraries(common PUBLIC ${Boost_LIBRARIES} fmt::fmt microprofile)
 target_link_libraries(common PRIVATE lz4::lz4 xbyak)
 if (MSVC)
   target_link_libraries(common PRIVATE zstd::zstd)


### PR DESCRIPTION
Fixes a regression by 761206cf81b271f7f4dd6a167a120325b760dbf3, causing yuzu to not build on at least Linux with any version of Boost except a cached 1.73 Conan version from before about a day ago.

Moves the Boost requirement out of the `REQUIRED_LIBS` pseudo-2D-array for Conan to instead be manually configured, using Conan as a fallback solution if the system does not meet our requirements.

~~Requires rebuilding the `linux-fresh` container in order to build/pass CI. As of writing, that container uses the mentioned cached version of Boost and is incompatible with these changes.~~ Partially compatible now.

**DO NOT MERGE** until someone with the MSVC toolchain can verify this works there, too.