### PR TITLE
kernel: clean up waiting implementation

### DIFF
--- a/src/core/hle/kernel/k_process.cpp
+++ b/src/core/hle/kernel/k_process.cpp
@@ -161,7 +161,7 @@ bool KProcess::ReleaseUserException(KThread* thread) {
                 std::addressof(num_waiters),
                 reinterpret_cast<uintptr_t>(std::addressof(exception_thread)));
             next != nullptr) {
-            next->SetState(ThreadState::Runnable);
+            next->EndWait(ResultSuccess);
         }
 
         KScheduler::SetSchedulerUpdateNeeded(kernel);


### PR DESCRIPTION
See [13.0.0 release notes](https://switchbrew.org/wiki/13.0.0), specifically under "A complete re-work/unification was done for the various kinds of thread waiting operations in the kernel." This fixes a few things that were missed.