### PR TITLE
input_common: Release mouse buttons on out of focus

### DIFF
--- a/src/input_common/mouse/mouse_input.cpp
+++ b/src/input_common/mouse/mouse_input.cpp
@@ -143,6 +143,15 @@ void Mouse::ReleaseButton(MouseButton button_) {
     mouse_info[button_index].data.axis = {0, 0};
 }
 
+void Mouse::ReleaseAllButtons() {
+    buttons = 0;
+    for (auto& info : mouse_info) {
+        info.tilt_speed = 0;
+        info.data.pressed = false;
+        info.data.axis = {0, 0};
+    }
+}
+
 void Mouse::BeginConfiguration() {
     buttons = 0;
     last_button = MouseButton::Undefined;

--- a/src/input_common/mouse/mouse_input.h
+++ b/src/input_common/mouse/mouse_input.h
@@ -65,9 +65,15 @@ public:
     void MouseMove(int x, int y, int center_x, int center_y);
 
     /**
-     * Signals that a motion sensor tilt has ended.
+     * Signals that a button is released.
+     * @param button_ the button pressed
      */
     void ReleaseButton(MouseButton button_);
+
+    /**
+     * Signals that all buttons are released
+     */
+    void ReleaseAllButtons();
 
     [[nodiscard]] bool ToggleButton(std::size_t button_);
     [[nodiscard]] bool UnlockButton(std::size_t button_);

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -539,6 +539,8 @@ bool GRenderWindow::event(QEvent* event) {
 void GRenderWindow::focusOutEvent(QFocusEvent* event) {
     QWidget::focusOutEvent(event);
     input_subsystem->GetKeyboard()->ReleaseAllKeys();
+    input_subsystem->GetMouse()->ReleaseAllButtons();
+    this->TouchReleased(0);
 }
 
 void GRenderWindow::resizeEvent(QResizeEvent* event) {


### PR DESCRIPTION
When the OSK opens mouse input gets pressed permanently until next event. This will release any mouse button if the game loses focus.