### PR TITLE
vk_rasterizer: Fix dynamic StencilOp updating when two faces are enabled

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -765,12 +765,7 @@ void RasterizerVulkan::UpdateStencilOp(Tegra::Engines::Maxwell3D::Regs& regs) {
     const Maxwell::StencilOp zpass = regs.stencil_front_op_zpass;
     const Maxwell::ComparisonOp compare = regs.stencil_front_func_func;
     if (regs.stencil_two_side_enable) {
-        scheduler.Record([fail, zfail, zpass, compare](vk::CommandBuffer cmdbuf) {
-            cmdbuf.SetStencilOpEXT(VK_STENCIL_FACE_FRONT_AND_BACK, MaxwellToVK::StencilOp(fail),
-                                   MaxwellToVK::StencilOp(zpass), MaxwellToVK::StencilOp(zfail),
-                                   MaxwellToVK::ComparisonOp(compare));
-        });
-    } else {
+        // Separate stencil op per face
         const Maxwell::StencilOp back_fail = regs.stencil_back_op_fail;
         const Maxwell::StencilOp back_zfail = regs.stencil_back_op_zfail;
         const Maxwell::StencilOp back_zpass = regs.stencil_back_op_zpass;
@@ -784,6 +779,13 @@ void RasterizerVulkan::UpdateStencilOp(Tegra::Engines::Maxwell3D::Regs& regs) {
                                    MaxwellToVK::StencilOp(back_zpass),
                                    MaxwellToVK::StencilOp(back_zfail),
                                    MaxwellToVK::ComparisonOp(back_compare));
+        });
+    } else {
+        // Front face defines the stencil op of both faces
+        scheduler.Record([fail, zfail, zpass, compare](vk::CommandBuffer cmdbuf) {
+            cmdbuf.SetStencilOpEXT(VK_STENCIL_FACE_FRONT_AND_BACK, MaxwellToVK::StencilOp(fail),
+                                   MaxwellToVK::StencilOp(zpass), MaxwellToVK::StencilOp(zfail),
+                                   MaxwellToVK::ComparisonOp(compare));
         });
     }
 }


### PR DESCRIPTION
This function was incorrectly using the stencil_two_side_enable register when dynamically updating the StencilOp.

Fixes missing graphics in `WarioWare: Get It Together!` when using the Vulkan API

Before |  After
:-------------------------:|:-------------------------: 
![wario-bug](https://user-images.githubusercontent.com/52414509/133000174-af39ae3e-8e58-45f0-8562-512214761fa2.png) | ![wario-fix](https://user-images.githubusercontent.com/52414509/133000178-6ae15552-9024-40d3-abd6-9c3eaa8b58f8.png)

