### PR TITLE
Fix IP validator error

### DIFF
--- a/src/yuzu/configuration/configure_motion_touch.cpp
+++ b/src/yuzu/configuration/configure_motion_touch.cpp
@@ -185,8 +185,9 @@ void ConfigureMotionTouch::ConnectEvents() {
 }
 
 void ConfigureMotionTouch::OnUDPAddServer() {
-    QRegExp re(tr(R"re(^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4]"
-                  "[0-9]|[01]?[0-9][0-9]?)$)re")); // a valid ip address
+    // Validator for IP address
+    QRegExp re(QStringLiteral(
+        R"re(^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)re"));
     bool ok;
     QString port_text = ui->udp_port->text();
     QString server_text = ui->udp_server->text();


### PR DESCRIPTION
Fixes error introduced in #5156. Where the last octet produced an error if the value was higher than 199. For example 192.168.1.200 

This is caused by the break line in the string. Putting the string in a single line fixes the issue.
