### PR TITLE
renderer_vulkan: Check return value of AcquireNextImage

### DIFF
--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -143,7 +143,10 @@ void RendererVulkan::SwapBuffers(const Tegra::FramebufferConfig* framebuffer) {
 
         scheduler.WaitWorker();
 
-        swapchain.AcquireNextImage();
+        while (!swapchain.AcquireNextImage()) {
+            swapchain.Create(layout.width, layout.height, is_srgb);
+            blit_screen.Recreate();
+        }
         const VkSemaphore render_semaphore = blit_screen.Draw(*framebuffer, use_accelerated);
 
         scheduler.Flush(render_semaphore);

--- a/src/video_core/renderer_vulkan/vk_swapchain.cpp
+++ b/src/video_core/renderer_vulkan/vk_swapchain.cpp
@@ -82,11 +82,13 @@ void VKSwapchain::Create(u32 width, u32 height, bool srgb) {
     resource_ticks.resize(image_count);
 }
 
-void VKSwapchain::AcquireNextImage() {
-    device.GetLogical().AcquireNextImageKHR(*swapchain, std::numeric_limits<u64>::max(),
-                                            *present_semaphores[frame_index], {}, &image_index);
+bool VKSwapchain::AcquireNextImage() {
+    const VkResult result =
+        device.GetLogical().AcquireNextImageKHR(*swapchain, std::numeric_limits<u64>::max(),
+                                                *present_semaphores[frame_index], {}, &image_index);
 
     scheduler.Wait(resource_ticks[image_index]);
+    return result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR;
 }
 
 bool VKSwapchain::Present(VkSemaphore render_semaphore) {

--- a/src/video_core/renderer_vulkan/vk_swapchain.h
+++ b/src/video_core/renderer_vulkan/vk_swapchain.h
@@ -28,7 +28,7 @@ public:
     void Create(u32 width, u32 height, bool srgb);
 
     /// Acquires the next image in the swapchain, waits as needed.
-    void AcquireNextImage();
+    bool AcquireNextImage();
 
     /// Presents the rendered image to the swapchain. Returns true when the swapchains had to be
     /// recreated. Takes responsability for the ownership of fence.


### PR DESCRIPTION
We can get into a really bad state by ignoring this
leading to device loss and using incorrect resources.