### PR TITLE
memory: Fix issues with thread safety

### DIFF
--- a/src/common/page_table.cpp
+++ b/src/common/page_table.cpp
@@ -10,16 +10,12 @@ PageTable::PageTable() = default;
 
 PageTable::~PageTable() noexcept = default;
 
-void PageTable::Resize(std::size_t address_space_width_in_bits, std::size_t page_size_in_bits,
-                       bool has_attribute) {
+void PageTable::Resize(std::size_t address_space_width_in_bits, std::size_t page_size_in_bits) {
     const std::size_t num_page_table_entries{1ULL
                                              << (address_space_width_in_bits - page_size_in_bits)};
     pointers.resize(num_page_table_entries);
     backing_addr.resize(num_page_table_entries);
-
-    if (has_attribute) {
-        attributes.resize(num_page_table_entries);
-    }
+    attributes.resize(num_page_table_entries);
 }
 
 } // namespace Common

--- a/src/common/page_table.h
+++ b/src/common/page_table.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <tuple>
 
 #include "common/common_types.h"
@@ -47,7 +48,8 @@ struct SpecialRegion {
  * A (reasonably) fast way of allowing switchable and remappable process address spaces. It loosely
  * mimics the way a real CPU page table works.
  */
-struct PageTable {
+class PageTable {
+public:
     PageTable();
     ~PageTable() noexcept;
 
@@ -62,12 +64,42 @@ struct PageTable {
      * a given address space.
      *
      * @param address_space_width_in_bits The address size width in bits.
-     * @param page_size_in_bits           The page size in bits.
-     * @param has_attribute               Whether or not this page has any backing attributes.
+     * @param page_size_in_bits The page size in bits.
      */
-    void Resize(std::size_t address_space_width_in_bits, std::size_t page_size_in_bits,
-                bool has_attribute);
+    void Resize(std::size_t address_space_width_in_bits, std::size_t page_size_in_bits);
 
+    struct Entry {
+        u8* const pointer;
+        const u64 backing_addr;
+        const Common::PageType attribute;
+    };
+
+    VirtualBuffer<u8*>& GetPointers() {
+        return pointers;
+    }
+
+    u64 GetBackingAddr(std::size_t base) {
+        std::lock_guard<std::mutex> lock(guard);
+        return backing_addr[base];
+    }
+
+    Entry GetEntry(std::size_t base) {
+        std::lock_guard<std::mutex> lock(guard);
+        return {
+            .pointer = pointers[base],
+            .backing_addr = backing_addr[base],
+            .attribute = attributes[base],
+        };
+    }
+
+    void SetEntry(std::size_t base, const Entry& entry) {
+        std::lock_guard<std::mutex> lock(guard);
+        pointers[base] = entry.pointer;
+        backing_addr[base] = entry.backing_addr;
+        attributes[base] = entry.attribute;
+    }
+
+private:
     /**
      * Vector of memory pointers backing each page. An entry can only be non-null if the
      * corresponding entry in the `attributes` vector is of type `Memory`.
@@ -77,6 +109,8 @@ struct PageTable {
     VirtualBuffer<u64> backing_addr;
 
     VirtualBuffer<PageType> attributes;
+
+    std::mutex guard;
 };
 
 } // namespace Common

--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -10,7 +10,7 @@
 #include "core/hardware_properties.h"
 
 namespace Common {
-struct PageTable;
+class PageTable;
 }
 
 namespace Kernel {

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -131,7 +131,7 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable& 
     static constexpr std::size_t PAGE_BITS = 12;
     static constexpr std::size_t NUM_PAGE_TABLE_ENTRIES = 1 << (32 - PAGE_BITS);
     config.page_table = reinterpret_cast<std::array<std::uint8_t*, NUM_PAGE_TABLE_ENTRIES>*>(
-        page_table.pointers.data());
+        page_table.GetPointers().data());
     config.absolute_offset_page_table = true;
     config.detect_misaligned_access_via_page_table = 16 | 32 | 64 | 128;
     config.only_detect_misalignment_via_page_table_on_page_boundary = true;

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -150,7 +150,7 @@ std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable& 
     config.callbacks = cb.get();
 
     // Memory
-    config.page_table = reinterpret_cast<void**>(page_table.pointers.data());
+    config.page_table = reinterpret_cast<void**>(page_table.GetPointers().data());
     config.page_table_address_space_bits = address_space_bits;
     config.silently_mirror_page_table = false;
     config.absolute_offset_page_table = true;

--- a/src/core/hle/kernel/memory/page_table.cpp
+++ b/src/core/hle/kernel/memory/page_table.cpp
@@ -265,7 +265,7 @@ ResultCode PageTable::InitializeForProcess(FileSys::ProgramAddressSpaceType as_t
     physical_memory_usage = 0;
     memory_pool = pool;
 
-    page_table_impl.Resize(address_space_width, PageBits, true);
+    page_table_impl.Resize(address_space_width, PageBits);
 
     return InitializeMemoryLayout(start, end);
 }

--- a/src/core/hle/kernel/memory/page_table.h
+++ b/src/core/hle/kernel/memory/page_table.h
@@ -211,8 +211,9 @@ public:
     constexpr bool IsInsideASLRRegion(VAddr address, std::size_t size) const {
         return !IsOutsideASLRRegion(address, size);
     }
-    constexpr PAddr GetPhysicalAddr(VAddr addr) {
-        return page_table_impl.backing_addr[addr >> Memory::PageBits] + addr;
+
+    PAddr GetPhysicalAddr(VAddr addr) {
+        return page_table_impl.GetBackingAddr(addr >> Memory::PageBits) + addr;
     }
 
 private:

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -11,7 +11,7 @@
 #include "common/memory_hook.h"
 
 namespace Common {
-struct PageTable;
+class PageTable;
 }
 
 namespace Core {
@@ -128,7 +128,7 @@ public:
      *
      * @returns True if the given virtual address is valid, false otherwise.
      */
-    bool IsValidVirtualAddress(const Kernel::Process& process, VAddr vaddr) const;
+    bool IsValidVirtualAddress(Kernel::Process& process, VAddr vaddr) const;
 
     /**
      * Checks whether or not the supplied address is a valid virtual
@@ -343,8 +343,7 @@ public:
      * @post The range [dest_buffer, size) contains the read bytes from the
      *       process' address space.
      */
-    void ReadBlock(const Kernel::Process& process, VAddr src_addr, void* dest_buffer,
-                   std::size_t size);
+    void ReadBlock(Kernel::Process& process, VAddr src_addr, void* dest_buffer, std::size_t size);
 
     /**
      * Reads a contiguous block of bytes from a specified process' address space.
@@ -364,7 +363,7 @@ public:
      * @post The range [dest_buffer, size) contains the read bytes from the
      *       process' address space.
      */
-    void ReadBlockUnsafe(const Kernel::Process& process, VAddr src_addr, void* dest_buffer,
+    void ReadBlockUnsafe(Kernel::Process& process, VAddr src_addr, void* dest_buffer,
                          std::size_t size);
 
     /**
@@ -424,7 +423,7 @@ public:
      *       and will mark that region as invalidated to caches that the active
      *       graphics backend may be maintaining over the course of execution.
      */
-    void WriteBlock(const Kernel::Process& process, VAddr dest_addr, const void* src_buffer,
+    void WriteBlock(Kernel::Process& process, VAddr dest_addr, const void* src_buffer,
                     std::size_t size);
 
     /**
@@ -444,7 +443,7 @@ public:
      *       will be ignored and an error will be logged.
      *
      */
-    void WriteBlockUnsafe(const Kernel::Process& process, VAddr dest_addr, const void* src_buffer,
+    void WriteBlockUnsafe(Kernel::Process& process, VAddr dest_addr, const void* src_buffer,
                           std::size_t size);
 
     /**
@@ -496,7 +495,7 @@ public:
      * @post The range [dest_addr, size) within the process' address space is
      *       filled with zeroes.
      */
-    void ZeroBlock(const Kernel::Process& process, VAddr dest_addr, std::size_t size);
+    void ZeroBlock(Kernel::Process& process, VAddr dest_addr, std::size_t size);
 
     /**
      * Fills the specified address range within the current process' address space with zeroes.
@@ -521,8 +520,7 @@ public:
      * @post The range [dest_addr, size) within the process' address space contains the
      *       same data within the range [src_addr, size).
      */
-    void CopyBlock(const Kernel::Process& process, VAddr dest_addr, VAddr src_addr,
-                   std::size_t size);
+    void CopyBlock(Kernel::Process& process, VAddr dest_addr, VAddr src_addr, std::size_t size);
 
     /**
      * Copies data within the current process' address space to another location within the

--- a/src/tests/core/arm/arm_test_common.h
+++ b/src/tests/core/arm/arm_test_common.h
@@ -13,7 +13,7 @@
 #include "core/hle/kernel/kernel.h"
 
 namespace Common {
-struct PageTable;
+class PageTable;
 }
 
 namespace ArmTests {


### PR DESCRIPTION
The way that we access page tables is not thread safe. Much of this code existed before our multicore CPU and asynchronous GPU implementations. Two main issues come to mind:
* We do not atomically access a page address from its metadata on reads/writes
* The current page table might change (e.g. on a reschedule) while some other thread is accessing it (e.g. the GPU thread)

This change should fix the above.

Thanks to @ReinUsesLisp for bringing this to my attention.