### PR TITLE
main: Resolve error string not displaying

### DIFF
--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -185,6 +185,10 @@ constexpr std::array<const char*, 66> RESULT_MESSAGES{
     "The INI file contains more than the maximum allowable number of KIP files.",
 };
 
+std::string GetResultStatusString(ResultStatus status) {
+    return RESULT_MESSAGES.at(static_cast<std::size_t>(status));
+}
+
 std::ostream& operator<<(std::ostream& os, ResultStatus status) {
     os << RESULT_MESSAGES.at(static_cast<std::size_t>(status));
     return os;

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -135,6 +135,7 @@ enum class ResultStatus : u16 {
     ErrorINITooManyKIPs,
 };
 
+std::string GetResultStatusString(ResultStatus status);
 std::ostream& operator<<(std::ostream& os, ResultStatus status);
 
 /// Interface for loading an application

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1058,8 +1058,9 @@ bool GMainWindow::LoadROM(const QString& filename, std::size_t program_index) {
                     tr("%1<br>Please follow <a href='https://yuzu-emu.org/help/quickstart/'>the "
                        "yuzu quickstart guide</a> to redump your files.<br>You can refer "
                        "to the yuzu wiki</a> or the yuzu Discord</a> for help.",
-                       "%1 signifies a numeric error ID.")
-                        .arg(error_id);
+                       "%1 signifies an error string.")
+                        .arg(QString::fromStdString(
+                            GetResultStatusString(static_cast<Loader::ResultStatus>(error_id))));
 
                 QMessageBox::critical(this, title, description);
             } else {


### PR DESCRIPTION
During the transition to make the error dialog translatable, I accidentally got rid of the conversion to ResultStatus, which prevented operator<< from being invoked during formatting.

This adds a function to directly retrieve the result status string instead so that it displays again.