### PR TITLE
nvhost_ctrl: Only mark EventState::Busy as BadParameter

### DIFF
--- a/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
+++ b/src/core/hle/service/nvdrv/devices/nvhost_ctrl.cpp
@@ -134,7 +134,7 @@ NvResult nvhost_ctrl::IocCtrlEventWait(const std::vector<u8>& input, std::vector
     }
 
     EventState status = events_interface.status[event_id];
-    const bool bad_parameter = status != EventState::Free && status != EventState::Registered;
+    const bool bad_parameter = status == EventState::Busy;
     if (bad_parameter) {
         std::memcpy(output.data(), &params, sizeof(params));
         return NvResult::BadParameter;


### PR DESCRIPTION
Fixes an svc break in `Kirby and the Forgotten Land` with async GPU enabled.