### PR TITLE
GPU Memory Manager - Correct handling of non continuous backing memory.

### DIFF
--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -127,8 +127,13 @@ void MemoryManager::SetPageEntry(GPUVAddr gpu_addr, PageEntry page_entry, std::s
 
     //// Lock the new page
     // TryLockPage(page_entry, size);
+    auto& current_page = page_table[PageEntryIndex(gpu_addr)];
+    if (current_page.IsValid() != page_entry.IsValid() ||
+        current_page.ToAddress() != page_entry.ToAddress()) {
+        rasterizer->ModifyGPUMemory(gpu_addr, size);
+    }
 
-    page_table[PageEntryIndex(gpu_addr)] = page_entry;
+    current_page = page_entry;
 }
 
 std::optional<GPUVAddr> MemoryManager::FindFreeRange(std::size_t size, std::size_t align,

--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -80,7 +80,6 @@ void MemoryManager::Unmap(GPUVAddr gpu_addr, std::size_t size) {
         rasterizer->UnmapMemory(*cpu_addr, map.second);
     }
 
-
     UpdateRange(gpu_addr, PageEntry::State::Unmapped, size);
 }
 

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -76,6 +76,8 @@ public:
 
     [[nodiscard]] std::optional<VAddr> GpuToCpuAddress(GPUVAddr addr) const;
 
+    [[nodiscard]] std::optional<VAddr> GpuToCpuAddress(GPUVAddr addr, std::size_t size) const;
+
     template <typename T>
     [[nodiscard]] T Read(GPUVAddr addr) const;
 
@@ -115,6 +117,24 @@ public:
      * IsGranularRange checks if a gpu region can be simply read with a pointer.
      */
     [[nodiscard]] bool IsGranularRange(GPUVAddr gpu_addr, std::size_t size) const;
+
+    /**
+     * IsContinousRange checks if a gpu region is mapped by a single range of cpu addresses.
+     */
+    [[nodiscard]] bool IsContinousRange(GPUVAddr gpu_addr, std::size_t size) const;
+
+    /**
+     * IsFullyMappedRange checks if a gpu region is mapped entirely.
+     */
+    [[nodiscard]] bool IsFullyMappedRange(GPUVAddr gpu_addr, std::size_t size) const;
+
+    /**
+     * GetSubmappedRange returns a vector with all the subranges of cpu addresses mapped beneath.
+     * if the region is continous, a single pair will be returned. If it's unmapped, an empty vector
+     * will be returned;
+     */
+    std::vector<std::pair<GPUVAddr, std::size_t>> GetSubmappedRange(GPUVAddr gpu_addr,
+                                                                    std::size_t size) const;
 
     [[nodiscard]] GPUVAddr Map(VAddr cpu_addr, GPUVAddr gpu_addr, std::size_t size);
     [[nodiscard]] GPUVAddr MapAllocate(VAddr cpu_addr, std::size_t size, std::size_t align);

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -114,22 +114,22 @@ public:
     void WriteBlockUnsafe(GPUVAddr gpu_dest_addr, const void* src_buffer, std::size_t size);
 
     /**
-     * IsGranularRange checks if a gpu region can be simply read with a pointer.
+     * Checks if a gpu region can be simply read with a pointer.
      */
     [[nodiscard]] bool IsGranularRange(GPUVAddr gpu_addr, std::size_t size) const;
 
     /**
-     * IsContinousRange checks if a gpu region is mapped by a single range of cpu addresses.
+     * Checks if a gpu region is mapped by a single range of cpu addresses.
      */
     [[nodiscard]] bool IsContinousRange(GPUVAddr gpu_addr, std::size_t size) const;
 
     /**
-     * IsFullyMappedRange checks if a gpu region is mapped entirely.
+     * Checks if a gpu region is mapped entirely.
      */
     [[nodiscard]] bool IsFullyMappedRange(GPUVAddr gpu_addr, std::size_t size) const;
 
     /**
-     * GetSubmappedRange returns a vector with all the subranges of cpu addresses mapped beneath.
+     * Returns a vector with all the subranges of cpu addresses mapped beneath.
      * if the region is continous, a single pair will be returned. If it's unmapped, an empty vector
      * will be returned;
      */

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -87,6 +87,9 @@ public:
     /// Unmap memory range
     virtual void UnmapMemory(VAddr addr, u64 size) = 0;
 
+    /// Unmap memory range
+    virtual void ModifyGPUMemory(GPUVAddr addr, u64 size) = 0;
+
     /// Notify rasterizer that any caches of the specified region should be flushed to Switch memory
     /// and invalidated
     virtual void FlushAndInvalidateRegion(VAddr addr, u64 size) = 0;

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -87,7 +87,7 @@ public:
     /// Unmap memory range
     virtual void UnmapMemory(VAddr addr, u64 size) = 0;
 
-    /// Unmap memory range
+    /// Remap GPU memory range. This means underneath backing memory changed
     virtual void ModifyGPUMemory(GPUVAddr addr, u64 size) = 0;
 
     /// Notify rasterizer that any caches of the specified region should be flushed to Switch memory

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -611,6 +611,13 @@ void RasterizerOpenGL::UnmapMemory(VAddr addr, u64 size) {
     shader_cache.OnCPUWrite(addr, size);
 }
 
+void RasterizerOpenGL::ModifyGPUMemory(GPUVAddr addr, u64 size) {
+    {
+        std::scoped_lock lock{texture_cache.mutex};
+        texture_cache.UnmapGPUMemory(addr, size);
+    }
+}
+
 void RasterizerOpenGL::SignalSemaphore(GPUVAddr addr, u32 value) {
     if (!gpu.IsAsync()) {
         gpu_memory.Write<u32>(addr, value);

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -80,6 +80,7 @@ public:
     void OnCPUWrite(VAddr addr, u64 size) override;
     void SyncGuestHost() override;
     void UnmapMemory(VAddr addr, u64 size) override;
+    void ModifyGPUMemory(GPUVAddr addr, u64 size) override;
     void SignalSemaphore(GPUVAddr addr, u32 value) override;
     void SignalSyncPoint(u32 value) override;
     void ReleaseFences() override;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -557,6 +557,13 @@ void RasterizerVulkan::UnmapMemory(VAddr addr, u64 size) {
     pipeline_cache.OnCPUWrite(addr, size);
 }
 
+void RasterizerVulkan::ModifyGPUMemory(GPUVAddr addr, u64 size) {
+    {
+        std::scoped_lock lock{texture_cache.mutex};
+        texture_cache.UnmapGPUMemory(addr, size);
+    }
+}
+
 void RasterizerVulkan::SignalSemaphore(GPUVAddr addr, u32 value) {
     if (!gpu.IsAsync()) {
         gpu_memory.Write<u32>(addr, value);

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -72,6 +72,7 @@ public:
     void OnCPUWrite(VAddr addr, u64 size) override;
     void SyncGuestHost() override;
     void UnmapMemory(VAddr addr, u64 size) override;
+    void ModifyGPUMemory(GPUVAddr addr, u64 size) override;
     void SignalSemaphore(GPUVAddr addr, u32 value) override;
     void SignalSyncPoint(u32 value) override;
     void ReleaseFences() override;

--- a/src/video_core/texture_cache/image_base.cpp
+++ b/src/video_core/texture_cache/image_base.cpp
@@ -69,6 +69,9 @@ ImageBase::ImageBase(const ImageInfo& info_, GPUVAddr gpu_addr_, VAddr cpu_addr_
     }
 }
 
+ImageMapView::ImageMapView(GPUVAddr gpu_addr_, VAddr cpu_addr_, size_t size_, ImageId image_id_)
+    : gpu_addr{gpu_addr_}, cpu_addr{cpu_addr_}, size{size_}, image_id{image_id_} {}
+
 std::optional<SubresourceBase> ImageBase::TryFindBase(GPUVAddr other_addr) const noexcept {
     if (other_addr < gpu_addr) {
         // Subresource address can't be lower than the base

--- a/src/video_core/texture_cache/image_base.h
+++ b/src/video_core/texture_cache/image_base.h
@@ -57,6 +57,12 @@ struct ImageBase {
         return cpu_addr < overlap_end && overlap_cpu_addr < cpu_addr_end;
     }
 
+    [[nodiscard]] bool OverlapsGPU(GPUVAddr overlap_gpu_addr, size_t overlap_size) const noexcept {
+        const VAddr overlap_end = overlap_gpu_addr + overlap_size;
+        const GPUVAddr gpu_addr_end = gpu_addr + guest_size_bytes;
+        return gpu_addr < overlap_end && overlap_gpu_addr < gpu_addr_end;
+    }
+
     void CheckBadOverlapState();
     void CheckAliasState();
 
@@ -84,6 +90,8 @@ struct ImageBase {
 
     std::vector<AliasedImage> aliased_images;
     std::vector<ImageId> overlapping_images;
+    ImageMapId map_view_id{};
+    bool is_sparse{};
 };
 
 struct ImageAllocBase {

--- a/src/video_core/texture_cache/image_base.h
+++ b/src/video_core/texture_cache/image_base.h
@@ -29,10 +29,10 @@ enum class ImageFlagBits : u32 {
     Sparse = 1 << 9,      ///< Image has non continous submemory.
 
     // Garbage Collection Flags
-    BadOverlap = 1 << 10,///< This image overlaps other but doesn't fit, has higher
-                         ///< garbage collection priority
-    Alias = 1 << 11,     ///< This image has aliases and has priority on garbage
-                         ///< collection
+    BadOverlap = 1 << 10, ///< This image overlaps other but doesn't fit, has higher
+                          ///< garbage collection priority
+    Alias = 1 << 11,      ///< This image has aliases and has priority on garbage
+                          ///< collection
 };
 DECLARE_ENUM_FLAG_OPERATORS(ImageFlagBits)
 

--- a/src/video_core/texture_cache/image_base.h
+++ b/src/video_core/texture_cache/image_base.h
@@ -25,11 +25,12 @@ enum class ImageFlagBits : u32 {
     Strong = 1 << 5,      ///< Exists in the image table, the dimensions are can be trusted
     Registered = 1 << 6,  ///< True when the image is registered
     Picked = 1 << 7,      ///< Temporary flag to mark the image as picked
+    Remapped = 1 << 8,    ///< Image has been remapped.
 
     // Garbage Collection Flags
-    BadOverlap = 1 << 8, ///< This image overlaps other but doesn't fit, has higher
+    BadOverlap = 1 << 9, ///< This image overlaps other but doesn't fit, has higher
                          ///< garbage collection priority
-    Alias = 1 << 9,      ///< This image has aliases and has priority on garbage
+    Alias = 1 << 10,     ///< This image has aliases and has priority on garbage
                          ///< collection
 };
 DECLARE_ENUM_FLAG_OPERATORS(ImageFlagBits)

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -1169,7 +1169,12 @@ ImageId TextureCache<P>::JoinImages(const ImageInfo& info, GPUVAddr gpu_addr, VA
     ForEachImageInRegion(cpu_addr, size_bytes, region_check);
     const auto region_check_gpu = [&](ImageId overlap_id, ImageBase& overlap) {
         if (!overlaps_found.contains(overlap_id)) {
-            ignore_textures.insert(overlap_id);
+            if (True(overlap.flags & ImageFlagBits::Remapped)) {
+                ignore_textures.insert(overlap_id);
+            }
+            if (overlap.gpu_addr == gpu_addr && overlap.guest_size_bytes == size_bytes) {
+                ignore_textures.insert(overlap_id);
+            }
         }
     };
     ForEachSparseImageInRegion(gpu_addr, size_bytes, region_check_gpu);

--- a/src/video_core/texture_cache/types.h
+++ b/src/video_core/texture_cache/types.h
@@ -16,6 +16,7 @@ constexpr size_t MAX_MIP_LEVELS = 14;
 constexpr SlotId CORRUPT_ID{0xfffffffe};
 
 using ImageId = SlotId;
+using ImageMapId = SlotId;
 using ImageViewId = SlotId;
 using ImageAllocId = SlotId;
 using SamplerId = SlotId;

--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -664,6 +664,16 @@ LevelArray CalculateMipLevelOffsets(const ImageInfo& info) noexcept {
     return offsets;
 }
 
+LevelArray CalculateMipLevelSizes(const ImageInfo& info) noexcept {
+    const u32 num_levels = info.resources.levels;
+    const LevelInfo level_info = MakeLevelInfo(info);
+    LevelArray sizes{};
+    for (u32 level = 0; level < num_levels; ++level) {
+        sizes[level] = CalculateLevelSize(level_info, level);
+    }
+    return sizes;
+}
+
 std::vector<u32> CalculateSliceOffsets(const ImageInfo& info) {
     ASSERT(info.type == ImageType::e3D);
     std::vector<u32> offsets;
@@ -776,14 +786,37 @@ std::vector<ImageCopy> MakeShrinkImageCopies(const ImageInfo& dst, const ImageIn
     return copies;
 }
 
-bool IsValidAddress(const Tegra::MemoryManager& gpu_memory, const TICEntry& config) {
-    if (config.Address() == 0) {
+bool IsValidAddress(const Tegra::MemoryManager& gpu_memory, GPUVAddr gpu_addr) {
+    if (gpu_addr == 0) {
         return false;
     }
-    if (config.Address() > (u64(1) << 48)) {
+    if (gpu_addr > (u64(1) << 48)) {
         return false;
     }
-    return gpu_memory.GpuToCpuAddress(config.Address()).has_value();
+    const auto cpu_addr = gpu_memory.GpuToCpuAddress(gpu_addr);
+    return cpu_addr.has_value() && *cpu_addr != 0;
+}
+
+bool IsValidEntry(const Tegra::MemoryManager& gpu_memory, const TICEntry& config) {
+    const GPUVAddr gpu_addr = config.Address();
+    if (IsValidAddress(gpu_memory, gpu_addr)) {
+        return true;
+    }
+    if (!config.IsBlockLinear()) {
+        return false;
+    }
+    const size_t levels = config.max_mip_level + 1;
+    if (levels <= 1) {
+        return false;
+    }
+    const ImageInfo info{config};
+    const LevelArray offsets = CalculateMipLevelOffsets(info);
+    for (size_t level = 1; level < levels; level++) {
+        if (IsValidAddress(gpu_memory, static_cast<GPUVAddr>(gpu_addr + offsets[level]))) {
+            return true;
+        }
+    }
+    return false;
 }
 
 std::vector<BufferImageCopy> UnswizzleImage(Tegra::MemoryManager& gpu_memory, GPUVAddr gpu_addr,

--- a/src/video_core/texture_cache/util.h
+++ b/src/video_core/texture_cache/util.h
@@ -57,8 +57,6 @@ struct OverlapResult {
                                                            const ImageInfo& src,
                                                            SubresourceBase base);
 
-[[nodiscard]] bool IsValidAddress(const Tegra::MemoryManager& gpu_memory, GPUVAddr gpu_addr);
-
 [[nodiscard]] bool IsValidEntry(const Tegra::MemoryManager& gpu_memory, const TICEntry& config);
 
 [[nodiscard]] std::vector<BufferImageCopy> UnswizzleImage(Tegra::MemoryManager& gpu_memory,

--- a/src/video_core/texture_cache/util.h
+++ b/src/video_core/texture_cache/util.h
@@ -40,6 +40,8 @@ struct OverlapResult {
 
 [[nodiscard]] LevelArray CalculateMipLevelOffsets(const ImageInfo& info) noexcept;
 
+[[nodiscard]] LevelArray CalculateMipLevelSizes(const ImageInfo& info) noexcept;
+
 [[nodiscard]] std::vector<u32> CalculateSliceOffsets(const ImageInfo& info);
 
 [[nodiscard]] std::vector<SubresourceBase> CalculateSliceSubresources(const ImageInfo& info);
@@ -55,7 +57,9 @@ struct OverlapResult {
                                                            const ImageInfo& src,
                                                            SubresourceBase base);
 
-[[nodiscard]] bool IsValidAddress(const Tegra::MemoryManager& gpu_memory, const TICEntry& config);
+[[nodiscard]] bool IsValidAddress(const Tegra::MemoryManager& gpu_memory, GPUVAddr gpu_addr);
+
+[[nodiscard]] bool IsValidEntry(const Tegra::MemoryManager& gpu_memory, const TICEntry& config);
 
 [[nodiscard]] std::vector<BufferImageCopy> UnswizzleImage(Tegra::MemoryManager& gpu_memory,
                                                           GPUVAddr gpu_addr, const ImageInfo& info,


### PR DESCRIPTION
This PR takes care of addressing the issues about resources that are partially mapped, uncontinuously mapped or not mapped at all. This should improve the tracking of such resources in the texture cache.

As a consequence: this fixes texture streaming in UE4 games (Oceanhorn 2, Spyro, Bravely Default 2, etc). Have in mind that most UE4 still need the fixes of Hades. 