### PR TITLE
main: Make the loader error dialog fully translatable 

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1054,14 +1054,18 @@ bool GMainWindow::LoadROM(const QString& filename, std::size_t program_index) {
                 const u16 error_id = static_cast<u16>(result) - loader_id;
                 const std::string error_code = fmt::format("({:04X}-{:04X})", loader_id, error_id);
                 LOG_CRITICAL(Frontend, "Failed to load ROM! {}", error_code);
-                QMessageBox::critical(
-                    this,
-                    tr("Error while loading ROM! ").append(QString::fromStdString(error_code)),
-                    QString::fromStdString(fmt::format(
-                        "{}<br>Please follow <a href='https://yuzu-emu.org/help/quickstart/'>the "
-                        "yuzu quickstart guide</a> to redump your files.<br>You can refer "
-                        "to the yuzu wiki</a> or the yuzu Discord</a> for help.",
-                        static_cast<Loader::ResultStatus>(error_id))));
+
+                const auto title =
+                    tr("Error while loading ROM! %1", "%1 signifies a numeric error code.")
+                        .arg(QString::fromStdString(error_code));
+                const auto description =
+                    tr("%1<br>Please follow <a href='https://yuzu-emu.org/help/quickstart/'>the "
+                       "yuzu quickstart guide</a> to redump your files.<br>You can refer "
+                       "to the yuzu wiki</a> or the yuzu Discord</a> for help.",
+                       "%1 signifies a numeric error ID.")
+                        .arg(error_id);
+
+                QMessageBox::critical(this, title, description);
             } else {
                 QMessageBox::critical(
                     this, tr("Error while loading ROM!"),

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1049,8 +1049,7 @@ bool GMainWindow::LoadROM(const QString& filename, std::size_t program_index) {
             break;
 
         default:
-            if (static_cast<u32>(result) >
-                static_cast<u32>(Core::System::ResultStatus::ErrorLoader)) {
+            if (result > Core::System::ResultStatus::ErrorLoader) {
                 const u16 loader_id = static_cast<u16>(Core::System::ResultStatus::ErrorLoader);
                 const u16 error_id = static_cast<u16>(result) - loader_id;
                 const std::string error_code = fmt::format("({:04X}-{:04X})", loader_id, error_id);


### PR DESCRIPTION
Allows the dialog text to be fully translated, as opposed to only the title. While we're at it, we can add annotation comments to explain what the contents of the formatting specifiers are for translators.