### PR TITLE
input_common: Add option to configure gyro threshold

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -749,6 +749,7 @@ void EmulatedController::SetMotion(const Common::Input::CallbackStatus& callback
         raw_status.gyro.y.value,
         raw_status.gyro.z.value,
     });
+    emulated.SetGyroThreshold(raw_status.gyro.x.properties.threshold);
     emulated.UpdateRotation(raw_status.delta_timestamp);
     emulated.UpdateOrientation(raw_status.delta_timestamp);
     force_update_motion = raw_status.force_update;

--- a/src/core/hid/motion_input.cpp
+++ b/src/core/hid/motion_input.cpp
@@ -10,7 +10,7 @@ namespace Core::HID {
 MotionInput::MotionInput() {
     // Initialize PID constants with default values
     SetPID(0.3f, 0.005f, 0.0f);
-    SetGyroThreshold(0.00005f);
+    SetGyroThreshold(0.007f);
 }
 
 void MotionInput::SetPID(f32 new_kp, f32 new_ki, f32 new_kd) {
@@ -31,7 +31,7 @@ void MotionInput::SetGyroscope(const Common::Vec3f& gyroscope) {
         gyro_bias = (gyro_bias * 0.9999f) + (gyroscope * 0.0001f);
     }
 
-    if (gyro.Length2() < gyro_threshold) {
+    if (gyro.Length() < gyro_threshold) {
         gyro = {};
     } else {
         only_accelerometer = false;

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -403,10 +403,22 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
         connect(button, &QPushButton::customContextMenuRequested,
                 [=, this](const QPoint& menu_location) {
                     QMenu context_menu;
+                    Common::ParamPackage param = emulated_controller->GetMotionParam(motion_id);
                     context_menu.addAction(tr("Clear"), [&] {
                         emulated_controller->SetMotionParam(motion_id, {});
                         motion_map[motion_id]->setText(tr("[not set]"));
                     });
+                    if (param.Has("motion")) {
+                        context_menu.addAction(tr("Set gyro threshold"), [&] {
+                            const int gyro_threshold =
+                                static_cast<int>(param.Get("threshold", 0.007f) * 1000.0f);
+                            const int new_threshold = QInputDialog::getInt(
+                                this, tr("Set threshold"), tr("Choose a value between 0% and 100%"),
+                                gyro_threshold, 0, 100);
+                            param.Set("threshold", new_threshold / 1000.0f);
+                            emulated_controller->SetMotionParam(motion_id, param);
+                        });
+                    }
                     context_menu.exec(motion_map[motion_id]->mapToGlobal(menu_location));
                 });
     }


### PR DESCRIPTION
Depending on the sensitivity and quality of the sensor one might want to change the gyro threshold to provide the best motion experience for everyone. 

90% of the time you will not need to change this. Only if you experience gyro drift or motion is not detected on very slow movements.