### PR TITLE
yuzu_cmd: Allow user to specify config file location

### DIFF
--- a/src/yuzu_cmd/config.cpp
+++ b/src/yuzu_cmd/config.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include <memory>
+#include <optional>
 #include <sstream>
 
 // Ignore -Wimplicit-fallthrough due to https://github.com/libsdl-org/SDL/issues/4307
@@ -29,11 +30,12 @@
 
 namespace FS = Common::FS;
 
-Config::Config() {
-    // TODO: Don't hardcode the path; let the frontend decide where to put the config files.
-    sdl2_config_loc = FS::GetYuzuPath(FS::YuzuPath::ConfigDir) / "sdl2-config.ini";
-    sdl2_config = std::make_unique<INIReader>(FS::PathToUTF8String(sdl2_config_loc));
+const std::filesystem::path default_config_path =
+    FS::GetYuzuPath(FS::YuzuPath::ConfigDir) / "sdl2-config.ini";
 
+Config::Config(std::optional<std::filesystem::path> config_path)
+    : sdl2_config_loc{config_path.value_or(default_config_path)},
+      sdl2_config{std::make_unique<INIReader>(FS::PathToUTF8String(sdl2_config_loc))} {
     Reload();
 }
 

--- a/src/yuzu_cmd/config.h
+++ b/src/yuzu_cmd/config.h
@@ -6,6 +6,7 @@
 
 #include <filesystem>
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "common/settings.h"
@@ -13,14 +14,14 @@
 class INIReader;
 
 class Config {
-    std::unique_ptr<INIReader> sdl2_config;
     std::filesystem::path sdl2_config_loc;
+    std::unique_ptr<INIReader> sdl2_config;
 
     bool LoadINI(const std::string& default_contents = "", bool retry = true);
     void ReadValues();
 
 public:
-    Config();
+    explicit Config(std::optional<std::filesystem::path> config_path);
     ~Config();
 
     void Reload();


### PR DESCRIPTION
Adds an option `-c` or `--config` with one required argument that allows the user to specify to where the config file is located. Useful for scripts that run specific games with different preferences for settings.