### PR TITLE
applets/web: Keep foreground (websession) web applet open

### DIFF
--- a/src/core/hle/service/am/applets/applet_web_browser.cpp
+++ b/src/core/hle/service/am/applets/applet_web_browser.cpp
@@ -446,6 +446,14 @@ void WebBrowser::ExecuteLogin() {
 }
 
 void WebBrowser::ExecuteOffline() {
+    // TODO (Morph): This is a hack for WebSession foreground web applets such as those used by
+    //               Super Mario 3D All-Stars.
+    // TODO (Morph): Implement WebSession.
+    if (applet_mode == LibraryAppletMode::AllForegroundInitiallyHidden) {
+        LOG_WARNING(Service_AM, "WebSession is not implemented");
+        return;
+    }
+
     const auto main_url = GetMainURL(Common::FS::PathToUTF8String(offline_document));
 
     if (!Common::FS::Exists(main_url)) {


### PR DESCRIPTION
This is a hack to keep the foreground (websession) web applet open in games using these such as Super Mario 3D All-Stars.