### PR TITLE
Prevent over scheduling audio events and add motion update unschedule event

### DIFF
--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -103,7 +103,14 @@ void Stream::PlayNextBuffer(std::chrono::nanoseconds ns_late) {
 
     sink_stream.EnqueueSamples(GetNumChannels(), active_buffer->GetSamples());
 
-    core_timing.ScheduleEvent(GetBufferReleaseNS(*active_buffer) - ns_late, release_event, {});
+    const auto buffer_release_ns = GetBufferReleaseNS(*active_buffer);
+
+    // If ns_late is higher than the update rate ignore the delay
+    if (ns_late > buffer_release_ns) {
+        ns_late = {};
+    }
+
+    core_timing.ScheduleEvent(buffer_release_ns - ns_late, release_event, {});
 }
 
 void Stream::ReleaseActiveBuffer(std::chrono::nanoseconds ns_late) {

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -104,6 +104,7 @@ void IAppletResource::DeactivateController(HidController controller) {
 
 IAppletResource ::~IAppletResource() {
     system.CoreTiming().UnscheduleEvent(pad_update_event, 0);
+    system.CoreTiming().UnscheduleEvent(motion_update_event, 0);
 }
 
 void IAppletResource::GetSharedMemoryHandle(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
Similar to #5861 audio stream can schedule events in negative time. This can be noticeable when you pause the game for a long period of time and then unpause it. The game will stutter and lag for quite some time until the audio event get's back to positive time.

This PR also adds a missing UnscheduleEvent for the motion update event.