### PR TITLE
common/fs: Fix file write/append access when file does not exist.

### DIFF
--- a/src/common/fs/file.cpp
+++ b/src/common/fs/file.cpp
@@ -172,23 +172,13 @@ std::string ReadStringFromFile(const std::filesystem::path& path, FileType type)
 
 size_t WriteStringToFile(const std::filesystem::path& path, FileType type,
                          std::string_view string) {
-    if (!IsFile(path)) {
-        return 0;
-    }
-
     IOFile io_file{path, FileAccessMode::Write, type};
-
     return io_file.WriteString(string);
 }
 
 size_t AppendStringToFile(const std::filesystem::path& path, FileType type,
                           std::string_view string) {
-    if (!IsFile(path)) {
-        return 0;
-    }
-
     IOFile io_file{path, FileAccessMode::Append, type};
-
     return io_file.WriteString(string);
 }
 

--- a/src/common/fs/file.h
+++ b/src/common/fs/file.h
@@ -72,6 +72,7 @@ template <typename Path>
 /**
  * Writes a string to a file at path and returns the number of characters successfully written.
  * If a file already exists at path, its contents will be erased.
+ * If a file does not exist at path, it creates and opens a new empty file for writing.
  * If the filesystem object at path is not a file, this function returns 0.
  *
  * @param path Filesystem path
@@ -95,6 +96,7 @@ template <typename Path>
 
 /**
  * Appends a string to a file at path and returns the number of characters successfully written.
+ * If a file does not exist at path, it creates and opens a new empty file for appending.
  * If the filesystem object at path is not a file, this function returns 0.
  *
  * @param path Filesystem path

--- a/src/common/fs/fs.cpp
+++ b/src/common/fs/fs.cpp
@@ -135,9 +135,13 @@ std::shared_ptr<IOFile> FileOpen(const fs::path& path, FileAccessMode mode, File
         return nullptr;
     }
 
-    if (!IsFile(path)) {
-        LOG_ERROR(Common_Filesystem, "Filesystem object at path={} is not a file",
-                  PathToUTF8String(path));
+    const bool needs_existing_file =
+        mode == FileAccessMode::Read || mode == FileAccessMode::ReadWrite;
+    if (needs_existing_file && !IsFile(path)) {
+        LOG_ERROR(Common_Filesystem,
+                  "Filesystem object at path={} is not a file."
+                  "FileAccessMode={} requires a file to exist in order to be accessed",
+                  PathToUTF8String(path), mode);
         return nullptr;
     }
 


### PR DESCRIPTION
This fixes errors when a file is being opened for write/append access, but the file does not exist initially.

These functions were not respecting the FileAccessMode which specify that the file will be created if it does not exist.