### PR TITLE
general: Rename "Frame Limit" references to "Speed Limit"

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -48,8 +48,8 @@ void LogSettings() {
     log_setting("Core_UseMultiCore", values.use_multi_core.GetValue());
     log_setting("CPU_Accuracy", values.cpu_accuracy.GetValue());
     log_setting("Renderer_UseResolutionFactor", values.resolution_factor.GetValue());
-    log_setting("Renderer_UseFrameLimit", values.use_frame_limit.GetValue());
-    log_setting("Renderer_FrameLimit", values.frame_limit.GetValue());
+    log_setting("Renderer_UseSpeedLimit", values.use_speed_limit.GetValue());
+    log_setting("Renderer_SpeedLimit", values.speed_limit.GetValue());
     log_setting("Renderer_UseDiskShaderCache", values.use_disk_shader_cache.GetValue());
     log_setting("Renderer_GPUAccuracyLevel", values.gpu_accuracy.GetValue());
     log_setting("Renderer_UseAsynchronousGpuEmulation",
@@ -132,8 +132,8 @@ void RestoreGlobalState(bool is_powered_on) {
     values.vulkan_device.SetGlobal(true);
     values.aspect_ratio.SetGlobal(true);
     values.max_anisotropy.SetGlobal(true);
-    values.use_frame_limit.SetGlobal(true);
-    values.frame_limit.SetGlobal(true);
+    values.use_speed_limit.SetGlobal(true);
+    values.speed_limit.SetGlobal(true);
     values.use_disk_shader_cache.SetGlobal(true);
     values.gpu_accuracy.SetGlobal(true);
     values.use_asynchronous_gpu_emulation.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -322,8 +322,8 @@ struct Values {
         "fullscreen_mode"};
     Setting<int> aspect_ratio{0, "aspect_ratio"};
     Setting<int> max_anisotropy{0, "max_anisotropy"};
-    Setting<bool> use_frame_limit{true, "use_frame_limit"};
-    Setting<u16> frame_limit{100, "frame_limit"};
+    Setting<bool> use_speed_limit{true, "use_speed_limit"};
+    Setting<u16> speed_limit{100, "speed_limit"};
     Setting<bool> use_disk_shader_cache{true, "use_disk_shader_cache"};
     Setting<GPUAccuracy> gpu_accuracy{GPUAccuracy::High, "gpu_accuracy"};
     Setting<bool> use_asynchronous_gpu_emulation{true, "use_asynchronous_gpu_emulation"};

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -411,7 +411,7 @@ struct System::Impl {
     std::string status_details = "";
 
     std::unique_ptr<Core::PerfStats> perf_stats;
-    Core::FrameLimiter frame_limiter;
+    Core::SpeedLimiter speed_limiter;
 
     bool is_multicore{};
     bool is_async_gpu{};
@@ -606,12 +606,12 @@ const Core::PerfStats& System::GetPerfStats() const {
     return *impl->perf_stats;
 }
 
-Core::FrameLimiter& System::FrameLimiter() {
-    return impl->frame_limiter;
+Core::SpeedLimiter& System::SpeedLimiter() {
+    return impl->speed_limiter;
 }
 
-const Core::FrameLimiter& System::FrameLimiter() const {
-    return impl->frame_limiter;
+const Core::SpeedLimiter& System::SpeedLimiter() const {
+    return impl->speed_limiter;
 }
 
 Loader::ResultStatus System::GetGameName(std::string& out) const {

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -94,7 +94,7 @@ class ARM_Interface;
 class CpuManager;
 class DeviceMemory;
 class ExclusiveMonitor;
-class FrameLimiter;
+class SpeedLimiter;
 class PerfStats;
 class Reporter;
 class TelemetrySession;
@@ -292,11 +292,11 @@ public:
     /// Provides a constant reference to the internal PerfStats instance.
     [[nodiscard]] const Core::PerfStats& GetPerfStats() const;
 
-    /// Provides a reference to the frame limiter;
-    [[nodiscard]] Core::FrameLimiter& FrameLimiter();
+    /// Provides a reference to the speed limiter;
+    [[nodiscard]] Core::SpeedLimiter& SpeedLimiter();
 
-    /// Provides a constant referent to the frame limiter
-    [[nodiscard]] const Core::FrameLimiter& FrameLimiter() const;
+    /// Provides a constant reference to the speed limiter
+    [[nodiscard]] const Core::SpeedLimiter& SpeedLimiter() const;
 
     /// Gets the name of the current game
     [[nodiscard]] Loader::ResultStatus GetGameName(std::string& out) const;

--- a/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvdisp_disp0.cpp
@@ -54,7 +54,7 @@ void nvdisp_disp0::flip(u32 buffer_handle, u32 offset, u32 format, u32 width, u3
 
     system.GetPerfStats().EndSystemFrame();
     system.GPU().SwapBuffers(&framebuffer);
-    system.FrameLimiter().DoFrameLimiting(system.CoreTiming().GetGlobalTimeUs());
+    system.SpeedLimiter().DoSpeedLimiting(system.CoreTiming().GetGlobalTimeUs());
     system.GetPerfStats().BeginSystemFrame();
 }
 

--- a/src/core/perf_stats.cpp
+++ b/src/core/perf_stats.cpp
@@ -127,15 +127,15 @@ double PerfStats::GetLastFrameTimeScale() const {
     return duration_cast<DoubleSecs>(previous_frame_length).count() / FRAME_LENGTH;
 }
 
-void FrameLimiter::DoFrameLimiting(microseconds current_system_time_us) {
-    if (!Settings::values.use_frame_limit.GetValue() ||
+void SpeedLimiter::DoSpeedLimiting(microseconds current_system_time_us) {
+    if (!Settings::values.use_speed_limit.GetValue() ||
         Settings::values.use_multi_core.GetValue()) {
         return;
     }
 
     auto now = Clock::now();
 
-    const double sleep_scale = Settings::values.frame_limit.GetValue() / 100.0;
+    const double sleep_scale = Settings::values.speed_limit.GetValue() / 100.0;
 
     // Max lag caused by slow frames. Shouldn't be more than the length of a frame at the current
     // speed percent or it will clamp too much and prevent this from properly limiting to that
@@ -143,17 +143,17 @@ void FrameLimiter::DoFrameLimiting(microseconds current_system_time_us) {
     // limiting
     const microseconds max_lag_time_us = duration_cast<microseconds>(
         std::chrono::duration<double, std::chrono::microseconds::period>(25ms / sleep_scale));
-    frame_limiting_delta_err += duration_cast<microseconds>(
+    speed_limiting_delta_err += duration_cast<microseconds>(
         std::chrono::duration<double, std::chrono::microseconds::period>(
             (current_system_time_us - previous_system_time_us) / sleep_scale));
-    frame_limiting_delta_err -= duration_cast<microseconds>(now - previous_walltime);
-    frame_limiting_delta_err =
-        std::clamp(frame_limiting_delta_err, -max_lag_time_us, max_lag_time_us);
+    speed_limiting_delta_err -= duration_cast<microseconds>(now - previous_walltime);
+    speed_limiting_delta_err =
+        std::clamp(speed_limiting_delta_err, -max_lag_time_us, max_lag_time_us);
 
-    if (frame_limiting_delta_err > microseconds::zero()) {
-        std::this_thread::sleep_for(frame_limiting_delta_err);
+    if (speed_limiting_delta_err > microseconds::zero()) {
+        std::this_thread::sleep_for(speed_limiting_delta_err);
         auto now_after_sleep = Clock::now();
-        frame_limiting_delta_err -= duration_cast<microseconds>(now_after_sleep - now);
+        speed_limiting_delta_err -= duration_cast<microseconds>(now_after_sleep - now);
         now = now_after_sleep;
     }
 

--- a/src/core/perf_stats.h
+++ b/src/core/perf_stats.h
@@ -85,11 +85,11 @@ private:
     double previous_fps = 0;
 };
 
-class FrameLimiter {
+class SpeedLimiter {
 public:
     using Clock = std::chrono::high_resolution_clock;
 
-    void DoFrameLimiting(std::chrono::microseconds current_system_time_us);
+    void DoSpeedLimiting(std::chrono::microseconds current_system_time_us);
 
 private:
     /// Emulated system time (in microseconds) at the last limiter invocation
@@ -98,7 +98,7 @@ private:
     Clock::time_point previous_walltime = Clock::now();
 
     /// Accumulated difference between walltime and emulated time
-    std::chrono::microseconds frame_limiting_delta_err{0};
+    std::chrono::microseconds speed_limiting_delta_err{0};
 };
 
 } // namespace Core

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -221,8 +221,8 @@ void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader,
              TranslateRenderer(Settings::values.renderer_backend.GetValue()));
     AddField(field_type, "Renderer_ResolutionFactor",
              Settings::values.resolution_factor.GetValue());
-    AddField(field_type, "Renderer_UseFrameLimit", Settings::values.use_frame_limit.GetValue());
-    AddField(field_type, "Renderer_FrameLimit", Settings::values.frame_limit.GetValue());
+    AddField(field_type, "Renderer_UseSpeedLimit", Settings::values.use_speed_limit.GetValue());
+    AddField(field_type, "Renderer_SpeedLimit", Settings::values.speed_limit.GetValue());
     AddField(field_type, "Renderer_UseDiskShaderCache",
              Settings::values.use_disk_shader_cache.GetValue());
     AddField(field_type, "Renderer_GPUAccuracyLevel",

--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -20,7 +20,7 @@ RendererBase::~RendererBase() = default;
 void RendererBase::RefreshBaseSettings() {
     UpdateCurrentFramebufferLayout();
 
-    renderer_settings.use_framelimiter = Settings::values.use_frame_limit.GetValue();
+    renderer_settings.use_framelimiter = Settings::values.use_speed_limit.GetValue();
     renderer_settings.set_background_color = true;
 }
 

--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -19,9 +19,6 @@ RendererBase::~RendererBase() = default;
 
 void RendererBase::RefreshBaseSettings() {
     UpdateCurrentFramebufferLayout();
-
-    renderer_settings.use_framelimiter = Settings::values.use_speed_limit.GetValue();
-    renderer_settings.set_background_color = true;
 }
 
 void RendererBase::UpdateCurrentFramebufferLayout() {

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -21,9 +21,6 @@ class GraphicsContext;
 namespace VideoCore {
 
 struct RendererSettings {
-    std::atomic_bool use_framelimiter{false};
-    std::atomic_bool set_background_color{false};
-
     // Screenshot
     std::atomic<bool> screenshot_requested{false};
     void* screenshot_bits{};

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -332,12 +332,10 @@ void RendererOpenGL::ConfigureFramebufferTexture(TextureInfo& texture,
 }
 
 void RendererOpenGL::DrawScreen(const Layout::FramebufferLayout& layout) {
-    if (renderer_settings.set_background_color) {
-        // Update background color before drawing
-        glClearColor(Settings::values.bg_red.GetValue() / 255.0f,
-                     Settings::values.bg_green.GetValue() / 255.0f,
-                     Settings::values.bg_blue.GetValue() / 255.0f, 1.0f);
-    }
+    // Update background color before drawing
+    glClearColor(Settings::values.bg_red.GetValue() / 255.0f,
+                 Settings::values.bg_green.GetValue() / 255.0f,
+                 Settings::values.bg_blue.GetValue() / 255.0f, 1.0f);
 
     // Set projection matrix
     const std::array ortho_matrix =

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -806,8 +806,8 @@ void Config::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.fullscreen_mode);
     ReadGlobalSetting(Settings::values.aspect_ratio);
     ReadGlobalSetting(Settings::values.max_anisotropy);
-    ReadGlobalSetting(Settings::values.use_frame_limit);
-    ReadGlobalSetting(Settings::values.frame_limit);
+    ReadGlobalSetting(Settings::values.use_speed_limit);
+    ReadGlobalSetting(Settings::values.speed_limit);
     ReadGlobalSetting(Settings::values.use_disk_shader_cache);
     ReadGlobalSetting(Settings::values.gpu_accuracy);
     ReadGlobalSetting(Settings::values.use_asynchronous_gpu_emulation);
@@ -1332,8 +1332,8 @@ void Config::SaveRendererValues() {
     WriteGlobalSetting(Settings::values.fullscreen_mode);
     WriteGlobalSetting(Settings::values.aspect_ratio);
     WriteGlobalSetting(Settings::values.max_anisotropy);
-    WriteGlobalSetting(Settings::values.use_frame_limit);
-    WriteGlobalSetting(Settings::values.frame_limit);
+    WriteGlobalSetting(Settings::values.use_speed_limit);
+    WriteGlobalSetting(Settings::values.speed_limit);
     WriteGlobalSetting(Settings::values.use_disk_shader_cache);
     WriteSetting(QString::fromStdString(Settings::values.gpu_accuracy.GetLabel()),
                  static_cast<u32>(Settings::values.gpu_accuracy.GetValue(global)),

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -24,8 +24,8 @@ ConfigureGeneral::ConfigureGeneral(QWidget* parent)
     SetConfiguration();
 
     if (Settings::IsConfiguringGlobal()) {
-        connect(ui->toggle_frame_limit, &QCheckBox::clicked, ui->frame_limit,
-                [this]() { ui->frame_limit->setEnabled(ui->toggle_frame_limit->isChecked()); });
+        connect(ui->toggle_speed_limit, &QCheckBox::clicked, ui->speed_limit,
+                [this]() { ui->speed_limit->setEnabled(ui->toggle_speed_limit->isChecked()); });
     }
 
     connect(ui->button_reset_defaults, &QPushButton::clicked, this,
@@ -45,16 +45,16 @@ void ConfigureGeneral::SetConfiguration() {
     ui->toggle_background_pause->setChecked(UISettings::values.pause_when_in_background.GetValue());
     ui->toggle_hide_mouse->setChecked(UISettings::values.hide_mouse.GetValue());
 
-    ui->toggle_frame_limit->setChecked(Settings::values.use_frame_limit.GetValue());
-    ui->frame_limit->setValue(Settings::values.frame_limit.GetValue());
+    ui->toggle_speed_limit->setChecked(Settings::values.use_speed_limit.GetValue());
+    ui->speed_limit->setValue(Settings::values.speed_limit.GetValue());
 
     ui->button_reset_defaults->setEnabled(runtime_lock);
 
     if (Settings::IsConfiguringGlobal()) {
-        ui->frame_limit->setEnabled(Settings::values.use_frame_limit.GetValue());
+        ui->speed_limit->setEnabled(Settings::values.use_speed_limit.GetValue());
     } else {
-        ui->frame_limit->setEnabled(Settings::values.use_frame_limit.GetValue() &&
-                                    use_frame_limit != ConfigurationShared::CheckState::Global);
+        ui->speed_limit->setEnabled(Settings::values.use_speed_limit.GetValue() &&
+                                    use_speed_limit != ConfigurationShared::CheckState::Global);
     }
 }
 
@@ -88,19 +88,19 @@ void ConfigureGeneral::ApplyConfiguration() {
         UISettings::values.hide_mouse = ui->toggle_hide_mouse->isChecked();
 
         // Guard if during game and set to game-specific value
-        if (Settings::values.use_frame_limit.UsingGlobal()) {
-            Settings::values.use_frame_limit.SetValue(ui->toggle_frame_limit->checkState() ==
+        if (Settings::values.use_speed_limit.UsingGlobal()) {
+            Settings::values.use_speed_limit.SetValue(ui->toggle_speed_limit->checkState() ==
                                                       Qt::Checked);
-            Settings::values.frame_limit.SetValue(ui->frame_limit->value());
+            Settings::values.speed_limit.SetValue(ui->speed_limit->value());
         }
     } else {
-        bool global_frame_limit = use_frame_limit == ConfigurationShared::CheckState::Global;
-        Settings::values.use_frame_limit.SetGlobal(global_frame_limit);
-        Settings::values.frame_limit.SetGlobal(global_frame_limit);
-        if (!global_frame_limit) {
-            Settings::values.use_frame_limit.SetValue(ui->toggle_frame_limit->checkState() ==
+        bool global_speed_limit = use_speed_limit == ConfigurationShared::CheckState::Global;
+        Settings::values.use_speed_limit.SetGlobal(global_speed_limit);
+        Settings::values.speed_limit.SetGlobal(global_speed_limit);
+        if (!global_speed_limit) {
+            Settings::values.use_speed_limit.SetValue(ui->toggle_speed_limit->checkState() ==
                                                       Qt::Checked);
-            Settings::values.frame_limit.SetValue(ui->frame_limit->value());
+            Settings::values.speed_limit.SetValue(ui->speed_limit->value());
         }
     }
 }
@@ -122,8 +122,8 @@ void ConfigureGeneral::SetupPerGameUI() {
         // Disables each setting if:
         //  - A game is running (thus settings in use), and
         //  - A non-global setting is applied.
-        ui->toggle_frame_limit->setEnabled(Settings::values.use_frame_limit.UsingGlobal());
-        ui->frame_limit->setEnabled(Settings::values.frame_limit.UsingGlobal());
+        ui->toggle_speed_limit->setEnabled(Settings::values.use_speed_limit.UsingGlobal());
+        ui->speed_limit->setEnabled(Settings::values.speed_limit.UsingGlobal());
 
         return;
     }
@@ -135,13 +135,13 @@ void ConfigureGeneral::SetupPerGameUI() {
 
     ui->button_reset_defaults->setVisible(false);
 
-    ConfigurationShared::SetColoredTristate(ui->toggle_frame_limit,
-                                            Settings::values.use_frame_limit, use_frame_limit);
+    ConfigurationShared::SetColoredTristate(ui->toggle_speed_limit,
+                                            Settings::values.use_speed_limit, use_speed_limit);
     ConfigurationShared::SetColoredTristate(ui->use_multi_core, Settings::values.use_multi_core,
                                             use_multi_core);
 
-    connect(ui->toggle_frame_limit, &QCheckBox::clicked, ui->frame_limit, [this]() {
-        ui->frame_limit->setEnabled(ui->toggle_frame_limit->isChecked() &&
-                                    (use_frame_limit != ConfigurationShared::CheckState::Global));
+    connect(ui->toggle_speed_limit, &QCheckBox::clicked, ui->speed_limit, [this]() {
+        ui->speed_limit->setEnabled(ui->toggle_speed_limit->isChecked() &&
+                                    (use_speed_limit != ConfigurationShared::CheckState::Global));
     });
 }

--- a/src/yuzu/configuration/configure_general.h
+++ b/src/yuzu/configuration/configure_general.h
@@ -43,6 +43,6 @@ private:
 
     std::unique_ptr<Ui::ConfigureGeneral> ui;
 
-    ConfigurationShared::CheckState use_frame_limit;
+    ConfigurationShared::CheckState use_speed_limit;
     ConfigurationShared::CheckState use_multi_core;
 };

--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -27,14 +27,14 @@
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <item>
-             <widget class="QCheckBox" name="toggle_frame_limit">
+             <widget class="QCheckBox" name="toggle_speed_limit">
               <property name="text">
                <string>Limit Speed Percent</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QSpinBox" name="frame_limit">
+             <widget class="QSpinBox" name="speed_limit">
               <property name="suffix">
                <string>%</string>
               </property>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -985,23 +985,23 @@ void GMainWindow::InitializeHotkeys() {
             });
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Toggle Speed Limit"), this),
             &QShortcut::activated, this, [&] {
-                Settings::values.use_frame_limit.SetValue(
-                    !Settings::values.use_frame_limit.GetValue());
+                Settings::values.use_speed_limit.SetValue(
+                    !Settings::values.use_speed_limit.GetValue());
                 UpdateStatusBar();
             });
     constexpr u16 SPEED_LIMIT_STEP = 5;
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Increase Speed Limit"), this),
             &QShortcut::activated, this, [&] {
-                if (Settings::values.frame_limit.GetValue() < 9999 - SPEED_LIMIT_STEP) {
-                    Settings::values.frame_limit.SetValue(SPEED_LIMIT_STEP +
-                                                          Settings::values.frame_limit.GetValue());
+                if (Settings::values.speed_limit.GetValue() < 9999 - SPEED_LIMIT_STEP) {
+                    Settings::values.speed_limit.SetValue(SPEED_LIMIT_STEP +
+                                                          Settings::values.speed_limit.GetValue());
                     UpdateStatusBar();
                 }
             });
     connect(hotkey_registry.GetHotkey(main_window, QStringLiteral("Decrease Speed Limit"), this),
             &QShortcut::activated, this, [&] {
-                if (Settings::values.frame_limit.GetValue() > SPEED_LIMIT_STEP) {
-                    Settings::values.frame_limit.SetValue(Settings::values.frame_limit.GetValue() -
+                if (Settings::values.speed_limit.GetValue() > SPEED_LIMIT_STEP) {
+                    Settings::values.speed_limit.SetValue(Settings::values.speed_limit.GetValue() -
                                                           SPEED_LIMIT_STEP);
                     UpdateStatusBar();
                 }
@@ -2912,10 +2912,10 @@ void GMainWindow::UpdateStatusBar() {
         shader_building_label->setVisible(false);
     }
 
-    if (Settings::values.use_frame_limit.GetValue()) {
+    if (Settings::values.use_speed_limit.GetValue()) {
         emu_speed_label->setText(tr("Speed: %1% / %2%")
                                      .arg(results.emulation_speed * 100.0, 0, 'f', 0)
-                                     .arg(Settings::values.frame_limit.GetValue()));
+                                     .arg(Settings::values.speed_limit.GetValue()));
     } else {
         emu_speed_label->setText(tr("Speed: %1%").arg(results.emulation_speed * 100.0, 0, 'f', 0));
     }

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -449,8 +449,8 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.fullscreen_mode);
     ReadSetting("Renderer", Settings::values.aspect_ratio);
     ReadSetting("Renderer", Settings::values.max_anisotropy);
-    ReadSetting("Renderer", Settings::values.use_frame_limit);
-    ReadSetting("Renderer", Settings::values.frame_limit);
+    ReadSetting("Renderer", Settings::values.use_speed_limit);
+    ReadSetting("Renderer", Settings::values.speed_limit);
     ReadSetting("Renderer", Settings::values.use_disk_shader_cache);
     ReadSetting("Renderer", Settings::values.gpu_accuracy);
     ReadSetting("Renderer", Settings::values.use_asynchronous_gpu_emulation);

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -256,13 +256,13 @@ use_nvdec_emulation =
 # 0: Off, 1 (default): On
 accelerate_astc =
 
-# Turns on the frame limiter, which will limit frames output to the target game speed
+# Turns on the speed limiter, which will limit the emulation speed to the desired speed limit value
 # 0: Off, 1: On (default)
-use_frame_limit =
+use_speed_limit =
 
 # Limits the speed of the game to run no faster than this value as a percentage of target speed
 # 1 - 9999: Speed limit as a percentage of target game speed. 100 (default)
-frame_limit =
+speed_limit =
 
 # Whether to use disk based shader cache
 # 0: Off, 1 (default): On


### PR DESCRIPTION
This setting is best referred to as a speed limit, as it involves the limits of all timing based aspects of the emulator, not only framerate.
This allows us to differentiate it from the FPS unlocker setting.

This change also uncovered unused renderer settings that are now being removed.