### PR TITLE
build: remove -fconcepts

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,12 +103,6 @@ else()
         -Wno-unused-parameter
     )
 
-    # TODO: Remove when we update to a GCC compiler that enables this
-    #       by default (i.e. GCC 10 or newer).
-    if (CMAKE_CXX_COMPILER_ID STREQUAL GNU)
-        add_compile_options(-fconcepts)
-    endif()
-
     if (ARCHITECTURE_x86_64)
         add_compile_options("-mcx16")
     endif()


### PR DESCRIPTION
It was needed on GCC versions not supporting `-std=c++20`, but GCC 10 and newer (required to compile yuzu) don't need it anymore

Edit: added in https://github.com/yuzu-emu/yuzu/commit/dd2ff236217cb02275cbfa66f50c265a578d1f1e, CC: @lioncash 