### PR TITLE
externals/CMakeLists: fix detection/init of Switch controllers in SDL 2.0.18

### DIFF
--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -52,12 +52,12 @@ endif()
 # SDL2
 if (YUZU_USE_EXTERNAL_SDL2)
     if (NOT WIN32)
-        # Yuzu itself needs: Events Joystick Haptic Sensor Timers Audio Threads Atomic
-        # Since 2.0.18 Threads/Atomic required for HIDAPI/libusb (see https://github.com/libsdl-org/SDL/issues/5095)
+        # Yuzu itself needs: Atomic Audio Events Joystick Haptic Sensor Threads Timers
+        # Since 2.0.18 Atomic+Threads required for HIDAPI/libusb (see https://github.com/libsdl-org/SDL/issues/5095)
         # Yuzu-cmd also needs: Video (depends on Loadso/Dlopen)
         set(SDL_UNUSED_SUBSYSTEMS
-            Render Power File CPUinfo
-            Filesystem Locale)
+            CPUinfo File Filesystem
+            Locale Power Render)
         foreach(_SUB ${SDL_UNUSED_SUBSYSTEMS})
           string(TOUPPER ${_SUB} _OPT)
           option(SDL_${_OPT} "" OFF)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -52,11 +52,12 @@ endif()
 # SDL2
 if (YUZU_USE_EXTERNAL_SDL2)
     if (NOT WIN32)
-        # Yuzu itself needs: Events Joystick Haptic Sensor Timers Audio
+        # Yuzu itself needs: Events Joystick Haptic Sensor Timers Audio Threads Atomic
+        # Since 2.0.18 Threads/Atomic required for HIDAPI/libusb (see https://github.com/libsdl-org/SDL/issues/5095)
         # Yuzu-cmd also needs: Video (depends on Loadso/Dlopen)
         set(SDL_UNUSED_SUBSYSTEMS
-            Atomic Render Power Threads
-            File CPUinfo Filesystem Locale)
+            Render Power File CPUinfo
+            Filesystem Locale)
         foreach(_SUB ${SDL_UNUSED_SUBSYSTEMS})
           string(TOUPPER ${_SUB} _OPT)
           option(SDL_${_OPT} "" OFF)


### PR DESCRIPTION
The latest Linux builds do not see my Switch Pro Controller. @v1993 also confirms that joycons are not seen. It shows ` input_common/drivers/sdl_driver.cpp:InitJoystick:287: Failed to open joystick 0`.

Enable `SDL_THREADS` and `SDL_ATOMIC`. They are now required explicitly since 2.0.18  to have HIDAPI and libusb work.

Set `SDL_WAYLAND=OFF` due to [build issue](https://github.com/libsdl-org/SDL/commit/e2ade2bfc46d915cd306c63c830b81d800b2575f) (patch is not available in 2.0.18).

[Related issue](https://github.com/libsdl-org/SDL/issues/5095)