### PR TITLE
gl_texture_cache: Fix GL_INVALID_OPERATION on compressed formats with dimensions < 4x4

### DIFF
--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -824,6 +824,13 @@ void Image::CopyBufferToImage(const VideoCommon::BufferImageCopy& copy, size_t b
     const bool is_compressed = gl_format == GL_NONE;
     const void* const offset = reinterpret_cast<const void*>(copy.buffer_offset + buffer_offset);
 
+    if (is_compressed && !IsPixelFormatASTC(info.format) &&
+        (copy.image_extent.width < 4 || copy.image_extent.height < 4)) {
+        // Per the documentation for the BPTC, S3TC, and RGTC formats, INVALID_OPERATION will be
+        // generated if either of the dimensions are not a multiple of four. This mainly occurs on
+        // small levels of mip-mapped textures, which this condition will catch.
+        return;
+    }
     switch (info.type) {
     case ImageType::e1D:
         if (is_compressed) {


### PR DESCRIPTION
Per the documentation of the [BPTC](https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_texture_compression_bptc.txt), [S3TC](https://www.khronos.org/registry/OpenGL/extensions/EXT/EXT_texture_compression_s3tc.txt), and [RGTC](https://www.khronos.org/registry/OpenGL/extensions/ARB/ARB_texture_compression_rgtc.txt) formats, `GL_INVALID_OPERATION` will be generated if either of the width and height dimensions are not a multiple of four when used in `glCompressedTextureSubImage`. 

In yuzu, this error is mainly generated on small levels of mip-mapped textures, where texture sizes can reach 2x2 and 1x1. This condition will catch these cases, reducing the noisy errors generated as a result.