### PR TITLE
loader: log the type of mismatching file-extension

### DIFF
--- a/src/core/loader/loader.cpp
+++ b/src/core/loader/loader.cpp
@@ -261,7 +261,8 @@ std::unique_ptr<AppLoader> GetLoader(Core::System& system, FileSys::VirtualFile 
 
     // Special case: 00 is either a NCA or NAX.
     if (type != filename_type && !(file->GetName() == "00" && type == FileType::NAX)) {
-        LOG_WARNING(Loader, "File {} has a different type than its extension.", file->GetName());
+        LOG_WARNING(Loader, "File {} has a different type ({}) than its extension.",
+                    file->GetName(), GetFileTypeString(type));
         if (FileType::Unknown == type) {
             type = filename_type;
         }


### PR DESCRIPTION
This change additionally logs the deduced type of a mismatching type/file-extension combination.
For instance loading a ```my_cool.xci``` that is actually a NSP type will log out:
```[   0.148175] Loader <Warning> core/loader/loader.cpp:GetLoader:264: my_cool.xci has a different type (NSP) than its extension.```