### PR TITLE
ShaderCache: Order Phi Arguments from farthest away to nearest.

### DIFF
--- a/src/shader_recompiler/backend/glasm/emit_glasm_not_implemented.cpp
+++ b/src/shader_recompiler/backend/glasm/emit_glasm_not_implemented.cpp
@@ -18,7 +18,7 @@ namespace Shader::Backend::GLASM {
 #define NotImplemented() throw NotImplementedException("GLASM instruction {}", __LINE__)
 
 static void DefinePhi(EmitContext& ctx, IR::Inst& phi) {
-    switch (phi.Arg(0).Type()) {
+    switch (phi.Type()) {
     case IR::Type::U1:
     case IR::Type::U32:
     case IR::Type::F32:

--- a/src/shader_recompiler/backend/glsl/emit_glsl_special.cpp
+++ b/src/shader_recompiler/backend/glsl/emit_glsl_special.cpp
@@ -68,7 +68,7 @@ void EmitPhi(EmitContext& ctx, IR::Inst& phi) {
     }
     if (!phi.Definition<Id>().is_valid) {
         // The phi node wasn't forward defined
-        ctx.var_alloc.PhiDefine(phi, phi.Arg(0).Type());
+        ctx.var_alloc.PhiDefine(phi, phi.Type());
     }
 }
 
@@ -80,7 +80,7 @@ void EmitReference(EmitContext& ctx, const IR::Value& value) {
 
 void EmitPhiMove(EmitContext& ctx, const IR::Value& phi_value, const IR::Value& value) {
     IR::Inst& phi{*phi_value.InstRecursive()};
-    const auto phi_type{phi.Arg(0).Type()};
+    const auto phi_type{phi.Type()};
     if (!phi.Definition<Id>().is_valid) {
         // The phi node wasn't forward defined
         ctx.var_alloc.PhiDefine(phi, phi_type);

--- a/src/shader_recompiler/frontend/ir/basic_block.h
+++ b/src/shader_recompiler/frontend/ir/basic_block.h
@@ -152,6 +152,17 @@ public:
         return instructions.crend();
     }
 
+    // Set the order of the block, it can be set pre order, the user decides
+    void SetOrder(u32 new_order) {
+        order = new_order;
+    }
+
+    // Get the order of the block.
+    // The higher, the closer is the block to the end.
+    [[nodiscard]] u32 GetOrder() const {
+        return order;
+    }
+
 private:
     /// Memory pool for instruction list
     ObjectPool<Inst>* inst_pool;
@@ -171,6 +182,9 @@ private:
 
     /// Intrusively stored host definition of this block.
     u32 definition{};
+
+    /// Order of the block.
+    u32 order{};
 };
 
 using BlockList = std::vector<Block*>;

--- a/src/shader_recompiler/frontend/ir/microinstruction.cpp
+++ b/src/shader_recompiler/frontend/ir/microinstruction.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 
 #include "shader_recompiler/exception.h"
+#include "shader_recompiler/frontend/ir/basic_block.h"
 #include "shader_recompiler/frontend/ir/type.h"
 #include "shader_recompiler/frontend/ir/value.h"
 
@@ -289,6 +290,16 @@ void Inst::AddPhiOperand(Block* predecessor, const Value& value) {
         Use(value);
     }
     phi_args.emplace_back(predecessor, value);
+}
+
+void Inst::OrderPhiArgs() {
+    if (op != Opcode::Phi) {
+        throw LogicError("{} is not a Phi instruction", op);
+    }
+    std::sort(phi_args.begin(), phi_args.end(),
+              [](const std::pair<Block*, Value>& a, const std::pair<Block*, Value>& b) {
+                  return a.first->GetOrder() < b.first->GetOrder();
+              });
 }
 
 void Inst::Invalidate() {

--- a/src/shader_recompiler/frontend/ir/microinstruction.cpp
+++ b/src/shader_recompiler/frontend/ir/microinstruction.cpp
@@ -254,6 +254,10 @@ Inst* Inst::GetAssociatedPseudoOperation(IR::Opcode opcode) {
 }
 
 IR::Type Inst::Type() const {
+    if (op == IR::Opcode::Phi) {
+        // The type of a phi node is stored in its flags
+        return Flags<IR::Type>();
+    }
     return TypeOf(op);
 }
 

--- a/src/shader_recompiler/frontend/ir/value.h
+++ b/src/shader_recompiler/frontend/ir/value.h
@@ -182,6 +182,9 @@ public:
     /// Add phi operand to a phi instruction.
     void AddPhiOperand(Block* predecessor, const Value& value);
 
+    /// Orders the Phi arguments from farthest away to nearest.
+    void OrderPhiArgs();
+
     void Invalidate();
     void ClearArgs();
 

--- a/src/shader_recompiler/frontend/maxwell/translate_program.cpp
+++ b/src/shader_recompiler/frontend/maxwell/translate_program.cpp
@@ -27,9 +27,11 @@ IR::BlockList GenerateBlocks(const IR::AbstractSyntaxList& syntax_list) {
     }
     IR::BlockList blocks;
     blocks.reserve(num_syntax_blocks);
+    u32 order_index{};
     for (const auto& node : syntax_list) {
         if (node.type == IR::AbstractSyntaxNode::Type::Block) {
             blocks.push_back(node.data.block);
+            blocks.back()->SetOrder(order_index++);
         }
     }
     return blocks;

--- a/src/shader_recompiler/ir_opt/ssa_rewrite_pass.cpp
+++ b/src/shader_recompiler/ir_opt/ssa_rewrite_pass.cpp
@@ -378,6 +378,13 @@ void SsaRewritePass(IR::Program& program) {
     for (auto block = program.post_order_blocks.rbegin(); block != end; ++block) {
         VisitBlock(pass, *block);
     }
+    for (auto block = program.post_order_blocks.rbegin(); block != end; ++block) {
+        for (IR::Inst& inst : (*block)->Instructions()) {
+            if (inst.GetOpcode() == IR::Opcode::Phi) {
+                inst.OrderPhiArgs();
+            }
+        }
+    }
 }
 
 } // namespace Shader::Optimization


### PR DESCRIPTION
This fixes the post processing in Mario Party SuperStars.

The idea of this is so the tracking algorithm, gets the nearest instances first rather than the oldest instances of a value.