### PR TITLE
a workaround if the mouse cursor leaves the rendering window in panning mode

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3595,7 +3595,15 @@ void GMainWindow::dragMoveEvent(QDragMoveEvent* event) {
 
 void GMainWindow::leaveEvent(QEvent* event) {
     if (Settings::values.mouse_panning) {
-        mouse_center_timer.start();
+        const QRect& rect = geometry();
+        QPoint position = QCursor::pos();
+
+        qint32 x = qBound(rect.left(), position.x(), rect.right());
+        qint32 y = qBound(rect.top(), position.y(), rect.bottom());
+        /* only start the timer if the mouse has left the window bound, the leave event is also triggered when the window looses focus */
+        if (x != position.x() || y != position.y()) {
+            mouse_center_timer.start();
+        }
         event->accept();
     }
 }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3306,16 +3306,9 @@ void GMainWindow::ShowMouseCursor() {
 }
 
 void GMainWindow::CenterMouseCursor() {
-    static bool logged = false;
     if (emu_thread == nullptr || !Settings::values.mouse_panning) {
         mouse_center_timer.stop();
-        logged = false;
-        LOG_INFO(Debug, "Stopped centering cursor!");
         return;
-    }
-    if (!logged) {
-        LOG_INFO(Debug, "Started centering cursor!");
-        logged = true;
     }
     const int center_x = render_window->width() / 2;
     const int center_y = render_window->height() / 2;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3310,6 +3310,10 @@ void GMainWindow::CenterMouseCursor() {
         mouse_center_timer.stop();
         return;
     }
+   if (!this->isActiveWindow()) {
+        mouse_center_timer.stop();
+        return;
+    }
     const int center_x = render_window->width() / 2;
     const int center_y = render_window->height() / 2;
 

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3600,7 +3600,8 @@ void GMainWindow::leaveEvent(QEvent* event) {
 
         qint32 x = qBound(rect.left(), position.x(), rect.right());
         qint32 y = qBound(rect.top(), position.y(), rect.bottom());
-        /* only start the timer if the mouse has left the window bound, the leave event is also triggered when the window looses focus */
+        // Only start the timer if the mouse has left the window bound.
+        // The leave event is also triggered when the window looses focus.
         if (x != position.x() || y != position.y()) {
             mouse_center_timer.start();
         }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3310,7 +3310,7 @@ void GMainWindow::CenterMouseCursor() {
         mouse_center_timer.stop();
         return;
     }
-   if (!this->isActiveWindow()) {
+    if (!this->isActiveWindow()) {
         mouse_center_timer.stop();
         return;
     }

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -328,6 +328,7 @@ private:
     void UpdateUISettings();
     void HideMouseCursor();
     void ShowMouseCursor();
+    void CenterMouseCursor();
     void OpenURL(const QUrl& url);
     void LoadTranslation();
     void OpenPerGameConfiguration(u64 title_id, const std::string& file_name);
@@ -372,6 +373,7 @@ private:
     bool auto_paused = false;
     bool auto_muted = false;
     QTimer mouse_hide_timer;
+    QTimer mouse_center_timer;
 
     // FS
     std::shared_ptr<FileSys::VfsFilesystem> vfs;
@@ -418,4 +420,5 @@ protected:
     void dropEvent(QDropEvent* event) override;
     void dragEnterEvent(QDragEnterEvent* event) override;
     void dragMoveEvent(QDragMoveEvent* event) override;
+    void leaveEvent(QEvent* event) override;
 };


### PR DESCRIPTION
If the mouse DPI is high enough or the rendering window size is small enough the mouse cursor can leave the window, which can cause some annoying behavior, just in case a workaround for that issue.