### PR TITLE
core: Silence various warnings on Clang 12

### DIFF
--- a/src/core/hle/service/am/applets/controller.cpp
+++ b/src/core/hle/service/am/applets/controller.cpp
@@ -211,7 +211,8 @@ void Controller::Execute() {
     case ControllerSupportMode::ShowControllerFirmwareUpdate:
         UNIMPLEMENTED_MSG("ControllerSupportMode={} is not implemented",
                           controller_private_arg.mode);
-        [[fallthrough]];
+        ConfigurationComplete();
+        break;
     default: {
         ConfigurationComplete();
         break;

--- a/src/core/hle/service/nfp/nfp.cpp
+++ b/src/core/hle/service/nfp/nfp.cpp
@@ -215,7 +215,7 @@ private:
         const auto& amiibo = nfp_interface.GetAmiiboBuffer();
         const TagInfo tag_info{
             .uuid = amiibo.uuid,
-            .uuid_length = static_cast<u8>(tag_info.uuid.size()),
+            .uuid_length = static_cast<u8>(amiibo.uuid.size()),
             .padding_1 = {},
             .protocol = 1, // TODO(ogniK): Figure out actual values
             .tag_type = 2,

--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -453,7 +453,8 @@ std::pair<s32, Errno> BSD::SocketImpl(Domain domain, Type type, Protocol protoco
         return {-1, Errno::MFILE};
     }
 
-    FileDescriptor& descriptor = file_descriptors[fd].emplace();
+    file_descriptors[fd] = FileDescriptor{};
+    FileDescriptor& descriptor = *file_descriptors[fd];
     // ENONMEM might be thrown here
 
     LOG_INFO(Service, "New socket fd={}", fd);
@@ -548,7 +549,8 @@ std::pair<s32, Errno> BSD::AcceptImpl(s32 fd, std::vector<u8>& write_buffer) {
         return {-1, Translate(bsd_errno)};
     }
 
-    FileDescriptor& new_descriptor = file_descriptors[new_fd].emplace();
+    file_descriptors[new_fd] = FileDescriptor{};
+    FileDescriptor& new_descriptor = *file_descriptors[new_fd];
     new_descriptor.socket = std::move(result.socket);
     new_descriptor.is_connection_based = descriptor.is_connection_based;
 


### PR DESCRIPTION
Allows Clang 12 to successfully build the core library. Also resolves an uninitialized read.