### PR TITLE
ui: Status bars dock button becomes DOCKED/HANDHELD button

### DIFF
--- a/dist/qt_themes/default/style.qss
+++ b/dist/qt_themes/default/style.qss
@@ -58,6 +58,19 @@ QPushButton#GPUStatusBarButton:!checked {
     color: #109010;
 }
 
+QPushButton#DockingStatusBarButton {
+    min-width: 0px;
+    color: #000000;
+    border: 1px solid transparent;
+    background-color: transparent;
+    padding: 0px 3px 0px 3px;
+    text-align: center;
+}
+
+QPushButton#DockingStatusBarButton:hover {
+    border: 1px solid #76797C;
+}
+
 QPushButton#buttonRefreshDevices {
     min-width: 21px;
     min-height: 21px;

--- a/dist/qt_themes/qdarkstyle/style.qss
+++ b/dist/qt_themes/qdarkstyle/style.qss
@@ -1304,6 +1304,19 @@ QPushButton#GPUStatusBarButton:!checked {
     color: #40dd40;
 }
 
+QPushButton#DockingStatusBarButton {
+    min-width: 0px;
+    color: #ffffff;
+    border: 1px solid transparent;
+    background-color: transparent;
+    padding: 0px 3px 0px 3px;
+    text-align: center;
+}
+
+QPushButton#DockingStatusBarButton:hover {
+    border: 1px solid #76797C;
+}
+
 QPushButton#buttonRefreshDevices {
     min-width: 23px;
     min-height: 23px;

--- a/dist/qt_themes/qdarkstyle_midnight_blue/style.qss
+++ b/dist/qt_themes/qdarkstyle_midnight_blue/style.qss
@@ -2207,6 +2207,19 @@ QPushButton#GPUStatusBarButton:!checked {
   color: #40dd40;
 }
 
+QPushButton#DockingStatusBarButton {
+    min-width: 0px;
+    color: #ffffff;
+    border: 1px solid transparent;
+    background-color: transparent;
+    padding: 0px 3px 0px 3px;
+    text-align: center;
+}
+
+QPushButton#DockingStatusBarButton:hover {
+    border: 1px solid #76797C;
+}
+
 QPushButton#buttonRefreshDevices {
   min-width: 19px;
   min-height: 19px;

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -827,12 +827,11 @@ void GMainWindow::InitializeWidgets() {
 
     // Setup Dock button
     dock_status_button = new QPushButton();
-    dock_status_button->setObjectName(QStringLiteral("TogglableStatusBarButton"));
+    dock_status_button->setObjectName(QStringLiteral("DockingStatusBarButton"));
     dock_status_button->setFocusPolicy(Qt::NoFocus);
     connect(dock_status_button, &QPushButton::clicked, this, &GMainWindow::OnToggleDockedMode);
-    dock_status_button->setText(tr("DOCK"));
     dock_status_button->setCheckable(true);
-    dock_status_button->setChecked(Settings::values.use_docked_mode.GetValue());
+    UpdateDockedButton();
     statusBar()->insertPermanentWidget(0, dock_status_button);
 
     gpu_accuracy_button = new QPushButton();
@@ -2858,7 +2857,7 @@ void GMainWindow::OnToggleDockedMode() {
     }
 
     Settings::values.use_docked_mode.SetValue(!is_docked);
-    dock_status_button->setChecked(!is_docked);
+    UpdateDockedButton();
     OnDockedModeChanged(is_docked, !is_docked, *system);
 }
 
@@ -3224,6 +3223,12 @@ void GMainWindow::UpdateGPUAccuracyButton() {
     }
 }
 
+void GMainWindow::UpdateDockedButton() {
+    const bool is_docked = Settings::values.use_docked_mode.GetValue();
+    dock_status_button->setChecked(is_docked);
+    dock_status_button->setText(is_docked ? tr("DOCKED") : tr("HANDHELD"));
+}
+
 void GMainWindow::UpdateFilterText() {
     const auto filter = Settings::values.scaling_filter.GetValue();
     switch (filter) {
@@ -3267,10 +3272,10 @@ void GMainWindow::UpdateAAText() {
 }
 
 void GMainWindow::UpdateStatusButtons() {
-    dock_status_button->setChecked(Settings::values.use_docked_mode.GetValue());
     renderer_status_button->setChecked(Settings::values.renderer_backend.GetValue() ==
                                        Settings::RendererBackend::Vulkan);
     UpdateGPUAccuracyButton();
+    UpdateDockedButton();
     UpdateFilterText();
     UpdateAAText();
 }

--- a/src/yuzu/main.h
+++ b/src/yuzu/main.h
@@ -320,6 +320,7 @@ private:
     void MigrateConfigFiles();
     void UpdateWindowTitle(std::string_view title_name = {}, std::string_view title_version = {},
                            std::string_view gpu_vendor = {});
+    void UpdateDockedButton();
     void UpdateFilterText();
     void UpdateAAText();
     void UpdateStatusBar();


### PR DESCRIPTION
For people not used to the Yuzu UI it's not always clear if the emulated
console is docked or not.  The other items update their text when clicked,
this PR brings the DOCK button in line with this.

DOCK -> DOCK or UNDOCK

Revised to

DOCK -> DOCKED or HANDHELD

---
![image](https://user-images.githubusercontent.com/190571/171356848-95c7770d-5341-4bec-942a-ad913ecb9d6e.png)
![image](https://user-images.githubusercontent.com/190571/171356904-770b7043-cf12-48f9-ae34-307228346398.png)

