### PR TITLE
maxwell_dma: fix bytes_per_pixel

### DIFF
--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -134,7 +134,7 @@ void MaxwellDMA::CopyBlockLinearToPitch() {
 
     // Deswizzle the input and copy it over.
     UNIMPLEMENTED_IF(regs.launch_dma.remap_enable != 0);
-    const u32 bytes_per_pixel = regs.pitch_out / regs.line_length_in;
+    const u32 bytes_per_pixel = 1;
     const Parameters& src_params = regs.src_params;
     const u32 width = src_params.width;
     const u32 height = src_params.height;
@@ -166,7 +166,7 @@ void MaxwellDMA::CopyPitchToBlockLinear() {
     UNIMPLEMENTED_IF(regs.launch_dma.remap_enable != 0);
 
     const auto& dst_params = regs.dst_params;
-    const u32 bytes_per_pixel = regs.pitch_in / regs.line_length_in;
+    const u32 bytes_per_pixel = 1;
     const u32 width = dst_params.width;
     const u32 height = dst_params.height;
     const u32 depth = dst_params.depth;
@@ -210,7 +210,7 @@ void MaxwellDMA::CopyPitchToBlockLinear() {
 }
 
 void MaxwellDMA::FastCopyBlockLinearToPitch() {
-    const u32 bytes_per_pixel = regs.pitch_out / regs.line_length_in;
+    const u32 bytes_per_pixel = 1;
     const size_t src_size = GOB_SIZE;
     const size_t dst_size = static_cast<size_t>(regs.pitch_out) * regs.line_count;
     u32 pos_x = regs.src_params.origin.x;

--- a/src/video_core/engines/maxwell_dma.cpp
+++ b/src/video_core/engines/maxwell_dma.cpp
@@ -134,7 +134,8 @@ void MaxwellDMA::CopyBlockLinearToPitch() {
 
     // Deswizzle the input and copy it over.
     UNIMPLEMENTED_IF(regs.launch_dma.remap_enable != 0);
-    const u32 bytes_per_pixel = 1;
+    const u32 bytes_per_pixel =
+        regs.launch_dma.remap_enable ? regs.pitch_out / regs.line_length_in : 1;
     const Parameters& src_params = regs.src_params;
     const u32 width = src_params.width;
     const u32 height = src_params.height;
@@ -166,7 +167,8 @@ void MaxwellDMA::CopyPitchToBlockLinear() {
     UNIMPLEMENTED_IF(regs.launch_dma.remap_enable != 0);
 
     const auto& dst_params = regs.dst_params;
-    const u32 bytes_per_pixel = 1;
+    const u32 bytes_per_pixel =
+        regs.launch_dma.remap_enable ? regs.pitch_in / regs.line_length_in : 1;
     const u32 width = dst_params.width;
     const u32 height = dst_params.height;
     const u32 depth = dst_params.depth;
@@ -210,7 +212,8 @@ void MaxwellDMA::CopyPitchToBlockLinear() {
 }
 
 void MaxwellDMA::FastCopyBlockLinearToPitch() {
-    const u32 bytes_per_pixel = 1;
+    const u32 bytes_per_pixel =
+        regs.launch_dma.remap_enable ? regs.pitch_out / regs.line_length_in : 1;
     const size_t src_size = GOB_SIZE;
     const size_t dst_size = static_cast<size_t>(regs.pitch_out) * regs.line_count;
     u32 pos_x = regs.src_params.origin.x;


### PR DESCRIPTION
This is supposed to just be 1 when not remapping. There is no relationship between the pitch divided by the line length and the BPP value.

|Before|After|
|-|-|
|![010049900f546003_2022-05-06_18-16-21-493](https://user-images.githubusercontent.com/9658600/167223279-feb51f83-b14f-40c4-8957-a0209aab7f6f.png)|![010049900f546003_2022-05-06_18-08-18-472](https://user-images.githubusercontent.com/9658600/167223254-4186ea0e-4b6c-46d8-9787-7cb6d02d1b5a.png)|