### PR TITLE
yuzu: config: Improve analog stick mapping

### DIFF
--- a/src/core/hid/input_converter.cpp
+++ b/src/core/hid/input_converter.cpp
@@ -327,7 +327,7 @@ void SanitizeStick(Common::Input::AnalogStatus& analog_x, Common::Input::AnalogS
     raw_y += properties_y.offset;
 
     // Apply X scale correction from offset
-    if (std::abs(properties_x.offset) < 0.5f) {
+    if (std::abs(properties_x.offset) < 0.75f) {
         if (raw_x > 0) {
             raw_x /= 1 + properties_x.offset;
         } else {
@@ -336,7 +336,7 @@ void SanitizeStick(Common::Input::AnalogStatus& analog_x, Common::Input::AnalogS
     }
 
     // Apply Y scale correction from offset
-    if (std::abs(properties_y.offset) < 0.5f) {
+    if (std::abs(properties_y.offset) < 0.75f) {
         if (raw_y > 0) {
             raw_y /= 1 + properties_y.offset;
         } else {

--- a/src/input_common/input_poller.cpp
+++ b/src/input_common/input_poller.cpp
@@ -732,7 +732,7 @@ std::unique_ptr<Common::Input::InputDevice> InputFactory::CreateHatButtonDevice(
 std::unique_ptr<Common::Input::InputDevice> InputFactory::CreateStickDevice(
     const Common::ParamPackage& params) {
     const auto deadzone = std::clamp(params.Get("deadzone", 0.15f), 0.0f, 1.0f);
-    const auto range = std::clamp(params.Get("range", 1.0f), 0.25f, 1.50f);
+    const auto range = std::clamp(params.Get("range", 0.95f), 0.25f, 1.50f);
     const auto threshold = std::clamp(params.Get("threshold", 0.5f), 0.0f, 1.0f);
     const PadIdentifier identifier = {
         .guid = Common::UUID{params.Get("guid", "")},

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -520,7 +520,28 @@ ConfigureInputPlayer::ConfigureInputPlayer(QWidget* parent, std::size_t player_i
                         QMenu context_menu;
                         Common::ParamPackage param = emulated_controller->GetStickParam(analog_id);
                         context_menu.addAction(tr("Clear"), [&] {
-                            emulated_controller->SetStickParam(analog_id, {});
+                            if (param.Get("engine", "") != "analog_from_button") {
+                                emulated_controller->SetStickParam(analog_id, {});
+                                for (auto button : analog_map_buttons[analog_id]) {
+                                    button->setText(tr("[not set]"));
+                                }
+                                return;
+                            }
+                            switch (sub_button_id) {
+                            case 0:
+                                param.Erase("up");
+                                break;
+                            case 1:
+                                param.Erase("down");
+                                break;
+                            case 2:
+                                param.Erase("left");
+                                break;
+                            case 3:
+                                param.Erase("right");
+                                break;
+                            }
+                            emulated_controller->SetStickParam(analog_id, param);
                             analog_map_buttons[analog_id][sub_button_id]->setText(tr("[not set]"));
                         });
                         context_menu.addAction(tr("Center axis"), [&] {

--- a/src/yuzu/configuration/configure_input_player.cpp
+++ b/src/yuzu/configuration/configure_input_player.cpp
@@ -988,7 +988,7 @@ void ConfigureInputPlayer::UpdateUI() {
             slider_value = static_cast<int>(param.Get("deadzone", 0.15f) * 100);
             deadzone_label->setText(tr("Deadzone: %1%").arg(slider_value));
             deadzone_slider->setValue(slider_value);
-            range_spinbox->setValue(static_cast<int>(param.Get("range", 1.0f) * 100));
+            range_spinbox->setValue(static_cast<int>(param.Get("range", 0.95f) * 100));
         } else {
             slider_value = static_cast<int>(param.Get("modifier_scale", 0.5f) * 100);
             modifier_label->setText(tr("Modifier Range: %1%").arg(slider_value));

--- a/src/yuzu/configuration/configure_input_player.ui
+++ b/src/yuzu/configuration/configure_input_player.ui
@@ -754,13 +754,13 @@
                       <string>%</string>
                      </property>
                      <property name="minimum">
-                      <number>50</number>
+                      <number>25</number>
                      </property>
                      <property name="maximum">
                       <number>150</number>
                      </property>
                      <property name="value">
-                      <number>100</number>
+                      <number>95</number>
                      </property>
                     </widget>
                    </item>
@@ -2985,13 +2985,13 @@
                       <string>%</string>
                      </property>
                      <property name="minimum">
-                      <number>50</number>
+                      <number>25</number>
                      </property>
                      <property name="maximum">
                       <number>150</number>
                      </property>
                      <property name="value">
-                      <number>100</number>
+                      <number>95</number>
                      </property>
                     </widget>
                    </item>


### PR DESCRIPTION
Fixes 4 minor issues with analog sticks.

- Default range is now 95% to give a little guarantee that a game sees the max range posible
- Minimum range is lowered from 50% to 25%
- Center correction now is applied to offsets up to 75%
- You can now delete individual axis if buttons are mapped