### PR TITLE
yuzu-cmd: Fix OpenGL rendering

### DIFF
--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.cpp
@@ -32,7 +32,7 @@
 
 class SDLGLContext : public Core::Frontend::GraphicsContext {
 public:
-    explicit SDLGLContext(SDL_Window* window) : window(window) {
+    explicit SDLGLContext(SDL_Window* window_) : window{window_} {
         context = SDL_GL_CreateContext(window);
     }
 

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.cpp
@@ -32,17 +32,17 @@
 
 class SDLGLContext : public Core::Frontend::GraphicsContext {
 public:
-    explicit SDLGLContext() {
-        // create a hidden window to make the shared context against
-        window = SDL_CreateWindow(NULL, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 0, 0,
-                                  SDL_WINDOW_HIDDEN | SDL_WINDOW_OPENGL);
+    explicit SDLGLContext(SDL_Window* window) : window(window) {
         context = SDL_GL_CreateContext(window);
     }
 
     ~SDLGLContext() {
         DoneCurrent();
         SDL_GL_DeleteContext(context);
-        SDL_DestroyWindow(window);
+    }
+
+    void SwapBuffers() override {
+        SDL_GL_SwapWindow(window);
     }
 
     void MakeCurrent() override {
@@ -114,9 +114,6 @@ EmuWindow_SDL2_GL::EmuWindow_SDL2_GL(InputCommon::InputSubsystem* input_subsyste
         exit(1);
     }
 
-    dummy_window = SDL_CreateWindow(NULL, SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, 0, 0,
-                                    SDL_WINDOW_HIDDEN | SDL_WINDOW_OPENGL);
-
     SetWindowIcon();
 
     if (fullscreen) {
@@ -159,5 +156,5 @@ EmuWindow_SDL2_GL::~EmuWindow_SDL2_GL() {
 }
 
 std::unique_ptr<Core::Frontend::GraphicsContext> EmuWindow_SDL2_GL::CreateSharedContext() const {
-    return std::make_unique<SDLGLContext>();
+    return std::make_unique<SDLGLContext>(render_window);
 }

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.h
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.h
@@ -20,9 +20,6 @@ public:
     std::unique_ptr<Core::Frontend::GraphicsContext> CreateSharedContext() const override;
 
 private:
-    /// Fake hidden window for the core context
-    SDL_Window* dummy_window{};
-
     /// Whether the GPU and driver supports the OpenGL extension required
     bool SupportsRequiredGLExtensions();
 


### PR DESCRIPTION
Commit 7003090187e02c8625f4eb7a024ac97f9b0159aa changed the way rendering is performed, but it was incorrectly modified in yuzu-cmd, resulting in the disappearance of buffer swapping. This PR recovers the rendering for sdl2 GL.