### PR TITLE
core/memory: Check our memory fallbacks for out-of-bound behavior.

### DIFF
--- a/src/common/page_table.cpp
+++ b/src/common/page_table.cpp
@@ -14,6 +14,7 @@ void PageTable::Resize(size_t address_space_width_in_bits, size_t page_size_in_b
     const size_t num_page_table_entries{1ULL << (address_space_width_in_bits - page_size_in_bits)};
     pointers.resize(num_page_table_entries);
     backing_addr.resize(num_page_table_entries);
+    current_address_space_width_in_bits = address_space_width_in_bits;
 }
 
 } // namespace Common

--- a/src/common/page_table.h
+++ b/src/common/page_table.h
@@ -98,6 +98,10 @@ struct PageTable {
      */
     void Resize(size_t address_space_width_in_bits, size_t page_size_in_bits);
 
+    size_t GetAddressSpaceBits() const {
+        return current_address_space_width_in_bits;
+    }
+
     /**
      * Vector of memory pointers backing each page. An entry can only be non-null if the
      * corresponding attribute element is of type `Memory`.
@@ -105,6 +109,8 @@ struct PageTable {
     VirtualBuffer<PageInfo> pointers;
 
     VirtualBuffer<u64> backing_addr;
+
+    size_t current_address_space_width_in_bits;
 };
 
 } // namespace Common

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -24,45 +24,46 @@ namespace Core {
 
 class DynarmicCallbacks32 : public Dynarmic::A32::UserCallbacks {
 public:
-    explicit DynarmicCallbacks32(ARM_Dynarmic_32& parent_) : parent{parent_} {}
+    explicit DynarmicCallbacks32(ARM_Dynarmic_32& parent_)
+        : parent{parent_}, memory(parent.system.Memory()) {}
 
     u8 MemoryRead8(u32 vaddr) override {
-        return parent.system.Memory().Read8(vaddr);
+        return memory.Read8(vaddr);
     }
     u16 MemoryRead16(u32 vaddr) override {
-        return parent.system.Memory().Read16(vaddr);
+        return memory.Read16(vaddr);
     }
     u32 MemoryRead32(u32 vaddr) override {
-        return parent.system.Memory().Read32(vaddr);
+        return memory.Read32(vaddr);
     }
     u64 MemoryRead64(u32 vaddr) override {
-        return parent.system.Memory().Read64(vaddr);
+        return memory.Read64(vaddr);
     }
 
     void MemoryWrite8(u32 vaddr, u8 value) override {
-        parent.system.Memory().Write8(vaddr, value);
+        memory.Write8(vaddr, value);
     }
     void MemoryWrite16(u32 vaddr, u16 value) override {
-        parent.system.Memory().Write16(vaddr, value);
+        memory.Write16(vaddr, value);
     }
     void MemoryWrite32(u32 vaddr, u32 value) override {
-        parent.system.Memory().Write32(vaddr, value);
+        memory.Write32(vaddr, value);
     }
     void MemoryWrite64(u32 vaddr, u64 value) override {
-        parent.system.Memory().Write64(vaddr, value);
+        memory.Write64(vaddr, value);
     }
 
     bool MemoryWriteExclusive8(u32 vaddr, u8 value, u8 expected) override {
-        return parent.system.Memory().WriteExclusive8(vaddr, value, expected);
+        return memory.WriteExclusive8(vaddr, value, expected);
     }
     bool MemoryWriteExclusive16(u32 vaddr, u16 value, u16 expected) override {
-        return parent.system.Memory().WriteExclusive16(vaddr, value, expected);
+        return memory.WriteExclusive16(vaddr, value, expected);
     }
     bool MemoryWriteExclusive32(u32 vaddr, u32 value, u32 expected) override {
-        return parent.system.Memory().WriteExclusive32(vaddr, value, expected);
+        return memory.WriteExclusive32(vaddr, value, expected);
     }
     bool MemoryWriteExclusive64(u32 vaddr, u64 value, u64 expected) override {
-        return parent.system.Memory().WriteExclusive64(vaddr, value, expected);
+        return memory.WriteExclusive64(vaddr, value, expected);
     }
 
     void InterpreterFallback(u32 pc, std::size_t num_instructions) override {
@@ -112,6 +113,7 @@ public:
     }
 
     ARM_Dynarmic_32& parent;
+    Core::Memory::Memory& memory;
     std::size_t num_interpreted_instructions{};
     static constexpr u64 minimum_run_cycles = 1000U;
 };

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -27,57 +27,56 @@ using Vector = Dynarmic::A64::Vector;
 
 class DynarmicCallbacks64 : public Dynarmic::A64::UserCallbacks {
 public:
-    explicit DynarmicCallbacks64(ARM_Dynarmic_64& parent_) : parent{parent_} {}
+    explicit DynarmicCallbacks64(ARM_Dynarmic_64& parent_)
+        : parent{parent_}, memory(parent.system.Memory()) {}
 
     u8 MemoryRead8(u64 vaddr) override {
-        return parent.system.Memory().Read8(vaddr);
+        return memory.Read8(vaddr);
     }
     u16 MemoryRead16(u64 vaddr) override {
-        return parent.system.Memory().Read16(vaddr);
+        return memory.Read16(vaddr);
     }
     u32 MemoryRead32(u64 vaddr) override {
-        return parent.system.Memory().Read32(vaddr);
+        return memory.Read32(vaddr);
     }
     u64 MemoryRead64(u64 vaddr) override {
-        return parent.system.Memory().Read64(vaddr);
+        return memory.Read64(vaddr);
     }
     Vector MemoryRead128(u64 vaddr) override {
-        auto& memory = parent.system.Memory();
         return {memory.Read64(vaddr), memory.Read64(vaddr + 8)};
     }
 
     void MemoryWrite8(u64 vaddr, u8 value) override {
-        parent.system.Memory().Write8(vaddr, value);
+        memory.Write8(vaddr, value);
     }
     void MemoryWrite16(u64 vaddr, u16 value) override {
-        parent.system.Memory().Write16(vaddr, value);
+        memory.Write16(vaddr, value);
     }
     void MemoryWrite32(u64 vaddr, u32 value) override {
-        parent.system.Memory().Write32(vaddr, value);
+        memory.Write32(vaddr, value);
     }
     void MemoryWrite64(u64 vaddr, u64 value) override {
-        parent.system.Memory().Write64(vaddr, value);
+        memory.Write64(vaddr, value);
     }
     void MemoryWrite128(u64 vaddr, Vector value) override {
-        auto& memory = parent.system.Memory();
         memory.Write64(vaddr, value[0]);
         memory.Write64(vaddr + 8, value[1]);
     }
 
     bool MemoryWriteExclusive8(u64 vaddr, std::uint8_t value, std::uint8_t expected) override {
-        return parent.system.Memory().WriteExclusive8(vaddr, value, expected);
+        return memory.WriteExclusive8(vaddr, value, expected);
     }
     bool MemoryWriteExclusive16(u64 vaddr, std::uint16_t value, std::uint16_t expected) override {
-        return parent.system.Memory().WriteExclusive16(vaddr, value, expected);
+        return memory.WriteExclusive16(vaddr, value, expected);
     }
     bool MemoryWriteExclusive32(u64 vaddr, std::uint32_t value, std::uint32_t expected) override {
-        return parent.system.Memory().WriteExclusive32(vaddr, value, expected);
+        return memory.WriteExclusive32(vaddr, value, expected);
     }
     bool MemoryWriteExclusive64(u64 vaddr, std::uint64_t value, std::uint64_t expected) override {
-        return parent.system.Memory().WriteExclusive64(vaddr, value, expected);
+        return memory.WriteExclusive64(vaddr, value, expected);
     }
     bool MemoryWriteExclusive128(u64 vaddr, Vector value, Vector expected) override {
-        return parent.system.Memory().WriteExclusive128(vaddr, value, expected);
+        return memory.WriteExclusive128(vaddr, value, expected);
     }
 
     void InterpreterFallback(u64 pc, std::size_t num_instructions) override {
@@ -139,6 +138,7 @@ public:
     }
 
     ARM_Dynarmic_64& parent;
+    Core::Memory::Memory& memory;
     u64 tpidrro_el0 = 0;
     u64 tpidr_el0 = 0;
     static constexpr u64 minimum_run_cycles = 1000U;


### PR DESCRIPTION
This makes it by far harder to crash yuzu.
Also implement the 48bit masking of AARCH64 while touching this code.