### PR TITLE
video_core/memory_manager: Fixes for sparse memory management

### DIFF
--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -155,6 +155,11 @@ private:
 
     void FlushRegion(GPUVAddr gpu_addr, size_t size) const;
 
+    void ReadBlockImpl(GPUVAddr gpu_src_addr, void* dest_buffer, std::size_t size,
+                       bool is_safe) const;
+    void WriteBlockImpl(GPUVAddr gpu_dest_addr, const void* src_buffer, std::size_t size,
+                        bool is_safe);
+
     [[nodiscard]] static constexpr std::size_t PageEntryIndex(GPUVAddr gpu_addr) {
         return (gpu_addr >> page_bits) & page_table_mask;
     }

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -1376,9 +1376,7 @@ void TextureCache<P>::ForEachSparseSegment(ImageBase& image, Func&& func) {
     using FuncReturn = typename std::invoke_result<Func, GPUVAddr, VAddr, size_t>::type;
     static constexpr bool RETURNS_BOOL = std::is_same_v<FuncReturn, bool>;
     const auto segments = gpu_memory.GetSubmappedRange(image.gpu_addr, image.guest_size_bytes);
-    for (auto& segment : segments) {
-        const auto gpu_addr = segment.first;
-        const auto size = segment.second;
+    for (const auto& [gpu_addr, size] : segments) {
         std::optional<VAddr> cpu_addr = gpu_memory.GpuToCpuAddress(gpu_addr);
         ASSERT(cpu_addr);
         if constexpr (RETURNS_BOOL) {


### PR DESCRIPTION
This fixes a few oversights in memory management for sparse (non-contiguous) GPU backed memory. 

The main issue fixed was in `GetSubmappedRange` which did not account for page offsets in the ranges returned in the result.

It also avoids reading/writing to memory whose CPU backed address is 0, as these are the non-resident portions of the sparse memory regions.

This should fix memory related issues that occur in titles that heavily make use of sparse textures, notably UE4 games.