### PR TITLE
CMakeLists: Disable YUZU_ENABLE_BOXCAT if ENABLE_WEB_SERVICE is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,10 @@ option(ENABLE_CUBEB "Enables the cubeb audio backend" ON)
 
 option(USE_DISCORD_PRESENCE "Enables Discord Rich Presence" OFF)
 
+if (NOT ENABLE_WEB_SERVICE)
+    set(YUZU_ENABLE_BOXCAT OFF)
+endif()
+
 # Default to a Release build
 get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if (NOT IS_MULTI_CONFIG AND NOT CMAKE_BUILD_TYPE)
@@ -239,7 +243,7 @@ if(ENABLE_QT)
     if (YUZU_USE_QT_WEB_ENGINE)
         find_package(Qt5 COMPONENTS WebEngineCore WebEngineWidgets)
     endif()
-	
+
     if (ENABLE_QT_TRANSLATION)
         find_package(Qt5 REQUIRED COMPONENTS LinguistTools ${QT_PREFIX_HINT})
     endif()
@@ -322,7 +326,7 @@ if (CONAN_REQUIRED_LIBS)
             list(APPEND Boost_LIBRARIES Boost::context)
         endif()
     endif()
-    
+
     # Due to issues with variable scopes in functions, we need to also find_package(qt5) outside of the function
     if(ENABLE_QT)
         list(APPEND CMAKE_MODULE_PATH "${CONAN_QT_ROOT_RELEASE}")


### PR DESCRIPTION
Boxcat is a web service but is still enabled despite ENABLE_WEB_SERVICE's state during CMake generation, causing compilation issues with either missing headers or missing libraries.

If ENABLE_WEB_SERVICE is disabled, this disables YUZU_ENABLE_BOXCAT.

...Apparently, this also strips trailing spaces in the main CMakeLists.txt.

Closes #3269
(The root of that issue from long ago has been otherwise fixed or disappeared. This just fixes a newer issue using the same parameters.)