### PR TITLE
service: hid: Improve stub of IRS

### DIFF
--- a/src/core/hle/service/hid/irs.cpp
+++ b/src/core/hle/service/hid/irs.cpp
@@ -5,7 +5,9 @@
 #include "core/core_timing.h"
 #include "core/hle/ipc_helpers.h"
 #include "core/hle/kernel/k_shared_memory.h"
+#include "core/hle/kernel/k_transfer_memory.h"
 #include "core/hle/kernel/kernel.h"
+#include "core/hle/service/hid/errors.h"
 #include "core/hle/service/hid/irs.h"
 
 namespace Service::HID {
@@ -38,21 +40,32 @@ IRS::IRS(Core::System& system_) : ServiceFramework{system_, "irs"} {
 }
 
 void IRS::ActivateIrsensor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    const auto applet_resource_user_id{rp.Pop<u64>()};
+
+    LOG_WARNING(Service_HID, "(STUBBED) called, applet_resource_user_id={}",
+                applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
 }
 
 void IRS::DeactivateIrsensor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    const auto applet_resource_user_id{rp.Pop<u64>()};
+
+    LOG_WARNING(Service_HID, "(STUBBED) called, applet_resource_user_id={}",
+                applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
 }
 
 void IRS::GetIrsensorSharedMemoryHandle(Kernel::HLERequestContext& ctx) {
-    LOG_DEBUG(Service_IRS, "called");
+    IPC::RequestParser rp{ctx};
+    const auto applet_resource_user_id{rp.Pop<u64>()};
+
+    LOG_DEBUG(Service_IRS, "called, applet_resource_user_id={}", applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2, 1};
     rb.Push(ResultSuccess);
@@ -60,35 +73,109 @@ void IRS::GetIrsensorSharedMemoryHandle(Kernel::HLERequestContext& ctx) {
 }
 
 void IRS::StopImageProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    struct Parameters {
+        IrCameraHandle camera_handle;
+        INSERT_PADDING_WORDS_NOINIT(1);
+        u64 applet_resource_user_id;
+    };
+    static_assert(sizeof(Parameters) == 0x10, "Parameters has incorrect size.");
+
+    const auto parameters{rp.PopRaw<Parameters>()};
+
+    LOG_WARNING(Service_IRS,
+                "(STUBBED) called, npad_type={}, npad_id={}, applet_resource_user_id={}",
+                parameters.camera_handle.npad_type, parameters.camera_handle.npad_id,
+                parameters.applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
 }
 
 void IRS::RunMomentProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    struct Parameters {
+        IrCameraHandle camera_handle;
+        INSERT_PADDING_WORDS_NOINIT(1);
+        u64 applet_resource_user_id;
+        PackedMomentProcessorConfig processor_config;
+    };
+    static_assert(sizeof(Parameters) == 0x30, "Parameters has incorrect size.");
+
+    const auto parameters{rp.PopRaw<Parameters>()};
+
+    LOG_WARNING(Service_IRS,
+                "(STUBBED) called, npad_type={}, npad_id={}, applet_resource_user_id={}",
+                parameters.camera_handle.npad_type, parameters.camera_handle.npad_id,
+                parameters.applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
 }
 
 void IRS::RunClusteringProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    struct Parameters {
+        IrCameraHandle camera_handle;
+        INSERT_PADDING_WORDS_NOINIT(1);
+        u64 applet_resource_user_id;
+        PackedClusteringProcessorConfig processor_config;
+    };
+    static_assert(sizeof(Parameters) == 0x40, "Parameters has incorrect size.");
+
+    const auto parameters{rp.PopRaw<Parameters>()};
+
+    LOG_WARNING(Service_IRS,
+                "(STUBBED) called, npad_type={}, npad_id={}, applet_resource_user_id={}",
+                parameters.camera_handle.npad_type, parameters.camera_handle.npad_id,
+                parameters.applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
 }
 
 void IRS::RunImageTransferProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    struct Parameters {
+        IrCameraHandle camera_handle;
+        INSERT_PADDING_WORDS_NOINIT(1);
+        u64 applet_resource_user_id;
+        PackedImageTransferProcessorConfig processor_config;
+        u32 transfer_memory_size;
+    };
+    static_assert(sizeof(Parameters) == 0x30, "Parameters has incorrect size.");
+
+    const auto parameters{rp.PopRaw<Parameters>()};
+    const auto t_mem_handle{ctx.GetCopyHandle(0)};
+
+    auto t_mem =
+        system.CurrentProcess()->GetHandleTable().GetObject<Kernel::KTransferMemory>(t_mem_handle);
+
+    LOG_WARNING(Service_IRS,
+                "(STUBBED) called, npad_type={}, npad_id={}, transfer_memory_size={}, "
+                "applet_resource_user_id={}",
+                parameters.camera_handle.npad_type, parameters.camera_handle.npad_id,
+                parameters.transfer_memory_size, parameters.applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
 }
 
 void IRS::GetImageTransferProcessorState(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    struct Parameters {
+        IrCameraHandle camera_handle;
+        INSERT_PADDING_WORDS_NOINIT(1);
+        u64 applet_resource_user_id;
+    };
+    static_assert(sizeof(Parameters) == 0x10, "Parameters has incorrect size.");
+
+    const auto parameters{rp.PopRaw<Parameters>()};
+
+    LOG_WARNING(Service_IRS,
+                "(STUBBED) called, npad_type={}, npad_id={}, applet_resource_user_id={}",
+                parameters.camera_handle.npad_type, parameters.camera_handle.npad_id,
+                parameters.applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 5};
     rb.Push(ResultSuccess);
@@ -97,71 +184,195 @@ void IRS::GetImageTransferProcessorState(Kernel::HLERequestContext& ctx) {
 }
 
 void IRS::RunTeraPluginProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    const auto camera_handle{rp.PopRaw<IrCameraHandle>()};
+    const auto processor_config{rp.PopRaw<PackedTeraPluginProcessorConfig>()};
+    const auto applet_resource_user_id{rp.Pop<u64>()};
+
+    LOG_WARNING(Service_IRS,
+                "(STUBBED) called, npad_type={}, npad_id={}, mode={}, mcu_version={}.{}, "
+                "applet_resource_user_id={}",
+                camera_handle.npad_type, camera_handle.npad_id, processor_config.mode,
+                processor_config.required_mcu_version.major,
+                processor_config.required_mcu_version.minor, applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
 }
 
 void IRS::GetNpadIrCameraHandle(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    const auto npad_id{rp.PopEnum<Core::HID::NpadIdType>()};
+
+    if (npad_id > Core::HID::NpadIdType::Player8 && npad_id != Core::HID::NpadIdType::Invalid &&
+        npad_id != Core::HID::NpadIdType::Handheld) {
+        IPC::ResponseBuilder rb{ctx, 2};
+        rb.Push(InvalidNpadId);
+        return;
+    }
+
+    IrCameraHandle camera_handle{
+        .npad_id = static_cast<u8>(NpadIdTypeToIndex(npad_id)),
+        .npad_type = Core::HID::NpadStyleIndex::None,
+    };
+
+    LOG_WARNING(Service_IRS, "(STUBBED) called, npad_id={}, camera_npad_id={}, camera_npad_type={}",
+                npad_id, camera_handle.npad_id, camera_handle.npad_type);
 
     IPC::ResponseBuilder rb{ctx, 3};
     rb.Push(ResultSuccess);
-    rb.PushRaw<u32>(device_handle);
+    rb.PushRaw(camera_handle);
 }
 
 void IRS::RunPointingProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    const auto camera_handle{rp.PopRaw<IrCameraHandle>()};
+    const auto processor_config{rp.PopRaw<PackedPointingProcessorConfig>()};
+    const auto applet_resource_user_id{rp.Pop<u64>()};
+
+    LOG_WARNING(
+        Service_IRS,
+        "(STUBBED) called, npad_type={}, npad_id={}, mcu_version={}.{}, applet_resource_user_id={}",
+        camera_handle.npad_type, camera_handle.npad_id, processor_config.required_mcu_version.major,
+        processor_config.required_mcu_version.minor, applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
 }
 
 void IRS::SuspendImageProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    struct Parameters {
+        IrCameraHandle camera_handle;
+        INSERT_PADDING_WORDS_NOINIT(1);
+        u64 applet_resource_user_id;
+    };
+    static_assert(sizeof(Parameters) == 0x10, "Parameters has incorrect size.");
+
+    const auto parameters{rp.PopRaw<Parameters>()};
+
+    LOG_WARNING(Service_IRS,
+                "(STUBBED) called, npad_type={}, npad_id={}, applet_resource_user_id={}",
+                parameters.camera_handle.npad_type, parameters.camera_handle.npad_id,
+                parameters.applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
 }
 
 void IRS::CheckFirmwareVersion(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    const auto camera_handle{rp.PopRaw<IrCameraHandle>()};
+    const auto mcu_version{rp.PopRaw<PackedMcuVersion>()};
+    const auto applet_resource_user_id{rp.Pop<u64>()};
+
+    LOG_WARNING(
+        Service_IRS,
+        "(STUBBED) called, npad_type={}, npad_id={}, applet_resource_user_id={}, mcu_version={}.{}",
+        camera_handle.npad_type, camera_handle.npad_id, applet_resource_user_id, mcu_version.major,
+        mcu_version.minor);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
 }
 
 void IRS::SetFunctionLevel(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    struct Parameters {
+        IrCameraHandle camera_handle;
+        PackedFunctionLevel function_level;
+        u64 applet_resource_user_id;
+    };
+    static_assert(sizeof(Parameters) == 0x10, "Parameters has incorrect size.");
+
+    const auto parameters{rp.PopRaw<Parameters>()};
+
+    LOG_WARNING(Service_IRS,
+                "(STUBBED) called, npad_type={}, npad_id={}, applet_resource_user_id={}",
+                parameters.camera_handle.npad_type, parameters.camera_handle.npad_id,
+                parameters.applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
 }
 
 void IRS::RunImageTransferExProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    struct Parameters {
+        IrCameraHandle camera_handle;
+        INSERT_PADDING_WORDS_NOINIT(1);
+        u64 applet_resource_user_id;
+        PackedImageTransferProcessorExConfig processor_config;
+        u64 transfer_memory_size;
+    };
+    static_assert(sizeof(Parameters) == 0x38, "Parameters has incorrect size.");
+
+    const auto parameters{rp.PopRaw<Parameters>()};
+    const auto t_mem_handle{ctx.GetCopyHandle(0)};
+
+    auto t_mem =
+        system.CurrentProcess()->GetHandleTable().GetObject<Kernel::KTransferMemory>(t_mem_handle);
+
+    LOG_WARNING(Service_IRS,
+                "(STUBBED) called, npad_type={}, npad_id={}, transfer_memory_size={}, "
+                "applet_resource_user_id={}",
+                parameters.camera_handle.npad_type, parameters.camera_handle.npad_id,
+                parameters.transfer_memory_size, parameters.applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
 }
 
 void IRS::RunIrLedProcessor(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    const auto camera_handle{rp.PopRaw<IrCameraHandle>()};
+    const auto processor_config{rp.PopRaw<PackedIrLedProcessorConfig>()};
+    const auto applet_resource_user_id{rp.Pop<u64>()};
+
+    LOG_WARNING(Service_IRS,
+                "(STUBBED) called, npad_type={}, npad_id={}, light_target={}, mcu_version={}.{} "
+                "applet_resource_user_id={}",
+                camera_handle.npad_type, camera_handle.npad_id, processor_config.light_target,
+                processor_config.required_mcu_version.major,
+                processor_config.required_mcu_version.minor, applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
 }
 
 void IRS::StopImageProcessorAsync(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    struct Parameters {
+        IrCameraHandle camera_handle;
+        INSERT_PADDING_WORDS_NOINIT(1);
+        u64 applet_resource_user_id;
+    };
+    static_assert(sizeof(Parameters) == 0x10, "Parameters has incorrect size.");
+
+    const auto parameters{rp.PopRaw<Parameters>()};
+
+    LOG_WARNING(Service_IRS,
+                "(STUBBED) called, npad_type={}, npad_id={}, applet_resource_user_id={}",
+                parameters.camera_handle.npad_type, parameters.camera_handle.npad_id,
+                parameters.applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);
 }
 
 void IRS::ActivateIrsensorWithFunctionLevel(Kernel::HLERequestContext& ctx) {
-    LOG_WARNING(Service_IRS, "(STUBBED) called");
+    IPC::RequestParser rp{ctx};
+    struct Parameters {
+        PackedFunctionLevel function_level;
+        INSERT_PADDING_WORDS_NOINIT(1);
+        u64 applet_resource_user_id;
+    };
+    static_assert(sizeof(Parameters) == 0x10, "Parameters has incorrect size.");
+
+    const auto parameters{rp.PopRaw<Parameters>()};
+
+    LOG_WARNING(Service_IRS, "(STUBBED) called, function_level={}, applet_resource_user_id={}",
+                parameters.function_level.function_level, parameters.applet_resource_user_id);
 
     IPC::ResponseBuilder rb{ctx, 2};
     rb.Push(ResultSuccess);

--- a/src/core/hle/service/hid/irs.h
+++ b/src/core/hle/service/hid/irs.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "core/hid/hid_types.h"
 #include "core/hle/service/service.h"
 
 namespace Core {
@@ -17,6 +18,235 @@ public:
     ~IRS() override;
 
 private:
+    // This is nn::irsensor::IrCameraStatus
+    enum IrCameraStatus : u32 {
+        Available,
+        Unsupported,
+        Unconnected,
+    };
+
+    // This is nn::irsensor::IrCameraInternalStatus
+    enum IrCameraInternalStatus : u32 {
+        Stopped,
+        FirmwareUpdateNeeded,
+        Unkown2,
+        Unkown3,
+        Unkown4,
+        FirmwareVersionRequested,
+        FirmwareVersionIsInvalid,
+        Ready,
+        Setting,
+    };
+
+    // This is nn::irsensor::detail::StatusManager::IrSensorMode
+    enum IrSensorMode : u64 {
+        None,
+        MomentProcessor,
+        ClusteringProcessor,
+        ImageTransferProcessor,
+        PointingProcessorMarker,
+        TeraPluginProcessor,
+        IrLedProcessor,
+    };
+
+    // This is nn::irsensor::ImageProcessorStatus
+    enum ImageProcessorStatus : u8 {
+        stopped,
+        running,
+    };
+
+    // This is nn::irsensor::ImageTransferProcessorFormat
+    enum ImageTransferProcessorFormat : u8 {
+        Size320x240,
+        Size160x120,
+        Size80x60,
+        Size40x30,
+        Size20x15,
+    };
+
+    // This is nn::irsensor::AdaptiveClusteringMode
+    enum AdaptiveClusteringMode : u8 {
+        StaticFov,
+        DynamicFov,
+    };
+
+    // This is nn::irsensor::AdaptiveClusteringTargetDistance
+    enum AdaptiveClusteringTargetDistance : u8 {
+        Near,
+        Middle,
+        Far,
+    };
+
+    // This is nn::irsensor::IrsHandAnalysisMode
+    enum IrsHandAnalysisMode : u8 {
+        Silhouette,
+        Image,
+        SilhoueteAndImage,
+        SilhuetteOnly,
+    };
+
+    // This is nn::irsensor::IrSensorFunctionLevel
+    enum IrSensorFunctionLevel : u8 {
+        unknown0,
+        unknown1,
+        unknown2,
+        unknown3,
+        unknown4,
+    };
+
+    // This is nn::irsensor::IrCameraHandle
+    struct IrCameraHandle {
+        u8 npad_id{};
+        Core::HID::NpadStyleIndex npad_type{Core::HID::NpadStyleIndex::None};
+        INSERT_PADDING_BYTES(2);
+    };
+    static_assert(sizeof(IrCameraHandle) == 4, "IrCameraHandle is an invalid size");
+
+    struct IrsRect {
+        s16 x;
+        s16 y;
+        s16 width;
+        s16 height;
+    };
+
+    // This is nn::irsensor::PackedMcuVersion
+    struct PackedMcuVersion {
+        u16 major;
+        u16 minor;
+    };
+    static_assert(sizeof(PackedMcuVersion) == 4, "PackedMcuVersion is an invalid size");
+
+    // This is nn::irsensor::MomentProcessorConfig
+    struct MomentProcessorConfig {
+        u64 exposire_time;
+        u8 light_target;
+        u8 gain;
+        u8 is_negative_used;
+        INSERT_PADDING_BYTES(7);
+        IrsRect window_of_interest;
+        u8 preprocess;
+        u8 preprocess_intensity_threshold;
+        INSERT_PADDING_BYTES(5);
+    };
+    static_assert(sizeof(MomentProcessorConfig) == 0x28,
+                  "MomentProcessorConfig is an invalid size");
+
+    // This is nn::irsensor::PackedMomentProcessorConfig
+    struct PackedMomentProcessorConfig {
+        u64 exposire_time;
+        u8 light_target;
+        u8 gain;
+        u8 is_negative_used;
+        INSERT_PADDING_BYTES(5);
+        IrsRect window_of_interest;
+        PackedMcuVersion required_mcu_version;
+        u8 preprocess;
+        u8 preprocess_intensity_threshold;
+        INSERT_PADDING_BYTES(2);
+    };
+    static_assert(sizeof(PackedMomentProcessorConfig) == 0x20,
+                  "PackedMomentProcessorConfig is an invalid size");
+
+    // This is nn::irsensor::ClusteringProcessorConfig
+    struct ClusteringProcessorConfig {
+        u64 exposire_time;
+        u32 light_target;
+        u32 gain;
+        u8 is_negative_used;
+        INSERT_PADDING_BYTES(7);
+        IrsRect window_of_interest;
+        u32 pixel_count_min;
+        u32 pixel_count_max;
+        u32 object_intensity_min;
+        u8 is_external_light_filter_enabled;
+        INSERT_PADDING_BYTES(3);
+    };
+    static_assert(sizeof(ClusteringProcessorConfig) == 0x30,
+                  "ClusteringProcessorConfig is an invalid size");
+
+    // This is nn::irsensor::PackedClusteringProcessorConfig
+    struct PackedClusteringProcessorConfig {
+        u64 exposire_time;
+        u8 light_target;
+        u8 gain;
+        u8 is_negative_used;
+        INSERT_PADDING_BYTES(5);
+        IrsRect window_of_interest;
+        PackedMcuVersion required_mcu_version;
+        u32 pixel_count_min;
+        u32 pixel_count_max;
+        u32 object_intensity_min;
+        u8 is_external_light_filter_enabled;
+        INSERT_PADDING_BYTES(2);
+    };
+    static_assert(sizeof(PackedClusteringProcessorConfig) == 0x30,
+                  "PackedClusteringProcessorConfig is an invalid size");
+
+    // This is nn::irsensor::PackedImageTransferProcessorConfig
+    struct PackedImageTransferProcessorConfig {
+        u64 exposire_time;
+        u8 light_target;
+        u8 gain;
+        u8 is_negative_used;
+        INSERT_PADDING_BYTES(5);
+        PackedMcuVersion required_mcu_version;
+        u8 format;
+        INSERT_PADDING_BYTES(3);
+    };
+    static_assert(sizeof(PackedImageTransferProcessorConfig) == 0x18,
+                  "PackedImageTransferProcessorConfig is an invalid size");
+
+    // This is nn::irsensor::PackedTeraPluginProcessorConfig
+    struct PackedTeraPluginProcessorConfig {
+        PackedMcuVersion required_mcu_version;
+        u8 mode;
+        INSERT_PADDING_BYTES(3);
+    };
+    static_assert(sizeof(PackedTeraPluginProcessorConfig) == 0x8,
+                  "PackedTeraPluginProcessorConfig is an invalid size");
+
+    // This is nn::irsensor::PackedPointingProcessorConfig
+    struct PackedPointingProcessorConfig {
+        IrsRect window_of_interest;
+        PackedMcuVersion required_mcu_version;
+    };
+    static_assert(sizeof(PackedPointingProcessorConfig) == 0xC,
+                  "PackedPointingProcessorConfig is an invalid size");
+
+    // This is nn::irsensor::PackedFunctionLevel
+    struct PackedFunctionLevel {
+        IrSensorFunctionLevel function_level;
+        INSERT_PADDING_BYTES(3);
+    };
+    static_assert(sizeof(PackedFunctionLevel) == 0x4, "PackedFunctionLevel is an invalid size");
+
+    // This is nn::irsensor::PackedImageTransferProcessorExConfig
+    struct PackedImageTransferProcessorExConfig {
+        u64 exposire_time;
+        u8 light_target;
+        u8 gain;
+        u8 is_negative_used;
+        INSERT_PADDING_BYTES(5);
+        PackedMcuVersion required_mcu_version;
+        ImageTransferProcessorFormat origin_format;
+        ImageTransferProcessorFormat trimming_format;
+        u16 trimming_start_x;
+        u16 trimming_start_y;
+        u8 is_external_light_filter_enabled;
+        INSERT_PADDING_BYTES(3);
+    };
+    static_assert(sizeof(PackedImageTransferProcessorExConfig) == 0x20,
+                  "PackedImageTransferProcessorExConfig is an invalid size");
+
+    // This is nn::irsensor::PackedIrLedProcessorConfig
+    struct PackedIrLedProcessorConfig {
+        PackedMcuVersion required_mcu_version;
+        u8 light_target;
+        INSERT_PADDING_BYTES(3);
+    };
+    static_assert(sizeof(PackedIrLedProcessorConfig) == 0x8,
+                  "PackedIrLedProcessorConfig is an invalid size");
+
     void ActivateIrsensor(Kernel::HLERequestContext& ctx);
     void DeactivateIrsensor(Kernel::HLERequestContext& ctx);
     void GetIrsensorSharedMemoryHandle(Kernel::HLERequestContext& ctx);
@@ -35,8 +265,6 @@ private:
     void RunIrLedProcessor(Kernel::HLERequestContext& ctx);
     void StopImageProcessorAsync(Kernel::HLERequestContext& ctx);
     void ActivateIrsensorWithFunctionLevel(Kernel::HLERequestContext& ctx);
-
-    const u32 device_handle{0xABCD};
 };
 
 class IRS_SYS final : public ServiceFramework<IRS_SYS> {


### PR DESCRIPTION
This service is stubbed with the bare minimum causing some issues with games that do use this service. This PR improves the implementation by adding logging and creating the IRS enum and structs. Fixes memory errors in `Nintendo Labo Toy-Con 01: Variety Kit`. 

While the service remains stubbed it helps to setup a base while I start implementing this service.