### PR TITLE
Logging: Impl refactor

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ if (MSVC)
     # /Zc:externConstexpr - Allow extern constexpr variables to have external linkage, like the standard mandates
     # /Zc:inline          - Let codegen omit inline functions in object files
     # /Zc:throwingNew     - Let codegen assume `operator new` (without std::nothrow) will never return null
+    # /GT                 - Supports fiber safety for data allocated using static thread-local storage
     add_compile_options(
         /MP
         /Zi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,7 @@ if (MSVC)
         /Zc:externConstexpr
         /Zc:inline
         /Zc:throwingNew
+        /GT
 
         # External headers diagnostics
         /experimental:external  # Enables the external headers options. This option isn't required in Visual Studio 2019 version 16.10 and later
@@ -68,6 +69,10 @@ if (MSVC)
         /we4834 # Discarding return value of function with 'nodiscard' attribute
         /we5038 # data member 'member1' will be initialized after data member 'member2'
     )
+
+    if (ARCHITECTURE_x86_64)
+        add_compile_options(/QIntel-jcc-erratum)
+    endif()
 
     # /GS- - No stack buffer overflow checks
     add_compile_options("$<$<CONFIG:Release>:/GS->")

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <climits>
 #include <exception>
+#include <stop_token>
 #include <thread>
 #include <vector>
 
@@ -186,6 +187,10 @@ public:
         initialization_in_progress_suppress_logging = false;
     }
 
+    static void Start() {
+        instance->StartBackendThread();
+    }
+
     Impl(const Impl&) = delete;
     Impl& operator=(const Impl&) = delete;
 
@@ -201,7 +206,7 @@ public:
     }
 
     void PushEntry(Class log_class, Level log_level, const char* filename, unsigned int line_num,
-                   const char* function, std::string message) {
+                   const char* function, std::string&& message) {
         if (!filter.CheckMessage(log_class, log_level))
             return;
         const Entry& entry =
@@ -211,40 +216,39 @@ public:
 
 private:
     Impl(const std::filesystem::path& file_backend_filename, const Filter& filter_)
-        : filter{filter_}, file_backend{file_backend_filename}, backend_thread{std::thread([this] {
-              Common::SetCurrentThreadName("yuzu:Log");
-              Entry entry;
-              const auto write_logs = [this, &entry]() {
-                  ForEachBackend([&entry](Backend& backend) { backend.Write(entry); });
-              };
-              while (true) {
-                  entry = message_queue.PopWait();
-                  if (entry.final_entry) {
-                      break;
-                  }
-                  write_logs();
-              }
-              // Drain the logging queue. Only writes out up to MAX_LOGS_TO_WRITE to prevent a
-              // case where a system is repeatedly spamming logs even on close.
-              int max_logs_to_write = filter.IsDebug() ? INT_MAX : 100;
-              while (max_logs_to_write-- && message_queue.Pop(entry)) {
-                  write_logs();
-              }
-          })} {}
+        : filter{filter_}, file_backend{file_backend_filename} {}
 
     ~Impl() {
         StopBackendThread();
     }
 
+    void StartBackendThread() {
+        backend_thread{std::thread([this] {
+            Common::SetCurrentThreadName("yuzu:Log");
+            Entry entry;
+            const auto write_logs = [this, &entry]() {
+                ForEachBackend([&entry](Backend& backend) { backend.Write(entry); });
+            };
+            while (!stop.stop_requested()) {
+                entry = message_queue.PopWait();
+                write_logs();
+            }
+            // Drain the logging queue. Only writes out up to MAX_LOGS_TO_WRITE to prevent a
+            // case where a system is repeatedly spamming logs even on close.
+            int max_logs_to_write = filter.IsDebug() ? INT_MAX : 100;
+            while (max_logs_to_write-- && message_queue.Pop(entry)) {
+                write_logs();
+            }
+        })};
+    }
+
     void StopBackendThread() {
-        Entry stop_entry{};
-        stop_entry.final_entry = true;
-        message_queue.Push(stop_entry);
+        stop.request_stop();
         backend_thread.join();
     }
 
     Entry CreateEntry(Class log_class, Level log_level, const char* filename, unsigned int line_nr,
-                      const char* function, std::string message) const {
+                      const char* function, std::string&& message) const {
         using std::chrono::duration_cast;
         using std::chrono::microseconds;
         using std::chrono::steady_clock;
@@ -257,7 +261,6 @@ private:
             .line_num = line_nr,
             .function = function,
             .message = std::move(message),
-            .final_entry = false,
         };
     }
 
@@ -278,6 +281,7 @@ private:
     ColorConsoleBackend color_console_backend{};
     FileBackend file_backend;
 
+    std::stop_source stop;
     std::thread backend_thread;
     MPSCQueue<Entry> message_queue{};
     std::chrono::steady_clock::time_point time_origin{std::chrono::steady_clock::now()};
@@ -286,6 +290,10 @@ private:
 
 void Initialize() {
     Impl::Initialize();
+}
+
+void Start() {
+    Impl::Start();
 }
 
 void DisableLoggingInTests() {

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -223,15 +223,17 @@ private:
     }
 
     void StartBackendThread() {
-        backend_thread{std::thread([this] {
+        backend_thread = std::thread([this] {
             Common::SetCurrentThreadName("yuzu:Log");
             Entry entry;
             const auto write_logs = [this, &entry]() {
                 ForEachBackend([&entry](Backend& backend) { backend.Write(entry); });
             };
             while (!stop.stop_requested()) {
-                entry = message_queue.PopWait();
-                write_logs();
+                entry = message_queue.PopWait(stop.get_token());
+                if (entry.filename != nullptr) {
+                    write_logs();
+                }
             }
             // Drain the logging queue. Only writes out up to MAX_LOGS_TO_WRITE to prevent a
             // case where a system is repeatedly spamming logs even on close.
@@ -239,7 +241,7 @@ private:
             while (max_logs_to_write-- && message_queue.Pop(entry)) {
                 write_logs();
             }
-        })};
+        });
     }
 
     void StopBackendThread() {
@@ -283,7 +285,7 @@ private:
 
     std::stop_source stop;
     std::thread backend_thread;
-    MPSCQueue<Entry> message_queue{};
+    MPSCQueue<Entry, true> message_queue{};
     std::chrono::steady_clock::time_point time_origin{std::chrono::steady_clock::now()};
 };
 } // namespace

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -223,15 +223,17 @@ private:
     }
 
     void StartBackendThread() {
-        backend_thread{std::thread([this] {
+        backend_thread = std::thread([this] {
             Common::SetCurrentThreadName("yuzu:Log");
             Entry entry;
             const auto write_logs = [this, &entry]() {
                 ForEachBackend([&entry](Backend& backend) { backend.Write(entry); });
             };
             while (!stop.stop_requested()) {
-                entry = message_queue.PopWait();
-                write_logs();
+                entry = message_queue.PopWait(stop.get_token());
+                if (entry.filename != nullptr) {
+                    write_logs();
+                }
             }
             // Drain the logging queue. Only writes out up to MAX_LOGS_TO_WRITE to prevent a
             // case where a system is repeatedly spamming logs even on close.
@@ -239,7 +241,7 @@ private:
             while (max_logs_to_write-- && message_queue.Pop(entry)) {
                 write_logs();
             }
-        })};
+        });
     }
 
     void StopBackendThread() {

--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -223,17 +223,15 @@ private:
     }
 
     void StartBackendThread() {
-        backend_thread = std::thread([this] {
+        backend_thread{std::thread([this] {
             Common::SetCurrentThreadName("yuzu:Log");
             Entry entry;
             const auto write_logs = [this, &entry]() {
                 ForEachBackend([&entry](Backend& backend) { backend.Write(entry); });
             };
             while (!stop.stop_requested()) {
-                entry = message_queue.PopWait(stop.get_token());
-                if (entry.filename != nullptr) {
-                    write_logs();
-                }
+                entry = message_queue.PopWait();
+                write_logs();
             }
             // Drain the logging queue. Only writes out up to MAX_LOGS_TO_WRITE to prevent a
             // case where a system is repeatedly spamming logs even on close.
@@ -241,7 +239,7 @@ private:
             while (max_logs_to_write-- && message_queue.Pop(entry)) {
                 write_logs();
             }
-        });
+        })};
     }
 
     void StopBackendThread() {

--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -14,6 +14,8 @@ class Filter;
 /// Initializes the logging system. This should be the first thing called in main.
 void Initialize();
 
+void Start();
+
 void DisableLoggingInTests();
 
 /**

--- a/src/common/logging/log_entry.h
+++ b/src/common/logging/log_entry.h
@@ -22,7 +22,6 @@ struct Entry {
     unsigned int line_num = 0;
     std::string function;
     std::string message;
-    bool final_entry = false;
 };
 
 } // namespace Common::Log

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -263,7 +263,7 @@ void ARM_Dynarmic_64::Run() {
 }
 
 void ARM_Dynarmic_64::Step() {
-    cb->InterpreterFallback(jit->GetPC(), 1);
+    jit->Step();
 }
 
 ARM_Dynarmic_64::ARM_Dynarmic_64(System& system_, CPUInterrupts& interrupt_handlers_,

--- a/src/core/file_sys/control_metadata.cpp
+++ b/src/core/file_sys/control_metadata.cpp
@@ -9,7 +9,7 @@
 
 namespace FileSys {
 
-const std::array<const char*, 15> LANGUAGE_NAMES{{
+const std::array<const char*, 16> LANGUAGE_NAMES{{
     "AmericanEnglish",
     "BritishEnglish",
     "Japanese",
@@ -25,6 +25,7 @@ const std::array<const char*, 15> LANGUAGE_NAMES{{
     "Korean",
     "Taiwanese",
     "Chinese",
+    "BrazilianPortuguese",
 }};
 
 std::string LanguageEntry::GetApplicationName() const {

--- a/src/core/file_sys/control_metadata.h
+++ b/src/core/file_sys/control_metadata.h
@@ -88,11 +88,12 @@ enum class Language : u8 {
     Korean = 12,
     Taiwanese = 13,
     Chinese = 14,
+    BrazilianPortuguese = 15,
 
     Default = 255,
 };
 
-extern const std::array<const char*, 15> LANGUAGE_NAMES;
+extern const std::array<const char*, 16> LANGUAGE_NAMES;
 
 // A class representing the format used by NX metadata files, typically named Control.nacp.
 // These store application name, dev name, title id, and other miscellaneous data.

--- a/src/core/hle/kernel/k_scheduler.h
+++ b/src/core/hle/kernel/k_scheduler.h
@@ -49,6 +49,11 @@ public:
     /// Gets the current running thread
     [[nodiscard]] KThread* GetCurrentThread() const;
 
+    /// Gets the idle thread
+    [[nodiscard]] KThread* GetIdleThread() const {
+        return idle_thread;
+    }
+
     /// Returns true if the scheduler is idle
     [[nodiscard]] bool IsIdle() const {
         return GetCurrentThread() == idle_thread;

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -206,7 +206,7 @@ public:
         return result;
     }
 
-    ResultVal(const ResultVal& o) : result_code(o.result_code) {
+    ResultVal(const ResultVal& o) noexcept : result_code(o.result_code) {
         if (!o.empty()) {
             new (&object) T(o.object);
         }
@@ -224,7 +224,7 @@ public:
         }
     }
 
-    ResultVal& operator=(const ResultVal& o) {
+    ResultVal& operator=(const ResultVal& o) noexcept {
         if (this == &o) {
             return *this;
         }
@@ -237,6 +237,26 @@ public:
         } else {
             if (!o.empty()) {
                 new (&object) T(o.object);
+            }
+        }
+        result_code = o.result_code;
+
+        return *this;
+    }
+
+    ResultVal& operator=(ResultVal&& o) noexcept {
+        if (this == &o) {
+            return *this;
+        }
+        if (!empty()) {
+            if (!o.empty()) {
+                object = std::move(o.object);
+            } else {
+                object.~T();
+            }
+        } else {
+            if (!o.empty()) {
+                new (&object) T(std::move(o.object));
             }
         }
         result_code = o.result_code;

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -349,8 +349,8 @@ template <typename T, typename... Args>
  * copy or move constructing.
  */
 template <typename Arg>
-[[nodiscard]] ResultVal<std::remove_reference_t<Arg>> MakeResult(Arg&& arg) {
-    return ResultVal<std::remove_reference_t<Arg>>::WithCode(ResultSuccess, std::forward<Arg>(arg));
+[[nodiscard]] ResultVal<std::remove_cvref_t<Arg>> MakeResult(Arg&& arg) {
+    return ResultVal<std::remove_cvref_t<Arg>>::WithCode(ResultSuccess, std::forward<Arg>(arg));
 }
 
 /**

--- a/src/core/hle/service/ns/language.cpp
+++ b/src/core/hle/service/ns/language.cpp
@@ -277,6 +277,25 @@ constexpr ApplicationLanguagePriorityList priority_list_simplified_chinese = {{
     ApplicationLanguage::Korean,
 }};
 
+constexpr ApplicationLanguagePriorityList priority_list_brazilian_portuguese = {{
+    ApplicationLanguage::BrazilianPortuguese,
+    ApplicationLanguage::Portuguese,
+    ApplicationLanguage::LatinAmericanSpanish,
+    ApplicationLanguage::AmericanEnglish,
+    ApplicationLanguage::BritishEnglish,
+    ApplicationLanguage::Japanese,
+    ApplicationLanguage::French,
+    ApplicationLanguage::German,
+    ApplicationLanguage::Spanish,
+    ApplicationLanguage::Italian,
+    ApplicationLanguage::Dutch,
+    ApplicationLanguage::CanadianFrench,
+    ApplicationLanguage::Russian,
+    ApplicationLanguage::Korean,
+    ApplicationLanguage::SimplifiedChinese,
+    ApplicationLanguage::TraditionalChinese,
+}};
+
 const ApplicationLanguagePriorityList* GetApplicationLanguagePriorityList(
     const ApplicationLanguage lang) {
     switch (lang) {
@@ -310,6 +329,8 @@ const ApplicationLanguagePriorityList* GetApplicationLanguagePriorityList(
         return &priority_list_traditional_chinese;
     case ApplicationLanguage::SimplifiedChinese:
         return &priority_list_simplified_chinese;
+    case ApplicationLanguage::BrazilianPortuguese:
+        return &priority_list_brazilian_portuguese;
     default:
         return nullptr;
     }
@@ -339,7 +360,6 @@ std::optional<ApplicationLanguage> ConvertToApplicationLanguage(
     case Set::LanguageCode::FR_CA:
         return ApplicationLanguage::CanadianFrench;
     case Set::LanguageCode::PT:
-    case Set::LanguageCode::PT_BR:
         return ApplicationLanguage::Portuguese;
     case Set::LanguageCode::RU:
         return ApplicationLanguage::Russian;
@@ -351,6 +371,8 @@ std::optional<ApplicationLanguage> ConvertToApplicationLanguage(
     case Set::LanguageCode::ZH_CN:
     case Set::LanguageCode::ZH_HANS:
         return ApplicationLanguage::SimplifiedChinese;
+    case Set::LanguageCode::PT_BR:
+        return ApplicationLanguage::BrazilianPortuguese;
     default:
         return std::nullopt;
     }
@@ -388,6 +410,8 @@ std::optional<Set::LanguageCode> ConvertToLanguageCode(const ApplicationLanguage
         return Set::LanguageCode::ZH_HANT;
     case ApplicationLanguage::SimplifiedChinese:
         return Set::LanguageCode::ZH_HANS;
+    case ApplicationLanguage::BrazilianPortuguese:
+        return Set::LanguageCode::PT_BR;
     default:
         return std::nullopt;
     }

--- a/src/core/hle/service/ns/language.h
+++ b/src/core/hle/service/ns/language.h
@@ -30,6 +30,7 @@ enum class ApplicationLanguage : u8 {
     Korean,
     TraditionalChinese,
     SimplifiedChinese,
+    BrazilianPortuguese,
     Count
 };
 using ApplicationLanguagePriorityList =

--- a/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_nvdec_common.h
@@ -56,19 +56,16 @@ protected:
         s32 target{};
         s32 target_offset{};
     };
-    static_assert(sizeof(Reloc) == 0x10, "CommandBuffer has incorrect size");
+    static_assert(sizeof(Reloc) == 0x10, "Reloc has incorrect size");
 
     struct SyncptIncr {
         u32 id{};
         u32 increments{};
+        u32 unk0{};
+        u32 unk1{};
+        u32 unk2{};
     };
-    static_assert(sizeof(SyncptIncr) == 0x8, "CommandBuffer has incorrect size");
-
-    struct Fence {
-        u32 id{};
-        u32 value{};
-    };
-    static_assert(sizeof(Fence) == 0x8, "CommandBuffer has incorrect size");
+    static_assert(sizeof(SyncptIncr) == 0x14, "SyncptIncr has incorrect size");
 
     struct IoctlGetSyncpoint {
         // Input

--- a/src/input_common/gcadapter/gc_adapter.cpp
+++ b/src/input_common/gcadapter/gc_adapter.cpp
@@ -14,15 +14,73 @@
 
 namespace GCAdapter {
 
+class LibUSBContext {
+public:
+    explicit LibUSBContext() {
+        init_result = libusb_init(&ctx);
+    }
+
+    ~LibUSBContext() {
+        libusb_exit(ctx);
+    }
+
+    LibUSBContext& operator=(const LibUSBContext&) = delete;
+    LibUSBContext(const LibUSBContext&) = delete;
+
+    LibUSBContext& operator=(LibUSBContext&&) noexcept = delete;
+    LibUSBContext(LibUSBContext&&) noexcept = delete;
+
+    [[nodiscard]] int InitResult() const noexcept {
+        return init_result;
+    }
+
+    [[nodiscard]] libusb_context* get() noexcept {
+        return ctx;
+    }
+
+private:
+    libusb_context* ctx;
+    int init_result{};
+};
+
+class LibUSBDeviceHandle {
+public:
+    explicit LibUSBDeviceHandle(libusb_context* ctx, uint16_t vid, uint16_t pid) noexcept {
+        handle = libusb_open_device_with_vid_pid(ctx, vid, pid);
+    }
+
+    ~LibUSBDeviceHandle() noexcept {
+        if (handle) {
+            libusb_release_interface(handle, 1);
+            libusb_close(handle);
+        }
+    }
+
+    LibUSBDeviceHandle& operator=(const LibUSBDeviceHandle&) = delete;
+    LibUSBDeviceHandle(const LibUSBDeviceHandle&) = delete;
+
+    LibUSBDeviceHandle& operator=(LibUSBDeviceHandle&&) noexcept = delete;
+    LibUSBDeviceHandle(LibUSBDeviceHandle&&) noexcept = delete;
+
+    [[nodiscard]] libusb_device_handle* get() noexcept {
+        return handle;
+    }
+
+private:
+    libusb_device_handle* handle{};
+};
+
 Adapter::Adapter() {
-    if (usb_adapter_handle != nullptr) {
+    if (usb_adapter_handle) {
         return;
     }
     LOG_INFO(Input, "GC Adapter Initialization started");
 
-    const int init_res = libusb_init(&libusb_ctx);
+    libusb_ctx = std::make_unique<LibUSBContext>();
+    const int init_res = libusb_ctx->InitResult();
     if (init_res == LIBUSB_SUCCESS) {
-        adapter_scan_thread = std::thread(&Adapter::AdapterScanThread, this);
+        adapter_scan_thread =
+            std::jthread([this](std::stop_token stop_token) { AdapterScanThread(stop_token); });
     } else {
         LOG_ERROR(Input, "libusb could not be initialized. failed with error = {}", init_res);
     }
@@ -32,17 +90,15 @@ Adapter::~Adapter() {
     Reset();
 }
 
-void Adapter::AdapterInputThread() {
+void Adapter::AdapterInputThread(std::stop_token stop_token) {
     LOG_DEBUG(Input, "GC Adapter input thread started");
     s32 payload_size{};
     AdapterPayload adapter_payload{};
 
-    if (adapter_scan_thread.joinable()) {
-        adapter_scan_thread.join();
-    }
+    adapter_scan_thread = {};
 
-    while (adapter_input_thread_running) {
-        libusb_interrupt_transfer(usb_adapter_handle, input_endpoint, adapter_payload.data(),
+    while (!stop_token.stop_requested()) {
+        libusb_interrupt_transfer(usb_adapter_handle->get(), input_endpoint, adapter_payload.data(),
                                   static_cast<s32>(adapter_payload.size()), &payload_size, 16);
         if (IsPayloadCorrect(adapter_payload, payload_size)) {
             UpdateControllers(adapter_payload);
@@ -52,7 +108,8 @@ void Adapter::AdapterInputThread() {
     }
 
     if (restart_scan_thread) {
-        adapter_scan_thread = std::thread(&Adapter::AdapterScanThread, this);
+        adapter_scan_thread =
+            std::jthread([this](std::stop_token token) { AdapterScanThread(token); });
         restart_scan_thread = false;
     }
 }
@@ -64,7 +121,7 @@ bool Adapter::IsPayloadCorrect(const AdapterPayload& adapter_payload, s32 payloa
                   adapter_payload[0]);
         if (input_error_counter++ > 20) {
             LOG_ERROR(Input, "GC adapter timeout, Is the adapter connected?");
-            adapter_input_thread_running = false;
+            adapter_input_thread.request_stop();
             restart_scan_thread = true;
         }
         return false;
@@ -96,7 +153,7 @@ void Adapter::UpdatePadType(std::size_t port, ControllerTypes pad_type) {
         return;
     }
     // Device changed reset device and set new type
-    ResetDevice(port);
+    pads[port] = {};
     pads[port].type = pad_type;
 }
 
@@ -213,8 +270,9 @@ void Adapter::SendVibrations() {
     const u8 p3 = pads[2].enable_vibration;
     const u8 p4 = pads[3].enable_vibration;
     std::array<u8, 5> payload = {rumble_command, p1, p2, p3, p4};
-    const int err = libusb_interrupt_transfer(usb_adapter_handle, output_endpoint, payload.data(),
-                                              static_cast<s32>(payload.size()), &size, 16);
+    const int err =
+        libusb_interrupt_transfer(usb_adapter_handle->get(), output_endpoint, payload.data(),
+                                  static_cast<s32>(payload.size()), &size, 16);
     if (err) {
         LOG_DEBUG(Input, "Adapter libusb write failed: {}", libusb_error_name(err));
         if (output_error_counter++ > 5) {
@@ -233,56 +291,53 @@ bool Adapter::RumblePlay(std::size_t port, u8 amplitude) {
     return rumble_enabled;
 }
 
-void Adapter::AdapterScanThread() {
-    adapter_scan_thread_running = true;
-    adapter_input_thread_running = false;
-    if (adapter_input_thread.joinable()) {
-        adapter_input_thread.join();
-    }
-    ClearLibusbHandle();
-    ResetDevices();
-    while (adapter_scan_thread_running && !adapter_input_thread_running) {
-        Setup();
-        std::this_thread::sleep_for(std::chrono::seconds(1));
+void Adapter::AdapterScanThread(std::stop_token stop_token) {
+    usb_adapter_handle = nullptr;
+    pads = {};
+    while (!stop_token.stop_requested() && !Setup()) {
+        std::this_thread::sleep_for(std::chrono::seconds(2));
     }
 }
 
-void Adapter::Setup() {
-    usb_adapter_handle = libusb_open_device_with_vid_pid(libusb_ctx, 0x057e, 0x0337);
-
-    if (usb_adapter_handle == NULL) {
-        return;
+bool Adapter::Setup() {
+    constexpr u16 nintendo_vid = 0x057e;
+    constexpr u16 gc_adapter_pid = 0x0337;
+    usb_adapter_handle =
+        std::make_unique<LibUSBDeviceHandle>(libusb_ctx->get(), nintendo_vid, gc_adapter_pid);
+    if (!usb_adapter_handle->get()) {
+        return false;
     }
     if (!CheckDeviceAccess()) {
-        ClearLibusbHandle();
-        return;
+        usb_adapter_handle = nullptr;
+        return false;
     }
 
-    libusb_device* device = libusb_get_device(usb_adapter_handle);
+    libusb_device* const device = libusb_get_device(usb_adapter_handle->get());
 
     LOG_INFO(Input, "GC adapter is now connected");
     // GC Adapter found and accessible, registering it
     if (GetGCEndpoint(device)) {
-        adapter_scan_thread_running = false;
-        adapter_input_thread_running = true;
         rumble_enabled = true;
         input_error_counter = 0;
         output_error_counter = 0;
-        adapter_input_thread = std::thread(&Adapter::AdapterInputThread, this);
+        adapter_input_thread =
+            std::jthread([this](std::stop_token stop_token) { AdapterInputThread(stop_token); });
+        return true;
     }
+    return false;
 }
 
 bool Adapter::CheckDeviceAccess() {
     // This fixes payload problems from offbrand GCAdapters
     const s32 control_transfer_error =
-        libusb_control_transfer(usb_adapter_handle, 0x21, 11, 0x0001, 0, nullptr, 0, 1000);
+        libusb_control_transfer(usb_adapter_handle->get(), 0x21, 11, 0x0001, 0, nullptr, 0, 1000);
     if (control_transfer_error < 0) {
         LOG_ERROR(Input, "libusb_control_transfer failed with error= {}", control_transfer_error);
     }
 
-    s32 kernel_driver_error = libusb_kernel_driver_active(usb_adapter_handle, 0);
+    s32 kernel_driver_error = libusb_kernel_driver_active(usb_adapter_handle->get(), 0);
     if (kernel_driver_error == 1) {
-        kernel_driver_error = libusb_detach_kernel_driver(usb_adapter_handle, 0);
+        kernel_driver_error = libusb_detach_kernel_driver(usb_adapter_handle->get(), 0);
         if (kernel_driver_error != 0 && kernel_driver_error != LIBUSB_ERROR_NOT_SUPPORTED) {
             LOG_ERROR(Input, "libusb_detach_kernel_driver failed with error = {}",
                       kernel_driver_error);
@@ -290,15 +345,13 @@ bool Adapter::CheckDeviceAccess() {
     }
 
     if (kernel_driver_error && kernel_driver_error != LIBUSB_ERROR_NOT_SUPPORTED) {
-        libusb_close(usb_adapter_handle);
         usb_adapter_handle = nullptr;
         return false;
     }
 
-    const int interface_claim_error = libusb_claim_interface(usb_adapter_handle, 0);
+    const int interface_claim_error = libusb_claim_interface(usb_adapter_handle->get(), 0);
     if (interface_claim_error) {
         LOG_ERROR(Input, "libusb_claim_interface failed with error = {}", interface_claim_error);
-        libusb_close(usb_adapter_handle);
         usb_adapter_handle = nullptr;
         return false;
     }
@@ -332,57 +385,17 @@ bool Adapter::GetGCEndpoint(libusb_device* device) {
     // This transfer seems to be responsible for clearing the state of the adapter
     // Used to clear the "busy" state of when the device is unexpectedly unplugged
     unsigned char clear_payload = 0x13;
-    libusb_interrupt_transfer(usb_adapter_handle, output_endpoint, &clear_payload,
+    libusb_interrupt_transfer(usb_adapter_handle->get(), output_endpoint, &clear_payload,
                               sizeof(clear_payload), nullptr, 16);
     return true;
 }
 
-void Adapter::JoinThreads() {
-    restart_scan_thread = false;
-    adapter_input_thread_running = false;
-    adapter_scan_thread_running = false;
-
-    if (adapter_scan_thread.joinable()) {
-        adapter_scan_thread.join();
-    }
-
-    if (adapter_input_thread.joinable()) {
-        adapter_input_thread.join();
-    }
-}
-
-void Adapter::ClearLibusbHandle() {
-    if (usb_adapter_handle) {
-        libusb_release_interface(usb_adapter_handle, 1);
-        libusb_close(usb_adapter_handle);
-        usb_adapter_handle = nullptr;
-    }
-}
-
-void Adapter::ResetDevices() {
-    for (std::size_t i = 0; i < pads.size(); ++i) {
-        ResetDevice(i);
-    }
-}
-
-void Adapter::ResetDevice(std::size_t port) {
-    pads[port].type = ControllerTypes::None;
-    pads[port].enable_vibration = false;
-    pads[port].rumble_amplitude = 0;
-    pads[port].buttons = 0;
-    pads[port].last_button = PadButton::Undefined;
-    pads[port].axis_values.fill(0);
-    pads[port].reset_origin_counter = 0;
-}
-
 void Adapter::Reset() {
-    JoinThreads();
-    ClearLibusbHandle();
-    ResetDevices();
-
-    if (libusb_ctx) {
-        libusb_exit(libusb_ctx);
-    }
+    adapter_scan_thread = {};
+    adapter_input_thread = {};
+    usb_adapter_handle = nullptr;
+    pads = {};
+    libusb_ctx = nullptr;
 }
 
 std::vector<Common::ParamPackage> Adapter::GetInputDevices() const {

--- a/src/shader_recompiler/ir_opt/texture_pass.cpp
+++ b/src/shader_recompiler/ir_opt/texture_pass.cpp
@@ -492,7 +492,7 @@ void TexturePass(Environment& env, IR::Program& program) {
             const auto insert_point{IR::Block::InstructionList::s_iterator_to(*inst)};
             IR::IREmitter ir{*texture_inst.block, insert_point};
             const IR::U32 shift{ir.Imm32(std::countr_zero(DESCRIPTOR_SIZE))};
-            inst->SetArg(0, ir.SMin(ir.ShiftRightArithmetic(cbuf.dynamic_offset, shift),
+            inst->SetArg(0, ir.UMin(ir.ShiftRightArithmetic(cbuf.dynamic_offset, shift),
                                     ir.Imm32(DESCRIPTOR_SIZE - 1)));
         } else {
             inst->SetArg(0, IR::Value{});

--- a/src/video_core/dirty_flags.h
+++ b/src/video_core/dirty_flags.h
@@ -38,6 +38,9 @@ enum : u8 {
 
     Shaders,
 
+    // Special entries
+    DepthBiasGlobal,
+
     LastCommonEntry,
 };
 

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -181,6 +181,21 @@ Device::Device() {
         LOG_ERROR(Render_OpenGL, "Assembly shaders enabled but not supported");
         shader_backend = Settings::ShaderBackend::GLSL;
     }
+
+    if (shader_backend == Settings::ShaderBackend::GLSL && is_nvidia &&
+        !Settings::values.renderer_debug) {
+        const std::string_view driver_version = version.substr(13);
+        const int version_major =
+            std::atoi(driver_version.substr(0, driver_version.find(".")).data());
+
+        if (version_major >= 495) {
+            LOG_WARNING(Render_OpenGL, "NVIDIA drivers 495 and later causes significant problems "
+                                       "with yuzu. Forcing GLASM as a mitigation.");
+            shader_backend = Settings::ShaderBackend::GLASM;
+            use_assembly_shaders = true;
+        }
+    }
+
     // Blocks AMD and Intel OpenGL drivers on Windows from using asynchronous shader compilation.
     use_asynchronous_shaders = Settings::values.use_asynchronous_shaders.GetValue() &&
                                !(is_amd || (is_intel && !is_linux));

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -627,9 +627,21 @@ void RasterizerVulkan::UpdateDepthBias(Tegra::Engines::Maxwell3D::Regs& regs) {
     if (!state_tracker.TouchDepthBias()) {
         return;
     }
-    scheduler.Record([constant = regs.polygon_offset_units, clamp = regs.polygon_offset_clamp,
+    float units = regs.polygon_offset_units / 2.0f;
+    const bool is_d24 = regs.zeta.format == Tegra::DepthFormat::S8_UINT_Z24_UNORM ||
+                        regs.zeta.format == Tegra::DepthFormat::D24X8_UNORM ||
+                        regs.zeta.format == Tegra::DepthFormat::D24S8_UNORM ||
+                        regs.zeta.format == Tegra::DepthFormat::D24C8_UNORM;
+    if (is_d24 && !device.SupportsD24DepthBuffer()) {
+        // the base formulas can be obtained from here:
+        //   https://docs.microsoft.com/en-us/windows/win32/direct3d11/d3d10-graphics-programming-guide-output-merger-stage-depth-bias
+        const double rescale_factor =
+            static_cast<double>(1ULL << (32 - 24)) / (static_cast<double>(0x1.ep+127));
+        units = static_cast<float>(static_cast<double>(units) * rescale_factor);
+    }
+    scheduler.Record([constant = units, clamp = regs.polygon_offset_clamp,
                       factor = regs.polygon_offset_factor](vk::CommandBuffer cmdbuf) {
-        cmdbuf.SetDepthBias(constant, clamp, factor / 2.0f);
+        cmdbuf.SetDepthBias(constant, clamp, factor);
     });
 }
 

--- a/src/video_core/renderer_vulkan/vk_state_tracker.cpp
+++ b/src/video_core/renderer_vulkan/vk_state_tracker.cpp
@@ -54,6 +54,7 @@ void SetupDirtyViewports(Tables& tables) {
     FillBlock(tables[0], OFF(viewport_transform), NUM(viewport_transform), Viewports);
     FillBlock(tables[0], OFF(viewports), NUM(viewports), Viewports);
     tables[0][OFF(viewport_transform_enabled)] = Viewports;
+    tables[1][OFF(screen_y_control)] = Viewports;
 }
 
 void SetupDirtyScissors(Tables& tables) {

--- a/src/video_core/renderer_vulkan/vk_state_tracker.h
+++ b/src/video_core/renderer_vulkan/vk_state_tracker.h
@@ -79,7 +79,8 @@ public:
     }
 
     bool TouchDepthBias() {
-        return Exchange(Dirty::DepthBias, false);
+        return Exchange(Dirty::DepthBias, false) ||
+               Exchange(VideoCommon::Dirty::DepthBiasGlobal, false);
     }
 
     bool TouchBlendConstants() {

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -221,6 +221,7 @@ void TextureCache<P>::UpdateRenderTargets(bool is_clear) {
         BindRenderTarget(&render_targets.depth_buffer_id, FindDepthBuffer(is_clear));
     }
     const ImageViewId depth_buffer_id = render_targets.depth_buffer_id;
+
     PrepareImageView(depth_buffer_id, true, is_clear && IsFullClear(depth_buffer_id));
 
     for (size_t index = 0; index < NUM_RT; ++index) {
@@ -230,6 +231,8 @@ void TextureCache<P>::UpdateRenderTargets(bool is_clear) {
         maxwell3d.regs.render_area.width,
         maxwell3d.regs.render_area.height,
     };
+
+    flags[Dirty::DepthBiasGlobal] = true;
 }
 
 template <class P>

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -623,6 +623,10 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
         is_float16_supported = false;
     }
 
+    supports_d24_depth =
+        IsFormatSupported(VK_FORMAT_D24_UNORM_S8_UINT,
+                          VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT, FormatType::Optimal);
+
     graphics_queue = logical.GetQueue(graphics_family);
     present_queue = logical.GetQueue(present_family);
 }

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -332,6 +332,10 @@ public:
         return sets_per_pool;
     }
 
+    bool SupportsD24DepthBuffer() const {
+        return supports_d24_depth;
+    }
+
 private:
     /// Checks if the physical device is suitable.
     void CheckSuitability(bool requires_swapchain) const;
@@ -425,6 +429,7 @@ private:
     bool has_broken_cube_compatibility{};   ///< Has broken cube compatiblity bit
     bool has_renderdoc{};                   ///< Has RenderDoc attached
     bool has_nsight_graphics{};             ///< Has Nsight Graphics attached
+    bool supports_d24_depth{};              ///< Supports D24 depth buffers.
 
     // Telemetry parameters
     std::string vendor_name;                       ///< Device's driver name.

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -299,6 +299,11 @@ if (YUZU_USE_BUNDLED_QT)
     copy_yuzu_Qt5_deps(yuzu)
 endif()
 
+if (ENABLE_SDL2)
+    target_link_libraries(yuzu PRIVATE SDL2)
+    target_compile_definitions(yuzu PRIVATE HAVE_SDL2)
+endif()
+
 if (MSVC)
     include(CopyYuzuSDLDeps)
     include(CopyYuzuFFmpegDeps)

--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -81,8 +81,11 @@ ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry,
     SetConfiguration();
     PopulateSelectionList();
 
-    connect(ui->tabWidget, &QTabWidget::currentChanged, this,
-            [this]() { debug_tab_tab->SetCurrentIndex(0); });
+    connect(ui->tabWidget, &QTabWidget::currentChanged, this, [this](int index) {
+        if (index != -1) {
+            debug_tab_tab->SetCurrentIndex(0);
+        }
+    });
     connect(ui_tab.get(), &ConfigureUi::LanguageChanged, this, &ConfigureDialog::OnLanguageChanged);
     connect(ui->selectorList, &QListWidget::itemSelectionChanged, this,
             &ConfigureDialog::UpdateVisibleTabs);

--- a/src/yuzu/configuration/configure_per_game.cpp
+++ b/src/yuzu/configuration/configure_per_game.cpp
@@ -66,7 +66,7 @@ ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id, const std::str
     ui->tabWidget->addTab(system_tab.get(), tr("System"));
     ui->tabWidget->addTab(cpu_tab.get(), tr("CPU"));
     ui->tabWidget->addTab(graphics_tab.get(), tr("Graphics"));
-    ui->tabWidget->addTab(graphics_advanced_tab.get(), tr("GraphicsAdvanced"));
+    ui->tabWidget->addTab(graphics_advanced_tab.get(), tr("Adv. Graphics"));
     ui->tabWidget->addTab(audio_tab.get(), tr("Audio"));
 
     setFocusPolicy(Qt::ClickFocus);

--- a/src/yuzu/configuration/configure_per_game.ui
+++ b/src/yuzu/configuration/configure_per_game.ui
@@ -2,14 +2,6 @@
 <ui version="4.0">
  <class>ConfigurePerGame</class>
  <widget class="QDialog" name="ConfigurePerGame">
-  <property name="geometry">
-   <rect>
-    <x>0</x>
-    <y>0</y>
-    <width>900</width>
-    <height>630</height>
-   </rect>
-  </property>
   <property name="minimumSize">
    <size>
     <width>900</width>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -291,13 +291,7 @@ GMainWindow::GMainWindow()
 
     ui->action_Fullscreen->setChecked(false);
 
-#if defined(HAVE_SDL2) && !defined(_WIN32)
-    SDL_InitSubSystem(SDL_INIT_VIDEO);
-    // SDL disables the screen saver by default, and setting the hint
-    // SDL_HINT_VIDEO_ALLOW_SCREENSAVER doesn't seem to work, so we just enable the screen saver
-    // for now.
-    SDL_EnableScreenSaver();
-#endif
+    Common::Log::Start();
 
     QStringList args = QApplication::arguments();
 


### PR DESCRIPTION
This addresses a few problems I have had with the logger.

Moving the backend thread out of the constructor gives the queue some time to build some entrys before starting to PopWait them off. I would occasionally crash on booting yuzu due to collision in the queue.

Moving to a stop_source ensures that there is a clean shutdown. I would have to manually kill my gdb session because the logger would be stuck waiting on an entry to pop. 