### PR TITLE
yuzu: main: Increase the open file limit on Windows to 8192

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3626,8 +3626,8 @@ int main(int argc, char* argv[]) {
     QCoreApplication::setApplicationName(QStringLiteral("yuzu"));
 
 #ifdef _WIN32
-    // Increases the maximum open file limit to 4096
-    _setmaxstdio(4096);
+    // Increases the maximum open file limit to 8192
+    _setmaxstdio(8192);
 #endif
 
 #ifdef __APPLE__


### PR DESCRIPTION
This is a temporary solution for now to accommodate for mods containing more than 4096 files.