### PR TITLE
CMakeLists: Treat -Wsign-compare as an error on GCC/Clang

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,7 @@ else()
         -Werror=missing-declarations
         -Werror=missing-field-initializers
         -Werror=reorder
+        -Werror=sign-compare
         -Werror=switch
         -Werror=uninitialized
         -Werror=unused-function

--- a/src/audio_core/CMakeLists.txt
+++ b/src/audio_core/CMakeLists.txt
@@ -51,9 +51,6 @@ if (NOT MSVC)
     target_compile_options(audio_core PRIVATE
         -Werror=conversion
         -Werror=ignored-qualifiers
-        -Werror=implicit-fallthrough
-        -Werror=reorder
-        -Werror=sign-compare
         -Werror=shadow
         -Werror=unused-parameter
         -Werror=unused-variable

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -667,8 +667,6 @@ else()
     target_compile_options(core PRIVATE
         -Werror=conversion
         -Werror=ignored-qualifiers
-        -Werror=implicit-fallthrough
-        -Werror=sign-compare
         -Werror=shadow
 
         $<$<CXX_COMPILER_ID:GNU>:-Werror=class-memaccess>

--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -44,10 +44,7 @@ else()
         -Werror
         -Werror=conversion
         -Werror=ignored-qualifiers
-        -Werror=implicit-fallthrough
-        -Werror=reorder
         -Werror=shadow
-        -Werror=sign-compare
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-variable>
         -Werror=unused-variable


### PR DESCRIPTION
Treats (un)signed comparison mismatches as errors to be consistent with MSVC