### PR TITLE
build: enable VA-API on FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,7 +508,7 @@ set(FFmpeg_COMPONENTS
     avutil
     swscale)
 
-if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
+if (UNIX AND NOT APPLE)
     Include(FindPkgConfig REQUIRED)
     pkg_check_modules(LIBVA libva)
 endif()

--- a/src/video_core/command_classes/codecs/codec.cpp
+++ b/src/video_core/command_classes/codecs/codec.cpp
@@ -32,7 +32,7 @@ constexpr std::array PREFERRED_GPU_DECODERS = {
 #ifdef _WIN32
     AV_HWDEVICE_TYPE_D3D11VA,
     AV_HWDEVICE_TYPE_DXVA2,
-#elif defined(__linux__)
+#elif defined(__unix__)
     AV_HWDEVICE_TYPE_VAAPI,
     AV_HWDEVICE_TYPE_VDPAU,
 #endif


### PR DESCRIPTION
VA-API drivers for Intel/AMD GPUs exist on DragonFly, FreeBSD, NetBSD , OpenBSD and probably more. NVIDIA even provides the binary blob for FreeBSD and Solaris. Let's relax the conditionals.

See also [build log](http://www.ipv6proxy.net/go.php?u=http://beefy14.nyi.freebsd.org/data/130amd64-quarterly/300ff0bddeaa/logs/yuzu-qt5-s20211218.log).
