### PR TITLE
service: hid: Access shared memory directly

### DIFF
--- a/src/core/hid/hid_types.h
+++ b/src/core/hid/hid_types.h
@@ -316,27 +316,27 @@ static_assert(sizeof(TouchAttribute) == 0x4, "TouchAttribute is an invalid size"
 
 // This is nn::hid::TouchState
 struct TouchState {
-    u64 delta_time;
-    TouchAttribute attribute;
-    u32 finger;
-    Common::Point<u32> position;
-    u32 diameter_x;
-    u32 diameter_y;
-    u32 rotation_angle;
+    u64 delta_time{};
+    TouchAttribute attribute{};
+    u32 finger{};
+    Common::Point<u32> position{};
+    u32 diameter_x{};
+    u32 diameter_y{};
+    u32 rotation_angle{};
 };
 static_assert(sizeof(TouchState) == 0x28, "Touchstate is an invalid size");
 
 // This is nn::hid::NpadControllerColor
 struct NpadControllerColor {
-    u32 body;
-    u32 button;
+    u32 body{};
+    u32 button{};
 };
 static_assert(sizeof(NpadControllerColor) == 8, "NpadControllerColor is an invalid size");
 
 // This is nn::hid::AnalogStickState
 struct AnalogStickState {
-    s32 x;
-    s32 y;
+    s32 x{};
+    s32 y{};
 };
 static_assert(sizeof(AnalogStickState) == 8, "AnalogStickState is an invalid size");
 
@@ -354,10 +354,10 @@ static_assert(sizeof(NpadBatteryLevel) == 0x4, "NpadBatteryLevel is an invalid s
 
 // This is nn::hid::system::NpadPowerInfo
 struct NpadPowerInfo {
-    bool is_powered;
-    bool is_charging;
+    bool is_powered{};
+    bool is_charging{};
     INSERT_PADDING_BYTES(0x6);
-    NpadBatteryLevel battery_level;
+    NpadBatteryLevel battery_level{8};
 };
 static_assert(sizeof(NpadPowerInfo) == 0xC, "NpadPowerInfo is an invalid size");
 
@@ -474,8 +474,8 @@ static_assert(sizeof(DebugPadButton) == 0x4, "DebugPadButton is an invalid size"
 
 // This is nn::hid::ConsoleSixAxisSensorHandle
 struct ConsoleSixAxisSensorHandle {
-    u8 unknown_1;
-    u8 unknown_2;
+    u8 unknown_1{};
+    u8 unknown_2{};
     INSERT_PADDING_BYTES_NOINIT(2);
 };
 static_assert(sizeof(ConsoleSixAxisSensorHandle) == 4,
@@ -483,9 +483,9 @@ static_assert(sizeof(ConsoleSixAxisSensorHandle) == 4,
 
 // This is nn::hid::SixAxisSensorHandle
 struct SixAxisSensorHandle {
-    NpadStyleIndex npad_type;
-    u8 npad_id;
-    DeviceIndex device_index;
+    NpadStyleIndex npad_type{NpadStyleIndex::None};
+    u8 npad_id{};
+    DeviceIndex device_index{DeviceIndex::None};
     INSERT_PADDING_BYTES_NOINIT(1);
 };
 static_assert(sizeof(SixAxisSensorHandle) == 4, "SixAxisSensorHandle is an invalid size");
@@ -500,19 +500,19 @@ static_assert(sizeof(SixAxisSensorFusionParameters) == 8,
 
 // This is nn::hid::VibrationDeviceHandle
 struct VibrationDeviceHandle {
-    NpadStyleIndex npad_type;
-    u8 npad_id;
-    DeviceIndex device_index;
+    NpadStyleIndex npad_type{NpadStyleIndex::None};
+    u8 npad_id{};
+    DeviceIndex device_index{DeviceIndex::None};
     INSERT_PADDING_BYTES_NOINIT(1);
 };
 static_assert(sizeof(VibrationDeviceHandle) == 4, "SixAxisSensorHandle is an invalid size");
 
 // This is nn::hid::VibrationValue
 struct VibrationValue {
-    f32 low_amplitude;
-    f32 low_frequency;
-    f32 high_amplitude;
-    f32 high_frequency;
+    f32 low_amplitude{};
+    f32 low_frequency{};
+    f32 high_amplitude{};
+    f32 high_frequency{};
 };
 static_assert(sizeof(VibrationValue) == 0x10, "VibrationValue has incorrect size.");
 
@@ -561,7 +561,7 @@ static_assert(sizeof(KeyboardAttribute) == 0x4, "KeyboardAttribute is an invalid
 // This is nn::hid::KeyboardKey
 struct KeyboardKey {
     // This should be a 256 bit flag
-    std::array<u8, 32> key;
+    std::array<u8, 32> key{};
 };
 static_assert(sizeof(KeyboardKey) == 0x20, "KeyboardKey is an invalid size");
 
@@ -590,16 +590,16 @@ static_assert(sizeof(MouseAttribute) == 0x4, "MouseAttribute is an invalid size"
 
 // This is nn::hid::detail::MouseState
 struct MouseState {
-    s64 sampling_number;
-    s32 x;
-    s32 y;
-    s32 delta_x;
-    s32 delta_y;
+    s64 sampling_number{};
+    s32 x{};
+    s32 y{};
+    s32 delta_x{};
+    s32 delta_y{};
     // Axis Order in HW is switched for the wheel
-    s32 delta_wheel_y;
-    s32 delta_wheel_x;
-    MouseButton button;
-    MouseAttribute attribute;
+    s32 delta_wheel_y{};
+    s32 delta_wheel_x{};
+    MouseButton button{};
+    MouseAttribute attribute{};
 };
 static_assert(sizeof(MouseState) == 0x28, "MouseState is an invalid size");
 

--- a/src/core/hle/service/hid/controllers/console_sixaxis.cpp
+++ b/src/core/hle/service/hid/controllers/console_sixaxis.cpp
@@ -15,8 +15,8 @@ Controller_ConsoleSixAxis::Controller_ConsoleSixAxis(Core::HID::HIDCore& hid_cor
     console = hid_core.GetEmulatedConsole();
     static_assert(SHARED_MEMORY_OFFSET + sizeof(ConsoleSharedMemory) < shared_memory_size,
                   "ConsoleSharedMemory is bigger than the shared memory");
-    shared_memory =
-        std::construct_at(reinterpret_cast<ConsoleSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
+    shared_memory = std::construct_at(
+        reinterpret_cast<ConsoleSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
 }
 
 Controller_ConsoleSixAxis::~Controller_ConsoleSixAxis() = default;

--- a/src/core/hle/service/hid/controllers/console_sixaxis.cpp
+++ b/src/core/hle/service/hid/controllers/console_sixaxis.cpp
@@ -9,9 +9,14 @@
 namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3C200;
 
-Controller_ConsoleSixAxis::Controller_ConsoleSixAxis(Core::HID::HIDCore& hid_core_)
+Controller_ConsoleSixAxis::Controller_ConsoleSixAxis(Core::HID::HIDCore& hid_core_,
+                                                     u8* raw_shared_memory_)
     : ControllerBase{hid_core_} {
     console = hid_core.GetEmulatedConsole();
+    static_assert(SHARED_MEMORY_OFFSET + sizeof(ConsoleSharedMemory) < shared_memory_size,
+                  "ConsoleSharedMemory is bigger than the shared memory");
+    shared_memory =
+        std::construct_at(reinterpret_cast<ConsoleSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
 }
 
 Controller_ConsoleSixAxis::~Controller_ConsoleSixAxis() = default;
@@ -20,8 +25,7 @@ void Controller_ConsoleSixAxis::OnInit() {}
 
 void Controller_ConsoleSixAxis::OnRelease() {}
 
-void Controller_ConsoleSixAxis::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
-                                         std::size_t size) {
+void Controller_ConsoleSixAxis::OnUpdate(const Core::Timing::CoreTiming& core_timing) {
     if (!IsControllerActivated() || !is_transfer_memory_set) {
         seven_sixaxis_lifo.buffer_count = 0;
         seven_sixaxis_lifo.buffer_tail = 0;
@@ -48,13 +52,11 @@ void Controller_ConsoleSixAxis::OnUpdate(const Core::Timing::CoreTiming& core_ti
         -motion_status.quaternion.xyz.z,
     };
 
-    console_six_axis.sampling_number++;
-    console_six_axis.is_seven_six_axis_sensor_at_rest = motion_status.is_at_rest;
-    console_six_axis.verticalization_error = motion_status.verticalization_error;
-    console_six_axis.gyro_bias = motion_status.gyro_bias;
+    shared_memory->sampling_number++;
+    shared_memory->is_seven_six_axis_sensor_at_rest = motion_status.is_at_rest;
+    shared_memory->verticalization_error = motion_status.verticalization_error;
+    shared_memory->gyro_bias = motion_status.gyro_bias;
 
-    // Update console six axis shared memory
-    std::memcpy(data + SHARED_MEMORY_OFFSET, &console_six_axis, sizeof(console_six_axis));
     // Update seven six axis transfer memory
     seven_sixaxis_lifo.WriteNextEntry(next_seven_sixaxis_state);
     std::memcpy(transfer_memory, &seven_sixaxis_lifo, sizeof(seven_sixaxis_lifo));

--- a/src/core/hle/service/hid/controllers/console_sixaxis.h
+++ b/src/core/hle/service/hid/controllers/console_sixaxis.h
@@ -17,7 +17,7 @@ class EmulatedConsole;
 namespace Service::HID {
 class Controller_ConsoleSixAxis final : public ControllerBase {
 public:
-    explicit Controller_ConsoleSixAxis(Core::HID::HIDCore& hid_core_);
+    explicit Controller_ConsoleSixAxis(Core::HID::HIDCore& hid_core_, u8* raw_shared_memory_);
     ~Controller_ConsoleSixAxis() override;
 
     // Called when the controller is initialized
@@ -27,7 +27,7 @@ public:
     void OnRelease() override;
 
     // When the controller is requesting an update for the shared memory
-    void OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data, size_t size) override;
+    void OnUpdate(const Core::Timing::CoreTiming& core_timing) override;
 
     // Called on InitializeSevenSixAxisSensor
     void SetTransferMemoryPointer(u8* t_mem);
@@ -61,12 +61,13 @@ private:
     Lifo<SevenSixAxisState, 0x21> seven_sixaxis_lifo{};
     static_assert(sizeof(seven_sixaxis_lifo) == 0xA70, "SevenSixAxisState is an invalid size");
 
+    ConsoleSharedMemory* shared_memory;
+
     Core::HID::EmulatedConsole* console;
     u8* transfer_memory = nullptr;
     bool is_transfer_memory_set = false;
     u64 last_saved_timestamp{};
     u64 last_global_timestamp{};
-    ConsoleSharedMemory console_six_axis{};
     SevenSixAxisState next_seven_sixaxis_state{};
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/console_sixaxis.h
+++ b/src/core/hle/service/hid/controllers/console_sixaxis.h
@@ -61,13 +61,13 @@ private:
     Lifo<SevenSixAxisState, 0x21> seven_sixaxis_lifo{};
     static_assert(sizeof(seven_sixaxis_lifo) == 0xA70, "SevenSixAxisState is an invalid size");
 
-    ConsoleSharedMemory* shared_memory;
-
-    Core::HID::EmulatedConsole* console;
+    SevenSixAxisState next_seven_sixaxis_state{};
     u8* transfer_memory = nullptr;
+    ConsoleSharedMemory* shared_memory = nullptr;
+    Core::HID::EmulatedConsole* console = nullptr;
+
     bool is_transfer_memory_set = false;
     u64 last_saved_timestamp{};
     u64 last_global_timestamp{};
-    SevenSixAxisState next_seven_sixaxis_state{};
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/controller_base.h
+++ b/src/core/hle/service/hid/controllers/controller_base.h
@@ -26,12 +26,10 @@ public:
     virtual void OnRelease() = 0;
 
     // When the controller is requesting an update for the shared memory
-    virtual void OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
-                          std::size_t size) = 0;
+    virtual void OnUpdate(const Core::Timing::CoreTiming& core_timing) = 0;
 
     // When the controller is requesting a motion update for the shared memory
-    virtual void OnMotionUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
-                                std::size_t size) {}
+    virtual void OnMotionUpdate(const Core::Timing::CoreTiming& core_timing) {}
 
     void ActivateController();
 
@@ -40,6 +38,7 @@ public:
     bool IsControllerActivated() const;
 
     static const std::size_t hid_entry_count = 17;
+    static const std::size_t shared_memory_size = 0x40000;
 
 protected:
     bool is_activated{false};

--- a/src/core/hle/service/hid/controllers/debug_pad.h
+++ b/src/core/hle/service/hid/controllers/debug_pad.h
@@ -41,11 +41,11 @@ private:
 
     // This is nn::hid::DebugPadState
     struct DebugPadState {
-        s64 sampling_number;
-        DebugPadAttribute attribute;
-        Core::HID::DebugPadButton pad_state;
-        Core::HID::AnalogStickState r_stick;
-        Core::HID::AnalogStickState l_stick;
+        s64 sampling_number{};
+        DebugPadAttribute attribute{};
+        Core::HID::DebugPadButton pad_state{};
+        Core::HID::AnalogStickState r_stick{};
+        Core::HID::AnalogStickState l_stick{};
     };
     static_assert(sizeof(DebugPadState) == 0x20, "DebugPadState is an invalid state");
 
@@ -57,9 +57,8 @@ private:
     };
     static_assert(sizeof(DebugPadSharedMemory) == 0x400, "DebugPadSharedMemory is an invalid size");
 
-    DebugPadSharedMemory* shared_memory;
-
     DebugPadState next_state{};
-    Core::HID::EmulatedController* controller;
+    DebugPadSharedMemory* shared_memory = nullptr;
+    Core::HID::EmulatedController* controller = nullptr;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/gesture.cpp
+++ b/src/core/hle/service/hid/controllers/gesture.cpp
@@ -27,8 +27,8 @@ Controller_Gesture::Controller_Gesture(Core::HID::HIDCore& hid_core_, u8* raw_sh
     : ControllerBase(hid_core_) {
     static_assert(SHARED_MEMORY_OFFSET + sizeof(GestureSharedMemory) < shared_memory_size,
                   "GestureSharedMemory is bigger than the shared memory");
-    shared_memory =
-        std::construct_at(reinterpret_cast<GestureSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
+    shared_memory = std::construct_at(
+        reinterpret_cast<GestureSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
     console = hid_core.GetEmulatedConsole();
 }
 Controller_Gesture::~Controller_Gesture() = default;

--- a/src/core/hle/service/hid/controllers/gesture.cpp
+++ b/src/core/hle/service/hid/controllers/gesture.cpp
@@ -23,25 +23,28 @@ constexpr f32 Square(s32 num) {
     return static_cast<f32>(num * num);
 }
 
-Controller_Gesture::Controller_Gesture(Core::HID::HIDCore& hid_core_) : ControllerBase(hid_core_) {
+Controller_Gesture::Controller_Gesture(Core::HID::HIDCore& hid_core_, u8* raw_shared_memory_)
+    : ControllerBase(hid_core_) {
+    static_assert(SHARED_MEMORY_OFFSET + sizeof(GestureSharedMemory) < shared_memory_size,
+                  "GestureSharedMemory is bigger than the shared memory");
+    shared_memory =
+        std::construct_at(reinterpret_cast<GestureSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
     console = hid_core.GetEmulatedConsole();
 }
 Controller_Gesture::~Controller_Gesture() = default;
 
 void Controller_Gesture::OnInit() {
-    gesture_lifo.buffer_count = 0;
-    gesture_lifo.buffer_tail = 0;
+    shared_memory->gesture_lifo.buffer_count = 0;
+    shared_memory->gesture_lifo.buffer_tail = 0;
     force_update = true;
 }
 
 void Controller_Gesture::OnRelease() {}
 
-void Controller_Gesture::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
-                                  std::size_t size) {
+void Controller_Gesture::OnUpdate(const Core::Timing::CoreTiming& core_timing) {
     if (!IsControllerActivated()) {
-        gesture_lifo.buffer_count = 0;
-        gesture_lifo.buffer_tail = 0;
-        std::memcpy(data + SHARED_MEMORY_OFFSET, &gesture_lifo, sizeof(gesture_lifo));
+        shared_memory->gesture_lifo.buffer_count = 0;
+        shared_memory->gesture_lifo.buffer_tail = 0;
         return;
     }
 
@@ -49,15 +52,15 @@ void Controller_Gesture::OnUpdate(const Core::Timing::CoreTiming& core_timing, u
 
     GestureProperties gesture = GetGestureProperties();
     f32 time_difference =
-        static_cast<f32>(gesture_lifo.timestamp - last_update_timestamp) / (1000 * 1000 * 1000);
+        static_cast<f32>(shared_memory->gesture_lifo.timestamp - last_update_timestamp) /
+        (1000 * 1000 * 1000);
 
     // Only update if necesary
     if (!ShouldUpdateGesture(gesture, time_difference)) {
         return;
     }
 
-    last_update_timestamp = gesture_lifo.timestamp;
-    UpdateGestureSharedMemory(data, size, gesture, time_difference);
+    last_update_timestamp = shared_memory->gesture_lifo.timestamp;
 }
 
 void Controller_Gesture::ReadTouchInput() {
@@ -97,7 +100,7 @@ void Controller_Gesture::UpdateGestureSharedMemory(u8* data, std::size_t size,
     GestureType type = GestureType::Idle;
     GestureAttribute attributes{};
 
-    const auto& last_entry = gesture_lifo.ReadCurrentEntry().state;
+    const auto& last_entry = shared_memory->gesture_lifo.ReadCurrentEntry().state;
 
     // Reset next state to default
     next_state.sampling_number = last_entry.sampling_number + 1;
@@ -127,8 +130,7 @@ void Controller_Gesture::UpdateGestureSharedMemory(u8* data, std::size_t size,
     next_state.points = gesture.points;
     last_gesture = gesture;
 
-    gesture_lifo.WriteNextEntry(next_state);
-    std::memcpy(data + SHARED_MEMORY_OFFSET, &gesture_lifo, sizeof(gesture_lifo));
+    shared_memory->gesture_lifo.WriteNextEntry(next_state);
 }
 
 void Controller_Gesture::NewGesture(GestureProperties& gesture, GestureType& type,
@@ -305,7 +307,7 @@ void Controller_Gesture::SetSwipeEvent(GestureProperties& gesture,
 }
 
 const Controller_Gesture::GestureState& Controller_Gesture::GetLastGestureEntry() const {
-    return gesture_lifo.ReadCurrentEntry().state;
+    return shared_memory->gesture_lifo.ReadCurrentEntry().state;
 }
 
 Controller_Gesture::GestureProperties Controller_Gesture::GetGestureProperties() {

--- a/src/core/hle/service/hid/controllers/gesture.h
+++ b/src/core/hle/service/hid/controllers/gesture.h
@@ -14,7 +14,7 @@
 namespace Service::HID {
 class Controller_Gesture final : public ControllerBase {
 public:
-    explicit Controller_Gesture(Core::HID::HIDCore& hid_core_);
+    explicit Controller_Gesture(Core::HID::HIDCore& hid_core_, u8* raw_shared_memory_);
     ~Controller_Gesture() override;
 
     // Called when the controller is initialized
@@ -24,7 +24,7 @@ public:
     void OnRelease() override;
 
     // When the controller is requesting an update for the shared memory
-    void OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data, size_t size) override;
+    void OnUpdate(const Core::Timing::CoreTiming& core_timing) override;
 
 private:
     static constexpr size_t MAX_FINGERS = 16;
@@ -92,6 +92,14 @@ private:
         f32 angle{};
     };
 
+    struct GestureSharedMemory {
+        // This is nn::hid::detail::GestureLifo
+        Lifo<GestureState, hid_entry_count> gesture_lifo{};
+        static_assert(sizeof(gesture_lifo) == 0x708, "gesture_lifo is an invalid size");
+        INSERT_PADDING_WORDS(0x3E);
+    };
+    static_assert(sizeof(GestureSharedMemory) == 0x800, "GestureSharedMemory is an invalid size");
+
     // Reads input from all available input engines
     void ReadTouchInput();
 
@@ -134,11 +142,8 @@ private:
     // Returns the average distance, angle and middle point of the active fingers
     GestureProperties GetGestureProperties();
 
-    // This is nn::hid::detail::GestureLifo
-    Lifo<GestureState, hid_entry_count> gesture_lifo{};
-    static_assert(sizeof(gesture_lifo) == 0x708, "gesture_lifo is an invalid size");
+    GestureSharedMemory* shared_memory;
     GestureState next_state{};
-
     Core::HID::EmulatedConsole* console;
 
     std::array<Core::HID::TouchFinger, MAX_POINTS> fingers{};

--- a/src/core/hle/service/hid/controllers/gesture.h
+++ b/src/core/hle/service/hid/controllers/gesture.h
@@ -66,19 +66,19 @@ private:
 
     // This is nn::hid::GestureState
     struct GestureState {
-        s64 sampling_number;
-        s64 detection_count;
-        GestureType type;
-        GestureDirection direction;
-        Common::Point<s32> pos;
-        Common::Point<s32> delta;
-        f32 vel_x;
-        f32 vel_y;
-        GestureAttribute attributes;
-        f32 scale;
-        f32 rotation_angle;
-        s32 point_count;
-        std::array<Common::Point<s32>, 4> points;
+        s64 sampling_number{};
+        s64 detection_count{};
+        GestureType type{GestureType::Idle};
+        GestureDirection direction{GestureDirection::None};
+        Common::Point<s32> pos{};
+        Common::Point<s32> delta{};
+        f32 vel_x{};
+        f32 vel_y{};
+        GestureAttribute attributes{};
+        f32 scale{};
+        f32 rotation_angle{};
+        s32 point_count{};
+        std::array<Common::Point<s32>, 4> points{};
     };
     static_assert(sizeof(GestureState) == 0x60, "GestureState is an invalid size");
 
@@ -142,9 +142,9 @@ private:
     // Returns the average distance, angle and middle point of the active fingers
     GestureProperties GetGestureProperties();
 
-    GestureSharedMemory* shared_memory;
     GestureState next_state{};
-    Core::HID::EmulatedConsole* console;
+    GestureSharedMemory* shared_memory = nullptr;
+    Core::HID::EmulatedConsole* console = nullptr;
 
     std::array<Core::HID::TouchFinger, MAX_POINTS> fingers{};
     GestureProperties last_gesture{};

--- a/src/core/hle/service/hid/controllers/keyboard.cpp
+++ b/src/core/hle/service/hid/controllers/keyboard.cpp
@@ -12,8 +12,12 @@
 namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3800;
 
-Controller_Keyboard::Controller_Keyboard(Core::HID::HIDCore& hid_core_)
+Controller_Keyboard::Controller_Keyboard(Core::HID::HIDCore& hid_core_, u8* raw_shared_memory_)
     : ControllerBase{hid_core_} {
+    static_assert(SHARED_MEMORY_OFFSET + sizeof(KeyboardSharedMemory) < shared_memory_size,
+                  "KeyboardSharedMemory is bigger than the shared memory");
+    shared_memory =
+        std::construct_at(reinterpret_cast<KeyboardSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
     emulated_devices = hid_core.GetEmulatedDevices();
 }
 
@@ -23,16 +27,14 @@ void Controller_Keyboard::OnInit() {}
 
 void Controller_Keyboard::OnRelease() {}
 
-void Controller_Keyboard::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
-                                   std::size_t size) {
+void Controller_Keyboard::OnUpdate(const Core::Timing::CoreTiming& core_timing) {
     if (!IsControllerActivated()) {
-        keyboard_lifo.buffer_count = 0;
-        keyboard_lifo.buffer_tail = 0;
-        std::memcpy(data + SHARED_MEMORY_OFFSET, &keyboard_lifo, sizeof(keyboard_lifo));
+        shared_memory->keyboard_lifo.buffer_count = 0;
+        shared_memory->keyboard_lifo.buffer_tail = 0;
         return;
     }
 
-    const auto& last_entry = keyboard_lifo.ReadCurrentEntry().state;
+    const auto& last_entry = shared_memory->keyboard_lifo.ReadCurrentEntry().state;
     next_state.sampling_number = last_entry.sampling_number + 1;
 
     if (Settings::values.keyboard_enabled) {
@@ -44,8 +46,7 @@ void Controller_Keyboard::OnUpdate(const Core::Timing::CoreTiming& core_timing, 
         next_state.attribute.is_connected.Assign(1);
     }
 
-    keyboard_lifo.WriteNextEntry(next_state);
-    std::memcpy(data + SHARED_MEMORY_OFFSET, &keyboard_lifo, sizeof(keyboard_lifo));
+    shared_memory->keyboard_lifo.WriteNextEntry(next_state);
 }
 
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/keyboard.cpp
+++ b/src/core/hle/service/hid/controllers/keyboard.cpp
@@ -16,8 +16,8 @@ Controller_Keyboard::Controller_Keyboard(Core::HID::HIDCore& hid_core_, u8* raw_
     : ControllerBase{hid_core_} {
     static_assert(SHARED_MEMORY_OFFSET + sizeof(KeyboardSharedMemory) < shared_memory_size,
                   "KeyboardSharedMemory is bigger than the shared memory");
-    shared_memory =
-        std::construct_at(reinterpret_cast<KeyboardSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
+    shared_memory = std::construct_at(
+        reinterpret_cast<KeyboardSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
     emulated_devices = hid_core.GetEmulatedDevices();
 }
 

--- a/src/core/hle/service/hid/controllers/keyboard.h
+++ b/src/core/hle/service/hid/controllers/keyboard.h
@@ -31,10 +31,10 @@ public:
 private:
     // This is nn::hid::detail::KeyboardState
     struct KeyboardState {
-        s64 sampling_number;
-        Core::HID::KeyboardModifier modifier;
-        Core::HID::KeyboardAttribute attribute;
-        Core::HID::KeyboardKey key;
+        s64 sampling_number{};
+        Core::HID::KeyboardModifier modifier{};
+        Core::HID::KeyboardAttribute attribute{};
+        Core::HID::KeyboardKey key{};
     };
     static_assert(sizeof(KeyboardState) == 0x30, "KeyboardState is an invalid size");
 
@@ -46,8 +46,8 @@ private:
     };
     static_assert(sizeof(KeyboardSharedMemory) == 0x400, "KeyboardSharedMemory is an invalid size");
 
-    KeyboardSharedMemory* shared_memory;
     KeyboardState next_state{};
-    Core::HID::EmulatedDevices* emulated_devices;
+    KeyboardSharedMemory* shared_memory = nullptr;
+    Core::HID::EmulatedDevices* emulated_devices = nullptr;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/mouse.cpp
+++ b/src/core/hle/service/hid/controllers/mouse.cpp
@@ -12,7 +12,11 @@
 namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3400;
 
-Controller_Mouse::Controller_Mouse(Core::HID::HIDCore& hid_core_) : ControllerBase{hid_core_} {
+Controller_Mouse::Controller_Mouse(Core::HID::HIDCore& hid_core_, u8* raw_shared_memory_)
+    : ControllerBase{hid_core_} {
+    static_assert(SHARED_MEMORY_OFFSET + sizeof(MouseSharedMemory) < shared_memory_size,
+                  "MouseSharedMemory is bigger than the shared memory");
+    shared_memory = std::construct_at(reinterpret_cast<MouseSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
     emulated_devices = hid_core.GetEmulatedDevices();
 }
 
@@ -21,16 +25,14 @@ Controller_Mouse::~Controller_Mouse() = default;
 void Controller_Mouse::OnInit() {}
 void Controller_Mouse::OnRelease() {}
 
-void Controller_Mouse::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
-                                std::size_t size) {
+void Controller_Mouse::OnUpdate(const Core::Timing::CoreTiming& core_timing) {
     if (!IsControllerActivated()) {
-        mouse_lifo.buffer_count = 0;
-        mouse_lifo.buffer_tail = 0;
-        std::memcpy(data + SHARED_MEMORY_OFFSET, &mouse_lifo, sizeof(mouse_lifo));
+        shared_memory->mouse_lifo.buffer_count = 0;
+        shared_memory->mouse_lifo.buffer_tail = 0;
         return;
     }
 
-    const auto& last_entry = mouse_lifo.ReadCurrentEntry().state;
+    const auto& last_entry = shared_memory->mouse_lifo.ReadCurrentEntry().state;
     next_state.sampling_number = last_entry.sampling_number + 1;
 
     next_state.attribute.raw = 0;
@@ -50,8 +52,7 @@ void Controller_Mouse::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8*
         next_state.button = mouse_button_state;
     }
 
-    mouse_lifo.WriteNextEntry(next_state);
-    std::memcpy(data + SHARED_MEMORY_OFFSET, &mouse_lifo, sizeof(mouse_lifo));
+    shared_memory->mouse_lifo.WriteNextEntry(next_state);
 }
 
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/mouse.cpp
+++ b/src/core/hle/service/hid/controllers/mouse.cpp
@@ -16,7 +16,8 @@ Controller_Mouse::Controller_Mouse(Core::HID::HIDCore& hid_core_, u8* raw_shared
     : ControllerBase{hid_core_} {
     static_assert(SHARED_MEMORY_OFFSET + sizeof(MouseSharedMemory) < shared_memory_size,
                   "MouseSharedMemory is bigger than the shared memory");
-    shared_memory = std::construct_at(reinterpret_cast<MouseSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
+    shared_memory = std::construct_at(
+        reinterpret_cast<MouseSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
     emulated_devices = hid_core.GetEmulatedDevices();
 }
 

--- a/src/core/hle/service/hid/controllers/mouse.h
+++ b/src/core/hle/service/hid/controllers/mouse.h
@@ -16,7 +16,7 @@ struct AnalogStickState;
 namespace Service::HID {
 class Controller_Mouse final : public ControllerBase {
 public:
-    explicit Controller_Mouse(Core::HID::HIDCore& hid_core_);
+    explicit Controller_Mouse(Core::HID::HIDCore& hid_core_, u8* raw_shared_memory_);
     ~Controller_Mouse() override;
 
     // Called when the controller is initialized
@@ -26,15 +26,20 @@ public:
     void OnRelease() override;
 
     // When the controller is requesting an update for the shared memory
-    void OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data, std::size_t size) override;
+    void OnUpdate(const Core::Timing::CoreTiming& core_timing) override;
 
 private:
-    // This is nn::hid::detail::MouseLifo
-    Lifo<Core::HID::MouseState, hid_entry_count> mouse_lifo{};
-    static_assert(sizeof(mouse_lifo) == 0x350, "mouse_lifo is an invalid size");
-    Core::HID::MouseState next_state{};
+    struct MouseSharedMemory {
+        // This is nn::hid::detail::MouseLifo
+        Lifo<Core::HID::MouseState, hid_entry_count> mouse_lifo{};
+        static_assert(sizeof(mouse_lifo) == 0x350, "mouse_lifo is an invalid size");
+        INSERT_PADDING_WORDS(0x2C);
+    };
+    static_assert(sizeof(MouseSharedMemory) == 0x400, "MouseSharedMemory is an invalid size");
 
-    Core::HID::AnalogStickState last_mouse_wheel_state;
+    MouseSharedMemory* shared_memory;
+    Core::HID::MouseState next_state{};
+    Core::HID::AnalogStickState last_mouse_wheel_state{};
     Core::HID::EmulatedDevices* emulated_devices;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/mouse.h
+++ b/src/core/hle/service/hid/controllers/mouse.h
@@ -37,9 +37,9 @@ private:
     };
     static_assert(sizeof(MouseSharedMemory) == 0x400, "MouseSharedMemory is an invalid size");
 
-    MouseSharedMemory* shared_memory;
     Core::HID::MouseState next_state{};
     Core::HID::AnalogStickState last_mouse_wheel_state{};
-    Core::HID::EmulatedDevices* emulated_devices;
+    MouseSharedMemory* shared_memory = nullptr;
+    Core::HID::EmulatedDevices* emulated_devices = nullptr;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -187,7 +187,7 @@ public:
     static bool IsDeviceHandleValid(const Core::HID::VibrationDeviceHandle& device_handle);
 
 private:
-    static const std::size_t NPAD_COUNT = 10;
+    static constexpr std::size_t NPAD_COUNT = 10;
 
     // This is nn::hid::detail::ColorAttribute
     enum class ColorAttribute : u32 {
@@ -470,9 +470,9 @@ private:
     };
 
     struct NpadControllerData {
-        Core::HID::EmulatedController* device;
         Kernel::KEvent* styleset_changed_event{};
-        NpadInternalState* shared_memory;
+        NpadInternalState* shared_memory = nullptr;
+        Core::HID::EmulatedController* device = nullptr;
 
         std::array<VibrationData, 2> vibration{};
         bool unintended_home_button_input_protection{};
@@ -502,8 +502,7 @@ private:
         SixAxisSensorState sixaxis_dual_right_state{};
         SixAxisSensorState sixaxis_left_lifo_state{};
         SixAxisSensorState sixaxis_right_lifo_state{};
-
-        int callback_key;
+        int callback_key{};
     };
 
     void ControllerUpdate(Core::HID::ControllerTriggerType type, std::size_t controller_idx);

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -35,7 +35,7 @@ namespace Service::HID {
 
 class Controller_NPad final : public ControllerBase {
 public:
-    explicit Controller_NPad(Core::HID::HIDCore& hid_core_,
+    explicit Controller_NPad(Core::HID::HIDCore& hid_core_, u8* raw_shared_memory_,
                              KernelHelpers::ServiceContext& service_context_);
     ~Controller_NPad() override;
 
@@ -46,11 +46,10 @@ public:
     void OnRelease() override;
 
     // When the controller is requesting an update for the shared memory
-    void OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data, std::size_t size) override;
+    void OnUpdate(const Core::Timing::CoreTiming& core_timing) override;
 
     // When the controller is requesting a motion update for the shared memory
-    void OnMotionUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
-                        std::size_t size) override;
+    void OnMotionUpdate(const Core::Timing::CoreTiming& core_timing) override;
 
     // This is nn::hid::GyroscopeZeroDriftMode
     enum class GyroscopeZeroDriftMode : u32 {
@@ -188,6 +187,8 @@ public:
     static bool IsDeviceHandleValid(const Core::HID::VibrationDeviceHandle& device_handle);
 
 private:
+    static const std::size_t NPAD_COUNT = 10;
+
     // This is nn::hid::detail::ColorAttribute
     enum class ColorAttribute : u32 {
         Ok = 0,
@@ -409,6 +410,13 @@ private:
         U,
     };
 
+    struct AppletNfcXcd {
+        union {
+            AppletFooterUi applet_footer{};
+            Lifo<NfcXcdDeviceHandleStateImpl, 0x2> nfc_xcd_device_lifo;
+        };
+    };
+
     // This is nn::hid::detail::NpadInternalState
     struct NpadInternalState {
         Core::HID::NpadStyleTag style_tag{Core::HID::NpadStyleSet::None};
@@ -435,10 +443,7 @@ private:
         Core::HID::NpadBatteryLevel battery_level_dual{};
         Core::HID::NpadBatteryLevel battery_level_left{};
         Core::HID::NpadBatteryLevel battery_level_right{};
-        union {
-            AppletFooterUi applet_footer{};
-            Lifo<NfcXcdDeviceHandleStateImpl, 0x2> nfc_xcd_device_lifo;
-        };
+        AppletNfcXcd applet_nfc_xcd{};
         INSERT_PADDING_BYTES(0x20); // Unknown
         Lifo<NpadGcTriggerState, hid_entry_count> gc_trigger_lifo{};
         NpadLarkType lark_type_l_and_main{};
@@ -467,7 +472,7 @@ private:
     struct NpadControllerData {
         Core::HID::EmulatedController* device;
         Kernel::KEvent* styleset_changed_event{};
-        NpadInternalState shared_memory_entry{};
+        NpadInternalState* shared_memory;
 
         std::array<VibrationData, 2> vibration{};
         bool unintended_home_button_input_protection{};
@@ -505,7 +510,7 @@ private:
     void InitNewlyAddedController(Core::HID::NpadIdType npad_id);
     bool IsControllerSupported(Core::HID::NpadStyleIndex controller) const;
     void RequestPadStateUpdate(Core::HID::NpadIdType npad_id);
-    void WriteEmptyEntry(NpadInternalState& npad);
+    void WriteEmptyEntry(NpadInternalState* npad);
 
     NpadControllerData& GetControllerFromHandle(
         const Core::HID::SixAxisSensorHandle& device_handle);
@@ -520,7 +525,7 @@ private:
 
     std::atomic<u64> press_state{};
 
-    std::array<NpadControllerData, 10> controller_data{};
+    std::array<NpadControllerData, NPAD_COUNT> controller_data{};
     KernelHelpers::ServiceContext& service_context;
     std::mutex mutex;
     std::vector<Core::HID::NpadIdType> supported_npad_id_types{};

--- a/src/core/hle/service/hid/controllers/stubbed.cpp
+++ b/src/core/hle/service/hid/controllers/stubbed.cpp
@@ -9,15 +9,18 @@
 
 namespace Service::HID {
 
-Controller_Stubbed::Controller_Stubbed(Core::HID::HIDCore& hid_core_) : ControllerBase{hid_core_} {}
+Controller_Stubbed::Controller_Stubbed(Core::HID::HIDCore& hid_core_, u8* raw_shared_memory_)
+    : ControllerBase{hid_core_} {
+    raw_shared_memory = raw_shared_memory_;
+}
+
 Controller_Stubbed::~Controller_Stubbed() = default;
 
 void Controller_Stubbed::OnInit() {}
 
 void Controller_Stubbed::OnRelease() {}
 
-void Controller_Stubbed::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
-                                  std::size_t size) {
+void Controller_Stubbed::OnUpdate(const Core::Timing::CoreTiming& core_timing) {
     if (!smart_update) {
         return;
     }
@@ -28,7 +31,7 @@ void Controller_Stubbed::OnUpdate(const Core::Timing::CoreTiming& core_timing, u
     header.entry_count = 0;
     header.last_entry_index = 0;
 
-    std::memcpy(data + common_offset, &header, sizeof(CommonHeader));
+    std::memcpy(raw_shared_memory + common_offset, &header, sizeof(CommonHeader));
 }
 
 void Controller_Stubbed::SetCommonHeaderOffset(std::size_t off) {

--- a/src/core/hle/service/hid/controllers/stubbed.h
+++ b/src/core/hle/service/hid/controllers/stubbed.h
@@ -25,14 +25,14 @@ public:
 
 private:
     struct CommonHeader {
-        s64 timestamp;
-        s64 total_entry_count;
-        s64 last_entry_index;
-        s64 entry_count;
+        s64 timestamp{};
+        s64 total_entry_count{};
+        s64 last_entry_index{};
+        s64 entry_count{};
     };
     static_assert(sizeof(CommonHeader) == 0x20, "CommonHeader is an invalid size");
 
-    u8* raw_shared_memory;
+    u8* raw_shared_memory = nullptr;
     bool smart_update{};
     std::size_t common_offset{};
 };

--- a/src/core/hle/service/hid/controllers/stubbed.h
+++ b/src/core/hle/service/hid/controllers/stubbed.h
@@ -9,7 +9,7 @@
 namespace Service::HID {
 class Controller_Stubbed final : public ControllerBase {
 public:
-    explicit Controller_Stubbed(Core::HID::HIDCore& hid_core_);
+    explicit Controller_Stubbed(Core::HID::HIDCore& hid_core_, u8* raw_shared_memory_);
     ~Controller_Stubbed() override;
 
     // Called when the controller is initialized
@@ -19,7 +19,7 @@ public:
     void OnRelease() override;
 
     // When the controller is requesting an update for the shared memory
-    void OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data, std::size_t size) override;
+    void OnUpdate(const Core::Timing::CoreTiming& core_timing) override;
 
     void SetCommonHeaderOffset(std::size_t off);
 
@@ -32,6 +32,7 @@ private:
     };
     static_assert(sizeof(CommonHeader) == 0x20, "CommonHeader is an invalid size");
 
+    u8* raw_shared_memory;
     bool smart_update{};
     std::size_t common_offset{};
 };

--- a/src/core/hle/service/hid/controllers/touchscreen.cpp
+++ b/src/core/hle/service/hid/controllers/touchscreen.cpp
@@ -15,8 +15,12 @@
 namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x400;
 
-Controller_Touchscreen::Controller_Touchscreen(Core::HID::HIDCore& hid_core_)
+Controller_Touchscreen::Controller_Touchscreen(Core::HID::HIDCore& hid_core_,
+                                               u8* raw_shared_memory_)
     : ControllerBase{hid_core_} {
+    static_assert(SHARED_MEMORY_OFFSET + sizeof(TouchSharedMemory) < shared_memory_size,
+                  "TouchSharedMemory is bigger than the shared memory");
+    shared_memory = std::construct_at(reinterpret_cast<TouchSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
     console = hid_core.GetEmulatedConsole();
 }
 
@@ -26,14 +30,12 @@ void Controller_Touchscreen::OnInit() {}
 
 void Controller_Touchscreen::OnRelease() {}
 
-void Controller_Touchscreen::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
-                                      std::size_t size) {
-    touch_screen_lifo.timestamp = core_timing.GetCPUTicks();
+void Controller_Touchscreen::OnUpdate(const Core::Timing::CoreTiming& core_timing) {
+    shared_memory->touch_screen_lifo.timestamp = core_timing.GetCPUTicks();
 
     if (!IsControllerActivated()) {
-        touch_screen_lifo.buffer_count = 0;
-        touch_screen_lifo.buffer_tail = 0;
-        std::memcpy(data, &touch_screen_lifo, sizeof(touch_screen_lifo));
+        shared_memory->touch_screen_lifo.buffer_count = 0;
+        shared_memory->touch_screen_lifo.buffer_tail = 0;
         return;
     }
 
@@ -74,7 +76,7 @@ void Controller_Touchscreen::OnUpdate(const Core::Timing::CoreTiming& core_timin
         static_cast<std::size_t>(std::distance(active_fingers.begin(), end_iter));
 
     const u64 tick = core_timing.GetCPUTicks();
-    const auto& last_entry = touch_screen_lifo.ReadCurrentEntry().state;
+    const auto& last_entry = shared_memory->touch_screen_lifo.ReadCurrentEntry().state;
 
     next_state.sampling_number = last_entry.sampling_number + 1;
     next_state.entry_count = static_cast<s32>(active_fingers_count);
@@ -106,8 +108,7 @@ void Controller_Touchscreen::OnUpdate(const Core::Timing::CoreTiming& core_timin
         }
     }
 
-    touch_screen_lifo.WriteNextEntry(next_state);
-    std::memcpy(data + SHARED_MEMORY_OFFSET, &touch_screen_lifo, sizeof(touch_screen_lifo));
+    shared_memory->touch_screen_lifo.WriteNextEntry(next_state);
 }
 
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/touchscreen.cpp
+++ b/src/core/hle/service/hid/controllers/touchscreen.cpp
@@ -20,7 +20,8 @@ Controller_Touchscreen::Controller_Touchscreen(Core::HID::HIDCore& hid_core_,
     : ControllerBase{hid_core_} {
     static_assert(SHARED_MEMORY_OFFSET + sizeof(TouchSharedMemory) < shared_memory_size,
                   "TouchSharedMemory is bigger than the shared memory");
-    shared_memory = std::construct_at(reinterpret_cast<TouchSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
+    shared_memory = std::construct_at(
+        reinterpret_cast<TouchSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
     console = hid_core.GetEmulatedConsole();
 }
 

--- a/src/core/hle/service/hid/controllers/touchscreen.h
+++ b/src/core/hle/service/hid/controllers/touchscreen.h
@@ -25,7 +25,7 @@ public:
 
     // This is nn::hid::TouchScreenConfigurationForNx
     struct TouchScreenConfigurationForNx {
-        TouchScreenModeForNx mode;
+        TouchScreenModeForNx mode{TouchScreenModeForNx::UseSystemSetting};
         INSERT_PADDING_BYTES_NOINIT(0x7);
         INSERT_PADDING_BYTES_NOINIT(0xF); // Reserved
     };
@@ -49,10 +49,10 @@ private:
 
     // This is nn::hid::TouchScreenState
     struct TouchScreenState {
-        s64 sampling_number;
-        s32 entry_count;
+        s64 sampling_number{};
+        s32 entry_count{};
         INSERT_PADDING_BYTES(4); // Reserved
-        std::array<Core::HID::TouchState, MAX_FINGERS> states;
+        std::array<Core::HID::TouchState, MAX_FINGERS> states{};
     };
     static_assert(sizeof(TouchScreenState) == 0x290, "TouchScreenState is an invalid size");
 
@@ -64,10 +64,10 @@ private:
     };
     static_assert(sizeof(TouchSharedMemory) == 0x3000, "TouchSharedMemory is an invalid size");
 
-    TouchSharedMemory* shared_memory;
-
     TouchScreenState next_state{};
-    std::array<Core::HID::TouchFinger, MAX_FINGERS> fingers;
-    Core::HID::EmulatedConsole* console;
+    TouchSharedMemory* shared_memory = nullptr;
+    Core::HID::EmulatedConsole* console = nullptr;
+
+    std::array<Core::HID::TouchFinger, MAX_FINGERS> fingers{};
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/xpad.cpp
+++ b/src/core/hle/service/hid/controllers/xpad.cpp
@@ -14,7 +14,8 @@ Controller_XPad::Controller_XPad(Core::HID::HIDCore& hid_core_, u8* raw_shared_m
     : ControllerBase{hid_core_} {
     static_assert(SHARED_MEMORY_OFFSET + sizeof(XpadSharedMemory) < shared_memory_size,
                   "XpadSharedMemory is bigger than the shared memory");
-    shared_memory = std::construct_at(reinterpret_cast<XpadSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
+    shared_memory = std::construct_at(
+        reinterpret_cast<XpadSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
 }
 Controller_XPad::~Controller_XPad() = default;
 

--- a/src/core/hle/service/hid/controllers/xpad.cpp
+++ b/src/core/hle/service/hid/controllers/xpad.cpp
@@ -10,28 +10,30 @@
 namespace Service::HID {
 constexpr std::size_t SHARED_MEMORY_OFFSET = 0x3C00;
 
-Controller_XPad::Controller_XPad(Core::HID::HIDCore& hid_core_) : ControllerBase{hid_core_} {}
+Controller_XPad::Controller_XPad(Core::HID::HIDCore& hid_core_, u8* raw_shared_memory_)
+    : ControllerBase{hid_core_} {
+    static_assert(SHARED_MEMORY_OFFSET + sizeof(XpadSharedMemory) < shared_memory_size,
+                  "XpadSharedMemory is bigger than the shared memory");
+    shared_memory = std::construct_at(reinterpret_cast<XpadSharedMemory*>(raw_shared_memory_ + SHARED_MEMORY_OFFSET));
+}
 Controller_XPad::~Controller_XPad() = default;
 
 void Controller_XPad::OnInit() {}
 
 void Controller_XPad::OnRelease() {}
 
-void Controller_XPad::OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data,
-                               std::size_t size) {
+void Controller_XPad::OnUpdate(const Core::Timing::CoreTiming& core_timing) {
     if (!IsControllerActivated()) {
-        basic_xpad_lifo.buffer_count = 0;
-        basic_xpad_lifo.buffer_tail = 0;
-        std::memcpy(data + SHARED_MEMORY_OFFSET, &basic_xpad_lifo, sizeof(basic_xpad_lifo));
+        shared_memory->basic_xpad_lifo.buffer_count = 0;
+        shared_memory->basic_xpad_lifo.buffer_tail = 0;
         return;
     }
 
-    const auto& last_entry = basic_xpad_lifo.ReadCurrentEntry().state;
+    const auto& last_entry = shared_memory->basic_xpad_lifo.ReadCurrentEntry().state;
     next_state.sampling_number = last_entry.sampling_number + 1;
     // TODO(ogniK): Update xpad states
 
-    basic_xpad_lifo.WriteNextEntry(next_state);
-    std::memcpy(data + SHARED_MEMORY_OFFSET, &basic_xpad_lifo, sizeof(basic_xpad_lifo));
+    shared_memory->basic_xpad_lifo.WriteNextEntry(next_state);
 }
 
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/xpad.h
+++ b/src/core/hle/service/hid/controllers/xpad.h
@@ -90,11 +90,11 @@ private:
 
     // This is nn::hid::detail::BasicXpadState
     struct BasicXpadState {
-        s64 sampling_number;
-        BasicXpadAttributeSet attributes;
-        BasicXpadButtonSet pad_states;
-        Core::HID::AnalogStickState l_stick;
-        Core::HID::AnalogStickState r_stick;
+        s64 sampling_number{};
+        BasicXpadAttributeSet attributes{};
+        BasicXpadButtonSet pad_states{};
+        Core::HID::AnalogStickState l_stick{};
+        Core::HID::AnalogStickState r_stick{};
     };
     static_assert(sizeof(BasicXpadState) == 0x20, "BasicXpadState is an invalid size");
 
@@ -106,7 +106,7 @@ private:
     };
     static_assert(sizeof(XpadSharedMemory) == 0x400, "XpadSharedMemory is an invalid size");
 
-    XpadSharedMemory* shared_memory;
     BasicXpadState next_state{};
+    XpadSharedMemory* shared_memory = nullptr;
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/controllers/xpad.h
+++ b/src/core/hle/service/hid/controllers/xpad.h
@@ -12,7 +12,7 @@
 namespace Service::HID {
 class Controller_XPad final : public ControllerBase {
 public:
-    explicit Controller_XPad(Core::HID::HIDCore& hid_core_);
+    explicit Controller_XPad(Core::HID::HIDCore& hid_core_, u8* raw_shared_memory_);
     ~Controller_XPad() override;
 
     // Called when the controller is initialized
@@ -22,7 +22,7 @@ public:
     void OnRelease() override;
 
     // When the controller is requesting an update for the shared memory
-    void OnUpdate(const Core::Timing::CoreTiming& core_timing, u8* data, std::size_t size) override;
+    void OnUpdate(const Core::Timing::CoreTiming& core_timing) override;
 
 private:
     // This is nn::hid::BasicXpadAttributeSet
@@ -98,9 +98,15 @@ private:
     };
     static_assert(sizeof(BasicXpadState) == 0x20, "BasicXpadState is an invalid size");
 
-    // This is nn::hid::detail::BasicXpadLifo
-    Lifo<BasicXpadState, hid_entry_count> basic_xpad_lifo{};
-    static_assert(sizeof(basic_xpad_lifo) == 0x2C8, "basic_xpad_lifo is an invalid size");
+    struct XpadSharedMemory {
+        // This is nn::hid::detail::BasicXpadLifo
+        Lifo<BasicXpadState, hid_entry_count> basic_xpad_lifo{};
+        static_assert(sizeof(basic_xpad_lifo) == 0x2C8, "basic_xpad_lifo is an invalid size");
+        INSERT_PADDING_WORDS(0x4E);
+    };
+    static_assert(sizeof(XpadSharedMemory) == 0x400, "XpadSharedMemory is an invalid size");
+
+    XpadSharedMemory* shared_memory;
     BasicXpadState next_state{};
 };
 } // namespace Service::HID

--- a/src/core/hle/service/hid/hid.h
+++ b/src/core/hle/service/hid/hid.h
@@ -58,13 +58,14 @@ public:
 
 private:
     template <typename T>
-    void MakeController(HidController controller) {
-        controllers[static_cast<std::size_t>(controller)] = std::make_unique<T>(system.HIDCore());
+    void MakeController(HidController controller, u8* shared_memory) {
+        controllers[static_cast<std::size_t>(controller)] =
+            std::make_unique<T>(system.HIDCore(), shared_memory);
     }
     template <typename T>
-    void MakeControllerWithServiceContext(HidController controller) {
+    void MakeControllerWithServiceContext(HidController controller, u8* shared_memory) {
         controllers[static_cast<std::size_t>(controller)] =
-            std::make_unique<T>(system.HIDCore(), service_context);
+            std::make_unique<T>(system.HIDCore(), shared_memory, service_context);
     }
 
     void GetSharedMemoryHandle(Kernel::HLERequestContext& ctx);


### PR DESCRIPTION
Currently we have a duplicate of the shared memory. Each single change we do needs to be copied to ensure both locations have the same data. This made the service prone to data mismatches or delays.

On some edge cases a game could be reading wrong data. This PR fixes the issue by casting a pointer to the shared memory and eliminating all data duplication. This fixes the issues on my unit test and has the potential to fix many games. Specially the ones who had wrong state like #8162 or pokemon let's go not detecting controllers properly