### PR TITLE
Add shader support for const buffer indirect addressing

### DIFF
--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.cpp
@@ -464,6 +464,7 @@ EmitContext::EmitContext(const Profile& profile_, const RuntimeInfo& runtime_inf
     DefineSharedMemory(program);
     DefineSharedMemoryFunctions(program);
     DefineConstantBuffers(program.info, uniform_binding);
+    DefineConstantBufferIndirectFunctions(program.info);
     DefineStorageBuffers(program.info, storage_binding);
     DefineTextureBuffers(program.info, texture_binding);
     DefineImageBuffers(program.info, image_binding);
@@ -1025,6 +1026,69 @@ void EmitContext::DefineConstantBuffers(const Info& info, u32& binding) {
                            sizeof(u32[2]));
     }
     binding += static_cast<u32>(info.constant_buffer_descriptors.size());
+}
+
+void EmitContext::DefineConstantBufferIndirectFunctions(const Info& info) {
+    if (!info.uses_cbuf_indirect) {
+        return;
+    }
+
+    const auto make_accessor{[&](Id buffer_type, Id UniformDefinitions::*member_ptr) {
+        const Id func_type{TypeFunction(buffer_type, U32[1], U32[1])};
+        const Id func{OpFunction(buffer_type, spv::FunctionControlMask::MaskNone, func_type)};
+        const Id binding{OpFunctionParameter(U32[1])};
+        const Id offset{OpFunctionParameter(U32[1])};
+
+        AddLabel();
+
+        const Id merge_label{OpLabel()};
+        const Id uniform_type{uniform_types.*member_ptr};
+
+        std::array<Id, Info::MAX_CBUFS> buf_labels;
+        std::array<Sirit::Literal, Info::MAX_CBUFS> buf_literals;
+        for (u32 i = 0; i < Info::MAX_CBUFS; i++) {
+            buf_labels[i] = OpLabel();
+            buf_literals[i] = Sirit::Literal{i};
+        }
+
+        OpSelectionMerge(merge_label, spv::SelectionControlMask::MaskNone);
+        OpSwitch(binding, buf_labels[0], buf_literals, buf_labels);
+
+        for (u32 i = 0; i < Info::MAX_CBUFS; i++) {
+            AddLabel(buf_labels[i]);
+            const Id cbuf{cbufs[i].*member_ptr};
+            const Id access_chain{OpAccessChain(uniform_type, cbuf, u32_zero_value, offset)};
+            const Id result{OpLoad(buffer_type, access_chain)};
+            OpReturnValue(result);
+        }
+
+        AddLabel(merge_label);
+        OpUnreachable();
+        OpFunctionEnd();
+
+        return func;
+    }};
+
+    IR::Type types{info.used_constant_buffer_types};
+
+    if (True(types & IR::Type::U8)) {
+        load_const_func_u8 = make_accessor(U8, &UniformDefinitions::U8);
+    }
+    if (True(types & IR::Type::U16)) {
+        load_const_func_u16 = make_accessor(U16, &UniformDefinitions::U16);
+    }
+    if (True(types & IR::Type::F32)) {
+        load_const_func_f32 = make_accessor(F32[1], &UniformDefinitions::F32);
+    }
+    if (True(types & IR::Type::U32)) {
+        load_const_func_u32 = make_accessor(U32[1], &UniformDefinitions::U32);
+    }
+    if (True(types & IR::Type::U32x2)) {
+        load_const_func_u32x2 = make_accessor(U32[2], &UniformDefinitions::U32x2);
+    }
+    if (True(types & IR::Type::U32x4)) {
+        load_const_func_u32x4 = make_accessor(U32[4], &UniformDefinitions::U32x4);
+    }
 }
 
 void EmitContext::DefineStorageBuffers(const Info& info, u32& binding) {

--- a/src/shader_recompiler/backend/spirv/spirv_emit_context.h
+++ b/src/shader_recompiler/backend/spirv/spirv_emit_context.h
@@ -294,6 +294,13 @@ public:
 
     std::vector<Id> interfaces;
 
+    Id load_const_func_u8{};
+    Id load_const_func_u16{};
+    Id load_const_func_u32{};
+    Id load_const_func_f32{};
+    Id load_const_func_u32x2{};
+    Id load_const_func_u32x4{};
+
 private:
     void DefineCommonTypes(const Info& info);
     void DefineCommonConstants();
@@ -302,6 +309,7 @@ private:
     void DefineSharedMemory(const IR::Program& program);
     void DefineSharedMemoryFunctions(const IR::Program& program);
     void DefineConstantBuffers(const Info& info, u32& binding);
+    void DefineConstantBufferIndirectFunctions(const Info& info);
     void DefineStorageBuffers(const Info& info, u32& binding);
     void DefineTextureBuffers(const Info& info, u32& binding);
     void DefineImageBuffers(const Info& info, u32& binding);

--- a/src/shader_recompiler/frontend/maxwell/translate/impl/load_constant.cpp
+++ b/src/shader_recompiler/frontend/maxwell/translate/impl/load_constant.cpp
@@ -11,10 +11,20 @@ namespace Shader::Maxwell {
 using namespace LDC;
 namespace {
 std::pair<IR::U32, IR::U32> Slot(IR::IREmitter& ir, Mode mode, const IR::U32& imm_index,
-                                 const IR::U32& reg, const IR::U32& imm) {
+                                 const IR::U32& reg, const IR::U32& imm_offset) {
     switch (mode) {
     case Mode::Default:
-        return {imm_index, ir.IAdd(reg, imm)};
+        return {imm_index, ir.IAdd(reg, imm_offset)};
+    case Mode::IS: {
+        // Segmented addressing mode
+        // Ra+imm_offset points into a flat mapping of const buffer
+        // address space
+        const IR::U32 address{ir.IAdd(reg, imm_offset)};
+        const IR::U32 index{ir.BitFieldExtract(address, ir.Imm32(16), ir.Imm32(16))};
+        const IR::U32 offset{ir.BitFieldExtract(address, ir.Imm32(0), ir.Imm32(16))};
+
+        return {ir.IAdd(index, imm_index), offset};
+    }
     default:
         break;
     }

--- a/src/shader_recompiler/ir_opt/collect_shader_info_pass.cpp
+++ b/src/shader_recompiler/ir_opt/collect_shader_info_pass.cpp
@@ -30,6 +30,8 @@ void AddConstantBufferDescriptor(Info& info, u32 index, u32 count) {
 }
 
 void AddRegisterIndexedLdc(Info& info) {
+    info.uses_cbuf_indirect = true;
+
     // The shader can use any possible constant buffer
     info.constant_buffer_mask = (1 << Info::MAX_CBUFS) - 1;
 

--- a/src/shader_recompiler/shader_info.h
+++ b/src/shader_recompiler/shader_info.h
@@ -173,6 +173,7 @@ struct Info {
     bool uses_atomic_image_u32{};
     bool uses_shadow_lod{};
     bool uses_rescaling_uniform{};
+    bool uses_cbuf_indirect{};
 
     IR::Type used_constant_buffer_types{};
     IR::Type used_storage_buffer_types{};

--- a/src/shader_recompiler/shader_info.h
+++ b/src/shader_recompiler/shader_info.h
@@ -177,6 +177,7 @@ struct Info {
 
     IR::Type used_constant_buffer_types{};
     IR::Type used_storage_buffer_types{};
+    IR::Type used_indirect_cbuf_types{};
 
     u32 constant_buffer_mask{};
     std::array<u32, MAX_CBUFS> constant_buffer_used_sizes{};


### PR DESCRIPTION
This implements SPIR-V shader support for register-addressed const buffer accesses.

Assumptions:
- LDC can access any const buffer
- LDC can access anywhere in the buffer

The implementation idea is to create a jumptable with each possible const buffer index and use its entries to fill the load destination. In GLSL it would look like something like this:
```glsl
uniform float cb0[0x10000];
uniform float cb1[0x10000];
uniform float cb2[0x10000];
uniform float cb3[0x10000];
// ...

{
    float result;

    switch (cb_index) {
    case 0: result = cb0[cb_offset]; break;
    case 1: result = cb1[cb_offset]; break;
    case 2: result = cb2[cb_offset]; break;
    case 3: result = cb3[cb_offset]; break;
    // ...
    }
}
```
This is significantly less invasive than other potential approaches like flattening all uniform inputs.

Potentially this could create very large shaders due to the large amount of code generated by a single instruction. If code size is a concern, each access type can be split into a unique function and the functions generated separately instead of inline.

This PR also implements the LDC.IS addressing mode. This allows Mario's body to appear in Galaxy and Sunshine.
![010049900f546002_2022-03-13_22-58-31-638](https://user-images.githubusercontent.com/9658600/158622036-ea0b84d6-f889-4740-a3fb-2f50dd4d7c82.png)
![010049900f546002_2022-03-14_19-00-29-779](https://user-images.githubusercontent.com/9658600/158622064-27c84320-5ffb-4dae-bef8-f18f370aea4b.png)
