### PR TITLE
Various fixes to HLE service thread management

### DIFF
--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -341,10 +341,6 @@ public:
         return *thread;
     }
 
-    bool IsThreadWaiting() const {
-        return is_thread_waiting;
-    }
-
 private:
     friend class IPC::ResponseBuilder;
 
@@ -379,7 +375,6 @@ private:
     u32 domain_offset{};
 
     std::shared_ptr<SessionRequestManager> manager;
-    bool is_thread_waiting{};
 
     KernelCore& kernel;
     Core::Memory::Memory& memory;

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -406,6 +406,9 @@ void KScheduler::EnableScheduling(KernelCore& kernel, u64 cores_needing_scheduli
     } else {
         RescheduleCores(kernel, cores_needing_scheduling);
     }
+
+    // Special case to ensure dummy threads that are waiting block.
+    current_thread->IfDummyThreadTryWait();
 }
 
 u64 KScheduler::UpdateHighestPriorityThreads(KernelCore& kernel) {

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -739,6 +739,11 @@ void KScheduler::ScheduleImpl() {
         next_thread = idle_thread;
     }
 
+    // We never want to schedule a dummy thread, as these are only used by host threads for locking.
+    if (next_thread->GetThreadType() == ThreadType::Dummy) {
+        next_thread = idle_thread;
+    }
+
     // If we're not actually switching thread, there's nothing to do.
     if (next_thread == current_thread.load()) {
         previous_thread->EnableDispatch();

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -741,6 +741,7 @@ void KScheduler::ScheduleImpl() {
 
     // We never want to schedule a dummy thread, as these are only used by host threads for locking.
     if (next_thread->GetThreadType() == ThreadType::Dummy) {
+        ASSERT_MSG(false, "Dummy threads should never be scheduled!");
         next_thread = idle_thread;
     }
 

--- a/src/core/hle/kernel/k_server_session.cpp
+++ b/src/core/hle/kernel/k_server_session.cpp
@@ -171,13 +171,8 @@ ResultCode KServerSession::CompleteSyncRequest(HLERequestContext& context) {
         convert_to_domain = false;
     }
 
-    // Some service requests require the thread to block
-    {
-        KScopedSchedulerLock lock(kernel);
-        if (!context.IsThreadWaiting()) {
-            context.GetThread().EndWait(result);
-        }
-    }
+    // The calling thread is waiting for this request to complete, so wake it up.
+    context.GetThread().EndWait(result);
 
     return result;
 }

--- a/src/core/hle/kernel/k_server_session.cpp
+++ b/src/core/hle/kernel/k_server_session.cpp
@@ -8,7 +8,6 @@
 #include "common/assert.h"
 #include "common/common_types.h"
 #include "common/logging/log.h"
-#include "common/scope_exit.h"
 #include "core/core_timing.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/hle_ipc.h"
@@ -123,20 +122,10 @@ ResultCode KServerSession::QueueSyncRequest(KThread* thread, Core::Memory::Memor
 
     context->PopulateFromIncomingCommandBuffer(kernel.CurrentProcess()->GetHandleTable(), cmd_buf);
 
-    // In the event that something fails here, stub a result to prevent the game from crashing.
-    // This is a work-around in the event that somehow we process a service request after the
-    // session has been closed by the game. This has been observed to happen rarely in Pokemon
-    // Sword/Shield and is likely a result of us using host threads/scheduling for services.
-    // TODO(bunnei): Find a better solution here.
-    auto error_guard = SCOPE_GUARD({ CompleteSyncRequest(*context); });
-
     // Ensure we have a session request handler
     if (manager->HasSessionRequestHandler(*context)) {
         if (auto strong_ptr = manager->GetServiceThread().lock()) {
             strong_ptr->QueueSyncRequest(*parent, std::move(context));
-
-            // We succeeded.
-            error_guard.Cancel();
         } else {
             ASSERT_MSG(false, "strong_ptr is nullptr!");
         }

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -1097,14 +1097,14 @@ void KThread::EndWait(ResultCode wait_result_) {
     // Lock the scheduler.
     KScopedSchedulerLock sl(kernel);
 
-    // Dummy threads are just used by host threads for locking, and will never have a wait_queue.
-    if (thread_type == ThreadType::Dummy) {
-        ASSERT_MSG(false, "Dummy threads should never call EndWait!");
-        return;
-    }
-
     // If we're waiting, notify our queue that we're available.
     if (GetState() == ThreadState::Waiting) {
+        if (wait_queue == nullptr) {
+            // This should never happen, but avoid a hard crash below to get this logged.
+            ASSERT_MSG(false, "wait_queue is nullptr!");
+            return;
+        }
+
         wait_queue->EndWait(this, wait_result_);
     }
 }

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -140,7 +140,7 @@ ResultCode KThread::Initialize(KThreadFunction func, uintptr_t arg, VAddr user_s
         UNREACHABLE_MSG("KThread::Initialize: Unknown ThreadType {}", static_cast<u32>(type));
         break;
     }
-    thread_type_for_debugging = type;
+    thread_type = type;
 
     // Set the ideal core ID and affinity mask.
     virtual_ideal_core_id = virt_core;

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -106,7 +106,7 @@ KThread::~KThread() = default;
 ResultCode KThread::Initialize(KThreadFunction func, uintptr_t arg, VAddr user_stack_top, s32 prio,
                                s32 virt_core, KProcess* owner, ThreadType type) {
     // Assert parameters are valid.
-    ASSERT((type == ThreadType::Main) ||
+    ASSERT((type == ThreadType::Main) || (type == ThreadType::Dummy) ||
            (Svc::HighestThreadPriority <= prio && prio <= Svc::LowestThreadPriority));
     ASSERT((owner != nullptr) || (type != ThreadType::User));
     ASSERT(0 <= virt_core && virt_core < static_cast<s32>(Common::BitSize<u64>()));
@@ -262,7 +262,7 @@ ResultCode KThread::InitializeThread(KThread* thread, KThreadFunction func, uint
 }
 
 ResultCode KThread::InitializeDummyThread(KThread* thread) {
-    return thread->Initialize({}, {}, {}, DefaultThreadPriority, 3, {}, ThreadType::Dummy);
+    return thread->Initialize({}, {}, {}, DummyThreadPriority, 3, {}, ThreadType::Dummy);
 }
 
 ResultCode KThread::InitializeIdleThread(Core::System& system, KThread* thread, s32 virt_core) {
@@ -1099,6 +1099,7 @@ void KThread::EndWait(ResultCode wait_result_) {
 
     // Dummy threads are just used by host threads for locking, and will never have a wait_queue.
     if (thread_type == ThreadType::Dummy) {
+        ASSERT_MSG(false, "Dummy threads should never call EndWait!");
         return;
     }
 

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -1097,6 +1097,11 @@ void KThread::EndWait(ResultCode wait_result_) {
     // Lock the scheduler.
     KScopedSchedulerLock sl(kernel);
 
+    // Dummy threads are just used by host threads for locking, and will never have a wait_queue.
+    if (thread_type == ThreadType::Dummy) {
+        return;
+    }
+
     // If we're waiting, notify our queue that we're available.
     if (GetState() == ThreadState::Waiting) {
         wait_queue->EndWait(this, wait_result_);

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -112,6 +112,7 @@ private:
 public:
     static constexpr s32 DefaultThreadPriority = 44;
     static constexpr s32 IdleThreadPriority = Svc::LowestThreadPriority + 1;
+    static constexpr s32 DummyThreadPriority = Svc::LowestThreadPriority + 2;
 
     explicit KThread(KernelCore& kernel_);
     ~KThread() override;

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -553,8 +553,8 @@ public:
         return wait_reason_for_debugging;
     }
 
-    [[nodiscard]] ThreadType GetThreadTypeForDebugging() const {
-        return thread_type_for_debugging;
+    [[nodiscard]] ThreadType GetThreadType() const {
+        return thread_type;
     }
 
     void SetWaitObjectsForDebugging(const std::span<KSynchronizationObject*>& objects) {
@@ -753,12 +753,12 @@ private:
     // For emulation
     std::shared_ptr<Common::Fiber> host_context{};
     bool is_single_core{};
+    ThreadType thread_type{};
 
     // For debugging
     std::vector<KSynchronizationObject*> wait_objects_for_debugging;
     VAddr mutex_wait_address_for_debugging{};
     ThreadWaitReasonForDebugging wait_reason_for_debugging{};
-    ThreadType thread_type_for_debugging{};
 
 public:
     using ConditionVariableThreadTreeType = ConditionVariableThreadTree;

--- a/src/core/hle/kernel/service_thread.cpp
+++ b/src/core/hle/kernel/service_thread.cpp
@@ -12,6 +12,7 @@
 #include "common/scope_exit.h"
 #include "common/thread.h"
 #include "core/hle/kernel/k_session.h"
+#include "core/hle/kernel/k_thread.h"
 #include "core/hle/kernel/kernel.h"
 #include "core/hle/kernel/service_thread.h"
 
@@ -49,6 +50,10 @@ ServiceThread::Impl::Impl(KernelCore& kernel, std::size_t num_threads, const std
             }
 
             kernel.RegisterHostThread();
+
+            // Ensure the dummy thread allocated for this host thread is closed on exit.
+            auto* dummy_thread = kernel.GetCurrentEmuThread();
+            SCOPE_EXIT({ dummy_thread->Close(); });
 
             while (true) {
                 std::function<void()> task;

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -95,7 +95,7 @@ std::vector<std::unique_ptr<WaitTreeThread>> WaitTreeItem::MakeThreadItemList(
     std::size_t row = 0;
     auto add_threads = [&](const std::vector<Kernel::KThread*>& threads) {
         for (std::size_t i = 0; i < threads.size(); ++i) {
-            if (threads[i]->GetThreadTypeForDebugging() == Kernel::ThreadType::User) {
+            if (threads[i]->GetThreadType() == Kernel::ThreadType::User) {
                 item_list.push_back(std::make_unique<WaitTreeThread>(*threads[i], system));
                 item_list.back()->row = row;
             }
@@ -153,7 +153,7 @@ QString WaitTreeCallstack::GetText() const {
 std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeCallstack::GetChildren() const {
     std::vector<std::unique_ptr<WaitTreeItem>> list;
 
-    if (thread.GetThreadTypeForDebugging() != Kernel::ThreadType::User) {
+    if (thread.GetThreadType() != Kernel::ThreadType::User) {
         return list;
     }
 


### PR DESCRIPTION
This change includes various fixes and improvements for HLE service thread management. Primarily, this was motivated by a KThread leak of dummy threads allocated to back service host threads, which are used for grabbing the kernel locks. Previously, we would not release these dummy threads when the service threads were destroyed. For games that create/destroy service interfaces frequently (e.g. Pokémon Sword and Shield), this would result in a pretty severe leak over long gameplay sessions.

Furthermore, previously, these dummy threads could inadvertently get scheduled on core 3 under certain conditions. These aren't threads that can actually be scheduled by the guest emulation, and this could result in a crash (e.g. in Pokémon Sword and Shield after many hours of gameplay). We add some checks to ensure this never happens, as well as decrease the dummy thread priority such that the idle thread is always preferred.

