### PR TITLE
video_core: rasterizer_cache: Use u16 for cached page count.

### DIFF
--- a/src/video_core/rasterizer_accelerated.cpp
+++ b/src/video_core/rasterizer_accelerated.cpp
@@ -18,10 +18,10 @@ RasterizerAccelerated::~RasterizerAccelerated() = default;
 void RasterizerAccelerated::UpdatePagesCachedCount(VAddr addr, u64 size, int delta) {
     const auto page_end = Common::DivCeil(addr + size, Core::Memory::PAGE_SIZE);
     for (auto page = addr >> Core::Memory::PAGE_BITS; page != page_end; ++page) {
-        auto& count = cached_pages.at(page >> 3).Count(page);
+        auto& count = cached_pages.at(page >> 2).Count(page);
 
         if (delta > 0) {
-            ASSERT_MSG(count < UINT8_MAX, "Count may overflow!");
+            ASSERT_MSG(count < UINT16_MAX, "Count may overflow!");
         } else if (delta < 0) {
             ASSERT_MSG(count > 0, "Count may underflow!");
         } else {
@@ -29,7 +29,7 @@ void RasterizerAccelerated::UpdatePagesCachedCount(VAddr addr, u64 size, int del
         }
 
         // Adds or subtracts 1, as count is a unsigned 8-bit value
-        count += static_cast<u8>(delta);
+        count += static_cast<u16>(delta);
 
         // Assume delta is either -1 or 1
         if (count == 0) {

--- a/src/video_core/rasterizer_accelerated.h
+++ b/src/video_core/rasterizer_accelerated.h
@@ -29,20 +29,20 @@ private:
     public:
         CacheEntry() = default;
 
-        std::atomic_uint8_t& Count(std::size_t page) {
-            return values[page & 7];
+        std::atomic_uint16_t& Count(std::size_t page) {
+            return values[page & 3];
         }
 
-        const std::atomic_uint8_t& Count(std::size_t page) const {
-            return values[page & 7];
+        const std::atomic_uint16_t& Count(std::size_t page) const {
+            return values[page & 3];
         }
 
     private:
-        std::array<std::atomic_uint8_t, 8> values{};
+        std::array<std::atomic_uint16_t, 4> values{};
     };
     static_assert(sizeof(CacheEntry) == 8, "CacheEntry should be 8 bytes!");
 
-    std::array<CacheEntry, 0x800000> cached_pages;
+    std::array<CacheEntry, 0x1000000> cached_pages;
     Core::Memory::Memory& cpu_memory;
 };
 


### PR DESCRIPTION
- Greatly reduces the risk of overflow, at the cost of doubling the size of this array.