### PR TITLE
common/div_ceil: Return numerator type

### DIFF
--- a/src/common/div_ceil.h
+++ b/src/common/div_ceil.h
@@ -11,16 +11,16 @@ namespace Common {
 
 /// Ceiled integer division.
 template <typename N, typename D>
-requires std::is_integral_v<N>&& std::is_unsigned_v<D>[[nodiscard]] constexpr auto DivCeil(
-    N number, D divisor) {
-    return (static_cast<D>(number) + divisor - 1) / divisor;
+requires std::is_integral_v<N>&& std::is_unsigned_v<D>[[nodiscard]] constexpr N DivCeil(N number,
+                                                                                        D divisor) {
+    return static_cast<N>((static_cast<D>(number) + divisor - 1) / divisor);
 }
 
 /// Ceiled integer division with logarithmic divisor in base 2
 template <typename N, typename D>
-requires std::is_integral_v<N>&& std::is_unsigned_v<D>[[nodiscard]] constexpr auto DivCeilLog2(
+requires std::is_integral_v<N>&& std::is_unsigned_v<D>[[nodiscard]] constexpr N DivCeilLog2(
     N value, D alignment_log2) {
-    return (static_cast<D>(value) + (D(1) << alignment_log2) - 1) >> alignment_log2;
+    return static_cast<N>((static_cast<D>(value) + (D(1) << alignment_log2) - 1) >> alignment_log2);
 }
 
 } // namespace Common


### PR DESCRIPTION
Fixes instances where DivCeil(u32, u64) would surprisingly return u64, instead of the more natural u32.