### PR TITLE
vk_blit_screen: Add missing framebuffer format

### DIFF
--- a/src/video_core/renderer_vulkan/vk_blit_screen.cpp
+++ b/src/video_core/renderer_vulkan/vk_blit_screen.cpp
@@ -100,6 +100,8 @@ VkFormat GetFormat(const Tegra::FramebufferConfig& framebuffer) {
         return VK_FORMAT_A8B8G8R8_UNORM_PACK32;
     case Tegra::FramebufferConfig::PixelFormat::RGB565_UNORM:
         return VK_FORMAT_R5G6B5_UNORM_PACK16;
+    case Tegra::FramebufferConfig::PixelFormat::B8G8R8A8_UNORM:
+        return VK_FORMAT_B8G8R8A8_UNORM;
     default:
         UNIMPLEMENTED_MSG("Unknown framebuffer pixel format: {}",
                           static_cast<u32>(framebuffer.pixel_format));


### PR DESCRIPTION
- Used by Yo Kai Watch 4.