### PR TITLE
Kernel Memory Updates (Part 7): Various fixes to code memory (Skyline support)

### DIFF
--- a/src/core/hle/kernel/k_code_memory.cpp
+++ b/src/core/hle/kernel/k_code_memory.cpp
@@ -28,7 +28,8 @@ ResultCode KCodeMemory::Initialize(Core::DeviceMemory& device_memory, VAddr addr
     auto& page_table = m_owner->PageTable();
 
     // Construct the page group.
-    m_page_group = KPageLinkedList(addr, Common::DivideUp(size, PageSize));
+    m_page_group =
+        KPageLinkedList(page_table.GetPhysicalAddr(addr), Common::DivideUp(size, PageSize));
 
     // Lock the memory.
     R_TRY(page_table.LockForCodeMemory(addr, size))

--- a/src/core/hle/kernel/k_page_linked_list.h
+++ b/src/core/hle/kernel/k_page_linked_list.h
@@ -89,6 +89,10 @@ public:
         return ResultSuccess;
     }
 
+    bool Empty() const {
+        return nodes.empty();
+    }
+
 private:
     std::list<Node> nodes;
 };

--- a/src/core/hle/kernel/k_page_table.h
+++ b/src/core/hle/kernel/k_page_table.h
@@ -164,6 +164,17 @@ private:
                                       attr_mask, attr, ignore_attr);
     }
 
+    ResultCode LockMemoryAndOpen(KPageLinkedList* out_pg, PAddr* out_paddr, VAddr addr, size_t size,
+                                 KMemoryState state_mask, KMemoryState state,
+                                 KMemoryPermission perm_mask, KMemoryPermission perm,
+                                 KMemoryAttribute attr_mask, KMemoryAttribute attr,
+                                 KMemoryPermission new_perm, KMemoryAttribute lock_attr);
+    ResultCode UnlockMemory(VAddr addr, size_t size, KMemoryState state_mask, KMemoryState state,
+                            KMemoryPermission perm_mask, KMemoryPermission perm,
+                            KMemoryAttribute attr_mask, KMemoryAttribute attr,
+                            KMemoryPermission new_perm, KMemoryAttribute lock_attr,
+                            const KPageLinkedList* pg);
+
     ResultCode MakePageGroup(KPageLinkedList& pg, VAddr addr, size_t num_pages);
 
     bool IsLockedByCurrentThread() const {
@@ -174,6 +185,14 @@ private:
         ASSERT(this->IsLockedByCurrentThread());
 
         return layout.IsHeapPhysicalAddress(cached_physical_heap_region, phys_addr);
+    }
+
+    bool GetPhysicalAddressLocked(PAddr* out, VAddr virt_addr) const {
+        ASSERT(this->IsLockedByCurrentThread());
+
+        *out = GetPhysicalAddr(virt_addr);
+
+        return *out != 0;
     }
 
     mutable KLightLock general_lock;

--- a/src/core/hle/kernel/k_page_table.h
+++ b/src/core/hle/kernel/k_page_table.h
@@ -72,6 +72,10 @@ public:
     ResultCode UnlockForDeviceAddressSpace(VAddr addr, std::size_t size);
     ResultCode LockForCodeMemory(VAddr addr, std::size_t size);
     ResultCode UnlockForCodeMemory(VAddr addr, std::size_t size);
+    ResultCode MakeAndOpenPageGroup(KPageLinkedList* out, VAddr address, size_t num_pages,
+                                    KMemoryState state_mask, KMemoryState state,
+                                    KMemoryPermission perm_mask, KMemoryPermission perm,
+                                    KMemoryAttribute attr_mask, KMemoryAttribute attr);
 
     Common::PageTable& PageTableImpl() {
         return page_table_impl;
@@ -159,6 +163,8 @@ private:
         return this->CheckMemoryState(nullptr, addr, size, state_mask, state, perm_mask, perm,
                                       attr_mask, attr, ignore_attr);
     }
+
+    ResultCode MakePageGroup(KPageLinkedList& pg, VAddr addr, size_t num_pages);
 
     bool IsLockedByCurrentThread() const {
         return general_lock.IsLockedByCurrentThread();

--- a/src/core/hle/kernel/k_page_table.h
+++ b/src/core/hle/kernel/k_page_table.h
@@ -12,6 +12,7 @@
 #include "core/file_sys/program_metadata.h"
 #include "core/hle/kernel/k_light_lock.h"
 #include "core/hle/kernel/k_memory_block.h"
+#include "core/hle/kernel/k_memory_layout.h"
 #include "core/hle/kernel/k_memory_manager.h"
 #include "core/hle/result.h"
 
@@ -161,6 +162,12 @@ private:
 
     bool IsLockedByCurrentThread() const {
         return general_lock.IsLockedByCurrentThread();
+    }
+
+    bool IsHeapPhysicalAddress(const KMemoryLayout& layout, PAddr phys_addr) {
+        ASSERT(this->IsLockedByCurrentThread());
+
+        return layout.IsHeapPhysicalAddress(cached_physical_heap_region, phys_addr);
     }
 
     mutable KLightLock general_lock;
@@ -322,6 +329,7 @@ private:
     bool is_aslr_enabled{};
 
     u32 heap_fill_value{};
+    const KMemoryRegion* cached_physical_heap_region{};
 
     KMemoryManager::Pool memory_pool{KMemoryManager::Pool::Application};
     KMemoryManager::Direction allocation_option{KMemoryManager::Direction::FromFront};

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1664,7 +1664,7 @@ static ResultCode UnmapProcessCodeMemory(Core::System& system, Handle process_ha
         return ResultInvalidAddress;
     }
 
-    if (size == 0 || Common::Is4KBAligned(size)) {
+    if (size == 0 || !Common::Is4KBAligned(size)) {
         LOG_ERROR(Kernel_SVC, "Size is zero or not page-aligned (size=0x{:016X}).", size);
         return ResultInvalidSize;
     }

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1362,8 +1362,11 @@ static ResultCode MapProcessMemory(Core::System& system, VAddr dst_address, Hand
              ResultInvalidMemoryRegion);
 
     // Create a new page group.
-    KMemoryInfo kBlockInfo = dst_pt.QueryInfo(dst_address);
-    KPageLinkedList pg(kBlockInfo.GetAddress(), kBlockInfo.GetNumPages());
+    KPageLinkedList pg;
+    R_TRY(src_pt.MakeAndOpenPageGroup(
+        std::addressof(pg), src_address, size / PageSize, KMemoryState::FlagCanMapProcess,
+        KMemoryState::FlagCanMapProcess, KMemoryPermission::None, KMemoryPermission::None,
+        KMemoryAttribute::All, KMemoryAttribute::None));
 
     // Map the group.
     R_TRY(dst_pt.MapPages(dst_address, pg, KMemoryState::SharedCode,

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1408,8 +1408,8 @@ static ResultCode UnmapProcessMemory(Core::System& system, VAddr dst_address, Ha
 }
 
 static ResultCode CreateCodeMemory(Core::System& system, Handle* out, VAddr address, size_t size) {
-    LOG_TRACE(Kernel_SVC, "called, handle_out={}, address=0x{:X}, size=0x{:X}",
-              static_cast<void*>(out), address, size);
+    LOG_TRACE(Kernel_SVC, "called, address=0x{:X}, size=0x{:X}", address, size);
+
     // Get kernel instance.
     auto& kernel = system.Kernel();
 


### PR DESCRIPTION
This is a continuation of my work to bring our kernel memory management up to speed with recent system updates and the latest known information (see previous PRs #8013, https://github.com/yuzu-emu/yuzu/pull/7974, https://github.com/yuzu-emu/yuzu/pull/7956, https://github.com/yuzu-emu/yuzu/pull/7701, https://github.com/yuzu-emu/yuzu/pull/7698, and https://github.com/yuzu-emu/yuzu/pull/7684 for a history of this effort).

With this change, we:
* Fix implementations of LockForCodeMemory & UnlockForCodeMemory.
* Fix MapProcessMemory bug where we were mapping onto virtual address space.
* Fix KCodeMemoryBug where we were addressing physical memory with a virtual address.
* Fix a bad alignment check in UnmapProcessCodeMemory.
* Various cleanup & smaller improvements.

The goal with this batch of changes is to wrap up the work from #7392 and get [Skyline](https://github.com/skyline-dev/skyline) working in yuzu. Things should be working better now, but I am not too familiar with Skyline, so please report any remaining issues here.

Thanks to @jam1garner, @itsmeft24 and @tech-ticks for assistance here and for doing most of the legwork.