### PR TITLE
core/debugger: allow remote connections

### DIFF
--- a/src/core/debugger/debugger.cpp
+++ b/src/core/debugger/debugger.cpp
@@ -96,7 +96,7 @@ private:
         connection_thread = std::jthread([&, port](std::stop_token stop_token) {
             try {
                 // Initialize the listening socket and accept a new client.
-                tcp::endpoint endpoint{boost::asio::ip::address_v4::loopback(), port};
+                tcp::endpoint endpoint{boost::asio::ip::address_v4::any(), port};
                 tcp::acceptor acceptor{io_context, endpoint};
 
                 acceptor.async_accept(client_socket, [](const auto&) {});


### PR DESCRIPTION
The previous debugger available in Citra [did this](https://github.com/citra-emu/citra/blob/88a475970240e1dbade1720b02f9e5338647b1b8/src/core/gdbstub/gdbstub.cpp#L1164-L1167). Considering it is not enabled by default, it's probably not that big of an issue.

Fixes #8453