### PR TITLE
qt_controller: Fix input when the controller applet is ignored

### DIFF
--- a/src/yuzu/applets/qt_controller.cpp
+++ b/src/yuzu/applets/qt_controller.cpp
@@ -205,6 +205,9 @@ QtControllerSelectorDialog::QtControllerSelectorDialog(
     // If all the parameters are met AND only allows a single player,
     // stop the constructor here as we do not need to continue.
     if (CheckIfParametersMet() && parameters.enable_single_mode) {
+        for (std::size_t player_index = 0; player_index < NUM_PLAYERS; ++player_index) {
+            system.HIDCore().GetEmulatedControllerByIndex(player_index)->DisableConfiguration();
+        }
         return;
     }
 


### PR DESCRIPTION
Turns out when the applet is not shown the controllers stay in configuration mode. This PR ensures the controllers are enabled again