### PR TITLE
Improve handling of homebrew shutdown

### DIFF
--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -115,7 +115,9 @@ void EmuThread::run() {
     }
 
     // Shutdown the core emulation
-    system.Shutdown();
+    if (system.IsPoweredOn()) {
+        system.Shutdown();
+    }
 
 #if MICROPROFILE_ENABLED
     MicroProfileOnThreadExit();

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2947,8 +2947,12 @@ void GMainWindow::UpdateStatusBar() {
 
     auto& system = Core::System::GetInstance();
     auto results = system.GetAndResetPerfStats();
-    auto& shader_notify = system.GPU().ShaderNotify();
-    const int shaders_building = shader_notify.ShadersBuilding();
+
+    int shaders_building = 0;
+    if (system.IsPoweredOn()) {
+        auto& shader_notify = system.GPU().ShaderNotify();
+        shaders_building = shader_notify.ShadersBuilding();
+    }
 
     if (shaders_building > 0) {
         shader_building_label->setText(tr("Building: %n shader(s)", "", shaders_building));


### PR DESCRIPTION
Homebrew can terminate to exit to HOS. Yuzu doesn't handle this well and used to segfault.

This PR aims to improve that. Now problems only begin when stopping emulation and I intend to improve it further.