### PR TITLE
Inline2Memory: Flush before writing buffer.

### DIFF
--- a/src/video_core/buffer_cache/buffer_cache.h
+++ b/src/video_core/buffer_cache/buffer_cache.h
@@ -1661,6 +1661,7 @@ bool BufferCache<P>::InlineMemory(VAddr dest_address, size_t copy_size,
 
     const IntervalType subtract_interval{dest_address, dest_address + copy_size};
     ClearDownload(subtract_interval);
+    common_ranges.subtract(subtract_interval);
 
     BufferId buffer_id = FindBuffer(dest_address, static_cast<u32>(copy_size));
     auto& buffer = slot_buffers[buffer_id];
@@ -1677,7 +1678,7 @@ bool BufferCache<P>::InlineMemory(VAddr dest_address, size_t copy_size,
         std::memcpy(src_pointer, inlined_buffer.data(), copy_size);
         runtime.CopyBuffer(buffer, upload_staging.buffer, copies);
     } else {
-        buffer.ImmediateUpload(buffer.Offset(dest_address), inlined_buffer);
+        buffer.ImmediateUpload(buffer.Offset(dest_address), inlined_buffer.first(copy_size));
     }
 
     return true;

--- a/src/video_core/engines/engine_upload.cpp
+++ b/src/video_core/engines/engine_upload.cpp
@@ -32,6 +32,7 @@ void State::ProcessData(const u32 data, const bool is_last_call) {
     }
     const GPUVAddr address{regs.dest.Address()};
     if (is_linear) {
+        memory_manager.FlushRegion(address, copy_size);
         memory_manager.WriteBlock(address, inner_buffer.data(), copy_size);
     } else {
         UNIMPLEMENTED_IF(regs.dest.z != 0);

--- a/src/video_core/engines/engine_upload.cpp
+++ b/src/video_core/engines/engine_upload.cpp
@@ -37,7 +37,7 @@ void State::ProcessData(const u32 data, const bool is_last_call) {
     }
     const GPUVAddr address{regs.dest.Address()};
     if (is_linear) {
-        rasterizer->AccelerateInline2Memory(address, copy_size, inner_buffer);
+        rasterizer->AccelerateInlineToMemory(address, copy_size, inner_buffer);
     } else {
         UNIMPLEMENTED_IF(regs.dest.z != 0);
         UNIMPLEMENTED_IF(regs.dest.depth != 1);

--- a/src/video_core/engines/engine_upload.h
+++ b/src/video_core/engines/engine_upload.h
@@ -12,6 +12,10 @@ namespace Tegra {
 class MemoryManager;
 }
 
+namespace VideoCore {
+class RasterizerInterface;
+}
+
 namespace Tegra::Engines::Upload {
 
 struct Registers {
@@ -60,6 +64,9 @@ public:
     void ProcessExec(bool is_linear_);
     void ProcessData(u32 data, bool is_last_call);
 
+    /// Binds a rasterizer to this engine.
+    void BindRasterizer(VideoCore::RasterizerInterface* rasterizer);
+
 private:
     u32 write_offset = 0;
     u32 copy_size = 0;
@@ -68,6 +75,7 @@ private:
     bool is_linear = false;
     Registers& regs;
     MemoryManager& memory_manager;
+    VideoCore::RasterizerInterface* rasterizer = nullptr;
 };
 
 } // namespace Tegra::Engines::Upload

--- a/src/video_core/engines/kepler_compute.cpp
+++ b/src/video_core/engines/kepler_compute.cpp
@@ -22,6 +22,7 @@ KeplerCompute::~KeplerCompute() = default;
 
 void KeplerCompute::BindRasterizer(VideoCore::RasterizerInterface* rasterizer_) {
     rasterizer = rasterizer_;
+    upload_state.BindRasterizer(rasterizer);
 }
 
 void KeplerCompute::CallMethod(u32 method, u32 method_argument, bool is_last_call) {

--- a/src/video_core/engines/kepler_memory.cpp
+++ b/src/video_core/engines/kepler_memory.cpp
@@ -19,6 +19,10 @@ KeplerMemory::KeplerMemory(Core::System& system_, MemoryManager& memory_manager)
 
 KeplerMemory::~KeplerMemory() = default;
 
+void KeplerMemory::BindRasterizer(VideoCore::RasterizerInterface* rasterizer_) {
+    upload_state.BindRasterizer(rasterizer_);
+}
+
 void KeplerMemory::CallMethod(u32 method, u32 method_argument, bool is_last_call) {
     ASSERT_MSG(method < Regs::NUM_REGS,
                "Invalid KeplerMemory register, increase the size of the Regs structure");

--- a/src/video_core/engines/kepler_memory.h
+++ b/src/video_core/engines/kepler_memory.h
@@ -22,6 +22,10 @@ namespace Tegra {
 class MemoryManager;
 }
 
+namespace VideoCore {
+class RasterizerInterface;
+}
+
 namespace Tegra::Engines {
 
 /**
@@ -37,6 +41,9 @@ class KeplerMemory final : public EngineInterface {
 public:
     explicit KeplerMemory(Core::System& system_, MemoryManager& memory_manager);
     ~KeplerMemory() override;
+
+    /// Binds a rasterizer to this engine.
+    void BindRasterizer(VideoCore::RasterizerInterface* rasterizer);
 
     /// Write the value to the register identified by method.
     void CallMethod(u32 method, u32 method_argument, bool is_last_call) override;

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -31,6 +31,7 @@ Maxwell3D::~Maxwell3D() = default;
 
 void Maxwell3D::BindRasterizer(VideoCore::RasterizerInterface* rasterizer_) {
     rasterizer = rasterizer_;
+    upload_state.BindRasterizer(rasterizer_);
 }
 
 void Maxwell3D::InitializeRegisterDefaults() {

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1557,7 +1557,7 @@ private:
 
     static constexpr u32 null_cb_data = 0xFFFFFFFF;
     struct CBDataState {
-        static constexpr size_t inline_size = 0x8000;
+        static constexpr size_t inline_size = 0x4000;
         std::array<std::array<u32, inline_size>, 16> buffer;
         u32 current{null_cb_data};
         u32 id{null_cb_data};

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1557,7 +1557,8 @@ private:
 
     static constexpr u32 null_cb_data = 0xFFFFFFFF;
     struct CBDataState {
-        std::array<std::array<u32, 0x4000>, 16> buffer;
+        static constexpr size_t inline_size = 0x8000;
+        std::array<std::array<u32, inline_size>, 16> buffer;
         u32 current{null_cb_data};
         u32 id{null_cb_data};
         u32 start_pos{};

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -504,14 +504,12 @@ struct GPU::Impl {
         case BufferMethods::SemaphoreAddressLow:
         case BufferMethods::SemaphoreSequence:
             break;
-        case BufferMethods::UnkCacheFlush: {
+        case BufferMethods::UnkCacheFlush:
             rasterizer->SyncGuestHost();
             break;
-        }
-        case BufferMethods::WrcacheFlush: {
+        case BufferMethods::WrcacheFlush:
             rasterizer->SignalReference();
             break;
-        }
         case BufferMethods::FenceValue:
             break;
         case BufferMethods::RefCnt:

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -59,6 +59,7 @@ struct GPU::Impl {
         maxwell_3d->BindRasterizer(rasterizer);
         fermi_2d->BindRasterizer(rasterizer);
         kepler_compute->BindRasterizer(rasterizer);
+        kepler_memory->BindRasterizer(rasterizer);
         maxwell_dma->BindRasterizer(rasterizer);
     }
 

--- a/src/video_core/gpu.cpp
+++ b/src/video_core/gpu.cpp
@@ -503,8 +503,15 @@ struct GPU::Impl {
         case BufferMethods::SemaphoreAddressHigh:
         case BufferMethods::SemaphoreAddressLow:
         case BufferMethods::SemaphoreSequence:
-        case BufferMethods::UnkCacheFlush:
-        case BufferMethods::WrcacheFlush:
+            break;
+        case BufferMethods::UnkCacheFlush: {
+            rasterizer->SyncGuestHost();
+            break;
+        }
+        case BufferMethods::WrcacheFlush: {
+            rasterizer->SignalReference();
+            break;
+        }
         case BufferMethods::FenceValue:
             break;
         case BufferMethods::RefCnt:
@@ -514,7 +521,7 @@ struct GPU::Impl {
             ProcessFenceActionMethod();
             break;
         case BufferMethods::WaitForInterrupt:
-            ProcessWaitForInterruptMethod();
+            rasterizer->WaitForIdle();
             break;
         case BufferMethods::SemaphoreTrigger: {
             ProcessSemaphoreTriggerMethod();

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -143,6 +143,8 @@ public:
     [[nodiscard]] GPUVAddr Allocate(std::size_t size, std::size_t align);
     void Unmap(GPUVAddr gpu_addr, std::size_t size);
 
+    void FlushRegion(GPUVAddr gpu_addr, size_t size) const;
+
 private:
     [[nodiscard]] PageEntry GetPageEntry(GPUVAddr gpu_addr) const;
     void SetPageEntry(GPUVAddr gpu_addr, PageEntry page_entry, std::size_t size = page_size);
@@ -152,8 +154,6 @@ private:
 
     void TryLockPage(PageEntry page_entry, std::size_t size);
     void TryUnlockPage(PageEntry page_entry, std::size_t size);
-
-    void FlushRegion(GPUVAddr gpu_addr, size_t size) const;
 
     void ReadBlockImpl(GPUVAddr gpu_src_addr, void* dest_buffer, std::size_t size,
                        bool is_safe) const;

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -123,6 +123,9 @@ public:
 
     [[nodiscard]] virtual Tegra::Engines::AccelerateDMAInterface& AccessAccelerateDMA() = 0;
 
+    virtual void AccelerateInline2Memory(GPUVAddr address, size_t copy_size,
+                                         std::span<u8> memory) = 0;
+
     /// Attempt to use a faster method to display the framebuffer to screen
     [[nodiscard]] virtual bool AccelerateDisplay(const Tegra::FramebufferConfig& config,
                                                  VAddr framebuffer_addr, u32 pixel_stride) {

--- a/src/video_core/rasterizer_interface.h
+++ b/src/video_core/rasterizer_interface.h
@@ -123,8 +123,8 @@ public:
 
     [[nodiscard]] virtual Tegra::Engines::AccelerateDMAInterface& AccessAccelerateDMA() = 0;
 
-    virtual void AccelerateInline2Memory(GPUVAddr address, size_t copy_size,
-                                         std::span<u8> memory) = 0;
+    virtual void AccelerateInlineToMemory(GPUVAddr address, size_t copy_size,
+                                          std::span<u8> memory) = 0;
 
     /// Attempt to use a faster method to display the framebuffer to screen
     [[nodiscard]] virtual bool AccelerateDisplay(const Tegra::FramebufferConfig& config,

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -484,8 +484,8 @@ Tegra::Engines::AccelerateDMAInterface& RasterizerOpenGL::AccessAccelerateDMA() 
     return accelerate_dma;
 }
 
-void RasterizerOpenGL::AccelerateInline2Memory(GPUVAddr address, size_t copy_size,
-                                               std::span<u8> memory) {
+void RasterizerOpenGL::AccelerateInlineToMemory(GPUVAddr address, size_t copy_size,
+                                                std::span<u8> memory) {
     auto cpu_addr = gpu_memory.GpuToCpuAddress(address);
     if (!cpu_addr) [[unlikely]] {
         gpu_memory.WriteBlock(address, memory.data(), copy_size);

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -106,7 +106,8 @@ public:
                                const Tegra::Engines::Fermi2D::Surface& dst,
                                const Tegra::Engines::Fermi2D::Config& copy_config) override;
     Tegra::Engines::AccelerateDMAInterface& AccessAccelerateDMA() override;
-    void AccelerateInline2Memory(GPUVAddr address, size_t copy_size, std::span<u8> memory) override;
+    void AccelerateInlineToMemory(GPUVAddr address, size_t copy_size,
+                                  std::span<u8> memory) override;
     bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
                            u32 pixel_stride) override;
     void LoadDiskResources(u64 title_id, std::stop_token stop_loading,

--- a/src/video_core/renderer_opengl/gl_rasterizer.h
+++ b/src/video_core/renderer_opengl/gl_rasterizer.h
@@ -106,6 +106,7 @@ public:
                                const Tegra::Engines::Fermi2D::Surface& dst,
                                const Tegra::Engines::Fermi2D::Config& copy_config) override;
     Tegra::Engines::AccelerateDMAInterface& AccessAccelerateDMA() override;
+    void AccelerateInline2Memory(GPUVAddr address, size_t copy_size, std::span<u8> memory) override;
     bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
                            u32 pixel_stride) override;
     void LoadDiskResources(u64 title_id, std::stop_token stop_loading,

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -548,8 +548,8 @@ Tegra::Engines::AccelerateDMAInterface& RasterizerVulkan::AccessAccelerateDMA() 
     return accelerate_dma;
 }
 
-void RasterizerVulkan::AccelerateInline2Memory(GPUVAddr address, size_t copy_size,
-                                               std::span<u8> memory) {
+void RasterizerVulkan::AccelerateInlineToMemory(GPUVAddr address, size_t copy_size,
+                                                std::span<u8> memory) {
     auto cpu_addr = gpu_memory.GpuToCpuAddress(address);
     if (!cpu_addr) [[unlikely]] {
         gpu_memory.WriteBlock(address, memory.data(), copy_size);

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -548,6 +548,28 @@ Tegra::Engines::AccelerateDMAInterface& RasterizerVulkan::AccessAccelerateDMA() 
     return accelerate_dma;
 }
 
+void RasterizerVulkan::AccelerateInline2Memory(GPUVAddr address, size_t copy_size,
+                                               std::span<u8> memory) {
+    auto cpu_addr = gpu_memory.GpuToCpuAddress(address);
+    if (!cpu_addr) [[unlikely]] {
+        gpu_memory.WriteBlock(address, memory.data(), copy_size);
+        return;
+    }
+    gpu_memory.WriteBlockUnsafe(address, memory.data(), copy_size);
+    {
+        std::unique_lock<std::mutex> lock{buffer_cache.mutex};
+        if (!buffer_cache.InlineMemory(*cpu_addr, copy_size, memory)) {
+            buffer_cache.WriteMemory(*cpu_addr, copy_size);
+        }
+    }
+    {
+        std::scoped_lock lock_texture{texture_cache.mutex};
+        texture_cache.WriteMemory(*cpu_addr, copy_size);
+    }
+    pipeline_cache.InvalidateRegion(*cpu_addr, copy_size);
+    query_cache.InvalidateRegion(*cpu_addr, copy_size);
+}
+
 bool RasterizerVulkan::AccelerateDisplay(const Tegra::FramebufferConfig& config,
                                          VAddr framebuffer_addr, u32 pixel_stride) {
     if (!framebuffer_addr) {

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -99,7 +99,8 @@ public:
                                const Tegra::Engines::Fermi2D::Surface& dst,
                                const Tegra::Engines::Fermi2D::Config& copy_config) override;
     Tegra::Engines::AccelerateDMAInterface& AccessAccelerateDMA() override;
-    void AccelerateInline2Memory(GPUVAddr address, size_t copy_size, std::span<u8> memory) override;
+    void AccelerateInlineToMemory(GPUVAddr address, size_t copy_size,
+                                  std::span<u8> memory) override;
     bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
                            u32 pixel_stride) override;
     void LoadDiskResources(u64 title_id, std::stop_token stop_loading,

--- a/src/video_core/renderer_vulkan/vk_rasterizer.h
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.h
@@ -99,6 +99,7 @@ public:
                                const Tegra::Engines::Fermi2D::Surface& dst,
                                const Tegra::Engines::Fermi2D::Config& copy_config) override;
     Tegra::Engines::AccelerateDMAInterface& AccessAccelerateDMA() override;
+    void AccelerateInline2Memory(GPUVAddr address, size_t copy_size, std::span<u8> memory) override;
     bool AccelerateDisplay(const Tegra::FramebufferConfig& config, VAddr framebuffer_addr,
                            u32 pixel_stride) override;
     void LoadDiskResources(u64 title_id, std::stop_token stop_loading,


### PR DESCRIPTION
This fixes vertex explosions on Pokemon Legends Arceus and likely other BCR regressions. (mostly, there's a bit of random flicker every 2-3 mins or so, but fixes itself)

Credits to epicboy for noticing was writing GPU modified pages.