### PR TITLE
acc/lbl: Remove unused variables

### DIFF
--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -702,16 +702,12 @@ void Module::Interface::IsUserRegistrationRequestPermitted(Kernel::HLERequestCon
 }
 
 void Module::Interface::InitializeApplicationInfo(Kernel::HLERequestContext& ctx) {
-    IPC::RequestParser rp{ctx};
-
     LOG_DEBUG(Service_ACC, "called");
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(InitializeApplicationInfoBase());
 }
 
 void Module::Interface::InitializeApplicationInfoRestricted(Kernel::HLERequestContext& ctx) {
-    IPC::RequestParser rp{ctx};
-
     LOG_WARNING(Service_ACC, "(Partial implementation) called");
 
     // TODO(ogniK): We require checking if the user actually owns the title and what not. As of

--- a/src/core/hle/service/lbl/lbl.cpp
+++ b/src/core/hle/service/lbl/lbl.cpp
@@ -79,7 +79,6 @@ private:
     }
 
     void GetCurrentBrightnessSetting(Kernel::HLERequestContext& ctx) {
-        IPC::RequestParser rp{ctx};
         auto brightness = current_brightness;
         if (!std::isfinite(brightness)) {
             LOG_ERROR(Service_LBL, "Brightness is infinite!");
@@ -272,7 +271,6 @@ private:
     }
 
     void GetCurrentBrightnessSettingForVrMode(Kernel::HLERequestContext& ctx) {
-        IPC::RequestParser rp{ctx};
         auto brightness = current_vr_brightness;
         if (!std::isfinite(brightness)) {
             LOG_ERROR(Service_LBL, "Brightness is infinite!");


### PR DESCRIPTION
These request parsers aren't used at all, so we can remove them.