### PR TITLE
Fix crash in logging in CreateStrayLayer

### DIFF
--- a/src/core/hle/service/vi/vi.cpp
+++ b/src/core/hle/service/vi/vi.cpp
@@ -1158,7 +1158,7 @@ private:
 
         const auto layer_id = nv_flinger.CreateLayer(display_id);
         if (!layer_id) {
-            LOG_ERROR(Service_VI, "Layer not found! layer_id={}", *layer_id);
+            LOG_ERROR(Service_VI, "Layer not found! display_id={}", display_id);
             IPC::ResponseBuilder rb{ctx, 2};
             rb.Push(ERR_NOT_FOUND);
             return;


### PR DESCRIPTION
It was trying to log value of `layer_id` which is specifically known not to exist, potentially leading to segfault. Log `display_id` instead.