### PR TITLE
Spir-V: Rescale the frag depth to 0,1 mode when -1,1 mode is used in Vulkan.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -477,7 +477,13 @@ void EmitSetSampleMask(EmitContext& ctx, Id value) {
 }
 
 void EmitSetFragDepth(EmitContext& ctx, Id value) {
-    ctx.OpStore(ctx.frag_depth, value);
+    if (!ctx.runtime_info.convert_depth_mode) {
+        ctx.OpStore(ctx.frag_depth, value);
+        return;
+    }
+    const Id unit{ctx.Const(0.5f)};
+    const Id new_depth{ctx.OpFma(ctx.F32[1], value, unit, unit)};
+    ctx.OpStore(ctx.frag_depth, new_depth);
 }
 
 void EmitGetZFlag(EmitContext&) {


### PR DESCRIPTION
This fixes Shadows in UE4 games on Vulkan.