### PR TITLE
vk_staging_buffer_pool: Rework stream buffer usage

### DIFF
--- a/src/video_core/renderer_vulkan/vk_staging_buffer_pool.h
+++ b/src/video_core/renderer_vulkan/vk_staging_buffer_pool.h
@@ -67,7 +67,7 @@ private:
 
     StagingBufferRef GetStreamBuffer(size_t size);
 
-    bool AreRegionsActive(size_t region_begin, size_t region_end) const;
+    std::optional<size_t> NextAvailableStreamIndex(size_t num_regions) const;
 
     StagingBufferRef GetStagingBuffer(size_t size, MemoryUsage usage);
 
@@ -89,9 +89,7 @@ private:
     vk::DeviceMemory stream_memory;
     u8* stream_pointer = nullptr;
 
-    size_t iterator = 0;
-    size_t used_iterator = 0;
-    size_t free_iterator = 0;
+    size_t next_index = 0;
     std::array<u64, NUM_SYNCS> sync_ticks{};
 
     StagingBuffersCache device_local_cache;

--- a/src/video_core/renderer_vulkan/vk_staging_buffer_pool.h
+++ b/src/video_core/renderer_vulkan/vk_staging_buffer_pool.h
@@ -25,7 +25,7 @@ struct StagingBufferRef {
 
 class StagingBufferPool {
 public:
-    static constexpr size_t NUM_SYNCS = 16;
+    static constexpr size_t NUM_STREAM_REGIONS = 0x8000;
 
     explicit StagingBufferPool(const Device& device, MemoryAllocator& memory_allocator,
                                VKScheduler& scheduler);
@@ -90,7 +90,7 @@ private:
     u8* stream_pointer = nullptr;
 
     size_t next_index = 0;
-    std::array<u64, NUM_SYNCS> sync_ticks{};
+    std::array<u64, NUM_STREAM_REGIONS> sync_ticks{};
 
     StagingBuffersCache device_local_cache;
     StagingBuffersCache upload_cache;


### PR DESCRIPTION
This PR aims to fix random vertex explosions and other graphical issues in titles such as `Kirby and the Forgotten Land`
when using the Vulkan backend.

The previous implementation was susceptible to off-by-one errors such as checking 
if `Region(i + 1)` is available but then consuming `Region(i)` or vice versa, or 
begin/end iterators being equal causing their usage in std algorithms to be no-ops.

This PR attempts to account for these issues by simplifying the implementation. 
The stream buffer is now divided into `NUM_STREAM_REGIONS`, with each region 
having an associated master semaphore tick indicating which tick it was being used in.

The one downside compared to the previous implementation is that each stream 
buffer region (currently 4K in size) can only be used by one upload request, no matter how small.

The previous implementation was seemingly able to pack multiple uploads into a single region,
although it's unclear if this was intentional or a consequence of the aforementioned indexing errors.

