### PR TITLE
Fix:Deriving Keys dialog isn't a child of main

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2709,7 +2709,7 @@ void GMainWindow::OnReinitializeKeys(ReinitializeKeyBehavior behavior) {
                     .arg(errors));
         }
 
-        QProgressDialog prog;
+        QProgressDialog prog(this);
         prog.setRange(0, 0);
         prog.setLabelText(tr("Deriving keys...\nThis may take up to a minute depending \non your "
                              "system's performance."));


### PR DESCRIPTION
What the title suggests, the window "Deriving Keys" isn't set as a child of the main window.
 
Before the fix while the main window has an icon the dialog doesn't cause it doesn't belong to it:
![image](https://user-images.githubusercontent.com/67879877/104137205-d0a23c80-53a3-11eb-8a74-9899c113d8c4.png)


After the fix the dialog has an icon cause the main window is the parent:
![image](https://user-images.githubusercontent.com/67879877/104137238-0515f880-53a4-11eb-8f15-adbfcf487911.png)

