### PR TITLE
video_core: host_shaders: Don't pass --quiet to glslangValidator if unavailable

### DIFF
--- a/src/video_core/host_shaders/CMakeLists.txt
+++ b/src/video_core/host_shaders/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SHADER_FILES
 find_program(GLSLANGVALIDATOR "glslangValidator" REQUIRED)
 
 set(GLSL_FLAGS "")
+set(QUIET_FLAG "--quiet")
 
 set(SHADER_INCLUDE ${CMAKE_CURRENT_BINARY_DIR}/include)
 set(SHADER_DIR ${SHADER_INCLUDE}/video_core/host_shaders)
@@ -27,6 +28,23 @@ set(HOST_SHADERS_INCLUDE ${SHADER_INCLUDE} PARENT_SCOPE)
 
 set(INPUT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/source_shader.h.in)
 set(HEADER_GENERATOR ${CMAKE_CURRENT_SOURCE_DIR}/StringShaderHeader.cmake)
+
+# Check if `--quiet` is available on host's glslangValidator version
+# glslangValidator prints to STDERR iff an unrecognized flag is passed to it
+execute_process(
+    COMMAND
+        ${GLSLANGVALIDATOR} ${QUIET_FLAG}
+    ERROR_VARIABLE
+        GLSLANG_ERROR
+    # STDOUT variable defined to silence unnecessary output during CMake configuration
+    OUTPUT_VARIABLE
+        GLSLANG_OUTPUT
+)
+
+if (NOT GLSLANG_ERROR STREQUAL "")
+    message(WARNING "Refusing to use unavailable flag `${QUIET_FLAG}` on `${GLSLANGVALIDATOR}`")
+    set(QUIET_FLAG "")
+endif()
 
 foreach(FILENAME IN ITEMS ${SHADER_FILES})
     string(REPLACE "." "_" SHADER_NAME ${FILENAME})
@@ -55,7 +73,7 @@ foreach(FILENAME IN ITEMS ${SHADER_FILES})
             OUTPUT
                 ${SPIRV_HEADER_FILE}
             COMMAND
-                ${GLSLANGVALIDATOR} -V --quiet ${GLSL_FLAGS} --variable-name ${SPIRV_VARIABLE_NAME} -o ${SPIRV_HEADER_FILE} ${SOURCE_FILE}
+                ${GLSLANGVALIDATOR} -V ${QUIET_FLAG} ${GLSL_FLAGS} --variable-name ${SPIRV_VARIABLE_NAME} -o ${SPIRV_HEADER_FILE} ${SOURCE_FILE}
             MAIN_DEPENDENCY
                 ${SOURCE_FILE}
         )


### PR DESCRIPTION
Prevents CMake from calling `glslangValidator` with `--quiet` when it is not available, i.e. on older downstream versions from Ubuntu.

Needs testing on the MSVC toolchain before merge (someone else needs to do that, I can't test it locally.)
