### PR TITLE
OpenGL: interpret face flips according to GL NDC

### DIFF
--- a/src/video_core/renderer_opengl/gl_rasterizer.cpp
+++ b/src/video_core/renderer_opengl/gl_rasterizer.cpp
@@ -563,12 +563,11 @@ void RasterizerOpenGL::SyncViewport() {
         flags[Dirty::FrontFace] = false;
 
         GLenum mode = MaxwellToGL::FrontFace(regs.front_face);
-        bool flip_faces = false;
-        if (regs.screen_y_control.triangle_rast_flip != 0 &&
-            regs.viewport_transform[0].scale_y < 0.0f) {
+        bool flip_faces = true;
+        if (regs.screen_y_control.triangle_rast_flip != 0) {
             flip_faces = !flip_faces;
         }
-        if (regs.viewport_transform[0].scale_z < 0.0f) {
+        if (regs.viewport_transform[0].scale_y < 0.0f) {
             flip_faces = !flip_faces;
         }
         if (flip_faces) {


### PR DESCRIPTION
Better version of #8149. Now you can play Super Mario 64 in OpenGL.
Might still be wrong, but I tested a bunch of games and I didn't have any issues.

![010049900f546001_2022-05-06_20-06-12-727](https://user-images.githubusercontent.com/9658600/167229416-59a1e4bf-5505-46e5-8f73-4999faab937e.png)
