### PR TITLE
cmake: Remove use of bintray for externals.

### DIFF
--- a/.ci/templates/build-msvc.yml
+++ b/.ci/templates/build-msvc.yml
@@ -8,7 +8,7 @@ steps:
   displayName: 'Install vulkan-sdk'
 - script: python -m pip install --upgrade pip conan
   displayName: 'Install conan'
-- script: refreshenv && mkdir build && cd build && cmake -G "Visual Studio 16 2019" -A x64 -DYUZU_USE_BUNDLED_QT=1 -DYUZU_USE_QT_WEB_ENGINE=ON -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DYUZU_ENABLE_COMPATIBILITY_REPORTING=${COMPAT} -DUSE_DISCORD_PRESENCE=ON -DENABLE_QT_TRANSLATION=ON -DDISPLAY_VERSION=${{ parameters['version'] }} .. && cmake --install . --config Release && cd ..
+- script: refreshenv && mkdir build && cd build && cmake -G "Visual Studio 16 2019" -A x64 -DYUZU_USE_BUNDLED_QT=1 -DYUZU_USE_BUNDLED_SDL2=1 -DYUZU_USE_QT_WEB_ENGINE=ON -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DYUZU_ENABLE_COMPATIBILITY_REPORTING=${COMPAT} -DUSE_DISCORD_PRESENCE=ON -DENABLE_QT_TRANSLATION=ON -DDISPLAY_VERSION=${{ parameters['version'] }} .. && cmake --install . --config Release && cd ..
   displayName: 'Configure CMake'
 - task: MSBuild@1
   displayName: 'Build'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ project(yuzu)
 # Set bundled sdl2/qt as dependent options.
 # OFF by default, but if ENABLE_SDL2 and MSVC are true then ON
 option(ENABLE_SDL2 "Enable the SDL2 frontend" ON)
+CMAKE_DEPENDENT_OPTION(YUZU_USE_BUNDLED_SDL2 "Download bundled SDL2 binaries" ON "ENABLE_SDL2;MSVC" OFF)
 
 option(ENABLE_QT "Enable the Qt frontend" ON)
 option(ENABLE_QT_TRANSLATION "Enable translations for the Qt frontend" OFF)
@@ -166,8 +167,6 @@ macro(yuzu_find_packages)
     #    Cmake Pkg Prefix  Version     Conan Pkg
         "Catch2            2.13        catch2/2.13.0"
         "fmt               7.1         fmt/7.1.2"
-    # can't use until https://github.com/bincrafters/community/issues/1173
-        #"libzip            1.5         libzip/1.5.2@bincrafters/stable"
         "lz4               1.8         lz4/1.9.2"
         "nlohmann_json     3.8         nlohmann_json/3.8.0"
         "ZLIB              1.2         zlib/1.2.11"
@@ -251,22 +250,44 @@ if(ENABLE_QT)
     if (ENABLE_QT_TRANSLATION)
         find_package(Qt5 REQUIRED COMPONENTS LinguistTools ${QT_PREFIX_HINT})
     endif()
-    if (NOT Qt5_FOUND)
-        list(APPEND CONAN_REQUIRED_LIBS "qt/5.14.1@bincrafters/stable")
-    endif()
 endif()
 # find SDL2 exports a bunch of variables that are needed, so its easier to do this outside of the yuzu_find_package
-if(ENABLE_SDL2)
-    if(EXISTS ${CMAKE_BINARY_DIR}/sdl2Config.cmake)
-        include(${CMAKE_BINARY_DIR}/sdl2Config.cmake)
-        list(APPEND CMAKE_MODULE_PATH "${CONAN_SDL2_ROOT_RELEASE}")
-        list(APPEND CMAKE_PREFIX_PATH "${CONAN_SDL2_ROOT_RELEASE}")
+if (ENABLE_SDL2)
+    if (YUZU_USE_BUNDLED_SDL2)
+        # Detect toolchain and platform
+        if ((MSVC_VERSION GREATER_EQUAL 1910 AND MSVC_VERSION LESS 1930) AND ARCHITECTURE_x86_64)
+            set(SDL2_VER "SDL2-2.0.14")
+        else()
+            message(FATAL_ERROR "No bundled SDL2 binaries for your toolchain. Disable YUZU_USE_BUNDLED_SDL2 and provide your own.")
+        endif()
+
+        if (DEFINED SDL2_VER)
+            download_bundled_external("sdl2/" ${SDL2_VER} SDL2_PREFIX)
+        endif()
+
+        set(SDL2_FOUND YES)
+        set(SDL2_INCLUDE_DIR "${SDL2_PREFIX}/include" CACHE PATH "Path to SDL2 headers")
+        set(SDL2_LIBRARY "${SDL2_PREFIX}/lib/x64/SDL2.lib" CACHE PATH "Path to SDL2 library")
+        set(SDL2_DLL_DIR "${SDL2_PREFIX}/lib/x64/" CACHE PATH "Path to SDL2.dll")
+
+        add_library(SDL2 INTERFACE)
+        target_link_libraries(SDL2 INTERFACE "${SDL2_LIBRARY}")
+        target_include_directories(SDL2 INTERFACE "${SDL2_INCLUDE_DIR}")
+    else()
+        find_package(SDL2 REQUIRED)
+
+        # Some installations don't set SDL2_LIBRARIES
+        if("${SDL2_LIBRARIES}" STREQUAL "")
+            message(WARNING "SDL2_LIBRARIES wasn't set, manually setting to SDL2::SDL2")
+            set(SDL2_LIBRARIES "SDL2::SDL2")
+        endif()
+
+        include_directories(SYSTEM ${SDL2_INCLUDE_DIRS})
+        add_library(SDL2 INTERFACE)
+        target_link_libraries(SDL2 INTERFACE "${SDL2_LIBRARIES}")
     endif()
-    find_package(SDL2)
-    if (NOT SDL2_FOUND)
-        # otherwise add this to the list of libraries to install
-        list(APPEND CONAN_REQUIRED_LIBS "sdl2/2.0.14@bincrafters/stable")
-    endif()
+else()
+    set(SDL2_FOUND NO)
 endif()
 
 # Install any missing dependencies with conan install
@@ -287,9 +308,6 @@ if (CONAN_REQUIRED_LIBS)
     )
 
     conan_check(VERSION 1.24.0 REQUIRED)
-    # Add the bincrafters remote
-    conan_add_remote(NAME bincrafters
-                    URL https://api.bintray.com/conan/bincrafters/public-conan)
 
     # Manually add iconv to fix a dep conflict between qt and sdl2
     # We don't need to add it through find_package or anything since the other two can find it just fine
@@ -340,11 +358,6 @@ if (CONAN_REQUIRED_LIBS)
             find_package(Qt5 REQUIRED COMPONENTS WebEngineCore WebEngineWidgets)
         endif()
     endif()
-    if(ENABLE_SDL2)
-        list(APPEND CMAKE_MODULE_PATH "${CONAN_SDL2_ROOT_RELEASE}")
-        list(APPEND CMAKE_PREFIX_PATH "${CONAN_SDL2_ROOT_RELEASE}")
-        find_package(SDL2 REQUIRED)
-    endif()
 
 endif()
 
@@ -358,23 +371,6 @@ if (TARGET Boost::Boost)
 elseif (TARGET Boost::boost)
     set_target_properties(Boost::boost PROPERTIES IMPORTED_GLOBAL TRUE)
     add_library(boost ALIAS Boost::boost)
-endif()
-
-if (TARGET sdl2::sdl2)
-    # imported from the conan generated sdl2Config.cmake
-    set_target_properties(sdl2::sdl2 PROPERTIES IMPORTED_GLOBAL TRUE)
-    add_library(SDL2 ALIAS sdl2::sdl2)
-elseif(SDL2_FOUND)
-    # found through the system package manager
-    # Some installations don't set SDL2_LIBRARIES
-    if("${SDL2_LIBRARIES}" STREQUAL "")
-        message(WARNING "SDL2_LIBRARIES wasn't set, manually setting to SDL2::SDL2")
-        set(SDL2_LIBRARIES "SDL2::SDL2")
-    endif()
-
-    include_directories(SYSTEM ${SDL2_INCLUDE_DIRS})
-    add_library(SDL2 INTERFACE)
-    target_link_libraries(SDL2 INTERFACE "${SDL2_LIBRARIES}")
 endif()
 
 # Ensure libusb is properly configured (based on dolphin libusb include)


### PR DESCRIPTION
- Bintray will be deprecated on May 1st 2021 (https://bintray.com/)
- We were previously using this for Qt (non-Windows) and SDL.
- I've moved to bundled SDL on Windows.