### PR TITLE
yuzu: Remove gdbstub configuration

### DIFF
--- a/src/core/settings.cpp
+++ b/src/core/settings.cpp
@@ -72,8 +72,6 @@ void LogSettings() {
     log_setting("DataStorage_UseVirtualSd", values.use_virtual_sd);
     log_setting("DataStorage_NandDir", Common::FS::GetUserPath(Common::FS::UserPath::NANDDir));
     log_setting("DataStorage_SdmcDir", Common::FS::GetUserPath(Common::FS::UserPath::SDMCDir));
-    log_setting("Debugging_UseGdbstub", values.use_gdbstub);
-    log_setting("Debugging_GdbstubPort", values.gdbstub_port);
     log_setting("Debugging_ProgramArgs", values.program_args);
     log_setting("Services_BCATBackend", values.bcat_backend);
     log_setting("Services_BCATBoxcatLocal", values.bcat_boxcat_local);

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -637,8 +637,6 @@ void Config::ReadDebuggingValues() {
     // Intentionally not using the QT default setting as this is intended to be changed in the ini
     Settings::values.record_frame_times =
         qt_config->value(QStringLiteral("record_frame_times"), false).toBool();
-    Settings::values.use_gdbstub = ReadSetting(QStringLiteral("use_gdbstub"), false).toBool();
-    Settings::values.gdbstub_port = ReadSetting(QStringLiteral("gdbstub_port"), 24689).toInt();
     Settings::values.program_args =
         ReadSetting(QStringLiteral("program_args"), QString{}).toString().toStdString();
     Settings::values.dump_exefs = ReadSetting(QStringLiteral("dump_exefs"), false).toBool();
@@ -1236,8 +1234,6 @@ void Config::SaveDebuggingValues() {
 
     // Intentionally not using the QT default setting as this is intended to be changed in the ini
     qt_config->setValue(QStringLiteral("record_frame_times"), Settings::values.record_frame_times);
-    WriteSetting(QStringLiteral("use_gdbstub"), Settings::values.use_gdbstub, false);
-    WriteSetting(QStringLiteral("gdbstub_port"), Settings::values.gdbstub_port, 24689);
     WriteSetting(QStringLiteral("program_args"),
                  QString::fromStdString(Settings::values.program_args), QString{});
     WriteSetting(QStringLiteral("dump_exefs"), Settings::values.dump_exefs, false);

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -28,9 +28,6 @@ ConfigureDebug::ConfigureDebug(QWidget* parent) : QWidget(parent), ui(new Ui::Co
 ConfigureDebug::~ConfigureDebug() = default;
 
 void ConfigureDebug::SetConfiguration() {
-    ui->toggle_gdbstub->setChecked(Settings::values.use_gdbstub);
-    ui->gdbport_spinbox->setEnabled(Settings::values.use_gdbstub);
-    ui->gdbport_spinbox->setValue(Settings::values.gdbstub_port);
     ui->toggle_console->setEnabled(!Core::System::GetInstance().IsPoweredOn());
     ui->toggle_console->setChecked(UISettings::values.show_console);
     ui->log_filter_edit->setText(QString::fromStdString(Settings::values.log_filter));
@@ -45,8 +42,6 @@ void ConfigureDebug::SetConfiguration() {
 }
 
 void ConfigureDebug::ApplyConfiguration() {
-    Settings::values.use_gdbstub = ui->toggle_gdbstub->isChecked();
-    Settings::values.gdbstub_port = ui->gdbport_spinbox->value();
     UISettings::values.show_console = ui->toggle_console->isChecked();
     Settings::values.log_filter = ui->log_filter_edit->text().toStdString();
     Settings::values.program_args = ui->homebrew_args_edit->text().toStdString();

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -7,64 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>467</height>
+    <height>486</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_1">
-   <item>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-     <item>
-      <widget class="QGroupBox" name="groupBox">
-       <property name="title">
-        <string>GDB</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_3">
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_1">
-          <item>
-           <widget class="QCheckBox" name="toggle_gdbstub">
-            <property name="text">
-             <string>Enable GDB Stub</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-          <item>
-           <widget class="QLabel" name="label_1">
-            <property name="text">
-             <string>Port:</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QSpinBox" name="gdbport_spinbox">
-            <property name="maximum">
-             <number>65536</number>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item>
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
@@ -258,8 +207,6 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>toggle_gdbstub</tabstop>
-  <tabstop>gdbport_spinbox</tabstop>
   <tabstop>log_filter_edit</tabstop>
   <tabstop>toggle_console</tabstop>
   <tabstop>open_log_button</tabstop>
@@ -269,22 +216,5 @@
   <tabstop>quest_flag</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>toggle_gdbstub</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>gdbport_spinbox</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>84</x>
-     <y>157</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>342</x>
-     <y>158</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -429,9 +429,6 @@ void Config::ReadValues() {
     // Debugging
     Settings::values.record_frame_times =
         sdl2_config->GetBoolean("Debugging", "record_frame_times", false);
-    Settings::values.use_gdbstub = sdl2_config->GetBoolean("Debugging", "use_gdbstub", false);
-    Settings::values.gdbstub_port =
-        static_cast<u16>(sdl2_config->GetInteger("Debugging", "gdbstub_port", 24689));
     Settings::values.program_args = sdl2_config->Get("Debugging", "program_args", "");
     Settings::values.dump_exefs = sdl2_config->GetBoolean("Debugging", "dump_exefs", false);
     Settings::values.dump_nso = sdl2_config->GetBoolean("Debugging", "dump_nso", false);

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -318,9 +318,6 @@ log_filter = *:Trace
 [Debugging]
 # Record frame time data, can be found in the log directory. Boolean value
 record_frame_times =
-# Port for listening to GDB connections.
-use_gdbstub=false
-gdbstub_port=24689
 # Determines whether or not yuzu will dump the ExeFS of all games it attempts to load while loading them
 dump_exefs=false
 # Determines whether or not yuzu will dump all NSOs it attempts to load while loading them

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -64,7 +64,6 @@ __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 static void PrintHelp(const char* argv0) {
     std::cout << "Usage: " << argv0
               << " [options] <filename>\n"
-                 "-g, --gdbport=NUMBER  Enable gdb stub on port NUMBER\n"
                  "-f, --fullscreen      Start in fullscreen mode\n"
                  "-h, --help            Display this help and exit\n"
                  "-v, --version         Output version information and exit\n"
@@ -96,8 +95,6 @@ int main(int argc, char** argv) {
     Config config;
 
     int option_index = 0;
-    bool use_gdbstub = Settings::values.use_gdbstub;
-    u32 gdb_port = static_cast<u32>(Settings::values.gdbstub_port);
 
     InitializeLogging();
 
@@ -116,26 +113,17 @@ int main(int argc, char** argv) {
     bool fullscreen = false;
 
     static struct option long_options[] = {
-        {"gdbport", required_argument, 0, 'g'}, {"fullscreen", no_argument, 0, 'f'},
-        {"help", no_argument, 0, 'h'},          {"version", no_argument, 0, 'v'},
-        {"program", optional_argument, 0, 'p'}, {0, 0, 0, 0},
+        {"fullscreen", no_argument, 0, 'f'},
+        {"help", no_argument, 0, 'h'},
+        {"version", no_argument, 0, 'v'},
+        {"program", optional_argument, 0, 'p'},
+        {0, 0, 0, 0},
     };
 
     while (optind < argc) {
         int arg = getopt_long(argc, argv, "g:fhvp::", long_options, &option_index);
         if (arg != -1) {
             switch (static_cast<char>(arg)) {
-            case 'g':
-                errno = 0;
-                gdb_port = strtoul(optarg, &endarg, 0);
-                use_gdbstub = true;
-                if (endarg == optarg)
-                    errno = EINVAL;
-                if (errno != 0) {
-                    perror("--gdbport");
-                    exit(1);
-                }
-                break;
             case 'f':
                 fullscreen = true;
                 LOG_INFO(Frontend, "Starting in fullscreen mode...");
@@ -177,8 +165,6 @@ int main(int argc, char** argv) {
     InputCommon::InputSubsystem input_subsystem;
 
     // Apply the command line arguments
-    Settings::values.gdbstub_port = gdb_port;
-    Settings::values.use_gdbstub = use_gdbstub;
     Settings::Apply(system);
 
     std::unique_ptr<EmuWindow_SDL2> emu_window;

--- a/src/yuzu_tester/config.cpp
+++ b/src/yuzu_tester/config.cpp
@@ -158,7 +158,6 @@ void Config::ReadValues() {
     Settings::values.use_dev_keys = sdl2_config->GetBoolean("Miscellaneous", "use_dev_keys", false);
 
     // Debugging
-    Settings::values.use_gdbstub = false;
     Settings::values.program_args = "";
     Settings::values.dump_exefs = sdl2_config->GetBoolean("Debugging", "dump_exefs", false);
     Settings::values.dump_nso = sdl2_config->GetBoolean("Debugging", "dump_nso", false);

--- a/src/yuzu_tester/yuzu.cpp
+++ b/src/yuzu_tester/yuzu.cpp
@@ -162,7 +162,6 @@ int main(int argc, char** argv) {
 
     Core::System& system{Core::System::GetInstance()};
 
-    Settings::values.use_gdbstub = false;
     Settings::Apply(system);
 
     const auto emu_window{std::make_unique<EmuWindow_SDL2_Hide>()};


### PR DESCRIPTION
The gdbstub itself was removed with https://github.com/yuzu-emu/yuzu/pull/5028.
This PR just removes the remaining gdb configuration code from the emulator and the UI.