### PR TITLE
configure_hotkeys: Make first column stretch and not last column

### DIFF
--- a/src/yuzu/configuration/configure_hotkeys.cpp
+++ b/src/yuzu/configuration/configure_hotkeys.cpp
@@ -35,8 +35,9 @@ ConfigureHotkeys::ConfigureHotkeys(Core::HID::HIDCore& hid_core, QWidget* parent
     ui->hotkey_list->setContextMenuPolicy(Qt::CustomContextMenu);
     ui->hotkey_list->setModel(model);
 
-    ui->hotkey_list->setColumnWidth(name_column, 200);
-    ui->hotkey_list->resizeColumnToContents(hotkey_column);
+    ui->hotkey_list->header()->setStretchLastSection(false);
+    ui->hotkey_list->header()->setSectionResizeMode(name_column, QHeaderView::ResizeMode::Stretch);
+    ui->hotkey_list->header()->setMinimumSectionSize(150);
 
     connect(ui->button_restore_defaults, &QPushButton::clicked, this,
             &ConfigureHotkeys::RestoreDefaults);
@@ -76,8 +77,8 @@ void ConfigureHotkeys::Populate(const HotkeyRegistry& registry) {
     }
 
     ui->hotkey_list->expandAll();
-    ui->hotkey_list->resizeColumnToContents(name_column);
     ui->hotkey_list->resizeColumnToContents(hotkey_column);
+    ui->hotkey_list->resizeColumnToContents(controller_column);
 }
 
 void ConfigureHotkeys::changeEvent(QEvent* event) {


### PR DESCRIPTION
Also configure minimum width of columns to be 150px.

Makes for more sensible column widths.

![image](https://user-images.githubusercontent.com/8682882/161384214-db5497c1-3e0f-49c4-a4b0-0148cae9104f.png)
