### PR TITLE
gpu_thread: Disable flush on read on normal GPU accuracy

### DIFF
--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -106,14 +106,10 @@ void ThreadManager::FlushRegion(VAddr addr, u64 size) {
         PushCommand(FlushRegionCommand(addr, size));
         return;
     }
-
     // Asynchronous GPU mode
     switch (Settings::values.gpu_accuracy.GetValue()) {
     case Settings::GPUAccuracy::Normal:
-        PushCommand(FlushRegionCommand(addr, size));
-        break;
     case Settings::GPUAccuracy::High:
-        // TODO(bunnei): Is this right? Preserving existing behavior for now
         break;
     case Settings::GPUAccuracy::Extreme: {
         auto& gpu = system.GPU();


### PR DESCRIPTION
This is an unfortunate oversight when adding more GPU accuracies. It
makes no sense to be more accurate (and fail to do so) in normal
accuracy than in high.

I plan to merge Normal and High in the same setting in the future.