### PR TITLE
service/hid: Initialize applet_resource on SetNpadAnalogStickUseCenterClamp

### DIFF
--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -1176,7 +1176,8 @@ void Hid::SetNpadAnalogStickUseCenterClamp(Kernel::HLERequestContext& ctx) {
 
     const auto parameters{rp.PopRaw<Parameters>()};
 
-    applet_resource->GetController<Controller_NPad>(HidController::NPad)
+    GetAppletResource()
+        ->GetController<Controller_NPad>(HidController::NPad)
         .SetAnalogStickUseCenterClamp(parameters.analog_stick_use_center_clamp);
 
     LOG_WARNING(Service_HID,


### PR DESCRIPTION
According to RE SetNpadAnalogStickUseCenterClamp is able to initialize applet_resource if it wasn't initialized before.

Fixes crash at boot on `パワプロクンポケットR`