### PR TITLE
nvdrv: /dev/nvhost-prof-gpu for production

### DIFF
--- a/src/core/hle/service/nvdrv/interface.cpp
+++ b/src/core/hle/service/nvdrv/interface.cpp
@@ -40,7 +40,7 @@ void NVDRV::Open(Kernel::HLERequestContext& ctx) {
         rb.Push<DeviceFD>(0);
         rb.PushEnum(NvResult::NotSupported);
 
-        LOG_WARNING(Service_NVDRV, "/dev/nvhost-prof-gpu cannot be openned on production");
+        LOG_WARNING(Service_NVDRV, "/dev/nvhost-prof-gpu cannot be opened in production");
         return;
     }
 


### PR DESCRIPTION
While we're at it, we can fix the is_initialized error code.
This fixes the crashes on Shante