### PR TITLE
common: fs: file: Flush the file to the disk when Flush() is called

### DIFF
--- a/src/common/fs/file.cpp
+++ b/src/common/fs/file.cpp
@@ -309,7 +309,11 @@ bool IOFile::Flush() const {
 
     errno = 0;
 
-    const auto flush_result = std::fflush(file) == 0;
+#ifdef _WIN32
+    const auto flush_result = std::fflush(file) == 0 && _commit(fileno(file)) == 0;
+#else
+    const auto flush_result = std::fflush(file) == 0 && fsync(fileno(file)) == 0;
+#endif
 
     if (!flush_result) {
         const auto ec = std::error_code{errno, std::generic_category()};


### PR DESCRIPTION
std::fflush does not guarantee that file buffers are flushed to the disk.

Use _commit on Windows and fsync on all other OSes to ensure that the file is flushed to the disk.