### PR TITLE
file_sys: Dump patched exefs rather than base

### DIFF
--- a/src/core/file_sys/patch_manager.cpp
+++ b/src/core/file_sys/patch_manager.cpp
@@ -128,15 +128,6 @@ VirtualDir PatchManager::PatchExeFS(VirtualDir exefs) const {
     if (exefs == nullptr)
         return exefs;
 
-    if (Settings::values.dump_exefs) {
-        LOG_INFO(Loader, "Dumping ExeFS for title_id={:016X}", title_id);
-        const auto dump_dir = fs_controller.GetModificationDumpRoot(title_id);
-        if (dump_dir != nullptr) {
-            const auto exefs_dir = GetOrCreateDirectoryRelative(dump_dir, "/exefs");
-            VfsRawCopyD(exefs, exefs_dir);
-        }
-    }
-
     const auto& disabled = Settings::values.disabled_addons[title_id];
     const auto update_disabled =
         std::find(disabled.cbegin(), disabled.cend(), "Update") != disabled.cend();
@@ -176,6 +167,15 @@ VirtualDir PatchManager::PatchExeFS(VirtualDir exefs) const {
         if (layered != nullptr) {
             LOG_INFO(Loader, "    ExeFS: LayeredExeFS patches applied successfully");
             exefs = std::move(layered);
+        }
+    }
+
+    if (Settings::values.dump_exefs) {
+        LOG_INFO(Loader, "Dumping ExeFS for title_id={:016X}", title_id);
+        const auto dump_dir = fs_controller.GetModificationDumpRoot(title_id);
+        if (dump_dir != nullptr) {
+            const auto exefs_dir = GetOrCreateDirectoryRelative(dump_dir, "/exefs");
+            VfsRawCopyD(exefs, exefs_dir);
         }
     }
 


### PR DESCRIPTION
Currently we dump the base exeFS, this PR changes it to dump the patched exeFS instead, which I think is more useful. Gives you access to game updates, and you can still get the base by disabling game updates. Thanks @gidoly for testing this for me.