### PR TITLE
configure_graphics: Prevent stack-use-after-scope

### DIFF
--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -227,7 +227,7 @@ void ConfigureGraphics::RetrieveVulkanDevices() try {
     vulkan_devices.clear();
     vulkan_devices.reserve(physical_devices.size());
     for (const VkPhysicalDevice device : physical_devices) {
-        const char* const name = vk::PhysicalDevice(device, dld).GetProperties().deviceName;
+        const std::string name = vk::PhysicalDevice(device, dld).GetProperties().deviceName;
         vulkan_devices.push_back(QString::fromStdString(name));
     }
 


### PR DESCRIPTION
Address Sanitizer reports stack-use-after-scope on line 231 `vulkan_devices.push_back(QString::fromStdString(name));`. Instead of using a pointer, copy the string into a std::string and use that, instead.

Issue was found while opening the Configure menu. Might fix the issue where I sometimes get "rce GTX 980 Ti" instead of "GeForce GTX 980 Ti" in my Vulkan drop down.