### PR TITLE
general: Avoid ambiguous format_to compilation errors

### DIFF
--- a/src/core/arm/dynarmic/arm_dynarmic_cp15.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_cp15.cpp
@@ -20,7 +20,7 @@ struct fmt::formatter<Dynarmic::A32::CoprocReg> {
     }
     template <typename FormatContext>
     auto format(const Dynarmic::A32::CoprocReg& reg, FormatContext& ctx) {
-        return format_to(ctx.out(), "cp{}", static_cast<size_t>(reg));
+        return fmt::format_to(ctx.out(), "cp{}", static_cast<size_t>(reg));
     }
 };
 

--- a/src/shader_recompiler/frontend/ir/opcodes.h
+++ b/src/shader_recompiler/frontend/ir/opcodes.h
@@ -103,6 +103,6 @@ struct fmt::formatter<Shader::IR::Opcode> {
     }
     template <typename FormatContext>
     auto format(const Shader::IR::Opcode& op, FormatContext& ctx) {
-        return format_to(ctx.out(), "{}", Shader::IR::NameOf(op));
+        return fmt::format_to(ctx.out(), "{}", Shader::IR::NameOf(op));
     }
 };

--- a/src/shader_recompiler/frontend/maxwell/opcodes.h
+++ b/src/shader_recompiler/frontend/maxwell/opcodes.h
@@ -24,6 +24,6 @@ struct fmt::formatter<Shader::Maxwell::Opcode> {
     }
     template <typename FormatContext>
     auto format(const Shader::Maxwell::Opcode& opcode, FormatContext& ctx) {
-        return format_to(ctx.out(), "{}", NameOf(opcode));
+        return fmt::format_to(ctx.out(), "{}", NameOf(opcode));
     }
 };


### PR DESCRIPTION
Ensures that we're using the fmt version of format_to.

These are also the only three outliers. All of the other formatters we have are properly qualified.