### PR TITLE
software_keyboard: Implement Finalize request command

### DIFF
--- a/src/core/hle/service/am/applets/software_keyboard.cpp
+++ b/src/core/hle/service/am/applets/software_keyboard.cpp
@@ -121,6 +121,10 @@ void SoftwareKeyboard::ExecuteInteractive() {
         std::memcpy(&request, data.data(), sizeof(Request));
 
         switch (request) {
+        case Request::Finalize:
+            complete = true;
+            broker.SignalStateChanged();
+            break;
         case Request::Calc: {
             broker.PushNormalDataFromApplet(std::make_shared<IStorage>(system, std::vector<u8>{1}));
             broker.SignalStateChanged();


### PR DESCRIPTION
Implements the Finalize request command according to hardware tests. This is fairly trivial to implement as it requests the applet to exit. The attached homebrew is used to verify the behavior on hardware.

Before (failed to process the finalize request):
![image](https://user-images.githubusercontent.com/39850852/107605727-01270180-6c02-11eb-828f-40b57483ede6.png)

After (successfully processed the finalize request):
![image](https://user-images.githubusercontent.com/39850852/107605744-0be19680-6c02-11eb-9f1f-93f574cdfb6d.png)

[software-keyboard-finalize.zip](https://github.com/yuzu-emu/yuzu/files/5963316/software-keyboard-finalize.zip)

Further tests will be conducted to verify/fix the rest of the software keyboard implementation