### PR TITLE
First Nugget: Reworked Garbage Collection to be smarter [originally from Project YFC]

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -464,9 +464,9 @@ BufferCache<P>::BufferCache(VideoCore::RasterizerInterface& rasterizer_,
     const s64 device_memory = static_cast<s64>(runtime.GetDeviceLocalMemory());
     const s64 min_spacing_expected = device_memory - 1_GiB - 512_MiB;
     const s64 min_spacing_critical = device_memory - 1_GiB;
-    const s64 mem_tresshold = std::min(device_memory, TARGET_THRESHOLD);
-    const s64 min_vacancy_expected = (6 * mem_tresshold) / 10;
-    const s64 min_vacancy_critical = (3 * mem_tresshold) / 10;
+    const s64 mem_threshold = std::min(device_memory, TARGET_THRESHOLD);
+    const s64 min_vacancy_expected = (6 * mem_threshold) / 10;
+    const s64 min_vacancy_critical = (3 * mem_threshold) / 10;
     minimum_memory = static_cast<u64>(
         std::max(std::min(device_memory - min_vacancy_expected, min_spacing_expected),
                  DEFAULT_EXPECTED_MEMORY));

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -136,21 +136,17 @@ BufferCacheRuntime::BufferCacheRuntime(const Device& device_)
         glNamedBufferData(buffer.handle, 0x10'000, nullptr, GL_STREAM_COPY);
     }
 
-    device_access_memory = []() -> u64 {
-        if (GLAD_GL_NVX_gpu_memory_info) {
-            GLint cur_avail_mem_kb = 0;
-            glGetIntegerv(GL_GPU_MEMORY_INFO_TOTAL_AVAILABLE_MEMORY_NVX, &cur_avail_mem_kb);
-            return static_cast<u64>(cur_avail_mem_kb) * 1_KiB;
+    device_access_memory = [this]() -> u64 {
+        if (device.CanReportMemoryUsage()) {
+            return device.GetCurrentDedicatedVideoMemory() + 512_MiB;
         }
         return 2_GiB; // Return minimum requirements
     }();
 }
 
 u64 BufferCacheRuntime::GetDeviceMemoryUsage() const {
-    if (GLAD_GL_NVX_gpu_memory_info) {
-        GLint cur_avail_mem_kb = 0;
-        glGetIntegerv(GL_GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX, &cur_avail_mem_kb);
-        return device_access_memory - static_cast<u64>(cur_avail_mem_kb) * 1_KiB;
+    if (device.CanReportMemoryUsage()) {
+        return device_access_memory - device.GetCurrentDedicatedVideoMemory();
     }
     return 2_GiB;
 }

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -135,6 +135,24 @@ BufferCacheRuntime::BufferCacheRuntime(const Device& device_)
         buffer.Create();
         glNamedBufferData(buffer.handle, 0x10'000, nullptr, GL_STREAM_COPY);
     }
+
+    device_access_memory = []() -> u64 {
+        if (GLAD_GL_NVX_gpu_memory_info) {
+            GLint cur_avail_mem_kb = 0;
+            glGetIntegerv(GL_GPU_MEMORY_INFO_TOTAL_AVAILABLE_MEMORY_NVX, &cur_avail_mem_kb);
+            return static_cast<u64>(cur_avail_mem_kb) * 1_KiB;
+        }
+        return 2_GiB; // Return minimum requirements
+    }();
+}
+
+u64 BufferCacheRuntime::GetDeviceMemoryUsage() const {
+    if (GLAD_GL_NVX_gpu_memory_info) {
+        GLint cur_avail_mem_kb = 0;
+        glGetIntegerv(GL_GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX, &cur_avail_mem_kb);
+        return static_cast<u64>(cur_avail_mem_kb) * 1_KiB;
+    }
+    return 2_GiB;
 }
 
 void BufferCacheRuntime::CopyBuffer(Buffer& dst_buffer, Buffer& src_buffer,

--- a/src/video_core/renderer_opengl/gl_buffer_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.cpp
@@ -150,7 +150,7 @@ u64 BufferCacheRuntime::GetDeviceMemoryUsage() const {
     if (GLAD_GL_NVX_gpu_memory_info) {
         GLint cur_avail_mem_kb = 0;
         glGetIntegerv(GL_GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX, &cur_avail_mem_kb);
-        return static_cast<u64>(cur_avail_mem_kb) * 1_KiB;
+        return device_access_memory - static_cast<u64>(cur_avail_mem_kb) * 1_KiB;
     }
     return 2_GiB;
 }

--- a/src/video_core/renderer_opengl/gl_buffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.h
@@ -89,6 +89,8 @@ public:
     void BindImageBuffer(Buffer& buffer, u32 offset, u32 size,
                          VideoCore::Surface::PixelFormat format);
 
+    u64 GetDeviceMemoryUsage() const;
+
     void BindFastUniformBuffer(size_t stage, u32 binding_index, u32 size) {
         const GLuint handle = fast_uniforms[stage][binding_index].handle;
         const GLsizeiptr gl_size = static_cast<GLsizeiptr>(size);
@@ -155,10 +157,8 @@ public:
         return device_access_memory;
     }
 
-    u64 GetDeviceMemoryUsage() const;
-
     bool CanReportMemoryUsage() const {
-        return GLAD_GL_NVX_gpu_memory_info;
+        return device.CanReportMemoryUsage();
     }
 
 private:

--- a/src/video_core/renderer_opengl/gl_buffer_cache.h
+++ b/src/video_core/renderer_opengl/gl_buffer_cache.h
@@ -151,6 +151,16 @@ public:
         use_storage_buffers = use_storage_buffers_;
     }
 
+    u64 GetDeviceLocalMemory() const {
+        return device_access_memory;
+    }
+
+    u64 GetDeviceMemoryUsage() const;
+
+    bool CanReportMemoryUsage() const {
+        return GLAD_GL_NVX_gpu_memory_info;
+    }
+
 private:
     static constexpr std::array PABO_LUT{
         GL_VERTEX_PROGRAM_PARAMETER_BUFFER_NV,          GL_TESS_CONTROL_PROGRAM_PARAMETER_BUFFER_NV,
@@ -184,6 +194,8 @@ private:
     std::array<OGLBuffer, VideoCommon::NUM_COMPUTE_UNIFORM_BUFFERS> copy_compute_uniforms;
 
     u32 index_buffer_offset = 0;
+
+    u64 device_access_memory;
 };
 
 struct BufferCacheParams {

--- a/src/video_core/renderer_opengl/gl_device.cpp
+++ b/src/video_core/renderer_opengl/gl_device.cpp
@@ -13,11 +13,14 @@
 
 #include <glad/glad.h>
 
+#include "common/literals.h"
 #include "common/logging/log.h"
 #include "common/settings.h"
 #include "shader_recompiler/stage.h"
 #include "video_core/renderer_opengl/gl_device.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
+
+using namespace Common::Literals;
 
 namespace OpenGL {
 namespace {
@@ -165,6 +168,7 @@ Device::Device() {
     has_sparse_texture_2 = GLAD_GL_ARB_sparse_texture2;
     warp_size_potentially_larger_than_guest = !is_nvidia && !is_intel;
     need_fastmath_off = is_nvidia;
+    can_report_memory = GLAD_GL_NVX_gpu_memory_info;
 
     // At the moment of writing this, only Nvidia's driver optimizes BufferSubData on exclusive
     // uniform buffers as "push constants"
@@ -274,6 +278,12 @@ void main() {
     precise float tmp_value = vec4(texture(tex, coords)).x;
     out_value = tmp_value;
 })");
+}
+
+u64 Device::GetCurrentDedicatedVideoMemory() const {
+    GLint cur_avail_mem_kb = 0;
+    glGetIntegerv(GL_GPU_MEMORY_INFO_DEDICATED_VIDMEM_NVX, &cur_avail_mem_kb);
+    return static_cast<u64>(cur_avail_mem_kb) * 1_KiB;
 }
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_device.h
+++ b/src/video_core/renderer_opengl/gl_device.h
@@ -20,6 +20,8 @@ public:
 
     [[nodiscard]] std::string GetVendorName() const;
 
+    u64 GetCurrentDedicatedVideoMemory() const;
+
     u32 GetMaxUniformBuffers(Shader::Stage stage) const noexcept {
         return max_uniform_buffers[static_cast<size_t>(stage)];
     }
@@ -168,6 +170,10 @@ public:
         return vendor_name == "ATI Technologies Inc.";
     }
 
+    bool CanReportMemoryUsage() const {
+        return can_report_memory;
+    }
+
 private:
     static bool TestVariableAoffi();
     static bool TestPreciseBug();
@@ -210,6 +216,7 @@ private:
     bool need_fastmath_off{};
     bool has_cbuf_ftou_bug{};
     bool has_bool_ref_bug{};
+    bool can_report_memory{};
 
     std::string vendor_name;
 };

--- a/src/video_core/renderer_opengl/gl_texture_cache.cpp
+++ b/src/video_core/renderer_opengl/gl_texture_cache.cpp
@@ -513,7 +513,7 @@ u64 TextureCacheRuntime::GetDeviceMemoryUsage() const {
     if (GLAD_GL_NVX_gpu_memory_info) {
         GLint cur_avail_mem_kb = 0;
         glGetIntegerv(GL_GPU_MEMORY_INFO_CURRENT_AVAILABLE_VIDMEM_NVX, &cur_avail_mem_kb);
-        return static_cast<u64>(cur_avail_mem_kb) * 1_KiB;
+        return device_access_memory - static_cast<u64>(cur_avail_mem_kb) * 1_KiB;
     }
     return 2_GiB;
 }
@@ -695,7 +695,7 @@ Image::Image(TextureCacheRuntime& runtime_, const VideoCommon::ImageInfo& info_,
     }
     if (IsConverted(runtime->device, info.format, info.type)) {
         flags |= ImageFlagBits::Converted;
-        flags |= ImageFlagBits::GCProtected;
+        flags |= ImageFlagBits::CostlyLoad;
         gl_internal_format = IsPixelFormatSRGB(info.format) ? GL_SRGB8_ALPHA8 : GL_RGBA8;
         gl_format = GL_RGBA;
         gl_type = GL_UNSIGNED_INT_8_8_8_8_REV;

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -10,6 +10,7 @@
 #include <glad/glad.h>
 
 #include "shader_recompiler/shader_info.h"
+#include "video_core/renderer_opengl/gl_device.h"
 #include "video_core/renderer_opengl/gl_resource_manager.h"
 #include "video_core/renderer_opengl/util_shaders.h"
 #include "video_core/texture_cache/image_view_base.h"
@@ -21,7 +22,6 @@ struct ResolutionScalingInfo;
 
 namespace OpenGL {
 
-class Device;
 class ProgramManager;
 class StateTracker;
 
@@ -90,7 +90,7 @@ public:
     u64 GetDeviceMemoryUsage() const;
 
     bool CanReportMemoryUsage() const {
-        return GLAD_GL_NVX_gpu_memory_info;
+        return device.CanReportMemoryUsage();
     }
 
     bool ShouldReinterpret([[maybe_unused]] Image& dst, [[maybe_unused]] Image& src) {

--- a/src/video_core/renderer_opengl/gl_texture_cache.h
+++ b/src/video_core/renderer_opengl/gl_texture_cache.h
@@ -83,7 +83,15 @@ public:
 
     ImageBufferMap DownloadStagingBuffer(size_t size);
 
-    u64 GetDeviceLocalMemory() const;
+    u64 GetDeviceLocalMemory() const {
+        return device_access_memory;
+    }
+
+    u64 GetDeviceMemoryUsage() const;
+
+    bool CanReportMemoryUsage() const {
+        return GLAD_GL_NVX_gpu_memory_info;
+    }
 
     bool ShouldReinterpret([[maybe_unused]] Image& dst, [[maybe_unused]] Image& src) {
         return true;
@@ -172,6 +180,7 @@ private:
     std::array<OGLFramebuffer, 4> rescale_draw_fbos;
     std::array<OGLFramebuffer, 4> rescale_read_fbos;
     const Settings::ResolutionScalingInfo& resolution;
+    u64 device_access_memory;
 };
 
 class Image : public VideoCommon::ImageBase {

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.cpp
@@ -141,6 +141,18 @@ StagingBufferRef BufferCacheRuntime::DownloadStagingBuffer(size_t size) {
     return staging_pool.Request(size, MemoryUsage::Download);
 }
 
+u64 BufferCacheRuntime::GetDeviceLocalMemory() const {
+    return device.GetDeviceLocalMemory();
+}
+
+u64 BufferCacheRuntime::GetDeviceMemoryUsage() const {
+    return device.GetDeviceMemoryUsage();
+}
+
+bool BufferCacheRuntime::CanReportMemoryUsage() const {
+    return device.CanReportMemoryUsage();
+}
+
 void BufferCacheRuntime::Finish() {
     scheduler.Finish();
 }

--- a/src/video_core/renderer_vulkan/vk_buffer_cache.h
+++ b/src/video_core/renderer_vulkan/vk_buffer_cache.h
@@ -65,6 +65,12 @@ public:
 
     void Finish();
 
+    u64 GetDeviceLocalMemory() const;
+
+    u64 GetDeviceMemoryUsage() const;
+
+    bool CanReportMemoryUsage() const;
+
     [[nodiscard]] StagingBufferRef UploadStagingBuffer(size_t size);
 
     [[nodiscard]] StagingBufferRef DownloadStagingBuffer(size_t size);

--- a/src/video_core/renderer_vulkan/vk_staging_buffer_pool.cpp
+++ b/src/video_core/renderer_vulkan/vk_staging_buffer_pool.cpp
@@ -118,7 +118,7 @@ StagingBufferPool::StagingBufferPool(const Device& device_, MemoryAllocator& mem
         .image = nullptr,
         .buffer = *stream_buffer,
     };
-    const auto memory_properties = device.GetPhysical().GetMemoryProperties();
+    const auto memory_properties = device.GetPhysical().GetMemoryProperties().memoryProperties;
     VkMemoryAllocateInfo stream_memory_info{
         .sType = VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO,
         .pNext = make_dedicated ? &dedicated_info : nullptr,

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -1189,6 +1189,14 @@ u64 TextureCacheRuntime::GetDeviceLocalMemory() const {
     return device.GetDeviceLocalMemory();
 }
 
+u64 TextureCacheRuntime::GetDeviceMemoryUsage() const {
+    return device.GetDeviceMemoryUsage();
+}
+
+bool TextureCacheRuntime::CanReportMemoryUsage() const {
+    return device.CanReportMemoryUsage();
+}
+
 void TextureCacheRuntime::TickFrame() {}
 
 Image::Image(TextureCacheRuntime& runtime_, const ImageInfo& info_, GPUVAddr gpu_addr_,
@@ -1203,6 +1211,7 @@ Image::Image(TextureCacheRuntime& runtime_, const ImageInfo& info_, GPUVAddr gpu
         } else {
             flags |= VideoCommon::ImageFlagBits::Converted;
         }
+        flags |= VideoCommon::ImageFlagBits::GCProtected;
     }
     if (runtime->device.HasDebuggingToolAttached()) {
         original_image.SetObjectNameEXT(VideoCommon::Name(*this).c_str());

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -1211,7 +1211,7 @@ Image::Image(TextureCacheRuntime& runtime_, const ImageInfo& info_, GPUVAddr gpu
         } else {
             flags |= VideoCommon::ImageFlagBits::Converted;
         }
-        flags |= VideoCommon::ImageFlagBits::GCProtected;
+        flags |= VideoCommon::ImageFlagBits::CostlyLoad;
     }
     if (runtime->device.HasDebuggingToolAttached()) {
         original_image.SetObjectNameEXT(VideoCommon::Name(*this).c_str());

--- a/src/video_core/renderer_vulkan/vk_texture_cache.h
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.h
@@ -55,6 +55,10 @@ public:
 
     u64 GetDeviceLocalMemory() const;
 
+    u64 GetDeviceMemoryUsage() const;
+
+    bool CanReportMemoryUsage() const;
+
     void BlitImage(Framebuffer* dst_framebuffer, ImageView& dst, ImageView& src,
                    const Region2D& dst_region, const Region2D& src_region,
                    Tegra::Engines::Fermi2D::Filter filter,

--- a/src/video_core/texture_cache/image_base.h
+++ b/src/video_core/texture_cache/image_base.h
@@ -29,15 +29,16 @@ enum class ImageFlagBits : u32 {
     Sparse = 1 << 9,      ///< Image has non continous submemory.
 
     // Garbage Collection Flags
-    BadOverlap = 1 << 10, ///< This image overlaps other but doesn't fit, has higher
-                          ///< garbage collection priority
-    Alias = 1 << 11,      ///< This image has aliases and has priority on garbage
-                          ///< collection
+    BadOverlap = 1 << 10,  ///< This image overlaps other but doesn't fit, has higher
+                           ///< garbage collection priority
+    Alias = 1 << 11,       ///< This image has aliases and has priority on garbage
+                           ///< collection
+    GCProtected = 1 << 12, ///< Protected from low-tier GC as they are costy to load back.
 
     // Rescaler
-    Rescaled = 1 << 12,
-    CheckingRescalable = 1 << 13,
-    IsRescalable = 1 << 14,
+    Rescaled = 1 << 13,
+    CheckingRescalable = 1 << 14,
+    IsRescalable = 1 << 15,
 };
 DECLARE_ENUM_FLAG_OPERATORS(ImageFlagBits)
 

--- a/src/video_core/texture_cache/image_base.h
+++ b/src/video_core/texture_cache/image_base.h
@@ -29,11 +29,11 @@ enum class ImageFlagBits : u32 {
     Sparse = 1 << 9,      ///< Image has non continous submemory.
 
     // Garbage Collection Flags
-    BadOverlap = 1 << 10,  ///< This image overlaps other but doesn't fit, has higher
-                           ///< garbage collection priority
-    Alias = 1 << 11,       ///< This image has aliases and has priority on garbage
-                           ///< collection
-    GCProtected = 1 << 12, ///< Protected from low-tier GC as they are costy to load back.
+    BadOverlap = 1 << 10, ///< This image overlaps other but doesn't fit, has higher
+                          ///< garbage collection priority
+    Alias = 1 << 11,      ///< This image has aliases and has priority on garbage
+                          ///< collection
+    CostlyLoad = 1 << 12, ///< Protected from low-tier GC as it is costly to load back.
 
     // Rescaler
     Rescaled = 1 << 13,

--- a/src/video_core/texture_cache/texture_cache_base.h
+++ b/src/video_core/texture_cache/texture_cache_base.h
@@ -60,8 +60,6 @@ class TextureCache {
     static constexpr bool HAS_DEVICE_MEMORY_INFO = P::HAS_DEVICE_MEMORY_INFO;
 
     static constexpr s64 TARGET_THRESHOLD = 4_GiB;
-    static constexpr s64 MIN_VACANCY_EXPECTED = (6 * TARGET_THRESHOLD) / 10;
-    static constexpr s64 MIN_VACANCY_CRITICAL = (3 * TARGET_THRESHOLD) / 10;
     static constexpr s64 DEFAULT_EXPECTED_MEMORY = 1_GiB + 125_MiB;
     static constexpr s64 DEFAULT_CRITICAL_MEMORY = 1_GiB + 625_MiB;
     static constexpr size_t GC_EMERGENCY_COUNTS = 2;

--- a/src/video_core/texture_cache/texture_cache_base.h
+++ b/src/video_core/texture_cache/texture_cache_base.h
@@ -59,8 +59,12 @@ class TextureCache {
     /// True when the API can provide info about the memory of the device.
     static constexpr bool HAS_DEVICE_MEMORY_INFO = P::HAS_DEVICE_MEMORY_INFO;
 
-    static constexpr u64 DEFAULT_EXPECTED_MEMORY = 1_GiB;
-    static constexpr u64 DEFAULT_CRITICAL_MEMORY = 2_GiB;
+    static constexpr s64 TARGET_THRESHOLD = 4_GiB;
+    static constexpr s64 MIN_VACANCY_EXPECTED = (6 * TARGET_THRESHOLD) / 10;
+    static constexpr s64 MIN_VACANCY_CRITICAL = (3 * TARGET_THRESHOLD) / 10;
+    static constexpr s64 DEFAULT_EXPECTED_MEMORY = 1_GiB + 125_MiB;
+    static constexpr s64 DEFAULT_CRITICAL_MEMORY = 1_GiB + 625_MiB;
+    static constexpr size_t GC_EMERGENCY_COUNTS = 2;
 
     using Runtime = typename P::Runtime;
     using Image = typename P::Image;
@@ -372,6 +376,7 @@ private:
     u64 minimum_memory;
     u64 expected_memory;
     u64 critical_memory;
+    size_t critical_gc;
 
     SlotVector<Image> slot_images;
     SlotVector<ImageMapView> slot_map_views;

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -598,10 +598,10 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     }
     logical = vk::Device::Create(physical, queue_cis, extensions, first_next, dld);
 
-    is_integrated = (properties.deviceType & VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU) != 0;
-    is_virtual = (properties.deviceType & VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU) != 0;
-    is_non_gpu = (properties.deviceType & VK_PHYSICAL_DEVICE_TYPE_OTHER) != 0 ||
-                 (properties.deviceType & VK_PHYSICAL_DEVICE_TYPE_CPU) != 0;
+    is_integrated = properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU;
+    is_virtual = properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU;
+    is_non_gpu = properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_OTHER ||
+                 properties.deviceType == VK_PHYSICAL_DEVICE_TYPE_CPU;
 
     CollectPhysicalMemoryInfo();
     CollectTelemetryParameters();
@@ -1298,7 +1298,7 @@ void Device::CollectPhysicalMemoryInfo() {
     u64 local_memory = 0;
     for (size_t element = 0; element < num_properties; ++element) {
         const bool is_heap_local =
-            mem_properties.memoryHeaps[element].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT != 0;
+            (mem_properties.memoryHeaps[element].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) != 0;
         if (!is_integrated && !is_heap_local) {
             continue;
         }
@@ -1319,7 +1319,6 @@ void Device::CollectPhysicalMemoryInfo() {
     const s64 available_memory = static_cast<s64>(device_access_memory - device_initial_usage);
     device_access_memory = static_cast<u64>(std::max<s64>(
         std::min<s64>(available_memory - 8_GiB, 4_GiB), static_cast<s64>(local_memory)));
-    device_initial_usage = 0;
 }
 
 void Device::CollectToolingInfo() {

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -341,6 +341,12 @@ public:
         return device_access_memory;
     }
 
+    bool CanReportMemoryUsage() const {
+        return ext_memory_budget;
+    }
+
+    u64 GetDeviceMemoryUsage() const;
+
     u32 GetSetsPerPool() const {
         return sets_per_pool;
     }
@@ -421,6 +427,9 @@ private:
     bool is_topology_list_restart_supported{};  ///< Support for primitive restart with list
                                                 ///< topologies.
     bool is_patch_list_restart_supported{};     ///< Support for primitive restart with list patch.
+    bool is_integrated{};                       ///< Is GPU an iGPU.
+    bool is_virtual{};                          ///< Is GPU a virtual GPU.
+    bool is_non_gpu{};                          ///< Is SoftwareRasterizer, FPGA, non-GPU device.
     bool nv_viewport_swizzle{};                 ///< Support for VK_NV_viewport_swizzle.
     bool nv_viewport_array2{};                  ///< Support for VK_NV_viewport_array2.
     bool nv_geometry_shader_passthrough{};      ///< Support for VK_NV_geometry_shader_passthrough.
@@ -445,6 +454,7 @@ private:
     bool ext_shader_atomic_int64{};         ///< Support for VK_KHR_shader_atomic_int64.
     bool ext_conservative_rasterization{};  ///< Support for VK_EXT_conservative_rasterization.
     bool ext_provoking_vertex{};            ///< Support for VK_EXT_provoking_vertex.
+    bool ext_memory_budget{};               ///< Support for VK_EXT_memory_budget.
     bool nv_device_diagnostics_config{};    ///< Support for VK_NV_device_diagnostics_config.
     bool has_broken_cube_compatibility{};   ///< Has broken cube compatiblity bit
     bool has_renderdoc{};                   ///< Has RenderDoc attached
@@ -456,6 +466,7 @@ private:
     // Telemetry parameters
     std::string vendor_name;                       ///< Device's driver name.
     std::vector<std::string> supported_extensions; ///< Reported Vulkan extensions.
+    std::vector<size_t> valid_heap_memory;         ///< Heaps used.
 
     /// Format properties dictionary.
     std::unordered_map<VkFormat, VkFormatProperties> format_properties;

--- a/src/video_core/vulkan_common/vulkan_memory_allocator.cpp
+++ b/src/video_core/vulkan_common/vulkan_memory_allocator.cpp
@@ -227,7 +227,7 @@ void MemoryCommit::Release() {
 }
 
 MemoryAllocator::MemoryAllocator(const Device& device_, bool export_allocations_)
-    : device{device_}, properties{device_.GetPhysical().GetMemoryProperties()},
+    : device{device_}, properties{device_.GetPhysical().GetMemoryProperties().memoryProperties},
       export_allocations{export_allocations_},
       buffer_image_granularity{
           device_.GetPhysical().GetProperties().limits.bufferImageGranularity} {}

--- a/src/video_core/vulkan_common/vulkan_wrapper.cpp
+++ b/src/video_core/vulkan_common/vulkan_wrapper.cpp
@@ -237,8 +237,8 @@ bool Load(VkInstance instance, InstanceDispatch& dld) noexcept {
     return X(vkCreateDevice) && X(vkDestroyDevice) && X(vkDestroyDevice) &&
            X(vkEnumerateDeviceExtensionProperties) && X(vkEnumeratePhysicalDevices) &&
            X(vkGetDeviceProcAddr) && X(vkGetPhysicalDeviceFormatProperties) &&
-           X(vkGetPhysicalDeviceMemoryProperties) && X(vkGetPhysicalDeviceProperties) &&
-           X(vkGetPhysicalDeviceQueueFamilyProperties);
+           X(vkGetPhysicalDeviceMemoryProperties) && X(vkGetPhysicalDeviceMemoryProperties2) &&
+           X(vkGetPhysicalDeviceProperties) && X(vkGetPhysicalDeviceQueueFamilyProperties);
 #undef X
 }
 
@@ -926,9 +926,12 @@ std::vector<VkPresentModeKHR> PhysicalDevice::GetSurfacePresentModesKHR(
     return modes;
 }
 
-VkPhysicalDeviceMemoryProperties PhysicalDevice::GetMemoryProperties() const noexcept {
-    VkPhysicalDeviceMemoryProperties properties;
-    dld->vkGetPhysicalDeviceMemoryProperties(physical_device, &properties);
+VkPhysicalDeviceMemoryProperties2 PhysicalDevice::GetMemoryProperties(
+    void* next_structures) const noexcept {
+    VkPhysicalDeviceMemoryProperties2 properties{};
+    properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2;
+    properties.pNext = next_structures;
+    dld->vkGetPhysicalDeviceMemoryProperties2(physical_device, &properties);
     return properties;
 }
 

--- a/src/video_core/vulkan_common/vulkan_wrapper.h
+++ b/src/video_core/vulkan_common/vulkan_wrapper.h
@@ -172,6 +172,7 @@ struct InstanceDispatch {
     PFN_vkGetPhysicalDeviceFeatures2KHR vkGetPhysicalDeviceFeatures2KHR{};
     PFN_vkGetPhysicalDeviceFormatProperties vkGetPhysicalDeviceFormatProperties{};
     PFN_vkGetPhysicalDeviceMemoryProperties vkGetPhysicalDeviceMemoryProperties{};
+    PFN_vkGetPhysicalDeviceMemoryProperties2 vkGetPhysicalDeviceMemoryProperties2{};
     PFN_vkGetPhysicalDeviceProperties vkGetPhysicalDeviceProperties{};
     PFN_vkGetPhysicalDeviceProperties2KHR vkGetPhysicalDeviceProperties2KHR{};
     PFN_vkGetPhysicalDeviceQueueFamilyProperties vkGetPhysicalDeviceQueueFamilyProperties{};
@@ -950,7 +951,8 @@ public:
 
     std::vector<VkPresentModeKHR> GetSurfacePresentModesKHR(VkSurfaceKHR) const;
 
-    VkPhysicalDeviceMemoryProperties GetMemoryProperties() const noexcept;
+    VkPhysicalDeviceMemoryProperties2 GetMemoryProperties(
+        void* next_structures = nullptr) const noexcept;
 
 private:
     VkPhysicalDevice physical_device = nullptr;


### PR DESCRIPTION
This PR adds a few fixes to GC from project YFC as well as a bunch of improvements.

Improvements:

- Rebalance minimum, expected and critical thresholds to be more fair for GPUs with a lot of memory while keeping it great for low memory GPUs.
- Add GPU Memory Usage querying for Vulkan on AMD, NVIDIA & Intel and OGL for NVIDIA. This means that instead of estimating memory usage, we'll use the correct amount to make better decisions on when to clean memory.
- Improved Memory Cleaning & Estimation on iGPUs.
- Made ASTC and converted formats less easier to clean. (Thanks to @sayanns2 for figuring it that out).
- Tuned cleaning aggressiveness accordingly.

This feature used to be part of Project YFC but since it has been brought to my attention that the GC issues are very heavy right now. I have decided to release it separately.