### PR TITLE
k_resource_limit: Cleanup of member variables/headers

### DIFF
--- a/src/core/hle/kernel/k_resource_limit.h
+++ b/src/core/hle/kernel/k_resource_limit.h
@@ -2,9 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-// This file references various implementation details from Atmosphere, an open-source firmware for
-// the Nintendo Switch. Copyright 2018-2020 Atmosphere-NX.
-
 #pragma once
 
 #include <array>
@@ -15,8 +12,8 @@
 
 union ResultCode;
 
-namespace Core {
-class System;
+namespace Core::Timing {
+class CoreTiming;
 }
 
 namespace Kernel {
@@ -37,7 +34,7 @@ constexpr bool IsValidResourceType(LimitableResource type) {
 
 class KResourceLimit final : public Object {
 public:
-    explicit KResourceLimit(KernelCore& kernel, Core::System& system);
+    explicit KResourceLimit(KernelCore& kernel, const Core::Timing::CoreTiming& core_timing_);
     ~KResourceLimit();
 
     s64 GetLimitValue(LimitableResource which) const;
@@ -75,7 +72,6 @@ private:
     mutable KLightLock lock;
     s32 waiter_count{};
     KLightConditionVariable cond_var;
-    KernelCore& kernel;
-    Core::System& system;
+    const Core::Timing::CoreTiming& core_timing;
 };
 } // namespace Kernel

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -72,7 +72,7 @@ struct KernelCore::Impl {
         KMemoryLayout memory_layout;
         DeriveInitialMemoryLayout(memory_layout);
         InitializeMemoryLayout(memory_layout);
-        InitializeSystemResourceLimit(kernel, system, memory_layout);
+        InitializeSystemResourceLimit(kernel, system.CoreTiming(), memory_layout);
         InitializeSlabHeaps();
         InitializeSchedulers();
         InitializeSuspendThreads();
@@ -142,9 +142,10 @@ struct KernelCore::Impl {
     }
 
     // Creates the default system resource limit
-    void InitializeSystemResourceLimit(KernelCore& kernel, Core::System& system,
+    void InitializeSystemResourceLimit(KernelCore& kernel,
+                                       const Core::Timing::CoreTiming& core_timing,
                                        const KMemoryLayout& memory_layout) {
-        system_resource_limit = std::make_shared<KResourceLimit>(kernel, system);
+        system_resource_limit = std::make_shared<KResourceLimit>(kernel, core_timing);
         const auto [total_size, kernel_size] = memory_layout.GetTotalAndKernelMemorySizes();
 
         // If setting the default system values fails, then something seriously wrong has occurred.

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -2156,7 +2156,7 @@ static ResultCode CreateResourceLimit(Core::System& system, Handle* out_handle) 
     LOG_DEBUG(Kernel_SVC, "called");
 
     auto& kernel = system.Kernel();
-    auto resource_limit = std::make_shared<KResourceLimit>(kernel, system);
+    auto resource_limit = std::make_shared<KResourceLimit>(kernel, system.CoreTiming());
 
     auto* const current_process = kernel.CurrentProcess();
     ASSERT(current_process != nullptr);


### PR DESCRIPTION
Functionally no change, simply cleans up some of the headers member variables in k_resource_limit 