### PR TITLE
yuzu qt, core: Support LayeredFS mods from SDMC directory

### DIFF
--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -407,7 +407,7 @@ static void ApplyLayeredFS(VirtualFile& romfs, u64 title_id, ContentRecordType t
 }
 
 VirtualFile PatchManager::PatchRomFS(VirtualFile romfs, u64 ivfc_offset, ContentRecordType type,
-                                     VirtualFile update_raw) const {
+                                     VirtualFile update_raw, bool apply_layeredfs) const {
     const auto log_string = fmt::format("Patching RomFS for title_id={:016X}, type={:02X}",
                                         title_id, static_cast<u8>(type));
 
@@ -447,7 +447,9 @@ VirtualFile PatchManager::PatchRomFS(VirtualFile romfs, u64 ivfc_offset, Content
     }
 
     // LayeredFS
-    ApplyLayeredFS(romfs, title_id, type, fs_controller);
+    if (apply_layeredfs) {
+        ApplyLayeredFS(romfs, title_id, type, fs_controller);
+    }
 
     return romfs;
 }

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -345,8 +345,10 @@ std::vector<Core::Memory::CheatEntry> PatchManager::CreateCheatList(
 static void ApplyLayeredFS(VirtualFile& romfs, u64 title_id, ContentRecordType type,
                            const Service::FileSystem::FileSystemController& fs_controller) {
     const auto load_dir = fs_controller.GetModificationLoadRoot(title_id);
+    const auto sdmc_load_dir = fs_controller.GetSDMCModificationLoadRoot(title_id);
     if ((type != ContentRecordType::Program && type != ContentRecordType::Data) ||
-        load_dir == nullptr || load_dir->GetSize() <= 0) {
+        ((load_dir == nullptr || load_dir->GetSize() <= 0) &&
+         (sdmc_load_dir == nullptr || sdmc_load_dir->GetSize() <= 0))) {
         return;
     }
 
@@ -356,7 +358,10 @@ static void ApplyLayeredFS(VirtualFile& romfs, u64 title_id, ContentRecordType t
     }
 
     const auto& disabled = Settings::values.disabled_addons[title_id];
-    auto patch_dirs = load_dir->GetSubdirectories();
+    std::vector<VirtualDir> patch_dirs = load_dir->GetSubdirectories();
+    if (std::find(disabled.cbegin(), disabled.cend(), "SDMC") == disabled.cend()) {
+        patch_dirs.push_back(sdmc_load_dir);
+    }
     std::sort(patch_dirs.begin(), patch_dirs.end(),
               [](const VirtualDir& l, const VirtualDir& r) { return l->GetName() < r->GetName(); });
 
@@ -521,6 +526,28 @@ PatchManager::PatchVersionNames PatchManager::GetPatchVersionNames(VirtualFile u
             const auto mod_disabled =
                 std::find(disabled.begin(), disabled.end(), mod->GetName()) != disabled.end();
             out.insert_or_assign(mod_disabled ? "[D] " + mod->GetName() : mod->GetName(), types);
+        }
+    }
+
+    // SDMC mod directory (LayeredFS)
+    const auto sdmc_mod_dir = fs_controller.GetSDMCModificationLoadRoot(title_id);
+    if (sdmc_mod_dir != nullptr && sdmc_mod_dir->GetSize() > 0) {
+        std::string types;
+
+        const auto exefs_dir = FindSubdirectoryCaseless(sdmc_mod_dir, "exefs");
+        if (IsDirValidAndNonEmpty(exefs_dir)) {
+            bool layeredfs = false;
+
+            if (layeredfs)
+                AppendCommaIfNotEmpty(types, "LayeredExeFS");
+        }
+        if (IsDirValidAndNonEmpty(FindSubdirectoryCaseless(sdmc_mod_dir, "romfs")))
+            AppendCommaIfNotEmpty(types, "LayeredFS");
+
+        if (!types.empty()) {
+            const auto mod_disabled =
+                std::find(disabled.begin(), disabled.end(), "SDMC") != disabled.end();
+            out.insert_or_assign(mod_disabled ? "[D] SDMC" : "SDMC", types);
         }
     }
 

--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -529,26 +529,13 @@ PatchManager::PatchVersionNames PatchManager::GetPatchVersionNames(VirtualFile u
         }
     }
 
-    // SDMC mod directory (LayeredFS)
+    // SDMC mod directory (RomFS LayeredFS)
     const auto sdmc_mod_dir = fs_controller.GetSDMCModificationLoadRoot(title_id);
-    if (sdmc_mod_dir != nullptr && sdmc_mod_dir->GetSize() > 0) {
-        std::string types;
-
-        const auto exefs_dir = FindSubdirectoryCaseless(sdmc_mod_dir, "exefs");
-        if (IsDirValidAndNonEmpty(exefs_dir)) {
-            bool layeredfs = false;
-
-            if (layeredfs)
-                AppendCommaIfNotEmpty(types, "LayeredExeFS");
-        }
-        if (IsDirValidAndNonEmpty(FindSubdirectoryCaseless(sdmc_mod_dir, "romfs")))
-            AppendCommaIfNotEmpty(types, "LayeredFS");
-
-        if (!types.empty()) {
-            const auto mod_disabled =
-                std::find(disabled.begin(), disabled.end(), "SDMC") != disabled.end();
-            out.insert_or_assign(mod_disabled ? "[D] SDMC" : "SDMC", types);
-        }
+    if (sdmc_mod_dir != nullptr && sdmc_mod_dir->GetSize() > 0 &&
+        IsDirValidAndNonEmpty(FindSubdirectoryCaseless(sdmc_mod_dir, "romfs"))) {
+        const auto mod_disabled =
+            std::find(disabled.begin(), disabled.end(), "SDMC") != disabled.end();
+        out.insert_or_assign(mod_disabled ? "[D] SDMC" : "SDMC", "LayeredFS");
     }
 
     // DLC

--- a/src/core/file_sys/patch_manager.h
+++ b/src/core/file_sys/patch_manager.h
@@ -64,7 +64,8 @@ public:
     // - LayeredFS
     [[nodiscard]] VirtualFile PatchRomFS(VirtualFile base, u64 ivfc_offset,
                                          ContentRecordType type = ContentRecordType::Program,
-                                         VirtualFile update_raw = nullptr) const;
+                                         VirtualFile update_raw = nullptr,
+                                         bool apply_layeredfs = true) const;
 
     // Returns a vector of pairs between patch names and patch versions.
     // i.e. Update 3.2.2 will return {"Update", "3.2.2"}

--- a/src/core/file_sys/sdmc_factory.cpp
+++ b/src/core/file_sys/sdmc_factory.cpp
@@ -29,8 +29,9 @@ ResultVal<VirtualDir> SDMCFactory::Open() const {
 
 VirtualDir SDMCFactory::GetSDMCModificationLoadRoot(u64 title_id) const {
     // LayeredFS doesn't work on updates and title id-less homebrew
-    if (title_id == 0 || (title_id & 0xFFF) == 0x800)
+    if (title_id == 0 || (title_id & 0xFFF) == 0x800) {
         return nullptr;
+    }
     return GetOrCreateDirectoryRelative(dir, fmt::format("/atmosphere/contents/{:016X}", title_id));
 }
 

--- a/src/core/file_sys/sdmc_factory.cpp
+++ b/src/core/file_sys/sdmc_factory.cpp
@@ -27,6 +27,13 @@ ResultVal<VirtualDir> SDMCFactory::Open() const {
     return MakeResult<VirtualDir>(dir);
 }
 
+VirtualDir SDMCFactory::GetSDMCModificationLoadRoot(u64 title_id) const {
+    // LayeredFS doesn't work on updates and title id-less homebrew
+    if (title_id == 0 || (title_id & 0xFFF) == 0x800)
+        return nullptr;
+    return GetOrCreateDirectoryRelative(dir, fmt::format("/atmosphere/contents/{:016X}", title_id));
+}
+
 VirtualDir SDMCFactory::GetSDMCContentDirectory() const {
     return GetOrCreateDirectoryRelative(dir, "/Nintendo/Contents");
 }

--- a/src/core/file_sys/sdmc_factory.cpp
+++ b/src/core/file_sys/sdmc_factory.cpp
@@ -12,19 +12,20 @@ namespace FileSys {
 
 constexpr u64 SDMC_TOTAL_SIZE = 0x10000000000; // 1 TiB
 
-SDMCFactory::SDMCFactory(VirtualDir dir_)
-    : dir(std::move(dir_)), contents(std::make_unique<RegisteredCache>(
-                                GetOrCreateDirectoryRelative(dir, "/Nintendo/Contents/registered"),
-                                [](const VirtualFile& file, const NcaID& id) {
-                                    return NAX{file, id}.GetDecrypted();
-                                })),
+SDMCFactory::SDMCFactory(VirtualDir sd_dir_, VirtualDir sd_mod_dir_)
+    : sd_dir(std::move(sd_dir_)), sd_mod_dir(std::move(sd_mod_dir_)),
+      contents(std::make_unique<RegisteredCache>(
+          GetOrCreateDirectoryRelative(sd_dir, "/Nintendo/Contents/registered"),
+          [](const VirtualFile& file, const NcaID& id) {
+              return NAX{file, id}.GetDecrypted();
+          })),
       placeholder(std::make_unique<PlaceholderCache>(
-          GetOrCreateDirectoryRelative(dir, "/Nintendo/Contents/placehld"))) {}
+          GetOrCreateDirectoryRelative(sd_dir, "/Nintendo/Contents/placehld"))) {}
 
 SDMCFactory::~SDMCFactory() = default;
 
 ResultVal<VirtualDir> SDMCFactory::Open() const {
-    return MakeResult<VirtualDir>(dir);
+    return MakeResult<VirtualDir>(sd_dir);
 }
 
 VirtualDir SDMCFactory::GetSDMCModificationLoadRoot(u64 title_id) const {
@@ -32,11 +33,11 @@ VirtualDir SDMCFactory::GetSDMCModificationLoadRoot(u64 title_id) const {
     if (title_id == 0 || (title_id & 0xFFF) == 0x800) {
         return nullptr;
     }
-    return GetOrCreateDirectoryRelative(dir, fmt::format("/atmosphere/contents/{:016X}", title_id));
+    return GetOrCreateDirectoryRelative(sd_mod_dir, fmt::format("/{:016X}", title_id));
 }
 
 VirtualDir SDMCFactory::GetSDMCContentDirectory() const {
-    return GetOrCreateDirectoryRelative(dir, "/Nintendo/Contents");
+    return GetOrCreateDirectoryRelative(sd_dir, "/Nintendo/Contents");
 }
 
 RegisteredCache* SDMCFactory::GetSDMCContents() const {
@@ -48,11 +49,11 @@ PlaceholderCache* SDMCFactory::GetSDMCPlaceholder() const {
 }
 
 VirtualDir SDMCFactory::GetImageDirectory() const {
-    return GetOrCreateDirectoryRelative(dir, "/Nintendo/Album");
+    return GetOrCreateDirectoryRelative(sd_dir, "/Nintendo/Album");
 }
 
 u64 SDMCFactory::GetSDMCFreeSpace() const {
-    return GetSDMCTotalSpace() - dir->GetSize();
+    return GetSDMCTotalSpace() - sd_dir->GetSize();
 }
 
 u64 SDMCFactory::GetSDMCTotalSpace() const {

--- a/src/core/file_sys/sdmc_factory.h
+++ b/src/core/file_sys/sdmc_factory.h
@@ -21,6 +21,7 @@ public:
 
     ResultVal<VirtualDir> Open() const;
 
+    VirtualDir GetSDMCModificationLoadRoot(u64 title_id) const;
     VirtualDir GetSDMCContentDirectory() const;
 
     RegisteredCache* GetSDMCContents() const;

--- a/src/core/file_sys/sdmc_factory.h
+++ b/src/core/file_sys/sdmc_factory.h
@@ -16,7 +16,7 @@ class PlaceholderCache;
 /// File system interface to the SDCard archive
 class SDMCFactory {
 public:
-    explicit SDMCFactory(VirtualDir dir);
+    explicit SDMCFactory(VirtualDir sd_dir_, VirtualDir sd_mod_dir_);
     ~SDMCFactory();
 
     ResultVal<VirtualDir> Open() const;
@@ -33,7 +33,8 @@ public:
     u64 GetSDMCTotalSpace() const;
 
 private:
-    VirtualDir dir;
+    VirtualDir sd_dir;
+    VirtualDir sd_mod_dir;
 
     std::unique_ptr<RegisteredCache> contents;
     std::unique_ptr<PlaceholderCache> placeholder;

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -706,8 +706,9 @@ FileSys::VirtualDir FileSystemController::GetModificationLoadRoot(u64 title_id) 
 FileSys::VirtualDir FileSystemController::GetSDMCModificationLoadRoot(u64 title_id) const {
     LOG_TRACE(Service_FS, "Opening SDMC mod load root for tid={:016X}", title_id);
 
-    if (sdmc_factory == nullptr)
+    if (sdmc_factory == nullptr) {
         return nullptr;
+    }
 
     return sdmc_factory->GetSDMCModificationLoadRoot(title_id);
 }

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -743,20 +743,23 @@ void FileSystemController::CreateFactories(FileSys::VfsFilesystem& vfs, bool ove
     }
 
     using YuzuPath = Common::FS::YuzuPath;
+    const auto sdmc_dir_path = Common::FS::GetYuzuPath(YuzuPath::SDMCDir);
+    const auto sdmc_load_dir_path = sdmc_dir_path / "atmosphere/contents";
     const auto rw_mode = FileSys::Mode::ReadWrite;
 
     auto nand_directory =
         vfs.OpenDirectory(Common::FS::GetYuzuPathString(YuzuPath::NANDDir), rw_mode);
-    auto sd_directory =
-        vfs.OpenDirectory(Common::FS::GetYuzuPathString(YuzuPath::SDMCDir), rw_mode);
+    auto sd_directory = vfs.OpenDirectory(Common::FS::PathToUTF8String(sdmc_dir_path), rw_mode);
     auto load_directory =
         vfs.OpenDirectory(Common::FS::GetYuzuPathString(YuzuPath::LoadDir), FileSys::Mode::Read);
+    auto sd_load_directory =
+        vfs.OpenDirectory(Common::FS::PathToUTF8String(sdmc_load_dir_path), FileSys::Mode::Read);
     auto dump_directory =
         vfs.OpenDirectory(Common::FS::GetYuzuPathString(YuzuPath::DumpDir), rw_mode);
 
     if (bis_factory == nullptr) {
-        bis_factory =
-            std::make_unique<FileSys::BISFactory>(nand_directory, load_directory, dump_directory);
+        bis_factory = std::make_unique<FileSys::BISFactory>(
+            nand_directory, std::move(load_directory), std::move(dump_directory));
         system.RegisterContentProvider(FileSys::ContentProviderUnionSlot::SysNAND,
                                        bis_factory->GetSystemNANDContents());
         system.RegisterContentProvider(FileSys::ContentProviderUnionSlot::UserNAND,
@@ -769,7 +772,8 @@ void FileSystemController::CreateFactories(FileSys::VfsFilesystem& vfs, bool ove
     }
 
     if (sdmc_factory == nullptr) {
-        sdmc_factory = std::make_unique<FileSys::SDMCFactory>(std::move(sd_directory));
+        sdmc_factory = std::make_unique<FileSys::SDMCFactory>(std::move(sd_directory),
+                                                              std::move(sd_load_directory));
         system.RegisterContentProvider(FileSys::ContentProviderUnionSlot::SDMC,
                                        sdmc_factory->GetSDMCContents());
     }

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -703,6 +703,15 @@ FileSys::VirtualDir FileSystemController::GetModificationLoadRoot(u64 title_id) 
     return bis_factory->GetModificationLoadRoot(title_id);
 }
 
+FileSys::VirtualDir FileSystemController::GetSDMCModificationLoadRoot(u64 title_id) const {
+    LOG_TRACE(Service_FS, "Opening SDMC mod load root for tid={:016X}", title_id);
+
+    if (sdmc_factory == nullptr)
+        return nullptr;
+
+    return sdmc_factory->GetSDMCModificationLoadRoot(title_id);
+}
+
 FileSys::VirtualDir FileSystemController::GetModificationDumpRoot(u64 title_id) const {
     LOG_TRACE(Service_FS, "Opening mod dump root for tid={:016X}", title_id);
 

--- a/src/core/hle/service/filesystem/filesystem.h
+++ b/src/core/hle/service/filesystem/filesystem.h
@@ -115,6 +115,7 @@ public:
     FileSys::VirtualDir GetContentDirectory(ContentStorageId id) const;
     FileSys::VirtualDir GetImageDirectory(ImageDirectoryId id) const;
 
+    FileSys::VirtualDir GetSDMCModificationLoadRoot(u64 title_id) const;
     FileSys::VirtualDir GetModificationLoadRoot(u64 title_id) const;
     FileSys::VirtualDir GetModificationDumpRoot(u64 title_id) const;
 

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -521,7 +521,9 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, const std::stri
     QAction* remove_custom_config = remove_menu->addAction(tr("Remove Custom Configuration"));
     remove_menu->addSeparator();
     QAction* remove_all_content = remove_menu->addAction(tr("Remove All Installed Contents"));
-    QAction* dump_romfs = context_menu.addAction(tr("Dump RomFS"));
+    QMenu* dump_romfs_menu = context_menu.addMenu(tr("Dump RomFS"));
+    QAction* dump_romfs = dump_romfs_menu->addAction(tr("Dump RomFS"));
+    QAction* dump_romfs_sdmc = dump_romfs_menu->addAction(tr("Dump RomFS to SDMC"));
     QAction* copy_tid = context_menu.addAction(tr("Copy Title ID to Clipboard"));
     QAction* navigate_to_gamedb_entry = context_menu.addAction(tr("Navigate to GameDB entry"));
     context_menu.addSeparator();
@@ -570,8 +572,12 @@ void GameList::AddGamePopup(QMenu& context_menu, u64 program_id, const std::stri
     connect(remove_custom_config, &QAction::triggered, [this, program_id, path]() {
         emit RemoveFileRequested(program_id, GameListRemoveTarget::CustomConfiguration, path);
     });
-    connect(dump_romfs, &QAction::triggered,
-            [this, program_id, path]() { emit DumpRomFSRequested(program_id, path); });
+    connect(dump_romfs, &QAction::triggered, [this, program_id, path]() {
+        emit DumpRomFSRequested(program_id, path, DumpRomFSTarget::Normal);
+    });
+    connect(dump_romfs_sdmc, &QAction::triggered, [this, program_id, path]() {
+        emit DumpRomFSRequested(program_id, path, DumpRomFSTarget::SDMC);
+    });
     connect(copy_tid, &QAction::triggered,
             [this, program_id]() { emit CopyTIDRequested(program_id); });
     connect(navigate_to_gamedb_entry, &QAction::triggered, [this, program_id]() {

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -45,6 +45,11 @@ enum class GameListRemoveTarget {
     CustomConfiguration,
 };
 
+enum class DumpRomFSTarget {
+    Normal,
+    SDMC,
+};
+
 enum class InstalledEntryType {
     Game,
     Update,
@@ -92,7 +97,7 @@ signals:
     void RemoveInstalledEntryRequested(u64 program_id, InstalledEntryType type);
     void RemoveFileRequested(u64 program_id, GameListRemoveTarget target,
                              const std::string& game_path);
-    void DumpRomFSRequested(u64 program_id, const std::string& game_path);
+    void DumpRomFSRequested(u64 program_id, const std::string& game_path, DumpRomFSTarget target);
     void CopyTIDRequested(u64 program_id);
     void NavigateToGamedbEntryRequested(u64 program_id,
                                         const CompatibilityList& compatibility_list);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1922,7 +1922,8 @@ void GMainWindow::OnGameListDumpRomFS(u64 program_id, const std::string& game_pa
     if (*romfs_title_id == program_id) {
         const u64 ivfc_offset = loader->ReadRomFSIVFCOffset();
         const FileSys::PatchManager pm{program_id, system.GetFileSystemController(), installed};
-        romfs = pm.PatchRomFS(file, ivfc_offset, FileSys::ContentRecordType::Program);
+        romfs =
+            pm.PatchRomFS(file, ivfc_offset, FileSys::ContentRecordType::Program, nullptr, false);
     } else {
         romfs = installed.GetEntry(*romfs_title_id, FileSys::ContentRecordType::Data)->GetRomFS();
     }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1880,7 +1880,8 @@ void GMainWindow::RemoveCustomConfiguration(u64 program_id, const std::string& g
     }
 }
 
-void GMainWindow::OnGameListDumpRomFS(u64 program_id, const std::string& game_path) {
+void GMainWindow::OnGameListDumpRomFS(u64 program_id, const std::string& game_path,
+                                      DumpRomFSTarget target) {
     const auto failed = [this] {
         QMessageBox::warning(this, tr("RomFS Extraction Failed!"),
                              tr("There was an error copying the RomFS files or the user "
@@ -1908,7 +1909,10 @@ void GMainWindow::OnGameListDumpRomFS(u64 program_id, const std::string& game_pa
         return;
     }
 
-    const auto dump_dir = Common::FS::GetYuzuPath(Common::FS::YuzuPath::DumpDir);
+    const auto dump_dir =
+        target == DumpRomFSTarget::Normal
+            ? Common::FS::GetYuzuPath(Common::FS::YuzuPath::DumpDir)
+            : Common::FS::GetYuzuPath(Common::FS::YuzuPath::SDMCDir) / "atmosphere" / "contents";
     const auto romfs_dir = fmt::format("{:016X}/romfs", *romfs_title_id);
 
     const auto path = Common::FS::PathToUTF8String(dump_dir / romfs_dir);

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -34,6 +34,7 @@ class QProgressDialog;
 class WaitTreeWidget;
 enum class GameListOpenTarget;
 enum class GameListRemoveTarget;
+enum class DumpRomFSTarget;
 enum class InstalledEntryType;
 class GameListPlaceholder;
 
@@ -244,7 +245,7 @@ private slots:
     void OnGameListRemoveInstalledEntry(u64 program_id, InstalledEntryType type);
     void OnGameListRemoveFile(u64 program_id, GameListRemoveTarget target,
                               const std::string& game_path);
-    void OnGameListDumpRomFS(u64 program_id, const std::string& game_path);
+    void OnGameListDumpRomFS(u64 program_id, const std::string& game_path, DumpRomFSTarget target);
     void OnGameListCopyTID(u64 program_id);
     void OnGameListNavigateToGamedbEntry(u64 program_id,
                                          const CompatibilityList& compatibility_list);


### PR DESCRIPTION
This was just a literal shower thought about making it easier to use [Ultimate Mod Manager](https://github.com/ultimate-research/UltimateModManager) on yuzu.

Adds to yuzu's Qt frontend a context menu option to dump the RomFS to either the normal directory, or to a subdirectory in the sdmc data directory (`yuzu/sdmc/atmosphere/contents/[title_id]/romfs`). In core, an extra singular mod is added to each game that has contents in this directory.

So now, to use UMM, it should be as easy as right clicking SSBU -> Dump RomFS -> Dump RomFS to SDMC Directory, then opening UMM and installing your mods, then booting SSBU.