### PR TITLE
kernel: Mark lock helper classes as [[nodiscard]]

### DIFF
--- a/src/core/hle/kernel/k_scheduler.h
+++ b/src/core/hle/kernel/k_scheduler.h
@@ -200,7 +200,7 @@ private:
 
 class [[nodiscard]] KScopedSchedulerLock : KScopedLock<GlobalSchedulerContext::LockType> {
 public:
-    explicit KScopedSchedulerLock(KernelCore& kernel);
+    explicit KScopedSchedulerLock(KernelCore & kernel);
     ~KScopedSchedulerLock();
 };
 

--- a/src/core/hle/kernel/k_scheduler.h
+++ b/src/core/hle/kernel/k_scheduler.h
@@ -198,7 +198,7 @@ private:
     Common::SpinLock guard{};
 };
 
-class KScopedSchedulerLock : KScopedLock<GlobalSchedulerContext::LockType> {
+class [[nodiscard]] KScopedSchedulerLock : KScopedLock<GlobalSchedulerContext::LockType> {
 public:
     explicit KScopedSchedulerLock(KernelCore& kernel);
     ~KScopedSchedulerLock();

--- a/src/core/hle/kernel/k_scoped_lock.h
+++ b/src/core/hle/kernel/k_scoped_lock.h
@@ -25,14 +25,17 @@ public:
     explicit KScopedLock(T* l) : lock_ptr(l) {
         this->lock_ptr->Lock();
     }
-    explicit KScopedLock(T& l) : KScopedLock(std::addressof(l)) { /* ... */
-    }
+    explicit KScopedLock(T& l) : KScopedLock(std::addressof(l)) {}
+
     ~KScopedLock() {
         this->lock_ptr->Unlock();
     }
 
     KScopedLock(const KScopedLock&) = delete;
+    KScopedLock& operator=(const KScopedLock&) = delete;
+
     KScopedLock(KScopedLock&&) = delete;
+    KScopedLock& operator=(KScopedLock&&) = delete;
 
 private:
     T* lock_ptr;

--- a/src/core/hle/kernel/k_scoped_lock.h
+++ b/src/core/hle/kernel/k_scoped_lock.h
@@ -22,10 +22,10 @@ concept KLockable = !std::is_reference_v<T> && requires(T & t) {
 template <typename T>
 requires KLockable<T> class [[nodiscard]] KScopedLock {
 public:
-    explicit KScopedLock(T* l) : lock_ptr(l) {
+    explicit KScopedLock(T * l) : lock_ptr(l) {
         this->lock_ptr->Lock();
     }
-    explicit KScopedLock(T& l) : KScopedLock(std::addressof(l)) {}
+    explicit KScopedLock(T & l) : KScopedLock(std::addressof(l)) {}
 
     ~KScopedLock() {
         this->lock_ptr->Unlock();
@@ -34,7 +34,7 @@ public:
     KScopedLock(const KScopedLock&) = delete;
     KScopedLock& operator=(const KScopedLock&) = delete;
 
-    KScopedLock(KScopedLock&&) = delete;
+    KScopedLock(KScopedLock &&) = delete;
     KScopedLock& operator=(KScopedLock&&) = delete;
 
 private:

--- a/src/core/hle/kernel/k_scoped_lock.h
+++ b/src/core/hle/kernel/k_scoped_lock.h
@@ -20,7 +20,7 @@ concept KLockable = !std::is_reference_v<T> && requires(T & t) {
 };
 
 template <typename T>
-requires KLockable<T> class KScopedLock {
+requires KLockable<T> class [[nodiscard]] KScopedLock {
 public:
     explicit KScopedLock(T* l) : lock_ptr(l) {
         this->lock_ptr->Lock();

--- a/src/core/hle/kernel/k_scoped_scheduler_lock_and_sleep.h
+++ b/src/core/hle/kernel/k_scoped_scheduler_lock_and_sleep.h
@@ -15,7 +15,7 @@
 
 namespace Kernel {
 
-class KScopedSchedulerLockAndSleep {
+class [[nodiscard]] KScopedSchedulerLockAndSleep {
 public:
     explicit KScopedSchedulerLockAndSleep(KernelCore& kernel, KThread* t, s64 timeout)
         : kernel(kernel), thread(t), timeout_tick(timeout) {

--- a/src/core/hle/kernel/k_scoped_scheduler_lock_and_sleep.h
+++ b/src/core/hle/kernel/k_scoped_scheduler_lock_and_sleep.h
@@ -17,7 +17,7 @@ namespace Kernel {
 
 class [[nodiscard]] KScopedSchedulerLockAndSleep {
 public:
-    explicit KScopedSchedulerLockAndSleep(KernelCore& kernel, KThread* t, s64 timeout)
+    explicit KScopedSchedulerLockAndSleep(KernelCore & kernel, KThread * t, s64 timeout)
         : kernel(kernel), thread(t), timeout_tick(timeout) {
         // Lock the scheduler.
         kernel.GlobalSchedulerContext().scheduler_lock.Lock();


### PR DESCRIPTION
Prevents logic bugs where

```cpp
KScopedSchedulerLock{kernel};
```

is written instead of:

```cpp
KScopedSchedulerLock lock{kernel};
```

from slipping through silently. Now the compiler is obliged to warn about cases like that.