### PR TITLE
cpu_manager: properly check idle on return from preemption

### DIFF
--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -194,7 +194,9 @@ void CpuManager::PreemptSingleCore(bool from_running_enviroment) {
     {
         auto& scheduler = system.Kernel().Scheduler(current_core);
         scheduler.Reload(scheduler.GetSchedulerCurrentThread());
-        idle_count = 0;
+        if (!scheduler.IsIdle()) {
+            idle_count = 0;
+        }
     }
 }
 

--- a/src/core/hle/kernel/k_scheduler.h
+++ b/src/core/hle/kernel/k_scheduler.h
@@ -55,6 +55,11 @@ public:
         return idle_thread;
     }
 
+    /// Returns true if the scheduler is idle
+    [[nodiscard]] bool IsIdle() const {
+        return GetSchedulerCurrentThread() == idle_thread;
+    }
+
     /// Gets the timestamp for the last context switch in ticks.
     [[nodiscard]] u64 GetLastContextSwitchTicks() const;
 


### PR DESCRIPTION
Unbreaks single core mode after #8475.