### PR TITLE
applets/swkbd: Skip text checking if the text has been confirmed

### DIFF
--- a/src/core/frontend/applets/software_keyboard.cpp
+++ b/src/core/frontend/applets/software_keyboard.cpp
@@ -16,7 +16,8 @@ DefaultSoftwareKeyboardApplet::~DefaultSoftwareKeyboardApplet() = default;
 
 void DefaultSoftwareKeyboardApplet::InitializeKeyboard(
     bool is_inline, KeyboardInitializeParameters initialize_parameters,
-    std::function<void(Service::AM::Applets::SwkbdResult, std::u16string)> submit_normal_callback_,
+    std::function<void(Service::AM::Applets::SwkbdResult, std::u16string, bool)>
+        submit_normal_callback_,
     std::function<void(Service::AM::Applets::SwkbdReplyType, std::u16string, s32)>
         submit_inline_callback_) {
     if (is_inline) {
@@ -128,7 +129,7 @@ void DefaultSoftwareKeyboardApplet::ExitKeyboard() const {
 }
 
 void DefaultSoftwareKeyboardApplet::SubmitNormalText(std::u16string text) const {
-    submit_normal_callback(Service::AM::Applets::SwkbdResult::Ok, text);
+    submit_normal_callback(Service::AM::Applets::SwkbdResult::Ok, text, true);
 }
 
 void DefaultSoftwareKeyboardApplet::SubmitInlineText(std::u16string_view text) const {

--- a/src/core/frontend/applets/software_keyboard.h
+++ b/src/core/frontend/applets/software_keyboard.h
@@ -57,7 +57,7 @@ public:
 
     virtual void InitializeKeyboard(
         bool is_inline, KeyboardInitializeParameters initialize_parameters,
-        std::function<void(Service::AM::Applets::SwkbdResult, std::u16string)>
+        std::function<void(Service::AM::Applets::SwkbdResult, std::u16string, bool)>
             submit_normal_callback_,
         std::function<void(Service::AM::Applets::SwkbdReplyType, std::u16string, s32)>
             submit_inline_callback_) = 0;
@@ -82,7 +82,7 @@ public:
 
     void InitializeKeyboard(
         bool is_inline, KeyboardInitializeParameters initialize_parameters,
-        std::function<void(Service::AM::Applets::SwkbdResult, std::u16string)>
+        std::function<void(Service::AM::Applets::SwkbdResult, std::u16string, bool)>
             submit_normal_callback_,
         std::function<void(Service::AM::Applets::SwkbdReplyType, std::u16string, s32)>
             submit_inline_callback_) override;
@@ -106,7 +106,7 @@ private:
 
     KeyboardInitializeParameters parameters;
 
-    mutable std::function<void(Service::AM::Applets::SwkbdResult, std::u16string)>
+    mutable std::function<void(Service::AM::Applets::SwkbdResult, std::u16string, bool)>
         submit_normal_callback;
     mutable std::function<void(Service::AM::Applets::SwkbdReplyType, std::u16string, s32)>
         submit_inline_callback;

--- a/src/core/hle/service/am/applets/applet_software_keyboard.cpp
+++ b/src/core/hle/service/am/applets/applet_software_keyboard.cpp
@@ -109,13 +109,18 @@ void SoftwareKeyboard::Execute() {
     ShowNormalKeyboard();
 }
 
-void SoftwareKeyboard::SubmitTextNormal(SwkbdResult result, std::u16string submitted_text) {
+void SoftwareKeyboard::SubmitTextNormal(SwkbdResult result, std::u16string submitted_text,
+                                        bool confirmed) {
     if (complete) {
         return;
     }
 
     if (swkbd_config_common.use_text_check && result == SwkbdResult::Ok) {
-        SubmitForTextCheck(submitted_text);
+        if (confirmed) {
+            SubmitNormalOutputAndExit(result, submitted_text);
+        } else {
+            SubmitForTextCheck(submitted_text);
+        }
     } else {
         SubmitNormalOutputAndExit(result, submitted_text);
     }
@@ -583,11 +588,12 @@ void SoftwareKeyboard::InitializeFrontendKeyboard() {
             .disable_cancel_button{disable_cancel_button},
         };
 
-        frontend.InitializeKeyboard(false, std::move(initialize_parameters),
-                                    [this](SwkbdResult result, std::u16string submitted_text) {
-                                        SubmitTextNormal(result, submitted_text);
-                                    },
-                                    {});
+        frontend.InitializeKeyboard(
+            false, std::move(initialize_parameters),
+            [this](SwkbdResult result, std::u16string submitted_text, bool confirmed) {
+                SubmitTextNormal(result, submitted_text, confirmed);
+            },
+            {});
     }
 }
 

--- a/src/core/hle/service/am/applets/applet_software_keyboard.h
+++ b/src/core/hle/service/am/applets/applet_software_keyboard.h
@@ -36,8 +36,9 @@ public:
      *
      * @param result SwkbdResult enum
      * @param submitted_text UTF-16 encoded string
+     * @param confirmed Whether the text has been confirmed after TextCheckResult::Confirm
      */
-    void SubmitTextNormal(SwkbdResult result, std::u16string submitted_text);
+    void SubmitTextNormal(SwkbdResult result, std::u16string submitted_text, bool confirmed);
 
     /**
      * Submits the input text to the application.

--- a/src/yuzu/applets/qt_software_keyboard.cpp
+++ b/src/yuzu/applets/qt_software_keyboard.cpp
@@ -413,7 +413,7 @@ void QtSoftwareKeyboardDialog::ShowTextCheckDialog(
                         ? ui->text_edit_osk->toPlainText().toStdU16String()
                         : ui->line_edit_osk->text().toStdU16String();
 
-        emit SubmitNormalText(SwkbdResult::Ok, std::move(text));
+        emit SubmitNormalText(SwkbdResult::Ok, std::move(text), true);
         break;
     }
     }
@@ -1510,7 +1510,8 @@ QtSoftwareKeyboard::~QtSoftwareKeyboard() = default;
 
 void QtSoftwareKeyboard::InitializeKeyboard(
     bool is_inline, Core::Frontend::KeyboardInitializeParameters initialize_parameters,
-    std::function<void(Service::AM::Applets::SwkbdResult, std::u16string)> submit_normal_callback_,
+    std::function<void(Service::AM::Applets::SwkbdResult, std::u16string, bool)>
+        submit_normal_callback_,
     std::function<void(Service::AM::Applets::SwkbdReplyType, std::u16string, s32)>
         submit_inline_callback_) {
     if (is_inline) {
@@ -1609,8 +1610,8 @@ void QtSoftwareKeyboard::ExitKeyboard() const {
 }
 
 void QtSoftwareKeyboard::SubmitNormalText(Service::AM::Applets::SwkbdResult result,
-                                          std::u16string submitted_text) const {
-    submit_normal_callback(result, submitted_text);
+                                          std::u16string submitted_text, bool confirmed) const {
+    submit_normal_callback(result, submitted_text, confirmed);
 }
 
 void QtSoftwareKeyboard::SubmitInlineText(Service::AM::Applets::SwkbdReplyType reply_type,

--- a/src/yuzu/applets/qt_software_keyboard.h
+++ b/src/yuzu/applets/qt_software_keyboard.h
@@ -51,8 +51,8 @@ public:
     void ExitKeyboard();
 
 signals:
-    void SubmitNormalText(Service::AM::Applets::SwkbdResult result,
-                          std::u16string submitted_text) const;
+    void SubmitNormalText(Service::AM::Applets::SwkbdResult result, std::u16string submitted_text,
+                          bool confirmed = false) const;
 
     void SubmitInlineText(Service::AM::Applets::SwkbdReplyType reply_type,
                           std::u16string submitted_text, s32 cursor_position) const;
@@ -234,7 +234,7 @@ public:
 
     void InitializeKeyboard(
         bool is_inline, Core::Frontend::KeyboardInitializeParameters initialize_parameters,
-        std::function<void(Service::AM::Applets::SwkbdResult, std::u16string)>
+        std::function<void(Service::AM::Applets::SwkbdResult, std::u16string, bool)>
             submit_normal_callback_,
         std::function<void(Service::AM::Applets::SwkbdReplyType, std::u16string, s32)>
             submit_inline_callback_) override;
@@ -272,13 +272,13 @@ signals:
     void MainWindowExitKeyboard() const;
 
 private:
-    void SubmitNormalText(Service::AM::Applets::SwkbdResult result,
-                          std::u16string submitted_text) const;
+    void SubmitNormalText(Service::AM::Applets::SwkbdResult result, std::u16string submitted_text,
+                          bool confirmed) const;
 
     void SubmitInlineText(Service::AM::Applets::SwkbdReplyType reply_type,
                           std::u16string submitted_text, s32 cursor_position) const;
 
-    mutable std::function<void(Service::AM::Applets::SwkbdResult, std::u16string)>
+    mutable std::function<void(Service::AM::Applets::SwkbdResult, std::u16string, bool)>
         submit_normal_callback;
     mutable std::function<void(Service::AM::Applets::SwkbdReplyType, std::u16string, s32)>
         submit_inline_callback;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -483,8 +483,9 @@ void GMainWindow::SoftwareKeyboardInitialize(
     } else {
         connect(
             software_keyboard, &QtSoftwareKeyboardDialog::SubmitNormalText, this,
-            [this](Service::AM::Applets::SwkbdResult result, std::u16string submitted_text) {
-                emit SoftwareKeyboardSubmitNormalText(result, submitted_text);
+            [this](Service::AM::Applets::SwkbdResult result, std::u16string submitted_text,
+                   bool confirmed) {
+                emit SoftwareKeyboardSubmitNormalText(result, submitted_text, confirmed);
             },
             Qt::QueuedConnection);
     }

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -150,7 +150,7 @@ signals:
     void ProfileSelectorFinishedSelection(std::optional<Common::UUID> uuid);
 
     void SoftwareKeyboardSubmitNormalText(Service::AM::Applets::SwkbdResult result,
-                                          std::u16string submitted_text);
+                                          std::u16string submitted_text, bool confirmed);
     void SoftwareKeyboardSubmitInlineText(Service::AM::Applets::SwkbdReplyType reply_type,
                                           std::u16string submitted_text, s32 cursor_position);
 


### PR DESCRIPTION
Confirm means that the text has already been checked by the application to be correct, but is asking the user for confirmation.
This also fixes the corrupted text in the confirmation dialog, which is caused by using the incorrect encoding.

Fixes #6712 

Fixes the software keyboard in Famicom Detective Club: The Missing Heir