### PR TITLE
yuzu/main: Fix 'Hide mouse on inactivity' and port citra-emu/citra#5476

### DIFF
--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -397,7 +397,7 @@ void GRenderWindow::mousePressEvent(QMouseEvent* event) {
         this->TouchPressed(x, y);
     }
 
-    QWidget::mousePressEvent(event);
+    emit MouseActivity();
 }
 
 void GRenderWindow::mouseMoveEvent(QMouseEvent* event) {
@@ -411,7 +411,7 @@ void GRenderWindow::mouseMoveEvent(QMouseEvent* event) {
     input_subsystem->GetMouse()->MouseMove(x, y);
     this->TouchMoved(x, y);
 
-    QWidget::mouseMoveEvent(event);
+    emit MouseActivity();
 }
 
 void GRenderWindow::mouseReleaseEvent(QMouseEvent* event) {
@@ -687,4 +687,11 @@ void GRenderWindow::showEvent(QShowEvent* event) {
     // windowHandle() is not initialized until the Window is shown, so we connect it here.
     connect(windowHandle(), &QWindow::screenChanged, this, &GRenderWindow::OnFramebufferSizeChanged,
             Qt::UniqueConnection);
+}
+
+bool GRenderWindow::eventFilter(QObject* object, QEvent* event) {
+    if (event->type() == QEvent::HoverMove) {
+        emit MouseActivity();
+    }
+    return false;
 }

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -184,6 +184,7 @@ signals:
     void Closed();
     void FirstFrameDisplayed();
     void ExecuteProgramSignal(std::size_t program_index);
+    void MouseActivity();
 
 private:
     void TouchBeginEvent(const QTouchEvent* event);
@@ -216,4 +217,5 @@ private:
 
 protected:
     void showEvent(QShowEvent* event) override;
+    bool eventFilter(QObject* object, QEvent* event) override;
 };

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1134,6 +1134,7 @@ void GMainWindow::BootGame(const QString& filename, std::size_t program_index) {
         [this](std::size_t program_index) { render_window->ExecuteProgram(program_index); });
 
     connect(render_window, &GRenderWindow::Closed, this, &GMainWindow::OnStopGame);
+    connect(render_window, &GRenderWindow::MouseActivity, this, &GMainWindow::OnMouseActivity);
     // BlockingQueuedConnection is important here, it makes sure we've finished refreshing our views
     // before the CPU continues
     connect(emu_thread.get(), &EmuThread::DebugModeEntered, waitTreeWidget,
@@ -1157,8 +1158,8 @@ void GMainWindow::BootGame(const QString& filename, std::size_t program_index) {
 
     if (UISettings::values.hide_mouse) {
         mouse_hide_timer.start();
-        setMouseTracking(true);
-        ui.centralwidget->setMouseTracking(true);
+        render_window->installEventFilter(render_window);
+        render_window->setAttribute(Qt::WA_Hover, true);
     }
 
     std::string title_name;
@@ -1235,8 +1236,8 @@ void GMainWindow::ShutdownGame() {
     }
     game_list->SetFilterFocus();
 
-    setMouseTracking(false);
-    ui.centralwidget->setMouseTracking(false);
+    render_window->removeEventFilter(render_window);
+    render_window->setAttribute(Qt::WA_Hover, false);
 
     UpdateWindowTitle();
 
@@ -2317,12 +2318,12 @@ void GMainWindow::OnConfigure() {
     config->Save();
 
     if (UISettings::values.hide_mouse && emulation_running) {
-        setMouseTracking(true);
-        ui.centralwidget->setMouseTracking(true);
+        render_window->installEventFilter(render_window);
+        render_window->setAttribute(Qt::WA_Hover, true);
         mouse_hide_timer.start();
     } else {
-        setMouseTracking(false);
-        ui.centralwidget->setMouseTracking(false);
+        render_window->removeEventFilter(render_window);
+        render_window->setAttribute(Qt::WA_Hover, false);
     }
 
     UpdateStatusButtons();
@@ -2565,21 +2566,17 @@ void GMainWindow::HideMouseCursor() {
         ShowMouseCursor();
         return;
     }
-    setCursor(QCursor(Qt::BlankCursor));
+    render_window->setCursor(QCursor(Qt::BlankCursor));
 }
 
 void GMainWindow::ShowMouseCursor() {
-    unsetCursor();
+    render_window->unsetCursor();
     if (emu_thread != nullptr && UISettings::values.hide_mouse) {
         mouse_hide_timer.start();
     }
 }
 
-void GMainWindow::mouseMoveEvent(QMouseEvent* event) {
-    ShowMouseCursor();
-}
-
-void GMainWindow::mousePressEvent(QMouseEvent* event) {
+void GMainWindow::OnMouseActivity() {
     ShowMouseCursor();
 }
 

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -248,6 +248,7 @@ private slots:
     void OnCoreError(Core::System::ResultStatus, std::string);
     void OnReinitializeKeys(ReinitializeKeyBehavior behavior);
     void OnLanguageChanged(const QString& locale);
+    void OnMouseActivity();
 
 private:
     void RemoveBaseContent(u64 program_id, const QString& entry_type);
@@ -335,6 +336,4 @@ protected:
     void dropEvent(QDropEvent* event) override;
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dragMoveEvent(QDragMoveEvent* event) override;
-    void mouseMoveEvent(QMouseEvent* event) override;
-    void mousePressEvent(QMouseEvent* event) override;
 };


### PR DESCRIPTION
The mouseMoveEvent never gets triggered for some reason, causing the mouse to never reappear, unless pressed or moved to the menu bar. Using eventFilter instead solves this issue.
I don't have a lot of experience with Qt, so any suggestions/alternative solutions are welcome.