### PR TITLE
ci: Add clang build scripts

### DIFF
--- a/.ci/scripts/clang/docker.sh
+++ b/.ci/scripts/clang/docker.sh
@@ -1,0 +1,18 @@
+#!/bin/bash -ex
+
+# Exit on error, rather than continuing with the rest of the script.
+set -e
+
+cd /yuzu
+
+ccache -s
+
+mkdir build || true && cd build
+cmake .. -DDISPLAY_VERSION=$1 -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=/usr/lib/ccache/clang -DCMAKE_CXX_COMPILER=/usr/lib/ccache/clang++ -DYUZU_ENABLE_COMPATIBILITY_REPORTING=${ENABLE_COMPATIBILITY_REPORTING:-"OFF"} -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DUSE_DISCORD_PRESENCE=ON -DENABLE_QT_TRANSLATION=ON -DCMAKE_INSTALL_PREFIX="/usr"
+
+make -j$(nproc)
+
+ccache -s
+
+ctest -VV -C Release
+

--- a/.ci/scripts/clang/exec.sh
+++ b/.ci/scripts/clang/exec.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -ex
+
+mkdir -p "ccache"  || true
+chmod a+x ./.ci/scripts/clang/docker.sh
+# the UID for the container yuzu user is 1027
+sudo chown -R 1027 ./
+docker run -e ENABLE_COMPATIBILITY_REPORTING -e CCACHE_DIR=/yuzu/ccache -v $(pwd):/yuzu yuzuemu/build-environments:linux-fresh /bin/bash /yuzu/.ci/scripts/clang/docker.sh $1
+sudo chown -R $UID ./

--- a/.ci/scripts/clang/upload.sh
+++ b/.ci/scripts/clang/upload.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -ex
+
+. .ci/scripts/common/pre-upload.sh
+
+REV_NAME="yuzu-linux-${GITDATE}-${GITREV}"
+ARCHIVE_NAME="${REV_NAME}.tar.xz"
+COMPRESSION_FLAGS="-cJvf"
+
+if [ "${RELEASE_NAME}" = "mainline" ]; then
+    DIR_NAME="${REV_NAME}"
+else
+    DIR_NAME="${REV_NAME}_${RELEASE_NAME}"
+fi
+
+mkdir "$DIR_NAME"
+
+cp build/bin/yuzu-cmd "$DIR_NAME"
+cp build/bin/yuzu "$DIR_NAME"
+
+. .ci/scripts/common/post-upload.sh

--- a/.ci/templates/build-standard.yml
+++ b/.ci/templates/build-standard.yml
@@ -12,6 +12,9 @@ jobs:
       windows:
         BuildSuffix: 'windows-mingw'
         ScriptFolder: 'windows'
+      clang:
+        BuildSuffix: 'clang'
+        ScriptFolder: 'clang'
       linux:
         BuildSuffix: 'linux'
         ScriptFolder: 'linux'


### PR DESCRIPTION
Adds scripts necessary to compile yuzu using Clang on the yuzu-emu/build-environments:linux-fresh Docker container.

These scripts are mostly a copy of those in .ci/scripts/linux, minus AppImage building since that isn't necessary. Re-uses linux-fresh since that container has Clang 12 installed.

Apparently also adds a trailing newline to the end of a script.

I hope I got the template right, but I'm not familiar with that format. Please do not merge until CI passes with Clang.