### PR TITLE
audio_core: Workaround for audio pops and clicks

### DIFF
--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -87,6 +87,7 @@ static void VolumeAdjustSamples(std::vector<s16>& samples, float game_volume) {
 }
 
 void Stream::PlayNextBuffer(std::chrono::nanoseconds ns_late) {
+#ifndef _WIN32
     auto now = std::chrono::steady_clock::now();
     auto duration = now.time_since_epoch();
     auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(duration);
@@ -94,6 +95,7 @@ void Stream::PlayNextBuffer(std::chrono::nanoseconds ns_late) {
     if (nanoseconds > expected_cb_time) {
         ns_late = nanoseconds - expected_cb_time;
     }
+#endif
 
     if (!IsPlaying()) {
         // Ensure we are in playing state before playing the next buffer
@@ -129,7 +131,9 @@ void Stream::PlayNextBuffer(std::chrono::nanoseconds ns_late) {
         ns_late = {};
     }
 
+#ifndef _WIN32
     expected_cb_time = nanoseconds + (buffer_release_ns - ns_late);
+#endif
     core_timing.ScheduleEvent(buffer_release_ns - ns_late, release_event, {});
 }
 

--- a/src/audio_core/stream.h
+++ b/src/audio_core/stream.h
@@ -117,13 +117,14 @@ private:
     ReleaseCallback release_callback; ///< Buffer release callback for the stream
     State state{State::Stopped};      ///< Playback state of the stream
     std::shared_ptr<Core::Timing::EventType>
-        release_event;                      ///< Core timing release event for the stream
-    BufferPtr active_buffer;                ///< Actively playing buffer in the stream
-    std::queue<BufferPtr> queued_buffers;   ///< Buffers queued to be played in the stream
-    std::queue<BufferPtr> released_buffers; ///< Buffers recently released from the stream
-    SinkStream& sink_stream;                ///< Output sink for the stream
-    Core::Timing::CoreTiming& core_timing;  ///< Core timing instance.
-    std::string name;                       ///< Name of the stream, must be unique
+        release_event;                              ///< Core timing release event for the stream
+    BufferPtr active_buffer;                        ///< Actively playing buffer in the stream
+    std::queue<BufferPtr> queued_buffers;           ///< Buffers queued to be played in the stream
+    std::queue<BufferPtr> released_buffers;         ///< Buffers recently released from the stream
+    SinkStream& sink_stream;                        ///< Output sink for the stream
+    Core::Timing::CoreTiming& core_timing;          ///< Core timing instance.
+    std::string name;                               ///< Name of the stream, must be unique
+    std::chrono::nanoseconds expected_cb_time = {}; ///< Estimated time of next callback
 };
 
 using StreamPtr = std::shared_ptr<Stream>;

--- a/src/audio_core/stream.h
+++ b/src/audio_core/stream.h
@@ -117,14 +117,16 @@ private:
     ReleaseCallback release_callback; ///< Buffer release callback for the stream
     State state{State::Stopped};      ///< Playback state of the stream
     std::shared_ptr<Core::Timing::EventType>
-        release_event;                              ///< Core timing release event for the stream
-    BufferPtr active_buffer;                        ///< Actively playing buffer in the stream
-    std::queue<BufferPtr> queued_buffers;           ///< Buffers queued to be played in the stream
-    std::queue<BufferPtr> released_buffers;         ///< Buffers recently released from the stream
-    SinkStream& sink_stream;                        ///< Output sink for the stream
-    Core::Timing::CoreTiming& core_timing;          ///< Core timing instance.
-    std::string name;                               ///< Name of the stream, must be unique
+        release_event;                      ///< Core timing release event for the stream
+    BufferPtr active_buffer;                ///< Actively playing buffer in the stream
+    std::queue<BufferPtr> queued_buffers;   ///< Buffers queued to be played in the stream
+    std::queue<BufferPtr> released_buffers; ///< Buffers recently released from the stream
+    SinkStream& sink_stream;                ///< Output sink for the stream
+    Core::Timing::CoreTiming& core_timing;  ///< Core timing instance.
+    std::string name;                       ///< Name of the stream, must be unique
+#ifndef _WIN32
     std::chrono::nanoseconds expected_cb_time = {}; ///< Estimated time of next callback
+#endif
 };
 
 using StreamPtr = std::shared_ptr<Stream>;


### PR DESCRIPTION
This is most evident on Linux, but happens everywhere. See issue #7144 for more details and original patch by @vasishath .

This hides an issue in yuzu and should NOT be merged into master. Just a temporary fix to make life less miserable.