### PR TITLE
src/common/CMakeLists.txt: fix variable escaping

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -21,14 +21,14 @@ find_package(Git QUIET)
 
 add_custom_command(OUTPUT scm_rev.cpp
     COMMAND ${CMAKE_COMMAND}
-      -DSRC_DIR="${CMAKE_SOURCE_DIR}"
-      -DBUILD_REPOSITORY="${BUILD_REPOSITORY}"
-      -DTITLE_BAR_FORMAT_IDLE="${TITLE_BAR_FORMAT_IDLE}"
-      -DTITLE_BAR_FORMAT_RUNNING="${TITLE_BAR_FORMAT_RUNNING}"
-      -DBUILD_TAG="${BUILD_TAG}"
-      -DBUILD_ID="${DISPLAY_VERSION}"
-      -DGIT_EXECUTABLE="${GIT_EXECUTABLE}"
-      -P "${CMAKE_SOURCE_DIR}/CMakeModules/GenerateSCMRev.cmake"
+      -DSRC_DIR=${CMAKE_SOURCE_DIR}
+      -DBUILD_REPOSITORY=${BUILD_REPOSITORY}
+      -DTITLE_BAR_FORMAT_IDLE=${TITLE_BAR_FORMAT_IDLE}
+      -DTITLE_BAR_FORMAT_RUNNING=${TITLE_BAR_FORMAT_RUNNING}
+      -DBUILD_TAG=${BUILD_TAG}
+      -DBUILD_ID=${DISPLAY_VERSION}
+      -DGIT_EXECUTABLE=${GIT_EXECUTABLE}
+      -P ${CMAKE_SOURCE_DIR}/CMakeModules/GenerateSCMRev.cmake
     DEPENDS
       # WARNING! It was too much work to try and make a common location for this list,
       # so if you need to change it, please update CMakeModules/GenerateSCMRev.cmake as well
@@ -92,6 +92,7 @@ add_custom_command(OUTPUT scm_rev.cpp
       "${CMAKE_CURRENT_SOURCE_DIR}/scm_rev.h"
       # technically we should regenerate if the git version changed, but its not worth the effort imo
       "${CMAKE_SOURCE_DIR}/CMakeModules/GenerateSCMRev.cmake"
+    VERBATIM
 )
 
 add_library(common STATIC


### PR DESCRIPTION
Fix the variable escaping in `src/common/CMakeLists.txt`.

According to CMake (https://cmake.org/cmake/help/latest/command/add_custom_command.html):
>  All arguments to the commands will be escaped properly for the build tool so that the invoked command receives each argument unchanged. Note that one level of escapes is still used by the CMake language processor before add_custom_command even sees the arguments. Use of VERBATIM is recommended as it enables correct behavior. When VERBATIM is not given the behavior is platform specific because there is no protection of tool-specific special characters.

This should resolve the title bar text issue on Linux.