### PR TITLE
buffer_cache, maxwell_dma: Minor refactoring and code fixes

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -570,13 +570,12 @@ bool BufferCache<P>::DMACopy(GPUVAddr src_address, GPUVAddr dest_address, u64 am
     ForEachWrittenRange(*cpu_src_address, amount, mirror);
     // This subtraction in this order is important for overlapping copies.
     common_ranges.subtract(subtract_interval);
-    bool atleast_1_download = tmp_intervals.size() != 0;
-    for (const IntervalType add_interval : tmp_intervals) {
+    const bool has_new_downloads = tmp_intervals.size() != 0;
+    for (const IntervalType& add_interval : tmp_intervals) {
         common_ranges.add(add_interval);
     }
-
     runtime.CopyBuffer(dest_buffer, src_buffer, copies);
-    if (atleast_1_download) {
+    if (has_new_downloads) {
         dest_buffer.MarkRegionAsGpuModified(*cpu_dest_address, amount);
     }
     std::vector<u8> tmp_buffer(amount);

--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -175,7 +175,7 @@ public:
     static_assert(sizeof(LaunchDMA) == 4);
 
     struct RemapConst {
-        enum Swizzle : u32 {
+        enum class Swizzle : u32 {
             SRC_X = 0,
             SRC_Y = 1,
             SRC_Z = 2,

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -147,8 +147,7 @@ void BufferCacheRuntime::CopyBuffer(Buffer& dst_buffer, Buffer& src_buffer,
 
 void BufferCacheRuntime::ClearBuffer(Buffer& dest_buffer, u32 offset, size_t size, u32 value) {
     glClearNamedBufferSubData(dest_buffer.Handle(), GL_R32UI, static_cast<GLintptr>(offset),
-                              static_cast<GLsizeiptr>(size / sizeof(u32)), GL_RED, GL_UNSIGNED_INT,
-                              &value);
+                              static_cast<GLsizeiptr>(size), GL_RED, GL_UNSIGNED_INT, &value);
 }
 
 void BufferCacheRuntime::BindIndexBuffer(Buffer& buffer, u32 offset, u32 size) {


### PR DESCRIPTION
This change brings some minor refactoring for code clarity, behavior is unchanged save for a few small fixes:
The size calculation for the buffer clear in OpenGL (the size is expected to be in bytes), 
and a minor fix to loop through DMA copy intervals by reference.