### PR TITLE
shader_recompiler: Remove unnecessary [[nodiscard]] instances

### DIFF
--- a/src/shader_recompiler/frontend/ir/ir_emitter.h
+++ b/src/shader_recompiler/frontend/ir/ir_emitter.h
@@ -327,8 +327,8 @@ public:
                                       const Value& derivates, const Value& offset,
                                       const F32& lod_clamp, TextureInstInfo info);
     [[nodiscard]] Value ImageRead(const Value& handle, const Value& coords, TextureInstInfo info);
-    [[nodiscard]] void ImageWrite(const Value& handle, const Value& coords, const Value& color,
-                                  TextureInstInfo info);
+    void ImageWrite(const Value& handle, const Value& coords, const Value& color,
+                    TextureInstInfo info);
 
     [[nodiscard]] Value ImageAtomicIAdd(const Value& handle, const Value& coords,
                                         const Value& value, TextureInstInfo info);

--- a/src/shader_recompiler/frontend/ir/value.h
+++ b/src/shader_recompiler/frontend/ir/value.h
@@ -197,8 +197,8 @@ public:
     }
 
     template <typename FlagsType>
-    requires(sizeof(FlagsType) <= sizeof(u32) && std::is_trivially_copyable_v<FlagsType>)
-        [[nodiscard]] void SetFlags(FlagsType value) noexcept {
+    requires(sizeof(FlagsType) <= sizeof(u32) &&
+             std::is_trivially_copyable_v<FlagsType>) void SetFlags(FlagsType value) noexcept {
         std::memcpy(&flags, &value, sizeof(value));
     }
 


### PR DESCRIPTION
[[nodiscard]] doesn't do anything on functions with a void return type and causes superfluous warnings.