### PR TITLE
control_flow: Fix duplicate switch case in OpcodeToken

### DIFF
--- a/src/shader_recompiler/frontend/maxwell/control_flow.cpp
+++ b/src/shader_recompiler/frontend/maxwell/control_flow.cpp
@@ -73,7 +73,7 @@ Token OpcodeToken(Opcode opcode) {
         return Token::PBK;
     case Opcode::PCNT:
     case Opcode::CONT:
-        return Token::PBK;
+        return Token::PCNT;
     case Opcode::PEXIT:
     case Opcode::EXIT:
         return Token::PEXIT;


### PR DESCRIPTION
This previously duplicated the case of the PBK case above it.