### PR TITLE
common/fiber: make fibers easier to use

### DIFF
--- a/src/common/fiber.cpp
+++ b/src/common/fiber.cpp
@@ -20,10 +20,8 @@ struct Fiber::FiberImpl {
     VirtualBuffer<u8> rewind_stack;
 
     std::mutex guard;
-    std::function<void(void*)> entry_point;
-    std::function<void(void*)> rewind_point;
-    void* rewind_parameter{};
-    void* start_parameter{};
+    std::function<void()> entry_point;
+    std::function<void()> rewind_point;
     std::shared_ptr<Fiber> previous_fiber;
     bool is_thread_fiber{};
     bool released{};
@@ -34,13 +32,8 @@ struct Fiber::FiberImpl {
     boost::context::detail::fcontext_t rewind_context{};
 };
 
-void Fiber::SetStartParameter(void* new_parameter) {
-    impl->start_parameter = new_parameter;
-}
-
-void Fiber::SetRewindPoint(std::function<void(void*)>&& rewind_func, void* rewind_param) {
+void Fiber::SetRewindPoint(std::function<void()>&& rewind_func) {
     impl->rewind_point = std::move(rewind_func);
-    impl->rewind_parameter = rewind_param;
 }
 
 void Fiber::Start(boost::context::detail::transfer_t& transfer) {
@@ -48,7 +41,7 @@ void Fiber::Start(boost::context::detail::transfer_t& transfer) {
     impl->previous_fiber->impl->context = transfer.fctx;
     impl->previous_fiber->impl->guard.unlock();
     impl->previous_fiber.reset();
-    impl->entry_point(impl->start_parameter);
+    impl->entry_point();
     UNREACHABLE();
 }
 
@@ -59,7 +52,7 @@ void Fiber::OnRewind([[maybe_unused]] boost::context::detail::transfer_t& transf
     u8* tmp = impl->stack_limit;
     impl->stack_limit = impl->rewind_stack_limit;
     impl->rewind_stack_limit = tmp;
-    impl->rewind_point(impl->rewind_parameter);
+    impl->rewind_point();
     UNREACHABLE();
 }
 
@@ -73,10 +66,8 @@ void Fiber::RewindStartFunc(boost::context::detail::transfer_t transfer) {
     fiber->OnRewind(transfer);
 }
 
-Fiber::Fiber(std::function<void(void*)>&& entry_point_func, void* start_parameter)
-    : impl{std::make_unique<FiberImpl>()} {
+Fiber::Fiber(std::function<void()>&& entry_point_func) : impl{std::make_unique<FiberImpl>()} {
     impl->entry_point = std::move(entry_point_func);
-    impl->start_parameter = start_parameter;
     impl->stack_limit = impl->stack.data();
     impl->rewind_stack_limit = impl->rewind_stack.data();
     u8* stack_base = impl->stack_limit + default_stack_size;

--- a/src/common/fiber.h
+++ b/src/common/fiber.h
@@ -29,7 +29,7 @@ namespace Common {
  */
 class Fiber {
 public:
-    Fiber(std::function<void(void*)>&& entry_point_func, void* start_parameter);
+    Fiber(std::function<void()>&& entry_point_func);
     ~Fiber();
 
     Fiber(const Fiber&) = delete;
@@ -43,15 +43,12 @@ public:
     static void YieldTo(std::weak_ptr<Fiber> weak_from, Fiber& to);
     [[nodiscard]] static std::shared_ptr<Fiber> ThreadToFiber();
 
-    void SetRewindPoint(std::function<void(void*)>&& rewind_func, void* rewind_param);
+    void SetRewindPoint(std::function<void()>&& rewind_func);
 
     void Rewind();
 
     /// Only call from main thread's fiber
     void Exit();
-
-    /// Changes the start parameter of the fiber. Has no effect if the fiber already started
-    void SetStartParameter(void* new_parameter);
 
 private:
     Fiber();

--- a/src/core/cpu_manager.h
+++ b/src/core/cpu_manager.h
@@ -50,10 +50,15 @@ public:
     void Initialize();
     void Shutdown();
 
-    static std::function<void(void*)> GetGuestThreadStartFunc();
-    static std::function<void(void*)> GetIdleThreadStartFunc();
-    static std::function<void(void*)> GetShutdownThreadStartFunc();
-    void* GetStartFuncParameter();
+    std::function<void()> GetGuestThreadStartFunc() {
+        return [this] { GuestThreadFunction(); };
+    }
+    std::function<void()> GetIdleThreadStartFunc() {
+        return [this] { IdleThreadFunction(); };
+    }
+    std::function<void()> GetShutdownThreadStartFunc() {
+        return [this] { ShutdownThreadFunction(); };
+    }
 
     void PreemptSingleCore(bool from_running_enviroment = true);
 
@@ -62,10 +67,10 @@ public:
     }
 
 private:
-    static void GuestThreadFunction(void* cpu_manager);
-    static void GuestRewindFunction(void* cpu_manager);
-    static void IdleThreadFunction(void* cpu_manager);
-    static void ShutdownThreadFunction(void* cpu_manager);
+    void GuestThreadFunction();
+    void GuestRewindFunction();
+    void IdleThreadFunction();
+    void ShutdownThreadFunction();
 
     void MultiCoreRunGuestThread();
     void MultiCoreRunGuestLoop();

--- a/src/core/hle/kernel/k_scheduler.cpp
+++ b/src/core/hle/kernel/k_scheduler.cpp
@@ -622,7 +622,7 @@ void KScheduler::YieldToAnyThread(KernelCore& kernel) {
 }
 
 KScheduler::KScheduler(Core::System& system_, s32 core_id_) : system{system_}, core_id{core_id_} {
-    switch_fiber = std::make_shared<Common::Fiber>(OnSwitch, this);
+    switch_fiber = std::make_shared<Common::Fiber>([this] { SwitchToCurrent(); });
     state.needs_scheduling.store(true);
     state.interrupt_task_thread_runnable = false;
     state.should_count_idle = false;
@@ -776,11 +776,6 @@ void KScheduler::ScheduleImpl() {
     /// When a thread wakes up, the scheduler may have changed to other in another core.
     auto& next_scheduler = *system.Kernel().CurrentScheduler();
     next_scheduler.SwitchContextStep2();
-}
-
-void KScheduler::OnSwitch(void* this_scheduler) {
-    KScheduler* sched = static_cast<KScheduler*>(this_scheduler);
-    sched->SwitchToCurrent();
 }
 
 void KScheduler::SwitchToCurrent() {

--- a/src/core/hle/kernel/k_scheduler.h
+++ b/src/core/hle/kernel/k_scheduler.h
@@ -165,7 +165,6 @@ private:
      */
     void UpdateLastContextSwitchTime(KThread* thread, KProcess* process);
 
-    static void OnSwitch(void* this_scheduler);
     void SwitchToCurrent();
 
     KThread* prev_thread{};

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -729,8 +729,7 @@ private:
     [[nodiscard]] static Result InitializeThread(KThread* thread, KThreadFunction func,
                                                  uintptr_t arg, VAddr user_stack_top, s32 prio,
                                                  s32 core, KProcess* owner, ThreadType type,
-                                                 std::function<void(void*)>&& init_func,
-                                                 void* init_func_parameter);
+                                                 std::function<void()>&& init_func);
 
     static void RestorePriority(KernelCore& kernel_ctx, KThread* thread);
 


### PR DESCRIPTION
Changes the `std::function<void(void*)>` + `void*` invocation parameter to a `std::function<void()>`. `std::function` already acts as a closure so there is no point in carrying around the extra `void*`, and having to use extra indirection makes it more annoying to write fibers than it really needs to be.