### PR TITLE
yuzu: Fix UI elements not updating correctly

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1547,6 +1547,8 @@ void GMainWindow::ShutdownGame() {
     emu_thread->wait();
     emu_thread = nullptr;
 
+    emulation_running = false;
+
     discord_rpc->Update();
 
     // The emulation is stopped, so closing the window or not does not matter anymore
@@ -1584,8 +1586,6 @@ void GMainWindow::ShutdownGame() {
     game_fps_label->setVisible(false);
     emu_frametime_label->setVisible(false);
     renderer_status_button->setEnabled(true);
-
-    emulation_running = false;
 
     game_path.clear();
 


### PR DESCRIPTION
Some UI elements like stop/start or configure current game weren't disabled after a game was stopped. To fix this we update the emulation_running flag just after stopping the emu_thread