### PR TITLE
yuzu qt: Start games from context menu

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -505,6 +505,10 @@ void GameList::PopupContextMenu(const QPoint& menu_location) {
 void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, const std::string& path) {
     QAction* favorite = context_menu.addAction(tr("Favorite"));
     context_menu.addSeparator();
+    QAction* start_game = context_menu.addAction(tr("Start Game"));
+    QAction* start_game_global =
+        context_menu.addAction(tr("Start Game without Custom Configuration"));
+    context_menu.addSeparator();
     QAction* open_save_location = context_menu.addAction(tr("Open Save Data Location"));
     QAction* open_mod_location = context_menu.addAction(tr("Open Mod Data Location"));
     QAction* open_transferable_shader_cache =
@@ -539,6 +543,12 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, const std::stri
     connect(favorite, &QAction::triggered, [this, program_id]() { ToggleFavorite(program_id); });
     connect(open_save_location, &QAction::triggered, [this, program_id, path]() {
         emit OpenFolderRequested(program_id, GameListOpenTarget::SaveData, path);
+    });
+    connect(start_game, &QAction::triggered, [this, path]() {
+        emit BootGame(QString::fromStdString(path), 0, StartGameType::Normal);
+    });
+    connect(start_game_global, &QAction::triggered, [this, path]() {
+        emit BootGame(QString::fromStdString(path), 0, StartGameType::Global);
     });
     connect(open_mod_location, &QAction::triggered, [this, program_id, path]() {
         emit OpenFolderRequested(program_id, GameListOpenTarget::ModData, path);

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -28,6 +28,7 @@ class GameListWorker;
 class GameListSearchField;
 class GameListDir;
 class GMainWindow;
+enum class StartGameType;
 
 namespace FileSys {
 class ManualContentProvider;
@@ -82,6 +83,7 @@ public:
     static const QStringList supported_file_extensions;
 
 signals:
+    void BootGame(const QString& game_path, std::size_t program_index, StartGameType type);
     void GameChosen(const QString& game_path);
     void ShouldCancelWorker();
     void OpenFolderRequested(u64 program_id, GameListOpenTarget target,

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1094,6 +1094,7 @@ void GMainWindow::OnAppFocusStateChanged(Qt::ApplicationState state) {
 }
 
 void GMainWindow::ConnectWidgetEvents() {
+    connect(game_list, &GameList::BootGame, this, &GMainWindow::BootGame);
     connect(game_list, &GameList::GameChosen, this, &GMainWindow::OnGameListLoadFile);
     connect(game_list, &GameList::OpenDirectory, this, &GMainWindow::OnGameListOpenDirectory);
     connect(game_list, &GameList::OpenFolderRequested, this, &GMainWindow::OnGameListOpenFolder);
@@ -1320,7 +1321,7 @@ void GMainWindow::SelectAndSetCurrentUser() {
     Settings::values.current_user = dialog.GetIndex();
 }
 
-void GMainWindow::BootGame(const QString& filename, std::size_t program_index) {
+void GMainWindow::BootGame(const QString& filename, std::size_t program_index, StartGameType type) {
     LOG_INFO(Frontend, "yuzu starting...");
     StoreRecentFile(filename); // Put the filename on top of the list
 
@@ -1332,7 +1333,8 @@ void GMainWindow::BootGame(const QString& filename, std::size_t program_index) {
     const auto v_file = Core::GetGameFileFromPath(vfs, filename.toUtf8().constData());
     const auto loader = Loader::GetLoader(system, v_file, program_index);
 
-    if (!(loader == nullptr || loader->ReadProgramId(title_id) != Loader::ResultStatus::Success)) {
+    if (loader != nullptr && loader->ReadProgramId(title_id) == Loader::ResultStatus::Success &&
+        type == StartGameType::Normal) {
         // Load per game settings
         const auto file_path = std::filesystem::path{filename.toStdU16String()};
         const auto config_file_name = title_id == 0

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -39,6 +39,11 @@ class GameListPlaceholder;
 
 class QtSoftwareKeyboardDialog;
 
+enum class StartGameType {
+    Normal, // Can use custom configuration
+    Global, // Only uses global configuration
+};
+
 namespace Core::Frontend {
 struct ControllerParameters;
 struct InlineAppearParameters;
@@ -181,7 +186,8 @@ private:
     void AllowOSSleep();
 
     bool LoadROM(const QString& filename, std::size_t program_index);
-    void BootGame(const QString& filename, std::size_t program_index = 0);
+    void BootGame(const QString& filename, std::size_t program_index = 0,
+                  StartGameType with_config = StartGameType::Normal);
     void ShutdownGame();
 
     void ShowTelemetryCallout();


### PR DESCRIPTION
"Oh yeah, I was going to do that..."

This connects the `BootGame` function to the context menu. In addition, there is also an option to boot without using the custom configuration.

Closes #6425 