### PR TITLE
service: am: Stub PerformSystemButtonPressingIfInFocus

### DIFF
--- a/src/core/hle/service/am/am.cpp
+++ b/src/core/hle/service/am/am.cpp
@@ -686,7 +686,7 @@ ICommonStateGetter::ICommonStateGetter(Core::System& system_,
         {66, &ICommonStateGetter::SetCpuBoostMode, "SetCpuBoostMode"},
         {67, nullptr, "CancelCpuBoostMode"},
         {68, nullptr, "GetBuiltInDisplayType"},
-        {80, nullptr, "PerformSystemButtonPressingIfInFocus"},
+        {80, &ICommonStateGetter::PerformSystemButtonPressingIfInFocus, "PerformSystemButtonPressingIfInFocus"},
         {90, nullptr, "SetPerformanceConfigurationChangedNotification"},
         {91, nullptr, "GetCurrentPerformanceConfiguration"},
         {100, nullptr, "SetHandlingHomeButtonShortPressedEnabled"},
@@ -824,6 +824,16 @@ void ICommonStateGetter::SetCpuBoostMode(Kernel::HLERequestContext& ctx) {
     ASSERT(apm_sys != nullptr);
 
     apm_sys->SetCpuBoostMode(ctx);
+}
+
+void ICommonStateGetter::PerformSystemButtonPressingIfInFocus(Kernel::HLERequestContext& ctx) {
+    IPC::RequestParser rp{ctx};
+    const auto system_button{rp.PopEnum<SystemButtonType>()};
+
+    LOG_WARNING(Service_AM, "(STUBBED) called, system_button={}", system_button);
+
+    IPC::ResponseBuilder rb{ctx, 2};
+    rb.Push(ResultSuccess);
 }
 
 void ICommonStateGetter::SetRequestExitToLibraryAppletAtExecuteNextProgramEnabled(

--- a/src/core/hle/service/am/am.h
+++ b/src/core/hle/service/am/am.h
@@ -220,6 +220,18 @@ private:
         Docked = 1,
     };
 
+    // This is nn::am::service::SystemButtonType
+    enum class SystemButtonType {
+        None,
+        HomeButtonShortPressing,
+        HomeButtonLongPressing,
+        PowerButtonShortPressing,
+        PowerButtonLongPressing,
+        ShutdownSystem,
+        CaptureButtonShortPressing,
+        CaptureButtonLongPressing,
+    };
+
     void GetEventHandle(Kernel::HLERequestContext& ctx);
     void ReceiveMessage(Kernel::HLERequestContext& ctx);
     void GetCurrentFocusState(Kernel::HLERequestContext& ctx);
@@ -234,6 +246,7 @@ private:
     void EndVrModeEx(Kernel::HLERequestContext& ctx);
     void GetDefaultDisplayResolution(Kernel::HLERequestContext& ctx);
     void SetCpuBoostMode(Kernel::HLERequestContext& ctx);
+    void PerformSystemButtonPressingIfInFocus(Kernel::HLERequestContext& ctx);
     void SetRequestExitToLibraryAppletAtExecuteNextProgramEnabled(Kernel::HLERequestContext& ctx);
 
     std::shared_ptr<AppletMessageQueue> msg_queue;


### PR DESCRIPTION
Used by Ring Fit Adventure when you press ZR or ZL. This fixes a svc crash. 