### PR TITLE
Fix check is thread current in GetThreadContext

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1078,8 +1078,8 @@ static ResultCode GetThreadContext(Core::System& system, VAddr out_context, Hand
             for (auto i = 0; i < static_cast<s32>(Core::Hardware::NUM_CPU_CORES); ++i) {
                 if (thread.GetPointerUnsafe() == kernel.Scheduler(i).GetCurrentThread()) {
                     current = true;
+                    break;
                 }
-                break;
             }
 
             // If the thread is current, retry until it isn't.


### PR DESCRIPTION
Misplaced break made it only check for the first core. Probably fixes some multicore issues? Found by static analysis (thanks to PVS-Studio!).

~~While we're at it, won't calling `continue` in `if` directly below cause release and re-acquiring of scoped lock on `kernel`? Is this intended?~~ Edit: clarified to be intended on discord, no problem here.