### PR TITLE
yuzu: Remove unused variables in Qt code

### DIFF
--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -117,31 +117,13 @@ void ConfigureDialog::UpdateVisibleTabs() {
         return;
     }
 
-    const std::map<QWidget*, QString> widgets = {
-        {ui->generalTab, tr("General")},
-        {ui->systemTab, tr("System")},
-        {ui->profileManagerTab, tr("Profiles")},
-        {ui->inputTab, tr("Controls")},
-        {ui->hotkeysTab, tr("Hotkeys")},
-        {ui->cpuTab, tr("CPU")},
-        {ui->cpuDebugTab, tr("Debug")},
-        {ui->graphicsTab, tr("Graphics")},
-        {ui->graphicsAdvancedTab, tr("Advanced")},
-        {ui->audioTab, tr("Audio")},
-        {ui->debugTab, tr("Debug")},
-        {ui->webTab, tr("Web")},
-        {ui->uiTab, tr("UI")},
-        {ui->filesystemTab, tr("Filesystem")},
-        {ui->serviceTab, tr("Services")},
-    };
-
     [[maybe_unused]] const QSignalBlocker blocker(ui->tabWidget);
 
     ui->tabWidget->clear();
 
-    const QList<QWidget*> tabs = qvariant_cast<QList<QWidget*>>(items[0]->data(Qt::UserRole));
+    const auto tabs = qvariant_cast<QList<QWidget*>>(items[0]->data(Qt::UserRole));
 
-    for (const auto tab : tabs) {
+    for (auto* const tab : tabs) {
         ui->tabWidget->addTab(tab, tab->accessibleName());
     }
 }

--- a/src/yuzu/configuration/configure_motion_touch.cpp
+++ b/src/yuzu/configuration/configure_motion_touch.cpp
@@ -112,7 +112,6 @@ ConfigureMotionTouch::~ConfigureMotionTouch() = default;
 void ConfigureMotionTouch::SetConfiguration() {
     const Common::ParamPackage motion_param(Settings::values.motion_device);
     const Common::ParamPackage touch_param(Settings::values.touch_device);
-    const std::string motion_engine = motion_param.Get("engine", "motion_emu");
     const std::string touch_engine = touch_param.Get("engine", "emu_window");
 
     ui->touch_provider->setCurrentIndex(


### PR DESCRIPTION
Removes two unused variables in out Qt code. In this case the removal of these two results in less allocations, given std::map allocates on the heap.