### PR TITLE
core, video_core: Fix two crashes when failing to create the emulated GPU instance

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -326,7 +326,9 @@ struct System::Impl {
         is_powered_on = false;
         exit_lock = false;
 
-        gpu_core->NotifyShutdown();
+        if (gpu_core != nullptr) {
+            gpu_core->NotifyShutdown();
+        }
 
         services.reset();
         service_manager.reset();

--- a/src/core/frontend/emu_window.h
+++ b/src/core/frontend/emu_window.h
@@ -42,11 +42,20 @@ public:
             context.MakeCurrent();
         }
         ~Scoped() {
-            context.DoneCurrent();
+            if (active) {
+                context.DoneCurrent();
+            }
+        }
+
+        /// In the event that context was destroyed before the Scoped is destroyed, this provides a
+        /// mechanism to prevent calling a destroyed object's method during the deconstructor
+        void Cancel() {
+            active = false;
         }
 
     private:
         GraphicsContext& context;
+        bool active{true};
     };
 
     /// Calls MakeCurrent on the context and calls DoneCurrent when the scope for the returned value

--- a/src/video_core/video_core.cpp
+++ b/src/video_core/video_core.cpp
@@ -50,6 +50,7 @@ std::unique_ptr<Tegra::GPU> CreateGPU(Core::Frontend::EmuWindow& emu_window, Cor
         gpu->BindRenderer(std::move(renderer));
         return gpu;
     } catch (const std::runtime_error& exception) {
+        scope.Cancel();
         LOG_ERROR(HW_GPU, "Failed to initialize GPU: {}", exception.what());
         return nullptr;
     }


### PR DESCRIPTION
This PR aims to fix two crashes when yuzu fails to create the emulated GPU instance (e.g. no Vulkan driver is present). The first is when `CreateGPU` fails yuzu would try and shutdown the GPU instance regardless of whether any instance was actually created. 

Secondly, when `CreateRenderer` fails, the `GraphicsContext` that was `std::move`'d into it is destroyed before the `Scoped` that was created to manage its currency. In that case, the `GraphicsContext::Scoped` will still call its destructor at the ending of the function. And because the `context` is destroyed, the `Scoped` will cause a crash as it attempts to call a destroyed object's `DoneCurrent` function.

~~The first issue if fixed by checking for `nullptr` before calling those methods. The second is fixed by avoiding using any `Scoped` and instead manage the context currency manually through a functor.~~ See commit messages

For Vulkan, `DoneCurrent` is not redefined so this is to manage an empty function -- it appears that it's purely for compatibility with OpenGL.