### PR TITLE
Support `InfoType_MesosphereCurrentProcess`

### DIFF
--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -692,6 +692,9 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, Handle
         // 6.0.0+
         TotalPhysicalMemoryAvailableWithoutSystemResource = 21,
         TotalPhysicalMemoryUsedWithoutSystemResource = 22,
+
+        // Homebrew only
+        MesosphereCurrentProcess = 65001,
     };
 
     const auto info_id_type = static_cast<GetInfoType>(info_id);
@@ -912,6 +915,17 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, Handle
 
         // Get the idle tick count.
         *result = system.Kernel().CurrentScheduler()->GetIdleThread()->GetCpuTime();
+        return ResultSuccess;
+    }
+    case GetInfoType::MesosphereCurrentProcess: {
+        R_UNLESS(handle == InvalidHandle, ResultInvalidHandle);
+        R_UNLESS(info_sub_id == 0, ResultInvalidCombination);
+
+        KProcess* const current_process = system.Kernel().CurrentProcess();
+        Handle process_handle{};
+        R_TRY(current_process->GetHandleTable().Add(&process_handle, current_process));
+
+        *result = process_handle;
         return ResultSuccess;
     }
     default:

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -917,6 +917,7 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, Handle
         *result = system.Kernel().CurrentScheduler()->GetIdleThread()->GetCpuTime();
         return ResultSuccess;
     }
+    case GetInfoType::MesosphereCurrentProcess: {
         // Verify the input handle is invalid.
         R_UNLESS(handle == InvalidHandle, ResultInvalidHandle);
 
@@ -933,9 +934,10 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, Handle
 
         // Set the output.
         *result = tmp;
-        
+
         // We succeeded.
         return ResultSuccess;
+    }
     default:
         LOG_ERROR(Kernel_SVC, "Unimplemented svcGetInfo id=0x{:016X}", info_id);
         return ResultInvalidEnumValue;

--- a/src/core/hle/kernel/svc.cpp
+++ b/src/core/hle/kernel/svc.cpp
@@ -917,17 +917,25 @@ static ResultCode GetInfo(Core::System& system, u64* result, u64 info_id, Handle
         *result = system.Kernel().CurrentScheduler()->GetIdleThread()->GetCpuTime();
         return ResultSuccess;
     }
-    case GetInfoType::MesosphereCurrentProcess: {
+        // Verify the input handle is invalid.
         R_UNLESS(handle == InvalidHandle, ResultInvalidHandle);
+
+        // Verify the sub-type is valid.
         R_UNLESS(info_sub_id == 0, ResultInvalidCombination);
 
-        KProcess* const current_process = system.Kernel().CurrentProcess();
-        Handle process_handle{};
-        R_TRY(current_process->GetHandleTable().Add(&process_handle, current_process));
+        // Get the handle table.
+        KProcess* current_process = system.Kernel().CurrentProcess();
+        KHandleTable& handle_table = current_process->GetHandleTable();
 
-        *result = process_handle;
+        // Get a new handle for the current process.
+        Handle tmp;
+        R_TRY(handle_table.Add(&tmp, current_process));
+
+        // Set the output.
+        *result = tmp;
+        
+        // We succeeded.
         return ResultSuccess;
-    }
     default:
         LOG_ERROR(Kernel_SVC, "Unimplemented svcGetInfo id=0x{:016X}", info_id);
         return ResultInvalidEnumValue;


### PR DESCRIPTION
I'm not sure whether this patch is desired or not; as the name suggests, this is not stock Switch behavior but something specific to Atmosphere.

My use case for this is to make [exlaunch](https://github.com/shadowninja108/exlaunch), a hooking framework, work in Yuzu.  That said, exlaunch also supports an [alternative method](https://github.com/shadowninja108/exlaunch/blob/b7eb687fba27b2d579aad2944d583c99c30198a8/source/lib/util/sys/cur_proc_handle.cpp#L33) of getting a current-process handle which uses only stock syscalls.  Unfortunately, the syscalls in question include `svcCreateSession` and `svcSendSyncRequest`, which are not implemented by Yuzu.  It seemed to me like implementing them would be much more work than implementing `MesosphereCurrentProcess`, so I didn't try. ¯\\\_(ツ)\_/¯