### PR TITLE
ui: Set Link Color when setting theme

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3652,6 +3652,16 @@ void GMainWindow::UpdateUITheme() {
         setStyleSheet({});
     }
 
+    QPalette new_pal(qApp->palette());
+    if (UISettings::IsDarkTheme()) {
+        new_pal.setColor(QPalette::Text, QColor(255, 255, 255, 255));
+        new_pal.setColor(QPalette::Link, QColor(0, 190, 255, 255));
+    } else {
+        new_pal.setColor(QPalette::Text, QColor(0, 0, 0, 255));
+        new_pal.setColor(QPalette::Link, QColor(0, 140, 200, 255));
+    }
+    qApp->setPalette(new_pal);
+
     QIcon::setThemeName(current_theme);
     QIcon::setThemeSearchPaths(theme_paths);
 }

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3654,10 +3654,8 @@ void GMainWindow::UpdateUITheme() {
 
     QPalette new_pal(qApp->palette());
     if (UISettings::IsDarkTheme()) {
-        new_pal.setColor(QPalette::Text, QColor(255, 255, 255, 255));
         new_pal.setColor(QPalette::Link, QColor(0, 190, 255, 255));
     } else {
-        new_pal.setColor(QPalette::Text, QColor(0, 0, 0, 255));
         new_pal.setColor(QPalette::Link, QColor(0, 140, 200, 255));
     }
     qApp->setPalette(new_pal);

--- a/src/yuzu/uisettings.cpp
+++ b/src/yuzu/uisettings.cpp
@@ -15,6 +15,14 @@ const Themes themes{{
     {"Midnight Blue Colorful", "colorful_midnight_blue"},
 }};
 
+bool IsDarkTheme() {
+    const auto& theme = UISettings::values.theme;
+    return theme == QStringLiteral("qdarkstyle") ||
+           theme == QStringLiteral("qdarkstyle_midnight_blue") ||
+           theme == QStringLiteral("colorful_dark") ||
+           theme == QStringLiteral("colorful_midnight_blue");
+}
+
 Values values = {};
 
 } // namespace UISettings

--- a/src/yuzu/uisettings.h
+++ b/src/yuzu/uisettings.h
@@ -17,6 +17,8 @@
 
 namespace UISettings {
 
+bool IsDarkTheme();
+
 struct ContextualShortcut {
     QString keyseq;
     QString controller_keyseq;


### PR DESCRIPTION
Long story short, QT doesn't allow the link colors to be set via their stylesheets.

There are two ways to work with this, specify the color manually for every link (See the About dialog) The other way is to change the default palette.

IsDarkTheme is copy/pasted from src/yuzu/debugger/wait_tree.cpp

I considered setting the link color to be the same light blue as in the license dialog, but with a bit of testing I found that it wasn't a good fit. I lightened it for the dark theme, and darkened it for the light theme. 

Before
![image](https://user-images.githubusercontent.com/190571/162640079-e52dba4a-a48d-4f7a-b5b6-97a16e4c8cff.png)

After
![image](https://user-images.githubusercontent.com/190571/162640261-73fd8ee8-d6b1-4fd9-ba77-42425615335a.png)
