### PR TITLE
input_common: Reintroduce motion from mouse and use button names

### DIFF
--- a/src/common/input.h
+++ b/src/common/input.h
@@ -209,6 +209,13 @@ enum class ButtonNames {
     Triangle,
     Share,
     Options,
+
+    // Mouse buttons
+    ButtonMouseWheel,
+    ButtonBackward,
+    ButtonForward,
+    ButtonTask,
+    ButtonExtra,
 };
 
 // Callback data consisting of an input type and the equivalent data status

--- a/src/input_common/drivers/mouse.cpp
+++ b/src/input_common/drivers/mouse.cpp
@@ -16,6 +16,7 @@ constexpr int mouse_axis_x = 0;
 constexpr int mouse_axis_y = 1;
 constexpr int wheel_axis_x = 2;
 constexpr int wheel_axis_y = 3;
+constexpr int motion_wheel_y = 4;
 constexpr int touch_axis_x = 10;
 constexpr int touch_axis_y = 11;
 constexpr PadIdentifier identifier = {
@@ -30,6 +31,7 @@ Mouse::Mouse(std::string input_engine_) : InputEngine(std::move(input_engine_)) 
     PreSetAxis(identifier, mouse_axis_y);
     PreSetAxis(identifier, wheel_axis_x);
     PreSetAxis(identifier, wheel_axis_y);
+    PreSetAxis(identifier, motion_wheel_y);
     PreSetAxis(identifier, touch_axis_x);
     PreSetAxis(identifier, touch_axis_x);
     update_thread = std::jthread([this](std::stop_token stop_token) { UpdateThread(stop_token); });
@@ -47,6 +49,8 @@ void Mouse::UpdateThread(std::stop_token stop_token) {
             SetAxis(identifier, mouse_axis_x, last_mouse_change.x * sensitivity);
             SetAxis(identifier, mouse_axis_y, -last_mouse_change.y * sensitivity);
         }
+
+        SetAxis(identifier, motion_wheel_y, 0.0f);
 
         if (mouse_panning_timout++ > 20) {
             StopPanning();
@@ -136,6 +140,7 @@ void Mouse::MouseWheelChange(int x, int y) {
     wheel_position.y += y;
     SetAxis(identifier, wheel_axis_x, static_cast<f32>(wheel_position.x));
     SetAxis(identifier, wheel_axis_y, static_cast<f32>(wheel_position.y));
+    SetAxis(identifier, motion_wheel_y, static_cast<f32>(y) / 100.0f);
 }
 
 void Mouse::ReleaseAllButtons() {
@@ -171,12 +176,38 @@ AnalogMapping Mouse::GetAnalogMappingForDevice(
     return mapping;
 }
 
+Common::Input::ButtonNames Mouse::GetUIButtonName(const Common::ParamPackage& params) const {
+    const auto button = static_cast<MouseButton>(params.Get("button", 0));
+    switch (button) {
+    case MouseButton::Left:
+        return Common::Input::ButtonNames::ButtonLeft;
+    case MouseButton::Right:
+        return Common::Input::ButtonNames::ButtonRight;
+    case MouseButton::Wheel:
+        return Common::Input::ButtonNames::ButtonMouseWheel;
+    case MouseButton::Backward:
+        return Common::Input::ButtonNames::ButtonBackward;
+    case MouseButton::Forward:
+        return Common::Input::ButtonNames::ButtonForward;
+    case MouseButton::Task:
+        return Common::Input::ButtonNames::ButtonTask;
+    case MouseButton::Extra:
+        return Common::Input::ButtonNames::ButtonExtra;
+    case MouseButton::Undefined:
+    default:
+        return Common::Input::ButtonNames::Undefined;
+    }
+}
+
 Common::Input::ButtonNames Mouse::GetUIName(const Common::ParamPackage& params) const {
     if (params.Has("button")) {
-        return Common::Input::ButtonNames::Value;
+        return GetUIButtonName(params);
     }
     if (params.Has("axis")) {
         return Common::Input::ButtonNames::Value;
+    }
+    if (params.Has("axis_x") && params.Has("axis_y") && params.Has("axis_z")) {
+        return Common::Input::ButtonNames::Engine;
     }
 
     return Common::Input::ButtonNames::Invalid;

--- a/src/input_common/drivers/mouse.h
+++ b/src/input_common/drivers/mouse.h
@@ -69,6 +69,8 @@ private:
     void UpdateThread(std::stop_token stop_token);
     void StopPanning();
 
+    Common::Input::ButtonNames GetUIButtonName(const Common::ParamPackage& params) const;
+
     Common::Vec2<int> mouse_origin;
     Common::Vec2<int> last_mouse_position;
     Common::Vec2<float> last_mouse_change;

--- a/src/input_common/input_mapping.cpp
+++ b/src/input_common/input_mapping.cpp
@@ -143,6 +143,19 @@ void MappingFactory::RegisterMotion(const MappingData& data) {
     }
     new_input.Set("port", static_cast<int>(data.pad.port));
     new_input.Set("pad", static_cast<int>(data.pad.pad));
+
+    // If engine is mouse map the mouse position as 3 axis motion
+    if (data.engine == "mouse") {
+        new_input.Set("axis_x", 1);
+        new_input.Set("invert_x", "-");
+        new_input.Set("axis_y", 0);
+        new_input.Set("axis_z", 4);
+        new_input.Set("range", 1.0f);
+        new_input.Set("deadzone", 0.0f);
+        input_queue.Push(new_input);
+        return;
+    }
+
     switch (data.type) {
     case EngineInputType::Button:
     case EngineInputType::HatButton:

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -102,6 +102,16 @@ QString GetButtonName(Common::Input::ButtonNames button_name) {
         return QObject::tr("Share");
     case Common::Input::ButtonNames::Options:
         return QObject::tr("Options");
+    case Common::Input::ButtonNames::ButtonMouseWheel:
+        return QObject::tr("Wheel", "Indicates the mouse wheel");
+    case Common::Input::ButtonNames::ButtonBackward:
+        return QObject::tr("Backward");
+    case Common::Input::ButtonNames::ButtonForward:
+        return QObject::tr("Forward");
+    case Common::Input::ButtonNames::ButtonTask:
+        return QObject::tr("Task");
+    case Common::Input::ButtonNames::ButtonExtra:
+        return QObject::tr("Extra");
     default:
         return QObject::tr("[undefined]");
     }


### PR DESCRIPTION
We now have the necessary code to map the mouse as a motion device. This time with the z axis as the wheel input. On top of that use mouse button names since these are well defined.