### PR TITLE
yuzu qt: Handle per-game configs for title id 0

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -16,7 +16,7 @@
 
 namespace FS = Common::FS;
 
-Config::Config(const std::string& config_name, ConfigType config_type) : type(config_type) {
+Config::Config(std::string_view config_name, ConfigType config_type) : type(config_type) {
     global = config_type == ConfigType::GlobalConfig;
 
     Initialize(config_name);
@@ -242,7 +242,7 @@ const std::array<UISettings::Shortcut, 17> Config::default_hotkeys{{
 }};
 // clang-format on
 
-void Config::Initialize(const std::string& config_name) {
+void Config::Initialize(std::string_view config_name) {
     const auto fs_config_loc = FS::GetYuzuPath(FS::YuzuPath::ConfigDir);
     const auto config_file = fmt::format("{}.ini", config_name);
 

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -22,7 +22,7 @@ public:
         InputProfile,
     };
 
-    explicit Config(const std::string& config_name = "qt-config",
+    explicit Config(std::string_view config_name = "qt-config",
                     ConfigType config_type = ConfigType::GlobalConfig);
     ~Config();
 
@@ -45,7 +45,7 @@ public:
     static const std::array<UISettings::Shortcut, 17> default_hotkeys;
 
 private:
-    void Initialize(const std::string& config_name);
+    void Initialize(std::string_view config_name);
 
     void ReadValues();
     void ReadPlayerValue(std::size_t player_index);

--- a/src/yuzu/configuration/configure_per_game.cpp
+++ b/src/yuzu/configuration/configure_per_game.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <string>
 #include <utility>
 
 #include <QCheckBox>
@@ -14,6 +15,7 @@
 #include <QTimer>
 #include <QTreeView>
 
+#include "common/fs/path_util.h"
 #include "core/core.h"
 #include "core/file_sys/control_metadata.h"
 #include "core/file_sys/patch_manager.h"
@@ -26,10 +28,15 @@
 #include "yuzu/uisettings.h"
 #include "yuzu/util/util.h"
 
-ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id)
+ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id, std::string_view file_name)
     : QDialog(parent), ui(std::make_unique<Ui::ConfigurePerGame>()), title_id(title_id) {
-    game_config = std::make_unique<Config>(fmt::format("{:016X}", title_id),
-                                           Config::ConfigType::PerGameConfig);
+    if (title_id == 0) {
+        game_config = std::make_unique<Config>(Common::FS::GetFilename(file_name),
+                                               Config::ConfigType::PerGameConfig);
+    } else {
+        game_config = std::make_unique<Config>(fmt::format("{:016X}", title_id),
+                                               Config::ConfigType::PerGameConfig);
+    }
 
     Settings::SetConfiguringGlobal(false);
 

--- a/src/yuzu/configuration/configure_per_game.h
+++ b/src/yuzu/configuration/configure_per_game.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <string>
 #include <vector>
 
 #include <QDialog>
@@ -27,7 +28,7 @@ class ConfigurePerGame : public QDialog {
     Q_OBJECT
 
 public:
-    explicit ConfigurePerGame(QWidget* parent, u64 title_id);
+    explicit ConfigurePerGame(QWidget* parent, u64 title_id, std::string_view file_name);
     ~ConfigurePerGame() override;
 
     /// Save all button configurations to settings file

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -561,11 +561,11 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, const std::stri
     connect(remove_dlc, &QAction::triggered, [this, program_id]() {
         emit RemoveInstalledEntryRequested(program_id, InstalledEntryType::AddOnContent);
     });
-    connect(remove_shader_cache, &QAction::triggered, [this, program_id]() {
-        emit RemoveFileRequested(program_id, GameListRemoveTarget::ShaderCache);
+    connect(remove_shader_cache, &QAction::triggered, [this, program_id, path]() {
+        emit RemoveFileRequested(program_id, GameListRemoveTarget::ShaderCache, path);
     });
-    connect(remove_custom_config, &QAction::triggered, [this, program_id]() {
-        emit RemoveFileRequested(program_id, GameListRemoveTarget::CustomConfiguration);
+    connect(remove_custom_config, &QAction::triggered, [this, program_id, path]() {
+        emit RemoveFileRequested(program_id, GameListRemoveTarget::CustomConfiguration, path);
     });
     connect(dump_romfs, &QAction::triggered,
             [this, program_id, path]() { emit DumpRomFSRequested(program_id, path); });

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -88,7 +88,8 @@ signals:
                              const std::string& game_path);
     void OpenTransferableShaderCacheRequested(u64 program_id);
     void RemoveInstalledEntryRequested(u64 program_id, InstalledEntryType type);
-    void RemoveFileRequested(u64 program_id, GameListRemoveTarget target);
+    void RemoveFileRequested(u64 program_id, GameListRemoveTarget target,
+                             std::string_view game_path);
     void DumpRomFSRequested(u64 program_id, const std::string& game_path);
     void CopyTIDRequested(u64 program_id);
     void NavigateToGamedbEntryRequested(u64 program_id,

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1334,7 +1334,13 @@ void GMainWindow::BootGame(const QString& filename, std::size_t program_index) {
 
     if (!(loader == nullptr || loader->ReadProgramId(title_id) != Loader::ResultStatus::Success)) {
         // Load per game settings
-        Config per_game_config(fmt::format("{:016X}", title_id), Config::ConfigType::PerGameConfig);
+        if (title_id == 0) {
+            Config per_game_config(Common::FS::GetFilename(filename.toStdString()),
+                                   Config::ConfigType::PerGameConfig);
+        } else {
+            Config per_game_config(fmt::format("{:016X}", title_id),
+                                   Config::ConfigType::PerGameConfig);
+        }
     }
 
     ConfigureVibration::SetAllVibrationDevices();
@@ -1795,7 +1801,8 @@ void GMainWindow::RemoveAddOnContent(u64 program_id, const QString& entry_type) 
                              tr("Successfully removed %1 installed DLC.").arg(count));
 }
 
-void GMainWindow::OnGameListRemoveFile(u64 program_id, GameListRemoveTarget target) {
+void GMainWindow::OnGameListRemoveFile(u64 program_id, GameListRemoveTarget target,
+                                       std::string_view game_path) {
     const QString question = [this, target] {
         switch (target) {
         case GameListRemoveTarget::ShaderCache:
@@ -1817,7 +1824,7 @@ void GMainWindow::OnGameListRemoveFile(u64 program_id, GameListRemoveTarget targ
         RemoveTransferableShaderCache(program_id);
         break;
     case GameListRemoveTarget::CustomConfiguration:
-        RemoveCustomConfiguration(program_id);
+        RemoveCustomConfiguration(program_id, game_path);
         break;
     }
 }
@@ -1842,9 +1849,16 @@ void GMainWindow::RemoveTransferableShaderCache(u64 program_id) {
     }
 }
 
-void GMainWindow::RemoveCustomConfiguration(u64 program_id) {
-    const auto custom_config_file_path = Common::FS::GetYuzuPath(Common::FS::YuzuPath::ConfigDir) /
-                                         "custom" / fmt::format("{:016X}.ini", program_id);
+void GMainWindow::RemoveCustomConfiguration(u64 program_id, std::string_view game_path) {
+    std::string custom_config_file_path;
+    if (program_id == 0) {
+        custom_config_file_path = Common::FS::GetYuzuPath(Common::FS::YuzuPath::ConfigDir) /
+                                  "custom" /
+                                  fmt::format("{:s}.ini", Common::FS::GetFilename(game_path));
+    } else {
+        custom_config_file_path = Common::FS::GetYuzuPath(Common::FS::YuzuPath::ConfigDir) /
+                                  "custom" / fmt::format("{:016X}.ini", program_id);
+    }
 
     if (!Common::FS::Exists(custom_config_file_path)) {
         QMessageBox::warning(this, tr("Error Removing Custom Configuration"),
@@ -2633,7 +2647,7 @@ void GMainWindow::OpenPerGameConfiguration(u64 title_id, const std::string& file
     const auto v_file = Core::GetGameFileFromPath(vfs, file_name);
     const auto& system = Core::System::GetInstance();
 
-    ConfigurePerGame dialog(this, title_id);
+    ConfigurePerGame dialog(this, title_id, file_name);
     dialog.LoadFromFile(v_file);
     const auto result = dialog.exec();
     if (result == QDialog::Accepted) {

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -236,7 +236,8 @@ private slots:
                               const std::string& game_path);
     void OnTransferableShaderCacheOpenFile(u64 program_id);
     void OnGameListRemoveInstalledEntry(u64 program_id, InstalledEntryType type);
-    void OnGameListRemoveFile(u64 program_id, GameListRemoveTarget target);
+    void OnGameListRemoveFile(u64 program_id, GameListRemoveTarget target,
+                              std::string_view game_path);
     void OnGameListDumpRomFS(u64 program_id, const std::string& game_path);
     void OnGameListCopyTID(u64 program_id);
     void OnGameListNavigateToGamedbEntry(u64 program_id,
@@ -275,7 +276,7 @@ private:
     void RemoveUpdateContent(u64 program_id, const QString& entry_type);
     void RemoveAddOnContent(u64 program_id, const QString& entry_type);
     void RemoveTransferableShaderCache(u64 program_id);
-    void RemoveCustomConfiguration(u64 program_id);
+    void RemoveCustomConfiguration(u64 program_id, std::string_view game_path);
     std::optional<u64> SelectRomFSDumpTarget(const FileSys::ContentProvider&, u64 program_id);
     InstallResult InstallNSPXCI(const QString& filename);
     InstallResult InstallNCA(const QString& filename);


### PR DESCRIPTION
Currently with programs that have a 0 title id, yuzu loads the custom configuration `0000000000000000.ini` for per-game configs. This is not ideal since many homebrews share this id. Instead for these programs, we load a config that is simply the file name and `.ini` appended to it.

This also changes a few things to use a `std::string_view` instead of a `const std::string&`.