### PR TITLE
CpuManager: simplify pausing

### DIFF
--- a/src/core/cpu_manager.h
+++ b/src/core/cpu_manager.h
@@ -69,13 +69,11 @@ private:
     void MultiCoreRunGuestLoop();
     void MultiCoreRunIdleThread();
     void MultiCoreRunSuspendThread();
-    void MultiCorePause(bool paused);
 
     void SingleCoreRunGuestThread();
     void SingleCoreRunGuestLoop();
     void SingleCoreRunIdleThread();
     void SingleCoreRunSuspendThread();
-    void SingleCorePause(bool paused);
 
     static void ThreadStart(std::stop_token stop_token, CpuManager& cpu_manager, std::size_t core);
 
@@ -83,16 +81,13 @@ private:
 
     struct CoreData {
         std::shared_ptr<Common::Fiber> host_context;
-        std::unique_ptr<Common::Event> enter_barrier;
-        std::unique_ptr<Common::Event> exit_barrier;
-        std::atomic<bool> is_running;
-        std::atomic<bool> is_paused;
-        std::atomic<bool> initialized;
         std::jthread host_thread;
     };
 
     std::atomic<bool> running_mode{};
-    std::atomic<bool> paused_state{};
+    std::atomic<bool> pause_state{};
+    std::unique_ptr<Common::Barrier> pause_barrier{};
+    std::mutex pause_lock{};
 
     std::array<CoreData, Core::Hardware::NUM_CPU_CORES> core_data{};
 

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -252,6 +252,7 @@ struct KernelCore::Impl {
                                                          core_id)
                        .IsSuccess());
             suspend_threads[core_id]->SetName(fmt::format("SuspendThread:{}", core_id));
+            suspend_threads[core_id]->DisableDispatch();
         }
     }
 
@@ -1073,9 +1074,6 @@ void KernelCore::Suspend(bool in_suspention) {
             impl->suspend_threads[core_id]->SetState(state);
             impl->suspend_threads[core_id]->SetWaitReasonForDebugging(
                 ThreadWaitReasonForDebugging::Suspended);
-            if (!should_suspend) {
-                impl->suspend_threads[core_id]->DisableDispatch();
-            }
         }
     }
 }


### PR DESCRIPTION
This uses host-provided concurrency primitives to implement the condition and barrier needed to do single-core and multi-core guest pauses, instead of spinning on variables.