### PR TITLE
exception: Make constructors explicit

### DIFF
--- a/src/shader_recompiler/exception.h
+++ b/src/shader_recompiler/exception.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include <stdexcept>
+#include <exception>
 #include <string>
 #include <string_view>
 #include <utility>

--- a/src/shader_recompiler/exception.h
+++ b/src/shader_recompiler/exception.h
@@ -17,7 +17,7 @@ class Exception : public std::exception {
 public:
     explicit Exception(std::string message) noexcept : err_message{std::move(message)} {}
 
-    const char* what() const noexcept override {
+    [[nodiscard]] const char* what() const noexcept override {
         return err_message.c_str();
     }
 

--- a/src/shader_recompiler/exception.h
+++ b/src/shader_recompiler/exception.h
@@ -36,21 +36,21 @@ private:
 class LogicError : public Exception {
 public:
     template <typename... Args>
-    LogicError(const char* message, Args&&... args)
+    explicit LogicError(const char* message, Args&&... args)
         : Exception{fmt::format(fmt::runtime(message), std::forward<Args>(args)...)} {}
 };
 
 class RuntimeError : public Exception {
 public:
     template <typename... Args>
-    RuntimeError(const char* message, Args&&... args)
+    explicit RuntimeError(const char* message, Args&&... args)
         : Exception{fmt::format(fmt::runtime(message), std::forward<Args>(args)...)} {}
 };
 
 class NotImplementedException : public Exception {
 public:
     template <typename... Args>
-    NotImplementedException(const char* message, Args&&... args)
+    explicit NotImplementedException(const char* message, Args&&... args)
         : Exception{fmt::format(fmt::runtime(message), std::forward<Args>(args)...)} {
         Append(" is not implemented");
     }
@@ -59,7 +59,7 @@ public:
 class InvalidArgument : public Exception {
 public:
     template <typename... Args>
-    InvalidArgument(const char* message, Args&&... args)
+    explicit InvalidArgument(const char* message, Args&&... args)
         : Exception{fmt::format(fmt::runtime(message), std::forward<Args>(args)...)} {}
 };
 


### PR DESCRIPTION
Makes the constructors explicit to match their inheriting `Exception` constructor.

While we're in the area, we can narrow the included header from `<stdexcept>` to `<exception>`, since only `std::exception` is made use of, which avoids a little inclusion churn from indirectly including `<exception>`