### PR TITLE
settings_ui: Add emulated joystick position dot to controller preview

### DIFF
--- a/dist/qt_themes/default/style.qss
+++ b/dist/qt_themes/default/style.qss
@@ -51,11 +51,11 @@ QPushButton#GPUStatusBarButton:hover {
 }
 
 QPushButton#GPUStatusBarButton:checked {
-    color: #ff8040;
+    color: #b06020;
 }
 
 QPushButton#GPUStatusBarButton:!checked {
-    color: #40dd40;
+    color: #109010;
 }
 
 QPushButton#buttonRefreshDevices {

--- a/src/yuzu/configuration/configure_input_player_widget.cpp
+++ b/src/yuzu/configuration/configure_input_player_widget.cpp
@@ -122,6 +122,7 @@ void PlayerControlPreview::UpdateColors() {
         colors.slider_arrow = QColor(14, 15, 18);
         colors.font2 = QColor(255, 255, 255);
         colors.indicator = QColor(170, 238, 255);
+        colors.indicator2 = QColor(100, 255, 100);
         colors.deadzone = QColor(204, 136, 136);
         colors.slider_button = colors.button;
     }
@@ -139,6 +140,7 @@ void PlayerControlPreview::UpdateColors() {
         colors.slider_arrow = QColor(65, 68, 73);
         colors.font2 = QColor(0, 0, 0);
         colors.indicator = QColor(0, 0, 200);
+        colors.indicator2 = QColor(0, 150, 0);
         colors.deadzone = QColor(170, 0, 0);
         colors.slider_button = QColor(153, 149, 149);
     }
@@ -317,8 +319,7 @@ void PlayerControlPreview::DrawLeftController(QPainter& p, const QPointF center)
         using namespace Settings::NativeAnalog;
         DrawJoystick(p, center + QPointF(9, -69) + (axis_values[LStick].value * 8), 1.8f,
                      button_values[Settings::NativeButton::LStick]);
-        DrawRawJoystick(p, center + QPointF(-140, 90), axis_values[LStick].raw_value,
-                        axis_values[LStick].properties);
+        DrawRawJoystick(p, center + QPointF(-140, 90), QPointF(0, 0));
     }
 
     using namespace Settings::NativeButton;
@@ -432,8 +433,7 @@ void PlayerControlPreview::DrawRightController(QPainter& p, const QPointF center
         using namespace Settings::NativeAnalog;
         DrawJoystick(p, center + QPointF(-9, 11) + (axis_values[RStick].value * 8), 1.8f,
                      button_values[Settings::NativeButton::RStick]);
-        DrawRawJoystick(p, center + QPointF(140, 90), axis_values[RStick].raw_value,
-                        axis_values[RStick].properties);
+        DrawRawJoystick(p, QPointF(0, 0), center + QPointF(140, 90));
     }
 
     using namespace Settings::NativeButton;
@@ -547,8 +547,7 @@ void PlayerControlPreview::DrawDualController(QPainter& p, const QPointF center)
 
         DrawJoystick(p, center + QPointF(-65, -65) + (l_stick.value * 7), 1.62f, l_button);
         DrawJoystick(p, center + QPointF(65, 12) + (r_stick.value * 7), 1.62f, r_button);
-        DrawRawJoystick(p, center + QPointF(-180, 90), l_stick.raw_value, l_stick.properties);
-        DrawRawJoystick(p, center + QPointF(180, 90), r_stick.raw_value, r_stick.properties);
+        DrawRawJoystick(p, center + QPointF(-180, 90), center + QPointF(180, 90));
     }
 
     using namespace Settings::NativeButton;
@@ -634,8 +633,7 @@ void PlayerControlPreview::DrawHandheldController(QPainter& p, const QPointF cen
 
         DrawJoystick(p, center + QPointF(-171, -41) + (l_stick.value * 4), 1.0f, l_button);
         DrawJoystick(p, center + QPointF(171, 8) + (r_stick.value * 4), 1.0f, r_button);
-        DrawRawJoystick(p, center + QPointF(-50, 0), l_stick.raw_value, l_stick.properties);
-        DrawRawJoystick(p, center + QPointF(50, 0), r_stick.raw_value, r_stick.properties);
+        DrawRawJoystick(p, center + QPointF(-50, 0), center + QPointF(50, 0));
     }
 
     using namespace Settings::NativeButton;
@@ -728,10 +726,7 @@ void PlayerControlPreview::DrawProController(QPainter& p, const QPointF center) 
                         button_values[Settings::NativeButton::LStick]);
         DrawProJoystick(p, center + QPointF(51, 0), axis_values[RStick].value, 11,
                         button_values[Settings::NativeButton::RStick]);
-        DrawRawJoystick(p, center + QPointF(-50, 105), axis_values[LStick].raw_value,
-                        axis_values[LStick].properties);
-        DrawRawJoystick(p, center + QPointF(50, 105), axis_values[RStick].raw_value,
-                        axis_values[RStick].properties);
+        DrawRawJoystick(p, center + QPointF(-50, 105), center + QPointF(50, 105));
     }
 
     using namespace Settings::NativeButton;
@@ -821,10 +816,7 @@ void PlayerControlPreview::DrawGCController(QPainter& p, const QPointF center) {
         p.setBrush(colors.font);
         DrawSymbol(p, center + QPointF(61, 37) + (axis_values[RStick].value * 9.5f), Symbol::C,
                    1.0f);
-        DrawRawJoystick(p, center + QPointF(-198, -125), axis_values[LStick].raw_value,
-                        axis_values[LStick].properties);
-        DrawRawJoystick(p, center + QPointF(198, -125), axis_values[RStick].raw_value,
-                        axis_values[RStick].properties);
+        DrawRawJoystick(p, center + QPointF(-198, -125), center + QPointF(198, -125));
     }
 
     using namespace Settings::NativeButton;
@@ -2358,8 +2350,33 @@ void PlayerControlPreview::DrawGCJoystick(QPainter& p, const QPointF center, boo
     DrawCircle(p, center, 7.5f);
 }
 
-void PlayerControlPreview::DrawRawJoystick(QPainter& p, const QPointF center, const QPointF value,
-                                           const Input::AnalogProperties& properties) {
+void PlayerControlPreview::DrawRawJoystick(QPainter& p, QPointF center_left, QPointF center_right) {
+    using namespace Settings::NativeAnalog;
+    if (controller_type != Settings::ControllerType::LeftJoycon) {
+        DrawJoystickProperties(p, center_right, axis_values[RStick].properties);
+        p.setPen(colors.indicator);
+        p.setBrush(colors.indicator);
+        DrawJoystickDot(p, center_right, axis_values[RStick].raw_value,
+                        axis_values[RStick].properties);
+        p.setPen(colors.indicator2);
+        p.setBrush(colors.indicator2);
+        DrawJoystickDot(p, center_right, axis_values[RStick].value, axis_values[RStick].properties);
+    }
+
+    if (controller_type != Settings::ControllerType::RightJoycon) {
+        DrawJoystickProperties(p, center_left, axis_values[LStick].properties);
+        p.setPen(colors.indicator);
+        p.setBrush(colors.indicator);
+        DrawJoystickDot(p, center_left, axis_values[LStick].raw_value,
+                        axis_values[LStick].properties);
+        p.setPen(colors.indicator2);
+        p.setBrush(colors.indicator2);
+        DrawJoystickDot(p, center_left, axis_values[LStick].value, axis_values[LStick].properties);
+    }
+}
+
+void PlayerControlPreview::DrawJoystickProperties(QPainter& p, const QPointF center,
+                                                  const Input::AnalogProperties& properties) {
     constexpr float size = 45.0f;
     const float range = size * properties.range;
     const float deadzone = size * properties.deadzone;
@@ -2376,10 +2393,14 @@ void PlayerControlPreview::DrawRawJoystick(QPainter& p, const QPointF center, co
     pen.setColor(colors.deadzone);
     p.setPen(pen);
     DrawCircle(p, center, deadzone);
+}
+
+void PlayerControlPreview::DrawJoystickDot(QPainter& p, const QPointF center, const QPointF value,
+                                           const Input::AnalogProperties& properties) {
+    constexpr float size = 45.0f;
+    const float range = size * properties.range;
 
     // Dot pointer
-    p.setPen(colors.indicator);
-    p.setBrush(colors.indicator);
     DrawCircle(p, center + (value * range), 2);
 }
 

--- a/src/yuzu/configuration/configure_input_player_widget.h
+++ b/src/yuzu/configuration/configure_input_player_widget.h
@@ -90,6 +90,7 @@ private:
         QColor highlight2{};
         QColor transparent{};
         QColor indicator{};
+        QColor indicator2{};
         QColor led_on{};
         QColor led_off{};
         QColor slider{};
@@ -139,7 +140,10 @@ private:
     // Draw joystick functions
     void DrawJoystick(QPainter& p, QPointF center, float size, bool pressed);
     void DrawJoystickSideview(QPainter& p, QPointF center, float angle, float size, bool pressed);
-    void DrawRawJoystick(QPainter& p, QPointF center, QPointF value,
+    void DrawRawJoystick(QPainter& p, QPointF center_left, QPointF center_right);
+    void DrawJoystickProperties(QPainter& p, QPointF center,
+                                const Input::AnalogProperties& properties);
+    void DrawJoystickDot(QPainter& p, QPointF center, QPointF value,
                          const Input::AnalogProperties& properties);
     void DrawProJoystick(QPainter& p, QPointF center, QPointF offset, float scalar, bool pressed);
     void DrawGCJoystick(QPainter& p, QPointF center, bool pressed);


### PR DESCRIPTION
Adds a green dot indicating the current position of the joystick since the animated controller doesn't reflect an easy way to see how far the joystick has moved. 

While testing on light theme I noticed the GPU accuracy colors had terrible contrast on my monitor. I changed them to a darker color.