### PR TITLE
core: Enforce C4715 (not all control paths return a value)

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -635,6 +635,8 @@ if (MSVC)
         /we4267
         # 'context' : truncation from 'type1' to 'type2'
         /we4305
+        # 'function' : not all control paths return a value
+        /we4715
     )
 else()
     target_compile_options(core PRIVATE

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -143,6 +143,7 @@ u64 GetSignatureTypeDataSize(SignatureType type) {
         return 0x3C;
     }
     UNREACHABLE();
+    return 0;
 }
 
 u64 GetSignatureTypePaddingSize(SignatureType type) {
@@ -157,6 +158,7 @@ u64 GetSignatureTypePaddingSize(SignatureType type) {
         return 0x40;
     }
     UNREACHABLE();
+    return 0;
 }
 
 SignatureType Ticket::GetSignatureType() const {
@@ -169,8 +171,7 @@ SignatureType Ticket::GetSignatureType() const {
     if (const auto* ticket = std::get_if<ECDSATicket>(&data)) {
         return ticket->sig_type;
     }
-
-    UNREACHABLE();
+    throw std::bad_variant_access{};
 }
 
 TicketData& Ticket::GetData() {
@@ -183,8 +184,7 @@ TicketData& Ticket::GetData() {
     if (auto* ticket = std::get_if<ECDSATicket>(&data)) {
         return ticket->data;
     }
-
-    UNREACHABLE();
+    throw std::bad_variant_access{};
 }
 
 const TicketData& Ticket::GetData() const {
@@ -197,8 +197,7 @@ const TicketData& Ticket::GetData() const {
     if (const auto* ticket = std::get_if<ECDSATicket>(&data)) {
         return ticket->data;
     }
-
-    UNREACHABLE();
+    throw std::bad_variant_access{};
 }
 
 u64 Ticket::GetSize() const {

--- a/src/core/file_sys/nca_patch.cpp
+++ b/src/core/file_sys/nca_patch.cpp
@@ -51,8 +51,8 @@ std::pair<std::size_t, std::size_t> SearchBucketEntry(u64 offset, const BlockTyp
             low = mid + 1;
         }
     }
-
     UNREACHABLE_MSG("Offset could not be found in BKTR block.");
+    return {0, 0};
 }
 } // Anonymous namespace
 

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -105,7 +105,8 @@ ContentRecordType GetCRTypeFromNCAType(NCAContentType type) {
         // TODO(DarkLordZach): Peek at NCA contents to differentiate Manual and Legal.
         return ContentRecordType::HtmlDocument;
     default:
-        UNREACHABLE_MSG("Invalid NCAContentType={:02X}", static_cast<u8>(type));
+        UNREACHABLE_MSG("Invalid NCAContentType={:02X}", type);
+        return ContentRecordType{};
     }
 }
 

--- a/src/core/hle/kernel/memory/address_space_info.cpp
+++ b/src/core/hle/kernel/memory/address_space_info.cpp
@@ -96,6 +96,7 @@ u64 AddressSpaceInfo::GetAddressSpaceStart(std::size_t width, Type type) {
         return AddressSpaceInfos[AddressSpaceIndices39Bit[index]].address;
     }
     UNREACHABLE();
+    return 0;
 }
 
 std::size_t AddressSpaceInfo::GetAddressSpaceSize(std::size_t width, Type type) {
@@ -112,6 +113,7 @@ std::size_t AddressSpaceInfo::GetAddressSpaceSize(std::size_t width, Type type) 
         return AddressSpaceInfos[AddressSpaceIndices39Bit[index]].size;
     }
     UNREACHABLE();
+    return 0;
 }
 
 } // namespace Kernel::Memory

--- a/src/core/hle/service/sockets/sockets_translate.cpp
+++ b/src/core/hle/service/sockets/sockets_translate.cpp
@@ -64,6 +64,7 @@ Network::Type Translate(Type type) {
         return Network::Type::DGRAM;
     default:
         UNIMPLEMENTED_MSG("Unimplemented type={}", type);
+        return Network::Type{};
     }
 }
 


### PR DESCRIPTION
Same as #5226 but for `core`.

On some instances a reference was being returned, so I replaced `UNREACHABLE` with an exception.