### PR TITLE
input_common: Make button threshold customizable

### DIFF
--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -660,7 +660,8 @@ public:
 
         if (params.Has("axis")) {
             const int axis = params.Get("axis", 0);
-            const float threshold = params.Get("threshold", 0.5f);
+            // Convert range from (0.0, 1.0) to (-1.0, 1.0)
+            const float threshold = (params.Get("threshold", 0.5f) - 0.5f) * 2.0f;
             const std::string direction_name = params.Get("direction", "");
             bool trigger_if_greater;
             if (direction_name == "+") {
@@ -933,12 +934,11 @@ Common::ParamPackage BuildAnalogParamPackageForButton(int port, std::string guid
     params.Set("port", port);
     params.Set("guid", std::move(guid));
     params.Set("axis", axis);
+    params.Set("threshold", "0.5");
     if (value > 0) {
         params.Set("direction", "+");
-        params.Set("threshold", "0.5");
     } else {
         params.Set("direction", "-");
-        params.Set("threshold", "-0.5");
     }
     return params;
 }

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -321,8 +321,16 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
                                 this, tr("Set threshold"), tr("Choose a value between 0% and 100%"),
                                 button_threshold, 0, 100);
                             buttons_param[button_id].Set("threshold", new_threshold / 100.0f);
+
+                            if (button_id == Settings::NativeButton::ZL) {
+                                ui->sliderZLThreshold->setValue(new_threshold);
+                            }
+                            if (button_id == Settings::NativeButton::ZR) {
+                                ui->sliderZRThreshold->setValue(new_threshold);
+                            }
                         });
                     }
+
                     context_menu.exec(button_map[button_id]->mapToGlobal(menu_location));
                     ui->controllerFrame->SetPlayerInput(player_index, buttons_param, analogs_param);
                 });
@@ -350,6 +358,20 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
                     context_menu.exec(motion_map[motion_id]->mapToGlobal(menu_location));
                 });
     }
+
+    connect(ui->sliderZLThreshold, &QSlider::valueChanged, [=, this] {
+        if (buttons_param[Settings::NativeButton::ZL].Has("threshold")) {
+            const auto slider_value = ui->sliderZLThreshold->value();
+            buttons_param[Settings::NativeButton::ZL].Set("threshold", slider_value / 100.0f);
+        }
+    });
+
+    connect(ui->sliderZRThreshold, &QSlider::valueChanged, [=, this] {
+        if (buttons_param[Settings::NativeButton::ZR].Has("threshold")) {
+            const auto slider_value = ui->sliderZRThreshold->value();
+            buttons_param[Settings::NativeButton::ZR].Set("threshold", slider_value / 100.0f);
+        }
+    });
 
     for (int analog_id = 0; analog_id < Settings::NativeAnalog::NumAnalogs; ++analog_id) {
         for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM; ++sub_button_id) {
@@ -857,6 +879,18 @@ void ConfigureInputPlayer::ClearAll() {
 void ConfigureInputPlayer::UpdateUI() {
     for (int button = 0; button < Settings::NativeButton::NumButtons; ++button) {
         button_map[button]->setText(ButtonToText(buttons_param[button]));
+    }
+
+    if (buttons_param[Settings::NativeButton::ZL].Has("threshold")) {
+        const int button_threshold = static_cast<int>(
+            buttons_param[Settings::NativeButton::ZL].Get("threshold", 0.5f) * 100.0f);
+        ui->sliderZLThreshold->setValue(button_threshold);
+    }
+
+    if (buttons_param[Settings::NativeButton::ZR].Has("threshold")) {
+        const int button_threshold = static_cast<int>(
+            buttons_param[Settings::NativeButton::ZR].Get("threshold", 0.5f) * 100.0f);
+        ui->sliderZRThreshold->setValue(button_threshold);
     }
 
     for (int motion_id = 0; motion_id < Settings::NativeMotion::NumMotions; ++motion_id) {

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -313,6 +313,16 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
                         buttons_param[button_id].Set("toggle", toggle_value);
                         button_map[button_id]->setText(ButtonToText(buttons_param[button_id]));
                     });
+                    if (buttons_param[button_id].Has("threshold")) {
+                        context_menu.addAction(tr("Set threshold"), [&] {
+                            const int button_threshold = static_cast<int>(
+                                buttons_param[button_id].Get("threshold", 0.5f) * 100.0f);
+                            const int new_threshold = QInputDialog::getInt(
+                                this, tr("Set threshold"), tr("Choose a value between 0% and 100%"),
+                                button_threshold, 0, 100);
+                            buttons_param[button_id].Set("threshold", new_threshold / 100.0f);
+                        });
+                    }
                     context_menu.exec(button_map[button_id]->mapToGlobal(menu_location));
                     ui->controllerFrame->SetPlayerInput(player_index, buttons_param, analogs_param);
                 });

--- a/src/yuzu/configuration/configure_input_player.ui
+++ b/src/yuzu/configuration/configure_input_player.ui
@@ -1334,6 +1334,12 @@
                 </item>
                 <item>
                  <widget class="QGroupBox" name="buttonShoulderButtonsButtonZLGroup">
+                   <property name="sizePolicy">
+                     <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                     </sizepolicy>
+                   </property>
                   <property name="title">
                    <string>ZL</string>
                   </property>
@@ -1378,6 +1384,22 @@
                      </property>
                     </widget>
                    </item>
+                    <item>
+                      <widget class="QSlider" name="sliderZLThreshold">
+                        <property name="maximumSize">
+                          <size>
+                            <width>70</width>
+                            <height>15</height>
+                          </size>
+                        </property>
+                        <property name="maximum">
+                          <number>100</number>
+                        </property>
+                        <property name="orientation">
+                          <enum>Qt::Horizontal</enum>
+                        </property>
+                      </widget>
+                    </item>
                   </layout>
                  </widget>
                 </item>
@@ -1759,6 +1781,12 @@
                 </item>
                 <item>
                  <widget class="QGroupBox" name="buttonShoulderButtonsZRGroup">
+                   <property name="sizePolicy">
+                     <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                     </sizepolicy>
+                   </property>
                   <property name="title">
                    <string>ZR</string>
                   </property>
@@ -1803,6 +1831,22 @@
                      </property>
                     </widget>
                    </item>
+                    <item>
+                      <widget class="QSlider" name="sliderZRThreshold">
+                        <property name="maximumSize">
+                          <size>
+                            <width>70</width>
+                            <height>15</height>
+                          </size>
+                        </property>
+                        <property name="maximum">
+                          <number>100</number>
+                        </property>
+                        <property name="orientation">
+                          <enum>Qt::Horizontal</enum>
+                        </property>
+                      </widget>
+                    </item>
                   </layout>
                  </widget>
                 </item>


### PR DESCRIPTION
Kills two birds with one stone:
- Analog triggers from SDL2 had a range from -1.0 to 1.0 we where setting the trigger to 0.5 which is around 75% of the button pressed. This PR fixes the SDL threshold value to 50%.
- Adds an UI option on right click to set any threshold value for each button

Closes #6644 