### PR TITLE
ci,linux: Support Patreon releases

### DIFF
--- a/.ci/scripts/linux/upload.sh
+++ b/.ci/scripts/linux/upload.sh
@@ -20,7 +20,9 @@ fi
 mkdir "$DIR_NAME"
 
 cp build/bin/yuzu-cmd "$DIR_NAME"
-cp build/bin/yuzu "$DIR_NAME"
+if [ "${RELEASE_NAME}" != "early-access" ] && [ "${RELEASE_NAME}" != "mainline" ]; then
+    cp build/bin/yuzu "$DIR_NAME"
+fi
 
 # Build an AppImage
 cd build
@@ -31,6 +33,11 @@ chmod 755 appimagetool-x86_64.AppImage
 # if FUSE is not available, then fallback to extract and run
 if ! ./appimagetool-x86_64.AppImage --version; then
     export APPIMAGE_EXTRACT_AND_RUN=1
+fi
+
+# Don't let AppImageLauncher ask to integrate EA
+if [ "${RELEASE_NAME}" = "mainline" ] || [ "${RELEASE_NAME}" = "early-access" ]; then
+    echo "X-AppImage-Integrate=false" >> AppDir/org.yuzu_emu.yuzu.desktop
 fi
 
 if [ "${RELEASE_NAME}" = "mainline" ]; then

--- a/.ci/scripts/linux/upload.sh
+++ b/.ci/scripts/linux/upload.sh
@@ -5,15 +5,16 @@
 
 . .ci/scripts/common/pre-upload.sh
 
-APPIMAGE_NAME="yuzu-${GITDATE}-${GITREV}.AppImage"
-REV_NAME="yuzu-linux-${GITDATE}-${GITREV}"
+APPIMAGE_NAME="yuzu-${RELEASE_NAME}-${GITDATE}-${GITREV}.AppImage"
+BASE_NAME="yuzu-linux"
+REV_NAME="${BASE_NAME}-${GITDATE}-${GITREV}"
 ARCHIVE_NAME="${REV_NAME}.tar.xz"
 COMPRESSION_FLAGS="-cJvf"
 
-if [ "${RELEASE_NAME}" = "mainline" ]; then
-    DIR_NAME="${REV_NAME}"
+if [ "${RELEASE_NAME}" = "mainline" ] || [ "${RELEASE_NAME}" = "early-access" ]; then
+    DIR_NAME="${BASE_NAME}-${RELEASE_NAME}"
 else
-    DIR_NAME="${REV_NAME}_${RELEASE_NAME}"
+    DIR_NAME="${REV_NAME}-${RELEASE_NAME}"
 fi
 
 mkdir "$DIR_NAME"
@@ -44,6 +45,11 @@ cd ..
 cp "build/${APPIMAGE_NAME}" "${ARTIFACTS_DIR}/"
 if [ -f "build/${APPIMAGE_NAME}.zsync" ]; then
     cp "build/${APPIMAGE_NAME}.zsync" "${ARTIFACTS_DIR}/"
+fi
+
+# Copy the AppImage to the general release directory and remove git revision info
+if [ "${RELEASE_NAME}" = "mainline" ] || [ "${RELEASE_NAME}" = "early-access" ]; then
+    cp "build/${APPIMAGE_NAME}" "${DIR_NAME}/yuzu-${RELEASE_NAME}.AppImage"
 fi
 
 . .ci/scripts/common/post-upload.sh

--- a/.ci/yuzu-patreon-step2.yml
+++ b/.ci/yuzu-patreon-step2.yml
@@ -8,10 +8,10 @@ variables:
   DisplayVersion: $[counter(variables['DisplayPrefix'], 1)]
 
 stages:
-- stage: build_gcc
-  displayName: 'build-gcc'
+- stage: build
+  displayName: 'build'
   jobs:
-  - job: build
+  - job: linux
     timeoutInMinutes: 120
     displayName: 'linux'
     pool:
@@ -32,11 +32,7 @@ stages:
         artifactSource: 'false'
         cache: $(parameters.cache)
         version: $(DisplayVersion)
-- stage: build_msvc
-  dependsOn: []
-  displayName: 'build-msvc'
-  jobs:
-  - job: build
+  - job: msvc
     timeoutInMinutes: 120
     displayName: 'windows'
     pool:
@@ -53,9 +49,7 @@ stages:
         version: $(DisplayVersion)
 - stage: release
   displayName: 'release'
-  dependsOn:
-  - build_gcc
-  - build_msvc
+  dependsOn: build
   jobs:
     - job: release
       displayName: 'source'

--- a/.ci/yuzu-patreon-step2.yml
+++ b/.ci/yuzu-patreon-step2.yml
@@ -8,12 +8,37 @@ variables:
   DisplayVersion: $[counter(variables['DisplayPrefix'], 1)]
 
 stages:
-- stage: build
-  displayName: 'build'
+- stage: build_gcc
+  displayName: 'build-gcc'
   jobs:
   - job: build
     timeoutInMinutes: 120
-    displayName: 'windows-msvc'
+    displayName: 'linux'
+    pool:
+      vmImage: ubuntu-latest
+    strategy:
+      maxParallel: 10
+      matrix:
+        linux:
+          BuildSuffix: 'linux'
+          ScriptFolder: 'linux'
+    steps:
+    - template: ./templates/sync-source.yml
+      parameters:
+        artifactSource: $(parameters.artifactSource)
+        needSubmodules: 'true'
+    - template: ./templates/build-single.yml
+      parameters:
+        artifactSource: 'false'
+        cache: $(parameters.cache)
+        version: $(DisplayVersion)
+- stage: build_msvc
+  dependsOn: []
+  displayName: 'build-msvc'
+  jobs:
+  - job: build
+    timeoutInMinutes: 120
+    displayName: 'windows'
     pool:
       vmImage: windows-2019
     steps:
@@ -28,7 +53,9 @@ stages:
         version: $(DisplayVersion)
 - stage: release
   displayName: 'release'
-  dependsOn: build
+  dependsOn:
+  - build_gcc
+  - build_msvc
   jobs:
     - job: release
       displayName: 'source'


### PR DESCRIPTION
Soft-requires yuzu-emu/liftinstall#28

The Early Access AppImage needs to be accessible through liftinstall, so a couple modifications need to made:

The DIR_NAME needs to not include the revision info.
The EA AppImage name cannot contain revision info.
The EA AppImage has to be packaged with the rest of the yuzu package, which means both binaries and the source are bundled with it now in an archive.

In addition, fix the source archive so yuzu can actually be built from it.

This also makes the yuzu mainline releases compatible with liftinstall and its shortcuts.