### PR TITLE
Revert "Memory GPU <-> CPU: reduce infighting in the texture cache by adding CPU Cached memory."

### DIFF
--- a/src/core/memory.cpp
+++ b/src/core/memory.cpp
@@ -322,7 +322,7 @@ struct Memory::Impl {
         }
 
         if (Settings::IsFastmemEnabled()) {
-            const bool is_read_enable = !Settings::IsGPULevelExtreme() || !cached;
+            const bool is_read_enable = Settings::IsGPULevelHigh() || !cached;
             system.DeviceMemory().buffer.Protect(vaddr, size, is_read_enable, !cached);
         }
 

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -352,7 +352,7 @@ void RasterizerOpenGL::OnCPUWrite(VAddr addr, u64 size) {
     shader_cache.OnCPUWrite(addr, size);
     {
         std::scoped_lock lock{texture_cache.mutex};
-        texture_cache.CachedWriteMemory(addr, size);
+        texture_cache.WriteMemory(addr, size);
     }
     {
         std::scoped_lock lock{buffer_cache.mutex};
@@ -363,10 +363,6 @@ void RasterizerOpenGL::OnCPUWrite(VAddr addr, u64 size) {
 void RasterizerOpenGL::SyncGuestHost() {
     MICROPROFILE_SCOPE(OpenGL_CacheManagement);
     shader_cache.SyncGuestHost();
-    {
-        std::scoped_lock lock{texture_cache.mutex};
-        texture_cache.FlushCachedWrites();
-    }
     {
         std::scoped_lock lock{buffer_cache.mutex};
         buffer_cache.FlushCachedWrites();

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -408,7 +408,7 @@ void RasterizerVulkan::OnCPUWrite(VAddr addr, u64 size) {
     pipeline_cache.OnCPUWrite(addr, size);
     {
         std::scoped_lock lock{texture_cache.mutex};
-        texture_cache.CachedWriteMemory(addr, size);
+        texture_cache.WriteMemory(addr, size);
     }
     {
         std::scoped_lock lock{buffer_cache.mutex};
@@ -418,10 +418,6 @@ void RasterizerVulkan::OnCPUWrite(VAddr addr, u64 size) {
 
 void RasterizerVulkan::SyncGuestHost() {
     pipeline_cache.SyncGuestHost();
-    {
-        std::scoped_lock lock{texture_cache.mutex};
-        texture_cache.FlushCachedWrites();
-    }
     {
         std::scoped_lock lock{buffer_cache.mutex};
         buffer_cache.FlushCachedWrites();

--- a/src/video_core/texture_cache/image_base.h
+++ b/src/video_core/texture_cache/image_base.h
@@ -39,9 +39,6 @@ enum class ImageFlagBits : u32 {
     Rescaled = 1 << 13,
     CheckingRescalable = 1 << 14,
     IsRescalable = 1 << 15,
-
-    // Cached CPU
-    CachedCpuModified = 1 << 16, ///< Contents have been modified from the CPU
 };
 DECLARE_ENUM_FLAG_OPERATORS(ImageFlagBits)
 

--- a/src/video_core/texture_cache/texture_cache_base.h
+++ b/src/video_core/texture_cache/texture_cache_base.h
@@ -8,7 +8,6 @@
 #include <span>
 #include <type_traits>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 #include <queue>
 
@@ -50,9 +49,6 @@ template <class P>
 class TextureCache {
     /// Address shift for caching images into a hash table
     static constexpr u64 PAGE_BITS = 20;
-
-    static constexpr u64 CPU_PAGE_BITS = 12;
-    static constexpr u64 CPU_PAGE_SIZE = 1ULL << CPU_PAGE_BITS;
 
     /// Enables debugging features to the texture cache
     static constexpr bool ENABLE_VALIDATION = P::ENABLE_VALIDATION;
@@ -140,9 +136,6 @@ public:
     /// Mark images in a range as modified from the CPU
     void WriteMemory(VAddr cpu_addr, size_t size);
 
-    /// Mark images in a range as modified from the CPU
-    void CachedWriteMemory(VAddr cpu_addr, size_t size);
-
     /// Download contents of host images to guest memory in a region
     void DownloadMemory(VAddr cpu_addr, size_t size);
 
@@ -151,8 +144,6 @@ public:
 
     /// Remove images in a region
     void UnmapGPUMemory(GPUVAddr gpu_addr, size_t size);
-
-    void FlushCachedWrites();
 
     /// Blit an image with the given parameters
     void BlitImage(const Tegra::Engines::Fermi2D::Surface& dst,
@@ -374,8 +365,6 @@ private:
     std::unordered_map<u64, std::vector<ImageId>, IdentityHash<u64>> sparse_page_table;
 
     std::unordered_map<ImageId, std::vector<ImageViewId>> sparse_views;
-
-    std::unordered_set<ImageId> cached_cpu_invalidate;
 
     VAddr virtual_invalid_space{};
 


### PR DESCRIPTION
Reverts yuzu-emu/yuzu#8080

Causes graphical issues in SMO, and kills performance in Pokemon Sword/Shield with Extreme GPU accuracy. @FernandoS27 to address.