### PR TITLE
settings: Disable FPS unlimit setting between title launches

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -327,7 +327,7 @@ struct Values {
     Setting<bool> use_nvdec_emulation{true, "use_nvdec_emulation"};
     Setting<bool> accelerate_astc{true, "accelerate_astc"};
     Setting<bool> use_vsync{true, "use_vsync"};
-    Setting<bool> disable_fps_limit{false, "disable_fps_limit"};
+    BasicSetting<bool> disable_fps_limit{false, "disable_fps_limit"};
     Setting<bool> use_assembly_shaders{false, "use_assembly_shaders"};
     Setting<bool> use_asynchronous_shaders{false, "use_asynchronous_shaders"};
     Setting<bool> use_fast_gpu_time{true, "use_fast_gpu_time"};

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -833,7 +833,6 @@ void Config::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.use_nvdec_emulation);
     ReadGlobalSetting(Settings::values.accelerate_astc);
     ReadGlobalSetting(Settings::values.use_vsync);
-    ReadGlobalSetting(Settings::values.disable_fps_limit);
     ReadGlobalSetting(Settings::values.use_assembly_shaders);
     ReadGlobalSetting(Settings::values.use_asynchronous_shaders);
     ReadGlobalSetting(Settings::values.use_fast_gpu_time);
@@ -1358,7 +1357,6 @@ void Config::SaveRendererValues() {
     WriteGlobalSetting(Settings::values.use_nvdec_emulation);
     WriteGlobalSetting(Settings::values.accelerate_astc);
     WriteGlobalSetting(Settings::values.use_vsync);
-    WriteGlobalSetting(Settings::values.disable_fps_limit);
     WriteGlobalSetting(Settings::values.use_assembly_shaders);
     WriteGlobalSetting(Settings::values.use_asynchronous_shaders);
     WriteGlobalSetting(Settings::values.use_fast_gpu_time);

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -28,7 +28,6 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
     ui->anisotropic_filtering_combobox->setEnabled(runtime_lock);
 
     ui->use_vsync->setChecked(Settings::values.use_vsync.GetValue());
-    ui->disable_fps_limit->setChecked(Settings::values.disable_fps_limit.GetValue());
     ui->use_assembly_shaders->setChecked(Settings::values.use_assembly_shaders.GetValue());
     ui->use_asynchronous_shaders->setChecked(Settings::values.use_asynchronous_shaders.GetValue());
     ui->use_caches_gc->setChecked(Settings::values.use_caches_gc.GetValue());
@@ -59,8 +58,6 @@ void ConfigureGraphicsAdvanced::ApplyConfiguration() {
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.max_anisotropy,
                                              ui->anisotropic_filtering_combobox);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_vsync, ui->use_vsync, use_vsync);
-    ConfigurationShared::ApplyPerGameSetting(&Settings::values.disable_fps_limit,
-                                             ui->disable_fps_limit, disable_fps_limit);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_assembly_shaders,
                                              ui->use_assembly_shaders, use_assembly_shaders);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_asynchronous_shaders,
@@ -103,7 +100,6 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     if (Settings::IsConfiguringGlobal()) {
         ui->gpu_accuracy->setEnabled(Settings::values.gpu_accuracy.UsingGlobal());
         ui->use_vsync->setEnabled(Settings::values.use_vsync.UsingGlobal());
-        ui->disable_fps_limit->setEnabled(Settings::values.disable_fps_limit.UsingGlobal());
         ui->use_assembly_shaders->setEnabled(Settings::values.use_assembly_shaders.UsingGlobal());
         ui->use_asynchronous_shaders->setEnabled(
             Settings::values.use_asynchronous_shaders.UsingGlobal());
@@ -116,8 +112,6 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
     }
 
     ConfigurationShared::SetColoredTristate(ui->use_vsync, Settings::values.use_vsync, use_vsync);
-    ConfigurationShared::SetColoredTristate(ui->disable_fps_limit,
-                                            Settings::values.disable_fps_limit, disable_fps_limit);
     ConfigurationShared::SetColoredTristate(
         ui->use_assembly_shaders, Settings::values.use_assembly_shaders, use_assembly_shaders);
     ConfigurationShared::SetColoredTristate(ui->use_asynchronous_shaders,

--- a/src/yuzu/configuration/configure_graphics_advanced.h
+++ b/src/yuzu/configuration/configure_graphics_advanced.h
@@ -35,7 +35,6 @@ private:
     std::unique_ptr<Ui::ConfigureGraphicsAdvanced> ui;
 
     ConfigurationShared::CheckState use_vsync;
-    ConfigurationShared::CheckState disable_fps_limit;
     ConfigurationShared::CheckState use_assembly_shaders;
     ConfigurationShared::CheckState use_asynchronous_shaders;
     ConfigurationShared::CheckState use_fast_gpu_time;

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -77,24 +77,6 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="disable_fps_limit">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="toolTip">
-           <string>
-            &lt;html&gt;&lt;head/&gt;&lt;body&gt;
-            &lt;p&gt;Presents guest frames as they become available, disabling the FPS limit in most titles.&lt;/p&gt;
-            &lt;p&gt;NOTE: Will cause instabilities.&lt;/p&gt;
-            &lt;/body&gt;&lt;/html&gt;
-           </string>
-          </property>
-          <property name="text">
-           <string>Disable framerate limit (experimental)</string>
-          </property>
-         </widget>
-        </item>
-        <item>
          <widget class="QCheckBox" name="use_assembly_shaders">
           <property name="toolTip">
            <string>Enabling this reduces shader stutter. Enables OpenGL assembly shaders on supported Nvidia devices (NV_gpu_program5 is required). This feature is experimental.</string>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1355,6 +1355,9 @@ void GMainWindow::BootGame(const QString& filename, std::size_t program_index, S
 
     ConfigureVibration::SetAllVibrationDevices();
 
+    // Disable fps limit toggle when booting a new title
+    Settings::values.disable_fps_limit.SetValue(false);
+
     // Save configurations
     UpdateUISettings();
     game_list->SaveInterfaceLayout();
@@ -2913,7 +2916,12 @@ void GMainWindow::UpdateStatusBar() {
     } else {
         emu_speed_label->setText(tr("Speed: %1%").arg(results.emulation_speed * 100.0, 0, 'f', 0));
     }
-    game_fps_label->setText(tr("Game: %1 FPS").arg(results.average_game_fps, 0, 'f', 0));
+    if (Settings::values.disable_fps_limit) {
+        game_fps_label->setText(
+            tr("Game: %1 FPS (Limit off)").arg(results.average_game_fps, 0, 'f', 0));
+    } else {
+        game_fps_label->setText(tr("Game: %1 FPS").arg(results.average_game_fps, 0, 'f', 0));
+    }
     emu_frametime_label->setText(tr("Frame: %1 ms").arg(results.frametime * 1000.0, 0, 'f', 2));
 
     emu_speed_label->setVisible(!Settings::values.use_multi_core.GetValue());


### PR DESCRIPTION
Some titles crash if the FPS limit is disabled when launching. This change ensures that titles launch with the limit in-place to avoid issues.

In order to simplify the change, the UI toggle was removed as it would have always been overridden at launch to be disabled.
The setting can still be toggled during gameplay with the hotkey, and indicated by the fps label in the status bar.