### PR TITLE
shader_recompiler/EXIT: increment output register on failed enable test

### DIFF
--- a/src/shader_recompiler/frontend/maxwell/translate/impl/exit_program.cpp
+++ b/src/shader_recompiler/frontend/maxwell/translate/impl/exit_program.cpp
@@ -15,6 +15,7 @@ void ExitFragment(TranslatorVisitor& v) {
         const std::array<bool, 4> mask{sph.ps.EnabledOutputComponents(render_target)};
         for (u32 component = 0; component < 4; ++component) {
             if (!mask[component]) {
+                ++src_reg;
                 continue;
             }
             v.ir.SetFragColor(render_target, component, v.F(src_reg));


### PR DESCRIPTION
This fixes a miscompilation when
- a register is written to as a fragment output
- not all channels of the output are enabled

The source shader
```
    .headerflags    @"EF_CUDA_SM53 EF_CUDA_PTX_SM(EF_CUDA_SM53)"
        /*0008*/                   IMNMX R0, RZ, c[0x2][0x1c], !PT ;
        /*0010*/                   IMNMX R0, R0, 0xff, PT ;
        /*0018*/                   LOP32I.AND R0, R0, 0xfc ;
        /*0028*/                   SHR.U32 R0, R0, 0x2 ;
        /*0030*/                   I2F.F32.S32 R0, R0 ;
        /*0038*/         {         FMUL32I.FTZ R3, R0, 0.015873016789555549622 ;
        /*0048*/                   EXIT         }
        /*0050*/                   BRA 0x50 ;
```
originally generates this IR after passes, which is incorrect as the multiplication is dropped.
```
[0000000002635248]          Prologue
[00000000026347f8] %3     = GetCbufU32 #3, #232 (uses: 1)
[00000000026348e8] %4     = Identity %3 (uses: 1)
[0000000002634960] %5     = ShiftRightArithmetic32 %4, #2 (uses: 1)
[0000000002634a50] %6     = Identity #true (uses: 1)
[0000000002634b40] %7     = Identity %5 (uses: 1)
[0000000002634c30] %8     = Identity %7 (uses: 1)
[0000000002634ca8] %9     = ConvertF32U32 %8 (uses: 1)
[00000000026350e0] %10    = Identity %9 (uses: 1)
[0000000002635158]          SetFragColor #0, #3, %10
```
The IR generated after this change is:
```
[000000000261dbe8]          Prologue
[000000000261d198] %3     = GetCbufU32 #3, #232 (uses: 1)
[000000000261d288] %4     = Identity %3 (uses: 1)
[000000000261d300] %5     = ShiftRightArithmetic32 %4, #2 (uses: 1)
[000000000261d3f0] %6     = Identity #true (uses: 1)
[000000000261d4e0] %7     = Identity %5 (uses: 1)
[000000000261d5d0] %8     = Identity %7 (uses: 1)
[000000000261d648] %9     = ConvertF32U32 %8 (uses: 1)
[000000000261d828] %10    = Identity %9 (uses: 1)
[000000000261d8a0] %11    = FPMul32 %10, #0.015873017 (uses: 1)
[000000000261da80] %12    = Identity %11 (uses: 1)
[000000000261daf8]          SetFragColor #0, #3, %12
```
This fixes the black sphere and the ground shadow in Sunshine.
![010049900f546002_2022-03-17_20-54-33-025](https://user-images.githubusercontent.com/9658600/158924490-6cc6913d-26f5-470b-9d00-353c973f64b4.png)
![010049900f546002_2022-03-17_22-06-18-545](https://user-images.githubusercontent.com/9658600/158924496-3320439a-3d96-42b5-a541-405bbe13d708.png)
