### PR TITLE
process_capability: Handle extended SVC range

### DIFF
--- a/src/core/hle/kernel/process_capability.cpp
+++ b/src/core/hle/kernel/process_capability.cpp
@@ -281,11 +281,6 @@ ResultCode ProcessCapabilities::HandleSyscallFlags(u32& set_svc_bits, u32 flags)
             continue;
         }
 
-        if (svc_number >= svc_capabilities.size()) {
-            LOG_ERROR(Kernel, "Process svc capability is out of range! svc_number={}", svc_number);
-            return ResultOutOfRange;
-        }
-
         svc_capabilities[svc_number] = true;
     }
 

--- a/src/core/hle/kernel/process_capability.h
+++ b/src/core/hle/kernel/process_capability.h
@@ -68,7 +68,7 @@ enum class ProgramType {
 class ProcessCapabilities {
 public:
     using InterruptCapabilities = std::bitset<1024>;
-    using SyscallCapabilities = std::bitset<128>;
+    using SyscallCapabilities = std::bitset<192>;
 
     ProcessCapabilities() = default;
     ProcessCapabilities(const ProcessCapabilities&) = delete;


### PR DESCRIPTION
12.x extended the range of SVC IDs, so we need to expand the range of bits that need to be tested.

The upside of this is that we can eliminate a range check, given the whole range is used.