### PR TITLE
audio_core: Update current process revision

### DIFF
--- a/src/audio_core/common.h
+++ b/src/audio_core/common.h
@@ -15,7 +15,9 @@ constexpr ResultCode ERR_INVALID_PARAMETERS{ErrorModule::Audio, 41};
 constexpr ResultCode ERR_SPLITTER_SORT_FAILED{ErrorModule::Audio, 43};
 } // namespace Audren
 
-constexpr u32_le CURRENT_PROCESS_REVISION = Common::MakeMagic('R', 'E', 'V', '9');
+constexpr u8 BASE_REVISION = '0';
+constexpr u32_le CURRENT_PROCESS_REVISION =
+    Common::MakeMagic('R', 'E', 'V', static_cast<u8>(BASE_REVISION + 0xA));
 constexpr std::size_t MAX_MIX_BUFFERS = 24;
 constexpr std::size_t MAX_BIQUAD_FILTERS = 2;
 constexpr std::size_t MAX_CHANNEL_COUNT = 6;


### PR DESCRIPTION
Update CURRENT_PROCESS_REVISION from REV9 to REVA.

Used by Nintendo Entertainment System - Nintendo Switch Online 6.0.0 and Super Nintendo Entertainment System - Nintendo Switch Online 3.0.0.