### PR TITLE
arp: Prevent potential uninitialized read of launch member variable

### DIFF
--- a/src/core/hle/service/glue/arp.cpp
+++ b/src/core/hle/service/glue/arp.cpp
@@ -157,9 +157,9 @@ class IRegistrar final : public ServiceFramework<IRegistrar> {
     friend class ARP_W;
 
 public:
-    explicit IRegistrar(
-        Core::System& system_,
-        std::function<ResultCode(u64, ApplicationLaunchProperty, std::vector<u8>)> issuer)
+    using IssuerFn = std::function<ResultCode(u64, ApplicationLaunchProperty, std::vector<u8>)>;
+
+    explicit IRegistrar(Core::System& system_, IssuerFn&& issuer)
         : ServiceFramework{system_, "IRegistrar"}, issue_process_id{std::move(issuer)} {
         // clang-format off
         static const FunctionInfo functions[] = {
@@ -238,7 +238,7 @@ private:
         rb.Push(RESULT_SUCCESS);
     }
 
-    std::function<ResultCode(u64, ApplicationLaunchProperty, std::vector<u8>)> issue_process_id;
+    IssuerFn issue_process_id;
     bool issued = false;
     ApplicationLaunchProperty launch{};
     std::vector<u8> control;

--- a/src/core/hle/service/glue/arp.cpp
+++ b/src/core/hle/service/glue/arp.cpp
@@ -240,7 +240,7 @@ private:
 
     std::function<ResultCode(u64, ApplicationLaunchProperty, std::vector<u8>)> issue_process_id;
     bool issued = false;
-    ApplicationLaunchProperty launch;
+    ApplicationLaunchProperty launch{};
     std::vector<u8> control;
 };
 


### PR DESCRIPTION
If anything happened to call arp functions in the wrong order and called IRegistrar's Issue function before SetApplicationLaunchProperty, we'd read from an uninitialized ApplicationLaunchProperty instance. Instead, we can always initialize it so if this does happen, then the outcome of doing such a thing is at least consistently reproducible, as opposed to using whatever was in memory at that time. Unlikely to occur, but is a bug vector class that's trivial to eliminate here.

While we're in the area, we can also deduplicate the issuer function type, so that it's in one place and makes the code a little nicer to read.