### PR TITLE
general: Get the current process program id directly from the system

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -639,6 +639,10 @@ const Core::SpeedLimiter& System::SpeedLimiter() const {
     return impl->speed_limiter;
 }
 
+u64 System::GetCurrentProcessProgramID() const {
+    return impl->kernel.CurrentProcess()->GetProgramID();
+}
+
 Loader::ResultStatus System::GetGameName(std::string& out) const {
     return impl->GetGameName(out);
 }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -349,7 +349,7 @@ struct System::Impl {
         }
 
         Service::Glue::ApplicationLaunchProperty launch{};
-        launch.title_id = process.GetTitleID();
+        launch.title_id = process.GetProgramID();
 
         FileSys::PatchManager pm{launch.title_id, fs_controller, *content_provider};
         launch.version = pm.GetGameVersion().value_or(0);

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -297,6 +297,8 @@ public:
     /// Provides a constant reference to the speed limiter
     [[nodiscard]] const Core::SpeedLimiter& SpeedLimiter() const;
 
+    [[nodiscard]] u64 GetCurrentProcessProgramID() const;
+
     /// Gets the name of the current game
     [[nodiscard]] Loader::ResultStatus GetGameName(std::string& out) const;
 

--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -9,7 +9,6 @@
 #include "core/core.h"
 #include "core/file_sys/savedata_factory.h"
 #include "core/file_sys/vfs.h"
-#include "core/hle/kernel/k_process.h"
 
 namespace FileSys {
 
@@ -143,7 +142,7 @@ std::string SaveDataFactory::GetFullPath(Core::System& system, SaveDataSpaceId s
     // be interpreted as the title id of the current process.
     if (type == SaveDataType::SaveData || type == SaveDataType::DeviceSaveData) {
         if (title_id == 0) {
-            title_id = system.CurrentProcess()->GetProgramID();
+            title_id = system.GetCurrentProcessProgramID();
         }
     }
 

--- a/src/core/file_sys/savedata_factory.cpp
+++ b/src/core/file_sys/savedata_factory.cpp
@@ -143,7 +143,7 @@ std::string SaveDataFactory::GetFullPath(Core::System& system, SaveDataSpaceId s
     // be interpreted as the title id of the current process.
     if (type == SaveDataType::SaveData || type == SaveDataType::DeviceSaveData) {
         if (title_id == 0) {
-            title_id = system.CurrentProcess()->GetTitleID();
+            title_id = system.CurrentProcess()->GetProgramID();
         }
     }
 

--- a/src/core/hle/kernel/k_process.h
+++ b/src/core/hle/kernel/k_process.h
@@ -154,8 +154,8 @@ public:
         return process_id;
     }
 
-    /// Gets the title ID corresponding to this process.
-    u64 GetTitleID() const {
+    /// Gets the program ID corresponding to this process.
+    u64 GetProgramID() const {
         return program_id;
     }
 

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -768,7 +768,7 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, Handle
             return ResultSuccess;
 
         case GetInfoType::TitleId:
-            *result = process->GetTitleID();
+            *result = process->GetProgramID();
             return ResultSuccess;
 
         case GetInfoType::UserExceptionContextAddr:

--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -16,7 +16,6 @@
 #include "core/file_sys/control_metadata.h"
 #include "core/file_sys/patch_manager.h"
 #include "core/hle/ipc_helpers.h"
-#include "core/hle/kernel/k_process.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/service/acc/acc.h"
 #include "core/hle/service/acc/acc_aa.h"
@@ -759,9 +758,8 @@ ResultCode Module::Interface::InitializeApplicationInfoBase() {
     // TODO(ogniK): This should be changed to reflect the target process for when we have multiple
     // processes emulated. As we don't actually have pid support we should assume we're just using
     // our own process
-    const auto& current_process = system.Kernel().CurrentProcess();
     const auto launch_property =
-        system.GetARPManager().GetLaunchProperty(current_process->GetProgramID());
+        system.GetARPManager().GetLaunchProperty(system.GetCurrentProcessProgramID());
 
     if (launch_property.Failed()) {
         LOG_ERROR(Service_ACC, "Failed to get launch property");
@@ -805,7 +803,7 @@ void Module::Interface::IsUserAccountSwitchLocked(Kernel::HLERequestContext& ctx
     bool is_locked = false;
 
     if (res != Loader::ResultStatus::Success) {
-        const FileSys::PatchManager pm{system.CurrentProcess()->GetProgramID(),
+        const FileSys::PatchManager pm{system.GetCurrentProcessProgramID(),
                                        system.GetFileSystemController(),
                                        system.GetContentProvider()};
         const auto nacp_unique = pm.GetControlMetadata().first;

--- a/src/core/hle/service/acc/acc.cpp
+++ b/src/core/hle/service/acc/acc.cpp
@@ -761,7 +761,7 @@ ResultCode Module::Interface::InitializeApplicationInfoBase() {
     // our own process
     const auto& current_process = system.Kernel().CurrentProcess();
     const auto launch_property =
-        system.GetARPManager().GetLaunchProperty(current_process->GetTitleID());
+        system.GetARPManager().GetLaunchProperty(current_process->GetProgramID());
 
     if (launch_property.Failed()) {
         LOG_ERROR(Service_ACC, "Failed to get launch property");
@@ -805,7 +805,7 @@ void Module::Interface::IsUserAccountSwitchLocked(Kernel::HLERequestContext& ctx
     bool is_locked = false;
 
     if (res != Loader::ResultStatus::Success) {
-        const FileSys::PatchManager pm{system.CurrentProcess()->GetTitleID(),
+        const FileSys::PatchManager pm{system.CurrentProcess()->GetProgramID(),
                                        system.GetFileSystemController(),
                                        system.GetContentProvider()};
         const auto nacp_unique = pm.GetControlMetadata().first;

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -15,7 +15,6 @@
 #include "core/file_sys/savedata_factory.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/k_event.h"
-#include "core/hle/kernel/k_process.h"
 #include "core/hle/kernel/k_transfer_memory.h"
 #include "core/hle/service/acc/profile_manager.h"
 #include "core/hle/service/am/am.h"
@@ -1429,8 +1428,7 @@ void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
         u64 build_id{};
         std::memcpy(&build_id, build_id_full.data(), sizeof(u64));
 
-        auto data =
-            backend->GetLaunchParameter({system.CurrentProcess()->GetProgramID(), build_id});
+        auto data = backend->GetLaunchParameter({system.GetCurrentProcessProgramID(), build_id});
         if (data.has_value()) {
             IPC::ResponseBuilder rb{ctx, 2, 0, 1};
             rb.Push(ResultSuccess);
@@ -1482,7 +1480,7 @@ void IApplicationFunctions::EnsureSaveData(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called, uid={:016X}{:016X}", user_id[1], user_id[0]);
 
     FileSys::SaveDataAttribute attribute{};
-    attribute.title_id = system.CurrentProcess()->GetProgramID();
+    attribute.title_id = system.GetCurrentProcessProgramID();
     attribute.user_id = user_id;
     attribute.type = FileSys::SaveDataType::SaveData;
     const auto res = system.GetFileSystemController().CreateSaveData(
@@ -1512,7 +1510,7 @@ void IApplicationFunctions::GetDisplayVersion(Kernel::HLERequestContext& ctx) {
     std::array<u8, 0x10> version_string{};
 
     const auto res = [this] {
-        const auto title_id = system.CurrentProcess()->GetProgramID();
+        const auto title_id = system.GetCurrentProcessProgramID();
 
         const FileSys::PatchManager pm{title_id, system.GetFileSystemController(),
                                        system.GetContentProvider()};
@@ -1549,7 +1547,7 @@ void IApplicationFunctions::GetDesiredLanguage(Kernel::HLERequestContext& ctx) {
     u32 supported_languages = 0;
 
     const auto res = [this] {
-        const auto title_id = system.CurrentProcess()->GetProgramID();
+        const auto title_id = system.GetCurrentProcessProgramID();
 
         const FileSys::PatchManager pm{title_id, system.GetFileSystemController(),
                                        system.GetContentProvider()};
@@ -1657,8 +1655,7 @@ void IApplicationFunctions::ExtendSaveData(Kernel::HLERequestContext& ctx) {
               static_cast<u8>(type), user_id[1], user_id[0], new_normal_size, new_journal_size);
 
     system.GetFileSystemController().WriteSaveDataSize(
-        type, system.CurrentProcess()->GetProgramID(), user_id,
-        {new_normal_size, new_journal_size});
+        type, system.GetCurrentProcessProgramID(), user_id, {new_normal_size, new_journal_size});
 
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(ResultSuccess);
@@ -1682,7 +1679,7 @@ void IApplicationFunctions::GetSaveDataSize(Kernel::HLERequestContext& ctx) {
               user_id[0]);
 
     const auto size = system.GetFileSystemController().ReadSaveDataSize(
-        type, system.CurrentProcess()->GetProgramID(), user_id);
+        type, system.GetCurrentProcessProgramID(), user_id);
 
     IPC::ResponseBuilder rb{ctx, 6};
     rb.Push(ResultSuccess);

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -1429,7 +1429,8 @@ void IApplicationFunctions::PopLaunchParameter(Kernel::HLERequestContext& ctx) {
         u64 build_id{};
         std::memcpy(&build_id, build_id_full.data(), sizeof(u64));
 
-        auto data = backend->GetLaunchParameter({system.CurrentProcess()->GetTitleID(), build_id});
+        auto data =
+            backend->GetLaunchParameter({system.CurrentProcess()->GetProgramID(), build_id});
         if (data.has_value()) {
             IPC::ResponseBuilder rb{ctx, 2, 0, 1};
             rb.Push(ResultSuccess);
@@ -1481,7 +1482,7 @@ void IApplicationFunctions::EnsureSaveData(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_AM, "called, uid={:016X}{:016X}", user_id[1], user_id[0]);
 
     FileSys::SaveDataAttribute attribute{};
-    attribute.title_id = system.CurrentProcess()->GetTitleID();
+    attribute.title_id = system.CurrentProcess()->GetProgramID();
     attribute.user_id = user_id;
     attribute.type = FileSys::SaveDataType::SaveData;
     const auto res = system.GetFileSystemController().CreateSaveData(
@@ -1511,7 +1512,7 @@ void IApplicationFunctions::GetDisplayVersion(Kernel::HLERequestContext& ctx) {
     std::array<u8, 0x10> version_string{};
 
     const auto res = [this] {
-        const auto title_id = system.CurrentProcess()->GetTitleID();
+        const auto title_id = system.CurrentProcess()->GetProgramID();
 
         const FileSys::PatchManager pm{title_id, system.GetFileSystemController(),
                                        system.GetContentProvider()};
@@ -1548,7 +1549,7 @@ void IApplicationFunctions::GetDesiredLanguage(Kernel::HLERequestContext& ctx) {
     u32 supported_languages = 0;
 
     const auto res = [this] {
-        const auto title_id = system.CurrentProcess()->GetTitleID();
+        const auto title_id = system.CurrentProcess()->GetProgramID();
 
         const FileSys::PatchManager pm{title_id, system.GetFileSystemController(),
                                        system.GetContentProvider()};
@@ -1656,7 +1657,8 @@ void IApplicationFunctions::ExtendSaveData(Kernel::HLERequestContext& ctx) {
               static_cast<u8>(type), user_id[1], user_id[0], new_normal_size, new_journal_size);
 
     system.GetFileSystemController().WriteSaveDataSize(
-        type, system.CurrentProcess()->GetTitleID(), user_id, {new_normal_size, new_journal_size});
+        type, system.CurrentProcess()->GetProgramID(), user_id,
+        {new_normal_size, new_journal_size});
 
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(ResultSuccess);
@@ -1680,7 +1682,7 @@ void IApplicationFunctions::GetSaveDataSize(Kernel::HLERequestContext& ctx) {
               user_id[0]);
 
     const auto size = system.GetFileSystemController().ReadSaveDataSize(
-        type, system.CurrentProcess()->GetTitleID(), user_id);
+        type, system.CurrentProcess()->GetProgramID(), user_id);
 
     IPC::ResponseBuilder rb{ctx, 6};
     rb.Push(ResultSuccess);

--- a/src/core/hle/service/am/applets/applet_error.cpp
+++ b/src/core/hle/service/am/applets/applet_error.cpp
@@ -167,7 +167,7 @@ void Error::Execute() {
     }
 
     const auto callback = [this] { DisplayCompleted(); };
-    const auto title_id = system.CurrentProcess()->GetTitleID();
+    const auto title_id = system.CurrentProcess()->GetProgramID();
     const auto& reporter{system.GetReporter()};
 
     switch (mode) {

--- a/src/core/hle/service/am/applets/applet_error.cpp
+++ b/src/core/hle/service/am/applets/applet_error.cpp
@@ -9,7 +9,6 @@
 #include "common/string_util.h"
 #include "core/core.h"
 #include "core/frontend/applets/error.h"
-#include "core/hle/kernel/k_process.h"
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/am/applets/applet_error.h"
 #include "core/reporter.h"
@@ -167,7 +166,7 @@ void Error::Execute() {
     }
 
     const auto callback = [this] { DisplayCompleted(); };
-    const auto title_id = system.CurrentProcess()->GetProgramID();
+    const auto title_id = system.GetCurrentProcessProgramID();
     const auto& reporter{system.GetReporter()};
 
     switch (mode) {

--- a/src/core/hle/service/am/applets/applet_general_backend.cpp
+++ b/src/core/hle/service/am/applets/applet_general_backend.cpp
@@ -7,7 +7,6 @@
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/frontend/applets/general_frontend.h"
-#include "core/hle/kernel/k_process.h"
 #include "core/hle/result.h"
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/am/applets/applet_general_backend.h"
@@ -187,7 +186,7 @@ void PhotoViewer::Execute() {
     const auto callback = [this] { ViewFinished(); };
     switch (mode) {
     case PhotoViewerAppletMode::CurrentApp:
-        frontend.ShowPhotosForApplication(system.CurrentProcess()->GetProgramID(), callback);
+        frontend.ShowPhotosForApplication(system.GetCurrentProcessProgramID(), callback);
         break;
     case PhotoViewerAppletMode::AllApps:
         frontend.ShowAllPhotos(callback);

--- a/src/core/hle/service/am/applets/applet_general_backend.cpp
+++ b/src/core/hle/service/am/applets/applet_general_backend.cpp
@@ -187,7 +187,7 @@ void PhotoViewer::Execute() {
     const auto callback = [this] { ViewFinished(); };
     switch (mode) {
     case PhotoViewerAppletMode::CurrentApp:
-        frontend.ShowPhotosForApplication(system.CurrentProcess()->GetTitleID(), callback);
+        frontend.ShowPhotosForApplication(system.CurrentProcess()->GetProgramID(), callback);
         break;
     case PhotoViewerAppletMode::AllApps:
         frontend.ShowAllPhotos(callback);

--- a/src/core/hle/service/am/applets/applet_web_browser.cpp
+++ b/src/core/hle/service/am/applets/applet_web_browser.cpp
@@ -395,7 +395,7 @@ void WebBrowser::InitializeOffline() {
     switch (document_kind) {
     case DocumentKind::OfflineHtmlPage:
     default:
-        title_id = system.CurrentProcess()->GetTitleID();
+        title_id = system.CurrentProcess()->GetProgramID();
         nca_type = FileSys::ContentRecordType::HtmlDocument;
         additional_paths = "html-document";
         break;

--- a/src/core/hle/service/am/applets/applet_web_browser.cpp
+++ b/src/core/hle/service/am/applets/applet_web_browser.cpp
@@ -18,7 +18,6 @@
 #include "core/file_sys/system_archive/system_archive.h"
 #include "core/file_sys/vfs_vector.h"
 #include "core/frontend/applets/web_browser.h"
-#include "core/hle/kernel/k_process.h"
 #include "core/hle/result.h"
 #include "core/hle/service/am/am.h"
 #include "core/hle/service/am/applets/applet_web_browser.h"
@@ -395,7 +394,7 @@ void WebBrowser::InitializeOffline() {
     switch (document_kind) {
     case DocumentKind::OfflineHtmlPage:
     default:
-        title_id = system.CurrentProcess()->GetProgramID();
+        title_id = system.GetCurrentProcessProgramID();
         nca_type = FileSys::ContentRecordType::HtmlDocument;
         additional_paths = "html-document";
         break;

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -152,7 +152,7 @@ void AOC_U::CountAddOnContent(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(ResultSuccess);
 
-    const auto current = system.CurrentProcess()->GetTitleID();
+    const auto current = system.CurrentProcess()->GetProgramID();
 
     const auto& disabled = Settings::values.disabled_addons[current];
     if (std::find(disabled.begin(), disabled.end(), "DLC") != disabled.end()) {
@@ -179,7 +179,7 @@ void AOC_U::ListAddOnContent(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_AOC, "called with offset={}, count={}, process_id={}", offset, count,
               process_id);
 
-    const auto current = system.CurrentProcess()->GetTitleID();
+    const auto current = system.CurrentProcess()->GetProgramID();
 
     std::vector<u32> out;
     const auto& disabled = Settings::values.disabled_addons[current];
@@ -225,7 +225,7 @@ void AOC_U::GetAddOnContentBaseId(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(ResultSuccess);
 
-    const auto title_id = system.CurrentProcess()->GetTitleID();
+    const auto title_id = system.CurrentProcess()->GetProgramID();
     const FileSys::PatchManager pm{title_id, system.GetFileSystemController(),
                                    system.GetContentProvider()};
 

--- a/src/core/hle/service/aoc/aoc_u.cpp
+++ b/src/core/hle/service/aoc/aoc_u.cpp
@@ -17,7 +17,6 @@
 #include "core/file_sys/registered_cache.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/k_event.h"
-#include "core/hle/kernel/k_process.h"
 #include "core/hle/service/aoc/aoc_u.h"
 #include "core/loader/loader.h"
 
@@ -152,7 +151,7 @@ void AOC_U::CountAddOnContent(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(ResultSuccess);
 
-    const auto current = system.CurrentProcess()->GetProgramID();
+    const auto current = system.GetCurrentProcessProgramID();
 
     const auto& disabled = Settings::values.disabled_addons[current];
     if (std::find(disabled.begin(), disabled.end(), "DLC") != disabled.end()) {
@@ -179,7 +178,7 @@ void AOC_U::ListAddOnContent(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_AOC, "called with offset={}, count={}, process_id={}", offset, count,
               process_id);
 
-    const auto current = system.CurrentProcess()->GetProgramID();
+    const auto current = system.GetCurrentProcessProgramID();
 
     std::vector<u32> out;
     const auto& disabled = Settings::values.disabled_addons[current];
@@ -225,7 +224,7 @@ void AOC_U::GetAddOnContentBaseId(Kernel::HLERequestContext& ctx) {
     IPC::ResponseBuilder rb{ctx, 4};
     rb.Push(ResultSuccess);
 
-    const auto title_id = system.CurrentProcess()->GetProgramID();
+    const auto title_id = system.GetCurrentProcessProgramID();
     const FileSys::PatchManager pm{title_id, system.GetFileSystemController(),
                                    system.GetContentProvider()};
 

--- a/src/core/hle/service/bcat/bcat_module.cpp
+++ b/src/core/hle/service/bcat/bcat_module.cpp
@@ -11,7 +11,6 @@
 #include "core/core.h"
 #include "core/file_sys/vfs.h"
 #include "core/hle/ipc_helpers.h"
-#include "core/hle/kernel/k_process.h"
 #include "core/hle/kernel/k_readable_event.h"
 #include "core/hle/service/bcat/backend/backend.h"
 #include "core/hle/service/bcat/bcat.h"
@@ -178,7 +177,7 @@ private:
     void RequestSyncDeliveryCache(Kernel::HLERequestContext& ctx) {
         LOG_DEBUG(Service_BCAT, "called");
 
-        backend.Synchronize({system.CurrentProcess()->GetProgramID(),
+        backend.Synchronize({system.GetCurrentProcessProgramID(),
                              GetCurrentBuildID(system.GetCurrentProcessBuildID())},
                             GetProgressBackend(SyncType::Normal));
 
@@ -195,7 +194,7 @@ private:
 
         LOG_DEBUG(Service_BCAT, "called, name={}", name);
 
-        backend.SynchronizeDirectory({system.CurrentProcess()->GetProgramID(),
+        backend.SynchronizeDirectory({system.GetCurrentProcessProgramID(),
                                       GetCurrentBuildID(system.GetCurrentProcessBuildID())},
                                      name, GetProgressBackend(SyncType::Directory));
 
@@ -556,7 +555,7 @@ private:
 void Module::Interface::CreateDeliveryCacheStorageService(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_BCAT, "called");
 
-    const auto title_id = system.CurrentProcess()->GetProgramID();
+    const auto title_id = system.GetCurrentProcessProgramID();
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IDeliveryCacheStorageService>(system, fsc.GetBCATDirectory(title_id));

--- a/src/core/hle/service/bcat/bcat_module.cpp
+++ b/src/core/hle/service/bcat/bcat_module.cpp
@@ -178,7 +178,7 @@ private:
     void RequestSyncDeliveryCache(Kernel::HLERequestContext& ctx) {
         LOG_DEBUG(Service_BCAT, "called");
 
-        backend.Synchronize({system.CurrentProcess()->GetTitleID(),
+        backend.Synchronize({system.CurrentProcess()->GetProgramID(),
                              GetCurrentBuildID(system.GetCurrentProcessBuildID())},
                             GetProgressBackend(SyncType::Normal));
 
@@ -195,7 +195,7 @@ private:
 
         LOG_DEBUG(Service_BCAT, "called, name={}", name);
 
-        backend.SynchronizeDirectory({system.CurrentProcess()->GetTitleID(),
+        backend.SynchronizeDirectory({system.CurrentProcess()->GetProgramID(),
                                       GetCurrentBuildID(system.GetCurrentProcessBuildID())},
                                      name, GetProgressBackend(SyncType::Directory));
 
@@ -556,7 +556,7 @@ private:
 void Module::Interface::CreateDeliveryCacheStorageService(Kernel::HLERequestContext& ctx) {
     LOG_DEBUG(Service_BCAT, "called");
 
-    const auto title_id = system.CurrentProcess()->GetTitleID();
+    const auto title_id = system.CurrentProcess()->GetProgramID();
     IPC::ResponseBuilder rb{ctx, 2, 0, 1};
     rb.Push(ResultSuccess);
     rb.PushIpcInterface<IDeliveryCacheStorageService>(system, fsc.GetBCATDirectory(title_id));

--- a/src/core/hle/service/fatal/fatal.cpp
+++ b/src/core/hle/service/fatal/fatal.cpp
@@ -11,7 +11,6 @@
 #include "common/swap.h"
 #include "core/core.h"
 #include "core/hle/ipc_helpers.h"
-#include "core/hle/kernel/k_process.h"
 #include "core/hle/service/fatal/fatal.h"
 #include "core/hle/service/fatal/fatal_p.h"
 #include "core/hle/service/fatal/fatal_u.h"
@@ -66,7 +65,7 @@ enum class FatalType : u32 {
 
 static void GenerateErrorReport(Core::System& system, ResultCode error_code,
                                 const FatalInfo& info) {
-    const auto title_id = system.CurrentProcess()->GetProgramID();
+    const auto title_id = system.GetCurrentProcessProgramID();
     std::string crash_report = fmt::format(
         "Yuzu {}-{} crash report\n"
         "Title ID:                        {:016x}\n"

--- a/src/core/hle/service/fatal/fatal.cpp
+++ b/src/core/hle/service/fatal/fatal.cpp
@@ -66,7 +66,7 @@ enum class FatalType : u32 {
 
 static void GenerateErrorReport(Core::System& system, ResultCode error_code,
                                 const FatalInfo& info) {
-    const auto title_id = system.CurrentProcess()->GetTitleID();
+    const auto title_id = system.CurrentProcess()->GetProgramID();
     std::string crash_report = fmt::format(
         "Yuzu {}-{} crash report\n"
         "Title ID:                        {:016x}\n"

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -320,7 +320,7 @@ ResultVal<FileSys::VirtualFile> FileSystemController::OpenRomFSCurrentProcess() 
         return ResultUnknown;
     }
 
-    return romfs_factory->OpenCurrentProcess(system.CurrentProcess()->GetTitleID());
+    return romfs_factory->OpenCurrentProcess(system.CurrentProcess()->GetProgramID());
 }
 
 ResultVal<FileSys::VirtualFile> FileSystemController::OpenPatchedRomFS(
@@ -505,7 +505,7 @@ FileSys::SaveDataSize FileSystemController::ReadSaveDataSize(FileSys::SaveDataTy
         const auto res = system.GetAppLoader().ReadControlData(nacp);
 
         if (res != Loader::ResultStatus::Success) {
-            const FileSys::PatchManager pm{system.CurrentProcess()->GetTitleID(),
+            const FileSys::PatchManager pm{system.CurrentProcess()->GetProgramID(),
                                            system.GetFileSystemController(),
                                            system.GetContentProvider()};
             const auto metadata = pm.GetControlMetadata();

--- a/src/core/hle/service/filesystem/filesystem.cpp
+++ b/src/core/hle/service/filesystem/filesystem.cpp
@@ -20,7 +20,6 @@
 #include "core/file_sys/sdmc_factory.h"
 #include "core/file_sys/vfs.h"
 #include "core/file_sys/vfs_offset.h"
-#include "core/hle/kernel/k_process.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/hle/service/filesystem/fsp_ldr.h"
 #include "core/hle/service/filesystem/fsp_pr.h"
@@ -320,7 +319,7 @@ ResultVal<FileSys::VirtualFile> FileSystemController::OpenRomFSCurrentProcess() 
         return ResultUnknown;
     }
 
-    return romfs_factory->OpenCurrentProcess(system.CurrentProcess()->GetProgramID());
+    return romfs_factory->OpenCurrentProcess(system.GetCurrentProcessProgramID());
 }
 
 ResultVal<FileSys::VirtualFile> FileSystemController::OpenPatchedRomFS(
@@ -505,7 +504,7 @@ FileSys::SaveDataSize FileSystemController::ReadSaveDataSize(FileSys::SaveDataTy
         const auto res = system.GetAppLoader().ReadControlData(nacp);
 
         if (res != Loader::ResultStatus::Success) {
-            const FileSys::PatchManager pm{system.CurrentProcess()->GetProgramID(),
+            const FileSys::PatchManager pm{system.GetCurrentProcessProgramID(),
                                            system.GetFileSystemController(),
                                            system.GetContentProvider()};
             const auto metadata = pm.GetControlMetadata();

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -26,7 +26,6 @@
 #include "core/file_sys/system_archive/system_archive.h"
 #include "core/file_sys/vfs.h"
 #include "core/hle/ipc_helpers.h"
-#include "core/hle/kernel/k_process.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/hle/service/filesystem/fsp_srv.h"
 #include "core/reporter.h"
@@ -1034,9 +1033,8 @@ void FSP_SRV::OpenDataStorageWithProgramIndex(Kernel::HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_FS, "called, program_index={}", program_index);
 
-    auto patched_romfs =
-        fsc.OpenPatchedRomFSWithProgramIndex(system.CurrentProcess()->GetProgramID(), program_index,
-                                             FileSys::ContentRecordType::Program);
+    auto patched_romfs = fsc.OpenPatchedRomFSWithProgramIndex(
+        system.GetCurrentProcessProgramID(), program_index, FileSys::ContentRecordType::Program);
 
     if (patched_romfs.Failed()) {
         // TODO: Find the right error code to use here

--- a/src/core/hle/service/filesystem/fsp_srv.cpp
+++ b/src/core/hle/service/filesystem/fsp_srv.cpp
@@ -1034,8 +1034,9 @@ void FSP_SRV::OpenDataStorageWithProgramIndex(Kernel::HLERequestContext& ctx) {
 
     LOG_DEBUG(Service_FS, "called, program_index={}", program_index);
 
-    auto patched_romfs = fsc.OpenPatchedRomFSWithProgramIndex(
-        system.CurrentProcess()->GetTitleID(), program_index, FileSys::ContentRecordType::Program);
+    auto patched_romfs =
+        fsc.OpenPatchedRomFSWithProgramIndex(system.CurrentProcess()->GetProgramID(), program_index,
+                                             FileSys::ContentRecordType::Program);
 
     if (patched_romfs.Failed()) {
         // TODO: Find the right error code to use here

--- a/src/core/hle/service/glue/arp.cpp
+++ b/src/core/hle/service/glue/arp.cpp
@@ -26,7 +26,7 @@ std::optional<u64> GetTitleIDForProcessID(const Core::System& system, u64 proces
         return std::nullopt;
     }
 
-    return (*iter)->GetTitleID();
+    return (*iter)->GetProgramID();
 }
 } // Anonymous namespace
 

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -12,7 +12,6 @@
 #include "core/core.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/k_page_table.h"
-#include "core/hle/kernel/k_process.h"
 #include "core/hle/kernel/k_system_control.h"
 #include "core/hle/kernel/svc_results.h"
 #include "core/hle/service/ldr/ldr.h"
@@ -247,7 +246,7 @@ public:
             return;
         }
 
-        if (system.CurrentProcess()->GetProgramID() != header.application_id) {
+        if (system.GetCurrentProcessProgramID() != header.application_id) {
             LOG_ERROR(Service_LDR,
                       "Attempting to load NRR with title ID other than current process. (actual "
                       "{:016X})!",

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -247,7 +247,7 @@ public:
             return;
         }
 
-        if (system.CurrentProcess()->GetTitleID() != header.application_id) {
+        if (system.CurrentProcess()->GetProgramID() != header.application_id) {
             LOG_ERROR(Service_LDR,
                       "Attempting to load NRR with title ID other than current process. (actual "
                       "{:016X})!",

--- a/src/core/hle/service/pctl/pctl_module.cpp
+++ b/src/core/hle/service/pctl/pctl_module.cpp
@@ -7,7 +7,6 @@
 #include "core/file_sys/control_metadata.h"
 #include "core/file_sys/patch_manager.h"
 #include "core/hle/ipc_helpers.h"
-#include "core/hle/kernel/k_process.h"
 #include "core/hle/service/pctl/pctl.h"
 #include "core/hle/service/pctl/pctl_module.h"
 
@@ -189,7 +188,7 @@ private:
 
         // TODO(ogniK): Recovery flag initialization for pctl:r
 
-        const auto tid = system.CurrentProcess()->GetProgramID();
+        const auto tid = system.GetCurrentProcessProgramID();
         if (tid != 0) {
             const FileSys::PatchManager pm{tid, system.GetFileSystemController(),
                                            system.GetContentProvider()};

--- a/src/core/hle/service/pctl/pctl_module.cpp
+++ b/src/core/hle/service/pctl/pctl_module.cpp
@@ -189,7 +189,7 @@ private:
 
         // TODO(ogniK): Recovery flag initialization for pctl:r
 
-        const auto tid = system.CurrentProcess()->GetTitleID();
+        const auto tid = system.CurrentProcess()->GetProgramID();
         if (tid != 0) {
             const FileSys::PatchManager pm{tid, system.GetFileSystemController(),
                                            system.GetContentProvider()};

--- a/src/core/hle/service/pm/pm.cpp
+++ b/src/core/hle/service/pm/pm.cpp
@@ -101,7 +101,7 @@ private:
 
         const auto process =
             SearchProcessList(kernel.GetProcessList(), [title_id](const auto& proc) {
-                return proc->GetTitleID() == title_id;
+                return proc->GetProgramID() == title_id;
             });
 
         if (!process.has_value()) {
@@ -152,7 +152,7 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 4};
         rb.Push(ResultSuccess);
-        rb.Push((*process)->GetTitleID());
+        rb.Push((*process)->GetProgramID());
     }
 
     const std::vector<Kernel::KProcess*>& process_list;

--- a/src/core/hle/service/prepo/prepo.cpp
+++ b/src/core/hle/service/prepo/prepo.cpp
@@ -6,7 +6,6 @@
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/hle/ipc_helpers.h"
-#include "core/hle/kernel/k_process.h"
 #include "core/hle/service/acc/profile_manager.h"
 #include "core/hle/service/prepo/prepo.h"
 #include "core/hle/service/service.h"
@@ -73,7 +72,7 @@ private:
                   Type, process_id, data1.size(), data2.size());
 
         const auto& reporter{system.GetReporter()};
-        reporter.SavePlayReport(Type, system.CurrentProcess()->GetProgramID(), {data1, data2},
+        reporter.SavePlayReport(Type, system.GetCurrentProcessProgramID(), {data1, data2},
                                 process_id);
 
         IPC::ResponseBuilder rb{ctx, 2};
@@ -101,7 +100,7 @@ private:
                   Type, user_id[1], user_id[0], process_id, data1.size(), data2.size());
 
         const auto& reporter{system.GetReporter()};
-        reporter.SavePlayReport(Type, system.CurrentProcess()->GetProgramID(), {data1, data2},
+        reporter.SavePlayReport(Type, system.GetCurrentProcessProgramID(), {data1, data2},
                                 process_id, user_id);
 
         IPC::ResponseBuilder rb{ctx, 2};

--- a/src/core/hle/service/prepo/prepo.cpp
+++ b/src/core/hle/service/prepo/prepo.cpp
@@ -73,7 +73,7 @@ private:
                   Type, process_id, data1.size(), data2.size());
 
         const auto& reporter{system.GetReporter()};
-        reporter.SavePlayReport(Type, system.CurrentProcess()->GetTitleID(), {data1, data2},
+        reporter.SavePlayReport(Type, system.CurrentProcess()->GetProgramID(), {data1, data2},
                                 process_id);
 
         IPC::ResponseBuilder rb{ctx, 2};
@@ -101,7 +101,7 @@ private:
                   Type, user_id[1], user_id[0], process_id, data1.size(), data2.size());
 
         const auto& reporter{system.GetReporter()};
-        reporter.SavePlayReport(Type, system.CurrentProcess()->GetTitleID(), {data1, data2},
+        reporter.SavePlayReport(Type, system.CurrentProcess()->GetProgramID(), {data1, data2},
                                 process_id, user_id);
 
         IPC::ResponseBuilder rb{ctx, 2};

--- a/src/core/memory/cheat_engine.cpp
+++ b/src/core/memory/cheat_engine.cpp
@@ -192,7 +192,7 @@ void CheatEngine::Initialize() {
     core_timing.ScheduleEvent(CHEAT_ENGINE_NS, event);
 
     metadata.process_id = system.CurrentProcess()->GetProcessID();
-    metadata.title_id = system.CurrentProcess()->GetProgramID();
+    metadata.title_id = system.GetCurrentProcessProgramID();
 
     const auto& page_table = system.CurrentProcess()->PageTable();
     metadata.heap_extents = {

--- a/src/core/memory/cheat_engine.cpp
+++ b/src/core/memory/cheat_engine.cpp
@@ -192,7 +192,7 @@ void CheatEngine::Initialize() {
     core_timing.ScheduleEvent(CHEAT_ENGINE_NS, event);
 
     metadata.process_id = system.CurrentProcess()->GetProcessID();
-    metadata.title_id = system.CurrentProcess()->GetTitleID();
+    metadata.title_id = system.CurrentProcess()->GetProgramID();
 
     const auto& page_table = system.CurrentProcess()->PageTable();
     metadata.heap_extents = {

--- a/src/core/reporter.cpp
+++ b/src/core/reporter.cpp
@@ -236,7 +236,7 @@ void Reporter::SaveSvcBreakReport(u32 type, bool signal_debugger, u64 info1, u64
     }
 
     const auto timestamp = GetTimestamp();
-    const auto title_id = system.CurrentProcess()->GetTitleID();
+    const auto title_id = system.CurrentProcess()->GetProgramID();
     auto out = GetFullDataAuto(timestamp, title_id, system);
 
     auto break_out = json{
@@ -263,7 +263,7 @@ void Reporter::SaveUnimplementedFunctionReport(Kernel::HLERequestContext& ctx, u
     }
 
     const auto timestamp = GetTimestamp();
-    const auto title_id = system.CurrentProcess()->GetTitleID();
+    const auto title_id = system.CurrentProcess()->GetProgramID();
     auto out = GetFullDataAuto(timestamp, title_id, system);
 
     auto function_out = GetHLERequestContextData(ctx, system.Memory());
@@ -285,7 +285,7 @@ void Reporter::SaveUnimplementedAppletReport(
     }
 
     const auto timestamp = GetTimestamp();
-    const auto title_id = system.CurrentProcess()->GetTitleID();
+    const auto title_id = system.CurrentProcess()->GetProgramID();
     auto out = GetFullDataAuto(timestamp, title_id, system);
 
     out["applet_common_args"] = {
@@ -377,7 +377,7 @@ void Reporter::SaveUserReport() const {
     }
 
     const auto timestamp = GetTimestamp();
-    const auto title_id = system.CurrentProcess()->GetTitleID();
+    const auto title_id = system.CurrentProcess()->GetProgramID();
 
     SaveToFile(GetFullDataAuto(timestamp, title_id, system),
                GetPath("user_report", title_id, timestamp));

--- a/src/core/reporter.cpp
+++ b/src/core/reporter.cpp
@@ -236,7 +236,7 @@ void Reporter::SaveSvcBreakReport(u32 type, bool signal_debugger, u64 info1, u64
     }
 
     const auto timestamp = GetTimestamp();
-    const auto title_id = system.CurrentProcess()->GetProgramID();
+    const auto title_id = system.GetCurrentProcessProgramID();
     auto out = GetFullDataAuto(timestamp, title_id, system);
 
     auto break_out = json{
@@ -263,7 +263,7 @@ void Reporter::SaveUnimplementedFunctionReport(Kernel::HLERequestContext& ctx, u
     }
 
     const auto timestamp = GetTimestamp();
-    const auto title_id = system.CurrentProcess()->GetProgramID();
+    const auto title_id = system.GetCurrentProcessProgramID();
     auto out = GetFullDataAuto(timestamp, title_id, system);
 
     auto function_out = GetHLERequestContextData(ctx, system.Memory());
@@ -285,7 +285,7 @@ void Reporter::SaveUnimplementedAppletReport(
     }
 
     const auto timestamp = GetTimestamp();
-    const auto title_id = system.CurrentProcess()->GetProgramID();
+    const auto title_id = system.GetCurrentProcessProgramID();
     auto out = GetFullDataAuto(timestamp, title_id, system);
 
     out["applet_common_args"] = {
@@ -377,7 +377,7 @@ void Reporter::SaveUserReport() const {
     }
 
     const auto timestamp = GetTimestamp();
-    const auto title_id = system.CurrentProcess()->GetProgramID();
+    const auto title_id = system.GetCurrentProcessProgramID();
 
     SaveToFile(GetFullDataAuto(timestamp, title_id, system),
                GetPath("user_report", title_id, timestamp));

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -66,7 +66,7 @@ void EmuThread::run() {
 
     if (Settings::values.use_disk_shader_cache.GetValue()) {
         system.Renderer().ReadRasterizer()->LoadDiskResources(
-            system.CurrentProcess()->GetTitleID(), stop_token,
+            system.CurrentProcess()->GetProgramID(), stop_token,
             [this](VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total) {
                 emit LoadProgress(stage, value, total);
             });

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -32,7 +32,6 @@
 #include "common/settings.h"
 #include "core/core.h"
 #include "core/frontend/framebuffer_layout.h"
-#include "core/hle/kernel/k_process.h"
 #include "input_common/keyboard.h"
 #include "input_common/main.h"
 #include "input_common/mouse/mouse_input.h"
@@ -66,7 +65,7 @@ void EmuThread::run() {
 
     if (Settings::values.use_disk_shader_cache.GetValue()) {
         system.Renderer().ReadRasterizer()->LoadDiskResources(
-            system.CurrentProcess()->GetProgramID(), stop_token,
+            system.GetCurrentProcessProgramID(), stop_token,
             [this](VideoCore::LoadCallbackStage stage, std::size_t value, std::size_t total) {
                 emit LoadProgress(stage, value, total);
             });

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2762,7 +2762,7 @@ void GMainWindow::OnConfigureTas() {
 }
 
 void GMainWindow::OnConfigurePerGame() {
-    const u64 title_id = system->CurrentProcess()->GetProgramID();
+    const u64 title_id = system->GetCurrentProcessProgramID();
     OpenPerGameConfiguration(title_id, game_path.toStdString());
 }
 
@@ -2861,7 +2861,7 @@ void GMainWindow::OnToggleFilterBar() {
 }
 
 void GMainWindow::OnCaptureScreenshot() {
-    const u64 title_id = system->CurrentProcess()->GetProgramID();
+    const u64 title_id = system->GetCurrentProcessProgramID();
     const auto screenshot_path =
         QString::fromStdString(Common::FS::GetYuzuPathString(Common::FS::YuzuPath::ScreenshotsDir));
     const auto date =

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2762,7 +2762,7 @@ void GMainWindow::OnConfigureTas() {
 }
 
 void GMainWindow::OnConfigurePerGame() {
-    const u64 title_id = system->CurrentProcess()->GetTitleID();
+    const u64 title_id = system->CurrentProcess()->GetProgramID();
     OpenPerGameConfiguration(title_id, game_path.toStdString());
 }
 
@@ -2861,7 +2861,7 @@ void GMainWindow::OnToggleFilterBar() {
 }
 
 void GMainWindow::OnCaptureScreenshot() {
-    const u64 title_id = system->CurrentProcess()->GetTitleID();
+    const u64 title_id = system->CurrentProcess()->GetProgramID();
     const auto screenshot_path =
         QString::fromStdString(Common::FS::GetYuzuPathString(Common::FS::YuzuPath::ScreenshotsDir));
     const auto date =

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -28,7 +28,6 @@
 #include "core/crypto/key_manager.h"
 #include "core/file_sys/registered_cache.h"
 #include "core/file_sys/vfs_real.h"
-#include "core/hle/kernel/k_process.h"
 #include "core/hle/service/filesystem/filesystem.h"
 #include "core/loader/loader.h"
 #include "core/telemetry_session.h"
@@ -203,7 +202,7 @@ int main(int argc, char** argv) {
 
     if (Settings::values.use_disk_shader_cache.GetValue()) {
         system.Renderer().ReadRasterizer()->LoadDiskResources(
-            system.CurrentProcess()->GetProgramID(), std::stop_token{},
+            system.GetCurrentProcessProgramID(), std::stop_token{},
             [](VideoCore::LoadCallbackStage, size_t value, size_t total) {});
     }
 

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -203,7 +203,7 @@ int main(int argc, char** argv) {
 
     if (Settings::values.use_disk_shader_cache.GetValue()) {
         system.Renderer().ReadRasterizer()->LoadDiskResources(
-            system.CurrentProcess()->GetTitleID(), std::stop_token{},
+            system.CurrentProcess()->GetProgramID(), std::stop_token{},
             [](VideoCore::LoadCallbackStage, size_t value, size_t total) {});
     }
 


### PR DESCRIPTION
This allows us to avoid including KProcess' header file in files that only need to get the current process' program id.