### PR TITLE
bsd: Remove unnecessary log in EventFd stub

### DIFF
--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -417,11 +417,10 @@ void BSD::Close(Kernel::HLERequestContext& ctx) {
 }
 
 void BSD::EventFd(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service, "(STUBBED) called");
     IPC::RequestParser rp{ctx};
     const s32 fd = rp.Pop<s32>();
 
-    LOG_DEBUG(Service, "called. fd={}", fd);
+    LOG_WARNING(Service, "(STUBBED) called. fd={}", fd);
 
     BuildErrnoResponse(ctx, Errno::SUCCESS);
 }


### PR DESCRIPTION
Combines the two logs into one.