### PR TITLE
HID: Update the HID service to match more closely to switchbrew part 1

### DIFF
--- a/src/core/hle/service/am/applets/controller.cpp
+++ b/src/core/hle/service/am/applets/controller.cpp
@@ -37,7 +37,7 @@ static Core::Frontend::ControllerParameters ConvertToFrontendParameters(
         .border_colors = std::move(identification_colors),
         .enable_explain_text = enable_text,
         .explain_text = std::move(text),
-        .allow_pro_controller = npad_style_set.pro_controller == 1,
+        .allow_pro_controller = npad_style_set.fullkey == 1,
         .allow_handheld = npad_style_set.handheld == 1,
         .allow_dual_joycons = npad_style_set.joycon_dual == 1,
         .allow_left_joycon = npad_style_set.joycon_left == 1,

--- a/src/core/hle/service/hid/controllers/keyboard.cpp
+++ b/src/core/hle/service/hid/controllers/keyboard.cpp
@@ -39,16 +39,25 @@ void Controller_Keyboard::OnUpdate(const Core::Timing::CoreTiming& core_timing, 
     cur_entry.sampling_number2 = cur_entry.sampling_number;
 
     cur_entry.key.fill(0);
-    cur_entry.modifier = 0;
     if (Settings::values.keyboard_enabled) {
         for (std::size_t i = 0; i < keyboard_keys.size(); ++i) {
             auto& entry = cur_entry.key[i / KEYS_PER_BYTE];
             entry = static_cast<u8>(entry | (keyboard_keys[i]->GetStatus() << (i % KEYS_PER_BYTE)));
         }
 
-        for (std::size_t i = 0; i < keyboard_mods.size(); ++i) {
-            cur_entry.modifier |= (keyboard_mods[i]->GetStatus() << i);
-        }
+        using namespace Settings::NativeKeyboard;
+
+        // TODO: Assign the correct key to all modifiers
+        cur_entry.modifier.control.Assign(keyboard_mods[LeftControl]->GetStatus());
+        cur_entry.modifier.shift.Assign(keyboard_mods[LeftShift]->GetStatus());
+        cur_entry.modifier.left_alt.Assign(keyboard_mods[LeftAlt]->GetStatus());
+        cur_entry.modifier.right_alt.Assign(keyboard_mods[RightAlt]->GetStatus());
+        cur_entry.modifier.gui.Assign(0);
+        cur_entry.modifier.caps_lock.Assign(keyboard_mods[CapsLock]->GetStatus());
+        cur_entry.modifier.scroll_lock.Assign(keyboard_mods[ScrollLock]->GetStatus());
+        cur_entry.modifier.num_lock.Assign(keyboard_mods[NumLock]->GetStatus());
+        cur_entry.modifier.katana.Assign(0);
+        cur_entry.modifier.hiragana.Assign(0);
     }
     std::memcpy(data + SHARED_MEMORY_OFFSET, &shared_memory, sizeof(SharedMemory));
 }

--- a/src/core/hle/service/hid/controllers/keyboard.cpp
+++ b/src/core/hle/service/hid/controllers/keyboard.cpp
@@ -56,7 +56,7 @@ void Controller_Keyboard::OnUpdate(const Core::Timing::CoreTiming& core_timing, 
         cur_entry.modifier.caps_lock.Assign(keyboard_mods[CapsLock]->GetStatus());
         cur_entry.modifier.scroll_lock.Assign(keyboard_mods[ScrollLock]->GetStatus());
         cur_entry.modifier.num_lock.Assign(keyboard_mods[NumLock]->GetStatus());
-        cur_entry.modifier.katana.Assign(0);
+        cur_entry.modifier.katakana.Assign(0);
         cur_entry.modifier.hiragana.Assign(0);
     }
     std::memcpy(data + SHARED_MEMORY_OFFSET, &shared_memory, sizeof(SharedMemory));

--- a/src/core/hle/service/hid/controllers/keyboard.h
+++ b/src/core/hle/service/hid/controllers/keyboard.h
@@ -34,7 +34,7 @@ public:
 private:
     struct Modifiers {
         union {
-            s32_le raw{};
+            u32_le raw{};
             BitField<0, 1, u32> control;
             BitField<1, 1, u32> shift;
             BitField<2, 1, u32> left_alt;
@@ -43,7 +43,7 @@ private:
             BitField<8, 1, u32> caps_lock;
             BitField<9, 1, u32> scroll_lock;
             BitField<10, 1, u32> num_lock;
-            BitField<11, 1, u32> katana;
+            BitField<11, 1, u32> katakana;
             BitField<12, 1, u32> hiragana;
         };
     };

--- a/src/core/hle/service/hid/controllers/keyboard.h
+++ b/src/core/hle/service/hid/controllers/keyboard.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include "common/bit_field.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
@@ -31,12 +32,28 @@ public:
     void OnLoadInputDevices() override;
 
 private:
+    struct Modifiers {
+        union {
+            s32_le raw{};
+            BitField<0, 1, u32> control;
+            BitField<1, 1, u32> shift;
+            BitField<2, 1, u32> left_alt;
+            BitField<3, 1, u32> right_alt;
+            BitField<4, 1, u32> gui;
+            BitField<8, 1, u32> caps_lock;
+            BitField<9, 1, u32> scroll_lock;
+            BitField<10, 1, u32> num_lock;
+            BitField<11, 1, u32> katana;
+            BitField<12, 1, u32> hiragana;
+        };
+    };
+    static_assert(sizeof(Modifiers) == 0x4, "Modifiers is an invalid size");
+
     struct KeyboardState {
         s64_le sampling_number;
         s64_le sampling_number2;
 
-        s32_le modifier;
-        s32_le attribute;
+        Modifiers modifier;
         std::array<u8, 32> key;
     };
     static_assert(sizeof(KeyboardState) == 0x38, "KeyboardState is an invalid size");

--- a/src/core/hle/service/hid/controllers/mouse.cpp
+++ b/src/core/hle/service/hid/controllers/mouse.cpp
@@ -35,7 +35,7 @@ void Controller_Mouse::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8*
 
     cur_entry.sampling_number = last_entry.sampling_number + 1;
     cur_entry.sampling_number2 = cur_entry.sampling_number;
-
+    cur_entry.attribute.raw = 0;
     if (Settings::values.mouse_enabled) {
         const auto [px, py, sx, sy] = mouse_device->GetStatus();
         const auto x = static_cast<s32>(px * Layout::ScreenUndocked::Width);
@@ -46,10 +46,14 @@ void Controller_Mouse::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8*
         cur_entry.delta_y = y - last_entry.y;
         cur_entry.mouse_wheel_x = sx;
         cur_entry.mouse_wheel_y = sy;
+        cur_entry.attribute.is_connected.Assign(1);
 
-        for (std::size_t i = 0; i < mouse_button_devices.size(); ++i) {
-            cur_entry.button |= (mouse_button_devices[i]->GetStatus() << i);
-        }
+        using namespace Settings::NativeMouseButton;
+        cur_entry.button.left.Assign(mouse_button_devices[Left]->GetStatus());
+        cur_entry.button.right.Assign(mouse_button_devices[Right]->GetStatus());
+        cur_entry.button.middle.Assign(mouse_button_devices[Middle]->GetStatus());
+        cur_entry.button.forward.Assign(mouse_button_devices[Forward]->GetStatus());
+        cur_entry.button.back.Assign(mouse_button_devices[Back]->GetStatus());
     }
 
     std::memcpy(data + SHARED_MEMORY_OFFSET, &shared_memory, sizeof(SharedMemory));

--- a/src/core/hle/service/hid/controllers/mouse.cpp
+++ b/src/core/hle/service/hid/controllers/mouse.cpp
@@ -35,6 +35,7 @@ void Controller_Mouse::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8*
 
     cur_entry.sampling_number = last_entry.sampling_number + 1;
     cur_entry.sampling_number2 = cur_entry.sampling_number;
+
     cur_entry.attribute.raw = 0;
     if (Settings::values.mouse_enabled) {
         const auto [px, py, sx, sy] = mouse_device->GetStatus();

--- a/src/core/hle/service/hid/controllers/mouse.h
+++ b/src/core/hle/service/hid/controllers/mouse.h
@@ -33,7 +33,7 @@ public:
 private:
     struct Buttons {
         union {
-            s32_le raw{};
+            u32_le raw{};
             BitField<0, 1, u32> left;
             BitField<1, 1, u32> right;
             BitField<2, 1, u32> middle;
@@ -45,7 +45,7 @@ private:
 
     struct Attributes {
         union {
-            s32_le raw{};
+            u32_le raw{};
             BitField<0, 1, u32> transferable;
             BitField<1, 1, u32> is_connected;
         };

--- a/src/core/hle/service/hid/controllers/mouse.h
+++ b/src/core/hle/service/hid/controllers/mouse.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include "common/bit_field.h"
 #include "common/common_types.h"
 #include "common/swap.h"
 #include "core/frontend/input.h"
@@ -30,6 +31,27 @@ public:
     void OnLoadInputDevices() override;
 
 private:
+    struct Buttons {
+        union {
+            s32_le raw{};
+            BitField<0, 1, u32> left;
+            BitField<1, 1, u32> right;
+            BitField<2, 1, u32> middle;
+            BitField<3, 1, u32> forward;
+            BitField<4, 1, u32> back;
+        };
+    };
+    static_assert(sizeof(Buttons) == 0x4, "Buttons is an invalid size");
+
+    struct Attributes {
+        union {
+            s32_le raw{};
+            BitField<0, 1, u32> transferable;
+            BitField<1, 1, u32> is_connected;
+        };
+    };
+    static_assert(sizeof(Attributes) == 0x4, "Attributes is an invalid size");
+
     struct MouseState {
         s64_le sampling_number;
         s64_le sampling_number2;
@@ -39,8 +61,8 @@ private:
         s32_le delta_y;
         s32_le mouse_wheel_x;
         s32_le mouse_wheel_y;
-        s32_le button;
-        s32_le attribute;
+        Buttons button;
+        Attributes attribute;
     };
     static_assert(sizeof(MouseState) == 0x30, "MouseState is an invalid size");
 

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -609,7 +609,9 @@ void Controller_NPad::OnMotionUpdate(const Core::Timing::CoreTiming& core_timing
             UNREACHABLE();
             break;
         case NPadControllerType::ProController:
+            full_sixaxis_entry.attribute.raw = 0;
             if (sixaxis_sensors_enabled && motions[i][0]) {
+                full_sixaxis_entry.attribute.IsConnected.Assign(1);
                 full_sixaxis_entry.accel = motion_devices[0].accel;
                 full_sixaxis_entry.gyro = motion_devices[0].gyro;
                 full_sixaxis_entry.rotation = motion_devices[0].rotation;
@@ -617,7 +619,9 @@ void Controller_NPad::OnMotionUpdate(const Core::Timing::CoreTiming& core_timing
             }
             break;
         case NPadControllerType::Handheld:
+            handheld_sixaxis_entry.attribute.raw = 0;
             if (sixaxis_sensors_enabled && motions[i][0]) {
+                handheld_sixaxis_entry.attribute.IsConnected.Assign(1);
                 handheld_sixaxis_entry.accel = motion_devices[0].accel;
                 handheld_sixaxis_entry.gyro = motion_devices[0].gyro;
                 handheld_sixaxis_entry.rotation = motion_devices[0].rotation;
@@ -625,8 +629,11 @@ void Controller_NPad::OnMotionUpdate(const Core::Timing::CoreTiming& core_timing
             }
             break;
         case NPadControllerType::JoyDual:
+            dual_left_sixaxis_entry.attribute.raw = 0;
+            dual_right_sixaxis_entry.attribute.raw = 0;
             if (sixaxis_sensors_enabled && motions[i][0]) {
                 // Set motion for the left joycon
+                dual_left_sixaxis_entry.attribute.IsConnected.Assign(1);
                 dual_left_sixaxis_entry.accel = motion_devices[0].accel;
                 dual_left_sixaxis_entry.gyro = motion_devices[0].gyro;
                 dual_left_sixaxis_entry.rotation = motion_devices[0].rotation;
@@ -634,6 +641,7 @@ void Controller_NPad::OnMotionUpdate(const Core::Timing::CoreTiming& core_timing
             }
             if (sixaxis_sensors_enabled && motions[i][1]) {
                 // Set motion for the right joycon
+                dual_right_sixaxis_entry.attribute.IsConnected.Assign(1);
                 dual_right_sixaxis_entry.accel = motion_devices[1].accel;
                 dual_right_sixaxis_entry.gyro = motion_devices[1].gyro;
                 dual_right_sixaxis_entry.rotation = motion_devices[1].rotation;
@@ -641,7 +649,9 @@ void Controller_NPad::OnMotionUpdate(const Core::Timing::CoreTiming& core_timing
             }
             break;
         case NPadControllerType::JoyLeft:
+            left_sixaxis_entry.attribute.raw = 0;
             if (sixaxis_sensors_enabled && motions[i][0]) {
+                left_sixaxis_entry.attribute.IsConnected.Assign(1);
                 left_sixaxis_entry.accel = motion_devices[0].accel;
                 left_sixaxis_entry.gyro = motion_devices[0].gyro;
                 left_sixaxis_entry.rotation = motion_devices[0].rotation;
@@ -649,7 +659,9 @@ void Controller_NPad::OnMotionUpdate(const Core::Timing::CoreTiming& core_timing
             }
             break;
         case NPadControllerType::JoyRight:
+            right_sixaxis_entry.attribute.raw = 0;
             if (sixaxis_sensors_enabled && motions[i][1]) {
+                right_sixaxis_entry.attribute.IsConnected.Assign(1);
                 right_sixaxis_entry.accel = motion_devices[1].accel;
                 right_sixaxis_entry.gyro = motion_devices[1].gyro;
                 right_sixaxis_entry.rotation = motion_devices[1].rotation;

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -170,6 +170,7 @@ void Controller_NPad::InitNewlyAddedController(std::size_t controller_idx) {
         controller.system_properties.use_plus.Assign(1);
         controller.system_properties.use_minus.Assign(1);
         controller.assignment_mode = NpadAssignments::Single;
+        controller.footer_type = AppletFooterUiType::SwitchProController;
         break;
     case NPadControllerType::Handheld:
         controller.style_set.handheld.Assign(1);
@@ -179,6 +180,7 @@ void Controller_NPad::InitNewlyAddedController(std::size_t controller_idx) {
         controller.system_properties.use_plus.Assign(1);
         controller.system_properties.use_minus.Assign(1);
         controller.assignment_mode = NpadAssignments::Dual;
+        controller.footer_type = AppletFooterUiType::HandheldJoyConLeftJoyConRight;
         break;
     case NPadControllerType::JoyDual:
         controller.style_set.joycon_dual.Assign(1);
@@ -188,6 +190,7 @@ void Controller_NPad::InitNewlyAddedController(std::size_t controller_idx) {
         controller.system_properties.use_plus.Assign(1);
         controller.system_properties.use_minus.Assign(1);
         controller.assignment_mode = NpadAssignments::Dual;
+        controller.footer_type = AppletFooterUiType::JoyDual;
         break;
     case NPadControllerType::JoyLeft:
         controller.style_set.joycon_left.Assign(1);
@@ -195,6 +198,7 @@ void Controller_NPad::InitNewlyAddedController(std::size_t controller_idx) {
         controller.system_properties.is_horizontal.Assign(1);
         controller.system_properties.use_minus.Assign(1);
         controller.assignment_mode = NpadAssignments::Single;
+        controller.footer_type = AppletFooterUiType::JoyLeftHorizontal;
         break;
     case NPadControllerType::JoyRight:
         controller.style_set.joycon_right.Assign(1);
@@ -202,6 +206,7 @@ void Controller_NPad::InitNewlyAddedController(std::size_t controller_idx) {
         controller.system_properties.is_horizontal.Assign(1);
         controller.system_properties.use_plus.Assign(1);
         controller.assignment_mode = NpadAssignments::Single;
+        controller.footer_type = AppletFooterUiType::JoyRightHorizontal;
         break;
     case NPadControllerType::Pokeball:
         controller.style_set.palma.Assign(1);
@@ -224,6 +229,7 @@ void Controller_NPad::InitNewlyAddedController(std::size_t controller_idx) {
     controller.joycon_color.right.button =
         Settings::values.players.GetValue()[controller_idx].button_color_right;
 
+    // TODO: Investigate when we should report all batery types
     controller.battery_level_dual = BATTERY_FULL;
     controller.battery_level_left = BATTERY_FULL;
     controller.battery_level_right = BATTERY_FULL;
@@ -450,7 +456,7 @@ void Controller_NPad::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* 
             npad.system_ext_states.npad[npad.system_ext_states.common.last_entry_index];
 
         libnx_entry.connection_status.raw = 0;
-        libnx_entry.connection_status.IsConnected.Assign(1);
+        libnx_entry.connection_status.is_connected.Assign(1);
 
         switch (controller_type) {
         case NPadControllerType::None:
@@ -458,67 +464,67 @@ void Controller_NPad::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* 
             break;
         case NPadControllerType::ProController:
             main_controller.connection_status.raw = 0;
-            main_controller.connection_status.IsConnected.Assign(1);
-            main_controller.connection_status.IsWired.Assign(1);
+            main_controller.connection_status.is_connected.Assign(1);
+            main_controller.connection_status.is_wired.Assign(1);
             main_controller.pad.pad_states.raw = pad_state.pad_states.raw;
             main_controller.pad.l_stick = pad_state.l_stick;
             main_controller.pad.r_stick = pad_state.r_stick;
 
-            libnx_entry.connection_status.IsWired.Assign(1);
+            libnx_entry.connection_status.is_wired.Assign(1);
             break;
         case NPadControllerType::Handheld:
             handheld_entry.connection_status.raw = 0;
-            handheld_entry.connection_status.IsConnected.Assign(1);
-            handheld_entry.connection_status.IsWired.Assign(1);
-            handheld_entry.connection_status.IsLeftJoyConnected.Assign(1);
-            handheld_entry.connection_status.IsRightJoyConnected.Assign(1);
-            handheld_entry.connection_status.IsLeftJoyWired.Assign(1);
-            handheld_entry.connection_status.IsRightJoyWired.Assign(1);
+            handheld_entry.connection_status.is_connected.Assign(1);
+            handheld_entry.connection_status.is_wired.Assign(1);
+            handheld_entry.connection_status.is_left_connected.Assign(1);
+            handheld_entry.connection_status.is_right_connected.Assign(1);
+            handheld_entry.connection_status.is_left_wired.Assign(1);
+            handheld_entry.connection_status.is_right_wired.Assign(1);
             handheld_entry.pad.pad_states.raw = pad_state.pad_states.raw;
             handheld_entry.pad.l_stick = pad_state.l_stick;
             handheld_entry.pad.r_stick = pad_state.r_stick;
 
-            libnx_entry.connection_status.IsWired.Assign(1);
-            libnx_entry.connection_status.IsLeftJoyConnected.Assign(1);
-            libnx_entry.connection_status.IsRightJoyConnected.Assign(1);
-            libnx_entry.connection_status.IsLeftJoyWired.Assign(1);
-            libnx_entry.connection_status.IsRightJoyWired.Assign(1);
+            libnx_entry.connection_status.is_wired.Assign(1);
+            libnx_entry.connection_status.is_left_connected.Assign(1);
+            libnx_entry.connection_status.is_right_connected.Assign(1);
+            libnx_entry.connection_status.is_left_wired.Assign(1);
+            libnx_entry.connection_status.is_right_wired.Assign(1);
             break;
         case NPadControllerType::JoyDual:
             dual_entry.connection_status.raw = 0;
-            dual_entry.connection_status.IsConnected.Assign(1);
-            dual_entry.connection_status.IsLeftJoyConnected.Assign(1);
-            dual_entry.connection_status.IsRightJoyConnected.Assign(1);
+            dual_entry.connection_status.is_connected.Assign(1);
+            dual_entry.connection_status.is_left_connected.Assign(1);
+            dual_entry.connection_status.is_right_connected.Assign(1);
             dual_entry.pad.pad_states.raw = pad_state.pad_states.raw;
             dual_entry.pad.l_stick = pad_state.l_stick;
             dual_entry.pad.r_stick = pad_state.r_stick;
 
-            libnx_entry.connection_status.IsLeftJoyConnected.Assign(1);
-            libnx_entry.connection_status.IsRightJoyConnected.Assign(1);
+            libnx_entry.connection_status.is_left_connected.Assign(1);
+            libnx_entry.connection_status.is_right_connected.Assign(1);
             break;
         case NPadControllerType::JoyLeft:
             left_entry.connection_status.raw = 0;
-            left_entry.connection_status.IsConnected.Assign(1);
-            left_entry.connection_status.IsLeftJoyConnected.Assign(1);
+            left_entry.connection_status.is_connected.Assign(1);
+            left_entry.connection_status.is_left_connected.Assign(1);
             left_entry.pad.pad_states.raw = pad_state.pad_states.raw;
             left_entry.pad.l_stick = pad_state.l_stick;
             left_entry.pad.r_stick = pad_state.r_stick;
 
-            libnx_entry.connection_status.IsLeftJoyConnected.Assign(1);
+            libnx_entry.connection_status.is_left_connected.Assign(1);
             break;
         case NPadControllerType::JoyRight:
             right_entry.connection_status.raw = 0;
-            right_entry.connection_status.IsConnected.Assign(1);
-            right_entry.connection_status.IsRightJoyConnected.Assign(1);
+            right_entry.connection_status.is_connected.Assign(1);
+            right_entry.connection_status.is_right_connected.Assign(1);
             right_entry.pad.pad_states.raw = pad_state.pad_states.raw;
             right_entry.pad.l_stick = pad_state.l_stick;
             right_entry.pad.r_stick = pad_state.r_stick;
 
-            libnx_entry.connection_status.IsRightJoyConnected.Assign(1);
+            libnx_entry.connection_status.is_right_connected.Assign(1);
             break;
         case NPadControllerType::Pokeball:
             pokeball_entry.connection_status.raw = 0;
-            pokeball_entry.connection_status.IsConnected.Assign(1);
+            pokeball_entry.connection_status.is_connected.Assign(1);
             pokeball_entry.pad.pad_states.raw = pad_state.pad_states.raw;
             pokeball_entry.pad.l_stick = pad_state.l_stick;
             pokeball_entry.pad.r_stick = pad_state.r_stick;
@@ -609,7 +615,7 @@ void Controller_NPad::OnMotionUpdate(const Core::Timing::CoreTiming& core_timing
         case NPadControllerType::ProController:
             full_sixaxis_entry.attribute.raw = 0;
             if (sixaxis_sensors_enabled && motions[i][0]) {
-                full_sixaxis_entry.attribute.IsConnected.Assign(1);
+                full_sixaxis_entry.attribute.is_connected.Assign(1);
                 full_sixaxis_entry.accel = motion_devices[0].accel;
                 full_sixaxis_entry.gyro = motion_devices[0].gyro;
                 full_sixaxis_entry.rotation = motion_devices[0].rotation;
@@ -619,7 +625,7 @@ void Controller_NPad::OnMotionUpdate(const Core::Timing::CoreTiming& core_timing
         case NPadControllerType::Handheld:
             handheld_sixaxis_entry.attribute.raw = 0;
             if (sixaxis_sensors_enabled && motions[i][0]) {
-                handheld_sixaxis_entry.attribute.IsConnected.Assign(1);
+                handheld_sixaxis_entry.attribute.is_connected.Assign(1);
                 handheld_sixaxis_entry.accel = motion_devices[0].accel;
                 handheld_sixaxis_entry.gyro = motion_devices[0].gyro;
                 handheld_sixaxis_entry.rotation = motion_devices[0].rotation;
@@ -631,7 +637,7 @@ void Controller_NPad::OnMotionUpdate(const Core::Timing::CoreTiming& core_timing
             dual_right_sixaxis_entry.attribute.raw = 0;
             if (sixaxis_sensors_enabled && motions[i][0]) {
                 // Set motion for the left joycon
-                dual_left_sixaxis_entry.attribute.IsConnected.Assign(1);
+                dual_left_sixaxis_entry.attribute.is_connected.Assign(1);
                 dual_left_sixaxis_entry.accel = motion_devices[0].accel;
                 dual_left_sixaxis_entry.gyro = motion_devices[0].gyro;
                 dual_left_sixaxis_entry.rotation = motion_devices[0].rotation;
@@ -639,7 +645,7 @@ void Controller_NPad::OnMotionUpdate(const Core::Timing::CoreTiming& core_timing
             }
             if (sixaxis_sensors_enabled && motions[i][1]) {
                 // Set motion for the right joycon
-                dual_right_sixaxis_entry.attribute.IsConnected.Assign(1);
+                dual_right_sixaxis_entry.attribute.is_connected.Assign(1);
                 dual_right_sixaxis_entry.accel = motion_devices[1].accel;
                 dual_right_sixaxis_entry.gyro = motion_devices[1].gyro;
                 dual_right_sixaxis_entry.rotation = motion_devices[1].rotation;
@@ -649,7 +655,7 @@ void Controller_NPad::OnMotionUpdate(const Core::Timing::CoreTiming& core_timing
         case NPadControllerType::JoyLeft:
             left_sixaxis_entry.attribute.raw = 0;
             if (sixaxis_sensors_enabled && motions[i][0]) {
-                left_sixaxis_entry.attribute.IsConnected.Assign(1);
+                left_sixaxis_entry.attribute.is_connected.Assign(1);
                 left_sixaxis_entry.accel = motion_devices[0].accel;
                 left_sixaxis_entry.gyro = motion_devices[0].gyro;
                 left_sixaxis_entry.rotation = motion_devices[0].rotation;
@@ -659,7 +665,7 @@ void Controller_NPad::OnMotionUpdate(const Core::Timing::CoreTiming& core_timing
         case NPadControllerType::JoyRight:
             right_sixaxis_entry.attribute.raw = 0;
             if (sixaxis_sensors_enabled && motions[i][1]) {
-                right_sixaxis_entry.attribute.IsConnected.Assign(1);
+                right_sixaxis_entry.attribute.is_connected.Assign(1);
                 right_sixaxis_entry.accel = motion_devices[1].accel;
                 right_sixaxis_entry.gyro = motion_devices[1].gyro;
                 right_sixaxis_entry.rotation = motion_devices[1].rotation;
@@ -937,6 +943,13 @@ void Controller_NPad::DisconnectNpadAtIndex(std::size_t npad_index) {
     controller.device_type.raw = 0;
     controller.system_properties.raw = 0;
     controller.button_properties.raw = 0;
+    controller.battery_level_dual = 0;
+    controller.battery_level_left = 0;
+    controller.battery_level_right = 0;
+    controller.fullkey_color = {};
+    controller.joycon_color = {};
+    controller.assignment_mode = NpadAssignments::Dual;
+    controller.footer_type = AppletFooterUiType::None;
 
     SignalStyleSetChangedEvent(IndexToNPad(npad_index));
 }

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -113,8 +113,13 @@ public:
             BitField<2, 1, u32> joycon_dual;
             BitField<3, 1, u32> joycon_left;
             BitField<4, 1, u32> joycon_right;
-
-            BitField<6, 1, u32> pokeball; // TODO(ogniK): Confirm when possible
+            BitField<5, 1, u32> gamecube;
+            BitField<6, 1, u32> pokeball;
+            BitField<7, 1, u32> lark;
+            BitField<8, 1, u32> handheld_lark;
+            BitField<9, 1, u32> lucia;
+            BitField<29, 1, u32> system_ext;
+            BitField<30, 1, u32> system;
         };
     };
     static_assert(sizeof(NpadStyleSet) == 4, "NpadStyleSet is an invalid size");
@@ -285,6 +290,9 @@ private:
 
             BitField<26, 1, u64> right_sl;
             BitField<27, 1, u64> right_sr;
+
+            BitField<28, 1, u64> palma;
+            BitField<30, 1, u64> handheld_left_b;
         };
     };
     static_assert(sizeof(ControllerPadState) == 8, "ControllerPadState is an invalid size");
@@ -329,6 +337,15 @@ private:
     };
     static_assert(sizeof(NPadGeneric) == 0x350, "NPadGeneric is an invalid size");
 
+    struct SixAxisAttributes {
+        union {
+            u32_le raw{};
+            BitField<0, 1, u32> IsConnected;
+            BitField<1, 1, u32> IsInterpolated;
+        };
+    };
+    static_assert(sizeof(SixAxisAttributes) == 4, "SixAxisAttributes is an invalid size");
+
     struct SixAxisStates {
         s64_le timestamp{};
         INSERT_PADDING_WORDS(2);
@@ -337,7 +354,8 @@ private:
         Common::Vec3f gyro{};
         Common::Vec3f rotation{};
         std::array<Common::Vec3f, 3> orientation{};
-        s64_le always_one{1};
+        SixAxisAttributes attribute;
+        INSERT_PADDING_BYTES(4); // Reserved
     };
     static_assert(sizeof(SixAxisStates) == 0x68, "SixAxisStates is an invalid size");
 
@@ -356,10 +374,19 @@ private:
     struct NPadProperties {
         union {
             s64_le raw{};
+            BitField<0, 1, s64> is_charging_joy_dual;
+            BitField<1, 1, s64> is_charging_joy_left;
+            BitField<2, 1, s64> is_charging_joy_right;
+            BitField<3, 1, s64> is_powered_joy_dual;
+            BitField<4, 1, s64> is_powered_joy_left;
+            BitField<5, 1, s64> is_powered_joy_right;
+            BitField<9, 1, s64> is_system_unsuported_button;
+            BitField<10, 1, s64> is_system_ext_unsuported_button;
             BitField<11, 1, s64> is_vertical;
             BitField<12, 1, s64> is_horizontal;
             BitField<13, 1, s64> use_plus;
             BitField<14, 1, s64> use_minus;
+            BitField<15, 1, s64> use_directional_buttons;
         };
     };
 

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -326,12 +326,12 @@ private:
     struct ConnectionState {
         union {
             u32_le raw{};
-            BitField<0, 1, u32> IsConnected;
-            BitField<1, 1, u32> IsWired;
-            BitField<2, 1, u32> IsLeftJoyConnected;
-            BitField<3, 1, u32> IsLeftJoyWired;
-            BitField<4, 1, u32> IsRightJoyConnected;
-            BitField<5, 1, u32> IsRightJoyWired;
+            BitField<0, 1, u32> is_connected;
+            BitField<1, 1, u32> is_wired;
+            BitField<2, 1, u32> is_left_connected;
+            BitField<3, 1, u32> is_left_wired;
+            BitField<4, 1, u32> is_right_connected;
+            BitField<5, 1, u32> is_right_wired;
         };
     };
     static_assert(sizeof(ConnectionState) == 4, "ConnectionState is an invalid size");
@@ -360,8 +360,8 @@ private:
     struct SixAxisAttributes {
         union {
             u32_le raw{};
-            BitField<0, 1, u32> IsConnected;
-            BitField<1, 1, u32> IsInterpolated;
+            BitField<0, 1, u32> is_connected;
+            BitField<1, 1, u32> is_interpolated;
         };
     };
     static_assert(sizeof(SixAxisAttributes) == 4, "SixAxisAttributes is an invalid size");
@@ -394,8 +394,8 @@ private:
             BitField<3, 1, s64> is_powered_joy_dual;
             BitField<4, 1, s64> is_powered_joy_left;
             BitField<5, 1, s64> is_powered_joy_right;
-            BitField<9, 1, s64> is_system_unsuported_button;
-            BitField<10, 1, s64> is_system_ext_unsuported_button;
+            BitField<9, 1, s64> is_system_unsupported_button;
+            BitField<10, 1, s64> is_system_ext_unsupported_button;
             BitField<11, 1, s64> is_vertical;
             BitField<12, 1, s64> is_horizontal;
             BitField<13, 1, s64> use_plus;
@@ -443,6 +443,38 @@ private:
         std::array<Common::Vec3f, 3> orientation;
     };
 
+    struct NfcXcdHandle {
+        INSERT_PADDING_BYTES(0x60);
+    };
+
+    struct AppletFooterUiAttributes {
+        INSERT_PADDING_BYTES(0x4);
+    };
+
+    enum class AppletFooterUiType : u8 {
+        None = 0,
+        HandheldNone = 1,
+        HandheldJoyConLeftOnly = 1,
+        HandheldJoyConRightOnly = 3,
+        HandheldJoyConLeftJoyConRight = 4,
+        JoyDual = 5,
+        JoyDualLeftOnly = 6,
+        JoyDualRightOnly = 7,
+        JoyLeftHorizontal = 8,
+        JoyLeftVertical = 9,
+        JoyRightHorizontal = 10,
+        JoyRightVertical = 11,
+        SwitchProController = 12,
+        CompatibleProController = 13,
+        CompatibleJoyCon = 14,
+        LarkHvc1 = 15,
+        LarkHvc2 = 16,
+        LarkNesLeft = 17,
+        LarkNesRight = 18,
+        Lucia = 19,
+        Verification = 20,
+    };
+
     struct NPadEntry {
         NpadStyleSet style_set;
         NpadAssignments assignment_mode;
@@ -469,8 +501,11 @@ private:
         u32 battery_level_dual;
         u32 battery_level_left;
         u32 battery_level_right;
-        INSERT_PADDING_BYTES(0x5c);
-        INSERT_PADDING_BYTES(0xdf8);
+        AppletFooterUiAttributes footer_attributes;
+        AppletFooterUiType footer_type;
+        // nfc_states needs to be checked switchbrew does not match with HW
+        NfcXcdHandle nfc_states;
+        INSERT_PADDING_BYTES(0xdef);
     };
     static_assert(sizeof(NPadEntry) == 0x5000, "NPadEntry is an invalid size");
 
@@ -506,7 +541,6 @@ private:
     std::vector<u32> supported_npad_id_types{};
     NpadHoldType hold_type{NpadHoldType::Vertical};
     NpadHandheldActivationMode handheld_activation_mode{NpadHandheldActivationMode::Dual};
-    // NpadCommunicationMode is unknown, default value is 1
     NpadCommunicationMode communication_mode{NpadCommunicationMode::Default};
     // Each controller should have their own styleset changed event
     std::array<Kernel::EventPair, 10> styleset_changed_events;

--- a/src/core/hle/service/hid/controllers/xpad.h
+++ b/src/core/hle/service/hid/controllers/xpad.h
@@ -31,13 +31,13 @@ public:
 private:
     struct Attributes {
         union {
-            s32_le raw{};
-            BitField<0, 1, u32> IsConnected;
-            BitField<1, 1, u32> IsWired;
-            BitField<2, 1, u32> IsLeftConnected;
-            BitField<3, 1, u32> IsLeftWired;
-            BitField<4, 1, u32> IsRightConnected;
-            BitField<5, 1, u32> IsRightWired;
+            u32_le raw{};
+            BitField<0, 1, u32> is_connected;
+            BitField<1, 1, u32> is_wired;
+            BitField<2, 1, u32> is_left_connected;
+            BitField<3, 1, u32> is_left_wired;
+            BitField<4, 1, u32> is_right_connected;
+            BitField<5, 1, u32> is_right_wired;
         };
     };
     static_assert(sizeof(Attributes) == 4, "Attributes is an invalid size");

--- a/src/core/hle/service/hid/controllers/xpad.h
+++ b/src/core/hle/service/hid/controllers/xpad.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "common/bit_field.h"
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/swap.h"
@@ -28,6 +29,67 @@ public:
     void OnLoadInputDevices() override;
 
 private:
+    struct Attributes {
+        union {
+            s32_le raw{};
+            BitField<0, 1, u32> IsConnected;
+            BitField<1, 1, u32> IsWired;
+            BitField<2, 1, u32> IsLeftConnected;
+            BitField<3, 1, u32> IsLeftWired;
+            BitField<4, 1, u32> IsRightConnected;
+            BitField<5, 1, u32> IsRightWired;
+        };
+    };
+    static_assert(sizeof(Attributes) == 4, "Attributes is an invalid size");
+
+    struct Buttons {
+        union {
+            u32_le raw{};
+            // Button states
+            BitField<0, 1, u32> a;
+            BitField<1, 1, u32> b;
+            BitField<2, 1, u32> x;
+            BitField<3, 1, u32> y;
+            BitField<4, 1, u32> l_stick;
+            BitField<5, 1, u32> r_stick;
+            BitField<6, 1, u32> l;
+            BitField<7, 1, u32> r;
+            BitField<8, 1, u32> zl;
+            BitField<9, 1, u32> zr;
+            BitField<10, 1, u32> plus;
+            BitField<11, 1, u32> minus;
+
+            // D-Pad
+            BitField<12, 1, u32> d_left;
+            BitField<13, 1, u32> d_up;
+            BitField<14, 1, u32> d_right;
+            BitField<15, 1, u32> d_down;
+
+            // Left JoyStick
+            BitField<16, 1, u32> l_stick_left;
+            BitField<17, 1, u32> l_stick_up;
+            BitField<18, 1, u32> l_stick_right;
+            BitField<19, 1, u32> l_stick_down;
+
+            // Right JoyStick
+            BitField<20, 1, u32> r_stick_left;
+            BitField<21, 1, u32> r_stick_up;
+            BitField<22, 1, u32> r_stick_right;
+            BitField<23, 1, u32> r_stick_down;
+
+            // Not always active?
+            BitField<24, 1, u32> left_sl;
+            BitField<25, 1, u32> left_sr;
+
+            BitField<26, 1, u32> right_sl;
+            BitField<27, 1, u32> right_sr;
+
+            BitField<28, 1, u32> palma;
+            BitField<30, 1, u32> handheld_left_b;
+        };
+    };
+    static_assert(sizeof(Buttons) == 4, "Buttons is an invalid size");
+
     struct AnalogStick {
         s32_le x;
         s32_le y;
@@ -37,10 +99,10 @@ private:
     struct XPadState {
         s64_le sampling_number;
         s64_le sampling_number2;
-        s32_le attributes;
-        u32_le pad_states;
-        AnalogStick x_stick;
-        AnalogStick y_stick;
+        Attributes attributes;
+        Buttons pad_states;
+        AnalogStick l_stick;
+        AnalogStick r_stick;
     };
     static_assert(sizeof(XPadState) == 0x28, "XPadState is an invalid size");
 

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -59,20 +59,26 @@ IAppletResource::IAppletResource(Core::System& system_)
     MakeController<Controller_Mouse>(HidController::Mouse);
     MakeController<Controller_Keyboard>(HidController::Keyboard);
     MakeController<Controller_XPad>(HidController::XPad);
-    MakeController<Controller_Stubbed>(HidController::Unknown1);
-    MakeController<Controller_Stubbed>(HidController::Unknown2);
-    MakeController<Controller_Stubbed>(HidController::Unknown3);
-    MakeController<Controller_Stubbed>(HidController::SixAxisSensor);
+    MakeController<Controller_Stubbed>(HidController::HomeButton);
+    MakeController<Controller_Stubbed>(HidController::SleepButton);
+    MakeController<Controller_Stubbed>(HidController::CaptureButton);
+    MakeController<Controller_Stubbed>(HidController::InputDetector);
+    MakeController<Controller_Stubbed>(HidController::UniquePad);
     MakeController<Controller_NPad>(HidController::NPad);
     MakeController<Controller_Gesture>(HidController::Gesture);
+    MakeController<Controller_Stubbed>(HidController::ConsoleSixAxisSensor);
 
     // Homebrew doesn't try to activate some controllers, so we activate them by default
     GetController<Controller_NPad>(HidController::NPad).ActivateController();
     GetController<Controller_Touchscreen>(HidController::Touchscreen).ActivateController();
 
-    GetController<Controller_Stubbed>(HidController::Unknown1).SetCommonHeaderOffset(0x4c00);
-    GetController<Controller_Stubbed>(HidController::Unknown2).SetCommonHeaderOffset(0x4e00);
-    GetController<Controller_Stubbed>(HidController::Unknown3).SetCommonHeaderOffset(0x5000);
+    GetController<Controller_Stubbed>(HidController::HomeButton).SetCommonHeaderOffset(0x4C00);
+    GetController<Controller_Stubbed>(HidController::SleepButton).SetCommonHeaderOffset(0x4E00);
+    GetController<Controller_Stubbed>(HidController::CaptureButton).SetCommonHeaderOffset(0x5000);
+    GetController<Controller_Stubbed>(HidController::InputDetector).SetCommonHeaderOffset(0x5200);
+    GetController<Controller_Stubbed>(HidController::UniquePad).SetCommonHeaderOffset(0x5A00);
+    GetController<Controller_Stubbed>(HidController::ConsoleSixAxisSensor)
+        .SetCommonHeaderOffset(0x3C200);
 
     // Register update callbacks
     pad_update_event = Core::Timing::CreateEvent(

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -29,12 +29,14 @@ enum class HidController : std::size_t {
     Mouse,
     Keyboard,
     XPad,
-    Unknown1,
-    Unknown2,
-    Unknown3,
-    SixAxisSensor,
+    HomeButton,
+    SleepButton,
+    CaptureButton,
+    InputDetector,
+    UniquePad,
     NPad,
     Gesture,
+    ConsoleSixAxisSensor,
 
     MaxControllers,
 };

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -886,7 +886,7 @@ void ConfigureInputPlayer::SetConnectableControllers() {
         index_controller_type_pairs.clear();
         ui->comboControllerType->clear();
 
-        if (enable_all || npad_style_set.pro_controller == 1) {
+        if (enable_all || npad_style_set.fullkey == 1) {
             index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
                                                      Settings::ControllerType::ProController);
             ui->comboControllerType->addItem(tr("Pro Controller"));


### PR DESCRIPTION
Updates the HID service to match more closely to switchbrew. Functionality wise nothing should be changed.

- Adds missing controller types and properties.
- Renames properties names to match switchbrew