### PR TITLE
Fixed invalid iterator usage

### DIFF
--- a/src/common/host_memory.cpp
+++ b/src/common/host_memory.cpp
@@ -314,8 +314,8 @@ private:
     }
 
     void UntrackPlaceholder(boost::icl::separate_interval_set<size_t>::iterator it) {
-        placeholders.erase(it);
         placeholder_host_pointers.erase(it->lower());
+        placeholders.erase(it);
     }
 
     /// Return true when a given memory region is a "nieche" and the placeholders don't have to be


### PR DESCRIPTION
Since the `it` parameter comes from `placeholders`, using `placeholders.erase` invalidates the iterator. Simply reordering this is the simplest way to fix it. As far as I can see `UntrackPlaceholder` is only used in one place.