### PR TITLE
Respect Vulkan bufferImageGranularity

### DIFF
--- a/src/video_core/vulkan_common/vulkan_memory_allocator.h
+++ b/src/video_core/vulkan_common/vulkan_memory_allocator.h
@@ -123,6 +123,8 @@ private:
     const VkPhysicalDeviceMemoryProperties properties; ///< Physical device properties.
     const bool export_allocations; ///< True when memory allocations have to be exported.
     std::vector<std::unique_ptr<MemoryAllocation>> allocations; ///< Current allocations.
+    VkDeviceSize buffer_image_granularity; // The granularity for adjacent offsets between buffers
+                                           // and optimal images
 };
 
 /// Returns true when a memory usage is guaranteed to be host visible.


### PR DESCRIPTION
Closes #6764

The Vulkan spec says:
> bufferImageGranularity is the granularity, in bytes, at which buffer or linear image resources, and optimal image resources can be bound to adjacent offsets in the same VkDeviceMemory object without aliasing.

Yuzu did not respect this.
In the case of Mario Odyssey it caused image copies to write into the index buffer placed right after that image in host GPU memory. 

The value of this is 1024 on Nvidia GPUs. It does not appear to be a problem on AMD GPUs as the value for those is either 1 or 64 depending on the driver.

This probably impacts a bunch of other games on Nvidia GPUs.