### PR TITLE
time: Assign the current time point to the ClockSnapshot

### DIFF
--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -140,6 +140,8 @@ ResultCode Module::Interface::GetClockSnapshotFromSystemClockContextInternal(
 
     const auto current_time_point{
         time_manager.GetStandardSteadyClockCore().GetCurrentTimePoint(system)};
+    clock_snapshot.steady_clock_time_point = current_time_point;
+
     if (const ResultCode result{Clock::ClockSnapshot::GetCurrentTime(
             clock_snapshot.user_time, current_time_point, clock_snapshot.user_context)};
         result != RESULT_SUCCESS) {


### PR DESCRIPTION
Fixes the timer in Super Smash Bros Ultimate's Spirit Board.

![image](https://user-images.githubusercontent.com/39850852/110664612-8f58be00-8195-11eb-8f45-166b73f154a3.png)
