### PR TITLE
ui: retranslate the network tab

### DIFF
--- a/src/yuzu/configuration/configure_network.cpp
+++ b/src/yuzu/configuration/configure_network.cpp
@@ -26,7 +26,15 @@ void ConfigureNetwork::ApplyConfiguration() {
     Settings::values.network_interface = ui->network_interface->currentText().toStdString();
 }
 
-void ConfigureNetwork::RetranslateUi() {
+void ConfigureNetwork::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
+void ConfigureNetwork::RetranslateUI() {
     ui->retranslateUi(this);
 }
 

--- a/src/yuzu/configuration/configure_network.h
+++ b/src/yuzu/configuration/configure_network.h
@@ -18,9 +18,10 @@ public:
     ~ConfigureNetwork() override;
 
     void ApplyConfiguration();
-    void RetranslateUi();
 
 private:
+    void changeEvent(QEvent*) override;
+    void RetranslateUI();
     void SetConfiguration();
 
     std::unique_ptr<Ui::ConfigureNetwork> ui;


### PR DESCRIPTION
Looks like it was just missed when the tab was added, as currently the Network Tab only has one item
RetranslateUI is used more commonly throughout the project

If you open UI in English and switch to Japanese, Network tab isn't told to re translate
Before example
![image](https://user-images.githubusercontent.com/190571/166183333-1cc324b0-9a58-48e2-af4d-2fb9b546982a.png)

After example
![image](https://user-images.githubusercontent.com/190571/166183429-fe14335a-4f22-4e3a-9278-bd156a1cfc40.png)
