### PR TITLE
object_pool: Add missing return in Chunk move assignment operator

### DIFF
--- a/src/shader_recompiler/object_pool.h
+++ b/src/shader_recompiler/object_pool.h
@@ -63,6 +63,7 @@ private:
             used_objects = std::exchange(rhs.used_objects, 0);
             num_objects = std::exchange(rhs.num_objects, 0);
             storage = std::move(rhs.storage);
+            return *this;
         }
 
         Chunk(Chunk&& rhs) noexcept


### PR DESCRIPTION
Prevents cases of undefined behavior from occurring.