### PR TITLE
Revert "gc_adapter: fix libusb import on GCC11.2"

### DIFF
--- a/src/input_common/drivers/gc_adapter.cpp
+++ b/src/input_common/drivers/gc_adapter.cpp
@@ -2,11 +2,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 
 #include <fmt/format.h>
-#ifdef _WIN32
 #include <libusb.h>
-#else
-#include <libusb-1.0/libusb.h>
-#endif
 
 #include "common/logging/log.h"
 #include "common/param_package.h"


### PR DESCRIPTION
Reverts yuzu-emu/yuzu#8295

According to @lat9nq the aforementioned PR breaks `YUZU_USE_BUNDLED_LIBUSB`