### PR TITLE
Yuzu: New hotkeys and mute audio on background

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -65,12 +65,14 @@ const std::array<int, 2> Config::default_stick_mod = {
 // This must be in alphabetical order according to action name as it must have the same order as
 // UISetting::values.shortcuts, which is alphabetically ordered.
 // clang-format off
-const std::array<UISettings::Shortcut, 20> Config::default_hotkeys{{
+const std::array<UISettings::Shortcut, 22> Config::default_hotkeys{{
     {QStringLiteral("Audio Mute/Unmute"),        QStringLiteral("Main Window"), {QStringLiteral("Ctrl+M"),  QStringLiteral("Home+Dpad_Right"), Qt::WindowShortcut}},
     {QStringLiteral("Audio Volume Down"),        QStringLiteral("Main Window"), {QStringLiteral("-"),       QStringLiteral("Home+Dpad_Down"), Qt::ApplicationShortcut}},
     {QStringLiteral("Audio Volume Up"),          QStringLiteral("Main Window"), {QStringLiteral("+"),       QStringLiteral("Home+Dpad_Up"), Qt::ApplicationShortcut}},
     {QStringLiteral("Capture Screenshot"),       QStringLiteral("Main Window"), {QStringLiteral("Ctrl+P"),  QStringLiteral("Screenshot"), Qt::WidgetWithChildrenShortcut}},
+    {QStringLiteral("Change Adapting Filter"),   QStringLiteral("Main Window"), {QStringLiteral("F8"),      QStringLiteral("Home+L"), Qt::ApplicationShortcut}},
     {QStringLiteral("Change Docked Mode"),       QStringLiteral("Main Window"), {QStringLiteral("F10"),     QStringLiteral("Home+X"), Qt::ApplicationShortcut}},
+    {QStringLiteral("Change GPU Accuracy"),      QStringLiteral("Main Window"), {QStringLiteral("F9"),      QStringLiteral("Home+R"), Qt::ApplicationShortcut}},
     {QStringLiteral("Continue/Pause Emulation"), QStringLiteral("Main Window"), {QStringLiteral("F4"),      QStringLiteral("Home+Plus"), Qt::WindowShortcut}},
     {QStringLiteral("Exit Fullscreen"),          QStringLiteral("Main Window"), {QStringLiteral("Esc"),     QStringLiteral(""), Qt::WindowShortcut}},
     {QStringLiteral("Exit yuzu"),                QStringLiteral("Main Window"), {QStringLiteral("Ctrl+Q"),  QStringLiteral("Home+Minus"), Qt::WindowShortcut}},

--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -769,6 +769,7 @@ void Config::ReadUIValues() {
     ReadBasicSetting(UISettings::values.callout_flags);
     ReadBasicSetting(UISettings::values.show_console);
     ReadBasicSetting(UISettings::values.pause_when_in_background);
+    ReadBasicSetting(UISettings::values.mute_when_in_background);
     ReadBasicSetting(UISettings::values.hide_mouse);
 
     qt_config->endGroup();
@@ -1297,6 +1298,7 @@ void Config::SaveUIValues() {
     WriteBasicSetting(UISettings::values.callout_flags);
     WriteBasicSetting(UISettings::values.show_console);
     WriteBasicSetting(UISettings::values.pause_when_in_background);
+    WriteBasicSetting(UISettings::values.mute_when_in_background);
     WriteBasicSetting(UISettings::values.hide_mouse);
 
     qt_config->endGroup();

--- a/src/yuzu/configuration/config.h
+++ b/src/yuzu/configuration/config.h
@@ -46,7 +46,7 @@ public:
         default_mouse_buttons;
     static const std::array<int, Settings::NativeKeyboard::NumKeyboardKeys> default_keyboard_keys;
     static const std::array<int, Settings::NativeKeyboard::NumKeyboardMods> default_keyboard_mods;
-    static const std::array<UISettings::Shortcut, 20> default_hotkeys;
+    static const std::array<UISettings::Shortcut, 22> default_hotkeys;
 
     static constexpr UISettings::Theme default_theme{
 #ifdef _WIN32

--- a/src/yuzu/configuration/configure_general.cpp
+++ b/src/yuzu/configuration/configure_general.cpp
@@ -46,6 +46,7 @@ void ConfigureGeneral::SetConfiguration() {
     ui->toggle_check_exit->setChecked(UISettings::values.confirm_before_closing.GetValue());
     ui->toggle_user_on_boot->setChecked(UISettings::values.select_user_on_boot.GetValue());
     ui->toggle_background_pause->setChecked(UISettings::values.pause_when_in_background.GetValue());
+    ui->toggle_background_mute->setChecked(UISettings::values.mute_when_in_background.GetValue());
     ui->toggle_hide_mouse->setChecked(UISettings::values.hide_mouse.GetValue());
 
     ui->toggle_speed_limit->setChecked(Settings::values.use_speed_limit.GetValue());
@@ -95,6 +96,7 @@ void ConfigureGeneral::ApplyConfiguration() {
         UISettings::values.confirm_before_closing = ui->toggle_check_exit->isChecked();
         UISettings::values.select_user_on_boot = ui->toggle_user_on_boot->isChecked();
         UISettings::values.pause_when_in_background = ui->toggle_background_pause->isChecked();
+        UISettings::values.mute_when_in_background = ui->toggle_background_mute->isChecked();
         UISettings::values.hide_mouse = ui->toggle_hide_mouse->isChecked();
 
         Settings::values.fps_cap.SetValue(ui->fps_cap->value());

--- a/src/yuzu/configuration/configure_general.ui
+++ b/src/yuzu/configuration/configure_general.ui
@@ -164,6 +164,13 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="toggle_background_mute">
+            <property name="text">
+             <string>Mute audio when in background</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="toggle_hide_mouse">
             <property name="text">
              <string>Hide mouse on inactivity</string>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1034,14 +1034,14 @@ void GMainWindow::RestoreUIState() {
 }
 
 void GMainWindow::OnAppFocusStateChanged(Qt::ApplicationState state) {
-    if (!UISettings::values.pause_when_in_background) {
-        return;
-    }
     if (state != Qt::ApplicationHidden && state != Qt::ApplicationInactive &&
         state != Qt::ApplicationActive) {
         LOG_DEBUG(Frontend, "ApplicationState unusual flag: {} ", state);
     }
-    if (emulation_running) {
+    if (!emulation_running) {
+        return;
+    }
+    if (UISettings::values.pause_when_in_background) {
         if (emu_thread->IsRunning() &&
             (state & (Qt::ApplicationHidden | Qt::ApplicationInactive))) {
             auto_paused = true;
@@ -1049,6 +1049,16 @@ void GMainWindow::OnAppFocusStateChanged(Qt::ApplicationState state) {
         } else if (!emu_thread->IsRunning() && auto_paused && state == Qt::ApplicationActive) {
             auto_paused = false;
             OnStartGame();
+        }
+    }
+    if (UISettings::values.mute_when_in_background) {
+        if (!Settings::values.audio_muted &&
+            (state & (Qt::ApplicationHidden | Qt::ApplicationInactive))) {
+            Settings::values.audio_muted = true;
+            auto_muted = true;
+        } else if (auto_muted && state == Qt::ApplicationActive) {
+            Settings::values.audio_muted = false;
+            auto_muted = false;
         }
     }
 }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -806,21 +806,8 @@ void GMainWindow::InitializeWidgets() {
     filter_status_button = new QPushButton();
     filter_status_button->setObjectName(QStringLiteral("TogglableStatusBarButton"));
     filter_status_button->setFocusPolicy(Qt::NoFocus);
-    connect(filter_status_button, &QPushButton::clicked, [&] {
-        auto filter = Settings::values.scaling_filter.GetValue();
-        if (filter == Settings::ScalingFilter::LastFilter) {
-            filter = Settings::ScalingFilter::NearestNeighbor;
-        } else {
-            filter = static_cast<Settings::ScalingFilter>(static_cast<u32>(filter) + 1);
-        }
-        if (Settings::values.renderer_backend.GetValue() == Settings::RendererBackend::OpenGL &&
-            filter == Settings::ScalingFilter::Fsr) {
-            filter = Settings::ScalingFilter::NearestNeighbor;
-        }
-        Settings::values.scaling_filter.SetValue(filter);
-        filter_status_button->setChecked(true);
-        UpdateFilterText();
-    });
+    connect(filter_status_button, &QPushButton::clicked, this,
+            &GMainWindow::OnToggleAdaptingFilter);
     auto filter = Settings::values.scaling_filter.GetValue();
     if (Settings::values.renderer_backend.GetValue() == Settings::RendererBackend::OpenGL &&
         filter == Settings::ScalingFilter::Fsr) {
@@ -835,25 +822,7 @@ void GMainWindow::InitializeWidgets() {
     dock_status_button = new QPushButton();
     dock_status_button->setObjectName(QStringLiteral("TogglableStatusBarButton"));
     dock_status_button->setFocusPolicy(Qt::NoFocus);
-    connect(dock_status_button, &QPushButton::clicked, [&] {
-        const bool is_docked = Settings::values.use_docked_mode.GetValue();
-        auto* player_1 = system->HIDCore().GetEmulatedController(Core::HID::NpadIdType::Player1);
-        auto* handheld = system->HIDCore().GetEmulatedController(Core::HID::NpadIdType::Handheld);
-
-        if (!is_docked && handheld->IsConnected()) {
-            QMessageBox::warning(this, tr("Invalid config detected"),
-                                 tr("Handheld controller can't be used on docked mode. Pro "
-                                    "controller will be selected."));
-            handheld->Disconnect();
-            player_1->SetNpadStyleIndex(Core::HID::NpadStyleIndex::ProController);
-            player_1->Connect();
-            controller_dialog->refreshConfiguration();
-        }
-
-        Settings::values.use_docked_mode.SetValue(!is_docked);
-        dock_status_button->setChecked(!is_docked);
-        OnDockedModeChanged(is_docked, !is_docked, *system);
-    });
+    connect(dock_status_button, &QPushButton::clicked, this, &GMainWindow::OnToggleDockedMode);
     dock_status_button->setText(tr("DOCK"));
     dock_status_button->setCheckable(true);
     dock_status_button->setChecked(Settings::values.use_docked_mode.GetValue());
@@ -863,22 +832,7 @@ void GMainWindow::InitializeWidgets() {
     gpu_accuracy_button->setObjectName(QStringLiteral("GPUStatusBarButton"));
     gpu_accuracy_button->setCheckable(true);
     gpu_accuracy_button->setFocusPolicy(Qt::NoFocus);
-    connect(gpu_accuracy_button, &QPushButton::clicked, [this] {
-        switch (Settings::values.gpu_accuracy.GetValue()) {
-        case Settings::GPUAccuracy::High: {
-            Settings::values.gpu_accuracy.SetValue(Settings::GPUAccuracy::Normal);
-            break;
-        }
-        case Settings::GPUAccuracy::Normal:
-        case Settings::GPUAccuracy::Extreme:
-        default: {
-            Settings::values.gpu_accuracy.SetValue(Settings::GPUAccuracy::High);
-        }
-        }
-
-        system->ApplySettings();
-        UpdateGPUAccuracyButton();
-    });
+    connect(gpu_accuracy_button, &QPushButton::clicked, this, &GMainWindow::OnToggleGpuAccuracy);
     UpdateGPUAccuracyButton();
     statusBar()->insertPermanentWidget(0, gpu_accuracy_button);
 
@@ -1009,12 +963,10 @@ void GMainWindow::InitializeHotkeys() {
             ToggleFullscreen();
         }
     });
-    connect_shortcut(QStringLiteral("Change Docked Mode"), [&] {
-        Settings::values.use_docked_mode.SetValue(!Settings::values.use_docked_mode.GetValue());
-        OnDockedModeChanged(!Settings::values.use_docked_mode.GetValue(),
-                            Settings::values.use_docked_mode.GetValue(), *system);
-        dock_status_button->setChecked(Settings::values.use_docked_mode.GetValue());
-    });
+    connect_shortcut(QStringLiteral("Change Adapting Filter"),
+                     &GMainWindow::OnToggleAdaptingFilter);
+    connect_shortcut(QStringLiteral("Change Docked Mode"), &GMainWindow::OnToggleDockedMode);
+    connect_shortcut(QStringLiteral("Change GPU Accuracy"), &GMainWindow::OnToggleGpuAccuracy);
     connect_shortcut(QStringLiteral("Audio Mute/Unmute"),
                      [] { Settings::values.audio_muted = !Settings::values.audio_muted; });
     connect_shortcut(QStringLiteral("Audio Volume Down"), [] {
@@ -2866,6 +2818,59 @@ void GMainWindow::OnTasRecord() {
 
 void GMainWindow::OnTasReset() {
     input_subsystem->GetTas()->Reset();
+}
+
+void GMainWindow::OnToggleDockedMode() {
+    const bool is_docked = Settings::values.use_docked_mode.GetValue();
+    auto* player_1 = system->HIDCore().GetEmulatedController(Core::HID::NpadIdType::Player1);
+    auto* handheld = system->HIDCore().GetEmulatedController(Core::HID::NpadIdType::Handheld);
+
+    if (!is_docked && handheld->IsConnected()) {
+        QMessageBox::warning(this, tr("Invalid config detected"),
+                             tr("Handheld controller can't be used on docked mode. Pro "
+                                "controller will be selected."));
+        handheld->Disconnect();
+        player_1->SetNpadStyleIndex(Core::HID::NpadStyleIndex::ProController);
+        player_1->Connect();
+        controller_dialog->refreshConfiguration();
+    }
+
+    Settings::values.use_docked_mode.SetValue(!is_docked);
+    dock_status_button->setChecked(!is_docked);
+    OnDockedModeChanged(is_docked, !is_docked, *system);
+}
+
+void GMainWindow::OnToggleGpuAccuracy() {
+    switch (Settings::values.gpu_accuracy.GetValue()) {
+    case Settings::GPUAccuracy::High: {
+        Settings::values.gpu_accuracy.SetValue(Settings::GPUAccuracy::Normal);
+        break;
+    }
+    case Settings::GPUAccuracy::Normal:
+    case Settings::GPUAccuracy::Extreme:
+    default: {
+        Settings::values.gpu_accuracy.SetValue(Settings::GPUAccuracy::High);
+    }
+    }
+
+    system->ApplySettings();
+    UpdateGPUAccuracyButton();
+}
+
+void GMainWindow::OnToggleAdaptingFilter() {
+    auto filter = Settings::values.scaling_filter.GetValue();
+    if (filter == Settings::ScalingFilter::LastFilter) {
+        filter = Settings::ScalingFilter::NearestNeighbor;
+    } else {
+        filter = static_cast<Settings::ScalingFilter>(static_cast<u32>(filter) + 1);
+    }
+    if (Settings::values.renderer_backend.GetValue() == Settings::RendererBackend::OpenGL &&
+        filter == Settings::ScalingFilter::Fsr) {
+        filter = Settings::ScalingFilter::NearestNeighbor;
+    }
+    Settings::values.scaling_filter.SetValue(filter);
+    filter_status_button->setChecked(true);
+    UpdateFilterText();
 }
 
 void GMainWindow::OnConfigurePerGame() {

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -372,6 +372,7 @@ private:
     QString game_path;
 
     bool auto_paused = false;
+    bool auto_muted = false;
     QTimer mouse_hide_timer;
 
     // FS

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -284,6 +284,9 @@ private slots:
     void OnTasStartStop();
     void OnTasRecord();
     void OnTasReset();
+    void OnToggleDockedMode();
+    void OnToggleGpuAccuracy();
+    void OnToggleAdaptingFilter();
     void OnConfigurePerGame();
     void OnLoadAmiibo();
     void OnOpenYuzuFolder();

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -73,6 +73,7 @@ struct Values {
     Settings::BasicSetting<bool> confirm_before_closing{true, "confirmClose"};
     Settings::BasicSetting<bool> first_start{true, "firstStart"};
     Settings::BasicSetting<bool> pause_when_in_background{false, "pauseWhenInBackground"};
+    Settings::BasicSetting<bool> mute_when_in_background{false, "muteWhenInBackground"};
     Settings::BasicSetting<bool> hide_mouse{true, "hideInactiveMouse"};
 
     Settings::BasicSetting<bool> select_user_on_boot{false, "select_user_on_boot"};


### PR DESCRIPTION
This PR adds a couple of user requested features. 

- Hotkeys for docked mode, window adapting filter and gpu accuracy.
- Setting to mute audio when the window is on background.

closes #7844
closes #7134 
