### PR TITLE
vs2022

### DIFF
--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -38,6 +38,7 @@ if (MSVC)
         /we4244 # 'conversion': conversion from 'type1' to 'type2', possible loss of data
         /we4245 # 'conversion': conversion from 'type1' to 'type2', signed/unsigned mismatch
         /we4254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
+        /wd4701 # potentially uninitialized local variable 'result' used
     )
 else()
     target_compile_options(input_common PRIVATE

--- a/src/shader_recompiler/backend/spirv/emit_spirv.h
+++ b/src/shader_recompiler/backend/spirv/emit_spirv.h
@@ -22,7 +22,7 @@ constexpr u32 NUM_TEXTURE_AND_IMAGE_SCALING_WORDS =
 struct RescalingLayout {
     alignas(16) std::array<u32, NUM_TEXTURE_SCALING_WORDS> rescaling_textures;
     alignas(16) std::array<u32, NUM_IMAGE_SCALING_WORDS> rescaling_images;
-    alignas(16) u32 down_factor;
+    u32 down_factor;
 };
 constexpr u32 RESCALING_LAYOUT_WORDS_OFFSET = offsetof(RescalingLayout, rescaling_textures);
 constexpr u32 RESCALING_LAYOUT_DOWN_FACTOR_OFFSET = offsetof(RescalingLayout, down_factor);

--- a/src/video_core/renderer_vulkan/vk_compute_pass.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pass.cpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include <optional>
 #include <utility>
+#include <array>
 
 #include "common/alignment.h"
 #include "common/assert.h"
@@ -292,7 +293,7 @@ std::pair<VkBuffer, VkDeviceSize> QuadIndexedPass::Assemble(
             .srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT,
             .dstAccessMask = VK_ACCESS_INDEX_READ_BIT,
         };
-        const std::array push_constants{base_vertex, index_shift};
+        const std::array<u32, 2> push_constants{base_vertex, index_shift};
         const VkDescriptorSet set = descriptor_allocator.Commit();
         device.GetLogical().UpdateDescriptorSet(set, *descriptor_template, descriptor_data);
         cmdbuf.BindPipeline(VK_PIPELINE_BIND_POINT_COMPUTE, *pipeline);


### PR DESCRIPTION
I have removed my VS2017/VS2019 from my pc to install VS2022 and I was curious to compile yuzu with it.

I made a pull request but it's more to show where the problems are than to be integrated inside master because my fixes might not be the right ones.
The first issue is inside externals/libressl (not in my pull request because I didin't want to fork externals/libressl just for that) and especially with the following define inside externals/libresslCMakeLists.txt:

```
if(WIN32)
	add_definitions(-Drestrict) 
```
because Windows headers files now seems to include the macro _CRTRESTRICT:

```
_Check_return_ _Ret_maybenull_ _Post_writable_byte_size_(_Count * _Size)
_ACRTIMP _CRTALLOCATOR _CRTRESTRICT
void* __cdecl _calloc_base(
    _In_ size_t _Count,
    _In_ size_t _Size
    );
```

The macro is defined like that:

```
#if defined _CRT_SUPPRESS_RESTRICT || defined _CORECRT_BUILD
    #define _CRTRESTRICT
#else
    #define _CRTRESTRICT __declspec(restrict)
#endif
```

So you caneither define _CRT_SUPPRESS_RESTRICT  or remove the add_definitions(-Drestrict).
Personally I did this:

```
if(WIN32)
	add_definitions(-D_CRT_SUPPRESS_RESTRICT)
	add_definitions(-Drestrict)
```

[src/input_common/CMakeLists.txt]
Inside boost 1.78 there is a warning inside include\boost\crc.hpp about potentially uninitialized local variable 'result' used so I have added /wd4701

