### PR TITLE
service: filesystem: Return proper error codes for CreateFile

### DIFF
--- a/src/core/file_sys/errors.h
+++ b/src/core/file_sys/errors.h
@@ -9,6 +9,7 @@
 namespace FileSys {
 
 constexpr ResultCode ERROR_PATH_NOT_FOUND{ErrorModule::FS, 1};
+constexpr ResultCode ERROR_PATH_ALREADY_EXISTS{ErrorModule::FS, 2};
 constexpr ResultCode ERROR_ENTITY_NOT_FOUND{ErrorModule::FS, 1002};
 constexpr ResultCode ERROR_SD_CARD_NOT_FOUND{ErrorModule::FS, 2001};
 constexpr ResultCode ERROR_OUT_OF_BOUNDS{ErrorModule::FS, 3005};

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -55,10 +55,15 @@ std::string VfsDirectoryServiceWrapper::GetName() const {
 ResultCode VfsDirectoryServiceWrapper::CreateFile(const std::string& path_, u64 size) const {
     std::string path(Common::FS::SanitizePath(path_));
     auto dir = GetDirectoryRelativeWrapped(backing, Common::FS::GetParentPath(path));
-    // dir can be nullptr if path contains subdirectories, create those prior to creating the file.
     if (dir == nullptr) {
-        dir = backing->CreateSubdirectory(Common::FS::GetParentPath(path));
+        return FileSys::ERROR_PATH_NOT_FOUND;
     }
+
+    const auto entry_type = GetEntryType(path);
+    if (entry_type.Code() == RESULT_SUCCESS) {
+        return FileSys::ERROR_PATH_ALREADY_EXISTS;
+    }
+
     auto file = dir->CreateFile(Common::FS::GetFilename(path));
     if (file == nullptr) {
         // TODO(DarkLordZach): Find a better error code for this


### PR DESCRIPTION
This improves the accuracy of CreateFile by returning the correct error codes on certain conditions (parent directory does not exist, path already exists).

This fixes saving and the loading of existing saves in New Pokemon Snap