### PR TITLE
texture_cache: Allow disabling preemptive texture downloads

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -54,6 +54,8 @@ void LogSettings() {
     log_setting("Renderer_GPUAccuracyLevel", values.gpu_accuracy.GetValue());
     log_setting("Renderer_UseAsynchronousGpuEmulation",
                 values.use_asynchronous_gpu_emulation.GetValue());
+    log_setting("Renderer_EnablePreemptiveDownloads",
+                values.enable_preemptive_downloads.GetValue());
     log_setting("Renderer_UseNvdecEmulation", values.use_nvdec_emulation.GetValue());
     log_setting("Renderer_AccelerateASTC", values.accelerate_astc.GetValue());
     log_setting("Renderer_UseVsync", values.use_vsync.GetValue());
@@ -137,6 +139,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.use_disk_shader_cache.SetGlobal(true);
     values.gpu_accuracy.SetGlobal(true);
     values.use_asynchronous_gpu_emulation.SetGlobal(true);
+    values.enable_preemptive_downloads.SetGlobal(true);
     values.use_nvdec_emulation.SetGlobal(true);
     values.accelerate_astc.SetGlobal(true);
     values.use_vsync.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -327,6 +327,7 @@ struct Values {
     Setting<bool> use_disk_shader_cache{true, "use_disk_shader_cache"};
     Setting<GPUAccuracy> gpu_accuracy{GPUAccuracy::High, "gpu_accuracy"};
     Setting<bool> use_asynchronous_gpu_emulation{true, "use_asynchronous_gpu_emulation"};
+    Setting<bool> enable_preemptive_downloads{true, "enable_preemptive_downloads"};
     Setting<bool> use_nvdec_emulation{true, "use_nvdec_emulation"};
     Setting<bool> accelerate_astc{true, "accelerate_astc"};
     Setting<bool> use_vsync{true, "use_vsync"};

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -229,6 +229,8 @@ void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader,
              TranslateGPUAccuracyLevel(Settings::values.gpu_accuracy.GetValue()));
     AddField(field_type, "Renderer_UseAsynchronousGpuEmulation",
              Settings::values.use_asynchronous_gpu_emulation.GetValue());
+    AddField(field_type, "Renderer_EnablePreemptiveDownloads",
+             Settings::values.enable_preemptive_downloads.GetValue());
     AddField(field_type, "Renderer_UseNvdecEmulation",
              Settings::values.use_nvdec_emulation.GetValue());
     AddField(field_type, "Renderer_AccelerateASTC", Settings::values.accelerate_astc.GetValue());

--- a/src/video_core/texture_cache/image_view_base.cpp
+++ b/src/video_core/texture_cache/image_view_base.cpp
@@ -29,7 +29,7 @@ ImageViewBase::ImageViewBase(const ImageViewInfo& info, const ImageInfo& image_i
                image_info.format);
     const bool is_async = Settings::values.use_asynchronous_gpu_emulation.GetValue();
     if (image_info.type == ImageType::Linear && is_async) {
-        flags |= ImageViewFlagBits::PreemtiveDownload;
+        flags |= ImageViewFlagBits::PreemptiveDownload;
     }
     if (image_info.type == ImageType::e3D && info.type != ImageViewType::e3D) {
         flags |= ImageViewFlagBits::Slice;

--- a/src/video_core/texture_cache/image_view_base.h
+++ b/src/video_core/texture_cache/image_view_base.h
@@ -18,7 +18,7 @@ struct ImageInfo;
 struct NullImageParams {};
 
 enum class ImageViewFlagBits : u16 {
-    PreemtiveDownload = 1 << 0,
+    PreemptiveDownload = 1 << 0,
     Strong = 1 << 1,
     Slice = 1 << 2,
 };

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -811,6 +811,7 @@ void Config::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.use_disk_shader_cache);
     ReadGlobalSetting(Settings::values.gpu_accuracy);
     ReadGlobalSetting(Settings::values.use_asynchronous_gpu_emulation);
+    ReadGlobalSetting(Settings::values.enable_preemptive_downloads);
     ReadGlobalSetting(Settings::values.use_nvdec_emulation);
     ReadGlobalSetting(Settings::values.accelerate_astc);
     ReadGlobalSetting(Settings::values.use_vsync);
@@ -1340,6 +1341,7 @@ void Config::SaveRendererValues() {
                  static_cast<u32>(Settings::values.gpu_accuracy.GetDefault()),
                  Settings::values.gpu_accuracy.UsingGlobal());
     WriteGlobalSetting(Settings::values.use_asynchronous_gpu_emulation);
+    WriteGlobalSetting(Settings::values.enable_preemptive_downloads);
     WriteGlobalSetting(Settings::values.use_nvdec_emulation);
     WriteGlobalSetting(Settings::values.accelerate_astc);
     WriteGlobalSetting(Settings::values.use_vsync);

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -75,7 +75,8 @@ void ConfigureGraphics::SetConfiguration() {
     ui->use_disk_shader_cache->setChecked(Settings::values.use_disk_shader_cache.GetValue());
     ui->use_asynchronous_gpu_emulation->setChecked(
         Settings::values.use_asynchronous_gpu_emulation.GetValue());
-    ui->enable_preemptive_downloads->setChecked(Settings::values.enable_preemptive_downloads.GetValue());
+    ui->enable_preemptive_downloads->setChecked(
+        Settings::values.enable_preemptive_downloads.GetValue());
     ui->use_nvdec_emulation->setChecked(Settings::values.use_nvdec_emulation.GetValue());
     ui->accelerate_astc->setChecked(Settings::values.accelerate_astc.GetValue());
 
@@ -279,8 +280,6 @@ void ConfigureGraphics::SetupPerGameUI() {
 
     ConfigurationShared::SetColoredTristate(
         ui->use_disk_shader_cache, Settings::values.use_disk_shader_cache, use_disk_shader_cache);
-    ConfigurationShared::SetColoredTristate(ui->enable_preemptive_downloads,
-        Settings::values.enable_preemptive_downloads, enable_preemptive_downloads);
     ConfigurationShared::SetColoredTristate(
         ui->use_nvdec_emulation, Settings::values.use_nvdec_emulation, use_nvdec_emulation);
     ConfigurationShared::SetColoredTristate(ui->accelerate_astc, Settings::values.accelerate_astc,
@@ -288,6 +287,9 @@ void ConfigureGraphics::SetupPerGameUI() {
     ConfigurationShared::SetColoredTristate(ui->use_asynchronous_gpu_emulation,
                                             Settings::values.use_asynchronous_gpu_emulation,
                                             use_asynchronous_gpu_emulation);
+    ConfigurationShared::SetColoredTristate(ui->enable_preemptive_downloads,
+                                            Settings::values.enable_preemptive_downloads,
+                                            enable_preemptive_downloads);
 
     ConfigurationShared::SetColoredComboBox(ui->aspect_ratio_combobox, ui->ar_label,
                                             Settings::values.aspect_ratio.GetValue(true));

--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -68,12 +68,14 @@ void ConfigureGraphics::SetConfiguration() {
 
     ui->api->setEnabled(runtime_lock);
     ui->use_asynchronous_gpu_emulation->setEnabled(runtime_lock);
+    ui->enable_preemptive_downloads->setEnabled(runtime_lock);
     ui->use_disk_shader_cache->setEnabled(runtime_lock);
     ui->use_nvdec_emulation->setEnabled(runtime_lock);
     ui->accelerate_astc->setEnabled(runtime_lock);
     ui->use_disk_shader_cache->setChecked(Settings::values.use_disk_shader_cache.GetValue());
     ui->use_asynchronous_gpu_emulation->setChecked(
         Settings::values.use_asynchronous_gpu_emulation.GetValue());
+    ui->enable_preemptive_downloads->setChecked(Settings::values.enable_preemptive_downloads.GetValue());
     ui->use_nvdec_emulation->setChecked(Settings::values.use_nvdec_emulation.GetValue());
     ui->accelerate_astc->setChecked(Settings::values.accelerate_astc.GetValue());
 
@@ -118,6 +120,9 @@ void ConfigureGraphics::ApplyConfiguration() {
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_asynchronous_gpu_emulation,
                                              ui->use_asynchronous_gpu_emulation,
                                              use_asynchronous_gpu_emulation);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.enable_preemptive_downloads,
+                                             ui->enable_preemptive_downloads,
+                                             enable_preemptive_downloads);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_nvdec_emulation,
                                              ui->use_nvdec_emulation, use_nvdec_emulation);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.accelerate_astc, ui->accelerate_astc,
@@ -257,6 +262,8 @@ void ConfigureGraphics::SetupPerGameUI() {
         ui->aspect_ratio_combobox->setEnabled(Settings::values.aspect_ratio.UsingGlobal());
         ui->use_asynchronous_gpu_emulation->setEnabled(
             Settings::values.use_asynchronous_gpu_emulation.UsingGlobal());
+        ui->enable_preemptive_downloads->setEnabled(
+            Settings::values.enable_preemptive_downloads.UsingGlobal());
         ui->use_nvdec_emulation->setEnabled(Settings::values.use_nvdec_emulation.UsingGlobal());
         ui->accelerate_astc->setEnabled(Settings::values.accelerate_astc.UsingGlobal());
         ui->use_disk_shader_cache->setEnabled(Settings::values.use_disk_shader_cache.UsingGlobal());
@@ -272,6 +279,8 @@ void ConfigureGraphics::SetupPerGameUI() {
 
     ConfigurationShared::SetColoredTristate(
         ui->use_disk_shader_cache, Settings::values.use_disk_shader_cache, use_disk_shader_cache);
+    ConfigurationShared::SetColoredTristate(ui->enable_preemptive_downloads,
+        Settings::values.enable_preemptive_downloads, enable_preemptive_downloads);
     ConfigurationShared::SetColoredTristate(
         ui->use_nvdec_emulation, Settings::values.use_nvdec_emulation, use_nvdec_emulation);
     ConfigurationShared::SetColoredTristate(ui->accelerate_astc, Settings::values.accelerate_astc,

--- a/src/yuzu/configuration/configure_graphics.h
+++ b/src/yuzu/configuration/configure_graphics.h
@@ -50,6 +50,7 @@ private:
     ConfigurationShared::CheckState accelerate_astc;
     ConfigurationShared::CheckState use_disk_shader_cache;
     ConfigurationShared::CheckState use_asynchronous_gpu_emulation;
+    ConfigurationShared::CheckState enable_preemptive_downloads;
 
     std::vector<QString> vulkan_devices;
     u32 vulkan_device{};

--- a/src/yuzu/configuration/configure_graphics.ui
+++ b/src/yuzu/configuration/configure_graphics.ui
@@ -98,6 +98,13 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="enable_preemptive_downloads">
+          <property name="text">
+           <string>Enable preemptive texture downloads from asynchronous GPU</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QCheckBox" name="use_nvdec_emulation">
           <property name="text">
            <string>Use NVDEC emulation</string>

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -453,6 +453,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.use_disk_shader_cache);
     ReadSetting("Renderer", Settings::values.gpu_accuracy);
     ReadSetting("Renderer", Settings::values.use_asynchronous_gpu_emulation);
+    ReadSetting("Renderer", Settings::values.enable_preemptive_downloads);
     ReadSetting("Renderer", Settings::values.use_vsync);
     ReadSetting("Renderer", Settings::values.disable_fps_limit);
     ReadSetting("Renderer", Settings::values.use_assembly_shaders);

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -244,6 +244,10 @@ use_assembly_shaders =
 # 0 (default): Off, 1: On
 use_asynchronous_shaders =
 
+# Enable preemptive texture downloads from asynchronous GPU.
+# 0: Off, 1 (default): On
+enable_preemptive_downloads =
+
 # Enable NVDEC emulation.
 # 0: Off, 1 (default): On
 use_nvdec_emulation =


### PR DESCRIPTION
Preemptive texture downloads is causing me 10 FPS of lag. With it disabled, Animal Crossing finally runs at 30 FPS.