### PR TITLE
vk_shader_decompiler: Show comments as OpUndef with a type

### DIFF
--- a/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
+++ b/src/video_core/renderer_vulkan/vk_shader_decompiler.cpp
@@ -1334,7 +1334,10 @@ private:
         }
 
         if (const auto comment = std::get_if<CommentNode>(&*node)) {
-            Name(OpUndef(t_void), comment->GetText());
+            if (device.HasDebuggingToolAttached()) {
+                // We should insert comments with OpString instead of using named variables
+                Name(OpUndef(t_int), comment->GetText());
+            }
             return {};
         }
 


### PR DESCRIPTION
Silence the new validation layer error about SPIR-V not allowing OpUndef
on a OpTypeVoid, even when the SPIR-V spec doesn't say anything against
it.

They will be inserted as an undefined int to avoid SPIRV-Cross and
validation errors, but only when a debugging tool is attached.

We should use OpString for this in the future.