### PR TITLE
configure_general: Swap positions of speed limit and frame limit options

### DIFF
--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -25,6 +25,36 @@
         <item>
          <layout class="QVBoxLayout" name="GeneralVerticalLayout">
           <item>
+            <layout class="QHBoxLayout" name="horizontalLayout_2">
+              <item>
+                <widget class="QLabel" name="fps_cap_label">
+                  <property name="text">
+                    <string>Framerate Cap</string>
+                  </property>
+                  <property name="toolTip">
+                    <string>Requires the use of the FPS Limiter Toggle hotkey to take effect.</string>
+                  </property>
+                </widget>
+              </item>
+              <item>
+                <widget class="QSpinBox" name="fps_cap">
+                  <property name="suffix">
+                    <string>x</string>
+                  </property>
+                  <property name="minimum">
+                    <number>1</number>
+                  </property>
+                  <property name="maximum">
+                    <number>1000</number>
+                  </property>
+                  <property name="value">
+                    <number>500</number>
+                  </property>
+                </widget>
+              </item>
+            </layout>
+          </item>
+          <item>
            <layout class="QHBoxLayout" name="horizontalLayout_2">
             <item>
              <widget class="QCheckBox" name="toggle_speed_limit">
@@ -46,36 +76,6 @@
               </property>
               <property name="value">
                <number>100</number>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QHBoxLayout" name="horizontalLayout_2">
-            <item>
-             <widget class="QLabel" name="fps_cap_label">
-              <property name="text">
-               <string>Framerate Cap</string>
-              </property>
-              <property name="toolTip">
-                <string>Requires the use of the FPS Limiter Toggle hotkey to take effect.</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QSpinBox" name="fps_cap">
-              <property name="suffix">
-               <string>x</string>
-              </property>
-              <property name="minimum">
-               <number>1</number>
-              </property>
-              <property name="maximum">
-               <number>1000</number>
-              </property>
-              <property name="value">
-               <number>500</number>
               </property>
              </widget>
             </item>


### PR DESCRIPTION
A minor change, but one that makes the general config UI look a bit tidier.

Before:
![image](https://user-images.githubusercontent.com/52414509/128621397-cab33f2c-ce6e-41cb-8327-8dea73948b9d.png)


After:
![image](https://user-images.githubusercontent.com/52414509/128621378-f75406db-bc2a-4865-917a-e95c2867edf9.png)
