### PR TITLE
 kernel: More accurately utilize resource_limit

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -174,6 +174,7 @@ add_library(core STATIC
     hle/kernel/k_scheduler.h
     hle/kernel/k_scheduler_lock.h
     hle/kernel/k_scoped_lock.h
+    hle/kernel/k_scoped_resource_reservation.h
     hle/kernel/k_scoped_scheduler_lock_and_sleep.h
     hle/kernel/k_synchronization_object.cpp
     hle/kernel/k_synchronization_object.h

--- a/src/core/hle/kernel/k_scoped_resource_reservation.h
+++ b/src/core/hle/kernel/k_scoped_resource_reservation.h
@@ -1,0 +1,67 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+// This file references various implementation details from Atmosphere, an open-source firmware for
+// the Nintendo Switch. Copyright 2018-2020 Atmosphere-NX.
+
+#pragma once
+
+#include "common/common_types.h"
+#include "core/hle/kernel/k_resource_limit.h"
+#include "core/hle/kernel/process.h"
+
+namespace Kernel {
+
+class KScopedResourceReservation {
+public:
+    explicit KScopedResourceReservation(std::shared_ptr<KResourceLimit> l, LimitableResource r,
+                                        s64 v, s64 timeout)
+        : resource_limit(std::move(l)), value(v), resource(r) {
+        if (resource_limit && value) {
+            success = resource_limit->Reserve(resource, value, timeout);
+        } else {
+            success = true;
+        }
+    }
+
+    explicit KScopedResourceReservation(std::shared_ptr<KResourceLimit> l, LimitableResource r,
+                                        s64 v = 1)
+        : resource_limit(std::move(l)), value(v), resource(r) {
+        if (resource_limit && value) {
+            success = resource_limit->Reserve(resource, value);
+        } else {
+            success = true;
+        }
+    }
+
+    explicit KScopedResourceReservation(const Process* p, LimitableResource r, s64 v, s64 t)
+        : KScopedResourceReservation(p->GetResourceLimit(), r, v, t) {}
+
+    explicit KScopedResourceReservation(const Process* p, LimitableResource r, s64 v = 1)
+        : KScopedResourceReservation(p->GetResourceLimit(), r, v) {}
+
+    ~KScopedResourceReservation() noexcept {
+        if (resource_limit && value && success) {
+            // resource was not committed, release the reservation.
+            resource_limit->Release(resource, value);
+        }
+    }
+
+    /// Commit the resource reservation, destruction of this object does not release the resource
+    void Commit() {
+        resource_limit = nullptr;
+    }
+
+    [[nodiscard]] bool Succeeded() const {
+        return success;
+    }
+
+private:
+    std::shared_ptr<KResourceLimit> resource_limit;
+    s64 value;
+    LimitableResource resource;
+    bool success;
+};
+
+} // namespace Kernel

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -141,11 +141,17 @@ struct KernelCore::Impl {
         ASSERT(system_resource_limit->SetLimitValue(LimitableResource::Events, 700).IsSuccess());
         ASSERT(system_resource_limit->SetLimitValue(LimitableResource::TransferMemory, 200)
                    .IsSuccess());
-        ASSERT(system_resource_limit->SetLimitValue(LimitableResource::Sessions, 900).IsSuccess());
+        ASSERT(system_resource_limit->SetLimitValue(LimitableResource::Sessions, 933).IsSuccess());
 
-        if (!system_resource_limit->Reserve(LimitableResource::PhysicalMemory, 0x60000)) {
+        // Derived from recent software updates. The kernel reserves 27MB
+        constexpr u64 kernel_size{0x1b00000};
+        if (!system_resource_limit->Reserve(LimitableResource::PhysicalMemory, kernel_size)) {
             UNREACHABLE();
         }
+        // Reserve secure applet memory, introduced in firmware 5.0.0
+        constexpr u64 secure_applet_memory_size{0x400000};
+        ASSERT(system_resource_limit->Reserve(LimitableResource::PhysicalMemory,
+                                              secure_applet_memory_size));
     }
 
     void InitializePreemption(KernelCore& kernel) {
@@ -302,8 +308,11 @@ struct KernelCore::Impl {
         // Allocate slab heaps
         user_slab_heap_pages = std::make_unique<Memory::SlabHeap<Memory::Page>>();
 
+        constexpr u64 user_slab_heap_size{0x1ef000};
+        // Reserve slab heaps
+        ASSERT(
+            system_resource_limit->Reserve(LimitableResource::PhysicalMemory, user_slab_heap_size));
         // Initialize slab heaps
-        constexpr u64 user_slab_heap_size{0x3de000};
         user_slab_heap_pages->Initialize(
             system.DeviceMemory().GetPointer(Core::DramMemoryMap::SlabHeapBase),
             user_slab_heap_size);

--- a/src/core/hle/kernel/process.cpp
+++ b/src/core/hle/kernel/process.cpp
@@ -39,6 +39,7 @@ namespace {
  */
 void SetupMainThread(Core::System& system, Process& owner_process, u32 priority, VAddr stack_top) {
     const VAddr entry_point = owner_process.PageTable().GetCodeRegionStart();
+    ASSERT(owner_process.GetResourceLimit()->Reserve(LimitableResource::Threads, 1));
     auto thread_res = KThread::Create(system, ThreadType::User, "main", entry_point, priority, 0,
                                       owner_process.GetIdealCoreId(), stack_top, &owner_process);
 
@@ -279,7 +280,7 @@ ResultCode Process::LoadFromMetadata(const FileSys::ProgramMetadata& metadata,
     if (!memory_reservation.Succeeded()) {
         LOG_ERROR(Kernel, "Could not reserve process memory requirements of size {:X} bytes",
                   code_size + system_resource_size);
-        return ERR_RESOURCE_LIMIT_EXCEEDED;
+        return ResultResourceLimitedExceeded;
     }
     // Initialize proces address space
     if (const ResultCode result{

--- a/src/core/hle/kernel/session.cpp
+++ b/src/core/hle/kernel/session.cpp
@@ -4,15 +4,23 @@
 
 #include "common/assert.h"
 #include "core/hle/kernel/client_session.h"
+#include "core/hle/kernel/k_scoped_resource_reservation.h"
 #include "core/hle/kernel/server_session.h"
 #include "core/hle/kernel/session.h"
 
 namespace Kernel {
 
 Session::Session(KernelCore& kernel) : KSynchronizationObject{kernel} {}
-Session::~Session() = default;
+Session::~Session() {
+    // Release reserved resource when the Session pair was created.
+    kernel.GetSystemResourceLimit()->Release(LimitableResource::Sessions, 1);
+}
 
 Session::SessionPair Session::Create(KernelCore& kernel, std::string name) {
+    // Reserve a new session from the resource limit.
+    KScopedResourceReservation session_reservation(kernel.GetSystemResourceLimit(),
+                                                   LimitableResource::Sessions);
+    ASSERT(session_reservation.Succeeded());
     auto session{std::make_shared<Session>(kernel)};
     auto client_session{Kernel::ClientSession::Create(kernel, session, name + "_Client").Unwrap()};
     auto server_session{Kernel::ServerSession::Create(kernel, session, name + "_Server").Unwrap()};
@@ -21,6 +29,7 @@ Session::SessionPair Session::Create(KernelCore& kernel, std::string name) {
     session->client = client_session;
     session->server = server_session;
 
+    session_reservation.Commit();
     return std::make_pair(std::move(client_session), std::move(server_session));
 }
 

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -14,7 +14,9 @@ namespace Kernel {
 SharedMemory::SharedMemory(KernelCore& kernel, Core::DeviceMemory& device_memory)
     : Object{kernel}, device_memory{device_memory} {}
 
-SharedMemory::~SharedMemory() = default;
+SharedMemory::~SharedMemory() {
+    kernel.GetSystemResourceLimit()->Release(LimitableResource::PhysicalMemory, size);
+}
 
 std::shared_ptr<SharedMemory> SharedMemory::Create(
     KernelCore& kernel, Core::DeviceMemory& device_memory, Process* owner_process,

--- a/src/core/hle/kernel/shared_memory.cpp
+++ b/src/core/hle/kernel/shared_memory.cpp
@@ -4,6 +4,7 @@
 
 #include "common/assert.h"
 #include "core/core.h"
+#include "core/hle/kernel/k_scoped_resource_reservation.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/memory/page_table.h"
 #include "core/hle/kernel/shared_memory.h"
@@ -21,6 +22,11 @@ std::shared_ptr<SharedMemory> SharedMemory::Create(
     Memory::MemoryPermission user_permission, PAddr physical_address, std::size_t size,
     std::string name) {
 
+    const auto resource_limit = kernel.GetSystemResourceLimit();
+    KScopedResourceReservation memory_reservation(resource_limit, LimitableResource::PhysicalMemory,
+                                                  size);
+    ASSERT(memory_reservation.Succeeded());
+
     std::shared_ptr<SharedMemory> shared_memory{
         std::make_shared<SharedMemory>(kernel, device_memory)};
 
@@ -32,6 +38,7 @@ std::shared_ptr<SharedMemory> SharedMemory::Create(
     shared_memory->size = size;
     shared_memory->name = name;
 
+    memory_reservation.Commit();
     return shared_memory;
 }
 

--- a/src/core/hle/kernel/transfer_memory.cpp
+++ b/src/core/hle/kernel/transfer_memory.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "core/hle/kernel/k_resource_limit.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/memory/page_table.h"
 #include "core/hle/kernel/process.h"
@@ -17,6 +18,7 @@ TransferMemory::TransferMemory(KernelCore& kernel, Core::Memory::Memory& memory)
 TransferMemory::~TransferMemory() {
     // Release memory region when transfer memory is destroyed
     Reset();
+    owner_process->GetResourceLimit()->Release(LimitableResource::TransferMemory, 1);
 }
 
 std::shared_ptr<TransferMemory> TransferMemory::Create(KernelCore& kernel,


### PR DESCRIPTION
This PR aims to more accurately utilize the `resource_limit` to reserve and release resources closer to the way the hardware does.

There is one major inaccuracy which has not been addressed yet, which is the `Process`'s resource limit usage. Currently, each new `Process` creates its own `KResourceLimit`, when it should instead use the system wide resource limit. 
This is critical particularly for `Process::GetTotalPhysicalMemoryAvailable()`, which must return a very specific result, but this requires complete accuracy with the kernel resource reservation, and currently differs in its accuracy from one title to the next. 

This leads me to believe that the size reported as required for each title may be innacurate. For now, Processes continue to create their own resource limit until it can be further investigated and RE'd.