### PR TITLE
CMakeLists: Update requirement to CMake 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.18)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/externals/cmake-modules")


### PR DESCRIPTION
Requires https://github.com/yuzu-emu/build-environments/pull/42

Edit: Seems like another issue has been uncovered.
For the MinGW build, it is failing with
```
CMake Error at externals/CMakeLists.txt:75 (add_library):
  add_library cannot create ALIAS target "SDL2" because another target with
  the same name already exists.
```