### PR TITLE
service: sfdnsres: unbreak build on FreeBSD

### DIFF
--- a/src/core/hle/service/sockets/sfdnsres.cpp
+++ b/src/core/hle/service/sockets/sfdnsres.cpp
@@ -18,7 +18,11 @@
 #elif YUZU_UNIX
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <netinet/in.h>
 #include <sys/socket.h>
+#ifndef EAI_NODATA
+#define EAI_NODATA EAI_NONAME
+#endif
 #endif
 
 namespace Service::Sockets {


### PR DESCRIPTION
Regressed by #8171 (82d46a974ad4). See https://github.com/freebsd/freebsd-src/commit/37b3e941672a + https://github.com/freebsd/freebsd-src/commit/27f9f4194284. Affects DragonFly and FreeBSD but not NetBSD and OpenBSD.

```c++
src/core/hle/service/sockets/sfdnsres.cpp: In function 'Service::Sockets::NetDbError Service::Sockets::AddrInfoErrorToNetDbError(s32)':
src/core/hle/service/sockets/sfdnsres.cpp:66:10: error: 'EAI_NODATA' was not declared in this scope; did you mean 'EAI_NONAME'?
   66 |     case EAI_NODATA:
      |          ^~~~~~~~~~
      |          EAI_NONAME
src/core/hle/service/sockets/sfdnsres.cpp: In function 'std::vector<unsigned char> Service::Sockets::SerializeAddrInfo(const addrinfo*, s32, std::string_view)':
src/core/hle/service/sockets/sfdnsres.cpp:127:53: error: 'sockaddr_in' does not name a type; did you mean 'SockAddrIn'?
  127 |                 const auto addr = *reinterpret_cast<sockaddr_in*>(current->ai_addr);
      |                                                     ^~~~~~~~~~~
      |                                                     SockAddrIn
src/core/hle/service/sockets/sfdnsres.cpp:127:64: error: expected '>' before '*' token
  127 |                 const auto addr = *reinterpret_cast<sockaddr_in*>(current->ai_addr);
      |                                                                ^
src/core/hle/service/sockets/sfdnsres.cpp:127:64: error: expected '(' before '*' token
  127 |                 const auto addr = *reinterpret_cast<sockaddr_in*>(current->ai_addr);
      |                                                                ^
      |                                                                (
src/core/hle/service/sockets/sfdnsres.cpp:127:65: error: expected primary-expression before '>' token
  127 |                 const auto addr = *reinterpret_cast<sockaddr_in*>(current->ai_addr);
      |                                                                 ^
src/core/hle/service/sockets/sfdnsres.cpp:127:84: error: expected ')' before ';' token
  127 |                 const auto addr = *reinterpret_cast<sockaddr_in*>(current->ai_addr);
      |                                                                                    ^
      |                                                                                    )
src/core/hle/service/sockets/sfdnsres.cpp:148:53: error: 'sockaddr_in6' does not name a type; did you mean 'SockAddrIn6'?
  148 |                 const auto addr = *reinterpret_cast<sockaddr_in6*>(current->ai_addr);
      |                                                     ^~~~~~~~~~~~
      |                                                     SockAddrIn6
src/core/hle/service/sockets/sfdnsres.cpp:148:65: error: expected '>' before '*' token
  148 |                 const auto addr = *reinterpret_cast<sockaddr_in6*>(current->ai_addr);
      |                                                                 ^
src/core/hle/service/sockets/sfdnsres.cpp:148:65: error: expected '(' before '*' token
  148 |                 const auto addr = *reinterpret_cast<sockaddr_in6*>(current->ai_addr);
      |                                                                 ^
      |                                                                 (
src/core/hle/service/sockets/sfdnsres.cpp:148:66: error: expected primary-expression before '>' token
  148 |                 const auto addr = *reinterpret_cast<sockaddr_in6*>(current->ai_addr);
      |                                                                  ^
src/core/hle/service/sockets/sfdnsres.cpp:148:85: error: expected ')' before ';' token
  148 |                 const auto addr = *reinterpret_cast<sockaddr_in6*>(current->ai_addr);
      |                                                                                     ^
      |                                                                                     )
```
