### PR TITLE
common/cityhash: Use common types

### DIFF
--- a/src/common/cityhash.cpp
+++ b/src/common/cityhash.cpp
@@ -28,8 +28,10 @@
 // compromising on hash quality.
 
 #include <algorithm>
-#include <string.h> // for memcpy and memset
-#include "cityhash.h"
+#include <cstring>
+#include <utility>
+
+#include "common/cityhash.h"
 #include "common/swap.h"
 
 // #include "config.h"
@@ -42,21 +44,17 @@
 
 using namespace std;
 
-typedef uint8_t uint8;
-typedef uint32_t uint32;
-typedef uint64_t uint64;
-
 namespace Common {
 
-static uint64 UNALIGNED_LOAD64(const char* p) {
-    uint64 result;
-    memcpy(&result, p, sizeof(result));
+static u64 unaligned_load64(const char* p) {
+    u64 result;
+    std::memcpy(&result, p, sizeof(result));
     return result;
 }
 
-static uint32 UNALIGNED_LOAD32(const char* p) {
-    uint32 result;
-    memcpy(&result, p, sizeof(result));
+static u32 unaligned_load32(const char* p) {
+    u32 result;
+    std::memcpy(&result, p, sizeof(result));
     return result;
 }
 
@@ -76,64 +74,64 @@ static uint32 UNALIGNED_LOAD32(const char* p) {
 #endif
 #endif
 
-static uint64 Fetch64(const char* p) {
-    return uint64_in_expected_order(UNALIGNED_LOAD64(p));
+static u64 Fetch64(const char* p) {
+    return uint64_in_expected_order(unaligned_load64(p));
 }
 
-static uint32 Fetch32(const char* p) {
-    return uint32_in_expected_order(UNALIGNED_LOAD32(p));
+static u32 Fetch32(const char* p) {
+    return uint32_in_expected_order(unaligned_load32(p));
 }
 
 // Some primes between 2^63 and 2^64 for various uses.
-static const uint64 k0 = 0xc3a5c85c97cb3127ULL;
-static const uint64 k1 = 0xb492b66fbe98f273ULL;
-static const uint64 k2 = 0x9ae16a3b2f90404fULL;
+static constexpr u64 k0 = 0xc3a5c85c97cb3127ULL;
+static constexpr u64 k1 = 0xb492b66fbe98f273ULL;
+static constexpr u64 k2 = 0x9ae16a3b2f90404fULL;
 
 // Bitwise right rotate.  Normally this will compile to a single
 // instruction, especially if the shift is a manifest constant.
-static uint64 Rotate(uint64 val, int shift) {
+static u64 Rotate(u64 val, int shift) {
     // Avoid shifting by 64: doing so yields an undefined result.
     return shift == 0 ? val : ((val >> shift) | (val << (64 - shift)));
 }
 
-static uint64 ShiftMix(uint64 val) {
+static u64 ShiftMix(u64 val) {
     return val ^ (val >> 47);
 }
 
-static uint64 HashLen16(uint64 u, uint64 v) {
-    return Hash128to64(uint128(u, v));
+static u64 HashLen16(u64 u, u64 v) {
+    return Hash128to64(u128{u, v});
 }
 
-static uint64 HashLen16(uint64 u, uint64 v, uint64 mul) {
+static u64 HashLen16(u64 u, u64 v, u64 mul) {
     // Murmur-inspired hashing.
-    uint64 a = (u ^ v) * mul;
+    u64 a = (u ^ v) * mul;
     a ^= (a >> 47);
-    uint64 b = (v ^ a) * mul;
+    u64 b = (v ^ a) * mul;
     b ^= (b >> 47);
     b *= mul;
     return b;
 }
 
-static uint64 HashLen0to16(const char* s, std::size_t len) {
+static u64 HashLen0to16(const char* s, size_t len) {
     if (len >= 8) {
-        uint64 mul = k2 + len * 2;
-        uint64 a = Fetch64(s) + k2;
-        uint64 b = Fetch64(s + len - 8);
-        uint64 c = Rotate(b, 37) * mul + a;
-        uint64 d = (Rotate(a, 25) + b) * mul;
+        u64 mul = k2 + len * 2;
+        u64 a = Fetch64(s) + k2;
+        u64 b = Fetch64(s + len - 8);
+        u64 c = Rotate(b, 37) * mul + a;
+        u64 d = (Rotate(a, 25) + b) * mul;
         return HashLen16(c, d, mul);
     }
     if (len >= 4) {
-        uint64 mul = k2 + len * 2;
-        uint64 a = Fetch32(s);
+        u64 mul = k2 + len * 2;
+        u64 a = Fetch32(s);
         return HashLen16(len + (a << 3), Fetch32(s + len - 4), mul);
     }
     if (len > 0) {
-        uint8 a = s[0];
-        uint8 b = s[len >> 1];
-        uint8 c = s[len - 1];
-        uint32 y = static_cast<uint32>(a) + (static_cast<uint32>(b) << 8);
-        uint32 z = static_cast<uint32>(len) + (static_cast<uint32>(c) << 2);
+        u8 a = s[0];
+        u8 b = s[len >> 1];
+        u8 c = s[len - 1];
+        u32 y = static_cast<u32>(a) + (static_cast<u32>(b) << 8);
+        u32 z = static_cast<u32>(len) + (static_cast<u32>(c) << 2);
         return ShiftMix(y * k2 ^ z * k0) * k2;
     }
     return k2;
@@ -141,22 +139,21 @@ static uint64 HashLen0to16(const char* s, std::size_t len) {
 
 // This probably works well for 16-byte strings as well, but it may be overkill
 // in that case.
-static uint64 HashLen17to32(const char* s, std::size_t len) {
-    uint64 mul = k2 + len * 2;
-    uint64 a = Fetch64(s) * k1;
-    uint64 b = Fetch64(s + 8);
-    uint64 c = Fetch64(s + len - 8) * mul;
-    uint64 d = Fetch64(s + len - 16) * k2;
+static u64 HashLen17to32(const char* s, size_t len) {
+    u64 mul = k2 + len * 2;
+    u64 a = Fetch64(s) * k1;
+    u64 b = Fetch64(s + 8);
+    u64 c = Fetch64(s + len - 8) * mul;
+    u64 d = Fetch64(s + len - 16) * k2;
     return HashLen16(Rotate(a + b, 43) + Rotate(c, 30) + d, a + Rotate(b + k2, 18) + c, mul);
 }
 
 // Return a 16-byte hash for 48 bytes.  Quick and dirty.
 // Callers do best to use "random-looking" values for a and b.
-static pair<uint64, uint64> WeakHashLen32WithSeeds(uint64 w, uint64 x, uint64 y, uint64 z, uint64 a,
-                                                   uint64 b) {
+static pair<u64, u64> WeakHashLen32WithSeeds(u64 w, u64 x, u64 y, u64 z, u64 a, u64 b) {
     a += w;
     b = Rotate(b + a + z, 21);
-    uint64 c = a;
+    u64 c = a;
     a += x;
     a += y;
     b += Rotate(a, 44);
@@ -164,34 +161,34 @@ static pair<uint64, uint64> WeakHashLen32WithSeeds(uint64 w, uint64 x, uint64 y,
 }
 
 // Return a 16-byte hash for s[0] ... s[31], a, and b.  Quick and dirty.
-static pair<uint64, uint64> WeakHashLen32WithSeeds(const char* s, uint64 a, uint64 b) {
+static pair<u64, u64> WeakHashLen32WithSeeds(const char* s, u64 a, u64 b) {
     return WeakHashLen32WithSeeds(Fetch64(s), Fetch64(s + 8), Fetch64(s + 16), Fetch64(s + 24), a,
                                   b);
 }
 
 // Return an 8-byte hash for 33 to 64 bytes.
-static uint64 HashLen33to64(const char* s, std::size_t len) {
-    uint64 mul = k2 + len * 2;
-    uint64 a = Fetch64(s) * k2;
-    uint64 b = Fetch64(s + 8);
-    uint64 c = Fetch64(s + len - 24);
-    uint64 d = Fetch64(s + len - 32);
-    uint64 e = Fetch64(s + 16) * k2;
-    uint64 f = Fetch64(s + 24) * 9;
-    uint64 g = Fetch64(s + len - 8);
-    uint64 h = Fetch64(s + len - 16) * mul;
-    uint64 u = Rotate(a + g, 43) + (Rotate(b, 30) + c) * 9;
-    uint64 v = ((a + g) ^ d) + f + 1;
-    uint64 w = swap64((u + v) * mul) + h;
-    uint64 x = Rotate(e + f, 42) + c;
-    uint64 y = (swap64((v + w) * mul) + g) * mul;
-    uint64 z = e + f + c;
+static u64 HashLen33to64(const char* s, size_t len) {
+    u64 mul = k2 + len * 2;
+    u64 a = Fetch64(s) * k2;
+    u64 b = Fetch64(s + 8);
+    u64 c = Fetch64(s + len - 24);
+    u64 d = Fetch64(s + len - 32);
+    u64 e = Fetch64(s + 16) * k2;
+    u64 f = Fetch64(s + 24) * 9;
+    u64 g = Fetch64(s + len - 8);
+    u64 h = Fetch64(s + len - 16) * mul;
+    u64 u = Rotate(a + g, 43) + (Rotate(b, 30) + c) * 9;
+    u64 v = ((a + g) ^ d) + f + 1;
+    u64 w = swap64((u + v) * mul) + h;
+    u64 x = Rotate(e + f, 42) + c;
+    u64 y = (swap64((v + w) * mul) + g) * mul;
+    u64 z = e + f + c;
     a = swap64((x + z) * mul + y) + b;
     b = ShiftMix((z + a) * mul + d + h) * mul;
     return b + x;
 }
 
-uint64 CityHash64(const char* s, std::size_t len) {
+u64 CityHash64(const char* s, size_t len) {
     if (len <= 32) {
         if (len <= 16) {
             return HashLen0to16(s, len);
@@ -204,15 +201,15 @@ uint64 CityHash64(const char* s, std::size_t len) {
 
     // For strings over 64 bytes we hash the end first, and then as we
     // loop we keep 56 bytes of state: v, w, x, y, and z.
-    uint64 x = Fetch64(s + len - 40);
-    uint64 y = Fetch64(s + len - 16) + Fetch64(s + len - 56);
-    uint64 z = HashLen16(Fetch64(s + len - 48) + len, Fetch64(s + len - 24));
-    pair<uint64, uint64> v = WeakHashLen32WithSeeds(s + len - 64, len, z);
-    pair<uint64, uint64> w = WeakHashLen32WithSeeds(s + len - 32, y + k1, x);
+    u64 x = Fetch64(s + len - 40);
+    u64 y = Fetch64(s + len - 16) + Fetch64(s + len - 56);
+    u64 z = HashLen16(Fetch64(s + len - 48) + len, Fetch64(s + len - 24));
+    pair<u64, u64> v = WeakHashLen32WithSeeds(s + len - 64, len, z);
+    pair<u64, u64> w = WeakHashLen32WithSeeds(s + len - 32, y + k1, x);
     x = x * k1 + Fetch64(s);
 
     // Decrease len to the nearest multiple of 64, and operate on 64-byte chunks.
-    len = (len - 1) & ~static_cast<std::size_t>(63);
+    len = (len - 1) & ~static_cast<size_t>(63);
     do {
         x = Rotate(x + y + v.first + Fetch64(s + 8), 37) * k1;
         y = Rotate(y + v.second + Fetch64(s + 48), 42) * k1;
@@ -229,21 +226,21 @@ uint64 CityHash64(const char* s, std::size_t len) {
                      HashLen16(v.second, w.second) + x);
 }
 
-uint64 CityHash64WithSeed(const char* s, std::size_t len, uint64 seed) {
+u64 CityHash64WithSeed(const char* s, size_t len, u64 seed) {
     return CityHash64WithSeeds(s, len, k2, seed);
 }
 
-uint64 CityHash64WithSeeds(const char* s, std::size_t len, uint64 seed0, uint64 seed1) {
+u64 CityHash64WithSeeds(const char* s, size_t len, u64 seed0, u64 seed1) {
     return HashLen16(CityHash64(s, len) - seed0, seed1);
 }
 
 // A subroutine for CityHash128().  Returns a decent 128-bit hash for strings
 // of any length representable in signed long.  Based on City and Murmur.
-static uint128 CityMurmur(const char* s, std::size_t len, uint128 seed) {
-    uint64 a = Uint128Low64(seed);
-    uint64 b = Uint128High64(seed);
-    uint64 c = 0;
-    uint64 d = 0;
+static u128 CityMurmur(const char* s, size_t len, u128 seed) {
+    u64 a = seed[0];
+    u64 b = seed[1];
+    u64 c = 0;
+    u64 d = 0;
     signed long l = static_cast<long>(len) - 16;
     if (l <= 0) { // len <= 16
         a = ShiftMix(a * k1) * k1;
@@ -266,20 +263,20 @@ static uint128 CityMurmur(const char* s, std::size_t len, uint128 seed) {
     }
     a = HashLen16(a, c);
     b = HashLen16(d, b);
-    return uint128(a ^ b, HashLen16(b, a));
+    return u128{a ^ b, HashLen16(b, a)};
 }
 
-uint128 CityHash128WithSeed(const char* s, std::size_t len, uint128 seed) {
+u128 CityHash128WithSeed(const char* s, size_t len, u128 seed) {
     if (len < 128) {
         return CityMurmur(s, len, seed);
     }
 
     // We expect len >= 128 to be the common case.  Keep 56 bytes of state:
     // v, w, x, y, and z.
-    pair<uint64, uint64> v, w;
-    uint64 x = Uint128Low64(seed);
-    uint64 y = Uint128High64(seed);
-    uint64 z = len * k1;
+    pair<u64, u64> v, w;
+    u64 x = seed[0];
+    u64 y = seed[1];
+    u64 z = len * k1;
     v.first = Rotate(y ^ k1, 49) * k1 + Fetch64(s);
     v.second = Rotate(v.first, 42) * k1 + Fetch64(s + 8);
     w.first = Rotate(y + z, 35) * k1 + x;
@@ -313,7 +310,7 @@ uint128 CityHash128WithSeed(const char* s, std::size_t len, uint128 seed) {
     w.first *= 9;
     v.first *= k0;
     // If 0 < len < 128, hash up to 4 chunks of 32 bytes each from the end of s.
-    for (std::size_t tail_done = 0; tail_done < len;) {
+    for (size_t tail_done = 0; tail_done < len;) {
         tail_done += 32;
         y = Rotate(x + y, 42) * k0 + v.second;
         w.first += Fetch64(s + len - tail_done + 16);
@@ -328,13 +325,12 @@ uint128 CityHash128WithSeed(const char* s, std::size_t len, uint128 seed) {
     // different 56-byte-to-8-byte hashes to get a 16-byte final result.
     x = HashLen16(x, v.first);
     y = HashLen16(y + z, w.first);
-    return uint128(HashLen16(x + v.second, w.second) + y, HashLen16(x + w.second, y + v.second));
+    return u128{HashLen16(x + v.second, w.second) + y, HashLen16(x + w.second, y + v.second)};
 }
 
-uint128 CityHash128(const char* s, std::size_t len) {
-    return len >= 16
-               ? CityHash128WithSeed(s + 16, len - 16, uint128(Fetch64(s), Fetch64(s + 8) + k0))
-               : CityHash128WithSeed(s, len, uint128(k0, k1));
+u128 CityHash128(const char* s, size_t len) {
+    return len >= 16 ? CityHash128WithSeed(s + 16, len - 16, u128{Fetch64(s), Fetch64(s + 8) + k0})
+                     : CityHash128WithSeed(s, len, u128{k0, k1});
 }
 
 } // namespace Common

--- a/src/common/cityhash.h
+++ b/src/common/cityhash.h
@@ -61,50 +61,38 @@
 
 #pragma once
 
-#include <cstddef>
-#include <cstdint>
-#include <utility>
+#include "common/common_types.h"
 
 namespace Common {
 
-using uint128 = std::pair<uint64_t, uint64_t>;
-
-[[nodiscard]] inline uint64_t Uint128Low64(const uint128& x) {
-    return x.first;
-}
-[[nodiscard]] inline uint64_t Uint128High64(const uint128& x) {
-    return x.second;
-}
-
 // Hash function for a byte array.
-[[nodiscard]] uint64_t CityHash64(const char* buf, std::size_t len);
+[[nodiscard]] u64 CityHash64(const char* buf, size_t len);
 
 // Hash function for a byte array.  For convenience, a 64-bit seed is also
 // hashed into the result.
-[[nodiscard]] uint64_t CityHash64WithSeed(const char* buf, std::size_t len, uint64_t seed);
+[[nodiscard]] u64 CityHash64WithSeed(const char* buf, size_t len, u64 seed);
 
 // Hash function for a byte array.  For convenience, two seeds are also
 // hashed into the result.
-[[nodiscard]] uint64_t CityHash64WithSeeds(const char* buf, std::size_t len, uint64_t seed0,
-                                           uint64_t seed1);
+[[nodiscard]] u64 CityHash64WithSeeds(const char* buf, size_t len, u64 seed0, u64 seed1);
 
 // Hash function for a byte array.
-[[nodiscard]] uint128 CityHash128(const char* s, std::size_t len);
+[[nodiscard]] u128 CityHash128(const char* s, size_t len);
 
 // Hash function for a byte array.  For convenience, a 128-bit seed is also
 // hashed into the result.
-[[nodiscard]] uint128 CityHash128WithSeed(const char* s, std::size_t len, uint128 seed);
+[[nodiscard]] u128 CityHash128WithSeed(const char* s, size_t len, u128 seed);
 
 // Hash 128 input bits down to 64 bits of output.
 // This is intended to be a reasonably good hash function.
-[[nodiscard]] inline uint64_t Hash128to64(const uint128& x) {
+[[nodiscard]] inline u64 Hash128to64(const u128& x) {
     // Murmur-inspired hashing.
-    const uint64_t kMul = 0x9ddfea08eb382d69ULL;
-    uint64_t a = (Uint128Low64(x) ^ Uint128High64(x)) * kMul;
+    const u64 mul = 0x9ddfea08eb382d69ULL;
+    u64 a = (x[0] ^ x[1]) * mul;
     a ^= (a >> 47);
-    uint64_t b = (Uint128High64(x) ^ a) * kMul;
+    u64 b = (x[1] ^ a) * mul;
     b ^= (b >> 47);
-    b *= kMul;
+    b *= mul;
     return b;
 }
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_executable(tests
     common/bit_field.cpp
+    common/cityhash.cpp
     common/fibers.cpp
     common/param_package.cpp
     common/ring_buffer.cpp

--- a/src/tests/common/cityhash.cpp
+++ b/src/tests/common/cityhash.cpp
@@ -1,0 +1,22 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <catch2/catch.hpp>
+
+#include "common/cityhash.h"
+
+constexpr char msg[] = "The blue frogs are singing under the crimson sky.\n"
+                       "It is time to run, Robert.";
+
+using namespace Common;
+
+TEST_CASE("CityHash", "[common]") {
+    // These test results were built against a known good version.
+    REQUIRE(CityHash64(msg, sizeof(msg)) == 0x92d5c2e9cbfbbc01);
+    REQUIRE(CityHash64WithSeed(msg, sizeof(msg), 0xdead) == 0xbfbe93f21a2820dd);
+    REQUIRE(CityHash64WithSeeds(msg, sizeof(msg), 0xbeef, 0xcafe) == 0xb343317955fc8a06);
+    REQUIRE(CityHash128(msg, sizeof(msg)) == uint128{0x98e60d0423747eaa, 0xd8694c5b6fcaede9});
+    REQUIRE(CityHash128WithSeed(msg, sizeof(msg), {0xdead, 0xbeef}) ==
+            uint128{0xf0307dba81199ebe, 0xd77764e0c4a9eb74});
+}

--- a/src/tests/common/cityhash.cpp
+++ b/src/tests/common/cityhash.cpp
@@ -16,7 +16,7 @@ TEST_CASE("CityHash", "[common]") {
     REQUIRE(CityHash64(msg, sizeof(msg)) == 0x92d5c2e9cbfbbc01);
     REQUIRE(CityHash64WithSeed(msg, sizeof(msg), 0xdead) == 0xbfbe93f21a2820dd);
     REQUIRE(CityHash64WithSeeds(msg, sizeof(msg), 0xbeef, 0xcafe) == 0xb343317955fc8a06);
-    REQUIRE(CityHash128(msg, sizeof(msg)) == uint128{0x98e60d0423747eaa, 0xd8694c5b6fcaede9});
+    REQUIRE(CityHash128(msg, sizeof(msg)) == u128{0x98e60d0423747eaa, 0xd8694c5b6fcaede9});
     REQUIRE(CityHash128WithSeed(msg, sizeof(msg), {0xdead, 0xbeef}) ==
-            uint128{0xf0307dba81199ebe, 0xd77764e0c4a9eb74});
+            u128{0xf0307dba81199ebe, 0xd77764e0c4a9eb74});
 }


### PR DESCRIPTION
Allow sharing return types with the rest of the code base. For example, we use `u128 = std::array<u64, 2>`, meanwhile Google's code uses `uint128 = std::pair<u64, u64>`. While we are at it, use size_t instead of std::size_t.

I've added tests to make sure this doesn't break backwards compatibility.