### PR TITLE
core/hid: Reduce gyro threshold even more

### DIFF
--- a/src/core/hid/motion_input.cpp
+++ b/src/core/hid/motion_input.cpp
@@ -10,7 +10,7 @@ namespace Core::HID {
 MotionInput::MotionInput() {
     // Initialize PID constants with default values
     SetPID(0.3f, 0.005f, 0.0f);
-    SetGyroThreshold(0.001f);
+    SetGyroThreshold(0.00005f);
 }
 
 void MotionInput::SetPID(f32 new_kp, f32 new_ki, f32 new_kd) {


### PR DESCRIPTION
The initial value was estimated to be safe. But some motion devices are capable to input really fine values. This PR reduces the threshold to allow for those motion devices to work properly.

Closes #7696