### PR TITLE
CMakeLists: Update zstd to 1.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,7 @@ macro(yuzu_find_packages)
         "lz4               1.8         lz4/1.9.2"
         "nlohmann_json     3.8         nlohmann_json/3.8.0"
         "ZLIB              1.2         zlib/1.2.11"
-        "zstd              1.4         zstd/1.4.8"
+        "zstd              1.5         zstd/1.5.0"
     # can't use opus until AVX check is fixed: https://github.com/yuzu-emu/yuzu/pull/4068
         #"opus              1.3         opus/1.3.1"
     )


### PR DESCRIPTION
zstd 1.5.0 brings numerous performance improvements to the library, as well as faster decompression speed. Should result in a tiny boost to shader cache compression/decompression.

More info can be seen [here](https://github.com/facebook/zstd/releases/tag/v1.5.0)