### PR TITLE
controller_applet: Only populate supported controllers

### DIFF
--- a/src/yuzu/applets/qt_controller.cpp
+++ b/src/yuzu/applets/qt_controller.cpp
@@ -400,36 +400,66 @@ void QtControllerSelectorDialog::SetSupportedControllers() {
 }
 
 void QtControllerSelectorDialog::SetEmulatedControllers(std::size_t player_index) {
+    const auto npad_style_set = system.HIDCore().GetSupportedStyleTag();
     auto& pairs = index_controller_type_pairs[player_index];
 
     pairs.clear();
     emulated_controllers[player_index]->clear();
 
-    pairs.emplace_back(emulated_controllers[player_index]->count(),
-                       Core::HID::NpadStyleIndex::ProController);
-    emulated_controllers[player_index]->addItem(tr("Pro Controller"));
+    const auto add_item = [&](Core::HID::NpadStyleIndex controller_type,
+                              const QString& controller_name) {
+        pairs.emplace_back(emulated_controllers[player_index]->count(), controller_type);
+        emulated_controllers[player_index]->addItem(controller_name);
+    };
 
-    pairs.emplace_back(emulated_controllers[player_index]->count(),
-                       Core::HID::NpadStyleIndex::JoyconDual);
-    emulated_controllers[player_index]->addItem(tr("Dual Joycons"));
-
-    pairs.emplace_back(emulated_controllers[player_index]->count(),
-                       Core::HID::NpadStyleIndex::JoyconLeft);
-    emulated_controllers[player_index]->addItem(tr("Left Joycon"));
-
-    pairs.emplace_back(emulated_controllers[player_index]->count(),
-                       Core::HID::NpadStyleIndex::JoyconRight);
-    emulated_controllers[player_index]->addItem(tr("Right Joycon"));
-
-    if (player_index == 0) {
-        pairs.emplace_back(emulated_controllers[player_index]->count(),
-                           Core::HID::NpadStyleIndex::Handheld);
-        emulated_controllers[player_index]->addItem(tr("Handheld"));
+    if (npad_style_set.fullkey == 1) {
+        add_item(Core::HID::NpadStyleIndex::ProController, tr("Pro Controller"));
     }
 
-    pairs.emplace_back(emulated_controllers[player_index]->count(),
-                       Core::HID::NpadStyleIndex::GameCube);
-    emulated_controllers[player_index]->addItem(tr("GameCube Controller"));
+    if (npad_style_set.joycon_dual == 1) {
+        add_item(Core::HID::NpadStyleIndex::JoyconDual, tr("Dual Joycons"));
+    }
+
+    if (npad_style_set.joycon_left == 1) {
+        add_item(Core::HID::NpadStyleIndex::JoyconLeft, tr("Left Joycon"));
+    }
+
+    if (npad_style_set.joycon_right == 1) {
+        add_item(Core::HID::NpadStyleIndex::JoyconRight, tr("Right Joycon"));
+    }
+
+    if (player_index == 0 && npad_style_set.handheld == 1) {
+        add_item(Core::HID::NpadStyleIndex::Handheld, tr("Handheld"));
+    }
+
+    if (npad_style_set.gamecube == 1) {
+        add_item(Core::HID::NpadStyleIndex::GameCube, tr("GameCube Controller"));
+    }
+
+    // Disable all unsupported controllers
+    if (!Settings::values.enable_all_controllers) {
+        return;
+    }
+
+    if (npad_style_set.palma == 1) {
+        add_item(Core::HID::NpadStyleIndex::Pokeball, tr("Poke Ball Plus"));
+    }
+
+    if (npad_style_set.lark == 1) {
+        add_item(Core::HID::NpadStyleIndex::NES, tr("NES Controller"));
+    }
+
+    if (npad_style_set.lucia == 1) {
+        add_item(Core::HID::NpadStyleIndex::SNES, tr("SNES Controller"));
+    }
+
+    if (npad_style_set.lagoon == 1) {
+        add_item(Core::HID::NpadStyleIndex::N64, tr("N64 Controller"));
+    }
+
+    if (npad_style_set.lager == 1) {
+        add_item(Core::HID::NpadStyleIndex::SegaGenesis, tr("Sega Genesis"));
+    }
 }
 
 Core::HID::NpadStyleIndex QtControllerSelectorDialog::GetControllerTypeFromIndex(

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -907,78 +907,63 @@ void ConfigureInputPlayer::UpdateUI() {
 }
 
 void ConfigureInputPlayer::SetConnectableControllers() {
-    Core::HID::NpadStyleTag npad_style_set = hid_core.GetSupportedStyleTag();
+    const auto npad_style_set = hid_core.GetSupportedStyleTag();
     index_controller_type_pairs.clear();
     ui->comboControllerType->clear();
 
+    const auto add_item = [&](Core::HID::NpadStyleIndex controller_type,
+                              const QString& controller_name) {
+        index_controller_type_pairs.emplace_back(ui->comboControllerType->count(), controller_type);
+        ui->comboControllerType->addItem(controller_name);
+    };
+
     if (npad_style_set.fullkey == 1) {
-        index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
-                                                 Core::HID::NpadStyleIndex::ProController);
-        ui->comboControllerType->addItem(tr("Pro Controller"));
+        add_item(Core::HID::NpadStyleIndex::ProController, tr("Pro Controller"));
     }
 
     if (npad_style_set.joycon_dual == 1) {
-        index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
-                                                 Core::HID::NpadStyleIndex::JoyconDual);
-        ui->comboControllerType->addItem(tr("Dual Joycons"));
+        add_item(Core::HID::NpadStyleIndex::JoyconDual, tr("Dual Joycons"));
     }
 
     if (npad_style_set.joycon_left == 1) {
-        index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
-                                                 Core::HID::NpadStyleIndex::JoyconLeft);
-        ui->comboControllerType->addItem(tr("Left Joycon"));
+        add_item(Core::HID::NpadStyleIndex::JoyconLeft, tr("Left Joycon"));
     }
 
     if (npad_style_set.joycon_right == 1) {
-        index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
-                                                 Core::HID::NpadStyleIndex::JoyconRight);
-        ui->comboControllerType->addItem(tr("Right Joycon"));
+        add_item(Core::HID::NpadStyleIndex::JoyconRight, tr("Right Joycon"));
     }
 
     if (player_index == 0 && npad_style_set.handheld == 1) {
-        index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
-                                                 Core::HID::NpadStyleIndex::Handheld);
-        ui->comboControllerType->addItem(tr("Handheld"));
+        add_item(Core::HID::NpadStyleIndex::Handheld, tr("Handheld"));
     }
 
     if (npad_style_set.gamecube == 1) {
-        index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
-                                                 Core::HID::NpadStyleIndex::GameCube);
-        ui->comboControllerType->addItem(tr("GameCube Controller"));
+        add_item(Core::HID::NpadStyleIndex::GameCube, tr("GameCube Controller"));
     }
 
     // Disable all unsupported controllers
     if (!Settings::values.enable_all_controllers) {
         return;
     }
+
     if (npad_style_set.palma == 1) {
-        index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
-                                                 Core::HID::NpadStyleIndex::Pokeball);
-        ui->comboControllerType->addItem(tr("Poke Ball Plus"));
+        add_item(Core::HID::NpadStyleIndex::Pokeball, tr("Poke Ball Plus"));
     }
 
     if (npad_style_set.lark == 1) {
-        index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
-                                                 Core::HID::NpadStyleIndex::NES);
-        ui->comboControllerType->addItem(tr("NES Controller"));
+        add_item(Core::HID::NpadStyleIndex::NES, tr("NES Controller"));
     }
 
     if (npad_style_set.lucia == 1) {
-        index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
-                                                 Core::HID::NpadStyleIndex::SNES);
-        ui->comboControllerType->addItem(tr("SNES Controller"));
+        add_item(Core::HID::NpadStyleIndex::SNES, tr("SNES Controller"));
     }
 
     if (npad_style_set.lagoon == 1) {
-        index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
-                                                 Core::HID::NpadStyleIndex::N64);
-        ui->comboControllerType->addItem(tr("N64 Controller"));
+        add_item(Core::HID::NpadStyleIndex::N64, tr("N64 Controller"));
     }
 
     if (npad_style_set.lager == 1) {
-        index_controller_type_pairs.emplace_back(ui->comboControllerType->count(),
-                                                 Core::HID::NpadStyleIndex::SegaGenesis);
-        ui->comboControllerType->addItem(tr("Sega Genesis"));
+        add_item(Core::HID::NpadStyleIndex::SegaGenesis, tr("Sega Genesis"));
     }
 }
 


### PR DESCRIPTION
There is no need to display all controller types if game only allows a few.