### PR TITLE
network: fix ternary operator in Socket::SendTo

### DIFF
--- a/src/core/network/network.cpp
+++ b/src/core/network/network.cpp
@@ -570,7 +570,7 @@ std::pair<s32, Errno> Socket::SendTo(u32 flags, const std::vector<u8>& message,
     ASSERT(flags == 0);
 
     const sockaddr* to = nullptr;
-    const int tolen = addr ? 0 : sizeof(sockaddr);
+    const int tolen = addr ? sizeof(sockaddr) : 0;
     sockaddr host_addr_in;
 
     if (addr) {


### PR DESCRIPTION
The ternary operator in core/network/network.cpp is written the wrong way round. The addrlen parameter for sendto should be non-zero if addr isn't a nullptr. Otherwise this call to sendto will generate an EINVAL error.