### PR TITLE
Kernel Memory Updates (Part 2): SetProcessMemoryPermission, update permissions, and other minor changes.

### DIFF
--- a/src/core/hle/kernel/k_page_table.cpp
+++ b/src/core/hle/kernel/k_page_table.cpp
@@ -298,7 +298,7 @@ ResultCode KPageTable::MapProcessCode(VAddr addr, std::size_t num_pages, KMemory
     return ResultSuccess;
 }
 
-ResultCode KPageTable::MapProcessCodeMemory(VAddr dst_addr, VAddr src_addr, std::size_t size) {
+ResultCode KPageTable::MapCodeMemory(VAddr dst_addr, VAddr src_addr, std::size_t size) {
     std::lock_guard lock{page_table_lock};
 
     const std::size_t num_pages{size / PageSize};
@@ -335,7 +335,7 @@ ResultCode KPageTable::MapProcessCodeMemory(VAddr dst_addr, VAddr src_addr, std:
     return ResultSuccess;
 }
 
-ResultCode KPageTable::UnmapProcessCodeMemory(VAddr dst_addr, VAddr src_addr, std::size_t size) {
+ResultCode KPageTable::UnmapCodeMemory(VAddr dst_addr, VAddr src_addr, std::size_t size) {
     std::lock_guard lock{page_table_lock};
 
     if (!size) {

--- a/src/core/hle/kernel/k_page_table.h
+++ b/src/core/hle/kernel/k_page_table.h
@@ -43,7 +43,8 @@ public:
     ResultCode MapPages(VAddr addr, KPageLinkedList& page_linked_list, KMemoryState state,
                         KMemoryPermission perm);
     ResultCode UnmapPages(VAddr addr, KPageLinkedList& page_linked_list, KMemoryState state);
-    ResultCode SetProcessMemoryPermission(VAddr addr, std::size_t size, KMemoryPermission perm);
+    ResultCode SetProcessMemoryPermission(VAddr addr, std::size_t size,
+                                          Svc::MemoryPermission svc_perm);
     KMemoryInfo QueryInfo(VAddr addr);
     ResultCode ReserveTransferMemory(VAddr addr, std::size_t size, KMemoryPermission perm);
     ResultCode ResetTransferMemory(VAddr addr, std::size_t size);

--- a/src/core/hle/kernel/k_page_table.h
+++ b/src/core/hle/kernel/k_page_table.h
@@ -31,8 +31,8 @@ public:
                                     KMemoryManager::Pool pool);
     ResultCode MapProcessCode(VAddr addr, std::size_t pages_count, KMemoryState state,
                               KMemoryPermission perm);
-    ResultCode MapProcessCodeMemory(VAddr dst_addr, VAddr src_addr, std::size_t size);
-    ResultCode UnmapProcessCodeMemory(VAddr dst_addr, VAddr src_addr, std::size_t size);
+    ResultCode MapCodeMemory(VAddr dst_addr, VAddr src_addr, std::size_t size);
+    ResultCode UnmapCodeMemory(VAddr dst_addr, VAddr src_addr, std::size_t size);
     ResultCode UnmapProcessMemory(VAddr dst_addr, std::size_t size, KPageTable& src_page_table,
                                   VAddr src_addr);
     ResultCode MapPhysicalMemory(VAddr addr, std::size_t size);

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -509,7 +509,7 @@ VAddr KProcess::CreateTLSRegion() {
     const VAddr tls_page_addr{page_table
                                   ->AllocateAndMapMemory(1, PageSize, true, start, size / PageSize,
                                                          KMemoryState::ThreadLocal,
-                                                         KMemoryPermission::ReadAndWrite,
+                                                         KMemoryPermission::UserReadWrite,
                                                          tls_map_addr)
                                   .ValueOr(0)};
 
@@ -550,7 +550,7 @@ void KProcess::LoadModule(CodeSet code_set, VAddr base_addr) {
 
     ReprotectSegment(code_set.CodeSegment(), KMemoryPermission::ReadAndExecute);
     ReprotectSegment(code_set.RODataSegment(), KMemoryPermission::Read);
-    ReprotectSegment(code_set.DataSegment(), KMemoryPermission::ReadAndWrite);
+    ReprotectSegment(code_set.DataSegment(), KMemoryPermission::UserReadWrite);
 }
 
 bool KProcess::IsSignaled() const {
@@ -587,7 +587,7 @@ ResultCode KProcess::AllocateMainThreadStack(std::size_t stack_size) {
     CASCADE_RESULT(main_thread_stack_top,
                    page_table->AllocateAndMapMemory(
                        main_thread_stack_size / PageSize, PageSize, false, start, size / PageSize,
-                       KMemoryState::Stack, KMemoryPermission::ReadAndWrite));
+                       KMemoryState::Stack, KMemoryPermission::UserReadWrite));
 
     main_thread_stack_top += main_thread_stack_size;
 

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -541,16 +541,16 @@ void KProcess::FreeTLSRegion(VAddr tls_address) {
 
 void KProcess::LoadModule(CodeSet code_set, VAddr base_addr) {
     const auto ReprotectSegment = [&](const CodeSet::Segment& segment,
-                                      KMemoryPermission permission) {
+                                      Svc::MemoryPermission permission) {
         page_table->SetProcessMemoryPermission(segment.addr + base_addr, segment.size, permission);
     };
 
     kernel.System().Memory().WriteBlock(*this, base_addr, code_set.memory.data(),
                                         code_set.memory.size());
 
-    ReprotectSegment(code_set.CodeSegment(), KMemoryPermission::ReadAndExecute);
-    ReprotectSegment(code_set.RODataSegment(), KMemoryPermission::Read);
-    ReprotectSegment(code_set.DataSegment(), KMemoryPermission::UserReadWrite);
+    ReprotectSegment(code_set.CodeSegment(), Svc::MemoryPermission::ReadExecute);
+    ReprotectSegment(code_set.RODataSegment(), Svc::MemoryPermission::Read);
+    ReprotectSegment(code_set.DataSegment(), Svc::MemoryPermission::ReadWrite);
 }
 
 bool KProcess::IsSignaled() const {

--- a/src/core/hle/kernel/physical_core.cpp
+++ b/src/core/hle/kernel/physical_core.cpp
@@ -16,17 +16,25 @@ namespace Kernel {
 PhysicalCore::PhysicalCore(std::size_t core_index_, Core::System& system_, KScheduler& scheduler_,
                            Core::CPUInterrupts& interrupts_)
     : core_index{core_index_}, system{system_}, scheduler{scheduler_},
-      interrupts{interrupts_}, guard{std::make_unique<Common::SpinLock>()} {}
+      interrupts{interrupts_}, guard{std::make_unique<Common::SpinLock>()} {
+#ifdef ARCHITECTURE_x86_64
+    // TODO(bunnei): Initialization relies on a core being available. We may later replace this with
+    // a 32-bit instance of Dynarmic. This should be abstracted out to a CPU manager.
+    auto& kernel = system.Kernel();
+    arm_interface = std::make_unique<Core::ARM_Dynarmic_64>(
+        system, interrupts, kernel.IsMulticore(), kernel.GetExclusiveMonitor(), core_index);
+#else
+#error Platform not supported yet.
+#endif
+}
 
 PhysicalCore::~PhysicalCore() = default;
 
 void PhysicalCore::Initialize([[maybe_unused]] bool is_64_bit) {
 #ifdef ARCHITECTURE_x86_64
     auto& kernel = system.Kernel();
-    if (is_64_bit) {
-        arm_interface = std::make_unique<Core::ARM_Dynarmic_64>(
-            system, interrupts, kernel.IsMulticore(), kernel.GetExclusiveMonitor(), core_index);
-    } else {
+    if (!is_64_bit) {
+        // We already initialized a 64-bit core, replace with a 32-bit one.
         arm_interface = std::make_unique<Core::ARM_Dynarmic_32>(
             system, interrupts, kernel.IsMulticore(), kernel.GetExclusiveMonitor(), core_index);
     }

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1626,7 +1626,7 @@ static ResultCode MapProcessCodeMemory(Core::System& system, Handle process_hand
         return ResultInvalidMemoryRegion;
     }
 
-    return page_table.MapProcessCodeMemory(dst_address, src_address, size);
+    return page_table.MapCodeMemory(dst_address, src_address, size);
 }
 
 static ResultCode UnmapProcessCodeMemory(Core::System& system, Handle process_handle,
@@ -1694,7 +1694,7 @@ static ResultCode UnmapProcessCodeMemory(Core::System& system, Handle process_ha
         return ResultInvalidMemoryRegion;
     }
 
-    return page_table.UnmapProcessCodeMemory(dst_address, src_address, size);
+    return page_table.UnmapCodeMemory(dst_address, src_address, size);
 }
 
 /// Exits the current process

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1309,6 +1309,8 @@ static ResultCode SetProcessMemoryPermission(Core::System& system, Handle proces
     R_UNLESS(Common::IsAligned(size, PageSize), ResultInvalidSize);
     R_UNLESS(size > 0, ResultInvalidSize);
     R_UNLESS((address < address + size), ResultInvalidCurrentMemory);
+    R_UNLESS(address == static_cast<uintptr_t>(address), ResultInvalidCurrentMemory);
+    R_UNLESS(size == static_cast<size_t>(size), ResultInvalidCurrentMemory);
 
     // Validate the memory permission.
     R_UNLESS(IsValidProcessMemoryPermission(perm), ResultInvalidNewMemoryPermission);
@@ -1323,7 +1325,7 @@ static ResultCode SetProcessMemoryPermission(Core::System& system, Handle proces
     R_UNLESS(page_table.Contains(address, size), ResultInvalidCurrentMemory);
 
     // Set the memory permission.
-    return page_table.SetProcessMemoryPermission(address, size, ConvertToKMemoryPermission(perm));
+    return page_table.SetProcessMemoryPermission(address, size, perm);
 }
 
 static ResultCode MapProcessMemory(Core::System& system, VAddr dst_address, Handle process_handle,

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -402,7 +402,7 @@ public:
             ro_start, data_start - ro_start, Kernel::KMemoryPermission::Read));
 
         return process->PageTable().SetProcessMemoryPermission(
-            data_start, bss_end_addr - data_start, Kernel::KMemoryPermission::ReadAndWrite);
+            data_start, bss_end_addr - data_start, Kernel::KMemoryPermission::UserReadWrite);
     }
 
     void LoadModule(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -530,9 +530,13 @@ public:
     ResultCode UnmapNro(const NROInfo& info) {
         // Each region must be unmapped separately to validate memory state
         auto& page_table{system.CurrentProcess()->PageTable()};
-        CASCADE_CODE(page_table.UnmapCodeMemory(info.nro_address + info.text_size + info.ro_size +
-                                                    info.data_size,
-                                                info.bss_address, info.bss_size));
+
+        if (info.bss_size != 0) {
+            CASCADE_CODE(page_table.UnmapCodeMemory(info.nro_address + info.text_size +
+                                                        info.ro_size + info.data_size,
+                                                    info.bss_address, info.bss_size));
+        }
+
         CASCADE_CODE(page_table.UnmapCodeMemory(info.nro_address + info.text_size + info.ro_size,
                                                 info.src_addr + info.text_size + info.ro_size,
                                                 info.data_size));

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -325,7 +325,7 @@ public:
         for (std::size_t retry = 0; retry < MAXIMUM_MAP_RETRIES; retry++) {
             auto& page_table{process->PageTable()};
             const VAddr addr{GetRandomMapRegion(page_table, size)};
-            const ResultCode result{page_table.MapProcessCodeMemory(addr, baseAddress, size)};
+            const ResultCode result{page_table.MapCodeMemory(addr, baseAddress, size)};
 
             if (result == Kernel::ResultInvalidCurrentMemory) {
                 continue;
@@ -351,12 +351,12 @@ public:
 
             if (bss_size) {
                 auto block_guard = detail::ScopeExit([&] {
-                    page_table.UnmapProcessCodeMemory(addr + nro_size, bss_addr, bss_size);
-                    page_table.UnmapProcessCodeMemory(addr, nro_addr, nro_size);
+                    page_table.UnmapCodeMemory(addr + nro_size, bss_addr, bss_size);
+                    page_table.UnmapCodeMemory(addr, nro_addr, nro_size);
                 });
 
                 const ResultCode result{
-                    page_table.MapProcessCodeMemory(addr + nro_size, bss_addr, bss_size)};
+                    page_table.MapCodeMemory(addr + nro_size, bss_addr, bss_size)};
 
                 if (result == Kernel::ResultInvalidCurrentMemory) {
                     continue;
@@ -530,16 +530,15 @@ public:
     ResultCode UnmapNro(const NROInfo& info) {
         // Each region must be unmapped separately to validate memory state
         auto& page_table{system.CurrentProcess()->PageTable()};
-        CASCADE_CODE(page_table.UnmapProcessCodeMemory(info.nro_address + info.text_size +
-                                                           info.ro_size + info.data_size,
-                                                       info.bss_address, info.bss_size));
-        CASCADE_CODE(page_table.UnmapProcessCodeMemory(
-            info.nro_address + info.text_size + info.ro_size,
-            info.src_addr + info.text_size + info.ro_size, info.data_size));
-        CASCADE_CODE(page_table.UnmapProcessCodeMemory(
-            info.nro_address + info.text_size, info.src_addr + info.text_size, info.ro_size));
-        CASCADE_CODE(
-            page_table.UnmapProcessCodeMemory(info.nro_address, info.src_addr, info.text_size));
+        CASCADE_CODE(page_table.UnmapCodeMemory(info.nro_address + info.text_size + info.ro_size +
+                                                    info.data_size,
+                                                info.bss_address, info.bss_size));
+        CASCADE_CODE(page_table.UnmapCodeMemory(info.nro_address + info.text_size + info.ro_size,
+                                                info.src_addr + info.text_size + info.ro_size,
+                                                info.data_size));
+        CASCADE_CODE(page_table.UnmapCodeMemory(info.nro_address + info.text_size,
+                                                info.src_addr + info.text_size, info.ro_size));
+        CASCADE_CODE(page_table.UnmapCodeMemory(info.nro_address, info.src_addr, info.text_size));
         return ResultSuccess;
     }
 

--- a/src/core/hle/service/ldr/ldr.cpp
+++ b/src/core/hle/service/ldr/ldr.cpp
@@ -14,6 +14,7 @@
 #include "core/hle/kernel/k_page_table.h"
 #include "core/hle/kernel/k_system_control.h"
 #include "core/hle/kernel/svc_results.h"
+#include "core/hle/kernel/svc_types.h"
 #include "core/hle/service/ldr/ldr.h"
 #include "core/hle/service/service.h"
 #include "core/loader/nro.h"
@@ -397,12 +398,12 @@ public:
                  nro_header.segment_headers[DATA_INDEX].memory_size);
 
         CASCADE_CODE(process->PageTable().SetProcessMemoryPermission(
-            text_start, ro_start - text_start, Kernel::KMemoryPermission::ReadAndExecute));
+            text_start, ro_start - text_start, Kernel::Svc::MemoryPermission::ReadExecute));
         CASCADE_CODE(process->PageTable().SetProcessMemoryPermission(
-            ro_start, data_start - ro_start, Kernel::KMemoryPermission::Read));
+            ro_start, data_start - ro_start, Kernel::Svc::MemoryPermission::Read));
 
         return process->PageTable().SetProcessMemoryPermission(
-            data_start, bss_end_addr - data_start, Kernel::KMemoryPermission::UserReadWrite);
+            data_start, bss_end_addr - data_start, Kernel::Svc::MemoryPermission::ReadWrite);
     }
 
     void LoadModule(Kernel::HLERequestContext& ctx) {


### PR DESCRIPTION
This is the second set of several changes bringing our memory implementation up to speed with latest HOS, as well as various updates to improve accuracy. With these changes, we:
* Rename MapProcessCodeMemory and UnmapProcessCodeMemory functions to MapCodeMemory and UnmapCodeMemory, to be consistent with the official naming.
* Update all usage of KMemoryPermission::ReadAndWrite to UserReadWrite, as this is what should be used for the user-space applications that yuzu aims to emulate.
* Fixes an issue with LDR where we were trying to unmap BSS section of a shared module, even when BSS might be unset.
* Updates our implementation of SetProcessMemoryPermission to be more accurate.