### PR TITLE
cmake: Enforce -Wuninitialized

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -62,6 +62,7 @@ else()
         -Werror=implicit-fallthrough
         -Werror=missing-declarations
         -Werror=reorder
+        -Werror=uninitialized
         -Werror=unused-result
         -Wextra
         -Wmissing-declarations

--- a/src/core/hle/service/pcie/pcie.cpp
+++ b/src/core/hle/service/pcie/pcie.cpp
@@ -48,7 +48,7 @@ public:
 
 class PCIe final : public ServiceFramework<PCIe> {
 public:
-    explicit PCIe(Core::System& system_) : ServiceFramework{system, "pcie"} {
+    explicit PCIe(Core::System& system_) : ServiceFramework{system_, "pcie"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, nullptr, "RegisterClassDriver"},


### PR DESCRIPTION
Enforce `-Wuninitialized` treating it as an error on the whole project.