### PR TITLE
shader_recompiler: Remove unnecessary [[nodiscard]] specifier

### DIFF
--- a/src/shader_recompiler/frontend/maxwell/translate_program.h
+++ b/src/shader_recompiler/frontend/maxwell/translate_program.h
@@ -21,7 +21,6 @@ namespace Shader::Maxwell {
 [[nodiscard]] IR::Program MergeDualVertexPrograms(IR::Program& vertex_a, IR::Program& vertex_b,
                                                   Environment& env_vertex_b);
 
-[[nodiscard]] void ConvertLegacyToGeneric(IR::Program& program,
-                                          const Shader::RuntimeInfo& runtime_info);
+void ConvertLegacyToGeneric(IR::Program& program, const RuntimeInfo& runtime_info);
 
 } // namespace Shader::Maxwell


### PR DESCRIPTION
Since `ConvertLegacyToGeneric` has a void return value, there's nothing that is actually returned by the function.

Should get rid of some warnings when compiling