### PR TITLE
common/input: Avoid numerous large copies of CallbackStatus

### DIFF
--- a/src/common/input.h
+++ b/src/common/input.h
@@ -236,14 +236,10 @@ public:
     virtual ~InputDevice() = default;
 
     // Request input device to update if necessary
-    virtual void SoftUpdate() {
-        return;
-    }
+    virtual void SoftUpdate() {}
 
     // Force input device to update data regardless of the current state
-    virtual void ForceUpdate() {
-        return;
-    }
+    virtual void ForceUpdate() {}
 
     // Sets the function to be triggered when input changes
     void SetCallback(InputCallback callback_) {

--- a/src/common/input.h
+++ b/src/common/input.h
@@ -227,7 +227,7 @@ struct CallbackStatus {
 
 // Triggered once every input change
 struct InputCallback {
-    std::function<void(CallbackStatus)> on_change;
+    std::function<void(const CallbackStatus&)> on_change;
 };
 
 /// An abstract class template for an input device (a button, an analog input, etc.).
@@ -247,7 +247,7 @@ public:
     }
 
     // Triggers the function set in the callback
-    void TriggerOnChange(CallbackStatus status) {
+    void TriggerOnChange(const CallbackStatus& status) {
         if (callback.on_change) {
             callback.on_change(status);
         }

--- a/src/core/hid/emulated_console.h
+++ b/src/core/hid/emulated_console.h
@@ -155,14 +155,14 @@ private:
      * Updates the motion status of the console
      * @param callback A CallbackStatus containing gyro and accelerometer data
      */
-    void SetMotion(Common::Input::CallbackStatus callback);
+    void SetMotion(const Common::Input::CallbackStatus& callback);
 
     /**
      * Updates the touch status of the console
      * @param callback A CallbackStatus containing the touch position
      * @param index Finger ID to be updated
      */
-    void SetTouch(Common::Input::CallbackStatus callback, std::size_t index);
+    void SetTouch(const Common::Input::CallbackStatus& callback, std::size_t index);
 
     /**
      * Triggers a callback that something has changed on the console status

--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -205,11 +205,12 @@ void EmulatedController::ReloadInput() {
             continue;
         }
         const auto uuid = Common::UUID{button_params[index].Get("guid", "")};
-        Common::Input::InputCallback button_callback{
-            [this, index, uuid](Common::Input::CallbackStatus callback) {
-                SetButton(callback, index, uuid);
-            }};
-        button_devices[index]->SetCallback(button_callback);
+        button_devices[index]->SetCallback({
+            .on_change =
+                [this, index, uuid](const Common::Input::CallbackStatus& callback) {
+                    SetButton(callback, index, uuid);
+                },
+        });
         button_devices[index]->ForceUpdate();
     }
 
@@ -218,11 +219,12 @@ void EmulatedController::ReloadInput() {
             continue;
         }
         const auto uuid = Common::UUID{stick_params[index].Get("guid", "")};
-        Common::Input::InputCallback stick_callback{
-            [this, index, uuid](Common::Input::CallbackStatus callback) {
-                SetStick(callback, index, uuid);
-            }};
-        stick_devices[index]->SetCallback(stick_callback);
+        stick_devices[index]->SetCallback({
+            .on_change =
+                [this, index, uuid](const Common::Input::CallbackStatus& callback) {
+                    SetStick(callback, index, uuid);
+                },
+        });
         stick_devices[index]->ForceUpdate();
     }
 
@@ -231,11 +233,12 @@ void EmulatedController::ReloadInput() {
             continue;
         }
         const auto uuid = Common::UUID{trigger_params[index].Get("guid", "")};
-        Common::Input::InputCallback trigger_callback{
-            [this, index, uuid](Common::Input::CallbackStatus callback) {
-                SetTrigger(callback, index, uuid);
-            }};
-        trigger_devices[index]->SetCallback(trigger_callback);
+        trigger_devices[index]->SetCallback({
+            .on_change =
+                [this, index, uuid](const Common::Input::CallbackStatus& callback) {
+                    SetTrigger(callback, index, uuid);
+                },
+        });
         trigger_devices[index]->ForceUpdate();
     }
 
@@ -243,9 +246,12 @@ void EmulatedController::ReloadInput() {
         if (!battery_devices[index]) {
             continue;
         }
-        Common::Input::InputCallback battery_callback{
-            [this, index](Common::Input::CallbackStatus callback) { SetBattery(callback, index); }};
-        battery_devices[index]->SetCallback(battery_callback);
+        battery_devices[index]->SetCallback({
+            .on_change =
+                [this, index](const Common::Input::CallbackStatus& callback) {
+                    SetBattery(callback, index);
+                },
+        });
         battery_devices[index]->ForceUpdate();
     }
 
@@ -253,9 +259,12 @@ void EmulatedController::ReloadInput() {
         if (!motion_devices[index]) {
             continue;
         }
-        Common::Input::InputCallback motion_callback{
-            [this, index](Common::Input::CallbackStatus callback) { SetMotion(callback, index); }};
-        motion_devices[index]->SetCallback(motion_callback);
+        motion_devices[index]->SetCallback({
+            .on_change =
+                [this, index](const Common::Input::CallbackStatus& callback) {
+                    SetMotion(callback, index);
+                },
+        });
         motion_devices[index]->ForceUpdate();
     }
 
@@ -267,22 +276,24 @@ void EmulatedController::ReloadInput() {
         if (!tas_button_devices[index]) {
             continue;
         }
-        Common::Input::InputCallback button_callback{
-            [this, index, tas_uuid](Common::Input::CallbackStatus callback) {
-                SetButton(callback, index, tas_uuid);
-            }};
-        tas_button_devices[index]->SetCallback(button_callback);
+        tas_button_devices[index]->SetCallback({
+            .on_change =
+                [this, index, tas_uuid](const Common::Input::CallbackStatus& callback) {
+                    SetButton(callback, index, tas_uuid);
+                },
+        });
     }
 
     for (std::size_t index = 0; index < tas_stick_devices.size(); ++index) {
         if (!tas_stick_devices[index]) {
             continue;
         }
-        Common::Input::InputCallback stick_callback{
-            [this, index, tas_uuid](Common::Input::CallbackStatus callback) {
-                SetStick(callback, index, tas_uuid);
-            }};
-        tas_stick_devices[index]->SetCallback(stick_callback);
+        tas_stick_devices[index]->SetCallback({
+            .on_change =
+                [this, index, tas_uuid](const Common::Input::CallbackStatus& callback) {
+                    SetStick(callback, index, tas_uuid);
+                },
+        });
     }
 }
 
@@ -440,7 +451,7 @@ void EmulatedController::SetButtonParam(std::size_t index, Common::ParamPackage 
     if (index >= button_params.size()) {
         return;
     }
-    button_params[index] = param;
+    button_params[index] = std::move(param);
     ReloadInput();
 }
 
@@ -448,7 +459,7 @@ void EmulatedController::SetStickParam(std::size_t index, Common::ParamPackage p
     if (index >= stick_params.size()) {
         return;
     }
-    stick_params[index] = param;
+    stick_params[index] = std::move(param);
     ReloadInput();
 }
 
@@ -456,11 +467,11 @@ void EmulatedController::SetMotionParam(std::size_t index, Common::ParamPackage 
     if (index >= motion_params.size()) {
         return;
     }
-    motion_params[index] = param;
+    motion_params[index] = std::move(param);
     ReloadInput();
 }
 
-void EmulatedController::SetButton(Common::Input::CallbackStatus callback, std::size_t index,
+void EmulatedController::SetButton(const Common::Input::CallbackStatus& callback, std::size_t index,
                                    Common::UUID uuid) {
     if (index >= controller.button_values.size()) {
         return;
@@ -600,7 +611,7 @@ void EmulatedController::SetButton(Common::Input::CallbackStatus callback, std::
     TriggerOnChange(ControllerTriggerType::Button, true);
 }
 
-void EmulatedController::SetStick(Common::Input::CallbackStatus callback, std::size_t index,
+void EmulatedController::SetStick(const Common::Input::CallbackStatus& callback, std::size_t index,
                                   Common::UUID uuid) {
     if (index >= controller.stick_values.size()) {
         return;
@@ -650,8 +661,8 @@ void EmulatedController::SetStick(Common::Input::CallbackStatus callback, std::s
     TriggerOnChange(ControllerTriggerType::Stick, true);
 }
 
-void EmulatedController::SetTrigger(Common::Input::CallbackStatus callback, std::size_t index,
-                                    Common::UUID uuid) {
+void EmulatedController::SetTrigger(const Common::Input::CallbackStatus& callback,
+                                    std::size_t index, Common::UUID uuid) {
     if (index >= controller.trigger_values.size()) {
         return;
     }
@@ -692,7 +703,8 @@ void EmulatedController::SetTrigger(Common::Input::CallbackStatus callback, std:
     TriggerOnChange(ControllerTriggerType::Trigger, true);
 }
 
-void EmulatedController::SetMotion(Common::Input::CallbackStatus callback, std::size_t index) {
+void EmulatedController::SetMotion(const Common::Input::CallbackStatus& callback,
+                                   std::size_t index) {
     if (index >= controller.motion_values.size()) {
         return;
     }
@@ -730,7 +742,8 @@ void EmulatedController::SetMotion(Common::Input::CallbackStatus callback, std::
     TriggerOnChange(ControllerTriggerType::Motion, true);
 }
 
-void EmulatedController::SetBattery(Common::Input::CallbackStatus callback, std::size_t index) {
+void EmulatedController::SetBattery(const Common::Input::CallbackStatus& callback,
+                                    std::size_t index) {
     if (index >= controller.battery_values.size()) {
         return;
     }
@@ -1110,7 +1123,7 @@ void EmulatedController::TriggerOnChange(ControllerTriggerType type, bool is_npa
 
 int EmulatedController::SetCallback(ControllerUpdateCallback update_callback) {
     std::lock_guard lock{mutex};
-    callback_list.insert_or_assign(last_callback_key, update_callback);
+    callback_list.insert_or_assign(last_callback_key, std::move(update_callback));
     return last_callback_key++;
 }
 

--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -328,35 +328,38 @@ private:
      * @param callback A CallbackStatus containing the button status
      * @param index Button ID of the to be updated
      */
-    void SetButton(Common::Input::CallbackStatus callback, std::size_t index, Common::UUID uuid);
+    void SetButton(const Common::Input::CallbackStatus& callback, std::size_t index,
+                   Common::UUID uuid);
 
     /**
      * Updates the analog stick status of the controller
      * @param callback A CallbackStatus containing the analog stick status
      * @param index stick ID of the to be updated
      */
-    void SetStick(Common::Input::CallbackStatus callback, std::size_t index, Common::UUID uuid);
+    void SetStick(const Common::Input::CallbackStatus& callback, std::size_t index,
+                  Common::UUID uuid);
 
     /**
      * Updates the trigger status of the controller
      * @param callback A CallbackStatus containing the trigger status
      * @param index trigger ID of the to be updated
      */
-    void SetTrigger(Common::Input::CallbackStatus callback, std::size_t index, Common::UUID uuid);
+    void SetTrigger(const Common::Input::CallbackStatus& callback, std::size_t index,
+                    Common::UUID uuid);
 
     /**
      * Updates the motion status of the controller
      * @param callback A CallbackStatus containing gyro and accelerometer data
      * @param index motion ID of the to be updated
      */
-    void SetMotion(Common::Input::CallbackStatus callback, std::size_t index);
+    void SetMotion(const Common::Input::CallbackStatus& callback, std::size_t index);
 
     /**
      * Updates the battery status of the controller
      * @param callback A CallbackStatus containing the battery status
      * @param index Button ID of the to be updated
      */
-    void SetBattery(Common::Input::CallbackStatus callback, std::size_t index);
+    void SetBattery(const Common::Input::CallbackStatus& callback, std::size_t index);
 
     /**
      * Triggers a callback that something has changed on the controller status

--- a/src/core/hid/emulated_devices.cpp
+++ b/src/core/hid/emulated_devices.cpp
@@ -70,50 +70,55 @@ void EmulatedDevices::ReloadInput() {
         if (!mouse_button_devices[index]) {
             continue;
         }
-        Common::Input::InputCallback button_callback{
-            [this, index](Common::Input::CallbackStatus callback) {
-                SetMouseButton(callback, index);
-            }};
-        mouse_button_devices[index]->SetCallback(button_callback);
+        mouse_button_devices[index]->SetCallback({
+            .on_change =
+                [this, index](const Common::Input::CallbackStatus& callback) {
+                    SetMouseButton(callback, index);
+                },
+        });
     }
 
     for (std::size_t index = 0; index < mouse_analog_devices.size(); ++index) {
         if (!mouse_analog_devices[index]) {
             continue;
         }
-        Common::Input::InputCallback button_callback{
-            [this, index](Common::Input::CallbackStatus callback) {
-                SetMouseAnalog(callback, index);
-            }};
-        mouse_analog_devices[index]->SetCallback(button_callback);
+        mouse_analog_devices[index]->SetCallback({
+            .on_change =
+                [this, index](const Common::Input::CallbackStatus& callback) {
+                    SetMouseAnalog(callback, index);
+                },
+        });
     }
 
     if (mouse_stick_device) {
-        Common::Input::InputCallback button_callback{
-            [this](Common::Input::CallbackStatus callback) { SetMouseStick(callback); }};
-        mouse_stick_device->SetCallback(button_callback);
+        mouse_stick_device->SetCallback({
+            .on_change =
+                [this](const Common::Input::CallbackStatus& callback) { SetMouseStick(callback); },
+        });
     }
 
     for (std::size_t index = 0; index < keyboard_devices.size(); ++index) {
         if (!keyboard_devices[index]) {
             continue;
         }
-        Common::Input::InputCallback button_callback{
-            [this, index](Common::Input::CallbackStatus callback) {
-                SetKeyboardButton(callback, index);
-            }};
-        keyboard_devices[index]->SetCallback(button_callback);
+        keyboard_devices[index]->SetCallback({
+            .on_change =
+                [this, index](const Common::Input::CallbackStatus& callback) {
+                    SetKeyboardButton(callback, index);
+                },
+        });
     }
 
     for (std::size_t index = 0; index < keyboard_modifier_devices.size(); ++index) {
         if (!keyboard_modifier_devices[index]) {
             continue;
         }
-        Common::Input::InputCallback button_callback{
-            [this, index](Common::Input::CallbackStatus callback) {
-                SetKeyboardModifier(callback, index);
-            }};
-        keyboard_modifier_devices[index]->SetCallback(button_callback);
+        keyboard_modifier_devices[index]->SetCallback({
+            .on_change =
+                [this, index](const Common::Input::CallbackStatus& callback) {
+                    SetKeyboardModifier(callback, index);
+                },
+        });
     }
 }
 
@@ -159,7 +164,8 @@ void EmulatedDevices::RestoreConfig() {
     ReloadFromSettings();
 }
 
-void EmulatedDevices::SetKeyboardButton(Common::Input::CallbackStatus callback, std::size_t index) {
+void EmulatedDevices::SetKeyboardButton(const Common::Input::CallbackStatus& callback,
+                                        std::size_t index) {
     if (index >= device_status.keyboard_values.size()) {
         return;
     }
@@ -216,7 +222,7 @@ void EmulatedDevices::UpdateKey(std::size_t key_index, bool status) {
     }
 }
 
-void EmulatedDevices::SetKeyboardModifier(Common::Input::CallbackStatus callback,
+void EmulatedDevices::SetKeyboardModifier(const Common::Input::CallbackStatus& callback,
                                           std::size_t index) {
     if (index >= device_status.keyboard_moddifier_values.size()) {
         return;
@@ -286,7 +292,8 @@ void EmulatedDevices::SetKeyboardModifier(Common::Input::CallbackStatus callback
     TriggerOnChange(DeviceTriggerType::KeyboardModdifier);
 }
 
-void EmulatedDevices::SetMouseButton(Common::Input::CallbackStatus callback, std::size_t index) {
+void EmulatedDevices::SetMouseButton(const Common::Input::CallbackStatus& callback,
+                                     std::size_t index) {
     if (index >= device_status.mouse_button_values.size()) {
         return;
     }
@@ -347,7 +354,8 @@ void EmulatedDevices::SetMouseButton(Common::Input::CallbackStatus callback, std
     TriggerOnChange(DeviceTriggerType::Mouse);
 }
 
-void EmulatedDevices::SetMouseAnalog(Common::Input::CallbackStatus callback, std::size_t index) {
+void EmulatedDevices::SetMouseAnalog(const Common::Input::CallbackStatus& callback,
+                                     std::size_t index) {
     if (index >= device_status.mouse_analog_values.size()) {
         return;
     }
@@ -374,7 +382,7 @@ void EmulatedDevices::SetMouseAnalog(Common::Input::CallbackStatus callback, std
     TriggerOnChange(DeviceTriggerType::Mouse);
 }
 
-void EmulatedDevices::SetMouseStick(Common::Input::CallbackStatus callback) {
+void EmulatedDevices::SetMouseStick(const Common::Input::CallbackStatus& callback) {
     std::lock_guard lock{mutex};
     const auto touch_value = TransformToTouch(callback);
 
@@ -435,7 +443,7 @@ void EmulatedDevices::TriggerOnChange(DeviceTriggerType type) {
 
 int EmulatedDevices::SetCallback(InterfaceUpdateCallback update_callback) {
     std::lock_guard lock{mutex};
-    callback_list.insert_or_assign(last_callback_key, update_callback);
+    callback_list.insert_or_assign(last_callback_key, std::move(update_callback));
     return last_callback_key++;
 }
 

--- a/src/core/hid/emulated_devices.h
+++ b/src/core/hid/emulated_devices.h
@@ -156,35 +156,34 @@ private:
      * @param callback A CallbackStatus containing the key status
      * @param index key ID to be updated
      */
-    void SetKeyboardButton(Common::Input::CallbackStatus callback, std::size_t index);
+    void SetKeyboardButton(const Common::Input::CallbackStatus& callback, std::size_t index);
 
     /**
      * Updates the keyboard status of the keyboard device
      * @param callback A CallbackStatus containing the modifier key status
      * @param index modifier key ID to be updated
      */
-    void SetKeyboardModifier(Common::Input::CallbackStatus callback, std::size_t index);
+    void SetKeyboardModifier(const Common::Input::CallbackStatus& callback, std::size_t index);
 
     /**
      * Updates the mouse button status of the mouse device
      * @param callback A CallbackStatus containing the button status
      * @param index Button ID to be updated
      */
-    void SetMouseButton(Common::Input::CallbackStatus callback, std::size_t index);
+    void SetMouseButton(const Common::Input::CallbackStatus& callback, std::size_t index);
 
     /**
      * Updates the mouse wheel status of the mouse device
      * @param callback A CallbackStatus containing the wheel status
      * @param index wheel ID to be updated
      */
-    void SetMouseAnalog(Common::Input::CallbackStatus callback, std::size_t index);
+    void SetMouseAnalog(const Common::Input::CallbackStatus& callback, std::size_t index);
 
     /**
      * Updates the mouse position status of the mouse device
      * @param callback A CallbackStatus containing the position status
-     * @param index stick ID to be updated
      */
-    void SetMouseStick(Common::Input::CallbackStatus callback);
+    void SetMouseStick(const Common::Input::CallbackStatus& callback);
 
     /**
      * Triggers a callback that something has changed on the device status

--- a/src/input_common/helpers/stick_from_buttons.cpp
+++ b/src/input_common/helpers/stick_from_buttons.cpp
@@ -19,23 +19,36 @@ public:
         : up(std::move(up_)), down(std::move(down_)), left(std::move(left_)),
           right(std::move(right_)), modifier(std::move(modifier_)), modifier_scale(modifier_scale_),
           modifier_angle(modifier_angle_) {
-        Common::Input::InputCallback button_up_callback{
-            [this](Common::Input::CallbackStatus callback_) { UpdateUpButtonStatus(callback_); }};
-        Common::Input::InputCallback button_down_callback{
-            [this](Common::Input::CallbackStatus callback_) { UpdateDownButtonStatus(callback_); }};
-        Common::Input::InputCallback button_left_callback{
-            [this](Common::Input::CallbackStatus callback_) { UpdateLeftButtonStatus(callback_); }};
-        Common::Input::InputCallback button_right_callback{
-            [this](Common::Input::CallbackStatus callback_) {
-                UpdateRightButtonStatus(callback_);
-            }};
-        Common::Input::InputCallback button_modifier_callback{
-            [this](Common::Input::CallbackStatus callback_) { UpdateModButtonStatus(callback_); }};
-        up->SetCallback(button_up_callback);
-        down->SetCallback(button_down_callback);
-        left->SetCallback(button_left_callback);
-        right->SetCallback(button_right_callback);
-        modifier->SetCallback(button_modifier_callback);
+        up->SetCallback({
+            .on_change =
+                [this](const Common::Input::CallbackStatus& callback_) {
+                    UpdateUpButtonStatus(callback_);
+                },
+        });
+        down->SetCallback({
+            .on_change =
+                [this](const Common::Input::CallbackStatus& callback_) {
+                    UpdateDownButtonStatus(callback_);
+                },
+        });
+        left->SetCallback({
+            .on_change =
+                [this](const Common::Input::CallbackStatus& callback_) {
+                    UpdateLeftButtonStatus(callback_);
+                },
+        });
+        right->SetCallback({
+            .on_change =
+                [this](const Common::Input::CallbackStatus& callback_) {
+                    UpdateRightButtonStatus(callback_);
+                },
+        });
+        modifier->SetCallback({
+            .on_change =
+                [this](const Common::Input::CallbackStatus& callback_) {
+                    UpdateModButtonStatus(callback_);
+                },
+        });
         last_x_axis_value = 0.0f;
         last_y_axis_value = 0.0f;
     }
@@ -133,27 +146,27 @@ public:
         }
     }
 
-    void UpdateUpButtonStatus(Common::Input::CallbackStatus button_callback) {
+    void UpdateUpButtonStatus(const Common::Input::CallbackStatus& button_callback) {
         up_status = button_callback.button_status.value;
         UpdateStatus();
     }
 
-    void UpdateDownButtonStatus(Common::Input::CallbackStatus button_callback) {
+    void UpdateDownButtonStatus(const Common::Input::CallbackStatus& button_callback) {
         down_status = button_callback.button_status.value;
         UpdateStatus();
     }
 
-    void UpdateLeftButtonStatus(Common::Input::CallbackStatus button_callback) {
+    void UpdateLeftButtonStatus(const Common::Input::CallbackStatus& button_callback) {
         left_status = button_callback.button_status.value;
         UpdateStatus();
     }
 
-    void UpdateRightButtonStatus(Common::Input::CallbackStatus button_callback) {
+    void UpdateRightButtonStatus(const Common::Input::CallbackStatus& button_callback) {
         right_status = button_callback.button_status.value;
         UpdateStatus();
     }
 
-    void UpdateModButtonStatus(Common::Input::CallbackStatus button_callback) {
+    void UpdateModButtonStatus(const Common::Input::CallbackStatus& button_callback) {
         modifier_status = button_callback.button_status.value;
         UpdateStatus();
     }
@@ -265,18 +278,18 @@ private:
     Button left;
     Button right;
     Button modifier;
-    float modifier_scale;
-    float modifier_angle;
+    float modifier_scale{};
+    float modifier_angle{};
     float angle{};
     float goal_angle{};
     float amplitude{};
-    bool up_status;
-    bool down_status;
-    bool left_status;
-    bool right_status;
-    bool modifier_status;
-    float last_x_axis_value;
-    float last_y_axis_value;
+    bool up_status{};
+    bool down_status{};
+    bool left_status{};
+    bool right_status{};
+    bool modifier_status{};
+    float last_x_axis_value{};
+    float last_y_axis_value{};
     const Common::Input::AnalogProperties properties{0.0f, 1.0f, 0.5f, 0.0f, false};
     std::chrono::time_point<std::chrono::steady_clock> last_update;
 };

--- a/src/input_common/helpers/touch_from_buttons.cpp
+++ b/src/input_common/helpers/touch_from_buttons.cpp
@@ -14,10 +14,13 @@ public:
     using Button = std::unique_ptr<Common::Input::InputDevice>;
     TouchFromButtonDevice(Button button_, int touch_id_, float x_, float y_)
         : button(std::move(button_)), touch_id(touch_id_), x(x_), y(y_) {
-        Common::Input::InputCallback button_up_callback{
-            [this](Common::Input::CallbackStatus callback_) { UpdateButtonStatus(callback_); }};
         last_button_value = false;
-        button->SetCallback(button_up_callback);
+        button->SetCallback({
+            .on_change =
+                [this](const Common::Input::CallbackStatus& callback_) {
+                    UpdateButtonStatus(callback_);
+                },
+        });
         button->ForceUpdate();
     }
 
@@ -47,7 +50,7 @@ public:
         return status;
     }
 
-    void UpdateButtonStatus(Common::Input::CallbackStatus button_callback) {
+    void UpdateButtonStatus(const Common::Input::CallbackStatus& button_callback) {
         const Common::Input::CallbackStatus status{
             .type = Common::Input::InputType::Touch,
             .touch_status = GetStatus(button_callback.button_status.value),

--- a/src/input_common/input_poller.cpp
+++ b/src/input_common/input_poller.cpp
@@ -12,8 +12,7 @@ namespace InputCommon {
 
 class DummyInput final : public Common::Input::InputDevice {
 public:
-    explicit DummyInput() {}
-    ~DummyInput() {}
+    explicit DummyInput() = default;
 };
 
 class InputFromButton final : public Common::Input::InputDevice {
@@ -33,7 +32,7 @@ public:
         callback_key = input_engine->SetCallback(input_identifier);
     }
 
-    ~InputFromButton() {
+    ~InputFromButton() override {
         input_engine->DeleteCallback(callback_key);
     }
 
@@ -45,7 +44,7 @@ public:
         };
     }
 
-    void ForceUpdate() {
+    void ForceUpdate() override {
         const Common::Input::CallbackStatus status{
             .type = Common::Input::InputType::Button,
             .button_status = GetStatus(),
@@ -94,7 +93,7 @@ public:
         callback_key = input_engine->SetCallback(input_identifier);
     }
 
-    ~InputFromHatButton() {
+    ~InputFromHatButton() override {
         input_engine->DeleteCallback(callback_key);
     }
 
@@ -106,7 +105,7 @@ public:
         };
     }
 
-    void ForceUpdate() {
+    void ForceUpdate() override {
         const Common::Input::CallbackStatus status{
             .type = Common::Input::InputType::Button,
             .button_status = GetStatus(),
@@ -167,7 +166,7 @@ public:
         callback_key_y = input_engine->SetCallback(y_input_identifier);
     }
 
-    ~InputFromStick() {
+    ~InputFromStick() override {
         input_engine->DeleteCallback(callback_key_x);
         input_engine->DeleteCallback(callback_key_y);
     }
@@ -190,7 +189,7 @@ public:
         return status;
     }
 
-    void ForceUpdate() {
+    void ForceUpdate() override {
         const Common::Input::CallbackStatus status{
             .type = Common::Input::InputType::Stick,
             .stick_status = GetStatus(),
@@ -266,7 +265,7 @@ public:
         callback_key_y = input_engine->SetCallback(y_input_identifier);
     }
 
-    ~InputFromTouch() {
+    ~InputFromTouch() override {
         input_engine->DeleteCallback(callback_key_button);
         input_engine->DeleteCallback(callback_key_x);
         input_engine->DeleteCallback(callback_key_y);
@@ -352,7 +351,7 @@ public:
         axis_callback_key = input_engine->SetCallback(axis_input_identifier);
     }
 
-    ~InputFromTrigger() {
+    ~InputFromTrigger() override {
         input_engine->DeleteCallback(callback_key_button);
         input_engine->DeleteCallback(axis_callback_key);
     }
@@ -419,7 +418,7 @@ public:
         callback_key = input_engine->SetCallback(input_identifier);
     }
 
-    ~InputFromAnalog() {
+    ~InputFromAnalog() override {
         input_engine->DeleteCallback(callback_key);
     }
 
@@ -466,7 +465,7 @@ public:
         callback_key = input_engine->SetCallback(input_identifier);
     }
 
-    ~InputFromBattery() {
+    ~InputFromBattery() override {
         input_engine->DeleteCallback(callback_key);
     }
 
@@ -474,7 +473,7 @@ public:
         return static_cast<Common::Input::BatteryLevel>(input_engine->GetBattery(identifier));
     }
 
-    void ForceUpdate() {
+    void ForceUpdate() override {
         const Common::Input::CallbackStatus status{
             .type = Common::Input::InputType::Battery,
             .battery_status = GetStatus(),
@@ -518,7 +517,7 @@ public:
         callback_key = input_engine->SetCallback(input_identifier);
     }
 
-    ~InputFromMotion() {
+    ~InputFromMotion() override {
         input_engine->DeleteCallback(callback_key);
     }
 
@@ -593,7 +592,7 @@ public:
         callback_key_z = input_engine->SetCallback(z_input_identifier);
     }
 
-    ~InputFromAxisMotion() {
+    ~InputFromAxisMotion() override {
         input_engine->DeleteCallback(callback_key_x);
         input_engine->DeleteCallback(callback_key_y);
         input_engine->DeleteCallback(callback_key_z);
@@ -618,7 +617,7 @@ public:
         return status;
     }
 
-    void ForceUpdate() {
+    void ForceUpdate() override {
         const Common::Input::CallbackStatus status{
             .type = Common::Input::InputType::Motion,
             .motion_status = GetStatus(),
@@ -668,16 +667,16 @@ public:
     explicit OutputFromIdentifier(PadIdentifier identifier_, InputEngine* input_engine_)
         : identifier(identifier_), input_engine(input_engine_) {}
 
-    virtual void SetLED(const Common::Input::LedStatus& led_status) {
+    void SetLED(const Common::Input::LedStatus& led_status) override {
         input_engine->SetLeds(identifier, led_status);
     }
 
-    virtual Common::Input::VibrationError SetVibration(
-        const Common::Input::VibrationStatus& vibration_status) {
+    Common::Input::VibrationError SetVibration(
+        const Common::Input::VibrationStatus& vibration_status) override {
         return input_engine->SetRumble(identifier, vibration_status);
     }
 
-    virtual Common::Input::PollingError SetPollingMode(Common::Input::PollingMode polling_mode) {
+    Common::Input::PollingError SetPollingMode(Common::Input::PollingMode polling_mode) override {
         return input_engine->SetPollingMode(identifier, polling_mode);
     }
 


### PR DESCRIPTION
CallbackStatus instances aren't the cheapest things to copy around (relative to everything else), given that they're currently 520 bytes in size and are currently copied numerous times when callbacks are invoked.

Instead, we can pass the status by const reference to avoid all the copying.