### PR TITLE
buffer_cache: reset cached write bits after flushing invalidations

### DIFF
--- a/src/video_core/buffer_cache/buffer_base.h
+++ b/src/video_core/buffer_cache/buffer_base.h
@@ -212,7 +212,7 @@ public:
     void FlushCachedWrites() noexcept {
         flags &= ~BufferFlagBits::CachedWrites;
         const u64 num_words = NumWords();
-        const u64* const cached_words = Array<Type::CachedCPU>();
+        u64* const cached_words = Array<Type::CachedCPU>();
         u64* const untracked_words = Array<Type::Untracked>();
         u64* const cpu_words = Array<Type::CPU>();
         for (u64 word_index = 0; word_index < num_words; ++word_index) {
@@ -220,6 +220,7 @@ public:
             NotifyRasterizer<false>(word_index, untracked_words[word_index], cached_bits);
             untracked_words[word_index] |= cached_bits;
             cpu_words[word_index] |= cached_bits;
+            cached_words[word_index] = 0;
         }
     }
 


### PR DESCRIPTION
This fixes a bug in the original implementation.

An access pattern in the guest game like the following:
```c
const size_t ALLOC_SIZE = 10'485'760
void *mapping = AllocateGPUMemory(ALLOC_SIZE);
memset(mapping, 0, ALLOC_SIZE)
```
would result in every single page in the buffer being marked as having a cached write. For small buffers, this likely never manifested as an issue as it doesn't create much extra memory traffic, but for large buffers this is a problem as it results in enormous buffer copies, experimentally resulting in hundreds of megabytes of data transfers per frame.

This also improves the performance of Galaxy without any hacks; the game should be virtually issue-free now.
Supercedes #8055 and #8033.