### PR TITLE
cmake: Revert FFmpeg 4.3.1 update for Windows builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,7 +504,7 @@ if (YUZU_USE_BUNDLED_FFMPEG)
         endif()
     else() # WIN32
         # Use yuzu FFmpeg binaries
-        set(FFmpeg_EXT_NAME "ffmpeg-4.3.1")
+        set(FFmpeg_EXT_NAME "ffmpeg-4.2.1")
         set(FFmpeg_PATH "${CMAKE_BINARY_DIR}/externals/${FFmpeg_EXT_NAME}")
         download_bundled_external("ffmpeg/" ${FFmpeg_EXT_NAME} "")
         set(FFmpeg_FOUND YES)

--- a/CMakeModules/CopyYuzuFFmpegDeps.cmake
+++ b/CMakeModules/CopyYuzuFFmpegDeps.cmake
@@ -1,7 +1,7 @@
 function(copy_yuzu_FFmpeg_deps target_dir)
     include(WindowsCopyFiles)
     set(DLL_DEST "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/")
-    windows_copy_files(${target_dir} ${FFMPEG_DLL_DIR} ${DLL_DEST}
+    windows_copy_files(${target_dir} ${FFmpeg_DLL_DIR} ${DLL_DEST}
         avcodec-58.dll
         avutil-56.dll
         swresample-3.dll


### PR DESCRIPTION
The 4.3.1 externals build seems to not be compatible with yuzu. 
This also fixes an oversight for a renamed CMake variable.