### PR TITLE
core: Add -fsized-dealloction as a Clang flag

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -653,6 +653,8 @@ else()
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-variable>
 
+        $<$<CXX_COMPILER_ID:Clang>:-fsized-deallocation>
+
         -Wno-sign-conversion
     )
 endif()


### PR DESCRIPTION
Prevents an operator delete error when compiling with Clang 11.