### PR TITLE
common/fs/file: Default initialize IOFile members

### DIFF
--- a/src/common/fs/file.h
+++ b/src/common/fs/file.h
@@ -117,7 +117,7 @@ template <typename Path>
 }
 #endif
 
-class IOFile final : NonCopyable {
+class IOFile final {
 public:
     IOFile();
 
@@ -143,6 +143,9 @@ public:
                     FileShareFlag flag = FileShareFlag::ShareReadOnly);
 
     ~IOFile();
+
+    IOFile(const IOFile&) = delete;
+    IOFile& operator=(const IOFile&) = delete;
 
     IOFile(IOFile&& other) noexcept;
     IOFile& operator=(IOFile&& other) noexcept;

--- a/src/common/fs/file.h
+++ b/src/common/fs/file.h
@@ -142,7 +142,7 @@ public:
                     FileType type = FileType::BinaryFile,
                     FileShareFlag flag = FileShareFlag::ShareReadOnly);
 
-    virtual ~IOFile();
+    ~IOFile();
 
     IOFile(IOFile&& other) noexcept;
     IOFile& operator=(IOFile&& other) noexcept;

--- a/src/common/fs/file.h
+++ b/src/common/fs/file.h
@@ -441,8 +441,8 @@ public:
 
 private:
     std::filesystem::path file_path;
-    FileAccessMode file_access_mode;
-    FileType file_type;
+    FileAccessMode file_access_mode{};
+    FileType file_type{};
 
     std::FILE* file = nullptr;
 };


### PR DESCRIPTION
Prevents a potential uninitialized read bug vector in the move constructor in some circumstances (e.g. moving into a default constructed IOFile object)

While we're in the same area, we can make a few minor adjustments.