### PR TITLE
pctl: Rework how pctl works to be more accurate

### DIFF
--- a/src/core/file_sys/control_metadata.cpp
+++ b/src/core/file_sys/control_metadata.cpp
@@ -100,6 +100,14 @@ u64 NACP::GetDeviceSaveDataSize() const {
     return raw.device_save_data_size;
 }
 
+u32 NACP::GetParentalControlFlag() const {
+    return raw.parental_control;
+}
+
+const std::array<u8, 0x20>& NACP::GetRatingAge() const {
+    return raw.rating_age;
+}
+
 std::vector<u8> NACP::GetRawBytes() const {
     std::vector<u8> out(sizeof(RawNACP));
     std::memcpy(out.data(), &raw, sizeof(RawNACP));

--- a/src/core/file_sys/control_metadata.h
+++ b/src/core/file_sys/control_metadata.h
@@ -114,6 +114,8 @@ public:
     std::vector<u8> GetRawBytes() const;
     bool GetUserAccountSwitchLock() const;
     u64 GetDeviceSaveDataSize() const;
+    u32 GetParentalControlFlag() const;
+    const std::array<u8, 0x20>& GetRatingAge() const;
 
 private:
     RawNACP raw{};

--- a/src/core/hle/service/pctl/module.h
+++ b/src/core/hle/service/pctl/module.h
@@ -13,13 +13,13 @@ class System;
 
 namespace Service::PCTL {
 
-enum class Capability : s32 {
-    None = 0x0,
+enum class Capability : u32 {
+    None = 0,
     Application = 1 << 0,
     SnsPost = 1 << 1,
     Recovery = 1 << 6,
     Status = 1 << 8,
-    SteroVision = 1 << 9,
+    StereoVision = 1 << 9,
     System = 1 << 15,
 };
 DECLARE_ENUM_FLAG_OPERATORS(Capability);

--- a/src/core/hle/service/pctl/module.h
+++ b/src/core/hle/service/pctl/module.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "common/common_funcs.h"
 #include "core/hle/service/service.h"
 
 namespace Core {
@@ -12,12 +13,23 @@ class System;
 
 namespace Service::PCTL {
 
+enum class Capability : s32 {
+    None = 0x0,
+    Application = 1 << 0,
+    SnsPost = 1 << 1,
+    Recovery = 1 << 6,
+    Status = 1 << 8,
+    SteroVision = 1 << 9,
+    System = 1 << 15,
+};
+DECLARE_ENUM_FLAG_OPERATORS(Capability);
+
 class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        explicit Interface(Core::System& system_, std::shared_ptr<Module> module_,
-                           const char* name);
+        explicit Interface(Core::System& system_, std::shared_ptr<Module> module_, const char* name,
+                           Capability capability);
         ~Interface() override;
 
         void CreateService(Kernel::HLERequestContext& ctx);
@@ -25,6 +37,9 @@ public:
 
     protected:
         std::shared_ptr<Module> module;
+
+    private:
+        Capability capability{};
     };
 };
 

--- a/src/core/hle/service/pctl/pctl.cpp
+++ b/src/core/hle/service/pctl/pctl.cpp
@@ -6,8 +6,9 @@
 
 namespace Service::PCTL {
 
-PCTL::PCTL(Core::System& system_, std::shared_ptr<Module> module_, const char* name)
-    : Interface{system_, std::move(module_), name} {
+PCTL::PCTL(Core::System& system_, std::shared_ptr<Module> module_, const char* name,
+           Capability capability)
+    : Interface{system_, std::move(module_), name, capability} {
     static const FunctionInfo functions[] = {
         {0, &PCTL::CreateService, "CreateService"},
         {1, &PCTL::CreateServiceWithoutInitialize, "CreateServiceWithoutInitialize"},

--- a/src/core/hle/service/pctl/pctl.h
+++ b/src/core/hle/service/pctl/pctl.h
@@ -14,7 +14,8 @@ namespace Service::PCTL {
 
 class PCTL final : public Module::Interface {
 public:
-    explicit PCTL(Core::System& system_, std::shared_ptr<Module> module_, const char* name);
+    explicit PCTL(Core::System& system_, std::shared_ptr<Module> module_, const char* name,
+                  Capability capability);
     ~PCTL() override;
 };
 


### PR DESCRIPTION
Introduces the usage of compatibilities to allow the module to be closer to how it works on hardware.

Closes #6111 