### PR TITLE
Improve management of kernel objects

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -517,6 +517,8 @@ add_library(core STATIC
     hle/service/psc/psc.h
     hle/service/ptm/psm.cpp
     hle/service/ptm/psm.h
+    hle/service/kernel_helpers.cpp
+    hle/service/kernel_helpers.h
     hle/service/service.cpp
     hle/service/service.h
     hle/service/set/set.cpp

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -58,6 +58,9 @@ bool SessionRequestManager::HasSessionRequestHandler(const HLERequestContext& co
 
 void SessionRequestHandler::ClientConnected(KServerSession* session) {
     session->ClientConnected(shared_from_this());
+
+    // Ensure our server session is tracked globally.
+    kernel.RegisterServerSession(session);
 }
 
 void SessionRequestHandler::ClientDisconnected(KServerSession* session) {

--- a/src/core/hle/kernel/k_auto_object.cpp
+++ b/src/core/hle/kernel/k_auto_object.cpp
@@ -3,12 +3,21 @@
 // Refer to the license.txt file included.
 
 #include "core/hle/kernel/k_auto_object.h"
+#include "core/hle/kernel/kernel.h"
 
 namespace Kernel {
 
 KAutoObject* KAutoObject::Create(KAutoObject* obj) {
     obj->m_ref_count = 1;
     return obj;
+}
+
+void KAutoObject::RegisterWithKernel() {
+    kernel.RegisterKernelObject(this);
+}
+
+void KAutoObject::UnregisterWithKernel() {
+    kernel.UnregisterKernelObject(this);
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/k_auto_object.h
+++ b/src/core/hle/kernel/k_auto_object.h
@@ -85,8 +85,12 @@ private:
     KERNEL_AUTOOBJECT_TRAITS(KAutoObject, KAutoObject);
 
 public:
-    explicit KAutoObject(KernelCore& kernel_) : kernel(kernel_) {}
-    virtual ~KAutoObject() = default;
+    explicit KAutoObject(KernelCore& kernel_) : kernel(kernel_) {
+        RegisterWithKernel();
+    }
+    virtual ~KAutoObject() {
+        UnregisterWithKernel();
+    }
 
     static KAutoObject* Create(KAutoObject* ptr);
 
@@ -165,6 +169,10 @@ public:
             this->Destroy();
         }
     }
+
+private:
+    void RegisterWithKernel();
+    void UnregisterWithKernel();
 
 protected:
     KernelCore& kernel;

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -409,6 +409,9 @@ void KProcess::Finalize() {
         resource_limit->Close();
     }
 
+    // Finalize the handle table and close any open handles.
+    handle_table.Finalize();
+
     // Perform inherited finalization.
     KAutoObjectWithSlabHeapAndContainer<KProcess, KSynchronizationObject>::Finalize();
 }

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -10,6 +10,7 @@
 #include "common/alignment.h"
 #include "common/assert.h"
 #include "common/logging/log.h"
+#include "common/scope_exit.h"
 #include "common/settings.h"
 #include "core/core.h"
 #include "core/device_memory.h"
@@ -43,6 +44,8 @@ void SetupMainThread(Core::System& system, KProcess& owner_process, u32 priority
     ASSERT(owner_process.GetResourceLimit()->Reserve(LimitableResource::Threads, 1));
 
     KThread* thread = KThread::Create(system.Kernel());
+    SCOPE_EXIT({ thread->Close(); });
+
     ASSERT(KThread::InitializeUserThread(system, thread, entry_point, 0, stack_top, priority,
                                          owner_process.GetIdealCoreId(), &owner_process)
                .IsSuccess());

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -165,7 +165,7 @@ void KProcess::DecrementThreadCount() {
     ASSERT(num_threads > 0);
 
     if (const auto count = --num_threads; count == 0) {
-        UNIMPLEMENTED_MSG("Process termination is not implemented!");
+        LOG_WARNING(Kernel, "Process termination is not fully implemented.");
     }
 }
 

--- a/src/core/hle/kernel/k_server_session.cpp
+++ b/src/core/hle/kernel/k_server_session.cpp
@@ -28,7 +28,10 @@ namespace Kernel {
 
 KServerSession::KServerSession(KernelCore& kernel_) : KSynchronizationObject{kernel_} {}
 
-KServerSession::~KServerSession() {}
+KServerSession::~KServerSession() {
+    // Ensure that the global list tracking server sessions does not hold on to a reference.
+    kernel.UnregisterServerSession(this);
+}
 
 void KServerSession::Initialize(KSession* parent_session_, std::string&& name_,
                                 std::shared_ptr<SessionRequestManager> manager_) {

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -91,6 +91,12 @@ struct KernelCore::Impl {
     }
 
     void Shutdown() {
+        if (current_process) {
+            current_process->Finalize();
+            current_process->Close();
+            current_process = nullptr;
+        }
+
         process_list.clear();
 
         // Ensures all service threads gracefully shutdown
@@ -111,11 +117,6 @@ struct KernelCore::Impl {
         }
 
         cores.clear();
-
-        if (current_process) {
-            current_process->Close();
-            current_process = nullptr;
-        }
 
         global_handle_table->Finalize();
         global_handle_table.reset();

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -91,15 +91,39 @@ struct KernelCore::Impl {
     }
 
     void Shutdown() {
+        // Shutdown all processes.
         if (current_process) {
             current_process->Finalize();
             current_process->Close();
             current_process = nullptr;
         }
-
         process_list.clear();
 
-        // Ensures all service threads gracefully shutdown
+        // Close all open server ports.
+        std::unordered_set<KServerPort*> server_ports_;
+        {
+            std::lock_guard lk(server_ports_lock);
+            server_ports_ = server_ports;
+            server_ports.clear();
+        }
+        for (auto* server_port : server_ports_) {
+            server_port->Close();
+        }
+        // Close all open server sessions.
+        std::unordered_set<KServerSession*> server_sessions_;
+        {
+            std::lock_guard lk(server_sessions_lock);
+            server_sessions_ = server_sessions;
+            server_sessions.clear();
+        }
+        for (auto* server_session : server_sessions_) {
+            server_session->Close();
+        }
+
+        // Ensure that the object list container is finalized and properly shutdown.
+        object_list_container.Finalize();
+
+        // Ensures all service threads gracefully shutdown.
         service_threads.clear();
 
         next_object_id = 0;
@@ -147,10 +171,13 @@ struct KernelCore::Impl {
         next_host_thread_id = Core::Hardware::NUM_CPU_CORES;
 
         // Track kernel objects that were not freed on shutdown
-        if (registered_objects.size()) {
-            LOG_WARNING(Kernel, "{} kernel objects were dangling on shutdown!",
-                        registered_objects.size());
-            registered_objects.clear();
+        {
+            std::lock_guard lk(registered_objects_lock);
+            if (registered_objects.size()) {
+                LOG_WARNING(Kernel, "{} kernel objects were dangling on shutdown!",
+                            registered_objects.size());
+                registered_objects.clear();
+            }
         }
     }
 
@@ -640,6 +667,21 @@ struct KernelCore::Impl {
             user_slab_heap_size);
     }
 
+    KClientPort* CreateNamedServicePort(std::string name) {
+        auto search = service_interface_factory.find(name);
+        if (search == service_interface_factory.end()) {
+            UNIMPLEMENTED();
+            return {};
+        }
+
+        KClientPort* port = &search->second(system.ServiceManager(), system);
+        {
+            std::lock_guard lk(server_ports_lock);
+            server_ports.insert(&port->GetParent()->GetServerPort());
+        }
+        return port;
+    }
+
     std::atomic<u32> next_object_id{0};
     std::atomic<u64> next_kernel_process_id{KProcess::InitialKIPIDMin};
     std::atomic<u64> next_user_process_id{KProcess::ProcessIDMin};
@@ -666,7 +708,12 @@ struct KernelCore::Impl {
     /// the ConnectToPort SVC.
     std::unordered_map<std::string, ServiceInterfaceFactory> service_interface_factory;
     NamedPortTable named_ports;
+    std::unordered_set<KServerPort*> server_ports;
+    std::unordered_set<KServerSession*> server_sessions;
     std::unordered_set<KAutoObject*> registered_objects;
+    std::mutex server_ports_lock;
+    std::mutex server_sessions_lock;
+    std::mutex registered_objects_lock;
 
     std::unique_ptr<Core::ExclusiveMonitor> exclusive_monitor;
     std::vector<Kernel::PhysicalCore> cores;
@@ -855,19 +902,26 @@ void KernelCore::RegisterNamedService(std::string name, ServiceInterfaceFactory&
 }
 
 KClientPort* KernelCore::CreateNamedServicePort(std::string name) {
-    auto search = impl->service_interface_factory.find(name);
-    if (search == impl->service_interface_factory.end()) {
-        UNIMPLEMENTED();
-        return {};
-    }
-    return &search->second(impl->system.ServiceManager(), impl->system);
+    return impl->CreateNamedServicePort(std::move(name));
+}
+
+void KernelCore::RegisterServerSession(KServerSession* server_session) {
+    std::lock_guard lk(impl->server_sessions_lock);
+    impl->server_sessions.insert(server_session);
+}
+
+void KernelCore::UnregisterServerSession(KServerSession* server_session) {
+    std::lock_guard lk(impl->server_sessions_lock);
+    impl->server_sessions.erase(server_session);
 }
 
 void KernelCore::RegisterKernelObject(KAutoObject* object) {
+    std::lock_guard lk(impl->registered_objects_lock);
     impl->registered_objects.insert(object);
 }
 
 void KernelCore::UnregisterKernelObject(KAutoObject* object) {
+    std::lock_guard lk(impl->registered_objects_lock);
     impl->registered_objects.erase(object);
 }
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -61,6 +61,7 @@ struct KernelCore::Impl {
     void Initialize(KernelCore& kernel) {
         global_scheduler_context = std::make_unique<Kernel::GlobalSchedulerContext>(kernel);
         global_handle_table = std::make_unique<Kernel::KHandleTable>(kernel);
+        global_handle_table->Initialize(KHandleTable::MaxTableSize);
 
         is_phantom_mode_for_singlecore = false;
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -117,6 +117,7 @@ struct KernelCore::Impl {
             current_process = nullptr;
         }
 
+        global_handle_table->Finalize();
         global_handle_table.reset();
 
         preemption_event = nullptr;

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -45,6 +45,7 @@ class KPort;
 class KProcess;
 class KResourceLimit;
 class KScheduler;
+class KServerSession;
 class KSession;
 class KSharedMemory;
 class KThread;
@@ -184,6 +185,14 @@ public:
 
     /// Opens a port to a service previously registered with RegisterNamedService.
     KClientPort* CreateNamedServicePort(std::string name);
+
+    /// Registers a server session with the gobal emulation state, to be freed on shutdown. This is
+    /// necessary because we do not emulate processes for HLE sessions.
+    void RegisterServerSession(KServerSession* server_session);
+
+    /// Unregisters a server session previously registered with RegisterServerSession when it was
+    /// destroyed during the current emulation session.
+    void UnregisterServerSession(KServerSession* server_session);
 
     /// Registers all kernel objects with the global emulation state, this is purely for tracking
     /// leaks after emulation has been shutdown.

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -185,6 +185,14 @@ public:
     /// Opens a port to a service previously registered with RegisterNamedService.
     KClientPort* CreateNamedServicePort(std::string name);
 
+    /// Registers all kernel objects with the global emulation state, this is purely for tracking
+    /// leaks after emulation has been shutdown.
+    void RegisterKernelObject(KAutoObject* object);
+
+    /// Unregisters a kernel object previously registered with RegisterKernelObject when it was
+    /// destroyed during the current emulation session.
+    void UnregisterKernelObject(KAutoObject* object);
+
     /// Determines whether or not the given port is a valid named port.
     bool IsValidNamedPort(NamedPortTable::const_iterator port) const;
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -298,6 +298,7 @@ static ResultCode ConnectToNamedPort(Core::System& system, Handle* out, VAddr po
     // Create a session.
     KClientSession* session{};
     R_TRY(port->CreateSession(std::addressof(session)));
+    port->Close();
 
     // Register the session in the table, close the extra reference.
     handle_table.Register(*out, session);

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1440,11 +1440,6 @@ static void ExitProcess(Core::System& system) {
     LOG_INFO(Kernel_SVC, "Process {} exiting", current_process->GetProcessID());
     ASSERT_MSG(current_process->GetStatus() == ProcessStatus::Running,
                "Process has already exited");
-
-    current_process->PrepareForTermination();
-
-    // Kill the current thread
-    system.Kernel().CurrentScheduler()->GetCurrentThread()->Exit();
 }
 
 static void ExitProcess32(Core::System& system) {

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -254,7 +254,6 @@ void Controller_NPad::InitNewlyAddedController(std::size_t controller_idx) {
 }
 
 void Controller_NPad::OnInit() {
-    auto& kernel = system.Kernel();
     for (std::size_t i = 0; i < styleset_changed_events.size(); ++i) {
         styleset_changed_events[i] =
             service_context.CreateEvent(fmt::format("npad:NpadStyleSetChanged_{}", i));

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -20,6 +20,10 @@ class KEvent;
 class KReadableEvent;
 } // namespace Kernel
 
+namespace Service::KernelHelpers {
+class ServiceContext;
+}
+
 namespace Service::HID {
 
 constexpr u32 NPAD_HANDHELD = 32;
@@ -27,7 +31,8 @@ constexpr u32 NPAD_UNKNOWN = 16; // TODO(ogniK): What is this?
 
 class Controller_NPad final : public ControllerBase {
 public:
-    explicit Controller_NPad(Core::System& system_);
+    explicit Controller_NPad(Core::System& system_,
+                             KernelHelpers::ServiceContext& service_context_);
     ~Controller_NPad() override;
 
     // Called when the controller is initialized
@@ -566,6 +571,7 @@ private:
         std::array<std::unique_ptr<Input::MotionDevice>, Settings::NativeMotion::NUM_MOTIONS_HID>,
         10>;
 
+    KernelHelpers::ServiceContext& service_context;
     std::mutex mutex;
     ButtonArray buttons;
     StickArray sticks;

--- a/src/core/hle/service/kernel_helpers.cpp
+++ b/src/core/hle/service/kernel_helpers.cpp
@@ -1,0 +1,64 @@
+// Copyright 2021 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/core.h"
+#include "core/hle/kernel/k_event.h"
+#include "core/hle/kernel/k_process.h"
+#include "core/hle/kernel/k_readable_event.h"
+#include "core/hle/kernel/k_resource_limit.h"
+#include "core/hle/kernel/k_scoped_resource_reservation.h"
+#include "core/hle/kernel/k_writable_event.h"
+#include "core/hle/service/kernel_helpers.h"
+
+namespace Service::KernelHelpers {
+
+ServiceContext::ServiceContext(Core::System& system_, std::string name_)
+    : kernel(system_.Kernel()) {
+    process = Kernel::KProcess::Create(kernel);
+    ASSERT(Kernel::KProcess::Initialize(process, system_, std::move(name_),
+                                        Kernel::KProcess::ProcessType::Userland)
+               .IsSuccess());
+}
+
+ServiceContext::~ServiceContext() {
+    process->Close();
+    process = nullptr;
+}
+
+Kernel::KEvent* ServiceContext::CreateEvent(std::string&& name) {
+    // Reserve a new event from the process resource limit
+    Kernel::KScopedResourceReservation event_reservation(process,
+                                                         Kernel::LimitableResource::Events);
+    if (!event_reservation.Succeeded()) {
+        LOG_CRITICAL(Service, "Resource limit reached!");
+        return {};
+    }
+
+    // Create a new event.
+    auto* event = Kernel::KEvent::Create(kernel);
+    if (!event) {
+        LOG_CRITICAL(Service, "Unable to create event!");
+        return {};
+    }
+
+    // Initialize the event.
+    event->Initialize(std::move(name));
+
+    // Commit the thread reservation.
+    event_reservation.Commit();
+
+    // Register the event.
+    Kernel::KEvent::Register(kernel, event);
+
+    return event;
+}
+
+void ServiceContext::CloseEvent(Kernel::KEvent* event) {
+    event->GetReadableEvent().Close();
+    event->GetWritableEvent().Close();
+}
+
+} // namespace Service::KernelHelpers

--- a/src/core/hle/service/kernel_helpers.cpp
+++ b/src/core/hle/service/kernel_helpers.cpp
@@ -2,8 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#pragma once
-
 #include "core/core.h"
 #include "core/hle/kernel/k_event.h"
 #include "core/hle/kernel/k_process.h"

--- a/src/core/hle/service/kernel_helpers.h
+++ b/src/core/hle/service/kernel_helpers.h
@@ -1,0 +1,35 @@
+// Copyright 2021 yuzu emulator team
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+
+namespace Core {
+class System;
+}
+
+namespace Kernel {
+class KernelCore;
+class KEvent;
+class KProcess;
+} // namespace Kernel
+
+namespace Service::KernelHelpers {
+
+class ServiceContext {
+public:
+    ServiceContext(Core::System& system_, std::string name_);
+    ~ServiceContext();
+
+    Kernel::KEvent* CreateEvent(std::string&& name);
+
+    void CloseEvent(Kernel::KEvent* event);
+
+private:
+    Kernel::KernelCore& kernel;
+    Kernel::KProcess* process{};
+};
+
+} // namespace Service::KernelHelpers

--- a/src/core/hle/service/nvdrv/nvdrv.cpp
+++ b/src/core/hle/service/nvdrv/nvdrv.cpp
@@ -41,7 +41,6 @@ void InstallInterfaces(SM::ServiceManager& service_manager, NVFlinger::NVFlinger
 
 Module::Module(Core::System& system)
     : syncpoint_manager{system.GPU()}, service_context{system, "nvdrv"} {
-    auto& kernel = system.Kernel();
     for (u32 i = 0; i < MaxNvEvents; i++) {
         events_interface.events[i].event =
             service_context.CreateEvent(fmt::format("NVDRV::NvEvent_{}", i));

--- a/src/core/hle/service/nvdrv/nvdrv.cpp
+++ b/src/core/hle/service/nvdrv/nvdrv.cpp
@@ -39,11 +39,12 @@ void InstallInterfaces(SM::ServiceManager& service_manager, NVFlinger::NVFlinger
     nvflinger.SetNVDrvInstance(module_);
 }
 
-Module::Module(Core::System& system) : syncpoint_manager{system.GPU()} {
+Module::Module(Core::System& system)
+    : syncpoint_manager{system.GPU()}, service_context{system, "nvdrv"} {
     auto& kernel = system.Kernel();
     for (u32 i = 0; i < MaxNvEvents; i++) {
-        events_interface.events[i].event = Kernel::KEvent::Create(kernel);
-        events_interface.events[i].event->Initialize(fmt::format("NVDRV::NvEvent_{}", i));
+        events_interface.events[i].event =
+            service_context.CreateEvent(fmt::format("NVDRV::NvEvent_{}", i));
         events_interface.status[i] = EventState::Free;
         events_interface.registered[i] = false;
     }
@@ -65,8 +66,7 @@ Module::Module(Core::System& system) : syncpoint_manager{system.GPU()} {
 
 Module::~Module() {
     for (u32 i = 0; i < MaxNvEvents; i++) {
-        events_interface.events[i].event->Close();
-        events_interface.events[i].event = nullptr;
+        service_context.CloseEvent(events_interface.events[i].event);
     }
 }
 

--- a/src/core/hle/service/nvdrv/nvdrv.h
+++ b/src/core/hle/service/nvdrv/nvdrv.h
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "common/common_types.h"
+#include "core/hle/service/kernel_helpers.h"
 #include "core/hle/service/nvdrv/nvdata.h"
 #include "core/hle/service/nvdrv/syncpoint_manager.h"
 #include "core/hle/service/service.h"
@@ -154,6 +155,8 @@ private:
     std::unordered_map<std::string, std::shared_ptr<Devices::nvdevice>> devices;
 
     EventInterface events_interface;
+
+    KernelHelpers::ServiceContext service_context;
 };
 
 /// Registers all NVDRV services with the specified service manager.

--- a/src/core/hle/service/service.cpp
+++ b/src/core/hle/service/service.cpp
@@ -104,23 +104,22 @@ ServiceFrameworkBase::~ServiceFrameworkBase() {
 void ServiceFrameworkBase::InstallAsService(SM::ServiceManager& service_manager) {
     const auto guard = LockService();
 
-    ASSERT(!port_installed);
+    ASSERT(!service_registered);
 
-    auto port = service_manager.RegisterService(service_name, max_sessions).Unwrap();
-    port->SetSessionHandler(shared_from_this());
-    port_installed = true;
+    service_manager.RegisterService(service_name, max_sessions, shared_from_this());
+    service_registered = true;
 }
 
 Kernel::KClientPort& ServiceFrameworkBase::CreatePort() {
     const auto guard = LockService();
 
-    ASSERT(!port_installed);
+    ASSERT(!service_registered);
 
     auto* port = Kernel::KPort::Create(kernel);
     port->Initialize(max_sessions, false, service_name);
     port->GetServerPort().SetSessionHandler(shared_from_this());
 
-    port_installed = true;
+    service_registered = true;
 
     return port->GetClientPort();
 }

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -125,7 +125,7 @@ private:
 
     /// Flag to store if a port was already create/installed to detect multiple install attempts,
     /// which is not supported.
-    bool port_installed = false;
+    bool service_registered = false;
 
     /// Function used to safely up-cast pointers to the derived class before invoking a handler.
     InvokerFn* handler_invoker;

--- a/src/core/hle/service/service.h
+++ b/src/core/hle/service/service.h
@@ -96,6 +96,9 @@ protected:
     /// System context that the service operates under.
     Core::System& system;
 
+    /// Identifier string used to connect to the service.
+    std::string service_name;
+
 private:
     template <typename T>
     friend class ServiceFramework;
@@ -117,8 +120,6 @@ private:
     void RegisterHandlersBaseTipc(const FunctionInfoBase* functions, std::size_t n);
     void ReportUnimplementedFunction(Kernel::HLERequestContext& ctx, const FunctionInfoBase* info);
 
-    /// Identifier string used to connect to the service.
-    std::string service_name;
     /// Maximum number of concurrent sessions that this service can handle.
     u32 max_sessions;
 


### PR DESCRIPTION
Currently, the emulation session can create tons of kernel objects that are not tracked. This is particularly a problem with HLE services, which are created and torn down between emulation sessions (unlike what would happen on a real Switch), yet often create many kernel objects themselves for things like sessions, events, etc. which are not tracked. This can easily end up with ~1000+ dangling kernel objects after emulation is shutdown.

This change tries to address this by tracking the worst offenders here. These are:

* Adding global tracking of kernel objects, and logging which are dangling after emulation is shutdown.
* Ensuring handle tables are actually shutdown, freeing all of the object references held by the handle table.
* Ensuring events created by HLE services are properly shutdown, in which we added some new helper code to manage this.
* Reserving a dummy KProcess for each HLE service, to allow us to better manage resource limits.
* Globally tracking KServerPorts and KServerSessions and ensuring they are shutdown. This is a simplification/workaround, as services should manage these themselves, but we'll need to entirely rethink how we emulate HLE services before this happens.
* Better management of guest threads and processes.

Some brief testing results:
* Puyo Puyo Tetris, after going in game:
  * Before: 946 dangling kernel objects after close
  * After: 16 dangling kernel objects after close
* Super Mario Odyssey, after going in game:
  * Before: 1046 dangling kernel objects after close
  * After: 33 dangling kernel objects after close
* Breath of the Wild, after going in game:
  * Before: 987 dangling kernel objects after close
  * After: 43 dangling kernel objects after close
* Pokemon Sword, after going in game:
  * Before: 1007 dangling kernel objects after close
  * After: 17 dangling kernel objects after close

Not perfect, but a lot better.