### PR TITLE
time: Fix GetClockSnapshotFromSystemClockContext

### DIFF
--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -303,7 +303,7 @@ void Module::Interface::GetClockSnapshotFromSystemClockContext(Kernel::HLEReques
     IPC::RequestParser rp{ctx};
     const auto type{rp.PopEnum<Clock::TimeType>()};
 
-    rp.AlignWithPadding();
+    rp.Skip(1, false);
 
     const Clock::SystemClockContext user_context{rp.PopRaw<Clock::SystemClockContext>()};
     const Clock::SystemClockContext network_context{rp.PopRaw<Clock::SystemClockContext>()};
@@ -319,9 +319,10 @@ void Module::Interface::GetClockSnapshotFromSystemClockContext(Kernel::HLEReques
         return;
     }
 
+    ctx.WriteBuffer(clock_snapshot);
+
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
-    ctx.WriteBuffer(clock_snapshot);
 }
 
 void Module::Interface::CalculateStandardUserSystemClockDifferenceByUser(

--- a/src/core/hle/service/time/time.cpp
+++ b/src/core/hle/service/time/time.cpp
@@ -294,9 +294,10 @@ void Module::Interface::GetClockSnapshot(Kernel::HLERequestContext& ctx) {
         return;
     }
 
+    ctx.WriteBuffer(clock_snapshot);
+
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
-    ctx.WriteBuffer(clock_snapshot);
 }
 
 void Module::Interface::GetClockSnapshotFromSystemClockContext(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
This removes an incorrect alignment usage and corrects the positions of the popped parameters.

- Fixes Super Kirby Clash crashing on boot
- Also fixes Yo-Kai Watch 4 (JP) crashing on boot

![image](https://user-images.githubusercontent.com/39850852/115260639-f2c4fc80-a100-11eb-8cf1-a095f496e562.png)

![image](https://user-images.githubusercontent.com/39850852/115260871-256ef500-a101-11eb-8672-781b34069cff.png)

![image](https://user-images.githubusercontent.com/39850852/115260920-2e5fc680-a101-11eb-8e87-36b56334d654.png)

![image](https://user-images.githubusercontent.com/39850852/115260961-361f6b00-a101-11eb-9726-66561b10af02.png)

![image](https://user-images.githubusercontent.com/39850852/115261057-4d5e5880-a101-11eb-908b-f0eeba6def05.png)

Fixes #4045 
