### PR TITLE
common/param_package: Allow heterogenous key lookup 

### DIFF
--- a/src/common/param_package.cpp
+++ b/src/common/param_package.cpp
@@ -73,8 +73,8 @@ std::string ParamPackage::Serialize() const {
     return result;
 }
 
-std::string ParamPackage::Get(const std::string& key, const std::string& default_value) const {
-    auto pair = data.find(key);
+std::string ParamPackage::Get(std::string_view key, const std::string& default_value) const {
+    const auto pair = data.find(key);
     if (pair == data.end()) {
         LOG_DEBUG(Common, "key '{}' not found", key);
         return default_value;
@@ -83,8 +83,8 @@ std::string ParamPackage::Get(const std::string& key, const std::string& default
     return pair->second;
 }
 
-int ParamPackage::Get(const std::string& key, int default_value) const {
-    auto pair = data.find(key);
+int ParamPackage::Get(std::string_view key, int default_value) const {
+    const auto pair = data.find(key);
     if (pair == data.end()) {
         LOG_DEBUG(Common, "key '{}' not found", key);
         return default_value;
@@ -98,8 +98,8 @@ int ParamPackage::Get(const std::string& key, int default_value) const {
     }
 }
 
-float ParamPackage::Get(const std::string& key, float default_value) const {
-    auto pair = data.find(key);
+float ParamPackage::Get(std::string_view key, float default_value) const {
+    const auto pair = data.find(key);
     if (pair == data.end()) {
         LOG_DEBUG(Common, "key {} not found", key);
         return default_value;
@@ -125,8 +125,8 @@ void ParamPackage::Set(const std::string& key, float value) {
     data.insert_or_assign(key, std::to_string(value));
 }
 
-bool ParamPackage::Has(const std::string& key) const {
-    return data.find(key) != data.end();
+bool ParamPackage::Has(std::string_view key) const {
+    return data.contains(key);
 }
 
 void ParamPackage::Erase(const std::string& key) {

--- a/src/common/param_package.h
+++ b/src/common/param_package.h
@@ -33,7 +33,7 @@ public:
     ParamPackage(ParamPackage&& other) noexcept = default;
 
     ParamPackage& operator=(const ParamPackage& other) = default;
-    ParamPackage& operator=(ParamPackage&& other) = default;
+    ParamPackage& operator=(ParamPackage&& other) noexcept = default;
 
     [[nodiscard]] std::string Serialize() const;
     [[nodiscard]] std::string Get(std::string_view key, const std::string& default_value) const;

--- a/src/common/param_package.h
+++ b/src/common/param_package.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <functional>
 #include <initializer_list>
 #include <string>
 #include <unordered_map>
@@ -13,7 +14,17 @@ namespace Common {
 /// A string-based key-value container supporting serializing to and deserializing from a string
 class ParamPackage {
 public:
-    using DataType = std::unordered_map<std::string, std::string>;
+    struct DataHash final {
+        using is_transparent = void;
+
+        [[nodiscard]] size_t operator()(std::string_view view) const noexcept {
+            return std::hash<std::string_view>{}(view);
+        }
+        [[nodiscard]] size_t operator()(const std::string& str) const noexcept {
+            return std::hash<std::string>{}(str);
+        }
+    };
+    using DataType = std::unordered_map<std::string, std::string, DataHash, std::equal_to<>>;
 
     ParamPackage() = default;
     explicit ParamPackage(const std::string& serialized);
@@ -25,13 +36,13 @@ public:
     ParamPackage& operator=(ParamPackage&& other) = default;
 
     [[nodiscard]] std::string Serialize() const;
-    [[nodiscard]] std::string Get(const std::string& key, const std::string& default_value) const;
-    [[nodiscard]] int Get(const std::string& key, int default_value) const;
-    [[nodiscard]] float Get(const std::string& key, float default_value) const;
+    [[nodiscard]] std::string Get(std::string_view key, const std::string& default_value) const;
+    [[nodiscard]] int Get(std::string_view key, int default_value) const;
+    [[nodiscard]] float Get(std::string_view key, float default_value) const;
     void Set(const std::string& key, std::string value);
     void Set(const std::string& key, int value);
     void Set(const std::string& key, float value);
-    [[nodiscard]] bool Has(const std::string& key) const;
+    [[nodiscard]] bool Has(std::string_view key) const;
     void Erase(const std::string& key);
     void Clear();
 


### PR DESCRIPTION
Allows the functions that only query or retrieve from the underlying map to be able to handle keys in various string formats.

This means we can make these bits of the API non-allocating by default.
