### PR TITLE
Enable toggle buttons for keyboard and mouse

### DIFF
--- a/src/input_common/mouse/mouse_input.cpp
+++ b/src/input_common/mouse/mouse_input.cpp
@@ -157,6 +157,42 @@ void Mouse::EndConfiguration() {
     configuring = false;
 }
 
+bool Mouse::ToggleButton(std::size_t button_) {
+    if (button_ >= mouse_info.size()) {
+        return false;
+    }
+    const auto button = 1U << button_;
+    const bool button_state = (toggle_buttons & button) != 0;
+    const bool button_lock = (lock_buttons & button) != 0;
+
+    if (button_lock) {
+        return button_state;
+    }
+
+    lock_buttons |= static_cast<u16>(button);
+
+    if (button_state) {
+        toggle_buttons &= static_cast<u16>(0xFF - button);
+    } else {
+        toggle_buttons |= static_cast<u16>(button);
+    }
+
+    return !button_state;
+}
+
+bool Mouse::UnlockButton(std::size_t button_) {
+    if (button_ >= mouse_info.size()) {
+        return false;
+    }
+
+    const auto button = 1U << button_;
+    const bool button_state = (toggle_buttons & button) != 0;
+
+    lock_buttons &= static_cast<u16>(0xFF - button);
+
+    return button_state;
+}
+
 Common::SPSCQueue<MouseStatus>& Mouse::GetMouseQueue() {
     return mouse_queue;
 }

--- a/src/input_common/mouse/mouse_input.h
+++ b/src/input_common/mouse/mouse_input.h
@@ -67,6 +67,9 @@ public:
      */
     void ReleaseButton(int button_);
 
+    [[nodiscard]] bool ToggleButton(std::size_t button_);
+    [[nodiscard]] bool UnlockButton(std::size_t button_);
+
     [[nodiscard]] Common::SPSCQueue<MouseStatus>& GetMouseQueue();
     [[nodiscard]] const Common::SPSCQueue<MouseStatus>& GetMouseQueue() const;
 
@@ -92,6 +95,8 @@ private:
     };
 
     u16 buttons{};
+    u16 toggle_buttons{};
+    u16 lock_buttons{};
     std::thread update_thread;
     MouseButton last_button{MouseButton::Undefined};
     std::array<MouseInfo, 5> mouse_info;

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -376,11 +376,15 @@ void GRenderWindow::closeEvent(QCloseEvent* event) {
 }
 
 void GRenderWindow::keyPressEvent(QKeyEvent* event) {
-    input_subsystem->GetKeyboard()->PressKey(event->key());
+    if (!event->isAutoRepeat()) {
+        input_subsystem->GetKeyboard()->PressKey(event->key());
+    }
 }
 
 void GRenderWindow::keyReleaseEvent(QKeyEvent* event) {
-    input_subsystem->GetKeyboard()->ReleaseKey(event->key());
+    if (!event->isAutoRepeat()) {
+        input_subsystem->GetKeyboard()->ReleaseKey(event->key());
+    }
 }
 
 void GRenderWindow::mousePressEvent(QMouseEvent* event) {

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -158,7 +158,8 @@ QString ButtonToText(const Common::ParamPackage& param) {
     if (param.Get("engine", "") == "mouse") {
         if (param.Has("button")) {
             const QString button_str = QString::number(int(param.Get("button", 0)));
-            return QObject::tr("Click %1").arg(button_str);
+            const QString toggle = QString::fromStdString(param.Get("toggle", false) ? "~" : "");
+            return QObject::tr("%1Click %2").arg(toggle, button_str);
         }
         return GetKeyName(param.Get("code", 0));
     }

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -302,6 +302,11 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
                         buttons_param[button_id].Clear();
                         button_map[button_id]->setText(tr("[not set]"));
                     });
+                    context_menu.addAction(tr("Toggle button"), [&] {
+                        const bool toggle_value = !buttons_param[button_id].Get("toggle", false);
+                        buttons_param[button_id].Set("toggle", toggle_value);
+                        button_map[button_id]->setText(ButtonToText(buttons_param[button_id]));
+                    });
                     context_menu.exec(button_map[button_id]->mapToGlobal(menu_location));
                     ui->controllerFrame->SetPlayerInput(player_index, buttons_param, analogs_param);
                 });

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -104,7 +104,9 @@ QString ButtonToText(const Common::ParamPackage& param) {
     }
 
     if (param.Get("engine", "") == "keyboard") {
-        return GetKeyName(param.Get("code", 0));
+        const QString button_str = GetKeyName(param.Get("code", 0));
+        const QString toggle = QString::fromStdString(param.Get("toggle", false) ? "~" : "");
+        return QObject::tr("%1%2").arg(toggle, button_str);
     }
 
     if (param.Get("engine", "") == "gcpad") {
@@ -411,6 +413,15 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
                     context_menu.addAction(tr("Clear"), [&] {
                         analogs_param[analog_id].Set("modifier", "");
                         analog_map_modifier_button[analog_id]->setText(tr("[not set]"));
+                    });
+                    context_menu.addAction(tr("Toggle button"), [&] {
+                        Common::ParamPackage modifier_param =
+                            Common::ParamPackage{analogs_param[analog_id].Get("modifier", "")};
+                        const bool toggle_value = !modifier_param.Get("toggle", false);
+                        modifier_param.Set("toggle", toggle_value);
+                        analogs_param[analog_id].Set("modifier", modifier_param.Serialize());
+                        analog_map_modifier_button[analog_id]->setText(
+                            ButtonToText(modifier_param));
                     });
                     context_menu.exec(
                         analog_map_modifier_button[analog_id]->mapToGlobal(menu_location));


### PR DESCRIPTION
Since keyboard and mouse has a limit in how many keys can be pressed at the same time. I added the ability to make buttons a toggle button. This way you can free a button from your keyboard by just pressing it once and it will remain pressed until you press it again.

Right click the modifier button then select "toggle button" to enable it or disable it.