### PR TITLE
Add support for linking against system Opus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ option(ENABLE_CUBEB "Enables the cubeb audio backend" ON)
 
 option(USE_DISCORD_PRESENCE "Enables Discord Rich Presence" OFF)
 
+option(YUZU_USE_BUNDLED_OPUS "Compile bundled opus" ON)
+
 # Default to a Release build
 get_property(IS_MULTI_CONFIG GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if (NOT IS_MULTI_CONFIG AND NOT CMAKE_BUILD_TYPE)

--- a/externals/CMakeLists.txt
+++ b/externals/CMakeLists.txt
@@ -116,8 +116,8 @@ if (ENABLE_WEB_SERVICE)
 endif()
 
 # Opus
-find_package(opus 1.3)
-if (NOT opus_FOUND)
-    message(STATUS "opus 1.3 or newer not found, falling back to externals")
+if (YUZU_USE_BUNDLED_OPUS)
     add_subdirectory(opus EXCLUDE_FROM_ALL)
+else()
+    find_package(opus 1.3 REQUIRED)
 endif()


### PR DESCRIPTION
Adds support for the following system libs with CMake defines:

* opus - `YUZU_USE_BUNDLED_OPUS=OFF`

~~I have been using this patch since about the beginning of this year with over 99 different builds spanning every yuzu-mainline tag since then. I have not experienced any issues using system libs for these vs the bundled.~~
