### PR TITLE
general: Add missing copyright notices

### DIFF
--- a/src/audio_core/delay_line.cpp
+++ b/src/audio_core/delay_line.cpp
@@ -1,3 +1,7 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 #include <cstring>
 #include "audio_core/delay_line.h"
 

--- a/src/audio_core/delay_line.h
+++ b/src/audio_core/delay_line.h
@@ -1,3 +1,7 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 #pragma once
 
 #include "common/common_types.h"

--- a/src/common/host_memory.cpp
+++ b/src/common/host_memory.cpp
@@ -1,3 +1,7 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 #ifdef _WIN32
 
 #include <iterator>

--- a/src/core/hle/service/nvdrv/nvdata.h
+++ b/src/core/hle/service/nvdrv/nvdata.h
@@ -1,3 +1,7 @@
+// Copyright 2019 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 #pragma once
 
 #include <array>

--- a/src/shader_recompiler/environment.h
+++ b/src/shader_recompiler/environment.h
@@ -1,3 +1,7 @@
+// Copyright 2021 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
 #pragma once
 
 #include <array>


### PR DESCRIPTION
A few source files didn't have the yuzu copyright notice.