### PR TITLE
[game_list] Correct light theme loading

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -341,11 +341,7 @@ GameList::GameList(FileSys::VirtualFilesystem vfs, FileSys::ManualContentProvide
     connect(tree_view, &QTreeView::customContextMenuRequested, this, &GameList::PopupContextMenu);
     connect(tree_view, &QTreeView::expanded, this, &GameList::OnItemExpanded);
     connect(tree_view, &QTreeView::collapsed, this, &GameList::OnItemExpanded);
-    connect(tree_view->header(), &QHeaderView::sectionResized, this,
-            &GameList::SaveInterfaceLayout);
-    connect(tree_view->header(), &QHeaderView::sectionMoved, this, &GameList::SaveInterfaceLayout);
-    connect(tree_view->header(), &QHeaderView::sortIndicatorChanged, this,
-            &GameList::SaveInterfaceLayout);
+
     // We must register all custom types with the Qt Automoc system so that we are able to use
     // it with signals/slots. In this case, QList falls under the umbrells of custom types.
     qRegisterMetaType<QList<QStandardItem*>>("QList<QStandardItem*>");
@@ -355,7 +351,6 @@ GameList::GameList(FileSys::VirtualFilesystem vfs, FileSys::ManualContentProvide
     layout->addWidget(tree_view);
     layout->addWidget(search_field);
     setLayout(layout);
-    is_initializing = false;
 }
 
 GameList::~GameList() {
@@ -731,9 +726,7 @@ void GameList::PopulateAsync(QVector<UISettings::GameDir>& game_dirs) {
 }
 
 void GameList::SaveInterfaceLayout() {
-    if (!is_initializing) {
-        UISettings::values.gamelist_header_state = tree_view->header()->saveState();
-    }
+    UISettings::values.gamelist_header_state = tree_view->header()->saveState();
 }
 
 void GameList::LoadInterfaceLayout() {

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -355,6 +355,7 @@ GameList::GameList(FileSys::VirtualFilesystem vfs, FileSys::ManualContentProvide
     layout->addWidget(tree_view);
     layout->addWidget(search_field);
     setLayout(layout);
+    is_initializing = false;
 }
 
 GameList::~GameList() {
@@ -730,7 +731,9 @@ void GameList::PopulateAsync(QVector<UISettings::GameDir>& game_dirs) {
 }
 
 void GameList::SaveInterfaceLayout() {
-    UISettings::values.gamelist_header_state = tree_view->header()->saveState();
+    if (!is_initializing) {
+        UISettings::values.gamelist_header_state = tree_view->header()->saveState();
+    }
 }
 
 void GameList::LoadInterfaceLayout() {

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -133,6 +133,7 @@ private:
     GameListWorker* current_worker = nullptr;
     QFileSystemWatcher* watcher = nullptr;
     CompatibilityList compatibility_list;
+    bool is_initializing = true;
 
     friend class GameListSearchField;
 };

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -133,7 +133,6 @@ private:
     GameListWorker* current_worker = nullptr;
     QFileSystemWatcher* watcher = nullptr;
     CompatibilityList compatibility_list;
-    bool is_initializing = true;
 
     friend class GameListSearchField;
 };


### PR DESCRIPTION
The setLayout call in game list instanciation will call resizing signals with default values in light theme, which was then being erroneously saved. setLayout doesn't seem to call resizing for any other theme, so I'm not sure why that happens.