### PR TITLE
npad: Remove duplicated class member variable

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -147,7 +147,7 @@ bool Controller_NPad::IsDeviceHandleValid(const DeviceHandle& device_handle) {
            device_handle.device_index < DeviceIndex::MaxDeviceIndex;
 }
 
-Controller_NPad::Controller_NPad(Core::System& system) : ControllerBase(system), system(system) {
+Controller_NPad::Controller_NPad(Core::System& system) : ControllerBase(system) {
     latest_vibration_values.fill({DEFAULT_VIBRATION_VALUE, DEFAULT_VIBRATION_VALUE});
 }
 

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -587,6 +587,5 @@ private:
     std::array<ControllerPad, 10> npad_pad_states{};
     std::array<TriggerState, 10> npad_trigger_states{};
     bool is_in_lr_assignment_mode{false};
-    Core::System& system;
 };
 } // namespace Service::HID


### PR DESCRIPTION
ControllerBase already has a System reference that can be accessed from this class, so we can get rid of this to make the class layout a little more straightforward.