### PR TITLE
hid/gesture: Simplify point related code

### DIFF
--- a/src/core/hle/service/hid/controllers/gesture.cpp
+++ b/src/core/hle/service/hid/controllers/gesture.cpp
@@ -123,8 +123,7 @@ void Controller_Gesture::UpdateGestureSharedMemory(u8* data, std::size_t size,
     cur_entry.sampling_number2 = cur_entry.sampling_number;
 
     // Reset values to default
-    cur_entry.delta_x = 0;
-    cur_entry.delta_y = 0;
+    cur_entry.delta = {};
     cur_entry.vel_x = 0;
     cur_entry.vel_y = 0;
     cur_entry.direction = Direction::None;
@@ -147,10 +146,7 @@ void Controller_Gesture::UpdateGestureSharedMemory(u8* data, std::size_t size,
     cur_entry.attributes = attributes;
     cur_entry.pos = gesture.mid_point;
     cur_entry.point_count = static_cast<s32>(gesture.active_points);
-    for (size_t id = 0; id < MAX_POINTS; id++) {
-        cur_entry.points[id].x = gesture.points[id].x;
-        cur_entry.points[id].y = gesture.points[id].y;
-    }
+    cur_entry.points = gesture.points;
     last_gesture = gesture;
 
     std::memcpy(data + SHARED_MEMORY_OFFSET, &shared_memory, sizeof(SharedMemory));
@@ -261,11 +257,10 @@ void Controller_Gesture::UpdatePanEvent(GestureProperties& gesture,
     auto& cur_entry = shared_memory.gesture_states[shared_memory.header.last_entry_index];
     const auto& last_entry =
         shared_memory.gesture_states[(shared_memory.header.last_entry_index + 16) % 17];
-    cur_entry.delta_x = gesture.mid_point.x - last_entry.pos.x;
-    cur_entry.delta_y = gesture.mid_point.y - last_entry.pos.y;
+    cur_entry.delta = gesture.mid_point - last_entry.pos;
 
-    cur_entry.vel_x = static_cast<f32>(cur_entry.delta_x) / time_difference;
-    cur_entry.vel_y = static_cast<f32>(cur_entry.delta_y) / time_difference;
+    cur_entry.vel_x = static_cast<f32>(cur_entry.delta.x) / time_difference;
+    cur_entry.vel_y = static_cast<f32>(cur_entry.delta.y) / time_difference;
     last_pan_time_difference = time_difference;
 
     // Promote to pinch type
@@ -292,9 +287,9 @@ void Controller_Gesture::EndPanEvent(GestureProperties& gesture,
     const auto& last_entry =
         shared_memory.gesture_states[(shared_memory.header.last_entry_index + 16) % 17];
     cur_entry.vel_x =
-        static_cast<f32>(last_entry.delta_x) / (last_pan_time_difference + time_difference);
+        static_cast<f32>(last_entry.delta.x) / (last_pan_time_difference + time_difference);
     cur_entry.vel_y =
-        static_cast<f32>(last_entry.delta_y) / (last_pan_time_difference + time_difference);
+        static_cast<f32>(last_entry.delta.y) / (last_pan_time_difference + time_difference);
     const f32 curr_vel =
         std::sqrt((cur_entry.vel_x * cur_entry.vel_x) + (cur_entry.vel_y * cur_entry.vel_y));
 
@@ -319,17 +314,17 @@ void Controller_Gesture::SetSwipeEvent(GestureProperties& gesture,
     type = TouchType::Swipe;
     gesture = last_gesture_props;
     force_update = true;
-    cur_entry.delta_x = last_entry.delta_x;
-    cur_entry.delta_y = last_entry.delta_y;
-    if (std::abs(cur_entry.delta_x) > std::abs(cur_entry.delta_y)) {
-        if (cur_entry.delta_x > 0) {
+    cur_entry.delta = last_entry.delta;
+
+    if (std::abs(cur_entry.delta.x) > std::abs(cur_entry.delta.y)) {
+        if (cur_entry.delta.x > 0) {
             cur_entry.direction = Direction::Right;
             return;
         }
         cur_entry.direction = Direction::Left;
         return;
     }
-    if (cur_entry.delta_y > 0) {
+    if (cur_entry.delta.y > 0) {
         cur_entry.direction = Direction::Down;
         return;
     }
@@ -375,8 +370,7 @@ std::size_t Controller_Gesture::UpdateTouchInputEvent(
             finger_id = first_free_id.value();
             fingers[finger_id].pressed = true;
         }
-        fingers[finger_id].x = x;
-        fingers[finger_id].y = y;
+        fingers[finger_id].pos = {x, y};
         return finger_id;
     }
 
@@ -396,17 +390,18 @@ Controller_Gesture::GestureProperties Controller_Gesture::GetGestureProperties()
         static_cast<std::size_t>(std::distance(active_fingers.begin(), end_iter));
 
     for (size_t id = 0; id < gesture.active_points; ++id) {
-        gesture.points[id].x =
-            static_cast<s32>(active_fingers[id].x * Layout::ScreenUndocked::Width);
-        gesture.points[id].y =
-            static_cast<s32>(active_fingers[id].y * Layout::ScreenUndocked::Height);
+        const auto& [active_x, active_y] = active_fingers[id].pos;
+        gesture.points[id] = {
+            .x = static_cast<s32>(active_x * Layout::ScreenUndocked::Width),
+            .y = static_cast<s32>(active_y * Layout::ScreenUndocked::Height),
+        };
 
         // Hack: There is no touch in docked but games still allow it
         if (Settings::values.use_docked_mode.GetValue()) {
-            gesture.points[id].x =
-                static_cast<s32>(active_fingers[id].x * Layout::ScreenDocked::Width);
-            gesture.points[id].y =
-                static_cast<s32>(active_fingers[id].y * Layout::ScreenDocked::Height);
+            gesture.points[id] = {
+                .x = static_cast<s32>(active_x * Layout::ScreenDocked::Width),
+                .y = static_cast<s32>(active_y * Layout::ScreenDocked::Height),
+            };
         }
 
         gesture.mid_point.x += static_cast<s32>(gesture.points[id].x / gesture.active_points);

--- a/src/core/hle/service/hid/controllers/gesture.cpp
+++ b/src/core/hle/service/hid/controllers/gesture.cpp
@@ -91,8 +91,7 @@ bool Controller_Gesture::ShouldUpdateGesture(const GestureProperties& gesture,
 
     // Update if coordinates change
     for (size_t id = 0; id < MAX_POINTS; id++) {
-        if (gesture.points[id].x != last_gesture.points[id].x ||
-            gesture.points[id].y != last_gesture.points[id].y) {
+        if (gesture.points[id] != last_gesture.points[id]) {
             return true;
         }
     }
@@ -179,8 +178,7 @@ void Controller_Gesture::UpdateExistingGesture(GestureProperties& gesture, Touch
 
     // Promote to pan type if touch moved
     for (size_t id = 0; id < MAX_POINTS; id++) {
-        if (gesture.points[id].x != last_gesture.points[id].x ||
-            gesture.points[id].y != last_gesture.points[id].y) {
+        if (gesture.points[id] != last_gesture.points[id]) {
             type = TouchType::Pan;
             break;
         }
@@ -192,10 +190,7 @@ void Controller_Gesture::UpdateExistingGesture(GestureProperties& gesture, Touch
         enable_press_and_tap = false;
         gesture.active_points = 0;
         gesture.mid_point = {};
-        for (size_t id = 0; id < MAX_POINTS; id++) {
-            gesture.points[id].x = 0;
-            gesture.points[id].y = 0;
-        }
+        gesture.points.fill({});
         return;
     }
 

--- a/src/core/hle/service/hid/controllers/gesture.cpp
+++ b/src/core/hle/service/hid/controllers/gesture.cpp
@@ -145,8 +145,7 @@ void Controller_Gesture::UpdateGestureSharedMemory(u8* data, std::size_t size,
     cur_entry.detection_count = gesture.detection_count;
     cur_entry.type = type;
     cur_entry.attributes = attributes;
-    cur_entry.x = gesture.mid_point.x;
-    cur_entry.y = gesture.mid_point.y;
+    cur_entry.pos = gesture.mid_point;
     cur_entry.point_count = static_cast<s32>(gesture.active_points);
     for (size_t id = 0; id < MAX_POINTS; id++) {
         cur_entry.points[id].x = gesture.points[id].x;
@@ -262,8 +261,8 @@ void Controller_Gesture::UpdatePanEvent(GestureProperties& gesture,
     auto& cur_entry = shared_memory.gesture_states[shared_memory.header.last_entry_index];
     const auto& last_entry =
         shared_memory.gesture_states[(shared_memory.header.last_entry_index + 16) % 17];
-    cur_entry.delta_x = gesture.mid_point.x - last_entry.x;
-    cur_entry.delta_y = gesture.mid_point.y - last_entry.y;
+    cur_entry.delta_x = gesture.mid_point.x - last_entry.pos.x;
+    cur_entry.delta_y = gesture.mid_point.y - last_entry.pos.y;
 
     cur_entry.vel_x = static_cast<f32>(cur_entry.delta_x) / time_difference;
     cur_entry.vel_y = static_cast<f32>(cur_entry.delta_y) / time_difference;

--- a/src/core/hle/service/hid/controllers/gesture.h
+++ b/src/core/hle/service/hid/controllers/gesture.h
@@ -180,10 +180,10 @@ private:
     std::unique_ptr<Input::TouchDevice> touch_mouse_device;
     std::unique_ptr<Input::TouchDevice> touch_udp_device;
     std::unique_ptr<Input::TouchDevice> touch_btn_device;
-    std::array<size_t, MAX_FINGERS> mouse_finger_id;
-    std::array<size_t, MAX_FINGERS> keyboard_finger_id;
-    std::array<size_t, MAX_FINGERS> udp_finger_id;
-    std::array<Finger, MAX_POINTS> fingers;
+    std::array<size_t, MAX_FINGERS> mouse_finger_id{};
+    std::array<size_t, MAX_FINGERS> keyboard_finger_id{};
+    std::array<size_t, MAX_FINGERS> udp_finger_id{};
+    std::array<Finger, MAX_POINTS> fingers{};
     GestureProperties last_gesture{};
     s64_le last_update_timestamp{};
     s64_le last_tap_timestamp{};

--- a/src/core/hle/service/hid/controllers/gesture.h
+++ b/src/core/hle/service/hid/controllers/gesture.h
@@ -63,11 +63,11 @@ private:
     };
     static_assert(sizeof(Attribute) == 4, "Attribute is an invalid size");
 
-    struct Points {
+    struct Point {
         s32_le x;
         s32_le y;
     };
-    static_assert(sizeof(Points) == 8, "Points is an invalid size");
+    static_assert(sizeof(Point) == 8, "Point is an invalid size");
 
     struct GestureState {
         s64_le sampling_number;
@@ -85,7 +85,7 @@ private:
         f32 scale;
         f32 rotation_angle;
         s32_le point_count;
-        std::array<Points, 4> points;
+        std::array<Point, 4> points;
     };
     static_assert(sizeof(GestureState) == 0x68, "GestureState is an invalid size");
 
@@ -102,9 +102,9 @@ private:
     };
 
     struct GestureProperties {
-        std::array<Points, MAX_POINTS> points{};
+        std::array<Point, MAX_POINTS> points{};
         std::size_t active_points{};
-        Points mid_point{};
+        Point mid_point{};
         s64_le detection_count{};
         u64_le delta_time{};
         f32 average_distance{};

--- a/src/core/hle/service/hid/controllers/gesture.h
+++ b/src/core/hle/service/hid/controllers/gesture.h
@@ -77,8 +77,7 @@ private:
         s64_le detection_count;
         TouchType type;
         Direction direction;
-        s32_le x;
-        s32_le y;
+        Point pos;
         s32_le delta_x;
         s32_le delta_y;
         f32 vel_x;

--- a/src/core/hle/service/hid/controllers/gesture.h
+++ b/src/core/hle/service/hid/controllers/gesture.h
@@ -64,8 +64,10 @@ private:
     static_assert(sizeof(Attribute) == 4, "Attribute is an invalid size");
 
     struct Point {
-        s32_le x;
-        s32_le y;
+        s32_le x{};
+        s32_le y{};
+
+        friend bool operator==(const Point&, const Point&) = default;
     };
     static_assert(sizeof(Point) == 8, "Point is an invalid size");
 

--- a/src/core/hle/service/hid/controllers/gesture.h
+++ b/src/core/hle/service/hid/controllers/gesture.h
@@ -63,13 +63,28 @@ private:
     };
     static_assert(sizeof(Attribute) == 4, "Attribute is an invalid size");
 
+    template <typename T>
     struct Point {
-        s32_le x{};
-        s32_le y{};
+        T x{};
+        T y{};
+
+        friend Point operator+(const Point& lhs, const Point& rhs) {
+            return {
+                .x = lhs.x + rhs.x,
+                .y = lhs.y + rhs.y,
+            };
+        }
+
+        friend Point operator-(const Point& lhs, const Point& rhs) {
+            return {
+                .x = lhs.x - rhs.x,
+                .y = lhs.y - rhs.y,
+            };
+        }
 
         friend bool operator==(const Point&, const Point&) = default;
     };
-    static_assert(sizeof(Point) == 8, "Point is an invalid size");
+    static_assert(sizeof(Point<s32_le>) == 8, "Point is an invalid size");
 
     struct GestureState {
         s64_le sampling_number;
@@ -77,16 +92,15 @@ private:
         s64_le detection_count;
         TouchType type;
         Direction direction;
-        Point pos;
-        s32_le delta_x;
-        s32_le delta_y;
+        Point<s32_le> pos;
+        Point<s32_le> delta;
         f32 vel_x;
         f32 vel_y;
         Attribute attributes;
         f32 scale;
         f32 rotation_angle;
         s32_le point_count;
-        std::array<Point, 4> points;
+        std::array<Point<s32_le>, 4> points;
     };
     static_assert(sizeof(GestureState) == 0x68, "GestureState is an invalid size");
 
@@ -97,15 +111,14 @@ private:
     static_assert(sizeof(SharedMemory) == 0x708, "SharedMemory is an invalid size");
 
     struct Finger {
-        f32 x{};
-        f32 y{};
+        Point<f32> pos{};
         bool pressed{};
     };
 
     struct GestureProperties {
-        std::array<Point, MAX_POINTS> points{};
+        std::array<Point<s32_le>, MAX_POINTS> points{};
         std::size_t active_points{};
-        Point mid_point{};
+        Point<s32_le> mid_point{};
         s64_le detection_count{};
         u64_le delta_time{};
         f32 average_distance{};

--- a/src/core/hle/service/hid/controllers/gesture.h
+++ b/src/core/hle/service/hid/controllers/gesture.h
@@ -162,7 +162,11 @@ private:
                        TouchType& type);
 
     // Returns an unused finger id, if there is no fingers available std::nullopt is returned.
-    std::optional<size_t> GetUnusedFingerID() const;
+    [[nodiscard]] std::optional<size_t> GetUnusedFingerID() const;
+
+    // Retrieves the last gesture entry, as indicated by shared memory indices.
+    [[nodiscard]] GestureState& GetLastGestureEntry();
+    [[nodiscard]] const GestureState& GetLastGestureEntry() const;
 
     /**
      * If the touch is new it tries to assign a new finger id, if there is no fingers available no


### PR DESCRIPTION
We can extend the point struct a little bit to make comparisons and other related operations with points a little less noisy for reading.