### PR TITLE
emu_window: unsigned -> u32

### DIFF
--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -60,13 +60,13 @@ EmuWindow::~EmuWindow() {
  * @param framebuffer_y Framebuffer y-coordinate to check
  * @return True if the coordinates are within the touchpad, otherwise false
  */
-static bool IsWithinTouchscreen(const Layout::FramebufferLayout& layout, unsigned framebuffer_x,
-                                unsigned framebuffer_y) {
+static bool IsWithinTouchscreen(const Layout::FramebufferLayout& layout, u32 framebuffer_x,
+                                u32 framebuffer_y) {
     return (framebuffer_y >= layout.screen.top && framebuffer_y < layout.screen.bottom &&
             framebuffer_x >= layout.screen.left && framebuffer_x < layout.screen.right);
 }
 
-std::tuple<unsigned, unsigned> EmuWindow::ClipToTouchScreen(unsigned new_x, unsigned new_y) const {
+std::tuple<u32, u32> EmuWindow::ClipToTouchScreen(u32 new_x, u32 new_y) const {
     new_x = std::max(new_x, framebuffer_layout.screen.left);
     new_x = std::min(new_x, framebuffer_layout.screen.right - 1);
 
@@ -76,7 +76,7 @@ std::tuple<unsigned, unsigned> EmuWindow::ClipToTouchScreen(unsigned new_x, unsi
     return std::make_tuple(new_x, new_y);
 }
 
-void EmuWindow::TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y, std::size_t id) {
+void EmuWindow::TouchPressed(u32 framebuffer_x, u32 framebuffer_y, size_t id) {
     if (!IsWithinTouchscreen(framebuffer_layout, framebuffer_x, framebuffer_y)) {
         return;
     }
@@ -95,7 +95,7 @@ void EmuWindow::TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y, std
     touch_state->status[id] = std::make_tuple(x, y, true);
 }
 
-void EmuWindow::TouchReleased(std::size_t id) {
+void EmuWindow::TouchReleased(size_t id) {
     if (id >= touch_state->status.size()) {
         return;
     }
@@ -103,7 +103,7 @@ void EmuWindow::TouchReleased(std::size_t id) {
     touch_state->status[id] = std::make_tuple(0.0f, 0.0f, false);
 }
 
-void EmuWindow::TouchMoved(unsigned framebuffer_x, unsigned framebuffer_y, std::size_t id) {
+void EmuWindow::TouchMoved(u32 framebuffer_x, u32 framebuffer_y, size_t id) {
     if (id >= touch_state->status.size()) {
         return;
     }
@@ -116,7 +116,7 @@ void EmuWindow::TouchMoved(unsigned framebuffer_x, unsigned framebuffer_y, std::
     TouchPressed(framebuffer_x, framebuffer_y, id);
 }
 
-void EmuWindow::UpdateCurrentFramebufferLayout(unsigned width, unsigned height) {
+void EmuWindow::UpdateCurrentFramebufferLayout(u32 width, u32 height) {
     NotifyFramebufferLayoutChanged(Layout::DefaultFrameLayout(width, height));
 }
 

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -66,14 +66,14 @@ static bool IsWithinTouchscreen(const Layout::FramebufferLayout& layout, u32 fra
             framebuffer_x >= layout.screen.left && framebuffer_x < layout.screen.right);
 }
 
-std::tuple<u32, u32> EmuWindow::ClipToTouchScreen(u32 new_x, u32 new_y) const {
+std::pair<u32, u32> EmuWindow::ClipToTouchScreen(u32 new_x, u32 new_y) const {
     new_x = std::max(new_x, framebuffer_layout.screen.left);
     new_x = std::min(new_x, framebuffer_layout.screen.right - 1);
 
     new_y = std::max(new_y, framebuffer_layout.screen.top);
     new_y = std::min(new_y, framebuffer_layout.screen.bottom - 1);
 
-    return std::make_tuple(new_x, new_y);
+    return std::make_pair(new_x, new_y);
 }
 
 void EmuWindow::TouchPressed(u32 framebuffer_x, u32 framebuffer_y, size_t id) {
@@ -107,11 +107,14 @@ void EmuWindow::TouchMoved(u32 framebuffer_x, u32 framebuffer_y, size_t id) {
     if (id >= touch_state->status.size()) {
         return;
     }
-    if (!std::get<2>(touch_state->status[id]))
-        return;
 
-    if (!IsWithinTouchscreen(framebuffer_layout, framebuffer_x, framebuffer_y))
+    if (!std::get<2>(touch_state->status[id])) {
+        return;
+    }
+
+    if (!IsWithinTouchscreen(framebuffer_layout, framebuffer_x, framebuffer_y)) {
         std::tie(framebuffer_x, framebuffer_y) = ClipToTouchScreen(framebuffer_x, framebuffer_y);
+    }
 
     TouchPressed(framebuffer_x, framebuffer_y, id);
 }

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -228,7 +228,7 @@ private:
     /**
      * Clip the provided coordinates to be inside the touchscreen area.
      */
-    std::tuple<u32, u32> ClipToTouchScreen(u32 new_x, u32 new_y) const;
+    std::pair<u32, u32> ClipToTouchScreen(u32 new_x, u32 new_y) const;
 
     Layout::FramebufferLayout framebuffer_layout; ///< Current framebuffer layout
 

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -82,7 +82,7 @@ public:
         bool fullscreen = false;
         int res_width = 0;
         int res_height = 0;
-        std::pair<unsigned, unsigned> min_client_area_size;
+        std::pair<u32, u32> min_client_area_size;
     };
 
     /// Data describing host window system information
@@ -119,13 +119,13 @@ public:
      * @param framebuffer_y Framebuffer y-coordinate that was pressed
      * @param id Touch event ID
      */
-    void TouchPressed(unsigned framebuffer_x, unsigned framebuffer_y, std::size_t id);
+    void TouchPressed(u32 framebuffer_x, u32 framebuffer_y, size_t id);
 
     /**
      * Signal that a touch released event has occurred (e.g. mouse click released)
      * @param id Touch event ID
      */
-    void TouchReleased(std::size_t id);
+    void TouchReleased(size_t id);
 
     /**
      * Signal that a touch movement event has occurred (e.g. mouse was moved over the emu window)
@@ -133,7 +133,7 @@ public:
      * @param framebuffer_y Framebuffer y-coordinate
      * @param id Touch event ID
      */
-    void TouchMoved(unsigned framebuffer_x, unsigned framebuffer_y, std::size_t id);
+    void TouchMoved(u32 framebuffer_x, u32 framebuffer_y, size_t id);
 
     /**
      * Returns currently active configuration.
@@ -173,7 +173,7 @@ public:
      * Convenience method to update the current frame layout
      * Read from the current settings to determine which layout to use.
      */
-    void UpdateCurrentFramebufferLayout(unsigned width, unsigned height);
+    void UpdateCurrentFramebufferLayout(u32 width, u32 height);
 
 protected:
     explicit EmuWindow();
@@ -208,7 +208,7 @@ protected:
      * Update internal client area size with the given parameter.
      * @note EmuWindow implementations will usually use this in window resize event handlers.
      */
-    void NotifyClientAreaSizeChanged(const std::pair<unsigned, unsigned>& size) {
+    void NotifyClientAreaSizeChanged(std::pair<u32, u32> size) {
         client_area_width = size.first;
         client_area_height = size.second;
     }
@@ -221,14 +221,19 @@ private:
      * For the request to be honored, EmuWindow implementations will usually reimplement this
      * function.
      */
-    virtual void OnMinimalClientAreaChangeRequest(std::pair<unsigned, unsigned>) {
+    virtual void OnMinimalClientAreaChangeRequest(std::pair<u32, u32>) {
         // By default, ignore this request and do nothing.
     }
 
+    /**
+     * Clip the provided coordinates to be inside the touchscreen area.
+     */
+    std::tuple<u32, u32> ClipToTouchScreen(u32 new_x, u32 new_y) const;
+
     Layout::FramebufferLayout framebuffer_layout; ///< Current framebuffer layout
 
-    unsigned client_area_width;  ///< Current client width, should be set by window impl.
-    unsigned client_area_height; ///< Current client height, should be set by window impl.
+    u32 client_area_width;  ///< Current client width, should be set by window impl.
+    u32 client_area_height; ///< Current client height, should be set by window impl.
 
     WindowConfig config;        ///< Internal configuration (changes pending for being applied in
                                 /// ProcessConfigurationChanges)
@@ -236,11 +241,6 @@ private:
 
     class TouchState;
     std::shared_ptr<TouchState> touch_state;
-
-    /**
-     * Clip the provided coordinates to be inside the touchscreen area.
-     */
-    std::tuple<unsigned, unsigned> ClipToTouchScreen(unsigned new_x, unsigned new_y) const;
 };
 
 } // namespace Core::Frontend

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
@@ -238,6 +238,6 @@ void EmuWindow_SDL2::SetWindowIcon() {
     SDL_FreeSurface(window_icon);
 }
 
-void EmuWindow_SDL2::OnMinimalClientAreaChangeRequest(std::pair<unsigned, unsigned> minimal_size) {
+void EmuWindow_SDL2::OnMinimalClientAreaChangeRequest(std::pair<u32, u32> minimal_size) {
     SDL_SetWindowMinimumSize(render_window, minimal_size.first, minimal_size.second);
 }

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.h
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.h
@@ -71,7 +71,7 @@ protected:
     void Fullscreen();
 
     /// Called when a configuration change affects the minimal size of the window
-    void OnMinimalClientAreaChangeRequest(std::pair<unsigned, unsigned> minimal_size) override;
+    void OnMinimalClientAreaChangeRequest(std::pair<u32, u32> minimal_size) override;
 
     /// Is the window still open?
     bool is_open = true;


### PR DESCRIPTION
This is more concise and consistent with the rest of the codebase.

While we're at it, we can convert a function to return a std::pair instead of a std::tuple.