### PR TITLE
hotkeys: Don't allow hotkeys to spam

### DIFF
--- a/src/yuzu/hotkeys.cpp
+++ b/src/yuzu/hotkeys.cpp
@@ -46,6 +46,8 @@ QShortcut* HotkeyRegistry::GetHotkey(const QString& group, const QString& action
     if (!hk.shortcut)
         hk.shortcut = new QShortcut(hk.keyseq, widget, nullptr, nullptr, hk.context);
 
+    hk.shortcut->setAutoRepeat(false);
+
     return hk.shortcut;
 }
 


### PR DESCRIPTION
If you hold a hotkey it will start to spam. This is totally undesired 