### PR TITLE
Vulkan Rasterizer: Move counter updates just before the draw.

### DIFF
--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -183,8 +183,6 @@ void RasterizerVulkan::Draw(bool is_indexed, bool is_instanced) {
     SCOPE_EXIT({ gpu.TickWork(); });
     FlushWork();
 
-    query_cache.UpdateCounters();
-
     GraphicsPipeline* const pipeline{pipeline_cache.CurrentGraphicsPipeline()};
     if (!pipeline) {
         return;
@@ -195,6 +193,8 @@ void RasterizerVulkan::Draw(bool is_indexed, bool is_instanced) {
     BeginTransformFeedback();
 
     UpdateDynamicStates();
+
+    query_cache.UpdateCounters();
 
     const auto& regs{maxwell3d.regs};
     const u32 num_instances{maxwell3d.mme_draw.instance_count};


### PR DESCRIPTION
Fixes Splatoon 2 Ink when there's multiple floors on Vulkan.

Long story short: there were empty queries continuously created due to "OutOfRenderPass" operations on the scheduler, causing counters to be filled with nothing.