### PR TITLE
dynarmic: Invalidate CPU cache on all cores

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -93,17 +93,19 @@ public:
             static constexpr u64 ICACHE_LINE_SIZE = 64;
 
             const u64 cache_line_start = value & ~(ICACHE_LINE_SIZE - 1);
-            parent.InvalidateCacheRange(cache_line_start, ICACHE_LINE_SIZE);
+            parent.system.InvalidateCpuInstructionCacheRange(cache_line_start, ICACHE_LINE_SIZE);
             break;
         }
         case Dynarmic::A64::InstructionCacheOperation::InvalidateAllToPoU:
-            parent.ClearInstructionCache();
+            parent.system.InvalidateCpuInstructionCaches();
             break;
         case Dynarmic::A64::InstructionCacheOperation::InvalidateAllToPoUInnerSharable:
         default:
             LOG_DEBUG(Core_ARM, "Unprocesseed instruction cache operation: {}", op);
             break;
         }
+
+        parent.jit->HaltExecution();
     }
 
     void ExceptionRaised(u64 pc, Dynarmic::A64::Exception exception) override {


### PR DESCRIPTION
Multicore, huh. Closes #8096.

Likely fixes code memory related invalidation issues.