### PR TITLE
fsp_srv: Add a small delay to OutputAccessLogToSdCard

### DIFF
--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <iterator>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -1061,6 +1062,8 @@ void FSP_SRV::OutputAccessLogToSdCard(Kernel::HLERequestContext& ctx) {
     const auto raw = ctx.ReadBuffer();
     auto log = Common::StringFromFixedZeroTerminatedBuffer(
         reinterpret_cast<const char*>(raw.data()), raw.size());
+
+    std::this_thread::sleep_for(std::chrono::microseconds(50));
 
     LOG_DEBUG(Service_FS, "called, log='{}'", log);
 


### PR DESCRIPTION
This simulates a delay when an entry is logged.

Fixes softlocks during loading in Xenoblade Chronicles 2 when certain DLC is enabled.

Thanks to @gidoly for helping me test this.