### PR TITLE
common/uuid: Add validity checking functions to interface

### DIFF
--- a/src/common/uuid.h
+++ b/src/common/uuid.h
@@ -58,6 +58,13 @@ struct UUID {
         uuid = INVALID_UUID;
     }
 
+    [[nodiscard]] constexpr bool IsInvalid() const {
+        return uuid == INVALID_UUID;
+    }
+    [[nodiscard]] constexpr bool IsValid() const {
+        return !IsInvalid();
+    }
+
     // TODO(ogniK): Properly generate a Nintendo ID
     [[nodiscard]] constexpr u64 GetNintendoID() const {
         return uuid[0];

--- a/src/core/frontend/applets/profile_select.cpp
+++ b/src/core/frontend/applets/profile_select.cpp
@@ -13,7 +13,8 @@ ProfileSelectApplet::~ProfileSelectApplet() = default;
 void DefaultProfileSelectApplet::SelectProfile(
     std::function<void(std::optional<Common::UUID>)> callback) const {
     Service::Account::ProfileManager manager;
-    callback(manager.GetUser(Settings::values.current_user.GetValue()).value_or(Common::UUID{}));
+    callback(manager.GetUser(Settings::values.current_user.GetValue())
+                 .value_or(Common::UUID{Common::INVALID_UUID}));
     LOG_INFO(Service_ACC, "called, selecting current user instead of prompting...");
 }
 

--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -929,8 +929,7 @@ void Module::Interface::TrySelectUserWithoutInteraction(Kernel::HLERequestContex
     }
 
     const auto user_list = profile_manager->GetAllUsers();
-    if (std::all_of(user_list.begin(), user_list.end(),
-                    [](const auto& user) { return user.uuid == Common::INVALID_UUID; })) {
+    if (std::ranges::all_of(user_list, [](const auto& user) { return user.IsInvalid(); })) {
         rb.Push(ResultUnknown); // TODO(ogniK): Find the correct error code
         rb.PushRaw<u128>(Common::INVALID_UUID);
         return;

--- a/src/core/hle/service/acc/profile_manager.cpp
+++ b/src/core/hle/service/acc/profile_manager.cpp
@@ -208,9 +208,10 @@ bool ProfileManager::UserExists(UUID uuid) const {
 }
 
 bool ProfileManager::UserExistsIndex(std::size_t index) const {
-    if (index >= MAX_USERS)
+    if (index >= MAX_USERS) {
         return false;
-    return profiles[index].user_uuid.uuid != Common::INVALID_UUID;
+    }
+    return profiles[index].user_uuid.IsValid();
 }
 
 /// Opens a specific user
@@ -304,7 +305,7 @@ bool ProfileManager::RemoveUser(UUID uuid) {
 
 bool ProfileManager::SetProfileBase(UUID uuid, const ProfileBase& profile_new) {
     const auto index = GetUserIndex(uuid);
-    if (!index || profile_new.user_uuid == UUID(Common::INVALID_UUID)) {
+    if (!index || profile_new.user_uuid.IsInvalid()) {
         return false;
     }
 
@@ -346,7 +347,7 @@ void ProfileManager::ParseUserSaveFile() {
     }
 
     for (const auto& user : data.users) {
-        if (user.uuid == UUID(Common::INVALID_UUID)) {
+        if (user.uuid.IsInvalid()) {
             continue;
         }
 

--- a/src/core/hle/service/am/applets/applet_profile_select.cpp
+++ b/src/core/hle/service/am/applets/applet_profile_select.cpp
@@ -60,7 +60,7 @@ void ProfileSelect::Execute() {
 void ProfileSelect::SelectionComplete(std::optional<Common::UUID> uuid) {
     UserSelectionOutput output{};
 
-    if (uuid.has_value() && uuid->uuid != Common::INVALID_UUID) {
+    if (uuid.has_value() && uuid->IsValid()) {
         output.result = 0;
         output.uuid_selected = uuid->uuid;
     } else {


### PR DESCRIPTION
Given we have a function to invalidate, we should also have ones to query the validity. Also makes the code more straightforward to read.

Also fixes an uninitialized read case in the default profile selection applet that I came across while making this