### PR TITLE
arm_dynarmic_32: Print out CPSR.T on exception

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -71,8 +71,9 @@ public:
     }
 
     void ExceptionRaised(u32 pc, Dynarmic::A32::Exception exception) override {
-        LOG_CRITICAL(Core_ARM, "ExceptionRaised(exception = {}, pc = {:08X}, code = {:08X})",
-                     exception, pc, MemoryReadCode(pc));
+        LOG_CRITICAL(Core_ARM,
+                     "ExceptionRaised(exception = {}, pc = {:08X}, code = {:08X}, thumb = {})",
+                     exception, pc, MemoryReadCode(pc), parent.IsInThumbMode());
         UNIMPLEMENTED();
     }
 

--- a/src/core/arm/dynarmic/arm_dynarmic_32.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.h
@@ -50,6 +50,10 @@ public:
     u64 GetTPIDR_EL0() const override;
     void ChangeProcessorID(std::size_t new_core_id) override;
 
+    bool IsInThumbMode() const {
+        return (GetPSTATE() & 0x20) != 0;
+    }
+
     void SaveContext(ThreadContext32& ctx) override;
     void SaveContext(ThreadContext64& ctx) override {}
     void LoadContext(const ThreadContext32& ctx) override;


### PR DESCRIPTION
Eases debugging if we know the processor is in thumb mode.