### PR TITLE
GCC 12 fixes

### DIFF
--- a/src/common/settings.cpp
+++ b/src/common/settings.cpp
@@ -10,7 +10,7 @@
 
 namespace Settings {
 
-Values values = {};
+Values values;
 static bool configuring_global = true;
 
 std::string GetTimeZoneString() {

--- a/src/shader_recompiler/ir_opt/verification_pass.cpp
+++ b/src/shader_recompiler/ir_opt/verification_pass.cpp
@@ -43,7 +43,7 @@ static void ValidateUses(const IR::Program& program) {
             }
         }
     }
-    for (const auto [inst, uses] : actual_uses) {
+    for (const auto& [inst, uses] : actual_uses) {
         if (inst->UseCount() != uses) {
             throw LogicError("Invalid uses in block: {}", IR::DumpProgram(program));
         }

--- a/src/video_core/shader_environment.cpp
+++ b/src/video_core/shader_environment.cpp
@@ -188,11 +188,11 @@ void GenericEnvironment::Serialize(std::ofstream& file) const {
         .write(reinterpret_cast<const char*>(&cached_highest), sizeof(cached_highest))
         .write(reinterpret_cast<const char*>(&stage), sizeof(stage))
         .write(reinterpret_cast<const char*>(code.data()), code_size);
-    for (const auto [key, type] : texture_types) {
+    for (const auto& [key, type] : texture_types) {
         file.write(reinterpret_cast<const char*>(&key), sizeof(key))
             .write(reinterpret_cast<const char*>(&type), sizeof(type));
     }
-    for (const auto [key, type] : cbuf_values) {
+    for (const auto& [key, type] : cbuf_values) {
         file.write(reinterpret_cast<const char*>(&key), sizeof(key))
             .write(reinterpret_cast<const char*>(&type), sizeof(type));
     }


### PR DESCRIPTION
These changes are needed for GCC 12, but are not sufficient for yuzu to be compiled with GCC 12 due to [numerous](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105420) [compiler](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105423) [bugs](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105424). Once the bugs are fixed, it should compile.