### PR TITLE
main: Don't add an extra separator when the title version is absent

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2913,8 +2913,13 @@ void GMainWindow::UpdateWindowTitle(std::string_view title_name, std::string_vie
     if (title_name.empty()) {
         setWindowTitle(QString::fromStdString(window_title));
     } else {
-        const auto run_title =
-            fmt::format("{} | {} | {} | {}", window_title, title_name, title_version, gpu_vendor);
+        const auto run_title = [window_title, title_name, title_version, gpu_vendor]() {
+            if (title_version.empty()) {
+                return fmt::format("{} | {} | {}", window_title, title_name, gpu_vendor);
+            }
+            return fmt::format("{} | {} | {} | {}", window_title, title_name, title_version,
+                               gpu_vendor);
+        }();
         setWindowTitle(QString::fromStdString(run_title));
     }
 }


### PR DESCRIPTION
Some titles, such as homebrew, do not have any version string. Because yuzu hard codes the title bar string assuming a version string is preset, booting homebrew causes yuzu to add an extra separator with no content between.

This uses a lambda expression to prevent that from happening.

Before:

![Screenshot_2021-09-30_18-53-39](https://user-images.githubusercontent.com/22451773/135540660-b325df12-7cdc-495f-9f1d-bb61aed08ddd.png)


After:

![Screenshot_2021-09-30_18-51-23](https://user-images.githubusercontent.com/22451773/135540673-cf64e9d8-c080-4d06-8d6e-c30ebf318583.png)

