### PR TITLE
yuzu_cmd, yuzu qt: Use SDL to disable the screen saver

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -299,6 +299,11 @@ if (YUZU_USE_BUNDLED_QT)
     copy_yuzu_Qt5_deps(yuzu)
 endif()
 
+if (ENABLE_SDL2)
+    target_link_libraries(yuzu PRIVATE SDL2)
+    target_compile_definitions(yuzu PRIVATE HAVE_SDL2)
+endif()
+
 if (MSVC)
     include(CopyYuzuSDLDeps)
     include(CopyYuzuFFmpegDeps)


### PR DESCRIPTION
This disables the screen saver when yuzu is running a game via SDL2's screen saver functions. Adds an option to allow or disable the screen saver in General options.

I went and finished this, got ready to make the PR, and noticed #6421 already exists. I thought I propose this, anyway, since (a) this implements it in 1/3 of the code, (b) doesn't add any new dependencies, and (c) SDL2's screen saver inhibition is platform-agnostic --- we implement it here for Linux, and it'll work on Android and macOS and anything else that SDL2's screen saver functions are implemented for, too.

Closes #6262