### PR TITLE
game_list: Add persistent setting for the favorites row expanded state

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -776,6 +776,7 @@ void Config::ReadUIGamelistValues() {
     ReadBasicSetting(UISettings::values.row_1_text_id);
     ReadBasicSetting(UISettings::values.row_2_text_id);
     ReadBasicSetting(UISettings::values.cache_game_list);
+    ReadBasicSetting(UISettings::values.favorites_expanded);
     const int favorites_size = qt_config->beginReadArray(QStringLiteral("favorites"));
     for (int i = 0; i < favorites_size; i++) {
         qt_config->setArrayIndex(i);
@@ -1300,6 +1301,7 @@ void Config::SaveUIGamelistValues() {
     WriteBasicSetting(UISettings::values.row_1_text_id);
     WriteBasicSetting(UISettings::values.row_2_text_id);
     WriteBasicSetting(UISettings::values.cache_game_list);
+    WriteBasicSetting(UISettings::values.favorites_expanded);
     qt_config->beginWriteArray(QStringLiteral("favorites"));
     for (int i = 0; i < UISettings::values.favorited_ids.size(); i++) {
         qt_config->setArrayIndex(i);

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -74,7 +74,6 @@ struct Values {
     QString game_dir_deprecated;
     bool game_dir_deprecated_deepscan;
     QVector<UISettings::GameDir> game_dirs;
-    QVector<u64> favorited_ids;
     QStringList recent_files;
     QString language;
 
@@ -96,6 +95,8 @@ struct Values {
     Settings::BasicSetting<uint8_t> row_2_text_id{2, "row_2_text_id"};
     std::atomic_bool is_game_list_reload_pending{false};
     Settings::BasicSetting<bool> cache_game_list{true, "cache_game_list"};
+    Settings::BasicSetting<bool> favorites_expanded{true, "favorites_expanded"};
+    QVector<u64> favorited_ids;
 
     bool configuration_applied;
     bool reset_to_defaults;


### PR DESCRIPTION
Previously, the favorites row was always expanded on launch. 
This change introduces a persistent setting that allows the favorites row's expanded state to be remembered between launches.