### PR TITLE
configure_general: Allow framerate cap to be used in custom game configs

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -183,6 +183,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.max_anisotropy.SetGlobal(true);
     values.use_speed_limit.SetGlobal(true);
     values.speed_limit.SetGlobal(true);
+    values.fps_cap.SetGlobal(true);
     values.use_disk_shader_cache.SetGlobal(true);
     values.gpu_accuracy.SetGlobal(true);
     values.use_asynchronous_gpu_emulation.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -525,7 +525,7 @@ struct Values {
     Setting<NvdecEmulation> nvdec_emulation{NvdecEmulation::GPU, "nvdec_emulation"};
     Setting<bool> accelerate_astc{true, "accelerate_astc"};
     Setting<bool> use_vsync{true, "use_vsync"};
-    BasicRangedSetting<u16> fps_cap{1000, 1, 1000, "fps_cap"};
+    RangedSetting<u16> fps_cap{1000, 1, 1000, "fps_cap"};
     BasicSetting<bool> disable_fps_limit{false, "disable_fps_limit"};
     RangedSetting<ShaderBackend> shader_backend{ShaderBackend::GLASM, ShaderBackend::GLSL,
                                                 ShaderBackend::SPIRV, "shader_backend"};

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -830,6 +830,7 @@ void Config::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.max_anisotropy);
     ReadGlobalSetting(Settings::values.use_speed_limit);
     ReadGlobalSetting(Settings::values.speed_limit);
+    ReadGlobalSetting(Settings::values.fps_cap);
     ReadGlobalSetting(Settings::values.use_disk_shader_cache);
     ReadGlobalSetting(Settings::values.gpu_accuracy);
     ReadGlobalSetting(Settings::values.use_asynchronous_gpu_emulation);
@@ -844,7 +845,6 @@ void Config::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.bg_blue);
 
     if (global) {
-        ReadBasicSetting(Settings::values.fps_cap);
         ReadBasicSetting(Settings::values.renderer_debug);
         ReadBasicSetting(Settings::values.renderer_shader_feedback);
         ReadBasicSetting(Settings::values.enable_nsight_aftermath);
@@ -1382,6 +1382,7 @@ void Config::SaveRendererValues() {
     WriteGlobalSetting(Settings::values.max_anisotropy);
     WriteGlobalSetting(Settings::values.use_speed_limit);
     WriteGlobalSetting(Settings::values.speed_limit);
+    WriteGlobalSetting(Settings::values.fps_cap);
     WriteGlobalSetting(Settings::values.use_disk_shader_cache);
     WriteSetting(QString::fromStdString(Settings::values.gpu_accuracy.GetLabel()),
                  static_cast<u32>(Settings::values.gpu_accuracy.GetValue(global)),
@@ -1405,7 +1406,6 @@ void Config::SaveRendererValues() {
     WriteGlobalSetting(Settings::values.bg_blue);
 
     if (global) {
-        WriteBasicSetting(Settings::values.fps_cap);
         WriteBasicSetting(Settings::values.renderer_debug);
         WriteBasicSetting(Settings::values.renderer_shader_feedback);
         WriteBasicSetting(Settings::values.enable_nsight_aftermath);

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -30,6 +30,9 @@ ConfigureGeneral::ConfigureGeneral(const Core::System& system_, QWidget* parent)
 
     connect(ui->button_reset_defaults, &QPushButton::clicked, this,
             &ConfigureGeneral::ResetDefaults);
+
+    ui->fps_cap_label->setVisible(Settings::IsConfiguringGlobal());
+    ui->fps_cap_combobox->setVisible(!Settings::IsConfiguringGlobal());
 }
 
 ConfigureGeneral::~ConfigureGeneral() = default;
@@ -57,6 +60,11 @@ void ConfigureGeneral::SetConfiguration() {
     } else {
         ui->speed_limit->setEnabled(Settings::values.use_speed_limit.GetValue() &&
                                     use_speed_limit != ConfigurationShared::CheckState::Global);
+
+        ui->fps_cap_combobox->setCurrentIndex(Settings::values.fps_cap.UsingGlobal() ? 0 : 1);
+        ui->fps_cap->setEnabled(!Settings::values.fps_cap.UsingGlobal());
+        ConfigurationShared::SetHighlight(ui->fps_cap_layout,
+                                          !Settings::values.fps_cap.UsingGlobal());
     }
 }
 
@@ -106,6 +114,13 @@ void ConfigureGeneral::ApplyConfiguration() {
                                                       Qt::Checked);
             Settings::values.speed_limit.SetValue(ui->speed_limit->value());
         }
+
+        if (ui->fps_cap_combobox->currentIndex() == ConfigurationShared::USE_GLOBAL_INDEX) {
+            Settings::values.fps_cap.SetGlobal(true);
+        } else {
+            Settings::values.fps_cap.SetGlobal(false);
+            Settings::values.fps_cap.SetValue(ui->fps_cap->value());
+        }
     }
 }
 
@@ -147,5 +162,10 @@ void ConfigureGeneral::SetupPerGameUI() {
     connect(ui->toggle_speed_limit, &QCheckBox::clicked, ui->speed_limit, [this]() {
         ui->speed_limit->setEnabled(ui->toggle_speed_limit->isChecked() &&
                                     (use_speed_limit != ConfigurationShared::CheckState::Global));
+    });
+
+    connect(ui->fps_cap_combobox, qOverload<int>(&QComboBox::activated), this, [this](int index) {
+        ui->fps_cap->setEnabled(index == 1);
+        ConfigurationShared::SetHighlight(ui->fps_cap_layout, index == 1);
     });
 }

--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>329</width>
-    <height>407</height>
+    <width>744</width>
+    <height>568</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -28,34 +28,85 @@
         <item>
          <layout class="QVBoxLayout" name="GeneralVerticalLayout">
           <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
-              <item>
-                <widget class="QLabel" name="fps_cap_label">
+           <widget class="QWidget" name="fps_cap_layout" native="true">
+            <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_4">
+               <item>
+                <widget class="QComboBox" name="fps_cap_combobox">
+                 <property name="currentText">
+                  <string>Use global framerate cap</string>
+                 </property>
+                 <property name="currentIndex">
+                  <number>0</number>
+                 </property>
+                 <item>
                   <property name="text">
-                    <string>Framerate Cap</string>
+                   <string>Use global framerate cap</string>
                   </property>
-                  <property name="toolTip">
-                    <string>Requires the use of the FPS Limiter Toggle hotkey to take effect.</string>
+                 </item>
+                 <item>
+                  <property name="text">
+                   <string>Set framerate cap:</string>
                   </property>
+                 </item>
                 </widget>
-              </item>
-              <item>
-                <widget class="QSpinBox" name="fps_cap">
-                  <property name="suffix">
-                    <string>x</string>
-                  </property>
-                  <property name="minimum">
-                    <number>1</number>
-                  </property>
-                  <property name="maximum">
-                    <number>1000</number>
-                  </property>
-                  <property name="value">
-                    <number>500</number>
-                  </property>
+               </item>
+               <item>
+                <widget class="QLabel" name="fps_cap_label">
+                 <property name="toolTip">
+                  <string>Requires the use of the FPS Limiter Toggle hotkey to take effect.</string>
+                 </property>
+                 <property name="text">
+                  <string>Framerate Cap</string>
+                 </property>
                 </widget>
-              </item>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QSpinBox" name="fps_cap">
+               <property name="suffix">
+                <string>x</string>
+               </property>
+               <property name="minimum">
+                <number>1</number>
+               </property>
+               <property name="maximum">
+                <number>1000</number>
+               </property>
+               <property name="value">
+                <number>500</number>
+               </property>
+              </widget>
+             </item>
             </layout>
+           </widget>
           </item>
           <item>
            <layout class="QHBoxLayout" name="horizontalLayout_2">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5352197/142769608-f864bd6c-91ac-4970-9d56-6e51b0cccfd0.png)
![image](https://user-images.githubusercontent.com/5352197/142769579-0d91d11a-bc0f-47c6-bcc5-f60e4ab695e2.png)

With my 144Hz monitor I'll be setting global to 3x for 60 fps games and custom configs to 5x for 30 fps games.