### PR TITLE
bootmanager: Create a dummy render widget

### DIFF
--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -567,6 +567,12 @@ std::unique_ptr<Core::Frontend::GraphicsContext> GRenderWindow::CreateSharedCont
 bool GRenderWindow::InitRenderTarget() {
     ReleaseRenderTarget();
 
+    {
+        // Create a dummy render widget so that Qt
+        // places the render window at the correct position.
+        const RenderWidget dummy_widget{this};
+    }
+
     first_frame = false;
 
     switch (Settings::values.renderer_backend.GetValue()) {


### PR DESCRIPTION
This ensures that Qt positions the render window at the correct position on initializing the respective render backends.

Fixes the black bars / offset render window when starting yuzu on a secondary monitor,