### PR TITLE
cpu_detect: Refactor detection of processor features

### DIFF
--- a/src/common/bit_util.h
+++ b/src/common/bit_util.h
@@ -57,4 +57,11 @@ requires std::is_integral_v<T>
     return static_cast<T>(1ULL << ((8U * sizeof(T)) - std::countl_zero(value - 1U)));
 }
 
+template <size_t bit_index, typename T>
+requires std::is_integral_v<T>
+[[nodiscard]] constexpr bool Bit(const T value) {
+    static_assert(bit_index < BitSize<T>(), "bit_index must be smaller than size of T");
+    return ((value >> bit_index) & T(1)) == T(1);
+}
+
 } // namespace Common

--- a/src/common/x64/cpu_detect.cpp
+++ b/src/common/x64/cpu_detect.cpp
@@ -138,6 +138,7 @@ static CPUCaps Detect() {
     if (max_ex_fn >= 0x80000001) {
         // Check for more features
         __cpuid(cpu_id, 0x80000001);
+        caps.lzcnt = Common::Bit<5>(cpu_id[2]);
         caps.fma4 = Common::Bit<16>(cpu_id[2]);
     }
 

--- a/src/common/x64/cpu_detect.h
+++ b/src/common/x64/cpu_detect.h
@@ -1,12 +1,13 @@
-// Copyright 2013 Dolphin Emulator Project / 2015 Citra Emulator Project
-// Licensed under GPLv2 or any later version
-// Refer to the license.txt file included.
+// Copyright 2013 Dolphin Emulator Project / 2015 Citra Emulator Project / 2022 Yuzu Emulator
+// Project Project Licensed under GPLv2 or any later version Refer to the license.txt file included.
 
 #pragma once
 
+#include "common/common_types.h"
+
 namespace Common {
 
-enum class Manufacturer : u32 {
+enum class Manufacturer : u8 {
     Intel = 0,
     AMD = 1,
     Hygon = 2,
@@ -18,25 +19,25 @@ struct CPUCaps {
     Manufacturer manufacturer;
     char cpu_string[0x21];
     char brand_string[0x41];
-    bool sse;
-    bool sse2;
-    bool sse3;
-    bool ssse3;
-    bool sse4_1;
-    bool sse4_2;
-    bool lzcnt;
-    bool avx;
-    bool avx2;
-    bool avx512;
-    bool bmi1;
-    bool bmi2;
-    bool fma;
-    bool fma4;
-    bool aes;
-    bool invariant_tsc;
     u32 base_frequency;
     u32 max_frequency;
     u32 bus_frequency;
+    bool sse : 1;
+    bool sse2 : 1;
+    bool sse3 : 1;
+    bool ssse3 : 1;
+    bool sse4_1 : 1;
+    bool sse4_2 : 1;
+    bool lzcnt : 1;
+    bool avx : 1;
+    bool avx2 : 1;
+    bool avx512 : 1;
+    bool bmi1 : 1;
+    bool bmi2 : 1;
+    bool fma : 1;
+    bool fma4 : 1;
+    bool aes : 1;
+    bool invariant_tsc : 1;
 };
 
 /**

--- a/src/common/x64/cpu_detect.h
+++ b/src/common/x64/cpu_detect.h
@@ -3,25 +3,32 @@
 
 #pragma once
 
+#include <string_view>
 #include "common/common_types.h"
 
 namespace Common {
 
-enum class Manufacturer : u8 {
-    Intel = 0,
-    AMD = 1,
-    Hygon = 2,
-    Unknown = 3,
-};
-
 /// x86/x64 CPU capabilities that may be detected by this module
 struct CPUCaps {
+
+    enum class Manufacturer : u8 {
+        Unknown = 0,
+        Intel = 1,
+        AMD = 2,
+        Hygon = 3,
+    };
+
+    static Manufacturer ParseManufacturer(std::string_view brand_string);
+
     Manufacturer manufacturer;
-    char cpu_string[0x21];
-    char brand_string[0x41];
+    char brand_string[13];
+
+    char cpu_string[48];
+
     u32 base_frequency;
     u32 max_frequency;
     u32 bus_frequency;
+
     bool sse : 1;
     bool sse2 : 1;
     bool sse3 : 1;


### PR DESCRIPTION
These are some updates and fixes for `cpu_detect`'s `CPUCaps` structure to make it more robust for later feature-detection additions.