### PR TITLE
input_common/udp_client: Replace deprecated from_string()/to_ulong() functions

### DIFF
--- a/src/input_common/drivers/udp_client.cpp
+++ b/src/input_common/drivers/udp_client.cpp
@@ -349,8 +349,8 @@ PadIdentifier UDPClient::GetPadIdentifier(std::size_t pad_index) const {
 }
 
 Common::UUID UDPClient::GetHostUUID(const std::string& host) const {
-    const auto ip = boost::asio::ip::address_v4::from_string(host);
-    const auto hex_host = fmt::format("{:06x}", ip.to_ulong());
+    const auto ip = boost::asio::ip::make_address_v4(host);
+    const auto hex_host = fmt::format("{:06x}", ip.to_uint());
     return Common::UUID{hex_host};
 }
 

--- a/src/input_common/drivers/udp_client.cpp
+++ b/src/input_common/drivers/udp_client.cpp
@@ -339,7 +339,7 @@ void UDPClient::StartCommunication(std::size_t client, const std::string& host, 
     }
 }
 
-const PadIdentifier UDPClient::GetPadIdentifier(std::size_t pad_index) const {
+PadIdentifier UDPClient::GetPadIdentifier(std::size_t pad_index) const {
     const std::size_t client = pad_index / PADS_PER_CLIENT;
     return {
         .guid = clients[client].uuid,
@@ -348,7 +348,7 @@ const PadIdentifier UDPClient::GetPadIdentifier(std::size_t pad_index) const {
     };
 }
 
-const Common::UUID UDPClient::GetHostUUID(const std::string host) const {
+Common::UUID UDPClient::GetHostUUID(const std::string& host) const {
     const auto ip = boost::asio::ip::address_v4::from_string(host);
     const auto hex_host = fmt::format("{:06x}", ip.to_ulong());
     return Common::UUID{hex_host};

--- a/src/input_common/drivers/udp_client.h
+++ b/src/input_common/drivers/udp_client.h
@@ -145,8 +145,8 @@ private:
     void OnPortInfo(Response::PortInfo);
     void OnPadData(Response::PadData, std::size_t client);
     void StartCommunication(std::size_t client, const std::string& host, u16 port);
-    const PadIdentifier GetPadIdentifier(std::size_t pad_index) const;
-    const Common::UUID GetHostUUID(const std::string host) const;
+    PadIdentifier GetPadIdentifier(std::size_t pad_index) const;
+    Common::UUID GetHostUUID(const std::string& host) const;
 
     Common::Input::ButtonNames GetUIButtonName(const Common::ParamPackage& params) const;
 


### PR DESCRIPTION
These are deprecated and `make_address` variants and `to_uint()` should be used instead.

Just prevents the UDP client from breaking in the event the deprecated functions get removed at some point.