### PR TITLE
Vulkan: crop to screen dimensions if crop not explicitly requested

### DIFF
--- a/src/video_core/renderer_vulkan/vk_blit_screen.cpp
+++ b/src/video_core/renderer_vulkan/vk_blit_screen.cpp
@@ -1406,8 +1406,9 @@ void VKBlitScreen::SetVertexData(BufferData& data, const Tegra::FramebufferConfi
     UNIMPLEMENTED_IF(framebuffer_crop_rect.top != 0);
     UNIMPLEMENTED_IF(framebuffer_crop_rect.left != 0);
 
-    f32 scale_u = 1.0f;
-    f32 scale_v = 1.0f;
+    f32 scale_u = static_cast<f32>(framebuffer.width) / static_cast<f32>(screen_info.width);
+    f32 scale_v = static_cast<f32>(framebuffer.height) / static_cast<f32>(screen_info.height);
+
     // Scale the output by the crop width/height. This is commonly used with 1280x720 rendering
     // (e.g. handheld mode) on a 1920x1080 framebuffer.
     if (!fsr) {


### PR DESCRIPTION
This hides the black bar at the bottom of Sunshine.
|Before|After|
|-|-|
|![010049900f546002_2022-04-04_11-46-38-078](https://user-images.githubusercontent.com/9658600/161582073-07ecf671-dfb7-439b-8bab-19ce7de1f79a.png)|![010049900f546002_2022-04-04_11-45-57-390](https://user-images.githubusercontent.com/9658600/161582103-07600287-5bb9-421a-9564-52692ff076a1.png)|