### PR TITLE
dynarmic: Update and enable DYNARMIC_IGNORE_ASSERTS

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -21,6 +21,7 @@ target_include_directories(catch-single-include INTERFACE catch/single_include)
 if (ARCHITECTURE_x86_64)
     set(DYNARMIC_TESTS OFF)
     set(DYNARMIC_NO_BUNDLED_FMT ON)
+    set(DYNARMIC_IGNORE_ASSERTS ON CACHE BOOL "" FORCE)
     add_subdirectory(dynarmic)
 endif()
 

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -7,7 +7,9 @@ include(DownloadExternals)
 # xbyak
 if (ARCHITECTURE_x86 OR ARCHITECTURE_x86_64)
     add_library(xbyak INTERFACE)
-    target_include_directories(xbyak SYSTEM INTERFACE ./xbyak/xbyak)
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/xbyak/include)
+    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/xbyak/xbyak DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/xbyak/include)
+    target_include_directories(xbyak SYSTEM INTERFACE ${CMAKE_CURRENT_BINARY_DIR}/xbyak/include)
     target_compile_definitions(xbyak INTERFACE XBYAK_NO_OP_NAMES)
 endif()
 

--- a/src/common/x64/xbyak_abi.h
+++ b/src/common/x64/xbyak_abi.h
@@ -6,7 +6,7 @@
 
 #include <bitset>
 #include <initializer_list>
-#include <xbyak.h>
+#include <xbyak/xbyak.h>
 #include "common/assert.h"
 
 namespace Common::X64 {

--- a/src/common/x64/xbyak_util.h
+++ b/src/common/x64/xbyak_util.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <type_traits>
-#include <xbyak.h>
+#include <xbyak/xbyak.h>
 #include "common/x64/xbyak_abi.h"
 
 namespace Common::X64 {

--- a/src/video_core/macro/macro_jit_x64.h
+++ b/src/video_core/macro/macro_jit_x64.h
@@ -6,7 +6,7 @@
 
 #include <array>
 #include <bitset>
-#include <xbyak.h>
+#include <xbyak/xbyak.h>
 #include "common/bit_field.h"
 #include "common/common_types.h"
 #include "common/x64/xbyak_abi.h"


### PR DESCRIPTION
We've never hit a dynarmic assert (and these are exercised quite well during fuzzing), so disable them at runtime.