### PR TITLE
core: Resolve misc straggler cases of variable shadowing

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_cp15.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_cp15.cpp
@@ -94,12 +94,11 @@ CallbackOrAccessOneWord DynarmicCP15::CompileGetOneWord(bool two, unsigned opc1,
 CallbackOrAccessTwoWords DynarmicCP15::CompileGetTwoWords(bool two, unsigned opc, CoprocReg CRm) {
     if (!two && opc == 0 && CRm == CoprocReg::C14) {
         // CNTPCT
-        const auto callback = static_cast<u64 (*)(Dynarmic::A32::Jit*, void*, u32, u32)>(
-            [](Dynarmic::A32::Jit*, void* arg, u32, u32) -> u64 {
-                ARM_Dynarmic_32& parent = *(ARM_Dynarmic_32*)arg;
-                return parent.system.CoreTiming().GetClockTicks();
-            });
-        return Dynarmic::A32::Coprocessor::Callback{callback, (void*)&parent};
+        const auto callback = [](Dynarmic::A32::Jit*, void* arg, u32, u32) -> u64 {
+            const auto& parent_arg = *static_cast<ARM_Dynarmic_32*>(arg);
+            return parent_arg.system.CoreTiming().GetClockTicks();
+        };
+        return Callback{callback, &parent};
     }
 
     LOG_CRITICAL(Core_ARM, "CP15: mrrc{} p15, {}, <Rt>, <Rt2>, {}", two ? "2" : "", opc, CRm);

--- a/src/core/core_timing.cpp
+++ b/src/core/core_timing.cpp
@@ -133,8 +133,8 @@ void CoreTiming::UnscheduleEvent(const std::shared_ptr<EventType>& event_type,
     }
 }
 
-void CoreTiming::AddTicks(u64 ticks) {
-    this->ticks += ticks;
+void CoreTiming::AddTicks(u64 ticks_to_add) {
+    ticks += ticks_to_add;
     downcount -= static_cast<s64>(ticks);
 }
 

--- a/src/core/core_timing.h
+++ b/src/core/core_timing.h
@@ -102,7 +102,7 @@ public:
     /// We only permit one event of each type in the queue at a time.
     void RemoveEvent(const std::shared_ptr<EventType>& event_type);
 
-    void AddTicks(u64 ticks);
+    void AddTicks(u64 ticks_to_add);
 
     void ResetTicks();
 

--- a/src/core/cpu_manager.h
+++ b/src/core/cpu_manager.h
@@ -35,13 +35,13 @@ public:
     CpuManager& operator=(CpuManager&&) = delete;
 
     /// Sets if emulation is multicore or single core, must be set before Initialize
-    void SetMulticore(bool is_multicore) {
-        this->is_multicore = is_multicore;
+    void SetMulticore(bool is_multi) {
+        is_multicore = is_multi;
     }
 
     /// Sets if emulation is using an asynchronous GPU.
-    void SetAsyncGpu(bool is_async_gpu) {
-        this->is_async_gpu = is_async_gpu;
+    void SetAsyncGpu(bool is_async) {
+        is_async_gpu = is_async;
     }
 
     void Initialize();

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -79,8 +79,8 @@ AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(
     : AppLoader(directory->GetFile("main")), dir(std::move(directory)),
       override_update(override_update) {}
 
-FileType AppLoader_DeconstructedRomDirectory::IdentifyType(const FileSys::VirtualFile& file) {
-    if (FileSys::IsDirectoryExeFS(file->GetContainingDirectory())) {
+FileType AppLoader_DeconstructedRomDirectory::IdentifyType(const FileSys::VirtualFile& dir_file) {
+    if (FileSys::IsDirectoryExeFS(dir_file->GetContainingDirectory())) {
         return FileType::DeconstructedRomDirectory;
     }
 

--- a/src/core/loader/deconstructed_rom_directory.h
+++ b/src/core/loader/deconstructed_rom_directory.h
@@ -31,11 +31,14 @@ public:
                                                  bool override_update = false);
 
     /**
-     * Returns the type of the file
-     * @param file open file
-     * @return FileType found, or FileType::Error if this loader doesn't know it
+     * Identifies whether or not the given file is a deconstructed ROM directory.
+     *
+     * @param dir_file The file to verify.
+     *
+     * @return FileType::DeconstructedRomDirectory, or FileType::Error
+     *         if the file is not a deconstructed ROM directory.
      */
-    static FileType IdentifyType(const FileSys::VirtualFile& file);
+    static FileType IdentifyType(const FileSys::VirtualFile& dir_file);
 
     FileType GetFileType() const override {
         return IdentifyType(file);

--- a/src/core/memory/cheat_engine.cpp
+++ b/src/core/memory/cheat_engine.cpp
@@ -222,8 +222,8 @@ void CheatEngine::SetMainMemoryParameters(VAddr main_region_begin, u64 main_regi
     };
 }
 
-void CheatEngine::Reload(std::vector<CheatEntry> cheats) {
-    this->cheats = std::move(cheats);
+void CheatEngine::Reload(std::vector<CheatEntry> reload_cheats) {
+    cheats = std::move(reload_cheats);
     is_pending_reload.exchange(true);
 }
 

--- a/src/core/memory/cheat_engine.h
+++ b/src/core/memory/cheat_engine.h
@@ -68,7 +68,7 @@ public:
     void Initialize();
     void SetMainMemoryParameters(VAddr main_region_begin, u64 main_region_size);
 
-    void Reload(std::vector<CheatEntry> cheats);
+    void Reload(std::vector<CheatEntry> reload_cheats);
 
 private:
     void FrameCallback(std::uintptr_t user_data, std::chrono::nanoseconds ns_late);

--- a/src/core/tools/freezer.cpp
+++ b/src/core/tools/freezer.cpp
@@ -67,8 +67,8 @@ Freezer::~Freezer() {
     core_timing.UnscheduleEvent(event, 0);
 }
 
-void Freezer::SetActive(bool active) {
-    if (!this->active.exchange(active)) {
+void Freezer::SetActive(bool is_active) {
+    if (!active.exchange(is_active)) {
         FillEntryReads();
         core_timing.ScheduleEvent(memory_freezer_ns, event);
         LOG_DEBUG(Common_Memory, "Memory freezer activated!");

--- a/src/core/tools/freezer.h
+++ b/src/core/tools/freezer.h
@@ -43,7 +43,7 @@ public:
     ~Freezer();
 
     // Enables or disables the entire memory freezer.
-    void SetActive(bool active);
+    void SetActive(bool is_active);
 
     // Returns whether or not the freezer is active.
     bool IsActive() const;


### PR DESCRIPTION
Resolves shadowing warnings that aren't in a particularly large subsection of core. Brings us closer to turning -Wshadow into an error.

All that remains now is for cases in the kernel (left untouched for now since a big change by bunnei is pending), and a few left over in the service code (will be tackled next).