### PR TITLE
NvHost: Fix some regressions and correct signaling on timeout.

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -106,30 +106,32 @@ NvResult nvhost_ctrl::IocCtrlEventWait(const std::vector<u8>& input, std::vector
 
     auto& event = events_interface.events[event_id];
     auto& gpu = system.GPU();
-
-    // This is mostly to take into account unimplemented features. As synced
-    // gpu is always synced.
-    if (!gpu.IsAsync()) {
-        event.event->GetWritableEvent().Signal();
-        return NvResult::Success;
-    }
     const u32 current_syncpoint_value = event.fence.value;
     const s32 diff = current_syncpoint_value - params.threshold;
-    if (diff >= 0) {
-        event.event->GetWritableEvent().Signal();
-        params.value = current_syncpoint_value;
-        std::memcpy(output.data(), &params, sizeof(params));
-        events_interface.failed[event_id] = false;
-        return NvResult::Success;
-    }
-    const u32 target_value = current_syncpoint_value - diff;
+    const u32 target_value = params.value;
 
     if (!is_async) {
         params.value = 0;
     }
 
+    const auto check_failing = [&]() {
+        if (events_interface.failed[event_id]) {
+            {
+                auto lk = system.StallCPU();
+                gpu.WaitFence(params.syncpt_id, target_value);
+                system.UnstallCPU();
+            }
+            std::memcpy(output.data(), &params, sizeof(params));
+            events_interface.failed[event_id] = false;
+            return true;
+        }
+        return false;
+    };
+
     if (params.timeout == 0) {
-        std::memcpy(output.data(), &params, sizeof(params));
+        if (check_failing()) {
+            return NvResult::Success;
+        }
         return NvResult::Timeout;
     }
 
@@ -148,15 +150,7 @@ NvResult nvhost_ctrl::IocCtrlEventWait(const std::vector<u8>& input, std::vector
         params.value = ((params.syncpt_id & 0xfff) << 16) | 0x10000000;
     }
     params.value |= event_id;
-    event.event->GetWritableEvent().Clear();
-    if (events_interface.failed[event_id]) {
-        {
-            auto lk = system.StallCPU();
-            gpu.WaitFence(params.syncpt_id, target_value);
-            system.UnstallCPU();
-        }
-        std::memcpy(output.data(), &params, sizeof(params));
-        events_interface.failed[event_id] = false;
+    if (check_failing()) {
         return NvResult::Success;
     }
     gpu.RegisterSyncptInterrupt(params.syncpt_id, target_value);

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -92,7 +92,7 @@ NvResult nvhost_ctrl::IocCtrlEventWait(const std::vector<u8>& input, std::vector
     if (syncpoint_manager.IsSyncpointExpired(params.syncpt_id, params.threshold)) {
         params.value = syncpoint_manager.GetSyncpointMin(params.syncpt_id);
         std::memcpy(output.data(), &params, sizeof(params));
-        events_interface.failed[event_id] = false;
+        events_interface.fails[event_id] = 0;
         return NvResult::Success;
     }
 
@@ -100,29 +100,26 @@ NvResult nvhost_ctrl::IocCtrlEventWait(const std::vector<u8>& input, std::vector
         syncpoint_manager.IsSyncpointExpired(params.syncpt_id, params.threshold)) {
         params.value = new_value;
         std::memcpy(output.data(), &params, sizeof(params));
-        events_interface.failed[event_id] = false;
+        events_interface.fails[event_id] = 0;
         return NvResult::Success;
     }
 
-    auto& event = events_interface.events[event_id];
     auto& gpu = system.GPU();
-    const u32 current_syncpoint_value = event.fence.value;
-    const s32 diff = current_syncpoint_value - params.threshold;
-    const u32 target_value = params.value;
+    const u32 target_value = syncpoint_manager.GetSyncpointMax(params.syncpt_id);
 
     if (!is_async) {
         params.value = 0;
     }
 
     const auto check_failing = [&]() {
-        if (events_interface.failed[event_id]) {
+        if (events_interface.fails[event_id] > 1) {
             {
                 auto lk = system.StallCPU();
                 gpu.WaitFence(params.syncpt_id, target_value);
                 system.UnstallCPU();
             }
             std::memcpy(output.data(), &params, sizeof(params));
-            events_interface.failed[event_id] = false;
+            events_interface.fails[event_id] = 0;
             return true;
         }
         return false;
@@ -208,7 +205,7 @@ NvResult nvhost_ctrl::IocCtrlClearEventWait(const std::vector<u8>& input, std::v
     if (events_interface.status[event_id] == EventState::Waiting) {
         events_interface.LiberateEvent(event_id);
     }
-    events_interface.failed[event_id] = true;
+    events_interface.fails[event_id]++;
 
     syncpoint_manager.RefreshSyncpoint(events_interface.events[event_id].fence.id);
 

--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <vector>
+#include "common/bit_field.h"
 #include "common/common_types.h"
 #include "core/hle/service/nvdrv/devices/nvdevice.h"
 #include "core/hle/service/nvdrv/nvdrv.h"
@@ -27,6 +28,24 @@ public:
 
     void OnOpen(DeviceFD fd) override;
     void OnClose(DeviceFD fd) override;
+
+    union SyncpointEventValue {
+        u32 raw;
+
+        union {
+            BitField<0, 4, u32> partial_slot;
+            BitField<4, 28, u32> syncpoint_id;
+        };
+
+        struct {
+            u16 slot;
+            union {
+                BitField<0, 12, u16> syncpoint_id_for_allocation;
+                BitField<12, 1, u16> event_allocated;
+            };
+        };
+    };
+    static_assert(sizeof(SyncpointEventValue) == sizeof(u32));
 
 private:
     struct IocSyncptReadParams {
@@ -84,27 +103,18 @@ private:
     };
     static_assert(sizeof(IocGetConfigParams) == 387, "IocGetConfigParams is incorrect size");
 
-    struct IocCtrlEventSignalParams {
-        u32_le event_id{};
+    struct IocCtrlEventClearParams {
+        SyncpointEventValue event_id{};
     };
-    static_assert(sizeof(IocCtrlEventSignalParams) == 4,
-                  "IocCtrlEventSignalParams is incorrect size");
+    static_assert(sizeof(IocCtrlEventClearParams) == 4,
+                  "IocCtrlEventClearParams is incorrect size");
 
     struct IocCtrlEventWaitParams {
-        u32_le syncpt_id{};
-        u32_le threshold{};
-        s32_le timeout{};
-        u32_le value{};
-    };
-    static_assert(sizeof(IocCtrlEventWaitParams) == 16, "IocCtrlEventWaitParams is incorrect size");
-
-    struct IocCtrlEventWaitAsyncParams {
-        u32_le syncpt_id{};
-        u32_le threshold{};
+        Fence fence{};
         u32_le timeout{};
-        u32_le value{};
+        SyncpointEventValue value{};
     };
-    static_assert(sizeof(IocCtrlEventWaitAsyncParams) == 16,
+    static_assert(sizeof(IocCtrlEventWaitParams) == 16,
                   "IocCtrlEventWaitAsyncParams is incorrect size");
 
     struct IocCtrlEventRegisterParams {
@@ -125,10 +135,13 @@ private:
     static_assert(sizeof(IocCtrlEventKill) == 8, "IocCtrlEventKill is incorrect size");
 
     NvResult NvOsGetConfigU32(const std::vector<u8>& input, std::vector<u8>& output);
-    NvResult IocCtrlEventWait(const std::vector<u8>& input, std::vector<u8>& output, bool is_async);
+    NvResult IocCtrlEventWait(const std::vector<u8>& input, std::vector<u8>& output,
+                              bool is_allocation);
     NvResult IocCtrlEventRegister(const std::vector<u8>& input, std::vector<u8>& output);
     NvResult IocCtrlEventUnregister(const std::vector<u8>& input, std::vector<u8>& output);
     NvResult IocCtrlClearEventWait(const std::vector<u8>& input, std::vector<u8>& output);
+
+    NvResult FreeEvent(u32 slot);
 
     EventInterface& events_interface;
     SyncpointManager& syncpoint_manager;

--- a/src/core/hle/service/nvdrv/nvdata.h
+++ b/src/core/hle/service/nvdrv/nvdata.h
@@ -1,3 +1,8 @@
+// Copyright 2021 yuzu emulator team
+// Copyright 2021 Skyline Team and Contributors (https://github.com/skyline-emu/)
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 #pragma once
 
 #include <array>
@@ -81,11 +86,15 @@ enum class NvResult : u32 {
     ModuleNotPresent = 0xA000E,
 };
 
+// obtained from
+// https://github.com/skyline-emu/skyline/blob/nvdec-dev/app/src/main/cpp/skyline/services/nvdrv/devices/nvhost/ctrl.h#L47
 enum class EventState {
-    Free = 0,
-    Registered = 1,
-    Waiting = 2,
-    Busy = 3,
+    Available = 0,
+    Waiting = 1,
+    Cancelling = 2,
+    Signalling = 3,
+    Signalled = 4,
+    Cancelled = 5,
 };
 
 union Ioctl {

--- a/src/core/hle/service/nvdrv/nvdrv.h
+++ b/src/core/hle/service/nvdrv/nvdrv.h
@@ -50,7 +50,7 @@ struct EventInterface {
     // Tells if an NVEvent is registered or not
     std::array<bool, MaxNvEvents> registered{};
     // Tells the NVEvent that it has failed.
-    std::array<bool, MaxNvEvents> failed{};
+    std::array<u32, MaxNvEvents> fails{};
     // When an NVEvent is waiting on GPU interrupt, this is the sync_point
     // associated with it.
     std::array<u32, MaxNvEvents> assigned_syncpt{};

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -216,7 +216,7 @@ public:
 
     void RegisterSyncptInterrupt(u32 syncpoint_id, u32 value);
 
-    [[nodiscard]] bool CancelSyncptInterrupt(u32 syncpoint_id, u32 value);
+    bool CancelSyncptInterrupt(u32 syncpoint_id, u32 value);
 
     [[nodiscard]] u64 GetTicks() const;
 


### PR DESCRIPTION
This is a series of fixes half fixing regressions and other half suggested by ByLaws from skyline emulation.