### PR TITLE
Replace "Light" theme by "Default"

### DIFF
--- a/src/yuzu/uisettings.cpp
+++ b/src/yuzu/uisettings.cpp
@@ -7,8 +7,8 @@
 namespace UISettings {
 
 const Themes themes{{
-    {"Light", "default"},
-    {"Light Colorful", "colorful"},
+    {"Default", "default"},
+    {"Default Colorful", "colorful"},
     {"Dark", "qdarkstyle"},
     {"Dark Colorful", "colorful_dark"},
     {"Midnight Blue", "qdarkstyle_midnight_blue"},


### PR DESCRIPTION
This reflects the current behavior: Light = System default. If your
system is set to dark theme, then Light = Dark, which is a bit confusing
for the end user.

In this PR, I propose to change "Light" with "Default". This way, the
user has "Default" and "Default Colorful", which will apply the system
theme. Now that the Flatpak respects the system theme, I think this
makes much more sense.

I also simplified the theme update. Before the code was branching
between the default theme and the others, but I think we can have
something simpler by forcing the default theme if no theme is defined in
the settings, or if the selected theme doesn't exist. And if there's an
error, tell the theme name in the error message.