### PR TITLE
Move the cmake submodule checkout command to a new line

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ function(check_submodules_present)
         string(REGEX REPLACE "path *= *" "" module ${module})
         if (NOT EXISTS "${PROJECT_SOURCE_DIR}/${module}/.git")
             message(FATAL_ERROR "Git submodule ${module} not found. "
-                    "Please run: git submodule update --init --recursive")
+                    "Please run: \ngit submodule update --init --recursive")
         endif()
     endforeach()
 endfunction()


### PR DESCRIPTION
Move the cmake submodule checkout command to a new line

Presently, if you forget to initialize the git submodules before
running cmake, there'll be a helpful message that reminds you to do so.
However, on narrow terminals (e.g. 80 wide) there's a word wrap that
includes a new line in the middle of the git command, precluding easy
copy-paste.  This moves the entire git command to its own line to avoid
such tragedies.

Before:

```
CMake Error at CMakeLists.txt:59 (message):
  Git submodule externals/inih/inih not found.  Please run: git submodule
  update --init --recursive
```

After:

```
CMake Error at CMakeLists.txt:59 (message):
  Git submodule externals/inih/inih not found.  Please run:

  git submodule update --init --recursive
```