### PR TITLE
service: apm: Stub ISession SetCpuOverclockEnabled

### DIFF
--- a/src/core/hle/service/apm/apm_interface.cpp
+++ b/src/core/hle/service/apm/apm_interface.cpp
@@ -17,7 +17,7 @@ public:
         static const FunctionInfo functions[] = {
             {0, &ISession::SetPerformanceConfiguration, "SetPerformanceConfiguration"},
             {1, &ISession::GetPerformanceConfiguration, "GetPerformanceConfiguration"},
-            {2, nullptr, "SetCpuOverclockEnabled"},
+            {2, &ISession::SetCpuOverclockEnabled, "SetCpuOverclockEnabled"},
         };
         RegisterHandlers(functions);
     }
@@ -45,6 +45,18 @@ private:
         IPC::ResponseBuilder rb{ctx, 3};
         rb.Push(ResultSuccess);
         rb.PushEnum(controller.GetCurrentPerformanceConfiguration(mode));
+    }
+
+    void SetCpuOverclockEnabled(Kernel::HLERequestContext& ctx) {
+        IPC::RequestParser rp{ctx};
+
+        const auto cpu_overclock_enabled = rp.Pop<bool>();
+
+        LOG_WARNING(Service_APM, "(STUBBED) called, cpu_overclock_enabled={}",
+                    cpu_overclock_enabled);
+
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(ResultSuccess);
     }
 
     Controller& controller;


### PR DESCRIPTION
Since we don't currently support CPU overclocking within the emulated system, this can be stubbed for now, like APM IsCpuOverclockEnabled.

Fixes #7748 