### PR TITLE
yuzu: Disable auto repeat on hotkeys again

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -965,6 +965,7 @@ void GMainWindow::LinkActionShortcut(QAction* action, const QString& action_name
     static const QString main_window = QStringLiteral("Main Window");
     action->setShortcut(hotkey_registry.GetKeySequence(main_window, action_name));
     action->setShortcutContext(hotkey_registry.GetShortcutContext(main_window, action_name));
+    action->setAutoRepeat(false);
 
     this->addAction(action);
 


### PR DESCRIPTION
I did this once for GetHotkey but LinkActionShortcut was introduced afterwards reintroducing the same bug