### PR TITLE
common/alignment: Rename AlignBits to AlignUpLog2 and use constraints

### DIFF
--- a/src/common/alignment.h
+++ b/src/common/alignment.h
@@ -9,8 +9,7 @@
 namespace Common {
 
 template <typename T>
-[[nodiscard]] constexpr T AlignUp(T value, std::size_t size) {
-    static_assert(std::is_unsigned_v<T>, "T must be an unsigned value.");
+requires std::is_unsigned_v<T>[[nodiscard]] constexpr T AlignUp(T value, size_t size) {
     auto mod{static_cast<T>(value % size)};
     value -= mod;
     return static_cast<T>(mod == T{0} ? value : value + size);
@@ -22,36 +21,33 @@ requires std::is_unsigned_v<T>[[nodiscard]] constexpr T AlignUpLog2(T value, siz
 }
 
 template <typename T>
-[[nodiscard]] constexpr T AlignDown(T value, std::size_t size) {
-    static_assert(std::is_unsigned_v<T>, "T must be an unsigned value.");
+requires std::is_unsigned_v<T>[[nodiscard]] constexpr T AlignDown(T value, size_t size) {
     return static_cast<T>(value - value % size);
 }
 
 template <typename T>
-[[nodiscard]] constexpr bool Is4KBAligned(T value) {
-    static_assert(std::is_unsigned_v<T>, "T must be an unsigned value.");
+requires std::is_unsigned_v<T>[[nodiscard]] constexpr bool Is4KBAligned(T value) {
     return (value & 0xFFF) == 0;
 }
 
 template <typename T>
-[[nodiscard]] constexpr bool IsWordAligned(T value) {
-    static_assert(std::is_unsigned_v<T>, "T must be an unsigned value.");
+requires std::is_unsigned_v<T>[[nodiscard]] constexpr bool IsWordAligned(T value) {
     return (value & 0b11) == 0;
 }
 
 template <typename T>
-[[nodiscard]] constexpr bool IsAligned(T value, std::size_t alignment) {
-    using U = typename std::make_unsigned<T>::type;
+requires std::is_integral_v<T>[[nodiscard]] constexpr bool IsAligned(T value, size_t alignment) {
+    using U = typename std::make_unsigned_t<T>;
     const U mask = static_cast<U>(alignment - 1);
     return (value & mask) == 0;
 }
 
-template <typename T, std::size_t Align = 16>
+template <typename T, size_t Align = 16>
 class AlignmentAllocator {
 public:
     using value_type = T;
-    using size_type = std::size_t;
-    using difference_type = std::ptrdiff_t;
+    using size_type = size_t;
+    using difference_type = ptrdiff_t;
 
     using propagate_on_container_copy_assignment = std::true_type;
     using propagate_on_container_move_assignment = std::true_type;

--- a/src/common/alignment.h
+++ b/src/common/alignment.h
@@ -17,15 +17,14 @@ template <typename T>
 }
 
 template <typename T>
-[[nodiscard]] constexpr T AlignDown(T value, std::size_t size) {
-    static_assert(std::is_unsigned_v<T>, "T must be an unsigned value.");
-    return static_cast<T>(value - value % size);
+requires std::is_unsigned_v<T>[[nodiscard]] constexpr T AlignUpLog2(T value, size_t align_log2) {
+    return static_cast<T>((value + ((1ULL << align_log2) - 1)) >> align_log2 << align_log2);
 }
 
 template <typename T>
-[[nodiscard]] constexpr T AlignBits(T value, std::size_t align) {
+[[nodiscard]] constexpr T AlignDown(T value, std::size_t size) {
     static_assert(std::is_unsigned_v<T>, "T must be an unsigned value.");
-    return static_cast<T>((value + ((1ULL << align) - 1)) >> align << align);
+    return static_cast<T>(value - value % size);
 }
 
 template <typename T>

--- a/src/video_core/texture_cache/accelerated_swizzle.cpp
+++ b/src/video_core/texture_cache/accelerated_swizzle.cpp
@@ -27,7 +27,7 @@ BlockLinearSwizzle2DParams MakeBlockLinearSwizzle2DParams(const SwizzleParameter
     const Extent3D num_tiles = swizzle.num_tiles;
     const u32 bytes_per_block = BytesPerBlock(info.format);
     const u32 stride_alignment = CalculateLevelStrideAlignment(info, swizzle.level);
-    const u32 stride = Common::AlignBits(num_tiles.width, stride_alignment) * bytes_per_block;
+    const u32 stride = Common::AlignUpLog2(num_tiles.width, stride_alignment) * bytes_per_block;
     const u32 gobs_in_x = Common::DivCeilLog2(stride, GOB_SIZE_X_SHIFT);
     return BlockLinearSwizzle2DParams{
         .origin{0, 0, 0},
@@ -47,7 +47,7 @@ BlockLinearSwizzle3DParams MakeBlockLinearSwizzle3DParams(const SwizzleParameter
     const Extent3D num_tiles = swizzle.num_tiles;
     const u32 bytes_per_block = BytesPerBlock(info.format);
     const u32 stride_alignment = CalculateLevelStrideAlignment(info, swizzle.level);
-    const u32 stride = Common::AlignBits(num_tiles.width, stride_alignment) * bytes_per_block;
+    const u32 stride = Common::AlignUpLog2(num_tiles.width, stride_alignment) * bytes_per_block;
 
     const u32 gobs_in_x = (stride + GOB_SIZE_X - 1) >> GOB_SIZE_X_SHIFT;
     const u32 block_size = gobs_in_x << (GOB_SIZE_SHIFT + block.height + block.depth);

--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -279,7 +279,7 @@ template <u32 GOB_EXTENT>
     const bool is_small = IsSmallerThanGobSize(blocks, gob, info.block.depth);
     const u32 alignment = is_small ? 0 : info.tile_width_spacing;
     return Extent2D{
-        .width = Common::AlignBits(gobs.width, alignment),
+        .width = Common::AlignUpLog2(gobs.width, alignment),
         .height = gobs.height,
     };
 }
@@ -352,7 +352,7 @@ template <u32 GOB_EXTENT>
     // https://github.com/Ryujinx/Ryujinx/blob/1c9aba6de1520aea5480c032e0ff5664ac1bb36f/Ryujinx.Graphics.Texture/SizeCalculator.cs#L134
     if (tile_width_spacing > 0) {
         const u32 alignment_log2 = GOB_SIZE_SHIFT + tile_width_spacing + block.height + block.depth;
-        return Common::AlignBits(size_bytes, alignment_log2);
+        return Common::AlignUpLog2(size_bytes, alignment_log2);
     }
     const u32 aligned_height = Common::AlignUp(size.height, tile_size_y);
     while (block.height != 0 && aligned_height <= (1U << (block.height - 1)) * GOB_SIZE_Y) {
@@ -528,9 +528,9 @@ template <u32 GOB_EXTENT>
     const u32 alignment = StrideAlignment(num_tiles, info.block, bpp_log2, info.tile_width_spacing);
     const Extent3D mip_block = AdjustMipBlockSize(num_tiles, info.block, 0);
     return Extent3D{
-        .width = Common::AlignBits(num_tiles.width, alignment),
-        .height = Common::AlignBits(num_tiles.height, GOB_SIZE_Y_SHIFT + mip_block.height),
-        .depth = Common::AlignBits(num_tiles.depth, GOB_SIZE_Z_SHIFT + mip_block.depth),
+        .width = Common::AlignUpLog2(num_tiles.width, alignment),
+        .height = Common::AlignUpLog2(num_tiles.height, GOB_SIZE_Y_SHIFT + mip_block.height),
+        .depth = Common::AlignUpLog2(num_tiles.depth, GOB_SIZE_Z_SHIFT + mip_block.depth),
     };
 }
 

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -49,7 +49,7 @@ void Swizzle(std::span<u8> output, std::span<const u8> input, u32 bytes_per_pixe
     // We can configure here a custom pitch
     // As it's not exposed 'width * bpp' will be the expected pitch.
     const u32 pitch = width * bytes_per_pixel;
-    const u32 stride = Common::AlignBits(width, stride_alignment) * bytes_per_pixel;
+    const u32 stride = Common::AlignUpLog2(width, stride_alignment) * bytes_per_pixel;
 
     const u32 gobs_in_x = Common::DivCeilLog2(stride, GOB_SIZE_X_SHIFT);
     const u32 block_size = gobs_in_x << (GOB_SIZE_SHIFT + block_height + block_depth);
@@ -217,9 +217,9 @@ void SwizzleKepler(const u32 width, const u32 height, const u32 dst_x, const u32
 std::size_t CalculateSize(bool tiled, u32 bytes_per_pixel, u32 width, u32 height, u32 depth,
                           u32 block_height, u32 block_depth) {
     if (tiled) {
-        const u32 aligned_width = Common::AlignBits(width * bytes_per_pixel, GOB_SIZE_X_SHIFT);
-        const u32 aligned_height = Common::AlignBits(height, GOB_SIZE_Y_SHIFT + block_height);
-        const u32 aligned_depth = Common::AlignBits(depth, GOB_SIZE_Z_SHIFT + block_depth);
+        const u32 aligned_width = Common::AlignUpLog2(width * bytes_per_pixel, GOB_SIZE_X_SHIFT);
+        const u32 aligned_height = Common::AlignUpLog2(height, GOB_SIZE_Y_SHIFT + block_height);
+        const u32 aligned_depth = Common::AlignUpLog2(depth, GOB_SIZE_Z_SHIFT + block_depth);
         return aligned_width * aligned_height * aligned_depth;
     } else {
         return width * height * depth * bytes_per_pixel;


### PR DESCRIPTION
AlignUpLog2 describes what the function does better than AlignBits.

`clang-format` changes the formatting of this between versions, adding a space before `[[nodiscard]]`. CI formatting should validate if I got this right.