### PR TITLE
Port citra-emu/citra#5666: "Rotate previous log file to "citra_log.txt.old""

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -146,6 +146,9 @@ void ColorConsoleBackend::Write(const Entry& entry) {
 }
 
 FileBackend::FileBackend(const std::string& filename) : bytes_written(0) {
+    if (FileUtil::Exists(filename + ".old.txt")) {
+        FileUtil::Delete(filename + ".old.txt");
+    }
     if (FileUtil::Exists(filename)) {
         FileUtil::Rename(filename, filename + ".old.txt");
     }

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -145,10 +145,15 @@ void ColorConsoleBackend::Write(const Entry& entry) {
     PrintColoredMessage(entry);
 }
 
-// _SH_DENYWR allows read only access to the file for other programs.
-// It is #defined to 0 on other platforms
-FileBackend::FileBackend(const std::string& filename)
-    : file(filename, "w", _SH_DENYWR), bytes_written(0) {}
+FileBackend::FileBackend(const std::string& filename) : bytes_written(0) {
+    if (FileUtil::Exists(filename)) {
+        FileUtil::Rename(filename, filename + ".old");
+    }
+
+    // _SH_DENYWR allows read only access to the file for other programs.
+    // It is #defined to 0 on other platforms
+    file = FileUtil::IOFile(filename, "w", _SH_DENYWR);
+}
 
 void FileBackend::Write(const Entry& entry) {
     // prevent logs from going over the maximum size (in case its spamming and the user doesn't

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -147,7 +147,7 @@ void ColorConsoleBackend::Write(const Entry& entry) {
 
 FileBackend::FileBackend(const std::string& filename) : bytes_written(0) {
     if (FileUtil::Exists(filename)) {
-        FileUtil::Rename(filename, filename + ".old");
+        FileUtil::Rename(filename, filename + ".old.txt");
     }
 
     // _SH_DENYWR allows read only access to the file for other programs.

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -146,16 +146,16 @@ void ColorConsoleBackend::Write(const Entry& entry) {
 }
 
 FileBackend::FileBackend(const std::string& filename) : bytes_written(0) {
-    if (FileUtil::Exists(filename + ".old.txt")) {
-        FileUtil::Delete(filename + ".old.txt");
+    if (Common::FS::Exists(filename + ".old.txt")) {
+        Common::FS::Delete(filename + ".old.txt");
     }
-    if (FileUtil::Exists(filename)) {
-        FileUtil::Rename(filename, filename + ".old.txt");
+    if (Common::FS::Exists(filename)) {
+        Common::FS::Rename(filename, filename + ".old.txt");
     }
 
     // _SH_DENYWR allows read only access to the file for other programs.
     // It is #defined to 0 on other platforms
-    file = FileUtil::IOFile(filename, "w", _SH_DENYWR);
+    file = Common::FS::IOFile(filename, "w", _SH_DENYWR);
 }
 
 void FileBackend::Write(const Entry& entry) {


### PR DESCRIPTION
See citra-emu/citra#5666 for more details.

**Original description:**
Particularly useful for Android as Android will immediately restart the app/Activity if it crashes, immediately overwriting the old log file before it can be read. Also could be useful for the common case of users restarting Citra and overwriting their log on Desktop.