### PR TITLE
Maxwell3D: Fix 3D semaphore counter type 0 handling

### DIFF
--- a/src/video_core/engines/maxwell_3d.cpp
+++ b/src/video_core/engines/maxwell_3d.cpp
@@ -595,8 +595,8 @@ void Maxwell3D::DrawArrays() {
 
 std::optional<u64> Maxwell3D::GetQueryResult() {
     switch (regs.query.query_get.select) {
-    case Regs::QuerySelect::Zero:
-        return 0;
+    case Regs::QuerySelect::Payload:
+        return regs.query.query_sequence;
     case Regs::QuerySelect::SamplesPassed:
         // Deferred.
         rasterizer->Query(regs.query.QueryAddress(), QueryType::SamplesPassed,

--- a/src/video_core/engines/maxwell_3d.h
+++ b/src/video_core/engines/maxwell_3d.h
@@ -93,7 +93,7 @@ public:
         };
 
         enum class QuerySelect : u32 {
-            Zero = 0,
+            Payload = 0,
             TimeElapsed = 2,
             TransformFeedbackPrimitivesGenerated = 11,
             PrimitivesGenerated = 18,


### PR DESCRIPTION
Counter type 0 actually releases the semaphore payload rather than a constant zero as was previously thought. This is required by Skyrim.