### PR TITLE
cmake: Download Boost from ext-linux-bin if inadequate local version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ CMAKE_DEPENDENT_OPTION(YUZU_USE_BUNDLED_QT "Download bundled Qt binaries" ON "EN
 
 option(ENABLE_WEB_SERVICE "Enable web services (telemetry, etc.)" ON)
 
+option(YUZU_USE_BUNDLED_BOOST "Download bundled Boost" OFF)
+
 CMAKE_DEPENDENT_OPTION(YUZU_USE_BUNDLED_FFMPEG "Download/Build bundled FFmpeg" ON "WIN32" OFF)
 
 option(YUZU_USE_QT_WEB_ENGINE "Use QtWebEngine for web applet implementation" OFF)
@@ -199,7 +201,9 @@ macro(yuzu_find_packages)
     unset(FN_FORCE_REQUIRED)
 endmacro()
 
-find_package(Boost 1.73.0 COMPONENTS context headers QUIET)
+if (NOT YUZU_USE_BUNDLED_BOOST)
+    find_package(Boost 1.73.0 COMPONENTS context headers QUIET)
+endif()
 if (Boost_FOUND)
     set(Boost_LIBRARIES Boost::boost)
     # Conditionally add Boost::context only if the active version of the Conan or system Boost package provides it
@@ -210,6 +214,20 @@ if (Boost_FOUND)
     if (TARGET Boost::context)
         list(APPEND Boost_LIBRARIES Boost::context)
     endif()
+elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux" OR YUZU_USE_BUNDLED_BOOST)
+    message(STATUS "Boost 1.73.0 or newer not found, falling back to externals")
+    set(YUZU_USE_BUNDLED_BOOST ON CACHE BOOL "Download bundled Boost" FORCE)
+
+    # Use yuzu Boost binaries
+    set(Boost_EXT_NAME "boost_1_75_0")
+    set(Boost_PATH "${CMAKE_BINARY_DIR}/externals/${Boost_EXT_NAME}")
+    download_bundled_external("boost/" ${Boost_EXT_NAME} "")
+    set(Boost_USE_DEBUG_RUNTIME FALSE)
+    set(Boost_USE_STATIC_LIBS ON)
+    find_package(Boost 1.75.0 REQUIRED COMPONENTS context headers PATHS ${Boost_PATH} NO_DEFAULT_PATH)
+    # Manually set the include dirs since the find_package sets it incorrectly
+    set(Boost_INCLUDE_DIRS ${Boost_PATH}/include CACHE PATH "Path to Boost headers" FORCE)
+    include_directories(SYSTEM "${Boost_INCLUDE_DIRS}")
 else()
     message(STATUS "Boost 1.73.0 or newer not found, falling back to Conan")
     list(APPEND CONAN_REQUIRED_LIBS "boost/1.73.0")

--- a/CMakeModules/DownloadExternals.cmake
+++ b/CMakeModules/DownloadExternals.cmake
@@ -4,13 +4,27 @@
 #   remote_path: path to the file to download, relative to the remote repository root
 #   prefix_var: name of a variable which will be set with the path to the extracted contents
 function(download_bundled_external remote_path lib_name prefix_var)
+
+set(package_repo "no_platform")
+set(package_extension "no_platform")
+if (WIN32)
+    set(package_repo "ext-windows-bin/raw/master/")
+    set(package_extension ".7z")
+elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    set(package_repo "ext-linux-bin/raw/main/")
+    set(package_extension ".tar.xz")
+else()
+    message(FATAL_ERROR "No package available for this platform")
+endif()
+set(package_url "https://github.com/yuzu-emu/${package_repo}")
+
 set(prefix "${CMAKE_BINARY_DIR}/externals/${lib_name}")
 if (NOT EXISTS "${prefix}")
     message(STATUS "Downloading binaries for ${lib_name}...")
     file(DOWNLOAD
-        https://github.com/yuzu-emu/ext-windows-bin/raw/master/${remote_path}${lib_name}.7z
-        "${CMAKE_BINARY_DIR}/externals/${lib_name}.7z" SHOW_PROGRESS)
-    execute_process(COMMAND ${CMAKE_COMMAND} -E tar xf "${CMAKE_BINARY_DIR}/externals/${lib_name}.7z"
+        ${package_url}${remote_path}${lib_name}${package_extension}
+        "${CMAKE_BINARY_DIR}/externals/${lib_name}${package_extension}" SHOW_PROGRESS)
+    execute_process(COMMAND ${CMAKE_COMMAND} -E tar xf "${CMAKE_BINARY_DIR}/externals/${lib_name}${package_extension}"
         WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/externals")
 endif()
 message(STATUS "Using bundled binaries at ${prefix}")


### PR DESCRIPTION
Since #6207, building SDL2 from externals on systems with low or no system Boost version is incompatible with Conan's version of libiconv, a requirement of Conan's Boost package. The solution proposed here is to use the same Boost package as the linux-fresh container. This tells CMake to download boost_1_75_0.tar.xz from [yuzu-emu/ext-linux-bin](https://github.com/yuzu-emu/ext-linux-bin) at CMake's configuration step, much the same way Qt and FFmpeg are downloaded for Windows.

This also makes DownloadExternals.cmake cross-platform between Windows and Linux. Although the CMake code is not entirely specific to Linux, only Linux has Boost libraries available at ext-linux-bin, whereas there is no equivalent Boost package for Windows at ext-windows-bin. This also does not work for any of the other *nix's: Conan is there as a fallback, but those will need to have at least some updated libraries visible to CMake from elsewhere (basically, this PR changes nothing for the other *nix's.)

IIRC the linux-mingw bot will check DownloadExternals.cmake for WIN32 (it needs it for FFmpeg), but I would be more comfortable if someone using the MSVC toolchain would test this PR, as well.