### PR TITLE
hid: Correct assignment source for rotations

### DIFF
--- a/src/core/hid/emulated_console.cpp
+++ b/src/core/hid/emulated_console.cpp
@@ -158,7 +158,7 @@ void EmulatedConsole::SetMotion(const Common::Input::CallbackStatus& callback) {
     auto& motion = console.motion_state;
     motion.accel = emulated.GetAcceleration();
     motion.gyro = emulated.GetGyroscope();
-    motion.rotation = emulated.GetGyroscope();
+    motion.rotation = emulated.GetRotations();
     motion.orientation = emulated.GetOrientation();
     motion.quaternion = emulated.GetQuaternion();
     motion.gyro_bias = emulated.GetGyroBias();


### PR DESCRIPTION
Found by static analysis with PVS-Studio.

It's only a guess, but code looks wrong as is. @german77 should check if this is indeed a correct replacement.