### PR TITLE
Fix player 1 turning on handheld and not updating handheld settings

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -1005,7 +1005,8 @@ void Config::SavePlayerValue(std::size_t player_index) {
                  static_cast<u8>(Settings::ControllerType::ProController));
 
     if (!player_prefix.isEmpty()) {
-        WriteSetting(QStringLiteral("%1connected").arg(player_prefix), player.connected, false);
+        WriteSetting(QStringLiteral("%1connected").arg(player_prefix), player.connected,
+                     player_index == 0);
         WriteSetting(QStringLiteral("%1vibration_enabled").arg(player_prefix),
                      player.vibration_enabled, true);
         WriteSetting(QStringLiteral("%1vibration_strength").arg(player_prefix),

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -575,6 +575,16 @@ void ConfigureInputPlayer::ApplyConfiguration() {
 
     std::transform(motions_param.begin(), motions_param.end(), motions.begin(),
                    [](const Common::ParamPackage& param) { return param.Serialize(); });
+
+    // Apply configuration for handheld
+    if (player_index == 0) {
+        auto& handheld = Settings::values.players.GetValue()[HANDHELD_INDEX];
+        if (player.controller_type == Settings::ControllerType::Handheld) {
+            handheld = player;
+        }
+        handheld.connected = ui->groupConnectedController->isChecked() &&
+                             player.controller_type == Settings::ControllerType::Handheld;
+    }
 }
 
 void ConfigureInputPlayer::TryConnectSelectedController() {


### PR DESCRIPTION
The default connected value when loading the player 1 is true and the default connected value when saving the player 1 was false. Because of this the player 1 was always on, regardless of the config. 

Handheld configuration is a copy of the configuration of player 1 but the configuration only was updated when handheld was turned on for the first time.

This PR addresses both issues. By fixing the default value for player 1 and always updating the configuration for handheld when it's turned on.
