### PR TITLE
content_archive: Remove unnecessary include to <ranges>

### DIFF
--- a/src/core/file_sys/content_archive.cpp
+++ b/src/core/file_sys/content_archive.cpp
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <cstring>
 #include <optional>
-#include <ranges>
 #include <utility>
 
 #include "common/logging/log.h"


### PR DESCRIPTION
Fixes build issues on clang.