### PR TITLE
CMakeLists: Update catch to 2.13.7

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ macro(yuzu_find_packages)
     # Capitalization matters here. We need the naming to match the generated paths from Conan
     set(REQUIRED_LIBS
     #    Cmake Pkg Prefix  Version     Conan Pkg
-        "Catch2            2.13        catch2/2.13.0"
+        "Catch2            2.13.7      catch2/2.13.7"
         "fmt               8.0         fmt/8.0.0"
         "lz4               1.8         lz4/1.9.2"
         "nlohmann_json     3.8         nlohmann_json/3.8.0"


### PR DESCRIPTION
Keeps the testing libraries up to date.

Also fixes compilation related to changes with glibc