### PR TITLE
{video_,}core/cmake: Remove Werror flags already defined code-base wide 

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -643,9 +643,7 @@ else()
         -Werror=conversion
         -Werror=ignored-qualifiers
         -Werror=implicit-fallthrough
-        -Werror=reorder
         -Werror=sign-compare
-        -Werror=unused-variable
 
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-variable>

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -312,9 +312,7 @@ else()
         -Werror=pessimizing-move
         -Werror=redundant-move
         -Werror=shadow
-        -Werror=switch
         -Werror=type-limits
-        -Werror=unused-variable
 
         $<$<CXX_COMPILER_ID:GNU>:-Werror=class-memaccess>
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>


### PR DESCRIPTION
These flags are already defined in src/cmake.