### PR TITLE
input_common: Make vibration request async

### DIFF
--- a/src/common/input.h
+++ b/src/common/input.h
@@ -72,6 +72,7 @@ enum class PollingError {
 enum class VibrationAmplificationType {
     Linear,
     Exponential,
+    Test,
 };
 
 // Analog properties for calibration


### PR DESCRIPTION
Some controllers are too slow to respond when a vibration request was made. This caused the whole emulated thread to be delayed causing some heavy stutters.

This PR pushes SDL vibrations to a queue where they can be executed on a different thread. This avoids locking the main emulation thread
