### PR TITLE
Implement/Port Fastmem from Citra to Yuzu

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -131,6 +131,8 @@ add_library(common STATIC
     hash.h
     hex_util.cpp
     hex_util.h
+    host_memory.cpp
+    host_memory.h
     intrusive_red_black_tree.h
     logging/backend.cpp
     logging/backend.h

--- a/src/common/host_memory.cpp
+++ b/src/common/host_memory.cpp
@@ -1,0 +1,320 @@
+#ifdef __linux__
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#elif defined(_WIN32) // ^^^ Linux ^^^ vvv Windows vvv
+#ifdef _WIN32_WINNT
+#undef _WIN32_WINNT
+#endif
+#define _WIN32_WINNT 0x0A00 // Windows 10
+
+#include <windows.h>
+
+#include <boost/icl/separate_interval_set.hpp>
+
+#include <iterator>
+#include <unordered_map>
+
+#pragma comment(lib, "mincore.lib")
+
+#endif // ^^^ Windows ^^^
+
+#include <mutex>
+
+#include "common/assert.h"
+#include "common/host_memory.h"
+#include "common/logging/log.h"
+
+namespace Common {
+
+constexpr size_t PageAlignment = 0x1000;
+
+#ifdef _WIN32
+
+class HostMemory::Impl {
+public:
+    explicit Impl(size_t backing_size_, size_t virtual_size_)
+        : backing_size{backing_size_}, virtual_size{virtual_size_}, process{GetCurrentProcess()} {
+        // Allocate backing file map
+        backing_handle =
+            CreateFileMapping2(INVALID_HANDLE_VALUE, nullptr, FILE_MAP_WRITE | FILE_MAP_READ,
+                               PAGE_READWRITE, SEC_COMMIT, backing_size, nullptr, nullptr, 0);
+        if (!backing_handle) {
+            throw std::bad_alloc{};
+        }
+        // Allocate a virtual memory for the backing file map as placeholder
+        backing_base = static_cast<u8*>(VirtualAlloc2(process, nullptr, backing_size,
+                                                      MEM_RESERVE | MEM_RESERVE_PLACEHOLDER,
+                                                      PAGE_NOACCESS, nullptr, 0));
+        if (!backing_base) {
+            Release();
+            throw std::bad_alloc{};
+        }
+        // Map backing placeholder
+        void* const ret = MapViewOfFile3(backing_handle, process, backing_base, 0, backing_size,
+                                         MEM_REPLACE_PLACEHOLDER, PAGE_READWRITE, nullptr, 0);
+        if (ret != backing_base) {
+            Release();
+            throw std::bad_alloc{};
+        }
+        // Allocate virtual address placeholder
+        virtual_base = static_cast<u8*>(VirtualAlloc2(process, nullptr, virtual_size,
+                                                      MEM_RESERVE | MEM_RESERVE_PLACEHOLDER,
+                                                      PAGE_NOACCESS, nullptr, 0));
+        if (!virtual_base) {
+            Release();
+            throw std::bad_alloc{};
+        }
+    }
+
+    ~Impl() {
+        Release();
+    }
+
+    void Map(size_t virtual_offset, size_t host_offset, size_t length) {
+        std::unique_lock lock{placeholder_mutex};
+        if (!IsNiechePlaceholder(virtual_offset, length)) {
+            Split(virtual_offset, length);
+        }
+        ASSERT(placeholders.find({virtual_offset, virtual_offset + length}) == placeholders.end());
+        TrackPlaceholder(virtual_offset, host_offset, length);
+
+        MapView(virtual_offset, host_offset, length);
+    }
+
+    void Unmap(size_t virtual_offset, size_t length) {
+        std::lock_guard lock{placeholder_mutex};
+
+        // Unmap until there are no more placeholders
+        while (UnmapOnePlaceholder(virtual_offset, length)) {
+        }
+    }
+
+    void Protect(size_t virtual_offset, size_t length, bool read, bool write) {
+        DWORD new_flags{};
+        if (read && write) {
+            new_flags = PAGE_READWRITE;
+        } else if (read && !write) {
+            new_flags = PAGE_READONLY;
+        } else if (!read && !write) {
+            new_flags = PAGE_NOACCESS;
+        } else {
+            UNIMPLEMENTED_MSG("Protection flag combination read={} write={}", read, write);
+        }
+        DWORD old_flags{};
+        if (!VirtualProtect(virtual_base + virtual_offset, length, new_flags, &old_flags)) {
+            LOG_CRITICAL(HW_Memory, "Failed to change virtual memory protect rules");
+        }
+    }
+
+    const size_t backing_size; ///< Size of the backing memory in bytes
+    const size_t virtual_size; ///< Size of the virtual address placeholder in bytes
+
+    u8* backing_base{};
+    u8* virtual_base{};
+
+private:
+    /// Release all resources in the object
+    void Release() {
+        if (!placeholders.empty()) {
+            for (const auto& placeholder : placeholders) {
+                if (!UnmapViewOfFile2(process, virtual_base + placeholder.lower(),
+                                      MEM_PRESERVE_PLACEHOLDER)) {
+                    LOG_CRITICAL(HW_Memory, "Failed to unmap virtual memory placeholder");
+                }
+            }
+            Coalesce(0, virtual_size);
+        }
+        if (virtual_base) {
+            if (!VirtualFree(virtual_base, 0, MEM_RELEASE)) {
+                LOG_CRITICAL(HW_Memory, "Failed to free virtual memory");
+            }
+        }
+        if (backing_base) {
+            if (!UnmapViewOfFile2(process, backing_base, MEM_PRESERVE_PLACEHOLDER)) {
+                LOG_CRITICAL(HW_Memory, "Failed to unmap backing memory placeholder");
+            }
+            if (!VirtualFreeEx(process, backing_base, 0, MEM_RELEASE)) {
+                LOG_CRITICAL(HW_Memory, "Failed to free backing memory");
+            }
+        }
+        if (!CloseHandle(backing_handle)) {
+            LOG_CRITICAL(HW_Memory, "Failed to free backing memory file handle");
+        }
+    }
+
+    /// Unmap one placeholder in the given range (partial unmaps are supported)
+    /// Return true when there are no more placeholders to unmap
+    bool UnmapOnePlaceholder(size_t virtual_offset, size_t length) {
+        const auto it = placeholders.find({virtual_offset, virtual_offset + length});
+        const auto begin = placeholders.begin();
+        const auto end = placeholders.end();
+        if (it == end) {
+            return false;
+        }
+        const size_t placeholder_begin = it->lower();
+        const size_t placeholder_end = it->upper();
+        const size_t unmap_begin = std::max(virtual_offset, placeholder_begin);
+        const size_t unmap_end = std::min(virtual_offset + length, placeholder_end);
+        ASSERT(unmap_begin >= placeholder_begin && unmap_begin < placeholder_end);
+        ASSERT(unmap_end <= placeholder_end && unmap_end > placeholder_begin);
+
+        const auto host_pointer_it = placeholder_host_pointers.find(placeholder_begin);
+        ASSERT(host_pointer_it != placeholder_host_pointers.end());
+        const size_t host_offset = host_pointer_it->second;
+
+        const bool split_left = unmap_begin > placeholder_begin;
+        const bool split_right = unmap_end < placeholder_end;
+
+        if (!UnmapViewOfFile2(process, virtual_base + placeholder_begin,
+                              MEM_PRESERVE_PLACEHOLDER)) {
+            LOG_CRITICAL(HW_Memory, "Failed to unmap placeholder");
+        }
+        // If we have to remap memory regions due to partial unmaps, we are in a data race as
+        // Windows doesn't support remapping memory without unmapping first. Avoid adding any extra
+        // logic within the panic region described below.
+
+        // Panic region, we are in a data race right now
+        if (split_left || split_right) {
+            Split(unmap_begin, unmap_end - unmap_begin);
+        }
+        if (split_left) {
+            MapView(placeholder_begin, host_offset, unmap_begin - placeholder_begin);
+        }
+        if (split_right) {
+            MapView(unmap_end, host_offset + unmap_end - placeholder_begin,
+                    placeholder_end - unmap_end);
+        }
+        // End panic region
+
+        size_t coalesce_begin = unmap_begin;
+        if (!split_left) {
+            // Try to coalesce pages to the left
+            coalesce_begin = it == begin ? 0 : std::prev(it)->upper();
+            if (coalesce_begin != placeholder_begin) {
+                Coalesce(coalesce_begin, unmap_end - coalesce_begin);
+            }
+        }
+        if (!split_right) {
+            // Try to coalesce pages to the right
+            const auto next = std::next(it);
+            const size_t next_begin = next == end ? virtual_size : next->lower();
+            if (placeholder_end != next_begin) {
+                // We can coalesce to the right
+                Coalesce(coalesce_begin, next_begin - coalesce_begin);
+            }
+        }
+        // Remove and reinsert placeholder trackers
+        UntrackPlaceholder(it);
+        if (split_left) {
+            TrackPlaceholder(placeholder_begin, host_offset, unmap_begin - placeholder_begin);
+        }
+        if (split_right) {
+            TrackPlaceholder(unmap_end, host_offset + unmap_end - placeholder_begin,
+                             placeholder_end - unmap_end);
+        }
+        return true;
+    }
+
+    void MapView(size_t virtual_offset, size_t host_offset, size_t length) {
+        if (!MapViewOfFile3(backing_handle, process, virtual_base + virtual_offset, host_offset,
+                            length, MEM_REPLACE_PLACEHOLDER, PAGE_READWRITE, nullptr, 0)) {
+            LOG_CRITICAL(HW_Memory, "Failed to map placeholder");
+        }
+    }
+
+    void Split(size_t virtual_offset, size_t length) {
+        if (!VirtualFreeEx(process, reinterpret_cast<LPVOID>(virtual_base + virtual_offset), length,
+                           MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER)) {
+            LOG_CRITICAL(HW_Memory, "Failed to split placeholder");
+        }
+    }
+
+    void Coalesce(size_t virtual_offset, size_t length) {
+        if (!VirtualFreeEx(process, reinterpret_cast<LPVOID>(virtual_base + virtual_offset), length,
+                           MEM_RELEASE | MEM_COALESCE_PLACEHOLDERS)) {
+            LOG_CRITICAL(HW_Memory, "Failed to coalesce placeholders");
+        }
+    }
+
+    void TrackPlaceholder(size_t virtual_offset, size_t host_offset, size_t length) {
+        placeholders.insert({virtual_offset, virtual_offset + length});
+        placeholder_host_pointers.emplace(virtual_offset, host_offset);
+    }
+
+    void UntrackPlaceholder(boost::icl::separate_interval_set<size_t>::iterator it) {
+        placeholders.erase(it);
+        placeholder_host_pointers.erase(it->lower());
+    }
+
+    /// Return true when a given memory region is a "nieche" and the placeholders don't have to be
+    /// splitted.
+    bool IsNiechePlaceholder(size_t virtual_offset, size_t length) const {
+        const auto it = placeholders.upper_bound({virtual_offset, virtual_offset + length});
+        if (it != placeholders.end() && it->lower() == virtual_offset + length) {
+            const bool is_root = it == placeholders.begin() && virtual_offset == 0;
+            return is_root || std::prev(it)->upper() == virtual_offset;
+        }
+        return false;
+    }
+
+    HANDLE process{};        ///< Current process handle
+    HANDLE backing_handle{}; ///< File based backing memory
+
+    std::mutex placeholder_mutex;                                 ///< Mutex for placeholders
+    boost::icl::separate_interval_set<size_t> placeholders;       ///< Mapped placeholders
+    std::unordered_map<size_t, size_t> placeholder_host_pointers; ///< Placeholder backing offset
+};
+
+#else
+
+#error Please implement the host memory for your platform
+
+#endif
+
+HostMemory::HostMemory(size_t backing_size, size_t virtual_size)
+    : impl{std::make_unique<HostMemory::Impl>(backing_size, virtual_size)},
+      backing_base{impl->backing_base}, virtual_base{impl->virtual_base} {}
+
+HostMemory::~HostMemory() = default;
+
+HostMemory::HostMemory(HostMemory&&) noexcept = default;
+
+HostMemory& HostMemory::operator=(HostMemory&&) noexcept = default;
+
+void HostMemory::Map(size_t virtual_offset, size_t host_offset, size_t length) {
+    ASSERT(virtual_offset % PageAlignment == 0);
+    ASSERT(host_offset % PageAlignment == 0);
+    ASSERT(length % PageAlignment == 0);
+    ASSERT(virtual_offset + length <= impl->virtual_size);
+    ASSERT(host_offset + length <= impl->backing_size);
+    if (length == 0) {
+        return;
+    }
+    impl->Map(virtual_offset, host_offset, length);
+}
+
+void HostMemory::Unmap(size_t virtual_offset, size_t length) {
+    ASSERT(virtual_offset % PageAlignment == 0);
+    ASSERT(length % PageAlignment == 0);
+    ASSERT(virtual_offset + length <= impl->virtual_size);
+    if (length == 0) {
+        return;
+    }
+    impl->Unmap(virtual_offset, length);
+}
+
+void HostMemory::Protect(size_t virtual_offset, size_t length, bool read, bool write) {
+    ASSERT(virtual_offset % PageAlignment == 0);
+    ASSERT(length % PageAlignment == 0);
+    ASSERT(virtual_offset + length <= impl->virtual_size);
+    if (length == 0) {
+        return;
+    }
+    impl->Protect(virtual_offset, length, read, write);
+}
+
+} // namespace Common

--- a/src/common/host_memory.h
+++ b/src/common/host_memory.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 #include "common/common_types.h"
+#include "common/virtual_buffer.h"
 
 namespace Common {
 
@@ -61,6 +62,9 @@ private:
     u8* backing_base{};
     u8* virtual_base{};
     size_t virtual_base_offset{};
+
+    // Fallback if fastmem is not supported on this platform
+    std::unique_ptr<Common::VirtualBuffer<u8>> fallback_buffer;
 };
 
 } // namespace Common

--- a/src/common/host_memory.h
+++ b/src/common/host_memory.h
@@ -15,7 +15,7 @@ namespace Common {
  */
 class HostMemory {
 public:
-    explicit HostMemory(size_t backing_size, size_t virtual_size);
+    explicit HostMemory(size_t backing_size_, size_t virtual_size_);
     ~HostMemory();
 
     /**
@@ -52,11 +52,15 @@ public:
     }
 
 private:
+    size_t backing_size{};
+    size_t virtual_size{};
+
     // Low level handler for the platform dependent memory routines
     class Impl;
     std::unique_ptr<Impl> impl;
     u8* backing_base{};
     u8* virtual_base{};
+    size_t virtual_base_offset{};
 };
 
 } // namespace Common

--- a/src/common/host_memory.h
+++ b/src/common/host_memory.h
@@ -1,0 +1,62 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include "common/common_types.h"
+
+namespace Common {
+
+/**
+ * A low level linear memory buffer, which supports multiple mappings
+ * Its purpose is to rebuild a given sparse memory layout, including mirrors.
+ */
+class HostMemory {
+public:
+    explicit HostMemory(size_t backing_size, size_t virtual_size);
+    ~HostMemory();
+
+    /**
+     * Copy constructors. They shall return a copy of the buffer without the mappings.
+     * TODO: Implement them with COW if needed.
+     */
+    HostMemory(const HostMemory& other) = delete;
+    HostMemory& operator=(const HostMemory& other) = delete;
+
+    /**
+     * Move constructors. They will move the buffer and the mappings to the new object.
+     */
+    HostMemory(HostMemory&& other) noexcept;
+    HostMemory& operator=(HostMemory&& other) noexcept;
+
+    void Map(size_t virtual_offset, size_t host_offset, size_t length);
+
+    void Unmap(size_t virtual_offset, size_t length);
+
+    void Protect(size_t virtual_offset, size_t length, bool read, bool write);
+
+    [[nodiscard]] u8* BackingBasePointer() noexcept {
+        return backing_base;
+    }
+    [[nodiscard]] const u8* BackingBasePointer() const noexcept {
+        return backing_base;
+    }
+
+    [[nodiscard]] u8* VirtualBasePointer() noexcept {
+        return virtual_base;
+    }
+    [[nodiscard]] const u8* VirtualBasePointer() const noexcept {
+        return virtual_base;
+    }
+
+private:
+    // Low level handler for the platform dependent memory routines
+    class Impl;
+    std::unique_ptr<Impl> impl;
+    u8* backing_base{};
+    u8* virtual_base{};
+};
+
+} // namespace Common

--- a/src/common/page_table.h
+++ b/src/common/page_table.h
@@ -111,6 +111,8 @@ struct PageTable {
     VirtualBuffer<u64> backing_addr;
 
     size_t current_address_space_width_in_bits;
+
+    u8* fastmem_arena;
 };
 
 } // namespace Common

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -90,6 +90,13 @@ bool IsGPULevelHigh() {
            values.gpu_accuracy.GetValue() == GPUAccuracy::High;
 }
 
+bool IsFastmemEnabled() {
+    if (values.cpu_accuracy.GetValue() == CPUAccuracy::DebugMode) {
+        return values.cpuopt_fastmem;
+    }
+    return true;
+}
+
 float Volume() {
     if (values.audio_muted) {
         return 0.0f;
@@ -115,6 +122,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.cpuopt_unsafe_unfuse_fma.SetGlobal(true);
     values.cpuopt_unsafe_reduce_fp_error.SetGlobal(true);
     values.cpuopt_unsafe_inaccurate_nan.SetGlobal(true);
+    values.cpuopt_unsafe_fastmem_check.SetGlobal(true);
 
     // Renderer
     values.renderer_backend.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -125,10 +125,12 @@ struct Values {
     bool cpuopt_const_prop;
     bool cpuopt_misc_ir;
     bool cpuopt_reduce_misalign_checks;
+    bool cpuopt_fastmem;
 
     Setting<bool> cpuopt_unsafe_unfuse_fma;
     Setting<bool> cpuopt_unsafe_reduce_fp_error;
     Setting<bool> cpuopt_unsafe_inaccurate_nan;
+    Setting<bool> cpuopt_unsafe_fastmem_check;
 
     // Renderer
     Setting<RendererBackend> renderer_backend;
@@ -248,6 +250,8 @@ void SetConfiguringGlobal(bool is_global);
 
 bool IsGPULevelExtreme();
 bool IsGPULevelHigh();
+
+bool IsFastmemEnabled();
 
 float Volume();
 

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -144,7 +144,7 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
 
     // Code cache size
     config.code_cache_size = 512 * 1024 * 1024;
-    config.far_code_offset = 256 * 1024 * 1024;
+    config.far_code_offset = 400 * 1024 * 1024;
 
     // Safe optimizations
     if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::DebugMode) {
@@ -171,6 +171,9 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
         }
         if (!Settings::values.cpuopt_reduce_misalign_checks) {
             config.only_detect_misalignment_via_page_table_on_page_boundary = false;
+        }
+        if (!Settings::values.cpuopt_fastmem) {
+            config.fastmem_pointer = nullptr;
         }
     }
 

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -128,6 +128,7 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
     if (page_table) {
         config.page_table = reinterpret_cast<std::array<std::uint8_t*, NUM_PAGE_TABLE_ENTRIES>*>(
             page_table->pointers.data());
+        config.fastmem_pointer = page_table->fastmem_arena;
     }
     config.absolute_offset_page_table = true;
     config.page_table_pointer_mask_bits = Common::PageTable::ATTRIBUTE_BITS;

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -185,7 +185,7 @@ std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* 
 
     // Code cache size
     config.code_cache_size = 512 * 1024 * 1024;
-    config.far_code_offset = 256 * 1024 * 1024;
+    config.far_code_offset = 400 * 1024 * 1024;
 
     // Safe optimizations
     if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::DebugMode) {
@@ -213,6 +213,9 @@ std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* 
         if (!Settings::values.cpuopt_reduce_misalign_checks) {
             config.only_detect_misalignment_via_page_table_on_page_boundary = false;
         }
+        if (!Settings::values.cpuopt_fastmem) {
+            config.fastmem_pointer = nullptr;
+        }
     }
 
     // Unsafe optimizations
@@ -226,6 +229,9 @@ std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* 
         }
         if (Settings::values.cpuopt_unsafe_inaccurate_nan.GetValue()) {
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
+        }
+        if (Settings::values.cpuopt_unsafe_fastmem_check.GetValue()) {
+            config.fastmem_address_space_bits = 64;
         }
     }
 

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -160,6 +160,10 @@ std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* 
         config.absolute_offset_page_table = true;
         config.detect_misaligned_access_via_page_table = 16 | 32 | 64 | 128;
         config.only_detect_misalignment_via_page_table_on_page_boundary = true;
+
+        config.fastmem_pointer = page_table->fastmem_arena;
+        config.fastmem_address_space_bits = address_space_bits;
+        config.silently_mirror_fastmem = false;
     }
 
     // Multi-process state

--- a/src/core/device_memory.cpp
+++ b/src/core/device_memory.cpp
@@ -6,7 +6,7 @@
 
 namespace Core {
 
-DeviceMemory::DeviceMemory() : buffer{DramMemoryMap::Size} {}
+DeviceMemory::DeviceMemory() : buffer{DramMemoryMap::Size, 1ULL << 39} {}
 DeviceMemory::~DeviceMemory() = default;
 
 } // namespace Core

--- a/src/core/device_memory.h
+++ b/src/core/device_memory.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include "common/common_types.h"
-#include "common/virtual_buffer.h"
+#include "common/host_memory.h"
 
 namespace Core {
 
@@ -21,27 +21,30 @@ enum : u64 {
 };
 }; // namespace DramMemoryMap
 
-class DeviceMemory : NonCopyable {
+class DeviceMemory {
 public:
     explicit DeviceMemory();
     ~DeviceMemory();
 
+    DeviceMemory& operator=(const DeviceMemory&) = delete;
+    DeviceMemory(const DeviceMemory&) = delete;
+
     template <typename T>
     PAddr GetPhysicalAddr(const T* ptr) const {
-        return (reinterpret_cast<uintptr_t>(ptr) - reinterpret_cast<uintptr_t>(buffer.data())) +
+        return (reinterpret_cast<uintptr_t>(ptr) -
+                reinterpret_cast<uintptr_t>(buffer.BackingBasePointer())) +
                DramMemoryMap::Base;
     }
 
     u8* GetPointer(PAddr addr) {
-        return buffer.data() + (addr - DramMemoryMap::Base);
+        return buffer.BackingBasePointer() + (addr - DramMemoryMap::Base);
     }
 
     const u8* GetPointer(PAddr addr) const {
-        return buffer.data() + (addr - DramMemoryMap::Base);
+        return buffer.BackingBasePointer() + (addr - DramMemoryMap::Base);
     }
 
-private:
-    Common::VirtualBuffer<u8> buffer;
+    Common::HostMemory buffer;
 };
 
 } // namespace Core

--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -12,6 +12,7 @@
 #include "common/common_types.h"
 #include "common/logging/log.h"
 #include "common/page_table.h"
+#include "common/settings.h"
 #include "common/swap.h"
 #include "core/arm/arm_interface.h"
 #include "core/core.h"
@@ -32,6 +33,7 @@ struct Memory::Impl {
 
     void SetCurrentPageTable(Kernel::KProcess& process, u32 core_id) {
         current_page_table = &process.PageTable().PageTableImpl();
+        current_page_table->fastmem_arena = system.DeviceMemory().buffer.VirtualBasePointer();
 
         const std::size_t address_space_width = process.PageTable().GetAddressSpaceWidth();
 
@@ -41,13 +43,19 @@ struct Memory::Impl {
     void MapMemoryRegion(Common::PageTable& page_table, VAddr base, u64 size, PAddr target) {
         ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: {:016X}", size);
         ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: {:016X}", base);
+        ASSERT_MSG(target >= DramMemoryMap::Base && target < DramMemoryMap::End,
+                   "Out of bounds target: {:016X}", target);
         MapPages(page_table, base / PAGE_SIZE, size / PAGE_SIZE, target, Common::PageType::Memory);
+
+        system.DeviceMemory().buffer.Map(base, target - DramMemoryMap::Base, size);
     }
 
     void UnmapRegion(Common::PageTable& page_table, VAddr base, u64 size) {
         ASSERT_MSG((size & PAGE_MASK) == 0, "non-page aligned size: {:016X}", size);
         ASSERT_MSG((base & PAGE_MASK) == 0, "non-page aligned base: {:016X}", base);
         MapPages(page_table, base / PAGE_SIZE, size / PAGE_SIZE, 0, Common::PageType::Unmapped);
+
+        system.DeviceMemory().buffer.Unmap(base, size);
     }
 
     bool IsValidVirtualAddress(const Kernel::KProcess& process, const VAddr vaddr) const {
@@ -466,6 +474,10 @@ struct Memory::Impl {
         if (vaddr == 0) {
             return;
         }
+
+        const bool is_read_enable = Settings::IsGPULevelHigh() || !cached;
+        system.DeviceMemory().buffer.Protect(vaddr, size, is_read_enable, !cached);
+
         // Iterate over a contiguous CPU address space, which corresponds to the specified GPU
         // address space, marking the region as un/cached. The region is marked un/cached at a
         // granularity of CPU pages, hence why we iterate on a CPU page basis (note: GPU page size

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(tests
     common/bit_field.cpp
     common/cityhash.cpp
     common/fibers.cpp
+    common/host_memory.cpp
     common/param_package.cpp
     common/ring_buffer.cpp
     core/core_timing.cpp

--- a/src/tests/common/host_memory.cpp
+++ b/src/tests/common/host_memory.cpp
@@ -1,0 +1,183 @@
+// Copyright 2021 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include <catch2/catch.hpp>
+
+#include "common/host_memory.h"
+
+using Common::HostMemory;
+
+static constexpr size_t VIRTUAL_SIZE = 1ULL << 39;
+static constexpr size_t BACKING_SIZE = 4ULL * 1024 * 1024 * 1024;
+
+TEST_CASE("HostMemory: Initialize and deinitialize", "[common]") {
+    { HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE); }
+    { HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE); }
+}
+
+TEST_CASE("HostMemory: Simple map", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x5000, 0x8000, 0x1000);
+
+    volatile u8* const data = mem.VirtualBasePointer() + 0x5000;
+    data[0] = 50;
+    REQUIRE(data[0] == 50);
+}
+
+TEST_CASE("HostMemory: Simple mirror map", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x5000, 0x3000, 0x2000);
+    mem.Map(0x8000, 0x4000, 0x1000);
+
+    volatile u8* const mirror_a = mem.VirtualBasePointer() + 0x5000;
+    volatile u8* const mirror_b = mem.VirtualBasePointer() + 0x8000;
+    mirror_b[0] = 76;
+    REQUIRE(mirror_a[0x1000] == 76);
+}
+
+TEST_CASE("HostMemory: Simple unmap", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x5000, 0x3000, 0x2000);
+
+    volatile u8* const data = mem.VirtualBasePointer() + 0x5000;
+    data[75] = 50;
+    REQUIRE(data[75] == 50);
+
+    mem.Unmap(0x5000, 0x2000);
+}
+
+TEST_CASE("HostMemory: Simple unmap and remap", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x5000, 0x3000, 0x2000);
+
+    volatile u8* const data = mem.VirtualBasePointer() + 0x5000;
+    data[0] = 50;
+    REQUIRE(data[0] == 50);
+
+    mem.Unmap(0x5000, 0x2000);
+
+    mem.Map(0x5000, 0x3000, 0x2000);
+    REQUIRE(data[0] == 50);
+
+    mem.Map(0x7000, 0x2000, 0x5000);
+    REQUIRE(data[0x3000] == 50);
+}
+
+TEST_CASE("HostMemory: Nieche allocation", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x0000, 0, 0x20000);
+    mem.Unmap(0x0000, 0x4000);
+    mem.Map(0x1000, 0, 0x2000);
+    mem.Map(0x3000, 0, 0x1000);
+    mem.Map(0, 0, 0x1000);
+}
+
+TEST_CASE("HostMemory: Full unmap", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x8000, 0, 0x4000);
+    mem.Unmap(0x8000, 0x4000);
+    mem.Map(0x6000, 0, 0x16000);
+}
+
+TEST_CASE("HostMemory: Right out of bounds unmap", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x0000, 0, 0x4000);
+    mem.Unmap(0x2000, 0x4000);
+    mem.Map(0x2000, 0x80000, 0x4000);
+}
+
+TEST_CASE("HostMemory: Left out of bounds unmap", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x8000, 0, 0x4000);
+    mem.Unmap(0x6000, 0x4000);
+    mem.Map(0x8000, 0, 0x2000);
+}
+
+TEST_CASE("HostMemory: Multiple placeholder unmap", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x0000, 0, 0x4000);
+    mem.Map(0x4000, 0, 0x1b000);
+    mem.Unmap(0x3000, 0x1c000);
+    mem.Map(0x3000, 0, 0x20000);
+}
+
+TEST_CASE("HostMemory: Unmap between placeholders", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x0000, 0, 0x4000);
+    mem.Map(0x4000, 0, 0x4000);
+    mem.Unmap(0x2000, 0x4000);
+    mem.Map(0x2000, 0, 0x4000);
+}
+
+TEST_CASE("HostMemory: Unmap to origin", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x4000, 0, 0x4000);
+    mem.Map(0x8000, 0, 0x4000);
+    mem.Unmap(0x4000, 0x4000);
+    mem.Map(0, 0, 0x4000);
+    mem.Map(0x4000, 0, 0x4000);
+}
+
+TEST_CASE("HostMemory: Unmap to right", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x4000, 0, 0x4000);
+    mem.Map(0x8000, 0, 0x4000);
+    mem.Unmap(0x8000, 0x4000);
+    mem.Map(0x8000, 0, 0x4000);
+}
+
+TEST_CASE("HostMemory: Partial right unmap check bindings", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x4000, 0x10000, 0x4000);
+
+    volatile u8* const ptr = mem.VirtualBasePointer() + 0x4000;
+    ptr[0x1000] = 17;
+
+    mem.Unmap(0x6000, 0x2000);
+
+    REQUIRE(ptr[0x1000] == 17);
+}
+
+TEST_CASE("HostMemory: Partial left unmap check bindings", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x4000, 0x10000, 0x4000);
+
+    volatile u8* const ptr = mem.VirtualBasePointer() + 0x4000;
+    ptr[0x3000] = 19;
+    ptr[0x3fff] = 12;
+
+    mem.Unmap(0x4000, 0x2000);
+
+    REQUIRE(ptr[0x3000] == 19);
+    REQUIRE(ptr[0x3fff] == 12);
+}
+
+TEST_CASE("HostMemory: Partial middle unmap check bindings", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x4000, 0x10000, 0x4000);
+
+    volatile u8* const ptr = mem.VirtualBasePointer() + 0x4000;
+    ptr[0x0000] = 19;
+    ptr[0x3fff] = 12;
+
+    mem.Unmap(0x1000, 0x2000);
+
+    REQUIRE(ptr[0x0000] == 19);
+    REQUIRE(ptr[0x3fff] == 12);
+}
+
+TEST_CASE("HostMemory: Partial sparse middle unmap and check bindings", "[common]") {
+    HostMemory mem(BACKING_SIZE, VIRTUAL_SIZE);
+    mem.Map(0x4000, 0x10000, 0x2000);
+    mem.Map(0x6000, 0x20000, 0x2000);
+
+    volatile u8* const ptr = mem.VirtualBasePointer() + 0x4000;
+    ptr[0x0000] = 19;
+    ptr[0x3fff] = 12;
+
+    mem.Unmap(0x5000, 0x2000);
+
+    REQUIRE(ptr[0x0000] == 19);
+    REQUIRE(ptr[0x3fff] == 12);
+}

--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -99,25 +99,13 @@ void ThreadManager::FlushRegion(VAddr addr, u64 size) {
         PushCommand(FlushRegionCommand(addr, size));
         return;
     }
-
-    // Asynchronous GPU mode
-    switch (Settings::values.gpu_accuracy.GetValue()) {
-    case Settings::GPUAccuracy::Normal:
-        PushCommand(FlushRegionCommand(addr, size));
-        break;
-    case Settings::GPUAccuracy::High:
-        // TODO(bunnei): Is this right? Preserving existing behavior for now
-        break;
-    case Settings::GPUAccuracy::Extreme: {
-        auto& gpu = system.GPU();
-        u64 fence = gpu.RequestFlush(addr, size);
-        PushCommand(GPUTickCommand(), true);
-        ASSERT(fence <= gpu.CurrentFlushRequestFence());
-        break;
+    if (!Settings::IsGPULevelExtreme()) {
+        return;
     }
-    default:
-        UNIMPLEMENTED_MSG("Unsupported gpu_accuracy {}", Settings::values.gpu_accuracy.GetValue());
-    }
+    auto& gpu = system.GPU();
+    u64 fence = gpu.RequestFlush(addr, size);
+    PushCommand(GPUTickCommand(), true);
+    ASSERT(fence <= gpu.CurrentFlushRequestFence());
 }
 
 void ThreadManager::InvalidateRegion(VAddr addr, u64 size) {

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -756,6 +756,8 @@ void Config::ReadCpuValues() {
                       QStringLiteral("cpuopt_unsafe_reduce_fp_error"), true);
     ReadSettingGlobal(Settings::values.cpuopt_unsafe_inaccurate_nan,
                       QStringLiteral("cpuopt_unsafe_inaccurate_nan"), true);
+    ReadSettingGlobal(Settings::values.cpuopt_unsafe_fastmem_check,
+                      QStringLiteral("cpuopt_unsafe_fastmem_check"), true);
 
     if (global) {
         Settings::values.cpuopt_page_tables =
@@ -774,6 +776,8 @@ void Config::ReadCpuValues() {
             ReadSetting(QStringLiteral("cpuopt_misc_ir"), true).toBool();
         Settings::values.cpuopt_reduce_misalign_checks =
             ReadSetting(QStringLiteral("cpuopt_reduce_misalign_checks"), true).toBool();
+        Settings::values.cpuopt_fastmem =
+            ReadSetting(QStringLiteral("cpuopt_fastmem"), true).toBool();
     }
 
     qt_config->endGroup();
@@ -1332,6 +1336,8 @@ void Config::SaveCpuValues() {
                        Settings::values.cpuopt_unsafe_reduce_fp_error, true);
     WriteSettingGlobal(QStringLiteral("cpuopt_unsafe_inaccurate_nan"),
                        Settings::values.cpuopt_unsafe_inaccurate_nan, true);
+    WriteSettingGlobal(QStringLiteral("cpuopt_unsafe_fastmem_check"),
+                       Settings::values.cpuopt_unsafe_fastmem_check, true);
 
     if (global) {
         WriteSetting(QStringLiteral("cpuopt_page_tables"), Settings::values.cpuopt_page_tables,
@@ -1348,6 +1354,7 @@ void Config::SaveCpuValues() {
         WriteSetting(QStringLiteral("cpuopt_misc_ir"), Settings::values.cpuopt_misc_ir, true);
         WriteSetting(QStringLiteral("cpuopt_reduce_misalign_checks"),
                      Settings::values.cpuopt_reduce_misalign_checks, true);
+        WriteSetting(QStringLiteral("cpuopt_fastmem"), Settings::values.cpuopt_fastmem, true);
     }
 
     qt_config->endGroup();

--- a/src/yuzu/configuration/configure_cpu.cpp
+++ b/src/yuzu/configuration/configure_cpu.cpp
@@ -35,12 +35,15 @@ void ConfigureCpu::SetConfiguration() {
     ui->cpuopt_unsafe_unfuse_fma->setEnabled(runtime_lock);
     ui->cpuopt_unsafe_reduce_fp_error->setEnabled(runtime_lock);
     ui->cpuopt_unsafe_inaccurate_nan->setEnabled(runtime_lock);
+    ui->cpuopt_unsafe_fastmem_check->setEnabled(runtime_lock);
 
     ui->cpuopt_unsafe_unfuse_fma->setChecked(Settings::values.cpuopt_unsafe_unfuse_fma.GetValue());
     ui->cpuopt_unsafe_reduce_fp_error->setChecked(
         Settings::values.cpuopt_unsafe_reduce_fp_error.GetValue());
     ui->cpuopt_unsafe_inaccurate_nan->setChecked(
         Settings::values.cpuopt_unsafe_inaccurate_nan.GetValue());
+    ui->cpuopt_unsafe_fastmem_check->setChecked(
+        Settings::values.cpuopt_unsafe_fastmem_check.GetValue());
 
     if (Settings::IsConfiguringGlobal()) {
         ui->accuracy->setCurrentIndex(static_cast<int>(Settings::values.cpu_accuracy.GetValue()));
@@ -84,6 +87,9 @@ void ConfigureCpu::ApplyConfiguration() {
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.cpuopt_unsafe_inaccurate_nan,
                                              ui->cpuopt_unsafe_inaccurate_nan,
                                              cpuopt_unsafe_inaccurate_nan);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.cpuopt_unsafe_fastmem_check,
+                                             ui->cpuopt_unsafe_fastmem_check,
+                                             cpuopt_unsafe_fastmem_check);
 
     if (Settings::IsConfiguringGlobal()) {
         // Guard if during game and set to game-specific value
@@ -134,4 +140,7 @@ void ConfigureCpu::SetupPerGameUI() {
     ConfigurationShared::SetColoredTristate(ui->cpuopt_unsafe_inaccurate_nan,
                                             Settings::values.cpuopt_unsafe_inaccurate_nan,
                                             cpuopt_unsafe_inaccurate_nan);
+    ConfigurationShared::SetColoredTristate(ui->cpuopt_unsafe_fastmem_check,
+                                            Settings::values.cpuopt_unsafe_fastmem_check,
+                                            cpuopt_unsafe_fastmem_check);
 }

--- a/src/yuzu/configuration/configure_cpu.h
+++ b/src/yuzu/configuration/configure_cpu.h
@@ -41,4 +41,5 @@ private:
     ConfigurationShared::CheckState cpuopt_unsafe_unfuse_fma;
     ConfigurationShared::CheckState cpuopt_unsafe_reduce_fp_error;
     ConfigurationShared::CheckState cpuopt_unsafe_inaccurate_nan;
+    ConfigurationShared::CheckState cpuopt_unsafe_fastmem_check;
 };

--- a/src/yuzu/configuration/configure_cpu.ui
+++ b/src/yuzu/configuration/configure_cpu.ui
@@ -123,6 +123,18 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QCheckBox" name="cpuopt_unsafe_fastmem_check">
+          <property name="toolTip">
+           <string>
+            &lt;div&gt;This option improves speed by eliminating a safety check before every memory read/write in guest. Disabling it may allow a game to read/write the emulator's memory.&lt;/div&gt;
+           </string>
+          </property>
+          <property name="text">
+           <string>Disable address space checks</string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>

--- a/src/yuzu/configuration/configure_cpu_debug.cpp
+++ b/src/yuzu/configuration/configure_cpu_debug.cpp
@@ -39,6 +39,8 @@ void ConfigureCpuDebug::SetConfiguration() {
     ui->cpuopt_misc_ir->setChecked(Settings::values.cpuopt_misc_ir);
     ui->cpuopt_reduce_misalign_checks->setEnabled(runtime_lock);
     ui->cpuopt_reduce_misalign_checks->setChecked(Settings::values.cpuopt_reduce_misalign_checks);
+    ui->cpuopt_fastmem->setEnabled(runtime_lock);
+    ui->cpuopt_fastmem->setChecked(Settings::values.cpuopt_fastmem);
 }
 
 void ConfigureCpuDebug::ApplyConfiguration() {
@@ -50,6 +52,7 @@ void ConfigureCpuDebug::ApplyConfiguration() {
     Settings::values.cpuopt_const_prop = ui->cpuopt_const_prop->isChecked();
     Settings::values.cpuopt_misc_ir = ui->cpuopt_misc_ir->isChecked();
     Settings::values.cpuopt_reduce_misalign_checks = ui->cpuopt_reduce_misalign_checks->isChecked();
+    Settings::values.cpuopt_fastmem = ui->cpuopt_fastmem->isChecked();
 }
 
 void ConfigureCpuDebug::changeEvent(QEvent* event) {

--- a/src/yuzu/configuration/configure_cpu_debug.ui
+++ b/src/yuzu/configuration/configure_cpu_debug.ui
@@ -139,6 +139,20 @@
           </property>
          </widget>
         </item>
+        <item>
+         <widget class="QCheckBox" name="cpuopt_fastmem">
+          <property name="text">
+           <string>Enable Host MMU Emulation</string>
+          </property>
+          <property name="toolTip">
+           <string>
+            &lt;div style="white-space: nowrap"&gt;This optimization speeds up memory accesses by the guest program.&lt;/div&gt;
+            &lt;div style="white-space: nowrap"&gt;Enabling it causes guest memory reads/writes to be done directly into memory and make use of Host's MMU.&lt;/div&gt;
+            &lt;div style="white-space: nowrap"&gt;Disabling this forces all memory accesses to use Software MMU Emulation.&lt;/div&gt;
+           </string>
+          </property>
+         </widget>
+        </item>
        </layout>
       </widget>
      </item>

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -150,6 +150,10 @@ cpuopt_misc_ir =
 # 0: Disabled, 1 (default): Enabled
 cpuopt_reduce_misalign_checks =
 
+# Enable Host MMU Emulation (faster guest memory access)
+# 0: Disabled, 1 (default): Enabled
+cpuopt_fastmem =
+
 [Renderer]
 # Which backend API to use.
 # 0 (default): OpenGL, 1: Vulkan


### PR DESCRIPTION
This Pull Request finally implements a long requested feature from Citra: Fastmem. Fastmem is the name we have given to emulating the MMU by using Host allocation instead of software MMU emulation. In the previous approach, we would emulate Guest virtual memory through a page table where we would store addresses to physical memory for each virtual page the application/game had. Whenever a game accessed memory, we would look into the emulated page table check if we have a valid physical mem address and then read the memory, if the physical address wasn't valid, the game would call an emulator fallback. All this costed around 10-15 instructions.

On fastmem, we use instead about 4 instructions: 3 for checking if the address is within the emulated address space (can be disabled with Unsafe CPU -> disable address space checks) and 1 instruction for memory read/write. In case of a Page Fault, dynarmic will invalidate the code block and recompile it under the first software approach. This is typical when dealing with GPU marked memory.

**Important note for windows users**: This PR only works for newest versions of Windows 10. Please make sure to update to latest version to avoid any inconveniences. (or build 1803 or later)

I do not take credit for most of this work, since I only advised and mixed everyone's efforts together. The credit goes to everyone above.

Credits:
- @MerryMage For implementing fastmem in dynarmic.
- @degasus For implementing Linux version of fastmem and original design.
- @ReinUsesLisp For Implementing Windows version of fastmem/host memory handling.
- @BreadFish64 For showing us on his gameboy emulator that placeholder memory could be aligned to 4kb, thus, avoid the biggest layback on windows MMU emulation: Windows page granularity for most part is 64kb.
- @bunnei for setting up the kernel swiftly and nicely.