### PR TITLE
Translate english plurals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@ doc-build/
 
 # Generated source files
 src/common/scm_rev.cpp
-.travis.descriptor.json
+dist/english_plurals/generated_en.ts
 
 # Project/editor files
 *.swp

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -2,7 +2,8 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Comment: It is best to use this file to record copyright information about
          generated, binary and third party files
 
-Files: dist/icons/controller/*.png
+Files: dist/english_plurals/*
+       dist/icons/controller/*.png
        dist/icons/overlay/*.png
        dist/languages/*
        dist/qt_themes/*/icons/index.theme

--- a/dist/english_plurals/README.md
+++ b/dist/english_plurals/README.md
@@ -1,0 +1,19 @@
+# English Plurals
+
+Qt has "Translation Rules for Plurals", small example
+
+    // Take a source line like
+    tr("Building: %n shader(s)", "", i)
+
+    // i = 1:
+    Building: 1 shader
+    // i = 2:
+    Building: 2 shaders
+
+For yuzu the source language used is English, for all other languages handling of plurals is handled by Qt and the translation collaboration site. Handling plurals in the source language (English) requires special consideration.
+
+With CMake flag GENERATE_QT_TRANSLATION a generated_en.ts file is created from the source. It ignored by git (`.gitignore` in the project root). It is placed in this directory so that the relative refrences with the source code is correct.
+
+Having the plurals look nice isn't critical, and automation to use translation collaboration sites may require specifing the project language as "Pirate English", so this has been done manually.
+
+The en.ts in this directory is taken from a build, edited in Qt Linguist and then committed. As the code is in XML, using the tool is not strictly required.

--- a/dist/english_plurals/en.ts
+++ b/dist/english_plurals/en.ts
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="en_US" sourcelanguage="en_US">
+<context>
+    <name>GMainWindow</name>
+    <message numerus="yes">
+        <location filename="../../src/yuzu/main.cpp" line="2322"/>
+        <source>%n file(s) remaining</source>
+        <translation>
+            <numerusform>%n file remaining</numerusform>
+            <numerusform>%n files remaining</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/yuzu/main.cpp" line="2377"/>
+        <source>%n file(s) were newly installed
+</source>
+        <translation>
+            <numerusform>%n file was newly installed
+</numerusform>
+            <numerusform>%n files were newly installed
+</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/yuzu/main.cpp" line="2380"/>
+        <source>%n file(s) were overwritten
+</source>
+        <translation>
+            <numerusform>%n file was overwritten
+</numerusform>
+            <numerusform>%n were overwritten
+</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/yuzu/main.cpp" line="2382"/>
+        <source>%n file(s) failed to install
+</source>
+        <translation>
+            <numerusform>%n file failed to install
+</numerusform>
+            <numerusform>%n files failed to install
+</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../../src/yuzu/main.cpp" line="3264"/>
+        <source>Building: %n shader(s)</source>
+        <translation>
+            <numerusform>Building: %n shader</numerusform>
+            <numerusform>Building: %n shaders</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
+    <name>GameListSearchField</name>
+    <message numerus="yes">
+        <location filename="../../src/yuzu/game_list.cpp" line="87"/>
+        <source>%1 of %n result(s)</source>
+        <translation>
+            <numerusform>%1 of %n result</numerusform>
+            <numerusform>%1 of %n results</numerusform>
+        </translation>
+    </message>
+</context>
+</TS>

--- a/src/yuzu/CMakeLists.txt
+++ b/src/yuzu/CMakeLists.txt
@@ -221,6 +221,9 @@ if (ENABLE_QT_TRANSLATION)
     # Update source TS file if enabled
     if (GENERATE_QT_TRANSLATION)
         get_target_property(SRCS yuzu SOURCES)
+        # these calls to qt_create_translation also creates a rule to generate en.qm which conflicts with providing english plurals
+        # so we have to set a OUTPUT_LOCATION so that we don't have multiple rules to generate en.qm
+        set_source_files_properties(${YUZU_QT_LANGUAGES}/en.ts PROPERTIES OUTPUT_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/translations")
         qt_create_translation(QM_FILES
             ${SRCS}
             ${UIS}
@@ -229,7 +232,13 @@ if (ENABLE_QT_TRANSLATION)
             -source-language en_US
             -target-language en_US
         )
-        add_custom_target(translation ALL DEPENDS ${YUZU_QT_LANGUAGES}/en.ts)
+
+        # Generate plurals into dist/english_plurals/generated_en.ts so it can be used to revise dist/english_plurals/en.ts
+        set(GENERATED_PLURALS_FILE ${PROJECT_SOURCE_DIR}/dist/english_plurals/generated_en.ts)
+        set_source_files_properties(${GENERATED_PLURALS_FILE} PROPERTIES OUTPUT_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/plurals")
+        qt_create_translation(QM_FILES ${SRCS} ${UIS} ${GENERATED_PLURALS_FILE} OPTIONS -pluralonly -source-language en_US -target-language en_US)
+
+        add_custom_target(translation ALL DEPENDS ${YUZU_QT_LANGUAGES}/en.ts ${GENERATED_PLURALS_FILE})
     endif()
 
     # Find all TS files except en.ts
@@ -238,6 +247,9 @@ if (ENABLE_QT_TRANSLATION)
 
     # Compile TS files to QM files
     qt_add_translation(LANGUAGES_QM ${LANGUAGES_TS})
+
+    # Compile english plurals TS file to en.qm
+    qt_add_translation(LANGUAGES_QM ${PROJECT_SOURCE_DIR}/dist/english_plurals/en.ts)
 
     # Build a QRC file from the QM file list
     set(LANGUAGES_QRC ${CMAKE_CURRENT_BINARY_DIR}/languages.qrc)

--- a/src/yuzu/configuration/configure_ui.cpp
+++ b/src/yuzu/configuration/configure_ui.cpp
@@ -219,6 +219,7 @@ void ConfigureUi::InitializeLanguageComboBox() {
     for (const auto& lang : languages) {
         if (QString::fromLatin1(lang.id) == QStringLiteral("en")) {
             ui->language_combobox->addItem(lang.name, QStringLiteral("en"));
+            language_files.removeOne(QStringLiteral("en.qm"));
             continue;
         }
         for (int i = 0; i < language_files.size(); ++i) {

--- a/src/yuzu/main.cpp
+++ b/src/yuzu/main.cpp
@@ -3975,11 +3975,6 @@ void GMainWindow::UpdateUITheme() {
 }
 
 void GMainWindow::LoadTranslation() {
-    // If the selected language is English, no need to install any translation
-    if (UISettings::values.language == QStringLiteral("en")) {
-        return;
-    }
-
     bool loaded;
 
     if (UISettings::values.language.isEmpty()) {


### PR DESCRIPTION
Turns out that for Qt to properly handle plurals in English a
translation needs to be provided, otherwise the user is left with
messages such as "Building: 2 shader(s)"

Plurals for other all other languages are handled on transifex. 
I wrote the README.md to just refer to it as a translation 
collaboration site just in case we ever switch.

These translations being out of date won't pose any technical problems
so I believe it is fine to handle them manually on a "best effort"
basis.

The files are generated into the source directory so that the
relative filenames are correct. The generated file is added to
.gitignore

-------


We might be able to technobabble something decent out of Transifex so I'm submitting this as a draft. Attn: @FearlessTobi 

But in my extensive research on this the best I could find is a reference to Crowdin (a different site that handles crowd sourced translations) having difficulties in handling translations of plurals for the source language. https://wiki.mudlet.org/w/Translating_Mudlet#Plural_forms_in_.28American.29_English

You can pull the source file from transifex, and this is what comes back.

```xml
    <message numerus="yes">
        <location filename="../../src/yuzu/main.cpp" line="3262"/>
        <source>Building: %n shader(s)</source>
        <translation><numerusform>Building: %n shader(s)</numerusform><numerusform>Building: %n shader(s)</numerusform></translation>
    </message>
```