### PR TITLE
externals: libusb: Use autotools for MinGW

### DIFF
--- a/.ci/scripts/windows/docker.sh
+++ b/.ci/scripts/windows/docker.sh
@@ -47,3 +47,6 @@ python3 .ci/scripts/windows/scan_dll.py package/imageformats/*.dll "package/"
 EXTERNALS_PATH="$(pwd)/build/externals"
 FFMPEG_DLL_PATH="$(find ${EXTERNALS_PATH} -maxdepth 1 -type d | grep ffmpeg)/bin"
 find ${FFMPEG_DLL_PATH} -type f -regex ".*\.dll" -exec cp -v {} package/ ';'
+
+# copy libraries from yuzu.exe path
+find "$(pwd)/build/bin/" -type f -regex ".*\.dll" -exec cp -v {} package/ ';'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,7 +426,7 @@ if(NOT APPLE)
 endif()
 if (NOT LIBUSB_FOUND)
     add_subdirectory(externals/libusb)
-    set(LIBUSB_INCLUDE_DIR "")
+    set(LIBUSB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/externals/libusb/libusb/libusb")
     set(LIBUSB_LIBRARIES usb)
 endif()
 

--- a/externals/libusb/CMakeLists.txt
+++ b/externals/libusb/CMakeLists.txt
@@ -1,155 +1,239 @@
-# Ensure libusb compiles with UTF-8 encoding on MSVC
-if(MSVC)
-    add_compile_options(/utf-8)
-endif()
+if (MINGW)
+    # The MinGW toolchain for some reason doesn't work with this CMakeLists file after updating to
+    # 1.0.24, so we do it the old-fashioned way for now. We may want to move native Linux toolchains
+    # to here, too (TODO lat9nq?).
 
-add_library(usb STATIC EXCLUDE_FROM_ALL
-    libusb/libusb/core.c
-    libusb/libusb/core.c
-    libusb/libusb/descriptor.c
-    libusb/libusb/hotplug.c
-    libusb/libusb/io.c
-    libusb/libusb/strerror.c
-    libusb/libusb/sync.c
-)
-set_target_properties(usb PROPERTIES VERSION 1.0.23)
-if(WIN32)
-    target_include_directories(usb
-        BEFORE
-        PUBLIC
-          libusb/libusb
+    set(LIBUSB_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/libusb")
+    set(LIBUSB_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libusb")
+    # Workarounds for MSYS/MinGW
+    if (MSYS)
+        # CMake on Windows passes `C:/`, but we need `/C/` or `/c/` to use `configure`
+        string(REPLACE ":/" "/" LIBUSB_SRC_DIR "${LIBUSB_SRC_DIR}")
+        set(LIBUSB_SRC_DIR "/${LIBUSB_SRC_DIR}")
 
-        PRIVATE
-          "${CMAKE_CURRENT_BINARY_DIR}"
-    )
-
-    if (NOT MINGW)
-        target_include_directories(usb BEFORE PRIVATE libusb/msvc)
+        # And now that we are using /C/ for srcdir but everything else is using C:/, we need to
+        # compile everything in the source directory, else `configure` won't think the build
+        # environment is sane.
+        set(LIBUSB_PREFIX "${LIBUSB_SRC_DIR}")
     endif()
 
-    # Works around other libraries providing their own definition of USB GUIDs (e.g. SDL2)
-    target_compile_definitions(usb PRIVATE "-DGUID_DEVINTERFACE_USB_DEVICE=(GUID){ 0xA5DCBF10, 0x6530, 0x11D2, {0x90, 0x1F, 0x00, 0xC0, 0x4F, 0xB9, 0x51, 0xED}}")
-else()
-target_include_directories(usb
-    # turns out other projects also have "config.h", so make sure the
-    # LibUSB one comes first
-    BEFORE
+    set(LIBUSB_CONFIGURE "${LIBUSB_SRC_DIR}/configure")
+    set(LIBUSB_MAKEFILE "${LIBUSB_PREFIX}/Makefile")
+    set(LIBUSB_LIBRARY "${LIBUSB_PREFIX}/libusb/.libs/libusb-1.0.dll.a")
+    set(LIBUSB_SHARED_LIBRARY "${LIBUSB_PREFIX}/libusb/.libs/libusb-1.0.dll")
+    set(LIBUSB_SHARED_LIBRARY_DEST "${CMAKE_BINARY_DIR}/bin/libusb-1.0.dll")
 
-    PUBLIC
-      libusb/libusb
+    # Causes "externals/libusb/libusb/libusb/os/windows_winusb.c:1427:2: error: conversion to non-scalar type requested", so cannot statically link it for now.
+    # set(LIBUSB_CFLAGS "-DGUID_DEVINTERFACE_USB_DEVICE=\\(GUID\\){0xA5DCBF10,0x6530,0x11D2,{0x90,0x1F,0x00,0xC0,0x4F,0xB9,0x51,0xED}}")
 
-    PRIVATE
-      "${CMAKE_CURRENT_BINARY_DIR}"
-)
-endif()
+    make_directory("${LIBUSB_PREFIX}")
 
-if(WIN32 OR CYGWIN)
-    target_sources(usb PRIVATE
-      libusb/libusb/os/threads_windows.c
-      libusb/libusb/os/windows_winusb.c
-      libusb/libusb/os/windows_usbdk.c
-      libusb/libusb/os/windows_common.c
+    add_custom_command(
+        OUTPUT
+            "${LIBUSB_LIBRARY}"
+        COMMAND
+            make
+        WORKING_DIRECTORY
+            "${LIBUSB_PREFIX}"
     )
-    set(OS_WINDOWS TRUE)
-elseif(APPLE)
-    target_sources(usb PRIVATE
-        libusb/libusb/os/darwin_usb.c
+
+    # We may use this path for other GNU toolchains, so put all of the MinGW-specific stuff here
+    if (MINGW)
+        set(LIBUSB_CONFIGURE_ARGS --host=x86_64-w64-mingw32 --build=x86_64-windows)
+    endif()
+
+    add_custom_command(
+        OUTPUT
+            "${LIBUSB_MAKEFILE}"
+        COMMAND
+            # /bin/env
+            #     CFLAGS="${LIBUSB_CFLAGS}"
+            /bin/sh "${LIBUSB_CONFIGURE}"
+                ${LIBUSB_CONFIGURE_ARGS}
+                --srcdir="${LIBUSB_SRC_DIR}"
+        WORKING_DIRECTORY
+            "${LIBUSB_PREFIX}"
     )
-    find_library(COREFOUNDATION_LIBRARY CoreFoundation)
-    find_library(IOKIT_LIBRARY IOKit)
-    find_library(OBJC_LIBRARY objc)
-    target_link_libraries(usb PRIVATE
-        ${COREFOUNDATION_LIBRARY}
-        ${IOKIT_LIBRARY}
-        ${OBJC_LIBRARY}
+
+    add_custom_command(
+        OUTPUT
+            "${LIBUSB_CONFIGURE}"
+        COMMAND
+            /bin/sh "${LIBUSB_SRC_DIR}/bootstrap.sh"
+        WORKING_DIRECTORY
+            "${LIBUSB_SRC_DIR}"
     )
-    set(OS_DARWIN TRUE)
-elseif(ANDROID)
-    target_sources(usb PRIVATE
-        libusb/libusb/os/linux_usbfs.c
-        libusb/libusb/os/linux_netlink.c
+
+    add_custom_command(
+        OUTPUT
+            "${LIBUSB_SHARED_LIBRARY_DEST}"
+        COMMAND
+            /bin/cp "${LIBUSB_SHARED_LIBRARY}" "${LIBUSB_SHARED_LIBRARY_DEST}"
     )
-    find_library(LOG_LIBRARY log)
-    target_link_libraries(usb PRIVATE ${LOG_LIBRARY})
-    set(OS_LINUX TRUE)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    target_sources(usb PRIVATE
-        libusb/libusb/os/linux_usbfs.c
+
+    add_custom_target(usb-bootstrap ALL DEPENDS "${LIBUSB_CONFIGURE}")
+    add_custom_target(usb-configure ALL DEPENDS "${LIBUSB_MAKEFILE}" usb-bootstrap)
+    add_custom_target(usb-build ALL DEPENDS "${LIBUSB_LIBRARY}" usb-configure)
+    # Workaround since static linking didn't work out -- We need to copy the DLL to the bin directory
+    add_custom_target(usb-copy ALL DEPENDS "${LIBUSB_SHARED_LIBRARY_DEST}" usb-build)
+
+    # Make `usb` alias to LIBUSB_LIBRARY
+    add_library(usb INTERFACE)
+    target_link_libraries(usb INTERFACE "${LIBUSB_LIBRARY}")
+else() # MINGW
+    # Ensure libusb compiles with UTF-8 encoding on MSVC
+    if(MSVC)
+        add_compile_options(/utf-8)
+    endif()
+
+    add_library(usb STATIC EXCLUDE_FROM_ALL
+        libusb/libusb/core.c
+        libusb/libusb/core.c
+        libusb/libusb/descriptor.c
+        libusb/libusb/hotplug.c
+        libusb/libusb/io.c
+        libusb/libusb/strerror.c
+        libusb/libusb/sync.c
     )
-    find_package(Libudev)
-    if(LIBUDEV_FOUND)
-        target_sources(usb PRIVATE
-            libusb/libusb/os/linux_udev.c
+    set_target_properties(usb PROPERTIES VERSION 1.0.24)
+    if(WIN32)
+        target_include_directories(usb
+            BEFORE
+            PUBLIC
+              libusb/libusb
+
+            PRIVATE
+              "${CMAKE_CURRENT_BINARY_DIR}"
         )
-        target_link_libraries(usb PRIVATE "${LIBUDEV_LIBRARIES}")
-        target_include_directories(usb PRIVATE "${LIBUDEV_INCLUDE_DIR}")
-        set(HAVE_LIBUDEV TRUE)
-        set(USE_UDEV TRUE)
+
+        if (NOT MINGW)
+            target_include_directories(usb BEFORE PRIVATE libusb/msvc)
+        endif()
+
+        # Works around other libraries providing their own definition of USB GUIDs (e.g. SDL2)
+        target_compile_definitions(usb PRIVATE "-DGUID_DEVINTERFACE_USB_DEVICE=(GUID){ 0xA5DCBF10, 0x6530, 0x11D2, {0x90, 0x1F, 0x00, 0xC0, 0x4F, 0xB9, 0x51, 0xED}}")
     else()
+        target_include_directories(usb
+            # turns out other projects also have "config.h", so make sure the
+            # LibUSB one comes first
+            BEFORE
+
+            PUBLIC
+              libusb/libusb
+
+            PRIVATE
+              "${CMAKE_CURRENT_BINARY_DIR}"
+        )
+    endif()
+
+    if(WIN32 OR CYGWIN)
         target_sources(usb PRIVATE
+          libusb/libusb/os/threads_windows.c
+          libusb/libusb/os/windows_winusb.c
+          libusb/libusb/os/windows_usbdk.c
+          libusb/libusb/os/windows_common.c
+        )
+        set(OS_WINDOWS TRUE)
+    elseif(APPLE)
+        target_sources(usb PRIVATE
+            libusb/libusb/os/darwin_usb.c
+        )
+        find_library(COREFOUNDATION_LIBRARY CoreFoundation)
+        find_library(IOKIT_LIBRARY IOKit)
+        find_library(OBJC_LIBRARY objc)
+        target_link_libraries(usb PRIVATE
+            ${COREFOUNDATION_LIBRARY}
+            ${IOKIT_LIBRARY}
+            ${OBJC_LIBRARY}
+        )
+        set(OS_DARWIN TRUE)
+    elseif(ANDROID)
+        target_sources(usb PRIVATE
+            libusb/libusb/os/linux_usbfs.c
             libusb/libusb/os/linux_netlink.c
         )
+        find_library(LOG_LIBRARY log)
+        target_link_libraries(usb PRIVATE ${LOG_LIBRARY})
+        set(OS_LINUX TRUE)
+    elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+        target_sources(usb PRIVATE
+            libusb/libusb/os/linux_usbfs.c
+        )
+        find_package(Libudev)
+        if(LIBUDEV_FOUND)
+            target_sources(usb PRIVATE
+                libusb/libusb/os/linux_udev.c
+            )
+            target_link_libraries(usb PRIVATE "${LIBUDEV_LIBRARIES}")
+            target_include_directories(usb PRIVATE "${LIBUDEV_INCLUDE_DIR}")
+            set(HAVE_LIBUDEV TRUE)
+            set(USE_UDEV TRUE)
+        else()
+            target_sources(usb PRIVATE
+                libusb/libusb/os/linux_netlink.c
+            )
+        endif()
+        set(OS_LINUX TRUE)
+    elseif(${CMAKE_SYSTEM_NAME} MATCHES "NetBSD")
+        target_sources(usb PRIVATE
+            libusb/libusb/os/netbsd_usb.c
+        )
+        set(OS_NETBSD TRUE)
+    elseif(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
+        target_sources(usb PRIVATE
+            libusb/libusb/os/openbsd_usb.c
+        )
+        set(OS_OPENBSD TRUE)
     endif()
-    set(OS_LINUX TRUE)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "NetBSD")
-    target_sources(usb PRIVATE
-        libusb/libusb/os/netbsd_usb.c
-    )
-    set(OS_NETBSD TRUE)
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "OpenBSD")
-    target_sources(usb PRIVATE
-        libusb/libusb/os/openbsd_usb.c
-    )
-    set(OS_OPENBSD TRUE)
-endif()
 
-if(UNIX)
-    target_sources(usb PRIVATE
-        libusb/libusb/os/events_posix.c
-        libusb/libusb/os/threads_posix.c
-    )
-    find_package(Threads REQUIRED)
-    if(THREADS_HAVE_PTHREAD_ARG)
-      target_compile_options(usb PUBLIC "-pthread")
+    if(UNIX)
+        target_sources(usb PRIVATE
+            libusb/libusb/os/events_posix.c
+            libusb/libusb/os/threads_posix.c
+        )
+        find_package(Threads REQUIRED)
+        if(THREADS_HAVE_PTHREAD_ARG)
+          target_compile_options(usb PUBLIC "-pthread")
+        endif()
+        if(CMAKE_THREAD_LIBS_INIT)
+          target_link_libraries(usb PRIVATE "${CMAKE_THREAD_LIBS_INIT}")
+        endif()
+        set(THREADS_POSIX TRUE)
+    elseif(WIN32)
+        target_sources(usb PRIVATE
+            libusb/libusb/os/events_windows.c
+            libusb/libusb/os/threads_windows.c
+        )
     endif()
-    if(CMAKE_THREAD_LIBS_INIT)
-      target_link_libraries(usb PRIVATE "${CMAKE_THREAD_LIBS_INIT}")
+
+    include(CheckFunctionExists)
+    include(CheckIncludeFiles)
+    include(CheckTypeSize)
+    check_include_files(asm/types.h HAVE_ASM_TYPES_H)
+    check_function_exists(gettimeofday HAVE_GETTIMEOFDAY)
+    check_include_files(linux/filter.h HAVE_LINUX_FILTER_H)
+    check_include_files(linux/netlink.h HAVE_LINUX_NETLINK_H)
+    check_include_files(poll.h HAVE_POLL_H)
+    check_include_files(signal.h HAVE_SIGNAL_H)
+    check_include_files(strings.h HAVE_STRINGS_H)
+    check_type_size("struct timespec" STRUCT_TIMESPEC)
+    check_function_exists(syslog HAVE_SYSLOG_FUNC)
+    check_include_files(syslog.h HAVE_SYSLOG_H)
+    check_include_files(sys/socket.h HAVE_SYS_SOCKET_H)
+    check_include_files(sys/time.h HAVE_SYS_TIME_H)
+    check_include_files(sys/types.h HAVE_SYS_TYPES_H)
+
+    set(CMAKE_EXTRA_INCLUDE_FILES poll.h)
+    check_type_size("nfds_t" nfds_t)
+    unset(CMAKE_EXTRA_INCLUDE_FILES)
+    if(HAVE_NFDS_T)
+        set(POLL_NFDS_TYPE "nfds_t")
+    else()
+        set(POLL_NFDS_TYPE "unsigned int")
     endif()
-    set(THREADS_POSIX TRUE)
-elseif(WIN32)
-    target_sources(usb PRIVATE
-        libusb/libusb/os/events_windows.c
-        libusb/libusb/os/threads_windows.c
-    )
-endif()
 
-include(CheckFunctionExists)
-include(CheckIncludeFiles)
-include(CheckTypeSize)
-check_include_files(asm/types.h HAVE_ASM_TYPES_H)
-check_function_exists(gettimeofday HAVE_GETTIMEOFDAY)
-check_include_files(linux/filter.h HAVE_LINUX_FILTER_H)
-check_include_files(linux/netlink.h HAVE_LINUX_NETLINK_H)
-check_include_files(poll.h HAVE_POLL_H)
-check_include_files(signal.h HAVE_SIGNAL_H)
-check_include_files(strings.h HAVE_STRINGS_H)
-check_type_size("struct timespec" STRUCT_TIMESPEC)
-check_function_exists(syslog HAVE_SYSLOG_FUNC)
-check_include_files(syslog.h HAVE_SYSLOG_H)
-check_include_files(sys/socket.h HAVE_SYS_SOCKET_H)
-check_include_files(sys/time.h HAVE_SYS_TIME_H)
-check_include_files(sys/types.h HAVE_SYS_TYPES_H)
-
-set(CMAKE_EXTRA_INCLUDE_FILES poll.h)
-check_type_size("nfds_t" nfds_t)
-unset(CMAKE_EXTRA_INCLUDE_FILES)
-if(HAVE_NFDS_T)
-    set(POLL_NFDS_TYPE "nfds_t")
-else()
-    set(POLL_NFDS_TYPE "unsigned int")
-endif()
-
-check_include_files(sys/timerfd.h USBI_TIMERFD_AVAILABLE)
+    check_include_files(sys/timerfd.h USBI_TIMERFD_AVAILABLE)
 
 
-configure_file(config.h.in config.h)
+    configure_file(config.h.in config.h)
+endif() # MINGW


### PR DESCRIPTION
After updating to 1.0.24, MinGW fails to build libusb as a result of numerous errors. So we build libusb their way and let them update the nontrivial stuff.

This only applies to MinGW: the old path is still in use for Linux toolchains as well as MSVC.

This will dynamically link libusb, since I hit build errors with the old way we used to resolve the conflict with SDL2.

git diff is going to git diff, but everything after the `else() # MINGW` is identical to the previous version, sans a indentation correction.