### PR TITLE
input_common: Remove battery duplicated struct and update every button press

### DIFF
--- a/src/input_common/drivers/sdl_driver.cpp
+++ b/src/input_common/drivers/sdl_driver.cpp
@@ -175,22 +175,23 @@ public:
         return false;
     }
 
-    BatteryLevel GetBatteryLevel() {
+    Common::Input::BatteryLevel GetBatteryLevel() {
         const auto level = SDL_JoystickCurrentPowerLevel(sdl_joystick.get());
         switch (level) {
         case SDL_JOYSTICK_POWER_EMPTY:
-            return BatteryLevel::Empty;
+            return Common::Input::BatteryLevel::Empty;
         case SDL_JOYSTICK_POWER_LOW:
-            return BatteryLevel::Low;
+            return Common::Input::BatteryLevel::Low;
         case SDL_JOYSTICK_POWER_MEDIUM:
-            return BatteryLevel::Medium;
+            return Common::Input::BatteryLevel::Medium;
         case SDL_JOYSTICK_POWER_FULL:
         case SDL_JOYSTICK_POWER_MAX:
-            return BatteryLevel::Full;
-        case SDL_JOYSTICK_POWER_UNKNOWN:
+            return Common::Input::BatteryLevel::Full;
         case SDL_JOYSTICK_POWER_WIRED:
+            return Common::Input::BatteryLevel::Charging;
+        case SDL_JOYSTICK_POWER_UNKNOWN:
         default:
-            return BatteryLevel::Charging;
+            return Common::Input::BatteryLevel::None;
         }
     }
 
@@ -351,6 +352,8 @@ void SDLDriver::HandleGameControllerEvent(const SDL_Event& event) {
         if (const auto joystick = GetSDLJoystickBySDLID(event.jbutton.which)) {
             const PadIdentifier identifier = joystick->GetPadIdentifier();
             SetButton(identifier, event.jbutton.button, true);
+            // Battery doesn't trigger an event so just update every button press
+            SetBattery(identifier, joystick->GetBatteryLevel());
         }
         break;
     }

--- a/src/input_common/drivers/udp_client.cpp
+++ b/src/input_common/drivers/udp_client.cpp
@@ -192,22 +192,22 @@ std::size_t UDPClient::GetClientNumber(std::string_view host, u16 port) const {
     return MAX_UDP_CLIENTS;
 }
 
-BatteryLevel UDPClient::GetBatteryLevel(Response::Battery battery) const {
+Common::Input::BatteryLevel UDPClient::GetBatteryLevel(Response::Battery battery) const {
     switch (battery) {
     case Response::Battery::Dying:
-        return BatteryLevel::Empty;
+        return Common::Input::BatteryLevel::Empty;
     case Response::Battery::Low:
-        return BatteryLevel::Critical;
+        return Common::Input::BatteryLevel::Critical;
     case Response::Battery::Medium:
-        return BatteryLevel::Low;
+        return Common::Input::BatteryLevel::Low;
     case Response::Battery::High:
-        return BatteryLevel::Medium;
+        return Common::Input::BatteryLevel::Medium;
     case Response::Battery::Full:
     case Response::Battery::Charged:
-        return BatteryLevel::Full;
+        return Common::Input::BatteryLevel::Full;
     case Response::Battery::Charging:
     default:
-        return BatteryLevel::Charging;
+        return Common::Input::BatteryLevel::Charging;
     }
 }
 

--- a/src/input_common/drivers/udp_client.h
+++ b/src/input_common/drivers/udp_client.h
@@ -141,7 +141,7 @@ private:
     std::size_t GetClientNumber(std::string_view host, u16 port) const;
 
     // Translates UDP battery level to input engine battery level
-    BatteryLevel GetBatteryLevel(Response::Battery battery) const;
+    Common::Input::BatteryLevel GetBatteryLevel(Response::Battery battery) const;
 
     void OnVersion(Response::Version);
     void OnPortInfo(Response::PortInfo);

--- a/src/input_common/input_engine.cpp
+++ b/src/input_common/input_engine.cpp
@@ -70,7 +70,7 @@ void InputEngine::SetAxis(const PadIdentifier& identifier, int axis, f32 value) 
     TriggerOnAxisChange(identifier, axis, value);
 }
 
-void InputEngine::SetBattery(const PadIdentifier& identifier, BatteryLevel value) {
+void InputEngine::SetBattery(const PadIdentifier& identifier, Common::Input::BatteryLevel value) {
     {
         std::lock_guard lock{mutex};
         ControllerData& controller = controller_list.at(identifier);
@@ -143,13 +143,13 @@ f32 InputEngine::GetAxis(const PadIdentifier& identifier, int axis) const {
     return axis_iter->second;
 }
 
-BatteryLevel InputEngine::GetBattery(const PadIdentifier& identifier) const {
+Common::Input::BatteryLevel InputEngine::GetBattery(const PadIdentifier& identifier) const {
     std::lock_guard lock{mutex};
     const auto controller_iter = controller_list.find(identifier);
     if (controller_iter == controller_list.cend()) {
         LOG_ERROR(Input, "Invalid identifier guid={}, pad={}, port={}", identifier.guid.Format(),
                   identifier.pad, identifier.port);
-        return BatteryLevel::Charging;
+        return Common::Input::BatteryLevel::Charging;
     }
     const ControllerData& controller = controller_iter->second;
     return controller.battery;
@@ -270,7 +270,7 @@ void InputEngine::TriggerOnAxisChange(const PadIdentifier& identifier, int axis,
 }
 
 void InputEngine::TriggerOnBatteryChange(const PadIdentifier& identifier,
-                                         [[maybe_unused]] BatteryLevel value) {
+                                         [[maybe_unused]] Common::Input::BatteryLevel value) {
     std::lock_guard lock{mutex_callback};
     for (const auto& poller_pair : callback_list) {
         const InputIdentifier& poller = poller_pair.second;

--- a/src/input_common/input_engine.h
+++ b/src/input_common/input_engine.h
@@ -34,16 +34,6 @@ struct BasicMotion {
     u64 delta_timestamp{};
 };
 
-// Stages of a battery charge
-enum class BatteryLevel {
-    Empty,
-    Critical,
-    Low,
-    Medium,
-    Full,
-    Charging,
-};
-
 // Types of input that are stored in the engine
 enum class EngineInputType {
     None,
@@ -178,7 +168,7 @@ public:
     bool GetButton(const PadIdentifier& identifier, int button) const;
     bool GetHatButton(const PadIdentifier& identifier, int button, u8 direction) const;
     f32 GetAxis(const PadIdentifier& identifier, int axis) const;
-    BatteryLevel GetBattery(const PadIdentifier& identifier) const;
+    Common::Input::BatteryLevel GetBattery(const PadIdentifier& identifier) const;
     BasicMotion GetMotion(const PadIdentifier& identifier, int motion) const;
 
     int SetCallback(InputIdentifier input_identifier);
@@ -189,7 +179,7 @@ protected:
     void SetButton(const PadIdentifier& identifier, int button, bool value);
     void SetHatButton(const PadIdentifier& identifier, int button, u8 value);
     void SetAxis(const PadIdentifier& identifier, int axis, f32 value);
-    void SetBattery(const PadIdentifier& identifier, BatteryLevel value);
+    void SetBattery(const PadIdentifier& identifier, Common::Input::BatteryLevel value);
     void SetMotion(const PadIdentifier& identifier, int motion, const BasicMotion& value);
 
     virtual std::string GetHatButtonName([[maybe_unused]] u8 direction_value) const {
@@ -202,13 +192,13 @@ private:
         std::unordered_map<int, u8> hat_buttons;
         std::unordered_map<int, float> axes;
         std::unordered_map<int, BasicMotion> motions;
-        BatteryLevel battery{};
+        Common::Input::BatteryLevel battery{};
     };
 
     void TriggerOnButtonChange(const PadIdentifier& identifier, int button, bool value);
     void TriggerOnHatButtonChange(const PadIdentifier& identifier, int button, u8 value);
     void TriggerOnAxisChange(const PadIdentifier& identifier, int axis, f32 value);
-    void TriggerOnBatteryChange(const PadIdentifier& identifier, BatteryLevel value);
+    void TriggerOnBatteryChange(const PadIdentifier& identifier, Common::Input::BatteryLevel value);
     void TriggerOnMotionChange(const PadIdentifier& identifier, int motion,
                                const BasicMotion& value);
 

--- a/src/input_common/input_poller.cpp
+++ b/src/input_common/input_poller.cpp
@@ -470,7 +470,7 @@ public:
     }
 
     Common::Input::BatteryStatus GetStatus() const {
-        return static_cast<Common::Input::BatteryLevel>(input_engine->GetBattery(identifier));
+        return input_engine->GetBattery(identifier);
     }
 
     void ForceUpdate() override {


### PR DESCRIPTION
Finally figured out why battery values wasn't reported correctly. This PR Should reflect correct battery values for SDL controllers