### PR TITLE
Maxwell3D: Use vertex array limit calculator instead of estimate.

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -322,7 +322,7 @@ struct Memory::Impl {
         }
 
         if (Settings::IsFastmemEnabled()) {
-            const bool is_read_enable = Settings::IsGPULevelHigh() || !cached;
+            const bool is_read_enable = !Settings::IsGPULevelExtreme() || !cached;
             system.DeviceMemory().buffer.Protect(vaddr, size, is_read_enable, !cached);
         }
 

--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -30,6 +30,7 @@ Maxwell3D::Maxwell3D(Core::System& system_, MemoryManager& memory_manager_)
       upload_state{memory_manager, regs.upload} {
     dirty.flags.flip();
     InitializeRegisterDefaults();
+    accelerated_reads = Settings::IsFastmemEnabled();
 }
 
 Maxwell3D::~Maxwell3D() = default;
@@ -696,7 +697,7 @@ void Maxwell3D::RecalculateVertexArrayLimit() {
 
     auto maybe_ptr = memory_manager.GpuToHostPointer(start_address + offset);
     u8* ptr;
-    if (maybe_ptr) {
+    if (accelerated_reads && maybe_ptr) {
         ptr = *maybe_ptr;
     } else {
         vn_state.index_buffer_cache.resize(Common::DivideUp(expected_size, sizeof(u32)));

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1349,6 +1349,12 @@ public:
                         return static_cast<GPUVAddr>((static_cast<GPUVAddr>(limit_high) << 32) |
                                                      limit_low);
                     }
+
+                    void SetAddress(GPUVAddr address) {
+                        limit_low = static_cast<u32>(address);
+                        limit_high = static_cast<u32>(address >> 32);
+                    }
+
                 } vertex_array_limit[NumVertexArrays];
 
                 struct {
@@ -1492,6 +1498,14 @@ public:
         Tables tables{};
     } dirty;
 
+    struct VertexNumApproxState {
+        GPUVAddr last_index_array_start;
+        u32 current_max_index;
+        u32 current_min_index;
+        u32 current_num_vertices;
+        std::vector<u32> index_buffer_cache;
+    } vertex_num_approx_state;
+
 private:
     void InitializeRegisterDefaults();
 
@@ -1559,6 +1573,8 @@ private:
 
     // Handles a instance drawcall from MME
     void StepInstance(MMEDrawMode expected_mode, u32 count);
+
+    void RecalculateVertexArrayLimit();
 
     /// Returns a query's value or an empty object if the value will be deferred through a cache.
     std::optional<u64> GetQueryResult();

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -1506,6 +1506,8 @@ public:
         std::vector<u32> index_buffer_cache;
     } vertex_num_approx_state;
 
+    bool accelerated_reads{};
+
 private:
     void InitializeRegisterDefaults();
 

--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -6,6 +6,7 @@
 
 #include "common/alignment.h"
 #include "common/assert.h"
+#include "common/host_memory.h"
 #include "common/logging/log.h"
 #include "core/core.h"
 #include "core/hle/kernel/k_page_table.h"
@@ -184,6 +185,19 @@ std::optional<VAddr> MemoryManager::GpuToCpuAddress(GPUVAddr gpu_addr) const {
     }
 
     return page_entry.ToAddress() + (gpu_addr & page_mask);
+}
+
+std::optional<u8*> MemoryManager::GpuToHostPointer(GPUVAddr gpu_addr) const {
+    auto cpu_addr = GpuToCpuAddress(gpu_addr);
+    if (!cpu_addr) {
+        return std::nullopt;
+    }
+    auto& device_memory = system.DeviceMemory();
+    auto base = device_memory.buffer.VirtualBasePointer();
+    if (!base) {
+        return std::nullopt;
+    }
+    return base + *cpu_addr;
 }
 
 std::optional<VAddr> MemoryManager::GpuToCpuAddress(GPUVAddr addr, std::size_t size) const {

--- a/src/video_core/memory_manager.h
+++ b/src/video_core/memory_manager.h
@@ -76,6 +76,8 @@ public:
 
     [[nodiscard]] std::optional<VAddr> GpuToCpuAddress(GPUVAddr addr) const;
 
+    [[nodiscard]] std::optional<u8*> GpuToHostPointer(GPUVAddr addr) const;
+
     [[nodiscard]] std::optional<VAddr> GpuToCpuAddress(GPUVAddr addr, std::size_t size) const;
 
     template <typename T>


### PR DESCRIPTION
This is a proper implementation of a vertex array size calculator instead of using an approximation. Therefore, it's mostly accurate (except flushing). This accelerates SM3DAS without hacking at an small cost. Currently we only do it on "small indices" as it may be more expensive on other 

TODO: figure what's wrong in linux and fastmem.

Replaces: https://github.com/yuzu-emu/yuzu/pull/8033