### PR TITLE
video_core/shader_cache: Take std::span in RemoveShadersFromStorage()

### DIFF
--- a/src/video_core/shader_cache.cpp
+++ b/src/video_core/shader_cache.cpp
@@ -170,7 +170,7 @@ void ShaderCache::RemovePendingShaders() {
     marked_for_removal.clear();
 
     if (!removed_shaders.empty()) {
-        RemoveShadersFromStorage(std::move(removed_shaders));
+        RemoveShadersFromStorage(removed_shaders);
     }
 }
 
@@ -213,7 +213,7 @@ void ShaderCache::UnmarkMemory(Entry* entry) {
     rasterizer.UpdatePagesCachedCount(addr, size, -1);
 }
 
-void ShaderCache::RemoveShadersFromStorage(std::vector<ShaderInfo*> removed_shaders) {
+void ShaderCache::RemoveShadersFromStorage(std::span<ShaderInfo*> removed_shaders) {
     // Remove them from the cache
     std::erase_if(storage, [&removed_shaders](const std::unique_ptr<ShaderInfo>& shader) {
         return std::ranges::find(removed_shaders, shader.get()) != removed_shaders.end();

--- a/src/video_core/shader_cache.h
+++ b/src/video_core/shader_cache.h
@@ -138,7 +138,7 @@ private:
     /// @param removed_shaders Shaders to be removed from the storage
     /// @pre invalidation_mutex is locked
     /// @pre lookup_mutex is locked
-    void RemoveShadersFromStorage(std::vector<ShaderInfo*> removed_shaders);
+    void RemoveShadersFromStorage(std::span<ShaderInfo*> removed_shaders);
 
     /// @brief Creates a new entry in the lookup cache and returns its pointer
     /// @pre lookup_mutex is locked

--- a/src/video_core/shader_cache.h
+++ b/src/video_core/shader_cache.h
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <algorithm>
 #include <array>
 #include <memory>
 #include <mutex>


### PR DESCRIPTION
Same behavior, but without the need to move into the function to avoid an allocation.