### PR TITLE
video_core: unbreak build with FFmpeg 5.0

### DIFF
--- a/src/video_core/command_classes/codecs/codec.h
+++ b/src/video_core/command_classes/codecs/codec.h
@@ -66,7 +66,7 @@ private:
     bool initialized{};
     NvdecCommon::VideoCodec current_codec{NvdecCommon::VideoCodec::None};
 
-    AVCodec* av_codec{nullptr};
+    const AVCodec* av_codec{nullptr};
     AVCodecContext* av_codec_ctx{nullptr};
     AVBufferRef* av_gpu_decoder{nullptr};
 


### PR DESCRIPTION
Regressed by https://github.com/ffmpeg/ffmpeg/commit/626535f6a169. From [error log](https://github.com/yuzu-emu/yuzu/files/7904669/yuzu-s20220119_1.log):
```c++
src/video_core/command_classes/codecs/codec.cpp: In member function 'void Tegra::Codec::Initialize()':
src/video_core/command_classes/codecs/codec.cpp:177:36: error: invalid conversion from 'const AVCodec*' to 'AVCodec*' [-fpermissive]
  177 |     av_codec = avcodec_find_decoder(codec);
      |                ~~~~~~~~~~~~~~~~~~~~^~~~~~~
      |                                    |
      |                                    const AVCodec*
```
Runtime tested on [FreeBSD](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=261302) via Super Mario Odyssey (sailing destination previews), Bayonetta 2 (some cut scenes), Metroid Dread (intro).
