### PR TITLE
externals: Use defaults for building SDL2 on WIN32

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -47,19 +47,21 @@ target_include_directories(unicorn-headers INTERFACE ./unicorn/include)
 
 # SDL2
 if (NOT SDL2_FOUND AND ENABLE_SDL2)
-    # Yuzu itself needs: Events Joystick Haptic Sensor Timers
-    # Yuzu-cmd also needs: Video (depends on Loadso/Dlopen)
-    set(SDL_UNUSED_SUBSYSTEMS
-        Atomic Audio Render Power Threads
-        File CPUinfo Filesystem Locale)
-    foreach(_SUB ${SDL_UNUSED_SUBSYSTEMS})
-      string(TOUPPER ${_SUB} _OPT)
-      option(SDL_${_OPT} "" OFF)
-    endforeach()
+    if (NOT WIN32)
+        # Yuzu itself needs: Events Joystick Haptic Sensor Timers
+        # Yuzu-cmd also needs: Video (depends on Loadso/Dlopen)
+        set(SDL_UNUSED_SUBSYSTEMS
+            Atomic Audio Render Power Threads
+            File CPUinfo Filesystem Locale)
+        foreach(_SUB ${SDL_UNUSED_SUBSYSTEMS})
+          string(TOUPPER ${_SUB} _OPT)
+          option(SDL_${_OPT} "" OFF)
+        endforeach()
 
+        option(HIDAPI "" ON)
+    endif()
     set(SDL_STATIC ON)
     set(SDL_SHARED OFF)
-    option(HIDAPI "" ON)
 
     add_subdirectory(SDL EXCLUDE_FROM_ALL)
     add_library(SDL2 ALIAS SDL2-static)


### PR DESCRIPTION
Whatever those settings do breaks controller detection on Windows, at least with the MinGW container. If-guard it against WIN32 and just let SDL2 configure using its defaults, aside from static linking.