### PR TITLE
video_core/codecs: more robust ffmpeg hwdecoder selection logic

### DIFF
--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -3,6 +3,7 @@ add_subdirectory(host_shaders)
 if(LIBVA_FOUND)
     set_source_files_properties(command_classes/codecs/codec.cpp
         PROPERTIES COMPILE_DEFINITIONS LIBVA_FOUND=1)
+    list(APPEND FFmpeg_LIBRARIES ${LIBVA_LIBRARIES})
 endif()
 
 add_library(video_core STATIC

--- a/src/video_core/command_classes/codecs/codec.cpp
+++ b/src/video_core/command_classes/codecs/codec.cpp
@@ -23,14 +23,17 @@ namespace Tegra {
 namespace {
 constexpr AVPixelFormat PREFERRED_GPU_FMT = AV_PIX_FMT_NV12;
 constexpr AVPixelFormat PREFERRED_CPU_FMT = AV_PIX_FMT_YUV420P;
-constexpr std::array PREFERRED_GPU_DECODERS = {AV_HWDEVICE_TYPE_CUDA,
+constexpr std::array PREFERRED_GPU_DECODERS = {
+    AV_HWDEVICE_TYPE_CUDA,
 #ifdef _WIN32
-                                               AV_HWDEVICE_TYPE_D3D11VA, AV_HWDEVICE_TYPE_DXVA2,
-#elif linux
-                                               AV_HWDEVICE_TYPE_VDPAU,
+    AV_HWDEVICE_TYPE_D3D11VA,
+    AV_HWDEVICE_TYPE_DXVA2,
+#elif defined(__linux__)
+    AV_HWDEVICE_TYPE_VDPAU,
 #endif
-                                               // last resort for Linux Flatpak (w/ NVIDIA)
-                                               AV_HWDEVICE_TYPE_VULKAN};
+    // last resort for Linux Flatpak (w/ NVIDIA)
+    AV_HWDEVICE_TYPE_VULKAN,
+};
 
 void AVPacketDeleter(AVPacket* ptr) {
     av_packet_free(&ptr);
@@ -72,12 +75,13 @@ Codec::~Codec() {
 // List all the currently available hwcontext in ffmpeg
 static std::vector<AVHWDeviceType> ListSupportedContexts() {
     std::vector<AVHWDeviceType> contexts{};
-    enum AVHWDeviceType current_device_type = AV_HWDEVICE_TYPE_NONE;
+    AVHWDeviceType current_device_type = AV_HWDEVICE_TYPE_NONE;
     do {
         current_device_type = av_hwdevice_iterate_types(current_device_type);
         // filter out VA-API since we will try that first if supported
-        if (current_device_type != AV_HWDEVICE_TYPE_VAAPI)
+        if (current_device_type != AV_HWDEVICE_TYPE_VAAPI) {
             contexts.push_back(current_device_type);
+        }
     } while (current_device_type != AV_HWDEVICE_TYPE_NONE);
     return contexts;
 }


### PR DESCRIPTION
This pull request will hopefully solve the FFmpeg hardware decoder selection issue.

The new logic will ask FFmpeg what contexts it supports on the current platform and current hardware, then we will check if the following hardware decoders are supported one-by-one in this order:

- CUDA
- [WIN only] D3D11VA
- [WIN only] DXVA2 (D3D9 on Win7-, Media Foundation on Win7+)
- [Linux only] VDPAU
- VULKAN

Some broader user-testing is required before merging.