### PR TITLE
config: Only read/write current_user on global config

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -873,10 +873,6 @@ void Config::ReadShortcutValues() {
 void Config::ReadSystemValues() {
     qt_config->beginGroup(QStringLiteral("System"));
 
-    ReadBasicSetting(Settings::values.current_user);
-    Settings::values.current_user = std::clamp<int>(Settings::values.current_user.GetValue(), 0,
-                                                    Service::Account::MAX_USERS - 1);
-
     ReadGlobalSetting(Settings::values.language_index);
 
     ReadGlobalSetting(Settings::values.region_index);
@@ -897,6 +893,10 @@ void Config::ReadSystemValues() {
     }
 
     if (global) {
+        ReadBasicSetting(Settings::values.current_user);
+        Settings::values.current_user = std::clamp<int>(Settings::values.current_user.GetValue(), 0,
+                                                        Service::Account::MAX_USERS - 1);
+
         const auto custom_rtc_enabled =
             ReadSetting(QStringLiteral("custom_rtc_enabled"), false).toBool();
         if (custom_rtc_enabled) {
@@ -1406,7 +1406,6 @@ void Config::SaveShortcutValues() {
 void Config::SaveSystemValues() {
     qt_config->beginGroup(QStringLiteral("System"));
 
-    WriteBasicSetting(Settings::values.current_user);
     WriteGlobalSetting(Settings::values.language_index);
     WriteGlobalSetting(Settings::values.region_index);
     WriteGlobalSetting(Settings::values.time_zone_index);
@@ -1418,6 +1417,8 @@ void Config::SaveSystemValues() {
                  0, Settings::values.rng_seed.UsingGlobal());
 
     if (global) {
+        WriteBasicSetting(Settings::values.current_user);
+
         WriteSetting(QStringLiteral("custom_rtc_enabled"), Settings::values.custom_rtc.has_value(),
                      false);
         WriteSetting(QStringLiteral("custom_rtc"),


### PR DESCRIPTION
Currently the configuration re-reads current_user when booting a game with a custom configuration. This overwrites the global configuration's current_user value and causes yuzu to use the first profile always.

Read this setting inside the if (global) if statement, instead.