### PR TITLE
input_common: Add advanced setting for 8 player support

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -72,6 +72,9 @@ void LogSettings() {
     log_setting("Debugging_ProgramArgs", values.program_args.GetValue());
     log_setting("Services_BCATBackend", values.bcat_backend.GetValue());
     log_setting("Services_BCATBoxcatLocal", values.bcat_boxcat_local.GetValue());
+    log_setting("Input_EnableMotion", values.motion_enabled.GetValue());
+    log_setting("Input_EnableVibration", values.vibration_enabled.GetValue());
+    log_setting("Input_EnableRawInput", values.enable_raw_input.GetValue());
 }
 
 bool IsConfiguringGlobal() {

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -16,7 +16,6 @@
 
 #include "common/common_types.h"
 #include "common/settings_input.h"
-#include "input_common/udp/client.h"
 
 namespace Settings {
 
@@ -498,14 +497,15 @@ struct Values {
 
     Setting<bool> use_docked_mode{true, "use_docked_mode"};
 
+    BasicSetting<bool> enable_raw_input{false, "enable_raw_input"};
+
     Setting<bool> vibration_enabled{true, "vibration_enabled"};
     Setting<bool> enable_accurate_vibrations{false, "enable_accurate_vibrations"};
 
     Setting<bool> motion_enabled{true, "motion_enabled"};
     BasicSetting<std::string> motion_device{"engine:motion_emu,update_period:100,sensitivity:0.01",
                                             "motion_device"};
-    BasicSetting<std::string> udp_input_servers{InputCommon::CemuhookUDP::DEFAULT_SRV,
-                                                "udp_input_servers"};
+    BasicSetting<std::string> udp_input_servers{"127.0.0.1:26760", "udp_input_servers"};
 
     BasicSetting<bool> mouse_panning{false, "mouse_panning"};
     BasicRangedSetting<u8> mouse_panning_sensitivity{10, 1, 100, "mouse_panning_sensitivity"};

--- a/src/input_common/sdl/sdl_impl.cpp
+++ b/src/input_common/sdl/sdl_impl.cpp
@@ -21,7 +21,7 @@
 #include "common/logging/log.h"
 #include "common/math_util.h"
 #include "common/param_package.h"
-#include "common/settings_input.h"
+#include "common/settings.h"
 #include "common/threadsafe_queue.h"
 #include "core/frontend/input.h"
 #include "input_common/motion_input.h"
@@ -889,8 +889,10 @@ SDLState::SDLState() {
     RegisterFactory<VibrationDevice>("sdl", vibration_factory);
     RegisterFactory<MotionDevice>("sdl", motion_factory);
 
-    // Disable raw input. When enabled this setting causes SDL to die when a web applet opens
-    SDL_SetHint(SDL_HINT_JOYSTICK_RAWINPUT, "0");
+    if (!Settings::values.enable_raw_input) {
+        // Disable raw input. When enabled this setting causes SDL to die when a web applet opens
+        SDL_SetHint(SDL_HINT_JOYSTICK_RAWINPUT, "0");
+    }
 
     // Enable HIDAPI rumble. This prevents SDL from disabling motion on PS4 and PS5 controllers
     SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1");
@@ -898,10 +900,10 @@ SDLState::SDLState() {
 
     // Tell SDL2 to use the hidapi driver. This will allow joycons to be detected as a
     // GameController and not a generic one
-    SDL_SetHint("SDL_JOYSTICK_HIDAPI_JOY_CONS", "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_JOY_CONS, "1");
 
     // Turn off Pro controller home led
-    SDL_SetHint("SDL_JOYSTICK_HIDAPI_SWITCH_HOME_LED", "0");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_SWITCH_HOME_LED, "0");
 
     // If the frontend is going to manage the event loop, then we don't start one here
     start_thread = SDL_WasInit(SDL_INIT_JOYSTICK) == 0;

--- a/src/input_common/udp/client.h
+++ b/src/input_common/udp/client.h
@@ -21,8 +21,6 @@
 
 namespace InputCommon::CemuhookUDP {
 
-constexpr char DEFAULT_SRV[] = "127.0.0.1:26760";
-
 class Socket;
 
 namespace Response {

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -560,6 +560,7 @@ void Config::ReadControlValues() {
     ReadTouchscreenValues();
     ReadMotionTouchValues();
 
+    ReadBasicSetting(Settings::values.enable_raw_input);
     ReadBasicSetting(Settings::values.emulate_analog_keyboard);
     Settings::values.mouse_panning = false;
     ReadBasicSetting(Settings::values.mouse_panning_sensitivity);
@@ -1184,6 +1185,7 @@ void Config::SaveControlValues() {
     WriteGlobalSetting(Settings::values.vibration_enabled);
     WriteGlobalSetting(Settings::values.enable_accurate_vibrations);
     WriteGlobalSetting(Settings::values.motion_enabled);
+    WriteBasicSetting(Settings::values.enable_raw_input);
     WriteBasicSetting(Settings::values.keyboard_enabled);
     WriteBasicSetting(Settings::values.emulate_analog_keyboard);
     WriteBasicSetting(Settings::values.mouse_panning_sensitivity);

--- a/src/yuzu/configuration/configure_input_advanced.cpp
+++ b/src/yuzu/configuration/configure_input_advanced.cpp
@@ -126,6 +126,7 @@ void ConfigureInputAdvanced::ApplyConfiguration() {
     Settings::values.mouse_panning_sensitivity =
         static_cast<float>(ui->mouse_panning_sensitivity->value());
     Settings::values.touchscreen.enabled = ui->touchscreen_enabled->isChecked();
+    Settings::values.enable_raw_input = ui->enable_raw_input->isChecked();
 }
 
 void ConfigureInputAdvanced::LoadConfiguration() {
@@ -155,6 +156,7 @@ void ConfigureInputAdvanced::LoadConfiguration() {
     ui->mouse_panning->setChecked(Settings::values.mouse_panning.GetValue());
     ui->mouse_panning_sensitivity->setValue(Settings::values.mouse_panning_sensitivity.GetValue());
     ui->touchscreen_enabled->setChecked(Settings::values.touchscreen.enabled);
+    ui->enable_raw_input->setChecked(Settings::values.enable_raw_input.GetValue());
 
     UpdateUIEnabled();
 }

--- a/src/yuzu/configuration/configure_input_advanced.ui
+++ b/src/yuzu/configuration/configure_input_advanced.ui
@@ -2672,6 +2672,22 @@
                  </property>
                 </widget>
                </item>
+               <item row="9" column="0">
+                 <widget class="QCheckBox" name="enable_raw_input">
+                   <property name="toolTip">
+                     <string>Requires restarting yuzu</string>
+                   </property>
+                   <property name="minimumSize">
+                     <size>
+                       <width>0</width>
+                       <height>23</height>
+                     </size>
+                   </property>
+                   <property name="text">
+                     <string>Enable XInput 8 player support (disables web applet)</string>
+                   </property>
+                 </widget>
+               </item>
               </layout>
              </widget>
             </item>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -557,7 +557,8 @@ void GMainWindow::WebBrowserOpenWebPage(const std::string& main_url,
                                         const std::string& additional_args, bool is_local) {
 #ifdef YUZU_USE_QT_WEB_ENGINE
 
-    if (disable_web_applet) {
+    // Raw input breaks with the web applet, Disable web applets if enabled
+    if (disable_web_applet || Settings::values.enable_raw_input) {
         emit WebBrowserClosed(Service::AM::Applets::WebExitReason::WindowClosed,
                               "http://localhost/");
         return;


### PR DESCRIPTION
I feel like experimenting today.  

Add a setting to enable 8 player support with xinput controllers since this was disabled because input stops working if the web applet opens. This setting will effectively disable the web applets.

Replace SDL config strings with the equivalent.

Log important settings that might affect gameplay