### PR TITLE
ci/linux: Build an AppImage

### DIFF
--- a/.ci/scripts/common/post-upload.sh
+++ b/.ci/scripts/common/post-upload.sh
@@ -15,5 +15,5 @@ mv "${REV_NAME}-source.tar.xz" $RELEASE_NAME
 7z a "$REV_NAME.7z" $RELEASE_NAME
 
 # move the compiled archive into the artifacts directory to be uploaded by travis releases
-mv "$ARCHIVE_NAME" artifacts/
-mv "$REV_NAME.7z" artifacts/
+mv "$ARCHIVE_NAME" "${ARTIFACTS_DIR}/"
+mv "$REV_NAME.7z" "${ARTIFACTS_DIR}/"

--- a/.ci/scripts/common/pre-upload.sh
+++ b/.ci/scripts/common/pre-upload.sh
@@ -2,5 +2,6 @@
 
 GITDATE="`git show -s --date=short --format='%ad' | sed 's/-//g'`"
 GITREV="`git show -s --format='%h'`"
+ARTIFACTS_DIR="artifacts"
 
-mkdir -p artifacts
+mkdir -p "${ARTIFACTS_DIR}/"

--- a/.ci/scripts/linux/docker.sh
+++ b/.ci/scripts/linux/docker.sh
@@ -1,14 +1,54 @@
 #!/bin/bash -ex
 
+# Exit on error, rather than continuing with the rest of the script.
+set -e
+
 cd /yuzu
 
 ccache -s
 
 mkdir build || true && cd build
-cmake .. -G Ninja -DDISPLAY_VERSION=$1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/lib/ccache/gcc -DCMAKE_CXX_COMPILER=/usr/lib/ccache/g++ -DYUZU_ENABLE_COMPATIBILITY_REPORTING=${ENABLE_COMPATIBILITY_REPORTING:-"OFF"} -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DUSE_DISCORD_PRESENCE=ON -DENABLE_QT_TRANSLATION=ON
+cmake .. -DDISPLAY_VERSION=$1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/lib/ccache/gcc -DCMAKE_CXX_COMPILER=/usr/lib/ccache/g++ -DYUZU_ENABLE_COMPATIBILITY_REPORTING=${ENABLE_COMPATIBILITY_REPORTING:-"OFF"} -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DUSE_DISCORD_PRESENCE=ON -DENABLE_QT_TRANSLATION=ON -DCMAKE_INSTALL_PREFIX="/usr"
 
-ninja
+make -j$(nproc)
 
 ccache -s
 
 ctest -VV -C Release
+
+make install DESTDIR=AppDir
+rm -vf AppDir/usr/bin/yuzu-cmd AppDir/usr/bin/yuzu-tester
+
+# Download tools needed to build an AppImage
+wget -nc https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
+wget -nc https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
+wget -nc https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+wget -nc https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/AppRun-patched-x86_64
+wget -nc https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so
+# Set executable bit
+chmod 755 \
+    appimagetool-x86_64.AppImage \
+    AppRun-patched-x86_64 \
+    exec-x86_64.so \
+    linuxdeploy-x86_64.AppImage \
+    linuxdeploy-plugin-qt-x86_64.AppImage
+
+# Workaround for https://github.com/AppImage/AppImageKit/issues/828
+export APPIMAGE_EXTRACT_AND_RUN=1
+
+mkdir -p AppDir/usr/optional
+mkdir -p AppDir/usr/optional/libstdc++
+mkdir -p AppDir/usr/optional/libgcc_s
+
+# Deploy yuzu's needed dependencies
+./linuxdeploy-x86_64.AppImage --appdir AppDir --plugin qt
+
+# Workaround for building yuzu with GCC 10 but also trying to distribute it to Ubuntu 18.04 et al.
+# See https://github.com/darealshinji/AppImageKit-checkrt
+cp exec-x86_64.so AppDir/usr/optional/exec.so
+cp AppRun-patched-x86_64 AppDir/AppRun
+cp --dereference /usr/lib/x86_64-linux-gnu/libstdc++.so.6 AppDir/usr/optional/libstdc++/libstdc++.so.6
+cp --dereference /lib/x86_64-linux-gnu/libgcc_s.so.1 AppDir/usr/optional/libgcc_s/libgcc_s.so.1
+
+# Build the AppImage
+./appimagetool-x86_64.AppImage AppDir

--- a/.ci/scripts/linux/upload.sh
+++ b/.ci/scripts/linux/upload.sh
@@ -2,6 +2,8 @@
 
 . .ci/scripts/common/pre-upload.sh
 
+APPIMAGE_NAME="yuzu-x86_64.AppImage"
+NEW_APPIMAGE_NAME="yuzu-${GITDATE}-${GITREV}-x86_64.AppImage"
 REV_NAME="yuzu-linux-${GITDATE}-${GITREV}"
 ARCHIVE_NAME="${REV_NAME}.tar.xz"
 COMPRESSION_FLAGS="-cJvf"
@@ -16,5 +18,8 @@ mkdir "$DIR_NAME"
 
 cp build/bin/yuzu-cmd "$DIR_NAME"
 cp build/bin/yuzu "$DIR_NAME"
+
+# Copy the AppImage to the artifacts directory and avoid compressing it
+cp "build/${APPIMAGE_NAME}" "${ARTIFACTS_DIR}/${NEW_APPIMAGE_NAME}"
 
 . .ci/scripts/common/post-upload.sh


### PR DESCRIPTION
This builds yuzu in an [AppImage](https://appimage.org/) alongside the other archives during release. Required to allow distributing yuzu in the future with upgraded dependencies, such as Qt. As a result of using an AppImage, we remove the need for users to install dependencies before running yuzu on wild Linux distros. Since the build system recently switched to Ubuntu 18.04, this change also brings yuzu back to Ubuntu 18.04, Debian Buster, CentOS 8, and similar.

There are a few changes of note to make this possible:
- Puts the `artifacts/` directory into a variable. The variable is used to directly copy the AppImage to `artifacts/` from within the Linux-specific scripts.
- Reverts to using GNU Make in order to install yuzu to a custom directory.
- Downloads needed tools at build time to generate the AppImage.
- Script exits prematurely if there's an error, rather than continuing with the rest of the script like nothing wrong happened.

The AppImage will be released alongside the other archives, not inside and not replacing them. AppImages are already compressed, so double-compressing one would be ill-advised.

Any yuzu AppImages generated between now and April 2021 will not be valid for submission on [AppImageHub](https://appimage.github.io/) due to incompatibilities with Ubuntu 16.04 as in their [guidelines](https://docs.appimage.org/packaging-guide/distribution.html#appimagehub). Beyond that, I believe there is more work needed to make yuzu eligible. That makes this PR more like preliminary work.

Thanks to @jroweboy for informing me about [CheckRT](https://github.com/darealshinji/AppImageKit-checkrt), which is required to run programs on older Linux installs despite using newer versions of GCC to build them with. (This was several months ago, but nevertheless...)

Double-thank you to @AniLeo for talking to me about launchpad PPAs of GCC 10 and Qt for Ubuntu 18.04.

As a side note, this is also a bit of a test for the 18.04 container, since it is fairly young and hasn't checked many PRs yet.