### PR TITLE
emit_spirv: Add Xfb execution mode when transform feedback is used

### DIFF
--- a/src/shader_recompiler/backend/spirv/emit_spirv.cpp
+++ b/src/shader_recompiler/backend/spirv/emit_spirv.cpp
@@ -387,6 +387,14 @@ void SetupSignedNanCapabilities(const Profile& profile, const IR::Program& progr
     }
 }
 
+void SetupTransformFeedbackCapabilities(EmitContext& ctx, Id main_func) {
+    if (ctx.runtime_info.xfb_varyings.empty()) {
+        return;
+    }
+    ctx.AddCapability(spv::Capability::TransformFeedback);
+    ctx.AddExecutionMode(main_func, spv::ExecutionMode::Xfb);
+}
+
 void SetupCapabilities(const Profile& profile, const Info& info, EmitContext& ctx) {
     if (info.uses_sampled_1d) {
         ctx.AddCapability(spv::Capability::Sampled1D);
@@ -442,9 +450,6 @@ void SetupCapabilities(const Profile& profile, const Info& info, EmitContext& ct
     if (info.uses_sample_id) {
         ctx.AddCapability(spv::Capability::SampleRateShading);
     }
-    if (!ctx.runtime_info.xfb_varyings.empty()) {
-        ctx.AddCapability(spv::Capability::TransformFeedback);
-    }
     if (info.uses_derivatives) {
         ctx.AddCapability(spv::Capability::DerivativeControl);
     }
@@ -484,6 +489,7 @@ std::vector<u32> EmitSPIRV(const Profile& profile, const RuntimeInfo& runtime_in
         SetupSignedNanCapabilities(profile, program, ctx, main);
     }
     SetupCapabilities(profile, program.info, ctx);
+    SetupTransformFeedbackCapabilities(ctx, main);
     PatchPhiNodes(program, ctx);
     return ctx.Assemble();
 }


### PR DESCRIPTION
Fixes Transform Feedback on AMD Vulkan drivers.


Before |  After
:-------------------------:|:-------------------------: 
![pla_before](https://user-images.githubusercontent.com/52414509/151627553-634e4065-4414-4c81-8971-b64f2d6e792a.png) | ![pla_after](https://user-images.githubusercontent.com/52414509/151627567-bd4cbdb5-fd97-48e4-bb40-fad16e2eb679.png)
![xc_before](https://user-images.githubusercontent.com/52414509/151627596-1884f66f-4756-4ee1-b6f0-4b679e7ce40f.png) | ![xc_after](https://user-images.githubusercontent.com/52414509/151627608-17c19e82-ca3f-4ad1-a988-5eebe0f71ae6.png)

closes #7790 closes #6612 closes #5004