### PR TITLE
tweak API usage in qt_web_browser.cpp

### DIFF
--- a/src/yuzu/applets/qt_web_browser.cpp
+++ b/src/yuzu/applets/qt_web_browser.cpp
@@ -52,8 +52,8 @@ QtNXWebEngineView::QtNXWebEngineView(QWidget* parent, Core::System& system,
     : QWebEngineView(parent), input_subsystem{input_subsystem_},
       url_interceptor(std::make_unique<UrlRequestInterceptor>()),
       input_interpreter(std::make_unique<InputInterpreter>(system)),
-      default_profile{QWebEngineProfile::defaultProfile()},
-      global_settings{QWebEngineSettings::globalSettings()} {
+      default_profile{QWebEngineProfile::defaultProfile()}, global_settings{
+                                                                default_profile->settings()} {
     default_profile->setPersistentStoragePath(QString::fromStdString(Common::FS::PathToUTF8String(
         Common::FS::GetYuzuPath(Common::FS::YuzuPath::YuzuDir) / "qtwebengine")));
 
@@ -78,7 +78,7 @@ QtNXWebEngineView::QtNXWebEngineView(QWidget* parent, Core::System& system,
     default_profile->scripts()->insert(gamepad);
     default_profile->scripts()->insert(window_nx);
 
-    default_profile->setRequestInterceptor(url_interceptor.get());
+    default_profile->setUrlRequestInterceptor(url_interceptor.get());
 
     global_settings->setAttribute(QWebEngineSettings::LocalContentCanAccessRemoteUrls, true);
     global_settings->setAttribute(QWebEngineSettings::FullScreenSupportEnabled, true);


### PR DESCRIPTION
In testing future versions of Qt I forgot to compile with `YUZU_USE_QT_WEB_ENGINE`, so with that flag enabled there are two issues that cropped up.

1. yuzu currently uses setRequestInterceptor, added in Qt 5.6, deprecated in 5.13 with this explaination at https://doc.qt.io/qt-5/qwebengineprofile-obsolete.html
Interceptors installed with this method will call QWebEngineUrlRequestInterceptor::interceptRequest on the I/O thread. Therefore the user has to provide thread-safe interaction with the other user classes. For a duration of this call ui thread is blocked. Use setUrlRequestInterceptor instead.

2. QWebEngineSettings::globalSettings() pointer no longer exists in later versions of Qt

From what I can tell, QtNXWebEngineView doesn't need to set these globally,
when we make changes to settings(), QtWebEngineView::page() creates the page
object if it doesn't exist yet. I don't see the page object being destroyed
or otherwise replaced, except via destroying the QtNXWebEngineView object.

The globalSettings() make sense if Pages or Views objects are being
created outside of yuzu's control.

To test this I've compared what Mario Odyssey's Action guide does in mainline 1049 and this PR.

--------
~~When I had a test build with last weeks Qt "dev" I got a black screen and a bunch of OpenGL errors written to the log window, but not to yuzu.log so it's not like we could just jump to Qt6~~

Worked with Qt 6.3.1 as mentioned below