### PR TITLE
glue: Add ectx:aw service placeholder

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -377,6 +377,8 @@ add_library(core STATIC
     hle/service/glue/arp.h
     hle/service/glue/bgtc.cpp
     hle/service/glue/bgtc.h
+    hle/service/glue/ectx.cpp
+    hle/service/glue/ectx.h
     hle/service/glue/errors.h
     hle/service/glue/glue.cpp
     hle/service/glue/glue.h

--- a/src/core/hle/service/glue/ectx.cpp
+++ b/src/core/hle/service/glue/ectx.cpp
@@ -1,0 +1,22 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/service/glue/ectx.h"
+
+namespace Service::Glue {
+
+ECTX_AW::ECTX_AW(Core::System& system_) : ServiceFramework{system_, "ectx:aw"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "CreateContextRegistrar"},
+        {1, nullptr, "CommitContext"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+ECTX_AW::~ECTX_AW() = default;
+
+} // namespace Service::Glue

--- a/src/core/hle/service/glue/ectx.h
+++ b/src/core/hle/service/glue/ectx.h
@@ -1,0 +1,21 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Core {
+class System;
+}
+
+namespace Service::Glue {
+
+class ECTX_AW final : public ServiceFramework<ECTX_AW> {
+public:
+    explicit ECTX_AW(Core::System& system_);
+    ~ECTX_AW() override;
+};
+
+} // namespace Service::Glue

--- a/src/core/hle/service/glue/glue.cpp
+++ b/src/core/hle/service/glue/glue.cpp
@@ -6,6 +6,7 @@
 #include "core/core.h"
 #include "core/hle/service/glue/arp.h"
 #include "core/hle/service/glue/bgtc.h"
+#include "core/hle/service/glue/ectx.h"
 #include "core/hle/service/glue/glue.h"
 
 namespace Service::Glue {
@@ -20,6 +21,9 @@ void InstallInterfaces(Core::System& system) {
     // BackGround Task Controller
     std::make_shared<BGTC_T>(system)->InstallAsService(system.ServiceManager());
     std::make_shared<BGTC_SC>(system)->InstallAsService(system.ServiceManager());
+
+    // Error Context
+    std::make_shared<ECTX_AW>(system)->InstallAsService(system.ServiceManager());
 }
 
 } // namespace Service::Glue


### PR DESCRIPTION
Adds the ectx:aw service used in Pixel Game Maker Series Werewolf Princess Kaguya. Allows the game to be played.