### PR TITLE
externals: Update fmt to 8.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,7 +172,7 @@ macro(yuzu_find_packages)
     set(REQUIRED_LIBS
     #    Cmake Pkg Prefix  Version     Conan Pkg
         "Catch2            2.13        catch2/2.13.0"
-        "fmt               7.1         fmt/7.1.2"
+        "fmt               8.0         fmt/8.0.0"
         "lz4               1.8         lz4/1.9.2"
         "nlohmann_json     3.8         nlohmann_json/3.8.0"
         "ZLIB              1.2         zlib/1.2.11"

--- a/src/common/hex_util.h
+++ b/src/common/hex_util.h
@@ -53,8 +53,9 @@ template <typename ContiguousContainer>
     std::string out;
     out.reserve(std::size(data) * pad_width);
 
+    const auto format_str = fmt::runtime(upper ? "{:02X}" : "{:02x}");
     for (const u8 c : data) {
-        out += fmt::format(upper ? "{:02X}" : "{:02x}", c);
+        out += fmt::format(format_str, c);
     }
 
     return out;

--- a/src/core/crypto/key_manager.cpp
+++ b/src/core/crypto/key_manager.cpp
@@ -835,7 +835,7 @@ void KeyManager::SetKey(S128KeyType id, Key128 key, u64 field1, u64 field2) {
             "key_area_key_ocean_{:02X}",
             "key_area_key_system_{:02X}",
         };
-        WriteKeyToFile(category, fmt::format(kak_names.at(field2), field1), key);
+        WriteKeyToFile(category, fmt::format(fmt::runtime(kak_names.at(field2)), field1), key);
     } else if (id == S128KeyType::Master) {
         WriteKeyToFile(category, fmt::format("master_key_{:02X}", field1), key);
     } else if (id == S128KeyType::Package1) {

--- a/src/core/file_sys/registered_cache.cpp
+++ b/src/core/file_sys/registered_cache.cpp
@@ -58,14 +58,17 @@ static bool FollowsNcaIdFormat(std::string_view name) {
 
 static std::string GetRelativePathFromNcaID(const std::array<u8, 16>& nca_id, bool second_hex_upper,
                                             bool within_two_digit, bool cnmt_suffix) {
-    if (!within_two_digit)
-        return fmt::format(cnmt_suffix ? "{}.cnmt.nca" : "/{}.nca",
-                           Common::HexToString(nca_id, second_hex_upper));
+    if (!within_two_digit) {
+        const auto format_str = fmt::runtime(cnmt_suffix ? "{}.cnmt.nca" : "/{}.nca");
+        return fmt::format(format_str, Common::HexToString(nca_id, second_hex_upper));
+    }
 
     Core::Crypto::SHA256Hash hash{};
     mbedtls_sha256_ret(nca_id.data(), nca_id.size(), hash.data(), 0);
-    return fmt::format(cnmt_suffix ? "/000000{:02X}/{}.cnmt.nca" : "/000000{:02X}/{}.nca", hash[0],
-                       Common::HexToString(nca_id, second_hex_upper));
+
+    const auto format_str =
+        fmt::runtime(cnmt_suffix ? "/000000{:02X}/{}.cnmt.nca" : "/000000{:02X}/{}.nca");
+    return fmt::format(format_str, hash[0], Common::HexToString(nca_id, second_hex_upper));
 }
 
 static std::string GetCNMTName(TitleType type, u64 title_id) {

--- a/src/core/frontend/input.h
+++ b/src/core/frontend/input.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <memory>
 #include <string>
 #include <tuple>

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -149,10 +149,10 @@ void ServiceFrameworkBase::ReportUnimplementedFunction(Kernel::HLERequestContext
     std::string function_name = info == nullptr ? fmt::format("{}", ctx.GetCommand()) : info->name;
 
     fmt::memory_buffer buf;
-    fmt::format_to(buf, "function '{}': port='{}' cmd_buf={{[0]=0x{:X}", function_name,
-                   service_name, cmd_buf[0]);
+    fmt::format_to(std::back_inserter(buf), "function '{}': port='{}' cmd_buf={{[0]=0x{:X}",
+                   function_name, service_name, cmd_buf[0]);
     for (int i = 1; i <= 8; ++i) {
-        fmt::format_to(buf, ", [{}]=0x{:X}", i, cmd_buf[i]);
+        fmt::format_to(std::back_inserter(buf), ", [{}]=0x{:X}", i, cmd_buf[i]);
     }
     buf.push_back('}');
 

--- a/src/video_core/renderer_opengl/gl_arb_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_arb_decompiler.cpp
@@ -454,7 +454,7 @@ private:
 
     template <typename... Args>
     void AddExpression(std::string_view text, Args&&... args) {
-        shader_source += fmt::format(text, std::forward<Args>(args)...);
+        shader_source += fmt::format(fmt::runtime(text), std::forward<Args>(args)...);
     }
 
     template <typename... Args>

--- a/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_decompiler.cpp
@@ -96,7 +96,7 @@ public:
     // etc).
     template <typename... Args>
     void AddLine(std::string_view text, Args&&... args) {
-        AddExpression(fmt::format(text, std::forward<Args>(args)...));
+        AddExpression(fmt::format(fmt::runtime(text), std::forward<Args>(args)...));
         AddNewLine();
     }
 

--- a/src/yuzu/about_dialog.cpp
+++ b/src/yuzu/about_dialog.cpp
@@ -14,7 +14,8 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent), ui(new Ui::AboutDia
     const auto build_id = std::string(Common::g_build_id);
 
     const auto yuzu_build = fmt::format("yuzu Development Build | {}-{}", branch_name, description);
-    const auto override_build = fmt::format(std::string(Common::g_title_bar_format_idle), build_id);
+    const auto override_build =
+        fmt::format(fmt::runtime(std::string(Common::g_title_bar_format_idle)), build_id);
     const auto yuzu_build_version = override_build.empty() ? yuzu_build : override_build;
 
     ui->setupUi(this);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -236,7 +236,8 @@ GMainWindow::GMainWindow()
     const auto build_id = std::string(Common::g_build_id);
 
     const auto yuzu_build = fmt::format("yuzu Development Build | {}-{}", branch_name, description);
-    const auto override_build = fmt::format(std::string(Common::g_title_bar_format_idle), build_id);
+    const auto override_build =
+        fmt::format(fmt::runtime(std::string(Common::g_title_bar_format_idle)), build_id);
     const auto yuzu_build_version = override_build.empty() ? yuzu_build : override_build;
 
     LOG_INFO(Frontend, "yuzu Version: {}", yuzu_build_version);
@@ -2858,7 +2859,8 @@ void GMainWindow::UpdateWindowTitle(const std::string& title_name,
     const auto build_id = std::string(Common::g_build_id);
 
     const auto yuzu_title = fmt::format("yuzu | {}-{}", branch_name, description);
-    const auto override_title = fmt::format(std::string(Common::g_title_bar_format_idle), build_id);
+    const auto override_title =
+        fmt::format(fmt::runtime(std::string(Common::g_title_bar_format_idle)), build_id);
     const auto window_title = override_title.empty() ? yuzu_title : override_title;
 
     if (title_name.empty()) {


### PR DESCRIPTION
Keeps us up to date with the latest major release.

Also allows compilers that support it to perform compile-time format string checking, allowing format string errors to be caught sooner.

8.0.0 introduces quite a bunch of changes, so the entire changelog can be viewed [here](https://github.com/fmtlib/fmt/releases/tag/8.0.0).