### PR TITLE
common/logging: Reduce dependent header include overhead

### DIFF
--- a/src/audio_core/command_generator.cpp
+++ b/src/audio_core/command_generator.cpp
@@ -2,13 +2,16 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
 #include <cmath>
 #include <numbers>
+
 #include "audio_core/algorithm/interpolate.h"
 #include "audio_core/command_generator.h"
 #include "audio_core/effect_context.h"
 #include "audio_core/mix_context.h"
 #include "audio_core/voice_context.h"
+#include "common/common_types.h"
 #include "core/memory.h"
 
 namespace AudioCore {

--- a/src/audio_core/mix_context.cpp
+++ b/src/audio_core/mix_context.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
+
 #include "audio_core/behavior_info.h"
 #include "audio_core/common.h"
 #include "audio_core/effect_context.h"

--- a/src/audio_core/voice_context.cpp
+++ b/src/audio_core/voice_context.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
+
 #include "audio_core/behavior_info.h"
 #include "audio_core/voice_context.h"
 #include "core/memory.h"

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -79,6 +79,7 @@ add_library(common STATIC
     logging/filter.cpp
     logging/filter.h
     logging/log.h
+    logging/log_entry.h
     logging/text_formatter.cpp
     logging/text_formatter.h
     logging/types.h

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -9,6 +9,8 @@
 #include <thread>
 #include <vector>
 
+#include <fmt/format.h>
+
 #ifdef _WIN32
 #include <windows.h> // For OutputDebugStringW
 #endif
@@ -22,6 +24,7 @@
 
 #include "common/logging/backend.h"
 #include "common/logging/log.h"
+#include "common/logging/log_entry.h"
 #include "common/logging/text_formatter.h"
 #include "common/settings.h"
 #ifdef _WIN32

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -7,7 +7,7 @@
 #include <algorithm>
 #include <string_view>
 
-#include <fmt/format.h>
+#include <fmt/core.h>
 
 #include "common/logging/types.h"
 

--- a/src/common/logging/log.h
+++ b/src/common/logging/log.h
@@ -4,7 +4,11 @@
 
 #pragma once
 
+#include <algorithm>
+#include <string_view>
+
 #include <fmt/format.h>
+
 #include "common/logging/types.h"
 
 namespace Common::Log {

--- a/src/common/logging/log_entry.h
+++ b/src/common/logging/log_entry.h
@@ -1,0 +1,28 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <chrono>
+
+#include "common/logging/types.h"
+
+namespace Common::Log {
+
+/**
+ * A log entry. Log entries are store in a structured format to permit more varied output
+ * formatting on different frontends, as well as facilitating filtering and aggregation.
+ */
+struct Entry {
+    std::chrono::microseconds timestamp;
+    Class log_class{};
+    Level log_level{};
+    const char* filename = nullptr;
+    unsigned int line_num = 0;
+    std::string function;
+    std::string message;
+    bool final_entry = false;
+};
+
+} // namespace Common::Log

--- a/src/common/logging/text_formatter.cpp
+++ b/src/common/logging/text_formatter.cpp
@@ -13,6 +13,7 @@
 #include "common/common_funcs.h"
 #include "common/logging/filter.h"
 #include "common/logging/log.h"
+#include "common/logging/log_entry.h"
 #include "common/logging/text_formatter.h"
 #include "common/string_util.h"
 

--- a/src/common/logging/types.h
+++ b/src/common/logging/types.h
@@ -4,8 +4,6 @@
 
 #pragma once
 
-#include <chrono>
-
 #include "common/common_types.h"
 
 namespace Common::Log {
@@ -129,21 +127,6 @@ enum class Class : u8 {
     Network,           ///< Network emulation
     WebService,        ///< Interface to yuzu Web Services
     Count              ///< Total number of logging classes
-};
-
-/**
- * A log entry. Log entries are store in a structured format to permit more varied output
- * formatting on different frontends, as well as facilitating filtering and aggregation.
- */
-struct Entry {
-    std::chrono::microseconds timestamp;
-    Class log_class{};
-    Level log_level{};
-    const char* filename = nullptr;
-    unsigned int line_num = 0;
-    std::string function;
-    std::string message;
-    bool final_entry = false;
 };
 
 } // namespace Common::Log

--- a/src/common/param_package.cpp
+++ b/src/common/param_package.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <array>
+#include <stdexcept>
 #include <utility>
 #include <vector>
 

--- a/src/core/hle/kernel/k_auto_object_container.cpp
+++ b/src/core/hle/kernel/k_auto_object_container.cpp
@@ -2,6 +2,8 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <algorithm>
+
 #include "core/hle/kernel/k_auto_object_container.h"
 
 namespace Kernel {

--- a/src/core/hle/service/lbl/lbl.cpp
+++ b/src/core/hle/service/lbl/lbl.cpp
@@ -2,6 +2,7 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cmath>
 #include <memory>
 
 #include "common/logging/log.h"

--- a/src/core/hle/service/time/system_clock_context_update_callback.h
+++ b/src/core/hle/service/time/system_clock_context_update_callback.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "core/hle/service/time/clock_types.h"

--- a/src/core/hle/service/time/system_clock_core.h
+++ b/src/core/hle/service/time/system_clock_core.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "common/common_types.h"
 #include "core/hle/service/time/clock_types.h"
 

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <bitset>
+#include <cmath>
 #include <limits>
 #include <optional>
 #include <type_traits>


### PR DESCRIPTION
This PR aims to reduce the compile overhead of including `log.h` by removing the dependency on `chrono`
 from `logging/types.h`. It also reduces the scope of the included `fmt` header in log.h, in an effort to 
alleviate the compile overhead further.