### PR TITLE
core/CMakeLists: Add web_types.h

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -266,6 +266,7 @@ add_library(core STATIC
     hle/service/am/applets/software_keyboard.h
     hle/service/am/applets/web_browser.cpp
     hle/service/am/applets/web_browser.h
+    hle/service/am/applets/web_types.h
     hle/service/am/idle.cpp
     hle/service/am/idle.h
     hle/service/am/omm.cpp


### PR DESCRIPTION
Looks like I forgot to add this in the web applet PR, oops