### PR TITLE
settings: Forbid docked mode on handheld

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -514,6 +514,13 @@ void Config::ReadControlValues() {
         ReadSetting(QStringLiteral("mouse_panning_sensitivity"), 1).toFloat();
 
     ReadSettingGlobal(Settings::values.use_docked_mode, QStringLiteral("use_docked_mode"), true);
+
+    // Disable docked mode if handheld is selected
+    const auto controller_type = Settings::values.players.GetValue()[0].controller_type;
+    if (controller_type == Settings::ControllerType::Handheld) {
+        Settings::values.use_docked_mode.SetValue(false);
+    }
+
     ReadSettingGlobal(Settings::values.vibration_enabled, QStringLiteral("vibration_enabled"),
                       true);
     ReadSettingGlobal(Settings::values.enable_accurate_vibrations,

--- a/src/yuzu/debugger/controller.cpp
+++ b/src/yuzu/debugger/controller.cpp
@@ -38,6 +38,7 @@ void ControllerDialog::refreshConfiguration() {
     widget->SetPlayerInputRaw(player, players[player].buttons, players[player].analogs);
     widget->SetConnectedStatus(players[player].connected);
     widget->SetControllerType(players[player].controller_type);
+    widget->repaint();
 }
 
 QAction* ControllerDialog::toggleViewAction() {


### PR DESCRIPTION
It's imposible to use docked mode on handheld on real HW. This breaks some games like XC2. This PR fixes this issue by changing the controller type to Pro controller if an user tries to enable docked mode.