### PR TITLE
common/compression: Make use of std::span

### DIFF
--- a/src/common/lz4_compression.cpp
+++ b/src/common/lz4_compression.cpp
@@ -59,8 +59,7 @@ std::vector<u8> CompressDataLZ4HCMax(const u8* source, std::size_t source_size) 
     return CompressDataLZ4HC(source, source_size, LZ4HC_CLEVEL_MAX);
 }
 
-std::vector<u8> DecompressDataLZ4(const std::vector<u8>& compressed,
-                                  std::size_t uncompressed_size) {
+std::vector<u8> DecompressDataLZ4(std::span<const u8> compressed, std::size_t uncompressed_size) {
     std::vector<u8> uncompressed(uncompressed_size);
     const int size_check = LZ4_decompress_safe(reinterpret_cast<const char*>(compressed.data()),
                                                reinterpret_cast<char*>(uncompressed.data()),

--- a/src/common/lz4_compression.h
+++ b/src/common/lz4_compression.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <span>
 #include <vector>
 
 #include "common/common_types.h"
@@ -53,7 +54,7 @@ namespace Common::Compression {
  *
  * @return the decompressed data.
  */
-[[nodiscard]] std::vector<u8> DecompressDataLZ4(const std::vector<u8>& compressed,
+[[nodiscard]] std::vector<u8> DecompressDataLZ4(std::span<const u8> compressed,
                                                 std::size_t uncompressed_size);
 
 } // namespace Common::Compression

--- a/src/common/zstd_compression.cpp
+++ b/src/common/zstd_compression.cpp
@@ -32,7 +32,7 @@ std::vector<u8> CompressDataZSTDDefault(const u8* source, std::size_t source_siz
     return CompressDataZSTD(source, source_size, ZSTD_CLEVEL_DEFAULT);
 }
 
-std::vector<u8> DecompressDataZSTD(const std::vector<u8>& compressed) {
+std::vector<u8> DecompressDataZSTD(std::span<const u8> compressed) {
     const std::size_t decompressed_size =
         ZSTD_getDecompressedSize(compressed.data(), compressed.size());
     std::vector<u8> decompressed(decompressed_size);

--- a/src/common/zstd_compression.h
+++ b/src/common/zstd_compression.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <span>
 #include <vector>
 
 #include "common/common_types.h"
@@ -40,6 +41,6 @@ namespace Common::Compression {
  *
  * @return the decompressed data.
  */
-[[nodiscard]] std::vector<u8> DecompressDataZSTD(const std::vector<u8>& compressed);
+[[nodiscard]] std::vector<u8> DecompressDataZSTD(std::span<const u8> compressed);
 
 } // namespace Common::Compression


### PR DESCRIPTION
Allows the incoming data streams to the APIs to be non-allocating and support more container types.