### PR TITLE
program_metadata: Explicitly specify copy/move operators/functions

### DIFF
--- a/src/core/file_sys/program_metadata.h
+++ b/src/core/file_sys/program_metadata.h
@@ -44,6 +44,12 @@ public:
     ProgramMetadata();
     ~ProgramMetadata();
 
+    ProgramMetadata(const ProgramMetadata&) = default;
+    ProgramMetadata& operator=(const ProgramMetadata&) = default;
+
+    ProgramMetadata(ProgramMetadata&&) = default;
+    ProgramMetadata& operator=(ProgramMetadata&&) = default;
+
     /// Gets a default ProgramMetadata configuration, should only be used for homebrew formats where
     /// we do not have an NPDM file
     static ProgramMetadata GetDefault();


### PR DESCRIPTION
The generation of the copy assignment operators are deprecated on being generated when a user-provided destructor is present. We can explicitly specify that we desire this behavior to keep the class forward compatible with future standards.