### PR TITLE
DMAEngine: Accelerate BufferClear [accelerateDMA Part 2]

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -329,6 +329,8 @@ private:
 
     [[nodiscard]] bool HasFastUniformBufferBound(size_t stage, u32 binding_index) const noexcept;
 
+    void ClearDownload(IntervalType subtract_interval);
+
     VideoCore::RasterizerInterface& rasterizer;
     Tegra::Engines::Maxwell3D& maxwell3d;
     Tegra::Engines::KeplerCompute& kepler_compute;
@@ -468,6 +470,14 @@ void BufferCache<P>::DownloadMemory(VAddr cpu_addr, u64 size) {
 }
 
 template <class P>
+void BufferCache<P>::ClearDownload(IntervalType subtract_interval) {
+    uncommitted_ranges.subtract(subtract_interval);
+    for (auto& interval_set : committed_ranges) {
+        interval_set.subtract(subtract_interval);
+    }
+}
+
+template <class P>
 bool BufferCache<P>::DMACopy(GPUVAddr src_address, GPUVAddr dest_address, u64 amount) {
     const std::optional<VAddr> cpu_src_address = gpu_memory.GpuToCpuAddress(src_address);
     const std::optional<VAddr> cpu_dest_address = gpu_memory.GpuToCpuAddress(dest_address);
@@ -481,10 +491,7 @@ bool BufferCache<P>::DMACopy(GPUVAddr src_address, GPUVAddr dest_address, u64 am
     }
 
     const IntervalType subtract_interval{*cpu_dest_address, *cpu_dest_address + amount};
-    uncommitted_ranges.subtract(subtract_interval);
-    for (auto& interval_set : committed_ranges) {
-        interval_set.subtract(subtract_interval);
-    }
+    ClearDownload(subtract_interval);
 
     BufferId buffer_a;
     BufferId buffer_b;
@@ -496,7 +503,6 @@ bool BufferCache<P>::DMACopy(GPUVAddr src_address, GPUVAddr dest_address, u64 am
     auto& src_buffer = slot_buffers[buffer_a];
     auto& dest_buffer = slot_buffers[buffer_b];
     SynchronizeBuffer(src_buffer, *cpu_src_address, static_cast<u32>(amount));
-    SynchronizeBuffer(dest_buffer, *cpu_dest_address, static_cast<u32>(amount));
     std::array copies{BufferCopy{
         .src_offset = src_buffer.Offset(*cpu_src_address),
         .dst_offset = dest_buffer.Offset(*cpu_dest_address),
@@ -515,12 +521,17 @@ bool BufferCache<P>::DMACopy(GPUVAddr src_address, GPUVAddr dest_address, u64 am
     ForEachWrittenRange(*cpu_src_address, amount, mirror);
     // This subtraction in this order is important for overlapping copies.
     common_ranges.subtract(subtract_interval);
+    bool atleast_1_download = tmp_intervals.size() != 0;
     for (const IntervalType add_interval : tmp_intervals) {
         common_ranges.add(add_interval);
     }
 
+    if (dest_buffer.HasCachedWrites()) {
+        dest_buffer.FlushCachedWrites();
+    }
     runtime.CopyBuffer(dest_buffer, src_buffer, copies);
-    if (IsRegionGpuModified(*cpu_src_address, amount)) {
+    dest_buffer.UnmarkRegionAsCpuModified(*cpu_dest_address, amount);
+    if (atleast_1_download) {
         dest_buffer.MarkRegionAsGpuModified(*cpu_dest_address, amount);
     }
     std::vector<u8> tmp_buffer(amount);
@@ -541,10 +552,7 @@ bool BufferCache<P>::DMAClear(GPUVAddr dst_address, u64 amount, u32 value) {
     }
 
     const IntervalType subtract_interval{*cpu_dst_address, *cpu_dst_address + amount * sizeof(u32)};
-    uncommitted_ranges.subtract(subtract_interval);
-    for (auto& interval_set : committed_ranges) {
-        interval_set.subtract(subtract_interval);
-    }
+    ClearDownload(subtract_interval);
     common_ranges.subtract(subtract_interval);
 
     const size_t size = amount * sizeof(u32);
@@ -557,6 +565,7 @@ bool BufferCache<P>::DMAClear(GPUVAddr dst_address, u64 amount, u32 value) {
     auto& dest_buffer = slot_buffers[buffer];
     const u32 offset = static_cast<u32>(*cpu_dst_address - dest_buffer.CpuAddr());
     runtime.ClearBuffer(dest_buffer, offset, size, value);
+    dest_buffer.UnmarkRegionAsCpuModified(*cpu_dst_address, size);
     return true;
 }
 
@@ -1482,6 +1491,7 @@ void BufferCache<P>::DownloadBufferMemory(Buffer& buffer, VAddr cpu_addr, u64 si
         const VAddr end_address = start_address + range_size;
         ForEachWrittenRange(start_address, range_size, add_download);
         const IntervalType subtract_interval{start_address, end_address};
+        ClearDownload(subtract_interval);
         common_ranges.subtract(subtract_interval);
     });
     if (total_size_bytes == 0) {

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -164,10 +164,15 @@ public:
     /// Pop asynchronous downloads
     void PopAsyncFlushes();
 
-    [[nodiscard]] bool DMACopy(GPUVAddr src_address, GPUVAddr dest_address, u64 amount);
+    bool DMACopy(GPUVAddr src_address, GPUVAddr dest_address, u64 amount);
+
+    bool DMAClear(GPUVAddr src_address, u64 amount, u32 value);
 
     /// Return true when a CPU region is modified from the GPU
     [[nodiscard]] bool IsRegionGpuModified(VAddr addr, size_t size);
+
+    /// Return true when a region is registered on the cache
+    [[nodiscard]] bool IsRegionRegistered(VAddr addr, size_t size);
 
     /// Return true when a CPU region is modified from the CPU
     [[nodiscard]] bool IsRegionCpuModified(VAddr addr, size_t size);
@@ -469,8 +474,8 @@ bool BufferCache<P>::DMACopy(GPUVAddr src_address, GPUVAddr dest_address, u64 am
     if (!cpu_src_address || !cpu_dest_address) {
         return false;
     }
-    const bool source_dirty = IsRegionGpuModified(*cpu_src_address, amount);
-    const bool dest_dirty = IsRegionGpuModified(*cpu_dest_address, amount);
+    const bool source_dirty = IsRegionRegistered(*cpu_src_address, amount);
+    const bool dest_dirty = IsRegionRegistered(*cpu_dest_address, amount);
     if (!source_dirty && !dest_dirty) {
         return false;
     }
@@ -515,12 +520,43 @@ bool BufferCache<P>::DMACopy(GPUVAddr src_address, GPUVAddr dest_address, u64 am
     }
 
     runtime.CopyBuffer(dest_buffer, src_buffer, copies);
-    if (source_dirty) {
+    if (IsRegionGpuModified(*cpu_src_address, amount)) {
         dest_buffer.MarkRegionAsGpuModified(*cpu_dest_address, amount);
     }
     std::vector<u8> tmp_buffer(amount);
     cpu_memory.ReadBlockUnsafe(*cpu_src_address, tmp_buffer.data(), amount);
     cpu_memory.WriteBlockUnsafe(*cpu_dest_address, tmp_buffer.data(), amount);
+    return true;
+}
+
+template <class P>
+bool BufferCache<P>::DMAClear(GPUVAddr dst_address, u64 amount, u32 value) {
+    const std::optional<VAddr> cpu_dst_address = gpu_memory.GpuToCpuAddress(dst_address);
+    if (!cpu_dst_address) {
+        return false;
+    }
+    const bool dest_dirty = IsRegionRegistered(*cpu_dst_address, amount);
+    if (!dest_dirty) {
+        return false;
+    }
+
+    const IntervalType subtract_interval{*cpu_dst_address, *cpu_dst_address + amount * sizeof(u32)};
+    uncommitted_ranges.subtract(subtract_interval);
+    for (auto& interval_set : committed_ranges) {
+        interval_set.subtract(subtract_interval);
+    }
+    common_ranges.subtract(subtract_interval);
+
+    const size_t size = amount * sizeof(u32);
+    BufferId buffer;
+    do {
+        has_deleted_buffers = false;
+        buffer = FindBuffer(*cpu_dst_address, static_cast<u32>(size));
+    } while (has_deleted_buffers);
+
+    auto& dest_buffer = slot_buffers[buffer];
+    const u32 offset = static_cast<u32>(*cpu_dst_address - dest_buffer.CpuAddr());
+    runtime.ClearBuffer(dest_buffer, offset, size, value);
     return true;
 }
 
@@ -776,6 +812,27 @@ bool BufferCache<P>::IsRegionGpuModified(VAddr addr, size_t size) {
             return true;
         }
         const VAddr end_addr = buffer.CpuAddr() + buffer.SizeBytes();
+        page = Common::DivCeil(end_addr, PAGE_SIZE);
+    }
+    return false;
+}
+
+template <class P>
+bool BufferCache<P>::IsRegionRegistered(VAddr addr, size_t size) {
+    const VAddr end_addr = addr + size;
+    const u64 page_end = Common::DivCeil(end_addr, PAGE_SIZE);
+    for (u64 page = addr >> PAGE_BITS; page < page_end;) {
+        const BufferId buffer_id = page_table[page];
+        if (!buffer_id) {
+            ++page;
+            continue;
+        }
+        Buffer& buffer = slot_buffers[buffer_id];
+        const VAddr buf_start_addr = buffer.CpuAddr();
+        const VAddr buf_end_addr = buf_start_addr + buffer.SizeBytes();
+        if (buf_start_addr < end_addr && addr < buf_end_addr) {
+            return true;
+        }
         page = Common::DivCeil(end_addr, PAGE_SIZE);
     }
     return false;

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -87,9 +87,11 @@ void MaxwellDMA::CopyPitchToPitch() {
         // TODO: allow multisized components.
         if (is_buffer_clear) {
             ASSERT(regs.remap_const.component_size_minus_one == 3);
+            accelerate.BufferClear(regs.offset_out, regs.line_length_in, regs.remap_consta_value);
             std::vector<u32> tmp_buffer(regs.line_length_in, regs.remap_consta_value);
-            memory_manager.WriteBlock(regs.offset_out, reinterpret_cast<u8*>(tmp_buffer.data()),
-                                      regs.line_length_in * sizeof(u32));
+            memory_manager.WriteBlockUnsafe(regs.offset_out,
+                                            reinterpret_cast<u8*>(tmp_buffer.data()),
+                                            regs.line_length_in * sizeof(u32));
             return;
         }
         UNIMPLEMENTED_IF(regs.launch_dma.remap_enable != 0);

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -4,6 +4,7 @@
 
 #include "common/assert.h"
 #include "common/logging/log.h"
+#include "common/microprofile.h"
 #include "common/settings.h"
 #include "core/core.h"
 #include "video_core/engines/maxwell_3d.h"
@@ -11,6 +12,9 @@
 #include "video_core/memory_manager.h"
 #include "video_core/renderer_base.h"
 #include "video_core/textures/decoders.h"
+
+MICROPROFILE_DECLARE(GPU_DMAEngine);
+MICROPROFILE_DEFINE(GPU_DMAEngine, "GPU", "DMA Engine", MP_RGB(224, 224, 128));
 
 namespace Tegra::Engines {
 
@@ -43,6 +47,7 @@ void MaxwellDMA::CallMultiMethod(u32 method, const u32* base_start, u32 amount,
 }
 
 void MaxwellDMA::Launch() {
+    MICROPROFILE_SCOPE(GPU_DMAEngine);
     LOG_TRACE(Render_OpenGL, "DMA copy 0x{:x} -> 0x{:x}", static_cast<GPUVAddr>(regs.offset_in),
               static_cast<GPUVAddr>(regs.offset_out));
 

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -181,8 +181,13 @@ void MaxwellDMA::CopyPitchToBlockLinear() {
         write_buffer.resize(dst_size);
     }
 
-    memory_manager.ReadBlock(regs.offset_in, read_buffer.data(), src_size);
-    memory_manager.ReadBlock(regs.offset_out, write_buffer.data(), dst_size);
+    if (Settings::IsGPULevelExtreme()) {
+        memory_manager.ReadBlock(regs.offset_in, read_buffer.data(), src_size);
+        memory_manager.ReadBlock(regs.offset_out, write_buffer.data(), dst_size);
+    } else {
+        memory_manager.ReadBlockUnsafe(regs.offset_in, read_buffer.data(), src_size);
+        memory_manager.ReadBlockUnsafe(regs.offset_out, write_buffer.data(), dst_size);
+    }
 
     // If the input is linear and the output is tiled, swizzle the input and copy it over.
     if (regs.dst_params.block_size.depth > 0) {

--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -31,6 +31,8 @@ class AccelerateDMAInterface {
 public:
     /// Write the value to the register identified by method.
     virtual bool BufferCopy(GPUVAddr src_address, GPUVAddr dest_address, u64 amount) = 0;
+
+    virtual bool BufferClear(GPUVAddr src_address, u64 amount, u32 value) = 0;
 };
 
 /**

--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -327,7 +327,7 @@ void MemoryManager::WriteBlock(GPUVAddr gpu_dest_addr, const void* src_buffer, s
 
             // Invalidate must happen on the rasterizer interface, such that memory is always
             // synchronous when it is written (even when in asynchronous GPU mode).
-            rasterizer->InvalidateRegion(dest_addr, copy_amount);
+            rasterizer->UnmapMemory(dest_addr, copy_amount);
             system.Memory().WriteBlockUnsafe(dest_addr, src_buffer, copy_amount);
         }
 

--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -327,7 +327,7 @@ void MemoryManager::WriteBlock(GPUVAddr gpu_dest_addr, const void* src_buffer, s
 
             // Invalidate must happen on the rasterizer interface, such that memory is always
             // synchronous when it is written (even when in asynchronous GPU mode).
-            rasterizer->UnmapMemory(dest_addr, copy_amount);
+            rasterizer->InvalidateRegion(dest_addr, copy_amount);
             system.Memory().WriteBlockUnsafe(dest_addr, src_buffer, copy_amount);
         }
 

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -98,6 +98,12 @@ void BufferCacheRuntime::CopyBuffer(Buffer& dst_buffer, Buffer& src_buffer,
     }
 }
 
+void BufferCacheRuntime::ClearBuffer(Buffer& dest_buffer, u32 offset, size_t size, u32 value) {
+    glClearNamedBufferSubData(dest_buffer.Handle(), GL_R32UI, static_cast<GLintptr>(offset),
+                              static_cast<GLsizeiptr>(size / sizeof(u32)), GL_RGBA, GL_UNSIGNED_INT,
+                              &value);
+}
+
 void BufferCacheRuntime::BindIndexBuffer(Buffer& buffer, u32 offset, u32 size) {
     if (has_unified_vertex_buffers) {
         buffer.MakeResident(GL_READ_ONLY);

--- a/src/video_core/renderer_opengl/gl_buffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.h
@@ -57,6 +57,8 @@ public:
     void CopyBuffer(Buffer& dst_buffer, Buffer& src_buffer,
                     std::span<const VideoCommon::BufferCopy> copies);
 
+    void ClearBuffer(Buffer& dest_buffer, u32 offset, size_t size, u32 value);
+
     void BindIndexBuffer(Buffer& buffer, u32 offset, u32 size);
 
     void BindVertexBuffer(u32 index, Buffer& buffer, u32 offset, u32 size, u32 stride);

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -1407,4 +1407,9 @@ bool AccelerateDMA::BufferCopy(GPUVAddr src_address, GPUVAddr dest_address, u64 
     return buffer_cache.DMACopy(src_address, dest_address, amount);
 }
 
+bool AccelerateDMA::BufferClear(GPUVAddr src_address, u64 amount, u32 value) {
+    std::scoped_lock lock{buffer_cache.mutex};
+    return buffer_cache.DMAClear(src_address, amount, value);
+}
+
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -65,6 +65,8 @@ public:
 
     bool BufferCopy(GPUVAddr src_address, GPUVAddr dest_address, u64 amount) override;
 
+    bool BufferClear(GPUVAddr src_address, u64 amount, u32 value) override;
+
 private:
     BufferCache& buffer_cache;
 };

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.h
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.h
@@ -60,6 +60,8 @@ public:
     void CopyBuffer(VkBuffer src_buffer, VkBuffer dst_buffer,
                     std::span<const VideoCommon::BufferCopy> copies);
 
+    void ClearBuffer(VkBuffer dest_buffer, u32 offset, size_t size, u32 value);
+
     void BindIndexBuffer(PrimitiveTopology topology, IndexFormat index_format, u32 num_indices,
                          u32 base_vertex, VkBuffer buffer, u32 offset, u32 size);
 

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -704,6 +704,11 @@ void RasterizerVulkan::FlushWork() {
 
 AccelerateDMA::AccelerateDMA(BufferCache& buffer_cache_) : buffer_cache{buffer_cache_} {}
 
+bool AccelerateDMA::BufferClear(GPUVAddr src_address, u64 amount, u32 value) {
+    std::scoped_lock lock{buffer_cache.mutex};
+    return buffer_cache.DMAClear(src_address, amount, value);
+}
+
 bool AccelerateDMA::BufferCopy(GPUVAddr src_address, GPUVAddr dest_address, u64 amount) {
     std::scoped_lock lock{buffer_cache.mutex};
     return buffer_cache.DMACopy(src_address, dest_address, amount);

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -56,6 +56,8 @@ public:
 
     bool BufferCopy(GPUVAddr start_address, GPUVAddr end_address, u64 amount) override;
 
+    bool BufferClear(GPUVAddr src_address, u64 amount, u32 value) override;
+
 private:
     BufferCache& buffer_cache;
 };


### PR DESCRIPTION
This part adds BufferClears to accelerateDMA for both Vulkan and OGL.

This fixes the black textures on some characters caused by faulty normals (the compute shader messed up as the buffer wasn't clear on time).