### PR TITLE
yuzu-cmd/CMakeLists: Correct attribution for this function.

### DIFF
--- a/src/yuzu_cmd/CMakeLists.txt
+++ b/src/yuzu_cmd/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR}/CMakeModules)
 
+# Credits to PinappleEA team for this function.
 function(create_resource file output filename)
     # Read hex data from file
     file(READ ${file} filedata HEX)

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.cpp
@@ -232,6 +232,7 @@ void EmuWindow_SDL2::WaitEvent() {
     }
 }
 
+// Credits to PinappleEA team for this function.
 void EmuWindow_SDL2::SetWindowIcon() {
     SDL_RWops* const yuzu_icon_stream = SDL_RWFromConstMem((void*)yuzu_icon, yuzu_icon_size);
     if (yuzu_icon_stream == nullptr) {


### PR DESCRIPTION
This function was originally from https://github.com/yuzu-emu/yuzu/pull/5364/commits/55d8d30c7278485df3f137c6c9cee1674331e6e7

sadly on https://github.com/yuzu-emu/yuzu/commit/eae9f2e4404f6bdf8a192bc9c09e53cd87e4359d no correct attribution was given. (the entire commit)

I'de like to correct that. Sadly the commits are divergent and going all the way back to fix authorship is not easy. I've left a few comments though. Hope it's enough.
