### PR TITLE
gl_device: unblock async shaders on other Unix systems

### DIFF
--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -210,7 +210,7 @@ Device::Device() {
     const bool is_amd = vendor == "ATI Technologies Inc.";
     const bool is_intel = vendor == "Intel";
 
-#ifdef __linux__
+#ifdef __unix__
     const bool is_linux = true;
 #else
     const bool is_linux = false;


### PR DESCRIPTION
Tested on
```
yuzu Version: yuzu Development Build | master-716285fab
Host CPU: Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz | AVX2 | FMA
Host OS: FreeBSD 12.2-RELEASE
Host RAM: 63.68 GB
Host Swap: 0.00 GB
[...]
GL_VERSION: 4.6 (Compatibility Profile) Mesa 21.1.0-devel (git-52e7297f9c7)
GL_VENDOR: Intel
GL_RENDERER: Mesa Intel(R) HD Graphics 530 (SKL GT2)
```
