### PR TITLE
applets/controller: Make use of std::span

### DIFF
--- a/src/core/frontend/applets/controller.h
+++ b/src/core/frontend/applets/controller.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <functional>
+#include <span>
 
 #include "common/common_types.h"
 
@@ -23,9 +24,9 @@ struct ControllerParameters {
     bool keep_controllers_connected{};
     bool enable_single_mode{};
     bool enable_border_color{};
-    std::vector<BorderColor> border_colors{};
+    std::span<BorderColor> border_colors{};
     bool enable_explain_text{};
-    std::vector<ExplainText> explain_text{};
+    std::span<ExplainText> explain_text{};
     bool allow_pro_controller{};
     bool allow_handheld{};
     bool allow_dual_joycons{};

--- a/src/core/hle/service/am/applets/controller.cpp
+++ b/src/core/hle/service/am/applets/controller.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <span>
 
 #include "common/assert.h"
 #include "common/logging/log.h"
@@ -24,7 +25,7 @@ namespace Service::AM::Applets {
 
 static Core::Frontend::ControllerParameters ConvertToFrontendParameters(
     ControllerSupportArgPrivate private_arg, ControllerSupportArgHeader header, bool enable_text,
-    std::vector<IdentificationColor> identification_colors, std::vector<ExplainText> text) {
+    std::span<IdentificationColor> identification_colors, std::span<ExplainText> text) {
     HID::Controller_NPad::NpadStyleSet npad_style_set;
     npad_style_set.raw = private_arg.style_set;
 
@@ -169,24 +170,18 @@ void Controller::Execute() {
             case ControllerAppletVersion::Version3:
             case ControllerAppletVersion::Version4:
             case ControllerAppletVersion::Version5:
-                return ConvertToFrontendParameters(
-                    controller_private_arg, controller_user_arg_old.header,
-                    controller_user_arg_old.enable_explain_text,
-                    std::vector<IdentificationColor>(
-                        controller_user_arg_old.identification_colors.begin(),
-                        controller_user_arg_old.identification_colors.end()),
-                    std::vector<ExplainText>(controller_user_arg_old.explain_text.begin(),
-                                             controller_user_arg_old.explain_text.end()));
+                return ConvertToFrontendParameters(controller_private_arg,
+                                                   controller_user_arg_old.header,
+                                                   controller_user_arg_old.enable_explain_text,
+                                                   controller_user_arg_old.identification_colors,
+                                                   controller_user_arg_old.explain_text);
             case ControllerAppletVersion::Version7:
             default:
-                return ConvertToFrontendParameters(
-                    controller_private_arg, controller_user_arg_new.header,
-                    controller_user_arg_new.enable_explain_text,
-                    std::vector<IdentificationColor>(
-                        controller_user_arg_new.identification_colors.begin(),
-                        controller_user_arg_new.identification_colors.end()),
-                    std::vector<ExplainText>(controller_user_arg_new.explain_text.begin(),
-                                             controller_user_arg_new.explain_text.end()));
+                return ConvertToFrontendParameters(controller_private_arg,
+                                                   controller_user_arg_new.header,
+                                                   controller_user_arg_new.enable_explain_text,
+                                                   controller_user_arg_new.identification_colors,
+                                                   controller_user_arg_new.explain_text);
             }
         }();
 


### PR DESCRIPTION
Eliminates the need to convert an array into a vector