### PR TITLE
gl_texture_cache: Workaround slow PBO downloads on radeonsi

### DIFF
--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -122,7 +122,7 @@ private:
     bool has_broken_texture_view_formats = false;
 
     StagingBuffers upload_buffers{GL_MAP_WRITE_BIT, GL_MAP_WRITE_BIT | GL_MAP_FLUSH_EXPLICIT_BIT};
-    StagingBuffers download_buffers{GL_MAP_READ_BIT, GL_MAP_READ_BIT};
+    StagingBuffers download_buffers{GL_MAP_READ_BIT | GL_CLIENT_STORAGE_BIT, GL_MAP_READ_BIT};
 
     OGLTexture null_image_1d_array;
     OGLTexture null_image_cube_array;


### PR DESCRIPTION
There's an optimization bug on non-git mesa versions where not
specifying GL_CLIENT_STORAGE_BIT causes very slow reads on the CPU
side.

Add this bit for all vendors.

- Fixes performance issues on radeonsi on Skyward Sword (from ~8 FPS to 60 FPS)