### PR TITLE
Vulkan Fastmem 3: No more loading stutters

### DIFF
--- a/src/core/device_memory.cpp
+++ b/src/core/device_memory.cpp
@@ -2,11 +2,19 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include "common/logging/log.h"
 #include "core/device_memory.h"
 
 namespace Core {
 
-DeviceMemory::DeviceMemory() : buffer{DramMemoryMap::Size, 1ULL << 39} {}
+DeviceMemory::DeviceMemory() : buffer{DramMemoryMap::Size, 1ULL << 39} {
+    auto ptr = reinterpret_cast<std::size_t>(buffer.BackingBasePointer());
+    if (ptr & 0xfff || !ptr) {
+        LOG_CRITICAL(HW_Memory, "Unaligned DeviceMemory");
+        abort();
+    }
+}
+
 DeviceMemory::~DeviceMemory() = default;
 
 } // namespace Core

--- a/src/core/device_memory.h
+++ b/src/core/device_memory.h
@@ -12,7 +12,9 @@ namespace Core {
 namespace DramMemoryMap {
 enum : u64 {
     Base = 0x80000000ULL,
-    Size = 0x100000000ULL,
+    GiB = 0x40000000ULL,
+    GiBs = 4,
+    Size = GiB * GiBs,
     End = Base + Size,
     KernelReserveBase = Base + 0x60000,
     SlabHeapBase = KernelReserveBase + 0x85000,

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -14,8 +14,9 @@ struct PageTable;
 }
 
 namespace Core {
+class DeviceMemory;
 class System;
-}
+} // namespace Core
 
 namespace Kernel {
 class PhysicalMemory;
@@ -39,6 +40,17 @@ enum : VAddr {
 
     /// Application stack
     DEFAULT_STACK_SIZE = 0x100000,
+};
+
+constexpr u32 MAX_READ_POINTERS = 100000;
+
+struct ReadPointers {
+    struct ReadPointer {
+        u32 copy_amount;
+        u64 backing_offset;
+    };
+    std::array<ReadPointer, MAX_READ_POINTERS> data;
+    ReadPointer* tail;
 };
 
 /// Central class that handles all memory operations and state.
@@ -348,6 +360,8 @@ public:
      */
     void ReadBlockUnsafe(VAddr src_addr, void* dest_buffer, std::size_t size);
 
+    void ReadBlockPointersUnsafe(VAddr src_addr, ReadPointers& result, std::size_t size);
+
     /**
      * Writes a range of bytes into a given process' address space at the specified
      * virtual address.
@@ -434,6 +448,8 @@ public:
      *               marked as cached or uncached.
      */
     void RasterizerMarkRegionCached(VAddr vaddr, u64 size, bool cached);
+
+    Core::DeviceMemory& GetDeviceMemory();
 
 private:
     Core::System& system;

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -132,6 +132,8 @@ add_library(video_core STATIC
     renderer_vulkan/vk_fence_manager.h
     renderer_vulkan/vk_graphics_pipeline.cpp
     renderer_vulkan/vk_graphics_pipeline.h
+    renderer_vulkan/vk_host_memory.cpp
+    renderer_vulkan/vk_host_memory.h
     renderer_vulkan/vk_master_semaphore.cpp
     renderer_vulkan/vk_master_semaphore.h
     renderer_vulkan/vk_pipeline_cache.cpp

--- a/src/video_core/host_shaders/CMakeLists.txt
+++ b/src/video_core/host_shaders/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SHADER_FILES
     vulkan_present.vert
     vulkan_quad_indexed.comp
     vulkan_uint8.comp
+    vulkan_unswizzle.comp
 )
 
 find_program(GLSLANGVALIDATOR "glslangValidator")

--- a/src/video_core/host_shaders/vulkan_unswizzle.comp
+++ b/src/video_core/host_shaders/vulkan_unswizzle.comp
@@ -1,0 +1,100 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#version 460 core
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_8bit_storage : require
+
+layout (local_size_x = 64) in;
+
+//layout (constant_id = 0) const int BYTES_PER_PIXEL = 1;
+
+layout(binding = 0, std430) readonly buffer InputBufferU8 { uint8_t u8data[]; };
+layout(binding = 0, std430) readonly buffer InputBufferU16 { uint16_t u16data[]; };
+layout(binding = 0, std430) readonly buffer InputBufferU32 { uint u32data[]; };
+layout(binding = 0, std430) readonly buffer InputBufferU64 { uvec2 u64data[]; };
+layout(binding = 0, std430) readonly buffer InputBufferU128 { uvec4 u128data[]; };
+
+layout(binding = 1) writeonly uniform image2DArray output_image;
+
+layout (push_constant) uniform constants {
+    uint size;
+    uint ptr;
+    uint so_far;
+    uint bytes_per_pixel;
+    uint pitch;
+    uint height;
+    uint depth;
+    uint block_height;
+    uint block_depth;
+    uint gobs_in_x;
+    uint dcl2;
+};
+
+const uint GiB = 0x40000000U;
+
+uvec4 ReadTexel(uint offset) {
+    if (offset >= GiB) {
+        return uvec4(0);
+    }
+    switch (bytes_per_pixel) {
+    case 1:
+//        return uvec4(0xFF, 0, 0, 0);
+        return uvec4(u8data[offset], 0, 0, 0);
+    case 2:
+        return uvec4(u16data[offset / 2], 0, 0, 0);
+    case 4:
+//        return uvec4(0xFF, 0xFF, 0, 0xFF);
+        uint data4 = u32data[offset / 4];
+//        return uvec4(data4 & 0xffu, (data4 >> 8) & 0xffu, (data4 >> 16) & 0xffu, (data4 >> 24) & 0xffu);
+        return uvec4((data4 >> 24) & 0xffu, (data4 >> 16) & 0xffu, (data4 >> 8) & 0xffu, data4 & 0xffu);
+//        return uvec4(u32data[offset / 4], 0, 0, 0);
+    case 8:
+        return uvec4(u64data[offset / 8], 0, 0);
+    case 16:
+        return u128data[offset / 16];
+    }
+    return uvec4(0);
+}
+
+void main() {
+    if (gl_GlobalInvocationID.x >= size) {
+        return;
+    }
+    const uint swizzled_offset = gl_GlobalInvocationID.x + so_far;
+//    const uint swizzled_offset = 0;
+    const uint lesser_x_shift = block_height + block_depth;
+    const uint lesser_slice_size = dcl2 * gobs_in_x;
+    const uint block_height_mask = (1U << block_height) - 1;
+    const uint block_depth_mask = (1U << block_depth) - 1;
+    const uint entry = swizzled_offset & 511U;
+    const uint y_table = ((entry >> 5) & 6U) | ((entry >> 4) & 1U);
+    const uint x_entry = ((entry >> 3) & 32U) | ((entry >> 1) & 16U) | (entry & 15U);
+    const uint base_swizzled_offset = swizzled_offset >> 9;
+    const uint set_y = (base_swizzled_offset & block_height_mask) << 3;
+    const uint set_z = (base_swizzled_offset >> block_height) & block_depth_mask;
+    const uint inner_swizzled = base_swizzled_offset >> lesser_x_shift;
+    const uint sli = inner_swizzled / lesser_slice_size;
+    const uint gb = inner_swizzled % lesser_slice_size;
+    const uint x_inner = (gb % gobs_in_x) << 6;
+    const uint y_inner = (gb / gobs_in_x) << (block_height + 3);
+    const uint z_inner = sli << block_depth;
+    const uint x = x_inner + x_entry;
+    const uint y = y_inner + set_y + y_table;
+    const uint z = z_inner + set_z;
+    if (x >= pitch || y >= height || z >= depth) {
+        return;
+    }
+    if (z != 0) {
+        return; // TODO
+    }
+    const uvec4 texel = ReadTexel(ptr + swizzled_offset);
+//    const uvec4 texel = ReadTexel(0);
+//    imageStore(output_image, ivec3(x, y, z), texel);
+    imageStore(output_image, ivec3(x, y, z), vec4(texel)/255);
+//    imageStore(output_image, ivec3(x, y, z), uvec4(1, 1, 1, 1) * ((ptr >> 12) & 0xFF));
+//    imageStore(output_image, ivec3(x * 4, y * 4, z), texel);
+//    imageStore(output_image, ivec3(x * 4, y * 4, z), uvec4(255, 0, 255, 255));
+//    imageStore(output_image, ivec3(x, y, z), uvec4(255, 0, 255, 255));
+}

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -16,6 +16,9 @@ class RasterizerInterface;
 
 namespace Core {
 class System;
+namespace Memory {
+struct ReadPointers;
+}
 }
 
 namespace Tegra {
@@ -111,6 +114,8 @@ public:
      * being flushed.
      */
     void ReadBlockUnsafe(GPUVAddr gpu_src_addr, void* dest_buffer, std::size_t size) const;
+    void ReadBlockPointersUnsafe(GPUVAddr gpu_src_addr, Core::Memory::ReadPointers& result,
+                                 std::size_t size) const;
     void WriteBlockUnsafe(GPUVAddr gpu_dest_addr, const void* src_buffer, std::size_t size);
 
     /**

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -671,8 +671,11 @@ Image::Image(TextureCacheRuntime& runtime, const VideoCommon::ImageInfo& info_, 
 
 Image::~Image() = default;
 
-void Image::UploadMemory(const ImageBufferMap& map,
-                         std::span<const VideoCommon::BufferImageCopy> copies) {
+void Image::UploadMemory(const ImageBufferMap& map, Tegra::MemoryManager& gpu_memory,
+                         std::array<u8, VideoCommon::MAX_GUEST_SIZE>& scratch) {
+    const std::span<u8> mapped_span = map.mapped_span;
+    const auto copies =
+        VideoCommon::UnswizzleImage(gpu_memory, gpu_addr, info, scratch, mapped_span);
     glBindBuffer(GL_PIXEL_UNPACK_BUFFER, map.buffer);
     glFlushMappedBufferRange(GL_PIXEL_UNPACK_BUFFER, map.offset, unswizzled_size_bytes);
 

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -151,8 +151,8 @@ public:
     Image(Image&&) = default;
     Image& operator=(Image&&) = default;
 
-    void UploadMemory(const ImageBufferMap& map,
-                      std::span<const VideoCommon::BufferImageCopy> copies);
+    void UploadMemory(const ImageBufferMap& map, Tegra::MemoryManager& gpu_memory,
+                      std::array<u8, VideoCommon::MAX_GUEST_SIZE>& scratch);
 
     void DownloadMemory(ImageBufferMap& map, std::span<const VideoCommon::BufferImageCopy> copies);
 

--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -107,6 +107,7 @@ RendererVulkan::RendererVulkan(Core::TelemetrySession& telemetry_session_,
       debug_callback(Settings::values.renderer_debug ? CreateDebugCallback(instance) : nullptr),
       surface(CreateSurface(instance, render_window)),
       device(CreateDevice(instance, dld, *surface)),
+      host_memory(cpu_memory.GetDeviceMemory(), device),
       memory_allocator(device, false),
       state_tracker(gpu),
       scheduler(device, state_tracker),
@@ -115,7 +116,7 @@ RendererVulkan::RendererVulkan(Core::TelemetrySession& telemetry_session_,
       blit_screen(cpu_memory, render_window, device, memory_allocator, swapchain, scheduler,
                   screen_info),
       rasterizer(render_window, gpu, gpu.MemoryManager(), cpu_memory, screen_info, device,
-                 memory_allocator, state_tracker, scheduler) {
+                 memory_allocator, state_tracker, scheduler, host_memory) {
     Report();
 } catch (const vk::Exception& exception) {
     LOG_ERROR(Render_Vulkan, "Vulkan initialization failed with error: {}", exception.what());

--- a/src/video_core/renderer_vulkan/renderer_vulkan.h
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.h
@@ -11,6 +11,7 @@
 #include "common/dynamic_library.h"
 #include "video_core/renderer_base.h"
 #include "video_core/renderer_vulkan/vk_blit_screen.h"
+#include "video_core/renderer_vulkan/vk_host_memory.h"
 #include "video_core/renderer_vulkan/vk_rasterizer.h"
 #include "video_core/renderer_vulkan/vk_scheduler.h"
 #include "video_core/renderer_vulkan/vk_state_tracker.h"
@@ -70,6 +71,7 @@ private:
     VKScreenInfo screen_info;
 
     Device device;
+    VulkanHostMemory host_memory;
     MemoryAllocator memory_allocator;
     StateTracker state_tracker;
     VKScheduler scheduler;

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -458,6 +458,7 @@ void GraphicsPipeline::ConfigureImpl(bool is_indexed) {
 }
 
 void GraphicsPipeline::ConfigureDraw() {
+    const void* const descriptor_data{update_descriptor_queue.UpdateData()};
     texture_cache.UpdateRenderTargets(false);
     scheduler.RequestRenderpass(texture_cache.GetFramebuffer());
 
@@ -469,7 +470,6 @@ void GraphicsPipeline::ConfigureDraw() {
         });
     }
     const bool bind_pipeline{scheduler.UpdateGraphicsPipeline(this)};
-    const void* const descriptor_data{update_descriptor_queue.UpdateData()};
     scheduler.Record([this, descriptor_data, bind_pipeline](vk::CommandBuffer cmdbuf) {
         if (bind_pipeline) {
             cmdbuf.BindPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS, *pipeline);

--- a/src/video_core/renderer_vulkan/vk_host_memory.cpp
+++ b/src/video_core/renderer_vulkan/vk_host_memory.cpp
@@ -1,0 +1,100 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+// Originally from
+// https://github.com/google/vulkan_test_applications/blob/74e3a9790fb38303cd1646bbc098173fbb9200fa/application_sandbox/external_memory_host/main.cpp
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/logging/log.h"
+#include "video_core/renderer_vulkan/vk_host_memory.h"
+#include "video_core/renderer_vulkan/vk_staging_buffer_pool.h"
+
+namespace Vulkan {
+
+namespace {
+const VkBufferCreateInfo BUFFER_CREATE_INFO = {
+    .sType = VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+    .pNext = nullptr,
+    .flags = 0,
+    .size = Core::DramMemoryMap::GiB,
+    .usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+    .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
+    .queueFamilyIndexCount = 0,
+    .pQueueFamilyIndices = nullptr,
+};
+} // namespace
+
+VulkanHostMemory::VulkanHostMemory(Core::DeviceMemory& memory, Device& device) {
+    VkImportMemoryHostPointerInfoEXT import_memory_info{
+        .sType = VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT,
+        .pNext = nullptr,
+        .handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT,
+        .pHostPointer = nullptr,
+    };
+    VkMemoryAllocateInfo allocate_info{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
+        .pNext = &import_memory_info,
+        .allocationSize = Core::DramMemoryMap::GiB,
+        .memoryTypeIndex = 0,
+    };
+    const auto& logical = device.GetLogical();
+    const auto memory_properties = device.GetPhysical().GetMemoryProperties();
+    auto host = memory.buffer.BackingBasePointer();
+    for (auto& page : pages) {
+        page.second = logical.CreateBuffer(BUFFER_CREATE_INFO);
+        auto requirements = logical.GetBufferMemoryRequirements(*page.second, nullptr);
+        if (requirements.size != Core::DramMemoryMap::GiB) {
+            LOG_CRITICAL(Render_Vulkan, "Unexpected required size {}", requirements.size);
+            abort();
+        }
+        if (requirements.alignment > 4096) {
+            LOG_CRITICAL(Render_Vulkan, "Unexpected required alignment {}", requirements.alignment);
+            abort();
+        }
+        u32 host_pointer_memory_type_bits = logical.GetMemoryHostPointerProperties(host);
+        import_memory_info.pHostPointer = host;
+        u32 memory_type_bits = requirements.memoryTypeBits & host_pointer_memory_type_bits;
+        if (!memory_type_bits) {
+            LOG_CRITICAL(
+                Render_Vulkan,
+                "Buffer memory bits({}) are not compatible with host pointer memory type bits ({})",
+                requirements.memoryTypeBits, host_pointer_memory_type_bits);
+            abort();
+        }
+        allocate_info.memoryTypeIndex =
+            FindMemoryTypeIndex(memory_properties, memory_type_bits, false);
+        page.first = logical.AllocateMemory(allocate_info);
+        page.second.BindMemory(*page.first, 0);
+        host += Core::DramMemoryMap::GiB;
+    }
+}
+
+void VulkanHostMemory::BindPage(VKUpdateDescriptorQueue& update_descriptor_queue, u32 page) {
+    if (page >= Core::DramMemoryMap::GiBs) {
+        abort();
+    }
+//    page = 0;
+    std::pair<vk::DeviceMemory, vk::Buffer>& pair = pages[page];
+    [[maybe_unused]] auto mapping = pair.first.Map(0, Core::DramMemoryMap::GiB);
+//    mapping[0] = 0xFF;
+//    mapping[1] = 0xFF;
+//    mapping[2] = 0xFF;
+//    mapping[3] = 0xFF;
+    pair.first.Unmap();
+    update_descriptor_queue.AddBuffer(*pair.second, 0, Core::DramMemoryMap::GiB);
+}
+
+} // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_host_memory.h
+++ b/src/video_core/renderer_vulkan/vk_host_memory.h
@@ -1,0 +1,23 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/device_memory.h"
+#include "video_core/renderer_vulkan/vk_update_descriptor.h"
+#include "video_core/vulkan_common/vulkan_device.h"
+
+#pragma once
+
+namespace Vulkan {
+
+class VulkanHostMemory {
+public:
+    explicit VulkanHostMemory(Core::DeviceMemory& memory, Device& device);
+
+    void BindPage(VKUpdateDescriptorQueue& update_descriptor_queue, u32 page);
+
+private:
+    std::array<std::pair<vk::DeviceMemory, vk::Buffer>, Core::DramMemoryMap::GiBs> pages;
+};
+
+} // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -21,6 +21,7 @@
 #include "video_core/renderer_vulkan/vk_buffer_cache.h"
 #include "video_core/renderer_vulkan/vk_descriptor_pool.h"
 #include "video_core/renderer_vulkan/vk_fence_manager.h"
+#include "video_core/renderer_vulkan/vk_host_memory.h"
 #include "video_core/renderer_vulkan/vk_pipeline_cache.h"
 #include "video_core/renderer_vulkan/vk_query_cache.h"
 #include "video_core/renderer_vulkan/vk_render_pass_cache.h"
@@ -67,7 +68,7 @@ public:
                               Tegra::MemoryManager& gpu_memory_, Core::Memory::Memory& cpu_memory_,
                               VKScreenInfo& screen_info_, const Device& device_,
                               MemoryAllocator& memory_allocator_, StateTracker& state_tracker_,
-                              VKScheduler& scheduler_);
+                              VKScheduler& scheduler_, VulkanHostMemory& host_memory_);
     ~RasterizerVulkan() override;
 
     void Draw(bool is_indexed, bool is_instanced) override;
@@ -154,6 +155,7 @@ private:
     VKUpdateDescriptorQueue update_descriptor_queue;
     BlitImageHelper blit_image;
     ASTCDecoderPass astc_decoder_pass;
+    UnswizzlePass unswizzle_pass;
     RenderPassCache render_pass_cache;
 
     TextureCacheRuntime texture_cache_runtime;

--- a/src/video_core/renderer_vulkan/vk_staging_buffer_pool.cpp
+++ b/src/video_core/renderer_vulkan/vk_staging_buffer_pool.cpp
@@ -61,6 +61,11 @@ std::optional<u32> FindMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& p
     return std::nullopt;
 }
 
+size_t Region(size_t iterator) noexcept {
+    return iterator / REGION_SIZE;
+}
+} // Anonymous namespace
+
 u32 FindMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& props, u32 type_mask,
                         bool try_device_local) {
     std::optional<u32> type;
@@ -79,11 +84,6 @@ u32 FindMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& props, u32 type_
     // This should never happen, and in case it does, signal it as an out of memory situation
     throw vk::Exception(VK_ERROR_OUT_OF_DEVICE_MEMORY);
 }
-
-size_t Region(size_t iterator) noexcept {
-    return iterator / REGION_SIZE;
-}
-} // Anonymous namespace
 
 StagingBufferPool::StagingBufferPool(const Device& device_, MemoryAllocator& memory_allocator_,
                                      VKScheduler& scheduler_)

--- a/src/video_core/renderer_vulkan/vk_staging_buffer_pool.h
+++ b/src/video_core/renderer_vulkan/vk_staging_buffer_pool.h
@@ -23,6 +23,9 @@ struct StagingBufferRef {
     std::span<u8> mapped_span;
 };
 
+u32 FindMemoryTypeIndex(const VkPhysicalDeviceMemoryProperties& props, u32 type_mask,
+                        bool try_device_local);
+
 class StagingBufferPool {
 public:
     static constexpr size_t NUM_SYNCS = 16;

--- a/src/video_core/renderer_vulkan/vk_update_descriptor.h
+++ b/src/video_core/renderer_vulkan/vk_update_descriptor.h
@@ -77,7 +77,7 @@ private:
 
     DescriptorUpdateEntry* payload_cursor = nullptr;
     const DescriptorUpdateEntry* upload_start = nullptr;
-    std::array<DescriptorUpdateEntry, 0x10000> payload;
+    std::array<DescriptorUpdateEntry, 0x100000> payload;
 };
 
 } // namespace Vulkan

--- a/src/video_core/texture_cache/texture_cache_base.h
+++ b/src/video_core/texture_cache/texture_cache_base.h
@@ -217,9 +217,8 @@ private:
     /// Refresh the contents (pixel data) of an image
     void RefreshContents(Image& image, ImageId image_id);
 
-    /// Upload data from guest to an image
-    template <typename StagingBuffer>
-    void UploadImageContents(Image& image, StagingBuffer& staging_buffer);
+    /// Upload data from guest to an imag
+    void UploadImageContents(Image& image);
 
     /// Find or create an image view from a guest descriptor
     [[nodiscard]] ImageViewId FindImageView(const TICEntry& config);
@@ -328,6 +327,7 @@ private:
     Tegra::Engines::Maxwell3D& maxwell3d;
     Tegra::Engines::KeplerCompute& kepler_compute;
     Tegra::MemoryManager& gpu_memory;
+    std::array<u8, MAX_GUEST_SIZE> unswizzle_scratch;
 
     DescriptorTable<TICEntry> graphics_image_table{gpu_memory};
     DescriptorTable<TSCEntry> graphics_sampler_table{gpu_memory};

--- a/src/video_core/texture_cache/types.h
+++ b/src/video_core/texture_cache/types.h
@@ -145,4 +145,18 @@ struct SwizzleParameters {
     s32 level;
 };
 
+struct UnswizzlePushConstants {
+    u32 size;
+    u32 ptr;
+    u32 so_far;
+    u32 bytes_per_pixel;
+    u32 pitch;
+    u32 height;
+    u32 depth;
+    u32 block_height;
+    u32 block_depth;
+    u32 gobs_in_x;
+    u32 dcl2;
+};
+
 } // namespace VideoCommon

--- a/src/video_core/texture_cache/util.h
+++ b/src/video_core/texture_cache/util.h
@@ -28,6 +28,77 @@ struct OverlapResult {
     SubresourceExtent resources;
 };
 
+// This ought to be enough for anybody
+constexpr size_t MAX_GUEST_SIZE = 0x4000000;
+
+struct LevelInfo {
+    Extent3D size;
+    Extent3D block;
+    Extent2D tile_size;
+    u32 bpp_log2;
+    u32 tile_width_spacing;
+};
+
+[[nodiscard]] u32 AdjustTileSize(u32 shift, u32 unit_factor, u32 dimension);
+[[nodiscard]] u32 AdjustMipSize(u32 size, u32 level);
+[[nodiscard]] Extent3D AdjustMipSize(Extent3D size, s32 level);
+[[nodiscard]] Extent3D AdjustSamplesSize(Extent3D size, s32 num_samples);
+template <u32 GOB_EXTENT>
+[[nodiscard]] u32 AdjustMipBlockSize(u32 num_tiles, u32 block_size, u32 level);
+[[nodiscard]] Extent3D AdjustMipBlockSize(Extent3D num_tiles, Extent3D block_size, u32 level);
+[[nodiscard]] Extent3D AdjustTileSize(Extent3D size, Extent2D tile_size);
+[[nodiscard]] u32 BytesPerBlockLog2(u32 bytes_per_block);
+[[nodiscard]] u32 BytesPerBlockLog2(PixelFormat format);
+[[nodiscard]] u32 NumBlocks(Extent3D size, Extent2D tile_size);
+[[nodiscard]] u32 AdjustSize(u32 size, u32 level, u32 block_size);
+[[nodiscard]] Extent2D DefaultBlockSize(PixelFormat format);
+[[nodiscard]] Extent3D NumLevelBlocks(const LevelInfo& info, u32 level);
+[[nodiscard]] Extent3D TileShift(const LevelInfo& info, u32 level);
+[[nodiscard]] Extent2D GobSize(u32 bpp_log2, u32 block_height, u32 tile_width_spacing);
+[[nodiscard]] bool IsSmallerThanGobSize(Extent3D num_tiles, Extent2D gob, u32 block_depth);
+[[nodiscard]] u32 StrideAlignment(Extent3D num_tiles, Extent3D block, Extent2D gob, u32 bpp_log2);
+[[nodiscard]] u32 StrideAlignment(Extent3D num_tiles, Extent3D block, u32 bpp_log2,
+                                  u32 tile_width_spacing);
+[[nodiscard]] Extent2D NumGobs(const LevelInfo& info, u32 level);
+[[nodiscard]] Extent3D LevelTiles(const LevelInfo& info, u32 level);
+[[nodiscard]] u32 CalculateLevelSize(const LevelInfo& info, u32 level);
+[[nodiscard]] LevelArray CalculateLevelSizes(const LevelInfo& info, u32 num_levels);
+[[nodiscard]] u32 CalculateLevelBytes(const LevelArray& sizes, u32 num_levels);
+[[nodiscard]] LevelInfo MakeLevelInfo(PixelFormat format, Extent3D size, Extent3D block,
+                                      u32 tile_width_spacing);
+[[nodiscard]] LevelInfo MakeLevelInfo(const ImageInfo& info);
+[[nodiscard]] u32 CalculateLevelOffset(PixelFormat format, Extent3D size, Extent3D block,
+                                       u32 tile_width_spacing, u32 level);
+[[nodiscard]] u32 AlignLayerSize(u32 size_bytes, Extent3D size, Extent3D block, u32 tile_size_y,
+                                 u32 tile_width_spacing);
+[[nodiscard]] std::optional<SubresourceExtent> ResolveOverlapEqualAddress(const ImageInfo& new_info,
+                                                                          const ImageBase& overlap,
+                                                                          bool strict_size);
+[[nodiscard]] std::optional<SubresourceExtent> ResolveOverlapRightAddress3D(
+    const ImageInfo& new_info, GPUVAddr gpu_addr, const ImageBase& overlap, bool strict_size);
+[[nodiscard]] std::optional<SubresourceExtent> ResolveOverlapRightAddress2D(
+    const ImageInfo& new_info, GPUVAddr gpu_addr, const ImageBase& overlap, bool strict_size);
+[[nodiscard]] std::optional<OverlapResult> ResolveOverlapRightAddress(const ImageInfo& new_info,
+                                                                      GPUVAddr gpu_addr,
+                                                                      VAddr cpu_addr,
+                                                                      const ImageBase& overlap,
+                                                                      bool strict_size);
+[[nodiscard]] std::optional<OverlapResult> ResolveOverlapLeftAddress(const ImageInfo& new_info,
+                                                                     GPUVAddr gpu_addr,
+                                                                     VAddr cpu_addr,
+                                                                     const ImageBase& overlap,
+                                                                     bool strict_size);
+[[nodiscard]] Extent2D PitchLinearAlignedSize(const ImageInfo& info);
+[[nodiscard]] Extent3D BlockLinearAlignedSize(const ImageInfo& info, u32 level);
+[[nodiscard]] u32 NumBlocksPerLayer(const ImageInfo& info, Extent2D tile_size) noexcept;
+[[nodiscard]] u32 NumSlices(const ImageInfo& info) noexcept;
+void SwizzlePitchLinearImage(Tegra::MemoryManager& gpu_memory, GPUVAddr gpu_addr,
+                             const ImageInfo& info, const BufferImageCopy& copy,
+                             std::span<const u8> memory);
+void SwizzleBlockLinearImage(Tegra::MemoryManager& gpu_memory, GPUVAddr gpu_addr,
+                             const ImageInfo& info, const BufferImageCopy& copy,
+                             std::span<const u8> input);
+
 [[nodiscard]] u32 CalculateGuestSizeInBytes(const ImageInfo& info) noexcept;
 
 [[nodiscard]] u32 CalculateUnswizzledSizeBytes(const ImageInfo& info) noexcept;
@@ -61,6 +132,7 @@ struct OverlapResult {
 
 [[nodiscard]] std::vector<BufferImageCopy> UnswizzleImage(Tegra::MemoryManager& gpu_memory,
                                                           GPUVAddr gpu_addr, const ImageInfo& info,
+                                                          std::array<u8, MAX_GUEST_SIZE>& scratch,
                                                           std::span<u8> output);
 
 [[nodiscard]] BufferCopy UploadBufferCopy(Tegra::MemoryManager& gpu_memory, GPUVAddr gpu_addr,

--- a/src/video_core/textures/decoders.h
+++ b/src/video_core/textures/decoders.h
@@ -7,6 +7,7 @@
 #include <span>
 
 #include "common/common_types.h"
+#include "video_core/texture_cache/types.h"
 #include "video_core/textures/texture.h"
 
 namespace Tegra::Texture {
@@ -39,6 +40,10 @@ constexpr SwizzleTable MakeSwizzleTable() {
     return table;
 }
 constexpr SwizzleTable SWIZZLE_TABLE = MakeSwizzleTable();
+
+void CalculateUnswizzle(VideoCommon::UnswizzlePushConstants& result, u32 bytes_per_pixel, u32 width,
+                        u32 height, u32 depth, u32 block_height, u32 block_depth,
+                        u32 stride_alignment);
 
 /// Unswizzles a block linear texture into linear memory.
 void UnswizzleTexture(std::span<u8> output, std::span<const u8> input, u32 bytes_per_pixel,

--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -180,6 +180,7 @@ void Load(VkDevice device, DeviceDispatch& dld) noexcept {
 #ifdef _WIN32
     X(vkGetMemoryWin32HandleKHR);
 #endif
+    X(vkGetMemoryHostPointerPropertiesEXT);
     X(vkGetQueryPoolResults);
     X(vkGetPipelineExecutablePropertiesKHR);
     X(vkGetPipelineExecutableStatisticsKHR);
@@ -809,6 +810,17 @@ VkMemoryRequirements Device::GetImageMemoryRequirements(VkImage image) const noe
     VkMemoryRequirements requirements;
     dld->vkGetImageMemoryRequirements(handle, image, &requirements);
     return requirements;
+}
+
+u32 Device::GetMemoryHostPointerProperties(const void* ptr) const noexcept {
+    VkMemoryHostPointerPropertiesEXT properties{
+        .sType = VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT,
+        .pNext = nullptr,
+        .memoryTypeBits = 0,
+    };
+    Check(dld->vkGetMemoryHostPointerPropertiesEXT(
+        handle, VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT, ptr, &properties));
+    return properties.memoryTypeBits;
 }
 
 std::vector<VkPipelineExecutablePropertiesKHR> Device::GetPipelineExecutablePropertiesKHR(

--- a/src/video_core/vulkan_common/vulkan_wrapper.h
+++ b/src/video_core/vulkan_common/vulkan_wrapper.h
@@ -295,6 +295,7 @@ struct DeviceDispatch : InstanceDispatch {
 #ifdef _WIN32
     PFN_vkGetMemoryWin32HandleKHR vkGetMemoryWin32HandleKHR{};
 #endif
+    PFN_vkGetMemoryHostPointerPropertiesEXT vkGetMemoryHostPointerPropertiesEXT{};
     PFN_vkGetPipelineExecutablePropertiesKHR vkGetPipelineExecutablePropertiesKHR{};
     PFN_vkGetPipelineExecutableStatisticsKHR vkGetPipelineExecutableStatisticsKHR{};
     PFN_vkGetQueryPoolResults vkGetQueryPoolResults{};
@@ -880,6 +881,8 @@ public:
                                                      void* pnext = nullptr) const noexcept;
 
     VkMemoryRequirements GetImageMemoryRequirements(VkImage image) const noexcept;
+
+    u32 GetMemoryHostPointerProperties(const void* ptr) const noexcept;
 
     std::vector<VkPipelineExecutablePropertiesKHR> GetPipelineExecutablePropertiesKHR(
         VkPipeline pipeline) const;


### PR DESCRIPTION
This moves UnswizzleTexture which can take as much as 20 milliseconds to the GPU. Just like CPU fastmem I use memory mapping to let the GPU see the emulated memory. The function now takes less than 1 millisecond.

Link's Awakening's intro video plays at 50 FPS maximum instead of 44 FPS. Kirby Star Allies doesn't stutter any more while loading such as when pressing A after starting emulation.