### PR TITLE
Use Default Colorful theme by default outside of Windows

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -745,8 +745,7 @@ void Config::ReadUIValues() {
     UISettings::values.theme =
         ReadSetting(
             QStringLiteral("theme"),
-            QString::fromUtf8(
-                UISettings::themes[static_cast<size_t>(UISettings::Theme::DarkColorful)].second))
+            QString::fromUtf8(UISettings::themes[static_cast<size_t>(default_theme)].second))
             .toString();
     ReadBasicSetting(UISettings::values.enable_discord_presence);
     ReadBasicSetting(UISettings::values.select_user_on_boot);
@@ -1273,10 +1272,8 @@ void Config::SaveSystemValues() {
 void Config::SaveUIValues() {
     qt_config->beginGroup(QStringLiteral("UI"));
 
-    WriteSetting(
-        QStringLiteral("theme"), UISettings::values.theme,
-        QString::fromUtf8(
-            UISettings::themes[static_cast<size_t>(UISettings::Theme::DarkColorful)].second));
+    WriteSetting(QStringLiteral("theme"), UISettings::values.theme,
+                 QString::fromUtf8(UISettings::themes[static_cast<size_t>(default_theme)].second));
     WriteBasicSetting(UISettings::values.enable_discord_presence);
     WriteBasicSetting(UISettings::values.select_user_on_boot);
 

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -48,6 +48,14 @@ public:
     static const std::array<int, Settings::NativeKeyboard::NumKeyboardMods> default_keyboard_mods;
     static const std::array<UISettings::Shortcut, 21> default_hotkeys;
 
+    static constexpr UISettings::Theme default_theme{
+#ifdef _WIN32
+        UISettings::Theme::DarkColorful
+#else
+        UISettings::Theme::DefaultColorful
+#endif
+    };
+
 private:
     void Initialize(const std::string& config_name);
 


### PR DESCRIPTION
On OSes with system-wide theming this allows yuzu to follow system style, regardless of its exact coloration, working well with both light and dark system themes. Dark /Colorful, on the other hand, forces dark theme regardless of user preferences set in system settings, making for a poor default.

Use Colorful variation to keep in line with icon style of patron-voted Dark Colorful.