### PR TITLE
general: Use Common::U16StringFromBuffer in place of QString::toStdU16String

### DIFF
--- a/src/common/string_util.cpp
+++ b/src/common/string_util.cpp
@@ -178,6 +178,10 @@ std::wstring UTF8ToUTF16W(const std::string& input) {
 
 #endif
 
+std::u16string U16StringFromBuffer(const u16* input, std::size_t length) {
+    return std::u16string(reinterpret_cast<const char16_t*>(input), length);
+}
+
 std::string StringFromFixedZeroTerminatedBuffer(std::string_view buffer, std::size_t max_len) {
     std::size_t len = 0;
     while (len < buffer.length() && len < max_len && buffer[len] != '\0') {

--- a/src/common/string_util.h
+++ b/src/common/string_util.h
@@ -44,6 +44,8 @@ bool SplitPath(const std::string& full_path, std::string* _pPath, std::string* _
 
 #endif
 
+[[nodiscard]] std::u16string U16StringFromBuffer(const u16* input, std::size_t length);
+
 /**
  * Compares the string defined by the range [`begin`, `end`) to the null-terminated C-string
  * `other` for equality.

--- a/src/yuzu/applets/qt_software_keyboard.cpp
+++ b/src/yuzu/applets/qt_software_keyboard.cpp
@@ -411,11 +411,11 @@ void QtSoftwareKeyboardDialog::ShowTextCheckDialog(
             break;
         }
 
-        const auto& text = ui->topOSK->currentIndex() == 1 ? ui->text_edit_osk->toPlainText()
-                                                           : ui->line_edit_osk->text();
-        std::u16string text_s = Common::U16StringFromBuffer(text.utf16(), text.size());
+        const auto text = ui->topOSK->currentIndex() == 1 ? ui->text_edit_osk->toPlainText()
+                                                          : ui->line_edit_osk->text();
+        auto text_str = Common::U16StringFromBuffer(text.utf16(), text.size());
 
-        emit SubmitNormalText(SwkbdResult::Ok, std::move(text_s), true);
+        emit SubmitNormalText(SwkbdResult::Ok, std::move(text_str), true);
         break;
     }
     }
@@ -1119,11 +1119,11 @@ void QtSoftwareKeyboardDialog::NormalKeyboardButtonClicked(QPushButton* button) 
     }
 
     if (button == ui->button_ok || button == ui->button_ok_shift || button == ui->button_ok_num) {
-        const auto& text = ui->topOSK->currentIndex() == 1 ? ui->text_edit_osk->toPlainText()
-                                                           : ui->line_edit_osk->text();
-        std::u16string text_s = Common::U16StringFromBuffer(text.utf16(), text.size());
+        const auto text = ui->topOSK->currentIndex() == 1 ? ui->text_edit_osk->toPlainText()
+                                                          : ui->line_edit_osk->text();
+        auto text_str = Common::U16StringFromBuffer(text.utf16(), text.size());
 
-        emit SubmitNormalText(SwkbdResult::Ok, std::move(text_s));
+        emit SubmitNormalText(SwkbdResult::Ok, std::move(text_str));
         return;
     }
 
@@ -1189,8 +1189,8 @@ void QtSoftwareKeyboardDialog::InlineKeyboardButtonClicked(QPushButton* button) 
         return;
     }
 
-    InlineTextInsertString(
-        Common::U16StringFromBuffer(button->text().utf16(), button->text().size()));
+    const auto button_text = button->text();
+    InlineTextInsertString(Common::U16StringFromBuffer(button_text.utf16(), button_text.size()));
 
     // Revert the keyboard to lowercase if the shift key is active.
     if (bottom_osk_index == BottomOSKIndex::UpperCase && !caps_lock_enabled) {
@@ -1283,11 +1283,11 @@ void QtSoftwareKeyboardDialog::TranslateButtonPress(Core::HID::NpadButton button
         if (is_inline) {
             emit SubmitInlineText(SwkbdReplyType::DecidedCancel, current_text, cursor_position);
         } else {
-            const auto& text = ui->topOSK->currentIndex() == 1 ? ui->text_edit_osk->toPlainText()
-                                                               : ui->line_edit_osk->text();
-            std::u16string text_s = Common::U16StringFromBuffer(text.utf16(), text.size());
+            const auto text = ui->topOSK->currentIndex() == 1 ? ui->text_edit_osk->toPlainText()
+                                                              : ui->line_edit_osk->text();
+            auto text_str = Common::U16StringFromBuffer(text.utf16(), text.size());
 
-            emit SubmitNormalText(SwkbdResult::Cancel, std::move(text_s));
+            emit SubmitNormalText(SwkbdResult::Cancel, std::move(text_str));
         }
         break;
     case Core::HID::NpadButton::Y:

--- a/src/yuzu/applets/qt_software_keyboard.cpp
+++ b/src/yuzu/applets/qt_software_keyboard.cpp
@@ -411,11 +411,11 @@ void QtSoftwareKeyboardDialog::ShowTextCheckDialog(
             break;
         }
 
-        auto text = ui->topOSK->currentIndex() == 1
-                        ? ui->text_edit_osk->toPlainText().toStdU16String()
-                        : ui->line_edit_osk->text().toStdU16String();
+        const auto& text = ui->topOSK->currentIndex() == 1 ? ui->text_edit_osk->toPlainText()
+                                                           : ui->line_edit_osk->text();
+        std::u16string text_s = Common::U16StringFromBuffer(text.utf16(), text.size());
 
-        emit SubmitNormalText(SwkbdResult::Ok, std::move(text), true);
+        emit SubmitNormalText(SwkbdResult::Ok, std::move(text_s), true);
         break;
     }
     }
@@ -562,7 +562,7 @@ void QtSoftwareKeyboardDialog::keyPressEvent(QKeyEvent* event) {
         return;
     }
 
-    InlineTextInsertString(entered_text.toStdU16String());
+    InlineTextInsertString(Common::U16StringFromBuffer(entered_text.utf16(), entered_text.size()));
 }
 
 void QtSoftwareKeyboardDialog::MoveAndResizeWindow(QPoint pos, QSize size) {
@@ -1119,11 +1119,11 @@ void QtSoftwareKeyboardDialog::NormalKeyboardButtonClicked(QPushButton* button) 
     }
 
     if (button == ui->button_ok || button == ui->button_ok_shift || button == ui->button_ok_num) {
-        auto text = ui->topOSK->currentIndex() == 1
-                        ? ui->text_edit_osk->toPlainText().toStdU16String()
-                        : ui->line_edit_osk->text().toStdU16String();
+        const auto& text = ui->topOSK->currentIndex() == 1 ? ui->text_edit_osk->toPlainText()
+                                                           : ui->line_edit_osk->text();
+        std::u16string text_s = Common::U16StringFromBuffer(text.utf16(), text.size());
 
-        emit SubmitNormalText(SwkbdResult::Ok, std::move(text));
+        emit SubmitNormalText(SwkbdResult::Ok, std::move(text_s));
         return;
     }
 
@@ -1189,7 +1189,8 @@ void QtSoftwareKeyboardDialog::InlineKeyboardButtonClicked(QPushButton* button) 
         return;
     }
 
-    InlineTextInsertString(button->text().toStdU16String());
+    InlineTextInsertString(
+        Common::U16StringFromBuffer(button->text().utf16(), button->text().size()));
 
     // Revert the keyboard to lowercase if the shift key is active.
     if (bottom_osk_index == BottomOSKIndex::UpperCase && !caps_lock_enabled) {
@@ -1282,11 +1283,11 @@ void QtSoftwareKeyboardDialog::TranslateButtonPress(Core::HID::NpadButton button
         if (is_inline) {
             emit SubmitInlineText(SwkbdReplyType::DecidedCancel, current_text, cursor_position);
         } else {
-            auto text = ui->topOSK->currentIndex() == 1
-                            ? ui->text_edit_osk->toPlainText().toStdU16String()
-                            : ui->line_edit_osk->text().toStdU16String();
+            const auto& text = ui->topOSK->currentIndex() == 1 ? ui->text_edit_osk->toPlainText()
+                                                               : ui->line_edit_osk->text();
+            std::u16string text_s = Common::U16StringFromBuffer(text.utf16(), text.size());
 
-            emit SubmitNormalText(SwkbdResult::Cancel, std::move(text));
+            emit SubmitNormalText(SwkbdResult::Cancel, std::move(text_s));
         }
         break;
     case Core::HID::NpadButton::Y:

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1401,7 +1401,8 @@ void GMainWindow::BootGame(const QString& filename, u64 program_id, std::size_t 
     if (loader != nullptr && loader->ReadProgramId(title_id) == Loader::ResultStatus::Success &&
         type == StartGameType::Normal) {
         // Load per game settings
-        const auto file_path = std::filesystem::path{filename.toStdU16String()};
+        const auto file_path =
+            std::filesystem::path{Common::U16StringFromBuffer(filename.utf16(), filename.size())};
         const auto config_file_name = title_id == 0
                                           ? Common::FS::PathToUTF8String(file_path.filename())
                                           : fmt::format("{:016X}", title_id);
@@ -1482,7 +1483,8 @@ void GMainWindow::BootGame(const QString& filename, u64 program_id, std::size_t 
     }
     if (res != Loader::ResultStatus::Success || title_name.empty()) {
         title_name = Common::FS::PathToUTF8String(
-            std::filesystem::path{filename.toStdU16String()}.filename());
+            std::filesystem::path{Common::U16StringFromBuffer(filename.utf16(), filename.size())}
+                .filename());
     }
     const bool is_64bit = system->Kernel().CurrentProcess()->Is64BitProcess();
     const auto instruction_set_suffix = is_64bit ? tr("(64-bit)") : tr("(32-bit)");


### PR DESCRIPTION
This PR aims to fix linking errors when compiling yuzu against Qt 5.15.2 and libstdc++ 12 or later with Clang 13 or 14. Linking something that uses `QString::toStdU16String` throws missing symbol errors. Without investigating it, my guess is that it requires a function that was dropped or changed from previous libstdc++ versions. 

This adds and uses `Common::U16StringFromBuffer` in string_util, which effectively works the same as the Qt function but resolves linker issues.