### PR TITLE
Add missing include of "core/hle/kernel/kernel.h"

### DIFF
--- a/src/core/hle/kernel/k_scheduler_lock.h
+++ b/src/core/hle/kernel/k_scheduler_lock.h
@@ -10,6 +10,7 @@
 #include "common/assert.h"
 #include "common/spin_lock.h"
 #include "core/hardware_properties.h"
+#include "core/hle/kernel/kernel.h"
 
 namespace Kernel {
 


### PR DESCRIPTION
This is needed as the header invokes methods on KernelCore.