### PR TITLE
k_affinity_mask: Avoid implicit truncation to bool

### DIFF
--- a/src/core/hle/kernel/k_affinity_mask.h
+++ b/src/core/hle/kernel/k_affinity_mask.h
@@ -27,7 +27,7 @@ public:
     }
 
     [[nodiscard]] constexpr bool GetAffinity(s32 core) const {
-        return this->mask & GetCoreBit(core);
+        return (this->mask & GetCoreBit(core)) != 0;
     }
 
     constexpr void SetAffinity(s32 core, bool set) {


### PR DESCRIPTION
This can cause compiler warnings. Instead, we can explicitly add a boolean expression around it to naturally turn the result into a bool.