### PR TITLE
profiler: Use QWheelEvent position().toPoint()

### DIFF
--- a/src/yuzu/debugger/profiler.cpp
+++ b/src/yuzu/debugger/profiler.cpp
@@ -163,7 +163,7 @@ void MicroProfileWidget::mouseReleaseEvent(QMouseEvent* ev) {
 }
 
 void MicroProfileWidget::wheelEvent(QWheelEvent* ev) {
-    const auto wheel_position = ev->pos();
+    const auto wheel_position = ev->position().toPoint();
     MicroProfileMousePosition(wheel_position.x() / x_scale, wheel_position.y() / y_scale,
                               ev->angleDelta().y() / 120);
     ev->accept();


### PR DESCRIPTION
QWheelEvent::pos() is deprecated. Make use of position().toPoint() instead.