### PR TITLE
hle: kernel: Invalidate icache in UnmapProcessMemory (fixes #8174)

### DIFF
--- a/src/core/hle/kernel/k_page_table.cpp
+++ b/src/core/hle/kernel/k_page_table.cpp
@@ -563,6 +563,8 @@ ResultCode KPageTable::UnmapProcessMemory(VAddr dst_addr, std::size_t size,
     block_manager->Update(dst_addr, num_pages, KMemoryState::Free, KMemoryPermission::None,
                           KMemoryAttribute::None);
 
+    system.InvalidateCpuInstructionCaches();
+
     return ResultSuccess;
 }
 


### PR DESCRIPTION
Thanks to @bunnei for the hint!

Fixes #8174