### PR TITLE
Settings: Eliminate ASYNC & MULTICORE Toggles and add GPU Accuracy to  status bar

### DIFF
--- a/dist/qt_themes/default/style.qss
+++ b/dist/qt_themes/default/style.qss
@@ -38,6 +38,26 @@ QPushButton#RendererStatusBarButton:!checked {
     color: #0066ff;
 }
 
+QPushButton#GPUStatusBarButton {
+    color: #656565;
+    border: 1px solid transparent;
+    background-color: transparent;
+    padding: 0px 3px 0px 3px;
+    text-align: center;
+}
+
+QPushButton#GPUStatusBarButton:hover {
+    border: 1px solid #76797C;
+}
+
+QPushButton#GPUStatusBarButton:checked {
+    color: #ff8040;
+}
+
+QPushButton#GPUStatusBarButton:!checked {
+    color: #40dd40;
+}
+
 QPushButton#buttonRefreshDevices {
     min-width: 21px;
     min-height: 21px;

--- a/dist/qt_themes/qdarkstyle/style.qss
+++ b/dist/qt_themes/qdarkstyle/style.qss
@@ -1283,6 +1283,27 @@ QPushButton#RendererStatusBarButton:!checked {
     color: #00ccdd;
 }
 
+QPushButton#GPUStatusBarButton {
+    min-width: 0px;
+    color: #656565;
+    border: 1px solid transparent;
+    background-color: transparent;
+    padding: 0px 3px 0px 3px;
+    text-align: center;
+}
+
+QPushButton#GPUStatusBarButton:hover {
+    border: 1px solid #76797C;
+}
+
+QPushButton#GPUStatusBarButton:checked {
+    color: #ff8040;
+}
+
+QPushButton#GPUStatusBarButton:!checked {
+    color: #40dd40;
+}
+
 QPushButton#buttonRefreshDevices {
     min-width: 23px;
     min-height: 23px;

--- a/dist/qt_themes/qdarkstyle_midnight_blue/style.qss
+++ b/dist/qt_themes/qdarkstyle_midnight_blue/style.qss
@@ -2186,6 +2186,27 @@ QPushButton#RendererStatusBarButton:!checked {
   color: #00ccdd;
 }
 
+QPushButton#GPUStatusBarButton {
+  min-width: 0px;
+  color: #656565;
+  border: 1px solid transparent;
+  background-color: transparent;
+  padding: 0px 3px 0px 3px;
+  text-align: center;
+}
+
+QPushButton#GPUStatusBarButton:hover {
+  border: 1px solid #76797C;
+}
+
+QPushButton#GPUStatusBarButton:checked {
+  color: #ff8040;
+}
+
+QPushButton#GPUStatusBarButton:!checked {
+  color: #40dd40;
+}
+
 QPushButton#buttonRefreshDevices {
   min-width: 19px;
   min-height: 19px;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2907,12 +2907,12 @@ void GMainWindow::UpdateStatusBar() {
 void GMainWindow::UpdateGPUAccuracyButton() {
     switch (Settings::values.gpu_accuracy.GetValue()) {
     case Settings::GPUAccuracy::Normal: {
-        gpu_accuracy_button->setText(tr("GPU NORMAL "));
+        gpu_accuracy_button->setText(tr("GPU NORMAL"));
         gpu_accuracy_button->setChecked(false);
         break;
     }
     case Settings::GPUAccuracy::High: {
-        gpu_accuracy_button->setText(tr("GPU HIGH   "));
+        gpu_accuracy_button->setText(tr("GPU HIGH"));
         gpu_accuracy_button->setChecked(true);
         break;
     }

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -291,6 +291,7 @@ private:
     void UpdateWindowTitle(std::string_view title_name = {}, std::string_view title_version = {},
                            std::string_view gpu_vendor = {});
     void UpdateStatusBar();
+    void UpdateGPUAccuracyButton();
     void UpdateStatusButtons();
     void UpdateUISettings();
     void HideMouseCursor();
@@ -316,8 +317,7 @@ private:
     QLabel* emu_speed_label = nullptr;
     QLabel* game_fps_label = nullptr;
     QLabel* emu_frametime_label = nullptr;
-    QPushButton* async_status_button = nullptr;
-    QPushButton* multicore_status_button = nullptr;
+    QPushButton* gpu_accuracy_button = nullptr;
     QPushButton* renderer_status_button = nullptr;
     QPushButton* dock_status_button = nullptr;
     QTimer status_bar_update_timer;


### PR DESCRIPTION
This Pull Request seeks to eliminate the MULTICORE and ASYNC toggles. This toggles were added because on their release they weren't too stable and caused issues in some games. Now-a-days almost none ever uses this toggles anymore, so we are removing them as part of our options simplification.

We are also adding a new toggle: GPU Accuracy. Which allows to switch between Normal and High GPU accuracy. This is meant for users who can't trade the accuracy for the performance. Normal, is pretty safe but breaks effects in many games.