### PR TITLE
Various input profile changes

### DIFF
--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -106,6 +106,13 @@ struct TouchFromButtonMap {
     std::vector<std::string> buttons;
 };
 
+struct InputProfile {
+    ControllerType controller_type;
+    ButtonsRaw buttons;
+    AnalogsRaw analogs;
+    MotionsRaw motions;
+};
+
 struct Values {
     // Audio
     std::string audio_device_id;

--- a/src/input_common/settings.h
+++ b/src/input_common/settings.h
@@ -357,6 +357,8 @@ struct PlayerInput {
     u32 body_color_right;
     u32 button_color_left;
     u32 button_color_right;
+
+    std::string input_profile;
 };
 
 struct TouchscreenInput {

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -31,6 +31,8 @@ public:
 
     void ReadControlPlayerValue(std::size_t player_index);
     void SaveControlPlayerValue(std::size_t player_index);
+    void ReadToProfileStruct(Settings::InputProfile& profile);
+    void WriteFromProfileStruct(const Settings::InputProfile& profile);
 
     const std::string& GetConfigFilePath() const;
 

--- a/src/yuzu/configuration/configure_input.h
+++ b/src/yuzu/configuration/configure_input.h
@@ -52,7 +52,10 @@ private:
 
     void UpdateDockedState(bool is_handheld);
     void UpdateAllInputDevices();
-    void UpdateAllInputProfiles(std::size_t player_index);
+    void UpdateAllInputProfiles();
+    void LoadAllProfiles();
+    void RenameInputProfile(const QString& old_name, const QString& new_name);
+    void TabWindowChanged(std::size_t new_tab);
 
     /// Load configuration settings.
     void LoadConfiguration();
@@ -64,6 +67,7 @@ private:
     std::unique_ptr<Ui::ConfigureInput> ui;
 
     std::unique_ptr<InputProfiles> profiles;
+    std::size_t current_tab = 0;
 
     std::array<ConfigureInputPlayer*, 8> player_controllers;
     std::array<QWidget*, 8> player_tabs;

--- a/src/yuzu/configuration/configure_input_player.h
+++ b/src/yuzu/configuration/configure_input_player.h
@@ -75,6 +75,18 @@ public:
     /// Updates the list of controller profiles.
     void UpdateInputProfiles();
 
+    /// Renames the specified input profile.
+    void RenameSpecifiedProfile(const std::string& old_name, const std::string& new_name);
+
+    /// Returns the current profile.
+    std::string GetCurrentProfile() const;
+
+    /// Loads the selected controller profile.
+    void LoadProfile();
+
+    /// Saves the current controller configuration into a selected controller profile.
+    void SaveProfile(const std::string& profile_name);
+
     /// Restore all buttons to their default values.
     void RestoreDefaults();
 
@@ -88,12 +100,14 @@ signals:
     void HandheldStateChanged(bool is_handheld);
     /// Emitted when the input devices combobox is being refreshed.
     void RefreshInputDevices();
-    /**
-     * Emitted when the input profiles combobox is being refreshed.
-     * The player_index represents the current player's index, and the profile combobox
-     * will not be updated for this index as they are already updated by other mechanisms.
-     */
-    void RefreshInputProfiles(std::size_t player_index);
+    /// Emitted when the input profiles combobox is being refreshed.
+    void RefreshInputProfiles();
+    /// Emitted when an input profile has been deleted.
+    void InputProfileDeleted();
+    /// Emitted when an input profile has been renamed.
+    void InputProfileRenamed(QString old_name, QString new_name);
+    /// Emitted when a new player tab is selected.
+    void PlayerTabSelected(std::size_t player_index);
 
 protected:
     void showEvent(QShowEvent* event) override;
@@ -155,11 +169,11 @@ private:
     /// Deletes the selected controller profile.
     void DeleteProfile();
 
-    /// Loads the selected controller profile.
-    void LoadProfile();
+    /// Renames the selected input profile.
+    void RenameProfile();
 
-    /// Saves the current controller configuration into a selected controller profile.
-    void SaveProfile();
+    /// Saves the previous controller profile and then loads the new one selected.
+    void ProfileChanged();
 
     std::unique_ptr<Ui::ConfigureInputPlayer> ui;
 
@@ -169,6 +183,8 @@ private:
     InputCommon::InputSubsystem* input_subsystem;
 
     InputProfiles* profiles;
+    std::string current_profile;
+    const std::string unselected_profile = "[none]";
 
     std::unique_ptr<QTimer> timeout_timer;
     std::unique_ptr<QTimer> poll_timer;

--- a/src/yuzu/configuration/configure_input_player.ui
+++ b/src/yuzu/configuration/configure_input_player.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>780</width>
+    <width>923</width>
     <height>487</height>
    </rect>
   </property>
@@ -220,22 +220,6 @@
            </widget>
           </item>
           <item>
-           <widget class="QPushButton" name="buttonProfilesSave">
-            <property name="maximumSize">
-             <size>
-              <width>68</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="styleSheet">
-             <string notr="true">min-width: 68px;</string>
-            </property>
-            <property name="text">
-             <string>Save</string>
-            </property>
-           </widget>
-          </item>
-          <item>
            <widget class="QPushButton" name="buttonProfilesNew">
             <property name="maximumSize">
              <size>
@@ -248,6 +232,22 @@
             </property>
             <property name="text">
              <string>New</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="buttonProfilesRename">
+            <property name="maximumSize">
+             <size>
+              <width>68</width>
+              <height>16777215</height>
+             </size>
+            </property>
+            <property name="styleSheet">
+             <string notr="true">min-width: 68px;</string>
+            </property>
+            <property name="text">
+             <string>Rename</string>
             </property>
            </widget>
           </item>
@@ -412,7 +412,7 @@
                      <widget class="QPushButton" name="buttonLStickUp">
                       <property name="minimumSize">
                        <size>
-                        <width>68</width>
+                        <width>70</width>
                         <height>0</height>
                        </size>
                       </property>
@@ -482,7 +482,7 @@
                     <widget class="QPushButton" name="buttonLStickLeft">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -531,7 +531,7 @@
                     <widget class="QPushButton" name="buttonLStickRight">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -613,7 +613,7 @@
                      <widget class="QPushButton" name="buttonLStickDown">
                       <property name="minimumSize">
                        <size>
-                        <width>68</width>
+                        <width>70</width>
                         <height>0</height>
                        </size>
                       </property>
@@ -683,7 +683,7 @@
                     <widget class="QPushButton" name="buttonLStick">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -732,7 +732,7 @@
                     <widget class="QPushButton" name="buttonLStickMod">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -985,7 +985,7 @@
                      <widget class="QPushButton" name="buttonDpadUp">
                       <property name="minimumSize">
                        <size>
-                        <width>68</width>
+                        <width>70</width>
                         <height>0</height>
                        </size>
                       </property>
@@ -1055,7 +1055,7 @@
                     <widget class="QPushButton" name="buttonDpadLeft">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -1104,7 +1104,7 @@
                     <widget class="QPushButton" name="buttonDpadRight">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -1186,7 +1186,7 @@
                      <widget class="QPushButton" name="buttonDpadDown">
                       <property name="minimumSize">
                        <size>
-                        <width>68</width>
+                        <width>70</width>
                         <height>0</height>
                        </size>
                       </property>
@@ -1311,7 +1311,7 @@
                     <widget class="QPushButton" name="buttonL">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -1360,7 +1360,7 @@
                     <widget class="QPushButton" name="buttonZL">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -1464,7 +1464,7 @@
                     <widget class="QPushButton" name="buttonMinus">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -1513,7 +1513,7 @@
                     <widget class="QPushButton" name="buttonScreenshot">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -1583,7 +1583,7 @@
                     <widget class="QPushButton" name="buttonPlus">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -1632,7 +1632,7 @@
                     <widget class="QPushButton" name="buttonHome">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -1736,7 +1736,7 @@
                     <widget class="QPushButton" name="buttonR">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -1785,7 +1785,7 @@
                     <widget class="QPushButton" name="buttonZR">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -1889,7 +1889,7 @@
                     <widget class="QPushButton" name="buttonSL">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -1938,7 +1938,7 @@
                     <widget class="QPushButton" name="buttonSR">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -2046,7 +2046,7 @@
                  <widget class="QPushButton" name="buttonMotionLeft">
                   <property name="minimumSize">
                    <size>
-                    <width>68</width>
+                    <width>70</width>
                     <height>0</height>
                    </size>
                   </property>
@@ -2095,7 +2095,7 @@
                  <widget class="QPushButton" name="buttonMotionRight">
                   <property name="minimumSize">
                    <size>
-                    <width>68</width>
+                    <width>70</width>
                     <height>0</height>
                    </size>
                   </property>
@@ -2244,7 +2244,7 @@
                      <widget class="QPushButton" name="buttonX">
                       <property name="minimumSize">
                        <size>
-                        <width>68</width>
+                        <width>70</width>
                         <height>0</height>
                        </size>
                       </property>
@@ -2314,7 +2314,7 @@
                     <widget class="QPushButton" name="buttonY">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -2363,7 +2363,7 @@
                     <widget class="QPushButton" name="buttonA">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -2445,7 +2445,7 @@
                      <widget class="QPushButton" name="buttonB">
                       <property name="minimumSize">
                        <size>
-                        <width>68</width>
+                        <width>70</width>
                         <height>0</height>
                        </size>
                       </property>
@@ -2599,7 +2599,7 @@
                      <widget class="QPushButton" name="buttonRStickUp">
                       <property name="minimumSize">
                        <size>
-                        <width>68</width>
+                        <width>70</width>
                         <height>0</height>
                        </size>
                       </property>
@@ -2669,7 +2669,7 @@
                     <widget class="QPushButton" name="buttonRStickLeft">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -2718,7 +2718,7 @@
                     <widget class="QPushButton" name="buttonRStickRight">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -2800,7 +2800,7 @@
                      <widget class="QPushButton" name="buttonRStickDown">
                       <property name="minimumSize">
                        <size>
-                        <width>68</width>
+                        <width>70</width>
                         <height>0</height>
                        </size>
                       </property>
@@ -2870,7 +2870,7 @@
                     <widget class="QPushButton" name="buttonRStick">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>
@@ -2919,7 +2919,7 @@
                     <widget class="QPushButton" name="buttonRStickMod">
                      <property name="minimumSize">
                       <size>
-                       <width>68</width>
+                       <width>70</width>
                        <height>0</height>
                       </size>
                      </property>

--- a/src/yuzu/configuration/input_profiles.h
+++ b/src/yuzu/configuration/input_profiles.h
@@ -8,6 +8,8 @@
 #include <string_view>
 #include <unordered_map>
 
+#include "core/settings.h"
+
 class Config;
 
 class InputProfiles {
@@ -16,17 +18,15 @@ public:
     explicit InputProfiles();
     virtual ~InputProfiles();
 
+    std::unordered_map<std::string, Settings::InputProfile> map_profiles;
+
     std::vector<std::string> GetInputProfileNames();
 
+    bool ProfileExistsInMap(const std::string& profile_name) const;
     static bool IsProfileNameValid(std::string_view profile_name);
 
-    bool CreateProfile(const std::string& profile_name, std::size_t player_index);
-    bool DeleteProfile(const std::string& profile_name);
-    bool LoadProfile(const std::string& profile_name, std::size_t player_index);
-    bool SaveProfile(const std::string& profile_name, std::size_t player_index);
+    void SaveAllProfiles();
 
 private:
-    bool ProfileExistsInMap(const std::string& profile_name) const;
-
-    std::unordered_map<std::string, std::unique_ptr<Config>> map_profiles;
+    std::unordered_map<std::string, std::unique_ptr<Config>> map_profiles_old;
 };


### PR DESCRIPTION
**Functionality**

- The selected profile is saved and loaded between config sessions.
- Removes the save button and instead saves the profiles in a struct and only writes to disk if the configuration is confirmed.
- If multiple players have the same profile selected and you edit button mappings for one of those, it'll change all of them.
- Adds a button to rename profiles.

**Code**

- No longer saves the vibration parameters, as they're applied separately at ConfigureInputPlayer::ApplyConfiguration and when booting games.
- Saves and loads the profiles directly in ConfigureInputPlayer since it need to read the current button mappings, plus there's no more need to have extra checks in the filesystem.
- The default value of PlayerInput::input_profile is currently an empty QString, but if it should be `[none]` I'm thinking it should be a static constexpr char[]. If so, where would be the best way to put it?

**Intentions/Bug testing**
The intended functionality is as mentioned above. Any changes that are made for a player that has an input profile selected is meant to change for all other players that have the same profile selected. I think I've got it working as it should, but if someone want to help bug test they're very welcome to!