### PR TITLE
video_core/macro: Move impl classes into their cpp files

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -240,7 +240,7 @@ void Maxwell3D::CallMacroMethod(u32 method, const std::vector<u32>& parameters) 
         ((method - MacroRegistersStart) >> 1) % static_cast<u32>(macro_positions.size());
 
     // Execute the current macro.
-    macro_engine->Execute(*this, macro_positions[entry], parameters);
+    macro_engine->Execute(macro_positions[entry], parameters);
     if (mme_draw.current_mode != MMEDrawMode::Undefined) {
         FlushMMEInlineDraw();
     }

--- a/src/video_core/macro/macro.cpp
+++ b/src/video_core/macro/macro.cpp
@@ -24,8 +24,7 @@ void MacroEngine::AddCode(u32 method, u32 data) {
     uploaded_macro_code[method].push_back(data);
 }
 
-void MacroEngine::Execute(Engines::Maxwell3D& maxwell3d, u32 method,
-                          const std::vector<u32>& parameters) {
+void MacroEngine::Execute(u32 method, const std::vector<u32>& parameters) {
     auto compiled_macro = macro_cache.find(method);
     if (compiled_macro != macro_cache.end()) {
         const auto& cache_info = compiled_macro->second;

--- a/src/video_core/macro/macro.cpp
+++ b/src/video_core/macro/macro.cpp
@@ -65,10 +65,9 @@ void MacroEngine::Execute(u32 method, const std::vector<u32>& parameters) {
             cache_info.lle_program = Compile(code);
         }
 
-        auto hle_program = hle_macros->GetHLEProgram(cache_info.hash);
-        if (hle_program.has_value()) {
+        if (auto hle_program = hle_macros->GetHLEProgram(cache_info.hash)) {
             cache_info.has_hle_program = true;
-            cache_info.hle_program = std::move(hle_program.value());
+            cache_info.hle_program = std::move(hle_program);
             cache_info.hle_program->Execute(parameters, method);
         } else {
             cache_info.lle_program->Execute(parameters, method);

--- a/src/video_core/macro/macro.cpp
+++ b/src/video_core/macro/macro.cpp
@@ -2,12 +2,13 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <cstring>
 #include <optional>
+
 #include <boost/container_hash/hash.hpp>
+
 #include "common/assert.h"
-#include "common/logging/log.h"
 #include "common/settings.h"
-#include "video_core/engines/maxwell_3d.h"
 #include "video_core/macro/macro.h"
 #include "video_core/macro/macro_hle.h"
 #include "video_core/macro/macro_interpreter.h"

--- a/src/video_core/macro/macro.h
+++ b/src/video_core/macro/macro.h
@@ -119,7 +119,7 @@ public:
     void AddCode(u32 method, u32 data);
 
     // Compiles the macro if its not in the cache, and executes the compiled macro
-    void Execute(Engines::Maxwell3D& maxwell3d, u32 method, const std::vector<u32>& parameters);
+    void Execute(u32 method, const std::vector<u32>& parameters);
 
 protected:
     virtual std::unique_ptr<CachedMacro> Compile(const std::vector<u32>& code) = 0;

--- a/src/video_core/macro/macro_hle.cpp
+++ b/src/video_core/macro/macro_hle.cpp
@@ -105,11 +105,11 @@ private:
 HLEMacro::HLEMacro(Engines::Maxwell3D& maxwell3d_) : maxwell3d{maxwell3d_} {}
 HLEMacro::~HLEMacro() = default;
 
-std::optional<std::unique_ptr<CachedMacro>> HLEMacro::GetHLEProgram(u64 hash) const {
+std::unique_ptr<CachedMacro> HLEMacro::GetHLEProgram(u64 hash) const {
     const auto it = std::find_if(hle_funcs.cbegin(), hle_funcs.cend(),
                                  [hash](const auto& pair) { return pair.first == hash; });
     if (it == hle_funcs.end()) {
-        return std::nullopt;
+        return nullptr;
     }
     return std::make_unique<HLEMacroImpl>(maxwell3d, it->second);
 }

--- a/src/video_core/macro/macro_hle.h
+++ b/src/video_core/macro/macro_hle.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <memory>
-#include <optional>
 #include "common/common_types.h"
 
 namespace Tegra {
@@ -19,7 +18,9 @@ public:
     explicit HLEMacro(Engines::Maxwell3D& maxwell3d_);
     ~HLEMacro();
 
-    std::optional<std::unique_ptr<CachedMacro>> GetHLEProgram(u64 hash) const;
+    // Allocates and returns a cached macro if the hash matches a known function.
+    // Returns nullptr otherwise.
+    [[nodiscard]] std::unique_ptr<CachedMacro> GetHLEProgram(u64 hash) const;
 
 private:
     Engines::Maxwell3D& maxwell3d;

--- a/src/video_core/macro/macro_hle.h
+++ b/src/video_core/macro/macro_hle.h
@@ -6,17 +6,13 @@
 
 #include <memory>
 #include <optional>
-#include <vector>
 #include "common/common_types.h"
-#include "video_core/macro/macro.h"
 
 namespace Tegra {
 
 namespace Engines {
 class Maxwell3D;
 }
-
-using HLEFunction = void (*)(Engines::Maxwell3D& maxwell3d, const std::vector<u32>& parameters);
 
 class HLEMacro {
 public:
@@ -27,18 +23,6 @@ public:
 
 private:
     Engines::Maxwell3D& maxwell3d;
-};
-
-class HLEMacroImpl : public CachedMacro {
-public:
-    explicit HLEMacroImpl(Engines::Maxwell3D& maxwell3d, HLEFunction func);
-    ~HLEMacroImpl();
-
-    void Execute(const std::vector<u32>& parameters, u32 method) override;
-
-private:
-    Engines::Maxwell3D& maxwell3d;
-    HLEFunction func;
 };
 
 } // namespace Tegra

--- a/src/video_core/macro/macro_interpreter.h
+++ b/src/video_core/macro/macro_interpreter.h
@@ -3,10 +3,9 @@
 // Refer to the license.txt file included.
 
 #pragma once
-#include <array>
-#include <optional>
+
 #include <vector>
-#include "common/bit_field.h"
+
 #include "common/common_types.h"
 #include "video_core/macro/macro.h"
 
@@ -24,79 +23,6 @@ protected:
 
 private:
     Engines::Maxwell3D& maxwell3d;
-};
-
-class MacroInterpreterImpl : public CachedMacro {
-public:
-    explicit MacroInterpreterImpl(Engines::Maxwell3D& maxwell3d_, const std::vector<u32>& code_);
-    void Execute(const std::vector<u32>& params, u32 method) override;
-
-private:
-    /// Resets the execution engine state, zeroing registers, etc.
-    void Reset();
-
-    /**
-     * Executes a single macro instruction located at the current program counter. Returns whether
-     * the interpreter should keep running.
-     *
-     * @param is_delay_slot Whether the current step is being executed due to a delay slot in a
-     *                      previous instruction.
-     */
-    bool Step(bool is_delay_slot);
-
-    /// Calculates the result of an ALU operation. src_a OP src_b;
-    u32 GetALUResult(Macro::ALUOperation operation, u32 src_a, u32 src_b);
-
-    /// Performs the result operation on the input result and stores it in the specified register
-    /// (if necessary).
-    void ProcessResult(Macro::ResultOperation operation, u32 reg, u32 result);
-
-    /// Evaluates the branch condition and returns whether the branch should be taken or not.
-    bool EvaluateBranchCondition(Macro::BranchCondition cond, u32 value) const;
-
-    /// Reads an opcode at the current program counter location.
-    Macro::Opcode GetOpcode() const;
-
-    /// Returns the specified register's value. Register 0 is hardcoded to always return 0.
-    u32 GetRegister(u32 register_id) const;
-
-    /// Sets the register to the input value.
-    void SetRegister(u32 register_id, u32 value);
-
-    /// Sets the method address to use for the next Send instruction.
-    void SetMethodAddress(u32 address);
-
-    /// Calls a GPU Engine method with the input parameter.
-    void Send(u32 value);
-
-    /// Reads a GPU register located at the method address.
-    u32 Read(u32 method) const;
-
-    /// Returns the next parameter in the parameter queue.
-    u32 FetchParameter();
-
-    Engines::Maxwell3D& maxwell3d;
-
-    /// Current program counter
-    u32 pc;
-    /// Program counter to execute at after the delay slot is executed.
-    std::optional<u32> delayed_pc;
-
-    /// General purpose macro registers.
-    std::array<u32, Macro::NUM_MACRO_REGISTERS> registers = {};
-
-    /// Method address to use for the next Send instruction.
-    Macro::MethodAddress method_address = {};
-
-    /// Input parameters of the current macro.
-    std::unique_ptr<u32[]> parameters;
-    std::size_t num_parameters = 0;
-    std::size_t parameters_capacity = 0;
-    /// Index of the next parameter that will be fetched by the 'parm' instruction.
-    u32 next_parameter_index = 0;
-
-    bool carry_flag = false;
-    const std::vector<u32>& code;
 };
 
 } // namespace Tegra

--- a/src/video_core/macro/macro_jit_x64.cpp
+++ b/src/video_core/macro/macro_jit_x64.cpp
@@ -40,6 +40,10 @@ const std::bitset<32> PERSISTENT_REGISTERS = Common::X64::BuildRegSet({
 // Arbitrarily chosen based on current booting games.
 constexpr size_t MAX_CODE_SIZE = 0x10000;
 
+std::bitset<32> PersistentCallerSavedRegs() {
+    return PERSISTENT_REGISTERS & Common::X64::ABI_ALL_CALLER_SAVED;
+}
+
 class MacroJITx64Impl final : public Xbyak::CodeGenerator, public CachedMacro {
 public:
     explicit MacroJITx64Impl(Engines::Maxwell3D& maxwell3d_, const std::vector<u32>& code_)
@@ -70,7 +74,6 @@ private:
     void Compile_Send(Xbyak::Reg32 value);
 
     Macro::Opcode GetOpCode() const;
-    std::bitset<32> PersistentCallerSavedRegs() const;
 
     struct JITState {
         Engines::Maxwell3D* maxwell3d{};
@@ -673,10 +676,6 @@ void MacroJITx64Impl::Compile_ProcessResult(Macro::ResultOperation operation, u3
 Macro::Opcode MacroJITx64Impl::GetOpCode() const {
     ASSERT(pc < code.size());
     return {code[pc]};
-}
-
-std::bitset<32> MacroJITx64Impl::PersistentCallerSavedRegs() const {
-    return PERSISTENT_REGISTERS & Common::X64::ABI_ALL_CALLER_SAVED;
 }
 } // Anonymous namespace
 

--- a/src/video_core/macro/macro_jit_x64.cpp
+++ b/src/video_core/macro/macro_jit_x64.cpp
@@ -2,9 +2,17 @@
 // Licensed under GPLv2 or any later version
 // Refer to the license.txt file included.
 
+#include <array>
+#include <bitset>
+#include <optional>
+
+#include <xbyak/xbyak.h>
+
 #include "common/assert.h"
+#include "common/bit_field.h"
 #include "common/logging/log.h"
 #include "common/microprofile.h"
+#include "common/x64/xbyak_abi.h"
 #include "common/x64/xbyak_util.h"
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/macro/macro_interpreter.h"
@@ -14,13 +22,14 @@ MICROPROFILE_DEFINE(MacroJitCompile, "GPU", "Compile macro JIT", MP_RGB(173, 255
 MICROPROFILE_DEFINE(MacroJitExecute, "GPU", "Execute macro JIT", MP_RGB(255, 255, 0));
 
 namespace Tegra {
+namespace {
 constexpr Xbyak::Reg64 STATE = Xbyak::util::rbx;
 constexpr Xbyak::Reg32 RESULT = Xbyak::util::ebp;
 constexpr Xbyak::Reg64 PARAMETERS = Xbyak::util::r12;
 constexpr Xbyak::Reg32 METHOD_ADDRESS = Xbyak::util::r14d;
 constexpr Xbyak::Reg64 BRANCH_HOLDER = Xbyak::util::r15;
 
-static const std::bitset<32> PERSISTENT_REGISTERS = Common::X64::BuildRegSet({
+const std::bitset<32> PERSISTENT_REGISTERS = Common::X64::BuildRegSet({
     STATE,
     RESULT,
     PARAMETERS,
@@ -28,19 +37,73 @@ static const std::bitset<32> PERSISTENT_REGISTERS = Common::X64::BuildRegSet({
     BRANCH_HOLDER,
 });
 
-MacroJITx64::MacroJITx64(Engines::Maxwell3D& maxwell3d_)
-    : MacroEngine{maxwell3d_}, maxwell3d{maxwell3d_} {}
+// Arbitrarily chosen based on current booting games.
+constexpr size_t MAX_CODE_SIZE = 0x10000;
 
-std::unique_ptr<CachedMacro> MacroJITx64::Compile(const std::vector<u32>& code) {
-    return std::make_unique<MacroJITx64Impl>(maxwell3d, code);
-}
+class MacroJITx64Impl final : public Xbyak::CodeGenerator, public CachedMacro {
+public:
+    explicit MacroJITx64Impl(Engines::Maxwell3D& maxwell3d_, const std::vector<u32>& code_)
+        : CodeGenerator{MAX_CODE_SIZE}, code{code_}, maxwell3d{maxwell3d_} {
+        Compile();
+    }
 
-MacroJITx64Impl::MacroJITx64Impl(Engines::Maxwell3D& maxwell3d_, const std::vector<u32>& code_)
-    : CodeGenerator{MAX_CODE_SIZE}, code{code_}, maxwell3d{maxwell3d_} {
-    Compile();
-}
+    void Execute(const std::vector<u32>& parameters, u32 method) override;
 
-MacroJITx64Impl::~MacroJITx64Impl() = default;
+    void Compile_ALU(Macro::Opcode opcode);
+    void Compile_AddImmediate(Macro::Opcode opcode);
+    void Compile_ExtractInsert(Macro::Opcode opcode);
+    void Compile_ExtractShiftLeftImmediate(Macro::Opcode opcode);
+    void Compile_ExtractShiftLeftRegister(Macro::Opcode opcode);
+    void Compile_Read(Macro::Opcode opcode);
+    void Compile_Branch(Macro::Opcode opcode);
+
+private:
+    void Optimizer_ScanFlags();
+
+    void Compile();
+    bool Compile_NextInstruction();
+
+    Xbyak::Reg32 Compile_FetchParameter();
+    Xbyak::Reg32 Compile_GetRegister(u32 index, Xbyak::Reg32 dst);
+
+    void Compile_ProcessResult(Macro::ResultOperation operation, u32 reg);
+    void Compile_Send(Xbyak::Reg32 value);
+
+    Macro::Opcode GetOpCode() const;
+    std::bitset<32> PersistentCallerSavedRegs() const;
+
+    struct JITState {
+        Engines::Maxwell3D* maxwell3d{};
+        std::array<u32, Macro::NUM_MACRO_REGISTERS> registers{};
+        u32 carry_flag{};
+    };
+    static_assert(offsetof(JITState, maxwell3d) == 0, "Maxwell3D is not at 0x0");
+    using ProgramType = void (*)(JITState*, const u32*);
+
+    struct OptimizerState {
+        bool can_skip_carry{};
+        bool has_delayed_pc{};
+        bool zero_reg_skip{};
+        bool skip_dummy_addimmediate{};
+        bool optimize_for_method_move{};
+        bool enable_asserts{};
+    };
+    OptimizerState optimizer{};
+
+    std::optional<Macro::Opcode> next_opcode{};
+    ProgramType program{nullptr};
+
+    std::array<Xbyak::Label, MAX_CODE_SIZE> labels;
+    std::array<Xbyak::Label, MAX_CODE_SIZE> delay_skip;
+    Xbyak::Label end_of_code{};
+
+    bool is_delay_slot{};
+    u32 pc{};
+    std::optional<u32> delayed_pc;
+
+    const std::vector<u32>& code;
+    Engines::Maxwell3D& maxwell3d;
+};
 
 void MacroJITx64Impl::Execute(const std::vector<u32>& parameters, u32 method) {
     MICROPROFILE_SCOPE(MacroJitExecute);
@@ -307,11 +370,11 @@ void MacroJITx64Impl::Compile_Read(Macro::Opcode opcode) {
     Compile_ProcessResult(opcode.result_operation, opcode.dst);
 }
 
-static void Send(Engines::Maxwell3D* maxwell3d, Macro::MethodAddress method_address, u32 value) {
+void Send(Engines::Maxwell3D* maxwell3d, Macro::MethodAddress method_address, u32 value) {
     maxwell3d->CallMethodFromMME(method_address.address, value);
 }
 
-void Tegra::MacroJITx64Impl::Compile_Send(Xbyak::Reg32 value) {
+void MacroJITx64Impl::Compile_Send(Xbyak::Reg32 value) {
     Common::X64::ABI_PushRegistersAndAdjustStack(*this, PersistentCallerSavedRegs(), 0);
     mov(Common::X64::ABI_PARAM1, qword[STATE]);
     mov(Common::X64::ABI_PARAM2, METHOD_ADDRESS);
@@ -338,7 +401,7 @@ void Tegra::MacroJITx64Impl::Compile_Send(Xbyak::Reg32 value) {
     L(dont_process);
 }
 
-void Tegra::MacroJITx64Impl::Compile_Branch(Macro::Opcode opcode) {
+void MacroJITx64Impl::Compile_Branch(Macro::Opcode opcode) {
     ASSERT_MSG(!is_delay_slot, "Executing a branch in a delay slot is not valid");
     const s32 jump_address =
         static_cast<s32>(pc) + static_cast<s32>(opcode.GetBranchTarget() / sizeof(s32));
@@ -392,7 +455,7 @@ void Tegra::MacroJITx64Impl::Compile_Branch(Macro::Opcode opcode) {
     L(end);
 }
 
-void Tegra::MacroJITx64Impl::Optimizer_ScanFlags() {
+void MacroJITx64Impl::Optimizer_ScanFlags() {
     optimizer.can_skip_carry = true;
     optimizer.has_delayed_pc = false;
     for (auto raw_op : code) {
@@ -534,7 +597,7 @@ bool MacroJITx64Impl::Compile_NextInstruction() {
     return true;
 }
 
-Xbyak::Reg32 Tegra::MacroJITx64Impl::Compile_FetchParameter() {
+Xbyak::Reg32 MacroJITx64Impl::Compile_FetchParameter() {
     mov(eax, dword[PARAMETERS]);
     add(PARAMETERS, sizeof(u32));
     return eax;
@@ -615,5 +678,12 @@ Macro::Opcode MacroJITx64Impl::GetOpCode() const {
 std::bitset<32> MacroJITx64Impl::PersistentCallerSavedRegs() const {
     return PERSISTENT_REGISTERS & Common::X64::ABI_ALL_CALLER_SAVED;
 }
+} // Anonymous namespace
 
+MacroJITx64::MacroJITx64(Engines::Maxwell3D& maxwell3d_)
+    : MacroEngine{maxwell3d_}, maxwell3d{maxwell3d_} {}
+
+std::unique_ptr<CachedMacro> MacroJITx64::Compile(const std::vector<u32>& code) {
+    return std::make_unique<MacroJITx64Impl>(maxwell3d, code);
+}
 } // namespace Tegra

--- a/src/video_core/macro/macro_jit_x64.cpp
+++ b/src/video_core/macro/macro_jit_x64.cpp
@@ -102,7 +102,6 @@ private:
 
     bool is_delay_slot{};
     u32 pc{};
-    std::optional<u32> delayed_pc;
 
     const std::vector<u32>& code;
     Engines::Maxwell3D& maxwell3d;

--- a/src/video_core/macro/macro_jit_x64.h
+++ b/src/video_core/macro/macro_jit_x64.h
@@ -4,12 +4,7 @@
 
 #pragma once
 
-#include <array>
-#include <bitset>
-#include <xbyak/xbyak.h>
-#include "common/bit_field.h"
 #include "common/common_types.h"
-#include "common/x64/xbyak_abi.h"
 #include "video_core/macro/macro.h"
 
 namespace Tegra {
@@ -17,9 +12,6 @@ namespace Tegra {
 namespace Engines {
 class Maxwell3D;
 }
-
-/// MAX_CODE_SIZE is arbitrarily chosen based on current booting games
-constexpr size_t MAX_CODE_SIZE = 0x10000;
 
 class MacroJITx64 final : public MacroEngine {
 public:
@@ -29,69 +21,6 @@ protected:
     std::unique_ptr<CachedMacro> Compile(const std::vector<u32>& code) override;
 
 private:
-    Engines::Maxwell3D& maxwell3d;
-};
-
-class MacroJITx64Impl : public Xbyak::CodeGenerator, public CachedMacro {
-public:
-    explicit MacroJITx64Impl(Engines::Maxwell3D& maxwell3d_, const std::vector<u32>& code_);
-    ~MacroJITx64Impl();
-
-    void Execute(const std::vector<u32>& parameters, u32 method) override;
-
-    void Compile_ALU(Macro::Opcode opcode);
-    void Compile_AddImmediate(Macro::Opcode opcode);
-    void Compile_ExtractInsert(Macro::Opcode opcode);
-    void Compile_ExtractShiftLeftImmediate(Macro::Opcode opcode);
-    void Compile_ExtractShiftLeftRegister(Macro::Opcode opcode);
-    void Compile_Read(Macro::Opcode opcode);
-    void Compile_Branch(Macro::Opcode opcode);
-
-private:
-    void Optimizer_ScanFlags();
-
-    void Compile();
-    bool Compile_NextInstruction();
-
-    Xbyak::Reg32 Compile_FetchParameter();
-    Xbyak::Reg32 Compile_GetRegister(u32 index, Xbyak::Reg32 dst);
-
-    void Compile_ProcessResult(Macro::ResultOperation operation, u32 reg);
-    void Compile_Send(Xbyak::Reg32 value);
-
-    Macro::Opcode GetOpCode() const;
-    std::bitset<32> PersistentCallerSavedRegs() const;
-
-    struct JITState {
-        Engines::Maxwell3D* maxwell3d{};
-        std::array<u32, Macro::NUM_MACRO_REGISTERS> registers{};
-        u32 carry_flag{};
-    };
-    static_assert(offsetof(JITState, maxwell3d) == 0, "Maxwell3D is not at 0x0");
-    using ProgramType = void (*)(JITState*, const u32*);
-
-    struct OptimizerState {
-        bool can_skip_carry{};
-        bool has_delayed_pc{};
-        bool zero_reg_skip{};
-        bool skip_dummy_addimmediate{};
-        bool optimize_for_method_move{};
-        bool enable_asserts{};
-    };
-    OptimizerState optimizer{};
-
-    std::optional<Macro::Opcode> next_opcode{};
-    ProgramType program{nullptr};
-
-    std::array<Xbyak::Label, MAX_CODE_SIZE> labels;
-    std::array<Xbyak::Label, MAX_CODE_SIZE> delay_skip;
-    Xbyak::Label end_of_code{};
-
-    bool is_delay_slot{};
-    u32 pc{};
-    std::optional<u32> delayed_pc;
-
-    const std::vector<u32>& code;
     Engines::Maxwell3D& maxwell3d;
 };
 


### PR DESCRIPTION
Moves the impl classes like `HLEMacroImpl`, `MacroInterpreterImpl`, and `MacroJITx64Impl` into their respective cpp files to keep implementation details hidden and also lessen header dependencies for those implementations in their header files (which is nice, since xbyak is no longer included into files unrelated to the x86-64 implementation).

Now the implementations can be freely modified without needing to rebuild all of the implementations at once.

This is mainly moving code around (save for a few commits)