### PR TITLE
file_sys/ns: Add Brazilian Portuguese to the list of ApplicationLanguage

### DIFF
--- a/src/core/file_sys/control_metadata.cpp
+++ b/src/core/file_sys/control_metadata.cpp
@@ -9,7 +9,7 @@
 
 namespace FileSys {
 
-const std::array<const char*, 15> LANGUAGE_NAMES{{
+const std::array<const char*, 16> LANGUAGE_NAMES{{
     "AmericanEnglish",
     "BritishEnglish",
     "Japanese",
@@ -25,6 +25,7 @@ const std::array<const char*, 15> LANGUAGE_NAMES{{
     "Korean",
     "Taiwanese",
     "Chinese",
+    "BrazilianPortuguese",
 }};
 
 std::string LanguageEntry::GetApplicationName() const {

--- a/src/core/file_sys/control_metadata.h
+++ b/src/core/file_sys/control_metadata.h
@@ -88,11 +88,12 @@ enum class Language : u8 {
     Korean = 12,
     Taiwanese = 13,
     Chinese = 14,
+    BrazilianPortuguese = 15,
 
     Default = 255,
 };
 
-extern const std::array<const char*, 15> LANGUAGE_NAMES;
+extern const std::array<const char*, 16> LANGUAGE_NAMES;
 
 // A class representing the format used by NX metadata files, typically named Control.nacp.
 // These store application name, dev name, title id, and other miscellaneous data.

--- a/src/core/hle/service/ns/language.cpp
+++ b/src/core/hle/service/ns/language.cpp
@@ -277,6 +277,25 @@ constexpr ApplicationLanguagePriorityList priority_list_simplified_chinese = {{
     ApplicationLanguage::Korean,
 }};
 
+constexpr ApplicationLanguagePriorityList priority_list_brazilian_portuguese = {{
+    ApplicationLanguage::BrazilianPortuguese,
+    ApplicationLanguage::Portuguese,
+    ApplicationLanguage::LatinAmericanSpanish,
+    ApplicationLanguage::AmericanEnglish,
+    ApplicationLanguage::BritishEnglish,
+    ApplicationLanguage::Japanese,
+    ApplicationLanguage::French,
+    ApplicationLanguage::German,
+    ApplicationLanguage::Spanish,
+    ApplicationLanguage::Italian,
+    ApplicationLanguage::Dutch,
+    ApplicationLanguage::CanadianFrench,
+    ApplicationLanguage::Russian,
+    ApplicationLanguage::Korean,
+    ApplicationLanguage::SimplifiedChinese,
+    ApplicationLanguage::TraditionalChinese,
+}};
+
 const ApplicationLanguagePriorityList* GetApplicationLanguagePriorityList(
     const ApplicationLanguage lang) {
     switch (lang) {
@@ -310,6 +329,8 @@ const ApplicationLanguagePriorityList* GetApplicationLanguagePriorityList(
         return &priority_list_traditional_chinese;
     case ApplicationLanguage::SimplifiedChinese:
         return &priority_list_simplified_chinese;
+    case ApplicationLanguage::BrazilianPortuguese:
+        return &priority_list_brazilian_portuguese;
     default:
         return nullptr;
     }
@@ -339,7 +360,6 @@ std::optional<ApplicationLanguage> ConvertToApplicationLanguage(
     case Set::LanguageCode::FR_CA:
         return ApplicationLanguage::CanadianFrench;
     case Set::LanguageCode::PT:
-    case Set::LanguageCode::PT_BR:
         return ApplicationLanguage::Portuguese;
     case Set::LanguageCode::RU:
         return ApplicationLanguage::Russian;
@@ -351,6 +371,8 @@ std::optional<ApplicationLanguage> ConvertToApplicationLanguage(
     case Set::LanguageCode::ZH_CN:
     case Set::LanguageCode::ZH_HANS:
         return ApplicationLanguage::SimplifiedChinese;
+    case Set::LanguageCode::PT_BR:
+        return ApplicationLanguage::BrazilianPortuguese;
     default:
         return std::nullopt;
     }
@@ -388,6 +410,8 @@ std::optional<Set::LanguageCode> ConvertToLanguageCode(const ApplicationLanguage
         return Set::LanguageCode::ZH_HANT;
     case ApplicationLanguage::SimplifiedChinese:
         return Set::LanguageCode::ZH_HANS;
+    case ApplicationLanguage::BrazilianPortuguese:
+        return Set::LanguageCode::PT_BR;
     default:
         return std::nullopt;
     }

--- a/src/core/hle/service/ns/language.h
+++ b/src/core/hle/service/ns/language.h
@@ -30,6 +30,7 @@ enum class ApplicationLanguage : u8 {
     Korean,
     TraditionalChinese,
     SimplifiedChinese,
+    BrazilianPortuguese,
     Count
 };
 using ApplicationLanguagePriorityList =


### PR DESCRIPTION
It seems that Nintendo finally filled that last empty spot in ApplicationLanguage for a total of 16 supported languages.

Should fix pt-BR language support in Mario Party Superstars