### PR TITLE
Kernel: Improve shutdown by attempting to close open object references

### DIFF
--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -44,7 +44,7 @@ bool SessionRequestManager::HasSessionRequestHandler(const HLERequestContext& co
             LOG_CRITICAL(IPC, "object_id {} is too big!", object_id);
             return false;
         }
-        return DomainHandler(object_id - 1).lock() != nullptr;
+        return !DomainHandler(object_id - 1).expired();
     } else {
         return session_handler != nullptr;
     }

--- a/src/core/hle/kernel/hle_ipc.h
+++ b/src/core/hle/kernel/hle_ipc.h
@@ -134,7 +134,7 @@ public:
 
     void CloseDomainHandler(std::size_t index) {
         if (index < DomainHandlerCount()) {
-            domain_handlers[index] = nullptr;
+            domain_handlers[index].reset();
         } else {
             UNREACHABLE_MSG("Unexpected handler index {}", index);
         }

--- a/src/core/hle/kernel/k_thread_local_page.cpp
+++ b/src/core/hle/kernel/k_thread_local_page.cpp
@@ -37,6 +37,11 @@ ResultCode KThreadLocalPage::Initialize(KernelCore& kernel, KProcess* process) {
 }
 
 ResultCode KThreadLocalPage::Finalize() {
+    // If we are actively shutting down, there is nothing to do here.
+    if (m_kernel->IsShuttingDown()) {
+        return ResultSuccess;
+    }
+
     // Get the physical address of the page.
     const PAddr phys_addr = m_owner->PageTable().GetPhysicalAddr(m_virt_addr);
     ASSERT(phys_addr);

--- a/src/core/hle/kernel/slab_helpers.h
+++ b/src/core/hle/kernel/slab_helpers.h
@@ -79,7 +79,7 @@ public:
             this->Finalize();
         }
         Free(kernel, static_cast<Derived*>(this));
-        if (is_initialized) {
+        if (is_initialized && !kernel.IsShuttingDown()) {
             Derived::PostDestroy(arg);
         }
     }


### PR DESCRIPTION
Currently, when we tear down emulation, we do not close objects that still have open references. Since these are backed by guest memory, there is not a memory leak, but it means that finalize procedures are not invoked. With this change, we attempt to close any dangling objects on shutdown, fixing an issue where some services (e.g. HID) might not be fully torn down.