### PR TITLE
Xbox controller default name nit pick

### DIFF
--- a/src/input_common/drivers/sdl_driver.cpp
+++ b/src/input_common/drivers/sdl_driver.cpp
@@ -198,9 +198,9 @@ public:
         if (sdl_controller) {
             switch (SDL_GameControllerGetType(sdl_controller.get())) {
             case SDL_CONTROLLER_TYPE_XBOX360:
-                return "XBox 360 Controller";
+                return "Xbox 360 Controller";
             case SDL_CONTROLLER_TYPE_XBOXONE:
-                return "XBox One Controller";
+                return "Xbox One Controller";
             case SDL_CONTROLLER_TYPE_PS3:
                 return "DualShock 3 Controller";
             case SDL_CONTROLLER_TYPE_PS4:


### PR DESCRIPTION
Discord User moon lacer pointed us that official name is 'Xbox' not 'XBox'