### PR TITLE
yuzu-cmd: Add touch_from_button in config file

### DIFF
--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -317,6 +317,43 @@ void Config::ReadValues() {
         sdl2_config->GetInteger("ControlsGeneral", "touch_diameter_x", 15);
     Settings::values.touchscreen.diameter_y =
         sdl2_config->GetInteger("ControlsGeneral", "touch_diameter_y", 15);
+
+    int num_touch_from_button_maps =
+        sdl2_config->GetInteger("ControlsGeneral", "touch_from_button_map", 0);
+    if (num_touch_from_button_maps > 0) {
+        for (int i = 0; i < num_touch_from_button_maps; ++i) {
+            Settings::TouchFromButtonMap map;
+            map.name = sdl2_config->Get("ControlsGeneral",
+                                        std::string("touch_from_button_maps_") + std::to_string(i) +
+                                            std::string("_name"),
+                                        "default");
+            const int num_touch_maps = sdl2_config->GetInteger(
+                "ControlsGeneral",
+                std::string("touch_from_button_maps_") + std::to_string(i) + std::string("_count"),
+                0);
+            map.buttons.reserve(num_touch_maps);
+
+            for (int j = 0; j < num_touch_maps; ++j) {
+                std::string touch_mapping =
+                    sdl2_config->Get("ControlsGeneral",
+                                     std::string("touch_from_button_maps_") + std::to_string(i) +
+                                         std::string("_bind_") + std::to_string(j),
+                                     "");
+                map.buttons.emplace_back(std::move(touch_mapping));
+            }
+
+            Settings::values.touch_from_button_maps.emplace_back(std::move(map));
+        }
+    } else {
+        Settings::values.touch_from_button_maps.emplace_back(
+            Settings::TouchFromButtonMap{"default", {}});
+        num_touch_from_button_maps = 1;
+    }
+    Settings::values.use_touch_from_button =
+        sdl2_config->GetBoolean("ControlsGeneral", "use_touch_from_button", false);
+    Settings::values.touch_from_button_map_index =
+        std::clamp(Settings::values.touch_from_button_map_index, 0, num_touch_from_button_maps - 1);
+
     Settings::values.udp_input_servers =
         sdl2_config->Get("Controls", "udp_input_address", InputCommon::CemuhookUDP::DEFAULT_SRV);
 

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -7,7 +7,7 @@
 namespace DefaultINI {
 
 const char* sdl2_config_file = R"(
-[Controls]
+[ControlsGeneral]
 # The input devices and parameters for each Switch native input
 # It should be in the format of "engine:[engine_name],[param1]:[value1],[param2]:[value2]..."
 # Escape characters $0 (for ':'), $1 (for ',') and $2 (for '$') can be used in values
@@ -85,6 +85,18 @@ motion_device=
 #  - "cemuhookudp" reads touch input from a udp server that uses cemuhook's udp protocol
 #      - "min_x", "min_y", "max_x", "max_y": defines the udp device's touch screen coordinate system
 touch_device=
+
+# Whether to enable or disable touch input from button
+# 0 (default): Disabled, 1: Enabled
+use_touch_from_button=
+
+# for mapping buttons to touch inputs.
+#touch_from_button_map=1
+#touch_from_button_maps_0_name=default
+#touch_from_button_maps_0_count=2
+#touch_from_button_maps_0_bind_0=foo
+#touch_from_button_maps_0_bind_1=bar
+# etc.
 
 # Most desktop operating systems do not expose a way to poll the motion state of the controllers
 # so as a way around it, cemuhook created a udp client/server protocol to broadcast the data directly


### PR DESCRIPTION
Current yuzu-cmd produces a segfault in `TouchFromButtonDevice::TouchFromButtonDevice()`, because touch from button settings are not parsed or initialized for yuzu-cmd. This PR suggests options for setting touch from button feature inside `sdl2-config.ini` and parses those settings. Additionally, it fixes the section name `[Controls]` to `[ControlsGeneral]` in the default config file, which was changed a while ago.