### PR TITLE
Make asynchronous shaders exclusive to OpenGL

### DIFF
--- a/src/video_core/renderer_vulkan/vk_pipeline_cache.h
+++ b/src/video_core/renderer_vulkan/vk_pipeline_cache.h
@@ -117,8 +117,6 @@ public:
 private:
     [[nodiscard]] GraphicsPipeline* CurrentGraphicsPipelineSlowPath();
 
-    [[nodiscard]] GraphicsPipeline* BuiltPipeline(GraphicsPipeline* pipeline) const noexcept;
-
     std::unique_ptr<GraphicsPipeline> CreateGraphicsPipeline();
 
     std::unique_ptr<GraphicsPipeline> CreateGraphicsPipeline(
@@ -149,7 +147,6 @@ private:
     BufferCache& buffer_cache;
     TextureCache& texture_cache;
     VideoCore::ShaderNotify& shader_notify;
-    bool use_asynchronous_shaders{};
     bool use_vulkan_pipeline_cache{};
 
     GraphicsPipelineCacheKey graphics_key{};

--- a/src/yuzu/configuration/configure_graphics_advanced.ui
+++ b/src/yuzu/configuration/configure_graphics_advanced.ui
@@ -92,10 +92,10 @@
         <item>
          <widget class="QCheckBox" name="use_asynchronous_shaders">
           <property name="toolTip">
-           <string>Enables asynchronous shader compilation, which may reduce shader stutter. This feature is experimental.</string>
+           <string>Enables asynchronous shader compilation, which may reduce shader stutter. This feature is experimental and may cause graphical issues.</string>
           </property>
           <property name="text">
-           <string>Use asynchronous shader building (Hack)</string>
+           <string>Use asynchronous shader building (Hack, OpenGL only)</string>
           </property>
          </widget>
         </item>

--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -314,7 +314,7 @@ use_vsync =
 # 0: GLSL, 1 (default): GLASM, 2: SPIR-V
 shader_backend =
 
-# Whether to allow asynchronous shader building.
+# (OpenGL) Whether to allow asynchronous shader building.
 # 0 (default): Off, 1: On
 use_asynchronous_shaders =
 


### PR DESCRIPTION
Since the release of Project Hades, the shader de/recompiler rewrite, shader compilation under the Vulkan API has improved significantly compared to the previous shader recompiler.
This setting was conceived when shader compilation was significantly slower than it is now, and thus, its utility is greatly diminished on the Vulkan backend.
This makes the setting exclusive to OpenGL, where its still provides a significant benefit.

~~A fix to asynchronous shaders on OpenGL is currently being developed, and will be released imminently once testing is concluded.~~ Update: The fix #7969 has been merged.