### PR TITLE
debugger: console: Set console output codepage to UTF-8

### DIFF
--- a/src/yuzu/debugger/console.cpp
+++ b/src/yuzu/debugger/console.cpp
@@ -30,6 +30,7 @@ void ToggleConsole() {
             freopen_s(&temp, "CONIN$", "r", stdin);
             freopen_s(&temp, "CONOUT$", "w", stdout);
             freopen_s(&temp, "CONOUT$", "w", stderr);
+            SetConsoleOutputCP(65001);
             SetColorConsoleBackendEnabled(true);
         }
     } else {


### PR DESCRIPTION
This allows the console to display multi-byte encoded characters.

Note that the font used in the console needs to support rendering these characters, otherwise they will be rendered as ?