### PR TITLE
fixed_pipeline_cache: Use dirty flags to lazily update key

### DIFF
--- a/src/video_core/renderer_vulkan/fixed_pipeline_state.h
+++ b/src/video_core/renderer_vulkan/fixed_pipeline_state.h
@@ -58,7 +58,7 @@ struct FixedPipelineState {
             BitField<30, 1, u32> enable;
         };
 
-        void Fill(const Maxwell& regs, std::size_t index);
+        void Refresh(const Maxwell& regs, size_t index);
 
         constexpr std::array<bool, 4> Mask() const noexcept {
             return {mask_r != 0, mask_g != 0, mask_b != 0, mask_a != 0};
@@ -96,8 +96,6 @@ struct FixedPipelineState {
         BitField<6, 14, u32> offset;
         BitField<20, 3, u32> type;
         BitField<23, 6, u32> size;
-        // Not really an element of a vertex attribute, but it can be packed here
-        BitField<29, 1, u32> binding_index_enabled;
 
         constexpr Maxwell::VertexAttribute::Type Type() const noexcept {
             return static_cast<Maxwell::VertexAttribute::Type>(type.Value());
@@ -108,7 +106,7 @@ struct FixedPipelineState {
         }
     };
 
-    template <std::size_t Position>
+    template <size_t Position>
     union StencilFace {
         BitField<Position + 0, 3, u32> action_stencil_fail;
         BitField<Position + 3, 3, u32> action_depth_fail;
@@ -152,7 +150,7 @@ struct FixedPipelineState {
         // Vertex stride is a 12 bits value, we have 4 bits to spare per element
         std::array<u16, Maxwell::NumVertexArrays> vertex_strides;
 
-        void Fill(const Maxwell& regs);
+        void Refresh(const Maxwell& regs);
 
         Maxwell::ComparisonOp DepthTestFunc() const noexcept {
             return UnpackComparisonOp(depth_test_func);
@@ -199,9 +197,9 @@ struct FixedPipelineState {
     std::array<u16, Maxwell::NumViewports> viewport_swizzles;
     DynamicState dynamic_state;
 
-    void Fill(const Maxwell& regs, bool has_extended_dynamic_state);
+    void Refresh(Tegra::Engines::Maxwell3D& maxwell3d, bool has_extended_dynamic_state);
 
-    std::size_t Hash() const noexcept;
+    size_t Hash() const noexcept;
 
     bool operator==(const FixedPipelineState& rhs) const noexcept;
 
@@ -209,8 +207,8 @@ struct FixedPipelineState {
         return !operator==(rhs);
     }
 
-    std::size_t Size() const noexcept {
-        const std::size_t total_size = sizeof *this;
+    size_t Size() const noexcept {
+        const size_t total_size = sizeof *this;
         return total_size - (no_extended_dynamic_state != 0 ? 0 : sizeof(DynamicState));
     }
 };
@@ -224,7 +222,7 @@ namespace std {
 
 template <>
 struct hash<Vulkan::FixedPipelineState> {
-    std::size_t operator()(const Vulkan::FixedPipelineState& k) const noexcept {
+    size_t operator()(const Vulkan::FixedPipelineState& k) const noexcept {
         return k.Hash();
     }
 };

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -221,9 +221,6 @@ vk::Pipeline VKGraphicsPipeline::CreatePipeline(const SPIRVProgram& program,
     std::vector<VkVertexInputBindingDescription> vertex_bindings;
     std::vector<VkVertexInputBindingDivisorDescriptionEXT> vertex_binding_divisors;
     for (std::size_t index = 0; index < Maxwell::NumVertexArrays; ++index) {
-        if (state.attributes[index].binding_index_enabled == 0) {
-            continue;
-        }
         const bool instanced = state.binding_divisors[index] != 0;
         const auto rate = instanced ? VK_VERTEX_INPUT_RATE_INSTANCE : VK_VERTEX_INPUT_RATE_VERTEX;
         vertex_bindings.push_back({

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -20,6 +20,7 @@
 #include "video_core/renderer_vulkan/vk_buffer_cache.h"
 #include "video_core/renderer_vulkan/vk_descriptor_pool.h"
 #include "video_core/renderer_vulkan/vk_fence_manager.h"
+#include "video_core/renderer_vulkan/vk_graphics_pipeline.h"
 #include "video_core/renderer_vulkan/vk_pipeline_cache.h"
 #include "video_core/renderer_vulkan/vk_query_cache.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
@@ -172,6 +173,8 @@ private:
     VKDescriptorPool descriptor_pool;
     VKUpdateDescriptorQueue update_descriptor_queue;
     BlitImageHelper blit_image;
+
+    GraphicsPipelineCacheKey graphics_key;
 
     TextureCacheRuntime texture_cache_runtime;
     TextureCache texture_cache;

--- a/src/video_core/renderer_vulkan/vk_state_tracker.cpp
+++ b/src/video_core/renderer_vulkan/vk_state_tracker.cpp
@@ -18,9 +18,7 @@
 #define NUM(field_name) (sizeof(Maxwell3D::Regs::field_name) / (sizeof(u32)))
 
 namespace Vulkan {
-
 namespace {
-
 using namespace Dirty;
 using namespace VideoCommon::Dirty;
 using Tegra::Engines::Maxwell3D;
@@ -128,6 +126,34 @@ void SetupDirtyStencilTestEnable(Tables& tables) {
     tables[0][OFF(stencil_enable)] = StencilTestEnable;
 }
 
+void SetupDirtyBlending(Tables& tables) {
+    tables[0][OFF(color_mask_common)] = Blending;
+    tables[0][OFF(independent_blend_enable)] = Blending;
+    FillBlock(tables[0], OFF(color_mask), NUM(color_mask), Blending);
+    FillBlock(tables[0], OFF(blend), NUM(blend), Blending);
+    FillBlock(tables[0], OFF(independent_blend), NUM(independent_blend), Blending);
+}
+
+void SetupDirtyInstanceDivisors(Tables& tables) {
+    static constexpr size_t divisor_offset = 3;
+    for (size_t index = 0; index < Regs::NumVertexArrays; ++index) {
+        tables[0][OFF(instanced_arrays) + index] = InstanceDivisors;
+        tables[0][OFF(vertex_array) + index * NUM(vertex_array[0]) + divisor_offset] =
+            InstanceDivisors;
+    }
+}
+
+void SetupDirtyVertexAttributes(Tables& tables) {
+    FillBlock(tables[0], OFF(vertex_attrib_format), NUM(vertex_attrib_format), VertexAttributes);
+}
+
+void SetupDirtyViewportSwizzles(Tables& tables) {
+    static constexpr size_t swizzle_offset = 6;
+    for (size_t index = 0; index < Regs::NumViewports; ++index) {
+        tables[0][OFF(viewport_transform) + index * NUM(viewport_transform[0]) + swizzle_offset] =
+            ViewportSwizzles;
+    }
+}
 } // Anonymous namespace
 
 StateTracker::StateTracker(Tegra::GPU& gpu)
@@ -148,6 +174,10 @@ StateTracker::StateTracker(Tegra::GPU& gpu)
     SetupDirtyFrontFace(tables);
     SetupDirtyStencilOp(tables);
     SetupDirtyStencilTestEnable(tables);
+    SetupDirtyBlending(tables);
+    SetupDirtyInstanceDivisors(tables);
+    SetupDirtyVertexAttributes(tables);
+    SetupDirtyViewportSwizzles(tables);
 }
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_state_tracker.h
+++ b/src/video_core/renderer_vulkan/vk_state_tracker.h
@@ -35,6 +35,11 @@ enum : u8 {
     StencilOp,
     StencilTestEnable,
 
+    Blending,
+    InstanceDivisors,
+    VertexAttributes,
+    ViewportSwizzles,
+
     Last
 };
 static_assert(Last <= std::numeric_limits<u8>::max());


### PR DESCRIPTION
Use dirty flags to avoid building pipeline key from scratch on each draw call. This saves a bit of unnecessary work on each draw call.

Increases 1 to 2 frames per second on SMO on Lost Kingdom.