### PR TITLE
perf_stats: Rework FPS counter to be more accurate

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -289,7 +289,8 @@ struct System::Impl {
 
             telemetry_session->AddField(performance, "Shutdown_EmulationSpeed",
                                         perf_results.emulation_speed * 100.0);
-            telemetry_session->AddField(performance, "Shutdown_Framerate", perf_results.game_fps);
+            telemetry_session->AddField(performance, "Shutdown_Framerate",
+                                        perf_results.average_game_fps);
             telemetry_session->AddField(performance, "Shutdown_Frametime",
                                         perf_results.frametime * 1000.0);
             telemetry_session->AddField(performance, "Mean_Frametime_MS",

--- a/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
@@ -52,7 +52,6 @@ void nvdisp_disp0::flip(u32 buffer_handle, u32 offset, u32 format, u32 width, u3
         addr,      offset,   width, height, stride, static_cast<PixelFormat>(format),
         transform, crop_rect};
 
-    system.GetPerfStats().EndGameFrame();
     system.GetPerfStats().EndSystemFrame();
     system.GPU().SwapBuffers(&framebuffer);
     system.FrameLimiter().DoFrameLimiting(system.CoreTiming().GetGlobalTimeUs());

--- a/src/core/perf_stats.h
+++ b/src/core/perf_stats.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <mutex>
@@ -15,8 +16,8 @@ namespace Core {
 struct PerfStatsResults {
     /// System FPS (LCD VBlanks) in Hz
     double system_fps;
-    /// Game FPS (GSP frame submissions) in Hz
-    double game_fps;
+    /// Average game FPS (GPU frame renders) in Hz
+    double average_game_fps;
     /// Walltime per system frame, in seconds, excluding any waits
     double frametime;
     /// Ratio of walltime / emulated time elapsed
@@ -72,7 +73,7 @@ private:
     /// Cumulative number of system frames (LCD VBlanks) presented since last reset
     u32 system_frames = 0;
     /// Cumulative number of game frames (GSP frame submissions) since last reset
-    u32 game_frames = 0;
+    std::atomic<u32> game_frames = 0;
 
     /// Point when the previous system frame ended
     Clock::time_point previous_frame_end = reset_point;
@@ -80,6 +81,8 @@ private:
     Clock::time_point frame_begin = reset_point;
     /// Total visible duration (including frame-limiting, etc.) of the previous system frame
     Clock::duration previous_frame_length = Clock::duration::zero();
+    /// Previously computed fps
+    double previous_fps = 0;
 };
 
 class FrameLimiter {

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -13,6 +13,7 @@
 #include "core/frontend/emu_window.h"
 #include "core/hardware_interrupt_manager.h"
 #include "core/memory.h"
+#include "core/perf_stats.h"
 #include "video_core/engines/fermi_2d.h"
 #include "video_core/engines/kepler_compute.h"
 #include "video_core/engines/kepler_memory.h"
@@ -189,6 +190,10 @@ u64 GPU::GetTicks() const {
     const u64 nanoseconds_num = nanoseconds / gpu_ticks_den;
     const u64 nanoseconds_rem = nanoseconds % gpu_ticks_den;
     return nanoseconds_num * gpu_ticks_num + (nanoseconds_rem * gpu_ticks_num) / gpu_ticks_den;
+}
+
+void GPU::RendererFrameEndNotify() {
+    system.GetPerfStats().EndGameFrame();
 }
 
 void GPU::FlushCommands() {

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -247,6 +247,8 @@ public:
         return use_nvdec;
     }
 
+    void RendererFrameEndNotify();
+
     enum class FenceOperation : u32 {
         Acquire = 0,
         Increment = 1,

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -155,6 +155,7 @@ void RendererOpenGL::SwapBuffers(const Tegra::FramebufferConfig* framebuffer) {
 
     ++m_current_frame;
 
+    gpu.RendererFrameEndNotify();
     rasterizer.TickFrame();
 
     context->SwapBuffers();

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -154,6 +154,7 @@ void RendererVulkan::SwapBuffers(const Tegra::FramebufferConfig* framebuffer) {
         if (swapchain.Present(render_semaphore)) {
             blit_screen.Recreate();
         }
+        gpu.RendererFrameEndNotify();
         rasterizer.TickFrame();
     }
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1377,7 +1377,7 @@ void GMainWindow::BootGame(const QString& filename, std::size_t program_index) {
         game_list->hide();
         game_list_placeholder->hide();
     }
-    status_bar_update_timer.start(2000);
+    status_bar_update_timer.start(500);
     async_status_button->setDisabled(true);
     multicore_status_button->setDisabled(true);
     renderer_status_button->setDisabled(true);
@@ -2797,7 +2797,7 @@ void GMainWindow::UpdateStatusBar() {
     } else {
         emu_speed_label->setText(tr("Speed: %1%").arg(results.emulation_speed * 100.0, 0, 'f', 0));
     }
-    game_fps_label->setText(tr("Game: %1 FPS").arg(results.game_fps, 0, 'f', 0));
+    game_fps_label->setText(tr("Game: %1 FPS").arg(results.average_game_fps, 0, 'f', 0));
     emu_frametime_label->setText(tr("Frame: %1 ms").arg(results.frametime * 1000.0, 0, 'f', 2));
 
     emu_speed_label->setVisible(!Settings::values.use_multi_core.GetValue());

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
@@ -215,7 +215,7 @@ void EmuWindow_SDL2::WaitEvent() {
         const auto results = Core::System::GetInstance().GetAndResetPerfStats();
         const auto title =
             fmt::format("yuzu {} | {}-{} | FPS: {:.0f} ({:.0f}%)", Common::g_build_fullname,
-                        Common::g_scm_branch, Common::g_scm_desc, results.game_fps,
+                        Common::g_scm_branch, Common::g_scm_desc, results.average_game_fps,
                         results.emulation_speed * 100.0);
         SDL_SetWindowTitle(render_window, title.c_str());
         last_time = current_time;


### PR DESCRIPTION
The FPS counter was based on metrics in the nvdisp swapbuffers call. This metric would be accurate if the gpu thread/renderer were synchronous with the nvdisp service, but that's no longer the case.

This commit moves the frame counting responsibility onto the concrete renderers after their frame draw calls. Resulting in more meaningful metrics.

The displayed FPS is now made up of the average framerate between the previous and most recent update, in order to avoid distracting FPS counter updates when framerate is oscillating between close values.

The status bar update frequency was also changed from 2 seconds to 500ms to allow for more frequent and up-tp-date information to be displayed.