### PR TITLE
common: uuid: Add hash function for UUID

### DIFF
--- a/src/common/uuid.h
+++ b/src/common/uuid.h
@@ -69,3 +69,14 @@ struct UUID {
 static_assert(sizeof(UUID) == 16, "UUID is an invalid size!");
 
 } // namespace Common
+
+namespace std {
+
+template <>
+struct hash<Common::UUID> {
+    size_t operator()(const Common::UUID& uuid) const noexcept {
+        return uuid.uuid[1] ^ uuid.uuid[0];
+    }
+};
+
+} // namespace std


### PR DESCRIPTION
Used when UUID is a key in an unordered_map. The hash is produced by XORing the high and low 64-bits of the UUID together.