### PR TITLE
vulkan_device: Temporarily disable CollectToolingInfo

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -1161,7 +1161,8 @@ void Device::CollectPhysicalMemoryInfo() {
 }
 
 void Device::CollectToolingInfo() {
-    if (!ext_tooling_info) {
+    if (!ext_tooling_info || true) {
+        // Disabled to work around https://github.com/yuzu-emu/yuzu/issues/6835
         return;
     }
     const auto vkGetPhysicalDeviceToolPropertiesEXT =


### PR DESCRIPTION
Multiple users on Discord and GitHub are affected by #6835. Let's disable CollectToolingInfo for now so they can play. This is workaround not a fix but it'll help those users greatly.