### PR TITLE
yuzu/main: Add basic command line arguments

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -292,12 +292,48 @@ GMainWindow::GMainWindow()
     connect(&mouse_hide_timer, &QTimer::timeout, this, &GMainWindow::HideMouseCursor);
     connect(ui.menubar, &QMenuBar::hovered, this, &GMainWindow::ShowMouseCursor);
 
+    MigrateConfigFiles();
+
+    ui.action_Fullscreen->setChecked(false);
+
     QStringList args = QApplication::arguments();
-    if (args.length() >= 2) {
-        BootGame(args[1]);
+
+    if (args.size() < 2) {
+        return;
     }
 
-    MigrateConfigFiles();
+    QString game_path;
+
+    for (int i = 1; i < args.size(); ++i) {
+        // Preserves drag/drop functionality
+        if (args.size() == 2 && !args[1].startsWith(QChar::fromLatin1('-'))) {
+            game_path = args[1];
+            break;
+        }
+
+        // Launch game in fullscreen mode
+        if (args[i] == QStringLiteral("-f")) {
+            ui.action_Fullscreen->setChecked(true);
+            continue;
+        }
+
+        // Launch game at path
+        if (args[i] == QStringLiteral("-g")) {
+            if (i >= args.size() - 1) {
+                continue;
+            }
+
+            if (args[i + 1].startsWith(QChar::fromLatin1('-'))) {
+                continue;
+            }
+
+            game_path = args[++i];
+        }
+    }
+
+    if (!game_path.isEmpty()) {
+        BootGame(game_path);
+    }
 }
 
 GMainWindow::~GMainWindow() {


### PR DESCRIPTION
The following command line arguments are supported:

`yuzu.exe "path_to_game"` - Launches a game at `path_to_game`
`yuzu.exe -f` - Launches the next game in fullscreen
`yuzu.exe -g "path_to_game"` - Launches a game at `path_to_game`
`yuzu.exe -f -g "path_to_game"` - Launches a game at `path_to_game` in fullscreen

Closes #5033 and closes #5177