### PR TITLE
service: ns, set: Add PT_BR (Brazilian Portuguese)

### DIFF
--- a/src/core/hle/service/ns/language.cpp
+++ b/src/core/hle/service/ns/language.cpp
@@ -339,6 +339,7 @@ std::optional<ApplicationLanguage> ConvertToApplicationLanguage(
     case Set::LanguageCode::FR_CA:
         return ApplicationLanguage::CanadianFrench;
     case Set::LanguageCode::PT:
+    case Set::LanguageCode::PT_BR:
         return ApplicationLanguage::Portuguese;
     case Set::LanguageCode::RU:
         return ApplicationLanguage::Russian;

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -72,8 +72,8 @@ constexpr std::array<std::pair<LanguageCode, KeyboardLayout>, 18> language_to_la
     {LanguageCode::PT_BR, KeyboardLayout::Portuguese},
 }};
 
-constexpr std::size_t pre4_0_0_max_entries = 15;
-constexpr std::size_t post4_0_0_max_entries = 17;
+constexpr std::size_t PRE_4_0_0_MAX_ENTRIES = 0xF;
+constexpr std::size_t POST_4_0_0_MAX_ENTRIES = 0x40;
 
 constexpr ResultCode ERR_INVALID_LANGUAGE{ErrorModule::Settings, 625};
 
@@ -83,9 +83,9 @@ void PushResponseLanguageCode(Kernel::HLERequestContext& ctx, std::size_t num_la
     rb.Push(static_cast<u32>(num_language_codes));
 }
 
-void GetAvailableLanguageCodesImpl(Kernel::HLERequestContext& ctx, std::size_t max_size) {
+void GetAvailableLanguageCodesImpl(Kernel::HLERequestContext& ctx, std::size_t max_entries) {
     const std::size_t requested_amount = ctx.GetWriteBufferSize() / sizeof(LanguageCode);
-    const std::size_t copy_amount = std::min(requested_amount, max_size);
+    const std::size_t copy_amount = std::min(requested_amount, max_entries);
     const std::size_t copy_size = copy_amount * sizeof(LanguageCode);
 
     ctx.WriteBuffer(available_language_codes.data(), copy_size);
@@ -120,7 +120,7 @@ LanguageCode GetLanguageCodeFromIndex(std::size_t index) {
 void SET::GetAvailableLanguageCodes(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_SET, "called");
 
-    GetAvailableLanguageCodesImpl(ctx, pre4_0_0_max_entries);
+    GetAvailableLanguageCodesImpl(ctx, PRE_4_0_0_MAX_ENTRIES);
 }
 
 void SET::MakeLanguageCode(Kernel::HLERequestContext& ctx) {
@@ -142,19 +142,19 @@ void SET::MakeLanguageCode(Kernel::HLERequestContext& ctx) {
 void SET::GetAvailableLanguageCodes2(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_SET, "called");
 
-    GetAvailableLanguageCodesImpl(ctx, post4_0_0_max_entries);
+    GetAvailableLanguageCodesImpl(ctx, POST_4_0_0_MAX_ENTRIES);
 }
 
 void SET::GetAvailableLanguageCodeCount(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_SET, "called");
 
-    PushResponseLanguageCode(ctx, pre4_0_0_max_entries);
+    PushResponseLanguageCode(ctx, PRE_4_0_0_MAX_ENTRIES);
 }
 
 void SET::GetAvailableLanguageCodeCount2(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_SET, "called");
 
-    PushResponseLanguageCode(ctx, post4_0_0_max_entries);
+    PushResponseLanguageCode(ctx, POST_4_0_0_MAX_ENTRIES);
 }
 
 void SET::GetQuestFlag(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -12,7 +12,7 @@
 
 namespace Service::Set {
 namespace {
-constexpr std::array<LanguageCode, 17> available_language_codes = {{
+constexpr std::array<LanguageCode, 18> available_language_codes = {{
     LanguageCode::JA,
     LanguageCode::EN_US,
     LanguageCode::FR,
@@ -30,6 +30,7 @@ constexpr std::array<LanguageCode, 17> available_language_codes = {{
     LanguageCode::ES_419,
     LanguageCode::ZH_HANS,
     LanguageCode::ZH_HANT,
+    LanguageCode::PT_BR,
 }};
 
 enum class KeyboardLayout : u64 {
@@ -50,7 +51,7 @@ enum class KeyboardLayout : u64 {
     ChineseTraditional = 14,
 };
 
-constexpr std::array<std::pair<LanguageCode, KeyboardLayout>, 17> language_to_layout{{
+constexpr std::array<std::pair<LanguageCode, KeyboardLayout>, 18> language_to_layout{{
     {LanguageCode::JA, KeyboardLayout::Japanese},
     {LanguageCode::EN_US, KeyboardLayout::EnglishUs},
     {LanguageCode::FR, KeyboardLayout::French},
@@ -68,6 +69,7 @@ constexpr std::array<std::pair<LanguageCode, KeyboardLayout>, 17> language_to_la
     {LanguageCode::ES_419, KeyboardLayout::SpanishLatin},
     {LanguageCode::ZH_HANS, KeyboardLayout::ChineseSimplified},
     {LanguageCode::ZH_HANT, KeyboardLayout::ChineseTraditional},
+    {LanguageCode::PT_BR, KeyboardLayout::Portuguese},
 }};
 
 constexpr std::size_t pre4_0_0_max_entries = 15;

--- a/src/core/hle/service/set/set.h
+++ b/src/core/hle/service/set/set.h
@@ -31,6 +31,7 @@ enum class LanguageCode : u64 {
     ES_419 = 0x00003931342D7365,
     ZH_HANS = 0x00736E61482D687A,
     ZH_HANT = 0x00746E61482D687A,
+    PT_BR = 0x00000052422D7470,
 };
 LanguageCode GetLanguageCodeFromIndex(std::size_t idx);
 

--- a/src/yuzu/configuration/configure_system.ui
+++ b/src/yuzu/configuration/configure_system.ui
@@ -401,6 +401,11 @@
               <string>Traditional Chinese (正體中文)</string>
              </property>
             </item>
+            <item>
+             <property name="text">
+              <string>Brazilian Portuguese (português do Brasil)</string>
+             </property>
+            </item>
            </widget>
           </item>
           <item row="5" column="0">

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -363,7 +363,7 @@ custom_rtc =
 # Sets the systems language index
 # 0: Japanese, 1: English (default), 2: French, 3: German, 4: Italian, 5: Spanish, 6: Chinese,
 # 7: Korean, 8: Dutch, 9: Portuguese, 10: Russian, 11: Taiwanese, 12: British English, 13: Canadian French,
-# 14: Latin American Spanish, 15: Simplified Chinese, 16: Traditional Chinese
+# 14: Latin American Spanish, 15: Simplified Chinese, 16: Traditional Chinese, 17: Brazilian Portuguese
 language_index =
 
 # The system region that yuzu will use during emulation


### PR DESCRIPTION
Adds Brazilian Portuguese to the list of languages, which was added in NX firmware 10.1.0.