### PR TITLE
vulkan_device: Reorder Float16Int8 declaration

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -368,8 +368,9 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     };
     SetNext(next, demote);
 
+    VkPhysicalDeviceFloat16Int8FeaturesKHR float16_int8;
     if (is_int8_supported || is_float16_supported) {
-        VkPhysicalDeviceFloat16Int8FeaturesKHR float16_int8{
+        float16_int8 = {
             .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT16_INT8_FEATURES_KHR,
             .pNext = nullptr,
             .shaderFloat16 = is_float16_supported,

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -243,7 +243,6 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     SetupFamilies(surface);
     SetupFeatures();
     SetupProperties();
-    CollectTelemetryParameters();
 
     const auto queue_cis = GetDeviceQueueCreateInfos();
     const std::vector extensions = LoadExtensions(surface != nullptr);
@@ -368,18 +367,6 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
         .shaderDemoteToHelperInvocation = true,
     };
     SetNext(next, demote);
-
-    if (driver_id == VK_DRIVER_ID_AMD_PROPRIETARY || driver_id == VK_DRIVER_ID_AMD_OPEN_SOURCE) {
-        const u32 version = properties.driverVersion;
-        // Broken in this driver
-        if (version > VK_MAKE_API_VERSION(0, 2, 0, 193)) {
-            LOG_WARNING(Render_Vulkan, "AMD proprietary driver versions newer than 21.9.1 "
-                                       "(windows) / 0.2.0.194 (amdvlk) have "
-                                       "broken VkPhysicalDeviceFloat16Int8FeaturesKHR");
-            is_int8_supported = false;
-            is_float16_supported = false;
-        }
-    }
 
     if (is_int8_supported || is_float16_supported) {
         VkPhysicalDeviceFloat16Int8FeaturesKHR float16_int8{
@@ -573,6 +560,7 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     logical = vk::Device::Create(physical, queue_cis, extensions, first_next, dld);
 
     CollectPhysicalMemoryInfo();
+    CollectTelemetryParameters();
     CollectToolingInfo();
 
     if (driver_id == VK_DRIVER_ID_NVIDIA_PROPRIETARY_KHR) {


### PR DESCRIPTION
This variable was going out of scope before its usage in the vulkan device creation, causing a crash on very specific drivers, notably recent proprietary AMD drivers.