### PR TITLE
cmake: Enforce -Wunused-function code-base wise

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,7 @@ else()
         -Werror=reorder
         -Werror=switch
         -Werror=uninitialized
+        -Werror=unused-function
         -Werror=unused-result
         -Werror=unused-variable
         -Wextra

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -314,7 +314,6 @@ else()
         -Werror=shadow
         -Werror=switch
         -Werror=type-limits
-        -Werror=unused-function
         -Werror=unused-variable
 
         $<$<CXX_COMPILER_ID:GNU>:-Werror=class-memaccess>

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -314,6 +314,7 @@ else()
         -Werror=shadow
         -Werror=switch
         -Werror=type-limits
+        -Werror=unused-function
         -Werror=unused-variable
 
         $<$<CXX_COMPILER_ID:GNU>:-Werror=class-memaccess>

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
@@ -34,10 +34,6 @@ constexpr VkAccessFlags UPLOAD_ACCESS_BARRIERS =
 constexpr VkAccessFlags TRANSFORM_FEEDBACK_WRITE_ACCESS =
     VK_ACCESS_TRANSFORM_FEEDBACK_WRITE_BIT_EXT | VK_ACCESS_TRANSFORM_FEEDBACK_COUNTER_WRITE_BIT_EXT;
 
-std::unique_ptr<VKStreamBuffer> CreateStreamBuffer(const Device& device, VKScheduler& scheduler) {
-    return std::make_unique<VKStreamBuffer>(device, scheduler);
-}
-
 } // Anonymous namespace
 
 Buffer::Buffer(const Device& device_, VKMemoryManager& memory_manager, VKScheduler& scheduler_,


### PR DESCRIPTION
Stops us from merging code with unused functions in the future.

If something is invoked behind conditionally evaluated code in
a way that the language can't see it (e.g. preprocessor macros), the
potentially unused function should use [[maybe_unused]].