### PR TITLE
structured_control_flow: Remove constexpr Flow::Block

### DIFF
--- a/src/shader_recompiler/frontend/maxwell/structured_control_flow.cpp
+++ b/src/shader_recompiler/frontend/maxwell/structured_control_flow.cpp
@@ -975,13 +975,7 @@ private:
     Environment& env;
     IR::AbstractSyntaxList& syntax_list;
     bool uses_demote_to_helper{};
-
-// TODO: C++20 Remove this when all compilers support constexpr std::vector
-#if __cpp_lib_constexpr_vector >= 201907
-    static constexpr Flow::Block dummy_flow_block;
-#else
     const Flow::Block dummy_flow_block;
-#endif
 };
 } // Anonymous namespace
 


### PR DESCRIPTION
This seems to be unsupported in newer libstdc++ versions due to Flow::Block's base class being a non-literal type. It's not clear to me why this was permitted in earlier versions.

Suggested to me by @Morph1984 that I pull this commit from #8455 to give it its own PR. That one and #8439 will need to rebase on this one once merged.