### PR TITLE
Update dynarmic and add new unsafe CPU option.

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -122,6 +122,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.cpu_accuracy.SetGlobal(true);
     values.cpuopt_unsafe_unfuse_fma.SetGlobal(true);
     values.cpuopt_unsafe_reduce_fp_error.SetGlobal(true);
+    values.cpuopt_unsafe_ignore_standard_fpcr.SetGlobal(true);
     values.cpuopt_unsafe_inaccurate_nan.SetGlobal(true);
     values.cpuopt_unsafe_fastmem_check.SetGlobal(true);
 

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -129,6 +129,7 @@ struct Values {
 
     Setting<bool> cpuopt_unsafe_unfuse_fma;
     Setting<bool> cpuopt_unsafe_reduce_fp_error;
+    Setting<bool> cpuopt_unsafe_ignore_standard_fpcr;
     Setting<bool> cpuopt_unsafe_inaccurate_nan;
     Setting<bool> cpuopt_unsafe_fastmem_check;
 

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -186,6 +186,9 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
         if (Settings::values.cpuopt_unsafe_reduce_fp_error.GetValue()) {
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_ReducedErrorFP;
         }
+        if (Settings::values.cpuopt_unsafe_ignore_standard_fpcr.GetValue()) {
+            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreStandardFPCRValue;
+        }
         if (Settings::values.cpuopt_unsafe_inaccurate_nan.GetValue()) {
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
         }

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -756,6 +756,8 @@ void Config::ReadCpuValues() {
                       QStringLiteral("cpuopt_unsafe_unfuse_fma"), true);
     ReadSettingGlobal(Settings::values.cpuopt_unsafe_reduce_fp_error,
                       QStringLiteral("cpuopt_unsafe_reduce_fp_error"), true);
+    ReadSettingGlobal(Settings::values.cpuopt_unsafe_ignore_standard_fpcr,
+                      QStringLiteral("cpuopt_unsafe_ignore_standard_fpcr"), true);
     ReadSettingGlobal(Settings::values.cpuopt_unsafe_inaccurate_nan,
                       QStringLiteral("cpuopt_unsafe_inaccurate_nan"), true);
     ReadSettingGlobal(Settings::values.cpuopt_unsafe_fastmem_check,
@@ -1339,6 +1341,8 @@ void Config::SaveCpuValues() {
                        Settings::values.cpuopt_unsafe_unfuse_fma, true);
     WriteSettingGlobal(QStringLiteral("cpuopt_unsafe_reduce_fp_error"),
                        Settings::values.cpuopt_unsafe_reduce_fp_error, true);
+    WriteSettingGlobal(QStringLiteral("cpuopt_unsafe_ignore_standard_fpcr"),
+                       Settings::values.cpuopt_unsafe_ignore_standard_fpcr, true);
     WriteSettingGlobal(QStringLiteral("cpuopt_unsafe_inaccurate_nan"),
                        Settings::values.cpuopt_unsafe_inaccurate_nan, true);
     WriteSettingGlobal(QStringLiteral("cpuopt_unsafe_fastmem_check"),

--- a/src/yuzu/configuration/configure_cpu.cpp
+++ b/src/yuzu/configuration/configure_cpu.cpp
@@ -34,12 +34,15 @@ void ConfigureCpu::SetConfiguration() {
     ui->accuracy->setEnabled(runtime_lock);
     ui->cpuopt_unsafe_unfuse_fma->setEnabled(runtime_lock);
     ui->cpuopt_unsafe_reduce_fp_error->setEnabled(runtime_lock);
+    ui->cpuopt_unsafe_ignore_standard_fpcr->setEnabled(runtime_lock);
     ui->cpuopt_unsafe_inaccurate_nan->setEnabled(runtime_lock);
     ui->cpuopt_unsafe_fastmem_check->setEnabled(runtime_lock);
 
     ui->cpuopt_unsafe_unfuse_fma->setChecked(Settings::values.cpuopt_unsafe_unfuse_fma.GetValue());
     ui->cpuopt_unsafe_reduce_fp_error->setChecked(
         Settings::values.cpuopt_unsafe_reduce_fp_error.GetValue());
+    ui->cpuopt_unsafe_ignore_standard_fpcr->setChecked(
+        Settings::values.cpuopt_unsafe_ignore_standard_fpcr.GetValue());
     ui->cpuopt_unsafe_inaccurate_nan->setChecked(
         Settings::values.cpuopt_unsafe_inaccurate_nan.GetValue());
     ui->cpuopt_unsafe_fastmem_check->setChecked(
@@ -84,6 +87,9 @@ void ConfigureCpu::ApplyConfiguration() {
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.cpuopt_unsafe_reduce_fp_error,
                                              ui->cpuopt_unsafe_reduce_fp_error,
                                              cpuopt_unsafe_reduce_fp_error);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.cpuopt_unsafe_ignore_standard_fpcr,
+                                             ui->cpuopt_unsafe_ignore_standard_fpcr,
+                                             cpuopt_unsafe_ignore_standard_fpcr);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.cpuopt_unsafe_inaccurate_nan,
                                              ui->cpuopt_unsafe_inaccurate_nan,
                                              cpuopt_unsafe_inaccurate_nan);
@@ -137,6 +143,9 @@ void ConfigureCpu::SetupPerGameUI() {
     ConfigurationShared::SetColoredTristate(ui->cpuopt_unsafe_reduce_fp_error,
                                             Settings::values.cpuopt_unsafe_reduce_fp_error,
                                             cpuopt_unsafe_reduce_fp_error);
+    ConfigurationShared::SetColoredTristate(ui->cpuopt_unsafe_ignore_standard_fpcr,
+                                            Settings::values.cpuopt_unsafe_ignore_standard_fpcr,
+                                            cpuopt_unsafe_ignore_standard_fpcr);
     ConfigurationShared::SetColoredTristate(ui->cpuopt_unsafe_inaccurate_nan,
                                             Settings::values.cpuopt_unsafe_inaccurate_nan,
                                             cpuopt_unsafe_inaccurate_nan);

--- a/src/yuzu/configuration/configure_cpu.h
+++ b/src/yuzu/configuration/configure_cpu.h
@@ -40,6 +40,7 @@ private:
 
     ConfigurationShared::CheckState cpuopt_unsafe_unfuse_fma;
     ConfigurationShared::CheckState cpuopt_unsafe_reduce_fp_error;
+    ConfigurationShared::CheckState cpuopt_unsafe_ignore_standard_fpcr;
     ConfigurationShared::CheckState cpuopt_unsafe_inaccurate_nan;
     ConfigurationShared::CheckState cpuopt_unsafe_fastmem_check;
 };

--- a/src/yuzu/configuration/configure_cpu.ui
+++ b/src/yuzu/configuration/configure_cpu.ui
@@ -112,6 +112,18 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="cpuopt_unsafe_ignore_standard_fpcr">
+          <property name="toolTip">
+           <string>
+            &lt;div&gt;This option improves the speed of 32 bits ASIMD floating-point functions by running with incorrect rounding modes.&lt;/div&gt;
+           </string>
+          </property>
+          <property name="text">
+           <string>Faster ASIMD instructions (32 bits only)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QCheckBox" name="cpuopt_unsafe_inaccurate_nan">
           <property name="toolTip">
            <string>


### PR DESCRIPTION
This PR updates dynarmic and adds an option to loose the rounding mode on ASIMD instructions (32 bits).