### PR TITLE
input_common/main: Pass MappingData by const reference in callbacks

### DIFF
--- a/src/input_common/input_engine.h
+++ b/src/input_common/input_engine.h
@@ -89,7 +89,7 @@ struct UpdateCallback {
 
 // Triggered if data changed on the controller and the engine is on configuring mode
 struct MappingCallback {
-    std::function<void(MappingData)> on_data;
+    std::function<void(const MappingData&)> on_data;
 };
 
 // Input Identifier of data source

--- a/src/input_common/input_engine.h
+++ b/src/input_common/input_engine.h
@@ -16,7 +16,7 @@
 
 // Pad Identifier of data source
 struct PadIdentifier {
-    Common::UUID guid{};
+    Common::UUID guid{Common::INVALID_UUID};
     std::size_t port{};
     std::size_t pad{};
 

--- a/src/input_common/input_mapping.cpp
+++ b/src/input_common/input_mapping.cpp
@@ -56,7 +56,7 @@ void MappingFactory::StopMapping() {
 void MappingFactory::RegisterButton(const MappingData& data) {
     Common::ParamPackage new_input;
     new_input.Set("engine", data.engine);
-    if (data.pad.guid != Common::UUID{}) {
+    if (data.pad.guid.IsValid()) {
         new_input.Set("guid", data.pad.guid.Format());
     }
     new_input.Set("port", static_cast<int>(data.pad.port));
@@ -92,7 +92,7 @@ void MappingFactory::RegisterButton(const MappingData& data) {
 void MappingFactory::RegisterStick(const MappingData& data) {
     Common::ParamPackage new_input;
     new_input.Set("engine", data.engine);
-    if (data.pad.guid != Common::UUID{}) {
+    if (data.pad.guid.IsValid()) {
         new_input.Set("guid", data.pad.guid.Format());
     }
     new_input.Set("port", static_cast<int>(data.pad.port));
@@ -137,7 +137,7 @@ void MappingFactory::RegisterStick(const MappingData& data) {
 void MappingFactory::RegisterMotion(const MappingData& data) {
     Common::ParamPackage new_input;
     new_input.Set("engine", data.engine);
-    if (data.pad.guid != Common::UUID{}) {
+    if (data.pad.guid.IsValid()) {
         new_input.Set("guid", data.pad.guid.Format());
     }
     new_input.Set("port", static_cast<int>(data.pad.port));

--- a/src/input_common/input_mapping.cpp
+++ b/src/input_common/input_mapping.cpp
@@ -9,7 +9,7 @@
 
 namespace InputCommon {
 
-MappingFactory::MappingFactory() {}
+MappingFactory::MappingFactory() = default;
 
 void MappingFactory::BeginMapping(Polling::InputType type) {
     is_enabled = true;

--- a/src/input_common/input_mapping.cpp
+++ b/src/input_common/input_mapping.cpp
@@ -2,7 +2,6 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included
 
-#include "common/common_types.h"
 #include "common/settings.h"
 #include "input_common/input_engine.h"
 #include "input_common/input_mapping.h"

--- a/src/input_common/input_mapping.cpp
+++ b/src/input_common/input_mapping.cpp
@@ -19,7 +19,7 @@ void MappingFactory::BeginMapping(Polling::InputType type) {
     second_axis = -1;
 }
 
-[[nodiscard]] const Common::ParamPackage MappingFactory::GetNextInput() {
+Common::ParamPackage MappingFactory::GetNextInput() {
     Common::ParamPackage input;
     input_queue.Pop(input);
     return input;

--- a/src/input_common/input_mapping.h
+++ b/src/input_common/input_mapping.h
@@ -3,7 +3,13 @@
 // Refer to the license.txt file included
 
 #pragma once
+
+#include "common/param_package.h"
 #include "common/threadsafe_queue.h"
+
+namespace InputCommon::Polling {
+enum class InputType;
+}
 
 namespace InputCommon {
 class InputEngine;

--- a/src/input_common/input_mapping.h
+++ b/src/input_common/input_mapping.h
@@ -20,7 +20,7 @@ public:
     void BeginMapping(Polling::InputType type);
 
     /// Returns an input event with mapping information from the input_queue
-    [[nodiscard]] const Common::ParamPackage GetNextInput();
+    [[nodiscard]] Common::ParamPackage GetNextInput();
 
     /**
      * Registers mapping input data from the driver

--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -394,7 +394,7 @@ void InputSubsystem::BeginMapping(Polling::InputType type) {
     impl->mapping_factory->BeginMapping(type);
 }
 
-const Common::ParamPackage InputSubsystem::GetNextInput() const {
+Common::ParamPackage InputSubsystem::GetNextInput() const {
     return impl->mapping_factory->GetNextInput();
 }
 

--- a/src/input_common/main.cpp
+++ b/src/input_common/main.cpp
@@ -27,7 +27,7 @@ namespace InputCommon {
 struct InputSubsystem::Impl {
     void Initialize() {
         mapping_factory = std::make_shared<MappingFactory>();
-        MappingCallback mapping_callback{[this](MappingData data) { RegisterInput(data); }};
+        MappingCallback mapping_callback{[this](const MappingData& data) { RegisterInput(data); }};
 
         keyboard = std::make_shared<Keyboard>("keyboard");
         keyboard->SetMappingCallback(mapping_callback);
@@ -284,7 +284,7 @@ struct InputSubsystem::Impl {
 #endif
     }
 
-    void RegisterInput(MappingData data) {
+    void RegisterInput(const MappingData& data) {
         mapping_factory->RegisterInput(data);
     }
 

--- a/src/input_common/main.h
+++ b/src/input_common/main.h
@@ -126,7 +126,7 @@ public:
     void BeginMapping(Polling::InputType type);
 
     /// Returns an input event with mapping information.
-    [[nodiscard]] const Common::ParamPackage GetNextInput() const;
+    [[nodiscard]] Common::ParamPackage GetNextInput() const;
 
     /// Stop polling from all backends.
     void StopMapping() const;


### PR DESCRIPTION
Avoids creating unnecessary 168 byte copies per callback invocation.

Also does some minor touchups while in the area.