### PR TITLE
[testing] fiber: Double default stack size

### DIFF
--- a/src/common/fiber.cpp
+++ b/src/common/fiber.cpp
@@ -11,7 +11,7 @@
 
 namespace Common {
 
-constexpr std::size_t default_stack_size = 256 * 1024;
+constexpr std::size_t default_stack_size = 512 * 1024;
 
 struct Fiber::FiberImpl {
     FiberImpl() : stack{default_stack_size}, rewind_stack{default_stack_size} {}


### PR DESCRIPTION
When we hit limits we bump the limits.

---

? Stack overflow when running 32-bit guest applications. Bump stack size in order to attempt to avoid this.