### PR TITLE
config: Enable docked mode by default

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -514,7 +514,7 @@ void Config::ReadControlValues() {
     Settings::values.emulate_analog_keyboard =
         ReadSetting(QStringLiteral("emulate_analog_keyboard"), false).toBool();
 
-    ReadSettingGlobal(Settings::values.use_docked_mode, QStringLiteral("use_docked_mode"), false);
+    ReadSettingGlobal(Settings::values.use_docked_mode, QStringLiteral("use_docked_mode"), true);
     ReadSettingGlobal(Settings::values.vibration_enabled, QStringLiteral("vibration_enabled"),
                       true);
     ReadSettingGlobal(Settings::values.enable_accurate_vibrations,
@@ -1176,7 +1176,7 @@ void Config::SaveControlValues() {
     SaveTouchscreenValues();
     SaveMotionTouchValues();
 
-    WriteSettingGlobal(QStringLiteral("use_docked_mode"), Settings::values.use_docked_mode, false);
+    WriteSettingGlobal(QStringLiteral("use_docked_mode"), Settings::values.use_docked_mode, true);
     WriteSettingGlobal(QStringLiteral("vibration_enabled"), Settings::values.vibration_enabled,
                        true);
     WriteSettingGlobal(QStringLiteral("enable_accurate_vibrations"),

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -344,7 +344,7 @@ void Config::ReadValues() {
 
     // System
     Settings::values.use_docked_mode.SetValue(
-        sdl2_config->GetBoolean("System", "use_docked_mode", false));
+        sdl2_config->GetBoolean("System", "use_docked_mode", true));
 
     Settings::values.current_user = std::clamp<int>(
         sdl2_config->GetInteger("System", "current_user", 0), 0, Service::Account::MAX_USERS - 1);

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -274,7 +274,7 @@ gamecard_path =
 
 [System]
 # Whether the system is docked
-# 1: Yes, 0 (default): No
+# 1 (default): Yes, 0: No
 use_docked_mode =
 
 # Allow the use of NFC in games

--- a/src/yuzu_tester/config.cpp
+++ b/src/yuzu_tester/config.cpp
@@ -86,7 +86,7 @@ void Config::ReadValues() {
     Settings::values.touchscreen.diameter_y = 15;
 
     Settings::values.use_docked_mode.SetValue(
-        sdl2_config->GetBoolean("Controls", "use_docked_mode", false));
+        sdl2_config->GetBoolean("Controls", "use_docked_mode", true));
 
     // Data Storage
     Settings::values.use_virtual_sd =

--- a/src/yuzu_tester/default_ini.h
+++ b/src/yuzu_tester/default_ini.h
@@ -116,7 +116,7 @@ use_virtual_sd =
 
 [System]
 # Whether the system is docked
-# 1: Yes, 0 (default): No
+# 1 (default): Yes, 0: No
 use_docked_mode =
 
 # Allow the use of NFC in games


### PR DESCRIPTION
Enables the docked mode by default.

This has 2 advantages:
1. Makes games run at their best quality/resolution.
2. A workaround for the SMO flickering issue when GLASM (OpenGL Assembly Shaders) is enabled with a NVIDIA GPU in undocked mode.