### PR TITLE
renderer_opengl: Avoid precompiled cache and force NV GL cache directory

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -138,6 +138,8 @@ add_library(common STATIC
     microprofile.h
     microprofileui.h
     misc.cpp
+    nvidia_flags.cpp
+    nvidia_flags.h
     page_table.cpp
     page_table.h
     param_package.cpp

--- a/src/common/nvidia_flags.cpp
+++ b/src/common/nvidia_flags.cpp
@@ -1,0 +1,27 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <filesystem>
+#include <stdlib.h>
+
+#include <fmt/format.h>
+
+#include "common/file_util.h"
+#include "common/nvidia_flags.h"
+
+namespace Common {
+
+void ConfigureNvidiaEnvironmentFlags() {
+#ifdef _WIN32
+    const std::string shader_path = Common::FS::SanitizePath(
+        fmt::format("{}/nvidia/", Common::FS::GetUserPath(Common::FS::UserPath::ShaderDir)));
+    const std::string windows_path =
+        Common::FS::SanitizePath(shader_path, Common::FS::DirectorySeparator::BackwardSlash);
+    void(Common::FS::CreateFullPath(shader_path + '/'));
+    void(_putenv(fmt::format("__GL_SHADER_DISK_CACHE_PATH={}", windows_path).c_str()));
+    void(_putenv("__GL_SHADER_DISK_CACHE_SKIP_CLEANUP=1"));
+#endif
+}
+
+} // namespace Common

--- a/src/common/nvidia_flags.h
+++ b/src/common/nvidia_flags.h
@@ -1,0 +1,10 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+namespace Common {
+
+/// Configure platform specific flags for Nvidia's driver
+void ConfigureNvidiaEnvironmentFlags();
+
+} // namespace Common

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -246,6 +246,7 @@ Device::Device()
                            GLAD_GL_NV_transform_feedback && GLAD_GL_NV_transform_feedback2;
 
     use_asynchronous_shaders = Settings::values.use_asynchronous_shaders.GetValue();
+    use_driver_cache = is_nvidia;
 
     LOG_INFO(Render_OpenGL, "Renderer_VariableAOFFI: {}", has_variable_aoffi);
     LOG_INFO(Render_OpenGL, "Renderer_ComponentIndexingBug: {}", has_component_indexing_bug);

--- a/src/video_core/renderer_opengl/gl_device.h
+++ b/src/video_core/renderer_opengl/gl_device.h
@@ -120,6 +120,10 @@ public:
         return use_asynchronous_shaders;
     }
 
+    bool UseDriverCache() const {
+        return use_driver_cache;
+    }
+
 private:
     static bool TestVariableAoffi();
     static bool TestPreciseBug();
@@ -147,6 +151,7 @@ private:
     bool has_debugging_tool_attached{};
     bool use_assembly_shaders{};
     bool use_asynchronous_shaders{};
+    bool use_driver_cache{};
 };
 
 } // namespace OpenGL

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -16,6 +16,7 @@
 #include "applets/profile_select.h"
 #include "applets/software_keyboard.h"
 #include "applets/web_browser.h"
+#include "common/nvidia_flags.h"
 #include "configuration/configure_input.h"
 #include "configuration/configure_per_game.h"
 #include "configuration/configure_vibration.h"
@@ -3022,6 +3023,8 @@ int main(int argc, char* argv[]) {
     Common::DetachedTasks detached_tasks;
     MicroProfileOnThreadCreate("Frontend");
     SCOPE_EXIT({ MicroProfileShutdown(); });
+
+    Common::ConfigureNvidiaEnvironmentFlags();
 
     // Init settings params
     QCoreApplication::setOrganizationName(QStringLiteral("yuzu team"));

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -17,6 +17,7 @@
 #include "common/logging/filter.h"
 #include "common/logging/log.h"
 #include "common/microprofile.h"
+#include "common/nvidia_flags.h"
 #include "common/scm_rev.h"
 #include "common/scope_exit.h"
 #include "common/string_util.h"
@@ -151,6 +152,8 @@ int main(int argc, char** argv) {
 
     MicroProfileOnThreadCreate("EmuThread");
     SCOPE_EXIT({ MicroProfileShutdown(); });
+
+    Common::ConfigureNvidiaEnvironmentFlags();
 
     if (filepath.empty()) {
         LOG_CRITICAL(Frontend, "Failed to load ROM: No ROM specified");


### PR DESCRIPTION
Setting __GL_SHADER_DISK_CACHE_PATH we can force the cache directory to
be in yuzu's user directory to stop commonly distributed malware from
deleting our driver shader cache. And by setting
__GL_SHADER_DISK_CACHE_SKIP_CLEANUP we can have an unbounded shader
cache size.

This has only been implemented on Windows, mostly because previous tests
didn't seem to work on Linux.

Disable the precompiled cache on Nvidia's driver. There's no need to
hide information the driver already has in its own cache.

Thanks to Exzap from Cemu for telling me what environment flags to set on Windows.