### PR TITLE
fsp_srv: Fix filesystem access logging

### DIFF
--- a/src/common/fs/file.cpp
+++ b/src/common/fs/file.cpp
@@ -183,10 +183,6 @@ size_t WriteStringToFile(const std::filesystem::path& path, FileType type,
 
 size_t AppendStringToFile(const std::filesystem::path& path, FileType type,
                           std::string_view string) {
-    if (!Exists(path)) {
-        return WriteStringToFile(path, type, string);
-    }
-
     if (!IsFile(path)) {
         return 0;
     }

--- a/src/common/fs/file.h
+++ b/src/common/fs/file.h
@@ -71,7 +71,7 @@ template <typename Path>
 
 /**
  * Writes a string to a file at path and returns the number of characters successfully written.
- * If an file already exists at path, its contents will be erased.
+ * If a file already exists at path, its contents will be erased.
  * If the filesystem object at path is not a file, this function returns 0.
  *
  * @param path Filesystem path
@@ -95,7 +95,6 @@ template <typename Path>
 
 /**
  * Appends a string to a file at path and returns the number of characters successfully written.
- * If a file does not exist at path, WriteStringToFile is called instead.
  * If the filesystem object at path is not a file, this function returns 0.
  *
  * @param path Filesystem path

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -218,6 +218,7 @@ struct Values {
     std::string program_args;
     bool dump_exefs;
     bool dump_nso;
+    bool enable_fs_access_log;
     bool reporting_services;
     bool quest_flag;
     bool disable_macro_jit;

--- a/src/core/hle/service/filesystem/fsp_srv.h
+++ b/src/core/hle/service/filesystem/fsp_srv.h
@@ -24,11 +24,10 @@ enum class AccessLogVersion : u32 {
     Latest = V7_0_0,
 };
 
-enum class LogMode : u32 {
-    Off,
+enum class AccessLogMode : u32 {
+    None,
     Log,
-    RedirectToSdCard,
-    LogToSdCard = Log | RedirectToSdCard,
+    SdCard,
 };
 
 class FSP_SRV final : public ServiceFramework<FSP_SRV> {
@@ -59,13 +58,12 @@ private:
 
     FileSystemController& fsc;
     const FileSys::ContentProvider& content_provider;
+    const Core::Reporter& reporter;
 
     FileSys::VirtualFile romfs;
     u64 current_process_id = 0;
     u32 access_log_program_index = 0;
-    LogMode log_mode = LogMode::LogToSdCard;
-
-    const Core::Reporter& reporter;
+    AccessLogMode access_log_mode = AccessLogMode::None;
 };
 
 } // namespace Service::FileSystem

--- a/src/core/reporter.h
+++ b/src/core/reporter.h
@@ -16,10 +16,6 @@ namespace Kernel {
 class HLERequestContext;
 } // namespace Kernel
 
-namespace Service::FileSystem {
-enum class LogMode : u32;
-}
-
 namespace Service::LM {
 struct LogMessage;
 } // namespace Service::LM
@@ -69,14 +65,15 @@ public:
                          std::optional<std::string> custom_text_main = {},
                          std::optional<std::string> custom_text_detail = {}) const;
 
-    void SaveFilesystemAccessReport(Service::FileSystem::LogMode log_mode,
-                                    std::string log_message) const;
+    void SaveFSAccessLog(std::string_view log_message) const;
 
     // Can be used anywhere to generate a backtrace and general info report at any point during
     // execution. Not intended to be used for anything other than debugging or testing.
     void SaveUserReport() const;
 
 private:
+    void ClearFSAccessLog() const;
+
     bool IsReportingEnabled() const;
 
     System& system;

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -647,6 +647,8 @@ void Config::ReadDebuggingValues() {
         ReadSetting(QStringLiteral("program_args"), QString{}).toString().toStdString();
     Settings::values.dump_exefs = ReadSetting(QStringLiteral("dump_exefs"), false).toBool();
     Settings::values.dump_nso = ReadSetting(QStringLiteral("dump_nso"), false).toBool();
+    Settings::values.enable_fs_access_log =
+        ReadSetting(QStringLiteral("enable_fs_access_log"), false).toBool();
     Settings::values.reporting_services =
         ReadSetting(QStringLiteral("reporting_services"), false).toBool();
     Settings::values.quest_flag = ReadSetting(QStringLiteral("quest_flag"), false).toBool();
@@ -1258,6 +1260,8 @@ void Config::SaveDebuggingValues() {
                  QString::fromStdString(Settings::values.program_args), QString{});
     WriteSetting(QStringLiteral("dump_exefs"), Settings::values.dump_exefs, false);
     WriteSetting(QStringLiteral("dump_nso"), Settings::values.dump_nso, false);
+    WriteSetting(QStringLiteral("enable_fs_access_log"), Settings::values.enable_fs_access_log,
+                 false);
     WriteSetting(QStringLiteral("quest_flag"), Settings::values.quest_flag, false);
     WriteSetting(QStringLiteral("use_debug_asserts"), Settings::values.use_debug_asserts, false);
     WriteSetting(QStringLiteral("disable_macro_jit"), Settings::values.disable_macro_jit, false);

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -28,17 +28,21 @@ ConfigureDebug::ConfigureDebug(QWidget* parent) : QWidget(parent), ui(new Ui::Co
 ConfigureDebug::~ConfigureDebug() = default;
 
 void ConfigureDebug::SetConfiguration() {
-    ui->toggle_console->setEnabled(!Core::System::GetInstance().IsPoweredOn());
+    const bool runtime_lock = !Core::System::GetInstance().IsPoweredOn();
+
+    ui->toggle_console->setEnabled(runtime_lock);
     ui->toggle_console->setChecked(UISettings::values.show_console);
     ui->log_filter_edit->setText(QString::fromStdString(Settings::values.log_filter));
     ui->homebrew_args_edit->setText(QString::fromStdString(Settings::values.program_args));
+    ui->fs_access_log->setEnabled(runtime_lock);
+    ui->fs_access_log->setChecked(Settings::values.enable_fs_access_log);
     ui->reporting_services->setChecked(Settings::values.reporting_services);
     ui->quest_flag->setChecked(Settings::values.quest_flag);
     ui->use_debug_asserts->setChecked(Settings::values.use_debug_asserts);
     ui->use_auto_stub->setChecked(Settings::values.use_auto_stub);
-    ui->enable_graphics_debugging->setEnabled(!Core::System::GetInstance().IsPoweredOn());
+    ui->enable_graphics_debugging->setEnabled(runtime_lock);
     ui->enable_graphics_debugging->setChecked(Settings::values.renderer_debug);
-    ui->disable_macro_jit->setEnabled(!Core::System::GetInstance().IsPoweredOn());
+    ui->disable_macro_jit->setEnabled(runtime_lock);
     ui->disable_macro_jit->setChecked(Settings::values.disable_macro_jit);
     ui->extended_logging->setChecked(Settings::values.extended_logging);
 }
@@ -47,6 +51,7 @@ void ConfigureDebug::ApplyConfiguration() {
     UISettings::values.show_console = ui->toggle_console->isChecked();
     Settings::values.log_filter = ui->log_filter_edit->text().toStdString();
     Settings::values.program_args = ui->homebrew_args_edit->text().toStdString();
+    Settings::values.enable_fs_access_log = ui->fs_access_log->isChecked();
     Settings::values.reporting_services = ui->reporting_services->isChecked();
     Settings::values.quest_flag = ui->quest_flag->isChecked();
     Settings::values.use_debug_asserts = ui->use_debug_asserts->isChecked();

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -144,9 +144,16 @@
    <item>
     <widget class="QGroupBox" name="groupBox_5">
      <property name="title">
-      <string>Dump</string>
+      <string>Debugging</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_7">
+      <item>
+       <widget class="QCheckBox" name="fs_access_log">
+        <property name="text">
+         <string>Enable FS Access Log</string>
+        </property>
+       </widget>
+      </item>
       <item>
        <widget class="QCheckBox" name="reporting_services">
         <property name="text">

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -477,6 +477,8 @@ void Config::ReadValues() {
     Settings::values.program_args = sdl2_config->Get("Debugging", "program_args", "");
     Settings::values.dump_exefs = sdl2_config->GetBoolean("Debugging", "dump_exefs", false);
     Settings::values.dump_nso = sdl2_config->GetBoolean("Debugging", "dump_nso", false);
+    Settings::values.enable_fs_access_log =
+        sdl2_config->GetBoolean("Debugging", "enable_fs_access_log", false);
     Settings::values.reporting_services =
         sdl2_config->GetBoolean("Debugging", "reporting_services", false);
     Settings::values.quest_flag = sdl2_config->GetBoolean("Debugging", "quest_flag", false);

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -338,6 +338,8 @@ record_frame_times =
 dump_exefs=false
 # Determines whether or not yuzu will dump all NSOs it attempts to load while loading them
 dump_nso=false
+# Determines whether or not yuzu will save the filesystem access log.
+enable_fs_access_log=false
 # Determines whether or not yuzu will report to the game that the emulated console is in Kiosk Mode
 # false: Retail/Normal Mode (default), true: Kiosk Mode
 quest_flag =


### PR DESCRIPTION
This introduces a new setting Enable FS Access Log which saves the filesystem access log to sdmc:/FsAccessLog.txt

![image](https://user-images.githubusercontent.com/39850852/121800520-6e728f80-cc00-11eb-9c8a-3b8879f14025.png)
![image](https://user-images.githubusercontent.com/39850852/121800528-7df1d880-cc00-11eb-8891-0403d8bc6aa2.png)

If this setting is not enabled, this will indicate to FS to not call OutputAccessLogToSdCard.

NOTE: This setting is not enabled by default.
NOTE2: This setting **does not need to be enabled** to fix the loading softlock in XC2, it is only **meant for debugging purposes**

Fixes softlocks during loading in Xenoblade Chronicles 2 when certain DLC is enabled.

Supersedes #6458 

Fixes #4712 

Thanks to @gidoly, @OZtistic and @G-Spawn for testing