### PR TITLE
input/SDL: Update SDL hints

### DIFF
--- a/src/input_common/drivers/sdl_driver.cpp
+++ b/src/input_common/drivers/sdl_driver.cpp
@@ -403,10 +403,11 @@ SDLDriver::SDLDriver(const std::string& input_engine_) : InputEngine(input_engin
 
     // Use hidapi driver for joycons. This will allow joycons to be detected as a GameController and
     // not a generic one
-    SDL_SetHint("SDL_JOYSTICK_HIDAPI_JOY_CONS", "1");
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_JOY_CONS, "1");
 
-    // Turn off Pro controller home led
-    SDL_SetHint("SDL_JOYSTICK_HIDAPI_SWITCH_HOME_LED", "0");
+    // Disable hidapi driver for xbox. Already default on Windows, this causes conflict with native
+    // driver on Linux.
+    SDL_SetHint(SDL_HINT_JOYSTICK_HIDAPI_XBOX, "0");
 
     // If the frontend is going to manage the event loop, then we don't start one here
     start_thread = SDL_WasInit(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER) == 0;


### PR DESCRIPTION
`SDL_HINT_JOYSTICK_HIDAPI_SWITCH_HOME_LED` is no longer needed thanks to new default in SDL 2.0.18.

`SDL_HINT_JOYSTICK_HIDAPI_XBOX` is reported to cause conflicts with native driver Xbox driver on Linux, and Xbox controllers don't benefit from hidapi anyways.