### PR TITLE
gdbstub: Support reading guest thread names

### DIFF
--- a/src/core/debugger/gdbstub.h
+++ b/src/core/debugger/gdbstub.h
@@ -34,7 +34,6 @@ private:
     std::optional<std::string> DetachCommand();
     Kernel::KThread* GetThreadByID(u64 thread_id);
 
-    static u8 CalculateChecksum(std::string_view data);
     void SendReply(std::string_view data);
     void SendStatus(char status);
 

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -198,6 +198,10 @@ ResultCode KThread::Initialize(KThreadFunction func, uintptr_t arg, VAddr user_s
     resource_limit_release_hint = false;
     cpu_time = 0;
 
+    // Set debug context.
+    stack_top = user_stack_top;
+    argument = arg;
+
     // Clear our stack parameters.
     std::memset(static_cast<void*>(std::addressof(GetStackParameters())), 0,
                 sizeof(StackParameters));

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -660,6 +660,14 @@ public:
     void IfDummyThreadTryWait();
     void IfDummyThreadEndWait();
 
+    [[nodiscard]] uintptr_t GetArgument() const {
+        return argument;
+    }
+
+    [[nodiscard]] VAddr GetUserStackTop() const {
+        return stack_top;
+    }
+
 private:
     static constexpr size_t PriorityInheritanceCountMax = 10;
     union SyncObjectBuffer {
@@ -791,6 +799,8 @@ private:
     std::vector<KSynchronizationObject*> wait_objects_for_debugging;
     VAddr mutex_wait_address_for_debugging{};
     ThreadWaitReasonForDebugging wait_reason_for_debugging{};
+    uintptr_t argument;
+    VAddr stack_top;
 
 public:
     using ConditionVariableThreadTreeType = ConditionVariableThreadTree;


### PR DESCRIPTION
It was pointed out to me by members of Reswitched that guest threads can indeed have names, even though there is no SVC to set a thread name. Reads the thread name from the `nn::os::ThreadType` struct available in TLS.

![Screenshot from 2022-06-01 21-04-21](https://user-images.githubusercontent.com/9658600/171526131-c55c5db1-d232-44c1-9cac-980fc11b9f2a.png)

![image](https://user-images.githubusercontent.com/9658600/171526354-47021f1e-55cb-4663-a362-06a4d95ac3e1.png)

