### PR TITLE
core: hid: Allow to reconnect all players on button input

### DIFF
--- a/src/core/hid/emulated_controller.h
+++ b/src/core/hid/emulated_controller.h
@@ -167,6 +167,12 @@ public:
     void SetSupportedNpadStyleTag(NpadStyleTag supported_styles);
 
     /**
+     * Tries to turn on the controller if a button is pressed
+     * @param button_index index to verify if controller should be connected
+     */
+    void TryReconnectController(std::size_t button_index);
+
+    /**
      * Sets the connected status to true
      * @param use_temporary_value If true tmp_npad_type will be used
      */


### PR DESCRIPTION
Currently only the first player was able to turn on the controller with any button input. This PR tries to add this feature to all players that doesn't have the default keyboard mappings.