### PR TITLE
logging: Fix log filter during initialization

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -5,6 +5,7 @@
 #include <atomic>
 #include <chrono>
 #include <climits>
+#include <exception>
 #include <thread>
 #include <vector>
 
@@ -152,7 +153,7 @@ public:
     void EnableForStacktrace() override {}
 };
 
-bool initialization_in_progress_suppress_logging = false;
+bool initialization_in_progress_suppress_logging = true;
 
 /**
  * Static state as a singleton.
@@ -161,17 +162,17 @@ class Impl {
 public:
     static Impl& Instance() {
         if (!instance) {
-            abort();
+            throw std::runtime_error("Using Logging instance before its initialization");
         }
         return *instance;
     }
 
     static void Initialize() {
         if (instance) {
-            abort();
+            LOG_WARNING(Log, "Reinitializing logging backend");
+            return;
         }
         using namespace Common::FS;
-        initialization_in_progress_suppress_logging = true;
         const auto& log_dir = GetYuzuPath(YuzuPath::LogDir);
         void(CreateDir(log_dir));
         Filter filter;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <atomic>
+#include <exception>
 #include <memory>
 #include <utility>
 
@@ -423,9 +424,16 @@ struct System::Impl {
 System::System() : impl{std::make_unique<Impl>(*this)} {}
 System::~System() = default;
 
+System& System::GetInstance() {
+    if (!s_instance) {
+        throw std::runtime_error("Using System instance before its initialization");
+    }
+    return *s_instance;
+}
+
 void System::InitializeGlobalInstance() {
     if (s_instance) {
-        abort();
+        throw std::runtime_error("Reinitializing Global System instance.");
     }
     s_instance = std::unique_ptr<System>(new System);
 }

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -120,12 +120,7 @@ public:
      * Gets the instance of the System singleton class.
      * @returns Reference to the instance of the System singleton class.
      */
-    [[deprecated("Use of the global system instance is deprecated")]] static System& GetInstance() {
-        if (!s_instance) {
-            abort();
-        }
-        return *s_instance;
-    }
+    [[deprecated("Use of the global system instance is deprecated")]] static System& GetInstance();
 
     static void InitializeGlobalInstance();
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -192,6 +192,7 @@ GMainWindow::GMainWindow()
     : input_subsystem{std::make_shared<InputCommon::InputSubsystem>()},
       config{std::make_unique<Config>()}, vfs{std::make_shared<FileSys::RealVfsFilesystem>()},
       provider{std::make_unique<FileSys::ManualContentProvider>()} {
+    Common::Log::Initialize();
     LoadTranslation();
 
     setAcceptDrops(true);
@@ -3381,7 +3382,6 @@ void GMainWindow::SetDiscordEnabled([[maybe_unused]] bool state) {
 #endif
 
 int main(int argc, char* argv[]) {
-    Common::Log::Initialize();
     Common::DetachedTasks detached_tasks;
     MicroProfileOnThreadCreate("Frontend");
     SCOPE_EXIT({ MicroProfileShutdown(); });


### PR DESCRIPTION
After #6869, the log filter was being ignored on initialization due to the logging instance being initialized before the config instance, so the log filter was set to its default value.

This fixes that oversight, along with using descriptive exceptions instead of abort() calls.