### PR TITLE
core/hid: Increment shake force

### DIFF
--- a/src/core/hid/input_converter.cpp
+++ b/src/core/hid/input_converter.cpp
@@ -114,7 +114,7 @@ Common::Input::MotionStatus TransformToMotion(const Common::Input::CallbackStatu
         if (TransformToButton(callback).value) {
             std::random_device device;
             std::mt19937 gen(device());
-            std::uniform_int_distribution<s16> distribution(-1000, 1000);
+            std::uniform_int_distribution<s16> distribution(-5000, 5000);
             status.accel.x.raw_value = static_cast<f32>(distribution(gen)) * 0.001f;
             status.accel.y.raw_value = static_cast<f32>(distribution(gen)) * 0.001f;
             status.accel.z.raw_value = static_cast<f32>(distribution(gen)) * 0.001f;


### PR DESCRIPTION
With the current settings 2p mode in pokemon let's go wasn't showing up.  By making the shake more violent we can make it appear without any effort using the keyboard