### PR TITLE
Added unnecessary hex conversion optimizations

### DIFF
--- a/src/common/hex_util.h
+++ b/src/common/hex_util.h
@@ -15,15 +15,11 @@
 namespace Common {
 
 [[nodiscard]] constexpr u8 ToHexNibble(char c) {
-    if (c >= 65 && c <= 70) {
-        return static_cast<u8>(c - 55);
-    }
-
-    if (c >= 97 && c <= 102) {
-        return static_cast<u8>(c - 87);
-    }
-
-    return static_cast<u8>(c - 48);
+    c ^= '0'; // cut of high nibble for only '0' <= c <= '9'
+    // if c > 9 keep low nibble and add 9.
+    // 'A' = 0x41. 0x41 & 7 = 1. 1 + 9 = 0xA
+    // 'a' = 0x61. 0x61 & 7 = 1. 1 + 9 = 0xA
+    return c & ~0xf ? (c & 7) + 9 : c;
 }
 
 [[nodiscard]] std::vector<u8> HexStringToVector(std::string_view str, bool little_endian);


### PR DESCRIPTION
Muh nanoseconds.

If the cast is necessary before returning let me know and I'll add it. I didn't seem to get any warning for it but I currently have it mixed in with other changes that causes the build to fail so I don't fully know if it will or not.

Here's the proof for the monstrosity. Oddly enough it generates better assembly with the parameter/return type you see in the link. It won't really matter since this is guaranteed to be inlined. [godbolt](https://gcc.godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGISQAcpK4AMngMmAByPgBGmMQgZgCspAAOqAqETgwe3r7%2BQemZjgJhEdEscQnJtpj2JQxCBEzEBLk%2BfoG19dlNLQRlUbHxiSkKza3t%2BV3j/YMVVaMAlLaoXsTI7BwA9NsA1AAqAJ6pmHtHa8R7aFh7CPGYpHske7SoTOh7hnuYqqyp9AAdCYNABBcwAZnCyG8txMELcyHG%2BEE8OwIPBZihDBhXjhCKc42ImFYaIxkOhsLO8LcRPCwDJYIpOKpexpaBxmFSBAUjNBs0cyD2XgYmWAEU%2BbyMewAXqQAO7wqxMsFeTLSrwBNkQgAiwvCBACAH0CEryWCDYdUAAJX6RPAxGL0CAG7nEE17VRLNkAdmVoL2gc9bKS6N1ezAHA0kbNYKDe2JBHWDGD5gAbHsAH4aVRUbUAMT2EFUewAtHsfd703suEk9iBPbHwT6debwSrQZaWExwhAq36MfH%2BFcIMgEC1rtq9ZHoxwlZOafDpxwAJwxiEWa7WaxLQfxoPIkAoNYEbVuGl7Q8gIhGulGCAHG12h1OzCjpZVhEXyMRucbveBleaBeAQgKpCBEAxkkbgMJGu7/nGQbDkWY4TkKS6/qC66buhX7hpG%2BbYVulg7gB%2B5ASeZ4XleN53sAD5Pqo9qOs6yAflRCK/r%2BTbxhRIFgRBUEwXBPFIS8o7jlcuHLkwRG4ee%2BEcFQcnbpYu6Iful4EOgR7Aaei6cTRqC3gQxD0gxtpMS%2BrHsQZbhcdh5IthwKy0JwSS8H4Ua8KgnDniRliXpcmxsliPCkAQmguSsADWIAQhCgIJclKWpWm%2BicJInlRaQvkcLwCggBoEVRSscCwEgaAsKkdDxOQlBVTV9AJDChjAFwZgaFwfB0AQ8SFRAMQ5TE4QtEcnDhVVbCCAA8gwtDjd5pBYN2RjiEt%2BDEg4eAAG6YIVS2/JgyAgVsWjkIIdQ5bQDrEGNHhYDlpl4CwE0uXwBjAAoABqeCYPKM2nF54X8IIIhiOwUgyIIigqOoS26N1BhGCgqk2DdMSFZAKyoNy2QHaWyJLqYAUWJ1ZYzRCBV1MdDQuAw7ieB0eihOEQyVCM3VFFkAhTH4XMZDzDDzMMCTdXYtO9BMbRM/k4s09tAh9K0Isc2LtjS3zeizCrbMLJzKwKMFkMRcSWw8K57nZUteWqAEaalmmkjXMjwA1mYgIaICXBFv5ViWE8uCEC8kLdXsHjVbVVyh0svCRd5H6kHFCVJalacJelbkcFlpBeedeUFUVJUJ6Q5WICAR0nUQZAUBALRfcohh1EICCoPKwO8I1dBMA0jcRLQLdt3nneoJHzUgO1HWkF3zUzSBg/tzllegsQX2cLwldNCi6/Q8IojiFDoPyEoag5Yj%2BhtajpP6A6WN9rleMCAdBXG9r2nhH3zet4v3Bx2bb0KjuqkN6lsOAeVzjlPK2BVDHRAi8O2DsnZ7GAMgIUXAuCAjML7NGgd8DV1ChCLgsdi5aETsnRK6d04ZWztbfOO9CrFXjqQ0BZhaE%2BR3kw6KpA9rEEyM4SQQA)