### PR TITLE
kernel: Optimize GetHostThreadID

### DIFF
--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -267,20 +267,23 @@ struct KernelCore::Impl {
         }
     }
 
-    /// Creates a new host thread ID, should only be called by GetHostThreadId
-    u32 AllocateHostThreadId(std::optional<std::size_t> core_id) {
-        if (core_id) {
-            // The first for slots are reserved for CPU core threads
-            ASSERT(*core_id < Core::Hardware::NUM_CPU_CORES);
-            return static_cast<u32>(*core_id);
-        } else {
-            return next_host_thread_id++;
+    static inline thread_local u32 host_thread_id = UINT32_MAX;
+
+    /// Gets the host thread ID for the caller, allocating a new one if this is the first time
+    u32 GetHostThreadId(std::size_t core_id) {
+        if (host_thread_id == UINT32_MAX) {
+            // The first four slots are reserved for CPU core threads
+            ASSERT(core_id < Core::Hardware::NUM_CPU_CORES);
+            host_thread_id = static_cast<u32>(core_id);
         }
+        return host_thread_id;
     }
 
     /// Gets the host thread ID for the caller, allocating a new one if this is the first time
-    u32 GetHostThreadId(std::optional<std::size_t> core_id = std::nullopt) {
-        const thread_local auto host_thread_id{AllocateHostThreadId(core_id)};
+    u32 GetHostThreadId() {
+        if (host_thread_id == UINT32_MAX) {
+            host_thread_id = next_host_thread_id++;
+        }
         return host_thread_id;
     }
 


### PR DESCRIPTION
I profiled the *Fire Emblem: Three Houses* loading screen and found that `GetHostThreadID` was taking up a fair chunk of CPU time. It seems like `thread_local` initialization and the optional parameter for ID allocation hurt the chances of inlining and eliminating some checks in each path.
Here's a profile of the old implementation:
![image](https://user-images.githubusercontent.com/28246325/129492211-c1eee325-296f-417d-934d-85b48609f691.png)
And this implementation:
![image](https://user-images.githubusercontent.com/28246325/129492230-8bb90340-7fea-4c81-99f2-57a32fbb2179.png)
