### PR TITLE
common: Move error handling functions out of common_funcs

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -53,6 +53,8 @@ add_library(common STATIC
     div_ceil.h
     dynamic_library.cpp
     dynamic_library.h
+    error.cpp
+    error.h
     fiber.cpp
     fiber.h
     fs/file.cpp
@@ -88,7 +90,6 @@ add_library(common STATIC
     microprofile.cpp
     microprofile.h
     microprofileui.h
-    misc.cpp
     nvidia_flags.cpp
     nvidia_flags.h
     page_table.cpp

--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include <algorithm>
 #include <array>
+#include <iterator>
 
 #if !defined(ARCHITECTURE_x86_64)
 #include <cstdlib> // for exit

--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -6,7 +6,6 @@
 
 #include <algorithm>
 #include <array>
-#include <string>
 
 #if !defined(ARCHITECTURE_x86_64)
 #include <cstdlib> // for exit
@@ -48,16 +47,6 @@ __declspec(dllimport) void __stdcall DebugBreak(void);
 #define Crash() DebugBreak()
 
 #endif // _MSC_VER ndef
-
-// Generic function to get last error message.
-// Call directly after the command or use the error num.
-// This function might change the error code.
-// Defined in misc.cpp.
-[[nodiscard]] std::string GetLastErrorMsg();
-
-// Like GetLastErrorMsg(), but passing an explicit error code.
-// Defined in misc.cpp.
-[[nodiscard]] std::string NativeErrorToString(int e);
 
 #define DECLARE_ENUM_FLAG_OPERATORS(type)                                                          \
     [[nodiscard]] constexpr type operator|(type a, type b) noexcept {                              \

--- a/src/common/error.cpp
+++ b/src/common/error.cpp
@@ -10,7 +10,9 @@
 #include <cstring>
 #endif
 
-#include "common/common_funcs.h"
+#include "common/error.h"
+
+namespace Common {
 
 std::string NativeErrorToString(int e) {
 #ifdef _WIN32
@@ -50,3 +52,5 @@ std::string GetLastErrorMsg() {
     return NativeErrorToString(errno);
 #endif
 }
+
+} // namespace Common

--- a/src/common/error.h
+++ b/src/common/error.h
@@ -1,0 +1,21 @@
+// Copyright 2013 Dolphin Emulator Project / 2014 Citra Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <string>
+
+namespace Common {
+
+// Generic function to get last error message.
+// Call directly after the command or use the error num.
+// This function might change the error code.
+// Defined in error.cpp.
+[[nodiscard]] std::string GetLastErrorMsg();
+
+// Like GetLastErrorMsg(), but passing an explicit error code.
+// Defined in error.cpp.
+[[nodiscard]] std::string NativeErrorToString(int e);
+
+} // namespace Common

--- a/src/common/thread.cpp
+++ b/src/common/thread.cpp
@@ -2,7 +2,9 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
-#include "common/common_funcs.h"
+#include <string>
+
+#include "common/error.h"
 #include "common/logging/log.h"
 #include "common/thread.h"
 #ifdef __APPLE__
@@ -20,8 +22,6 @@
 #ifndef _WIN32
 #include <unistd.h>
 #endif
-
-#include <string>
 
 #ifdef __FreeBSD__
 #define cpu_set_t cpuset_t

--- a/src/core/file_sys/kernel_executable.h
+++ b/src/core/file_sys/kernel_executable.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <string>
 #include <vector>
 
 #include "common/common_funcs.h"

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <array>
+#include <functional>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/src/core/network/network.cpp
+++ b/src/core/network/network.cpp
@@ -7,7 +7,8 @@
 #include <limits>
 #include <utility>
 #include <vector>
-#include "common/common_funcs.h"
+
+#include "common/error.h"
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -223,7 +224,7 @@ Errno GetAndLogLastError() {
     if (err == Errno::AGAIN) {
         return err;
     }
-    LOG_ERROR(Network, "Socket operation error: {}", NativeErrorToString(e));
+    LOG_ERROR(Network, "Socket operation error: {}", Common::NativeErrorToString(e));
     return err;
 }
 

--- a/src/video_core/command_classes/codecs/codec.h
+++ b/src/video_core/command_classes/codecs/codec.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <memory>
+#include <string_view>
 #include <queue>
 #include "common/common_types.h"
 #include "video_core/command_classes/nvdec_common.h"

--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
+
 #include "common/alignment.h"
 #include "common/assert.h"
 #include "common/logging/log.h"

--- a/src/video_core/renderer_vulkan/vk_descriptor_pool.cpp
+++ b/src/video_core/renderer_vulkan/vk_descriptor_pool.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <mutex>
 #include <span>
 #include <vector>

--- a/src/video_core/shader_environment.cpp
+++ b/src/video_core/shader_environment.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <memory>

--- a/src/video_core/texture_cache/slot_vector.h
+++ b/src/video_core/texture_cache/slot_vector.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <array>
 #include <bit>
 #include <concepts>


### PR DESCRIPTION
This avoids implicitly including `<string>` (and by extension `<string_view>`) in all files including common_funcs.h
While we're at it, we can also replace `<algorithm>` with `<iterator>` for `std::size` in common_funcs.h