### PR TITLE
MaxwellDMA: Implement semaphore operations

### DIFF
--- a/src/video_core/engines/maxwell_dma.h
+++ b/src/video_core/engines/maxwell_dma.h
@@ -224,6 +224,8 @@ private:
 
     void FastCopyBlockLinearToPitch();
 
+    void ReleaseSemaphore();
+
     Core::System& system;
 
     MemoryManager& memory_manager;


### PR DESCRIPTION
This implements the missing semaphore for MaxwellDMA.
- Used by BOTW & PLA.