### PR TITLE
ci/windows: Use Clang for MinGW builds

### DIFF
--- a/.ci/scripts/windows/docker.sh
+++ b/.ci/scripts/windows/docker.sh
@@ -5,7 +5,14 @@ cd /yuzu
 ccache -s
 
 mkdir build || true && cd build
-cmake .. -G Ninja -DDISPLAY_VERSION=$1 -DCMAKE_TOOLCHAIN_FILE="$(pwd)/../CMakeModules/MinGWCross.cmake" -DUSE_CCACHE=ON -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON -DCMAKE_BUILD_TYPE=Release -DENABLE_QT_TRANSLATION=ON
+cmake .. \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_TOOLCHAIN_FILE="$(pwd)/../CMakeModules/MinGWCross.cmake" \
+    -DDISPLAY_VERSION=$1 \
+    -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON \
+    -DENABLE_QT_TRANSLATION=ON \
+    -DUSE_CCACHE=ON \
+    -GNinja \
 ninja
 
 ccache -s

--- a/.ci/scripts/windows/docker.sh
+++ b/.ci/scripts/windows/docker.sh
@@ -1,19 +1,27 @@
 #!/bin/bash -ex
 
+set -e
+
 cd /yuzu
 
 ccache -s
 
 mkdir build || true && cd build
+LDFLAGS="-fuse-ld=lld"
+# -femulated-tls required due to an incompatibility between GCC and Clang
+# TODO(lat9nq): If this is widespread, we probably need to add this to CMakeLists where appropriate
 cmake .. \
     -DCMAKE_BUILD_TYPE=Release \
-    -DCMAKE_TOOLCHAIN_FILE="$(pwd)/../CMakeModules/MinGWCross.cmake" \
+    -DCMAKE_CXX_FLAGS="-femulated-tls" \
+    -DCMAKE_TOOLCHAIN_FILE="$(pwd)/../CMakeModules/MinGWClangCross.cmake" \
     -DDISPLAY_VERSION=$1 \
     -DENABLE_COMPATIBILITY_LIST_DOWNLOAD=ON \
     -DENABLE_QT_TRANSLATION=ON \
     -DUSE_CCACHE=ON \
-    -GNinja \
-ninja
+    -DYUZU_USE_BUNDLED_SDL2=OFF \
+    -DYUZU_USE_EXTERNAL_SDL2=OFF \
+    -GNinja
+ninja yuzu yuzu-cmd
 
 ccache -s
 

--- a/CMakeModules/MinGWClangCross.cmake
+++ b/CMakeModules/MinGWClangCross.cmake
@@ -1,0 +1,55 @@
+set(MINGW_PREFIX                /usr/x86_64-w64-mingw32/)
+set(CMAKE_SYSTEM_NAME           Windows)
+set(CMAKE_SYSTEM_PROCESSOR      x86_64)
+
+set(CMAKE_FIND_ROOT_PATH        ${MINGW_PREFIX})
+set(SDL2_PATH                   ${MINGW_PREFIX})
+set(MINGW_TOOL_PREFIX           ${CMAKE_SYSTEM_PROCESSOR}-w64-mingw32-)
+
+# Specify the cross compiler
+set(CMAKE_C_COMPILER            ${MINGW_TOOL_PREFIX}clang)
+set(CMAKE_CXX_COMPILER          ${MINGW_TOOL_PREFIX}clang++)
+set(CMAKE_RC_COMPILER           ${MINGW_TOOL_PREFIX}windres)
+set(CMAKE_C_COMPILER_AR         ${MINGW_TOOL_PREFIX}ar)
+set(CMAKE_CXX_COMPILER_AR       ${MINGW_TOOL_PREFIX}ar)
+set(CMAKE_C_COMPILER_RANLIB     ${MINGW_TOOL_PREFIX}ranlib)
+set(CMAKE_CXX_COMPILER_RANLIB   ${MINGW_TOOL_PREFIX}ranlib)
+
+# Mingw tools
+set(STRIP                       ${MINGW_TOOL_PREFIX}strip)
+set(WINDRES                     ${MINGW_TOOL_PREFIX}windres)
+set(ENV{PKG_CONFIG}             ${MINGW_TOOL_PREFIX}pkg-config)
+
+# ccache wrapper
+option(USE_CCACHE "Use ccache for compilation" OFF)
+if(USE_CCACHE)
+    find_program(CCACHE ccache)
+    if(CCACHE)
+        message(STATUS "Using ccache found in PATH")
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ${CCACHE})
+        set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ${CCACHE})
+    else(CCACHE)
+        message(WARNING "USE_CCACHE enabled, but no ccache found")
+    endif(CCACHE)
+endif(USE_CCACHE)
+
+# Search for programs in the build host directories
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+
+
+# Echo modified cmake vars to screen for debugging purposes
+if(NOT DEFINED ENV{MINGW_DEBUG_INFO})
+        message("")
+        message("Custom cmake vars: (blank = system default)")
+        message("-----------------------------------------")
+        message("* CMAKE_C_COMPILER                     : ${CMAKE_C_COMPILER}")
+        message("* CMAKE_CXX_COMPILER                   : ${CMAKE_CXX_COMPILER}")
+        message("* CMAKE_RC_COMPILER                    : ${CMAKE_RC_COMPILER}")
+        message("* WINDRES                              : ${WINDRES}")
+        message("* ENV{PKG_CONFIG}                      : $ENV{PKG_CONFIG}")
+        message("* STRIP                                : ${STRIP}")
+        message("* USE_CCACHE                           : ${USE_CCACHE}")
+        message("")
+        # So that the debug info only appears once
+        set(ENV{MINGW_DEBUG_INFO} SHOWN)
+endif()


### PR DESCRIPTION
The reason I wanted to do this is twofold: GCC 12 appears to have optimization errors and bogus warnings, and in the future I want to move MinGW to Clang anyway for possibly releasing these builds instead of those from MSVC.

We aren't ready to release any MinGW build though due to stability issues in yuzu's VFS. However, the timing of this part wasn't entirely my choice since Arch Linux has moved their MinGW compiler to GCC 12.

I would still like to see https://github.com/yuzu-emu/yuzu/pull/8439 working before merging this, but if for some reason it doesn't seem worth it, that isn't a hard requirement.

One last thing: I wanted to include [Polly](https://polly.llvm.org/) optimizations in this PR, but I'd rather back that up with evidence showing that we benefit from it at a later time.