### PR TITLE
kernel: fix some uses of disable_count

### DIFF
--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -57,18 +57,13 @@ void SetupMainThread(Core::System& system, KProcess& owner_process, u32 priority
     thread->GetContext64().cpu_registers[0] = 0;
     thread->GetContext32().cpu_registers[1] = thread_handle;
     thread->GetContext64().cpu_registers[1] = thread_handle;
-    thread->DisableDispatch();
 
-    auto& kernel = system.Kernel();
-    // Threads by default are dormant, wake up the main thread so it runs when the scheduler fires
-    {
-        KScopedSchedulerLock lock{kernel};
-        thread->SetState(ThreadState::Runnable);
-
-        if (system.DebuggerEnabled()) {
-            thread->RequestSuspend(SuspendType::Debug);
-        }
+    if (system.DebuggerEnabled()) {
+        thread->RequestSuspend(SuspendType::Debug);
     }
+
+    // Run our thread.
+    void(thread->Run());
 }
 } // Anonymous namespace
 

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -829,6 +829,7 @@ void KScheduler::Initialize() {
     idle_thread = KThread::Create(system.Kernel());
     ASSERT(KThread::InitializeIdleThread(system, idle_thread, core_id).IsSuccess());
     idle_thread->SetName(fmt::format("IdleThread:{}", core_id));
+    idle_thread->EnableDispatch();
 }
 
 KScopedSchedulerLock::KScopedSchedulerLock(KernelCore& kernel)

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -225,7 +225,7 @@ ResultCode KThread::Initialize(KThreadFunction func, uintptr_t arg, VAddr user_s
     // Setup the stack parameters.
     StackParameters& sp = GetStackParameters();
     sp.cur_thread = this;
-    sp.disable_count = 0;
+    sp.disable_count = 1;
     SetInExceptionHandler();
 
     // Set thread ID.
@@ -1013,8 +1013,6 @@ ResultCode KThread::Run() {
 
         // Set our state and finish.
         SetState(ThreadState::Runnable);
-
-        DisableDispatch();
 
         return ResultSuccess;
     }

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -254,7 +254,6 @@ struct KernelCore::Impl {
                                                          core_id)
                        .IsSuccess());
             shutdown_threads[core_id]->SetName(fmt::format("SuspendThread:{}", core_id));
-            shutdown_threads[core_id]->DisableDispatch();
         }
     }
 


### PR DESCRIPTION
Aligns more of this with Atmosphere. Note that we have to specially mark the idle threads because we perform scheduling dispatch from them, which I will address at a later date.