### PR TITLE
hle: service: sm: Remove redundant session reservation, etc.

### DIFF
--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -41,7 +41,10 @@ class ServiceManager;
 }
 
 /// Default number of maximum connections to a server session.
-static constexpr u32 ServerSessionCountMax = 0x10000;
+static constexpr u32 ServerSessionCountMax = 0x40;
+static_assert(ServerSessionCountMax == 0x40,
+              "ServerSessionCountMax isn't 0x40 somehow, this assert is a reminder that this will "
+              "break lots of things");
 
 /**
  * This is an non-templated base of ServiceFramework to reduce code bloat and compilation times, it

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -151,27 +151,19 @@ ResultVal<Kernel::KClientSession*> SM::GetServiceImpl(Kernel::HLERequestContext&
     std::string name(PopServiceName(rp));
 
     // Find the named port.
-    auto result = service_manager.GetServicePort(name);
-    if (result.Failed()) {
-        LOG_ERROR(Service_SM, "called service={} -> error 0x{:08X}", name, result.Code().raw);
-        return result.Code();
+    auto port_result = service_manager.GetServicePort(name);
+    if (port_result.Failed()) {
+        LOG_ERROR(Service_SM, "called service={} -> error 0x{:08X}", name, port_result.Code().raw);
+        return port_result.Code();
     }
-    auto* port = result.Unwrap();
-
-    // Reserve a new session from the process resource limit.
-    Kernel::KScopedResourceReservation session_reservation(
-        kernel.CurrentProcess()->GetResourceLimit(), Kernel::LimitableResource::Sessions);
-    R_UNLESS(session_reservation.Succeeded(), Kernel::ResultLimitReached);
+    auto& port = port_result.Unwrap()->GetClientPort();
 
     // Create a new session.
     Kernel::KClientSession* session{};
-    port->GetClientPort().CreateSession(std::addressof(session));
-
-    // Commit the session reservation.
-    session_reservation.Commit();
-
-    // Enqueue the session with the named port.
-    port->EnqueueSession(&session->GetParent()->GetServerSession());
+    if (const auto result = port.CreateSession(std::addressof(session)); result.IsError()) {
+        LOG_ERROR(Service_SM, "called service={} -> error 0x{:08X}", name, result.raw);
+        return result;
+    }
 
     LOG_DEBUG(Service_SM, "called service={} -> session={}", name, session->GetId());
 


### PR DESCRIPTION
- We were double-reserving, causing us to run out of sessions in Pokemon Sword & Shield.