### PR TITLE
npad: Add check for HANDHELD_INDEX in UpdateControllerAt()

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -892,7 +892,7 @@ void Controller_NPad::UpdateControllerAt(NPadControllerType controller, std::siz
         return;
     }
 
-    if (controller == NPadControllerType::Handheld) {
+    if (controller == NPadControllerType::Handheld && npad_index == HANDHELD_INDEX) {
         Settings::values.players.GetValue()[HANDHELD_INDEX].controller_type =
             MapNPadToSettingsType(controller);
         Settings::values.players.GetValue()[HANDHELD_INDEX].connected = true;


### PR DESCRIPTION
Ensures the handheld controller is only connected if the correct npad_index is sent