### PR TITLE
shader: Fold UnpackFloat2x16 and PackFloat2x16

### DIFF
--- a/src/shader_recompiler/ir_opt/constant_propagation_pass.cpp
+++ b/src/shader_recompiler/ir_opt/constant_propagation_pass.cpp
@@ -476,6 +476,10 @@ void ConstantPropagation(IR::Block& block, IR::Inst& inst) {
         return FoldInverseFunc(inst, IR::Opcode::UnpackHalf2x16);
     case IR::Opcode::UnpackHalf2x16:
         return FoldInverseFunc(inst, IR::Opcode::PackHalf2x16);
+    case IR::Opcode::PackFloat2x16:
+        return FoldInverseFunc(inst, IR::Opcode::UnpackFloat2x16);
+    case IR::Opcode::UnpackFloat2x16:
+        return FoldInverseFunc(inst, IR::Opcode::PackFloat2x16);
     case IR::Opcode::SelectU1:
     case IR::Opcode::SelectU8:
     case IR::Opcode::SelectU16:


### PR DESCRIPTION
Simplifies the code a bit when possible. These instructions should be no-ops codegen wise. #6760 was needed for this.