### PR TITLE
configure_ui: Add translation context for file-scope strings

### DIFF
--- a/src/yuzu/configuration/configure_ui.cpp
+++ b/src/yuzu/configuration/configure_ui.cpp
@@ -17,17 +17,30 @@
 
 namespace {
 constexpr std::array default_icon_sizes{
-    std::make_pair(0, QT_TR_NOOP("None")),
-    std::make_pair(32, QT_TR_NOOP("Small (32x32)")),
-    std::make_pair(64, QT_TR_NOOP("Standard (64x64)")),
-    std::make_pair(128, QT_TR_NOOP("Large (128x128)")),
-    std::make_pair(256, QT_TR_NOOP("Full Size (256x256)")),
+    std::make_pair(0, QT_TRANSLATE_NOOP("ConfigureUI", "None")),
+    std::make_pair(32, QT_TRANSLATE_NOOP("ConfigureUI", "Small (32x32)")),
+    std::make_pair(64, QT_TRANSLATE_NOOP("ConfigureUI", "Standard (64x64)")),
+    std::make_pair(128, QT_TRANSLATE_NOOP("ConfigureUI", "Large (128x128)")),
+    std::make_pair(256, QT_TRANSLATE_NOOP("ConfigureUI", "Full Size (256x256)")),
 };
 
+// clang-format off
 constexpr std::array row_text_names{
-    QT_TR_NOOP("Filename"),   QT_TR_NOOP("Filetype"), QT_TR_NOOP("Title ID"),
-    QT_TR_NOOP("Title Name"), QT_TR_NOOP("None"),
+    QT_TRANSLATE_NOOP("ConfigureUI", "Filename"),
+    QT_TRANSLATE_NOOP("ConfigureUI", "Filetype"),
+    QT_TRANSLATE_NOOP("ConfigureUI", "Title ID"),
+    QT_TRANSLATE_NOOP("ConfigureUI", "Title Name"),
+    QT_TRANSLATE_NOOP("ConfigureUI", "None"),
 };
+// clang-format on
+
+QString GetTranslatedIconSize(size_t index) {
+    return QCoreApplication::translate("ConfigureUI", default_icon_sizes[index].second);
+}
+
+QString GetTranslatedRowTextName(size_t index) {
+    return QCoreApplication::translate("ConfigureUI", row_text_names[index]);
+}
 } // Anonymous namespace
 
 ConfigureUi::ConfigureUi(QWidget* parent) : QWidget(parent), ui(new Ui::ConfigureUi) {
@@ -121,11 +134,11 @@ void ConfigureUi::RetranslateUI() {
     ui->retranslateUi(this);
 
     for (int i = 0; i < ui->icon_size_combobox->count(); i++) {
-        ui->icon_size_combobox->setItemText(i, tr(default_icon_sizes[i].second));
+        ui->icon_size_combobox->setItemText(i, GetTranslatedIconSize(static_cast<size_t>(i)));
     }
 
     for (int i = 0; i < ui->row_1_text_combobox->count(); i++) {
-        const QString name = tr(row_text_names[i]);
+        const QString name = GetTranslatedRowTextName(static_cast<size_t>(i));
 
         ui->row_1_text_combobox->setItemText(i, name);
         ui->row_2_text_combobox->setItemText(i, name);
@@ -152,8 +165,9 @@ void ConfigureUi::InitializeLanguageComboBox() {
 }
 
 void ConfigureUi::InitializeIconSizeComboBox() {
-    for (const auto& size : default_icon_sizes) {
-        ui->icon_size_combobox->addItem(QString::fromUtf8(size.second), size.first);
+    for (size_t i = 0; i < default_icon_sizes.size(); i++) {
+        const auto size = default_icon_sizes[i].first;
+        ui->icon_size_combobox->addItem(GetTranslatedIconSize(i), size);
     }
 }
 
@@ -170,7 +184,7 @@ void ConfigureUi::UpdateFirstRowComboBox(bool init) {
     ui->row_1_text_combobox->clear();
 
     for (std::size_t i = 0; i < row_text_names.size(); i++) {
-        const QString row_text_name = QString::fromUtf8(row_text_names[i]);
+        const QString row_text_name = GetTranslatedRowTextName(i);
         ui->row_1_text_combobox->addItem(row_text_name, QVariant::fromValue(i));
     }
 
@@ -189,7 +203,7 @@ void ConfigureUi::UpdateSecondRowComboBox(bool init) {
     ui->row_2_text_combobox->clear();
 
     for (std::size_t i = 0; i < row_text_names.size(); ++i) {
-        const QString row_text_name = QString::fromUtf8(row_text_names[i]);
+        const QString row_text_name = GetTranslatedRowTextName(i);
         ui->row_2_text_combobox->addItem(row_text_name, QVariant::fromValue(i));
     }
 


### PR DESCRIPTION
Allows for these strings to show up in the translation files.

Also silences some warnings when generating the ts files.