### PR TITLE
Update gc_adapter.cpp

### DIFF
--- a/src/input_common/drivers/gc_adapter.cpp
+++ b/src/input_common/drivers/gc_adapter.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <fmt/format.h>
-#include <libusb.h>
+#include <libusb-1.0/libusb.h>
 
 #include "common/logging/log.h"
 #include "common/param_package.h"


### PR DESCRIPTION
Just to silence an intermittent error.
GCC11.2 complains cannot find 'libusb.h' during a fresh build.