### PR TITLE
DMAEngine: Introduce Accelerate DMA.

### DIFF
--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -21,7 +21,17 @@ namespace Tegra {
 class MemoryManager;
 }
 
+namespace VideoCore {
+class RasterizerInterface;
+}
+
 namespace Tegra::Engines {
+
+class AccelerateDMAInterface {
+public:
+    /// Write the value to the register identified by method.
+    virtual bool BufferCopy(GPUVAddr src_address, GPUVAddr dest_address, u64 amount) = 0;
+};
 
 /**
  * This engine is known as gk104_copy. Documentation can be found in:
@@ -187,6 +197,8 @@ public:
     };
     static_assert(sizeof(RemapConst) == 12);
 
+    void BindRasterizer(VideoCore::RasterizerInterface* rasterizer);
+
     explicit MaxwellDMA(Core::System& system_, MemoryManager& memory_manager_);
     ~MaxwellDMA() override;
 
@@ -213,6 +225,7 @@ private:
     Core::System& system;
 
     MemoryManager& memory_manager;
+    VideoCore::RasterizerInterface* rasterizer;
 
     std::vector<u8> read_buffer;
     std::vector<u8> write_buffer;
@@ -240,7 +253,9 @@ private:
                 u32 pitch_out;
                 u32 line_length_in;
                 u32 line_count;
-                u32 reserved06[0xb8];
+                u32 reserved06[0xb6];
+                u32 remap_consta_value;
+                u32 remap_constb_value;
                 RemapConst remap_const;
                 Parameters dst_params;
                 u32 reserved07[0x1];

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -50,6 +50,7 @@ void GPU::BindRenderer(std::unique_ptr<VideoCore::RendererBase> renderer_) {
     maxwell_3d->BindRasterizer(rasterizer);
     fermi_2d->BindRasterizer(rasterizer);
     kepler_compute->BindRasterizer(rasterizer);
+    maxwell_dma->BindRasterizer(rasterizer);
 }
 
 Engines::Maxwell3D& GPU::Maxwell3D() {

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -10,13 +10,15 @@
 #include <stop_token>
 #include "common/common_types.h"
 #include "video_core/engines/fermi_2d.h"
-#include "video_core/engines/maxwell_dma.h"
 #include "video_core/gpu.h"
 #include "video_core/guest_driver.h"
 
 namespace Tegra {
 class MemoryManager;
+namespace Engines {
+class AccelerateDMAInterface;
 }
+} // namespace Tegra
 
 namespace VideoCore {
 

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -10,6 +10,7 @@
 #include <stop_token>
 #include "common/common_types.h"
 #include "video_core/engines/fermi_2d.h"
+#include "video_core/engines/maxwell_dma.h"
 #include "video_core/gpu.h"
 #include "video_core/guest_driver.h"
 
@@ -118,6 +119,8 @@ public:
         const Tegra::Engines::Fermi2D::Config& copy_config) {
         return false;
     }
+
+    [[nodiscard]] virtual Tegra::Engines::AccelerateDMAInterface& AccessAccelerateDMA() = 0;
 
     /// Attempt to use a faster method to display the framebuffer to screen
     [[nodiscard]] virtual bool AccelerateDisplay(const Tegra::FramebufferConfig& config,

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -49,6 +49,16 @@ struct VKScreenInfo;
 
 class StateTracker;
 
+class AccelerateDMA : public Tegra::Engines::AccelerateDMAInterface {
+public:
+  explicit AccelerateDMA(BufferCache& buffer_cache);
+
+  bool BufferCopy(GPUVAddr start_address, GPUVAddr end_address, u64 amount) override;
+
+  private:
+  BufferCache& buffer_cache;
+};
+
 class RasterizerVulkan final : public VideoCore::RasterizerAccelerated {
 public:
     explicit RasterizerVulkan(Core::Frontend::EmuWindow& emu_window_, Tegra::GPU& gpu_,
@@ -86,6 +96,7 @@ public:
     bool AccelerateSurfaceCopy(const Tegra::Engines::Fermi2D::Surface& src,
                                const Tegra::Engines::Fermi2D::Surface& dst,
                                const Tegra::Engines::Fermi2D::Config& copy_config) override;
+    Tegra::Engines::AccelerateDMAInterface& AccessAccelerateDMA() override;
     bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
                            u32 pixel_stride) override;
 
@@ -186,6 +197,7 @@ private:
     BufferCache buffer_cache;
     VKPipelineCache pipeline_cache;
     VKQueryCache query_cache;
+    AccelerateDMA accelerate_dma;
     VKFenceManager fence_manager;
 
     vk::Event wfi_event;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -13,6 +13,7 @@
 #include <boost/container/static_vector.hpp>
 
 #include "common/common_types.h"
+#include "video_core/engines/maxwell_dma.h"
 #include "video_core/rasterizer_accelerated.h"
 #include "video_core/rasterizer_interface.h"
 #include "video_core/renderer_vulkan/blit_image.h"
@@ -51,12 +52,12 @@ class StateTracker;
 
 class AccelerateDMA : public Tegra::Engines::AccelerateDMAInterface {
 public:
-  explicit AccelerateDMA(BufferCache& buffer_cache);
+    explicit AccelerateDMA(BufferCache& buffer_cache);
 
-  bool BufferCopy(GPUVAddr start_address, GPUVAddr end_address, u64 amount) override;
+    bool BufferCopy(GPUVAddr start_address, GPUVAddr end_address, u64 amount) override;
 
-  private:
-  BufferCache& buffer_cache;
+private:
+    BufferCache& buffer_cache;
 };
 
 class RasterizerVulkan final : public VideoCore::RasterizerAccelerated {


### PR DESCRIPTION
This PR introduces DMA accelerations, this means doing a DMA Engine operation on the host GPU instead of the Guest GPU. Currently, the workflow is to Read memory and flush from host if needed, do a LLE DMA operation and then do Write that invalidates Host Caches. This is a very expensive operation on certain scenario.

This PR introduces DMA accelerations for Buffer Copies only. In the future more accelerations will be added for the BlockLinear-Pitch and back copies.

This PR fixes Shin Megami Tensei III Nocturne