### PR TITLE
Make yuzu-cmd respect log_filter setting

### DIFF
--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -138,6 +138,12 @@ int main(int argc, char** argv) {
 
     Config config{config_path};
 
+    // apply the log_filter setting
+    // the logger was initialized before and doesn't pick up the filter on its own
+    Common::Log::Filter filter;
+    filter.ParseFilterString(Settings::values.log_filter.GetValue());
+    Common::Log::SetGlobalFilter(filter);
+
     if (!program_args.empty()) {
         Settings::values.program_args = program_args;
     }


### PR DESCRIPTION
Because logging infrastructure initializes before the loading of the
config, it reads the default setting for log_filter and ignores the one
set in config. To change log_filter after logging initialization some
additional calls need to be made.