### PR TITLE
ci/linux: Make Mainline AppImages updateable

### DIFF
--- a/.ci/scripts/linux/docker.sh
+++ b/.ci/scripts/linux/docker.sh
@@ -22,12 +22,10 @@ rm -vf AppDir/usr/bin/yuzu-cmd AppDir/usr/bin/yuzu-tester
 # Download tools needed to build an AppImage
 wget -nc https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
 wget -nc https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
-wget -nc https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
 wget -nc https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/AppRun-patched-x86_64
 wget -nc https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so
 # Set executable bit
 chmod 755 \
-    appimagetool-x86_64.AppImage \
     AppRun-patched-x86_64 \
     exec-x86_64.so \
     linuxdeploy-x86_64.AppImage \
@@ -49,6 +47,3 @@ cp exec-x86_64.so AppDir/usr/optional/exec.so
 cp AppRun-patched-x86_64 AppDir/AppRun
 cp --dereference /usr/lib/x86_64-linux-gnu/libstdc++.so.6 AppDir/usr/optional/libstdc++/libstdc++.so.6
 cp --dereference /lib/x86_64-linux-gnu/libgcc_s.so.1 AppDir/usr/optional/libgcc_s/libgcc_s.so.1
-
-# Build the AppImage
-./appimagetool-x86_64.AppImage AppDir

--- a/.ci/scripts/linux/upload.sh
+++ b/.ci/scripts/linux/upload.sh
@@ -2,8 +2,7 @@
 
 . .ci/scripts/common/pre-upload.sh
 
-APPIMAGE_NAME="yuzu-x86_64.AppImage"
-NEW_APPIMAGE_NAME="yuzu-${GITDATE}-${GITREV}-x86_64.AppImage"
+APPIMAGE_NAME="yuzu-${GITDATE}-${GITREV}.AppImage"
 REV_NAME="yuzu-linux-${GITDATE}-${GITREV}"
 ARCHIVE_NAME="${REV_NAME}.tar.xz"
 COMPRESSION_FLAGS="-cJvf"
@@ -19,7 +18,24 @@ mkdir "$DIR_NAME"
 cp build/bin/yuzu-cmd "$DIR_NAME"
 cp build/bin/yuzu "$DIR_NAME"
 
-# Copy the AppImage to the artifacts directory and avoid compressing it
-cp "build/${APPIMAGE_NAME}" "${ARTIFACTS_DIR}/${NEW_APPIMAGE_NAME}"
+# Build an AppImage
+cd build
+
+wget -nc https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+chmod 755 appimagetool-x86_64.AppImage
+
+if [ "${RELEASE_NAME}" = "mainline" ]; then
+    # Generate update information if releasing to mainline
+    ./appimagetool-x86_64.AppImage -u "gh-releases-zsync|yuzu-emu|yuzu-${RELEASE_NAME}|latest|yuzu-*.AppImage.zsync" AppDir "${APPIMAGE_NAME}"
+else
+    ./appimagetool-x86_64.AppImage AppDir "${APPIMAGE_NAME}"
+fi
+cd ..
+
+# Copy the AppImage and update info to the artifacts directory and avoid compressing it
+cp "build/${APPIMAGE_NAME}" "${ARTIFACTS_DIR}/"
+if [ -f "build/${APPIMAGE_NAME}.zsync" ]; then
+    cp "build/${APPIMAGE_NAME}.zsync" "${ARTIFACTS_DIR}/"
+fi
 
 . .ci/scripts/common/post-upload.sh


### PR DESCRIPTION
Moves the final step for building the AppImage to the upload script. Instructs appimagetool to embed update information into the AppImage if the release target is Mainline. Also tells it to create a zsync file to enable partial-downloads when updating the AppImage.

Renames the AppImage from `yuzu-{version info}-x86_64.AppImage` to `yuzu-{version info}.AppImage` to avoid a bug in the downloads page at https://yuzu-emu.org/downloads.

This needed to be a followup to #5250 in order to allow local testing with update files after a Mainline release was made live.

Requires yuzu-emu/build-environments#25 before merging