### PR TITLE
buffer_cache: Heuristically decide to skip cache on uniform buffers

### DIFF
--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -73,7 +73,8 @@ BufferCacheRuntime::BufferCacheRuntime(const Device& device_)
     for (auto& stage_uniforms : fast_uniforms) {
         for (OGLBuffer& buffer : stage_uniforms) {
             buffer.Create();
-            glNamedBufferData(buffer.handle, BufferCache::SKIP_CACHE_SIZE, nullptr, GL_STREAM_DRAW);
+            glNamedBufferData(buffer.handle, BufferCache::DEFAULT_SKIP_CACHE_SIZE, nullptr,
+                              GL_STREAM_DRAW);
         }
     }
     for (auto& stage_uniforms : copy_uniforms) {


### PR DESCRIPTION
Some games benefit from skipping caches (Pokémon Sword), and others don't (Animal Crossing: New Horizons). Add an heuristic to decide this at runtime, an alternative solution would be to have a database of games that benefit from this but that's ugly.

The cache hit ratio has to be ~98% or better to not skip the cache. There are 16 frames of buffer.

I tested the mentioned games as well as Super Mario Odyssey and The Legend of Zelda Breath of the wild. These two games fall under the skip cache category, so they won't be affected by this change. More testing would be appreciated.

- Fixes a performance regression introduced after the initial release of the buffer cache rewrite on Vulkan on AC:NH.