### PR TITLE
default_ini: List use_extended_memory_layout in default config file

### DIFF
--- a/src/yuzu_cmd/default_ini.h
+++ b/src/yuzu_cmd/default_ini.h
@@ -124,7 +124,11 @@ keyboard_enabled =
 [Core]
 # Whether to use multi-core for CPU emulation
 # 0: Disabled, 1 (default): Enabled
-use_multi_core=
+use_multi_core =
+
+# Enable extended guest system memory layout (6GB DRAM)
+# 0 (default): Disabled, 1: Enabled
+use_extended_memory_layout =
 
 [Cpu]
 # Adjusts various optimizations.


### PR DESCRIPTION
yuzu-cmd already reads the setting from 70482e6b26, this just puts the setting in the default ini.