### PR TITLE
input_common: Add DS5 to HD rumble list

### DIFF
--- a/src/input_common/drivers/sdl_driver.cpp
+++ b/src/input_common/drivers/sdl_driver.cpp
@@ -109,8 +109,9 @@ public:
 
     bool HasHDRumble() const {
         if (sdl_controller) {
-            return (SDL_GameControllerGetType(sdl_controller.get()) ==
-                    SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_PRO);
+            const auto type = SDL_GameControllerGetType(sdl_controller.get());
+            return (type == SDL_CONTROLLER_TYPE_NINTENDO_SWITCH_PRO) ||
+                   (type == SDL_CONTROLLER_TYPE_PS5);
         }
         return false;
     }


### PR DESCRIPTION
Dual sense controllers support HD rumble. So they should use a linear amplitude instead of the exponential for motors. This makes the controller vibrate with less force 