### PR TITLE
general: Use smaller array types where applicable

### DIFF
--- a/src/audio_core/command_generator.cpp
+++ b/src/audio_core/command_generator.cpp
@@ -129,17 +129,17 @@ s32 ToS32(float sample) {
     return static_cast<s32>(rescaled_sample);
 }
 
-constexpr std::array<std::size_t, 20> REVERB_TAP_INDEX_1CH{0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-                                                           0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+constexpr std::array<u8, 20> REVERB_TAP_INDEX_1CH{0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                                                  0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 
-constexpr std::array<std::size_t, 20> REVERB_TAP_INDEX_2CH{0, 0, 0, 1, 1, 1, 1, 0, 0, 0,
-                                                           1, 1, 1, 0, 0, 0, 0, 1, 1, 1};
+constexpr std::array<u8, 20> REVERB_TAP_INDEX_2CH{0, 0, 0, 1, 1, 1, 1, 0, 0, 0,
+                                                  1, 1, 1, 0, 0, 0, 0, 1, 1, 1};
 
-constexpr std::array<std::size_t, 20> REVERB_TAP_INDEX_4CH{0, 0, 0, 1, 1, 1, 1, 2, 2, 2,
-                                                           1, 1, 1, 0, 0, 0, 0, 3, 3, 3};
+constexpr std::array<u8, 20> REVERB_TAP_INDEX_4CH{0, 0, 0, 1, 1, 1, 1, 2, 2, 2,
+                                                  1, 1, 1, 0, 0, 0, 0, 3, 3, 3};
 
-constexpr std::array<std::size_t, 20> REVERB_TAP_INDEX_6CH{4, 0, 0, 1, 1, 1, 1, 2, 2, 2,
-                                                           1, 1, 1, 0, 0, 0, 0, 3, 3, 3};
+constexpr std::array<u8, 20> REVERB_TAP_INDEX_6CH{4, 0, 0, 1, 1, 1, 1, 2, 2, 2,
+                                                  1, 1, 1, 0, 0, 0, 0, 3, 3, 3};
 
 template <std::size_t CHANNEL_COUNT>
 void ApplyReverbGeneric(

--- a/src/core/hle/service/time/time_zone_manager.cpp
+++ b/src/core/hle/service/time/time_zone_manager.cpp
@@ -110,10 +110,9 @@ static constexpr s64 GetLeapDaysFromYear(s64 year) {
     }
 }
 
-static constexpr int GetMonthLength(bool is_leap_year, int month) {
-    constexpr std::array<int, 12> month_lengths{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
-    constexpr std::array<int, 12> month_lengths_leap{31, 29, 31, 30, 31, 30,
-                                                     31, 31, 30, 31, 30, 31};
+static constexpr s8 GetMonthLength(bool is_leap_year, int month) {
+    constexpr std::array<s8, 12> month_lengths{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    constexpr std::array<s8, 12> month_lengths_leap{31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
     return is_leap_year ? month_lengths_leap[month] : month_lengths[month];
 }
 

--- a/src/video_core/command_classes/codecs/vp9.cpp
+++ b/src/video_core/command_classes/codecs/vp9.cpp
@@ -153,7 +153,7 @@ constexpr Vp9EntropyProbs default_probs{
     .high_precision{128, 128},
 };
 
-constexpr std::array<s32, 256> norm_lut{
+constexpr std::array<u8, 256> norm_lut{
     0, 7, 6, 6, 5, 5, 5, 5, 4, 4, 4, 4, 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3, 3,
     2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -164,7 +164,7 @@ constexpr std::array<s32, 256> norm_lut{
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 };
 
-constexpr std::array<s32, 254> map_lut{
+constexpr std::array<u8, 254> map_lut{
     20,  21,  22,  23,  24,  25,  0,   26,  27,  28,  29,  30,  31,  32,  33,  34,  35,  36,  37,
     1,   38,  39,  40,  41,  42,  43,  44,  45,  46,  47,  48,  49,  2,   50,  51,  52,  53,  54,
     55,  56,  57,  58,  59,  60,  61,  3,   62,  63,  64,  65,  66,  67,  68,  69,  70,  71,  72,
@@ -232,7 +232,7 @@ constexpr std::array<s32, 254> map_lut{
             std::max(0, RecenterNonNeg(0xff - 1 - new_prob, 0xff - 1 - old_prob) - 1));
     }
 
-    return map_lut[index];
+    return static_cast<s32>(map_lut[index]);
 }
 } // Anonymous namespace
 
@@ -819,7 +819,7 @@ void VpxRangeEncoder::Write(bool bit, s32 probability) {
         local_range = range - split;
     }
 
-    s32 shift = norm_lut[local_range];
+    s32 shift = static_cast<s32>(norm_lut[local_range]);
     local_range <<= shift;
     count += shift;
 

--- a/src/video_core/surface.h
+++ b/src/video_core/surface.h
@@ -147,7 +147,7 @@ enum class SurfaceTarget {
     TextureCubeArray,
 };
 
-constexpr std::array<u32, MaxPixelFormat> BLOCK_WIDTH_TABLE = {{
+constexpr std::array<u8, MaxPixelFormat> BLOCK_WIDTH_TABLE = {{
     1,  // A8B8G8R8_UNORM
     1,  // A8B8G8R8_SNORM
     1,  // A8B8G8R8_SINT
@@ -249,7 +249,7 @@ constexpr u32 DefaultBlockWidth(PixelFormat format) {
     return BLOCK_WIDTH_TABLE[static_cast<std::size_t>(format)];
 }
 
-constexpr std::array<u32, MaxPixelFormat> BLOCK_HEIGHT_TABLE = {{
+constexpr std::array<u8, MaxPixelFormat> BLOCK_HEIGHT_TABLE = {{
     1,  // A8B8G8R8_UNORM
     1,  // A8B8G8R8_SNORM
     1,  // A8B8G8R8_SINT
@@ -351,7 +351,7 @@ constexpr u32 DefaultBlockHeight(PixelFormat format) {
     return BLOCK_HEIGHT_TABLE[static_cast<std::size_t>(format)];
 }
 
-constexpr std::array<u32, MaxPixelFormat> BITS_PER_BLOCK_TABLE = {{
+constexpr std::array<u8, MaxPixelFormat> BITS_PER_BLOCK_TABLE = {{
     32,  // A8B8G8R8_UNORM
     32,  // A8B8G8R8_SNORM
     32,  // A8B8G8R8_SINT


### PR DESCRIPTION
Using smaller array types allows for a slightly more compact executable.
This PR leads to a total reduction of 36352 bytes in the compiled executable on MSVC.

Note: There are other arrays that use larger-than-necessary types, but they do not reduce the size of the compiled executable, hence why the changes are limited to these 4 files.
Note2: The usage of u8 in BITS_PER_BLOCK_TABLE assumes that 256 bit (32 byte) formats (such as R64G64B64A64) do not exist on the Tegra X1 due to their inefficiency and impracticality.