### PR TITLE
Simple async addition to audio_renderer.cpp

### DIFF
--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -321,10 +321,11 @@ void AudioRenderer::ReleaseAndQueueBuffers() {
     const auto released_buffers{audio_out->GetTagsAndReleaseBuffers(stream)};
     queue_mixed_multithread.resize(released_buffers.size());
     for (const auto& tag : released_buffers) {
-        queue_mixed_multithread[thread_counter] = std::async(std::launch::async, [=, voice_context = voice_context, 
-          splitter_context = splitter_context, mix_context = mix_context] { 
-            QueueMixedBuffer(tag, released_buffers.size(), thread_counter+1);
-        });
+        queue_mixed_multithread[thread_counter] = std::async(
+            std::launch::async, [=, voice_context = voice_context, 
+                                 splitter_context = splitter_context, mix_context = mix_context] { 
+                QueueMixedBuffer(tag, released_buffers.size(), thread_counter+1);
+            });
         thread_counter++;
     }
     for (std::size_t thread = 0; thread < released_buffers.size(); thread++) {

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -317,12 +317,12 @@ void AudioRenderer::QueueMixedBuffer(Buffer::Tag tag) {
 }
 
 void AudioRenderer::ReleaseAndQueueBuffers() {
-    s16 thread_counter = 0;
+    std::size_t thread_counter = 0;
     const auto released_buffers{audio_out->GetTagsAndReleaseBuffers(stream)};
     queue_mixed_multithread.resize(released_buffers.size());
     for (const auto& tag : released_buffers) {
         queue_mixed_multithread[thread_counter] = std::async(
-            std::launch::async, [=, voice_context = voice_context, splitter_context = splitter_context,
+            std::launch::async, [this, tag, voice_context = voice_context, splitter_context = splitter_context,
                                  mix_context = mix_context] { QueueMixedBuffer(tag); });
         thread_counter++;
     }

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -329,7 +329,7 @@ void AudioRenderer::ReleaseAndQueueBuffers() {
         thread_counter++;
     }
     for (std::size_t thread = 0; thread < released_buffers.size(); thread++) {
-        queue_mixed_multithread[thread_to_refrence].wait();
+        queue_mixed_multithread[thread].wait();
     }
 }
 

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -322,10 +322,8 @@ void AudioRenderer::ReleaseAndQueueBuffers() {
     queue_mixed_multithread.resize(released_buffers.size());
     for (const auto& tag : released_buffers) {
         queue_mixed_multithread[thread_counter] = std::async(
-            std::launch::async, [=, voice_context = voice_context,
-                                 splitter_context = splitter_context, mix_context = mix_context] {
-                QueueMixedBuffer(tag);
-            });
+            std::launch::async, [=, voice_context = voice_context, splitter_context = splitter_context,
+                                 mix_context = mix_context] { QueueMixedBuffer(tag); });
         thread_counter++;
     }
     for (std::size_t thread = 0; thread < released_buffers.size(); thread++) {

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -202,8 +202,7 @@ ResultCode AudioRenderer::UpdateAudioRenderer(const std::vector<u8>& input_param
     return RESULT_SUCCESS;
 }
 
-void AudioRenderer::QueueMixedBuffer(Buffer::Tag tag, s16 buffer_max,
-                                     s16 current_thread) {
+void AudioRenderer::QueueMixedBuffer(Buffer::Tag tag, s16 buffer_max, s16 current_thread) {
     command_generator.PreCommand();
     // Clear mix buffers before our next operation
     command_generator.ClearMixBuffers();

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -321,10 +321,10 @@ void AudioRenderer::ReleaseAndQueueBuffers() {
     const auto released_buffers{audio_out->GetTagsAndReleaseBuffers(stream)};
     queue_mixed_multithread.resize(released_buffers.size());
     for (const auto& tag : released_buffers) {
-        queue_mixed_multithread[thread_counter] = std::async(
-            std::launch::async, [this, tag, voice_context = voice_context,
-                                 splitter_context = splitter_context,
-                                 mix_context = mix_context] { QueueMixedBuffer(tag); });
+        queue_mixed_multithread[thread_counter] = 
+            std::async(std::launch::async, [this, tag, voice_context = voice_context,
+                                            splitter_context = splitter_context,
+                                            mix_context = mix_context] { QueueMixedBuffer(tag); });
         thread_counter++;
     }
     for (std::size_t thread = 0; thread < released_buffers.size(); thread++) {

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -90,10 +90,10 @@ AudioRenderer::AudioRenderer(Core::Timing::CoreTiming& core_timing, Core::Memory
         fmt::format("AudioRenderer-Instance{}", instance_number), std::move(release_callback));
     audio_out->StartStream(stream);
 
-    QueueMixedBuffer(0, 0, 0);
-    QueueMixedBuffer(1, 0, 0);
-    QueueMixedBuffer(2, 0, 0);
-    QueueMixedBuffer(3, 0, 0);
+    QueueMixedBuffer(0);
+    QueueMixedBuffer(1);
+    QueueMixedBuffer(2);
+    QueueMixedBuffer(3);
 }
 
 AudioRenderer::~AudioRenderer() = default;
@@ -202,7 +202,7 @@ ResultCode AudioRenderer::UpdateAudioRenderer(const std::vector<u8>& input_param
     return RESULT_SUCCESS;
 }
 
-void AudioRenderer::QueueMixedBuffer(Buffer::Tag tag, s16 buffer_max, s16 current_thread) {
+void AudioRenderer::QueueMixedBuffer(Buffer::Tag tag) {
     command_generator.PreCommand();
     // Clear mix buffers before our next operation
     command_generator.ClearMixBuffers();
@@ -324,7 +324,7 @@ void AudioRenderer::ReleaseAndQueueBuffers() {
         queue_mixed_multithread[thread_counter] = std::async(
             std::launch::async, [=, voice_context = voice_context,
                                  splitter_context = splitter_context, mix_context = mix_context] {
-                QueueMixedBuffer(tag, released_buffers.size(), thread_counter + 1);
+                QueueMixedBuffer(tag);
             });
         thread_counter++;
     }

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -322,8 +322,8 @@ void AudioRenderer::ReleaseAndQueueBuffers() {
     queue_mixed_multithread.resize(released_buffers.size());
     for (const auto& tag : released_buffers) {
         queue_mixed_multithread[thread_counter] = std::async(
-            std::launch::async, [=, voice_context = voice_context, 
-                                 splitter_context = splitter_context, mix_context = mix_context] { 
+            std::launch::async, [=, voice_context = voice_context,
+                                 splitter_context = splitter_context, mix_context = mix_context] {
                 QueueMixedBuffer(tag, released_buffers.size(), thread_counter + 1);
             });
         thread_counter++;

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -321,7 +321,7 @@ void AudioRenderer::ReleaseAndQueueBuffers() {
     const auto released_buffers{audio_out->GetTagsAndReleaseBuffers(stream)};
     queue_mixed_multithread.resize(released_buffers.size());
     for (const auto& tag : released_buffers) {
-        queue_mixed_multithread[thread_counter] = 
+        queue_mixed_multithread[thread_counter] =
             std::async(std::launch::async, [this, tag, voice_context = voice_context,
                                             splitter_context = splitter_context,
                                             mix_context = mix_context] { QueueMixedBuffer(tag); });

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -3,9 +3,9 @@
 // Refer to the license.txt file included.
 
 #include <limits>
-#include <vector>
 #include <future>
 #include <mutex>
+#include <vector>
 
 #include "audio_core/audio_out.h"
 #include "audio_core/audio_renderer.h"
@@ -324,7 +324,7 @@ void AudioRenderer::ReleaseAndQueueBuffers() {
         queue_mixed_multithread[thread_counter] = std::async(
             std::launch::async, [=, voice_context = voice_context, 
                                  splitter_context = splitter_context, mix_context = mix_context] { 
-                QueueMixedBuffer(tag, released_buffers.size(), thread_counter+1);
+                QueueMixedBuffer(tag, released_buffers.size(), thread_counter + 1);
             });
         thread_counter++;
     }

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -2,8 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include <limits>
 #include <future>
+#include <limits>
 #include <mutex>
 #include <vector>
 

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -322,7 +322,8 @@ void AudioRenderer::ReleaseAndQueueBuffers() {
     queue_mixed_multithread.resize(released_buffers.size());
     for (const auto& tag : released_buffers) {
         queue_mixed_multithread[thread_counter] = std::async(
-            std::launch::async, [this, tag, voice_context = voice_context, splitter_context = splitter_context,
+            std::launch::async, [this, tag, voice_context = voice_context,
+                                 splitter_context = splitter_context,
                                  mix_context = mix_context] { QueueMixedBuffer(tag); });
         thread_counter++;
     }

--- a/src/audio_core/audio_renderer.cpp
+++ b/src/audio_core/audio_renderer.cpp
@@ -328,7 +328,7 @@ void AudioRenderer::ReleaseAndQueueBuffers() {
         });
         thread_counter++;
     }
-    for (std::size_t thread_to_refrence = 0; thread_to_refrence < released_buffers.size(); thread_to_refrence++) {
+    for (std::size_t thread = 0; thread < released_buffers.size(); thread++) {
         queue_mixed_multithread[thread_to_refrence].wait();
     }
 }

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -47,7 +47,7 @@ public:
 
     [[nodiscard]] ResultCode UpdateAudioRenderer(const std::vector<u8>& input_params,
                                                  std::vector<u8>& output_params);
-    void QueueMixedBuffer(Buffer::Tag tag, s16 buffer_max, s16 current_thread);
+    void QueueMixedBuffer(Buffer::Tag tag);
     void ReleaseAndQueueBuffers();
     [[nodiscard]] u32 GetSampleRate() const;
     [[nodiscard]] u32 GetSampleCount() const;

--- a/src/audio_core/audio_renderer.h
+++ b/src/audio_core/audio_renderer.h
@@ -5,10 +5,10 @@
 #pragma once
 
 #include <array>
-#include <memory>
-#include <vector>
 #include <future>
+#include <memory>
 #include <mutex>
+#include <vector>
 
 #include "audio_core/behavior_info.h"
 #include "audio_core/command_generator.h"


### PR DESCRIPTION
simple addition of std::async for asynchronous processing of a function call in ReleaseAndQueueBuffers; I wrote down specifics and justification in my branch's PR (Point being that I can add a comment of my justification) - **this is not a full rework of the audio core, this is just a minor performance improvement** (though it would be compatible with dedicating a thread to the audio_core for no viability loss) 