### PR TITLE
cmake: Update FFmpeg to 4.3.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,6 +37,6 @@
 [submodule "opus"]
 	path = externals/opus/opus
 	url = https://github.com/xiph/opus.git
-[submodule "externals/ffmpeg"]
+[submodule "ffmpeg"]
 	path = externals/ffmpeg
 	url = https://git.ffmpeg.org/ffmpeg.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -504,7 +504,7 @@ if (YUZU_USE_BUNDLED_FFMPEG)
         endif()
     else() # WIN32
         # Use yuzu FFmpeg binaries
-        set(FFmpeg_EXT_NAME "ffmpeg-4.2.1")
+        set(FFmpeg_EXT_NAME "ffmpeg-4.3.1")
         set(FFmpeg_PATH "${CMAKE_BINARY_DIR}/externals/${FFmpeg_EXT_NAME}")
         download_bundled_external("ffmpeg/" ${FFmpeg_EXT_NAME} "")
         set(FFmpeg_FOUND YES)

--- a/CMakeModules/CopyYuzuFFmpegDeps.cmake
+++ b/CMakeModules/CopyYuzuFFmpegDeps.cmake
@@ -1,10 +1,6 @@
 function(copy_yuzu_FFmpeg_deps target_dir)
     include(WindowsCopyFiles)
     set(DLL_DEST "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/")
-    windows_copy_files(${target_dir} ${FFmpeg_DLL_DIR} ${DLL_DEST}
-        avcodec-58.dll
-        avutil-56.dll
-        swresample-3.dll
-        swscale-5.dll
-    )
+    file(READ "${FFmpeg_PATH}/requirements.txt" FFmpeg_REQUIRED_DLLS)
+    windows_copy_files(${target_dir} ${FFmpeg_DLL_DIR} ${DLL_DEST} ${FFmpeg_REQUIRED_DLLS})
 endfunction(copy_yuzu_FFmpeg_deps)


### PR DESCRIPTION
Download FFmpeg package version 4.3.1. Uses a file defined within the package to determine with DLLs to copy. Also corrects a submodule name.

