### PR TITLE
texture_cache: Implement a very basic GC

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -97,6 +97,7 @@ bool IsFastmemEnabled() {
         return values.cpuopt_fastmem;
     }
     return true;
+}
 
 bool UseGarbageCollect() {
     return values.use_garbage_collect.GetValue();

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -52,6 +52,8 @@ void LogSettings() {
     log_setting("Renderer_FrameLimit", values.frame_limit.GetValue());
     log_setting("Renderer_UseDiskShaderCache", values.use_disk_shader_cache.GetValue());
     log_setting("Renderer_GPUAccuracyLevel", values.gpu_accuracy.GetValue());
+    log_setting("Renderer_UseGarbageCollect", values.use_garbage_collect.GetValue());
+    log_setting("Renderer_GarbageCollectLevel", values.garbage_collect_level.GetValue());
     log_setting("Renderer_UseAsynchronousGpuEmulation",
                 values.use_asynchronous_gpu_emulation.GetValue());
     log_setting("Renderer_UseNvdecEmulation", values.use_nvdec_emulation.GetValue());
@@ -95,6 +97,24 @@ bool IsFastmemEnabled() {
         return values.cpuopt_fastmem;
     }
     return true;
+
+bool UseGarbageCollect() {
+    return values.use_garbage_collect.GetValue();
+}
+
+std::chrono::minutes GarbageCollectTimer() {
+    switch (values.garbage_collect_level.GetValue()) {
+    case Settings::GCLevel::Aggressive:
+        return std::chrono::minutes(1);
+    case Settings::GCLevel::Normal:
+        return std::chrono::minutes(4);
+    case Settings::GCLevel::Relaxed:
+        return std::chrono::minutes(10);
+    }
+    UNREACHABLE_MSG("Garbage collection set to unknown value!",
+                    static_cast<int>(values.garbage_collect_level.GetValue()));
+    values.use_garbage_collect.SetValue(false);
+    return {};
 }
 
 float Volume() {
@@ -133,6 +153,8 @@ void RestoreGlobalState(bool is_powered_on) {
     values.frame_limit.SetGlobal(true);
     values.use_disk_shader_cache.SetGlobal(true);
     values.gpu_accuracy.SetGlobal(true);
+    values.use_garbage_collect.SetGlobal(true);
+    values.garbage_collect_level.SetGlobal(true);
     values.use_asynchronous_gpu_emulation.SetGlobal(true);
     values.use_nvdec_emulation.SetGlobal(true);
     values.use_vsync.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -34,6 +34,12 @@ enum class CPUAccuracy : u32 {
     DebugMode = 2,
 };
 
+enum class GCLevel : u32 {
+    Aggressive = 0,
+    Normal = 1,
+    Relaxed = 2,
+};
+
 template <typename Type>
 class Setting final {
 public:
@@ -145,6 +151,8 @@ struct Values {
     Setting<u16> frame_limit;
     Setting<bool> use_disk_shader_cache;
     Setting<GPUAccuracy> gpu_accuracy;
+    Setting<bool> use_garbage_collect;
+    Setting<GCLevel> garbage_collect_level;
     Setting<bool> use_asynchronous_gpu_emulation;
     Setting<bool> use_nvdec_emulation;
     Setting<bool> use_vsync;
@@ -252,6 +260,9 @@ bool IsGPULevelExtreme();
 bool IsGPULevelHigh();
 
 bool IsFastmemEnabled();
+
+bool UseGarbageCollect();
+std::chrono::minutes GarbageCollectTimer();
 
 float Volume();
 

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -72,6 +72,18 @@ static const char* TranslateGPUAccuracyLevel(Settings::GPUAccuracy backend) {
     return "Unknown";
 }
 
+static const char* TranslateGarbageCollectLevel(Settings::GCLevel backend) {
+    switch (backend) {
+    case Settings::GCLevel::Aggressive:
+        return "Aggressive";
+    case Settings::GCLevel::Normal:
+        return "Normal";
+    case Settings::GCLevel::Relaxed:
+        return "Relaxed";
+    }
+    return "Unknown";
+}
+
 u64 GetTelemetryId() {
     u64 telemetry_id{};
     const auto filename = Common::FS::GetYuzuPath(Common::FS::YuzuPath::ConfigDir) / "telemetry_id";
@@ -226,6 +238,10 @@ void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader,
              Settings::values.use_disk_shader_cache.GetValue());
     AddField(field_type, "Renderer_GPUAccuracyLevel",
              TranslateGPUAccuracyLevel(Settings::values.gpu_accuracy.GetValue()));
+    AddField(field_type, "Renderer_UseGarbageCollect",
+             Settings::values.use_garbage_collect.GetValue());
+    AddField(field_type, "Renderer_GarbageCollectLevel",
+             TranslateGarbageCollectLevel(Settings::values.garbage_collect_level.GetValue()));
     AddField(field_type, "Renderer_UseAsynchronousGpuEmulation",
              Settings::values.use_asynchronous_gpu_emulation.GetValue());
     AddField(field_type, "Renderer_UseNvdecEmulation",

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -635,6 +635,7 @@ void RasterizerVulkan::TickFrame() {
         std::scoped_lock lock{buffer_cache.mutex};
         buffer_cache.TickFrame();
     }
+    memory_allocator.TickFrame();
 }
 
 bool RasterizerVulkan::AccelerateSurfaceCopy(const Tegra::Engines::Fermi2D::Surface& src,

--- a/src/video_core/texture_cache/image_base.cpp
+++ b/src/video_core/texture_cache/image_base.cpp
@@ -62,7 +62,8 @@ ImageBase::ImageBase(const ImageInfo& info_, GPUVAddr gpu_addr_, VAddr cpu_addr_
       unswizzled_size_bytes{CalculateUnswizzledSizeBytes(info)},
       converted_size_bytes{CalculateConvertedSizeBytes(info)}, gpu_addr{gpu_addr_},
       cpu_addr{cpu_addr_}, cpu_addr_end{cpu_addr + guest_size_bytes},
-      mip_level_offsets{CalculateMipLevelOffsets(info)} {
+      last_access_time{std::chrono::steady_clock::now()}, mip_level_offsets{
+                                                              CalculateMipLevelOffsets(info)} {
     if (info.type == ImageType::e3D) {
         slice_offsets = CalculateSliceOffsets(info);
         slice_subresources = CalculateSliceSubresources(info);

--- a/src/video_core/texture_cache/image_base.h
+++ b/src/video_core/texture_cache/image_base.h
@@ -62,6 +62,7 @@ struct ImageBase {
 
     u64 modification_tick = 0;
     u64 frame_tick = 0;
+    std::chrono::time_point<std::chrono::steady_clock> last_access_time;
 
     std::array<u32, MAX_MIP_LEVELS> mip_level_offsets{};
 

--- a/src/video_core/texture_cache/slot_vector.h
+++ b/src/video_core/texture_cache/slot_vector.h
@@ -70,6 +70,14 @@ public:
         ResetStorageBit(id.index);
     }
 
+    [[nodiscard]] size_t Size() const noexcept {
+        return stored_bitset.size() * 64;
+    }
+
+    [[nodiscard]] bool IsIndexFree(SlotId id) noexcept {
+        return ReadStorageBit(id.index);
+    }
+
 private:
     struct NonTrivialDummy {
         NonTrivialDummy() noexcept {}

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -803,6 +803,11 @@ void Config::ReadRendererValues() {
     ReadSettingGlobal(Settings::values.use_disk_shader_cache,
                       QStringLiteral("use_disk_shader_cache"), true);
     ReadSettingGlobal(Settings::values.gpu_accuracy, QStringLiteral("gpu_accuracy"), 1);
+    ReadSettingGlobal(Settings::values.use_garbage_collect, QStringLiteral("use_garbage_collect"),
+                      true);
+    ReadSettingGlobal(Settings::values.garbage_collect_level,
+                      QStringLiteral("garbage_collect_level"),
+                      static_cast<int>(Settings::GCLevel::Normal));
     ReadSettingGlobal(Settings::values.use_asynchronous_gpu_emulation,
                       QStringLiteral("use_asynchronous_gpu_emulation"), true);
     ReadSettingGlobal(Settings::values.use_nvdec_emulation, QStringLiteral("use_nvdec_emulation"),
@@ -1384,6 +1389,12 @@ void Config::SaveRendererValues() {
     WriteSettingGlobal(QStringLiteral("gpu_accuracy"),
                        static_cast<int>(Settings::values.gpu_accuracy.GetValue(global)),
                        Settings::values.gpu_accuracy.UsingGlobal(), 1);
+    WriteSettingGlobal(QStringLiteral("use_garbage_collect"), Settings::values.use_garbage_collect,
+                       true);
+    WriteSettingGlobal(QStringLiteral("garbage_collect_level"),
+                       static_cast<int>(Settings::values.garbage_collect_level.GetValue(global)),
+                       Settings::values.garbage_collect_level.UsingGlobal(),
+                       static_cast<int>(Settings::GCLevel::Normal));
     WriteSettingGlobal(QStringLiteral("use_asynchronous_gpu_emulation"),
                        Settings::values.use_asynchronous_gpu_emulation, true);
     WriteSettingGlobal(QStringLiteral("use_nvdec_emulation"), Settings::values.use_nvdec_emulation,

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -135,3 +135,4 @@ private:
 Q_DECLARE_METATYPE(Settings::CPUAccuracy);
 Q_DECLARE_METATYPE(Settings::RendererBackend);
 Q_DECLARE_METATYPE(Settings::GPUAccuracy);
+Q_DECLARE_METATYPE(Settings::GCLevel);

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -80,7 +80,6 @@ void ConfigureGeneral::ResetDefaults() {
 void ConfigureGeneral::ApplyConfiguration() {
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_multi_core, ui->use_multi_core,
                                              use_multi_core);
-
     if (Settings::IsConfiguringGlobal()) {
         UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
         UISettings::values.select_user_on_boot = ui->toggle_user_on_boot->isChecked();

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -22,11 +22,14 @@ ConfigureGraphicsAdvanced::~ConfigureGraphicsAdvanced() = default;
 
 void ConfigureGraphicsAdvanced::SetConfiguration() {
     const bool runtime_lock = !Core::System::GetInstance().IsPoweredOn();
+    ui->use_garbage_collect->setEnabled(runtime_lock);
+    ui->garbage_collect_level->setEnabled(runtime_lock);
     ui->use_vsync->setEnabled(runtime_lock);
     ui->use_assembly_shaders->setEnabled(runtime_lock);
     ui->use_asynchronous_shaders->setEnabled(runtime_lock);
     ui->anisotropic_filtering_combobox->setEnabled(runtime_lock);
 
+    ui->use_garbage_collect->setChecked(Settings::values.use_garbage_collect.GetValue());
     ui->use_vsync->setChecked(Settings::values.use_vsync.GetValue());
     ui->use_assembly_shaders->setChecked(Settings::values.use_assembly_shaders.GetValue());
     ui->use_asynchronous_shaders->setChecked(Settings::values.use_asynchronous_shaders.GetValue());
@@ -35,10 +38,14 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
     if (Settings::IsConfiguringGlobal()) {
         ui->gpu_accuracy->setCurrentIndex(
             static_cast<int>(Settings::values.gpu_accuracy.GetValue()));
+        ui->garbage_collect_level->setCurrentIndex(
+            static_cast<int>(Settings::values.garbage_collect_level.GetValue()));
         ui->anisotropic_filtering_combobox->setCurrentIndex(
             Settings::values.max_anisotropy.GetValue());
     } else {
         ConfigurationShared::SetPerGameSetting(ui->gpu_accuracy, &Settings::values.gpu_accuracy);
+        ConfigurationShared::SetPerGameSetting(ui->garbage_collect_level,
+                                               &Settings::values.garbage_collect_level);
         ConfigurationShared::SetPerGameSetting(ui->anisotropic_filtering_combobox,
                                                &Settings::values.max_anisotropy);
         ConfigurationShared::SetHighlight(ui->label_gpu_accuracy,
@@ -53,7 +60,12 @@ void ConfigureGraphicsAdvanced::ApplyConfiguration() {
     const auto gpu_accuracy = static_cast<Settings::GPUAccuracy>(
         ui->gpu_accuracy->currentIndex() -
         ((Settings::IsConfiguringGlobal()) ? 0 : ConfigurationShared::USE_GLOBAL_OFFSET));
+    const auto gc_level = static_cast<Settings::GCLevel>(
+        ui->garbage_collect_level->currentIndex() -
+        ((Settings::IsConfiguringGlobal()) ? 0 : ConfigurationShared::USE_GLOBAL_OFFSET));
 
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_garbage_collect,
+                                             ui->use_garbage_collect, use_garbage_collect);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.max_anisotropy,
                                              ui->anisotropic_filtering_combobox);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_vsync, ui->use_vsync, use_vsync);
@@ -70,12 +82,21 @@ void ConfigureGraphicsAdvanced::ApplyConfiguration() {
         if (Settings::values.gpu_accuracy.UsingGlobal()) {
             Settings::values.gpu_accuracy.SetValue(gpu_accuracy);
         }
+        if (Settings::values.garbage_collect_level.UsingGlobal()) {
+            Settings::values.garbage_collect_level.SetValue(gc_level);
+        }
     } else {
         if (ui->gpu_accuracy->currentIndex() == ConfigurationShared::USE_GLOBAL_INDEX) {
             Settings::values.gpu_accuracy.SetGlobal(true);
         } else {
             Settings::values.gpu_accuracy.SetGlobal(false);
             Settings::values.gpu_accuracy.SetValue(gpu_accuracy);
+        }
+        if (ui->garbage_collect_level->currentIndex() == ConfigurationShared::USE_GLOBAL_INDEX) {
+            Settings::values.garbage_collect_level.SetGlobal(true);
+        } else {
+            Settings::values.garbage_collect_level.SetGlobal(false);
+            Settings::values.garbage_collect_level.SetValue(gc_level);
         }
     }
 }
@@ -96,6 +117,8 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     // Disable if not global (only happens during game)
     if (Settings::IsConfiguringGlobal()) {
         ui->gpu_accuracy->setEnabled(Settings::values.gpu_accuracy.UsingGlobal());
+        ui->use_garbage_collect->setEnabled(Settings::values.use_garbage_collect.UsingGlobal());
+        ui->garbage_collect_level->setEnabled(Settings::values.garbage_collect_level.UsingGlobal());
         ui->use_vsync->setEnabled(Settings::values.use_vsync.UsingGlobal());
         ui->use_assembly_shaders->setEnabled(Settings::values.use_assembly_shaders.UsingGlobal());
         ui->use_asynchronous_shaders->setEnabled(
@@ -107,6 +130,8 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
         return;
     }
 
+    ConfigurationShared::SetColoredTristate(
+        ui->use_garbage_collect, Settings::values.use_garbage_collect, use_garbage_collect);
     ConfigurationShared::SetColoredTristate(ui->use_vsync, Settings::values.use_vsync, use_vsync);
     ConfigurationShared::SetColoredTristate(
         ui->use_assembly_shaders, Settings::values.use_assembly_shaders, use_assembly_shaders);
@@ -118,6 +143,9 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     ConfigurationShared::SetColoredComboBox(
         ui->gpu_accuracy, ui->label_gpu_accuracy,
         static_cast<int>(Settings::values.gpu_accuracy.GetValue(true)));
+    ConfigurationShared::SetColoredComboBox(
+        ui->garbage_collect_level, ui->garbage_collect_level,
+        static_cast<int>(Settings::values.garbage_collect_level.GetValue(true)));
     ConfigurationShared::SetColoredComboBox(
         ui->anisotropic_filtering_combobox, ui->af_label,
         static_cast<int>(Settings::values.max_anisotropy.GetValue(true)));

--- a/src/yuzu/configuration/configure_graphics_advanced.h
+++ b/src/yuzu/configuration/configure_graphics_advanced.h
@@ -34,6 +34,7 @@ private:
 
     std::unique_ptr<Ui::ConfigureGraphicsAdvanced> ui;
 
+    ConfigurationShared::CheckState use_garbage_collect;
     ConfigurationShared::CheckState use_vsync;
     ConfigurationShared::CheckState use_assembly_shaders;
     ConfigurationShared::CheckState use_asynchronous_shaders;

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -67,6 +67,42 @@
          </widget>
         </item>
         <item>
+         <layout class="QHBoxLayout" name="garbage_collect_layout">
+          <item>
+           <widget class="QCheckBox" name="use_garbage_collect">
+            <property name="toolTip">
+             <string>Enable periodic removal of textures from memory, reducing VRAM usage. Lower settings work more often, lowering VRAM usage but potentially causes hitching. Set to a shorter duration if you experience out of memory crashes.</string>
+            </property>
+            <property name="text">
+             <string>Garbage Collector:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="garbage_collect_level">
+            <property name="currentIndex">
+             <number>1</number>
+            </property>
+            <item>
+             <property name="text">
+              <string notr="true">Aggressive</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">Normal</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string notr="true">Relaxed</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item>
          <widget class="QCheckBox" name="use_vsync">
           <property name="toolTip">
            <string>VSync prevents the screen from tearing, but some graphics cards have lower performance with VSync enabled. Keep it enabled if you don't notice a performance difference.</string>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -439,6 +439,12 @@ void Config::ReadValues() {
         sdl2_config->GetBoolean("Renderer", "use_disk_shader_cache", false));
     const int gpu_accuracy_level = sdl2_config->GetInteger("Renderer", "gpu_accuracy", 1);
     Settings::values.gpu_accuracy.SetValue(static_cast<Settings::GPUAccuracy>(gpu_accuracy_level));
+    Settings::values.use_garbage_collect.SetValue(
+        sdl2_config->GetBoolean("Renderer", "use_garbage_collect", true));
+    const int garbage_collect_level = sdl2_config->GetInteger(
+        "Renderer", "garbage_collect_level", static_cast<int>(Settings::GCLevel::Normal));
+    Settings::values.garbage_collect_level.SetValue(
+        static_cast<Settings::GCLevel>(garbage_collect_level));
     Settings::values.use_asynchronous_gpu_emulation.SetValue(
         sdl2_config->GetBoolean("Renderer", "use_asynchronous_gpu_emulation", true));
     Settings::values.use_vsync.SetValue(

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -210,6 +210,16 @@ use_disk_shader_cache =
 # 0 (Normal), 1 (High), 2 (Extreme)
 gpu_accuracy =
 
+# Enable the garbage collector?
+# 0: Off, 1: On (default)
+use_garbage_collect =
+
+# How quickly the garbage collector removes images from the texture cache
+# 0 (Aggressive): 1 minute
+# 1 (Normal): 4 minutes
+# 2 (Relaxed): 10 minutes
+garbage_collect_level =
+
 # Whether to use asynchronous GPU emulation
 # 0 : Off (slow), 1 (default): On (fast)
 use_asynchronous_gpu_emulation =


### PR DESCRIPTION
This PR assigns the current timestamp to an image each time it's used in the cache, and then periodically checks all images, removing any which go above their timestamp + a constant expiration time. So if an image was seen at time 0, then the next GC check after 0 + 3 minutes, it will be removed, if it wasn't refreshed in that time to extend its lifetime.

This is in no way meant to be permanent at all because it's really bad, I just wanted to try and make something placeholder while Hades/a proper and more comprehensive solution is made. This clears out images from the texture cache based on a simple time since last use, which alone works for OpenGL. For Vulkan, it also removes empty allocations based on a time metric too, as they're not always effectively recycled. RAM usage isn't affected by this, I'm not sure where those allocations are coming from. If anyone has any ideas on that let me know.

Here's a 8x sped-up video of the effect in the most extreme situation I could find. Just moving between these 2 areas eats up 12GB VRAM in 4 minutes flat. Other games I've tried don't allocate nearly this much, but I wanted to show the effect clearly: https://dl.dropbox.com/s/90o9i1zxmrk6dg0/texture_cache.mp4

This should prevent almost all VRAM crashing for now I think. But again, this isn't a good solution and something much more robust would be better. I just wanted to get *something* in as some games (like the one shown) are hard to deal with when crashing every 20-30 minutes during normal play. 

I tried to make this small and not touch too many files to make it easy to remove later, but I'm not sure if you guys want to accept this as-is though since it's not great, so feel free to reject it. :)