### PR TITLE
externals: Don't set FOUND or VERSION on LIBUSB

### DIFF
--- a/externals/libusb/CMakeLists.txt
+++ b/externals/libusb/CMakeLists.txt
@@ -1,7 +1,7 @@
-set(LIBUSB_FOUND ON CACHE BOOL "libusb is present" FORCE)
-set(LIBUSB_VERSION "1.0.24" CACHE STRING "libusb version string" FORCE)
-
 if (MINGW OR (${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
+    set(LIBUSB_FOUND ON CACHE BOOL "libusb is present" FORCE)
+    set(LIBUSB_VERSION "1.0.24" CACHE STRING "libusb version string" FORCE)
+
     # GNU toolchains for some reason doesn't work with the later half of this CMakeLists after
     # updating to 1.0.24, so we do it the old-fashioned way for now.
 


### PR DESCRIPTION
Fixes an issue where libusb.h wouldn't be found when building yuzu on MSVC.

This only affects the "traditional" CMake pathway for linking libusb to yuzu AKA MSVC. For autotools we still want to set these variables before configuring SDL.