### PR TITLE
ci: linux: Freeze AppImage binaries

### DIFF
--- a/.ci/scripts/linux/docker.sh
+++ b/.ci/scripts/linux/docker.sh
@@ -30,10 +30,10 @@ make install DESTDIR=AppDir
 rm -vf AppDir/usr/bin/yuzu-cmd AppDir/usr/bin/yuzu-tester
 
 # Download tools needed to build an AppImage
-wget -nc https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage
-wget -nc https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage
-wget -nc https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/AppRun-patched-x86_64
-wget -nc https://github.com/darealshinji/AppImageKit-checkrt/releases/download/continuous/exec-x86_64.so
+wget -nc https://github.com/yuzu-emu/ext-linux-bin/raw/main/appimage/linuxdeploy-x86_64.AppImage
+wget -nc https://github.com/yuzu-emu/ext-linux-bin/raw/main/appimage/linuxdeploy-plugin-qt-x86_64.AppImage
+wget -nc https://github.com/yuzu-emu/ext-linux-bin/raw/main/appimage/AppRun-patched-x86_64
+wget -nc https://github.com/yuzu-emu/ext-linux-bin/raw/main/appimage/exec-x86_64.so
 # Set executable bit
 chmod 755 \
     AppRun-patched-x86_64 \

--- a/.ci/scripts/linux/upload.sh
+++ b/.ci/scripts/linux/upload.sh
@@ -21,7 +21,7 @@ cp build/bin/yuzu "$DIR_NAME"
 # Build an AppImage
 cd build
 
-wget -nc https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+wget -nc https://github.com/yuzu-emu/ext-linux-bin/raw/main/appimage/appimagetool-x86_64.AppImage
 chmod 755 appimagetool-x86_64.AppImage
 
 if [ "${RELEASE_NAME}" = "mainline" ]; then


### PR DESCRIPTION
A regression was introduced on May 13 by linuxdeploy that causes file open dialogs to crash yuzu in the AppImage (likely this commit 1e28ee38fa174279defe70cdaadf2a552c80258c from linuxdeploy/linuxdeploy-desktopfile). Instead of downloading the latest version from each of the repos we use to build the AppImage, just download the ones hosted at yuzu-emu/ext-linux-bin. See yuzu-emu/ext-linux-bin a5bfaae7262630a83d2899e908cc4b6943ba6635 for the specific commits used for each binary.

These are the same binaries we have been using, but verified to be working and won't update on us beyond our control.

This can eventually be moved into the container itself and remove the need to download them at build time.