### PR TITLE
[OpenGL] Signed atomic min/max, texelFetch offsets

### DIFF
--- a/src/video_core/shader/decode/texture.cpp
+++ b/src/video_core/shader/decode/texture.cpp
@@ -339,8 +339,6 @@ u32 ShaderIR::DecodeTexture(NodeBlock& bb, u32 pc) {
         const TextureType texture_type{instr.tlds.GetTextureType()};
         const bool is_array{instr.tlds.IsArrayTexture()};
 
-        UNIMPLEMENTED_IF_MSG(instr.tlds.UsesMiscMode(TextureMiscMode::AOFFI),
-                             "AOFFI is not implemented");
         UNIMPLEMENTED_IF_MSG(instr.tlds.UsesMiscMode(TextureMiscMode::MZ), "MZ is not implemented");
 
         const Node4 components = GetTldsCode(instr, texture_type, is_array);
@@ -822,7 +820,7 @@ Node4 ShaderIR::GetTldsCode(Instruction instr, TextureType texture_type, bool is
     for (std::size_t i = 0; i < type_coord_count; ++i) {
         const bool last = (i == (type_coord_count - 1)) && (type_coord_count > 1);
         coords.push_back(
-            GetRegister(last && !aoffi_enabled ? last_coord_register : coord_register + i));
+            GetRegister(last && !aoffi_enabled ? last_coord_register : (coord_register + i)));
     }
 
     const Node array = is_array ? GetRegister(array_register) : nullptr;


### PR DESCRIPTION
I didn't know how to really implement the atomics. I feel like this implementation is terrible, so if anyone has any ideas on how to better do it, let me know. I didn't want to always include the helpers as part of every shader, and I also needed mutliple versions depending on the variables used. 

I decided to just log if a particular helper was needed, and for atomic in paticular, the memory types seen during decompile. Forward-declare the functions at the top, and then implement them after decompiling the shader so I knew what was needed. I tried to make it in such a way that new helper functions can be added more easily in the future.

As part of that, I decided to rename shared memory from smem to shared_mem, to match the assembly shaders and Vulkan.