### PR TITLE
CMakeLists: Update Conan requirement to 1.45.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,9 +405,7 @@ if (CONAN_REQUIRED_LIBS)
     # Download conan.cmake automatically, you can also just copy the conan.cmake file
     if(NOT EXISTS "${CMAKE_BINARY_DIR}/conan.cmake")
         message(STATUS "Downloading conan.cmake from https://github.com/conan-io/cmake-conan")
-        # TODO: Use a tagged release. The latest tagged release does not support VS2022 as of this writing.
-        file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/43e385830ee35377dbd2dcbe8d5a9e750301ea00/conan.cmake"
-                        "${CMAKE_BINARY_DIR}/conan.cmake")
+        file(DOWNLOAD "https://raw.githubusercontent.com/conan-io/cmake-conan/release/0.18/conan.cmake" "${CMAKE_BINARY_DIR}/conan.cmake")
     endif()
     include(${CMAKE_BINARY_DIR}/conan.cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,7 +411,7 @@ if (CONAN_REQUIRED_LIBS)
     endif()
     include(${CMAKE_BINARY_DIR}/conan.cmake)
 
-    conan_check(VERSION 1.41.0 REQUIRED)
+    conan_check(VERSION 1.45.0 REQUIRED)
 
     # Manually add iconv to fix a dep conflict between qt and sdl2
     # We don't need to add it through find_package or anything since the other two can find it just fine


### PR DESCRIPTION
Additionally, download an updated conan.cmake file from https://raw.githubusercontent.com/conan-io/cmake-conan/release/0.18/conan.cmake