### PR TITLE
build: cleanup installation of yuzu and yuzu-cmd

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -293,7 +293,7 @@ if (YUZU_USE_QT_WEB_ENGINE)
 endif ()
 
 if(UNIX AND NOT APPLE)
-    install(TARGETS yuzu RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+    install(TARGETS yuzu)
 endif()
 
 if (YUZU_USE_BUNDLED_QT)

--- a/src/yuzu_cmd/CMakeLists.txt
+++ b/src/yuzu_cmd/CMakeLists.txt
@@ -45,7 +45,7 @@ if (YUZU_USE_EXTERNAL_SDL2)
 endif()
 
 if(UNIX AND NOT APPLE)
-    install(TARGETS yuzu-cmd RUNTIME DESTINATION "${CMAKE_INSTALL_PREFIX}/bin")
+    install(TARGETS yuzu-cmd)
 endif()
 
 if (MSVC)


### PR DESCRIPTION
Explicitly specifying an install destination is not needed anymore since CMake 3.14.

By removing the hardcoded `${CMAKE_INSTALL_PREFIX}/bin` it is also now possible to override the install destination via the command line. For example, you can now install yuzu to `/usr/games` with `-DCMAKE_INSTALL_BINDIR=games`