### PR TITLE
common_funcs: Move R_ macros to result.h

### DIFF
--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -97,17 +97,6 @@ __declspec(dllimport) void __stdcall DebugBreak(void);
         return static_cast<T>(key) == 0;                                                           \
     }
 
-/// Evaluates a boolean expression, and returns a result unless that expression is true.
-#define R_UNLESS(expr, res)                                                                        \
-    {                                                                                              \
-        if (!(expr)) {                                                                             \
-            if (res.IsError()) {                                                                   \
-                LOG_ERROR(Kernel, "Failed with result: {}", res.raw);                              \
-            }                                                                                      \
-            return res;                                                                            \
-        }                                                                                          \
-    }
-
 #define YUZU_NON_COPYABLE(cls)                                                                     \
     cls(const cls&) = delete;                                                                      \
     cls& operator=(const cls&) = delete
@@ -115,20 +104,6 @@ __declspec(dllimport) void __stdcall DebugBreak(void);
 #define YUZU_NON_MOVEABLE(cls)                                                                     \
     cls(cls&&) = delete;                                                                           \
     cls& operator=(cls&&) = delete
-
-#define R_SUCCEEDED(res) (res.IsSuccess())
-
-/// Evaluates an expression that returns a result, and returns the result if it would fail.
-#define R_TRY(res_expr)                                                                            \
-    {                                                                                              \
-        const auto _tmp_r_try_rc = (res_expr);                                                     \
-        if (_tmp_r_try_rc.IsError()) {                                                             \
-            return _tmp_r_try_rc;                                                                  \
-        }                                                                                          \
-    }
-
-/// Evaluates a boolean expression, and succeeds if that expression is true.
-#define R_SUCCEED_IF(expr) R_UNLESS(!(expr), RESULT_SUCCESS)
 
 namespace Common {
 

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -358,3 +358,28 @@ ResultVal<std::remove_reference_t<Arg>> MakeResult(Arg&& arg) {
             return CONCAT2(check_result_L, __LINE__);                                              \
         }                                                                                          \
     } while (false)
+
+#define R_SUCCEEDED(res) (res.IsSuccess())
+
+/// Evaluates a boolean expression, and succeeds if that expression is true.
+#define R_SUCCEED_IF(expr) R_UNLESS(!(expr), RESULT_SUCCESS)
+
+/// Evaluates a boolean expression, and returns a result unless that expression is true.
+#define R_UNLESS(expr, res)                                                                        \
+    {                                                                                              \
+        if (!(expr)) {                                                                             \
+            if (res.IsError()) {                                                                   \
+                LOG_ERROR(Kernel, "Failed with result: {}", res.raw);                              \
+            }                                                                                      \
+            return res;                                                                            \
+        }                                                                                          \
+    }
+
+/// Evaluates an expression that returns a result, and returns the result if it would fail.
+#define R_TRY(res_expr)                                                                            \
+    {                                                                                              \
+        const auto _tmp_r_try_rc = (res_expr);                                                     \
+        if (_tmp_r_try_rc.IsError()) {                                                             \
+            return _tmp_r_try_rc;                                                                  \
+        }                                                                                          \
+    }


### PR DESCRIPTION
These macros all interact with the result code type, so they should ideally be within this file as well, so all the common_funcs machinery doesn't need to be pulled in just to use them.

Moves an implicit core dependency out of common.