### PR TITLE
CMakeLists: Add /utf-8 compile option for MSVC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,6 +27,7 @@ if (MSVC)
     # /Zo                 - Enhanced debug info for optimized builds
     # /permissive-        - Enables stricter C++ standards conformance checks
     # /EHsc               - C++-only exception handling semantics
+    # /utf-8              - Set source and execution character sets to UTF-8
     # /volatile:iso       - Use strict standards-compliant volatile semantics.
     # /Zc:externConstexpr - Allow extern constexpr variables to have external linkage, like the standard mandates
     # /Zc:inline          - Let codegen omit inline functions in object files
@@ -38,6 +39,7 @@ if (MSVC)
         /permissive-
         /EHsc
         /std:c++latest
+        /utf-8
         /volatile:iso
         /Zc:externConstexpr
         /Zc:inline


### PR DESCRIPTION
Ensures that the source and execution character sets are in UTF-8

Also fixes the Move Up / Down arrows 
![image](https://user-images.githubusercontent.com/39850852/109770489-a281f180-7bc9-11eb-8f17-c0f6771e935c.png)
