### PR TITLE
Update some files with Qt 5.15.2 best practices in mind

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -187,7 +187,7 @@ if (ENABLE_QT_TRANSLATION)
     # Update source TS file if enabled
     if (GENERATE_QT_TRANSLATION)
         get_target_property(SRCS yuzu SOURCES)
-        qt5_create_translation(QM_FILES
+        qt_create_translation(QM_FILES
             ${SRCS}
             ${UIS}
             ${YUZU_QT_LANGUAGES}/en.ts
@@ -203,7 +203,7 @@ if (ENABLE_QT_TRANSLATION)
     list(REMOVE_ITEM LANGUAGES_TS ${YUZU_QT_LANGUAGES}/en.ts)
 
     # Compile TS files to QM files
-    qt5_add_translation(LANGUAGES_QM ${LANGUAGES_TS})
+    qt_add_translation(LANGUAGES_QM ${LANGUAGES_TS})
 
     # Build a QRC file from the QM file list
     set(LANGUAGES_QRC ${CMAKE_CURRENT_BINARY_DIR}/languages.qrc)
@@ -215,7 +215,7 @@ if (ENABLE_QT_TRANSLATION)
     file(APPEND ${LANGUAGES_QRC} "</qresource></RCC>")
 
     # Add the QRC file to package in all QM files
-    qt5_add_resources(LANGUAGES ${LANGUAGES_QRC})
+    qt_add_resources(LANGUAGES ${LANGUAGES_QRC})
 else()
     set(LANGUAGES)
 endif()
@@ -236,7 +236,11 @@ if (APPLE)
     set_target_properties(yuzu PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${CMAKE_CURRENT_SOURCE_DIR}/Info.plist)
 elseif(WIN32)
     # compile as a win32 gui application instead of a console application
-    target_link_libraries(yuzu PRIVATE Qt5::WinMain)
+    if (QT_VERSION VERSION_GREATER 6)
+        target_link_libraries(yuzu PRIVATE Qt6::EntryPointPrivate)
+    else()
+        target_link_libraries(yuzu PRIVATE Qt5::WinMain)
+    endif()
     if(MSVC)
         set_target_properties(yuzu PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS")
     elseif(MINGW)
@@ -247,7 +251,7 @@ endif()
 create_target_directory_groups(yuzu)
 
 target_link_libraries(yuzu PRIVATE common core input_common video_core)
-target_link_libraries(yuzu PRIVATE Boost::boost glad Qt5::Widgets)
+target_link_libraries(yuzu PRIVATE Boost::boost glad Qt::Widgets)
 target_link_libraries(yuzu PRIVATE ${PLATFORM_LIBRARIES} Threads::Threads)
 
 target_include_directories(yuzu PRIVATE ../../externals/Vulkan-Headers/include)
@@ -255,7 +259,7 @@ if (NOT WIN32)
     target_include_directories(yuzu PRIVATE ${Qt5Gui_PRIVATE_INCLUDE_DIRS})
 endif()
 if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-    target_link_libraries(yuzu PRIVATE Qt5::DBus)
+    target_link_libraries(yuzu PRIVATE Qt::DBus)
 endif()
 
 target_compile_definitions(yuzu PRIVATE
@@ -291,7 +295,7 @@ if (USE_DISCORD_PRESENCE)
 endif()
 
 if (YUZU_USE_QT_WEB_ENGINE)
-    target_link_libraries(yuzu PRIVATE Qt5::WebEngineCore Qt5::WebEngineWidgets)
+    target_link_libraries(yuzu PRIVATE Qt::WebEngineCore Qt::WebEngineWidgets)
     target_compile_definitions(yuzu PRIVATE -DYUZU_USE_QT_WEB_ENGINE)
 endif ()
 

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -747,7 +747,7 @@ void GRenderWindow::mouseMoveEvent(QMouseEvent* event) {
     input_subsystem->GetMouse()->MouseMove(x, y, touch_x, touch_y, center_x, center_y);
 
     if (Settings::values.mouse_panning && !Settings::values.mouse_enabled) {
-        QCursor::setPos(mapToGlobal({center_x, center_y}));
+        QCursor::setPos(mapToGlobal(QPoint{center_x, center_y}));
     }
 
     emit MouseActivity();

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -10,6 +10,7 @@
 #include <mutex>
 
 #include <QImage>
+#include <QStringList>
 #include <QThread>
 #include <QTouchEvent>
 #include <QWidget>
@@ -20,7 +21,6 @@
 class GRenderWindow;
 class GMainWindow;
 class QKeyEvent;
-class QStringList;
 
 namespace Core {
 enum class SystemResultStatus : u32;

--- a/src/yuzu/configuration/configure_motion_touch.cpp
+++ b/src/yuzu/configuration/configure_motion_touch.cpp
@@ -151,6 +151,8 @@ void ConfigureMotionTouch::ConnectEvents() {
             &ConfigureMotionTouch::OnConfigureTouchCalibration);
     connect(ui->touch_from_button_config_btn, &QPushButton::clicked, this,
             &ConfigureMotionTouch::OnConfigureTouchFromButton);
+    connect(ui->buttonBox, &QDialogButtonBox::accepted, this,
+            &ConfigureMotionTouch::ApplyConfiguration);
     connect(ui->buttonBox, &QDialogButtonBox::rejected, this, [this] {
         if (CanCloseDialog()) {
             reject();

--- a/src/yuzu/configuration/configure_motion_touch.ui
+++ b/src/yuzu/configuration/configure_motion_touch.ui
@@ -293,22 +293,5 @@
   </layout>
  </widget>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>ConfigureMotionTouch</receiver>
-   <slot>ApplyConfiguration()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/src/yuzu/configuration/configure_system.cpp
+++ b/src/yuzu/configuration/configure_system.cpp
@@ -130,8 +130,7 @@ void ConfigureSystem::ApplyConfiguration() {
         // Guard if during game and set to game-specific value
         if (Settings::values.rng_seed.UsingGlobal()) {
             if (ui->rng_seed_checkbox->isChecked()) {
-                Settings::values.rng_seed.SetValue(
-                    ui->rng_seed_edit->text().toULongLong(nullptr, 16));
+                Settings::values.rng_seed.SetValue(ui->rng_seed_edit->text().toUInt(nullptr, 16));
             } else {
                 Settings::values.rng_seed.SetValue(std::nullopt);
             }
@@ -142,8 +141,7 @@ void ConfigureSystem::ApplyConfiguration() {
         case ConfigurationShared::CheckState::Off:
             Settings::values.rng_seed.SetGlobal(false);
             if (ui->rng_seed_checkbox->isChecked()) {
-                Settings::values.rng_seed.SetValue(
-                    ui->rng_seed_edit->text().toULongLong(nullptr, 16));
+                Settings::values.rng_seed.SetValue(ui->rng_seed_edit->text().toUInt(nullptr, 16));
             } else {
                 Settings::values.rng_seed.SetValue(std::nullopt);
             }

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -483,7 +483,7 @@ void GameList::DonePopulating(const QStringList& watch_list) {
     // Also artificially caps the watcher to a certain number of directories
     constexpr int LIMIT_WATCH_DIRECTORIES = 5000;
     constexpr int SLICE_SIZE = 25;
-    int len = std::min(watch_list.length(), LIMIT_WATCH_DIRECTORIES);
+    int len = std::min(static_cast<int>(watch_list.size()), LIMIT_WATCH_DIRECTORIES);
     for (int i = 0; i < len; i += SLICE_SIZE) {
         watcher->addPaths(watch_list.mid(i, i + SLICE_SIZE));
         QCoreApplication::processEvents();

--- a/src/yuzu/loading_screen.cpp
+++ b/src/yuzu/loading_screen.cpp
@@ -183,7 +183,7 @@ void LoadingScreen::OnLoadProgress(VideoCore::LoadCallbackStage stage, std::size
 
 void LoadingScreen::paintEvent(QPaintEvent* event) {
     QStyleOption opt;
-    opt.init(this);
+    opt.initFrom(this);
     QPainter p(this);
     style()->drawPrimitive(QStyle::PE_Widget, &opt, &p, this);
     QWidget::paintEvent(event);

--- a/src/yuzu/loading_screen.h
+++ b/src/yuzu/loading_screen.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <QString>
 #include <QWidget>
+#include <QtGlobal>
 
 #if !QT_CONFIG(movie)
 #define YUZU_QT_MOVIE_MISSING 1
@@ -88,4 +89,6 @@ private:
     std::size_t slow_shader_first_value = 0;
 };
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
 Q_DECLARE_METATYPE(VideoCore::LoadCallbackStage);
+#endif

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1581,7 +1581,7 @@ void GMainWindow::StoreRecentFile(const QString& filename) {
 
 void GMainWindow::UpdateRecentFiles() {
     const int num_recent_files =
-        std::min(UISettings::values.recent_files.size(), max_recent_files_item);
+        std::min(static_cast<int>(UISettings::values.recent_files.size()), max_recent_files_item);
 
     for (int i = 0; i < num_recent_files; i++) {
         const QString text = QStringLiteral("&%1. %2").arg(i + 1).arg(
@@ -3319,7 +3319,7 @@ void GMainWindow::CenterMouseCursor() {
     const int center_x = render_window->width() / 2;
     const int center_y = render_window->height() / 2;
 
-    QCursor::setPos(mapToGlobal({center_x, center_y}));
+    QCursor::setPos(mapToGlobal(QPoint{center_x, center_y}));
 }
 
 void GMainWindow::OnMouseActivity() {


### PR DESCRIPTION
Update some files with Qt 5.15.2 best practices in mind

There was some discussion about updating to Qt6 and I figured I would
work on some smaller parts. For Windows platform the WinMain function has moved
from the Qt5::WinMain to a new one called Qt6::EntryPointPrivate

Also Qt5 supports versionless CMake targets
https://www.qt.io/blog/versionless-cmake-targets-qt-5.15

These other changes in this commit are to support Qt6, but in ways that don't mess with Qt5.

src/yuzu/bootmanager.cpp: Qt6 complains about not being able to know to use QPoint or QPointF, picking QPoint
src/yuzu/bootmanager.h: Qt6 prefers that QStringList.h be included rather than an empty class definition
src/yuzu/configuration/configure_system.cpp: toULongLong intends to return unsigned 64 bit integer, but
   Settings::values.rng_seed is only 32 bits wide
src/yuzu/game_list.cpp: Qt6 returns a different datatype for QStringList.length than Qt5,
   it used to be int, but in Qt6 its now qsizetype
src/yuzu/loading_screen.cpp: Qt5's for QStyleOption.init say to switch to initFrom.
   The QStyleOption.init doesn't exist in Qt6
src/yuzu/main.cpp: Another QPointer and QStringList.size, lets standardize on count()


---
I did a hasty "Make Qt6 work just for me" build, and now I'm going back and the plan is to do everything nicely in a way that Qt5 and Qt6 are happy

