### PR TITLE
input_common: Improve SDL joystick and hide toggle option

### DIFF
--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -304,10 +304,10 @@ std::vector<std::unique_ptr<Polling::DevicePoller>> InputSubsystem::GetPollers([
 }
 
 std::string GenerateKeyboardParam(int key_code) {
-    Common::ParamPackage param{
-        {"engine", "keyboard"},
-        {"code", std::to_string(key_code)},
-    };
+    Common::ParamPackage param;
+    param.Set("engine", "keyboard");
+    param.Set("code", key_code);
+    param.Set("toggle", false);
     return param.Serialize();
 }
 

--- a/src/input_common/mouse/mouse_poller.cpp
+++ b/src/input_common/mouse/mouse_poller.cpp
@@ -57,6 +57,7 @@ Common::ParamPackage MouseButtonFactory::GetNextInput() const {
         if (pad.button != MouseInput::MouseButton::Undefined) {
             params.Set("engine", "mouse");
             params.Set("button", static_cast<u16>(pad.button));
+            params.Set("toggle", false);
             return params;
         }
     }

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -309,11 +309,14 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
                         buttons_param[button_id].Clear();
                         button_map[button_id]->setText(tr("[not set]"));
                     });
-                    context_menu.addAction(tr("Toggle button"), [&] {
-                        const bool toggle_value = !buttons_param[button_id].Get("toggle", false);
-                        buttons_param[button_id].Set("toggle", toggle_value);
-                        button_map[button_id]->setText(ButtonToText(buttons_param[button_id]));
-                    });
+                    if (buttons_param[button_id].Has("toggle")) {
+                        context_menu.addAction(tr("Toggle button"), [&] {
+                            const bool toggle_value =
+                                !buttons_param[button_id].Get("toggle", false);
+                            buttons_param[button_id].Set("toggle", toggle_value);
+                            button_map[button_id]->setText(ButtonToText(buttons_param[button_id]));
+                        });
+                    }
                     if (buttons_param[button_id].Has("threshold")) {
                         context_menu.addAction(tr("Set threshold"), [&] {
                             const int button_threshold = static_cast<int>(


### PR DESCRIPTION
Some QoL changes:
- Hides the toggle button on all buttons that don't support this setting
- Avoids resetting the SDL controller every time the mappings are edited
- Adds a property to set a desired SDL joystick center
- The auto mapper will set the joystick center automatically

Closes #6555
Closes #6455 