### PR TITLE
core: use old pausing mechanism

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -138,6 +138,7 @@ struct System::Impl {
 
         kernel.Suspend(false);
         core_timing.SyncPause(false);
+        cpu_manager.Pause(false);
         is_paused = false;
 
         return status;
@@ -149,6 +150,7 @@ struct System::Impl {
 
         core_timing.SyncPause(true);
         kernel.Suspend(true);
+        cpu_manager.Pause(true);
         is_paused = true;
 
         return status;
@@ -158,6 +160,7 @@ struct System::Impl {
         std::unique_lock<std::mutex> lk(suspend_guard);
         kernel.Suspend(true);
         core_timing.SyncPause(true);
+        cpu_manager.Pause(true);
         return lk;
     }
 
@@ -165,6 +168,7 @@ struct System::Impl {
         if (!is_paused) {
             core_timing.SyncPause(false);
             kernel.Suspend(false);
+            cpu_manager.Pause(false);
         }
     }
 
@@ -330,8 +334,6 @@ struct System::Impl {
             gpu_core->NotifyShutdown();
         }
 
-        kernel.ShutdownCores();
-        cpu_manager.Shutdown();
         debugger.reset();
         services.reset();
         service_manager.reset();

--- a/src/core/cpu_manager.cpp
+++ b/src/core/cpu_manager.cpp
@@ -25,8 +25,10 @@ void CpuManager::ThreadStart(std::stop_token stop_token, CpuManager& cpu_manager
 }
 
 void CpuManager::Initialize() {
+    running_mode = true;
     num_cores = is_multicore ? Core::Hardware::NUM_CPU_CORES : 1;
     gpu_barrier = std::make_unique<Common::Barrier>(num_cores + 1);
+    pause_barrier = std::make_unique<Common::Barrier>(num_cores + 1);
 
     for (std::size_t core = 0; core < num_cores; core++) {
         core_data[core].host_thread = std::jthread(ThreadStart, std::ref(*this), core);
@@ -34,11 +36,8 @@ void CpuManager::Initialize() {
 }
 
 void CpuManager::Shutdown() {
-    for (std::size_t core = 0; core < num_cores; core++) {
-        if (core_data[core].host_thread.joinable()) {
-            core_data[core].host_thread.join();
-        }
-    }
+    running_mode = false;
+    Pause(false);
 }
 
 void CpuManager::GuestThreadFunction() {
@@ -63,10 +62,6 @@ void CpuManager::IdleThreadFunction() {
     } else {
         SingleCoreRunIdleThread();
     }
-}
-
-void CpuManager::ShutdownThreadFunction() {
-    ShutdownThread();
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -181,13 +176,41 @@ void CpuManager::PreemptSingleCore(bool from_running_enviroment) {
     }
 }
 
-void CpuManager::ShutdownThread() {
+void CpuManager::SuspendThread() {
     auto& kernel = system.Kernel();
-    auto core = is_multicore ? kernel.CurrentPhysicalCoreIndex() : 0;
-    auto* current_thread = kernel.GetCurrentEmuThread();
+    kernel.CurrentScheduler()->OnThreadStart();
 
-    Common::Fiber::YieldTo(current_thread->GetHostContext(), *core_data[core].host_context);
-    UNREACHABLE();
+    while (true) {
+        auto core = is_multicore ? kernel.CurrentPhysicalCoreIndex() : 0;
+        auto& scheduler = *kernel.CurrentScheduler();
+        Kernel::KThread* current_thread = scheduler.GetSchedulerCurrentThread();
+        Common::Fiber::YieldTo(current_thread->GetHostContext(), *core_data[core].host_context);
+
+        // This shouldn't be here. This is here because the scheduler needs the current
+        // thread to have dispatch disabled before explicitly rescheduling. Ideally in the
+        // future this will be called by RequestScheduleOnInterrupt and explicitly disabling
+        // dispatch outside the scheduler will not be necessary.
+        current_thread->DisableDispatch();
+
+        scheduler.RescheduleCurrentCore();
+    }
+}
+
+void CpuManager::Pause(bool paused) {
+    std::scoped_lock lk{pause_lock};
+
+    if (pause_state == paused) {
+        return;
+    }
+
+    // Set the new state
+    pause_state.store(paused);
+
+    // Wake up any waiting threads
+    pause_state.notify_all();
+
+    // Wait for all threads to successfully change state before returning
+    pause_barrier->Sync();
 }
 
 void CpuManager::RunThread(std::size_t core) {
@@ -218,9 +241,27 @@ void CpuManager::RunThread(std::size_t core) {
         system.GPU().ObtainContext();
     }
 
-    auto* current_thread = system.Kernel().CurrentScheduler()->GetIdleThread();
-    Kernel::SetCurrentThread(system.Kernel(), current_thread);
-    Common::Fiber::YieldTo(data.host_context, *current_thread->GetHostContext());
+    {
+        // Set the current thread on entry
+        auto* current_thread = system.Kernel().CurrentScheduler()->GetIdleThread();
+        Kernel::SetCurrentThread(system.Kernel(), current_thread);
+    }
+
+    while (running_mode) {
+        if (pause_state.load(std::memory_order_relaxed)) {
+            // Wait for caller to acknowledge pausing
+            pause_barrier->Sync();
+
+            // Wait until unpaused
+            pause_state.wait(true, std::memory_order_relaxed);
+
+            // Wait for caller to acknowledge unpausing
+            pause_barrier->Sync();
+        }
+
+        auto current_thread = system.Kernel().CurrentScheduler()->GetSchedulerCurrentThread();
+        Common::Fiber::YieldTo(data.host_context, *current_thread->GetHostContext());
+    }
 }
 
 } // namespace Core

--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -269,7 +269,7 @@ Result KThread::InitializeIdleThread(Core::System& system, KThread* thread, s32 
 Result KThread::InitializeHighPriorityThread(Core::System& system, KThread* thread,
                                              KThreadFunction func, uintptr_t arg, s32 virt_core) {
     return InitializeThread(thread, func, arg, {}, {}, virt_core, nullptr, ThreadType::HighPriority,
-                            system.GetCpuManager().GetShutdownThreadStartFunc());
+                            system.GetCpuManager().GetSuspendThreadStartFunc());
 }
 
 Result KThread::InitializeUserThread(Core::System& system, KThread* thread, KThreadFunction func,
@@ -739,19 +739,6 @@ void KThread::Continue() {
 
     // Note the state change in scheduler.
     KScheduler::OnThreadStateChanged(kernel, this, old_state);
-}
-
-void KThread::WaitUntilSuspended() {
-    // Make sure we have a suspend requested.
-    ASSERT(IsSuspendRequested());
-
-    // Loop until the thread is not executing on any core.
-    for (std::size_t i = 0; i < static_cast<std::size_t>(Core::Hardware::NUM_CPU_CORES); ++i) {
-        KThread* core_thread{};
-        do {
-            core_thread = kernel.Scheduler(i).GetSchedulerCurrentThread();
-        } while (core_thread == this);
-    }
 }
 
 Result KThread::SetActivity(Svc::ThreadActivity activity) {

--- a/src/core/hle/kernel/k_thread.h
+++ b/src/core/hle/kernel/k_thread.h
@@ -208,8 +208,6 @@ public:
 
     void Continue();
 
-    void WaitUntilSuspended();
-
     constexpr void SetSyncedIndex(s32 index) {
         synced_index = index;
     }

--- a/src/core/hle/kernel/kernel.h
+++ b/src/core/hle/kernel/kernel.h
@@ -280,9 +280,6 @@ public:
     /// Exceptional exit all processes.
     void ExceptionalExit();
 
-    /// Notify emulated CPU cores to shut down.
-    void ShutdownCores();
-
     bool IsMulticore() const;
 
     bool IsShuttingDown() const;


### PR DESCRIPTION
We are still seeing graphical lockups in Fire Emblems, tracked down to the KProcess suspend PR, so just do that the old way. Reverts the CPU-side part of #8457.