### PR TITLE
qt: Set DISPLAY env var when not present

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -59,6 +59,7 @@ static FileSys::VirtualFile VfsDirectoryCreateFileWrapper(const FileSys::Virtual
 #include <QPushButton>
 #include <QShortcut>
 #include <QStatusBar>
+#include <QString>
 #include <QSysInfo>
 #include <QUrl>
 #include <QtConcurrent/QtConcurrent>
@@ -2997,6 +2998,14 @@ int main(int argc, char* argv[]) {
     // the user folder in the Qt Frontend, we need to cd into that working directory
     const std::string bin_path = Common::FS::GetBundleDirectory() + DIR_SEP + "..";
     chdir(bin_path.c_str());
+#endif
+
+#ifdef __linux__
+    // Set the DISPLAY variable in order to open web browsers
+    // TODO (lat9nq): Find a better solution for AppImages to start external applications
+    if (QString::fromLocal8Bit(qgetenv("DISPLAY")).isEmpty()) {
+        qputenv("DISPLAY", ":0");
+    }
 #endif
 
     // Enables the core to make the qt created contexts current on std::threads


### PR DESCRIPTION
Fixes web browser opening (Help > Open Mods Page, Help > Open Quickstart Guide)

```
$ ./yuzu-20210110-a8cc9db87-x86_64.AppImage 
Error: no DISPLAY environment variable specified
```

Same issue as https://github.com/RPCS3/rpcs3/issues/5959, same fix as https://github.com/RPCS3/rpcs3/pull/7461