### PR TITLE
backend: Ensure backend_thread is destructed before message_queue

### DIFF
--- a/src/common/logging/backend.cpp
+++ b/src/common/logging/backend.cpp
@@ -276,9 +276,9 @@ private:
     ColorConsoleBackend color_console_backend{};
     FileBackend file_backend;
 
-    std::jthread backend_thread;
     MPSCQueue<Entry, true> message_queue{};
     std::chrono::steady_clock::time_point time_origin{std::chrono::steady_clock::now()};
+    std::jthread backend_thread;
 };
 } // namespace
 


### PR DESCRIPTION
Ensures that stop_token signals that stop has been requested before destruction of conditional_variable.

Should close #7992.