### PR TITLE
service: Replace all service event creation with ServiceContext::CreateEvent

### DIFF
--- a/src/core/hle/service/acc/async_context.h
+++ b/src/core/hle/service/acc/async_context.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <atomic>
-#include "core/hle/kernel/k_event.h"
+#include "core/hle/service/kernel_helpers.h"
 #include "core/hle/service/service.h"
 
 namespace Core {
@@ -17,6 +17,7 @@ namespace Service::Account {
 class IAsyncContext : public ServiceFramework<IAsyncContext> {
 public:
     explicit IAsyncContext(Core::System& system_);
+    ~IAsyncContext() override;
 
     void GetSystemEvent(Kernel::HLERequestContext& ctx);
     void Cancel(Kernel::HLERequestContext& ctx);
@@ -30,8 +31,10 @@ protected:
 
     void MarkComplete();
 
+    KernelHelpers::ServiceContext service_context;
+
     std::atomic<bool> is_complete{false};
-    Kernel::KEvent compeletion_event;
+    Kernel::KEvent* completion_event;
 };
 
 } // namespace Service::Account

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -8,7 +8,7 @@
 #include <memory>
 #include <queue>
 
-#include "core/hle/kernel/k_event.h"
+#include "core/hle/service/kernel_helpers.h"
 #include "core/hle/service/service.h"
 
 namespace Kernel {
@@ -53,7 +53,7 @@ public:
         PerformanceModeChanged = 31,
     };
 
-    explicit AppletMessageQueue(Kernel::KernelCore& kernel);
+    explicit AppletMessageQueue(Core::System& system);
     ~AppletMessageQueue();
 
     Kernel::KReadableEvent& GetMessageReceiveEvent();
@@ -66,9 +66,12 @@ public:
     void OperationModeChanged();
 
 private:
+    KernelHelpers::ServiceContext service_context;
+
+    Kernel::KEvent* on_new_message;
+    Kernel::KEvent* on_operation_mode_changed;
+
     std::queue<AppletMessage> messages;
-    Kernel::KEvent on_new_message;
-    Kernel::KEvent on_operation_mode_changed;
 };
 
 class IWindowController final : public ServiceFramework<IWindowController> {
@@ -156,8 +159,11 @@ private:
     };
 
     NVFlinger::NVFlinger& nvflinger;
-    Kernel::KEvent launchable_event;
-    Kernel::KEvent accumulated_suspended_tick_changed_event;
+
+    KernelHelpers::ServiceContext service_context;
+
+    Kernel::KEvent* launchable_event;
+    Kernel::KEvent* accumulated_suspended_tick_changed_event;
 
     u32 idle_time_detection_extension = 0;
     u64 num_fatal_sections_entered = 0;
@@ -298,13 +304,15 @@ private:
     void GetNotificationStorageChannelEvent(Kernel::HLERequestContext& ctx);
     void GetHealthWarningDisappearedSystemEvent(Kernel::HLERequestContext& ctx);
 
+    KernelHelpers::ServiceContext service_context;
+
     bool launch_popped_application_specific = false;
     bool launch_popped_account_preselect = false;
     s32 previous_program_index{-1};
-    Kernel::KEvent gpu_error_detected_event;
-    Kernel::KEvent friend_invitation_storage_channel_event;
-    Kernel::KEvent notification_storage_channel_event;
-    Kernel::KEvent health_warning_disappeared_system_event;
+    Kernel::KEvent* gpu_error_detected_event;
+    Kernel::KEvent* friend_invitation_storage_channel_event;
+    Kernel::KEvent* notification_storage_channel_event;
+    Kernel::KEvent* health_warning_disappeared_system_event;
 };
 
 class IHomeMenuFunctions final : public ServiceFramework<IHomeMenuFunctions> {
@@ -316,7 +324,9 @@ private:
     void RequestToGetForeground(Kernel::HLERequestContext& ctx);
     void GetPopFromGeneralChannelEvent(Kernel::HLERequestContext& ctx);
 
-    Kernel::KEvent pop_from_general_channel_event;
+    KernelHelpers::ServiceContext service_context;
+
+    Kernel::KEvent* pop_from_general_channel_event;
 };
 
 class IGlobalStateController final : public ServiceFramework<IGlobalStateController> {

--- a/src/core/hle/service/am/applets/applets.h
+++ b/src/core/hle/service/am/applets/applets.h
@@ -8,7 +8,7 @@
 #include <queue>
 
 #include "common/swap.h"
-#include "core/hle/kernel/k_event.h"
+#include "core/hle/service/kernel_helpers.h"
 
 union ResultCode;
 
@@ -105,6 +105,8 @@ private:
     Core::System& system;
     LibraryAppletMode applet_mode;
 
+    KernelHelpers::ServiceContext service_context;
+
     // Queues are named from applet's perspective
 
     // PopNormalDataToApplet and PushNormalDataFromGame
@@ -119,13 +121,13 @@ private:
     // PopInteractiveDataToGame and PushInteractiveDataFromApplet
     std::deque<std::shared_ptr<IStorage>> out_interactive_channel;
 
-    Kernel::KEvent state_changed_event;
+    Kernel::KEvent* state_changed_event;
 
     // Signaled on PushNormalDataFromApplet
-    Kernel::KEvent pop_out_data_event;
+    Kernel::KEvent* pop_out_data_event;
 
     // Signaled on PushInteractiveDataFromApplet
-    Kernel::KEvent pop_interactive_out_data_event;
+    Kernel::KEvent* pop_interactive_out_data_event;
 };
 
 class Applet {

--- a/src/core/hle/service/aoc/aoc_u.h
+++ b/src/core/hle/service/aoc/aoc_u.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "core/hle/kernel/k_event.h"
+#include "core/hle/service/kernel_helpers.h"
 #include "core/hle/service/service.h"
 
 namespace Core {
@@ -33,7 +33,9 @@ private:
     void CreatePermanentEcPurchasedEventManager(Kernel::HLERequestContext& ctx);
 
     std::vector<u64> add_on_content;
-    Kernel::KEvent aoc_change_event;
+    KernelHelpers::ServiceContext service_context;
+
+    Kernel::KEvent* aoc_change_event;
 };
 
 /// Registers all AOC services with the specified service manager.

--- a/src/core/hle/service/audio/audin_u.cpp
+++ b/src/core/hle/service/audio/audin_u.cpp
@@ -12,7 +12,7 @@
 namespace Service::Audio {
 
 IAudioIn::IAudioIn(Core::System& system_)
-    : ServiceFramework{system_, "IAudioIn"}, buffer_event{system_.Kernel()} {
+    : ServiceFramework{system_, "IAudioIn"}, service_context{system_, "IAudioIn"} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {0, nullptr, "GetAudioInState"},
@@ -35,11 +35,12 @@ IAudioIn::IAudioIn(Core::System& system_)
 
     RegisterHandlers(functions);
 
-    Kernel::KAutoObject::Create(std::addressof(buffer_event));
-    buffer_event.Initialize("IAudioIn:BufferEvent");
+    buffer_event = service_context.CreateEvent("IAudioIn:BufferEvent");
 }
 
-IAudioIn::~IAudioIn() = default;
+IAudioIn::~IAudioIn() {
+    service_context.CloseEvent(buffer_event);
+}
 
 void IAudioIn::Start(Kernel::HLERequestContext& ctx) {
     LOG_WARNING(Service_Audio, "(STUBBED) called");
@@ -53,7 +54,7 @@ void IAudioIn::RegisterBufferEvent(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 2, 1};
     rb.Push(ResultSuccess);
-    rb.PushCopyObjects(buffer_event.GetReadableEvent());
+    rb.PushCopyObjects(buffer_event->GetReadableEvent());
 }
 
 void IAudioIn::AppendAudioInBufferAuto(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/audio/audin_u.h
+++ b/src/core/hle/service/audio/audin_u.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "core/hle/kernel/k_event.h"
+#include "core/hle/service/kernel_helpers.h"
 #include "core/hle/service/service.h"
 
 namespace Core {
@@ -27,7 +27,9 @@ private:
     void RegisterBufferEvent(Kernel::HLERequestContext& ctx);
     void AppendAudioInBufferAuto(Kernel::HLERequestContext& ctx);
 
-    Kernel::KEvent buffer_event;
+    KernelHelpers::ServiceContext service_context;
+
+    Kernel::KEvent* buffer_event;
 };
 
 class AudInU final : public ServiceFramework<AudInU> {

--- a/src/core/hle/service/audio/audren_u.h
+++ b/src/core/hle/service/audio/audren_u.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "core/hle/kernel/k_event.h"
+#include "core/hle/service/kernel_helpers.h"
 #include "core/hle/service/service.h"
 
 namespace Core {
@@ -31,8 +31,10 @@ private:
 
     void OpenAudioRendererImpl(Kernel::HLERequestContext& ctx);
 
+    KernelHelpers::ServiceContext service_context;
+
     std::size_t audren_instance_count = 0;
-    Kernel::KEvent buffer_event;
+    Kernel::KEvent* buffer_event;
 };
 
 // Describes a particular audio feature that may be supported in a particular revision.

--- a/src/core/hle/service/bcat/backend/backend.h
+++ b/src/core/hle/service/bcat/backend/backend.h
@@ -11,8 +11,8 @@
 
 #include "common/common_types.h"
 #include "core/file_sys/vfs_types.h"
-#include "core/hle/kernel/k_event.h"
 #include "core/hle/result.h"
+#include "core/hle/service/kernel_helpers.h"
 
 namespace Core {
 class System;
@@ -70,6 +70,8 @@ class ProgressServiceBackend {
     friend class IBcatService;
 
 public:
+    ~ProgressServiceBackend();
+
     // Clients should call this with true if any of the functions are going to be called from a
     // non-HLE thread and this class need to lock the hle mutex. (default is false)
     void SetNeedHLELock(bool need);
@@ -97,15 +99,17 @@ public:
     void FinishDownload(ResultCode result);
 
 private:
-    explicit ProgressServiceBackend(Kernel::KernelCore& kernel, std::string_view event_name);
+    explicit ProgressServiceBackend(Core::System& system, std::string_view event_name);
 
     Kernel::KReadableEvent& GetEvent();
     DeliveryCacheProgressImpl& GetImpl();
 
     void SignalUpdate();
 
+    KernelHelpers::ServiceContext service_context;
+
     DeliveryCacheProgressImpl impl{};
-    Kernel::KEvent update_event;
+    Kernel::KEvent* update_event;
     bool need_hle_lock = false;
 };
 

--- a/src/core/hle/service/bcat/bcat_module.cpp
+++ b/src/core/hle/service/bcat/bcat_module.cpp
@@ -127,8 +127,8 @@ public:
     explicit IBcatService(Core::System& system_, Backend& backend_)
         : ServiceFramework{system_, "IBcatService"}, backend{backend_},
           progress{{
-              ProgressServiceBackend{system_.Kernel(), "Normal"},
-              ProgressServiceBackend{system_.Kernel(), "Directory"},
+              ProgressServiceBackend{system_, "Normal"},
+              ProgressServiceBackend{system_, "Directory"},
           }} {
         // clang-format off
         static const FunctionInfo functions[] = {

--- a/src/core/hle/service/nfp/nfp.h
+++ b/src/core/hle/service/nfp/nfp.h
@@ -7,7 +7,7 @@
 #include <array>
 #include <vector>
 
-#include "core/hle/kernel/k_event.h"
+#include "core/hle/service/kernel_helpers.h"
 #include "core/hle/service/service.h"
 
 namespace Kernel {
@@ -42,12 +42,13 @@ public:
         Kernel::KReadableEvent& GetNFCEvent();
         const AmiiboFile& GetAmiiboBuffer() const;
 
-    private:
-        Kernel::KEvent nfc_tag_load;
-        AmiiboFile amiibo{};
-
     protected:
         std::shared_ptr<Module> module;
+
+    private:
+        KernelHelpers::ServiceContext service_context;
+        Kernel::KEvent* nfc_tag_load;
+        AmiiboFile amiibo{};
     };
 };
 

--- a/src/core/hle/service/time/standard_user_system_clock_core.h
+++ b/src/core/hle/service/time/standard_user_system_clock_core.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "core/hle/kernel/k_event.h"
+#include "core/hle/service/kernel_helpers.h"
 #include "core/hle/service/time/clock_types.h"
 #include "core/hle/service/time/system_clock_core.h"
 
@@ -26,6 +26,8 @@ public:
     StandardUserSystemClockCore(StandardLocalSystemClockCore& local_system_clock_core_,
                                 StandardNetworkSystemClockCore& network_system_clock_core_,
                                 Core::System& system_);
+
+    ~StandardUserSystemClockCore() override;
 
     ResultCode SetAutomaticCorrectionEnabled(Core::System& system, bool value);
 
@@ -55,7 +57,8 @@ private:
     StandardNetworkSystemClockCore& network_system_clock_core;
     bool auto_correction_enabled{};
     SteadyClockTimePoint auto_correction_time;
-    Kernel::KEvent auto_correction_event;
+    KernelHelpers::ServiceContext service_context;
+    Kernel::KEvent* auto_correction_event;
 };
 
 } // namespace Service::Time::Clock


### PR DESCRIPTION
The service context helps to manage all created events and allows us to close them upon destruction.