### PR TITLE
hle: service: nvflinger: buffer_queue: Do not reset id/layer_id on Connect.

### DIFF
--- a/src/core/hle/service/nvflinger/buffer_queue.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue.cpp
@@ -157,8 +157,6 @@ void BufferQueue::ReleaseBuffer(u32 slot) {
 
 void BufferQueue::Connect() {
     queue_sequence.clear();
-    id = 1;
-    layer_id = 1;
     is_connect = true;
 }
 


### PR DESCRIPTION
- This behavior is a mistake, fixes Katana Zero.