### PR TITLE
buffer_queue: Fix data race by protecting queue_sequence access

### DIFF
--- a/src/core/hle/service/nvflinger/buffer_queue.h
+++ b/src/core/hle/service/nvflinger/buffer_queue.h
@@ -129,8 +129,10 @@ private:
     std::list<u32> queue_sequence;
     Kernel::EventPair buffer_wait_event;
 
-    std::mutex queue_mutex;
-    std::condition_variable condition;
+    std::mutex free_buffers_mutex;
+    std::condition_variable free_buffers_condition;
+
+    std::mutex queue_sequence_mutex;
 };
 
 } // namespace Service::NVFlinger


### PR DESCRIPTION
Fixes a data race introduced by #5208 where `queue_sequence` was accessed and manipulated by multiple threads, but was not protected.

Thanks to @ReinUsesLisp for a reproducible test scenario confirming the data race and its fix.