### PR TITLE
vulkan_device: Require VK_EXT_robustness2

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -285,7 +285,6 @@ private:
     bool ext_transform_feedback{};              ///< Support for VK_EXT_transform_feedback.
     bool ext_custom_border_color{};             ///< Support for VK_EXT_custom_border_color.
     bool ext_extended_dynamic_state{};          ///< Support for VK_EXT_extended_dynamic_state.
-    bool ext_robustness2{};                     ///< Support for VK_EXT_robustness2.
     bool ext_shader_stencil_export{};           ///< Support for VK_EXT_shader_stencil_export.
     bool nv_device_diagnostics_config{};        ///< Support for VK_NV_device_diagnostics_config.
     bool has_renderdoc{};                       ///< Has RenderDoc attached


### PR DESCRIPTION
We are already using robustness2 features without requiring it
explicitly, causing potential crashes on drivers without the extension.
Requiring this at boot allows better diagnostics for it and formalizes
our usage on the extension.