### PR TITLE
pl_u: Fix read out of bounds

### DIFF
--- a/src/core/hle/service/ns/pl_u.cpp
+++ b/src/core/hle/service/ns/pl_u.cpp
@@ -65,13 +65,18 @@ static void DecryptSharedFont(const std::vector<u32>& input, Kernel::PhysicalMem
 void DecryptSharedFontToTTF(const std::vector<u32>& input, std::vector<u8>& output) {
     ASSERT_MSG(input[0] == EXPECTED_MAGIC, "Failed to derive key, unexpected magic number");
 
+    if (input.size() < 2) {
+        LOG_ERROR(Service_NS, "Input font is empty");
+        return;
+    }
+
     const u32 KEY = input[0] ^ EXPECTED_RESULT; // Derive key using an inverse xor
     std::vector<u32> transformed_font(input.size());
     // TODO(ogniK): Figure out a better way to do this
     std::transform(input.begin(), input.end(), transformed_font.begin(),
                    [&KEY](u32 font_data) { return Common::swap32(font_data ^ KEY); });
-    transformed_font[1] = Common::swap32(transformed_font[1]) ^ KEY; // "re-encrypt" the size
-    std::memcpy(output.data(), transformed_font.data() + 2, transformed_font.size() * sizeof(u32));
+    std::memcpy(output.data(), transformed_font.data() + 2,
+                (transformed_font.size() - 2) * sizeof(u32));
 }
 
 void EncryptSharedFont(const std::vector<u32>& input, std::vector<u8>& output,


### PR DESCRIPTION
Closes #5291 #5825 

Few things to note:
* Please verify that behaviour is unchanged on windows. On linux the web applet currently doesn't work anyways.
* I removed `transformed_font[1] = Common::swap32(transformed_font[1]) ^ KEY; // "re-encrypt" the size` cause I can only assume it was a wrong copy-paste from above.

* ~~Weirdly enough removing that line (or any transformed_font[x] = y line) makes the compiler warn with~~

  >   [1/5] Building CXX object src/core/CMakeFiles/core.dir/hle/service/ns/pl_u.cpp.o
  >   ../src/core/hle/service/ns/pl_u.cpp: In function ‘void Service::NS::DecryptSharedFontToTTF(const std::vector&, std::vector&)’:
  >   ../src/core/hle/service/ns/pl_u.cpp:73:16: warning: ‘void* memcpy(void*, const void*, size_t)’ specified bound 18446744073709551608 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
 
  ~~False positive?~~
