### PR TITLE
main: Add GPU Vendor name to running title bar

### DIFF
--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -42,6 +42,8 @@ public:
 
     [[nodiscard]] virtual RasterizerInterface* ReadRasterizer() = 0;
 
+    [[nodiscard]] virtual std::string GetDeviceVendor() const = 0;
+
     // Getter/setter functions:
     // ------------------------
 

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -282,20 +282,45 @@ std::string Device::GetVendorName() const {
     if (vendor_name == "ATI Technologies Inc.") {
         return "AMD";
     }
-    if (vendor_name == "Intel" || vendor_name == "Intel Open Source Technology Center") {
+    if (vendor_name == "Intel") {
+        // For Mesa, `Intel` is an overloaded vendor string that could mean crocus or iris.
+        // Simply return `INTEL` for those as well as the Windows driver.
         return "INTEL";
     }
+    if (vendor_name == "Intel Open Source Technology Center") {
+        return "I965";
+    }
     if (vendor_name == "Mesa Project") {
-        return "MESA";
+        return "I915";
     }
     if (vendor_name == "Mesa/X.org") {
-        return "LLVMPIPE";
+        // This vendor string is overloaded between llvmpipe, softpipe, and virgl, so just return
+        // MESA instead of one of those driver names.
+        return "MESA";
     }
     if (vendor_name == "AMD") {
         return "RADEONSI";
     }
     if (vendor_name == "nouveau") {
         return "NOUVEAU";
+    }
+    if (vendor_name == "X.Org") {
+        return "R600";
+    }
+    if (vendor_name == "Collabora Ltd") {
+        return "ZINK";
+    }
+    if (vendor_name == "Intel Corporation") {
+        return "OPENSWR";
+    }
+    if (vendor_name == "Microsoft Corporation") {
+        return "D3D12";
+    }
+    if (vendor_name == "NVIDIA") {
+        // Mesa's tegra driver reports `NVIDIA`. Only present in this list because the default
+        // strategy would have returned `NVIDIA` here for this driver, the same result as the
+        // proprietary driver.
+        return "TEGRA";
     }
     return vendor_name;
 }

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -202,13 +202,13 @@ Device::Device() {
         LOG_ERROR(Render_OpenGL, "OpenGL 4.6 is not available");
         throw std::runtime_error{"Insufficient version"};
     }
-    const std::string_view vendor = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
+    vendor_name = reinterpret_cast<const char*>(glGetString(GL_VENDOR));
     const std::string_view version = reinterpret_cast<const char*>(glGetString(GL_VERSION));
     const std::vector extensions = GetExtensions();
 
-    const bool is_nvidia = vendor == "NVIDIA Corporation";
-    const bool is_amd = vendor == "ATI Technologies Inc.";
-    const bool is_intel = vendor == "Intel";
+    const bool is_nvidia = vendor_name == "NVIDIA Corporation";
+    const bool is_amd = vendor_name == "ATI Technologies Inc.";
+    const bool is_intel = vendor_name == "Intel";
 
 #ifdef __unix__
     const bool is_linux = true;
@@ -273,6 +273,31 @@ Device::Device() {
     if (Settings::values.use_asynchronous_shaders.GetValue() && !use_asynchronous_shaders) {
         LOG_WARNING(Render_OpenGL, "Asynchronous shader compilation enabled but not supported");
     }
+}
+
+std::string Device::GetVendorName() const {
+    if (vendor_name == "NVIDIA Corporation") {
+        return "NVIDIA";
+    }
+    if (vendor_name == "ATI Technologies Inc.") {
+        return "AMD";
+    }
+    if (vendor_name == "Intel" || vendor_name == "Intel Open Source Technology Center") {
+        return "INTEL";
+    }
+    if (vendor_name == "Mesa Project") {
+        return "MESA";
+    }
+    if (vendor_name == "Mesa/X.org") {
+        return "LLVMPIPE";
+    }
+    if (vendor_name == "AMD") {
+        return "RADEONSI";
+    }
+    if (vendor_name == "nouveau") {
+        return "NOUVEAU";
+    }
+    return vendor_name;
 }
 
 Device::Device(std::nullptr_t) {

--- a/src/video_core/renderer_opengl/gl_device.h
+++ b/src/video_core/renderer_opengl/gl_device.h
@@ -22,6 +22,8 @@ public:
     explicit Device();
     explicit Device(std::nullptr_t);
 
+    [[nodiscard]] std::string GetVendorName() const;
+
     u32 GetMaxUniformBuffers(Tegra::Engines::ShaderType shader_type) const noexcept {
         return max_uniform_buffers[static_cast<std::size_t>(shader_type)];
     }
@@ -130,6 +132,7 @@ private:
     static bool TestVariableAoffi();
     static bool TestPreciseBug();
 
+    std::string vendor_name;
     std::array<u32, Tegra::Engines::MaxShaderTypes> max_uniform_buffers{};
     std::array<BaseBindings, Tegra::Engines::MaxShaderTypes> base_bindings{};
     size_t uniform_buffer_alignment{};

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -70,6 +70,10 @@ public:
         return &rasterizer;
     }
 
+    [[nodiscard]] std::string GetDeviceVendor() const override {
+        return device.GetVendorName();
+    }
+
 private:
     /// Initializes the OpenGL state and creates persistent objects.
     void InitOpenGLObjects();

--- a/src/video_core/renderer_vulkan/renderer_vulkan.h
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.h
@@ -47,6 +47,10 @@ public:
         return &rasterizer;
     }
 
+    [[nodiscard]] std::string GetDeviceVendor() const override {
+        return device.GetDriverName();
+    }
+
 private:
     void Report() const;
 

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -531,6 +531,27 @@ bool Device::IsFormatSupported(VkFormat wanted_format, VkFormatFeatureFlags want
     return (supported_usage & wanted_usage) == wanted_usage;
 }
 
+std::string Device::GetDriverName() const {
+    switch (driver_id) {
+    case VK_DRIVER_ID_AMD_PROPRIETARY:
+        return "AMD";
+    case VK_DRIVER_ID_AMD_OPEN_SOURCE:
+        return "AMDVLK";
+    case VK_DRIVER_ID_MESA_RADV:
+        return "RADV";
+    case VK_DRIVER_ID_NVIDIA_PROPRIETARY:
+        return "NVIDIA";
+    case VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS:
+        return "INTEL";
+    case VK_DRIVER_ID_INTEL_OPEN_SOURCE_MESA:
+        return "ANV";
+    case VK_DRIVER_ID_MESA_LLVMPIPE:
+        return "LAVAPIPE";
+    default:
+        return vendor_name;
+    }
+}
+
 void Device::CheckSuitability(bool requires_swapchain) const {
     std::bitset<REQUIRED_EXTENSIONS.size()> available_extensions;
     bool has_swapchain = false;

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -45,6 +45,9 @@ public:
     /// Reports a shader to Nsight Aftermath.
     void SaveShader(const std::vector<u32>& spirv) const;
 
+    /// Returns the name of the VkDriverId reported from Vulkan.
+    std::string GetDriverName() const;
+
     /// Returns the dispatch loader with direct function pointers of the device.
     const vk::DeviceDispatch& GetDispatchLoader() const {
         return dld;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -104,6 +104,7 @@ static FileSys::VirtualFile VfsDirectoryCreateFileWrapper(const FileSys::Virtual
 #include "input_common/main.h"
 #include "util/overlay_dialog.h"
 #include "video_core/gpu.h"
+#include "video_core/renderer_base.h"
 #include "video_core/shader_notify.h"
 #include "yuzu/about_dialog.h"
 #include "yuzu/bootmanager.h"
@@ -1418,7 +1419,8 @@ void GMainWindow::BootGame(const QString& filename, std::size_t program_index, S
             std::filesystem::path{filename.toStdU16String()}.filename());
     }
     LOG_INFO(Frontend, "Booting game: {:016X} | {} | {}", title_id, title_name, title_version);
-    UpdateWindowTitle(title_name, title_version);
+    const auto gpu_vendor = system.GPU().Renderer().GetDeviceVendor();
+    UpdateWindowTitle(title_name, title_version, gpu_vendor);
 
     loading_screen->Prepare(system.GetAppLoader());
     loading_screen->show();
@@ -2847,8 +2849,8 @@ void GMainWindow::MigrateConfigFiles() {
     }
 }
 
-void GMainWindow::UpdateWindowTitle(const std::string& title_name,
-                                    const std::string& title_version) {
+void GMainWindow::UpdateWindowTitle(std::string_view title_name, std::string_view title_version,
+                                    std::string_view gpu_vendor) {
     const auto branch_name = std::string(Common::g_scm_branch);
     const auto description = std::string(Common::g_scm_desc);
     const auto build_id = std::string(Common::g_build_id);
@@ -2860,7 +2862,8 @@ void GMainWindow::UpdateWindowTitle(const std::string& title_name,
     if (title_name.empty()) {
         setWindowTitle(QString::fromStdString(window_title));
     } else {
-        const auto run_title = fmt::format("{} | {} | {}", window_title, title_name, title_version);
+        const auto run_title =
+            fmt::format("{} | {} | {} | {}", window_title, title_name, title_version, gpu_vendor);
         setWindowTitle(QString::fromStdString(run_title));
     }
 }

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -287,8 +287,8 @@ private:
     InstallResult InstallNSPXCI(const QString& filename);
     InstallResult InstallNCA(const QString& filename);
     void MigrateConfigFiles();
-    void UpdateWindowTitle(const std::string& title_name = {},
-                           const std::string& title_version = {});
+    void UpdateWindowTitle(std::string_view title_name = {}, std::string_view title_version = {},
+                           std::string_view gpu_vendor = {});
     void UpdateStatusBar();
     void UpdateStatusButtons();
     void UpdateUISettings();


### PR DESCRIPTION
Adds the GPU driver vendor to the title bar of yuzu while running a title, making it easier to confirm which driver is currently being used as the renderer.

Currently the mappings are for the most common drivers and drivers which benefit from being clearly identified (i.e. the OPENSWR software renderer, which misleadingly reports the vendor name as `Intel Corporation`)

Huge thanks to @lat9nq for confirming and populating Linux driver mappings.

Example screenshot:
![image](https://user-images.githubusercontent.com/52414509/122699705-df750100-d217-11eb-8e2f-e4a2bec42378.png)
