### PR TITLE
k_thread: Move dereference after null check in Initialize()

### DIFF
--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -168,13 +168,13 @@ ResultCode KThread::Initialize(KThreadFunction func, uintptr_t arg, VAddr user_s
     std::memset(static_cast<void*>(std::addressof(GetStackParameters())), 0,
                 sizeof(StackParameters));
 
-    // Setup the TLS, if needed.
-    if (type == ThreadType::User) {
-        tls_address = owner->CreateTLSRegion();
-    }
-
     // Set parent, if relevant.
     if (owner != nullptr) {
+        // Setup the TLS, if needed.
+        if (type == ThreadType::User) {
+            tls_address = owner->CreateTLSRegion();
+        }
+
         parent = owner;
         parent->Open();
         parent->IncrementThreadCount();


### PR DESCRIPTION
Prevents a -Wnonnull warning on GCC.