### PR TITLE
update submodule discord-rpc to latest [now deprecated]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,7 +18,7 @@
 	url = https://github.com/libusb/libusb.git
 [submodule "discord-rpc"]
     path = externals/discord-rpc
-    url = https://github.com/discordapp/discord-rpc.git
+    url = https://github.com/discord/discord-rpc.git
 [submodule "Vulkan-Headers"]
     path = externals/Vulkan-Headers
     url = https://github.com/KhronosGroup/Vulkan-Headers.git


### PR DESCRIPTION
This PR updates the discord-rpc submodule to last upstream commit, before it was deprecated in favour of Discord's new GameSDK. Since the new SDK is closed-source, we can't upgrade to it.  

However, Discord RPC still uses the same underlying code for Rich Presence and hence RPC compatibilty is not broken (*yet!*).

The changes from last-updated commit include few minor bugfixes and readme changes.