### PR TITLE
service: set: Correct copy amount in GetAvailableLanguageCodes

### DIFF
--- a/src/core/hle/service/set/set.cpp
+++ b/src/core/hle/service/set/set.cpp
@@ -85,7 +85,8 @@ void PushResponseLanguageCode(Kernel::HLERequestContext& ctx, std::size_t num_la
 
 void GetAvailableLanguageCodesImpl(Kernel::HLERequestContext& ctx, std::size_t max_entries) {
     const std::size_t requested_amount = ctx.GetWriteBufferSize() / sizeof(LanguageCode);
-    const std::size_t copy_amount = std::min(requested_amount, max_entries);
+    const std::size_t max_amount = std::min(requested_amount, max_entries);
+    const std::size_t copy_amount = std::min(available_language_codes.size(), max_amount);
     const std::size_t copy_size = copy_amount * sizeof(LanguageCode);
 
     ctx.WriteBuffer(available_language_codes.data(), copy_size);


### PR DESCRIPTION
Fixes a regression introduced by #6752 which caused the language in Paper Mario The Origami King to display in Japanese instead of the selected system language.