### PR TITLE
hid: Stub IsUsbFullKeyControllerEnabled

### DIFF
--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -320,7 +320,7 @@ Hid::Hid(Core::System& system_)
         {308, nullptr, "SetSevenSixAxisSensorFusionStrength"},
         {309, nullptr, "GetSevenSixAxisSensorFusionStrength"},
         {310, &Hid::ResetSevenSixAxisSensorTimestamp, "ResetSevenSixAxisSensorTimestamp"},
-        {400, nullptr, "IsUsbFullKeyControllerEnabled"},
+        {400, &Hid::IsUsbFullKeyControllerEnabled, "IsUsbFullKeyControllerEnabled"},
         {401, nullptr, "EnableUsbFullKeyController"},
         {402, nullptr, "IsUsbFullKeyControllerConnected"},
         {403, nullptr, "HasBattery"},
@@ -1671,6 +1671,16 @@ void Hid::ResetSevenSixAxisSensorTimestamp(Kernel::HLERequestContext& ctx) {
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
+}
+
+void Hid::IsUsbFullKeyControllerEnabled(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+
+    LOG_WARNING(Service_HID, "(STUBBED) called");
+
+    IPC::ResponseBuilder rb{ctx, 3};
+    rb.Push(ResultSuccess);
+    rb.Push(false);
 }
 
 void Hid::SetIsPalmaAllConnectable(Kernel::HLERequestContext& ctx) {

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -159,6 +159,7 @@ private:
     void InitializeSevenSixAxisSensor(Kernel::HLERequestContext& ctx);
     void FinalizeSevenSixAxisSensor(Kernel::HLERequestContext& ctx);
     void ResetSevenSixAxisSensorTimestamp(Kernel::HLERequestContext& ctx);
+    void IsUsbFullKeyControllerEnabled(Kernel::HLERequestContext& ctx);
     void SetIsPalmaAllConnectable(Kernel::HLERequestContext& ctx);
     void SetPalmaBoostMode(Kernel::HLERequestContext& ctx);
     void SetNpadCommunicationMode(Kernel::HLERequestContext& ctx);


### PR DESCRIPTION
Used by Splatoon 2, when opening the inventory from a LAN battle lobby.

Still not really familiar with stubbing functions, and `rb.Push(false);` feels wrong to me. I felt the need to point this out before someone reviews this PR.

Reference: https://switchbrew.org/wiki/HID_services#IsUsbFullKeyControllerEnabled