### PR TITLE
yuzu: Add volume hotkeys

### DIFF
--- a/src/audio_core/stream.cpp
+++ b/src/audio_core/stream.cpp
@@ -79,8 +79,8 @@ static void VolumeAdjustSamples(std::vector<s16>& samples, float game_volume) {
         return;
     }
 
-    // Implementation of a volume slider with a dynamic range of 60 dB
-    const float volume_scale_factor = volume == 0 ? 0 : std::exp(6.90775f * volume) * 0.001f;
+    // Perceived volume is not the same as the volume level
+    const float volume_scale_factor = (0.85f * ((volume * volume) - volume)) + volume;
     for (auto& sample : samples) {
         sample = static_cast<s16>(sample * volume_scale_factor);
     }

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -65,7 +65,10 @@ const std::array<int, 2> Config::default_stick_mod = {
 // This must be in alphabetical order according to action name as it must have the same order as
 // UISetting::values.shortcuts, which is alphabetically ordered.
 // clang-format off
-const std::array<UISettings::Shortcut, 18> Config::default_hotkeys{{
+const std::array<UISettings::Shortcut, 20> Config::default_hotkeys{{
+    {QStringLiteral("Audio Mute/Unmute"),        QStringLiteral("Main Window"), {QStringLiteral("Ctrl+M"),  QStringLiteral("Home+Dpad_Right"), Qt::WindowShortcut}},
+    {QStringLiteral("Audio Volume Down"),        QStringLiteral("Main Window"), {QStringLiteral("-"),       QStringLiteral("Home+Dpad_Down"), Qt::ApplicationShortcut}},
+    {QStringLiteral("Audio Volume Up"),          QStringLiteral("Main Window"), {QStringLiteral("+"),       QStringLiteral("Home+Dpad_Up"), Qt::ApplicationShortcut}},
     {QStringLiteral("Capture Screenshot"),       QStringLiteral("Main Window"), {QStringLiteral("Ctrl+P"),  QStringLiteral("Screenshot"), Qt::WidgetWithChildrenShortcut}},
     {QStringLiteral("Change Docked Mode"),       QStringLiteral("Main Window"), {QStringLiteral("F10"),     QStringLiteral("Home+X"), Qt::ApplicationShortcut}},
     {QStringLiteral("Continue/Pause Emulation"), QStringLiteral("Main Window"), {QStringLiteral("F4"),      QStringLiteral("Home+Plus"), Qt::WindowShortcut}},
@@ -74,7 +77,6 @@ const std::array<UISettings::Shortcut, 18> Config::default_hotkeys{{
     {QStringLiteral("Fullscreen"),               QStringLiteral("Main Window"), {QStringLiteral("F11"),     QStringLiteral("Home+B"), Qt::WindowShortcut}},
     {QStringLiteral("Load Amiibo"),              QStringLiteral("Main Window"), {QStringLiteral("F2"),      QStringLiteral("Home+A"), Qt::WidgetWithChildrenShortcut}},
     {QStringLiteral("Load File"),                QStringLiteral("Main Window"), {QStringLiteral("Ctrl+O"),  QStringLiteral(""), Qt::WidgetWithChildrenShortcut}},
-    {QStringLiteral("Mute Audio"),               QStringLiteral("Main Window"), {QStringLiteral("Ctrl+M"),  QStringLiteral(""), Qt::WindowShortcut}},
     {QStringLiteral("Restart Emulation"),        QStringLiteral("Main Window"), {QStringLiteral("F6"),      QStringLiteral(""), Qt::WindowShortcut}},
     {QStringLiteral("Stop Emulation"),           QStringLiteral("Main Window"), {QStringLiteral("F5"),      QStringLiteral(""), Qt::WindowShortcut}},
     {QStringLiteral("TAS Start/Stop"),           QStringLiteral("Main Window"), {QStringLiteral("Ctrl+F5"), QStringLiteral(""), Qt::ApplicationShortcut}},

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -65,15 +65,13 @@ const std::array<int, 2> Config::default_stick_mod = {
 // This must be in alphabetical order according to action name as it must have the same order as
 // UISetting::values.shortcuts, which is alphabetically ordered.
 // clang-format off
-const std::array<UISettings::Shortcut, 21> Config::default_hotkeys{{
+const std::array<UISettings::Shortcut, 18> Config::default_hotkeys{{
     {QStringLiteral("Capture Screenshot"),       QStringLiteral("Main Window"), {QStringLiteral("Ctrl+P"),  QStringLiteral("Screenshot"), Qt::WidgetWithChildrenShortcut}},
     {QStringLiteral("Change Docked Mode"),       QStringLiteral("Main Window"), {QStringLiteral("F10"),     QStringLiteral("Home+X"), Qt::ApplicationShortcut}},
     {QStringLiteral("Continue/Pause Emulation"), QStringLiteral("Main Window"), {QStringLiteral("F4"),      QStringLiteral("Home+Plus"), Qt::WindowShortcut}},
-    {QStringLiteral("Decrease Speed Limit"),     QStringLiteral("Main Window"), {QStringLiteral("-"),       QStringLiteral(""), Qt::ApplicationShortcut}},
     {QStringLiteral("Exit Fullscreen"),          QStringLiteral("Main Window"), {QStringLiteral("Esc"),     QStringLiteral(""), Qt::WindowShortcut}},
     {QStringLiteral("Exit yuzu"),                QStringLiteral("Main Window"), {QStringLiteral("Ctrl+Q"),  QStringLiteral("Home+Minus"), Qt::WindowShortcut}},
     {QStringLiteral("Fullscreen"),               QStringLiteral("Main Window"), {QStringLiteral("F11"),     QStringLiteral("Home+B"), Qt::WindowShortcut}},
-    {QStringLiteral("Increase Speed Limit"),     QStringLiteral("Main Window"), {QStringLiteral("+"),       QStringLiteral(""), Qt::ApplicationShortcut}},
     {QStringLiteral("Load Amiibo"),              QStringLiteral("Main Window"), {QStringLiteral("F2"),      QStringLiteral("Home+A"), Qt::WidgetWithChildrenShortcut}},
     {QStringLiteral("Load File"),                QStringLiteral("Main Window"), {QStringLiteral("Ctrl+O"),  QStringLiteral(""), Qt::WidgetWithChildrenShortcut}},
     {QStringLiteral("Mute Audio"),               QStringLiteral("Main Window"), {QStringLiteral("Ctrl+M"),  QStringLiteral(""), Qt::WindowShortcut}},
@@ -85,7 +83,6 @@ const std::array<UISettings::Shortcut, 21> Config::default_hotkeys{{
     {QStringLiteral("Toggle Filter Bar"),        QStringLiteral("Main Window"), {QStringLiteral("Ctrl+F"),  QStringLiteral(""), Qt::WindowShortcut}},
     {QStringLiteral("Toggle Framerate Limit"),   QStringLiteral("Main Window"), {QStringLiteral("Ctrl+U"),  QStringLiteral("Home+Y"), Qt::ApplicationShortcut}},
     {QStringLiteral("Toggle Mouse Panning"),     QStringLiteral("Main Window"), {QStringLiteral("Ctrl+F9"), QStringLiteral(""), Qt::ApplicationShortcut}},
-    {QStringLiteral("Toggle Speed Limit"),       QStringLiteral("Main Window"), {QStringLiteral("Ctrl+Z"),  QStringLiteral(""), Qt::ApplicationShortcut}},
     {QStringLiteral("Toggle Status Bar"),        QStringLiteral("Main Window"), {QStringLiteral("Ctrl+S"),  QStringLiteral(""), Qt::WindowShortcut}},
 }};
 // clang-format on

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -46,7 +46,7 @@ public:
         default_mouse_buttons;
     static const std::array<int, Settings::NativeKeyboard::NumKeyboardKeys> default_keyboard_keys;
     static const std::array<int, Settings::NativeKeyboard::NumKeyboardMods> default_keyboard_mods;
-    static const std::array<UISettings::Shortcut, 21> default_hotkeys;
+    static const std::array<UISettings::Shortcut, 18> default_hotkeys;
 
 private:
     void Initialize(const std::string& config_name);

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -46,7 +46,7 @@ public:
         default_mouse_buttons;
     static const std::array<int, Settings::NativeKeyboard::NumKeyboardKeys> default_keyboard_keys;
     static const std::array<int, Settings::NativeKeyboard::NumKeyboardMods> default_keyboard_mods;
-    static const std::array<UISettings::Shortcut, 18> default_hotkeys;
+    static const std::array<UISettings::Shortcut, 20> default_hotkeys;
 
 private:
     void Initialize(const std::string& config_name);

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1008,25 +1008,6 @@ void GMainWindow::InitializeHotkeys() {
             ToggleFullscreen();
         }
     });
-    connect_shortcut(QStringLiteral("Toggle Speed Limit"), [&] {
-        Settings::values.use_speed_limit.SetValue(!Settings::values.use_speed_limit.GetValue());
-        UpdateStatusBar();
-    });
-    constexpr u16 SPEED_LIMIT_STEP = 5;
-    connect_shortcut(QStringLiteral("Increase Speed Limit"), [&] {
-        if (Settings::values.speed_limit.GetValue() < 9999 - SPEED_LIMIT_STEP) {
-            Settings::values.speed_limit.SetValue(SPEED_LIMIT_STEP +
-                                                  Settings::values.speed_limit.GetValue());
-            UpdateStatusBar();
-        }
-    });
-    connect_shortcut(QStringLiteral("Decrease Speed Limit"), [&] {
-        if (Settings::values.speed_limit.GetValue() > SPEED_LIMIT_STEP) {
-            Settings::values.speed_limit.SetValue(Settings::values.speed_limit.GetValue() -
-                                                  SPEED_LIMIT_STEP);
-            UpdateStatusBar();
-        }
-    });
     connect_shortcut(QStringLiteral("Change Docked Mode"), [&] {
         Settings::values.use_docked_mode.SetValue(!Settings::values.use_docked_mode.GetValue());
         OnDockedModeChanged(!Settings::values.use_docked_mode.GetValue(),

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1014,8 +1014,18 @@ void GMainWindow::InitializeHotkeys() {
                             Settings::values.use_docked_mode.GetValue(), *system);
         dock_status_button->setChecked(Settings::values.use_docked_mode.GetValue());
     });
-    connect_shortcut(QStringLiteral("Mute Audio"),
+    connect_shortcut(QStringLiteral("Audio Mute/Unmute"),
                      [] { Settings::values.audio_muted = !Settings::values.audio_muted; });
+    connect_shortcut(QStringLiteral("Audio Volume Down"), [] {
+        const auto current_volume = static_cast<int>(Settings::values.volume.GetValue());
+        const auto new_volume = std::max(current_volume - 5, 0);
+        Settings::values.volume.SetValue(static_cast<u8>(new_volume));
+    });
+    connect_shortcut(QStringLiteral("Audio Volume Up"), [] {
+        const auto current_volume = static_cast<int>(Settings::values.volume.GetValue());
+        const auto new_volume = std::min(current_volume + 5, 100);
+        Settings::values.volume.SetValue(static_cast<u8>(new_volume));
+    });
     connect_shortcut(QStringLiteral("Toggle Framerate Limit"), [] {
         Settings::values.disable_fps_limit.SetValue(!Settings::values.disable_fps_limit.GetValue());
     });


### PR DESCRIPTION
Since the idea is to do everything with the gamepad It was decided to add hotkeys to control the volume. I removed the emulation speed hotkeys mainly since they only work on single core and it's not recommended anymore to use single core.

As an extra I noticed the volume % was a little far from ideal. So I changed the formula to something better.