### PR TITLE
Kernel Memory Updates (Part 6): Use guest memory for slab heaps & update TLS.

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -245,6 +245,8 @@ add_library(core STATIC
     hle/kernel/k_system_control.h
     hle/kernel/k_thread.cpp
     hle/kernel/k_thread.h
+    hle/kernel/k_thread_local_page.cpp
+    hle/kernel/k_thread_local_page.h
     hle/kernel/k_thread_queue.cpp
     hle/kernel/k_thread_queue.h
     hle/kernel/k_trace.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -207,6 +207,7 @@ add_library(core STATIC
     hle/kernel/k_memory_region.h
     hle/kernel/k_memory_region_type.h
     hle/kernel/k_page_bitmap.h
+    hle/kernel/k_page_buffer.h
     hle/kernel/k_page_heap.cpp
     hle/kernel/k_page_heap.h
     hle/kernel/k_page_linked_list.h

--- a/src/core/hle/ipc_helpers.h
+++ b/src/core/hle/ipc_helpers.h
@@ -385,7 +385,7 @@ public:
     T PopRaw();
 
     template <class T>
-    std::shared_ptr<T> PopIpcInterface() {
+    std::weak_ptr<T> PopIpcInterface() {
         ASSERT(context->Session()->IsDomain());
         ASSERT(context->GetDomainMessageHeader().input_object_count > 0);
         return context->GetDomainHandler<T>(Pop<u32>() - 1);

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -45,7 +45,7 @@ bool SessionRequestManager::HasSessionRequestHandler(const HLERequestContext& co
             LOG_CRITICAL(IPC, "object_id {} is too big!", object_id);
             return false;
         }
-        return DomainHandler(object_id - 1) != nullptr;
+        return DomainHandler(object_id - 1).lock() != nullptr;
     } else {
         return session_handler != nullptr;
     }

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -53,9 +53,6 @@ bool SessionRequestManager::HasSessionRequestHandler(const HLERequestContext& co
 
 void SessionRequestHandler::ClientConnected(KServerSession* session) {
     session->ClientConnected(shared_from_this());
-
-    // Ensure our server session is tracked globally.
-    kernel.RegisterServerSession(session);
 }
 
 void SessionRequestHandler::ClientDisconnected(KServerSession* session) {

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -94,6 +94,7 @@ protected:
     std::weak_ptr<ServiceThread> service_thread;
 };
 
+using SessionRequestHandlerWeakPtr = std::weak_ptr<SessionRequestHandler>;
 using SessionRequestHandlerPtr = std::shared_ptr<SessionRequestHandler>;
 
 /**
@@ -139,7 +140,7 @@ public:
         }
     }
 
-    SessionRequestHandlerPtr DomainHandler(std::size_t index) const {
+    SessionRequestHandlerWeakPtr DomainHandler(std::size_t index) const {
         ASSERT_MSG(index < DomainHandlerCount(), "Unexpected handler index {}", index);
         return domain_handlers.at(index);
     }
@@ -328,10 +329,10 @@ public:
 
     template <typename T>
     std::shared_ptr<T> GetDomainHandler(std::size_t index) const {
-        return std::static_pointer_cast<T>(manager->DomainHandler(index));
+        return std::static_pointer_cast<T>(manager.lock()->DomainHandler(index).lock());
     }
 
-    void SetSessionRequestManager(std::shared_ptr<SessionRequestManager> manager_) {
+    void SetSessionRequestManager(std::weak_ptr<SessionRequestManager> manager_) {
         manager = std::move(manager_);
     }
 
@@ -374,7 +375,7 @@ private:
     u32 handles_offset{};
     u32 domain_offset{};
 
-    std::shared_ptr<SessionRequestManager> manager;
+    std::weak_ptr<SessionRequestManager> manager;
 
     KernelCore& kernel;
     Core::Memory::Memory& memory;

--- a/src/core/hle/kernel/init/init_slab_setup.cpp
+++ b/src/core/hle/kernel/init/init_slab_setup.cpp
@@ -107,6 +107,12 @@ VAddr InitializeSlabHeap(Core::System& system, KMemoryLayout& memory_layout, VAd
     return start + size;
 }
 
+size_t CalculateSlabHeapGapSize() {
+    constexpr size_t KernelSlabHeapGapSize = 2_MiB - 296_KiB;
+    static_assert(KernelSlabHeapGapSize <= KernelSlabHeapGapsSizeMax);
+    return KernelSlabHeapGapSize;
+}
+
 } // namespace
 
 KSlabResourceCounts KSlabResourceCounts::CreateDefault() {
@@ -135,12 +141,6 @@ void InitializeSlabResourceCounts(KernelCore& kernel) {
     if (KSystemControl::Init::ShouldIncreaseThreadResourceLimit()) {
         kernel.SlabResourceCounts().num_KThread += SlabCountExtraKThread;
     }
-}
-
-size_t CalculateSlabHeapGapSize() {
-    constexpr size_t KernelSlabHeapGapSize = 2_MiB - 296_KiB;
-    static_assert(KernelSlabHeapGapSize <= KernelSlabHeapGapsSizeMax);
-    return KernelSlabHeapGapSize;
 }
 
 size_t CalculateTotalSlabHeapSize(const KernelCore& kernel) {

--- a/src/core/hle/kernel/init/init_slab_setup.cpp
+++ b/src/core/hle/kernel/init/init_slab_setup.cpp
@@ -7,19 +7,23 @@
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "core/core.h"
+#include "core/device_memory.h"
 #include "core/hardware_properties.h"
 #include "core/hle/kernel/init/init_slab_setup.h"
 #include "core/hle/kernel/k_code_memory.h"
 #include "core/hle/kernel/k_event.h"
 #include "core/hle/kernel/k_memory_layout.h"
 #include "core/hle/kernel/k_memory_manager.h"
+#include "core/hle/kernel/k_page_buffer.h"
 #include "core/hle/kernel/k_port.h"
 #include "core/hle/kernel/k_process.h"
 #include "core/hle/kernel/k_resource_limit.h"
 #include "core/hle/kernel/k_session.h"
 #include "core/hle/kernel/k_shared_memory.h"
+#include "core/hle/kernel/k_shared_memory_info.h"
 #include "core/hle/kernel/k_system_control.h"
 #include "core/hle/kernel/k_thread.h"
+#include "core/hle/kernel/k_thread_local_page.h"
 #include "core/hle/kernel/k_transfer_memory.h"
 
 namespace Kernel::Init {
@@ -32,9 +36,13 @@ namespace Kernel::Init {
     HANDLER(KEvent, (SLAB_COUNT(KEvent)), ##__VA_ARGS__)                                           \
     HANDLER(KPort, (SLAB_COUNT(KPort)), ##__VA_ARGS__)                                             \
     HANDLER(KSharedMemory, (SLAB_COUNT(KSharedMemory)), ##__VA_ARGS__)                             \
+    HANDLER(KSharedMemoryInfo, (SLAB_COUNT(KSharedMemory) * 8), ##__VA_ARGS__)                     \
     HANDLER(KTransferMemory, (SLAB_COUNT(KTransferMemory)), ##__VA_ARGS__)                         \
     HANDLER(KCodeMemory, (SLAB_COUNT(KCodeMemory)), ##__VA_ARGS__)                                 \
     HANDLER(KSession, (SLAB_COUNT(KSession)), ##__VA_ARGS__)                                       \
+    HANDLER(KThreadLocalPage,                                                                      \
+            (SLAB_COUNT(KProcess) + (SLAB_COUNT(KProcess) + SLAB_COUNT(KThread)) / 8),             \
+            ##__VA_ARGS__)                                                                         \
     HANDLER(KResourceLimit, (SLAB_COUNT(KResourceLimit)), ##__VA_ARGS__)
 
 namespace {
@@ -50,38 +58,46 @@ enum KSlabType : u32 {
 // Constexpr counts.
 constexpr size_t SlabCountKProcess = 80;
 constexpr size_t SlabCountKThread = 800;
-constexpr size_t SlabCountKEvent = 700;
+constexpr size_t SlabCountKEvent = 900;
 constexpr size_t SlabCountKInterruptEvent = 100;
-constexpr size_t SlabCountKPort = 256 + 0x20; // Extra 0x20 ports over Nintendo for homebrew.
+constexpr size_t SlabCountKPort = 384;
 constexpr size_t SlabCountKSharedMemory = 80;
 constexpr size_t SlabCountKTransferMemory = 200;
 constexpr size_t SlabCountKCodeMemory = 10;
 constexpr size_t SlabCountKDeviceAddressSpace = 300;
-constexpr size_t SlabCountKSession = 933;
+constexpr size_t SlabCountKSession = 1133;
 constexpr size_t SlabCountKLightSession = 100;
 constexpr size_t SlabCountKObjectName = 7;
 constexpr size_t SlabCountKResourceLimit = 5;
 constexpr size_t SlabCountKDebug = Core::Hardware::NUM_CPU_CORES;
-constexpr size_t SlabCountKAlpha = 1;
-constexpr size_t SlabCountKBeta = 6;
+constexpr size_t SlabCountKIoPool = 1;
+constexpr size_t SlabCountKIoRegion = 6;
 
 constexpr size_t SlabCountExtraKThread = 160;
+
+/// Helper function to translate from the slab virtual address to the reserved location in physical
+/// memory.
+static PAddr TranslateSlabAddrToPhysical(KMemoryLayout& memory_layout, VAddr slab_addr) {
+    slab_addr -= memory_layout.GetSlabRegionAddress();
+    return slab_addr + Core::DramMemoryMap::SlabHeapBase;
+}
 
 template <typename T>
 VAddr InitializeSlabHeap(Core::System& system, KMemoryLayout& memory_layout, VAddr address,
                          size_t num_objects) {
-    // TODO(bunnei): This is just a place holder. We should initialize the appropriate KSlabHeap for
-    // kernel object type T with the backing kernel memory pointer once we emulate kernel memory.
 
     const size_t size = Common::AlignUp(sizeof(T) * num_objects, alignof(void*));
     VAddr start = Common::AlignUp(address, alignof(T));
 
-    // This is intentionally empty. Once KSlabHeap is fully implemented, we can replace this with
-    // the pointer to emulated memory to pass along. Until then, KSlabHeap will just allocate/free
-    // host memory.
-    void* backing_kernel_memory{};
+    // This should use the virtual memory address passed in, but currently, we do not setup the
+    // kernel virtual memory layout. Instead, we simply map these at a region of physical memory
+    // that we reserve for the slab heaps.
+    // TODO(bunnei): Fix this once we support the kernel virtual memory layout.
 
     if (size > 0) {
+        void* backing_kernel_memory{
+            system.DeviceMemory().GetPointer(TranslateSlabAddrToPhysical(memory_layout, start))};
+
         const KMemoryRegion* region = memory_layout.FindVirtual(start + size - 1);
         ASSERT(region != nullptr);
         ASSERT(region->IsDerivedFrom(KMemoryRegionType_KernelSlab));
@@ -109,8 +125,8 @@ KSlabResourceCounts KSlabResourceCounts::CreateDefault() {
         .num_KObjectName = SlabCountKObjectName,
         .num_KResourceLimit = SlabCountKResourceLimit,
         .num_KDebug = SlabCountKDebug,
-        .num_KAlpha = SlabCountKAlpha,
-        .num_KBeta = SlabCountKBeta,
+        .num_KIoPool = SlabCountKIoPool,
+        .num_KIoRegion = SlabCountKIoRegion,
     };
 }
 
@@ -119,6 +135,12 @@ void InitializeSlabResourceCounts(KernelCore& kernel) {
     if (KSystemControl::Init::ShouldIncreaseThreadResourceLimit()) {
         kernel.SlabResourceCounts().num_KThread += SlabCountExtraKThread;
     }
+}
+
+size_t CalculateSlabHeapGapSize() {
+    constexpr size_t KernelSlabHeapGapSize = 2_MiB - 296_KiB;
+    static_assert(KernelSlabHeapGapSize <= KernelSlabHeapGapsSizeMax);
+    return KernelSlabHeapGapSize;
 }
 
 size_t CalculateTotalSlabHeapSize(const KernelCore& kernel) {
@@ -136,9 +158,32 @@ size_t CalculateTotalSlabHeapSize(const KernelCore& kernel) {
 #undef ADD_SLAB_SIZE
 
     // Add the reserved size.
-    size += KernelSlabHeapGapsSize;
+    size += CalculateSlabHeapGapSize();
 
     return size;
+}
+
+void InitializeKPageBufferSlabHeap(Core::System& system) {
+    auto& kernel = system.Kernel();
+
+    const auto& counts = kernel.SlabResourceCounts();
+    const size_t num_pages =
+        counts.num_KProcess + counts.num_KThread + (counts.num_KProcess + counts.num_KThread) / 8;
+    const size_t slab_size = num_pages * PageSize;
+
+    // Reserve memory from the system resource limit.
+    ASSERT(kernel.GetSystemResourceLimit()->Reserve(LimitableResource::PhysicalMemory, slab_size));
+
+    // Allocate memory for the slab.
+    constexpr auto AllocateOption = KMemoryManager::EncodeOption(
+        KMemoryManager::Pool::System, KMemoryManager::Direction::FromFront);
+    const PAddr slab_address =
+        kernel.MemoryManager().AllocateAndOpenContinuous(num_pages, 1, AllocateOption);
+    ASSERT(slab_address != 0);
+
+    // Initialize the slabheap.
+    KPageBuffer::InitializeSlabHeap(kernel, system.DeviceMemory().GetPointer(slab_address),
+                                    slab_size);
 }
 
 void InitializeSlabHeaps(Core::System& system, KMemoryLayout& memory_layout) {
@@ -160,13 +205,13 @@ void InitializeSlabHeaps(Core::System& system, KMemoryLayout& memory_layout) {
     }
 
     // Create an array to represent the gaps between the slabs.
-    const size_t total_gap_size = KernelSlabHeapGapsSize;
+    const size_t total_gap_size = CalculateSlabHeapGapSize();
     std::array<size_t, slab_types.size()> slab_gaps;
-    for (size_t i = 0; i < slab_gaps.size(); i++) {
+    for (auto& slab_gap : slab_gaps) {
         // Note: This is an off-by-one error from Nintendo's intention, because GenerateRandomRange
         // is inclusive. However, Nintendo also has the off-by-one error, and it's "harmless", so we
         // will include it ourselves.
-        slab_gaps[i] = KSystemControl::GenerateRandomRange(0, total_gap_size);
+        slab_gap = KSystemControl::GenerateRandomRange(0, total_gap_size);
     }
 
     // Sort the array, so that we can treat differences between values as offsets to the starts of
@@ -177,13 +222,21 @@ void InitializeSlabHeaps(Core::System& system, KMemoryLayout& memory_layout) {
         }
     }
 
-    for (size_t i = 0; i < slab_types.size(); i++) {
+    // Track the gaps, so that we can free them to the unused slab tree.
+    VAddr gap_start = address;
+    size_t gap_size = 0;
+
+    for (size_t i = 0; i < slab_gaps.size(); i++) {
         // Add the random gap to the address.
-        address += (i == 0) ? slab_gaps[0] : slab_gaps[i] - slab_gaps[i - 1];
+        const auto cur_gap = (i == 0) ? slab_gaps[0] : slab_gaps[i] - slab_gaps[i - 1];
+        address += cur_gap;
+        gap_size += cur_gap;
 
 #define INITIALIZE_SLAB_HEAP(NAME, COUNT, ...)                                                     \
     case KSlabType_##NAME:                                                                         \
-        address = InitializeSlabHeap<NAME>(system, memory_layout, address, COUNT);                 \
+        if (COUNT > 0) {                                                                           \
+            address = InitializeSlabHeap<NAME>(system, memory_layout, address, COUNT);             \
+        }                                                                                          \
         break;
 
         // Initialize the slabheap.
@@ -192,7 +245,13 @@ void InitializeSlabHeaps(Core::System& system, KMemoryLayout& memory_layout) {
             FOREACH_SLAB_TYPE(INITIALIZE_SLAB_HEAP)
             // If we somehow get an invalid type, abort.
         default:
-            UNREACHABLE();
+            UNREACHABLE_MSG("Unknown slab type: {}", slab_types[i]);
+        }
+
+        // If we've hit the end of a gap, free it.
+        if (gap_start + gap_size != address) {
+            gap_start = address;
+            gap_size = 0;
         }
     }
 }

--- a/src/core/hle/kernel/init/init_slab_setup.h
+++ b/src/core/hle/kernel/init/init_slab_setup.h
@@ -32,12 +32,13 @@ struct KSlabResourceCounts {
     size_t num_KObjectName;
     size_t num_KResourceLimit;
     size_t num_KDebug;
-    size_t num_KAlpha;
-    size_t num_KBeta;
+    size_t num_KIoPool;
+    size_t num_KIoRegion;
 };
 
 void InitializeSlabResourceCounts(KernelCore& kernel);
 size_t CalculateTotalSlabHeapSize(const KernelCore& kernel);
+void InitializeKPageBufferSlabHeap(Core::System& system);
 void InitializeSlabHeaps(Core::System& system, KMemoryLayout& memory_layout);
 
 } // namespace Kernel::Init

--- a/src/core/hle/kernel/k_address_arbiter.cpp
+++ b/src/core/hle/kernel/k_address_arbiter.cpp
@@ -115,7 +115,7 @@ ResultCode KAddressArbiter::Signal(VAddr addr, s32 count) {
     {
         KScopedSchedulerLock sl(kernel);
 
-        auto it = thread_tree.nfind_light({addr, -1});
+        auto it = thread_tree.nfind_key({addr, -1});
         while ((it != thread_tree.end()) && (count <= 0 || num_waiters < count) &&
                (it->GetAddressArbiterKey() == addr)) {
             // End the thread's wait.
@@ -148,7 +148,7 @@ ResultCode KAddressArbiter::SignalAndIncrementIfEqual(VAddr addr, s32 value, s32
             return ResultInvalidState;
         }
 
-        auto it = thread_tree.nfind_light({addr, -1});
+        auto it = thread_tree.nfind_key({addr, -1});
         while ((it != thread_tree.end()) && (count <= 0 || num_waiters < count) &&
                (it->GetAddressArbiterKey() == addr)) {
             // End the thread's wait.
@@ -171,7 +171,7 @@ ResultCode KAddressArbiter::SignalAndModifyByWaitingCountIfEqual(VAddr addr, s32
     {
         [[maybe_unused]] const KScopedSchedulerLock sl(kernel);
 
-        auto it = thread_tree.nfind_light({addr, -1});
+        auto it = thread_tree.nfind_key({addr, -1});
         // Determine the updated value.
         s32 new_value{};
         if (count <= 0) {

--- a/src/core/hle/kernel/k_condition_variable.cpp
+++ b/src/core/hle/kernel/k_condition_variable.cpp
@@ -244,7 +244,7 @@ void KConditionVariable::Signal(u64 cv_key, s32 count) {
     {
         KScopedSchedulerLock sl(kernel);
 
-        auto it = thread_tree.nfind_light({cv_key, -1});
+        auto it = thread_tree.nfind_key({cv_key, -1});
         while ((it != thread_tree.end()) && (count <= 0 || num_waiters < count) &&
                (it->GetConditionVariableKey() == cv_key)) {
             KThread* target_thread = std::addressof(*it);

--- a/src/core/hle/kernel/k_memory_layout.h
+++ b/src/core/hle/kernel/k_memory_layout.h
@@ -57,11 +57,11 @@ constexpr std::size_t KernelPageTableHeapSize = GetMaximumOverheadSize(MainMemor
 constexpr std::size_t KernelInitialPageHeapSize = 128_KiB;
 
 constexpr std::size_t KernelSlabHeapDataSize = 5_MiB;
-constexpr std::size_t KernelSlabHeapGapsSize = 2_MiB - 64_KiB;
-constexpr std::size_t KernelSlabHeapSize = KernelSlabHeapDataSize + KernelSlabHeapGapsSize;
+constexpr std::size_t KernelSlabHeapGapsSizeMax = 2_MiB - 64_KiB;
+constexpr std::size_t KernelSlabHeapSize = KernelSlabHeapDataSize + KernelSlabHeapGapsSizeMax;
 
 // NOTE: This is calculated from KThread slab counts, assuming KThread size <= 0x860.
-constexpr std::size_t KernelSlabHeapAdditionalSize = 416_KiB;
+constexpr std::size_t KernelSlabHeapAdditionalSize = 0x68000;
 
 constexpr std::size_t KernelResourceSize =
     KernelPageTableHeapSize + KernelInitialPageHeapSize + KernelSlabHeapSize;

--- a/src/core/hle/kernel/k_page_buffer.h
+++ b/src/core/hle/kernel/k_page_buffer.h
@@ -1,0 +1,34 @@
+// Copyright 2022 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <array>
+
+#include "common/alignment.h"
+#include "common/assert.h"
+#include "common/common_types.h"
+#include "core/core.h"
+#include "core/device_memory.h"
+#include "core/hle/kernel/memory_types.h"
+
+namespace Kernel {
+
+class KPageBuffer final : public KSlabAllocated<KPageBuffer> {
+public:
+    KPageBuffer() = default;
+
+    static KPageBuffer* FromPhysicalAddress(Core::System& system, PAddr phys_addr) {
+        ASSERT(Common::IsAligned(phys_addr, PageSize));
+        return reinterpret_cast<KPageBuffer*>(system.DeviceMemory().GetPointer(phys_addr));
+    }
+
+private:
+    [[maybe_unused]] alignas(PageSize) std::array<u8, PageSize> m_buffer{};
+};
+
+static_assert(sizeof(KPageBuffer) == PageSize);
+static_assert(alignof(KPageBuffer) == PageSize);
+
+} // namespace Kernel

--- a/src/core/hle/kernel/k_port.cpp
+++ b/src/core/hle/kernel/k_port.cpp
@@ -57,7 +57,12 @@ ResultCode KPort::EnqueueSession(KServerSession* session) {
     R_UNLESS(state == State::Normal, ResultPortClosed);
 
     server.EnqueueSession(session);
-    server.GetSessionRequestHandler()->ClientConnected(server.AcceptSession());
+
+    if (auto session_ptr = server.GetSessionRequestHandler().lock()) {
+        session_ptr->ClientConnected(server.AcceptSession());
+    } else {
+        UNREACHABLE();
+    }
 
     return ResultSuccess;
 }

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -404,9 +404,6 @@ void KProcess::PrepareForTermination() {
 }
 
 void KProcess::Finalize() {
-    // Finalize the handle table and close any open handles.
-    handle_table.Finalize();
-
     // Free all shared memory infos.
     {
         auto it = shared_memory_list.begin();
@@ -430,6 +427,9 @@ void KProcess::Finalize() {
         resource_limit->Close();
         resource_limit = nullptr;
     }
+
+    // Finalize the page table.
+    page_table.reset();
 
     // Perform inherited finalization.
     KAutoObjectWithSlabHeapAndContainer<KProcess, KWorkerTask>::Finalize();

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -70,58 +70,6 @@ void SetupMainThread(Core::System& system, KProcess& owner_process, u32 priority
 }
 } // Anonymous namespace
 
-// Represents a page used for thread-local storage.
-//
-// Each TLS page contains slots that may be used by processes and threads.
-// Every process and thread is created with a slot in some arbitrary page
-// (whichever page happens to have an available slot).
-class TLSPage {
-public:
-    static constexpr std::size_t num_slot_entries =
-        Core::Memory::PAGE_SIZE / Core::Memory::TLS_ENTRY_SIZE;
-
-    explicit TLSPage(VAddr address) : base_address{address} {}
-
-    bool HasAvailableSlots() const {
-        return !is_slot_used.all();
-    }
-
-    VAddr GetBaseAddress() const {
-        return base_address;
-    }
-
-    std::optional<VAddr> ReserveSlot() {
-        for (std::size_t i = 0; i < is_slot_used.size(); i++) {
-            if (is_slot_used[i]) {
-                continue;
-            }
-
-            is_slot_used[i] = true;
-            return base_address + (i * Core::Memory::TLS_ENTRY_SIZE);
-        }
-
-        return std::nullopt;
-    }
-
-    void ReleaseSlot(VAddr address) {
-        // Ensure that all given addresses are consistent with how TLS pages
-        // are intended to be used when releasing slots.
-        ASSERT(IsWithinPage(address));
-        ASSERT((address % Core::Memory::TLS_ENTRY_SIZE) == 0);
-
-        const std::size_t index = (address - base_address) / Core::Memory::TLS_ENTRY_SIZE;
-        is_slot_used[index] = false;
-    }
-
-private:
-    bool IsWithinPage(VAddr address) const {
-        return base_address <= address && address < base_address + Core::Memory::PAGE_SIZE;
-    }
-
-    VAddr base_address;
-    std::bitset<num_slot_entries> is_slot_used;
-};
-
 ResultCode KProcess::Initialize(KProcess* process, Core::System& system, std::string process_name,
                                 ProcessType type, KResourceLimit* res_limit) {
     auto& kernel = system.Kernel();
@@ -404,7 +352,7 @@ ResultCode KProcess::LoadFromMetadata(const FileSys::ProgramMetadata& metadata,
     }
 
     // Create TLS region
-    tls_region_address = CreateTLSRegion();
+    R_TRY(this->CreateThreadLocalRegion(std::addressof(tls_region_address)));
     memory_reservation.Commit();
 
     return handle_table.Initialize(capabilities.GetHandleTableSize());
@@ -444,7 +392,7 @@ void KProcess::PrepareForTermination() {
 
     stop_threads(kernel.System().GlobalSchedulerContext().GetThreadList());
 
-    FreeTLSRegion(tls_region_address);
+    this->DeleteThreadLocalRegion(tls_region_address);
     tls_region_address = 0;
 
     if (resource_limit) {
@@ -487,63 +435,103 @@ void KProcess::Finalize() {
     KAutoObjectWithSlabHeapAndContainer<KProcess, KWorkerTask>::Finalize();
 }
 
-/**
- * Attempts to find a TLS page that contains a free slot for
- * use by a thread.
- *
- * @returns If a page with an available slot is found, then an iterator
- *          pointing to the page is returned. Otherwise the end iterator
- *          is returned instead.
- */
-static auto FindTLSPageWithAvailableSlots(std::vector<TLSPage>& tls_pages) {
-    return std::find_if(tls_pages.begin(), tls_pages.end(),
-                        [](const auto& page) { return page.HasAvailableSlots(); });
-}
+ResultCode KProcess::CreateThreadLocalRegion(VAddr* out) {
+    KThreadLocalPage* tlp = nullptr;
+    VAddr tlr = 0;
 
-VAddr KProcess::CreateTLSRegion() {
-    KScopedSchedulerLock lock(kernel);
-    if (auto tls_page_iter{FindTLSPageWithAvailableSlots(tls_pages)};
-        tls_page_iter != tls_pages.cend()) {
-        return *tls_page_iter->ReserveSlot();
+    // See if we can get a region from a partially used TLP.
+    {
+        KScopedSchedulerLock sl{kernel};
+
+        if (auto it = partially_used_tlp_tree.begin(); it != partially_used_tlp_tree.end()) {
+            tlr = it->Reserve();
+            ASSERT(tlr != 0);
+
+            if (it->IsAllUsed()) {
+                tlp = std::addressof(*it);
+                partially_used_tlp_tree.erase(it);
+                fully_used_tlp_tree.insert(*tlp);
+            }
+
+            *out = tlr;
+            return ResultSuccess;
+        }
     }
 
-    Page* const tls_page_ptr{kernel.GetUserSlabHeapPages().Allocate()};
-    ASSERT(tls_page_ptr);
+    // Allocate a new page.
+    tlp = KThreadLocalPage::Allocate(kernel);
+    R_UNLESS(tlp != nullptr, ResultOutOfMemory);
+    auto tlp_guard = SCOPE_GUARD({ KThreadLocalPage::Free(kernel, tlp); });
 
-    const VAddr start{page_table->GetKernelMapRegionStart()};
-    const VAddr size{page_table->GetKernelMapRegionEnd() - start};
-    const PAddr tls_map_addr{kernel.System().DeviceMemory().GetPhysicalAddr(tls_page_ptr)};
-    const VAddr tls_page_addr{page_table
-                                  ->AllocateAndMapMemory(1, PageSize, true, start, size / PageSize,
-                                                         KMemoryState::ThreadLocal,
-                                                         KMemoryPermission::UserReadWrite,
-                                                         tls_map_addr)
-                                  .ValueOr(0)};
+    // Initialize the new page.
+    R_TRY(tlp->Initialize(kernel, this));
 
-    ASSERT(tls_page_addr);
+    // Reserve a TLR.
+    tlr = tlp->Reserve();
+    ASSERT(tlr != 0);
 
-    std::memset(tls_page_ptr, 0, PageSize);
-    tls_pages.emplace_back(tls_page_addr);
+    // Insert into our tree.
+    {
+        KScopedSchedulerLock sl{kernel};
+        if (tlp->IsAllUsed()) {
+            fully_used_tlp_tree.insert(*tlp);
+        } else {
+            partially_used_tlp_tree.insert(*tlp);
+        }
+    }
 
-    const auto reserve_result{tls_pages.back().ReserveSlot()};
-    ASSERT(reserve_result.has_value());
-
-    return *reserve_result;
+    // We succeeded!
+    tlp_guard.Cancel();
+    *out = tlr;
+    return ResultSuccess;
 }
 
-void KProcess::FreeTLSRegion(VAddr tls_address) {
-    KScopedSchedulerLock lock(kernel);
-    const VAddr aligned_address = Common::AlignDown(tls_address, Core::Memory::PAGE_SIZE);
-    auto iter =
-        std::find_if(tls_pages.begin(), tls_pages.end(), [aligned_address](const auto& page) {
-            return page.GetBaseAddress() == aligned_address;
-        });
+ResultCode KProcess::DeleteThreadLocalRegion(VAddr addr) {
+    KThreadLocalPage* page_to_free = nullptr;
 
-    // Something has gone very wrong if we're freeing a region
-    // with no actual page available.
-    ASSERT(iter != tls_pages.cend());
+    // Release the region.
+    {
+        KScopedSchedulerLock sl{kernel};
 
-    iter->ReleaseSlot(tls_address);
+        // Try to find the page in the partially used list.
+        auto it = partially_used_tlp_tree.find_key(Common::AlignDown(addr, PageSize));
+        if (it == partially_used_tlp_tree.end()) {
+            // If we don't find it, it has to be in the fully used list.
+            it = fully_used_tlp_tree.find_key(Common::AlignDown(addr, PageSize));
+            R_UNLESS(it != fully_used_tlp_tree.end(), ResultInvalidAddress);
+
+            // Release the region.
+            it->Release(addr);
+
+            // Move the page out of the fully used list.
+            KThreadLocalPage* tlp = std::addressof(*it);
+            fully_used_tlp_tree.erase(it);
+            if (tlp->IsAllFree()) {
+                page_to_free = tlp;
+            } else {
+                partially_used_tlp_tree.insert(*tlp);
+            }
+        } else {
+            // Release the region.
+            it->Release(addr);
+
+            // Handle the all-free case.
+            KThreadLocalPage* tlp = std::addressof(*it);
+            if (tlp->IsAllFree()) {
+                partially_used_tlp_tree.erase(it);
+                page_to_free = tlp;
+            }
+        }
+    }
+
+    // If we should free the page it was in, do so.
+    if (page_to_free != nullptr) {
+        page_to_free->Finalize();
+
+        KThreadLocalPage::Free(kernel, page_to_free);
+    }
+
+    return ResultSuccess;
 }
 
 void KProcess::LoadModule(CodeSet code_set, VAddr base_addr) {

--- a/src/core/hle/kernel/k_server_port.h
+++ b/src/core/hle/kernel/k_server_port.h
@@ -30,11 +30,11 @@ public:
 
     /// Whether or not this server port has an HLE handler available.
     bool HasSessionRequestHandler() const {
-        return session_handler != nullptr;
+        return !session_handler.expired();
     }
 
     /// Gets the HLE handler for this port.
-    SessionRequestHandlerPtr GetSessionRequestHandler() const {
+    SessionRequestHandlerWeakPtr GetSessionRequestHandler() const {
         return session_handler;
     }
 
@@ -42,7 +42,7 @@ public:
      * Sets the HLE handler template for the port. ServerSessions crated by connecting to this port
      * will inherit a reference to this handler.
      */
-    void SetSessionHandler(SessionRequestHandlerPtr&& handler) {
+    void SetSessionHandler(SessionRequestHandlerWeakPtr&& handler) {
         session_handler = std::move(handler);
     }
 
@@ -66,7 +66,7 @@ private:
     void CleanupSessions();
 
     SessionList session_list;
-    SessionRequestHandlerPtr session_handler;
+    SessionRequestHandlerWeakPtr session_handler;
     KPort* parent{};
 };
 

--- a/src/core/hle/kernel/k_server_session.cpp
+++ b/src/core/hle/kernel/k_server_session.cpp
@@ -98,7 +98,12 @@ ResultCode KServerSession::HandleDomainSyncRequest(Kernel::HLERequestContext& co
             UNREACHABLE();
             return ResultSuccess; // Ignore error if asserts are off
         }
-        return manager->DomainHandler(object_id - 1)->HandleSyncRequest(*this, context);
+        if (auto strong_ptr = manager->DomainHandler(object_id - 1).lock()) {
+            return strong_ptr->HandleSyncRequest(*this, context);
+        } else {
+            UNREACHABLE();
+            return ResultSuccess;
+        }
 
     case IPC::DomainMessageHeader::CommandType::CloseVirtualHandle: {
         LOG_DEBUG(IPC, "CloseVirtualHandle, object_id=0x{:08X}", object_id);

--- a/src/core/hle/kernel/k_server_session.cpp
+++ b/src/core/hle/kernel/k_server_session.cpp
@@ -27,10 +27,7 @@ namespace Kernel {
 
 KServerSession::KServerSession(KernelCore& kernel_) : KSynchronizationObject{kernel_} {}
 
-KServerSession::~KServerSession() {
-    // Ensure that the global list tracking server sessions does not hold on to a reference.
-    kernel.UnregisterServerSession(this);
-}
+KServerSession::~KServerSession() = default;
 
 void KServerSession::Initialize(KSession* parent_session_, std::string&& name_,
                                 std::shared_ptr<SessionRequestManager> manager_) {

--- a/src/core/hle/kernel/k_server_session.cpp
+++ b/src/core/hle/kernel/k_server_session.cpp
@@ -49,6 +49,9 @@ void KServerSession::Destroy() {
     parent->OnServerClosed();
 
     parent->Close();
+
+    // Release host emulation members.
+    manager.reset();
 }
 
 void KServerSession::OnClientClosed() {

--- a/src/core/hle/kernel/k_slab_heap.h
+++ b/src/core/hle/kernel/k_slab_heap.h
@@ -16,39 +16,34 @@ class KernelCore;
 
 namespace impl {
 
-class KSlabHeapImpl final {
-public:
+class KSlabHeapImpl {
     YUZU_NON_COPYABLE(KSlabHeapImpl);
     YUZU_NON_MOVEABLE(KSlabHeapImpl);
 
+public:
     struct Node {
         Node* next{};
     };
 
+public:
     constexpr KSlabHeapImpl() = default;
-    constexpr ~KSlabHeapImpl() = default;
 
-    void Initialize(std::size_t size) {
-        ASSERT(head == nullptr);
-        obj_size = size;
-    }
-
-    constexpr std::size_t GetObjectSize() const {
-        return obj_size;
+    void Initialize() {
+        ASSERT(m_head == nullptr);
     }
 
     Node* GetHead() const {
-        return head;
+        return m_head;
     }
 
     void* Allocate() {
-        Node* ret = head.load();
+        Node* ret = m_head.load();
 
         do {
             if (ret == nullptr) {
                 break;
             }
-        } while (!head.compare_exchange_weak(ret, ret->next));
+        } while (!m_head.compare_exchange_weak(ret, ret->next));
 
         return ret;
     }
@@ -56,170 +51,157 @@ public:
     void Free(void* obj) {
         Node* node = static_cast<Node*>(obj);
 
-        Node* cur_head = head.load();
+        Node* cur_head = m_head.load();
         do {
             node->next = cur_head;
-        } while (!head.compare_exchange_weak(cur_head, node));
+        } while (!m_head.compare_exchange_weak(cur_head, node));
     }
 
 private:
-    std::atomic<Node*> head{};
-    std::size_t obj_size{};
+    std::atomic<Node*> m_head{};
 };
 
 } // namespace impl
 
-class KSlabHeapBase {
-public:
+template <bool SupportDynamicExpansion>
+class KSlabHeapBase : protected impl::KSlabHeapImpl {
     YUZU_NON_COPYABLE(KSlabHeapBase);
     YUZU_NON_MOVEABLE(KSlabHeapBase);
 
+private:
+    size_t m_obj_size{};
+    uintptr_t m_peak{};
+    uintptr_t m_start{};
+    uintptr_t m_end{};
+
+private:
+    void UpdatePeakImpl(uintptr_t obj) {
+        static_assert(std::atomic_ref<uintptr_t>::is_always_lock_free);
+        std::atomic_ref<uintptr_t> peak_ref(m_peak);
+
+        const uintptr_t alloc_peak = obj + this->GetObjectSize();
+        uintptr_t cur_peak = m_peak;
+        do {
+            if (alloc_peak <= cur_peak) {
+                break;
+            }
+        } while (!peak_ref.compare_exchange_strong(cur_peak, alloc_peak));
+    }
+
+public:
     constexpr KSlabHeapBase() = default;
-    constexpr ~KSlabHeapBase() = default;
 
-    constexpr bool Contains(uintptr_t addr) const {
-        return start <= addr && addr < end;
+    bool Contains(uintptr_t address) const {
+        return m_start <= address && address < m_end;
     }
 
-    constexpr std::size_t GetSlabHeapSize() const {
-        return (end - start) / GetObjectSize();
-    }
-
-    constexpr std::size_t GetObjectSize() const {
-        return impl.GetObjectSize();
-    }
-
-    constexpr uintptr_t GetSlabHeapAddress() const {
-        return start;
-    }
-
-    std::size_t GetObjectIndexImpl(const void* obj) const {
-        return (reinterpret_cast<uintptr_t>(obj) - start) / GetObjectSize();
-    }
-
-    std::size_t GetPeakIndex() const {
-        return GetObjectIndexImpl(reinterpret_cast<const void*>(peak));
-    }
-
-    void* AllocateImpl() {
-        return impl.Allocate();
-    }
-
-    void FreeImpl(void* obj) {
-        // Don't allow freeing an object that wasn't allocated from this heap
-        ASSERT(Contains(reinterpret_cast<uintptr_t>(obj)));
-
-        impl.Free(obj);
-    }
-
-    void InitializeImpl(std::size_t obj_size, void* memory, std::size_t memory_size) {
-        // Ensure we don't initialize a slab using null memory
+    void Initialize(size_t obj_size, void* memory, size_t memory_size) {
+        // Ensure we don't initialize a slab using null memory.
         ASSERT(memory != nullptr);
 
-        // Initialize the base allocator
-        impl.Initialize(obj_size);
+        // Set our object size.
+        m_obj_size = obj_size;
 
-        // Set our tracking variables
-        const std::size_t num_obj = (memory_size / obj_size);
-        start = reinterpret_cast<uintptr_t>(memory);
-        end = start + num_obj * obj_size;
-        peak = start;
+        // Initialize the base allocator.
+        KSlabHeapImpl::Initialize();
 
-        // Free the objects
-        u8* cur = reinterpret_cast<u8*>(end);
+        // Set our tracking variables.
+        const size_t num_obj = (memory_size / obj_size);
+        m_start = reinterpret_cast<uintptr_t>(memory);
+        m_end = m_start + num_obj * obj_size;
+        m_peak = m_start;
 
-        for (std::size_t i{}; i < num_obj; i++) {
+        // Free the objects.
+        u8* cur = reinterpret_cast<u8*>(m_end);
+
+        for (size_t i = 0; i < num_obj; i++) {
             cur -= obj_size;
-            impl.Free(cur);
+            KSlabHeapImpl::Free(cur);
         }
     }
 
-private:
-    using Impl = impl::KSlabHeapImpl;
+    size_t GetSlabHeapSize() const {
+        return (m_end - m_start) / this->GetObjectSize();
+    }
 
-    Impl impl;
-    uintptr_t peak{};
-    uintptr_t start{};
-    uintptr_t end{};
+    size_t GetObjectSize() const {
+        return m_obj_size;
+    }
+
+    void* Allocate() {
+        void* obj = KSlabHeapImpl::Allocate();
+
+        return obj;
+    }
+
+    void Free(void* obj) {
+        // Don't allow freeing an object that wasn't allocated from this heap.
+        const bool contained = this->Contains(reinterpret_cast<uintptr_t>(obj));
+        ASSERT(contained);
+        KSlabHeapImpl::Free(obj);
+    }
+
+    size_t GetObjectIndex(const void* obj) const {
+        if constexpr (SupportDynamicExpansion) {
+            if (!this->Contains(reinterpret_cast<uintptr_t>(obj))) {
+                return std::numeric_limits<size_t>::max();
+            }
+        }
+
+        return (reinterpret_cast<uintptr_t>(obj) - m_start) / this->GetObjectSize();
+    }
+
+    size_t GetPeakIndex() const {
+        return this->GetObjectIndex(reinterpret_cast<const void*>(m_peak));
+    }
+
+    uintptr_t GetSlabHeapAddress() const {
+        return m_start;
+    }
+
+    size_t GetNumRemaining() const {
+        // Only calculate the number of remaining objects under debug configuration.
+        return 0;
+    }
 };
 
 template <typename T>
-class KSlabHeap final : public KSlabHeapBase {
+class KSlabHeap final : public KSlabHeapBase<false> {
+private:
+    using BaseHeap = KSlabHeapBase<false>;
+
 public:
-    enum class AllocationType {
-        Host,
-        Guest,
-    };
+    constexpr KSlabHeap() = default;
 
-    explicit constexpr KSlabHeap(AllocationType allocation_type_ = AllocationType::Host)
-        : KSlabHeapBase(), allocation_type{allocation_type_} {}
-
-    void Initialize(void* memory, std::size_t memory_size) {
-        if (allocation_type == AllocationType::Guest) {
-            InitializeImpl(sizeof(T), memory, memory_size);
-        }
+    void Initialize(void* memory, size_t memory_size) {
+        BaseHeap::Initialize(sizeof(T), memory, memory_size);
     }
 
     T* Allocate() {
-        switch (allocation_type) {
-        case AllocationType::Host:
-            // Fallback for cases where we do not yet support allocating guest memory from the slab
-            // heap, such as for kernel memory regions.
-            return new T;
+        T* obj = static_cast<T*>(BaseHeap::Allocate());
 
-        case AllocationType::Guest:
-            T* obj = static_cast<T*>(AllocateImpl());
-            if (obj != nullptr) {
-                new (obj) T();
-            }
-            return obj;
+        if (obj != nullptr) [[likely]] {
+            std::construct_at(obj);
         }
-
-        UNREACHABLE_MSG("Invalid AllocationType {}", allocation_type);
-        return nullptr;
+        return obj;
     }
 
-    T* AllocateWithKernel(KernelCore& kernel) {
-        switch (allocation_type) {
-        case AllocationType::Host:
-            // Fallback for cases where we do not yet support allocating guest memory from the slab
-            // heap, such as for kernel memory regions.
-            return new T(kernel);
+    T* Allocate(KernelCore& kernel) {
+        T* obj = static_cast<T*>(BaseHeap::Allocate());
 
-        case AllocationType::Guest:
-            T* obj = static_cast<T*>(AllocateImpl());
-            if (obj != nullptr) {
-                new (obj) T(kernel);
-            }
-            return obj;
+        if (obj != nullptr) [[likely]] {
+            std::construct_at(obj, kernel);
         }
-
-        UNREACHABLE_MSG("Invalid AllocationType {}", allocation_type);
-        return nullptr;
+        return obj;
     }
 
     void Free(T* obj) {
-        switch (allocation_type) {
-        case AllocationType::Host:
-            // Fallback for cases where we do not yet support allocating guest memory from the slab
-            // heap, such as for kernel memory regions.
-            delete obj;
-            return;
-
-        case AllocationType::Guest:
-            FreeImpl(obj);
-            return;
-        }
-
-        UNREACHABLE_MSG("Invalid AllocationType {}", allocation_type);
+        BaseHeap::Free(obj);
     }
 
-    constexpr std::size_t GetObjectIndex(const T* obj) const {
-        return GetObjectIndexImpl(obj);
+    size_t GetObjectIndex(const T* obj) const {
+        return BaseHeap::GetObjectIndex(obj);
     }
-
-private:
-    const AllocationType allocation_type;
 };
 
 } // namespace Kernel

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -210,7 +210,7 @@ ResultCode KThread::Initialize(KThreadFunction func, uintptr_t arg, VAddr user_s
     if (owner != nullptr) {
         // Setup the TLS, if needed.
         if (type == ThreadType::User) {
-            tls_address = owner->CreateTLSRegion();
+            R_TRY(owner->CreateThreadLocalRegion(std::addressof(tls_address)));
         }
 
         parent = owner;
@@ -305,7 +305,7 @@ void KThread::Finalize() {
 
     // If the thread has a local region, delete it.
     if (tls_address != 0) {
-        parent->FreeTLSRegion(tls_address);
+        ASSERT(parent->DeleteThreadLocalRegion(tls_address).IsSuccess());
     }
 
     // Release any waiters.

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -326,6 +326,9 @@ void KThread::Finalize() {
         }
     }
 
+    // Release host emulation members.
+    host_context.reset();
+
     // Perform inherited finalization.
     KSynchronizationObject::Finalize();
 }

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -656,7 +656,7 @@ private:
     static_assert(sizeof(SyncObjectBuffer::sync_objects) == sizeof(SyncObjectBuffer::handles));
 
     struct ConditionVariableComparator {
-        struct LightCompareType {
+        struct RedBlackKeyType {
             u64 cv_key{};
             s32 priority{};
 
@@ -672,8 +672,8 @@ private:
         template <typename T>
         requires(
             std::same_as<T, KThread> ||
-            std::same_as<T, LightCompareType>) static constexpr int Compare(const T& lhs,
-                                                                            const KThread& rhs) {
+            std::same_as<T, RedBlackKeyType>) static constexpr int Compare(const T& lhs,
+                                                                           const KThread& rhs) {
             const u64 l_key = lhs.GetConditionVariableKey();
             const u64 r_key = rhs.GetConditionVariableKey();
 

--- a/src/core/hle/kernel/k_thread_local_page.cpp
+++ b/src/core/hle/kernel/k_thread_local_page.cpp
@@ -1,0 +1,65 @@
+// Copyright 2022 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/scope_exit.h"
+#include "core/hle/kernel/k_memory_block.h"
+#include "core/hle/kernel/k_page_table.h"
+#include "core/hle/kernel/k_process.h"
+#include "core/hle/kernel/k_thread_local_page.h"
+#include "core/hle/kernel/kernel.h"
+
+namespace Kernel {
+
+ResultCode KThreadLocalPage::Initialize(KernelCore& kernel, KProcess* process) {
+    // Set that this process owns us.
+    m_owner = process;
+    m_kernel = &kernel;
+
+    // Allocate a new page.
+    KPageBuffer* page_buf = KPageBuffer::Allocate(kernel);
+    R_UNLESS(page_buf != nullptr, ResultOutOfMemory);
+    auto page_buf_guard = SCOPE_GUARD({ KPageBuffer::Free(kernel, page_buf); });
+
+    // Map the address in.
+    const auto phys_addr = kernel.System().DeviceMemory().GetPhysicalAddr(page_buf);
+    R_TRY(m_owner->PageTable().MapPages(std::addressof(m_virt_addr), 1, PageSize, phys_addr,
+                                        KMemoryState::ThreadLocal,
+                                        KMemoryPermission::UserReadWrite));
+
+    // We succeeded.
+    page_buf_guard.Cancel();
+
+    return ResultSuccess;
+}
+
+ResultCode KThreadLocalPage::Finalize() {
+    // Get the physical address of the page.
+    const PAddr phys_addr = m_owner->PageTable().GetPhysicalAddr(m_virt_addr);
+    ASSERT(phys_addr);
+
+    // Unmap the page.
+    R_TRY(m_owner->PageTable().UnmapPages(this->GetAddress(), 1, KMemoryState::ThreadLocal));
+
+    // Free the page.
+    KPageBuffer::Free(*m_kernel, KPageBuffer::FromPhysicalAddress(m_kernel->System(), phys_addr));
+
+    return ResultSuccess;
+}
+
+VAddr KThreadLocalPage::Reserve() {
+    for (size_t i = 0; i < m_is_region_free.size(); i++) {
+        if (m_is_region_free[i]) {
+            m_is_region_free[i] = false;
+            return this->GetRegionAddress(i);
+        }
+    }
+
+    return 0;
+}
+
+void KThreadLocalPage::Release(VAddr addr) {
+    m_is_region_free[this->GetRegionIndex(addr)] = true;
+}
+
+} // namespace Kernel

--- a/src/core/hle/kernel/k_thread_local_page.h
+++ b/src/core/hle/kernel/k_thread_local_page.h
@@ -1,0 +1,112 @@
+// Copyright 2022 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#pragma once
+
+#include <algorithm>
+#include <array>
+
+#include "common/alignment.h"
+#include "common/assert.h"
+#include "common/common_types.h"
+#include "common/intrusive_red_black_tree.h"
+#include "core/hle/kernel/k_page_buffer.h"
+#include "core/hle/kernel/memory_types.h"
+#include "core/hle/kernel/slab_helpers.h"
+#include "core/hle/result.h"
+
+namespace Kernel {
+
+class KernelCore;
+class KProcess;
+
+class KThreadLocalPage final : public Common::IntrusiveRedBlackTreeBaseNode<KThreadLocalPage>,
+                               public KSlabAllocated<KThreadLocalPage> {
+public:
+    static constexpr size_t RegionsPerPage = PageSize / Svc::ThreadLocalRegionSize;
+    static_assert(RegionsPerPage > 0);
+
+public:
+    constexpr explicit KThreadLocalPage(VAddr addr = {}) : m_virt_addr(addr) {
+        m_is_region_free.fill(true);
+    }
+
+    constexpr VAddr GetAddress() const {
+        return m_virt_addr;
+    }
+
+    ResultCode Initialize(KernelCore& kernel, KProcess* process);
+    ResultCode Finalize();
+
+    VAddr Reserve();
+    void Release(VAddr addr);
+
+    bool IsAllUsed() const {
+        return std::ranges::all_of(m_is_region_free.begin(), m_is_region_free.end(),
+                                   [](bool is_free) { return !is_free; });
+    }
+
+    bool IsAllFree() const {
+        return std::ranges::all_of(m_is_region_free.begin(), m_is_region_free.end(),
+                                   [](bool is_free) { return is_free; });
+    }
+
+    bool IsAnyUsed() const {
+        return !this->IsAllFree();
+    }
+
+    bool IsAnyFree() const {
+        return !this->IsAllUsed();
+    }
+
+public:
+    using RedBlackKeyType = VAddr;
+
+    static constexpr RedBlackKeyType GetRedBlackKey(const RedBlackKeyType& v) {
+        return v;
+    }
+    static constexpr RedBlackKeyType GetRedBlackKey(const KThreadLocalPage& v) {
+        return v.GetAddress();
+    }
+
+    template <typename T>
+    requires(std::same_as<T, KThreadLocalPage> ||
+             std::same_as<T, RedBlackKeyType>) static constexpr int Compare(const T& lhs,
+                                                                            const KThreadLocalPage&
+                                                                                rhs) {
+        const VAddr lval = GetRedBlackKey(lhs);
+        const VAddr rval = GetRedBlackKey(rhs);
+
+        if (lval < rval) {
+            return -1;
+        } else if (lval == rval) {
+            return 0;
+        } else {
+            return 1;
+        }
+    }
+
+private:
+    constexpr VAddr GetRegionAddress(size_t i) const {
+        return this->GetAddress() + i * Svc::ThreadLocalRegionSize;
+    }
+
+    constexpr bool Contains(VAddr addr) const {
+        return this->GetAddress() <= addr && addr < this->GetAddress() + PageSize;
+    }
+
+    constexpr size_t GetRegionIndex(VAddr addr) const {
+        ASSERT(Common::IsAligned(addr, Svc::ThreadLocalRegionSize));
+        ASSERT(this->Contains(addr));
+        return (addr - this->GetAddress()) / Svc::ThreadLocalRegionSize;
+    }
+
+private:
+    VAddr m_virt_addr{};
+    KProcess* m_owner{};
+    KernelCore* m_kernel{};
+    std::array<bool, RegionsPerPage> m_is_region_free{};
+};
+
+} // namespace Kernel

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -283,15 +283,16 @@ struct KernelCore::Impl {
 
     // Gets the dummy KThread for the caller, allocating a new one if this is the first time
     KThread* GetHostDummyThread() {
-        auto make_thread = [this]() {
-            KThread* thread = KThread::Create(system.Kernel());
+        auto initialize = [this](KThread* thread) {
             ASSERT(KThread::InitializeDummyThread(thread).IsSuccess());
             thread->SetName(fmt::format("DummyThread:{}", GetHostThreadId()));
             return thread;
         };
 
-        thread_local KThread* saved_thread = make_thread();
-        return saved_thread;
+        thread_local auto raw_thread = KThread(system.Kernel());
+        thread_local auto thread = initialize(&raw_thread);
+
+        return thread;
     }
 
     /// Registers a CPU core thread by allocating a host thread ID for it

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -182,8 +182,8 @@ struct KernelCore::Impl {
         {
             std::lock_guard lk(registered_objects_lock);
             if (registered_objects.size()) {
-                LOG_WARNING(Kernel, "{} kernel objects were dangling on shutdown!",
-                            registered_objects.size());
+                LOG_DEBUG(Kernel, "{} kernel objects were dangling on shutdown!",
+                          registered_objects.size());
                 registered_objects.clear();
             }
         }

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -196,14 +196,6 @@ public:
     /// Opens a port to a service previously registered with RegisterNamedService.
     KClientPort* CreateNamedServicePort(std::string name);
 
-    /// Registers a server session with the gobal emulation state, to be freed on shutdown. This is
-    /// necessary because we do not emulate processes for HLE sessions.
-    void RegisterServerSession(KServerSession* server_session);
-
-    /// Unregisters a server session previously registered with RegisterServerSession when it was
-    /// destroyed during the current emulation session.
-    void UnregisterServerSession(KServerSession* server_session);
-
     /// Registers all kernel objects with the global emulation state, this is purely for tracking
     /// leaks after emulation has been shutdown.
     void RegisterKernelObject(KAutoObject* object);

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -43,6 +43,7 @@ class KHandleTable;
 class KLinkedListNode;
 class KMemoryLayout;
 class KMemoryManager;
+class KPageBuffer;
 class KPort;
 class KProcess;
 class KResourceLimit;
@@ -52,6 +53,7 @@ class KSession;
 class KSharedMemory;
 class KSharedMemoryInfo;
 class KThread;
+class KThreadLocalPage;
 class KTransferMemory;
 class KWorkerTaskManager;
 class KWritableEvent;
@@ -239,12 +241,6 @@ public:
     /// Gets the virtual memory manager for the kernel.
     const KMemoryManager& MemoryManager() const;
 
-    /// Gets the slab heap allocated for user space pages.
-    KSlabHeap<Page>& GetUserSlabHeapPages();
-
-    /// Gets the slab heap allocated for user space pages.
-    const KSlabHeap<Page>& GetUserSlabHeapPages() const;
-
     /// Gets the shared memory object for HID services.
     Kernel::KSharedMemory& GetHidSharedMem();
 
@@ -336,6 +332,10 @@ public:
             return slab_heap_container->writeable_event;
         } else if constexpr (std::is_same_v<T, KCodeMemory>) {
             return slab_heap_container->code_memory;
+        } else if constexpr (std::is_same_v<T, KPageBuffer>) {
+            return slab_heap_container->page_buffer;
+        } else if constexpr (std::is_same_v<T, KThreadLocalPage>) {
+            return slab_heap_container->thread_local_page;
         }
     }
 
@@ -397,6 +397,8 @@ private:
         KSlabHeap<KTransferMemory> transfer_memory;
         KSlabHeap<KWritableEvent> writeable_event;
         KSlabHeap<KCodeMemory> code_memory;
+        KSlabHeap<KPageBuffer> page_buffer;
+        KSlabHeap<KThreadLocalPage> thread_local_page;
     };
 
     std::unique_ptr<SlabHeapContainer> slab_heap_container;

--- a/src/core/hle/kernel/service_thread.cpp
+++ b/src/core/hle/kernel/service_thread.cpp
@@ -49,11 +49,8 @@ ServiceThread::Impl::Impl(KernelCore& kernel, std::size_t num_threads, const std
                 return;
             }
 
+            // Allocate a dummy guest thread for this host thread.
             kernel.RegisterHostThread();
-
-            // Ensure the dummy thread allocated for this host thread is closed on exit.
-            auto* dummy_thread = kernel.GetCurrentEmuThread();
-            SCOPE_EXIT({ dummy_thread->Close(); });
 
             while (true) {
                 std::function<void()> task;

--- a/src/core/hle/kernel/slab_helpers.h
+++ b/src/core/hle/kernel/slab_helpers.h
@@ -59,7 +59,7 @@ class KAutoObjectWithSlabHeapAndContainer : public Base {
 
 private:
     static Derived* Allocate(KernelCore& kernel) {
-        return kernel.SlabHeap<Derived>().AllocateWithKernel(kernel);
+        return kernel.SlabHeap<Derived>().Allocate(kernel);
     }
 
     static void Free(KernelCore& kernel, Derived* obj) {

--- a/src/core/hle/kernel/svc_types.h
+++ b/src/core/hle/kernel/svc_types.h
@@ -96,4 +96,6 @@ constexpr inline s32 IdealCoreNoUpdate = -3;
 constexpr inline s32 LowestThreadPriority = 63;
 constexpr inline s32 HighestThreadPriority = 0;
 
+constexpr inline size_t ThreadLocalRegionSize = 0x200;
+
 } // namespace Kernel::Svc

--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -980,7 +980,7 @@ private:
         LOG_DEBUG(Service_AM, "called");
 
         IPC::RequestParser rp{ctx};
-        applet->GetBroker().PushNormalDataFromGame(rp.PopIpcInterface<IStorage>());
+        applet->GetBroker().PushNormalDataFromGame(rp.PopIpcInterface<IStorage>().lock());
 
         IPC::ResponseBuilder rb{ctx, 2};
         rb.Push(ResultSuccess);
@@ -1007,7 +1007,7 @@ private:
         LOG_DEBUG(Service_AM, "called");
 
         IPC::RequestParser rp{ctx};
-        applet->GetBroker().PushInteractiveDataFromGame(rp.PopIpcInterface<IStorage>());
+        applet->GetBroker().PushInteractiveDataFromGame(rp.PopIpcInterface<IStorage>().lock());
 
         ASSERT(applet->IsInitialized());
         applet->ExecuteInteractive();

--- a/src/core/hle/service/kernel_helpers.cpp
+++ b/src/core/hle/service/kernel_helpers.cpp
@@ -17,21 +17,12 @@ namespace Service::KernelHelpers {
 
 ServiceContext::ServiceContext(Core::System& system_, std::string name_)
     : kernel(system_.Kernel()) {
-
-    // Create a resource limit for the process.
-    const auto physical_memory_size =
-        kernel.MemoryManager().GetSize(Kernel::KMemoryManager::Pool::System);
-    auto* resource_limit = Kernel::CreateResourceLimitForProcess(system_, physical_memory_size);
-
     // Create the process.
     process = Kernel::KProcess::Create(kernel);
     ASSERT(Kernel::KProcess::Initialize(process, system_, std::move(name_),
                                         Kernel::KProcess::ProcessType::KernelInternal,
-                                        resource_limit)
+                                        kernel.GetSystemResourceLimit())
                .IsSuccess());
-
-    // Close reference to our resource limit, as the process opens one.
-    resource_limit->Close();
 }
 
 ServiceContext::~ServiceContext() {

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -81,6 +81,8 @@ ResultVal<Kernel::KPort*> ServiceManager::GetServicePort(const std::string& name
     }
 
     auto* port = Kernel::KPort::Create(kernel);
+    SCOPE_EXIT({ port->Close(); });
+
     port->Initialize(ServerSessionCountMax, false, name);
     auto handler = it->second;
     port->GetServerPort().SetSessionHandler(std::move(handler));


### PR DESCRIPTION
This is a continuation of my work to bring our kernel memory management up to speed with recent system updates and the latest known information (see previous PRs #7974, https://github.com/yuzu-emu/yuzu/pull/7956, https://github.com/yuzu-emu/yuzu/pull/7701, https://github.com/yuzu-emu/yuzu/pull/7698, and https://github.com/yuzu-emu/yuzu/pull/7684 for a history of this effort).

With this change, we:
* Migrate slab heaps for guest kernel objects from host heap memory to emulated guest memory. We now accurately track overall system limits for these. Because they are now allocated in guest memory, it is impossible for these to cause host leaks; we would simply run out of space and abort.
* With the above, we've fixed several more kernel object leaks that affected a few games, but were largely unnoticed due to the previous implementation allowing unlimited allocations.
* Rewrite thread local storage (TLS) to be accurate based on latest known HOS behavior, which was a dependency on the above.
* Refresh our implementations of BSD tree, intrusive red/black tree, etc.
* Remove various heap allocation tracking hacks, as we can know guest memory is always freed on shutdown, which kernel objects now use. 

In addition to simply being more accurate to HOS behavior, the goal of these changes is to improve memory usage and overall emulation stability.