### PR TITLE
video_core: gpu: WaitFence: Do not block threads during shutdown.

### DIFF
--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -389,6 +389,8 @@ private:
     std::unique_ptr<Engines::KeplerMemory> kepler_memory;
     /// Shader build notifier
     std::unique_ptr<VideoCore::ShaderNotify> shader_notify;
+    /// When true, we are about to shut down emulation session, so terminate outstanding tasks
+    std::atomic_bool shutting_down{};
 
     std::array<std::atomic<u32>, Service::Nvidia::MaxSyncPoints> syncpoints{};
 


### PR DESCRIPTION
- Fixes a hang on shutdown when NVFlinger thread is waiting on a syncpoint that will never occur.
- Commonly observed when stopping emulation in Super Mario Odyssey.