### PR TITLE
Memory GPU <-> CPU: reduce infighting in the texture cache by adding CPU Cached memory.

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -322,7 +322,7 @@ struct Memory::Impl {
         }
 
         if (Settings::IsFastmemEnabled()) {
-            const bool is_read_enable = Settings::IsGPULevelHigh() || !cached;
+            const bool is_read_enable = !Settings::IsGPULevelExtreme() || !cached;
             system.DeviceMemory().buffer.Protect(vaddr, size, is_read_enable, !cached);
         }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -352,7 +352,7 @@ void RasterizerOpenGL::OnCPUWrite(VAddr addr, u64 size) {
     shader_cache.OnCPUWrite(addr, size);
     {
         std::scoped_lock lock{texture_cache.mutex};
-        texture_cache.WriteMemory(addr, size);
+        texture_cache.CachedWriteMemory(addr, size);
     }
     {
         std::scoped_lock lock{buffer_cache.mutex};
@@ -363,6 +363,10 @@ void RasterizerOpenGL::OnCPUWrite(VAddr addr, u64 size) {
 void RasterizerOpenGL::SyncGuestHost() {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
     shader_cache.SyncGuestHost();
+    {
+        std::scoped_lock lock{texture_cache.mutex};
+        texture_cache.FlushCachedWrites();
+    }
     {
         std::scoped_lock lock{buffer_cache.mutex};
         buffer_cache.FlushCachedWrites();

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -408,7 +408,7 @@ void RasterizerVulkan::OnCPUWrite(VAddr addr, u64 size) {
     pipeline_cache.OnCPUWrite(addr, size);
     {
         std::scoped_lock lock{texture_cache.mutex};
-        texture_cache.WriteMemory(addr, size);
+        texture_cache.CachedWriteMemory(addr, size);
     }
     {
         std::scoped_lock lock{buffer_cache.mutex};
@@ -418,6 +418,10 @@ void RasterizerVulkan::OnCPUWrite(VAddr addr, u64 size) {
 
 void RasterizerVulkan::SyncGuestHost() {
     pipeline_cache.SyncGuestHost();
+    {
+        std::scoped_lock lock{texture_cache.mutex};
+        texture_cache.FlushCachedWrites();
+    }
     {
         std::scoped_lock lock{buffer_cache.mutex};
         buffer_cache.FlushCachedWrites();

--- a/src/video_core/texture_cache/image_base.h
+++ b/src/video_core/texture_cache/image_base.h
@@ -39,6 +39,9 @@ enum class ImageFlagBits : u32 {
     Rescaled = 1 << 13,
     CheckingRescalable = 1 << 14,
     IsRescalable = 1 << 15,
+
+    // Cached CPU
+    CachedCpuModified = 1 << 16, ///< Contents have been modified from the CPU
 };
 DECLARE_ENUM_FLAG_OPERATORS(ImageFlagBits)
 

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -438,6 +438,23 @@ void TextureCache<P>::WriteMemory(VAddr cpu_addr, size_t size) {
 }
 
 template <class P>
+void TextureCache<P>::CachedWriteMemory(VAddr cpu_addr, size_t size) {
+    const VAddr new_cpu_addr = Common::AlignDown(cpu_addr, CPU_PAGE_SIZE);
+    const size_t new_size = Common::AlignUp(size + cpu_addr - new_cpu_addr, CPU_PAGE_SIZE);
+    ForEachImageInRegion(new_cpu_addr, new_size, [this](ImageId image_id, Image& image) {
+        if (True(image.flags & ImageFlagBits::CachedCpuModified)) {
+            return;
+        }
+        image.flags |= ImageFlagBits::CachedCpuModified;
+        cached_cpu_invalidate.insert(image_id);
+
+        if (True(image.flags & ImageFlagBits::Tracked)) {
+            UntrackImage(image, image_id);
+        }
+    });
+}
+
+template <class P>
 void TextureCache<P>::DownloadMemory(VAddr cpu_addr, size_t size) {
     std::vector<ImageId> images;
     ForEachImageInRegion(cpu_addr, size, [this, &images](ImageId image_id, ImageBase& image) {
@@ -492,6 +509,18 @@ void TextureCache<P>::UnmapGPUMemory(GPUVAddr gpu_addr, size_t size) {
             UntrackImage(image, id);
         }
     }
+}
+
+template <class P>
+void TextureCache<P>::FlushCachedWrites() {
+    for (ImageId image_id : cached_cpu_invalidate) {
+        Image& image = slot_images[image_id];
+        if (True(image.flags & ImageFlagBits::CachedCpuModified)) {
+            image.flags &= ~ImageFlagBits::CachedCpuModified;
+            image.flags |= ImageFlagBits::CpuModified;
+        }
+    }
+    cached_cpu_invalidate.clear();
 }
 
 template <class P>
@@ -1560,6 +1589,9 @@ void TextureCache<P>::UnregisterImage(ImageId image_id) {
 template <class P>
 void TextureCache<P>::TrackImage(ImageBase& image, ImageId image_id) {
     ASSERT(False(image.flags & ImageFlagBits::Tracked));
+    if (True(image.flags & ImageFlagBits::CachedCpuModified)) {
+        return;
+    }
     image.flags |= ImageFlagBits::Tracked;
     if (False(image.flags & ImageFlagBits::Sparse)) {
         rasterizer.UpdatePagesCachedCount(image.cpu_addr, image.guest_size_bytes, 1);
@@ -1616,6 +1648,9 @@ void TextureCache<P>::DeleteImage(ImageId image_id, bool immediate_delete) {
         tentative_size = EstimatedDecompressedSize(tentative_size, image.info.format);
     }
     total_used_memory -= Common::AlignUp(tentative_size, 1024);
+    if (True(image.flags & ImageFlagBits::CachedCpuModified)) {
+        cached_cpu_invalidate.erase(image_id);
+    }
     const GPUVAddr gpu_addr = image.gpu_addr;
     const auto alloc_it = image_allocs_table.find(gpu_addr);
     if (alloc_it == image_allocs_table.end()) {
@@ -1782,7 +1817,11 @@ template <class P>
 void TextureCache<P>::PrepareImage(ImageId image_id, bool is_modification, bool invalidate) {
     Image& image = slot_images[image_id];
     if (invalidate) {
-        image.flags &= ~(ImageFlagBits::CpuModified | ImageFlagBits::GpuModified);
+        if (True(image.flags & ImageFlagBits::CachedCpuModified)) {
+            cached_cpu_invalidate.erase(image_id);
+        }
+        image.flags &= ~(ImageFlagBits::CpuModified | ImageFlagBits::GpuModified |
+                         ImageFlagBits::CachedCpuModified);
         if (False(image.flags & ImageFlagBits::Tracked)) {
             TrackImage(image, image_id);
         }


### PR DESCRIPTION
Additionally, make sure to not protect read memory on Normal / High accuracy (it was High only before)