### PR TITLE
input_common: Implement SDL motion

### DIFF
--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -153,6 +153,11 @@ struct InputSubsystem::Impl {
             // TODO return the correct motion device
             return {};
         }
+#ifdef HAVE_SDL2
+        if (params.Get("class", "") == "sdl") {
+            return sdl->GetMotionMappingForDevice(params);
+        }
+#endif
         return {};
     }
 

--- a/src/input_common/sdl/sdl.h
+++ b/src/input_common/sdl/sdl.h
@@ -37,6 +37,9 @@ public:
     virtual AnalogMapping GetAnalogMappingForDevice(const Common::ParamPackage&) {
         return {};
     }
+    virtual MotionMapping GetMotionMappingForDevice(const Common::ParamPackage&) {
+        return {};
+    }
 };
 
 class NullState : public State {

--- a/src/input_common/sdl/sdl_impl.h
+++ b/src/input_common/sdl/sdl_impl.h
@@ -57,6 +57,7 @@ public:
 
     ButtonMapping GetButtonMappingForDevice(const Common::ParamPackage& params) override;
     AnalogMapping GetAnalogMappingForDevice(const Common::ParamPackage& params) override;
+    MotionMapping GetMotionMappingForDevice(const Common::ParamPackage& params) override;
 
 private:
     void InitJoystick(int joystick_index);

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -153,6 +153,10 @@ QString ButtonToText(const Common::ParamPackage& param) {
             return QObject::tr("Button %1").arg(button_str);
         }
 
+        if (param.Has("motion")) {
+            return QObject::tr("SDL Motion");
+        }
+
         return {};
     }
 
@@ -1245,11 +1249,15 @@ void ConfigureInputPlayer::UpdateMappingWithDefaults() {
     const auto& device = input_devices[ui->comboDevices->currentIndex()];
     auto button_mapping = input_subsystem->GetButtonMappingForDevice(device);
     auto analog_mapping = input_subsystem->GetAnalogMappingForDevice(device);
+    auto motion_mapping = input_subsystem->GetMotionMappingForDevice(device);
     for (std::size_t i = 0; i < buttons_param.size(); ++i) {
         buttons_param[i] = button_mapping[static_cast<Settings::NativeButton::Values>(i)];
     }
     for (std::size_t i = 0; i < analogs_param.size(); ++i) {
         analogs_param[i] = analog_mapping[static_cast<Settings::NativeAnalog::Values>(i)];
+    }
+    for (std::size_t i = 0; i < motions_param.size(); ++i) {
+        motions_param[i] = motion_mapping[static_cast<Settings::NativeMotion::Values>(i)];
     }
 
     UpdateUI();


### PR DESCRIPTION
Adds the motion backend for SDL2 since it's now supported. Need testing to find supported controllers.

- [x] Adds auto mapping for motion. 
- [ ] Calibrate the sensors
- [ ] Fine tune the SDL motion
- [x] Find supported controllers, currently PS4, PS5, Pro controller, Joycons.
