### PR TITLE
main: Always remove the frameless window flag when restoring UI state

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1052,8 +1052,10 @@ void GMainWindow::SetDefaultUIGeometry() {
 }
 
 void GMainWindow::RestoreUIState() {
+    setWindowFlags(windowFlags() & ~Qt::FramelessWindowHint);
     restoreGeometry(UISettings::values.geometry);
     restoreState(UISettings::values.state);
+    render_window->setWindowFlags(render_window->windowFlags() & ~Qt::FramelessWindowHint);
     render_window->restoreGeometry(UISettings::values.renderwindow_geometry);
 #if MICROPROFILE_ENABLED
     microProfileDialog->restoreGeometry(UISettings::values.microprofile_geometry);


### PR DESCRIPTION
For unknown reasons, this flag may persist after the application has been closed.
Removing this flag when restoring the UI state ensures that a frameless window will not be shown on startup.