### PR TITLE
fix UI opening fullscreen after certain crashes

### DIFF
--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -1015,6 +1015,10 @@ void GMainWindow::SetDefaultUIGeometry() {
 void GMainWindow::RestoreUIState() {
     setWindowFlags(windowFlags() & ~Qt::FramelessWindowHint);
     restoreGeometry(UISettings::values.geometry);
+    // Work-around because the games list isn't supposed to be full screen
+    if (isFullScreen()) {
+        showNormal();
+    }
     restoreState(UISettings::values.state);
     render_window->setWindowFlags(render_window->windowFlags() & ~Qt::FramelessWindowHint);
     render_window->restoreGeometry(UISettings::values.renderwindow_geometry);


### PR DESCRIPTION
Sometimes when yuzu crashes, it restarts with the games list in fullscreen,
which would be fine, except there isn't an easy way to exit this.
It also doesn't occur often enough for qt-config.ini files to be in good supply.

UILayout\geometry value in qt-config.ini is the culprit,
 at least for the one provided.

Proposed fix is to simply check isFullScreen when yuzu is starting up,
and take it out of full screen immediately