### PR TITLE
yuzu/main: Save settings when starting guest

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1106,6 +1106,11 @@ void GMainWindow::BootGame(const QString& filename, std::size_t program_index) {
 
     ConfigureVibration::SetAllVibrationDevices();
 
+    // Save configurations
+    UpdateUISettings();
+    game_list->SaveInterfaceLayout();
+    config->Save();
+
     Settings::LogSettings();
 
     if (UISettings::values.select_user_on_boot) {
@@ -2521,6 +2526,24 @@ void GMainWindow::UpdateStatusButtons() {
 #endif
 }
 
+void GMainWindow::UpdateUISettings() {
+    if (!ui.action_Fullscreen->isChecked()) {
+        UISettings::values.geometry = saveGeometry();
+        UISettings::values.renderwindow_geometry = render_window->saveGeometry();
+    }
+    UISettings::values.state = saveState();
+#if MICROPROFILE_ENABLED
+    UISettings::values.microprofile_geometry = microProfileDialog->saveGeometry();
+    UISettings::values.microprofile_visible = microProfileDialog->isVisible();
+#endif
+    UISettings::values.single_window_mode = ui.action_Single_Window_Mode->isChecked();
+    UISettings::values.fullscreen = ui.action_Fullscreen->isChecked();
+    UISettings::values.display_titlebar = ui.action_Display_Dock_Widget_Headers->isChecked();
+    UISettings::values.show_filter_bar = ui.action_Show_Filter_Bar->isChecked();
+    UISettings::values.show_status_bar = ui.action_Show_Status_Bar->isChecked();
+    UISettings::values.first_start = false;
+}
+
 void GMainWindow::HideMouseCursor() {
     if (emu_thread == nullptr || UISettings::values.hide_mouse == false) {
         mouse_hide_timer.stop();
@@ -2754,22 +2777,7 @@ void GMainWindow::closeEvent(QCloseEvent* event) {
         return;
     }
 
-    if (!ui.action_Fullscreen->isChecked()) {
-        UISettings::values.geometry = saveGeometry();
-        UISettings::values.renderwindow_geometry = render_window->saveGeometry();
-    }
-    UISettings::values.state = saveState();
-#if MICROPROFILE_ENABLED
-    UISettings::values.microprofile_geometry = microProfileDialog->saveGeometry();
-    UISettings::values.microprofile_visible = microProfileDialog->isVisible();
-#endif
-    UISettings::values.single_window_mode = ui.action_Single_Window_Mode->isChecked();
-    UISettings::values.fullscreen = ui.action_Fullscreen->isChecked();
-    UISettings::values.display_titlebar = ui.action_Display_Dock_Widget_Headers->isChecked();
-    UISettings::values.show_filter_bar = ui.action_Show_Filter_Bar->isChecked();
-    UISettings::values.show_status_bar = ui.action_Show_Status_Bar->isChecked();
-    UISettings::values.first_start = false;
-
+    UpdateUISettings();
     game_list->SaveInterfaceLayout();
     hotkey_registry.SaveHotkeys();
 

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -257,6 +257,7 @@ private:
                            const std::string& title_version = {});
     void UpdateStatusBar();
     void UpdateStatusButtons();
+    void UpdateUISettings();
     void HideMouseCursor();
     void ShowMouseCursor();
     void OpenURL(const QUrl& url);


### PR DESCRIPTION
Saves UISettings and Settings when booting a guest. Moves updating UISettings::values from GMainWindow::closeEvent into its own function, then reuses it in GMainWindow::BootGame.