### PR TITLE
Make the coding conventions more consistant

### DIFF
--- a/src/audio_core/algorithm/interpolate.cpp
+++ b/src/audio_core/algorithm/interpolate.cpp
@@ -218,7 +218,7 @@ void Resample(s32* output, const s32* input, s32 pitch, s32& fraction, std::size
         const auto l2 = lut[lut_index + 2];
         const auto l3 = lut[lut_index + 3];
 
-        const auto s0 = static_cast<s32>(input[index]);
+        const auto s0 = static_cast<s32>(input[index + 0]);
         const auto s1 = static_cast<s32>(input[index + 1]);
         const auto s2 = static_cast<s32>(input[index + 2]);
         const auto s3 = static_cast<s32>(input[index + 3]);


### PR DESCRIPTION
lut_index had 0 added when nothing was supposed to be added

despite this, index was not added to 0 when nothing was supposed to be added...