### PR TITLE
cmake: Enforce C4062, C4265, C4388, and C5038

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,10 +45,14 @@ if (MSVC)
 
         # Warnings
         /W3
+        /we4062 # enumerator 'identifier' in a switch of enum 'enumeration' is not handled
+        /we4265 # 'class': class has virtual functions, but destructor is not virtual
+        /we4388 # signed/unsigned mismatch
         /we4547 # 'operator' : operator before comma has no effect; expected operator with side-effect
         /we4549 # 'operator1': operator before comma has no effect; did you intend 'operator2'?
         /we4555 # Expression has no effect; expected expression with side-effect
         /we4834 # Discarding return value of function with 'nodiscard' attribute
+        /we5038 # data member 'member1' will be initialized after data member 'member2'
     )
 
     # /GS- - No stack buffer overflow checks

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -71,15 +71,8 @@ public:
     }
 
     void ExceptionRaised(u32 pc, Dynarmic::A32::Exception exception) override {
-        switch (exception) {
-        case Dynarmic::A32::Exception::UndefinedInstruction:
-        case Dynarmic::A32::Exception::UnpredictableInstruction:
-            break;
-        case Dynarmic::A32::Exception::Breakpoint:
-            break;
-        }
         LOG_CRITICAL(Core_ARM, "ExceptionRaised(exception = {}, pc = {:08X}, code = {:08X})",
-                     static_cast<std::size_t>(exception), pc, MemoryReadCode(pc));
+                     exception, pc, MemoryReadCode(pc));
         UNIMPLEMENTED();
     }
 

--- a/src/core/file_sys/registered_cache.h
+++ b/src/core/file_sys/registered_cache.h
@@ -67,18 +67,18 @@ public:
     virtual void Refresh() = 0;
 
     virtual bool HasEntry(u64 title_id, ContentRecordType type) const = 0;
-    virtual bool HasEntry(ContentProviderEntry entry) const;
+    bool HasEntry(ContentProviderEntry entry) const;
 
     virtual std::optional<u32> GetEntryVersion(u64 title_id) const = 0;
 
     virtual VirtualFile GetEntryUnparsed(u64 title_id, ContentRecordType type) const = 0;
-    virtual VirtualFile GetEntryUnparsed(ContentProviderEntry entry) const;
+    VirtualFile GetEntryUnparsed(ContentProviderEntry entry) const;
 
     virtual VirtualFile GetEntryRaw(u64 title_id, ContentRecordType type) const = 0;
-    virtual VirtualFile GetEntryRaw(ContentProviderEntry entry) const;
+    VirtualFile GetEntryRaw(ContentProviderEntry entry) const;
 
     virtual std::unique_ptr<NCA> GetEntry(u64 title_id, ContentRecordType type) const = 0;
-    virtual std::unique_ptr<NCA> GetEntry(ContentProviderEntry entry) const;
+    std::unique_ptr<NCA> GetEntry(ContentProviderEntry entry) const;
 
     virtual std::vector<ContentProviderEntry> ListEntries() const;
 

--- a/src/core/hle/service/nvflinger/buffer_queue.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue.cpp
@@ -180,9 +180,11 @@ u32 BufferQueue::Query(QueryType type) {
     switch (type) {
     case QueryType::NativeWindowFormat:
         return static_cast<u32>(PixelFormat::RGBA8888);
+    case QueryType::NativeWindowWidth:
+    case QueryType::NativeWindowHeight:
+        break;
     }
-
-    UNIMPLEMENTED();
+    UNIMPLEMENTED_MSG("Unimplemented query type={}", type);
     return 0;
 }
 

--- a/src/tests/common/ring_buffer.cpp
+++ b/src/tests/common/ring_buffer.cpp
@@ -20,60 +20,60 @@ TEST_CASE("RingBuffer: Basic Tests", "[common]") {
     for (std::size_t i = 0; i < 4; i++) {
         const char elem = static_cast<char>(i);
         const std::size_t count = buf.Push(&elem, 1);
-        REQUIRE(count == 1);
+        REQUIRE(count == 1U);
     }
 
-    REQUIRE(buf.Size() == 4);
+    REQUIRE(buf.Size() == 4U);
 
     // Pushing values into a full ring buffer should fail.
     {
         const char elem = static_cast<char>(42);
         const std::size_t count = buf.Push(&elem, 1);
-        REQUIRE(count == 0);
+        REQUIRE(count == 0U);
     }
 
-    REQUIRE(buf.Size() == 4);
+    REQUIRE(buf.Size() == 4U);
 
     // Popping multiple values from a ring buffer with values should succeed.
     {
         const std::vector<char> popped = buf.Pop(2);
-        REQUIRE(popped.size() == 2);
+        REQUIRE(popped.size() == 2U);
         REQUIRE(popped[0] == 0);
         REQUIRE(popped[1] == 1);
     }
 
-    REQUIRE(buf.Size() == 2);
+    REQUIRE(buf.Size() == 2U);
 
     // Popping a single value from a ring buffer with values should succeed.
     {
         const std::vector<char> popped = buf.Pop(1);
-        REQUIRE(popped.size() == 1);
+        REQUIRE(popped.size() == 1U);
         REQUIRE(popped[0] == 2);
     }
 
-    REQUIRE(buf.Size() == 1);
+    REQUIRE(buf.Size() == 1U);
 
     // Pushing more values than space available should partially suceed.
     {
         std::vector<char> to_push(6);
         std::iota(to_push.begin(), to_push.end(), 88);
         const std::size_t count = buf.Push(to_push);
-        REQUIRE(count == 3);
+        REQUIRE(count == 3U);
     }
 
-    REQUIRE(buf.Size() == 4);
+    REQUIRE(buf.Size() == 4U);
 
     // Doing an unlimited pop should pop all values.
     {
         const std::vector<char> popped = buf.Pop();
-        REQUIRE(popped.size() == 4);
+        REQUIRE(popped.size() == 4U);
         REQUIRE(popped[0] == 3);
         REQUIRE(popped[1] == 88);
         REQUIRE(popped[2] == 89);
         REQUIRE(popped[3] == 90);
     }
 
-    REQUIRE(buf.Size() == 0);
+    REQUIRE(buf.Size() == 0U);
 }
 
 TEST_CASE("RingBuffer: Threaded Test", "[common]") {
@@ -93,7 +93,7 @@ TEST_CASE("RingBuffer: Threaded Test", "[common]") {
         std::size_t i = 0;
         while (i < count) {
             if (const std::size_t c = buf.Push(&value[0], 1); c > 0) {
-                REQUIRE(c == 1);
+                REQUIRE(c == 1U);
                 i++;
                 next_value(value);
             } else {
@@ -108,7 +108,7 @@ TEST_CASE("RingBuffer: Threaded Test", "[common]") {
         std::size_t i = 0;
         while (i < count) {
             if (const std::vector<char> v = buf.Pop(1); v.size() > 0) {
-                REQUIRE(v.size() == 2);
+                REQUIRE(v.size() == 2U);
                 REQUIRE(v[0] == value[0]);
                 REQUIRE(v[1] == value[1]);
                 i++;
@@ -123,7 +123,7 @@ TEST_CASE("RingBuffer: Threaded Test", "[common]") {
     producer.join();
     consumer.join();
 
-    REQUIRE(buf.Size() == 0);
+    REQUIRE(buf.Size() == 0U);
     printf("RingBuffer: Threaded Test: full: %zu, empty: %zu\n", full, empty);
 }
 


### PR DESCRIPTION
This should match some warnings we treat as errors on gcc and clang (-Wswitch and -Wreorder), catching bugs early and reducing the number of instances where we have to edit commits to make CI happy when developing from Windows.