### PR TITLE
Removed MacOS build link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ If you want to contribute to the user interface translation, please check out th
 
 * __Windows__: [Windows Build](https://github.com/yuzu-emu/yuzu/wiki/Building-For-Windows)
 * __Linux__: [Linux Build](https://github.com/yuzu-emu/yuzu/wiki/Building-For-Linux)
-* __macOS__: [macOS Build](https://github.com/yuzu-emu/yuzu/wiki/Building-for-macOS)
 
 
 ### Support


### PR DESCRIPTION
The MacOS build link was removed in the README.md because it no longer exist.