### PR TITLE
service: Resolve cases of member field shadowing

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -198,13 +198,13 @@ void ARM_Dynarmic_32::Step() {
     jit->Step();
 }
 
-ARM_Dynarmic_32::ARM_Dynarmic_32(System& system, CPUInterrupts& interrupt_handlers,
-                                 bool uses_wall_clock, ExclusiveMonitor& exclusive_monitor,
-                                 std::size_t core_index)
-    : ARM_Interface{system, interrupt_handlers, uses_wall_clock},
+ARM_Dynarmic_32::ARM_Dynarmic_32(System& system_, CPUInterrupts& interrupt_handlers_,
+                                 bool uses_wall_clock_, ExclusiveMonitor& exclusive_monitor_,
+                                 std::size_t core_index_)
+    : ARM_Interface{system_, interrupt_handlers_, uses_wall_clock_},
       cb(std::make_unique<DynarmicCallbacks32>(*this)),
-      cp15(std::make_shared<DynarmicCP15>(*this)), core_index{core_index},
-      exclusive_monitor{dynamic_cast<DynarmicExclusiveMonitor&>(exclusive_monitor)},
+      cp15(std::make_shared<DynarmicCP15>(*this)), core_index{core_index_},
+      exclusive_monitor{dynamic_cast<DynarmicExclusiveMonitor&>(exclusive_monitor_)},
       jit(MakeJit(nullptr)) {}
 
 ARM_Dynarmic_32::~ARM_Dynarmic_32() = default;

--- a/src/core/arm/dynarmic/arm_dynarmic_32.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.h
@@ -29,8 +29,8 @@ class System;
 
 class ARM_Dynarmic_32 final : public ARM_Interface {
 public:
-    ARM_Dynarmic_32(System& system, CPUInterrupts& interrupt_handlers, bool uses_wall_clock,
-                    ExclusiveMonitor& exclusive_monitor, std::size_t core_index);
+    ARM_Dynarmic_32(System& system_, CPUInterrupts& interrupt_handlers_, bool uses_wall_clock_,
+                    ExclusiveMonitor& exclusive_monitor_, std::size_t core_index_);
     ~ARM_Dynarmic_32() override;
 
     void SetPC(u64 pc) override;

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -238,12 +238,12 @@ void ARM_Dynarmic_64::Step() {
     cb->InterpreterFallback(jit->GetPC(), 1);
 }
 
-ARM_Dynarmic_64::ARM_Dynarmic_64(System& system, CPUInterrupts& interrupt_handlers,
-                                 bool uses_wall_clock, ExclusiveMonitor& exclusive_monitor,
-                                 std::size_t core_index)
-    : ARM_Interface{system, interrupt_handlers, uses_wall_clock},
-      cb(std::make_unique<DynarmicCallbacks64>(*this)), core_index{core_index},
-      exclusive_monitor{dynamic_cast<DynarmicExclusiveMonitor&>(exclusive_monitor)},
+ARM_Dynarmic_64::ARM_Dynarmic_64(System& system_, CPUInterrupts& interrupt_handlers_,
+                                 bool uses_wall_clock_, ExclusiveMonitor& exclusive_monitor_,
+                                 std::size_t core_index_)
+    : ARM_Interface{system_, interrupt_handlers_, uses_wall_clock_},
+      cb(std::make_unique<DynarmicCallbacks64>(*this)), core_index{core_index_},
+      exclusive_monitor{dynamic_cast<DynarmicExclusiveMonitor&>(exclusive_monitor_)},
       jit(MakeJit(nullptr, 48)) {}
 
 ARM_Dynarmic_64::~ARM_Dynarmic_64() = default;

--- a/src/core/arm/dynarmic/arm_dynarmic_64.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.h
@@ -26,8 +26,8 @@ class System;
 
 class ARM_Dynarmic_64 final : public ARM_Interface {
 public:
-    ARM_Dynarmic_64(System& system, CPUInterrupts& interrupt_handlers, bool uses_wall_clock,
-                    ExclusiveMonitor& exclusive_monitor, std::size_t core_index);
+    ARM_Dynarmic_64(System& system_, CPUInterrupts& interrupt_handlers_, bool uses_wall_clock_,
+                    ExclusiveMonitor& exclusive_monitor_, std::size_t core_index_);
     ~ARM_Dynarmic_64() override;
 
     void SetPC(u64 pc) override;

--- a/src/core/hle/service/acc/acc_aa.cpp
+++ b/src/core/hle/service/acc/acc_aa.cpp
@@ -6,9 +6,10 @@
 
 namespace Service::Account {
 
-ACC_AA::ACC_AA(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> profile_manager,
-               Core::System& system)
-    : Module::Interface(std::move(module), std::move(profile_manager), system, "acc:aa") {
+ACC_AA::ACC_AA(std::shared_ptr<Module> module_, std::shared_ptr<ProfileManager> profile_manager_,
+               Core::System& system_)
+    : Interface(std::move(module_), std::move(profile_manager_), system_, "acc:aa") {
+    // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "EnsureCacheAsync"},
         {1, nullptr, "LoadCache"},
@@ -16,6 +17,7 @@ ACC_AA::ACC_AA(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> p
         {50, nullptr, "RegisterNotificationTokenAsync"},   // 1.0.0 - 6.2.0
         {51, nullptr, "UnregisterNotificationTokenAsync"}, // 1.0.0 - 6.2.0
     };
+    // clang-format on
     RegisterHandlers(functions);
 }
 

--- a/src/core/hle/service/acc/acc_aa.h
+++ b/src/core/hle/service/acc/acc_aa.h
@@ -10,8 +10,8 @@ namespace Service::Account {
 
 class ACC_AA final : public Module::Interface {
 public:
-    explicit ACC_AA(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> profile_manager,
-                    Core::System& system);
+    explicit ACC_AA(std::shared_ptr<Module> module_,
+                    std::shared_ptr<ProfileManager> profile_manager_, Core::System& system_);
     ~ACC_AA() override;
 };
 

--- a/src/core/hle/service/acc/acc_su.cpp
+++ b/src/core/hle/service/acc/acc_su.cpp
@@ -6,9 +6,9 @@
 
 namespace Service::Account {
 
-ACC_SU::ACC_SU(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> profile_manager,
-               Core::System& system)
-    : Module::Interface(std::move(module), std::move(profile_manager), system, "acc:su") {
+ACC_SU::ACC_SU(std::shared_ptr<Module> module_, std::shared_ptr<ProfileManager> profile_manager_,
+               Core::System& system_)
+    : Interface(std::move(module_), std::move(profile_manager_), system_, "acc:su") {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &ACC_SU::GetUserCount, "GetUserCount"},

--- a/src/core/hle/service/acc/acc_su.h
+++ b/src/core/hle/service/acc/acc_su.h
@@ -10,8 +10,8 @@ namespace Service::Account {
 
 class ACC_SU final : public Module::Interface {
 public:
-    explicit ACC_SU(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> profile_manager,
-                    Core::System& system);
+    explicit ACC_SU(std::shared_ptr<Module> module_,
+                    std::shared_ptr<ProfileManager> profile_manager_, Core::System& system_);
     ~ACC_SU() override;
 };
 

--- a/src/core/hle/service/acc/acc_u0.cpp
+++ b/src/core/hle/service/acc/acc_u0.cpp
@@ -6,9 +6,9 @@
 
 namespace Service::Account {
 
-ACC_U0::ACC_U0(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> profile_manager,
-               Core::System& system)
-    : Module::Interface(std::move(module), std::move(profile_manager), system, "acc:u0") {
+ACC_U0::ACC_U0(std::shared_ptr<Module> module_, std::shared_ptr<ProfileManager> profile_manager_,
+               Core::System& system_)
+    : Interface(std::move(module_), std::move(profile_manager_), system_, "acc:u0") {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &ACC_U0::GetUserCount, "GetUserCount"},

--- a/src/core/hle/service/acc/acc_u0.h
+++ b/src/core/hle/service/acc/acc_u0.h
@@ -10,8 +10,8 @@ namespace Service::Account {
 
 class ACC_U0 final : public Module::Interface {
 public:
-    explicit ACC_U0(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> profile_manager,
-                    Core::System& system);
+    explicit ACC_U0(std::shared_ptr<Module> module_,
+                    std::shared_ptr<ProfileManager> profile_manager_, Core::System& system_);
     ~ACC_U0() override;
 };
 

--- a/src/core/hle/service/acc/acc_u1.cpp
+++ b/src/core/hle/service/acc/acc_u1.cpp
@@ -6,9 +6,9 @@
 
 namespace Service::Account {
 
-ACC_U1::ACC_U1(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> profile_manager,
-               Core::System& system)
-    : Module::Interface(std::move(module), std::move(profile_manager), system, "acc:u1") {
+ACC_U1::ACC_U1(std::shared_ptr<Module> module_, std::shared_ptr<ProfileManager> profile_manager_,
+               Core::System& system_)
+    : Interface(std::move(module_), std::move(profile_manager_), system_, "acc:u1") {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &ACC_U1::GetUserCount, "GetUserCount"},

--- a/src/core/hle/service/acc/acc_u1.h
+++ b/src/core/hle/service/acc/acc_u1.h
@@ -10,8 +10,8 @@ namespace Service::Account {
 
 class ACC_U1 final : public Module::Interface {
 public:
-    explicit ACC_U1(std::shared_ptr<Module> module, std::shared_ptr<ProfileManager> profile_manager,
-                    Core::System& system);
+    explicit ACC_U1(std::shared_ptr<Module> module_,
+                    std::shared_ptr<ProfileManager> profile_manager_, Core::System& system_);
     ~ACC_U1() override;
 };
 

--- a/src/core/hle/service/am/applets/software_keyboard.cpp
+++ b/src/core/hle/service/am/applets/software_keyboard.cpp
@@ -241,7 +241,7 @@ void SoftwareKeyboard::InitializeForeground() {
     InitializeFrontendKeyboard();
 }
 
-void SoftwareKeyboard::InitializeBackground(LibraryAppletMode applet_mode) {
+void SoftwareKeyboard::InitializeBackground(LibraryAppletMode library_applet_mode) {
     LOG_INFO(Service_AM, "Initializing Inline Software Keyboard Applet.");
 
     is_background = true;
@@ -256,9 +256,9 @@ void SoftwareKeyboard::InitializeBackground(LibraryAppletMode applet_mode) {
                 swkbd_inline_initialize_arg.size());
 
     if (swkbd_initialize_arg.library_applet_mode_flag) {
-        ASSERT(applet_mode == LibraryAppletMode::Background);
+        ASSERT(library_applet_mode == LibraryAppletMode::Background);
     } else {
-        ASSERT(applet_mode == LibraryAppletMode::BackgroundIndirectDisplay);
+        ASSERT(library_applet_mode == LibraryAppletMode::BackgroundIndirectDisplay);
     }
 }
 

--- a/src/core/hle/service/am/applets/software_keyboard.h
+++ b/src/core/hle/service/am/applets/software_keyboard.h
@@ -57,7 +57,7 @@ private:
     void InitializeForeground();
 
     /// Initializes the inline software keyboard.
-    void InitializeBackground(LibraryAppletMode applet_mode);
+    void InitializeBackground(LibraryAppletMode library_applet_mode);
 
     /// Processes the text check sent by the application.
     void ProcessTextCheck();

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -27,9 +27,10 @@ namespace Service::Audio {
 
 class IAudioRenderer final : public ServiceFramework<IAudioRenderer> {
 public:
-    explicit IAudioRenderer(Core::System& system, AudioCommon::AudioRendererParameter audren_params,
+    explicit IAudioRenderer(Core::System& system_,
+                            const AudioCommon::AudioRendererParameter& audren_params,
                             const std::size_t instance_number)
-        : ServiceFramework{system, "IAudioRenderer"} {
+        : ServiceFramework{system_, "IAudioRenderer"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IAudioRenderer::GetSampleRate, "GetSampleRate"},

--- a/src/core/hle/service/bcat/bcat.cpp
+++ b/src/core/hle/service/bcat/bcat.cpp
@@ -6,9 +6,9 @@
 
 namespace Service::BCAT {
 
-BCAT::BCAT(Core::System& system, std::shared_ptr<Module> module,
-           FileSystem::FileSystemController& fsc, const char* name)
-    : Interface(system, std::move(module), fsc, name) {
+BCAT::BCAT(Core::System& system_, std::shared_ptr<Module> module_,
+           FileSystem::FileSystemController& fsc_, const char* name_)
+    : Interface(system_, std::move(module_), fsc_, name_) {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &BCAT::CreateBcatService, "CreateBcatService"},

--- a/src/core/hle/service/bcat/bcat.h
+++ b/src/core/hle/service/bcat/bcat.h
@@ -14,8 +14,8 @@ namespace Service::BCAT {
 
 class BCAT final : public Module::Interface {
 public:
-    explicit BCAT(Core::System& system, std::shared_ptr<Module> module,
-                  FileSystem::FileSystemController& fsc, const char* name);
+    explicit BCAT(Core::System& system_, std::shared_ptr<Module> module_,
+                  FileSystem::FileSystemController& fsc_, const char* name_);
     ~BCAT() override;
 };
 

--- a/src/core/hle/service/grc/grc.cpp
+++ b/src/core/hle/service/grc/grc.cpp
@@ -12,7 +12,7 @@ namespace Service::GRC {
 
 class GRC final : public ServiceFramework<GRC> {
 public:
-    explicit GRC(Core::System& system) : ServiceFramework{system, "grc:c"} {
+    explicit GRC(Core::System& system_) : ServiceFramework{system_, "grc:c"} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {1, nullptr, "OpenContinuousRecorder"},

--- a/src/core/hle/service/hid/controllers/console_sixaxis.cpp
+++ b/src/core/hle/service/hid/controllers/console_sixaxis.cpp
@@ -9,8 +9,8 @@
 namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3C200;
 
-Controller_ConsoleSixAxis::Controller_ConsoleSixAxis(Core::System& system)
-    : ControllerBase(system) {}
+Controller_ConsoleSixAxis::Controller_ConsoleSixAxis(Core::System& system_)
+    : ControllerBase{system_} {}
 Controller_ConsoleSixAxis::~Controller_ConsoleSixAxis() = default;
 
 void Controller_ConsoleSixAxis::OnInit() {}

--- a/src/core/hle/service/hid/controllers/console_sixaxis.h
+++ b/src/core/hle/service/hid/controllers/console_sixaxis.h
@@ -14,7 +14,7 @@
 namespace Service::HID {
 class Controller_ConsoleSixAxis final : public ControllerBase {
 public:
-    explicit Controller_ConsoleSixAxis(Core::System& system);
+    explicit Controller_ConsoleSixAxis(Core::System& system_);
     ~Controller_ConsoleSixAxis() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/debug_pad.cpp
+++ b/src/core/hle/service/hid/controllers/debug_pad.cpp
@@ -14,7 +14,7 @@ constexpr s32 HID_JOYSTICK_MAX = 0x7fff;
 [[maybe_unused]] constexpr s32 HID_JOYSTICK_MIN = -0x7fff;
 enum class JoystickId : std::size_t { Joystick_Left, Joystick_Right };
 
-Controller_DebugPad::Controller_DebugPad(Core::System& system) : ControllerBase(system) {}
+Controller_DebugPad::Controller_DebugPad(Core::System& system_) : ControllerBase{system_} {}
 Controller_DebugPad::~Controller_DebugPad() = default;
 
 void Controller_DebugPad::OnInit() {}

--- a/src/core/hle/service/hid/controllers/debug_pad.h
+++ b/src/core/hle/service/hid/controllers/debug_pad.h
@@ -16,7 +16,7 @@
 namespace Service::HID {
 class Controller_DebugPad final : public ControllerBase {
 public:
-    explicit Controller_DebugPad(Core::System& system);
+    explicit Controller_DebugPad(Core::System& system_);
     ~Controller_DebugPad() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/gesture.cpp
+++ b/src/core/hle/service/hid/controllers/gesture.cpp
@@ -15,7 +15,7 @@ constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3BA00;
 constexpr f32 angle_threshold = 0.08f;
 constexpr f32 pinch_threshold = 100.0f;
 
-Controller_Gesture::Controller_Gesture(Core::System& system) : ControllerBase(system) {}
+Controller_Gesture::Controller_Gesture(Core::System& system_) : ControllerBase{system_} {}
 Controller_Gesture::~Controller_Gesture() = default;
 
 void Controller_Gesture::OnInit() {

--- a/src/core/hle/service/hid/controllers/gesture.h
+++ b/src/core/hle/service/hid/controllers/gesture.h
@@ -14,7 +14,7 @@
 namespace Service::HID {
 class Controller_Gesture final : public ControllerBase {
 public:
-    explicit Controller_Gesture(Core::System& system);
+    explicit Controller_Gesture(Core::System& system_);
     ~Controller_Gesture() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/keyboard.cpp
+++ b/src/core/hle/service/hid/controllers/keyboard.cpp
@@ -12,7 +12,7 @@ namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3800;
 constexpr u8 KEYS_PER_BYTE = 8;
 
-Controller_Keyboard::Controller_Keyboard(Core::System& system) : ControllerBase(system) {}
+Controller_Keyboard::Controller_Keyboard(Core::System& system_) : ControllerBase{system_} {}
 Controller_Keyboard::~Controller_Keyboard() = default;
 
 void Controller_Keyboard::OnInit() {}

--- a/src/core/hle/service/hid/controllers/keyboard.h
+++ b/src/core/hle/service/hid/controllers/keyboard.h
@@ -16,7 +16,7 @@
 namespace Service::HID {
 class Controller_Keyboard final : public ControllerBase {
 public:
-    explicit Controller_Keyboard(Core::System& system);
+    explicit Controller_Keyboard(Core::System& system_);
     ~Controller_Keyboard() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/mouse.cpp
+++ b/src/core/hle/service/hid/controllers/mouse.cpp
@@ -11,7 +11,7 @@
 namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3400;
 
-Controller_Mouse::Controller_Mouse(Core::System& system) : ControllerBase(system) {}
+Controller_Mouse::Controller_Mouse(Core::System& system_) : ControllerBase{system_} {}
 Controller_Mouse::~Controller_Mouse() = default;
 
 void Controller_Mouse::OnInit() {}

--- a/src/core/hle/service/hid/controllers/mouse.h
+++ b/src/core/hle/service/hid/controllers/mouse.h
@@ -15,7 +15,7 @@
 namespace Service::HID {
 class Controller_Mouse final : public ControllerBase {
 public:
-    explicit Controller_Mouse(Core::System& system);
+    explicit Controller_Mouse(Core::System& system_);
     ~Controller_Mouse() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -147,7 +147,7 @@ bool Controller_NPad::IsDeviceHandleValid(const DeviceHandle& device_handle) {
            device_handle.device_index < DeviceIndex::MaxDeviceIndex;
 }
 
-Controller_NPad::Controller_NPad(Core::System& system) : ControllerBase(system) {
+Controller_NPad::Controller_NPad(Core::System& system_) : ControllerBase{system_} {
     latest_vibration_values.fill({DEFAULT_VIBRATION_VALUE, DEFAULT_VIBRATION_VALUE});
 }
 

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -26,7 +26,7 @@ constexpr u32 NPAD_UNKNOWN = 16; // TODO(ogniK): What is this?
 
 class Controller_NPad final : public ControllerBase {
 public:
-    explicit Controller_NPad(Core::System& system);
+    explicit Controller_NPad(Core::System& system_);
     ~Controller_NPad() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/stubbed.cpp
+++ b/src/core/hle/service/hid/controllers/stubbed.cpp
@@ -9,7 +9,7 @@
 
 namespace Service::HID {
 
-Controller_Stubbed::Controller_Stubbed(Core::System& system) : ControllerBase(system) {}
+Controller_Stubbed::Controller_Stubbed(Core::System& system_) : ControllerBase{system_} {}
 Controller_Stubbed::~Controller_Stubbed() = default;
 
 void Controller_Stubbed::OnInit() {}

--- a/src/core/hle/service/hid/controllers/stubbed.h
+++ b/src/core/hle/service/hid/controllers/stubbed.h
@@ -10,7 +10,7 @@
 namespace Service::HID {
 class Controller_Stubbed final : public ControllerBase {
 public:
-    explicit Controller_Stubbed(Core::System& system);
+    explicit Controller_Stubbed(Core::System& system_);
     ~Controller_Stubbed() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/touchscreen.cpp
+++ b/src/core/hle/service/hid/controllers/touchscreen.cpp
@@ -15,7 +15,7 @@
 namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x400;
 
-Controller_Touchscreen::Controller_Touchscreen(Core::System& system) : ControllerBase(system) {}
+Controller_Touchscreen::Controller_Touchscreen(Core::System& system_) : ControllerBase{system_} {}
 Controller_Touchscreen::~Controller_Touchscreen() = default;
 
 void Controller_Touchscreen::OnInit() {

--- a/src/core/hle/service/hid/controllers/touchscreen.h
+++ b/src/core/hle/service/hid/controllers/touchscreen.h
@@ -14,7 +14,7 @@
 namespace Service::HID {
 class Controller_Touchscreen final : public ControllerBase {
 public:
-    explicit Controller_Touchscreen(Core::System& system);
+    explicit Controller_Touchscreen(Core::System& system_);
     ~Controller_Touchscreen() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/xpad.cpp
+++ b/src/core/hle/service/hid/controllers/xpad.cpp
@@ -10,7 +10,7 @@
 namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3C00;
 
-Controller_XPad::Controller_XPad(Core::System& system) : ControllerBase(system) {}
+Controller_XPad::Controller_XPad(Core::System& system_) : ControllerBase{system_} {}
 Controller_XPad::~Controller_XPad() = default;
 
 void Controller_XPad::OnInit() {}

--- a/src/core/hle/service/hid/controllers/xpad.h
+++ b/src/core/hle/service/hid/controllers/xpad.h
@@ -13,7 +13,7 @@
 namespace Service::HID {
 class Controller_XPad final : public ControllerBase {
 public:
-    explicit Controller_XPad(Core::System& system);
+    explicit Controller_XPad(Core::System& system_);
     ~Controller_XPad() override;
 
     // Called when the controller is initialized

--- a/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
@@ -14,8 +14,8 @@
 
 namespace Service::Nvidia::Devices {
 
-nvdisp_disp0::nvdisp_disp0(Core::System& system, std::shared_ptr<nvmap> nvmap_dev)
-    : nvdevice(system), nvmap_dev(std::move(nvmap_dev)) {}
+nvdisp_disp0::nvdisp_disp0(Core::System& system_, std::shared_ptr<nvmap> nvmap_dev_)
+    : nvdevice{system_}, nvmap_dev{std::move(nvmap_dev_)} {}
 nvdisp_disp0 ::~nvdisp_disp0() = default;
 
 NvResult nvdisp_disp0::Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& input,

--- a/src/core/hle/service/nvdrv/devices/nvdisp_disp0.h
+++ b/src/core/hle/service/nvdrv/devices/nvdisp_disp0.h
@@ -17,7 +17,7 @@ class nvmap;
 
 class nvdisp_disp0 final : public nvdevice {
 public:
-    explicit nvdisp_disp0(Core::System& system, std::shared_ptr<nvmap> nvmap_dev);
+    explicit nvdisp_disp0(Core::System& system_, std::shared_ptr<nvmap> nvmap_dev_);
     ~nvdisp_disp0() override;
 
     NvResult Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& input,

--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
@@ -17,8 +17,8 @@
 
 namespace Service::Nvidia::Devices {
 
-nvhost_as_gpu::nvhost_as_gpu(Core::System& system, std::shared_ptr<nvmap> nvmap_dev)
-    : nvdevice(system), nvmap_dev(std::move(nvmap_dev)) {}
+nvhost_as_gpu::nvhost_as_gpu(Core::System& system_, std::shared_ptr<nvmap> nvmap_dev_)
+    : nvdevice{system_}, nvmap_dev{std::move(nvmap_dev_)} {}
 nvhost_as_gpu::~nvhost_as_gpu() = default;
 
 NvResult nvhost_as_gpu::Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& input,

--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.h
@@ -30,7 +30,7 @@ DECLARE_ENUM_FLAG_OPERATORS(AddressSpaceFlags);
 
 class nvhost_as_gpu final : public nvdevice {
 public:
-    explicit nvhost_as_gpu(Core::System& system, std::shared_ptr<nvmap> nvmap_dev);
+    explicit nvhost_as_gpu(Core::System& system_, std::shared_ptr<nvmap> nvmap_dev_);
     ~nvhost_as_gpu() override;
 
     NvResult Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& input,

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -15,9 +15,10 @@
 
 namespace Service::Nvidia::Devices {
 
-nvhost_ctrl::nvhost_ctrl(Core::System& system, EventInterface& events_interface,
-                         SyncpointManager& syncpoint_manager)
-    : nvdevice(system), events_interface{events_interface}, syncpoint_manager{syncpoint_manager} {}
+nvhost_ctrl::nvhost_ctrl(Core::System& system_, EventInterface& events_interface_,
+                         SyncpointManager& syncpoint_manager_)
+    : nvdevice{system_}, events_interface{events_interface_}, syncpoint_manager{
+                                                                  syncpoint_manager_} {}
 nvhost_ctrl::~nvhost_ctrl() = default;
 
 NvResult nvhost_ctrl::Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& input,

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
@@ -14,8 +14,8 @@ namespace Service::Nvidia::Devices {
 
 class nvhost_ctrl final : public nvdevice {
 public:
-    explicit nvhost_ctrl(Core::System& system, EventInterface& events_interface,
-                         SyncpointManager& syncpoint_manager);
+    explicit nvhost_ctrl(Core::System& system_, EventInterface& events_interface_,
+                         SyncpointManager& syncpoint_manager_);
     ~nvhost_ctrl() override;
 
     NvResult Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& input,

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.cpp
@@ -12,7 +12,7 @@
 
 namespace Service::Nvidia::Devices {
 
-nvhost_ctrl_gpu::nvhost_ctrl_gpu(Core::System& system) : nvdevice(system) {}
+nvhost_ctrl_gpu::nvhost_ctrl_gpu(Core::System& system_) : nvdevice{system_} {}
 nvhost_ctrl_gpu::~nvhost_ctrl_gpu() = default;
 
 NvResult nvhost_ctrl_gpu::Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& input,

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl_gpu.h
@@ -13,7 +13,7 @@ namespace Service::Nvidia::Devices {
 
 class nvhost_ctrl_gpu final : public nvdevice {
 public:
-    explicit nvhost_ctrl_gpu(Core::System& system);
+    explicit nvhost_ctrl_gpu(Core::System& system_);
     ~nvhost_ctrl_gpu() override;
 
     NvResult Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& input,

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.cpp
@@ -14,11 +14,11 @@
 
 namespace Service::Nvidia::Devices {
 
-nvhost_gpu::nvhost_gpu(Core::System& system, std::shared_ptr<nvmap> nvmap_dev,
-                       SyncpointManager& syncpoint_manager)
-    : nvdevice(system), nvmap_dev(std::move(nvmap_dev)), syncpoint_manager{syncpoint_manager} {
-    channel_fence.id = syncpoint_manager.AllocateSyncpoint();
-    channel_fence.value = system.GPU().GetSyncpointValue(channel_fence.id);
+nvhost_gpu::nvhost_gpu(Core::System& system_, std::shared_ptr<nvmap> nvmap_dev_,
+                       SyncpointManager& syncpoint_manager_)
+    : nvdevice{system_}, nvmap_dev{std::move(nvmap_dev_)}, syncpoint_manager{syncpoint_manager_} {
+    channel_fence.id = syncpoint_manager_.AllocateSyncpoint();
+    channel_fence.value = system_.GPU().GetSyncpointValue(channel_fence.id);
 }
 
 nvhost_gpu::~nvhost_gpu() = default;

--- a/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_gpu.h
@@ -22,8 +22,8 @@ namespace Service::Nvidia::Devices {
 class nvmap;
 class nvhost_gpu final : public nvdevice {
 public:
-    explicit nvhost_gpu(Core::System& system, std::shared_ptr<nvmap> nvmap_dev,
-                        SyncpointManager& syncpoint_manager);
+    explicit nvhost_gpu(Core::System& system_, std::shared_ptr<nvmap> nvmap_dev_,
+                        SyncpointManager& syncpoint_manager_);
     ~nvhost_gpu() override;
 
     NvResult Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& input,

--- a/src/core/hle/service/nvdrv/devices/nvhost_nvdec.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvdec.cpp
@@ -11,9 +11,9 @@
 
 namespace Service::Nvidia::Devices {
 
-nvhost_nvdec::nvhost_nvdec(Core::System& system, std::shared_ptr<nvmap> nvmap_dev,
-                           SyncpointManager& syncpoint_manager)
-    : nvhost_nvdec_common(system, std::move(nvmap_dev), syncpoint_manager) {}
+nvhost_nvdec::nvhost_nvdec(Core::System& system_, std::shared_ptr<nvmap> nvmap_dev_,
+                           SyncpointManager& syncpoint_manager_)
+    : nvhost_nvdec_common{system_, std::move(nvmap_dev_), syncpoint_manager_} {}
 nvhost_nvdec::~nvhost_nvdec() = default;
 
 NvResult nvhost_nvdec::Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& input,

--- a/src/core/hle/service/nvdrv/devices/nvhost_nvdec.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvdec.h
@@ -11,8 +11,8 @@ namespace Service::Nvidia::Devices {
 
 class nvhost_nvdec final : public nvhost_nvdec_common {
 public:
-    explicit nvhost_nvdec(Core::System& system, std::shared_ptr<nvmap> nvmap_dev,
-                          SyncpointManager& syncpoint_manager);
+    explicit nvhost_nvdec(Core::System& system_, std::shared_ptr<nvmap> nvmap_dev_,
+                          SyncpointManager& syncpoint_manager_);
     ~nvhost_nvdec() override;
 
     NvResult Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& input,

--- a/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.cpp
@@ -42,9 +42,9 @@ std::size_t WriteVectors(std::vector<u8>& dst, const std::vector<T>& src, std::s
 }
 } // Anonymous namespace
 
-nvhost_nvdec_common::nvhost_nvdec_common(Core::System& system, std::shared_ptr<nvmap> nvmap_dev,
-                                         SyncpointManager& syncpoint_manager)
-    : nvdevice(system), nvmap_dev(std::move(nvmap_dev)), syncpoint_manager(syncpoint_manager) {}
+nvhost_nvdec_common::nvhost_nvdec_common(Core::System& system_, std::shared_ptr<nvmap> nvmap_dev_,
+                                         SyncpointManager& syncpoint_manager_)
+    : nvdevice{system_}, nvmap_dev{std::move(nvmap_dev_)}, syncpoint_manager{syncpoint_manager_} {}
 nvhost_nvdec_common::~nvhost_nvdec_common() = default;
 
 NvResult nvhost_nvdec_common::SetNVMAPfd(const std::vector<u8>& input) {

--- a/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.h
@@ -18,8 +18,8 @@ class nvmap;
 
 class nvhost_nvdec_common : public nvdevice {
 public:
-    explicit nvhost_nvdec_common(Core::System& system, std::shared_ptr<nvmap> nvmap_dev,
-                                 SyncpointManager& syncpoint_manager);
+    explicit nvhost_nvdec_common(Core::System& system_, std::shared_ptr<nvmap> nvmap_dev_,
+                                 SyncpointManager& syncpoint_manager_);
     ~nvhost_nvdec_common() override;
 
 protected:

--- a/src/core/hle/service/nvdrv/devices/nvhost_nvjpg.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvjpg.cpp
@@ -10,7 +10,7 @@
 
 namespace Service::Nvidia::Devices {
 
-nvhost_nvjpg::nvhost_nvjpg(Core::System& system) : nvdevice(system) {}
+nvhost_nvjpg::nvhost_nvjpg(Core::System& system_) : nvdevice{system_} {}
 nvhost_nvjpg::~nvhost_nvjpg() = default;
 
 NvResult nvhost_nvjpg::Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& input,

--- a/src/core/hle/service/nvdrv/devices/nvhost_nvjpg.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvjpg.h
@@ -13,7 +13,7 @@ namespace Service::Nvidia::Devices {
 
 class nvhost_nvjpg final : public nvdevice {
 public:
-    explicit nvhost_nvjpg(Core::System& system);
+    explicit nvhost_nvjpg(Core::System& system_);
     ~nvhost_nvjpg() override;
 
     NvResult Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& input,

--- a/src/core/hle/service/nvdrv/devices/nvhost_vic.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_vic.cpp
@@ -10,9 +10,9 @@
 #include "video_core/renderer_base.h"
 
 namespace Service::Nvidia::Devices {
-nvhost_vic::nvhost_vic(Core::System& system, std::shared_ptr<nvmap> nvmap_dev,
-                       SyncpointManager& syncpoint_manager)
-    : nvhost_nvdec_common(system, std::move(nvmap_dev), syncpoint_manager) {}
+nvhost_vic::nvhost_vic(Core::System& system_, std::shared_ptr<nvmap> nvmap_dev_,
+                       SyncpointManager& syncpoint_manager_)
+    : nvhost_nvdec_common{system_, std::move(nvmap_dev_), syncpoint_manager_} {}
 
 nvhost_vic::~nvhost_vic() = default;
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_vic.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_vic.h
@@ -10,8 +10,8 @@ namespace Service::Nvidia::Devices {
 
 class nvhost_vic final : public nvhost_nvdec_common {
 public:
-    explicit nvhost_vic(Core::System& system, std::shared_ptr<nvmap> nvmap_dev,
-                        SyncpointManager& syncpoint_manager);
+    explicit nvhost_vic(Core::System& system_, std::shared_ptr<nvmap> nvmap_dev_,
+                        SyncpointManager& syncpoint_manager_);
     ~nvhost_vic();
 
     NvResult Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& input,

--- a/src/core/hle/service/nvdrv/devices/nvmap.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvmap.cpp
@@ -11,7 +11,7 @@
 
 namespace Service::Nvidia::Devices {
 
-nvmap::nvmap(Core::System& system) : nvdevice(system) {
+nvmap::nvmap(Core::System& system_) : nvdevice{system_} {
     // Handle 0 appears to be used when remapping, so we create a placeholder empty nvmap object to
     // represent this.
     CreateObject(0);

--- a/src/core/hle/service/nvdrv/devices/nvmap.h
+++ b/src/core/hle/service/nvdrv/devices/nvmap.h
@@ -16,7 +16,7 @@ namespace Service::Nvidia::Devices {
 
 class nvmap final : public nvdevice {
 public:
-    explicit nvmap(Core::System& system);
+    explicit nvmap(Core::System& system_);
     ~nvmap() override;
 
     NvResult Ioctl1(DeviceFD fd, Ioctl command, const std::vector<u8>& input,

--- a/src/core/hle/service/pctl/module.cpp
+++ b/src/core/hle/service/pctl/module.cpp
@@ -24,9 +24,8 @@ constexpr ResultCode ResultNoRestrictionEnabled{ErrorModule::PCTL, 181};
 
 class IParentalControlService final : public ServiceFramework<IParentalControlService> {
 public:
-    explicit IParentalControlService(Core::System& system_, Capability capability)
-        : ServiceFramework{system_, "IParentalControlService"}, system(system_),
-          capability(capability) {
+    explicit IParentalControlService(Core::System& system_, Capability capability_)
+        : ServiceFramework{system_, "IParentalControlService"}, capability{capability_} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {1, &IParentalControlService::Initialize, "Initialize"},
@@ -363,7 +362,6 @@ private:
     ParentalControlSettings settings{};
     std::array<char, 8> pin_code{};
     bool can_use_stereo_vision = true;
-    Core::System& system;
     Capability capability{};
 };
 
@@ -386,8 +384,8 @@ void Module::Interface::CreateServiceWithoutInitialize(Kernel::HLERequestContext
 }
 
 Module::Interface::Interface(Core::System& system_, std::shared_ptr<Module> module_,
-                             const char* name, Capability capability)
-    : ServiceFramework{system_, name}, module{std::move(module_)}, capability(capability) {}
+                             const char* name_, Capability capability_)
+    : ServiceFramework{system_, name_}, module{std::move(module_)}, capability{capability_} {}
 
 Module::Interface::~Interface() = default;
 

--- a/src/core/hle/service/pctl/module.h
+++ b/src/core/hle/service/pctl/module.h
@@ -28,8 +28,8 @@ class Module final {
 public:
     class Interface : public ServiceFramework<Interface> {
     public:
-        explicit Interface(Core::System& system_, std::shared_ptr<Module> module_, const char* name,
-                           Capability capability);
+        explicit Interface(Core::System& system_, std::shared_ptr<Module> module_,
+                           const char* name_, Capability capability_);
         ~Interface() override;
 
         void CreateService(Kernel::HLERequestContext& ctx);

--- a/src/core/hle/service/time/interface.cpp
+++ b/src/core/hle/service/time/interface.cpp
@@ -6,8 +6,8 @@
 
 namespace Service::Time {
 
-Time::Time(std::shared_ptr<Module> module, Core::System& system, const char* name)
-    : Interface(std::move(module), system, name) {
+Time::Time(std::shared_ptr<Module> module_, Core::System& system_, const char* name_)
+    : Interface{std::move(module_), system_, name_} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, &Time::GetStandardUserSystemClock, "GetStandardUserSystemClock"},

--- a/src/core/hle/service/time/interface.h
+++ b/src/core/hle/service/time/interface.h
@@ -14,7 +14,7 @@ namespace Service::Time {
 
 class Time final : public Module::Interface {
 public:
-    explicit Time(std::shared_ptr<Module> time, Core::System& system, const char* name);
+    explicit Time(std::shared_ptr<Module> time, Core::System& system_, const char* name_);
     ~Time() override;
 };
 


### PR DESCRIPTION
Now all that remains is for kernel code to be 'shadow-free' and then -Wshadow can be turned into an error.