### PR TITLE
video_core/macro: clear code on upload address assignment

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -173,6 +173,8 @@ void Maxwell3D::ProcessMethodCall(u32 method, u32 argument, u32 nonshadow_argume
     case MAXWELL3D_REG_INDEX(shadow_ram_control):
         shadow_state.shadow_ram_control = static_cast<Regs::ShadowRamControl>(nonshadow_argument);
         return;
+    case MAXWELL3D_REG_INDEX(macros.upload_address):
+        return macro_engine->ClearCode(regs.macros.upload_address);
     case MAXWELL3D_REG_INDEX(macros.data):
         return macro_engine->AddCode(regs.macros.upload_address, argument);
     case MAXWELL3D_REG_INDEX(macros.bind):

--- a/src/video_core/macro/macro.cpp
+++ b/src/video_core/macro/macro.cpp
@@ -45,6 +45,11 @@ void MacroEngine::AddCode(u32 method, u32 data) {
     uploaded_macro_code[method].push_back(data);
 }
 
+void MacroEngine::ClearCode(u32 method) {
+    macro_cache.erase(method);
+    uploaded_macro_code.erase(method);
+}
+
 void MacroEngine::Execute(u32 method, const std::vector<u32>& parameters) {
     auto compiled_macro = macro_cache.find(method);
     if (compiled_macro != macro_cache.end()) {

--- a/src/video_core/macro/macro.h
+++ b/src/video_core/macro/macro.h
@@ -117,6 +117,9 @@ public:
     // Store the uploaded macro code to compile them when they're called.
     void AddCode(u32 method, u32 data);
 
+    // Clear the code associated with a method.
+    void ClearCode(u32 method);
+
     // Compiles the macro if its not in the cache, and executes the compiled macro
     void Execute(u32 method, const std::vector<u32>& parameters);
 


### PR DESCRIPTION
Allows NSO N64 to boot, since it reassigned the same macros multiple times with different code. This is more or less a workaround for the fact that we don't implement macro code uploads in a hardware-accurate way.