### PR TITLE
gpu: Remove obsoleted CDmaPusher() accessors

### DIFF
--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -12,9 +12,6 @@
 #include "video_core/framebuffer_config.h"
 
 namespace Core {
-namespace Frontend {
-class EmuWindow;
-}
 class System;
 } // namespace Core
 
@@ -25,7 +22,6 @@ class ShaderNotify;
 
 namespace Tegra {
 class DmaPusher;
-class CDmaPusher;
 struct CommandList;
 
 enum class RenderTargetFormat : u32 {
@@ -88,15 +84,9 @@ enum class DepthFormat : u32 {
     D32_FLOAT_S8X24_UINT = 0x19,
 };
 
-struct CommandListHeader;
-class DebugContext;
-
 namespace Engines {
-class Fermi2D;
 class Maxwell3D;
-class MaxwellDMA;
 class KeplerCompute;
-class KeplerMemory;
 } // namespace Engines
 
 enum class EngineID {

--- a/src/video_core/gpu.h
+++ b/src/video_core/gpu.h
@@ -190,12 +190,6 @@ public:
     /// Returns a const reference to the GPU DMA pusher.
     [[nodiscard]] const Tegra::DmaPusher& DmaPusher() const;
 
-    /// Returns a reference to the GPU CDMA pusher.
-    [[nodiscard]] Tegra::CDmaPusher& CDmaPusher();
-
-    /// Returns a const reference to the GPU CDMA pusher.
-    [[nodiscard]] const Tegra::CDmaPusher& CDmaPusher() const;
-
     /// Returns a reference to the underlying renderer.
     [[nodiscard]] VideoCore::RendererBase& Renderer();
 


### PR DESCRIPTION
These were obsoleted in 2c47f8aa1886522898b5b3a73185b5662be3e9f3 but were accidentally overlooked.

While we're in the same area, we can remove some forward declarations that are no longer necessary.