### PR TITLE
common,video-core: unbreak GCC 11 build on FreeBSD 13

### DIFF
--- a/src/common/cityhash.h
+++ b/src/common/cityhash.h
@@ -61,6 +61,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include "common/common_types.h"
 
 namespace Common {

--- a/src/video_core/shader_notify.cpp
+++ b/src/video_core/shader_notify.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <mutex>
 #include "video_core/shader_notify.h"
 
 using namespace std::chrono_literals;


### PR DESCRIPTION
From [error log](https://github.com/yuzu-emu/yuzu/files/6025872/yuzu-qt5-s20210222.log):
```c++
src/./common/cityhash.h:69:47: error: 'size_t' has not been declared
   69 | [[nodiscard]] u64 CityHash64(const char* buf, size_t len);
      |                                               ^~~~~~
src/./common/cityhash.h:73:55: error: 'size_t' has not been declared
   73 | [[nodiscard]] u64 CityHash64WithSeed(const char* buf, size_t len, u64 seed);
      |                                                       ^~~~~~
src/./common/cityhash.h:77:56: error: 'size_t' has not been declared
   77 | [[nodiscard]] u64 CityHash64WithSeeds(const char* buf, size_t len, u64 seed0, u64 seed1);
      |                                                        ^~~~~~
src/./common/cityhash.h:80:47: error: 'size_t' has not been declared
   80 | [[nodiscard]] u128 CityHash128(const char* s, size_t len);
      |                                               ^~~~~~
src/./common/cityhash.h:84:55: error: 'size_t' has not been declared
   84 | [[nodiscard]] u128 CityHash128WithSeed(const char* s, size_t len, u128 seed);
      |                                                       ^~~~~~
src/video_core/shader_notify.cpp:33:10: error: 'unique_lock' is not a member of 'std'
   33 |     std::unique_lock lock{mutex};
      |          ^~~~~~~~~~~
src/video_core/shader_notify.cpp:6:1: note: 'std::unique_lock' is defined in header '<mutex>'; did you forget to '#include <mutex>'?
    5 | #include "video_core/shader_notify.h"
  +++ |+#include <mutex>
    6 | 
src/video_core/shader_notify.cpp: In member function 'void VideoCore::ShaderNotify::MarkSharderBuilding()':
src/video_core/shader_notify.cpp:38:10: error: 'unique_lock' is not a member of 'std'
   38 |     std::unique_lock lock{mutex};
      |          ^~~~~~~~~~~
src/video_core/shader_notify.cpp:38:10: note: 'std::unique_lock' is defined in header '<mutex>'; did you forget to '#include <mutex>'?
```
