### PR TITLE
Kernel: Track open references to KServerPort and KServerSession.

### DIFF
--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -59,6 +59,9 @@ bool SessionRequestManager::HasSessionRequestHandler(const HLERequestContext& co
 
 void SessionRequestHandler::ClientConnected(KServerSession* session) {
     session->ClientConnected(shared_from_this());
+
+    // Ensure our server session is tracked globally.
+    kernel.RegisterServerObject(session);
 }
 
 void SessionRequestHandler::ClientDisconnected(KServerSession* session) {

--- a/src/core/hle/kernel/hle_ipc.cpp
+++ b/src/core/hle/kernel/hle_ipc.cpp
@@ -51,7 +51,7 @@ bool SessionRequestManager::HasSessionRequestHandler(const HLERequestContext& co
             LOG_CRITICAL(IPC, "object_id {} is too big!", object_id);
             return false;
         }
-        return DomainHandler(object_id - 1).lock() != nullptr;
+        return !DomainHandler(object_id - 1).expired();
     } else {
         return session_handler != nullptr;
     }

--- a/src/core/hle/kernel/k_auto_object.h
+++ b/src/core/hle/kernel/k_auto_object.h
@@ -89,9 +89,7 @@ public:
     explicit KAutoObject(KernelCore& kernel_) : kernel(kernel_) {
         RegisterWithKernel();
     }
-    virtual ~KAutoObject() {
-        UnregisterWithKernel();
-    }
+    virtual ~KAutoObject() = default;
 
     static KAutoObject* Create(KAutoObject* ptr);
 
@@ -168,6 +166,7 @@ public:
         // If ref count hits zero, destroy the object.
         if (cur_ref_count - 1 == 0) {
             this->Destroy();
+            this->UnregisterWithKernel();
         }
     }
 

--- a/src/core/hle/kernel/k_server_port.cpp
+++ b/src/core/hle/kernel/k_server_port.cpp
@@ -65,6 +65,9 @@ void KServerPort::Destroy() {
 
     // Release host emulation members.
     session_handler.reset();
+
+    // Ensure that the global list tracking server objects does not hold on to a reference.
+    kernel.UnregisterServerObject(this);
 }
 
 bool KServerPort::IsSignaled() const {

--- a/src/core/hle/kernel/k_server_port.cpp
+++ b/src/core/hle/kernel/k_server_port.cpp
@@ -62,6 +62,9 @@ void KServerPort::Destroy() {
 
     // Close our reference to our parent.
     parent->Close();
+
+    // Release host emulation members.
+    session_handler.reset();
 }
 
 bool KServerPort::IsSignaled() const {

--- a/src/core/hle/kernel/k_server_session.cpp
+++ b/src/core/hle/kernel/k_server_session.cpp
@@ -49,6 +49,9 @@ void KServerSession::Destroy() {
 
     // Release host emulation members.
     manager.reset();
+
+    // Ensure that the global list tracking server objects does not hold on to a reference.
+    kernel.UnregisterServerObject(this);
 }
 
 void KServerSession::OnClientClosed() {

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -195,6 +195,14 @@ public:
     /// Opens a port to a service previously registered with RegisterNamedService.
     KClientPort* CreateNamedServicePort(std::string name);
 
+    /// Registers a server session or port with the gobal emulation state, to be freed on shutdown.
+    /// This is necessary because we do not emulate processes for HLE sessions and ports.
+    void RegisterServerObject(KAutoObject* server_object);
+
+    /// Unregisters a server session or port previously registered with RegisterServerSession when
+    /// it was destroyed during the current emulation session.
+    void UnregisterServerObject(KAutoObject* server_object);
+
     /// Registers all kernel objects with the global emulation state, this is purely for tracking
     /// leaks after emulation has been shutdown.
     void RegisterKernelObject(KAutoObject* object);

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -153,6 +153,7 @@ ResultVal<Kernel::KClientSession*> SM::GetServiceImpl(Kernel::HLERequestContext&
     auto& port = port_result.Unwrap();
     SCOPE_EXIT({ port->GetClientPort().Close(); });
 
+    kernel.RegisterServerObject(&port->GetServerPort());
 
     // Create a new session.
     Kernel::KClientSession* session{};

--- a/src/core/hle/service/sm/sm.cpp
+++ b/src/core/hle/service/sm/sm.cpp
@@ -153,7 +153,6 @@ ResultVal<Kernel::KClientSession*> SM::GetServiceImpl(Kernel::HLERequestContext&
     auto& port = port_result.Unwrap();
     SCOPE_EXIT({ port->GetClientPort().Close(); });
 
-    server_ports.emplace_back(&port->GetServerPort());
 
     // Create a new session.
     Kernel::KClientSession* session{};
@@ -224,10 +223,6 @@ SM::SM(ServiceManager& service_manager_, Core::System& system_)
     });
 }
 
-SM::~SM() {
-    for (auto& server_port : server_ports) {
-        server_port->Close();
-    }
-}
+SM::~SM() = default;
 
 } // namespace Service::SM

--- a/src/core/hle/service/sm/sm.h
+++ b/src/core/hle/service/sm/sm.h
@@ -22,7 +22,6 @@ class KClientPort;
 class KClientSession;
 class KernelCore;
 class KPort;
-class KServerPort;
 class SessionRequestHandler;
 } // namespace Kernel
 
@@ -48,7 +47,6 @@ private:
     ServiceManager& service_manager;
     bool is_initialized{};
     Kernel::KernelCore& kernel;
-    std::vector<Kernel::KServerPort*> server_ports;
 };
 
 class ServiceManager {


### PR DESCRIPTION
Since we do not emulate multi-process, these need to me managed somewhere. This adds a single place where we can register/unregister open ports and sessions, and ensure they are closed when we tear down all services and the kernel. This fixes a regression introduced by #8005, as that removed KServerSession tracking, which resulted in services not getting their dtor called. 

We still had such code in place for KServerPort. But instead of keeping the duplication, we have a single place for all KServer* tracking now.

Supersedes #8136 and #8108.