### PR TITLE
settings: Eliminate usage of float-point setting values

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -103,7 +103,7 @@ float Volume() {
     if (values.audio_muted) {
         return 0.0f;
     }
-    return values.volume.GetValue();
+    return values.volume.GetValue() / 100.0f;
 }
 
 void RestoreGlobalState(bool is_powered_on) {

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -278,7 +278,7 @@ struct Values {
     BasicSetting<std::string> sink_id{"auto", "output_engine"};
     BasicSetting<bool> audio_muted{false, "audio_muted"};
     Setting<bool> enable_audio_stretching{true, "enable_audio_stretching"};
-    Setting<float> volume{1.0f, "volume"};
+    Setting<u8> volume{100, "volume"};
 
     // Core
     Setting<bool> use_multi_core{true, "use_multi_core"};

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -333,9 +333,9 @@ struct Values {
     Setting<bool> use_fast_gpu_time{true, "use_fast_gpu_time"};
     Setting<bool> use_caches_gc{false, "use_caches_gc"};
 
-    Setting<float> bg_red{0.0f, "bg_red"};
-    Setting<float> bg_green{0.0f, "bg_green"};
-    Setting<float> bg_blue{0.0f, "bg_blue"};
+    Setting<u8> bg_red{0, "bg_red"};
+    Setting<u8> bg_green{0, "bg_green"};
+    Setting<u8> bg_blue{0, "bg_blue"};
 
     // System
     Setting<std::optional<u32>> rng_seed{std::optional<u32>(), "rng_seed"};

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -365,7 +365,7 @@ struct Values {
                                                 "udp_input_servers"};
 
     BasicSetting<bool> mouse_panning{false, "mouse_panning"};
-    BasicSetting<float> mouse_panning_sensitivity{1.0f, "mouse_panning_sensitivity"};
+    BasicSetting<u8> mouse_panning_sensitivity{1, "mouse_panning_sensitivity"};
     BasicSetting<bool> mouse_enabled{false, "mouse_enabled"};
     std::string mouse_device;
     MouseButtonsRaw mouse_buttons;

--- a/src/input_common/mouse/mouse_poller.cpp
+++ b/src/input_common/mouse/mouse_poller.cpp
@@ -84,7 +84,7 @@ public:
         std::lock_guard lock{mutex};
         const auto axis_value =
             static_cast<float>(mouse_input->GetMouseState(button).axis.at(axis));
-        const float sensitivity = Settings::values.mouse_panning_sensitivity.GetValue();
+        const float sensitivity = Settings::values.mouse_panning_sensitivity.GetValue() * 0.15f;
         return axis_value * sensitivity / (100.0f * range);
     }
 

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -229,9 +229,6 @@ void RendererOpenGL::LoadColorToActiveGLTexture(u8 color_r, u8 color_g, u8 color
 }
 
 void RendererOpenGL::InitOpenGLObjects() {
-    glClearColor(Settings::values.bg_red.GetValue(), Settings::values.bg_green.GetValue(),
-                 Settings::values.bg_blue.GetValue(), 0.0f);
-
     // Create shader programs
     OGLShader vertex_shader;
     vertex_shader.Create(HostShaders::OPENGL_PRESENT_VERT, GL_VERTEX_SHADER);
@@ -337,8 +334,9 @@ void RendererOpenGL::ConfigureFramebufferTexture(TextureInfo& texture,
 void RendererOpenGL::DrawScreen(const Layout::FramebufferLayout& layout) {
     if (renderer_settings.set_background_color) {
         // Update background color before drawing
-        glClearColor(Settings::values.bg_red.GetValue(), Settings::values.bg_green.GetValue(),
-                     Settings::values.bg_blue.GetValue(), 0.0f);
+        glClearColor(Settings::values.bg_red.GetValue() / 255.0f,
+                     Settings::values.bg_green.GetValue() / 255.0f,
+                     Settings::values.bg_blue.GetValue() / 255.0f, 1.0f);
     }
 
     // Set projection matrix

--- a/src/video_core/renderer_vulkan/vk_blit_screen.cpp
+++ b/src/video_core/renderer_vulkan/vk_blit_screen.cpp
@@ -225,8 +225,11 @@ VkSemaphore VKBlitScreen::Draw(const Tegra::FramebufferConfig& framebuffer, bool
                       descriptor_set = descriptor_sets[image_index], buffer = *buffer,
                       size = swapchain.GetSize(), pipeline = *pipeline,
                       layout = *pipeline_layout](vk::CommandBuffer cmdbuf) {
+        const f32 bg_red = Settings::values.bg_red.GetValue() / 255.0f;
+        const f32 bg_green = Settings::values.bg_green.GetValue() / 255.0f;
+        const f32 bg_blue = Settings::values.bg_blue.GetValue() / 255.0f;
         const VkClearValue clear_color{
-            .color = {.float32 = {0.0f, 0.0f, 0.0f, 0.0f}},
+            .color = {.float32 = {bg_red, bg_green, bg_blue, 1.0f}},
         };
         const VkRenderPassBeginInfo renderpass_bi{
             .sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO,

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -311,37 +311,12 @@ void Config::WriteBasicSetting(const Settings::BasicSetting<std::string>& settin
     qt_config->setValue(name, QString::fromStdString(value));
 }
 
-// Explicit float definition: use a double as Qt doesn't write legible floats to config files
-template <>
-void Config::WriteBasicSetting(const Settings::BasicSetting<float>& setting) {
-    const QString name = QString::fromStdString(setting.GetLabel());
-    const double value = setting.GetValue();
-    qt_config->setValue(name + QStringLiteral("/default"),
-                        setting.GetValue() == setting.GetDefault());
-    qt_config->setValue(name, value);
-}
-
 template <typename Type>
 void Config::WriteBasicSetting(const Settings::BasicSetting<Type>& setting) {
     const QString name = QString::fromStdString(setting.GetLabel());
     const Type value = setting.GetValue();
     qt_config->setValue(name + QStringLiteral("/default"), value == setting.GetDefault());
     qt_config->setValue(name, value);
-}
-
-// Explicit float definition: use a double as Qt doesn't write legible floats to config files
-template <>
-void Config::WriteGlobalSetting(const Settings::Setting<float>& setting) {
-    const QString name = QString::fromStdString(setting.GetLabel());
-    const double value = setting.GetValue(global);
-    if (!global) {
-        qt_config->setValue(name + QStringLiteral("/use_global"), setting.UsingGlobal());
-    }
-    if (global || !setting.UsingGlobal()) {
-        qt_config->setValue(name + QStringLiteral("/default"),
-                            setting.GetValue(global) == setting.GetDefault());
-        qt_config->setValue(name, value);
-    }
 }
 
 template <typename Type>

--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -47,7 +47,8 @@ void ConfigureAudio::SetConfiguration() {
 
     SetAudioDeviceFromDeviceID();
 
-    ui->volume_slider->setValue(Settings::values.volume.GetValue() * ui->volume_slider->maximum());
+    const auto volume_value = Settings::values.volume.GetValue() * ui->volume_slider->maximum();
+    ui->volume_slider->setValue(volume_value / 100);
 
     ui->toggle_audio_stretching->setChecked(Settings::values.enable_audio_stretching.GetValue());
 
@@ -112,18 +113,16 @@ void ConfigureAudio::ApplyConfiguration() {
 
         // Guard if during game and set to game-specific value
         if (Settings::values.volume.UsingGlobal()) {
-            Settings::values.volume.SetValue(
-                static_cast<float>(ui->volume_slider->sliderPosition()) /
-                ui->volume_slider->maximum());
+            const s32 volume = ui->volume_slider->sliderPosition() / ui->volume_slider->maximum();
+            Settings::values.volume.SetValue(static_cast<u8>(100 * volume));
         }
     } else {
         if (ui->volume_combo_box->currentIndex() == 0) {
             Settings::values.volume.SetGlobal(true);
         } else {
             Settings::values.volume.SetGlobal(false);
-            Settings::values.volume.SetValue(
-                static_cast<float>(ui->volume_slider->sliderPosition()) /
-                ui->volume_slider->maximum());
+            const s32 volume = ui->volume_slider->sliderPosition() / ui->volume_slider->maximum();
+            Settings::values.volume.SetValue(static_cast<u8>(100 * volume));
         }
     }
 }

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -101,9 +101,9 @@ void ConfigureGraphics::SetConfiguration() {
         ConfigurationShared::SetHighlight(ui->bg_layout, !Settings::values.bg_red.UsingGlobal());
     }
 
-    UpdateBackgroundColorButton(QColor::fromRgbF(Settings::values.bg_red.GetValue(),
-                                                 Settings::values.bg_green.GetValue(),
-                                                 Settings::values.bg_blue.GetValue()));
+    UpdateBackgroundColorButton(QColor::fromRgb(Settings::values.bg_red.GetValue(),
+                                                Settings::values.bg_green.GetValue(),
+                                                Settings::values.bg_blue.GetValue()));
     UpdateDeviceComboBox();
 }
 
@@ -132,9 +132,9 @@ void ConfigureGraphics::ApplyConfiguration() {
             Settings::values.vulkan_device.SetValue(vulkan_device);
         }
         if (Settings::values.bg_red.UsingGlobal()) {
-            Settings::values.bg_red.SetValue(static_cast<float>(bg_color.redF()));
-            Settings::values.bg_green.SetValue(static_cast<float>(bg_color.greenF()));
-            Settings::values.bg_blue.SetValue(static_cast<float>(bg_color.blueF()));
+            Settings::values.bg_red.SetValue(static_cast<u8>(bg_color.red()));
+            Settings::values.bg_green.SetValue(static_cast<u8>(bg_color.green()));
+            Settings::values.bg_blue.SetValue(static_cast<u8>(bg_color.blue()));
         }
     } else {
         if (ui->api->currentIndex() == ConfigurationShared::USE_GLOBAL_INDEX) {
@@ -159,9 +159,9 @@ void ConfigureGraphics::ApplyConfiguration() {
             Settings::values.bg_red.SetGlobal(false);
             Settings::values.bg_green.SetGlobal(false);
             Settings::values.bg_blue.SetGlobal(false);
-            Settings::values.bg_red.SetValue(static_cast<float>(bg_color.redF()));
-            Settings::values.bg_green.SetValue(static_cast<float>(bg_color.greenF()));
-            Settings::values.bg_blue.SetValue(static_cast<float>(bg_color.blueF()));
+            Settings::values.bg_red.SetValue(static_cast<u8>(bg_color.red()));
+            Settings::values.bg_green.SetValue(static_cast<u8>(bg_color.green()));
+            Settings::values.bg_blue.SetValue(static_cast<u8>(bg_color.blue()));
         }
     }
 }

--- a/src/yuzu/configuration/configure_input_advanced.ui
+++ b/src/yuzu/configuration/configure_input_advanced.ui
@@ -2573,27 +2573,24 @@
                   </widget>
                 </item>
                 <item row="2" column="2">
-                    <widget class="QDoubleSpinBox" name="mouse_panning_sensitivity">
+                    <widget class="QSpinBox" name="mouse_panning_sensitivity">
                       <property name="toolTip">
                         <string>Mouse sensitivity</string>
                       </property>
                       <property name="alignment">
                         <set>Qt::AlignCenter</set>
                       </property>
-                      <property name="decimals">
-                        <number>2</number>
+                      <property name="suffix">
+                        <string>%</string>
                       </property>
                       <property name="minimum">
-                        <double>0.100000000000000</double>
+                        <number>1</number>
                       </property>
                       <property name="maximum">
-                        <double>16.000000000000000</double>
-                      </property>
-                      <property name="singleStep">
-                        <double>0.010000000000000</double>
+                        <number>100</number>
                       </property>
                       <property name="value">
-                        <double>1.000000000000000</double>
+                        <number>100</number>
                       </property>
                     </widget>
                 </item>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -242,17 +242,15 @@ static const std::array<int, 8> keyboard_mods{
 };
 
 template <>
-void Config::ReadSetting(const std::string& group, Settings::BasicSetting<float>& setting) {
-    setting = sdl2_config->GetReal(group, setting.GetLabel(), setting.GetDefault());
-}
-template <>
 void Config::ReadSetting(const std::string& group, Settings::BasicSetting<std::string>& setting) {
     setting = sdl2_config->Get(group, setting.GetLabel(), setting.GetDefault());
 }
+
 template <>
 void Config::ReadSetting(const std::string& group, Settings::BasicSetting<bool>& setting) {
     setting = sdl2_config->GetBoolean(group, setting.GetLabel(), setting.GetDefault());
 }
+
 template <typename Type>
 void Config::ReadSetting(const std::string& group, Settings::BasicSetting<Type>& setting) {
     setting = static_cast<Type>(sdl2_config->GetInteger(group, setting.GetLabel(),

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -281,7 +281,7 @@ enable_audio_stretching =
 output_device =
 
 # Output volume.
-# 1.0 (default): 100%, 0.0; mute
+# 100 (default): 100%, 0; mute
 volume =
 
 [Data Storage]

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -232,7 +232,7 @@ use_vsync =
 use_caches_gc =
 
 # The clear color for the renderer. What shows up on the sides of the bottom screen.
-# Must be in range of 0.0-1.0. Defaults to 1.0 for all.
+# Must be in range of 0-255. Defaults to 0 for all.
 bg_red =
 bg_blue =
 bg_green =


### PR DESCRIPTION
This PR replaces the usage of floating point settings with discrete integer values.

Qt is notorious for its sub-adequate support for floating point values in its configurations, and there are instances of comparing the value of settings with the defaults, which introduces precision issues when the settings are floating point values. The use of integers alleviates these issues.