### PR TITLE
Remove audio stretching

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -61,7 +61,6 @@ void LogSettings() {
     log_setting("Renderer_UseAsynchronousShaders", values.use_asynchronous_shaders.GetValue());
     log_setting("Renderer_AnisotropicFilteringLevel", values.max_anisotropy.GetValue());
     log_setting("Audio_OutputEngine", values.sink_id.GetValue());
-    log_setting("Audio_EnableAudioStretching", values.enable_audio_stretching.GetValue());
     log_setting("Audio_OutputDevice", values.audio_device_id.GetValue());
     log_setting("DataStorage_UseVirtualSd", values.use_virtual_sd.GetValue());
     log_path("DataStorage_CacheDir", Common::FS::GetYuzuPath(Common::FS::YuzuPath::CacheDir));
@@ -111,9 +110,7 @@ void RestoreGlobalState(bool is_powered_on) {
         return;
     }
 
-    // Audio
-    values.enable_audio_stretching.SetGlobal(true);
-    values.volume.SetGlobal(true);
+    // Audio: None
 
     // Core
     values.use_multi_core.SetGlobal(true);

--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -110,7 +110,8 @@ void RestoreGlobalState(bool is_powered_on) {
         return;
     }
 
-    // Audio: None
+    // Audio
+    values.volume.SetGlobal(true);
 
     // Core
     values.use_multi_core.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -415,7 +415,6 @@ struct Values {
     BasicSetting<std::string> audio_device_id{"auto", "output_device"};
     BasicSetting<std::string> sink_id{"auto", "output_engine"};
     BasicSetting<bool> audio_muted{false, "audio_muted"};
-    Setting<bool> enable_audio_stretching{true, "enable_audio_stretching"};
     RangedSetting<u8> volume{100, 0, 100, "volume"};
 
     // Core

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -226,8 +226,6 @@ void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader,
     // Log user configuration information
     constexpr auto field_type = Telemetry::FieldType::UserConfig;
     AddField(field_type, "Audio_SinkId", Settings::values.sink_id.GetValue());
-    AddField(field_type, "Audio_EnableAudioStretching",
-             Settings::values.enable_audio_stretching.GetValue());
     AddField(field_type, "Core_UseMultiCore", Settings::values.use_multi_core.GetValue());
     AddField(field_type, "Renderer_Backend",
              TranslateRenderer(Settings::values.renderer_backend.GetValue()));

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -542,7 +542,6 @@ void Config::ReadAudioValues() {
         ReadBasicSetting(Settings::values.audio_device_id);
         ReadBasicSetting(Settings::values.sink_id);
     }
-    ReadGlobalSetting(Settings::values.enable_audio_stretching);
     ReadGlobalSetting(Settings::values.volume);
 
     qt_config->endGroup();
@@ -1163,7 +1162,6 @@ void Config::SaveAudioValues() {
         WriteBasicSetting(Settings::values.sink_id);
         WriteBasicSetting(Settings::values.audio_device_id);
     }
-    WriteGlobalSetting(Settings::values.enable_audio_stretching);
     WriteGlobalSetting(Settings::values.volume);
 
     qt_config->endGroup();

--- a/src/yuzu/configuration/configure_audio.cpp
+++ b/src/yuzu/configuration/configure_audio.cpp
@@ -50,8 +50,6 @@ void ConfigureAudio::SetConfiguration() {
     const auto volume_value = static_cast<int>(Settings::values.volume.GetValue());
     ui->volume_slider->setValue(volume_value);
 
-    ui->toggle_audio_stretching->setChecked(Settings::values.enable_audio_stretching.GetValue());
-
     if (!Settings::IsConfiguringGlobal()) {
         if (Settings::values.volume.UsingGlobal()) {
             ui->volume_combo_box->setCurrentIndex(0);
@@ -100,8 +98,6 @@ void ConfigureAudio::SetVolumeIndicatorText(int percentage) {
 }
 
 void ConfigureAudio::ApplyConfiguration() {
-    ConfigurationShared::ApplyPerGameSetting(&Settings::values.enable_audio_stretching,
-                                             ui->toggle_audio_stretching, enable_audio_stretching);
 
     if (Settings::IsConfiguringGlobal()) {
         Settings::values.sink_id =
@@ -162,15 +158,10 @@ void ConfigureAudio::RetranslateUI() {
 void ConfigureAudio::SetupPerGameUI() {
     if (Settings::IsConfiguringGlobal()) {
         ui->volume_slider->setEnabled(Settings::values.volume.UsingGlobal());
-        ui->toggle_audio_stretching->setEnabled(
-            Settings::values.enable_audio_stretching.UsingGlobal());
 
         return;
     }
 
-    ConfigurationShared::SetColoredTristate(ui->toggle_audio_stretching,
-                                            Settings::values.enable_audio_stretching,
-                                            enable_audio_stretching);
     connect(ui->volume_combo_box, qOverload<int>(&QComboBox::activated), this, [this](int index) {
         ui->volume_slider->setEnabled(index == 1);
         ConfigurationShared::SetHighlight(ui->volume_layout, index == 1);

--- a/src/yuzu/configuration/configure_audio.h
+++ b/src/yuzu/configuration/configure_audio.h
@@ -41,5 +41,4 @@ private:
     void SetupPerGameUI();
 
     std::unique_ptr<Ui::ConfigureAudio> ui;
-
 };

--- a/src/yuzu/configuration/configure_audio.h
+++ b/src/yuzu/configuration/configure_audio.h
@@ -42,5 +42,4 @@ private:
 
     std::unique_ptr<Ui::ConfigureAudio> ui;
 
-    ConfigurationShared::CheckState enable_audio_stretching;
 };

--- a/src/yuzu/configuration/configure_audio.ui
+++ b/src/yuzu/configuration/configure_audio.ui
@@ -32,16 +32,6 @@
        </layout>
       </item>
       <item>
-       <widget class="QCheckBox" name="toggle_audio_stretching">
-        <property name="toolTip">
-         <string>This post-processing effect adjusts audio speed to match emulation speed and helps prevent audio stutter. This however increases audio latency.</string>
-        </property>
-        <property name="text">
-         <string>Enable audio stretching</string>
-        </property>
-       </widget>
-      </item>
-      <item>
        <layout class="QHBoxLayout" name="_2">
         <item>
          <widget class="QLabel" name="audio_device_label">

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -475,7 +475,6 @@ void Config::ReadValues() {
 
     // Audio
     ReadSetting("Audio", Settings::values.sink_id);
-    ReadSetting("Audio", Settings::values.enable_audio_stretching);
     ReadSetting("Audio", Settings::values.audio_device_id);
     ReadSetting("Audio", Settings::values.volume);
 


### PR DESCRIPTION
Removes the "Enable audio stretching" setting, as it is not utilized anymore. Also removes it from the setting read from the logs