### PR TITLE
service: hid: Partially revert #8123

### DIFF
--- a/src/core/hle/service/hid/hid.cpp
+++ b/src/core/hle/service/hid/hid.cpp
@@ -63,6 +63,10 @@ IAppletResource::IAppletResource(Core::System& system_,
     MakeController<Controller_Gesture>(HidController::Gesture);
     MakeController<Controller_ConsoleSixAxis>(HidController::ConsoleSixAxisSensor);
 
+    // Homebrew doesn't try to activate some controllers, so we activate them by default
+    GetController<Controller_NPad>(HidController::NPad).ActivateController();
+    GetController<Controller_Touchscreen>(HidController::Touchscreen).ActivateController();
+
     GetController<Controller_Stubbed>(HidController::HomeButton).SetCommonHeaderOffset(0x4C00);
     GetController<Controller_Stubbed>(HidController::SleepButton).SetCommonHeaderOffset(0x4E00);
     GetController<Controller_Stubbed>(HidController::CaptureButton).SetCommonHeaderOffset(0x5000);


### PR DESCRIPTION
Fixes random input issues introduced in #8123 by adding the hack back. Fixes input issues with DOOM, Dark Souls remastered  and Dragon quest builders 2. 

Closes #8155 