### PR TITLE
cmake: Improve Linux dependency checking for externals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,11 +253,82 @@ if(ENABLE_QT)
 
     # Check for system Qt on Linux, fallback to bundled Qt
     if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-        if (NOT YUZU_USE_BUNDLED_QT)
-            find_package(Qt5 ${QT_VERSION} COMPONENTS Widgets QUIET)
-            if (NOT Qt5_FOUND)
-                set(YUZU_USE_BUNDLED_QT ON CACHE BOOL "Download bundled Qt" FORCE)
+        find_package(Qt5 ${QT_VERSION} COMPONENTS Widgets)
+        if (NOT Qt5_FOUND OR YUZU_USE_BUNDLED_QT)
+            # Check for dependencies, then enable bundled Qt download
+
+            # Check that the system GLIBCXX version is compatible
+            find_program(OBJDUMP objdump)
+            if ("${OBJDUMP}" STREQUAL "OBJDUMP-NOTFOUND")
+                message(FATAL_ERROR "Required program `objdump` not found.")
             endif()
+            find_library(LIBSTDCXX libstdc++.so.6)
+            execute_process(
+                COMMAND
+                    ${OBJDUMP} -T ${LIBSTDCXX}
+                COMMAND
+                    grep GLIBCXX_3.4.28
+                COMMAND
+                    sed "s/[0-9a-f]*.*  //"
+                COMMAND
+                    sed "s/ .*//"
+                COMMAND
+                    sort -u
+                OUTPUT_VARIABLE
+                    GLIBCXX_MET
+            )
+            if (NOT GLIBCXX_MET)
+                message(FATAL_ERROR "Qt too old or not found, and bundled Qt package is not \
+                    compatible with this system. Either install Qt ${QT_VERSION}, or provide the path \
+                    to Qt by setting the variable Qt5_ROOT.")
+            endif()
+
+            # Check for headers
+            Include(FindPkgConfig REQUIRED)
+            pkg_check_modules(QT_DEP_GLU QUIET glu>=9.0.0)
+            if (NOT QT_DEP_GLU_FOUND)
+                message(FATAL_ERROR "Qt bundled pacakge dependency `glu` not found. \
+                    Perhaps `libglu1-mesa-dev` needs to be installed?")
+            endif()
+            pkg_check_modules(QT_DEP_MESA QUIET dri>=20.0.8)
+            if (NOT QT_DEP_MESA_FOUND)
+                message(FATAL_ERROR "Qt bundled pacakge dependency `dri` not found. \
+                    Perhaps `mesa-common-dev` needs to be installed?")
+            endif()
+
+            # Check for X libraries
+            set(BUNDLED_QT_REQUIREMENTS
+                libxcb-icccm.so.4
+                libxcb-image.so.0
+                libxcb-keysyms.so.1
+                libxcb-randr.so.0
+                libxcb-render-util.so.0
+                libxcb-render.so.0
+                libxcb-shape.so.0
+                libxcb-shm.so.0
+                libxcb-sync.so.1
+                libxcb-xfixes.so.0
+                libxcb-xinerama.so.0
+                libxcb-xkb.so.1
+                libxcb.so.1
+                libxkbcommon-x11.so.0
+                libxkbcommon.so.0
+            )
+            set(UNRESOLVED_QT_DEPS "")
+            foreach (REQUIREMENT ${BUNDLED_QT_REQUIREMENTS})
+                find_library(BUNDLED_QT_${REQUIREMENT} ${REQUIREMENT})
+                if ("${BUNDLED_QT_${REQUIREMENT}}" STREQUAL "BUNDLED_QT_${REQUIREMENT}-NOTFOUND")
+                    set(UNRESOLVED_QT_DEPS ${UNRESOLVED_QT_DEPS} ${REQUIREMENT})
+                endif()
+                unset(BUNDLED_QT_${REQUIREMENT})
+            endforeach()
+            unset(BUNDLED_QT_REQUIREMENTS)
+
+            if (NOT "${UNRESOLVED_QT_DEPS}" STREQUAL "")
+                message(FATAL_ERROR "Bundled Qt package missing required dependencies: ${UNRESOLVED_QT_DEPS}")
+            endif()
+
+            set(YUZU_USE_BUNDLED_QT ON CACHE BOOL "Download bundled Qt" FORCE)
         endif()
         if (YUZU_USE_BUNDLED_QT)
             # Binary package currently does not support Qt webengine, so make sure it's disabled

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -473,7 +473,15 @@ if (YUZU_USE_BUNDLED_FFMPEG)
 
         # FFmpeg has source that requires one of nasm or yasm to assemble it.
         # REQUIRED throws an error if not found here during configuration rather than during compilation.
-        find_program(ASSEMBLER NAMES nasm yasm REQUIRED)
+        find_program(ASSEMBLER NAMES nasm yasm)
+        if ("${ASSEMBLER}" STREQUAL "ASSEMBLER-NOTFOUND")
+            message(FATAL_ERROR "One of either `nasm` or `yasm` not found but is required.")
+        endif()
+
+        find_program(AUTOCONF autoconf)
+        if ("${AUTOCONF}" STREQUAL "AUTOCONF-NOTFOUND")
+            message(FATAL_ERROR "Required program `autoconf` not found.")
+        endif()
 
         set(FFmpeg_PREFIX ${PROJECT_SOURCE_DIR}/externals/ffmpeg)
         set(FFmpeg_BUILD_DIR ${PROJECT_BINARY_DIR}/externals/ffmpeg)

--- a/externals/libusb/CMakeLists.txt
+++ b/externals/libusb/CMakeLists.txt
@@ -5,6 +5,17 @@ if (MINGW OR (${CMAKE_SYSTEM_NAME} MATCHES "Linux"))
     # GNU toolchains for some reason doesn't work with the later half of this CMakeLists after
     # updating to 1.0.24, so we do it the old-fashioned way for now.
 
+    # Require autoconf and libtoolize here, rather than crash during compilation
+    find_program(AUTOCONF autoconf)
+    if ("${AUTOCONF}" STREQUAL "AUTOCONF-NOTFOUND")
+        message(FATAL_ERROR "Required program `autoconf` not found.")
+    endif()
+
+    find_program(LIBTOOLIZE libtoolize)
+    if ("${LIBTOOLIZE}" STREQUAL "LIBTOOLIZE-NOTFOUND")
+        message(FATAL_ERROR "Required program `libtoolize` not found.")
+    endif()
+
     set(LIBUSB_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/libusb")
     set(LIBUSB_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libusb")
 

--- a/src/video_core/host_shaders/CMakeLists.txt
+++ b/src/video_core/host_shaders/CMakeLists.txt
@@ -18,7 +18,10 @@ set(SHADER_FILES
     vulkan_uint8.comp
 )
 
-find_program(GLSLANGVALIDATOR "glslangValidator" REQUIRED)
+find_program(GLSLANGVALIDATOR "glslangValidator")
+if ("${GLSLANGVALIDATOR}" STREQUAL "GLSLANGVALIDATOR-NOTFOUND")
+    message(FATAL_ERROR "Required program `glslangValidator` not found.")
+endif()
 
 set(GLSL_FLAGS "")
 set(QUIET_FLAG "--quiet")


### PR DESCRIPTION
On a few externals our CMake code will begin to configure or build, but missing programs/libraries/headers will cause crashes later on, often during compilation. This PR does three things to improve that:

1. Our code requires CMake 3.15, but our usages of `find_program` use `REQUIRE`, a 3.18 feature. This removes `REQUIRE` from those and instead checks the success of those functions the old way.
2. Check for required tools needed to configure FFmpeg and libusb before compile time, since we configure those during compilation.
3. Check for dependencies and compatibility with the Qt 5.15.2 bundled package. The ensures that the GLIBCXX version is compatible, all headers are needed for the bundle package, and the xcb/xkb libraries needed during yuzu's runtime are present.

Draft just so I can make sure this works on Fedora when it's not so late.