### PR TITLE
Vulkan: Add support for VK_EXT_depth_clip_control.

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_context_get_set.cpp
@@ -461,7 +461,7 @@ void EmitSetSampleMask(EmitContext& ctx, Id value) {
 }
 
 void EmitSetFragDepth(EmitContext& ctx, Id value) {
-    if (!ctx.runtime_info.convert_depth_mode) {
+    if (!ctx.runtime_info.convert_depth_mode || ctx.profile.support_native_ndc) {
         ctx.OpStore(ctx.frag_depth, value);
         return;
     }

--- a/src/shader_recompiler/backend/spirv/emit_spirv_special.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv_special.cpp
@@ -116,7 +116,8 @@ void EmitPrologue(EmitContext& ctx) {
 }
 
 void EmitEpilogue(EmitContext& ctx) {
-    if (ctx.stage == Stage::VertexB && ctx.runtime_info.convert_depth_mode) {
+    if (ctx.stage == Stage::VertexB && ctx.runtime_info.convert_depth_mode &&
+        !ctx.profile.support_native_ndc) {
         ConvertDepthMode(ctx);
     }
     if (ctx.stage == Stage::Fragment) {
@@ -125,7 +126,7 @@ void EmitEpilogue(EmitContext& ctx) {
 }
 
 void EmitEmitVertex(EmitContext& ctx, const IR::Value& stream) {
-    if (ctx.runtime_info.convert_depth_mode) {
+    if (ctx.runtime_info.convert_depth_mode && !ctx.profile.support_native_ndc) {
         ConvertDepthMode(ctx);
     }
     if (stream.IsImmediate()) {

--- a/src/shader_recompiler/profile.h
+++ b/src/shader_recompiler/profile.h
@@ -35,6 +35,7 @@ struct Profile {
     bool support_int64_atomics{};
     bool support_derivative_control{};
     bool support_geometry_shader_passthrough{};
+    bool support_native_ndc{};
     bool support_gl_nv_gpu_shader_5{};
     bool support_gl_amd_gpu_shader_half_float{};
     bool support_gl_texture_shadow_lod{};

--- a/src/video_core/renderer_opengl/gl_shader_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_shader_cache.cpp
@@ -203,6 +203,7 @@ ShaderCache::ShaderCache(RasterizerOpenGL& rasterizer_, Core::Frontend::EmuWindo
           .support_int64_atomics = false,
           .support_derivative_control = device.HasDerivativeControl(),
           .support_geometry_shader_passthrough = device.HasGeometryShaderPassthrough(),
+          .support_native_ndc = true,
           .support_gl_nv_gpu_shader_5 = device.HasNvGpuShader5(),
           .support_gl_amd_gpu_shader_half_float = device.HasAmdShaderHalfFloat(),
           .support_gl_texture_shadow_lod = device.HasTextureShadowLod(),

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.cpp
@@ -634,23 +634,33 @@ void GraphicsPipeline::MakePipeline(VkRenderPass render_pass) {
     };
     std::array<VkViewportSwizzleNV, Maxwell::NumViewports> swizzles;
     std::ranges::transform(key.state.viewport_swizzles, swizzles.begin(), UnpackViewportSwizzle);
-    const VkPipelineViewportSwizzleStateCreateInfoNV swizzle_ci{
+    VkPipelineViewportSwizzleStateCreateInfoNV swizzle_ci{
         .sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV,
         .pNext = nullptr,
         .flags = 0,
         .viewportCount = Maxwell::NumViewports,
         .pViewportSwizzles = swizzles.data(),
     };
-    const VkPipelineViewportStateCreateInfo viewport_ci{
+    VkPipelineViewportDepthClipControlCreateInfoEXT ndc_info{
+        .sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_DEPTH_CLIP_CONTROL_CREATE_INFO_EXT,
+        .pNext = nullptr,
+        .negativeOneToOne = key.state.ndc_minus_one_to_one.Value() != 0 ? VK_TRUE : VK_FALSE,
+    };
+    VkPipelineViewportStateCreateInfo viewport_ci{
         .sType = VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO,
-        .pNext = device.IsNvViewportSwizzleSupported() ? &swizzle_ci : nullptr,
+        .pNext = nullptr,
         .flags = 0,
         .viewportCount = Maxwell::NumViewports,
         .pViewports = nullptr,
         .scissorCount = Maxwell::NumViewports,
         .pScissors = nullptr,
     };
-
+    if (device.IsNvViewportSwizzleSupported()) {
+        swizzle_ci.pNext = std::exchange(viewport_ci.pNext, &swizzle_ci);
+    }
+    if (device.IsExtDepthClipControlSupported()) {
+        ndc_info.pNext = std::exchange(viewport_ci.pNext, &ndc_info);
+    }
     VkPipelineRasterizationStateCreateInfo rasterization_ci{
         .sType = VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
         .pNext = nullptr,

--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.cpp
@@ -321,6 +321,7 @@ PipelineCache::PipelineCache(RasterizerVulkan& rasterizer_, const Device& device
         .support_int64_atomics = device.IsExtShaderAtomicInt64Supported(),
         .support_derivative_control = true,
         .support_geometry_shader_passthrough = device.IsNvGeometryShaderPassthroughSupported(),
+        .support_native_ndc = device.IsExtDepthClipControlSupported(),
 
         .warp_size_potentially_larger_than_guest = device.IsWarpSizePotentiallyBiggerThanGuest(),
 

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -660,6 +660,16 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
         LOG_INFO(Render_Vulkan, "Device doesn't support depth range unrestricted");
     }
 
+    VkPhysicalDeviceDepthClipControlFeaturesEXT depth_clip_control_features;
+    if (ext_depth_clip_control) {
+        depth_clip_control_features = {
+            .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_CONTROL_FEATURES_EXT,
+            .pNext = nullptr,
+            .depthClipControl = VK_TRUE,
+        };
+        SetNext(next, depth_clip_control_features);
+    }
+
     VkDeviceDiagnosticsConfigCreateInfoNV diagnostics_nv;
     if (Settings::values.enable_nsight_aftermath && nv_device_diagnostics_config) {
         nsight_aftermath_tracker = std::make_unique<NsightAftermathTracker>();
@@ -1083,6 +1093,7 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
     bool has_ext_vertex_input_dynamic_state{};
     bool has_ext_line_rasterization{};
     bool has_ext_primitive_topology_list_restart{};
+    bool has_ext_depth_clip_control{};
     for (const std::string& extension : supported_extensions) {
         const auto test = [&](std::optional<std::reference_wrapper<bool>> status, const char* name,
                               bool push) {
@@ -1116,6 +1127,7 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
         test(ext_shader_stencil_export, VK_EXT_SHADER_STENCIL_EXPORT_EXTENSION_NAME, true);
         test(ext_conservative_rasterization, VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME,
              true);
+        test(has_ext_depth_clip_control, VK_EXT_DEPTH_CLIP_CONTROL_EXTENSION_NAME, false);
         test(has_ext_transform_feedback, VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME, false);
         test(has_ext_custom_border_color, VK_EXT_CUSTOM_BORDER_COLOR_EXTENSION_NAME, false);
         test(has_ext_extended_dynamic_state, VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME, false);
@@ -1277,6 +1289,19 @@ std::vector<const char*> Device::LoadExtensions(bool requires_surface) {
         if (line_raster.rectangularLines && line_raster.smoothLines) {
             extensions.push_back(VK_EXT_LINE_RASTERIZATION_EXTENSION_NAME);
             ext_line_rasterization = true;
+        }
+    }
+    if (has_ext_depth_clip_control) {
+        VkPhysicalDeviceDepthClipControlFeaturesEXT depth_clip_control_features;
+        depth_clip_control_features.sType =
+            VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_CONTROL_FEATURES_EXT;
+        depth_clip_control_features.pNext = nullptr;
+        features.pNext = &depth_clip_control_features;
+        physical.GetFeatures2(features);
+
+        if (depth_clip_control_features.depthClipControl) {
+            extensions.push_back(VK_EXT_DEPTH_CLIP_CONTROL_EXTENSION_NAME);
+            ext_depth_clip_control = true;
         }
     }
     if (has_khr_workgroup_memory_explicit_layout) {

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -256,6 +256,11 @@ public:
         return ext_depth_range_unrestricted;
     }
 
+    /// Returns true if the device supports VK_EXT_depth_clip_control.
+    bool IsExtDepthClipControlSupported() const {
+        return ext_depth_clip_control;
+    }
+
     /// Returns true if the device supports VK_EXT_shader_viewport_index_layer.
     bool IsExtShaderViewportIndexLayerSupported() const {
         return ext_shader_viewport_index_layer;
@@ -446,6 +451,7 @@ private:
     bool khr_swapchain_mutable_format{};         ///< Support for VK_KHR_swapchain_mutable_format.
     bool ext_index_type_uint8{};                 ///< Support for VK_EXT_index_type_uint8.
     bool ext_sampler_filter_minmax{};            ///< Support for VK_EXT_sampler_filter_minmax.
+    bool ext_depth_clip_control{};               ///< Support for VK_EXT_depth_clip_control
     bool ext_depth_range_unrestricted{};         ///< Support for VK_EXT_depth_range_unrestricted.
     bool ext_shader_viewport_index_layer{}; ///< Support for VK_EXT_shader_viewport_index_layer.
     bool ext_tooling_info{};                ///< Support for VK_EXT_tooling_info.


### PR DESCRIPTION
Currently only NVIDIA Vulkan BETA drivers support it. It does not seem to fix anything.