### PR TITLE
Kernel Memory Updates (Part 5): Revamp MapCodeMemory and UnmapCodeMemory.

### DIFF
--- a/src/core/hle/kernel/k_page_table.h
+++ b/src/core/hle/kernel/k_page_table.h
@@ -36,8 +36,8 @@ public:
                                     KMemoryManager::Pool pool);
     ResultCode MapProcessCode(VAddr addr, std::size_t pages_count, KMemoryState state,
                               KMemoryPermission perm);
-    ResultCode MapCodeMemory(VAddr dst_addr, VAddr src_addr, std::size_t size);
-    ResultCode UnmapCodeMemory(VAddr dst_addr, VAddr src_addr, std::size_t size);
+    ResultCode MapCodeMemory(VAddr dst_address, VAddr src_address, std::size_t size);
+    ResultCode UnmapCodeMemory(VAddr dst_address, VAddr src_address, std::size_t size);
     ResultCode UnmapProcessMemory(VAddr dst_addr, std::size_t size, KPageTable& src_page_table,
                                   VAddr src_addr);
     ResultCode MapPhysicalMemory(VAddr addr, std::size_t size);


### PR DESCRIPTION
This is a continuation of my work to bring our kernel memory management up to speed with recent system updates and the latest known updates (see previous PRs #7956, https://github.com/yuzu-emu/yuzu/pull/7701, https://github.com/yuzu-emu/yuzu/pull/7698, and https://github.com/yuzu-emu/yuzu/pull/7684 for a history of this effort).

- This makes these functions more accurate to the real HOS implementations.
- Fixes memory access issues in Super Smash Bros. Ultimate that occur when un/mapping NROs.