### PR TITLE
common_funcs: Add enum flag bitwise shift operator overloads

### DIFF
--- a/src/common/common_funcs.h
+++ b/src/common/common_funcs.h
@@ -61,6 +61,14 @@ __declspec(dllimport) void __stdcall DebugBreak(void);
         using T = std::underlying_type_t<type>;                                                    \
         return static_cast<type>(static_cast<T>(a) ^ static_cast<T>(b));                           \
     }                                                                                              \
+    [[nodiscard]] constexpr type operator<<(type a, type b) noexcept {                             \
+        using T = std::underlying_type_t<type>;                                                    \
+        return static_cast<type>(static_cast<T>(a) << static_cast<T>(b));                          \
+    }                                                                                              \
+    [[nodiscard]] constexpr type operator>>(type a, type b) noexcept {                             \
+        using T = std::underlying_type_t<type>;                                                    \
+        return static_cast<type>(static_cast<T>(a) >> static_cast<T>(b));                          \
+    }                                                                                              \
     constexpr type& operator|=(type& a, type b) noexcept {                                         \
         a = a | b;                                                                                 \
         return a;                                                                                  \
@@ -71,6 +79,14 @@ __declspec(dllimport) void __stdcall DebugBreak(void);
     }                                                                                              \
     constexpr type& operator^=(type& a, type b) noexcept {                                         \
         a = a ^ b;                                                                                 \
+        return a;                                                                                  \
+    }                                                                                              \
+    constexpr type& operator<<=(type& a, type b) noexcept {                                        \
+        a = a << b;                                                                                \
+        return a;                                                                                  \
+    }                                                                                              \
+    constexpr type& operator>>=(type& a, type b) noexcept {                                        \
+        a = a >> b;                                                                                \
         return a;                                                                                  \
     }                                                                                              \
     [[nodiscard]] constexpr type operator~(type key) noexcept {                                    \


### PR DESCRIPTION
This adds bitwise shift operator overloads (<<, >>, <<=, >>=) in the macro DECLARE_ENUM_FLAG_OPERATORS(type)