### PR TITLE
Revert "vulkan_device: Block AMDVLK's VK_KHR_push_descriptor"

### DIFF
--- a/src/video_core/vulkan_common/vulkan_device.cpp
+++ b/src/video_core/vulkan_common/vulkan_device.cpp
@@ -669,17 +669,6 @@ Device::Device(VkInstance instance_, vk::PhysicalDevice physical_, VkSurfaceKHR 
     const bool is_amd =
         driver_id == VK_DRIVER_ID_AMD_PROPRIETARY || driver_id == VK_DRIVER_ID_AMD_OPEN_SOURCE;
     if (is_amd) {
-        // TODO(lat9nq): Add an upper bound when AMD fixes their VK_KHR_push_descriptor
-        const bool has_broken_push_descriptor = VK_VERSION_MAJOR(properties.driverVersion) == 2 &&
-                                                VK_VERSION_MINOR(properties.driverVersion) == 0 &&
-                                                VK_VERSION_PATCH(properties.driverVersion) >= 226;
-        if (khr_push_descriptor && has_broken_push_descriptor) {
-            LOG_WARNING(
-                Render_Vulkan,
-                "Disabling AMD driver 2.0.226 and later from broken VK_KHR_push_descriptor");
-            khr_push_descriptor = false;
-        }
-
         // AMD drivers need a higher amount of Sets per Pool in certain circunstances like in XC2.
         sets_per_pool = 96;
         // Disable VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT on AMD GCN4 and lower as it is broken.


### PR DESCRIPTION
Reverts yuzu-emu/yuzu#8379

AMD's latest driver fixes the issue worked around in #8379, but retains the same version string in the driver -- 2.0.226.

So since AMD didn't update the version string, solution here is to just revert it and tell people to update their driver if they experience crashes.