### PR TITLE
config: Read connected setting for controllers

### DIFF
--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -278,6 +278,9 @@ void Config::ReadValues() {
             if (Settings::values.players.GetValue()[p].analogs[i].empty())
                 Settings::values.players.GetValue()[p].analogs[i] = default_param;
         }
+
+        Settings::values.players.GetValue()[p].connected =
+            sdl2_config->GetBoolean(group, "connected", false);
     }
 
     ReadSetting("ControlsGeneral", Settings::values.mouse_enabled);


### PR DESCRIPTION
Currently yuzu will read the mapping but does not connect a controller despite adding subsequent configurations for it. Read the `connected` setting for now as a boolean like the Qt frontend.