### PR TITLE
video_core: Fix jthread related hangs when stopping emulation

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -305,7 +305,6 @@ struct System::Impl {
         is_powered_on = false;
         exit_lock = false;
 
-        gpu_core.reset();
         services.reset();
         service_manager.reset();
         cheat_engine.reset();
@@ -315,6 +314,7 @@ struct System::Impl {
         core_timing.Shutdown();
         app_loader.reset();
         perf_stats.reset();
+        gpu_core.reset();
         kernel.Shutdown();
         memory.Reset();
         applet_manager.ClearAll();

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -212,7 +212,6 @@ private:
     vk::CommandBuffer current_cmdbuf;
 
     std::unique_ptr<CommandChunk> chunk;
-    std::jthread worker_thread;
 
     State state;
 
@@ -226,6 +225,7 @@ private:
     std::mutex work_mutex;
     std::condition_variable_any work_cv;
     std::condition_variable wait_cv;
+    std::jthread worker_thread;
 };
 
 } // namespace Vulkan


### PR DESCRIPTION
jthread on some compilers is more picky when it comes to the order in which objects are destroyed.