### PR TITLE
analog_from_button: Fix update_thread.join exception

### DIFF
--- a/src/input_common/analog_from_button.cpp
+++ b/src/input_common/analog_from_button.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <thread>
@@ -20,13 +21,16 @@ public:
         : up(std::move(up_)), down(std::move(down_)), left(std::move(left_)),
           right(std::move(right_)), modifier(std::move(modifier_)), modifier_scale(modifier_scale_),
           modifier_angle(modifier_angle_) {
+        update_thread_running.store(true);
         update_thread = std::thread(&Analog::UpdateStatus, this);
     }
 
     ~Analog() override {
-        update_thread_running = false;
-        if (update_thread.joinable()) {
-            update_thread.join();
+        if (update_thread_running.load()) {
+            update_thread_running.store(false);
+            if (update_thread.joinable()) {
+                update_thread.join();
+            }
         }
     }
 
@@ -58,7 +62,7 @@ public:
     }
 
     void UpdateStatus() {
-        while (update_thread_running) {
+        while (update_thread_running.load()) {
             const float coef = modifier->GetStatus() ? modifier_scale : 1.0f;
 
             bool r = right->GetStatus();
@@ -160,7 +164,7 @@ private:
     float angle{};
     float amplitude{};
     std::thread update_thread;
-    bool update_thread_running{true};
+    std::atomic<bool> update_thread_running{};
 };
 
 std::unique_ptr<Input::AnalogDevice> AnalogFromButton::Create(const Common::ParamPackage& params) {


### PR DESCRIPTION
This PR aims to address an exception that sometimes occurs when trying to join the Analog object's `update_thread` when launching a title.

By using an atomic bool for the status of the update thread, we ensure its value is consistent across the threads accessing it, and avoid trying to join a thread that was never running.