### PR TITLE
decoders: Double the performance

### DIFF
--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -74,39 +74,7 @@ void SwizzleImpl(std::span<u8> output, std::span<const u8> input, u32 width, u32
                 u8* const dst = &output[TO_LINEAR ? swizzled_offset : unswizzled_offset];
                 const u8* const src = &input[TO_LINEAR ? unswizzled_offset : swizzled_offset];
 
-                switch (BYTES_PER_PIXEL) {
-                case 1: {
-                    *dst = *src;
-                    break;
-                }
-                case 2: {
-                    const auto dst2 = reinterpret_cast<u16* const>(dst);
-                    const auto src2 = reinterpret_cast<const u16* const>(src);
-                    *dst2 = *src2;
-                    break;
-                }
-                case 4: {
-                    const auto dst4 = reinterpret_cast<u32* const>(dst);
-                    const auto src4 = reinterpret_cast<const u32* const>(src);
-                    *dst4 = *src4;
-                    break;
-                }
-                case 8: {
-                    const auto dst8 = reinterpret_cast<u64* const>(dst);
-                    const auto src8 = reinterpret_cast<const u64* const>(src);
-                    *dst8 = *src8;
-                    break;
-                }
-                case 16: {
-                    const auto dst16 = reinterpret_cast<u128* const>(dst);
-                    const auto src16 = reinterpret_cast<const u128* const>(src);
-                    *dst16 = *src16;
-                    break;
-                }
-                default: {
-                    UNREACHABLE();
-                }
-                }
+                std::memcpy(dst, src, BYTES_PER_PIXEL);
             }
         }
     }
@@ -116,34 +84,23 @@ template <bool TO_LINEAR>
 void Swizzle(std::span<u8> output, std::span<const u8> input, u32 bytes_per_pixel, u32 width,
              u32 height, u32 depth, u32 block_height, u32 block_depth, u32 stride_alignment) {
     switch (bytes_per_pixel) {
-    case 1: {
-        SwizzleImpl<TO_LINEAR, 1>(output, input, width, height, depth, block_height, block_depth,
-                                  stride_alignment);
-        break;
-    }
-    case 2: {
-        SwizzleImpl<TO_LINEAR, 2>(output, input, width, height, depth, block_height, block_depth,
-                                  stride_alignment);
-        break;
-    }
-    case 4: {
-        SwizzleImpl<TO_LINEAR, 4>(output, input, width, height, depth, block_height, block_depth,
-                                  stride_alignment);
-        break;
-    }
-    case 8: {
-        SwizzleImpl<TO_LINEAR, 8>(output, input, width, height, depth, block_height, block_depth,
-                                  stride_alignment);
-        break;
-    }
-    case 16: {
-        SwizzleImpl<TO_LINEAR, 16>(output, input, width, height, depth, block_height, block_depth,
-                                   stride_alignment);
-        break;
-    }
-    default: {
+    case 1:
+        return SwizzleImpl<TO_LINEAR, 1>(output, input, width, height, depth, block_height,
+                                         block_depth, stride_alignment);
+    case 2:
+        return SwizzleImpl<TO_LINEAR, 2>(output, input, width, height, depth, block_height,
+                                         block_depth, stride_alignment);
+    case 4:
+        return SwizzleImpl<TO_LINEAR, 4>(output, input, width, height, depth, block_height,
+                                         block_depth, stride_alignment);
+    case 8:
+        return SwizzleImpl<TO_LINEAR, 8>(output, input, width, height, depth, block_height,
+                                         block_depth, stride_alignment);
+    case 16:
+        return SwizzleImpl<TO_LINEAR, 16>(output, input, width, height, depth, block_height,
+                                          block_depth, stride_alignment);
+    default:
         UNIMPLEMENTED_MSG("Unknown bytes_per_pixel {}", bytes_per_pixel);
-    }
     }
 }
 } // Anonymous namespace

--- a/src/video_core/textures/decoders.cpp
+++ b/src/video_core/textures/decoders.cpp
@@ -90,17 +90,26 @@ void Swizzle(std::span<u8> output, std::span<const u8> input, u32 bytes_per_pixe
     case 2:
         return SwizzleImpl<TO_LINEAR, 2>(output, input, width, height, depth, block_height,
                                          block_depth, stride_alignment);
+    case 3:
+        return SwizzleImpl<TO_LINEAR, 3>(output, input, width, height, depth, block_height,
+                                         block_depth, stride_alignment);
     case 4:
         return SwizzleImpl<TO_LINEAR, 4>(output, input, width, height, depth, block_height,
+                                         block_depth, stride_alignment);
+    case 6:
+        return SwizzleImpl<TO_LINEAR, 6>(output, input, width, height, depth, block_height,
                                          block_depth, stride_alignment);
     case 8:
         return SwizzleImpl<TO_LINEAR, 8>(output, input, width, height, depth, block_height,
                                          block_depth, stride_alignment);
+    case 12:
+        return SwizzleImpl<TO_LINEAR, 12>(output, input, width, height, depth, block_height,
+                                          block_depth, stride_alignment);
     case 16:
         return SwizzleImpl<TO_LINEAR, 16>(output, input, width, height, depth, block_height,
                                           block_depth, stride_alignment);
     default:
-        UNIMPLEMENTED_MSG("Unknown bytes_per_pixel {}", bytes_per_pixel);
+        UNREACHABLE_MSG("Invalid bytes_per_pixel={}", bytes_per_pixel);
     }
 }
 } // Anonymous namespace


### PR DESCRIPTION
This makes UnswizzleTexture two times faster. It is the main bottleneck in video decoding.

| What | Before | After |
|-|-|-|
| Pokemon intro movie | 27 FPS | 30 FPS |
| Kirby intro movies | 29 FPS | 44 FPS |
| Kirby first world | 25 FPS | 30 FPS |
| Kirby first level | 22 FPS | 27 FPS |
| Link's Awakening intro movie | 12 FPS | 21 FPS |
| Animal crossing set-up | 25 FPS | 30 FPS |
| Animal crossing intro movie | 29 FPS | 30 FPS |
| Animal crossing in-game | 18 FPS | 23 FPS |