### PR TITLE
[OpenGL] Override viewport ClipControl depth if depth_range_0_1 is set

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -862,9 +862,12 @@ void RasterizerOpenGL::SyncViewport() {
         if (regs.screen_y_control.y_negate != 0) {
             flip_y = !flip_y;
         }
-        const bool is_zero_to_one = regs.depth_mode == Maxwell::DepthMode::ZeroToOne;
+
         const GLenum origin = flip_y ? GL_UPPER_LEFT : GL_LOWER_LEFT;
-        const GLenum depth = is_zero_to_one ? GL_ZERO_TO_ONE : GL_NEGATIVE_ONE_TO_ONE;
+        const GLenum depth = regs.view_volume_clip_control.depth_range_0_1 ||
+                                     regs.depth_mode == Maxwell::DepthMode::ZeroToOne
+                                 ? GL_ZERO_TO_ONE
+                                 : GL_NEGATIVE_ONE_TO_ONE;
         state_tracker.ClipControl(origin, depth);
         state_tracker.SetYNegate(regs.screen_y_control.y_negate != 0);
     }
@@ -889,6 +892,7 @@ void RasterizerOpenGL::SyncViewport() {
             const GLdouble reduce_z = regs.depth_mode == Maxwell::DepthMode::MinusOneToOne;
             const GLdouble near_depth = src.translate_z - src.scale_z * reduce_z;
             const GLdouble far_depth = src.translate_z + src.scale_z;
+
             glDepthRangeIndexed(static_cast<GLuint>(i), near_depth, far_depth);
 
             if (!GLAD_GL_NV_viewport_swizzle) {


### PR DESCRIPTION
Idea was taken from: https://github.com/envytools/envytools/blob/master/rnndb/graph/gf100_3d.xml#L1029

Fixes Disgaea 6 and Link's Awakening (and hopefully others). So far I haven't noticed any regressions in other games. If anyone can test this against their library and see if there are any, it'd be very appreciated.

Some before/after examples:
![LA](https://user-images.githubusercontent.com/34639600/108790562-eeeb8280-7574-11eb-8c48-716c1f3539d2.png)
![D6](https://user-images.githubusercontent.com/34639600/108786702-1427c300-756c-11eb-9d70-d6ba8f28a2c7.png)
