### PR TITLE
core/debugger: fix asio write usage

### DIFF
--- a/src/core/debugger/debugger.cpp
+++ b/src/core/debugger/debugger.cpp
@@ -66,7 +66,7 @@ public:
         }
         stopped = true;
 
-        signal_pipe.write_some(boost::asio::buffer(&thread, sizeof(thread)));
+        boost::asio::write(signal_pipe, boost::asio::buffer(&thread, sizeof(thread)));
         return true;
     }
 
@@ -75,7 +75,7 @@ public:
     }
 
     void WriteToClient(std::span<const u8> data) override {
-        client_socket.write_some(boost::asio::buffer(data.data(), data.size_bytes()));
+        boost::asio::write(client_socket, boost::asio::buffer(data.data(), data.size_bytes()));
     }
 
     void SetActiveThread(Kernel::KThread* thread) override {


### PR DESCRIPTION
`write_some` is only guaranteed to write [at least one byte](https://www.boost.org/doc/libs/1_79_0/doc/html/boost_asio/reference/basic_stream_socket/write_some/overload1.html), but the intended behavior in both of these cases is that the entire buffer should be written in a blocking fashion.