### PR TITLE
cmake: Disable PIE for performance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,7 +145,7 @@ else()
 endif()
 
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    add_compile_options(-fno-pie -no-pie)
+    add_compile_options(-fno-pie)
     add_link_options(-no-pie)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,11 @@ else()
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 endif()
 
+if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+    add_compile_options(-fno-pie -no-pie)
+    add_link_options(-no-pie)
+endif()
+
 # Output binaries to bin/
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin)
 


### PR DESCRIPTION
This makes yuzu faster by disabling PIE. PIE is used for shared libraries and the ASLR security feature. We are an executable not a shared library and we don't need extra security because we are dumping games trusted by Nintendo. This PR also makes the addr2line debugging tool work after-the-fact without gdb.