### PR TITLE
GPU: Prequeue frame swaps.

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvdisp_disp0.h
+++ b/src/core/hle/service/nvdrv/devices/nvdisp_disp0.h
@@ -33,7 +33,7 @@ public:
     /// Performs a screen flip, drawing the buffer pointed to by the handle.
     void flip(u32 buffer_handle, u32 offset, u32 format, u32 width, u32 height, u32 stride,
               NVFlinger::BufferQueue::BufferTransformFlags transform,
-              const Common::Rectangle<int>& crop_rect);
+              const Common::Rectangle<int>& crop_rect, const MultiFence& fence);
 
 private:
     std::shared_ptr<nvmap> nvmap_dev;

--- a/src/core/hle/service/nvflinger/buffer_queue.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue.cpp
@@ -88,6 +88,10 @@ const IGBPBuffer& BufferQueue::RequestBuffer(u32 slot) const {
     return buffers[slot].igbp_buffer;
 }
 
+const BufferQueue::Buffer& BufferQueue::AccessBuffer(u32 slot) const {
+    return buffers[slot];
+}
+
 void BufferQueue::QueueBuffer(u32 slot, BufferTransformFlags transform,
                               const Common::Rectangle<int>& crop_rect, u32 swap_interval,
                               Service::Nvidia::MultiFence& multi_fence) {

--- a/src/core/hle/service/nvflinger/buffer_queue.h
+++ b/src/core/hle/service/nvflinger/buffer_queue.h
@@ -107,6 +107,7 @@ public:
     void Connect();
     void Disconnect();
     u32 Query(QueryType type);
+    const Buffer& AccessBuffer(u32 slot) const;
 
     u32 GetId() const {
         return id;

--- a/src/core/hle/service/nvflinger/nvflinger.h
+++ b/src/core/hle/service/nvflinger/nvflinger.h
@@ -77,6 +77,8 @@ public:
     /// Obtains a buffer queue identified by the ID.
     [[nodiscard]] BufferQueue* FindBufferQueue(u32 id);
 
+    void PrequeueFrame(u32 buffer_queue_id, u32 slot);
+
     /// Performs a composition request to the emulated nvidia GPU and triggers the vsync events when
     /// finished.
     void Compose();

--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -592,6 +592,7 @@ private:
             buffer_queue.QueueBuffer(request.data.slot, request.data.transform,
                                      request.data.GetCropRect(), request.data.swap_interval,
                                      request.data.multi_fence);
+            nv_flinger.PrequeueFrame(id, request.data.slot);
 
             IGBPQueueBufferResponseParcel response{1280, 720};
             ctx.WriteBuffer(response.Serialize());

--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -105,7 +105,7 @@ void ThreadManager::FlushRegion(VAddr addr, u64 size) {
     auto& gpu = system.GPU();
     u64 fence = gpu.RequestFlush(addr, size);
     PushCommand(GPUTickCommand(), true);
-    ASSERT(fence <= gpu.CurrentFlushRequestFence());
+    ASSERT(fence <= gpu.CurrentWorkRequestFence());
 }
 
 void ThreadManager::InvalidateRegion(VAddr addr, u64 size) {

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -214,6 +214,8 @@ void RasterizerOpenGL::Clear() {
 void RasterizerOpenGL::Draw(bool is_indexed, bool is_instanced) {
     MICROPROFILE_SCOPE(OpenGL_Drawing);
 
+    SCOPE_EXIT({ gpu.TickWork(); });
+
     query_cache.UpdateCounters();
 
     SyncState();
@@ -269,8 +271,6 @@ void RasterizerOpenGL::Draw(bool is_indexed, bool is_instanced) {
 
     ++num_queued_commands;
     has_written_global_memory |= pipeline->WritesGlobalMemory();
-
-    gpu.TickWork();
 }
 
 void RasterizerOpenGL::DispatchCompute() {
@@ -401,6 +401,7 @@ void RasterizerOpenGL::SignalSemaphore(GPUVAddr addr, u32 value) {
 }
 
 void RasterizerOpenGL::SignalSyncPoint(u32 value) {
+    gpu.IncrementSyncPointGuest(value);
     if (!gpu.IsAsync()) {
         gpu.IncrementSyncPoint(value);
         return;

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -387,6 +387,7 @@ void RasterizerVulkan::SignalSemaphore(GPUVAddr addr, u32 value) {
 }
 
 void RasterizerVulkan::SignalSyncPoint(u32 value) {
+    gpu.IncrementSyncPointGuest(value);
     if (!gpu.IsAsync()) {
         gpu.IncrementSyncPoint(value);
         return;


### PR DESCRIPTION
The idea of this change is to fix an issue that was phantom added since I introduced the fence manager. Originally frame swaps were sent exactly when the fence was met. However, now fence release is delayed until the host gpu catches up, this causes swaps to be delayed further than they should.

This commit aims to solve that issue by prequeuing frames. 

This solves the bad frame pacing on MHR.