### PR TITLE
ci: windows: Copy the Qt styles directory when packaging

### DIFF
--- a/.ci/scripts/windows/docker.sh
+++ b/.ci/scripts/windows/docker.sh
@@ -18,19 +18,20 @@ cd ..
 mkdir package
 
 if [ -d "/usr/x86_64-w64-mingw32/lib/qt5/plugins/platforms/" ]; then
-  QT_PLATFORM_DLL_PATH='/usr/x86_64-w64-mingw32/lib/qt5/plugins/platforms/'
+  QT_PLUGINS_PATH='/usr/x86_64-w64-mingw32/lib/qt5/plugins'
 else
   #fallback to qt
-  QT_PLATFORM_DLL_PATH='/usr/x86_64-w64-mingw32/lib/qt/plugins/platforms/'
+  QT_PLUGINS_PATH='/usr/x86_64-w64-mingw32/lib/qt/plugins'
 fi
 
 find build/ -name "yuzu*.exe" -exec cp {} 'package' \;
 
 # copy Qt plugins
 mkdir package/platforms
-cp "${QT_PLATFORM_DLL_PATH}/qwindows.dll" package/platforms/
-cp -rv "${QT_PLATFORM_DLL_PATH}/../mediaservice/" package/
-cp -rv "${QT_PLATFORM_DLL_PATH}/../imageformats/" package/
+cp -v "${QT_PLUGINS_PATH}/platforms/qwindows.dll" package/platforms/
+cp -rv "${QT_PLUGINS_PATH}/mediaservice/" package/
+cp -rv "${QT_PLUGINS_PATH}/imageformats/" package/
+cp -rv "${QT_PLUGINS_PATH}/styles/" package/
 rm -f package/mediaservice/*d.dll
 
 for i in package/*.exe; do


### PR DESCRIPTION
Qt can make use of `qwindowsvistastyle.dll` if present, and our MinGW container has the library, but it was not being copied during the packaging process. Thus, yuzu looked like a Windows 98 application when using the MinGW PR-verify artifacts.

This copies over the DLL during packaging, for that sweet-sweet Windows Vista style.

In addition, set the Qt plugins path instead of the plugins/platforms path. This way we can use the directory directly, rather than appending a `..` every time we need something just outside of it.