### PR TITLE
service: Eliminate cases of member variable shadowing

### DIFF
--- a/src/core/hle/service/am/applets/error.cpp
+++ b/src/core/hle/service/am/applets/error.cpp
@@ -158,11 +158,11 @@ void Error::Execute() {
         break;
     case ErrorAppletMode::ShowSystemError:
     case ErrorAppletMode::ShowApplicationError: {
-        const auto system = mode == ErrorAppletMode::ShowSystemError;
+        const auto is_system = mode == ErrorAppletMode::ShowSystemError;
         const auto& main_text =
-            system ? args->system_error.main_text : args->application_error.main_text;
+            is_system ? args->system_error.main_text : args->application_error.main_text;
         const auto& detail_text =
-            system ? args->system_error.detail_text : args->application_error.detail_text;
+            is_system ? args->system_error.detail_text : args->application_error.detail_text;
 
         const auto main_text_string =
             Common::StringFromFixedZeroTerminatedBuffer(main_text.data(), main_text.size());

--- a/src/core/hle/service/am/applets/general_backend.cpp
+++ b/src/core/hle/service/am/applets/general_backend.cpp
@@ -96,7 +96,7 @@ void Auth::Execute() {
 
     switch (type) {
     case AuthAppletType::ShowParentalAuthentication: {
-        const auto callback = [this](bool successful) { AuthFinished(successful); };
+        const auto callback = [this](bool is_successful) { AuthFinished(is_successful); };
 
         if (arg0 == 1 && arg1 == 0 && arg2 == 1) {
             // ShowAuthenticatorForConfiguration

--- a/src/core/hle/service/bcat/backend/boxcat.cpp
+++ b/src/core/hle/service/bcat/backend/boxcat.cpp
@@ -415,9 +415,9 @@ std::optional<std::vector<u8>> Boxcat::GetLaunchParameter(TitleIDVersion title) 
     if (Settings::values.bcat_boxcat_local) {
         LOG_INFO(Service_BCAT, "Boxcat using local data by override, skipping download.");
     } else {
-        Boxcat::Client client{path, title.title_id, title.build_id};
+        Client launch_client{path, title.title_id, title.build_id};
 
-        const auto res = client.DownloadLaunchParam();
+        const auto res = launch_client.DownloadLaunchParam();
         if (res != DownloadResult::Success) {
             LOG_ERROR(Service_BCAT, "Boxcat synchronization failed with error '{}'!", res);
 

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -72,7 +72,7 @@ NVFlinger::NVFlinger(Core::System& system) : system(system) {
     // Schedule the screen composition events
     composition_event = Core::Timing::CreateEvent(
         "ScreenComposition", [this](std::uintptr_t, std::chrono::nanoseconds ns_late) {
-            const auto guard = Lock();
+            const auto lock_guard = Lock();
             Compose();
 
             const auto ticks = std::chrono::nanoseconds{GetNextTicks()};
@@ -112,7 +112,7 @@ void NVFlinger::SetNVDrvInstance(std::shared_ptr<Nvidia::Module> instance) {
 }
 
 std::optional<u64> NVFlinger::OpenDisplay(std::string_view name) {
-    const auto guard = Lock();
+    const auto lock_guard = Lock();
 
     LOG_DEBUG(Service, "Opening \"{}\" display", name);
 
@@ -131,7 +131,7 @@ std::optional<u64> NVFlinger::OpenDisplay(std::string_view name) {
 }
 
 std::optional<u64> NVFlinger::CreateLayer(u64 display_id) {
-    const auto guard = Lock();
+    const auto lock_guard = Lock();
     auto* const display = FindDisplay(display_id);
 
     if (display == nullptr) {
@@ -147,7 +147,7 @@ std::optional<u64> NVFlinger::CreateLayer(u64 display_id) {
 }
 
 void NVFlinger::CloseLayer(u64 layer_id) {
-    const auto guard = Lock();
+    const auto lock_guard = Lock();
 
     for (auto& display : displays) {
         display.CloseLayer(layer_id);
@@ -155,7 +155,7 @@ void NVFlinger::CloseLayer(u64 layer_id) {
 }
 
 std::optional<u32> NVFlinger::FindBufferQueueId(u64 display_id, u64 layer_id) const {
-    const auto guard = Lock();
+    const auto lock_guard = Lock();
     const auto* const layer = FindLayer(display_id, layer_id);
 
     if (layer == nullptr) {
@@ -166,7 +166,7 @@ std::optional<u32> NVFlinger::FindBufferQueueId(u64 display_id, u64 layer_id) co
 }
 
 std::shared_ptr<Kernel::KReadableEvent> NVFlinger::FindVsyncEvent(u64 display_id) const {
-    const auto guard = Lock();
+    const auto lock_guard = Lock();
     auto* const display = FindDisplay(display_id);
 
     if (display == nullptr) {
@@ -177,7 +177,7 @@ std::shared_ptr<Kernel::KReadableEvent> NVFlinger::FindVsyncEvent(u64 display_id
 }
 
 BufferQueue* NVFlinger::FindBufferQueue(u32 id) {
-    const auto guard = Lock();
+    const auto lock_guard = Lock();
     const auto itr = std::find_if(buffer_queues.begin(), buffer_queues.end(),
                                   [id](const auto& queue) { return queue->GetId() == id; });
 

--- a/src/core/hle/service/time/standard_user_system_clock_core.cpp
+++ b/src/core/hle/service/time/standard_user_system_clock_core.cpp
@@ -45,12 +45,12 @@ ResultCode StandardUserSystemClockCore::GetClockContext(Core::System& system,
     return local_system_clock_core.GetClockContext(system, context);
 }
 
-ResultCode StandardUserSystemClockCore::Flush(const SystemClockContext& context) {
+ResultCode StandardUserSystemClockCore::Flush(const SystemClockContext&) {
     UNREACHABLE();
     return ERROR_NOT_IMPLEMENTED;
 }
 
-ResultCode StandardUserSystemClockCore::SetClockContext(const SystemClockContext& context) {
+ResultCode StandardUserSystemClockCore::SetClockContext(const SystemClockContext&) {
     UNREACHABLE();
     return ERROR_NOT_IMPLEMENTED;
 }

--- a/src/core/hle/service/time/standard_user_system_clock_core.h
+++ b/src/core/hle/service/time/standard_user_system_clock_core.h
@@ -39,7 +39,7 @@ public:
     }
 
 protected:
-    ResultCode Flush(const SystemClockContext& context) override;
+    ResultCode Flush(const SystemClockContext&) override;
 
     ResultCode SetClockContext(const SystemClockContext&) override;
 

--- a/src/core/hle/service/time/system_clock_core.cpp
+++ b/src/core/hle/service/time/system_clock_core.cpp
@@ -45,18 +45,18 @@ ResultCode SystemClockCore::SetCurrentTime(Core::System& system, s64 posix_time)
     return Flush(clock_context);
 }
 
-ResultCode SystemClockCore::Flush(const SystemClockContext& context) {
+ResultCode SystemClockCore::Flush(const SystemClockContext& clock_context) {
     if (!system_clock_context_update_callback) {
         return RESULT_SUCCESS;
     }
-    return system_clock_context_update_callback->Update(context);
+    return system_clock_context_update_callback->Update(clock_context);
 }
 
-ResultCode SystemClockCore::SetSystemClockContext(const SystemClockContext& context) {
-    if (const ResultCode result{SetClockContext(context)}; result != RESULT_SUCCESS) {
+ResultCode SystemClockCore::SetSystemClockContext(const SystemClockContext& clock_context) {
+    if (const ResultCode result{SetClockContext(clock_context)}; result != RESULT_SUCCESS) {
         return result;
     }
-    return Flush(context);
+    return Flush(clock_context);
 }
 
 bool SystemClockCore::IsClockSetup(Core::System& system) const {

--- a/src/core/hle/service/time/system_clock_core.h
+++ b/src/core/hle/service/time/system_clock_core.h
@@ -43,7 +43,7 @@ public:
         return RESULT_SUCCESS;
     }
 
-    virtual ResultCode Flush(const SystemClockContext& context);
+    virtual ResultCode Flush(const SystemClockContext& clock_context);
 
     void SetUpdateCallbackInstance(std::shared_ptr<SystemClockContextUpdateCallback> callback) {
         system_clock_context_update_callback = std::move(callback);

--- a/src/core/hle/service/time/time_manager.cpp
+++ b/src/core/hle/service/time/time_manager.cpp
@@ -129,7 +129,7 @@ struct TimeManager::Impl final {
         return 0;
     }
 
-    void SetupStandardSteadyClock(Core::System& system, Common::UUID clock_source_id,
+    void SetupStandardSteadyClock(Core::System& system_, Common::UUID clock_source_id,
                                   Clock::TimeSpanType setup_value,
                                   Clock::TimeSpanType internal_offset, bool is_rtc_reset_detected) {
         standard_steady_clock_core.SetClockSourceId(clock_source_id);
@@ -137,21 +137,21 @@ struct TimeManager::Impl final {
         standard_steady_clock_core.SetInternalOffset(internal_offset);
         standard_steady_clock_core.MarkAsInitialized();
 
-        const auto current_time_point{standard_steady_clock_core.GetCurrentRawTimePoint(system)};
-        shared_memory.SetupStandardSteadyClock(system, clock_source_id, current_time_point);
+        const auto current_time_point{standard_steady_clock_core.GetCurrentRawTimePoint(system_)};
+        shared_memory.SetupStandardSteadyClock(clock_source_id, current_time_point);
     }
 
-    void SetupStandardLocalSystemClock(Core::System& system,
+    void SetupStandardLocalSystemClock(Core::System& system_,
                                        Clock::SystemClockContext clock_context, s64 posix_time) {
         standard_local_system_clock_core.SetUpdateCallbackInstance(
             local_system_clock_context_writer);
 
         const auto current_time_point{
-            standard_local_system_clock_core.GetSteadyClockCore().GetCurrentTimePoint(system)};
+            standard_local_system_clock_core.GetSteadyClockCore().GetCurrentTimePoint(system_)};
         if (current_time_point.clock_source_id == clock_context.steady_time_point.clock_source_id) {
             standard_local_system_clock_core.SetSystemClockContext(clock_context);
         } else {
-            if (standard_local_system_clock_core.SetCurrentTime(system, posix_time) !=
+            if (standard_local_system_clock_core.SetCurrentTime(system_, posix_time) !=
                 RESULT_SUCCESS) {
                 UNREACHABLE();
                 return;
@@ -177,10 +177,10 @@ struct TimeManager::Impl final {
         standard_network_system_clock_core.MarkAsInitialized();
     }
 
-    void SetupStandardUserSystemClock(Core::System& system, bool is_automatic_correction_enabled,
+    void SetupStandardUserSystemClock(Core::System& system_, bool is_automatic_correction_enabled,
                                       Clock::SteadyClockTimePoint steady_clock_time_point) {
         if (standard_user_system_clock_core.SetAutomaticCorrectionEnabled(
-                system, is_automatic_correction_enabled) != RESULT_SUCCESS) {
+                system_, is_automatic_correction_enabled) != RESULT_SUCCESS) {
             UNREACHABLE();
             return;
         }
@@ -196,10 +196,10 @@ struct TimeManager::Impl final {
         ephemeral_network_system_clock_core.MarkAsInitialized();
     }
 
-    void UpdateLocalSystemClockTime(Core::System& system, s64 posix_time) {
-        const auto timespan{Service::Time::Clock::TimeSpanType::FromSeconds(posix_time)};
+    void UpdateLocalSystemClockTime(Core::System& system_, s64 posix_time) {
+        const auto timespan{Clock::TimeSpanType::FromSeconds(posix_time)};
         if (GetStandardLocalSystemClockCore()
-                .SetCurrentTime(system, timespan.ToSeconds())
+                .SetCurrentTime(system_, timespan.ToSeconds())
                 .IsError()) {
             UNREACHABLE();
             return;

--- a/src/core/hle/service/time/time_sharedmemory.cpp
+++ b/src/core/hle/service/time/time_sharedmemory.cpp
@@ -26,8 +26,7 @@ std::shared_ptr<Kernel::KSharedMemory> SharedMemory::GetSharedMemoryHolder() con
     return shared_memory_holder;
 }
 
-void SharedMemory::SetupStandardSteadyClock(Core::System& system,
-                                            const Common::UUID& clock_source_id,
+void SharedMemory::SetupStandardSteadyClock(const Common::UUID& clock_source_id,
                                             Clock::TimeSpanType current_time_point) {
     const Clock::TimeSpanType ticks_time_span{Clock::TimeSpanType::FromTicks(
         system.CoreTiming().GetClockTicks(), Core::Hardware::CNTFREQ)};

--- a/src/core/hle/service/time/time_sharedmemory.h
+++ b/src/core/hle/service/time/time_sharedmemory.h
@@ -56,8 +56,8 @@ public:
     };
     static_assert(sizeof(Format) == 0xd8, "Format is an invalid size");
 
-    void SetupStandardSteadyClock(Core::System& system, const Common::UUID& clock_source_id,
-                                  Clock::TimeSpanType currentTimePoint);
+    void SetupStandardSteadyClock(const Common::UUID& clock_source_id,
+                                  Clock::TimeSpanType current_time_point);
     void UpdateLocalSystemClockContext(const Clock::SystemClockContext& context);
     void UpdateNetworkSystemClockContext(const Clock::SystemClockContext& context);
     void SetAutomaticCorrectionEnabled(bool is_enabled);

--- a/src/core/hle/service/vi/display/vi_display.cpp
+++ b/src/core/hle/service/vi/display/vi_display.cpp
@@ -41,24 +41,22 @@ void Display::SignalVSyncEvent() {
     vsync_event->GetWritableEvent()->Signal();
 }
 
-void Display::CreateLayer(u64 id, NVFlinger::BufferQueue& buffer_queue) {
+void Display::CreateLayer(u64 layer_id, NVFlinger::BufferQueue& buffer_queue) {
     // TODO(Subv): Support more than 1 layer.
     ASSERT_MSG(layers.empty(), "Only one layer is supported per display at the moment");
 
-    layers.emplace_back(std::make_shared<Layer>(id, buffer_queue));
+    layers.emplace_back(std::make_shared<Layer>(layer_id, buffer_queue));
 }
 
-void Display::CloseLayer(u64 id) {
-    layers.erase(
-        std::remove_if(layers.begin(), layers.end(),
-                       [id](const std::shared_ptr<Layer>& layer) { return layer->GetID() == id; }),
-        layers.end());
+void Display::CloseLayer(u64 layer_id) {
+    std::erase_if(layers, [layer_id](const auto& layer) { return layer->GetID() == layer_id; });
 }
 
-Layer* Display::FindLayer(u64 id) {
+Layer* Display::FindLayer(u64 layer_id) {
     const auto itr =
-        std::find_if(layers.begin(), layers.end(),
-                     [id](const std::shared_ptr<Layer>& layer) { return layer->GetID() == id; });
+        std::find_if(layers.begin(), layers.end(), [layer_id](const std::shared_ptr<Layer>& layer) {
+            return layer->GetID() == layer_id;
+        });
 
     if (itr == layers.end()) {
         return nullptr;
@@ -67,10 +65,11 @@ Layer* Display::FindLayer(u64 id) {
     return itr->get();
 }
 
-const Layer* Display::FindLayer(u64 id) const {
+const Layer* Display::FindLayer(u64 layer_id) const {
     const auto itr =
-        std::find_if(layers.begin(), layers.end(),
-                     [id](const std::shared_ptr<Layer>& layer) { return layer->GetID() == id; });
+        std::find_if(layers.begin(), layers.end(), [layer_id](const std::shared_ptr<Layer>& layer) {
+            return layer->GetID() == layer_id;
+        });
 
     if (itr == layers.end()) {
         return nullptr;

--- a/src/core/hle/service/vi/display/vi_display.h
+++ b/src/core/hle/service/vi/display/vi_display.h
@@ -68,34 +68,34 @@ public:
 
     /// Creates and adds a layer to this display with the given ID.
     ///
-    /// @param id           The ID to assign to the created layer.
+    /// @param layer_id     The ID to assign to the created layer.
     /// @param buffer_queue The buffer queue for the layer instance to use.
     ///
-    void CreateLayer(u64 id, NVFlinger::BufferQueue& buffer_queue);
+    void CreateLayer(u64 layer_id, NVFlinger::BufferQueue& buffer_queue);
 
     /// Closes and removes a layer from this display with the given ID.
     ///
-    /// @param id           The ID assigned to the layer to close.
+    /// @param layer_id The ID assigned to the layer to close.
     ///
-    void CloseLayer(u64 id);
+    void CloseLayer(u64 layer_id);
 
     /// Attempts to find a layer with the given ID.
     ///
-    /// @param id The layer ID.
+    /// @param layer_id The layer ID.
     ///
     /// @returns If found, the Layer instance with the given ID.
     ///          If not found, then nullptr is returned.
     ///
-    Layer* FindLayer(u64 id);
+    Layer* FindLayer(u64 layer_id);
 
     /// Attempts to find a layer with the given ID.
     ///
-    /// @param id The layer ID.
+    /// @param layer_id The layer ID.
     ///
     /// @returns If found, the Layer instance with the given ID.
     ///          If not found, then nullptr is returned.
     ///
-    const Layer* FindLayer(u64 id) const;
+    const Layer* FindLayer(u64 layer_id) const;
 
 private:
     u64 id;


### PR DESCRIPTION
Resolves a few localized instances of member variable shadowing. Brings us a little closer to turning shadowing warnings into errors.