### PR TITLE
prevent access violation from iob in Memory::IsValidVirtualAddress

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -587,7 +587,11 @@ void Memory::UnmapRegion(Common::PageTable& page_table, VAddr base, u64 size) {
 bool Memory::IsValidVirtualAddress(const VAddr vaddr) const {
     const Kernel::KProcess& process = *system.CurrentProcess();
     const auto& page_table = process.PageTable().PageTableImpl();
-    const auto [pointer, type] = page_table.pointers[vaddr >> PAGE_BITS].PointerType();
+    const size_t page = vaddr >> PAGE_BITS;
+    if (page >= page_table.pointers.size()) {
+        return false;
+    }
+    const auto [pointer, type] = page_table.pointers[page].PointerType();
     return pointer != nullptr || type == Common::PageType::RasterizerCachedMemory;
 }
 


### PR DESCRIPTION
I encountered this while debugging my reimplementation of the gdb stub. gdb sends `mfffffffc,4#{checksum}` and this is where it occurs. I'm not sure if this is a hotspot or not but if it is and the check causes problems an alternative would be to make `page_table.pointers` large enough for every possible page value. (I don't know how large this would be)

I have not yet had time to test this change so someone may want to manually check it.