### PR TITLE
qt/main: Make title string more i18n-friendly

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1428,8 +1428,10 @@ void GMainWindow::BootGame(const QString& filename, std::size_t program_index, S
             std::filesystem::path{filename.toStdU16String()}.filename());
     }
     const bool is_64bit = system.Kernel().CurrentProcess()->Is64BitProcess();
-    const auto instruction_set_suffix = is_64bit ? " (64-bit)" : " (32-bit)";
-    title_name += instruction_set_suffix;
+    const auto instruction_set_suffix = is_64bit ? tr("(64-bit)") : tr("(32-bit)");
+    title_name = tr("%1 %2", "%1 is the title name. %2 indicates if the title is 64-bit or 32-bit")
+                     .arg(QString::fromStdString(title_name), instruction_set_suffix)
+                     .toStdString();
     LOG_INFO(Frontend, "Booting game: {:016X} | {} | {}", title_id, title_name, title_version);
     const auto gpu_vendor = system.GPU().Renderer().GetDeviceVendor();
     UpdateWindowTitle(title_name, title_version, gpu_vendor);


### PR DESCRIPTION
Currently, whether or not the title is 32-bit or 64-bit was being appended as a suffix to the title, which is fine for left-to-right languages, but may not always fly so smoothly with some right-to-left languages.

We also weren't marking that portion of the string as translatable, which prevents translators from translating part of the title string.