### PR TITLE
Port citra-emu/citra#5668: "Update zstd to v1.4.8"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,7 +165,7 @@ macro(yuzu_find_packages)
         "lz4               1.8         lz4/1.9.2"
         "nlohmann_json     3.8         nlohmann_json/3.8.0"
         "ZLIB              1.2         zlib/1.2.11"
-        "zstd              1.4         zstd/1.4.5"
+        "zstd              1.4         zstd/1.4.8"
     )
 
     foreach(PACKAGE ${REQUIRED_LIBS})


### PR DESCRIPTION
See citra-emu/citra#5668 for more details.

**Original description**:
Silences a warning on newer CMake versions about CMake < 2.8.12 support.
The update may also result in a 5% increase in decompression performance, according to https://github.com/facebook/zstd/releases/tag/v1.4.5