### PR TITLE
core: hid: Remove service callbacks on game close

### DIFF
--- a/src/core/hid/emulated_controller.cpp
+++ b/src/core/hid/emulated_controller.cpp
@@ -1207,4 +1207,12 @@ void EmulatedController::DeleteCallback(int key) {
     }
     callback_list.erase(iterator);
 }
+
+void EmulatedController::RemoveServiceCallbacks() {
+    std::lock_guard lock{mutex};
+    const auto count = std::erase_if(
+        callback_list, [](const auto& callback) { return callback.second.is_npad_service; });
+    LOG_DEBUG(Input, "Elements deleted {}", count);
+}
+
 } // namespace Core::HID

--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -335,6 +335,9 @@ public:
      */
     void DeleteCallback(int key);
 
+    /// Removes all callbacks created from npad services
+    void RemoveServiceCallbacks();
+
 private:
     /// creates input devices from params
     void LoadDevices();

--- a/src/core/hid/hid_core.cpp
+++ b/src/core/hid/hid_core.cpp
@@ -211,4 +211,17 @@ void HIDCore::UnloadInputDevices() {
     devices->UnloadInput();
 }
 
+void HIDCore::RemoveServiceCallbacks() {
+    player_1->RemoveServiceCallbacks();
+    player_2->RemoveServiceCallbacks();
+    player_3->RemoveServiceCallbacks();
+    player_4->RemoveServiceCallbacks();
+    player_5->RemoveServiceCallbacks();
+    player_6->RemoveServiceCallbacks();
+    player_7->RemoveServiceCallbacks();
+    player_8->RemoveServiceCallbacks();
+    other->RemoveServiceCallbacks();
+    handheld->RemoveServiceCallbacks();
+}
+
 } // namespace Core::HID

--- a/src/core/hid/hid_core.h
+++ b/src/core/hid/hid_core.h
@@ -61,6 +61,9 @@ public:
     /// Removes all callbacks from input common
     void UnloadInputDevices();
 
+    /// Removes all callbacks from npad services
+    void RemoveServiceCallbacks();
+
     /// Number of emulated controllers
     static constexpr std::size_t available_controllers{10};
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1533,8 +1533,9 @@ void GMainWindow::ShutdownGame() {
     input_subsystem->GetTas()->Stop();
     OnTasStateChanged();
 
-    // Enable all controllers
+    // Enable all controllers types and remove all service callbacks
     system->HIDCore().SetSupportedStyleTag({Core::HID::NpadStyleSet::All});
+    system->HIDCore().RemoveServiceCallbacks();
 
     render_window->removeEventFilter(render_window);
     render_window->setAttribute(Qt::WA_Hover, false);


### PR DESCRIPTION
Currently not all services are destroyed and callbacks are never released for the same reason. To prevent triggering a callback on a partially dead npad service we manually remove all the input callbacks related to services.

#8108 tries to fix the issue but it's not doing it cleanly. For now this PR ensures issues like this never happen.