### PR TITLE
hid: Cleanup SixAxisFusionParameters

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -946,20 +946,19 @@ void Controller_NPad::SetSixAxisEnabled(bool six_axis_status) {
     sixaxis_sensors_enabled = six_axis_status;
 }
 
-void Controller_NPad::SetSixAxisFusionParameters(const DeviceHandle& handle, f32 parameter1,
-                                                 f32 parameter2) {
+void Controller_NPad::SetSixAxisFusionParameters(f32 parameter1, f32 parameter2) {
     sixaxis_fusion_parameter1 = parameter1;
     sixaxis_fusion_parameter2 = parameter2;
 }
 
-std::pair<f32, f32> Controller_NPad::GetSixAxisFusionParameters(const DeviceHandle& handle) {
+std::pair<f32, f32> Controller_NPad::GetSixAxisFusionParameters() {
     return {
         sixaxis_fusion_parameter1,
         sixaxis_fusion_parameter2,
     };
 }
 
-void Controller_NPad::ResetSixAxisFusionParameters(const DeviceHandle& handle) {
+void Controller_NPad::ResetSixAxisFusionParameters() {
     sixaxis_fusion_parameter1 = 0.0f;
     sixaxis_fusion_parameter2 = 0.0f;
 }

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -202,9 +202,9 @@ public:
     GyroscopeZeroDriftMode GetGyroscopeZeroDriftMode() const;
     bool IsSixAxisSensorAtRest() const;
     void SetSixAxisEnabled(bool six_axis_status);
-    void SetSixAxisFusionParameters(const DeviceHandle& handle, f32 parameter1, f32 parameter2);
-    std::pair<f32, f32> GetSixAxisFusionParameters(const DeviceHandle& handle);
-    void ResetSixAxisFusionParameters(const DeviceHandle& handle);
+    void SetSixAxisFusionParameters(f32 parameter1, f32 parameter2);
+    std::pair<f32, f32> GetSixAxisFusionParameters();
+    void ResetSixAxisFusionParameters();
     LedPattern GetLedPattern(u32 npad_id);
     bool IsUnintendedHomeButtonInputProtectionEnabled(u32 npad_id) const;
     void SetUnintendedHomeButtonInputProtectionEnabled(bool is_protection_enabled, u32 npad_id);

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -520,6 +520,7 @@ void Hid::EnableSixAxisSensorFusion(Kernel::HLERequestContext& ctx) {
         Controller_NPad::DeviceHandle sixaxis_handle;
         u64 applet_resource_user_id;
     };
+    static_assert(sizeof(Parameters) == 0x10, "Parameters has incorrect size.");
 
     const auto parameters{rp.PopRaw<Parameters>()};
 
@@ -542,6 +543,7 @@ void Hid::SetSixAxisSensorFusionParameters(Kernel::HLERequestContext& ctx) {
         f32 parameter2;
         u64 applet_resource_user_id;
     };
+    static_assert(sizeof(Parameters) == 0x18, "Parameters has incorrect size.");
 
     const auto parameters{rp.PopRaw<Parameters>()};
 
@@ -549,11 +551,11 @@ void Hid::SetSixAxisSensorFusionParameters(Kernel::HLERequestContext& ctx) {
         .SetSixAxisFusionParameters(parameters.parameter1, parameters.parameter2);
 
     LOG_WARNING(Service_HID,
-                "(STUBBED) called, float1={}, float2={}, npad_type={}, npad_id={}, "
-                "device_index={}, applet_resource_user_id={}",
-                parameters.parameter1, parameters.parameter2, parameters.sixaxis_handle.npad_type,
-                parameters.sixaxis_handle.npad_id, parameters.sixaxis_handle.device_index,
-                parameters.applet_resource_user_id);
+                "(STUBBED) called, npad_type={}, npad_id={}, device_index={}, parameter1={}, "
+                "parameter2={}, applet_resource_user_id={}",
+                parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
+                parameters.sixaxis_handle.device_index, parameters.parameter1,
+                parameters.parameter2, parameters.applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
@@ -565,6 +567,7 @@ void Hid::GetSixAxisSensorFusionParameters(Kernel::HLERequestContext& ctx) {
         Controller_NPad::DeviceHandle sixaxis_handle;
         u64 applet_resource_user_id;
     };
+    static_assert(sizeof(Parameters) == 0x10, "Parameters has incorrect size.");
 
     f32 parameter1 = 0;
     f32 parameter2 = 0;
@@ -574,11 +577,11 @@ void Hid::GetSixAxisSensorFusionParameters(Kernel::HLERequestContext& ctx) {
         applet_resource->GetController<Controller_NPad>(HidController::NPad)
             .GetSixAxisFusionParameters();
 
-    LOG_WARNING(Service_HID,
-                "(STUBBED) called, npad_type={}, npad_id={}, "
-                "device_index={}, applet_resource_user_id={}",
-                parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
-                parameters.sixaxis_handle.device_index, parameters.applet_resource_user_id);
+    LOG_WARNING(
+        Service_HID,
+        "(STUBBED) called, npad_type={}, npad_id={}, device_index={}, applet_resource_user_id={}",
+        parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
+        parameters.sixaxis_handle.device_index, parameters.applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(RESULT_SUCCESS);
@@ -592,17 +595,18 @@ void Hid::ResetSixAxisSensorFusionParameters(Kernel::HLERequestContext& ctx) {
         Controller_NPad::DeviceHandle sixaxis_handle;
         u64 applet_resource_user_id;
     };
+    static_assert(sizeof(Parameters) == 0x10, "Parameters has incorrect size.");
 
     const auto parameters{rp.PopRaw<Parameters>()};
 
     applet_resource->GetController<Controller_NPad>(HidController::NPad)
         .ResetSixAxisFusionParameters();
 
-    LOG_WARNING(Service_HID,
-                "(STUBBED) called, npad_type={}, npad_id={}, "
-                "device_index={}, applet_resource_user_id={}",
-                parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
-                parameters.sixaxis_handle.device_index, parameters.applet_resource_user_id);
+    LOG_WARNING(
+        Service_HID,
+        "(STUBBED) called, npad_type={}, npad_id={}, device_index={}, applet_resource_user_id={}",
+        parameters.sixaxis_handle.npad_type, parameters.sixaxis_handle.npad_id,
+        parameters.sixaxis_handle.device_index, parameters.applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -546,8 +546,7 @@ void Hid::SetSixAxisSensorFusionParameters(Kernel::HLERequestContext& ctx) {
     const auto parameters{rp.PopRaw<Parameters>()};
 
     applet_resource->GetController<Controller_NPad>(HidController::NPad)
-        .SetSixAxisFusionParameters(parameters.sixaxis_handle, parameters.parameter1,
-                                    parameters.parameter2);
+        .SetSixAxisFusionParameters(parameters.parameter1, parameters.parameter2);
 
     LOG_WARNING(Service_HID,
                 "(STUBBED) called, float1={}, float2={}, npad_type={}, npad_id={}, "
@@ -573,7 +572,7 @@ void Hid::GetSixAxisSensorFusionParameters(Kernel::HLERequestContext& ctx) {
 
     std::tie(parameter1, parameter2) =
         applet_resource->GetController<Controller_NPad>(HidController::NPad)
-            .GetSixAxisFusionParameters(parameters.sixaxis_handle);
+            .GetSixAxisFusionParameters();
 
     LOG_WARNING(Service_HID,
                 "(STUBBED) called, npad_type={}, npad_id={}, "
@@ -597,7 +596,7 @@ void Hid::ResetSixAxisSensorFusionParameters(Kernel::HLERequestContext& ctx) {
     const auto parameters{rp.PopRaw<Parameters>()};
 
     applet_resource->GetController<Controller_NPad>(HidController::NPad)
-        .ResetSixAxisFusionParameters(parameters.sixaxis_handle);
+        .ResetSixAxisFusionParameters();
 
     LOG_WARNING(Service_HID,
                 "(STUBBED) called, npad_type={}, npad_id={}, "


### PR DESCRIPTION
Inserts padding in `Parameters` struct where applicable and removes unused device handle function parameters