### PR TITLE
nvdrv: Cleanup CDMA Processor on device closure

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_nvdec.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvdec.cpp
@@ -32,11 +32,6 @@ NvResult nvhost_nvdec::Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>&
         case 0x9:
             return MapBuffer(input, output);
         case 0xa: {
-            if (command.length == 0x1c) {
-                LOG_INFO(Service_NVDRV, "NVDEC video stream ended");
-                Tegra::ChCommandHeaderList cmdlist{{0xDEADB33F}};
-                system.GPU().PushCommandBuffer(cmdlist);
-            }
             return UnmapBuffer(input, output);
         }
         default:
@@ -70,6 +65,9 @@ NvResult nvhost_nvdec::Ioctl3(DeviceFD fd, Ioctl command, const std::vector<u8>&
 }
 
 void nvhost_nvdec::OnOpen(DeviceFD fd) {}
-void nvhost_nvdec::OnClose(DeviceFD fd) {}
+
+void nvhost_nvdec::OnClose(DeviceFD fd) {
+    system.GPU().ClearCommandBuffer();
+}
 
 } // namespace Service::Nvidia::Devices

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -494,9 +494,8 @@ void GPU::PushCommandBuffer(Tegra::ChCommandHeaderList& entries) {
 
 void GPU::ClearCommandBuffer() {
     // This condition fires when a video stream ends, clear all intermediary data
-    if (cdma_pusher) {
-        cdma_pusher.reset();
-    }
+    cdma_pusher.reset();
+    LOG_INFO(Service_NVDRV, "NVDEC video stream ended");
 }
 
 void GPU::SwapBuffers(const Tegra::FramebufferConfig* framebuffer) {

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -480,11 +480,7 @@ void GPU::PushCommandBuffer(Tegra::ChCommandHeaderList& entries) {
     if (!use_nvdec) {
         return;
     }
-    // This condition fires when a video stream ends, clear all intermediary data
-    if (entries[0].raw == 0xDEADB33F) {
-        cdma_pusher.reset();
-        return;
-    }
+
     if (!cdma_pusher) {
         cdma_pusher = std::make_unique<Tegra::CDmaPusher>(*this);
     }
@@ -494,6 +490,13 @@ void GPU::PushCommandBuffer(Tegra::ChCommandHeaderList& entries) {
     // gpu_thread.SubmitCommandBuffer(std::move(entries));
 
     cdma_pusher->ProcessEntries(std::move(entries));
+}
+
+void GPU::ClearCommandBuffer() {
+    // This condition fires when a video stream ends, clear all intermediary data
+    if (cdma_pusher) {
+        cdma_pusher.reset();
+    }
 }
 
 void GPU::SwapBuffers(const Tegra::FramebufferConfig* framebuffer) {

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -324,6 +324,9 @@ public:
     /// Push GPU command buffer entries to be processed
     void PushCommandBuffer(Tegra::ChCommandHeaderList& entries);
 
+    /// Frees the CDMAPusher to free up resources
+    void ClearCommandBuffer();
+
     /// Swap buffers (render frame)
     void SwapBuffers(const Tegra::FramebufferConfig* framebuffer);
 


### PR DESCRIPTION
Brings us a step closer to unifying all channels to share a common interface.