### PR TITLE
gl_fence_manager: Minor optimization to signal querying

### DIFF
--- a/src/video_core/renderer_opengl/gl_fence_manager.cpp
+++ b/src/video_core/renderer_opengl/gl_fence_manager.cpp
@@ -31,9 +31,8 @@ bool GLInnerFence::IsSignaled() const {
         return true;
     }
     ASSERT(sync_object.handle != 0);
-    GLsizei length;
     GLint sync_status;
-    glGetSynciv(sync_object.handle, GL_SYNC_STATUS, sizeof(GLint), &length, &sync_status);
+    glGetSynciv(sync_object.handle, GL_SYNC_STATUS, 1, nullptr, &sync_status);
     return sync_status == GL_SIGNALED;
 }
 


### PR DESCRIPTION
Per the [spec](https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glGetSync.xhtml), bufSize is the number of integers that will be written, in this case, 1.

Also, the length argument is optional if the the number of elements written is not needed.