### PR TITLE
audio_core: Preserve front channel volume after 6 to 2 downmix

### DIFF
--- a/src/audio_core/command_generator.h
+++ b/src/audio_core/command_generator.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <span>
 #include "audio_core/common.h"
 #include "audio_core/voice_context.h"
 #include "common/common_types.h"
@@ -41,10 +42,10 @@ public:
     void PreCommand();
     void PostCommand();
 
-    [[nodiscard]] s32* GetChannelMixBuffer(s32 channel);
-    [[nodiscard]] const s32* GetChannelMixBuffer(s32 channel) const;
-    [[nodiscard]] s32* GetMixBuffer(std::size_t index);
-    [[nodiscard]] const s32* GetMixBuffer(std::size_t index) const;
+    [[nodiscard]] std::span<s32> GetChannelMixBuffer(s32 channel);
+    [[nodiscard]] std::span<const s32> GetChannelMixBuffer(s32 channel) const;
+    [[nodiscard]] std::span<s32> GetMixBuffer(std::size_t index);
+    [[nodiscard]] std::span<const s32> GetMixBuffer(std::size_t index) const;
     [[nodiscard]] std::size_t GetMixChannelBufferOffset(s32 channel) const;
 
     [[nodiscard]] std::size_t GetTotalMixBufferCount() const;
@@ -77,10 +78,11 @@ private:
     void GenerateAuxCommand(s32 mix_buffer_offset, EffectBase* info, bool enabled);
     [[nodiscard]] ServerSplitterDestinationData* GetDestinationData(s32 splitter_id, s32 index);
 
-    s32 WriteAuxBuffer(AuxInfoDSP& dsp_info, VAddr send_buffer, u32 max_samples, const s32* data,
-                       u32 sample_count, u32 write_offset, u32 write_count);
-    s32 ReadAuxBuffer(AuxInfoDSP& recv_info, VAddr recv_buffer, u32 max_samples, s32* out_data,
-                      u32 sample_count, u32 read_offset, u32 read_count);
+    s32 WriteAuxBuffer(AuxInfoDSP& dsp_info, VAddr send_buffer, u32 max_samples,
+                       std::span<const s32> data, u32 sample_count, u32 write_offset,
+                       u32 write_count);
+    s32 ReadAuxBuffer(AuxInfoDSP& recv_info, VAddr recv_buffer, u32 max_samples,
+                      std::span<s32> out_data, u32 sample_count, u32 read_offset, u32 read_count);
 
     void InitializeI3dl2Reverb(I3dl2ReverbParams& info, I3dl2ReverbState& state,
                                std::vector<u8>& work_buffer);
@@ -90,8 +92,9 @@ private:
                     s32 sample_end_offset, s32 sample_count, s32 channel, std::size_t mix_offset);
     s32 DecodeAdpcm(ServerVoiceInfo& voice_info, VoiceState& dsp_state, s32 sample_start_offset,
                     s32 sample_end_offset, s32 sample_count, s32 channel, std::size_t mix_offset);
-    void DecodeFromWaveBuffers(ServerVoiceInfo& voice_info, s32* output, VoiceState& dsp_state,
-                               s32 channel, s32 target_sample_rate, s32 sample_count, s32 node_id);
+    void DecodeFromWaveBuffers(ServerVoiceInfo& voice_info, std::span<s32> output,
+                               VoiceState& dsp_state, s32 channel, s32 target_sample_rate,
+                               s32 sample_count, s32 node_id);
 
     AudioCommon::AudioRendererParameter& worker_params;
     VoiceContext& voice_context;

--- a/src/audio_core/sink_context.cpp
+++ b/src/audio_core/sink_context.cpp
@@ -15,10 +15,17 @@ std::size_t SinkContext::GetCount() const {
 void SinkContext::UpdateMainSink(const SinkInfo::InParams& in) {
     ASSERT(in.type == SinkTypes::Device);
 
-    has_downmix_coefs = in.device.down_matrix_enabled;
-    if (has_downmix_coefs) {
+    if (in.device.down_matrix_enabled) {
         downmix_coefficients = in.device.down_matrix_coef;
+    } else {
+        downmix_coefficients = {
+            1.0f,   // front
+            0.707f, // center
+            0.0f,   // lfe
+            0.707f, // back
+        };
     }
+
     in_use = in.in_use;
     use_count = in.device.input_count;
     buffers = in.device.input;
@@ -32,10 +39,6 @@ std::vector<u8> SinkContext::OutputBuffers() const {
     std::vector<u8> buffer_ret(use_count);
     std::memcpy(buffer_ret.data(), buffers.data(), use_count);
     return buffer_ret;
-}
-
-bool SinkContext::HasDownMixingCoefficients() const {
-    return has_downmix_coefs;
 }
 
 const DownmixCoefficients& SinkContext::GetDownmixCoefficients() const {

--- a/src/audio_core/sink_context.h
+++ b/src/audio_core/sink_context.h
@@ -84,7 +84,6 @@ public:
     [[nodiscard]] bool InUse() const;
     [[nodiscard]] std::vector<u8> OutputBuffers() const;
 
-    [[nodiscard]] bool HasDownMixingCoefficients() const;
     [[nodiscard]] const DownmixCoefficients& GetDownmixCoefficients() const;
 
 private:
@@ -92,7 +91,6 @@ private:
     s32 use_count{};
     std::array<u8, AudioCommon::MAX_CHANNEL_COUNT> buffers{};
     std::size_t sink_count{};
-    bool has_downmix_coefs{false};
     DownmixCoefficients downmix_coefficients{};
 };
 } // namespace AudioCore


### PR DESCRIPTION
Many games report 6 channel output while only providing data for 2. We only output 2-channel audio regardless, and in the downmixing, front left/right are only providing 36% of their volume. This is done assuming all of the other channels also contain valid data, but in a few games they don't. This PR alters the downmixing to preserve front left/right, so volume is not lost.

This improves Link's Awakening, New Super Mario Bros U, Disgaea 6, Super Kirby Clash.

Buffer raw pointers have been replaced with spans as well. This was mainly to aid debugging, as MSVC won't show elements of pointers, but will show the whole span.