### PR TITLE
common: Add -fsized-deallocation as a Clang flag

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -206,6 +206,8 @@ if (MSVC)
 else()
   target_compile_options(common PRIVATE
     -Werror
+
+    $<$<CXX_COMPILER_ID:Clang>:-fsized-deallocation>
   )
 endif()
 


### PR DESCRIPTION
Prevents an operator delete error when compiling with Clang 11.