### PR TITLE
video_core: Resolve -Wdocumentation warnings

### DIFF
--- a/src/video_core/buffer_cache/buffer_base.h
+++ b/src/video_core/buffer_cache/buffer_base.h
@@ -446,7 +446,7 @@ private:
      * @param offset Offset in bytes from the start of the buffer
      * @param size   Size in bytes of the region to query for modifications
      *
-     * @tparam True to query GPU modified pages, false for CPU pages
+     * @tparam gpu True to query GPU modified pages, false for CPU pages
      */
     template <bool gpu>
     [[nodiscard]] std::pair<u64, u64> ModifiedRegion(u64 offset, u64 size) const noexcept {

--- a/src/video_core/vulkan_common/vulkan_memory_allocator.h
+++ b/src/video_core/vulkan_common/vulkan_memory_allocator.h
@@ -74,11 +74,10 @@ public:
     MemoryAllocator(const MemoryAllocator&) = delete;
 
     /**
-     * Commits a memory with the specified requeriments.
+     * Commits a memory with the specified requirements.
      *
      * @param requirements Requirements returned from a Vulkan call.
-     * @param host_visible Signals the allocator that it *must* use host visible and coherent
-     *                     memory. When passing false, it will try to allocate device local memory.
+     * @param usage        Indicates how the memory will be used.
      *
      * @returns A memory commit.
      */


### PR DESCRIPTION
Silences some -Wdocumentation warnings on Clang.

Also fixes a minor typo, given we're in the same area.