### PR TITLE
memory: Clean up code

### DIFF
--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -1,4 +1,4 @@
-// Copyright 2014 Citra Emulator Project
+// Copyright 2021 Citra Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
@@ -39,11 +39,6 @@ enum : VAddr {
 
     /// Application stack
     DEFAULT_STACK_SIZE = 0x100000,
-
-    /// Kernel Virtual Address Range
-    KERNEL_REGION_VADDR = 0xFFFFFF8000000000,
-    KERNEL_REGION_SIZE = 0x7FFFE00000,
-    KERNEL_REGION_END = KERNEL_REGION_VADDR + KERNEL_REGION_SIZE,
 };
 
 /// Central class that handles all memory operations and state.
@@ -56,7 +51,7 @@ public:
     Memory& operator=(const Memory&) = delete;
 
     Memory(Memory&&) = default;
-    Memory& operator=(Memory&&) = default;
+    Memory& operator=(Memory&&) = delete;
 
     /**
      * Resets the state of the Memory system.
@@ -92,24 +87,13 @@ public:
 
     /**
      * Checks whether or not the supplied address is a valid virtual
-     * address for the given process.
-     *
-     * @param process The emulated process to check the address against.
-     * @param vaddr   The virtual address to check the validity of.
-     *
-     * @returns True if the given virtual address is valid, false otherwise.
-     */
-    bool IsValidVirtualAddress(const Kernel::KProcess& process, VAddr vaddr) const;
-
-    /**
-     * Checks whether or not the supplied address is a valid virtual
      * address for the current process.
      *
      * @param vaddr The virtual address to check the validity of.
      *
      * @returns True if the given virtual address is valid, false otherwise.
      */
-    bool IsValidVirtualAddress(VAddr vaddr) const;
+    [[nodiscard]] bool IsValidVirtualAddress(VAddr vaddr) const;
 
     /**
      * Gets a pointer to the given address.
@@ -134,7 +118,7 @@ public:
      * @returns The pointer to the given address, if the address is valid.
      *          If the address is not valid, nullptr will be returned.
      */
-    const u8* GetPointer(VAddr vaddr) const;
+    [[nodiscard]] const u8* GetPointer(VAddr vaddr) const;
 
     template <typename T>
     const T* GetPointer(VAddr vaddr) const {
@@ -328,27 +312,6 @@ public:
                    std::size_t size);
 
     /**
-     * Reads a contiguous block of bytes from a specified process' address space.
-     * This unsafe version does not trigger GPU flushing.
-     *
-     * @param process     The process to read the data from.
-     * @param src_addr    The virtual address to begin reading from.
-     * @param dest_buffer The buffer to place the read bytes into.
-     * @param size        The amount of data to read, in bytes.
-     *
-     * @note If a size of 0 is specified, then this function reads nothing and
-     *       no attempts to access memory are made at all.
-     *
-     * @pre dest_buffer must be at least size bytes in length, otherwise a
-     *      buffer overrun will occur.
-     *
-     * @post The range [dest_buffer, size) contains the read bytes from the
-     *       process' address space.
-     */
-    void ReadBlockUnsafe(const Kernel::KProcess& process, VAddr src_addr, void* dest_buffer,
-                         std::size_t size);
-
-    /**
      * Reads a contiguous block of bytes from the current process' address space.
      *
      * @param src_addr    The virtual address to begin reading from.
@@ -409,26 +372,6 @@ public:
                     std::size_t size);
 
     /**
-     * Writes a range of bytes into a given process' address space at the specified
-     * virtual address.
-     * This unsafe version does not invalidate GPU Memory.
-     *
-     * @param process    The process to write data into the address space of.
-     * @param dest_addr  The destination virtual address to begin writing the data at.
-     * @param src_buffer The data to write into the process' address space.
-     * @param size       The size of the data to write, in bytes.
-     *
-     * @post The address range [dest_addr, size) in the process' address space
-     *       contains the data that was within src_buffer.
-     *
-     * @post If an attempt is made to write into an unmapped region of memory, the writes
-     *       will be ignored and an error will be logged.
-     *
-     */
-    void WriteBlockUnsafe(const Kernel::KProcess& process, VAddr dest_addr, const void* src_buffer,
-                          std::size_t size);
-
-    /**
      * Writes a range of bytes into the current process' address space at the specified
      * virtual address.
      *
@@ -468,29 +411,6 @@ public:
     void WriteBlockUnsafe(VAddr dest_addr, const void* src_buffer, std::size_t size);
 
     /**
-     * Fills the specified address range within a process' address space with zeroes.
-     *
-     * @param process   The process that will have a portion of its memory zeroed out.
-     * @param dest_addr The starting virtual address of the range to zero out.
-     * @param size      The size of the address range to zero out, in bytes.
-     *
-     * @post The range [dest_addr, size) within the process' address space is
-     *       filled with zeroes.
-     */
-    void ZeroBlock(const Kernel::KProcess& process, VAddr dest_addr, std::size_t size);
-
-    /**
-     * Fills the specified address range within the current process' address space with zeroes.
-     *
-     * @param dest_addr The starting virtual address of the range to zero out.
-     * @param size      The size of the address range to zero out, in bytes.
-     *
-     * @post The range [dest_addr, size) within the current process' address space is
-     *       filled with zeroes.
-     */
-    void ZeroBlock(VAddr dest_addr, std::size_t size);
-
-    /**
      * Copies data within a process' address space to another location within the
      * same address space.
      *
@@ -504,19 +424,6 @@ public:
      */
     void CopyBlock(const Kernel::KProcess& process, VAddr dest_addr, VAddr src_addr,
                    std::size_t size);
-
-    /**
-     * Copies data within the current process' address space to another location within the
-     * same address space.
-     *
-     * @param dest_addr The destination virtual address to begin copying the data into.
-     * @param src_addr  The source virtual address to begin copying the data from.
-     * @param size      The size of the data to copy, in bytes.
-     *
-     * @post The range [dest_addr, size) within the current process' address space
-     *       contains the same data within the range [src_addr, size).
-     */
-    void CopyBlock(VAddr dest_addr, VAddr src_addr, std::size_t size);
 
     /**
      * Marks each page within the specified address range as cached or uncached.
@@ -534,8 +441,5 @@ private:
     struct Impl;
     std::unique_ptr<Impl> impl;
 };
-
-/// Determines if the given VAddr is a kernel address
-bool IsKernelVirtualAddress(VAddr vaddr);
 
 } // namespace Core::Memory

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -1,4 +1,4 @@
-// Copyright 2021 Citra Emulator Project
+// Copyright 2014 Citra Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 


### PR DESCRIPTION
This deduplicates code, fixes all warnings and removes unused code.

This also fixes some logging bugs. I plan to use the new `WalkBlock` function later.