### PR TITLE
wall_clock: Use standard wall clock if rtsc frequency is too low

### DIFF
--- a/src/common/wall_clock.cpp
+++ b/src/common/wall_clock.cpp
@@ -72,7 +72,9 @@ std::unique_ptr<WallClock> CreateBestMatchingClock(u32 emulated_cpu_frequency,
     if (caps.invariant_tsc) {
         rtsc_frequency = EstimateRDTSCFrequency();
     }
-    if (rtsc_frequency == 0) {
+
+    // Fallback to StandardWallClock if rtsc period is higher than a nano second
+    if (rtsc_frequency <= 1000000000) {
         return std::make_unique<StandardWallClock>(emulated_cpu_frequency,
                                                    emulated_clock_frequency);
     } else {


### PR DESCRIPTION
If the rtsc frequency is lower than 1,000,000,000hz it will cause udiv128 to overflow. To prevent this issue we fallback to the StandardWallClock.

Fixes issue where yuzu crash at boot with no logs.