### PR TITLE
main: Apply confirm exit setting in exit locked scenarios

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3174,12 +3174,11 @@ std::optional<u64> GMainWindow::SelectRomFSDumpTarget(const FileSys::ContentProv
 }
 
 bool GMainWindow::ConfirmClose() {
-    if (emu_thread == nullptr || !UISettings::values.confirm_before_closing)
+    if (emu_thread == nullptr || !UISettings::values.confirm_before_closing) {
         return true;
-
-    QMessageBox::StandardButton answer =
-        QMessageBox::question(this, tr("yuzu"), tr("Are you sure you want to close yuzu?"),
-                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+    }
+    const auto text = tr("Are you sure you want to close yuzu?");
+    const auto answer = QMessageBox::question(this, tr("yuzu"), text);
     return answer != QMessageBox::No;
 }
 
@@ -3261,14 +3260,13 @@ bool GMainWindow::ConfirmChangeGame() {
 }
 
 bool GMainWindow::ConfirmForceLockedExit() {
-    if (emu_thread == nullptr)
+    if (emu_thread == nullptr || !UISettings::values.confirm_before_closing) {
         return true;
+    }
+    const auto text = tr("The currently running application has requested yuzu to not exit.\n\n"
+                         "Would you like to bypass this and exit anyway?");
 
-    const auto answer =
-        QMessageBox::question(this, tr("yuzu"),
-                              tr("The currently running application has requested yuzu to not "
-                                 "exit.\n\nWould you like to bypass this and exit anyway?"),
-                              QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+    const auto answer = QMessageBox::question(this, tr("yuzu"), text);
     return answer != QMessageBox::No;
 }
 


### PR DESCRIPTION
Some titles set an exit lock through HLE, which prompts an exit confirmation when stopping emulation if the system is locked.

This change allows bypassing this confirmation if the setting to confirm exits has been disabled by the user.