### PR TITLE
main: Prevent installing base titles into NAND

### DIFF
--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -12,6 +12,7 @@
 #include "common/logging/log.h"
 #include "core/crypto/key_manager.h"
 #include "core/file_sys/card_image.h"
+#include "core/file_sys/common_funcs.h"
 #include "core/file_sys/content_archive.h"
 #include "core/file_sys/nca_metadata.h"
 #include "core/file_sys/registered_cache.h"
@@ -592,6 +593,12 @@ InstallResult RegisteredCache::InstallEntry(const NSP& nsp, bool overwrite_if_ex
     const CNMT cnmt(cnmt_file);
 
     const auto title_id = cnmt.GetTitleID();
+    const auto version = cnmt.GetTitleVersion();
+
+    if (title_id == GetBaseTitleID(title_id) && version == 0) {
+        return InstallResult::ErrorBaseInstall;
+    }
+
     const auto result = RemoveExistingEntry(title_id);
 
     // Install Metadata File

--- a/src/core/file_sys/registered_cache.h
+++ b/src/core/file_sys/registered_cache.h
@@ -38,6 +38,7 @@ enum class InstallResult {
     ErrorAlreadyExists,
     ErrorCopyFailed,
     ErrorMetaFailed,
+    ErrorBaseInstall,
 };
 
 struct ContentProviderEntry {

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -76,6 +76,7 @@ enum class InstallResult {
     Success,
     Overwrite,
     Failure,
+    BaseInstallAttempted,
 };
 
 enum class ReinitializeKeyBehavior {


### PR DESCRIPTION
Many users have been installing their base titles into NAND instead of adding them into the games list. This prevents users from installing any base titles and warns the user about the action.

Note: The warning message is not finalized yet.