### PR TITLE
video_core/memory_manager: Mark memory range as remapped when mapping

### DIFF
--- a/src/video_core/memory_manager.cpp
+++ b/src/video_core/memory_manager.cpp
@@ -40,6 +40,9 @@ GPUVAddr MemoryManager::UpdateRange(GPUVAddr gpu_addr, PageEntry page_entry, std
 }
 
 GPUVAddr MemoryManager::Map(VAddr cpu_addr, GPUVAddr gpu_addr, std::size_t size) {
+    // Mark any pre-existing rasterizer memory in this range as remapped
+    rasterizer->ModifyGPUMemory(gpu_addr, size);
+
     const auto it = std::ranges::lower_bound(map_ranges, gpu_addr, {}, &MapRange::first);
     if (it != map_ranges.end() && it->first == gpu_addr) {
         it->second = size;

--- a/src/video_core/texture_cache/texture_cache_base.h
+++ b/src/video_core/texture_cache/texture_cache_base.h
@@ -139,6 +139,9 @@ public:
     /// Download contents of host images to guest memory in a region
     void DownloadMemory(VAddr cpu_addr, size_t size);
 
+    /// Download contents of host images to guest memory
+    void DownloadImage(ImageId image_id);
+
     /// Remove images in a region
     void UnmapMemory(VAddr cpu_addr, size_t size);
 


### PR DESCRIPTION
This change reduces video memory usage, especially in `Kirby and the Forgotten Land`