### PR TITLE
settings: Disable controller preview if controller is not active

### DIFF
--- a/src/yuzu/configuration/configure_input_player_widget.cpp
+++ b/src/yuzu/configuration/configure_input_player_widget.cpp
@@ -85,6 +85,8 @@ void PlayerControlPreview::SetConnectedStatus(bool checked) {
     led_color[1] = led_pattern.position2 ? colors.led_on : colors.led_off;
     led_color[2] = led_pattern.position3 ? colors.led_on : colors.led_off;
     led_color[3] = led_pattern.position4 ? colors.led_on : colors.led_off;
+    is_enabled = checked;
+    ResetInputs();
 }
 
 void PlayerControlPreview::SetControllerType(const Settings::ControllerType type) {
@@ -108,6 +110,7 @@ void PlayerControlPreview::EndMapping() {
     analog_mapping_index = Settings::NativeAnalog::NumAnalogs;
     mapping_active = false;
     blink_counter = 0;
+    ResetInputs();
 }
 
 void PlayerControlPreview::UpdateColors() {
@@ -156,7 +159,23 @@ void PlayerControlPreview::UpdateColors() {
     // colors.right = QColor(Settings::values.players.GetValue()[player_index].body_color_right);
 }
 
+void PlayerControlPreview::ResetInputs() {
+    for (std::size_t index = 0; index < button_values.size(); ++index) {
+        button_values[index] = false;
+    }
+
+    for (std::size_t index = 0; index < axis_values.size(); ++index) {
+        axis_values[index].properties = {0, 1, 0};
+        axis_values[index].value = {0, 0};
+        axis_values[index].raw_value = {0, 0};
+    }
+    update();
+}
+
 void PlayerControlPreview::UpdateInput() {
+    if (!is_enabled && !mapping_active) {
+        return;
+    }
     bool input_changed = false;
     const auto& button_state = buttons;
     for (std::size_t index = 0; index < button_values.size(); ++index) {

--- a/src/yuzu/configuration/configure_input_player_widget.h
+++ b/src/yuzu/configuration/configure_input_player_widget.h
@@ -100,6 +100,7 @@ private:
 
     static LedPattern GetColorPattern(std::size_t index, bool player_on);
     void UpdateColors();
+    void ResetInputs();
 
     // Draw controller functions
     void DrawHandheldController(QPainter& p, QPointF center);
@@ -176,6 +177,7 @@ private:
     using StickArray =
         std::array<std::unique_ptr<Input::AnalogDevice>, Settings::NativeAnalog::NUM_STICKS_HID>;
 
+    bool is_enabled{};
     bool mapping_active{};
     int blink_counter{};
     QColor button_color{};

--- a/src/yuzu/debugger/controller.cpp
+++ b/src/yuzu/debugger/controller.cpp
@@ -28,6 +28,7 @@ ControllerDialog::ControllerDialog(QWidget* parent) : QWidget(parent, Qt::Dialog
     // Configure focus so that widget is focusable and the dialog automatically forwards focus to
     // it.
     setFocusProxy(widget);
+    widget->SetConnectedStatus(false);
     widget->setFocusPolicy(Qt::StrongFocus);
     widget->setFocus();
 }
@@ -36,9 +37,8 @@ void ControllerDialog::refreshConfiguration() {
     const auto& players = Settings::values.players.GetValue();
     constexpr std::size_t player = 0;
     widget->SetPlayerInputRaw(player, players[player].buttons, players[player].analogs);
-    widget->SetConnectedStatus(players[player].connected);
     widget->SetControllerType(players[player].controller_type);
-    widget->repaint();
+    widget->SetConnectedStatus(players[player].connected);
 }
 
 QAction* ControllerDialog::toggleViewAction() {
@@ -56,6 +56,7 @@ void ControllerDialog::showEvent(QShowEvent* ev) {
     if (toggle_view_action) {
         toggle_view_action->setChecked(isVisible());
     }
+    refreshConfiguration();
     QWidget::showEvent(ev);
 }
 
@@ -63,5 +64,6 @@ void ControllerDialog::hideEvent(QHideEvent* ev) {
     if (toggle_view_action) {
         toggle_view_action->setChecked(isVisible());
     }
+    widget->SetConnectedStatus(false);
     QWidget::hideEvent(ev);
 }


### PR DESCRIPTION
Currently the controller debugger it's running even if it's on background. This is not ideal since it's only consuming resources.

This also helps detecting wrong configurations since it will not update until the controller it's enabled 