### PR TITLE
nvhost_ctrl_gpu: Avoid sending null pointer to memcpy

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
@@ -248,7 +248,13 @@ NvResult nvhost_ctrl_gpu::ZBCSetTable(const std::vector<u8>& input, std::vector<
     IoctlZbcSetTable params{};
     std::memcpy(&params, input.data(), input.size());
     // TODO(ogniK): What does this even actually do?
-    std::memcpy(output.data(), &params, output.size());
+
+    // Prevent null pointer being passed as arg 1
+    if (output.empty()) {
+        LOG_WARNING(Service_NVDRV, "Avoiding passing null pointer to memcpy");
+    } else {
+        std::memcpy(output.data(), &params, output.size());
+    }
     return NvResult::Success;
 }
 


### PR DESCRIPTION
Undefined Behaviour Sanitizer reports a null pointer is being sent to memcpy, thought it's "guaranteed to never be null". Guard it with an if statement, and log when the action has been averted.

Issue was found while booting SSBU. This change may be needed on the rest of the functions in nvhost_ctrl_gpu, but ubsan has not caught anything else there, yet. *Fixing the error, not any potential cause.*