### PR TITLE
program_metadata: Set a default resource size when a NPDM is not present

### DIFF
--- a/src/core/file_sys/program_metadata.cpp
+++ b/src/core/file_sys/program_metadata.cpp
@@ -58,7 +58,8 @@ Loader::ResultStatus ProgramMetadata::Load(VirtualFile file) {
     result.LoadManual(
         true /*is_64_bit*/, FileSys::ProgramAddressSpaceType::Is39Bit /*address_space*/,
         0x2c /*main_thread_prio*/, 0 /*main_thread_core*/, 0x00100000 /*main_thread_stack_size*/,
-        {}, 0xFFFFFFFFFFFFFFFF /*filesystem_permissions*/, {} /*capabilities*/);
+        0 /*title_id*/, 0xFFFFFFFFFFFFFFFF /*filesystem_permissions*/,
+        0x1FE00000 /*system_resource_size*/, {} /*capabilities*/);
 
     return result;
 }
@@ -66,7 +67,7 @@ Loader::ResultStatus ProgramMetadata::Load(VirtualFile file) {
 void ProgramMetadata::LoadManual(bool is_64_bit, ProgramAddressSpaceType address_space,
                                  s32 main_thread_prio, u32 main_thread_core,
                                  u32 main_thread_stack_size, u64 title_id,
-                                 u64 filesystem_permissions,
+                                 u64 filesystem_permissions, u32 system_resource_size,
                                  KernelCapabilityDescriptors capabilities) {
     npdm_header.has_64_bit_instructions.Assign(is_64_bit);
     npdm_header.address_space_type.Assign(address_space);
@@ -75,6 +76,7 @@ void ProgramMetadata::LoadManual(bool is_64_bit, ProgramAddressSpaceType address
     npdm_header.main_stack_size = main_thread_stack_size;
     aci_header.title_id = title_id;
     aci_file_access.permissions = filesystem_permissions;
+    npdm_header.system_resource_size = system_resource_size;
     aci_kernel_capabilities = std ::move(capabilities);
 }
 

--- a/src/core/file_sys/program_metadata.h
+++ b/src/core/file_sys/program_metadata.h
@@ -53,7 +53,8 @@ public:
     /// Load from parameters instead of NPDM file, used for KIP
     void LoadManual(bool is_64_bit, ProgramAddressSpaceType address_space, s32 main_thread_prio,
                     u32 main_thread_core, u32 main_thread_stack_size, u64 title_id,
-                    u64 filesystem_permissions, KernelCapabilityDescriptors capabilities);
+                    u64 filesystem_permissions, u32 system_resource_size,
+                    KernelCapabilityDescriptors capabilities);
 
     bool Is64BitProgram() const;
     ProgramAddressSpaceType GetAddressSpaceType() const;

--- a/src/core/loader/kip.cpp
+++ b/src/core/loader/kip.cpp
@@ -68,7 +68,8 @@ AppLoader::LoadResult AppLoader_KIP::Load(Kernel::Process& process,
     FileSys::ProgramMetadata metadata;
     metadata.LoadManual(kip->Is64Bit(), address_space, kip->GetMainThreadPriority(),
                         kip->GetMainThreadCpuCore(), kip->GetMainThreadStackSize(),
-                        kip->GetTitleID(), 0xFFFFFFFFFFFFFFFF, kip->GetKernelCapabilities());
+                        kip->GetTitleID(), 0xFFFFFFFFFFFFFFFF, 0x1FE00000,
+                        kip->GetKernelCapabilities());
 
     const VAddr base_address = process.PageTable().GetCodeRegionStart();
     Kernel::CodeSet codeset;


### PR DESCRIPTION
Sets a default size of 0x1FE00000 bytes (510 MiB) for the system_resource_size when a NPDM is not present.