### PR TITLE
[audren] Report 2 channels active rather than 1

### DIFF
--- a/src/core/hle/service/audio/audren_u.cpp
+++ b/src/core/hle/service/audio/audren_u.cpp
@@ -290,7 +290,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(ResultSuccess);
-        rb.Push<u32>(1);
+        rb.Push<u32>(2);
     }
 
     // Should be similar to QueryAudioDeviceOutputEvent


### PR DESCRIPTION
Tales of Vesperia calls this, and caps the number of channels it will output to the result. Only sending back 1 was limiting it to left speaker-only mono audio.

Ideally it should be pulled from the actual active buffer's channel count (?), but I'm not sure how to access it from this service. I don't know why it's calling through audren to get the channels for audout. It doesn't even use audren at all otherwise, just this single function.

Closes https://github.com/yuzu-emu/yuzu/issues/6175.

Edit: Setting the maximum of 6 channels actually caused issues with the audio quality in the game, not sure why. Just reporting 2 instead for now.