### PR TITLE
emit_spirv_context_get_set: Fix Get FrontFace return value

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -333,8 +333,9 @@ Id EmitGetAttribute(EmitContext& ctx, IR::Attribute attr, Id vertex) {
             return ctx.OpBitcast(ctx.F32[1], ctx.OpISub(ctx.U32[1], index, base));
         }
     case IR::Attribute::FrontFace:
-        return ctx.OpSelect(ctx.U32[1], ctx.OpLoad(ctx.U1, ctx.front_face),
-                            ctx.Const(std::numeric_limits<u32>::max()), ctx.u32_zero_value);
+        return ctx.OpSelect(ctx.F32[1], ctx.OpLoad(ctx.U1, ctx.front_face),
+                            ctx.OpBitcast(ctx.F32[1], ctx.Const(std::numeric_limits<u32>::max())),
+                            ctx.f32_zero_value);
     case IR::Attribute::PointSpriteS:
         return ctx.OpLoad(ctx.F32[1],
                           ctx.OpAccessChain(ctx.input_f32, ctx.point_coord, ctx.u32_zero_value));


### PR DESCRIPTION
The IR expects GetAttribute to return an F32 value. This case was returning a U32 instead.

Fixes Mario's mustache color on Intel drivers.

![image](https://user-images.githubusercontent.com/52414509/131058039-0dae9077-c306-4a3d-9b13-642213e24371.png)
![image](https://user-images.githubusercontent.com/52414509/131057840-65786a4f-cf55-4292-be4e-dd85eb90c994.png)
