### PR TITLE
codec: Fix GPU decoder detection on Windows and a memory leak

### DIFF
--- a/src/video_core/command_classes/codecs/codec.cpp
+++ b/src/video_core/command_classes/codecs/codec.cpp
@@ -98,6 +98,8 @@ bool Codec::CreateGpuAvDevice() {
             LOG_DEBUG(Service_NVDRV, "{} explicitly unsupported", av_hwdevice_get_type_name(type));
             continue;
         }
+        // Avoid memory leak from not cleaning up after av_hwdevice_ctx_create
+        av_buffer_unref(&av_gpu_decoder);
         const int hwdevice_res = av_hwdevice_ctx_create(&av_gpu_decoder, type, nullptr, nullptr, 0);
         if (hwdevice_res < 0) {
             LOG_DEBUG(Service_NVDRV, "{} av_hwdevice_ctx_create failed {}",


### PR DESCRIPTION
It was reported that decoders with the `HW_FRAMES_CTX` config  method causes crashes on certain Linux decoding backends, hence the check to avoid it. This check subsequently caused Windows GPU decoders to never be selected and always fall back to CPU decoding. 

This PR disables `HW_FRAMES_CTX` config check on Windows for now.

This PR also addresses a memory leak relating to the allocation of GPU decoder contexts for the desired decoders which was not being freed.