### PR TITLE
Core: Stub services and functions needed for checkpoint

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -479,6 +479,8 @@ add_library(core STATIC
     hle/service/ns/language.h
     hle/service/ns/ns.cpp
     hle/service/ns/ns.h
+    hle/service/ns/pdm_qry.cpp
+    hle/service/ns/pdm_qry.h
     hle/service/ns/pl_u.cpp
     hle/service/ns/pl_u.h
     hle/service/nvdrv/devices/nvdevice.h

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -1883,7 +1883,7 @@ public:
             {317, nullptr, "GetNpadLeftRightInterfaceType"},
             {318, nullptr, "HasBattery"},
             {319, nullptr, "HasLeftRightBattery"},
-            {321, nullptr, "GetUniquePadsFromNpad"},
+            {321, &HidSys::GetUniquePadsFromNpad, "GetUniquePadsFromNpad"},
             {322, nullptr, "GetIrSensorState"},
             {323, nullptr, "GetXcdHandleForNpadWithIrSensor"},
             {324, nullptr, "GetUniquePadButtonSet"},
@@ -2053,6 +2053,18 @@ private:
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(ResultSuccess);
+    }
+
+    void GetUniquePadsFromNpad(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+        const auto npad_id_type{rp.PopEnum<Core::HID::NpadIdType>()};
+
+        const s64 total_entries = 0;
+        LOG_WARNING(Service_HID, "(STUBBED) called, npad_id_type={}", npad_id_type);
+
+        IPC::ResponseBuilder rb{ctx, 3};
+        rb.Push(ResultSuccess);
+        rb.Push(total_entries);
     }
 };
 

--- a/src/core/hle/service/ns/ns.cpp
+++ b/src/core/hle/service/ns/ns.cpp
@@ -12,6 +12,7 @@
 #include "core/hle/service/ns/errors.h"
 #include "core/hle/service/ns/language.h"
 #include "core/hle/service/ns/ns.h"
+#include "core/hle/service/ns/pdm_qry.h"
 #include "core/hle/service/ns/pl_u.h"
 #include "core/hle/service/set/set.h"
 
@@ -737,6 +738,8 @@ void InstallInterfaces(SM::ServiceManager& service_manager, Core::System& system
     std::make_shared<NS_DEV>(system)->InstallAsService(service_manager);
     std::make_shared<NS_SU>(system)->InstallAsService(service_manager);
     std::make_shared<NS_VM>(system)->InstallAsService(service_manager);
+
+    std::make_shared<PDM_QRY>(system)->InstallAsService(service_manager);
 
     std::make_shared<PL_U>(system)->InstallAsService(service_manager);
 }

--- a/src/core/hle/service/ns/ns.cpp
+++ b/src/core/hle/service/ns/ns.cpp
@@ -571,11 +571,29 @@ IFactoryResetInterface::IFactoryResetInterface(Core::System& system_)
 
 IFactoryResetInterface::~IFactoryResetInterface() = default;
 
+IReadOnlyApplicationControlDataInterface::IReadOnlyApplicationControlDataInterface(
+    Core::System& system_)
+    : ServiceFramework{system_, "IReadOnlyApplicationControlDataInterface"} {
+    // clang-format off
+    static const FunctionInfo functions[] = {
+        {0, nullptr, "GetApplicationControlData"},
+        {1, nullptr, "GetApplicationDesiredLanguage"},
+        {2, nullptr, "ConvertApplicationLanguageToLanguageCode"},
+        {3, nullptr, "ConvertLanguageCodeToApplicationLanguage"},
+        {4, nullptr, "SelectApplicationDesiredLanguage"},
+    };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+IReadOnlyApplicationControlDataInterface::~IReadOnlyApplicationControlDataInterface() = default;
+
 NS::NS(const char* name, Core::System& system_) : ServiceFramework{system_, name} {
     // clang-format off
     static const FunctionInfo functions[] = {
         {7988, nullptr, "GetDynamicRightsInterface"},
-        {7989, nullptr, "GetReadOnlyApplicationControlDataInterface"},
+        {7989, &NS::PushInterface<IReadOnlyApplicationControlDataInterface>, "GetReadOnlyApplicationControlDataInterface"},
         {7991, nullptr, "GetReadOnlyApplicationRecordInterface"},
         {7992, &NS::PushInterface<IECommerceInterface>, "GetECommerceInterface"},
         {7993, &NS::PushInterface<IApplicationVersionInterface>, "GetApplicationVersionInterface"},

--- a/src/core/hle/service/ns/ns.h
+++ b/src/core/hle/service/ns/ns.h
@@ -74,6 +74,13 @@ public:
     ~IFactoryResetInterface() override;
 };
 
+class IReadOnlyApplicationControlDataInterface final
+    : public ServiceFramework<IReadOnlyApplicationControlDataInterface> {
+public:
+    explicit IReadOnlyApplicationControlDataInterface(Core::System& system_);
+    ~IReadOnlyApplicationControlDataInterface() override;
+};
+
 class NS final : public ServiceFramework<NS> {
 public:
     explicit NS(const char* name, Core::System& system_);

--- a/src/core/hle/service/ns/pdm_qry.cpp
+++ b/src/core/hle/service/ns/pdm_qry.cpp
@@ -1,0 +1,69 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included
+
+#include <memory>
+
+#include "common/logging/log.h"
+#include "common/uuid.h"
+#include "core/hle/ipc_helpers.h"
+#include "core/hle/service/ns/pdm_qry.h"
+#include "core/hle/service/service.h"
+#include "core/hle/service/sm/sm.h"
+
+namespace Service::NS {
+
+PDM_QRY::PDM_QRY(Core::System& system_) : ServiceFramework{system_, "pdm:qry"} {
+    // clang-format off
+        static const FunctionInfo functions[] = {
+            {0, nullptr, "QueryAppletEvent"},
+            {1, nullptr, "QueryPlayStatistics"},
+            {2, nullptr, "QueryPlayStatisticsByUserAccountId"},
+            {3, nullptr, "QueryPlayStatisticsByNetworkServiceAccountId"},
+            {4, nullptr, "QueryPlayStatisticsByApplicationId"},
+            {5, &PDM_QRY::QueryPlayStatisticsByApplicationIdAndUserAccountId, "QueryPlayStatisticsByApplicationIdAndUserAccountId"},
+            {6, nullptr, "QueryPlayStatisticsByApplicationIdAndNetworkServiceAccountId"},
+            {7, nullptr, "QueryLastPlayTimeV0"},
+            {8, nullptr, "QueryPlayEvent"},
+            {9, nullptr, "GetAvailablePlayEventRange"},
+            {10, nullptr, "QueryAccountEvent"},
+            {11, nullptr, "QueryAccountPlayEvent"},
+            {12, nullptr, "GetAvailableAccountPlayEventRange"},
+            {13, nullptr, "QueryApplicationPlayStatisticsForSystemV0"},
+            {14, nullptr, "QueryRecentlyPlayedApplication"},
+            {15, nullptr, "GetRecentlyPlayedApplicationUpdateEvent"},
+            {16, nullptr, "QueryApplicationPlayStatisticsByUserAccountIdForSystemV0"},
+            {17, nullptr, "QueryLastPlayTime"},
+            {18, nullptr, "QueryApplicationPlayStatisticsForSystem"},
+            {19, nullptr, "QueryApplicationPlayStatisticsByUserAccountIdForSystem"},
+        };
+    // clang-format on
+
+    RegisterHandlers(functions);
+}
+
+PDM_QRY::~PDM_QRY() = default;
+
+void PDM_QRY::QueryPlayStatisticsByApplicationIdAndUserAccountId(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto unknown = rp.Pop<bool>();
+    rp.Pop<u8>(); // Padding
+    const auto application_id = rp.Pop<u64>();
+    const auto user_account_uid = rp.PopRaw<Common::UUID>();
+
+    // TODO(German77): Read statistics of the game
+    PlayStatistics statistics{
+        .application_id = application_id,
+        .total_launches = 1,
+    };
+
+    LOG_WARNING(Service_NS,
+                "(STUBBED) called. unknown={}. application_id=0x{:016X}, user_account_uid=0x{}",
+                unknown, application_id, user_account_uid.Format());
+
+    IPC::ResponseBuilder rb{ctx, 12};
+    rb.Push(ResultSuccess);
+    rb.PushRaw(statistics);
+}
+
+} // namespace Service::NS

--- a/src/core/hle/service/ns/pdm_qry.h
+++ b/src/core/hle/service/ns/pdm_qry.h
@@ -1,0 +1,33 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included
+
+#pragma once
+
+#include "core/hle/service/service.h"
+
+namespace Service::NS {
+
+struct PlayStatistics {
+    u64 application_id{};
+    u32 first_entry_index{};
+    u32 first_timestamp_user{};
+    u32 first_timestamp_network{};
+    u32 last_entry_index{};
+    u32 last_timestamp_user{};
+    u32 last_timestamp_network{};
+    u32 play_time_in_minutes{};
+    u32 total_launches{};
+};
+static_assert(sizeof(PlayStatistics) == 0x28, "PlayStatistics is an invalid size");
+
+class PDM_QRY final : public ServiceFramework<PDM_QRY> {
+public:
+    explicit PDM_QRY(Core::System& system_);
+    ~PDM_QRY() override;
+
+private:
+    void QueryPlayStatisticsByApplicationIdAndUserAccountId(Kernel::HLERequestContext& ctx);
+};
+
+} // namespace Service::NS


### PR DESCRIPTION
Adds pdm_qry, IReadOnlyApplicationControlDataInterface
Stubs GetUniquePadsFromNpad, QueryPlayStatisticsByApplicationIdAndUserAccountId

Checkpoint needs more implementations to work properly. This PR just reduces the amount of missing services 