### PR TITLE
yuzu: Disconnect amiibos on drag and drop

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -2937,6 +2937,7 @@ void GMainWindow::OnLoadAmiibo() {
     if (nfc_state == Service::NFP::DeviceState::TagFound ||
         nfc_state == Service::NFP::DeviceState::TagMounted) {
         nfc->CloseAmiibo();
+        QMessageBox::warning(this, tr("Amiibo"), tr("The current amiibo has been removed"));
         return;
     }
 
@@ -2962,6 +2963,15 @@ void GMainWindow::LoadAmiibo(const QString& filename) {
     Service::SM::ServiceManager& sm = system->ServiceManager();
     auto nfc = sm.GetService<Service::NFP::Module::Interface>("nfp:user");
     if (nfc == nullptr) {
+        return;
+    }
+
+    // Remove amiibo if one is connected
+    const auto nfc_state = nfc->GetCurrentState();
+    if (nfc_state == Service::NFP::DeviceState::TagFound ||
+        nfc_state == Service::NFP::DeviceState::TagMounted) {
+        nfc->CloseAmiibo();
+        QMessageBox::warning(this, tr("Amiibo"), tr("The current amiibo has been removed"));
         return;
     }
 


### PR DESCRIPTION
Currently if you drag and drop an amiibo bin file and the previous one is connected it will fail to connect the new amiibo. Adding a little check and message to disconnect the amiibo ensures the next attempt will be successful 