### PR TITLE
hid/am: Stub SetTouchScreenConfiguration and implement GetNotificationStorageChannelEvent

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -1270,7 +1270,8 @@ void ILibraryAppletCreator::CreateHandleStorage(Kernel::HLERequestContext& ctx) 
 IApplicationFunctions::IApplicationFunctions(Core::System& system_)
     : ServiceFramework{system_, "IApplicationFunctions"}, gpu_error_detected_event{system.Kernel()},
       friend_invitation_storage_channel_event{system.Kernel()},
-      health_warning_disappeared_system_event{system.Kernel()} {
+      notification_storage_channel_event{system.Kernel()}, health_warning_disappeared_system_event{
+                                                               system.Kernel()} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {1, &IApplicationFunctions::PopLaunchParameter, "PopLaunchParameter"},
@@ -1322,7 +1323,7 @@ IApplicationFunctions::IApplicationFunctions(Core::System& system_)
         {131, nullptr, "SetDelayTimeToAbortOnGpuError"},
         {140, &IApplicationFunctions::GetFriendInvitationStorageChannelEvent, "GetFriendInvitationStorageChannelEvent"},
         {141, &IApplicationFunctions::TryPopFromFriendInvitationStorageChannel, "TryPopFromFriendInvitationStorageChannel"},
-        {150, nullptr, "GetNotificationStorageChannelEvent"},
+        {150, &IApplicationFunctions::GetNotificationStorageChannelEvent, "GetNotificationStorageChannelEvent"},
         {151, nullptr, "TryPopFromNotificationStorageChannel"},
         {160, &IApplicationFunctions::GetHealthWarningDisappearedSystemEvent, "GetHealthWarningDisappearedSystemEvent"},
         {170, nullptr, "SetHdcpAuthenticationActivated"},
@@ -1340,11 +1341,14 @@ IApplicationFunctions::IApplicationFunctions(Core::System& system_)
 
     Kernel::KAutoObject::Create(std::addressof(gpu_error_detected_event));
     Kernel::KAutoObject::Create(std::addressof(friend_invitation_storage_channel_event));
+    Kernel::KAutoObject::Create(std::addressof(notification_storage_channel_event));
     Kernel::KAutoObject::Create(std::addressof(health_warning_disappeared_system_event));
 
     gpu_error_detected_event.Initialize("IApplicationFunctions:GpuErrorDetectedSystemEvent");
     friend_invitation_storage_channel_event.Initialize(
         "IApplicationFunctions:FriendInvitationStorageChannelEvent");
+    notification_storage_channel_event.Initialize(
+        "IApplicationFunctions:NotificationStorageChannelEvent");
     health_warning_disappeared_system_event.Initialize(
         "IApplicationFunctions:HealthWarningDisappearedSystemEvent");
 }
@@ -1760,6 +1764,14 @@ void IApplicationFunctions::TryPopFromFriendInvitationStorageChannel(
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ERR_NO_DATA_IN_CHANNEL);
+}
+
+void IApplicationFunctions::GetNotificationStorageChannelEvent(Kernel::HLERequestContext& ctx) {
+    LOG_DEBUG(Service_AM, "called");
+
+    IPC::ResponseBuilder rb{ctx, 2, 1};
+    rb.Push(ResultSuccess);
+    rb.PushCopyObjects(notification_storage_channel_event.GetReadableEvent());
 }
 
 void IApplicationFunctions::GetHealthWarningDisappearedSystemEvent(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -295,6 +295,7 @@ private:
     void GetGpuErrorDetectedSystemEvent(Kernel::HLERequestContext& ctx);
     void GetFriendInvitationStorageChannelEvent(Kernel::HLERequestContext& ctx);
     void TryPopFromFriendInvitationStorageChannel(Kernel::HLERequestContext& ctx);
+    void GetNotificationStorageChannelEvent(Kernel::HLERequestContext& ctx);
     void GetHealthWarningDisappearedSystemEvent(Kernel::HLERequestContext& ctx);
 
     bool launch_popped_application_specific = false;
@@ -302,6 +303,7 @@ private:
     s32 previous_program_index{-1};
     Kernel::KEvent gpu_error_detected_event;
     Kernel::KEvent friend_invitation_storage_channel_event;
+    Kernel::KEvent notification_storage_channel_event;
     Kernel::KEvent health_warning_disappeared_system_event;
 };
 

--- a/src/core/hle/service/hid/controllers/touchscreen.h
+++ b/src/core/hle/service/hid/controllers/touchscreen.h
@@ -15,6 +15,20 @@
 namespace Service::HID {
 class Controller_Touchscreen final : public ControllerBase {
 public:
+    enum class TouchScreenModeForNx : u8 {
+        UseSystemSetting,
+        Finger,
+        Heat2,
+    };
+
+    struct TouchScreenConfigurationForNx {
+        TouchScreenModeForNx mode;
+        INSERT_PADDING_BYTES_NOINIT(0x7);
+        INSERT_PADDING_BYTES_NOINIT(0xF); // Reserved
+    };
+    static_assert(sizeof(TouchScreenConfigurationForNx) == 0x17,
+                  "TouchScreenConfigurationForNx is an invalid size");
+
     explicit Controller_Touchscreen(Core::System& system_);
     ~Controller_Touchscreen() override;
 

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -331,7 +331,7 @@ Hid::Hid(Core::System& system_)
         {529, nullptr, "SetDisallowedPalmaConnection"},
         {1000, &Hid::SetNpadCommunicationMode, "SetNpadCommunicationMode"},
         {1001, &Hid::GetNpadCommunicationMode, "GetNpadCommunicationMode"},
-        {1002, nullptr, "SetTouchScreenConfiguration"},
+        {1002, &Hid::SetTouchScreenConfiguration, "SetTouchScreenConfiguration"},
         {1003, nullptr, "IsFirmwareUpdateNeededForNotification"},
         {2000, nullptr, "ActivateDigitizer"},
     };
@@ -1629,6 +1629,18 @@ void Hid::GetNpadCommunicationMode(Kernel::HLERequestContext& ctx) {
     rb.Push(ResultSuccess);
     rb.PushEnum(applet_resource->GetController<Controller_NPad>(HidController::NPad)
                     .GetNpadCommunicationMode());
+}
+
+void Hid::SetTouchScreenConfiguration(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto touchscreen_mode{rp.PopRaw<Controller_Touchscreen::TouchScreenConfigurationForNx>()};
+    const auto applet_resource_user_id{rp.Pop<u64>()};
+
+    LOG_WARNING(Service_HID, "(STUBBED) called, touchscreen_mode={}, applet_resource_user_id={}",
+                touchscreen_mode.mode, applet_resource_user_id);
+
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(ResultSuccess);
 }
 
 class HidDbg final : public ServiceFramework<HidDbg> {

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -159,6 +159,7 @@ private:
     void SetPalmaBoostMode(Kernel::HLERequestContext& ctx);
     void SetNpadCommunicationMode(Kernel::HLERequestContext& ctx);
     void GetNpadCommunicationMode(Kernel::HLERequestContext& ctx);
+    void SetTouchScreenConfiguration(Kernel::HLERequestContext& ctx);
 
     enum class VibrationDeviceType : u32 {
         Unknown = 0,


### PR DESCRIPTION
Both functions are needed for `Dr Kawashima’s Brain Training for Nintendo Switch` to boot 