### PR TITLE
common/log: Move Log namespace into the Common namespace

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -37,8 +37,11 @@ public:
         return backend;
     }
 
-    Impl(Impl const&) = delete;
-    const Impl& operator=(Impl const&) = delete;
+    Impl(const Impl&) = delete;
+    Impl& operator=(const Impl&) = delete;
+
+    Impl(Impl&&) = delete;
+    Impl& operator=(Impl&&) = delete;
 
     void PushEntry(Class log_class, Level log_level, const char* filename, unsigned int line_num,
                    const char* function, std::string message) {

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -25,7 +25,7 @@
 #include "common/threadsafe_queue.h"
 #include "core/settings.h"
 
-namespace Log {
+namespace Common::Log {
 
 /**
  * Static state as a singleton.
@@ -132,7 +132,7 @@ private:
     std::mutex writing_mutex;
     std::thread backend_thread;
     std::vector<std::unique_ptr<Backend>> backends;
-    Common::MPSCQueue<Log::Entry> message_queue;
+    MPSCQueue<Entry> message_queue;
     Filter filter;
     std::chrono::steady_clock::time_point time_origin{std::chrono::steady_clock::now()};
 };
@@ -146,16 +146,16 @@ void ColorConsoleBackend::Write(const Entry& entry) {
 }
 
 FileBackend::FileBackend(const std::string& filename) : bytes_written(0) {
-    if (Common::FS::Exists(filename + ".old.txt")) {
-        Common::FS::Delete(filename + ".old.txt");
+    if (FS::Exists(filename + ".old.txt")) {
+        FS::Delete(filename + ".old.txt");
     }
-    if (Common::FS::Exists(filename)) {
-        Common::FS::Rename(filename, filename + ".old.txt");
+    if (FS::Exists(filename)) {
+        FS::Rename(filename, filename + ".old.txt");
     }
 
     // _SH_DENYWR allows read only access to the file for other programs.
     // It is #defined to 0 on other platforms
-    file = Common::FS::IOFile(filename, "w", _SH_DENYWR);
+    file = FS::IOFile(filename, "w", _SH_DENYWR);
 }
 
 void FileBackend::Write(const Entry& entry) {
@@ -182,7 +182,7 @@ void FileBackend::Write(const Entry& entry) {
 
 void DebuggerBackend::Write(const Entry& entry) {
 #ifdef _WIN32
-    ::OutputDebugStringW(Common::UTF8ToUTF16W(FormatLogMessage(entry).append(1, '\n')).c_str());
+    ::OutputDebugStringW(UTF8ToUTF16W(FormatLogMessage(entry).append(1, '\n')).c_str());
 #endif
 }
 
@@ -342,4 +342,4 @@ void FmtLogMessageImpl(Class log_class, Level log_level, const char* filename,
     instance.PushEntry(log_class, log_level, filename, line_num, function,
                        fmt::vformat(format, args));
 }
-} // namespace Log
+} // namespace Common::Log

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -11,7 +11,7 @@
 #include "common/logging/filter.h"
 #include "common/logging/log.h"
 
-namespace Log {
+namespace Common::Log {
 
 class Filter;
 
@@ -135,4 +135,4 @@ const char* GetLevelName(Level log_level);
  * never get the message
  */
 void SetGlobalFilter(const Filter& filter);
-} // namespace Log
+} // namespace Common::Log

--- a/src/common/logging/filter.cpp
+++ b/src/common/logging/filter.cpp
@@ -7,7 +7,7 @@
 #include "common/logging/filter.h"
 #include "common/string_util.h"
 
-namespace Log {
+namespace Common::Log {
 namespace {
 template <typename It>
 Level GetLevelByName(const It begin, const It end) {
@@ -103,4 +103,4 @@ bool Filter::IsDebug() const {
     });
 }
 
-} // namespace Log
+} // namespace Common::Log

--- a/src/common/logging/filter.h
+++ b/src/common/logging/filter.h
@@ -9,7 +9,7 @@
 #include <string_view>
 #include "common/logging/log.h"
 
-namespace Log {
+namespace Common::Log {
 
 /**
  * Implements a log message filter which allows different log classes to have different minimum
@@ -51,4 +51,4 @@ public:
 private:
     std::array<Level, static_cast<std::size_t>(Class::Count)> class_levels;
 };
-} // namespace Log
+} // namespace Common::Log

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -7,7 +7,7 @@
 #include <fmt/format.h>
 #include "common/common_types.h"
 
-namespace Log {
+namespace Common::Log {
 
 // trims up to and including the last of ../, ..\, src/, src\ in a string
 constexpr const char* TrimSourcePath(std::string_view source) {
@@ -148,28 +148,34 @@ void FmtLogMessage(Class log_class, Level log_level, const char* filename, unsig
                       fmt::make_format_args(args...));
 }
 
-} // namespace Log
+} // namespace Common::Log
 
 #ifdef _DEBUG
 #define LOG_TRACE(log_class, ...)                                                                  \
-    ::Log::FmtLogMessage(::Log::Class::log_class, ::Log::Level::Trace,                             \
-                         ::Log::TrimSourcePath(__FILE__), __LINE__, __func__, __VA_ARGS__)
+    Common::Log::FmtLogMessage(Common::Log::Class::log_class, Common::Log::Level::Trace,           \
+                               Common::Log::TrimSourcePath(__FILE__), __LINE__, __func__,          \
+                               __VA_ARGS__)
 #else
 #define LOG_TRACE(log_class, fmt, ...) (void(0))
 #endif
 
 #define LOG_DEBUG(log_class, ...)                                                                  \
-    ::Log::FmtLogMessage(::Log::Class::log_class, ::Log::Level::Debug,                             \
-                         ::Log::TrimSourcePath(__FILE__), __LINE__, __func__, __VA_ARGS__)
+    Common::Log::FmtLogMessage(Common::Log::Class::log_class, Common::Log::Level::Debug,           \
+                               Common::Log::TrimSourcePath(__FILE__), __LINE__, __func__,          \
+                               __VA_ARGS__)
 #define LOG_INFO(log_class, ...)                                                                   \
-    ::Log::FmtLogMessage(::Log::Class::log_class, ::Log::Level::Info,                              \
-                         ::Log::TrimSourcePath(__FILE__), __LINE__, __func__, __VA_ARGS__)
+    Common::Log::FmtLogMessage(Common::Log::Class::log_class, Common::Log::Level::Info,            \
+                               Common::Log::TrimSourcePath(__FILE__), __LINE__, __func__,          \
+                               __VA_ARGS__)
 #define LOG_WARNING(log_class, ...)                                                                \
-    ::Log::FmtLogMessage(::Log::Class::log_class, ::Log::Level::Warning,                           \
-                         ::Log::TrimSourcePath(__FILE__), __LINE__, __func__, __VA_ARGS__)
+    Common::Log::FmtLogMessage(Common::Log::Class::log_class, Common::Log::Level::Warning,         \
+                               Common::Log::TrimSourcePath(__FILE__), __LINE__, __func__,          \
+                               __VA_ARGS__)
 #define LOG_ERROR(log_class, ...)                                                                  \
-    ::Log::FmtLogMessage(::Log::Class::log_class, ::Log::Level::Error,                             \
-                         ::Log::TrimSourcePath(__FILE__), __LINE__, __func__, __VA_ARGS__)
+    Common::Log::FmtLogMessage(Common::Log::Class::log_class, Common::Log::Level::Error,           \
+                               Common::Log::TrimSourcePath(__FILE__), __LINE__, __func__,          \
+                               __VA_ARGS__)
 #define LOG_CRITICAL(log_class, ...)                                                               \
-    ::Log::FmtLogMessage(::Log::Class::log_class, ::Log::Level::Critical,                          \
-                         ::Log::TrimSourcePath(__FILE__), __LINE__, __func__, __VA_ARGS__)
+    Common::Log::FmtLogMessage(Common::Log::Class::log_class, Common::Log::Level::Critical,        \
+                               Common::Log::TrimSourcePath(__FILE__), __LINE__, __func__,          \
+                               __VA_ARGS__)

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -16,7 +16,7 @@
 #include "common/logging/text_formatter.h"
 #include "common/string_util.h"
 
-namespace Log {
+namespace Common::Log {
 
 std::string FormatLogMessage(const Entry& entry) {
     unsigned int time_seconds = static_cast<unsigned int>(entry.timestamp.count() / 1000000);
@@ -108,4 +108,4 @@ void PrintColoredMessage(const Entry& entry) {
 #undef ESC
 #endif
 }
-} // namespace Log
+} // namespace Common::Log

--- a/src/common/logging/text_formatter.h
+++ b/src/common/logging/text_formatter.h
@@ -7,7 +7,7 @@
 #include <cstddef>
 #include <string>
 
-namespace Log {
+namespace Common::Log {
 
 struct Entry;
 
@@ -17,4 +17,4 @@ std::string FormatLogMessage(const Entry& entry);
 void PrintMessage(const Entry& entry);
 /// Prints the same message as `PrintMessage`, but colored according to the severity level.
 void PrintColoredMessage(const Entry& entry);
-} // namespace Log
+} // namespace Common::Log

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -53,9 +53,9 @@ void ConfigureDebug::ApplyConfiguration() {
     Settings::values.disable_macro_jit = ui->disable_macro_jit->isChecked();
     Settings::values.extended_logging = ui->extended_logging->isChecked();
     Debugger::ToggleConsole();
-    Log::Filter filter;
+    Common::Log::Filter filter;
     filter.ParseFilterString(Settings::values.log_filter);
-    Log::SetGlobalFilter(filter);
+    Common::Log::SetGlobalFilter(filter);
 }
 
 void ConfigureDebug::changeEvent(QEvent* event) {

--- a/src/yuzu/debugger/console.cpp
+++ b/src/yuzu/debugger/console.cpp
@@ -29,13 +29,13 @@ void ToggleConsole() {
             freopen_s(&temp, "CONIN$", "r", stdin);
             freopen_s(&temp, "CONOUT$", "w", stdout);
             freopen_s(&temp, "CONOUT$", "w", stderr);
-            Log::AddBackend(std::make_unique<Log::ColorConsoleBackend>());
+            Common::Log::AddBackend(std::make_unique<Common::Log::ColorConsoleBackend>());
         }
     } else {
         if (FreeConsole()) {
             // In order to close the console, we have to also detach the streams on it.
             // Just redirect them to NUL if there is no console window
-            Log::RemoveBackend(Log::ColorConsoleBackend::Name());
+            Common::Log::RemoveBackend(Common::Log::ColorConsoleBackend::Name());
             freopen_s(&temp, "NUL", "r", stdin);
             freopen_s(&temp, "NUL", "w", stdout);
             freopen_s(&temp, "NUL", "w", stderr);
@@ -43,9 +43,9 @@ void ToggleConsole() {
     }
 #else
     if (UISettings::values.show_console) {
-        Log::AddBackend(std::make_unique<Log::ColorConsoleBackend>());
+        Common::Log::AddBackend(std::make_unique<Common::Log::ColorConsoleBackend>());
     } else {
-        Log::RemoveBackend(Log::ColorConsoleBackend::Name());
+        Common::Log::RemoveBackend(Common::Log::ColorConsoleBackend::Name());
     }
 #endif
 }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -171,12 +171,14 @@ void GMainWindow::ShowTelemetryCallout() {
 const int GMainWindow::max_recent_files_item;
 
 static void InitializeLogging() {
+    using namespace Common;
+
     Log::Filter log_filter;
     log_filter.ParseFilterString(Settings::values.log_filter);
     Log::SetGlobalFilter(log_filter);
 
-    const std::string& log_dir = Common::FS::GetUserPath(Common::FS::UserPath::LogDir);
-    Common::FS::CreateFullPath(log_dir);
+    const std::string& log_dir = FS::GetUserPath(FS::UserPath::LogDir);
+    FS::CreateFullPath(log_dir);
     Log::AddBackend(std::make_unique<Log::FileBackend>(log_dir + LOG_FILE));
 #ifdef _WIN32
     Log::AddBackend(std::make_unique<Log::DebuggerBackend>());

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -74,14 +74,16 @@ static void PrintVersion() {
 }
 
 static void InitializeLogging() {
+    using namespace Common;
+
     Log::Filter log_filter(Log::Level::Debug);
     log_filter.ParseFilterString(Settings::values.log_filter);
     Log::SetGlobalFilter(log_filter);
 
     Log::AddBackend(std::make_unique<Log::ColorConsoleBackend>());
 
-    const std::string& log_dir = Common::FS::GetUserPath(Common::FS::UserPath::LogDir);
-    Common::FS::CreateFullPath(log_dir);
+    const std::string& log_dir = FS::GetUserPath(FS::UserPath::LogDir);
+    FS::CreateFullPath(log_dir);
     Log::AddBackend(std::make_unique<Log::FileBackend>(log_dir + LOG_FILE));
 #ifdef _WIN32
     Log::AddBackend(std::make_unique<Log::DebuggerBackend>());


### PR DESCRIPTION
Forgot to move this over when I moved the rest of the source files with lacking namespaces over.

Thankfully aspects of this namespace outside of the defines aren't touched much, so this is a pretty straightforward change.