### PR TITLE
vulkan_debug_callback: Ignore InvalidCommandBuffer-VkDescriptorSet errors

### DIFF
--- a/src/video_core/vulkan_common/vulkan_debug_callback.cpp
+++ b/src/video_core/vulkan_common/vulkan_debug_callback.cpp
@@ -16,6 +16,7 @@ VkBool32 Callback(VkDebugUtilsMessageSeverityFlagBitsEXT severity,
     switch (static_cast<u32>(data->messageIdNumber)) {
     case 0x682a878au: // VUID-vkCmdBindVertexBuffers2EXT-pBuffers-parameter
     case 0x99fb7dfdu: // UNASSIGNED-RequiredParameter (vkCmdBindVertexBuffers2EXT pBuffers[0])
+    case 0xe8616bf2u: // Bound VkDescriptorSet 0x0[] was destroyed. Likely push_descriptor related
         return VK_FALSE;
     default:
         break;


### PR DESCRIPTION
This validation error is spammed on some titles, asserting that VkDescriptorSet 0x0[] was destroyed.

This is likely a validation layer bug when using VK_KHR_push_descriptor, which can avoid using traditional VkDescriptorSet (hence the VkDescriptorSet address is 0x0). It should be safe to ignore for now.