### PR TITLE
maxwell3d: Add missing return in default SizeInBytes() case

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -242,6 +242,7 @@ public:
                     return 4;
                 default:
                     UNREACHABLE();
+                    return 1;
                 }
             }
 


### PR DESCRIPTION
We were returning '1' in ComponentCount()'s default case but were neglecting to do the same with SizeInBytes().

Resolves a warning on *nix platforms and makes it a little more consistent in terms of behavior (assuming anything ever actually hits this).