### PR TITLE
renderer_(gl/vk): Implement ASTC_10x6_UNORM

### DIFF
--- a/src/video_core/compatible_formats.cpp
+++ b/src/video_core/compatible_formats.cpp
@@ -131,8 +131,11 @@ constexpr std::array VIEW_CLASS_ASTC_8x8_RGBA{
 // PixelFormat::ASTC_2D_10X5_SRGB
 
 // Missing formats:
-// PixelFormat::ASTC_2D_10X6_UNORM
 // PixelFormat::ASTC_2D_10X6_SRGB
+
+constexpr std::array VIEW_CLASS_ASTC_10x6_RGBA{
+    PixelFormat::ASTC_2D_10X6_UNORM,
+};
 
 constexpr std::array VIEW_CLASS_ASTC_10x8_RGBA{
     PixelFormat::ASTC_2D_10X8_UNORM,
@@ -226,6 +229,7 @@ constexpr Table MakeViewTable() {
     EnableRange(view, VIEW_CLASS_ASTC_6x6_RGBA);
     EnableRange(view, VIEW_CLASS_ASTC_8x5_RGBA);
     EnableRange(view, VIEW_CLASS_ASTC_8x8_RGBA);
+    EnableRange(view, VIEW_CLASS_ASTC_10x6_RGBA);
     EnableRange(view, VIEW_CLASS_ASTC_10x8_RGBA);
     EnableRange(view, VIEW_CLASS_ASTC_10x10_RGBA);
     EnableRange(view, VIEW_CLASS_ASTC_12x12_RGBA);

--- a/src/video_core/renderer_opengl/maxwell_to_gl.h
+++ b/src/video_core/renderer_opengl/maxwell_to_gl.h
@@ -98,6 +98,7 @@ constexpr std::array<FormatTuple, VideoCore::Surface::MaxPixelFormat> FORMAT_TAB
     {GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x8_KHR},                       // ASTC_2D_10X8_SRGB
     {GL_COMPRESSED_RGBA_ASTC_6x6_KHR},                                // ASTC_2D_6X6_UNORM
     {GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x6_KHR},                        // ASTC_2D_6X6_SRGB
+    {GL_COMPRESSED_RGBA_ASTC_10x6_KHR},                               // ASTC_2D_10X6_UNORM
     {GL_COMPRESSED_RGBA_ASTC_10x10_KHR},                              // ASTC_2D_10X10_UNORM
     {GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR},                      // ASTC_2D_10X10_SRGB
     {GL_COMPRESSED_RGBA_ASTC_12x12_KHR},                              // ASTC_2D_12X12_UNORM

--- a/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
+++ b/src/video_core/renderer_vulkan/maxwell_to_vk.cpp
@@ -195,6 +195,7 @@ struct FormatTuple {
     {VK_FORMAT_ASTC_10x8_SRGB_BLOCK},                          // ASTC_2D_10X8_SRGB
     {VK_FORMAT_ASTC_6x6_UNORM_BLOCK},                          // ASTC_2D_6X6_UNORM
     {VK_FORMAT_ASTC_6x6_SRGB_BLOCK},                           // ASTC_2D_6X6_SRGB
+    {VK_FORMAT_ASTC_10x6_UNORM_BLOCK},                         // ASTC_2D_10X6_UNORM
     {VK_FORMAT_ASTC_10x10_UNORM_BLOCK},                        // ASTC_2D_10X10_UNORM
     {VK_FORMAT_ASTC_10x10_SRGB_BLOCK},                         // ASTC_2D_10X10_SRGB
     {VK_FORMAT_ASTC_12x12_UNORM_BLOCK},                        // ASTC_2D_12X12_UNORM

--- a/src/video_core/surface.cpp
+++ b/src/video_core/surface.cpp
@@ -247,6 +247,7 @@ bool IsPixelFormatASTC(PixelFormat format) {
     case PixelFormat::ASTC_2D_10X8_SRGB:
     case PixelFormat::ASTC_2D_6X6_UNORM:
     case PixelFormat::ASTC_2D_6X6_SRGB:
+    case PixelFormat::ASTC_2D_10X6_UNORM:
     case PixelFormat::ASTC_2D_10X10_UNORM:
     case PixelFormat::ASTC_2D_10X10_SRGB:
     case PixelFormat::ASTC_2D_12X12_UNORM:

--- a/src/video_core/surface.h
+++ b/src/video_core/surface.h
@@ -94,6 +94,7 @@ enum class PixelFormat {
     ASTC_2D_10X8_SRGB,
     ASTC_2D_6X6_UNORM,
     ASTC_2D_6X6_SRGB,
+    ASTC_2D_10X6_UNORM,
     ASTC_2D_10X10_UNORM,
     ASTC_2D_10X10_SRGB,
     ASTC_2D_12X12_UNORM,
@@ -227,6 +228,7 @@ constexpr std::array<u8, MaxPixelFormat> BLOCK_WIDTH_TABLE = {{
     10, // ASTC_2D_10X8_SRGB
     6,  // ASTC_2D_6X6_UNORM
     6,  // ASTC_2D_6X6_SRGB
+    10, // ASTC_2D_10X6_UNORM
     10, // ASTC_2D_10X10_UNORM
     10, // ASTC_2D_10X10_SRGB
     12, // ASTC_2D_12X12_UNORM
@@ -329,6 +331,7 @@ constexpr std::array<u8, MaxPixelFormat> BLOCK_HEIGHT_TABLE = {{
     8,  // ASTC_2D_10X8_SRGB
     6,  // ASTC_2D_6X6_UNORM
     6,  // ASTC_2D_6X6_SRGB
+    6,  // ASTC_2D_10X6_UNORM
     10, // ASTC_2D_10X10_UNORM
     10, // ASTC_2D_10X10_SRGB
     12, // ASTC_2D_12X12_UNORM
@@ -431,6 +434,7 @@ constexpr std::array<u8, MaxPixelFormat> BITS_PER_BLOCK_TABLE = {{
     128, // ASTC_2D_10X8_SRGB
     128, // ASTC_2D_6X6_UNORM
     128, // ASTC_2D_6X6_SRGB
+    128, // ASTC_2D_10X6_UNORM
     128, // ASTC_2D_10X10_UNORM
     128, // ASTC_2D_10X10_SRGB
     128, // ASTC_2D_12X12_UNORM

--- a/src/video_core/texture_cache/format_lookup_table.cpp
+++ b/src/video_core/texture_cache/format_lookup_table.cpp
@@ -206,6 +206,8 @@ PixelFormat PixelFormatFromTextureInfo(TextureFormat format, ComponentType red, 
         return PixelFormat::ASTC_2D_6X6_UNORM;
     case Hash(TextureFormat::ASTC_2D_6X6, UNORM, SRGB):
         return PixelFormat::ASTC_2D_6X6_SRGB;
+    case Hash(TextureFormat::ASTC_2D_10X6, UNORM, LINEAR):
+        return PixelFormat::ASTC_2D_10X6_UNORM;
     case Hash(TextureFormat::ASTC_2D_10X10, UNORM, LINEAR):
         return PixelFormat::ASTC_2D_10X10_UNORM;
     case Hash(TextureFormat::ASTC_2D_10X10, UNORM, SRGB):

--- a/src/video_core/texture_cache/formatter.h
+++ b/src/video_core/texture_cache/formatter.h
@@ -175,6 +175,8 @@ struct fmt::formatter<VideoCore::Surface::PixelFormat> : fmt::formatter<fmt::str
                 return "ASTC_2D_6X6_UNORM";
             case PixelFormat::ASTC_2D_6X6_SRGB:
                 return "ASTC_2D_6X6_SRGB";
+            case PixelFormat::ASTC_2D_10X6_UNORM:
+                return "ASTC_2D_10X6_UNORM";
             case PixelFormat::ASTC_2D_10X10_UNORM:
                 return "ASTC_2D_10X10_UNORM";
             case PixelFormat::ASTC_2D_10X10_SRGB:


### PR DESCRIPTION
- Used by Monster Hunter Rise Update 10.0.2

Note: This is **not** enough to fix the broken graphics

@FernandoS27 