### PR TITLE
Skip checking if a u64 is non-negative

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -414,7 +414,7 @@ static ResultCode WaitSynchronization(Core::System& system, s32* index, VAddr ha
               handles_address, num_handles, nano_seconds);
 
     // Ensure number of handles is valid.
-    R_UNLESS(0 <= num_handles && num_handles <= ArgumentHandleCountMax, ResultOutOfRange);
+    R_UNLESS(num_handles <= ArgumentHandleCountMax, ResultOutOfRange);
 
     auto& kernel = system.Kernel();
     std::vector<KSynchronizationObject*> objs(num_handles);


### PR DESCRIPTION
It is sufficient to allow the compiler to check if num_handles in
svc.cpp:WaitSynchronization is non-negative because it is unsigned, so
let's not put code (and compiler warnings!) towards that.