### PR TITLE
Implement ExitProcess svc

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -1726,11 +1726,12 @@ static ResultCode UnmapProcessCodeMemory(Core::System& system, Handle process_ha
 /// Exits the current process
 static void ExitProcess(Core::System& system) {
     auto* current_process = system.Kernel().CurrentProcess();
-    UNIMPLEMENTED();
 
     LOG_INFO(Kernel_SVC, "Process {} exiting", current_process->GetProcessID());
     ASSERT_MSG(current_process->GetStatus() == ProcessStatus::Running,
                "Process has already exited");
+
+    system.Exit();
 }
 
 static void ExitProcess32(Core::System& system) {


### PR DESCRIPTION
Currently this just stops all the emulation
This works under assumption that only application will try to use
ExitProcess, with services not touching it
If application exits - it quite makes sense to end the emulation