### PR TITLE
kernel: fix usage of waiter_list in Finalize

### DIFF
--- a/src/core/hle/kernel/k_thread.cpp
+++ b/src/core/hle/kernel/k_thread.cpp
@@ -308,14 +308,20 @@ void KThread::Finalize() {
 
         auto it = waiter_list.begin();
         while (it != waiter_list.end()) {
-            // Clear the lock owner
-            it->SetLockOwner(nullptr);
+            // Get the thread.
+            KThread* const waiter = std::addressof(*it);
+
+            // The thread shouldn't be a kernel waiter.
+            ASSERT(!IsKernelAddressKey(waiter->GetAddressKey()));
+
+            // Clear the lock owner.
+            waiter->SetLockOwner(nullptr);
 
             // Erase the waiter from our list.
             it = waiter_list.erase(it);
 
             // Cancel the thread's wait.
-            it->CancelWait(ResultInvalidState, true);
+            waiter->CancelWait(ResultInvalidState, true);
         }
     }
 


### PR DESCRIPTION
This error is due to incorrect copying from Atmosphere code. This mistake causes a finalizing KThread to cancel the next waiter instead of the current one, which will lead to the first waiter in the list never getting canceled, and a bogus cancel getting called on the finalizing thread itself as the last element.