### PR TITLE
hle: kernel: Remove service thread manager and use weak_ptr.

### DIFF
--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -41,6 +41,21 @@ SessionRequestManager::SessionRequestManager(KernelCore& kernel_) : kernel{kerne
 
 SessionRequestManager::~SessionRequestManager() = default;
 
+bool SessionRequestManager::HasSessionRequestHandler(const HLERequestContext& context) const {
+    if (IsDomain() && context.HasDomainMessageHeader()) {
+        const auto& message_header = context.GetDomainMessageHeader();
+        const auto object_id = message_header.object_id;
+
+        if (object_id > DomainHandlerCount()) {
+            LOG_CRITICAL(IPC, "object_id {} is too big!", object_id);
+            return false;
+        }
+        return DomainHandler(object_id - 1) != nullptr;
+    } else {
+        return session_handler != nullptr;
+    }
+}
+
 void SessionRequestHandler::ClientConnected(KServerSession* session) {
     session->SetSessionHandler(shared_from_this());
 }

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -85,8 +85,8 @@ public:
      */
     void ClientDisconnected(KServerSession* session);
 
-    std::shared_ptr<ServiceThread> GetServiceThread() const {
-        return service_thread.lock();
+    std::weak_ptr<ServiceThread> GetServiceThread() const {
+        return service_thread;
     }
 
 protected:
@@ -152,7 +152,7 @@ public:
         session_handler = std::move(handler);
     }
 
-    std::shared_ptr<ServiceThread> GetServiceThread() const {
+    std::weak_ptr<ServiceThread> GetServiceThread() const {
         return session_handler->GetServiceThread();
     }
 

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -156,6 +156,8 @@ public:
         return session_handler->GetServiceThread();
     }
 
+    bool HasSessionRequestHandler(const HLERequestContext& context) const;
+
 private:
     bool is_domain{};
     SessionRequestHandlerPtr session_handler;
@@ -163,7 +165,6 @@ private:
 
 private:
     KernelCore& kernel;
-    std::weak_ptr<ServiceThread> service_thread;
 };
 
 /**

--- a/src/core/hle/kernel/k_server_session.cpp
+++ b/src/core/hle/kernel/k_server_session.cpp
@@ -8,6 +8,7 @@
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "common/logging/log.h"
+#include "common/scope_exit.h"
 #include "core/core_timing.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/hle_ipc.h"
@@ -119,11 +120,20 @@ ResultCode KServerSession::QueueSyncRequest(KThread* thread, Core::Memory::Memor
 
     context->PopulateFromIncomingCommandBuffer(kernel.CurrentProcess()->GetHandleTable(), cmd_buf);
 
+    // In the event that something fails here, stub a result to prevent the game from crashing.
+    // This is a work-around in the event that somehow we process a service request after the
+    // session has been closed by the game. This has been observed to happen rarely in Pokemon
+    // Sword/Shield and is likely a result of us using host threads/scheduling for services.
+    // TODO(bunnei): Find a better solution here.
+    auto error_guard = SCOPE_GUARD({ CompleteSyncRequest(*context); });
+
     // Ensure we have a session request handler
     if (manager->HasSessionRequestHandler(*context)) {
         if (auto strong_ptr = manager->GetServiceThread().lock()) {
             strong_ptr->QueueSyncRequest(*parent, std::move(context));
-            return ResultSuccess;
+
+            // We succeeded.
+            error_guard.Cancel();
         } else {
             ASSERT_MSG(false, "strong_ptr is nullptr!");
         }
@@ -136,13 +146,20 @@ ResultCode KServerSession::QueueSyncRequest(KThread* thread, Core::Memory::Memor
 
 ResultCode KServerSession::CompleteSyncRequest(HLERequestContext& context) {
     ResultCode result = ResultSuccess;
+
     // If the session has been converted to a domain, handle the domain request
-    if (IsDomain() && context.HasDomainMessageHeader()) {
-        result = HandleDomainSyncRequest(context);
-        // If there is no domain header, the regular session handler is used
-    } else if (manager->HasSessionHandler()) {
-        // If this ServerSession has an associated HLE handler, forward the request to it.
-        result = manager->SessionHandler().HandleSyncRequest(*this, context);
+    if (manager->HasSessionRequestHandler(context)) {
+        if (IsDomain() && context.HasDomainMessageHeader()) {
+            result = HandleDomainSyncRequest(context);
+            // If there is no domain header, the regular session handler is used
+        } else if (manager->HasSessionHandler()) {
+            // If this ServerSession has an associated HLE handler, forward the request to it.
+            result = manager->SessionHandler().HandleSyncRequest(*this, context);
+        }
+    } else {
+        ASSERT_MSG(false, "Session handler is invalid, stubbing response!");
+        IPC::ResponseBuilder rb(context, 2);
+        rb.Push(ResultSuccess);
     }
 
     if (convert_to_domain) {

--- a/src/core/hle/kernel/k_server_session.cpp
+++ b/src/core/hle/kernel/k_server_session.cpp
@@ -119,11 +119,16 @@ ResultCode KServerSession::QueueSyncRequest(KThread* thread, Core::Memory::Memor
 
     context->PopulateFromIncomingCommandBuffer(kernel.CurrentProcess()->GetHandleTable(), cmd_buf);
 
-    if (auto strong_ptr = manager->GetServiceThread().lock()) {
-        strong_ptr->QueueSyncRequest(*parent, std::move(context));
-        return ResultSuccess;
+    // Ensure we have a session request handler
+    if (manager->HasSessionRequestHandler(*context)) {
+        if (auto strong_ptr = manager->GetServiceThread().lock()) {
+            strong_ptr->QueueSyncRequest(*parent, std::move(context));
+            return ResultSuccess;
+        } else {
+            ASSERT_MSG(false, "strong_ptr is nullptr!");
+        }
     } else {
-        ASSERT_MSG(false, "strong_ptr was nullptr!");
+        ASSERT_MSG(false, "handler is invalid!");
     }
 
     return ResultSuccess;

--- a/src/core/hle/kernel/k_server_session.cpp
+++ b/src/core/hle/kernel/k_server_session.cpp
@@ -119,7 +119,7 @@ ResultCode KServerSession::QueueSyncRequest(KThread* thread, Core::Memory::Memor
 
     context->PopulateFromIncomingCommandBuffer(kernel.CurrentProcess()->GetHandleTable(), cmd_buf);
 
-    if (auto strong_ptr = manager->GetServiceThread(); strong_ptr) {
+    if (auto strong_ptr = manager->GetServiceThread().lock()) {
         strong_ptr->QueueSyncRequest(*parent, std::move(context));
         return ResultSuccess;
     } else {


### PR DESCRIPTION
- We no longer need to queue up service threads to be destroyed.
- Fixes a race condition where a thread could be destroyed too early, which caused a crash in Pokemon Sword/Shield.