### PR TITLE
common_types: Remove NonCopyable struct

### DIFF
--- a/src/common/common_types.h
+++ b/src/common/common_types.h
@@ -46,13 +46,3 @@ using GPUVAddr = u64; ///< Represents a pointer in the GPU virtual address space
 
 using u128 = std::array<std::uint64_t, 2>;
 static_assert(sizeof(u128) == 16, "u128 must be 128 bits wide");
-
-// An inheritable class to disallow the copy constructor and operator= functions
-class NonCopyable {
-protected:
-    constexpr NonCopyable() = default;
-    ~NonCopyable() = default;
-
-    NonCopyable(const NonCopyable&) = delete;
-    NonCopyable& operator=(const NonCopyable&) = delete;
-};

--- a/src/common/telemetry.h
+++ b/src/common/telemetry.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include "common/common_funcs.h"
 #include "common/common_types.h"
 
 namespace Common::Telemetry {
@@ -28,7 +29,7 @@ struct VisitorInterface;
 /**
  * Interface class for telemetry data fields.
  */
-class FieldInterface : NonCopyable {
+class FieldInterface {
 public:
     virtual ~FieldInterface() = default;
 
@@ -52,14 +53,15 @@ public:
 template <typename T>
 class Field : public FieldInterface {
 public:
+    YUZU_NON_COPYABLE(Field);
+
     Field(FieldType type_, std::string name_, T value_)
         : name(std::move(name_)), type(type_), value(std::move(value_)) {}
 
-    Field(const Field&) = default;
-    Field& operator=(const Field&) = default;
+    ~Field() override = default;
 
-    Field(Field&&) = default;
-    Field& operator=(Field&& other) = default;
+    Field(Field&&) noexcept = default;
+    Field& operator=(Field&& other) noexcept = default;
 
     void Accept(VisitorInterface& visitor) const override;
 
@@ -98,9 +100,15 @@ private:
 /**
  * Collection of data fields that have been logged.
  */
-class FieldCollection final : NonCopyable {
+class FieldCollection final {
 public:
+    YUZU_NON_COPYABLE(FieldCollection);
+
     FieldCollection() = default;
+    ~FieldCollection() = default;
+
+    FieldCollection(FieldCollection&&) noexcept = default;
+    FieldCollection& operator=(FieldCollection&&) noexcept = default;
 
     /**
      * Accept method for the visitor pattern, visits each field in the collection.
@@ -133,7 +141,7 @@ private:
  * Telemetry fields visitor interface class. A backend to log to a web service should implement
  * this interface.
  */
-struct VisitorInterface : NonCopyable {
+struct VisitorInterface {
     virtual ~VisitorInterface() = default;
 
     virtual void Visit(const Field<bool>& field) = 0;
@@ -160,8 +168,8 @@ struct VisitorInterface : NonCopyable {
  * Empty implementation of VisitorInterface that drops all fields. Used when a functional
  * backend implementation is not available.
  */
-struct NullVisitor : public VisitorInterface {
-    ~NullVisitor() = default;
+struct NullVisitor final : public VisitorInterface {
+    YUZU_NON_COPYABLE(NullVisitor);
 
     void Visit(const Field<bool>& /*field*/) override {}
     void Visit(const Field<double>& /*field*/) override {}

--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -6,6 +6,7 @@
 
 #include <array>
 #include <vector>
+#include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "core/hardware_properties.h"
 
@@ -24,8 +25,11 @@ class CPUInterruptHandler;
 using CPUInterrupts = std::array<CPUInterruptHandler, Core::Hardware::NUM_CPU_CORES>;
 
 /// Generic ARMv8 CPU interface
-class ARM_Interface : NonCopyable {
+class ARM_Interface {
 public:
+    YUZU_NON_COPYABLE(ARM_Interface);
+    YUZU_NON_MOVEABLE(ARM_Interface);
+
     explicit ARM_Interface(System& system_, CPUInterrupts& interrupt_handlers_,
                            bool uses_wall_clock_)
         : system{system_}, interrupt_handlers{interrupt_handlers_}, uses_wall_clock{

--- a/src/core/file_sys/vfs.h
+++ b/src/core/file_sys/vfs.h
@@ -12,6 +12,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "core/file_sys/vfs_types.h"
 
@@ -29,8 +30,11 @@ enum class VfsEntryType {
 // A class representing an abstract filesystem. A default implementation given the root VirtualDir
 // is provided for convenience, but if the Vfs implementation has any additional state or
 // functionality, they will need to override.
-class VfsFilesystem : NonCopyable {
+class VfsFilesystem {
 public:
+    YUZU_NON_COPYABLE(VfsFilesystem);
+    YUZU_NON_MOVEABLE(VfsFilesystem);
+
     explicit VfsFilesystem(VirtualDir root);
     virtual ~VfsFilesystem();
 
@@ -77,8 +81,12 @@ protected:
 };
 
 // A class representing a file in an abstract filesystem.
-class VfsFile : NonCopyable {
+class VfsFile {
 public:
+    YUZU_NON_COPYABLE(VfsFile);
+    YUZU_NON_MOVEABLE(VfsFile);
+
+    VfsFile() = default;
     virtual ~VfsFile();
 
     // Retrieves the file name.
@@ -176,8 +184,12 @@ public:
 };
 
 // A class representing a directory in an abstract filesystem.
-class VfsDirectory : NonCopyable {
+class VfsDirectory {
 public:
+    YUZU_NON_COPYABLE(VfsDirectory);
+    YUZU_NON_MOVEABLE(VfsDirectory);
+
+    VfsDirectory() = default;
     virtual ~VfsDirectory();
 
     // Retrives the file located at path as if the current directory was root. Returns nullptr if

--- a/src/core/hid/emulated_console.h
+++ b/src/core/hid/emulated_console.h
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <unordered_map>
 
+#include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/input.h"
 #include "common/param_package.h"

--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -13,8 +13,6 @@
 #include "common/common_types.h"
 #include "common/input.h"
 #include "common/param_package.h"
-#include "common/point.h"
-#include "common/quaternion.h"
 #include "common/settings.h"
 #include "common/vector_math.h"
 #include "core/hid/hid_types.h"

--- a/src/core/hid/hid_core.h
+++ b/src/core/hid/hid_core.h
@@ -6,6 +6,7 @@
 
 #include <memory>
 
+#include "common/common_funcs.h"
 #include "core/hid/hid_types.h"
 
 namespace Core::HID {

--- a/src/core/hle/kernel/k_auto_object.h
+++ b/src/core/hle/kernel/k_auto_object.h
@@ -20,8 +20,6 @@ class KernelCore;
 class KProcess;
 
 #define KERNEL_AUTOOBJECT_TRAITS(CLASS, BASE_CLASS)                                                \
-    YUZU_NON_COPYABLE(CLASS);                                                                      \
-    YUZU_NON_MOVEABLE(CLASS);                                                                      \
                                                                                                    \
 private:                                                                                           \
     friend class ::Kernel::KClassTokenGenerator;                                                   \
@@ -32,6 +30,9 @@ private:                                                                        
     }                                                                                              \
                                                                                                    \
 public:                                                                                            \
+    YUZU_NON_COPYABLE(CLASS);                                                                      \
+    YUZU_NON_MOVEABLE(CLASS);                                                                      \
+                                                                                                   \
     using BaseClass = BASE_CLASS;                                                                  \
     static constexpr TypeObj GetStaticTypeObj() {                                                  \
         constexpr ClassTokenType Token = ClassToken();                                             \
@@ -224,9 +225,9 @@ private:
 
 template <typename T>
 class KScopedAutoObject {
+public:
     YUZU_NON_COPYABLE(KScopedAutoObject);
 
-public:
     constexpr KScopedAutoObject() = default;
 
     constexpr KScopedAutoObject(T* o) : m_obj(o) {

--- a/src/core/hle/kernel/k_auto_object_container.h
+++ b/src/core/hle/kernel/k_auto_object_container.h
@@ -16,13 +16,12 @@ class KernelCore;
 class KProcess;
 
 class KAutoObjectWithListContainer {
+public:
     YUZU_NON_COPYABLE(KAutoObjectWithListContainer);
     YUZU_NON_MOVEABLE(KAutoObjectWithListContainer);
 
-public:
     using ListType = boost::intrusive::rbtree<KAutoObjectWithList>;
 
-public:
     class ListAccessor : public KScopedLightLock {
     public:
         explicit ListAccessor(KAutoObjectWithListContainer* container)
@@ -48,7 +47,6 @@ public:
 
     friend class ListAccessor;
 
-public:
     KAutoObjectWithListContainer(KernelCore& kernel) : m_lock(kernel), m_object_list() {}
 
     void Initialize() {}

--- a/src/core/hle/kernel/k_handle_table.h
+++ b/src/core/hle/kernel/k_handle_table.h
@@ -22,13 +22,12 @@ namespace Kernel {
 class KernelCore;
 
 class KHandleTable {
+public:
     YUZU_NON_COPYABLE(KHandleTable);
     YUZU_NON_MOVEABLE(KHandleTable);
 
-public:
     static constexpr size_t MaxTableSize = 1024;
 
-public:
     explicit KHandleTable(KernelCore& kernel_);
     ~KHandleTable();
 

--- a/src/core/hle/kernel/k_memory_manager.h
+++ b/src/core/hle/kernel/k_memory_manager.h
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <tuple>
 
+#include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "core/hle/kernel/k_page_heap.h"
 #include "core/hle/result.h"
@@ -20,8 +21,11 @@ namespace Kernel {
 
 class KPageLinkedList;
 
-class KMemoryManager final : NonCopyable {
+class KMemoryManager final {
 public:
+    YUZU_NON_COPYABLE(KMemoryManager);
+    YUZU_NON_MOVEABLE(KMemoryManager);
+
     enum class Pool : u32 {
         Application = 0,
         Applet = 1,
@@ -88,26 +92,13 @@ public:
     }
 
 private:
-    class Impl final : NonCopyable {
-    private:
-        using RefCount = u16;
-
-    private:
-        KPageHeap heap;
-        Pool pool{};
-
+    class Impl final {
     public:
-        static std::size_t CalculateManagementOverheadSize(std::size_t region_size);
+        YUZU_NON_COPYABLE(Impl);
+        YUZU_NON_MOVEABLE(Impl);
 
-        static constexpr std::size_t CalculateOptimizedProcessOverheadSize(
-            std::size_t region_size) {
-            return (Common::AlignUp((region_size / PageSize), Common::BitSize<u64>()) /
-                    Common::BitSize<u64>()) *
-                   sizeof(u64);
-        }
-
-    public:
         Impl() = default;
+        ~Impl() = default;
 
         std::size_t Initialize(Pool new_pool, u64 start_address, u64 end_address);
 
@@ -130,6 +121,21 @@ private:
         constexpr VAddr GetEndAddress() const {
             return heap.GetEndAddress();
         }
+
+        static std::size_t CalculateManagementOverheadSize(std::size_t region_size);
+
+        static constexpr std::size_t CalculateOptimizedProcessOverheadSize(
+            std::size_t region_size) {
+            return (Common::AlignUp((region_size / PageSize), Common::BitSize<u64>()) /
+                    Common::BitSize<u64>()) *
+                   sizeof(u64);
+        }
+
+    private:
+        using RefCount = u16;
+
+        KPageHeap heap;
+        Pool pool{};
     };
 
 private:

--- a/src/core/hle/kernel/k_page_table.cpp
+++ b/src/core/hle/kernel/k_page_table.cpp
@@ -63,6 +63,8 @@ constexpr std::size_t GetSizeInRange(const KMemoryInfo& info, VAddr start, VAddr
 
 KPageTable::KPageTable(Core::System& system_) : system{system_} {}
 
+KPageTable::~KPageTable() = default;
+
 ResultCode KPageTable::InitializeForProcess(FileSys::ProgramAddressSpaceType as_type,
                                             bool enable_aslr, VAddr code_addr,
                                             std::size_t code_size, KMemoryManager::Pool pool) {

--- a/src/core/hle/kernel/k_page_table.h
+++ b/src/core/hle/kernel/k_page_table.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <mutex>
 
+#include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "common/page_table.h"
 #include "core/file_sys/program_metadata.h"
@@ -22,9 +23,13 @@ namespace Kernel {
 
 class KMemoryBlockManager;
 
-class KPageTable final : NonCopyable {
+class KPageTable final {
 public:
+    YUZU_NON_COPYABLE(KPageTable);
+    YUZU_NON_MOVEABLE(KPageTable);
+
     explicit KPageTable(Core::System& system_);
+    ~KPageTable();
 
     ResultCode InitializeForProcess(FileSys::ProgramAddressSpaceType as_type, bool enable_aslr,
                                     VAddr code_addr, std::size_t code_size,

--- a/src/core/hle/kernel/k_slab_heap.h
+++ b/src/core/hle/kernel/k_slab_heap.h
@@ -7,6 +7,7 @@
 #include <atomic>
 
 #include "common/assert.h"
+#include "common/common_funcs.h"
 #include "common/common_types.h"
 
 namespace Kernel {
@@ -15,13 +16,17 @@ class KernelCore;
 
 namespace impl {
 
-class KSlabHeapImpl final : NonCopyable {
+class KSlabHeapImpl final {
 public:
+    YUZU_NON_COPYABLE(KSlabHeapImpl);
+    YUZU_NON_MOVEABLE(KSlabHeapImpl);
+
     struct Node {
         Node* next{};
     };
 
     constexpr KSlabHeapImpl() = default;
+    constexpr ~KSlabHeapImpl() = default;
 
     void Initialize(std::size_t size) {
         ASSERT(head == nullptr);
@@ -64,9 +69,13 @@ private:
 
 } // namespace impl
 
-class KSlabHeapBase : NonCopyable {
+class KSlabHeapBase {
 public:
+    YUZU_NON_COPYABLE(KSlabHeapBase);
+    YUZU_NON_MOVEABLE(KSlabHeapBase);
+
     constexpr KSlabHeapBase() = default;
+    constexpr ~KSlabHeapBase() = default;
 
     constexpr bool Contains(uintptr_t addr) const {
         return start <= addr && addr < end;

--- a/src/core/hle/service/vi/display/vi_display.h
+++ b/src/core/hle/service/vi/display/vi_display.h
@@ -28,10 +28,10 @@ class Layer;
 
 /// Represents a single display type
 class Display {
+public:
     YUZU_NON_COPYABLE(Display);
     YUZU_NON_MOVEABLE(Display);
 
-public:
     /// Constructs a display with a given unique ID and name.
     ///
     /// @param id The unique ID for this display.

--- a/src/core/loader/loader.h
+++ b/src/core/loader/loader.h
@@ -11,6 +11,7 @@
 #include <utility>
 #include <vector>
 
+#include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "core/file_sys/control_metadata.h"
 #include "core/file_sys/vfs.h"
@@ -139,8 +140,11 @@ std::string GetResultStatusString(ResultStatus status);
 std::ostream& operator<<(std::ostream& os, ResultStatus status);
 
 /// Interface for loading an application
-class AppLoader : NonCopyable {
+class AppLoader {
 public:
+    YUZU_NON_COPYABLE(AppLoader);
+    YUZU_NON_MOVEABLE(AppLoader);
+
     struct LoadParameters {
         s32 main_thread_priority;
         u64 main_thread_stack_size;

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -5,9 +5,10 @@
 #pragma once
 
 #include <atomic>
+#include <functional>
 #include <memory>
-#include <optional>
 
+#include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "core/frontend/emu_window.h"
 #include "video_core/gpu.h"
@@ -28,8 +29,11 @@ struct RendererSettings {
     Layout::FramebufferLayout screenshot_framebuffer_layout;
 };
 
-class RendererBase : NonCopyable {
+class RendererBase {
 public:
+    YUZU_NON_COPYABLE(RendererBase);
+    YUZU_NON_MOVEABLE(RendererBase);
+
     explicit RendererBase(Core::Frontend::EmuWindow& window,
                           std::unique_ptr<Core::Frontend::GraphicsContext> context);
     virtual ~RendererBase();

--- a/src/video_core/renderer_opengl/gl_resource_manager.h
+++ b/src/video_core/renderer_opengl/gl_resource_manager.h
@@ -7,12 +7,14 @@
 #include <string_view>
 #include <utility>
 #include <glad/glad.h>
-#include "common/common_types.h"
+#include "common/common_funcs.h"
 
 namespace OpenGL {
 
-class OGLRenderbuffer : private NonCopyable {
+class OGLRenderbuffer final {
 public:
+    YUZU_NON_COPYABLE(OGLRenderbuffer);
+
     OGLRenderbuffer() = default;
 
     OGLRenderbuffer(OGLRenderbuffer&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
@@ -36,8 +38,10 @@ public:
     GLuint handle = 0;
 };
 
-class OGLTexture : private NonCopyable {
+class OGLTexture final {
 public:
+    YUZU_NON_COPYABLE(OGLTexture);
+
     OGLTexture() = default;
 
     OGLTexture(OGLTexture&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
@@ -61,8 +65,10 @@ public:
     GLuint handle = 0;
 };
 
-class OGLTextureView : private NonCopyable {
+class OGLTextureView final {
 public:
+    YUZU_NON_COPYABLE(OGLTextureView);
+
     OGLTextureView() = default;
 
     OGLTextureView(OGLTextureView&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
@@ -86,8 +92,10 @@ public:
     GLuint handle = 0;
 };
 
-class OGLSampler : private NonCopyable {
+class OGLSampler final {
 public:
+    YUZU_NON_COPYABLE(OGLSampler);
+
     OGLSampler() = default;
 
     OGLSampler(OGLSampler&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
@@ -111,8 +119,10 @@ public:
     GLuint handle = 0;
 };
 
-class OGLShader : private NonCopyable {
+class OGLShader final {
 public:
+    YUZU_NON_COPYABLE(OGLShader);
+
     OGLShader() = default;
 
     OGLShader(OGLShader&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
@@ -132,8 +142,10 @@ public:
     GLuint handle = 0;
 };
 
-class OGLProgram : private NonCopyable {
+class OGLProgram final {
 public:
+    YUZU_NON_COPYABLE(OGLProgram);
+
     OGLProgram() = default;
 
     OGLProgram(OGLProgram&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
@@ -154,8 +166,10 @@ public:
     GLuint handle = 0;
 };
 
-class OGLAssemblyProgram : private NonCopyable {
+class OGLAssemblyProgram final {
 public:
+    YUZU_NON_COPYABLE(OGLAssemblyProgram);
+
     OGLAssemblyProgram() = default;
 
     OGLAssemblyProgram(OGLAssemblyProgram&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
@@ -176,8 +190,10 @@ public:
     GLuint handle = 0;
 };
 
-class OGLPipeline : private NonCopyable {
+class OGLPipeline final {
 public:
+    YUZU_NON_COPYABLE(OGLPipeline);
+
     OGLPipeline() = default;
     OGLPipeline(OGLPipeline&& o) noexcept : handle{std::exchange<GLuint>(o.handle, 0)} {}
 
@@ -198,8 +214,10 @@ public:
     GLuint handle = 0;
 };
 
-class OGLBuffer : private NonCopyable {
+class OGLBuffer final {
 public:
+    YUZU_NON_COPYABLE(OGLBuffer);
+
     OGLBuffer() = default;
 
     OGLBuffer(OGLBuffer&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
@@ -223,8 +241,10 @@ public:
     GLuint handle = 0;
 };
 
-class OGLSync : private NonCopyable {
+class OGLSync final {
 public:
+    YUZU_NON_COPYABLE(OGLSync);
+
     OGLSync() = default;
 
     OGLSync(OGLSync&& o) noexcept : handle(std::exchange(o.handle, nullptr)) {}
@@ -247,8 +267,10 @@ public:
     GLsync handle = 0;
 };
 
-class OGLFramebuffer : private NonCopyable {
+class OGLFramebuffer final {
 public:
+    YUZU_NON_COPYABLE(OGLFramebuffer);
+
     OGLFramebuffer() = default;
 
     OGLFramebuffer(OGLFramebuffer&& o) noexcept : handle(std::exchange(o.handle, 0)) {}
@@ -272,8 +294,10 @@ public:
     GLuint handle = 0;
 };
 
-class OGLQuery : private NonCopyable {
+class OGLQuery final {
 public:
+    YUZU_NON_COPYABLE(OGLQuery);
+
     OGLQuery() = default;
 
     OGLQuery(OGLQuery&& o) noexcept : handle(std::exchange(o.handle, 0)) {}


### PR DESCRIPTION
We have both `YUZU_NON_COPYABLE` and `YUZU_NON_MOVEABLE` defines which already allow a more fine-grained specifying of intent, so we can make use of those and get rid of the `NonCopyable` struct, so that we don't have two things around that do the same thing.