### PR TITLE
configure_per_game_addons: Stretch first column and not last

### DIFF
--- a/src/yuzu/configuration/configure_per_game_addons.cpp
+++ b/src/yuzu/configuration/configure_per_game_addons.cpp
@@ -49,6 +49,7 @@ ConfigurePerGameAddons::ConfigurePerGameAddons(Core::System& system_, QWidget* p
 
     tree_view->header()->setStretchLastSection(false);
     tree_view->header()->setSectionResizeMode(0, QHeaderView::ResizeMode::Stretch);
+    tree_view->header()->setMinimumSectionSize(150);
 
     // We must register all custom types with the Qt Automoc system so that we are able to use it
     // with signals/slots. In this case, QList falls under the umbrella of custom types.

--- a/src/yuzu/configuration/configure_per_game_addons.cpp
+++ b/src/yuzu/configuration/configure_per_game_addons.cpp
@@ -47,6 +47,9 @@ ConfigurePerGameAddons::ConfigurePerGameAddons(Core::System& system_, QWidget* p
     item_model->setHeaderData(0, Qt::Horizontal, tr("Patch Name"));
     item_model->setHeaderData(1, Qt::Horizontal, tr("Version"));
 
+    tree_view->header()->setStretchLastSection(false);
+    tree_view->header()->setSectionResizeMode(0, QHeaderView::ResizeMode::Stretch);
+
     // We must register all custom types with the Qt Automoc system so that we are able to use it
     // with signals/slots. In this case, QList falls under the umbrella of custom types.
     qRegisterMetaType<QList<QStandardItem*>>("QList<QStandardItem*>");
@@ -138,5 +141,5 @@ void ConfigurePerGameAddons::LoadConfiguration() {
         item_model->appendRow(list_items.back());
     }
 
-    tree_view->setColumnWidth(0, 5 * tree_view->width() / 16);
+    tree_view->resizeColumnToContents(1);
 }


### PR DESCRIPTION
This provides more sensible column widths.

![image](https://user-images.githubusercontent.com/8682882/161383794-e692d9b1-8afd-47f7-9299-33e90237447c.png)
