### PR TITLE
hid: Implement GameCube Controller Vibrations

### DIFF
--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -136,6 +136,8 @@ private:
     void PermitVibration(Kernel::HLERequestContext& ctx);
     void IsVibrationPermitted(Kernel::HLERequestContext& ctx);
     void SendVibrationValues(Kernel::HLERequestContext& ctx);
+    void SendVibrationGcErmCommand(Kernel::HLERequestContext& ctx);
+    void GetActualVibrationGcErmCommand(Kernel::HLERequestContext& ctx);
     void BeginPermitVibrationSession(Kernel::HLERequestContext& ctx);
     void EndPermitVibrationSession(Kernel::HLERequestContext& ctx);
     void IsVibrationDeviceMounted(Kernel::HLERequestContext& ctx);
@@ -154,13 +156,21 @@ private:
     void GetNpadCommunicationMode(Kernel::HLERequestContext& ctx);
 
     enum class VibrationDeviceType : u32 {
+        Unknown = 0,
         LinearResonantActuator = 1,
+        GcErm = 2,
     };
 
     enum class VibrationDevicePosition : u32 {
         None = 0,
         Left = 1,
         Right = 2,
+    };
+
+    enum class VibrationGcErmCommand : u64 {
+        Stop = 0,
+        Start = 1,
+        StopHard = 2,
     };
 
     struct VibrationDeviceInfo {


### PR DESCRIPTION
Implements both SendVibrationGcErmCommand and GetActualVibrationGcErmCommand, and modifies GetVibrationDeviceInfo to account for additional controllers.

This allows vibrations to work when the GameCube Controller is selected in the list of emulated controllers.