### PR TITLE
applets: Use subdirectory of main data directory for QtWebEngine storage

### DIFF
--- a/src/yuzu/applets/qt_web_browser.cpp
+++ b/src/yuzu/applets/qt_web_browser.cpp
@@ -54,6 +54,9 @@ QtNXWebEngineView::QtNXWebEngineView(QWidget* parent, Core::System& system,
       input_interpreter(std::make_unique<InputInterpreter>(system)),
       default_profile{QWebEngineProfile::defaultProfile()},
       global_settings{QWebEngineSettings::globalSettings()} {
+    default_profile->setPersistentStoragePath(QString::fromStdString(Common::FS::PathToUTF8String(
+        Common::FS::GetYuzuPath(Common::FS::YuzuPath::YuzuDir) / "qtwebengine")));
+
     QWebEngineScript gamepad;
     QWebEngineScript window_nx;
 


### PR DESCRIPTION
Store QtWebEngine data in `yuzu_directory/qtwebengine`.

Previously, an unrelated directory was used for this. Keep everything together for consistency.