### PR TITLE
yuzu: Add auto center on right click

### DIFF
--- a/src/input_common/drivers/sdl_driver.cpp
+++ b/src/input_common/drivers/sdl_driver.cpp
@@ -811,7 +811,7 @@ AnalogMapping SDLDriver::GetAnalogMappingForDevice(const Common::ParamPackage& p
         PreSetAxis(identifier, binding_left_x.value.axis);
         PreSetAxis(identifier, binding_left_y.value.axis);
         const auto left_offset_x = -GetAxis(identifier, binding_left_x.value.axis);
-        const auto left_offset_y = -GetAxis(identifier, binding_left_y.value.axis);
+        const auto left_offset_y = GetAxis(identifier, binding_left_y.value.axis);
         mapping.insert_or_assign(Settings::NativeAnalog::LStick,
                                  BuildParamPackageForAnalog(identifier, binding_left_x.value.axis,
                                                             binding_left_y.value.axis,
@@ -822,7 +822,7 @@ AnalogMapping SDLDriver::GetAnalogMappingForDevice(const Common::ParamPackage& p
         PreSetAxis(identifier, binding_left_x.value.axis);
         PreSetAxis(identifier, binding_left_y.value.axis);
         const auto left_offset_x = -GetAxis(identifier, binding_left_x.value.axis);
-        const auto left_offset_y = -GetAxis(identifier, binding_left_y.value.axis);
+        const auto left_offset_y = GetAxis(identifier, binding_left_y.value.axis);
         mapping.insert_or_assign(Settings::NativeAnalog::LStick,
                                  BuildParamPackageForAnalog(identifier, binding_left_x.value.axis,
                                                             binding_left_y.value.axis,
@@ -837,7 +837,7 @@ AnalogMapping SDLDriver::GetAnalogMappingForDevice(const Common::ParamPackage& p
     PreSetAxis(identifier, binding_right_x.value.axis);
     PreSetAxis(identifier, binding_right_y.value.axis);
     const auto right_offset_x = -GetAxis(identifier, binding_right_x.value.axis);
-    const auto right_offset_y = -GetAxis(identifier, binding_right_y.value.axis);
+    const auto right_offset_y = GetAxis(identifier, binding_right_y.value.axis);
     mapping.insert_or_assign(Settings::NativeAnalog::RStick,
                              BuildParamPackageForAnalog(identifier, binding_right_x.value.axis,
                                                         binding_right_y.value.axis, right_offset_x,

--- a/src/input_common/input_poller.cpp
+++ b/src/input_common/input_poller.cpp
@@ -181,7 +181,7 @@ public:
             .raw_value = input_engine->GetAxis(identifier, axis_y),
             .properties = properties_y,
         };
-        // This is a workaround too keep compatibility with old yuzu versions. Vertical axis is
+        // This is a workaround to keep compatibility with old yuzu versions. Vertical axis is
         // inverted on SDL compared to Nintendo
         if (invert_axis_y) {
             status.y.raw_value = -status.y.raw_value;

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -488,6 +488,32 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
                             emulated_controller->SetStickParam(analog_id, {});
                             analog_map_buttons[analog_id][sub_button_id]->setText(tr("[not set]"));
                         });
+                        context_menu.addAction(tr("Center axis"), [&] {
+                            const auto stick_value =
+                                emulated_controller->GetSticksValues()[analog_id];
+                            const float offset_x = stick_value.x.properties.offset;
+                            const float offset_y = stick_value.y.properties.offset;
+                            float raw_value_x = stick_value.x.raw_value;
+                            float raw_value_y = stick_value.y.raw_value;
+                            // See Core::HID::SanitizeStick() to obtain the original raw axis value
+                            if (std::abs(offset_x) < 0.5f) {
+                                if (raw_value_x > 0) {
+                                    raw_value_x *= 1 + offset_x;
+                                } else {
+                                    raw_value_x *= 1 - offset_x;
+                                }
+                            }
+                            if (std::abs(offset_x) < 0.5f) {
+                                if (raw_value_y > 0) {
+                                    raw_value_y *= 1 + offset_y;
+                                } else {
+                                    raw_value_y *= 1 - offset_y;
+                                }
+                            }
+                            param.Set("offset_x", -raw_value_x + offset_x);
+                            param.Set("offset_y", -raw_value_y + offset_y);
+                            emulated_controller->SetStickParam(analog_id, param);
+                        });
                         context_menu.addAction(tr("Invert axis"), [&] {
                             if (sub_button_id == 2 || sub_button_id == 3) {
                                 const bool invert_value = param.Get("invert_x", "+") == "-";


### PR DESCRIPTION
Adds the ability to auto center the stick with right click. On top of that seems like Y axis had the offset in the wrong direction. Resulting in even larger drift.