### PR TITLE
gl_graphics_pipeline: Improve shader builder synchronization using fences

### DIFF
--- a/src/video_core/renderer_opengl/gl_graphics_pipeline.cpp
+++ b/src/video_core/renderer_opengl/gl_graphics_pipeline.cpp
@@ -587,16 +587,18 @@ void GraphicsPipeline::WaitForBuild() {
     is_built = true;
 }
 
-bool GraphicsPipeline::IsBuilt() const noexcept {
+bool GraphicsPipeline::IsBuilt() noexcept {
     if (is_built) {
         return true;
     }
     if (built_fence.handle == 0) {
         return false;
     }
-    GLint sync_status{};
-    glGetSynciv(built_fence.handle, GL_SYNC_STATUS, 1, nullptr, &sync_status);
-    return sync_status == GL_SIGNALED;
+    // Timeout of zero means this is non-blocking
+    const auto sync_status = glClientWaitSync(built_fence.handle, 0, 0);
+    ASSERT(sync_status != GL_WAIT_FAILED);
+    is_built = sync_status != GL_TIMEOUT_EXPIRED;
+    return is_built;
 }
 
 } // namespace OpenGL

--- a/src/video_core/renderer_opengl/gl_graphics_pipeline.h
+++ b/src/video_core/renderer_opengl/gl_graphics_pipeline.h
@@ -100,7 +100,7 @@ public:
         return writes_global_memory;
     }
 
-    [[nodiscard]] bool IsBuilt() const noexcept;
+    [[nodiscard]] bool IsBuilt() noexcept;
 
     template <typename Spec>
     static auto MakeConfigureSpecFunc() {

--- a/src/video_core/renderer_opengl/gl_graphics_pipeline.h
+++ b/src/video_core/renderer_opengl/gl_graphics_pipeline.h
@@ -100,9 +100,7 @@ public:
         return writes_global_memory;
     }
 
-    [[nodiscard]] bool IsBuilt() const noexcept {
-        return is_built.load(std::memory_order::relaxed);
-    }
+    [[nodiscard]] bool IsBuilt() const noexcept;
 
     template <typename Spec>
     static auto MakeConfigureSpecFunc() {
@@ -154,7 +152,8 @@ private:
 
     std::mutex built_mutex;
     std::condition_variable built_condvar;
-    std::atomic_bool is_built{false};
+    OGLSync built_fence{};
+    bool is_built{false};
 };
 
 } // namespace OpenGL


### PR DESCRIPTION
This PR aims to alleviate reported issues with async shaders on OpenGL where graphical issues persist during the session.

The challenge with async shaders on OpenGL is that there are two levels of asynchronous execution happening:
- The CPU shader builder thread runs concurrently, and has to coordinate with the main thread to inform it when the thread completed its work
- OGL commands are asynchronous by nature, and run concurrently with the CPU code.

So, even though the shader builder CPU thread completes its CPU work, it doesn't imply that the OGL commands it issued have been completed by the OGL context it shares with with main thread. 

This PR improves on async shaders by making use of `GLsync` fences to better coordinate when the builder thread has completed the OpenGL commands in its context. This is an improvement from before since this ensures the GL commands have been fully executed once the `GLsync` fence was reached, and these changes have been propagated to the contexts which `Wait` on the fence.