### PR TITLE
settings: Add debug setting to enable all controllers

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -604,6 +604,7 @@ struct Values {
     BasicSetting<bool> extended_logging{false, "extended_logging"};
     BasicSetting<bool> use_debug_asserts{false, "use_debug_asserts"};
     BasicSetting<bool> use_auto_stub{false, "use_auto_stub"};
+    BasicSetting<bool> enable_all_controllers{false, "enable_all_controllers"};
 
     // Miscellaneous
     BasicSetting<std::string> log_filter{"*:Info", "log_filter"};

--- a/src/common/settings_input.h
+++ b/src/common/settings_input.h
@@ -370,6 +370,11 @@ enum class ControllerType {
     RightJoycon,
     Handheld,
     GameCube,
+    Pokeball,
+    NES,
+    SNES,
+    N64,
+    SegaGenesis,
 };
 
 struct PlayerInput {

--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -27,6 +27,16 @@ NpadStyleIndex EmulatedController::MapSettingsTypeToNPad(Settings::ControllerTyp
         return NpadStyleIndex::Handheld;
     case Settings::ControllerType::GameCube:
         return NpadStyleIndex::GameCube;
+    case Settings::ControllerType::Pokeball:
+        return NpadStyleIndex::Pokeball;
+    case Settings::ControllerType::NES:
+        return NpadStyleIndex::NES;
+    case Settings::ControllerType::SNES:
+        return NpadStyleIndex::SNES;
+    case Settings::ControllerType::N64:
+        return NpadStyleIndex::N64;
+    case Settings::ControllerType::SegaGenesis:
+        return NpadStyleIndex::SegaGenesis;
     default:
         return NpadStyleIndex::ProController;
     }
@@ -46,6 +56,16 @@ Settings::ControllerType EmulatedController::MapNPadToSettingsType(NpadStyleInde
         return Settings::ControllerType::Handheld;
     case NpadStyleIndex::GameCube:
         return Settings::ControllerType::GameCube;
+    case NpadStyleIndex::Pokeball:
+        return Settings::ControllerType::Pokeball;
+    case NpadStyleIndex::NES:
+        return Settings::ControllerType::NES;
+    case NpadStyleIndex::SNES:
+        return Settings::ControllerType::SNES;
+    case NpadStyleIndex::N64:
+        return Settings::ControllerType::N64;
+    case NpadStyleIndex::SegaGenesis:
+        return Settings::ControllerType::SegaGenesis;
     default:
         return Settings::ControllerType::ProController;
     }

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -263,6 +263,10 @@ void Controller_NPad::OnInit() {
         style.fullkey.Assign(1);
         style.gamecube.Assign(1);
         style.palma.Assign(1);
+        style.lark.Assign(1);
+        style.lucia.Assign(1);
+        style.lagoon.Assign(1);
+        style.lager.Assign(1);
         hid_core.SetSupportedStyleTag(style);
     }
 

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -508,6 +508,7 @@ void Config::ReadDebuggingValues() {
     ReadBasicSetting(Settings::values.extended_logging);
     ReadBasicSetting(Settings::values.use_debug_asserts);
     ReadBasicSetting(Settings::values.use_auto_stub);
+    ReadBasicSetting(Settings::values.enable_all_controllers);
 
     qt_config->endGroup();
 }
@@ -1051,6 +1052,7 @@ void Config::SaveDebuggingValues() {
     WriteBasicSetting(Settings::values.quest_flag);
     WriteBasicSetting(Settings::values.use_debug_asserts);
     WriteBasicSetting(Settings::values.disable_macro_jit);
+    WriteBasicSetting(Settings::values.enable_all_controllers);
 
     qt_config->endGroup();
 }

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -42,6 +42,7 @@ void ConfigureDebug::SetConfiguration() {
     ui->quest_flag->setChecked(Settings::values.quest_flag.GetValue());
     ui->use_debug_asserts->setChecked(Settings::values.use_debug_asserts.GetValue());
     ui->use_auto_stub->setChecked(Settings::values.use_auto_stub.GetValue());
+    ui->enable_all_controllers->setChecked(Settings::values.enable_all_controllers.GetValue());
     ui->enable_graphics_debugging->setEnabled(runtime_lock);
     ui->enable_graphics_debugging->setChecked(Settings::values.renderer_debug.GetValue());
     ui->enable_shader_feedback->setEnabled(runtime_lock);
@@ -67,6 +68,7 @@ void ConfigureDebug::ApplyConfiguration() {
     Settings::values.quest_flag = ui->quest_flag->isChecked();
     Settings::values.use_debug_asserts = ui->use_debug_asserts->isChecked();
     Settings::values.use_auto_stub = ui->use_auto_stub->isChecked();
+    Settings::values.enable_all_controllers = ui->enable_all_controllers->isChecked();
     Settings::values.renderer_debug = ui->enable_graphics_debugging->isChecked();
     Settings::values.renderer_shader_feedback = ui->enable_shader_feedback->isChecked();
     Settings::values.cpu_debug_mode = ui->enable_cpu_debugging->isChecked();

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -198,6 +198,13 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="enable_all_controllers">
+        <property name="text">
+         <string>Enable all Controller Types</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -947,6 +947,40 @@ void ConfigureInputPlayer::SetConnectableControllers() {
                                                      Core::HID::NpadStyleIndex::GameCube);
             ui->comboControllerType->addItem(tr("GameCube Controller"));
         }
+
+        // Disable all unsupported controllers
+        if (!Settings::values.enable_all_controllers) {
+            return;
+        }
+        if (enable_all || npad_style_set.palma == 1) {
+            index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
+                                                     Core::HID::NpadStyleIndex::Pokeball);
+            ui->comboControllerType->addItem(tr("Poke Ball Plus"));
+        }
+
+        if (enable_all || npad_style_set.lark == 1) {
+            index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
+                                                     Core::HID::NpadStyleIndex::NES);
+            ui->comboControllerType->addItem(tr("NES Controller"));
+        }
+
+        if (enable_all || npad_style_set.lucia == 1) {
+            index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
+                                                     Core::HID::NpadStyleIndex::SNES);
+            ui->comboControllerType->addItem(tr("SNES Controller"));
+        }
+
+        if (enable_all || npad_style_set.lagoon == 1) {
+            index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
+                                                     Core::HID::NpadStyleIndex::N64);
+            ui->comboControllerType->addItem(tr("N64 Controller"));
+        }
+
+        if (enable_all || npad_style_set.lager == 1) {
+            index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
+                                                     Core::HID::NpadStyleIndex::SegaGenesis);
+            ui->comboControllerType->addItem(tr("Sega Genesis"));
+        }
     };
 
     if (!is_powered_on) {


### PR DESCRIPTION
I often have to hack through my settings to test a new controller. This setting allows to select any Nintendo controller regardless if they work properly or not.