### PR TITLE
hle: api_version: Update HOS version to 12.1.0

### DIFF
--- a/src/core/hle/api_version.h
+++ b/src/core/hle/api_version.h
@@ -12,9 +12,9 @@ namespace HLE::ApiVersion {
 
 // Horizon OS version constants.
 
-constexpr u8 HOS_VERSION_MAJOR = 11;
-constexpr u8 HOS_VERSION_MINOR = 0;
-constexpr u8 HOS_VERSION_MICRO = 1;
+constexpr u8 HOS_VERSION_MAJOR = 12;
+constexpr u8 HOS_VERSION_MINOR = 1;
+constexpr u8 HOS_VERSION_MICRO = 0;
 
 // NintendoSDK version constants.
 
@@ -22,15 +22,15 @@ constexpr u8 SDK_REVISION_MAJOR = 1;
 constexpr u8 SDK_REVISION_MINOR = 0;
 
 constexpr char PLATFORM_STRING[] = "NX";
-constexpr char VERSION_HASH[] = "69103fcb2004dace877094c2f8c29e6113be5dbf";
-constexpr char DISPLAY_VERSION[] = "11.0.1";
-constexpr char DISPLAY_TITLE[] = "NintendoSDK Firmware for NX 11.0.1-1.0";
+constexpr char VERSION_HASH[] = "76b10c2dab7d3aa73fc162f8dff1655e6a21caf4";
+constexpr char DISPLAY_VERSION[] = "12.1.0";
+constexpr char DISPLAY_TITLE[] = "NintendoSDK Firmware for NX 12.1.0-1.0";
 
 // Atmosphere version constants.
 
 constexpr u8 ATMOSPHERE_RELEASE_VERSION_MAJOR = 0;
 constexpr u8 ATMOSPHERE_RELEASE_VERSION_MINOR = 19;
-constexpr u8 ATMOSPHERE_RELEASE_VERSION_MICRO = 4;
+constexpr u8 ATMOSPHERE_RELEASE_VERSION_MICRO = 5;
 
 constexpr u32 GetTargetFirmware() {
     return u32{HOS_VERSION_MAJOR} << 24 | u32{HOS_VERSION_MINOR} << 16 |


### PR DESCRIPTION
Keeps us up to date with reporting the system version.