### PR TITLE
Vulkan: Fix Scheduler Chunks when their FuncType is 0.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_scheduler.cpp
+++ b/src/video_core/renderer_vulkan/vk_scheduler.cpp
@@ -140,12 +140,12 @@ bool VKScheduler::UpdateRescaling(bool is_rescaling) {
 void VKScheduler::WorkerThread(std::stop_token stop_token) {
     Common::SetCurrentThreadName("yuzu:VulkanWorker");
     do {
-        if (work_queue.empty()) {
-            wait_cv.notify_all();
-        }
         std::unique_ptr<CommandChunk> work;
         {
             std::unique_lock lock{work_mutex};
+            if (work_queue.empty()) {
+                wait_cv.notify_all();
+            }
             work_cv.wait(lock, stop_token, [this] { return !work_queue.empty(); });
             if (stop_token.stop_requested()) {
                 continue;

--- a/src/video_core/renderer_vulkan/vk_scheduler.h
+++ b/src/video_core/renderer_vulkan/vk_scheduler.h
@@ -146,6 +146,7 @@ private:
             using FuncType = TypedCommand<T>;
             static_assert(sizeof(FuncType) < sizeof(data), "Lambda is too large");
 
+            recorded_counts++;
             command_offset = Common::AlignUp(command_offset, alignof(FuncType));
             if (command_offset > sizeof(data) - sizeof(FuncType)) {
                 return false;
@@ -167,7 +168,7 @@ private:
         }
 
         bool Empty() const {
-            return command_offset == 0;
+            return recorded_counts == 0;
         }
 
         bool HasSubmit() const {
@@ -178,6 +179,7 @@ private:
         Command* first = nullptr;
         Command* last = nullptr;
 
+        size_t recorded_counts = 0;
         size_t command_offset = 0;
         bool submit = false;
         alignas(std::max_align_t) std::array<u8, 0x8000> data{};


### PR DESCRIPTION
This fixes some weird freezes in some games on some GPUs, mostly iGPUs. It affected Super Mario 64 Port (Homebrew) and Super Mario All Stars.