### PR TITLE
gpu_thread: Block on FlushRegion for all GPU accuracies

### DIFF
--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -90,6 +90,10 @@ void ThreadManager::FlushRegion(VAddr addr, u64 size) {
         return;
     }
     if (!Settings::IsGPULevelExtreme()) {
+        // Push a command and block here before proceeding, addresses a synchronization
+        // bug causing an SVC break in Kirby and the Forgotten Land
+        // GPUTickCommand is essentially a no-op if we don't RequestFlush()
+        PushCommand(GPUTickCommand(), true);
         return;
     }
     auto& gpu = system.GPU();


### PR DESCRIPTION
This addresses a synchronization issue that causes an SVC break in `Kirby and the Forgotten Land`.

My own benchmarking showed the block incurs 1-2 milliseconds of overhead every 5-10 frames or so, so relatively unnoticeable. Further performance testing would be appreciated.