### PR TITLE
k_thread: Remove [[nodiscard]] attribute from ClearWaitCancelled()

### DIFF
--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -402,7 +402,7 @@ public:
         return wait_cancelled;
     }
 
-    [[nodiscard]] void ClearWaitCancelled() {
+    void ClearWaitCancelled() {
         wait_cancelled = false;
     }
 


### PR DESCRIPTION
This function has a void return value, so this attribute doesn't apply to it.