### PR TITLE
hid: Fix touch not initializing properly if disabled

### DIFF
--- a/src/core/hle/service/hid/controllers/gesture.cpp
+++ b/src/core/hle/service/hid/controllers/gesture.cpp
@@ -33,7 +33,7 @@ void Controller_Gesture::OnUpdate(const Core::Timing::CoreTiming& core_timing, u
     shared_memory.header.timestamp = core_timing.GetCPUTicks();
     shared_memory.header.total_entry_count = 17;
 
-    if (!IsControllerActivated() || !Settings::values.touchscreen.enabled) {
+    if (!IsControllerActivated()) {
         shared_memory.header.entry_count = 0;
         shared_memory.header.last_entry_index = 0;
         return;
@@ -129,6 +129,10 @@ void Controller_Gesture::OnLoadInputDevices() {
 }
 
 std::optional<std::size_t> Controller_Gesture::GetUnusedFingerID() const {
+    // Dont assign any touch input to a point if disabled
+    if (!Settings::values.touchscreen.enabled) {
+        return std::nullopt;
+    }
     std::size_t first_free_id = 0;
     while (first_free_id < MAX_POINTS) {
         if (!fingers[first_free_id].pressed) {

--- a/src/core/hle/service/hid/controllers/touchscreen.cpp
+++ b/src/core/hle/service/hid/controllers/touchscreen.cpp
@@ -33,7 +33,7 @@ void Controller_Touchscreen::OnUpdate(const Core::Timing::CoreTiming& core_timin
     shared_memory.header.timestamp = core_timing.GetCPUTicks();
     shared_memory.header.total_entry_count = 17;
 
-    if (!IsControllerActivated() || !Settings::values.touchscreen.enabled) {
+    if (!IsControllerActivated()) {
         shared_memory.header.entry_count = 0;
         shared_memory.header.last_entry_index = 0;
         return;
@@ -105,6 +105,10 @@ void Controller_Touchscreen::OnLoadInputDevices() {
 }
 
 std::optional<std::size_t> Controller_Touchscreen::GetUnusedFingerID() const {
+    // Dont assign any touch input to a finger if disabled
+    if (!Settings::values.touchscreen.enabled) {
+        return std::nullopt;
+    }
     std::size_t first_free_id = 0;
     while (first_free_id < MAX_FINGERS) {
         if (!fingers[first_free_id].pressed) {


### PR DESCRIPTION
A regression was introduced in #6264. Removes previous changes and uses another solution that allows touch to be set correctly while ignoring all input devices if disabled.