### PR TITLE
configure_input: Modify controller connection delay

### DIFF
--- a/src/yuzu/applets/controller.cpp
+++ b/src/yuzu/applets/controller.cpp
@@ -535,7 +535,7 @@ void QtControllerSelectorDialog::UpdateControllerState(std::size_t player_index)
     // This emulates a delay between disconnecting and reconnecting controllers as some games
     // do not respond to a change in controller type if it was instantaneous.
     using namespace std::chrono_literals;
-    std::this_thread::sleep_for(20ms);
+    std::this_thread::sleep_for(60ms);
 
     UpdateController(controller_type, player_index, player_connected);
 }

--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <thread>
 
 #include <QSignalBlocker>
 #include <QTimer>
@@ -181,8 +182,18 @@ QList<QWidget*> ConfigureInput::GetSubTabs() const {
 }
 
 void ConfigureInput::ApplyConfiguration() {
-    for (auto controller : player_controllers) {
+    for (auto* controller : player_controllers) {
         controller->ApplyConfiguration();
+        controller->TryDisconnectSelectedController();
+    }
+
+    // This emulates a delay between disconnecting and reconnecting controllers as some games
+    // do not respond to a change in controller type if it was instantaneous.
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(60ms);
+
+    for (auto* controller : player_controllers) {
+        controller->TryConnectSelectedController();
     }
 
     advanced->ApplyConfiguration();

--- a/src/yuzu/configuration/configure_input_player.h
+++ b/src/yuzu/configuration/configure_input_player.h
@@ -54,6 +54,18 @@ public:
     /// Save all button configurations to settings file.
     void ApplyConfiguration();
 
+    /**
+     * Attempts to connect the currently selected controller in the HID backend.
+     * This function will not do anything if it is not connected in the frontend.
+     */
+    void TryConnectSelectedController();
+
+    /**
+     * Attempts to disconnect the currently selected controller in the HID backend.
+     * This function will not do anything if the configuration has not changed.
+     */
+    void TryDisconnectSelectedController();
+
     /// Set the connection state checkbox (used to sync state).
     void ConnectPlayer(bool connected);
 


### PR DESCRIPTION
Increases the controller connection delay to 60ms and refactors it to attempt to disconnect all controllers prior to connecting all controllers in HID.

This change is necessary due to #5208

Also, this should be merged **after** #5208 