### PR TITLE
Fix GCC undefined behavior sanitizer.

### DIFF
--- a/src/core/file_sys/program_metadata.cpp
+++ b/src/core/file_sys/program_metadata.cpp
@@ -150,7 +150,9 @@ void ProgramMetadata::Print() const {
     LOG_DEBUG(Service_FS, " > Is Retail:           {}", acid_header.is_retail ? "YES" : "NO");
     LOG_DEBUG(Service_FS, "Title ID Min:           0x{:016X}", acid_header.title_id_min);
     LOG_DEBUG(Service_FS, "Title ID Max:           0x{:016X}", acid_header.title_id_max);
-    LOG_DEBUG(Service_FS, "Filesystem Access:      0x{:016X}\n", acid_file_access.permissions);
+    u64_le permissions_l; // local copy to fix alignment error
+    std::memcpy(&permissions_l, &acid_file_access.permissions, sizeof(permissions_l));
+    LOG_DEBUG(Service_FS, "Filesystem Access:      0x{:016X}\n", permissions_l);
 
     // Begin ACI0 printing (actual perms, unsigned)
     LOG_DEBUG(Service_FS, "Magic:                  {:.4}", aci_header.magic.data());

--- a/src/video_core/buffer_cache/buffer_base.h
+++ b/src/video_core/buffer_cache/buffer_base.h
@@ -476,6 +476,9 @@ private:
                     current_size = 0;
                     on_going = false;
                 }
+                if (empty_bits == PAGES_PER_WORD) {
+                    break;
+                }
                 page += empty_bits;
 
                 const int continuous_bits = std::countr_one(word >> page);

--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -647,6 +647,9 @@ u32 CalculateLayerSize(const ImageInfo& info) noexcept {
 }
 
 LevelArray CalculateMipLevelOffsets(const ImageInfo& info) noexcept {
+    if (info.type == ImageType::Linear) {
+        return {};
+    }
     ASSERT(info.resources.levels <= static_cast<s32>(MAX_MIP_LEVELS));
     const LevelInfo level_info = MakeLevelInfo(info);
     LevelArray offsets{};


### PR DESCRIPTION
* Wrong alignment in u64 LOG_DEBUG -> memcpy.
* Huge shift exponent in stride calculation for linear buffer, unused result -> skipped.
* Large shift in buffer cache if word = 0, skip checking for set bits.

Non of those were critical, so this should not change any behavior.
At least with the assumption, that the last one used masking behavior, which always yield continuous_bits = 0.

Credit for the texture cache bug @ReinUsesLisp 
Supersedes #6144 and #6147