### PR TITLE
core/arm: better support for backtrace generation

### DIFF
--- a/src/core/arm/arm_interface.cpp
+++ b/src/core/arm/arm_interface.cpp
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: Copyright 2018 yuzu Emulator Project
 // SPDX-License-Identifier: GPL-2.0-or-later
 
+#ifndef _MSC_VER
+#include <cxxabi.h>
+#endif
+
 #include <map>
 #include <optional>
 #include "common/bit_field.h"
@@ -68,8 +72,19 @@ void ARM_Interface::SymbolicateBacktrace(Core::System& system, std::vector<Backt
         if (symbol_set != symbols.end()) {
             const auto symbol = Symbols::GetSymbolName(symbol_set->second, entry.offset);
             if (symbol.has_value()) {
+#ifdef _MSC_VER
                 // TODO(DarkLordZach): Add demangling of symbol names.
                 entry.name = *symbol;
+#else
+                int status{-1};
+                char* demangled{abi::__cxa_demangle(symbol->c_str(), nullptr, nullptr, &status)};
+                if (status == 0 && demangled != nullptr) {
+                    entry.name = demangled;
+                    std::free(demangled);
+                } else {
+                    entry.name = *symbol;
+                }
+#endif
             }
         }
     }

--- a/src/core/arm/dynarmic/arm_dynarmic_32.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_32.h
@@ -78,7 +78,7 @@ protected:
 private:
     std::shared_ptr<Dynarmic::A32::Jit> MakeJit(Common::PageTable* page_table) const;
 
-    static std::vector<BacktraceEntry> GetBacktrace(Core::System& system, u64 sp, u64 lr);
+    static std::vector<BacktraceEntry> GetBacktrace(Core::System& system, u64 fp, u64 lr, u64 pc);
 
     using JitCacheKey = std::pair<Common::PageTable*, std::size_t>;
     using JitCacheType =

--- a/src/core/arm/dynarmic/arm_dynarmic_64.cpp
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.cpp
@@ -480,22 +480,22 @@ void ARM_Dynarmic_64::PageTableChanged(Common::PageTable& page_table,
 }
 
 std::vector<ARM_Interface::BacktraceEntry> ARM_Dynarmic_64::GetBacktrace(Core::System& system,
-                                                                         u64 fp, u64 lr) {
+                                                                         u64 fp, u64 lr, u64 pc) {
     std::vector<BacktraceEntry> out;
     auto& memory = system.Memory();
 
-    // fp (= r29) points to the last frame record.
-    // Note that this is the frame record for the *previous* frame, not the current one.
-    // Note we need to subtract 4 from our last read to get the proper address
+    out.push_back({"", 0, pc, 0, ""});
+
+    // fp (= x29) points to the previous frame record.
     // Frame records are two words long:
     // fp+0 : pointer to previous frame record
     // fp+8 : value of lr for frame
     while (true) {
         out.push_back({"", 0, lr, 0, ""});
-        if (!fp) {
+        if (!fp || (fp % 4 != 0) || !memory.IsValidVirtualAddressRange(fp, 16)) {
             break;
         }
-        lr = memory.Read64(fp + 8) - 4;
+        lr = memory.Read64(fp + 8);
         fp = memory.Read64(fp);
     }
 
@@ -506,11 +506,12 @@ std::vector<ARM_Interface::BacktraceEntry> ARM_Dynarmic_64::GetBacktrace(Core::S
 
 std::vector<ARM_Interface::BacktraceEntry> ARM_Dynarmic_64::GetBacktraceFromContext(
     System& system, const ThreadContext64& ctx) {
-    return GetBacktrace(system, ctx.cpu_registers[29], ctx.cpu_registers[30]);
+    const auto& reg = ctx.cpu_registers;
+    return GetBacktrace(system, reg[29], reg[30], ctx.pc);
 }
 
 std::vector<ARM_Interface::BacktraceEntry> ARM_Dynarmic_64::GetBacktrace() const {
-    return GetBacktrace(system, GetReg(29), GetReg(30));
+    return GetBacktrace(system, GetReg(29), GetReg(30), GetPC());
 }
 
 } // namespace Core

--- a/src/core/arm/dynarmic/arm_dynarmic_64.h
+++ b/src/core/arm/dynarmic/arm_dynarmic_64.h
@@ -73,7 +73,7 @@ private:
     std::shared_ptr<Dynarmic::A64::Jit> MakeJit(Common::PageTable* page_table,
                                                 std::size_t address_space_bits) const;
 
-    static std::vector<BacktraceEntry> GetBacktrace(Core::System& system, u64 fp, u64 lr);
+    static std::vector<BacktraceEntry> GetBacktrace(Core::System& system, u64 fp, u64 lr, u64 pc);
 
     using JitCacheKey = std::pair<Common::PageTable*, std::size_t>;
     using JitCacheType =


### PR DESCRIPTION
- Add the frame at the PC as the top frame in the stacktrace
- 32-bit games are compiled with frame pointer support, report backtraces from this the way the creport sysmodule would
- Demangle names when compiling with libstdc++ or libc++