### PR TITLE
input_common: sdl: lower vibration frequency and use it's own unique thread

### DIFF
--- a/src/core/hle/service/hid/controllers/npad.cpp
+++ b/src/core/hle/service/hid/controllers/npad.cpp
@@ -820,11 +820,11 @@ bool Controller_NPad::VibrateControllerAtIndex(Core::HID::NpadIdType npad_id,
 
         const auto now = steady_clock::now();
 
-        // Filter out non-zero vibrations that are within 10ms of each other.
+        // Filter out non-zero vibrations that are within 15ms of each other.
         if ((vibration_value.low_amplitude != 0.0f || vibration_value.high_amplitude != 0.0f) &&
             duration_cast<milliseconds>(
                 now - controller.vibration[device_index].last_vibration_timepoint) <
-                milliseconds(10)) {
+                milliseconds(15)) {
             return false;
         }
 

--- a/src/input_common/drivers/sdl_driver.cpp
+++ b/src/input_common/drivers/sdl_driver.cpp
@@ -438,8 +438,15 @@ SDLDriver::SDLDriver(std::string input_engine_) : InputEngine(std::move(input_en
             using namespace std::chrono_literals;
             while (initialized) {
                 SDL_PumpEvents();
-                SendVibrations();
                 std::this_thread::sleep_for(1ms);
+            }
+        });
+        vibration_thread = std::thread([this] {
+            Common::SetCurrentThreadName("yuzu:input:SDL_Vibration");
+            using namespace std::chrono_literals;
+            while (initialized) {
+                SendVibrations();
+                std::this_thread::sleep_for(10ms);
             }
         });
     }
@@ -457,6 +464,7 @@ SDLDriver::~SDLDriver() {
     initialized = false;
     if (start_thread) {
         poll_thread.join();
+        vibration_thread.join();
         SDL_QuitSubSystem(SDL_INIT_JOYSTICK | SDL_INIT_GAMECONTROLLER);
     }
 }

--- a/src/input_common/drivers/sdl_driver.h
+++ b/src/input_common/drivers/sdl_driver.h
@@ -128,5 +128,6 @@ private:
     std::atomic<bool> initialized = false;
 
     std::thread poll_thread;
+    std::thread vibration_thread;
 };
 } // namespace InputCommon


### PR DESCRIPTION
When I moved vibrations to the poll thread it created a whole new set of issues. As now controllers would now go unresponsive rather than having stutter on the game. This PR reduces the amount of vibrations send per second as well move them out of the poll thread to avoid locking any controller input.

If issues still persist I might consider disabling vibration devices on the fly if they take too long to respond.