### PR TITLE
core/debugger: Define defaulted virtual destructors

### DIFF
--- a/src/core/debugger/debugger.cpp
+++ b/src/core/debugger/debugger.cpp
@@ -50,7 +50,7 @@ public:
         InitializeServer(port);
     }
 
-    ~DebuggerImpl() {
+    ~DebuggerImpl() override {
         ShutdownServer();
     }
 

--- a/src/core/debugger/debugger_interface.h
+++ b/src/core/debugger/debugger_interface.h
@@ -24,6 +24,8 @@ enum class DebuggerAction {
 
 class DebuggerBackend {
 public:
+    virtual ~DebuggerBackend() = default;
+
     /**
      * Can be invoked from a callback to synchronously wait for more data.
      * Will return as soon as least one byte is received. Reads up to 4096 bytes.
@@ -50,6 +52,8 @@ public:
 class DebuggerFrontend {
 public:
     explicit DebuggerFrontend(DebuggerBackend& backend_) : backend{backend_} {}
+
+    virtual ~DebuggerFrontend() = default;
 
     /**
      * Called after the client has successfully connected to the port.

--- a/src/core/debugger/gdbstub.h
+++ b/src/core/debugger/gdbstub.h
@@ -19,7 +19,7 @@ class System;
 class GDBStub : public DebuggerFrontend {
 public:
     explicit GDBStub(DebuggerBackend& backend, Core::System& system);
-    ~GDBStub();
+    ~GDBStub() override;
 
     void Connected() override;
     void Stopped(Kernel::KThread* thread) override;


### PR DESCRIPTION
Resolves an MSVC warning where a virtual destructor is not defined in the base class with virtual functions.