### PR TITLE
host_memory: Correct MEM_RESERVE_PLACEHOLDER

### DIFF
--- a/src/common/host_memory.cpp
+++ b/src/common/host_memory.cpp
@@ -34,7 +34,7 @@ constexpr size_t HugePageSize = 0x200000;
 
 // Manually imported for MinGW compatibility
 #ifndef MEM_RESERVE_PLACEHOLDER
-#define MEM_RESERVE_PLACEHOLDER 0x0004000
+#define MEM_RESERVE_PLACEHOLDER 0x00040000
 #endif
 #ifndef MEM_REPLACE_PLACEHOLDER
 #define MEM_REPLACE_PLACEHOLDER 0x00004000


### PR DESCRIPTION
Microsoft defines `MEM_RESERVE_PLACEHOLDER` as `0x00040000` [here](https://docs.microsoft.com/en-us/windows/win32/api/memoryapi/nf-memoryapi-virtualalloc2), but our manually imported version of it drops the last zero.

This fixes fastmem failing to load on MinGW builds.