### PR TITLE
dynarmic: Fix race when switching page tables

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_32.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <unordered_map>
 
@@ -80,7 +81,11 @@ private:
     std::shared_ptr<DynarmicCP15> cp15;
     std::size_t core_index;
     DynarmicExclusiveMonitor& exclusive_monitor;
-    std::shared_ptr<Dynarmic::A32::Jit> jit;
+
+    std::shared_ptr<Dynarmic::A32::Jit> null_jit;
+
+    // A raw pointer here is fine; we never delete Jit instances.
+    std::atomic<Dynarmic::A32::Jit*> jit;
 
     // SVC callback
     u32 svc_swi{};

--- a/src/core/arm/dynarmic/arm_dynarmic_64.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <unordered_map>
 
@@ -74,7 +75,10 @@ private:
     std::size_t core_index;
     DynarmicExclusiveMonitor& exclusive_monitor;
 
-    std::shared_ptr<Dynarmic::A64::Jit> jit;
+    std::shared_ptr<Dynarmic::A64::Jit> null_jit;
+
+    // A raw pointer here is fine; we never delete Jit instances.
+    std::atomic<Dynarmic::A64::Jit*> jit;
 
     // SVC callback
     u32 svc_swi{};


### PR DESCRIPTION
Addresses #8185.

Zero performance impact. (`std::atomic::load` is free.)

A proper fix would be to make it a core-option but that's awaiting refactor.