### PR TITLE
vk_texture_cache: Use 3D scale helpers for MSAA texture scaling on Intel Windows drivers

### DIFF
--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -148,6 +148,8 @@ public:
 private:
     bool BlitScaleHelper(bool scale_up);
 
+    bool NeedsScaleHelper() const;
+
     VKScheduler* scheduler{};
     TextureCacheRuntime* runtime{};
 

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -638,14 +638,19 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
         }
     }
 
-    if (ext_vertex_input_dynamic_state && driver_id == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS) {
+    const bool is_intel_windows = driver_id == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS;
+    if (ext_vertex_input_dynamic_state && is_intel_windows) {
         LOG_WARNING(Render_Vulkan, "Blacklisting Intel for VK_EXT_vertex_input_dynamic_state");
         ext_vertex_input_dynamic_state = false;
     }
-    if (is_float16_supported && driver_id == VK_DRIVER_ID_INTEL_PROPRIETARY_WINDOWS) {
+    if (is_float16_supported && is_intel_windows) {
         // Intel's compiler crashes when using fp16 on Astral Chain, disable it for the time being.
         LOG_WARNING(Render_Vulkan, "Blacklisting Intel proprietary from float16 math");
         is_float16_supported = false;
+    }
+    if (is_intel_windows) {
+        LOG_WARNING(Render_Vulkan, "Intel proprietary drivers do not support MSAA image blits");
+        cant_blit_msaa = true;
     }
 
     supports_d24_depth =

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -350,6 +350,10 @@ public:
         return supports_d24_depth;
     }
 
+    bool CantBlitMSAA() const {
+        return cant_blit_msaa;
+    }
+
 private:
     /// Checks if the physical device is suitable.
     void CheckSuitability(bool requires_swapchain) const;
@@ -443,6 +447,7 @@ private:
     bool has_renderdoc{};                   ///< Has RenderDoc attached
     bool has_nsight_graphics{};             ///< Has Nsight Graphics attached
     bool supports_d24_depth{};              ///< Supports D24 depth buffers.
+    bool cant_blit_msaa{};                  ///< Does not support MSAA<->MSAA blitting.
 
     // Telemetry parameters
     std::string vendor_name;                       ///< Device's driver name.


### PR DESCRIPTION
Fixes a crash when scaling MSAA textures in titles such as Sonic Colors Ultimate.