### PR TITLE
InputCommon: Improve UDP communications

### DIFF
--- a/src/input_common/udp/client.h
+++ b/src/input_common/udp/client.h
@@ -84,7 +84,7 @@ public:
 
     std::vector<Common::ParamPackage> GetInputDevices() const;
 
-    bool DeviceConnected(std::size_t client) const;
+    bool DeviceConnected(std::size_t pad) const;
     void ReloadSockets();
 
     Common::SPSCQueue<UDPPadStatus>& GetPadQueue();
@@ -97,38 +97,40 @@ public:
     const Input::TouchStatus& GetTouchState() const;
 
 private:
-    struct ClientData {
-        ClientData();
-        ~ClientData();
-
-        std::string host{"127.0.0.1"};
-        u16 port{26760};
+    struct PadData {
         std::size_t pad_index{};
-        std::unique_ptr<Socket> socket;
+        bool connected{};
         DeviceStatus status;
-        std::thread thread;
         u64 packet_sequence{};
-        s8 active{-1};
 
         // Realtime values
         // motion is initalized with PID values for drift correction on joycons
         InputCommon::MotionInput motion{0.3f, 0.005f, 0.0f};
-        std::chrono::time_point<std::chrono::steady_clock> last_motion_update;
+        std::chrono::time_point<std::chrono::steady_clock> last_update;
+    };
+
+    struct ClientConnection {
+        ClientConnection();
+        ~ClientConnection();
+        std::string host{"127.0.0.1"};
+        u16 port{26760};
+        s8 active{-1};
+        std::unique_ptr<Socket> socket;
+        std::thread thread;
     };
 
     // For shutting down, clear all data, join all threads, release usb
     void Reset();
 
     // Translates configuration to client number
-    std::size_t GetClientNumber(std::string_view host, u16 port, std::size_t pad) const;
+    std::size_t GetClientNumber(std::string_view host, u16 port) const;
 
     void OnVersion(Response::Version);
     void OnPortInfo(Response::PortInfo);
     void OnPadData(Response::PadData, std::size_t client);
-    void StartCommunication(std::size_t client, const std::string& host, u16 port,
-                            std::size_t pad_index);
-    void UpdateYuzuSettings(std::size_t client, const Common::Vec3<float>& acc,
-                            const Common::Vec3<float>& gyro);
+    void StartCommunication(std::size_t client, const std::string& host, u16 port);
+    void UpdateYuzuSettings(std::size_t client, std::size_t pad_index,
+                            const Common::Vec3<float>& acc, const Common::Vec3<float>& gyro);
 
     // Returns an unused finger id, if there is no fingers available std::nullopt will be
     // returned
@@ -140,10 +142,12 @@ private:
     bool configuring = false;
 
     // Allocate clients for 8 udp servers
-    static constexpr std::size_t MAX_UDP_CLIENTS = 4 * 8;
+    static constexpr std::size_t MAX_UDP_CLIENTS = 8;
+    static constexpr std::size_t PADS_PER_CLIENT = 4;
     // Each client can have up 2 touch inputs
     static constexpr std::size_t MAX_TOUCH_FINGERS = MAX_UDP_CLIENTS * 2;
-    std::array<ClientData, MAX_UDP_CLIENTS> clients{};
+    std::array<PadData, MAX_UDP_CLIENTS * PADS_PER_CLIENT> pads{};
+    std::array<ClientConnection, MAX_UDP_CLIENTS> clients{};
     Common::SPSCQueue<UDPPadStatus> pad_queue{};
     Input::TouchStatus touch_status{};
     std::array<std::size_t, MAX_TOUCH_FINGERS> finger_id{};
@@ -164,7 +168,7 @@ public:
      * @param status_callback Callback for job status updates
      * @param data_callback Called when calibration data is ready
      */
-    explicit CalibrationConfigurationJob(const std::string& host, u16 port, std::size_t pad_index,
+    explicit CalibrationConfigurationJob(const std::string& host, u16 port,
                                          std::function<void(Status)> status_callback,
                                          std::function<void(u16, u16, u16, u16)> data_callback);
     ~CalibrationConfigurationJob();
@@ -174,7 +178,7 @@ private:
     Common::Event complete_event;
 };
 
-void TestCommunication(const std::string& host, u16 port, std::size_t pad_index,
+void TestCommunication(const std::string& host, u16 port,
                        const std::function<void()>& success_callback,
                        const std::function<void()>& failure_callback);
 

--- a/src/yuzu/configuration/configure_motion_touch.cpp
+++ b/src/yuzu/configuration/configure_motion_touch.cpp
@@ -23,8 +23,7 @@
 #include "yuzu/configuration/configure_touch_from_button.h"
 
 CalibrationConfigurationDialog::CalibrationConfigurationDialog(QWidget* parent,
-                                                               const std::string& host, u16 port,
-                                                               u8 pad_index)
+                                                               const std::string& host, u16 port)
     : QDialog(parent) {
     layout = new QVBoxLayout;
     status_label = new QLabel(tr("Communicating with the server..."));
@@ -41,7 +40,7 @@ CalibrationConfigurationDialog::CalibrationConfigurationDialog(QWidget* parent,
 
     using namespace InputCommon::CemuhookUDP;
     job = std::make_unique<CalibrationConfigurationJob>(
-        host, port, pad_index,
+        host, port,
         [this](CalibrationConfigurationJob::Status status) {
             QString text;
             switch (status) {
@@ -217,7 +216,7 @@ void ConfigureMotionTouch::OnCemuhookUDPTest() {
     ui->udp_test->setText(tr("Testing"));
     udp_test_in_progress = true;
     InputCommon::CemuhookUDP::TestCommunication(
-        ui->udp_server->text().toStdString(), static_cast<u16>(ui->udp_port->text().toInt()), 0,
+        ui->udp_server->text().toStdString(), static_cast<u16>(ui->udp_port->text().toInt()),
         [this] {
             LOG_INFO(Frontend, "UDP input test success");
             QMetaObject::invokeMethod(this, "ShowUDPTestResult", Q_ARG(bool, true));
@@ -232,7 +231,7 @@ void ConfigureMotionTouch::OnConfigureTouchCalibration() {
     ui->touch_calibration_config->setEnabled(false);
     ui->touch_calibration_config->setText(tr("Configuring"));
     CalibrationConfigurationDialog dialog(this, ui->udp_server->text().toStdString(),
-                                          static_cast<u16>(ui->udp_port->text().toUInt()), 0);
+                                          static_cast<u16>(ui->udp_port->text().toUInt()));
     dialog.exec();
     if (dialog.completed) {
         min_x = dialog.min_x;

--- a/src/yuzu/configuration/configure_motion_touch.h
+++ b/src/yuzu/configuration/configure_motion_touch.h
@@ -29,8 +29,7 @@ class ConfigureMotionTouch;
 class CalibrationConfigurationDialog : public QDialog {
     Q_OBJECT
 public:
-    explicit CalibrationConfigurationDialog(QWidget* parent, const std::string& host, u16 port,
-                                            u8 pad_index);
+    explicit CalibrationConfigurationDialog(QWidget* parent, const std::string& host, u16 port);
     ~CalibrationConfigurationDialog() override;
 
 private:


### PR DESCRIPTION
In an attempt to improve the reliability of motion servers I decided to use a single connection per server instead of one per controller. This will simplify communications and reduce the chance for errors.  

Connection tests now check if there is data for all controllers and finish early if connection is successful.

With those changes hopefully users will have less problems. Since communication method changed this need to be tested on production to ensure all UDP servers support this mode.