### PR TITLE
ui: Fix Game Compatibility list translations

### DIFF
--- a/src/yuzu/compatdb.ui
+++ b/src/yuzu/compatdb.ui
@@ -86,7 +86,7 @@
     <item row="4" column="0">
      <widget class="QRadioButton" name="radioButton_Great">
       <property name="text">
-       <string>Great </string>
+       <string>Great</string>
       </property>
      </widget>
     </item>

--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -25,6 +25,7 @@
 #include "yuzu/configuration/configure_ui.h"
 #include "yuzu/configuration/configure_web.h"
 #include "yuzu/hotkeys.h"
+#include "yuzu/uisettings.h"
 
 ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry,
                                  InputCommon::InputSubsystem* input_subsystem,
@@ -169,6 +170,8 @@ void ConfigureDialog::PopulateSelectionList() {
 
 void ConfigureDialog::OnLanguageChanged(const QString& locale) {
     emit LanguageChanged(locale);
+    //  Reloading the game list is needed to force retranslation.
+    UISettings::values.is_game_list_reload_pending = true;
     // first apply the configuration, and then restore the display
     ApplyConfiguration();
     RetranslateUI();

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -164,8 +164,8 @@ public:
         }
         const CompatStatus& status = iterator->second;
         setData(compatibility, CompatNumberRole);
-        setText(QObject::tr(status.text));
-        setToolTip(QObject::tr(status.tooltip));
+        setText(tr(status.text));
+        setToolTip(tr(status.tooltip));
         setData(CreateCirclePixmapFromColor(status.color), Qt::DecorationRole);
     }
 


### PR DESCRIPTION
Reported by GillianMC on Discord.  Translations of the states, such as "Perfect" and "Bad" are done, but not used.

Looks to be a small quirk in the QT API.



Technical detail
setText(QObject::tr(status.text));
bringing up QObject broke the connection to the GameListItemCompat class.

Also related, certain strings are duplicated in translation, which can confuse translators. 
QT_TR_NOOP("Perfect") -> QT_TRANSLATE_NOOP("CompatDB", "Perfect")

If you're wondering about "Not Tested" being left alone, its not possible to submit a compatibility report stating that you didn't test the game.

Also I thought removing the space from `Great` in src/yuzu/compatdb.ui would disconnect the translation but things are still Gut 

![image](https://user-images.githubusercontent.com/190571/163291809-b34695f5-f5d5-425d-9b7d-c193041b388b.png)
