### PR TITLE
vulkan_device: fix missing format in ANV

### DIFF
--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -554,10 +554,12 @@ void CopyBufferToImage(vk::CommandBuffer cmdbuf, VkBuffer src_buffer, VkImage im
     };
 }
 
-[[nodiscard]] bool IsFormatFlipped(PixelFormat format) {
+[[nodiscard]] bool IsFormatFlipped(PixelFormat format, bool emulate_bgr565) {
     switch (format) {
     case PixelFormat::A1B5G5R5_UNORM:
         return true;
+    case PixelFormat::B5G6R5_UNORM:
+        return emulate_bgr565;
     default:
         return false;
     }
@@ -1488,7 +1490,7 @@ ImageView::ImageView(TextureCacheRuntime& runtime, const VideoCommon::ImageViewI
     };
     if (!info.IsRenderTarget()) {
         swizzle = info.Swizzle();
-        if (IsFormatFlipped(format)) {
+        if (IsFormatFlipped(format, device->MustEmulateBGR565())) {
             std::ranges::transform(swizzle, swizzle.begin(), SwapBlueRed);
         }
         if ((aspect_mask & (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) != 0) {

--- a/src/video_core/vulkan_common/vulkan_device.h
+++ b/src/video_core/vulkan_common/vulkan_device.h
@@ -354,6 +354,10 @@ public:
         return cant_blit_msaa;
     }
 
+    bool MustEmulateBGR565() const {
+        return must_emulate_bgr565;
+    }
+
 private:
     /// Checks if the physical device is suitable.
     void CheckSuitability(bool requires_swapchain) const;
@@ -448,6 +452,7 @@ private:
     bool has_nsight_graphics{};             ///< Has Nsight Graphics attached
     bool supports_d24_depth{};              ///< Supports D24 depth buffers.
     bool cant_blit_msaa{};                  ///< Does not support MSAA<->MSAA blitting.
+    bool must_emulate_bgr565{};             ///< Emulates BGR565 by swizzling RGB565 format.
 
     // Telemetry parameters
     std::string vendor_name;                       ///< Device's driver name.


### PR DESCRIPTION
Currently Mesa's ANV driver [does not support VK_FORMAT_B5G6R5_UNORM_PACK16](https://gitlab.freedesktop.org/mesa/mesa/-/blob/21.3/src/intel/vulkan/anv_formats.c#L152) which results in a crash; implement an alternative for it.

Fixes #6958 and part of #7023