### PR TITLE
hle/result: Add ResultRange overload in ResultVal

### DIFF
--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -181,7 +181,7 @@ public:
     consteval ResultRange(ErrorModule module, u32 description_start, u32 description_end_)
         : code{module, description_start}, description_end{description_end_} {}
 
-    [[nodiscard]] consteval operator ResultCode() const {
+    [[nodiscard]] constexpr operator ResultCode() const {
         return code;
     }
 
@@ -231,6 +231,8 @@ public:
     constexpr ResultVal() : expected{} {}
 
     constexpr ResultVal(ResultCode code) : expected{Common::Unexpected(code)} {}
+
+    constexpr ResultVal(ResultRange range) : expected{Common::Unexpected(range)} {}
 
     template <typename U>
     constexpr ResultVal(U&& val) : expected{std::forward<U>(val)} {}

--- a/src/core/hle/result.h
+++ b/src/core/hle/result.h
@@ -319,7 +319,7 @@ public:
     }
 
 private:
-    // TODO: Replace this with std::expected once it is standardized in the STL.
+    // TODO (Morph): Replace this with C++23 std::expected.
     Common::Expected<T, ResultCode> expected;
 };
 


### PR DESCRIPTION
Also marks the implicit conversion operator as constexpr instead of consteval as the constructor is not constant evaluated.