### PR TITLE
kernel: make current thread pointer thread local

### DIFF
--- a/src/core/arm/arm_interface.cpp
+++ b/src/core/arm/arm_interface.cpp
@@ -95,7 +95,7 @@ void ARM_Interface::Run() {
     using Kernel::SuspendType;
 
     while (true) {
-        Kernel::KThread* current_thread{system.Kernel().CurrentScheduler()->GetCurrentThread()};
+        Kernel::KThread* current_thread{Kernel::GetCurrentThreadPointer(system.Kernel())};
         Dynarmic::HaltReason hr{};
 
         // Notify the debugger and go to sleep if a step was performed

--- a/src/core/hle/kernel/k_address_arbiter.cpp
+++ b/src/core/hle/kernel/k_address_arbiter.cpp
@@ -234,7 +234,7 @@ ResultCode KAddressArbiter::SignalAndModifyByWaitingCountIfEqual(VAddr addr, s32
 
 ResultCode KAddressArbiter::WaitIfLessThan(VAddr addr, s32 value, bool decrement, s64 timeout) {
     // Prepare to wait.
-    KThread* cur_thread = kernel.CurrentScheduler()->GetCurrentThread();
+    KThread* cur_thread = GetCurrentThreadPointer(kernel);
     ThreadQueueImplForKAddressArbiter wait_queue(kernel, std::addressof(thread_tree));
 
     {
@@ -287,7 +287,7 @@ ResultCode KAddressArbiter::WaitIfLessThan(VAddr addr, s32 value, bool decrement
 
 ResultCode KAddressArbiter::WaitIfEqual(VAddr addr, s32 value, s64 timeout) {
     // Prepare to wait.
-    KThread* cur_thread = kernel.CurrentScheduler()->GetCurrentThread();
+    KThread* cur_thread = GetCurrentThreadPointer(kernel);
     ThreadQueueImplForKAddressArbiter wait_queue(kernel, std::addressof(thread_tree));
 
     {

--- a/src/core/hle/kernel/k_condition_variable.cpp
+++ b/src/core/hle/kernel/k_condition_variable.cpp
@@ -106,7 +106,7 @@ KConditionVariable::KConditionVariable(Core::System& system_)
 KConditionVariable::~KConditionVariable() = default;
 
 ResultCode KConditionVariable::SignalToAddress(VAddr addr) {
-    KThread* owner_thread = kernel.CurrentScheduler()->GetCurrentThread();
+    KThread* owner_thread = GetCurrentThreadPointer(kernel);
 
     // Signal the address.
     {
@@ -147,7 +147,7 @@ ResultCode KConditionVariable::SignalToAddress(VAddr addr) {
 }
 
 ResultCode KConditionVariable::WaitForAddress(Handle handle, VAddr addr, u32 value) {
-    KThread* cur_thread = kernel.CurrentScheduler()->GetCurrentThread();
+    KThread* cur_thread = GetCurrentThreadPointer(kernel);
     ThreadQueueImplForKConditionVariableWaitForAddress wait_queue(kernel);
 
     // Wait for the address.

--- a/src/core/hle/kernel/k_interrupt_manager.cpp
+++ b/src/core/hle/kernel/k_interrupt_manager.cpp
@@ -15,8 +15,7 @@ void HandleInterrupt(KernelCore& kernel, s32 core_id) {
         return;
     }
 
-    auto& scheduler = kernel.Scheduler(core_id);
-    auto& current_thread = *scheduler.GetCurrentThread();
+    auto& current_thread = GetCurrentThread(kernel);
 
     // If the user disable count is set, we may need to pin the current thread.
     if (current_thread.GetUserDisableCount() && !process->GetPinnedThread(core_id)) {
@@ -26,7 +25,7 @@ void HandleInterrupt(KernelCore& kernel, s32 core_id) {
         process->PinCurrentThread(core_id);
 
         // Set the interrupt flag for the thread.
-        scheduler.GetCurrentThread()->SetInterruptFlag();
+        GetCurrentThread(kernel).SetInterruptFlag();
     }
 }
 

--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -176,7 +176,8 @@ void KProcess::PinCurrentThread(s32 core_id) {
     ASSERT(kernel.GlobalSchedulerContext().IsLocked());
 
     // Get the current thread.
-    KThread* cur_thread = kernel.Scheduler(static_cast<std::size_t>(core_id)).GetCurrentThread();
+    KThread* cur_thread =
+        kernel.Scheduler(static_cast<std::size_t>(core_id)).GetSchedulerCurrentThread();
 
     // If the thread isn't terminated, pin it.
     if (!cur_thread->IsTerminationRequested()) {
@@ -193,7 +194,8 @@ void KProcess::UnpinCurrentThread(s32 core_id) {
     ASSERT(kernel.GlobalSchedulerContext().IsLocked());
 
     // Get the current thread.
-    KThread* cur_thread = kernel.Scheduler(static_cast<std::size_t>(core_id)).GetCurrentThread();
+    KThread* cur_thread =
+        kernel.Scheduler(static_cast<std::size_t>(core_id)).GetSchedulerCurrentThread();
 
     // Unpin it.
     cur_thread->Unpin();
@@ -420,11 +422,11 @@ void KProcess::PrepareForTermination() {
     ChangeStatus(ProcessStatus::Exiting);
 
     const auto stop_threads = [this](const std::vector<KThread*>& in_thread_list) {
-        for (auto& thread : in_thread_list) {
+        for (auto* thread : in_thread_list) {
             if (thread->GetOwnerProcess() != this)
                 continue;
 
-            if (thread == kernel.CurrentScheduler()->GetCurrentThread())
+            if (thread == GetCurrentThreadPointer(kernel))
                 continue;
 
             // TODO(Subv): When are the other running/ready threads terminated?

--- a/src/core/hle/kernel/k_scheduler.h
+++ b/src/core/hle/kernel/k_scheduler.h
@@ -48,16 +48,11 @@ public:
     void Reload(KThread* thread);
 
     /// Gets the current running thread
-    [[nodiscard]] KThread* GetCurrentThread() const;
+    [[nodiscard]] KThread* GetSchedulerCurrentThread() const;
 
     /// Gets the idle thread
     [[nodiscard]] KThread* GetIdleThread() const {
         return idle_thread;
-    }
-
-    /// Returns true if the scheduler is idle
-    [[nodiscard]] bool IsIdle() const {
-        return GetCurrentThread() == idle_thread;
     }
 
     /// Gets the timestamp for the last context switch in ticks.
@@ -149,10 +144,7 @@ private:
 
     void RotateScheduledQueue(s32 cpu_core_id, s32 priority);
 
-    void Schedule() {
-        ASSERT(GetCurrentThread()->GetDisableDispatchCount() == 1);
-        this->ScheduleImpl();
-    }
+    void Schedule();
 
     /// Switches the CPU's active thread context to that of the specified thread
     void ScheduleImpl();

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -382,7 +382,7 @@ void KThread::FinishTermination() {
         for (std::size_t i = 0; i < static_cast<std::size_t>(Core::Hardware::NUM_CPU_CORES); ++i) {
             KThread* core_thread{};
             do {
-                core_thread = kernel.Scheduler(i).GetCurrentThread();
+                core_thread = kernel.Scheduler(i).GetSchedulerCurrentThread();
             } while (core_thread == this);
         }
     }
@@ -631,7 +631,7 @@ ResultCode KThread::SetCoreMask(s32 core_id_, u64 v_affinity_mask) {
             s32 thread_core;
             for (thread_core = 0; thread_core < static_cast<s32>(Core::Hardware::NUM_CPU_CORES);
                  ++thread_core) {
-                if (kernel.Scheduler(thread_core).GetCurrentThread() == this) {
+                if (kernel.Scheduler(thread_core).GetSchedulerCurrentThread() == this) {
                     thread_is_current = true;
                     break;
                 }
@@ -756,7 +756,7 @@ void KThread::WaitUntilSuspended() {
     for (std::size_t i = 0; i < static_cast<std::size_t>(Core::Hardware::NUM_CPU_CORES); ++i) {
         KThread* core_thread{};
         do {
-            core_thread = kernel.Scheduler(i).GetCurrentThread();
+            core_thread = kernel.Scheduler(i).GetSchedulerCurrentThread();
         } while (core_thread == this);
     }
 }
@@ -822,7 +822,7 @@ ResultCode KThread::SetActivity(Svc::ThreadActivity activity) {
                 // Check if the thread is currently running.
                 // If it is, we'll need to retry.
                 for (auto i = 0; i < static_cast<s32>(Core::Hardware::NUM_CPU_CORES); ++i) {
-                    if (kernel.Scheduler(i).GetCurrentThread() == this) {
+                    if (kernel.Scheduler(i).GetSchedulerCurrentThread() == this) {
                         thread_is_current = true;
                         break;
                     }
@@ -1173,6 +1173,10 @@ void KThread::SetState(ThreadState state) {
 
 std::shared_ptr<Common::Fiber>& KThread::GetHostContext() {
     return host_context;
+}
+
+void SetCurrentThread(KernelCore& kernel, KThread* thread) {
+    kernel.SetCurrentEmuThread(thread);
 }
 
 KThread* GetCurrentThreadPointer(KernelCore& kernel) {

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -106,6 +106,7 @@ enum class StepState : u32 {
     StepPerformed, ///< Thread has stepped, waiting to be scheduled again
 };
 
+void SetCurrentThread(KernelCore& kernel, KThread* thread);
 [[nodiscard]] KThread* GetCurrentThreadPointer(KernelCore& kernel);
 [[nodiscard]] KThread& GetCurrentThread(KernelCore& kernel);
 [[nodiscard]] s32 GetCurrentCoreId(KernelCore& kernel);

--- a/src/core/hle/kernel/kernel.cpp
+++ b/src/core/hle/kernel/kernel.cpp
@@ -331,6 +331,8 @@ struct KernelCore::Impl {
         return is_shutting_down.load(std::memory_order_relaxed);
     }
 
+    static inline thread_local KThread* current_thread{nullptr};
+
     KThread* GetCurrentEmuThread() {
         // If we are shutting down the kernel, none of this is relevant anymore.
         if (IsShuttingDown()) {
@@ -341,7 +343,12 @@ struct KernelCore::Impl {
         if (thread_id >= Core::Hardware::NUM_CPU_CORES) {
             return GetHostDummyThread();
         }
-        return schedulers[thread_id]->GetCurrentThread();
+
+        return current_thread;
+    }
+
+    void SetCurrentEmuThread(KThread* thread) {
+        current_thread = thread;
     }
 
     void DeriveInitialMemoryLayout() {
@@ -1022,6 +1029,10 @@ u32 KernelCore::GetCurrentHostThreadID() const {
 
 KThread* KernelCore::GetCurrentEmuThread() const {
     return impl->GetCurrentEmuThread();
+}
+
+void KernelCore::SetCurrentEmuThread(KThread* thread) {
+    impl->SetCurrentEmuThread(thread);
 }
 
 KMemoryManager& KernelCore::MemoryManager() {

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -226,6 +226,9 @@ public:
     /// Gets the current host_thread/guest_thread pointer.
     KThread* GetCurrentEmuThread() const;
 
+    /// Sets the current guest_thread pointer.
+    void SetCurrentEmuThread(KThread* thread);
+
     /// Gets the current host_thread handle.
     u32 GetCurrentHostThreadID() const;
 


### PR DESCRIPTION
Another Atmosphere consistency item. When in kernel mode, the platform register stores the current thread pointer, so we emulate this with a thread local that stores the current thread pointer. This is required for reworking the idle mechanism, as on entry, the scheduler will not have set a current thread and so its pointer will be null.