### PR TITLE
video_core: Enforce C4715 (not all control paths return a value)

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -303,6 +303,7 @@ if (MSVC)
         /we4457 # Declaration of 'identifier' hides function parameter
         /we4458 # Declaration of 'identifier' hides class member
         /we4459 # Declaration of 'identifier' hides global declaration
+        /we4715 # 'function' : not all control paths return a value
     )
 else()
     target_compile_options(video_core PRIVATE

--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
@@ -2094,6 +2094,7 @@ private:
             return OpFOrdGreaterThanEqual(t_bool, operand_1, operand_2);
         default:
             UNREACHABLE();
+            return v_true;
         }
     }
 


### PR DESCRIPTION
Most of the time people write code that always returns a value,
terminates execution, throws an exception, or uses an unconventional
jump primitive.

This is not always true when we build without asserts on mainline builds.
To avoid introducing undefined behavior on our most used builds, enforce
this warning signalling an error and stopping the build from shipping.