### PR TITLE
core: hle: ldn: Error out on call to Initialization.

### DIFF
--- a/src/core/hle/service/ldn/ldn.cpp
+++ b/src/core/hle/service/ldn/ldn.cpp
@@ -156,7 +156,7 @@ public:
         is_initialized = true;
 
         IPC::ResponseBuilder rb{ctx, 2};
-        rb.Push(RESULT_SUCCESS);
+        rb.Push(ERROR_DISABLED);
     }
 
 private:


### PR DESCRIPTION
- Since we do not emulate LDN, returning an error here makes more sense.