### PR TITLE
configuration: Add Paranoid CPU accuracy level

### DIFF
--- a/src/common/settings.h
+++ b/src/common/settings.h
@@ -38,6 +38,7 @@ enum class CPUAccuracy : u32 {
     Auto = 0,
     Accurate = 1,
     Unsafe = 2,
+    Paranoid = 3,
 };
 
 enum class FullscreenMode : u32 {
@@ -470,7 +471,7 @@ struct Values {
 
     // Cpu
     RangedSetting<CPUAccuracy> cpu_accuracy{CPUAccuracy::Auto, CPUAccuracy::Auto,
-                                            CPUAccuracy::Unsafe, "cpu_accuracy"};
+                                            CPUAccuracy::Paranoid, "cpu_accuracy"};
     // TODO: remove cpu_accuracy_first_time, migration setting added 8 July 2021
     BasicSetting<bool> cpu_accuracy_first_time{true, "cpu_accuracy_first_time"};
     BasicSetting<bool> cpu_debug_mode{false, "cpu_debug_mode"};

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -186,35 +186,41 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
         if (!Settings::values.cpuopt_recompile_exclusives) {
             config.recompile_on_exclusive_fastmem_failure = false;
         }
-    }
+    } else {
+        // Unsafe optimizations
+        if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Unsafe) {
+            config.unsafe_optimizations = true;
+            if (Settings::values.cpuopt_unsafe_unfuse_fma) {
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
+            }
+            if (Settings::values.cpuopt_unsafe_reduce_fp_error) {
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_ReducedErrorFP;
+            }
+            if (Settings::values.cpuopt_unsafe_ignore_standard_fpcr) {
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreStandardFPCRValue;
+            }
+            if (Settings::values.cpuopt_unsafe_inaccurate_nan) {
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
+            }
+            if (Settings::values.cpuopt_unsafe_ignore_global_monitor) {
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreGlobalMonitor;
+            }
+        }
 
-    // Unsafe optimizations
-    if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Unsafe) {
-        config.unsafe_optimizations = true;
-        if (Settings::values.cpuopt_unsafe_unfuse_fma) {
+        // Curated optimizations
+        if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Auto) {
+            config.unsafe_optimizations = true;
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
-        }
-        if (Settings::values.cpuopt_unsafe_reduce_fp_error) {
-            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_ReducedErrorFP;
-        }
-        if (Settings::values.cpuopt_unsafe_ignore_standard_fpcr) {
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreStandardFPCRValue;
-        }
-        if (Settings::values.cpuopt_unsafe_inaccurate_nan) {
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
-        }
-        if (Settings::values.cpuopt_unsafe_ignore_global_monitor) {
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreGlobalMonitor;
         }
-    }
 
-    // Curated optimizations
-    if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Auto) {
-        config.unsafe_optimizations = true;
-        config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
-        config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreStandardFPCRValue;
-        config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
-        config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreGlobalMonitor;
+        // Paranoia mode for debugging optimizations
+        if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Paranoid) {
+            config.unsafe_optimizations = false;
+            config.optimizations = Dynarmic::no_optimizations;
+        }
     }
 
     return std::make_unique<Dynarmic::A32::Jit>(config);

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -246,35 +246,41 @@ std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* 
         if (!Settings::values.cpuopt_recompile_exclusives) {
             config.recompile_on_exclusive_fastmem_failure = false;
         }
-    }
+    } else {
+        // Unsafe optimizations
+        if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Unsafe) {
+            config.unsafe_optimizations = true;
+            if (Settings::values.cpuopt_unsafe_unfuse_fma) {
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
+            }
+            if (Settings::values.cpuopt_unsafe_reduce_fp_error) {
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_ReducedErrorFP;
+            }
+            if (Settings::values.cpuopt_unsafe_inaccurate_nan) {
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
+            }
+            if (Settings::values.cpuopt_unsafe_fastmem_check) {
+                config.fastmem_address_space_bits = 64;
+            }
+            if (Settings::values.cpuopt_unsafe_ignore_global_monitor) {
+                config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreGlobalMonitor;
+            }
+        }
 
-    // Unsafe optimizations
-    if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Unsafe) {
-        config.unsafe_optimizations = true;
-        if (Settings::values.cpuopt_unsafe_unfuse_fma) {
+        // Curated optimizations
+        if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Auto) {
+            config.unsafe_optimizations = true;
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
-        }
-        if (Settings::values.cpuopt_unsafe_reduce_fp_error) {
-            config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_ReducedErrorFP;
-        }
-        if (Settings::values.cpuopt_unsafe_inaccurate_nan) {
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
-        }
-        if (Settings::values.cpuopt_unsafe_fastmem_check) {
             config.fastmem_address_space_bits = 64;
-        }
-        if (Settings::values.cpuopt_unsafe_ignore_global_monitor) {
             config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreGlobalMonitor;
         }
-    }
 
-    // Curated optimizations
-    if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Auto) {
-        config.unsafe_optimizations = true;
-        config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_UnfuseFMA;
-        config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_InaccurateNaN;
-        config.fastmem_address_space_bits = 64;
-        config.optimizations |= Dynarmic::OptimizationFlag::Unsafe_IgnoreGlobalMonitor;
+        // Paranoia mode for debugging optimizations
+        if (Settings::values.cpu_accuracy.GetValue() == Settings::CPUAccuracy::Paranoid) {
+            config.unsafe_optimizations = false;
+            config.optimizations = Dynarmic::no_optimizations;
+        }
     }
 
     return std::make_shared<Dynarmic::A64::Jit>(config);

--- a/src/yuzu/configuration/configure_cpu.ui
+++ b/src/yuzu/configuration/configure_cpu.ui
@@ -54,7 +54,7 @@
              </item>
              <item>
               <property name="text">
-               <string>Paranoid</string>
+               <string>Paranoid (disables most optimizations)</string>
               </property>
              </item>
             </widget>

--- a/src/yuzu/configuration/configure_cpu.ui
+++ b/src/yuzu/configuration/configure_cpu.ui
@@ -52,6 +52,11 @@
                <string>Unsafe</string>
               </property>
              </item>
+             <item>
+              <property name="text">
+               <string>Paranoid</string>
+              </property>
+             </item>
             </widget>
            </item>
           </layout>


### PR DESCRIPTION
Disables most optimizations for the paranoid. Notably this does **not** disable fastmem and memory related opts (because doing so would be absolutely killer). Intended for users to be able to self-diagnose and report issues with CPU optimizations. If this option fixes issues that should be reported as a bug.

While we're here also ensure that when cpu debug mode is enabled, list of opts don't get fiddled with afterwards.

There is probably something around `USE_GLOBAL_OFFSET` I'm not understanding here, pls check.