### PR TITLE
service: bsd: Stub Read

### DIFF
--- a/src/core/hle/service/sockets/bsd.cpp
+++ b/src/core/hle/service/sockets/bsd.cpp
@@ -419,13 +419,12 @@ void BSD::Read(Kernel::HLERequestContext& ctx) {
     IPC::RequestParser rp{ctx};
     const s32 fd = rp.Pop<s32>();
 
-    LOG_DEBUG(Service, "called. fd={} len={}", fd, ctx.GetWriteBufferSize());
+    LOG_WARNING(Service, "(STUBBED) called. fd={} len={}", fd, ctx.GetWriteBufferSize());
 
-    ExecuteWork(ctx, RecvWork{
-                         .fd = fd,
-                         .flags = 0,
-                         .message = std::vector<u8>(ctx.GetWriteBufferSize()),
-                     });
+    IPC::ResponseBuilder rb{ctx, 4};
+    rb.Push(ResultSuccess);
+    rb.Push<u32>(0); // ret
+    rb.Push<u32>(0); // bsd errno
 }
 
 void BSD::Close(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
- Used by Diablo II: Resurrected

Note: While an implementation exists in #7082, this will cause the aforementioned game to softlock due to needing other BSD functions to be fully implemented.