### PR TITLE
Fix image update/download error when width too small

### DIFF
--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -219,6 +219,7 @@ private:
     GLenum gl_internal_format = GL_NONE;
     GLenum gl_format = GL_NONE;
     GLenum gl_type = GL_NONE;
+    GLsizei gl_num_levels{};
     TextureCacheRuntime* runtime{};
     GLuint current_texture{};
 };


### PR DESCRIPTION
Currently, there is a restriction on the level when create an image, but there is no such restriction when update and download, opengl report an error when calling the corresponding method.