### PR TITLE
KPageTable: Remove extraneous assert

### DIFF
--- a/src/core/hle/kernel/k_page_table.cpp
+++ b/src/core/hle/kernel/k_page_table.cpp
@@ -65,7 +65,6 @@ ResultCode KPageTable::InitializeForProcess(FileSys::ProgramAddressSpaceType as_
     std::size_t alias_region_size{GetSpaceSize(KAddressSpaceInfo::Type::Alias)};
     std::size_t heap_region_size{GetSpaceSize(KAddressSpaceInfo::Type::Heap)};
 
-    ASSERT(start <= code_addr);
     ASSERT(code_addr < code_addr + code_size);
     ASSERT(code_addr + code_size - 1 <= end - 1);
 


### PR DESCRIPTION
Since start is always 0 and VAddr is unsigned, we can safely remove this assert.

Resolves a `-Wtype-limits` warning on GCC/Clang