### PR TITLE
qt_software_keyboard: Fix out of bounds array access

### DIFF
--- a/src/yuzu/applets/qt_software_keyboard.cpp
+++ b/src/yuzu/applets/qt_software_keyboard.cpp
@@ -475,11 +475,26 @@ void QtSoftwareKeyboardDialog::open() {
     row = 0;
     column = 0;
 
-    const auto* const curr_button =
-        keyboard_buttons[static_cast<int>(bottom_osk_index)][row][column];
+    switch (bottom_osk_index) {
+    case BottomOSKIndex::LowerCase:
+    case BottomOSKIndex::UpperCase: {
+        const auto* const curr_button =
+            keyboard_buttons[static_cast<std::size_t>(bottom_osk_index)][row][column];
 
-    // This is a workaround for setFocus() randomly not showing focus in the UI
-    QCursor::setPos(curr_button->mapToGlobal(curr_button->rect().center()));
+        // This is a workaround for setFocus() randomly not showing focus in the UI
+        QCursor::setPos(curr_button->mapToGlobal(curr_button->rect().center()));
+        break;
+    }
+    case BottomOSKIndex::NumberPad: {
+        const auto* const curr_button = numberpad_buttons[row][column];
+
+        // This is a workaround for setFocus() randomly not showing focus in the UI
+        QCursor::setPos(curr_button->mapToGlobal(curr_button->rect().center()));
+        break;
+    }
+    default:
+        break;
+    }
 
     StartInputThread();
 }


### PR DESCRIPTION
We were unconditionally accessing the keyboard_buttons array, even if the bottom_osk_index was for the numberpad, leading to an out of bounds array access. Fix this by accessing the proper array for the current button when the index is for the numberpad.

Fixes #7573 