### PR TITLE
build: update cubeb and remove the result_of comment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,7 +131,7 @@ add_definitions(-DBOOST_ASIO_DISABLE_CONCEPTS)
 if (MSVC)
     add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/std:c++latest>)
 
-    # cubeb and boost still make use of deprecated result_of.
+    # boost still makes use of deprecated result_of.
     add_definitions(-D_HAS_DEPRECATED_RESULT_OF)
 else()
     set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
Cubeb doesn't use result_of anymore, it has been dropped in commit mozilla/cubeb@75d9d125ee655ef80f3bfcd97ae5a805931042b8

Edit: I can't test this right now, I'll rely on the CI