### PR TITLE
common/common_funcs: Rename INSERT_UNION_PADDING_{BYTES,WORDS} to _NOINIT

### DIFF
--- a/src/audio_core/sink_context.h
+++ b/src/audio_core/sink_context.h
@@ -40,17 +40,17 @@ public:
         SinkSampleFormat sample_format;
         std::array<u8, AudioCommon::MAX_CHANNEL_COUNT> input;
         bool in_use;
-        INSERT_UNION_PADDING_BYTES(5);
+        INSERT_PADDING_BYTES_NOINIT(5);
     };
     static_assert(sizeof(CircularBufferIn) == 0x28,
                   "SinkInfo::CircularBufferIn is in invalid size");
 
     struct DeviceIn {
         std::array<u8, 255> device_name;
-        INSERT_UNION_PADDING_BYTES(1);
+        INSERT_PADDING_BYTES_NOINIT(1);
         s32_le input_count;
         std::array<u8, AudioCommon::MAX_CHANNEL_COUNT> input;
-        INSERT_UNION_PADDING_BYTES(1);
+        INSERT_PADDING_BYTES_NOINIT(1);
         bool down_matrix_enabled;
         DownmixCoefficients down_matrix_coef;
     };

--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -24,10 +24,10 @@
 #define INSERT_PADDING_WORDS(num_words)                                                            \
     std::array<u32, num_words> CONCAT2(pad, __LINE__) {}
 
-/// These are similar to the INSERT_PADDING_* macros, but are needed for padding unions. This is
-/// because unions can only be initialized by one member.
-#define INSERT_UNION_PADDING_BYTES(num_bytes) std::array<u8, num_bytes> CONCAT2(pad, __LINE__)
-#define INSERT_UNION_PADDING_WORDS(num_words) std::array<u32, num_words> CONCAT2(pad, __LINE__)
+/// These are similar to the INSERT_PADDING_* macros but do not zero-initialize the contents.
+/// This keeps the structure trivial to construct.
+#define INSERT_PADDING_BYTES_NOINIT(num_bytes) std::array<u8, num_bytes> CONCAT2(pad, __LINE__)
+#define INSERT_PADDING_WORDS_NOINIT(num_words) std::array<u32, num_words> CONCAT2(pad, __LINE__)
 
 #ifndef _MSC_VER
 

--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -43,17 +43,17 @@ static_assert(sizeof(IVFCLevel) == 0x18, "IVFCLevel has incorrect size.");
 struct IVFCHeader {
     u32_le magic;
     u32_le magic_number;
-    INSERT_UNION_PADDING_BYTES(8);
+    INSERT_PADDING_BYTES_NOINIT(8);
     std::array<IVFCLevel, 6> levels;
-    INSERT_UNION_PADDING_BYTES(64);
+    INSERT_PADDING_BYTES_NOINIT(64);
 };
 static_assert(sizeof(IVFCHeader) == 0xE0, "IVFCHeader has incorrect size.");
 
 struct NCASectionHeaderBlock {
-    INSERT_UNION_PADDING_BYTES(3);
+    INSERT_PADDING_BYTES_NOINIT(3);
     NCASectionFilesystemType filesystem_type;
     NCASectionCryptoType crypto_type;
-    INSERT_UNION_PADDING_BYTES(3);
+    INSERT_PADDING_BYTES_NOINIT(3);
 };
 static_assert(sizeof(NCASectionHeaderBlock) == 0x8, "NCASectionHeaderBlock has incorrect size.");
 
@@ -61,7 +61,7 @@ struct NCASectionRaw {
     NCASectionHeaderBlock header;
     std::array<u8, 0x138> block_data;
     std::array<u8, 0x8> section_ctr;
-    INSERT_UNION_PADDING_BYTES(0xB8);
+    INSERT_PADDING_BYTES_NOINIT(0xB8);
 };
 static_assert(sizeof(NCASectionRaw) == 0x200, "NCASectionRaw has incorrect size.");
 
@@ -69,19 +69,19 @@ struct PFS0Superblock {
     NCASectionHeaderBlock header_block;
     std::array<u8, 0x20> hash;
     u32_le size;
-    INSERT_UNION_PADDING_BYTES(4);
+    INSERT_PADDING_BYTES_NOINIT(4);
     u64_le hash_table_offset;
     u64_le hash_table_size;
     u64_le pfs0_header_offset;
     u64_le pfs0_size;
-    INSERT_UNION_PADDING_BYTES(0x1B0);
+    INSERT_PADDING_BYTES_NOINIT(0x1B0);
 };
 static_assert(sizeof(PFS0Superblock) == 0x200, "PFS0Superblock has incorrect size.");
 
 struct RomFSSuperblock {
     NCASectionHeaderBlock header_block;
     IVFCHeader ivfc;
-    INSERT_UNION_PADDING_BYTES(0x118);
+    INSERT_PADDING_BYTES_NOINIT(0x118);
 };
 static_assert(sizeof(RomFSSuperblock) == 0x200, "RomFSSuperblock has incorrect size.");
 
@@ -89,19 +89,19 @@ struct BKTRHeader {
     u64_le offset;
     u64_le size;
     u32_le magic;
-    INSERT_UNION_PADDING_BYTES(0x4);
+    INSERT_PADDING_BYTES_NOINIT(0x4);
     u32_le number_entries;
-    INSERT_UNION_PADDING_BYTES(0x4);
+    INSERT_PADDING_BYTES_NOINIT(0x4);
 };
 static_assert(sizeof(BKTRHeader) == 0x20, "BKTRHeader has incorrect size.");
 
 struct BKTRSuperblock {
     NCASectionHeaderBlock header_block;
     IVFCHeader ivfc;
-    INSERT_UNION_PADDING_BYTES(0x18);
+    INSERT_PADDING_BYTES_NOINIT(0x18);
     BKTRHeader relocation;
     BKTRHeader subsection;
-    INSERT_UNION_PADDING_BYTES(0xC0);
+    INSERT_PADDING_BYTES_NOINIT(0xC0);
 };
 static_assert(sizeof(BKTRSuperblock) == 0x200, "BKTRSuperblock has incorrect size.");
 

--- a/src/core/hle/ipc.h
+++ b/src/core/hle/ipc.h
@@ -160,7 +160,7 @@ struct DomainMessageHeader {
         // Used when responding to an IPC request, Server -> Client.
         struct {
             u32_le num_objects;
-            INSERT_UNION_PADDING_WORDS(3);
+            INSERT_PADDING_WORDS_NOINIT(3);
         };
 
         // Used when performing an IPC request, Client -> Server.
@@ -171,7 +171,7 @@ struct DomainMessageHeader {
                 BitField<16, 16, u32> size;
             };
             u32_le object_id;
-            INSERT_UNION_PADDING_WORDS(2);
+            INSERT_PADDING_WORDS_NOINIT(2);
         };
 
         std::array<u32, 4> raw{};

--- a/src/core/hle/service/am/applets/error.cpp
+++ b/src/core/hle/service/am/applets/error.cpp
@@ -20,9 +20,9 @@ namespace Service::AM::Applets {
 struct ShowError {
     u8 mode;
     bool jump;
-    INSERT_UNION_PADDING_BYTES(4);
+    INSERT_PADDING_BYTES_NOINIT(4);
     bool use_64bit_error_code;
-    INSERT_UNION_PADDING_BYTES(1);
+    INSERT_PADDING_BYTES_NOINIT(1);
     u64 error_code_64;
     u32 error_code_32;
 };
@@ -32,7 +32,7 @@ static_assert(sizeof(ShowError) == 0x14, "ShowError has incorrect size.");
 struct ShowErrorRecord {
     u8 mode;
     bool jump;
-    INSERT_UNION_PADDING_BYTES(6);
+    INSERT_PADDING_BYTES_NOINIT(6);
     u64 error_code_64;
     u64 posix_time;
 };
@@ -41,7 +41,7 @@ static_assert(sizeof(ShowErrorRecord) == 0x18, "ShowErrorRecord has incorrect si
 struct SystemErrorArg {
     u8 mode;
     bool jump;
-    INSERT_UNION_PADDING_BYTES(6);
+    INSERT_PADDING_BYTES_NOINIT(6);
     u64 error_code_64;
     std::array<char, 8> language_code;
     std::array<char, 0x800> main_text;
@@ -52,7 +52,7 @@ static_assert(sizeof(SystemErrorArg) == 0x1018, "SystemErrorArg has incorrect si
 struct ApplicationErrorArg {
     u8 mode;
     bool jump;
-    INSERT_UNION_PADDING_BYTES(6);
+    INSERT_PADDING_BYTES_NOINIT(6);
     u32 error_code;
     std::array<char, 8> language_code;
     std::array<char, 0x800> main_text;

--- a/src/video_core/engines/fermi_2d.h
+++ b/src/video_core/engines/fermi_2d.h
@@ -171,30 +171,30 @@ public:
         static constexpr std::size_t NUM_REGS = 0x258;
         struct {
             u32 object;
-            INSERT_UNION_PADDING_WORDS(0x3F);
+            INSERT_PADDING_WORDS_NOINIT(0x3F);
             u32 no_operation;
             NotifyType notify;
-            INSERT_UNION_PADDING_WORDS(0x2);
+            INSERT_PADDING_WORDS_NOINIT(0x2);
             u32 wait_for_idle;
-            INSERT_UNION_PADDING_WORDS(0xB);
+            INSERT_PADDING_WORDS_NOINIT(0xB);
             u32 pm_trigger;
-            INSERT_UNION_PADDING_WORDS(0xF);
+            INSERT_PADDING_WORDS_NOINIT(0xF);
             u32 context_dma_notify;
             u32 dst_context_dma;
             u32 src_context_dma;
             u32 semaphore_context_dma;
-            INSERT_UNION_PADDING_WORDS(0x1C);
+            INSERT_PADDING_WORDS_NOINIT(0x1C);
             Surface dst;
             CpuIndexWrap pixels_from_cpu_index_wrap;
             u32 kind2d_check_enable;
             Surface src;
             SectorPromotion pixels_from_memory_sector_promotion;
-            INSERT_UNION_PADDING_WORDS(0x1);
+            INSERT_PADDING_WORDS_NOINIT(0x1);
             NumTpcs num_tpcs;
             u32 render_enable_addr_upper;
             u32 render_enable_addr_lower;
             RenderEnableMode render_enable_mode;
-            INSERT_UNION_PADDING_WORDS(0x4);
+            INSERT_PADDING_WORDS_NOINIT(0x4);
             u32 clip_x0;
             u32 clip_y0;
             u32 clip_width;
@@ -212,7 +212,7 @@ public:
                 BitField<8, 6, u32> y;
             } pattern_offset;
             BitField<0, 2, PatternSelect> pattern_select;
-            INSERT_UNION_PADDING_WORDS(0xC);
+            INSERT_PADDING_WORDS_NOINIT(0xC);
             struct {
                 BitField<0, 3, MonochromePatternColorFormat> color_format;
                 BitField<0, 1, MonochromePatternFormat> format;
@@ -227,15 +227,15 @@ public:
                 std::array<u32, 0x20> X1R5G5B5;
                 std::array<u32, 0x10> Y8;
             } color_pattern;
-            INSERT_UNION_PADDING_WORDS(0x10);
+            INSERT_PADDING_WORDS_NOINIT(0x10);
             struct {
                 u32 prim_mode;
                 u32 prim_color_format;
                 u32 prim_color;
                 u32 line_tie_break_bits;
-                INSERT_UNION_PADDING_WORDS(0x14);
+                INSERT_PADDING_WORDS_NOINIT(0x14);
                 u32 prim_point_xy;
-                INSERT_UNION_PADDING_WORDS(0x7);
+                INSERT_PADDING_WORDS_NOINIT(0x7);
                 std::array<Point, 0x40> prim_point;
             } render_solid;
             struct {
@@ -247,7 +247,7 @@ public:
                 u32 color0;
                 u32 color1;
                 u32 mono_opacity;
-                INSERT_UNION_PADDING_WORDS(0x6);
+                INSERT_PADDING_WORDS_NOINIT(0x6);
                 u32 src_width;
                 u32 src_height;
                 u32 dx_du_frac;
@@ -260,9 +260,9 @@ public:
                 u32 dst_y0_int;
                 u32 data;
             } pixels_from_cpu;
-            INSERT_UNION_PADDING_WORDS(0x3);
+            INSERT_PADDING_WORDS_NOINIT(0x3);
             u32 big_endian_control;
-            INSERT_UNION_PADDING_WORDS(0x3);
+            INSERT_PADDING_WORDS_NOINIT(0x3);
             struct {
                 BitField<0, 3, u32> block_shape;
                 BitField<0, 5, u32> corral_size;
@@ -271,7 +271,7 @@ public:
                     BitField<0, 1, Origin> origin;
                     BitField<4, 1, Filter> filter;
                 } sample_mode;
-                INSERT_UNION_PADDING_WORDS(0x8);
+                INSERT_PADDING_WORDS_NOINIT(0x8);
                 s32 dst_x0;
                 s32 dst_y0;
                 s32 dst_width;

--- a/src/video_core/engines/kepler_compute.h
+++ b/src/video_core/engines/kepler_compute.h
@@ -55,7 +55,7 @@ public:
 
         union {
             struct {
-                INSERT_UNION_PADDING_WORDS(0x60);
+                INSERT_PADDING_WORDS_NOINIT(0x60);
 
                 Upload::Registers upload;
 
@@ -67,7 +67,7 @@ public:
 
                 u32 data_upload;
 
-                INSERT_UNION_PADDING_WORDS(0x3F);
+                INSERT_PADDING_WORDS_NOINIT(0x3F);
 
                 struct {
                     u32 address;
@@ -76,11 +76,11 @@ public:
                     }
                 } launch_desc_loc;
 
-                INSERT_UNION_PADDING_WORDS(0x1);
+                INSERT_PADDING_WORDS_NOINIT(0x1);
 
                 u32 launch;
 
-                INSERT_UNION_PADDING_WORDS(0x4A7);
+                INSERT_PADDING_WORDS_NOINIT(0x4A7);
 
                 struct {
                     u32 address_high;
@@ -92,7 +92,7 @@ public:
                     }
                 } tsc;
 
-                INSERT_UNION_PADDING_WORDS(0x3);
+                INSERT_PADDING_WORDS_NOINIT(0x3);
 
                 struct {
                     u32 address_high;
@@ -104,7 +104,7 @@ public:
                     }
                 } tic;
 
-                INSERT_UNION_PADDING_WORDS(0x22);
+                INSERT_PADDING_WORDS_NOINIT(0x22);
 
                 struct {
                     u32 address_high;
@@ -115,11 +115,11 @@ public:
                     }
                 } code_loc;
 
-                INSERT_UNION_PADDING_WORDS(0x3FE);
+                INSERT_PADDING_WORDS_NOINIT(0x3FE);
 
                 u32 tex_cb_index;
 
-                INSERT_UNION_PADDING_WORDS(0x374);
+                INSERT_PADDING_WORDS_NOINIT(0x374);
             };
             std::array<u32, NUM_REGS> reg_array;
         };

--- a/src/video_core/engines/kepler_memory.h
+++ b/src/video_core/engines/kepler_memory.h
@@ -50,7 +50,7 @@ public:
 
         union {
             struct {
-                INSERT_UNION_PADDING_WORDS(0x60);
+                INSERT_PADDING_WORDS_NOINIT(0x60);
 
                 Upload::Registers upload;
 
@@ -62,7 +62,7 @@ public:
 
                 u32 data;
 
-                INSERT_UNION_PADDING_WORDS(0x11);
+                INSERT_PADDING_WORDS_NOINIT(0x11);
             };
             std::array<u32, NUM_REGS> reg_array;
         };

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -536,7 +536,7 @@ public:
             Equation equation_a;
             Factor factor_source_a;
             Factor factor_dest_a;
-            INSERT_UNION_PADDING_WORDS(1);
+            INSERT_PADDING_WORDS_NOINIT(1);
         };
 
         enum class TessellationPrimitive : u32 {
@@ -608,7 +608,7 @@ public:
             };
             u32 layer_stride;
             u32 base_layer;
-            INSERT_UNION_PADDING_WORDS(7);
+            INSERT_PADDING_WORDS_NOINIT(7);
 
             GPUVAddr Address() const {
                 return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
@@ -640,7 +640,7 @@ public:
                 BitField<8, 3, ViewportSwizzle> z;
                 BitField<12, 3, ViewportSwizzle> w;
             } swizzle;
-            INSERT_UNION_PADDING_WORDS(1);
+            INSERT_PADDING_WORDS_NOINIT(1);
 
             Common::Rectangle<f32> GetRect() const {
                 return {
@@ -700,7 +700,7 @@ public:
             u32 address_low;
             s32 buffer_size;
             s32 buffer_offset;
-            INSERT_UNION_PADDING_WORDS(3);
+            INSERT_PADDING_WORDS_NOINIT(3);
 
             GPUVAddr Address() const {
                 return static_cast<GPUVAddr>((static_cast<GPUVAddr>(address_high) << 32) |
@@ -713,7 +713,7 @@ public:
             u32 stream;
             u32 varying_count;
             u32 stride;
-            INSERT_UNION_PADDING_WORDS(1);
+            INSERT_PADDING_WORDS_NOINIT(1);
         };
         static_assert(sizeof(TransformFeedbackLayout) == 16);
 
@@ -731,7 +731,7 @@ public:
 
         union {
             struct {
-                INSERT_UNION_PADDING_WORDS(0x44);
+                INSERT_PADDING_WORDS_NOINIT(0x44);
 
                 u32 wait_for_idle;
 
@@ -744,7 +744,7 @@ public:
 
                 ShadowRamControl shadow_ram_control;
 
-                INSERT_UNION_PADDING_WORDS(0x16);
+                INSERT_PADDING_WORDS_NOINIT(0x16);
 
                 Upload::Registers upload;
                 struct {
@@ -755,11 +755,11 @@ public:
 
                 u32 data_upload;
 
-                INSERT_UNION_PADDING_WORDS(0x16);
+                INSERT_PADDING_WORDS_NOINIT(0x16);
 
                 u32 force_early_fragment_tests;
 
-                INSERT_UNION_PADDING_WORDS(0x2D);
+                INSERT_PADDING_WORDS_NOINIT(0x2D);
 
                 struct {
                     union {
@@ -769,7 +769,7 @@ public:
                     };
                 } sync_info;
 
-                INSERT_UNION_PADDING_WORDS(0x15);
+                INSERT_PADDING_WORDS_NOINIT(0x15);
 
                 union {
                     BitField<0, 2, TessellationPrimitive> prim;
@@ -781,21 +781,21 @@ public:
                 std::array<f32, 4> tess_level_outer;
                 std::array<f32, 2> tess_level_inner;
 
-                INSERT_UNION_PADDING_WORDS(0x10);
+                INSERT_PADDING_WORDS_NOINIT(0x10);
 
                 u32 rasterize_enable;
 
                 std::array<TransformFeedbackBinding, NumTransformFeedbackBuffers> tfb_bindings;
 
-                INSERT_UNION_PADDING_WORDS(0xC0);
+                INSERT_PADDING_WORDS_NOINIT(0xC0);
 
                 std::array<TransformFeedbackLayout, NumTransformFeedbackBuffers> tfb_layouts;
 
-                INSERT_UNION_PADDING_WORDS(0x1);
+                INSERT_PADDING_WORDS_NOINIT(0x1);
 
                 u32 tfb_enabled;
 
-                INSERT_UNION_PADDING_WORDS(0x2E);
+                INSERT_PADDING_WORDS_NOINIT(0x2E);
 
                 std::array<RenderTargetConfig, NumRenderTargets> rt;
 
@@ -803,7 +803,7 @@ public:
 
                 std::array<ViewPort, NumViewports> viewports;
 
-                INSERT_UNION_PADDING_WORDS(0x1D);
+                INSERT_PADDING_WORDS_NOINIT(0x1D);
 
                 struct {
                     u32 first;
@@ -815,16 +815,16 @@ public:
                 float clear_color[4];
                 float clear_depth;
 
-                INSERT_UNION_PADDING_WORDS(0x3);
+                INSERT_PADDING_WORDS_NOINIT(0x3);
 
                 s32 clear_stencil;
 
-                INSERT_UNION_PADDING_WORDS(0x2);
+                INSERT_PADDING_WORDS_NOINIT(0x2);
 
                 PolygonMode polygon_mode_front;
                 PolygonMode polygon_mode_back;
 
-                INSERT_UNION_PADDING_WORDS(0x3);
+                INSERT_PADDING_WORDS_NOINIT(0x3);
 
                 u32 polygon_offset_point_enable;
                 u32 polygon_offset_line_enable;
@@ -832,47 +832,47 @@ public:
 
                 u32 patch_vertices;
 
-                INSERT_UNION_PADDING_WORDS(0x4);
+                INSERT_PADDING_WORDS_NOINIT(0x4);
 
                 u32 fragment_barrier;
 
-                INSERT_UNION_PADDING_WORDS(0x7);
+                INSERT_PADDING_WORDS_NOINIT(0x7);
 
                 std::array<ScissorTest, NumViewports> scissor_test;
 
-                INSERT_UNION_PADDING_WORDS(0x15);
+                INSERT_PADDING_WORDS_NOINIT(0x15);
 
                 s32 stencil_back_func_ref;
                 u32 stencil_back_mask;
                 u32 stencil_back_func_mask;
 
-                INSERT_UNION_PADDING_WORDS(0x5);
+                INSERT_PADDING_WORDS_NOINIT(0x5);
 
                 u32 invalidate_texture_data_cache;
 
-                INSERT_UNION_PADDING_WORDS(0x1);
+                INSERT_PADDING_WORDS_NOINIT(0x1);
 
                 u32 tiled_cache_barrier;
 
-                INSERT_UNION_PADDING_WORDS(0x4);
+                INSERT_PADDING_WORDS_NOINIT(0x4);
 
                 u32 color_mask_common;
 
-                INSERT_UNION_PADDING_WORDS(0x2);
+                INSERT_PADDING_WORDS_NOINIT(0x2);
 
                 f32 depth_bounds[2];
 
-                INSERT_UNION_PADDING_WORDS(0x2);
+                INSERT_PADDING_WORDS_NOINIT(0x2);
 
                 u32 rt_separate_frag_data;
 
-                INSERT_UNION_PADDING_WORDS(0x1);
+                INSERT_PADDING_WORDS_NOINIT(0x1);
 
                 u32 multisample_raster_enable;
                 u32 multisample_raster_samples;
                 std::array<u32, 4> multisample_sample_mask;
 
-                INSERT_UNION_PADDING_WORDS(0x5);
+                INSERT_PADDING_WORDS_NOINIT(0x5);
 
                 struct {
                     u32 address_high;
@@ -898,7 +898,7 @@ public:
                     };
                 } render_area;
 
-                INSERT_UNION_PADDING_WORDS(0x3F);
+                INSERT_PADDING_WORDS_NOINIT(0x3F);
 
                 union {
                     BitField<0, 4, u32> stencil;
@@ -907,24 +907,24 @@ public:
                     BitField<12, 4, u32> viewport;
                 } clear_flags;
 
-                INSERT_UNION_PADDING_WORDS(0x10);
+                INSERT_PADDING_WORDS_NOINIT(0x10);
 
                 u32 fill_rectangle;
 
-                INSERT_UNION_PADDING_WORDS(0x8);
+                INSERT_PADDING_WORDS_NOINIT(0x8);
 
                 std::array<VertexAttribute, NumVertexAttributes> vertex_attrib_format;
 
                 std::array<MsaaSampleLocation, 4> multisample_sample_locations;
 
-                INSERT_UNION_PADDING_WORDS(0x2);
+                INSERT_PADDING_WORDS_NOINIT(0x2);
 
                 union {
                     BitField<0, 1, u32> enable;
                     BitField<4, 3, u32> target;
                 } multisample_coverage_to_color;
 
-                INSERT_UNION_PADDING_WORDS(0x8);
+                INSERT_PADDING_WORDS_NOINIT(0x8);
 
                 struct {
                     union {
@@ -947,7 +947,7 @@ public:
                     }
                 } rt_control;
 
-                INSERT_UNION_PADDING_WORDS(0x2);
+                INSERT_PADDING_WORDS_NOINIT(0x2);
 
                 u32 zeta_width;
                 u32 zeta_height;
@@ -958,11 +958,11 @@ public:
 
                 SamplerIndex sampler_index;
 
-                INSERT_UNION_PADDING_WORDS(0x25);
+                INSERT_PADDING_WORDS_NOINIT(0x25);
 
                 u32 depth_test_enable;
 
-                INSERT_UNION_PADDING_WORDS(0x5);
+                INSERT_PADDING_WORDS_NOINIT(0x5);
 
                 u32 independent_blend_enable;
 
@@ -970,7 +970,7 @@ public:
 
                 u32 alpha_test_enabled;
 
-                INSERT_UNION_PADDING_WORDS(0x6);
+                INSERT_PADDING_WORDS_NOINIT(0x6);
 
                 u32 d3d_cull_mode;
 
@@ -985,7 +985,7 @@ public:
                     float a;
                 } blend_color;
 
-                INSERT_UNION_PADDING_WORDS(0x4);
+                INSERT_PADDING_WORDS_NOINIT(0x4);
 
                 struct {
                     u32 separate_alpha;
@@ -994,7 +994,7 @@ public:
                     Blend::Factor factor_dest_rgb;
                     Blend::Equation equation_a;
                     Blend::Factor factor_source_a;
-                    INSERT_UNION_PADDING_WORDS(1);
+                    INSERT_PADDING_WORDS_NOINIT(1);
                     Blend::Factor factor_dest_a;
 
                     u32 enable_common;
@@ -1010,7 +1010,7 @@ public:
                 u32 stencil_front_func_mask;
                 u32 stencil_front_mask;
 
-                INSERT_UNION_PADDING_WORDS(0x2);
+                INSERT_PADDING_WORDS_NOINIT(0x2);
 
                 u32 frag_color_clamp;
 
@@ -1022,17 +1022,17 @@ public:
                 float line_width_smooth;
                 float line_width_aliased;
 
-                INSERT_UNION_PADDING_WORDS(0x1B);
+                INSERT_PADDING_WORDS_NOINIT(0x1B);
 
                 u32 invalidate_sampler_cache_no_wfi;
                 u32 invalidate_texture_header_cache_no_wfi;
 
-                INSERT_UNION_PADDING_WORDS(0x2);
+                INSERT_PADDING_WORDS_NOINIT(0x2);
 
                 u32 vb_element_base;
                 u32 vb_base_instance;
 
-                INSERT_UNION_PADDING_WORDS(0x35);
+                INSERT_PADDING_WORDS_NOINIT(0x35);
 
                 u32 clip_distance_enabled;
 
@@ -1040,11 +1040,11 @@ public:
 
                 float point_size;
 
-                INSERT_UNION_PADDING_WORDS(0x1);
+                INSERT_PADDING_WORDS_NOINIT(0x1);
 
                 u32 point_sprite_enable;
 
-                INSERT_UNION_PADDING_WORDS(0x3);
+                INSERT_PADDING_WORDS_NOINIT(0x3);
 
                 CounterReset counter_reset;
 
@@ -1057,7 +1057,7 @@ public:
                     BitField<4, 1, u32> alpha_to_one;
                 } multisample_control;
 
-                INSERT_UNION_PADDING_WORDS(0x4);
+                INSERT_PADDING_WORDS_NOINIT(0x4);
 
                 struct {
                     u32 address_high;
@@ -1081,7 +1081,7 @@ public:
                     }
                 } tsc;
 
-                INSERT_UNION_PADDING_WORDS(0x1);
+                INSERT_PADDING_WORDS_NOINIT(0x1);
 
                 float polygon_offset_factor;
 
@@ -1098,7 +1098,7 @@ public:
                     }
                 } tic;
 
-                INSERT_UNION_PADDING_WORDS(0x5);
+                INSERT_PADDING_WORDS_NOINIT(0x5);
 
                 u32 stencil_two_side_enable;
                 StencilOp stencil_back_op_fail;
@@ -1106,17 +1106,17 @@ public:
                 StencilOp stencil_back_op_zpass;
                 ComparisonOp stencil_back_func_func;
 
-                INSERT_UNION_PADDING_WORDS(0x4);
+                INSERT_PADDING_WORDS_NOINIT(0x4);
 
                 u32 framebuffer_srgb;
 
                 float polygon_offset_units;
 
-                INSERT_UNION_PADDING_WORDS(0x4);
+                INSERT_PADDING_WORDS_NOINIT(0x4);
 
                 Tegra::Texture::MsaaMode multisample_mode;
 
-                INSERT_UNION_PADDING_WORDS(0xC);
+                INSERT_PADDING_WORDS_NOINIT(0xC);
 
                 union {
                     BitField<2, 1, u32> coord_origin;
@@ -1132,7 +1132,7 @@ public:
                             (static_cast<GPUVAddr>(code_address_high) << 32) | code_address_low);
                     }
                 } code_address;
-                INSERT_UNION_PADDING_WORDS(1);
+                INSERT_PADDING_WORDS_NOINIT(1);
 
                 struct {
                     u32 vertex_end_gl;
@@ -1144,14 +1144,14 @@ public:
                     };
                 } draw;
 
-                INSERT_UNION_PADDING_WORDS(0xA);
+                INSERT_PADDING_WORDS_NOINIT(0xA);
 
                 struct {
                     u32 enabled;
                     u32 index;
                 } primitive_restart;
 
-                INSERT_UNION_PADDING_WORDS(0x5F);
+                INSERT_PADDING_WORDS_NOINIT(0x5F);
 
                 struct {
                     u32 start_addr_high;
@@ -1192,9 +1192,9 @@ public:
                     }
                 } index_array;
 
-                INSERT_UNION_PADDING_WORDS(0x7);
+                INSERT_PADDING_WORDS_NOINIT(0x7);
 
-                INSERT_UNION_PADDING_WORDS(0x1F);
+                INSERT_PADDING_WORDS_NOINIT(0x1F);
 
                 float polygon_offset_clamp;
 
@@ -1208,14 +1208,14 @@ public:
                     }
                 } instanced_arrays;
 
-                INSERT_UNION_PADDING_WORDS(0x4);
+                INSERT_PADDING_WORDS_NOINIT(0x4);
 
                 union {
                     BitField<0, 1, u32> enable;
                     BitField<4, 8, u32> unk4;
                 } vp_point_size;
 
-                INSERT_UNION_PADDING_WORDS(1);
+                INSERT_PADDING_WORDS_NOINIT(1);
 
                 u32 cull_test_enabled;
                 FrontFace front_face;
@@ -1223,11 +1223,11 @@ public:
 
                 u32 pixel_center_integer;
 
-                INSERT_UNION_PADDING_WORDS(0x1);
+                INSERT_PADDING_WORDS_NOINIT(0x1);
 
                 u32 viewport_transform_enabled;
 
-                INSERT_UNION_PADDING_WORDS(0x3);
+                INSERT_PADDING_WORDS_NOINIT(0x3);
 
                 union {
                     BitField<0, 1, u32> depth_range_0_1;
@@ -1236,18 +1236,18 @@ public:
                     BitField<11, 1, u32> depth_clamp_disabled;
                 } view_volume_clip_control;
 
-                INSERT_UNION_PADDING_WORDS(0x1F);
+                INSERT_PADDING_WORDS_NOINIT(0x1F);
 
                 u32 depth_bounds_enable;
 
-                INSERT_UNION_PADDING_WORDS(1);
+                INSERT_PADDING_WORDS_NOINIT(1);
 
                 struct {
                     u32 enable;
                     LogicOperation operation;
                 } logic_op;
 
-                INSERT_UNION_PADDING_WORDS(0x1);
+                INSERT_PADDING_WORDS_NOINIT(0x1);
 
                 union {
                     u32 raw;
@@ -1260,9 +1260,9 @@ public:
                     BitField<6, 4, u32> RT;
                     BitField<10, 11, u32> layer;
                 } clear_buffers;
-                INSERT_UNION_PADDING_WORDS(0xB);
+                INSERT_PADDING_WORDS_NOINIT(0xB);
                 std::array<ColorMask, NumRenderTargets> color_mask;
-                INSERT_UNION_PADDING_WORDS(0x38);
+                INSERT_PADDING_WORDS_NOINIT(0x38);
 
                 struct {
                     u32 query_address_high;
@@ -1284,7 +1284,7 @@ public:
                     }
                 } query;
 
-                INSERT_UNION_PADDING_WORDS(0x3C);
+                INSERT_PADDING_WORDS_NOINIT(0x3C);
 
                 struct {
                     union {
@@ -1325,10 +1325,10 @@ public:
                         BitField<4, 4, ShaderProgram> program;
                     };
                     u32 offset;
-                    INSERT_UNION_PADDING_WORDS(14);
+                    INSERT_PADDING_WORDS_NOINIT(14);
                 } shader_config[MaxShaderProgram];
 
-                INSERT_UNION_PADDING_WORDS(0x60);
+                INSERT_PADDING_WORDS_NOINIT(0x60);
 
                 u32 firmware[0x20];
 
@@ -1345,7 +1345,7 @@ public:
                     }
                 } const_buffer;
 
-                INSERT_UNION_PADDING_WORDS(0x10);
+                INSERT_PADDING_WORDS_NOINIT(0x10);
 
                 struct {
                     union {
@@ -1353,18 +1353,18 @@ public:
                         BitField<0, 1, u32> valid;
                         BitField<4, 5, u32> index;
                     };
-                    INSERT_UNION_PADDING_WORDS(7);
+                    INSERT_PADDING_WORDS_NOINIT(7);
                 } cb_bind[MaxShaderStage];
 
-                INSERT_UNION_PADDING_WORDS(0x56);
+                INSERT_PADDING_WORDS_NOINIT(0x56);
 
                 u32 tex_cb_index;
 
-                INSERT_UNION_PADDING_WORDS(0x7D);
+                INSERT_PADDING_WORDS_NOINIT(0x7D);
 
                 std::array<std::array<u8, 128>, NumTransformFeedbackBuffers> tfb_varying_locs;
 
-                INSERT_UNION_PADDING_WORDS(0x298);
+                INSERT_PADDING_WORDS_NOINIT(0x298);
 
                 struct {
                     /// Compressed address of a buffer that holds information about bound SSBOs.
@@ -1376,14 +1376,14 @@ public:
                     }
                 } ssbo_info;
 
-                INSERT_UNION_PADDING_WORDS(0x11);
+                INSERT_PADDING_WORDS_NOINIT(0x11);
 
                 struct {
                     u32 address[MaxShaderStage];
                     u32 size[MaxShaderStage];
                 } tex_info_buffers;
 
-                INSERT_UNION_PADDING_WORDS(0xCC);
+                INSERT_PADDING_WORDS_NOINIT(0xCC);
             };
             std::array<u32, NUM_REGS> reg_array;
         };

--- a/src/video_core/engines/shader_header.h
+++ b/src/video_core/engines/shader_header.h
@@ -68,10 +68,10 @@ struct Header {
 
     union {
         struct {
-            INSERT_UNION_PADDING_BYTES(3);  // ImapSystemValuesA
-            INSERT_UNION_PADDING_BYTES(1);  // ImapSystemValuesB
-            INSERT_UNION_PADDING_BYTES(16); // ImapGenericVector[32]
-            INSERT_UNION_PADDING_BYTES(2);  // ImapColor
+            INSERT_PADDING_BYTES_NOINIT(3);  // ImapSystemValuesA
+            INSERT_PADDING_BYTES_NOINIT(1);  // ImapSystemValuesB
+            INSERT_PADDING_BYTES_NOINIT(16); // ImapGenericVector[32]
+            INSERT_PADDING_BYTES_NOINIT(2);  // ImapColor
             union {
                 BitField<0, 8, u16> clip_distances;
                 BitField<8, 1, u16> point_sprite_s;
@@ -82,20 +82,20 @@ struct Header {
                 BitField<14, 1, u16> instance_id;
                 BitField<15, 1, u16> vertex_id;
             };
-            INSERT_UNION_PADDING_BYTES(5);  // ImapFixedFncTexture[10]
-            INSERT_UNION_PADDING_BYTES(1);  // ImapReserved
-            INSERT_UNION_PADDING_BYTES(3);  // OmapSystemValuesA
-            INSERT_UNION_PADDING_BYTES(1);  // OmapSystemValuesB
-            INSERT_UNION_PADDING_BYTES(16); // OmapGenericVector[32]
-            INSERT_UNION_PADDING_BYTES(2);  // OmapColor
-            INSERT_UNION_PADDING_BYTES(2);  // OmapSystemValuesC
-            INSERT_UNION_PADDING_BYTES(5);  // OmapFixedFncTexture[10]
-            INSERT_UNION_PADDING_BYTES(1);  // OmapReserved
+            INSERT_PADDING_BYTES_NOINIT(5);  // ImapFixedFncTexture[10]
+            INSERT_PADDING_BYTES_NOINIT(1);  // ImapReserved
+            INSERT_PADDING_BYTES_NOINIT(3);  // OmapSystemValuesA
+            INSERT_PADDING_BYTES_NOINIT(1);  // OmapSystemValuesB
+            INSERT_PADDING_BYTES_NOINIT(16); // OmapGenericVector[32]
+            INSERT_PADDING_BYTES_NOINIT(2);  // OmapColor
+            INSERT_PADDING_BYTES_NOINIT(2);  // OmapSystemValuesC
+            INSERT_PADDING_BYTES_NOINIT(5);  // OmapFixedFncTexture[10]
+            INSERT_PADDING_BYTES_NOINIT(1);  // OmapReserved
         } vtg;
 
         struct {
-            INSERT_UNION_PADDING_BYTES(3); // ImapSystemValuesA
-            INSERT_UNION_PADDING_BYTES(1); // ImapSystemValuesB
+            INSERT_PADDING_BYTES_NOINIT(3); // ImapSystemValuesA
+            INSERT_PADDING_BYTES_NOINIT(1); // ImapSystemValuesB
 
             union {
                 BitField<0, 2, PixelImap> x;
@@ -105,10 +105,10 @@ struct Header {
                 u8 raw;
             } imap_generic_vector[32];
 
-            INSERT_UNION_PADDING_BYTES(2);  // ImapColor
-            INSERT_UNION_PADDING_BYTES(2);  // ImapSystemValuesC
-            INSERT_UNION_PADDING_BYTES(10); // ImapFixedFncTexture[10]
-            INSERT_UNION_PADDING_BYTES(2);  // ImapReserved
+            INSERT_PADDING_BYTES_NOINIT(2);  // ImapColor
+            INSERT_PADDING_BYTES_NOINIT(2);  // ImapSystemValuesC
+            INSERT_PADDING_BYTES_NOINIT(10); // ImapFixedFncTexture[10]
+            INSERT_PADDING_BYTES_NOINIT(2);  // ImapReserved
 
             struct {
                 u32 target;

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -270,7 +270,7 @@ public:
 
         union {
             struct {
-                INSERT_UNION_PADDING_WORDS(0x4);
+                INSERT_PADDING_WORDS_NOINIT(0x4);
                 struct {
                     u32 address_high;
                     u32 address_low;
@@ -283,18 +283,18 @@ public:
 
                 u32 semaphore_sequence;
                 u32 semaphore_trigger;
-                INSERT_UNION_PADDING_WORDS(0xC);
+                INSERT_PADDING_WORDS_NOINIT(0xC);
 
                 // The pusher and the puller share the reference counter, the pusher only has read
                 // access
                 u32 reference_count;
-                INSERT_UNION_PADDING_WORDS(0x5);
+                INSERT_PADDING_WORDS_NOINIT(0x5);
 
                 u32 semaphore_acquire;
                 u32 semaphore_release;
                 u32 fence_value;
                 FenceAction fence_action;
-                INSERT_UNION_PADDING_WORDS(0xE2);
+                INSERT_PADDING_WORDS_NOINIT(0xE2);
 
                 // Puller state
                 u32 acquire_mode;


### PR DESCRIPTION
`INSERT_PADDING_BYTES_NOINIT` is more descriptive of the underlying behavior.