### PR TITLE
core/hid: Cancel any vibration after the test

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -843,23 +843,18 @@ bool EmulatedController::SetVibration(std::size_t device_index, VibrationValue v
 }
 
 bool EmulatedController::TestVibration(std::size_t device_index) {
-    if (device_index >= output_devices.size()) {
-        return false;
-    }
-    if (!output_devices[device_index]) {
-        return false;
-    }
-
-    // Send a slight vibration to test for rumble support
-    constexpr Common::Input::VibrationStatus status = {
+    static constexpr VibrationValue test_vibration = {
         .low_amplitude = 0.001f,
         .low_frequency = 160.0f,
         .high_amplitude = 0.001f,
         .high_frequency = 320.0f,
-        .type = Common::Input::VibrationAmplificationType::Linear,
     };
-    return output_devices[device_index]->SetVibration(status) ==
-           Common::Input::VibrationError::None;
+
+    // Send a slight vibration to test for rumble support
+    SetVibration(device_index, test_vibration);
+
+    // Stop any vibration and return the result
+    return SetVibration(device_index, DEFAULT_VIBRATION_VALUE);
 }
 
 void EmulatedController::SetLedPattern() {

--- a/src/core/hid/hid_types.h
+++ b/src/core/hid/hid_types.h
@@ -496,6 +496,13 @@ struct VibrationValue {
 };
 static_assert(sizeof(VibrationValue) == 0x10, "VibrationValue has incorrect size.");
 
+constexpr VibrationValue DEFAULT_VIBRATION_VALUE{
+    .low_amplitude = 0.0f,
+    .low_frequency = 160.0f,
+    .high_amplitude = 0.0f,
+    .high_frequency = 320.0f,
+};
+
 // This is nn::hid::VibrationDeviceInfo
 struct VibrationDeviceInfo {
     VibrationDeviceType type{};

--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -66,9 +66,9 @@ Controller_NPad::Controller_NPad(Core::HID::HIDCore& hid_core_,
         auto& controller = controller_data[i];
         controller.device = hid_core.GetEmulatedControllerByIndex(i);
         controller.vibration[Core::HID::EmulatedDeviceIndex::LeftIndex].latest_vibration_value =
-            DEFAULT_VIBRATION_VALUE;
+            Core::HID::DEFAULT_VIBRATION_VALUE;
         controller.vibration[Core::HID::EmulatedDeviceIndex::RightIndex].latest_vibration_value =
-            DEFAULT_VIBRATION_VALUE;
+            Core::HID::DEFAULT_VIBRATION_VALUE;
         Core::HID::ControllerUpdateCallback engine_callback{
             .on_change = [this,
                           i](Core::HID::ControllerTriggerType type) { ControllerUpdate(type, i); },
@@ -781,7 +781,8 @@ bool Controller_NPad::VibrateControllerAtIndex(Core::HID::NpadIdType npad_id,
             Core::HID::VibrationValue vibration{0.0f, 160.0f, 0.0f, 320.0f};
             controller.device->SetVibration(device_index, vibration);
             // Then reset the vibration value to its default value.
-            controller.vibration[device_index].latest_vibration_value = DEFAULT_VIBRATION_VALUE;
+            controller.vibration[device_index].latest_vibration_value =
+                Core::HID::DEFAULT_VIBRATION_VALUE;
         }
 
         return false;

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -90,13 +90,6 @@ public:
         Default = 3,
     };
 
-    static constexpr Core::HID::VibrationValue DEFAULT_VIBRATION_VALUE{
-        .low_amplitude = 0.0f,
-        .low_frequency = 160.0f,
-        .high_amplitude = 0.0f,
-        .high_frequency = 320.0f,
-    };
-
     void SetSupportedStyleSet(Core::HID::NpadStyleTag style_set);
     Core::HID::NpadStyleTag GetSupportedStyleSet() const;
 

--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -1404,7 +1404,7 @@ void Hid::SendVibrationGcErmCommand(Kernel::HLERequestContext& ctx) {
                 .high_frequency = 0.0f,
             };
         default:
-            return Controller_NPad::DEFAULT_VIBRATION_VALUE;
+            return Core::HID::DEFAULT_VIBRATION_VALUE;
         }
     }();
 


### PR DESCRIPTION
Some games test the device rumble all the time. Resulting in an unpleasant continuous rumble. To avoid this we set the amplitude to zero after the test