### PR TITLE
Config-graphics: reword GLASM option

### DIFF
--- a/src/yuzu/configuration/configure_graphics.cpp
+++ b/src/yuzu/configuration/configure_graphics.cpp
@@ -31,7 +31,7 @@ ConfigureGraphics::ConfigureGraphics(QWidget* parent)
     }
 
     ui->backend->addItem(QStringLiteral("GLSL"));
-    ui->backend->addItem(tr("GLASM (NVIDIA Only)"));
+    ui->backend->addItem(tr("GLASM (Assembly Shaders, NVIDIA Only)"));
     ui->backend->addItem(QStringLiteral("SPIR-V (Experimental, Mesa Only)"));
 
     SetupPerGameUI();


### PR DESCRIPTION
* Change wording to explain that GLASM is actually short for Assembly Shaders