### PR TITLE
main: Display the instruction set of the running title in the window name

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1422,6 +1422,9 @@ void GMainWindow::BootGame(const QString& filename, std::size_t program_index, S
         title_name = Common::FS::PathToUTF8String(
             std::filesystem::path{filename.toStdU16String()}.filename());
     }
+    const bool is_64bit = system.Kernel().CurrentProcess()->Is64BitProcess();
+    const auto instruction_set_suffix = is_64bit ? " (64-bit)" : " (32-bit)";
+    title_name += instruction_set_suffix;
     LOG_INFO(Frontend, "Booting game: {:016X} | {} | {}", title_id, title_name, title_version);
     UpdateWindowTitle(title_name, title_version);
 


### PR DESCRIPTION
Displays whether the currently running title uses 64-bit instructions or only 32-bit instructions.

Useful to know which games would benefit from certain optimizations, since some of the CPU/dynarmic unsafe options apply only to 32-bit titles.

Example screenshot:
![image](https://user-images.githubusercontent.com/52414509/123582128-4744c200-d7ab-11eb-9529-edf802dcccfb.png)
