### PR TITLE
configure_motion_touch: Migrate off QRegExp to QRegularExpression

### DIFF
--- a/src/yuzu/configuration/configure_motion_touch.cpp
+++ b/src/yuzu/configuration/configure_motion_touch.cpp
@@ -4,12 +4,15 @@
 
 #include <array>
 #include <sstream>
+
 #include <QCloseEvent>
 #include <QLabel>
 #include <QMessageBox>
 #include <QPushButton>
+#include <QRegularExpression>
 #include <QStringListModel>
 #include <QVBoxLayout>
+
 #include "common/logging/log.h"
 #include "core/settings.h"
 #include "input_common/main.h"
@@ -186,14 +189,14 @@ void ConfigureMotionTouch::ConnectEvents() {
 
 void ConfigureMotionTouch::OnUDPAddServer() {
     // Validator for IP address
-    QRegExp re(QStringLiteral(
+    const QRegularExpression re(QStringLiteral(
         R"re(^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$)re"));
     bool ok;
-    QString port_text = ui->udp_port->text();
-    QString server_text = ui->udp_server->text();
+    const QString port_text = ui->udp_port->text();
+    const QString server_text = ui->udp_server->text();
     const QString server_string = tr("%1:%2").arg(server_text, port_text);
-    int port_number = port_text.toInt(&ok, 10);
-    int row = udp_server_list_model->rowCount();
+    const int port_number = port_text.toInt(&ok, 10);
+    const int row = udp_server_list_model->rowCount();
 
     if (!ok) {
         QMessageBox::warning(this, tr("yuzu"), tr("Port number has invalid characters"));
@@ -203,7 +206,7 @@ void ConfigureMotionTouch::OnUDPAddServer() {
         QMessageBox::warning(this, tr("yuzu"), tr("Port has to be in range 0 and 65353"));
         return;
     }
-    if (!re.exactMatch(server_text)) {
+    if (!re.match(server_text).hasMatch()) {
         QMessageBox::warning(this, tr("yuzu"), tr("IP address is not valid"));
         return;
     }


### PR DESCRIPTION
`QRegularExpression` was introduced in Qt 5 as a better replacement for `QRegExp`. In Qt 6.0 `QRegExp` is removed entirely.

To remain forward compatible with Qt 6.0, we can transition over to using `QRegularExpression`.