### PR TITLE
ffmpeg: Fix mis-maching argument warning for endif

### DIFF
--- a/externals/ffmpeg/CMakeLists.txt
+++ b/externals/ffmpeg/CMakeLists.txt
@@ -214,6 +214,6 @@ else(WIN32)
     set(FFmpeg_LDFLAGS "${FFmpeg_LDFLAGS}" PARENT_SCOPE)
     set(FFmpeg_LIBRARIES "${FFmpeg_LIBRARIES}" PARENT_SCOPE)
     set(FFmpeg_INCLUDE_DIR "${FFmpeg_INCLUDE_DIR}" PARENT_SCOPE)
-endif(WIN32)
+endif()
 
 unset(FFmpeg_COMPONENTS)


### PR DESCRIPTION
The correct expression should be `endif(NOT WIN32)` (because that's what was in the if statement), but that's confusing, so just remove it.

This resolves the related CMake warning.