### PR TITLE
maxwell_to_vk: Initialize usage variable in SurfaceFormat()

### DIFF
--- a/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
@@ -239,7 +239,7 @@ FormatInfo SurfaceFormat(const VKDevice& device, FormatType format_type, PixelFo
     const bool attachable = tuple.usage & Attachable;
     const bool storage = tuple.usage & Storage;
 
-    VkFormatFeatureFlags usage;
+    VkFormatFeatureFlags usage{};
     switch (format_type) {
     case FormatType::Buffer:
         usage =


### PR DESCRIPTION
Silences a -Wmaybe-uninitialized warning

Fixes #5259