### PR TITLE
Fix Icon Theme issues on some Linux Desktop Environments/Window Managers

### DIFF
--- a/dist/qt_themes/colorful_dark/icons/index.theme
+++ b/dist/qt_themes/colorful_dark/icons/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=colorful_dark
 Comment=Colorful theme (Dark style)
-Inherits=default
+Inherits=colorful
 Directories=16x16
  
 [16x16]

--- a/dist/qt_themes/colorful_midnight_blue/icons/index.theme
+++ b/dist/qt_themes/colorful_midnight_blue/icons/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=colorful_midnight_blue
 Comment=Colorful theme (Midnight Blue style)
-Inherits=default
+Inherits=colorful
 Directories=16x16
 
 [16x16]

--- a/dist/qt_themes/qdarkstyle_midnight_blue/style.qss
+++ b/dist/qt_themes/qdarkstyle_midnight_blue/style.qss
@@ -1257,10 +1257,6 @@ QComboBox::item:alternate {
   background: #19232D;
 }
 
-QComboBox::item:checked {
-  font-weight: bold;
-}
-
 QComboBox::item:selected {
   border: 0px solid transparent;
 }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2927,7 +2927,7 @@ void GMainWindow::filterBarSetChecked(bool state) {
 }
 
 void GMainWindow::UpdateUITheme() {
-    const QString default_icons = QStringLiteral(":/icons/default");
+    const QString default_icons = QStringLiteral("default");
     const QString& current_theme = UISettings::values.theme;
     const bool is_default_theme = current_theme == QString::fromUtf8(UISettings::themes[0].second);
     QStringList theme_paths(default_theme_paths);
@@ -2943,7 +2943,6 @@ void GMainWindow::UpdateUITheme() {
             qApp->setStyleSheet({});
             setStyleSheet({});
         }
-        theme_paths.append(default_icons);
         QIcon::setThemeName(default_icons);
     } else {
         const QString theme_uri(QLatin1Char{':'} + current_theme + QStringLiteral("/style.qss"));
@@ -2955,10 +2954,7 @@ void GMainWindow::UpdateUITheme() {
         } else {
             LOG_ERROR(Frontend, "Unable to set style, stylesheet file not found");
         }
-
-        const QString theme_name = QStringLiteral(":/icons/") + current_theme;
-        theme_paths.append({default_icons, theme_name});
-        QIcon::setThemeName(theme_name);
+        QIcon::setThemeName(current_theme);
     }
 
     QIcon::setThemeSearchPaths(theme_paths);


### PR DESCRIPTION
Closes #5269 

While working on some GTK desktop environments (like GNOME), the icon theme was broken for most DEs/WMs.

yuzu on KDE:
![image](https://user-images.githubusercontent.com/67879877/105917200-b4a4c900-603a-11eb-9c73-20fe79bc6a90.png)
Falling back to the Breeze icon theme while printing
`Icon theme ":/icons/colorful" not found.`
and many `QPixmap::scaled: Pixmap is a null pixmap` warnings.

yuzu on LXQt
![image](https://user-images.githubusercontent.com/67879877/105917476-06e5ea00-603b-11eb-8b62-a5fc464d314b.png)
The fallback is hicolor which didn't provide the folder icon so it looks even worse.

A temporary workaround was to export `QT_QPA_PLATFORMTHEME=gtk3` which made yuzu look like it did in GNOME.

The reason was that yuzu on a Qt Desktop was looking for the theme ":/icons/colorful" (using Light Colorful as the example) which is a path instead of "colorful" which is the name of the theme. Since the method `QIcon::themeSearchPaths();` already returns `:/icons` the path was axed from the `QIcon::setThemeName();` method. For this to work the two colorful dark themes were changed to inherit the icons from the colorful themes.

Using a custom debug build that prints the theme names and paths we can see more clearly what the Qt gui does when run normally on a Qt DE and when run with the env
![image](https://user-images.githubusercontent.com/67879877/105918913-6b09ad80-603d-11eb-93e7-dbecf992ba95.png)
 
When the env is set, Fallback Theme is null and the Search Paths are scattered differently.

According to https://doc.qt.io/qt-5/qicon.html#fallbackThemeName:
"On X11, if not set, the fallback icon theme depends on your desktop settings. On other platforms it is not set by default."
so perhaps a fallback theme being set "steals" the priority from the :/icons path from the Search Paths.

After all this, yuzu looks nice:
![image](https://user-images.githubusercontent.com/67879877/105919312-11ee4980-603e-11eb-8262-c9d5b6bf35f9.png)

Another issue resolved by this PR plagued GTK DE users made QComboBox huge when it was hovered on the Midnight Blue themes.

The reason was that the checked item was Bold. Since the other themes don't utilize bold and this wasn't visible on Windows it was removed.

Bellow a screenshot from KDE
![image](https://user-images.githubusercontent.com/67879877/105919756-d99b3b00-603e-11eb-9c3c-bbe552147b34.png)
(For some reason the angles are missing on KDE)

And screenshots in a GTK DE
Before:
![image](https://user-images.githubusercontent.com/67879877/105919500-6c87a580-603e-11eb-84ec-bb5a1215c300.png)

After:
![image](https://user-images.githubusercontent.com/67879877/105919869-0a7b7000-603f-11eb-807b-e69887a95e05.png)

Testing on Windows required.