### PR TITLE
Network error handling reform

### DIFF
--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -52,8 +52,12 @@ __declspec(dllimport) void __stdcall DebugBreak(void);
 // Generic function to get last error message.
 // Call directly after the command or use the error num.
 // This function might change the error code.
-// Defined in Misc.cpp.
+// Defined in misc.cpp.
 [[nodiscard]] std::string GetLastErrorMsg();
+
+// Like GetLastErrorMsg(), but passing an explicit error code.
+// Defined in misc.cpp.
+[[nodiscard]] std::string NativeErrorToString(int e);
 
 #define DECLARE_ENUM_FLAG_OPERATORS(type)                                                          \
     [[nodiscard]] constexpr type operator|(type a, type b) noexcept {                              \

--- a/src/common/misc.cpp
+++ b/src/common/misc.cpp
@@ -12,27 +12,41 @@
 
 #include "common/common_funcs.h"
 
-// Generic function to get last error message.
-// Call directly after the command or use the error num.
-// This function might change the error code.
-std::string GetLastErrorMsg() {
-    static constexpr std::size_t buff_size = 255;
-    char err_str[buff_size];
-
+std::string NativeErrorToString(int e) {
 #ifdef _WIN32
-    FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, nullptr, GetLastError(),
-                   MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), err_str, buff_size, nullptr);
-    return std::string(err_str, buff_size);
-#elif defined(__GLIBC__) && (_GNU_SOURCE || (_POSIX_C_SOURCE < 200112L && _XOPEN_SOURCE < 600))
+    LPSTR err_str;
+
+    DWORD res = FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                                   FORMAT_MESSAGE_IGNORE_INSERTS,
+                               nullptr, e, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                               reinterpret_cast<LPSTR>(&err_str), 1, nullptr);
+    if (!res) {
+        return "(FormatMessageA failed to format error)";
+    }
+    std::string ret(err_str);
+    LocalFree(err_str);
+    return ret;
+#else
+    char err_str[255];
+#if defined(__GLIBC__) && (_GNU_SOURCE || (_POSIX_C_SOURCE < 200112L && _XOPEN_SOURCE < 600))
     // Thread safe (GNU-specific)
-    const char* str = strerror_r(errno, err_str, buff_size);
+    const char* str = strerror_r(e, err_str, sizeof(err_str));
     return std::string(str);
 #else
     // Thread safe (XSI-compliant)
-    const int success = strerror_r(errno, err_str, buff_size);
-    if (success != 0) {
-        return {};
+    int second_err = strerror_r(e, err_str, sizeof(err_str));
+    if (second_err != 0) {
+        return "(strerror_r failed to format error)";
     }
     return std::string(err_str);
+#endif // GLIBC etc.
+#endif // _WIN32
+}
+
+std::string GetLastErrorMsg() {
+#ifdef _WIN32
+    return NativeErrorToString(GetLastError());
+#else
+    return NativeErrorToString(errno);
 #endif
 }

--- a/src/core/network/network.h
+++ b/src/core/network/network.h
@@ -7,6 +7,7 @@
 #include <array>
 #include <utility>
 
+#include "common/common_funcs.h"
 #include "common/common_types.h"
 
 namespace Network {
@@ -21,6 +22,11 @@ enum class Errno {
     MFILE,
     NOTCONN,
     AGAIN,
+    CONNREFUSED,
+    HOSTUNREACH,
+    NETDOWN,
+    NETUNREACH,
+    OTHER,
 };
 
 /// Address families

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ add_executable(tests
     common/param_package.cpp
     common/ring_buffer.cpp
     core/core_timing.cpp
+    core/network/network.cpp
     tests.cpp
     video_core/buffer_base.cpp
 )

--- a/src/tests/core/network/network.cpp
+++ b/src/tests/core/network/network.cpp
@@ -1,0 +1,28 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <catch2/catch.hpp>
+
+#include "core/network/network.h"
+#include "core/network/sockets.h"
+
+TEST_CASE("Network::Errors", "[core]") {
+    Network::NetworkInstance network_instance; // initialize network
+
+    Network::Socket socks[2];
+    for (Network::Socket& sock : socks) {
+        REQUIRE(sock.Initialize(Network::Domain::INET, Network::Type::STREAM,
+                                Network::Protocol::TCP) == Network::Errno::SUCCESS);
+    }
+
+    Network::SockAddrIn addr{
+        Network::Domain::INET,
+        {127, 0, 0, 1},
+        1, // hopefully nobody running this test has something listening on port 1
+    };
+    REQUIRE(socks[0].Connect(addr) == Network::Errno::CONNREFUSED);
+
+    std::vector<u8> message{1, 2, 3, 4};
+    REQUIRE(socks[1].Recv(0, message).second == Network::Errno::NOTCONN);
+}


### PR DESCRIPTION
`network.cpp` has several error paths which either:
- report "Unhandled host socket error=n" and return `SUCCESS`, or
- switch on a few possible errors, log them, and translate them to
  Errno; the same switch statement is copied and pasted in multiple
  places in the code

Convert these paths to use a helper function `GetAndLogLastError`, which
is roughly the equivalent of one of the switch statements, but:
- handling more cases (both ones that were already in `Errno`, and a few
  more I added), and
- using OS functions to convert the error to a string when logging, so
  it'll describe the error even if it's not one of the ones in the
  switch statement.
  - To handle this, refactor the logic in `GetLastErrorMsg` to expose
    new functions `WinErrorToString` and `UnixErrnoToString` which take
    the error number explicitly as an argument.  And improve the Windows
    version a bit.

Also, add a test which exercises two random error paths.