### PR TITLE
OpenGL: fix cropping

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -520,6 +520,8 @@ bool RasterizerOpenGL::AccelerateDisplay(const Tegra::FramebufferConfig& config,
     // ASSERT_MSG(image_view->size.width == config.width, "Framebuffer width is different");
     // ASSERT_MSG(image_view->size.height == config.height, "Framebuffer height is different");
 
+    screen_info.texture.width = image_view->size.width;
+    screen_info.texture.height = image_view->size.height;
     screen_info.display_texture = image_view->Handle(Shader::TextureType::Color2D);
     screen_info.display_srgb = VideoCore::Surface::IsPixelFormatSRGB(image_view->format);
     return true;

--- a/src/video_core/renderer_opengl/renderer_opengl.cpp
+++ b/src/video_core/renderer_opengl/renderer_opengl.cpp
@@ -208,6 +208,8 @@ void RendererOpenGL::LoadFBToScreenInfo(const Tegra::FramebufferConfig& framebuf
     // Framebuffer orientation handling
     framebuffer_transform_flags = framebuffer.transform_flags;
     framebuffer_crop_rect = framebuffer.crop_rect;
+    framebuffer_width = framebuffer.width;
+    framebuffer_height = framebuffer.height;
 
     const VAddr framebuffer_addr{framebuffer.address + framebuffer.offset};
     screen_info.was_accelerated =
@@ -480,9 +482,12 @@ void RendererOpenGL::DrawScreen(const Layout::FramebufferLayout& layout) {
     ASSERT_MSG(framebuffer_crop_rect.top == 0, "Unimplemented");
     ASSERT_MSG(framebuffer_crop_rect.left == 0, "Unimplemented");
 
+    f32 scale_u = static_cast<f32>(framebuffer_width) / static_cast<f32>(screen_info.texture.width);
+    f32 scale_v =
+        static_cast<f32>(framebuffer_height) / static_cast<f32>(screen_info.texture.height);
+
     // Scale the output by the crop width/height. This is commonly used with 1280x720 rendering
     // (e.g. handheld mode) on a 1920x1080 framebuffer.
-    f32 scale_u = 1.f, scale_v = 1.f;
     if (framebuffer_crop_rect.GetWidth() > 0) {
         scale_u = static_cast<f32>(framebuffer_crop_rect.GetWidth()) /
                   static_cast<f32>(screen_info.texture.width);

--- a/src/video_core/renderer_opengl/renderer_opengl.h
+++ b/src/video_core/renderer_opengl/renderer_opengl.h
@@ -137,6 +137,8 @@ private:
     /// Used for transforming the framebuffer orientation
     Service::android::BufferTransformFlags framebuffer_transform_flags{};
     Common::Rectangle<int> framebuffer_crop_rect;
+    u32 framebuffer_width;
+    u32 framebuffer_height;
 };
 
 } // namespace OpenGL


### PR DESCRIPTION
Addresses the same issues as #8150, and also fixes the case where the framebuffer and rendered texture dimensions are different, which caused Galaxy to be rendered squished in OpenGL even when it should not have been.