### PR TITLE
configure_filesystem: Add missing changeEvent() override

### DIFF
--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -109,7 +109,7 @@ void ConfigureDialog::ApplyConfiguration() {
     ui_tab->ApplyConfiguration();
     system_tab->ApplyConfiguration();
     profile_tab->ApplyConfiguration();
-    filesystem_tab->applyConfiguration();
+    filesystem_tab->ApplyConfiguration();
     input_tab->ApplyConfiguration();
     hotkeys_tab->ApplyConfiguration(registry);
     cpu_tab->ApplyConfiguration();

--- a/src/yuzu/configuration/configure_filesystem.cpp
+++ b/src/yuzu/configuration/configure_filesystem.cpp
@@ -14,7 +14,7 @@
 ConfigureFilesystem::ConfigureFilesystem(QWidget* parent)
     : QWidget(parent), ui(std::make_unique<Ui::ConfigureFilesystem>()) {
     ui->setupUi(this);
-    this->setConfiguration();
+    SetConfiguration();
 
     connect(ui->nand_directory_button, &QToolButton::pressed, this,
             [this] { SetDirectory(DirectoryTarget::NAND, ui->nand_directory_edit); });
@@ -38,7 +38,7 @@ ConfigureFilesystem::ConfigureFilesystem(QWidget* parent)
 
 ConfigureFilesystem::~ConfigureFilesystem() = default;
 
-void ConfigureFilesystem::setConfiguration() {
+void ConfigureFilesystem::SetConfiguration() {
     ui->nand_directory_edit->setText(
         QString::fromStdString(Common::FS::GetYuzuPathString(Common::FS::YuzuPath::NANDDir)));
     ui->sdmc_directory_edit->setText(
@@ -60,7 +60,7 @@ void ConfigureFilesystem::setConfiguration() {
     UpdateEnabledControls();
 }
 
-void ConfigureFilesystem::applyConfiguration() {
+void ConfigureFilesystem::ApplyConfiguration() {
     Common::FS::SetYuzuPath(Common::FS::YuzuPath::NANDDir,
                             ui->nand_directory_edit->text().toStdString());
     Common::FS::SetYuzuPath(Common::FS::YuzuPath::SDMCDir,
@@ -143,6 +143,6 @@ void ConfigureFilesystem::UpdateEnabledControls() {
                                          !ui->gamecard_current_game->isChecked());
 }
 
-void ConfigureFilesystem::retranslateUi() {
+void ConfigureFilesystem::RetranslateUI() {
     ui->retranslateUi(this);
 }

--- a/src/yuzu/configuration/configure_filesystem.cpp
+++ b/src/yuzu/configuration/configure_filesystem.cpp
@@ -38,6 +38,14 @@ ConfigureFilesystem::ConfigureFilesystem(QWidget* parent)
 
 ConfigureFilesystem::~ConfigureFilesystem() = default;
 
+void ConfigureFilesystem::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
 void ConfigureFilesystem::SetConfiguration() {
     ui->nand_directory_edit->setText(
         QString::fromStdString(Common::FS::GetYuzuPathString(Common::FS::YuzuPath::NANDDir)));

--- a/src/yuzu/configuration/configure_filesystem.h
+++ b/src/yuzu/configuration/configure_filesystem.h
@@ -20,11 +20,11 @@ public:
     explicit ConfigureFilesystem(QWidget* parent = nullptr);
     ~ConfigureFilesystem() override;
 
-    void applyConfiguration();
-    void retranslateUi();
+    void ApplyConfiguration();
 
 private:
-    void setConfiguration();
+    void RetranslateUI();
+    void SetConfiguration();
 
     enum class DirectoryTarget {
         NAND,

--- a/src/yuzu/configuration/configure_filesystem.h
+++ b/src/yuzu/configuration/configure_filesystem.h
@@ -23,6 +23,8 @@ public:
     void ApplyConfiguration();
 
 private:
+    void changeEvent(QEvent* event) override;
+
     void RetranslateUI();
     void SetConfiguration();
 


### PR DESCRIPTION
This allows the dialog to be retranslated during runtime if the language is changed.

Makes the filesystem widget consistent with all of the other ones.