### PR TITLE
hle: kernel: Invalidate entire icache in UnmapProcessMemory and UnmapCodeMemory (fixes #8174)

### DIFF
--- a/src/core/hle/kernel/k_page_table.h
+++ b/src/core/hle/kernel/k_page_table.h
@@ -26,6 +26,8 @@ class KMemoryBlockManager;
 
 class KPageTable final {
 public:
+    enum class ICacheInvalidationStrategy : u32 { InvalidateRange, InvalidateAll };
+
     YUZU_NON_COPYABLE(KPageTable);
     YUZU_NON_MOVEABLE(KPageTable);
 
@@ -38,7 +40,8 @@ public:
     ResultCode MapProcessCode(VAddr addr, std::size_t pages_count, KMemoryState state,
                               KMemoryPermission perm);
     ResultCode MapCodeMemory(VAddr dst_address, VAddr src_address, std::size_t size);
-    ResultCode UnmapCodeMemory(VAddr dst_address, VAddr src_address, std::size_t size);
+    ResultCode UnmapCodeMemory(VAddr dst_address, VAddr src_address, std::size_t size,
+                               ICacheInvalidationStrategy icache_invalidation_strategy);
     ResultCode UnmapProcessMemory(VAddr dst_addr, std::size_t size, KPageTable& src_page_table,
                                   VAddr src_addr);
     ResultCode MapPhysicalMemory(VAddr addr, std::size_t size);

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1713,7 +1713,8 @@ static ResultCode UnmapProcessCodeMemory(Core::System& system, Handle process_ha
         return ResultInvalidMemoryRegion;
     }
 
-    return page_table.UnmapCodeMemory(dst_address, src_address, size);
+    return page_table.UnmapCodeMemory(dst_address, src_address, size,
+                                      KPageTable::ICacheInvalidationStrategy::InvalidateAll);
 }
 
 /// Exits the current process


### PR DESCRIPTION
Thanks to @bunnei for figuring this out!

- Adds icache invalidation to `UnmapProcessMemory`
- Forces invalidation of the entire icache in `UnmapCodeMemory`
  - icache invalidation is still constrained to a range when unloading NROs to avoid potential performance regressions in Super Smash Bros. Ultimate

Fixes #8174