### PR TITLE
core/arm: re-enable cycle counting

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -112,7 +112,9 @@ public:
     }
 
     void AddTicks(u64 ticks) override {
-        ASSERT_MSG(!parent.uses_wall_clock, "This should never happen - dynarmic ticking disabled");
+        if (parent.uses_wall_clock) {
+            return;
+        }
 
         // Divide the number of ticks by the amount of CPU cores. TODO(Subv): This yields only a
         // rough approximation of the amount of executed ticks in the system, it may be thrown off
@@ -129,7 +131,12 @@ public:
     }
 
     u64 GetTicksRemaining() override {
-        ASSERT_MSG(!parent.uses_wall_clock, "This should never happen - dynarmic ticking disabled");
+        if (parent.uses_wall_clock) {
+            if (!parent.interrupt_handlers[parent.core_index].IsInterrupted()) {
+                return minimum_run_cycles;
+            }
+            return 0U;
+        }
 
         return std::max<s64>(parent.system.CoreTiming().GetDowncount(), 0);
     }
@@ -182,7 +189,7 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
 
     // Timing
     config.wall_clock_cntpct = uses_wall_clock;
-    config.enable_cycle_counting = !uses_wall_clock;
+    config.enable_cycle_counting = true;
 
     // Code cache size
     config.code_cache_size = 512_MiB;

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -161,7 +161,7 @@ public:
     Core::Memory::Memory& memory;
     std::size_t num_interpreted_instructions{};
     bool debugger_enabled{};
-    static constexpr u64 minimum_run_cycles = 1000U;
+    static constexpr u64 minimum_run_cycles = 10000U;
 };
 
 std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* page_table) const {

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -209,7 +209,7 @@ public:
     u64 tpidrro_el0 = 0;
     u64 tpidr_el0 = 0;
     bool debugger_enabled{};
-    static constexpr u64 minimum_run_cycles = 1000U;
+    static constexpr u64 minimum_run_cycles = 10000U;
 };
 
 std::shared_ptr<Dynarmic::A64::Jit> ARM_Dynarmic_64::MakeJit(Common::PageTable* page_table,


### PR DESCRIPTION
Partial revert of #8148
Fixes #8211
@merryhime 

This allows Galaxy to be progressed past video playback scenes once again, and fixes stuttery FMV audio playback in this game, as well as normal audio playback in the N64 emulator. It also provides about a 10% speedup in Galaxy with the framerate unlocked.

There seems to be some fundamental timing issue, at the very least regarding cntpct_el0, that needs to be addressed before accurate cycle counting can correctly be disabled. All of these games depend on a relatively precise thread sleep followed by a busy wait for the remaining time to smoothly match timings of the systems they are emulating; in pseudocode they do this
```cpp
u64 tick_start = clock_ns();
u64 tick_end = tick_start + delay_ns;

if (tick_end - tick_start > 1000000) {
    nanosleep(tick_end - tick_start - 50000);
}

while (clock_ns() < tick_end)
    ;
```
, and not using cycle-accurate counting causes them to stutter (and in Galaxy's case, softlock entirely -- at least part of this may be because it performs signed 32-bit arithmetic on tick values).