### PR TITLE
debugger: controller: Add access key

### DIFF
--- a/src/yuzu/debugger/controller.cpp
+++ b/src/yuzu/debugger/controller.cpp
@@ -42,7 +42,7 @@ void ControllerDialog::refreshConfiguration() {
 
 QAction* ControllerDialog::toggleViewAction() {
     if (toggle_view_action == nullptr) {
-        toggle_view_action = new QAction(windowTitle(), this);
+        toggle_view_action = new QAction(tr("&Controller P1"), this);
         toggle_view_action->setCheckable(true);
         toggle_view_action->setChecked(isVisible());
         connect(toggle_view_action, &QAction::toggled, this, &ControllerDialog::setVisible);


### PR DESCRIPTION
Adds the access key to the Controller P1 selection at View -> Debugger -> Controller P1. Avoids using the windowTitle as that would add a literal & to the beginning of the window title.