### PR TITLE
core: Make variable shadowing a compile-time error

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -651,20 +651,17 @@ endif()
 
 if (MSVC)
     target_compile_options(core PRIVATE
-        # 'expression' : signed/unsigned mismatch
-        /we4018
-        # 'argument' : conversion from 'type1' to 'type2', possible loss of data (floating-point)
-        /we4244
-        # 'conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch
-        /we4245
-        # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
-        /we4254
-        # 'var' : conversion from 'size_t' to 'type', possible loss of data
-        /we4267
-        # 'context' : truncation from 'type1' to 'type2'
-        /we4305
-        # 'function' : not all control paths return a value
-        /we4715
+        /we4018 # 'expression' : signed/unsigned mismatch
+        /we4244 # 'argument' : conversion from 'type1' to 'type2', possible loss of data (floating-point)
+        /we4245 # 'conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch
+        /we4254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
+        /we4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data
+        /we4305 # 'context' : truncation from 'type1' to 'type2'
+        /we4456 # Declaration of 'identifier' hides previous local declaration
+        /we4457 # Declaration of 'identifier' hides function parameter
+        /we4458 # Declaration of 'identifier' hides class member
+        /we4459 # Declaration of 'identifier' hides global declaration
+        /we4715 # 'function' : not all control paths return a value
     )
 else()
     target_compile_options(core PRIVATE
@@ -672,6 +669,7 @@ else()
         -Werror=ignored-qualifiers
         -Werror=implicit-fallthrough
         -Werror=sign-compare
+        -Werror=shadow
 
         $<$<CXX_COMPILER_ID:GNU>:-Werror=class-memaccess>
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -24,7 +24,7 @@ namespace Core {
 
 class DynarmicCallbacks32 : public Dynarmic::A32::UserCallbacks {
 public:
-    explicit DynarmicCallbacks32(ARM_Dynarmic_32& parent) : parent(parent) {}
+    explicit DynarmicCallbacks32(ARM_Dynarmic_32& parent_) : parent{parent_} {}
 
     u8 MemoryRead8(u32 vaddr) override {
         return parent.system.Memory().Read8(vaddr);

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -27,7 +27,7 @@ using Vector = Dynarmic::A64::Vector;
 
 class DynarmicCallbacks64 : public Dynarmic::A64::UserCallbacks {
 public:
-    explicit DynarmicCallbacks64(ARM_Dynarmic_64& parent) : parent(parent) {}
+    explicit DynarmicCallbacks64(ARM_Dynarmic_64& parent_) : parent{parent_} {}
 
     u8 MemoryRead8(u64 vaddr) override {
         return parent.system.Memory().Read8(vaddr);

--- a/src/core/arm/dynarmic/arm_dynarmic_cp15.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_cp15.h
@@ -18,7 +18,7 @@ class DynarmicCP15 final : public Dynarmic::A32::Coprocessor {
 public:
     using CoprocReg = Dynarmic::A32::CoprocReg;
 
-    explicit DynarmicCP15(ARM_Dynarmic_32& parent) : parent(parent) {}
+    explicit DynarmicCP15(ARM_Dynarmic_32& parent_) : parent{parent_} {}
 
     std::optional<Callback> CompileInternalOperation(bool two, unsigned opc1, CoprocReg CRd,
                                                      CoprocReg CRn, CoprocReg CRm,

--- a/src/core/arm/dynarmic/arm_exclusive_monitor.cpp
+++ b/src/core/arm/dynarmic/arm_exclusive_monitor.cpp
@@ -9,8 +9,8 @@
 
 namespace Core {
 
-DynarmicExclusiveMonitor::DynarmicExclusiveMonitor(Memory::Memory& memory, std::size_t core_count)
-    : monitor(core_count), memory{memory} {}
+DynarmicExclusiveMonitor::DynarmicExclusiveMonitor(Memory::Memory& memory_, std::size_t core_count_)
+    : monitor{core_count_}, memory{memory_} {}
 
 DynarmicExclusiveMonitor::~DynarmicExclusiveMonitor() = default;
 

--- a/src/core/arm/dynarmic/arm_exclusive_monitor.h
+++ b/src/core/arm/dynarmic/arm_exclusive_monitor.h
@@ -22,7 +22,7 @@ namespace Core {
 
 class DynarmicExclusiveMonitor final : public ExclusiveMonitor {
 public:
-    explicit DynarmicExclusiveMonitor(Memory::Memory& memory, std::size_t core_count);
+    explicit DynarmicExclusiveMonitor(Memory::Memory& memory_, std::size_t core_count_);
     ~DynarmicExclusiveMonitor() override;
 
     u8 ExclusiveRead8(std::size_t core_index, VAddr addr) override;

--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -18,7 +18,7 @@
 
 namespace Core {
 
-CpuManager::CpuManager(System& system) : system{system} {}
+CpuManager::CpuManager(System& system_) : system{system_} {}
 CpuManager::~CpuManager() = default;
 
 void CpuManager::ThreadStart(CpuManager& cpu_manager, std::size_t core) {

--- a/src/core/cpu_manager.h
+++ b/src/core/cpu_manager.h
@@ -25,7 +25,7 @@ class System;
 
 class CpuManager {
 public:
-    explicit CpuManager(System& system);
+    explicit CpuManager(System& system_);
     CpuManager(const CpuManager&) = delete;
     CpuManager(CpuManager&&) = delete;
 

--- a/src/core/crypto/ctr_encryption_layer.cpp
+++ b/src/core/crypto/ctr_encryption_layer.cpp
@@ -10,8 +10,8 @@
 namespace Core::Crypto {
 
 CTREncryptionLayer::CTREncryptionLayer(FileSys::VirtualFile base_, Key128 key_,
-                                       std::size_t base_offset)
-    : EncryptionLayer(std::move(base_)), base_offset(base_offset), cipher(key_, Mode::CTR) {}
+                                       std::size_t base_offset_)
+    : EncryptionLayer(std::move(base_)), base_offset(base_offset_), cipher(key_, Mode::CTR) {}
 
 std::size_t CTREncryptionLayer::Read(u8* data, std::size_t length, std::size_t offset) const {
     if (length == 0)

--- a/src/core/crypto/ctr_encryption_layer.h
+++ b/src/core/crypto/ctr_encryption_layer.h
@@ -17,7 +17,7 @@ class CTREncryptionLayer : public EncryptionLayer {
 public:
     using IVData = std::array<u8, 16>;
 
-    CTREncryptionLayer(FileSys::VirtualFile base, Key128 key, std::size_t base_offset);
+    CTREncryptionLayer(FileSys::VirtualFile base_, Key128 key_, std::size_t base_offset_);
 
     std::size_t Read(u8* data, std::size_t length, std::size_t offset) const override;
 

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -458,7 +458,7 @@ static std::array<u8, size> operator^(const std::array<u8, size>& lhs,
                                       const std::array<u8, size>& rhs) {
     std::array<u8, size> out;
     std::transform(lhs.begin(), lhs.end(), rhs.begin(), out.begin(),
-                   [](u8 lhs, u8 rhs) { return u8(lhs ^ rhs); });
+                   [](u8 lhs_elem, u8 rhs_elem) { return u8(lhs_elem ^ rhs_elem); });
     return out;
 }
 

--- a/src/core/file_sys/nca_metadata.cpp
+++ b/src/core/file_sys/nca_metadata.cpp
@@ -39,10 +39,10 @@ CNMT::CNMT(VirtualFile file) {
     }
 }
 
-CNMT::CNMT(CNMTHeader header, OptionalHeader opt_header, std::vector<ContentRecord> content_records,
-           std::vector<MetaRecord> meta_records)
-    : header(std::move(header)), opt_header(std::move(opt_header)),
-      content_records(std::move(content_records)), meta_records(std::move(meta_records)) {}
+CNMT::CNMT(CNMTHeader header_, OptionalHeader opt_header_,
+           std::vector<ContentRecord> content_records_, std::vector<MetaRecord> meta_records_)
+    : header(std::move(header_)), opt_header(std::move(opt_header_)),
+      content_records(std::move(content_records_)), meta_records(std::move(meta_records_)) {}
 
 CNMT::~CNMT() = default;
 

--- a/src/core/file_sys/nca_metadata.h
+++ b/src/core/file_sys/nca_metadata.h
@@ -87,8 +87,8 @@ static_assert(sizeof(CNMTHeader) == 0x20, "CNMTHeader has incorrect size.");
 class CNMT {
 public:
     explicit CNMT(VirtualFile file);
-    CNMT(CNMTHeader header, OptionalHeader opt_header, std::vector<ContentRecord> content_records,
-         std::vector<MetaRecord> meta_records);
+    CNMT(CNMTHeader header_, OptionalHeader opt_header_,
+         std::vector<ContentRecord> content_records_, std::vector<MetaRecord> meta_records_);
     ~CNMT();
 
     u64 GetTitleID() const;

--- a/src/core/file_sys/submission_package.cpp
+++ b/src/core/file_sys/submission_package.cpp
@@ -20,8 +20,8 @@
 
 namespace FileSys {
 
-NSP::NSP(VirtualFile file_, std::size_t program_index)
-    : file(std::move(file_)), program_index(program_index), status{Loader::ResultStatus::Success},
+NSP::NSP(VirtualFile file_, std::size_t program_index_)
+    : file(std::move(file_)), program_index(program_index_), status{Loader::ResultStatus::Success},
       pfs(std::make_shared<PartitionFilesystem>(file)), keys{Core::Crypto::KeyManager::Instance()} {
     if (pfs->GetStatus() != Loader::ResultStatus::Success) {
         status = pfs->GetStatus();

--- a/src/core/file_sys/submission_package.h
+++ b/src/core/file_sys/submission_package.h
@@ -27,7 +27,7 @@ enum class ContentRecordType : u8;
 
 class NSP : public ReadOnlyVfsDirectory {
 public:
-    explicit NSP(VirtualFile file, std::size_t program_index = 0);
+    explicit NSP(VirtualFile file_, std::size_t program_index_ = 0);
     ~NSP() override;
 
     Loader::ResultStatus GetStatus() const;

--- a/src/core/file_sys/vfs_concat.cpp
+++ b/src/core/file_sys/vfs_concat.cpp
@@ -23,8 +23,8 @@ static bool VerifyConcatenationMapContinuity(const std::multimap<u64, VirtualFil
     return map.begin()->first == 0;
 }
 
-ConcatenatedVfsFile::ConcatenatedVfsFile(std::vector<VirtualFile> files_, std::string name)
-    : name(std::move(name)) {
+ConcatenatedVfsFile::ConcatenatedVfsFile(std::vector<VirtualFile> files_, std::string name_)
+    : name(std::move(name_)) {
     std::size_t next_offset = 0;
     for (const auto& file : files_) {
         files.emplace(next_offset, file);
@@ -32,8 +32,8 @@ ConcatenatedVfsFile::ConcatenatedVfsFile(std::vector<VirtualFile> files_, std::s
     }
 }
 
-ConcatenatedVfsFile::ConcatenatedVfsFile(std::multimap<u64, VirtualFile> files_, std::string name)
-    : files(std::move(files_)), name(std::move(name)) {
+ConcatenatedVfsFile::ConcatenatedVfsFile(std::multimap<u64, VirtualFile> files_, std::string name_)
+    : files(std::move(files_)), name(std::move(name_)) {
     ASSERT(VerifyConcatenationMapContinuity(files));
 }
 

--- a/src/core/file_sys/vfs_concat.h
+++ b/src/core/file_sys/vfs_concat.h
@@ -14,8 +14,8 @@ namespace FileSys {
 // Class that wraps multiple vfs files and concatenates them, making reads seamless. Currently
 // read-only.
 class ConcatenatedVfsFile : public VfsFile {
-    ConcatenatedVfsFile(std::vector<VirtualFile> files, std::string name);
-    ConcatenatedVfsFile(std::multimap<u64, VirtualFile> files, std::string name);
+    explicit ConcatenatedVfsFile(std::vector<VirtualFile> files, std::string name_);
+    explicit ConcatenatedVfsFile(std::multimap<u64, VirtualFile> files, std::string name_);
 
 public:
     ~ConcatenatedVfsFile() override;

--- a/src/core/file_sys/vfs_layered.cpp
+++ b/src/core/file_sys/vfs_layered.cpp
@@ -8,8 +8,8 @@
 
 namespace FileSys {
 
-LayeredVfsDirectory::LayeredVfsDirectory(std::vector<VirtualDir> dirs, std::string name)
-    : dirs(std::move(dirs)), name(std::move(name)) {}
+LayeredVfsDirectory::LayeredVfsDirectory(std::vector<VirtualDir> dirs_, std::string name_)
+    : dirs(std::move(dirs_)), name(std::move(name_)) {}
 
 LayeredVfsDirectory::~LayeredVfsDirectory() = default;
 

--- a/src/core/file_sys/vfs_layered.h
+++ b/src/core/file_sys/vfs_layered.h
@@ -13,7 +13,7 @@ namespace FileSys {
 // one and falling back to the one after. The highest priority directory (overwrites all others)
 // should be element 0 in the dirs vector.
 class LayeredVfsDirectory : public VfsDirectory {
-    LayeredVfsDirectory(std::vector<VirtualDir> dirs, std::string name);
+    explicit LayeredVfsDirectory(std::vector<VirtualDir> dirs_, std::string name_);
 
 public:
     ~LayeredVfsDirectory() override;

--- a/src/core/file_sys/vfs_libzip.cpp
+++ b/src/core/file_sys/vfs_libzip.cpp
@@ -3,7 +3,16 @@
 // Refer to the license.txt file included.
 
 #include <string>
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
 #include <zip.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
 #include "common/logging/backend.h"
 #include "core/file_sys/vfs.h"
 #include "core/file_sys/vfs_libzip.h"

--- a/src/core/file_sys/vfs_static.h
+++ b/src/core/file_sys/vfs_static.h
@@ -14,9 +14,9 @@ namespace FileSys {
 
 class StaticVfsFile : public VfsFile {
 public:
-    explicit StaticVfsFile(u8 value, std::size_t size = 0, std::string name = "",
-                           VirtualDir parent = nullptr)
-        : value{value}, size{size}, name{std::move(name)}, parent{std::move(parent)} {}
+    explicit StaticVfsFile(u8 value_, std::size_t size_ = 0, std::string name_ = "",
+                           VirtualDir parent_ = nullptr)
+        : value{value_}, size{size_}, name{std::move(name_)}, parent{std::move(parent_)} {}
 
     std::string GetName() const override {
         return name;

--- a/src/core/file_sys/vfs_vector.cpp
+++ b/src/core/file_sys/vfs_vector.cpp
@@ -7,8 +7,8 @@
 #include "core/file_sys/vfs_vector.h"
 
 namespace FileSys {
-VectorVfsFile::VectorVfsFile(std::vector<u8> initial_data, std::string name, VirtualDir parent)
-    : data(std::move(initial_data)), parent(std::move(parent)), name(std::move(name)) {}
+VectorVfsFile::VectorVfsFile(std::vector<u8> initial_data, std::string name_, VirtualDir parent_)
+    : data(std::move(initial_data)), parent(std::move(parent_)), name(std::move(name_)) {}
 
 VectorVfsFile::~VectorVfsFile() = default;
 

--- a/src/core/file_sys/vfs_vector.h
+++ b/src/core/file_sys/vfs_vector.h
@@ -75,8 +75,8 @@ std::shared_ptr<ArrayVfsFile<Size>> MakeArrayFile(const std::array<u8, Size>& da
 // An implementation of VfsFile that is backed by a vector optionally supplied upon construction
 class VectorVfsFile : public VfsFile {
 public:
-    explicit VectorVfsFile(std::vector<u8> initial_data = {}, std::string name = "",
-                           VirtualDir parent = nullptr);
+    explicit VectorVfsFile(std::vector<u8> initial_data = {}, std::string name_ = "",
+                           VirtualDir parent_ = nullptr);
     ~VectorVfsFile() override;
 
     std::string GetName() const override;

--- a/src/core/frontend/emu_window.cpp
+++ b/src/core/frontend/emu_window.cpp
@@ -26,7 +26,7 @@ public:
 private:
     class Device : public Input::TouchDevice {
     public:
-        explicit Device(std::weak_ptr<TouchState>&& touch_state) : touch_state(touch_state) {}
+        explicit Device(std::weak_ptr<TouchState>&& touch_state_) : touch_state(touch_state_) {}
         Input::TouchStatus GetStatus() const override {
             if (auto state = touch_state.lock()) {
                 std::lock_guard guard{state->mutex};

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -33,8 +33,8 @@ protected:
 public:
     explicit RequestHelperBase(u32* command_buffer) : cmdbuf(command_buffer) {}
 
-    explicit RequestHelperBase(Kernel::HLERequestContext& context)
-        : context(&context), cmdbuf(context.CommandBuffer()) {}
+    explicit RequestHelperBase(Kernel::HLERequestContext& ctx)
+        : context(&ctx), cmdbuf(ctx.CommandBuffer()) {}
 
     void Skip(u32 size_in_words, bool set_to_null) {
         if (set_to_null) {
@@ -71,12 +71,12 @@ public:
         AlwaysMoveHandles = 1,
     };
 
-    explicit ResponseBuilder(Kernel::HLERequestContext& ctx, u32 normal_params_size,
-                             u32 num_handles_to_copy = 0, u32 num_objects_to_move = 0,
+    explicit ResponseBuilder(Kernel::HLERequestContext& ctx, u32 normal_params_size_,
+                             u32 num_handles_to_copy_ = 0, u32 num_objects_to_move_ = 0,
                              Flags flags = Flags::None)
-        : RequestHelperBase(ctx), normal_params_size(normal_params_size),
-          num_handles_to_copy(num_handles_to_copy),
-          num_objects_to_move(num_objects_to_move), kernel{ctx.kernel} {
+        : RequestHelperBase(ctx), normal_params_size(normal_params_size_),
+          num_handles_to_copy(num_handles_to_copy_),
+          num_objects_to_move(num_objects_to_move_), kernel{ctx.kernel} {
 
         memset(cmdbuf, 0, sizeof(u32) * IPC::COMMAND_BUFFER_LENGTH);
 
@@ -110,14 +110,14 @@ public:
 
         ctx.data_size = static_cast<u32>(raw_data_size);
         header.data_size.Assign(static_cast<u32>(raw_data_size));
-        if (num_handles_to_copy || num_handles_to_move) {
+        if (num_handles_to_copy != 0 || num_handles_to_move != 0) {
             header.enable_handle_descriptor.Assign(1);
         }
         PushRaw(header);
 
         if (header.enable_handle_descriptor) {
             IPC::HandleDescriptorHeader handle_descriptor_header{};
-            handle_descriptor_header.num_handles_to_copy.Assign(num_handles_to_copy);
+            handle_descriptor_header.num_handles_to_copy.Assign(num_handles_to_copy_);
             handle_descriptor_header.num_handles_to_move.Assign(num_handles_to_move);
             PushRaw(handle_descriptor_header);
 

--- a/src/core/hle/kernel/global_scheduler_context.cpp
+++ b/src/core/hle/kernel/global_scheduler_context.cpp
@@ -12,8 +12,8 @@
 
 namespace Kernel {
 
-GlobalSchedulerContext::GlobalSchedulerContext(KernelCore& kernel)
-    : kernel{kernel}, scheduler_lock{kernel} {}
+GlobalSchedulerContext::GlobalSchedulerContext(KernelCore& kernel_)
+    : kernel{kernel_}, scheduler_lock{kernel_} {}
 
 GlobalSchedulerContext::~GlobalSchedulerContext() = default;
 

--- a/src/core/hle/kernel/global_scheduler_context.h
+++ b/src/core/hle/kernel/global_scheduler_context.h
@@ -34,7 +34,7 @@ class GlobalSchedulerContext final {
 public:
     using LockType = KAbstractSchedulerLock<KScheduler>;
 
-    explicit GlobalSchedulerContext(KernelCore& kernel);
+    explicit GlobalSchedulerContext(KernelCore& kernel_);
     ~GlobalSchedulerContext();
 
     /// Adds a new thread to the scheduler

--- a/src/core/hle/kernel/k_light_condition_variable.h
+++ b/src/core/hle/kernel/k_light_condition_variable.h
@@ -18,7 +18,8 @@ class KernelCore;
 
 class KLightConditionVariable {
 public:
-    explicit KLightConditionVariable(KernelCore& kernel) : thread_queue(kernel), kernel(kernel) {}
+    explicit KLightConditionVariable(KernelCore& kernel_)
+        : thread_queue(kernel_), kernel(kernel_) {}
 
     void Wait(KLightLock* lock, s64 timeout = -1) {
         WaitImpl(lock, timeout);

--- a/src/core/hle/kernel/k_linked_list.h
+++ b/src/core/hle/kernel/k_linked_list.h
@@ -201,10 +201,10 @@ public:
     }
 
     iterator insert(const_iterator pos, reference ref) {
-        KLinkedListNode* node = KLinkedListNode::Allocate(kernel);
-        ASSERT(node != nullptr);
-        node->Initialize(std::addressof(ref));
-        return iterator(BaseList::insert(pos.m_base_it, *node));
+        KLinkedListNode* new_node = KLinkedListNode::Allocate(kernel);
+        ASSERT(new_node != nullptr);
+        new_node->Initialize(std::addressof(ref));
+        return iterator(BaseList::insert(pos.m_base_it, *new_node));
     }
 
     void push_back(reference ref) {

--- a/src/core/hle/kernel/k_memory_block_manager.cpp
+++ b/src/core/hle/kernel/k_memory_block_manager.cpp
@@ -7,8 +7,8 @@
 
 namespace Kernel {
 
-KMemoryBlockManager::KMemoryBlockManager(VAddr start_addr, VAddr end_addr)
-    : start_addr{start_addr}, end_addr{end_addr} {
+KMemoryBlockManager::KMemoryBlockManager(VAddr start_addr_, VAddr end_addr_)
+    : start_addr{start_addr_}, end_addr{end_addr_} {
     const u64 num_pages{(end_addr - start_addr) / PageSize};
     memory_block_tree.emplace_back(start_addr, num_pages, KMemoryState::Free,
                                    KMemoryPermission::None, KMemoryAttribute::None);

--- a/src/core/hle/kernel/k_memory_block_manager.h
+++ b/src/core/hle/kernel/k_memory_block_manager.h
@@ -19,7 +19,7 @@ public:
     using const_iterator = MemoryBlockTree::const_iterator;
 
 public:
-    KMemoryBlockManager(VAddr start_addr, VAddr end_addr);
+    KMemoryBlockManager(VAddr start_addr_, VAddr end_addr_);
 
     iterator end() {
         return memory_block_tree.end();

--- a/src/core/hle/kernel/k_page_linked_list.h
+++ b/src/core/hle/kernel/k_page_linked_list.h
@@ -17,7 +17,7 @@ class KPageLinkedList final {
 public:
     class Node final {
     public:
-        constexpr Node(u64 addr, std::size_t num_pages) : addr{addr}, num_pages{num_pages} {}
+        constexpr Node(u64 addr_, std::size_t num_pages_) : addr{addr_}, num_pages{num_pages_} {}
 
         constexpr u64 GetAddress() const {
             return addr;

--- a/src/core/hle/kernel/k_page_table.cpp
+++ b/src/core/hle/kernel/k_page_table.cpp
@@ -58,7 +58,7 @@ constexpr std::size_t GetSizeInRange(const KMemoryInfo& info, VAddr start, VAddr
 
 } // namespace
 
-KPageTable::KPageTable(Core::System& system) : system{system} {}
+KPageTable::KPageTable(Core::System& system_) : system{system_} {}
 
 ResultCode KPageTable::InitializeForProcess(FileSys::ProgramAddressSpaceType as_type,
                                             bool enable_aslr, VAddr code_addr,
@@ -906,8 +906,8 @@ ResultCode KPageTable::LockForDeviceAddressSpace(VAddr addr, std::size_t size) {
 
     block_manager->UpdateLock(
         addr, size / PageSize,
-        [](KMemoryBlockManager::iterator block, KMemoryPermission perm) {
-            block->ShareToDevice(perm);
+        [](KMemoryBlockManager::iterator block, KMemoryPermission permission) {
+            block->ShareToDevice(permission);
         },
         perm);
 
@@ -929,8 +929,8 @@ ResultCode KPageTable::UnlockForDeviceAddressSpace(VAddr addr, std::size_t size)
 
     block_manager->UpdateLock(
         addr, size / PageSize,
-        [](KMemoryBlockManager::iterator block, KMemoryPermission perm) {
-            block->UnshareToDevice(perm);
+        [](KMemoryBlockManager::iterator block, KMemoryPermission permission) {
+            block->UnshareToDevice(permission);
         },
         perm);
 

--- a/src/core/hle/kernel/k_page_table.h
+++ b/src/core/hle/kernel/k_page_table.h
@@ -24,7 +24,7 @@ class KMemoryBlockManager;
 
 class KPageTable final : NonCopyable {
 public:
-    explicit KPageTable(Core::System& system);
+    explicit KPageTable(Core::System& system_);
 
     ResultCode InitializeForProcess(FileSys::ProgramAddressSpaceType as_type, bool enable_aslr,
                                     VAddr code_addr, std::size_t code_size,

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -607,7 +607,7 @@ void KScheduler::YieldToAnyThread(KernelCore& kernel) {
     }
 }
 
-KScheduler::KScheduler(Core::System& system, s32 core_id) : system(system), core_id(core_id) {
+KScheduler::KScheduler(Core::System& system_, s32 core_id_) : system{system_}, core_id{core_id_} {
     switch_fiber = std::make_shared<Common::Fiber>(OnSwitch, this);
     state.needs_scheduling.store(true);
     state.interrupt_task_thread_runnable = false;

--- a/src/core/hle/kernel/k_scheduler.h
+++ b/src/core/hle/kernel/k_scheduler.h
@@ -30,7 +30,7 @@ class KThread;
 
 class KScheduler final {
 public:
-    explicit KScheduler(Core::System& system, s32 core_id);
+    explicit KScheduler(Core::System& system_, s32 core_id_);
     ~KScheduler();
 
     /// Reschedules to the next available thread (call after current thread is suspended)

--- a/src/core/hle/kernel/k_scoped_scheduler_lock_and_sleep.h
+++ b/src/core/hle/kernel/k_scoped_scheduler_lock_and_sleep.h
@@ -17,8 +17,8 @@ namespace Kernel {
 
 class [[nodiscard]] KScopedSchedulerLockAndSleep {
 public:
-    explicit KScopedSchedulerLockAndSleep(KernelCore & kernel, KThread * t, s64 timeout)
-        : kernel(kernel), thread(t), timeout_tick(timeout) {
+    explicit KScopedSchedulerLockAndSleep(KernelCore & kernel_, KThread * t, s64 timeout)
+        : kernel(kernel_), thread(t), timeout_tick(timeout) {
         // Lock the scheduler.
         kernel.GlobalSchedulerContext().scheduler_lock.Lock();
     }

--- a/src/core/hle/kernel/k_thread_queue.h
+++ b/src/core/hle/kernel/k_thread_queue.h
@@ -10,7 +10,7 @@ namespace Kernel {
 
 class KThreadQueue {
 public:
-    explicit KThreadQueue(KernelCore& kernel) : kernel{kernel} {}
+    explicit KThreadQueue(KernelCore& kernel_) : kernel{kernel_} {}
 
     bool IsEmpty() const {
         return wait_list.empty();

--- a/src/core/hle/kernel/physical_core.cpp
+++ b/src/core/hle/kernel/physical_core.cpp
@@ -13,10 +13,10 @@
 
 namespace Kernel {
 
-PhysicalCore::PhysicalCore(std::size_t core_index, Core::System& system,
-                           Kernel::KScheduler& scheduler, Core::CPUInterrupts& interrupts)
-    : core_index{core_index}, system{system}, scheduler{scheduler},
-      interrupts{interrupts}, guard{std::make_unique<Common::SpinLock>()} {}
+PhysicalCore::PhysicalCore(std::size_t core_index_, Core::System& system_, KScheduler& scheduler_,
+                           Core::CPUInterrupts& interrupts_)
+    : core_index{core_index_}, system{system_}, scheduler{scheduler_},
+      interrupts{interrupts_}, guard{std::make_unique<Common::SpinLock>()} {}
 
 PhysicalCore::~PhysicalCore() = default;
 

--- a/src/core/hle/kernel/physical_core.h
+++ b/src/core/hle/kernel/physical_core.h
@@ -28,8 +28,8 @@ namespace Kernel {
 
 class PhysicalCore {
 public:
-    PhysicalCore(std::size_t core_index, Core::System& system, Kernel::KScheduler& scheduler,
-                 Core::CPUInterrupts& interrupts);
+    PhysicalCore(std::size_t core_index_, Core::System& system_, KScheduler& scheduler_,
+                 Core::CPUInterrupts& interrupts_);
     ~PhysicalCore();
 
     PhysicalCore(const PhysicalCore&) = delete;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -819,10 +819,10 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, Handle
             return RESULT_SUCCESS;
         }
 
-        Handle handle{};
-        R_TRY(handle_table.Add(&handle, resource_limit));
+        Handle resource_handle{};
+        R_TRY(handle_table.Add(&resource_handle, resource_limit));
 
-        *result = handle;
+        *result = resource_handle;
         return RESULT_SUCCESS;
     }
 

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -56,7 +56,7 @@ enum class ErrorModule : u32 {
     PCIe = 120,
     Friends = 121,
     BCAT = 122,
-    SSL = 123,
+    SSLSrv = 123,
     Account = 124,
     News = 125,
     Mii = 126,

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -833,7 +833,7 @@ IStorageImpl::~IStorageImpl() = default;
 
 class StorageDataImpl final : public IStorageImpl {
 public:
-    explicit StorageDataImpl(std::vector<u8>&& buffer) : buffer{std::move(buffer)} {}
+    explicit StorageDataImpl(std::vector<u8>&& buffer_) : buffer{std::move(buffer_)} {}
 
     std::vector<u8>& GetData() override {
         return buffer;
@@ -1513,9 +1513,9 @@ void IApplicationFunctions::GetDisplayVersion(Kernel::HLERequestContext& ctx) {
 
         const FileSys::PatchManager pm{title_id, system.GetFileSystemController(),
                                        system.GetContentProvider()};
-        auto res = pm.GetControlMetadata();
-        if (res.first != nullptr) {
-            return res;
+        auto metadata = pm.GetControlMetadata();
+        if (metadata.first != nullptr) {
+            return metadata;
         }
 
         const FileSys::PatchManager pm_update{FileSys::GetUpdateTitleID(title_id),
@@ -1550,9 +1550,9 @@ void IApplicationFunctions::GetDesiredLanguage(Kernel::HLERequestContext& ctx) {
 
         const FileSys::PatchManager pm{title_id, system.GetFileSystemController(),
                                        system.GetContentProvider()};
-        auto res = pm.GetControlMetadata();
-        if (res.first != nullptr) {
-            return res;
+        auto metadata = pm.GetControlMetadata();
+        if (metadata.first != nullptr) {
+            return metadata;
         }
 
         const FileSys::PatchManager pm_update{FileSys::GetUpdateTitleID(title_id),

--- a/src/core/hle/service/apm/controller.cpp
+++ b/src/core/hle/service/apm/controller.cpp
@@ -15,11 +15,11 @@ namespace Service::APM {
 
 constexpr auto DEFAULT_PERFORMANCE_CONFIGURATION = PerformanceConfiguration::Config7;
 
-Controller::Controller(Core::Timing::CoreTiming& core_timing)
-    : core_timing{core_timing}, configs{
-                                    {PerformanceMode::Handheld, DEFAULT_PERFORMANCE_CONFIGURATION},
-                                    {PerformanceMode::Docked, DEFAULT_PERFORMANCE_CONFIGURATION},
-                                } {}
+Controller::Controller(Core::Timing::CoreTiming& core_timing_)
+    : core_timing{core_timing_}, configs{
+                                     {PerformanceMode::Handheld, DEFAULT_PERFORMANCE_CONFIGURATION},
+                                     {PerformanceMode::Docked, DEFAULT_PERFORMANCE_CONFIGURATION},
+                                 } {}
 
 Controller::~Controller() = default;
 

--- a/src/core/hle/service/apm/controller.h
+++ b/src/core/hle/service/apm/controller.h
@@ -50,7 +50,7 @@ enum class PerformanceMode : u8 {
 // system during times of high load -- this simply maps to different PerformanceConfigs to use.
 class Controller {
 public:
-    explicit Controller(Core::Timing::CoreTiming& core_timing);
+    explicit Controller(Core::Timing::CoreTiming& core_timing_);
     ~Controller();
 
     void SetPerformanceConfiguration(PerformanceMode mode, PerformanceConfiguration config);

--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -362,7 +362,7 @@ void AudRenU::GetAudioRendererWorkBufferSize(Kernel::HLERequestContext& ctx) {
     static constexpr u64 max_perf_detail_entries = 100;
 
     // Size of the data structure representing the bulk of the voice-related state.
-    static constexpr u64 voice_state_size = 0x100;
+    static constexpr u64 voice_state_size_bytes = 0x100;
 
     // Size of the upsampler manager data structure
     constexpr u64 upsampler_manager_size = 0x48;
@@ -449,7 +449,8 @@ void AudRenU::GetAudioRendererWorkBufferSize(Kernel::HLERequestContext& ctx) {
         size += Common::AlignUp(voice_info_size * params.voice_count, info_field_alignment_size);
         size +=
             Common::AlignUp(voice_resource_size * params.voice_count, info_field_alignment_size);
-        size += Common::AlignUp(voice_state_size * params.voice_count, info_field_alignment_size);
+        size +=
+            Common::AlignUp(voice_state_size_bytes * params.voice_count, info_field_alignment_size);
         return size;
     };
 

--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -50,8 +50,8 @@ public:
         Enabled,
     };
 
-    explicit OpusDecoderState(OpusDecoderPtr decoder, u32 sample_rate, u32 channel_count)
-        : decoder{std::move(decoder)}, sample_rate{sample_rate}, channel_count{channel_count} {}
+    explicit OpusDecoderState(OpusDecoderPtr decoder_, u32 sample_rate_, u32 channel_count_)
+        : decoder{std::move(decoder_)}, sample_rate{sample_rate_}, channel_count{channel_count_} {}
 
     // Decodes interleaved Opus packets. Optionally allows reporting time taken to
     // perform the decoding, as well as any relevant extra behavior.
@@ -160,9 +160,9 @@ private:
 
 class IHardwareOpusDecoderManager final : public ServiceFramework<IHardwareOpusDecoderManager> {
 public:
-    explicit IHardwareOpusDecoderManager(Core::System& system_, OpusDecoderState decoder_state)
+    explicit IHardwareOpusDecoderManager(Core::System& system_, OpusDecoderState decoder_state_)
         : ServiceFramework{system_, "IHardwareOpusDecoderManager"}, decoder_state{
-                                                                        std::move(decoder_state)} {
+                                                                        std::move(decoder_state_)} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &IHardwareOpusDecoderManager::DecodeInterleavedOld, "DecodeInterleavedOld"},

--- a/src/core/hle/service/bcat/backend/boxcat.cpp
+++ b/src/core/hle/service/bcat/backend/boxcat.cpp
@@ -3,9 +3,18 @@
 // Refer to the license.txt file included.
 
 #include <fmt/ostream.h>
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wshadow"
+#endif
 #include <httplib.h>
 #include <mbedtls/sha256.h>
 #include <nlohmann/json.hpp>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
 #include "common/hex_util.h"
 #include "common/logging/backend.h"
 #include "common/logging/log.h"
@@ -178,8 +187,8 @@ bool VfsRawCopyDProgress(FileSys::VirtualDir src, FileSys::VirtualDir dest,
 
 class Boxcat::Client {
 public:
-    Client(std::string path, u64 title_id, u64 build_id)
-        : path(std::move(path)), title_id(title_id), build_id(build_id) {}
+    Client(std::string path_, u64 title_id_, u64 build_id_)
+        : path(std::move(path_)), title_id(title_id_), build_id(build_id_) {}
 
     DownloadResult DownloadDataZip() {
         return DownloadInternal(fmt::format(BOXCAT_PATHNAME_DATA, title_id), TIMEOUT_SECONDS,

--- a/src/core/hle/service/hid/controllers/controller_base.cpp
+++ b/src/core/hle/service/hid/controllers/controller_base.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::HID {
 
-ControllerBase::ControllerBase(Core::System& system) : system(system) {}
+ControllerBase::ControllerBase(Core::System& system_) : system(system_) {}
 ControllerBase::~ControllerBase() = default;
 
 void ControllerBase::ActivateController() {

--- a/src/core/hle/service/hid/controllers/controller_base.h
+++ b/src/core/hle/service/hid/controllers/controller_base.h
@@ -18,7 +18,7 @@ class System;
 namespace Service::HID {
 class ControllerBase {
 public:
-    explicit ControllerBase(Core::System& system);
+    explicit ControllerBase(Core::System& system_);
     virtual ~ControllerBase();
 
     // Called when the controller is initialized

--- a/src/core/hle/service/hid/controllers/gesture.h
+++ b/src/core/hle/service/hid/controllers/gesture.h
@@ -128,32 +128,34 @@ private:
     void UpdateExistingGesture(GestureProperties& gesture, TouchType& type, f32 time_difference);
 
     // Terminates exiting gesture
-    void EndGesture(GestureProperties& gesture, GestureProperties& last_gesture, TouchType& type,
-                    Attribute& attributes, f32 time_difference);
+    void EndGesture(GestureProperties& gesture, GestureProperties& last_gesture_props,
+                    TouchType& type, Attribute& attributes, f32 time_difference);
 
     // Set current event to a tap event
-    void SetTapEvent(GestureProperties& gesture, GestureProperties& last_gesture, TouchType& type,
-                     Attribute& attributes);
+    void SetTapEvent(GestureProperties& gesture, GestureProperties& last_gesture_props,
+                     TouchType& type, Attribute& attributes);
 
     // Calculates and set the extra parameters related to a pan event
-    void UpdatePanEvent(GestureProperties& gesture, GestureProperties& last_gesture,
+    void UpdatePanEvent(GestureProperties& gesture, GestureProperties& last_gesture_props,
                         TouchType& type, f32 time_difference);
 
     // Terminates the pan event
-    void EndPanEvent(GestureProperties& gesture, GestureProperties& last_gesture, TouchType& type,
-                     f32 time_difference);
+    void EndPanEvent(GestureProperties& gesture, GestureProperties& last_gesture_props,
+                     TouchType& type, f32 time_difference);
 
     // Set current event to a swipe event
-    void SetSwipeEvent(GestureProperties& gesture, GestureProperties& last_gesture,
+    void SetSwipeEvent(GestureProperties& gesture, GestureProperties& last_gesture_props,
                        TouchType& type);
 
-    // Returns an unused finger id, if there is no fingers avaliable MAX_FINGERS will be returned
+    // Returns an unused finger id, if there is no fingers available std::nullopt is returned.
     std::optional<size_t> GetUnusedFingerID() const;
 
-    /** If the touch is new it tries to assing a new finger id, if there is no fingers avaliable no
+    /**
+     * If the touch is new it tries to assign a new finger id, if there is no fingers available no
      * changes will be made. Updates the coordinates if the finger id it's already set. If the touch
      * ends delays the output by one frame to set the end_touch flag before finally freeing the
-     * finger id */
+     * finger id
+     */
     size_t UpdateTouchInputEvent(const std::tuple<float, float, bool>& touch_input,
                                  size_t finger_id);
 

--- a/src/core/hle/service/mii/manager.h
+++ b/src/core/hle/service/mii/manager.h
@@ -89,7 +89,7 @@ static_assert(std::has_unique_object_representations_v<MiiInfo>,
 #pragma pack(push, 4)
 
 struct MiiInfoElement {
-    MiiInfoElement(const MiiInfo& info, Source source) : info{info}, source{source} {}
+    MiiInfoElement(const MiiInfo& info_, Source source_) : info{info_}, source{source_} {}
 
     MiiInfo info{};
     Source source{};

--- a/src/core/hle/service/mii/mii.cpp
+++ b/src/core/hle/service/mii/mii.cpp
@@ -253,8 +253,8 @@ private:
 
 class MiiDBModule final : public ServiceFramework<MiiDBModule> {
 public:
-    explicit MiiDBModule(Core::System& system_, const char* name)
-        : ServiceFramework{system_, name} {
+    explicit MiiDBModule(Core::System& system_, const char* name_)
+        : ServiceFramework{system_, name_} {
         // clang-format off
         static const FunctionInfo functions[] = {
             {0, &MiiDBModule::GetDatabaseService, "GetDatabaseService"},

--- a/src/core/hle/service/nvdrv/devices/nvdevice.h
+++ b/src/core/hle/service/nvdrv/devices/nvdevice.h
@@ -21,7 +21,7 @@ namespace Service::Nvidia::Devices {
 /// implement the ioctl interface.
 class nvdevice {
 public:
-    explicit nvdevice(Core::System& system) : system{system} {}
+    explicit nvdevice(Core::System& system_) : system{system_} {}
     virtual ~nvdevice() = default;
 
     /**

--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.h
@@ -48,13 +48,13 @@ private:
     public:
         constexpr BufferMap() = default;
 
-        constexpr BufferMap(GPUVAddr start_addr, std::size_t size)
-            : start_addr{start_addr}, end_addr{start_addr + size} {}
+        constexpr BufferMap(GPUVAddr start_addr_, std::size_t size_)
+            : start_addr{start_addr_}, end_addr{start_addr_ + size_} {}
 
-        constexpr BufferMap(GPUVAddr start_addr, std::size_t size, VAddr cpu_addr,
-                            bool is_allocated)
-            : start_addr{start_addr}, end_addr{start_addr + size}, cpu_addr{cpu_addr},
-              is_allocated{is_allocated} {}
+        constexpr BufferMap(GPUVAddr start_addr_, std::size_t size_, VAddr cpu_addr_,
+                            bool is_allocated_)
+            : start_addr{start_addr_}, end_addr{start_addr_ + size_}, cpu_addr{cpu_addr_},
+              is_allocated{is_allocated_} {}
 
         constexpr VAddr StartAddr() const {
             return start_addr;

--- a/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.h
@@ -27,13 +27,13 @@ protected:
     public:
         constexpr BufferMap() = default;
 
-        constexpr BufferMap(GPUVAddr start_addr, std::size_t size)
-            : start_addr{start_addr}, end_addr{start_addr + size} {}
+        constexpr BufferMap(GPUVAddr start_addr_, std::size_t size_)
+            : start_addr{start_addr_}, end_addr{start_addr_ + size_} {}
 
-        constexpr BufferMap(GPUVAddr start_addr, std::size_t size, VAddr cpu_addr,
-                            bool is_allocated)
-            : start_addr{start_addr}, end_addr{start_addr + size}, cpu_addr{cpu_addr},
-              is_allocated{is_allocated} {}
+        constexpr BufferMap(GPUVAddr start_addr_, std::size_t size_, VAddr cpu_addr_,
+                            bool is_allocated_)
+            : start_addr{start_addr_}, end_addr{start_addr_ + size_}, cpu_addr{cpu_addr_},
+              is_allocated{is_allocated_} {}
 
         constexpr VAddr StartAddr() const {
             return start_addr;

--- a/src/core/hle/service/nvdrv/syncpoint_manager.cpp
+++ b/src/core/hle/service/nvdrv/syncpoint_manager.cpp
@@ -8,7 +8,7 @@
 
 namespace Service::Nvidia {
 
-SyncpointManager::SyncpointManager(Tegra::GPU& gpu) : gpu{gpu} {}
+SyncpointManager::SyncpointManager(Tegra::GPU& gpu_) : gpu{gpu_} {}
 
 SyncpointManager::~SyncpointManager() = default;
 

--- a/src/core/hle/service/nvdrv/syncpoint_manager.h
+++ b/src/core/hle/service/nvdrv/syncpoint_manager.h
@@ -18,7 +18,7 @@ namespace Service::Nvidia {
 
 class SyncpointManager final {
 public:
-    explicit SyncpointManager(Tegra::GPU& gpu);
+    explicit SyncpointManager(Tegra::GPU& gpu_);
     ~SyncpointManager();
 
     /**

--- a/src/core/hle/service/nvflinger/buffer_queue.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue.cpp
@@ -13,8 +13,8 @@
 
 namespace Service::NVFlinger {
 
-BufferQueue::BufferQueue(Kernel::KernelCore& kernel, u32 id, u64 layer_id)
-    : id(id), layer_id(layer_id), buffer_wait_event{kernel} {
+BufferQueue::BufferQueue(Kernel::KernelCore& kernel, u32 id_, u64 layer_id_)
+    : id(id_), layer_id(layer_id_), buffer_wait_event{kernel} {
     Kernel::KAutoObject::Create(std::addressof(buffer_wait_event));
     buffer_wait_event.Initialize("BufferQueue:WaitEvent");
 }

--- a/src/core/hle/service/nvflinger/buffer_queue.h
+++ b/src/core/hle/service/nvflinger/buffer_queue.h
@@ -54,7 +54,7 @@ public:
         NativeWindowFormat = 2,
     };
 
-    explicit BufferQueue(Kernel::KernelCore& kernel, u32 id, u64 layer_id);
+    explicit BufferQueue(Kernel::KernelCore& kernel, u32 id_, u64 layer_id_);
     ~BufferQueue();
 
     enum class BufferTransformFlags : u32 {

--- a/src/core/hle/service/nvflinger/nvflinger.cpp
+++ b/src/core/hle/service/nvflinger/nvflinger.cpp
@@ -61,7 +61,7 @@ void NVFlinger::SplitVSync() {
     }
 }
 
-NVFlinger::NVFlinger(Core::System& system) : system(system) {
+NVFlinger::NVFlinger(Core::System& system_) : system(system_) {
     displays.emplace_back(0, "Default", system);
     displays.emplace_back(1, "External", system);
     displays.emplace_back(2, "Edid", system);

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -45,7 +45,7 @@ class BufferQueue;
 
 class NVFlinger final {
 public:
-    explicit NVFlinger(Core::System& system);
+    explicit NVFlinger(Core::System& system_);
     ~NVFlinger();
 
     /// Sets the NVDrv module instance to use to send buffers to the GPU.

--- a/src/core/hle/service/pctl/pctl.cpp
+++ b/src/core/hle/service/pctl/pctl.cpp
@@ -7,8 +7,8 @@
 namespace Service::PCTL {
 
 PCTL::PCTL(Core::System& system_, std::shared_ptr<Module> module_, const char* name,
-           Capability capability)
-    : Interface{system_, std::move(module_), name, capability} {
+           Capability capability_)
+    : Interface{system_, std::move(module_), name, capability_} {
     static const FunctionInfo functions[] = {
         {0, &PCTL::CreateService, "CreateService"},
         {1, &PCTL::CreateServiceWithoutInitialize, "CreateServiceWithoutInitialize"},

--- a/src/core/hle/service/pctl/pctl.h
+++ b/src/core/hle/service/pctl/pctl.h
@@ -15,7 +15,7 @@ namespace Service::PCTL {
 class PCTL final : public Module::Interface {
 public:
     explicit PCTL(Core::System& system_, std::shared_ptr<Module> module_, const char* name,
-                  Capability capability);
+                  Capability capability_);
     ~PCTL() override;
 };
 

--- a/src/core/hle/service/pm/pm.cpp
+++ b/src/core/hle/service/pm/pm.cpp
@@ -31,8 +31,8 @@ std::optional<Kernel::KProcess*> SearchProcessList(
 
 void GetApplicationPidGeneric(Kernel::HLERequestContext& ctx,
                               const std::vector<Kernel::KProcess*>& process_list) {
-    const auto process = SearchProcessList(process_list, [](const auto& process) {
-        return process->GetProcessID() == Kernel::KProcess::ProcessIDMin;
+    const auto process = SearchProcessList(process_list, [](const auto& proc) {
+        return proc->GetProcessID() == Kernel::KProcess::ProcessIDMin;
     });
 
     IPC::ResponseBuilder rb{ctx, 4};
@@ -100,8 +100,8 @@ private:
         LOG_DEBUG(Service_PM, "called, title_id={:016X}", title_id);
 
         const auto process =
-            SearchProcessList(kernel.GetProcessList(), [title_id](const auto& process) {
-                return process->GetTitleID() == title_id;
+            SearchProcessList(kernel.GetProcessList(), [title_id](const auto& proc) {
+                return proc->GetTitleID() == title_id;
             });
 
         if (!process.has_value()) {
@@ -140,8 +140,8 @@ private:
 
         LOG_DEBUG(Service_PM, "called, process_id={:016X}", process_id);
 
-        const auto process = SearchProcessList(process_list, [process_id](const auto& process) {
-            return process->GetProcessID() == process_id;
+        const auto process = SearchProcessList(process_list, [process_id](const auto& proc) {
+            return proc->GetProcessID() == process_id;
         });
 
         if (!process.has_value()) {

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -155,17 +155,17 @@ protected:
         /**
          * Constructs a FunctionInfo for a function.
          *
-         * @param expected_header request header in the command buffer which will trigger dispatch
+         * @param expected_header_ request header in the command buffer which will trigger dispatch
          *     to this handler
-         * @param handler_callback member function in this service which will be called to handle
+         * @param handler_callback_ member function in this service which will be called to handle
          *     the request
-         * @param name human-friendly name for the request. Used mostly for logging purposes.
+         * @param name_ human-friendly name for the request. Used mostly for logging purposes.
          */
-        FunctionInfo(u32 expected_header, HandlerFnP<Self> handler_callback, const char* name)
+        FunctionInfo(u32 expected_header_, HandlerFnP<Self> handler_callback_, const char* name_)
             : FunctionInfoBase{
-                  expected_header,
+                  expected_header_,
                   // Type-erase member function pointer by casting it down to the base class.
-                  static_cast<HandlerFnP<ServiceFrameworkBase>>(handler_callback), name} {}
+                  static_cast<HandlerFnP<ServiceFrameworkBase>>(handler_callback_), name_} {}
     };
 
     /**

--- a/src/core/hle/service/time/ephemeral_network_system_clock_core.h
+++ b/src/core/hle/service/time/ephemeral_network_system_clock_core.h
@@ -10,8 +10,8 @@ namespace Service::Time::Clock {
 
 class EphemeralNetworkSystemClockCore final : public SystemClockCore {
 public:
-    explicit EphemeralNetworkSystemClockCore(SteadyClockCore& steady_clock_core)
-        : SystemClockCore{steady_clock_core} {}
+    explicit EphemeralNetworkSystemClockCore(SteadyClockCore& steady_clock_core_)
+        : SystemClockCore{steady_clock_core_} {}
 };
 
 } // namespace Service::Time::Clock

--- a/src/core/hle/service/time/local_system_clock_context_writer.h
+++ b/src/core/hle/service/time/local_system_clock_context_writer.h
@@ -12,8 +12,8 @@ namespace Service::Time::Clock {
 
 class LocalSystemClockContextWriter final : public SystemClockContextUpdateCallback {
 public:
-    explicit LocalSystemClockContextWriter(SharedMemory& shared_memory)
-        : SystemClockContextUpdateCallback{}, shared_memory{shared_memory} {}
+    explicit LocalSystemClockContextWriter(SharedMemory& shared_memory_)
+        : SystemClockContextUpdateCallback{}, shared_memory{shared_memory_} {}
 
 protected:
     ResultCode Update() override {

--- a/src/core/hle/service/time/network_system_clock_context_writer.h
+++ b/src/core/hle/service/time/network_system_clock_context_writer.h
@@ -12,8 +12,8 @@ namespace Service::Time::Clock {
 
 class NetworkSystemClockContextWriter final : public SystemClockContextUpdateCallback {
 public:
-    explicit NetworkSystemClockContextWriter(SharedMemory& shared_memory)
-        : SystemClockContextUpdateCallback{}, shared_memory{shared_memory} {}
+    explicit NetworkSystemClockContextWriter(SharedMemory& shared_memory_)
+        : SystemClockContextUpdateCallback{}, shared_memory{shared_memory_} {}
 
 protected:
     ResultCode Update() override {

--- a/src/core/hle/service/time/standard_local_system_clock_core.h
+++ b/src/core/hle/service/time/standard_local_system_clock_core.h
@@ -10,8 +10,8 @@ namespace Service::Time::Clock {
 
 class StandardLocalSystemClockCore final : public SystemClockCore {
 public:
-    explicit StandardLocalSystemClockCore(SteadyClockCore& steady_clock_core)
-        : SystemClockCore{steady_clock_core} {}
+    explicit StandardLocalSystemClockCore(SteadyClockCore& steady_clock_core_)
+        : SystemClockCore{steady_clock_core_} {}
 };
 
 } // namespace Service::Time::Clock

--- a/src/core/hle/service/time/standard_network_system_clock_core.h
+++ b/src/core/hle/service/time/standard_network_system_clock_core.h
@@ -16,21 +16,21 @@ namespace Service::Time::Clock {
 
 class StandardNetworkSystemClockCore final : public SystemClockCore {
 public:
-    explicit StandardNetworkSystemClockCore(SteadyClockCore& steady_clock_core)
-        : SystemClockCore{steady_clock_core} {}
+    explicit StandardNetworkSystemClockCore(SteadyClockCore& steady_clock_core_)
+        : SystemClockCore{steady_clock_core_} {}
 
     void SetStandardNetworkClockSufficientAccuracy(TimeSpanType value) {
         standard_network_clock_sufficient_accuracy = value;
     }
 
     bool IsStandardNetworkSystemClockAccuracySufficient(Core::System& system) const {
-        SystemClockContext context{};
-        if (GetClockContext(system, context) != RESULT_SUCCESS) {
+        SystemClockContext clock_ctx{};
+        if (GetClockContext(system, clock_ctx) != RESULT_SUCCESS) {
             return {};
         }
 
         s64 span{};
-        if (context.steady_time_point.GetSpanBetween(
+        if (clock_ctx.steady_time_point.GetSpanBetween(
                 GetSteadyClockCore().GetCurrentTimePoint(system), span) != RESULT_SUCCESS) {
             return {};
         }

--- a/src/core/hle/service/time/standard_user_system_clock_core.cpp
+++ b/src/core/hle/service/time/standard_user_system_clock_core.cpp
@@ -11,13 +11,13 @@
 namespace Service::Time::Clock {
 
 StandardUserSystemClockCore::StandardUserSystemClockCore(
-    StandardLocalSystemClockCore& local_system_clock_core,
-    StandardNetworkSystemClockCore& network_system_clock_core, Core::System& system)
-    : SystemClockCore(local_system_clock_core.GetSteadyClockCore()),
-      local_system_clock_core{local_system_clock_core},
-      network_system_clock_core{network_system_clock_core}, auto_correction_enabled{},
+    StandardLocalSystemClockCore& local_system_clock_core_,
+    StandardNetworkSystemClockCore& network_system_clock_core_, Core::System& system_)
+    : SystemClockCore(local_system_clock_core_.GetSteadyClockCore()),
+      local_system_clock_core{local_system_clock_core_},
+      network_system_clock_core{network_system_clock_core_},
       auto_correction_time{SteadyClockTimePoint::GetRandom()}, auto_correction_event{
-                                                                   system.Kernel()} {
+                                                                   system_.Kernel()} {
     Kernel::KAutoObject::Create(std::addressof(auto_correction_event));
     auto_correction_event.Initialize("StandardUserSystemClockCore:AutoCorrectionEvent");
 }
@@ -35,13 +35,13 @@ ResultCode StandardUserSystemClockCore::SetAutomaticCorrectionEnabled(Core::Syst
 }
 
 ResultCode StandardUserSystemClockCore::GetClockContext(Core::System& system,
-                                                        SystemClockContext& context) const {
+                                                        SystemClockContext& ctx) const {
     if (const ResultCode result{ApplyAutomaticCorrection(system, false)};
         result != RESULT_SUCCESS) {
         return result;
     }
 
-    return local_system_clock_core.GetClockContext(system, context);
+    return local_system_clock_core.GetClockContext(system, ctx);
 }
 
 ResultCode StandardUserSystemClockCore::Flush(const SystemClockContext&) {
@@ -64,13 +64,13 @@ ResultCode StandardUserSystemClockCore::ApplyAutomaticCorrection(Core::System& s
         return ERROR_UNINITIALIZED_CLOCK;
     }
 
-    SystemClockContext context{};
-    if (const ResultCode result{network_system_clock_core.GetClockContext(system, context)};
+    SystemClockContext ctx{};
+    if (const ResultCode result{network_system_clock_core.GetClockContext(system, ctx)};
         result != RESULT_SUCCESS) {
         return result;
     }
 
-    local_system_clock_core.SetClockContext(context);
+    local_system_clock_core.SetClockContext(ctx);
 
     return RESULT_SUCCESS;
 }

--- a/src/core/hle/service/time/standard_user_system_clock_core.h
+++ b/src/core/hle/service/time/standard_user_system_clock_core.h
@@ -23,13 +23,13 @@ class StandardNetworkSystemClockCore;
 
 class StandardUserSystemClockCore final : public SystemClockCore {
 public:
-    StandardUserSystemClockCore(StandardLocalSystemClockCore& local_system_clock_core,
-                                StandardNetworkSystemClockCore& network_system_clock_core,
-                                Core::System& system);
+    StandardUserSystemClockCore(StandardLocalSystemClockCore& local_system_clock_core_,
+                                StandardNetworkSystemClockCore& network_system_clock_core_,
+                                Core::System& system_);
 
     ResultCode SetAutomaticCorrectionEnabled(Core::System& system, bool value);
 
-    ResultCode GetClockContext(Core::System& system, SystemClockContext& context) const override;
+    ResultCode GetClockContext(Core::System& system, SystemClockContext& ctx) const override;
 
     bool IsAutomaticCorrectionEnabled() const {
         return auto_correction_enabled;

--- a/src/core/hle/service/time/system_clock_core.cpp
+++ b/src/core/hle/service/time/system_clock_core.cpp
@@ -8,8 +8,8 @@
 
 namespace Service::Time::Clock {
 
-SystemClockCore::SystemClockCore(SteadyClockCore& steady_clock_core)
-    : steady_clock_core{steady_clock_core} {
+SystemClockCore::SystemClockCore(SteadyClockCore& steady_clock_core_)
+    : steady_clock_core{steady_clock_core_} {
     context.steady_time_point.clock_source_id = steady_clock_core.GetClockSourceId();
 }
 

--- a/src/core/hle/service/time/system_clock_core.h
+++ b/src/core/hle/service/time/system_clock_core.h
@@ -21,7 +21,7 @@ class SystemClockContextUpdateCallback;
 
 class SystemClockCore {
 public:
-    explicit SystemClockCore(SteadyClockCore& steady_clock_core);
+    explicit SystemClockCore(SteadyClockCore& steady_clock_core_);
     virtual ~SystemClockCore();
 
     SteadyClockCore& GetSteadyClockCore() const {

--- a/src/core/hle/service/time/time_manager.cpp
+++ b/src/core/hle/service/time/time_manager.cpp
@@ -223,7 +223,7 @@ struct TimeManager::Impl final {
     TimeZone::TimeZoneContentManager time_zone_content_manager;
 };
 
-TimeManager::TimeManager(Core::System& system) : system{system} {}
+TimeManager::TimeManager(Core::System& system_) : system{system_} {}
 
 TimeManager::~TimeManager() = default;
 

--- a/src/core/hle/service/time/time_manager.h
+++ b/src/core/hle/service/time/time_manager.h
@@ -30,7 +30,7 @@ class NetworkSystemClockContextWriter;
 
 class TimeManager final {
 public:
-    explicit TimeManager(Core::System& system);
+    explicit TimeManager(Core::System& system_);
     ~TimeManager();
 
     void Initialize();

--- a/src/core/hle/service/time/time_sharedmemory.cpp
+++ b/src/core/hle/service/time/time_sharedmemory.cpp
@@ -15,7 +15,7 @@ namespace Service::Time {
 
 static constexpr std::size_t SHARED_MEMORY_SIZE{0x1000};
 
-SharedMemory::SharedMemory(Core::System& system) : system(system) {
+SharedMemory::SharedMemory(Core::System& system_) : system(system_) {
     std::memset(system.Kernel().GetTimeSharedMem().GetPointer(), 0, SHARED_MEMORY_SIZE);
 }
 

--- a/src/core/hle/service/time/time_sharedmemory.h
+++ b/src/core/hle/service/time/time_sharedmemory.h
@@ -14,7 +14,7 @@ namespace Service::Time {
 
 class SharedMemory final {
 public:
-    explicit SharedMemory(Core::System& system);
+    explicit SharedMemory(Core::System& system_);
     ~SharedMemory();
 
     // TODO(ogniK): We have to properly simulate memory barriers, how are we going to do this?

--- a/src/core/hle/service/time/time_zone_content_manager.cpp
+++ b/src/core/hle/service/time/time_zone_content_manager.cpp
@@ -68,8 +68,8 @@ static std::vector<std::string> BuildLocationNameCache(Core::System& system) {
     return location_name_cache;
 }
 
-TimeZoneContentManager::TimeZoneContentManager(Core::System& system)
-    : system{system}, location_name_cache{BuildLocationNameCache(system)} {}
+TimeZoneContentManager::TimeZoneContentManager(Core::System& system_)
+    : system{system_}, location_name_cache{BuildLocationNameCache(system)} {}
 
 void TimeZoneContentManager::Initialize(TimeManager& time_manager) {
     std::string location_name;

--- a/src/core/hle/service/time/time_zone_content_manager.h
+++ b/src/core/hle/service/time/time_zone_content_manager.h
@@ -21,7 +21,7 @@ namespace Service::Time::TimeZone {
 
 class TimeZoneContentManager final {
 public:
-    explicit TimeZoneContentManager(Core::System& system);
+    explicit TimeZoneContentManager(Core::System& system_);
 
     void Initialize(TimeManager& time_manager);
 

--- a/src/core/hle/service/vi/display/vi_display.cpp
+++ b/src/core/hle/service/vi/display/vi_display.cpp
@@ -17,8 +17,8 @@
 
 namespace Service::VI {
 
-Display::Display(u64 id, std::string name, Core::System& system)
-    : id{id}, name{std::move(name)}, vsync_event{system.Kernel()} {
+Display::Display(u64 id, std::string name_, Core::System& system)
+    : display_id{id}, name{std::move(name_)}, vsync_event{system.Kernel()} {
     Kernel::KAutoObject::Create(std::addressof(vsync_event));
     vsync_event.Initialize(fmt::format("Display VSync Event {}", id));
 }

--- a/src/core/hle/service/vi/display/vi_display.h
+++ b/src/core/hle/service/vi/display/vi_display.h
@@ -32,14 +32,14 @@ public:
     /// Constructs a display with a given unique ID and name.
     ///
     /// @param id   The unique ID for this display.
-    /// @param name The name for this display.
+    /// @param name_ The name for this display.
     ///
-    Display(u64 id, std::string name, Core::System& system);
+    Display(u64 id, std::string name_, Core::System& system);
     ~Display();
 
     /// Gets the unique ID assigned to this display.
     u64 GetID() const {
-        return id;
+        return display_id;
     }
 
     /// Gets the name of this display
@@ -96,7 +96,7 @@ public:
     const Layer* FindLayer(u64 layer_id) const;
 
 private:
-    u64 id;
+    u64 display_id;
     std::string name;
 
     std::vector<std::shared_ptr<Layer>> layers;

--- a/src/core/hle/service/vi/layer/vi_layer.cpp
+++ b/src/core/hle/service/vi/layer/vi_layer.cpp
@@ -6,7 +6,7 @@
 
 namespace Service::VI {
 
-Layer::Layer(u64 id, NVFlinger::BufferQueue& queue) : id{id}, buffer_queue{queue} {}
+Layer::Layer(u64 id, NVFlinger::BufferQueue& queue) : layer_id{id}, buffer_queue{queue} {}
 
 Layer::~Layer() = default;
 

--- a/src/core/hle/service/vi/layer/vi_layer.h
+++ b/src/core/hle/service/vi/layer/vi_layer.h
@@ -31,7 +31,7 @@ public:
 
     /// Gets the ID for this layer.
     u64 GetID() const {
-        return id;
+        return layer_id;
     }
 
     /// Gets a reference to the buffer queue this layer is using.
@@ -45,7 +45,7 @@ public:
     }
 
 private:
-    u64 id;
+    u64 layer_id;
     NVFlinger::BufferQueue& buffer_queue;
 };
 

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -212,7 +212,7 @@ private:
 
 class IGBPConnectRequestParcel : public Parcel {
 public:
-    explicit IGBPConnectRequestParcel(std::vector<u8> buffer) : Parcel(std::move(buffer)) {
+    explicit IGBPConnectRequestParcel(std::vector<u8> buffer_) : Parcel(std::move(buffer_)) {
         Deserialize();
     }
 
@@ -274,8 +274,8 @@ private:
 
 class IGBPSetPreallocatedBufferRequestParcel : public Parcel {
 public:
-    explicit IGBPSetPreallocatedBufferRequestParcel(std::vector<u8> buffer)
-        : Parcel(std::move(buffer)) {
+    explicit IGBPSetPreallocatedBufferRequestParcel(std::vector<u8> buffer_)
+        : Parcel(std::move(buffer_)) {
         Deserialize();
     }
 
@@ -312,7 +312,7 @@ protected:
 
 class IGBPCancelBufferRequestParcel : public Parcel {
 public:
-    explicit IGBPCancelBufferRequestParcel(std::vector<u8> buffer) : Parcel(std::move(buffer)) {
+    explicit IGBPCancelBufferRequestParcel(std::vector<u8> buffer_) : Parcel(std::move(buffer_)) {
         Deserialize();
     }
 
@@ -338,7 +338,7 @@ protected:
 
 class IGBPDequeueBufferRequestParcel : public Parcel {
 public:
-    explicit IGBPDequeueBufferRequestParcel(std::vector<u8> buffer) : Parcel(std::move(buffer)) {
+    explicit IGBPDequeueBufferRequestParcel(std::vector<u8> buffer_) : Parcel(std::move(buffer_)) {
         Deserialize();
     }
 
@@ -360,8 +360,8 @@ public:
 
 class IGBPDequeueBufferResponseParcel : public Parcel {
 public:
-    explicit IGBPDequeueBufferResponseParcel(u32 slot, Service::Nvidia::MultiFence& multi_fence)
-        : slot(slot), multi_fence(multi_fence) {}
+    explicit IGBPDequeueBufferResponseParcel(u32 slot_, Nvidia::MultiFence& multi_fence_)
+        : slot(slot_), multi_fence(multi_fence_) {}
 
 protected:
     void SerializeData() override {
@@ -377,7 +377,7 @@ protected:
 
 class IGBPRequestBufferRequestParcel : public Parcel {
 public:
-    explicit IGBPRequestBufferRequestParcel(std::vector<u8> buffer) : Parcel(std::move(buffer)) {
+    explicit IGBPRequestBufferRequestParcel(std::vector<u8> buffer_) : Parcel(std::move(buffer_)) {
         Deserialize();
     }
 
@@ -391,7 +391,7 @@ public:
 
 class IGBPRequestBufferResponseParcel : public Parcel {
 public:
-    explicit IGBPRequestBufferResponseParcel(NVFlinger::IGBPBuffer buffer) : buffer(buffer) {}
+    explicit IGBPRequestBufferResponseParcel(NVFlinger::IGBPBuffer buffer_) : buffer(buffer_) {}
     ~IGBPRequestBufferResponseParcel() override = default;
 
 protected:
@@ -408,7 +408,7 @@ protected:
 
 class IGBPQueueBufferRequestParcel : public Parcel {
 public:
-    explicit IGBPQueueBufferRequestParcel(std::vector<u8> buffer) : Parcel(std::move(buffer)) {
+    explicit IGBPQueueBufferRequestParcel(std::vector<u8> buffer_) : Parcel(std::move(buffer_)) {
         Deserialize();
     }
 
@@ -470,7 +470,7 @@ private:
 
 class IGBPQueryRequestParcel : public Parcel {
 public:
-    explicit IGBPQueryRequestParcel(std::vector<u8> buffer) : Parcel(std::move(buffer)) {
+    explicit IGBPQueryRequestParcel(std::vector<u8> buffer_) : Parcel(std::move(buffer_)) {
         Deserialize();
     }
 
@@ -484,7 +484,7 @@ public:
 
 class IGBPQueryResponseParcel : public Parcel {
 public:
-    explicit IGBPQueryResponseParcel(u32 value) : value(value) {}
+    explicit IGBPQueryResponseParcel(u32 value_) : value{value_} {}
     ~IGBPQueryResponseParcel() override = default;
 
 protected:

--- a/src/core/loader/deconstructed_rom_directory.cpp
+++ b/src/core/loader/deconstructed_rom_directory.cpp
@@ -22,8 +22,8 @@
 namespace Loader {
 
 AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(FileSys::VirtualFile file_,
-                                                                         bool override_update)
-    : AppLoader(std::move(file_)), override_update(override_update) {
+                                                                         bool override_update_)
+    : AppLoader(std::move(file_)), override_update(override_update_) {
     const auto file_dir = file->GetContainingDirectory();
 
     // Title ID
@@ -48,9 +48,9 @@ AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(FileSys
         // Any png, jpeg, or bmp file
         const auto& files = file_dir->GetFiles();
         const auto icon_iter =
-            std::find_if(files.begin(), files.end(), [](const FileSys::VirtualFile& file) {
-                return file->GetExtension() == "png" || file->GetExtension() == "jpg" ||
-                       file->GetExtension() == "bmp" || file->GetExtension() == "jpeg";
+            std::find_if(files.begin(), files.end(), [](const FileSys::VirtualFile& f) {
+                return f->GetExtension() == "png" || f->GetExtension() == "jpg" ||
+                       f->GetExtension() == "bmp" || f->GetExtension() == "jpeg";
             });
         if (icon_iter != files.end())
             icon_data = (*icon_iter)->ReadAllBytes();
@@ -61,9 +61,8 @@ AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(FileSys
     if (nacp_file == nullptr) {
         const auto& files = file_dir->GetFiles();
         const auto nacp_iter =
-            std::find_if(files.begin(), files.end(), [](const FileSys::VirtualFile& file) {
-                return file->GetExtension() == "nacp";
-            });
+            std::find_if(files.begin(), files.end(),
+                         [](const FileSys::VirtualFile& f) { return f->GetExtension() == "nacp"; });
         if (nacp_iter != files.end())
             nacp_file = *nacp_iter;
     }
@@ -75,9 +74,9 @@ AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(FileSys
 }
 
 AppLoader_DeconstructedRomDirectory::AppLoader_DeconstructedRomDirectory(
-    FileSys::VirtualDir directory, bool override_update)
+    FileSys::VirtualDir directory, bool override_update_)
     : AppLoader(directory->GetFile("main")), dir(std::move(directory)),
-      override_update(override_update) {}
+      override_update(override_update_) {}
 
 FileType AppLoader_DeconstructedRomDirectory::IdentifyType(const FileSys::VirtualFile& dir_file) {
     if (FileSys::IsDirectoryExeFS(dir_file->GetContainingDirectory())) {
@@ -184,8 +183,8 @@ AppLoader_DeconstructedRomDirectory::LoadResult AppLoader_DeconstructedRomDirect
     // Find the RomFS by searching for a ".romfs" file in this directory
     const auto& files = dir->GetFiles();
     const auto romfs_iter =
-        std::find_if(files.begin(), files.end(), [](const FileSys::VirtualFile& file) {
-            return file->GetName().find(".romfs") != std::string::npos;
+        std::find_if(files.begin(), files.end(), [](const FileSys::VirtualFile& f) {
+            return f->GetName().find(".romfs") != std::string::npos;
         });
 
     // Register the RomFS if a ".romfs" file was found

--- a/src/core/loader/deconstructed_rom_directory.h
+++ b/src/core/loader/deconstructed_rom_directory.h
@@ -24,11 +24,11 @@ namespace Loader {
 class AppLoader_DeconstructedRomDirectory final : public AppLoader {
 public:
     explicit AppLoader_DeconstructedRomDirectory(FileSys::VirtualFile main_file,
-                                                 bool override_update = false);
+                                                 bool override_update_ = false);
 
     // Overload to accept exefs directory. Must contain 'main' and 'main.npdm'
     explicit AppLoader_DeconstructedRomDirectory(FileSys::VirtualDir directory,
-                                                 bool override_update = false);
+                                                 bool override_update_ = false);
 
     /**
      * Identifies whether or not the given file is a deconstructed ROM directory.

--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -194,7 +194,7 @@ std::ostream& operator<<(std::ostream& os, ResultStatus status) {
     return os;
 }
 
-AppLoader::AppLoader(FileSys::VirtualFile file) : file(std::move(file)) {}
+AppLoader::AppLoader(FileSys::VirtualFile file_) : file(std::move(file_)) {}
 AppLoader::~AppLoader() = default;
 
 /**

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -147,7 +147,7 @@ public:
     };
     using LoadResult = std::pair<ResultStatus, std::optional<LoadParameters>>;
 
-    explicit AppLoader(FileSys::VirtualFile file);
+    explicit AppLoader(FileSys::VirtualFile file_);
     virtual ~AppLoader();
 
     /**

--- a/src/core/memory/cheat_engine.cpp
+++ b/src/core/memory/cheat_engine.cpp
@@ -37,8 +37,8 @@ std::string_view ExtractName(std::string_view data, std::size_t start_index, cha
 }
 } // Anonymous namespace
 
-StandardVmCallbacks::StandardVmCallbacks(Core::System& system, const CheatProcessMetadata& metadata)
-    : metadata(metadata), system(system) {}
+StandardVmCallbacks::StandardVmCallbacks(System& system_, const CheatProcessMetadata& metadata_)
+    : metadata{metadata_}, system{system_} {}
 
 StandardVmCallbacks::~StandardVmCallbacks() = default;
 
@@ -174,11 +174,11 @@ std::vector<CheatEntry> TextCheatParser::Parse(std::string_view data) const {
     return out;
 }
 
-CheatEngine::CheatEngine(Core::System& system, std::vector<CheatEntry> cheats,
-                         const std::array<u8, 0x20>& build_id)
-    : vm{std::make_unique<StandardVmCallbacks>(system, metadata)},
-      cheats(std::move(cheats)), core_timing{system.CoreTiming()}, system{system} {
-    metadata.main_nso_build_id = build_id;
+CheatEngine::CheatEngine(System& system_, std::vector<CheatEntry> cheats_,
+                         const std::array<u8, 0x20>& build_id_)
+    : vm{std::make_unique<StandardVmCallbacks>(system_, metadata)},
+      cheats(std::move(cheats_)), core_timing{system_.CoreTiming()}, system{system_} {
+    metadata.main_nso_build_id = build_id_;
 }
 
 CheatEngine::~CheatEngine() {

--- a/src/core/memory/cheat_engine.h
+++ b/src/core/memory/cheat_engine.h
@@ -25,7 +25,7 @@ namespace Core::Memory {
 
 class StandardVmCallbacks : public DmntCheatVm::Callbacks {
 public:
-    StandardVmCallbacks(Core::System& system, const CheatProcessMetadata& metadata);
+    StandardVmCallbacks(System& system_, const CheatProcessMetadata& metadata_);
     ~StandardVmCallbacks() override;
 
     void MemoryRead(VAddr address, void* data, u64 size) override;
@@ -38,7 +38,7 @@ private:
     VAddr SanitizeAddress(VAddr address) const;
 
     const CheatProcessMetadata& metadata;
-    Core::System& system;
+    System& system;
 };
 
 // Intermediary class that parses a text file or other disk format for storing cheats into a
@@ -61,8 +61,8 @@ public:
 // Class that encapsulates a CheatList and manages its interaction with memory and CoreTiming
 class CheatEngine final {
 public:
-    CheatEngine(Core::System& system_, std::vector<CheatEntry> cheats_,
-                const std::array<u8, 0x20>& build_id);
+    CheatEngine(System& system_, std::vector<CheatEntry> cheats_,
+                const std::array<u8, 0x20>& build_id_);
     ~CheatEngine();
 
     void Initialize();

--- a/src/core/memory/dmnt_cheat_vm.cpp
+++ b/src/core/memory/dmnt_cheat_vm.cpp
@@ -29,7 +29,8 @@
 
 namespace Core::Memory {
 
-DmntCheatVm::DmntCheatVm(std::unique_ptr<Callbacks> callbacks) : callbacks(std::move(callbacks)) {}
+DmntCheatVm::DmntCheatVm(std::unique_ptr<Callbacks> callbacks_)
+    : callbacks(std::move(callbacks_)) {}
 
 DmntCheatVm::~DmntCheatVm() = default;
 

--- a/src/core/memory/dmnt_cheat_vm.h
+++ b/src/core/memory/dmnt_cheat_vm.h
@@ -293,7 +293,7 @@ public:
     static constexpr std::size_t NumStaticRegisters =
         NumReadableStaticRegisters + NumWritableStaticRegisters;
 
-    explicit DmntCheatVm(std::unique_ptr<Callbacks> callbacks);
+    explicit DmntCheatVm(std::unique_ptr<Callbacks> callbacks_);
     ~DmntCheatVm();
 
     std::size_t GetProgramSize() const {

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -27,7 +27,7 @@ constexpr std::size_t IgnoreFrames = 5;
 
 namespace Core {
 
-PerfStats::PerfStats(u64 title_id) : title_id(title_id) {}
+PerfStats::PerfStats(u64 title_id_) : title_id(title_id_) {}
 
 PerfStats::~PerfStats() {
     if (!Settings::values.record_frame_times || title_id == 0) {

--- a/src/core/perf_stats.h
+++ b/src/core/perf_stats.h
@@ -29,7 +29,7 @@ struct PerfStatsResults {
  */
 class PerfStats {
 public:
-    explicit PerfStats(u64 title_id);
+    explicit PerfStats(u64 title_id_);
     ~PerfStats();
 
     using Clock = std::chrono::high_resolution_clock;

--- a/src/core/reporter.cpp
+++ b/src/core/reporter.cpp
@@ -192,7 +192,7 @@ json GetHLERequestContextData(Kernel::HLERequestContext& ctx, Core::Memory::Memo
 
 namespace Core {
 
-Reporter::Reporter(System& system) : system(system) {}
+Reporter::Reporter(System& system_) : system(system_) {}
 
 Reporter::~Reporter() = default;
 

--- a/src/core/reporter.h
+++ b/src/core/reporter.h
@@ -30,7 +30,7 @@ class System;
 
 class Reporter {
 public:
-    explicit Reporter(System& system);
+    explicit Reporter(System& system_);
     ~Reporter();
 
     // Used by fatal services


### PR DESCRIPTION
Now that we have most of core free of shadowing, we can enable the warning as an error to catch anything that may be remaining and also eliminate this class of logic bug entirely.