### PR TITLE
Accurately implement thread exit

### DIFF
--- a/src/common/fiber.cpp
+++ b/src/common/fiber.cpp
@@ -124,7 +124,10 @@ void Fiber::YieldTo(std::weak_ptr<Fiber> weak_from, Fiber& to) {
 
     // "from" might no longer be valid if the thread was killed
     if (auto from = weak_from.lock()) {
-        ASSERT(from->impl->previous_fiber != nullptr);
+        if (from->impl->previous_fiber == nullptr) {
+            ASSERT_MSG(false, "previous_fiber is nullptr!");
+            return;
+        }
         from->impl->previous_fiber->impl->context = transfer.fctx;
         from->impl->previous_fiber->impl->guard.unlock();
         from->impl->previous_fiber.reset();

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -247,6 +247,9 @@ add_library(core STATIC
     hle/kernel/k_trace.h
     hle/kernel/k_transfer_memory.cpp
     hle/kernel/k_transfer_memory.h
+    hle/kernel/k_worker_task.h
+    hle/kernel/k_worker_task_manager.cpp
+    hle/kernel/k_worker_task_manager.h
     hle/kernel/k_writable_event.cpp
     hle/kernel/k_writable_event.h
     hle/kernel/kernel.cpp

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -149,6 +149,10 @@ ResultCode KProcess::Initialize(KProcess* process, Core::System& system, std::st
     return ResultSuccess;
 }
 
+void KProcess::DoWorkerTaskImpl() {
+    UNIMPLEMENTED();
+}
+
 KResourceLimit* KProcess::GetResourceLimit() const {
     return resource_limit;
 }
@@ -477,7 +481,7 @@ void KProcess::Finalize() {
     }
 
     // Perform inherited finalization.
-    KAutoObjectWithSlabHeapAndContainer<KProcess, KSynchronizationObject>::Finalize();
+    KAutoObjectWithSlabHeapAndContainer<KProcess, KWorkerTask>::Finalize();
 }
 
 /**

--- a/src/core/hle/kernel/k_process.h
+++ b/src/core/hle/kernel/k_process.h
@@ -15,6 +15,7 @@
 #include "core/hle/kernel/k_condition_variable.h"
 #include "core/hle/kernel/k_handle_table.h"
 #include "core/hle/kernel/k_synchronization_object.h"
+#include "core/hle/kernel/k_worker_task.h"
 #include "core/hle/kernel/process_capability.h"
 #include "core/hle/kernel/slab_helpers.h"
 #include "core/hle/result.h"
@@ -62,8 +63,7 @@ enum class ProcessStatus {
     DebugBreak,
 };
 
-class KProcess final
-    : public KAutoObjectWithSlabHeapAndContainer<KProcess, KSynchronizationObject> {
+class KProcess final : public KAutoObjectWithSlabHeapAndContainer<KProcess, KWorkerTask> {
     KERNEL_AUTOOBJECT_TRAITS(KProcess, KSynchronizationObject);
 
 public:
@@ -344,6 +344,8 @@ public:
     }
 
     bool IsSignaled() const override;
+
+    void DoWorkerTaskImpl();
 
     void PinCurrentThread(s32 core_id);
     void UnpinCurrentThread(s32 core_id);

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -192,9 +192,9 @@ public:
 
     void TrySuspend();
 
-    void Continue();
+    void UpdateState();
 
-    void Suspend();
+    void Continue();
 
     constexpr void SetSyncedIndex(s32 index) {
         synced_index = index;

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -19,6 +19,7 @@
 #include "core/hle/kernel/k_light_lock.h"
 #include "core/hle/kernel/k_spin_lock.h"
 #include "core/hle/kernel/k_synchronization_object.h"
+#include "core/hle/kernel/k_worker_task.h"
 #include "core/hle/kernel/slab_helpers.h"
 #include "core/hle/kernel/svc_common.h"
 #include "core/hle/kernel/svc_types.h"
@@ -100,7 +101,7 @@ enum class ThreadWaitReasonForDebugging : u32 {
 [[nodiscard]] KThread& GetCurrentThread(KernelCore& kernel);
 [[nodiscard]] s32 GetCurrentCoreId(KernelCore& kernel);
 
-class KThread final : public KAutoObjectWithSlabHeapAndContainer<KThread, KSynchronizationObject>,
+class KThread final : public KAutoObjectWithSlabHeapAndContainer<KThread, KWorkerTask>,
                       public boost::intrusive::list_base_hook<> {
     KERNEL_AUTOOBJECT_TRAITS(KThread, KSynchronizationObject);
 
@@ -384,6 +385,8 @@ public:
     [[nodiscard]] bool IsSignaled() const override;
 
     void OnTimer();
+
+    void DoWorkerTaskImpl();
 
     static void PostDestroy(uintptr_t arg);
 
@@ -678,6 +681,8 @@ private:
     void RemoveWaiterImpl(KThread* thread);
 
     void StartTermination();
+
+    void FinishTermination();
 
     [[nodiscard]] ResultCode Initialize(KThreadFunction func, uintptr_t arg, VAddr user_stack_top,
                                         s32 prio, s32 virt_core, KProcess* owner, ThreadType type);

--- a/src/core/hle/kernel/k_worker_task.h
+++ b/src/core/hle/kernel/k_worker_task.h
@@ -1,0 +1,18 @@
+// Copyright 2022 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "core/hle/kernel/k_synchronization_object.h"
+
+namespace Kernel {
+
+class KWorkerTask : public KSynchronizationObject {
+public:
+    explicit KWorkerTask(KernelCore& kernel_);
+
+    void DoWorkerTask();
+};
+
+} // namespace Kernel

--- a/src/core/hle/kernel/k_worker_task_manager.cpp
+++ b/src/core/hle/kernel/k_worker_task_manager.cpp
@@ -1,0 +1,42 @@
+// Copyright 2022 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/assert.h"
+#include "core/hle/kernel/k_process.h"
+#include "core/hle/kernel/k_thread.h"
+#include "core/hle/kernel/k_worker_task.h"
+#include "core/hle/kernel/k_worker_task_manager.h"
+#include "core/hle/kernel/kernel.h"
+
+namespace Kernel {
+
+KWorkerTask::KWorkerTask(KernelCore& kernel_) : KSynchronizationObject{kernel_} {}
+
+void KWorkerTask::DoWorkerTask() {
+    if (auto* const thread = this->DynamicCast<KThread*>(); thread != nullptr) {
+        return thread->DoWorkerTaskImpl();
+    } else {
+        auto* const process = this->DynamicCast<KProcess*>();
+        ASSERT(process != nullptr);
+
+        return process->DoWorkerTaskImpl();
+    }
+}
+
+KWorkerTaskManager::KWorkerTaskManager() : m_waiting_thread(1, "yuzu:KWorkerTaskManager") {}
+
+void KWorkerTaskManager::AddTask(KernelCore& kernel, WorkerType type, KWorkerTask* task) {
+    ASSERT(type <= WorkerType::Count);
+    kernel.WorkerTaskManager().AddTask(kernel, task);
+}
+
+void KWorkerTaskManager::AddTask(KernelCore& kernel, KWorkerTask* task) {
+    KScopedSchedulerLock sl(kernel);
+    m_waiting_thread.QueueWork([task]() {
+        // Do the task.
+        task->DoWorkerTask();
+    });
+}
+
+} // namespace Kernel

--- a/src/core/hle/kernel/k_worker_task_manager.h
+++ b/src/core/hle/kernel/k_worker_task_manager.h
@@ -1,0 +1,33 @@
+// Copyright 2022 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include "common/common_types.h"
+#include "common/thread_worker.h"
+
+namespace Kernel {
+
+class KernelCore;
+class KWorkerTask;
+
+class KWorkerTaskManager final {
+public:
+    enum class WorkerType : u32 {
+        Exit,
+        Count,
+    };
+
+    KWorkerTaskManager();
+
+    static void AddTask(KernelCore& kernel_, WorkerType type, KWorkerTask* task);
+
+private:
+    void AddTask(KernelCore& kernel, KWorkerTask* task);
+
+private:
+    Common::ThreadWorker m_waiting_thread;
+};
+
+} // namespace Kernel

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -37,6 +37,7 @@
 #include "core/hle/kernel/k_shared_memory.h"
 #include "core/hle/kernel/k_slab_heap.h"
 #include "core/hle/kernel/k_thread.h"
+#include "core/hle/kernel/k_worker_task_manager.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/physical_core.h"
 #include "core/hle/kernel/service_thread.h"
@@ -798,6 +799,8 @@ struct KernelCore::Impl {
 
     std::array<u64, Core::Hardware::NUM_CPU_CORES> svc_ticks{};
 
+    KWorkerTaskManager worker_task_manager;
+
     // System context
     Core::System& system;
 };
@@ -1136,6 +1139,14 @@ Init::KSlabResourceCounts& KernelCore::SlabResourceCounts() {
 
 const Init::KSlabResourceCounts& KernelCore::SlabResourceCounts() const {
     return impl->slab_resource_counts;
+}
+
+KWorkerTaskManager& KernelCore::WorkerTaskManager() {
+    return impl->worker_task_manager;
+}
+
+const KWorkerTaskManager& KernelCore::WorkerTaskManager() const {
+    return impl->worker_task_manager;
 }
 
 bool KernelCore::IsPhantomModeForSingleCore() const {

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -52,6 +52,7 @@ class KSharedMemory;
 class KSharedMemoryInfo;
 class KThread;
 class KTransferMemory;
+class KWorkerTaskManager;
 class KWritableEvent;
 class KCodeMemory;
 class PhysicalCore;
@@ -342,6 +343,12 @@ public:
 
     /// Gets the current slab resource counts.
     const Init::KSlabResourceCounts& SlabResourceCounts() const;
+
+    /// Gets the current worker task manager, used for dispatching KThread/KProcess tasks.
+    KWorkerTaskManager& WorkerTaskManager();
+
+    /// Gets the current worker task manager, used for dispatching KThread/KProcess tasks.
+    const KWorkerTaskManager& WorkerTaskManager() const;
 
 private:
     friend class KProcess;


### PR DESCRIPTION
Previously, yuzu would close the KThread-owned reference when svcExitThread was called, while it was still scheduled on a core. Subsequently, another game thread calls svcCloseHandle, decrementing the last reference to the thread and destroying it, in a race condition that can happen while we are still scheduling, causing a crash in the emulator.

The accurate solution is to properly implement thread termination. With these changes, we introduce KWorkerTask and KWorkerTaskManager, which is a background task thread used to process tasks from threads and processes. When svcExitThread is called, a task is dispatched to finish the termination on this new kernel thread. Here, we wait for the thread to be unscheduled from all cores before we close the thread-owned reference. This ensures the thread is destroyed only once it is no longer running.

This fixes a longstanding crash in Pokemon Sword/Shield that can happen after long gameplay sessions (often characterized by the assertion "Assertion Failed! Destroying a fiber that's still running").

Fixes #6210 and #6437.

Together with PR #7711, Pokemon Sword/Shield do not appear to crash anymore after many hours of gameplay (I've let it run now for about 20 hours, crashes usually happen for me after 1-5).