### PR TITLE
Fix:Yuzu freezing when stopping emulation on Linux

### DIFF
--- a/src/video_core/shader/async_shaders.cpp
+++ b/src/video_core/shader/async_shaders.cpp
@@ -64,6 +64,7 @@ void AsyncShaders::FreeWorkers() {
 
 void AsyncShaders::KillWorkers() {
     is_thread_exiting.store(true);
+    cv.notify_all();
     for (auto& thread : worker_threads) {
         thread.detach();
     }


### PR DESCRIPTION
Closes #4161

While working on Windows, stopping emulation caused Yuzu to freeze on Linux. That includes closing the emulator window while a game was running, stopping the game running from Emulation>Stop and restarting it from Emulation>Restart. What happened was the threads weren't being notified by the cv before being destructed (ref. https://en.cppreference.com/w/cpp/thread/condition_variable/%7Econdition_variable) so they stayed waiting forever.

![image](https://user-images.githubusercontent.com/67879877/104332019-6cdd5800-54f8-11eb-8886-87b842b2f528.png)

And the emulator wasn't responding until it was killed.
Before:

https://user-images.githubusercontent.com/67879877/104332812-3f44de80-54f9-11eb-994d-e36acea11f6a.mp4

Now we notify the worker threads before terminating them.
After:

https://user-images.githubusercontent.com/67879877/104333322-c7c37f00-54f9-11eb-918a-d514f91d6633.mp4

Further testing needed, especially on Windows.