### PR TITLE
video_core: eliminate constant ternary

### DIFF
--- a/src/video_core/textures/texture.h
+++ b/src/video_core/textures/texture.h
@@ -159,7 +159,7 @@ static_assert(sizeof(TextureHandle) == 4, "TextureHandle has wrong size");
         return {raw, raw};
     } else {
         const Tegra::Texture::TextureHandle handle{raw};
-        return {handle.tic_id, via_header_index ? handle.tic_id : handle.tsc_id};
+        return {handle.tic_id, handle.tsc_id};
     }
 }
 


### PR DESCRIPTION
`via_header_index` is already checked above, so it would never be true in this branch. It worked all along and it makes sense, so it's probably fine.