### PR TITLE
core: arm_dynarmic: Ensure JIT state is saved/restored on page table changes.

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -306,13 +306,18 @@ void ARM_Dynarmic_32::ClearExclusiveState() {
 
 void ARM_Dynarmic_32::PageTableChanged(Common::PageTable& page_table,
                                        std::size_t new_address_space_size_in_bits) {
+    ThreadContext32 ctx{};
+    SaveContext(ctx);
+
     auto key = std::make_pair(&page_table, new_address_space_size_in_bits);
     auto iter = jit_cache.find(key);
     if (iter != jit_cache.end()) {
         jit = iter->second;
+        LoadContext(ctx);
         return;
     }
     jit = MakeJit(page_table, new_address_space_size_in_bits);
+    LoadContext(ctx);
     jit_cache.emplace(key, jit);
 }
 

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -348,13 +348,18 @@ void ARM_Dynarmic_64::ClearExclusiveState() {
 
 void ARM_Dynarmic_64::PageTableChanged(Common::PageTable& page_table,
                                        std::size_t new_address_space_size_in_bits) {
+    ThreadContext64 ctx{};
+    SaveContext(ctx);
+
     auto key = std::make_pair(&page_table, new_address_space_size_in_bits);
     auto iter = jit_cache.find(key);
     if (iter != jit_cache.end()) {
         jit = iter->second;
+        LoadContext(ctx);
         return;
     }
     jit = MakeJit(page_table, new_address_space_size_in_bits);
+    LoadContext(ctx);
     jit_cache.emplace(key, jit);
 }
 


### PR DESCRIPTION
- We re-create the JIT here without preserving any state.