### PR TITLE
ui: make game list dir icons smaller

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -945,7 +945,8 @@ void Config::ReadUIGamelistValues() {
     qt_config->beginGroup(QStringLiteral("UIGameList"));
 
     ReadBasicSetting(UISettings::values.show_add_ons);
-    ReadBasicSetting(UISettings::values.icon_size);
+    ReadBasicSetting(UISettings::values.game_icon_size);
+    ReadBasicSetting(UISettings::values.folder_icon_size);
     ReadBasicSetting(UISettings::values.row_1_text_id);
     ReadBasicSetting(UISettings::values.row_2_text_id);
     ReadBasicSetting(UISettings::values.cache_game_list);
@@ -1458,7 +1459,8 @@ void Config::SaveUIGamelistValues() {
     qt_config->beginGroup(QStringLiteral("UIGameList"));
 
     WriteBasicSetting(UISettings::values.show_add_ons);
-    WriteBasicSetting(UISettings::values.icon_size);
+    WriteBasicSetting(UISettings::values.game_icon_size);
+    WriteBasicSetting(UISettings::values.folder_icon_size);
     WriteBasicSetting(UISettings::values.row_1_text_id);
     WriteBasicSetting(UISettings::values.row_2_text_id);
     WriteBasicSetting(UISettings::values.cache_game_list);

--- a/src/yuzu/configuration/configure_ui.cpp
+++ b/src/yuzu/configuration/configure_ui.cpp
@@ -16,12 +16,19 @@
 #include "yuzu/uisettings.h"
 
 namespace {
-constexpr std::array default_icon_sizes{
+constexpr std::array default_game_icon_sizes{
     std::make_pair(0, QT_TRANSLATE_NOOP("ConfigureUI", "None")),
     std::make_pair(32, QT_TRANSLATE_NOOP("ConfigureUI", "Small (32x32)")),
     std::make_pair(64, QT_TRANSLATE_NOOP("ConfigureUI", "Standard (64x64)")),
     std::make_pair(128, QT_TRANSLATE_NOOP("ConfigureUI", "Large (128x128)")),
     std::make_pair(256, QT_TRANSLATE_NOOP("ConfigureUI", "Full Size (256x256)")),
+};
+
+constexpr std::array default_folder_icon_sizes{
+    std::make_pair(0, QT_TRANSLATE_NOOP("ConfigureUI", "None")),
+    std::make_pair(24, QT_TRANSLATE_NOOP("ConfigureUI", "Small (24x24)")),
+    std::make_pair(48, QT_TRANSLATE_NOOP("ConfigureUI", "Standard (48x48)")),
+    std::make_pair(72, QT_TRANSLATE_NOOP("ConfigureUI", "Large (72x72)")),
 };
 
 // clang-format off
@@ -34,8 +41,12 @@ constexpr std::array row_text_names{
 };
 // clang-format on
 
-QString GetTranslatedIconSize(size_t index) {
-    return QCoreApplication::translate("ConfigureUI", default_icon_sizes[index].second);
+QString GetTranslatedGameIconSize(size_t index) {
+    return QCoreApplication::translate("ConfigureUI", default_game_icon_sizes[index].second);
+}
+
+QString GetTranslatedFolderIconSize(size_t index) {
+    return QCoreApplication::translate("ConfigureUI", default_folder_icon_sizes[index].second);
 }
 
 QString GetTranslatedRowTextName(size_t index) {
@@ -60,8 +71,10 @@ ConfigureUi::ConfigureUi(QWidget* parent) : QWidget(parent), ui(new Ui::Configur
 
     // Force game list reload if any of the relevant settings are changed.
     connect(ui->show_add_ons, &QCheckBox::stateChanged, this, &ConfigureUi::RequestGameListUpdate);
-    connect(ui->icon_size_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+    connect(ui->game_icon_size_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &ConfigureUi::RequestGameListUpdate);
+    connect(ui->folder_icon_size_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged),
+            this, &ConfigureUi::RequestGameListUpdate);
     connect(ui->row_1_text_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
             &ConfigureUi::RequestGameListUpdate);
     connect(ui->row_2_text_combobox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
@@ -95,7 +108,8 @@ void ConfigureUi::ApplyConfiguration() {
     UISettings::values.theme =
         ui->theme_combobox->itemData(ui->theme_combobox->currentIndex()).toString();
     UISettings::values.show_add_ons = ui->show_add_ons->isChecked();
-    UISettings::values.icon_size = ui->icon_size_combobox->currentData().toUInt();
+    UISettings::values.game_icon_size = ui->game_icon_size_combobox->currentData().toUInt();
+    UISettings::values.folder_icon_size = ui->folder_icon_size_combobox->currentData().toUInt();
     UISettings::values.row_1_text_id = ui->row_1_text_combobox->currentData().toUInt();
     UISettings::values.row_2_text_id = ui->row_2_text_combobox->currentData().toUInt();
 
@@ -114,8 +128,10 @@ void ConfigureUi::SetConfiguration() {
     ui->language_combobox->setCurrentIndex(
         ui->language_combobox->findData(UISettings::values.language));
     ui->show_add_ons->setChecked(UISettings::values.show_add_ons.GetValue());
-    ui->icon_size_combobox->setCurrentIndex(
-        ui->icon_size_combobox->findData(UISettings::values.icon_size.GetValue()));
+    ui->game_icon_size_combobox->setCurrentIndex(
+        ui->game_icon_size_combobox->findData(UISettings::values.game_icon_size.GetValue()));
+    ui->folder_icon_size_combobox->setCurrentIndex(
+        ui->folder_icon_size_combobox->findData(UISettings::values.folder_icon_size.GetValue()));
 
     ui->enable_screenshot_save_as->setChecked(
         UISettings::values.enable_screenshot_save_as.GetValue());
@@ -134,8 +150,14 @@ void ConfigureUi::changeEvent(QEvent* event) {
 void ConfigureUi::RetranslateUI() {
     ui->retranslateUi(this);
 
-    for (int i = 0; i < ui->icon_size_combobox->count(); i++) {
-        ui->icon_size_combobox->setItemText(i, GetTranslatedIconSize(static_cast<size_t>(i)));
+    for (int i = 0; i < ui->game_icon_size_combobox->count(); i++) {
+        ui->game_icon_size_combobox->setItemText(i,
+                                                 GetTranslatedGameIconSize(static_cast<size_t>(i)));
+    }
+
+    for (int i = 0; i < ui->folder_icon_size_combobox->count(); i++) {
+        ui->folder_icon_size_combobox->setItemText(
+            i, GetTranslatedFolderIconSize(static_cast<size_t>(i)));
     }
 
     for (int i = 0; i < ui->row_1_text_combobox->count(); i++) {
@@ -166,9 +188,13 @@ void ConfigureUi::InitializeLanguageComboBox() {
 }
 
 void ConfigureUi::InitializeIconSizeComboBox() {
-    for (size_t i = 0; i < default_icon_sizes.size(); i++) {
-        const auto size = default_icon_sizes[i].first;
-        ui->icon_size_combobox->addItem(GetTranslatedIconSize(i), size);
+    for (size_t i = 0; i < default_game_icon_sizes.size(); i++) {
+        const auto size = default_game_icon_sizes[i].first;
+        ui->game_icon_size_combobox->addItem(GetTranslatedGameIconSize(i), size);
+    }
+    for (size_t i = 0; i < default_folder_icon_sizes.size(); i++) {
+        const auto size = default_folder_icon_sizes[i].first;
+        ui->folder_icon_size_combobox->addItem(GetTranslatedFolderIconSize(i), size);
     }
 }
 

--- a/src/yuzu/configuration/configure_ui.ui
+++ b/src/yuzu/configuration/configure_ui.ui
@@ -81,16 +81,30 @@
          </widget>
         </item>
         <item>
-         <layout class="QHBoxLayout" name="icon_size_qhbox_layout_2">
+         <layout class="QHBoxLayout" name="game_icon_size_qhbox_layout_2">
           <item>
-           <widget class="QLabel" name="icon_size_label">
+           <widget class="QLabel" name="game_icon_size_label">
             <property name="text">
-             <string>Icon Size:</string>
+             <string>Game Icon Size:</string>
             </property>
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="icon_size_combobox"/>
+           <widget class="QComboBox" name="game_icon_size_combobox"/>
+          </item>
+         </layout>
+        </item>
+        <item>
+         <layout class="QHBoxLayout" name="folder_icon_size_qhbox_layout_2">
+          <item>
+           <widget class="QLabel" name="folder_icon_size_label">
+            <property name="text">
+             <string>Folder Icon Size:</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="folder_icon_size_combobox"/>
           </item>
          </layout>
         </item>

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -244,7 +244,8 @@ void GameList::OnUpdateThemedIcons() {
     for (int i = 0; i < item_model->invisibleRootItem()->rowCount(); i++) {
         QStandardItem* child = item_model->invisibleRootItem()->child(i);
 
-        const int icon_size = 24;
+        const int icon_size = UISettings::values.folder_icon_size.GetValue();
+
         switch (child->data(GameListItem::TypeRole).value<GameListItemType>()) {
         case GameListItemType::SdmcDir:
             child->setData(

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -245,7 +245,7 @@ void GameList::OnUpdateThemedIcons() {
         QStandardItem* child = item_model->invisibleRootItem()->child(i);
 
         const int icon_size =
-            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 18);
+            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 24);
         switch (child->data(GameListItem::TypeRole).value<GameListItemType>()) {
         case GameListItemType::SdmcDir:
             child->setData(

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -244,8 +244,7 @@ void GameList::OnUpdateThemedIcons() {
     for (int i = 0; i < item_model->invisibleRootItem()->rowCount(); i++) {
         QStandardItem* child = item_model->invisibleRootItem()->child(i);
 
-        const int icon_size =
-            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 24);
+        const int icon_size = 24;
         switch (child->data(GameListItem::TypeRole).value<GameListItemType>()) {
         case GameListItemType::SdmcDir:
             child->setData(

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -245,7 +245,7 @@ void GameList::OnUpdateThemedIcons() {
         QStandardItem* child = item_model->invisibleRootItem()->child(i);
 
         const int icon_size =
-            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 64);
+            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 18);
         switch (child->data(GameListItem::TypeRole).value<GameListItemType>()) {
         case GameListItemType::SdmcDir:
             child->setData(

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -233,8 +233,7 @@ public:
         UISettings::GameDir* game_dir = &directory;
         setData(QVariant(UISettings::values.game_dirs.indexOf(directory)), GameDirRole);
 
-        const int icon_size =
-            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 24);
+        const int icon_size = 24;
         switch (dir_type) {
         case GameListItemType::SdmcDir:
             setData(
@@ -295,8 +294,7 @@ public:
     explicit GameListAddDir() {
         setData(type(), TypeRole);
 
-        const int icon_size =
-            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 24);
+        const int icon_size =  24;
         setData(QIcon::fromTheme(QStringLiteral("plus"))
                     .pixmap(icon_size)
                     .scaled(icon_size, icon_size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation),
@@ -318,8 +316,7 @@ public:
     explicit GameListFavorites() {
         setData(type(), TypeRole);
 
-        const int icon_size =
-            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 24);
+        const int icon_size = 24;
         setData(QIcon::fromTheme(QStringLiteral("star"))
                     .pixmap(icon_size)
                     .scaled(icon_size, icon_size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation),

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -80,7 +80,7 @@ public:
         setData(qulonglong(program_id), ProgramIdRole);
         setData(game_type, FileTypeRole);
 
-        const u32 size = UISettings::values.icon_size.GetValue();
+        const u32 size = UISettings::values.game_icon_size.GetValue();
 
         QPixmap picture;
         if (!picture.loadFromData(picture_data.data(), static_cast<u32>(picture_data.size()))) {
@@ -233,7 +233,7 @@ public:
         UISettings::GameDir* game_dir = &directory;
         setData(QVariant(UISettings::values.game_dirs.indexOf(directory)), GameDirRole);
 
-        const int icon_size = 24;
+        const int icon_size = UISettings::values.folder_icon_size.GetValue();
         switch (dir_type) {
         case GameListItemType::SdmcDir:
             setData(
@@ -294,7 +294,8 @@ public:
     explicit GameListAddDir() {
         setData(type(), TypeRole);
 
-        const int icon_size = 24;
+        const int icon_size = UISettings::values.folder_icon_size.GetValue();
+        ;
         setData(QIcon::fromTheme(QStringLiteral("plus"))
                     .pixmap(icon_size)
                     .scaled(icon_size, icon_size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation),
@@ -316,7 +317,8 @@ public:
     explicit GameListFavorites() {
         setData(type(), TypeRole);
 
-        const int icon_size = 24;
+        const int icon_size = UISettings::values.folder_icon_size.GetValue();
+        ;
         setData(QIcon::fromTheme(QStringLiteral("star"))
                     .pixmap(icon_size)
                     .scaled(icon_size, icon_size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation),

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -234,7 +234,7 @@ public:
         setData(QVariant(UISettings::values.game_dirs.indexOf(directory)), GameDirRole);
 
         const int icon_size =
-            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 64);
+            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 18);
         switch (dir_type) {
         case GameListItemType::SdmcDir:
             setData(
@@ -296,7 +296,7 @@ public:
         setData(type(), TypeRole);
 
         const int icon_size =
-            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 64);
+            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 18);
         setData(QIcon::fromTheme(QStringLiteral("plus"))
                     .pixmap(icon_size)
                     .scaled(icon_size, icon_size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation),
@@ -319,7 +319,7 @@ public:
         setData(type(), TypeRole);
 
         const int icon_size =
-            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 64);
+            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 18);
         setData(QIcon::fromTheme(QStringLiteral("star"))
                     .pixmap(icon_size)
                     .scaled(icon_size, icon_size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation),

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -295,7 +295,7 @@ public:
         setData(type(), TypeRole);
 
         const int icon_size = UISettings::values.folder_icon_size.GetValue();
-        ;
+
         setData(QIcon::fromTheme(QStringLiteral("plus"))
                     .pixmap(icon_size)
                     .scaled(icon_size, icon_size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation),
@@ -318,7 +318,7 @@ public:
         setData(type(), TypeRole);
 
         const int icon_size = UISettings::values.folder_icon_size.GetValue();
-        ;
+
         setData(QIcon::fromTheme(QStringLiteral("star"))
                     .pixmap(icon_size)
                     .scaled(icon_size, icon_size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation),

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -294,7 +294,7 @@ public:
     explicit GameListAddDir() {
         setData(type(), TypeRole);
 
-        const int icon_size =  24;
+        const int icon_size = 24;
         setData(QIcon::fromTheme(QStringLiteral("plus"))
                     .pixmap(icon_size)
                     .scaled(icon_size, icon_size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation),

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -234,7 +234,7 @@ public:
         setData(QVariant(UISettings::values.game_dirs.indexOf(directory)), GameDirRole);
 
         const int icon_size =
-            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 18);
+            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 24);
         switch (dir_type) {
         case GameListItemType::SdmcDir:
             setData(
@@ -296,7 +296,7 @@ public:
         setData(type(), TypeRole);
 
         const int icon_size =
-            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 18);
+            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 24);
         setData(QIcon::fromTheme(QStringLiteral("plus"))
                     .pixmap(icon_size)
                     .scaled(icon_size, icon_size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation),
@@ -319,7 +319,7 @@ public:
         setData(type(), TypeRole);
 
         const int icon_size =
-            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 18);
+            std::min(static_cast<int>(UISettings::values.icon_size.GetValue()), 24);
         setData(QIcon::fromTheme(QStringLiteral("star"))
                     .pixmap(icon_size)
                     .scaled(icon_size, icon_size, Qt::IgnoreAspectRatio, Qt::SmoothTransformation),

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -91,8 +91,8 @@ struct Values {
 
     // Game List
     Settings::BasicSetting<bool> show_add_ons{true, "show_add_ons"};
-    Settings::BasicSetting<uint32_t> game_icon_size{48, "game_icon_size"};
-    Settings::BasicSetting<uint32_t> folder_icon_size{64, "folder_icon_size"};
+    Settings::BasicSetting<uint32_t> game_icon_size{64, "game_icon_size"};
+    Settings::BasicSetting<uint32_t> folder_icon_size{48, "folder_icon_size"};
     Settings::BasicSetting<uint8_t> row_1_text_id{3, "row_1_text_id"};
     Settings::BasicSetting<uint8_t> row_2_text_id{2, "row_2_text_id"};
     std::atomic_bool is_game_list_reload_pending{false};

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -91,7 +91,8 @@ struct Values {
 
     // Game List
     Settings::BasicSetting<bool> show_add_ons{true, "show_add_ons"};
-    Settings::BasicSetting<uint32_t> icon_size{64, "icon_size"};
+    Settings::BasicSetting<uint32_t> game_icon_size{48, "game_icon_size"};
+    Settings::BasicSetting<uint32_t> folder_icon_size{64, "folder_icon_size"};
     Settings::BasicSetting<uint8_t> row_1_text_id{3, "row_1_text_id"};
     Settings::BasicSetting<uint8_t> row_2_text_id{2, "row_2_text_id"};
     std::atomic_bool is_game_list_reload_pending{false};


### PR DESCRIPTION
I don't know if this is intentional, but the icons for the folders in the game list tree view seem really big and are thus also a bit pixelated. In my opinion they would look a lot better if they were about the size of the text.

Before:
![Screenshot_20210728_210256](https://user-images.githubusercontent.com/48161361/127381040-947dbcba-dec0-44ac-a2e4-4e33d13e28ca.png)

After:
![Screenshot_20210728_210218](https://user-images.githubusercontent.com/48161361/127381039-422b6527-0411-490d-8277-d27b36bff73c.png)