### PR TITLE
vk_swapchain: Use immediate present mode when mailbox is unavailable and FPS is unlocked

### DIFF
--- a/src/video_core/renderer_vulkan/renderer_vulkan.cpp
+++ b/src/video_core/renderer_vulkan/renderer_vulkan.cpp
@@ -149,7 +149,7 @@ void RendererVulkan::SwapBuffers(const Tegra::FramebufferConfig* framebuffer) {
         const Layout::FramebufferLayout layout = render_window.GetFramebufferLayout();
         swapchain.Create(layout.width, layout.height, is_srgb);
     };
-    if (swapchain.IsSubOptimal() || swapchain.HasColorSpaceChanged(is_srgb)) {
+    if (swapchain.NeedsRecreation(is_srgb)) {
         recreate_swapchain();
     }
     bool is_outdated;

--- a/src/video_core/renderer_vulkan/vk_swapchain.h
+++ b/src/video_core/renderer_vulkan/vk_swapchain.h
@@ -33,6 +33,11 @@ public:
     /// Presents the rendered image to the swapchain.
     void Present(VkSemaphore render_semaphore);
 
+    /// Returns true when the swapchain needs to be recreated.
+    bool NeedsRecreation(bool is_srgb) const {
+        return HasColorSpaceChanged(is_srgb) || IsSubOptimal() || NeedsPresentModeUpdate();
+    }
+
     /// Returns true when the color space has changed.
     bool HasColorSpaceChanged(bool is_srgb) const {
         return current_srgb != is_srgb;
@@ -84,6 +89,10 @@ private:
 
     void Destroy();
 
+    bool HasFpsUnlockChanged() const;
+
+    bool NeedsPresentModeUpdate() const;
+
     const VkSurfaceKHR surface;
     const Device& device;
     VKScheduler& scheduler;
@@ -102,8 +111,10 @@ private:
 
     VkFormat image_view_format{};
     VkExtent2D extent{};
+    VkPresentModeKHR present_mode{};
 
     bool current_srgb{};
+    bool current_fps_unlocked{};
     bool is_outdated{};
     bool is_suboptimal{};
 };


### PR DESCRIPTION
Allows supported drivers that do not support `VK_PRESENT_MODE_MAILBOX_KHR` the ability to present at a framerate higher than the monitor's refresh rate when the FPS is unlocked.

Note that this may cause visible tearing as frames are always presented as they are complete without waiting for a vertical blank.