### PR TITLE
Maxwell3D: Limit vertex arrax limit based on max index_array count [HACK].

### DIFF
--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1349,6 +1349,12 @@ public:
                         return static_cast<GPUVAddr>((static_cast<GPUVAddr>(limit_high) << 32) |
                                                      limit_low);
                     }
+
+                    void SetAddress(GPUVAddr address) {
+                        limit_low = static_cast<u32>(address);
+                        limit_high = static_cast<u32>(address >> 32);
+                    }
+
                 } vertex_array_limit[NumVertexArrays];
 
                 struct {


### PR DESCRIPTION
This here is a hack for SM3DAS to make it use only the necessary memory. A more faster solution would require analysis of the index buffer. In lieu of a proper implementation, we'll use this for the time being.

Credits to @liamwhite for finding this out.

This fixes the performance of SM3DAS.