### PR TITLE
core: Reorder perf_stats destruction order on Shutdown

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -324,8 +324,8 @@ struct System::Impl {
         time_manager.Shutdown();
         core_timing.Shutdown();
         app_loader.reset();
-        perf_stats.reset();
         gpu_core.reset();
+        perf_stats.reset();
         kernel.Shutdown();
         memory.Reset();
         applet_manager.ClearAll();


### PR DESCRIPTION
Avoids the gpu_core using perf_stats after it's been freed.