### PR TITLE
vulkan_device: Block AMDVLK's VK_KHR_push_descriptor

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -664,6 +664,17 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     const bool is_amd =
         driver_id == VK_DRIVER_ID_AMD_PROPRIETARY || driver_id == VK_DRIVER_ID_AMD_OPEN_SOURCE;
     if (is_amd) {
+        // TODO(lat9nq): Add an upper bound when AMD fixes their VK_KHR_push_descriptor
+        const bool has_broken_push_descriptor = VK_VERSION_MAJOR(properties.driverVersion) == 2 &&
+                                                VK_VERSION_MINOR(properties.driverVersion) == 0 &&
+                                                VK_VERSION_PATCH(properties.driverVersion) >= 226;
+        if (khr_push_descriptor && has_broken_push_descriptor) {
+            LOG_WARNING(
+                Render_Vulkan,
+                "Disabling AMD driver 2.0.226 and later from broken VK_KHR_push_descriptor");
+            khr_push_descriptor = false;
+        }
+
         // AMD drivers need a higher amount of Sets per Pool in certain circunstances like in XC2.
         sets_per_pool = 96;
         // Disable VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT on AMD GCN4 and lower as it is broken.


### PR DESCRIPTION
Recent AMD Vulkan drivers (22.5.2, or 2.0.226 for specifically Vulkan) have a broken initial implementation of VK_KHR_push_descriptor that causes a crash in yuzu. Disable it for the time being.

Specifically RX 6400 and RX 6500XT devices will still crash to an unknown reason. All other cards appear to work with this as far as it's been tested.