### PR TITLE
service: hid: Correct some mistakes and add more validations

### DIFF
--- a/src/core/hid/hid_types.h
+++ b/src/core/hid/hid_types.h
@@ -272,6 +272,7 @@ enum class VibrationDeviceType : u32 {
     Unknown = 0,
     LinearResonantActuator = 1,
     GcErm = 2,
+    N64 = 3,
 };
 
 // This is nn::hid::VibrationGcErmCommand

--- a/src/core/hle/service/hid/controllers/npad.h
+++ b/src/core/hle/service/hid/controllers/npad.h
@@ -81,6 +81,7 @@ public:
         Dual = 0,
         Single = 1,
         None = 2,
+        MaxActivationMode = 3,
     };
 
     // This is nn::hid::NpadCommunicationMode
@@ -196,7 +197,7 @@ public:
     Core::HID::NpadButton GetAndResetPressState();
 
     static bool IsNpadIdValid(Core::HID::NpadIdType npad_id);
-    static bool IsDeviceHandleValid(const Core::HID::VibrationDeviceHandle& device_handle);
+    static Result IsDeviceHandleValid(const Core::HID::VibrationDeviceHandle& device_handle);
     static Result VerifyValidSixAxisSensorHandle(
         const Core::HID::SixAxisSensorHandle& device_handle);
 

--- a/src/core/hle/service/hid/errors.h
+++ b/src/core/hle/service/hid/errors.h
@@ -9,6 +9,9 @@ namespace Service::HID {
 
 constexpr Result NpadInvalidHandle{ErrorModule::HID, 100};
 constexpr Result NpadDeviceIndexOutOfRange{ErrorModule::HID, 107};
+constexpr Result VibrationInvalidStyleIndex{ErrorModule::HID, 122};
+constexpr Result VibrationInvalidNpadId{ErrorModule::HID, 123};
+constexpr Result VibrationDeviceIndexOutOfRange{ErrorModule::HID, 124};
 constexpr Result InvalidSixAxisFusionRange{ErrorModule::HID, 423};
 constexpr Result NpadIsDualJoycon{ErrorModule::HID, 601};
 constexpr Result NpadIsSameType{ErrorModule::HID, 602};


### PR DESCRIPTION
Some functions should always return success even on failure. Fixup behavior of `GetVibrationDeviceInfo` that has been bothering me for a while.

This should fix boot issues on `de Blob`