### PR TITLE
yuzu_cmd: Make use of fullscreen_mode setting

### DIFF
--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -446,6 +446,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.renderer_debug);
     ReadSetting("Renderer", Settings::values.vulkan_device);
 
+    ReadSetting("Renderer", Settings::values.fullscreen_mode);
     ReadSetting("Renderer", Settings::values.aspect_ratio);
     ReadSetting("Renderer", Settings::values.max_anisotropy);
     ReadSetting("Renderer", Settings::values.use_frame_limit);

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -224,6 +224,10 @@ debug =
 # Which Vulkan physical device to use (defaults to 0)
 vulkan_device =
 
+# Whether to use fullscreen or borderless window mode
+# 0 (Windows default): Borderless window, 1 (All other default): Exclusive fullscreen
+fullscreen_mode =
+
 # Aspect ratio
 # 0: Default (16:9), 1: Force 4:3, 2: Force 21:9, 3: Stretch to Window
 aspect_ratio =


### PR DESCRIPTION
Reverts 48259de0c1a6a1aca77eec31cb8aca5ca2b680dd to the previous hierarchy and fixes the resolution issue with this fullscreen mode. yuzu-cmd will now read the fullscreen_mode setting and use it appropriately.