### PR TITLE
vk_command_pool: Reduce the command pool size from 4096 to 4

### DIFF
--- a/src/video_core/renderer_vulkan/vk_command_pool.cpp
+++ b/src/video_core/renderer_vulkan/vk_command_pool.cpp
@@ -10,7 +10,7 @@
 
 namespace Vulkan {
 
-constexpr size_t COMMAND_BUFFER_POOL_SIZE = 0x1000;
+constexpr size_t COMMAND_BUFFER_POOL_SIZE = 4;
 
 struct CommandPool::Pool {
     vk::CommandPool handle;


### PR DESCRIPTION
This allows drivers to reuse memory more easily and preallocate less.
The optimal number has been measured booting Pokémon Sword.

Before this commit:
![imagen](https://user-images.githubusercontent.com/26564870/108914790-a54d7700-760a-11eb-85b0-fcd8d3f9a0c9.png)

After this commit:
![imagen](https://user-images.githubusercontent.com/26564870/108920753-ff066f00-7613-11eb-82ff-97d4867eca98.png)