### PR TITLE
Fix memory leak v2

### DIFF
--- a/src/core/hle/kernel/k_handle_table.cpp
+++ b/src/core/hle/kernel/k_handle_table.cpp
@@ -56,6 +56,7 @@ bool KHandleTable::Remove(Handle handle) {
     }
 
     // Close the object.
+    kernel.UnregisterInUseObject(obj);
     obj->Close();
     return true;
 }

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -434,11 +434,6 @@ void KProcess::PrepareForTermination() {
 }
 
 void KProcess::Finalize() {
-    // Release memory to the resource limit.
-    if (resource_limit != nullptr) {
-        resource_limit->Close();
-    }
-
     // Finalize the handle table and close any open handles.
     handle_table.Finalize();
 
@@ -458,6 +453,12 @@ void KProcess::Finalize() {
             it = shared_memory_list.erase(it);
             KSharedMemoryInfo::Free(kernel, info);
         }
+    }
+
+    // Release memory to the resource limit.
+    if (resource_limit != nullptr) {
+        resource_limit->Close();
+        resource_limit = nullptr;
     }
 
     // Perform inherited finalization.

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -174,8 +174,8 @@ struct KernelCore::Impl {
         {
             std::lock_guard lk(registered_in_use_objects_lock);
             if (registered_in_use_objects.size()) {
-                for (auto thread : registered_in_use_objects) {
-                    thread->Close();
+                for (auto& object : registered_in_use_objects) {
+                    object->Close();
                 }
                 registered_in_use_objects.clear();
             }

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -91,12 +91,6 @@ struct KernelCore::Impl {
     }
 
     void Shutdown() {
-        // Shutdown all processes.
-        if (current_process) {
-            current_process->Finalize();
-            current_process->Close();
-            current_process = nullptr;
-        }
         process_list.clear();
 
         // Close all open server ports.
@@ -179,6 +173,13 @@ struct KernelCore::Impl {
                 }
                 registered_in_use_objects.clear();
             }
+        }
+
+        // Shutdown all processes.
+        if (current_process) {
+            current_process->Finalize();
+            current_process->Close();
+            current_process = nullptr;
         }
 
         // Track kernel objects that were not freed on shutdown

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -170,6 +170,17 @@ struct KernelCore::Impl {
         // Next host thead ID to use, 0-3 IDs represent core threads, >3 represent others
         next_host_thread_id = Core::Hardware::NUM_CPU_CORES;
 
+        // Close kernel objects that were not freed on shutdown
+        {
+            std::lock_guard lk(registered_in_use_objects_lock);
+            if (registered_in_use_objects.size()) {
+                for (auto thread : registered_in_use_objects) {
+                    thread->Close();
+                }
+                registered_in_use_objects.clear();
+            }
+        }
+
         // Track kernel objects that were not freed on shutdown
         {
             std::lock_guard lk(registered_objects_lock);
@@ -714,9 +725,11 @@ struct KernelCore::Impl {
     std::unordered_set<KServerPort*> server_ports;
     std::unordered_set<KServerSession*> server_sessions;
     std::unordered_set<KAutoObject*> registered_objects;
+    std::unordered_set<KAutoObject*> registered_in_use_objects;
     std::mutex server_ports_lock;
     std::mutex server_sessions_lock;
     std::mutex registered_objects_lock;
+    std::mutex registered_in_use_objects_lock;
 
     std::unique_ptr<Core::ExclusiveMonitor> exclusive_monitor;
     std::vector<Kernel::PhysicalCore> cores;
@@ -926,6 +939,16 @@ void KernelCore::RegisterKernelObject(KAutoObject* object) {
 void KernelCore::UnregisterKernelObject(KAutoObject* object) {
     std::lock_guard lk(impl->registered_objects_lock);
     impl->registered_objects.erase(object);
+}
+
+void KernelCore::RegisterInUseObject(KAutoObject* object) {
+    std::lock_guard lk(impl->registered_in_use_objects_lock);
+    impl->registered_in_use_objects.insert(object);
+}
+
+void KernelCore::UnregisterInUseObject(KAutoObject* object) {
+    std::lock_guard lk(impl->registered_in_use_objects_lock);
+    impl->registered_in_use_objects.erase(object);
 }
 
 bool KernelCore::IsValidNamedPort(NamedPortTable::const_iterator port) const {

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -204,6 +204,14 @@ public:
     /// destroyed during the current emulation session.
     void UnregisterKernelObject(KAutoObject* object);
 
+    /// Registers kernel objects with guest in use state, this is purely for close
+    /// after emulation has been shutdown.
+    void RegisterInUseObject(KAutoObject* object);
+
+    /// Unregisters a kernel object previously registered with RegisterInUseObject when it was
+    /// destroyed during the current emulation session.
+    void UnregisterInUseObject(KAutoObject* object);
+
     /// Determines whether or not the given port is a valid named port.
     bool IsValidNamedPort(NamedPortTable::const_iterator port) const;
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -427,11 +427,15 @@ static ResultCode WaitSynchronization(Core::System& system, s32* index, VAddr ha
         R_UNLESS(handle_table.GetMultipleObjects<KSynchronizationObject>(objs.data(), handles,
                                                                          num_handles),
                  ResultInvalidHandle);
+        for (const auto& obj : objs) {
+            kernel.RegisterInUseObject(obj);
+        }
     }
 
     // Ensure handles are closed when we're done.
     SCOPE_EXIT({
         for (u64 i = 0; i < num_handles; ++i) {
+            kernel.UnregisterInUseObject(objs[i]);
             objs[i]->Close();
         }
     });
@@ -1544,6 +1548,7 @@ static ResultCode StartThread(Core::System& system, Handle thread_handle) {
 
     // If we succeeded, persist a reference to the thread.
     thread->Open();
+    system.Kernel().RegisterInUseObject(thread.GetPointerUnsafe());
 
     return ResultSuccess;
 }
@@ -1559,6 +1564,7 @@ static void ExitThread(Core::System& system) {
     auto* const current_thread = system.Kernel().CurrentScheduler()->GetCurrentThread();
     system.GlobalSchedulerContext().RemoveThread(current_thread);
     current_thread->Exit();
+    system.Kernel().UnregisterInUseObject(current_thread);
 }
 
 static void ExitThread32(Core::System& system) {


### PR DESCRIPTION
1. Fix svc WaitSynchronization objects may not be released correctly.
2. Fix svc StartThread thread leak.
3. Fix dangling kernel objects when exiting.
4. Revert #7009 