### PR TITLE
bootmanager: Don't create another screenshot request if previous one is not done yet

### DIFF
--- a/src/video_core/renderer_base.cpp
+++ b/src/video_core/renderer_base.cpp
@@ -26,6 +26,10 @@ void RendererBase::UpdateCurrentFramebufferLayout() {
     render_window.UpdateCurrentFramebufferLayout(layout.width, layout.height);
 }
 
+bool RendererBase::IsScreenshotPending() const {
+    return renderer_settings.screenshot_requested;
+}
+
 void RendererBase::RequestScreenshot(void* data, std::function<void(bool)> callback,
                                      const Layout::FramebufferLayout& layout) {
     if (renderer_settings.screenshot_requested) {

--- a/src/video_core/renderer_base.h
+++ b/src/video_core/renderer_base.h
@@ -83,6 +83,9 @@ public:
     /// Refreshes the settings common to all renderers
     void RefreshBaseSettings();
 
+    /// Returns true if a screenshot is being processed
+    bool IsScreenshotPending() const;
+
     /// Request a screenshot of the next frame
     void RequestScreenshot(void* data, std::function<void(bool)> callback,
                            const Layout::FramebufferLayout& layout);

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -933,6 +933,12 @@ void GRenderWindow::CaptureScreenshot(const QString& screenshot_path) {
     auto& renderer = system.Renderer();
     const f32 res_scale = Settings::values.resolution_info.up_factor;
 
+    if (renderer.IsScreenshotPending()) {
+        LOG_WARNING(Render,
+                    "A screenshot is already requested or in progress, ignoring the request");
+        return;
+    }
+
     const Layout::FramebufferLayout layout{Layout::FrameLayoutFromResolutionScale(res_scale)};
     screenshot_image = QImage(QSize(layout.width, layout.height), QImage::Format_RGB32);
     renderer.RequestScreenshot(


### PR DESCRIPTION
It's posible to make yuzu crash if on the loading splash screen you spam the screenshot button.  This was due to the callback being destroyed before it was able to reply. To avoid this issue we avoid requesting a screenshot at all if the backend is not ready