### PR TITLE
input/sdl_impl: fix rumble support on DualSense.

### DIFF
--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -130,10 +130,10 @@ public:
 
         if (sdl_controller) {
             return SDL_GameControllerRumble(sdl_controller.get(), amp_low, amp_high,
-                                            rumble_max_duration_ms) == 0;
+                                            rumble_max_duration_ms) != -1;
         } else if (sdl_joystick) {
             return SDL_JoystickRumble(sdl_joystick.get(), amp_low, amp_high,
-                                      rumble_max_duration_ms) == 0;
+                                      rumble_max_duration_ms) != -1;
         }
 
         return false;


### PR DESCRIPTION
# About:
- fix rumble on DualSense
- Dualsense return 78 value for using rumble, return 0 only if both frequency is 0, and after check function diferent value is normal

value return can be different 0, is not error is normal, error is only -1.