### PR TITLE
input_common: Fix UDP controller mappings

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -389,7 +389,8 @@ std::vector<Common::ParamPackage> EmulatedController::GetMappedDevices(
             devices.begin(), devices.end(), [param](const Common::ParamPackage param_) {
                 return param.Get("engine", "") == param_.Get("engine", "") &&
                        param.Get("guid", "") == param_.Get("guid", "") &&
-                       param.Get("port", 0) == param_.Get("port", 0);
+                       param.Get("port", 0) == param_.Get("port", 0) &&
+                       param.Get("pad", 0) == param_.Get("pad", 0);
             });
         if (devices_it != devices.end()) {
             continue;
@@ -398,6 +399,7 @@ std::vector<Common::ParamPackage> EmulatedController::GetMappedDevices(
         device.Set("engine", param.Get("engine", ""));
         device.Set("guid", param.Get("guid", ""));
         device.Set("port", param.Get("port", 0));
+        device.Set("pad", param.Get("pad", 0));
         devices.push_back(device);
     }
 
@@ -412,7 +414,8 @@ std::vector<Common::ParamPackage> EmulatedController::GetMappedDevices(
             devices.begin(), devices.end(), [param](const Common::ParamPackage param_) {
                 return param.Get("engine", "") == param_.Get("engine", "") &&
                        param.Get("guid", "") == param_.Get("guid", "") &&
-                       param.Get("port", 0) == param_.Get("port", 0);
+                       param.Get("port", 0) == param_.Get("port", 0) &&
+                       param.Get("pad", 0) == param_.Get("pad", 0);
             });
         if (devices_it != devices.end()) {
             continue;
@@ -421,6 +424,7 @@ std::vector<Common::ParamPackage> EmulatedController::GetMappedDevices(
         device.Set("engine", param.Get("engine", ""));
         device.Set("guid", param.Get("guid", ""));
         device.Set("port", param.Get("port", 0));
+        device.Set("pad", param.Get("pad", 0));
         devices.push_back(device);
     }
     return devices;

--- a/src/input_common/drivers/udp_client.cpp
+++ b/src/input_common/drivers/udp_client.cpp
@@ -442,14 +442,22 @@ MotionMapping UDPClient::GetMotionMappingForDevice(const Common::ParamPackage& p
     }
 
     MotionMapping mapping = {};
-    Common::ParamPackage motion_params;
-    motion_params.Set("engine", GetEngineName());
-    motion_params.Set("guid", params.Get("guid", ""));
-    motion_params.Set("port", params.Get("port", 0));
-    motion_params.Set("pad", params.Get("pad", 0));
-    motion_params.Set("motion", 0);
-    mapping.insert_or_assign(Settings::NativeMotion::MotionLeft, std::move(motion_params));
-    mapping.insert_or_assign(Settings::NativeMotion::MotionRight, std::move(motion_params));
+    Common::ParamPackage left_motion_params;
+    left_motion_params.Set("engine", GetEngineName());
+    left_motion_params.Set("guid", params.Get("guid", ""));
+    left_motion_params.Set("port", params.Get("port", 0));
+    left_motion_params.Set("pad", params.Get("pad", 0));
+    left_motion_params.Set("motion", 0);
+
+    Common::ParamPackage right_motion_params;
+    right_motion_params.Set("engine", GetEngineName());
+    right_motion_params.Set("guid", params.Get("guid", ""));
+    right_motion_params.Set("port", params.Get("port", 0));
+    right_motion_params.Set("pad", params.Get("pad", 0));
+    right_motion_params.Set("motion", 0);
+
+    mapping.insert_or_assign(Settings::NativeMotion::MotionLeft, std::move(left_motion_params));
+    mapping.insert_or_assign(Settings::NativeMotion::MotionRight, std::move(right_motion_params));
     return mapping;
 }
 

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -747,15 +747,16 @@ void ConfigureInputPlayer::UpdateInputDeviceCombobox() {
     const auto first_engine = devices[0].Get("engine", "");
     const auto first_guid = devices[0].Get("guid", "");
     const auto first_port = devices[0].Get("port", 0);
+    const auto first_pad = devices[0].Get("pad", 0);
 
     if (devices.size() == 1) {
-        const auto devices_it =
-            std::find_if(input_devices.begin(), input_devices.end(),
-                         [first_engine, first_guid, first_port](const Common::ParamPackage param) {
-                             return param.Get("engine", "") == first_engine &&
-                                    param.Get("guid", "") == first_guid &&
-                                    param.Get("port", 0) == first_port;
-                         });
+        const auto devices_it = std::find_if(
+            input_devices.begin(), input_devices.end(),
+            [first_engine, first_guid, first_port, first_pad](const Common::ParamPackage param) {
+                return param.Get("engine", "") == first_engine &&
+                       param.Get("guid", "") == first_guid && param.Get("port", 0) == first_port &&
+                       param.Get("pad", 0) == first_pad;
+            });
         const int device_index =
             devices_it != input_devices.end()
                 ? static_cast<int>(std::distance(input_devices.begin(), devices_it))


### PR DESCRIPTION
Fixes a couple of problems with UDP controllers. Where motion wasn't automapped and manually mapping a button will reset the selected device to the UDP controller 0

Thanks to @v1993 for detecting the issues