### PR TITLE
common: fs: fs_util: Add more string conversion functions

### DIFF
--- a/src/common/fs/fs_util.cpp
+++ b/src/common/fs/fs_util.cpp
@@ -2,12 +2,22 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
+
 #include "common/fs/fs_util.h"
 
 namespace Common::FS {
 
 std::u8string ToU8String(std::string_view utf8_string) {
     return std::u8string{utf8_string.begin(), utf8_string.end()};
+}
+
+std::u8string BufferToU8String(std::span<const u8> buffer) {
+    return std::u8string{buffer.begin(), std::ranges::find(buffer, u8{0})};
+}
+
+std::string ToUTF8String(std::u8string_view u8_string) {
+    return std::string{u8_string.begin(), u8_string.end()};
 }
 
 } // namespace Common::FS

--- a/src/common/fs/fs_util.cpp
+++ b/src/common/fs/fs_util.cpp
@@ -20,4 +20,8 @@ std::string ToUTF8String(std::u8string_view u8_string) {
     return std::string{u8_string.begin(), u8_string.end()};
 }
 
+std::string PathToUTF8String(const std::filesystem::path& path) {
+    return ToUTF8String(path.u8string());
+}
+
 } // namespace Common::FS

--- a/src/common/fs/fs_util.h
+++ b/src/common/fs/fs_util.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <concepts>
+#include <filesystem>
 #include <span>
 #include <string>
 #include <string_view>
@@ -44,5 +45,14 @@ concept IsChar = std::same_as<T, char>;
  * @returns UTF-8 encoded std::string.
  */
 [[nodiscard]] std::string ToUTF8String(std::u8string_view u8_string);
+
+/**
+ * Converts a filesystem path to a UTF-8 encoded std::string.
+ *
+ * @param path Filesystem path
+ *
+ * @returns UTF-8 encoded std::string.
+ */
+[[nodiscard]] std::string PathToUTF8String(const std::filesystem::path& path);
 
 } // namespace Common::FS

--- a/src/common/fs/fs_util.h
+++ b/src/common/fs/fs_util.h
@@ -5,8 +5,11 @@
 #pragma once
 
 #include <concepts>
+#include <span>
 #include <string>
 #include <string_view>
+
+#include "common/common_types.h"
 
 namespace Common::FS {
 
@@ -21,5 +24,25 @@ concept IsChar = std::same_as<T, char>;
  * @returns UTF-8 encoded std::u8string.
  */
 [[nodiscard]] std::u8string ToU8String(std::string_view utf8_string);
+
+/**
+ * Converts a buffer of bytes to a UTF8-encoded std::u8string.
+ * This converts from the start of the buffer until the first encountered null-terminator.
+ * If no null-terminator is found, this converts the entire buffer instead.
+ *
+ * @param buffer Buffer of bytes
+ *
+ * @returns UTF-8 encoded std::u8string.
+ */
+[[nodiscard]] std::u8string BufferToU8String(std::span<const u8> buffer);
+
+/**
+ * Converts a std::u8string or std::u8string_view to a UTF-8 encoded std::string.
+ *
+ * @param u8_string UTF-8 encoded u8string
+ *
+ * @returns UTF-8 encoded std::string.
+ */
+[[nodiscard]] std::string ToUTF8String(std::u8string_view u8_string);
 
 } // namespace Common::FS

--- a/src/common/fs/path_util.cpp
+++ b/src/common/fs/path_util.cpp
@@ -129,12 +129,6 @@ private:
     std::unordered_map<YuzuPath, fs::path> yuzu_paths;
 };
 
-std::string PathToUTF8String(const fs::path& path) {
-    const auto utf8_string = path.u8string();
-
-    return std::string{utf8_string.begin(), utf8_string.end()};
-}
-
 bool ValidatePath(const fs::path& path) {
     if (path.empty()) {
         LOG_ERROR(Common_Filesystem, "Input path is empty, path={}", PathToUTF8String(path));

--- a/src/common/fs/path_util.h
+++ b/src/common/fs/path_util.h
@@ -26,15 +26,6 @@ enum class YuzuPath {
 };
 
 /**
- * Converts a filesystem path to a UTF-8 encoded std::string.
- *
- * @param path Filesystem path
- *
- * @returns UTF-8 encoded std::string.
- */
-[[nodiscard]] std::string PathToUTF8String(const std::filesystem::path& path);
-
-/**
  * Validates a given path.
  *
  * A given path is valid if it meets these conditions:


### PR DESCRIPTION
These string conversion functions are required for enforcing UTF-8 encoded paths in the future,