### PR TITLE
applets/swkbd: Make use of QueuedConnection in returnPressed signal

### DIFF
--- a/src/yuzu/applets/software_keyboard.cpp
+++ b/src/yuzu/applets/software_keyboard.cpp
@@ -720,21 +720,9 @@ void QtSoftwareKeyboardDialog::SetTextDrawType() {
                     ui->line_edit_osk->setFocus();
                 });
 
-        connect(ui->line_edit_osk, &QLineEdit::returnPressed, [this] {
-            switch (bottom_osk_index) {
-            case BottomOSKIndex::LowerCase:
-                ui->button_ok->click();
-                break;
-            case BottomOSKIndex::UpperCase:
-                ui->button_ok_shift->click();
-                break;
-            case BottomOSKIndex::NumberPad:
-                ui->button_ok_num->click();
-                break;
-            default:
-                break;
-            }
-        });
+        connect(
+            ui->line_edit_osk, &QLineEdit::returnPressed, this,
+            [this] { TranslateButtonPress(HIDButton::Plus); }, Qt::QueuedConnection);
 
         ui->line_edit_osk->setPlaceholderText(
             QString::fromStdU16String(initialize_parameters.guide_text));


### PR DESCRIPTION
Some users have reported rare crashes when pressing the Enter key on the keyboard to confirm input in the normal software keyboard, particularly in Super Smash Bros. Ultimate while entering the name of a ruleset or controller layout.

It is suspected that the QLineEdit::returnPressed signal is causing a race condition as confirming input through other means does not produce the crash. Since Qt::QueuedConnection posts an event to the event queue of the callee's thread instead of executing it directly on the caller's thread, this eliminates any potential race conditions from occurring in this scenario.