### PR TITLE
core/debugger: Improved stepping mechanism and misc fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -222,6 +222,11 @@ else()
     list(APPEND CONAN_REQUIRED_LIBS "boost/1.79.0")
 endif()
 
+# boost:asio has functions that require AcceptEx et al
+if (MINGW)
+    find_library(MSWSOCK_LIBRARY mswsock REQUIRED)
+endif()
+
 # Attempt to locate any packages that are required and report the missing ones in CONAN_REQUIRED_LIBS
 yuzu_find_packages()
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -768,6 +768,9 @@ create_target_directory_groups(core)
 
 target_link_libraries(core PUBLIC common PRIVATE audio_core video_core)
 target_link_libraries(core PUBLIC Boost::boost PRIVATE fmt::fmt nlohmann_json::nlohmann_json mbedtls Opus::Opus)
+if (MINGW)
+    target_link_libraries(core PRIVATE ${MSWSOCK_LIBRARY})
+endif()
 
 if (ENABLE_WEB_SERVICE)
     target_compile_definitions(core PRIVATE -DENABLE_WEB_SERVICE)

--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -6,6 +6,9 @@
 
 #include <array>
 #include <vector>
+
+#include <dynarmic/interface/halt_reason.h>
+
 #include "common/common_funcs.h"
 #include "common/common_types.h"
 #include "core/hardware_properties.h"
@@ -64,7 +67,7 @@ public:
     static_assert(sizeof(ThreadContext64) == 0x320);
 
     /// Runs the CPU until an event happens
-    virtual void Run() = 0;
+    void Run();
 
     /// Clear all instruction cache
     virtual void ClearInstructionCache() = 0;
@@ -191,7 +194,10 @@ public:
 
     void LogBacktrace() const;
 
-    bool ShouldStep() const;
+    static constexpr Dynarmic::HaltReason step_thread = Dynarmic::HaltReason::Step;
+    static constexpr Dynarmic::HaltReason break_loop = Dynarmic::HaltReason::UserDefined2;
+    static constexpr Dynarmic::HaltReason svc_call = Dynarmic::HaltReason::UserDefined3;
+    static constexpr Dynarmic::HaltReason breakpoint = Dynarmic::HaltReason::UserDefined4;
 
 protected:
     /// System context that this ARM interface is running under.
@@ -200,6 +206,10 @@ protected:
     bool uses_wall_clock;
 
     static void SymbolicateBacktrace(Core::System& system, std::vector<BacktraceEntry>& out);
+
+    virtual Dynarmic::HaltReason RunJit() = 0;
+    virtual Dynarmic::HaltReason StepJit() = 0;
+    virtual u32 GetSvcNumber() const = 0;
 };
 
 } // namespace Core

--- a/src/core/arm/dynarmic/arm_dynarmic_32.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.h
@@ -41,7 +41,6 @@ public:
     void SetVectorReg(int index, u128 value) override;
     u32 GetPSTATE() const override;
     void SetPSTATE(u32 pstate) override;
-    void Run() override;
     VAddr GetTlsAddress() const override;
     void SetTlsAddress(VAddr address) override;
     void SetTPIDR_EL0(u64 value) override;
@@ -69,6 +68,11 @@ public:
 
     std::vector<BacktraceEntry> GetBacktrace() const override;
 
+protected:
+    Dynarmic::HaltReason RunJit() override;
+    Dynarmic::HaltReason StepJit() override;
+    u32 GetSvcNumber() const override;
+
 private:
     std::shared_ptr<Dynarmic::A32::Jit> MakeJit(Common::PageTable* page_table) const;
 
@@ -94,9 +98,6 @@ private:
 
     // SVC callback
     u32 svc_swi{};
-
-    // Debug restart address
-    u32 breakpoint_pc{};
 };
 
 } // namespace Core

--- a/src/core/arm/dynarmic/arm_dynarmic_64.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.h
@@ -39,7 +39,6 @@ public:
     void SetVectorReg(int index, u128 value) override;
     u32 GetPSTATE() const override;
     void SetPSTATE(u32 pstate) override;
-    void Run() override;
     VAddr GetTlsAddress() const override;
     void SetTlsAddress(VAddr address) override;
     void SetTPIDR_EL0(u64 value) override;
@@ -62,6 +61,11 @@ public:
                                                                const ThreadContext64& ctx);
 
     std::vector<BacktraceEntry> GetBacktrace() const override;
+
+protected:
+    Dynarmic::HaltReason RunJit() override;
+    Dynarmic::HaltReason StepJit() override;
+    u32 GetSvcNumber() const override;
 
 private:
     std::shared_ptr<Dynarmic::A64::Jit> MakeJit(Common::PageTable* page_table,
@@ -87,9 +91,6 @@ private:
 
     // SVC callback
     u32 svc_swi{};
-
-    // Debug restart address
-    u64 breakpoint_pc{};
 };
 
 } // namespace Core

--- a/src/core/debugger/debugger.h
+++ b/src/core/debugger/debugger.h
@@ -35,11 +35,6 @@ public:
      */
     bool NotifyThreadStopped(Kernel::KThread* thread);
 
-    /**
-     * Returns whether a step is in progress.
-     */
-    bool IsStepping() const;
-
 private:
     std::unique_ptr<DebuggerImpl> impl;
 };

--- a/src/core/debugger/debugger_interface.h
+++ b/src/core/debugger/debugger_interface.h
@@ -16,10 +16,11 @@ class KThread;
 namespace Core {
 
 enum class DebuggerAction {
-    Interrupt,         // Stop emulation as soon as possible.
-    Continue,          // Resume emulation.
-    StepThread,        // Step the currently-active thread.
-    ShutdownEmulation, // Shut down the emulator.
+    Interrupt,          ///< Stop emulation as soon as possible.
+    Continue,           ///< Resume emulation.
+    StepThreadLocked,   ///< Step the currently-active thread without resuming others.
+    StepThreadUnlocked, ///< Step the currently-active thread and resume others.
+    ShutdownEmulation,  ///< Shut down the emulator.
 };
 
 class DebuggerBackend {

--- a/src/core/debugger/gdbstub.h
+++ b/src/core/debugger/gdbstub.h
@@ -28,6 +28,7 @@ public:
 private:
     void ProcessData(std::vector<DebuggerAction>& actions);
     void ExecuteCommand(std::string_view packet, std::vector<DebuggerAction>& actions);
+    void HandleVCont(std::string_view command, std::vector<DebuggerAction>& actions);
     void HandleQuery(std::string_view command);
     std::vector<char>::const_iterator CommandEnd() const;
     std::optional<std::string> DetachCommand();
@@ -42,6 +43,7 @@ private:
     std::unique_ptr<GDBStubArch> arch;
     std::vector<char> current_command;
     std::map<VAddr, u32> replaced_instructions;
+    bool no_ack{};
 };
 
 } // namespace Core

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -100,6 +100,12 @@ enum class ThreadWaitReasonForDebugging : u32 {
     Suspended,       ///< Thread is waiting due to process suspension
 };
 
+enum class StepState : u32 {
+    NotStepping,   ///< Thread is not currently stepping
+    StepPending,   ///< Thread will step when next scheduled
+    StepPerformed, ///< Thread has stepped, waiting to be scheduled again
+};
+
 [[nodiscard]] KThread* GetCurrentThreadPointer(KernelCore& kernel);
 [[nodiscard]] KThread& GetCurrentThread(KernelCore& kernel);
 [[nodiscard]] s32 GetCurrentCoreId(KernelCore& kernel);
@@ -266,6 +272,14 @@ public:
     }
 
     void SetState(ThreadState state);
+
+    [[nodiscard]] StepState GetStepState() const {
+        return step_state;
+    }
+
+    void SetStepState(StepState state) {
+        step_state = state;
+    }
 
     [[nodiscard]] s64 GetLastScheduledTick() const {
         return last_scheduled_tick;
@@ -769,6 +783,7 @@ private:
     std::shared_ptr<Common::Fiber> host_context{};
     bool is_single_core{};
     ThreadType thread_type{};
+    StepState step_state{};
     std::mutex dummy_wait_lock;
     std::condition_variable dummy_wait_cv;
 

--- a/src/video_core/CMakeLists.txt
+++ b/src/video_core/CMakeLists.txt
@@ -277,3 +277,7 @@ else()
         $<$<CXX_COMPILER_ID:GNU>:-Werror=unused-but-set-variable>
     )
 endif()
+
+if (ARCHITECTURE_x86_64)
+    target_link_libraries(video_core PRIVATE dynarmic)
+endif()

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -319,3 +319,7 @@ endif()
 if (NOT APPLE)
     target_compile_definitions(yuzu PRIVATE HAS_OPENGL)
 endif()
+
+if (ARCHITECTURE_x86_64)
+    target_link_libraries(yuzu PRIVATE dynarmic)
+endif()


### PR DESCRIPTION
Fixes a bunch of issues found while battle testing the new debugger from #8394 over the past day and adds some new features for debugging.

- Implemented vCont GDB packet, which is required for GDB to issue step commands in servers that report thread support, instead of falling back to setting breakpoints.
- Implemented no-acknowledgement mode for GDB. May give a minor performance boost.
- Implemented detailed thread status reports in thread info XML, which allows GDB to list the state and wait reasons for all threads when stopped in the debugger.
- Fixed behavior of stepping. It sometimes could interact unpredictably with scheduling due to having a single debugger-wide step flag instead of a per-thread step flag, which would confuse and crash GDB. I no longer get any crashes with these changes.
- Fixed stepping into thread exits.
- Fixed deadlock on shutdown if debugger was not attached during start. 