### PR TITLE
vulkan_device: Workaround extension bug

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -566,7 +566,7 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     }
 
     VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR workgroup_layout;
-    if (khr_workgroup_memory_explicit_layout) {
+    if (khr_workgroup_memory_explicit_layout && is_shader_int16_supported) {
         workgroup_layout = {
             .sType =
                 VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_FEATURES_KHR,
@@ -577,6 +577,11 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
             .workgroupMemoryExplicitLayout16BitAccess = VK_TRUE,
         };
         SetNext(next, workgroup_layout);
+    } else if (khr_workgroup_memory_explicit_layout) {
+        // TODO(lat9nq): Find a proper fix for this
+        LOG_WARNING(Render_Vulkan, "Disabling VK_KHR_workgroup_memory_explicit_layout due to a "
+                                   "yuzu bug when host driver does not support 16-bit integers");
+        khr_workgroup_memory_explicit_layout = false;
     }
 
     VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR executable_properties;


### PR DESCRIPTION
A bug occurs in yuzu when VK_KHR_workgroup_memory_explicit_layout is available but 16-bit integers are not supported in the host driver. This occurs notably in AMD proprietary drivers from 22.3.2 and later on Polaris devices.

This disables usage of the extension when this case arises, since I don't have the expertise to come up with a proper fix at the moment.