### PR TITLE
Logging: Impl refactor

### DIFF
--- a/src/common/logging/backend.h
+++ b/src/common/logging/backend.h
@@ -14,6 +14,8 @@ class Filter;
 /// Initializes the logging system. This should be the first thing called in main.
 void Initialize();
 
+void Start();
+
 void DisableLoggingInTests();
 
 /**

--- a/src/common/logging/log_entry.h
+++ b/src/common/logging/log_entry.h
@@ -22,7 +22,6 @@ struct Entry {
     unsigned int line_num = 0;
     std::string function;
     std::string message;
-    bool final_entry = false;
 };
 
 } // namespace Common::Log

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -299,6 +299,8 @@ GMainWindow::GMainWindow()
     SDL_EnableScreenSaver();
 #endif
 
+    Common::Log::Start();
+
     QStringList args = QApplication::arguments();
 
     if (args.size() < 2) {


### PR DESCRIPTION
This addresses a few problems I have had with the logger.

Moving the backend thread out of the constructor gives the queue some time to build some entrys before starting to PopWait them off. I would occasionally crash on booting yuzu due to collision in the queue.

Moving to a stop_source ensures that there is a clean shutdown. I would have to manually kill my gdb session because the logger would be stuck waiting on an entry to pop.