### PR TITLE
input_common: Fix mouse panning behaivour

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -368,7 +368,7 @@ struct Values {
                                                 "udp_input_servers"};
 
     BasicSetting<bool> mouse_panning{false, "mouse_panning"};
-    BasicSetting<u8> mouse_panning_sensitivity{1, "mouse_panning_sensitivity"};
+    BasicSetting<u8> mouse_panning_sensitivity{10, "mouse_panning_sensitivity"};
     BasicSetting<bool> mouse_enabled{false, "mouse_enabled"};
     std::string mouse_device;
     MouseButtonsRaw mouse_buttons;

--- a/src/input_common/mouse/mouse_poller.cpp
+++ b/src/input_common/mouse/mouse_poller.cpp
@@ -84,7 +84,7 @@ public:
         std::lock_guard lock{mutex};
         const auto axis_value =
             static_cast<float>(mouse_input->GetMouseState(button).axis.at(axis));
-        const float sensitivity = Settings::values.mouse_panning_sensitivity.GetValue() * 0.15f;
+        const float sensitivity = Settings::values.mouse_panning_sensitivity.GetValue() * 0.10f;
         return axis_value * sensitivity / (100.0f * range);
     }
 

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -411,8 +411,9 @@ void GRenderWindow::mousePressEvent(QMouseEvent* event) {
     if (event->source() == Qt::MouseEventSynthesizedBySystem) {
         return;
     }
-
-    auto pos = event->pos();
+    // Qt sometimes returns the parent coordinates. To avoid this we read the global mouse
+    // coordinates and map them to the current render area
+    const auto pos = mapFromGlobal(QCursor::pos());
     const auto [x, y] = ScaleTouch(pos);
     const auto button = QtButtonToMouseButton(event->button());
     input_subsystem->GetMouse()->PressButton(x, y, button);
@@ -429,7 +430,9 @@ void GRenderWindow::mouseMoveEvent(QMouseEvent* event) {
     if (event->source() == Qt::MouseEventSynthesizedBySystem) {
         return;
     }
-    auto pos = event->pos();
+    // Qt sometimes returns the parent coordinates. To avoid this we read the global mouse
+    // coordinates and map them to the current render area
+    const auto pos = mapFromGlobal(QCursor::pos());
     const auto [x, y] = ScaleTouch(pos);
     const int center_x = width() / 2;
     const int center_y = height() / 2;


### PR DESCRIPTION
#6579 altered the default values for this setting. This PR corrects them and on top of that fixes an issue with multiple screens where the joystick was always pulled down