### PR TITLE
[Service::nifm] Fix bcat_backend's default initialisation

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -648,7 +648,7 @@ void Config::ReadDebuggingValues() {
 void Config::ReadServiceValues() {
     qt_config->beginGroup(QStringLiteral("Services"));
     Settings::values.bcat_backend =
-        ReadSetting(QStringLiteral("bcat_backend"), QStringLiteral("null"))
+        ReadSetting(QStringLiteral("bcat_backend"), QStringLiteral("none"))
             .toString()
             .toStdString();
     Settings::values.bcat_boxcat_local =
@@ -1239,7 +1239,7 @@ void Config::SaveDebuggingValues() {
 void Config::SaveServiceValues() {
     qt_config->beginGroup(QStringLiteral("Services"));
     WriteSetting(QStringLiteral("bcat_backend"),
-                 QString::fromStdString(Settings::values.bcat_backend), QStringLiteral("null"));
+                 QString::fromStdString(Settings::values.bcat_backend), QStringLiteral("none"));
     WriteSetting(QStringLiteral("bcat_boxcat_local"), Settings::values.bcat_boxcat_local, false);
     qt_config->endGroup();
 }

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -457,7 +457,7 @@ void Config::ReadValues() {
     Settings::values.yuzu_token = sdl2_config->Get("WebService", "yuzu_token", "");
 
     // Services
-    Settings::values.bcat_backend = sdl2_config->Get("Services", "bcat_backend", "null");
+    Settings::values.bcat_backend = sdl2_config->Get("Services", "bcat_backend", "none");
     Settings::values.bcat_boxcat_local =
         sdl2_config->GetBoolean("Services", "bcat_boxcat_local", false);
 }


### PR DESCRIPTION
bcat_backend checks for "none," but is default initialised to "null," leading to incorrectly returning a Connected state without bcat enabled due to the direct string comparisons. Not a huge deal, as opening and closing the settings at any time will fix it back to "none."