### PR TITLE
yuzu/main: Improve menubar access keys

### DIFF
--- a/src/yuzu/debugger/profiler.cpp
+++ b/src/yuzu/debugger/profiler.cpp
@@ -48,7 +48,7 @@ private:
 
 MicroProfileDialog::MicroProfileDialog(QWidget* parent) : QWidget(parent, Qt::Dialog) {
     setObjectName(QStringLiteral("MicroProfile"));
-    setWindowTitle(tr("MicroProfile"));
+    setWindowTitle(tr("&MicroProfile"));
     resize(1000, 600);
     // Remove the "?" button from the titlebar and enable the maximize button
     setWindowFlags((windowFlags() & ~Qt::WindowContextHelpButtonHint) |

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -457,7 +457,7 @@ void WaitTreeModel::InitItems() {
     thread_items = WaitTreeItem::MakeThreadItemList();
 }
 
-WaitTreeWidget::WaitTreeWidget(QWidget* parent) : QDockWidget(tr("Wait Tree"), parent) {
+WaitTreeWidget::WaitTreeWidget(QWidget* parent) : QDockWidget(tr("&Wait Tree"), parent) {
     setObjectName(QStringLiteral("WaitTreeWidget"));
     view = new QTreeView(this);
     view->setHeaderHidden(true);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -677,7 +677,7 @@ void GMainWindow::InitializeRecentFileMenuActions() {
     }
     ui.menu_recent_files->addSeparator();
     QAction* action_clear_recent_files = new QAction(this);
-    action_clear_recent_files->setText(tr("Clear Recent Files"));
+    action_clear_recent_files->setText(tr("&Clear Recent Files"));
     connect(action_clear_recent_files, &QAction::triggered, this, [this] {
         UISettings::values.recent_files.clear();
         UpdateRecentFiles();
@@ -2117,7 +2117,7 @@ void GMainWindow::OnStartGame() {
     connect(emu_thread.get(), &EmuThread::ErrorThrown, this, &GMainWindow::OnCoreError);
 
     ui.action_Start->setEnabled(false);
-    ui.action_Start->setText(tr("Continue"));
+    ui.action_Start->setText(tr("&Continue"));
 
     ui.action_Pause->setEnabled(true);
     ui.action_Stop->setEnabled(true);
@@ -2970,7 +2970,7 @@ void GMainWindow::OnLanguageChanged(const QString& locale) {
     UpdateWindowTitle();
 
     if (emulation_running)
-        ui.action_Start->setText(tr("Continue"));
+        ui.action_Start->setText(tr("&Continue"));
 }
 
 void GMainWindow::SetDiscordEnabled([[maybe_unused]] bool state) {

--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -25,16 +25,7 @@
   </property>
   <widget class="QWidget" name="centralwidget">
    <layout class="QHBoxLayout" name="horizontalLayout">
-    <property name="leftMargin">
-     <number>0</number>
-    </property>
-    <property name="topMargin">
-     <number>0</number>
-    </property>
-    <property name="rightMargin">
-     <number>0</number>
-    </property>
-    <property name="bottomMargin">
+    <property name="margin">
      <number>0</number>
     </property>
    </layout>
@@ -45,7 +36,7 @@
      <x>0</x>
      <y>0</y>
      <width>1280</width>
-     <height>21</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">
@@ -54,7 +45,7 @@
     </property>
     <widget class="QMenu" name="menu_recent_files">
      <property name="title">
-      <string>Recent Files</string>
+      <string>&amp;Recent Files</string>
      </property>
     </widget>
     <addaction name="action_Install_File_NAND"/>
@@ -89,7 +80,7 @@
     </property>
     <widget class="QMenu" name="menu_View_Debugging">
      <property name="title">
-      <string>Debugging</string>
+      <string>&amp;Debugging</string>
      </property>
     </widget>
     <addaction name="action_Fullscreen"/>
@@ -104,7 +95,7 @@
    </widget>
    <widget class="QMenu" name="menu_Tools">
     <property name="title">
-     <string>Tools</string>
+     <string>&amp;Tools</string>
     </property>
     <addaction name="action_Rederive"/>
     <addaction name="separator"/>
@@ -132,17 +123,17 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Install Files to NAND...</string>
+    <string>&amp;Install Files to NAND...</string>
    </property>
   </action>
   <action name="action_Load_File">
    <property name="text">
-    <string>Load File...</string>
+    <string>L&amp;oad File...</string>
    </property>
   </action>
   <action name="action_Load_Folder">
    <property name="text">
-    <string>Load Folder...</string>
+    <string>Load &amp;Folder...</string>
    </property>
   </action>
   <action name="action_Exit">
@@ -176,12 +167,12 @@
   </action>
   <action name="action_Rederive">
    <property name="text">
-    <string>Reinitialize keys...</string>
+    <string>&amp;Reinitialize keys...</string>
    </property>
   </action>
   <action name="action_About">
    <property name="text">
-    <string>About yuzu</string>
+    <string>&amp;About yuzu</string>
    </property>
   </action>
   <action name="action_Single_Window_Mode">
@@ -189,12 +180,12 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Single Window Mode</string>
+    <string>Single &amp;Window Mode</string>
    </property>
   </action>
   <action name="action_Configure">
    <property name="text">
-    <string>Configure...</string>
+    <string>Con&amp;figure...</string>
    </property>
   </action>
   <action name="action_Display_Dock_Widget_Headers">
@@ -202,7 +193,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Display Dock Widget Headers</string>
+    <string>Display D&amp;ock Widget Headers</string>
    </property>
   </action>
   <action name="action_Show_Filter_Bar">
@@ -210,7 +201,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Show Filter Bar</string>
+    <string>Show &amp;Filter Bar</string>
    </property>
   </action>
   <action name="action_Show_Status_Bar">
@@ -218,16 +209,25 @@
     <bool>true</bool>
    </property>
    <property name="text">
+    <string>Show &amp;Status Bar</string>
+   </property>
+   <property name="iconText">
     <string>Show Status Bar</string>
    </property>
   </action>
   <action name="action_Reset_Window_Size_720">
    <property name="text">
+    <string>Reset Window Size to &amp;720p</string>
+   </property>
+   <property name="iconText">
     <string>Reset Window Size to 720p</string>
    </property>
   </action>
   <action name="action_Reset_Window_Size_1080">
    <property name="text">
+    <string>Reset Window Size to &amp;1080p</string>
+   </property>
+   <property name="iconText">
     <string>Reset Window Size to 1080p</string>
    </property>
   </action>
@@ -236,7 +236,7 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Fullscreen</string>
+    <string>F&amp;ullscreen</string>
    </property>
   </action>
   <action name="action_Restart">
@@ -244,7 +244,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Restart</string>
+    <string>&amp;Restart</string>
    </property>
   </action>
   <action name="action_Load_Amiibo">
@@ -252,7 +252,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Load Amiibo...</string>
+    <string>Load &amp;Amiibo...</string>
    </property>
   </action>
   <action name="action_Report_Compatibility">
@@ -260,7 +260,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Report Compatibility</string>
+    <string>&amp;Report Compatibility</string>
    </property>
    <property name="visible">
     <bool>false</bool>
@@ -268,22 +268,22 @@
   </action>
   <action name="action_Open_Mods_Page">
    <property name="text">
-    <string>Open Mods Page</string>
+    <string>Open &amp;Mods Page</string>
    </property>
   </action>
   <action name="action_Open_Quickstart_Guide">
    <property name="text">
-    <string>Open Quickstart Guide</string>
+    <string>Open &amp;Quickstart Guide</string>
    </property>
   </action>
   <action name="action_Open_FAQ">
    <property name="text">
-    <string>FAQ</string>
+    <string>&amp;FAQ</string>
    </property>
   </action>
   <action name="action_Open_yuzu_Folder">
    <property name="text">
-    <string>Open yuzu Folder</string>
+    <string>Open &amp;yuzu Folder</string>
    </property>
   </action>
   <action name="action_Capture_Screenshot">
@@ -291,7 +291,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Capture Screenshot</string>
+    <string>&amp;Capture Screenshot</string>
    </property>
   </action>
   <action name="action_Configure_Current_Game">
@@ -299,7 +299,7 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Configure Current Game...</string>
+    <string>Configure C&amp;urrent Game...</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Adds a unique access key to each action within each menu. A few actions already had their own access key, so those were untouched.