### PR TITLE
Various improvements to IPC and session management

### DIFF
--- a/src/common/tree.h
+++ b/src/common/tree.h
@@ -322,7 +322,7 @@ void RB_INSERT_COLOR(RBHead<Node>* head, Node* elm) {
 template <typename Node>
 void RB_REMOVE_COLOR(RBHead<Node>* head, Node* parent, Node* elm) {
     Node* tmp;
-    while ((elm == nullptr || RB_IS_BLACK(elm)) && elm != head->Root()) {
+    while ((elm == nullptr || RB_IS_BLACK(elm)) && elm != head->Root() && parent != nullptr) {
         if (RB_LEFT(parent) == elm) {
             tmp = RB_RIGHT(parent);
             if (RB_IS_RED(tmp)) {

--- a/src/core/hle/ipc.h
+++ b/src/core/hle/ipc.h
@@ -32,7 +32,8 @@ enum class CommandType : u32 {
     Control = 5,
     RequestWithContext = 6,
     ControlWithContext = 7,
-    Unspecified,
+    TIPC_Close = 15,
+    TIPC_CommandRegion = 16, // Start of TIPC commands, this is an offset.
 };
 
 struct CommandHeader {
@@ -57,6 +58,20 @@ struct CommandHeader {
         BitField<10, 4, BufferDescriptorCFlag> buf_c_descriptor_flags;
         BitField<31, 1, u32> enable_handle_descriptor;
     };
+
+    bool IsTipc() const {
+        return type.Value() >= CommandType::TIPC_CommandRegion;
+    }
+
+    bool IsCloseCommand() const {
+        switch (type.Value()) {
+        case CommandType::Close:
+        case CommandType::TIPC_Close:
+            return true;
+        default:
+            return false;
+        }
+    }
 };
 static_assert(sizeof(CommandHeader) == 8, "CommandHeader size is incorrect");
 

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -108,6 +108,7 @@ public:
             header.type.Assign(ctx.GetCommandType());
         }
 
+        ctx.data_size = static_cast<u32>(raw_data_size);
         header.data_size.Assign(static_cast<u32>(raw_data_size));
         if (num_handles_to_copy || num_handles_to_move) {
             header.enable_handle_descriptor.Assign(1);

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -150,8 +150,8 @@ public:
         if (context->Session()->IsDomain()) {
             context->AddDomainObject(std::move(iface));
         } else {
-            kernel.CurrentProcess()->GetResourceLimit()->Reserve(
-                Kernel::LimitableResource::Sessions, 1);
+            // kernel.CurrentProcess()->GetResourceLimit()->Reserve(
+            //    Kernel::LimitableResource::Sessions, 1);
 
             auto* session = Kernel::KSession::Create(kernel);
             session->Initialize(nullptr, iface->GetServiceName());

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -15,6 +15,8 @@
 #include "core/hle/ipc.h"
 #include "core/hle/kernel/hle_ipc.h"
 #include "core/hle/kernel/k_client_port.h"
+#include "core/hle/kernel/k_process.h"
+#include "core/hle/kernel/k_resource_limit.h"
 #include "core/hle/kernel/k_session.h"
 #include "core/hle/result.h"
 
@@ -148,6 +150,9 @@ public:
         if (context->Session()->IsDomain()) {
             context->AddDomainObject(std::move(iface));
         } else {
+            kernel.CurrentProcess()->GetResourceLimit()->Reserve(
+                Kernel::LimitableResource::Sessions, 1);
+
             auto* session = Kernel::KSession::Create(kernel);
             session->Initialize(nullptr, iface->GetServiceName());
 

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -101,7 +101,7 @@ public:
         }
 
         if (ctx.Session()->IsDomain()) {
-            raw_data_size += sizeof(DomainMessageHeader) / 4 + num_domain_objects;
+            raw_data_size += static_cast<u32>(sizeof(DomainMessageHeader) / 4 + num_domain_objects);
         }
 
         if (ctx.IsTipc()) {

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -99,7 +99,7 @@ void HLERequestContext::ParseCommandBuffer(const KHandleTable& handle_table, u32
         buffer_w_desciptors.push_back(rp.PopRaw<IPC::BufferDescriptorABW>());
     }
 
-    buffer_c_offset = rp.GetCurrentOffset() + command_header->data_size;
+    const auto buffer_c_offset = rp.GetCurrentOffset() + command_header->data_size;
 
     // Padding to align to 16 bytes
     rp.AlignWithPadding();

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -55,7 +55,7 @@ void HLERequestContext::ParseCommandBuffer(const KHandleTable& handle_table, u32
     IPC::RequestParser rp(src_cmdbuf);
     command_header = rp.PopRaw<IPC::CommandHeader>();
 
-    if (command_header->type == IPC::CommandType::Close) {
+    if (command_header->IsCloseCommand()) {
         // Close does not populate the rest of the IPC header
         return;
     }
@@ -101,37 +101,41 @@ void HLERequestContext::ParseCommandBuffer(const KHandleTable& handle_table, u32
 
     const auto buffer_c_offset = rp.GetCurrentOffset() + command_header->data_size;
 
-    // Padding to align to 16 bytes
-    rp.AlignWithPadding();
+    if (!command_header->IsTipc()) {
+        // Padding to align to 16 bytes
+        rp.AlignWithPadding();
 
-    if (Session()->IsDomain() && ((command_header->type == IPC::CommandType::Request ||
-                                   command_header->type == IPC::CommandType::RequestWithContext) ||
-                                  !incoming)) {
-        // If this is an incoming message, only CommandType "Request" has a domain header
-        // All outgoing domain messages have the domain header, if only incoming has it
-        if (incoming || domain_message_header) {
-            domain_message_header = rp.PopRaw<IPC::DomainMessageHeader>();
-        } else {
-            if (Session()->IsDomain()) {
-                LOG_WARNING(IPC, "Domain request has no DomainMessageHeader!");
+        if (Session()->IsDomain() &&
+            ((command_header->type == IPC::CommandType::Request ||
+              command_header->type == IPC::CommandType::RequestWithContext) ||
+             !incoming)) {
+            // If this is an incoming message, only CommandType "Request" has a domain header
+            // All outgoing domain messages have the domain header, if only incoming has it
+            if (incoming || domain_message_header) {
+                domain_message_header = rp.PopRaw<IPC::DomainMessageHeader>();
+            } else {
+                if (Session()->IsDomain()) {
+                    LOG_WARNING(IPC, "Domain request has no DomainMessageHeader!");
+                }
             }
         }
-    }
 
-    data_payload_header = rp.PopRaw<IPC::DataPayloadHeader>();
+        data_payload_header = rp.PopRaw<IPC::DataPayloadHeader>();
 
-    data_payload_offset = rp.GetCurrentOffset();
+        data_payload_offset = rp.GetCurrentOffset();
 
-    if (domain_message_header && domain_message_header->command ==
-                                     IPC::DomainMessageHeader::CommandType::CloseVirtualHandle) {
-        // CloseVirtualHandle command does not have SFC* or any data
-        return;
-    }
+        if (domain_message_header &&
+            domain_message_header->command ==
+                IPC::DomainMessageHeader::CommandType::CloseVirtualHandle) {
+            // CloseVirtualHandle command does not have SFC* or any data
+            return;
+        }
 
-    if (incoming) {
-        ASSERT(data_payload_header->magic == Common::MakeMagic('S', 'F', 'C', 'I'));
-    } else {
-        ASSERT(data_payload_header->magic == Common::MakeMagic('S', 'F', 'C', 'O'));
+        if (incoming) {
+            ASSERT(data_payload_header->magic == Common::MakeMagic('S', 'F', 'C', 'I'));
+        } else {
+            ASSERT(data_payload_header->magic == Common::MakeMagic('S', 'F', 'C', 'O'));
+        }
     }
 
     rp.SetCurrentOffset(buffer_c_offset);
@@ -166,84 +170,55 @@ void HLERequestContext::ParseCommandBuffer(const KHandleTable& handle_table, u32
 ResultCode HLERequestContext::PopulateFromIncomingCommandBuffer(const KHandleTable& handle_table,
                                                                 u32_le* src_cmdbuf) {
     ParseCommandBuffer(handle_table, src_cmdbuf, true);
-    if (command_header->type == IPC::CommandType::Close) {
+
+    if (command_header->IsCloseCommand()) {
         // Close does not populate the rest of the IPC header
         return RESULT_SUCCESS;
     }
 
-    // The data_size already includes the payload header, the padding and the domain header.
-    std::size_t size = data_payload_offset + command_header->data_size -
-                       sizeof(IPC::DataPayloadHeader) / sizeof(u32) - 4;
-    if (domain_message_header)
-        size -= sizeof(IPC::DomainMessageHeader) / sizeof(u32);
-    std::copy_n(src_cmdbuf, size, cmd_buf.begin());
+    std::copy_n(src_cmdbuf, IPC::COMMAND_BUFFER_LENGTH, cmd_buf.begin());
+
     return RESULT_SUCCESS;
 }
 
 ResultCode HLERequestContext::WriteToOutgoingCommandBuffer(KThread& requesting_thread) {
+    auto current_offset = handles_offset;
     auto& owner_process = *requesting_thread.GetOwnerProcess();
     auto& handle_table = owner_process.GetHandleTable();
 
-    std::array<u32, IPC::COMMAND_BUFFER_LENGTH> dst_cmdbuf;
-    memory.ReadBlock(owner_process, requesting_thread.GetTLSAddress(), dst_cmdbuf.data(),
-                     dst_cmdbuf.size() * sizeof(u32));
-
-    // The header was already built in the internal command buffer. Attempt to parse it to verify
-    // the integrity and then copy it over to the target command buffer.
-    ParseCommandBuffer(handle_table, cmd_buf.data(), false);
-
-    // The data_size already includes the payload header, the padding and the domain header.
-    std::size_t size = data_payload_offset + command_header->data_size -
-                       sizeof(IPC::DataPayloadHeader) / sizeof(u32) - 4;
-    if (domain_message_header)
-        size -= sizeof(IPC::DomainMessageHeader) / sizeof(u32);
-
-    std::copy_n(cmd_buf.begin(), size, dst_cmdbuf.data());
-
-    if (command_header->enable_handle_descriptor) {
-        ASSERT_MSG(!move_objects.empty() || !copy_objects.empty(),
-                   "Handle descriptor bit set but no handles to translate");
-        // We write the translated handles at a specific offset in the command buffer, this space
-        // was already reserved when writing the header.
-        std::size_t current_offset =
-            (sizeof(IPC::CommandHeader) + sizeof(IPC::HandleDescriptorHeader)) / sizeof(u32);
-        ASSERT_MSG(!handle_descriptor_header->send_current_pid, "Sending PID is not implemented");
-
-        ASSERT(copy_objects.size() == handle_descriptor_header->num_handles_to_copy);
-        ASSERT(move_objects.size() == handle_descriptor_header->num_handles_to_move);
-
-        // We don't make a distinction between copy and move handles when translating since HLE
-        // services don't deal with handles directly. However, the guest applications might check
-        // for specific values in each of these descriptors.
-        for (auto& object : copy_objects) {
-            ASSERT(object != nullptr);
-            R_TRY(handle_table.Add(&dst_cmdbuf[current_offset++], object));
+    for (auto& object : copy_objects) {
+        Handle handle{};
+        if (object) {
+            R_TRY(handle_table.Add(&handle, object));
         }
+        cmd_buf[current_offset++] = handle;
+    }
+    for (auto& object : move_objects) {
+        Handle handle{};
+        if (object) {
+            R_TRY(handle_table.Add(&handle, object));
 
-        for (auto& object : move_objects) {
-            ASSERT(object != nullptr);
-            R_TRY(handle_table.Add(&dst_cmdbuf[current_offset++], object));
+            // Close our reference to the object, as it is being moved to the caller.
+            object->Close();
         }
+        cmd_buf[current_offset++] = handle;
     }
 
-    // TODO(Subv): Translate the X/A/B/W buffers.
+    // Write the domain objects to the command buffer, these go after the raw untranslated data.
+    // TODO(Subv): This completely ignores C buffers.
 
-    if (Session()->IsDomain() && domain_message_header) {
-        ASSERT(domain_message_header->num_objects == domain_objects.size());
-        // Write the domain objects to the command buffer, these go after the raw untranslated data.
-        // TODO(Subv): This completely ignores C buffers.
-        std::size_t domain_offset = size - domain_message_header->num_objects;
-
+    if (Session()->IsDomain()) {
+        current_offset = domain_offset - static_cast<u32>(domain_objects.size());
         for (const auto& object : domain_objects) {
             server_session->AppendDomainRequestHandler(object);
-            dst_cmdbuf[domain_offset++] =
+            cmd_buf[current_offset++] =
                 static_cast<u32_le>(server_session->NumDomainRequestHandlers());
         }
     }
 
     // Copy the translated command buffer back into the thread's command buffer area.
-    memory.WriteBlock(owner_process, requesting_thread.GetTLSAddress(), dst_cmdbuf.data(),
-                      dst_cmdbuf.size() * sizeof(u32));
+    memory.WriteBlock(owner_process, requesting_thread.GetTLSAddress(), cmd_buf.data(),
+                      cmd_buf.size() * sizeof(u32));
 
     return RESULT_SUCCESS;
 }

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -132,6 +132,10 @@ public:
         return command;
     }
 
+    bool IsTipc() const {
+        return command_header->IsTipc();
+    }
+
     IPC::CommandType GetCommandType() const {
         return command_header->type;
     }
@@ -291,8 +295,10 @@ private:
     std::vector<IPC::BufferDescriptorABW> buffer_w_desciptors;
     std::vector<IPC::BufferDescriptorC> buffer_c_desciptors;
 
-    unsigned data_payload_offset{};
-    unsigned buffer_c_offset{};
+    u32 data_payload_offset{};
+    u32 buffer_c_offset{};
+    u32 handles_offset{};
+    u32 domain_offset{};
     u32_le command{};
 
     std::vector<std::shared_ptr<SessionRequestHandler>> domain_request_handlers;

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -128,8 +128,17 @@ public:
     /// Writes data from this context back to the requesting process/thread.
     ResultCode WriteToOutgoingCommandBuffer(KThread& requesting_thread);
 
-    u32_le GetCommand() const {
+    u32_le GetHipcCommand() const {
         return command;
+    }
+
+    u32_le GetTipcCommand() const {
+        return static_cast<u32_le>(command_header->type.Value()) -
+               static_cast<u32_le>(IPC::CommandType::TIPC_CommandRegion);
+    }
+
+    u32_le GetCommand() const {
+        return command_header->IsTipc() ? GetTipcCommand() : GetHipcCommand();
     }
 
     bool IsTipc() const {
@@ -140,7 +149,7 @@ public:
         return command_header->type;
     }
 
-    unsigned GetDataPayloadOffset() const {
+    u32 GetDataPayloadOffset() const {
         return data_payload_offset;
     }
 
@@ -296,7 +305,6 @@ private:
     std::vector<IPC::BufferDescriptorC> buffer_c_desciptors;
 
     u32 data_payload_offset{};
-    u32 buffer_c_offset{};
     u32 handles_offset{};
     u32 domain_offset{};
     u32_le command{};

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -308,6 +308,7 @@ private:
     u32 data_payload_offset{};
     u32 handles_offset{};
     u32 domain_offset{};
+    u32 data_size{};
     u32_le command{};
 
     std::vector<std::shared_ptr<SessionRequestHandler>> domain_request_handlers;

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -66,7 +66,8 @@ public:
      * this request (ServerSession, Originator thread, Translated command buffer, etc).
      * @returns ResultCode the result code of the translate operation.
      */
-    virtual ResultCode HandleSyncRequest(Kernel::HLERequestContext& context) = 0;
+    virtual ResultCode HandleSyncRequest(Kernel::KServerSession& session,
+                                         Kernel::HLERequestContext& context) = 0;
 
     /**
      * Signals that a client has just connected to this HLE handler and keeps the

--- a/src/core/hle/kernel/k_client_port.cpp
+++ b/src/core/hle/kernel/k_client_port.cpp
@@ -58,9 +58,9 @@ bool KClientPort::IsSignaled() const {
 
 ResultCode KClientPort::CreateSession(KClientSession** out) {
     // Reserve a new session from the resource limit.
-    KScopedResourceReservation session_reservation(kernel.CurrentProcess()->GetResourceLimit(),
-                                                   LimitableResource::Sessions);
-    R_UNLESS(session_reservation.Succeeded(), ResultLimitReached);
+    // KScopedResourceReservation session_reservation(kernel.CurrentProcess()->GetResourceLimit(),
+    //                                               LimitableResource::Sessions);
+    // R_UNLESS(session_reservation.Succeeded(), ResultLimitReached);
 
     // Update the session counts.
     {
@@ -104,7 +104,7 @@ ResultCode KClientPort::CreateSession(KClientSession** out) {
     session->Initialize(this, parent->GetName());
 
     // Commit the session reservation.
-    session_reservation.Commit();
+    // session_reservation.Commit();
 
     // Register the session.
     KSession::Register(kernel, session);

--- a/src/core/hle/kernel/k_client_port.cpp
+++ b/src/core/hle/kernel/k_client_port.cpp
@@ -91,7 +91,7 @@ ResultCode KClientPort::CreateSession(KClientSession** out) {
     // Create a new session.
     KSession* session = KSession::Create(kernel);
     if (session == nullptr) {
-        /* Decrement the session count. */
+        // Decrement the session count.
         const auto prev = num_sessions--;
         if (prev == max_sessions) {
             this->NotifyAvailable();

--- a/src/core/hle/kernel/k_server_session.cpp
+++ b/src/core/hle/kernel/k_server_session.cpp
@@ -95,7 +95,7 @@ ResultCode KServerSession::HandleDomainSyncRequest(Kernel::HLERequestContext& co
             UNREACHABLE();
             return RESULT_SUCCESS; // Ignore error if asserts are off
         }
-        return domain_request_handlers[object_id - 1]->HandleSyncRequest(context);
+        return domain_request_handlers[object_id - 1]->HandleSyncRequest(*this, context);
 
     case IPC::DomainMessageHeader::CommandType::CloseVirtualHandle: {
         LOG_DEBUG(IPC, "CloseVirtualHandle, object_id=0x{:08X}", object_id);
@@ -135,7 +135,7 @@ ResultCode KServerSession::CompleteSyncRequest(HLERequestContext& context) {
         // If there is no domain header, the regular session handler is used
     } else if (hle_handler != nullptr) {
         // If this ServerSession has an associated HLE handler, forward the request to it.
-        result = hle_handler->HandleSyncRequest(context);
+        result = hle_handler->HandleSyncRequest(*this, context);
     }
 
     if (convert_to_domain) {

--- a/src/core/hle/kernel/k_session.cpp
+++ b/src/core/hle/kernel/k_session.cpp
@@ -78,7 +78,7 @@ void KSession::OnClientClosed() {
 void KSession::PostDestroy(uintptr_t arg) {
     // Release the session count resource the owner process holds.
     KProcess* owner = reinterpret_cast<KProcess*>(arg);
-    owner->GetResourceLimit()->Release(LimitableResource::Sessions, 1);
+    // owner->GetResourceLimit()->Release(LimitableResource::Sessions, 1);
     owner->Close();
 }
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -44,6 +44,7 @@
 #include "core/hle/kernel/time_manager.h"
 #include "core/hle/lock.h"
 #include "core/hle/result.h"
+#include "core/hle/service/sm/sm.h"
 #include "core/memory.h"
 
 MICROPROFILE_DEFINE(Kernel_SVC, "Kernel", "SVC", MP_RGB(70, 200, 70));
@@ -656,6 +657,7 @@ struct KernelCore::Impl {
 
     /// Map of named ports managed by the kernel, which can be retrieved using
     /// the ConnectToPort SVC.
+    std::unordered_map<std::string, ServiceInterfaceFactory> service_interface_factory;
     NamedPortTable named_ports;
 
     std::unique_ptr<Core::ExclusiveMonitor> exclusive_monitor;
@@ -844,18 +846,17 @@ void KernelCore::PrepareReschedule(std::size_t id) {
     // TODO: Reimplement, this
 }
 
-void KernelCore::AddNamedPort(std::string name, KClientPort* port) {
-    port->Open();
-    impl->named_ports.emplace(std::move(name), port);
+void KernelCore::RegisterNamedService(std::string name, ServiceInterfaceFactory&& factory) {
+    impl->service_interface_factory.emplace(std::move(name), factory);
 }
 
-KernelCore::NamedPortTable::iterator KernelCore::FindNamedPort(const std::string& name) {
-    return impl->named_ports.find(name);
-}
-
-KernelCore::NamedPortTable::const_iterator KernelCore::FindNamedPort(
-    const std::string& name) const {
-    return impl->named_ports.find(name);
+KClientPort* KernelCore::CreateNamedServicePort(std::string name) {
+    auto search = impl->service_interface_factory.find(name);
+    if (search == impl->service_interface_factory.end()) {
+        UNIMPLEMENTED();
+        return {};
+    }
+    return &search->second(impl->system.ServiceManager(), impl->system);
 }
 
 bool KernelCore::IsValidNamedPort(NamedPortTable::const_iterator port) const {

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -27,6 +27,10 @@ class CoreTiming;
 struct EventType;
 } // namespace Core::Timing
 
+namespace Service::SM {
+class ServiceManager;
+}
+
 namespace Kernel {
 
 class KClientPort;
@@ -50,6 +54,9 @@ class PhysicalCore;
 class ServiceThread;
 class Synchronization;
 class TimeManager;
+
+using ServiceInterfaceFactory =
+    std::function<KClientPort&(Service::SM::ServiceManager&, Core::System&)>;
 
 namespace Init {
 struct KSlabResourceCounts;
@@ -172,14 +179,11 @@ public:
 
     void InvalidateCpuInstructionCacheRange(VAddr addr, std::size_t size);
 
-    /// Adds a port to the named port table
-    void AddNamedPort(std::string name, KClientPort* port);
+    /// Registers a named HLE service, passing a factory used to open a port to that service.
+    void RegisterNamedService(std::string name, ServiceInterfaceFactory&& factory);
 
-    /// Finds a port within the named port table with the given name.
-    NamedPortTable::iterator FindNamedPort(const std::string& name);
-
-    /// Finds a port within the named port table with the given name.
-    NamedPortTable::const_iterator FindNamedPort(const std::string& name) const;
+    /// Opens a port to a service previously registered with RegisterNamedService.
+    KClientPort* CreateNamedServicePort(std::string name);
 
     /// Determines whether or not the given port is a valid named port.
     bool IsValidNamedPort(NamedPortTable::const_iterator port) const;

--- a/src/core/hle/kernel/slab_helpers.h
+++ b/src/core/hle/kernel/slab_helpers.h
@@ -67,11 +67,11 @@ class KAutoObjectWithSlabHeapAndContainer : public Base {
 
 private:
     static Derived* Allocate(KernelCore& kernel) {
-        return kernel.SlabHeap<Derived>().AllocateWithKernel(kernel);
+        return new Derived(kernel);
     }
 
     static void Free(KernelCore& kernel, Derived* obj) {
-        kernel.SlabHeap<Derived>().Free(obj);
+        delete obj;
     }
 
 public:

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -284,12 +284,11 @@ static ResultCode ConnectToNamedPort(Core::System& system, Handle* out, VAddr po
     auto& handle_table = kernel.CurrentProcess()->GetHandleTable();
 
     // Find the client port.
-    const auto it = kernel.FindNamedPort(port_name);
-    if (!kernel.IsValidNamedPort(it)) {
-        LOG_WARNING(Kernel_SVC, "tried to connect to unknown port: {}", port_name);
+    auto port = kernel.CreateNamedServicePort(port_name);
+    if (!port) {
+        LOG_ERROR(Kernel_SVC, "tried to connect to unknown port: {}", port_name);
         return ResultNotFound;
     }
-    auto port = it->second;
 
     // Reserve a handle for the port.
     // NOTE: Nintendo really does write directly to the output handle here.

--- a/src/core/hle/service/audio/audren_u.h
+++ b/src/core/hle/service/audio/audren_u.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "core/hle/kernel/k_event.h"
 #include "core/hle/service/service.h"
 
 namespace Core {
@@ -31,6 +32,7 @@ private:
     void OpenAudioRendererImpl(Kernel::HLERequestContext& ctx);
 
     std::size_t audren_instance_count = 0;
+    Kernel::KEvent buffer_event;
 };
 
 // Describes a particular audio feature that may be supported in a particular revision.

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -111,7 +111,7 @@ void ServiceFrameworkBase::InstallAsService(SM::ServiceManager& service_manager)
     port_installed = true;
 }
 
-void ServiceFrameworkBase::InstallAsNamedPort(Kernel::KernelCore& kernel) {
+Kernel::KClientPort& ServiceFrameworkBase::CreatePort(Kernel::KernelCore& kernel) {
     const auto guard = LockService();
 
     ASSERT(!port_installed);
@@ -119,9 +119,10 @@ void ServiceFrameworkBase::InstallAsNamedPort(Kernel::KernelCore& kernel) {
     auto* port = Kernel::KPort::Create(kernel);
     port->Initialize(max_sessions, false, service_name);
     port->GetServerPort().SetHleHandler(shared_from_this());
-    kernel.AddNamedPort(service_name, &port->GetClientPort());
 
     port_installed = true;
+
+    return port->GetClientPort();
 }
 
 void ServiceFrameworkBase::RegisterHandlersBase(const FunctionInfoBase* functions, std::size_t n) {

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -208,7 +208,7 @@ Services::Services(std::shared_ptr<SM::ServiceManager>& sm, Core::System& system
 
     system.GetFileSystemController().CreateFactories(*system.GetFilesystem(), false);
 
-    SM::ServiceManager::InstallInterfaces(sm, system);
+    system.Kernel().RegisterNamedService("sm:", SM::ServiceManager::InterfaceFactory);
 
     Account::InstallInterfaces(system);
     AM::InstallInterfaces(*sm, *nv_flinger, system);

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -71,7 +71,8 @@ public:
     Kernel::KClientPort& CreatePort(Kernel::KernelCore& kernel);
 
     /// Handles a synchronization request for the service.
-    ResultCode HandleSyncRequest(Kernel::HLERequestContext& context) override;
+    ResultCode HandleSyncRequest(Kernel::KServerSession& session,
+                                 Kernel::HLERequestContext& context) override;
 
 protected:
     /// Member-function pointer type of SyncRequest handlers.

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -64,10 +64,12 @@ public:
 
     /// Creates a port pair and registers this service with the given ServiceManager.
     void InstallAsService(SM::ServiceManager& service_manager);
-    /// Creates a port pair and registers it on the kernel's global port registry.
-    void InstallAsNamedPort(Kernel::KernelCore& kernel);
-    /// Invokes a service request routine.
+
+    /// Invokes a service request routine using the HIPC protocol.
     void InvokeRequest(Kernel::HLERequestContext& ctx);
+    /// Creates a port pair and registers it on the kernel's global port registry.
+    Kernel::KClientPort& CreatePort(Kernel::KernelCore& kernel);
+
     /// Handles a synchronization request for the service.
     ResultCode HandleSyncRequest(Kernel::HLERequestContext& context) override;
 

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -21,7 +21,9 @@ class System;
 
 namespace Kernel {
 class HLERequestContext;
-}
+class KClientPort;
+class KServerSession;
+} // namespace Kernel
 
 namespace Service {
 
@@ -67,6 +69,10 @@ public:
 
     /// Invokes a service request routine using the HIPC protocol.
     void InvokeRequest(Kernel::HLERequestContext& ctx);
+
+    /// Invokes a service request routine using the HIPC protocol.
+    void InvokeRequestTipc(Kernel::HLERequestContext& ctx);
+
     /// Creates a port pair and registers it on the kernel's global port registry.
     Kernel::KClientPort& CreatePort(Kernel::KernelCore& kernel);
 
@@ -105,6 +111,7 @@ private:
     ~ServiceFrameworkBase() override;
 
     void RegisterHandlersBase(const FunctionInfoBase* functions, std::size_t n);
+    void RegisterHandlersBaseTipc(const FunctionInfoBase* functions, std::size_t n);
     void ReportUnimplementedFunction(Kernel::HLERequestContext& ctx, const FunctionInfoBase* info);
 
     /// Identifier string used to connect to the service.
@@ -119,6 +126,7 @@ private:
     /// Function used to safely up-cast pointers to the derived class before invoking a handler.
     InvokerFn* handler_invoker;
     boost::container::flat_map<u32, FunctionInfoBase> handlers;
+    boost::container::flat_map<u32, FunctionInfoBase> handlers_tipc;
 
     /// Used to gain exclusive access to the service members, e.g. from CoreTiming thread.
     Common::SpinLock lock_service;
@@ -184,6 +192,20 @@ protected:
      */
     void RegisterHandlers(const FunctionInfo* functions, std::size_t n) {
         RegisterHandlersBase(functions, n);
+    }
+
+    /// Registers handlers in the service.
+    template <std::size_t N>
+    void RegisterHandlersTipc(const FunctionInfo (&functions)[N]) {
+        RegisterHandlersTipc(functions, N);
+    }
+
+    /**
+     * Registers handlers in the service. Usually prefer using the other RegisterHandlers
+     * overload in order to avoid needing to specify the array size.
+     */
+    void RegisterHandlersTipc(const FunctionInfo* functions, std::size_t n) {
+        RegisterHandlersBaseTipc(functions, n);
     }
 
 private:

--- a/src/core/hle/service/sm/controller.cpp
+++ b/src/core/hle/service/sm/controller.cpp
@@ -44,7 +44,7 @@ void Controller::QueryPointerBufferSize(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(RESULT_SUCCESS);
-    rb.Push<u16>(0x1000);
+    rb.Push<u16>(0x8000);
 }
 
 // https://switchbrew.org/wiki/IPC_Marshalling

--- a/src/core/hle/service/sm/controller.cpp
+++ b/src/core/hle/service/sm/controller.cpp
@@ -26,15 +26,23 @@ void Controller::CloneCurrentObject(Kernel::HLERequestContext& ctx) {
     // TODO(bunnei): This is just creating a new handle to the same Session. I assume this is wrong
     // and that we probably want to actually make an entirely new Session, but we still need to
     // verify this on hardware.
+
     LOG_DEBUG(Service, "called");
+
+    auto session = ctx.Session()->GetParent();
+
+    // Open a reference to the session to simulate a new one being created.
+    session->Open();
+    session->GetClientSession().Open();
+    session->GetServerSession().Open();
 
     IPC::ResponseBuilder rb{ctx, 2, 0, 1, IPC::ResponseBuilder::Flags::AlwaysMoveHandles};
     rb.Push(RESULT_SUCCESS);
-    rb.PushMoveObjects(ctx.Session()->GetParent()->GetClientSession());
+    rb.PushMoveObjects(session->GetClientSession());
 }
 
 void Controller::CloneCurrentObjectEx(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service, "(STUBBED) called, using CloneCurrentObject");
+    LOG_DEBUG(Service, "called");
 
     CloneCurrentObject(ctx);
 }

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -9,6 +9,7 @@
 #include "core/hle/kernel/k_client_port.h"
 #include "core/hle/kernel/k_client_session.h"
 #include "core/hle/kernel/k_port.h"
+#include "core/hle/kernel/k_scoped_resource_reservation.h"
 #include "core/hle/kernel/k_server_port.h"
 #include "core/hle/kernel/k_server_session.h"
 #include "core/hle/kernel/k_session.h"
@@ -18,6 +19,7 @@
 
 namespace Service::SM {
 
+constexpr ResultCode ERR_NOT_INITIALIZED(ErrorModule::SM, 2);
 constexpr ResultCode ERR_ALREADY_REGISTERED(ErrorModule::SM, 4);
 constexpr ResultCode ERR_INVALID_NAME(ErrorModule::SM, 6);
 constexpr ResultCode ERR_SERVICE_NOT_REGISTERED(ErrorModule::SM, 7);
@@ -34,20 +36,17 @@ static ResultCode ValidateServiceName(const std::string& name) {
         LOG_ERROR(Service_SM, "Invalid service name! service={}", name);
         return ERR_INVALID_NAME;
     }
-    if (name.rfind('\0') != std::string::npos) {
-        LOG_ERROR(Service_SM, "A non null terminated service was passed");
-        return ERR_INVALID_NAME;
-    }
     return RESULT_SUCCESS;
 }
 
-void ServiceManager::InstallInterfaces(std::shared_ptr<ServiceManager> self, Core::System& system) {
-    ASSERT(self->sm_interface.expired());
+Kernel::KClientPort& ServiceManager::InterfaceFactory(ServiceManager& self, Core::System& system) {
+    ASSERT(self.sm_interface.expired());
 
     auto sm = std::make_shared<SM>(self, system);
-    sm->InstallAsNamedPort(system.Kernel());
-    self->sm_interface = sm;
-    self->controller_interface = std::make_unique<Controller>(system);
+    self.sm_interface = sm;
+    self.controller_interface = std::make_unique<Controller>(system);
+
+    return sm->CreatePort(system.Kernel());
 }
 
 ResultVal<Kernel::KServerPort*> ServiceManager::RegisterService(std::string name,
@@ -114,21 +113,47 @@ void SM::Initialize(Kernel::HLERequestContext& ctx) {
 }
 
 void SM::GetService(Kernel::HLERequestContext& ctx) {
-    IPC::RequestParser rp{ctx};
-    auto name_buf = rp.PopRaw<std::array<char, 8>>();
-    auto end = std::find(name_buf.begin(), name_buf.end(), '\0');
-
-    std::string name(name_buf.begin(), end);
-
-    auto result = service_manager->GetServicePort(name);
-    if (result.Failed()) {
+    auto result = GetServiceImpl(ctx);
+    if (result.Succeeded()) {
+        IPC::ResponseBuilder rb{ctx, 2, 0, 1, IPC::ResponseBuilder::Flags::AlwaysMoveHandles};
+        rb.Push(result.Code());
+        rb.PushMoveObjects(result.Unwrap());
+    } else {
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(result.Code());
+    }
+}
+
+void SM::GetServiceTipc(Kernel::HLERequestContext& ctx) {
+    auto result = GetServiceImpl(ctx);
+    IPC::ResponseBuilder rb{ctx, 2, 0, 1, IPC::ResponseBuilder::Flags::AlwaysMoveHandles};
+    rb.Push(result.Code());
+    rb.PushMoveObjects(result.Succeeded() ? result.Unwrap() : nullptr);
+}
+
+static std::string PopServiceName(IPC::RequestParser& rp) {
+    auto name_buf = rp.PopRaw<std::array<char, 8>>();
+    std::string result;
+    for (const auto& c : name_buf) {
+        if (c >= ' ' && c <= '~') {
+            result.push_back(c);
+        }
+    }
+    return result;
+}
+
+ResultVal<Kernel::KClientSession*> SM::GetServiceImpl(Kernel::HLERequestContext& ctx) {
+    if (!is_initialized) {
+        return ERR_NOT_INITIALIZED;
+    }
+
+    IPC::RequestParser rp{ctx};
+    std::string name(PopServiceName(rp));
+
+    auto result = service_manager.GetServicePort(name);
+    if (result.Failed()) {
         LOG_ERROR(Service_SM, "called service={} -> error 0x{:08X}", name, result.Code().raw);
-        if (name.length() == 0)
-            return; // LibNX Fix
-        UNIMPLEMENTED();
-        return;
+        return result.Code();
     }
 
     auto* port = result.Unwrap();
@@ -150,18 +175,12 @@ void SM::GetService(Kernel::HLERequestContext& ctx) {
     }
 
     LOG_DEBUG(Service_SM, "called service={} -> session={}", name, session->GetId());
-    IPC::ResponseBuilder rb{ctx, 2, 0, 1, IPC::ResponseBuilder::Flags::AlwaysMoveHandles};
-    rb.Push(RESULT_SUCCESS);
-    rb.PushMoveObjects(session->GetClientSession());
+    return MakeResult(&session->GetClientSession());
 }
 
 void SM::RegisterService(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
-
-    const auto name_buf = rp.PopRaw<std::array<char, 8>>();
-    const auto end = std::find(name_buf.begin(), name_buf.end(), '\0');
-
-    const std::string name(name_buf.begin(), end);
+    std::string name(PopServiceName(rp));
 
     const auto is_light = static_cast<bool>(rp.PopRaw<u32>());
     const auto max_session_count = rp.PopRaw<u32>();
@@ -169,7 +188,7 @@ void SM::RegisterService(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_SM, "called with name={}, max_session_count={}, is_light={}", name,
               max_session_count, is_light);
 
-    auto handle = service_manager->RegisterService(name, max_session_count);
+    auto handle = service_manager.RegisterService(name, max_session_count);
     if (handle.Failed()) {
         LOG_ERROR(Service_SM, "failed to register service with error_code={:08X}",
                   handle.Code().raw);
@@ -187,28 +206,31 @@ void SM::RegisterService(Kernel::HLERequestContext& ctx) {
 
 void SM::UnregisterService(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
+    std::string name(PopServiceName(rp));
 
-    const auto name_buf = rp.PopRaw<std::array<char, 8>>();
-    const auto end = std::find(name_buf.begin(), name_buf.end(), '\0');
-
-    const std::string name(name_buf.begin(), end);
     LOG_DEBUG(Service_SM, "called with name={}", name);
 
     IPC::ResponseBuilder rb{ctx, 2};
-    rb.Push(service_manager->UnregisterService(name));
+    rb.Push(service_manager.UnregisterService(name));
 }
 
-SM::SM(std::shared_ptr<ServiceManager> service_manager_, Core::System& system_)
+SM::SM(ServiceManager& service_manager_, Core::System& system_)
     : ServiceFramework{system_, "sm:", 4},
-      service_manager{std::move(service_manager_)}, kernel{system_.Kernel()} {
-    static const FunctionInfo functions[] = {
+      service_manager{service_manager_}, kernel{system_.Kernel()} {
+    RegisterHandlers({
         {0, &SM::Initialize, "Initialize"},
         {1, &SM::GetService, "GetService"},
         {2, &SM::RegisterService, "RegisterService"},
         {3, &SM::UnregisterService, "UnregisterService"},
         {4, nullptr, "DetachClient"},
-    };
-    RegisterHandlers(functions);
+    });
+    RegisterHandlersTipc({
+        {0, &SM::Initialize, "Initialize"},
+        {1, &SM::GetServiceTipc, "GetService"},
+        {2, &SM::RegisterService, "RegisterService"},
+        {3, &SM::UnregisterService, "UnregisterService"},
+        {4, nullptr, "DetachClient"},
+    });
 }
 
 } // namespace Service::SM

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -158,15 +158,15 @@ ResultVal<Kernel::KClientSession*> SM::GetServiceImpl(Kernel::HLERequestContext&
 
     auto* port = result.Unwrap();
 
-    Kernel::KScopedResourceReservation session_reservation(
-        kernel.CurrentProcess()->GetResourceLimit(), Kernel::LimitableResource::Sessions);
-    R_UNLESS(session_reservation.Succeeded(), Kernel::ResultLimitReached);
+    // Kernel::KScopedResourceReservation session_reservation(
+    //    kernel.CurrentProcess()->GetResourceLimit(), Kernel::LimitableResource::Sessions);
+    // R_UNLESS(session_reservation.Succeeded(), Kernel::ResultLimitReached);
 
     auto* session = Kernel::KSession::Create(kernel);
     session->Initialize(&port->GetClientPort(), std::move(name));
 
     // Commit the session reservation.
-    session_reservation.Commit();
+    // session_reservation.Commit();
 
     if (port->GetServerPort().GetHLEHandler()) {
         port->GetServerPort().GetHLEHandler()->ClientConnected(&session->GetServerSession());

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -107,6 +107,8 @@ SM::~SM() = default;
 void SM::Initialize(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_SM, "called");
 
+    is_initialized = true;
+
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(RESULT_SUCCESS);
 }

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -34,23 +34,26 @@ class Controller;
 /// Interface to "sm:" service
 class SM final : public ServiceFramework<SM> {
 public:
-    explicit SM(std::shared_ptr<ServiceManager> service_manager_, Core::System& system_);
+    explicit SM(ServiceManager& service_manager_, Core::System& system_);
     ~SM() override;
 
 private:
     void Initialize(Kernel::HLERequestContext& ctx);
     void GetService(Kernel::HLERequestContext& ctx);
+    void GetServiceTipc(Kernel::HLERequestContext& ctx);
     void RegisterService(Kernel::HLERequestContext& ctx);
     void UnregisterService(Kernel::HLERequestContext& ctx);
 
-    std::shared_ptr<ServiceManager> service_manager;
+    ResultVal<Kernel::KClientSession*> GetServiceImpl(Kernel::HLERequestContext& ctx);
+
+    ServiceManager& service_manager;
     bool is_initialized{};
     Kernel::KernelCore& kernel;
 };
 
 class ServiceManager {
 public:
-    static void InstallInterfaces(std::shared_ptr<ServiceManager> self, Core::System& system);
+    static Kernel::KClientPort& InterfaceFactory(ServiceManager& self, Core::System& system);
 
     explicit ServiceManager(Kernel::KernelCore& kernel_);
     ~ServiceManager();

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -44,6 +44,7 @@ private:
     void UnregisterService(Kernel::HLERequestContext& ctx);
 
     std::shared_ptr<ServiceManager> service_manager;
+    bool is_initialized{};
     Kernel::KernelCore& kernel;
 };
 


### PR DESCRIPTION
* Adds initial implementation of TIPC, the new IPC protocol introduced with 12.0.0. I've tested the behavior of this with homebrew, although I am not aware of this being used in any retail games yet.
* Updates SM service to support TIPC. This also involved fixing several issues with SM error-checking, such as validating service names being broken.
* Corrects the behavior of svcConnectToNamedPort -- instead of creating static "installed" interfaces of named ports, we now register a factory method with the kernel, and create a new interface each time this is called. This was noticed in testing homebrew with TIPC, where SM is created twice (once for classic IPC, once for TIPC), and these interfaces should have separate state.
* Implements IPC "Close" command. Previously, we never actually closed sessions. This resulted in a small leak which was never noticed, because we did not enforce maximum number of sessions. Now that we do (introduced with #6266), this resulted in crashes in several games (Nintendo Labo, Pokemon Sword/Shield, probably more).
* Similarly, we now "move" objects when requested out of the IPC, rather than copy. This ensures our sessions will be destroyed when the caller closes their handle. This also contributes to fixing this leak.
* In implementing TIPC, I also took the opportunity to greatly simplify some IPC code that has not been touched in years. Should improve performance and memory usage a little bit.
* Increases SM point buffer size, various services expect this to be larger than 0x1000.
* We slightly improve DuplicateSession implementation, to now handle the changes to move objects. In a follow-up change, I will make this properly create a new session, rather than reusing the existing one.