### PR TITLE
yuzu: config: Fix mapping issues with the enter key

### DIFF
--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -1332,6 +1332,9 @@ void ConfigureInputPlayer::HandleClick(
     QPushButton* button, std::size_t button_id,
     std::function<void(const Common::ParamPackage&)> new_input_setter,
     InputCommon::Polling::InputType type) {
+    if (timeout_timer->isActive()) {
+        return;
+    }
     if (button == ui->buttonMotionLeft || button == ui->buttonMotionRight) {
         button->setText(tr("Shake!"));
     } else {

--- a/src/yuzu/configuration/configure_touch_from_button.cpp
+++ b/src/yuzu/configuration/configure_touch_from_button.cpp
@@ -227,6 +227,9 @@ void ConfigureTouchFromButton::RenameMapping() {
 }
 
 void ConfigureTouchFromButton::GetButtonInput(const int row_index, const bool is_new) {
+    if (timeout_timer->isActive()) {
+        return;
+    }
     binding_list_model->item(row_index, 0)->setText(tr("[press key]"));
 
     input_setter = [this, row_index, is_new](const Common::ParamPackage& params,


### PR DESCRIPTION
Pressing the enter key would restart the mapping process before the key is registered. Resulting on ignoring completely the enter key. By rejecting new inputs until the timer is disabled we can ensure the key will be detected properly.

Only missing key now it's the TAB key since this one is handled by Qt as switching object focus