### PR TITLE
CMakeLists: Ensure proper numerusform tags are generated for pluralized translations

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -182,7 +182,14 @@ if (ENABLE_QT_TRANSLATION)
     # Update source TS file if enabled
     if (GENERATE_QT_TRANSLATION)
         get_target_property(SRCS yuzu SOURCES)
-        qt5_create_translation(QM_FILES ${SRCS} ${UIS} ${YUZU_QT_LANGUAGES}/en.ts)
+        qt5_create_translation(QM_FILES
+            ${SRCS}
+            ${UIS}
+            ${YUZU_QT_LANGUAGES}/en.ts
+        OPTIONS
+            -source-language en_US
+            -target-language en_US
+        )
         add_custom_target(translation ALL DEPENDS ${YUZU_QT_LANGUAGES}/en.ts)
     endif()
 


### PR DESCRIPTION
If we don't set an explicit source and target language for the base English translation, then Linguist will generate an incorrect number of `<numerusform>` tags (which Transifex doesn't like).

This should allow translators to properly specify pluralization translations on relevant strings that make use of it.