### PR TITLE
kernel: svc: Add missing error check to CancelSynchronization.

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -449,8 +449,8 @@ static ResultCode CancelSynchronization(Core::System& system, Handle handle) {
 
     // Get the thread from its handle.
     KScopedAutoObject thread =
-        system.Kernel().CurrentProcess()->GetHandleTable().GetObject<KThread>(
-            static_cast<Handle>(handle));
+        system.Kernel().CurrentProcess()->GetHandleTable().GetObject<KThread>(handle);
+    R_UNLESS(thread.IsNotNull(), ResultInvalidHandle);
 
     // Cancel the thread's wait.
     thread->WaitCancel();


### PR DESCRIPTION
- Avoids a potential crash if the handle is invalid, and also makes this code accurate to real kernel behavior.