### PR TITLE
yuzu/game_list: Use non-deprecated version of QString's split() function

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -161,7 +161,7 @@ GameListSearchField::GameListSearchField(GameList* parent) : QWidget{parent} {
  * @return true if the haystack contains all words of userinput
  */
 static bool ContainsAllWords(const QString& haystack, const QString& userinput) {
-    const QStringList userinput_split = userinput.split(QLatin1Char{' '}, QString::SkipEmptyParts);
+    const QStringList userinput_split = userinput.split(QLatin1Char{' '}, Qt::SkipEmptyParts);
 
     return std::all_of(userinput_split.begin(), userinput_split.end(),
                        [&haystack](const QString& s) { return haystack.contains(s); });


### PR DESCRIPTION
The previous overload of split() was deprecated in 5.14. Keeps us a little more forward compatible with Qt 6