### PR TITLE
CMakeLists: Update boost to 1.79.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,8 +218,8 @@ if (Boost_FOUND)
         list(APPEND Boost_LIBRARIES Boost::context)
     endif()
 else()
-    message(STATUS "Boost 1.73.0 or newer not found, falling back to Conan")
-    list(APPEND CONAN_REQUIRED_LIBS "boost/1.78.0")
+    message(STATUS "Boost 1.79.0 or newer not found, falling back to Conan")
+    list(APPEND CONAN_REQUIRED_LIBS "boost/1.79.0")
 endif()
 
 # Attempt to locate any packages that are required and report the missing ones in CONAN_REQUIRED_LIBS


### PR DESCRIPTION
This version of boost brings in a number of bug fixes, especially to the asio library. Details can be seen here: https://www.boost.org/users/history/version_1_79_0.html