### PR TITLE
InputCommon: Use an unique client id for each udp socket instance

### DIFF
--- a/src/input_common/udp/client.h
+++ b/src/input_common/udp/client.h
@@ -126,7 +126,7 @@ private:
     void OnPortInfo(Response::PortInfo);
     void OnPadData(Response::PadData, std::size_t client);
     void StartCommunication(std::size_t client, const std::string& host, u16 port,
-                            std::size_t pad_index, u32 client_id);
+                            std::size_t pad_index);
     void UpdateYuzuSettings(std::size_t client, const Common::Vec3<float>& acc,
                             const Common::Vec3<float>& gyro);
 
@@ -165,7 +165,7 @@ public:
      * @param data_callback Called when calibration data is ready
      */
     explicit CalibrationConfigurationJob(const std::string& host, u16 port, std::size_t pad_index,
-                                         u32 client_id, std::function<void(Status)> status_callback,
+                                         std::function<void(Status)> status_callback,
                                          std::function<void(u16, u16, u16, u16)> data_callback);
     ~CalibrationConfigurationJob();
     void Stop();
@@ -174,7 +174,7 @@ private:
     Common::Event complete_event;
 };
 
-void TestCommunication(const std::string& host, u16 port, std::size_t pad_index, u32 client_id,
+void TestCommunication(const std::string& host, u16 port, std::size_t pad_index,
                        const std::function<void()>& success_callback,
                        const std::function<void()>& failure_callback);
 

--- a/src/yuzu/configuration/configure_motion_touch.cpp
+++ b/src/yuzu/configuration/configure_motion_touch.cpp
@@ -24,7 +24,7 @@
 
 CalibrationConfigurationDialog::CalibrationConfigurationDialog(QWidget* parent,
                                                                const std::string& host, u16 port,
-                                                               u8 pad_index, u16 client_id)
+                                                               u8 pad_index)
     : QDialog(parent) {
     layout = new QVBoxLayout;
     status_label = new QLabel(tr("Communicating with the server..."));
@@ -41,7 +41,7 @@ CalibrationConfigurationDialog::CalibrationConfigurationDialog(QWidget* parent,
 
     using namespace InputCommon::CemuhookUDP;
     job = std::make_unique<CalibrationConfigurationJob>(
-        host, port, pad_index, client_id,
+        host, port, pad_index,
         [this](CalibrationConfigurationJob::Status status) {
             QString text;
             switch (status) {
@@ -218,7 +218,6 @@ void ConfigureMotionTouch::OnCemuhookUDPTest() {
     udp_test_in_progress = true;
     InputCommon::CemuhookUDP::TestCommunication(
         ui->udp_server->text().toStdString(), static_cast<u16>(ui->udp_port->text().toInt()), 0,
-        24872,
         [this] {
             LOG_INFO(Frontend, "UDP input test success");
             QMetaObject::invokeMethod(this, "ShowUDPTestResult", Q_ARG(bool, true));
@@ -233,8 +232,7 @@ void ConfigureMotionTouch::OnConfigureTouchCalibration() {
     ui->touch_calibration_config->setEnabled(false);
     ui->touch_calibration_config->setText(tr("Configuring"));
     CalibrationConfigurationDialog dialog(this, ui->udp_server->text().toStdString(),
-                                          static_cast<u16>(ui->udp_port->text().toUInt()), 0,
-                                          24872);
+                                          static_cast<u16>(ui->udp_port->text().toUInt()), 0);
     dialog.exec();
     if (dialog.completed) {
         min_x = dialog.min_x;

--- a/src/yuzu/configuration/configure_motion_touch.h
+++ b/src/yuzu/configuration/configure_motion_touch.h
@@ -30,7 +30,7 @@ class CalibrationConfigurationDialog : public QDialog {
     Q_OBJECT
 public:
     explicit CalibrationConfigurationDialog(QWidget* parent, const std::string& host, u16 port,
-                                            u8 pad_index, u16 client_id);
+                                            u8 pad_index);
     ~CalibrationConfigurationDialog() override;
 
 private:


### PR DESCRIPTION
According to https://github.com/v1993/cemuhook-protocol each socket connection should have a unique client id. This should solve problems where test fails or you need to restart the server. Also removes the magic number 24872 that was used as client id for yuzu.

This is a candidate to be ported to citra since it has the same issue.