### PR TITLE
common: Publically link to pthreads

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -231,7 +231,7 @@ endif()
 
 create_target_directory_groups(common)
 
-target_link_libraries(common PUBLIC ${Boost_LIBRARIES} fmt::fmt microprofile)
+target_link_libraries(common PUBLIC ${Boost_LIBRARIES} fmt::fmt microprofile Threads::Threads)
 target_link_libraries(common PRIVATE lz4::lz4 xbyak)
 if (MSVC)
   target_link_libraries(common PRIVATE zstd::zstd)


### PR DESCRIPTION
Common requires pthreads but does not refer to it when linking to other modules. Fix this by linking to Threads where necessary.

(It's probably not called pthreads for MSVC.)