### PR TITLE
vp9: Ensure the first frame is complete

### DIFF
--- a/src/video_core/command_classes/codecs/vp9.cpp
+++ b/src/video_core/command_classes/codecs/vp9.cpp
@@ -397,14 +397,14 @@ Vp9FrameContainer VP9::GetCurrentFrame(const NvdecCommon::NvdecRegisters& state)
         next_frame = std::move(temp);
     } else {
         next_frame.info = current_frame.info;
-        next_frame.bit_stream = std::move(current_frame.bit_stream);
+        next_frame.bit_stream = current_frame.bit_stream;
     }
     return current_frame;
 }
 
 std::vector<u8> VP9::ComposeCompressedHeader() {
     VpxRangeEncoder writer{};
-    const bool update_probs = current_frame_info.show_frame && !current_frame_info.is_key_frame;
+    const bool update_probs = !current_frame_info.is_key_frame && current_frame_info.show_frame;
     if (!current_frame_info.lossless) {
         if (static_cast<u32>(current_frame_info.transform_mode) >= 3) {
             writer.Write(3, 2);

--- a/src/video_core/command_classes/codecs/vp9_types.h
+++ b/src/video_core/command_classes/codecs/vp9_types.h
@@ -176,7 +176,7 @@ struct PictureInfo {
             .frame_size_changed = (vp9_flags & FrameFlags::FrameSizeChanged) != 0,
             .error_resilient_mode = (vp9_flags & FrameFlags::ErrorResilientMode) != 0,
             .last_frame_shown = (vp9_flags & FrameFlags::LastShowFrame) != 0,
-            .show_frame = false,
+            .show_frame = true,
             .ref_frame_sign_bias = ref_frame_sign_bias,
             .base_q_index = base_q_index,
             .y_dc_delta_q = y_dc_delta_q,


### PR DESCRIPTION
Due to the necessity to buffer 1 frame in advance to decode VP9 streams, the first frame was missing its frame data bitstream. 

This change addresses that by making a duplicate copy of the first frame data rather than moving it, silencing a runtime FFmpeg error due to the first frame missing the frame data, and being set to hidden despite being a key-frame.