### PR TITLE
kernel: Manually destroy the current process during shut down

### DIFF
--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -182,7 +182,10 @@ struct KernelCore::Impl {
         // Shutdown all processes.
         if (current_process) {
             current_process->Finalize();
-            current_process->Close();
+            // current_process->Close();
+            // TODO: The current process should be destroyed based on accurate ref counting after
+            // calling Close(). Adding a manual Destroy() call instead to avoid a memory leak.
+            current_process->Destroy();
             current_process = nullptr;
         }
 


### PR DESCRIPTION
Avoids a memory leak after stopping emulation.

Before:
![leak_before](https://user-images.githubusercontent.com/52414509/146666366-a8ef8203-579a-4c05-a583-b3d3c45c0de0.PNG)

After:
![leak_after](https://user-images.githubusercontent.com/52414509/146666369-89747c62-038a-48b4-827c-afb598a1866b.PNG)

closes #7562