### PR TITLE
applets/web: Addressing QT Navigation issues in Linux

### DIFF
--- a/src/yuzu/applets/qt_web_browser.cpp
+++ b/src/yuzu/applets/qt_web_browser.cpp
@@ -107,6 +107,7 @@ void QtNXWebEngineView::LoadLocalWebPage(const std::string& main_url,
     is_local = true;
 
     LoadExtractedFonts();
+    FocusFirstLinkElement();
     SetUserAgent(UserAgent::WebApplet);
     SetFinished(false);
     SetExitReason(Service::AM::Applets::WebExitReason::EndButtonPressed);
@@ -121,6 +122,7 @@ void QtNXWebEngineView::LoadExternalWebPage(const std::string& main_url,
                                             const std::string& additional_args) {
     is_local = false;
 
+    FocusFirstLinkElement();
     SetUserAgent(UserAgent::WebApplet);
     SetFinished(false);
     SetExitReason(Service::AM::Applets::WebExitReason::EndButtonPressed);
@@ -362,6 +364,17 @@ void QtNXWebEngineView::LoadExtractedFonts() {
             page()->runJavaScript(QString::fromStdString(LOAD_NX_FONT));
         },
         Qt::QueuedConnection);
+}
+
+void QtNXWebEngineView::FocusFirstLinkElement() {
+    QWebEngineScript focus_link_element;
+
+    focus_link_element.setName(QStringLiteral("focus_link_element.js"));
+    focus_link_element.setSourceCode(QString::fromStdString(FOCUS_LINK_ELEMENT_SCRIPT));
+    focus_link_element.setWorldId(QWebEngineScript::MainWorld);
+    focus_link_element.setInjectionPoint(QWebEngineScript::Deferred);
+    focus_link_element.setRunsOnSubFrames(true);
+    default_profile->scripts()->insert(focus_link_element);
 }
 
 #endif

--- a/src/yuzu/applets/qt_web_browser.cpp
+++ b/src/yuzu/applets/qt_web_browser.cpp
@@ -210,7 +210,7 @@ void QtNXWebEngineView::HandleWindowFooterButtonPressedOnce() {
         if (input_interpreter->IsButtonPressedOnce(button)) {
             page()->runJavaScript(
                 QStringLiteral("yuzu_key_callbacks[%1] == null;").arg(static_cast<u8>(button)),
-                [&](const QVariant& variant) {
+                [this, button](const QVariant& variant) {
                     if (variant.toBool()) {
                         switch (button) {
                         case HIDButton::A:

--- a/src/yuzu/applets/qt_web_browser.h
+++ b/src/yuzu/applets/qt_web_browser.h
@@ -161,6 +161,9 @@ private:
     /// Loads the extracted fonts using JavaScript.
     void LoadExtractedFonts();
 
+    /// Brings focus to the first available link element.
+    void FocusFirstLinkElement();
+
     InputCommon::InputSubsystem* input_subsystem;
 
     std::unique_ptr<UrlRequestInterceptor> url_interceptor;

--- a/src/yuzu/applets/qt_web_browser_scripts.h
+++ b/src/yuzu/applets/qt_web_browser_scripts.h
@@ -73,6 +73,12 @@ constexpr char LOAD_NX_FONT[] = R"(
 })();
 )";
 
+constexpr char FOCUS_LINK_ELEMENT_SCRIPT[] = R"(
+if (document.getElementsByTagName("a").length > 0) {
+    document.getElementsByTagName("a")[0].focus();
+}
+)";
+
 constexpr char GAMEPAD_SCRIPT[] = R"(
 window.addEventListener("gamepadconnected", function(e) {
     console.log("Gamepad connected at index %d: %s. %d buttons, %d axes.",


### PR DESCRIPTION
The QT web applet was having issues with navigation in Super Mario Odyssey's Action Guide.  Neither face button presses nor analog stick movement were being picked up.  By highlighting the first available clickable element and dealing with the button value mysteriously changing before the press can be fully acknowledged, the problem seems to have been resolved in SMO at least.  Could use testing in Windows and other games, though.