### PR TITLE
Fix cancelation of getExistingDirectory dialog

### DIFF
--- a/src/yuzu/configuration/configure_filesystem.cpp
+++ b/src/yuzu/configuration/configure_filesystem.cpp
@@ -103,7 +103,10 @@ void ConfigureFilesystem::SetDirectory(DirectoryTarget target, QLineEdit* edit) 
         str = QFileDialog::getOpenFileName(this, caption, QFileInfo(edit->text()).dir().path(),
                                            QStringLiteral("NX Gamecard;*.xci"));
     } else {
-        str = QFileDialog::getExistingDirectory(this, caption, edit->text()) + QDir::separator();
+        str = QFileDialog::getExistingDirectory(this, caption, edit->text());
+        if (!str.isNull() && str.back() != QDir::separator()) {
+            str.append(QDir::separator());
+        }
     }
 
     if (str.isEmpty())


### PR DESCRIPTION
Do not change current path if QFileDialog::getExistingDirectory is cancelled. Fixes #4947.