### PR TITLE
Kernel: Improve threading & scheduling V3

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -185,6 +185,7 @@ add_library(core STATIC
     hle/kernel/k_event.h
     hle/kernel/k_handle_table.cpp
     hle/kernel/k_handle_table.h
+    hle/kernel/k_light_condition_variable.cpp
     hle/kernel/k_light_condition_variable.h
     hle/kernel/k_light_lock.cpp
     hle/kernel/k_light_lock.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -237,6 +237,7 @@ add_library(core STATIC
     hle/kernel/k_system_control.h
     hle/kernel/k_thread.cpp
     hle/kernel/k_thread.h
+    hle/kernel/k_thread_queue.cpp
     hle/kernel/k_thread_queue.h
     hle/kernel/k_trace.h
     hle/kernel/k_transfer_memory.cpp

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -521,12 +521,6 @@ const ARM_Interface& System::CurrentArmInterface() const {
     return impl->kernel.CurrentPhysicalCore().ArmInterface();
 }
 
-std::size_t System::CurrentCoreIndex() const {
-    std::size_t core = impl->kernel.GetCurrentHostThreadID();
-    ASSERT(core < Core::Hardware::NUM_CPU_CORES);
-    return core;
-}
-
 Kernel::PhysicalCore& System::CurrentPhysicalCore() {
     return impl->kernel.CurrentPhysicalCore();
 }

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -208,9 +208,6 @@ public:
     /// Gets an ARM interface to the CPU core that is currently running
     [[nodiscard]] const ARM_Interface& CurrentArmInterface() const;
 
-    /// Gets the index of the currently running CPU core
-    [[nodiscard]] std::size_t CurrentCoreIndex() const;
-
     /// Gets the physical core for the CPU core that is currently running
     [[nodiscard]] Kernel::PhysicalCore& CurrentPhysicalCore();
 

--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -117,17 +117,18 @@ void CpuManager::MultiCoreRunGuestLoop() {
             physical_core = &kernel.CurrentPhysicalCore();
         }
         system.ExitDynarmicProfile();
-        physical_core->ArmInterface().ClearExclusiveState();
-        kernel.CurrentScheduler()->RescheduleCurrentCore();
+        {
+            Kernel::KScopedDisableDispatch dd(kernel);
+            physical_core->ArmInterface().ClearExclusiveState();
+        }
     }
 }
 
 void CpuManager::MultiCoreRunIdleThread() {
     auto& kernel = system.Kernel();
     while (true) {
-        auto& physical_core = kernel.CurrentPhysicalCore();
-        physical_core.Idle();
-        kernel.CurrentScheduler()->RescheduleCurrentCore();
+        Kernel::KScopedDisableDispatch dd(kernel);
+        kernel.CurrentPhysicalCore().Idle();
     }
 }
 
@@ -135,12 +136,12 @@ void CpuManager::MultiCoreRunSuspendThread() {
     auto& kernel = system.Kernel();
     kernel.CurrentScheduler()->OnThreadStart();
     while (true) {
-        auto core = kernel.GetCurrentHostThreadID();
+        auto core = kernel.CurrentPhysicalCoreIndex();
         auto& scheduler = *kernel.CurrentScheduler();
         Kernel::KThread* current_thread = scheduler.GetCurrentThread();
         Common::Fiber::YieldTo(current_thread->GetHostContext(), *core_data[core].host_context);
         ASSERT(scheduler.ContextSwitchPending());
-        ASSERT(core == kernel.GetCurrentHostThreadID());
+        ASSERT(core == kernel.CurrentPhysicalCoreIndex());
         scheduler.RescheduleCurrentCore();
     }
 }

--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -32,7 +32,7 @@ void CpuManager::Initialize() {
             core_data[core].host_thread = std::jthread(ThreadStart, std::ref(*this), core);
         }
     } else {
-        core_data[0].host_thread = std::jthread(ThreadStart, std::ref(*this), -1);
+        core_data[0].host_thread = std::jthread(ThreadStart, std::ref(*this), 0);
     }
 }
 

--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -32,7 +32,7 @@ void CpuManager::Initialize() {
             core_data[core].host_thread = std::jthread(ThreadStart, std::ref(*this), core);
         }
     } else {
-        core_data[0].host_thread = std::jthread(ThreadStart, std::ref(*this), 0);
+        core_data[0].host_thread = std::jthread(ThreadStart, std::ref(*this), -1);
     }
 }
 
@@ -347,13 +347,9 @@ void CpuManager::RunThread(std::stop_token stop_token, std::size_t core) {
             sc_sync_first_use = false;
         }
 
-        // Abort if emulation was killed before the session really starts
-        if (!system.IsPoweredOn()) {
-            return;
-        }
-
+        // Emulation was stopped
         if (stop_token.stop_requested()) {
-            break;
+            return;
         }
 
         auto current_thread = system.Kernel().CurrentScheduler()->GetCurrentThread();

--- a/src/core/hle/kernel/k_address_arbiter.cpp
+++ b/src/core/hle/kernel/k_address_arbiter.cpp
@@ -28,7 +28,7 @@ bool ReadFromUser(Core::System& system, s32* out, VAddr address) {
 
 bool DecrementIfLessThan(Core::System& system, s32* out, VAddr address, s32 value) {
     auto& monitor = system.Monitor();
-    const auto current_core = system.CurrentCoreIndex();
+    const auto current_core = system.Kernel().CurrentPhysicalCoreIndex();
 
     // TODO(bunnei): We should disable interrupts here via KScopedInterruptDisable.
     // TODO(bunnei): We should call CanAccessAtomic(..) here.
@@ -58,7 +58,7 @@ bool DecrementIfLessThan(Core::System& system, s32* out, VAddr address, s32 valu
 
 bool UpdateIfEqual(Core::System& system, s32* out, VAddr address, s32 value, s32 new_value) {
     auto& monitor = system.Monitor();
-    const auto current_core = system.CurrentCoreIndex();
+    const auto current_core = system.Kernel().CurrentPhysicalCoreIndex();
 
     // TODO(bunnei): We should disable interrupts here via KScopedInterruptDisable.
     // TODO(bunnei): We should call CanAccessAtomic(..) here.

--- a/src/core/hle/kernel/k_address_arbiter.cpp
+++ b/src/core/hle/kernel/k_address_arbiter.cpp
@@ -87,9 +87,6 @@ bool UpdateIfEqual(Core::System& system, s32* out, VAddr address, s32 value, s32
 }
 
 class ThreadQueueImplForKAddressArbiter final : public KThreadQueue {
-private:
-    KAddressArbiter::ThreadTree* m_tree;
-
 public:
     explicit ThreadQueueImplForKAddressArbiter(KernelCore& kernel_, KAddressArbiter::ThreadTree* t)
         : KThreadQueue(kernel_), m_tree(t) {}
@@ -105,6 +102,9 @@ public:
         // Invoke the base cancel wait handler.
         KThreadQueue::CancelWait(waiting_thread, wait_result, cancel_timer_task);
     }
+
+private:
+    KAddressArbiter::ThreadTree* m_tree;
 };
 
 } // namespace

--- a/src/core/hle/kernel/k_address_arbiter.cpp
+++ b/src/core/hle/kernel/k_address_arbiter.cpp
@@ -91,8 +91,8 @@ public:
     explicit ThreadQueueImplForKAddressArbiter(KernelCore& kernel_, KAddressArbiter::ThreadTree* t)
         : KThreadQueue(kernel_), m_tree(t) {}
 
-    virtual void CancelWait(KThread* waiting_thread, ResultCode wait_result,
-                            bool cancel_timer_task) override {
+    void CancelWait(KThread* waiting_thread, ResultCode wait_result,
+                    bool cancel_timer_task) override {
         // If the thread is waiting on an address arbiter, remove it from the tree.
         if (waiting_thread->IsWaitingForAddressArbiter()) {
             m_tree->erase(m_tree->iterator_to(*waiting_thread));

--- a/src/core/hle/kernel/k_address_arbiter.cpp
+++ b/src/core/hle/kernel/k_address_arbiter.cpp
@@ -97,7 +97,7 @@ ResultCode KAddressArbiter::Signal(VAddr addr, s32 count) {
         while ((it != thread_tree.end()) && (count <= 0 || num_waiters < count) &&
                (it->GetAddressArbiterKey() == addr)) {
             KThread* target_thread = std::addressof(*it);
-            target_thread->SetSyncedObject(nullptr, ResultSuccess);
+            target_thread->SetWaitResult(ResultSuccess);
 
             ASSERT(target_thread->IsWaitingForAddressArbiter());
             target_thread->Wakeup();
@@ -130,7 +130,7 @@ ResultCode KAddressArbiter::SignalAndIncrementIfEqual(VAddr addr, s32 value, s32
         while ((it != thread_tree.end()) && (count <= 0 || num_waiters < count) &&
                (it->GetAddressArbiterKey() == addr)) {
             KThread* target_thread = std::addressof(*it);
-            target_thread->SetSyncedObject(nullptr, ResultSuccess);
+            target_thread->SetWaitResult(ResultSuccess);
 
             ASSERT(target_thread->IsWaitingForAddressArbiter());
             target_thread->Wakeup();
@@ -198,7 +198,7 @@ ResultCode KAddressArbiter::SignalAndModifyByWaitingCountIfEqual(VAddr addr, s32
         while ((it != thread_tree.end()) && (count <= 0 || num_waiters < count) &&
                (it->GetAddressArbiterKey() == addr)) {
             KThread* target_thread = std::addressof(*it);
-            target_thread->SetSyncedObject(nullptr, ResultSuccess);
+            target_thread->SetWaitResult(ResultSuccess);
 
             ASSERT(target_thread->IsWaitingForAddressArbiter());
             target_thread->Wakeup();
@@ -225,7 +225,7 @@ ResultCode KAddressArbiter::WaitIfLessThan(VAddr addr, s32 value, bool decrement
         }
 
         // Set the synced object.
-        cur_thread->SetSyncedObject(nullptr, ResultTimedOut);
+        cur_thread->SetWaitResult(ResultTimedOut);
 
         // Read the value from userspace.
         s32 user_value{};
@@ -274,8 +274,7 @@ ResultCode KAddressArbiter::WaitIfLessThan(VAddr addr, s32 value, bool decrement
     }
 
     // Get the result.
-    KSynchronizationObject* dummy{};
-    return cur_thread->GetWaitResult(&dummy);
+    return cur_thread->GetWaitResult();
 }
 
 ResultCode KAddressArbiter::WaitIfEqual(VAddr addr, s32 value, s64 timeout) {
@@ -292,7 +291,7 @@ ResultCode KAddressArbiter::WaitIfEqual(VAddr addr, s32 value, s64 timeout) {
         }
 
         // Set the synced object.
-        cur_thread->SetSyncedObject(nullptr, ResultTimedOut);
+        cur_thread->SetWaitResult(ResultTimedOut);
 
         // Read the value from userspace.
         s32 user_value{};
@@ -334,8 +333,7 @@ ResultCode KAddressArbiter::WaitIfEqual(VAddr addr, s32 value, s64 timeout) {
     }
 
     // Get the result.
-    KSynchronizationObject* dummy{};
-    return cur_thread->GetWaitResult(&dummy);
+    return cur_thread->GetWaitResult();
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/k_address_arbiter.cpp
+++ b/src/core/hle/kernel/k_address_arbiter.cpp
@@ -8,6 +8,7 @@
 #include "core/hle/kernel/k_scheduler.h"
 #include "core/hle/kernel/k_scoped_scheduler_lock_and_sleep.h"
 #include "core/hle/kernel/k_thread.h"
+#include "core/hle/kernel/k_thread_queue.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/svc_results.h"
 #include "core/hle/kernel/time_manager.h"
@@ -85,6 +86,27 @@ bool UpdateIfEqual(Core::System& system, s32* out, VAddr address, s32 value, s32
     return true;
 }
 
+class ThreadQueueImplForKAddressArbiter final : public KThreadQueue {
+private:
+    KAddressArbiter::ThreadTree* m_tree;
+
+public:
+    explicit ThreadQueueImplForKAddressArbiter(KernelCore& kernel_, KAddressArbiter::ThreadTree* t)
+        : KThreadQueue(kernel_), m_tree(t) {}
+
+    virtual void CancelWait(KThread* waiting_thread, ResultCode wait_result,
+                            bool cancel_timer_task) override {
+        // If the thread is waiting on an address arbiter, remove it from the tree.
+        if (waiting_thread->IsWaitingForAddressArbiter()) {
+            m_tree->erase(m_tree->iterator_to(*waiting_thread));
+            waiting_thread->ClearAddressArbiter();
+        }
+
+        // Invoke the base cancel wait handler.
+        KThreadQueue::CancelWait(waiting_thread, wait_result, cancel_timer_task);
+    }
+};
+
 } // namespace
 
 ResultCode KAddressArbiter::Signal(VAddr addr, s32 count) {
@@ -96,14 +118,14 @@ ResultCode KAddressArbiter::Signal(VAddr addr, s32 count) {
         auto it = thread_tree.nfind_light({addr, -1});
         while ((it != thread_tree.end()) && (count <= 0 || num_waiters < count) &&
                (it->GetAddressArbiterKey() == addr)) {
+            // End the thread's wait.
             KThread* target_thread = std::addressof(*it);
-            target_thread->SetWaitResult(ResultSuccess);
+            target_thread->EndWait(ResultSuccess);
 
             ASSERT(target_thread->IsWaitingForAddressArbiter());
-            target_thread->Wakeup();
+            target_thread->ClearAddressArbiter();
 
             it = thread_tree.erase(it);
-            target_thread->ClearAddressArbiter();
             ++num_waiters;
         }
     }
@@ -129,14 +151,14 @@ ResultCode KAddressArbiter::SignalAndIncrementIfEqual(VAddr addr, s32 value, s32
         auto it = thread_tree.nfind_light({addr, -1});
         while ((it != thread_tree.end()) && (count <= 0 || num_waiters < count) &&
                (it->GetAddressArbiterKey() == addr)) {
+            // End the thread's wait.
             KThread* target_thread = std::addressof(*it);
-            target_thread->SetWaitResult(ResultSuccess);
+            target_thread->EndWait(ResultSuccess);
 
             ASSERT(target_thread->IsWaitingForAddressArbiter());
-            target_thread->Wakeup();
+            target_thread->ClearAddressArbiter();
 
             it = thread_tree.erase(it);
-            target_thread->ClearAddressArbiter();
             ++num_waiters;
         }
     }
@@ -197,14 +219,14 @@ ResultCode KAddressArbiter::SignalAndModifyByWaitingCountIfEqual(VAddr addr, s32
 
         while ((it != thread_tree.end()) && (count <= 0 || num_waiters < count) &&
                (it->GetAddressArbiterKey() == addr)) {
+            // End the thread's wait.
             KThread* target_thread = std::addressof(*it);
-            target_thread->SetWaitResult(ResultSuccess);
+            target_thread->EndWait(ResultSuccess);
 
             ASSERT(target_thread->IsWaitingForAddressArbiter());
-            target_thread->Wakeup();
+            target_thread->ClearAddressArbiter();
 
             it = thread_tree.erase(it);
-            target_thread->ClearAddressArbiter();
             ++num_waiters;
         }
     }
@@ -214,6 +236,7 @@ ResultCode KAddressArbiter::SignalAndModifyByWaitingCountIfEqual(VAddr addr, s32
 ResultCode KAddressArbiter::WaitIfLessThan(VAddr addr, s32 value, bool decrement, s64 timeout) {
     // Prepare to wait.
     KThread* cur_thread = kernel.CurrentScheduler()->GetCurrentThread();
+    ThreadQueueImplForKAddressArbiter wait_queue(kernel, std::addressof(thread_tree));
 
     {
         KScopedSchedulerLockAndSleep slp{kernel, cur_thread, timeout};
@@ -223,9 +246,6 @@ ResultCode KAddressArbiter::WaitIfLessThan(VAddr addr, s32 value, bool decrement
             slp.CancelSleep();
             return ResultTerminationRequested;
         }
-
-        // Set the synced object.
-        cur_thread->SetWaitResult(ResultTimedOut);
 
         // Read the value from userspace.
         s32 user_value{};
@@ -256,21 +276,10 @@ ResultCode KAddressArbiter::WaitIfLessThan(VAddr addr, s32 value, bool decrement
         // Set the arbiter.
         cur_thread->SetAddressArbiter(&thread_tree, addr);
         thread_tree.insert(*cur_thread);
-        cur_thread->SetState(ThreadState::Waiting);
+
+        // Wait for the thread to finish.
+        cur_thread->BeginWait(std::addressof(wait_queue));
         cur_thread->SetWaitReasonForDebugging(ThreadWaitReasonForDebugging::Arbitration);
-    }
-
-    // Cancel the timer wait.
-    kernel.TimeManager().UnscheduleTimeEvent(cur_thread);
-
-    // Remove from the address arbiter.
-    {
-        KScopedSchedulerLock sl(kernel);
-
-        if (cur_thread->IsWaitingForAddressArbiter()) {
-            thread_tree.erase(thread_tree.iterator_to(*cur_thread));
-            cur_thread->ClearAddressArbiter();
-        }
     }
 
     // Get the result.
@@ -280,6 +289,7 @@ ResultCode KAddressArbiter::WaitIfLessThan(VAddr addr, s32 value, bool decrement
 ResultCode KAddressArbiter::WaitIfEqual(VAddr addr, s32 value, s64 timeout) {
     // Prepare to wait.
     KThread* cur_thread = kernel.CurrentScheduler()->GetCurrentThread();
+    ThreadQueueImplForKAddressArbiter wait_queue(kernel, std::addressof(thread_tree));
 
     {
         KScopedSchedulerLockAndSleep slp{kernel, cur_thread, timeout};
@@ -289,9 +299,6 @@ ResultCode KAddressArbiter::WaitIfEqual(VAddr addr, s32 value, s64 timeout) {
             slp.CancelSleep();
             return ResultTerminationRequested;
         }
-
-        // Set the synced object.
-        cur_thread->SetWaitResult(ResultTimedOut);
 
         // Read the value from userspace.
         s32 user_value{};
@@ -315,21 +322,10 @@ ResultCode KAddressArbiter::WaitIfEqual(VAddr addr, s32 value, s64 timeout) {
         // Set the arbiter.
         cur_thread->SetAddressArbiter(&thread_tree, addr);
         thread_tree.insert(*cur_thread);
-        cur_thread->SetState(ThreadState::Waiting);
+
+        // Wait for the thread to finish.
+        cur_thread->BeginWait(std::addressof(wait_queue));
         cur_thread->SetWaitReasonForDebugging(ThreadWaitReasonForDebugging::Arbitration);
-    }
-
-    // Cancel the timer wait.
-    kernel.TimeManager().UnscheduleTimeEvent(cur_thread);
-
-    // Remove from the address arbiter.
-    {
-        KScopedSchedulerLock sl(kernel);
-
-        if (cur_thread->IsWaitingForAddressArbiter()) {
-            thread_tree.erase(thread_tree.iterator_to(*cur_thread));
-            cur_thread->ClearAddressArbiter();
-        }
     }
 
     // Get the result.

--- a/src/core/hle/kernel/k_auto_object.h
+++ b/src/core/hle/kernel/k_auto_object.h
@@ -170,6 +170,10 @@ public:
         }
     }
 
+    const std::string& GetName() const {
+        return name;
+    }
+
 private:
     void RegisterWithKernel();
     void UnregisterWithKernel();

--- a/src/core/hle/kernel/k_condition_variable.cpp
+++ b/src/core/hle/kernel/k_condition_variable.cpp
@@ -63,8 +63,8 @@ public:
     explicit ThreadQueueImplForKConditionVariableWaitForAddress(KernelCore& kernel_)
         : KThreadQueue(kernel_) {}
 
-    virtual void CancelWait(KThread* waiting_thread, ResultCode wait_result,
-                            bool cancel_timer_task) override {
+    void CancelWait(KThread* waiting_thread, ResultCode wait_result,
+                    bool cancel_timer_task) override {
         // Remove the thread as a waiter from its owner.
         waiting_thread->GetLockOwner()->RemoveWaiter(waiting_thread);
 
@@ -82,8 +82,8 @@ public:
         KernelCore& kernel_, KConditionVariable::ThreadTree* t)
         : KThreadQueue(kernel_), m_tree(t) {}
 
-    virtual void CancelWait(KThread* waiting_thread, ResultCode wait_result,
-                            bool cancel_timer_task) override {
+    void CancelWait(KThread* waiting_thread, ResultCode wait_result,
+                    bool cancel_timer_task) override {
         // Remove the thread as a waiter from its owner.
         if (KThread* owner = waiting_thread->GetLockOwner(); owner != nullptr) {
             owner->RemoveWaiter(waiting_thread);

--- a/src/core/hle/kernel/k_condition_variable.cpp
+++ b/src/core/hle/kernel/k_condition_variable.cpp
@@ -33,7 +33,7 @@ bool WriteToUser(Core::System& system, VAddr address, const u32* p) {
 bool UpdateLockAtomic(Core::System& system, u32* out, VAddr address, u32 if_zero,
                       u32 new_orr_mask) {
     auto& monitor = system.Monitor();
-    const auto current_core = system.CurrentCoreIndex();
+    const auto current_core = system.Kernel().CurrentPhysicalCoreIndex();
 
     // Load the value from the address.
     const auto expected = monitor.ExclusiveRead32(current_core, address);

--- a/src/core/hle/kernel/k_condition_variable.cpp
+++ b/src/core/hle/kernel/k_condition_variable.cpp
@@ -121,26 +121,31 @@ ResultCode KConditionVariable::SignalToAddress(VAddr addr) {
 
         // Determine the next tag.
         u32 next_value{};
-        if (next_owner_thread) {
+        if (next_owner_thread != nullptr) {
             next_value = next_owner_thread->GetAddressKeyValue();
             if (num_waiters > 1) {
                 next_value |= Svc::HandleWaitMask;
             }
 
-            next_owner_thread->EndWait(ResultSuccess);
-        }
-
-        // Write the value to userspace.
-        if (!WriteToUser(system, addr, std::addressof(next_value))) {
-            if (next_owner_thread) {
-                next_owner_thread->SetWaitResult(ResultInvalidCurrentMemory);
+            // Write the value to userspace.
+            ResultCode result{ResultSuccess};
+            if (WriteToUser(system, addr, std::addressof(next_value))) [[likely]] {
+                result = ResultSuccess;
+            } else {
+                result = ResultInvalidCurrentMemory;
             }
 
-            return ResultInvalidCurrentMemory;
+            // Signal the next owner thread.
+            next_owner_thread->EndWait(result);
+            return result;
+        } else {
+            // Just write the value to userspace.
+            R_UNLESS(WriteToUser(system, addr, std::addressof(next_value)),
+                     ResultInvalidCurrentMemory);
+
+            return ResultSuccess;
         }
     }
-
-    return ResultSuccess;
 }
 
 ResultCode KConditionVariable::WaitForAddress(Handle handle, VAddr addr, u32 value) {
@@ -148,58 +153,45 @@ ResultCode KConditionVariable::WaitForAddress(Handle handle, VAddr addr, u32 val
     ThreadQueueImplForKConditionVariableWaitForAddress wait_queue(kernel);
 
     // Wait for the address.
-    {
-        KScopedAutoObject<KThread> owner_thread;
-        ASSERT(owner_thread.IsNull());
-        {
-            KScopedSchedulerLock sl(kernel);
-            cur_thread->SetWaitResult(ResultSuccess);
-
-            // Check if the thread should terminate.
-            R_UNLESS(!cur_thread->IsTerminationRequested(), ResultTerminationRequested);
-
-            {
-                // Read the tag from userspace.
-                u32 test_tag{};
-                R_UNLESS(ReadFromUser(system, std::addressof(test_tag), addr),
-                         ResultInvalidCurrentMemory);
-
-                // If the tag isn't the handle (with wait mask), we're done.
-                R_UNLESS(test_tag == (handle | Svc::HandleWaitMask), ResultSuccess);
-
-                // Get the lock owner thread.
-                owner_thread =
-                    kernel.CurrentProcess()->GetHandleTable().GetObjectWithoutPseudoHandle<KThread>(
-                        handle);
-                R_UNLESS(owner_thread.IsNotNull(), ResultInvalidHandle);
-
-                // Update the lock.
-                cur_thread->SetAddressKey(addr, value);
-                owner_thread->AddWaiter(cur_thread);
-
-                // Begin waiting.
-                cur_thread->BeginWait(std::addressof(wait_queue));
-                cur_thread->SetWaitReasonForDebugging(ThreadWaitReasonForDebugging::ConditionVar);
-                cur_thread->SetMutexWaitAddressForDebugging(addr);
-            }
-        }
-        ASSERT(owner_thread.IsNotNull());
-    }
-
-    // Remove the thread as a waiter from the lock owner.
+    KThread* owner_thread{};
     {
         KScopedSchedulerLock sl(kernel);
-        KThread* owner_thread = cur_thread->GetLockOwner();
-        if (owner_thread != nullptr) {
-            owner_thread->RemoveWaiter(cur_thread);
-        }
+
+        // Check if the thread should terminate.
+        R_UNLESS(!cur_thread->IsTerminationRequested(), ResultTerminationRequested);
+
+        // Read the tag from userspace.
+        u32 test_tag{};
+        R_UNLESS(ReadFromUser(system, std::addressof(test_tag), addr), ResultInvalidCurrentMemory);
+
+        // If the tag isn't the handle (with wait mask), we're done.
+        R_SUCCEED_IF(test_tag != (handle | Svc::HandleWaitMask));
+
+        // Get the lock owner thread.
+        owner_thread = kernel.CurrentProcess()
+                           ->GetHandleTable()
+                           .GetObjectWithoutPseudoHandle<KThread>(handle)
+                           .ReleasePointerUnsafe();
+        R_UNLESS(owner_thread != nullptr, ResultInvalidHandle);
+
+        // Update the lock.
+        cur_thread->SetAddressKey(addr, value);
+        owner_thread->AddWaiter(cur_thread);
+
+        // Begin waiting.
+        cur_thread->BeginWait(std::addressof(wait_queue));
+        cur_thread->SetWaitReasonForDebugging(ThreadWaitReasonForDebugging::ConditionVar);
+        cur_thread->SetMutexWaitAddressForDebugging(addr);
     }
+
+    // Close our reference to the owner thread, now that the wait is over.
+    owner_thread->Close();
 
     // Get the wait result.
     return cur_thread->GetWaitResult();
 }
 
-KThread* KConditionVariable::SignalImpl(KThread* thread) {
+void KConditionVariable::SignalImpl(KThread* thread) {
     // Check pre-conditions.
     ASSERT(kernel.GlobalSchedulerContext().IsLocked());
 
@@ -213,14 +205,13 @@ KThread* KConditionVariable::SignalImpl(KThread* thread) {
         // TODO(bunnei): We should disable interrupts here via KScopedInterruptDisable.
         // TODO(bunnei): We should call CanAccessAtomic(..) here.
         can_access = true;
-        if (can_access) {
+        if (can_access) [[likely]] {
             UpdateLockAtomic(system, std::addressof(prev_tag), address, own_tag,
                              Svc::HandleWaitMask);
         }
     }
 
-    KThread* thread_to_close = nullptr;
-    if (can_access) {
+    if (can_access) [[likely]] {
         if (prev_tag == Svc::InvalidHandle) {
             // If nobody held the lock previously, we're all good.
             thread->EndWait(ResultSuccess);
@@ -232,10 +223,10 @@ KThread* KConditionVariable::SignalImpl(KThread* thread) {
                                             static_cast<Handle>(prev_tag & ~Svc::HandleWaitMask))
                                         .ReleasePointerUnsafe();
 
-            if (owner_thread) {
+            if (owner_thread) [[likely]] {
                 // Add the thread as a waiter on the owner.
                 owner_thread->AddWaiter(thread);
-                thread_to_close = owner_thread;
+                owner_thread->Close();
             } else {
                 // The lock was tagged with a thread that doesn't exist.
                 thread->EndWait(ResultInvalidState);
@@ -245,20 +236,11 @@ KThread* KConditionVariable::SignalImpl(KThread* thread) {
         // If the address wasn't accessible, note so.
         thread->EndWait(ResultInvalidCurrentMemory);
     }
-
-    return thread_to_close;
 }
 
 void KConditionVariable::Signal(u64 cv_key, s32 count) {
-    // Prepare for signaling.
-    constexpr int MaxThreads = 16;
-
-    KLinkedList<KThread> thread_list{kernel};
-    std::array<KThread*, MaxThreads> thread_array;
-    s32 num_to_close{};
-
     // Perform signaling.
-    s32 num_waiters{};
+    int num_waiters = 0;
     {
         KScopedSchedulerLock sl(kernel);
 
@@ -267,14 +249,7 @@ void KConditionVariable::Signal(u64 cv_key, s32 count) {
                (it->GetConditionVariableKey() == cv_key)) {
             KThread* target_thread = std::addressof(*it);
 
-            if (KThread* thread = SignalImpl(target_thread); thread != nullptr) {
-                if (num_to_close < MaxThreads) {
-                    thread_array[num_to_close++] = thread;
-                } else {
-                    thread_list.push_back(*thread);
-                }
-            }
-
+            this->SignalImpl(target_thread);
             it = thread_tree.erase(it);
             target_thread->ClearConditionVariable();
             ++num_waiters;
@@ -282,33 +257,20 @@ void KConditionVariable::Signal(u64 cv_key, s32 count) {
 
         // If we have no waiters, clear the has waiter flag.
         if (it == thread_tree.end() || it->GetConditionVariableKey() != cv_key) {
-            const u32 has_waiter_flag{};
+            const u32 has_waiter_flag = 0;
             WriteToUser(system, cv_key, std::addressof(has_waiter_flag));
         }
-    }
-
-    // Close threads in the array.
-    for (auto i = 0; i < num_to_close; ++i) {
-        thread_array[i]->Close();
-    }
-
-    // Close threads in the list.
-    for (auto it = thread_list.begin(); it != thread_list.end(); it = thread_list.erase(it)) {
-        (*it).Close();
     }
 }
 
 ResultCode KConditionVariable::Wait(VAddr addr, u64 key, u32 value, s64 timeout) {
     // Prepare to wait.
-    KThread* cur_thread = kernel.CurrentScheduler()->GetCurrentThread();
+    KThread* cur_thread = GetCurrentThreadPointer(kernel);
     ThreadQueueImplForKConditionVariableWaitConditionVariable wait_queue(
         kernel, std::addressof(thread_tree));
 
     {
-        KScopedSchedulerLockAndSleep slp{kernel, cur_thread, timeout};
-
-        // Set the synced object.
-        cur_thread->SetWaitResult(ResultTimedOut);
+        KScopedSchedulerLockAndSleep slp(kernel, cur_thread, timeout);
 
         // Check that the thread isn't terminating.
         if (cur_thread->IsTerminationRequested()) {
@@ -350,38 +312,20 @@ ResultCode KConditionVariable::Wait(VAddr addr, u64 key, u32 value, s64 timeout)
             }
         }
 
+        // If timeout is zero, time out.
+        R_UNLESS(timeout != 0, ResultTimedOut);
+
         // Update condition variable tracking.
-        {
-            cur_thread->SetConditionVariable(std::addressof(thread_tree), addr, key, value);
-            thread_tree.insert(*cur_thread);
-        }
+        cur_thread->SetConditionVariable(std::addressof(thread_tree), addr, key, value);
+        thread_tree.insert(*cur_thread);
 
-        // If the timeout is non-zero, set the thread as waiting.
-        if (timeout != 0) {
-            cur_thread->BeginWait(std::addressof(wait_queue));
-            cur_thread->SetWaitReasonForDebugging(ThreadWaitReasonForDebugging::ConditionVar);
-            cur_thread->SetMutexWaitAddressForDebugging(addr);
-        }
+        // Begin waiting.
+        cur_thread->BeginWait(std::addressof(wait_queue));
+        cur_thread->SetWaitReasonForDebugging(ThreadWaitReasonForDebugging::ConditionVar);
+        cur_thread->SetMutexWaitAddressForDebugging(addr);
     }
 
-    // Cancel the timer wait.
-    kernel.TimeManager().UnscheduleTimeEvent(cur_thread);
-
-    // Remove from the condition variable.
-    {
-        KScopedSchedulerLock sl(kernel);
-
-        if (KThread* owner = cur_thread->GetLockOwner(); owner != nullptr) {
-            owner->RemoveWaiter(cur_thread);
-        }
-
-        if (cur_thread->IsWaitingForConditionVariable()) {
-            thread_tree.erase(thread_tree.iterator_to(*cur_thread));
-            cur_thread->ClearConditionVariable();
-        }
-    }
-
-    // Get the result.
+    // Get the wait result.
     return cur_thread->GetWaitResult();
 }
 

--- a/src/core/hle/kernel/k_condition_variable.cpp
+++ b/src/core/hle/kernel/k_condition_variable.cpp
@@ -240,7 +240,7 @@ void KConditionVariable::SignalImpl(KThread* thread) {
 
 void KConditionVariable::Signal(u64 cv_key, s32 count) {
     // Perform signaling.
-    int num_waiters = 0;
+    s32 num_waiters{};
     {
         KScopedSchedulerLock sl(kernel);
 
@@ -257,7 +257,7 @@ void KConditionVariable::Signal(u64 cv_key, s32 count) {
 
         // If we have no waiters, clear the has waiter flag.
         if (it == thread_tree.end() || it->GetConditionVariableKey() != cv_key) {
-            const u32 has_waiter_flag = 0;
+            const u32 has_waiter_flag{};
             WriteToUser(system, cv_key, std::addressof(has_waiter_flag));
         }
     }

--- a/src/core/hle/kernel/k_condition_variable.h
+++ b/src/core/hle/kernel/k_condition_variable.h
@@ -34,7 +34,7 @@ public:
     [[nodiscard]] ResultCode Wait(VAddr addr, u64 key, u32 value, s64 timeout);
 
 private:
-    [[nodiscard]] KThread* SignalImpl(KThread* thread);
+    void SignalImpl(KThread* thread);
 
     ThreadTree thread_tree;
 

--- a/src/core/hle/kernel/k_handle_table.cpp
+++ b/src/core/hle/kernel/k_handle_table.cpp
@@ -13,6 +13,7 @@ ResultCode KHandleTable::Finalize() {
     // Get the table and clear our record of it.
     u16 saved_table_size = 0;
     {
+        KScopedDisableDispatch dd(kernel);
         KScopedSpinLock lk(m_lock);
 
         std::swap(m_table_size, saved_table_size);
@@ -43,6 +44,7 @@ bool KHandleTable::Remove(Handle handle) {
     // Find the object and free the entry.
     KAutoObject* obj = nullptr;
     {
+        KScopedDisableDispatch dd(kernel);
         KScopedSpinLock lk(m_lock);
 
         if (this->IsValidHandle(handle)) {
@@ -62,6 +64,7 @@ bool KHandleTable::Remove(Handle handle) {
 }
 
 ResultCode KHandleTable::Add(Handle* out_handle, KAutoObject* obj, u16 type) {
+    KScopedDisableDispatch dd(kernel);
     KScopedSpinLock lk(m_lock);
 
     // Never exceed our capacity.
@@ -84,6 +87,7 @@ ResultCode KHandleTable::Add(Handle* out_handle, KAutoObject* obj, u16 type) {
 }
 
 ResultCode KHandleTable::Reserve(Handle* out_handle) {
+    KScopedDisableDispatch dd(kernel);
     KScopedSpinLock lk(m_lock);
 
     // Never exceed our capacity.
@@ -94,6 +98,7 @@ ResultCode KHandleTable::Reserve(Handle* out_handle) {
 }
 
 void KHandleTable::Unreserve(Handle handle) {
+    KScopedDisableDispatch dd(kernel);
     KScopedSpinLock lk(m_lock);
 
     // Unpack the handle.
@@ -112,6 +117,7 @@ void KHandleTable::Unreserve(Handle handle) {
 }
 
 void KHandleTable::Register(Handle handle, KAutoObject* obj, u16 type) {
+    KScopedDisableDispatch dd(kernel);
     KScopedSpinLock lk(m_lock);
 
     // Unpack the handle.

--- a/src/core/hle/kernel/k_handle_table.h
+++ b/src/core/hle/kernel/k_handle_table.h
@@ -68,6 +68,7 @@ public:
     template <typename T = KAutoObject>
     KScopedAutoObject<T> GetObjectWithoutPseudoHandle(Handle handle) const {
         // Lock and look up in table.
+        KScopedDisableDispatch dd(kernel);
         KScopedSpinLock lk(m_lock);
 
         if constexpr (std::is_same_v<T, KAutoObject>) {
@@ -122,6 +123,7 @@ public:
         size_t num_opened;
         {
             // Lock the table.
+            KScopedDisableDispatch dd(kernel);
             KScopedSpinLock lk(m_lock);
             for (num_opened = 0; num_opened < num_handles; num_opened++) {
                 // Get the current handle.

--- a/src/core/hle/kernel/k_light_condition_variable.cpp
+++ b/src/core/hle/kernel/k_light_condition_variable.cpp
@@ -18,8 +18,8 @@ public:
                                               bool term)
         : KThreadQueue(kernel_), m_wait_list(wl), m_allow_terminating_thread(term) {}
 
-    virtual void CancelWait(KThread* waiting_thread, ResultCode wait_result,
-                            bool cancel_timer_task) override {
+    void CancelWait(KThread* waiting_thread, ResultCode wait_result,
+                    bool cancel_timer_task) override {
         // Only process waits if we're allowed to.
         if (ResultTerminationRequested == wait_result && m_allow_terminating_thread) {
             return;

--- a/src/core/hle/kernel/k_light_condition_variable.cpp
+++ b/src/core/hle/kernel/k_light_condition_variable.cpp
@@ -1,0 +1,80 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "core/hle/kernel/k_light_condition_variable.h"
+#include "core/hle/kernel/k_scheduler.h"
+#include "core/hle/kernel/k_scoped_scheduler_lock_and_sleep.h"
+#include "core/hle/kernel/k_thread_queue.h"
+#include "core/hle/kernel/svc_results.h"
+
+namespace Kernel {
+
+namespace {
+
+class ThreadQueueImplForKLightConditionVariable final : public KThreadQueue {
+private:
+    KThread::WaiterList* m_wait_list;
+    bool m_allow_terminating_thread;
+
+public:
+    ThreadQueueImplForKLightConditionVariable(KernelCore& kernel_, KThread::WaiterList* wl,
+                                              bool term)
+        : KThreadQueue(kernel_), m_wait_list(wl), m_allow_terminating_thread(term) {}
+
+    virtual void CancelWait(KThread* waiting_thread, ResultCode wait_result,
+                            bool cancel_timer_task) override {
+        // Only process waits if we're allowed to.
+        if (ResultTerminationRequested == wait_result && m_allow_terminating_thread) {
+            return;
+        }
+
+        // Remove the thread from the waiting thread from the light condition variable.
+        m_wait_list->erase(m_wait_list->iterator_to(*waiting_thread));
+
+        // Invoke the base cancel wait handler.
+        KThreadQueue::CancelWait(waiting_thread, wait_result, cancel_timer_task);
+    }
+};
+
+} // namespace
+
+void KLightConditionVariable::Wait(KLightLock* lock, s64 timeout, bool allow_terminating_thread) {
+    // Create thread queue.
+    KThread* owner = GetCurrentThreadPointer(kernel);
+
+    ThreadQueueImplForKLightConditionVariable wait_queue(kernel, std::addressof(wait_list),
+                                                         allow_terminating_thread);
+
+    // Sleep the thread.
+    {
+        KScopedSchedulerLockAndSleep lk(kernel, owner, timeout);
+
+        if (!allow_terminating_thread && owner->IsTerminationRequested()) {
+            lk.CancelSleep();
+            return;
+        }
+
+        lock->Unlock();
+
+        // Add the thread to the queue.
+        wait_list.push_back(*owner);
+
+        // Begin waiting.
+        owner->BeginWait(std::addressof(wait_queue));
+    }
+
+    // Re-acquire the lock.
+    lock->Lock();
+}
+
+void KLightConditionVariable::Broadcast() {
+    KScopedSchedulerLock lk(kernel);
+
+    // Signal all threads.
+    for (auto it = wait_list.begin(); it != wait_list.end(); it = wait_list.erase(it)) {
+        it->EndWait(ResultSuccess);
+    }
+}
+
+} // namespace Kernel

--- a/src/core/hle/kernel/k_light_condition_variable.cpp
+++ b/src/core/hle/kernel/k_light_condition_variable.cpp
@@ -13,10 +13,6 @@ namespace Kernel {
 namespace {
 
 class ThreadQueueImplForKLightConditionVariable final : public KThreadQueue {
-private:
-    KThread::WaiterList* m_wait_list;
-    bool m_allow_terminating_thread;
-
 public:
     ThreadQueueImplForKLightConditionVariable(KernelCore& kernel_, KThread::WaiterList* wl,
                                               bool term)
@@ -35,6 +31,10 @@ public:
         // Invoke the base cancel wait handler.
         KThreadQueue::CancelWait(waiting_thread, wait_result, cancel_timer_task);
     }
+
+private:
+    KThread::WaiterList* m_wait_list;
+    bool m_allow_terminating_thread;
 };
 
 } // namespace

--- a/src/core/hle/kernel/k_light_condition_variable.h
+++ b/src/core/hle/kernel/k_light_condition_variable.h
@@ -1,73 +1,25 @@
-// Copyright 2020 yuzu Emulator Project
+// Copyright 2021 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
-
-// This file references various implementation details from Atmosphere, an open-source firmware for
-// the Nintendo Switch. Copyright 2018-2020 Atmosphere-NX.
 
 #pragma once
 
 #include "common/common_types.h"
-#include "core/hle/kernel/k_scheduler.h"
-#include "core/hle/kernel/k_scoped_scheduler_lock_and_sleep.h"
-#include "core/hle/kernel/time_manager.h"
+#include "core/hle/kernel/k_thread.h"
 
 namespace Kernel {
+
 class KernelCore;
+class KLightLock;
 
 class KLightConditionVariable {
 public:
     explicit KLightConditionVariable(KernelCore& kernel_) : kernel{kernel_} {}
 
-    void Wait(KLightLock* lock, s64 timeout = -1, bool allow_terminating_thread = true) {
-        WaitImpl(lock, timeout, allow_terminating_thread);
-    }
-
-    void Broadcast() {
-        KScopedSchedulerLock lk{kernel};
-
-        // Signal all threads.
-        for (auto& thread : wait_list) {
-            thread.SetState(ThreadState::Runnable);
-        }
-    }
+    void Wait(KLightLock* lock, s64 timeout = -1, bool allow_terminating_thread = true);
+    void Broadcast();
 
 private:
-    void WaitImpl(KLightLock* lock, s64 timeout, bool allow_terminating_thread) {
-        KThread* owner = GetCurrentThreadPointer(kernel);
-
-        // Sleep the thread.
-        {
-            KScopedSchedulerLockAndSleep lk{kernel, owner, timeout};
-
-            if (!allow_terminating_thread && owner->IsTerminationRequested()) {
-                lk.CancelSleep();
-                return;
-            }
-
-            lock->Unlock();
-
-            // Set the thread as waiting.
-            GetCurrentThread(kernel).SetState(ThreadState::Waiting);
-
-            // Add the thread to the queue.
-            wait_list.push_back(GetCurrentThread(kernel));
-        }
-
-        // Remove the thread from the wait list.
-        {
-            KScopedSchedulerLock sl{kernel};
-
-            wait_list.erase(wait_list.iterator_to(GetCurrentThread(kernel)));
-        }
-
-        // Cancel the task that the sleep setup.
-        kernel.TimeManager().UnscheduleTimeEvent(owner);
-
-        // Re-acquire the lock.
-        lock->Lock();
-    }
-
     KernelCore& kernel;
     KThread::WaiterList wait_list{};
 };

--- a/src/core/hle/kernel/k_light_condition_variable.h
+++ b/src/core/hle/kernel/k_light_condition_variable.h
@@ -1,4 +1,4 @@
-// Copyright 2021 yuzu Emulator Project
+// Copyright 2020 yuzu Emulator Project
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 

--- a/src/core/hle/kernel/k_light_lock.cpp
+++ b/src/core/hle/kernel/k_light_lock.cpp
@@ -5,44 +5,54 @@
 #include "core/hle/kernel/k_light_lock.h"
 #include "core/hle/kernel/k_scheduler.h"
 #include "core/hle/kernel/k_thread.h"
+#include "core/hle/kernel/k_thread_queue.h"
 #include "core/hle/kernel/kernel.h"
 
 namespace Kernel {
 
+namespace {
+
+class ThreadQueueImplForKLightLock final : public KThreadQueue {
+public:
+    explicit ThreadQueueImplForKLightLock(KernelCore& kernel_) : KThreadQueue(kernel_) {}
+
+    virtual void CancelWait([[maybe_unused]] KThread* waiting_thread,
+                            [[maybe_unused]] ResultCode wait_result,
+                            [[maybe_unused]] bool cancel_timer_task) override {
+        // Do nothing, waiting to acquire a light lock cannot be canceled.
+    }
+};
+
+} // namespace
+
 void KLightLock::Lock() {
     const uintptr_t cur_thread = reinterpret_cast<uintptr_t>(GetCurrentThreadPointer(kernel));
-    const uintptr_t cur_thread_tag = (cur_thread | 1);
 
     while (true) {
         uintptr_t old_tag = tag.load(std::memory_order_relaxed);
 
-        while (!tag.compare_exchange_weak(old_tag, (old_tag == 0) ? cur_thread : old_tag | 1,
+        while (!tag.compare_exchange_weak(old_tag, (old_tag == 0) ? cur_thread : (old_tag | 1),
                                           std::memory_order_acquire)) {
-            if ((old_tag | 1) == cur_thread_tag) {
-                return;
-            }
         }
 
-        if ((old_tag == 0) || ((old_tag | 1) == cur_thread_tag)) {
+        if (old_tag == 0 || this->LockSlowPath(old_tag | 1, cur_thread)) {
             break;
         }
-
-        LockSlowPath(old_tag | 1, cur_thread);
     }
 }
 
 void KLightLock::Unlock() {
     const uintptr_t cur_thread = reinterpret_cast<uintptr_t>(GetCurrentThreadPointer(kernel));
+
     uintptr_t expected = cur_thread;
-    do {
-        if (expected != cur_thread) {
-            return UnlockSlowPath(cur_thread);
-        }
-    } while (!tag.compare_exchange_weak(expected, 0, std::memory_order_release));
+    if (!tag.compare_exchange_strong(expected, 0, std::memory_order_release)) {
+        this->UnlockSlowPath(cur_thread);
+    }
 }
 
-void KLightLock::LockSlowPath(uintptr_t _owner, uintptr_t _cur_thread) {
+bool KLightLock::LockSlowPath(uintptr_t _owner, uintptr_t _cur_thread) {
     KThread* cur_thread = reinterpret_cast<KThread*>(_cur_thread);
+    ThreadQueueImplForKLightLock wait_queue(kernel);
 
     // Pend the current thread waiting on the owner thread.
     {
@@ -50,30 +60,23 @@ void KLightLock::LockSlowPath(uintptr_t _owner, uintptr_t _cur_thread) {
 
         // Ensure we actually have locking to do.
         if (tag.load(std::memory_order_relaxed) != _owner) {
-            return;
+            return false;
         }
 
         // Add the current thread as a waiter on the owner.
-        KThread* owner_thread = reinterpret_cast<KThread*>(_owner & ~1ULL);
+        KThread* owner_thread = reinterpret_cast<KThread*>(_owner & ~1ul);
         cur_thread->SetAddressKey(reinterpret_cast<uintptr_t>(std::addressof(tag)));
         owner_thread->AddWaiter(cur_thread);
 
-        // Set thread states.
-        cur_thread->SetState(ThreadState::Waiting);
+        // Begin waiting to hold the lock.
+        cur_thread->BeginWait(std::addressof(wait_queue));
 
         if (owner_thread->IsSuspended()) {
             owner_thread->ContinueIfHasKernelWaiters();
         }
     }
 
-    // We're no longer waiting on the lock owner.
-    {
-        KScopedSchedulerLock sl{kernel};
-
-        if (KThread* owner_thread = cur_thread->GetLockOwner(); owner_thread != nullptr) {
-            owner_thread->RemoveWaiter(cur_thread);
-        }
-    }
+    return true;
 }
 
 void KLightLock::UnlockSlowPath(uintptr_t _cur_thread) {
@@ -81,22 +84,20 @@ void KLightLock::UnlockSlowPath(uintptr_t _cur_thread) {
 
     // Unlock.
     {
-        KScopedSchedulerLock sl{kernel};
+        KScopedSchedulerLock sl(kernel);
 
         // Get the next owner.
-        s32 num_waiters = 0;
+        s32 num_waiters;
         KThread* next_owner = owner_thread->RemoveWaiterByKey(
             std::addressof(num_waiters), reinterpret_cast<uintptr_t>(std::addressof(tag)));
 
         // Pass the lock to the next owner.
         uintptr_t next_tag = 0;
         if (next_owner != nullptr) {
-            next_tag = reinterpret_cast<uintptr_t>(next_owner);
-            if (num_waiters > 1) {
-                next_tag |= 0x1;
-            }
+            next_tag =
+                reinterpret_cast<uintptr_t>(next_owner) | static_cast<uintptr_t>(num_waiters > 1);
 
-            next_owner->SetState(ThreadState::Runnable);
+            next_owner->EndWait(ResultSuccess);
 
             if (next_owner->IsSuspended()) {
                 next_owner->ContinueIfHasKernelWaiters();
@@ -110,7 +111,7 @@ void KLightLock::UnlockSlowPath(uintptr_t _cur_thread) {
         }
 
         // Write the new tag value.
-        tag.store(next_tag);
+        tag.store(next_tag, std::memory_order_release);
     }
 }
 

--- a/src/core/hle/kernel/k_light_lock.cpp
+++ b/src/core/hle/kernel/k_light_lock.cpp
@@ -16,8 +16,8 @@ class ThreadQueueImplForKLightLock final : public KThreadQueue {
 public:
     explicit ThreadQueueImplForKLightLock(KernelCore& kernel_) : KThreadQueue(kernel_) {}
 
-    virtual void CancelWait(KThread* waiting_thread, ResultCode wait_result,
-                            bool cancel_timer_task) override {
+    void CancelWait(KThread* waiting_thread, ResultCode wait_result,
+                    bool cancel_timer_task) override {
         // Remove the thread as a waiter from its owner.
         if (KThread* owner = waiting_thread->GetLockOwner(); owner != nullptr) {
             owner->RemoveWaiter(waiting_thread);

--- a/src/core/hle/kernel/k_light_lock.h
+++ b/src/core/hle/kernel/k_light_lock.h
@@ -20,7 +20,7 @@ public:
 
     void Unlock();
 
-    void LockSlowPath(uintptr_t owner, uintptr_t cur_thread);
+    bool LockSlowPath(uintptr_t owner, uintptr_t cur_thread);
 
     void UnlockSlowPath(uintptr_t cur_thread);
 

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -60,6 +60,7 @@ void SetupMainThread(Core::System& system, KProcess& owner_process, u32 priority
     thread->GetContext64().cpu_registers[0] = 0;
     thread->GetContext32().cpu_registers[1] = thread_handle;
     thread->GetContext64().cpu_registers[1] = thread_handle;
+    thread->DisableDispatch();
 
     auto& kernel = system.Kernel();
     // Threads by default are dormant, wake up the main thread so it runs when the scheduler fires

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -228,12 +228,15 @@ void KProcess::PinCurrentThread() {
     const s32 core_id = GetCurrentCoreId(kernel);
     KThread* cur_thread = GetCurrentThreadPointer(kernel);
 
-    // Pin it.
-    PinThread(core_id, cur_thread);
-    cur_thread->Pin();
+    // If the thread isn't terminated, pin it.
+    if (!cur_thread->IsTerminationRequested()) {
+        // Pin it.
+        PinThread(core_id, cur_thread);
+        cur_thread->Pin();
 
-    // An update is needed.
-    KScheduler::SetSchedulerUpdateNeeded(kernel);
+        // An update is needed.
+        KScheduler::SetSchedulerUpdateNeeded(kernel);
+    }
 }
 
 void KProcess::UnpinCurrentThread() {
@@ -246,6 +249,20 @@ void KProcess::UnpinCurrentThread() {
     // Unpin it.
     cur_thread->Unpin();
     UnpinThread(core_id, cur_thread);
+
+    // An update is needed.
+    KScheduler::SetSchedulerUpdateNeeded(kernel);
+}
+
+void KProcess::UnpinThread(KThread* thread) {
+    ASSERT(kernel.GlobalSchedulerContext().IsLocked());
+
+    // Get the thread's core id.
+    const auto core_id = thread->GetActiveCore();
+
+    // Unpin it.
+    UnpinThread(core_id, thread);
+    thread->Unpin();
 
     // An update is needed.
     KScheduler::SetSchedulerUpdateNeeded(kernel);

--- a/src/core/hle/kernel/k_process.h
+++ b/src/core/hle/kernel/k_process.h
@@ -259,7 +259,7 @@ public:
 
     [[nodiscard]] KThread* GetPinnedThread(s32 core_id) const {
         ASSERT(0 <= core_id && core_id < static_cast<s32>(Core::Hardware::NUM_CPU_CORES));
-        return pinned_threads[core_id];
+        return pinned_threads.at(core_id);
     }
 
     /// Gets 8 bytes of random data for svcGetInfo RandomEntropy
@@ -347,6 +347,7 @@ public:
 
     void PinCurrentThread();
     void UnpinCurrentThread();
+    void UnpinThread(KThread* thread);
 
     KLightLock& GetStateLock() {
         return state_lock;
@@ -368,14 +369,14 @@ private:
     void PinThread(s32 core_id, KThread* thread) {
         ASSERT(0 <= core_id && core_id < static_cast<s32>(Core::Hardware::NUM_CPU_CORES));
         ASSERT(thread != nullptr);
-        ASSERT(pinned_threads[core_id] == nullptr);
+        ASSERT(pinned_threads.at(core_id) == nullptr);
         pinned_threads[core_id] = thread;
     }
 
     void UnpinThread(s32 core_id, KThread* thread) {
         ASSERT(0 <= core_id && core_id < static_cast<s32>(Core::Hardware::NUM_CPU_CORES));
         ASSERT(thread != nullptr);
-        ASSERT(pinned_threads[core_id] == thread);
+        ASSERT(pinned_threads.at(core_id) == thread);
         pinned_threads[core_id] = nullptr;
     }
 

--- a/src/core/hle/kernel/k_process.h
+++ b/src/core/hle/kernel/k_process.h
@@ -259,7 +259,7 @@ public:
 
     [[nodiscard]] KThread* GetPinnedThread(s32 core_id) const {
         ASSERT(0 <= core_id && core_id < static_cast<s32>(Core::Hardware::NUM_CPU_CORES));
-        return pinned_threads.at(core_id);
+        return pinned_threads[core_id];
     }
 
     /// Gets 8 bytes of random data for svcGetInfo RandomEntropy
@@ -369,14 +369,14 @@ private:
     void PinThread(s32 core_id, KThread* thread) {
         ASSERT(0 <= core_id && core_id < static_cast<s32>(Core::Hardware::NUM_CPU_CORES));
         ASSERT(thread != nullptr);
-        ASSERT(pinned_threads.at(core_id) == nullptr);
+        ASSERT(pinned_threads[core_id] == nullptr);
         pinned_threads[core_id] = thread;
     }
 
     void UnpinThread(s32 core_id, KThread* thread) {
         ASSERT(0 <= core_id && core_id < static_cast<s32>(Core::Hardware::NUM_CPU_CORES));
         ASSERT(thread != nullptr);
-        ASSERT(pinned_threads.at(core_id) == thread);
+        ASSERT(pinned_threads[core_id] == thread);
         pinned_threads[core_id] = nullptr;
     }
 

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -699,11 +699,6 @@ void KScheduler::Reload(KThread* thread) {
     if (thread) {
         ASSERT_MSG(thread->GetState() == ThreadState::Runnable, "Thread must be runnable.");
 
-        auto* const thread_owner_process = thread->GetOwnerProcess();
-        if (thread_owner_process != nullptr) {
-            system.Kernel().MakeCurrentProcess(thread_owner_process);
-        }
-
         Core::ARM_Interface& cpu_core = system.ArmInterface(core_id);
         cpu_core.LoadContext(thread->GetContext32());
         cpu_core.LoadContext(thread->GetContext64());

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -617,11 +617,15 @@ KScheduler::KScheduler(Core::System& system_, s32 core_id_) : system{system_}, c
     state.highest_priority_thread = nullptr;
 }
 
-KScheduler::~KScheduler() {
+void KScheduler::Finalize() {
     if (idle_thread) {
         idle_thread->Close();
         idle_thread = nullptr;
     }
+}
+
+KScheduler::~KScheduler() {
+    ASSERT(!idle_thread);
 }
 
 KThread* KScheduler::GetCurrentThread() const {

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -391,10 +391,12 @@ void KScheduler::EnableScheduling(KernelCore& kernel, u64 cores_needing_scheduli
         return;
     }
 
-    ASSERT(GetCurrentThreadPointer(kernel)->GetDisableDispatchCount() >= 1);
+    auto* current_thread = GetCurrentThreadPointer(kernel);
 
-    if (GetCurrentThreadPointer(kernel)->GetDisableDispatchCount() > 1) {
-        GetCurrentThreadPointer(kernel)->EnableDispatch();
+    ASSERT(current_thread->GetDisableDispatchCount() >= 1);
+
+    if (current_thread->GetDisableDispatchCount() > 1) {
+        current_thread->EnableDispatch();
     } else {
         RescheduleCores(kernel, cores_needing_scheduling);
     }

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -240,8 +240,8 @@ void KScheduler::OnThreadPriorityChanged(KernelCore& kernel, KThread* thread, s3
 
     // If the thread is runnable, we want to change its priority in the queue.
     if (thread->GetRawState() == ThreadState::Runnable) {
-        GetPriorityQueue(kernel).ChangePriority(
-            old_priority, thread == kernel.CurrentScheduler()->GetCurrentThread(), thread);
+        GetPriorityQueue(kernel).ChangePriority(old_priority,
+                                                thread == kernel.GetCurrentEmuThread(), thread);
         IncrementScheduledCount(thread);
         SetSchedulerUpdateNeeded(kernel);
     }
@@ -360,7 +360,7 @@ void KScheduler::RotateScheduledQueue(s32 cpu_core_id, s32 priority) {
 }
 
 bool KScheduler::CanSchedule(KernelCore& kernel) {
-    return kernel.CurrentScheduler()->GetCurrentThread()->GetDisableDispatchCount() <= 1;
+    return kernel.GetCurrentEmuThread()->GetDisableDispatchCount() <= 1;
 }
 
 bool KScheduler::IsSchedulerUpdateNeeded(const KernelCore& kernel) {

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -376,11 +376,21 @@ void KScheduler::ClearSchedulerUpdateNeeded(KernelCore& kernel) {
 }
 
 void KScheduler::DisableScheduling(KernelCore& kernel) {
+    // If we are shutting down the kernel, none of this is relevant anymore.
+    if (kernel.IsShuttingDown()) {
+        return;
+    }
+
     ASSERT(GetCurrentThreadPointer(kernel)->GetDisableDispatchCount() >= 0);
     GetCurrentThreadPointer(kernel)->DisableDispatch();
 }
 
 void KScheduler::EnableScheduling(KernelCore& kernel, u64 cores_needing_scheduling) {
+    // If we are shutting down the kernel, none of this is relevant anymore.
+    if (kernel.IsShuttingDown()) {
+        return;
+    }
+
     ASSERT(GetCurrentThreadPointer(kernel)->GetDisableDispatchCount() >= 1);
 
     if (GetCurrentThreadPointer(kernel)->GetDisableDispatchCount() > 1) {

--- a/src/core/hle/kernel/k_scheduler.h
+++ b/src/core/hle/kernel/k_scheduler.h
@@ -33,6 +33,8 @@ public:
     explicit KScheduler(Core::System& system_, s32 core_id_);
     ~KScheduler();
 
+    void Finalize();
+
     /// Reschedules to the next available thread (call after current thread is suspended)
     void RescheduleCurrentCore();
 

--- a/src/core/hle/kernel/k_scheduler_lock.h
+++ b/src/core/hle/kernel/k_scheduler_lock.h
@@ -23,6 +23,11 @@ public:
     }
 
     void Lock() {
+        // If we are shutting down the kernel, none of this is relevant anymore.
+        if (kernel.IsShuttingDown()) {
+            return;
+        }
+
         if (IsLockedByCurrentThread()) {
             // If we already own the lock, we can just increment the count.
             ASSERT(lock_count > 0);
@@ -43,6 +48,11 @@ public:
     }
 
     void Unlock() {
+        // If we are shutting down the kernel, none of this is relevant anymore.
+        if (kernel.IsShuttingDown()) {
+            return;
+        }
+
         ASSERT(IsLockedByCurrentThread());
         ASSERT(lock_count > 0);
 

--- a/src/core/hle/kernel/k_scoped_scheduler_lock_and_sleep.h
+++ b/src/core/hle/kernel/k_scoped_scheduler_lock_and_sleep.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "common/common_types.h"
+#include "core/hle/kernel/global_scheduler_context.h"
 #include "core/hle/kernel/k_thread.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/time_manager.h"

--- a/src/core/hle/kernel/k_server_session.cpp
+++ b/src/core/hle/kernel/k_server_session.cpp
@@ -176,7 +176,7 @@ ResultCode KServerSession::CompleteSyncRequest(HLERequestContext& context) {
         KScopedSchedulerLock lock(kernel);
         if (!context.IsThreadWaiting()) {
             context.GetThread().Wakeup();
-            context.GetThread().SetSyncedObject(nullptr, result);
+            context.GetThread().SetWaitResult(result);
         }
     }
 

--- a/src/core/hle/kernel/k_server_session.cpp
+++ b/src/core/hle/kernel/k_server_session.cpp
@@ -175,8 +175,7 @@ ResultCode KServerSession::CompleteSyncRequest(HLERequestContext& context) {
     {
         KScopedSchedulerLock lock(kernel);
         if (!context.IsThreadWaiting()) {
-            context.GetThread().Wakeup();
-            context.GetThread().SetWaitResult(result);
+            context.GetThread().EndWait(result);
         }
     }
 

--- a/src/core/hle/kernel/k_synchronization_object.cpp
+++ b/src/core/hle/kernel/k_synchronization_object.cpp
@@ -46,8 +46,8 @@ public:
         KThreadQueue::EndWait(waiting_thread, wait_result);
     }
 
-    virtual void CancelWait(KThread* waiting_thread, ResultCode wait_result,
-                            bool cancel_timer_task) override {
+    void CancelWait(KThread* waiting_thread, ResultCode wait_result,
+                    bool cancel_timer_task) override {
         // Remove all nodes from our list.
         for (auto i = 0; i < m_count; ++i) {
             m_objects[i]->UnlinkNode(std::addressof(m_nodes[i]));

--- a/src/core/hle/kernel/k_synchronization_object.cpp
+++ b/src/core/hle/kernel/k_synchronization_object.cpp
@@ -17,19 +17,10 @@ namespace Kernel {
 namespace {
 
 class ThreadQueueImplForKSynchronizationObjectWait final : public KThreadQueueWithoutEndWait {
-private:
-    using ThreadListNode = KSynchronizationObject::ThreadListNode;
-
-private:
-    KSynchronizationObject** m_objects;
-    ThreadListNode* m_nodes;
-    s32 m_count;
-
 public:
     ThreadQueueImplForKSynchronizationObjectWait(KernelCore& kernel_, KSynchronizationObject** o,
-                                                 ThreadListNode* n, s32 c)
-        : KThreadQueueWithoutEndWait(kernel_), m_objects(o), m_nodes(n), m_count(c) { // ...
-    }
+                                                 KSynchronizationObject::ThreadListNode* n, s32 c)
+        : KThreadQueueWithoutEndWait(kernel_), m_objects(o), m_nodes(n), m_count(c) {}
 
     virtual void NotifyAvailable(KThread* waiting_thread, KSynchronizationObject* signaled_object,
                                  ResultCode wait_result) override {
@@ -68,6 +59,11 @@ public:
         // Invoke the base cancel wait handler.
         KThreadQueue::CancelWait(waiting_thread, wait_result, cancel_timer_task);
     }
+
+private:
+    KSynchronizationObject** m_objects;
+    KSynchronizationObject::ThreadListNode* m_nodes;
+    s32 m_count;
 };
 
 } // namespace

--- a/src/core/hle/kernel/k_synchronization_object.cpp
+++ b/src/core/hle/kernel/k_synchronization_object.cpp
@@ -22,8 +22,8 @@ public:
                                                  KSynchronizationObject::ThreadListNode* n, s32 c)
         : KThreadQueueWithoutEndWait(kernel_), m_objects(o), m_nodes(n), m_count(c) {}
 
-    virtual void NotifyAvailable(KThread* waiting_thread, KSynchronizationObject* signaled_object,
-                                 ResultCode wait_result) override {
+    void NotifyAvailable(KThread* waiting_thread, KSynchronizationObject* signaled_object,
+                         ResultCode wait_result) override {
         // Determine the sync index, and unlink all nodes.
         s32 sync_index = -1;
         for (auto i = 0; i < m_count; ++i) {

--- a/src/core/hle/kernel/k_synchronization_object.cpp
+++ b/src/core/hle/kernel/k_synchronization_object.cpp
@@ -8,10 +8,69 @@
 #include "core/hle/kernel/k_scoped_scheduler_lock_and_sleep.h"
 #include "core/hle/kernel/k_synchronization_object.h"
 #include "core/hle/kernel/k_thread.h"
+#include "core/hle/kernel/k_thread_queue.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/svc_results.h"
 
 namespace Kernel {
+
+namespace {
+
+class ThreadQueueImplForKSynchronizationObjectWait final : public KThreadQueueWithoutEndWait {
+private:
+    using ThreadListNode = KSynchronizationObject::ThreadListNode;
+
+private:
+    KSynchronizationObject** m_objects;
+    ThreadListNode* m_nodes;
+    s32 m_count;
+
+public:
+    ThreadQueueImplForKSynchronizationObjectWait(KernelCore& kernel_, KSynchronizationObject** o,
+                                                 ThreadListNode* n, s32 c)
+        : KThreadQueueWithoutEndWait(kernel_), m_objects(o), m_nodes(n), m_count(c) { // ...
+    }
+
+    virtual void NotifyAvailable(KThread* waiting_thread, KSynchronizationObject* signaled_object,
+                                 ResultCode wait_result) override {
+        // Determine the sync index, and unlink all nodes.
+        s32 sync_index = -1;
+        for (auto i = 0; i < m_count; ++i) {
+            // Check if this is the signaled object.
+            if (m_objects[i] == signaled_object && sync_index == -1) {
+                sync_index = i;
+            }
+
+            // Unlink the current node from the current object.
+            m_objects[i]->UnlinkNode(std::addressof(m_nodes[i]));
+        }
+
+        // Set the waiting thread's sync index.
+        waiting_thread->SetSyncedIndex(sync_index);
+
+        // Set the waiting thread as not cancellable.
+        waiting_thread->ClearCancellable();
+
+        // Invoke the base end wait handler.
+        KThreadQueue::EndWait(waiting_thread, wait_result);
+    }
+
+    virtual void CancelWait(KThread* waiting_thread, ResultCode wait_result,
+                            bool cancel_timer_task) override {
+        // Remove all nodes from our list.
+        for (auto i = 0; i < m_count; ++i) {
+            m_objects[i]->UnlinkNode(std::addressof(m_nodes[i]));
+        }
+
+        // Set the waiting thread as not cancellable.
+        waiting_thread->ClearCancellable();
+
+        // Invoke the base cancel wait handler.
+        KThreadQueue::CancelWait(waiting_thread, wait_result, cancel_timer_task);
+    }
+};
+
+} // namespace
 
 void KSynchronizationObject::Finalize() {
     this->OnFinalizeSynchronizationObject();
@@ -25,11 +84,19 @@ ResultCode KSynchronizationObject::Wait(KernelCore& kernel_ctx, s32* out_index,
     std::vector<ThreadListNode> thread_nodes(num_objects);
 
     // Prepare for wait.
-    KThread* thread = kernel_ctx.CurrentScheduler()->GetCurrentThread();
+    KThread* thread = GetCurrentThreadPointer(kernel_ctx);
+    ThreadQueueImplForKSynchronizationObjectWait wait_queue(kernel_ctx, objects,
+                                                            thread_nodes.data(), num_objects);
 
     {
         // Setup the scheduling lock and sleep.
-        KScopedSchedulerLockAndSleep slp{kernel_ctx, thread, timeout};
+        KScopedSchedulerLockAndSleep slp(kernel_ctx, thread, timeout);
+
+        // Check if the thread should terminate.
+        if (thread->IsTerminationRequested()) {
+            slp.CancelSleep();
+            return ResultTerminationRequested;
+        }
 
         // Check if any of the objects are already signaled.
         for (auto i = 0; i < num_objects; ++i) {
@@ -48,12 +115,6 @@ ResultCode KSynchronizationObject::Wait(KernelCore& kernel_ctx, s32* out_index,
             return ResultTimedOut;
         }
 
-        // Check if the thread should terminate.
-        if (thread->IsTerminationRequested()) {
-            slp.CancelSleep();
-            return ResultTerminationRequested;
-        }
-
         // Check if waiting was canceled.
         if (thread->IsWaitCancelled()) {
             slp.CancelSleep();
@@ -66,73 +127,25 @@ ResultCode KSynchronizationObject::Wait(KernelCore& kernel_ctx, s32* out_index,
             thread_nodes[i].thread = thread;
             thread_nodes[i].next = nullptr;
 
-            if (objects[i]->thread_list_tail == nullptr) {
-                objects[i]->thread_list_head = std::addressof(thread_nodes[i]);
-            } else {
-                objects[i]->thread_list_tail->next = std::addressof(thread_nodes[i]);
-            }
-
-            objects[i]->thread_list_tail = std::addressof(thread_nodes[i]);
+            objects[i]->LinkNode(std::addressof(thread_nodes[i]));
         }
 
-        // For debugging only
-        thread->SetWaitObjectsForDebugging({objects, static_cast<std::size_t>(num_objects)});
-
-        // Mark the thread as waiting.
+        // Mark the thread as cancellable.
         thread->SetCancellable();
-        thread->SetSyncedObject(nullptr, ResultTimedOut);
-        thread->SetState(ThreadState::Waiting);
+
+        // Clear the thread's synced index.
+        thread->SetSyncedIndex(-1);
+
+        // Wait for an object to be signaled.
+        thread->BeginWait(std::addressof(wait_queue));
         thread->SetWaitReasonForDebugging(ThreadWaitReasonForDebugging::Synchronization);
     }
 
-    // The lock/sleep is done, so we should be able to get our result.
-
-    // Thread is no longer cancellable.
-    thread->ClearCancellable();
-
-    // For debugging only
-    thread->SetWaitObjectsForDebugging({});
-
-    // Cancel the timer as needed.
-    kernel_ctx.TimeManager().UnscheduleTimeEvent(thread);
+    // Set the output index.
+    *out_index = thread->GetSyncedIndex();
 
     // Get the wait result.
-    ResultCode wait_result{ResultSuccess};
-    s32 sync_index = -1;
-    {
-        KScopedSchedulerLock lock(kernel_ctx);
-        KSynchronizationObject* synced_obj;
-        wait_result = thread->GetWaitResult(std::addressof(synced_obj));
-
-        for (auto i = 0; i < num_objects; ++i) {
-            // Unlink the object from the list.
-            ThreadListNode* prev_ptr =
-                reinterpret_cast<ThreadListNode*>(std::addressof(objects[i]->thread_list_head));
-            ThreadListNode* prev_val = nullptr;
-            ThreadListNode *prev, *tail_prev;
-
-            do {
-                prev = prev_ptr;
-                prev_ptr = prev_ptr->next;
-                tail_prev = prev_val;
-                prev_val = prev_ptr;
-            } while (prev_ptr != std::addressof(thread_nodes[i]));
-
-            if (objects[i]->thread_list_tail == std::addressof(thread_nodes[i])) {
-                objects[i]->thread_list_tail = tail_prev;
-            }
-
-            prev->next = thread_nodes[i].next;
-
-            if (objects[i] == synced_obj) {
-                sync_index = i;
-            }
-        }
-    }
-
-    // Set output.
-    *out_index = sync_index;
-    return wait_result;
+    return thread->GetWaitResult();
 }
 
 KSynchronizationObject::KSynchronizationObject(KernelCore& kernel_)
@@ -141,7 +154,7 @@ KSynchronizationObject::KSynchronizationObject(KernelCore& kernel_)
 KSynchronizationObject::~KSynchronizationObject() = default;
 
 void KSynchronizationObject::NotifyAvailable(ResultCode result) {
-    KScopedSchedulerLock lock(kernel);
+    KScopedSchedulerLock sl(kernel);
 
     // If we're not signaled, we've nothing to notify.
     if (!this->IsSignaled()) {
@@ -150,11 +163,7 @@ void KSynchronizationObject::NotifyAvailable(ResultCode result) {
 
     // Iterate over each thread.
     for (auto* cur_node = thread_list_head; cur_node != nullptr; cur_node = cur_node->next) {
-        KThread* thread = cur_node->thread;
-        if (thread->GetState() == ThreadState::Waiting) {
-            thread->SetSyncedObject(this, result);
-            thread->SetState(ThreadState::Runnable);
-        }
+        cur_node->thread->NotifyAvailable(this, result);
     }
 }
 

--- a/src/core/hle/kernel/k_synchronization_object.h
+++ b/src/core/hle/kernel/k_synchronization_object.h
@@ -35,18 +35,18 @@ public:
 
     [[nodiscard]] std::vector<KThread*> GetWaitingThreadsForDebugging() const;
 
-    void LinkNode(ThreadListNode* node) {
+    void LinkNode(ThreadListNode* node_) {
         // Link the node to the list.
         if (thread_list_tail == nullptr) {
-            thread_list_head = node;
+            thread_list_head = node_;
         } else {
-            thread_list_tail->next = node;
+            thread_list_tail->next = node_;
         }
 
-        thread_list_tail = node;
+        thread_list_tail = node_;
     }
 
-    void UnlinkNode(ThreadListNode* node) {
+    void UnlinkNode(ThreadListNode* node_) {
         // Unlink the node from the list.
         ThreadListNode* prev_ptr =
             reinterpret_cast<ThreadListNode*>(std::addressof(thread_list_head));
@@ -58,13 +58,13 @@ public:
             prev_ptr = prev_ptr->next;
             tail_prev = prev_val;
             prev_val = prev_ptr;
-        } while (prev_ptr != node);
+        } while (prev_ptr != node_);
 
-        if (thread_list_tail == node) {
+        if (thread_list_tail == node_) {
             thread_list_tail = tail_prev;
         }
 
-        prev->next = node->next;
+        prev->next = node_->next;
     }
 
 protected:

--- a/src/core/hle/kernel/k_synchronization_object.h
+++ b/src/core/hle/kernel/k_synchronization_object.h
@@ -35,6 +35,38 @@ public:
 
     [[nodiscard]] std::vector<KThread*> GetWaitingThreadsForDebugging() const;
 
+    void LinkNode(ThreadListNode* node) {
+        // Link the node to the list.
+        if (thread_list_tail == nullptr) {
+            thread_list_head = node;
+        } else {
+            thread_list_tail->next = node;
+        }
+
+        thread_list_tail = node;
+    }
+
+    void UnlinkNode(ThreadListNode* node) {
+        // Unlink the node from the list.
+        ThreadListNode* prev_ptr =
+            reinterpret_cast<ThreadListNode*>(std::addressof(thread_list_head));
+        ThreadListNode* prev_val = nullptr;
+        ThreadListNode *prev, *tail_prev;
+
+        do {
+            prev = prev_ptr;
+            prev_ptr = prev_ptr->next;
+            tail_prev = prev_val;
+            prev_val = prev_ptr;
+        } while (prev_ptr != node);
+
+        if (thread_list_tail == node) {
+            thread_list_tail = tail_prev;
+        }
+
+        prev->next = node->next;
+    }
+
 protected:
     explicit KSynchronizationObject(KernelCore& kernel);
     ~KSynchronizationObject() override;

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -303,7 +303,7 @@ void KThread::Wakeup() {
 
     if (GetState() == ThreadState::Waiting) {
         if (sleeping_queue != nullptr) {
-            sleeping_queue->WakeupThread(this);
+            sleeping_queue->EndWait(this, ResultSuccess);
         } else {
             SetState(ThreadState::Runnable);
         }
@@ -331,7 +331,7 @@ void KThread::StartTermination() {
 
     // Signal.
     signaled = true;
-    NotifyAvailable();
+    KSynchronizationObject::NotifyAvailable();
 
     // Clear previous thread in KScheduler.
     KScheduler::ClearPreviousThread(kernel, this);
@@ -1024,6 +1024,44 @@ ResultCode KThread::Sleep(s64 timeout) {
     kernel.TimeManager().UnscheduleTimeEvent(this);
 
     return ResultSuccess;
+}
+
+void KThread::BeginWait(KThreadQueue* queue) {
+    // Set our state as waiting.
+    SetState(ThreadState::Waiting);
+
+    // Set our wait queue.
+    sleeping_queue = queue;
+}
+
+void KThread::NotifyAvailable(KSynchronizationObject* signaled_object, ResultCode wait_result_) {
+    // Lock the scheduler.
+    KScopedSchedulerLock sl(kernel);
+
+    // If we're waiting, notify our queue that we're available.
+    if (GetState() == ThreadState::Waiting) {
+        sleeping_queue->NotifyAvailable(this, signaled_object, wait_result_);
+    }
+}
+
+void KThread::EndWait(ResultCode wait_result_) {
+    // Lock the scheduler.
+    KScopedSchedulerLock sl(kernel);
+
+    // If we're waiting, notify our queue that we're available.
+    if (GetState() == ThreadState::Waiting) {
+        sleeping_queue->EndWait(this, wait_result_);
+    }
+}
+
+void KThread::CancelWait(ResultCode wait_result_, bool cancel_timer_task) {
+    // Lock the scheduler.
+    KScopedSchedulerLock sl(kernel);
+
+    // If we're waiting, notify our queue that we're available.
+    if (GetState() == ThreadState::Waiting) {
+        sleeping_queue->CancelWait(this, wait_result_, cancel_timer_task);
+    }
 }
 
 void KThread::SetState(ThreadState state) {

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -113,6 +113,8 @@ ResultCode KThread::Initialize(KThreadFunction func, uintptr_t arg, VAddr user_s
         [[fallthrough]];
     case ThreadType::HighPriority:
         [[fallthrough]];
+    case ThreadType::Dummy:
+        [[fallthrough]];
     case ThreadType::User:
         ASSERT(((owner == nullptr) ||
                 (owner->GetCoreMask() | (1ULL << virt_core)) == owner->GetCoreMask()));
@@ -248,7 +250,7 @@ ResultCode KThread::InitializeThread(KThread* thread, KThreadFunction func, uint
 }
 
 ResultCode KThread::InitializeDummyThread(KThread* thread) {
-    return thread->Initialize({}, {}, {}, DefaultThreadPriority, 3, {}, ThreadType::Main);
+    return thread->Initialize({}, {}, {}, DefaultThreadPriority, 3, {}, ThreadType::Dummy);
 }
 
 ResultCode KThread::InitializeIdleThread(Core::System& system, KThread* thread, s32 virt_core) {

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -68,13 +68,9 @@ public:
 };
 
 class ThreadQueueImplForKThreadSetProperty final : public KThreadQueue {
-private:
-    KThread::WaiterList* m_wait_list;
-
 public:
     explicit ThreadQueueImplForKThreadSetProperty(KernelCore& kernel_, KThread::WaiterList* wl)
-        : KThreadQueue(kernel_), m_wait_list(wl) { // ...
-    }
+        : KThreadQueue(kernel_), m_wait_list(wl) {}
 
     virtual void CancelWait(KThread* waiting_thread, ResultCode wait_result,
                             bool cancel_timer_task) override {
@@ -84,6 +80,9 @@ public:
         // Invoke the base cancel wait handler.
         KThreadQueue::CancelWait(waiting_thread, wait_result, cancel_timer_task);
     }
+
+private:
+    KThread::WaiterList* m_wait_list;
 };
 
 } // namespace

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -130,9 +130,6 @@ ResultCode KThread::Initialize(KThreadFunction func, uintptr_t arg, VAddr user_s
     priority = prio;
     base_priority = prio;
 
-    // Set sync object and waiting lock to null.
-    synced_object = nullptr;
-
     // Initialize sleeping queue.
     sleeping_queue = nullptr;
 
@@ -279,7 +276,7 @@ void KThread::Finalize() {
         while (it != waiter_list.end()) {
             // The thread shouldn't be a kernel waiter.
             it->SetLockOwner(nullptr);
-            it->SetSyncedObject(nullptr, ResultInvalidState);
+            it->SetWaitResult(ResultInvalidState);
             it->Wakeup();
             it = waiter_list.erase(it);
         }
@@ -650,7 +647,7 @@ void KThread::WaitCancel() {
             sleeping_queue->WakeupThread(this);
             wait_cancelled = true;
         } else {
-            SetSyncedObject(nullptr, ResultCancelled);
+            SetWaitResult(ResultCancelled);
             SetState(ThreadState::Runnable);
             wait_cancelled = false;
         }

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -184,7 +184,7 @@ ResultCode KThread::Initialize(KThreadFunction func, uintptr_t arg, VAddr user_s
     // Setup the stack parameters.
     StackParameters& sp = GetStackParameters();
     sp.cur_thread = this;
-    sp.disable_count = 1;
+    sp.disable_count = 0;
     SetInExceptionHandler();
 
     // Set thread ID.
@@ -966,6 +966,9 @@ ResultCode KThread::Run() {
 
         // Set our state and finish.
         SetState(ThreadState::Runnable);
+
+        DisableDispatch();
+
         return ResultSuccess;
     }
 }
@@ -1048,6 +1051,18 @@ KThread& GetCurrentThread(KernelCore& kernel) {
 
 s32 GetCurrentCoreId(KernelCore& kernel) {
     return GetCurrentThread(kernel).GetCurrentCore();
+}
+
+KScopedDisableDispatch::~KScopedDisableDispatch() {
+    if (GetCurrentThread(kernel).GetDisableDispatchCount() <= 1) {
+        auto scheduler = kernel.CurrentScheduler();
+
+        if (scheduler) {
+            scheduler->RescheduleCurrentCore();
+        }
+    } else {
+        GetCurrentThread(kernel).EnableDispatch();
+    }
 }
 
 } // namespace Kernel

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -1089,6 +1089,11 @@ s32 GetCurrentCoreId(KernelCore& kernel) {
 }
 
 KScopedDisableDispatch::~KScopedDisableDispatch() {
+    // If we are shutting down the kernel, none of this is relevant anymore.
+    if (kernel.IsShuttingDown()) {
+        return;
+    }
+
     if (GetCurrentThread(kernel).GetDisableDispatchCount() <= 1) {
         auto scheduler = kernel.CurrentScheduler();
 

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -72,8 +72,8 @@ public:
     explicit ThreadQueueImplForKThreadSetProperty(KernelCore& kernel_, KThread::WaiterList* wl)
         : KThreadQueue(kernel_), m_wait_list(wl) {}
 
-    virtual void CancelWait(KThread* waiting_thread, ResultCode wait_result,
-                            bool cancel_timer_task) override {
+    void CancelWait(KThread* waiting_thread, ResultCode wait_result,
+                    bool cancel_timer_task) override {
         // Remove the thread from the wait list.
         m_wait_list->erase(m_wait_list->iterator_to(*waiting_thread));
 

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -13,6 +13,9 @@
 #include "common/common_types.h"
 #include "common/fiber.h"
 #include "common/logging/log.h"
+#include "common/scope_exit.h"
+#include "common/settings.h"
+#include "common/thread_queue_list.h"
 #include "core/core.h"
 #include "core/cpu_manager.h"
 #include "core/hardware_properties.h"
@@ -211,9 +214,10 @@ ResultCode KThread::InitializeThread(KThread* thread, KThreadFunction func, uint
     // Initialize the thread.
     R_TRY(thread->Initialize(func, arg, user_stack_top, prio, core, owner, type));
 
-    // Initialize host context.
+    // Initialize emulation parameters.
     thread->host_context =
         std::make_shared<Common::Fiber>(std::move(init_func), init_func_parameter);
+    thread->is_single_core = !Settings::values.use_multi_core.GetValue();
 
     return ResultSuccess;
 }

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -1096,6 +1096,11 @@ KScopedDisableDispatch::~KScopedDisableDispatch() {
         return;
     }
 
+    // Skip the reschedule if single-core, as dispatch tracking is disabled here.
+    if (!Settings::values.use_multi_core.GetValue()) {
+        return;
+    }
+
     if (GetCurrentThread(kernel).GetDisableDispatchCount() <= 1) {
         auto scheduler = kernel.CurrentScheduler();
 

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -450,16 +450,35 @@ public:
         sleeping_queue = q;
     }
 
+    [[nodiscard]] bool IsKernelThread() const {
+        return GetActiveCore() == 3;
+    }
+
     [[nodiscard]] s32 GetDisableDispatchCount() const {
+        if (IsKernelThread()) {
+            // TODO(bunnei): Until kernel threads are emulated, we cannot enable/disable dispatch.
+            return 1;
+        }
+
         return this->GetStackParameters().disable_count;
     }
 
     void DisableDispatch() {
+        if (IsKernelThread()) {
+            // TODO(bunnei): Until kernel threads are emulated, we cannot enable/disable dispatch.
+            return;
+        }
+
         ASSERT(GetCurrentThread(kernel).GetDisableDispatchCount() >= 0);
         this->GetStackParameters().disable_count++;
     }
 
     void EnableDispatch() {
+        if (IsKernelThread()) {
+            // TODO(bunnei): Until kernel threads are emulated, we cannot enable/disable dispatch.
+            return;
+        }
+
         ASSERT(GetCurrentThread(kernel).GetDisableDispatchCount() > 0);
         this->GetStackParameters().disable_count--;
     }
@@ -750,6 +769,18 @@ public:
     [[nodiscard]] ConditionVariableThreadTree* GetConditionVariableTree() const {
         return condvar_tree;
     }
+};
+
+class KScopedDisableDispatch {
+public:
+    explicit KScopedDisableDispatch(KernelCore& kernel_) : kernel{kernel_} {
+        GetCurrentThread(kernel).DisableDispatch();
+    }
+
+    ~KScopedDisableDispatch();
+
+private:
+    KernelCore& kernel;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -454,8 +454,12 @@ public:
         return GetActiveCore() == 3;
     }
 
+    [[nodiscard]] bool IsDispatchTrackingDisabled() const {
+        return is_single_core || IsKernelThread();
+    }
+
     [[nodiscard]] s32 GetDisableDispatchCount() const {
-        if (IsKernelThread()) {
+        if (IsDispatchTrackingDisabled()) {
             // TODO(bunnei): Until kernel threads are emulated, we cannot enable/disable dispatch.
             return 1;
         }
@@ -464,7 +468,7 @@ public:
     }
 
     void DisableDispatch() {
-        if (IsKernelThread()) {
+        if (IsDispatchTrackingDisabled()) {
             // TODO(bunnei): Until kernel threads are emulated, we cannot enable/disable dispatch.
             return;
         }
@@ -474,7 +478,7 @@ public:
     }
 
     void EnableDispatch() {
-        if (IsKernelThread()) {
+        if (IsDispatchTrackingDisabled()) {
             // TODO(bunnei): Until kernel threads are emulated, we cannot enable/disable dispatch.
             return;
         }
@@ -727,6 +731,7 @@ private:
 
     // For emulation
     std::shared_ptr<Common::Fiber> host_context{};
+    bool is_single_core{};
 
     // For debugging
     std::vector<KSynchronizationObject*> wait_objects_for_debugging;

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -773,7 +773,7 @@ public:
 
 class KScopedDisableDispatch {
 public:
-    explicit KScopedDisableDispatch(KernelCore& kernel_) : kernel{kernel_} {
+    [[nodiscard]] explicit KScopedDisableDispatch(KernelCore& kernel_) : kernel{kernel_} {
         GetCurrentThread(kernel).DisableDispatch();
     }
 

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -161,8 +161,6 @@ public:
         }
     }
 
-    void Wakeup();
-
     void SetBasePriority(s32 value);
 
     [[nodiscard]] ResultCode Run();
@@ -379,6 +377,8 @@ public:
     void Finalize() override;
 
     [[nodiscard]] bool IsSignaled() const override;
+
+    void OnTimer();
 
     static void PostDestroy(uintptr_t arg);
 

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -202,6 +202,23 @@ public:
         wait_result = wait_res;
     }
 
+    constexpr void SetSyncedIndex(s32 index) {
+        synced_index = index;
+    }
+
+    constexpr s32 GetSyncedIndex() const {
+        return synced_index;
+    }
+
+    constexpr void SetWaitResult(ResultCode wait_res) {
+        wait_result = wait_res;
+        synced_object = nullptr;
+    }
+
+    constexpr ResultCode GetWaitResult() const {
+        return wait_result;
+    }
+
     [[nodiscard]] ResultCode GetWaitResult(KSynchronizationObject** out) const {
         *out = synced_object;
         return wait_result;
@@ -596,6 +613,15 @@ public:
         address_key_value = val;
     }
 
+    void ClearWaitQueue() {
+        sleeping_queue = nullptr;
+    }
+
+    void BeginWait(KThreadQueue* queue);
+    void NotifyAvailable(KSynchronizationObject* signaled_object, ResultCode wait_result_);
+    void EndWait(ResultCode wait_result_);
+    void CancelWait(ResultCode wait_result_, bool cancel_timer_task);
+
     [[nodiscard]] bool HasWaiters() const {
         return !waiter_list.empty();
     }
@@ -707,6 +733,7 @@ private:
     u32 address_key_value{};
     u32 suspend_request_flags{};
     u32 suspend_allowed_flags{};
+    s32 synced_index{};
     ResultCode wait_result{ResultSuccess};
     s32 base_priority{};
     s32 physical_ideal_core_id{};

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -199,7 +199,7 @@ public:
         synced_index = index;
     }
 
-    constexpr s32 GetSyncedIndex() const {
+    [[nodiscard]] constexpr s32 GetSyncedIndex() const {
         return synced_index;
     }
 
@@ -207,7 +207,7 @@ public:
         wait_result = wait_res;
     }
 
-    constexpr ResultCode GetWaitResult() const {
+    [[nodiscard]] constexpr ResultCode GetWaitResult() const {
         return wait_result;
     }
 

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -197,11 +197,6 @@ public:
 
     void Suspend();
 
-    void SetSyncedObject(KSynchronizationObject* obj, ResultCode wait_res) {
-        synced_object = obj;
-        wait_result = wait_res;
-    }
-
     constexpr void SetSyncedIndex(s32 index) {
         synced_index = index;
     }
@@ -212,15 +207,9 @@ public:
 
     constexpr void SetWaitResult(ResultCode wait_res) {
         wait_result = wait_res;
-        synced_object = nullptr;
     }
 
     constexpr ResultCode GetWaitResult() const {
-        return wait_result;
-    }
-
-    [[nodiscard]] ResultCode GetWaitResult(KSynchronizationObject** out) const {
-        *out = synced_object;
         return wait_result;
     }
 
@@ -716,7 +705,6 @@ private:
     KAffinityMask physical_affinity_mask{};
     u64 thread_id{};
     std::atomic<s64> cpu_time{};
-    KSynchronizationObject* synced_object{};
     VAddr address_key{};
     KProcess* parent{};
     VAddr kernel_stack_top{};

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -48,6 +48,7 @@ enum class ThreadType : u32 {
     Kernel = 1,
     HighPriority = 2,
     User = 3,
+    Dummy = 100, // Special thread type for emulation purposes only
 };
 DECLARE_ENUM_FLAG_OPERATORS(ThreadType);
 

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -453,10 +453,6 @@ public:
         return per_core_priority_queue_entry[core];
     }
 
-    void SetSleepingQueue(KThreadQueue* q) {
-        sleeping_queue = q;
-    }
-
     [[nodiscard]] bool IsKernelThread() const {
         return GetActiveCore() == 3;
     }
@@ -604,7 +600,7 @@ public:
     }
 
     void ClearWaitQueue() {
-        sleeping_queue = nullptr;
+        wait_queue = nullptr;
     }
 
     void BeginWait(KThreadQueue* queue);
@@ -715,7 +711,7 @@ private:
     s64 schedule_count{};
     s64 last_scheduled_tick{};
     std::array<QueueEntry, Core::Hardware::NUM_CPU_CORES> per_core_priority_queue_entry{};
-    KThreadQueue* sleeping_queue{};
+    KThreadQueue* wait_queue{};
     WaiterList waiter_list{};
     WaiterList pinned_waiter_list{};
     KThread* lock_owner{};

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -794,6 +794,10 @@ public:
 class KScopedDisableDispatch {
 public:
     [[nodiscard]] explicit KScopedDisableDispatch(KernelCore& kernel_) : kernel{kernel_} {
+        // If we are shutting down the kernel, none of this is relevant anymore.
+        if (kernel.IsShuttingDown()) {
+            return;
+        }
         GetCurrentThread(kernel).DisableDispatch();
     }
 

--- a/src/core/hle/kernel/k_thread_queue.cpp
+++ b/src/core/hle/kernel/k_thread_queue.cpp
@@ -1,0 +1,51 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/kernel/k_thread_queue.h"
+#include "core/hle/kernel/kernel.h"
+#include "core/hle/kernel/time_manager.h"
+
+namespace Kernel {
+
+void KThreadQueue::NotifyAvailable([[maybe_unused]] KThread* waiting_thread,
+                                   [[maybe_unused]] KSynchronizationObject* signaled_object,
+                                   [[maybe_unused]] ResultCode wait_result) {}
+
+void KThreadQueue::EndWait(KThread* waiting_thread, ResultCode wait_result) {
+    // Set the thread's wait result.
+    waiting_thread->SetWaitResult(wait_result);
+
+    // Set the thread as runnable.
+    waiting_thread->SetState(ThreadState::Runnable);
+
+    // Clear the thread's wait queue.
+    waiting_thread->ClearWaitQueue();
+
+    // Cancel the thread task.
+    kernel.TimeManager().UnscheduleTimeEvent(waiting_thread);
+}
+
+void KThreadQueue::CancelWait(KThread* waiting_thread, ResultCode wait_result,
+                              bool cancel_timer_task) {
+    // Set the thread's wait result.
+    waiting_thread->SetWaitResult(wait_result);
+
+    // Set the thread as runnable.
+    waiting_thread->SetState(ThreadState::Runnable);
+
+    // Clear the thread's wait queue.
+    waiting_thread->ClearWaitQueue();
+
+    // Cancel the thread task.
+    if (cancel_timer_task) {
+        kernel.TimeManager().UnscheduleTimeEvent(waiting_thread);
+    }
+}
+
+void KThreadQueueWithoutEndWait::EndWait([[maybe_unused]] KThread* waiting_thread,
+                                         [[maybe_unused]] ResultCode wait_result) {}
+
+} // namespace Kernel

--- a/src/core/hle/kernel/k_thread_queue.h
+++ b/src/core/hle/kernel/k_thread_queue.h
@@ -20,69 +20,6 @@ public:
     virtual void CancelWait(KThread* waiting_thread, ResultCode wait_result,
                             bool cancel_timer_task);
 
-    // Deprecated, will be removed in subsequent commits.
-public:
-    bool IsEmpty() const {
-        return wait_list.empty();
-    }
-
-    KThread::WaiterList::iterator begin() {
-        return wait_list.begin();
-    }
-    KThread::WaiterList::iterator end() {
-        return wait_list.end();
-    }
-
-    bool SleepThread(KThread* t) {
-        KScopedSchedulerLock sl{kernel};
-
-        // If the thread needs terminating, don't enqueue it.
-        if (t->IsTerminationRequested()) {
-            return false;
-        }
-
-        // Set the thread's queue and mark it as waiting.
-        t->SetSleepingQueue(this);
-        t->SetState(ThreadState::Waiting);
-
-        // Add the thread to the queue.
-        wait_list.push_back(*t);
-
-        return true;
-    }
-
-    void WakeupThread(KThread* t) {
-        KScopedSchedulerLock sl{kernel};
-
-        // Remove the thread from the queue.
-        wait_list.erase(wait_list.iterator_to(*t));
-
-        // Mark the thread as no longer sleeping.
-        t->SetState(ThreadState::Runnable);
-        t->SetSleepingQueue(nullptr);
-    }
-
-    KThread* WakeupFrontThread() {
-        KScopedSchedulerLock sl{kernel};
-
-        if (wait_list.empty()) {
-            return nullptr;
-        } else {
-            // Remove the thread from the queue.
-            auto it = wait_list.begin();
-            KThread* thread = std::addressof(*it);
-            wait_list.erase(it);
-
-            ASSERT(thread->GetState() == ThreadState::Waiting);
-
-            // Mark the thread as no longer sleeping.
-            thread->SetState(ThreadState::Runnable);
-            thread->SetSleepingQueue(nullptr);
-
-            return thread;
-        }
-    }
-
 private:
     KernelCore& kernel;
     KThread::WaiterList wait_list{};

--- a/src/core/hle/kernel/k_thread_queue.h
+++ b/src/core/hle/kernel/k_thread_queue.h
@@ -12,7 +12,7 @@ namespace Kernel {
 class KThreadQueue {
 public:
     explicit KThreadQueue(KernelCore& kernel_) : kernel{kernel_} {}
-    virtual ~KThreadQueue(){};
+    virtual ~KThreadQueue() = default;
 
     virtual void NotifyAvailable(KThread* waiting_thread, KSynchronizationObject* signaled_object,
                                  ResultCode wait_result);

--- a/src/core/hle/kernel/k_thread_queue.h
+++ b/src/core/hle/kernel/k_thread_queue.h
@@ -29,7 +29,7 @@ class KThreadQueueWithoutEndWait : public KThreadQueue {
 public:
     explicit KThreadQueueWithoutEndWait(KernelCore& kernel_) : KThreadQueue(kernel_) {}
 
-    virtual void EndWait(KThread* waiting_thread, ResultCode wait_result) override final;
+    void EndWait(KThread* waiting_thread, ResultCode wait_result) override final;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -845,6 +845,14 @@ const Kernel::PhysicalCore& KernelCore::PhysicalCore(std::size_t id) const {
     return impl->cores[id];
 }
 
+size_t KernelCore::CurrentPhysicalCoreIndex() const {
+    const u32 core_id = impl->GetCurrentHostThreadID();
+    if (core_id >= Core::Hardware::NUM_CPU_CORES) {
+        return Core::Hardware::NUM_CPU_CORES - 1;
+    }
+    return core_id;
+}
+
 Kernel::PhysicalCore& KernelCore::CurrentPhysicalCore() {
     u32 core_id = impl->GetCurrentHostThreadID();
     ASSERT(core_id < Core::Hardware::NUM_CPU_CORES);

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -251,13 +251,11 @@ struct KernelCore::Impl {
                     KScopedSchedulerLock lock(kernel);
                     global_scheduler_context->PreemptThreads();
                 }
-                const auto time_interval = std::chrono::nanoseconds{
-                    Core::Timing::msToCycles(std::chrono::milliseconds(10))};
+                const auto time_interval = std::chrono::nanoseconds{std::chrono::milliseconds(10)};
                 system.CoreTiming().ScheduleEvent(time_interval, preemption_event);
             });
 
-        const auto time_interval =
-            std::chrono::nanoseconds{Core::Timing::msToCycles(std::chrono::milliseconds(10))};
+        const auto time_interval = std::chrono::nanoseconds{std::chrono::milliseconds(10)};
         system.CoreTiming().ScheduleEvent(time_interval, preemption_event);
     }
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -83,8 +83,9 @@ struct KernelCore::Impl {
     }
 
     void InitializeCores() {
-        for (auto& core : cores) {
-            core.Initialize(current_process->Is64BitProcess());
+        for (u32 core_id = 0; core_id < Core::Hardware::NUM_CPU_CORES; core_id++) {
+            cores[core_id].Initialize(current_process->Is64BitProcess());
+            system.Memory().SetCurrentPageTable(*current_process, core_id);
         }
     }
 
@@ -123,15 +124,6 @@ struct KernelCore::Impl {
         next_user_process_id = KProcess::ProcessIDMin;
         next_thread_id = 1;
 
-        for (u32 core_id = 0; core_id < Core::Hardware::NUM_CPU_CORES; core_id++) {
-            if (suspend_threads[core_id]) {
-                suspend_threads[core_id]->Close();
-                suspend_threads[core_id] = nullptr;
-            }
-
-            schedulers[core_id].reset();
-        }
-
         cores.clear();
 
         global_handle_table->Finalize();
@@ -158,6 +150,16 @@ struct KernelCore::Impl {
         CleanupObject(irs_shared_mem);
         CleanupObject(time_shared_mem);
         CleanupObject(system_resource_limit);
+
+        for (u32 core_id = 0; core_id < Core::Hardware::NUM_CPU_CORES; core_id++) {
+            if (suspend_threads[core_id]) {
+                suspend_threads[core_id]->Close();
+                suspend_threads[core_id] = nullptr;
+            }
+
+            schedulers[core_id]->Finalize();
+            schedulers[core_id].reset();
+        }
 
         // Next host thead ID to use, 0-3 IDs represent core threads, >3 represent others
         next_host_thread_id = Core::Hardware::NUM_CPU_CORES;
@@ -267,14 +269,6 @@ struct KernelCore::Impl {
 
     void MakeCurrentProcess(KProcess* process) {
         current_process = process;
-        if (process == nullptr) {
-            return;
-        }
-
-        const u32 core_id = GetCurrentHostThreadID();
-        if (core_id < Core::Hardware::NUM_CPU_CORES) {
-            system.Memory().SetCurrentPageTable(*process, core_id);
-        }
     }
 
     static inline thread_local u32 host_thread_id = UINT32_MAX;
@@ -1079,13 +1073,11 @@ void KernelCore::ExceptionalExit() {
 }
 
 void KernelCore::EnterSVCProfile() {
-    std::size_t core = impl->GetCurrentHostThreadID();
-    impl->svc_ticks[core] = MicroProfileEnter(MICROPROFILE_TOKEN(Kernel_SVC));
+    impl->svc_ticks[CurrentPhysicalCoreIndex()] = MicroProfileEnter(MICROPROFILE_TOKEN(Kernel_SVC));
 }
 
 void KernelCore::ExitSVCProfile() {
-    std::size_t core = impl->GetCurrentHostThreadID();
-    MicroProfileLeave(MICROPROFILE_TOKEN(Kernel_SVC), impl->svc_ticks[core]);
+    MicroProfileLeave(MICROPROFILE_TOKEN(Kernel_SVC), impl->svc_ticks[CurrentPhysicalCoreIndex()]);
 }
 
 std::weak_ptr<Kernel::ServiceThread> KernelCore::CreateServiceThread(const std::string& name) {

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -1055,6 +1055,9 @@ void KernelCore::Suspend(bool in_suspention) {
             impl->suspend_threads[core_id]->SetState(state);
             impl->suspend_threads[core_id]->SetWaitReasonForDebugging(
                 ThreadWaitReasonForDebugging::Suspended);
+            if (!should_suspend) {
+                impl->suspend_threads[core_id]->DisableDispatch();
+            }
         }
     }
 }

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -848,15 +848,11 @@ size_t KernelCore::CurrentPhysicalCoreIndex() const {
 }
 
 Kernel::PhysicalCore& KernelCore::CurrentPhysicalCore() {
-    u32 core_id = impl->GetCurrentHostThreadID();
-    ASSERT(core_id < Core::Hardware::NUM_CPU_CORES);
-    return impl->cores[core_id];
+    return impl->cores[CurrentPhysicalCoreIndex()];
 }
 
 const Kernel::PhysicalCore& KernelCore::CurrentPhysicalCore() const {
-    u32 core_id = impl->GetCurrentHostThreadID();
-    ASSERT(core_id < Core::Hardware::NUM_CPU_CORES);
-    return impl->cores[core_id];
+    return impl->cores[CurrentPhysicalCoreIndex()];
 }
 
 Kernel::KScheduler* KernelCore::CurrentScheduler() {

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -274,6 +274,8 @@ public:
 
     bool IsMulticore() const;
 
+    bool IsShuttingDown() const;
+
     void EnterSVCProfile();
 
     void ExitSVCProfile();

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -148,6 +148,9 @@ public:
     /// Gets the an instance of the respective physical CPU core.
     const Kernel::PhysicalCore& PhysicalCore(std::size_t id) const;
 
+    /// Gets the current physical core index for the running host thread.
+    std::size_t CurrentPhysicalCoreIndex() const;
+
     /// Gets the sole instance of the Scheduler at the current running core.
     Kernel::KScheduler* CurrentScheduler();
 

--- a/src/core/hle/kernel/service_thread.cpp
+++ b/src/core/hle/kernel/service_thread.cpp
@@ -25,24 +25,27 @@ public:
     void QueueSyncRequest(KSession& session, std::shared_ptr<HLERequestContext>&& context);
 
 private:
-    std::vector<std::thread> threads;
+    std::vector<std::jthread> threads;
     std::queue<std::function<void()>> requests;
     std::mutex queue_mutex;
-    std::condition_variable condition;
+    std::condition_variable_any condition;
     const std::string service_name;
-    bool stop{};
 };
 
 ServiceThread::Impl::Impl(KernelCore& kernel, std::size_t num_threads, const std::string& name)
     : service_name{name} {
-    for (std::size_t i = 0; i < num_threads; ++i)
-        threads.emplace_back([this, &kernel] {
+    for (std::size_t i = 0; i < num_threads; ++i) {
+        threads.emplace_back([this, &kernel](std::stop_token stop_token) {
             Common::SetCurrentThreadName(std::string{"yuzu:HleService:" + service_name}.c_str());
 
             // Wait for first request before trying to acquire a render context
             {
                 std::unique_lock lock{queue_mutex};
-                condition.wait(lock, [this] { return stop || !requests.empty(); });
+                condition.wait(lock, stop_token, [this] { return !requests.empty(); });
+            }
+
+            if (stop_token.stop_requested()) {
+                return;
             }
 
             kernel.RegisterHostThread();
@@ -52,10 +55,16 @@ ServiceThread::Impl::Impl(KernelCore& kernel, std::size_t num_threads, const std
 
                 {
                     std::unique_lock lock{queue_mutex};
-                    condition.wait(lock, [this] { return stop || !requests.empty(); });
-                    if (stop || requests.empty()) {
+                    condition.wait(lock, stop_token, [this] { return !requests.empty(); });
+
+                    if (stop_token.stop_requested()) {
                         return;
                     }
+
+                    if (requests.empty()) {
+                        continue;
+                    }
+
                     task = std::move(requests.front());
                     requests.pop();
                 }
@@ -63,6 +72,7 @@ ServiceThread::Impl::Impl(KernelCore& kernel, std::size_t num_threads, const std
                 task();
             }
         });
+    }
 }
 
 void ServiceThread::Impl::QueueSyncRequest(KSession& session,
@@ -87,16 +97,7 @@ void ServiceThread::Impl::QueueSyncRequest(KSession& session,
     condition.notify_one();
 }
 
-ServiceThread::Impl::~Impl() {
-    {
-        std::unique_lock lock{queue_mutex};
-        stop = true;
-    }
-    condition.notify_all();
-    for (std::thread& thread : threads) {
-        thread.join();
-    }
-}
+ServiceThread::Impl::~Impl() = default;
 
 ServiceThread::ServiceThread(KernelCore& kernel, std::size_t num_threads, const std::string& name)
     : impl{std::make_unique<Impl>(kernel, num_threads, name)} {}

--- a/src/core/hle/kernel/service_thread.cpp
+++ b/src/core/hle/kernel/service_thread.cpp
@@ -97,7 +97,13 @@ void ServiceThread::Impl::QueueSyncRequest(KSession& session,
     condition.notify_one();
 }
 
-ServiceThread::Impl::~Impl() = default;
+ServiceThread::Impl::~Impl() {
+    condition.notify_all();
+    for (auto& thread : threads) {
+        thread.request_stop();
+        thread.join();
+    }
+}
 
 ServiceThread::ServiceThread(KernelCore& kernel, std::size_t num_threads, const std::string& name)
     : impl{std::make_unique<Impl>(kernel, num_threads, name)} {}

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -873,7 +873,7 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, Handle
             const u64 thread_ticks = current_thread->GetCpuTime();
 
             out_ticks = thread_ticks + (core_timing.GetCPUTicks() - prev_ctx_ticks);
-        } else if (same_thread && info_sub_id == system.CurrentCoreIndex()) {
+        } else if (same_thread && info_sub_id == system.Kernel().CurrentPhysicalCoreIndex()) {
             out_ticks = core_timing.GetCPUTicks() - prev_ctx_ticks;
         }
 
@@ -887,7 +887,8 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, Handle
             return ResultInvalidHandle;
         }
 
-        if (info_sub_id != 0xFFFFFFFFFFFFFFFF && info_sub_id != system.CurrentCoreIndex()) {
+        if (info_sub_id != 0xFFFFFFFFFFFFFFFF &&
+            info_sub_id != system.Kernel().CurrentPhysicalCoreIndex()) {
             LOG_ERROR(Kernel_SVC, "Core is not the current core, got {}", info_sub_id);
             return ResultInvalidCombination;
         }

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -325,8 +325,7 @@ static ResultCode SendSyncRequest(Core::System& system, Handle handle) {
         }
     }
 
-    KSynchronizationObject* dummy{};
-    return thread->GetWaitResult(std::addressof(dummy));
+    return thread->GetWaitResult();
 }
 
 static ResultCode SendSyncRequest32(Core::System& system, Handle handle) {

--- a/src/core/hle/kernel/time_manager.cpp
+++ b/src/core/hle/kernel/time_manager.cpp
@@ -5,6 +5,7 @@
 #include "common/assert.h"
 #include "core/core.h"
 #include "core/core_timing.h"
+#include "core/hle/kernel/k_scheduler.h"
 #include "core/hle/kernel/k_thread.h"
 #include "core/hle/kernel/time_manager.h"
 
@@ -15,7 +16,10 @@ TimeManager::TimeManager(Core::System& system_) : system{system_} {
         Core::Timing::CreateEvent("Kernel::TimeManagerCallback",
                                   [this](std::uintptr_t thread_handle, std::chrono::nanoseconds) {
                                       KThread* thread = reinterpret_cast<KThread*>(thread_handle);
-                                      thread->Wakeup();
+                                      {
+                                          KScopedSchedulerLock sl(system.Kernel());
+                                          thread->OnTimer();
+                                      }
                                   });
 }
 


### PR DESCRIPTION
The primary goal of this PR is to continue to improve the accuracy of our scheduler and threading implementations, improve parity with recent HOS updates, and fix race conditions/deadlocks/crashes.

There are several changes here:
* Implement more complete tracking of KThread dispatch count through KScopedDisableDispatch.
* Improved KScheduler EnableScheduling/DisableScheduling routines as a result.
* Overall simplification of a few KScheduler implementations.
* Improved emulation of host-only HLE threads as simulated "guest threads" on core 3.
* Use std::jthread for CPU threads.
* Use std::jthread for service host threads. This fixes a deadlock that can cause a crash in Pokémon Sword & Shield.
* Improvements to thread pinning code.
* Updated our KThreadQueue implementation, and updated our synchronization primitives to use the new pattern.
* Fixed several kernel shutdown crashes.
* Updated KConditionVariable, KAddressArbiter, KLightLock, KSynchronizationObject, etc. implementations.

Fixes #6538

Supersedes #7398 and #6964 .

Credit to @FernandoS27 for helping with a few fixes with this change, and thank you to @gidoly, @G-Spawn, and others for all of the help testing.