### PR TITLE
prepo: Fix BufferDescriptorX invalid buffer index errors and add New variants of SaveReport

### DIFF
--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -338,6 +338,28 @@ std::size_t HLERequestContext::GetWriteBufferSize(std::size_t buffer_index) cons
     return 0;
 }
 
+bool HLERequestContext::CanReadBuffer(std::size_t buffer_index) const {
+    const bool is_buffer_a{BufferDescriptorA().size() > buffer_index &&
+                           BufferDescriptorA()[buffer_index].Size()};
+
+    if (is_buffer_a) {
+        return BufferDescriptorA().size() > buffer_index;
+    } else {
+        return BufferDescriptorX().size() > buffer_index;
+    }
+}
+
+bool HLERequestContext::CanWriteBuffer(std::size_t buffer_index) const {
+    const bool is_buffer_b{BufferDescriptorB().size() > buffer_index &&
+                           BufferDescriptorB()[buffer_index].Size()};
+
+    if (is_buffer_b) {
+        return BufferDescriptorB().size() > buffer_index;
+    } else {
+        return BufferDescriptorC().size() > buffer_index;
+    }
+}
+
 std::string HLERequestContext::Description() const {
     if (!command_header) {
         return "No command header available";

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -207,6 +207,12 @@ public:
     /// Helper function to get the size of the output buffer
     std::size_t GetWriteBufferSize(std::size_t buffer_index = 0) const;
 
+    /// Helper function to test whether the input buffer at buffer_index can be read
+    bool CanReadBuffer(std::size_t buffer_index = 0) const;
+
+    /// Helper function to test whether the output buffer at buffer_index can be written
+    bool CanWriteBuffer(std::size_t buffer_index = 0) const;
+
     template <typename T>
     std::shared_ptr<T> GetCopyObject(std::size_t index) {
         return DynamicObjectCast<T>(copy_objects.at(index));

--- a/src/core/hle/service/prepo/prepo.cpp
+++ b/src/core/hle/service/prepo/prepo.cpp
@@ -23,8 +23,8 @@ public:
             {10101, &PlayReport::SaveReportWithUser<Core::Reporter::PlayReportType::Old>, "SaveReportWithUserOld"},
             {10102, &PlayReport::SaveReport<Core::Reporter::PlayReportType::Old2>, "SaveReportOld2"},
             {10103, &PlayReport::SaveReportWithUser<Core::Reporter::PlayReportType::Old2>, "SaveReportWithUserOld2"},
-            {10104, nullptr, "SaveReport"},
-            {10105, nullptr, "SaveReportWithUser"},
+            {10104, &PlayReport::SaveReport<Core::Reporter::PlayReportType::New>, "SaveReport"},
+            {10105, &PlayReport::SaveReportWithUser<Core::Reporter::PlayReportType::New>, "SaveReportWithUser"},
             {10200, nullptr, "RequestImmediateTransmission"},
             {10300, nullptr, "GetTransmissionStatus"},
             {10400, nullptr, "GetSystemSessionId"},
@@ -59,16 +59,22 @@ private:
         IPC::RequestParser rp{ctx};
         const auto process_id = rp.PopRaw<u64>();
 
-        std::vector<std::vector<u8>> data{ctx.ReadBuffer(0)};
-        if constexpr (Type == Core::Reporter::PlayReportType::Old2) {
-            data.emplace_back(ctx.ReadBuffer(1));
-        }
+        const auto data1 = ctx.ReadBuffer(0);
+        const auto data2 = [ctx] {
+            if (ctx.CanReadBuffer(1)) {
+                return ctx.ReadBuffer(1);
+            }
 
-        LOG_DEBUG(Service_PREPO, "called, type={:02X}, process_id={:016X}, data1_size={:016X}",
-                  Type, process_id, data[0].size());
+            return std::vector<u8>{};
+        }();
+
+        LOG_DEBUG(Service_PREPO,
+                  "called, type={:02X}, process_id={:016X}, data1_size={:016X}, data2_size={:016X}",
+                  Type, process_id, data1.size(), data2.size());
 
         const auto& reporter{system.GetReporter()};
-        reporter.SavePlayReport(Type, system.CurrentProcess()->GetTitleID(), data, process_id);
+        reporter.SavePlayReport(Type, system.CurrentProcess()->GetTitleID(), {data1, data2},
+                                process_id);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -79,24 +85,24 @@ private:
         IPC::RequestParser rp{ctx};
         const auto user_id = rp.PopRaw<u128>();
         const auto process_id = rp.PopRaw<u64>();
-        std::vector<std::vector<u8>> data{ctx.ReadBuffer(0)};
 
-        if constexpr (Type == Core::Reporter::PlayReportType::Old2) {
-            const auto read_buffer_count =
-                ctx.BufferDescriptorX().size() + ctx.BufferDescriptorA().size();
-            if (read_buffer_count > 1) {
-                data.emplace_back(ctx.ReadBuffer(1));
+        const auto data1 = ctx.ReadBuffer(0);
+        const auto data2 = [ctx] {
+            if (ctx.CanReadBuffer(1)) {
+                return ctx.ReadBuffer(1);
             }
-        }
 
-        LOG_DEBUG(
-            Service_PREPO,
-            "called, type={:02X}, user_id={:016X}{:016X}, process_id={:016X}, data1_size={:016X}",
-            Type, user_id[1], user_id[0], process_id, data[0].size());
+            return std::vector<u8>{};
+        }();
+
+        LOG_DEBUG(Service_PREPO,
+                  "called, type={:02X}, user_id={:016X}{:016X}, process_id={:016X}, "
+                  "data1_size={:016X}, data2_size={:016X}",
+                  Type, user_id[1], user_id[0], process_id, data1.size(), data2.size());
 
         const auto& reporter{system.GetReporter()};
-        reporter.SavePlayReport(Type, system.CurrentProcess()->GetTitleID(), data, process_id,
-                                user_id);
+        reporter.SavePlayReport(Type, system.CurrentProcess()->GetTitleID(), {data1, data2},
+                                process_id, user_id);
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(RESULT_SUCCESS);
@@ -107,7 +113,13 @@ private:
         const auto title_id = rp.PopRaw<u64>();
 
         const auto data1 = ctx.ReadBuffer(0);
-        const auto data2 = ctx.ReadBuffer(1);
+        const auto data2 = [ctx] {
+            if (ctx.CanReadBuffer(1)) {
+                return ctx.ReadBuffer(1);
+            }
+
+            return std::vector<u8>{};
+        }();
 
         LOG_DEBUG(Service_PREPO, "called, title_id={:016X}, data1_size={:016X}, data2_size={:016X}",
                   title_id, data1.size(), data2.size());
@@ -125,7 +137,13 @@ private:
         const auto title_id = rp.PopRaw<u64>();
 
         const auto data1 = ctx.ReadBuffer(0);
-        const auto data2 = ctx.ReadBuffer(1);
+        const auto data2 = [ctx] {
+            if (ctx.CanReadBuffer(1)) {
+                return ctx.ReadBuffer(1);
+            }
+
+            return std::vector<u8>{};
+        }();
 
         LOG_DEBUG(Service_PREPO,
                   "called, user_id={:016X}{:016X}, title_id={:016X}, data1_size={:016X}, "


### PR DESCRIPTION
Fixes #4050

The second input buffer could be optional when prepo/srepo is called, test for the availability of the second buffer prior to reading from it.