### PR TITLE
input_common: Analog button, use time based position

### DIFF
--- a/src/core/frontend/input.h
+++ b/src/core/frontend/input.h
@@ -27,6 +27,10 @@ struct AnalogProperties {
     float range;
     float threshold;
 };
+template <typename StatusType>
+struct InputCallback {
+    std::function<void(StatusType)> on_change;
+};
 
 /// An abstract class template for an input device (a button, an analog input, etc.).
 template <typename StatusType>
@@ -50,6 +54,17 @@ public:
                                [[maybe_unused]] f32 freq_high) const {
         return {};
     }
+    void SetCallback(InputCallback<StatusType> callback_) {
+        callback = std::move(callback_);
+    }
+    void TriggerOnChange() {
+        if (callback.on_change) {
+            callback.on_change(GetStatus());
+        }
+    }
+
+private:
+    InputCallback<StatusType> callback;
 };
 
 /// An abstract class template for a factory that can create input devices.

--- a/src/input_common/keyboard.cpp
+++ b/src/input_common/keyboard.cpp
@@ -75,6 +75,7 @@ public:
                 } else {
                     pair.key_button->UnlockButton();
                 }
+                pair.key_button->TriggerOnChange();
             }
         }
     }


### PR DESCRIPTION
Use a different approach for emulating an analog stick from buttons.
- Removes the need for creating a thread for each joystick instance
- Fixes some crash errors on close

This also implements callbacks events on inputs to update data as soon it's available  