### PR TITLE
OpenGL: flip front faces if Z scale is inverted

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -561,8 +561,9 @@ void RasterizerOpenGL::SyncViewport() {
         flags[Dirty::FrontFace] = false;
 
         GLenum mode = MaxwellToGL::FrontFace(regs.front_face);
-        if (regs.screen_y_control.triangle_rast_flip != 0 &&
-            regs.viewport_transform[0].scale_y < 0.0f) {
+        if ((regs.screen_y_control.triangle_rast_flip != 0 &&
+             regs.viewport_transform[0].scale_y < 0.0f) ||
+            regs.viewport_transform[0].scale_z < 0.0f) {
             switch (mode) {
             case GL_CW:
                 mode = GL_CCW;

--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -557,13 +557,19 @@ void RasterizerOpenGL::SyncViewport() {
     const bool dirty_viewport = flags[Dirty::Viewports] || rescale_viewports;
     const bool dirty_clip_control = flags[Dirty::ClipControl];
 
-    if (dirty_clip_control || flags[Dirty::FrontFace]) {
+    if (dirty_viewport || dirty_clip_control || flags[Dirty::FrontFace]) {
         flags[Dirty::FrontFace] = false;
 
         GLenum mode = MaxwellToGL::FrontFace(regs.front_face);
-        if ((regs.screen_y_control.triangle_rast_flip != 0 &&
-             regs.viewport_transform[0].scale_y < 0.0f) ||
-            regs.viewport_transform[0].scale_z < 0.0f) {
+        bool flip_faces = false;
+        if (regs.screen_y_control.triangle_rast_flip != 0 &&
+            regs.viewport_transform[0].scale_y < 0.0f) {
+            flip_faces = !flip_faces;
+        }
+        if (regs.viewport_transform[0].scale_z < 0.0f) {
+            flip_faces = !flip_faces;
+        }
+        if (flip_faces) {
             switch (mode) {
             case GL_CW:
                 mode = GL_CCW;


### PR DESCRIPTION
With #8133, this allows Sunshine and Galaxy to render correctly on OpenGL GLSL and SPIR-V backends.
- Sunshine is more or less full speed on OpenGL and playable, aside from some areas like Pinna Park which have slowdowns.
- Galaxy is extremely slow on OpenGL and cannot be progressed due to missing depth buffer translation (see #8030). Users should prefer Vulkan for this title.

|Before|After|
|------|-----|
|![010049900f546002_2022-04-01_18-20-13-192](https://user-images.githubusercontent.com/9658600/161562609-30e6116a-e3b9-4621-9485-9b8291cae373.png)|![010049900f546002_2022-04-04_10-06-38-453](https://user-images.githubusercontent.com/9658600/161562628-5a520ee4-0533-4f70-b00c-b31a8fbb086b.png)|
|![010049900f546003_2022-04-04_10-10-35-436](https://user-images.githubusercontent.com/9658600/161562659-a1789c50-ffdd-47ea-85f5-8ad6a4857717.png)|![010049900f546003_2022-04-04_10-07-34-732](https://user-images.githubusercontent.com/9658600/161562671-b7a6b958-b292-4328-ae38-ea9032933922.png)|
