### PR TITLE
service: Remove unused class variables

### DIFF
--- a/src/core/hle/service/am/applets/web_browser.h
+++ b/src/core/hle/service/am/applets/web_browser.h
@@ -69,13 +69,12 @@ private:
     bool complete{false};
     ResultCode status{RESULT_SUCCESS};
 
-    WebAppletVersion web_applet_version;
-    WebExitReason web_exit_reason;
-    WebArgHeader web_arg_header;
+    WebAppletVersion web_applet_version{};
+    WebArgHeader web_arg_header{};
     WebArgInputTLVMap web_arg_input_tlv_map;
 
-    u64 title_id;
-    FileSys::ContentRecordType nca_type;
+    u64 title_id{};
+    FileSys::ContentRecordType nca_type{};
     std::string offline_cache_dir;
     std::string offline_document;
     FileSys::VirtualFile offline_romfs;

--- a/src/core/hle/service/lbl/lbl.cpp
+++ b/src/core/hle/service/lbl/lbl.cpp
@@ -312,7 +312,6 @@ private:
 
     bool vr_mode_enabled = false;
     float current_brightness = 1.0f;
-    float backlight_brightness = 1.0f;
     float ambient_light_value = 0.0f;
     float current_vr_brightness = 1.0f;
     bool dimming = true;

--- a/src/core/hle/service/pctl/module.cpp
+++ b/src/core/hle/service/pctl/module.cpp
@@ -361,7 +361,6 @@ private:
     States states{};
     ParentalControlSettings settings{};
     std::array<char, 8> pin_code{};
-    bool can_use_stereo_vision = true;
     Capability capability{};
 };
 


### PR DESCRIPTION
Prevents some warnings from occurring.

While in the same area, we can ensure all member variables of am's WebBrowser all have an initializer to make for deterministic initial state.