### PR TITLE
Follow-up fixes for NVFlinger rewrite (Part 3) 

### DIFF
--- a/src/core/hle/service/nvflinger/buffer_queue_core.cpp
+++ b/src/core/hle/service/nvflinger/buffer_queue_core.cpp
@@ -84,10 +84,6 @@ void BufferQueueCore::FreeBufferLocked(s32 slot) {
 
     slots[slot].graphic_buffer.reset();
 
-    if (slots[slot].buffer_state == BufferState::Acquired) {
-        slots[slot].needs_cleanup_on_release = true;
-    }
-
     slots[slot].buffer_state = BufferState::Free;
     slots[slot].frame_number = UINT32_MAX;
     slots[slot].acquire_called = false;

--- a/src/core/hle/service/nvflinger/buffer_slot.h
+++ b/src/core/hle/service/nvflinger/buffer_slot.h
@@ -31,7 +31,6 @@ struct BufferSlot final {
     u64 frame_number{};
     Fence fence;
     bool acquire_called{};
-    bool needs_cleanup_on_release{};
     bool attached_by_consumer{};
     bool is_preallocated{};
 };


### PR DESCRIPTION
Hopefully the last of the NVFlinger rewrite bug trail. This change tightly couples released buffers being marked as freed, which fixes frame pacing issues and matches the pre-rewrite behavior. As a side note, this change is not 1:1 with real Switch behavior. Due to the very multithreaded nature of yuzu (and the need to be consistent across varying host HW), we need to be more sensitive to timing here.

Fixes #8191.
Supersedes  #8354.