### PR TITLE
Avoid overwriting username

### DIFF
--- a/src/yuzu/configuration/configure_profile_manager.cpp
+++ b/src/yuzu/configuration/configure_profile_manager.cpp
@@ -116,8 +116,8 @@ ConfigureProfileManager ::ConfigureProfileManager(QWidget* parent)
     scene = new QGraphicsScene;
     ui->current_user_icon->setScene(scene);
 
-    SetConfiguration();
     RetranslateUI();
+    SetConfiguration();
 }
 
 ConfigureProfileManager::~ConfigureProfileManager() = default;


### PR DESCRIPTION
RetranslateUI overwrites the username to the default. Call the function first so the username isn't overwritten. 