### PR TITLE
gpu_thread: Use the previous MPSCQueue implementation

### DIFF
--- a/src/video_core/gpu_thread.cpp
+++ b/src/video_core/gpu_thread.cpp
@@ -31,8 +31,7 @@ static void RunThread(std::stop_token stop_token, Core::System& system,
     VideoCore::RasterizerInterface* const rasterizer = renderer.ReadRasterizer();
 
     while (!stop_token.stop_requested()) {
-        CommandDataContainer next;
-        state.queue.Pop(next, stop_token);
+        CommandDataContainer next = state.queue.PopWait(stop_token);
         if (stop_token.stop_requested()) {
             break;
         }

--- a/src/video_core/gpu_thread.h
+++ b/src/video_core/gpu_thread.h
@@ -10,7 +10,7 @@
 #include <thread>
 #include <variant>
 
-#include "common/bounded_threadsafe_queue.h"
+#include "common/threadsafe_queue.h"
 #include "video_core/framebuffer_config.h"
 
 namespace Tegra {
@@ -96,7 +96,7 @@ struct CommandDataContainer {
 
 /// Struct used to synchronize the GPU thread
 struct SynchState final {
-    using CommandQueue = Common::MPSCQueue<CommandDataContainer>;
+    using CommandQueue = Common::MPSCQueue<CommandDataContainer, true>;
     std::mutex write_lock;
     CommandQueue queue;
     u64 last_fence{};


### PR DESCRIPTION
The bounded MPSCQueue implementation causes crashes in Fire Emblem Three Houses, use the previous implementation for now.