### PR TITLE
ui: let system locale control format of Custom RTC

### DIFF
--- a/src/yuzu/configuration/configure_system.ui
+++ b/src/yuzu/configuration/configure_system.ui
@@ -474,9 +474,6 @@
               <day>1</day>
              </date>
             </property>
-            <property name="displayFormat">
-             <string>d MMM yyyy h:mm:ss AP</string>
-            </property>
            </widget>
           </item>
           <item row="6" column="1">


### PR DESCRIPTION
The Custom RTC widget is under the influence of the computers System Locale.
The format strings are not necessarily related. As a small example, setting the Windows Language to Dansk, and then trying to use yuzu in English the requested AM/PM indicator is simply not shown

The display format for the Custom RTC field needs to be removed from src/yuzu/configuration/configure_system.ui

modifying the display format needs to be moved to src/yuzu/configuration/configure_system.cpp

^ Wordy git commit message, this PR is related to discussion in #8289 