### PR TITLE
cmake: Enforce -Werror=switch and -Werror=unused-variable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,8 +67,10 @@ else()
         -Werror=implicit-fallthrough
         -Werror=missing-declarations
         -Werror=reorder
+        -Werror=switch
         -Werror=uninitialized
         -Werror=unused-result
+        -Werror=unused-variable
         -Wextra
         -Wmissing-declarations
         -Wno-attributes


### PR DESCRIPTION
switch is equivalent to MSVC's C4062
unused-variable is equivalent to MSVC's C4101