### PR TITLE
yuzu: Add setting to disable controller navigation

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -554,6 +554,7 @@ struct Values {
     Setting<bool> use_docked_mode{true, "use_docked_mode"};
 
     BasicSetting<bool> enable_raw_input{false, "enable_raw_input"};
+    BasicSetting<bool> controller_navigation{true, "controller_navigation"};
 
     Setting<bool> vibration_enabled{true, "vibration_enabled"};
     Setting<bool> enable_accurate_vibrations{false, "enable_accurate_vibrations"};

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -393,6 +393,8 @@ void Config::ReadControlValues() {
     ReadGlobalSetting(Settings::values.enable_accurate_vibrations);
     ReadGlobalSetting(Settings::values.motion_enabled);
 
+    ReadBasicSetting(Settings::values.controller_navigation);
+
     qt_config->endGroup();
 }
 
@@ -1001,6 +1003,7 @@ void Config::SaveControlValues() {
     WriteBasicSetting(Settings::values.keyboard_enabled);
     WriteBasicSetting(Settings::values.emulate_analog_keyboard);
     WriteBasicSetting(Settings::values.mouse_panning_sensitivity);
+    WriteBasicSetting(Settings::values.controller_navigation);
 
     WriteBasicSetting(Settings::values.tas_enable);
     WriteBasicSetting(Settings::values.tas_loop);

--- a/src/yuzu/configuration/configure_input_advanced.cpp
+++ b/src/yuzu/configuration/configure_input_advanced.cpp
@@ -131,6 +131,7 @@ void ConfigureInputAdvanced::ApplyConfiguration() {
     Settings::values.touchscreen.enabled = ui->touchscreen_enabled->isChecked();
     Settings::values.enable_raw_input = ui->enable_raw_input->isChecked();
     Settings::values.enable_udp_controller = ui->enable_udp_controller->isChecked();
+    Settings::values.controller_navigation = ui->controller_navigation->isChecked();
 }
 
 void ConfigureInputAdvanced::LoadConfiguration() {
@@ -162,6 +163,7 @@ void ConfigureInputAdvanced::LoadConfiguration() {
     ui->touchscreen_enabled->setChecked(Settings::values.touchscreen.enabled);
     ui->enable_raw_input->setChecked(Settings::values.enable_raw_input.GetValue());
     ui->enable_udp_controller->setChecked(Settings::values.enable_udp_controller.GetValue());
+    ui->controller_navigation->setChecked(Settings::values.controller_navigation.GetValue());
 
     UpdateUIEnabled();
 }

--- a/src/yuzu/configuration/configure_input_advanced.ui
+++ b/src/yuzu/configuration/configure_input_advanced.ui
@@ -2655,6 +2655,19 @@
                      </widget>
                    </item>
                    <item row="4" column="0">
+                     <widget class="QCheckBox" name="controller_navigation">
+                       <property name="minimumSize">
+                         <size>
+                           <width>0</width>
+                           <height>23</height>
+                         </size>
+                       </property>
+                       <property name="text">
+                         <string>Controller navigation</string>
+                       </property>
+                     </widget>
+                   </item>
+                   <item row="5" column="0">
                      <widget class="QCheckBox" name="mouse_panning">
                        <property name="minimumSize">
                          <size>
@@ -2667,7 +2680,7 @@
                        </property>
                      </widget>
                    </item>
-                   <item row="4" column="2">
+                   <item row="5" column="2">
                      <widget class="QSpinBox" name="mouse_panning_sensitivity">
                        <property name="toolTip">
                          <string>Mouse sensitivity</string>
@@ -2689,14 +2702,14 @@
                        </property>
                      </widget>
                    </item>
-                   <item row="5" column="0">
+                   <item row="6" column="0">
                      <widget class="QLabel" name="motion_touch">
                        <property name="text">
                          <string>Motion / Touch</string>
                        </property>
                      </widget>
                    </item>
-                   <item row="5" column="2">
+                   <item row="6" column="2">
                      <widget class="QPushButton" name="buttonMotionTouch">
                        <property name="text">
                          <string>Configure</string>

--- a/src/yuzu/hotkeys.cpp
+++ b/src/yuzu/hotkeys.cpp
@@ -190,6 +190,9 @@ void ControllerShortcut::ControllerUpdateEvent(Core::HID::ControllerTriggerType 
     if (type != Core::HID::ControllerTriggerType::Button) {
         return;
     }
+    if (!Settings::values.controller_navigation) {
+        return;
+    }
     if (button_sequence.npad.raw == Core::HID::NpadButton::None &&
         button_sequence.capture.raw == 0 && button_sequence.home.raw == 0) {
         return;

--- a/src/yuzu/util/controller_navigation.cpp
+++ b/src/yuzu/util/controller_navigation.cpp
@@ -40,6 +40,9 @@ void ControllerNavigation::TriggerButton(Settings::NativeButton::Values native_b
 
 void ControllerNavigation::ControllerUpdateEvent(Core::HID::ControllerTriggerType type) {
     std::lock_guard lock{mutex};
+    if (!Settings::values.controller_navigation) {
+        return;
+    }
     if (type == Core::HID::ControllerTriggerType::Button) {
         ControllerUpdateButton();
         return;


### PR DESCRIPTION
Some users use external programs to translate controller input into keyboard input. This conflicts with controller navigation. Add a setting to fully disable controller navigation.

Closes #7758