### PR TITLE
shader_recompiler: support const buffer indirect addressing on OpenGL

### DIFF
--- a/src/shader_recompiler/backend/glsl/glsl_emit_context.h
+++ b/src/shader_recompiler/backend/glsl/glsl_emit_context.h
@@ -162,6 +162,7 @@ public:
 private:
     void SetupExtensions();
     void DefineConstantBuffers(Bindings& bindings);
+    void DefineConstantBufferIndirect();
     void DefineStorageBuffers(Bindings& bindings);
     void DefineGenericOutput(size_t index, u32 invocations);
     void DefineHelperFunctions();

--- a/src/shader_recompiler/ir_opt/collect_shader_info_pass.cpp
+++ b/src/shader_recompiler/ir_opt/collect_shader_info_pass.cpp
@@ -32,13 +32,8 @@ void AddConstantBufferDescriptor(Info& info, u32 index, u32 count) {
 void AddRegisterIndexedLdc(Info& info) {
     info.uses_cbuf_indirect = true;
 
-    // The shader can use any possible constant buffer
-    info.constant_buffer_mask = (1 << Info::MAX_CBUFS) - 1;
-
-    auto& cbufs{info.constant_buffer_descriptors};
-    cbufs.clear();
-    for (u32 i = 0; i < Info::MAX_CBUFS; i++) {
-        cbufs.push_back(ConstantBufferDescriptor{.index = i, .count = 1});
+    for (u32 i = 0; i < Info::MAX_INDIRECT_CBUFS; i++) {
+        AddConstantBufferDescriptor(info, i, 1);
 
         // The shader can use any possible access size
         info.constant_buffer_used_sizes[i] = 0x10'000;

--- a/src/shader_recompiler/shader_info.h
+++ b/src/shader_recompiler/shader_info.h
@@ -105,7 +105,7 @@ struct ImageDescriptor {
 using ImageDescriptors = boost::container::small_vector<ImageDescriptor, 4>;
 
 struct Info {
-    static constexpr size_t MAX_INDIRECT_CBUFS{15};
+    static constexpr size_t MAX_INDIRECT_CBUFS{14};
     static constexpr size_t MAX_CBUFS{18};
     static constexpr size_t MAX_SSBOS{32};
 

--- a/src/shader_recompiler/shader_info.h
+++ b/src/shader_recompiler/shader_info.h
@@ -105,7 +105,7 @@ struct ImageDescriptor {
 using ImageDescriptors = boost::container::small_vector<ImageDescriptor, 4>;
 
 struct Info {
-    static constexpr size_t MAX_INDIRECT_CBUFS{16};
+    static constexpr size_t MAX_INDIRECT_CBUFS{15};
     static constexpr size_t MAX_CBUFS{18};
     static constexpr size_t MAX_SSBOS{32};
 

--- a/src/shader_recompiler/shader_info.h
+++ b/src/shader_recompiler/shader_info.h
@@ -105,6 +105,7 @@ struct ImageDescriptor {
 using ImageDescriptors = boost::container::small_vector<ImageDescriptor, 4>;
 
 struct Info {
+    static constexpr size_t MAX_INDIRECT_CBUFS{16};
     static constexpr size_t MAX_CBUFS{18};
     static constexpr size_t MAX_SSBOS{32};
 


### PR DESCRIPTION
This allows Mario's body to render in Sunshine using OpenGL GLSL and SPIR-V (no GLASM support for now). Note that due to current issues with the OpenGL renderer, which polygons are considered front facing is flipped, and so only back faces are rendered.

![010049900f546002_2022-04-01_11-23-11-742](https://user-images.githubusercontent.com/9658600/161293656-3737555f-505d-4b2b-8897-9c194a56559b.png)
![010049900f546002_2022-04-01_11-21-14-551](https://user-images.githubusercontent.com/9658600/161293336-91982440-3cce-4d8a-b2ae-e64e482ce21b.png)