### PR TITLE
input_common: process udp packets only for the correct pad

### DIFF
--- a/src/input_common/udp/client.cpp
+++ b/src/input_common/udp/client.cpp
@@ -225,6 +225,11 @@ void Client::OnPortInfo([[maybe_unused]] Response::PortInfo data) {
 }
 
 void Client::OnPadData(Response::PadData data, std::size_t client) {
+    // Accept packets only for the correct pad
+    if (static_cast<u8>(clients[client].pad_index) != data.info.id) {
+        return;
+    }
+
     LOG_TRACE(Input, "PadData packet received");
     if (data.packet_counter == clients[client].packet_sequence) {
         LOG_WARNING(


### PR DESCRIPTION
Currently, each of the four pads in a single socket process all new data packets, regardless of whether the packet is actually relevant to them. This works fine when only one pad is used in a single socket (though redundant, as each packet is processed four times, and the same motion input is reported as four different devices), but with additional pads that would result in corrupted motion input, as motion inputs from different devices are processed together.
This PR fixes this issue, by checking the pad index of the incoming packet before processing it.