### PR TITLE
common: wall_clock: Utilize constants for ms, us, and ns ratios

### DIFF
--- a/src/common/wall_clock.cpp
+++ b/src/common/wall_clock.cpp
@@ -65,16 +65,20 @@ private:
 
 #ifdef ARCHITECTURE_x86_64
 
-std::unique_ptr<WallClock> CreateBestMatchingClock(u32 emulated_cpu_frequency,
-                                                   u32 emulated_clock_frequency) {
+std::unique_ptr<WallClock> CreateBestMatchingClock(u64 emulated_cpu_frequency,
+                                                   u64 emulated_clock_frequency) {
     const auto& caps = GetCPUCaps();
     u64 rtsc_frequency = 0;
     if (caps.invariant_tsc) {
         rtsc_frequency = EstimateRDTSCFrequency();
     }
 
-    // Fallback to StandardWallClock if the hardware TSC does not have nanosecond precision.
-    if (rtsc_frequency <= WallClock::NS_RATIO) {
+    // Fallback to StandardWallClock if the hardware TSC does not have the precision greater than:
+    // - A nanosecond
+    // - The emulated CPU frequency
+    // - The emulated clock counter frequency (CNTFRQ)
+    if (rtsc_frequency <= WallClock::NS_RATIO || rtsc_frequency <= emulated_cpu_frequency ||
+        rtsc_frequency <= emulated_clock_frequency) {
         return std::make_unique<StandardWallClock>(emulated_cpu_frequency,
                                                    emulated_clock_frequency);
     } else {
@@ -85,8 +89,8 @@ std::unique_ptr<WallClock> CreateBestMatchingClock(u32 emulated_cpu_frequency,
 
 #else
 
-std::unique_ptr<WallClock> CreateBestMatchingClock(u32 emulated_cpu_frequency,
-                                                   u32 emulated_clock_frequency) {
+std::unique_ptr<WallClock> CreateBestMatchingClock(u64 emulated_cpu_frequency,
+                                                   u64 emulated_clock_frequency) {
     return std::make_unique<StandardWallClock>(emulated_cpu_frequency, emulated_clock_frequency);
 }
 

--- a/src/common/wall_clock.cpp
+++ b/src/common/wall_clock.cpp
@@ -73,8 +73,8 @@ std::unique_ptr<WallClock> CreateBestMatchingClock(u32 emulated_cpu_frequency,
         rtsc_frequency = EstimateRDTSCFrequency();
     }
 
-    // Fallback to StandardWallClock if rtsc period is higher than a nano second
-    if (rtsc_frequency <= 1000000000) {
+    // Fallback to StandardWallClock if the hardware TSC does not have nanosecond precision.
+    if (rtsc_frequency <= WallClock::NS_RATIO) {
         return std::make_unique<StandardWallClock>(emulated_cpu_frequency,
                                                    emulated_clock_frequency);
     } else {

--- a/src/common/wall_clock.h
+++ b/src/common/wall_clock.h
@@ -13,6 +13,10 @@ namespace Common {
 
 class WallClock {
 public:
+    static constexpr u64 NS_RATIO = 1'000'000'000;
+    static constexpr u64 US_RATIO = 1'000'000;
+    static constexpr u64 MS_RATIO = 1'000;
+
     virtual ~WallClock() = default;
 
     /// Returns current wall time in nanoseconds

--- a/src/common/wall_clock.h
+++ b/src/common/wall_clock.h
@@ -53,7 +53,7 @@ private:
     bool is_native;
 };
 
-[[nodiscard]] std::unique_ptr<WallClock> CreateBestMatchingClock(u32 emulated_cpu_frequency,
-                                                                 u32 emulated_clock_frequency);
+[[nodiscard]] std::unique_ptr<WallClock> CreateBestMatchingClock(u64 emulated_cpu_frequency,
+                                                                 u64 emulated_clock_frequency);
 
 } // namespace Common

--- a/src/common/x64/native_clock.cpp
+++ b/src/common/x64/native_clock.cpp
@@ -47,9 +47,9 @@ NativeClock::NativeClock(u64 emulated_cpu_frequency_, u64 emulated_clock_frequen
     _mm_mfence();
     time_point.inner.last_measure = __rdtsc();
     time_point.inner.accumulated_ticks = 0U;
-    ns_rtsc_factor = GetFixedPoint64Factor(1000000000, rtsc_frequency);
-    us_rtsc_factor = GetFixedPoint64Factor(1000000, rtsc_frequency);
-    ms_rtsc_factor = GetFixedPoint64Factor(1000, rtsc_frequency);
+    ns_rtsc_factor = GetFixedPoint64Factor(NS_RATIO, rtsc_frequency);
+    us_rtsc_factor = GetFixedPoint64Factor(US_RATIO, rtsc_frequency);
+    ms_rtsc_factor = GetFixedPoint64Factor(MS_RATIO, rtsc_frequency);
     clock_rtsc_factor = GetFixedPoint64Factor(emulated_clock_frequency, rtsc_frequency);
     cpu_rtsc_factor = GetFixedPoint64Factor(emulated_cpu_frequency, rtsc_frequency);
 }


### PR DESCRIPTION
Additionally, check the precision of the hardware TSC against the emulated CPU and clock counter frequencies. This ensures that the hardware clock is only used when it is more precise than these two frequencies.