### PR TITLE
service: hid: Improve accuracy of sixaxis functions

### DIFF
--- a/src/core/hid/hid_types.h
+++ b/src/core/hid/hid_types.h
@@ -491,9 +491,10 @@ struct SixAxisSensorHandle {
 };
 static_assert(sizeof(SixAxisSensorHandle) == 4, "SixAxisSensorHandle is an invalid size");
 
+// These parameters seem related to how much gyro/accelerometer is used
 struct SixAxisSensorFusionParameters {
-    f32 parameter1;
-    f32 parameter2;
+    f32 parameter1{0.03f}; // Range 0.0 to 1.0, default 0.03
+    f32 parameter2{0.4f};  // Default 0.4
 };
 static_assert(sizeof(SixAxisSensorFusionParameters) == 8,
               "SixAxisSensorFusionParameters is an invalid size");

--- a/src/core/hle/service/hid/errors.h
+++ b/src/core/hle/service/hid/errors.h
@@ -8,6 +8,8 @@
 
 namespace Service::HID {
 
-constexpr ResultCode ERR_NPAD_NOT_CONNECTED{ErrorModule::HID, 710};
+constexpr ResultCode NpadInvalidHandle{ErrorModule::HID, 100};
+constexpr ResultCode InvalidSixAxisFusionRange{ErrorModule::HID, 423};
+constexpr ResultCode NpadNotConnected{ErrorModule::HID, 710};
 
 } // namespace Service::HID

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -103,6 +103,7 @@ private:
     void DeactivateSixAxisSensor(Kernel::HLERequestContext& ctx);
     void StartSixAxisSensor(Kernel::HLERequestContext& ctx);
     void StopSixAxisSensor(Kernel::HLERequestContext& ctx);
+    void IsSixAxisSensorFusionEnabled(Kernel::HLERequestContext& ctx);
     void EnableSixAxisSensorFusion(Kernel::HLERequestContext& ctx);
     void SetSixAxisSensorFusionParameters(Kernel::HLERequestContext& ctx);
     void GetSixAxisSensorFusionParameters(Kernel::HLERequestContext& ctx);


### PR DESCRIPTION
The following fixes are obtained from unit test on HW and RE from each sixaxis function. This is the first batch of many PR aiming to solve yuzu inaccuracies on the HID side. Hopefully some games will be fixed.

Implements `IsSixAxisSensorFusionEnabled` verified on homebrew.