### PR TITLE
nvdec: Fix VP9 reference frame refreshes

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.cpp
@@ -178,30 +178,11 @@ NvResult nvhost_nvdec_common::MapBuffer(const std::vector<u8>& input, std::vecto
 }
 
 NvResult nvhost_nvdec_common::UnmapBuffer(const std::vector<u8>& input, std::vector<u8>& output) {
-    IoctlMapBuffer params{};
-    std::memcpy(&params, input.data(), sizeof(IoctlMapBuffer));
-    std::vector<MapBufferEntry> cmd_buffer_handles(params.num_entries);
-    SliceVectors(input, cmd_buffer_handles, params.num_entries, sizeof(IoctlMapBuffer));
-
-    auto& gpu = system.GPU();
-
-    for (auto& cmd_buffer : cmd_buffer_handles) {
-        const auto object{nvmap_dev->GetObject(cmd_buffer.map_handle)};
-        if (!object) {
-            LOG_ERROR(Service_NVDRV, "invalid cmd_buffer nvmap_handle={:X}", cmd_buffer.map_handle);
-            std::memcpy(output.data(), &params, output.size());
-            return NvResult::InvalidState;
-        }
-        if (const auto size{RemoveBufferMap(object->dma_map_addr)}; size) {
-            gpu.MemoryManager().Unmap(object->dma_map_addr, *size);
-        } else {
-            // This occurs quite frequently, however does not seem to impact functionality
-            LOG_DEBUG(Service_NVDRV, "invalid offset=0x{:X} dma=0x{:X}", object->addr,
-                      object->dma_map_addr);
-        }
-        object->dma_map_addr = 0;
-    }
+    // This is intntionally stubbed.
+    // Skip unmapping buffers here, as to not break the continuity of the VP9 reference frame
+    // addresses, and risk invalidating data before the async GPU thread is done with it
     std::memset(output.data(), 0, output.size());
+    LOG_DEBUG(Service_NVDRV, "(STUBBED) called");
     return NvResult::Success;
 }
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.cpp
@@ -166,8 +166,6 @@ NvResult nvhost_nvdec_common::MapBuffer(const std::vector<u8>& input, std::vecto
             LOG_ERROR(Service_NVDRV, "failed to map size={}", object->size);
         } else {
             cmd_buffer.map_address = object->dma_map_addr;
-            AddBufferMap(object->dma_map_addr, object->size, object->addr,
-                         object->status == nvmap::Object::Status::Allocated);
         }
     }
     std::memcpy(output.data(), &params, sizeof(IoctlMapBuffer));
@@ -191,35 +189,6 @@ NvResult nvhost_nvdec_common::SetSubmitTimeout(const std::vector<u8>& input,
     std::memcpy(&submit_timeout, input.data(), input.size());
     LOG_WARNING(Service_NVDRV, "(STUBBED) called");
     return NvResult::Success;
-}
-
-std::optional<nvhost_nvdec_common::BufferMap> nvhost_nvdec_common::FindBufferMap(
-    GPUVAddr gpu_addr) const {
-    const auto it = std::find_if(
-        buffer_mappings.begin(), buffer_mappings.upper_bound(gpu_addr), [&](const auto& entry) {
-            return (gpu_addr >= entry.second.StartAddr() && gpu_addr < entry.second.EndAddr());
-        });
-
-    ASSERT(it != buffer_mappings.end());
-    return it->second;
-}
-
-void nvhost_nvdec_common::AddBufferMap(GPUVAddr gpu_addr, std::size_t size, VAddr cpu_addr,
-                                       bool is_allocated) {
-    buffer_mappings.insert_or_assign(gpu_addr, BufferMap{gpu_addr, size, cpu_addr, is_allocated});
-}
-
-std::optional<std::size_t> nvhost_nvdec_common::RemoveBufferMap(GPUVAddr gpu_addr) {
-    const auto iter{buffer_mappings.find(gpu_addr)};
-    if (iter == buffer_mappings.end()) {
-        return std::nullopt;
-    }
-    std::size_t size = 0;
-    if (iter->second.IsAllocated()) {
-        size = iter->second.Size();
-    }
-    buffer_mappings.erase(iter);
-    return size;
 }
 
 } // namespace Service::Nvidia::Devices

--- a/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.h
@@ -23,45 +23,6 @@ public:
     ~nvhost_nvdec_common() override;
 
 protected:
-    class BufferMap final {
-    public:
-        constexpr BufferMap() = default;
-
-        constexpr BufferMap(GPUVAddr start_addr_, std::size_t size_)
-            : start_addr{start_addr_}, end_addr{start_addr_ + size_} {}
-
-        constexpr BufferMap(GPUVAddr start_addr_, std::size_t size_, VAddr cpu_addr_,
-                            bool is_allocated_)
-            : start_addr{start_addr_}, end_addr{start_addr_ + size_}, cpu_addr{cpu_addr_},
-              is_allocated{is_allocated_} {}
-
-        constexpr VAddr StartAddr() const {
-            return start_addr;
-        }
-
-        constexpr VAddr EndAddr() const {
-            return end_addr;
-        }
-
-        constexpr std::size_t Size() const {
-            return end_addr - start_addr;
-        }
-
-        constexpr VAddr CpuAddr() const {
-            return cpu_addr;
-        }
-
-        constexpr bool IsAllocated() const {
-            return is_allocated;
-        }
-
-    private:
-        GPUVAddr start_addr{};
-        GPUVAddr end_addr{};
-        VAddr cpu_addr{};
-        bool is_allocated{};
-    };
-
     struct IoctlSetNvmapFD {
         s32_le nvmap_fd{};
     };
@@ -154,17 +115,11 @@ protected:
     NvResult UnmapBuffer(const std::vector<u8>& input, std::vector<u8>& output);
     NvResult SetSubmitTimeout(const std::vector<u8>& input, std::vector<u8>& output);
 
-    std::optional<BufferMap> FindBufferMap(GPUVAddr gpu_addr) const;
-    void AddBufferMap(GPUVAddr gpu_addr, std::size_t size, VAddr cpu_addr, bool is_allocated);
-    std::optional<std::size_t> RemoveBufferMap(GPUVAddr gpu_addr);
-
     s32_le nvmap_fd{};
     u32_le submit_timeout{};
     std::shared_ptr<nvmap> nvmap_dev;
     SyncpointManager& syncpoint_manager;
     std::array<u32, MaxSyncPoints> device_syncpoints{};
-    // This is expected to be ordered, therefore we must use a map, not unordered_map
-    std::map<GPUVAddr, BufferMap> buffer_mappings;
 };
 }; // namespace Devices
 } // namespace Service::Nvidia

--- a/src/video_core/command_classes/codecs/vp9.h
+++ b/src/video_core/command_classes/codecs/vp9.h
@@ -184,7 +184,7 @@ private:
     std::array<FrameContexts, 4> frame_ctxs{};
     Vp9FrameContainer next_frame{};
     Vp9FrameContainer next_next_frame{};
-    bool swap_next_golden{};
+    bool swap_ref_indices{};
 
     Vp9PictureInfo current_frame_info{};
     Vp9EntropyProbs prev_frame_probs{};

--- a/src/video_core/command_classes/codecs/vp9.h
+++ b/src/video_core/command_classes/codecs/vp9.h
@@ -14,7 +14,6 @@
 
 namespace Tegra {
 class GPU;
-enum class FrameType { KeyFrame = 0, InterFrame = 1 };
 namespace Decoder {
 
 /// The VpxRangeEncoder, and VpxBitStreamWriter classes are used to compose the
@@ -124,7 +123,7 @@ public:
 
     /// Returns true if the most recent frame was a hidden frame.
     [[nodiscard]] bool WasFrameHidden() const {
-        return hidden;
+        return !current_frame_info.show_frame;
     }
 
 private:
@@ -178,19 +177,12 @@ private:
     std::array<s8, 4> loop_filter_ref_deltas{};
     std::array<s8, 2> loop_filter_mode_deltas{};
 
-    bool hidden = false;
-    s64 current_frame_number = -2; // since we buffer 2 frames
-    s32 grace_period = 6;          // frame offsets need to stabilize
-    std::array<FrameContexts, 4> frame_ctxs{};
     Vp9FrameContainer next_frame{};
-    Vp9FrameContainer next_next_frame{};
+    std::array<Vp9EntropyProbs, 4> frame_ctxs{};
     bool swap_ref_indices{};
 
     Vp9PictureInfo current_frame_info{};
     Vp9EntropyProbs prev_frame_probs{};
-
-    s32 diff_update_probability = 252;
-    s32 frame_sync_code = 0x498342;
 };
 
 } // namespace Decoder

--- a/src/video_core/command_classes/codecs/vp9_types.h
+++ b/src/video_core/command_classes/codecs/vp9_types.h
@@ -296,12 +296,6 @@ struct RefPoolElement {
     bool refresh{};
 };
 
-struct FrameContexts {
-    s64 from;
-    bool adapted;
-    Vp9EntropyProbs probs;
-};
-
 #define ASSERT_POSITION(field_name, position)                                                      \
     static_assert(offsetof(Vp9EntropyProbs, field_name) == position,                               \
                   "Field " #field_name " has invalid position")


### PR DESCRIPTION
The main issue with VP9 decoding was the need to guess which frames would be used as a reference as the video stream progressed. This change addresses that limitation.

By stubbing the UnmapBuffer ioctl, the reference frame addresses in the VP9 state remain consistent throughout the video stream, not being remapped to other addresses. This allows for increased confidence in which frames to use as a reference frame when composing the frame header that is sent to FFmpeg.

Stubbing the UnmapIoctl also avoid the flickering issues seen in Link's Awakening, and paves the way for an async nvdec implementation, whose main blocker was data being invalidated by nvdrv before its use by the gpu thread.

Here is a before and after comparison:


https://user-images.githubusercontent.com/52414509/127890988-a3b8da0d-e64a-4da5-a331-2277b3512d51.mp4


https://user-images.githubusercontent.com/52414509/127891022-f0d066c5-3ff0-4b50-8e05-0e2092e4a59e.mp4


Supersedes #4836 . Closes #4840. Closes #6766