### PR TITLE
yuzu: Make variable shadowing a compile-time error

### DIFF
--- a/externals/microprofile/microprofile.h
+++ b/externals/microprofile/microprofile.h
@@ -1246,7 +1246,7 @@ struct MicroProfileScopeLock
 {
     bool bUseLock;
     std::recursive_mutex& m;
-    MicroProfileScopeLock(std::recursive_mutex& m) : bUseLock(g_bUseLock), m(m)
+    MicroProfileScopeLock(std::recursive_mutex& m_) : bUseLock(g_bUseLock), m(m_)
     {
         if(bUseLock)
             m.lock();

--- a/externals/microprofile/microprofileui.h
+++ b/externals/microprofile/microprofileui.h
@@ -213,8 +213,8 @@ struct MicroProfileCustom
 
 struct SOptionDesc
 {
-    SOptionDesc(){}
-    SOptionDesc(uint8_t nSubType, uint8_t nIndex, const char* fmt, ...):nSubType(nSubType), nIndex(nIndex)
+    SOptionDesc()=default;
+    SOptionDesc(uint8_t nSubType_, uint8_t nIndex_, const char* fmt, ...):nSubType(nSubType_), nIndex(nIndex_)
     {
         va_list args;
         va_start (args, fmt);
@@ -573,10 +573,10 @@ inline void MicroProfileToolTipMeta(MicroProfileStringArray* pToolTip)
                     }
                     else
                     {
-                        for(int i = 0; i < MICROPROFILE_META_MAX; ++i)
+                        for(int k = 0; k < MICROPROFILE_META_MAX; ++k)
                         {
-                            nMetaSumInclusive[i] += nMetaSum[i];
-                            nMetaSum[i] = 0;
+                            nMetaSumInclusive[k] += nMetaSum[k];
+                            nMetaSum[k] = 0;
                         }
                     }
                     break;
@@ -708,10 +708,10 @@ inline void MicroProfileDrawFloatTooltip(uint32_t nX, uint32_t nY, uint32_t nTok
 
     if(UI.nMouseLeftMod)
     {
-        int nIndex = (g_MicroProfileUI.LockedToolTipFront + MICROPROFILE_TOOLTIP_MAX_LOCKED - 1) % MICROPROFILE_TOOLTIP_MAX_LOCKED;
-        g_MicroProfileUI.nLockedToolTipColor[nIndex] = S.TimerInfo[nTimerId].nColor;
-        MicroProfileStringArrayCopy(&g_MicroProfileUI.LockedToolTips[nIndex], &ToolTip);
-        g_MicroProfileUI.LockedToolTipFront = nIndex;
+        int nToolTipIndex = (g_MicroProfileUI.LockedToolTipFront + MICROPROFILE_TOOLTIP_MAX_LOCKED - 1) % MICROPROFILE_TOOLTIP_MAX_LOCKED;
+        g_MicroProfileUI.nLockedToolTipColor[nToolTipIndex] = S.TimerInfo[nTimerId].nColor;
+        MicroProfileStringArrayCopy(&g_MicroProfileUI.LockedToolTips[nToolTipIndex], &ToolTip);
+        g_MicroProfileUI.LockedToolTipFront = nToolTipIndex;
 
     }
 }
@@ -917,9 +917,8 @@ inline void MicroProfileDrawDetailedBars(uint32_t nWidth, uint32_t nHeight, int 
         float fStart = floor(fMsBase*fRcpStep) * fStep;
         for(float f = fStart; f < fMsEnd; )
         {
-            float fStart = f;
             float fNext = f + fStep;
-            MicroProfileDrawBox(((fStart-fMsBase) * fMsToScreen), nBaseY, (fNext-fMsBase) * fMsToScreen+1, nBaseY + nHeight, UI.nOpacityBackground | g_nMicroProfileBackColors[nColorIndex++ & 1]);
+            MicroProfileDrawBox(((f-fMsBase) * fMsToScreen), nBaseY, (fNext-fMsBase) * fMsToScreen+1, nBaseY + nHeight, UI.nOpacityBackground | g_nMicroProfileBackColors[nColorIndex++ & 1]);
             f = fNext;
         }
     }
@@ -1116,9 +1115,9 @@ inline void MicroProfileDrawDetailedBars(uint32_t nWidth, uint32_t nHeight, int 
 
                         nMaxStackDepth = MicroProfileMax(nMaxStackDepth, nStackPos);
                         float fMsStart = fToMs * MicroProfileLogTickDifference(nBaseTicks, nTickStart);
-                        float fMsEnd = fToMs * MicroProfileLogTickDifference(nBaseTicks, nTickEnd);
+                        float fMsEnd2 = fToMs * MicroProfileLogTickDifference(nBaseTicks, nTickEnd);
                         float fXStart = fMsStart * fMsToScreen;
-                        float fXEnd = fMsEnd * fMsToScreen;
+                        float fXEnd = fMsEnd2 * fMsToScreen;
                         float fYStart = (float)(nY + nStackPos * nYDelta);
                         float fYEnd = fYStart + (MICROPROFILE_DETAILED_BAR_HEIGHT);
                         float fXDist = MicroProfileMax(fXStart - fMouseX, fMouseX - fXEnd);
@@ -1269,22 +1268,22 @@ inline void MicroProfileDrawDetailedBars(uint32_t nWidth, uint32_t nHeight, int 
         if(UI.nRangeBegin != UI.nRangeEnd)
         {
             float fMsStart = fToMsCpu * MicroProfileLogTickDifference(nBaseTicksCpu, UI.nRangeBegin);
-            float fMsEnd = fToMsCpu * MicroProfileLogTickDifference(nBaseTicksCpu, UI.nRangeEnd);
+            float fMsEnd3 = fToMsCpu * MicroProfileLogTickDifference(nBaseTicksCpu, UI.nRangeEnd);
             float fXStart = fMsStart * fMsToScreen;
-            float fXEnd = fMsEnd * fMsToScreen;
+            float fXEnd = fMsEnd3 * fMsToScreen;
             MicroProfileDrawBox(fXStart, nBaseY, fXEnd, nHeight, MICROPROFILE_FRAME_COLOR_HIGHTLIGHT, MicroProfileBoxTypeFlat);
             MicroProfileDrawLineVertical(fXStart, nBaseY, nHeight, MICROPROFILE_FRAME_COLOR_HIGHTLIGHT | 0x44000000);
             MicroProfileDrawLineVertical(fXEnd, nBaseY, nHeight, MICROPROFILE_FRAME_COLOR_HIGHTLIGHT | 0x44000000);
 
             fMsStart += fDetailedOffset;
-            fMsEnd += fDetailedOffset;
+            fMsEnd3 += fDetailedOffset;
             char sBuffer[32];
             uint32_t nLenStart = snprintf(sBuffer, sizeof(sBuffer)-1, "%.2fms", fMsStart);
             float fStartTextWidth = (float)((1+MICROPROFILE_TEXT_WIDTH) * nLenStart);
             float fStartTextX = fXStart - fStartTextWidth - 2;
             MicroProfileDrawBox(fStartTextX, nBaseY, fStartTextX + fStartTextWidth + 2, MICROPROFILE_TEXT_HEIGHT + 2 + nBaseY, 0x33000000, MicroProfileBoxTypeFlat);
             MicroProfileDrawText(fStartTextX+1, nBaseY, UINT32_MAX, sBuffer, nLenStart);
-            uint32_t nLenEnd = snprintf(sBuffer, sizeof(sBuffer)-1, "%.2fms", fMsEnd);
+            uint32_t nLenEnd = snprintf(sBuffer, sizeof(sBuffer)-1, "%.2fms", fMsEnd3);
             MicroProfileDrawBox(fXEnd+1, nBaseY, fXEnd+1+(1+MICROPROFILE_TEXT_WIDTH) * nLenEnd + 3, MICROPROFILE_TEXT_HEIGHT + 2 + nBaseY, 0x33000000, MicroProfileBoxTypeFlat);
             MicroProfileDrawText(fXEnd+2, nBaseY+1, UINT32_MAX, sBuffer, nLenEnd);
 
@@ -1297,9 +1296,9 @@ inline void MicroProfileDrawDetailedBars(uint32_t nWidth, uint32_t nHeight, int 
         if(UI.nRangeBeginGpu != UI.nRangeEndGpu)
         {
             float fMsStart = fToMsGpu * MicroProfileLogTickDifference(nBaseTicksGpu, UI.nRangeBeginGpu);
-            float fMsEnd = fToMsGpu * MicroProfileLogTickDifference(nBaseTicksGpu, UI.nRangeEndGpu);
+            float fMsEnd4 = fToMsGpu * MicroProfileLogTickDifference(nBaseTicksGpu, UI.nRangeEndGpu);
             float fXStart = fMsStart * fMsToScreen;
-            float fXEnd = fMsEnd * fMsToScreen;
+            float fXEnd = fMsEnd4 * fMsToScreen;
             MicroProfileDrawBox(fXStart, nBaseY, fXEnd, nHeight, MICROPROFILE_FRAME_COLOR_HIGHTLIGHT_GPU, MicroProfileBoxTypeFlat);
             MicroProfileDrawLineVertical(fXStart, nBaseY, nHeight, MICROPROFILE_FRAME_COLOR_HIGHTLIGHT_GPU | 0x44000000);
             MicroProfileDrawLineVertical(fXEnd, nBaseY, nHeight, MICROPROFILE_FRAME_COLOR_HIGHTLIGHT_GPU | 0x44000000);
@@ -1307,14 +1306,14 @@ inline void MicroProfileDrawDetailedBars(uint32_t nWidth, uint32_t nHeight, int 
             nBaseY += MICROPROFILE_TEXT_HEIGHT+1;
 
             fMsStart += fDetailedOffset;
-            fMsEnd += fDetailedOffset;
+            fMsEnd4 += fDetailedOffset;
             char sBuffer[32];
             uint32_t nLenStart = snprintf(sBuffer, sizeof(sBuffer)-1, "%.2fms", fMsStart);
             float fStartTextWidth = (float)((1+MICROPROFILE_TEXT_WIDTH) * nLenStart);
             float fStartTextX = fXStart - fStartTextWidth - 2;
             MicroProfileDrawBox(fStartTextX, nBaseY, fStartTextX + fStartTextWidth + 2, MICROPROFILE_TEXT_HEIGHT + 2 + nBaseY, 0x33000000, MicroProfileBoxTypeFlat);
             MicroProfileDrawText(fStartTextX+1, nBaseY, UINT32_MAX, sBuffer, nLenStart);
-            uint32_t nLenEnd = snprintf(sBuffer, sizeof(sBuffer)-1, "%.2fms", fMsEnd);
+            uint32_t nLenEnd = snprintf(sBuffer, sizeof(sBuffer)-1, "%.2fms", fMsEnd4);
             MicroProfileDrawBox(fXEnd+1, nBaseY, fXEnd+1+(1+MICROPROFILE_TEXT_WIDTH) * nLenEnd + 3, MICROPROFILE_TEXT_HEIGHT + 2 + nBaseY, 0x33000000, MicroProfileBoxTypeFlat);
             MicroProfileDrawText(fXEnd+2, nBaseY+1, UINT32_MAX, sBuffer, nLenEnd);
         }
@@ -1716,8 +1715,8 @@ bool MicroProfileDrawGraph(uint32_t nScreenWidth, uint32_t nScreenHeight)
         uint32_t nTextCount = 0;
         uint32_t nGraphIndex = (S.nGraphPut + MICROPROFILE_GRAPH_HISTORY - int(MICROPROFILE_GRAPH_HISTORY*(1.f - fMouseXPrc))) % MICROPROFILE_GRAPH_HISTORY;
 
-        uint32_t nX = UI.nMouseX;
-        uint32_t nY = UI.nMouseY + 20;
+        uint32_t nMouseX = UI.nMouseX;
+        uint32_t nMouseY = UI.nMouseY + 20;
 
         for(uint32_t i = 0; i < MICROPROFILE_MAX_GRAPHS; ++i)
         {
@@ -1736,7 +1735,7 @@ bool MicroProfileDrawGraph(uint32_t nScreenWidth, uint32_t nScreenHeight)
         }
         if(nTextCount)
         {
-            MicroProfileDrawFloatWindow(nX, nY, Strings.ppStrings, Strings.nNumStrings, 0, pColors);
+            MicroProfileDrawFloatWindow(nMouseX, nMouseY, Strings.ppStrings, Strings.nNumStrings, 0, pColors);
         }
 
         if(UI.nMouseRight)
@@ -2321,8 +2320,8 @@ inline void MicroProfileDrawMenu(uint32_t nWidth, uint32_t nHeight)
     uint32_t    nMenuX[MICROPROFILE_MENU_MAX] = {0};
     uint32_t nNumMenuItems = 0;
 
-    int nLen = snprintf(buffer, 127, "MicroProfile");
-    MicroProfileDrawText(nX, nY, UINT32_MAX, buffer, nLen);
+    int nMPTextLen = snprintf(buffer, 127, "MicroProfile");
+    MicroProfileDrawText(nX, nY, UINT32_MAX, buffer, nMPTextLen);
     nX += (sizeof("MicroProfile")+2) * (MICROPROFILE_TEXT_WIDTH+1);
     pMenuText[nNumMenuItems++] = "Mode";
     pMenuText[nNumMenuItems++] = "Groups";
@@ -2438,16 +2437,16 @@ inline void MicroProfileDrawMenu(uint32_t nWidth, uint32_t nHeight)
         int nNumLines = 0;
         bool bSelected = false;
         const char* pString = CB(nNumLines, &bSelected);
-        uint32_t nWidth = 0, nHeight = 0;
+        uint32_t nTextWidth = 0, nTextHeight = 0;
         while(pString)
         {
-            nWidth = MicroProfileMax<int>(nWidth, (int)strlen(pString));
+            nTextWidth = MicroProfileMax<int>(nTextWidth, (int)strlen(pString));
             nNumLines++;
             pString = CB(nNumLines, &bSelected);
         }
-        nWidth = (2+nWidth) * (MICROPROFILE_TEXT_WIDTH+1);
-        nHeight = nNumLines * (MICROPROFILE_TEXT_HEIGHT+1);
-        if(UI.nMouseY <= nY + nHeight+0 && UI.nMouseY >= nY-0 && UI.nMouseX <= nX + nWidth + 0 && UI.nMouseX >= nX - 0)
+        nTextWidth = (2+nTextWidth) * (MICROPROFILE_TEXT_WIDTH+1);
+        nTextHeight = nNumLines * (MICROPROFILE_TEXT_HEIGHT+1);
+        if(UI.nMouseY <= nY + nTextHeight+0 && UI.nMouseY >= nY-0 && UI.nMouseX <= nX + nTextWidth + 0 && UI.nMouseX >= nX - 0)
         {
             UI.nActiveMenu = nMenu;
         }
@@ -2455,21 +2454,21 @@ inline void MicroProfileDrawMenu(uint32_t nWidth, uint32_t nHeight)
         {
             UI.nActiveMenu = UINT32_MAX;
         }
-        MicroProfileDrawBox(nX, nY, nX + nWidth, nY + nHeight, 0xff000000|g_nMicroProfileBackColors[1]);
+        MicroProfileDrawBox(nX, nY, nX + nTextWidth, nY + nTextHeight, 0xff000000|g_nMicroProfileBackColors[1]);
         for(int i = 0; i < nNumLines; ++i)
         {
-            bool bSelected = false;
-            const char* pString = CB(i, &bSelected);
+            bool bSelected2 = false;
+            const char* pString2 = CB(i, &bSelected2);
             if(UI.nMouseY >= nY && UI.nMouseY < nY + MICROPROFILE_TEXT_HEIGHT + 1)
             {
                 if(UI.nMouseLeft || UI.nMouseRight)
                 {
                     CBClick[nMenu](i);
                 }
-                MicroProfileDrawBox(nX, nY, nX + nWidth, nY + MICROPROFILE_TEXT_HEIGHT + 1, 0xff888888);
+                MicroProfileDrawBox(nX, nY, nX + nTextWidth, nY + MICROPROFILE_TEXT_HEIGHT + 1, 0xff888888);
             }
-            int nLen = snprintf(buffer, SBUF_SIZE-1, "%c %s", bSelected ? '*' : ' ' ,pString);
-            MicroProfileDrawText(nX, nY, UINT32_MAX, buffer, nLen);
+            int nTextLen = snprintf(buffer, SBUF_SIZE-1, "%c %s", bSelected2 ? '*' : ' ' ,pString2);
+            MicroProfileDrawText(nX, nY, UINT32_MAX, buffer, nTextLen);
             nY += MICROPROFILE_TEXT_HEIGHT+1;
         }
     }
@@ -2605,7 +2604,7 @@ inline void MicroProfileDrawCustom(uint32_t nWidth, uint32_t nHeight)
             for(uint32_t i = 0; i < nCount; ++i)
             {
                 nOffsetY += (1+MICROPROFILE_TEXT_HEIGHT);
-                uint32_t nWidth = MicroProfileMin(nMaxWidth, (uint32_t)(nMaxWidth * pMs[i] * fRcpReference));
+                nWidth = MicroProfileMin(nMaxWidth, (uint32_t)(nMaxWidth * pMs[i] * fRcpReference));
                 MicroProfileDrawBox(nMaxOffsetX, nOffsetY, nMaxOffsetX+nWidth, nOffsetY+MICROPROFILE_TEXT_HEIGHT, pColors[i]|0xff000000);
             }
         }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,10 @@ if (MSVC)
         /we4305 # 'context': truncation from 'type1' to 'type2'
         /we4388 # 'expression': signed/unsigned mismatch
         /we4389 # 'operator': signed/unsigned mismatch
+        /we4456 # Declaration of 'identifier' hides previous local declaration
+        /we4457 # Declaration of 'identifier' hides function parameter
+        /we4458 # Declaration of 'identifier' hides class member
+        /we4459 # Declaration of 'identifier' hides global declaration
         /we4505 # 'function': unreferenced local function has been removed
         /we4547 # 'operator': operator before comma has no effect; expected operator with side-effect
         /we4549 # 'operator1': operator before comma has no effect; did you intend 'operator2'?
@@ -92,6 +96,7 @@ else()
         -Werror=missing-declarations
         -Werror=missing-field-initializers
         -Werror=reorder
+        -Werror=shadow
         -Werror=sign-compare
         -Werror=switch
         -Werror=uninitialized

--- a/src/audio_core/CMakeLists.txt
+++ b/src/audio_core/CMakeLists.txt
@@ -49,9 +49,7 @@ if (NOT MSVC)
     target_compile_options(audio_core PRIVATE
         -Werror=conversion
         -Werror=ignored-qualifiers
-        -Werror=shadow
         -Werror=unused-parameter
-        -Werror=unused-variable
 
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-variable>

--- a/src/audio_core/CMakeLists.txt
+++ b/src/audio_core/CMakeLists.txt
@@ -49,7 +49,6 @@ if (NOT MSVC)
     target_compile_options(audio_core PRIVATE
         -Werror=conversion
         -Werror=ignored-qualifiers
-        -Werror=unused-parameter
 
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-variable>

--- a/src/common/detached_tasks.cpp
+++ b/src/common/detached_tasks.cpp
@@ -33,9 +33,9 @@ void DetachedTasks::AddTask(std::function<void()> task) {
     ++instance->count;
     std::thread([task{std::move(task)}]() {
         task();
-        std::unique_lock lock{instance->mutex};
+        std::unique_lock thread_lock{instance->mutex};
         --instance->count;
-        std::notify_all_at_thread_exit(instance->cv, std::move(lock));
+        std::notify_all_at_thread_exit(instance->cv, std::move(thread_lock));
     }).detach();
 }
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -743,16 +743,11 @@ if (MSVC)
         /we4244 # 'conversion': conversion from 'type1' to 'type2', possible loss of data
         /we4245 # 'conversion': conversion from 'type1' to 'type2', signed/unsigned mismatch
         /we4254 # 'operator': conversion from 'type1:field_bits' to 'type2:field_bits', possible loss of data
-        /we4456 # Declaration of 'identifier' hides previous local declaration
-        /we4457 # Declaration of 'identifier' hides function parameter
-        /we4458 # Declaration of 'identifier' hides class member
-        /we4459 # Declaration of 'identifier' hides global declaration
     )
 else()
     target_compile_options(core PRIVATE
         -Werror=conversion
         -Werror=ignored-qualifiers
-        -Werror=shadow
 
         $<$<CXX_COMPILER_ID:GNU>:-Werror=class-memaccess>
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>

--- a/src/input_common/CMakeLists.txt
+++ b/src/input_common/CMakeLists.txt
@@ -44,7 +44,6 @@ else()
         -Werror
         -Werror=conversion
         -Werror=ignored-qualifiers
-        -Werror=shadow
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-variable>
         -Werror=unused-variable

--- a/src/shader_recompiler/CMakeLists.txt
+++ b/src/shader_recompiler/CMakeLists.txt
@@ -253,9 +253,6 @@ else()
         -Werror
         -Werror=conversion
         -Werror=ignored-qualifiers
-        -Werror=implicit-fallthrough
-        -Werror=shadow
-        -Werror=sign-compare
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-parameter>
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-variable>
         -Werror=unused-variable

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -258,10 +258,6 @@ if (MSVC)
     target_compile_options(video_core PRIVATE
         /we4242 # 'identifier': conversion from 'type1' to 'type2', possible loss of data
         /we4244 # 'conversion': conversion from 'type1' to 'type2', possible loss of data
-        /we4456 # Declaration of 'identifier' hides previous local declaration
-        /we4457 # Declaration of 'identifier' hides function parameter
-        /we4458 # Declaration of 'identifier' hides class member
-        /we4459 # Declaration of 'identifier' hides global declaration
     )
 else()
     target_compile_options(video_core PRIVATE
@@ -269,7 +265,6 @@ else()
         -Wno-error=sign-conversion
         -Werror=pessimizing-move
         -Werror=redundant-move
-        -Werror=shadow
         -Werror=type-limits
 
         $<$<CXX_COMPILER_ID:GNU>:-Werror=class-memaccess>

--- a/src/web_service/telemetry_json.cpp
+++ b/src/web_service/telemetry_json.cpp
@@ -13,8 +13,8 @@ namespace WebService {
 namespace Telemetry = Common::Telemetry;
 
 struct TelemetryJson::Impl {
-    Impl(std::string host, std::string username, std::string token)
-        : host{std::move(host)}, username{std::move(username)}, token{std::move(token)} {}
+    Impl(std::string host_, std::string username_, std::string token_)
+        : host{std::move(host_)}, username{std::move(username_)}, token{std::move(token_)} {}
 
     nlohmann::json& TopSection() {
         return sections[static_cast<u8>(Telemetry::FieldType::None)];

--- a/src/web_service/web_backend.cpp
+++ b/src/web_service/web_backend.cpp
@@ -30,10 +30,10 @@ constexpr std::array<const char, 1> API_VERSION{'1'};
 constexpr std::size_t TIMEOUT_SECONDS = 30;
 
 struct Client::Impl {
-    Impl(std::string host, std::string username, std::string token)
-        : host{std::move(host)}, username{std::move(username)}, token{std::move(token)} {
+    Impl(std::string host_, std::string username_, std::string token_)
+        : host{std::move(host_)}, username{std::move(username_)}, token{std::move(token_)} {
         std::scoped_lock lock{jwt_cache.mutex};
-        if (this->username == jwt_cache.username && this->token == jwt_cache.token) {
+        if (username == jwt_cache.username && token == jwt_cache.token) {
             jwt = jwt_cache.jwt;
         }
     }
@@ -69,8 +69,8 @@ struct Client::Impl {
      */
     WebResult GenericRequest(const std::string& method, const std::string& path,
                              const std::string& data, const std::string& accept,
-                             const std::string& jwt = "", const std::string& username = "",
-                             const std::string& token = "") {
+                             const std::string& jwt_ = "", const std::string& username_ = "",
+                             const std::string& token_ = "") {
         if (cli == nullptr) {
             cli = std::make_unique<httplib::Client>(host.c_str());
         }
@@ -85,14 +85,14 @@ struct Client::Impl {
         cli->set_write_timeout(TIMEOUT_SECONDS);
 
         httplib::Headers params;
-        if (!jwt.empty()) {
+        if (!jwt_.empty()) {
             params = {
-                {std::string("Authorization"), fmt::format("Bearer {}", jwt)},
+                {std::string("Authorization"), fmt::format("Bearer {}", jwt_)},
             };
-        } else if (!username.empty()) {
+        } else if (!username_.empty()) {
             params = {
-                {std::string("x-username"), username},
-                {std::string("x-token"), token},
+                {std::string("x-username"), username_},
+                {std::string("x-token"), token_},
             };
         }
 

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -364,9 +364,9 @@ void GRenderWindow::RestoreGeometry() {
     QWidget::restoreGeometry(geometry);
 }
 
-void GRenderWindow::restoreGeometry(const QByteArray& geometry) {
+void GRenderWindow::restoreGeometry(const QByteArray& geometry_) {
     // Make sure users of this class don't need to deal with backing up the geometry themselves
-    QWidget::restoreGeometry(geometry);
+    QWidget::restoreGeometry(geometry_);
     BackupGeometry();
 }
 
@@ -1014,8 +1014,8 @@ QStringList GRenderWindow::GetUnsupportedGLExtensions() const {
     return unsupported_ext;
 }
 
-void GRenderWindow::OnEmulationStarting(EmuThread* emu_thread) {
-    this->emu_thread = emu_thread;
+void GRenderWindow::OnEmulationStarting(EmuThread* emu_thread_) {
+    emu_thread = emu_thread_;
 }
 
 void GRenderWindow::OnEmulationStopping() {

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -127,7 +127,7 @@ void EmuThread::run() {
 class OpenGLSharedContext : public Core::Frontend::GraphicsContext {
 public:
     /// Create the original context that should be shared from
-    explicit OpenGLSharedContext(QSurface* surface) : surface(surface) {
+    explicit OpenGLSharedContext(QSurface* surface_) : surface{surface_} {
         QSurfaceFormat format;
         format.setVersion(4, 6);
         format.setProfile(QSurfaceFormat::CompatibilityProfile);

--- a/src/yuzu/bootmanager.h
+++ b/src/yuzu/bootmanager.h
@@ -56,12 +56,12 @@ public:
 
     /**
      * Sets whether the emulation thread is running or not
-     * @param running Boolean value, set the emulation thread to running if true
+     * @param running_ Boolean value, set the emulation thread to running if true
      * @note This function is thread-safe
      */
-    void SetRunning(bool running) {
+    void SetRunning(bool running_) {
         std::unique_lock lock{running_mutex};
-        this->running = running;
+        running = running_;
         lock.unlock();
         running_cv.notify_all();
         if (!running) {
@@ -138,8 +138,8 @@ public:
 
     void BackupGeometry();
     void RestoreGeometry();
-    void restoreGeometry(const QByteArray& geometry); // overridden
-    QByteArray saveGeometry();                        // overridden
+    void restoreGeometry(const QByteArray& geometry_); // overridden
+    QByteArray saveGeometry();                         // overridden
 
     qreal windowPixelRatio() const;
 
@@ -189,7 +189,7 @@ public:
     void Exit();
 
 public slots:
-    void OnEmulationStarting(EmuThread* emu_thread);
+    void OnEmulationStarting(EmuThread* emu_thread_);
     void OnEmulationStopping();
     void OnFramebufferSizeChanged();
 

--- a/src/yuzu/configuration/configure_dialog.cpp
+++ b/src/yuzu/configuration/configure_dialog.cpp
@@ -27,12 +27,11 @@
 #include "yuzu/hotkeys.h"
 #include "yuzu/uisettings.h"
 
-ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry,
+ConfigureDialog::ConfigureDialog(QWidget* parent, HotkeyRegistry& registry_,
                                  InputCommon::InputSubsystem* input_subsystem,
                                  Core::System& system_)
-    : QDialog(parent), ui{std::make_unique<Ui::ConfigureDialog>()},
-      registry(registry), system{system_}, audio_tab{std::make_unique<ConfigureAudio>(system_,
-                                                                                      this)},
+    : QDialog(parent), ui{std::make_unique<Ui::ConfigureDialog>()}, registry{registry_},
+      system{system_}, audio_tab{std::make_unique<ConfigureAudio>(system_, this)},
       cpu_tab{std::make_unique<ConfigureCpu>(system_, this)},
       debug_tab_tab{std::make_unique<ConfigureDebugTab>(system_, this)},
       filesystem_tab{std::make_unique<ConfigureFilesystem>(this)},

--- a/src/yuzu/configuration/configure_dialog.h
+++ b/src/yuzu/configuration/configure_dialog.h
@@ -40,7 +40,7 @@ class ConfigureDialog : public QDialog {
     Q_OBJECT
 
 public:
-    explicit ConfigureDialog(QWidget* parent, HotkeyRegistry& registry,
+    explicit ConfigureDialog(QWidget* parent, HotkeyRegistry& registry_,
                              InputCommon::InputSubsystem* input_subsystem, Core::System& system_);
     ~ConfigureDialog() override;
 

--- a/src/yuzu/configuration/configure_per_game.cpp
+++ b/src/yuzu/configuration/configure_per_game.cpp
@@ -35,10 +35,10 @@
 #include "yuzu/uisettings.h"
 #include "yuzu/util/util.h"
 
-ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id, const std::string& file_name,
+ConfigurePerGame::ConfigurePerGame(QWidget* parent, u64 title_id_, const std::string& file_name,
                                    Core::System& system_)
-    : QDialog(parent), ui(std::make_unique<Ui::ConfigurePerGame>()),
-      title_id(title_id), system{system_} {
+    : QDialog(parent),
+      ui(std::make_unique<Ui::ConfigurePerGame>()), title_id{title_id_}, system{system_} {
     const auto file_path = std::filesystem::path(Common::FS::ToU8String(file_name));
     const auto config_file_name = title_id == 0 ? Common::FS::PathToUTF8String(file_path.filename())
                                                 : fmt::format("{:016X}", title_id);

--- a/src/yuzu/configuration/configure_per_game.cpp
+++ b/src/yuzu/configuration/configure_per_game.cpp
@@ -116,8 +116,8 @@ void ConfigurePerGame::HandleApplyButtonClicked() {
     ApplyConfiguration();
 }
 
-void ConfigurePerGame::LoadFromFile(FileSys::VirtualFile file) {
-    this->file = std::move(file);
+void ConfigurePerGame::LoadFromFile(FileSys::VirtualFile file_) {
+    file = std::move(file_);
     LoadConfiguration();
 }
 

--- a/src/yuzu/configuration/configure_per_game.h
+++ b/src/yuzu/configuration/configure_per_game.h
@@ -46,7 +46,7 @@ public:
     /// Save all button configurations to settings file
     void ApplyConfiguration();
 
-    void LoadFromFile(FileSys::VirtualFile file);
+    void LoadFromFile(FileSys::VirtualFile file_);
 
 private:
     void changeEvent(QEvent* event) override;

--- a/src/yuzu/configuration/configure_per_game.h
+++ b/src/yuzu/configuration/configure_per_game.h
@@ -39,7 +39,7 @@ class ConfigurePerGame : public QDialog {
 
 public:
     // Cannot use std::filesystem::path due to https://bugreports.qt.io/browse/QTBUG-73263
-    explicit ConfigurePerGame(QWidget* parent, u64 title_id, const std::string& file_name,
+    explicit ConfigurePerGame(QWidget* parent, u64 title_id_, const std::string& file_name,
                               Core::System& system_);
     ~ConfigurePerGame() override;
 

--- a/src/yuzu/configuration/configure_per_game_addons.cpp
+++ b/src/yuzu/configuration/configure_per_game_addons.cpp
@@ -89,8 +89,8 @@ void ConfigurePerGameAddons::ApplyConfiguration() {
     Settings::values.disabled_addons[title_id] = disabled_addons;
 }
 
-void ConfigurePerGameAddons::LoadFromFile(FileSys::VirtualFile file) {
-    this->file = std::move(file);
+void ConfigurePerGameAddons::LoadFromFile(FileSys::VirtualFile file_) {
+    file = std::move(file_);
     LoadConfiguration();
 }
 

--- a/src/yuzu/configuration/configure_per_game_addons.h
+++ b/src/yuzu/configuration/configure_per_game_addons.h
@@ -35,7 +35,7 @@ public:
     /// Save all button configurations to settings file
     void ApplyConfiguration();
 
-    void LoadFromFile(FileSys::VirtualFile file);
+    void LoadFromFile(FileSys::VirtualFile file_);
 
     void SetTitleId(u64 id);
 

--- a/src/yuzu/configuration/configure_ringcon.cpp
+++ b/src/yuzu/configuration/configure_ringcon.cpp
@@ -165,10 +165,10 @@ ConfigureRingController::ConfigureRingController(QWidget* parent,
                         const std::string invert_str = invert_value ? "+" : "-";
                         param.Set("invert_x", invert_str);
                         emulated_device->SetRingParam(param);
-                        for (int sub_button_id = 0; sub_button_id < ANALOG_SUB_BUTTONS_NUM;
-                             ++sub_button_id) {
-                            analog_map_buttons[sub_button_id]->setText(
-                                AnalogToText(param, analog_sub_buttons[sub_button_id]));
+                        for (int sub_button_id2 = 0; sub_button_id2 < ANALOG_SUB_BUTTONS_NUM;
+                             ++sub_button_id2) {
+                            analog_map_buttons[sub_button_id2]->setText(
+                                AnalogToText(param, analog_sub_buttons[sub_button_id2]));
                         }
                     });
                     context_menu.exec(

--- a/src/yuzu/configuration/configure_touch_from_button.cpp
+++ b/src/yuzu/configuration/configure_touch_from_button.cpp
@@ -68,10 +68,10 @@ static QString ButtonToText(const Common::ParamPackage& param) {
 }
 
 ConfigureTouchFromButton::ConfigureTouchFromButton(
-    QWidget* parent, const std::vector<Settings::TouchFromButtonMap>& touch_maps,
+    QWidget* parent, const std::vector<Settings::TouchFromButtonMap>& touch_maps_,
     InputCommon::InputSubsystem* input_subsystem_, const int default_index)
     : QDialog(parent), ui(std::make_unique<Ui::ConfigureTouchFromButton>()),
-      touch_maps(touch_maps), input_subsystem{input_subsystem_}, selected_index(default_index),
+      touch_maps{touch_maps_}, input_subsystem{input_subsystem_}, selected_index{default_index},
       timeout_timer(std::make_unique<QTimer>()), poll_timer(std::make_unique<QTimer>()) {
     ui->setupUi(this);
     binding_list_model = new QStandardItemModel(0, 3, this);

--- a/src/yuzu/configuration/configure_touch_from_button.h
+++ b/src/yuzu/configuration/configure_touch_from_button.h
@@ -37,7 +37,7 @@ class ConfigureTouchFromButton : public QDialog {
 
 public:
     explicit ConfigureTouchFromButton(QWidget* parent,
-                                      const std::vector<Settings::TouchFromButtonMap>& touch_maps,
+                                      const std::vector<Settings::TouchFromButtonMap>& touch_maps_,
                                       InputCommon::InputSubsystem* input_subsystem_,
                                       int default_index = 0);
     ~ConfigureTouchFromButton() override;

--- a/src/yuzu/debugger/wait_tree.cpp
+++ b/src/yuzu/debugger/wait_tree.cpp
@@ -113,9 +113,9 @@ QString WaitTreeText::GetText() const {
     return text;
 }
 
-WaitTreeMutexInfo::WaitTreeMutexInfo(VAddr mutex_address, const Kernel::KHandleTable& handle_table,
+WaitTreeMutexInfo::WaitTreeMutexInfo(VAddr mutex_address_, const Kernel::KHandleTable& handle_table,
                                      Core::System& system_)
-    : mutex_address(mutex_address), system{system_} {
+    : mutex_address{mutex_address_}, system{system_} {
     mutex_value = system.Memory().Read32(mutex_address);
     owner_handle = static_cast<Kernel::Handle>(mutex_value & Kernel::Svc::HandleWaitMask);
     owner = handle_table.GetObject<Kernel::KThread>(owner_handle).GetPointerUnsafe();
@@ -140,8 +140,8 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeMutexInfo::GetChildren() cons
     return list;
 }
 
-WaitTreeCallstack::WaitTreeCallstack(const Kernel::KThread& thread, Core::System& system_)
-    : thread(thread), system{system_} {}
+WaitTreeCallstack::WaitTreeCallstack(const Kernel::KThread& thread_, Core::System& system_)
+    : thread{thread_}, system{system_} {}
 WaitTreeCallstack::~WaitTreeCallstack() = default;
 
 QString WaitTreeCallstack::GetText() const {
@@ -171,8 +171,8 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeCallstack::GetChildren() cons
 }
 
 WaitTreeSynchronizationObject::WaitTreeSynchronizationObject(
-    const Kernel::KSynchronizationObject& o, Core::System& system_)
-    : object(o), system{system_} {}
+    const Kernel::KSynchronizationObject& object_, Core::System& system_)
+    : object{object_}, system{system_} {}
 WaitTreeSynchronizationObject::~WaitTreeSynchronizationObject() = default;
 
 WaitTreeExpandableItem::WaitTreeExpandableItem() = default;
@@ -380,8 +380,8 @@ std::vector<std::unique_ptr<WaitTreeItem>> WaitTreeThread::GetChildren() const {
     return list;
 }
 
-WaitTreeEvent::WaitTreeEvent(const Kernel::KReadableEvent& object, Core::System& system_)
-    : WaitTreeSynchronizationObject(object, system_) {}
+WaitTreeEvent::WaitTreeEvent(const Kernel::KReadableEvent& object_, Core::System& system_)
+    : WaitTreeSynchronizationObject(object_, system_) {}
 WaitTreeEvent::~WaitTreeEvent() = default;
 
 WaitTreeThreadList::WaitTreeThreadList(std::vector<Kernel::KThread*>&& list, Core::System& system_)

--- a/src/yuzu/debugger/wait_tree.h
+++ b/src/yuzu/debugger/wait_tree.h
@@ -78,7 +78,7 @@ public:
 class WaitTreeMutexInfo : public WaitTreeExpandableItem {
     Q_OBJECT
 public:
-    explicit WaitTreeMutexInfo(VAddr mutex_address, const Kernel::KHandleTable& handle_table,
+    explicit WaitTreeMutexInfo(VAddr mutex_address_, const Kernel::KHandleTable& handle_table,
                                Core::System& system_);
     ~WaitTreeMutexInfo() override;
 
@@ -97,7 +97,7 @@ private:
 class WaitTreeCallstack : public WaitTreeExpandableItem {
     Q_OBJECT
 public:
-    explicit WaitTreeCallstack(const Kernel::KThread& thread, Core::System& system_);
+    explicit WaitTreeCallstack(const Kernel::KThread& thread_, Core::System& system_);
     ~WaitTreeCallstack() override;
 
     QString GetText() const override;
@@ -112,7 +112,7 @@ private:
 class WaitTreeSynchronizationObject : public WaitTreeExpandableItem {
     Q_OBJECT
 public:
-    explicit WaitTreeSynchronizationObject(const Kernel::KSynchronizationObject& object,
+    explicit WaitTreeSynchronizationObject(const Kernel::KSynchronizationObject& object_,
                                            Core::System& system_);
     ~WaitTreeSynchronizationObject() override;
 
@@ -162,7 +162,7 @@ private:
 class WaitTreeEvent : public WaitTreeSynchronizationObject {
     Q_OBJECT
 public:
-    explicit WaitTreeEvent(const Kernel::KReadableEvent& object, Core::System& system_);
+    explicit WaitTreeEvent(const Kernel::KReadableEvent& object_, Core::System& system_);
     ~WaitTreeEvent() override;
 };
 

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -28,8 +28,8 @@
 #include "yuzu/uisettings.h"
 #include "yuzu/util/controller_navigation.h"
 
-GameListSearchField::KeyReleaseEater::KeyReleaseEater(GameList* gamelist, QObject* parent)
-    : QObject(parent), gamelist{gamelist} {}
+GameListSearchField::KeyReleaseEater::KeyReleaseEater(GameList* gamelist_, QObject* parent)
+    : QObject(parent), gamelist{gamelist_} {}
 
 // EventFilter in order to process systemkeys while editing the searchfield
 bool GameListSearchField::KeyReleaseEater::eventFilter(QObject* obj, QEvent* event) {
@@ -309,9 +309,9 @@ void GameList::OnFilterCloseClicked() {
     main_window->filterBarSetChecked(false);
 }
 
-GameList::GameList(FileSys::VirtualFilesystem vfs, FileSys::ManualContentProvider* provider,
+GameList::GameList(FileSys::VirtualFilesystem vfs_, FileSys::ManualContentProvider* provider_,
                    Core::System& system_, GMainWindow* parent)
-    : QWidget{parent}, vfs(std::move(vfs)), provider(provider), system{system_} {
+    : QWidget{parent}, vfs{std::move(vfs_)}, provider{provider_}, system{system_} {
     watcher = new QFileSystemWatcher(this);
     connect(watcher, &QFileSystemWatcher::directoryChanged, this, &GameList::RefreshGameDirectory);
 

--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -80,9 +80,9 @@ bool GameListSearchField::KeyReleaseEater::eventFilter(QObject* obj, QEvent* eve
     return QObject::eventFilter(obj, event);
 }
 
-void GameListSearchField::setFilterResult(int visible, int total) {
-    this->visible = visible;
-    this->total = total;
+void GameListSearchField::setFilterResult(int visible_, int total_) {
+    visible = visible_;
+    total = total_;
 
     label_filter_result->setText(tr("%1 of %n result(s)", "", total).arg(visible));
 }

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -67,8 +67,8 @@ public:
         COLUMN_COUNT, // Number of columns
     };
 
-    explicit GameList(std::shared_ptr<FileSys::VfsFilesystem> vfs,
-                      FileSys::ManualContentProvider* provider, Core::System& system_,
+    explicit GameList(std::shared_ptr<FileSys::VfsFilesystem> vfs_,
+                      FileSys::ManualContentProvider* provider_, Core::System& system_,
                       GMainWindow* parent = nullptr);
     ~GameList() override;
 

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -225,8 +225,8 @@ public:
     static constexpr int GameDirRole = Qt::UserRole + 2;
 
     explicit GameListDir(UISettings::GameDir& directory,
-                         GameListItemType dir_type = GameListItemType::CustomDir)
-        : dir_type{dir_type} {
+                         GameListItemType dir_type_ = GameListItemType::CustomDir)
+        : dir_type{dir_type_} {
         setData(type(), TypeRole);
 
         UISettings::GameDir* game_dir = &directory;
@@ -356,7 +356,7 @@ public:
 private:
     class KeyReleaseEater : public QObject {
     public:
-        explicit KeyReleaseEater(GameList* gamelist, QObject* parent = nullptr);
+        explicit KeyReleaseEater(GameList* gamelist_, QObject* parent = nullptr);
 
     private:
         GameList* gamelist = nullptr;

--- a/src/yuzu/game_list_p.h
+++ b/src/yuzu/game_list_p.h
@@ -348,7 +348,7 @@ public:
     explicit GameListSearchField(GameList* parent = nullptr);
 
     QString filterText() const;
-    void setFilterResult(int visible, int total);
+    void setFilterResult(int visible_, int total_);
 
     void clear();
     void setFocus();

--- a/src/yuzu/game_list_worker.cpp
+++ b/src/yuzu/game_list_worker.cpp
@@ -223,12 +223,12 @@ QList<QStandardItem*> MakeGameListEntry(const std::string& path, const std::stri
 }
 } // Anonymous namespace
 
-GameListWorker::GameListWorker(FileSys::VirtualFilesystem vfs,
-                               FileSys::ManualContentProvider* provider,
-                               QVector<UISettings::GameDir>& game_dirs,
-                               const CompatibilityList& compatibility_list, Core::System& system_)
-    : vfs(std::move(vfs)), provider(provider), game_dirs(game_dirs),
-      compatibility_list(compatibility_list), system{system_} {}
+GameListWorker::GameListWorker(FileSys::VirtualFilesystem vfs_,
+                               FileSys::ManualContentProvider* provider_,
+                               QVector<UISettings::GameDir>& game_dirs_,
+                               const CompatibilityList& compatibility_list_, Core::System& system_)
+    : vfs{std::move(vfs_)}, provider{provider_}, game_dirs{game_dirs_},
+      compatibility_list{compatibility_list_}, system{system_} {}
 
 GameListWorker::~GameListWorker() = default;
 

--- a/src/yuzu/game_list_worker.h
+++ b/src/yuzu/game_list_worker.h
@@ -33,10 +33,10 @@ class GameListWorker : public QObject, public QRunnable {
     Q_OBJECT
 
 public:
-    explicit GameListWorker(std::shared_ptr<FileSys::VfsFilesystem> vfs,
-                            FileSys::ManualContentProvider* provider,
-                            QVector<UISettings::GameDir>& game_dirs,
-                            const CompatibilityList& compatibility_list, Core::System& system_);
+    explicit GameListWorker(std::shared_ptr<FileSys::VfsFilesystem> vfs_,
+                            FileSys::ManualContentProvider* provider_,
+                            QVector<UISettings::GameDir>& game_dirs_,
+                            const CompatibilityList& compatibility_list_, Core::System& system_);
     ~GameListWorker() override;
 
     /// Starts the processing of directory tree information.

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -934,8 +934,7 @@ void GMainWindow::InitializeWidgets() {
             Settings::values.renderer_backend.SetValue(Settings::RendererBackend::Vulkan);
         } else {
             Settings::values.renderer_backend.SetValue(Settings::RendererBackend::OpenGL);
-            const auto filter = Settings::values.scaling_filter.GetValue();
-            if (filter == Settings::ScalingFilter::Fsr) {
+            if (Settings::values.scaling_filter.GetValue() == Settings::ScalingFilter::Fsr) {
                 Settings::values.scaling_filter.SetValue(Settings::ScalingFilter::NearestNeighbor);
                 UpdateFilterText();
             }
@@ -1508,7 +1507,7 @@ void GMainWindow::BootGame(const QString& filename, u64 program_id, std::size_t 
 
     // Register an ExecuteProgram callback such that Core can execute a sub-program
     system->RegisterExecuteProgramCallback(
-        [this](std::size_t program_index) { render_window->ExecuteProgram(program_index); });
+        [this](std::size_t program_index_) { render_window->ExecuteProgram(program_index_); });
 
     // Register an Exit callback such that Core can exit the currently running application.
     system->RegisterExitCallback([this]() { render_window->Exit(); });

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1442,7 +1442,7 @@ bool GMainWindow::LoadROM(const QString& filename, u64 program_id, std::size_t p
         }
         return false;
     }
-    game_path = filename;
+    current_game_path = filename;
 
     system->TelemetrySession().AddField(Common::Telemetry::FieldType::App, "Frontend", "Qt");
     return true;
@@ -1641,7 +1641,7 @@ void GMainWindow::ShutdownGame() {
     emu_frametime_label->setVisible(false);
     renderer_status_button->setEnabled(!UISettings::values.has_broken_vulkan);
 
-    game_path.clear();
+    current_game_path.clear();
 
     // When closing the game, destroy the GLWindow to clear the context after the game is closed
     render_window->ReleaseRenderTarget();
@@ -2560,7 +2560,7 @@ void GMainWindow::OnRestartGame() {
         return;
     }
     // Make a copy since BootGame edits game_path
-    BootGame(QString(game_path));
+    BootGame(QString(current_game_path));
 }
 
 void GMainWindow::OnPauseGame() {
@@ -2989,7 +2989,7 @@ void GMainWindow::OnToggleAdaptingFilter() {
 
 void GMainWindow::OnConfigurePerGame() {
     const u64 title_id = system->GetCurrentProcessProgramID();
-    OpenPerGameConfiguration(title_id, game_path.toStdString());
+    OpenPerGameConfiguration(title_id, current_game_path.toStdString());
 }
 
 void GMainWindow::OpenPerGameConfiguration(u64 title_id, const std::string& file_name) {

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -369,7 +369,7 @@ private:
     bool emulation_running = false;
     std::unique_ptr<EmuThread> emu_thread;
     // The path to the game currently running
-    QString game_path;
+    QString current_game_path;
 
     bool auto_paused = false;
     bool auto_muted = false;

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2.h
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2.h
@@ -20,7 +20,7 @@ enum class MouseButton;
 
 class EmuWindow_SDL2 : public Core::Frontend::EmuWindow {
 public:
-    explicit EmuWindow_SDL2(InputCommon::InputSubsystem* input_subsystem, Core::System& system_);
+    explicit EmuWindow_SDL2(InputCommon::InputSubsystem* input_subsystem_, Core::System& system_);
     ~EmuWindow_SDL2();
 
     /// Whether the window is still open, and a close request hasn't yet been sent

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.cpp
@@ -73,9 +73,9 @@ bool EmuWindow_SDL2_GL::SupportsRequiredGLExtensions() {
     return unsupported_ext.empty();
 }
 
-EmuWindow_SDL2_GL::EmuWindow_SDL2_GL(InputCommon::InputSubsystem* input_subsystem,
+EmuWindow_SDL2_GL::EmuWindow_SDL2_GL(InputCommon::InputSubsystem* input_subsystem_,
                                      Core::System& system_, bool fullscreen)
-    : EmuWindow_SDL2{input_subsystem, system_} {
+    : EmuWindow_SDL2{input_subsystem_, system_} {
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 6);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_COMPATIBILITY);

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.h
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_gl.h
@@ -17,7 +17,7 @@ class InputSubsystem;
 
 class EmuWindow_SDL2_GL final : public EmuWindow_SDL2 {
 public:
-    explicit EmuWindow_SDL2_GL(InputCommon::InputSubsystem* input_subsystem, Core::System& system_,
+    explicit EmuWindow_SDL2_GL(InputCommon::InputSubsystem* input_subsystem_, Core::System& system_,
                                bool fullscreen);
     ~EmuWindow_SDL2_GL();
 

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.cpp
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.cpp
@@ -21,9 +21,9 @@
 #include <SDL.h>
 #include <SDL_syswm.h>
 
-EmuWindow_SDL2_VK::EmuWindow_SDL2_VK(InputCommon::InputSubsystem* input_subsystem,
+EmuWindow_SDL2_VK::EmuWindow_SDL2_VK(InputCommon::InputSubsystem* input_subsystem_,
                                      Core::System& system_, bool fullscreen)
-    : EmuWindow_SDL2{input_subsystem, system_} {
+    : EmuWindow_SDL2{input_subsystem_, system_} {
     const std::string window_title = fmt::format("yuzu {} | {}-{} (Vulkan)", Common::g_build_name,
                                                  Common::g_scm_branch, Common::g_scm_desc);
     render_window =

--- a/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.h
+++ b/src/yuzu_cmd/emu_window/emu_window_sdl2_vk.h
@@ -18,7 +18,7 @@ class InputSubsystem;
 
 class EmuWindow_SDL2_VK final : public EmuWindow_SDL2 {
 public:
-    explicit EmuWindow_SDL2_VK(InputCommon::InputSubsystem* input_subsystem, Core::System& system,
+    explicit EmuWindow_SDL2_VK(InputCommon::InputSubsystem* input_subsystem_, Core::System& system,
                                bool fullscreen);
     ~EmuWindow_SDL2_VK() override;
 


### PR DESCRIPTION
Now that the entire project is free of variable shadowing, we can enforce this as a compile time error to prevent any further introduction of this logic bug.

Some things to keep in mind:
The following are treated as shadowing in GCC/Clang, but not MSVC:
```cpp
int a;
auto f = [] {
    int a; // shadows a above, even though its not in the capture list
};
```
```cpp
struct Impl {
    Impl(int a) : a{a} {} // MSVC should emit C4458 here, but doesn't for whatever reason

    void Set(int a) { // This does, though
        this->a = a;
    }

    int a;
};
```
Addendum: In the case above, GCC/Clang are inconsistent about emitting warnings regarding variable shadowing in constructors.