### PR TITLE
vk_texture_cache: Disable cube compatibility flag on non-mesa AMD GCN4 and earlier

### DIFF
--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -127,7 +127,7 @@ constexpr VkBorderColor ConvertBorderColor(const std::array<float, 4>& color) {
     const auto format_info = MaxwellToVK::SurfaceFormat(device, FormatType::Optimal, false, format);
     VkImageCreateFlags flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     if (info.type == ImageType::e2D && info.resources.layers >= 6 &&
-        info.size.width == info.size.height) {
+        info.size.width == info.size.height && !device.HasBrokenCubeImageCompability()) {
         flags |= VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
     }
     if (info.type == ImageType::e3D) {

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -309,6 +309,11 @@ public:
         return has_renderdoc || has_nsight_graphics;
     }
 
+    /// Returns true when the device does not properly support cube compatibility.
+    bool HasBrokenCubeImageCompability() const {
+        return has_broken_cube_compatibility;
+    }
+
     /// Returns the vendor name reported from Vulkan.
     std::string_view GetVendorName() const {
         return vendor_name;
@@ -417,6 +422,7 @@ private:
     bool ext_conservative_rasterization{};  ///< Support for VK_EXT_conservative_rasterization.
     bool ext_provoking_vertex{};            ///< Support for VK_EXT_provoking_vertex.
     bool nv_device_diagnostics_config{};    ///< Support for VK_NV_device_diagnostics_config.
+    bool has_broken_cube_compatibility{};   ///< Has broken cube compatiblity bit
     bool has_renderdoc{};                   ///< Has RenderDoc attached
     bool has_nsight_graphics{};             ///< Has Nsight Graphics attached
 


### PR DESCRIPTION
Fixes "rainbow textures" on BOTW and Age of Calamity when using older AMD GPUs on the proprietary drivers.

BOTW was setting this bit on an image which was bound to a shader that was sampling the texture as a 2D array. 
The issue seems to be that when this bit is set on an image, that image will be sampled as a cube map rather than the sampler type. 
From my unit testing, this change doesn't seem to regress proper cube map usage, but further testing is needed.

### Before

![01007ef00011e000_2021-09-23_16-52-42-666](https://user-images.githubusercontent.com/52414509/134593687-445f5929-3de6-4653-9489-1b81994943ee.png)

### After

![01007ef00011e000_2021-09-23_16-54-22-825](https://user-images.githubusercontent.com/52414509/134593694-f66b7227-30bc-4d2a-a0ab-8ea4f39eb006.png)

