### PR TITLE
dynarmic: Stop ReadCode callbacks to unmapped addresses

### DIFF
--- a/src/core/arm/arm_interface.cpp
+++ b/src/core/arm/arm_interface.cpp
@@ -119,16 +119,23 @@ void ARM_Interface::Run() {
         }
         system.ExitDynarmicProfile();
 
-        // Notify the debugger and go to sleep if a breakpoint was hit.
-        if (Has(hr, breakpoint)) {
+        // Notify the debugger and go to sleep if a breakpoint was hit,
+        // or if the thread is unable to continue for any reason.
+        if (Has(hr, breakpoint) || Has(hr, no_execute)) {
             RewindBreakpointInstruction();
-            system.GetDebugger().NotifyThreadStopped(current_thread);
-            current_thread->RequestSuspend(SuspendType::Debug);
+            if (system.DebuggerEnabled()) {
+                system.GetDebugger().NotifyThreadStopped(current_thread);
+            }
+            current_thread->RequestSuspend(Kernel::SuspendType::Debug);
             break;
         }
+
+        // Notify the debugger and go to sleep if a watchpoint was hit.
         if (Has(hr, watchpoint)) {
             RewindBreakpointInstruction();
-            system.GetDebugger().NotifyThreadWatchpoint(current_thread, *HaltedWatchpoint());
+            if (system.DebuggerEnabled()) {
+                system.GetDebugger().NotifyThreadWatchpoint(current_thread, *HaltedWatchpoint());
+            }
             current_thread->RequestSuspend(SuspendType::Debug);
             break;
         }

--- a/src/core/arm/arm_interface.h
+++ b/src/core/arm/arm_interface.h
@@ -204,6 +204,7 @@ public:
     static constexpr Dynarmic::HaltReason svc_call = Dynarmic::HaltReason::UserDefined3;
     static constexpr Dynarmic::HaltReason breakpoint = Dynarmic::HaltReason::UserDefined4;
     static constexpr Dynarmic::HaltReason watchpoint = Dynarmic::HaltReason::UserDefined5;
+    static constexpr Dynarmic::HaltReason no_execute = Dynarmic::HaltReason::UserDefined6;
 
 protected:
     /// System context that this ARM interface is running under.


### PR DESCRIPTION
Fixes #8488. Might slow down translation a bit, since Dynarmic won't attempt to use the page table during translation.