### PR TITLE
Vulkan: Use 3D helpers for MSAA scaling on NV drivers 510+

### DIFF
--- a/src/video_core/renderer_vulkan/blit_image.cpp
+++ b/src/video_core/renderer_vulkan/blit_image.cpp
@@ -367,17 +367,14 @@ BlitImageHelper::BlitImageHelper(const Device& device_, VKScheduler& scheduler_,
           PipelineLayoutCreateInfo(two_textures_set_layout.address()))),
       full_screen_vert(BuildShader(device, FULL_SCREEN_TRIANGLE_VERT_SPV)),
       blit_color_to_color_frag(BuildShader(device, VULKAN_BLIT_COLOR_FLOAT_FRAG_SPV)),
+      blit_depth_stencil_frag(BuildShader(device, VULKAN_BLIT_DEPTH_STENCIL_FRAG_SPV)),
       convert_depth_to_float_frag(BuildShader(device, CONVERT_DEPTH_TO_FLOAT_FRAG_SPV)),
       convert_float_to_depth_frag(BuildShader(device, CONVERT_FLOAT_TO_DEPTH_FRAG_SPV)),
       convert_abgr8_to_d24s8_frag(BuildShader(device, CONVERT_ABGR8_TO_D24S8_FRAG_SPV)),
       convert_d24s8_to_abgr8_frag(BuildShader(device, CONVERT_D24S8_TO_ABGR8_FRAG_SPV)),
       convert_s8d24_to_abgr8_frag(BuildShader(device, CONVERT_S8D24_TO_ABGR8_FRAG_SPV)),
       linear_sampler(device.GetLogical().CreateSampler(SAMPLER_CREATE_INFO<VK_FILTER_LINEAR>)),
-      nearest_sampler(device.GetLogical().CreateSampler(SAMPLER_CREATE_INFO<VK_FILTER_NEAREST>)) {
-    if (device.IsExtShaderStencilExportSupported()) {
-        blit_depth_stencil_frag = BuildShader(device, VULKAN_BLIT_DEPTH_STENCIL_FRAG_SPV);
-    }
-}
+      nearest_sampler(device.GetLogical().CreateSampler(SAMPLER_CREATE_INFO<VK_FILTER_NEAREST>)) {}
 
 BlitImageHelper::~BlitImageHelper() = default;
 

--- a/src/video_core/renderer_vulkan/vk_texture_cache.cpp
+++ b/src/video_core/renderer_vulkan/vk_texture_cache.cpp
@@ -1442,8 +1442,7 @@ bool Image::BlitScaleHelper(bool scale_up) {
 
         runtime->blit_image_helper.BlitColor(blit_framebuffer.get(), color_view, dst_region,
                                              src_region, operation, BLIT_OPERATION);
-    } else if (!runtime->device.IsBlitDepthStencilSupported() &&
-               aspect_mask == (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) {
+    } else if (aspect_mask == (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) {
         if (!blit_framebuffer) {
             blit_framebuffer = std::make_unique<Framebuffer>(*runtime, nullptr, view_ptr, extent);
         }

--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -614,6 +614,11 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
             khr_push_descriptor = false;
             break;
         }
+        const u32 nv_major_version = (properties.driverVersion >> 22) & 0x3ff;
+        if (nv_major_version >= 510) {
+            LOG_WARNING(Render_Vulkan, "NVIDIA Drivers >= 510 do not support MSAA image blits");
+            cant_blit_msaa = true;
+        }
     }
     const bool is_radv = driver_id == VK_DRIVER_ID_MESA_RADV;
     if (ext_extended_dynamic_state && is_radv) {


### PR DESCRIPTION
NVIDIA Vulkan drivers 510+ crash when blitting MSAA images. Fall-back to 3D scale helpers for MSAA image scaling on these drivers.

Fixes crashes when scaling was enabled on titles such as `Monster Hunter Rise`, `Rune Factory 5`, `Sonic Colors Ultimate`, among others.