### PR TITLE
input_common: Add missing modifier callback to analog from button

### DIFF
--- a/src/input_common/analog_from_button.cpp
+++ b/src/input_common/analog_from_button.cpp
@@ -27,6 +27,7 @@ public:
         down->SetCallback(callbacks);
         left->SetCallback(callbacks);
         right->SetCallback(callbacks);
+        modifier->SetCallback(callbacks);
     }
 
     bool IsAngleGreater(float old_angle, float new_angle) const {


### PR DESCRIPTION
Whoops I forgot to add this button. Joystick will now update if you press the modifier button