### PR TITLE
ci: common: Remove 7z packaging

### DIFF
--- a/.ci/scripts/common/post-upload.sh
+++ b/.ci/scripts/common/post-upload.sh
@@ -9,11 +9,5 @@ cp "${REV_NAME}-source.tar.xz" "$DIR_NAME"
 
 tar $COMPRESSION_FLAGS "$ARCHIVE_NAME" "$DIR_NAME"
 
-mv "$DIR_NAME" $RELEASE_NAME
-mv "${REV_NAME}-source.tar.xz" $RELEASE_NAME
-
-7z a "$REV_NAME.7z" $RELEASE_NAME
-
 # move the compiled archive into the artifacts directory to be uploaded by travis releases
 mv "$ARCHIVE_NAME" "${ARTIFACTS_DIR}/"
-mv "$REV_NAME.7z" "${ARTIFACTS_DIR}/"

--- a/.ci/scripts/windows/upload.sh
+++ b/.ci/scripts/windows/upload.sh
@@ -3,8 +3,8 @@
 . .ci/scripts/common/pre-upload.sh
 
 REV_NAME="yuzu-windows-mingw-${GITDATE}-${GITREV}"
-ARCHIVE_NAME="${REV_NAME}.tar.gz"
-COMPRESSION_FLAGS="-czvf"
+ARCHIVE_NAME="${REV_NAME}.tar.xz"
+COMPRESSION_FLAGS="-cJvf"
 
 if [ "${RELEASE_NAME}" = "mainline" ]; then
     DIR_NAME="${REV_NAME}"


### PR DESCRIPTION
Removes the 7z from being package during CI, as only .tar.xz preserves information needed on Linux, and otherwise is just extremely redundant to package in addition to the .tar.xz.  This affects Linux releases and PR-verify artifacts only. MSVC releases do not use this script to my knowledge.

Draft simply so I can verify that CI is correctly not packaging the .7z.