### PR TITLE
service/hid: Improve console motion accuracy

### DIFF
--- a/src/core/hid/emulated_console.cpp
+++ b/src/core/hid/emulated_console.cpp
@@ -157,7 +157,10 @@ void EmulatedConsole::SetMotion(Common::Input::CallbackStatus callback) {
     motion.rotation = emulated.GetGyroscope();
     motion.orientation = emulated.GetOrientation();
     motion.quaternion = emulated.GetQuaternion();
+    motion.gyro_bias = emulated.GetGyroBias();
     motion.is_at_rest = !emulated.IsMoving(motion_sensitivity);
+    // Find what is this value
+    motion.verticalization_error = 0.0f;
 
     TriggerOnChange(ConsoleTriggerType::Motion);
 }

--- a/src/core/hid/emulated_console.h
+++ b/src/core/hid/emulated_console.h
@@ -50,6 +50,8 @@ struct ConsoleMotion {
     Common::Vec3f rotation{};
     std::array<Common::Vec3f, 3> orientation{};
     Common::Quaternion<f32> quaternion{};
+    Common::Vec3f gyro_bias{};
+    f32 verticalization_error{};
     bool is_at_rest{};
 };
 

--- a/src/core/hid/motion_input.cpp
+++ b/src/core/hid/motion_input.cpp
@@ -23,11 +23,11 @@ void MotionInput::SetAcceleration(const Common::Vec3f& acceleration) {
 }
 
 void MotionInput::SetGyroscope(const Common::Vec3f& gyroscope) {
-    gyro = gyroscope - gyro_drift;
+    gyro = gyroscope - gyro_bias;
 
     // Auto adjust drift to minimize drift
     if (!IsMoving(0.1f)) {
-        gyro_drift = (gyro_drift * 0.9999f) + (gyroscope * 0.0001f);
+        gyro_bias = (gyro_bias * 0.9999f) + (gyroscope * 0.0001f);
     }
 
     if (gyro.Length2() < gyro_threshold) {
@@ -41,8 +41,8 @@ void MotionInput::SetQuaternion(const Common::Quaternion<f32>& quaternion) {
     quat = quaternion;
 }
 
-void MotionInput::SetGyroDrift(const Common::Vec3f& drift) {
-    gyro_drift = drift;
+void MotionInput::SetGyroBias(const Common::Vec3f& bias) {
+    gyro_bias = bias;
 }
 
 void MotionInput::SetGyroThreshold(f32 threshold) {
@@ -190,6 +190,10 @@ Common::Vec3f MotionInput::GetAcceleration() const {
 
 Common::Vec3f MotionInput::GetGyroscope() const {
     return gyro;
+}
+
+Common::Vec3f MotionInput::GetGyroBias() const {
+    return gyro_bias;
 }
 
 Common::Quaternion<f32> MotionInput::GetQuaternion() const {

--- a/src/core/hid/motion_input.h
+++ b/src/core/hid/motion_input.h
@@ -24,7 +24,7 @@ public:
     void SetAcceleration(const Common::Vec3f& acceleration);
     void SetGyroscope(const Common::Vec3f& gyroscope);
     void SetQuaternion(const Common::Quaternion<f32>& quaternion);
-    void SetGyroDrift(const Common::Vec3f& drift);
+    void SetGyroBias(const Common::Vec3f& bias);
     void SetGyroThreshold(f32 threshold);
 
     void EnableReset(bool reset);
@@ -36,6 +36,7 @@ public:
     [[nodiscard]] std::array<Common::Vec3f, 3> GetOrientation() const;
     [[nodiscard]] Common::Vec3f GetAcceleration() const;
     [[nodiscard]] Common::Vec3f GetGyroscope() const;
+    [[nodiscard]] Common::Vec3f GetGyroBias() const;
     [[nodiscard]] Common::Vec3f GetRotations() const;
     [[nodiscard]] Common::Quaternion<f32> GetQuaternion() const;
 
@@ -69,7 +70,7 @@ private:
     Common::Vec3f gyro;
 
     // Vector to be substracted from gyro measurements
-    Common::Vec3f gyro_drift;
+    Common::Vec3f gyro_bias;
 
     // Minimum gyro amplitude to detect if the device is moving
     f32 gyro_threshold = 0.0f;

--- a/src/core/hle/service/hid/controllers/console_sixaxis.h
+++ b/src/core/hle/service/hid/controllers/console_sixaxis.h
@@ -39,8 +39,9 @@ public:
 
 private:
     struct SevenSixAxisState {
-        INSERT_PADDING_WORDS(4); // unused
-        s64 sampling_number{};
+        INSERT_PADDING_WORDS(2); // unused
+        u64 timestamp{};
+        u64 sampling_number{};
         u64 unknown{};
         Common::Vec3f accel{};
         Common::Vec3f gyro{};
@@ -52,9 +53,10 @@ private:
     struct ConsoleSharedMemory {
         u64 sampling_number{};
         bool is_seven_six_axis_sensor_at_rest{};
-        INSERT_PADDING_BYTES(4); // padding
+        INSERT_PADDING_BYTES(3); // padding
         f32 verticalization_error{};
         Common::Vec3f gyro_bias{};
+        INSERT_PADDING_BYTES(4); // padding
     };
     static_assert(sizeof(ConsoleSharedMemory) == 0x20, "ConsoleSharedMemory is an invalid size");
 
@@ -64,6 +66,8 @@ private:
     Core::HID::EmulatedConsole* console;
     u8* transfer_memory = nullptr;
     bool is_transfer_memory_set = false;
+    u64 last_saved_timestamp{};
+    u64 last_global_timestamp{};
     ConsoleSharedMemory console_six_axis{};
     SevenSixAxisState next_seven_sixaxis_state{};
 };


### PR DESCRIPTION
Improve accuracy of the VR camera by filling all the data needed. Including gyro data that previously corrupted the camera movement