### PR TITLE
nvdrv: Unregister already registered events

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -155,7 +155,14 @@ NvResult nvhost_ctrl::IocCtrlEventRegister(const std::vector<u8>& input, std::ve
         return NvResult::BadParameter;
     }
     if (events_interface.registered[event_id]) {
-        return NvResult::BadParameter;
+        const auto event_state = events_interface.status[event_id];
+        if (event_state == EventState::Registered || event_state == EventState::Waiting ||
+            event_state == EventState::Busy) {
+            LOG_WARNING(Service_NVDRV, "Event already registered! Unregistering previous event");
+            events_interface.UnregisterEvent(event_id);
+        } else {
+            return NvResult::BadParameter;
+        }
     }
     events_interface.RegisterEvent(event_id);
     return NvResult::Success;

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -156,8 +156,7 @@ NvResult nvhost_ctrl::IocCtrlEventRegister(const std::vector<u8>& input, std::ve
     }
     if (events_interface.registered[event_id]) {
         const auto event_state = events_interface.status[event_id];
-        if (event_state == EventState::Registered || event_state == EventState::Waiting ||
-            event_state == EventState::Busy) {
+        if (event_state != EventState::Free) {
             LOG_WARNING(Service_NVDRV, "Event already registered! Unregistering previous event");
             events_interface.UnregisterEvent(event_id);
         } else {


### PR DESCRIPTION
Fixes softlocks in pokemon lets go caused by Nvdec.
Fixed softlock caused by leon in sword and shield
![2021-01-21_58-35-c2154a60-b2e4-461f-9d2b-f91e37929c7d-pL9AH7hq](https://user-images.githubusercontent.com/25727384/105576554-9aaf8000-5dc7-11eb-9764-78bb17ce32ff.jpg)
