### PR TITLE
hex_util: Fix incorrect array size in AsArray

### DIFF
--- a/src/common/hex_util.h
+++ b/src/common/hex_util.h
@@ -61,7 +61,7 @@ template <typename ContiguousContainer>
     return out;
 }
 
-[[nodiscard]] constexpr std::array<u8, 16> AsArray(const char (&data)[17]) {
+[[nodiscard]] constexpr std::array<u8, 16> AsArray(const char (&data)[33]) {
     return HexStringToArray<16>(data);
 }
 


### PR DESCRIPTION
Although this isn't used, this is a potential bug as HexStringToArray will perform an out-of-bounds read.