### PR TITLE
yuzu-qt: Call -Wl,--subsystem,windows directly

### DIFF
--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -240,7 +240,7 @@ elseif(WIN32)
     if(MSVC)
         set_target_properties(yuzu PROPERTIES LINK_FLAGS_RELEASE "/SUBSYSTEM:WINDOWS")
     elseif(MINGW)
-        set_target_properties(yuzu PROPERTIES LINK_FLAGS_RELEASE "-mwindows")
+        set_target_properties(yuzu PROPERTIES LINK_FLAGS_RELEASE "-Wl,--subsystem,windows")
     endif()
 endif()
 


### PR DESCRIPTION
`-mwindows` doesn't work with Clang. https://github.com/tpoechtrager/wclang resolves this by just using MinGW-GCC to link the executable, however this prevents us from using LLVM-exclusive tools when building yuzu.

Solution is to send the linker argument we need from `-mwindows` directly to the linker.
From https://gcc-help.gcc.gnu.narkive.com/FogklN5J/gcc-wl-subsystem-windows-mwindows-options