### PR TITLE
yuzu-cmd: hide mouse cursor when started fullscreen

### DIFF
--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
@@ -122,6 +122,10 @@ void EmuWindow_SDL2::OnResize() {
     UpdateCurrentFramebufferLayout(width, height);
 }
 
+void EmuWindow_SDL2::ShowCursor(bool show_cursor) {
+    SDL_ShowCursor(show_cursor ? SDL_ENABLE : SDL_DISABLE);
+}
+
 void EmuWindow_SDL2::Fullscreen() {
     switch (Settings::values.fullscreen_mode.GetValue()) {
     case Settings::FullscreenMode::Exclusive:

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.h
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.h
@@ -67,6 +67,9 @@ protected:
     /// Called by WaitEvent when any event that may cause the window to be resized occurs
     void OnResize();
 
+    /// Called when users want to hide the mouse cursor
+    void ShowCursor(bool show_cursor);
+
     /// Called when user passes the fullscreen parameter flag
     void Fullscreen();
 

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.cpp
@@ -111,6 +111,7 @@ EmuWindow_SDL2_GL::EmuWindow_SDL2_GL(InputCommon::InputSubsystem* input_subsyste
 
     if (fullscreen) {
         Fullscreen();
+        ShowCursor(false);
     }
 
     window_context = SDL_GL_CreateContext(render_window);

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.cpp
@@ -45,6 +45,7 @@ EmuWindow_SDL2_VK::EmuWindow_SDL2_VK(InputCommon::InputSubsystem* input_subsyste
 
     if (fullscreen) {
         Fullscreen();
+        ShowCursor(false);
     }
 
     switch (wm.subsystem) {


### PR DESCRIPTION
Exposed `SDL_ShowCursor` to `EmuWindow` as `ShowCursor(bool)`. Both the derived classes (GL and VK) call this function when started with the fullscreen flag.