### PR TITLE
buffer_cache: Simplify uniform disabling logic

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -110,6 +110,8 @@ public:
 
     void BindGraphicsUniformBuffer(size_t stage, u32 index, GPUVAddr gpu_addr, u32 size);
 
+    void DisableGraphicsUniformBuffer(size_t stage, u32 index);
+
     void UpdateGraphicsBuffers(bool is_indexed);
 
     void UpdateComputeBuffers();
@@ -419,16 +421,17 @@ template <class P>
 void BufferCache<P>::BindGraphicsUniformBuffer(size_t stage, u32 index, GPUVAddr gpu_addr,
                                                u32 size) {
     const std::optional<VAddr> cpu_addr = gpu_memory.GpuToCpuAddress(gpu_addr);
-    if (!cpu_addr) {
-        uniform_buffers[stage][index] = NULL_BINDING;
-        return;
-    }
     const Binding binding{
         .cpu_addr = *cpu_addr,
         .size = size,
         .buffer_id = BufferId{},
     };
     uniform_buffers[stage][index] = binding;
+}
+
+template <class P>
+void BufferCache<P>::DisableGraphicsUniformBuffer(size_t stage, u32 index) {
+    uniform_buffers[stage][index] = NULL_BINDING;
 }
 
 template <class P>

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -578,8 +578,12 @@ void Maxwell3D::ProcessCBBind(size_t stage_index) {
     buffer.size = regs.const_buffer.cb_size;
 
     const bool is_enabled = bind_data.valid.Value() != 0;
-    const GPUVAddr gpu_addr = is_enabled ? regs.const_buffer.BufferAddress() : 0;
-    const u32 size = is_enabled ? regs.const_buffer.cb_size : 0;
+    if (!is_enabled) {
+        rasterizer->DisableGraphicsUniformBuffer(stage_index, bind_data.index);
+        return;
+    }
+    const GPUVAddr gpu_addr = regs.const_buffer.BufferAddress();
+    const u32 size = regs.const_buffer.cb_size;
     rasterizer->BindGraphicsUniformBuffer(stage_index, bind_data.index, gpu_addr, size);
 }
 

--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -163,6 +163,9 @@ std::optional<GPUVAddr> MemoryManager::FindFreeRange(std::size_t size, std::size
 }
 
 std::optional<VAddr> MemoryManager::GpuToCpuAddress(GPUVAddr gpu_addr) const {
+    if (gpu_addr == 0) {
+        return std::nullopt;
+    }
     const auto page_entry{GetPageEntry(gpu_addr)};
     if (!page_entry.IsValid()) {
         return std::nullopt;

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -54,6 +54,9 @@ public:
     virtual void BindGraphicsUniformBuffer(size_t stage, u32 index, GPUVAddr gpu_addr,
                                            u32 size) = 0;
 
+    /// Signal disabling of a uniform buffer
+    virtual void DisableGraphicsUniformBuffer(size_t stage, u32 index) = 0;
+
     /// Signal a GPU based semaphore as a fence
     virtual void SignalSemaphore(GPUVAddr addr, u32 value) = 0;
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -526,6 +526,10 @@ void RasterizerOpenGL::BindGraphicsUniformBuffer(size_t stage, u32 index, GPUVAd
     buffer_cache.BindGraphicsUniformBuffer(stage, index, gpu_addr, size);
 }
 
+void RasterizerOpenGL::DisableGraphicsUniformBuffer(size_t stage, u32 index) {
+    buffer_cache.DisableGraphicsUniformBuffer(stage, index);
+}
+
 void RasterizerOpenGL::FlushAll() {}
 
 void RasterizerOpenGL::FlushRegion(VAddr addr, u64 size) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -72,6 +72,7 @@ public:
     void ResetCounter(VideoCore::QueryType type) override;
     void Query(GPUVAddr gpu_addr, VideoCore::QueryType type, std::optional<u64> timestamp) override;
     void BindGraphicsUniformBuffer(size_t stage, u32 index, GPUVAddr gpu_addr, u32 size) override;
+    void DisableGraphicsUniformBuffer(size_t stage, u32 index) override;
     void FlushAll() override;
     void FlushRegion(VAddr addr, u64 size) override;
     bool MustFlushRegion(VAddr addr, u64 size) override;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -476,6 +476,10 @@ void RasterizerVulkan::BindGraphicsUniformBuffer(size_t stage, u32 index, GPUVAd
     buffer_cache.BindGraphicsUniformBuffer(stage, index, gpu_addr, size);
 }
 
+void Vulkan::RasterizerVulkan::DisableGraphicsUniformBuffer(size_t stage, u32 index) {
+    buffer_cache.DisableGraphicsUniformBuffer(stage, index);
+}
+
 void RasterizerVulkan::FlushAll() {}
 
 void RasterizerVulkan::FlushRegion(VAddr addr, u64 size) {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -64,6 +64,7 @@ public:
     void ResetCounter(VideoCore::QueryType type) override;
     void Query(GPUVAddr gpu_addr, VideoCore::QueryType type, std::optional<u64> timestamp) override;
     void BindGraphicsUniformBuffer(size_t stage, u32 index, GPUVAddr gpu_addr, u32 size) override;
+    void DisableGraphicsUniformBuffer(size_t stage, u32 index) override;
     void FlushAll() override;
     void FlushRegion(VAddr addr, u64 size) override;
     bool MustFlushRegion(VAddr addr, u64 size) override;


### PR DESCRIPTION
Currently, In order to disable uniform buffers (set them to `NULL_BINDING`), the gpu address and size are set to zero and sent through the same path as the valid buffers that are being bound. This resulted in the GPU to CPU address lookup to fail, indicating that the buffer should be disabled.

This PR aims to make disabling uniform buffers more explicit. Disabling uniforms is now handled by `DisableGraphicsUniformBuffer`, alleviating `BindGraphicsUniformBuffer` from the responsibility to handle both the binding and disabling logic.