### PR TITLE
shader_recompiler: fix potential OOB access

### DIFF
--- a/src/shader_recompiler/backend/glsl/glsl_emit_context.cpp
+++ b/src/shader_recompiler/backend/glsl/glsl_emit_context.cpp
@@ -458,9 +458,10 @@ void EmitContext::DefineGenericOutput(size_t index, u32 invocations) {
         std::string definition{fmt::format("layout(location={}", index)};
         const u32 remainder{4 - element};
         const TransformFeedbackVarying* xfb_varying{};
-        if (!runtime_info.xfb_varyings.empty()) {
-            xfb_varying = &runtime_info.xfb_varyings[base_index + element];
-            xfb_varying = xfb_varying && xfb_varying->components > 0 ? xfb_varying : nullptr;
+        const size_t xfb_varying_index{base_index + element};
+        if (xfb_varying_index < runtime_info.xfb_varyings.size()) {
+            xfb_varying = &runtime_info.xfb_varyings[xfb_varying_index];
+            xfb_varying = xfb_varying->components > 0 ? xfb_varying : nullptr;
         }
         const u32 num_components{xfb_varying ? xfb_varying->components : remainder};
         if (element > 0) {

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -164,9 +164,10 @@ void DefineGenericOutput(EmitContext& ctx, size_t index, std::optional<u32> invo
     while (element < 4) {
         const u32 remainder{4 - element};
         const TransformFeedbackVarying* xfb_varying{};
-        if (!ctx.runtime_info.xfb_varyings.empty()) {
-            xfb_varying = &ctx.runtime_info.xfb_varyings[base_attr_index + element];
-            xfb_varying = xfb_varying && xfb_varying->components > 0 ? xfb_varying : nullptr;
+        const size_t xfb_varying_index{base_attr_index + element};
+        if (xfb_varying_index < ctx.runtime_info.xfb_varyings.size()) {
+            xfb_varying = &ctx.runtime_info.xfb_varyings[xfb_varying_index];
+            xfb_varying = xfb_varying->components > 0 ? xfb_varying : nullptr;
         }
         const u32 num_components{xfb_varying ? xfb_varying->components : remainder};
 


### PR DESCRIPTION
Found by static analysis with PVS-Studio. Original check wasn't actually checking for OOB and would segfault in case of it.