### PR TITLE
core: fix initialization in single core, sync GPU mode

### DIFF
--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -26,6 +26,7 @@ void CpuManager::ThreadStart(std::stop_token stop_token, CpuManager& cpu_manager
 
 void CpuManager::Initialize() {
     num_cores = is_multicore ? Core::Hardware::NUM_CPU_CORES : 1;
+    gpu_barrier = std::make_unique<Common::Barrier>(num_cores + 1);
 
     for (std::size_t core = 0; core < num_cores; core++) {
         core_data[core].host_thread = std::jthread(ThreadStart, std::ref(*this), core);
@@ -230,6 +231,8 @@ void CpuManager::RunThread(std::size_t core) {
     });
 
     // Running
+    gpu_barrier->Sync();
+
     if (!is_async_gpu && !is_multicore) {
         system.GPU().ObtainContext();
     }

--- a/src/core/cpu_manager.h
+++ b/src/core/cpu_manager.h
@@ -43,6 +43,10 @@ public:
         is_async_gpu = is_async;
     }
 
+    void OnGpuReady() {
+        gpu_barrier->Sync();
+    }
+
     void Initialize();
     void Shutdown();
 
@@ -81,6 +85,7 @@ private:
         std::jthread host_thread;
     };
 
+    std::unique_ptr<Common::Barrier> gpu_barrier{};
     std::array<CoreData, Core::Hardware::NUM_CPU_CORES> core_data{};
 
     bool is_async_gpu{};

--- a/src/yuzu/bootmanager.cpp
+++ b/src/yuzu/bootmanager.cpp
@@ -29,6 +29,7 @@
 #include "common/scm_rev.h"
 #include "common/settings.h"
 #include "core/core.h"
+#include "core/cpu_manager.h"
 #include "core/frontend/framebuffer_layout.h"
 #include "input_common/drivers/keyboard.h"
 #include "input_common/drivers/mouse.h"
@@ -72,6 +73,8 @@ void EmuThread::run() {
     emit LoadProgress(VideoCore::LoadCallbackStage::Complete, 0, 0);
 
     gpu.ReleaseContext();
+
+    system.GetCpuManager().OnGpuReady();
 
     // Holds whether the cpu was running during the last iteration,
     // so that the DebugModeLeft signal can be emitted before the

--- a/src/yuzu_cmd/yuzu.cpp
+++ b/src/yuzu_cmd/yuzu.cpp
@@ -21,6 +21,7 @@
 #include "common/string_util.h"
 #include "common/telemetry.h"
 #include "core/core.h"
+#include "core/cpu_manager.h"
 #include "core/crypto/key_manager.h"
 #include "core/file_sys/registered_cache.h"
 #include "core/file_sys/vfs_real.h"
@@ -216,6 +217,7 @@ int main(int argc, char** argv) {
 
     // Core is loaded, start the GPU (makes the GPU contexts current to this thread)
     system.GPU().Start();
+    system.GetCpuManager().OnGpuReady();
 
     if (Settings::values.use_disk_shader_cache.GetValue()) {
         system.Renderer().ReadRasterizer()->LoadDiskResources(


### PR DESCRIPTION
Fixes a race between CPU thread initialization and core GPU initialization that was uncovered in #8388.