### PR TITLE
service: Add a toggle for auto stub fallback

### DIFF
--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -146,6 +146,10 @@ void ServiceFrameworkBase::ReportUnimplementedFunction(Kernel::HLERequestContext
     system.GetReporter().SaveUnimplementedFunctionReport(ctx, ctx.GetCommand(), function_name,
                                                          service_name);
     UNIMPLEMENTED_MSG("Unknown / unimplemented {}", fmt::to_string(buf));
+
+    LOG_WARNING(Service, "Using auto stub fallback!");
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(RESULT_SUCCESS);
 }
 
 void ServiceFrameworkBase::InvokeRequest(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -70,6 +70,7 @@
 #include "core/hle/service/vi/vi.h"
 #include "core/hle/service/wlan/wlan.h"
 #include "core/reporter.h"
+#include "core/settings.h"
 
 namespace Service {
 
@@ -146,10 +147,11 @@ void ServiceFrameworkBase::ReportUnimplementedFunction(Kernel::HLERequestContext
     system.GetReporter().SaveUnimplementedFunctionReport(ctx, ctx.GetCommand(), function_name,
                                                          service_name);
     UNIMPLEMENTED_MSG("Unknown / unimplemented {}", fmt::to_string(buf));
-
-    LOG_WARNING(Service, "Using auto stub fallback!");
-    IPC::ResponseBuilder rb{ctx, 2};
-    rb.Push(RESULT_SUCCESS);
+    if (Settings::values.use_auto_stub) {
+        LOG_WARNING(Service, "Using auto stub fallback!");
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(RESULT_SUCCESS);
+    }
 }
 
 void ServiceFrameworkBase::InvokeRequest(Kernel::HLERequestContext& ctx) {

--- a/src/core/settings.h
+++ b/src/core/settings.h
@@ -222,6 +222,7 @@ struct Values {
     bool quest_flag;
     bool disable_macro_jit;
     bool extended_logging;
+    bool use_auto_stub;
 
     // Miscellaneous
     std::string log_filter;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -641,6 +641,7 @@ void Config::ReadDebuggingValues() {
         ReadSetting(QStringLiteral("disable_macro_jit"), false).toBool();
     Settings::values.extended_logging =
         ReadSetting(QStringLiteral("extended_logging"), false).toBool();
+    Settings::values.use_auto_stub = ReadSetting(QStringLiteral("use_auto_stub"), false).toBool();
 
     qt_config->endGroup();
 }

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -34,6 +34,7 @@ void ConfigureDebug::SetConfiguration() {
     ui->homebrew_args_edit->setText(QString::fromStdString(Settings::values.program_args));
     ui->reporting_services->setChecked(Settings::values.reporting_services);
     ui->quest_flag->setChecked(Settings::values.quest_flag);
+    ui->use_auto_stub->setChecked(Settings::values.use_auto_stub);
     ui->enable_graphics_debugging->setEnabled(!Core::System::GetInstance().IsPoweredOn());
     ui->enable_graphics_debugging->setChecked(Settings::values.renderer_debug);
     ui->disable_macro_jit->setEnabled(!Core::System::GetInstance().IsPoweredOn());
@@ -47,6 +48,7 @@ void ConfigureDebug::ApplyConfiguration() {
     Settings::values.program_args = ui->homebrew_args_edit->text().toStdString();
     Settings::values.reporting_services = ui->reporting_services->isChecked();
     Settings::values.quest_flag = ui->quest_flag->isChecked();
+    Settings::values.use_auto_stub = ui->use_auto_stub->isChecked();
     Settings::values.renderer_debug = ui->enable_graphics_debugging->isChecked();
     Settings::values.disable_macro_jit = ui->disable_macro_jit->isChecked();
     Settings::values.extended_logging = ui->extended_logging->isChecked();

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -185,6 +185,28 @@
         </property>
        </widget>
       </item>
+       <item>
+         <widget class="QCheckBox" name="use_auto_stub">
+           <property name="text">
+             <string>Enable Auto-Stub</string>
+           </property>
+         </widget>
+       </item>
+      <item>
+        <widget class="QLabel" name="label_3">
+          <property name="font">
+            <font>
+              <italic>true</italic>
+            </font>
+          </property>
+          <property name="text">
+            <string>This will be reset automatically when yuzu closes.</string>
+          </property>
+          <property name="indent">
+            <number>20</number>
+          </property>
+        </widget>
+      </item>
      </layout>
     </widget>
    </item>


### PR DESCRIPTION
This adds a toggle in the debugging tab to enable an auto stub fallback for unimplemented HLE service calls.

The toggle is reset when yuzu is relaunched, as this is an experimental feature not meant to remain enabled.

Supersedes #4237