### PR TITLE
texture_cache, vulkan pipelines: Reduce unneeded state modifications when resolution scaling is not used

### DIFF
--- a/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
+++ b/src/video_core/renderer_vulkan/vk_compute_pipeline.cpp
@@ -200,7 +200,7 @@ void ComputePipeline::Configure(Tegra::Engines::KeplerCompute& kepler_compute,
         });
     }
     const void* const descriptor_data{update_descriptor_queue.UpdateData()};
-    const bool is_rescaling = !info.texture_descriptors.empty() || !info.image_descriptors.empty();
+    const bool is_rescaling = info.uses_rescaling_uniform;
     scheduler.Record([this, descriptor_data, is_rescaling,
                       rescaling_data = rescaling.Data()](vk::CommandBuffer cmdbuf) {
         cmdbuf.BindPipeline(VK_PIPELINE_BIND_POINT_COMPUTE, *pipeline);

--- a/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
+++ b/src/video_core/renderer_vulkan/vk_graphics_pipeline.h
@@ -151,6 +151,7 @@ private:
     std::mutex build_mutex;
     std::atomic_bool is_built{false};
     bool uses_push_descriptor{false};
+    bool uses_rescale_unfiorm{false};
 };
 
 } // namespace Vulkan

--- a/src/video_core/renderer_vulkan/vk_rasterizer.cpp
+++ b/src/video_core/renderer_vulkan/vk_rasterizer.cpp
@@ -234,12 +234,9 @@ void RasterizerVulkan::Clear() {
     const VkExtent2D render_area = framebuffer->RenderArea();
     scheduler.RequestRenderpass(framebuffer);
 
-    u32 up_scale = 1;
-    u32 down_shift = 0;
-    if (texture_cache.IsRescaling()) {
-        up_scale = Settings::values.resolution_info.up_scale;
-        down_shift = Settings::values.resolution_info.down_shift;
-    }
+    const bool is_rescaling = texture_cache.IsRescaling();
+    const u32 up_scale = is_rescaling ? Settings::values.resolution_info.up_scale : 1U;
+    const u32 down_shift = is_rescaling ? Settings::values.resolution_info.down_shift : 0U;
     UpdateViewportsState(regs);
 
     VkClearRect clear_rect{
@@ -695,12 +692,9 @@ void RasterizerVulkan::UpdateScissorsState(Tegra::Engines::Maxwell3D::Regs& regs
     if (!state_tracker.TouchScissors()) {
         return;
     }
-    u32 up_scale = 1;
-    u32 down_shift = 0;
-    if (texture_cache.IsRescaling()) {
-        up_scale = Settings::values.resolution_info.up_scale;
-        down_shift = Settings::values.resolution_info.down_shift;
-    }
+    const bool is_rescaling = texture_cache.IsRescaling();
+    const u32 up_scale = is_rescaling ? Settings::values.resolution_info.up_scale : 1U;
+    const u32 down_shift = is_rescaling ? Settings::values.resolution_info.down_shift : 0U;
     const std::array scissors{
         GetScissorState(regs, 0, up_scale, down_shift),
         GetScissorState(regs, 1, up_scale, down_shift),

--- a/src/video_core/texture_cache/texture_cache.h
+++ b/src/video_core/texture_cache/texture_cache.h
@@ -328,7 +328,8 @@ void TextureCache<P>::UpdateRenderTargets(bool is_clear) {
     }
 
     const bool rescaled = RescaleRenderTargets(is_clear);
-    if (is_rescaling != rescaled) {
+    const auto& resolution_info = Settings::values.resolution_info;
+    if (resolution_info.active && is_rescaling != rescaled) {
         flags[Dirty::RescaleViewports] = true;
         flags[Dirty::RescaleScissors] = true;
         is_rescaling = rescaled;
@@ -345,12 +346,8 @@ void TextureCache<P>::UpdateRenderTargets(bool is_clear) {
     for (size_t index = 0; index < NUM_RT; ++index) {
         render_targets.draw_buffers[index] = static_cast<u8>(maxwell3d.regs.rt_control.Map(index));
     }
-    u32 up_scale = 1;
-    u32 down_shift = 0;
-    if (is_rescaling) {
-        up_scale = Settings::values.resolution_info.up_scale;
-        down_shift = Settings::values.resolution_info.down_shift;
-    }
+    const u32 up_scale = is_rescaling ? resolution_info.up_scale : 1U;
+    const u32 down_shift = is_rescaling ? resolution_info.down_shift : 0U;
     render_targets.size = Extent2D{
         (maxwell3d.regs.render_area.width * up_scale) >> down_shift,
         (maxwell3d.regs.render_area.height * up_scale) >> down_shift,


### PR DESCRIPTION
This change aims to reduce redundant state changes made by the following:
- The texture cache maintaining the `is_rescaled` logic, which is used to mark registers as dirty, even when resolution is set to 1x
- The Vulkan pipelines binding the resolution scaling push constant even when the shaders were not making use of the resolution scaling IR instructions