### PR TITLE
core,common,yuzu qt: Add CPU accuracy option 'Auto'

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -93,7 +93,7 @@ bool IsGPULevelHigh() {
 }
 
 bool IsFastmemEnabled() {
-    if (values.cpu_accuracy.GetValue() == CPUAccuracy::DebugMode) {
+    if (values.cpu_debug_mode) {
         return static_cast<bool>(values.cpuopt_fastmem);
     }
     return true;

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -34,7 +34,6 @@ enum class CPUAccuracy : u32 {
     Auto = 0,
     Accurate = 1,
     Unsafe = 2,
-    DebugMode = 3,
 };
 
 /** The BasicSetting class is a simple resource manager. It defines a label and default value
@@ -288,6 +287,7 @@ struct Values {
     Setting<CPUAccuracy> cpu_accuracy{CPUAccuracy::Auto, "cpu_accuracy"};
     // TODO: remove cpu_accuracy_first_time, migration setting added 8 July 2021
     BasicSetting<bool> cpu_accuracy_first_time{true, "cpu_accuracy_first_time"};
+    BasicSetting<bool> cpu_debug_mode{false, "cpu_debug_mode"};
 
     BasicSetting<bool> cpuopt_page_tables{true, "cpuopt_page_tables"};
     BasicSetting<bool> cpuopt_block_linking{true, "cpuopt_block_linking"};

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -286,6 +286,8 @@ struct Values {
 
     // Cpu
     Setting<CPUAccuracy> cpu_accuracy{CPUAccuracy::Auto, "cpu_accuracy"};
+    // TODO: remove cpu_accuracy_first_time, migration setting added 8 July 2021
+    BasicSetting<bool> cpu_accuracy_first_time{true, "cpu_accuracy_first_time"};
 
     BasicSetting<bool> cpuopt_page_tables{true, "cpuopt_page_tables"};
     BasicSetting<bool> cpuopt_block_linking{true, "cpuopt_block_linking"};

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -31,9 +31,10 @@ enum class GPUAccuracy : u32 {
 };
 
 enum class CPUAccuracy : u32 {
-    Accurate = 0,
-    Unsafe = 1,
-    DebugMode = 2,
+    Auto = 0,
+    Accurate = 1,
+    Unsafe = 2,
+    DebugMode = 3,
 };
 
 /** The BasicSetting class is a simple resource manager. It defines a label and default value
@@ -284,7 +285,7 @@ struct Values {
     Setting<bool> use_multi_core{true, "use_multi_core"};
 
     // Cpu
-    Setting<CPUAccuracy> cpu_accuracy{CPUAccuracy::Accurate, "cpu_accuracy"};
+    Setting<CPUAccuracy> cpu_accuracy{CPUAccuracy::Auto, "cpu_accuracy"};
 
     BasicSetting<bool> cpuopt_page_tables{true, "cpuopt_page_tables"};
     BasicSetting<bool> cpuopt_block_linking{true, "cpuopt_block_linking"};

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -200,15 +200,9 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
     // Curated optimizations
     if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Auto) {
         config.unsafe_optimizations = true;
-        if (Settings::values.cpuopt_unsafe_unfuse_fma) {
-            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
-        }
-        if (Settings::values.cpuopt_unsafe_ignore_standard_fpcr) {
-            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreStandardFPCRValue;
-        }
-        if (Settings::values.cpuopt_unsafe_inaccurate_nan) {
-            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
-        }
+        config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
+        config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreStandardFPCRValue;
+        config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
     }
 
     return std::make_unique<Dynarmic::A32::Jit>(config);

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -183,16 +183,30 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
     // Unsafe optimizations
     if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Unsafe) {
         config.unsafe_optimizations = true;
-        if (Settings::values.cpuopt_unsafe_unfuse_fma.GetValue()) {
+        if (Settings::values.cpuopt_unsafe_unfuse_fma) {
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
         }
-        if (Settings::values.cpuopt_unsafe_reduce_fp_error.GetValue()) {
+        if (Settings::values.cpuopt_unsafe_reduce_fp_error) {
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_ReducedErrorFP;
         }
-        if (Settings::values.cpuopt_unsafe_ignore_standard_fpcr.GetValue()) {
+        if (Settings::values.cpuopt_unsafe_ignore_standard_fpcr) {
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreStandardFPCRValue;
         }
-        if (Settings::values.cpuopt_unsafe_inaccurate_nan.GetValue()) {
+        if (Settings::values.cpuopt_unsafe_inaccurate_nan) {
+            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
+        }
+    }
+
+    // Curated optimizations
+    if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Auto) {
+        config.unsafe_optimizations = true;
+        if (Settings::values.cpuopt_unsafe_unfuse_fma) {
+            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
+        }
+        if (Settings::values.cpuopt_unsafe_ignore_standard_fpcr) {
+            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreStandardFPCRValue;
+        }
+        if (Settings::values.cpuopt_unsafe_inaccurate_nan) {
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
         }
     }

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -150,7 +150,7 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
     config.far_code_offset = 400_MiB;
 
     // Safe optimizations
-    if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::DebugMode) {
+    if (Settings::values.cpu_debug_mode) {
         if (!Settings::values.cpuopt_page_tables) {
             config.page_table = nullptr;
         }

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -240,15 +240,8 @@ std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* 
     // Curated optimizations
     if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Auto) {
         config.unsafe_optimizations = true;
-        if (Settings::values.cpuopt_unsafe_unfuse_fma) {
-            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
-        }
-        if (Settings::values.cpuopt_unsafe_inaccurate_nan) {
-            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
-        }
-        if (Settings::values.cpuopt_unsafe_fastmem_check) {
-            config.fastmem_address_space_bits = 64;
-        }
+        config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
+        config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
     }
 
     return std::make_shared<Dynarmic::A64::Jit>(config);

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -190,7 +190,7 @@ std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* 
     config.far_code_offset = 400_MiB;
 
     // Safe optimizations
-    if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::DebugMode) {
+    if (Settings::values.cpu_debug_mode) {
         if (!Settings::values.cpuopt_page_tables) {
             config.page_table = nullptr;
         }

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -223,16 +223,30 @@ std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* 
     // Unsafe optimizations
     if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Unsafe) {
         config.unsafe_optimizations = true;
-        if (Settings::values.cpuopt_unsafe_unfuse_fma.GetValue()) {
+        if (Settings::values.cpuopt_unsafe_unfuse_fma) {
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
         }
-        if (Settings::values.cpuopt_unsafe_reduce_fp_error.GetValue()) {
+        if (Settings::values.cpuopt_unsafe_reduce_fp_error) {
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_ReducedErrorFP;
         }
-        if (Settings::values.cpuopt_unsafe_inaccurate_nan.GetValue()) {
+        if (Settings::values.cpuopt_unsafe_inaccurate_nan) {
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
         }
-        if (Settings::values.cpuopt_unsafe_fastmem_check.GetValue()) {
+        if (Settings::values.cpuopt_unsafe_fastmem_check) {
+            config.fastmem_address_space_bits = 64;
+        }
+    }
+
+    // Curated optimizations
+    if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Auto) {
+        config.unsafe_optimizations = true;
+        if (Settings::values.cpuopt_unsafe_unfuse_fma) {
+            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
+        }
+        if (Settings::values.cpuopt_unsafe_inaccurate_nan) {
+            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
+        }
+        if (Settings::values.cpuopt_unsafe_fastmem_check) {
             config.fastmem_address_space_bits = 64;
         }
     }

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -242,6 +242,7 @@ std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* 
         config.unsafe_optimizations = true;
         config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
         config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
+        config.fastmem_address_space_bits = 64;
     }
 
     return std::make_shared<Dynarmic::A64::Jit>(config);

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -52,6 +52,9 @@ add_executable(yuzu
     configuration/configure_debug_controller.cpp
     configuration/configure_debug_controller.h
     configuration/configure_debug_controller.ui
+    configuration/configure_debug_tab.cpp
+    configuration/configure_debug_tab.h
+    configuration/configure_debug_tab.ui
     configuration/configure_dialog.cpp
     configuration/configure_dialog.h
     configuration/configure_filesystem.cpp

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -793,7 +793,13 @@ void Config::ReadPathValues() {
 void Config::ReadCpuValues() {
     qt_config->beginGroup(QStringLiteral("Cpu"));
 
-    ReadGlobalSetting(Settings::values.cpu_accuracy);
+    ReadBasicSetting(Settings::values.cpu_accuracy_first_time);
+    if (Settings::values.cpu_accuracy_first_time) {
+        Settings::values.cpu_accuracy.SetValue(Settings::values.cpu_accuracy.GetDefault());
+        Settings::values.cpu_accuracy_first_time.SetValue(false);
+    } else {
+        ReadGlobalSetting(Settings::values.cpu_accuracy);
+    }
 
     ReadGlobalSetting(Settings::values.cpuopt_unsafe_unfuse_fma);
     ReadGlobalSetting(Settings::values.cpuopt_unsafe_reduce_fp_error);
@@ -1309,6 +1315,7 @@ void Config::SavePathValues() {
 void Config::SaveCpuValues() {
     qt_config->beginGroup(QStringLiteral("Cpu"));
 
+    WriteBasicSetting(Settings::values.cpu_accuracy_first_time);
     WriteSetting(QStringLiteral("cpu_accuracy"),
                  static_cast<u32>(Settings::values.cpu_accuracy.GetValue(global)),
                  static_cast<u32>(Settings::values.cpu_accuracy.GetDefault()),

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -808,6 +808,7 @@ void Config::ReadCpuValues() {
     ReadGlobalSetting(Settings::values.cpuopt_unsafe_fastmem_check);
 
     if (global) {
+        ReadBasicSetting(Settings::values.cpu_debug_mode);
         ReadBasicSetting(Settings::values.cpuopt_page_tables);
         ReadBasicSetting(Settings::values.cpuopt_block_linking);
         ReadBasicSetting(Settings::values.cpuopt_return_stack_buffer);
@@ -1328,6 +1329,7 @@ void Config::SaveCpuValues() {
     WriteGlobalSetting(Settings::values.cpuopt_unsafe_fastmem_check);
 
     if (global) {
+        WriteBasicSetting(Settings::values.cpu_debug_mode);
         WriteBasicSetting(Settings::values.cpuopt_page_tables);
         WriteBasicSetting(Settings::values.cpuopt_block_linking);
         WriteBasicSetting(Settings::values.cpuopt_return_stack_buffer);

--- a/src/yuzu/configuration/configure.ui
+++ b/src/yuzu/configuration/configure.ui
@@ -41,7 +41,7 @@
      <item>
       <widget class="QTabWidget" name="tabWidget">
        <property name="currentIndex">
-        <number>0</number>
+        <number>11</number>
        </property>
        <widget class="ConfigureGeneral" name="generalTab">
         <property name="accessibleName">
@@ -107,14 +107,6 @@
          <string>CPU</string>
         </attribute>
        </widget>
-       <widget class="ConfigureCpuDebug" name="cpuDebugTab">
-        <property name="accessibleName">
-         <string>Debug</string>
-        </property>
-        <attribute name="title">
-         <string>Debug</string>
-        </attribute>
-       </widget>
        <widget class="ConfigureGraphics" name="graphicsTab">
         <property name="accessibleName">
          <string>Graphics</string>
@@ -139,7 +131,7 @@
          <string>Audio</string>
         </attribute>
        </widget>
-       <widget class="ConfigureDebug" name="debugTab">
+       <widget class="ConfigureDebugTab" name="debugTab">
         <property name="accessibleName">
          <string>Debug</string>
         </property>
@@ -208,21 +200,9 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>ConfigureDebug</class>
-   <extends>QWidget</extends>
-   <header>configuration/configure_debug.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>ConfigureCpu</class>
    <extends>QWidget</extends>
    <header>configuration/configure_cpu.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
-   <class>ConfigureCpuDebug</class>
-   <extends>QWidget</extends>
-   <header>configuration/configure_cpu_debug.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -267,6 +247,12 @@
    <header>configuration/configure_service.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>ConfigureDebugTab</class>
+   <extends>QWidget</extends>
+   <header>configuration/configure_debug_tab.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <resources/>
  <connections>
@@ -275,12 +261,32 @@
    <signal>accepted()</signal>
    <receiver>ConfigureDialog</receiver>
    <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
   <connection>
    <sender>buttonBox</sender>
    <signal>rejected()</signal>
    <receiver>ConfigureDialog</receiver>
    <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
   </connection>
  </connections>
 </ui>

--- a/src/yuzu/configuration/configure_cpu.cpp
+++ b/src/yuzu/configuration/configure_cpu.cpp
@@ -20,8 +20,6 @@ ConfigureCpu::ConfigureCpu(QWidget* parent) : QWidget(parent), ui(new Ui::Config
 
     SetConfiguration();
 
-    connect(ui->accuracy, qOverload<int>(&QComboBox::activated), this,
-            &ConfigureCpu::AccuracyUpdated);
     connect(ui->accuracy, qOverload<int>(&QComboBox::currentIndexChanged), this,
             &ConfigureCpu::UpdateGroup);
 }
@@ -56,20 +54,6 @@ void ConfigureCpu::SetConfiguration() {
                                           !Settings::values.cpu_accuracy.UsingGlobal());
     }
     UpdateGroup(ui->accuracy->currentIndex());
-}
-
-void ConfigureCpu::AccuracyUpdated(int index) {
-    if (Settings::IsConfiguringGlobal() &&
-        static_cast<Settings::CPUAccuracy>(index) == Settings::CPUAccuracy::DebugMode) {
-        const auto result = QMessageBox::warning(this, tr("Setting CPU to Debug Mode"),
-                                                 tr("CPU Debug Mode is only intended for developer "
-                                                    "use. Are you sure you want to enable this?"),
-                                                 QMessageBox::Yes | QMessageBox::No);
-        if (result == QMessageBox::No) {
-            ui->accuracy->setCurrentIndex(static_cast<int>(Settings::CPUAccuracy::Accurate));
-            UpdateGroup(static_cast<int>(Settings::CPUAccuracy::Accurate));
-        }
-    }
 }
 
 void ConfigureCpu::UpdateGroup(int index) {
@@ -134,8 +118,6 @@ void ConfigureCpu::SetupPerGameUI() {
     ConfigurationShared::SetColoredComboBox(
         ui->accuracy, ui->widget_accuracy,
         static_cast<u32>(Settings::values.cpu_accuracy.GetValue(true)));
-    ui->accuracy->removeItem(static_cast<u32>(Settings::CPUAccuracy::DebugMode) +
-                             ConfigurationShared::USE_GLOBAL_OFFSET);
 
     ConfigurationShared::SetColoredTristate(ui->cpuopt_unsafe_unfuse_fma,
                                             Settings::values.cpuopt_unsafe_unfuse_fma,

--- a/src/yuzu/configuration/configure_cpu.h
+++ b/src/yuzu/configuration/configure_cpu.h
@@ -29,7 +29,6 @@ private:
     void changeEvent(QEvent* event) override;
     void RetranslateUI();
 
-    void AccuracyUpdated(int index);
     void UpdateGroup(int index);
 
     void SetConfiguration();

--- a/src/yuzu/configuration/configure_cpu.ui
+++ b/src/yuzu/configuration/configure_cpu.ui
@@ -49,11 +49,6 @@
                <string>Unsafe</string>
               </property>
              </item>
-             <item>
-              <property name="text">
-               <string>Enable Debug Mode</string>
-              </property>
-             </item>
             </widget>
            </item>
           </layout>

--- a/src/yuzu/configuration/configure_cpu.ui
+++ b/src/yuzu/configuration/configure_cpu.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>321</height>
+    <width>448</width>
+    <height>433</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,7 @@
    <item>
     <layout class="QVBoxLayout">
      <item>
-      <widget class="QGroupBox">
+      <widget class="QGroupBox" name="groupBox">
        <property name="title">
         <string>General</string>
        </property>
@@ -34,6 +34,11 @@
            </item>
            <item>
             <widget class="QComboBox" name="accuracy">
+             <item>
+              <property name="text">
+               <string>Auto</string>
+              </property>
+             </item>
              <item>
               <property name="text">
                <string>Accurate</string>
@@ -57,7 +62,7 @@
         <item>
          <widget class="QLabel" name="label_recommended_accuracy">
           <property name="text">
-           <string>We recommend setting accuracy to &quot;Accurate&quot;.</string>
+           <string>We recommend setting accuracy to &quot;Auto&quot;.</string>
           </property>
           <property name="wordWrap">
            <bool>false</bool>

--- a/src/yuzu/configuration/configure_cpu_debug.ui
+++ b/src/yuzu/configuration/configure_cpu_debug.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>321</height>
+    <width>592</width>
+    <height>503</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,139 +17,131 @@
    <item>
     <layout class="QVBoxLayout">
      <item>
-      <widget class="QGroupBox">
+      <widget class="QGroupBox" name="groupBox">
        <property name="title">
         <string>Toggle CPU Optimizations</string>
        </property>
        <layout class="QVBoxLayout">
         <item>
-         <widget class="QLabel">
-          <property name="wordWrap">
-            <bool>1</bool>
-          </property>
+         <widget class="QLabel" name="label">
           <property name="text">
-           <string>
-            &lt;div&gt;
-            &lt;b&gt;For debugging only.&lt;/b&gt;
-            &lt;br&gt;
-            If you're not sure what these do, keep all of these enabled.
-            &lt;br&gt;
-            These settings, when disabled, only take effect when CPU Accuracy is "Debug Mode".
-            &lt;/div&gt;
-           </string>
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;For debugging only.&lt;/span&gt;&lt;br/&gt;If you're not sure what these do, keep all of these enabled. &lt;br/&gt;These settings, when disabled, only take effect when CPU Debugging is enabled. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="wordWrap">
+           <bool>false</bool>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QCheckBox" name="cpuopt_page_tables">
-          <property name="text">
-           <string>Enable inline page tables</string>
-          </property>
           <property name="toolTip">
            <string>
-            &lt;div style="white-space: nowrap"&gt;This optimization speeds up memory accesses by the guest program.&lt;/div&gt;
-            &lt;div style="white-space: nowrap"&gt;Enabling it inlines accesses to PageTable::pointers into emitted code.&lt;/div&gt;
-            &lt;div style="white-space: nowrap"&gt;Disabling this forces all memory accesses to go through the Memory::Read/Memory::Write functions.&lt;/div&gt;
+            &lt;div style=&quot;white-space: nowrap&quot;&gt;This optimization speeds up memory accesses by the guest program.&lt;/div&gt;
+            &lt;div style=&quot;white-space: nowrap&quot;&gt;Enabling it inlines accesses to PageTable::pointers into emitted code.&lt;/div&gt;
+            &lt;div style=&quot;white-space: nowrap&quot;&gt;Disabling this forces all memory accesses to go through the Memory::Read/Memory::Write functions.&lt;/div&gt;
            </string>
+          </property>
+          <property name="text">
+           <string>Enable inline page tables</string>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QCheckBox" name="cpuopt_block_linking">
-          <property name="text">
-           <string>Enable block linking</string>
-          </property>
           <property name="toolTip">
            <string>
             &lt;div&gt;This optimization avoids dispatcher lookups by allowing emitted basic blocks to jump directly to other basic blocks if the destination PC is static.&lt;/div&gt;
            </string>
           </property>
+          <property name="text">
+           <string>Enable block linking</string>
+          </property>
          </widget>
         </item>
         <item>
          <widget class="QCheckBox" name="cpuopt_return_stack_buffer">
-          <property name="text">
-           <string>Enable return stack buffer</string>
-          </property>
           <property name="toolTip">
            <string>
             &lt;div&gt;This optimization avoids dispatcher lookups by keeping track potential return addresses of BL instructions. This approximates what happens with a return stack buffer on a real CPU.&lt;/div&gt;
            </string>
           </property>
+          <property name="text">
+           <string>Enable return stack buffer</string>
+          </property>
          </widget>
         </item>
         <item>
          <widget class="QCheckBox" name="cpuopt_fast_dispatcher">
-          <property name="text">
-           <string>Enable fast dispatcher</string>
-          </property>
           <property name="toolTip">
            <string>
             &lt;div&gt;Enable a two-tiered dispatch system. A faster dispatcher written in assembly has a small MRU cache of jump destinations is used first. If that fails, dispatch falls back to the slower C++ dispatcher.&lt;/div&gt;
            </string>
           </property>
+          <property name="text">
+           <string>Enable fast dispatcher</string>
+          </property>
          </widget>
         </item>
         <item>
          <widget class="QCheckBox" name="cpuopt_context_elimination">
-          <property name="text">
-           <string>Enable context elimination</string>
-          </property>
           <property name="toolTip">
            <string>
             &lt;div&gt;Enables an IR optimization that reduces unnecessary accesses to the CPU context structure.&lt;/div&gt;
            </string>
           </property>
+          <property name="text">
+           <string>Enable context elimination</string>
+          </property>
          </widget>
         </item>
         <item>
          <widget class="QCheckBox" name="cpuopt_const_prop">
-          <property name="text">
-           <string>Enable constant propagation</string>
-          </property>
           <property name="toolTip">
            <string>
             &lt;div&gt;Enables IR optimizations that involve constant propagation.&lt;/div&gt;
            </string>
           </property>
+          <property name="text">
+           <string>Enable constant propagation</string>
+          </property>
          </widget>
         </item>
         <item>
          <widget class="QCheckBox" name="cpuopt_misc_ir">
-          <property name="text">
-           <string>Enable miscellaneous optimizations</string>
-          </property>
           <property name="toolTip">
            <string>
             &lt;div&gt;Enables miscellaneous IR optimizations.&lt;/div&gt;
            </string>
           </property>
+          <property name="text">
+           <string>Enable miscellaneous optimizations</string>
+          </property>
          </widget>
         </item>
         <item>
          <widget class="QCheckBox" name="cpuopt_reduce_misalign_checks">
-          <property name="text">
-           <string>Enable misalignment check reduction</string>
-          </property>
           <property name="toolTip">
            <string>
-            &lt;div style="white-space: nowrap"&gt;When enabled, a misalignment is only triggered when an access crosses a page boundary.&lt;/div&gt;
-            &lt;div style="white-space: nowrap"&gt;When disabled, a misalignment is triggered on all misaligned accesses.&lt;/div&gt;
+            &lt;div style=&quot;white-space: nowrap&quot;&gt;When enabled, a misalignment is only triggered when an access crosses a page boundary.&lt;/div&gt;
+            &lt;div style=&quot;white-space: nowrap&quot;&gt;When disabled, a misalignment is triggered on all misaligned accesses.&lt;/div&gt;
            </string>
+          </property>
+          <property name="text">
+           <string>Enable misalignment check reduction</string>
           </property>
          </widget>
         </item>
         <item>
          <widget class="QCheckBox" name="cpuopt_fastmem">
-          <property name="text">
-           <string>Enable Host MMU Emulation</string>
-          </property>
           <property name="toolTip">
            <string>
-            &lt;div style="white-space: nowrap"&gt;This optimization speeds up memory accesses by the guest program.&lt;/div&gt;
-            &lt;div style="white-space: nowrap"&gt;Enabling it causes guest memory reads/writes to be done directly into memory and make use of Host's MMU.&lt;/div&gt;
-            &lt;div style="white-space: nowrap"&gt;Disabling this forces all memory accesses to use Software MMU Emulation.&lt;/div&gt;
+            &lt;div style=&quot;white-space: nowrap&quot;&gt;This optimization speeds up memory accesses by the guest program.&lt;/div&gt;
+            &lt;div style=&quot;white-space: nowrap&quot;&gt;Enabling it causes guest memory reads/writes to be done directly into memory and make use of Host's MMU.&lt;/div&gt;
+            &lt;div style=&quot;white-space: nowrap&quot;&gt;Disabling this forces all memory accesses to use Software MMU Emulation.&lt;/div&gt;
            </string>
+          </property>
+          <property name="text">
+           <string>Enable Host MMU Emulation</string>
           </property>
          </widget>
         </item>

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -43,6 +43,8 @@ void ConfigureDebug::SetConfiguration() {
     ui->use_auto_stub->setChecked(Settings::values.use_auto_stub.GetValue());
     ui->enable_graphics_debugging->setEnabled(runtime_lock);
     ui->enable_graphics_debugging->setChecked(Settings::values.renderer_debug.GetValue());
+    ui->enable_cpu_debugging->setEnabled(runtime_lock);
+    ui->enable_cpu_debugging->setChecked(Settings::values.cpu_debug_mode.GetValue());
     ui->disable_macro_jit->setEnabled(runtime_lock);
     ui->disable_macro_jit->setChecked(Settings::values.disable_macro_jit.GetValue());
     ui->extended_logging->setChecked(Settings::values.extended_logging.GetValue());
@@ -58,6 +60,7 @@ void ConfigureDebug::ApplyConfiguration() {
     Settings::values.use_debug_asserts = ui->use_debug_asserts->isChecked();
     Settings::values.use_auto_stub = ui->use_auto_stub->isChecked();
     Settings::values.renderer_debug = ui->enable_graphics_debugging->isChecked();
+    Settings::values.cpu_debug_mode = ui->enable_cpu_debugging->isChecked();
     Settings::values.disable_macro_jit = ui->disable_macro_jit->isChecked();
     Settings::values.extended_logging = ui->extended_logging->isChecked();
     Debugger::ToggleConsole();

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>486</height>
+    <height>777</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -192,34 +192,41 @@
         </property>
        </widget>
       </item>
-       <item>
-         <widget class="QCheckBox" name="use_debug_asserts">
-           <property name="text">
-             <string>Enable Debug Asserts</string>
-           </property>
-         </widget>
-       </item>
-       <item>
-         <widget class="QCheckBox" name="use_auto_stub">
-           <property name="text">
-             <string>Enable Auto-Stub</string>
-           </property>
-         </widget>
-       </item>
       <item>
-        <widget class="QLabel" name="label_5">
-          <property name="font">
-            <font>
-              <italic>true</italic>
-            </font>
-          </property>
-          <property name="text">
-            <string>This will be reset automatically when yuzu closes.</string>
-          </property>
-          <property name="indent">
-            <number>20</number>
-          </property>
-        </widget>
+       <widget class="QCheckBox" name="enable_cpu_debugging">
+        <property name="text">
+         <string>Enable CPU Debugging</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="use_debug_asserts">
+        <property name="text">
+         <string>Enable Debug Asserts</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="use_auto_stub">
+        <property name="text">
+         <string>Enable Auto-Stub</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_5">
+        <property name="font">
+         <font>
+          <italic>true</italic>
+         </font>
+        </property>
+        <property name="text">
+         <string>This will be reset automatically when yuzu closes.</string>
+        </property>
+        <property name="indent">
+         <number>20</number>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/yuzu/configuration/configure_debug_tab.cpp
+++ b/src/yuzu/configuration/configure_debug_tab.cpp
@@ -1,0 +1,38 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "ui_configure_debug_tab.h"
+#include "yuzu/configuration/configure_debug_tab.h"
+
+ConfigureDebugTab::ConfigureDebugTab(QWidget* parent)
+    : QWidget(parent), ui(new Ui::ConfigureDebugTab) {
+    ui->setupUi(this);
+
+    SetConfiguration();
+}
+
+ConfigureDebugTab::~ConfigureDebugTab() = default;
+
+void ConfigureDebugTab::ApplyConfiguration() {
+    ui->debugTab->ApplyConfiguration();
+    ui->cpuDebugTab->ApplyConfiguration();
+}
+
+void ConfigureDebugTab::SetCurrentIndex(int index) {
+    ui->tabWidget->setCurrentIndex(index);
+}
+
+void ConfigureDebugTab::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
+void ConfigureDebugTab::RetranslateUI() {
+    ui->retranslateUi(this);
+}
+
+void ConfigureDebugTab::SetConfiguration() {}

--- a/src/yuzu/configuration/configure_debug_tab.h
+++ b/src/yuzu/configuration/configure_debug_tab.h
@@ -1,4 +1,4 @@
-// Copyright 2020 yuzu Emulator Project
+// Copyright 2021 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -8,17 +8,19 @@
 #include <QWidget>
 
 namespace Ui {
-class ConfigureCpuDebug;
+class ConfigureDebugTab;
 }
 
-class ConfigureCpuDebug : public QWidget {
+class ConfigureDebugTab : public QWidget {
     Q_OBJECT
 
 public:
-    explicit ConfigureCpuDebug(QWidget* parent = nullptr);
-    ~ConfigureCpuDebug() override;
+    explicit ConfigureDebugTab(QWidget* parent = nullptr);
+    ~ConfigureDebugTab() override;
 
     void ApplyConfiguration();
+
+    void SetCurrentIndex(int index);
 
 private:
     void changeEvent(QEvent* event) override;
@@ -26,5 +28,5 @@ private:
 
     void SetConfiguration();
 
-    std::unique_ptr<Ui::ConfigureCpuDebug> ui;
+    std::unique_ptr<Ui::ConfigureDebugTab> ui;
 };

--- a/src/yuzu/configuration/configure_debug_tab.ui
+++ b/src/yuzu/configuration/configure_debug_tab.ui
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ConfigureDebugTab</class>
+ <widget class="QWidget" name="ConfigureDebugTab">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>320</width>
+    <height>240</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>1</number>
+     </property>
+     <widget class="ConfigureDebug" name="debugTab">
+      <attribute name="title">
+       <string>General</string>
+      </attribute>
+     </widget>
+     <widget class="ConfigureCpuDebug" name="cpuDebugTab">
+      <attribute name="title">
+       <string>CPU</string>
+      </attribute>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ConfigureDebug</class>
+   <extends>QWidget</extends>
+   <header>configuration/configure_debug.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>ConfigureCpuDebug</class>
+   <extends>QWidget</extends>
+   <header>configuration/configure_cpu_debug.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -8,6 +8,7 @@
 #include <QListWidgetItem>
 #include <QPushButton>
 #include <QSignalBlocker>
+#include <QTabWidget>
 #include "common/settings.h"
 #include "core/core.h"
 #include "ui_configure.h"
@@ -32,6 +33,8 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry,
     SetConfiguration();
     PopulateSelectionList();
 
+    connect(ui->tabWidget, &QTabWidget::currentChanged, this,
+            [this]() { ui->debugTab->SetCurrentIndex(0); });
     connect(ui->uiTab, &ConfigureUi::LanguageChanged, this, &ConfigureDialog::OnLanguageChanged);
     connect(ui->selectorList, &QListWidget::itemSelectionChanged, this,
             &ConfigureDialog::UpdateVisibleTabs);
@@ -59,7 +62,6 @@ void ConfigureDialog::ApplyConfiguration() {
     ui->inputTab->ApplyConfiguration();
     ui->hotkeysTab->ApplyConfiguration(registry);
     ui->cpuTab->ApplyConfiguration();
-    ui->cpuDebugTab->ApplyConfiguration();
     ui->graphicsTab->ApplyConfiguration();
     ui->graphicsAdvancedTab->ApplyConfiguration();
     ui->audioTab->ApplyConfiguration();
@@ -102,7 +104,7 @@ void ConfigureDialog::PopulateSelectionList() {
     const std::array<std::pair<QString, QList<QWidget*>>, 6> items{
         {{tr("General"), {ui->generalTab, ui->hotkeysTab, ui->uiTab, ui->webTab, ui->debugTab}},
          {tr("System"), {ui->systemTab, ui->profileManagerTab, ui->serviceTab, ui->filesystemTab}},
-         {tr("CPU"), {ui->cpuTab, ui->cpuDebugTab}},
+         {tr("CPU"), {ui->cpuTab}},
          {tr("Graphics"), {ui->graphicsTab, ui->graphicsAdvancedTab}},
          {tr("Audio"), {ui->audioTab}},
          {tr("Controls"), ui->inputTab->GetSubTabs()}},


### PR DESCRIPTION
The current CPU accuracy settings in yuzu are fairly polarized and require more than common knowledge to know what the optimal settings for yuzu would be. This adds a curated option called 'Auto' that applies a few at the moment known-good unsafe optimizations to Dynarmic.

Specifically, sets `Unfuse FMA`, `Faster ASIMD instructions` (32 bits only), `Inaccurate NaN handling`, and `Disable address space checks`.

Also adds migration code, since the old CPU Accuracy setting won't translate well here since we're adding one at the beginning of the list. On first boot with the new setting, just use the default setting.

Now moves the CPU debugging tab and the Debug tab as sub tabs of General -> Debug.