### PR TITLE
configure_audio: Fix volume clamping to 0

### DIFF
--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -47,8 +47,8 @@ void ConfigureAudio::SetConfiguration() {
 
     SetAudioDeviceFromDeviceID();
 
-    const auto volume_value = Settings::values.volume.GetValue() * ui->volume_slider->maximum();
-    ui->volume_slider->setValue(volume_value / 100);
+    const auto volume_value = static_cast<int>(Settings::values.volume.GetValue());
+    ui->volume_slider->setValue(volume_value);
 
     ui->toggle_audio_stretching->setChecked(Settings::values.enable_audio_stretching.GetValue());
 
@@ -113,16 +113,16 @@ void ConfigureAudio::ApplyConfiguration() {
 
         // Guard if during game and set to game-specific value
         if (Settings::values.volume.UsingGlobal()) {
-            const s32 volume = ui->volume_slider->sliderPosition() / ui->volume_slider->maximum();
-            Settings::values.volume.SetValue(static_cast<u8>(100 * volume));
+            const auto volume = static_cast<u8>(ui->volume_slider->value());
+            Settings::values.volume.SetValue(volume);
         }
     } else {
         if (ui->volume_combo_box->currentIndex() == 0) {
             Settings::values.volume.SetGlobal(true);
         } else {
             Settings::values.volume.SetGlobal(false);
-            const s32 volume = ui->volume_slider->sliderPosition() / ui->volume_slider->maximum();
-            Settings::values.volume.SetValue(static_cast<u8>(100 * volume));
+            const auto volume = static_cast<u8>(ui->volume_slider->value());
+            Settings::values.volume.SetValue(volume);
         }
     }
 }


### PR DESCRIPTION
Fixes a regression introduced by #6579 