### PR TITLE
core: Fix memory leak

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -218,6 +218,7 @@ add_library(core STATIC
     hle/kernel/k_session.h
     hle/kernel/k_shared_memory.cpp
     hle/kernel/k_shared_memory.h
+    hle/kernel/k_shared_memory_info.h
     hle/kernel/k_slab_heap.h
     hle/kernel/k_spin_lock.cpp
     hle/kernel/k_spin_lock.h

--- a/src/core/hle/kernel/k_process.h
+++ b/src/core/hle/kernel/k_process.h
@@ -34,6 +34,7 @@ class KernelCore;
 class KPageTable;
 class KResourceLimit;
 class KThread;
+class KSharedMemoryInfo;
 class TLSPage;
 
 struct CodeSet;
@@ -447,6 +448,9 @@ private:
 
     /// List of threads that are running with this process as their owner.
     std::list<const KThread*> thread_list;
+
+    /// List of shared memory that are running with this process as their owner.
+    std::list<KSharedMemoryInfo*> shared_memory_list;
 
     /// Address of the top of the main thread's stack
     VAddr main_thread_stack_top{};

--- a/src/core/hle/kernel/k_shared_memory_info.h
+++ b/src/core/hle/kernel/k_shared_memory_info.h
@@ -1,0 +1,46 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <boost/intrusive/list.hpp>
+
+#include "common/assert.h"
+#include "core/hle/kernel/slab_helpers.h"
+
+namespace Kernel {
+
+class KSharedMemory;
+
+class KSharedMemoryInfo final : public KSlabAllocated<KSharedMemoryInfo>,
+                                public boost::intrusive::list_base_hook<> {
+
+public:
+    explicit KSharedMemoryInfo() = default;
+
+    constexpr void Initialize(KSharedMemory* shmem) {
+        shared_memory = shmem;
+    }
+
+    constexpr KSharedMemory* GetSharedMemory() const {
+        return shared_memory;
+    }
+
+    constexpr void Open() {
+        ++reference_count;
+    }
+
+    constexpr bool Close() {
+        return (--reference_count) == 0;
+    }
+
+private:
+    KSharedMemory* shared_memory{};
+    size_t reference_count{};
+};
+
+} // namespace Kernel

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -49,6 +49,7 @@ class KScheduler;
 class KServerSession;
 class KSession;
 class KSharedMemory;
+class KSharedMemoryInfo;
 class KThread;
 class KTransferMemory;
 class KWritableEvent;
@@ -309,6 +310,8 @@ public:
             return slab_heap_container->session;
         } else if constexpr (std::is_same_v<T, KSharedMemory>) {
             return slab_heap_container->shared_memory;
+        } else if constexpr (std::is_same_v<T, KSharedMemoryInfo>) {
+            return slab_heap_container->shared_memory_info;
         } else if constexpr (std::is_same_v<T, KThread>) {
             return slab_heap_container->thread;
         } else if constexpr (std::is_same_v<T, KTransferMemory>) {
@@ -362,6 +365,7 @@ private:
         KSlabHeap<KResourceLimit> resource_limit;
         KSlabHeap<KSession> session;
         KSlabHeap<KSharedMemory> shared_memory;
+        KSlabHeap<KSharedMemoryInfo> shared_memory_info;
         KSlabHeap<KThread> thread;
         KSlabHeap<KTransferMemory> transfer_memory;
         KSlabHeap<KWritableEvent> writeable_event;


### PR DESCRIPTION
1. Fix KScopedAutoObject leak when SendSyncRequest
  **Because the KScopedSchedulerLock triggers a fiber switch. when a suspend been triggered, the current KScopedAutoObject reference count may not be released**
2. Fix SharedMemory leak

Known Issue:
1. svc WaitSynchronization objects may not be released correctly
**KSynchronizationObject::Wait will trigger a fiber switch, causing the object not to be released**
2. svc StartThread thread leak
**It is possible that the shutdown was performed without calling ExitThread**
3. HLE Service's event leak
**The event object is treated as a member parameter, when the class is released, the event object will be destructured and needs to be changed to event pointer object**

I tried to solve the three problems above, but I found that sometimes it would run crash, so I'll put it aside for now