### PR TITLE
host_memory: enable fastmem on FreeBSD

### DIFF
--- a/src/common/host_memory.cpp
+++ b/src/common/host_memory.cpp
@@ -357,7 +357,12 @@ public:
         });
 
         // Backing memory initialization
+#if defined(__FreeBSD__) && __FreeBSD__ < 13
+        // XXX Drop after FreeBSD 12.* reaches EOL on 2024-06-30
+        fd = shm_open(SHM_ANON, O_RDWR, 0600);
+#else
         fd = memfd_create("HostMemory", 0);
+#endif
         if (fd == -1) {
             LOG_CRITICAL(HW_Memory, "memfd_create failed: {}", strerror(errno));
             throw std::bad_alloc{};

--- a/src/common/host_memory.cpp
+++ b/src/common/host_memory.cpp
@@ -6,7 +6,7 @@
 #include <windows.h>
 #include "common/dynamic_library.h"
 
-#elif defined(__linux__) // ^^^ Windows ^^^ vvv Linux vvv
+#elif defined(__linux__) || defined(__FreeBSD__) // ^^^ Windows ^^^ vvv Linux vvv
 
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -343,7 +343,7 @@ private:
     std::unordered_map<size_t, size_t> placeholder_host_pointers; ///< Placeholder backing offset
 };
 
-#elif defined(__linux__) // ^^^ Windows ^^^ vvv Linux vvv
+#elif defined(__linux__) || defined(__FreeBSD__) // ^^^ Windows ^^^ vvv Linux vvv
 
 class HostMemory::Impl {
 public:


### PR DESCRIPTION
FreeBSD >= 13.0 has [memfd_create(3)](https://man.freebsd.org/memfd_create/3), [implemented](https://reviews.freebsd.org/D21393) via `SHM_ANON`.