### PR TITLE
dynarmic: Interrupts

### DIFF
--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -171,6 +171,9 @@ public:
     /// Prepare core for thread reschedule (if needed to correctly handle state)
     virtual void PrepareReschedule() = 0;
 
+    /// Signal an interrupt and ask the core to halt as soon as possible.
+    virtual void SignalInterrupt() = 0;
+
     struct BacktraceEntry {
         std::string module;
         u64 address;

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -88,9 +88,8 @@ public:
     }
 
     void AddTicks(u64 ticks) override {
-        if (parent.uses_wall_clock) {
-            return;
-        }
+        ASSERT_MSG(!parent.uses_wall_clock, "This should never happen - dynarmic ticking disabled");
+
         // Divide the number of ticks by the amount of CPU cores. TODO(Subv): This yields only a
         // rough approximation of the amount of executed ticks in the system, it may be thrown off
         // if not all cores are doing a similar amount of work. Instead of doing this, we should
@@ -106,12 +105,8 @@ public:
     }
 
     u64 GetTicksRemaining() override {
-        if (parent.uses_wall_clock) {
-            if (!parent.interrupt_handlers[parent.core_index].IsInterrupted()) {
-                return minimum_run_cycles;
-            }
-            return 0U;
-        }
+        ASSERT_MSG(!parent.uses_wall_clock, "This should never happen - dynarmic ticking disabled");
+
         return std::max<s64>(parent.system.CoreTiming().GetDowncount(), 0);
     }
 
@@ -146,6 +141,7 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
 
     // Timing
     config.wall_clock_cntpct = uses_wall_clock;
+    config.enable_cycle_counting = !uses_wall_clock;
 
     // Code cache size
     config.code_cache_size = 512_MiB;
@@ -222,13 +218,13 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
 
 void ARM_Dynarmic_32::Run() {
     while (true) {
-        jit->Run();
+        const auto hr = jit->Run();
         if (!svc_called) {
             break;
         }
         svc_called = false;
         Kernel::Svc::Call(system, svc_swi);
-        if (shutdown) {
+        if (shutdown || Has(hr, Dynarmic::HaltReason::UserDefined2)) {
             break;
         }
     }
@@ -316,6 +312,10 @@ void ARM_Dynarmic_32::LoadContext(const ThreadContext32& ctx) {
 void ARM_Dynarmic_32::PrepareReschedule() {
     jit->HaltExecution();
     shutdown = true;
+}
+
+void ARM_Dynarmic_32::SignalInterrupt() {
+    jit->HaltExecution(Dynarmic::HaltReason::UserDefined2);
 }
 
 void ARM_Dynarmic_32::ClearInstructionCache() {

--- a/src/core/arm/dynarmic/arm_dynarmic_32.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.h
@@ -57,6 +57,7 @@ public:
     void LoadContext(const ThreadContext64& ctx) override {}
 
     void PrepareReschedule() override;
+    void SignalInterrupt() override;
     void ClearExclusiveState() override;
 
     void ClearInstructionCache() override;

--- a/src/core/arm/dynarmic/arm_dynarmic_64.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.h
@@ -51,6 +51,7 @@ public:
     void LoadContext(const ThreadContext64& ctx) override;
 
     void PrepareReschedule() override;
+    void SignalInterrupt() override;
     void ClearExclusiveState() override;
 
     void ClearInstructionCache() override;

--- a/src/core/hle/kernel/physical_core.cpp
+++ b/src/core/hle/kernel/physical_core.cpp
@@ -58,6 +58,7 @@ bool PhysicalCore::IsInterrupted() const {
 void PhysicalCore::Interrupt() {
     guard->lock();
     interrupts[core_index].SetInterrupt(true);
+    arm_interface->SignalInterrupt();
     guard->unlock();
 }
 


### PR DESCRIPTION
@FernandoS27 

Probably entirely the wrong way to go about this.

Design notes:
`HaltExecution` can be called from any thread, and will halt execution at the soonest possible opportunity.
If `HaltExecution` is called before `Run`, `Run` will halt immediately.
The return value of `Run` is [a set of bitflags](https://github.com/merryhime/dynarmic/blob/644172477eaf0d822178cb7e96c62b75caa96573/src/dynarmic/interface/halt_reason.h) of what caused the execution to halt. Halt reason state is atomically cleared on return from `Run`.