### PR TITLE
core/debugger: memory breakpoint support

### DIFF
--- a/src/common/page_table.h
+++ b/src/common/page_table.h
@@ -15,6 +15,9 @@ enum class PageType : u8 {
     Unmapped,
     /// Page is mapped to regular memory. This is the only type you can get pointers to.
     Memory,
+    /// Page is mapped to regular memory, but inaccessible from CPU fastmem and must use
+    /// the callbacks.
+    DebugMemory,
     /// Page is mapped to regular memory, but also needs to check for rasterizer cache flushing and
     /// invalidation
     RasterizerCachedMemory,

--- a/src/core/arm/dynarmic/arm_dynarmic_32.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.cpp
@@ -29,45 +29,62 @@ using namespace Common::Literals;
 class DynarmicCallbacks32 : public Dynarmic::A32::UserCallbacks {
 public:
     explicit DynarmicCallbacks32(ARM_Dynarmic_32& parent_)
-        : parent{parent_}, memory(parent.system.Memory()) {}
+        : parent{parent_},
+          memory(parent.system.Memory()), debugger_enabled{parent.system.DebuggerEnabled()} {}
 
     u8 MemoryRead8(u32 vaddr) override {
+        CheckMemoryAccess(vaddr, 1, Kernel::DebugWatchpointType::Read);
         return memory.Read8(vaddr);
     }
     u16 MemoryRead16(u32 vaddr) override {
+        CheckMemoryAccess(vaddr, 2, Kernel::DebugWatchpointType::Read);
         return memory.Read16(vaddr);
     }
     u32 MemoryRead32(u32 vaddr) override {
+        CheckMemoryAccess(vaddr, 4, Kernel::DebugWatchpointType::Read);
         return memory.Read32(vaddr);
     }
     u64 MemoryRead64(u32 vaddr) override {
+        CheckMemoryAccess(vaddr, 8, Kernel::DebugWatchpointType::Read);
         return memory.Read64(vaddr);
     }
 
     void MemoryWrite8(u32 vaddr, u8 value) override {
-        memory.Write8(vaddr, value);
+        if (CheckMemoryAccess(vaddr, 1, Kernel::DebugWatchpointType::Write)) {
+            memory.Write8(vaddr, value);
+        }
     }
     void MemoryWrite16(u32 vaddr, u16 value) override {
-        memory.Write16(vaddr, value);
+        if (CheckMemoryAccess(vaddr, 2, Kernel::DebugWatchpointType::Write)) {
+            memory.Write16(vaddr, value);
+        }
     }
     void MemoryWrite32(u32 vaddr, u32 value) override {
-        memory.Write32(vaddr, value);
+        if (CheckMemoryAccess(vaddr, 4, Kernel::DebugWatchpointType::Write)) {
+            memory.Write32(vaddr, value);
+        }
     }
     void MemoryWrite64(u32 vaddr, u64 value) override {
-        memory.Write64(vaddr, value);
+        if (CheckMemoryAccess(vaddr, 8, Kernel::DebugWatchpointType::Write)) {
+            memory.Write64(vaddr, value);
+        }
     }
 
     bool MemoryWriteExclusive8(u32 vaddr, u8 value, u8 expected) override {
-        return memory.WriteExclusive8(vaddr, value, expected);
+        return CheckMemoryAccess(vaddr, 1, Kernel::DebugWatchpointType::Write) &&
+               memory.WriteExclusive8(vaddr, value, expected);
     }
     bool MemoryWriteExclusive16(u32 vaddr, u16 value, u16 expected) override {
-        return memory.WriteExclusive16(vaddr, value, expected);
+        return CheckMemoryAccess(vaddr, 2, Kernel::DebugWatchpointType::Write) &&
+               memory.WriteExclusive16(vaddr, value, expected);
     }
     bool MemoryWriteExclusive32(u32 vaddr, u32 value, u32 expected) override {
-        return memory.WriteExclusive32(vaddr, value, expected);
+        return CheckMemoryAccess(vaddr, 4, Kernel::DebugWatchpointType::Write) &&
+               memory.WriteExclusive32(vaddr, value, expected);
     }
     bool MemoryWriteExclusive64(u32 vaddr, u64 value, u64 expected) override {
-        return memory.WriteExclusive64(vaddr, value, expected);
+        return CheckMemoryAccess(vaddr, 8, Kernel::DebugWatchpointType::Write) &&
+               memory.WriteExclusive64(vaddr, value, expected);
     }
 
     void InterpreterFallback(u32 pc, std::size_t num_instructions) override {
@@ -77,8 +94,8 @@ public:
     }
 
     void ExceptionRaised(u32 pc, Dynarmic::A32::Exception exception) override {
-        if (parent.system.DebuggerEnabled()) {
-            parent.jit.load()->Regs()[15] = pc;
+        if (debugger_enabled) {
+            parent.SaveContext(parent.breakpoint_context);
             parent.jit.load()->HaltExecution(ARM_Interface::breakpoint);
             return;
         }
@@ -117,9 +134,26 @@ public:
         return std::max<s64>(parent.system.CoreTiming().GetDowncount(), 0);
     }
 
+    bool CheckMemoryAccess(VAddr addr, u64 size, Kernel::DebugWatchpointType type) {
+        if (!debugger_enabled) {
+            return true;
+        }
+
+        const auto match{parent.MatchingWatchpoint(addr, size, type)};
+        if (match) {
+            parent.SaveContext(parent.breakpoint_context);
+            parent.jit.load()->HaltExecution(ARM_Interface::watchpoint);
+            parent.halted_watchpoint = match;
+            return false;
+        }
+
+        return true;
+    }
+
     ARM_Dynarmic_32& parent;
     Core::Memory::Memory& memory;
     std::size_t num_interpreted_instructions{};
+    bool debugger_enabled{};
     static constexpr u64 minimum_run_cycles = 1000U;
 };
 
@@ -153,6 +187,11 @@ std::shared_ptr<Dynarmic::A32::Jit> ARM_Dynarmic_32::MakeJit(Common::PageTable* 
     // Code cache size
     config.code_cache_size = 512_MiB;
     config.far_code_offset = 400_MiB;
+
+    // Allow memory fault handling to work
+    if (system.DebuggerEnabled()) {
+        config.check_halt_on_memory_access = true;
+    }
 
     // null_jit
     if (!page_table) {
@@ -246,6 +285,14 @@ Dynarmic::HaltReason ARM_Dynarmic_32::StepJit() {
 
 u32 ARM_Dynarmic_32::GetSvcNumber() const {
     return svc_swi;
+}
+
+const Kernel::DebugWatchpoint* ARM_Dynarmic_32::HaltedWatchpoint() const {
+    return halted_watchpoint;
+}
+
+void ARM_Dynarmic_32::RewindBreakpointInstruction() {
+    LoadContext(breakpoint_context);
 }
 
 ARM_Dynarmic_32::ARM_Dynarmic_32(System& system_, CPUInterrupts& interrupt_handlers_,

--- a/src/core/arm/dynarmic/arm_dynarmic_32.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.h
@@ -72,6 +72,8 @@ protected:
     Dynarmic::HaltReason RunJit() override;
     Dynarmic::HaltReason StepJit() override;
     u32 GetSvcNumber() const override;
+    const Kernel::DebugWatchpoint* HaltedWatchpoint() const override;
+    void RewindBreakpointInstruction() override;
 
 private:
     std::shared_ptr<Dynarmic::A32::Jit> MakeJit(Common::PageTable* page_table) const;
@@ -98,6 +100,10 @@ private:
 
     // SVC callback
     u32 svc_swi{};
+
+    // Watchpoint info
+    const Kernel::DebugWatchpoint* halted_watchpoint;
+    ThreadContext32 breakpoint_context;
 };
 
 } // namespace Core

--- a/src/core/arm/dynarmic/arm_dynarmic_64.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.h
@@ -66,6 +66,8 @@ protected:
     Dynarmic::HaltReason RunJit() override;
     Dynarmic::HaltReason StepJit() override;
     u32 GetSvcNumber() const override;
+    const Kernel::DebugWatchpoint* HaltedWatchpoint() const override;
+    void RewindBreakpointInstruction() override;
 
 private:
     std::shared_ptr<Dynarmic::A64::Jit> MakeJit(Common::PageTable* page_table,
@@ -91,6 +93,10 @@ private:
 
     // SVC callback
     u32 svc_swi{};
+
+    // Breakpoint info
+    const Kernel::DebugWatchpoint* halted_watchpoint;
+    ThreadContext64 breakpoint_context;
 };
 
 } // namespace Core

--- a/src/core/debugger/debugger.h
+++ b/src/core/debugger/debugger.h
@@ -9,7 +9,8 @@
 
 namespace Kernel {
 class KThread;
-}
+struct DebugWatchpoint;
+} // namespace Kernel
 
 namespace Core {
 class System;
@@ -39,6 +40,11 @@ public:
      * Notify the debugger that a shutdown is being performed now and disconnect.
      */
     void NotifyShutdown();
+
+    /*
+     * Notify the debugger that the given thread has stopped due to hitting a watchpoint.
+     */
+    bool NotifyThreadWatchpoint(Kernel::KThread* thread, const Kernel::DebugWatchpoint& watch);
 
 private:
     std::unique_ptr<DebuggerImpl> impl;

--- a/src/core/debugger/debugger_interface.h
+++ b/src/core/debugger/debugger_interface.h
@@ -11,7 +11,8 @@
 
 namespace Kernel {
 class KThread;
-}
+struct DebugWatchpoint;
+} // namespace Kernel
 
 namespace Core {
 
@@ -70,6 +71,11 @@ public:
      * Called when emulation is shutting down.
      */
     virtual void ShuttingDown() = 0;
+
+    /*
+     * Called when emulation has stopped on a watchpoint.
+     */
+    virtual void Watchpoint(Kernel::KThread* thread, const Kernel::DebugWatchpoint& watch) = 0;
 
     /**
      * Called when new data is asynchronously received on the client socket.

--- a/src/core/debugger/gdbstub.h
+++ b/src/core/debugger/gdbstub.h
@@ -24,6 +24,7 @@ public:
     void Connected() override;
     void Stopped(Kernel::KThread* thread) override;
     void ShuttingDown() override;
+    void Watchpoint(Kernel::KThread* thread, const Kernel::DebugWatchpoint& watch) override;
     std::vector<DebuggerAction> ClientData(std::span<const u8> data) override;
 
 private:
@@ -31,6 +32,8 @@ private:
     void ExecuteCommand(std::string_view packet, std::vector<DebuggerAction>& actions);
     void HandleVCont(std::string_view command, std::vector<DebuggerAction>& actions);
     void HandleQuery(std::string_view command);
+    void HandleBreakpointInsert(std::string_view command);
+    void HandleBreakpointRemove(std::string_view command);
     std::vector<char>::const_iterator CommandEnd() const;
     std::optional<std::string> DetachCommand();
     Kernel::KThread* GetThreadByID(u64 thread_id);

--- a/src/core/hardware_properties.h
+++ b/src/core/hardware_properties.h
@@ -25,6 +25,9 @@ constexpr std::array<s32, Common::BitSize<u64>()> VirtualToPhysicalCoreMap{
     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 3,
 };
 
+// Cortex-A57 supports 4 memory watchpoints
+constexpr u64 NUM_WATCHPOINTS = 4;
+
 } // namespace Hardware
 
 } // namespace Core

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -584,6 +584,52 @@ ResultCode KProcess::DeleteThreadLocalRegion(VAddr addr) {
     return ResultSuccess;
 }
 
+bool KProcess::InsertWatchpoint(Core::System& system, VAddr addr, u64 size,
+                                DebugWatchpointType type) {
+    const auto watch{std::find_if(watchpoints.begin(), watchpoints.end(), [&](const auto& wp) {
+        return wp.type == DebugWatchpointType::None;
+    })};
+
+    if (watch == watchpoints.end()) {
+        return false;
+    }
+
+    watch->start_address = addr;
+    watch->end_address = addr + size;
+    watch->type = type;
+
+    for (VAddr page = Common::AlignDown(addr, PageSize); page < addr + size; page += PageSize) {
+        debug_page_refcounts[page]++;
+        system.Memory().MarkRegionDebug(page, PageSize, true);
+    }
+
+    return true;
+}
+
+bool KProcess::RemoveWatchpoint(Core::System& system, VAddr addr, u64 size,
+                                DebugWatchpointType type) {
+    const auto watch{std::find_if(watchpoints.begin(), watchpoints.end(), [&](const auto& wp) {
+        return wp.start_address == addr && wp.end_address == addr + size && wp.type == type;
+    })};
+
+    if (watch == watchpoints.end()) {
+        return false;
+    }
+
+    watch->start_address = 0;
+    watch->end_address = 0;
+    watch->type = DebugWatchpointType::None;
+
+    for (VAddr page = Common::AlignDown(addr, PageSize); page < addr + size; page += PageSize) {
+        debug_page_refcounts[page]--;
+        if (!debug_page_refcounts[page]) {
+            system.Memory().MarkRegionDebug(page, PageSize, false);
+        }
+    }
+
+    return true;
+}
+
 void KProcess::LoadModule(CodeSet code_set, VAddr base_addr) {
     const auto ReprotectSegment = [&](const CodeSet::Segment& segment,
                                       Svc::MemoryPermission permission) {

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -710,6 +710,7 @@ void KScheduler::Reload(KThread* thread) {
     Core::ARM_Interface& cpu_core = system.ArmInterface(core_id);
     cpu_core.LoadContext(thread->GetContext32());
     cpu_core.LoadContext(thread->GetContext64());
+    cpu_core.LoadWatchpointArray(thread->GetOwnerProcess()->GetWatchpoints());
     cpu_core.SetTlsAddress(thread->GetTLSAddress());
     cpu_core.SetTPIDR_EL0(thread->GetTPIDR_EL0());
     cpu_core.ClearExclusiveState();

--- a/src/core/memory.h
+++ b/src/core/memory.h
@@ -446,6 +446,17 @@ public:
      */
     void RasterizerMarkRegionCached(VAddr vaddr, u64 size, bool cached);
 
+    /**
+     * Marks each page within the specified address range as debug or non-debug.
+     * Debug addresses are not accessible from fastmem pointers.
+     *
+     * @param vaddr The virtual address indicating the start of the address range.
+     * @param size  The size of the address range in bytes.
+     * @param debug Whether or not any pages within the address range should be
+     *              marked as debug or non-debug.
+     */
+    void MarkRegionDebug(VAddr vaddr, u64 size, bool debug);
+
 private:
     Core::System& system;
 


### PR DESCRIPTION
Implements support for both read and write memory breakpoints into the debugger, which is a highly requested feature.

This operates by removing affected pages from the fastmem page table, and checking accesses to the watched regions in the fallbacks when debugging is enabled. When the debugger is enabled, it has some performance impact, but most games which are able to run above full speed should remain above full speed. There is no effect when debugging is not enabled.

![Screenshot from 2022-06-06 19-11-58](https://user-images.githubusercontent.com/9658600/172264378-0e07afc2-c0ea-4ce6-862f-14c301483c6c.png)
