### PR TITLE
video_core: changes in garbage collector config, added item to GUI

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -61,6 +61,7 @@ void LogSettings() {
     log_setting("Renderer_UseVsync", values.use_vsync.GetValue());
     log_setting("Renderer_ShaderBackend", values.shader_backend.GetValue());
     log_setting("Renderer_UseAsynchronousShaders", values.use_asynchronous_shaders.GetValue());
+    log_setting("Renderer_UseGarbageCollectionAdvanced", values.use_caches_gc_adv.GetValue());
     log_setting("Renderer_AnisotropicFilteringLevel", values.max_anisotropy.GetValue());
     log_setting("Audio_OutputEngine", values.sink_id.GetValue());
     log_setting("Audio_OutputDevice", values.audio_device_id.GetValue());
@@ -193,6 +194,7 @@ void RestoreGlobalState(bool is_powered_on) {
     values.shader_backend.SetGlobal(true);
     values.use_asynchronous_shaders.SetGlobal(true);
     values.use_fast_gpu_time.SetGlobal(true);
+    values.use_caches_gc_adv.SetGlobal(true);
     values.bg_red.SetGlobal(true);
     values.bg_green.SetGlobal(true);
     values.bg_blue.SetGlobal(true);

--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -530,6 +530,7 @@ struct Values {
                                                 ShaderBackend::SPIRV, "shader_backend"};
     Setting<bool> use_asynchronous_shaders{false, "use_asynchronous_shaders"};
     Setting<bool> use_fast_gpu_time{true, "use_fast_gpu_time"};
+    Setting<bool> use_caches_gc_adv{false, "use_caches_gc_adv"};
 
     Setting<u8> bg_red{0, "bg_red"};
     Setting<u8> bg_green{0, "bg_green"};

--- a/src/core/telemetry_session.cpp
+++ b/src/core/telemetry_session.cpp
@@ -245,6 +245,8 @@ void TelemetrySession::AddInitialInfo(Loader::AppLoader& app_loader,
              static_cast<u32>(Settings::values.shader_backend.GetValue()));
     AddField(field_type, "Renderer_UseAsynchronousShaders",
              Settings::values.use_asynchronous_shaders.GetValue());
+    AddField(field_type, "Renderer_UseGarbageCollectionAdvanced",
+             Settings::values.use_caches_gc_adv.GetValue());
     AddField(field_type, "System_UseDockedMode", Settings::values.use_docked_mode.GetValue());
 }
 

--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -78,8 +78,8 @@ class BufferCache {
 
     static constexpr BufferId NULL_BUFFER_ID{0};
 
-    static constexpr u64 EXPECTED_MEMORY = 512_MiB;
-    static constexpr u64 CRITICAL_MEMORY = 1_GiB;
+    static constexpr u64 EXPECTED_MEMORY = 1_GiB;
+    static constexpr u64 CRITICAL_MEMORY = 2_GiB;
 
     using Maxwell = Tegra::Engines::Maxwell3D::Regs;
 

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -55,12 +55,10 @@ TextureCache<P>::TextureCache(Runtime& runtime_, VideoCore::RasterizerInterface&
         const u64 possible_critical_memory = (device_memory * 7) / 10;
         expected_memory = std::max(possible_expected_memory, DEFAULT_EXPECTED_MEMORY - 256_MiB);
         critical_memory = std::max(possible_critical_memory, DEFAULT_CRITICAL_MEMORY - 512_MiB);
-        minimum_memory = 0;
     } else {
         // On OpenGL we can be more conservatives as the driver takes care.
         expected_memory = DEFAULT_EXPECTED_MEMORY + 512_MiB;
         critical_memory = DEFAULT_CRITICAL_MEMORY + 1_GiB;
-        minimum_memory = 0;
     }
 }
 
@@ -99,7 +97,7 @@ void TextureCache<P>::RunGarbageCollector() {
 
 template <class P>
 void TextureCache<P>::TickFrame() {
-    if (total_used_memory > minimum_memory) {
+    if (total_used_memory > expected_memory) {
         RunGarbageCollector();
     }
     sentenced_images.Tick();

--- a/src/video_core/texture_cache/texture_cache_base.h
+++ b/src/video_core/texture_cache/texture_cache_base.h
@@ -369,6 +369,7 @@ private:
 
     bool has_deleted_images = false;
     bool is_rescaling = false;
+    bool over_4gb_memory = false;
     u64 total_used_memory = 0;
     u64 expected_memory;
     u64 critical_memory;

--- a/src/video_core/texture_cache/texture_cache_base.h
+++ b/src/video_core/texture_cache/texture_cache_base.h
@@ -370,7 +370,6 @@ private:
     bool has_deleted_images = false;
     bool is_rescaling = false;
     u64 total_used_memory = 0;
-    u64 minimum_memory;
     u64 expected_memory;
     u64 critical_memory;
 

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -645,6 +645,7 @@ void Config::ReadRendererValues() {
     ReadGlobalSetting(Settings::values.shader_backend);
     ReadGlobalSetting(Settings::values.use_asynchronous_shaders);
     ReadGlobalSetting(Settings::values.use_fast_gpu_time);
+    ReadGlobalSetting(Settings::values.use_caches_gc_adv);
     ReadGlobalSetting(Settings::values.bg_red);
     ReadGlobalSetting(Settings::values.bg_green);
     ReadGlobalSetting(Settings::values.bg_blue);
@@ -1192,6 +1193,7 @@ void Config::SaveRendererValues() {
                  Settings::values.shader_backend.UsingGlobal());
     WriteGlobalSetting(Settings::values.use_asynchronous_shaders);
     WriteGlobalSetting(Settings::values.use_fast_gpu_time);
+    WriteGlobalSetting(Settings::values.use_caches_gc_adv);
     WriteGlobalSetting(Settings::values.bg_red);
     WriteGlobalSetting(Settings::values.bg_green);
     WriteGlobalSetting(Settings::values.bg_blue);

--- a/src/yuzu/configuration/configure_graphics_advanced.cpp
+++ b/src/yuzu/configuration/configure_graphics_advanced.cpp
@@ -28,6 +28,7 @@ void ConfigureGraphicsAdvanced::SetConfiguration() {
 
     ui->use_vsync->setChecked(Settings::values.use_vsync.GetValue());
     ui->use_asynchronous_shaders->setChecked(Settings::values.use_asynchronous_shaders.GetValue());
+    ui->use_caches_gc_adv->setChecked(Settings::values.use_caches_gc_adv.GetValue());
     ui->use_fast_gpu_time->setChecked(Settings::values.use_fast_gpu_time.GetValue());
 
     if (Settings::IsConfiguringGlobal()) {
@@ -54,6 +55,8 @@ void ConfigureGraphicsAdvanced::ApplyConfiguration() {
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_asynchronous_shaders,
                                              ui->use_asynchronous_shaders,
                                              use_asynchronous_shaders);
+    ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_caches_gc_adv,
+                                             ui->use_caches_gc_adv, use_caches_gc_adv);
     ConfigurationShared::ApplyPerGameSetting(&Settings::values.use_fast_gpu_time,
                                              ui->use_fast_gpu_time, use_fast_gpu_time);
 }
@@ -78,6 +81,7 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
         ui->use_asynchronous_shaders->setEnabled(
             Settings::values.use_asynchronous_shaders.UsingGlobal());
         ui->use_fast_gpu_time->setEnabled(Settings::values.use_fast_gpu_time.UsingGlobal());
+        ui->use_caches_gc_adv->setEnabled(Settings::values.use_caches_gc_adv.UsingGlobal());
         ui->anisotropic_filtering_combobox->setEnabled(
             Settings::values.max_anisotropy.UsingGlobal());
 
@@ -90,6 +94,8 @@ void ConfigureGraphicsAdvanced::SetupPerGameUI() {
                                             use_asynchronous_shaders);
     ConfigurationShared::SetColoredTristate(ui->use_fast_gpu_time,
                                             Settings::values.use_fast_gpu_time, use_fast_gpu_time);
+    ConfigurationShared::SetColoredTristate(ui->use_caches_gc_adv,
+                                            Settings::values.use_caches_gc_adv, use_caches_gc_adv);
     ConfigurationShared::SetColoredComboBox(
         ui->gpu_accuracy, ui->label_gpu_accuracy,
         static_cast<int>(Settings::values.gpu_accuracy.GetValue(true)));

--- a/src/yuzu/configuration/configure_graphics_advanced.h
+++ b/src/yuzu/configuration/configure_graphics_advanced.h
@@ -40,6 +40,7 @@ private:
     ConfigurationShared::CheckState use_vsync;
     ConfigurationShared::CheckState use_asynchronous_shaders;
     ConfigurationShared::CheckState use_fast_gpu_time;
+    ConfigurationShared::CheckState use_caches_gc_adv;
 
     const Core::System& system;
 };

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -100,6 +100,16 @@
          </widget>
         </item>
         <item>
+         <widget class="QCheckBox" name="use_caches_gc_adv">
+          <property name="toolTip">
+           <string>This will try to unlock more than 4GB of VRAM with a late reset of the least used textures. More stable operation with increased video memory consumption.</string>
+          </property>
+          <property name="text">
+           <string>Advanced GPU Cache Garbage Collection Mode (Hack)</string>
+          </property>
+         </widget>
+        </item>
+        <item>
          <widget class="QWidget" name="af_layout" native="true">
           <layout class="QHBoxLayout" name="horizontalLayout_1">
            <property name="leftMargin">

--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -292,6 +292,7 @@ void Config::ReadValues() {
     ReadSetting("Renderer", Settings::values.nvdec_emulation);
     ReadSetting("Renderer", Settings::values.accelerate_astc);
     ReadSetting("Renderer", Settings::values.use_fast_gpu_time);
+    ReadSetting("Renderer", Settings::values.use_caches_gc_adv);
 
     ReadSetting("Renderer", Settings::values.bg_red);
     ReadSetting("Renderer", Settings::values.bg_green);

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -303,9 +303,9 @@ use_asynchronous_gpu_emulation =
 # 0: Off, 1 (default): On
 use_fast_gpu_time =
 
-# Whether to use garbage collection or not for GPU caches.
+# Whether to use garbage collection or not for GPU caches up max VRAM.
 # 0 (default): Off, 1: On
-use_caches_gc =
+use_caches_gc_adv =
 
 # The clear color for the renderer. What shows up on the sides of the bottom screen.
 # Must be in range of 0-255. Defaults to 0 for all.


### PR DESCRIPTION
1) Changed the modes of operation of the garbage collector (GC) texture cache:
- safe - always enabled if VRAM <= 4GiB, ticks and number of iterations have been changed
- high - call when 40% VRAM is exceeded, ticks and number of iterations have been changed
- aggressive - call when 70% VRAM is exceeded, ticks and number of iterations changed

2) Changed the size of the buffer cache (frequent GC calls were noticed in a number of games)

3) Added GUI settings to call GC only when 70% VRAM is exceeded (aggressive mode - disabled default)

As a result, when tested in the following games:
- ASTRAL CHAIN
- Xenoblade Chronicles 2
- No more heroes 3
managed to achieve smoother work when feeding frames, in particular when using scaling.