### PR TITLE
common: param_package: Demote DEBUG to TRACE for getters

### DIFF
--- a/src/common/param_package.cpp
+++ b/src/common/param_package.cpp
@@ -76,7 +76,7 @@ std::string ParamPackage::Serialize() const {
 std::string ParamPackage::Get(const std::string& key, const std::string& default_value) const {
     auto pair = data.find(key);
     if (pair == data.end()) {
-        LOG_DEBUG(Common, "key '{}' not found", key);
+        LOG_TRACE(Common, "key '{}' not found", key);
         return default_value;
     }
 
@@ -86,7 +86,7 @@ std::string ParamPackage::Get(const std::string& key, const std::string& default
 int ParamPackage::Get(const std::string& key, int default_value) const {
     auto pair = data.find(key);
     if (pair == data.end()) {
-        LOG_DEBUG(Common, "key '{}' not found", key);
+        LOG_TRACE(Common, "key '{}' not found", key);
         return default_value;
     }
 
@@ -101,7 +101,7 @@ int ParamPackage::Get(const std::string& key, int default_value) const {
 float ParamPackage::Get(const std::string& key, float default_value) const {
     auto pair = data.find(key);
     if (pair == data.end()) {
-        LOG_DEBUG(Common, "key {} not found", key);
+        LOG_TRACE(Common, "key {} not found", key);
         return default_value;
     }
 


### PR DESCRIPTION
Not all keys are saved in the config file to keep it as clean as posible. Every time input is loaded it will flood the log with these warnings if you are running under debug. Quite annoying for me since they don't provide any useful info and will return the default anyways.