### PR TITLE
externals/libusb/CMakeLists: Add /utf-8 compile option for MSVC

### DIFF
--- a/externals/libusb/CMakeLists.txt
+++ b/externals/libusb/CMakeLists.txt
@@ -1,3 +1,8 @@
+# Ensure libusb compiles with UTF-8 encoding on MSVC
+if(MSVC)
+    add_compile_options(/utf-8)
+endif()
+
 add_library(usb STATIC EXCLUDE_FROM_ALL
     libusb/libusb/core.c
     libusb/libusb/core.c


### PR DESCRIPTION
Resolves C2001 `newline in constant` errors in libusb's strerror.c