### PR TITLE
input_common: Replace usage of string guid to common uuid

### DIFF
--- a/src/input_common/drivers/sdl_driver.h
+++ b/src/input_common/drivers/sdl_driver.h
@@ -47,6 +47,7 @@ public:
      * Check how many identical joysticks (by guid) were connected before the one with sdl_id and so
      * tie it to a SDLJoystick with the same guid and that port
      */
+    std::shared_ptr<SDLJoystick> GetSDLJoystickByGUID(const Common::UUID& guid, int port);
     std::shared_ptr<SDLJoystick> GetSDLJoystickByGUID(const std::string& guid, int port);
 
     std::vector<Common::ParamPackage> GetInputDevices() const override;
@@ -79,18 +80,18 @@ private:
     /// Takes all vibrations from the queue and sends the command to the controller
     void SendVibrations();
 
-    Common::ParamPackage BuildAnalogParamPackageForButton(int port, std::string guid, s32 axis,
-                                                          float value = 0.1f) const;
-    Common::ParamPackage BuildButtonParamPackageForButton(int port, std::string guid,
+    Common::ParamPackage BuildAnalogParamPackageForButton(int port, const Common::UUID& guid,
+                                                          s32 axis, float value = 0.1f) const;
+    Common::ParamPackage BuildButtonParamPackageForButton(int port, const Common::UUID& guid,
                                                           s32 button) const;
 
-    Common::ParamPackage BuildHatParamPackageForButton(int port, std::string guid, s32 hat,
+    Common::ParamPackage BuildHatParamPackageForButton(int port, const Common::UUID& guid, s32 hat,
                                                        u8 value) const;
 
-    Common::ParamPackage BuildMotionParam(int port, std::string guid) const;
+    Common::ParamPackage BuildMotionParam(int port, const Common::UUID& guid) const;
 
     Common::ParamPackage BuildParamPackageForBinding(
-        int port, const std::string& guid, const SDL_GameControllerButtonBind& binding) const;
+        int port, const Common::UUID& guid, const SDL_GameControllerButtonBind& binding) const;
 
     Common::ParamPackage BuildParamPackageForAnalog(PadIdentifier identifier, int axis_x,
                                                     int axis_y, float offset_x,
@@ -120,7 +121,7 @@ private:
     Common::SPSCQueue<VibrationRequest> vibration_queue;
 
     /// Map of GUID of a list of corresponding virtual Joysticks
-    std::unordered_map<std::string, std::vector<std::shared_ptr<SDLJoystick>>> joystick_map;
+    std::unordered_map<Common::UUID, std::vector<std::shared_ptr<SDLJoystick>>> joystick_map;
     std::mutex joystick_map_mutex;
 
     bool start_thread = false;


### PR DESCRIPTION
At some point SDL returned a string with 33 characters which is bigger than the UUID size. This might be a bug on SDL side but s since we don't really need to use the string at all it's just easier to replace all instances with Common::UUID

This PR should have no difference for the user.