### PR TITLE
Detect depth mode by viewport

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -566,10 +566,8 @@ void RasterizerOpenGL::SyncViewport() {
         if (regs.screen_y_control.y_negate != 0) {
             flip_y = !flip_y;
         }
-        const bool is_zero_to_one = regs.depth_mode == Maxwell::DepthMode::ZeroToOne;
         const GLenum origin = flip_y ? GL_UPPER_LEFT : GL_LOWER_LEFT;
-        const GLenum depth = is_zero_to_one ? GL_ZERO_TO_ONE : GL_NEGATIVE_ONE_TO_ONE;
-        state_tracker.ClipControl(origin, depth);
+        state_tracker.SetOrigin(origin);
         state_tracker.SetYNegate(regs.screen_y_control.y_negate != 0);
     }
 
@@ -593,6 +591,15 @@ void RasterizerOpenGL::SyncViewport() {
             const GLdouble reduce_z = regs.depth_mode == Maxwell::DepthMode::MinusOneToOne;
             const GLdouble near_depth = src.translate_z - src.scale_z * reduce_z;
             const GLdouble far_depth = src.translate_z + src.scale_z;
+            if (i == 0) {
+                const auto& viewports = regs.viewports[i];
+                const GLenum depth = viewports.depth_range_near != src.translate_z &&
+                                             viewports.depth_range_far != src.translate_z
+                                         ? GL_NEGATIVE_ONE_TO_ONE
+                                         : GL_ZERO_TO_ONE;
+                state_tracker.SetDepthMode(depth);
+            }
+
             if (device.HasDepthBufferFloat()) {
                 glDepthRangeIndexeddNV(static_cast<GLuint>(i), near_depth, far_depth);
             } else {

--- a/src/video_core/renderer_opengl/gl_state_tracker.h
+++ b/src/video_core/renderer_opengl/gl_state_tracker.h
@@ -112,6 +112,22 @@ public:
         glClipControl(origin, depth);
     }
 
+    void SetOrigin(GLenum new_origin) {
+        if (new_origin == origin) {
+            return;
+        }
+        origin = new_origin;
+        glClipControl(origin, depth);
+    }
+
+    void SetDepthMode(GLenum new_depth) {
+        if (new_depth == depth) {
+            return;
+        }
+        depth = new_depth;
+        glClipControl(origin, depth);
+    }
+
     void SetYNegate(bool new_y_negate) {
         if (new_y_negate == y_negate) {
             return;


### PR DESCRIPTION
This PR aims to solve the blurred of ZLA in opengl mode.

By capturing the data using Renderdoc, the cause of the blurring is that one frame of data tried to drawing through 4 textures (see below), but there was an error in the depth texture that caused the blurred texture copy area to be calculated incorrectly.

![image](https://user-images.githubusercontent.com/3349963/133278499-56cf6f90-d63a-4bdb-9dc8-cceaaa6c2692.png)

According to my guess there should be a problem with the depth mode in the register. Currently I dynamically determine the value of the depth mode by comparing the values of viewport transform and viewport.

Before:
![image](https://user-images.githubusercontent.com/3349963/133280166-52f95733-5e01-4b22-9e13-58dd7ec510f2.png)

After:
![image](https://user-images.githubusercontent.com/3349963/133279290-2963f735-415d-4a45-8961-85c1233f0cd1.png)

