### PR TITLE
Simple resizing of Per-Game configuration window and removal of useless Help question mark button in the title bar

### DIFF
--- a/src/yuzu/configuration/configure_per_game.cpp
+++ b/src/yuzu/configuration/configure_per_game.cpp
@@ -47,6 +47,8 @@ ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id, const std::str
     ui->setupUi(this);
     setFocusPolicy(Qt::ClickFocus);
     setWindowTitle(tr("Properties"));
+    // remove Help question mark button from the title bar
+    setWindowFlags(windowFlags() & ~Qt::WindowContextHelpButtonHint);
 
     ui->addonsTab->SetTitleId(title_id);
 

--- a/src/yuzu/configuration/configure_per_game.ui
+++ b/src/yuzu/configuration/configure_per_game.ui
@@ -6,9 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>800</width>
+    <width>900</width>
     <height>600</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>900</width>
+   </size>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>


### PR DESCRIPTION
Corrects window sizing of Per-Game configuration window and removes the unused Help hint button from the title bar
![image](https://user-images.githubusercontent.com/71381851/123012741-2b859880-d406-11eb-8b8b-73373bf8d9fd.png)
