### PR TITLE
cmake: Use compatibility list in source directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,10 @@ if (ENABLE_COMPATIBILITY_LIST_DOWNLOAD AND NOT EXISTS ${PROJECT_BINARY_DIR}/dist
         https://api.yuzu-emu.org/gamedb/
         "${PROJECT_BINARY_DIR}/dist/compatibility_list/compatibility_list.json" SHOW_PROGRESS)
 endif()
+if (EXISTS ${PROJECT_SOURCE_DIR}/compatibility_list.json)
+    file(COPY "${PROJECT_SOURCE_DIR}/compatibility_list.json"
+        DESTINATION "${PROJECT_BINARY_DIR}/dist/compatibility_list/")
+endif()
 if (NOT EXISTS ${PROJECT_BINARY_DIR}/dist/compatibility_list/compatibility_list.json)
     file(WRITE ${PROJECT_BINARY_DIR}/dist/compatibility_list/compatibility_list.json "")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,15 +70,16 @@ endif()
 configure_file(${PROJECT_SOURCE_DIR}/dist/compatibility_list/compatibility_list.qrc
                ${PROJECT_BINARY_DIR}/dist/compatibility_list/compatibility_list.qrc
                COPYONLY)
+if (EXISTS ${PROJECT_SOURCE_DIR}/dist/compatibility_list/compatibility_list.json)
+    configure_file("${PROJECT_SOURCE_DIR}/dist/compatibility_list/compatibility_list.json"
+                   "${PROJECT_BINARY_DIR}/dist/compatibility_list/compatibility_list.json"
+                   COPYONLY)
+endif()
 if (ENABLE_COMPATIBILITY_LIST_DOWNLOAD AND NOT EXISTS ${PROJECT_BINARY_DIR}/dist/compatibility_list/compatibility_list.json)
     message(STATUS "Downloading compatibility list for yuzu...")
     file(DOWNLOAD
         https://api.yuzu-emu.org/gamedb/
         "${PROJECT_BINARY_DIR}/dist/compatibility_list/compatibility_list.json" SHOW_PROGRESS)
-endif()
-if (EXISTS ${PROJECT_SOURCE_DIR}/compatibility_list.json)
-    file(COPY "${PROJECT_SOURCE_DIR}/compatibility_list.json"
-        DESTINATION "${PROJECT_BINARY_DIR}/dist/compatibility_list/")
 endif()
 if (NOT EXISTS ${PROJECT_BINARY_DIR}/dist/compatibility_list/compatibility_list.json)
     file(WRITE ${PROJECT_BINARY_DIR}/dist/compatibility_list/compatibility_list.json "")


### PR DESCRIPTION
For [Flatpak builds](https://github.com/flathub/org.yuzu_emu.yuzu), the compatibility list is located in the source directory, because the Flatpak build system is not allowed access to the internet. In this case, CMake will copy it to `${PROJECT_BINARY_DIR}/dist/compatibility_list/`. This fixes the issue in the Flatpak build where the compatibility of all games is "not tested" as mentioned in  flathub/org.yuzu_emu.yuzu#6.