### PR TITLE
texture_cache: Always prepare image views on render targets

### DIFF
--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -599,6 +599,12 @@ void TextureCache<P>::UpdateRenderTargets(bool is_clear) {
     using namespace VideoCommon::Dirty;
     auto& flags = maxwell3d.dirty.flags;
     if (!flags[Dirty::RenderTargets]) {
+        for (size_t index = 0; index < NUM_RT; ++index) {
+            ImageViewId& color_buffer_id = render_targets.color_buffer_ids[index];
+            PrepareImageView(color_buffer_id, true, is_clear && IsFullClear(color_buffer_id));
+        }
+        const ImageViewId depth_buffer_id = render_targets.depth_buffer_id;
+        PrepareImageView(depth_buffer_id, true, is_clear && IsFullClear(depth_buffer_id));
         return;
     }
     flags[Dirty::RenderTargets] = false;


### PR DESCRIPTION
Images used as render targets were not being "prepared" when their dirty flags were not set, causing desynchronizations on the texture cache. Needs #6669 to avoid performance regressions on certain cooking titles.

This was originally included in #6585, but the change does not really belong there. This conflicts with #6585, it should be rebased after this is merged.

- Fixes black shadows on Age of Calamity.