### PR TITLE
key_manager: Create the keys directory if it does not exist

### DIFF
--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -568,6 +568,11 @@ KeyManager::KeyManager() {
     // Initialize keys
     const std::string hactool_keys_dir = Common::FS::GetHactoolConfigurationPath();
     const std::string yuzu_keys_dir = Common::FS::GetUserPath(Common::FS::UserPath::KeysDir);
+
+    if (!Common::FS::Exists(yuzu_keys_dir)) {
+        Common::FS::CreateDir(yuzu_keys_dir);
+    }
+
     if (Settings::values.use_dev_keys) {
         dev_mode = true;
         AttemptLoadKeyFile(yuzu_keys_dir, hactool_keys_dir, "dev.keys", false);


### PR DESCRIPTION
Removes the need for the user to create the keys directory manually