### PR TITLE
common: fs_util: Add buffer to string view utility functions

### DIFF
--- a/src/common/fs/fs_util.cpp
+++ b/src/common/fs/fs_util.cpp
@@ -16,12 +16,20 @@ std::u8string BufferToU8String(std::span<const u8> buffer) {
     return std::u8string{buffer.begin(), std::ranges::find(buffer, u8{0})};
 }
 
+std::u8string_view BufferToU8StringView(std::span<const u8> buffer) {
+    return std::u8string_view{reinterpret_cast<const char8_t*>(buffer.data())};
+}
+
 std::string ToUTF8String(std::u8string_view u8_string) {
     return std::string{u8_string.begin(), u8_string.end()};
 }
 
 std::string BufferToUTF8String(std::span<const u8> buffer) {
     return std::string{buffer.begin(), std::ranges::find(buffer, u8{0})};
+}
+
+std::string_view BufferToUTF8StringView(std::span<const u8> buffer) {
+    return std::string_view{reinterpret_cast<const char*>(buffer.data())};
 }
 
 std::string PathToUTF8String(const std::filesystem::path& path) {

--- a/src/common/fs/fs_util.h
+++ b/src/common/fs/fs_util.h
@@ -38,6 +38,15 @@ concept IsChar = std::same_as<T, char>;
 [[nodiscard]] std::u8string BufferToU8String(std::span<const u8> buffer);
 
 /**
+ * Same as BufferToU8String, but returns a string view of the buffer.
+ *
+ * @param buffer Buffer of bytes
+ *
+ * @returns UTF-8 encoded std::u8string_view.
+ */
+[[nodiscard]] std::u8string_view BufferToU8StringView(std::span<const u8> buffer);
+
+/**
  * Converts a std::u8string or std::u8string_view to a UTF-8 encoded std::string.
  *
  * @param u8_string UTF-8 encoded u8string
@@ -56,6 +65,15 @@ concept IsChar = std::same_as<T, char>;
  * @returns UTF-8 encoded std::string.
  */
 [[nodiscard]] std::string BufferToUTF8String(std::span<const u8> buffer);
+
+/**
+ * Same as BufferToUTF8String, but returns a string view of the buffer.
+ *
+ * @param buffer Buffer of bytes
+ *
+ * @returns UTF-8 encoded std::string_view.
+ */
+[[nodiscard]] std::string_view BufferToUTF8StringView(std::span<const u8> buffer);
 
 /**
  * Converts a filesystem path to a UTF-8 encoded std::string.


### PR DESCRIPTION
These functions allow to construct a string view from an input buffer, avoiding the copy done by the non string view counterparts. However, callers must be cognizant of the viewed buffer's lifetime to avoid a use-after-free.