### PR TITLE
shader_ir: int flags part 2

### DIFF
--- a/src/video_core/shader/shader_ir.cpp
+++ b/src/video_core/shader/shader_ir.cpp
@@ -431,6 +431,13 @@ void ShaderIR::SearchOperands(NodeBlock& nb, Node var) {
                 SetInternalFlag(nb, InternalFlag::Zero, std::move(zerop));
             }
             break;
+        case 4: // Immediate Node
+            if (const auto* imm = std::get_if<ImmediateNode>(operand.get())) {
+                LOG_INFO(HW_GPU, "Child ImmediateNode: value={}", imm->GetValue());
+                Node zerop = Operation(OperationCode::LogicalIEqual, std::move(operand));
+                SetInternalFlag(nb, InternalFlag::Zero, std::move(zerop));
+            }
+            break;
         default:
             LOG_WARNING(HW_GPU, "Child Node Type: {}", operand->index());
             break;


### PR DESCRIPTION
Adding Immediate Node to the search function as it is needed by Super Smash Bros.
Sadly I don't have this game so I can't test.
I set the log level to info for testing, I will change it to debug once we know this is working.