### PR TITLE
general: Enforce multiple warnings in MSVC

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,11 @@ if (MSVC)
         /Zc:inline
         /Zc:throwingNew
 
+        # External headers diagnostics
+        /experimental:external  # Enables the external headers options. This option isn't required in Visual Studio 2019 version 16.10 and later
+        /external:anglebrackets # Treats all headers included by #include <header>, where the header file is enclosed in angle brackets (< >), as external headers
+        /external:W0            # Sets the default warning level to 0 for external headers, effectively turning off warnings for external headers
+
         # Warnings
         /W3
         /we4018 # 'expression': signed/unsigned mismatch

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,11 +47,15 @@ if (MSVC)
 
         # Warnings
         /W3
-        /we4062 # enumerator 'identifier' in a switch of enum 'enumeration' is not handled
+        /we4018 # 'expression': signed/unsigned mismatch
+        /we4062 # Enumerator 'identifier' in a switch of enum 'enumeration' is not handled
         /we4101 # 'identifier': unreferenced local variable
         /we4265 # 'class': class has virtual functions, but destructor is not virtual
-        /we4388 # signed/unsigned mismatch
-        /we4547 # 'operator' : operator before comma has no effect; expected operator with side-effect
+        /we4267 # 'var': conversion from 'size_t' to 'type', possible loss of data
+        /we4305 # 'context': truncation from 'type1' to 'type2'
+        /we4388 # 'expression': signed/unsigned mismatch
+        /we4389 # 'operator': signed/unsigned mismatch
+        /we4547 # 'operator': operator before comma has no effect; expected operator with side-effect
         /we4549 # 'operator1': operator before comma has no effect; did you intend 'operator2'?
         /we4555 # Expression has no effect; expected expression with side-effect
         /we4715 # 'function': not all control paths return a value

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -654,17 +654,14 @@ endif()
 
 if (MSVC)
     target_compile_options(core PRIVATE
-        /we4018 # 'expression' : signed/unsigned mismatch
-        /we4244 # 'argument' : conversion from 'type1' to 'type2', possible loss of data (floating-point)
-        /we4245 # 'conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch
+        /we4242 # 'identifier': conversion from 'type1' to 'type2', possible loss of data
+        /we4244 # 'conversion': conversion from 'type1' to 'type2', possible loss of data
+        /we4245 # 'conversion': conversion from 'type1' to 'type2', signed/unsigned mismatch
         /we4254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
-        /we4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data
-        /we4305 # 'context' : truncation from 'type1' to 'type2'
         /we4456 # Declaration of 'identifier' hides previous local declaration
         /we4457 # Declaration of 'identifier' hides function parameter
         /we4458 # Declaration of 'identifier' hides class member
         /we4459 # Declaration of 'identifier' hides global declaration
-        /we4715 # 'function' : not all control paths return a value
     )
 else()
     target_compile_options(core PRIVATE

--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -34,18 +34,10 @@ if (MSVC)
         /W4
         /WX
 
-        # 'expression' : signed/unsigned mismatch
-        /we4018
-        # 'argument' : conversion from 'type1' to 'type2', possible loss of data (floating-point)
-        /we4244
-        # 'conversion' : conversion from 'type1' to 'type2', signed/unsigned mismatch
-        /we4245
-        # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
-        /we4254
-        # 'var' : conversion from 'size_t' to 'type', possible loss of data
-        /we4267
-        # 'context' : truncation from 'type1' to 'type2'
-        /we4305
+        /we4242 # 'identifier': conversion from 'type1' to 'type2', possible loss of data
+        /we4244 # 'conversion': conversion from 'type1' to 'type2', possible loss of data
+        /we4245 # 'conversion': conversion from 'type1' to 'type2', signed/unsigned mismatch
+        /we4254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
     )
 else()
     target_compile_options(input_common PRIVATE

--- a/src/input_common/gcadapter/gc_adapter.cpp
+++ b/src/input_common/gcadapter/gc_adapter.cpp
@@ -5,14 +5,7 @@
 #include <chrono>
 #include <thread>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4200) // nonstandard extension used : zero-sized array in struct/union
-#endif
 #include <libusb.h>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include "common/logging/log.h"
 #include "common/param_package.h"

--- a/src/input_common/udp/protocol.h
+++ b/src/input_common/udp/protocol.h
@@ -8,14 +8,7 @@
 #include <optional>
 #include <type_traits>
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4701)
-#endif
 #include <boost/crc.hpp>
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
 
 #include "common/bit_field.h"
 #include "common/swap.h"

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -292,13 +292,12 @@ endif()
 
 if (MSVC)
     target_compile_options(video_core PRIVATE
-        /we4267 # 'var' : conversion from 'size_t' to 'type', possible loss of data
-        /we4244 # 'var' : conversion from integer to 'type', possible loss of data
+        /we4242 # 'identifier': conversion from 'type1' to 'type2', possible loss of data
+        /we4244 # 'conversion': conversion from 'type1' to 'type2', possible loss of data
         /we4456 # Declaration of 'identifier' hides previous local declaration
         /we4457 # Declaration of 'identifier' hides function parameter
         /we4458 # Declaration of 'identifier' hides class member
         /we4459 # Declaration of 'identifier' hides global declaration
-        /we4715 # 'function' : not all control paths return a value
     )
 else()
     target_compile_options(video_core PRIVATE

--- a/src/video_core/command_classes/codecs/codec.h
+++ b/src/video_core/command_classes/codecs/codec.h
@@ -14,17 +14,9 @@ extern "C" {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #endif
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4242) // conversion from 'type' to 'type', possible loss of data
-#pragma warning(disable : 4244) // conversion from 'type' to 'type', possible loss of data
-#endif
 #include <libavcodec/avcodec.h>
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#pragma warning(pop)
 #endif
 }
 

--- a/src/video_core/command_classes/vic.cpp
+++ b/src/video_core/command_classes/vic.cpp
@@ -9,16 +9,9 @@ extern "C" {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wconversion"
 #endif
-#ifdef _MSC_VER
-#pragma warning(disable : 4244) // conversion from 'type' to 'type', possible loss of data
-#pragma warning(push)
-#endif
 #include <libswscale/swscale.h>
 #if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
-#endif
-#ifdef _MSC_VER
-#pragma warning(pop)
 #endif
 }
 

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -327,7 +327,8 @@ void ApplySwizzle(GLuint handle, PixelFormat format, std::array<SwizzleSource, 4
     if (format_info.is_compressed) {
         return false;
     }
-    if (std::ranges::find(ACCELERATED_FORMATS, internal_format) == ACCELERATED_FORMATS.end()) {
+    if (std::ranges::find(ACCELERATED_FORMATS, static_cast<int>(internal_format)) ==
+        ACCELERATED_FORMATS.end()) {
         return false;
     }
     if (format_info.compatibility_by_size) {

--- a/src/video_core/texture_cache/image_base.cpp
+++ b/src/video_core/texture_cache/image_base.cpp
@@ -82,7 +82,7 @@ std::optional<SubresourceBase> ImageBase::TryFindBase(GPUVAddr other_addr) const
     if (info.type != ImageType::e3D) {
         const auto [layer, mip_offset] = LayerMipOffset(diff, info.layer_stride);
         const auto end = mip_level_offsets.begin() + info.resources.levels;
-        const auto it = std::find(mip_level_offsets.begin(), end, mip_offset);
+        const auto it = std::find(mip_level_offsets.begin(), end, static_cast<u32>(mip_offset));
         if (layer > info.resources.layers || it == end) {
             return std::nullopt;
         }

--- a/src/video_core/texture_cache/util.cpp
+++ b/src/video_core/texture_cache/util.cpp
@@ -394,7 +394,7 @@ template <u32 GOB_EXTENT>
     const s32 mip_offset = diff % layer_stride;
     const std::array offsets = CalculateMipLevelOffsets(new_info);
     const auto end = offsets.begin() + new_info.resources.levels;
-    const auto it = std::find(offsets.begin(), end, mip_offset);
+    const auto it = std::find(offsets.begin(), end, static_cast<u32>(mip_offset));
     if (it == end) {
         // Mipmap is not aligned to any valid size
         return std::nullopt;

--- a/src/video_core/textures/astc.cpp
+++ b/src/video_core/textures/astc.cpp
@@ -1365,8 +1365,8 @@ static void DecompressBlock(std::span<const u8, 16> inBuf, const u32 blockWidth,
     // each partition.
 
     // Determine partitions, partition index, and color endpoint modes
-    s32 planeIdx = -1;
-    u32 partitionIndex;
+    u32 planeIdx{UINT32_MAX};
+    u32 partitionIndex{};
     u32 colorEndpointMode[4] = {0, 0, 0, 0};
 
     // Define color data.


### PR DESCRIPTION
Enforce C4242 in core, video_core, and input_common
Enforce C4018, C4267, C4305, C4389 throughout the entire project