### PR TITLE
udp: Silence warnings on Clang 12

### DIFF
--- a/src/input_common/udp/client.cpp
+++ b/src/input_common/udp/client.cpp
@@ -144,6 +144,10 @@ Client::~Client() {
     Reset();
 }
 
+Client::ClientData::ClientData() = default;
+
+Client::ClientData::~ClientData() = default;
+
 std::vector<Common::ParamPackage> Client::GetInputDevices() const {
     std::vector<Common::ParamPackage> devices;
     for (std::size_t client = 0; client < clients.size(); client++) {

--- a/src/input_common/udp/client.h
+++ b/src/input_common/udp/client.h
@@ -98,6 +98,9 @@ public:
 
 private:
     struct ClientData {
+        ClientData();
+        ~ClientData();
+
         std::string host{"127.0.0.1"};
         u16 port{26760};
         std::size_t pad_index{};

--- a/src/input_common/udp/udp.cpp
+++ b/src/input_common/udp/udp.cpp
@@ -84,8 +84,8 @@ public:
 
 private:
     const std::string ip;
-    const u16 port;
-    const u16 pad;
+    [[maybe_unused]] const u16 port;
+    [[maybe_unused]] const u16 pad;
     CemuhookUDP::Client* client;
     mutable std::mutex mutex;
 };


### PR DESCRIPTION
Allows the UDP code to successfully compile on Clang 12