### PR TITLE
buffer_cache: Reduce stream buffer allocations when expanding from the left

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -1474,6 +1474,8 @@ typename BufferCache<P>::OverlapResult BufferCache<P>::ResolveOverlaps(VAddr cpu
             // When this memory region has been joined a bunch of times, we assume it's being used
             // as a stream buffer. Increase the size to skip constantly recreating buffers.
             has_stream_leap = true;
+            begin -= PAGE_SIZE * 256;
+            cpu_addr = begin;
             end += PAGE_SIZE * 256;
         }
     }


### PR DESCRIPTION
The existing stream buffer optimization accounts for size increases at the end of the allocated buffer.

This adds the same optimization, increasing the size from the beginning of the buffer as well to reduce buffer allocations when expanding the same buffer from the left.

Fixes a crash in Pokemon Legends Arceus