### PR TITLE
profile_manager: Resize any image bigger than 256p

### DIFF
--- a/src/yuzu/configuration/configure_profile_manager.cpp
+++ b/src/yuzu/configuration/configure_profile_manager.cpp
@@ -306,6 +306,17 @@ void ConfigureProfileManager::SetUserImage() {
         return;
     }
 
+    // Some games crash when the profile image is too big. Resize any image bigger than 256x256
+    QImage image(image_path);
+    if (image.width() > 256 || image.height() > 256) {
+        image = image.scaled(256, 256, Qt::KeepAspectRatio);
+        if (!image.save(image_path)) {
+            QMessageBox::warning(this, tr("Error resizing user image"),
+                                 tr("Unable to resize image"));
+            return;
+        }
+    }
+
     const auto username = GetAccountUsername(*profile_manager, *uuid);
     item_model->setItem(index, 0,
                         new QStandardItem{GetIcon(*uuid), FormatUserEntryText(username, *uuid)});


### PR DESCRIPTION
Some games seem to be crashing if the profile picture is too big. To avoid this issue we simply resize the image to a smaller size 