### PR TITLE
core: hle: kernel: KPageTable: Fix UnmapPages.

### DIFF
--- a/src/core/hle/kernel/k_page_table.cpp
+++ b/src/core/hle/kernel/k_page_table.cpp
@@ -681,9 +681,8 @@ ResultCode KPageTable::UnmapPages(VAddr addr, const KPageLinkedList& page_linked
     VAddr cur_addr{addr};
 
     for (const auto& node : page_linked_list.Nodes()) {
-        const std::size_t num_pages{(addr - cur_addr) / PageSize};
-        if (const auto result{
-                Operate(addr, num_pages, KMemoryPermission::None, OperationType::Unmap)};
+        if (const auto result{Operate(cur_addr, node.GetNumPages(), KMemoryPermission::None,
+                                      OperationType::Unmap)};
             result.IsError()) {
             return result;
         }


### PR DESCRIPTION
- Fixes a logic bug in KPageTable::UnmapPages.