### PR TITLE
input_common: Use recursive mutex

### DIFF
--- a/src/input_common/input_engine.h
+++ b/src/input_common/input_engine.h
@@ -217,7 +217,7 @@ private:
                                 int index) const;
 
     mutable std::mutex mutex;
-    mutable std::mutex mutex_callback;
+    mutable std::recursive_mutex mutex_callback;
     bool configuring{false};
     const std::string input_engine;
     int last_callback_key = 0;


### PR DESCRIPTION
Fixes some crashes due calling the mutex twice while using hotkeys. 

Issue:
You press the button -> set the mutex ->triggers hotkey->hotkey opens another other window-> on out of focus releases all keys -> calls the mutex again 
