### PR TITLE
general: Replace high_resolution_clock with steady_clock

### DIFF
--- a/src/common/x64/native_clock.cpp
+++ b/src/common/x64/native_clock.cpp
@@ -19,16 +19,16 @@ u64 EstimateRDTSCFrequency() {
     // get current time
     _mm_mfence();
     const u64 tscStart = __rdtsc();
-    const auto startTime = std::chrono::high_resolution_clock::now();
+    const auto startTime = std::chrono::steady_clock::now();
     // wait roughly 3 seconds
     while (true) {
         auto milli = std::chrono::duration_cast<std::chrono::milliseconds>(
-            std::chrono::high_resolution_clock::now() - startTime);
+            std::chrono::steady_clock::now() - startTime);
         if (milli.count() >= 3000)
             break;
         std::this_thread::sleep_for(milli_10);
     }
-    const auto endTime = std::chrono::high_resolution_clock::now();
+    const auto endTime = std::chrono::steady_clock::now();
     _mm_mfence();
     const u64 tscEnd = __rdtsc();
     // calculate difference

--- a/src/core/hle/service/audio/hwopus.cpp
+++ b/src/core/hle/service/audio/hwopus.cpp
@@ -96,7 +96,7 @@ private:
 
     bool DecodeOpusData(u32& consumed, u32& sample_count, const std::vector<u8>& input,
                         std::vector<opus_int16>& output, u64* out_performance_time) const {
-        const auto start_time = std::chrono::high_resolution_clock::now();
+        const auto start_time = std::chrono::steady_clock::now();
         const std::size_t raw_output_sz = output.size() * sizeof(opus_int16);
         if (sizeof(OpusPacketHeader) > input.size()) {
             LOG_ERROR(Audio, "Input is smaller than the header size, header_sz={}, input_sz={}",
@@ -135,7 +135,7 @@ private:
             return false;
         }
 
-        const auto end_time = std::chrono::high_resolution_clock::now() - start_time;
+        const auto end_time = std::chrono::steady_clock::now() - start_time;
         sample_count = out_sample_count;
         consumed = static_cast<u32>(sizeof(OpusPacketHeader) + hdr.size);
         if (out_performance_time != nullptr) {

--- a/src/core/perf_stats.h
+++ b/src/core/perf_stats.h
@@ -33,7 +33,7 @@ public:
     explicit PerfStats(u64 title_id_);
     ~PerfStats();
 
-    using Clock = std::chrono::high_resolution_clock;
+    using Clock = std::chrono::steady_clock;
 
     void BeginSystemFrame();
     void EndSystemFrame();
@@ -87,7 +87,7 @@ private:
 
 class SpeedLimiter {
 public:
-    using Clock = std::chrono::high_resolution_clock;
+    using Clock = std::chrono::steady_clock;
 
     void DoSpeedLimiting(std::chrono::microseconds current_system_time_us);
 

--- a/src/video_core/shader_notify.cpp
+++ b/src/video_core/shader_notify.cpp
@@ -18,7 +18,7 @@ int ShaderNotify::ShadersBuilding() noexcept {
     const int now_complete = num_complete.load(std::memory_order::relaxed);
     const int now_building = num_building.load(std::memory_order::relaxed);
     if (now_complete == now_building) {
-        const auto now = std::chrono::high_resolution_clock::now();
+        const auto now = std::chrono::steady_clock::now();
         if (completed && num_complete == num_when_completed) {
             if (now - complete_time > TIME_TO_STOP_REPORTING) {
                 report_base = now_complete;

--- a/src/video_core/shader_notify.h
+++ b/src/video_core/shader_notify.h
@@ -28,6 +28,6 @@ private:
 
     bool completed{};
     int num_when_completed{};
-    std::chrono::high_resolution_clock::time_point complete_time;
+    std::chrono::steady_clock::time_point complete_time;
 };
 } // namespace VideoCore

--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -136,7 +136,7 @@ void LoadingScreen::OnLoadComplete() {
 void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size_t value,
                                    std::size_t total) {
     using namespace std::chrono;
-    const auto now = high_resolution_clock::now();
+    const auto now = steady_clock::now();
     // reset the timer if the stage changes
     if (stage != previous_stage) {
         ui->progress_bar->setStyleSheet(QString::fromUtf8(progressbar_style[stage]));
@@ -160,7 +160,7 @@ void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size
     // If theres a drastic slowdown in the rate, then display an estimate
     if (now - previous_time > milliseconds{50} || slow_shader_compile_start) {
         if (!slow_shader_compile_start) {
-            slow_shader_start = high_resolution_clock::now();
+            slow_shader_start = steady_clock::now();
             slow_shader_compile_start = true;
             slow_shader_first_value = value;
         }

--- a/src/yuzu/loading_screen.h
+++ b/src/yuzu/loading_screen.h
@@ -84,8 +84,8 @@ private:
     // shaders, it will start quickly but end slow if new shaders were added since previous launch.
     // These variables are used to detect the change in speed so we can generate an ETA
     bool slow_shader_compile_start = false;
-    std::chrono::high_resolution_clock::time_point slow_shader_start;
-    std::chrono::high_resolution_clock::time_point previous_time;
+    std::chrono::steady_clock::time_point slow_shader_start;
+    std::chrono::steady_clock::time_point previous_time;
     std::size_t slow_shader_first_value = 0;
 };
 


### PR DESCRIPTION
On some OSes, high_resolution_clock is an alias to system_clock and is not monotonic in nature. Replace this with steady_clock.