### PR TITLE
bounded_threadsafe_queue: Use constexpr capacity and mask

### DIFF
--- a/src/video_core/gpu_thread.h
+++ b/src/video_core/gpu_thread.h
@@ -98,7 +98,7 @@ struct CommandDataContainer {
 struct SynchState final {
     using CommandQueue = Common::MPSCQueue<CommandDataContainer>;
     std::mutex write_lock;
-    CommandQueue queue{512}; // size must be 2^n
+    CommandQueue queue;
     u64 last_fence{};
     std::atomic<u64> signaled_fence{};
     std::condition_variable_any cv;


### PR DESCRIPTION
While this is the primary change, we also:
- Remove the mpsc namespace and rename Queue to MPSCQueue
- Make Slot a private struct within MPSCQueue
- Remove the AlignedAllocator template argument, as we use std::allocator
- Replace instances of mask + 1 with capacity, and mask + 2 with capacity + 1

Also set the default capacity to 0x400 (1024) instead of 512