### PR TITLE
yuzu/main: Add user command line argument

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -320,6 +320,34 @@ GMainWindow::GMainWindow()
             continue;
         }
 
+        // Launch game with a specific user
+        if (args[i] == QStringLiteral("-u")) {
+            if (i >= args.size() - 1) {
+                continue;
+            }
+
+            if (args[i + 1].startsWith(QChar::fromLatin1('-'))) {
+                continue;
+            }
+
+            bool argument_ok;
+            const std::size_t selected_user = args[++i].toUInt(&argument_ok);
+
+            if (!argument_ok) {
+                LOG_ERROR(Frontend, "Invalid user argument");
+                continue;
+            }
+
+            const Service::Account::ProfileManager manager;
+            if (!manager.UserExistsIndex(selected_user)) {
+                LOG_ERROR(Frontend, "Selected user doesn't exist");
+                continue;
+            }
+
+            Settings::values.current_user = selected_user;
+            continue;
+        }
+
         // Launch game at path
         if (args[i] == QStringLiteral("-g")) {
             if (i >= args.size() - 1) {


### PR DESCRIPTION
Allows to select a specific user at boot. If the selected user is invalid the argument is ignored.
Example:
`yuzu.exe  -u 0`
`yuzu.exe -u 1 -g "path_to_game"`
`yuzu.exe -f -u 2 -g "path_to_game"`