### PR TITLE
nvdec: Better logging for unimplemented codecs

### DIFF
--- a/src/video_core/command_classes/nvdec.cpp
+++ b/src/video_core/command_classes/nvdec.cpp
@@ -39,7 +39,7 @@ void Nvdec::Execute() {
         codec->Decode();
         break;
     default:
-        UNIMPLEMENTED_MSG("Unknown codec {}", static_cast<u32>(codec->GetCurrentCodec()));
+        UNIMPLEMENTED_MSG("Codec {}", codec->GetCurrentCodecName());
         break;
     }
 }


### PR DESCRIPTION
Logs the string name of the codec. rather than the ambiguous numeric ID.