### PR TITLE
common: Move assert failure handling into a cpp file.

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -97,6 +97,7 @@ add_custom_command(OUTPUT scm_rev.cpp
 add_library(common STATIC
     algorithm.h
     alignment.h
+    assert.cpp
     assert.h
     atomic_ops.h
     detached_tasks.cpp

--- a/src/common/assert.cpp
+++ b/src/common/assert.cpp
@@ -1,0 +1,11 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/assert.h"
+
+#include "common/common_funcs.h"
+
+void assert_handle_failure() {
+    Crash();
+}


### PR DESCRIPTION
Advantage: Altering the handler does not need a full recompilation.
Disadvantage: noreturn is droped, so the caller is a bit slower.

We quite often run yuzu with a YOLO assertion handler. In fact, only very few
games run at all with asserts. This patch allows developers to patch the handler
without recompiling everything. The overhead of the missing "noreturn" attribute
shoul be negletable.

This will conflict on purpose with #1340.