### PR TITLE
yuzu/main: Fix version info in logging and about dialog

### DIFF
--- a/src/yuzu/about_dialog.cpp
+++ b/src/yuzu/about_dialog.cpp
@@ -9,17 +9,19 @@
 #include "yuzu/about_dialog.h"
 
 AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent), ui(new Ui::AboutDialog) {
+    const auto branch_name = std::string(Common::g_scm_branch);
+    const auto description = std::string(Common::g_scm_desc);
     const auto build_id = std::string(Common::g_build_id);
-    const auto fmt = std::string(Common::g_title_bar_format_idle);
-    const auto yuzu_build_version =
-        fmt::format(fmt.empty() ? "yuzu Development Build" : fmt, std::string{}, std::string{},
-                    std::string{}, std::string{}, std::string{}, build_id);
+
+    const auto yuzu_build = fmt::format("yuzu Development Build | {}-{}", branch_name, description);
+    const auto override_build = fmt::format(std::string(Common::g_title_bar_format_idle), build_id);
+    const auto yuzu_build_version = override_build.empty() ? yuzu_build : override_build;
 
     ui->setupUi(this);
     ui->labelLogo->setPixmap(QIcon::fromTheme(QStringLiteral("yuzu")).pixmap(200));
-    ui->labelBuildInfo->setText(ui->labelBuildInfo->text().arg(
-        QString::fromStdString(yuzu_build_version), QString::fromUtf8(Common::g_scm_branch),
-        QString::fromUtf8(Common::g_scm_desc), QString::fromUtf8(Common::g_build_date).left(10)));
+    ui->labelBuildInfo->setText(
+        ui->labelBuildInfo->text().arg(QString::fromStdString(yuzu_build_version),
+                                       QString::fromUtf8(Common::g_build_date).left(10)));
 }
 
 AboutDialog::~AboutDialog() = default;

--- a/src/yuzu/aboutdialog.ui
+++ b/src/yuzu/aboutdialog.ui
@@ -70,7 +70,7 @@
           </sizepolicy>
          </property>
          <property name="text">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 | %2-%3 (%4)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;%1 (%2)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
         </widget>
        </item>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -241,14 +241,15 @@ GMainWindow::GMainWindow()
     ConnectMenuEvents();
     ConnectWidgetEvents();
 
+    const auto branch_name = std::string(Common::g_scm_branch);
+    const auto description = std::string(Common::g_scm_desc);
     const auto build_id = std::string(Common::g_build_id);
-    const auto fmt = std::string(Common::g_title_bar_format_idle);
-    const auto yuzu_build_version =
-        fmt::format(fmt.empty() ? "yuzu Development Build" : fmt, std::string{}, std::string{},
-                    std::string{}, std::string{}, std::string{}, build_id);
 
-    LOG_INFO(Frontend, "yuzu Version: {} | {}-{}", yuzu_build_version, Common::g_scm_branch,
-             Common::g_scm_desc);
+    const auto yuzu_build = fmt::format("yuzu Development Build | {}-{}", branch_name, description);
+    const auto override_build = fmt::format(std::string(Common::g_title_bar_format_idle), build_id);
+    const auto yuzu_build_version = override_build.empty() ? yuzu_build : override_build;
+
+    LOG_INFO(Frontend, "yuzu Version: {}", yuzu_build_version);
 #ifdef ARCHITECTURE_x86_64
     const auto& caps = Common::GetCPUCaps();
     std::string cpu_string = caps.cpu_string;


### PR DESCRIPTION
The nixing of the infamous dot in #6316 caused the yuzu version to disappear from logs and the about dialog.  This PR amends that.