### PR TITLE
core/hid: Fix controller type validation

### DIFF
--- a/src/core/frontend/applets/controller.cpp
+++ b/src/core/frontend/applets/controller.cpp
@@ -45,26 +45,26 @@ void DefaultControllerApplet::ReconfigureControllers(std::function<void()> callb
         // Pro Controller -> Dual Joycons -> Left Joycon/Right Joycon -> Handheld
         if (parameters.allow_pro_controller) {
             controller->SetNpadStyleIndex(Core::HID::NpadStyleIndex::ProController);
-            controller->Connect();
+            controller->Connect(true);
         } else if (parameters.allow_dual_joycons) {
             controller->SetNpadStyleIndex(Core::HID::NpadStyleIndex::JoyconDual);
-            controller->Connect();
+            controller->Connect(true);
         } else if (parameters.allow_left_joycon && parameters.allow_right_joycon) {
             // Assign left joycons to even player indices and right joycons to odd player indices.
             // We do this since Captain Toad Treasure Tracker expects a left joycon for Player 1 and
             // a right Joycon for Player 2 in 2 Player Assist mode.
             if (index % 2 == 0) {
                 controller->SetNpadStyleIndex(Core::HID::NpadStyleIndex::JoyconLeft);
-                controller->Connect();
+                controller->Connect(true);
             } else {
                 controller->SetNpadStyleIndex(Core::HID::NpadStyleIndex::JoyconRight);
-                controller->Connect();
+                controller->Connect(true);
             }
         } else if (index == 0 && parameters.enable_single_mode && parameters.allow_handheld &&
                    !Settings::values.use_docked_mode.GetValue()) {
             // We should *never* reach here under any normal circumstances.
             controller->SetNpadStyleIndex(Core::HID::NpadStyleIndex::Handheld);
-            controller->Connect();
+            controller->Connect(true);
         } else {
             UNREACHABLE_MSG("Unable to add a new controller based on the given parameters!");
         }

--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -886,8 +886,9 @@ void EmulatedController::SetSupportedNpadStyleTag(NpadStyleTag supported_styles)
     }
 }
 
-bool EmulatedController::IsControllerSupported() const {
-    switch (npad_type) {
+bool EmulatedController::IsControllerSupported(bool use_temporary_value) const {
+    const auto type = is_configuring && use_temporary_value ? tmp_npad_type : npad_type;
+    switch (type) {
     case NpadStyleIndex::ProController:
         return supported_style_tag.fullkey;
     case NpadStyleIndex::Handheld:
@@ -915,9 +916,10 @@ bool EmulatedController::IsControllerSupported() const {
     }
 }
 
-void EmulatedController::Connect() {
-    if (!IsControllerSupported()) {
-        LOG_ERROR(Service_HID, "Controller type {} is not supported", npad_type);
+void EmulatedController::Connect(bool use_temporary_value) {
+    if (!IsControllerSupported(use_temporary_value)) {
+        const auto type = is_configuring && use_temporary_value ? tmp_npad_type : npad_type;
+        LOG_ERROR(Service_HID, "Controller type {} is not supported", type);
         return;
     }
     {

--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -167,8 +167,11 @@ public:
      */
     void SetSupportedNpadStyleTag(NpadStyleTag supported_styles);
 
-    /// Sets the connected status to true
-    void Connect();
+    /**
+     * Sets the connected status to true
+     * @param use_temporary_value If true tmp_npad_type will be used
+     */
+    void Connect(bool use_temporary_value = false);
 
     /// Sets the connected status to false
     void Disconnect();
@@ -319,9 +322,10 @@ private:
 
     /**
      * Checks the current controller type against the supported_style_tag
+     * @param use_temporary_value If true tmp_npad_type will be used
      * @return true if the controller is supported
      */
-    bool IsControllerSupported() const;
+    bool IsControllerSupported(bool use_temporary_value = false) const;
 
     /**
      * Updates the button status of the controller

--- a/src/yuzu/applets/qt_controller.cpp
+++ b/src/yuzu/applets/qt_controller.cpp
@@ -33,7 +33,7 @@ void UpdateController(Core::HID::EmulatedController* controller,
     }
     controller->SetNpadStyleIndex(controller_type);
     if (connected) {
-        controller->Connect();
+        controller->Connect(true);
     }
 }
 

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -599,11 +599,11 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
                     if (is_connected) {
                         if (type == Core::HID::NpadStyleIndex::Handheld) {
                             emulated_controller_p1->Disconnect();
-                            emulated_controller_handheld->Connect();
+                            emulated_controller_handheld->Connect(true);
                             emulated_controller = emulated_controller_handheld;
                         } else {
                             emulated_controller_handheld->Disconnect();
-                            emulated_controller_p1->Connect();
+                            emulated_controller_p1->Connect(true);
                             emulated_controller = emulated_controller_p1;
                         }
                     }
@@ -718,7 +718,7 @@ void ConfigureInputPlayer::LoadConfiguration() {
 void ConfigureInputPlayer::ConnectPlayer(bool connected) {
     ui->groupConnectedController->setChecked(connected);
     if (connected) {
-        emulated_controller->Connect();
+        emulated_controller->Connect(true);
     } else {
         emulated_controller->Disconnect();
     }


### PR DESCRIPTION
IsControllerValid() used the real npad type instead of the temporary type. This made imposible to connect controllers during configuring mode if the previous controller was invalid. Fixes 2 player mode on captain toad.