### PR TITLE
kernel: Fix resource release exception on exit

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -308,6 +308,9 @@ struct System::Impl {
         // Close all CPU/threading state
         cpu_manager.Shutdown();
 
+        // Release the Time Manager's resources
+        time_manager.Shutdown();
+
         // Shutdown kernel and core timing
         core_timing.Shutdown();
         kernel.Shutdown();

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -101,8 +101,6 @@ struct KernelCore::Impl {
 
         current_process = nullptr;
 
-        system_resource_limit = nullptr;
-
         global_handle_table.Clear();
 
         preemption_event = nullptr;
@@ -110,6 +108,13 @@ struct KernelCore::Impl {
         named_ports.clear();
 
         exclusive_monitor.reset();
+
+        hid_shared_mem = nullptr;
+        font_shared_mem = nullptr;
+        irs_shared_mem = nullptr;
+        time_shared_mem = nullptr;
+
+        system_resource_limit = nullptr;
 
         // Next host thead ID to use, 0-3 IDs represent core threads, >3 represent others
         next_host_thread_id = Core::Hardware::NUM_CPU_CORES;

--- a/src/core/hle/service/time/time_manager.cpp
+++ b/src/core/hle/service/time/time_manager.cpp
@@ -279,6 +279,10 @@ const SharedMemory& TimeManager::GetSharedMemory() const {
     return impl->shared_memory;
 }
 
+void TimeManager::Shutdown() {
+    impl.reset();
+}
+
 void TimeManager::UpdateLocalSystemClockTime(s64 posix_time) {
     impl->UpdateLocalSystemClockTime(system, posix_time);
 }

--- a/src/core/hle/service/time/time_manager.h
+++ b/src/core/hle/service/time/time_manager.h
@@ -61,6 +61,8 @@ public:
 
     const SharedMemory& GetSharedMemory() const;
 
+    void Shutdown();
+
     void SetupTimeZoneManager(std::string location_name,
                               Clock::SteadyClockTimePoint time_zone_updated_time_point,
                               std::size_t total_location_name_count, u128 time_zone_rule_version,


### PR DESCRIPTION
After rewriting the resource limit, objects releasing reserved resources require a live kernel instance.
This fixes exceptions that occur due to the kernel being destroyed before some objects released their resources, allowing for a graceful exit.