### PR TITLE
Fix connect and disconnect controller events

### DIFF
--- a/src/yuzu/configuration/configure_input.cpp
+++ b/src/yuzu/configuration/configure_input.cpp
@@ -190,11 +190,15 @@ void ConfigureInput::ApplyConfiguration() {
     // This emulates a delay between disconnecting and reconnecting controllers as some games
     // do not respond to a change in controller type if it was instantaneous.
     using namespace std::chrono_literals;
-    std::this_thread::sleep_for(60ms);
+    std::this_thread::sleep_for(150ms);
 
     for (auto* controller : player_controllers) {
         controller->TryConnectSelectedController();
     }
+
+    // This emulates a delay between disconnecting and reconnecting controllers as some games
+    // do not respond to a change in controller type if it was instantaneous.
+    std::this_thread::sleep_for(150ms);
 
     advanced->ApplyConfiguration();
 


### PR DESCRIPTION
Increases delay before and after connecting the controllers to reduce the chance of missing the event. Adds more rules to prevent sending invalid events like disconnecting a controller that it's already disconnected or the other way around. Rewrites handheld event handling to apply the same rules as the other controllers.

This fixes Pokemon let's go controller selection.