### PR TITLE
general: Reduce core.h includes

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -209,6 +209,7 @@ add_library(core STATIC
     hle/kernel/k_memory_region.h
     hle/kernel/k_memory_region_type.h
     hle/kernel/k_page_bitmap.h
+    hle/kernel/k_page_buffer.cpp
     hle/kernel/k_page_buffer.h
     hle/kernel/k_page_heap.cpp
     hle/kernel/k_page_heap.h

--- a/src/core/hle/kernel/k_page_buffer.cpp
+++ b/src/core/hle/kernel/k_page_buffer.cpp
@@ -1,0 +1,19 @@
+// Copyright 2022 yuzu Emulator Project
+// Licensed under GPLv2 or any later version
+// Refer to the license.txt file included.
+
+#include "common/alignment.h"
+#include "common/assert.h"
+#include "core/core.h"
+#include "core/device_memory.h"
+#include "core/hle/kernel/k_page_buffer.h"
+#include "core/hle/kernel/memory_types.h"
+
+namespace Kernel {
+
+KPageBuffer* KPageBuffer::FromPhysicalAddress(Core::System& system, PAddr phys_addr) {
+    ASSERT(Common::IsAligned(phys_addr, PageSize));
+    return reinterpret_cast<KPageBuffer*>(system.DeviceMemory().GetPointer(phys_addr));
+}
+
+} // namespace Kernel

--- a/src/core/hle/kernel/k_page_buffer.h
+++ b/src/core/hle/kernel/k_page_buffer.h
@@ -6,12 +6,10 @@
 
 #include <array>
 
-#include "common/alignment.h"
-#include "common/assert.h"
 #include "common/common_types.h"
-#include "core/core.h"
 #include "core/device_memory.h"
 #include "core/hle/kernel/memory_types.h"
+#include "core/hle/kernel/slab_helpers.h"
 
 namespace Kernel {
 
@@ -19,10 +17,7 @@ class KPageBuffer final : public KSlabAllocated<KPageBuffer> {
 public:
     KPageBuffer() = default;
 
-    static KPageBuffer* FromPhysicalAddress(Core::System& system, PAddr phys_addr) {
-        ASSERT(Common::IsAligned(phys_addr, PageSize));
-        return reinterpret_cast<KPageBuffer*>(system.DeviceMemory().GetPointer(phys_addr));
-    }
+    static KPageBuffer* FromPhysicalAddress(Core::System& system, PAddr phys_addr);
 
 private:
     [[maybe_unused]] alignas(PageSize) std::array<u8, PageSize> m_buffer{};

--- a/src/core/hle/kernel/k_thread_local_page.cpp
+++ b/src/core/hle/kernel/k_thread_local_page.cpp
@@ -3,6 +3,7 @@
 // Refer to the license.txt file included.
 
 #include "common/scope_exit.h"
+#include "core/core.h"
 #include "core/hle/kernel/k_memory_block.h"
 #include "core/hle/kernel/k_page_table.h"
 #include "core/hle/kernel/k_process.h"

--- a/src/video_core/fence_manager.h
+++ b/src/video_core/fence_manager.h
@@ -8,8 +8,6 @@
 #include <queue>
 
 #include "common/common_types.h"
-#include "common/settings.h"
-#include "core/core.h"
 #include "video_core/delayed_destruction_ring.h"
 #include "video_core/gpu.h"
 #include "video_core/memory_manager.h"

--- a/src/video_core/query_cache.h
+++ b/src/video_core/query_cache.h
@@ -18,7 +18,6 @@
 
 #include "common/assert.h"
 #include "common/settings.h"
-#include "core/core.h"
 #include "video_core/engines/maxwell_3d.h"
 #include "video_core/gpu.h"
 #include "video_core/memory_manager.h"

--- a/src/video_core/renderer_opengl/gl_state_tracker.h
+++ b/src/video_core/renderer_opengl/gl_state_tracker.h
@@ -9,7 +9,6 @@
 #include <glad/glad.h>
 
 #include "common/common_types.h"
-#include "core/core.h"
 #include "video_core/dirty_flags.h"
 #include "video_core/engines/maxwell_3d.h"
 

--- a/src/video_core/renderer_vulkan/vk_state_tracker.h
+++ b/src/video_core/renderer_vulkan/vk_state_tracker.h
@@ -8,7 +8,6 @@
 #include <limits>
 
 #include "common/common_types.h"
-#include "core/core.h"
 #include "video_core/dirty_flags.h"
 #include "video_core/engines/maxwell_3d.h"
 


### PR DESCRIPTION
This reduces the dependency on `core.h` in some common header files to reduce some compile time churn.