### PR TITLE
main: Fix screenshot filepath construction

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2823,7 +2823,7 @@ void GMainWindow::OnCaptureScreenshot() {
         QString::fromStdString(Common::FS::GetYuzuPathString(Common::FS::YuzuPath::ScreenshotsDir));
     const auto date =
         QDateTime::currentDateTime().toString(QStringLiteral("yyyy-MM-dd_hh-mm-ss-zzz"));
-    QString filename = QStringLiteral("%1%2_%3.png")
+    QString filename = QStringLiteral("%1/%2_%3.png")
                            .arg(screenshot_path)
                            .arg(title_id, 16, 16, QLatin1Char{'0'})
                            .arg(date);


### PR DESCRIPTION
The screenshot directory path returned does not have a trailing directory separator character. This caused screenshots to be saved in the parent directory of the configured screenshot directory.

This fixes that behavior