### PR TITLE
gl_texture_cache: Implement pixel format conversions for copies

### DIFF
--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -396,6 +396,10 @@ OGLTexture MakeImage(const VideoCommon::ImageInfo& info, GLenum gl_internal_form
     UNREACHABLE_MSG("Invalid image format={}", format);
     return GL_R32UI;
 }
+
+[[nodiscard]] u32 NextPow2(u32 value) {
+    return 1U << (32U - std::countl_zero(value - 1U));
+}
 } // Anonymous namespace
 
 ImageBufferMap::~ImageBufferMap() {
@@ -1304,7 +1308,7 @@ void FormatConversionPass::ConvertImage(Image& dst_image, Image& src_image,
         const u32 copy_size = region.width * region.height * region.depth * img_bpp;
         if (pbo_size < copy_size) {
             intermediate_pbo.Create();
-            pbo_size = copy_size;
+            pbo_size = NextPow2(copy_size);
             glNamedBufferData(intermediate_pbo.handle, pbo_size, nullptr, GL_STREAM_COPY);
         }
         // Copy from source to PBO

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -522,6 +522,12 @@ void TextureCacheRuntime::CopyImage(Image& dst_image, Image& src_image,
     }
 }
 
+void TextureCacheRuntime::ConvertImage(Image& dst, Image& src,
+                                       std::span<const VideoCommon::ImageCopy> copies) {
+    LOG_DEBUG(Render_OpenGL, "Converting {} to {}", src.info.format, dst.info.format);
+    format_conversion_pass.ConvertImage(dst, src, copies);
+}
+
 bool TextureCacheRuntime::CanImageBeCopied(const Image& dst, const Image& src) {
     if (dst.info.type == ImageType::e3D && dst.info.format == PixelFormat::BC4_UNORM) {
         return false;

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -86,6 +86,8 @@ public:
 
     void CopyImage(Image& dst, Image& src, std::span<const VideoCommon::ImageCopy> copies);
 
+    void ConvertImage(Image& dst, Image& src, std::span<const VideoCommon::ImageCopy> copies);
+
     void ConvertImage(Framebuffer* dst, ImageView& dst_view, ImageView& src_view, bool rescaled) {
         UNIMPLEMENTED();
     }
@@ -336,6 +338,7 @@ struct TextureCacheParams {
     static constexpr bool FRAMEBUFFER_BLITS = true;
     static constexpr bool HAS_EMULATED_COPIES = true;
     static constexpr bool HAS_DEVICE_MEMORY_INFO = true;
+    static constexpr bool HAS_PIXEL_FORMAT_CONVERSIONS = true;
 
     using Runtime = OpenGL::TextureCacheRuntime;
     using Image = OpenGL::Image;

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -52,17 +52,17 @@ struct FormatProperties {
     bool is_compressed;
 };
 
-class BGRCopyPass {
+class FormatConversionPass {
 public:
-    BGRCopyPass() = default;
-    ~BGRCopyPass() = default;
+    FormatConversionPass() = default;
+    ~FormatConversionPass() = default;
 
-    void CopyBGR(Image& dst_image, Image& src_image,
-                 std::span<const VideoCommon::ImageCopy> copies);
+    void ConvertImage(Image& dst_image, Image& src_image,
+                      std::span<const VideoCommon::ImageCopy> copies);
 
 private:
-    OGLBuffer bgr_pbo;
-    size_t bgr_pbo_size{};
+    OGLBuffer intermediate_pbo;
+    size_t pbo_size{};
 };
 
 class TextureCacheRuntime {
@@ -144,7 +144,7 @@ private:
     const Device& device;
     StateTracker& state_tracker;
     UtilShaders util_shaders;
-    BGRCopyPass bgr_copy_pass;
+    FormatConversionPass format_conversion_pass;
 
     std::array<std::unordered_map<GLenum, FormatProperties>, 3> format_properties;
     bool has_broken_texture_view_formats = false;

--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -316,6 +316,7 @@ struct TextureCacheParams {
     static constexpr bool FRAMEBUFFER_BLITS = false;
     static constexpr bool HAS_EMULATED_COPIES = false;
     static constexpr bool HAS_DEVICE_MEMORY_INFO = true;
+    static constexpr bool HAS_PIXEL_FORMAT_CONVERSIONS = false;
 
     using Runtime = Vulkan::TextureCacheRuntime;
     using Image = Vulkan::Image;

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -1759,6 +1759,9 @@ void TextureCache<P>::CopyImage(ImageId dst_id, ImageId src_id, std::vector<Imag
     }
     UNIMPLEMENTED_IF(dst.info.type != ImageType::e2D);
     UNIMPLEMENTED_IF(src.info.type != ImageType::e2D);
+    if constexpr (HAS_PIXEL_FORMAT_CONVERSIONS) {
+        return runtime.ConvertImage(dst, src, copies);
+    }
     for (const ImageCopy& copy : copies) {
         UNIMPLEMENTED_IF(copy.dst_subresource.num_layers != 1);
         UNIMPLEMENTED_IF(copy.src_subresource.num_layers != 1);

--- a/src/video_core/texture_cache/texture_cache_base.h
+++ b/src/video_core/texture_cache/texture_cache_base.h
@@ -59,6 +59,8 @@ class TextureCache {
     static constexpr bool HAS_EMULATED_COPIES = P::HAS_EMULATED_COPIES;
     /// True when the API can provide info about the memory of the device.
     static constexpr bool HAS_DEVICE_MEMORY_INFO = P::HAS_DEVICE_MEMORY_INFO;
+    /// True when the API provides utilities for pixel format conversions.
+    static constexpr bool HAS_PIXEL_FORMAT_CONVERSIONS = P::HAS_PIXEL_FORMAT_CONVERSIONS;
 
     static constexpr u64 DEFAULT_EXPECTED_MEMORY = 1_GiB;
     static constexpr u64 DEFAULT_CRITICAL_MEMORY = 2_GiB;


### PR DESCRIPTION
Texture copies with "incompatible" formats (i.e. Color <-> Depth) were left unimplemented on OpenGL after TCR. 
This PR aims to implement format conversions by repurposing the existing method used for BGR <-> RGB texture format conversion. 

This is expected to fix a number of issues. For example:



### Luigi's Mansion 3 Shadow Trail

https://user-images.githubusercontent.com/52414509/142131633-fa8aa4e6-5a58-4304-824e-4dc8e1b54aa9.mp4

https://user-images.githubusercontent.com/52414509/142131645-f295dc55-d1a2-4d3b-9f16-19939d19b902.mp4

### Bayonetta 2 Cutscene DOF

https://user-images.githubusercontent.com/52414509/142131213-cd13a780-e962-4f9d-9ce8-0abb3139ae18.mp4

https://user-images.githubusercontent.com/52414509/142131230-7eea0eae-d160-4556-99ba-77967da761e7.mp4


closes #6845 closes #4220 
