### PR TITLE
input_common: Update SDL to 2.0.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,7 +370,7 @@ if (ENABLE_SDL2)
     if (YUZU_USE_BUNDLED_SDL2)
         # Detect toolchain and platform
         if ((MSVC_VERSION GREATER_EQUAL 1920 AND MSVC_VERSION LESS 1940) AND ARCHITECTURE_x86_64)
-            set(SDL2_VER "SDL2-2.0.16")
+            set(SDL2_VER "SDL2-2.0.18")
         else()
             message(FATAL_ERROR "No bundled SDL2 binaries for your toolchain. Disable YUZU_USE_BUNDLED_SDL2 and provide your own.")
         endif()
@@ -390,7 +390,7 @@ if (ENABLE_SDL2)
     elseif (YUZU_USE_EXTERNAL_SDL2)
         message(STATUS "Using SDL2 from externals.")
     else()
-        find_package(SDL2 2.0.16 REQUIRED)
+        find_package(SDL2 2.0.18 REQUIRED)
 
         # Some installations don't set SDL2_LIBRARIES
         if("${SDL2_LIBRARIES}" STREQUAL "")


### PR DESCRIPTION
SDL 2.0.18 exposes HIDAPI driver needed for a custom driver for joycons. On top of that it seems like it also adds support to new controllers