### PR TITLE
yuzu-cmd: Update settings

### DIFF
--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -292,6 +292,8 @@ void Config::ReadValues() {
 
     ReadSetting("ControlsGeneral", Settings::values.motion_device);
 
+    ReadSetting("ControlsGeneral", Settings::values.touch_device);
+
     ReadSetting("ControlsGeneral", Settings::values.keyboard_enabled);
 
     ReadSetting("ControlsGeneral", Settings::values.debug_pad_enabled);
@@ -414,10 +416,30 @@ void Config::ReadValues() {
     }
 
     ReadSetting("System", Settings::values.language_index);
+    ReadSetting("System", Settings::values.region_index);
     ReadSetting("System", Settings::values.time_zone_index);
+    ReadSetting("System", Settings::values.sound_index);
 
     // Core
     ReadSetting("Core", Settings::values.use_multi_core);
+
+    // Cpu
+    ReadSetting("Cpu", Settings::values.cpu_accuracy);
+    ReadSetting("Cpu", Settings::values.cpu_debug_mode);
+    ReadSetting("Cpu", Settings::values.cpuopt_page_tables);
+    ReadSetting("Cpu", Settings::values.cpuopt_block_linking);
+    ReadSetting("Cpu", Settings::values.cpuopt_return_stack_buffer);
+    ReadSetting("Cpu", Settings::values.cpuopt_fast_dispatcher);
+    ReadSetting("Cpu", Settings::values.cpuopt_context_elimination);
+    ReadSetting("Cpu", Settings::values.cpuopt_const_prop);
+    ReadSetting("Cpu", Settings::values.cpuopt_misc_ir);
+    ReadSetting("Cpu", Settings::values.cpuopt_reduce_misalign_checks);
+    ReadSetting("Cpu", Settings::values.cpuopt_fastmem);
+    ReadSetting("Cpu", Settings::values.cpuopt_unsafe_unfuse_fma);
+    ReadSetting("Cpu", Settings::values.cpuopt_unsafe_reduce_fp_error);
+    ReadSetting("Cpu", Settings::values.cpuopt_unsafe_ignore_standard_fpcr);
+    ReadSetting("Cpu", Settings::values.cpuopt_unsafe_inaccurate_nan);
+    ReadSetting("Cpu", Settings::values.cpuopt_unsafe_fastmem_check);
 
     // Renderer
     ReadSetting("Renderer", Settings::values.renderer_backend);
@@ -438,6 +460,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.use_nvdec_emulation);
     ReadSetting("Renderer", Settings::values.accelerate_astc);
     ReadSetting("Renderer", Settings::values.use_fast_gpu_time);
+    ReadSetting("Renderer", Settings::values.use_caches_gc);
 
     ReadSetting("Renderer", Settings::values.bg_red);
     ReadSetting("Renderer", Settings::values.bg_green);
@@ -458,7 +481,6 @@ void Config::ReadValues() {
     // Debugging
     Settings::values.record_frame_times =
         sdl2_config->GetBoolean("Debugging", "record_frame_times", false);
-    ReadSetting("Debugging", Settings::values.program_args);
     ReadSetting("Debugging", Settings::values.dump_exefs);
     ReadSetting("Debugging", Settings::values.dump_nso);
     ReadSetting("Debugging", Settings::values.enable_fs_access_log);

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -65,6 +65,13 @@ button_screenshot=
 lstick=
 rstick=
 
+# To use the debug_pad, prepend `debug_pad_` before each button setting above.
+# i.e. debug_pad_button_a=
+
+# Enable debug pad inputs to the guest
+# 0 (default): Disabled, 1: Enabled
+debug_pad_enabled =
+
 # Whether to enable or disable vibration
 # 0: Disabled, 1 (default): Enabled
 vibration_enabled=
@@ -72,6 +79,10 @@ vibration_enabled=
 # Whether to enable or disable accurate vibrations
 # 0 (default): Disabled, 1: Enabled
 enable_accurate_vibrations=
+
+# Enables controller motion inputs
+# 0: Disabled, 1 (default): Enabled
+motion_enabled =
 
 # for motion input, the following devices are available:
 #  - "motion_emu" (default) for emulating motion input from mouse input. Required parameters:
@@ -98,12 +109,48 @@ use_touch_from_button=
 #touch_from_button_maps_0_bind_1=bar
 # etc.
 
+# List of Cemuhook UDP servers, delimited by ','.
+# Default: 127.0.0.1:26760
+# Example: 127.0.0.1:26760,123.4.5.67:26761
+udp_input_servers =
+
+# Enable controlling an axis via a mouse input.
+# 0 (default): Off, 1: On
+mouse_panning =
+
+# Set mouse sensitivity.
+# Default: 1.0
+mouse_panning_sensitivity =
+
+# Emulate an analog control stick from keyboard inputs.
+# 0 (default): Disabled, 1: Enabled
+emulate_analog_keyboard =
+
+# Enable mouse inputs to the guest
+# 0 (default): Disabled, 1: Enabled
+mouse_enabled =
+
+# Enable keyboard inputs to the guest
+# 0 (default): Disabled, 1: Enabled
+keyboard_enabled =
+
 [Core]
 # Whether to use multi-core for CPU emulation
 # 0: Disabled, 1 (default): Enabled
 use_multi_core=
 
 [Cpu]
+# Adjusts various optimizations.
+# Auto-select mode enables choice unsafe optimizations.
+# Accurate enables only safe optimizations.
+# Unsafe allows any unsafe optimizations.
+# 0 (default): Auto-select, 1: Accurate, 2: Enable unsafe optimizations
+cpu_accuracy =
+
+# Allow disabling safe optimizations.
+# 0 (default): Disabled, 1: Enabled
+cpu_debug_mode =
+
 # Enable inline page tables optimization (faster guest memory access)
 # 0: Disabled, 1 (default): Enabled
 cpuopt_page_tables =
@@ -139,6 +186,31 @@ cpuopt_reduce_misalign_checks =
 # Enable Host MMU Emulation (faster guest memory access)
 # 0: Disabled, 1 (default): Enabled
 cpuopt_fastmem =
+
+# Enable unfuse FMA (improve performance on CPUs without FMA)
+# Only enabled if cpu_accuracy is set to Unsafe. Automatically chosen with cpu_accuracy = Auto-select.
+# 0: Disabled, 1 (default): Enabled
+cpuopt_unsafe_unfuse_fma =
+
+# Enable faster FRSQRTE and FRECPE
+# Only enabled if cpu_accuracy is set to Unsafe.
+# 0: Disabled, 1 (default): Enabled
+cpuopt_unsafe_reduce_fp_error =
+
+# Enable faster ASIMD instructions (32 bits only)
+# Only enabled if cpu_accuracy is set to Unsafe. Automatically chosen with cpu_accuracy = Auto-select.
+# 0: Disabled, 1 (default): Enabled
+cpuopt_unsafe_ignore_standard_fpcr =
+
+# Enable inaccurate NaN handling
+# Only enabled if cpu_accuracy is set to Unsafe. Automatically chosen with cpu_accuracy = Auto-select.
+# 0: Disabled, 1 (default): Enabled
+cpuopt_unsafe_inaccurate_nan =
+
+# Disable address space checks (64 bits only)
+# Only enabled if cpu_accuracy is set to Unsafe. Automatically chosen with cpu_accuracy = Auto-select.
+# 0: Disabled, 1 (default): Enabled
+cpuopt_unsafe_fastmem_check =
 
 [Renderer]
 # Which backend API to use.
@@ -189,16 +261,20 @@ use_frame_limit =
 frame_limit =
 
 # Whether to use disk based shader cache
-# 0 (default): Off, 1 : On
+# 0: Off, 1 (default): On
 use_disk_shader_cache =
 
 # Which gpu accuracy level to use
-# 0 (Normal), 1 (High), 2 (Extreme)
+# 0: Normal, 1 (default): High, 2: Extreme (Very slow)
 gpu_accuracy =
 
 # Whether to use asynchronous GPU emulation
 # 0 : Off (slow), 1 (default): On (fast)
 use_asynchronous_gpu_emulation =
+
+# Inform the guest that GPU operations completed more quickly than they did.
+# 0: Off, 1 (default): On
+use_fast_gpu_time =
 
 # Whether to use garbage collection or not for GPU caches.
 # 0 (default): Off, 1: On
@@ -275,16 +351,24 @@ language_index =
 
 # The system region that yuzu will use during emulation
 # -1: Auto-select (default), 0: Japan, 1: USA, 2: Europe, 3: Australia, 4: China, 5: Korea, 6: Taiwan
-region_value =
+region_index =
 
 # The system time zone that yuzu will use during emulation
 # 0: Auto-select (default), 1: Default (system archive value), Others: Index for specified time zone
 time_zone_index =
 
+# Sets the sound output mode.
+# 0: Mono, 1 (default): Stereo, 2: Surround
+sound_index =
+
 [Miscellaneous]
 # A filter which removes logs below a certain logging level.
 # Examples: *:Debug Kernel.SVC:Trace Service.*:Critical
 log_filter = *:Trace
+
+# Use developer keys
+# 0 (default): Disabled, 1: Enabled
+use_dev_keys =
 
 [Debugging]
 # Record frame time data, can be found in the log directory. Boolean value
@@ -295,6 +379,8 @@ dump_exefs=false
 dump_nso=false
 # Determines whether or not yuzu will save the filesystem access log.
 enable_fs_access_log=false
+# Enables verbose reporting services
+reporting_services =
 # Determines whether or not yuzu will report to the game that the emulated console is in Kiosk Mode
 # false: Retail/Normal Mode (default), true: Kiosk Mode
 quest_flag =

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -98,20 +98,6 @@ use_touch_from_button=
 #touch_from_button_maps_0_bind_1=bar
 # etc.
 
-# Most desktop operating systems do not expose a way to poll the motion state of the controllers
-# so as a way around it, cemuhook created a udp client/server protocol to broadcast the data directly
-# from a controller device to the client program. Citra has a client that can connect and read
-# from any cemuhook compatible motion program.
-
-# IPv4 address of the udp input server (Default "127.0.0.1")
-udp_input_address=127.0.0.1
-
-# Port of the udp input server. (Default 26760)
-udp_input_port=
-
-# The pad to request data on. Should be between 0 (Pad 1) and 3 (Pad 4). (Default 0)
-udp_pad_index=
-
 [Core]
 # Whether to use multi-core for CPU emulation
 # 0: Disabled, 1 (default): Enabled
@@ -166,14 +152,6 @@ debug =
 # Which Vulkan physical device to use (defaults to 0)
 vulkan_device =
 
-# Whether to use software or hardware rendering.
-# 0: Software, 1 (default): Hardware
-use_hw_renderer =
-
-# Whether to use the Just-In-Time (JIT) compiler for shader emulation
-# 0: Interpreter (slow), 1 (default): JIT (fast)
-use_shader_jit =
-
 # Aspect ratio
 # 0: Default (16:9), 1: Force 4:3, 2: Force 21:9, 3: Stretch to Window
 aspect_ratio =
@@ -222,11 +200,6 @@ gpu_accuracy =
 # 0 : Off (slow), 1 (default): On (fast)
 use_asynchronous_gpu_emulation =
 
-# Forces VSync on the display thread. Usually doesn't impact performance, but on some drivers it can
-# so only turn this off if you notice a speed difference.
-# 0: Off, 1 (default): On
-use_vsync =
-
 # Whether to use garbage collection or not for GPU caches.
 # 0 (default): Off, 1: On
 use_caches_gc =
@@ -236,31 +209,6 @@ use_caches_gc =
 bg_red =
 bg_blue =
 bg_green =
-
-[Layout]
-# Layout for the screen inside the render window.
-# 0 (default): Default Top Bottom Screen, 1: Single Screen Only, 2: Large Screen Small Screen
-layout_option =
-
-# Toggle custom layout (using the settings below) on or off.
-# 0 (default): Off, 1: On
-custom_layout =
-
-# Screen placement when using Custom layout option
-# 0x, 0y is the top left corner of the render window.
-custom_top_left =
-custom_top_top =
-custom_top_right =
-custom_top_bottom =
-custom_bottom_left =
-custom_bottom_top =
-custom_bottom_right =
-custom_bottom_bottom =
-
-# Swaps the prominent screen with the other screen.
-# For example, if Single Screen is chosen, setting this to 1 will display the bottom screen instead of the top screen.
-# 0 (default): Top Screen is prominent, 1: Bottom Screen is prominent
-swap_screen =
 
 [Audio]
 # Which audio output engine to use.
@@ -308,10 +256,6 @@ gamecard_path =
 # 1 (default): Yes, 0: No
 use_docked_mode =
 
-# Allow the use of NFC in games
-# 1 (default): Yes, 0 : No
-enable_nfc =
-
 # Sets the seed for the RNG generator built into the switch
 # rng_seed will be ignored and randomly generated if rng_seed_enabled is false
 rng_seed_enabled =
@@ -322,10 +266,6 @@ rng_seed =
 # This override will only occur if custom_rtc_enabled is true, otherwise the current time is used
 custom_rtc_enabled =
 custom_rtc =
-
-# Sets the account username, max length is 32 characters
-# yuzu (default)
-username = yuzu
 
 # Sets the systems language index
 # 0: Japanese, 1: English (default), 2: French, 3: German, 4: Italian, 5: Spanish, 6: Chinese,
@@ -393,4 +333,4 @@ title_ids =
 # For each title ID, have a key/value pair called `disabled_<title_id>` equal to the names of the add-ons to disable (sep. by '|')
 # e.x. disabled_0100000000010000 = Update|DLC <- disables Updates and DLC on Super Mario Odyssey
 )";
-}
+} // namespace DefaultINI


### PR DESCRIPTION
yuzu-cmd's default settings currently has many more-or-less incorrect settings. Some are deprecated settings from Citra (i.e. `use_hw_renderer`), are reported in the default ini but not read during runtime (i.e. `use_caches_gc`), are read during runtime but not reported in the default ini (i.e. `mouse_panning`), report incorrect defaults (i.e. `gpu_accuracy`), or altogether are not acknowledged in yuzu-cmd (i.e. `cpu_debug_mode`). `use_vsync` was listed twice in default_ini.h.

This makes an effort to synchronize yuzu's settings with yuzu-cmd. Some settings such as `fullscreen_mode` were not addressed here as they require implementation in yuzu-cmd (or need dropped from Common and moved to the Qt frontend's UISettings). I also likely did not notice all of the wrong defaults in default_ini.h. A fresh pair of eyes would help here.
