### PR TITLE
Fix LDN Initialization return code & resulting AM overflow

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -400,6 +400,7 @@ add_library(core STATIC
     hle/service/hid/controllers/xpad.h
     hle/service/lbl/lbl.cpp
     hle/service/lbl/lbl.h
+    hle/service/ldn/errors.h
     hle/service/ldn/ldn.cpp
     hle/service/ldn/ldn.h
     hle/service/ldr/ldr.cpp

--- a/src/core/hle/service/ldn/errors.h
+++ b/src/core/hle/service/ldn/errors.h
@@ -1,0 +1,13 @@
+// Copyright 2021 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/result.h"
+
+namespace Service::LDN {
+
+constexpr ResultCode ERROR_DISABLED{ErrorModule::LDN, 22};
+
+} // namespace Service::LDN

--- a/src/core/hle/service/ldn/ldn.cpp
+++ b/src/core/hle/service/ldn/ldn.cpp
@@ -6,6 +6,7 @@
 
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/result.h"
+#include "core/hle/service/ldn/errors.h"
 #include "core/hle/service/ldn/ldn.h"
 #include "core/hle/service/sm/sm.h"
 
@@ -140,10 +141,11 @@ public:
 
     void Initialize2(Kernel::HLERequestContext& ctx) {
         LOG_WARNING(Service_LDN, "(STUBBED) called");
-        // Result success seem make this services start network and continue.
-        // If we just pass result error then it will stop and maybe try again and again.
+
+        // Return the disabled error to indicate that LDN is currently unavailable, otherwise games
+        // will continue to try to make a connection.
         IPC::ResponseBuilder rb{ctx, 2};
-        rb.Push(RESULT_UNKNOWN);
+        rb.Push(ERROR_DISABLED);
     }
 };
 

--- a/src/core/hle/service/ldn/ldn.cpp
+++ b/src/core/hle/service/ldn/ldn.cpp
@@ -104,7 +104,7 @@ public:
         : ServiceFramework{system_, "IUserLocalCommunicationService"} {
         // clang-format off
         static const FunctionInfo functions[] = {
-            {0, nullptr, "GetState"},
+            {0, &IUserLocalCommunicationService::GetState, "GetState"},
             {1, nullptr, "GetNetworkInfo"},
             {2, nullptr, "GetIpv4Address"},
             {3, nullptr, "GetDisconnectReason"},
@@ -139,14 +139,38 @@ public:
         RegisterHandlers(functions);
     }
 
-    void Initialize2(Kernel::HLERequestContext& ctx) {
+    void GetState(Kernel::HLERequestContext& ctx) {
         LOG_WARNING(Service_LDN, "(STUBBED) called");
 
-        // Return the disabled error to indicate that LDN is currently unavailable, otherwise games
-        // will continue to try to make a connection.
-        IPC::ResponseBuilder rb{ctx, 2};
-        rb.Push(ERROR_DISABLED);
+        IPC::ResponseBuilder rb{ctx, 3};
+
+        // Indicate a network error, as we do not actually emulate LDN
+        rb.Push(static_cast<u32>(State::Error));
+
+        rb.Push(RESULT_SUCCESS);
     }
+
+    void Initialize2(Kernel::HLERequestContext& ctx) {
+        LOG_DEBUG(Service_LDN, "called");
+
+        is_initialized = true;
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+    }
+
+private:
+    enum class State {
+        None,
+        Initialized,
+        AccessPointOpened,
+        AccessPointCreated,
+        StationOpened,
+        StationConnected,
+        Error,
+    };
+
+    bool is_initialized{};
 };
 
 class LDNS final : public ServiceFramework<LDNS> {


### PR DESCRIPTION
Two related changes that fix the crash in Pokemon Sword/Shield when pressing 'Y'. Note, you will still get an error, but the game will keep running

* hle: service: ldn: IUserLocalCommunicationService: Indicate that LDN is disabled.
  * Fixes crash on Pokemon Sword/Shield when pressing 'Y'.
* hle: service: am: IStorageAccessor: Fix out of bounds error handling.