### PR TITLE
nvhost-as-gpu: correct Remap method when no object is present.

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_as_gpu.cpp
@@ -146,6 +146,14 @@ NvResult nvhost_as_gpu::Remap(const std::vector<u8>& input, std::vector<u8>& out
         LOG_DEBUG(Service_NVDRV, "remap entry, offset=0x{:X} handle=0x{:X} pages=0x{:X}",
                   entry.offset, entry.nvmap_handle, entry.pages);
 
+        if (entry.nvmap_handle == 0) {
+            // If nvmap handle is null, we should unmap instead.
+            const auto offset{static_cast<GPUVAddr>(entry.offset) << 0x10};
+            const auto size{static_cast<u64>(entry.pages) << 0x10};
+            system.GPU().MemoryManager().Unmap(offset, size);
+            continue;
+        }
+
         const auto object{nvmap_dev->GetObject(entry.nvmap_handle)};
         if (!object) {
             LOG_CRITICAL(Service_NVDRV, "invalid nvmap_handle={:X}", entry.nvmap_handle);

--- a/src/core/hle/service/nvdrv/devices/nvmap.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvmap.cpp
@@ -11,11 +11,7 @@
 
 namespace Service::Nvidia::Devices {
 
-nvmap::nvmap(Core::System& system_) : nvdevice{system_} {
-    // Handle 0 appears to be used when remapping, so we create a placeholder empty nvmap object to
-    // represent this.
-    CreateObject(0);
-}
+nvmap::nvmap(Core::System& system_) : nvdevice{system_} {}
 
 nvmap::~nvmap() = default;
 

--- a/src/core/hle/service/nvdrv/devices/nvmap.h
+++ b/src/core/hle/service/nvdrv/devices/nvmap.h
@@ -56,10 +56,10 @@ public:
 
 private:
     /// Id to use for the next handle that is created.
-    u32 next_handle = 0;
+    u32 next_handle = 1;
 
     /// Id to use for the next object that is created.
-    u32 next_id = 0;
+    u32 next_id = 1;
 
     /// Mapping of currently allocated handles to the objects they represent.
     std::unordered_map<u32, std::shared_ptr<Object>> handles;

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -6,6 +6,7 @@
 
 #include <map>
 #include <optional>
+#include <set>
 #include <vector>
 
 #include "common/common_types.h"
@@ -155,6 +156,13 @@ private:
 
     void FlushRegion(GPUVAddr gpu_addr, size_t size) const;
 
+    void InsertRange(GPUVAddr gpu_addr, size_t size);
+    void RemoveRange(GPUVAddr gpu_addr, size_t size);
+
+    // For debugging only
+    bool IsFullyMapped(GPUVAddr gpu_addr, size_t size) const;
+    bool IsFullyUnmapped(GPUVAddr gpu_addr, size_t size) const;
+
     [[nodiscard]] static constexpr std::size_t PageEntryIndex(GPUVAddr gpu_addr) {
         return (gpu_addr >> page_bits) & page_table_mask;
     }
@@ -175,8 +183,22 @@ private:
 
     std::vector<PageEntry> page_table;
 
-    using MapRange = std::pair<GPUVAddr, size_t>;
-    std::vector<MapRange> map_ranges;
+    struct MemoryRegion {
+        MemoryRegion();
+        MemoryRegion(GPUVAddr gpu_addr, size_t size);
+
+        bool operator<(const MemoryRegion& other) const {
+            return address < other.address;
+        }
+
+        bool operator==(const MemoryRegion&) const = default;
+        bool operator!=(const MemoryRegion&) const = default;
+
+        GPUVAddr address{};
+        size_t size{};
+    };
+
+    std::set<MemoryRegion> map_ranges;
 
     std::vector<std::pair<VAddr, std::size_t>> cache_invalidate_queue;
 };


### PR DESCRIPTION
Special thanks to ByLaws from Skyline-emu for pointing this out.