### PR TITLE
yuzu qt: Add an Apply button to configuration dialogs

### DIFF
--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -2,8 +2,11 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <QAbstractButton>
+#include <QDialogButtonBox>
 #include <QHash>
 #include <QListWidgetItem>
+#include <QPushButton>
 #include <QSignalBlocker>
 #include "common/settings.h"
 #include "core/core.h"
@@ -30,6 +33,12 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry,
     connect(ui->uiTab, &ConfigureUi::LanguageChanged, this, &ConfigureDialog::OnLanguageChanged);
     connect(ui->selectorList, &QListWidget::itemSelectionChanged, this,
             &ConfigureDialog::UpdateVisibleTabs);
+
+    if (Core::System::GetInstance().IsPoweredOn()) {
+        QPushButton* apply_button = ui->buttonBox->addButton(QDialogButtonBox::Apply);
+        connect(apply_button, &QAbstractButton::clicked, this,
+                &ConfigureDialog::HandleApplyButtonClicked);
+    }
 
     adjustSize();
     ui->selectorList->setCurrentRow(0);
@@ -78,6 +87,11 @@ void ConfigureDialog::RetranslateUI() {
 
     UpdateVisibleTabs();
     ui->tabWidget->setCurrentIndex(old_index);
+}
+
+void ConfigureDialog::HandleApplyButtonClicked() {
+    UISettings::values.configuration_applied = true;
+    ApplyConfiguration();
 }
 
 Q_DECLARE_METATYPE(QList<QWidget*>);

--- a/src/yuzu/configuration/configure_dialog.h
+++ b/src/yuzu/configuration/configure_dialog.h
@@ -35,8 +35,9 @@ signals:
 
 private:
     void changeEvent(QEvent* event) override;
-
     void RetranslateUI();
+
+    void HandleApplyButtonClicked();
 
     void SetConfiguration();
     void UpdateVisibleTabs();

--- a/src/yuzu/configuration/configure_per_game.cpp
+++ b/src/yuzu/configuration/configure_per_game.cpp
@@ -6,9 +6,12 @@
 #include <memory>
 #include <utility>
 
+#include <QAbstractButton>
 #include <QCheckBox>
+#include <QDialogButtonBox>
 #include <QHeaderView>
 #include <QMenu>
+#include <QPushButton>
 #include <QStandardItemModel>
 #include <QString>
 #include <QTimer>
@@ -44,6 +47,12 @@ ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id)
     scene = new QGraphicsScene;
     ui->icon_view->setScene(scene);
 
+    if (Core::System::GetInstance().IsPoweredOn()) {
+        QPushButton* apply_button = ui->buttonBox->addButton(QDialogButtonBox::Apply);
+        connect(apply_button, &QAbstractButton::clicked, this,
+                &ConfigurePerGame::HandleApplyButtonClicked);
+    }
+
     LoadConfiguration();
 }
 
@@ -74,6 +83,11 @@ void ConfigurePerGame::changeEvent(QEvent* event) {
 
 void ConfigurePerGame::RetranslateUI() {
     ui->retranslateUi(this);
+}
+
+void ConfigurePerGame::HandleApplyButtonClicked() {
+    UISettings::values.configuration_applied = true;
+    ApplyConfiguration();
 }
 
 void ConfigurePerGame::LoadFromFile(FileSys::VirtualFile file) {

--- a/src/yuzu/configuration/configure_per_game.h
+++ b/src/yuzu/configuration/configure_per_game.h
@@ -39,6 +39,8 @@ private:
     void changeEvent(QEvent* event) override;
     void RetranslateUI();
 
+    void HandleApplyButtonClicked();
+
     void LoadConfiguration();
 
     std::unique_ptr<Ui::ConfigurePerGame> ui;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2578,12 +2578,12 @@ void GMainWindow::OnConfigure() {
             &GMainWindow::OnLanguageChanged);
 
     const auto result = configure_dialog.exec();
-    if (result != QDialog::Accepted) {
+    if (result != QDialog::Accepted && !UISettings::values.configuration_applied) {
         return;
+    } else if (result == QDialog::Accepted) {
+        configure_dialog.ApplyConfiguration();
+        controller_dialog->refreshConfiguration();
     }
-
-    configure_dialog.ApplyConfiguration();
-    controller_dialog->refreshConfiguration();
     InitializeHotkeys();
     if (UISettings::values.theme != old_theme) {
         UpdateUITheme();
@@ -2597,6 +2597,8 @@ void GMainWindow::OnConfigure() {
     if (reload) {
         game_list->PopulateAsync(UISettings::values.game_dirs);
     }
+
+    UISettings::values.configuration_applied = false;
 
     config->Save();
 
@@ -2627,23 +2629,27 @@ void GMainWindow::OpenPerGameConfiguration(u64 title_id, const std::string& file
     ConfigurePerGame dialog(this, title_id);
     dialog.LoadFromFile(v_file);
     const auto result = dialog.exec();
-    if (result == QDialog::Accepted) {
-        dialog.ApplyConfiguration();
 
-        const auto reload = UISettings::values.is_game_list_reload_pending.exchange(false);
-        if (reload) {
-            game_list->PopulateAsync(UISettings::values.game_dirs);
-        }
-
-        // Do not cause the global config to write local settings into the config file
-        const bool is_powered_on = system.IsPoweredOn();
-        Settings::RestoreGlobalState(is_powered_on);
-
-        if (!is_powered_on) {
-            config->Save();
-        }
-    } else {
+    if (result != QDialog::Accepted && !UISettings::values.configuration_applied) {
         Settings::RestoreGlobalState(system.IsPoweredOn());
+        return;
+    } else if (result == QDialog::Accepted) {
+        dialog.ApplyConfiguration();
+    }
+
+    const auto reload = UISettings::values.is_game_list_reload_pending.exchange(false);
+    if (reload) {
+        game_list->PopulateAsync(UISettings::values.game_dirs);
+    }
+
+    // Do not cause the global config to write local settings into the config file
+    const bool is_powered_on = system.IsPoweredOn();
+    Settings::RestoreGlobalState(is_powered_on);
+
+    UISettings::values.configuration_applied = false;
+
+    if (!is_powered_on) {
+        config->Save();
     }
 }
 

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -95,6 +95,8 @@ struct Values {
     uint8_t row_2_text_id;
     std::atomic_bool is_game_list_reload_pending{false};
     bool cache_game_list;
+
+    bool configuration_applied;
 };
 
 extern Values values;


### PR DESCRIPTION
Most of the code already exists to do this, but the Apply button itself was never added. This adds a button and boolean that tells yuzu to save the configuration after applying settings, even if close/Cancel is pressed on the dialog. Changes after applying will not be saved when Cancel is pressed, though.

The Apply button will only appear on the Configuration and Game Properties dialog if a game is running. This can be changed if people think it's too confusing.