### PR TITLE
yuzu qt: Disable the web applet by default

### DIFF
--- a/src/yuzu/configuration/config.cpp
+++ b/src/yuzu/configuration/config.cpp
@@ -775,6 +775,7 @@ void Config::ReadUIValues() {
     ReadBasicSetting(UISettings::values.pause_when_in_background);
     ReadBasicSetting(UISettings::values.mute_when_in_background);
     ReadBasicSetting(UISettings::values.hide_mouse);
+    ReadBasicSetting(UISettings::values.disable_web_applet);
 
     qt_config->endGroup();
 }
@@ -1308,6 +1309,7 @@ void Config::SaveUIValues() {
     WriteBasicSetting(UISettings::values.pause_when_in_background);
     WriteBasicSetting(UISettings::values.mute_when_in_background);
     WriteBasicSetting(UISettings::values.hide_mouse);
+    WriteBasicSetting(UISettings::values.disable_web_applet);
 
     qt_config->endGroup();
 }

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -61,7 +61,7 @@ void ConfigureDebug::SetConfiguration() {
     ui->extended_logging->setChecked(Settings::values.extended_logging.GetValue());
 
 #ifdef YUZU_USE_QT_WEB_ENGINE
-    ui->disable_web_applet->setChecked(UISettings::values.disable_web_applet);
+    ui->disable_web_applet->setChecked(UISettings::values.disable_web_applet.GetValue());
 #else
     ui->disable_web_applet->setEnabled(false);
     ui->disable_web_applet->setText(QString::fromUtf8("Web applet not compiled"));

--- a/src/yuzu/configuration/configure_debug.cpp
+++ b/src/yuzu/configuration/configure_debug.cpp
@@ -59,6 +59,13 @@ void ConfigureDebug::SetConfiguration() {
     ui->disable_loop_safety_checks->setChecked(
         Settings::values.disable_shader_loop_safety_checks.GetValue());
     ui->extended_logging->setChecked(Settings::values.extended_logging.GetValue());
+
+#ifdef YUZU_USE_QT_WEB_ENGINE
+    ui->disable_web_applet->setChecked(UISettings::values.disable_web_applet);
+#else
+    ui->disable_web_applet->setEnabled(false);
+    ui->disable_web_applet->setText(QString::fromUtf8("Web applet not compiled"));
+#endif
 }
 
 void ConfigureDebug::ApplyConfiguration() {
@@ -80,6 +87,7 @@ void ConfigureDebug::ApplyConfiguration() {
         ui->disable_loop_safety_checks->isChecked();
     Settings::values.disable_macro_jit = ui->disable_macro_jit->isChecked();
     Settings::values.extended_logging = ui->extended_logging->isChecked();
+    UISettings::values.disable_web_applet = ui->disable_web_applet->isChecked();
     Debugger::ToggleConsole();
     Common::Log::Filter filter;
     filter.ParseFilterString(Settings::values.log_filter.GetValue());

--- a/src/yuzu/configuration/configure_debug.ui
+++ b/src/yuzu/configuration/configure_debug.ui
@@ -8,49 +8,49 @@
      <property name="title">
       <string>Logging</string>
      </property>
-        <layout class="QGridLayout" name="gridLayout_1">
-         <item row="0" column="0" colspan="2">
-          <layout class="QHBoxLayout" name="horizontalLayout_1">
-          <item>
-           <widget class="QLabel" name="label_1">
-           <property name="text">
-            <string>Global Log Filter</string>
-           </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLineEdit" name="log_filter_edit"/>
-         </item>
-        </layout>
-         </item>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="toggle_console">
-           <property name="text">
-            <string>Show Log in Console</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-           <widget class="QPushButton" name="open_log_button">
-            <property name="text">
-             <string>Open Log Location</string>
-            </property>
-           </widget>
-          </item>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="extended_logging">
-          <property name="enabled">
-           <bool>true</bool>
-          </property>
-          <property name="toolTip">
-           <string>When checked, the max size of the log increases from 100 MB to 1 GB</string>
-          </property>
+     <layout class="QGridLayout" name="gridLayout_1">
+      <item row="0" column="0" colspan="2">
+       <layout class="QHBoxLayout" name="horizontalLayout_1">
+        <item>
+         <widget class="QLabel" name="label_1">
           <property name="text">
-           <string>Enable Extended Logging**</string>
+           <string>Global Log Filter</string>
           </property>
-          </widget>
-         </item>
-        </layout>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="log_filter_edit"/>
+        </item>
+       </layout>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="toggle_console">
+        <property name="text">
+         <string>Show Log in Console</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="open_log_button">
+        <property name="text">
+         <string>Open Log Location</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="extended_logging">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>When checked, the max size of the log increases from 100 MB to 1 GB</string>
+        </property>
+        <property name="text">
+         <string>Enable Extended Logging**</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
@@ -183,7 +183,7 @@
       <string>Advanced</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item> row="0" column="0">
+      <item row="0" column="0">
        <widget class="QCheckBox" name="quest_flag">
         <property name="text">
          <string>Kiosk (Quest) Mode</string>
@@ -215,6 +215,13 @@
        <widget class="QCheckBox" name="enable_all_controllers">
         <property name="text">
          <string>Enable all Controller Types</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="disable_web_applet">
+        <property name="text">
+         <string>Disable Web Applet**</string>
         </property>
        </widget>
       </item>

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -653,7 +653,8 @@ void GMainWindow::WebBrowserOpenWebPage(const std::string& main_url,
         const auto result = QMessageBox::warning(
             this, tr("Disable Web Applet"),
             tr("Disabling the web applet can lead to undefined behavior and should only be used "
-               "with Super Mario 3D All-Stars. Are you sure you want to disable the web applet?"),
+               "with Super Mario 3D All-Stars. Are you sure you want to disable the web "
+               "applet?\n(This can be re-enabled in the Debug settings.)"),
             QMessageBox::Yes | QMessageBox::No);
         if (result == QMessageBox::Yes) {
             UISettings::values.disable_web_applet = true;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -587,7 +587,7 @@ void GMainWindow::WebBrowserOpenWebPage(const std::string& main_url,
 #ifdef YUZU_USE_QT_WEB_ENGINE
 
     // Raw input breaks with the web applet, Disable web applets if enabled
-    if (disable_web_applet || Settings::values.enable_raw_input) {
+    if (UISettings::values.disable_web_applet || Settings::values.enable_raw_input) {
         emit WebBrowserClosed(Service::AM::Applets::WebExitReason::WindowClosed,
                               "http://localhost/");
         return;
@@ -657,7 +657,7 @@ void GMainWindow::WebBrowserOpenWebPage(const std::string& main_url,
                "Super Mario 3D All-Stars. Are you sure you want to disable the web applet?"),
             QMessageBox::Yes | QMessageBox::No);
         if (result == QMessageBox::Yes) {
-            disable_web_applet = true;
+            UISettings::values.disable_web_applet = true;
             web_browser_view.SetFinished(true);
         }
     });

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -652,9 +652,8 @@ void GMainWindow::WebBrowserOpenWebPage(const std::string& main_url,
     connect(exit_action, &QAction::triggered, this, [this, &web_browser_view] {
         const auto result = QMessageBox::warning(
             this, tr("Disable Web Applet"),
-            tr("Disabling the web applet will cause it to not be shown again for the rest of the "
-               "emulated session. This can lead to undefined behavior and should only be used with "
-               "Super Mario 3D All-Stars. Are you sure you want to disable the web applet?"),
+            tr("Disabling the web applet can lead to undefined behavior and should only be used "
+               "with Super Mario 3D All-Stars. Are you sure you want to disable the web applet?"),
             QMessageBox::Yes | QMessageBox::No);
         if (result == QMessageBox::Yes) {
             UISettings::values.disable_web_applet = true;

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -400,9 +400,6 @@ private:
     // Last game booted, used for multi-process apps
     QString last_filename_booted;
 
-    // Disables the web applet for the rest of the emulated session
-    bool disable_web_applet{};
-
     // Applets
     QtSoftwareKeyboardDialog* software_keyboard = nullptr;
 

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -114,6 +114,7 @@ struct Values {
 
     bool configuration_applied;
     bool reset_to_defaults;
+    bool disable_web_applet{};
 };
 
 extern Values values;

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -114,7 +114,7 @@ struct Values {
 
     bool configuration_applied;
     bool reset_to_defaults;
-    bool disable_web_applet{};
+    Settings::BasicSetting<bool> disable_web_applet{true, "disable_web_applet"};
 };
 
 extern Values values;


### PR DESCRIPTION
The web applet causes issues with the rest of the application. See #5973, #5044, and #5043. Additionally, crashes are reported, but I didn't find any documentation to link here.

Make the option save with the application, disable it by default, and add a debug option to re-enable it until a proper solution can be found.