### PR TITLE
GPU: Implement a garbage collector for GPU Caches (project Reaper+)

### DIFF
--- a/src/common/common_sizes.h
+++ b/src/common/common_sizes.h
@@ -24,6 +24,7 @@ enum : u64 {
     Size_128_MB = 128ULL * Size_1_MB,
     Size_448_MB = 448ULL * Size_1_MB,
     Size_507_MB = 507ULL * Size_1_MB,
+    Size_512_MB = 512ULL * Size_1_MB,
     Size_562_MB = 562ULL * Size_1_MB,
     Size_1554_MB = 1554ULL * Size_1_MB,
     Size_2048_MB = 2048ULL * Size_1_MB,

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -59,6 +59,7 @@ void LogSettings() {
     log_setting("Renderer_UseVsync", values.use_vsync.GetValue());
     log_setting("Renderer_UseAssemblyShaders", values.use_assembly_shaders.GetValue());
     log_setting("Renderer_UseAsynchronousShaders", values.use_asynchronous_shaders.GetValue());
+    log_setting("Renderer_UseGarbageCollection", values.use_caches_gc.GetValue());
     log_setting("Renderer_AnisotropicFilteringLevel", values.max_anisotropy.GetValue());
     log_setting("Audio_OutputEngine", values.sink_id);
     log_setting("Audio_EnableAudioStretching", values.enable_audio_stretching.GetValue());
@@ -141,6 +142,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.use_assembly_shaders.SetGlobal(true);
     values.use_asynchronous_shaders.SetGlobal(true);
     values.use_fast_gpu_time.SetGlobal(true);
+    values.use_caches_gc.SetGlobal(true);
     values.bg_red.SetGlobal(true);
     values.bg_green.SetGlobal(true);
     values.bg_blue.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -152,6 +152,7 @@ struct Values {
     Setting<bool> use_assembly_shaders;
     Setting<bool> use_asynchronous_shaders;
     Setting<bool> use_fast_gpu_time;
+    Setting<bool> use_caches_gc;
 
     Setting<float> bg_red;
     Setting<float> bg_green;

--- a/src/video_core/buffer_cache/buffer_base.h
+++ b/src/video_core/buffer_cache/buffer_base.h
@@ -256,6 +256,16 @@ public:
         stream_score += score;
     }
 
+    /// Sets the new frame tick
+    void SetFrameTick(u64 new_frame_tick) noexcept {
+        frame_tick = new_frame_tick;
+    }
+
+    /// Returns the new frame tick
+    [[nodiscard]] u64 FrameTick() const noexcept {
+        return frame_tick;
+    }
+
     /// Returns the likeliness of this being a stream buffer
     [[nodiscard]] int StreamScore() const noexcept {
         return stream_score;
@@ -586,6 +596,7 @@ private:
     RasterizerInterface* rasterizer = nullptr;
     VAddr cpu_addr = 0;
     Words words;
+    u64 frame_tick = 0;
     BufferFlagBits flags{};
     int stream_score = 0;
 };

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -16,6 +16,7 @@
 
 #include <boost/container/small_vector.hpp>
 
+#include "common/common_sizes.h"
 #include "common/common_types.h"
 #include "common/div_ceil.h"
 #include "common/microprofile.h"
@@ -65,8 +66,8 @@ class BufferCache {
 
     static constexpr BufferId NULL_BUFFER_ID{0};
 
-    static constexpr u64 expected_memory = 512ULL * 1024ULL * 1024ULL;
-    static constexpr u64 critical_memory = 1024ULL * 1024ULL * 1024ULL;
+    static constexpr u64 EXPECTED_MEMORY = Common::Size_512_MB;
+    static constexpr u64 CRITICAL_MEMORY = Common::Size_1_GB;
 
     using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 
@@ -368,13 +369,13 @@ void BufferCache<P>::TickFrame() {
     const bool skip_preferred = hits * 256 < shots * 251;
     uniform_buffer_skip_cache_size = skip_preferred ? DEFAULT_SKIP_CACHE_SIZE : 0;
 
-    const bool activate_gc = enabled_gc && total_used_memory >= expected_memory;
+    const bool activate_gc = enabled_gc && total_used_memory >= EXPECTED_MEMORY;
     if (!activate_gc) {
         return;
     }
-    const bool agressive_gc = total_used_memory >= critical_memory;
-    const u64 ticks_to_destroy = agressive_gc ? 60 : 120;
-    int num_iterations = agressive_gc ? 64 : 32;
+    const bool aggressive_gc = total_used_memory >= CRITICAL_MEMORY;
+    const u64 ticks_to_destroy = aggressive_gc ? 60 : 120;
+    int num_iterations = aggressive_gc ? 64 : 32;
     for (; num_iterations > 0; --num_iterations) {
         if (deletion_iterator == slot_buffers.end()) {
             deletion_iterator = slot_buffers.begin();

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -350,9 +350,10 @@ BufferCache<P>::BufferCache(VideoCore::RasterizerInterface& rasterizer_,
 
 template <class P>
 void BufferCache<P>::TickFrame() {
+    const bool enabled_gc = Settings::values.use_caches_gc.GetValue();
     SCOPE_EXIT({
-      ++frame_tick;
-      delayed_destruction_ring.Tick();
+        ++frame_tick;
+        delayed_destruction_ring.Tick();
     });
     // Calculate hits and shots and move hit bits to the right
     const u32 hits = std::reduce(uniform_cache_hits.begin(), uniform_cache_hits.end());
@@ -367,7 +368,7 @@ void BufferCache<P>::TickFrame() {
     const bool skip_preferred = hits * 256 < shots * 251;
     uniform_buffer_skip_cache_size = skip_preferred ? DEFAULT_SKIP_CACHE_SIZE : 0;
 
-    const bool activate_gc = total_used_memory >= expected_memory;
+    const bool activate_gc = enabled_gc && total_used_memory >= expected_memory;
     if (!activate_gc) {
         return;
     }

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -737,6 +737,8 @@ Image::Image(TextureCacheRuntime& runtime, const VideoCommon::ImageInfo& info_, 
     }
 }
 
+Image::~Image() = default;
+
 void Image::UploadMemory(const ImageBufferMap& map,
                          std::span<const VideoCommon::BufferImageCopy> copies) {
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, map.buffer);

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -235,6 +235,7 @@ struct TextureCacheParams {
     static constexpr bool ENABLE_VALIDATION = true;
     static constexpr bool FRAMEBUFFER_BLITS = true;
     static constexpr bool HAS_EMULATED_COPIES = true;
+    static constexpr bool HAS_DEVICE_MEMORY_INFO = false;
 
     using Runtime = OpenGL::TextureCacheRuntime;
     using Image = OpenGL::Image;

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -143,6 +143,14 @@ public:
     explicit Image(TextureCacheRuntime&, const VideoCommon::ImageInfo& info, GPUVAddr gpu_addr,
                    VAddr cpu_addr);
 
+    ~Image();
+
+    Image(const Image&) = delete;
+    Image& operator=(const Image&) = delete;
+
+    Image(Image&&) = default;
+    Image& operator=(Image&&) = default;
+
     void UploadMemory(const ImageBufferMap& map,
                       std::span<const VideoCommon::BufferImageCopy> copies);
 

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -880,6 +880,8 @@ Image::Image(TextureCacheRuntime& runtime, const ImageInfo& info_, GPUVAddr gpu_
     }
 }
 
+Image::~Image() = default;
+
 void Image::UploadMemory(const StagingBufferRef& map, std::span<const BufferImageCopy> copies) {
     // TODO: Move this to another API
     scheduler->RequestOutsideRenderPassOperationContext();

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -818,6 +818,10 @@ void TextureCacheRuntime::CopyImage(Image& dst, Image& src,
     });
 }
 
+u64 TextureCacheRuntime::GetDeviceLocalMemory() const {
+    return device.GetDeviceLocalMemory();
+}
+
 Image::Image(TextureCacheRuntime& runtime, const ImageInfo& info_, GPUVAddr gpu_addr_,
              VAddr cpu_addr_)
     : VideoCommon::ImageBase(info_, gpu_addr_, cpu_addr_), scheduler{&runtime.scheduler},

--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -106,6 +106,14 @@ public:
     explicit Image(TextureCacheRuntime&, const VideoCommon::ImageInfo& info, GPUVAddr gpu_addr,
                    VAddr cpu_addr);
 
+    ~Image();
+
+    Image(const Image&) = delete;
+    Image& operator=(const Image&) = delete;
+
+    Image(Image&&) = default;
+    Image& operator=(Image&&) = default;
+
     void UploadMemory(const StagingBufferRef& map,
                       std::span<const VideoCommon::BufferImageCopy> copies);
 

--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -97,6 +97,8 @@ struct TextureCacheRuntime {
         // All known Vulkan drivers can natively handle BGR textures
         return true;
     }
+
+    u64 GetDeviceLocalMemory() const;
 };
 
 class Image : public VideoCommon::ImageBase {
@@ -257,6 +259,7 @@ struct TextureCacheParams {
     static constexpr bool ENABLE_VALIDATION = true;
     static constexpr bool FRAMEBUFFER_BLITS = false;
     static constexpr bool HAS_EMULATED_COPIES = false;
+    static constexpr bool HAS_DEVICE_MEMORY_INFO = true;
 
     using Runtime = Vulkan::TextureCacheRuntime;
     using Image = Vulkan::Image;

--- a/src/video_core/surface.cpp
+++ b/src/video_core/surface.cpp
@@ -283,4 +283,11 @@ std::pair<u32, u32> GetASTCBlockSize(PixelFormat format) {
     return {DefaultBlockWidth(format), DefaultBlockHeight(format)};
 }
 
+u64 EstimatedDecompressedSize(u64 base_size, PixelFormat format) {
+    constexpr u64 RGBA8_PIXEL_SIZE = 4;
+    const u64 base_block_size = static_cast<u64>(DefaultBlockWidth(format)) *
+                                static_cast<u64>(DefaultBlockHeight(format)) * RGBA8_PIXEL_SIZE;
+    return (base_size * base_block_size) / BytesPerBlock(format);
+}
+
 } // namespace VideoCore::Surface

--- a/src/video_core/surface.h
+++ b/src/video_core/surface.h
@@ -462,4 +462,6 @@ bool IsPixelFormatSRGB(PixelFormat format);
 
 std::pair<u32, u32> GetASTCBlockSize(PixelFormat format);
 
+u64 EstimatedDecompressedSize(u64 base_size, PixelFormat format);
+
 } // namespace VideoCore::Surface

--- a/src/video_core/texture_cache/image_base.cpp
+++ b/src/video_core/texture_cache/image_base.cpp
@@ -113,6 +113,23 @@ void ImageBase::InsertView(const ImageViewInfo& view_info, ImageViewId image_vie
     image_view_ids.push_back(image_view_id);
 }
 
+bool ImageBase::IsSafeDownload() const noexcept {
+    // Skip images that were not modified from the GPU
+    if (False(flags & ImageFlagBits::GpuModified)) {
+        return false;
+    }
+    // Skip images that .are. modified from the CPU
+    // We don't want to write sensitive data from the guest
+    if (True(flags & ImageFlagBits::CpuModified)) {
+        return false;
+    }
+    if (info.num_samples > 1) {
+        LOG_WARNING(HW_GPU, "MSAA image downloads are not implemented");
+        return false;
+    }
+    return true;
+}
+
 void AddImageAlias(ImageBase& lhs, ImageBase& rhs, ImageId lhs_id, ImageId rhs_id) {
     static constexpr auto OPTIONS = RelaxedOptions::Size | RelaxedOptions::Format;
     ASSERT(lhs.info.type == rhs.info.type);

--- a/src/video_core/texture_cache/image_base.cpp
+++ b/src/video_core/texture_cache/image_base.cpp
@@ -130,6 +130,26 @@ bool ImageBase::IsSafeDownload() const noexcept {
     return true;
 }
 
+void ImageBase::CheckBadOverlapState() {
+    if (False(flags & ImageFlagBits::BadOverlap)) {
+        return;
+    }
+    if (!overlapping_images.empty()) {
+        return;
+    }
+    flags &= ~ImageFlagBits::BadOverlap;
+}
+
+void ImageBase::CheckAliasState() {
+    if (False(flags & ImageFlagBits::Alias)) {
+        return;
+    }
+    if (!aliased_images.empty()) {
+        return;
+    }
+    flags &= ~ImageFlagBits::Alias;
+}
+
 void AddImageAlias(ImageBase& lhs, ImageBase& rhs, ImageId lhs_id, ImageId rhs_id) {
     static constexpr auto OPTIONS = RelaxedOptions::Size | RelaxedOptions::Format;
     ASSERT(lhs.info.type == rhs.info.type);

--- a/src/video_core/texture_cache/image_base.h
+++ b/src/video_core/texture_cache/image_base.h
@@ -44,6 +44,8 @@ struct ImageBase {
 
     void InsertView(const ImageViewInfo& view_info, ImageViewId image_view_id);
 
+    [[nodiscard]] bool IsSafeDownload() const noexcept;
+
     [[nodiscard]] bool Overlaps(VAddr overlap_cpu_addr, size_t overlap_size) const noexcept {
         const VAddr overlap_end = overlap_cpu_addr + overlap_size;
         return cpu_addr < overlap_end && overlap_cpu_addr < cpu_addr_end;

--- a/src/video_core/texture_cache/image_base.h
+++ b/src/video_core/texture_cache/image_base.h
@@ -25,6 +25,12 @@ enum class ImageFlagBits : u32 {
     Strong = 1 << 5,      ///< Exists in the image table, the dimensions are can be trusted
     Registered = 1 << 6,  ///< True when the image is registered
     Picked = 1 << 7,      ///< Temporary flag to mark the image as picked
+
+    // Garbage Collection Flags
+    BadOverlap = 1 << 8,     ///< This image overlaps other but doesn't fit, has higher
+                             ///< garbage collection priority
+    Alias = 1 << 9,          ///< This image has aliases and has priority on garbage
+                             ///< collection
 };
 DECLARE_ENUM_FLAG_OPERATORS(ImageFlagBits)
 
@@ -51,6 +57,9 @@ struct ImageBase {
         return cpu_addr < overlap_end && overlap_cpu_addr < cpu_addr_end;
     }
 
+    void CheckBadOverlapState();
+    void CheckAliasState();
+
     ImageInfo info;
 
     u32 guest_size_bytes = 0;
@@ -74,6 +83,7 @@ struct ImageBase {
     std::vector<SubresourceBase> slice_subresources;
 
     std::vector<AliasedImage> aliased_images;
+    std::vector<ImageId> overlapping_images;
 };
 
 struct ImageAllocBase {

--- a/src/video_core/texture_cache/image_base.h
+++ b/src/video_core/texture_cache/image_base.h
@@ -27,10 +27,10 @@ enum class ImageFlagBits : u32 {
     Picked = 1 << 7,      ///< Temporary flag to mark the image as picked
 
     // Garbage Collection Flags
-    BadOverlap = 1 << 8,     ///< This image overlaps other but doesn't fit, has higher
-                             ///< garbage collection priority
-    Alias = 1 << 9,          ///< This image has aliases and has priority on garbage
-                             ///< collection
+    BadOverlap = 1 << 8, ///< This image overlaps other but doesn't fit, has higher
+                         ///< garbage collection priority
+    Alias = 1 << 9,      ///< This image has aliases and has priority on garbage
+                         ///< collection
 };
 DECLARE_ENUM_FLAG_OPERATORS(ImageFlagBits)
 

--- a/src/video_core/texture_cache/slot_vector.h
+++ b/src/video_core/texture_cache/slot_vector.h
@@ -79,7 +79,7 @@ public:
         Iterator(SlotVector<T>* slot_vector_, SlotId id_) noexcept
             : slot_vector{slot_vector_}, id{id_} {}
 
-        bool IsValid(const u64* bitset) noexcept {
+        bool IsValid(const u64* bitset) const noexcept {
             return ((bitset[id.index / 64] >> (id.index % 64)) & 1) != 0;
         }
 

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -397,8 +397,9 @@ TextureCache<P>::TextureCache(Runtime& runtime_, VideoCore::RasterizerInterface&
         expected_memory = std::max(possible_expected_memory, DEFAULT_EXPECTED_MEMORY);
         critical_memory = std::max(possible_critical_memory, DEFAULT_CRITICAL_MEMORY);
     } else {
-        expected_memory = DEFAULT_EXPECTED_MEMORY;
-        critical_memory = DEFAULT_CRITICAL_MEMORY;
+        // on OGL we can be more conservatives as the driver takes care.
+        expected_memory = DEFAULT_EXPECTED_MEMORY + Common::Size_512_MB;
+        critical_memory = DEFAULT_CRITICAL_MEMORY + Common::Size_1_GB;
     }
 }
 

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -344,6 +344,7 @@ private:
 
     bool has_deleted_images = false;
     u64 total_used_memory = 0;
+    u64 minimum_memory;
     u64 expected_memory;
     u64 critical_memory;
 
@@ -396,10 +397,12 @@ TextureCache<P>::TextureCache(Runtime& runtime_, VideoCore::RasterizerInterface&
         const u64 possible_critical_memory = (device_memory * 6) / 10;
         expected_memory = std::max(possible_expected_memory, DEFAULT_EXPECTED_MEMORY);
         critical_memory = std::max(possible_critical_memory, DEFAULT_CRITICAL_MEMORY);
+        minimum_memory = 0;
     } else {
         // on OGL we can be more conservatives as the driver takes care.
         expected_memory = DEFAULT_EXPECTED_MEMORY + Common::Size_512_MB;
         critical_memory = DEFAULT_CRITICAL_MEMORY + Common::Size_1_GB;
+        minimum_memory = expected_memory;
     }
 }
 
@@ -470,7 +473,7 @@ void TextureCache<P>::RunGarbageCollector() {
 
 template <class P>
 void TextureCache<P>::TickFrame() {
-    if (Settings::values.use_caches_gc.GetValue()) {
+    if (Settings::values.use_caches_gc.GetValue() && total_used_memory > minimum_memory) {
         RunGarbageCollector();
     }
     sentenced_images.Tick();

--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -581,6 +581,8 @@ void SwizzleBlockLinearImage(Tegra::MemoryManager& gpu_memory, GPUVAddr gpu_addr
 
     for (s32 layer = 0; layer < info.resources.layers; ++layer) {
         const std::span<const u8> src = input.subspan(host_offset);
+        gpu_memory.ReadBlockUnsafe(gpu_addr + guest_offset, dst.data(), dst.size_bytes());
+
         SwizzleTexture(dst, src, bytes_per_block, num_tiles.width, num_tiles.height,
                        num_tiles.depth, block.height, block.depth);
 

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -408,6 +408,7 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     }
     logical = vk::Device::Create(physical, queue_cis, extensions, first_next, dld);
 
+    CollectPhysicalMemoryInfo();
     CollectTelemetryParameters();
     CollectToolingInfo();
 
@@ -815,6 +816,19 @@ void Device::CollectTelemetryParameters() {
     reported_extensions.reserve(std::size(extensions));
     for (const auto& extension : extensions) {
         reported_extensions.emplace_back(extension.extensionName);
+    }
+}
+
+void Device::CollectPhysicalMemoryInfo() {
+    const auto mem_properties = physical.GetMemoryProperties();
+    const std::size_t num_properties = mem_properties.memoryTypeCount;
+    device_access_memory = 0;
+    for (std::size_t element = 0; element < num_properties; element++) {
+        if ((mem_properties.memoryTypes[element].propertyFlags &
+             VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) != 0) {
+            const std::size_t heap_index = mem_properties.memoryTypes[element].heapIndex;
+            device_access_memory += mem_properties.memoryHeaps[heap_index].size;
+        }
     }
 }
 

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -821,13 +821,11 @@ void Device::CollectTelemetryParameters() {
 
 void Device::CollectPhysicalMemoryInfo() {
     const auto mem_properties = physical.GetMemoryProperties();
-    const std::size_t num_properties = mem_properties.memoryTypeCount;
+    const std::size_t num_properties = mem_properties.memoryHeapCount;
     device_access_memory = 0;
     for (std::size_t element = 0; element < num_properties; element++) {
-        if ((mem_properties.memoryTypes[element].propertyFlags &
-             VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) != 0) {
-            const std::size_t heap_index = mem_properties.memoryTypes[element].heapIndex;
-            device_access_memory += mem_properties.memoryHeaps[heap_index].size;
+        if ((mem_properties.memoryHeaps[element].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) != 0) {
+            device_access_memory += mem_properties.memoryHeaps[element].size;
         }
     }
 }

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -225,6 +225,10 @@ public:
         return use_asynchronous_shaders;
     }
 
+    u64 GetDeviceLocalMemory() const {
+        return device_access_memory;
+    }
+
 private:
     /// Checks if the physical device is suitable.
     void CheckSuitability(bool requires_swapchain) const;
@@ -243,6 +247,9 @@ private:
 
     /// Collects information about attached tools.
     void CollectToolingInfo();
+
+    /// Collects information about the device's local memory.
+    void CollectPhysicalMemoryInfo();
 
     /// Returns a list of queue initialization descriptors.
     std::vector<VkDeviceQueueCreateInfo> GetDeviceQueueCreateInfos() const;
@@ -302,6 +309,8 @@ private:
 
     /// Nsight Aftermath GPU crash tracker
     std::unique_ptr<NsightAftermathTracker> nsight_aftermath_tracker;
+
+    u64 device_access_memory;
 };
 
 } // namespace Vulkan

--- a/src/video_core/vulkan_common/vulkan_memory_allocator.h
+++ b/src/video_core/vulkan_common/vulkan_memory_allocator.h
@@ -69,6 +69,8 @@ private:
 /// Memory allocator container.
 /// Allocates and releases memory allocations on demand.
 class MemoryAllocator {
+    friend MemoryAllocation;
+
 public:
     /**
      * Construct memory allocator
@@ -103,6 +105,9 @@ public:
 private:
     /// Tries to allocate a chunk of memory.
     bool TryAllocMemory(VkMemoryPropertyFlags flags, u32 type_mask, u64 size);
+
+    /// Releases a chunk of memory.
+    void ReleaseMemory(MemoryAllocation* alloc);
 
     /// Tries to allocate a memory commit.
     std::optional<MemoryCommit> TryCommit(const VkMemoryRequirements& requirements,

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -817,6 +817,7 @@ void Config::ReadRendererValues() {
                       QStringLiteral("use_asynchronous_shaders"), false);
     ReadSettingGlobal(Settings::values.use_fast_gpu_time, QStringLiteral("use_fast_gpu_time"),
                       true);
+    ReadSettingGlobal(Settings::values.use_caches_gc, QStringLiteral("use_caches_gc"), false);
     ReadSettingGlobal(Settings::values.bg_red, QStringLiteral("bg_red"), 0.0);
     ReadSettingGlobal(Settings::values.bg_green, QStringLiteral("bg_green"), 0.0);
     ReadSettingGlobal(Settings::values.bg_blue, QStringLiteral("bg_blue"), 0.0);
@@ -1401,6 +1402,7 @@ void Config::SaveRendererValues() {
                        Settings::values.use_asynchronous_shaders, false);
     WriteSettingGlobal(QStringLiteral("use_fast_gpu_time"), Settings::values.use_fast_gpu_time,
                        true);
+    WriteSettingGlobal(QStringLiteral("use_caches_gc"), Settings::values.use_caches_gc, false);
     // Cast to double because Qt's written float values are not human-readable
     WriteSettingGlobal(QStringLiteral("bg_red"), Settings::values.bg_red, 0.0);
     WriteSettingGlobal(QStringLiteral("bg_green"), Settings::values.bg_green, 0.0);

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -30,6 +30,7 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
     ui->use_vsync->setChecked(Settings::values.use_vsync.GetValue());
     ui->use_assembly_shaders->setChecked(Settings::values.use_assembly_shaders.GetValue());
     ui->use_asynchronous_shaders->setChecked(Settings::values.use_asynchronous_shaders.GetValue());
+    ui->use_caches_gc->setChecked(Settings::values.use_caches_gc.GetValue());
     ui->use_fast_gpu_time->setChecked(Settings::values.use_fast_gpu_time.GetValue());
 
     if (Settings::IsConfiguringGlobal()) {
@@ -62,6 +63,8 @@ void ConfigureGraphicsAdvanced::ApplyConfiguration() {
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_asynchronous_shaders,
                                              ui->use_asynchronous_shaders,
                                              use_asynchronous_shaders);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_caches_gc, ui->use_caches_gc,
+                                             use_caches_gc);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_fast_gpu_time,
                                              ui->use_fast_gpu_time, use_fast_gpu_time);
 
@@ -101,6 +104,7 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
         ui->use_asynchronous_shaders->setEnabled(
             Settings::values.use_asynchronous_shaders.UsingGlobal());
         ui->use_fast_gpu_time->setEnabled(Settings::values.use_fast_gpu_time.UsingGlobal());
+        ui->use_caches_gc->setEnabled(Settings::values.use_caches_gc.UsingGlobal());
         ui->anisotropic_filtering_combobox->setEnabled(
             Settings::values.max_anisotropy.UsingGlobal());
 
@@ -115,6 +119,8 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
                                             use_asynchronous_shaders);
     ConfigurationShared::SetColoredTristate(ui->use_fast_gpu_time,
                                             Settings::values.use_fast_gpu_time, use_fast_gpu_time);
+    ConfigurationShared::SetColoredTristate(ui->use_caches_gc, Settings::values.use_caches_gc,
+                                            use_caches_gc);
     ConfigurationShared::SetColoredComboBox(
         ui->gpu_accuracy, ui->label_gpu_accuracy,
         static_cast<int>(Settings::values.gpu_accuracy.GetValue(true)));

--- a/src/yuzu/configuration/configure_graphics_advanced.h
+++ b/src/yuzu/configuration/configure_graphics_advanced.h
@@ -38,4 +38,5 @@ private:
     ConfigurationShared::CheckState use_assembly_shaders;
     ConfigurationShared::CheckState use_asynchronous_shaders;
     ConfigurationShared::CheckState use_fast_gpu_time;
+    ConfigurationShared::CheckState use_caches_gc;
 };

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -109,7 +109,7 @@
            <string>Enables garbage collection for the GPU caches, this will try to keep VRAM within 3-4 GB by flushing the least used textures/buffers. May cause issues in a few games.</string>
           </property>
           <property name="text">
-           <string>Enable GPU caches garbage collection (unsafe)</string>
+           <string>Enable GPU cache garbage collection (unsafe)</string>
           </property>
          </widget>
         </item>

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -106,7 +106,7 @@
         <item>
          <widget class="QCheckBox" name="use_caches_gc">
           <property name="toolTip">
-           <string>Enables garbage collection for the GPU caches, this will try to keep VRAM within 3-4Gb and flush least used textures/buffers. This option may be unsafe on a few games</string>
+           <string>Enables garbage collection for the GPU caches, this will try to keep VRAM within 3-4 GB by flushing the least used textures/buffers. May cause issues in a few games.</string>
           </property>
           <property name="text">
            <string>Enable GPU caches garbage collection (unsafe)</string>

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -109,7 +109,7 @@
            <string>Enables garbage collection for the GPU caches, this will try to keep VRAM within 3-4 GB by flushing the least used textures/buffers. May cause issues in a few games.</string>
           </property>
           <property name="text">
-           <string>Enable GPU cache garbage collection (unsafe)</string>
+           <string>Enable GPU cache garbage collection (experimental)</string>
           </property>
          </widget>
         </item>

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -104,6 +104,16 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="use_caches_gc">
+          <property name="toolTip">
+           <string>Enables garbage collection for the GPU caches, this will try to keep VRAM within 3-4Gb and flush least used textures/buffers. This option may be unsafe on a few games</string>
+          </property>
+          <property name="text">
+           <string>Enable GPU caches garbage collection (unsafe)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QWidget" name="af_layout" native="true">
           <layout class="QHBoxLayout" name="horizontalLayout_1">
            <property name="leftMargin">

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -227,6 +227,10 @@ use_asynchronous_gpu_emulation =
 # 0: Off, 1 (default): On
 use_vsync =
 
+# Whether to use garbage collection or not.
+# 0 (default): Off, 1: On
+use_caches_gc =
+
 # The clear color for the renderer. What shows up on the sides of the bottom screen.
 # Must be in range of 0.0-1.0. Defaults to 1.0 for all.
 bg_red =

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -227,7 +227,7 @@ use_asynchronous_gpu_emulation =
 # 0: Off, 1 (default): On
 use_vsync =
 
-# Whether to use garbage collection or not.
+# Whether to use garbage collection or not for GPU caches.
 # 0 (default): Off, 1: On
 use_caches_gc =
 


### PR DESCRIPTION
This PR instroduces a new GC for GPU Caches, it will try keep memory at between 2.5-4Gb VRAM by removing `Least Used Resources` and Texture Cache leftovers. In general, the GC is pretty safe but it does seem to have some issues in games like SMO when travelling through kingdoms may cause graphics issues (very few to notice though). My current guess is that it's due to GPU VMM Remaps not notifying TCR. This will be fixed in a further PR.