### PR TITLE
aes_util: Make use of std::span

### DIFF
--- a/src/core/crypto/aes_util.cpp
+++ b/src/core/crypto/aes_util.cpp
@@ -119,9 +119,9 @@ void AESCipher<Key, KeySize>::XTSTranscode(const u8* src, std::size_t size, u8* 
 }
 
 template <typename Key, std::size_t KeySize>
-void AESCipher<Key, KeySize>::SetIVImpl(const u8* data, std::size_t size) {
-    ASSERT_MSG((mbedtls_cipher_set_iv(&ctx->encryption_context, data, size) ||
-                mbedtls_cipher_set_iv(&ctx->decryption_context, data, size)) == 0,
+void AESCipher<Key, KeySize>::SetIV(std::span<const u8> data) {
+    ASSERT_MSG((mbedtls_cipher_set_iv(&ctx->encryption_context, data.data(), data.size()) ||
+                mbedtls_cipher_set_iv(&ctx->decryption_context, data.data(), data.size())) == 0,
                "Failed to set IV on mbedtls ciphers.");
 }
 

--- a/src/core/crypto/aes_util.h
+++ b/src/core/crypto/aes_util.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <span>
 #include <type_traits>
 #include "common/common_types.h"
 #include "core/file_sys/vfs.h"
@@ -33,10 +34,7 @@ public:
     AESCipher(Key key, Mode mode);
     ~AESCipher();
 
-    template <typename ContiguousContainer>
-    void SetIV(const ContiguousContainer& container) {
-        SetIVImpl(std::data(container), std::size(container));
-    }
+    void SetIV(std::span<const u8> data);
 
     template <typename Source, typename Dest>
     void Transcode(const Source* src, std::size_t size, Dest* dest, Op op) const {
@@ -60,8 +58,6 @@ public:
                       std::size_t sector_size, Op op);
 
 private:
-    void SetIVImpl(const u8* data, std::size_t size);
-
     std::unique_ptr<CipherContext> ctx;
 };
 } // namespace Core::Crypto


### PR DESCRIPTION
Allows us to simplify the interface quite a bit as it will handle contiguous sequences for us.