### PR TITLE
dynarmic: Exit Run on every interrupt and after every service call

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -227,14 +227,9 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
 }
 
 void ARM_Dynarmic_32::Run() {
-    while (true) {
-        const auto hr = jit->Run();
-        if (Has(hr, svc_call)) {
-            Kernel::Svc::Call(system, svc_swi);
-        }
-        if (Has(hr, break_loop) || !uses_wall_clock) {
-            break;
-        }
+    const auto hr = jit->Run();
+    if (Has(hr, svc_call)) {
+        Kernel::Svc::Call(system, svc_swi);
     }
 }
 

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -288,14 +288,9 @@ std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* 
 }
 
 void ARM_Dynarmic_64::Run() {
-    while (true) {
-        const auto hr = jit->Run();
-        if (Has(hr, svc_call)) {
-            Kernel::Svc::Call(system, svc_swi);
-        }
-        if (Has(hr, break_loop) || !uses_wall_clock) {
-            break;
-        }
+    const auto hr = jit->Run();
+    if (Has(hr, svc_call)) {
+        Kernel::Svc::Call(system, svc_swi);
     }
 }
 


### PR DESCRIPTION
I am beginning to question the accuracy of the original code in deciding when returning is appropriate. Would it be possible for someone who has actually reverse engineered and understood HOS's rescheduling algorithm (i.e. @bunnei) to please confirm this?

Here we return from Run after any interrupt, cache invalidation, or svc call. Note that this currently also returns on every cache invalidation as well, which is excessive and clearly incorrect.