### PR TITLE
input_common/sdl: Implement HD rumble

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -64,6 +64,7 @@ if (YUZU_USE_EXTERNAL_SDL2)
         endforeach()
 
         option(HIDAPI "" ON)
+        set(WAYLAND_LIBDECOR OFF CACHE BOOL "" FORCE)
     endif()
     set(SDL_STATIC ON)
     set(SDL_SHARED OFF)


### PR DESCRIPTION
This PR adds HD rumble support for the joycons and pro controllers. It needs a SDL version that supports HD rumble (https://github.com/german77/SDL/tree/hd_rumble)

This is a WIP just to demonstrate proof of concept. The encoding has some errors but works way better than the current on/off rumble support SDL has for the joycons/pro controllers. Once the error in the encoding is fixed and the official SDL repo supports HD rumble this can be added to yuzu.