### PR TITLE
externals: Add SDL 2.0.12

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -40,3 +40,6 @@
 [submodule "ffmpeg"]
 	path = externals/ffmpeg
 	url = https://git.ffmpeg.org/ffmpeg.git
+[submodule "externals/SDL"]
+	path = externals/SDL
+	url = https://github.com/libsdl-org/SDL.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -40,6 +40,6 @@
 [submodule "ffmpeg"]
 	path = externals/ffmpeg
 	url = https://git.ffmpeg.org/ffmpeg.git
-[submodule "externals/SDL"]
+[submodule "SDL"]
 	path = externals/SDL
 	url = https://github.com/libsdl-org/SDL.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,17 +274,19 @@ if (ENABLE_SDL2)
         target_link_libraries(SDL2 INTERFACE "${SDL2_LIBRARY}")
         target_include_directories(SDL2 INTERFACE "${SDL2_INCLUDE_DIR}")
     else()
-        find_package(SDL2 REQUIRED)
+        find_package(SDL2 2.0.12)
 
-        # Some installations don't set SDL2_LIBRARIES
-        if("${SDL2_LIBRARIES}" STREQUAL "")
-            message(WARNING "SDL2_LIBRARIES wasn't set, manually setting to SDL2::SDL2")
-            set(SDL2_LIBRARIES "SDL2::SDL2")
+        if(SDL2_FOUND)
+            # Some installations don't set SDL2_LIBRARIES
+            if("${SDL2_LIBRARIES}" STREQUAL "")
+                message(WARNING "SDL2_LIBRARIES wasn't set, manually setting to SDL2::SDL2")
+                set(SDL2_LIBRARIES "SDL2::SDL2")
+            endif()
+
+            include_directories(SYSTEM ${SDL2_INCLUDE_DIRS})
+            add_library(SDL2 INTERFACE)
+            target_link_libraries(SDL2 INTERFACE "${SDL2_LIBRARIES}")
         endif()
-
-        include_directories(SYSTEM ${SDL2_INCLUDE_DIRS})
-        add_library(SDL2 INTERFACE)
-        target_link_libraries(SDL2 INTERFACE "${SDL2_LIBRARIES}")
     endif()
 else()
     set(SDL2_FOUND NO)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -45,6 +45,12 @@ target_include_directories(microprofile INTERFACE ./microprofile)
 add_library(unicorn-headers INTERFACE)
 target_include_directories(unicorn-headers INTERFACE ./unicorn/include)
 
+# SDL2
+if (NOT SDL2_FOUND)
+    set(SDL2_FOUND YES)
+    add_subdirectory(SDL EXCLUDE_FROM_ALL)
+endif()
+
 # SoundTouch
 add_subdirectory(soundtouch)
 


### PR DESCRIPTION
Since Bintray is (soon to be) no more and has been removed from yuzu, there needs to be a way to acquire updated SDL2. Since Ubuntu 20.04's version is older than our minimum required version (2.0.12), add it as an external.

Fixes #6203 