### PR TITLE
Fix titlebar icon on Linux (_NET_WM_ICON)

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -147,6 +147,7 @@ add_executable(yuzu
     util/util.h
     compatdb.cpp
     compatdb.h
+    yuzu.qrc
     yuzu.rc
 )
 

--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -303,6 +303,8 @@
    </property>
   </action>
  </widget>
- <resources/>
+ <resources>
+  <include location="yuzu.qrc"/>
+ </resources>
  <connections/>
 </ui>

--- a/src/yuzu/main.ui
+++ b/src/yuzu/main.ui
@@ -14,8 +14,8 @@
    <string>yuzu</string>
   </property>
   <property name="windowIcon">
-   <iconset>
-    <normaloff>../dist/yuzu.ico</normaloff>../dist/yuzu.ico</iconset>
+   <iconset resource="yuzu.qrc">
+    <normaloff>:/img/yuzu.ico</normaloff>:/img/yuzu.ico</iconset>
   </property>
   <property name="tabShape">
    <enum>QTabWidget::Rounded</enum>

--- a/src/yuzu/yuzu.qrc
+++ b/src/yuzu/yuzu.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/img">
+        <file alias="yuzu.ico">../../dist/yuzu.ico</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
Currently yuzu (and Citra) look for the file yuzu.ico on the folder dist outside of the directory the yuzu binary is called from, obviously this isn't correct. 

The way this is implemented by yuzu-emu/yuzu#3316 
`<normaloff>../dist/yuzu.ico</normaloff>../dist/yuzu.ico</iconset>`
searches for the file in an actual location on the Linux filesystem.

With this pull request, I implement a Qt Resource Collection File and point yuzu to a relative location inside the binary instead.

Since desktop environments like KDE or GNOME use the icon defined in the .desktop file as a fallback, I used mate to show the differences.

Before:
![image](https://user-images.githubusercontent.com/67879877/103446170-5d9f1480-4c85-11eb-97c6-22ee79408362.png)
_(As you see it has the generic icon)_

After:
![image](https://user-images.githubusercontent.com/67879877/103446237-f897ee80-4c85-11eb-8925-9dfac29d6f21.png)
_(It works!)_

Testing required on platforms other than Linux

_P.S. This obviously fixes only yuzu and not yuzu-cmd or yuzu-tester since they don't utilize Qt._