### PR TITLE
Fix screenshot dimensions when at 1x scale

### DIFF
--- a/src/core/frontend/framebuffer_layout.cpp
+++ b/src/core/frontend/framebuffer_layout.cpp
@@ -25,7 +25,12 @@ FramebufferLayout DefaultFrameLayout(u32 width, u32 height) {
     ASSERT(height > 0);
     // The drawing code needs at least somewhat valid values for both screens
     // so just calculate them both even if the other isn't showing.
-    FramebufferLayout res{width, height, false, {}};
+    FramebufferLayout res{
+        .width = width,
+        .height = height,
+        .screen = {},
+        .is_srgb = false,
+    };
 
     const float window_aspect_ratio = static_cast<float>(height) / static_cast<float>(width);
     const float emulation_aspect_ratio = EmulationAspectRatio(

--- a/src/core/frontend/framebuffer_layout.h
+++ b/src/core/frontend/framebuffer_layout.h
@@ -35,17 +35,8 @@ enum class AspectRatio {
 struct FramebufferLayout {
     u32 width{ScreenUndocked::Width};
     u32 height{ScreenUndocked::Height};
-    bool is_srgb{};
-
     Common::Rectangle<u32> screen;
-
-    /**
-     * Returns the ration of pixel size of the screen, compared to the native size of the undocked
-     * Switch screen.
-     */
-    float GetScalingRatio() const {
-        return static_cast<float>(screen.GetWidth()) / ScreenUndocked::Width;
-    }
+    bool is_srgb{};
 };
 
 /**

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -55,10 +55,4 @@ std::unique_ptr<Tegra::GPU> CreateGPU(Core::Frontend::EmuWindow& emu_window, Cor
     }
 }
 
-float GetResolutionScaleFactor(const RendererBase& renderer) {
-    return Settings::values.resolution_info.active
-               ? Settings::values.resolution_info.up_factor
-               : renderer.GetRenderWindow().GetFramebufferLayout().GetScalingRatio();
-}
-
 } // namespace VideoCore

--- a/src/video_core/video_core.h
+++ b/src/video_core/video_core.h
@@ -25,6 +25,4 @@ class RendererBase;
 /// Creates an emulated GPU instance using the given system context.
 std::unique_ptr<Tegra::GPU> CreateGPU(Core::Frontend::EmuWindow& emu_window, Core::System& system);
 
-float GetResolutionScaleFactor(const RendererBase& renderer);
-
 } // namespace VideoCore

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -630,7 +630,7 @@ void GRenderWindow::ReleaseRenderTarget() {
 
 void GRenderWindow::CaptureScreenshot(const QString& screenshot_path) {
     auto& renderer = system.Renderer();
-    const f32 res_scale = VideoCore::GetResolutionScaleFactor(renderer);
+    const f32 res_scale = Settings::values.resolution_info.up_factor;
 
     const Layout::FramebufferLayout layout{Layout::FrameLayoutFromResolutionScale(res_scale)};
     screenshot_image = QImage(QSize(layout.width, layout.height), QImage::Format_RGB32);


### PR DESCRIPTION
This was regressed by ART.
Prior to ART, the screenshots were saved at the title's framebuffer resolution. 
A misunderstanding of the existing logic led to screenshot dimensions becoming dependent on the host render window size with changes made in ART.

This PR changes the behavior to match how it was prior to ART at 1x, with screenshots now always being the title's framebuffer dimensions scaled by the resolution scaling factor.

closes #7388 