### PR TITLE
maxwell_to_(gl/vk): Add 11_11_10 float vertex format

### DIFF
--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -184,6 +184,8 @@ inline GLenum VertexFormat(Maxwell::VertexAttribute attrib) {
         case Maxwell::VertexAttribute::Size::Size_32_32_32:
         case Maxwell::VertexAttribute::Size::Size_32_32_32_32:
             return GL_FLOAT;
+        case Maxwell::VertexAttribute::Size::Size_11_11_10:
+            return GL_UNSIGNED_INT_10F_11F_11F_REV;
         default:
             break;
         }

--- a/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
@@ -495,6 +495,8 @@ VkFormat VertexFormat(Maxwell::VertexAttribute::Type type, Maxwell::VertexAttrib
             return VK_FORMAT_R32G32B32_SFLOAT;
         case Maxwell::VertexAttribute::Size::Size_32_32_32_32:
             return VK_FORMAT_R32G32B32A32_SFLOAT;
+        case Maxwell::VertexAttribute::Size::Size_11_11_10:
+            return VK_FORMAT_B10G11R11_UFLOAT_PACK32;
         default:
             break;
         }


### PR DESCRIPTION
- Used by パワプロクンポケットR

Fixes #7940