### PR TITLE
svc: demote SleepThread log to LOG_TRACE

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1583,7 +1583,7 @@ static void ExitThread32(Core::System& system) {
 
 /// Sleep the current thread
 static void SleepThread(Core::System& system, s64 nanoseconds) {
-    LOG_DEBUG(Kernel_SVC, "called nanoseconds={}", nanoseconds);
+    LOG_TRACE(Kernel_SVC, "called nanoseconds={}", nanoseconds);
 
     enum class SleepType : s64 {
         YieldWithoutCoreMigration = 0,


### PR DESCRIPTION
This log is called often, and introduces a lot of noise when debug logging is enabled, making it difficult to see other debug logs.