### PR TITLE
retranslate the game list placeholder

### DIFF
--- a/src/yuzu/game_list.cpp
+++ b/src/yuzu/game_list.cpp
@@ -870,7 +870,7 @@ GameListPlaceholder::GameListPlaceholder(GMainWindow* parent) : QWidget{parent} 
     layout->setAlignment(Qt::AlignCenter);
     image->setPixmap(QIcon::fromTheme(QStringLiteral("plus_folder")).pixmap(200));
 
-    text->setText(tr("Double-click to add a new folder to the game list"));
+    RetranslateUI();
     QFont font = text->font();
     font.setPointSize(20);
     text->setFont(font);
@@ -890,4 +890,16 @@ void GameListPlaceholder::onUpdateThemedIcons() {
 
 void GameListPlaceholder::mouseDoubleClickEvent(QMouseEvent* event) {
     emit GameListPlaceholder::AddDirectory();
+}
+
+void GameListPlaceholder::changeEvent(QEvent* event) {
+    if (event->type() == QEvent::LanguageChange) {
+        RetranslateUI();
+    }
+
+    QWidget::changeEvent(event);
+}
+
+void GameListPlaceholder::RetranslateUI() {
+    text->setText(tr("Double-click to add a new folder to the game list"));
 }

--- a/src/yuzu/game_list.h
+++ b/src/yuzu/game_list.h
@@ -166,6 +166,9 @@ protected:
     void mouseDoubleClickEvent(QMouseEvent* event) override;
 
 private:
+    void changeEvent(QEvent* event) override;
+    void RetranslateUI();
+
     QVBoxLayout* layout = nullptr;
     QLabel* image = nullptr;
     QLabel* text = nullptr;


### PR DESCRIPTION
This is the "Double-click to add a new folder to the game list" message
that shows up when users first launch yuzu and is most likely never seen
again. Previously this message was not re-translated.

-----
Bug is triggered by changing language before adding a directory to game list (Start in English, switch to Russian)
![image](https://user-images.githubusercontent.com/190571/173170014-542eaf3a-8b59-433c-bd10-744e9a749811.png)

With PR
![image](https://user-images.githubusercontent.com/190571/173170233-5b778d32-d87f-43e6-b542-7ade68771210.png)
