### PR TITLE
KTransferMemory: Return size instead of size * PageSize in GetSize()

### DIFF
--- a/src/core/hle/kernel/k_transfer_memory.h
+++ b/src/core/hle/kernel/k_transfer_memory.h
@@ -52,7 +52,7 @@ public:
     }
 
     size_t GetSize() const {
-        return is_initialized ? size * PageSize : 0;
+        return is_initialized ? size : 0;
     }
 
 private:


### PR DESCRIPTION
size is already the size in bytes. We do not need to multiply it by the page size