### PR TITLE
vk_texture_cache: Do not reinterpret DepthStencil source images

### DIFF
--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -781,11 +781,6 @@ bool TextureCacheRuntime::ShouldReinterpret(Image& dst, Image& src) {
         !device.IsExtShaderStencilExportSupported()) {
         return true;
     }
-    if (VideoCore::Surface::GetFormatType(src.info.format) ==
-            VideoCore::Surface::SurfaceType::DepthStencil &&
-        !device.IsExtShaderStencilExportSupported()) {
-        return true;
-    }
     if (dst.info.format == PixelFormat::D32_FLOAT_S8_UINT ||
         src.info.format == PixelFormat::D32_FLOAT_S8_UINT) {
         return true;


### PR DESCRIPTION
Fixes star pointer interactions in `Super Mario Galaxy` on some drivers, notably Nvidia.