### PR TITLE
vk_rasterizer: Fix loading shader addresses twice

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -277,7 +277,6 @@ void RasterizerVulkan::Draw(bool is_indexed, bool is_instanced) {
     const auto shaders = pipeline_cache.GetShaders();
     graphics_key.shaders = GetShaderAddresses(shaders);
 
-    graphics_key.shaders = GetShaderAddresses(shaders);
     SetupShaderDescriptors(shaders, is_indexed);
 
     const Framebuffer* const framebuffer = texture_cache.GetFramebuffer();


### PR DESCRIPTION
This was recently introduced on a wrongly rebased commit.