### PR TITLE
Hide XInput bypass on non-Windows OSes

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -560,7 +560,11 @@ void Config::ReadControlValues() {
     ReadTouchscreenValues();
     ReadMotionTouchValues();
 
+#ifdef _WIN32
     ReadBasicSetting(Settings::values.enable_raw_input);
+#else
+    Settings::values.enable_raw_input = false;
+#endif
     ReadBasicSetting(Settings::values.emulate_analog_keyboard);
     Settings::values.mouse_panning = false;
     ReadBasicSetting(Settings::values.mouse_panning_sensitivity);

--- a/src/yuzu/configuration/configure_input_advanced.cpp
+++ b/src/yuzu/configuration/configure_input_advanced.cpp
@@ -88,6 +88,10 @@ ConfigureInputAdvanced::ConfigureInputAdvanced(QWidget* parent)
     connect(ui->buttonMotionTouch, &QPushButton::clicked, this,
             &ConfigureInputAdvanced::CallMotionTouchConfigDialog);
 
+#ifndef _WIN32
+    ui->enable_raw_input->setVisible(false);
+#endif
+
     LoadConfiguration();
 }
 


### PR DESCRIPTION
Follow-up to #6950. This option is a no-op on other OSes and only serves to spread confusion there.