### PR TITLE
Kernel Memory Updates (Part 3): Clear KMemoryManager pages & other fixes

### DIFF
--- a/src/core/hle/kernel/k_memory_manager.h
+++ b/src/core/hle/kernel/k_memory_manager.h
@@ -12,6 +12,10 @@
 #include "core/hle/kernel/k_page_heap.h"
 #include "core/hle/result.h"
 
+namespace Core {
+class System;
+}
+
 namespace Kernel {
 
 class KPageLinkedList;
@@ -42,7 +46,7 @@ public:
         Mask = (0xF << Shift),
     };
 
-    KMemoryManager() = default;
+    explicit KMemoryManager(Core::System& system_);
 
     constexpr std::size_t GetSize(Pool pool) const {
         return managers[static_cast<std::size_t>(pool)].GetSize();
@@ -51,10 +55,10 @@ public:
     void InitializeManager(Pool pool, u64 start_address, u64 end_address);
 
     VAddr AllocateAndOpenContinuous(size_t num_pages, size_t align_pages, u32 option);
-    ResultCode Allocate(KPageLinkedList& page_list, std::size_t num_pages, Pool pool,
-                        Direction dir = Direction::FromFront);
-    ResultCode Free(KPageLinkedList& page_list, std::size_t num_pages, Pool pool,
-                    Direction dir = Direction::FromFront);
+    ResultCode Allocate(KPageLinkedList& page_list, std::size_t num_pages, Pool pool, Direction dir,
+                        u32 heap_fill_value = 0);
+    ResultCode Free(KPageLinkedList& page_list, std::size_t num_pages, Pool pool, Direction dir,
+                    u32 heap_fill_value = 0);
 
     static constexpr std::size_t MaxManagerCount = 10;
 
@@ -129,6 +133,7 @@ private:
     };
 
 private:
+    Core::System& system;
     std::array<std::mutex, static_cast<std::size_t>(Pool::Count)> pool_locks;
     std::array<Impl, MaxManagerCount> managers;
 };

--- a/src/core/hle/kernel/k_page_table.cpp
+++ b/src/core/hle/kernel/k_page_table.cpp
@@ -289,8 +289,8 @@ ResultCode KPageTable::MapProcessCode(VAddr addr, std::size_t num_pages, KMemory
     }
 
     KPageLinkedList page_linked_list;
-    CASCADE_CODE(
-        system.Kernel().MemoryManager().Allocate(page_linked_list, num_pages, memory_pool));
+    CASCADE_CODE(system.Kernel().MemoryManager().Allocate(page_linked_list, num_pages, memory_pool,
+                                                          allocation_option));
     CASCADE_CODE(Operate(addr, num_pages, page_linked_list, OperationType::MapGroup));
 
     block_manager->Update(addr, num_pages, state, perm);
@@ -457,8 +457,8 @@ ResultCode KPageTable::MapPhysicalMemory(VAddr addr, std::size_t size) {
 
     KPageLinkedList page_linked_list;
 
-    CASCADE_CODE(
-        system.Kernel().MemoryManager().Allocate(page_linked_list, remaining_pages, memory_pool));
+    CASCADE_CODE(system.Kernel().MemoryManager().Allocate(page_linked_list, remaining_pages,
+                                                          memory_pool, allocation_option));
 
     // We succeeded, so commit the memory reservation.
     memory_reservation.Commit();
@@ -541,7 +541,8 @@ ResultCode KPageTable::UnmapMemory(VAddr addr, std::size_t size) {
     }
 
     const std::size_t num_pages{size / PageSize};
-    system.Kernel().MemoryManager().Free(page_linked_list, num_pages, memory_pool);
+    system.Kernel().MemoryManager().Free(page_linked_list, num_pages, memory_pool,
+                                         allocation_option);
 
     block_manager->Update(addr, num_pages, KMemoryState::Free);
 
@@ -960,7 +961,7 @@ ResultCode KPageTable::SetHeapSize(VAddr* out, std::size_t size) {
     // Allocate pages for the heap extension.
     KPageLinkedList page_linked_list;
     R_TRY(system.Kernel().MemoryManager().Allocate(page_linked_list, allocation_size / PageSize,
-                                                   memory_pool));
+                                                   memory_pool, allocation_option));
 
     // Map the pages.
     {
@@ -1027,8 +1028,8 @@ ResultVal<VAddr> KPageTable::AllocateAndMapMemory(std::size_t needed_num_pages, 
         CASCADE_CODE(Operate(addr, needed_num_pages, perm, OperationType::Map, map_addr));
     } else {
         KPageLinkedList page_group;
-        CASCADE_CODE(
-            system.Kernel().MemoryManager().Allocate(page_group, needed_num_pages, memory_pool));
+        CASCADE_CODE(system.Kernel().MemoryManager().Allocate(page_group, needed_num_pages,
+                                                              memory_pool, allocation_option));
         CASCADE_CODE(Operate(addr, needed_num_pages, page_group, OperationType::MapGroup));
     }
 

--- a/src/core/hle/kernel/k_page_table.h
+++ b/src/core/hle/kernel/k_page_table.h
@@ -303,6 +303,7 @@ private:
     bool is_aslr_enabled{};
 
     KMemoryManager::Pool memory_pool{KMemoryManager::Pool::Application};
+    KMemoryManager::Direction allocation_option{KMemoryManager::Direction::FromFront};
 
     Common::PageTable page_table_impl;
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -629,7 +629,7 @@ struct KernelCore::Impl {
         const auto application_pool = memory_layout.GetKernelApplicationPoolRegionPhysicalExtents();
 
         // Initialize memory managers
-        memory_manager = std::make_unique<KMemoryManager>();
+        memory_manager = std::make_unique<KMemoryManager>(system);
         memory_manager->InitializeManager(KMemoryManager::Pool::Application,
                                           application_pool.GetAddress(),
                                           application_pool.GetEndAddress());


### PR DESCRIPTION
This is the third set of several changes bringing our memory implementation up to speed with latest HOS, as well as various updates to improve accuracy. With these changes, we:
- Zero heap allocated pages from within KMemoryManager.
- Explicitly passed along heap allocation option.