### PR TITLE
configure_service: Only compile FormatEventStatusString when YUZU_ENABLE_BOXCAT is enabled

### DIFF
--- a/src/yuzu/configuration/configure_service.cpp
+++ b/src/yuzu/configuration/configure_service.cpp
@@ -9,6 +9,7 @@
 #include "ui_configure_service.h"
 #include "yuzu/configuration/configure_service.h"
 
+#ifdef YUZU_ENABLE_BOXCAT
 namespace {
 QString FormatEventStatusString(const Service::BCAT::EventStatus& status) {
     QString out;
@@ -32,6 +33,7 @@ QString FormatEventStatusString(const Service::BCAT::EventStatus& status) {
     return out;
 }
 } // Anonymous namespace
+#endif
 
 ConfigureService::ConfigureService(QWidget* parent)
     : QWidget(parent), ui(std::make_unique<Ui::ConfigureService>()) {


### PR DESCRIPTION
The function is unused if YUZU_ENABLE_BOXCAT is disabled, causing a `-Wunused-function` error when compiled using GCC.

I am wrapping it with `#ifdef YUZU_ENABLE_BOXCAT` to prevent compiling the function when the variable is disabled. I am opting to not use `[[maybe unused]]` in case the function is totally unused in the future.