### PR TITLE
common: Add NullVisitor default constructor

### DIFF
--- a/src/common/telemetry.h
+++ b/src/common/telemetry.h
@@ -171,6 +171,9 @@ struct VisitorInterface {
 struct NullVisitor final : public VisitorInterface {
     YUZU_NON_COPYABLE(NullVisitor);
 
+    NullVisitor() = default;
+    ~NullVisitor() override = default;
+
     void Visit(const Field<bool>& /*field*/) override {}
     void Visit(const Field<double>& /*field*/) override {}
     void Visit(const Field<float>& /*field*/) override {}


### PR DESCRIPTION
Addresses https://github.com/yuzu-emu/yuzu/issues/7881 to fix linux builds.

`YUZU_NON_COPYABLE` deletes the `T(const T&)` constructor which will
cause the implicitly defined default ctor/dtor to no-longer generate.