### PR TITLE
core/hid: Add fallback to fullkey controllers

### DIFF
--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -321,6 +321,12 @@ private:
     void LoadTASParams();
 
     /**
+     * @param use_temporary_value If true tmp_npad_type will be used
+     * @return true if the controller style is fullkey
+     */
+    bool IsControllerFullkey(bool use_temporary_value = false) const;
+
+    /**
      * Checks the current controller type against the supported_style_tag
      * @param use_temporary_value If true tmp_npad_type will be used
      * @return true if the controller is supported


### PR DESCRIPTION
Fullkey controllers fallback to pro controllers in real HW. We currently don't do that. To avoid this issue we reconnect the controller as Pro controller to avoid having to open the config window.