### PR TITLE
Revert "core: Switch to unique_ptr for usage of Common::Fiber."

### DIFF
--- a/src/common/fiber.h
+++ b/src/common/fiber.h
@@ -41,8 +41,8 @@ public:
 
     /// Yields control from Fiber 'from' to Fiber 'to'
     /// Fiber 'from' must be the currently running fiber.
-    static void YieldTo(Fiber* from, Fiber* to);
-    [[nodiscard]] static std::unique_ptr<Fiber> ThreadToFiber();
+    static void YieldTo(std::shared_ptr<Fiber> from, std::shared_ptr<Fiber> to);
+    [[nodiscard]] static std::shared_ptr<Fiber> ThreadToFiber();
 
     void SetRewindPoint(std::function<void(void*)>&& rewind_func, void* rewind_param);
 

--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -111,7 +111,7 @@ void CpuManager::MultiCoreRunGuestThread() {
     auto& kernel = system.Kernel();
     kernel.CurrentScheduler()->OnThreadStart();
     auto* thread = kernel.CurrentScheduler()->GetCurrentThread();
-    auto host_context = thread->GetHostContext();
+    auto& host_context = thread->GetHostContext();
     host_context->SetRewindPoint(GuestRewindFunction, this);
     MultiCoreRunGuestLoop();
 }
@@ -148,8 +148,7 @@ void CpuManager::MultiCoreRunSuspendThread() {
         auto core = kernel.GetCurrentHostThreadID();
         auto& scheduler = *kernel.CurrentScheduler();
         Kernel::KThread* current_thread = scheduler.GetCurrentThread();
-        Common::Fiber::YieldTo(current_thread->GetHostContext(),
-                               core_data[core].host_context.get());
+        Common::Fiber::YieldTo(current_thread->GetHostContext(), core_data[core].host_context);
         ASSERT(scheduler.ContextSwitchPending());
         ASSERT(core == kernel.GetCurrentHostThreadID());
         scheduler.RescheduleCurrentCore();
@@ -202,7 +201,7 @@ void CpuManager::SingleCoreRunGuestThread() {
     auto& kernel = system.Kernel();
     kernel.CurrentScheduler()->OnThreadStart();
     auto* thread = kernel.CurrentScheduler()->GetCurrentThread();
-    auto host_context = thread->GetHostContext();
+    auto& host_context = thread->GetHostContext();
     host_context->SetRewindPoint(GuestRewindFunction, this);
     SingleCoreRunGuestLoop();
 }
@@ -246,7 +245,7 @@ void CpuManager::SingleCoreRunSuspendThread() {
         auto core = kernel.GetCurrentHostThreadID();
         auto& scheduler = *kernel.CurrentScheduler();
         Kernel::KThread* current_thread = scheduler.GetCurrentThread();
-        Common::Fiber::YieldTo(current_thread->GetHostContext(), core_data[0].host_context.get());
+        Common::Fiber::YieldTo(current_thread->GetHostContext(), core_data[0].host_context);
         ASSERT(scheduler.ContextSwitchPending());
         ASSERT(core == kernel.GetCurrentHostThreadID());
         scheduler.RescheduleCurrentCore();
@@ -364,7 +363,7 @@ void CpuManager::RunThread(std::size_t core) {
 
         auto current_thread = system.Kernel().CurrentScheduler()->GetCurrentThread();
         data.is_running = true;
-        Common::Fiber::YieldTo(data.host_context.get(), current_thread->GetHostContext());
+        Common::Fiber::YieldTo(data.host_context, current_thread->GetHostContext());
         data.is_running = false;
         data.is_paused = true;
         data.exit_barrier->Wait();

--- a/src/core/cpu_manager.h
+++ b/src/core/cpu_manager.h
@@ -83,7 +83,7 @@ private:
     void RunThread(std::size_t core);
 
     struct CoreData {
-        std::unique_ptr<Common::Fiber> host_context;
+        std::shared_ptr<Common::Fiber> host_context;
         std::unique_ptr<Common::Event> enter_barrier;
         std::unique_ptr<Common::Event> exit_barrier;
         std::atomic<bool> is_running;

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -608,7 +608,7 @@ void KScheduler::YieldToAnyThread(KernelCore& kernel) {
 }
 
 KScheduler::KScheduler(Core::System& system, s32 core_id) : system(system), core_id(core_id) {
-    switch_fiber = std::make_unique<Common::Fiber>(OnSwitch, this);
+    switch_fiber = std::make_shared<Common::Fiber>(OnSwitch, this);
     state.needs_scheduling.store(true);
     state.interrupt_task_thread_runnable = false;
     state.should_count_idle = false;
@@ -726,15 +726,15 @@ void KScheduler::ScheduleImpl() {
     // Save context for previous thread
     Unload(previous_thread);
 
-    Common::Fiber* old_context;
+    std::shared_ptr<Common::Fiber>* old_context;
     if (previous_thread != nullptr) {
-        old_context = previous_thread->GetHostContext();
+        old_context = &previous_thread->GetHostContext();
     } else {
-        old_context = idle_thread->GetHostContext();
+        old_context = &idle_thread->GetHostContext();
     }
     guard.unlock();
 
-    Common::Fiber::YieldTo(old_context, switch_fiber.get());
+    Common::Fiber::YieldTo(*old_context, switch_fiber);
     /// When a thread wakes up, the scheduler may have changed to other in another core.
     auto& next_scheduler = *system.Kernel().CurrentScheduler();
     next_scheduler.SwitchContextStep2();
@@ -769,13 +769,13 @@ void KScheduler::SwitchToCurrent() {
                     break;
                 }
             }
-            Common::Fiber* next_context;
+            std::shared_ptr<Common::Fiber>* next_context;
             if (next_thread != nullptr) {
-                next_context = next_thread->GetHostContext();
+                next_context = &next_thread->GetHostContext();
             } else {
-                next_context = idle_thread->GetHostContext();
+                next_context = &idle_thread->GetHostContext();
             }
-            Common::Fiber::YieldTo(switch_fiber.get(), next_context);
+            Common::Fiber::YieldTo(switch_fiber, *next_context);
         } while (!is_switch_pending());
     }
 }

--- a/src/core/hle/kernel/k_scheduler.h
+++ b/src/core/hle/kernel/k_scheduler.h
@@ -68,12 +68,12 @@ public:
 
     void OnThreadStart();
 
-    [[nodiscard]] Common::Fiber* ControlContext() {
-        return switch_fiber.get();
+    [[nodiscard]] std::shared_ptr<Common::Fiber>& ControlContext() {
+        return switch_fiber;
     }
 
-    [[nodiscard]] const Common::Fiber* ControlContext() const {
-        return switch_fiber.get();
+    [[nodiscard]] const std::shared_ptr<Common::Fiber>& ControlContext() const {
+        return switch_fiber;
     }
 
     [[nodiscard]] u64 UpdateHighestPriorityThread(KThread* highest_thread);
@@ -178,7 +178,7 @@ private:
 
     KThread* idle_thread;
 
-    std::unique_ptr<Common::Fiber> switch_fiber{};
+    std::shared_ptr<Common::Fiber> switch_fiber{};
 
     struct SchedulingState {
         std::atomic<bool> needs_scheduling;

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -991,6 +991,10 @@ void KThread::SetState(ThreadState state) {
     }
 }
 
+std::shared_ptr<Common::Fiber>& KThread::GetHostContext() {
+    return host_context;
+}
+
 ResultVal<std::shared_ptr<KThread>> KThread::Create(Core::System& system, ThreadType type_flags,
                                                     std::string name, VAddr entry_point,
                                                     u32 priority, u64 arg, s32 processor_id,
@@ -1024,7 +1028,7 @@ ResultVal<std::shared_ptr<KThread>> KThread::Create(Core::System& system, Thread
     scheduler.AddThread(thread);
 
     thread->host_context =
-        std::make_unique<Common::Fiber>(std::move(thread_start_func), thread_start_parameter);
+        std::make_shared<Common::Fiber>(std::move(thread_start_func), thread_start_parameter);
 
     return MakeResult<std::shared_ptr<KThread>>(std::move(thread));
 }

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -293,13 +293,7 @@ public:
         return thread_context_64;
     }
 
-    [[nodiscard]] Common::Fiber* GetHostContext() {
-        return host_context.get();
-    }
-
-    [[nodiscard]] const Common::Fiber* GetHostContext() const {
-        return host_context.get();
-    }
+    [[nodiscard]] std::shared_ptr<Common::Fiber>& GetHostContext();
 
     [[nodiscard]] ThreadState GetState() const {
         return thread_state & ThreadState::Mask;
@@ -725,7 +719,7 @@ private:
     Common::SpinLock context_guard{};
 
     // For emulation
-    std::unique_ptr<Common::Fiber> host_context{};
+    std::shared_ptr<Common::Fiber> host_context{};
 
     // For debugging
     std::vector<KSynchronizationObject*> wait_objects_for_debugging;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -2626,7 +2626,8 @@ void Call(Core::System& system, u32 immediate) {
     kernel.ExitSVCProfile();
 
     if (!thread->IsCallingSvc()) {
-        thread->GetHostContext()->Rewind();
+        auto* host_context = thread->GetHostContext().get();
+        host_context->Rewind();
     }
 
     system.EnterDynarmicProfile();


### PR DESCRIPTION
Reverts yuzu-emu/yuzu#6006

This can technically cause a crash by accessing fibers after use. Will address in a followup.