### PR TITLE
kernel: Add missing override specifiers

### DIFF
--- a/src/core/hle/kernel/k_client_port.h
+++ b/src/core/hle/kernel/k_client_port.h
@@ -22,7 +22,7 @@ class KClientPort final : public KSynchronizationObject {
 
 public:
     explicit KClientPort(KernelCore& kernel_);
-    virtual ~KClientPort() override;
+    ~KClientPort() override;
 
     void Initialize(KPort* parent_, s32 max_sessions_, std::string&& name_);
     void OnSessionFinalized();
@@ -49,8 +49,8 @@ public:
     bool IsServerClosed() const;
 
     // Overridden virtual functions.
-    virtual void Destroy() override;
-    virtual bool IsSignaled() const override;
+    void Destroy() override;
+    bool IsSignaled() const override;
 
     ResultCode CreateSession(KClientSession** out);
 

--- a/src/core/hle/kernel/k_client_session.h
+++ b/src/core/hle/kernel/k_client_session.h
@@ -34,7 +34,7 @@ class KClientSession final
 
 public:
     explicit KClientSession(KernelCore& kernel_);
-    virtual ~KClientSession();
+    ~KClientSession() override;
 
     void Initialize(KSession* parent_, std::string&& name_) {
         // Set member variables.
@@ -42,7 +42,7 @@ public:
         name = std::move(name_);
     }
 
-    virtual void Destroy() override;
+    void Destroy() override;
     static void PostDestroy([[maybe_unused]] uintptr_t arg) {}
 
     KSession* GetParent() const {

--- a/src/core/hle/kernel/k_event.h
+++ b/src/core/hle/kernel/k_event.h
@@ -20,23 +20,21 @@ class KEvent final : public KAutoObjectWithSlabHeapAndContainer<KEvent, KAutoObj
 
 public:
     explicit KEvent(KernelCore& kernel_);
-    virtual ~KEvent();
+    ~KEvent() override;
 
     void Initialize(std::string&& name);
 
-    virtual void Finalize() override;
+    void Finalize() override;
 
-    virtual bool IsInitialized() const override {
+    bool IsInitialized() const override {
         return initialized;
     }
 
-    virtual uintptr_t GetPostDestroyArgument() const override {
+    uintptr_t GetPostDestroyArgument() const override {
         return reinterpret_cast<uintptr_t>(owner);
     }
 
-    static void PostDestroy(uintptr_t arg);
-
-    virtual KProcess* GetOwner() const override {
+    KProcess* GetOwner() const override {
         return owner;
     }
 
@@ -47,6 +45,8 @@ public:
     KWritableEvent& GetWritableEvent() {
         return writable_event;
     }
+
+    static void PostDestroy(uintptr_t arg);
 
 private:
     KReadableEvent readable_event;

--- a/src/core/hle/kernel/k_port.h
+++ b/src/core/hle/kernel/k_port.h
@@ -22,7 +22,7 @@ class KPort final : public KAutoObjectWithSlabHeapAndContainer<KPort, KAutoObjec
 
 public:
     explicit KPort(KernelCore& kernel_);
-    virtual ~KPort();
+    ~KPort() override;
 
     static void PostDestroy([[maybe_unused]] uintptr_t arg) {}
 
@@ -59,7 +59,6 @@ private:
         ServerClosed = 3,
     };
 
-private:
     KServerPort server;
     KClientPort client;
     State state{State::Invalid};

--- a/src/core/hle/kernel/k_process.h
+++ b/src/core/hle/kernel/k_process.h
@@ -331,19 +331,19 @@ public:
 
     void LoadModule(CodeSet code_set, VAddr base_addr);
 
-    virtual bool IsInitialized() const override {
+    bool IsInitialized() const override {
         return is_initialized;
     }
 
     static void PostDestroy([[maybe_unused]] uintptr_t arg) {}
 
-    virtual void Finalize();
+    void Finalize() override;
 
-    virtual u64 GetId() const override final {
+    u64 GetId() const override {
         return GetProcessID();
     }
 
-    virtual bool IsSignaled() const override;
+    bool IsSignaled() const override;
 
     void PinCurrentThread();
     void UnpinCurrentThread();

--- a/src/core/hle/kernel/k_readable_event.h
+++ b/src/core/hle/kernel/k_readable_event.h
@@ -31,8 +31,8 @@ public:
         return parent;
     }
 
-    virtual bool IsSignaled() const override;
-    virtual void Destroy() override;
+    bool IsSignaled() const override;
+    void Destroy() override;
 
     ResultCode Signal();
     ResultCode Clear();

--- a/src/core/hle/kernel/k_resource_limit.h
+++ b/src/core/hle/kernel/k_resource_limit.h
@@ -37,10 +37,10 @@ class KResourceLimit final
 
 public:
     explicit KResourceLimit(KernelCore& kernel_);
-    virtual ~KResourceLimit();
+    ~KResourceLimit() override;
 
     void Initialize(const Core::Timing::CoreTiming* core_timing_);
-    virtual void Finalize() override;
+    void Finalize() override;
 
     s64 GetLimitValue(LimitableResource which) const;
     s64 GetCurrentValue(LimitableResource which) const;

--- a/src/core/hle/kernel/k_server_port.h
+++ b/src/core/hle/kernel/k_server_port.h
@@ -25,12 +25,9 @@ class SessionRequestHandler;
 class KServerPort final : public KSynchronizationObject {
     KERNEL_AUTOOBJECT_TRAITS(KServerPort, KSynchronizationObject);
 
-private:
-    using SessionList = boost::intrusive::list<KServerSession>;
-
 public:
     explicit KServerPort(KernelCore& kernel_);
-    virtual ~KServerPort() override;
+    ~KServerPort() override;
 
     void Initialize(KPort* parent_, std::string&& name_);
 
@@ -63,13 +60,14 @@ public:
     bool IsLight() const;
 
     // Overridden virtual functions.
-    virtual void Destroy() override;
-    virtual bool IsSignaled() const override;
+    void Destroy() override;
+    bool IsSignaled() const override;
 
 private:
+    using SessionList = boost::intrusive::list<KServerSession>;
+
     void CleanupSessions();
 
-private:
     SessionList session_list;
     SessionRequestHandlerPtr session_handler;
     KPort* parent{};

--- a/src/core/hle/kernel/k_server_session.h
+++ b/src/core/hle/kernel/k_server_session.h
@@ -42,9 +42,9 @@ class KServerSession final : public KSynchronizationObject,
 
 public:
     explicit KServerSession(KernelCore& kernel_);
-    virtual ~KServerSession() override;
+    ~KServerSession() override;
 
-    virtual void Destroy() override;
+    void Destroy() override;
 
     void Initialize(KSession* parent_, std::string&& name_);
 
@@ -56,7 +56,7 @@ public:
         return parent;
     }
 
-    virtual bool IsSignaled() const override;
+    bool IsSignaled() const override;
 
     void OnClientClosed();
 

--- a/src/core/hle/kernel/k_session.h
+++ b/src/core/hle/kernel/k_session.h
@@ -18,17 +18,17 @@ class KSession final : public KAutoObjectWithSlabHeapAndContainer<KSession, KAut
 
 public:
     explicit KSession(KernelCore& kernel_);
-    virtual ~KSession() override;
+    ~KSession() override;
 
     void Initialize(KClientPort* port_, const std::string& name_);
 
-    virtual void Finalize() override;
+    void Finalize() override;
 
-    virtual bool IsInitialized() const override {
+    bool IsInitialized() const override {
         return initialized;
     }
 
-    virtual uintptr_t GetPostDestroyArgument() const override {
+    uintptr_t GetPostDestroyArgument() const override {
         return reinterpret_cast<uintptr_t>(process);
     }
 
@@ -78,7 +78,6 @@ private:
         ServerClosed = 3,
     };
 
-private:
     void SetState(State state) {
         atomic_state = static_cast<u8>(state);
     }
@@ -87,7 +86,6 @@ private:
         return static_cast<State>(atomic_state.load(std::memory_order_relaxed));
     }
 
-private:
     KServerSession server;
     KClientSession client;
     std::atomic<std::underlying_type_t<State>> atomic_state{

--- a/src/core/hle/kernel/k_shared_memory.h
+++ b/src/core/hle/kernel/k_shared_memory.h
@@ -68,9 +68,9 @@ public:
         return device_memory->GetPointer(physical_address + offset);
     }
 
-    virtual void Finalize() override;
+    void Finalize() override;
 
-    virtual bool IsInitialized() const override {
+    bool IsInitialized() const override {
         return is_initialized;
     }
     static void PostDestroy([[maybe_unused]] uintptr_t arg) {}

--- a/src/core/hle/kernel/k_synchronization_object.h
+++ b/src/core/hle/kernel/k_synchronization_object.h
@@ -29,7 +29,7 @@ public:
                                          KSynchronizationObject** objects, const s32 num_objects,
                                          s64 timeout);
 
-    virtual void Finalize() override;
+    void Finalize() override;
 
     [[nodiscard]] virtual bool IsSignaled() const = 0;
 
@@ -37,7 +37,7 @@ public:
 
 protected:
     explicit KSynchronizationObject(KernelCore& kernel);
-    virtual ~KSynchronizationObject();
+    ~KSynchronizationObject() override;
 
     virtual void OnFinalizeSynchronizationObject() {}
 

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -358,21 +358,21 @@ public:
         return termination_requested || GetRawState() == ThreadState::Terminated;
     }
 
-    [[nodiscard]] virtual u64 GetId() const override final {
+    [[nodiscard]] u64 GetId() const override {
         return this->GetThreadID();
     }
 
-    [[nodiscard]] virtual bool IsInitialized() const override {
+    [[nodiscard]] bool IsInitialized() const override {
         return initialized;
     }
 
-    [[nodiscard]] virtual uintptr_t GetPostDestroyArgument() const override {
+    [[nodiscard]] uintptr_t GetPostDestroyArgument() const override {
         return reinterpret_cast<uintptr_t>(parent) | (resource_limit_release_hint ? 1 : 0);
     }
 
-    virtual void Finalize() override;
+    void Finalize() override;
 
-    [[nodiscard]] virtual bool IsSignaled() const override;
+    [[nodiscard]] bool IsSignaled() const override;
 
     static void PostDestroy(uintptr_t arg);
 

--- a/src/core/hle/kernel/k_transfer_memory.h
+++ b/src/core/hle/kernel/k_transfer_memory.h
@@ -27,23 +27,23 @@ class KTransferMemory final
 
 public:
     explicit KTransferMemory(KernelCore& kernel_);
-    virtual ~KTransferMemory() override;
+    ~KTransferMemory() override;
 
     ResultCode Initialize(VAddr address_, std::size_t size_, Svc::MemoryPermission owner_perm_);
 
-    virtual void Finalize() override;
+    void Finalize() override;
 
-    virtual bool IsInitialized() const override {
+    bool IsInitialized() const override {
         return is_initialized;
     }
 
-    virtual uintptr_t GetPostDestroyArgument() const override {
+    uintptr_t GetPostDestroyArgument() const override {
         return reinterpret_cast<uintptr_t>(owner);
     }
 
     static void PostDestroy(uintptr_t arg);
 
-    KProcess* GetOwner() const {
+    KProcess* GetOwner() const override {
         return owner;
     }
 

--- a/src/core/hle/kernel/k_writable_event.h
+++ b/src/core/hle/kernel/k_writable_event.h
@@ -21,7 +21,7 @@ public:
     explicit KWritableEvent(KernelCore& kernel_);
     ~KWritableEvent() override;
 
-    virtual void Destroy() override;
+    void Destroy() override;
 
     static void PostDestroy([[maybe_unused]] uintptr_t arg) {}
 


### PR DESCRIPTION
Over the course of the kernel refactoring a tiny bit of missing overrides slipped through review, so we can add these to prevent compiler warnings from occurring.

While we're at it, we can remove redundant virtual keywords where applicable as well, since override already signifies a virtual function.