### PR TITLE
k_priority_queue: Fix concepts use

### DIFF
--- a/src/common/concepts.h
+++ b/src/common/concepts.h
@@ -31,4 +31,8 @@ concept DerivedFrom = requires {
     std::is_convertible_v<const volatile Derived*, const volatile Base*>;
 };
 
+// TODO: Replace with std::convertible_to when libc++ implements it.
+template <typename From, typename To>
+concept ConvertibleTo = std::is_convertible_v<From, To>;
+
 } // namespace Common

--- a/src/core/hle/kernel/k_priority_queue.h
+++ b/src/core/hle/kernel/k_priority_queue.h
@@ -8,11 +8,13 @@
 #pragma once
 
 #include <array>
+#include <concepts>
 
 #include "common/assert.h"
 #include "common/bit_set.h"
 #include "common/bit_util.h"
 #include "common/common_types.h"
+#include "common/concepts.h"
 
 namespace Kernel {
 
@@ -21,7 +23,7 @@ class Thread;
 template <typename T>
 concept KPriorityQueueAffinityMask = !std::is_reference_v<T> && requires(T & t) {
     { t.GetAffinityMask() }
-    ->std::convertible_to<u64>;
+    ->Common::ConvertibleTo<u64>;
     {t.SetAffinityMask(std::declval<u64>())};
 
     { t.GetAffinity(std::declval<int32_t>()) }
@@ -48,9 +50,9 @@ concept KPriorityQueueMember = !std::is_reference_v<T> && requires(T & t) {
     ->KPriorityQueueAffinityMask;
 
     { t.GetActiveCore() }
-    ->std::convertible_to<s32>;
+    ->Common::ConvertibleTo<s32>;
     { t.GetPriority() }
-    ->std::convertible_to<s32>;
+    ->Common::ConvertibleTo<s32>;
 };
 
 template <typename Member, size_t _NumCores, int LowestPriority, int HighestPriority>


### PR DESCRIPTION
- For `std::same_as`, add missing include of `<concepts>`.

- For `std::convertible_to`, create a replacement in `common/concepts.h`
  and use that instead.

  This would also be found in `<concepts>`, but unlike `std::same_as`,
  `std::convertible_to` is not yet implemented in libc++, LLVM's STL
  implementation - not even in master.  (In fact, `std::same_as` is the
  *only* concept currently implemented.  For some reason.)