### PR TITLE
hle: kernel: svc: GetInfo: Fix error checking with IdleTickCount.

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -880,22 +880,17 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, Handle
         return ResultSuccess;
     }
     case GetInfoType::IdleTickCount: {
-        if (handle == 0) {
-            LOG_ERROR(Kernel_SVC, "Thread handle does not exist, handle=0x{:08X}",
-                      static_cast<Handle>(handle));
-            return ResultInvalidHandle;
-        }
+        // Verify the input handle is invalid.
+        R_UNLESS(handle == InvalidHandle, ResultInvalidHandle);
 
-        if (info_sub_id != 0xFFFFFFFFFFFFFFFF &&
-            info_sub_id != system.Kernel().CurrentPhysicalCoreIndex()) {
-            LOG_ERROR(Kernel_SVC, "Core is not the current core, got {}", info_sub_id);
-            return ResultInvalidCombination;
-        }
+        // Verify the requested core is valid.
+        const bool core_valid =
+            (info_sub_id == static_cast<u64>(-1ULL)) ||
+            (info_sub_id == static_cast<u64>(system.Kernel().CurrentPhysicalCoreIndex()));
+        R_UNLESS(core_valid, ResultInvalidCombination);
 
-        const auto& scheduler = *system.Kernel().CurrentScheduler();
-        const auto* const idle_thread = scheduler.GetIdleThread();
-
-        *result = idle_thread->GetCpuTime();
+        // Get the idle tick count.
+        *result = system.Kernel().CurrentScheduler()->GetIdleThread()->GetCpuTime();
         return ResultSuccess;
     }
     default:


### PR DESCRIPTION
- Enforce that the supplied handle is invalid, not valid.
- This gets Witcher 3 booting.

Note, lots of graphical issues, but it will now go in game with OpenGL.

![image](https://user-images.githubusercontent.com/6956688/147047529-f1619986-bab6-4b54-b903-7e74136b5846.png)
![image](https://user-images.githubusercontent.com/6956688/147047541-4f57b855-cc0c-4c6b-83ca-59cd8d456aa0.png)
