### PR TITLE
hle/result: Remove cv-qualifiers from Arg in MakeResult

### DIFF
--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -329,8 +329,8 @@ template <typename T, typename... Args>
  * copy or move constructing.
  */
 template <typename Arg>
-[[nodiscard]] ResultVal<std::remove_reference_t<Arg>> MakeResult(Arg&& arg) {
-    return ResultVal<std::remove_reference_t<Arg>>::WithCode(ResultSuccess, std::forward<Arg>(arg));
+[[nodiscard]] ResultVal<std::remove_cvref_t<Arg>> MakeResult(Arg&& arg) {
+    return ResultVal<std::remove_cvref_t<Arg>>::WithCode(ResultSuccess, std::forward<Arg>(arg));
 }
 
 /**


### PR DESCRIPTION
This removes the const qualification for types when MakeResult(arg) is used in a const member function, allowing for automatic deduction and removing the need to manually specify the non-const type as the template argument.