### PR TITLE
service: hid: Fix gesture regression

### DIFF
--- a/src/core/hle/service/hid/controllers/gesture.cpp
+++ b/src/core/hle/service/hid/controllers/gesture.cpp
@@ -61,6 +61,7 @@ void Controller_Gesture::OnUpdate(const Core::Timing::CoreTiming& core_timing) {
     }
 
     last_update_timestamp = shared_memory->gesture_lifo.timestamp;
+    UpdateGestureSharedMemory(gesture, time_difference);
 }
 
 void Controller_Gesture::ReadTouchInput() {
@@ -94,8 +95,7 @@ bool Controller_Gesture::ShouldUpdateGesture(const GestureProperties& gesture,
     return false;
 }
 
-void Controller_Gesture::UpdateGestureSharedMemory(u8* data, std::size_t size,
-                                                   GestureProperties& gesture,
+void Controller_Gesture::UpdateGestureSharedMemory(GestureProperties& gesture,
                                                    f32 time_difference) {
     GestureType type = GestureType::Idle;
     GestureAttribute attributes{};

--- a/src/core/hle/service/hid/controllers/gesture.h
+++ b/src/core/hle/service/hid/controllers/gesture.h
@@ -107,8 +107,7 @@ private:
     bool ShouldUpdateGesture(const GestureProperties& gesture, f32 time_difference);
 
     // Updates the shared memory to the next state
-    void UpdateGestureSharedMemory(u8* data, std::size_t size, GestureProperties& gesture,
-                                   f32 time_difference);
+    void UpdateGestureSharedMemory(GestureProperties& gesture, f32 time_difference);
 
     // Initializes new gesture
     void NewGesture(GestureProperties& gesture, GestureType& type, GestureAttribute& attributes);


### PR DESCRIPTION
I accidentally deleted `UpdateGestureSharedMemory` on #8229 this effectively broke gestures. Thanks to OZ for finding the issue.