### PR TITLE
gdbstub_arch: Add missing virtual destructor

### DIFF
--- a/src/core/debugger/gdbstub_arch.h
+++ b/src/core/debugger/gdbstub_arch.h
@@ -15,6 +15,7 @@ namespace Core {
 
 class GDBStubArch {
 public:
+    virtual ~GDBStubArch() = default;
     virtual std::string GetTargetXML() const = 0;
     virtual std::string RegRead(const Kernel::KThread* thread, size_t id) const = 0;
     virtual void RegWrite(Kernel::KThread* thread, size_t id, std::string_view value) const = 0;


### PR DESCRIPTION
The class is used polymorphically, so it's undefined behavior to delete instances of GDBStubA64 and GDBStubA32 from the base class pointer.